### PR TITLE
GH#27033: fix: qualify main-branch guidance by mode

### DIFF
--- a/.agents/tools/build-agent/agent-review.md
+++ b/.agents/tools/build-agent/agent-review.md
@@ -22,7 +22,7 @@ tools:
 **Trigger**: Session end, user correction, observable failure, periodic maintenance.
 **Self-Assessment**: Observe failure → complete task → cite evidence → search for `"pattern"` under `.agents/` with Grep → propose fix → ask permission.
 **Exact Search**: Use the Grep tool for content searches; when Bash is available, `rg "pattern" <path>` is an optional equivalent.
-**Write Restrictions (MANDATORY)**: On `main`/`master` — ALLOWED: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. BLOCKED: all other files. Code changes → return proposed edits for worktree application.
+**Write Restrictions (MANDATORY)**: Interactive sessions use a linked worktree for every edit, including planning files. Headless bookkeeping and explicitly planning-only workers may use only the narrow `main`/`master` exception enforced by `pre-edit-check.sh`; all other headless edits require a linked worktree. Follow `workflows/pre-edit.md` rather than copying its path allowlist here.
 
 <!-- AI-CONTEXT-END -->
 

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -55,7 +55,7 @@ tools:
 
 - **MCP tool patterns** (subagents only): `context7_*: true`, `wordpress-mcp_*: true`. Injected by plugin at startup — do not set in `opencode.json` directly.
 - **MCP tool filtering** (future `includeTools` — 17k→1.5k token savings): `mcp_requirements: { chrome-devtools: { tools: [navigate_page, take_screenshot] } }`
-- **Main-branch write restrictions**: ALLOWED: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. BLOCKED: all other files.
+- **Main-branch write restrictions**: Interactive sessions use a linked worktree for every edit. Only headless bookkeeping and explicitly planning-only workers may use the narrow exception enforced by `pre-edit-check.sh`; follow `workflows/pre-edit.md` instead of duplicating its allowlist.
 - **Adding a new MCP** (two files required — plugin is authoritative, not `opencode.json`):
   1. `mcp-registry.mjs` `getMcpRegistry()`: `{ name, command/url, eager: false, toolPattern: "foo_*", globallyEnabled: false }`
   2. `agent-loader.mjs` `AGENT_MCP_TOOLS`: `"my-agent": ["foo_*"]`

--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -18,9 +18,9 @@ Run before any file edits:
 
 Pass `--file <path>` when the target file is known — this enables path-based enforcement (t1712). `--task` description heuristics are a fallback for callers that don't know the target path.
 
-## Main-Branch Write Allowlist (t1712)
+## Mode-Scoped Main-Branch Write Allowlist (t1712, t1990)
 
-Only these paths are writable on `main`/`master` without a linked worktree:
+Interactive sessions have no `main`/`master` exception: every edit uses a linked worktree. For headless supervisor/routine/issue-sync bookkeeping and explicitly planning-only worker tasks, `pre-edit-check.sh` may allow these paths without a linked worktree:
 
 | Path | Purpose |
 |------|---------|
@@ -28,7 +28,7 @@ Only these paths are writable on `main`/`master` without a linked worktree:
 | `TODO.md` | Task backlog |
 | `todo/**` | Plans, briefs, task files |
 
-All other paths require a linked worktree. The `git_safety_guard.py` hook enforces this for `Edit` and `Write` tool calls automatically.
+All other paths and all interactive edits require a linked worktree. `pre-edit-check.sh` is authoritative for the mode and path decision; write-time hooks provide additional enforcement where available.
 
 ## Exit Codes
 
@@ -44,7 +44,7 @@ All other paths require a linked worktree. The `git_safety_guard.py` hook enforc
 > 1. Create worktree (recommended)
 > 2. Use different branch name
 
-Note: allowlisted paths (`README.md`, `TODO.md`, `todo/**`) short-circuit to exit `0` before this prompt is shown.
+Note: only qualifying headless flows can short-circuit to exit `0` for allowlisted paths (`README.md`, `TODO.md`, `todo/**`). Interactive sessions still receive this prompt and move every edit to a linked worktree.
 
 **Exit 3 prompt:**
 > On branch: `{branch}` (main repo, not worktree)
@@ -56,7 +56,7 @@ Note: allowlisted paths (`README.md`, `TODO.md`, `todo/**`) short-circuit to exi
 
 Pass `--file <path>` for path-based enforcement (preferred):
 
-- **Allowlisted path** (`README.md`, `TODO.md`, `todo/**`) → stay on `main`; planning publication may still become a PR if branch protection requires it
+- **Qualifying headless flow + allowlisted path** (`README.md`, `TODO.md`, `todo/**`) → stay on `main`; planning publication may still become a PR if branch protection requires it
 - **Any other path** → create worktree
 
 Fallback `--task` description keywords (when `--file` not provided):
@@ -68,7 +68,7 @@ Fallback `--task` description keywords (when `--file` not provided):
 
 Keep `~/Git/{repo}/` on `main`. Create linked worktrees under `${AIDEVOPS_WORKTREE_BASE_DIR:-~/Git/_worktrees}`. This avoids blocked branch switches, parallel sessions inheriting the wrong branch, and `local changes would be overwritten` errors.
 
-Stay on `main` only for allowlisted paths: `README.md`, `TODO.md`, `todo/**`. Planning-file commits use `planning-commit-helper.sh "plan: add new task"`; the helper opens a planning-only PR instead of direct-pushing when the default branch is protected.
+Stay on `main` only in a qualifying headless flow and only for allowlisted paths: `README.md`, `TODO.md`, `todo/**`. Planning-file commits use `planning-commit-helper.sh "plan: add new task"`; the helper opens a planning-only PR instead of direct-pushing when the default branch is protected. Interactive sessions always create a linked worktree first.
 
 Continue on current branch only when: task matches branch purpose, finishes this session, no parallel sessions expected.
 


### PR DESCRIPTION
## Summary

Clarified that interactive agent-authoring work always uses linked worktrees while preserving the pre-edit-enforced headless bookkeeping and planning-only exception.

## Files Changed

.agents/tools/build-agent/agent-review.md, .agents/tools/build-agent/build-agent.md, .agents/workflows/pre-edit.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Markdown style and secret checks passed via linters-local.sh; test-pre-edit-check.sh passed 10/10; test-git-safety-guard.sh passed 10/10; duplicate contradiction searches returned no stale agent-authoring allowlists.

Resolves #27033


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.16 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 22m and 235,359 tokens on this as a headless worker.