### PR TITLE
GH#27025: docs: deduplicate slash command guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -180,7 +180,6 @@ Run `aidevops security` for posture/scan/check/dismiss. Advisories arrive via `a
 - Self-improvement guidance: `reference/self-improvement.md`.
 - Token-optimized CLI: for interactive discovery, use `rtk-helper.sh gh issue/pr list` before raw list commands; rerun raw/direct when filtered output is insufficient; bypass exact evidence. Full rules: `reference/context-efficient-output.md`.
 - Agent lifecycle: `tools/build-agent/build-agent.md`; OpenCode glob allowlists require `subagent_validation.py` verification.
-- Slash commands resolve through `scripts/commands/<command>.md`, then `workflows/<command>.md`.
 - macOS bash upgrade, platform support, customization, and hot deploys: `reference/bash-compat.md`, `reference/platform-support.md`, `reference/customization.md`, `reference/hot-deploy.md`.
 - Scheduled jobs use `aidevops` labels: launchd `sh.aidevops.<name>`, plist `sh.aidevops.<name>.plist`, cron comment `# aidevops: <description>`.
 


### PR DESCRIPTION
## Summary

Removed the duplicate Maintenance-section slash-command resolution bullet while preserving the authoritative Tool and file discipline rule and its command-first, workflow-fallback behavior.

## Files Changed

.agents/AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Markdown lint passed; changed-file linters passed; whitespace validation passed; verified exactly one matching slash-command resolution instruction remains

Resolves #27025


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.15 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 11m and 49,802 tokens on this as a headless worker.