### PR TITLE
t18082: fix: clean detached sandbox descendants

### DIFF
--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -415,8 +415,8 @@ _sandbox_check_dns_exfil() {
 # the next sample. Cleanup revalidates every PID against its start token.
 # Arguments: $1 - root PID, $2 - snapshot file
 _sandbox_snapshot_descendants() {
-	local snapshot_root_pid="$1"
-	local snapshot_file="$2"
+	local snapshot_root_pid="${1:-}"
+	local snapshot_file="${2:-}"
 	local snapshot_rows=""
 	local snapshot_wanted=" ${snapshot_root_pid} "
 	local snapshot_changed=true
@@ -458,9 +458,9 @@ _sandbox_snapshot_descendants() {
 }
 
 _sandbox_snapshot_identity_matches() {
-	local identity_pid="$1"
-	local identity_pgid="$2"
-	local identity_token="$3"
+	local identity_pid="${1:-}"
+	local identity_pgid="${2:-}"
+	local identity_token="${3:-}"
 	local identity_current_pgid=""
 	local identity_current_token=""
 
@@ -532,34 +532,20 @@ _sandbox_pgkill_cleanup() {
 		local cleanup_pid=""
 		local cleanup_pgid=""
 		local cleanup_token=""
-		local cleanup_verified_pids=""
-		local cleanup_verified_pgids=""
 		while IFS=$'\t' read -r cleanup_pid cleanup_pgid cleanup_token; do
 			_sandbox_snapshot_identity_matches "$cleanup_pid" "$cleanup_pgid" "$cleanup_token" || continue
-			case " $cleanup_verified_pids " in
-			*" ${cleanup_pid} "*) ;;
-			*) cleanup_verified_pids="${cleanup_verified_pids} ${cleanup_pid}" ;;
-			esac
 			# A group signal is safe only when its verified leader was descended
 			# from the sandbox. Otherwise terminate the verified PID individually.
-			if [[ "$cleanup_pid" == "$cleanup_pgid" && "$cleanup_pgid" != "$cleanup_self_pgid" ]]; then
-				case " $cleanup_verified_pgids " in
-				*" ${cleanup_pgid} "*) ;;
-				*) cleanup_verified_pgids="${cleanup_verified_pgids} ${cleanup_pgid}" ;;
-				esac
+			if [[ "$cleanup_pid" == "$cleanup_pgid" && -n "$cleanup_self_pgid" && "$cleanup_pgid" != "$cleanup_self_pgid" ]]; then
+				kill -TERM -- "-${cleanup_pgid}" 2>/dev/null || true
+			else
+				kill -TERM "$cleanup_pid" 2>/dev/null || true
 			fi
 		done <"$cleanup_snapshot_file"
-
-		for cleanup_pgid in $cleanup_verified_pgids; do
-			kill -TERM -- "-${cleanup_pgid}" 2>/dev/null || true
-		done
-		for cleanup_pid in $cleanup_verified_pids; do
-			kill -TERM "$cleanup_pid" 2>/dev/null || true
-		done
 		sleep 0.5
 		while IFS=$'\t' read -r cleanup_pid cleanup_pgid cleanup_token; do
 			_sandbox_snapshot_identity_matches "$cleanup_pid" "$cleanup_pgid" "$cleanup_token" || continue
