### PR TITLE
GH#27034: Preserve directive provenance in agent reviews

### DIFF
--- a/.agents/scripts/tests/test-agent-review-provenance.sh
+++ b/.agents/scripts/tests/test-agent-review-provenance.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Guard intentional safety reinforcement against count-driven consolidation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+AGENT_REVIEW="$REPO_ROOT/.agents/tools/build-agent/agent-review.md"
+
+python3 - "$AGENT_REVIEW" <<'PY'
+import sys
+from pathlib import Path
+
+content = Path(sys.argv[1]).read_text()
+
+# The invariant is intentionally repeated because each copy protects a distinct
+# decision point. A review must not classify this fixture by text similarity alone.
+fixture = [
+    ("before-write", "Never expose credentials in generated files."),
+    ("before-push", "Never expose credentials in public changes."),
+]
+assert len({text.split(" in ")[0] for _, text in fixture}) == 1
+assert len({boundary for boundary, _ in fixture}) == 2
+
+required = [
+    "counts are heuristics, never standalone removal evidence",
+    "recent file history",
+    "exact duplication from reinforcement at another decision boundary",
+    "runtime-specific variants",
+    "similar-but-different hazards",
+    "reliable trigger that delivers the lesson at its decision point",
+    "obsolete or fully superseded",
+    "**Provenance**",
+    "**Boundary Analysis**",
+    "**Verification**",
+]
+missing = [phrase for phrase in required if phrase not in content]
+assert not missing, f"Agent Review lost provenance safeguards: {missing}"
+PY
+
+printf 'PASS Agent Review directive provenance contract\n'

--- a/.agents/tools/build-agent/agent-review.md
+++ b/.agents/tools/build-agent/agent-review.md
@@ -30,12 +30,14 @@ tools:
 
 | # | Check | Action if failing |
 |---|-------|-------------------|
-| 1 | **Instruction count** (~50-100 main, <100 subagent) | Consolidate, move to subagent, or remove |
-| 2 | **Universal applicability** (>80% tasks) | Extract task-specific content to subagents |
-| 3 | **Duplicate detection** (Grep for `"pattern"` under `.agents/`) | Single authoritative source per concept |
+| 1 | **Instruction count** (~50-100 main, <100 subagent) | Investigate load; counts are heuristics, never standalone removal evidence |
+| 2 | **Universal applicability** (>80% tasks) | Investigate whether a reliable task-specific trigger supports extraction |
+| 3 | **Duplicate detection** (Grep for `"pattern"` under `.agents/`) | Classify exact duplicates vs boundary reinforcement or variants |
 | 4 | **Code examples** (authoritative/working) | Keep; supplement with Grep references for `"pattern"` under `.agents/scripts/` |
 | 5 | **AI-CONTEXT block** (standalone essentials) | Rewrite if an AI would get stuck with only this |
 | 6 | **Slash commands** | Move to `scripts/commands/` or domain subagent |
+
+Before consolidating, relocating, or removing a directive, recover the protected failure/rationale from nearby task IDs, issue/PR context, and recent file history. Record its current enforcement or routing, and distinguish exact duplication from reinforcement at another decision boundary, runtime-specific variants, and similar-but-different hazards. Relocation must name the reliable trigger that delivers the lesson at its decision point. Removal requires evidence that the knowledge is obsolete or fully superseded and identifies any mechanism that preserves or enforces it.
 
 ## Improvement Proposal Format
 
@@ -44,9 +46,13 @@ tools:
 **File**: `.agents/[path]/[file].md`
 **Issue**: [Description]
 **Evidence**: [Failure, contradiction, or feedback]
+**Provenance**: [Protected failure/rationale and recent history inspected]
 **Related Files**: `.agents/[other-file].md` (checked for duplicates)
 **Proposed Change**: [Specific before/after]
-**Impact**: [ ] No conflicts [ ] Instruction count: [+/- N] [ ] Tested
+**Boundary Analysis**: [Exact duplicate, reinforcement, runtime variant, or similar-but-different hazard]
+**Delivery/Preservation**: [Reliable relocation trigger or superseding enforcement mechanism]
+**Verification**: [How retained behaviour and routing were tested]
+**Impact**: [ ] No conflicts [ ] Instruction count (diagnostic): [+/- N] [ ] Tested
 ```
 
 ## Review Categories

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -146,7 +146,7 @@ Linter order: (1) deterministic (ShellCheck, ESLint, Ruff/Pylint), (2) static an
 2. **Universally applicable?** >80% of tasks? If not → more specific subagent
 3. **Pointer instead?** Use `rg "pattern"` or Context7 MCP if content exists elsewhere
 4. **Code example?** Authoritative? Will it drift? Security: placeholders only
-5. **Instruction count?** Combine related, remove redundant
+5. **Instruction count?** Treat budgets as investigation heuristics; before reducing, recover directive provenance and distinguish exact duplicates from boundary reinforcement (see `agent-review.md`)
 6. **Duplicates?** `rg "pattern" .agents/` before adding
 7. **Existing agent?** Call and improve vs duplicate — never create a copy
 8. **Sources verified?** Primary, cross-referenced


### PR DESCRIPTION
## Summary

- Treat instruction budgets and applicability percentages as investigation heuristics rather than deletion targets.
- Require protected-failure provenance, recent history, boundary analysis, and reliable delivery or preservation before directive reduction.
- Add a regression fixture with intentionally repeated safety guidance at distinct decision boundaries.

## Testing

- `.agents/scripts/tests/test-agent-review-provenance.sh`
- `.agents/scripts/tests/test-agent-review-permissions.sh`
- `shellcheck .agents/scripts/tests/test-agent-review-provenance.sh`
- `bunx markdownlint-cli2 .agents/tools/build-agent/agent-review.md .agents/tools/build-agent/build-agent.md`
- `.agents/scripts/linters-local.sh --changed --strict`

## Runtime Testing

Self-assessed: documentation and deterministic test-only change.

Resolves #27034


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.16 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 19m and 236,554 tokens on this as a headless worker.
