### PR TITLE
GH#27048: allow sanctioned full-loop wrapper through OpenCode guard

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
@@ -2,6 +2,19 @@ import { execFileSync } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
 
+function isTrustedFullLoopCommitAndPr(command, scriptsDir, cwd) {
+  const wrapperMatch = command.match(
+    /(?:^|[($;|&\s])(?<wrapper>full-loop-helper\.sh|\.\/\.agents\/scripts\/full-loop-helper\.sh|\$PWD\/\.agents\/scripts\/full-loop-helper\.sh)\s+commit-and-pr(?:\s|$)/,
+  );
+  if (!wrapperMatch) return false;
+
+  const wrapper = wrapperMatch.groups.wrapper;
+  const expectedPath = wrapper === "full-loop-helper.sh"
+    ? join(scriptsDir, wrapper)
+    : join(cwd, ".agents", "scripts", "full-loop-helper.sh");
+  return existsSync(expectedPath);
+}
+
 export function checkCanonicalGitSafetyGate(command, scriptsDir, cwd = process.cwd()) {
   if (typeof command !== "string" || !command.includes("git")) return;
   const guard = join(scriptsDir, "canonical-git-command-guard.py");
@@ -9,7 +22,12 @@ export function checkCanonicalGitSafetyGate(command, scriptsDir, cwd = process.c
     throw new Error("BLOCKED: canonical Git guard is missing; refusing Git command");
   }
   try {
-    execFileSync("python3", [guard, "--cwd", cwd, "--command", command], {
+    // #aidevops:trust-boundary — only the repository-owned full-loop wrapper
+    // receives nested Git authority, and only from a verified linked worktree.
+    const guardedCommand = isTrustedFullLoopCommitAndPr(command, scriptsDir, cwd)
+      ? "git commit --dry-run"
+      : command;
+    execFileSync("python3", [guard, "--cwd", cwd, "--command", guardedCommand], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 10000,

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -9,20 +9,21 @@ import { checkCanonicalGitSafetyGate } from "../quality-hooks-git-safety.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const scriptsDir = join(here, "..", "..", "..", "scripts");
+const realGit = "/usr/bin/git";
 
 function setupRepo() {
   const root = mkdtempSync(join(tmpdir(), "aidevops-git-gate-"));
   const repo = join(root, "repo");
   const linked = join(root, "linked");
   mkdirSync(repo);
-  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: repo });
-  execFileSync("git", ["config", "user.name", "Test"], { cwd: repo });
-  execFileSync("git", ["config", "user.email", "test@example.invalid"], { cwd: repo });
-  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
+  execFileSync(realGit, ["init", "-q", "-b", "main"], { cwd: repo });
+  execFileSync(realGit, ["config", "user.name", "Test"], { cwd: repo });
+  execFileSync(realGit, ["config", "user.email", "test@example.invalid"], { cwd: repo });
+  execFileSync(realGit, ["config", "commit.gpgsign", "false"], { cwd: repo });
   writeFileSync(join(repo, "README.md"), "seed\n");
-  execFileSync("git", ["add", "README.md"], { cwd: repo });
-  execFileSync("git", ["commit", "-q", "-m", "seed"], { cwd: repo });
-  execFileSync("git", ["worktree", "add", "-q", "-b", "feature/test", linked], { cwd: repo });
+  execFileSync(realGit, ["add", "README.md"], { cwd: repo });
+  execFileSync(realGit, ["commit", "-q", "-m", "seed"], { cwd: repo });
+  execFileSync(realGit, ["worktree", "add", "-q", "-b", "feature/test", linked], { cwd: repo });
   return { root, repo, linked };
 }
 
@@ -33,7 +34,7 @@ test("blocks canonical branch mutation before execution", () => {
       () => checkCanonicalGitSafetyGate("git branch -m main safety/example", scriptsDir, repo),
       /canonical worktree mutation/,
     );
-    assert.equal(execFileSync("git", ["symbolic-ref", "--short", "HEAD"], { cwd: repo, encoding: "utf8" }).trim(), "main");
+    assert.equal(execFileSync(realGit, ["symbolic-ref", "--short", "HEAD"], { cwd: repo, encoding: "utf8" }).trim(), "main");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -44,6 +45,42 @@ test("allows read-only canonical commands and linked-worktree mutation", () => {
   try {
     assert.doesNotThrow(() => checkCanonicalGitSafetyGate("git status --short", scriptsDir, repo));
     assert.doesNotThrow(() => checkCanonicalGitSafetyGate("git switch -c feature/child", scriptsDir, linked));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("allows the repository full-loop commit-and-pr wrapper only from a linked worktree", () => {
+  const { root, repo, linked } = setupRepo();
+  const wrapperCommand = "PR_NUMBER=$(full-loop-helper.sh commit-and-pr --issue 123 --testing 'git tests pass')";
+  try {
+    mkdirSync(join(repo, ".agents", "scripts"), { recursive: true });
+    writeFileSync(join(repo, ".agents", "scripts", "full-loop-helper.sh"), "#!/bin/sh\n");
+    assert.throws(
+      () => checkCanonicalGitSafetyGate(wrapperCommand, scriptsDir, repo),
+      /canonical worktree mutation/,
+    );
+
+    mkdirSync(join(linked, ".agents", "scripts"), { recursive: true });
+    writeFileSync(join(linked, ".agents", "scripts", "full-loop-helper.sh"), "#!/bin/sh\n");
+    assert.doesNotThrow(() => checkCanonicalGitSafetyGate(wrapperCommand, scriptsDir, linked));
+    assert.doesNotThrow(() => checkCanonicalGitSafetyGate(
+      "./.agents/scripts/full-loop-helper.sh commit-and-pr --issue 123 --testing 'git tests pass'",
+      scriptsDir,
+      linked,
+    ));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("does not trust similarly named full-loop wrappers", () => {
+  const { root, linked } = setupRepo();
+  try {
+    assert.throws(
+      () => checkCanonicalGitSafetyGate("./tmp/full-loop-helper.sh commit-and-pr --testing 'git tests pass'", scriptsDir, linked),
+      /unclassified nested Git invocation/,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -334,14 +334,14 @@ describe("tryRepairSignature", () => {
     const repo = join(dir, "repo");
     const linked = join(dir, "repo-linked");
     mkdirSync(repo);
-    execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
-    execFileSync("git", ["config", "user.email", "test@example.invalid"], { cwd: repo });
-    execFileSync("git", ["config", "user.name", "Test"], { cwd: repo });
-    execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repo });
+    execFileSync("/usr/bin/git", ["init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("/usr/bin/git", ["config", "user.email", "test@example.invalid"], { cwd: repo });
+    execFileSync("/usr/bin/git", ["config", "user.name", "Test"], { cwd: repo });
+    execFileSync("/usr/bin/git", ["config", "commit.gpgsign", "false"], { cwd: repo });
     writeFileSync(join(repo, "README.md"), "fixture\n");
-    execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
-    execFileSync("git", ["commit", "--no-gpg-sign", "-m", "init"], { cwd: repo, stdio: "ignore" });
-    execFileSync("git", ["worktree", "add", "-b", "linked-fixture", linked], {
+    execFileSync("/usr/bin/git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+    execFileSync("/usr/bin/git", ["commit", "--no-gpg-sign", "-m", "init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("/usr/bin/git", ["worktree", "add", "-b", "linked-fixture", linked], {
       cwd: repo,
       stdio: "ignore",
     });


### PR DESCRIPTION
## Summary

- Trust the repository-owned `full-loop-helper.sh commit-and-pr` command only after linked-worktree validation.
- Preserve canonical-worktree blocking and reject similarly named wrappers.
- Isolate plugin repository fixtures from the deployed guard shim.

## Testing

- `npm test` in `.agents/plugins/opencode-aidevops`: 306 passed.
- Focused safety-gate suite: 5 passed.
- `git diff --check`: clean.

## Runtime Testing

- Runtime-verified through the OpenCode plugin test suite with canonical and linked worktree fixtures.

Resolves #27048

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.16 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 136,542 tokens on this as a headless worker.
