### PR TITLE
GH#26969: suppress resolved review feedback parents

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -38,6 +38,7 @@ _build_inline_findings() {
 				"(?s:\\bthank you for the update\\b.*?\\bimplementation\\b.*?\\bcorrectly address(es|ed)?\\b.*?\\brobust (approach|validation|handling)\\b)|" +
 				"(?s:\\bthank you for the update\\b.*?\\busing\\b.*?\\bconsistently\\b.*?\\bcorrect approach\\b.*?\\bverification steps\\b.*?\\bconfidence\\b)|" +
 				"(?s:\\bthank you for the clarification\\b.*?\\byou are (absolutely )?correct\\b.*?\\bproperly managed\\b.*?\\bcleanup routines?\\b)|" +
+				"(?s:\\bthank you for the clarification\\b.*?\\byou are (absolutely )?correct\\b.*?\\bissue is (indeed )?resolved\\b)|" +
 				"\\bno further concerns?\\b|" +
 				"\\bno further feedback\\b|" +
 				"\\bno further recommendations?\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -881,6 +881,59 @@ test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
 	return 0
 }
 
+test_scan_single_pr_filters_parent_of_resolution_reply() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+				repos/*/pulls/*/comments)
+					cat <<'JSON'
+[{"id":3559552023,"user":{"login":"gemini-code-assist[bot]"},"path":".agents/reference/safety-stop-recovery.md","line":null,"original_line":23,"position":1,"body":"The singular subject makes the plural verb incorrect. Change one failed approach to failed approaches.\n\n```suggestion\nfailed approaches are not evidence\n```","html_url":"https://example.invalid/original","created_at":"2026-07-10T14:11:03Z"},{"id":3559907312,"in_reply_to_id":3559552023,"user":{"login":"gemini-code-assist[bot]"},"path":".agents/reference/safety-stop-recovery.md","line":null,"original_line":23,"position":1,"body":"Thank you for the clarification. You are correct that the grammatical agreement has been addressed by the shift to Each requires. I have verified the current state of the file, and the issue is indeed resolved.","html_url":"https://example.invalid/reply","created_at":"2026-07-10T15:03:06Z"}]
+JSON
+					return 0
+					;;
+				repos/*/pulls/*/reviews)
+					echo '[]'
+					return 0
+					;;
+				repos/*/git/trees/*)
+					echo '[".agents/reference/safety-stop-recovery.md"]'
+					return 0
+					;;
+				repos/*)
+					echo "main"
+					return 0
+					;;
+				esac
+				shift
+			done
+			return 0
+			;;
+		label | pr) return 0 ;;
+		esac
+		return 0
+	}
+
+	local findings
+	findings=$(_scan_single_pr "owner/repo" "26935" "medium" "false" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "issue #26969 parent finding with a resolution reply is filtered" 0
+	else
+		print_result "issue #26969 parent finding with a resolution reply is filtered" 1 "expected 0 findings, got ${count}"
+	fi
+
+	_restore_mock_gh
+	return 0
+}
+
 test_scan_single_pr_filters_issue3158_review_body() {
 	# Regression: PR #3060 Gemini review — "The changes are correct and well-justified."
 	# with summary praise (effectively, improves, correct, well-justified) must be filtered

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -200,6 +200,14 @@ source "${SCRIPT_DIR}/test-quality-feedback-main-verification-scan.sh"
 
 # --- Main ---
 
+run_positive_review_filter_regressions() {
+	test_scan_single_pr_filters_issue4814_pr2166_exact_body
+	test_scan_single_pr_positive_body_with_inline_comments_not_summary_only
+	test_scan_single_pr_filters_positive_inline_acknowledgement_reply
+	test_scan_single_pr_filters_parent_of_resolution_reply
+	return 0
+}
+
 main() {
 	source "$HELPER"
 
@@ -286,9 +294,7 @@ main() {
 
 	echo ""
 	echo "Running positive-review filter regression tests (GH#4814)"
-	test_scan_single_pr_filters_issue4814_pr2166_exact_body
-	test_scan_single_pr_positive_body_with_inline_comments_not_summary_only
-	test_scan_single_pr_filters_positive_inline_acknowledgement_reply
+	run_positive_review_filter_regressions
 
 	echo ""
 	echo "Running merge/CI-status comment filter tests (GH#5668)"


### PR DESCRIPTION
## Summary

- recognise Gemini replies that explicitly confirm an issue is resolved
- suppress the acknowledged parent finding as well as the positive reply
- group positive-review regressions to keep the test runner below its complexity limit

## Verification

- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh` (77/77 passed)
- `bash .agents/scripts/linters-local.sh --changed` (passed)

Resolves #26969

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 13m and 126,664 tokens on this as a headless worker.