-			if [[ "$cleanup_pid" == "$cleanup_pgid" && "$cleanup_pgid" != "$cleanup_self_pgid" ]]; then
+			if [[ "$cleanup_pid" == "$cleanup_pgid" && -n "$cleanup_self_pgid" && "$cleanup_pgid" != "$cleanup_self_pgid" ]]; then
 				kill -KILL -- "-${cleanup_pgid}" 2>/dev/null || true
 			else
 				kill -KILL "$cleanup_pid" 2>/dev/null || true

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -410,7 +410,69 @@ _sandbox_check_dns_exfil() {
 # Sandbox Execution
 # =============================================================================
 
-# Kill a child process group and its secondary watchdog.
+# Record descendant identities while the original parent still owns them.
+# Entries are append-only because a detached descendant may be reparented before
+# the next sample. Cleanup revalidates every PID against its start token.
+# Arguments: $1 - root PID, $2 - snapshot file
+_sandbox_snapshot_descendants() {
+	local snapshot_root_pid="$1"
+	local snapshot_file="$2"
+	local snapshot_rows=""
+	local snapshot_wanted=" ${snapshot_root_pid} "
+	local snapshot_changed=true
+	local snapshot_pid=""
+	local snapshot_ppid=""
+	local snapshot_pgid=""
+	local snapshot_token=""
+
+	[[ "$snapshot_root_pid" =~ ^[0-9]+$ && -n "$snapshot_file" ]] || return 0
+	snapshot_rows="$(ps -axo pid=,ppid=,pgid= 2>/dev/null)" || return 0
+	while [[ "$snapshot_changed" == true ]]; do
+		snapshot_changed=false
+		while read -r snapshot_pid snapshot_ppid snapshot_pgid; do
+			[[ "$snapshot_pid" =~ ^[0-9]+$ && "$snapshot_ppid" =~ ^[0-9]+$ ]] || continue
+			case "$snapshot_wanted" in
+			*" ${snapshot_ppid} "*)
+				case "$snapshot_wanted" in
+				*" ${snapshot_pid} "*) ;;
+				*)
+					snapshot_wanted="${snapshot_wanted}${snapshot_pid} "
+					snapshot_changed=true
+					;;
+				esac
+				;;
+			esac
+		done <<<"$snapshot_rows"
+	done
+
+	while read -r snapshot_pid snapshot_ppid snapshot_pgid; do
+		[[ "$snapshot_pid" =~ ^[0-9]+$ && "$snapshot_pid" != "$snapshot_root_pid" ]] || continue
+		case "$snapshot_wanted" in
+		*" ${snapshot_pid} "*)
+			snapshot_token="$(_sandbox_get_proc_starttime "$snapshot_pid")"
+			[[ -n "$snapshot_token" ]] && printf '%s\t%s\t%s\n' "$snapshot_pid" "$snapshot_pgid" "$snapshot_token" >>"$snapshot_file"
+			;;
+		esac
+	done <<<"$snapshot_rows"
+	return 0
+}
+
+_sandbox_snapshot_identity_matches() {
+	local identity_pid="$1"
+	local identity_pgid="$2"
+	local identity_token="$3"
+	local identity_current_pgid=""
+	local identity_current_token=""
+
+	[[ "$identity_pid" =~ ^[0-9]+$ && -n "$identity_token" ]] || return 1
+	identity_current_token="$(_sandbox_get_proc_starttime "$identity_pid")"
+	[[ -n "$identity_current_token" && "$identity_current_token" == "$identity_token" ]] || return 1
+	identity_current_pgid="$(ps -o pgid= -p "$identity_pid" 2>/dev/null | tr -d '[:space:]')" || return 1
+	[[ -n "$identity_current_pgid" && "$identity_current_pgid" == "$identity_pgid" ]] || return 1
+	return 0
+}
+
+# Kill a child process group, verified detached descendants, and its watchdog.
 # Standalone cleanup function — called explicitly on all exit paths and
 # as an EXIT trap safety net. Takes explicit arguments instead of relying
 # on closure variables (extracted from nested _pgkill_cleanup in GH#6429).
