### PR TITLE
GH#27003: recover manual dispatch after uncertain dedup

### DIFF
--- a/.agents/scripts/dispatch-backoff-helper.sh
+++ b/.agents/scripts/dispatch-backoff-helper.sh
@@ -24,6 +24,10 @@
 # Subcommands:
 #   check <issue_num> [<slug>]  — exit 0 if clear, exit 1 if cooldown active,
 #                                 exit 2 on error (fail-open: dispatch proceeds)
+#   classify-lookup-failure <signal>
+#                              — print transient, persistent, or unknown
+#   lookup-retry-delay <signal> <attempt>
+#                              — print an evidence-aware bounded delay
 #   help                        — usage information
 #
 # Exit codes (check):
@@ -87,6 +91,72 @@ readonly _BACKOFF_SCHEDULE=(0 300 1800 7200 86400)  # [0]=unused [1]=5m [2]=30m 
 
 # Log prefix for all messages from this module.
 _DB_LOG_PREFIX="[dispatch-backoff]"
+
+#######################################
+# Classify a dispatch lookup failure without weakening fail-closed callers.
+# Persistent local/data failures must never be retried. Network/provider
+# failures are transient only when the signal contains concrete evidence.
+#
+# Args: $1 - failure signal
+# Stdout: transient, persistent, or unknown
+#######################################
+_db_classify_lookup_failure() {
+	local signal="$1"
+	local normalized=""
+	normalized=$(printf '%s' "$signal" | tr '[:upper:]' '[:lower:]')
+
+	case "$normalized" in
+	*jq-failure* | *malformed* | *invalid-json* | *"invalid json"* | *auth-failure* | *unauthorized* | *forbidden* | *not-found* | *"not found"* | *" 401"* | *" 403"* | *" 404"*)
+		printf 'persistent\n'
+		;;
+	*rate-limit* | *"rate limit"* | *retry-after* | *reset=* | *timeout* | *"timed out"* | *temporary* | *temporarily* | *"connection reset"* | *"connection closed"* | *"connection refused"* | *" 502"* | *" 503"* | *" 504"*)
+		printf 'transient\n'
+		;;
+	*gh-api-failure*rc=[1-9]*)
+		printf 'transient\n'
+		;;
+	*)
+		printf 'unknown\n'
+		;;
+	esac
+	return 0
+}
+
+#######################################
+# Derive a non-immediate retry delay from Retry-After/reset evidence or use a
+# small bounded delay for another explicitly transient signal.
+#
+# Args: $1 - failure signal, $2 - retry attempt (1-based)
+# Stdout: delay seconds
+# Returns: 0 when delay is within the configured bound, 1 otherwise
+#######################################
+_db_lookup_retry_delay() {
+	local signal="$1"
+	local attempt="$2"
+	local delay=""
+	local now=""
+	local reset_epoch=""
+	local max_delay="${AIDEVOPS_DSI_MAX_RETRY_DELAY_SECONDS:-60}"
+
+	if [[ "$signal" =~ [Rr]etry-[Aa]fter[^0-9]*([0-9]+) ]]; then
+		delay="${BASH_REMATCH[1]}"
+	elif [[ "$signal" =~ reset[^0-9]*([0-9]{10}) ]]; then
+		reset_epoch="${BASH_REMATCH[1]}"
+		now=$(date +%s)
+		delay=$((reset_epoch - now))
+	else
+		delay="$attempt"
+	fi
+
+	[[ "$delay" =~ ^[0-9]+$ ]] || return 1
+	[[ "$max_delay" =~ ^[0-9]+$ ]] || max_delay=60
+	((delay < 1)) && delay=1
+	if ((delay > max_delay)); then
+		return 1
+	fi
+	printf '%s\n' "$delay"
+	return 0
+}
 
 #######################################
 # Compute cooldown seconds for a given failure count.
