### PR TITLE
t18089: Align background model tiers and reasoning effort

### DIFF
--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -2,19 +2,19 @@
   "_comment": "Model routing table — SINGLE SOURCE OF TRUTH for tier-to-model mappings. All scripts, docs, and configs should reference this file rather than hardcoding model IDs. When a new model generation releases (e.g., gpt-5.6), update this file and its documented static fallbacks.",
   "_docs": "See .agents/tools/context/model-routing.md for routing rules, .agents/tools/ai-assistants/fallback-chains.md for integration.",
   "_agentic_note": "codex/code-completion models (gpt-5.3-codex, gpt-5.4-codex) are NOT agentic — zero tool calls observed (GH#17669). Never use them for headless worker dispatch. Only general-purpose models support agentic workflows.",
-  "_defaults": "OpenAI models are the headless-worker default and fallback chain. The first model in each tier's array is the primary; subsequent entries are tried in order when the primary is unavailable. Use custom/configs/model-routing-table.json or AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST for local overrides.",
+  "_defaults": "The first model in each tier's array is primary; subsequent entries are availability-checked fallbacks. GLM-5.2 is offered only through the Z.AI coding-plan provider. Use custom/configs/model-routing-table.json or AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST for local overrides.",
   "_model_overrides": "Model-override labels (model:*) express model intent but must still pass through provider allowlist and availability/fallback checks before dispatch. `model:opus-4-7` is treated as an opus-tier escalation intent, not an Anthropic provider pin. Resolution lives in pulse-model-routing.sh::resolve_dispatch_model_for_labels. Cascade rule: tier:thinking → tier:thinking + model:opus-4-7 intent → NMR (t2239).",
 
   "tiers": {
-    "local":  { "models": ["openai/gpt-5.4-mini"], "cost": 0 },
-    "haiku":  { "models": ["openai/gpt-5.6-terra"] },
-    "flash":  { "models": ["openai/gpt-5.6-terra"] },
-    "sonnet": { "models": ["openai/gpt-5.6-sol"] },
-    "pro":    { "models": ["openai/gpt-5.6-sol"] },
-    "opus":   { "models": ["openai/gpt-5.6-sol"] },
-    "coding": { "models": ["openai/gpt-5.6-sol"] },
-    "eval":   { "models": ["openai/gpt-5.6-sol"] },
-    "health": { "models": ["openai/gpt-5.6-terra"] }
+    "local":  { "models": [], "cost": 0, "_comment": "Resolved only from an installed llama.cpp or Ollama model; never falls back to cloud." },
+    "haiku":  { "models": ["openai/gpt-5.6-terra", "anthropic/claude-haiku-4-5"] },
+    "flash":  { "models": ["openai/gpt-5.6-terra", "anthropic/claude-haiku-4-5"] },
+    "sonnet": { "models": ["openai/gpt-5.6-sol", "zai-coding-plan/glm-5.2", "anthropic/claude-sonnet-4-6"] },
+    "pro":    { "models": ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-4-6"] },
+    "opus":   { "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"] },
+    "coding": { "models": ["openai/gpt-5.6-sol", "zai-coding-plan/glm-5.2", "anthropic/claude-sonnet-4-6"] },
+    "eval":   { "models": ["openai/gpt-5.6-sol", "zai-coding-plan/glm-5.2", "anthropic/claude-sonnet-4-6"] },
+    "health": { "models": ["openai/gpt-5.6-terra", "anthropic/claude-haiku-4-5"] }
   },
 
   "providers": {

--- a/.agents/scripts/fallback-chain-helper.sh
+++ b/.agents/scripts/fallback-chain-helper.sh
@@ -47,6 +47,7 @@ load_routing_table() {
 get_tier_models_from_table() {
 	local tier="$1"
 	local table_path="$2"
+	local sol_model="openai/gpt-5.6-sol"
 
 	local models
 	models=$(jq -r --arg t "$tier" '.tiers[$t].models // empty' "$table_path" 2>/dev/null) || true
@@ -59,9 +60,9 @@ get_tier_models_from_table() {
 			return 1
 			;;
 		haiku | flash | health) echo '["openai/gpt-5.6-terra","anthropic/claude-haiku-4-5"]' ;;
-		sonnet | coding | eval) echo '["openai/gpt-5.6-sol","zai-coding-plan/glm-5.2","anthropic/claude-sonnet-4-6"]' ;;
-		pro) echo '["openai/gpt-5.6-sol","anthropic/claude-sonnet-4-6"]' ;;
-		opus) echo '["openai/gpt-5.6-sol","anthropic/claude-opus-4-6"]' ;;
+		sonnet | coding | eval) printf '["%s","zai-coding-plan/glm-5.2","anthropic/claude-sonnet-4-6"]\n' "$sol_model" ;;
+		pro) printf '["%s","anthropic/claude-sonnet-4-6"]\n' "$sol_model" ;;
+		opus) printf '["%s","anthropic/claude-opus-4-6"]\n' "$sol_model" ;;
 		*)
 			print_error "Unknown tier: $tier"
 			return 1