@@ -419,10 +481,12 @@ _sandbox_check_dns_exfil() {
 #   $1 - watchdog_pid (may be empty)
 #   $2 - child_pgid (may be empty)
 #   $3 - child_pid (may be empty)
+#   $4 - descendant identity snapshot file (may be empty)
 _sandbox_pgkill_cleanup() {
 	local cleanup_watchdog_pid="$1"
 	local cleanup_child_pgid="$2"
 	local cleanup_child_pid="$3"
+	local cleanup_snapshot_file="${4:-}"
 
 	# Kill the secondary watchdog first to prevent it from firing
 	# after we've already cleaned up the child.
@@ -460,6 +524,48 @@ _sandbox_pgkill_cleanup() {
 		sleep 0.5
 		kill -0 "$cleanup_child_pid" 2>/dev/null &&
 			kill -9 "$cleanup_child_pid" 2>/dev/null || true
+	fi
+
+	# Descendants may have escaped the original PGID with setsid/setpgid. Only
+	# signal entries whose PID, PGID, and start token still match the snapshot.
+	if [[ -n "$cleanup_snapshot_file" && -f "$cleanup_snapshot_file" ]]; then
+		local cleanup_pid=""
+		local cleanup_pgid=""
+		local cleanup_token=""
+		local cleanup_verified_pids=""
+		local cleanup_verified_pgids=""
+		while IFS=$'\t' read -r cleanup_pid cleanup_pgid cleanup_token; do
+			_sandbox_snapshot_identity_matches "$cleanup_pid" "$cleanup_pgid" "$cleanup_token" || continue
+			case " $cleanup_verified_pids " in
+			*" ${cleanup_pid} "*) ;;
+			*) cleanup_verified_pids="${cleanup_verified_pids} ${cleanup_pid}" ;;
+			esac
+			# A group signal is safe only when its verified leader was descended
+			# from the sandbox. Otherwise terminate the verified PID individually.
+			if [[ "$cleanup_pid" == "$cleanup_pgid" && "$cleanup_pgid" != "$cleanup_self_pgid" ]]; then
+				case " $cleanup_verified_pgids " in
+				*" ${cleanup_pgid} "*) ;;
+				*) cleanup_verified_pgids="${cleanup_verified_pgids} ${cleanup_pgid}" ;;
+				esac
+			fi
+		done <"$cleanup_snapshot_file"
+
+		for cleanup_pgid in $cleanup_verified_pgids; do
+			kill -TERM -- "-${cleanup_pgid}" 2>/dev/null || true
+		done
+		for cleanup_pid in $cleanup_verified_pids; do
+			kill -TERM "$cleanup_pid" 2>/dev/null || true
+		done
+		sleep 0.5
+		while IFS=$'\t' read -r cleanup_pid cleanup_pgid cleanup_token; do
+			_sandbox_snapshot_identity_matches "$cleanup_pid" "$cleanup_pgid" "$cleanup_token" || continue
+			if [[ "$cleanup_pid" == "$cleanup_pgid" && "$cleanup_pgid" != "$cleanup_self_pgid" ]]; then
+				kill -KILL -- "-${cleanup_pgid}" 2>/dev/null || true
+			else
+				kill -KILL "$cleanup_pid" 2>/dev/null || true
+			fi
+		done <"$cleanup_snapshot_file"
+		rm -f "$cleanup_snapshot_file" 2>/dev/null || true
 	fi
 	return 0
 }
