### PR TITLE
GH#27014: Keep canonical guard setup compatible

### DIFF
--- a/.agents/scripts/canonical-git-command-guard.py
+++ b/.agents/scripts/canonical-git-command-guard.py
@@ -99,6 +99,8 @@ def _is_allowed_canonical(subcommand: str, args: list[str]) -> bool:
         return _branch_is_read_only(args)
     if subcommand == "config":
         return _config_is_read_only(args)
+    if subcommand == "clean":
+        return any(arg == "--dry-run" or (arg.startswith("-") and not arg.startswith("--") and "n" in arg[1:]) for arg in args)
     if subcommand == "remote":
         return not args or args[0] in {"-v", "--verbose", "get-url", "show"}
     if subcommand == "worktree":

--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+usage() {
+	printf 'Usage: canonical-recovery-helper.sh restore-default --repo PATH --issue N --confirm RESTORE_CANONICAL_DEFAULT\n'
+	return 0
+}
+
+cmd="${1:-}"
+shift || true
+repo_path=""
+issue_number=""
+confirmation=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--repo) repo_path="${2:-}"; shift 2 ;;
+	--issue) issue_number="${2:-}"; shift 2 ;;
+	--confirm) confirmation="${2:-}"; shift 2 ;;
+	*) usage; exit 2 ;;
+	esac
+done
+
+[[ "$cmd" == "restore-default" ]] || { usage; exit 2; }
+[[ -d "$repo_path" && "$issue_number" =~ ^[0-9]+$ ]] || { usage; exit 2; }
+[[ "$confirmation" == "RESTORE_CANONICAL_DEFAULT" ]] || {
+	printf 'BLOCKED: exact recovery confirmation is required\n' >&2
+	exit 1
+}
+
+REAL_GIT="${AIDEVOPS_REAL_GIT_BIN:-/usr/bin/git}"
+git_dir=$("$REAL_GIT" -C "$repo_path" rev-parse --path-format=absolute --git-dir 2>/dev/null)
+common_dir=$("$REAL_GIT" -C "$repo_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+[[ -n "$git_dir" && "$git_dir" == "$common_dir" ]] || {
+	printf 'BLOCKED: recovery target is not the canonical worktree\n' >&2
+	exit 1
+}
+[[ -z "$("$REAL_GIT" -C "$repo_path" status --porcelain)" ]] || {
+	printf 'BLOCKED: canonical worktree is not clean\n' >&2
+	exit 1
+}
+
+default_branch=$("$REAL_GIT" -C "$repo_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+default_branch="${default_branch#origin/}"
+[[ -n "$default_branch" ]] || {
+	printf 'BLOCKED: origin default branch cannot be resolved\n' >&2
+	exit 1
+}
+
+occupied_path=""
+while IFS= read -r line; do
+	case "$line" in
+	worktree\ *) occupied_path="${line#worktree }" ;;
+	branch\ refs/heads/"$default_branch")
+		if [[ "$occupied_path" != "$repo_path" ]]; then
+			printf 'BLOCKED: default branch is active in another worktree: %s\n' "$occupied_path" >&2
+			exit 1
+		fi
+		;;
+	esac
+done < <("$REAL_GIT" -C "$repo_path" worktree list --porcelain)
+
+lock_dir="${common_dir}/aidevops-canonical-recovery.lock"
+mkdir "$lock_dir" 2>/dev/null || {
+	printf 'BLOCKED: canonical recovery lock is already held\n' >&2
+	exit 1
+}
+trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
+
+audit_helper="${SCRIPT_DIR}/audit-log-helper.sh"
+[[ -x "$audit_helper" ]] || {
+	printf 'BLOCKED: tamper-evident audit helper is unavailable\n' >&2
+	exit 1
+}
+"$audit_helper" verify --quiet || {
+	printf 'BLOCKED: audit chain verification failed\n' >&2
+	exit 1
+}
+AUDIT_QUIET=true "$audit_helper" log operation.verify "Canonical default-branch recovery authorized" \
+	--detail "issue=${issue_number}" --detail "repo=${repo_path}" --detail "target=${default_branch}" >/dev/null || {
+	printf 'BLOCKED: recovery audit record could not be written\n' >&2
+	exit 1
+}
+
+"$REAL_GIT" -C "$repo_path" switch "$default_branch"
+[[ "$("$REAL_GIT" -C "$repo_path" branch --show-current)" == "$default_branch" ]] || exit 1
+printf 'Restored canonical repository to %s\n' "$default_branch"