--- a/.agents/scripts/fallback-chain-helper.sh
+++ b/.agents/scripts/fallback-chain-helper.sh
@@ -52,10 +52,16 @@ get_tier_models_from_table() {
 	models=$(jq -r --arg t "$tier" '.tiers[$t].models // empty' "$table_path" 2>/dev/null) || true
 
 	if [[ -z "$models" || "$models" == "null" ]]; then
-		# Hardcoded minimal fallback for unknown tiers
+		# Hardcoded minimal fallback for missing tier definitions.
 		case "$tier" in
-		haiku | flash | health) echo '["openai/gpt-5.6-terra"]' ;;
-		sonnet | pro | opus | eval | coding) echo '["openai/gpt-5.6-sol"]' ;;
+		local)
+			print_error "No local model is configured"
+			return 1
+			;;
+		haiku | flash | health) echo '["openai/gpt-5.6-terra","anthropic/claude-haiku-4-5"]' ;;
+		sonnet | coding | eval) echo '["openai/gpt-5.6-sol","zai-coding-plan/glm-5.2","anthropic/claude-sonnet-4-6"]' ;;
+		pro) echo '["openai/gpt-5.6-sol","anthropic/claude-sonnet-4-6"]' ;;
+		opus) echo '["openai/gpt-5.6-sol","anthropic/claude-opus-4-6"]' ;;
 		*)
 			print_error "Unknown tier: $tier"
 			return 1