@@ -506,7 +576,18 @@ _main() {
 	shift || true
 
 	case "$cmd" in
-		check)
+	classify-lookup-failure)
+		local failure_signal="${1:-}"
+		_db_classify_lookup_failure "$failure_signal"
+		return 0
+		;;
+	lookup-retry-delay)
+		local failure_signal="${1:-}"
+		local retry_attempt="${2:-1}"
+		_db_lookup_retry_delay "$failure_signal" "$retry_attempt"
+		return $?
+		;;
+	check)
 			local issue_number="${1:-}"
 			local slug="${2:-unknown}"
 
@@ -547,6 +628,8 @@ _main() {
 			printf 'dispatch-backoff-helper.sh — Per-issue rate_limit backoff gate (t2781)\n\n'
 			printf 'Usage:\n'
 			printf '  dispatch-backoff-helper.sh check <issue_num> [<slug>]  # exit 0=clear, 1=backoff active, 2=error\n'
+			printf '  dispatch-backoff-helper.sh classify-lookup-failure <signal>\n'
+			printf '  dispatch-backoff-helper.sh lookup-retry-delay <signal> <attempt>\n'
 			printf '\n'
 			printf 'Environment:\n'
 			printf '  DISPATCH_BACKOFF_METRICS_FILE      path to headless-runtime-metrics.jsonl\n'

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -30,9 +30,10 @@
 #      duplicating the template here.
 #
 # Exit codes:
-#   0  Worker dispatched (or skipped: already claimed / dry-run)
+#   0  Worker dispatched (or skipped: already claimed / clear dry-run)
 #   1  Validation failure (issue not found, parent-task, etc.)
 #   2  Invalid subcommand or missing required arg
+#   75 Dedup guard is uncertain; recovery checkpoint persisted
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -60,7 +61,9 @@ _DSI_HEADLESS="${_DSI_SCRIPT_DIR}/headless-runtime-helper.sh"
 _DSI_LEDGER_HELPER="${_DSI_SCRIPT_DIR}/dispatch-ledger-helper.sh"
 _DSI_WORKTREE_HELPER="${_DSI_SCRIPT_DIR}/worktree-helper.sh"
 _DSI_DEDUP_HELPER="${_DSI_SCRIPT_DIR}/dispatch-dedup-helper.sh"
+_DSI_BACKOFF_HELPER="${_DSI_SCRIPT_DIR}/dispatch-backoff-helper.sh"
 _DSI_DISPATCH_BASE_BRANCH=""
+_DSI_STATE_RECOVERING="recovering"
 
 # Colors (guarded — don't collide with shared-constants)
 [[ -z "${_DSI_GREEN+x}" ]] && _DSI_GREEN='\033[0;32m'
@@ -1025,7 +1028,7 @@ _dsi_parse_dispatch_args() {
 # Print dry-run plan. Caller has already loaded metadata + resolved model.
 # Args:
 #   $1 issue_number, $2 repo_slug, $3 session_key
-#   $4 dedup_state (blocked|clear|error), $5 dedup_rc, $6 dedup_result
+#   $4 dedup_state (blocked|clear|recovering|error), $5 dedup_rc, $6 dedup_result
 #######################################
 _dsi_print_dryrun() {
 	local issue_number="$1"
@@ -1057,9 +1060,99 @@ _dsi_print_dryrun() {
 	case "$dedup_state" in
 	blocked) _dsi_warn "  Dedup:        WOULD BLOCK — ${dedup_result}" ;;
 	clear) _dsi_info "  Dedup:        clear (no active claim)" ;;
+	"$_DSI_STATE_RECOVERING") _dsi_warn "  Dedup:        RECOVERING — dispatch remains unsafe: ${dedup_result}" ;;
 	error) _dsi_err "  Dedup:        ERROR (exit ${dedup_rc}) — would refuse to dispatch: ${dedup_result}" ;;
 	esac
