### PR TITLE
GH#27038: prevent duplicate cross-runner work

### DIFF
--- a/.agents/reference/cross-runner-coordination.md
+++ b/.agents/reference/cross-runner-coordination.md
@@ -128,6 +128,17 @@ The claim comment survives beyond the claim window, letting Layer 5
 (`has-dispatch-comment`) block re-dispatch in future pulse cycles while the
 issue stays open and the PR is unmerged.
 
+The same append-only consensus protocol also protects review-followup creation.
+`post-merge-review-scanner.sh` claims on the merged source PR conversation,
+rechecks for an existing follow-up after winning, and only then creates the
+issue. Abort paths post
+`CLAIM_RELEASED reason=review_followup_creation:<reason>` immediately. A
+successful creation writes a trusted `REVIEW_FOLLOWUP_CREATED` marker containing
+the source PR fingerprint and created issue number, then retains its bounded
+120-second claim. Future scanners verify that marker through the source PR's
+REST comment timeline, so safety does not depend on issue-search convergence.
+Dry-run scans never post claims, completion markers, or release markers.
+
 **Close-window deferrals (t2422):** When a losing runner's claim lost by only
 `DISPATCH_TIEBREAKER_WINDOW` seconds (default 5s), it posts a `CLAIM_DEFERRED`
 audit comment identifying the winner before releasing. This captures the
@@ -205,6 +216,18 @@ another runner's active claim.
 passively assigned to an issue for bookkeeping does not block dispatch unless
 an active status label is also present. Implements the `is-assigned` combined
 check from t1996.
+
+Manual single-issue dispatch follows the same Layer 7 protocol after its
+read-only dedup checks and before ceremony/worktree creation. Claim loss and
+claim API error both block (fail closed). Any failure after a winning claim but
+before worker launch posts `CLAIM_RELEASED reason=manual_dispatch_prelaunch:*`;
+successful workers retain the normal lifecycle-owned release behavior.
+
+Review-followup issues add a pre-launch canonicalization gate. Open issues for
+the same source-PR fingerprint are sorted by issue number; only the lowest
+number may proceed, while later duplicates are closed with an audit rationale.
+If GitHub cannot enumerate the duplicate set, validator exit 30 blocks that
+dispatch cycle in both pulse and manual paths.
 
 **Layer 6 sub-step (t2930 ignore filter, extended t3194):** before evaluating
 combined-signal blocking, the assignee list is filtered against

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -61,9 +61,12 @@ _DSI_HEADLESS="${_DSI_SCRIPT_DIR}/headless-runtime-helper.sh"
 _DSI_LEDGER_HELPER="${_DSI_SCRIPT_DIR}/dispatch-ledger-helper.sh"
 _DSI_WORKTREE_HELPER="${_DSI_SCRIPT_DIR}/worktree-helper.sh"
 _DSI_DEDUP_HELPER="${_DSI_SCRIPT_DIR}/dispatch-dedup-helper.sh"
+_DSI_VALIDATOR_HELPER="${_DSI_SCRIPT_DIR}/pre-dispatch-validator-helper.sh"
 _DSI_BACKOFF_HELPER="${_DSI_SCRIPT_DIR}/dispatch-backoff-helper.sh"
 _DSI_DISPATCH_BASE_BRANCH=""
 _DSI_STATE_RECOVERING="recovering"
+_DSI_CLAIM_WON=0
+_DSI_CLAIM_COMMENT_ID=""
 
 # Colors (guarded — don't collide with shared-constants)
 [[ -z "${_DSI_GREEN+x}" ]] && _DSI_GREEN='\033[0;32m'
@@ -1119,6 +1122,98 @@ _dsi_run_dedup_check() {
 	return 0
 }
 
+_dsi_acquire_consensus_claim() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="$3"
+	local claim_output=""
+	local claim_rc=0
+
+	_DSI_CLAIM_WON=0
+	_DSI_CLAIM_COMMENT_ID=""
+	if [[ -z "$self_login" ]]; then
+		_dsi_err "Cannot resolve runner login for consensus claim; refusing dispatch"
+		return 1
+	fi
+	claim_output=$("$_DSI_DEDUP_HELPER" claim "$issue_number" "$repo_slug" "$self_login" 2>&1) || claim_rc=$?
+	case "$claim_rc" in
+	0)
+		_DSI_CLAIM_WON=1
+		_DSI_CLAIM_COMMENT_ID=$(printf '%s' "$claim_output" | sed -n 's/.*comment_id=\([0-9][0-9]*\).*/\1/p')
+		_dsi_info "Consensus claim won for #${issue_number}"
+		return 0
+		;;
+	1)
+		_dsi_warn "Consensus claim lost for #${issue_number}; another runner won"
+		return 1
+		;;
+	*)
+		_dsi_err "Consensus claim error for #${issue_number} (rc=${claim_rc}) — failing closed"
+		_dsi_info "  Output: ${claim_output}"
+		return 1
+		;;
+	esac
+}
+
+_dsi_release_consensus_claim() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="$3"
+	local reason="$4"
+	local body=""
+	[[ "$_DSI_CLAIM_WON" -eq 1 ]] || return 0
+	if [[ "$_DSI_CLAIM_COMMENT_ID" =~ ^[0-9]+$ ]]; then
+		if gh api "repos/${repo_slug}/issues/comments/${_DSI_CLAIM_COMMENT_ID}" \
+			--method DELETE >/dev/null 2>&1; then
+			_DSI_CLAIM_WON=0
+			_DSI_CLAIM_COMMENT_ID=""
+			return 0
+		fi
+		_dsi_warn "Failed to delete prelaunch claim ${_DSI_CLAIM_COMMENT_ID}; posting release marker"
+	fi
+	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+CLAIM_RELEASED reason=manual_dispatch_prelaunch:${reason} runner=${self_login} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+<!-- ops:end -->"
+	if ! gh api "repos/${repo_slug}/issues/${issue_number}/comments" --method POST --field body="$body" >/dev/null 2>&1; then
+		_dsi_warn "Failed to post CLAIM_RELEASED for #${issue_number} after ${reason}"
+		return 1
+	fi
+	_DSI_CLAIM_WON=0
+	_DSI_CLAIM_COMMENT_ID=""
+	return 0
+}
+
+_dsi_run_required_predispatch_validator() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local validator_rc=0
+	if [[ ! -x "$_DSI_VALIDATOR_HELPER" ]]; then
+		_dsi_err "Pre-dispatch validator unavailable; refusing manual dispatch"
+		return 1
+	fi
+	"$_DSI_VALIDATOR_HELPER" validate "$issue_number" "$repo_slug" >/dev/null 2>&1 || validator_rc=$?
+	case "$validator_rc" in
+	0) return 0 ;;
+	20)
+		case ",${_DSI_ISSUE_LABELS}," in
+		*",review-followup,"* | *",source:review-scanner,"*)
+			_dsi_err "Review-followup validation is uncertain; failing closed"
+			return 1
+			;;
+		esac
+		return 0
+		;;
+	10)
+		_dsi_warn "Pre-dispatch validator closed or blocked #${issue_number}"
+		return 1
+		;;
+	*)
+		_dsi_err "Pre-dispatch validator returned rc=${validator_rc}; failing closed"
+		return 1
+		;;
+	esac
+}
+
 #######################################
 # Persist a machine-readable continuation checkpoint for an uncertain guard.
 # Args: $1 issue, $2 repo, $3 trigger, $4 attempts
