### PR TITLE
t18083: refresh Vault status after terminal handoff

### DIFF
--- a/.agents/reference/vault.md
+++ b/.agents/reference/vault.md
@@ -7,8 +7,11 @@
 > helper covers local metadata, passphrase wrapping, an in-memory broker,
 > locked-state gates, managed history gates, the first verified data-plane
 > migration helper, an initial encrypted sync/export/import transport, and
-> encrypted device-to-device message envelopes over opaque Git mailboxes;
-> GUI routing is still a future phase.
+> encrypted device-to-device message envelopes over opaque Git mailboxes. The
+> GUI now provides metadata-only locked-state surfaces and a desktop terminal
+> handoff for fixed `aidevops vault` actions; browser/API passphrase entry,
+> plaintext secret values, and direct encrypted-payload editing remain out of
+> scope.
 
 <!-- AI-CONTEXT-START -->
 

--- a/packages/gui-web/src/useGuiStatus.ts
+++ b/packages/gui-web/src/useGuiStatus.ts
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchStatus, mockedStatus, unavailableStatus } from "./status-client";
 import { type VaultDialogIntent, vaultDialogIntentForStatus } from "./VaultBadges";
 
+const VAULT_TERMINAL_REFRESH_DELAYS_MS = [1200, 3000, 7000] as const;
+
 interface GuiStatusController {
   markVaultTerminalLaunch: () => void;
   refreshStatus: () => Promise<void>;
@@ -18,6 +20,7 @@ export function useGuiStatus(): GuiStatusController {
   const [vaultDialogIntent, setVaultDialogIntent] = useState<VaultDialogIntent | null>(null);
   const hasPromptedVaultSetup = useRef(false);
   const refreshVaultAfterTerminal = useRef(false);
+  const vaultTerminalRefreshTimeouts = useRef<number[]>([]);
   const currentVaultIntent = vaultDialogIntentForStatus(status.data.vault);
   const shouldPromptSetup = shouldPromptVaultSetup(statusLoading, status.data.vault, hasPromptedVaultSetup.current);
 
@@ -36,16 +39,39 @@ export function useGuiStatus(): GuiStatusController {
     void refreshStatus();
   }, [refreshStatus]);
 
+  const clearVaultTerminalRefreshes = useCallback(() => {
+    for (const timeoutId of vaultTerminalRefreshTimeouts.current) {
+      window.clearTimeout(timeoutId);
+    }
+    vaultTerminalRefreshTimeouts.current = [];
+  }, []);
+
+  const runVaultTerminalRefresh = useCallback(() => {
+    if (refreshVaultAfterTerminal.current) {
+      void refreshStatus();
+    }
+  }, [refreshStatus]);
+
+  const scheduleVaultTerminalRefreshes = useCallback(() => {
+    clearVaultTerminalRefreshes();
+    vaultTerminalRefreshTimeouts.current = VAULT_TERMINAL_REFRESH_DELAYS_MS.map((delay) => (
+      window.setTimeout(runVaultTerminalRefresh, delay)
+    ));
+  }, [clearVaultTerminalRefreshes, runVaultTerminalRefresh]);
+
   useEffect(() => {
     const refreshAfterTerminal = () => {
       if (refreshVaultAfterTerminal.current) {
         refreshVaultAfterTerminal.current = false;
+        clearVaultTerminalRefreshes();
         void refreshStatus();
       }
     };
     window.addEventListener("focus", refreshAfterTerminal);
     return () => window.removeEventListener("focus", refreshAfterTerminal);
-  }, [refreshStatus]);
+  }, [clearVaultTerminalRefreshes, refreshStatus]);
+
+  useEffect(() => clearVaultTerminalRefreshes, [clearVaultTerminalRefreshes]);
 
   useEffect(() => {
     setVaultDialogIntent((openIntent) => openIntent !== null && openIntent !== currentVaultIntent ? null : openIntent);
@@ -61,6 +87,7 @@ export function useGuiStatus(): GuiStatusController {
   return {
     markVaultTerminalLaunch: () => {
       refreshVaultAfterTerminal.current = true;
+      scheduleVaultTerminalRefreshes();
     },
     refreshStatus,
     setVaultDialogIntent,

--- a/packages/gui-web/src/useGuiStatus.ts
+++ b/packages/gui-web/src/useGuiStatus.ts
@@ -20,6 +20,7 @@ export function useGuiStatus(): GuiStatusController {
   const [vaultDialogIntent, setVaultDialogIntent] = useState<VaultDialogIntent | null>(null);
   const hasPromptedVaultSetup = useRef(false);
   const refreshVaultAfterTerminal = useRef(false);
+  const vaultStatusAtTerminalLaunch = useRef<GuiStatusData["vault"]["status"] | null>(null);
   const vaultTerminalRefreshTimeouts = useRef<number[]>([]);
   const currentVaultIntent = vaultDialogIntentForStatus(status.data.vault);
   const shouldPromptSetup = shouldPromptVaultSetup(statusLoading, status.data.vault, hasPromptedVaultSetup.current);
@@ -71,7 +72,16 @@ export function useGuiStatus(): GuiStatusController {
     return () => window.removeEventListener("focus", refreshAfterTerminal);
   }, [clearVaultTerminalRefreshes, refreshStatus]);
 
-  useEffect(() => clearVaultTerminalRefreshes, [clearVaultTerminalRefreshes]);
+  useEffect(() => {
+    if (refreshVaultAfterTerminal.current && status.data.vault.status !== vaultStatusAtTerminalLaunch.current) {
+      refreshVaultAfterTerminal.current = false;
+      clearVaultTerminalRefreshes();
+    }
+  }, [clearVaultTerminalRefreshes, status.data.vault.status]);
+
+  useEffect(() => () => {
+    clearVaultTerminalRefreshes();
+  }, [clearVaultTerminalRefreshes]);
 
   useEffect(() => {
     setVaultDialogIntent((openIntent) => openIntent !== null && openIntent !== currentVaultIntent ? null : openIntent);
@@ -87,6 +97,7 @@ export function useGuiStatus(): GuiStatusController {
   return {
     markVaultTerminalLaunch: () => {
       refreshVaultAfterTerminal.current = true;
+      vaultStatusAtTerminalLaunch.current = status.data.vault.status;
       scheduleVaultTerminalRefreshes();
     },
     refreshStatus,

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -150,6 +150,9 @@ describe("dashboard shell", () => {
     expect(dialogControllerSource).toContain('button:not([disabled])');
     expect(dialogControllerSource).toContain("previousFocus?.focus()");
     expect(statusControllerSource).toContain('window.addEventListener("focus", refreshAfterTerminal)');
+    expect(statusControllerSource).toContain("VAULT_TERMINAL_REFRESH_DELAYS_MS");
+    expect(statusControllerSource).toContain("window.setTimeout(runVaultTerminalRefresh, delay)");
+    expect(statusControllerSource).toContain("window.clearTimeout(timeoutId)");
     expect(statusControllerSource).toContain("openIntent !== null && openIntent !== currentVaultIntent ? null : openIntent");
   });
 

--- a/packages/gui-web/tests/component.test.ts
+++ b/packages/gui-web/tests/component.test.ts
@@ -153,6 +153,8 @@ describe("dashboard shell", () => {
     expect(statusControllerSource).toContain("VAULT_TERMINAL_REFRESH_DELAYS_MS");
     expect(statusControllerSource).toContain("window.setTimeout(runVaultTerminalRefresh, delay)");
     expect(statusControllerSource).toContain("window.clearTimeout(timeoutId)");
+    expect(statusControllerSource).toContain("status.data.vault.status !== vaultStatusAtTerminalLaunch.current");
+    expect(statusControllerSource).toContain("vaultStatusAtTerminalLaunch.current = status.data.vault.status");
     expect(statusControllerSource).toContain("openIntent !== null && openIntent !== currentVaultIntent ? null : openIntent");
   });
 


### PR DESCRIPTION
Ref t18083

## Summary

- Add bounded post-terminal Vault status refreshes after the desktop terminal handoff opens.
- Keep the existing focus-return refresh and clear pending timers once focus refresh runs.
- Update the Vault RFC status note to reflect shipped GUI metadata surfaces and desktop terminal handoff.

## Testing

- `bun test packages/gui-web/tests/component.test.ts` — 43 pass, 0 fail
- `npm run gui:typecheck` — pass
- `git diff --check` — pass
- `npm run gui:ci` — pass

## Runtime Testing

- Self-assessed with full GUI CI. This changes a bounded client-side timer state path and does not alter CLI passphrase custody, API payloads, or native command allowlists.

## Key decisions

- Timers are bounded to three refresh attempts and are cancelled when focus-triggered refresh runs.
- Passphrase handling remains exclusively in the existing local terminal helper flow.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.5 spent 3d and 1,604,417 tokens on this with the user in an interactive session.
