### PR TITLE
GH#27007: Harden worker productivity safeguards

### DIFF
--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -488,7 +488,7 @@ echo "[lifecycle] defer marker" >>"$LIFECYCLE_LOG"
 
 ### Why it's a silent bug
 
-- **No observable failure.** The timeout becomes a no-op; nothing breaks loudly. Hard kill (`HARD_KILL_SECONDS`) becomes the only effective cap, defeating the purpose of the finer-grained stall timeout.
+- **No observable failure.** The stall timeout becomes a no-op; nothing breaks loudly. Because the hard elapsed threshold applies only after a confirmed stall, self-written output can defeat both checks and hide a genuinely stuck worker.
 - **Cross-function variants are subtler.** If function A writes to `$LOGFILE` and function B's polling loop reads `$LOGFILE`, A's writes register as B's "progress" — even when A had nothing to do with the work B was monitoring. (See `pulse-watchdog.sh:426` — idle-resume echo writes affect progress-check stall counter.)
 - **Bug ships unnoticed.** The canonical t3058 case shipped for ~1 year because there was no test that monitored watchdog firing in the marker-write path. Code review caught nothing; runtime behaviour caught nothing.
 

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -585,9 +585,7 @@ _merge_resolve_worktree_helper() {
 }
 
 _merge_remove_worktree_for_cleanup() {
-	local worktree_path="$1"
-	local branch_name="$2"
-	local canonical_dir="$3"
+	local branch_name="$1"
 	local helper_path=""
 
 	helper_path=$(_merge_resolve_worktree_helper 2>/dev/null || true)
@@ -621,7 +619,7 @@ _merge_cleanup_linked_worktree() {
 		return 0
 	fi
 
-	if _merge_remove_worktree_for_cleanup "$worktree_path" "$branch_name" "$canonical_dir"; then
+	if _merge_remove_worktree_for_cleanup "$branch_name"; then
 		git push origin --delete "$branch_name" >/dev/null 2>&1 || true
 		git branch -D "$branch_name" >/dev/null 2>&1 || true
 		print_success "Post-merge worktree cleanup complete for ${branch_name}"

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -593,12 +593,12 @@ _merge_remove_worktree_for_cleanup() {
 	helper_path=$(_merge_resolve_worktree_helper 2>/dev/null || true)
 	if [[ -n "$helper_path" ]]; then
 		WORKTREE_FORCE_REMOVE=1 "$helper_path" remove "$branch_name" --force >/dev/null 2>&1 && return 0
-		print_warning "Post-merge worktree cleanup: helper removal failed for ${branch_name}; trying git worktree remove"
+		print_warning "Post-merge worktree cleanup: guarded helper deferred removal for ${branch_name}"
+		return 1
 	fi
 
-	git -C "$canonical_dir" worktree remove --force "$worktree_path" >/dev/null 2>&1 || return 1
-	git -C "$canonical_dir" worktree prune >/dev/null 2>&1 || true
-	return 0
+	print_warning "Post-merge worktree cleanup: guarded worktree helper unavailable for ${branch_name}"
+	return 1
 }
 
 _merge_cleanup_linked_worktree() {

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -2028,9 +2028,8 @@ cmd_run() {
 			# reuse them here instead of re-declaring the literal so the
 			# repeated-string ratchet is not crossed.
 			local _ledger_fail="fail"
-			append_runtime_metric "$role" "$session_key" "$selected_model" \
-				"$(extract_provider "$selected_model")" \
-				"$_run_result_label" "79" "$_run_failure_reason" "1" "0"
+			# _execute_run_attempt already emitted the context-rich terminal metric.
+			# Do not append a second sparse row for the same hard-kill outcome.
 			_cmd_run_finish "$session_key" "$_ledger_fail"
 			return 1
 		fi

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -442,8 +442,9 @@ _opencode_project_table_migration_replay_detected() {
 #
 # Includes an activity watchdog. The timeout is a recovery backstop, not a
 # success/failure policy: output-active, CPU-active, and CI-wait states are
-# allowed to continue until the hard elapsed cap, while explicit provider
-# failures still recover promptly. Default is 600s because OpenAI/GPT-5.x
+# allowed to continue; the hard elapsed threshold applies only after a confirmed
+# output stall. Explicit provider failures still recover promptly. Default is
+# 600s because OpenAI/GPT-5.x
 # workers can spend several minutes reasoning before emitting more JSON/log
 # output; 300s caused false no-output kills before implementation/PR creation.
 _invoke_opencode() {

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -911,8 +911,9 @@ _activity_watchdog_handle_stall() {
 #
 # Runs as a background process alongside the worker. Polls the output file for
 # growth. Timing thresholds are recovery backstops, not strict success/failure
-# policy: output-active and CI-wait states continue until the hard elapsed cap,
-# while explicit provider failures recover promptly.
+# policy: output-active and CI-wait states continue, while the hard elapsed
+# threshold applies only after a confirmed stall. Explicit provider failures
+# recover promptly.
 #
 # The initial output always contains the sandbox startup line (~300 bytes).
 # This is NOT activity -- it's just the executor logging. Real activity

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -863,7 +863,11 @@ _worker_external_terminal_complete() {
 
 	local branch_name="${WORKER_TARGET_BRANCH:-}"
 	if [[ -n "$work_dir" && -d "$work_dir" ]]; then
-		branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+		local live_branch_name=""
+		live_branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+		if [[ -n "$live_branch_name" && "$live_branch_name" != "HEAD" ]]; then
+			branch_name="$live_branch_name"
+		fi
 	fi
 	[[ -n "$branch_name" && "$branch_name" != "HEAD" ]] || return 1
 

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -861,7 +861,7 @@ _worker_external_terminal_complete() {
 	issue_state=$(gh issue view "$issue_number" --repo "$repo_slug" --json state --jq '.state // empty' 2>/dev/null || true)
 	[[ "$issue_state" == "CLOSED" ]] || return 1
 
-	local branch_name=""
+	local branch_name="${WORKER_TARGET_BRANCH:-}"
 	if [[ -n "$work_dir" && -d "$work_dir" ]]; then
 		branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 	fi
@@ -1280,6 +1280,11 @@ _cmd_run_prepare() {
 	# t2923: Expose worktree path to exit trap handler so _push_wip_commits_on_exit
 	# can push any local-only commits before the worker releases its claim.
 	export _WORKER_WORKTREE_PATH="$work_dir"
+	# Preserve the dispatch branch independently of the directory. If guarded
+	# cleanup or another actor moves the worktree before final reconciliation,
+	# durable GitHub terminal-state checks can still match the merged PR.
+	WORKER_TARGET_BRANCH=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+	export WORKER_TARGET_BRANCH
 	_hrw_claim_worker_worktree "$session_key" "$work_dir" || return 1
 
 	# GH#6696: Register this dispatch in the in-flight ledger so the pulse

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -25,6 +25,7 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
 ($current.worker_terminal_events // 0 | number_or_zero) as $current_terminal_events |
 ($recent_summary.metrics.total // 0 | number_or_zero) as $recent_total |
 ($summary.metrics.total // 0 | number_or_zero) as $hist_total |
+($summary.metrics.terminal_session_total // $summary.metrics.total // 0 | number_or_zero) as $hist_terminal_total |
 ($summary.metrics.succeeded // 0 | number_or_zero) as $hist_success |
 ($api.graphql_circuit_breaker_trips // 0 | number_or_zero) as $graphql_trips |
 {
@@ -44,7 +45,7 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     recent_worker_events: $recent_total,
     historical_worker_events: $hist_total,
     historical_worker_successes: $hist_success,
-    historical_success_rate: (if $hist_total > 0 then (($hist_success / $hist_total) * 100 | floor) else null end),
+    historical_success_rate: (if $hist_terminal_total > 0 then (($hist_success / $hist_terminal_total) * 100 | floor) else null end),
     auto_dispatch_open: ($queue.aggregate.auto_dispatch_open // 0),
     auto_dispatch_available_unassigned: $available_issues,
     auto_dispatch_available_old: $old_available,
@@ -159,12 +160,12 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
         true
       )
     else empty end,
-    if ($hist_total >= 10 and (($hist_success * 100) / $hist_total) < 70) then
+    if ($hist_terminal_total >= 10 and (($hist_success * 100) / $hist_terminal_total) < 70) then
       finding(
         "worker-success-rate-regression";
         "medium";
         "Historical worker success rate is below the productivity target";
-        [("success_rate_percent=" + (((($hist_success * 100) / $hist_total) | floor) | tostring)), ("worker_events=" + ($hist_total | tostring))];
+        [("success_rate_percent=" + (((($hist_success * 100) / $hist_terminal_total) | floor) | tostring)), ("terminal_session_outcomes=" + ($hist_terminal_total | tostring)), ("worker_events=" + ($hist_total | tostring))];
         "Cluster failure families with worker-activity-helper summary --json, then file targeted fixes for the dominant cause instead of increasing concurrency.";
         false
       )

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -226,6 +226,29 @@ test_cmd_merge_removes_current_linked_worktree() {
 	return 0
 }
 
+test_cmd_merge_defers_cleanup_for_live_process_cwd() {
+	setup_subject
+	local canonical_repo="${TEST_ROOT}/repo"
+	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
+	local sleeper_pid=""
+	(
+		cd "$worktree_path" || exit 2
+		sleep 30
+	) &
+	sleeper_pid=$!
+	sleep 1
+
+	cmd_merge "123" "example/repo" --squash
+
+	local rc=0
+	[[ -d "$worktree_path" ]] || rc=1
+	git -C "$canonical_repo" worktree list --porcelain | grep -qF "$worktree_path" || rc=1
+	kill "$sleeper_pid" 2>/dev/null || true
+	wait "$sleeper_pid" 2>/dev/null || true
+	print_result "cmd_merge defers cleanup while another process uses worktree cwd" "$rc"
+	return 0
+}
+
 test_refresh_canonical_pulls_when_default_checked_out() {
 	local canonical_repo="${TEST_ROOT}/repo-default"
 	local origin_repo="${TEST_ROOT}/origin-default.git"
@@ -265,6 +288,7 @@ main() {
 	setup_subject
 	test_refresh_canonical_pulls_when_default_checked_out
 	test_cmd_merge_removes_current_linked_worktree
+	test_cmd_merge_defers_cleanup_for_live_process_cwd
 	printf '\n%d/%d tests passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
 	[[ "$TESTS_FAILED" -eq 0 ]] || return 1
 	return 0

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -2587,6 +2587,7 @@ test_cmd_run_finish_fail_confirmed_terminal_state_releases_complete() {
 	WORKER_TARGET_BRANCH=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD)
 	export WORKER_TARGET_BRANCH
 	rm -rf "$work_dir"
+	mkdir -p "$work_dir"
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
 	gh() {
 		if [[ "${*}" == *"issue view"* ]]; then printf 'CLOSED'
@@ -2607,7 +2608,7 @@ test_cmd_run_finish_fail_confirmed_terminal_state_releases_complete() {
 	unset WORKER_TARGET_BRANCH 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 	if [[ "$released_reason" == "worker_complete" && "$fast_fail_called" -eq 0 ]]; then
-		print_result "_cmd_run_finish fail uses cached branch for confirmed terminal GitHub state" 0
+		print_result "_cmd_run_finish fail uses cached branch when live worktree lookup is invalid" 0
 	else
 		print_result "_cmd_run_finish fail treats confirmed terminal GitHub state as complete" 1 \
 			"Expected worker_complete and no fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -2584,6 +2584,9 @@ test_cmd_run_finish_fail_confirmed_terminal_state_releases_complete() {
 	local work_dir="${TEST_ROOT}/repo-fail-terminal-complete"
 	local released_reason="" fast_fail_called=0
 	_setup_test_git_repo "$work_dir" 1
+	WORKER_TARGET_BRANCH=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD)
+	export WORKER_TARGET_BRANCH
+	rm -rf "$work_dir"
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
 	gh() {
 		if [[ "${*}" == *"issue view"* ]]; then printf 'CLOSED'
@@ -2601,9 +2604,10 @@ test_cmd_run_finish_fail_confirmed_terminal_state_releases_complete() {
 	_cmd_run_finish "issue-99999" "fail" "$work_dir"
 
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset WORKER_TARGET_BRANCH 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 	if [[ "$released_reason" == "worker_complete" && "$fast_fail_called" -eq 0 ]]; then
-		print_result "_cmd_run_finish fail treats confirmed terminal GitHub state as complete" 0
+		print_result "_cmd_run_finish fail uses cached branch for confirmed terminal GitHub state" 0
 	else
 		print_result "_cmd_run_finish fail treats confirmed terminal GitHub state as complete" 1 \
 			"Expected worker_complete and no fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -132,7 +132,7 @@ if [[ "$since" == "1h" ]]; then
 JSON
 else
   cat <<'JSON'
-{"window":{"since":"24h"},"metrics":{"total":10,"succeeded":8,"result_counts":{"success":8,"blocked":2},"diagnostic_focus":{},"timing_ms":{"samples":10,"avg":1000,"max":2000},"recent_examples":[{"repo_slug":"private/repo-one"}],"failure_groups":[],"failure_families":[]},"pulse_stats":{}}
+{"window":{"since":"24h"},"metrics":{"total":20,"terminal_session_total":10,"succeeded":9,"result_counts":{"success":9,"blocked":1},"diagnostic_focus":{},"timing_ms":{"samples":10,"avg":1000,"max":2000},"recent_examples":[{"repo_slug":"private/repo-one"}],"failure_groups":[],"failure_families":[]},"pulse_stats":{}}
 JSON
 fi
 SH
@@ -236,6 +236,8 @@ JSON_PRIVATE_COUNT=$(printf '%s' "$JSON_OUT" | grep -c "private/repo-one" 2>/dev
 assert_eq "json output removes raw worker examples" "0" "$JSON_PRIVATE_COUNT"
 ACTIVE_SOURCE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.active_workers_source')
 assert_eq "json uses process scan when available" "process_scan" "$ACTIVE_SOURCE"
+SUCCESS_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_success_rate')
+assert_eq "json success rate uses terminal session denominator" "90" "$SUCCESS_RATE"
 
 cat >"${TEST_ROOT}/current-state-active.sh" <<'SH'
 #!/usr/bin/env bash

--- a/.agents/scripts/tests/test-watchdog-hard-kill-continuous-output.sh
+++ b/.agents/scripts/tests/test-watchdog-hard-kill-continuous-output.sh
@@ -3,8 +3,9 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # test-watchdog-hard-kill-continuous-output.sh — GH#26469 regression test.
 #
-# Verifies worker-activity-watchdog.sh enforces HARD_KILL_SECONDS even when the
-# worker output file keeps growing and never reaches STALL_TIMEOUT.
+# Verifies HARD_KILL_SECONDS applies only to confirmed stalls. Continuous output
+# remains alive past the threshold, then the same worker is killed after output
+# stops and STALL_TIMEOUT is reached.
 
 set -euo pipefail
 
@@ -12,11 +13,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WATCHDOG_SCRIPT="${SCRIPT_DIR}/worker-activity-watchdog.sh"
 TEST_ROOT=""
 WORKER_PID=""
+WRITER_PID=""
+WATCHDOG_PID=""
 
 cleanup() {
 	if [[ -n "$WORKER_PID" ]]; then
 		kill "$WORKER_PID" >/dev/null 2>&1 || true
 		kill -9 "$WORKER_PID" >/dev/null 2>&1 || true
+	fi
+	if [[ -n "$WRITER_PID" ]]; then
+		kill "$WRITER_PID" >/dev/null 2>&1 || true
+		wait "$WRITER_PID" 2>/dev/null || true
+	fi
+	if [[ -n "$WATCHDOG_PID" ]]; then
+		kill "$WATCHDOG_PID" >/dev/null 2>&1 || true
+		wait "$WATCHDOG_PID" 2>/dev/null || true
 	fi
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
@@ -60,14 +71,10 @@ main() {
 	local lifecycle_log="${TEST_ROOT}/lifecycle.log"
 
 	: >"$output_file"
-	(
-		trap 'exit 0' TERM
-		while true; do
-			printf 'tick %s\n' "$(date +%s%N)" >>"$output_file"
-			sleep 0.2
-		done
-	) 2>/dev/null &
+	(trap 'exit 0' TERM; while true; do sleep 1; done) 2>/dev/null &
 	WORKER_PID=$!
+	(while true; do printf 'tick %s\n' "$(date +%s%N)" >>"$output_file"; sleep 0.2; done) 2>/dev/null &
+	WRITER_PID=$!
 
 	WORKER_LIFECYCLE_LOG="$lifecycle_log" "$WATCHDOG_SCRIPT" \
 		--output-file "$output_file" \
@@ -75,8 +82,23 @@ main() {
 		--exit-code-file "$exit_code_file" \
 		--phase1-timeout 1 \
 		--poll-interval 1 \
-		--stall-timeout 60 \
-		--hard-kill-seconds 2
+		--stall-timeout 2 \
+		--hard-kill-seconds 2 &
+	WATCHDOG_PID=$!
+
+	# The wall-clock threshold alone must not kill an output-active worker.
+	sleep 3
+	if [[ -e "${exit_code_file}.watchdog_killed" ]] || ! kill -0 "$WORKER_PID" 2>/dev/null; then
+		fail "output-active worker was killed at the wall-clock threshold"
+	fi
+
+	# Stop output while leaving the worker alive. The confirmed stall is already
+	# beyond the threshold, so it should now take the hard-kill path.
+	kill "$WRITER_PID" >/dev/null 2>&1 || true
+	wait "$WRITER_PID" 2>/dev/null || true
+	WRITER_PID=""
+	wait "$WATCHDOG_PID"
+	WATCHDOG_PID=""
 
 	assert_file_exists "${exit_code_file}.watchdog_killed" "watchdog kill sentinel"
 	assert_file_exists "${exit_code_file}.watchdog_stall_killed" "hard-kill sentinel"
@@ -85,7 +107,7 @@ main() {
 	assert_file_contains "$output_file" "hard_kill:" "worker output kill reason"
 	assert_file_contains "$lifecycle_log" "reason=hard_kill_stall" "lifecycle log"
 
-	printf 'PASS: continuous output does not bypass hard-kill cap\n'
+	printf 'PASS: hard-kill cap applies only after confirmed output stall\n'
 	return 0
 }
 

--- a/.agents/scripts/tests/test-watchdog-stall-cap.sh
+++ b/.agents/scripts/tests/test-watchdog-stall-cap.sh
@@ -220,6 +220,39 @@ test_cmd_run_kills_after_stall_cap() {
 	return 0
 }
 
+test_cmd_run_does_not_duplicate_exit_79_metric() {
+	local metric_calls=0
+	local finish_status=""
+
+	append_runtime_metric() {
+		metric_calls=$((metric_calls + 1))
+		return 0
+	}
+	_execute_run_attempt() {
+		_run_result_label="watchdog_stall_killed"
+		_run_failure_reason="watchdog_stall_killed"
+		_run_activity_detected="1"
+		append_runtime_metric worker test-stall-cap anthropic/claude-sonnet-4-6 anthropic \
+			watchdog_stall_killed 79 watchdog_stall_killed 1 100
+		return 79
+	}
+	_cmd_run_finish() { finish_status="${2:-}"; return 0; }
+
+	local cmd_exit=0
+	cmd_run --role worker --session-key "test-stall-cap" \
+		--dir "/tmp" --title "test" --prompt "test prompt" 2>/dev/null || cmd_exit=$?
+
+	local passed=1
+	local msg=""
+	if [[ "$metric_calls" -eq 1 && "$finish_status" == "fail" && "$cmd_exit" -eq 1 ]]; then
+		passed=0
+	else
+		msg="metric_calls=${metric_calls} finish_status=${finish_status} cmd_exit=${cmd_exit}"
+	fi
+	print_result "cmd_run records one context-rich metric for exit 79" "$passed" "$msg"
+	return 0
+}
+
 main() {
 	setup_test_env
 
@@ -234,6 +267,7 @@ main() {
 
 	# cmd_run integration test
 	test_cmd_run_kills_after_stall_cap
+	test_cmd_run_does_not_duplicate_exit_79_metric
 
 	teardown_test_env
 

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -131,6 +131,12 @@ T_FUTURE_SENTINEL_MS=$((T_FUTURE_SENTINEL * 1000))
 	printf '{"ts":%d,"role":"worker","session_key":"issue-12","model":"openai/gpt-5.5","provider":"openai","result":"service_interruption_exhausted","failure_reason":"local_error","runtime_error_type":"sigterm","launch_failure_cause":"local_runtime_error","next_action":"inspect_failure_excerpt_and_retry_if_transient","exit_code":81}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-14","model":"openai/gpt-5.5","provider":"openai","result":"local_kill","failure_reason":"no_output_stall","runtime_error_type":"sigterm","classification_source":"worker_kill_reason_sentinel","classification_pattern":"no_output_stall","launch_failure_cause":"local_kill","kill_reason":"no_output_stall","next_action":"inspect_local_kill_source","exit_code":83}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-15","model":"openai/gpt-5.5","provider":"openai","result":"provider_error","runtime_error_type":false,"exit_code":82}\n' "$T_2H_AGO"
+	# Historical duplicate sparse hard-kill row: must collapse into issue-3 and
+	# preserve the richer row above rather than counting a second failure.
+	printf '{"ts":%d,"role":"worker","session_key":"issue-3","result":"watchdog_stall_killed","exit_code":79}\n' "$T_2H_AGO"
+	# One logical session with a resumable interruption followed by success.
+	printf '{"ts":%d,"role":"worker","session_key":"issue-16","result":"signal_killed_continue","exit_code":78}\n' "$T_5MIN_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-16","result":"success","exit_code":0}\n' "$T_5MIN_AGO"
 } >"$METRICS"
 
 cat >"$OAUTH_POOL" <<EOF
@@ -215,11 +221,14 @@ else
 	echo "  output: $(printf '%q' "${JSON:0:300}")"
 fi
 
-# Assert exact counts. 24h window: events 1-6 + 8 + 11 + 12 + 14 + 15, excludes 7 (25h ago).
+# Assert exact terminal-session counts. Raw attempts collapse by session key;
+# continuation-only sessions are reported separately and omitted from outcomes.
 # issue-8 (watchdog_stall_continue with exit_code=124) tests the t3215
 # regression case — must count as wc, not of, despite non-zero exit.
-assert_eq "2c: total = 11" "11" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
-assert_eq "2d: succeeded = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
+assert_eq "2c: terminal outcomes = 9" "9" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "2c2: raw event total = 14" "14" "$(printf '%s' "$JSON" | jq -r '.metrics.event_total')"
+assert_eq "2c3: continuation events = 4" "4" "$(printf '%s' "$JSON" | jq -r '.metrics.continuation_events')"
+assert_eq "2d: succeeded = 3" "3" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
 assert_eq "2e: watchdog_killed = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
 assert_eq "2f: watchdog_continued = 2 (incl. nonzero-exit heartbeat)" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
@@ -228,9 +237,11 @@ assert_eq "2f2: service_interrupted = 1 (heartbeat)" "1" \
 assert_eq "2g: rate_limited = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.rate_limited')"
 assert_eq "2h: other_failure = 4 (heartbeat excluded, exhausted/local kill counted)" "4" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.other_failure')"
-assert_eq "2h2: rich result_counts includes success bucket" "2" \
+assert_eq "2h2: terminal result_counts includes success bucket" "3" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.result_counts.success')"
-assert_eq "2h3: timing summary includes samples" "11" \
+assert_eq "2h2b: raw result counts retain continuation evidence" "1" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.event_result_counts.signal_killed_continue')"
+assert_eq "2h3: timing summary includes terminal samples" "9" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.timing_ms.samples')"
 assert_eq "2h4: recent example carries load context" "2.0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-1") | .load_1min')"
@@ -248,11 +259,11 @@ assert_eq "2h10: failure groups expose provider status" "500" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-6") | .provider_status')"
 assert_eq "2h10b: failure groups expose classification pattern" "server_error|5xx|connection_failure|overloaded" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-6") | .classification_pattern')"
-assert_eq "2h11: failure groups carry provider evidence" "openai/gpt-5.5" \
-	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-11") | .model')"
+assert_eq "2h11: continuation-only session omitted from terminal failure groups" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.session_key == "issue-11")] | length')"
 assert_eq "2h12: diagnostic focus counts stall-killed sessions" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.diagnostic_focus.stall_hard_killed')"
-assert_eq "2h13: diagnostic focus counts local runtime errors" "2" \
+assert_eq "2h13: diagnostic focus counts terminal local runtime errors" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.diagnostic_focus.local_runtime_error')"
 assert_eq "2h13b: failure groups preserve false runtime markers" "false" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_groups[] | select(.session_key == "issue-15") | .runtime_error_type')"
@@ -286,10 +297,10 @@ echo
 echo "--- Section 3: 1h window ---"
 
 JSON=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 1h --no-pr-check --json 2>&1)
-# 1h window: only events at 5min ago (issue-1, issue-4) qualify; future
-# sentinel and missing-ts rows are invalid worker evidence.
-assert_eq "3a: 1h total = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
-assert_eq "3b: 1h succeeded = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
+# 1h window: issue-1 and resumed issue-16 are terminal successes; issue-4 is
+# continuation-only and therefore excluded from the outcome denominator.
+assert_eq "3a: 1h terminal total = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "3b: 1h succeeded = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
 assert_eq "3c: 1h watchdog_continued = 1" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
 assert_eq "3d: 1h watchdog_killed = 0" "0" \
@@ -324,7 +335,7 @@ OUT=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 24h --no-pr-check 2>&1)
 assert_contains "5a: human output names canonical jsonl source" \
 	"headless-runtime-metrics.jsonl" "$OUT"
 assert_contains "5b: human output names pulse-stats" "pulse-stats.json" "$OUT"
-assert_contains "5c: human output shows succeeded count" "Succeeded:                   2" "$OUT"
+assert_contains "5c: human output shows succeeded count" "Succeeded:                   3" "$OUT"
 assert_contains "5d: human output shows watchdog continued is heartbeat" \
 	"heartbeat" "$OUT"
 assert_contains "5d2: human output shows service interruption resumes" \

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -133,10 +133,17 @@ T_FUTURE_SENTINEL_MS=$((T_FUTURE_SENTINEL * 1000))
 	printf '{"ts":%d,"role":"worker","session_key":"issue-15","model":"openai/gpt-5.5","provider":"openai","result":"provider_error","runtime_error_type":false,"exit_code":82}\n' "$T_2H_AGO"
 	# Historical duplicate sparse hard-kill row: must collapse into issue-3 and
 	# preserve the richer row above rather than counting a second failure.
-	printf '{"ts":%d,"role":"worker","session_key":"issue-3","result":"watchdog_stall_killed","exit_code":79}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-3","model":"openai/gpt-5.5","provider":"openai","result":"watchdog_stall_killed","failure_reason":"watchdog_stall_killed","exit_code":79}\n' "$((T_2H_AGO + 1))"
 	# One logical session with a resumable interruption followed by success.
 	printf '{"ts":%d,"role":"worker","session_key":"issue-16","result":"signal_killed_continue","exit_code":78}\n' "$T_5MIN_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-16","result":"success","exit_code":0}\n' "$T_5MIN_AGO"
+	# Identical session keys in different repositories are independent outcomes.
+	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-a","session_key":"issue-17","result":"success","exit_code":0}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-b","session_key":"issue-17","result":"provider_error","exit_code":2}\n' "$T_2H_AGO"
+	# A context-rich unscoped legacy event is not a sparse duplicate and must
+	# remain distinct from a scoped event with the same session key.
+	printf '{"ts":%d,"role":"worker","session_key":"issue-18","issue_number":18,"model":"openai/gpt-5.5","result":"success","exit_code":0}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-c","session_key":"issue-18","result":"provider_error","exit_code":2}\n' "$((T_2H_AGO + 1))"
 } >"$METRICS"
 
 cat >"$OAUTH_POOL" <<EOF
@@ -225,23 +232,24 @@ fi
 # continuation-only sessions are reported separately and omitted from outcomes.
 # issue-8 (watchdog_stall_continue with exit_code=124) tests the t3215
 # regression case — must count as wc, not of, despite non-zero exit.
-assert_eq "2c: terminal outcomes = 9" "9" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
-assert_eq "2c2: raw event total = 14" "14" "$(printf '%s' "$JSON" | jq -r '.metrics.event_total')"
+assert_eq "2c: raw event total remains backward compatible" "18" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "2c2: terminal session outcomes = 13" "13" "$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
+assert_eq "2c2b: event_total aliases raw total" "18" "$(printf '%s' "$JSON" | jq -r '.metrics.event_total')"
 assert_eq "2c3: continuation events = 4" "4" "$(printf '%s' "$JSON" | jq -r '.metrics.continuation_events')"
-assert_eq "2d: succeeded = 3" "3" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
+assert_eq "2d: succeeded = 5" "5" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
 assert_eq "2e: watchdog_killed = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
 assert_eq "2f: watchdog_continued = 2 (incl. nonzero-exit heartbeat)" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
 assert_eq "2f2: service_interrupted = 1 (heartbeat)" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.service_interrupted')"
 assert_eq "2g: rate_limited = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.rate_limited')"
-assert_eq "2h: other_failure = 4 (heartbeat excluded, exhausted/local kill counted)" "4" \
+assert_eq "2h: other_failure = 6 (heartbeat excluded, scoped failures counted)" "6" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.other_failure')"
-assert_eq "2h2: terminal result_counts includes success bucket" "3" \
+assert_eq "2h2: terminal result_counts includes success bucket" "5" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.result_counts.success')"
 assert_eq "2h2b: raw result counts retain continuation evidence" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.event_result_counts.signal_killed_continue')"
-assert_eq "2h3: timing summary includes terminal samples" "9" \
+assert_eq "2h3: timing summary includes terminal samples" "13" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.timing_ms.samples')"
 assert_eq "2h4: recent example carries load context" "2.0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.session_key == "issue-1") | .load_1min')"
@@ -273,7 +281,6 @@ assert_eq "2h15: diagnostic focus groups local kills separately" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.diagnostic_focus.local_kill')"
 assert_eq "2h16: failure families expose local kill next action" "inspect_local_kill_source" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.failure_families[] | select(.launch_failure_cause == "local_kill") | .next_action')"
-
 # Pulse-stats counters (24h window: 25h-ago timestamp must be excluded).
 assert_eq "2i: circuit_broken = 2" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.pulse_dispatch_circuit_broken')"
@@ -299,7 +306,8 @@ echo "--- Section 3: 1h window ---"
 JSON=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 1h --no-pr-check --json 2>&1)
 # 1h window: issue-1 and resumed issue-16 are terminal successes; issue-4 is
 # continuation-only and therefore excluded from the outcome denominator.
-assert_eq "3a: 1h terminal total = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "3a: 1h raw total = 4" "4" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "3a2: 1h terminal total = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
 assert_eq "3b: 1h succeeded = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
 assert_eq "3c: 1h watchdog_continued = 1" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
@@ -335,7 +343,7 @@ OUT=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 24h --no-pr-check 2>&1)
 assert_contains "5a: human output names canonical jsonl source" \
 	"headless-runtime-metrics.jsonl" "$OUT"
 assert_contains "5b: human output names pulse-stats" "pulse-stats.json" "$OUT"
-assert_contains "5c: human output shows succeeded count" "Succeeded:                   3" "$OUT"
+assert_contains "5c: human output shows succeeded count" "Succeeded:                   5" "$OUT"
 assert_contains "5d: human output shows watchdog continued is heartbeat" \
 	"heartbeat" "$OUT"
 assert_contains "5d2: human output shows service interruption resumes" \
@@ -361,7 +369,7 @@ assert_eq "6b: openai available accounts exclude auth-error/rate-limited" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .available')"
 assert_eq "6c: openai capacity_slots uses redacted multiplier" "48" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .capacity_slots')"
-assert_eq "6c2: nonzero-exit success counts as other provider failure" "6" \
+assert_eq "6c2: provider diagnostics retain raw duplicate/attempt evidence" "7" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.provider_model_usage[] | select(.provider == "openai" and .model == "openai/gpt-5.5") | .other_failure')"
 
 JSONC_DEFAULTS="$FIXTURE_DIR/aidevops.defaults.jsonc"

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -49,6 +49,18 @@ WAH_SERVICE_INTERRUPTION_RESULT="service_interruption_continue"
 WAH_RESULT_WATCHDOG_STALL_KILLED="watchdog_stall_killed"
 WAH_RESULT_LOCAL_KILL="local_kill"
 
+# Shared jq definitions keep terminal-session semantics identical in the scalar
+# and rich aggregators without duplicating a long filter in both functions.
+WAH_SESSION_OUTCOME_JQ='
+	def _wah_nonterminal:
+		((.result // "") | endswith("_continue")) or (.result == "brief_recovery");
+	def _wah_session_outcomes:
+		to_entries
+		| group_by(if ((.value.session_key // "") | length) > 0 then .value.session_key else "__event_\(.key)" end)
+		| map(sort_by([(.value.ts // 0), (if (.value.issue_number // null) != null then 1 else 0 end), .key]) | last.value)
+		| map(select(_wah_nonterminal | not));
+'
+
 #######################################
 # Convert short window spec to seconds. Caller owns the cutoff math.
 # $1 — one of 1h | 6h | 24h | 48h | 7d
@@ -105,14 +117,9 @@ _wah_aggregate_metrics() {
 	local result service_result watchdog_killed_result
 	service_result="$WAH_SERVICE_INTERRUPTION_RESULT"
 	watchdog_killed_result="$WAH_RESULT_WATCHDOG_STALL_KILLED"
-	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" '
-		def _wah_nonterminal:
-			((.result // "") | endswith("_continue")) or (.result == "brief_recovery");
-		def _wah_session_outcomes:
-			to_entries
-			| group_by(if ((.value.session_key // "") != "") then .value.session_key else "__event_\(.key)" end)
-			| map(sort_by([(.value.ts // 0), (if (.value.issue_number // null) != null then 1 else 0 end), .key]) | last.value)
-			| map(select(_wah_nonterminal | not));
+	local jq_program
+	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
+	jq_program=$WAH_SESSION_OUTCOME_JQ'
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
 		| ($events | _wah_session_outcomes) as $w | {
 			total:  ($w | length),
@@ -129,7 +136,8 @@ _wah_aggregate_metrics() {
 				and .result != "rate_limit"
 			)] | length)
 		} | "\(.total) \(.succ) \(.wk) \(.wc) \(.sic) \(.rl) \(.of)"
-	' <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0"
+	'
+	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" "$jq_program" <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0"
 
 	[[ -n "$result" ]] || result="0 0 0 0 0 0 0"
 	printf '%s\n' "$result"
@@ -154,15 +162,10 @@ _wah_metric_details_json() {
 	fi
 	now_epoch="${2:-$(date +%s)}"
 
-	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" '
+	local jq_program
+	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
+	jq_program=$WAH_SESSION_OUTCOME_JQ'
 		def _wah_empty_if_null: if . == null then "" else . end;
-		def _wah_nonterminal:
-			((.result // "") | endswith("_continue")) or (.result == "brief_recovery");
-		def _wah_session_outcomes:
-			to_entries
-			| group_by(if ((.value.session_key // "") != "") then .value.session_key else "__event_\(.key)" end)
-			| map(sort_by([(.value.ts // 0), (if (.value.issue_number // null) != null then 1 else 0 end), .key]) | last.value)
-			| map(select(_wah_nonterminal | not));
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
 		| ($events | _wah_session_outcomes) as $w
 		| ($w | map(.duration_ms // 0)) as $durations
@@ -243,7 +246,8 @@ _wah_metric_details_json() {
 					examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, session_key, issue_number, repo_slug, result, exit_code, output_file, launch_failure_cause, kill_reason, next_action}))
 				})
 				| sort_by(.count) | reverse | .[0:10])
-		}' <"$metrics" 2>/dev/null || \
+		}'
+	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" "$jq_program" <"$metrics" 2>/dev/null || \
 		printf '{"result_counts":{},"diagnostic_focus":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[],"failure_groups":[],"failure_families":[]}'
 	return 0
 }

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -106,12 +106,20 @@ _wah_aggregate_metrics() {
 	service_result="$WAH_SERVICE_INTERRUPTION_RESULT"
 	watchdog_killed_result="$WAH_RESULT_WATCHDOG_STALL_KILLED"
 	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" '
-		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w | {
+		def _wah_nonterminal:
+			((.result // "") | endswith("_continue")) or (.result == "brief_recovery");
+		def _wah_session_outcomes:
+			to_entries
+			| group_by(if ((.value.session_key // "") != "") then .value.session_key else "__event_\(.key)" end)
+			| map(sort_by([(.value.ts // 0), (if (.value.issue_number // null) != null then 1 else 0 end), .key]) | last.value)
+			| map(select(_wah_nonterminal | not));
+		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
+		| ($events | _wah_session_outcomes) as $w | {
 			total:  ($w | length),
 			succ:   ([$w[] | select(.result == "success" and .exit_code == 0)] | length),
 			wk:     ([$w[] | select(.result == $watchdog_killed_result)] | length),
-			wc:     ([$w[] | select(.result == "watchdog_stall_continue")] | length),
-			sic:    ([$w[] | select(.result == $service_result)] | length),
+			wc:     ([$events[] | select(.result == "watchdog_stall_continue")] | length),
+			sic:    ([$events[] | select(.result == $service_result)] | length),
 			rl:     ([$w[] | select(.result == "rate_limit")] | length),
 			of:     ([$w[] | select(
 				(.result != "success" or .exit_code != 0)
@@ -148,11 +156,22 @@ _wah_metric_details_json() {
 
 	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" '
 		def _wah_empty_if_null: if . == null then "" else . end;
-		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
+		def _wah_nonterminal:
+			((.result // "") | endswith("_continue")) or (.result == "brief_recovery");
+		def _wah_session_outcomes:
+			to_entries
+			| group_by(if ((.value.session_key // "") != "") then .value.session_key else "__event_\(.key)" end)
+			| map(sort_by([(.value.ts // 0), (if (.value.issue_number // null) != null then 1 else 0 end), .key]) | last.value)
+			| map(select(_wah_nonterminal | not));
+		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
+		| ($events | _wah_session_outcomes) as $w
 		| ($w | map(.duration_ms // 0)) as $durations
 		| ($w | map(select((.result // "") != "success" or (.exit_code // 1) != 0))) as $failures
 		| {
+			event_total: ($events | length),
+			continuation_events: ($events | map(select(_wah_nonterminal)) | length),
 			result_counts: (reduce $w[] as $row ({}; .[$row.result // "unknown"] += 1)),
+			event_result_counts: (reduce $events[] as $row ({}; .[$row.result // "unknown"] += 1)),
 			diagnostic_focus: {
 				premature_exit: ($failures | map(select(.result == "premature_exit" or .launch_failure_cause == "model_stopped_before_completion")) | length),
 				local_runtime_error: ($failures | map(select(.result != $local_kill_result and .launch_failure_cause != $local_kill_result and (.failure_reason == "local_error" or .launch_failure_cause == "local_runtime_error" or (.runtime_error_type // "") != ""))) | length),
@@ -414,7 +433,8 @@ _wah_emit_human() {
 	printf '%s\n' "$divider"
 	printf '\n'
 	printf 'headless-runtime-metrics.jsonl (canonical worker outcomes):\n'
-	printf '  Total events:                %d\n' "$total"
+	printf '  Terminal session outcomes:   %d\n' "$total"
+	printf '  Raw attempt/events:          %s\n' "$(printf '%s' "$details_json" | jq -r '.event_total // 0' 2>/dev/null || printf '0')"
 	printf '  Succeeded:                   %d  (%s of terminal)\n' "$succ" "$rate_pct"
 	printf '  Watchdog stall-killed:       %d\n' "$wk"
 	printf '  Watchdog stall-continued:    %d  (heartbeat, not terminal)\n' "$wc"
@@ -520,6 +540,8 @@ _wah_emit_json() {
 			repo: (if $repo == "" then null else $repo end),
 			metrics: {
 				total: $total,
+				event_total: ($details.event_total // $total),
+				continuation_events: ($details.continuation_events // 0),
 				succeeded: $succ,
 				watchdog_killed: $wk,
 				watchdog_continued: $wc,
@@ -527,6 +549,7 @@ _wah_emit_json() {
 				rate_limited: $rl,
 				other_failure: $of,
 				result_counts: $details.result_counts,
+				event_result_counts: ($details.event_result_counts // $details.result_counts),
 				diagnostic_focus: ($details.diagnostic_focus // {}),
 				timing_ms: $details.timing_ms,
 				recent_examples: $details.recent_examples,

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -51,12 +51,34 @@ WAH_RESULT_LOCAL_KILL="local_kill"
 
 # Shared jq definitions keep terminal-session semantics identical in the scalar
 # and rich aggregators without duplicating a long filter in both functions.
+# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
 WAH_SESSION_OUTCOME_JQ='
 	def _wah_nonterminal:
 		((.result // "") | endswith("_continue")) or (.result == "brief_recovery");
 	def _wah_session_outcomes:
-		to_entries
-		| group_by(if ((.value.session_key // "") | length) > 0 then .value.session_key else "__event_\(.key)" end)
+		. as $all
+		| to_entries
+		| map(. as $entry | select(
+			(($entry.value.repo_slug // "") | length) > 0
+			or (($entry.value.issue_number // null) != null)
+			or (($entry.value.session_id // "") | length) > 0
+			or (($entry.value.work_dir // "") | length) > 0
+			or (($entry.value.output_file // "") | length) > 0
+			or (($entry.value.launch_failure_cause // "") | length) > 0
+			or (($entry.value.kill_reason // "") | length) > 0
+			or (($entry.value.next_action // "") | length) > 0
+			or ([$all[] | select(
+				((.repo_slug // "") | length) > 0
+				and .session_key == $entry.value.session_key
+				and ([((.ts // 0) - ($entry.value.ts // 0)), (($entry.value.ts // 0) - (.ts // 0))] | max) <= 2
+				and .result == $entry.value.result
+				and .exit_code == $entry.value.exit_code
+			)] | length) == 0
+		))
+		| group_by(
+			(if ((.value.repo_slug // "") | length) > 0 then .value.repo_slug else "legacy" end)
+			+ "|" + (if ((.value.session_key // "") | length) > 0 then .value.session_key else "__event_\(.key)" end)
+		)
 		| map(sort_by([(.value.ts // 0), (if (.value.issue_number // null) != null then 1 else 0 end), .key]) | last.value)
 		| map(select(_wah_nonterminal | not));
 '
@@ -88,8 +110,8 @@ _wah_parse_since() {
 #
 # $1 — cutoff_epoch (entries with ts < cutoff are dropped).
 # $2 — optional now_epoch (entries with ts > now are dropped).
-# stdout — seven space-separated integers:
-#   total succeeded watchdog_killed watchdog_continued service_interrupted rate_limited other_failure
+# stdout — eight space-separated integers:
+#   raw_total terminal_total succeeded watchdog_killed watchdog_continued service_interrupted rate_limited other_failure
 #######################################
 _wah_aggregate_metrics() {
 	local cutoff_epoch="$1"
@@ -97,7 +119,7 @@ _wah_aggregate_metrics() {
 	local now_epoch
 
 	if [[ ! -f "$metrics" ]]; then
-		printf '0 0 0 0 0 0 0\n'
+		printf '0 0 0 0 0 0 0 0\n'
 		return 0
 	fi
 	now_epoch="${2:-$(date +%s)}"
@@ -122,7 +144,8 @@ _wah_aggregate_metrics() {
 	jq_program=$WAH_SESSION_OUTCOME_JQ'
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
 		| ($events | _wah_session_outcomes) as $w | {
-			total:  ($w | length),
+			total:  ($events | length),
+			terminal: ($w | length),
 			succ:   ([$w[] | select(.result == "success" and .exit_code == 0)] | length),
 			wk:     ([$w[] | select(.result == $watchdog_killed_result)] | length),
 			wc:     ([$events[] | select(.result == "watchdog_stall_continue")] | length),
@@ -135,11 +158,11 @@ _wah_aggregate_metrics() {
 				and .result != $service_result
 				and .result != "rate_limit"
 			)] | length)
-		} | "\(.total) \(.succ) \(.wk) \(.wc) \(.sic) \(.rl) \(.of)"
+		} | "\(.total) \(.terminal) \(.succ) \(.wk) \(.wc) \(.sic) \(.rl) \(.of)"
 	'
-	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" "$jq_program" <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0"
+	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" "$jq_program" <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0 0"
 
-	[[ -n "$result" ]] || result="0 0 0 0 0 0 0"
+	[[ -n "$result" ]] || result="0 0 0 0 0 0 0 0"
 	printf '%s\n' "$result"
 	return 0
 }
@@ -416,10 +439,10 @@ _wah_solved_worker_count() {
 #######################################
 _wah_emit_human() {
 	local since_label="$1" cutoff_iso="$2"
-	local total="$3" succ="$4" wk="$5" wc="$6" sic="$7" rl="$8" of="$9"
-	local cb="${10}" gqlow="${11}" db_skip="${12}" nwbreaker="${13}"
-	local solved_count="${14}" pr_check_state="${15}" repo_label="${16}"
-	local details_json="${17}"
+	local total="$3" terminal_total="$4" succ="$5" wk="$6" wc="$7" sic="$8" rl="$9" of="${10}"
+	local cb="${11}" gqlow="${12}" db_skip="${13}" nwbreaker="${14}"
+	local solved_count="${15}" pr_check_state="${16}" repo_label="${17}"
+	local details_json="${18}"
 
 	local divider="==========================================================="
 
@@ -437,8 +460,8 @@ _wah_emit_human() {
 	printf '%s\n' "$divider"
 	printf '\n'
 	printf 'headless-runtime-metrics.jsonl (canonical worker outcomes):\n'
-	printf '  Terminal session outcomes:   %d\n' "$total"
-	printf '  Raw attempt/events:          %s\n' "$(printf '%s' "$details_json" | jq -r '.event_total // 0' 2>/dev/null || printf '0')"
+	printf '  Raw attempt/events:          %d\n' "$total"
+	printf '  Terminal session outcomes:   %d\n' "$terminal_total"
 	printf '  Succeeded:                   %d  (%s of terminal)\n' "$succ" "$rate_pct"
 	printf '  Watchdog stall-killed:       %d\n' "$wk"
 	printf '  Watchdog stall-continued:    %d  (heartbeat, not terminal)\n' "$wc"
@@ -511,10 +534,10 @@ _wah_emit_providers_human() {
 #######################################
 _wah_emit_json() {
 	local since_label="$1" cutoff_iso="$2" cutoff_epoch="$3"
-	local total="$4" succ="$5" wk="$6" wc="$7" sic="$8" rl="$9" of="${10}"
-	local cb="${11}" gqlow="${12}" db_skip="${13}" nwbreaker="${14}"
-	local solved_count="${15}" pr_check_state="${16}" repo_label="${17}"
-	local details_json="${18}"
+	local total="$4" terminal_total="$5" succ="$6" wk="$7" wc="$8" sic="$9" rl="${10}" of="${11}"
+	local cb="${12}" gqlow="${13}" db_skip="${14}" nwbreaker="${15}"
+	local solved_count="${16}" pr_check_state="${17}" repo_label="${18}"
+	local details_json="${19}"
 
 	# solved_count may be "?" on gh failure — coerce to null in JSON.
 	local solved_json="$solved_count"
@@ -525,6 +548,7 @@ _wah_emit_json() {
 		--arg cutoff_iso "$cutoff_iso" \
 		--argjson cutoff_epoch "$cutoff_epoch" \
 		--argjson total "$total" \
+		--argjson terminal_total "$terminal_total" \
 		--argjson succ "$succ" \
 		--argjson wk "$wk" \
 		--argjson wc "$wc" \
@@ -544,6 +568,7 @@ _wah_emit_json() {
 			repo: (if $repo == "" then null else $repo end),
 			metrics: {
 				total: $total,
+				terminal_session_total: $terminal_total,
 				event_total: ($details.event_total // $total),
 				continuation_events: ($details.continuation_events // 0),
 				succeeded: $succ,
@@ -626,9 +651,9 @@ cmd_summary() {
 		cutoff_iso="(unknown)"
 
 	# Aggregate metrics (single jq+awk pass).
-	local agg total succ wk wc sic rl of details_json
+	local agg total terminal_total succ wk wc sic rl of details_json
 	agg=$(_wah_aggregate_metrics "$cutoff_epoch" "$now_epoch")
-	read -r total succ wk wc sic rl of <<<"$agg"
+	read -r total terminal_total succ wk wc sic rl of <<<"$agg"
 	details_json=$(_wah_metric_details_json "$cutoff_epoch" "$now_epoch")
 
 	# Pulse-stats counters.
@@ -650,12 +675,12 @@ cmd_summary() {
 
 	if [[ $emit_json -eq 1 ]]; then
 		_wah_emit_json "$since_label" "$cutoff_iso" "$cutoff_epoch" \
-			"$total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
+			"$total" "$terminal_total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
 			"$pr_count" "$pr_check_state" "$repo_label" "$details_json"
 	else
 		_wah_emit_human "$since_label" "$cutoff_iso" \
-			"$total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
+			"$total" "$terminal_total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
 			"$pr_count" "$pr_check_state" "$repo_label" "$details_json"
 	fi

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -5,7 +5,8 @@
 #
 # Monitors a worker's output file for growth. Treats timing thresholds as
 # recovery backstops: kills only when there is no evidence of live work, an
-# explicit provider failure is visible, or the hard elapsed cap is reached.
+# explicit provider failure is visible, or a confirmed stall has crossed the
+# hard elapsed threshold.
 #
 # This script runs as an INDEPENDENT process (launched via nohup) so it
 # survives the worker subshell's lifecycle changes. The previous design
@@ -40,10 +41,11 @@
 #                             defer the kill until the hard backstop.
 #   --phase1-timeout SECS     Seconds for initial output (default: 30)
 #   --poll-interval SECS      Seconds between checks (default: 10)
-#   --hard-kill-seconds SECS  Total elapsed seconds before forced hard-kill
-#                             (default: 1500 = 25 min). When total elapsed time
-#                             crosses this threshold, even with output growth, the
-#                             watchdog writes the .watchdog_stall_killed
+#   --hard-kill-seconds SECS  Total elapsed seconds before a confirmed output
+#                             stall escalates to forced hard-kill (default: 1500
+#                             = 25 min). Output growth resets stall detection and
+#                             is never killed solely for crossing this threshold.
+#                             The watchdog writes the .watchdog_stall_killed
 #                             sentinel (in addition to .watchdog_killed) so the
 #                             helper can classify the result as exit code 79
 #                             (watchdog_stall_killed) instead of 78

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -621,13 +621,12 @@ CLAIM_RELEASED reason=watchdog_kill:${reason} runner=$(whoami) ts=$(date -u +%Y-
 # Phase 1: Wait for any output (dead runtime detection)
 # Phase 2: Monitor continuous growth (stall detection)
 #
-# t2956 / Issue #21231 and GH#26469: Total elapsed time is also tracked.
-# When HARD_KILL_SECONDS is non-zero and total elapsed has crossed that
-# threshold, the watchdog escalates to a hard-kill that emits the
+# t2956 / Issue #21231: Total elapsed time is also tracked while output is
+# stalled. When HARD_KILL_SECONDS is non-zero, a confirmed stall that has
+# crossed that threshold escalates to a hard-kill that emits the
 # `.watchdog_stall_killed` sentinel — telling the helper to classify as exit 79
-# (watchdog_stall_killed) instead of 78 (watchdog_stall_continue). This caps
-# the per-attempt cost even when output keeps growing and frees the dispatch slot
-# for re-dispatch instead of holding it through repeated continuations.
+# (watchdog_stall_killed) instead of 78 (watchdog_stall_continue). Output-active
+# workers are not stalls and must not be killed solely for reaching wall time.
 #######################################
 _monitor_init_state() {
 	_MONITOR_PHASE1_PASSED=0
@@ -798,13 +797,6 @@ _monitor() {
 		# Phase 1: any output at all
 		if _monitor_handle_phase1 "$current_size"; then
 			continue
-		fi
-
-		# GH#26469: Enforce the absolute runtime cap before output-growth tracking.
-		# Otherwise a worker that continuously writes output can keep resetting the
-		# stall counter and bypass HARD_KILL_SECONDS indefinitely.
-		if ! _monitor_enforce_hard_kill "$current_size"; then
-			return 0
 		fi
 
 		# Phase 2: continuous growth monitoring. Output growth is the cheapest

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -31,6 +31,7 @@
 # Include guard
 [[ -n "${_WORKTREE_CMDS_LIB_LOADED:-}" ]] && return 0
 _WORKTREE_CMDS_LIB_LOADED=1
+_WT_REMOVE_MODE_MANUAL="manual"
 
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -111,7 +112,7 @@ _remove_validate_path() {
 	# The shared guard blocks canonical repos, this shell's cwd, and every live
 	# process whose cwd is inside the target. --force may override ownership or
 	# dirty-state policy, but it must never override a live process cwd.
-	worktree_removal_guard "$path_to_remove" "$guard_caller" "manual" || return 1
+	worktree_removal_guard "$path_to_remove" "$guard_caller" "$_WT_REMOVE_MODE_MANUAL" || return 1
 
 	# Don't allow removing main worktree
 	# NOTE: avoid piping git worktree list through head — with set -o pipefail
@@ -164,6 +165,10 @@ _remove_cleanup_and_execute() {
 	# Capture branch name before removal for localdev cleanup (t1224.8)
 	local removed_branch=""
 	removed_branch="$(git -C "$path_to_remove" branch --show-current 2>/dev/null || echo "")"
+	# Close the validation/removal race as tightly as possible. A process may
+	# enter the worktree after cmd_remove validates it; recheck immediately
+	# before the directory is moved or deregistered.
+	worktree_removal_guard "$path_to_remove" "${SCRIPT_NAME:-worktree-helper.sh}" "$_WT_REMOVE_MODE_MANUAL" || return 1
 
 	echo -e "${BLUE}Removing worktree: $path_to_remove${NC}"
 	# Move the worktree directory to trash BEFORE git deregisters it.
@@ -182,7 +187,7 @@ _remove_cleanup_and_execute() {
 	echo -e "${GREEN}Worktree removed successfully${NC}"
 
 	# t2976: audit log — manual removal completed
-	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$path_to_remove" "manual" "trash"
+	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$path_to_remove" "$_WT_REMOVE_MODE_MANUAL" "trash"
 
 	# Localdev integration (t1224.8): auto-remove branch subdomain route
 	if [[ -n "$removed_branch" ]]; then

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -101,11 +101,17 @@ cmd_list() {
 # --- cmd_remove helpers ---
 
 # Validate that a resolved worktree path is safe to remove.
-# Checks: not main worktree, not current directory, ownership.
+# Checks: shared non-overridable removal guard, then ownership.
 # Args: $1=path_to_remove
 # Returns 0 if safe to remove, 1 if blocked.
 _remove_validate_path() {
 	local path_to_remove="$1"
+	local guard_caller="${SCRIPT_NAME:-worktree-helper.sh}"
+
+	# The shared guard blocks canonical repos, this shell's cwd, and every live
+	# process whose cwd is inside the target. --force may override ownership or
+	# dirty-state policy, but it must never override a live process cwd.
+	worktree_removal_guard "$path_to_remove" "$guard_caller" "manual" || return 1
 
 	# Don't allow removing main worktree
 	# NOTE: avoid piping git worktree list through head — with set -o pipefail


### PR DESCRIPTION
## Summary

Prevent output-active worker kills, deduplicate terminal outcome accounting across repositories, and defer worktree cleanup while a process still uses the cwd.

## Files Changed

.agents/reference/shell-style-guide.md, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/pulse-check-report.jq, .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-pulse-check-helper.sh, .agents/scripts/tests/test-watchdog-hard-kill-continuous-output.sh, .agents/scripts/tests/test-watchdog-stall-cap.sh, .agents/scripts/tests/test-worker-activity-helper.sh, .agents/scripts/worker-activity-helper.sh, .agents/scripts/worker-activity-watchdog.sh, .agents/scripts/worktree-helper-cmds.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Runtime-verified standalone watchdog growth/stall transition; 102 headless runtime tests; 73 worker activity tests; 21 pulse-check tests; watchdog cap, worktree cleanup, and removal-audit suites; changed-file quality gate passed.

Resolves #27007


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 with gpt-5.6-sol spent 1h 27m and 537,801 tokens on this with the user in an interactive session.