-	_dsi_ok "Dry-run complete (no worker launched)"
+	if [[ "$dedup_state" == "$_DSI_STATE_RECOVERING" ]]; then
+		_dsi_warn "Dry-run stopped at recoverable safety state (no worker launched)"
+	else
+		_dsi_ok "Dry-run complete (no worker launched)"
+	fi
+	return 0
+}
+
+#######################################
+# Run the external dedup guard and retry only evidenced transient uncertainty.
+# Sets _DSI_DEDUP_RESULT, _DSI_DEDUP_RC, _DSI_DEDUP_STATE, _DSI_DEDUP_ATTEMPTS.
+# Args: $1 issue number, $2 repo slug, $3 current login
+#######################################
+_dsi_run_dedup_check() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="$3"
+	local retry_number=0
+	local classification=""
+	local retry_delay=""
+
+	_DSI_DEDUP_ATTEMPTS=0
+	while ((_DSI_DEDUP_ATTEMPTS < 3)); do
+		_DSI_DEDUP_ATTEMPTS=$((_DSI_DEDUP_ATTEMPTS + 1))
+		_DSI_DEDUP_RC=0
+		_DSI_DEDUP_RESULT=$(ISSUE_META_JSON="$_DSI_ISSUE_META_JSON" \
+			"$_DSI_DEDUP_HELPER" is-assigned "$issue_number" "$repo_slug" "$self_login" 2>&1) || _DSI_DEDUP_RC=$?
+
+		if [[ "$_DSI_DEDUP_RC" -eq 0 && "$_DSI_DEDUP_RESULT" == GUARD_UNCERTAIN* ]]; then
+			_DSI_DEDUP_STATE="$_DSI_STATE_RECOVERING"
+		elif [[ "$_DSI_DEDUP_RC" -eq 0 ]]; then
+			_DSI_DEDUP_STATE="blocked"
+		elif [[ "$_DSI_DEDUP_RC" -eq 1 ]]; then
+			_DSI_DEDUP_STATE="clear"
+		else
+			_DSI_DEDUP_STATE="error"
+		fi
+
+		[[ "$_DSI_DEDUP_STATE" == "$_DSI_STATE_RECOVERING" ]] || return 0
+		((_DSI_DEDUP_ATTEMPTS < 3)) || return 0
+		classification=$("$_DSI_BACKOFF_HELPER" classify-lookup-failure "$_DSI_DEDUP_RESULT" 2>/dev/null || printf 'unknown')
+		[[ "$classification" == "transient" ]] || return 0
+		retry_number=$((retry_number + 1))
+		retry_delay=$("$_DSI_BACKOFF_HELPER" lookup-retry-delay "$_DSI_DEDUP_RESULT" "$retry_number" 2>/dev/null) || return 0
+		_dsi_warn "Dedup lookup uncertain with transient evidence; retry ${retry_number}/2 after ${retry_delay}s"
+		sleep "$retry_delay"
+	done
+	return 0
+}
+
+#######################################
+# Persist a machine-readable continuation checkpoint for an uncertain guard.
+# Args: $1 issue, $2 repo, $3 trigger, $4 attempts
+#######################################
+_dsi_write_recovery_checkpoint() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local trigger="$3"
+	local attempts="$4"
+	local checkpoint_dir="${AIDEVOPS_DSI_CHECKPOINT_DIR:-${HOME}/.aidevops/.agent-workspace/work/dispatch-recovery}"
+	local checkpoint_file="${checkpoint_dir}/${repo_slug//\//-}-${issue_number}.json"
+	local checkpoint_tmp="${checkpoint_file}.tmp.$$"
+	local resume_command=""
+	local -a resume_args=("${_DSI_SCRIPT_DIR}/dispatch-single-issue-helper.sh" dispatch "$issue_number" "$repo_slug")
+
+	[[ -n "$_DSI_ARG_MODEL" ]] && resume_args+=(--model "$_DSI_ARG_MODEL")
+	[[ -n "$_DSI_ARG_AGENT" ]] && resume_args+=(--agent "$_DSI_ARG_AGENT")
+	[[ -n "${AIDEVOPS_DISPATCH_BASE_REF:-}" ]] && resume_args+=(--base "$AIDEVOPS_DISPATCH_BASE_REF")
+	[[ "$_DSI_ARG_NO_CEREMONY" -eq 1 ]] && resume_args+=(--no-ceremony)
+	[[ "$_DSI_ARG_DRYRUN" -eq 1 ]] && resume_args+=(--dry-run)
+	printf -v resume_command '%q ' "${resume_args[@]}"
+	resume_command="${resume_command% }"
+
+	mkdir -p "$checkpoint_dir"
+	jq -n \
+		--arg status "$_DSI_STATE_RECOVERING" \
+		--arg issue "$issue_number" \
+		--arg repo "$repo_slug" \
+		--arg trigger "$trigger" \
+		--argjson attempts "$attempts" \
+		--arg resume_command "$resume_command" \
+		--arg resume_condition "one authoritative metadata/dedup read returns a definitive clear or blocked result" \
+		'{status:$status, issue:$issue, repo:$repo, trigger:$trigger, dedup_attempts:$attempts,
+		  completed_checks:["issue metadata loaded","target is an issue","dispatch holds checked","parent-task gate checked","dedup remained fail-closed"],
+		  unsafe_route_not_to_repeat:"bypass dedup or repeat an identical lookup without changed conditions",
+		  resume_command:$resume_command, resume_condition:$resume_condition}' >"$checkpoint_tmp" || return 1
+	mv "$checkpoint_tmp" "$checkpoint_file"
+	_dsi_warn "Recovery checkpoint: ${checkpoint_file}"
+	printf 'RECOVERY_CHECKPOINT_JSON='
+	jq -c . "$checkpoint_file"
 	return 0
 }
 
