### PR TITLE
GH#26989: Preserve agent test capture errexit

### DIFF
--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -801,8 +801,6 @@ _cmd_run_emit_json_metrics() {
 #   Updated results JSON array followed by outcome on stdout
 #######################################
 _cmd_run_capture_test() {
-	local capture_status=0
-
 	(
 		local test_json="$1"
 		local test_index="$2"
@@ -824,9 +822,7 @@ _cmd_run_capture_test() {
 			"$suite_agent" "$suite_model" "$suite_timeout" \
 			"$results"
 	)
-	capture_status=$?
-
-	return "$capture_status"
+	return $?
 }
 
 #######################################


### PR DESCRIPTION
## Summary

- Return the capture subshell status directly so Bash keeps errexit active inside the subshell.
- Remove redundant status storage while retaining an explicit function return.

## Testing

- `bash .agents/scripts/tests/test-agent-test-helper-output-channel.sh`
- `shellcheck .agents/scripts/agent-test-helper.sh .agents/scripts/tests/test-agent-test-helper-output-channel.sh`
- Pre-commit quality validation

Resolves #26989

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 9m and 56,312 tokens on this as a headless worker.