### PR TITLE
GH#27057: install durable aidevops CLI entrypoint

### DIFF
--- a/.agents/scripts/setup/modules/config.sh
+++ b/.agents/scripts/setup/modules/config.sh
@@ -34,6 +34,27 @@ setup_configs() {
 	return 0
 }
 
+_install_aidevops_cli_copy() {
+	local cli_source="$1"
+	local cli_target="$2"
+	local use_sudo="${3:-false}"
+	local cli_temp="${cli_target}.tmp.$$"
+
+	if [[ "$use_sudo" == "true" ]]; then
+		if sudo install -m 0755 "$cli_source" "$cli_temp" && sudo mv -f "$cli_temp" "$cli_target"; then
+			return 0
+		fi
+		sudo rm -f "$cli_temp" 2>/dev/null || true
+		return 1
+	fi
+
+	if install -m 0755 "$cli_source" "$cli_temp" && mv -f "$cli_temp" "$cli_target"; then
+		return 0
+	fi
+	rm -f "$cli_temp" 2>/dev/null || true
+	return 1
+}
+
 install_aidevops_cli() {
 	print_info "Installing aidevops CLI command..."
 
@@ -49,13 +70,14 @@ install_aidevops_cli() {
 
 	# Check if we can write to /usr/local/bin
 	if [[ -w "/usr/local/bin" ]]; then
-		# Direct symlink
-		ln -sf "$cli_source" "$cli_target"
+		# Install a standalone entrypoint. Symlinking here makes the command depend
+		# on the release worktree or temporary checkout that happened to run setup.
+		_install_aidevops_cli_copy "$cli_source" "$cli_target"
 		print_success "Installed aidevops command to $cli_target"
 	elif [[ -w "$HOME/.local/bin" ]] || mkdir -p "$HOME/.local/bin" 2>/dev/null; then
 		# Use ~/.local/bin instead
 		cli_target="$HOME/.local/bin/aidevops"
-		ln -sf "$cli_source" "$cli_target"
+		_install_aidevops_cli_copy "$cli_source" "$cli_target"
 		print_success "Installed aidevops command to $cli_target"
 
 		# Check if ~/.local/bin is in PATH and add it if not
@@ -65,7 +87,7 @@ install_aidevops_cli() {
 	else
 		# Need sudo
 		print_info "Installing aidevops command requires sudo..."
-		if sudo ln -sf "$cli_source" "$cli_target"; then
+		if _install_aidevops_cli_copy "$cli_source" "$cli_target" true; then
 			print_success "Installed aidevops command to $cli_target"
 		else
 			print_warning "Could not install aidevops command globally"

--- a/.agents/scripts/tests/test-setup-aidevops-cli-install.sh
+++ b/.agents/scripts/tests/test-setup-aidevops-cli-install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+CONFIG_LIB="${REPO_ROOT}/.agents/scripts/setup/modules/config.sh"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/aidevops-cli-install.XXXXXX")"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+print_info() { return 0; }
+print_success() { return 0; }
+print_warning() { return 0; }
+
+# shellcheck source=../setup/modules/config.sh
+source "$CONFIG_LIB"
+
+source_cli="$TEST_DIR/source-cli"
+target_cli="$TEST_DIR/bin/aidevops"
+old_target="$TEST_DIR/old-target"
+mkdir -p "$TEST_DIR/bin"
+printf '#!/usr/bin/env bash\nprintf "current\\n"\n' >"$source_cli"
+printf 'old\n' >"$old_target"
+chmod 0755 "$source_cli"
+ln -s "$old_target" "$target_cli"
+
+_install_aidevops_cli_copy "$source_cli" "$target_cli"
+
+if [[ -L "$target_cli" ]]; then
+	printf 'FAIL: installed CLI remains a symlink\n' >&2
+	exit 1
+fi
+if [[ ! -x "$target_cli" ]]; then
+	printf 'FAIL: installed CLI is not executable\n' >&2
+	exit 1
+fi
+if [[ "$("$target_cli")" != "current" ]]; then
+	printf 'FAIL: installed CLI does not contain the current entrypoint\n' >&2
+	exit 1
+fi
+if [[ "$(tr -d '\n' <"$old_target")" != "old" ]]; then
+	printf 'FAIL: replacing the symlink modified its former target\n' >&2
+	exit 1
+fi
+
+printf 'PASS: setup installs an executable standalone CLI atomically\n'

--- a/TODO.md
+++ b/TODO.md
@@ -1123,6 +1123,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18086 Strip image placeholders from OpenCode session titles #bug ref:GH#27036
 
+- [ ] t18091 Install aidevops CLI independently of release worktrees #auto-dispatch #bug ref:GH#27057
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Replace setup-created CLI symlinks with atomic standalone executable copies so updates do not depend on removable release worktrees.

## Files Changed

.agents/scripts/setup/modules/config.sh, .agents/scripts/tests/test-setup-aidevops-cli-install.sh, TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused CLI install regression passed under Bash; ShellCheck, shfmt, bash -n, and setup regression suites passed. Full local lint found only pre-existing repository-wide complexity debt and infrastructure timeouts.

Resolves #27057


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.17 with gpt-5.6-sol spent 1h 48m and 2,036,802 tokens on this with the user in an interactive session.