### PR TITLE
GH#27006: harden sandbox snapshot cleanup

### DIFF
--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -463,12 +463,22 @@ _sandbox_snapshot_identity_matches() {
 	local identity_token="${3:-}"
 	local identity_current_pgid=""
 	local identity_current_token=""
+	local identity_stat_content=""
+	local identity_after_comm=""
+	local -a identity_fields=()
 
 	[[ "$identity_pid" =~ ^[0-9]+$ && -n "$identity_token" ]] || return 1
-	identity_current_token="$(_sandbox_get_proc_starttime "$identity_pid")"
-	[[ -n "$identity_current_token" && "$identity_current_token" == "$identity_token" ]] || return 1
-	identity_current_pgid="$(ps -o pgid= -p "$identity_pid" 2>/dev/null | tr -d '[:space:]')" || return 1
-	[[ -n "$identity_current_pgid" && "$identity_current_pgid" == "$identity_pgid" ]] || return 1
+	if [[ -f "/proc/${identity_pid}/stat" ]]; then
+		IFS= read -r identity_stat_content <"/proc/${identity_pid}/stat" || return 1
+		identity_after_comm="${identity_stat_content##*) }"
+		read -r -a identity_fields <<<"$identity_after_comm"
+		[[ "${identity_fields[2]:-}" == "$identity_pgid" && "${identity_fields[19]:-}" == "$identity_token" ]] || return 1
+	else
+		identity_current_token="$(_sandbox_get_proc_starttime "$identity_pid")"
+		[[ -n "$identity_current_token" && "$identity_current_token" == "$identity_token" ]] || return 1
+		identity_current_pgid="$(ps -o pgid= -p "$identity_pid" 2>/dev/null | tr -d '[:space:]')" || return 1
+		[[ -n "$identity_current_pgid" && "$identity_current_pgid" == "$identity_pgid" ]] || return 1
+	fi
 	return 0
 }
 
