### PR TITLE
GH#27021: Fast-forward canonical recovery to origin tip

### DIFF
--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -72,12 +72,18 @@ trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
 
 local_ref="refs/heads/${default_branch}"
 remote_ref="refs/remotes/origin/${default_branch}"
+"$REAL_GIT" -C "$repo_path" fetch --no-tags origin \
+	"+refs/heads/${default_branch}:${remote_ref}" >/dev/null 2>&1 || {
+	printf 'BLOCKED: origin default branch tip could not be fetched\n' >&2
+	exit 1
+}
 target_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}" 2>/dev/null || true)
 [[ -n "$target_sha" ]] || {
 	printf 'BLOCKED: origin default branch tip cannot be resolved\n' >&2
 	exit 1
 }
-"$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}" >/dev/null 2>&1 || {
+local_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}" 2>/dev/null || true)
+[[ -n "$local_sha" ]] || {
 	printf 'BLOCKED: local default branch tip cannot be resolved\n' >&2
 	exit 1
 }
@@ -107,8 +113,13 @@ AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log opera
 	printf 'BLOCKED: origin default branch tip changed during recovery\n' >&2
 	exit 1
 }
+[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}")" == "$local_sha" ]] || {
+	printf 'BLOCKED: local default branch tip changed during recovery\n' >&2
+	exit 1
+}
 "$REAL_GIT" -C "$repo_path" switch "$default_branch"
 [[ "$("$REAL_GIT" -C "$repo_path" branch --show-current)" == "$default_branch" ]] || exit 1
 "$REAL_GIT" -C "$repo_path" merge --ff-only "$target_sha"
 [[ "$("$REAL_GIT" -C "$repo_path" rev-parse HEAD)" == "$target_sha" ]] || exit 1
+[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] || exit 1
 printf 'Restored canonical repository to %s\n' "$default_branch"

--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -70,6 +70,22 @@ mkdir "$lock_dir" 2>/dev/null || {
 }
 trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
 
