### PR TITLE
GH#27016: improve human-attention learning reliability

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -34,6 +34,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 ### Mission and style
 
 - Maximise development/operations ROI: leverage, efficiency, self-healing, gap awareness, verified outcomes, traceable git history.
+- Treat human attention as the scarcest resource: use AI context, compute, tools, and verification to resolve safe work autonomously; interrupt people only for taste, inaccessible context, consequential ambiguity, authority, or unknown secrets. Detailed responsibility and escalation model: `reference/self-improvement.md`.
 - Never generate or guess URLs. Use only URLs from user messages, tool output, or files.
 - Short, objective, GitHub-flavoured Markdown. No emojis unless requested. No preamble/postamble. Turn-end progress/status ≤200 words.
 - Every prompt, issue, PR, comment, and brief is mentorship: include file, pattern, and verification context.
@@ -46,6 +47,8 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Use TodoWrite for multi-step work. Mark one task in progress and complete items immediately.
 - Infer task intent: `/full-loop` or "work on this now" means implement now; "background/worker" means create a worker-ready brief and auto-dispatch; "later/save/log" means brief for later and ask numbered dispatch options. Task and issue bodies use `workflows/brief.md`. Details: `reference/task-lifecycle.md`.
 - Keep interactive subagents off the critical path and bounded; prefix delegated prompts with the lowest sufficient `[effort:simple|standard|thinking]`; details: `reference/agent-routing.md`.
+- When a context-rich session has already established safe, actionable work and the user authorises execution, preserve momentum through implementation and verification in that session; do not defer merely to reduce the current session's scope.
+- Run long checks and waits in the background when the runtime permits; poll at bounded intervals, act on completed gates promptly, and keep the user informed instead of disappearing behind one foreground command. Details: `reference/self-improvement.md`.
 - When UI/UX, branding, iconography, or visual preferences change during a session, update the repo `DESIGN.md` in the same PR or create a worker-ready follow-up if blocked.
 - During in-progress work, classify new user messages before acting: immediate correction/steerage changes the active plan; supplemental context is retained/applied when relevant; follow-up work becomes a todo after the current work reaches a safe pause or completion point.
 - Interactive sessions with active prior task context: if the user starts a clearly unrelated objective where clean context would materially help, briefly recommend `/new` or a new tab and ask whether to continue here. Details: `reference/session.md`.