@@ -532,26 +542,41 @@ _sandbox_pgkill_cleanup() {
 		local cleanup_pid=""
 		local cleanup_pgid=""
 		local cleanup_token=""
+		local cleanup_index=0
+		local -a cleanup_pids=()
+		local -a cleanup_pgids=()
+		local -a cleanup_tokens=()
 		while IFS=$'\t' read -r cleanup_pid cleanup_pgid cleanup_token; do
+			[[ -n "$cleanup_pid" ]] || continue
+			cleanup_pids+=("$cleanup_pid")
+			cleanup_pgids+=("$cleanup_pgid")
+			cleanup_tokens+=("$cleanup_token")
 			_sandbox_snapshot_identity_matches "$cleanup_pid" "$cleanup_pgid" "$cleanup_token" || continue
 			# A group signal is safe only when its verified leader was descended
-			# from the sandbox. Otherwise terminate the verified PID individually.
+			# from the sandbox and our own PGID is known. Otherwise terminate the
+			# verified PID individually to prevent a defensive self-kill.
 			if [[ "$cleanup_pid" == "$cleanup_pgid" && -n "$cleanup_self_pgid" && "$cleanup_pgid" != "$cleanup_self_pgid" ]]; then
 				kill -TERM -- "-${cleanup_pgid}" 2>/dev/null || true
 			else
 				kill -TERM "$cleanup_pid" 2>/dev/null || true
 			fi
 		done <"$cleanup_snapshot_file"
+		# Consume the snapshot before the grace period. A concurrent/repeated
+		# cleanup cannot act on stale identities while PIDs are being recycled.
+		rm -f "$cleanup_snapshot_file" 2>/dev/null || true
+		cleanup_snapshot_file=""
 		sleep 0.5
-		while IFS=$'\t' read -r cleanup_pid cleanup_pgid cleanup_token; do
+		for ((cleanup_index = 0; cleanup_index < ${#cleanup_pids[@]}; cleanup_index++)); do
+			cleanup_pid="${cleanup_pids[$cleanup_index]}"
+			cleanup_pgid="${cleanup_pgids[$cleanup_index]}"
+			cleanup_token="${cleanup_tokens[$cleanup_index]}"
 			_sandbox_snapshot_identity_matches "$cleanup_pid" "$cleanup_pgid" "$cleanup_token" || continue
 			if [[ "$cleanup_pid" == "$cleanup_pgid" && -n "$cleanup_self_pgid" && "$cleanup_pgid" != "$cleanup_self_pgid" ]]; then
 				kill -KILL -- "-${cleanup_pgid}" 2>/dev/null || true
 			else
 				kill -KILL "$cleanup_pid" 2>/dev/null || true
 			fi
-		done <"$cleanup_snapshot_file"
-		rm -f "$cleanup_snapshot_file" 2>/dev/null || true
+		done
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-sandbox-nested-process-group-cleanup.sh
+++ b/.agents/scripts/tests/test-sandbox-nested-process-group-cleanup.sh
@@ -11,6 +11,9 @@ TESTS_RUN=0
 TESTS_FAILED=0
 SURVIVOR_PIDS=""
 
+# shellcheck source=../sandbox-exec-helper.sh
+source "$HELPER"
+
 cleanup() {
 	local cleanup_pid=""
 	for cleanup_pid in $SURVIVOR_PIDS; do
@@ -150,13 +153,82 @@ test_start_token_mismatch() {
 	SURVIVOR_PIDS="${SURVIVOR_PIDS} ${candidate_pid}"
 	candidate_pgid="$(ps -o pgid= -p "$candidate_pid" | tr -d '[:space:]')"
 	printf '%s\t%s\t%s\n' "$candidate_pid" "$candidate_pgid" "definitely-not-the-start-token" >"$snapshot_file"
-	# shellcheck source=../sandbox-exec-helper.sh
-	source "$HELPER"
 	_sandbox_pgkill_cleanup "" "" "" "$snapshot_file"
 	if process_is_alive "$candidate_pid"; then
 		record_result "start-token mismatch prevents recycled PID signal" 0
 	else
 		record_result "start-token mismatch prevents recycled PID signal" 1 "pid=${candidate_pid} was signalled"
+	fi
+	return 0
+}
+
+test_snapshot_removed_before_grace_period() {
+	local snapshot_file="${TEST_ROOT}/consumed.tsv"
+	local marker_file="${TEST_ROOT}/snapshot-state"
+	local candidate_pid=""
+	local candidate_pgid=""
+	local candidate_token=""
+	command sleep 30 &
+	candidate_pid=$!
+	SURVIVOR_PIDS="${SURVIVOR_PIDS} ${candidate_pid}"
+	candidate_pgid="$(ps -o pgid= -p "$candidate_pid" | tr -d '[:space:]')"
+	candidate_token="$(_sandbox_get_proc_starttime "$candidate_pid")"
+	printf '%s\t%s\t%s\n' "$candidate_pid" "$candidate_pgid" "$candidate_token" >"$snapshot_file"
+	sleep() {
+		local sleep_delay="$1"
+		if [[ "$sleep_delay" == "0.5" ]]; then
+			if [[ -e "$snapshot_file" ]]; then
+				printf 'present\n' >"$marker_file"
+			else
+				printf 'removed\n' >"$marker_file"
+			fi
+		fi
+		command sleep "$sleep_delay"
+		return 0
+	}
+	_sandbox_pgkill_cleanup "" "" "" "$snapshot_file"
+	unset -f sleep
+	if [[ -f "$marker_file" && "$(<"$marker_file")" == "removed" ]]; then
+		record_result "snapshot is removed before TERM grace period" 0
+	else
+		record_result "snapshot is removed before TERM grace period" 1 "snapshot remained visible to terminating process"
+	fi
+	return 0
+}
+
+test_missing_self_pgid_avoids_group_signal() {
+	local snapshot_file="${TEST_ROOT}/missing-self-pgid.tsv"
+	local child_file="${TEST_ROOT}/missing-self-pgid-child.pid"
+	local leader_pid=""
+	local leader_pgid=""
+	local leader_token=""
+	local child_pid=""
+	# shellcheck disable=SC2016 # $! and $1 belong to the child shell.
+	setsid bash --norc --noprofile -c '
+		sleep 30 &
+		printf "%s\n" "$!" >"$1"
+		wait
+	' missing-self-pgid "$child_file" &
+	leader_pid=$!
+	SURVIVOR_PIDS="${SURVIVOR_PIDS} ${leader_pid}"
+	if ! wait_for_pid_file "$child_file"; then
+		record_result "missing self PGID avoids group signal" 1 "child PID file missing"
+		return 0
+	fi
+	child_pid="$(tr -d '[:space:]' <"$child_file")"
+	SURVIVOR_PIDS="${SURVIVOR_PIDS} ${child_pid}"
+	leader_pgid="$(ps -o pgid= -p "$leader_pid" | tr -d '[:space:]')"
+	leader_token="$(_sandbox_get_proc_starttime "$leader_pid")"
+	printf '%s\t%s\t%s\n' "$leader_pid" "$leader_pgid" "$leader_token" >"$snapshot_file"
+	ps() {
+		return 1
+	}
+	_sandbox_pgkill_cleanup "" "" "" "$snapshot_file"
+	unset -f ps
+	if ! process_is_alive "$leader_pid" && process_is_alive "$child_pid"; then
+		record_result "missing self PGID avoids group signal" 0
+	else
+		record_result "missing self PGID avoids group signal" 1 "cleanup signalled the process group"
 	fi
 	return 0
 }
@@ -170,6 +242,8 @@ main() {
 	test_timeout_cleanup
 	test_normal_exit_and_unrelated_process
 	test_start_token_mismatch
+	test_snapshot_removed_before_grace_period
+	test_missing_self_pgid_avoids_group_signal
 	printf 'Tests run: %d\nFailures: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 }


### PR DESCRIPTION
## Summary

Consume descendant snapshots before the TERM grace period, revalidate retained identities before KILL, avoid process-group signals when the cleanup process PGID is unavailable, and use a single /proc stat read on Linux.

## Files Changed

.agents/scripts/sandbox-exec-helper.sh, .agents/scripts/tests/test-sandbox-nested-process-group-cleanup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck passed for helper and regression test; six process-cleanup tests passed in the Linux worker container.

Resolves #27006


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 15m and 77,987 tokens on this as a headless worker.