### PR TITLE
GH#27035: Repair contributor guidance references

### DIFF
--- a/.agents/tools/build-agent/agent-review.md
+++ b/.agents/tools/build-agent/agent-review.md
@@ -30,10 +30,10 @@ tools:
 
 | # | Check | Action if failing |
 |---|-------|-------------------|
-| 1 | **Instruction count** (~50-100 main, <100 subagent) | Consolidate, move to subagent, or remove |
+| 1 | **Instruction count** (~50-100 per agent; maintainability heuristic) | Investigate overages; consolidate or extract duplication, but do not cut solely to hit the count |
 | 2 | **Universal applicability** (>80% tasks) | Extract task-specific content to subagents |
 | 3 | **Duplicate detection** (Grep for `"pattern"` under `.agents/`) | Single authoritative source per concept |
-| 4 | **Code examples** (authoritative/working) | Keep; supplement with Grep references for `"pattern"` under `.agents/scripts/` |
+| 4 | **Code examples** (authoritative/working) | Keep only when authoritative; otherwise use Grep references for `"pattern"` under `.agents/scripts/` or stable section headings |
 | 5 | **AI-CONTEXT block** (standalone essentials) | Rewrite if an AI would get stuck with only this |
 | 6 | **Slash commands** | Move to `scripts/commands/` or domain subagent |
 

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -13,7 +13,7 @@ mode: subagent
 
 ## Quick Reference
 
-- **Budget**: ~50-100 instructions per agent; root AGENTS.md universally applicable only
+- **Budget**: ~50-100 instructions per agent is a maintainability heuristic; investigate overages, don't cut solely to hit the count; root AGENTS.md universally applicable only
 - **Subdivision**: Docs >~300 lines → split into entry point + sub-docs; don't cut to hit a line count
 - **MCP servers**: Disabled globally, enabled per-agent
 - **Code refs**: `rg "pattern"` search patterns, not `file:line` (line numbers drift)

--- a/.github/workflows/agents-md-size-check.yml
+++ b/.github/workflows/agents-md-size-check.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - '.agents/AGENTS.md'
       - 'AGENTS.md'
-      - 'prompts/build.txt'
+      - '.agents/prompts/build.txt'
       - '.github/workflows/agents-md-size-check.yml'
   push:
     branches:
@@ -13,7 +13,7 @@ on:
     paths:
       - '.agents/AGENTS.md'
       - 'AGENTS.md'
-      - 'prompts/build.txt'
+      - '.agents/prompts/build.txt'
       - '.github/workflows/agents-md-size-check.yml'
 
 permissions:
@@ -52,3 +52,39 @@ jobs:
           fi
 
           echo "AGENTS.md size check passed"
+
+      - name: Validate contributor guidance references
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          root = pathlib.Path("AGENTS.md")
+          text = root.read_text(encoding="utf-8")
+          errors = []
+
+          for path_text in sorted(set(re.findall(r"`(\.agents/[^`\s]+)", text))):
+              path = pathlib.Path(path_text)
+              if not path.exists():
+                  errors.append(f"{root}: broken local path: {path_text}")
+
+          reference_pattern = re.compile(r'`(?P<path>\.agents/[^`]+\.md)` "(?P<headings>[^"]+)"')
+          for match in reference_pattern.finditer(text):
+              path = pathlib.Path(match.group("path"))
+              if not path.is_file():
+                  continue
+              headings = {
+                  heading.group(1).strip()
+                  for heading in re.finditer(r"^#{1,6}\s+(.+?)\s*$", path.read_text(encoding="utf-8"), re.MULTILINE)
+              }
+              for expected in (part.strip() for part in match.group("headings").split(" > ")):
+                  if expected not in headings:
+                      errors.append(f'{root}: missing heading "{expected}" in {path}')
+
+          if errors:
+              print("\n".join(errors), file=sys.stderr)
+              raise SystemExit(1)
+          print("Contributor guidance references passed")
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 - **User Guide**: `.agents/AGENTS.md` (deployed to `~/.aidevops/agents/`)
 - **Commands**: `./setup.sh` (deploy) | `.agents/scripts/linters-local.sh` (quality) | `.agents/scripts/version-manager.sh release [major|minor|patch]`