@@ -1249,6 +1344,13 @@ cmd_dispatch() {
 		return 1
 		;;
 	esac
+	if ! _dsi_acquire_consensus_claim "$issue_number" "$repo_slug" "$self_login"; then
+		return 1
+	fi
+	if ! _dsi_run_required_predispatch_validator "$issue_number" "$repo_slug"; then
+		_dsi_release_consensus_claim "$issue_number" "$repo_slug" "$self_login" "predispatch_validator_blocked" || true
+		return 1
+	fi
 
 	_dsi_dispatch_after_dedup_clear "$issue_number" "$repo_slug" "$self_login" "$session_key"
 	return $?
@@ -1307,6 +1409,7 @@ _dsi_reset_after_prelaunch_failure() {
 	local self_login="$3"
 	local reason="$4"
 
+	_dsi_release_consensus_claim "$issue_number" "$repo_slug" "$self_login" "$reason" || true
 	if [[ "$_DSI_ARG_NO_CEREMONY" -eq 1 ]]; then
 		return 0
 	fi

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -96,6 +96,7 @@ SCANNER_CLAIM_HELPER="${SCANNER_CLAIM_HELPER:-${SCRIPT_DIR}/dispatch-claim-helpe
 SCANNER_PREDISPATCH_HELPER="${SCANNER_PREDISPATCH_HELPER:-${SCRIPT_DIR}/pre-dispatch-validator-helper.sh}"
 SCANNER_CREATED_ISSUE_NUMBER=""
 SCANNER_EXISTING_ISSUE_NUMBER=""
+SCANNER_FALSE="false"
 
 SCANNER_DAYS="${SCANNER_DAYS:-7}"
 SCANNER_MAX_ISSUES="${SCANNER_MAX_ISSUES:-10}"
@@ -686,21 +687,23 @@ _creation_marker_issue_exists() {
 	local marker_issue=""
 	local marker_meta=""
 	local stale_claim=""
+	local comments_json=""
 	raw_comments=$(gh api "repos/${repo}/issues/${pr}/comments?per_page=100" \
 		--paginate --slurp 2>/dev/null) || return 2
-	marker_issue=$(printf '%s' "$raw_comments" | jq -r --arg source_pr "$pr" '
-		[if (type == "array" and ((.[0]? | type) == "array")) then .[] else . end
-		 | .[]
+	comments_json=$(printf '%s' "$raw_comments" | jq -c '
+		if type == "array" and (.[0]? | type) == "array" then [.[][]] else . end
+	' 2>/dev/null) || return 2
+	marker_issue=$(printf '%s' "$comments_json" | jq -r --arg source_pr "$pr" '
+		[.[]
 		 | select((.author_association // "") as $a | ["OWNER","MEMBER","COLLABORATOR"] | index($a))
 		 | (.body // "")
 		 | (capture("REVIEW_FOLLOWUP_CREATED source_pr=" + $source_pr + " issue=(?<issue>[0-9]+)")? | .issue)]
 		| map(select(. != null)) | last // ""
 	' 2>/dev/null) || return 2
 	if [[ -z "$marker_issue" ]]; then
-		stale_claim=$(printf '%s' "$raw_comments" | jq -r --argjson now "$(date +%s)" '
-			(if (type == "array" and ((.[0]? | type) == "array")) then [.[][]] else . end) as $rows
-			| ([$rows[] | select((.body // "") | ascii_downcase | contains("dispatch_claim nonce=")) | .created_at] | sort | last // "") as $claim
-			| ([$rows[] | select((.body // "") | ascii_downcase | contains("claim_released")) | .created_at] | sort | last // "") as $release
+		stale_claim=$(printf '%s' "$comments_json" | jq -r --argjson now "$(date +%s)" '
+			([.[] | select((.body // "") | ascii_downcase | contains("dispatch_claim nonce=")) | .created_at] | sort | last // "") as $claim
+			| ([.[] | select((.body // "") | ascii_downcase | contains("claim_released")) | .created_at] | sort | last // "") as $release
 			| if ($claim != "" and ($release == "" or $claim > $release) and ($now - ($claim | fromdateiso8601) > 120)) then "stale" else "" end
 		' 2>/dev/null) || return 2
 		if [[ "$stale_claim" == "stale" ]]; then
@@ -730,7 +733,7 @@ recover_creation_marker() {
 	[[ "$SCANNER_EXISTING_ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]] || return 0
 	_creation_marker_issue_exists "$repo" "$pr" || marker_rc=$?
 	[[ "$marker_rc" -eq 1 ]] || return 0
-	[[ "$dry_run" == "false" ]] || return 0
+	[[ "$dry_run" == "$SCANNER_FALSE" ]] || return 0
 	runner=$(gh api user --jq '.login' 2>/dev/null) || runner=""
 	[[ -n "$runner" ]] || return 0
 	record_creation_marker "$repo" "$pr" "$runner" "$SCANNER_EXISTING_ISSUE_NUMBER" || true
@@ -1226,9 +1229,9 @@ main() {
 		}
 	fi
 	case "$command" in
-	scan) do_scan "$repo" "false" ;;
+	scan) do_scan "$repo" "$SCANNER_FALSE" ;;
 	dry-run) do_scan "$repo" "true" ;;
-	refresh) do_refresh "$repo" "false" ;;
+	refresh) do_refresh "$repo" "$SCANNER_FALSE" ;;
 	refresh-dry-run) do_refresh "$repo" "true" ;;
 	-h | --help | help)
 		echo "Usage: $(basename "$0") {scan|dry-run|refresh|refresh-dry-run|help} [REPO]"

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -92,6 +92,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=shared-constants.sh
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+SCANNER_CLAIM_HELPER="${SCANNER_CLAIM_HELPER:-${SCRIPT_DIR}/dispatch-claim-helper.sh}"
+SCANNER_PREDISPATCH_HELPER="${SCANNER_PREDISPATCH_HELPER:-${SCRIPT_DIR}/pre-dispatch-validator-helper.sh}"
+SCANNER_CREATED_ISSUE_NUMBER=""
+SCANNER_EXISTING_ISSUE_NUMBER=""
 
 SCANNER_DAYS="${SCANNER_DAYS:-7}"
 SCANNER_MAX_ISSUES="${SCANNER_MAX_ISSUES:-10}"
@@ -491,6 +495,7 @@ fetch_file_refs_md() {
 _emit_pr_followup_body_header() {
 	local repo="$1" pr="$2"
 	cat <<MD
+<!-- aidevops:generator=review-followup source_pr=${pr} fingerprint=source-pr-${pr} -->
 ## Unaddressed review bot suggestions
 
 PR #${pr} was merged with unaddressed review bot feedback. Each comment
@@ -656,12 +661,137 @@ build_pr_followup_body() {
 }
 
 issue_exists() {
-	local repo="$1" pr="$2" count
+	local repo="$1" pr="$2" existing_number="" rc=0
 	local title_query="Review followup: PR #${pr} —"
-	count=$(gh issue list --repo "$repo" --label "$SCANNER_LABEL" \
+	SCANNER_EXISTING_ISSUE_NUMBER=""
+	existing_number=$(gh issue list --repo "$repo" --label "$SCANNER_LABEL" \
 		--search "in:title \"${title_query}\"" --state all --limit 100 \
-		--json number --jq 'length' || echo "0")
-	[[ "$count" -gt 0 ]]
+		--json number --jq '.[0].number // 0') || rc=$?
+	if [[ "$rc" -ne 0 || ! "$existing_number" =~ ^[0-9]+$ ]]; then
+		log "issue_exists: lookup failed for ${repo} source PR #${pr} (rc=${rc})"
+		return 2
+	fi
+	if [[ "$existing_number" -gt 0 ]]; then
+		SCANNER_EXISTING_ISSUE_NUMBER="$existing_number"
+		return 0
+	fi
+	_creation_marker_issue_exists "$repo" "$pr"
+	return $?
+}
+
+_creation_marker_issue_exists() {
+	local repo="$1"
+	local pr="$2"
+	local raw_comments=""
+	local marker_issue=""
+	local marker_meta=""
+	local stale_claim=""
+	raw_comments=$(gh api "repos/${repo}/issues/${pr}/comments?per_page=100" \
+		--paginate --slurp 2>/dev/null) || return 2
+	marker_issue=$(printf '%s' "$raw_comments" | jq -r --arg source_pr "$pr" '
+		[if (type == "array" and ((.[0]? | type) == "array")) then .[] else . end
+		 | .[]
+		 | select((.author_association // "") as $a | ["OWNER","MEMBER","COLLABORATOR"] | index($a))
+		 | (.body // "")
+		 | (capture("REVIEW_FOLLOWUP_CREATED source_pr=" + $source_pr + " issue=(?<issue>[0-9]+)")? | .issue)]
+		| map(select(. != null)) | last // ""
+	' 2>/dev/null) || return 2
+	if [[ -z "$marker_issue" ]]; then
+		stale_claim=$(printf '%s' "$raw_comments" | jq -r --argjson now "$(date +%s)" '
+			(if (type == "array" and ((.[0]? | type) == "array")) then [.[][]] else . end) as $rows
+			| ([$rows[] | select((.body // "") | ascii_downcase | contains("dispatch_claim nonce=")) | .created_at] | sort | last // "") as $claim
+			| ([$rows[] | select((.body // "") | ascii_downcase | contains("claim_released")) | .created_at] | sort | last // "") as $release
+			| if ($claim != "" and ($release == "" or $claim > $release) and ($now - ($claim | fromdateiso8601) > 120)) then "stale" else "" end
+		' 2>/dev/null) || return 2
+		if [[ "$stale_claim" == "stale" ]]; then
+			log "PR #${pr}: unresolved stale creation claim — fail closed pending search or marker recovery"
+			return 2
+		fi
+		return 1
+	fi
+	marker_meta=$(gh api "repos/${repo}/issues/${marker_issue}" \
+		--jq '[.title // "", .body // ""] | @tsv' 2>/dev/null) || return 2
+	if [[ "$marker_meta" == *"source_pr=${pr}"* \
+		|| "$marker_meta" == *"Source PR**: #${pr}"* \
+		|| "$marker_meta" == *"Review followup: PR #${pr}"* ]]; then
+		log "PR #${pr}: durable creation marker references issue #${marker_issue}"
+		return 0
+	fi
+	log "PR #${pr}: durable creation marker issue #${marker_issue} failed fingerprint verification"
+	return 2
+}
+
+recover_creation_marker() {
+	local repo="$1"
+	local pr="$2"
+	local dry_run="$3"
+	local marker_rc=0
+	local runner=""
+	[[ "$SCANNER_EXISTING_ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]] || return 0
+	_creation_marker_issue_exists "$repo" "$pr" || marker_rc=$?
+	[[ "$marker_rc" -eq 1 ]] || return 0
+	[[ "$dry_run" == "false" ]] || return 0
+	runner=$(gh api user --jq '.login' 2>/dev/null) || runner=""
+	[[ -n "$runner" ]] || return 0
+	record_creation_marker "$repo" "$pr" "$runner" "$SCANNER_EXISTING_ISSUE_NUMBER" || true
+	return 0
+}
+
+precreation_superseded() {
+	local repo="$1"
+	local pr="$2"
+	local body="$3"
+	local output="" rc=0
+	if [[ ! -x "$SCANNER_PREDISPATCH_HELPER" ]]; then
+		log "PR #${pr}: supersession helper unavailable — skip this scan cycle"
+		return 20
+	fi
+	output=$(printf '%s' "$body" | "$SCANNER_PREDISPATCH_HELPER" \
+		check-review-supersession "$repo" "$pr" 2>&1) || rc=$?
+	if [[ "$rc" -eq 10 ]]; then
+		log "PR #${pr}: findings already superseded (${output})"
+		return 10
+	fi
+	if [[ "$rc" -ne 0 ]]; then
+		log "PR #${pr}: supersession lookup uncertain (rc=${rc}) — skip this scan cycle"
+		return 20
+	fi
+	return 0
+}
+
+acquire_creation_claim() {
+	local repo="$1"
+	local pr="$2"
+	local runner="$3"
+	local output="" rc=0
+	if [[ ! -x "$SCANNER_CLAIM_HELPER" ]]; then
+		log "PR #${pr}: creation claim helper unavailable"
+		return 2
+	fi
+	output=$(DISPATCH_CLAIM_ASSIGNMENT_GUARD=disabled DISPATCH_CLAIM_MAX_AGE=120 \
+		"$SCANNER_CLAIM_HELPER" claim "$pr" "$repo" "$runner" 2>&1) || rc=$?
+	if [[ "$rc" -ne 0 ]]; then
+		log "PR #${pr}: creation claim not won (rc=${rc}): ${output}"
+		return "$rc"
+	fi
+	log "PR #${pr}: creation claim won"
+	return 0
+}
+
+release_creation_claim() {
+	local repo="$1"
+	local pr="$2"
+	local runner="$3"
+	local reason="$4"
+	local body=""
+	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+CLAIM_RELEASED reason=review_followup_creation:${reason} runner=${runner} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+<!-- ops:end -->"
+	if ! gh api "repos/${repo}/issues/${pr}/comments" --method POST --field body="$body" >/dev/null 2>&1; then
+		log "PR #${pr}: failed to release creation claim (${reason})"
+		return 1
+	fi
+	return 0
 }
 
 # Append the signature footer to a body. Uses gh-signature-helper.sh if
@@ -730,9 +860,127 @@ create_issue() {
 	local body_with_sig
 	body_with_sig=$(append_sig_footer "$body")
 
-	gh_create_issue --repo "$repo" --title "$title" \
+	local create_output=""
+	SCANNER_CREATED_ISSUE_NUMBER=""
+	if ! create_output=$(gh_create_issue --repo "$repo" --title "$title" \
 		--label "$label_list" \
-		--body "$body_with_sig"
+		--body "$body_with_sig"); then
+		log "PR #${pr}: issue create failed"
+		return 1
+	fi
+	printf '%s\n' "$create_output"
+	SCANNER_CREATED_ISSUE_NUMBER=$(printf '%s\n' "$create_output" | sed -En 's#.*issues/([0-9]+).*#\1#p' | tail -1)
+	if [[ ! "$SCANNER_CREATED_ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+		log "PR #${pr}: issue created but number could not be parsed from wrapper output"
+		return 1
+	fi
+	return 0
+}
+
+record_creation_marker() {
+	local repo="$1"
+	local pr="$2"
+	local runner="$3"
+	local issue_number="$4"
+	local body=""
+	local attempt=1
+	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+REVIEW_FOLLOWUP_CREATED source_pr=${pr} issue=${issue_number} fingerprint=source-pr-${pr} runner=${runner} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+<!-- ops:end -->"
+	while [[ "$attempt" -le 3 ]]; do
+		if gh api "repos/${repo}/issues/${pr}/comments" --method POST \
+			--field body="$body" >/dev/null 2>&1; then
+			return 0
+		fi
+		attempt=$((attempt + 1))
+		[[ "$attempt" -le 3 ]] && sleep 2
+	done
+	log "PR #${pr}: failed to persist durable creation marker for issue #${issue_number}"
+	return 1
+}
+
+_scan_one_pr() {
+	local repo="$1"
+	local pr="$2"
+	local dry_run="$3"
+	local exists_rc=0
+	local build_rc=0
+	local supersession_rc=0
+	local body=""
+
+	issue_exists "$repo" "$pr" || exists_rc=$?
+	case "$exists_rc" in
+	0)
+		recover_creation_marker "$repo" "$pr" "$dry_run"
+		log "PR #${pr}: issue exists, skip (use 'refresh' to rewrite)"
+		return 1
+		;;
+	2)
+		log "PR #${pr}: existing-issue lookup uncertain, skip this scan cycle"
+		return 1
+		;;
+	esac
+
+	body=$(build_pr_followup_body "$repo" "$pr") || build_rc=$?
+	if [[ "$build_rc" -eq 1 ]]; then
+		log "PR #${pr}: no actionable bot feedback, skip"
+		return 1
+	fi
+	if [[ "$build_rc" -ne 0 || -z "$body" ]]; then
+		log "PR #${pr}: fetch or body error, skip (will retry next scan)"
+		return 1
+	fi
+	precreation_superseded "$repo" "$pr" "$body" || supersession_rc=$?
+	if [[ "$supersession_rc" -ne 0 ]]; then
+		return 1
+	fi
+
+	local pr_title=""
+	pr_title=$(gh pr view "$pr" --repo "$repo" --json title --jq '.title' 2>/dev/null) || pr_title="Unknown"
+	if [[ "$dry_run" == "true" ]]; then
+		create_issue "$repo" "$pr" "$pr_title" "$body" "$dry_run"
+		return $?
+	fi
+
+	local runner=""
+	runner=$(gh api user --jq '.login' 2>/dev/null) || runner=""
+	if [[ -z "$runner" ]]; then
+		log "PR #${pr}: cannot resolve creation claimant — skip this scan cycle"
+		return 1
+	fi
+	if ! acquire_creation_claim "$repo" "$pr" "$runner"; then
+		return 1
+	fi
+
+	exists_rc=0
+	issue_exists "$repo" "$pr" || exists_rc=$?
+	if [[ "$exists_rc" -eq 0 ]]; then
+		log "PR #${pr}: issue appeared after claim, skip creation"
+		release_creation_claim "$repo" "$pr" "$runner" "post_claim_issue_exists" || true
+		return 1
+	fi
+	if [[ "$exists_rc" -eq 2 ]]; then
+		log "PR #${pr}: post-claim issue recheck uncertain, skip creation"
+		release_creation_claim "$repo" "$pr" "$runner" "post_claim_lookup_uncertain" || true
+		return 1
+	fi
+
+	log "PR #${pr}: creation claim winner creating issue"
+	if ! create_issue "$repo" "$pr" "$pr_title" "$body" "$dry_run"; then
+		release_creation_claim "$repo" "$pr" "$runner" "issue_create_failed" || true
+		return 1
+	fi
+	if ! record_creation_marker "$repo" "$pr" "$runner" "$SCANNER_CREATED_ISSUE_NUMBER"; then
+		# The issue exists, so do not report creation failure or release the
+		# consistency claim. Search and the retained claim remain defensive
+		# fallbacks while the marker write recovers on a later scan.
+		log "PR #${pr}: issue #${SCANNER_CREATED_ISSUE_NUMBER} created without durable marker; retaining claim"
+		return 0
+	fi
+	# Keep the winning 120-second claim active after creation. GitHub issue
+	# search is eventually consistent. The durable source-PR marker is the
+	# authoritative evidence after this bounded consistency window expires.
+	log "PR #${pr}: issue created; creation claim retained for consistency window"
 	return 0
 }
 
@@ -781,30 +1029,9 @@ do_scan() {
 			log "Max issues reached (${SCANNER_MAX_ISSUES})"
 			break
 		fi
-		if issue_exists "$repo" "$pr"; then
-			log "PR #${pr}: issue exists, skip (use 'refresh' to rewrite)"
-			continue
+		if _scan_one_pr "$repo" "$pr" "$dry_run"; then
+			issues_created=$((issues_created + 1))
 		fi
-		local body=""
-		local build_rc=0
-		body=$(build_pr_followup_body "$repo" "$pr") || build_rc=$?
-		if [[ "$build_rc" -eq 1 ]]; then
-			log "PR #${pr}: no actionable bot feedback, skip"
-			continue
-		fi
-		if [[ "$build_rc" -eq 2 ]]; then
-			log "PR #${pr}: fetch error, skip (will retry next scan)"
-			continue
-		fi
-		if [[ -z "$body" ]]; then
-			log "PR #${pr}: inconsistent state (rc=0 but empty body), skip"
-			continue
-		fi
-		local pr_title
-		pr_title=$(gh pr view "$pr" --repo "$repo" --json title --jq '.title' || echo "Unknown")
-		log "PR #${pr}: creating issue"
-		create_issue "$repo" "$pr" "$pr_title" "$body" "$dry_run"
-		issues_created=$((issues_created + 1))
 	done <<<"$pr_numbers"
 	clear_scan_cursor "$repo"
 	log "Done. Issues created: ${issues_created}"

--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -53,6 +53,17 @@ _log() {
 	return 0
 }
 
+_log_error() {
+	_log "ERROR" "$@"
+	return 0
+}
+
+_github_clone_url() {
+	local slug="$1"
+	printf 'https://github.com/%s.git' "$slug"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Registry — maps generator name → validator function name
 # Add new validators here by calling _register_validators() pattern.
@@ -330,7 +341,7 @@ _validator_ratchet_down() {
 
 	# Clone repo into scratch dir for a fresh read (avoids stale worktree reads)
 	local clone_url
-	clone_url="https://github.com/${slug}.git"
+	clone_url=$(_github_clone_url "$slug")
 
 	if ! git clone --depth 1 --quiet "$clone_url" "${SCRATCH_DIR}/repo" 2>/dev/null; then
 		_log "WARN" "ratchet-down validator: git clone failed for ${slug} — treating as validator error"
@@ -383,7 +394,7 @@ _validator_file_line_threshold_gate() {
 
 	# Clone repo into scratch dir for a fresh read against HEAD
 	local clone_url
-	clone_url="https://github.com/${slug}.git"
+	clone_url=$(_github_clone_url "$slug")
 
 	if ! git clone --depth 1 --quiet "$clone_url" "${SCRATCH_DIR}/repo" 2>/dev/null; then
 		_log "WARN" "${generator_name} validator: git clone failed for ${slug}"
@@ -447,7 +458,7 @@ _validator_function_complexity_gate() {
 
 	# Clone repo into scratch dir for a fresh read against HEAD
 	local clone_url
-	clone_url="https://github.com/${slug}.git"
+	clone_url=$(_github_clone_url "$slug")
 
 	if ! git clone --depth 1 --quiet "$clone_url" "${SCRATCH_DIR}/repo" 2>/dev/null; then
 		_log "WARN" "function-complexity-gate validator: git clone failed for ${slug}"
@@ -870,12 +881,15 @@ _rf_issue_in_supersession_scope() {
 	local issue_body="$1"
 	local labels="$2"
 	local title="$3"
-	local labels_lc=""
 	local title_lc=""
 
+	if _rf_is_review_followup_scope "$issue_body" "$labels" "$title"; then
+		return 0
+	fi
+	local labels_lc=""
 	labels_lc=$(printf '%s' "$labels" | tr '[:upper:]' '[:lower:]')
 	case ",${labels_lc}," in
-	*",source:review-feedback,"* | *",quality-debt,"* | *",review-followup,"* | *",source:review-scanner,"*)
+	*",source:review-feedback,"* | *",quality-debt,"*)
 		return 0
 		;;
 	esac
@@ -889,6 +903,20 @@ _rf_issue_in_supersession_scope() {
 		return 0
 	fi
 
+	return 1
+}
+
+_rf_is_review_followup_scope() {
+	local issue_body="$1"
+	local labels="$2"
+	local issue_title="$3"
+	local normalized_labels=""
+	normalized_labels=$(printf '%s' "$labels" | tr '[:upper:]' '[:lower:]')
+	case ",${normalized_labels}," in
+	*",review-followup,"* | *",source:review-scanner,"*) return 0 ;;
+	esac
+	[[ "$issue_title" == "Review followup: PR #"* ]] && return 0
+	[[ "$issue_body" == *"aidevops:generator=review-followup"* ]] && return 0
 	return 1
 }
 
@@ -907,8 +935,8 @@ _rf_search_merged_pr_numbers() {
 		-f sort=updated \
 		-f order=desc \
 		-f per_page="$limit" \
-		--jq '.items[]?.number' 2>/dev/null || true
-	return 0
+		--jq '.items[]?.number' 2>/dev/null
+	return $?
 }
 
 _rf_extract_source_pr_number() {
@@ -916,7 +944,7 @@ _rf_extract_source_pr_number() {
 	local issue_title="$2"
 	local source_pr=""
 
-	source_pr=$(printf '%s\n%s\n' "$issue_body" "$issue_title" | sed -En 's/.*\*\*Source PR\*\*:[[:space:]]*#?([0-9]+).*/\1/p; s/.*Review followup:[[:space:]]*PR[[:space:]]*#?([0-9]+).*/\1/p' | tail -1)
+	source_pr=$(printf '%s\n%s\n' "$issue_body" "$issue_title" | sed -En 's/.*source_pr=([0-9]+).*/\1/p; s/.*fingerprint=source-pr-([0-9]+).*/\1/p; s/.*\*\*Source PR\*\*:[[:space:]]*#?([0-9]+).*/\1/p; s/.*Review followup:[[:space:]]*PR[[:space:]]*#?([0-9]+).*/\1/p' | head -1)
 	if [[ "$source_pr" =~ ^[0-9]+$ ]]; then
 		printf '%s\n' "$source_pr"
 		return 0
@@ -990,6 +1018,11 @@ _rf_find_overlapping_paths() {
 
 _RF_KEYWORD_SCORE=0
 _RF_MATCHED_KEYWORDS=""
+_RF_SUPERSESSION_PR=""
+_RF_SUPERSESSION_MERGED_AT=""
+_RF_SUPERSESSION_OVERLAPS=""
+_RF_SUPERSESSION_MATCHED_KEYWORDS=""
+_RF_SUPERSESSION_AMBIGUOUS=""
 
 _rf_score_keywords() {
 	local keywords="$1"
@@ -1143,6 +1176,111 @@ EOF
 	return 0
 }
 
+# Evaluate same-file + finding-signal supersession without writing to GitHub.
+# This is the canonical matcher shared by pre-dispatch validation and the
+# post-merge scanner's precreation gate. Strict mode returns 20 whenever an API
+# lookup is uncertain; dispatch mode preserves the historical best-effort
+# candidate handling. Returns 10 on a clear match, 0 on no clear match, 20 on
+# strict-mode uncertainty.
+_rf_evaluate_supersession() {
+	local slug="$1"
+	local search_after="$2"
+	local issue_text="$3"
+	local issue_number="${4:-0}"
+	local strict_mode="${5:-false}"
+	local issue_paths=""
+	local keywords=""
+	local candidate_numbers=""
+	local pr_number=""
+
+	_RF_SUPERSESSION_PR=""
+	_RF_SUPERSESSION_MERGED_AT=""
+	_RF_SUPERSESSION_OVERLAPS=""
+	_RF_SUPERSESSION_MATCHED_KEYWORDS=""
+	_RF_SUPERSESSION_AMBIGUOUS=""
+
+	issue_paths=$(_rf_extract_file_paths_from_text "$issue_text")
+	[[ -n "$issue_paths" ]] || return 0
+	keywords=$(_rf_extract_keywords "$issue_text")
+	if ! candidate_numbers=$(_rf_search_merged_pr_numbers "$slug" "$search_after"); then
+		[[ "$strict_mode" == "true" ]] && return 20
+		return 0
+	fi
+	[[ -n "$candidate_numbers" ]] || return 0
+
+	while IFS= read -r pr_number; do
+		[[ "$pr_number" =~ ^[0-9]+$ ]] || continue
+		local pr_meta=""
+		local merged_at=""
+		local pr_title=""
+		local pr_body=""
+		if ! pr_meta=$(gh api "repos/${slug}/pulls/${pr_number}" --jq '[.merged_at // "", .title // "", .body // ""] | @tsv' 2>/dev/null); then
+			[[ "$strict_mode" == "true" ]] && return 20
+			continue
+		fi
+		IFS=$'\t' read -r merged_at pr_title pr_body <<<"$pr_meta"
+		if [[ -z "$merged_at" || "$merged_at" < "$search_after" || "$merged_at" == "$search_after" ]]; then
+			continue
+		fi
+
+		local pr_files=""
+		if ! pr_files=$(_rf_get_pr_files "$slug" "$pr_number"); then
+			[[ "$strict_mode" == "true" ]] && return 20
+			continue
+		fi
+		local overlaps=""
+		if ! overlaps=$(_rf_find_overlapping_paths "$issue_paths" "$pr_files"); then
+			continue
+		fi
+
+		local pr_patch=""
+		if ! pr_patch=$(_rf_get_pr_patch_text "$slug" "$pr_number"); then
+			[[ "$strict_mode" == "true" ]] && return 20
+			pr_patch=""
+		fi
+		local evidence="${pr_title}"$'\n'"${pr_body}"$'\n'"${pr_patch}"
+		_rf_score_keywords "$keywords" "$evidence"
+		if { [[ "$issue_number" =~ ^[1-9][0-9]*$ ]] && _rf_pr_references_issue "$issue_number" "$evidence"; } || [[ "$_RF_KEYWORD_SCORE" -ge 2 ]]; then
+			_RF_SUPERSESSION_PR="$pr_number"
+			_RF_SUPERSESSION_MERGED_AT="$merged_at"
+			_RF_SUPERSESSION_OVERLAPS="$overlaps"
+			_RF_SUPERSESSION_MATCHED_KEYWORDS="$_RF_MATCHED_KEYWORDS"
+			return 10
+		fi
+		_RF_SUPERSESSION_AMBIGUOUS="${_RF_SUPERSESSION_AMBIGUOUS}- PR #${pr_number} merged at ${merged_at}; same-file overlap: $(_rf_join_lines "$overlaps"); keyword matches: ${_RF_KEYWORD_SCORE}"$'\n'
+	done <<<"$candidate_numbers"
+
+	return 0
+}
+
+# Read a prospective scanner body from stdin and evaluate supersession after
+# the source PR merge. This path is read-only and fail-closed for API errors.
+cmd_check_review_supersession() {
+	local slug="$1"
+	local source_pr="$2"
+	local issue_text=""
+	local source_merged_at=""
+	local match_rc=0
+
+	if [[ -z "$slug" || ! "$source_pr" =~ ^[0-9]+$ ]]; then
+		_log_error "check-review-supersession requires <slug> <source-pr> and body on stdin"
+		return 20
+	fi
+	issue_text=$(cat)
+	if ! source_merged_at=$(_rf_get_source_pr_merged_at "$slug" "$source_pr"); then
+		_log "WARN" "source PR #${source_pr} merged_at lookup failed — precreation check blocked"
+		return 20
+	fi
+	_rf_evaluate_supersession "$slug" "$source_merged_at" "$issue_text" "0" "true" || match_rc=$?
+	if [[ "$match_rc" -eq 10 ]]; then
+		printf 'SUPERSEDED_BY_PR=%s merged_at=%s files=%s signal=%s\n' \
+			"$_RF_SUPERSESSION_PR" "$_RF_SUPERSESSION_MERGED_AT" \
+			"$(_rf_join_lines "$_RF_SUPERSESSION_OVERLAPS")" "${_RF_SUPERSESSION_MATCHED_KEYWORDS:-keywords}"
+		return 10
+	fi
+	return "$match_rc"
+}
+
 _detect_review_feedback_supersession() {
 	local issue_number="$1"
 	local slug="$2"
@@ -1159,6 +1297,10 @@ _detect_review_feedback_supersession() {
 	local issue_title=""
 	local labels=""
 	issue_meta=$(gh api "$issue_api_path" --jq '[.created_at // "", .title // "", ([.labels[]?.name] | join(","))] | @tsv' 2>/dev/null) || {
+		if printf '%s' "$issue_body" | grep -Eq 'aidevops:generator=review-followup|source:review-scanner|review-followup:PR|Unaddressed review bot suggestions'; then
+			_log "WARN" "#${issue_number}: review-followup metadata lookup failed — dispatch blocked for this cycle"
+			return 30
+		fi
 		_log "WARN" "#${issue_number}: failed to fetch issue metadata for review-feedback supersession check — dispatch proceeds"
 		return 0
 	}
@@ -1167,6 +1309,12 @@ _detect_review_feedback_supersession() {
 	if ! _rf_issue_in_supersession_scope "$issue_body" "$labels" "$issue_title"; then
 		_log "INFO" "#${issue_number}: not review-feedback/quality-debt — supersession detector skips"
 		return 0
+	fi
+
+	local duplicate_rc=0
+	_rf_canonicalize_review_followup_duplicates "$issue_number" "$slug" "$issue_body" "$issue_title" "$labels" || duplicate_rc=$?
+	if [[ "$duplicate_rc" -eq 10 || "$duplicate_rc" -eq 30 ]]; then
+		return "$duplicate_rc"
 	fi
 
 	if [[ -z "$created_at" || "$created_at" != *T* ]]; then
@@ -1180,9 +1328,6 @@ _detect_review_feedback_supersession() {
 		_log "INFO" "#${issue_number}: no cited file paths — review-feedback supersession detector skips"
 		return 0
 	fi
-
-	local keywords=""
-	keywords=$(_rf_extract_keywords "$issue_body")
 
 	local source_pr=""
 	local source_merged_at=""
@@ -1198,60 +1343,117 @@ _detect_review_feedback_supersession() {
 		fi
 	fi
 
-	local candidate_numbers=""
-	candidate_numbers=$(_rf_search_merged_pr_numbers "$slug" "$search_after") || candidate_numbers=""
-	if [[ -z "$candidate_numbers" ]]; then
-		_log "INFO" "#${issue_number}: no merged PR candidates in ${search_context} — dispatch proceeds"
+	local match_rc=0
+	_rf_evaluate_supersession "$slug" "$search_after" "$issue_body" "$issue_number" "false" || match_rc=$?
+	if [[ "$match_rc" -eq 10 ]]; then
+		_rf_close_with_supersession "$issue_number" "$slug" "$_RF_SUPERSESSION_PR" \
+			"$_RF_SUPERSESSION_MERGED_AT" "$_RF_SUPERSESSION_OVERLAPS" \
+			"$_RF_SUPERSESSION_MATCHED_KEYWORDS" "$search_context" "$source_pr"
+		return 10
+	fi
+	if [[ -n "$_RF_SUPERSESSION_AMBIGUOUS" ]]; then
+		local keywords=""
+		keywords=$(_rf_extract_keywords "$issue_body")
+		_rf_post_ambiguous_comment "$issue_number" "$slug" "$issue_paths" "$keywords" \
+			"$_RF_SUPERSESSION_AMBIGUOUS" "$search_context"
+	fi
+
+	return 0
+}
+
+_rf_close_review_followup_duplicate() {
+	local duplicate_number="$1"
+	local slug="$2"
+	local source_pr="$3"
+	local canonical_number="$4"
+	local comment_body=""
+
+	comment_body="<!-- review-followup-duplicate-canonicalized -->
+## Duplicate review follow-up
+
+This issue targets the same source PR/fingerprint as #${canonical_number} (source PR #${source_pr}). Closing it before worker launch so only the deterministic lowest-numbered canonical issue can proceed.
+
+Continue review-feedback work via #${canonical_number}."
+	if ! gh_issue_comment "$duplicate_number" --repo "$slug" --body "$comment_body" >/dev/null 2>&1; then
+		_log "WARN" "#${duplicate_number}: failed to post review-followup duplicate rationale"
+		return 1
+	fi
+	if ! gh issue close "$duplicate_number" --repo "$slug" --reason "$_PREDISPATCH_CLOSE_REASON_NOT_PLANNED" >/dev/null 2>&1; then
+		_log "WARN" "#${duplicate_number}: failed to close duplicate review-followup"
+		return 1
+	fi
+	_log "INFO" "#${duplicate_number}: closed duplicate review-followup; canonical=#${canonical_number} source_pr=#${source_pr}"
+	return 0
+}
+
+# Canonicalize legacy scanner duplicates before any worker launch. The scanner
+# emits one aggregate follow-up per source PR, so source PR is its stable
+# fingerprint; newer bodies also carry the explicit marker. Lookup uncertainty
+# is a hard dispatch block (rc=30), never permission to launch duplicate work.
+_rf_canonicalize_review_followup_duplicates() {
+	local issue_number="$1"
+	local slug="$2"
+	local issue_body="$3"
+	local issue_title="$4"
+	local labels="$5"
+	local source_pr=""
+	local issues_json=""
+	local matching_numbers=""
+	local row_number=""
+	local row_title=""
+	local row_body_b64=""
+	local row_body=""
+	local base64_decode_flag="-d"
+	[[ "$(uname -s)" == "Darwin" ]] && base64_decode_flag="-D"
+
+	if ! _rf_is_review_followup_scope "$issue_body" "$labels" "$issue_title"; then
 		return 0
 	fi
-
-	local pr_number=""
-	local ambiguous_evidence=""
-	while IFS= read -r pr_number; do
-		[[ "$pr_number" =~ ^[0-9]+$ ]] || continue
-
-		local pr_meta=""
-		local merged_at=""
-		local pr_title=""
-		local pr_body=""
-		pr_meta=$(gh api "repos/${slug}/pulls/${pr_number}" --jq '[.merged_at // "", .title // "", .body // ""] | @tsv' 2>/dev/null) || {
-			_log "WARN" "#${issue_number}: failed to fetch PR #${pr_number} metadata — skipping candidate"
-			continue
-		}
-		IFS=$'\t' read -r merged_at pr_title pr_body <<<"$pr_meta"
-
-		if [[ -z "$merged_at" || "$merged_at" < "$search_after" || "$merged_at" == "$search_after" ]]; then
-			continue
+	if ! source_pr=$(_rf_extract_source_pr_number "$issue_body" "$issue_title"); then
+		if [[ "$issue_title" == "Review followup: PR #"* \
+			|| "$issue_body" == *"aidevops:generator=review-followup"* ]]; then
+			_log "WARN" "#${issue_number}: scanner review-followup fingerprint missing — dispatch blocked"
+			return 30
 		fi
-
-		local pr_files=""
-		pr_files=$(_rf_get_pr_files "$slug" "$pr_number") || {
-			_log "WARN" "#${issue_number}: failed to fetch PR #${pr_number} files — skipping candidate"
-			continue
-		}
-
-		local overlaps=""
-		if ! overlaps=$(_rf_find_overlapping_paths "$issue_paths" "$pr_files"); then
-			continue
-		fi
-
-		local pr_patch=""
-		pr_patch=$(_rf_get_pr_patch_text "$slug" "$pr_number") || pr_patch=""
-		local evidence="${pr_title}"$'\n'"${pr_body}"$'\n'"${pr_patch}"
-		_rf_score_keywords "$keywords" "$evidence"
-
-		if _rf_pr_references_issue "$issue_number" "$evidence" || [[ "$_RF_KEYWORD_SCORE" -ge 2 ]]; then
-			_rf_close_with_supersession "$issue_number" "$slug" "$pr_number" "$merged_at" "$overlaps" "$_RF_MATCHED_KEYWORDS" "$search_context" "$source_pr"
-			return 10
-		fi
-
-		ambiguous_evidence="${ambiguous_evidence}- PR #${pr_number} merged at ${merged_at}; same-file overlap: $(_rf_join_lines "$overlaps"); keyword matches: ${_RF_KEYWORD_SCORE}"$'\n'
-	done <<<"$candidate_numbers"
-
-	if [[ -n "$ambiguous_evidence" ]]; then
-		_rf_post_ambiguous_comment "$issue_number" "$slug" "$issue_paths" "$keywords" "$ambiguous_evidence" "$search_context"
+		# Legacy/generic quality findings may carry a review-followup label
+		# without being the scanner's one-aggregate-per-source-PR contract.
+		return 0
+	fi
+	if ! issues_json=$(gh issue list --repo "$slug" --state open --limit 1000 \
+		--json number,title,body 2>/dev/null); then
+		_log "WARN" "#${issue_number}: review-followup duplicate lookup failed — dispatch blocked for this cycle"
+		return 30
+	fi
+	if ! printf '%s' "$issues_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+		_log "WARN" "#${issue_number}: malformed review-followup duplicate response — dispatch blocked"
+		return 30
 	fi
 
+	while IFS=$'\t' read -r row_number row_title row_body_b64; do
+		[[ "$row_number" =~ ^[0-9]+$ ]] || continue
+		row_body=$(printf '%s' "$row_body_b64" | base64 "$base64_decode_flag" 2>/dev/null || printf '')
+		if [[ "$(_rf_extract_source_pr_number "$row_body" "$row_title" 2>/dev/null || true)" == "$source_pr" ]]; then
+			matching_numbers="${matching_numbers}${row_number}"$'\n'
+		fi
+	done < <(printf '%s' "$issues_json" | jq -r '.[] | [.number, (.title // ""), ((.body // "") | @base64)] | @tsv')
+
+	local canonical_number=""
+	canonical_number=$(printf '%s' "$matching_numbers" | grep -E '^[0-9]+$' | sort -n | head -1 || true)
+	if ! printf '%s' "$matching_numbers" | grep -qxF "$issue_number"; then
+		_log "WARN" "#${issue_number}: current review-followup absent from duplicate enumeration — dispatch blocked"
+		return 30
+	fi
+	[[ -n "$canonical_number" ]] || return 30
+	local duplicate_count=0
+	duplicate_count=$(printf '%s' "$matching_numbers" | grep -Ec '^[0-9]+$' || true)
+	[[ "$duplicate_count" -gt 1 ]] || return 0
+
+	if [[ "$issue_number" != "$canonical_number" ]]; then
+		if ! _rf_close_review_followup_duplicate "$issue_number" "$slug" "$source_pr" "$canonical_number"; then
+			return 30
+		fi
+		return 10
+	fi
 	return 0
 }
 
@@ -1309,8 +1511,8 @@ _run_pre_generator_validators() {
 	# matches are commented and fail open so dispatch can proceed.
 	local review_feedback_rc=0
 	_detect_review_feedback_supersession "$issue_number" "$slug" "$issue_body" "$issue_api_path" || review_feedback_rc=$?
-	if [[ "$review_feedback_rc" -eq 10 ]]; then
-		return 10
+	if [[ "$review_feedback_rc" -eq 10 || "$review_feedback_rc" -eq 30 ]]; then
+		return "$review_feedback_rc"
 	fi
 	if [[ "$review_feedback_rc" -ne 0 ]]; then
 		_log "WARN" "#${issue_number}: review-feedback supersession detector returned rc=${review_feedback_rc} — dispatch proceeds"
@@ -1360,7 +1562,7 @@ cmd_validate() {
 	fi
 
 	if [[ -z "$issue_number" || -z "$slug" ]]; then
-		_log "ERROR" "validate requires <issue-number> <slug>"
+		_log_error "validate requires <issue-number> <slug>"
 		return 20
 	fi
 
@@ -1376,6 +1578,9 @@ cmd_validate() {
 	_run_pre_generator_validators "$issue_number" "$slug" "$issue_body" "$issue_api_path" || pre_generator_rc=$?
 	if [[ "$pre_generator_rc" -eq 10 ]]; then
 		return 10
+	fi
+	if [[ "$pre_generator_rc" -eq 30 ]]; then
+		return 30
 	fi
 	if [[ "$pre_generator_rc" -ne 0 ]]; then
 		_log "WARN" "#${issue_number}: pre-generator validator returned rc=${pre_generator_rc} — dispatch proceeds"
@@ -1449,12 +1654,14 @@ _usage() {
 	cat <<EOF
 Usage:
   pre-dispatch-validator-helper.sh validate <issue-number> <slug>
+  pre-dispatch-validator-helper.sh check-review-supersession <slug> <source-pr>
   pre-dispatch-validator-helper.sh help
 
 Exit codes (validate):
   0  — dispatch proceeds
   10 — premise falsified; issue closed with rationale comment
   20 — validator error; dispatch proceeds with warning
+  30 — duplicate-state lookup uncertain; dispatch must fail closed
 
 Environment:
   AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1  — bypass all validators (exit 0)
@@ -1464,9 +1671,10 @@ EOF
 
 case "${1:-help}" in
 validate) cmd_validate "${2:-}" "${3:-}" ;;
+check-review-supersession) cmd_check_review_supersession "${2:-}" "${3:-}" ;;
 help | --help | -h) _usage ;;
 *)
-	_log "ERROR" "Unknown subcommand: ${1:-}"
+	_log_error "Unknown subcommand: ${1:-}"
 	_usage
 	exit 1
 	;;

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1674,19 +1674,34 @@ dispatch_with_dedup() {
 	# GH#19118: Pre-dispatch validator — runs after dedup, before worker spawn.
 	# Checks generator-tagged auto-generated issues to verify the premise is
 	# still true. Exit 0 = dispatch proceeds; exit 10 = premise falsified
-	# (issue already closed by validator); exit 20 = validator error (dispatch
-	# proceeds with warning). Never blocks on validator bugs.
+	# (issue already closed by validator); exit 20 = optional validator error
+	# (dispatch proceeds with warning); exit 30 = duplicate-state uncertainty
+	# (fail closed for this cycle).
 	_ds_t0=$(_ds_now_ns)
 	_run_predispatch_validator "$issue_number" "$repo_slug"
 	local _validator_rc=$?
+	local _review_followup_validator_required=0
+	if printf '%s' "$issue_meta_json" | jq -e '[.labels[]?.name] | (index("review-followup") != null or index("source:review-scanner") != null)' >/dev/null 2>&1; then
+		_review_followup_validator_required=1
+	fi
 	_ds_record "$issue_number" "$repo_slug" "predispatch_validator" "$_ds_t0"
 	if [[ "$_validator_rc" -eq 10 ]]; then
 		echo "[dispatch_with_dedup] Pre-dispatch validator falsified premise for #${issue_number} in ${repo_slug} — issue closed, not dispatching" >>"$LOGFILE"
 		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "predispatch_validator_closed"
 		return 1
 	fi
+	if [[ "$_review_followup_validator_required" -eq 1 && "$_validator_rc" -ne 0 ]]; then
+		echo "[dispatch_with_dedup] Required review-followup validation failed for #${issue_number} in ${repo_slug} (rc=${_validator_rc}) — failing closed" >>"$LOGFILE"
+		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "predispatch_validator_uncertain"
+		return 1
+	fi
 	if [[ "$_validator_rc" -eq 20 ]]; then
 		echo "[dispatch_with_dedup] Pre-dispatch validator error for #${issue_number} in ${repo_slug} (rc=${_validator_rc}) — proceeding with dispatch" >>"$LOGFILE"
+	fi
+	if [[ "$_validator_rc" -eq 30 ]]; then
+		echo "[dispatch_with_dedup] Pre-dispatch duplicate lookup uncertain for #${issue_number} in ${repo_slug} — failing closed for this cycle" >>"$LOGFILE"
+		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "predispatch_validator_uncertain"
+		return 1
 	fi
 
 	# t2424/GH#20030: Generic eligibility gate — final check BEFORE worker spawn.
@@ -1858,6 +1873,7 @@ _ensure_issue_body_has_brief() {
 #   0  — dispatch proceeds (validator passed, unregistered generator, or helper missing)
 #   10 — premise falsified; caller must NOT dispatch (issue already closed by validator)
 #   20 — validator error; caller should log warning and continue dispatch
+#   30 — duplicate-state uncertainty; caller must fail closed
 #######################################
 _run_predispatch_validator() {
 	local issue_number="$1"
@@ -1866,8 +1882,8 @@ _run_predispatch_validator() {
 	local validator_helper
 	validator_helper="$(dirname "${BASH_SOURCE[0]}")/pre-dispatch-validator-helper.sh"
 	if [[ ! -x "$validator_helper" ]]; then
-		echo "[dispatch_with_dedup] GH#19118: pre-dispatch-validator-helper.sh not found — skipping (dispatch proceeds)" >>"$LOGFILE"
-		return 0
+		echo "[dispatch_with_dedup] GH#19118: pre-dispatch-validator-helper.sh not found — validator unavailable" >>"$LOGFILE"
+		return 20
 	fi
 
 	local validator_rc=0

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -757,6 +757,79 @@ test_unexpected_dedup_exit_remains_error() {
 	return 0
 }
 
+test_manual_consensus_claim_outcomes() {
+	local test_dir=""
+	test_dir=$(mktemp -d)
+	local helper="${test_dir}/dedup-helper.sh"
+	cat >"$helper" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" != "claim" ]]; then
+	exit 1
+fi
+case "${MOCK_CLAIM_RESULT:-win}" in
+win) printf '%s\n' 'CLAIM_WON: comment_id=123'; exit 0 ;;
+loss) printf '%s\n' 'CLAIM_LOST'; exit 1 ;;
+error) printf '%s\n' 'CLAIM_ERROR'; exit 2 ;;
+esac
+exit 2
+EOF
+	chmod +x "$helper"
+	local original_dedup_helper="$_DSI_DEDUP_HELPER"
+	_DSI_DEDUP_HELPER="$helper"
+
+	local rc=0
+	MOCK_CLAIM_RESULT=loss _dsi_acquire_consensus_claim 123 owner/repo runner-self >/dev/null 2>&1 || rc=$?
+	local loss_ok=1
+	[[ "$rc" -eq 1 && "$_DSI_CLAIM_WON" -eq 0 ]] && loss_ok=0
+	print_result "manual dispatch blocks a lost consensus claim" "$loss_ok" "rc=$rc won=$_DSI_CLAIM_WON"
+
+	rc=0
+	MOCK_CLAIM_RESULT=error _dsi_acquire_consensus_claim 123 owner/repo runner-self >/dev/null 2>&1 || rc=$?
+	local error_ok=1
+	[[ "$rc" -eq 1 && "$_DSI_CLAIM_WON" -eq 0 ]] && error_ok=0
+	print_result "manual dispatch fails closed on consensus claim error" "$error_ok" "rc=$rc won=$_DSI_CLAIM_WON"
+
+	rc=0
+	MOCK_CLAIM_RESULT=win _dsi_acquire_consensus_claim 123 owner/repo runner-self >/dev/null 2>&1 || rc=$?
+	local win_ok=1
+	[[ "$rc" -eq 0 && "$_DSI_CLAIM_WON" -eq 1 ]] && win_ok=0
+	print_result "manual dispatch proceeds only after consensus claim win" "$win_ok" "rc=$rc won=$_DSI_CLAIM_WON"
+
+	_DSI_CLAIM_WON=1
+	_DSI_CLAIM_COMMENT_ID=123
+	_dsi_release_consensus_claim 123 owner/repo runner-self test_failure >/dev/null 2>&1 || true
+	local release_ok=1
+	[[ "$_DSI_CLAIM_WON" -eq 0 && -z "$_DSI_CLAIM_COMMENT_ID" ]] && release_ok=0
+	print_result "manual prelaunch failure clears its claim without retaining local state" "$release_ok"
+
+	_DSI_DEDUP_HELPER="$original_dedup_helper"
+	rm -rf "$test_dir"
+	return 0
+}
+
+test_review_followup_validator_uncertainty_blocks_manual_dispatch() {
+	local test_dir=""
+	test_dir=$(mktemp -d)
+	local validator="${test_dir}/validator.sh"
+	cat >"$validator" <<'EOF'
+#!/usr/bin/env bash
+exit 20
+EOF
+	chmod +x "$validator"
+	local original_validator="$_DSI_VALIDATOR_HELPER"
+	_DSI_VALIDATOR_HELPER="$validator"
+	_DSI_ISSUE_LABELS="review-followup,source:review-scanner"
+	local rc=0
+	_dsi_run_required_predispatch_validator 123 owner/repo >/dev/null 2>&1 || rc=$?
+	local blocked=1
+	[[ "$rc" -eq 1 ]] && blocked=0
+	print_result "manual review-followup dispatch fails closed on validator uncertainty" "$blocked" "rc=$rc"
+	_DSI_VALIDATOR_HELPER="$original_validator"
+	rm -rf "$test_dir"
+	return 0
+}
+
 test_launch_worker_forwards_agent() {
 	local failed=1
 	if grep -Fq "cmd+=(--agent \"\$agent_name\")" "$HELPER_PATH"; then
@@ -1063,6 +1136,8 @@ _run_tests() {
 	test_transient_dedup_retries_are_bounded
 	test_persistent_uncertainty_does_not_retry_and_checkpoints_dryrun
 	test_unexpected_dedup_exit_remains_error
+	test_manual_consensus_claim_outcomes
+	test_review_followup_validator_uncertainty_blocks_manual_dispatch
 	test_agent_flag_parses_with_default
 	test_launch_worker_forwards_agent
 	test_launch_worker_forwards_repo_contract

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -631,10 +631,10 @@ cat >"${STUB_BIN}/gh" <<'MIXED_STUB_EOF'
 #!/usr/bin/env bash
 cmd="${1:-}"; sub="${2:-}"
 case "$cmd $sub" in
-"pr list") echo '[{"number":42}]' ;;
+"pr list") echo '42' ;;
 "api graphql") echo "simulated graphql failure" >&2; exit 1 ;;
 "api repos"*) echo '[]' ;;
-"issue list") echo '[]' ;;
+"issue list") echo '0' ;;
 "pr view") echo '{"title":"stub"}' ;;
 "repo view") echo 'stub/repo' ;;
 "label create") exit 0 ;;
@@ -761,6 +761,194 @@ else
 	echo "  FAIL: budgeted scan did not write expected cursor"
 	FAIL=$((FAIL + 1))
 fi
+install_ok_gh
+
+# -----------------------------------------------------------------------------
+# GH#27038 creation-race regressions
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "Test: issue_exists — issue-list failure is tri-state and fail-closed"
+cat >"${STUB_BIN}/gh" <<'ISSUE_EXISTS_FAIL_EOF'
+#!/usr/bin/env bash
+if [[ "${1:-} ${2:-}" == "issue list" ]]; then
+	exit 1
+fi
+exit 0
+ISSUE_EXISTS_FAIL_EOF
+chmod +x "${STUB_BIN}/gh"
+rc=0
+issue_exists stub/repo 42 >/dev/null 2>&1 || rc=$?
+assert_rc "issue lookup uncertainty returns rc=2" "2" "$rc"
+
+echo ""
+echo "Test: creation consensus claim — loss and error both block"
+claim_helper="${TMP_DIR}/claim-helper.sh"
+cat >"$claim_helper" <<'CLAIM_HELPER_EOF'
+#!/usr/bin/env bash
+case "${MOCK_CREATION_CLAIM:-win}" in
+win) printf '%s\n' 'CLAIM_WON'; exit 0 ;;
+loss) printf '%s\n' 'CLAIM_LOST'; exit 1 ;;
+*) printf '%s\n' 'CLAIM_ERROR'; exit 2 ;;
+esac
+CLAIM_HELPER_EOF
+chmod +x "$claim_helper"
+old_claim_helper="$SCANNER_CLAIM_HELPER"
+SCANNER_CLAIM_HELPER="$claim_helper"
+rc=0
+MOCK_CREATION_CLAIM=loss acquire_creation_claim stub/repo 42 runner >/dev/null 2>&1 || rc=$?
+assert_rc "losing creation claim blocks" "1" "$rc"
+rc=0
+MOCK_CREATION_CLAIM=error acquire_creation_claim stub/repo 42 runner >/dev/null 2>&1 || rc=$?
+assert_rc "creation claim error blocks" "2" "$rc"
+SCANNER_CLAIM_HELPER="$old_claim_helper"
+
+echo ""
+echo "Test: post-claim existence recheck prevents create"
+out=$(bash -c '
+set -euo pipefail
+source "$1"
+lookup_count=0
+issue_exists() {
+	local repo="$1"
+	local pr="$2"
+	: "$repo" "$pr"
+	lookup_count=$((lookup_count + 1))
+	[[ "$lookup_count" -gt 1 ]]
+	return $?
+}
+build_pr_followup_body() { local repo="$1"; local pr="$2"; : "$repo" "$pr"; printf "body"; return 0; }
+precreation_superseded() { local repo="$1"; local pr="$2"; local body="$3"; : "$repo" "$pr" "$body"; return 0; }
+acquire_creation_claim() { local repo="$1"; local pr="$2"; local runner="$3"; : "$repo" "$pr" "$runner"; return 0; }
+release_creation_claim() { local repo="$1"; local pr="$2"; local runner="$3"; local reason="$4"; : "$repo" "$pr" "$runner"; printf "RELEASE:%s\n" "$reason"; return 0; }
+create_issue() { printf "CREATE\n"; return 0; }
+gh() {
+	local command="$1"
+	local resource="$2"
+	if [[ "$command" == "api" && "$resource" == "user" ]]; then printf "runner\n"; else printf "title\n"; fi
+	return 0
+}
+_scan_one_pr stub/repo 42 false || true
+' _ "$SCANNER" 2>&1)
+assert_contains "post-claim recheck releases claim" "RELEASE:post_claim_issue_exists" "$out"
+assert_not_contains "post-claim recheck does not create" "CREATE" "$out"
+
+echo ""
+echo "Test: dry-run performs no creation-claim writes"
+out=$(bash -c '
+set -euo pipefail
+source "$1"
+issue_exists() { local repo="$1"; local pr="$2"; : "$repo" "$pr"; return 1; }
+build_pr_followup_body() { local repo="$1"; local pr="$2"; : "$repo" "$pr"; printf "body"; return 0; }
+precreation_superseded() { local repo="$1"; local pr="$2"; local body="$3"; : "$repo" "$pr" "$body"; return 0; }
+acquire_creation_claim() { printf "WRITE_CLAIM\n"; return 0; }
+release_creation_claim() { printf "WRITE_RELEASE\n"; return 0; }
+create_issue() { local repo="$1"; local pr="$2"; local title="$3"; local body="$4"; local dry_run="$5"; : "$repo" "$pr" "$title" "$body"; printf "DRY:%s\n" "$dry_run"; return 0; }
+gh() { printf "title\n"; return 0; }
+_scan_one_pr stub/repo 42 true
+' _ "$SCANNER" 2>&1)
+assert_contains "dry-run reaches read-only creation preview" "DRY:true" "$out"
+assert_not_contains "dry-run does not post creation claim" "WRITE_CLAIM" "$out"
+assert_not_contains "dry-run does not post release marker" "WRITE_RELEASE" "$out"
+
+echo ""
+echo "Test: failed create is not counted as success"
+out=$(SCANNER_CURSOR_DIR="${TMP_DIR}/failed-create-cursor" bash -c '
+set -euo pipefail
+source "$1"
+gh() {
+	local command="$1"
+	local resource="$2"
+	if [[ "$command" == "pr" && "$resource" == "list" ]]; then printf "42\n"; return 0; fi
+	if [[ "$command" == "api" && "$resource" == "user" ]]; then printf "runner\n"; return 0; fi
+	printf "title\n"
+	return 0
+}
+issue_exists() { local repo="$1"; local pr="$2"; : "$repo" "$pr"; return 1; }
+build_pr_followup_body() { local repo="$1"; local pr="$2"; : "$repo" "$pr"; printf "body"; return 0; }
+precreation_superseded() { local repo="$1"; local pr="$2"; local body="$3"; : "$repo" "$pr" "$body"; return 0; }
+acquire_creation_claim() { local repo="$1"; local pr="$2"; local runner="$3"; : "$repo" "$pr" "$runner"; return 0; }
+release_creation_claim() { local repo="$1"; local pr="$2"; local runner="$3"; local reason="$4"; : "$repo" "$pr" "$runner" "$reason"; return 0; }
+create_issue() { return 1; }
+do_scan stub/repo false
+' _ "$SCANNER" 2>&1)
+assert_contains "failed create leaves success count at zero" "Issues created: 0" "$out"
+
+echo ""
+echo "Test: successful create retains claim through search consistency window"
+out=$(bash -c '
+set -euo pipefail
+source "$1"
+lookup_count=0
+issue_exists() { local repo="$1"; local pr="$2"; : "$repo" "$pr"; lookup_count=$((lookup_count + 1)); return 1; }
+build_pr_followup_body() { local repo="$1"; local pr="$2"; : "$repo" "$pr"; printf "body"; return 0; }
+precreation_superseded() { local repo="$1"; local pr="$2"; local body="$3"; : "$repo" "$pr" "$body"; return 0; }
+acquire_creation_claim() { local repo="$1"; local pr="$2"; local runner="$3"; : "$repo" "$pr" "$runner"; return 0; }
+release_creation_claim() { printf "UNSAFE_RELEASE\n"; return 0; }
+create_issue() { SCANNER_CREATED_ISSUE_NUMBER=123; return 0; }
+record_creation_marker() { local repo="$1"; local pr="$2"; local runner="$3"; local issue="$4"; : "$repo" "$pr" "$runner"; printf "MARKER:%s\n" "$issue"; return 0; }
+gh() {
+	local command="$1"
+	local resource="$2"
+	if [[ "$command" == "api" && "$resource" == "user" ]]; then printf "runner\n"; else printf "title\n"; fi
+	return 0
+}
+_scan_one_pr stub/repo 42 false
+' _ "$SCANNER" 2>&1)
+assert_contains "successful create reports retained consistency claim" "claim retained for consistency window" "$out"
+assert_contains "successful create records durable issue marker" "MARKER:123" "$out"
+assert_not_contains "successful create does not release before search converges" "UNSAFE_RELEASE" "$out"
+
+echo ""
+echo "Test: durable source-PR marker survives delayed issue search"
+out=$(bash -c '
+set -euo pipefail
+source "$1"
+gh() {
+	local command="$1"
+	local endpoint="$2"
+	if [[ "$command" == "api" && "$endpoint" == *"/comments?"* ]]; then
+		printf "[[{\"author_association\":\"MEMBER\",\"body\":\"REVIEW_FOLLOWUP_CREATED source_pr=42 issue=123 fingerprint=source-pr-42\"}]]\n"
+		return 0
+	fi
+	if [[ "$command" == "api" && "$endpoint" == "repos/stub/repo/issues/123" ]]; then
+		printf "Review followup: PR #42 — retained\\t<!-- aidevops:generator=review-followup source_pr=42 -->\n"
+		return 0
+	fi
+	return 1
+}
+_creation_marker_issue_exists stub/repo 42
+' _ "$SCANNER" 2>&1)
+assert_contains "durable marker verifies referenced issue directly" "durable creation marker references issue #123" "$out"
+
+echo ""
+echo "Test: unresolved stale creation claim fails closed"
+rc=0
+out=$(bash -c '
+set -euo pipefail
+source "$1"
+gh() {
+	printf "[[{\"author_association\":\"MEMBER\",\"created_at\":\"2020-01-01T00:00:00Z\",\"body\":\"DISPATCH_CLAIM nonce=abc runner=runner ts=2020-01-01T00:00:00Z\"}]]\n"
+	return 0
+}
+_creation_marker_issue_exists stub/repo 42
+' _ "$SCANNER" 2>&1) || rc=$?
+assert_rc "stale unresolved creation claim returns uncertainty" "2" "$rc"
+assert_contains "stale unresolved creation claim logs fail-closed decision" "unresolved stale creation claim" "$out"
+
+echo ""
+echo "Test: indexed issue repairs missing durable marker"
+out=$(bash -c '
+set -euo pipefail
+source "$1"
+SCANNER_EXISTING_ISSUE_NUMBER=123
+_creation_marker_issue_exists() { return 1; }
+record_creation_marker() { local repo="$1"; local pr="$2"; local runner="$3"; local issue="$4"; : "$repo" "$pr" "$runner"; printf "RECOVERED:%s\n" "$issue"; return 0; }
+gh() { printf "runner\n"; return 0; }
+recover_creation_marker stub/repo 42 false
+' _ "$SCANNER" 2>&1)
+assert_contains "existing issue repairs missing source-PR marker" "RECOVERED:123" "$out"
+
 install_ok_gh
 
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
+++ b/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER_SCRIPT="${SCRIPT_DIR}/../pre-dispatch-validator-helper.sh"
+PULSE_CORE="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
 
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -76,8 +77,11 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/issues/* && "$endpoin
 	case "$arg_string" in
 	*'.body // ""'*)
 		case "$scenario" in
-		source-clear | source-ambiguous | source-fetch-failure)
+		source-clear | source-ambiguous | source-fetch-failure | duplicate-later | duplicate-canonical | duplicate-lookup-failure)
 			printf '**Source PR**: #50\n\n## Files to modify\n- `.agents/scripts/review-hook.sh`\n\n## Finding\nAdd the event payload guard before worker launch.\n'
+			;;
+		marker-only-duplicate | duplicate-current-absent)
+			printf '<!-- aidevops:generator=review-followup source_pr=50 fingerprint=source-pr-50 -->\n\n## Files to modify\n- `.agents/scripts/review-hook.sh`\n'
 			;;
 		malformed-source-clear)
 			printf '**Source PR**: pending\n\n## Files to modify\n- `.agents/scripts/review-hook.sh`\n\n## Finding\nAdd the event payload guard before worker launch.\n'
@@ -92,6 +96,9 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/issues/* && "$endpoin
 		;;
 	*'@tsv'*)
 		case "$scenario" in
+		duplicate-later | duplicate-canonical | duplicate-lookup-failure | marker-only-duplicate | duplicate-current-absent)
+			printf '2026-05-02T10:00:00Z\tReview followup: PR #50 — event payload guard\treview-followup,source:review-scanner,tier:standard\n'
+			;;
 		source-clear | source-ambiguous | source-fetch-failure | no-file)
 			printf '2026-05-02T10:00:00Z\treview-feedback: event payload guard\tquality-debt,source:review-feedback,tier:thinking\n'
 			;;
@@ -120,6 +127,7 @@ fi
 
 if [[ "${1:-}" == "api" && "$endpoint" == "search/issues" ]]; then
 	case "$scenario" in
+	precreation-search-failure) exit 1 ;;
 	clear) printf '200\n' ;;
 	ambiguous) printf '201\n' ;;
 	source-clear) printf '200\n' ;;
@@ -176,6 +184,30 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/pulls/*/files ]]; the
 		201) printf '.agents/scripts/review-hook.sh\n+ rename log_context to context_label\n' ;;
 		*) printf '' ;;
 		esac
+		;;
+	esac
+	exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+	case "$scenario" in
+	duplicate-later)
+		printf '[{"number":99,"title":"Review followup: PR #50 — first","body":"**Source PR**: #50"},{"number":100,"title":"Review followup: PR #50 — duplicate","body":"**Source PR**: #50"}]\n'
+		;;
+	duplicate-canonical)
+		printf '[{"number":100,"title":"Review followup: PR #50 — first","body":"**Source PR**: #50"},{"number":101,"title":"Review followup: PR #50 — duplicate","body":"**Source PR**: #50"}]\n'
+		;;
+	duplicate-lookup-failure)
+		exit 1
+		;;
+	marker-only-duplicate)
+		printf '[{"number":99,"title":"edited title","body":"<!-- aidevops:generator=review-followup source_pr=50 fingerprint=source-pr-50 -->"},{"number":100,"title":"another edited title","body":"<!-- aidevops:generator=review-followup source_pr=50 fingerprint=source-pr-50 -->"}]\n'
+		;;
+	duplicate-current-absent)
+		printf '[{"number":99,"title":"edited title","body":"<!-- aidevops:generator=review-followup source_pr=50 fingerprint=source-pr-50 -->"}]\n'
+		;;
+	*)
+		printf '[{"number":100,"title":"Review followup: PR #50 — current","body":"**Source PR**: #50"}]\n'
 		;;
 	esac
 	exit 0
@@ -293,6 +325,77 @@ test_merged_pr_before_issue_creation() {
 	return 0
 }
 
+test_precreation_source_pr_window() {
+	local output_file="${TEST_ROOT}/precreation.out"
+	local rc=0
+	export STUB_SCENARIO="source-clear"
+	printf '%s\n' '## Files to modify' "- \`.agents/scripts/review-hook.sh\`" 'Add the event payload guard before worker launch.' |
+		"$HELPER_SCRIPT" check-review-supersession owner/repo 50 >"$output_file" 2>&1 || rc=$?
+	if [[ "$rc" -eq 10 ]] && grep -qF 'SUPERSEDED_BY_PR=200' "$output_file"; then
+		print_result "precreation supersession uses source PR merge window" 0
+	else
+		print_result "precreation supersession uses source PR merge window" 1 "rc=${rc}; output=$(tr '\n' ' ' <"$output_file")"
+	fi
+	return 0
+}
+
+test_precreation_api_uncertainty_fails_closed() {
+	local output_file="${TEST_ROOT}/precreation-uncertain.out"
+	local rc=0
+	export STUB_SCENARIO="precreation-search-failure"
+	printf '%s\n' '## Files to modify' "- \`.agents/scripts/review-hook.sh\`" 'Add the event payload guard before worker launch.' |
+		"$HELPER_SCRIPT" check-review-supersession owner/repo 50 >"$output_file" 2>&1 || rc=$?
+	if [[ "$rc" -eq 20 ]]; then
+		print_result "precreation API uncertainty fails closed" 0
+	else
+		print_result "precreation API uncertainty fails closed" 1 "rc=${rc}; output=$(tr '\n' ' ' <"$output_file")"
+	fi
+	return 0
+}
+
+test_legacy_duplicate_noncanonical_closes() {
+	run_validator_case "duplicate-later" 10 "legacy duplicate noncanonical issue"
+	assert_log_contains "legacy duplicate closes later issue" "issue close 100 --repo owner/repo --reason not planned"
+	return 0
+}
+
+test_legacy_duplicate_canonical_does_not_mutate_peers() {
+	run_validator_case "duplicate-canonical" 0 "legacy duplicate canonical issue"
+	assert_log_not_contains "canonical issue leaves later duplicate for its own validator" "issue close 101 --repo owner/repo --reason not planned"
+	return 0
+}
+
+test_legacy_duplicate_lookup_fails_closed() {
+	run_validator_case "duplicate-lookup-failure" 30 "legacy duplicate lookup uncertainty"
+	assert_log_not_contains "lookup uncertainty does not close without evidence" "issue close 100"
+	return 0
+}
+
+test_explicit_fingerprint_survives_title_and_label_drift() {
+	run_validator_case "marker-only-duplicate" 10 "explicit review-followup fingerprint"
+	assert_log_contains "explicit fingerprint closes noncanonical current issue" "issue close 100 --repo owner/repo --reason not planned"
+	return 0
+}
+
+test_current_issue_absent_from_enumeration_fails_closed() {
+	run_validator_case "duplicate-current-absent" 30 "current issue absent from duplicate enumeration"
+	assert_log_not_contains "absent current issue does not mutate peers" "issue close 99"
+	return 0
+}
+
+test_pulse_blocks_duplicate_lookup_uncertainty() {
+	# shellcheck disable=SC2016 # Match literal shell source expressions.
+	if grep -qF "if [[ \"\$_validator_rc\" -eq 30 ]]" "$PULSE_CORE" \
+		&& grep -qF '$_review_followup_validator_required" -eq 1 && "$_validator_rc" -ne 0' "$PULSE_CORE" \
+		&& grep -qF 'predispatch_validator_uncertain' "$PULSE_CORE" \
+		&& grep -qF 'return 20' "$PULSE_CORE"; then
+		print_result "pulse blocks all required review-followup validator failures and releases its claim" 0
+	else
+		print_result "pulse blocks all required review-followup validator failures and releases its claim" 1
+	fi
+	return 0
+}
+
 main() {
 	printf 'Running review-feedback supersession validator tests (t3569, GH#23101)...\n\n'
 
@@ -312,6 +415,14 @@ main() {
 	test_no_file_finding_skips_supersession
 	test_no_matching_pr
 	test_merged_pr_before_issue_creation
+	test_precreation_source_pr_window
+	test_precreation_api_uncertainty_fails_closed
+	test_legacy_duplicate_noncanonical_closes
+	test_legacy_duplicate_canonical_does_not_mutate_peers
+	test_legacy_duplicate_lookup_fails_closed
+	test_explicit_fingerprint_survives_title_and_label_drift
+	test_current_issue_absent_from_enumeration_fails_closed
+	test_pulse_blocks_duplicate_lookup_uncertainty
 	teardown_test_env
 
 	printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Move review-followup supersession and deduplication ahead of issue creation, coordinate scanner and manual dispatch across machines, persist durable creation fingerprints, and fail closed on uncertain duplicate state.

## Files Changed

.agents/reference/cross-runner-coordination.md, .agents/scripts/dispatch-single-issue-helper.sh, .agents/scripts/post-merge-review-scanner.sh, .agents/scripts/pre-dispatch-validator-helper.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/tests/test-dispatch-single-issue-helper.sh, .agents/scripts/tests/test-post-merge-review-scanner.sh, .agents/scripts/tests/test-review-feedback-supersession-validator.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Scanner tests 71/71; supersession tests 34/34; manual dispatch tests 58/58; pre-dispatch tests 16/16; claim tests 57/57; cross-runner tests 44/44; ShellCheck clean; pulse canary 5/5; no new string-literal or Bash 3.2 regressions.

Resolves #27038


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.16 with gpt-5.6-sol spent 1h 38m and 1,061,188 tokens on this with the user in an interactive session.