### PR TITLE
GH#27114: stop runaway file-size debt issue creation

### DIFF
--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -404,46 +404,32 @@ _large_file_gate_find_existing_debt_issue() {
 	local _marker="generator=large-file-simplification-gate cited_file=${lf_path} "
 	local _server_query="\"${lf_path}\" large-file-simplification-gate in:body sort:created-asc"
 
-	# Open-state lookup. One retry with 2s backoff covers GitHub search
+	# Query both states together so the oldest issue remains canonical even
+	# when it is closed and a newer duplicate is open. One retry with 2s
+	# backoff covers GitHub search
 	# index lag (typically 1-3s after issue creation) — t2995 investigation
 	# step 4. We only retry when the call SUCCEEDED but returned empty;
 	# retrying a real failure would just hit the same timeout twice.
-	local _open _open_json _open_rc=0
-	_open_json=$(gh_issue_list --repo "$repo_slug" --state open \
+	local _match _match_json _match_rc=0
+	_match_json=$(gh_issue_list --repo "$repo_slug" --state all \
 		--label "file-size-debt" --search "$_server_query" \
-		--json number,body --limit 100 2>/dev/null) || _open_rc=$?
-	_open=$(printf '%s' "$_open_json" | jq -r --arg marker "$_marker" \
-		'[.[] | select((.body // "") | contains($marker)) | .number] | min // empty' 2>/dev/null) || _open_rc=$?
-	if [[ $_open_rc -eq 0 && -z "$_open" ]]; then
+		--json number,body,state --limit 100 2>/dev/null) || _match_rc=$?
+	_match=$(printf '%s' "$_match_json" | jq -r --arg marker "$_marker" \
+		'[.[] | select((.body // "") | contains($marker))] | sort_by(.number) | .[0] | if . then "\(.state | ascii_downcase):\(.number)" else empty end' 2>/dev/null) || _match_rc=$?
+	if [[ $_match_rc -eq 0 && -z "$_match" ]]; then
 		sleep 2
-		_open_json=$(gh_issue_list --repo "$repo_slug" --state open \
+		_match_json=$(gh_issue_list --repo "$repo_slug" --state all \
 			--label "file-size-debt" --search "$_server_query" \
-			--json number,body --limit 100 2>/dev/null) || _open_rc=$?
-		_open=$(printf '%s' "$_open_json" | jq -r --arg marker "$_marker" \
-			'[.[] | select((.body // "") | contains($marker)) | .number] | min // empty' 2>/dev/null) || _open_rc=$?
+			--json number,body,state --limit 100 2>/dev/null) || _match_rc=$?
+		_match=$(printf '%s' "$_match_json" | jq -r --arg marker "$_marker" \
+			'[.[] | select((.body // "") | contains($marker))] | sort_by(.number) | .[0] | if . then "\(.state | ascii_downcase):\(.number)" else empty end' 2>/dev/null) || _match_rc=$?
 	fi
-	if [[ $_open_rc -ne 0 ]]; then
-		echo "[pulse-wrapper] WARN: file-size-debt dedup open-search failed for ${lf_path} (rc=${_open_rc}); deferring (t2995)" >>"$LOGFILE"
+	if [[ $_match_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] WARN: file-size-debt dedup all-state search failed for ${lf_path} (rc=${_match_rc}); deferring (t2995)" >>"$LOGFILE"
 		return 2
 	fi
-	if [[ -n "$_open" ]]; then
-		printf 'open:%s' "$_open"
-		return 0
-	fi
-
-	local _closed _closed_json _closed_rc=0
-	_closed_json=$(gh_issue_list --repo "$repo_slug" \
-		--state closed --label "file-size-debt" \
-		--search "$_server_query" \
-		--json number,body --limit 100 2>/dev/null) || _closed_rc=$?
-	_closed=$(printf '%s' "$_closed_json" | jq -r --arg marker "$_marker" \
-		'[.[] | select((.body // "") | contains($marker)) | .number] | min // empty' 2>/dev/null) || _closed_rc=$?
-	if [[ $_closed_rc -ne 0 ]]; then
-		echo "[pulse-wrapper] WARN: file-size-debt dedup closed-search failed for ${lf_path} (rc=${_closed_rc}); deferring (t2995)" >>"$LOGFILE"
-		return 2
-	fi
-	if [[ -n "$_closed" ]]; then
-		printf 'closed:%s' "$_closed"
+	if [[ -n "$_match" ]]; then
+		printf '%s' "$_match"
 		return 0
 	fi
 	return 1

--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -402,6 +402,7 @@ _large_file_gate_find_existing_debt_issue() {
 	local repo_slug="$1"
 	local lf_path="$2"
 	local _marker="generator=large-file-simplification-gate cited_file=${lf_path} "
+	local _server_query="\"${lf_path}\" large-file-simplification-gate in:body sort:created-asc"
 
 	# Open-state lookup. One retry with 2s backoff covers GitHub search
 	# index lag (typically 1-3s after issue creation) — t2995 investigation
@@ -409,14 +410,14 @@ _large_file_gate_find_existing_debt_issue() {
 	# retrying a real failure would just hit the same timeout twice.
 	local _open _open_json _open_rc=0
 	_open_json=$(gh_issue_list --repo "$repo_slug" --state open \
-		--label "file-size-debt" --search "large-file-simplification-gate in:body" \
+		--label "file-size-debt" --search "$_server_query" \
 		--json number,body --limit 100 2>/dev/null) || _open_rc=$?
 	_open=$(printf '%s' "$_open_json" | jq -r --arg marker "$_marker" \
 		'[.[] | select((.body // "") | contains($marker)) | .number] | min // empty' 2>/dev/null) || _open_rc=$?
 	if [[ $_open_rc -eq 0 && -z "$_open" ]]; then
 		sleep 2
 		_open_json=$(gh_issue_list --repo "$repo_slug" --state open \
-			--label "file-size-debt" --search "large-file-simplification-gate in:body" \
+			--label "file-size-debt" --search "$_server_query" \
 			--json number,body --limit 100 2>/dev/null) || _open_rc=$?
 		_open=$(printf '%s' "$_open_json" | jq -r --arg marker "$_marker" \
 			'[.[] | select((.body // "") | contains($marker)) | .number] | min // empty' 2>/dev/null) || _open_rc=$?
@@ -433,7 +434,7 @@ _large_file_gate_find_existing_debt_issue() {
 	local _closed _closed_json _closed_rc=0
 	_closed_json=$(gh_issue_list --repo "$repo_slug" \
 		--state closed --label "file-size-debt" \
-		--search "large-file-simplification-gate in:body" \
+		--search "$_server_query" \
 		--json number,body --limit 100 2>/dev/null) || _closed_rc=$?
 	_closed=$(printf '%s' "$_closed_json" | jq -r --arg marker "$_marker" \
 		'[.[] | select((.body // "") | contains($marker)) | .number] | min // empty' 2>/dev/null) || _closed_rc=$?
@@ -460,12 +461,46 @@ _large_file_gate_normalize_debt_issue() {
 		--add-label "file-size-debt,auto-dispatch" >/dev/null 2>&1; then
 		return 1
 	fi
-	local _stale_label
+	local _labels="" _stale_label
+	_labels=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
+		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || return 1
 	for _stale_label in status:done not-planned simplification-incomplete; do
-		gh issue edit "$issue_number" --repo "$repo_slug" \
-			--remove-label "$_stale_label" >/dev/null 2>&1 || true
+		if [[ ",$_labels," == *",$_stale_label,"* ]]; then
+			if ! gh issue edit "$issue_number" --repo "$repo_slug" \
+				--remove-label "$_stale_label" >/dev/null 2>&1; then
+				return 1
+			fi
+		fi
 	done
 	return 0
+}
+
+#######################################
+# Close all open exact-marker matches except the canonical oldest issue.
+# This is retried whenever the canonical issue is encountered, so a transient
+# close failure cannot leave a duplicate permanently active.
+# Arguments: repo_slug, lf_path, canonical_issue
+#######################################
+_large_file_gate_close_duplicate_debt_issues() {
+	local repo_slug="$1"
+	local lf_path="$2"
+	local canonical_issue="$3"
+	local _marker="generator=large-file-simplification-gate cited_file=${lf_path} "
+	local _json="" _duplicate="" _failed=0
+
+	_json=$(gh_issue_list --repo "$repo_slug" --state open --label "file-size-debt" \
+		--search "\"${lf_path}\" large-file-simplification-gate in:body sort:created-asc" \
+		--json number,body --limit 100 2>/dev/null) || return 1
+	while IFS= read -r _duplicate; do
+		[[ -n "$_duplicate" && "$_duplicate" != "$canonical_issue" ]] || continue
+		if ! gh issue close "$_duplicate" --repo "$repo_slug" --reason "not planned" \
+			--comment "Superseded by canonical file-size-debt #${canonical_issue}; closed by duplicate reconciliation." >/dev/null 2>&1; then
+			_failed=1
+		fi
+	done < <(printf '%s' "$_json" | jq -r --arg marker "$_marker" \
+		'.[] | select((.body // "") | contains($marker)) | .number' 2>/dev/null)
+	[[ "$_failed" -eq 0 ]]
+	return $?
 }
 
 #######################################
@@ -559,8 +594,9 @@ _Created by large-file simplification gate (pulse-dispatch-core.sh)_"
 			_canonical_num="${_canonical_combined#open:}"
 		fi
 		if [[ -n "$_canonical_num" && "$_canonical_num" != "$_new_num" ]]; then
-			gh issue close "$_new_num" --repo "$repo_slug" --reason "not planned" \
-				--comment "Superseded by canonical file-size-debt #${_canonical_num}; closed by post-create race reconciliation." >/dev/null 2>&1 || true
+			if ! _large_file_gate_close_duplicate_debt_issues "$repo_slug" "$lf_path" "$_canonical_num"; then
+				echo "[pulse-wrapper] WARN: failed to close one or more duplicate file-size-debt issues for ${lf_path}; next pulse will retry" >>"$LOGFILE"
+			fi
 			printf '#%s (existing)' "$_canonical_num"
 			return 0
 		fi
@@ -627,6 +663,9 @@ _large_file_gate_create_debt_issue() {
 	fi
 
 	if [[ "$_existing_state" == "open" ]]; then
+		if ! _large_file_gate_close_duplicate_debt_issues "$repo_slug" "$lf_path" "$_existing"; then
+			echo "[pulse-wrapper] WARN: duplicate reconciliation incomplete for canonical file-size-debt #${_existing}; next pulse will retry" >>"$LOGFILE"
+		fi
 		if ! _large_file_gate_normalize_debt_issue "$_existing" "$repo_slug"; then
 			echo "[pulse-wrapper] WARN: failed to normalize canonical file-size-debt #${_existing}; deferring" >>"$LOGFILE"
 			return 0

--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -315,9 +315,8 @@ _large_file_gate_resolve_full_path() {
 # reduced the file below threshold. Returns:
 #   0 — "continuation is valid" (file now under threshold OR measurement
 #       unavailable; caller should emit the continuation reference)
-#   1 — "continuation is phantom" (file still over threshold; caller should
-#       fall through to create a fresh debt issue, and this helper has
-#       already logged the skip to $LOGFILE)
+#   1 — file still over threshold; caller should reopen the canonical debt
+#       issue, and this helper has already logged the decision to $LOGFILE
 #
 # t2169: When the issue carries the `simplification-incomplete` label
 # (applied by the Simplification Outcome Check workflow when a merged PR
@@ -342,7 +341,7 @@ _large_file_gate_verify_prior_reduced_size() {
 		_sc_labels=$(gh_issue_view "$existing_issue" --repo "$repo_slug" \
 			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _sc_labels=""
 		if [[ ",$_sc_labels," == *",simplification-incomplete,"* ]]; then
-			echo "[pulse-wrapper] Large-file gate: prior issue #${existing_issue} has simplification-incomplete label; filing fresh debt (outcome-check short-circuit) (t2169)" >>"$LOGFILE"
+			echo "[pulse-wrapper] Large-file gate: prior issue #${existing_issue} has simplification-incomplete label; reopening canonical debt issue (outcome-check short-circuit)" >>"$LOGFILE"
 			return 1
 		fi
 	fi
@@ -365,9 +364,8 @@ _large_file_gate_verify_prior_reduced_size() {
 		return 0
 	fi
 	if [[ "$_verify_lines" -ge "$LARGE_FILE_LINE_THRESHOLD" ]]; then
-		# File still over threshold — log the phantom-continuation skip
-		# so the gate's audit trail captures why a fresh issue is filed.
-		echo "[pulse-wrapper] Large-file gate: prior file-size-debt #${existing_issue} closed but ${lf_path} still ${_verify_lines} lines (threshold ${LARGE_FILE_LINE_THRESHOLD}); filing fresh debt issue (t2164)" >>"$LOGFILE"
+		# File still over threshold — preserve one durable issue per path.
+		echo "[pulse-wrapper] Large-file gate: prior file-size-debt #${existing_issue} closed but ${lf_path} still ${_verify_lines} lines (threshold ${LARGE_FILE_LINE_THRESHOLD}); reopening canonical debt issue" >>"$LOGFILE"
 		return 1
 	fi
 	# wc -l returned 0 (empty file / read error) — treat same as unavailable.
@@ -376,7 +374,8 @@ _large_file_gate_verify_prior_reduced_size() {
 
 #######################################
 # t2164 / t2995 helper — find an open or recently-closed file-size-debt
-# issue that mentions `_lf_basename`. Prints "<state>:<number>" on stdout
+# issue carrying the exact generated `cited_file` marker. Prints
+# "<state>:<number>" on stdout
 # when found (state is "open" or "closed"); prints nothing otherwise.
 #
 # State is emitted as a stdout prefix instead of via `printf -v` because the
@@ -391,7 +390,7 @@ _large_file_gate_verify_prior_reduced_size() {
 # scanner cycle that timed out — observed 7 duplicates for worktree-helper.sh
 # alone over 30 days).
 #
-# Arguments: repo_slug, lf_basename
+# Arguments: repo_slug, lf_path
 # Stdout: "open:12345", "closed:18706", or empty
 # Exit codes:
 #   0 — match found (stdout populated)
@@ -401,7 +400,8 @@ _large_file_gate_verify_prior_reduced_size() {
 #######################################
 _large_file_gate_find_existing_debt_issue() {
 	local repo_slug="$1"
-	local lf_basename="$2"
+	local lf_path="$2"
+	local _marker="generator=large-file-simplification-gate cited_file=${lf_path}"
 
 	# Open-state lookup. One retry with 2s backoff covers GitHub search
 	# index lag (typically 1-3s after issue creation) — t2995 investigation
@@ -409,16 +409,16 @@ _large_file_gate_find_existing_debt_issue() {
 	# retrying a real failure would just hit the same timeout twice.
 	local _open _open_rc=0
 	_open=$(gh_issue_list --repo "$repo_slug" --state open \
-		--label "file-size-debt" --search "$lf_basename" \
+		--label "file-size-debt" --search "\"$_marker\" in:body" \
 		--json number --jq '.[0].number // empty' --limit 5 2>/dev/null) || _open_rc=$?
 	if [[ $_open_rc -eq 0 && -z "$_open" ]]; then
 		sleep 2
 		_open=$(gh_issue_list --repo "$repo_slug" --state open \
-			--label "file-size-debt" --search "$lf_basename" \
+			--label "file-size-debt" --search "\"$_marker\" in:body" \
 			--json number --jq '.[0].number // empty' --limit 5 2>/dev/null) || _open_rc=$?
 	fi
 	if [[ $_open_rc -ne 0 ]]; then
-		echo "[pulse-wrapper] WARN: file-size-debt dedup open-search failed for ${lf_basename} (rc=${_open_rc}); deferring (t2995)" >>"$LOGFILE"
+		echo "[pulse-wrapper] WARN: file-size-debt dedup open-search failed for ${lf_path} (rc=${_open_rc}); deferring (t2995)" >>"$LOGFILE"
 		return 2
 	fi
 	if [[ -n "$_open" ]]; then
@@ -426,22 +426,14 @@ _large_file_gate_find_existing_debt_issue() {
 		return 0
 	fi
 
-	local _reopen_days="${LFG_DEBT_REOPEN_DAYS:-30}"
-	local _recent_date
-	_recent_date=$(date -u "-v-${_reopen_days}d" "+%Y-%m-%d" 2>/dev/null ||
-		date -u -d "${_reopen_days} days ago" "+%Y-%m-%d" 2>/dev/null || true)
-	if [[ -z "$_recent_date" ]]; then
-		return 1
-	fi
-
 	local _closed _closed_rc=0
 	_closed=$(gh_issue_list --repo "$repo_slug" \
 		--state closed --label "file-size-debt" \
-		--search "$lf_basename closed:>$_recent_date" \
+		--search "\"$_marker\" in:body" \
 		--json number --jq '.[0].number // empty' \
 		--limit 5 2>/dev/null) || _closed_rc=$?
 	if [[ $_closed_rc -ne 0 ]]; then
-		echo "[pulse-wrapper] WARN: file-size-debt dedup closed-search failed for ${lf_basename} (rc=${_closed_rc}); deferring (t2995)" >>"$LOGFILE"
+		echo "[pulse-wrapper] WARN: file-size-debt dedup closed-search failed for ${lf_path} (rc=${_closed_rc}); deferring (t2995)" >>"$LOGFILE"
 		return 2
 	fi
 	if [[ -n "$_closed" ]]; then
@@ -449,6 +441,28 @@ _large_file_gate_find_existing_debt_issue() {
 		return 0
 	fi
 	return 1
+}
+
+#######################################
+# Reopen the canonical debt issue when its cited file remains oversized.
+# Reusing the durable issue identity prevents close/create/auto-dispatch loops.
+# Arguments: issue_number, lf_path, repo_slug
+#######################################
+_large_file_gate_reopen_debt_issue() {
+	local issue_number="$1"
+	local lf_path="$2"
+	local repo_slug="$3"
+
+	if ! gh issue reopen "$issue_number" --repo "$repo_slug" >/dev/null 2>&1; then
+		echo "[pulse-wrapper] WARN: failed to reopen canonical file-size-debt #${issue_number} for ${lf_path}; deferring" >>"$LOGFILE"
+		return 1
+	fi
+	gh issue edit "$issue_number" --repo "$repo_slug" \
+		--add-label "file-size-debt,auto-dispatch" \
+		--remove-label "status:done,not-planned,simplification-incomplete" >/dev/null 2>&1 || true
+	echo "[pulse-wrapper] Reopened canonical file-size-debt issue #${issue_number} for ${lf_path}" >>"$LOGFILE"
+	printf '#%s (reopened)' "$issue_number"
+	return 0
 }
 
 #######################################
@@ -551,9 +565,6 @@ _large_file_gate_create_debt_issue() {
 	local parent_issue="$2"
 	local repo_slug="$3"
 	local repo_path="${4:-}"
-	local _lf_basename
-	_lf_basename=$(basename "$lf_path")
-
 	# t2164: helper encodes state in stdout as "<state>:<number>" — subshell
 	# boundary prevents `printf -v` from crossing the command substitution.
 	# t2995: helper now returns 2 when lookup fails (timeout / gh failure),
@@ -561,9 +572,9 @@ _large_file_gate_create_debt_issue() {
 	# to filing a fresh issue — that's the duplicate-creation bug. Defer to
 	# the next pulse cycle.
 	local _existing_combined _existing _existing_state _lookup_rc=0
-	_existing_combined=$(_large_file_gate_find_existing_debt_issue "$repo_slug" "$_lf_basename") || _lookup_rc=$?
+	_existing_combined=$(_large_file_gate_find_existing_debt_issue "$repo_slug" "$lf_path") || _lookup_rc=$?
 	if [[ "$_lookup_rc" -eq 2 ]]; then
-		echo "[pulse-wrapper] file-size-debt dedup lookup failed for ${_lf_basename} (parent #${parent_issue}); deferring filing to next cycle (t2995)" >>"$LOGFILE"
+		echo "[pulse-wrapper] file-size-debt dedup lookup failed for ${lf_path} (parent #${parent_issue}); deferring filing to next cycle (t2995)" >>"$LOGFILE"
 		return 0
 	fi
 	if [[ -n "$_existing_combined" && "$_existing_combined" == *:* ]]; then
@@ -589,9 +600,9 @@ _large_file_gate_create_debt_issue() {
 			printf '#%s (recently-closed — continuation)' "$_existing"
 			return 0
 		fi
-		# Fall through: prior attempt did not reduce file size — file a
-		# fresh debt issue that references the failed prior attempt.
-		_large_file_gate_file_new_debt_issue "$lf_path" "$parent_issue" "$repo_slug" "$_existing"
+		# The file remains oversized. Reopen the durable per-path issue instead
+		# of creating a successor that can feed an unbounded dispatch loop.
+		_large_file_gate_reopen_debt_issue "$_existing" "$lf_path" "$repo_slug" || true
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -401,21 +401,25 @@ _large_file_gate_verify_prior_reduced_size() {
 _large_file_gate_find_existing_debt_issue() {
 	local repo_slug="$1"
 	local lf_path="$2"
-	local _marker="generator=large-file-simplification-gate cited_file=${lf_path}"
+	local _marker="generator=large-file-simplification-gate cited_file=${lf_path} "
 
 	# Open-state lookup. One retry with 2s backoff covers GitHub search
 	# index lag (typically 1-3s after issue creation) — t2995 investigation
 	# step 4. We only retry when the call SUCCEEDED but returned empty;
 	# retrying a real failure would just hit the same timeout twice.
-	local _open _open_rc=0
-	_open=$(gh_issue_list --repo "$repo_slug" --state open \
-		--label "file-size-debt" --search "\"$_marker\" in:body" \
-		--json number --jq '.[0].number // empty' --limit 5 2>/dev/null) || _open_rc=$?
+	local _open _open_json _open_rc=0
+	_open_json=$(gh_issue_list --repo "$repo_slug" --state open \
+		--label "file-size-debt" --search "large-file-simplification-gate in:body" \
+		--json number,body --limit 100 2>/dev/null) || _open_rc=$?
+	_open=$(printf '%s' "$_open_json" | jq -r --arg marker "$_marker" \
+		'[.[] | select((.body // "") | contains($marker)) | .number] | min // empty' 2>/dev/null) || _open_rc=$?
 	if [[ $_open_rc -eq 0 && -z "$_open" ]]; then
 		sleep 2
-		_open=$(gh_issue_list --repo "$repo_slug" --state open \
-			--label "file-size-debt" --search "\"$_marker\" in:body" \
-			--json number --jq '.[0].number // empty' --limit 5 2>/dev/null) || _open_rc=$?
+		_open_json=$(gh_issue_list --repo "$repo_slug" --state open \
+			--label "file-size-debt" --search "large-file-simplification-gate in:body" \
+			--json number,body --limit 100 2>/dev/null) || _open_rc=$?
+		_open=$(printf '%s' "$_open_json" | jq -r --arg marker "$_marker" \
+			'[.[] | select((.body // "") | contains($marker)) | .number] | min // empty' 2>/dev/null) || _open_rc=$?
 	fi
 	if [[ $_open_rc -ne 0 ]]; then
 		echo "[pulse-wrapper] WARN: file-size-debt dedup open-search failed for ${lf_path} (rc=${_open_rc}); deferring (t2995)" >>"$LOGFILE"
@@ -426,12 +430,13 @@ _large_file_gate_find_existing_debt_issue() {
 		return 0
 	fi
 
-	local _closed _closed_rc=0
-	_closed=$(gh_issue_list --repo "$repo_slug" \
+	local _closed _closed_json _closed_rc=0
+	_closed_json=$(gh_issue_list --repo "$repo_slug" \
 		--state closed --label "file-size-debt" \
-		--search "\"$_marker\" in:body" \
-		--json number --jq '.[0].number // empty' \
-		--limit 5 2>/dev/null) || _closed_rc=$?
+		--search "large-file-simplification-gate in:body" \
+		--json number,body --limit 100 2>/dev/null) || _closed_rc=$?
+	_closed=$(printf '%s' "$_closed_json" | jq -r --arg marker "$_marker" \
+		'[.[] | select((.body // "") | contains($marker)) | .number] | min // empty' 2>/dev/null) || _closed_rc=$?
 	if [[ $_closed_rc -ne 0 ]]; then
 		echo "[pulse-wrapper] WARN: file-size-debt dedup closed-search failed for ${lf_path} (rc=${_closed_rc}); deferring (t2995)" >>"$LOGFILE"
 		return 2
@@ -441,6 +446,26 @@ _large_file_gate_find_existing_debt_issue() {
 		return 0
 	fi
 	return 1
+}
+
+#######################################
+# Restore the labels required for an active canonical debt issue.
+# Arguments: issue_number, repo_slug
+#######################################
+_large_file_gate_normalize_debt_issue() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	if ! gh issue edit "$issue_number" --repo "$repo_slug" \
+		--add-label "file-size-debt,auto-dispatch" >/dev/null 2>&1; then
+		return 1
+	fi
+	local _stale_label
+	for _stale_label in status:done not-planned simplification-incomplete; do
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--remove-label "$_stale_label" >/dev/null 2>&1 || true
+	done
+	return 0
 }
 
 #######################################
@@ -457,9 +482,10 @@ _large_file_gate_reopen_debt_issue() {
 		echo "[pulse-wrapper] WARN: failed to reopen canonical file-size-debt #${issue_number} for ${lf_path}; deferring" >>"$LOGFILE"
 		return 1
 	fi
-	gh issue edit "$issue_number" --repo "$repo_slug" \
-		--add-label "file-size-debt,auto-dispatch" \
-		--remove-label "status:done,not-planned,simplification-incomplete" >/dev/null 2>&1 || true
+	if ! _large_file_gate_normalize_debt_issue "$issue_number" "$repo_slug"; then
+		echo "[pulse-wrapper] WARN: reopened file-size-debt #${issue_number} but failed to normalize labels; next pulse will retry" >>"$LOGFILE"
+		return 1
+	fi
 	echo "[pulse-wrapper] Reopened canonical file-size-debt issue #${issue_number} for ${lf_path}" >>"$LOGFILE"
 	printf '#%s (reopened)' "$issue_number"
 	return 0
@@ -523,6 +549,21 @@ _Created by large-file simplification gate (pulse-dispatch-core.sh)_"
 		head -1 |
 		grep -oE '[0-9]+$' || true)
 	if [[ -n "$_new_num" ]]; then
+		# Reconcile concurrent search-then-create races after GitHub's search
+		# index has had time to expose both issues. The oldest exact-marker
+		# match is canonical; any later issue created by this caller is closed.
+		sleep 3
+		local _canonical_combined _canonical_num="" _reconcile_rc=0
+		_canonical_combined=$(_large_file_gate_find_existing_debt_issue "$repo_slug" "$lf_path") || _reconcile_rc=$?
+		if [[ "$_reconcile_rc" -eq 0 && "$_canonical_combined" == open:* ]]; then
+			_canonical_num="${_canonical_combined#open:}"
+		fi
+		if [[ -n "$_canonical_num" && "$_canonical_num" != "$_new_num" ]]; then
+			gh issue close "$_new_num" --repo "$repo_slug" --reason "not planned" \
+				--comment "Superseded by canonical file-size-debt #${_canonical_num}; closed by post-create race reconciliation." >/dev/null 2>&1 || true
+			printf '#%s (existing)' "$_canonical_num"
+			return 0
+		fi
 		printf '#%s (new)' "$_new_num"
 		echo "[pulse-wrapper] Created file-size-debt issue #${_new_num} for ${lf_path} (blocking #${parent_issue})" >>"$LOGFILE"
 	else
@@ -586,6 +627,10 @@ _large_file_gate_create_debt_issue() {
 	fi
 
 	if [[ "$_existing_state" == "open" ]]; then
+		if ! _large_file_gate_normalize_debt_issue "$_existing" "$repo_slug"; then
+			echo "[pulse-wrapper] WARN: failed to normalize canonical file-size-debt #${_existing}; deferring" >>"$LOGFILE"
+			return 0
+		fi
 		printf '#%s (existing)' "$_existing"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
+++ b/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
@@ -24,7 +24,7 @@
 #
 # Fix (t2164): add a wc -l verification step in the recently-closed branch.
 # Only short-circuit as continuation when the file is now under threshold.
-# If still over, log and fall through to file a fresh debt issue. Preserve
+# If still over, log and reopen the canonical debt issue. Preserve
 # the pre-t2164 behaviour (trust the closed signal) when repo_path is
 # missing or the file isn't on disk in this checkout — measurement
 # unavailable is safer-as-continuation than safer-as-duplicate.
@@ -33,7 +33,7 @@
 #   1. Closed exists, file UNDER threshold, repo_path provided
 #      → returns "(recently-closed — continuation)"
 #   2. Closed exists, file OVER threshold, repo_path provided
-#      → does NOT return continuation; creates new issue with prior-attempt ref
+#      → does NOT create a successor; reopens the canonical issue
 #   3. Closed exists, no repo_path
 #      → returns "(recently-closed — continuation)" (backward-compat fallback)
 #   4. Closed exists, repo_path set but file not on disk
@@ -134,6 +134,12 @@ gh() {
 			return 0
 		fi
 	fi
+	if [[ "$1" == "issue" && "$2" == "reopen" ]]; then
+		return 0
+	fi
+	if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+		return 0
+	fi
 
 	# label create — silent no-op
 	if [[ "$1" == "label" && "$2" == "create" ]]; then
@@ -205,19 +211,23 @@ assert_eq \
 	"#18706 (recently-closed — continuation)" \
 	"$out"
 
-# ---- Test 2 — closed exists, file OVER threshold → fall through to new ----
+# ---- Test 2 — closed exists, file OVER threshold → reopen canonical ----
 GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE="18706"
-GH_CREATE_RESPONSE_URL="https://github.com/owner/repo/issues/77777"
+GH_CREATE_RESPONSE_URL=""
 out=$(_large_file_gate_create_debt_issue "over.sh" "9999" "owner/repo" "$TMP")
 assert_eq \
-	"closed + file over threshold → NEW (not continuation, GH#19415 root cause)" \
-	"#77777 (new)" \
+	"closed + file over threshold → reopen canonical issue" \
+	"#18706 (reopened)" \
 	"$out"
 assert_contains \
-	"file-over-threshold path logs the prior-attempt skip" \
+	"file-over-threshold path logs canonical reopen" \
 	"prior file-size-debt #18706 closed but over.sh still 2050 lines" \
 	"$(cat "$LOGFILE")"
+assert_contains \
+	"file-over-threshold path calls gh issue reopen" \
+	"gh issue reopen 18706 --repo owner/repo" \
+	"$(cat "$GH_CALLS_LOG")"
 
 # ---- Test 3 — closed exists, no repo_path → backward-compat continuation ----
 GH_OPEN_RESPONSE=""

--- a/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
+++ b/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
@@ -128,6 +128,16 @@ gh() {
 		closed) saw_closed="true" ;;
 		esac
 	done
+	if [[ "$1" == "issue" && "$2" == "list" && "$saw_open" == "false" && "$saw_closed" == "false" ]]; then
+		if [[ -n "$GH_OPEN_RESPONSE" ]]; then
+			printf '[{"number":%s,"state":"OPEN","body":"generator=large-file-simplification-gate cited_file=under.sh threshold=2000 generator=large-file-simplification-gate cited_file=over.sh threshold=2000 generator=large-file-simplification-gate cited_file=missing.sh threshold=2000"}]\n' "$GH_OPEN_RESPONSE"
+		elif [[ -n "$GH_CLOSED_RESPONSE" ]]; then
+			printf '[{"number":%s,"state":"CLOSED","body":"generator=large-file-simplification-gate cited_file=under.sh threshold=2000 generator=large-file-simplification-gate cited_file=over.sh threshold=2000 generator=large-file-simplification-gate cited_file=missing.sh threshold=2000"}]\n' "$GH_CLOSED_RESPONSE"
+		else
+			printf '[]\n'
+		fi
+		return 0
+	fi
 
 	if [[ "$1" == "issue" && "$2" == "list" ]]; then
 		if [[ "$saw_closed" == "true" ]]; then

--- a/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
+++ b/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
@@ -126,11 +126,19 @@ gh() {
 
 	if [[ "$1" == "issue" && "$2" == "list" ]]; then
 		if [[ "$saw_closed" == "true" ]]; then
-			printf '%s\n' "$GH_CLOSED_RESPONSE"
+			if [[ -n "$GH_CLOSED_RESPONSE" ]]; then
+				printf '[{"number":%s,"body":"generator=large-file-simplification-gate cited_file=under.sh threshold=2000 generator=large-file-simplification-gate cited_file=over.sh threshold=2000 generator=large-file-simplification-gate cited_file=missing.sh threshold=2000"}]\n' "$GH_CLOSED_RESPONSE"
+			else
+				printf '[]\n'
+			fi
 			return 0
 		fi
 		if [[ "$saw_open" == "true" ]]; then
-			printf '%s\n' "$GH_OPEN_RESPONSE"
+			if [[ -n "$GH_OPEN_RESPONSE" ]]; then
+				printf '[{"number":%s,"body":"generator=large-file-simplification-gate cited_file=under.sh threshold=2000 generator=large-file-simplification-gate cited_file=over.sh threshold=2000 generator=large-file-simplification-gate cited_file=missing.sh threshold=2000"}]\n' "$GH_OPEN_RESPONSE"
+			else
+				printf '[]\n'
+			fi
 			return 0
 		fi
 	fi

--- a/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
+++ b/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
@@ -102,6 +102,11 @@ gh_issue_list() {
 	return $?
 }
 
+gh_issue_view() {
+	printf ''
+	return 0
+}
+
 # t2995: no-op the 2-second retry sleep introduced for search-index lag
 # so the test doesn't actually pause.
 sleep() { return 0; }

--- a/.agents/scripts/tests/test-large-file-gate-dedup.sh
+++ b/.agents/scripts/tests/test-large-file-gate-dedup.sh
@@ -119,12 +119,20 @@ gh_issue_list() {
 		echo "$_n" >"$OPEN_CALL_COUNTER"
 		# On the SECOND open call, return STUB_GH_LIST_RETRY_OUT if set.
 		if [[ "$_n" -ge 2 && -n "${STUB_GH_LIST_RETRY_OUT:-}" ]]; then
-			printf '%s' "$STUB_GH_LIST_RETRY_OUT"
+			printf '[{"number":%s,"body":"generator=large-file-simplification-gate cited_file=worktree-helper.sh threshold=1000 generator=large-file-simplification-gate cited_file=.agents/scripts/worktree-helper.sh threshold=1000"}]' "$STUB_GH_LIST_RETRY_OUT"
 			return 0
 		fi
-		printf '%s' "${STUB_GH_LIST_OPEN_OUT:-}"
+		if [[ -n "${STUB_GH_LIST_OPEN_OUT:-}" ]]; then
+			printf '[{"number":%s,"body":"generator=large-file-simplification-gate cited_file=worktree-helper.sh threshold=1000 generator=large-file-simplification-gate cited_file=.agents/scripts/worktree-helper.sh threshold=1000"}]' "$STUB_GH_LIST_OPEN_OUT"
+		else
+			printf '[]'
+		fi
 	elif [[ "$_state" == "closed" ]]; then
-		printf '%s' "${STUB_GH_LIST_CLOSED_OUT:-}"
+		if [[ -n "${STUB_GH_LIST_CLOSED_OUT:-}" ]]; then
+			printf '[{"number":%s,"body":"generator=large-file-simplification-gate cited_file=worktree-helper.sh threshold=1000 generator=large-file-simplification-gate cited_file=.agents/scripts/worktree-helper.sh threshold=1000"}]' "$STUB_GH_LIST_CLOSED_OUT"
+		else
+			printf '[]'
+		fi
 	fi
 	return "${STUB_GH_LIST_RC:-0}"
 }
@@ -154,6 +162,14 @@ export -f _large_file_gate_verify_prior_reduced_size
 # short-circuit it for deterministic test runtime.
 sleep() { return 0; }
 export -f sleep
+
+gh() {
+	if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+		return 0
+	fi
+	return 0
+}
+export -f gh
 
 # Bash 3.2 + LARGE_FILE_LINE_THRESHOLD (referenced by the gate script via
 # nested helpers). The dedup helper itself does not depend on this — but

--- a/.agents/scripts/tests/test-large-file-gate-dedup.sh
+++ b/.agents/scripts/tests/test-large-file-gate-dedup.sh
@@ -298,7 +298,7 @@ if [[ "$rc" == "0" && "$new_calls" == "0" ]]; then
 else
 	fail "caller:lookup-failed-defers" "rc=$rc new_calls=$new_calls out='$out'"
 fi
-if grep -q "file-size-debt dedup lookup failed for worktree-helper.sh" "$LOGFILE"; then
+if grep -q "file-size-debt dedup lookup failed for .agents/scripts/worktree-helper.sh" "$LOGFILE"; then
 	pass "caller:lookup-failed-defers logs deferral with parent ref"
 else
 	fail "caller:lookup-failed-defers logs" "log contents: $(cat "$LOGFILE")"
@@ -364,7 +364,7 @@ printf '\n%s\n\n' '--- Wrapper: gh_issue_list REST fallback parity for --search 
 				printf '0\n'
 				return 0
 			fi
-			if [[ "$2" =~ ^/search/issues ]]; then
+			if [[ "$*" == *"/search/issues"* ]]; then
 				# Real endpoint shape: { "items": [{ "number": 4242 }] }.
 				# After --jq ".items | .[0].number // empty" the result is "4242".
 				printf '4242\n'
@@ -387,7 +387,7 @@ printf '\n%s\n\n' '--- Wrapper: gh_issue_list REST fallback parity for --search 
 		--search worktree-helper.sh --json number --jq '.[0].number // empty' --limit 5 2>/dev/null)
 
 	# Verify /search/issues was called AND /repos/owner/repo/issues was NOT.
-	if grep -q "api /search/issues" "$GH_API_PATHS"; then
+	if grep -qE "api .*\/search/issues" "$GH_API_PATHS"; then
 		printf 'PASS_SEARCH\n' >"${TMP}/wrapper_result"
 	else
 		printf 'FAIL_SEARCH out=%s paths=%s\n' "$out" "$(cat "$GH_API_PATHS")" >"${TMP}/wrapper_result"

--- a/.agents/scripts/tests/test-large-file-gate-dedup.sh
+++ b/.agents/scripts/tests/test-large-file-gate-dedup.sh
@@ -170,6 +170,11 @@ gh() {
 	return 0
 }
 export -f gh
+gh_issue_view() {
+	printf ''
+	return 0
+}
+export -f gh_issue_view
 
 # Bash 3.2 + LARGE_FILE_LINE_THRESHOLD (referenced by the gate script via
 # nested helpers). The dedup helper itself does not depend on this — but

--- a/.agents/scripts/tests/test-large-file-gate-dedup.sh
+++ b/.agents/scripts/tests/test-large-file-gate-dedup.sh
@@ -112,6 +112,22 @@ gh_issue_list() {
 		*) shift ;;
 		esac
 	done
+	if [[ "$_state" == "all" ]]; then
+		local _all_n
+		_all_n=$(cat "$OPEN_CALL_COUNTER" 2>/dev/null || echo 0)
+		_all_n=$((_all_n + 1))
+		echo "$_all_n" >"$OPEN_CALL_COUNTER"
+		if [[ "$_all_n" -ge 2 && -n "${STUB_GH_LIST_RETRY_OUT:-}" ]]; then
+			printf '[{"number":%s,"state":"OPEN","body":"generator=large-file-simplification-gate cited_file=worktree-helper.sh threshold=1000 generator=large-file-simplification-gate cited_file=.agents/scripts/worktree-helper.sh threshold=1000"}]' "$STUB_GH_LIST_RETRY_OUT"
+		elif [[ -n "${STUB_GH_LIST_OPEN_OUT:-}" ]]; then
+			printf '[{"number":%s,"state":"OPEN","body":"generator=large-file-simplification-gate cited_file=worktree-helper.sh threshold=1000 generator=large-file-simplification-gate cited_file=.agents/scripts/worktree-helper.sh threshold=1000"}]' "$STUB_GH_LIST_OPEN_OUT"
+		elif [[ -n "${STUB_GH_LIST_CLOSED_OUT:-}" ]]; then
+			printf '[{"number":%s,"state":"CLOSED","body":"generator=large-file-simplification-gate cited_file=worktree-helper.sh threshold=1000 generator=large-file-simplification-gate cited_file=.agents/scripts/worktree-helper.sh threshold=1000"}]' "$STUB_GH_LIST_CLOSED_OUT"
+		else
+			printf '[]'
+		fi
+		return "${STUB_GH_LIST_RC:-0}"
+	fi
 	if [[ "$_state" == "open" ]]; then
 		local _n
 		_n=$(cat "$OPEN_CALL_COUNTER" 2>/dev/null || echo 0)
@@ -281,7 +297,7 @@ if [[ "$rc" == "2" && -z "$out" ]]; then
 else
 	fail "helper:lookup-failed" "rc=$rc out='$out'"
 fi
-if grep -q "file-size-debt dedup open-search failed for worktree-helper.sh" "$LOGFILE"; then
+if grep -q "file-size-debt dedup all-state search failed for worktree-helper.sh" "$LOGFILE"; then
 	pass "helper:lookup-failed logs WARN with basename"
 else
 	fail "helper:lookup-failed logs WARN" "log contents: $(cat "$LOGFILE")"


### PR DESCRIPTION
## Summary

- preserve one canonical file-size-debt issue per exact repository-relative path
- reopen the canonical issue when the file remains oversized instead of creating a successor
- reconcile concurrent search/create races and retry incomplete duplicate cleanup
- normalize dispatch labels and fail closed on lookup or repair errors

## Root cause

The large-file gate treated a closed debt issue whose file remained oversized as permission to create a fresh issue. Auto-dispatch then attempted the same simplification, closed it, and the next pulse created another issue. The lifecycle formed an unbounded close → recreate → dispatch loop.

## Verification

- `bash .agents/scripts/tests/test-large-file-gate-dedup.sh`
- `bash .agents/scripts/tests/test-large-file-gate-continuation-verify.sh`
- `shellcheck .agents/scripts/pulse-dispatch-large-file-gate.sh .agents/scripts/tests/test-large-file-gate-dedup.sh .agents/scripts/tests/test-large-file-gate-continuation-verify.sh`
- `.agents/scripts/linters-local.sh --full`

Resolves #27114

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18