--- a/.agents/aidevops/graduated-learnings.md
+++ b/.agents/aidevops/graduated-learnings.md
@@ -9,7 +9,7 @@ tools: { read: true, write: false, edit: false, bash: false, glob: false, grep: 
 
 # Graduated Learnings
 
-Validated patterns promoted from local memory (3+ accesses or high confidence).
+Validated, live, shareable patterns promoted from local memory (3+ accesses or high confidence). Personal `USER_PREFERENCE` records remain scoped and never auto-graduate into all-user guidance.
 Manage: `memory-graduate-helper.sh` · `memory-helper.sh graduate [candidates|graduate|status]`
 
 ## Anti-Patterns

--- a/.agents/reference/memory.md
+++ b/.agents/reference/memory.md
@@ -90,7 +90,7 @@ Runs on every `store` (at most once per 24h). Removes entries older than 90 days
 
 ## Semantic Search (Opt-in)
 
-Providers: `local` (all-MiniLM-L6-v2, 384d, Python 3.9+ sentence-transformers ~90MB) or `openai` (text-embedding-3-small, 1536d, requires API key). Search modes: keyword (default, FTS5 BM25), `--semantic` (vector similarity), `--hybrid` (keyword + semantic via RRF). Hybrid recommended for natural language queries. New memories auto-indexed once configured. See CLI Reference for setup commands.
+Providers: `local` (all-MiniLM-L6-v2, 384d, Python 3.9+ sentence-transformers ~90MB) or `openai` (text-embedding-3-small, 1536d, requires API key). Search modes: keyword (default, FTS5 BM25), `--semantic` (vector similarity), `--hybrid` (keyword + semantic via RRF). Semantic and hybrid results exclude debunked, retracted, and superseded memories. Until their query engine supports the keyword path's scope filters, combining semantic/hybrid mode with `--type`, `--project`, `--entity`, `--max-age-days`, capture-source filters, or `--shared` fails closed; use keyword recall for those queries. Hybrid is recommended for unscoped natural-language queries. New memories auto-indexed once configured. See CLI Reference for setup commands.
 
 ## Retrieval Feedback Loop
 
@@ -113,7 +113,7 @@ Handled by cross-session memory and pulse supervisor outcome observation (Step 2
 
 ## Memory Graduation
 
-Graduate validated local memories (`confidence = "high"` OR `access_count >= 3`) into shared docs. Appends to `.agents/aidevops/graduated-learnings.md`. **Slash command**: `/graduate-memories` or `/graduate-memories --dry-run`. See CLI Reference for commands.
+Graduate validated, live, unsuperseded local memories (`confidence = "high"` OR `access_count >= 3`) into shared docs. `USER_PREFERENCE` memories remain in their user/project scope and never auto-graduate into all-user guidance. Appends to `.agents/aidevops/graduated-learnings.md`. **Slash command**: `/graduate-memories` or `/graduate-memories --dry-run`. See CLI Reference for commands.
 
 ## Memory Audit Pulse
 

--- a/.agents/reference/self-improvement.md
+++ b/.agents/reference/self-improvement.md
@@ -3,7 +3,18 @@
 
 # Self-Improvement
 
-Every session must improve the system. Fix the process, not the symptom.
+Every session should deliver verified value or leave an auditable signal. Fix the process, not the symptom, but promote only scoped, reusable, evidence-backed learning rather than preserving every observation.
+
+## Human Attention and Responsibility
+
+Optimise for **verified value per unit of human attention**. Human time is a constrained, high-value input, not a routine approval mechanism.
+
+- **AI owns routine leverage:** remember details, inspect accumulated context, discover opportunities, compare options, estimate risk, implement and verify reversible improvements, measure outcomes, and maintain consistency across the harness.
+- **Humans supply exclusive inputs:** taste, lived experience, inaccessible or offline context, personal values, feedback from reality, and authority for consequential or irreversible commitments.
+- **Escalate by expected value:** before interrupting, determine whether existing evidence, a safe test, a reversible action, or a scoped inference can resolve the question. Ask only when human input is materially irreplaceable.
+- **Learn preferences autonomously:** infer and apply low-risk, reversible preferences within the narrowest supported scope. Seek confirmation when preferences conflict, scope is materially uncertain, or consequences are difficult to reverse. Personal evidence must not silently become universal policy.
+- **Make autonomous work observable:** launch long checks, CI waits, and worker monitoring in the background when possible; poll at bounded intervals, process results as soon as they are terminal, and report meaningful gate transitions. A synchronous foreground wait that leaves the user unable to distinguish work from a stall wastes attention.
+- **Measure returned time:** track useful work completed, recurring work eliminated, interruptions avoided, correction rate, and free time created—not merely tasks, tokens, or memories accumulated.
 
 ## Core Workflow
 
@@ -49,6 +60,7 @@ Use `framework-issue-helper.sh`, not `claim-task-id.sh`:
 Treat valuable session learning as system input, not disposable transcript context. Outliers are expensive to find intentionally; when one appears during normal work, convert it into reusable system knowledge before it evaporates.
 
 - **Apply now** when the lesson directly improves the user's requested aim without widening risk.
+- **Preserve context momentum:** when the session has enough evidence, authorization, and safe execution paths, continue through implementation and verification instead of handing reconstruction cost to a future session. Defer only for a real dependency, safety boundary, resource fuse, or explicit user choice.
 - **Brief for workers** when the lesson exposes a fixable bug, missing validator, missing doc, recurring failure mode, or automation gap. Use worker-ready context: files, pattern, evidence, verification, and an explicit note when paths are unknown.
 - **Store memory/reference** when the lesson is reusable but not immediately dispatchable, especially diagnostics, edge cases, duplicate patterns, and "similar but different" hazards.
 - **Route design learning by scope:** durable repo-specific UI patterns belong in that repo's `DESIGN.md`; generic aidevops briefing/verification patterns become aidevops issues with anonymised evidence; uncertain or broad design lessons become worker-ready follow-ups instead of bloating global docs.

--- a/.agents/scripts/conversation-helper-context.sh
+++ b/.agents/scripts/conversation-helper-context.sh
@@ -34,6 +34,19 @@ fi
 # --- Context Functions ---
 
 #######################################
+# Redact sensitive values from a complete context payload.
+# Args: payload
+#######################################
+_conversation_redact_context_payload() {
+	local payload="$1"
+	printf '%s\n' "$payload" | sed -E \
+		-e 's/[[:alnum:]._+%-]+@[[:alnum:].-]+\.[[:alpha:]]{2,}/[EMAIL]/g' \
+		-e 's/([[:digit:]]{1,3}\.){3}[[:digit:]]{1,3}/[IP]/g' \
+		-e 's/sk-[[:alnum:]_-]{20,}/[API_KEY]/g'
+	return 0
+}
+
+#######################################
 # Output conversation context as JSON
 # Args: esc_id esc_entity recent_messages
 #######################################
@@ -187,10 +200,10 @@ EOF
 		echo "  (no messages yet)"
 	else
 		if [[ "$privacy_filter" == true ]]; then
-			messages=$(echo "$messages" | sed \
-				-e 's/[a-zA-Z0-9._%+-]\+@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}/[EMAIL]/g' \
-				-e 's/\b[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\b/[IP]/g' \
-				-e 's/sk-[a-zA-Z0-9_-]\{20,\}/[API_KEY]/g')
+			messages=$(printf '%s\n' "$messages" | sed -E \
+				-e 's/[[:alnum:]._+%-]+@[[:alnum:].-]+\.[[:alpha:]]{2,}/[EMAIL]/g' \
+				-e 's/([[:digit:]]{1,3}\.){3}[[:digit:]]{1,3}/[IP]/g' \
+				-e 's/sk-[[:alnum:]_-]{20,}/[API_KEY]/g')
 		fi
 		echo "$messages"
 	fi
@@ -304,11 +317,18 @@ EOF
 	local esc_entity
 	esc_entity=$(conv_sql_escape "$entity_id")
 
+	local context_output=""
 	if [[ "$format" == "json" ]]; then
-		_context_output_json "$esc_id" "$esc_entity" "$recent_messages"
+		context_output=$(_context_output_json "$esc_id" "$esc_entity" "$recent_messages")
 	else
-		_context_output_text "$esc_id" "$esc_entity" "$entity_name" "$entity_type" \
-			"$channel" "$topic" "$recent_messages" "$privacy_filter"
+		context_output=$(_context_output_text "$esc_id" "$esc_entity" "$entity_name" "$entity_type" \
+			"$channel" "$topic" "$recent_messages" "$privacy_filter")
+	fi
+
+	if [[ "$privacy_filter" == true ]]; then
+		_conversation_redact_context_payload "$context_output"
+	else
+		printf '%s\n' "$context_output"
 	fi
 
 	return 0

--- a/.agents/scripts/entity-interaction-lib.sh
+++ b/.agents/scripts/entity-interaction-lib.sh
@@ -217,6 +217,19 @@ cmd_log_interaction() {
 # =============================================================================
 
 #######################################
+# Redact sensitive values from a complete entity context payload.
+# Args: payload
+#######################################
+_entity_redact_context_payload() {
+	local payload="$1"
+	printf '%s\n' "$payload" | sed -E \
+		-e 's/[[:alnum:]._+%-]+@[[:alnum:].-]+\.[[:alpha:]]{2,}/[EMAIL]/g' \
+		-e 's/([[:digit:]]{1,3}\.){3}[[:digit:]]{1,3}/[IP]/g' \
+		-e 's/sk-[[:alnum:]_-]{20,}/[API_KEY]/g'
+	return 0
+}
+
+#######################################
 # Emit JSON context for an entity (entity + channels + profile + interactions).
 # Args: esc_id channel_clause limit
 #######################################
@@ -315,11 +328,11 @@ EOF
 		echo "  (no interactions)"
 	else
 		if [[ "$privacy_filter" == true ]]; then
-			# Apply privacy filtering to output (sed required: regex quantifiers/char classes/word boundaries)
-			interactions=$(sed \
-				-e 's/[a-zA-Z0-9._%+-]\+@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}/[EMAIL]/g' \
-				-e 's/\b[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\b/[IP]/g' \
-				-e 's/sk-[a-zA-Z0-9_-]\{20,\}/[API_KEY]/g' <<<"$interactions")
+			# POSIX ERE keeps output filtering portable across BSD and GNU sed.
+			interactions=$(printf '%s\n' "$interactions" | sed -E \
+				-e 's/[[:alnum:]._+%-]+@[[:alnum:].-]+\.[[:alpha:]]{2,}/[EMAIL]/g' \
+				-e 's/([[:digit:]]{1,3}\.){3}[[:digit:]]{1,3}/[IP]/g' \
+				-e 's/sk-[[:alnum:]_-]{20,}/[API_KEY]/g')
 		fi
 		echo "$interactions"
 	fi
@@ -374,10 +387,17 @@ cmd_context() {
 		channel_clause="AND i.channel = '$(sql_escape "$channel_filter")'"
 	fi
 
+	local context_output=""
 	if [[ "$format" == "json" ]]; then
-		_context_json "$esc_id" "$channel_clause" "$limit"
+		context_output=$(_context_json "$esc_id" "$channel_clause" "$limit")
 	else
-		_context_text "$entity_id" "$esc_id" "$channel_clause" "$limit" "$privacy_filter"
+		context_output=$(_context_text "$entity_id" "$esc_id" "$channel_clause" "$limit" "$privacy_filter")
+	fi
+
+	if [[ "$privacy_filter" == true ]]; then
+		_entity_redact_context_payload "$context_output"
+	else
+		printf '%s\n' "$context_output"
 	fi
 
 	return 0

--- a/.agents/scripts/memory-embeddings-helper-engine.sh
+++ b/.agents/scripts/memory-embeddings-helper-engine.sh
@@ -244,6 +244,38 @@ PYEOF
 }
 
 #######################################
+# Write Python truth-maintenance predicate shared by semantic/hybrid search.
+#######################################
+_write_python_truth_filter() {
+	cat >>"$PYTHON_SCRIPT" <<'PYEOF'
+
+def _memory_is_live(mem_conn, memory_id: str) -> bool:
+    """Return True only for current memories that have not been retracted."""
+    row = mem_conn.execute(
+        """SELECT 1
+           FROM learnings l
+           WHERE l.id = ?
+             AND COALESCE((
+                 SELECT status
+                 FROM learning_truth_events truth_pick
+                 WHERE truth_pick.memory_id = l.id
+                 ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC
+                 LIMIT 1
+             ), 'live') NOT IN ('debunked', 'retracted')
+             AND NOT EXISTS (
+                 SELECT 1
+                 FROM learning_relations superseded_by
+                 WHERE superseded_by.supersedes_id = l.id
+                   AND superseded_by.relation_type = 'updates'
+             )""",
+        (memory_id,)
+    ).fetchone()
+    return row is not None
+PYEOF
+	return 0
+}
+
+#######################################
 # Write Python engine: DB init and cmd_embed/cmd_search
 #######################################
 _write_python_db_and_search() {
@@ -305,12 +337,14 @@ def cmd_search(provider: str, embeddings_db: str, memory_db: str, query: str, li
         results.append((memory_id, score))
 
     results.sort(key=lambda x: x[1], reverse=True)
-    top_results = results[:limit]
 
-    # Fetch memory content for top results
+    # Fetch only current memory content. Continue past stale top-ranked vectors
+    # until the requested number of live results has been collected.
     mem_conn = sqlite3.connect(memory_db)
     output = []
-    for memory_id, score in top_results:
+    for memory_id, score in results:
+        if not _memory_is_live(mem_conn, memory_id):
+            continue
         row = mem_conn.execute(
             "SELECT content, type, tags, confidence, created_at FROM learnings WHERE id = ?",
             (memory_id,)
@@ -326,6 +360,8 @@ def cmd_search(provider: str, embeddings_db: str, memory_db: str, query: str, li
                 "score": round(score, 4),
                 "search_method": "semantic",
             })
+            if len(output) >= limit:
+                break
     mem_conn.close()
     print(json.dumps(output))
 PYEOF
@@ -338,8 +374,8 @@ PYEOF
 _write_python_hybrid_semantic() {
 	cat >>"$PYTHON_SCRIPT" <<'PYEOF'
 
-def _hybrid_semantic_search(provider: str, embeddings_db: str, query: str, semantic_limit: int) -> list:
-    """Return top semantic candidates as [(memory_id, score)] sorted desc."""
+def _hybrid_semantic_search(provider: str, embeddings_db: str, query: str) -> list:
+    """Return all semantic candidates sorted desc for later truth filtering."""
     dim = get_embedding_dim(provider)
     query_embedding = embed_text(query, provider)
 
@@ -358,7 +394,7 @@ def _hybrid_semantic_search(provider: str, embeddings_db: str, query: str, seman
         results.append((memory_id, score))
 
     results.sort(key=lambda x: x[1], reverse=True)
-    return results[:semantic_limit]
+    return results
 PYEOF
 	return 0
 }
@@ -379,6 +415,17 @@ def _hybrid_fts5_search(mem_conn, query: str, semantic_limit: int) -> list:
             """SELECT id, bm25(learnings) as score
                FROM learnings
                WHERE learnings MATCH ?
+                 AND COALESCE((
+                     SELECT status FROM learning_truth_events truth_pick
+                     WHERE truth_pick.memory_id = learnings.id
+                     ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC
+                     LIMIT 1
+                 ), 'live') NOT IN ('debunked', 'retracted')
+                 AND NOT EXISTS (
+                     SELECT 1 FROM learning_relations superseded_by
+                     WHERE superseded_by.supersedes_id = learnings.id
+                       AND superseded_by.relation_type = 'updates'
+                 )
                ORDER BY score
                LIMIT ?""",
             (fts_query, semantic_limit)
@@ -452,12 +499,16 @@ def cmd_hybrid(provider: str, embeddings_db: str, memory_db: str, query: str, li
     """Hybrid search: combine FTS5 BM25 + semantic similarity using Reciprocal Rank Fusion."""
     semantic_limit = limit * 3
 
-    semantic_results = _hybrid_semantic_search(provider, embeddings_db, query, semantic_limit)
+    semantic_results = _hybrid_semantic_search(provider, embeddings_db, query)
 
     mem_conn = sqlite3.connect(memory_db)
     mem_conn.execute("PRAGMA busy_timeout=5000")
 
     try:
+        semantic_results = [
+            candidate for candidate in semantic_results
+            if _memory_is_live(mem_conn, candidate[0])
+        ][:semantic_limit]
         fts_results = _hybrid_fts5_search(mem_conn, query, semantic_limit)
         usefulness_lookup = _hybrid_usefulness_lookup(mem_conn, semantic_results, fts_results)
 
@@ -738,6 +789,7 @@ create_python_engine() {
 	: >"$PYTHON_SCRIPT"
 	_write_python_header
 	_write_python_embed_functions
+	_write_python_truth_filter
 	_write_python_db_and_search
 	_write_python_hybrid_semantic
 	_write_python_hybrid_fts5

--- a/.agents/scripts/memory-graduate-helper.sh
+++ b/.agents/scripts/memory-graduate-helper.sh
@@ -9,6 +9,7 @@
 #
 # Graduation criteria (configurable):
 #   - High confidence OR frequently accessed (access_count >= threshold)
+#   - Live, unsuperseded, and not a personal USER_PREFERENCE
 #   - Not already graduated
 #   - Content is actionable (not just session metadata)
 #
@@ -78,6 +79,23 @@ ensure_schema() {
 		return 1
 	fi
 
+	local has_truth_tables
+	has_truth_tables=$(db "$MEMORY_DB" \
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('learning_truth_events', 'learning_relations');" \
+		2>/dev/null || echo "0")
+	if [[ "$has_truth_tables" != "2" ]]; then
+		local memory_helper="$SCRIPT_DIR/memory-helper.sh"
+		if [[ ! -x "$memory_helper" ]]; then
+			log_error "Memory migration helper not found: $memory_helper"
+			return 1
+		fi
+		log_info "Migrating memory truth-maintenance schema before graduation..."
+		if ! AIDEVOPS_MEMORY_DIR="$MEMORY_DIR" "$memory_helper" validate >/dev/null 2>&1; then
+			log_error "Memory schema migration failed; graduation stopped"
+			return 1
+		fi
+	fi
+
 	local has_graduated
 	has_graduated=$(db "$MEMORY_DB" \
 		"SELECT COUNT(*) FROM pragma_table_info('learning_access') WHERE name='graduated_at';" \
@@ -95,11 +113,35 @@ ensure_schema() {
 }
 
 #######################################
-# Filter out session metadata and low-value content
-# Returns 0 if content is actionable, 1 if it should be skipped
+# Return 0 only when content is safe to expose in shared candidate output.
+#######################################
+is_shareable() {
+	local content="$1"
+
+	if [[ "$content" == *"GPG key"* || "$content" == *"pinentry-mac"* ]]; then
+		return 1
+	fi
+	if [[ "$content" =~ [[:alnum:]._+%-]+@[[:alnum:].-]+\.[[:alpha:]]{2,} ]]; then
+		return 1
+	fi
+	if [[ "$content" == *"/Users/"* || "$content" == *"/home/"* ||
+		"$content" == *"~/"* || "$content" == *":\\Users\\"* ||
+		"$content" == *"<private>"* || "$content" == *"</private>"* ]]; then
+		return 1
+	fi
+	return 0
+}
+
+#######################################
+# Filter out session metadata and low-value content.
+# Returns 0 if content is actionable, 1 if it should be skipped.
 #######################################
 is_actionable() {
 	local content="$1"
+
+	if ! is_shareable "$content"; then
+		return 1
+	fi
 
 	# Skip batch retrospectives (session metadata)
 	if [[ "$content" == *"Batch retrospective:"* ]]; then
@@ -123,14 +165,6 @@ is_actionable() {
 
 	# Skip entries shorter than 20 chars (too terse to be useful)
 	if [[ ${#content} -lt 20 ]]; then
-		return 1
-	fi
-
-	# Skip user-specific config (GPG keys, email addresses, local paths)
-	if [[ "$content" == *"GPG key"* || "$content" == *"pinentry-mac"* ]]; then
-		return 1
-	fi
-	if [[ "$content" == *"@"*".com"* && "$content" == *"initialized"* ]]; then
 		return 1
 	fi
 
@@ -161,7 +195,7 @@ categorize_memory() {
 	DECISION | ARCHITECTURAL_DECISION)
 		echo "Architecture Decisions"
 		;;
-	USER_PREFERENCE | TOOL_CONFIG)
+	TOOL_CONFIG)
 		echo "Configuration & Preferences"
 		;;
 	CONTEXT)
@@ -180,8 +214,9 @@ categorize_memory() {
 _query_candidates_json() {
 	local min_access="$1"
 	local limit="$2"
+	local raw_results=""
 
-	db -json "$MEMORY_DB" <<EOF
+	raw_results=$(db -json "$MEMORY_DB" <<EOF
 SELECT
     l.id,
     l.type,
@@ -197,13 +232,36 @@ WHERE (
     l.confidence = 'high'
     OR COALESCE(a.access_count, 0) >= $min_access
 )
+AND l.type != 'USER_PREFERENCE'
+AND COALESCE((
+    SELECT status FROM learning_truth_events truth_pick
+    WHERE truth_pick.memory_id = l.id
+    ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC
+    LIMIT 1
+), 'live') NOT IN ('debunked', 'retracted')
+AND NOT EXISTS (
+    SELECT 1 FROM learning_relations superseded_by
+    WHERE superseded_by.supersedes_id = l.id
+      AND superseded_by.relation_type = 'updates'
+)
 AND (a.graduated_at IS NULL OR a.graduated_at = '')
 ORDER BY
     CASE WHEN l.confidence = 'high' THEN 0 ELSE 1 END,
     COALESCE(a.access_count, 0) DESC,
-    l.created_at ASC
-LIMIT $limit;
+    l.created_at ASC;
 EOF
+	)
+
+	while IFS= read -r entry; do
+		local content=""
+		local tags=""
+		content=$(printf '%s' "$entry" | jq -r '.content')
+		tags=$(printf '%s' "$entry" | jq -r '.tags // ""')
+		if is_shareable "$content" && is_shareable "$tags"; then
+			printf '%s\n' "$entry"
+		fi
+	done < <(printf '%s' "${raw_results:-[]}" | jq -c '.[]') | jq -s ".[:$limit]"
+	return 0
 }
 
 #######################################
@@ -289,7 +347,8 @@ _candidates_parse_args() {
 
 #######################################
 # Find graduation candidates
-# Criteria: high confidence OR frequently accessed, not yet graduated
+# Criteria: high confidence OR frequently accessed, live, unsuperseded,
+# non-personal, and not yet graduated
 #######################################
 cmd_candidates() {
 	local parsed
@@ -314,7 +373,7 @@ cmd_candidates() {
 
 	if [[ -z "$results" || "$results" == "[]" ]]; then
 		log_info "No graduation candidates found."
-		log_info "Memories qualify when: confidence=high OR access_count >= $min_access"
+		log_info "Memories qualify when live and shareable, with confidence=high OR access_count >= $min_access"
 		return 0
 	fi
 
@@ -472,12 +531,13 @@ tools:
 
 # Graduated Learnings
 
-Validated learnings promoted from local memory databases into shared documentation.
-These patterns have been confirmed through repeated use across sessions.
+Validated, shareable learnings promoted from local memory databases into shared documentation.
+Personal preferences remain scoped to their user/project profiles and never graduate automatically.
 
-**How memories graduate**: Memories qualify when they reach high confidence or are
-accessed frequently (3+ times). The `memory-graduate-helper.sh` script identifies
-candidates and appends them here. Each graduation batch is timestamped.
+**How memories graduate**: Live, unsuperseded, non-personal memories qualify when
+they reach high confidence or are accessed frequently (3+ times). The
+`memory-graduate-helper.sh` script identifies candidates and appends them here.
+Each graduation batch is timestamped.
 
 **Categories**:
 
@@ -692,6 +752,9 @@ cmd_status() {
 SELECT COUNT(*) FROM learnings l
 LEFT JOIN learning_access a ON l.id = a.id
 WHERE l.confidence = 'high'
+AND l.type != 'USER_PREFERENCE'
+AND COALESCE((SELECT status FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1), 'live') NOT IN ('debunked', 'retracted')
+AND NOT EXISTS (SELECT 1 FROM learning_relations superseded_by WHERE superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates')
 AND (a.graduated_at IS NULL OR a.graduated_at = '');
 EOF
 	)
@@ -704,6 +767,9 @@ EOF
 SELECT COUNT(*) FROM learnings l
 LEFT JOIN learning_access a ON l.id = a.id
 WHERE COALESCE(a.access_count, 0) >= $DEFAULT_MIN_ACCESS
+AND l.type != 'USER_PREFERENCE'
+AND COALESCE((SELECT status FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1), 'live') NOT IN ('debunked', 'retracted')
+AND NOT EXISTS (SELECT 1 FROM learning_relations superseded_by WHERE superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates')
 AND (a.graduated_at IS NULL OR a.graduated_at = '');
 EOF
 	)
@@ -719,6 +785,9 @@ WHERE (
     l.confidence = 'high'
     OR COALESCE(a.access_count, 0) >= $DEFAULT_MIN_ACCESS
 )
+AND l.type != 'USER_PREFERENCE'
+AND COALESCE((SELECT status FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1), 'live') NOT IN ('debunked', 'retracted')
+AND NOT EXISTS (SELECT 1 FROM learning_relations superseded_by WHERE superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates')
 AND (a.graduated_at IS NULL OR a.graduated_at = '');
 EOF
 	)

--- a/.agents/scripts/memory-graduate-helper.sh
+++ b/.agents/scripts/memory-graduate-helper.sh
@@ -124,6 +124,9 @@ is_shareable() {
 	if [[ "$content" =~ [[:alnum:]._+%-]+@[[:alnum:].-]+\.[[:alpha:]]{2,} ]]; then
 		return 1
 	fi
+	if printf '%s' "$content" | grep -qE '(sk-[a-zA-Z0-9_-]{20,}|AKIA[0-9A-Z]{16}|ghp_[a-zA-Z0-9]{36}|gho_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{20,}|xox[baprs]-[a-zA-Z0-9-]{20,})'; then
+		return 1
+	fi
 	if [[ "$content" == *"/Users/"* || "$content" == *"/home/"* ||
 		"$content" == *"~/"* || "$content" == *":\\Users\\"* ||
 		"$content" == *"<private>"* || "$content" == *"</private>"* ]]; then

--- a/.agents/scripts/memory-graduate-helper.sh
+++ b/.agents/scripts/memory-graduate-helper.sh
@@ -117,6 +117,7 @@ ensure_schema() {
 #######################################
 is_shareable() {
 	local content="$1"
+	local scrubbed_content=""
 
 	if [[ "$content" == *"GPG key"* || "$content" == *"pinentry-mac"* ]]; then
 		return 1
@@ -124,7 +125,8 @@ is_shareable() {
 	if [[ "$content" =~ [[:alnum:]._+%-]+@[[:alnum:].-]+\.[[:alpha:]]{2,} ]]; then
 		return 1
 	fi
-	if printf '%s' "$content" | grep -qE '(sk-[a-zA-Z0-9_-]{20,}|AKIA[0-9A-Z]{16}|ghp_[a-zA-Z0-9]{36}|gho_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{20,}|xox[baprs]-[a-zA-Z0-9-]{20,})'; then
+	scrubbed_content=$(scrub_credentials "$content")
+	if [[ "$scrubbed_content" != "$content" ]]; then
 		return 1
 	fi
 	if [[ "$content" == *"/Users/"* || "$content" == *"/home/"* ||

--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -186,13 +186,14 @@ _recall_build_auto_filter() {
 
 #######################################
 # Build extra SQL filters (type, age, project)
-# Usage: _recall_build_extra_filters <type_filter> <max_age_days> <project_filter>
+# Usage: _recall_build_extra_filters <type_filter> <max_age_days> <project_filter> [column_prefix]
 # Outputs: SQL fragment or exits non-zero on validation error
 #######################################
 _recall_build_extra_filters() {
 	local type_filter="$1"
 	local max_age_days="$2"
 	local project_filter="$3"
+	local column_prefix="${4:-}"
 	local extra_filters=""
 
 	if [[ -n "$type_filter" ]]; then
@@ -202,21 +203,21 @@ _recall_build_extra_filters() {
 			log_error "Valid types: $VALID_TYPES"
 			return 1
 		fi
-		extra_filters="$extra_filters AND type = '$type_filter'"
+		extra_filters="$extra_filters AND ${column_prefix}type = '$type_filter'"
 	fi
 	if [[ -n "$max_age_days" ]]; then
 		if ! [[ "$max_age_days" =~ ^[0-9]+$ ]]; then
 			log_error "--max-age-days must be a positive integer"
 			return 1
 		fi
-		extra_filters="$extra_filters AND created_at >= datetime('now', '-$max_age_days days')"
+		extra_filters="$extra_filters AND ${column_prefix}created_at >= datetime('now', '-$max_age_days days')"
 	fi
 	if [[ -n "$project_filter" ]]; then
 		local escaped_project="${project_filter//"'"/"''"}"
 		escaped_project="${escaped_project//\\/\\\\}"
 		escaped_project="${escaped_project//%/\\%}"
 		escaped_project="${escaped_project//_/\\_}"
-		extra_filters="$extra_filters AND project_path LIKE '%$escaped_project%' ESCAPE '\\'"
+		extra_filters="$extra_filters AND ${column_prefix}project_path LIKE '%$escaped_project%' ESCAPE '\\'"
 	fi
 
 	printf '%s' "$extra_filters"
@@ -396,7 +397,7 @@ _recall_shared_search() {
 
 #######################################
 # Handle --recent mode: query and print recent memories
-# Usage: _recall_recent <db> <entity_join> <entity_where> <auto_filter> <limit> <format>
+# Usage: _recall_recent <db> <entity_join> <entity_where> <auto_filter> <limit> <format> <extra_filters>
 #######################################
 _recall_recent() {
 	local db_path="$1"
@@ -405,9 +406,10 @@ _recall_recent() {
 	local auto_filter="$4"
 	local limit="$5"
 	local format="$6"
+	local extra_filters="$7"
 
 	local results
-	results=$(db -json "$db_path" "SELECT l.id, l.content, l.type, l.tags, l.confidence, l.created_at, COALESCE(a.last_accessed_at, '') as last_accessed_at, COALESCE(a.access_count, 0) as access_count, COALESCE(a.auto_captured, 0) as auto_captured, COALESCE(a.usefulness_score, 0.0) as usefulness_score, COALESCE(latest_truth.status, 'live') as truth_status, COALESCE(latest_truth.evidence, '') as truth_evidence, COALESCE(latest_truth.replacement_id, '') as replacement_id, COALESCE(superseded_by.id, '') as superseded_by FROM learnings l LEFT JOIN learning_access a ON l.id = a.id LEFT JOIN learning_truth_events latest_truth ON latest_truth.event_id = (SELECT event_id FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1) LEFT JOIN learning_relations superseded_by ON superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates' $entity_join WHERE 1=1 $entity_where $auto_filter AND COALESCE(latest_truth.status, 'live') NOT IN ('debunked', 'retracted') AND superseded_by.id IS NULL ORDER BY l.created_at DESC LIMIT $limit;")
+	results=$(db -json "$db_path" "SELECT l.id, l.content, l.type, l.tags, l.confidence, l.created_at, COALESCE(a.last_accessed_at, '') as last_accessed_at, COALESCE(a.access_count, 0) as access_count, COALESCE(a.auto_captured, 0) as auto_captured, COALESCE(a.usefulness_score, 0.0) as usefulness_score, COALESCE(latest_truth.status, 'live') as truth_status, COALESCE(latest_truth.evidence, '') as truth_evidence, COALESCE(latest_truth.replacement_id, '') as replacement_id, COALESCE(superseded_by.id, '') as superseded_by FROM learnings l LEFT JOIN learning_access a ON l.id = a.id LEFT JOIN learning_truth_events latest_truth ON latest_truth.event_id = (SELECT event_id FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1) LEFT JOIN learning_relations superseded_by ON superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates' $entity_join WHERE 1=1 $entity_where $auto_filter $extra_filters AND COALESCE(latest_truth.status, 'live') NOT IN ('debunked', 'retracted') AND superseded_by.id IS NULL ORDER BY l.created_at DESC LIMIT $limit;")
 	if [[ "$format" == "json" ]]; then
 		printf '%s\n' "$results"
 	else
@@ -620,7 +622,13 @@ cmd_recall() {
 
 	# Handle --recent mode (no query required)
 	if [[ "$recent_mode" == true ]]; then
-		_recall_recent "$MEMORY_DB" "$entity_join" "$entity_where" "$auto_filter" "$limit" "$format"
+		if [[ "$semantic_mode" == true || "$hybrid_mode" == true || "$shared_mode" == true ]]; then
+			log_error "--recent cannot be combined with --semantic, --hybrid, or --shared"
+			return 1
+		fi
+		local recent_extra_filters=""
+		recent_extra_filters=$(_recall_build_extra_filters "$type_filter" "$max_age_days" "$project_filter" "l.") || return $?
+		_recall_recent "$MEMORY_DB" "$entity_join" "$entity_where" "$auto_filter" "$limit" "$format" "$recent_extra_filters"
 		return 0
 	fi
 
@@ -631,6 +639,15 @@ cmd_recall() {
 
 	# Handle --semantic or --hybrid mode (delegate to embeddings helper)
 	if [[ "$semantic_mode" == true || "$hybrid_mode" == true ]]; then
+		# Semantic retrieval currently owns truth maintenance but does not yet
+		# implement the keyword path's scope/type/age/capture/shared filters. Fail
+		# closed instead of silently returning out-of-scope memories.
+		if [[ -n "$type_filter" || -n "$max_age_days" || -n "$project_filter" ||
+			-n "$entity_filter" || "$auto_only" == true || "$manual_only" == true ||
+			"$shared_mode" == true ]]; then
+			log_error "Semantic/hybrid recall does not support scoped filters yet; use keyword recall for --type, --max-age-days, --project, --entity, --auto-only, --manual-only, or --shared"
+			return 1
+		fi
 		_recall_semantic "$query" "$limit" "$hybrid_mode" "$format"
 		return $?
 	fi

--- a/tests/test-entity-memory-integration.sh
+++ b/tests/test-entity-memory-integration.sh
@@ -487,6 +487,9 @@ test_privacy_filtering_output() {
 	entity_id=$(create_entity "Output Privacy" "person" "email" "user@example.com")
 	local conv_id
 	conv_id=$(create_conversation "$entity_id" "email" "user@example.com" "Privacy output test")
+	"$ENTITY_HELPER" profile-update "$entity_id" --key "private_contact" \
+		--value "profile.owner@example.com from 10.20.30.40" \
+		--evidence "privacy regression fixture" >/dev/null 2>&1
 
 	# Add message with email and IP
 	"$CONV_HELPER" add-message "$conv_id" \
@@ -498,8 +501,43 @@ test_privacy_filtering_output() {
 	filtered_context=$("$CONV_HELPER" context "$conv_id" --privacy-filter 2>&1)
 	assert_not_contains "$filtered_context" "alice@secret.com" "Email redacted in privacy-filtered output"
 	assert_not_contains "$filtered_context" "192.168.1.100" "IP redacted in privacy-filtered output"
+	assert_not_contains "$filtered_context" "profile.owner@example.com" "Profile email redacted in conversation context"
+	assert_not_contains "$filtered_context" "10.20.30.40" "Profile IP redacted in conversation context"
 	assert_contains "$filtered_context" "[EMAIL]" "Email replaced with [EMAIL] placeholder"
 	assert_contains "$filtered_context" "[IP]" "IP replaced with [IP] placeholder"
+
+	local filtered_conversation_json
+	filtered_conversation_json=$("$CONV_HELPER" context "$conv_id" --json --privacy-filter 2>&1)
+	assert_not_contains "$filtered_conversation_json" "user@example.com" "Conversation JSON redacts channel email"
+	assert_not_contains "$filtered_conversation_json" "profile.owner@example.com" "Conversation JSON redacts profile email"
+	assert_not_contains "$filtered_conversation_json" "10.20.30.40" "Conversation JSON redacts profile IP"
+	local conversation_json_valid=0
+	if jq -e . >/dev/null 2>&1 <<<"$filtered_conversation_json"; then
+		conversation_json_valid=1
+	fi
+	assert_eq "1" "$conversation_json_valid" "Conversation JSON remains valid after privacy filtering"
+
+	# Entity-level context uses an independent rendering path and must apply the
+	# same portable privacy contract.
+	local filtered_entity_context
+	filtered_entity_context=$("$ENTITY_HELPER" context "$entity_id" --privacy-filter 2>&1)
+	assert_not_contains "$filtered_entity_context" "alice@secret.com" "Entity context redacts email"
+	assert_not_contains "$filtered_entity_context" "192.168.1.100" "Entity context redacts IP"
+	assert_not_contains "$filtered_entity_context" "user@example.com" "Entity context redacts channel email"
+	assert_not_contains "$filtered_entity_context" "profile.owner@example.com" "Entity context redacts profile email"
+	assert_contains "$filtered_entity_context" "[EMAIL]" "Entity context emits [EMAIL] placeholder"
+	assert_contains "$filtered_entity_context" "[IP]" "Entity context emits [IP] placeholder"
+
+	local filtered_entity_json
+	filtered_entity_json=$("$ENTITY_HELPER" context "$entity_id" --json --privacy-filter 2>&1)
+	assert_not_contains "$filtered_entity_json" "user@example.com" "Entity JSON redacts channel email"
+	assert_not_contains "$filtered_entity_json" "profile.owner@example.com" "Entity JSON redacts profile email"
+	assert_not_contains "$filtered_entity_json" "10.20.30.40" "Entity JSON redacts profile IP"
+	local entity_json_valid=0
+	if jq -e . >/dev/null 2>&1 <<<"$filtered_entity_json"; then
+		entity_json_valid=1
+	fi
+	assert_eq "1" "$entity_json_valid" "Entity JSON remains valid after privacy filtering"
 
 	# Load context without privacy filter — should show raw data
 	local raw_context

--- a/tests/test-memory-graduation-safety.sh
+++ b/tests/test-memory-graduation-safety.sh
@@ -87,6 +87,8 @@ main() {
 	local results=""
 	local preview=""
 	local secret_value=""
+	local service_secret=""
+	local gitlab_secret=""
 
 	preference_id=$(store_memory_id --content "User prefers terse status summaries in personal sessions" --type USER_PREFERENCE --confidence high)
 	live_id=$(store_memory_id --content "Portable privacy filters use POSIX extended regular expressions" --type WORKING_SOLUTION --confidence high)
@@ -99,16 +101,23 @@ main() {
 	store_memory_id --content "Local evidence is stored at /Users/private-user/secret-project/report.md" --type TOOL_CONFIG --confidence high >/dev/null
 	store_memory_id --content "Safe-looking content with private metadata must remain local" --type CONTEXT --confidence high --tags "owner.private@example.test,/Users/private-user/project" >/dev/null
 	secret_value="sk-$(printf '%024d' 0)"
+	service_secret="ghs_$(printf '%020d' 0)"
+	gitlab_secret="glpat-$(printf '%020d' 0)"
 	sqlite3 "$TEST_DIR/memory.db" <<EOF
 INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source)
 VALUES ('mem_secret_content_fixture', '', 'Legacy credential $secret_value must remain local', 'CONTEXT', 'legacy', 'high', datetime('now'), '', '', 'legacy');
 INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source)
 VALUES ('mem_secret_tag_fixture', '', 'Safe content with credential metadata must remain local', 'CONTEXT', '$secret_value', 'high', datetime('now'), '', '', 'legacy');
+INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source)
+VALUES ('mem_service_secret_fixture', '', 'Legacy service credential $service_secret must remain local', 'CONTEXT', 'legacy', 'high', datetime('now'), '', '', 'legacy');
+INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source)
+VALUES ('mem_gitlab_secret_tag_fixture', '', 'Safe content with GitLab credential metadata must remain local', 'CONTEXT', '$gitlab_secret', 'high', datetime('now'), '', '', 'legacy');
 EOF
 
 	results=$(candidate_json)
 	if [[ "$results" == *"private.person@example.test"* || "$results" == *"owner.private@example.test"* ||
-		"$results" == *"/Users/private-user/"* || "$results" == *"$secret_value"* ]]; then
+		"$results" == *"/Users/private-user/"* || "$results" == *"$secret_value"* ||
+		"$results" == *"$service_secret"* || "$results" == *"$gitlab_secret"* ]]; then
 		printf 'FAIL: graduation candidate JSON exposed personal content\n' >&2
 		return 1
 	fi
@@ -122,7 +131,8 @@ EOF
 
 	preview=$(graduation_preview)
 	if [[ "$preview" == *"private.person@example.test"* || "$preview" == *"/Users/private-user/"* ||
-		"$preview" == *"$secret_value"* ]]; then
+		"$preview" == *"$secret_value"* || "$preview" == *"$service_secret"* ||
+		"$preview" == *"$gitlab_secret"* ]]; then
 		printf 'FAIL: graduation preview exposed personal content\n' >&2
 		return 1
 	fi

--- a/tests/test-memory-graduation-safety.sh
+++ b/tests/test-memory-graduation-safety.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression tests for safe memory graduation candidate selection.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+GRADUATE_HELPER="$REPO_ROOT/.agents/scripts/memory-graduate-helper.sh"
+TEST_DIR="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$TEST_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+store_memory_id() {
+	local output=""
+	local line=""
+	local memory_id=""
+	output=$(AIDEVOPS_MEMORY_DIR="$TEST_DIR" "$MEMORY_HELPER" store "$@")
+	while IFS= read -r line; do
+		if [[ "$line" == mem_* ]]; then
+			memory_id="$line"
+		fi
+	done <<<"$output"
+	printf '%s\n' "$memory_id"
+	return 0
+}
+
+candidate_json() {
+	local output=""
+	local line=""
+	local json=""
+	local capturing=0
+	output=$(AIDEVOPS_MEMORY_DIR="$TEST_DIR" "$GRADUATE_HELPER" candidates --json --limit 50)
+	while IFS= read -r line; do
+		if [[ "$line" == \[* ]]; then
+			capturing=1
+		fi
+		if [[ "$capturing" -eq 1 ]]; then
+			json+="$line"$'\n'
+		fi
+	done <<<"$output"
+	printf '%s' "$json"
+	return 0
+}
+
+graduation_preview() {
+	AIDEVOPS_MEMORY_DIR="$TEST_DIR" "$GRADUATE_HELPER" graduate --dry-run --limit 50 2>&1
+	return $?
+}
+
+test_legacy_schema_migration() {
+	local legacy_dir=""
+	local output=""
+	local truth_table_count=""
+	legacy_dir=$(mktemp -d)
+
+	AIDEVOPS_MEMORY_DIR="$legacy_dir" "$MEMORY_HELPER" store \
+		--content "Legacy schema graduation remains safely migratable" \
+		--type WORKING_SOLUTION --confidence high >/dev/null
+	sqlite3 "$legacy_dir/memory.db" "DROP TABLE learning_truth_events; DROP TABLE learning_relations;"
+
+	output=$(AIDEVOPS_MEMORY_DIR="$legacy_dir" "$GRADUATE_HELPER" candidates --json --limit 10)
+	truth_table_count=$(sqlite3 "$legacy_dir/memory.db" \
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('learning_truth_events', 'learning_relations');")
+	rm -rf "$legacy_dir"
+
+	if [[ "$truth_table_count" != "2" || "$output" != *"Legacy schema graduation remains safely migratable"* ]]; then
+		printf 'FAIL: graduation did not migrate a legacy truth-maintenance schema\n' >&2
+		return 1
+	fi
+	return 0
+}
+
+main() {
+	local preference_id=""
+	local live_id=""
+	local myth_id=""
+	local replacement_id=""
+	local old_id=""
+	local new_id=""
+	local results=""
+	local preview=""
+
+	preference_id=$(store_memory_id --content "User prefers terse status summaries in personal sessions" --type USER_PREFERENCE --confidence high)
+	live_id=$(store_memory_id --content "Portable privacy filters use POSIX extended regular expressions" --type WORKING_SOLUTION --confidence high)
+	myth_id=$(store_memory_id --content "Obsolete privacy claim should never graduate into shared guidance" --type FAILURE_PATTERN --confidence high)
+	replacement_id=$(store_memory_id --content "Verified privacy behavior replaces the obsolete shared claim" --type WORKING_SOLUTION --confidence high)
+	store_memory_id --content "Evidence disproves the obsolete privacy graduation claim" --type ERROR_FIX --confidence high --debunks "$myth_id" --replacement "$replacement_id" --evidence "Regression test" >/dev/null
+	old_id=$(store_memory_id --content "Old deployment guidance uses the retired memory path" --type TOOL_CONFIG --confidence high)
+	new_id=$(store_memory_id --content "Current deployment guidance uses the supported memory path" --type TOOL_CONFIG --confidence high --supersedes "$old_id" --relation updates)
+	store_memory_id --content "Contact private.person@example.test before publishing this workflow" --type CONTEXT --confidence high >/dev/null
+	store_memory_id --content "Local evidence is stored at /Users/private-user/secret-project/report.md" --type TOOL_CONFIG --confidence high >/dev/null
+	store_memory_id --content "Safe-looking content with private metadata must remain local" --type CONTEXT --confidence high --tags "owner.private@example.test,/Users/private-user/project" >/dev/null
+
+	results=$(candidate_json)
+	if [[ "$results" == *"private.person@example.test"* || "$results" == *"owner.private@example.test"* ||
+		"$results" == *"/Users/private-user/"* ]]; then
+		printf 'FAIL: graduation candidate JSON exposed personal content\n' >&2
+		return 1
+	fi
+
+	jq -e --arg id "$live_id" 'map(.id) | index($id) != null' <<<"$results" >/dev/null
+	jq -e --arg id "$replacement_id" 'map(.id) | index($id) != null' <<<"$results" >/dev/null
+	jq -e --arg id "$new_id" 'map(.id) | index($id) != null' <<<"$results" >/dev/null
+	jq -e --arg id "$preference_id" 'map(.id) | index($id) | not' <<<"$results" >/dev/null
+	jq -e --arg id "$myth_id" 'map(.id) | index($id) | not' <<<"$results" >/dev/null
+	jq -e --arg id "$old_id" 'map(.id) | index($id) | not' <<<"$results" >/dev/null
+
+	preview=$(graduation_preview)
+	if [[ "$preview" == *"private.person@example.test"* || "$preview" == *"/Users/private-user/"* ]]; then
+		printf 'FAIL: graduation preview exposed personal content\n' >&2
+		return 1
+	fi
+	test_legacy_schema_migration
+
+	printf 'PASS: graduation includes live shareable memories and excludes personal, private, debunked, and superseded records\n'
+	return 0
+}
+
+main "$@"

--- a/tests/test-memory-graduation-safety.sh
+++ b/tests/test-memory-graduation-safety.sh
@@ -86,6 +86,7 @@ main() {
 	local new_id=""
 	local results=""
 	local preview=""
+	local secret_value=""
 
 	preference_id=$(store_memory_id --content "User prefers terse status summaries in personal sessions" --type USER_PREFERENCE --confidence high)
 	live_id=$(store_memory_id --content "Portable privacy filters use POSIX extended regular expressions" --type WORKING_SOLUTION --confidence high)
@@ -97,10 +98,17 @@ main() {
 	store_memory_id --content "Contact private.person@example.test before publishing this workflow" --type CONTEXT --confidence high >/dev/null
 	store_memory_id --content "Local evidence is stored at /Users/private-user/secret-project/report.md" --type TOOL_CONFIG --confidence high >/dev/null
 	store_memory_id --content "Safe-looking content with private metadata must remain local" --type CONTEXT --confidence high --tags "owner.private@example.test,/Users/private-user/project" >/dev/null
+	secret_value="sk-$(printf '%024d' 0)"
+	sqlite3 "$TEST_DIR/memory.db" <<EOF
+INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source)
+VALUES ('mem_secret_content_fixture', '', 'Legacy credential $secret_value must remain local', 'CONTEXT', 'legacy', 'high', datetime('now'), '', '', 'legacy');
+INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source)
+VALUES ('mem_secret_tag_fixture', '', 'Safe content with credential metadata must remain local', 'CONTEXT', '$secret_value', 'high', datetime('now'), '', '', 'legacy');
+EOF
 
 	results=$(candidate_json)
 	if [[ "$results" == *"private.person@example.test"* || "$results" == *"owner.private@example.test"* ||
-		"$results" == *"/Users/private-user/"* ]]; then
+		"$results" == *"/Users/private-user/"* || "$results" == *"$secret_value"* ]]; then
 		printf 'FAIL: graduation candidate JSON exposed personal content\n' >&2
 		return 1
 	fi
@@ -113,7 +121,8 @@ main() {
 	jq -e --arg id "$old_id" 'map(.id) | index($id) | not' <<<"$results" >/dev/null
 
 	preview=$(graduation_preview)
-	if [[ "$preview" == *"private.person@example.test"* || "$preview" == *"/Users/private-user/"* ]]; then
+	if [[ "$preview" == *"private.person@example.test"* || "$preview" == *"/Users/private-user/"* ||
+		"$preview" == *"$secret_value"* ]]; then
 		printf 'FAIL: graduation preview exposed personal content\n' >&2
 		return 1
 	fi

--- a/tests/test-memory-mail.sh
+++ b/tests/test-memory-mail.sh
@@ -19,6 +19,7 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPTS_DIR="$REPO_DIR/.agents/scripts"
 MEMORY_SCRIPT="$SCRIPTS_DIR/memory-helper.sh"
 MAIL_SCRIPT="$SCRIPTS_DIR/mail-helper.sh"
+ENTITY_SCRIPT="$SCRIPTS_DIR/entity-helper.sh"
 
 # --- Test Framework ---
 PASS_COUNT=0
@@ -64,6 +65,38 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 # Helper: run memory command
 mem() {
 	bash "$MEMORY_SCRIPT" "$@" 2>&1
+}
+
+assert_scoped_recall_rejected() {
+	local label="$1"
+	shift
+	local output=""
+	local rc=0
+	output=$(mem recall --query "scoped semantic leak marker" "$@") || rc=$?
+	if [[ "$rc" -ne 0 && "$output" == *"does not support scoped filters"* &&
+		"$output" != *"must-not-leak"* ]]; then
+		pass "$label"
+	else
+		fail "$label" "rc=$rc output=$output"
+	fi
+	return 0
+}
+
+extract_json_payload() {
+	local output="$1"
+	local line=""
+	local json=""
+	local capturing=0
+	while IFS= read -r line; do
+		if [[ "$line" == \[* ]]; then
+			capturing=1
+		fi
+		if [[ "$capturing" -eq 1 ]]; then
+			json+="$line"$'\n'
+		fi
+	done <<<"$output"
+	printf '%s' "$json"
+	return 0
 }
 
 # Helper: run mail command
@@ -684,6 +717,41 @@ if echo "$hybrid_output" | grep -qiE "not available|setup|error|not found"; then
 else
 	# It might also succeed if embeddings happen to be available
 	pass "memory recall --hybrid flag accepted"
+fi
+
+# Scoped semantic/hybrid queries must fail closed until the embedding path can
+# apply the same project/type/entity/age filters as keyword recall.
+mem store --content "scoped semantic leak marker must-not-leak" --type WORKING_SOLUTION --tags "scope-test" >/dev/null
+entity_output=$(AIDEVOPS_MEMORY_DIR="$AIDEVOPS_MEMORY_DIR" "$ENTITY_SCRIPT" create --name "Semantic Scope Test" --type person 2>&1)
+entity_id=$(printf '%s\n' "$entity_output" | sed -n 's/.*\(ent_[a-zA-Z0-9_]*\).*/\1/p' | tail -1)
+
+for semantic_mode in --semantic --hybrid; do
+	assert_scoped_recall_rejected "$semantic_mode rejects --type" "$semantic_mode" --type WORKING_SOLUTION
+	assert_scoped_recall_rejected "$semantic_mode rejects --max-age-days" "$semantic_mode" --max-age-days 30
+	assert_scoped_recall_rejected "$semantic_mode rejects --project" "$semantic_mode" --project sample-project
+	assert_scoped_recall_rejected "$semantic_mode rejects --entity" "$semantic_mode" --entity "$entity_id"
+	assert_scoped_recall_rejected "$semantic_mode rejects --auto-only" "$semantic_mode" --auto-only
+	assert_scoped_recall_rejected "$semantic_mode rejects --manual-only" "$semantic_mode" --manual-only
+	assert_scoped_recall_rejected "$semantic_mode rejects --shared" "$semantic_mode" --shared
+done
+
+for incompatible_mode in --semantic --hybrid --shared; do
+	recent_rc=0
+	recent_output=$(mem recall --recent "$incompatible_mode" --type WORKING_SOLUTION --json) || recent_rc=$?
+	if [[ "$recent_rc" -ne 0 && "$recent_output" == *"--recent cannot be combined"* &&
+		"$recent_output" != *"must-not-leak"* ]]; then
+		pass "--recent rejects $incompatible_mode"
+	else
+		fail "--recent did not reject $incompatible_mode" "rc=$recent_rc output=$recent_output"
+	fi
+done
+
+recent_typed_output=$(mem recall --recent --type USER_PREFERENCE --json)
+recent_typed_output=$(extract_json_payload "$recent_typed_output")
+if jq -e 'all(.type == "USER_PREFERENCE")' >/dev/null 2>&1 <<<"$recent_typed_output"; then
+	pass "--recent applies supported type filters"
+else
+	fail "--recent ignored supported type filter" "$recent_typed_output"
 fi
 
 section "Embeddings: Config File Format"

--- a/tests/test-memory-truth-maintenance.sh
+++ b/tests/test-memory-truth-maintenance.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
 MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+EMBEDDINGS_ENGINE_LIB="$REPO_ROOT/.agents/scripts/memory-embeddings-helper-engine.sh"
 
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -208,6 +209,105 @@ EOF
 	return 0
 }
 
+test_semantic_engine_uses_truth_state() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	local test_dir
+	test_dir=$(setup_memory_dir)
+	local test_db="$test_dir/memory.db"
+	local engine_path="$test_dir/embeddings-engine.py"
+	local myth_id=""
+	local live_id=""
+	local old_id=""
+	local new_id=""
+	local rc=0
+
+	myth_id=$(store_memory_id "$test_dir" --content "semantic myth epsilon marker is obsolete" --type FAILURE_PATTERN --confidence high)
+	live_id=$(store_memory_id "$test_dir" --content "semantic epsilon marker current source is verified" --type WORKING_SOLUTION --confidence high)
+	store_memory_id "$test_dir" --content "semantic epsilon evidence disproves obsolete myth" --type ERROR_FIX --confidence high --debunks "$myth_id" --replacement "$live_id" --evidence "Regression test" >/dev/null
+	old_id=$(store_memory_id "$test_dir" --content "semantic zeta marker uses old guidance" --type TOOL_CONFIG --confidence high)
+	new_id=$(store_memory_id "$test_dir" --content "semantic zeta marker uses current guidance" --type TOOL_CONFIG --confidence high --supersedes "$old_id" --relation updates)
+
+	(
+		SCRIPT_DIR="$REPO_ROOT/.agents/scripts"
+		PYTHON_SCRIPT="$engine_path"
+		MEMORY_DIR="$test_dir"
+		CONFIG_FILE="$test_dir/.embeddings-config"
+		LOCAL_MODEL_NAME="all-MiniLM-L6-v2"
+		LOCAL_EMBEDDING_DIM=384
+		OPENAI_EMBEDDING_DIM=1536
+		# shellcheck source=../.agents/scripts/shared-constants.sh
+		source "$REPO_ROOT/.agents/scripts/shared-constants.sh"
+		# shellcheck source=../.agents/scripts/memory-embeddings-helper-engine.sh
+		source "$EMBEDDINGS_ENGINE_LIB"
+		create_python_engine
+	) || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		python3 - "$engine_path" "$test_db" "$myth_id" "$live_id" "$old_id" "$new_id" <<'PYEOF' || rc=$?
+import ast
+import sqlite3
+import sys
+
+engine_path, db_path, myth_id, live_id, old_id, new_id = sys.argv[1:]
+with open(engine_path, encoding="utf-8") as engine_file:
+    tree = ast.parse(engine_file.read(), filename=engine_path)
+
+functions = {
+    node.name: node for node in tree.body
+    if isinstance(node, ast.FunctionDef)
+    and node.name in {"_memory_is_live", "_hybrid_semantic_search"}
+}
+module = ast.Module(body=list(functions.values()), type_ignores=[])
+namespace = {"sqlite3": sqlite3}
+exec(compile(ast.fix_missing_locations(module), engine_path, "exec"), namespace)
+
+connection = sqlite3.connect(db_path)
+try:
+    assert not namespace["_memory_is_live"](connection, myth_id)
+    assert namespace["_memory_is_live"](connection, live_id)
+    assert not namespace["_memory_is_live"](connection, old_id)
+    assert namespace["_memory_is_live"](connection, new_id)
+finally:
+    connection.close()
+
+class FakeEmbeddingConnection:
+    def execute(self, _query, _params):
+        return self
+
+    def fetchall(self):
+        return [
+            ("stale-1", [0.99], 1),
+            ("stale-2", [0.98], 1),
+            ("stale-3", [0.97], 1),
+            ("live-lower-ranked", [0.50], 1),
+        ]
+
+    def close(self):
+        return None
+
+namespace.update({
+    "get_embedding_dim": lambda _provider: 1,
+    "embed_text": lambda _query, _provider: [1.0],
+    "init_embeddings_db": lambda _path: FakeEmbeddingConnection(),
+    "unpack_embedding": lambda blob, _dim: blob,
+    "cosine_similarity": lambda _query, stored: stored[0],
+})
+semantic_candidates = namespace["_hybrid_semantic_search"]("local", "unused", "query")
+assert len(semantic_candidates) == 4
+assert semantic_candidates[-1][0] == "live-lower-ranked"
+PYEOF
+	fi
+
+	if [[ "$rc" -eq 0 ]]; then
+		pass "semantic engine suppresses debunked and superseded memories"
+	else
+		fail "semantic engine suppresses debunked and superseded memories" "generated engine check failed"
+	fi
+
+	rm -rf "$test_dir"
+	return 0
+}
+
 main() {
 	echo ""
 	echo "=== Memory Truth Maintenance Tests ==="
@@ -218,6 +318,7 @@ main() {
 	test_updates_hide_superseded_memory
 	test_validate_reports_truth_state
 	test_migrates_old_relation_constraint
+	test_semantic_engine_uses_truth_state
 
 	echo ""
 	echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="


### PR DESCRIPTION
## Summary

- Make verified value per unit of human attention a canonical aidevops operating principle.
- Preserve context-rich execution momentum and require observable background waits for long-running gates.
- Fix complete text/JSON privacy filtering for conversation and entity context.
- Keep personal preferences out of automatic all-user graduation and block private/credential-bearing candidate content and tags.
- Apply truth maintenance to semantic/hybrid recall and fail closed on unsupported scope combinations.

## Verification

- 292 targeted memory, truth-maintenance, graduation, self-evolution, and entity integration tests passed.
- ShellCheck passed for all changed shell scripts and tests.
- Secretlint passed, including generated credential-pattern fixtures.
- Repository local gate reported no changed-file Bash 3.2, complexity, nesting, file-size, Markdown, TOON, secret-policy, pulse-canary, or Python regressions. Its aggregate exit remained non-zero only for pre-existing repository-wide complexity/nesting debt.
- Independent release audit found no blocking defects.

## Runtime Testing

Runtime-verified through isolated SQLite memory databases and executable shell integration suites covering legacy migration, text/JSON redaction, candidate filtering, truth/supersession, semantic/hybrid ranking, and fail-closed scope handling.

## Decisions

- Human attention is treated as scarce; autonomous, reversible AI work is preferred over routine approval prompts.
- Personal preferences may be learned and applied within scope but cannot silently become universal policy.
- Graduation reuses the canonical credential sanitizer instead of maintaining a divergent token-prefix list.
- Unsupported semantic scope combinations fail closed rather than returning potentially out-of-scope memories.

## Follow-up

- #27017 tracks a live capability-readiness contract and generated registry.
- #27018 tracks the unified observation, outcome, and reversible promotion lifecycle.

Resolves #27016

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.19 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 8h 45m and 2,034,964 tokens on this with the user in an interactive session. Solved in 4h 44m.
