### PR TITLE
GH#26991: fix: make quality feedback regexes Bash 3.2 safe

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -200,14 +200,16 @@ _extract_reference_line_fix_snippet() {
 	local body_full="$1"
 	local file_name=""
 	local target_line=""
+	local file_pattern="[Tt]he[[:space:]]referenced[[:space:]]file[[:space:]]'([^']+)'"
+	local line_pattern="[Pp]oint[[:space:]]only[[:space:]]to[[:space:]]line[[:space:]]([0-9]+)"
 
-	if [[ "$body_full" =~ [Tt]he[[:space:]]referenced[[:space:]]file[[:space:]]\'([^\']+)\' ]]; then
+	if [[ "$body_full" =~ $file_pattern ]]; then
 		file_name="${BASH_REMATCH[1]}"
 	else
 		return 1
 	fi
 
-	if [[ "$body_full" =~ [Pp]oint[[:space:]]only[[:space:]]to[[:space:]]line[[:space:]]([0-9]+) ]]; then
+	if [[ "$body_full" =~ $line_pattern ]]; then
 		target_line="${BASH_REMATCH[1]}"
 	else
 		return 1


### PR DESCRIPTION
## Summary

Moved quoted and special-character review regexes into local variables before unquoted =~ matching, preserving BASH_REMATCH behavior portably.

## Files Changed

.agents/scripts/quality-feedback-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** /bin/bash -n .agents/scripts/quality-feedback-helper.sh; shellcheck .agents/scripts/quality-feedback-helper.sh; /bin/bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (78/78); .agents/scripts/linters-local.sh

Resolves #26991


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 10m and 66,001 tokens on this as a headless worker.