### PR TITLE
GH#27036: strip image placeholders from session titles

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
@@ -6,6 +6,7 @@ import { join } from "path";
 
 const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
 const DEFAULT_SESSION_TITLE_RE = /^New session - /;
+const IMAGE_PLACEHOLDER_RE = /\[Image\s+\d+\]/gi;
 
 function readIfExists(filepath) {
   try {
@@ -33,8 +34,12 @@ export function readAidevopsVersion(agentsDir) {
   return "";
 }
 
+export function sanitizeSessionTitle(title) {
+  return String(title || "").replace(IMAGE_PLACEHOLDER_RE, " ").replace(/\s+/g, " ").trim();
+}
+
 export function withAidevopsTitleSuffix(title, version) {
-  const baseTitle = String(title || "").replace(AIDEVOPS_TITLE_SUFFIX_RE, "");
+  const baseTitle = sanitizeSessionTitle(String(title || "").replace(AIDEVOPS_TITLE_SUFFIX_RE, ""));
   if (!version) return baseTitle;
   return `${baseTitle} · AIDevOps ${version}`;
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import {
   createSessionTitleSuffixHandler,
   readAidevopsVersion,
+  sanitizeSessionTitle,
   withAidevopsTitleSuffix,
 } from "../session-title-suffix.mjs";
 import {
@@ -50,6 +51,17 @@ test("title suffix appends and replaces idempotently", () => {
   );
   assert.equal(
     withAidevopsTitleSuffix("Investigate title path · AIDevOps 3.20.101", "3.20.102"),
+    "Investigate title path · AIDevOps 3.20.102",
+  );
+});
+
+test("image placeholders are stripped while meaningful title text is preserved", () => {
+  assert.equal(
+    sanitizeSessionTitle("[Image 1] Investigate [Image 2] title path"),
+    "Investigate title path",
+  );
+  assert.equal(
+    withAidevopsTitleSuffix("[image 12] Investigate title path", "3.20.102"),
     "Investigate title path · AIDevOps 3.20.102",
   );
 });

--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -24,7 +24,7 @@ const { isDefaultBranchTitle, isTitleOverwritable } = await import(
   "../../../.opencode/lib/session-rename-guards.ts"
 );
 const { getDbPath } = await import("../../../.opencode/lib/opencode-db-path.ts");
-const { getAidevopsVersion, withAidevopsTitleSuffix } = await import(
+const { getAidevopsVersion, sanitizeSessionTitle, withAidevopsTitleSuffix } = await import(
   "../../../.opencode/lib/session-title-suffix.ts"
 );
 const { isTerminalTitleEnabled, sanitizeTerminalTitle, terminalTitleSequence } = await import(
@@ -185,6 +185,21 @@ assertEq(
   "missing version leaves title without stale suffix",
   "Issue #123: concise title",
   withAidevopsTitleSuffix("Issue #123: concise title · AIDevOps 1.2.3", ""),
+);
+assertEq(
+  "image placeholders are removed from generated titles",
+  "Review the session title rename",
+  sanitizeSessionTitle("[Image 1] Review the session [Image 2] title rename"),
+);
+assertEq(
+  "image placeholder matching is case-insensitive",
+  "Preserve useful title text",
+  sanitizeSessionTitle("Preserve [image 12] useful title text"),
+);
+assertEq(
+  "image placeholders are stripped before suffixing",
+  "Fix title renaming · AIDevOps 9.8.7",
+  withAidevopsTitleSuffix("[Image 1] Fix title renaming", "9.8.7"),
 );
 process.env.AIDEVOPS_VERSION = "7.6.5";
 assertEq("env version override is read", "7.6.5", getAidevopsVersion());

--- a/.opencode/lib/session-title-suffix.ts
+++ b/.opencode/lib/session-title-suffix.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/
+const IMAGE_PLACEHOLDER_RE = /\[Image\s+\d+\]/gi
 
 function readVersionFile(path: string): string {
   try {
@@ -31,8 +32,12 @@ export function getAidevopsVersion(): string {
   return ""
 }
 
+export function sanitizeSessionTitle(title: string): string {
+  return title.replace(IMAGE_PLACEHOLDER_RE, " ").replace(/\s+/g, " ").trim()
+}
+
 export function withAidevopsTitleSuffix(title: string, version = getAidevopsVersion()): string {
-  const baseTitle = title.replace(AIDEVOPS_TITLE_SUFFIX_RE, "")
+  const baseTitle = sanitizeSessionTitle(title.replace(AIDEVOPS_TITLE_SUFFIX_RE, ""))
   if (!version) return baseTitle
   return `${baseTitle} · AIDevOps ${version}`
 }

--- a/TODO.md
+++ b/TODO.md
@@ -1121,6 +1121,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18082 Fix sandbox cleanup for descendants that create new process groups #auto-dispatch #bug #framework #safety tier:standard ref:GH#26951 logged:2026-07-10 -> [todo/tasks/t18082-brief.md] pr:#27000 completed:2026-07-10
 
+- [ ] t18086 Strip image placeholders from OpenCode session titles #bug ref:GH#27036
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
Resolves #27036

## Summary

- Strip OpenCode image attachment placeholders such as `[Image 1]` from generated session titles.
- Apply the same sanitization to direct tool renames and plugin-driven title updates.
- Add regression coverage for multiple placeholders, casing, whitespace normalization, and suffix composition.

## Runtime Testing

- `bun run .agents/scripts/tests/test-session-rename-ts.mjs` (39 passed)
- `node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs` (13 passed)
- `bunx tsc --noEmit`
- `bunx biome check` on all four changed implementation/test files
- `.agents/scripts/linters-local.sh` completed changed-file checks; aggregate remained non-zero on pre-existing repository-wide shell complexity/nesting debt and an infrastructure timeout.

## Key decisions

- Match numbered image placeholders case-insensitively and collapse resulting whitespace.
- Sanitize in the shared suffix path so native, fallback, and explicit rename flows remain consistent.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.12 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 8m and 76,941 tokens on this with the user in an interactive session.
