### PR TITLE
GH#27054: reduce quality feedback test complexity

### DIFF
--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -53,6 +53,22 @@ _restore_mock_gh() {
 	return 0
 }
 
+_assert_scan_single_pr_has_no_findings() {
+	local pr_number="$1"
+	local result_message="$2"
+	local findings
+	findings=$(_scan_single_pr "owner/repo" "$pr_number" "medium" "false" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "$result_message" 0
+	else
+		print_result "$result_message" 1 "expected 0 findings, got ${count}"
+	fi
+	return 0
+}
+
 # --- Test Functions ---
 
 test_quality_debt_security_labels_for_security_review_feedback() {
@@ -845,37 +861,17 @@ test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
 		return 0
 	}
 
-	local findings
-	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
-	local count
-	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
-
-	if [[ "$count" -eq 0 ]]; then
-		print_result "positive inline acknowledgement reply is filtered" 0
-	else
-		print_result "positive inline acknowledgement reply is filtered" 1 "expected 0 findings, got ${count}"
-	fi
+	_assert_scan_single_pr_has_no_findings "1" \
+		"positive inline acknowledgement reply is filtered"
 
 	acknowledgement_body="The implementation looks correct and addressed the stale cleanup path."
-	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
-	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
-
-	if [[ "$count" -eq 0 ]]; then
-		print_result "positive inline acknowledgement reply using addressed is filtered" 0
-	else
-		print_result "positive inline acknowledgement reply using addressed is filtered" 1 "expected 0 findings, got ${count}"
-	fi
+	_assert_scan_single_pr_has_no_findings "1" \
+		"positive inline acknowledgement reply using addressed is filtered"
 
 	acknowledgement_body='Thank you for the update, marcusquinn. Using `${task_ref:-}` consistently for guard checks is the correct approach to prevent unbound variable errors when `set -u` is enabled. The verification steps you'
 	acknowledgement_body+="'ve taken, including the regression test, provide good confidence in this fix."
-	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
-	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
-
-	if [[ "$count" -eq 0 ]]; then
-		print_result "issue #26770 positive inline guard-check acknowledgement is filtered" 0
-	else
-		print_result "issue #26770 positive inline guard-check acknowledgement is filtered" 1 "expected 0 findings, got ${count}"
-	fi
+	_assert_scan_single_pr_has_no_findings "1" \
+		"issue #26770 positive inline guard-check acknowledgement is filtered"
 
 	gh() {
 		local command="$1"
@@ -913,14 +909,8 @@ test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
 		return 1
 	}
 
-	findings=$(_scan_single_pr "owner/repo" "26918" "medium" "false" 2>/dev/null)
-	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
-
-	if [[ "$count" -eq 0 ]]; then
-		print_result "issue #26971 addressed reply filters its parent finding" 0
-	else
-		print_result "issue #26971 addressed reply filters its parent finding" 1 "expected 0 findings, got ${count}"
-	fi
+	_assert_scan_single_pr_has_no_findings "26918" \
+		"issue #26971 addressed reply filters its parent finding"
 
 	_restore_mock_gh
 	return 0


### PR DESCRIPTION
## Summary

Extracted a shared no-findings assertion helper and reused it across the positive acknowledgement regression cases.

## Complexity Bump Justification

Scanner evidence: `.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh:825` identifies the refactored test function, with the extracted assertion helper at `.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh:56`.

Measurements: oversized functions `base=1, head=0, new=0`; target function `base_lines=118, head_lines=93, delta=-25`.

No complexity violation is being accepted: the helper extraction removes the reported debt while preserving the fixture's local dynamic scoping. The `complexity-bump-ok` label is applied because issue #27054 explicitly requires the extraction-related scanner override metadata.

## Files Changed

.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n and ShellCheck passed; quality-feedback suite 78/78 passed; complexity-gate suite 5/5 passed; linters-local.sh --changed passed with 0 oversized functions

Resolves #27054


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.20 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 70,305 tokens on this as a headless worker.