### PR TITLE
GH#27039: reap dead interactive pulse claims

### DIFF
--- a/.agents/scripts/interactive-session-helper-scan.sh
+++ b/.agents/scripts/interactive-session-helper-scan.sh
@@ -262,6 +262,45 @@ _isc_release_claim_by_stamp_path() {
 	return 0
 }
 
+# Release one stamped claim only when its original same-host owner process is
+# no longer alive. This narrow command is safe for scheduled pulse use: unlike
+# scan-stale it does not enumerate unrelated repositories or PR orphans.
+# Explicit no-auto-dispatch lockdowns and unverifiable metadata fail closed.
+_isc_cmd_release_if_dead() {
+	local issue="${1:-}"
+	local slug="${2:-}"
+	if [[ -z "$issue" || -z "$slug" ]]; then
+		_isc_err "usage: interactive-session-helper.sh release-if-dead <issue> <slug>"
+		return 2
+	fi
+
+	local stamp_path
+	stamp_path=$(_isc_stamp_path "$issue" "$slug")
+	[[ -f "$stamp_path" ]] || return 1
+
+	local stamp_hostname local_hostname pid stored_hash
+	stamp_hostname=$(jq -r '.hostname // empty' "$stamp_path" 2>/dev/null || echo "")
+	local_hostname=$(_isc_hostname_or_fallback)
+	[[ -n "$stamp_hostname" && "$stamp_hostname" == "$local_hostname" ]] || return 1
+
+	local label_rc=0
+	_isc_has_label "$issue" "$slug" "no-auto-dispatch" || label_rc=$?
+	case "$label_rc" in
+	0) return 1 ;;
+	2) return 1 ;;
+	esac
+
+	pid=$(jq -r '.pid // empty' "$stamp_path" 2>/dev/null || echo "")
+	stored_hash=$(jq -r '.owner_argv_hash // empty' "$stamp_path" 2>/dev/null || echo "")
+	if [[ -n "$pid" ]] && _is_process_alive_and_matches "$pid" "${WORKER_PROCESS_PATTERN:-}" "$stored_hash"; then
+		return 1
+	fi
+
+	_isc_info "release-if-dead: releasing #${issue} in ${slug} after same-host owner exit"
+	_isc_release_claim_by_stamp_path "$stamp_path"
+	return 0
+}
+
 # scan-stale Phase 1a helper (t2148) — stampless interactive claims.
 # -----------------------------------------------------------------------------
 # Iterates pulse-enabled repos from repos.json, calls

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -349,10 +349,8 @@ USAGE:
                  these as recovery candidates. Does NOT auto-reopen.
 
   interactive-session-helper.sh release-if-dead <issue> <slug>
-      Bounded pulse-safe recovery for one stamped claim. Releases only when
-      the stamp belongs to this host, its PID/argv identity is dead, and the
-      issue is not protected by no-auto-dispatch. Metadata lookup failures,
-      live owners, and cross-host stamps fail closed.
+      Pulse-safe single-claim recovery; releases a dead same-host owner unless
+      no-auto-dispatch applies. Live, cross-host, and unknown states fail closed.
 
   interactive-session-helper.sh post-merge <pr_number> [<slug>]
       Auto-heal two known drift patterns after a planning PR merges (t2225).

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -348,6 +348,12 @@ USAGE:
                  (last 14 days) whose linked issue is still OPEN. Surfaces
                  these as recovery candidates. Does NOT auto-reopen.
 
+  interactive-session-helper.sh release-if-dead <issue> <slug>
+      Bounded pulse-safe recovery for one stamped claim. Releases only when
+      the stamp belongs to this host, its PID/argv identity is dead, and the
+      issue is not protected by no-auto-dispatch. Metadata lookup failures,
+      live owners, and cross-host stamps fail closed.
+
   interactive-session-helper.sh post-merge <pr_number> [<slug>]
       Auto-heal two known drift patterns after a planning PR merges (t2225).
       Call after `gh pr merge` succeeds, alongside `release <N>`.
