### PR TITLE
GH#27014: Isolate canonical recovery audit chain

### DIFF
--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -71,15 +71,16 @@ mkdir "$lock_dir" 2>/dev/null || {
 trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
 
 audit_helper="${SCRIPT_DIR}/audit-log-helper.sh"
+recovery_audit_file="${HOME}/.aidevops/logs/canonical-recovery-audit.jsonl"
 [[ -x "$audit_helper" ]] || {
 	printf 'BLOCKED: tamper-evident audit helper is unavailable\n' >&2
 	exit 1
 }
-"$audit_helper" verify --quiet || {
+AUDIT_LOG_FILE="$recovery_audit_file" "$audit_helper" verify --quiet || {
 	printf 'BLOCKED: audit chain verification failed\n' >&2
 	exit 1
 }
-AUDIT_QUIET=true "$audit_helper" log operation.verify "Canonical default-branch recovery authorized" \
+AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log operation.verify "Canonical default-branch recovery authorized" \
 	--detail "issue=${issue_number}" --detail "repo=${repo_path}" --detail "target=${default_branch}" >/dev/null || {
 	printf 'BLOCKED: recovery audit record could not be written\n' >&2
 	exit 1

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -30,8 +30,11 @@ fi
 printf 'PASS recovery refuses occupied default branch\n'
 
 /usr/bin/git -C "$REPO" worktree remove "$OCCUPIED"
-if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null &&
-	[[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "main" ]]; then
+printf 'invalid global audit chain\n' >"${ROOT}/broken-global-audit.jsonl"
+if AUDIT_LOG_FILE="${ROOT}/broken-global-audit.jsonl" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null &&
+	[[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "main" ]] &&
+	[[ -s "$HOME/.aidevops/logs/canonical-recovery-audit.jsonl" ]]; then
 	printf 'PASS audited recovery restores only default branch\n'
 else
 	printf 'FAIL audited recovery did not restore default branch\n'


### PR DESCRIPTION
## Summary

Use a fixed dedicated tamper-evident audit chain for canonical recovery so unrelated corruption in the global audit chain cannot force a bypass or redirect recovery records.

## Files Changed

.agents/scripts/canonical-recovery-helper.sh, .agents/scripts/tests/test-canonical-recovery-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Canonical recovery test injects a corrupt inherited audit path and verifies successful default restoration plus a non-empty dedicated audit record; ShellCheck, changed-file lint, diff checks, and independent audit pass.

Resolves #27014


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.11 with gpt-5.6-sol spent 4h 34m and 2,961,076 tokens on this with the user in an interactive session.