### PR TITLE
GH#27028: simplify canonical Git command guard

### DIFF
--- a/.agents/scripts/canonical-git-command-guard.py
+++ b/.agents/scripts/canonical-git-command-guard.py
@@ -7,196 +7,62 @@ import argparse
 import json
 import os
 import re
-import shlex
-import shutil
-import subprocess
 import sys
-from pathlib import Path
+from typing import Optional
 
-BLOCK_EXIT = 42
-SHELL_OPERATORS = {"&&", "||", ";", "|", "(", ")", "&"}
-READ_ONLY = {
-    "status", "diff", "log", "show", "rev-parse", "show-ref", "for-each-ref",
-    "cat-file", "ls-files", "ls-tree", "merge-base", "describe", "grep", "blame",
-    "shortlog", "whatchanged", "name-rev", "count-objects", "version", "help",
-}
-GLOBAL_VALUE_OPTIONS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
-WRAPPERS = {"command", "sudo", "time", "nohup"}
+from canonical_git_policy import BLOCK_EXIT, classify_git_argv, real_git
+from canonical_shell_parser import git_invocations
 
 
-def _real_git(explicit: str = "") -> str:
-    if explicit:
-        return explicit
-    guard_dir = Path(__file__).resolve().parent
-    for directory in os.environ.get("PATH", "").split(os.pathsep):
-        candidate = Path(directory or ".") / "git"
-        try:
-            if candidate.is_file() and os.access(candidate, os.X_OK) and candidate.resolve().parent != guard_dir:
-                return str(candidate.resolve())
-        except OSError:
-            continue
-    return shutil.which("git") or "/usr/bin/git"
+def _parse_invocations(
+    command: str, cwd: str
+) -> tuple[list[tuple[list[str], str]], Optional[tuple[bool, str]]]:
+    try:
+        return git_invocations(command, cwd), None
+    except PermissionError:
+        return [], (
+            False,
+            "Git repository environment override is not permitted in guarded shell commands",
+        )
+    except ValueError:
+        if "git" in command:
+            return [], (False, "unable to parse command containing Git")
+        return [], (True, "no Git invocation")
 
 
-def _git_output(real_git: str, cwd: str, *args: str) -> str:
-    result = subprocess.run(
-        [real_git, *args], cwd=cwd, text=True, capture_output=True, timeout=5, check=False
-    )
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def _is_canonical(real_git: str, cwd: str, git_prefix: list[str]) -> bool:
-    git_dir = _git_output(real_git, cwd, *git_prefix, "rev-parse", "--path-format=absolute", "--git-dir")
-    common_dir = _git_output(real_git, cwd, *git_prefix, "rev-parse", "--path-format=absolute", "--git-common-dir")
-    if not git_dir or not common_dir:
-        return False
-    return os.path.realpath(git_dir) == os.path.realpath(common_dir)
-
-
-def _split_invocation(argv: list[str], base_cwd: str) -> tuple[list[str], str, str, list[str]]:
-    prefix: list[str] = []
-    cwd = base_cwd
-    index = 0
-    while index < len(argv):
-        arg = argv[index]
-        if arg == "--":
-            index += 1
-            break
-        if arg in GLOBAL_VALUE_OPTIONS:
-            if index + 1 >= len(argv):
-                return prefix, cwd, "", []
-            value = argv[index + 1]
-            prefix.extend([arg, value])
-            index += 2
-            continue
-        if arg.startswith("-"):
-            prefix.append(arg)
-            index += 1
-            continue
-        return prefix, cwd, arg, argv[index + 1 :]
-    return prefix, cwd, "", argv[index:]
-
-
-def _branch_is_read_only(args: list[str]) -> bool:
-    if not args:
-        return True
-    mutating = {"-d", "-D", "-m", "-M", "-c", "-C", "-f", "--delete", "--move", "--copy", "--force", "--edit-description", "--set-upstream-to", "--unset-upstream"}
-    if any(arg in mutating or arg.startswith(("--move=", "--copy=", "--set-upstream-to=")) for arg in args):
-        return False
-    listing = any(arg in {"--list", "--contains", "--merged", "--no-merged", "--points-at"} or arg.startswith(("--contains=", "--merged=", "--no-merged=", "--points-at=")) for arg in args)
-    return listing or all(arg.startswith("-") or arg in {"HEAD", "@"} for arg in args)
-
-
-def _config_is_read_only(args: list[str]) -> bool:
-    read_flags = {"--get", "--get-all", "--get-regexp", "--get-urlmatch", "--list", "-l", "--show-origin", "--show-scope", "--name-only", "--includes", "--null", "-z"}
-    return bool(args) and any(arg in read_flags for arg in args) and not any(arg in {"--add", "--unset", "--unset-all", "--rename-section", "--remove-section", "--replace-all"} for arg in args)
-
-
-def _is_allowed_canonical(subcommand: str, args: list[str]) -> bool:
-    if subcommand in READ_ONLY:
-        return True
-    if subcommand == "branch":
-        return _branch_is_read_only(args)
-    if subcommand == "config":
-        return _config_is_read_only(args)
-    if subcommand == "clean":
-        return any(arg == "--dry-run" or (arg.startswith("-") and not arg.startswith("--") and "n" in arg[1:]) for arg in args)
-    if subcommand == "remote":
-        return not args or args[0] in {"-v", "--verbose", "get-url", "show"}
-    if subcommand == "worktree":
-        return bool(args) and args[0] in {"list", "add"}
-    if subcommand == "tag":
-        return not args or any(arg in {"-l", "--list", "--contains", "--points-at"} or arg.startswith(("--contains=", "--points-at=")) for arg in args)
-    return False
-
-
-def classify_git_argv(argv: list[str], cwd: str, real_git: str, check_unresolved: bool = False) -> tuple[bool, str]:
-    prefix, effective_cwd, subcommand, args = _split_invocation(argv, cwd)
-    if not subcommand:
-        return False, "unable to classify Git subcommand"
-    repo_values: list[str] = []
-    for index, value in enumerate(prefix[:-1]):
-        if value in {"-C", "--git-dir", "--work-tree"}:
-            repo_values.append(prefix[index + 1])
-    for value in prefix:
-        if value.startswith(("--git-dir=", "--work-tree=")):
-            repo_values.append(value.split("=", 1)[1])
-    if check_unresolved and any(value.startswith("~") or re.search(r"[$`*?\[\]{}]", value) for value in repo_values):
-        return False, "unresolved shell syntax in Git repository target"
-    if not _is_canonical(real_git, effective_cwd, prefix):
-        return True, "linked worktree or non-repository target"
-    if _is_allowed_canonical(subcommand, args):
-        return True, "read-only canonical operation or linked-worktree creation"
-    return False, f"canonical worktree mutation via 'git {subcommand}'"
-
-
-def _shell_tokens(command: str) -> list[str]:
-    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    return list(lexer)
-
-
-def _git_invocations(command: str, cwd: str) -> list[tuple[list[str], str]]:
-    tokens = _shell_tokens(command)
-    invocations: list[tuple[list[str], str]] = []
-    segment: list[str] = []
-    segment_cwd = cwd
-    for token in tokens + [";"]:
-        if token not in SHELL_OPERATORS:
-            segment.append(token)
-            continue
-        if segment:
-            if segment[0] == "cd" and len(segment) >= 2:
-                target = os.path.expanduser(segment[1])
-                segment_cwd = target if os.path.isabs(target) else os.path.abspath(os.path.join(segment_cwd, target))
-            else:
-                index = 0
-                while index < len(segment):
-                    if "=" in segment[index] and not segment[index].startswith("-"):
-                        variable_name = segment[index].split("=", 1)[0]
-                        if variable_name in {"GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"}:
-                            raise PermissionError("Git repository environment override")
-                        index += 1
-                        continue
-                    if segment[index] in WRAPPERS:
-                        index += 1
-                        continue
-                    if segment[index] == "env":
-                        index += 1
-                        while index < len(segment) and "=" in segment[index] and not segment[index].startswith("-"):
-                            variable_name = segment[index].split("=", 1)[0]
-                            if variable_name in {"GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"}:
-                                raise PermissionError("Git repository environment override")
-                            index += 1
-                        continue
-                    break
-                if index < len(segment) and os.path.basename(segment[index]) == "git":
-                    invocations.append((segment[index + 1 :], segment_cwd))
-            segment = []
-    return invocations
+def _first_blocked_invocation(
+    invocations: list[tuple[list[str], str]], cwd: str, real_git_path: str
+) -> Optional[tuple[bool, str]]:
+    for argv, invocation_cwd in invocations:
+        if invocation_cwd != cwd and (
+            invocation_cwd.startswith("~") or re.search(r"[$`*?\[\]{}]", invocation_cwd)
+        ):
+            return False, "unresolved shell syntax in Git repository target"
+        allowed, reason = classify_git_argv(
+            argv, invocation_cwd, real_git_path, check_unresolved=True
+        )
+        if not allowed:
+            return False, reason
+    return None
 
 
 def classify_command(command: str, cwd: str, real_git: str) -> tuple[bool, str]:
     if re.search(r"(?:^|\s)GIT_(?:DIR|WORK_TREE|COMMON_DIR)=", command):