+local_ref="refs/heads/${default_branch}"
+remote_ref="refs/remotes/origin/${default_branch}"
+target_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}" 2>/dev/null || true)
+[[ -n "$target_sha" ]] || {
+	printf 'BLOCKED: origin default branch tip cannot be resolved\n' >&2
+	exit 1
+}
+"$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}" >/dev/null 2>&1 || {
+	printf 'BLOCKED: local default branch tip cannot be resolved\n' >&2
+	exit 1
+}
+"$REAL_GIT" -C "$repo_path" merge-base --is-ancestor "$local_ref" "$target_sha" || {
+	printf 'BLOCKED: local default branch has diverged from origin/%s\n' "$default_branch" >&2
+	exit 1
+}
+
 audit_helper="${SCRIPT_DIR}/audit-log-helper.sh"
 recovery_audit_file="${HOME}/.aidevops/logs/canonical-recovery-audit.jsonl"
 [[ -x "$audit_helper" ]] || {
@@ -81,11 +97,18 @@ AUDIT_LOG_FILE="$recovery_audit_file" "$audit_helper" verify --quiet || {
 	exit 1
 }
 AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log operation.verify "Canonical default-branch recovery authorized" \
-	--detail "issue=${issue_number}" --detail "repo=${repo_path}" --detail "target=${default_branch}" >/dev/null || {
+	--detail "issue=${issue_number}" --detail "repo=${repo_path}" \
+	--detail "target=${default_branch}" --detail "target_sha=${target_sha}" >/dev/null || {
 	printf 'BLOCKED: recovery audit record could not be written\n' >&2
 	exit 1
 }
 
+[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] || {
+	printf 'BLOCKED: origin default branch tip changed during recovery\n' >&2
+	exit 1
+}
 "$REAL_GIT" -C "$repo_path" switch "$default_branch"
 [[ "$("$REAL_GIT" -C "$repo_path" branch --show-current)" == "$default_branch" ]] || exit 1
+"$REAL_GIT" -C "$repo_path" merge --ff-only "$target_sha"
+[[ "$("$REAL_GIT" -C "$repo_path" rev-parse HEAD)" == "$target_sha" ]] || exit 1
 printf 'Restored canonical repository to %s\n' "$default_branch"

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -53,8 +53,7 @@ fi
 printf 'remote ahead\n' >>"${UPDATER}/README.md"
 /usr/bin/git -C "$UPDATER" commit -q -am 'remote ahead'
 /usr/bin/git -C "$UPDATER" push -q origin main
-/usr/bin/git -C "$REPO" fetch -q origin main
-remote_tip=$(/usr/bin/git -C "$REPO" rev-parse refs/remotes/origin/main)
+remote_tip=$(/usr/bin/git -C "$REMOTE" rev-parse refs/heads/main)
 if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null &&
 	[[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "main" ]] &&
 	[[ "$(/usr/bin/git -C "$REPO" rev-parse HEAD)" == "$remote_tip" ]]; then
@@ -73,7 +72,6 @@ local_tip=$(/usr/bin/git -C "$REPO" rev-parse main)
 printf 'remote divergence\n' >>"${UPDATER}/README.md"
 /usr/bin/git -C "$UPDATER" commit -q -am 'remote divergence'
 /usr/bin/git -C "$UPDATER" push -q origin main
-/usr/bin/git -C "$REPO" fetch -q origin main
 if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null 2>&1; then
 	printf 'FAIL recovery accepted divergent default branch\n'
 	exit 1

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -9,8 +9,11 @@ ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
 export HOME="${ROOT}/home"
 REPO="${ROOT}/repo"
+REMOTE="${ROOT}/remote.git"
+UPDATER="${ROOT}/updater"
 OCCUPIED="${ROOT}/main-worktree"
 mkdir -p "$HOME" "$REPO"
+/usr/bin/git init -q --bare "$REMOTE"
 /usr/bin/git -C "$REPO" init -q -b main
 /usr/bin/git -C "$REPO" config user.name Test
 /usr/bin/git -C "$REPO" config user.email test@example.invalid
@@ -18,8 +21,10 @@ mkdir -p "$HOME" "$REPO"
 printf 'seed\n' >"${REPO}/README.md"
 /usr/bin/git -C "$REPO" add README.md
 /usr/bin/git -C "$REPO" commit -q -m seed
-/usr/bin/git -C "$REPO" remote add origin "$REPO"
-/usr/bin/git -C "$REPO" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+/usr/bin/git -C "$REPO" remote add origin "$REMOTE"
+/usr/bin/git -C "$REPO" push -q -u origin main
+/usr/bin/git -C "$REMOTE" symbolic-ref HEAD refs/heads/main
+/usr/bin/git -C "$REPO" remote set-head origin main
 /usr/bin/git -C "$REPO" switch -q -c safety/test
 /usr/bin/git -C "$REPO" worktree add -q "$OCCUPIED" main
 
@@ -38,5 +43,45 @@ if AUDIT_LOG_FILE="${ROOT}/broken-global-audit.jsonl" AIDEVOPS_REAL_GIT_BIN=/usr
 	printf 'PASS audited recovery restores only default branch\n'
 else
 	printf 'FAIL audited recovery did not restore default branch\n'
+	exit 1
+fi
+
+/usr/bin/git -C "$REPO" switch -q safety/test
+/usr/bin/git clone -q "$REMOTE" "$UPDATER"
+/usr/bin/git -C "$UPDATER" config user.name Test
+/usr/bin/git -C "$UPDATER" config user.email test@example.invalid
+printf 'remote ahead\n' >>"${UPDATER}/README.md"
+/usr/bin/git -C "$UPDATER" commit -q -am 'remote ahead'
+/usr/bin/git -C "$UPDATER" push -q origin main
+/usr/bin/git -C "$REPO" fetch -q origin main
+remote_tip=$(/usr/bin/git -C "$REPO" rev-parse refs/remotes/origin/main)
+if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null &&
+	[[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "main" ]] &&
+	[[ "$(/usr/bin/git -C "$REPO" rev-parse HEAD)" == "$remote_tip" ]]; then
+	printf 'PASS audited recovery fast-forwards to exact origin default tip\n'
+else
+	printf 'FAIL audited recovery did not reach exact origin default tip\n'
+	exit 1
+fi
+
+/usr/bin/git -C "$REPO" switch -q safety/test
+/usr/bin/git -C "$REPO" worktree add -q "$OCCUPIED" main
+printf 'local divergence\n' >>"${OCCUPIED}/README.md"
+/usr/bin/git -C "$OCCUPIED" commit -q -am 'local divergence'
+/usr/bin/git -C "$REPO" worktree remove "$OCCUPIED"
+local_tip=$(/usr/bin/git -C "$REPO" rev-parse main)
+printf 'remote divergence\n' >>"${UPDATER}/README.md"
+/usr/bin/git -C "$UPDATER" commit -q -am 'remote divergence'
+/usr/bin/git -C "$UPDATER" push -q origin main
+/usr/bin/git -C "$REPO" fetch -q origin main
+if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null 2>&1; then
+	printf 'FAIL recovery accepted divergent default branch\n'
+	exit 1
+fi
+if [[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "safety/test" ]] &&
+	[[ "$(/usr/bin/git -C "$REPO" rev-parse main)" == "$local_tip" ]]; then
+	printf 'PASS recovery refuses divergence without changing refs\n'
+else
+	printf 'FAIL divergence refusal changed branch or refs\n'
 	exit 1
 fi


### PR DESCRIPTION
## Summary

- fetch and preflight the resolved origin default tip under the canonical recovery lock
- refuse divergent or concurrently changing local/remote refs
- fast-forward the canonical default branch to the exact audited SHA
- cover remote-ahead equality and divergence refusal in the focused test

Resolves #27021

## Verification

- `bash .agents/scripts/tests/test-canonical-recovery-helper.sh`
- `shellcheck .agents/scripts/canonical-recovery-helper.sh .agents/scripts/tests/test-canonical-recovery-helper.sh`
- `git diff --check origin/main...HEAD`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.12 plugin for [OpenCode](https://opencode.ai) v1.17.18