@@ -1102,15 +1195,10 @@ cmd_dispatch() {
 	# when we can't be sure of the state. The pulse has its own retry layers.
 	local self_login
 	self_login=$(gh api user --jq .login 2>/dev/null || echo "")
-	local dedup_result dedup_rc=0
-	ISSUE_META_JSON="$_DSI_ISSUE_META_JSON" \
-		dedup_result=$("$_DSI_DEDUP_HELPER" is-assigned "$issue_number" "$repo_slug" "$self_login" 2>&1) || dedup_rc=$?
-	local dedup_state
-	case "$dedup_rc" in
-	0) dedup_state="blocked" ;;
-	1) dedup_state="clear" ;;
-	*) dedup_state="error" ;;
-	esac
+	_dsi_run_dedup_check "$issue_number" "$repo_slug" "$self_login"
+	local dedup_result="$_DSI_DEDUP_RESULT"
+	local dedup_rc="$_DSI_DEDUP_RC"
+	local dedup_state="$_DSI_DEDUP_STATE"
 
 	# Step 4: fail closed if an active manual/pulse worker already owns the
 	# same repo+issue. This closes the gap where labels or ledger entries are
@@ -1127,6 +1215,10 @@ cmd_dispatch() {
 	# Step 6: dry-run short-circuit
 	if [[ "$_DSI_ARG_DRYRUN" -eq 1 ]]; then
 		_dsi_print_dryrun "$issue_number" "$repo_slug" "$session_key" "$dedup_state" "$dedup_rc" "$dedup_result"
+		if [[ "$dedup_state" == "$_DSI_STATE_RECOVERING" ]]; then
+			_dsi_write_recovery_checkpoint "$issue_number" "$repo_slug" "$dedup_result" "$_DSI_DEDUP_ATTEMPTS" || true
+			return 75
+		fi
 		return 0
 	fi
 
@@ -1137,6 +1229,12 @@ cmd_dispatch() {
 		_dsi_info "  Reason: ${dedup_result}"
 		_dsi_info "  Use a separate test issue, or release the existing claim first."
 		return 1
+		;;
+	"$_DSI_STATE_RECOVERING")
+		_dsi_err "Dedup guard is uncertain — failing closed, refusing to dispatch"
+		_dsi_info "  Trigger: ${dedup_result}"
+		_dsi_write_recovery_checkpoint "$issue_number" "$repo_slug" "$dedup_result" "$_DSI_DEDUP_ATTEMPTS" || true
+		return 75
 		;;
 	error)
 		_dsi_err "Dedup check failed (exit ${dedup_rc}) — failing closed, refusing to dispatch"

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -1109,6 +1109,12 @@ _dsi_run_dedup_check() {
 		retry_delay=$("$_DSI_BACKOFF_HELPER" lookup-retry-delay "$_DSI_DEDUP_RESULT" "$retry_number" 2>/dev/null) || return 0
 		_dsi_warn "Dedup lookup uncertain with transient evidence; retry ${retry_number}/2 after ${retry_delay}s"
 		sleep "$retry_delay"
+		# Change the lookup conditions before retrying: refresh the authoritative
+		# metadata rather than repeating the same prefetched payload immediately.
+		if ! _dsi_load_issue_meta "$issue_number" "$repo_slug"; then
+			_DSI_DEDUP_RESULT="${_DSI_DEDUP_RESULT} metadata-refresh-failed"
+			return 0
+		fi
 	done
 	return 0
 }

