### PR TITLE
GH#27067: guard launch helpers under nounset

### DIFF
--- a/.agents/scripts/headless-runtime-launch.sh
+++ b/.agents/scripts/headless-runtime-launch.sh
@@ -65,7 +65,7 @@ _cleanup_headless_runtime_temp_paths() {
 			;;
 		esac
 	done <<EOF
-$_HEADLESS_RUNTIME_TEMP_PATHS
+${_HEADLESS_RUNTIME_TEMP_PATHS:-}
 EOF
 	_HEADLESS_RUNTIME_TEMP_PATHS=""
 	return 0
@@ -191,26 +191,26 @@ _parse_run_args() {
 # _validate_run_args: check required fields and resolve prompt from file if needed.
 # Operates on caller-scoped variables set by _parse_run_args.
 _validate_run_args() {
-	[[ -n "$session_key" ]] || {
+	[[ -n "${session_key:-}" ]] || {
 		print_error "run requires --session-key"
 		return 1
 	}
-	[[ -n "$work_dir" ]] || {
+	[[ -n "${work_dir:-}" ]] || {
 		print_error "run requires --dir"
 		return 1
 	}
-	[[ -n "$title" ]] || {
+	[[ -n "${title:-}" ]] || {
 		print_error "run requires --title"
 		return 1
 	}
-	if [[ -z "$prompt" && -n "$prompt_file" ]]; then
-		[[ -f "$prompt_file" ]] || {
-			print_error "Prompt file not found: $prompt_file"
+	if [[ -z "${prompt:-}" && -n "${prompt_file:-}" ]]; then
+		[[ -f "${prompt_file:-}" ]] || {
+			print_error "Prompt file not found: ${prompt_file:-}"
 			return 1
 		}
 		prompt=$(<"$prompt_file")
 	fi
-	[[ -n "$prompt" ]] || {
+	[[ -n "${prompt:-}" ]] || {
 		print_error "run requires --prompt or --prompt-file"
 		return 1
 	}

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -146,6 +146,34 @@ test_parse_initial_model_does_not_set_explicit_override() {
 	return 0
 }
 
+test_launch_helpers_tolerate_unset_state_under_nounset() {
+	local status=0
+	(
+		unset _HEADLESS_RUNTIME_TEMP_PATHS
+		_cleanup_headless_runtime_temp_paths
+	) || status=$?
+
+	if [[ "$status" -eq 0 ]]; then
+		print_result "launch temp cleanup tolerates unset state under nounset" 0
+	else
+		print_result "launch temp cleanup tolerates unset state under nounset" 1 "status=$status"
+	fi
+
+	status=0
+	(
+		unset session_key work_dir title prompt prompt_file
+		_validate_run_args
+	) >/dev/null 2>&1 || status=$?
+
+	if [[ "$status" -eq 1 ]]; then
+		print_result "launch argument validation reports missing caller state under nounset" 0
+		return 0
+	fi
+
+	print_result "launch argument validation reports missing caller state under nounset" 1 "status=$status"
+	return 0
+}
+
 test_startup_no_activity_timeout_returns_watchdog_continue() {
 	local output_file="${TEST_ROOT}/startup-stall.log"
 	printf '%s\n' 'sqlite-migration:done' >"$output_file"
@@ -2713,6 +2741,7 @@ main() {
 	test_non_full_loop_prompt_unchanged
 	test_headless_contract_uses_deployed_framework_paths
 	test_parse_initial_model_does_not_set_explicit_override
+	test_launch_helpers_tolerate_unset_state_under_nounset
 	test_startup_no_activity_timeout_returns_watchdog_continue
 	test_startup_no_activity_can_rotate_after_continuation_budget
 	test_sigkill_with_activity_attempts_continuation


### PR DESCRIPTION
## Summary

Address high-priority review findings from PR #27068 by safely handling unset launch state and caller-scoped arguments under set -u, with regression coverage.

## Files Changed

.agents/scripts/headless-runtime-launch.sh, .agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n and ShellCheck passed; focused nounset regression tests passed; changed-file linters passed; full helper suite progressed through the new tests before the OpenCode canonical Git guard blocked its temporary-repo setup.

Resolves #27067


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.20 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 109,725 tokens on this as a headless worker.