### PR TITLE
GH#27007: Defer cleanup until parent runtime exits

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -598,7 +598,6 @@ _merge_remove_worktree_for_cleanup() {
 	print_warning "Post-merge worktree cleanup: guarded worktree helper unavailable for ${branch_name}"
 	return 1
 }
-
 _merge_cleanup_linked_worktree() {
 	local cleanup_plan="$1"
 	local repo="$2"
@@ -608,7 +607,6 @@ _merge_cleanup_linked_worktree() {
 	IFS=$'\t' read -r worktree_path branch_name canonical_dir <<<"$cleanup_plan"
 	[[ -n "$worktree_path" && -n "$branch_name" && -n "$canonical_dir" ]] || return 0
 	[[ -d "$canonical_dir" ]] || return 0
-
 	print_info "Post-merge worktree cleanup: removing linked worktree ${worktree_path} for ${branch_name} in ${repo}"
 	local default_branch=""
 	default_branch=$(_merge_default_branch_for_cleanup "$canonical_dir")
@@ -627,6 +625,35 @@ _merge_cleanup_linked_worktree() {
 	fi
 
 	print_warning "Post-merge worktree cleanup did not remove ${worktree_path}; safety-net cleanup will retry later"
+	return 0
+}
+
+_merge_record_deferred_cleanup_owner() {
+	local cleanup_plan="$1"
+	local worktree_path="" branch_name="" canonical_dir=""
+	IFS=$'\t' read -r worktree_path branch_name canonical_dir <<<"$cleanup_plan"
+	[[ -n "$worktree_path" && -n "$branch_name" ]] || return 1
+	[[ -d "$worktree_path" ]] || return 1
+
+	local owner_pid=""
+	if declare -F _resolve_worktree_owner_pid >/dev/null 2>&1; then
+		owner_pid=$(_resolve_worktree_owner_pid "" 2>/dev/null || true)
+	fi
+	[[ "$owner_pid" =~ ^[0-9]+$ ]] || owner_pid="$PPID"
+	[[ "$owner_pid" =~ ^[0-9]+$ ]] || return 1
+
+	local marker_dir="${worktree_path}/.agents"
+	local marker_path="${marker_dir}/.full-loop-cleanup-deferred"
+	mkdir -p "$marker_dir" || return 1
+	printf '%s\n' "$owner_pid" >"${marker_path}.tmp.$$" || return 1
+	mv "${marker_path}.tmp.$$" "$marker_path" || return 1
+
+	if declare -F claim_worktree_ownership >/dev/null 2>&1; then
+		claim_worktree_ownership "$worktree_path" "$branch_name" \
+			--owner-pid "$owner_pid" \
+			--session "${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-full-loop-merge}}" \
+			--task "post-merge-cleanup" >/dev/null 2>&1 || true
+	fi
 	return 0
 }
 
@@ -743,7 +770,15 @@ cmd_merge() {
 
 	_merge_unlock_resources "$pr_number" "$repo"
 	if [[ "$has_auto" -eq 0 && -n "$_cleanup_plan" ]]; then
-		_merge_cleanup_linked_worktree "$_cleanup_plan" "$repo" || true
+		# This helper runs inside a tool subprocess while the parent AI runtime may
+		# still use the worktree as its logical --dir even when no process has that
+		# OS cwd. Never remove it synchronously; the pulse safety-net proves the
+		# owner has exited before cleanup.
+		if _merge_record_deferred_cleanup_owner "$_cleanup_plan"; then
+			print_info "Post-merge worktree cleanup deferred until the parent runtime exits"
+		else
+			print_warning "Post-merge worktree cleanup deferred, but parent-runtime marker could not be recorded"
+		fi
 	fi
 
 	return 0

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -657,6 +657,34 @@ _merge_record_deferred_cleanup_owner() {
 	return 0
 }
 
+_merge_finalize_post_merge() {
+	local pr_number="$1"
+	local repo="$2"
+	local has_auto="$3"
+	local cleanup_plan="$4"
+	local linked_issue=""
+	linked_issue=$(gh pr view "$pr_number" --repo "$repo" --json body \
+		--jq '.body' 2>/dev/null |
+		grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' |
+		grep -oE '[0-9]+' | head -1) || linked_issue=""
+	if [[ -n "$linked_issue" ]]; then
+		release_interactive_claim_on_merge "$pr_number" "$repo" "$linked_issue" || true
+	fi
+	if [[ "$has_auto" -eq 0 && -n "$linked_issue" ]]; then
+		auto_file_next_phase "$linked_issue" "$repo" || true
+	fi
+
+	_merge_unlock_resources "$pr_number" "$repo"
+	if [[ "$has_auto" -eq 0 && -n "$cleanup_plan" ]]; then
+		if _merge_record_deferred_cleanup_owner "$cleanup_plan"; then
+			print_info "Post-merge worktree cleanup deferred until the parent runtime exits"
+		else
+			print_warning "Post-merge worktree cleanup deferred, but parent-runtime marker could not be recorded"
+		fi
+	fi
+	return 0
+}
+
 # --- Merge Command ---
 
 # Merge wrapper (GH#17541) — enforces review-bot-gate then merges.
@@ -745,41 +773,7 @@ cmd_merge() {
 	_retarget_stacked_children_interactive "$pr_number" "$repo"
 
 	_merge_execute "$pr_number" "$repo" "$merge_method" "$has_admin" "$has_auto" || return 1
-
-	# t2429 (GH#20067): Auto-release interactive claim on merge — parity with
-	# pulse-merge.sh. Extract the linked issue from the PR body (same pattern as
-	# _merge_unlock_resources) and call the shared release helper. Best-effort;
-	# failures are logged but never block the merge completion path.
-	local _linked_issue_for_release=""
-	_linked_issue_for_release=$(gh pr view "$pr_number" --repo "$repo" --json body \
-		--jq '.body' 2>/dev/null |
-		grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' |
-		grep -oE '[0-9]+' | head -1) || _linked_issue_for_release=""
-	if [[ -n "$_linked_issue_for_release" ]]; then
-		release_interactive_claim_on_merge "$pr_number" "$repo" "$_linked_issue_for_release" || true
-	fi
-
-	# Sequential phase auto-filing parity with pulse-merge.sh. Worker self-merge
-	# bypasses the deterministic pulse post-merge hook, so trigger the shared
-	# best-effort phase filer here after any immediate merge path succeeds,
-	# including the REST merge fallback used when GraphQL quota is exhausted.
-	# Do not fire for --auto: the PR is only queued, not merged yet.
-	if [[ "$has_auto" -eq 0 && -n "$_linked_issue_for_release" ]]; then
-		auto_file_next_phase "$_linked_issue_for_release" "$repo" || true
-	fi
-
-	_merge_unlock_resources "$pr_number" "$repo"
-	if [[ "$has_auto" -eq 0 && -n "$_cleanup_plan" ]]; then
-		# This helper runs inside a tool subprocess while the parent AI runtime may
-		# still use the worktree as its logical --dir even when no process has that
-		# OS cwd. Never remove it synchronously; the pulse safety-net proves the
-		# owner has exited before cleanup.
-		if _merge_record_deferred_cleanup_owner "$_cleanup_plan"; then
-			print_info "Post-merge worktree cleanup deferred until the parent runtime exits"
-		else
-			print_warning "Post-merge worktree cleanup deferred, but parent-runtime marker could not be recorded"
-		fi
-	fi
+	_merge_finalize_post_merge "$pr_number" "$repo" "$has_auto" "$_cleanup_plan"
 
 	return 0
 }

--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -545,6 +545,25 @@ unregister_worktree() {
 	return 0
 }
 
+unregister_worktree_if_owner_pid() {
+	local wt_path="$1"
+	local expected_owner_pid="$2"
+	[[ "$expected_owner_pid" =~ ^[0-9]+$ ]] || return 1
+	[[ -f "$WORKTREE_REGISTRY_DB" ]] || return 1
+	_init_registry_db
+	wt_path=$(_wt_registry_lookup_path "$wt_path")
+
+	local changed="0"
+	changed=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+		DELETE FROM worktree_owners
+		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
+		  AND owner_pid = ${expected_owner_pid};
+		SELECT changes();
+	" 2>/dev/null || printf '0')
+	[[ "$changed" == "1" ]] || return 1
+	return 0
+}
+
 # Check who owns a worktree
 # Arguments:
 #   $1 - worktree path

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -195,7 +195,7 @@ TRASH
 	return 0
 }
 
-test_cmd_merge_removes_current_linked_worktree() {
+test_cmd_merge_defers_current_linked_worktree() {
 	local canonical_repo="${TEST_ROOT}/repo"
 	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
 	local active_before=""
@@ -206,23 +206,25 @@ test_cmd_merge_removes_current_linked_worktree() {
 	cmd_merge "123" "example/repo" --squash
 
 	local rc=0
-	if git -C "$canonical_repo" worktree list --porcelain | grep -q "$worktree_path"; then
-		rc=1
-	fi
-	[[ ! -d "$worktree_path" ]] || rc=1
-	if git -C "$canonical_repo" show-ref --verify --quiet refs/heads/feature/full-loop-cleanup; then
-		rc=1
-	fi
+	local marker_path="${worktree_path}/.agents/.full-loop-cleanup-deferred"
+	local marker_pid=""
+	git -C "$canonical_repo" worktree list --porcelain | grep -q "$worktree_path" || rc=1
+	[[ -d "$worktree_path" ]] || rc=1
+	git -C "$canonical_repo" show-ref --verify --quiet refs/heads/feature/full-loop-cleanup || rc=1
+	[[ -f "$marker_path" ]] || rc=1
+	IFS= read -r marker_pid <"$marker_path" || rc=1
+	[[ "$marker_pid" =~ ^[0-9]+$ ]] || rc=1
+	kill -0 "$marker_pid" 2>/dev/null || rc=1
 	if [[ "$(git -C "$canonical_repo" branch --show-current)" != "feature/active" ]]; then
 		rc=1
 	fi
 	if [[ "$(git -C "$canonical_repo" rev-parse feature/active)" != "$active_before" ]]; then
 		rc=1
 	fi
-	if [[ "$(git -C "$canonical_repo" rev-parse main)" != "$remote_main" ]]; then
-		rc=1
-	fi
-	print_result "cmd_merge removes current linked worktree after immediate merge" "$rc"
+	# Cleanup is deferred before canonical refresh because the parent runtime may
+	# still use this logical project directory.
+	if [[ "$(git -C "$canonical_repo" rev-parse main)" == "$remote_main" ]]; then rc=1; fi
+	print_result "cmd_merge defers current linked worktree until parent runtime exits" "$rc"
 	return 0
 }
 
@@ -287,7 +289,7 @@ test_refresh_canonical_pulls_when_default_checked_out() {
 main() {
 	setup_subject
 	test_refresh_canonical_pulls_when_default_checked_out
-	test_cmd_merge_removes_current_linked_worktree
+	test_cmd_merge_defers_current_linked_worktree
 	test_cmd_merge_defers_cleanup_for_live_process_cwd
 	printf '\n%d/%d tests passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
 	[[ "$TESTS_FAILED" -eq 0 ]] || return 1

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -76,6 +76,8 @@ source_clean_lib_with_stubs() {
 	get_default_branch() { printf '%s\n' "main"; return 0; }
 	localdev_auto_branch_rm() { return 0; }
 	unregister_worktree() { return 0; }
+	unregister_worktree_if_owner_pid() { unregister_worktree "$1"; return 0; }
+	claim_worktree_ownership() { return 0; }
 	assert_git_available() { return 0; }
 	assert_main_worktree_sane() { return 0; }
 	gh_pr_list() { return 0; }
@@ -146,6 +148,159 @@ test_terminal_pr_proof_bypasses_protected_pass_skip() {
 	assert_file_contains "$log_file" "worktree-removed.*branch-merged.*mode=permanent.*merge_proof_result=github-merged-pr" || rc=1
 	print_result "terminal PR proof bypasses protected pass skip" "$rc" \
 		"Expected terminal PR proof to remove protected-pass worktree. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+test_terminal_pr_cleanup_waits_for_deferred_parent_exit() {
+	local repo_path="${TEST_ROOT}/repo-terminal-parent"
+	local wt_path="${TEST_ROOT}/wt-terminal-parent"
+	local log_file="${TEST_ROOT}/terminal-parent-cleanup.log"
+	local branch="feature/gh-99033-terminal-parent"
+	local owner_pid=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'terminal parent\n' >"$repo_path/terminal-parent.txt" || rc=1
+	git -C "$repo_path" add terminal-parent.txt || rc=1
+	git -C "$repo_path" commit -q -m "terminal parent branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+	mkdir -p "$wt_path/.agents"
+	sleep 30 &
+	owner_pid=$!
+	printf '%s\n' "$owner_pid" >"$wt_path/.agents/.full-loop-cleanup-deferred"
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_remove_merged "main" "$repo_path" "false" "$branch" "" "true" "" >/dev/null
+	) || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*parent-runtime-active.*mode=skipped" || rc=1
+
+	kill "$owner_pid" 2>/dev/null || true
+	wait "$owner_pid" 2>/dev/null || true
+	local registry_release_marker="${TEST_ROOT}/terminal-parent-registry-released"
+	(
+		cd "$repo_path" || exit 1
+		unset _WORKTREE_CLEAN_LIB_LOADED 2>/dev/null || true
+		source_clean_lib_with_stubs || exit 1
+		local registry_owned=1
+		is_worktree_owned_by_others() { [[ "$registry_owned" -eq 1 ]]; return $?; }
+		unregister_worktree_if_owner_pid() {
+			[[ "$2" == "$owner_pid" ]] || return 1
+			registry_owned=0
+			printf 'released\n' >"$registry_release_marker"
+			return 0
+		}
+		_clean_remove_merged "main" "$repo_path" "false" "$branch" "" "true" "" >/dev/null
+	) || rc=1
+	[[ ! -d "$wt_path" ]] || rc=1
+	[[ -f "$registry_release_marker" ]] || rc=1
+	print_result "terminal PR cleanup waits for deferred parent exit" "$rc" \
+		"Expected first pulse to defer and second pulse after owner exit to remove worktree"
+	return 0
+}
+
+test_dead_marker_preserves_replacement_owner() {
+	local repo_path="${TEST_ROOT}/repo-replacement-owner"
+	local wt_path="${TEST_ROOT}/wt-replacement-owner"
+	local log_file="${TEST_ROOT}/replacement-owner-cleanup.log"
+	local branch="feature/gh-99034-replacement-owner"
+	local replacement_pid=""
+	local unregister_marker="${TEST_ROOT}/replacement-owner-unregistered"
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'replacement owner\n' >"$repo_path/replacement-owner.txt" || rc=1
+	git -C "$repo_path" add replacement-owner.txt || rc=1
+	git -C "$repo_path" commit -q -m "replacement owner branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+	mkdir -p "$wt_path/.agents"
+	printf '999999\n' >"$wt_path/.agents/.full-loop-cleanup-deferred"
+	sleep 30 &
+	replacement_pid=$!
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		is_worktree_owned_by_others() { return 0; }
+		unregister_worktree_if_owner_pid() { return 1; }
+		unregister_worktree() { printf 'unexpected\n' >"$unregister_marker"; return 0; }
+		_clean_remove_merged "main" "$repo_path" "false" "$branch" "" "true" "" >/dev/null
+	) || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	[[ ! -f "$unregister_marker" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*owned-skip.*mode=skipped" || rc=1
+	kill "$replacement_pid" 2>/dev/null || true
+	wait "$replacement_pid" 2>/dev/null || true
+	print_result "dead marker preserves a different replacement owner" "$rc" \
+		"Expected mismatched live registry owner to block unregister and removal"
+	return 0
+}
+
+test_terminal_cleanup_requires_removal_lease() {
+	local repo_path="${TEST_ROOT}/repo-cleanup-lease"
+	local wt_path="${TEST_ROOT}/wt-cleanup-lease"
+	local log_file="${TEST_ROOT}/cleanup-lease.log"
+	local branch="feature/gh-99035-cleanup-lease"
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'cleanup lease\n' >"$repo_path/cleanup-lease.txt" || rc=1
+	git -C "$repo_path" add cleanup-lease.txt || rc=1
+	git -C "$repo_path" commit -q -m "cleanup lease branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		is_worktree_owned_by_others() { return 1; }
+		claim_worktree_ownership() { return 1; }
+		_clean_remove_merged "main" "$repo_path" "false" "$branch" "" "true" "" >/dev/null
+	) || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*cleanup-lease-skip.*mode=skipped" || rc=1
+	print_result "terminal cleanup requires an atomic removal lease" "$rc" \
+		"Expected a replacement-owner race to block physical cleanup"
+	return 0
+}
+
+test_cleanup_lease_released_when_removal_guard_blocks() {
+	local repo_path="${TEST_ROOT}/repo-guard-release"
+	local wt_path="${TEST_ROOT}/wt-guard-release"
+	local branch="feature/gh-99036-guard-release"
+	local release_marker="${TEST_ROOT}/guard-lease-released"
+	local rc=0
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'guard release\n' >"$repo_path/guard-release.txt" || rc=1
+	git -C "$repo_path" add guard-release.txt || rc=1
+	git -C "$repo_path" commit -q -m "guard release branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		claim_worktree_ownership() { return 0; }
+		worktree_removal_guard() { return 1; }
+		unregister_worktree_if_owner_pid() {
+			[[ "$2" == "$$" ]] || return 1
+			printf 'released\n' >"$release_marker"
+			return 0
+		}
+		_clean_remove_merged "main" "$repo_path" "false" "$branch" "" "true" "" >/dev/null
+	) || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	[[ -f "$release_marker" ]] || rc=1
+	print_result "cleanup lease releases when removal guard blocks" "$rc" \
+		"Expected guarded skip to conditionally release cleanup PID ownership"
 	return 0
 }
 
@@ -551,6 +706,10 @@ test_closed_issue_dirty_unproven_branch_stashes_and_preserves_branch() {
 echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
 test_terminal_pr_proof_bypasses_protected_pass_skip
+test_terminal_pr_cleanup_waits_for_deferred_parent_exit
+test_dead_marker_preserves_replacement_owner
+test_terminal_cleanup_requires_removal_lease
+test_cleanup_lease_released_when_removal_guard_blocks
 test_squash_merged_pr_without_ancestor_proof_classifies
 test_prefetched_merged_pr_metadata_skips_exact_head_lookup
 test_merged_pr_list_passes_explicit_repo_slug

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -35,6 +35,7 @@
 _WORKTREE_CLEAN_LIB_LOADED=1
 _WT_CLEAN_DEFERRED_MARKER=".agents/.full-loop-cleanup-deferred"
 _WT_CLEAN_DEFERRED_OWNER_PID=""
+_WT_CLEAN_REASON_OWNED_SKIP="owned-skip"
 
 # SCRIPT_DIR fallback — covers sourcing from test harnesses or direct invocation
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -70,6 +71,32 @@ _clean_acquire_removal_lease() {
 	claim_worktree_ownership "$wt_path" "$wt_branch" \
 		--owner-pid "$$" --session "cleanup:$$" --task "worktree-removal" >/dev/null 2>&1 || return 1
 	return 0
+}
+
+_clean_terminal_owner_blocks_cleanup() {
+	local wt_path="$1"
+	local deferred_parent_state=0
+	_clean_deferred_parent_alive "$wt_path" || deferred_parent_state=$?
+	if [[ "$deferred_parent_state" -eq 0 ]]; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "parent-runtime-active" "$_WT_CLEAN_MODE_SKIPPED"
+		return 0
+	fi
+	if [[ "$deferred_parent_state" -eq 2 ]]; then
+		if [[ -n "$_WT_CLEAN_DEFERRED_OWNER_PID" ]] && \
+			unregister_worktree_if_owner_pid "$wt_path" "$_WT_CLEAN_DEFERRED_OWNER_PID" 2>/dev/null; then
+			return 1
+		fi
+		if is_worktree_owned_by_others "$wt_path"; then
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "$_WT_CLEAN_REASON_OWNED_SKIP" "$_WT_CLEAN_MODE_SKIPPED"
+			return 0
+		fi
+		return 1
+	fi
+	if is_worktree_owned_by_others "$wt_path"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "$_WT_CLEAN_REASON_OWNED_SKIP" "$_WT_CLEAN_MODE_SKIPPED"
+		return 0
+	fi
+	return 1
 }
 
 get_validated_grace_hours() {
@@ -272,7 +299,7 @@ _skip_cleanup_for_owner() {
 		_skip_cleanup_emit "$wt_branch" "$wt_path" "dead owner PID $owner_pid in cooldown since $owner_dead_seen_at" "owner-pid-dead"
 		return 0
 	fi
-	_skip_cleanup_emit "$wt_branch" "$wt_path" "owned by active session PID $owner_pid" "owned-skip"
+		_skip_cleanup_emit "$wt_branch" "$wt_path" "owned by active session PID $owner_pid" "$_WT_CLEAN_REASON_OWNED_SKIP"
 	return 0
 }
 
@@ -841,26 +868,7 @@ _clean_classify_worktree() {
 	# protected-pass, grace, or dirty markers preserve terminal clutter forever.
 	if _clean_merge_type_has_terminal_pr_proof "$merge_type" ||
 		_clean_branch_has_terminal_pr_proof "$wt_branch" "$merged_prs" "$closed_prs"; then
-		local deferred_parent_state=0
-		_clean_deferred_parent_alive "$wt_path" || deferred_parent_state=$?
-		if [[ "$deferred_parent_state" -eq 0 ]]; then
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "parent-runtime-active" "$_WT_CLEAN_MODE_SKIPPED"
-			return 0
-		fi
-		if [[ "$deferred_parent_state" -eq 2 ]]; then
-			# Atomically release only the row owned by the exited marker PID. A
-			# replacement runtime may reclaim the path between cleanup operations.
-			if [[ -n "$_WT_CLEAN_DEFERRED_OWNER_PID" ]] && \
-				unregister_worktree_if_owner_pid "$wt_path" "$_WT_CLEAN_DEFERRED_OWNER_PID" 2>/dev/null; then
-				:
-			elif is_worktree_owned_by_others "$wt_path"; then
-				log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "owned-skip" "$_WT_CLEAN_MODE_SKIPPED"
-				return 0
-			fi
-		elif is_worktree_owned_by_others "$wt_path"; then
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "owned-skip" "$_WT_CLEAN_MODE_SKIPPED"
-			return 0
-		fi
+		_clean_terminal_owner_blocks_cleanup "$wt_path" && return 0
 		_skip_cleanup_for_current_worktree "$wt_path" "$wt_branch" && return 0
 	else
 		# Apply safety checks using shared helper
@@ -1033,7 +1041,7 @@ _clean_remove_merged() {
 						continue
 					fi
 					if is_worktree_owned_by_others "$worktree_path"; then
-						log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "owned-skip" "$_WT_CLEAN_MODE_SKIPPED"
+						log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "$_WT_CLEAN_REASON_OWNED_SKIP" "$_WT_CLEAN_MODE_SKIPPED"
 						echo -e "${YELLOW}Skipped $worktree_branch - worktree was reclaimed before removal${NC}" >&2
 						worktree_path=""
 						worktree_branch=""

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -33,6 +33,8 @@
 # Include guard
 [[ -n "${_WORKTREE_CLEAN_LIB_LOADED:-}" ]] && return 0
 _WORKTREE_CLEAN_LIB_LOADED=1
+_WT_CLEAN_DEFERRED_MARKER=".agents/.full-loop-cleanup-deferred"
+_WT_CLEAN_DEFERRED_OWNER_PID=""
 
 # SCRIPT_DIR fallback — covers sourcing from test harnesses or direct invocation
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -44,6 +46,31 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 fi
 
 # --- Functions ---
+
+_clean_deferred_parent_alive() {
+	local wt_path="$1"
+	local marker_path="${wt_path}/${_WT_CLEAN_DEFERRED_MARKER}"
+	_WT_CLEAN_DEFERRED_OWNER_PID=""
+	[[ -f "$marker_path" ]] || return 1
+
+	local owner_pid=""
+	IFS= read -r owner_pid <"$marker_path" || true
+	_WT_CLEAN_DEFERRED_OWNER_PID="$owner_pid"
+	if [[ "$owner_pid" =~ ^[0-9]+$ ]] && kill -0 "$owner_pid" 2>/dev/null; then
+		return 0
+	fi
+	rm -f "$marker_path" 2>/dev/null || true
+	return 2
+}
+
+_clean_acquire_removal_lease() {
+	local wt_path="$1"
+	local wt_branch="$2"
+	declare -F claim_worktree_ownership >/dev/null 2>&1 || return 1
+	claim_worktree_ownership "$wt_path" "$wt_branch" \
+		--owner-pid "$$" --session "cleanup:$$" --task "worktree-removal" >/dev/null 2>&1 || return 1
+	return 0
+}
 
 get_validated_grace_hours() {
 	local grace_hours="${WORKTREE_CLEAN_GRACE_HOURS:-4}"
@@ -814,6 +841,26 @@ _clean_classify_worktree() {
 	# protected-pass, grace, or dirty markers preserve terminal clutter forever.
 	if _clean_merge_type_has_terminal_pr_proof "$merge_type" ||
 		_clean_branch_has_terminal_pr_proof "$wt_branch" "$merged_prs" "$closed_prs"; then
+		local deferred_parent_state=0
+		_clean_deferred_parent_alive "$wt_path" || deferred_parent_state=$?
+		if [[ "$deferred_parent_state" -eq 0 ]]; then
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "parent-runtime-active" "$_WT_CLEAN_MODE_SKIPPED"
+			return 0
+		fi
+		if [[ "$deferred_parent_state" -eq 2 ]]; then
+			# Atomically release only the row owned by the exited marker PID. A
+			# replacement runtime may reclaim the path between cleanup operations.
+			if [[ -n "$_WT_CLEAN_DEFERRED_OWNER_PID" ]] && \
+				unregister_worktree_if_owner_pid "$wt_path" "$_WT_CLEAN_DEFERRED_OWNER_PID" 2>/dev/null; then
+				:
+			elif is_worktree_owned_by_others "$wt_path"; then
+				log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "owned-skip" "$_WT_CLEAN_MODE_SKIPPED"
+				return 0
+			fi
+		elif is_worktree_owned_by_others "$wt_path"; then
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "owned-skip" "$_WT_CLEAN_MODE_SKIPPED"
+			return 0
+		fi
 		_skip_cleanup_for_current_worktree "$wt_path" "$wt_branch" && return 0
 	else
 		# Apply safety checks using shared helper
@@ -985,7 +1032,22 @@ _clean_remove_merged() {
 						worktree_branch=""
 						continue
 					fi
+					if is_worktree_owned_by_others "$worktree_path"; then
+						log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "owned-skip" "$_WT_CLEAN_MODE_SKIPPED"
+						echo -e "${YELLOW}Skipped $worktree_branch - worktree was reclaimed before removal${NC}" >&2
+						worktree_path=""
+						worktree_branch=""
+						continue
+					fi
+					if ! _clean_acquire_removal_lease "$worktree_path" "$worktree_branch"; then
+						log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "cleanup-lease-skip" "$_WT_CLEAN_MODE_SKIPPED"
+						echo -e "${YELLOW}Skipped $worktree_branch - cleanup lease was not acquired${NC}" >&2
+						worktree_path=""
+						worktree_branch=""
+						continue
+					fi
 					if ! worktree_removal_guard "$worktree_path" "$_WTAR_WH_CALLER" "$_WT_CLEAN_REASON_BRANCH_MERGED"; then
+						unregister_worktree_if_owner_pid "$worktree_path" "$$" 2>/dev/null || true
 						echo -e "${YELLOW}Skipped $worktree_branch - removal guard refused path${NC}" >&2
 						worktree_path=""
 						worktree_branch=""
@@ -996,7 +1058,9 @@ _clean_remove_merged() {
 					rm -rf "$worktree_path/node_modules" 2>/dev/null || true
 					rm -rf "$worktree_path/.next" 2>/dev/null || true
 					rm -rf "$worktree_path/.turbo" 2>/dev/null || true
-					_clean_remove_classified_worktree "$worktree_path" "$worktree_branch" "$force_merged" "$preserve_branch" "$audit_context" || true
+					if ! _clean_remove_classified_worktree "$worktree_path" "$worktree_branch" "$force_merged" "$preserve_branch" "$audit_context"; then
+						unregister_worktree_if_owner_pid "$worktree_path" "$$" 2>/dev/null || true
+					fi
 				fi
 			fi
 			worktree_path=""

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -172,11 +172,11 @@ Verify it posted: `gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[
 full-loop-helper.sh merge "$PR_NUMBER" "$REPO"
 ```
 
-Calls `review-bot-gate-helper.sh wait` (polls every 60s, up to 10 min) then `gh pr merge --squash`. Gate failure blocks merge. Do NOT call `gh pr merge` directly — the wrapper is the only sanctioned merge path. After an immediate successful merge, the wrapper removes the current linked worktree when the current branch matches the PR head; `--auto` queues the merge and leaves cleanup to the safety-net sweep. In interactive admin/maintainer sessions, the wrapper may use `--admin` automatically when branch policy only blocks self-review/review count after checks and NMR gates pass; do not ask the user to approve their own PR. For self-modifying full-loop helper fixes, call the committed worktree path instead: `"$PWD/.agents/scripts/full-loop-helper.sh" merge "$PR_NUMBER" "$REPO"`.
+Calls `review-bot-gate-helper.sh wait` (polls every 60s, up to 10 min) then `gh pr merge --squash`. Gate failure blocks merge. Do NOT call `gh pr merge` directly — the wrapper is the only sanctioned merge path. After an immediate successful merge, the wrapper defers current-worktree removal because the parent AI runtime may still use it as its logical `--dir` without exposing an OS process cwd. The safety-net sweep removes it after runtime exit. `--auto` also leaves cleanup to the safety-net sweep. In interactive admin/maintainer sessions, the wrapper may use `--admin` automatically when branch policy only blocks self-review/review count after checks and NMR gates pass; do not ask the user to approve their own PR. For self-modifying full-loop helper fixes, call the committed worktree path instead: `"$PWD/.agents/scripts/full-loop-helper.sh" merge "$PR_NUMBER" "$REPO"`.
 
 Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$REPO"`.
 
-**4.5 Merge (via wrapper only):** Workers MUST use `full-loop-helper.sh merge`. Direct `gh pr merge --squash` bypasses the review bot gate (GH#17541). Wrapper enforces: (1) review-bot-gate wait, (2) squash merge, (3) no `--delete-branch` from inside worktree, (4) post-merge self-cleanup for the current linked worktree when the current branch matches the PR head. `--auto` queues only; scheduled cleanup handles it later.
+**4.5 Merge (via wrapper only):** Workers MUST use `full-loop-helper.sh merge`. Direct `gh pr merge --squash` bypasses the review bot gate (GH#17541). Wrapper enforces: (1) review-bot-gate wait, (2) squash merge, (3) no `--delete-branch` from inside worktree, (4) deferred current-worktree cleanup after parent runtime exit. `--auto` queues only; scheduled cleanup handles it later.
 
 **4.6 Auto-Release (aidevops only):** `version-manager.sh bump patch`, tag, push, `gh release create`, `setup.sh --non-interactive`.
 
@@ -184,7 +184,7 @@ Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$R
 
 **4.8 Postflight + Deploy:** verify release health; `setup.sh --non-interactive`. Emit: `<promise>FULL_LOOP_COMPLETE</promise>`.
 
-**4.9 Worktree Cleanup (GH#6740 — MANDATORY):** immediate merges through `full-loop-helper.sh merge` self-clean the current linked worktree. If cleanup is skipped/failed, manually `cd` canonical dir, pull, `worktree-helper.sh remove "$BRANCH_NAME" --force`, delete remote branch; scheduled pulse cleanup is only a safety net.
+**4.9 Worktree Cleanup (GH#6740 — MANDATORY):** immediate merges through `full-loop-helper.sh merge` defer current-worktree removal to the scheduled safety-net after parent runtime exit. This protects runtimes that use the worktree as a logical `--dir` without changing OS cwd. Never force-remove an actively owned worktree; after the owner exits, use guarded `worktree-helper.sh remove "$BRANCH_NAME"` if scheduled cleanup has not run.
 
 ---
 

--- a/.agents/workflows/worktree-cleanup.md
+++ b/.agents/workflows/worktree-cleanup.md
@@ -9,7 +9,7 @@ After a PR merges, clean up the linked worktree and return the canonical repo to
 
 ## Automated Cleanup (workers — GH#6740)
 
-Workers dispatched via `/full-loop` self-clean after successful immediate merges through `full-loop-helper.sh merge` (Step 4.9). The pulse `cleanup_worktrees()` stage is a safety net — workers must not rely on it; self-cleanup prevents accumulation during batch dispatch. `--auto` only queues the merge, so scheduled cleanup handles that later after the PR actually merges.
+Workers dispatched via `/full-loop` defer current-worktree cleanup after successful immediate merges through `full-loop-helper.sh merge` (Step 4.9). The parent runtime may still use the worktree as a logical project `--dir` even when no OS process cwd points there. The pulse `cleanup_worktrees()` stage removes the deferred worktree after the owner exits. `--auto` only queues the merge, so scheduled cleanup also handles that later after the PR actually merges.
 
 ```bash
 # Fallback/manual sequence after gh pr merge --squash succeeds:

--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -65,7 +65,7 @@ ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-sessions.sh list   # Li
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-sessions.sh open   # Interactive: select + open
 ```
 
-**Worker self-cleanup (GH#6740):** `full-loop-helper.sh merge` now removes the current linked worktree after an immediate successful merge when the current branch matches the PR head. The pulse cleanup stage remains a safety net — batch dispatches (50+ workers) can still accumulate abandoned worktrees faster than scheduled cleanup. See `full-loop.md` Step 4.9 and `commands/worktree-cleanup.md`.
+**Worker self-cleanup (GH#6740):** `full-loop-helper.sh merge` defers current linked-worktree removal to the pulse cleanup stage after parent runtime exit. A runtime can retain a logical `--dir` reference without an observable process cwd, so synchronous removal is unsafe. See `full-loop.md` Step 4.9 and `commands/worktree-cleanup.md`.
 
 ## Ownership Safety (t189)
 


### PR DESCRIPTION
## Summary

Persist the parent runtime PID after merge, make pulse cleanup wait for exit, atomically release matching ownership, and require a cleanup lease before physical removal.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh, .agents/scripts/shared-worktree-registry.sh, .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh, .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh, .agents/scripts/worktree-clean-lib.sh, .agents/workflows/full-loop.md, .agents/workflows/worktree-cleanup.md, .agents/workflows/worktree.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Runtime evidence reproduced logical --dir removal after PR #27010; 17 terminal cleanup lifecycle tests and 3 full-loop merge cleanup tests pass; ShellCheck clean; changed-file quality gate passed; independent audit found no blocking findings.

Resolves #27007


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2h 8m and 955,892 tokens on this with the user in an interactive session.