--- a/.agents/scripts/git
+++ b/.agents/scripts/git
@@ -18,6 +18,11 @@ resolve_real_git() {
 	while IFS= read -r candidate; do
 		[[ -n "$candidate" ]] || continue
 		[[ "$candidate" -ef "$SCRIPT_SOURCE" ]] && continue
+		local candidate_real=""
+		candidate_real=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$candidate" 2>/dev/null || true)
+		case "$candidate_real" in
+		*/.aidevops/agents/scripts/git | */.agents/scripts/git) continue ;;
+		esac
 		printf '%s' "$candidate"
 		return 0
 	done < <(which -a git 2>/dev/null)

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -1291,8 +1291,8 @@ _test_hook_run() {
 	local cmd="$3"
 	local result
 	local policy_guard="${SCRIPT_DIR}/canonical-git-command-guard.py"
-	result=$(cd "$cwd" && printf '%s\n' "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | \
-		AIDEVOPS_CANONICAL_GIT_GUARD="$policy_guard" python3 "$test_script" 2>/dev/null)
+	local hook_input="{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}"
+	result=$(cd "$cwd" && AIDEVOPS_CANONICAL_GIT_GUARD="$policy_guard" python3 "$test_script" 2>/dev/null <<<"$hook_input")
 	printf '%s\n' "$result"
 	return 0
 }

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -1261,27 +1261,27 @@ check_status() {
 }
 
 _test_hook_script_path() {
-	local test_script="$HOOK_SCRIPT"
-	if [[ ! -f "$test_script" ]]; then
-		# Fall back to source
-		test_script=$(find_source_hook) || return 1
-	fi
+	# Always test the source about to be installed. The currently deployed hook
+	# may be stale while setup is repairing an interrupted deployment.
+	local test_script=""
+	test_script=$(find_source_hook) || return 1
 	printf '%s\n' "$test_script"
 	return 0
 }
 
 _test_hook_create_repo() {
 	local test_root="$1"
-	git -C "$test_root" init -b main >/dev/null 2>&1 || {
-		git -C "$test_root" init >/dev/null 2>&1
-		git -C "$test_root" checkout -b main >/dev/null 2>&1
+	local real_git="${AIDEVOPS_REAL_GIT_BIN:-/usr/bin/git}"
+	"$real_git" -C "$test_root" init -b main >/dev/null 2>&1 || {
+		"$real_git" -C "$test_root" init >/dev/null 2>&1
+		"$real_git" -C "$test_root" checkout -b main >/dev/null 2>&1
 	}
-	git -C "$test_root" config user.name "Aidevops Hook Test"
-	git -C "$test_root" config user.email "test@example.com"
-	git -C "$test_root" config commit.gpgsign false
+	"$real_git" -C "$test_root" config user.name "Aidevops Hook Test"
+	"$real_git" -C "$test_root" config user.email "test@example.com"
+	"$real_git" -C "$test_root" config commit.gpgsign false
 	printf 'seed\n' >"${test_root}/README.md"
-	git -C "$test_root" add README.md >/dev/null 2>&1
-	git -C "$test_root" commit -m "test: seed hook self-test" >/dev/null 2>&1
+	"$real_git" -C "$test_root" add README.md >/dev/null 2>&1
+	"$real_git" -C "$test_root" commit -m "test: seed hook self-test" >/dev/null 2>&1
 	return 0
 }
 
@@ -1290,7 +1290,9 @@ _test_hook_run() {
 	local test_script="$2"
 	local cmd="$3"
 	local result
-	result=$(cd "$cwd" && printf '%s\n' "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | python3 "$test_script" 2>/dev/null)
+	local policy_guard="${SCRIPT_DIR}/canonical-git-command-guard.py"
+	result=$(cd "$cwd" && printf '%s\n' "{\"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"$cmd\"}}" | \
+		AIDEVOPS_CANONICAL_GIT_GUARD="$policy_guard" python3 "$test_script" 2>/dev/null)
 	printf '%s\n' "$result"
 	return 0
 }
@@ -1340,6 +1342,9 @@ _test_hook_run_blocked_cases() {
 		"git stash clear"
 		"/usr/bin/git reset --hard"
 		"git restore file.txt"
+		"git restore --staged file.txt"
+		"git push --force-with-lease"
+		"git branch -d old-branch"
 	)
 
 	for cmd in "${blocked_cmds[@]}"; do
@@ -1358,12 +1363,9 @@ _test_hook_run_allowed_cases() {
 	local cmd
 	local -a allowed_cmds=(
 		"git status"
-		"git restore --staged file.txt"
 		"git clean -fn"
 		"git clean --dry-run"
 		"rm -rf /tmp/test-dir"
-		"git push --force-with-lease"
-		"git branch -d old-branch"
 		"ls -la"
 	)
 
@@ -1408,7 +1410,8 @@ test_hook() {
 	_test_hook_create_repo "$test_root"
 
 	local linked_worktree="${test_root}/linked-wt"
-	git -C "$test_root" worktree add "$linked_worktree" -b feature/hook-linked-test >/dev/null 2>&1
+	local real_git="${AIDEVOPS_REAL_GIT_BIN:-/usr/bin/git}"
+	"$real_git" -C "$test_root" worktree add "$linked_worktree" -b feature/hook-linked-test >/dev/null 2>&1
 
 	HOOK_TEST_PASS=0
 	HOOK_TEST_FAIL=0
@@ -1416,7 +1419,7 @@ test_hook() {
 	_test_hook_run_allowed_cases "$test_root" "$test_script"
 	_test_hook_run_linked_worktree_cases "$linked_worktree" "$test_script"
 
-	git -C "$test_root" worktree remove "$linked_worktree" >/dev/null 2>&1 || rm -rf "$linked_worktree"
+	"$real_git" -C "$test_root" worktree remove "$linked_worktree" >/dev/null 2>&1 || rm -rf "$linked_worktree"
 	rm -rf "$test_root"
 
 	if [[ "$HOOK_TEST_FAIL" -eq 0 ]]; then

--- a/.agents/scripts/setup/_canonical_guard.sh
+++ b/.agents/scripts/setup/_canonical_guard.sh
@@ -58,7 +58,11 @@ setup_canonical_guard() {
 			continue
 		fi
 		if ! result=$(cd "$path" && bash "$installer_path" install 2>&1 </dev/null); then
-			err=$((err + 1))
+			if [[ "$result" == *"Refusing to overwrite"* || "$result" == *"NOT managed"* ]]; then
+				conflict=$((conflict + 1))
+			else
+				err=$((err + 1))
+			fi
 			continue
 		fi
 		if [[ "$result" == *"installed canonical-on-main-guard"* ]]; then
@@ -74,9 +78,12 @@ setup_canonical_guard() {
 
 	print_info "Canonical guard: ok=$ok already=$already conflict=$conflict skip=$skip err=$err"
 	local total_covered=$((ok + already))
-	if [[ "$conflict" -gt 0 || "$err" -gt 0 ]]; then
+	if [[ "$err" -gt 0 ]]; then
 		print_error "Canonical guard installation incomplete; refusing successful setup"
 		return 1
+	fi
+	if [[ "$conflict" -gt 0 ]]; then
+		print_warning "Canonical detector hook conflicts remain, but preventive runtime/PATH guards are active"
 	fi
 	setup_track_configured "Canonical guard (${total_covered} repos)"
 	return 0

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -14,6 +14,10 @@ LINKED="${TEST_ROOT}/linked"
 TESTS=0
 FAILURES=0
 
+# Fixture setup must bypass the guard under test; policy assertions invoke the
+# shim explicitly below.
+git() { /usr/bin/git "$@"; return $?; }
+
 pass() { TESTS=$((TESTS + 1)); printf 'PASS %s\n' "$1"; return 0; }
 fail() { TESTS=$((TESTS + 1)); FAILURES=$((FAILURES + 1)); printf 'FAIL %s\n' "$1"; return 0; }
 
@@ -75,6 +79,8 @@ assert_blocked "blocks wrapped canonical switch" "env TEST=1 command git switch 
 assert_blocked "blocks nested absolute Git bypass" "bash -c '/usr/bin/git switch --detach main'"
 assert_blocked "blocks chained canonical mutation" "git status && git branch -M renamed"
 assert_blocked "blocks canonical update-ref plumbing" "/usr/bin/git update-ref refs/heads/main HEAD"
+assert_blocked "blocks destructive clean with exclude containing n" "git clean --force --exclude=nope"
+assert_blocked "blocks interactive clean" "git clean --interactive"
 
 if [[ "$(git -C "$REPO" symbolic-ref --short HEAD)" == "main" ]] &&
 	[[ "$(git -C "$REPO" rev-parse HEAD)" == "$INITIAL_HEAD" ]] &&
@@ -106,12 +112,12 @@ fi
 SHIM_BIN="${TEST_ROOT}/bin"
 mkdir -p "$SHIM_BIN"
 ln -s "$SHIM" "${SHIM_BIN}/git"
-if (cd "$REPO" && PATH="${SHIM_BIN}:/usr/bin:/bin" git status --short >/dev/null); then
+if (cd "$REPO" && env PATH="${SHIM_BIN}:/usr/bin:/bin" git status --short >/dev/null); then
 	pass "deployed symlink shim resolves policy engine"
 else
 	fail "deployed symlink shim resolves policy engine"
 fi
-if (cd "$REPO" && PATH="${SHIM_BIN}:/usr/bin:/bin" git switch --detach main >/dev/null 2>&1); then
+if (cd "$REPO" && env PATH="${SHIM_BIN}:/usr/bin:/bin" git switch --detach main >/dev/null 2>&1); then
 	fail "deployed symlink shim blocks canonical mutation"
 else
 	[[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "main" ]] && pass "deployed symlink shim blocks canonical mutation" || fail "symlink shim changed canonical HEAD"
@@ -120,7 +126,7 @@ fi
 LITERAL_REPO="${TEST_ROOT}/repo[1]"
 mkdir -p "$LITERAL_REPO"
 /usr/bin/git -C "$LITERAL_REPO" init -q -b main
-if (cd "$LITERAL_REPO" && PATH="${SHIM_BIN}:/usr/bin:/bin" git status --short >/dev/null); then
+if (cd "$LITERAL_REPO" && env PATH="${SHIM_BIN}:/usr/bin:/bin" git status --short >/dev/null); then
 	pass "shim accepts already-expanded literal metacharacter path"
 else
 	fail "shim accepts already-expanded literal metacharacter path"

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/canonical-recovery-helper.sh"
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+export HOME="${ROOT}/home"
+REPO="${ROOT}/repo"
+OCCUPIED="${ROOT}/main-worktree"
+mkdir -p "$HOME" "$REPO"
+/usr/bin/git -C "$REPO" init -q -b main
+/usr/bin/git -C "$REPO" config user.name Test
+/usr/bin/git -C "$REPO" config user.email test@example.invalid
+/usr/bin/git -C "$REPO" config commit.gpgsign false
+printf 'seed\n' >"${REPO}/README.md"
+/usr/bin/git -C "$REPO" add README.md
+/usr/bin/git -C "$REPO" commit -q -m seed
+/usr/bin/git -C "$REPO" remote add origin "$REPO"
+/usr/bin/git -C "$REPO" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+/usr/bin/git -C "$REPO" switch -q -c safety/test
+/usr/bin/git -C "$REPO" worktree add -q "$OCCUPIED" main
+
+if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null 2>&1; then
+	printf 'FAIL recovery ignored occupied default branch\n'
+	exit 1
+fi
+printf 'PASS recovery refuses occupied default branch\n'
+
+/usr/bin/git -C "$REPO" worktree remove "$OCCUPIED"
+if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null &&
+	[[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "main" ]]; then
+	printf 'PASS audited recovery restores only default branch\n'
+else
+	printf 'FAIL audited recovery did not restore default branch\n'
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Repair v3.32.10 deployment compatibility: use source hook fixtures, safely resolve the real Git binary when both source and deployed shims are on PATH, keep clean dry-runs read-only without destructive long-option bypasses, classify unmanaged detector-hook conflicts without disabling preventive guards, and add an audited default-only canonical recovery helper.

## Files Changed

.agents/scripts/canonical-git-command-guard.py, .agents/scripts/canonical-recovery-helper.sh, .agents/scripts/git, .agents/scripts/install-hooks-helper.sh, .agents/scripts/setup/_canonical_guard.sh, .agents/scripts/tests/test-canonical-git-command-guard.sh, .agents/scripts/tests/test-canonical-recovery-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 31 canonical guard cases, 23 hook self-tests, canonical recovery occupancy/default/audit tests, setup summary, ShellCheck, Python compilation, changed-file lint, explicit complexity gate, and independent adversarial review pass.

Resolves #27014


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4h 20m and 2,641,622 tokens on this with the user in an interactive session.