-        return False, "Git repository environment override is not permitted in guarded shell commands"
-    try:
-        invocations = _git_invocations(command, cwd)
-    except PermissionError:
-        return False, "Git repository environment override is not permitted in guarded shell commands"
-    except ValueError:
-        if "git" in command:
-            return False, "unable to parse command containing Git"
-        return True, "no Git invocation"
-    if not invocations and "git" in command and re.search(r"(?:^|[\s'\"])(?:/\S*/)?git\s+", command):
+        return (
+            False,
+            "Git repository environment override is not permitted in guarded shell commands",
+        )
+    invocations, parse_result = _parse_invocations(command, cwd)
+    if parse_result is not None:
+        return parse_result
+    if (
+        not invocations
+        and "git" in command
+        and re.search(r"(?:^|[\s'\"])(?:/\S*/)?git\s+", command)
+    ):
         return False, "unclassified nested Git invocation"
-    for argv, invocation_cwd in invocations:
-        if invocation_cwd != cwd and (invocation_cwd.startswith("~") or re.search(r"[$`*?\[\]{}]", invocation_cwd)):
-            return False, "unresolved shell syntax in Git repository target"
-        allowed, reason = classify_git_argv(argv, invocation_cwd, real_git, check_unresolved=True)
-        if not allowed:
-            return False, reason
-    return True, "no prohibited canonical Git mutation"
+    blocked = _first_blocked_invocation(invocations, cwd, real_git)
+    return blocked or (True, "no prohibited canonical Git mutation")
 
 
 def main() -> int:
@@ -206,19 +72,22 @@ def main() -> int:
     parser.add_argument("--argv-json", default="")
     parser.add_argument("--real-git", default="")
     args = parser.parse_args()
-    real_git = _real_git(args.real_git)
+    real_git_path = real_git(args.real_git)
     if args.argv_json:
         try:
             git_argv = json.loads(args.argv_json)
         except json.JSONDecodeError:
             print("BLOCKED: invalid Git argv", file=sys.stderr)
             return BLOCK_EXIT
-        allowed, reason = classify_git_argv(git_argv, args.cwd, real_git)
+        allowed, reason = classify_git_argv(git_argv, args.cwd, real_git_path)
     else:
-        allowed, reason = classify_command(args.command, args.cwd, real_git)
+        allowed, reason = classify_command(args.command, args.cwd, real_git_path)
     if allowed:
         return 0
-    print(f"BLOCKED by canonical Git guard: {reason}. Use a linked worktree; canonical branch/ref mutation is never permitted.", file=sys.stderr)
+    print(
+        f"BLOCKED by canonical Git guard: {reason}. Use a linked worktree; canonical branch/ref mutation is never permitted.",
+        file=sys.stderr,
+    )
     return BLOCK_EXIT
 
 

--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Repository-target and subcommand policy for the canonical Git guard."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+BLOCK_EXIT = 42
+READ_ONLY = {
+    "status",
+    "diff",
+    "log",
+    "show",
+    "rev-parse",
+    "show-ref",
+    "for-each-ref",
+    "cat-file",
+    "ls-files",
+    "ls-tree",
+    "merge-base",
+    "describe",
+    "grep",
+    "blame",
+    "shortlog",
+    "whatchanged",
+    "name-rev",
+    "count-objects",
+    "version",
+    "help",
+}
+GLOBAL_VALUE_OPTIONS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
+
+
+def real_git(explicit: str = "") -> str:
+    """Resolve the real Git executable without selecting the sibling shim."""
+    if explicit:
+        return explicit
+    guard_dir = Path(__file__).resolve().parent
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(directory or ".") / "git"
+        try:
+            if (
+                candidate.is_file()
+                and os.access(candidate, os.X_OK)
+                and candidate.resolve().parent != guard_dir
+            ):
+                return str(candidate.resolve())
+        except OSError:
+            continue
+    return shutil.which("git") or "/usr/bin/git"
+
+
+def _git_output(real_git_path: str, cwd: str, *args: str) -> str:
+    result = subprocess.run(
+        [real_git_path, *args],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _is_canonical(real_git_path: str, cwd: str, git_prefix: list[str]) -> bool:
+    git_dir = _git_output(
+        real_git_path,
+        cwd,
+        *git_prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-dir",
+    )
+    common_dir = _git_output(
+        real_git_path,
+        cwd,
+        *git_prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+    )
+    return bool(
+        git_dir
+        and common_dir
+        and os.path.realpath(git_dir) == os.path.realpath(common_dir)
+    )
+
+
+def _split_invocation(
+    argv: list[str], base_cwd: str
+) -> tuple[list[str], str, str, list[str]]:
+    prefix: list[str] = []
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--":
+            index += 1
+            break
+        if arg in GLOBAL_VALUE_OPTIONS:
+            if index + 1 >= len(argv):
+                return prefix, base_cwd, "", []
+            prefix.extend([arg, argv[index + 1]])
+            index += 2
+            continue
+        if arg.startswith("-"):
+            prefix.append(arg)
+            index += 1
+            continue
+        return prefix, base_cwd, arg, argv[index + 1 :]
+    return prefix, base_cwd, "", argv[index:]
+
+
+def _branch_is_read_only(args: list[str]) -> bool:
+    if not args:
+        return True
+    mutating = {
+        "-d",
+        "-D",
+        "-m",
+        "-M",
+        "-c",
+        "-C",
+        "-f",
+        "--delete",
+        "--move",
+        "--copy",
+        "--force",
+        "--edit-description",
+        "--set-upstream-to",
+        "--unset-upstream",
+    }
+    if any(
+        arg in mutating or arg.startswith(("--move=", "--copy=", "--set-upstream-to="))
+        for arg in args
+    ):
+        return False
+    listing = any(
+        arg in {"--list", "--contains", "--merged", "--no-merged", "--points-at"}
+        or arg.startswith(("--contains=", "--merged=", "--no-merged=", "--points-at="))
+        for arg in args
+    )
+    return listing or all(arg.startswith("-") or arg in {"HEAD", "@"} for arg in args)
+
+
+def _config_is_read_only(args: list[str]) -> bool:
+    read_flags = {
+        "--get",
+        "--get-all",
+        "--get-regexp",
+        "--get-urlmatch",
+        "--list",
+        "-l",
+        "--show-origin",
+        "--show-scope",
+        "--name-only",
+        "--includes",
+        "--null",
+        "-z",
+    }
+    write_flags = {
+        "--add",
+        "--unset",
+        "--unset-all",
+        "--rename-section",
+        "--remove-section",
+        "--replace-all",
+    }
+    return (
+        bool(args)
+        and any(arg in read_flags for arg in args)
+        and not any(arg in write_flags for arg in args)
+    )
+
+
+def _clean_is_read_only(args: list[str]) -> bool:
+    return any(
+        arg == "--dry-run"
+        or (arg.startswith("-") and not arg.startswith("--") and "n" in arg[1:])
+        for arg in args
+    )
+
+
+def _remote_is_read_only(args: list[str]) -> bool:
+    return not args or args[0] in {"-v", "--verbose", "get-url", "show"}
+
+
+def _worktree_is_allowed(args: list[str]) -> bool:
+    return bool(args) and args[0] in {"list", "add"}
+
+
+def _tag_is_read_only(args: list[str]) -> bool:
+    return not args or any(
+        arg in {"-l", "--list", "--contains", "--points-at"}
+        or arg.startswith(("--contains=", "--points-at="))
+        for arg in args
+    )
+
+
+CANONICAL_CHECKS: dict[str, Callable[[list[str]], bool]] = {
+    "branch": _branch_is_read_only,
+    "config": _config_is_read_only,
+    "clean": _clean_is_read_only,
+    "remote": _remote_is_read_only,
+    "worktree": _worktree_is_allowed,
+    "tag": _tag_is_read_only,
+}
+
+
+def _is_allowed_canonical(subcommand: str, args: list[str]) -> bool:
+    if subcommand in READ_ONLY:
+        return True
+    checker = CANONICAL_CHECKS.get(subcommand)
+    return bool(checker and checker(args))
+
+
+def _repository_values(prefix: list[str]) -> list[str]:
+    values = [
+        prefix[index + 1]
+        for index, option in enumerate(prefix[:-1])
+        if option in {"-C", "--git-dir", "--work-tree"}
+    ]
+    values.extend(
+        value.split("=", 1)[1]
+        for value in prefix
+        if value.startswith(("--git-dir=", "--work-tree="))
+    )
+    return values
+
+
+def classify_git_argv(
+    argv: list[str], cwd: str, real_git_path: str, check_unresolved: bool = False
+) -> tuple[bool, str]:
+    """Classify one Git argv vector against canonical-worktree policy."""
+    prefix, effective_cwd, subcommand, args = _split_invocation(argv, cwd)
+    if not subcommand:
+        return False, "unable to classify Git subcommand"
+    repo_values = _repository_values(prefix)
+    if check_unresolved and any(
+        value.startswith("~") or re.search(r"[$`*?\[\]{}]", value)
+        for value in repo_values
+    ):
+        return False, "unresolved shell syntax in Git repository target"
+    if not _is_canonical(real_git_path, effective_cwd, prefix):
+        return True, "linked worktree or non-repository target"
+    if _is_allowed_canonical(subcommand, args):
+        return True, "read-only canonical operation or linked-worktree creation"
+    return False, f"canonical worktree mutation via 'git {subcommand}'"

--- a/.agents/scripts/canonical_shell_parser.py
+++ b/.agents/scripts/canonical_shell_parser.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Extract Git argv vectors and effective directories from shell commands."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from typing import Optional
+
+SHELL_OPERATORS = {"&&", "||", ";", "|", "(", ")", "&"}
+WRAPPERS = {"command", "sudo", "time", "nohup"}
+REPOSITORY_ENVIRONMENT = {"GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"}
+
+
+def _shell_tokens(command: str) -> list[str]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    return list(lexer)
+
+
+def _assignment_name(token: str) -> str:
+    if "=" not in token or token.startswith("-"):
+        return ""
+    return token.split("=", 1)[0]
+
+
+def _skip_assignments(segment: list[str], start: int) -> int:
+    index = start
+    while index < len(segment):
+        variable_name = _assignment_name(segment[index])
+        if not variable_name:
+            break
+        if variable_name in REPOSITORY_ENVIRONMENT:
+            raise PermissionError("Git repository environment override")
+        index += 1
+    return index
+
+
+def _command_index(segment: list[str]) -> int:
+    index = 0
+    while index < len(segment):
+        assignments_end = _skip_assignments(segment, index)
+        if assignments_end != index:
+            index = assignments_end
+            continue
+        if segment[index] in WRAPPERS:
+            index += 1
+            continue
+        if segment[index] == "env":
+            index = _skip_assignments(segment, index + 1)
+            continue
+        break
+    return index
+
+
+def _changed_directory(segment: list[str], cwd: str) -> str:
+    target = os.path.expanduser(segment[1])
+    return (
+        target if os.path.isabs(target) else os.path.abspath(os.path.join(cwd, target))
+    )
+
+
+def _segment_invocation(
+    segment: list[str], cwd: str
+) -> tuple[Optional[list[str]], str]:
+    if segment[0] == "cd" and len(segment) >= 2:
+        return None, _changed_directory(segment, cwd)
+    index = _command_index(segment)
+    if index < len(segment) and os.path.basename(segment[index]) == "git":
+        return segment[index + 1 :], cwd
+    return None, cwd
+
+
+def git_invocations(command: str, cwd: str) -> list[tuple[list[str], str]]:
+    """Return each direct Git invocation and its effective working directory."""
+    tokens = _shell_tokens(command)
+    invocations: list[tuple[list[str], str]] = []
+    segment: list[str] = []
+    segment_cwd = cwd
+    for token in tokens + [";"]:
+        if token not in SHELL_OPERATORS:
+            segment.append(token)
+            continue
+        if not segment:
+            continue
+        invocation, segment_cwd = _segment_invocation(segment, segment_cwd)
+        if invocation is not None:
+            invocations.append((invocation, segment_cwd))
+        segment = []
+    return invocations


### PR DESCRIPTION
## Summary

- split canonical repository policy and shell parsing into focused Python modules
- replace return-heavy subcommand branching with handler dispatch
- flatten shell-token traversal while preserving fail-closed behavior

## Testing

- `python3 -m py_compile` for all three modules
- `ruff check` and `ruff format --check` for all three modules
- `qlty check` and `qlty smells` for all three modules (zero findings)
- `.agents/scripts/tests/test-canonical-git-command-guard.sh` (31 passed)
- `.agents/scripts/test-canonical-guard.sh` (6 passed with system Git fixture setup)

## Runtime Testing

- Runtime-verified through the canonical command guard and detector integration suites.

Resolves #27028

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.12 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 8m and 139,257 tokens on this as a headless worker.