--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -104,6 +104,12 @@ get_configured_models() {
 		done < <(jq -r --arg tier "$tier_name" '.tiers[$tier].models[]? // empty' "$routing_table" 2>/dev/null)
 	fi
 
+	# Local is a privacy boundary: an empty local tier means unavailable, never
+	# permission to use the historical cloud fallback.
+	if [[ "$tier_name" == "local" ]]; then
+		return 0
+	fi
+
 	# Fallback: if routing derivation yielded nothing and no allowlist is forcing a
 	# provider subset, use the historical default when auth is available.
 	if [[ ${#models[@]} -eq 0 ]] && [[ -z "$allowlist_raw" ]]; then
@@ -417,12 +423,19 @@ resolve_headless_variant() {
 		variant=""
 	fi
 
-	# OpenAI publishes Sol xhigh coding/agent benchmarks and API pricing, but no
-	# equivalent Sol Pro API evidence. Default only thinking-tier issue workers
-	# to xhigh; explicit CLI and environment variants above continue to win.
-	if [[ -z "$variant" && "$role" == "worker" && "$tier_upper" == "OPUS" ]]; then
-		case "$selected_model" in
-		openai/gpt-5.6-sol | openai/gpt-5.6-sol-fast) variant="xhigh" ;;
+	# Background workers receive prescriptive briefs, so use bounded reasoning
+	# defaults. Explicit CLI/environment variants still win. Reserve xhigh for
+	# failure escalation, where the retry path passes --variant xhigh explicitly.
+	if [[ -z "$variant" && "$role" == "worker" ]]; then
+		case "$tier_upper:$selected_model" in
+		HAIKU:openai/gpt-5.6-terra | HAIKU:openai/gpt-5.6-terra-fast | \
+			FLASH:openai/gpt-5.6-terra | FLASH:openai/gpt-5.6-terra-fast | \
+			HEALTH:openai/gpt-5.6-terra | HEALTH:openai/gpt-5.6-terra-fast | \
+			SONNET:openai/gpt-5.6-sol | SONNET:openai/gpt-5.6-sol-fast | \
+			CODING:openai/gpt-5.6-sol | CODING:openai/gpt-5.6-sol-fast | \
+			EVAL:openai/gpt-5.6-sol | EVAL:openai/gpt-5.6-sol-fast) variant="low" ;;
+		PRO:openai/gpt-5.6-sol | PRO:openai/gpt-5.6-sol-fast | \
+			OPUS:openai/gpt-5.6-sol | OPUS:openai/gpt-5.6-sol-fast) variant="high" ;;
 		esac
 	fi
 

--- a/.agents/scripts/headless-runtime-provider.sh
+++ b/.agents/scripts/headless-runtime-provider.sh
@@ -149,6 +149,11 @@ provider_auth_available() {
 		fi
 		return 1
 		;;
+	zai-coding-plan)
+		# Z.AI Coding Plan is an OpenCode-managed subscription provider.
+		opencode_auth_has_provider "$provider"
+		return $?
+		;;
 	opencode)
 		# OpenCode gateway models use OpenCode's OAuth session
 		if [[ -f "$OPENCODE_AUTH_FILE" ]]; then

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -136,8 +136,7 @@ get_tier_models() {
 
 	# User-local override checked first — survives aidevops update.
 	# Copy configs/model-routing-table.json to custom/configs/ and edit.
-	# Framework default is Anthropic-only; users who want other providers
-	# (e.g., OpenCode free-tier models) add them to their custom copy.
+	# Framework defaults are ordered, availability-checked provider fallbacks.
 	local routing_table="${SCRIPT_DIR}/../custom/configs/model-routing-table.json"
 	if [[ ! -f "$routing_table" ]]; then
 		routing_table="${SCRIPT_DIR}/../configs/model-routing-table.json"
@@ -177,20 +176,17 @@ get_tier_models() {
 
 	# Hardcoded fallback — kept in sync with model-routing-table.json.
 	# If you're editing these, update the JSON file instead.
-	# Current smoke-tested OpenAI models are the headless defaults. Exclude Codex,
-	# unsupported *-pro IDs, and non-OpenAI fallback providers from dispatch.
+	# Current smoke-tested models are the headless defaults. An empty local value
+	# deliberately fails closed rather than sending local-only work to cloud.
 	case "$tier" in
-	local) current_model=$'openai/gpt-5.4-mini' ;;
-	haiku) current_model=$'openai/gpt-5.6-terra' ;;
-	flash) current_model=$'openai/gpt-5.6-terra' ;;
-	sonnet) current_model=$'openai/gpt-5.6-sol' ;;
-	pro) current_model=$'openai/gpt-5.6-sol' ;;
-	opus) current_model=$'openai/gpt-5.6-sol' ;;
-	health) current_model=$'openai/gpt-5.6-terra' ;;
-	eval) current_model=$'openai/gpt-5.6-sol' ;;
-	coding) current_model=$'openai/gpt-5.6-sol' ;;
+	local) current_model="" ;;
+	haiku | flash | health) current_model=$'openai/gpt-5.6-terra\nanthropic/claude-haiku-4-5' ;;
+	sonnet | coding | eval) current_model=$'openai/gpt-5.6-sol\nzai-coding-plan/glm-5.2\nanthropic/claude-sonnet-4-6' ;;
+	pro) current_model=$'openai/gpt-5.6-sol\nanthropic/claude-sonnet-4-6' ;;
+	opus) current_model=$'openai/gpt-5.6-sol\nanthropic/claude-opus-4-6' ;;
 	*) return 1 ;;
 	esac