--- a/.agents/scripts/tests/test-dispatch-dedup-fail-closed.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-fail-closed.sh
@@ -60,6 +60,10 @@ write_stub_gh_success() {
 	cat >"${STUB_DIR}/gh" <<STUB
 #!/usr/bin/env bash
 # Stub for test-dispatch-dedup-fail-closed.sh — exits 0, returns payload
+if [[ "\$1" == "api" && "\$2" == "rate_limit" ]]; then
+	printf '%s\n' '5000'
+	exit 0
+fi
 if [[ "\$1" == "issue" && "\$2" == "view" ]]; then
 	printf '%s\n' '${payload}'
 	exit 0
@@ -104,6 +108,10 @@ write_stub_gh_issue_ok_comments_fail() {
 	cat >"${STUB_DIR}/gh" <<STUB
 #!/usr/bin/env bash
 # Stub: issue view succeeds, comments api fails (GH#18816 test)
+if [[ "\$1" == "api" && "\$2" == "rate_limit" ]]; then
+	printf '%s\n' '5000'
+	exit 0
+fi
 if [[ "\$1" == "issue" && "\$2" == "view" ]]; then
 	printf '%s\n' '${payload}'
 	exit 0

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -17,6 +17,9 @@
 # running) and overriding `set_issue_status` with a mock that captures
 # every flag for assertion.
 
+# Generated child scripts intentionally defer these expressions until runtime.
+# shellcheck disable=SC2016
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
@@ -612,6 +615,148 @@ test_cmd_dispatch_blocks_needs_maintainer_review_before_dedup() {
 	return 0
 }
 
+test_dedup_receives_prefetched_issue_metadata() {
+	local test_dir=""
+	test_dir=$(mktemp -d)
+	local metadata_log="${test_dir}/metadata.json"
+	local helper="${test_dir}/dedup-helper.sh"
+	{
+		printf '%s\n' '#!/usr/bin/env bash'
+		printf '%s\n' 'printf "%s" "${ISSUE_META_JSON:-}" >"$MOCK_DEDUP_META_LOG"'
+		printf '%s\n' 'exit 1'
+	} >"$helper"
+	chmod +x "$helper"
+
+	local original_dedup_helper="$_DSI_DEDUP_HELPER"
+	_DSI_DEDUP_HELPER="$helper"
+	_DSI_ISSUE_META_JSON='{"number":123,"labels":[],"assignees":[],"state":"OPEN"}'
+	export MOCK_DEDUP_META_LOG="$metadata_log"
+	_dsi_run_dedup_check 123 owner/repo runner-self >/dev/null 2>&1
+
+	local forwarded=""
+	forwarded=$(<"$metadata_log")
+	local check=1
+	[[ "$_DSI_DEDUP_STATE" == "clear" && "$forwarded" == "$_DSI_ISSUE_META_JSON" ]] && check=0
+	print_result "dedup child receives prefetched issue metadata" "$check" "state=$_DSI_DEDUP_STATE metadata=$forwarded"
+
+	_DSI_DEDUP_HELPER="$original_dedup_helper"
+	unset MOCK_DEDUP_META_LOG
+	rm -rf "$test_dir"
+	return 0
+}
+
+test_transient_dedup_retries_are_bounded() {
+	local test_dir=""
+	test_dir=$(mktemp -d)
+	local count_log="${test_dir}/count"
+	local helper="${test_dir}/dedup-helper.sh"
+	{
+		printf '%s\n' '#!/usr/bin/env bash'
+		printf '%s\n' 'count=0'
+		printf '%s\n' '[[ -f "$MOCK_DEDUP_COUNT_LOG" ]] && count=$(<"$MOCK_DEDUP_COUNT_LOG")'
+		printf '%s\n' 'count=$((count + 1))'
+		printf '%s\n' 'printf "%s\n" "$count" >"$MOCK_DEDUP_COUNT_LOG"'
+		printf '%s\n' 'if ((count < 3)); then'
+		printf '%s\n' '  printf "%s\n" "GUARD_UNCERTAIN (reason=gh-api-failure detail=timeout Retry-After:1)"'
+		printf '%s\n' '  exit 0'
+		printf '%s\n' 'fi'
+		printf '%s\n' 'exit 1'
+	} >"$helper"
+	chmod +x "$helper"
+
+	local original_dedup_helper="$_DSI_DEDUP_HELPER"
+	_DSI_DEDUP_HELPER="$helper"
+	_DSI_ISSUE_META_JSON='{"number":123,"labels":[],"assignees":[],"state":"OPEN"}'
+	export MOCK_DEDUP_COUNT_LOG="$count_log"
+	_dsi_run_dedup_check 123 owner/repo runner-self >/dev/null 2>&1
+
+	local attempts=""
+	attempts=$(<"$count_log")
+	local check=1
+	[[ "$_DSI_DEDUP_STATE" == "clear" && "$_DSI_DEDUP_ATTEMPTS" -eq 3 && "$attempts" == "3" ]] && check=0
+	print_result "transient dedup retries stop after two retries" "$check" \
+		"state=$_DSI_DEDUP_STATE attempts=$_DSI_DEDUP_ATTEMPTS calls=$attempts"
+
+	_DSI_DEDUP_HELPER="$original_dedup_helper"
+	unset MOCK_DEDUP_COUNT_LOG
+	rm -rf "$test_dir"
+	return 0
+}
+
+test_persistent_uncertainty_does_not_retry_and_checkpoints_dryrun() {
+	local test_dir=""
+	test_dir=$(mktemp -d)
+	local count_log="${test_dir}/count"
+	local helper="${test_dir}/dedup-helper.sh"
+	{
+		printf '%s\n' '#!/usr/bin/env bash'
+		printf '%s\n' 'count=0'
+		printf '%s\n' '[[ -f "$MOCK_DEDUP_COUNT_LOG" ]] && count=$(<"$MOCK_DEDUP_COUNT_LOG")'
+		printf '%s\n' 'printf "%s\n" "$((count + 1))" >"$MOCK_DEDUP_COUNT_LOG"'
+		printf '%s\n' 'printf "%s\n" "GUARD_UNCERTAIN (reason=jq-failure call=assignees-extract)"'
+		printf '%s\n' 'exit 0'
+	} >"$helper"
+	chmod +x "$helper"
+
+	local original_dedup_helper="$_DSI_DEDUP_HELPER"
+	_DSI_DEDUP_HELPER="$helper"
+	export MOCK_DEDUP_COUNT_LOG="$count_log"
+	local -x AIDEVOPS_DSI_CHECKPOINT_DIR="${test_dir}/checkpoints"
+	MOCK_GH_FAIL="0"
+	MOCK_GH_TARGET_IS_PR="0"
+	MOCK_GH_ISSUE_STATE="OPEN"
+	MOCK_GH_LABELS_JSON="[]"
+
+	local out="" rc=0
+	out=$(cmd_dispatch 123 owner/repo --dry-run 2>&1) || rc=$?
+	local checkpoint_file="${AIDEVOPS_DSI_CHECKPOINT_DIR}/owner-repo-123.json"
+	local checkpoint_ok=1
+	if [[ -f "$checkpoint_file" ]] && jq -e \
+		'.status == "recovering" and .issue == "123" and .repo == "owner/repo" and
+		 .dedup_attempts == 1 and (.resume_command | contains("--dry-run")) and
+		 (.resume_condition | contains("definitive clear or blocked"))' \
+		"$checkpoint_file" >/dev/null; then
+		checkpoint_ok=0
+	fi
+	local calls=""
+	calls=$(<"$count_log")
+	local check=1
+	[[ "$rc" -eq 75 && "$calls" == "1" && "$checkpoint_ok" -eq 0 && "$out" == *"RECOVERY_CHECKPOINT_JSON="* ]] && check=0
+	print_result "persistent uncertain dry-run returns 75 and persists checkpoint" "$check" \
+		"rc=$rc calls=$calls checkpoint_ok=$checkpoint_ok output=$out"
+
+	_DSI_DEDUP_HELPER="$original_dedup_helper"
+	unset MOCK_DEDUP_COUNT_LOG
+	rm -rf "$test_dir"
+	return 0
+}
+
+test_unexpected_dedup_exit_remains_error() {
+	local test_dir=""
+	test_dir=$(mktemp -d)
+	local helper="${test_dir}/dedup-helper.sh"
+	{
+		printf '%s\n' '#!/usr/bin/env bash'
+		printf '%s\n' 'printf "%s\n" "unexpected helper failure"'
+		printf '%s\n' 'exit 2'
+	} >"$helper"
+	chmod +x "$helper"
+
+	local original_dedup_helper="$_DSI_DEDUP_HELPER"
+	_DSI_DEDUP_HELPER="$helper"
+	_DSI_ISSUE_META_JSON='{"number":123,"labels":[],"assignees":[],"state":"OPEN"}'
+	_dsi_run_dedup_check 123 owner/repo runner-self >/dev/null 2>&1
+
+	local check=1
+	[[ "$_DSI_DEDUP_STATE" == "error" && "$_DSI_DEDUP_RC" -eq 2 && "$_DSI_DEDUP_ATTEMPTS" -eq 1 ]] && check=0
+	print_result "unexpected dedup exit remains an error" "$check" \
+		"state=$_DSI_DEDUP_STATE rc=$_DSI_DEDUP_RC attempts=$_DSI_DEDUP_ATTEMPTS"
+
+	_DSI_DEDUP_HELPER="$original_dedup_helper"
+	rm -rf "$test_dir"
+	return 0
+}
+
 test_launch_worker_forwards_agent() {
 	local failed=1
 	if grep -Fq "cmd+=(--agent \"\$agent_name\")" "$HELPER_PATH"; then
@@ -914,6 +1059,10 @@ _run_tests() {
 	test_interactive_hold_guard_allows_auto_dispatch_review_handoff
 	test_maintainer_review_guard_blocks_manual_dispatch
 	test_cmd_dispatch_blocks_needs_maintainer_review_before_dedup
+	test_dedup_receives_prefetched_issue_metadata
+	test_transient_dedup_retries_are_bounded
+	test_persistent_uncertainty_does_not_retry_and_checkpoints_dryrun
+	test_unexpected_dedup_exit_remains_error
 	test_agent_flag_parses_with_default
 	test_launch_worker_forwards_agent
 	test_launch_worker_forwards_repo_contract


### PR DESCRIPTION
## Summary

- Forward prefetched issue metadata into the external dedup child.
- Distinguish recoverable `GUARD_UNCERTAIN` from active claims and unexpected helper errors.
- Retry only evidenced transient lookups twice after bounded delays and refreshed metadata.
- Persist a machine-readable continuation checkpoint and return exit 75 when uncertainty remains.

## Testing

- `shellcheck` on the four scoped scripts
- `bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh` (53 passed)
- `bash .agents/scripts/tests/test-dispatch-dedup-fail-closed.sh` (7 passed)
- `.agents/scripts/linters-local.sh --changed --no-cache`

## Runtime Testing

Runtime-verified through mocked manual-dispatch execution paths, including metadata forwarding, bounded retry, fail-closed classification, and checkpoint persistence.

Resolves #27003
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 12m and 160,056 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bounded retry handling for uncertain deduplication checks.
  - Added recovery checkpoints and resume details when dispatch safety checks remain uncertain.
  - Added new dispatcher commands for classifying lookup failures and calculating retry delays.
  - Dry runs now clearly report recovering states.

- **Bug Fixes**
  - Preserved fail-closed behavior for blocked or unexpected deduplication errors.

- **Tests**
  - Added coverage for retry limits, persistent failures, checkpoints, metadata forwarding, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->