### PR TITLE
GH#27024: fix: align agent review search permissions

### DIFF
--- a/.agents/scripts/tests/test-agent-review-permissions.sh
+++ b/.agents/scripts/tests/test-agent-review-permissions.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Guard Agent Review's search instructions against its declared permissions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+AGENT_REVIEW="$REPO_ROOT/.agents/tools/build-agent/agent-review.md"
+
+python3 - "$AGENT_REVIEW" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+content = path.read_text()
+parts = content.split("---", 2)
+assert len(parts) == 3, "Agent Review must retain YAML frontmatter"
+frontmatter, body = parts[1], parts[2]
+
+assert re.search(r"^\s+bash:\s+false\s*$", frontmatter, re.MULTILINE), \
+    "Agent Review must keep Bash disabled"
+assert re.search(r"^\s+grep:\s+true\s*$", frontmatter, re.MULTILINE), \
+    "Agent Review must keep Grep enabled"
+assert re.search(r"\*\*Duplicate detection\*\* \(Grep ", body), \
+    "Duplicate detection must remain mandatory through Grep"
+
+rg_lines = [line for line in body.splitlines() if re.search(r"`rg\b", line)]
+assert rg_lines, "Document the optional rg equivalent for Bash-enabled agents"
+assert all("when Bash is available" in line for line in rg_lines), \
+    "Every rg instruction must be conditional on Bash availability"
+PY
+
+printf 'PASS Agent Review permission/instruction contract\n'

--- a/.agents/scripts/tests/test-agent-review-permissions.sh
+++ b/.agents/scripts/tests/test-agent-review-permissions.sh
@@ -28,7 +28,7 @@ assert re.search(r"^\s+grep:\s+true\s*$", frontmatter, re.MULTILINE), \
 assert re.search(r"\*\*Duplicate detection\*\* \(Grep ", body), \
     "Duplicate detection must remain mandatory through Grep"
 
-rg_lines = [line for line in body.splitlines() if re.search(r"`rg\b", line)]
+rg_lines = [line for line in body.splitlines() if re.search(r"\brg\b", line)]
 assert rg_lines, "Document the optional rg equivalent for Bash-enabled agents"
 assert all("when Bash is available" in line for line in rg_lines), \
     "Every rg instruction must be conditional on Bash availability"

--- a/.agents/tools/build-agent/agent-review.md
+++ b/.agents/tools/build-agent/agent-review.md
@@ -20,7 +20,8 @@ tools:
 <!-- AI-CONTEXT-START -->
 
 **Trigger**: Session end, user correction, observable failure, periodic maintenance.
-**Self-Assessment**: Observe failure → complete task → cite evidence → `rg "pattern" .agents/` → propose fix → ask permission.
+**Self-Assessment**: Observe failure → complete task → cite evidence → search for `"pattern"` under `.agents/` with Grep → propose fix → ask permission.
+**Exact Search**: Use the Grep tool for content searches; when Bash is available, `rg "pattern" <path>` is an optional equivalent.
 **Write Restrictions (MANDATORY)**: On `main`/`master` — ALLOWED: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. BLOCKED: all other files. Code changes → return proposed edits for worktree application.
 
 <!-- AI-CONTEXT-END -->
@@ -31,8 +32,8 @@ tools:
 |---|-------|-------------------|
 | 1 | **Instruction count** (~50-100 main, <100 subagent) | Consolidate, move to subagent, or remove |
 | 2 | **Universal applicability** (>80% tasks) | Extract task-specific content to subagents |
-| 3 | **Duplicate detection** (`rg "pattern" .agents/`) | Single authoritative source per concept |
-| 4 | **Code examples** (authoritative/working) | Keep; supplement with `rg "pattern" .agents/scripts/` references |
+| 3 | **Duplicate detection** (Grep for `"pattern"` under `.agents/`) | Single authoritative source per concept |
+| 4 | **Code examples** (authoritative/working) | Keep; supplement with Grep references for `"pattern"` under `.agents/scripts/` |
 | 5 | **AI-CONTEXT block** (standalone essentials) | Rewrite if an AI would get stuck with only this |
 | 6 | **Slash commands** | Move to `scripts/commands/` or domain subagent |
 


### PR DESCRIPTION
## Summary

Use Grep for mandatory Agent Review searches, keep rg explicitly conditional on Bash availability, and add a static permission-contract regression test.

## Files Changed

.agents/scripts/tests/test-agent-review-permissions.sh, .agents/tools/build-agent/agent-review.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bunx markdownlint-cli2 .agents/tools/build-agent/agent-review.md; bash .agents/scripts/tests/test-agent-review-permissions.sh; bash .agents/scripts/tests/test-subagent-validation-globs.sh; .agents/scripts/linters-local.sh --changed

Resolves #27024


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.12 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 62,170 tokens on this as a headless worker.