@@ -531,13 +637,16 @@ _sandbox_spawn_child() {
 # Arguments:
 #   $1 - timeout in seconds
 #   $2 - child_pid to monitor
+#   $3 - descendant identity snapshot file
 _sandbox_poll_child() {
 	local poll_timeout="$1"
 	local poll_child_pid="$2"
+	local poll_snapshot_file="$3"
 	local half_secs_remaining=$((poll_timeout * 2))
 	local poll_state=""
 
 	while kill -0 "$poll_child_pid" 2>/dev/null; do
+		_sandbox_snapshot_descendants "$poll_child_pid" "$poll_snapshot_file"
 		poll_state="$(ps -o stat= -p "$poll_child_pid" 2>/dev/null | tr -d '[:space:]')" || true
 		if [[ "$poll_state" == *Z* ]]; then
 			return 0
@@ -585,14 +694,17 @@ _sandbox_exec_with_pgkill() {
 	local child_start_token=""
 	local t_exit_code=0
 	local watchdog_pid=""
+	local descendant_snapshot_file="${t_stderr_file}.descendants"
+	: >"$descendant_snapshot_file"
 
 	# EXIT trap uses a closure-style wrapper to pass current variable values
 	# to the standalone cleanup function.
-	trap '_sandbox_pgkill_cleanup "$watchdog_pid" "$child_pgid" "$child_pid"' EXIT
+	trap '_sandbox_pgkill_cleanup "$watchdog_pid" "$child_pgid" "$child_pid" "$descendant_snapshot_file"' EXIT
 
 	# Spawn the child in a new process group (sets child_pid, child_pgid,
 	# child_start_token via dynamic scoping).
 	_sandbox_spawn_child "$t_stdout_file" "$t_stderr_file" "$@"
+	_sandbox_snapshot_descendants "$child_pid" "$descendant_snapshot_file"
 
 	# Marker file for watchdog-initiated kills (GH#6414, CodeRabbit review).
 	# Derived from t_stderr_file path to avoid collisions across concurrent
@@ -609,9 +721,9 @@ _sandbox_exec_with_pgkill() {
 	watchdog_pid=$!
 
 	# Poll until the child exits or the deadline is reached.
-	if ! _sandbox_poll_child "$t_secs" "$child_pid"; then
+	if ! _sandbox_poll_child "$t_secs" "$child_pid" "$descendant_snapshot_file"; then
 		log_sandbox "WARN" "Command timed out after ${t_secs}s — killing process group ${child_pgid}"
-		_sandbox_pgkill_cleanup "$watchdog_pid" "$child_pgid" "$child_pid"
+		_sandbox_pgkill_cleanup "$watchdog_pid" "$child_pgid" "$child_pid" "$descendant_snapshot_file"
 		watchdog_pid=""
 		# Reap the child after killing it
 		wait "$child_pid" 2>/dev/null || true
@@ -646,7 +758,7 @@ _sandbox_exec_with_pgkill() {
 	# Explicitly clean up any remaining descendants in the process group.
 	# The EXIT trap is cleared below, so cleanup must be called explicitly
 	# here — the trap does not fire on a normal function return.
-	_sandbox_pgkill_cleanup "$watchdog_pid" "$child_pgid" "$child_pid"
+	_sandbox_pgkill_cleanup "$watchdog_pid" "$child_pgid" "$child_pid" "$descendant_snapshot_file"
 	watchdog_pid=""
 	trap - EXIT
 	return "$t_exit_code"

--- a/.agents/scripts/tests/test-sandbox-nested-process-group-cleanup.sh
+++ b/.agents/scripts/tests/test-sandbox-nested-process-group-cleanup.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../sandbox-exec-helper.sh"
+TEST_ROOT="$(mktemp -d)"
+TESTS_RUN=0
+TESTS_FAILED=0
+SURVIVOR_PIDS=""
+
+cleanup() {
+	local cleanup_pid=""
+	for cleanup_pid in $SURVIVOR_PIDS; do
+		kill -KILL "$cleanup_pid" 2>/dev/null || true
+	done
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+
+record_result() {
+	local test_name="$1"
+	local test_status="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$test_status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+	printf 'FAIL %s: %s\n' "$test_name" "$detail" >&2
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+process_is_alive() {
+	local process_pid="$1"
+	local process_state=""
+	if ! kill -0 "$process_pid" 2>/dev/null; then
+		return 1
+	fi
+	process_state="$(ps -o stat= -p "$process_pid" 2>/dev/null | tr -d '[:space:]')" || return 1
+	[[ "$process_state" != *Z* ]]
+}
+
+wait_for_pid_file() {
+	local pid_file="$1"
+	local attempts=0
+	while [[ ! -s "$pid_file" && "$attempts" -lt 30 ]]; do
+		sleep 0.1
+		attempts=$((attempts + 1))
+	done
+	[[ -s "$pid_file" ]]
+}
+
+wait_for_process_exit() {
+	local process_pid="$1"
+	local attempts=0
+	while process_is_alive "$process_pid" && [[ "$attempts" -lt 30 ]]; do
+		sleep 0.1
+		attempts=$((attempts + 1))
+	done
+	! process_is_alive "$process_pid"
+}
+
+write_fixture() {
+	local fixture_path="$1"
+	cat >"$fixture_path" <<'FIXTURE'
+#!/usr/bin/env bash
+pid_file="$1"
+mode="$2"
+setsid bash --norc --noprofile -c '
+	printf "%s\n" "$$" >"$1"
+	trap "" TERM
+	while :; do sleep 1; done
+' nested-session "$pid_file" &
+if [[ "$mode" == "timeout" ]]; then
+	wait
+else
+	sleep 1
+fi
+FIXTURE
+	chmod +x "$fixture_path"
+	return 0
+}
+
+test_timeout_cleanup() {
+	local fixture_path="${TEST_ROOT}/nested-fixture.sh"
+	local pid_file="${TEST_ROOT}/timeout.pid"
+	local sandbox_status=0
+	local nested_pid=""
+	write_fixture "$fixture_path"
+	set +e
+	"$HELPER" run --timeout 2 -- "$fixture_path" "$pid_file" timeout >/dev/null 2>&1
+	sandbox_status=$?
+	set -e
+	if ! wait_for_pid_file "$pid_file"; then
+		record_result "timeout fixture records nested PID" 1 "PID file missing"
+		return 0
+	fi
+	nested_pid="$(tr -d '[:space:]' <"$pid_file")"
+	SURVIVOR_PIDS="${SURVIVOR_PIDS} ${nested_pid}"
+	if [[ "$sandbox_status" -eq 124 ]] && wait_for_process_exit "$nested_pid"; then
+		record_result "timeout removes nested process group" 0
+	else
+		record_result "timeout removes nested process group" 1 "status=${sandbox_status} pid=${nested_pid}"
+	fi
+	return 0
+}
+
+test_normal_exit_and_unrelated_process() {
+	local fixture_path="${TEST_ROOT}/nested-fixture.sh"
+	local pid_file="${TEST_ROOT}/normal.pid"
+	local sandbox_status=0
+	local nested_pid=""
+	local unrelated_pid=""
+	sleep 30 &
+	unrelated_pid=$!
+	SURVIVOR_PIDS="${SURVIVOR_PIDS} ${unrelated_pid}"
+	set +e
+	"$HELPER" run --timeout 5 -- "$fixture_path" "$pid_file" normal >/dev/null 2>&1
+	sandbox_status=$?
+	set -e
+	if ! wait_for_pid_file "$pid_file"; then
+		record_result "normal fixture records nested PID" 1 "PID file missing"
+		return 0
+	fi
+	nested_pid="$(tr -d '[:space:]' <"$pid_file")"
+	SURVIVOR_PIDS="${SURVIVOR_PIDS} ${nested_pid}"
+	if [[ "$sandbox_status" -eq 0 ]] && wait_for_process_exit "$nested_pid"; then
+		record_result "normal exit removes nested process group" 0
+	else
+		record_result "normal exit removes nested process group" 1 "status=${sandbox_status} pid=${nested_pid}"
+	fi
+	if process_is_alive "$unrelated_pid"; then
+		record_result "cleanup leaves unrelated process alive" 0
+	else
+		record_result "cleanup leaves unrelated process alive" 1 "pid=${unrelated_pid} was signalled"
+	fi
+	return 0
+}
+
+test_start_token_mismatch() {
+	local snapshot_file="${TEST_ROOT}/recycled.tsv"
+	local candidate_pid=""
+	local candidate_pgid=""
+	sleep 30 &
+	candidate_pid=$!
+	SURVIVOR_PIDS="${SURVIVOR_PIDS} ${candidate_pid}"
+	candidate_pgid="$(ps -o pgid= -p "$candidate_pid" | tr -d '[:space:]')"
+	printf '%s\t%s\t%s\n' "$candidate_pid" "$candidate_pgid" "definitely-not-the-start-token" >"$snapshot_file"
+	# shellcheck source=../sandbox-exec-helper.sh
+	source "$HELPER"
+	_sandbox_pgkill_cleanup "" "" "" "$snapshot_file"
+	if process_is_alive "$candidate_pid"; then
+		record_result "start-token mismatch prevents recycled PID signal" 0
+	else
+		record_result "start-token mismatch prevents recycled PID signal" 1 "pid=${candidate_pid} was signalled"
+	fi
+	return 0
+}
+
+main() {
+	trap cleanup EXIT
+	if ! command -v setsid >/dev/null 2>&1; then
+		printf 'SKIP setsid is required for nested process-group fixture\n'
+		return 0
+	fi
+	test_timeout_cleanup
+	test_normal_exit_and_unrelated_process
+	test_start_token_mismatch
+	printf 'Tests run: %d\nFailures: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Track sandbox descendant PID, PGID, and start-token identities while the root is alive; preserve PGID-first cleanup and terminate only revalidated detached survivors. Add timeout, normal-exit, PID-recycling, and unrelated-process regression fixtures.

## Files Changed

.agents/scripts/sandbox-exec-helper.sh, .agents/scripts/tests/test-sandbox-nested-process-group-cleanup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-sandbox-nested-process-group-cleanup.sh; bash .agents/scripts/tests/test-sandbox-sensitive-output-guard.sh; .agents/scripts/linters-local.sh --changed

Resolves #26951


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1h 48m and 336,413 tokens on this as a headless worker.