### PR TITLE
GH#27032: Clarify authoritative OpenCode greeting precedence

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -58,8 +58,11 @@ describe("token cost advisory threshold", () => {
     await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
 
     assert.match(output.system[0], /Session-start greeting order/);
+    assert.match(output.system[0], /authoritative greeting instruction/);
+    assert.match(output.system[0], /do not read the greeting cache or VERSION/);
     assert.match(output.system[0], /this exact aidevops greeting/);
     assert.match(output.system[0], /We're running aidevops v3\.14\.23 in OpenCode v1\.14\.33\./);
+    assert.equal(output.system.filter((entry) => entry.includes("Session-start greeting order")).length, 1);
   });
 
   test("falls back to aidevops version when greeting cache is missing", async () => {

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -204,6 +204,7 @@ function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
 
   return [
     "## Session-start greeting order",
+    "This plugin-injected block is the authoritative greeting instruction. The version values are already resolved; do not read the greeting cache or VERSION before responding.",
     "On the first assistant turn of an interactive session, the first visible text in the assistant response MUST be this exact aidevops greeting:",
     "",
     "Hi!",

--- a/.agents/scripts/generate-runtime-config-agents.sh
+++ b/.agents/scripts/generate-runtime-config-agents.sh
@@ -61,8 +61,8 @@ _run_agent_discovery_python() {
 # Phase 2a: Agent Generation -- Per-Runtime Adapters
 # =============================================================================
 
-# Shared helper: write ~/.config/<runtime>/AGENTS.md with the cache-read greeting
-# template for the given runtime.
+# Shared helper: write ~/.config/<runtime>/AGENTS.md with the authoritative
+# plugin-injection precedence and cache/VERSION greeting fallback.
 # Arguments:
 #   $1 - runtime_id (e.g. "opencode", "claude-code")
 #   $2 - config_dir (e.g. "$HOME/.config/opencode")
@@ -119,8 +119,8 @@ NOT repeat toast content in the chat.
 
 **On interactive conversation start** (skip for headless sessions like \`/pulse\`, \`/full-loop\`):
 
-1. Read line 1 of \`${cache_path}\`. Format: \`aidevops v{X} running in ${display_name} v{Y} | ...\`. Extract \`{X}\` and \`{Y}\`.
-2. Before any tool call or task work, make the first visible text in your first assistant response exactly this template — no extra prose, no status dump:
+1. If this prompt contains a \`## Session-start greeting order\` block, that plugin-injected block is authoritative. Use its already-resolved exact greeting before any tool call or task work. Do not read the cache or VERSION first.
+2. Otherwise, the plugin injection is unavailable. Read line 1 of \`${cache_path}\`. Format: \`aidevops v{X} running in ${display_name} v{Y} | ...\`. Extract \`{X}\` and \`{Y}\`, then make the first visible text in your first assistant response exactly this template — no extra prose, no status dump:
 
        Hi!
 
@@ -128,8 +128,8 @@ NOT repeat toast content in the chat.
 
        What would you like to work on?
 
-3. If the cache file is missing, read \`~/.aidevops/agents/VERSION\` for \`{X}\` and greet: "Hi!\n\nWe're running aidevops v{X}.\n\nWhat would you like to work on?"
-4. Then respond to the user's actual message. If the user launched the session with an initial message, that user message may appear first in the transcript; still put the greeting first in your assistant response.
+3. In that fallback path, if the cache file is missing, read \`~/.aidevops/agents/VERSION\` for \`{X}\` and greet: "Hi!\n\nWe're running aidevops v{X}.\n\nWhat would you like to work on?"
+4. Then respond to the user's actual message. If the user launched the session with an initial message, that user message may appear first in the transcript; still put the greeting first in your assistant response. Never emit both the injected greeting and the fallback greeting.
 
 If the user later asks about aidevops updates, direct them to run \`aidevops update\` in a terminal session (or type \`!aidevops update\` below). Do not announce updates unprompted — the toast already did.
 

--- a/.agents/scripts/generate-runtime-config-agents.sh
+++ b/.agents/scripts/generate-runtime-config-agents.sh
@@ -119,7 +119,7 @@ NOT repeat toast content in the chat.
 
 **On interactive conversation start** (skip for headless sessions like \`/pulse\`, \`/full-loop\`):
 
-1. If this prompt contains a \`## Session-start greeting order\` block, that plugin-injected block is authoritative. Use its already-resolved exact greeting before any tool call or task work. Do not read the cache or VERSION first.
+1. If an earlier system instruction declares itself the authoritative plugin-injected greeting block and supplies exact version values, follow it before any tool call or task work. Do not read the cache or VERSION first.
 2. Otherwise, the plugin injection is unavailable. Read line 1 of \`${cache_path}\`. Format: \`aidevops v{X} running in ${display_name} v{Y} | ...\`. Extract \`{X}\` and \`{Y}\`, then make the first visible text in your first assistant response exactly this template — no extra prose, no status dump:
 
        Hi!

--- a/.agents/scripts/tests/test-greeting-precedence.sh
+++ b/.agents/scripts/tests/test-greeting-precedence.sh
@@ -60,6 +60,6 @@ grep -q 'do NOT re-run `aidevops-update-check.sh`' "$TEMPLATE_FILE"
 if grep -q 'Run .*aidevops-update-check.sh' "$TEMPLATE_FILE"; then
 	exit 1
 fi
-[[ "$(grep -c '^       Hi!$' "$TEMPLATE_FILE")" -eq 1 ]]
+[[ "$(grep -c '^   Hi!$' "$TEMPLATE_FILE")" -eq 1 ]]
 
 printf 'PASS: greeting injection precedence and fallback generation\n'

--- a/.agents/scripts/tests/test-greeting-precedence.sh
+++ b/.agents/scripts/tests/test-greeting-precedence.sh
@@ -38,7 +38,7 @@ _generate_greeting_agents_md opencode "$TMP_DIR"
 GENERATED_FILE="${TMP_DIR}/AGENTS.md"
 TEMPLATE_FILE="${REPO_ROOT}/templates/opencode-config-agents.md"
 
-grep -q 'plugin-injected block is authoritative' "$GENERATED_FILE"
+grep -q 'authoritative plugin-injected greeting block' "$GENERATED_FILE"
 grep -q 'plugin injection is unavailable' "$GENERATED_FILE"
 # shellcheck disable=SC2016
 grep -q 'if the cache file is missing, read `~/.aidevops/agents/VERSION`' "$GENERATED_FILE"
@@ -50,7 +50,7 @@ if grep -q 'Run .*aidevops-update-check.sh' "$GENERATED_FILE"; then
 fi
 [[ "$(grep -c '^       Hi!$' "$GENERATED_FILE")" -eq 1 ]]
 
-grep -q 'plugin-injected block is authoritative' "$TEMPLATE_FILE"
+grep -q 'authoritative plugin-injected greeting block' "$TEMPLATE_FILE"
 grep -q 'plugin injection is unavailable' "$TEMPLATE_FILE"
 # shellcheck disable=SC2016
 grep -q 'if the cache file is missing, read `~/.aidevops/agents/VERSION`' "$TEMPLATE_FILE"

--- a/.agents/scripts/tests/test-greeting-precedence.sh
+++ b/.agents/scripts/tests/test-greeting-precedence.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#27032 greeting precedence and fallback generation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+rt_display_name() {
+	local runtime_id="$1"
+	case "$runtime_id" in
+	opencode) printf '%s\n' "OpenCode" ;;
+	claude-code) printf '%s\n' "Claude Code" ;;
+	*) printf '%s\n' "$runtime_id" ;;
+	esac
+	return 0
+}
+
+print_success() {
+	local message="$1"
+	printf '%s\n' "$message" >/dev/null
+	return 0
+}
+
+# shellcheck source=../generate-runtime-config-agents.sh
+source "${SCRIPT_DIR}/generate-runtime-config-agents.sh"
+
+_generate_greeting_agents_md opencode "$TMP_DIR"
+GENERATED_FILE="${TMP_DIR}/AGENTS.md"
+TEMPLATE_FILE="${REPO_ROOT}/templates/opencode-config-agents.md"
+
+grep -q 'plugin-injected block is authoritative' "$GENERATED_FILE"
+grep -q 'plugin injection is unavailable' "$GENERATED_FILE"
+# shellcheck disable=SC2016
+grep -q 'if the cache file is missing, read `~/.aidevops/agents/VERSION`' "$GENERATED_FILE"
+grep -q 'Never emit both the injected greeting and the fallback greeting' "$GENERATED_FILE"
+# shellcheck disable=SC2016
+grep -q 'do NOT re-run `aidevops-update-check.sh`' "$GENERATED_FILE"
+if grep -q 'Run .*aidevops-update-check.sh' "$GENERATED_FILE"; then
+	exit 1
+fi
+[[ "$(grep -c '^       Hi!$' "$GENERATED_FILE")" -eq 1 ]]
+
+grep -q 'plugin-injected block is authoritative' "$TEMPLATE_FILE"
+grep -q 'plugin injection is unavailable' "$TEMPLATE_FILE"
+# shellcheck disable=SC2016
+grep -q 'if the cache file is missing, read `~/.aidevops/agents/VERSION`' "$TEMPLATE_FILE"
+grep -q 'Never emit both the injected greeting and the fallback greeting' "$TEMPLATE_FILE"
+# shellcheck disable=SC2016
+grep -q 'do NOT re-run `aidevops-update-check.sh`' "$TEMPLATE_FILE"
+if grep -q 'Run .*aidevops-update-check.sh' "$TEMPLATE_FILE"; then
+	exit 1
+fi
+[[ "$(grep -c '^       Hi!$' "$TEMPLATE_FILE")" -eq 1 ]]
+
+printf 'PASS: greeting injection precedence and fallback generation\n'

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -13,7 +13,7 @@ NOT repeat toast content in the chat.
 
 **On interactive conversation start** (skip for headless sessions like `/pulse` and `/full-loop`):
 
-1. If this prompt contains a `## Session-start greeting order` block, that plugin-injected block is authoritative. Use its already-resolved exact greeting before any tool call or task work. Do not read the cache or VERSION first.
+1. If an earlier system instruction declares itself the authoritative plugin-injected greeting block and supplies exact version values, follow it before any tool call or task work. Do not read the cache or VERSION first.
 2. Otherwise, the plugin injection is unavailable. Read line 1 of `~/.aidevops/cache/session-greeting.txt`. Format: `aidevops v{X} running in OpenCode v{Y} | ...`. Extract `{X}` and `{Y}`, then make the first visible text in your first assistant response exactly this template — no extra prose or status dump:
 
        Hi!

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -5,13 +5,27 @@
 
 ## aidevops Framework Status
 
-**On conversation start**:
-1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive` — the output is either a status line (format: `aidevops v{version} running in {app} v{app_version} | {repo}`) or `UPDATE_AVAILABLE|current|latest|AppName`. Parse `{version}` from the output accordingly.
-2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash). If that file does not exist, read `~/.aidevops/agents/VERSION` for the version. If neither exists, use `unknown` as the version.
-3. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version} in {app} v{app_version}.\n\nWhat would you like to work on?"
-4. Then respond to the user's actual message
+The opencode-aidevops plugin renders session-start framework status (versions,
+security posture, advisories, update hints) as a TUI toast before the first
+turn. Raw output is cached at `~/.aidevops/cache/session-greeting.txt`. The
+user has already seen it — do NOT re-run `aidevops-update-check.sh` and do
+NOT repeat toast content in the chat.
 
-If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest|AppName`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." If the output also contains a line `AUTO_UPDATE_ENABLED`, replace the manual update instruction with: "Auto-update is enabled and will apply this within ~10 minutes." This check does not apply when falling back to reading the cache or VERSION file (step 2).
+**On interactive conversation start** (skip for headless sessions like `/pulse` and `/full-loop`):
+
+1. If this prompt contains a `## Session-start greeting order` block, that plugin-injected block is authoritative. Use its already-resolved exact greeting before any tool call or task work. Do not read the cache or VERSION first.
+2. Otherwise, the plugin injection is unavailable. Read line 1 of `~/.aidevops/cache/session-greeting.txt`. Format: `aidevops v{X} running in OpenCode v{Y} | ...`. Extract `{X}` and `{Y}`, then make the first visible text in your first assistant response exactly this template — no extra prose or status dump:
+
+       Hi!
+
+       We're running aidevops v{X} in OpenCode v{Y}.
+
+       What would you like to work on?
+
+3. In that fallback path, if the cache file is missing, read `~/.aidevops/agents/VERSION` for `{X}` and greet: "Hi!\n\nWe're running aidevops v{X}.\n\nWhat would you like to work on?"
+4. Then respond to the user's actual message. If the user launched the session with an initial message, put the greeting first. Never emit both the injected greeting and the fallback greeting.
+
+If the user later asks about aidevops updates, direct them to run `aidevops update` in a terminal session (or type `!aidevops update` below). Do not announce updates unprompted — the toast already did.
 
 ## Pre-Edit Git Check
 

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -16,11 +16,13 @@ NOT repeat toast content in the chat.
 1. If an earlier system instruction declares itself the authoritative plugin-injected greeting block and supplies exact version values, follow it before any tool call or task work. Do not read the cache or VERSION first.
 2. Otherwise, the plugin injection is unavailable. Read line 1 of `~/.aidevops/cache/session-greeting.txt`. Format: `aidevops v{X} running in OpenCode v{Y} | ...`. Extract `{X}` and `{Y}`, then make the first visible text in your first assistant response exactly this template — no extra prose or status dump:
 
-       Hi!
+   ```text
+   Hi!
 
-       We're running aidevops v{X} in OpenCode v{Y}.
+   We're running aidevops v{X} in OpenCode v{Y}.
 
-       What would you like to work on?
+   What would you like to work on?
+   ```
 
 3. In that fallback path, if the cache file is missing, read `~/.aidevops/agents/VERSION` for `{X}` and greet: "Hi!\n\nWe're running aidevops v{X}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message. If the user launched the session with an initial message, put the greeting first. Never emit both the injected greeting and the fallback greeting.


### PR DESCRIPTION
## Summary

- make the plugin-injected, already-resolved greeting authoritative before tool calls
- preserve cache and VERSION fallback behavior when plugin injection is absent
- refresh the stale OpenCode template and add generated-config regression coverage

## Testing

- `node --test .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs`
- `bash .agents/scripts/tests/test-greeting-precedence.sh`
- `shellcheck .agents/scripts/generate-runtime-config-agents.sh .agents/scripts/tests/test-greeting-precedence.sh`
- `.agents/scripts/linters-local.sh --changed`
- Full plugin suite: 301/304 passed; three unrelated canonical-guard fixture failures were environment-specific.

## Runtime Testing

Self-assessed: prompt/config-only behavior with deterministic fixture and hook tests.

Resolves #27032
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.15 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 9m and 145,948 tokens on this as a headless worker.