-- **Config**: Runtime-specific (see `.agents/AGENTS.md` "Runtime-Specific References")
+- **Config**: Runtime-specific (see `.agents/AGENTS.md` "Runtime References")
 - **Quality**: `.agents/AGENTS.md` "Framework Rules"
 
 **File Structure**: `TODO.md` (tasks), `todo/` (plans, PRDs), `.agents/` (agents, tools, services, workflows, scripts).
@@ -29,8 +29,9 @@ The `.agents/AGENTS.md` is copied to `~/.aidevops/agents/AGENTS.md` by `setup.sh
 
 ## Development Lifecycle
 
-See `.agents/AGENTS.md` "Development Lifecycle" for the full lifecycle.
-Completion self-check: see `.agents/AGENTS.md` "Framework Rules > Completion and quality discipline".
+See `.agents/AGENTS.md` "Operational Routines" for code-change routing and
+`.agents/AGENTS.md` "Git Workflow" for the full lifecycle.
+Completion self-check: see `.agents/AGENTS.md` "Framework Rules > Task and completion discipline".
 
 ## Contributing
 
@@ -47,22 +48,22 @@ See `.agents/aidevops/` (architecture, setup) and `.agents/tools/` (agent/MCP au
 
 ## Agent Design Principles
 
-From `tools/build-agent/build-agent.md`:
+From `.agents/tools/build-agent/build-agent.md`:
 
-1. **Instruction budget**: ~50-100 max in root AGENTS.md
+1. **Instruction budget**: ~50-100 per agent is a maintainability heuristic; investigate overages, but do not cut solely to hit the count
 2. **Universal applicability**: Every instruction relevant to >80% of tasks
 3. **Progressive disclosure**: Pointers to subagents, not inline content
-4. **Code examples**: Only when authoritative (use `file:line` refs otherwise)
+4. **Code examples**: Only when authoritative; otherwise use stable `rg "pattern"` search references or section headings
 5. **Self-assessment**: Flag issues with evidence, complete task first
 
 Contributor rule: changes that add or expand always-loaded guidance (`AGENTS.md`,
-`.agents/AGENTS.md`, `prompts/build.txt`) must prefer a short pointer plus a
+`.agents/AGENTS.md`, `.agents/prompts/build.txt`) must prefer a short pointer plus a
 reference/workflow document, keep `.agents/AGENTS.md` under the CI size ratchet,
 and justify any intentional baseline increase in the PR body.
 
 ## Security
 
-Security rules: see `.agents/AGENTS.md` "Framework Rules > Security Rules". Additional contributor rule:
+Security rules: see `.agents/AGENTS.md` "Framework Rules > Security and external content". Additional contributor rule:
 - Use placeholders in examples, note secure storage location
 
 ## Quality Workflow
@@ -80,7 +81,7 @@ find .agents/scripts/ -name "*.sh" -exec shellcheck {} \;
 
 ## Self-Assessment Protocol
 
-From `tools/build-agent/build-agent.md`:
+From `.agents/tools/build-agent/build-agent.md`:
 
 - **Triggers**: Observable failure, user correction, contradiction, staleness
 - **Process**: Complete task, cite evidence, check duplicates, propose fix


### PR DESCRIPTION
## Summary

- Repair stale contributor-guide paths and heading references.
- Align instruction-budget and code-reference guidance with the authoritative build-agent docs.
- Add CI validation for local contributor paths and referenced headings while preserving the prompt-size ratchet.

## Testing

- `actionlint .github/workflows/agents-md-size-check.yml`
- Contributor reference validator
- `.agents/scripts/linters-local.sh --changed --strict`

Resolves #27035

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.16 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 19m and 445,430 tokens on this as a headless worker.