+	[[ -n "$current_model" ]] || return 1
 
 	if [[ ${#allowlist[@]} -eq 0 ]]; then
 		printf '%s\n' "$current_model" | paste -sd'|' -

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -113,7 +113,7 @@ get_provider_key_vars() {
 is_known_provider() {
 	local provider="$1"
 	case "$provider" in
-	anthropic | openai | google | openrouter | groq | deepseek | local | ollama) return 0 ;;
+	anthropic | openai | google | openrouter | groq | deepseek | zai-coding-plan | local | ollama) return 0 ;;
 	*) return 1 ;;
 	esac
 }

--- a/.agents/scripts/model-availability-probe-lib.sh
+++ b/.agents/scripts/model-availability-probe-lib.sh
@@ -704,6 +704,23 @@ _probe_execute_http() {
 	return "$exit_code"
 }
 
+_probe_opencode_subscription_provider() {
+	local provider="$1"
+	local quiet="$2"
+	local auth_file="${OPENCODE_AUTH_FILE:-${HOME}/.local/share/opencode/auth.json}"
+
+	if [[ -f "$auth_file" ]] && command -v jq >/dev/null 2>&1 && \
+		jq -e --arg provider "$provider" '.[$provider] | type == "object" and ((.access // .refresh // .token // .apiKey // "") != "")' "$auth_file" >/dev/null 2>&1; then
+		_record_health "$provider" "healthy" 200 0 "" 0
+		[[ "$quiet" != "true" ]] && print_success "$provider: authenticated through OpenCode"
+		return 0
+	fi
+
+	_record_health "$provider" "no-key" 0 0 "OpenCode subscription auth unavailable" 0
+	[[ "$quiet" != "true" ]] && print_warning "$provider: no OpenCode subscription auth"
+	return 1
+}
+
 probe_provider() {
 	local provider="$1"
 	local force="${2:-false}"
@@ -728,6 +745,10 @@ probe_provider() {
 	# OpenCode uses its local models cache — no HTTP probe needed
 	if [[ "$provider" == "opencode" ]]; then
 		_probe_opencode "$quiet"
+		return $?
+	fi
+	if [[ "$provider" == "zai-coding-plan" ]]; then
+		_probe_opencode_subscription_provider "$provider" "$quiet"
 		return $?
 	fi
 

--- a/.agents/scripts/tests/test-headless-openai-routing.sh
+++ b/.agents/scripts/tests/test-headless-openai-routing.sh
@@ -131,6 +131,25 @@ test_sonnet_alternatives_are_scoped() {
 	return 0
 }
 
+test_coding_plan_requires_provider_auth() {
+	printf '{"openai":{"type":"oauth","access":"test-openai-access"}}\n' >"${HOME}/.local/share/opencode/auth.json"
+	local selected=""
+	selected=$(AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=zai-coding-plan bash "$HELPER_SCRIPT" select --role worker --tier sonnet 2>/dev/null || true)
+	if [[ -n "$selected" ]]; then
+		print_result "Coding-plan GLM requires provider-specific auth" 1 "Unexpected model without coding-plan auth: ${selected}"
+		return 0
+	fi
+
+	printf '{"zai-coding-plan":{"type":"oauth","access":"test-zai-access"}}\n' >"${HOME}/.local/share/opencode/auth.json"
+	selected=$(AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=zai-coding-plan bash "$HELPER_SCRIPT" select --role worker --tier sonnet 2>/dev/null || true)
+	if [[ "$selected" == "zai-coding-plan/glm-5.2" ]]; then
+		print_result "Coding-plan GLM requires provider-specific auth" 0
+		return 0
+	fi
+	print_result "Coding-plan GLM requires provider-specific auth" 1 "Expected zai-coding-plan/glm-5.2, got ${selected:-<empty>}"
+	return 0
+}
+
 main_test() {
 	setup_test_env
 	test_openai_allowlist_selects_sonnet_tier_model
@@ -139,6 +158,7 @@ main_test() {
 	test_openai_allowlist_requires_openai_auth_entry
 	test_local_tier_never_uses_cloud_fallback
 	test_sonnet_alternatives_are_scoped
+	test_coding_plan_requires_provider_auth
 	teardown_test_env
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-headless-openai-routing.sh
+++ b/.agents/scripts/tests/test-headless-openai-routing.sh
@@ -107,12 +107,38 @@ test_openai_allowlist_requires_openai_auth_entry() {
 	return 0
 }
 
+test_local_tier_never_uses_cloud_fallback() {
+	local selected=""
+	selected=$(bash "$HELPER_SCRIPT" select --role worker --tier local 2>/dev/null || true)
+	if [[ -z "$selected" ]]; then
+		print_result "Local tier fails closed without an installed local model" 0
+		return 0
+	fi
+	print_result "Local tier fails closed without an installed local model" 1 "Expected no model, got ${selected}"
+	return 0
+}
+
+test_sonnet_alternatives_are_scoped() {
+	local routing_table="${SCRIPT_DIR}/../../configs/model-routing-table.json"
+	local models=""
+	models=$(jq -r '.tiers.sonnet.models[]' "$routing_table")
+	if printf '%s\n' "$models" | grep -qx 'zai-coding-plan/glm-5.2' && \
+		! printf '%s\n' "$models" | grep -qx 'zai/glm-5.2'; then
+		print_result "Sonnet tier includes coding-plan GLM-5.2 but excludes direct Z.AI" 0
+		return 0
+	fi
+	print_result "Sonnet tier includes coding-plan GLM-5.2 but excludes direct Z.AI" 1
+	return 0
+}
+
 main_test() {
 	setup_test_env
 	test_openai_allowlist_selects_sonnet_tier_model
 	test_openai_allowlist_selects_haiku_tier_model
 	test_openai_allowlist_selects_opus_tier_model
 	test_openai_allowlist_requires_openai_auth_entry
+	test_local_tier_never_uses_cloud_fallback
+	test_sonnet_alternatives_are_scoped
 	teardown_test_env
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-headless-runtime-variant.sh
+++ b/.agents/scripts/tests/test-headless-runtime-variant.sh
@@ -28,6 +28,7 @@ assert_equals() {
 with_clean_variant_env() {
 	unset AIDEVOPS_HEADLESS_VARIANT || true
 	unset AIDEVOPS_HEADLESS_VARIANT_SONNET || true
+	unset AIDEVOPS_HEADLESS_VARIANT_HAIKU || true
 	unset AIDEVOPS_HEADLESS_VARIANT_OPUS || true
 	unset AIDEVOPS_HEADLESS_WORKER_VARIANT || true
 	unset AIDEVOPS_HEADLESS_PULSE_VARIANT || true
@@ -56,24 +57,28 @@ assert_equals "high" "$actual" "pulse sonnet routing keeps configured variant" |
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "opus" "openai/gpt-5.6-sol")
-assert_equals "xhigh" "$actual" "GPT-5.6 Sol thinking worker defaults to xhigh" || true
+assert_equals "high" "$actual" "GPT-5.6 Sol thinking worker defaults to high" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "opus" "openai/gpt-5.6-sol-fast")
-assert_equals "xhigh" "$actual" "GPT-5.6 Sol Fast thinking worker defaults to xhigh" || true
+assert_equals "high" "$actual" "GPT-5.6 Sol Fast thinking worker defaults to high" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "sonnet" "openai/gpt-5.6-sol")
-assert_equals "" "$actual" "GPT-5.6 Sol standard worker keeps provider-default effort" || true
+assert_equals "low" "$actual" "GPT-5.6 Sol standard worker defaults to low" || true
+
+with_clean_variant_env
+actual=$(resolve_headless_variant "worker" "haiku" "openai/gpt-5.6-terra")
+assert_equals "low" "$actual" "GPT-5.6 Terra simple worker defaults to low" || true
 
 with_clean_variant_env
 AIDEVOPS_HEADLESS_VARIANT_OPUS="high"
 actual=$(resolve_headless_variant "worker" "opus" "openai/gpt-5.6-sol")
-assert_equals "high" "$actual" "explicit GPT-5.6 Sol thinking-tier variant overrides xhigh default" || true
+assert_equals "high" "$actual" "explicit GPT-5.6 Sol thinking-tier variant overrides the automatic default" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "pulse" "opus" "openai/gpt-5.6-sol")
-assert_equals "" "$actual" "pulse does not inherit worker thinking-tier xhigh default" || true
+assert_equals "" "$actual" "pulse does not inherit worker thinking-tier effort defaults" || true
 
 with_clean_variant_env
 

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -24,7 +24,7 @@ model: haiku
 
 - **Default**: `sonnet`. **Rule**: smallest model that produces acceptable quality.
 - **Spectrum**: local ($0) → composer2 (0.17x) → flash (0.20x) → haiku (0.25x) → sonnet (1x) → pro (1.5x) → opus (3x)
-- **Frontmatter**: `model: haiku` in YAML. Absent → `sonnet`. `local` requires `local-model-helper.sh`; falls back to `composer2`.
+- **Frontmatter**: `model: haiku` in YAML. Absent → `sonnet`. `local` requires an installed local model and otherwise fails closed.
 - **Vault metadata**: `data_classification`, `runtime_policy`, `needs_vault`, `needs_collections`, `needs_device`, and `needs_remote_unlock` can restrict dispatch before a prompt leaves the device.
 
 ## Model Tiers
@@ -35,13 +35,13 @@ model: haiku
 | `composer2` | cursor/composer-2 | Multi-file coding, large refactors (requires Cursor OAuth pool t1549) |
 | `flash` | openai/gpt-5.6-terra → claude-haiku-4-5 | >50K context, summarization, bulk processing, research sweeps |
 | `haiku` | openai/gpt-5.6-terra → claude-haiku-4-5 | Classification, triage, simple transforms, commit messages, routing |
-| `sonnet` | openai/gpt-5.6-sol → claude-sonnet-4-6 | Code, review, debugging, docs — most dev tasks |
+| `sonnet` | openai/gpt-5.6-sol → zai-coding-plan/glm-5.2 → claude-sonnet-4-6 | Code, review, debugging, docs — most dev tasks |
 | `pro` | openai/gpt-5.6-sol → claude-sonnet-4-6 | >100K codebases + complex reasoning |
-| `opus` | openai/gpt-5.6-sol (`xhigh`) → claude-opus-4-6 | Architecture, novel problems, security audits, complex trade-offs |
+| `opus` | openai/gpt-5.6-sol (`high`) → claude-opus-4-6 | Architecture, novel problems, security audits, complex trade-offs |
 
 **Model IDs**: Always fully-qualified (`claude-sonnet-4-6`, not `claude-sonnet-4`). Short-form → `ProviderModelNotFoundError`. CLI prefix: `anthropic/`, `google/`, `openai/`.
 
-**`local` fallback**: Privacy → FAIL (require `--allow-cloud`). Cost → Ollama → `composer2`. Local is opt-in only — default dispatch uses `haiku`. Users who explicitly configure local tier: llama.cpp → Ollama → `haiku`.
+**`local` fallback**: Local is opt-in and fails closed when llama.cpp/Ollama has no configured model. Cloud fallback requires the caller to select a cloud tier explicitly; local-only work is never silently transmitted.
 
 ## Decision Flowchart
 
@@ -58,11 +58,11 @@ Privacy/on-device or Vault local-only? → YES → local running? → YES: local
 
 | Tier | Fallback | Trigger |
 |------|----------|---------|
-| `local` | Ollama → composer2 (cost) / FAIL (privacy) | llama.cpp not running |
+| `local` | FAIL | No installed local model |
 | `flash` | claude-haiku-4-5 | OpenAI unavailable or provider-disallowed |
 | `haiku` | claude-haiku-4-5 | OpenAI unavailable or provider-disallowed |
 | `composer2` | sonnet | No Cursor OAuth pool |
-| `sonnet` | claude-sonnet-4-6 | OpenAI unavailable or provider-disallowed |
+| `sonnet` | zai-coding-plan/glm-5.2 → claude-sonnet-4-6 | Earlier provider unavailable, unauthenticated, or disallowed |
 | `pro` | claude-sonnet-4-6 | OpenAI unavailable or provider-disallowed |
 | `opus` | claude-opus-4-6 | OpenAI unavailable or provider-disallowed |
 
@@ -88,12 +88,13 @@ is always denied because secrets must flow through secret tooling, not prompts.
 - **Pulse**: Resolves `sonnet` through `model-availability-helper.sh resolve sonnet`, so it follows routing-table order, health checks, local routing-table overrides, and `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`.
 - **Workers**: Round-robin across the routed `sonnet` models after allowlist filtering and auth checks. Tier escalation still uses `resolve` (`tier:simple` → `haiku`, `tier:standard` → `sonnet`, `tier:thinking` → `opus`).
 - **Local switch**: Set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto the default OpenAI fallbacks. If you want OpenAI primary but Anthropic fallback, reorder `custom/configs/model-routing-table.json` and omit the allowlist.
-- **OpenAI default mapping**: `haiku`/`flash`/`health` resolve to `openai/gpt-5.6-terra`; all implementation tiers resolve to `openai/gpt-5.6-sol`. Thinking-tier workers automatically use `xhigh`; standard workers keep the provider-default effort.
+- **OpenAI default mapping**: `haiku`/`flash` resolve to `openai/gpt-5.6-terra` at `low`; standard `sonnet`/`coding` workers use `openai/gpt-5.6-sol` at `low`; `pro`/`opus` workers use Sol at `high`.
 - **OpenAI tier rationale**: Terra costs $2.50/M input and $15/M output and is competitive with GPT-5.5, making it the conservative choice for prescriptive/simple work. Sol costs $5/M input and $30/M output and is OpenAI's recommended flagship coding model. Its published `xhigh` agent benchmarks make it the evidence-backed thinking tier.
 - **OpenAI pro caveat**: `openai/gpt-5.6-sol-pro` passed a live OpenCode ChatGPT OAuth smoke test on 2026-07-10, but OpenAI publishes neither an API price nor comparative Sol Pro benchmarks. It remains excluded from automatic workers pending repository-specific completion-rate evidence. Historical `gpt-5.5-pro` and older `*-pro`/`o3-pro` IDs remain excluded.
-- **Reasoning effort**: OpenCode exposes GPT reasoning variants separately (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`). OpenAI also documents `max`, but OpenCode v1.17.18 does not expose it. Headless thinking-tier Sol workers default to `xhigh`; explicit CLI or environment variants still win.
+- **Reasoning effort**: OpenCode exposes GPT reasoning variants separately (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`). Briefed background work defaults to Terra/Sol `low` for simple/standard tiers and Sol `high` for thinking tiers. `xhigh` is reserved for an explicit failure-escalation retry. Explicit CLI or environment variants always win.
 - **GPT-5.5 standard workers**: For `openai/gpt-5.5` on worker `sonnet`/`pro` tiers, aidevops omits env-derived variants such as `AIDEVOPS_HEADLESS_VARIANT_SONNET=high` so OpenCode sends no explicit thinking override. Explicit CLI `--variant` still wins because it bypasses automatic variant resolution.
-- **Tier-aware effort**: Headless dispatch applies `xhigh` automatically to worker `opus` tiers on GPT-5.6 Sol. `AIDEVOPS_HEADLESS_VARIANT_OPUS` can override it; `AIDEVOPS_HEADLESS_VARIANT_SONNET` tunes standard Sol work. The GPT-5.5 exception above applies only to legacy GPT-5.5 env-derived sonnet/pro variants.
+- **GLM-5.2 option**: Standard/coding/eval routing may use `zai-coding-plan/glm-5.2` when that OpenCode provider is authenticated. Direct `zai/glm-5.2` is intentionally excluded. OpenCode Go can be added once its provider-qualified model ID is observable and smoke-tested.
+- **Tier-aware effort**: `AIDEVOPS_HEADLESS_VARIANT_OPUS` and `AIDEVOPS_HEADLESS_VARIANT_SONNET` override automatic defaults. The GPT-5.5 exception above applies only to legacy GPT-5.5 env-derived sonnet/pro variants.
 - **Fallback**: If routed resolution fails entirely, pulse falls back to `anthropic/claude-sonnet-4-6`; workers fall back to `DEFAULT_HEADLESS_MODELS` when no allowlist is forcing a subset.
 - **Deprecated**: `PULSE_MODEL` and `AIDEVOPS_HEADLESS_MODELS` env vars are respected as overrides for one release cycle with deprecation warnings. Remove from `credentials.sh`.
 

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -528,17 +528,18 @@ else
 	fail "local tier missing from get_tier_models case statement"
 fi
 
-# Verify local tier has a concrete configured or hardcoded fallback model.
+# Verify the shared local tier has no cloud fallback. Users add an installed
+# llama.cpp/Ollama model through their custom routing table.
 local_tier_model=""
 local_tier_model=$(grep "^[[:space:]]*local).*current_model" "$HELPER" | grep -oE "[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+" | head -1 || true)
 if [[ -z "$local_tier_model" && -f "$REPO_DIR/.agents/configs/model-routing-table.json" ]]; then
 	local_tier_model=$(jq -r '.tiers.local.models[0] // empty' "$REPO_DIR/.agents/configs/model-routing-table.json" 2>/dev/null || true)
 fi
-if [[ "$local_tier_model" == *"/"* ]]; then
-	pass "local tier has configured model: $local_tier_model"
+if [[ -z "$local_tier_model" ]]; then
+	pass "local tier fails closed without a user-configured local model"
 else
-	fail "local tier should have a configured model" \
-		"No provider/model found in local tier configuration or fallback"
+	fail "local tier should not have a shared fallback model" \
+		"Unexpected provider/model found: $local_tier_model"
 fi
 
 # Verify ollama is a known provider in the helper (check help output or source)


### PR DESCRIPTION
## Summary

Use bounded GPT-5.6 effort defaults for briefed workers, restore executable provider fallbacks, add auth-gated GLM-5.2 coding-plan routing, and make local routing fail closed.

## Files Changed

.agents/configs/model-routing-table.json, .agents/scripts/fallback-chain-helper.sh, .agents/scripts/headless-runtime-model.sh, .agents/scripts/headless-runtime-provider.sh, .agents/scripts/model-availability-helper.sh, .agents/scripts/model-availability-probe-lib.sh, .agents/scripts/tests/test-headless-openai-routing.sh, .agents/scripts/tests/test-headless-runtime-variant.sh, .agents/tools/context/model-routing.md, tests/test-model-availability.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Variant and routing regressions pass; model availability suite passes 59 tests with 18 environment skips; pulse canary passes; ShellCheck and JSON validation pass. Full local lint found no changed-file regression but remains non-zero on repository-wide pre-existing complexity/nesting debt.

Resolves #27045


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.15 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 51m and 399,078 tokens on this with the user in an interactive session.