### PR TITLE
GH#26960: Isolate agent test capture descriptors

### DIFF
--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -823,7 +823,8 @@ _cmd_run_capture_test() {
 			"$test_json" "$test_index" "$test_count" \
 			"$suite_agent" "$suite_model" "$suite_timeout" \
 			"$results"
-	) || capture_status=$?
+	)
+	capture_status=$?
 
 	return "$capture_status"
 }

--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -801,26 +801,31 @@ _cmd_run_emit_json_metrics() {
 #   Updated results JSON array followed by outcome on stdout
 #######################################
 _cmd_run_capture_test() {
-	local test_json="$1"
-	local test_index="$2"
-	local test_count="$3"
-	local suite_agent="$4"
-	local suite_model="$5"
-	local suite_timeout="$6"
-	local results="$7"
-	local json_output="$8"
+	local capture_status=0
 
-	exec 3>&1
-	if [[ "$json_output" == "false" ]]; then
-		exec 1>&2
-	else
-		exec 1>/dev/null
-	fi
-	_cmd_run_execute_test \
-		"$test_json" "$test_index" "$test_count" \
-		"$suite_agent" "$suite_model" "$suite_timeout" \
-		"$results"
-	return 0
+	(
+		local test_json="$1"
+		local test_index="$2"
+		local test_count="$3"
+		local suite_agent="$4"
+		local suite_model="$5"
+		local suite_timeout="$6"
+		local results="$7"
+		local json_output="$8"
+
+		exec 3>&1
+		if [[ "$json_output" == "false" ]]; then
+			exec 1>&2
+		else
+			exec 1>/dev/null
+		fi
+		_cmd_run_execute_test \
+			"$test_json" "$test_index" "$test_count" \
+			"$suite_agent" "$suite_model" "$suite_timeout" \
+			"$results"
+	) || capture_status=$?
+
+	return "$capture_status"
 }
 
 #######################################

--- a/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
+++ b/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
@@ -44,6 +44,18 @@ fail() {
 	return 1
 }
 
+direct_stdout="$TEST_ROOT/direct.stdout"
+direct_stderr="$TEST_ROOT/direct.stderr"
+direct_test='{"id":"direct-call","prompt":"direct","expect_contains":["mock response"]}'
+{
+	_cmd_run_capture_test "$direct_test" 0 1 "" "" 1 "[]" false
+	printf '%s\n' "stdout-still-open"
+} >"$direct_stdout" 2>"$direct_stderr"
+grep -q '^stdout-still-open$' "$direct_stdout" ||
+	fail "capture helper leaked its stdout redirection into the caller"
+grep -q '\[1/1\] direct-call' "$direct_stderr" ||
+	fail "direct capture omitted human-readable progress"
+
 pass_suite="$TEST_ROOT/pass-suite.json"
 cat >"$pass_suite" <<'JSON'
 {
@@ -89,6 +101,7 @@ grep -q 'Expected to contain: "missing"' "$human_fail_output" ||
 	fail "human output omitted expectation failure"
 grep -q 'Error/timeout' "$human_fail_output" ||
 	fail "human output omitted timeout failure"
+rm -f "$RESULTS_DIR"/output-channel-fail-*.json
 
 json_stdout="$TEST_ROOT/json.stdout"
 json_stderr="$TEST_ROOT/json.stderr"

--- a/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
+++ b/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
@@ -56,6 +56,16 @@ grep -q '^stdout-still-open$' "$direct_stdout" ||
 grep -q '\[1/1\] direct-call' "$direct_stderr" ||
 	fail "direct capture omitted human-readable progress"
 
+propagated_status=0
+(
+	_cmd_run_execute_test() {
+		return 7
+	}
+	_cmd_run_capture_test "$direct_test" 0 1 "" "" 1 "[]" true
+) || propagated_status=$?
+[[ $propagated_status -eq 7 ]] ||
+	fail "capture helper did not propagate the execution status"
+
 pass_suite="$TEST_ROOT/pass-suite.json"
 cat >"$pass_suite" <<'JSON'
 {

--- a/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
+++ b/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
@@ -66,6 +66,28 @@ propagated_status=0
 [[ $propagated_status -eq 7 ]] ||
 	fail "capture helper did not propagate the execution status"
 
+errexit_stdout="$TEST_ROOT/errexit.stdout"
+errexit_status=0
+set +e
+TEST_AGENT_HELPER="$REPO_ROOT/.agents/scripts/agent-test-helper.sh" bash -c '
+	set -euo pipefail
+	source "$TEST_AGENT_HELPER"
+	_cmd_run_execute_test() {
+		false
+		printf "%s\n" "unexpected-continuation" >&3
+		return 0
+	}
+	_cmd_run_capture_test "{}" 0 1 "" "" 1 "[]" true
+	printf "%s\n" "errexit-survived"
+' >"$errexit_stdout" 2>&1
+errexit_status=$?
+set -e
+[[ $errexit_status -ne 0 ]] ||
+	fail "capture helper suppressed errexit inside its subshell"
+if grep -q 'unexpected-continuation\|errexit-survived' "$errexit_stdout"; then
+	fail "capture helper continued after a command failed under errexit"
+fi
+
 pass_suite="$TEST_ROOT/pass-suite.json"
 cat >"$pass_suite" <<'JSON'
 {


### PR DESCRIPTION
## Summary

Isolated agent-test capture file-descriptor redirections in a subshell, propagated execution failures, and added direct-call regression coverage.

## Files Changed

.agents/scripts/agent-test-helper.sh, .agents/scripts/tests/test-agent-test-helper-output-channel.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck; Bash 3.2 syntax and output-channel regression test

Resolves #26960


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 15m and 129,505 tokens on this as a headless worker.