@@ -426,6 +432,9 @@ main() {
 		;;
 	scan-stale)
 		_isc_cmd_scan_stale "$@" || rc=$?
+		;;
+	release-if-dead)
+		_isc_cmd_release_if_dead "$@" || rc=$?
 		;;
 	post-merge)
 		_isc_cmd_post_merge "$@" || rc=$?

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -762,13 +762,24 @@ _normalize_unassign_stampless_interactive() {
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 			stamp="${stamp_dir}/${slug_flat}-${issue_num}.json"
 
-			# Skip if a stamp exists — a genuine interactive session
-			# is still responsible. scan-stale Phase 1 handles those
-			# via dead-PID + missing-worktree detection.
-			[[ -f "$stamp" ]] && continue
-
 			local labels_csv=""
 			labels_csv=$(printf '%s' "$json" | jq -r --argjson n "$issue_num" '[.[] | select(.number == $n) | .labels[].name] | join(",")' 2>/dev/null) || labels_csv=""
+			if [[ -f "$stamp" ]]; then
+				# A stamp is only durable liveness evidence while its same-host
+				# PID/argv identity remains alive. Scheduled pulse previously
+				# skipped these forever and relied on a future interactive
+				# session to run scan-stale, leaving footprint reservations and
+				# overlapping auto-dispatch work globally blocked. Reap one
+				# already-aged candidate through the bounded helper command.
+				[[ ",${labels_csv}," == *",no-auto-dispatch,"* ]] && continue
+				local claim_helper="${AIDEVOPS_INTERACTIVE_SESSION_HELPER:-${SCRIPT_DIR}/interactive-session-helper.sh}"
+				if [[ -x "$claim_helper" ]] && "$claim_helper" release-if-dead "$issue_num" "$slug" >>"$LOGFILE" 2>&1; then
+					total_released=$((total_released + 1))
+					echo "[pulse-wrapper] Stamped interactive auto-release: released dead same-host claim #${issue_num} in ${slug}" >>"$LOGFILE"
+				fi
+				continue
+			fi
+
 			if [[ ",${labels_csv}," == *",status:in-review,"* ]]; then
 				local open_pr_count=0 open_pr_rc=0
 				open_pr_count=$(gh_pr_list --repo "$slug" --state open --search "$issue_num" --json number --jq 'length' 2>/dev/null) || open_pr_rc=$?
@@ -847,7 +858,7 @@ normalize_active_issue_assignments() {
 	# Pass 2: reset stale assignments (active label, assignee present, no running worker)
 	_normalize_unassign_stale "$runner_user" "$repos_json" "$now_epoch" "$cross_runner_max_runtime"
 
-	# Pass 2b (t2148): auto-recover stampless origin:interactive claims.
+	# Pass 2b (t2148/GH#27039): recover aged origin:interactive claims.
 	# Closes the leak where `claim-task-id.sh` auto-assigns on creation
 	# (per t1970) but the interactive session never runs the formal
 	# claim flow, leaving an `origin:interactive + assignee` pair that
@@ -856,7 +867,9 @@ normalize_active_issue_assignments() {
 	# of a stamp file is itself the liveness signal: a real interactive
 	# session creates a stamp via `interactive-session-helper.sh claim`,
 	# while ad-hoc self-assigns from `claim-task-id.sh` (per t1970)
-	# never produce one. Override via STAMPLESS_INTERACTIVE_AGE_THRESHOLD
+	# never produce one. Stamped claims are also checked through the bounded
+	# release-if-dead command, which preserves live and cross-host owners.
+	# Override via STAMPLESS_INTERACTIVE_AGE_THRESHOLD
 	# (set to 86400 to restore the original 24h behaviour from t2148).
 	local stampless_age_threshold="${STAMPLESS_INTERACTIVE_AGE_THRESHOLD:-3600}"
 	_normalize_unassign_stampless_interactive "$runner_user" "$repos_json" "$now_epoch" "$stampless_age_threshold"

--- a/.agents/scripts/tests/test-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-issue-reconcile.sh
@@ -67,6 +67,12 @@ EOF
 # Stub directory — prepended to PATH
 STUB_DIR="${TEST_ROOT}/bin"
 mkdir -p "$STUB_DIR"
+export PATH="${STUB_DIR}:${PATH}"
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "${STUB_DIR}/gh"
 
 # =============================================================================
 # Source the module under test
@@ -82,6 +88,25 @@ unset _PULSE_ISSUE_RECONCILE_LOADED
 # shellcheck source=/dev/null
 source "${TEST_SCRIPTS_DIR}/pulse-issue-reconcile.sh" >/dev/null 2>&1
 set +e
+
+# Keep this unit test independent of shared cooldown/rate-limit state. The
+# production wrapper is covered separately; here each rewritten gh stub must
+# receive the command directly.
+_gh_with_timeout() {
+	local op_class="$1"
+	shift
+	[[ -n "$op_class" ]] || return 1
+	"$@"
+	return $?
+}
+gh() {
+	command "${STUB_DIR}/gh" "$@"
+	return $?
+}
+gh_issue_list() {
+	gh issue list "$@"
+	return $?
+}
 
 # =============================================================================
 # Part 1 — _normalize_reassign_self: self-assigns orphaned active issues
@@ -266,6 +291,43 @@ else
 	print_result "t2148: stampless auto-recovery skips issues with a stamp file" 1 \
 		"(should not have unassigned — stamp exists but gh edit was called)"
 fi
+
+# =============================================================================
+# Part 6b (GH#27039) — an aged stamped claim is routed through the bounded
+# release-if-dead command instead of being skipped forever.
+# =============================================================================
+DEAD_STAMP_HELPER_LOG="${TEST_ROOT}/dead-stamp-helper.log"
+DEAD_STAMP_HELPER="${STUB_DIR}/interactive-session-helper.sh"
+cat >"$DEAD_STAMP_HELPER" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"${DEAD_STAMP_HELPER_LOG}"
+exit 0
+STUB
+chmod +x "$DEAD_STAMP_HELPER"
+export AIDEVOPS_INTERACTIVE_SESSION_HELPER="$DEAD_STAMP_HELPER"
+
+cat >"${STUB_DIR}/gh" <<STUB
+#!/usr/bin/env bash
+if [[ "\$1" == "issue" && "\$2" == "list" ]]; then
+    echo '[{"number":557,"updatedAt":"2020-01-01T00:00:00Z","labels":[{"name":"origin:interactive"},{"name":"status:in-review"}]}]'
+    exit 0
+fi
+exit 1
+STUB
+chmod +x "${STUB_DIR}/gh"
+jq -n --arg host "$(hostname 2>/dev/null || echo unknown)" '{
+	issue: 557, slug: "owner/testrepo", pid: 99999, hostname: $host
+}' >"${STAMP_DIR}/owner-testrepo-557.json"
+
+_normalize_unassign_stampless_interactive "testrunner" "$REPOS_JSON" "$NOW_EPOCH_P5" "86400"
+if [[ -f "$DEAD_STAMP_HELPER_LOG" ]] && grep -q -- "release-if-dead 557 owner/testrepo" "$DEAD_STAMP_HELPER_LOG"; then
+	print_result "GH#27039: stamped stale claim uses bounded release-if-dead command" 0
+else
+	print_result "GH#27039: stamped stale claim uses bounded release-if-dead command" 1 \
+		"(helper log: $(cat "$DEAD_STAMP_HELPER_LOG" 2>/dev/null || echo 'file missing'))"
+fi
+unset AIDEVOPS_INTERACTIVE_SESSION_HELPER
+rm -f "${STAMP_DIR}/owner-testrepo-557.json"
 
 # Clean up
 rm -f "${STAMP_DIR}/owner-testrepo-555.json"

--- a/.agents/scripts/tests/test-scan-stale-auto-release.sh
+++ b/.agents/scripts/tests/test-scan-stale-auto-release.sh
@@ -38,6 +38,8 @@
 #   9. OPENCODE_SESSION_ID set, no TTY, no headless → dead+missing released (t3205)
 #   10. AIDEVOPS_HEADLESS + OPENCODE_SESSION_ID → stamp preserved (headless wins, t3205)
 #   11. report-only stale output includes worktree path (GH#22210)
+#   12. release-if-dead releases one same-host dead claim.
+#   13. release-if-dead preserves live, cross-host, and lockdown claims.
 #
 # Stub strategy: override `_isc_release_claim_by_stamp_path` as a shell function
 # after sourcing the helper to capture auto-release calls without real gh ops.
@@ -363,6 +365,44 @@ else
 	fail "AIDEVOPS_HEADLESS=1 + OPENCODE_SESSION_ID → stamp preserved (headless wins)" \
 		"stamp deleted — headless marker must take precedence over AI-agent marker"
 fi
+
+# =============================================================================
+# Tests 12-13 — bounded pulse command releases only a safe dead claim
+# =============================================================================
+_isc_has_label() { return 1; }
+write_stamp "owner-repo-112.json" "99999" "$EXISTING_WORKTREE" "112" "owner/repo"
+if _isc_cmd_release_if_dead "112" "owner/repo" >/dev/null 2>&1 && [[ ! -f "${STAMP_DIR}/owner-repo-112.json" ]]; then
+	pass "release-if-dead releases a same-host dead claim"
+else
+	fail "release-if-dead releases a same-host dead claim"
+fi
+
+write_stamp "owner-repo-113.json" "$LIVE_PID" "$EXISTING_WORKTREE" "113" "owner/repo"
+if ! _isc_cmd_release_if_dead "113" "owner/repo" >/dev/null 2>&1 && [[ -f "${STAMP_DIR}/owner-repo-113.json" ]]; then
+	pass "release-if-dead preserves a live claim"
+else
+	fail "release-if-dead preserves a live claim"
+fi
+rm -f "${STAMP_DIR}/owner-repo-113.json"
+
+write_stamp "owner-repo-114.json" "99999" "$EXISTING_WORKTREE" "114" "owner/repo"
+jq '.hostname = "another-host"' "${STAMP_DIR}/owner-repo-114.json" >"${STAMP_DIR}/owner-repo-114.tmp"
+mv "${STAMP_DIR}/owner-repo-114.tmp" "${STAMP_DIR}/owner-repo-114.json"
+if ! _isc_cmd_release_if_dead "114" "owner/repo" >/dev/null 2>&1 && [[ -f "${STAMP_DIR}/owner-repo-114.json" ]]; then
+	pass "release-if-dead preserves a cross-host claim"
+else
+	fail "release-if-dead preserves a cross-host claim"
+fi
+rm -f "${STAMP_DIR}/owner-repo-114.json"
+
+_isc_has_label() { return 0; }
+write_stamp "owner-repo-115.json" "99999" "$EXISTING_WORKTREE" "115" "owner/repo"
+if ! _isc_cmd_release_if_dead "115" "owner/repo" >/dev/null 2>&1 && [[ -f "${STAMP_DIR}/owner-repo-115.json" ]]; then
+	pass "release-if-dead preserves a no-auto-dispatch lockdown"
+else
+	fail "release-if-dead preserves a no-auto-dispatch lockdown"
+fi
+rm -f "${STAMP_DIR}/owner-repo-115.json"
 # Cleanup
 rm -f "${STAMP_DIR}/owner-repo-110.json"
 

--- a/.agents/scripts/tests/test-stamp-release-github-gap.sh
+++ b/.agents/scripts/tests/test-stamp-release-github-gap.sh
@@ -18,7 +18,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-ISH="${REPO_ROOT}/.agents/scripts/interactive-session-helper.sh"
+ISH_COMMANDS="${REPO_ROOT}/.agents/scripts/interactive-session-helper-commands.sh"
+ISH_SCAN="${REPO_ROOT}/.agents/scripts/interactive-session-helper-scan.sh"
 
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -109,6 +110,8 @@ test_auto_release_passes_unassign() {
 		# Minimal stubs required to prevent actual network calls
 		_isc_gh_reachable() { return 0; }
 		_isc_current_user() { printf 'testuser'; return 0; }
+		_isc_can_manage_issue_state() { return 0; }
+		_isc_issue_is_closed() { return 1; }
 		set_issue_status() {
 			# Record what we were called with
 			printf 'set_issue_status %s\n' "$*" >>"$captured_args_file"
@@ -122,15 +125,17 @@ test_auto_release_passes_unassign() {
 		_isc_info() { printf 'INFO: %s\n' "$*"; return 0; }
 		_isc_warn() { printf 'WARN: %s\n' "$*"; return 0; }
 		_isc_err() { printf 'ERR: %s\n' "$*"; return 0; }
-		export -f _isc_gh_reachable _isc_current_user set_issue_status
+		export -f _isc_gh_reachable _isc_current_user _isc_can_manage_issue_state _isc_issue_is_closed set_issue_status
 		export -f _isc_has_in_review _isc_delete_stamp _isc_info _isc_warn _isc_err
 		CLAIM_STAMP_DIR="$stamp_dir"
 		export CLAIM_STAMP_DIR
 
-		# Source only the functions we need (avoid full init)
-		# We extract and eval the two target functions from the helper.
-		eval "$(sed -n '/^_isc_cmd_release()/,/^}/p' "$ISH")"
-		eval "$(sed -n '/^_isc_release_claim_by_stamp_path()/,/^}/p' "$ISH")"
+		# Source the split libraries that own the target functions. This keeps
+		# the regression aligned with the production module graph.
+		# shellcheck disable=SC1090
+		source "$ISH_COMMANDS"
+		# shellcheck disable=SC1090
+		source "$ISH_SCAN"
 
 		_isc_release_claim_by_stamp_path "$stamp_path"
 		printf 'EXIT:%d\n' $?
@@ -164,6 +169,8 @@ test_release_surfaces_failure_message() {
 	result=$(
 		_isc_gh_reachable() { return 0; }
 		_isc_current_user() { printf 'testuser'; return 0; }
+		_isc_can_manage_issue_state() { return 0; }
+		_isc_issue_is_closed() { return 1; }
 		set_issue_status() {
 			# Simulate a gh failure with an error message on stderr
 			printf 'gh: HTTP 422: bad credentials\n' >&2
@@ -178,10 +185,11 @@ test_release_surfaces_failure_message() {
 			return 0
 		}
 		_isc_err() { printf 'ERR: %s\n' "$*"; return 0; }
-		export -f _isc_gh_reachable _isc_current_user set_issue_status
+		export -f _isc_gh_reachable _isc_current_user _isc_can_manage_issue_state _isc_issue_is_closed set_issue_status
 		export -f _isc_has_in_review _isc_delete_stamp _isc_info _isc_warn _isc_err
 
-		eval "$(sed -n '/^_isc_cmd_release()/,/^}/p' "$ISH")"
+		# shellcheck disable=SC1090
+		source "$ISH_COMMANDS"
 
 		_isc_cmd_release "99999" "owner/repo"
 		printf 'EXIT:%d\n' $?
@@ -218,16 +226,19 @@ test_missing_stamp_is_noop() {
 	result=$(
 		_isc_gh_reachable() { return 0; }
 		_isc_current_user() { printf 'testuser'; return 0; }
+		_isc_can_manage_issue_state() { return 0; }
+		_isc_issue_is_closed() { return 1; }
 		set_issue_status() { printf 'SHOULD_NOT_BE_CALLED\n'; return 0; }
 		_isc_has_in_review() { return 0; }
 		_isc_delete_stamp() { return 0; }
 		_isc_info() { printf 'INFO: %s\n' "$*"; return 0; }
 		_isc_warn() { printf 'WARN: %s\n' "$*"; return 0; }
 		_isc_err() { printf 'ERR: %s\n' "$*"; return 0; }
-		export -f _isc_gh_reachable _isc_current_user set_issue_status
+		export -f _isc_gh_reachable _isc_current_user _isc_can_manage_issue_state _isc_issue_is_closed set_issue_status
 		export -f _isc_has_in_review _isc_delete_stamp _isc_info _isc_warn _isc_err
 
-		eval "$(sed -n '/^_isc_release_claim_by_stamp_path()/,/^}/p' "$ISH")"
+		# shellcheck disable=SC1090
+		source "$ISH_SCAN"
 
 		_isc_release_claim_by_stamp_path "/nonexistent/stamp.json"
 		printf 'EXIT:%d\n' $?
@@ -247,6 +258,7 @@ test_missing_stamp_is_noop() {
 # ---------------------------------------------------------------------------
 test_offline_gh_is_fail_open() {
 	local stamp_dir="${TEST_DIR}/stamps_offline"
+	local offline_warn_file="${TEST_DIR}/offline_warn"
 	local stamp_path
 	stamp_path=$(write_stamp "$stamp_dir" "11111" "owner/repo2")
 
@@ -259,18 +271,21 @@ test_offline_gh_is_fail_open() {
 			return 0
 		}
 		_isc_info() { printf 'INFO: %s\n' "$*"; return 0; }
-		_isc_warn() { printf 'WARN: %s\n' "$*"; return 0; }
+		_isc_warn() { printf 'WARN: %s\n' "$*" >>"$offline_warn_file"; return 0; }
 		_isc_err() { printf 'ERR: %s\n' "$*"; return 0; }
 		export -f _isc_gh_reachable _isc_delete_stamp _isc_info _isc_warn _isc_err
 
-		eval "$(sed -n '/^_isc_cmd_release()/,/^}/p' "$ISH")"
+		# shellcheck disable=SC1090
+		source "$ISH_COMMANDS"
 
 		_isc_cmd_release "11111" "owner/repo2"
 		printf 'EXIT:%d\n' $?
 	) 2>&1 || true
 
 	assert_contains "offline gh exits 0 (fail-open)" "EXIT:0" "$result"
-	assert_contains "offline gh prints warning" "offline" "$result"
+	local offline_warn=""
+	[[ -f "$offline_warn_file" ]] && offline_warn=$(cat "$offline_warn_file")
+	assert_contains "offline gh prints warning" "offline" "$offline_warn"
 
 	return 0
 }

--- a/TODO.md
+++ b/TODO.md
@@ -1123,8 +1123,6 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18086 Strip image placeholders from OpenCode session titles #bug ref:GH#27036
 
-- [ ] t18087 Reap dead interactive claims during pulse dispatch #bug ref:GH#27039
-
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/TODO.md
+++ b/TODO.md
@@ -1123,6 +1123,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18086 Strip image placeholders from OpenCode session titles #bug ref:GH#27036
 
+- [ ] t18087 Reap dead interactive claims during pulse dispatch #bug ref:GH#27039
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Recover aged same-host interactive claim stamps with dead PID/argv owners during scheduled pulse reconciliation, preserving live, cross-host, lockdown, and unknown states; repair the split-module regression harness.

## Files Changed

.agents/scripts/interactive-session-helper-scan.sh, .agents/scripts/interactive-session-helper.sh, .agents/scripts/pulse-issue-reconcile.sh, .agents/scripts/tests/test-issue-reconcile.sh, .agents/scripts/tests/test-scan-stale-auto-release.sh, .agents/scripts/tests/test-stamp-release-github-gap.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused stale-claim suites pass (39 assertions); ShellCheck and scoped portability clean; full local gate has no changed-file complexity/Bash regressions (global portability scan timed out).

Resolves #27039


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.12 with gpt-5.6-sol spent 33m and 893,898 tokens on this with the user in an interactive session.