### PR TITLE
GH#27121: Optimise search CPU usage with scoped ripgrep

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -71,7 +71,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 ### Tool and file discipline
 
-- Prefer exact search first: `rg`/Grep, then `osgrep` for semantic search. File discovery with Bash available: `git ls-files '<pattern>'` for tracked files, `fd` for untracked, `rg --files -g '<pattern>'` for file lists. Glob is last resort.
+- Prefer exact search first: with Bash use scoped `rg` (or `git grep` for tracked content); use the runtime Grep tool only without Bash or for bounded searches. Then use `osgrep` for semantic search. File discovery with Bash available: `git ls-files '<pattern>'` for tracked files, `fd` for untracked, `rg --files -g '<pattern>'` for file lists. Glob is last resort.
 - Use Read for file reads. Always Read before Edit/Write existing files, re-read after modification before another edit, verify paths first, and include 3+ context lines in edits.
 - Output text directly; never use Bash `echo` to communicate. Call independent tools in parallel.
 - Slash commands: read `scripts/commands/<command>.md`, then `workflows/<command>.md` fallback.

--- a/.agents/scripts/issue-sync-lib-parse.sh
+++ b/.agents/scripts/issue-sync-lib-parse.sh
@@ -19,7 +19,7 @@
 #
 # Dependencies:
 #   - shared-constants.sh (print_error, print_info, log_verbose)
-#   - bash 3.2+, awk, sed, grep
+#   - bash 3.2+, awk, sed, grep; optional rg for faster tree searches
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -591,7 +591,11 @@ find_related_files() {
 	# 2. Search for files referencing this task ID in todo/tasks/
 	if [[ -d "$tasks_dir" ]]; then
 		local grep_files
-		grep_files=$(grep -rl "$task_id" "$tasks_dir" || true)
+		if command -v rg >/dev/null 2>&1; then
+			grep_files=$(rg -l -F -- "$task_id" "$tasks_dir" 2>/dev/null || true)
+		else
+			grep_files=$(grep -rlF -- "$task_id" "$tasks_dir" 2>/dev/null || true)
+		fi
 		if [[ -n "$grep_files" ]]; then
 			all_files="${all_files:+$all_files"$'\n'"}$grep_files"
 		fi

--- a/.agents/scripts/mission-skill-learner.sh
+++ b/.agents/scripts/mission-skill-learner.sh
@@ -299,7 +299,11 @@ _score_multi_feature_usage() {
 	if [[ -d "$mission_dir" ]]; then
 		local artifact_name
 		artifact_name=$(basename "$artifact_path")
-		ref_count=$(grep -rl "$artifact_name" "$mission_dir" 2>/dev/null | wc -l | tr -d ' ')
+		if command -v rg >/dev/null 2>&1; then
+			ref_count=$({ rg -l -F -- "$artifact_name" "$mission_dir" 2>/dev/null || true; } | wc -l | tr -d ' ')
+		else
+			ref_count=$({ grep -rlF -- "$artifact_name" "$mission_dir" 2>/dev/null || true; } | wc -l | tr -d ' ')
+		fi
 		# Subtract self-reference
 		ref_count=$((ref_count > 0 ? ref_count - 1 : 0))
 	fi
@@ -1247,4 +1251,6 @@ main() {
 	esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/testing-setup-helper.sh
+++ b/.agents/scripts/testing-setup-helper.sh
@@ -437,8 +437,13 @@ discover_ci() {
 	# GitHub Actions
 	if has_dir "$project_dir" ".github/workflows"; then
 		local has_test_step="false"
-		if grep -rl 'npm test\|yarn test\|pnpm test\|pytest\|cargo test\|go test\|bats' \
-			"${project_dir}/.github/workflows/" >/dev/null 2>&1; then
+		if command -v rg >/dev/null 2>&1 && \
+			rg -q -e 'npm test|yarn test|pnpm test|pytest|cargo test|go test|bats' \
+				"${project_dir}/.github/workflows/" 2>/dev/null; then
+			has_test_step="true"
+		elif ! command -v rg >/dev/null 2>&1 && \
+			grep -rEq 'npm test|yarn test|pnpm test|pytest|cargo test|go test|bats' \
+				"${project_dir}/.github/workflows/" 2>/dev/null; then
 			has_test_step="true"
 		fi
 		ci=$(echo "$ci" | jq --arg t "$has_test_step" \
@@ -1100,4 +1105,6 @@ main() {
 	return 0
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-scoped-ripgrep-searches.sh
+++ b/.agents/scripts/tests/test-scoped-ripgrep-searches.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression tests for scoped ripgrep search paths (GH#27121).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local label="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		printf '  [PASS] %s\n' "$label"
+		PASS=$((PASS + 1))
+	else
+		printf '  [FAIL] %s — expected %q got %q\n' "$label" "$expected" "$actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+mkdir -p "$TEST_ROOT/project/todo/tasks"
+printf '%s\n' '- [ ] t1[2] literal task' >"$TEST_ROOT/project/TODO.md"
+printf '%s\n' 'Task t1[2] is referenced here.' >"$TEST_ROOT/project/todo/tasks/literal.md"
+printf '%s\n' 'Task t12 must not match a fixed-string search.' >"$TEST_ROOT/project/todo/tasks/regex-lookalike.md"
+
+related_files=$(
+	SCRIPT_DIR="$REPO_ROOT/.agents/scripts"
+	# shellcheck source=../issue-sync-lib-parse.sh
+	source "$REPO_ROOT/.agents/scripts/issue-sync-lib-parse.sh"
+	find_related_files 't1[2]' "$TEST_ROOT/project"
+)
+assert_eq "issue sync treats task IDs as fixed strings" \
+	"$TEST_ROOT/project/todo/tasks/literal.md" "$related_files"
+
+mkdir -p "$TEST_ROOT/home/.aidevops/logs" "$TEST_ROOT/mission"
+artifact="$TEST_ROOT/mission/helper[1].sh"
+printf '%s\n' '# helper[1].sh' >"$artifact"
+printf '%s\n' 'uses helper[1].sh' >"$TEST_ROOT/mission/one.md"
+printf '%s\n' 'uses helper[1].sh' >"$TEST_ROOT/mission/two.md"
+printf '%s\n' 'uses helper[1].sh' >"$TEST_ROOT/mission/three.md"
+mission_score=$(HOME="$TEST_ROOT/home" \
+	JSONC_DEFAULTS="$REPO_ROOT/.agents/configs/aidevops.defaults.jsonc" bash -c \
+	'source "$1"; _score_multi_feature_usage "$2" "$3"' _ \
+	"$REPO_ROOT/.agents/scripts/mission-skill-learner.sh" "$artifact" "$TEST_ROOT/mission")
+assert_eq "mission scoring uses fixed-string artifact references" "20" "$mission_score"
+
+unused_artifact="$TEST_ROOT/mission/unused[1].sh"
+printf '%s\n' '# no references' >"$unused_artifact"
+unused_score=$(HOME="$TEST_ROOT/home" \
+	JSONC_DEFAULTS="$REPO_ROOT/.agents/configs/aidevops.defaults.jsonc" bash -c \
+	'source "$1"; _score_multi_feature_usage "$2" "$3"' _ \
+	"$REPO_ROOT/.agents/scripts/mission-skill-learner.sh" "$unused_artifact" "$TEST_ROOT/mission")
+assert_eq "mission scoring handles a no-match rg result" "0" "$unused_score"
+
+mkdir -p "$TEST_ROOT/project/.github/workflows"
+printf '%s\n' 'steps:' '  - run: pnpm test' >"$TEST_ROOT/project/.github/workflows/test.yml"
+ci_result=$(bash -c 'source "$1"; discover_ci "$2"' _ \
+	"$REPO_ROOT/.agents/scripts/testing-setup-helper.sh" "$TEST_ROOT/project")
+has_test_step=$(printf '%s' "$ci_result" | jq -r '.[0].has_test_step')
+assert_eq "CI discovery detects test commands with bounded search" "true" "$has_test_step"
+
+if rg -q 'rg -l -F --' "$REPO_ROOT/.agents/scripts/issue-sync-lib-parse.sh" && \
+	rg -q 'grep -rlF --' "$REPO_ROOT/.agents/scripts/issue-sync-lib-parse.sh"; then
+	assert_eq "issue sync retains portable grep fallback" "true" "true"
+else
+	assert_eq "issue sync retains portable grep fallback" "true" "false"
+fi
+
+printf '\nPassed: %d\nFailed: %d\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- route Bash-capable agent searches to scoped `rg` or `git grep`
- use ripgrep for recursive issue-sync and mission artifact searches, with portable fixed-string grep fallbacks
- make CI test-command discovery stop after its first match
- add regression coverage for fixed-string matching, no-match handling, and CI discovery

Resolves #27121

## Testing

- `bash .agents/scripts/tests/test-scoped-ripgrep-searches.sh`
- `bash -n` for all changed shell files
- `shellcheck` for all changed shell files
- `.agents/scripts/linters-local.sh --full`

## Runtime Testing

Self-assessed low-risk framework search optimisation. The focused regression suite executes the changed search paths against representative directory fixtures.

## Decisions

- retained `grep` for bounded streams and as a fallback where ripgrep is unavailable
- avoided a wholesale grep replacement because small-file portability checks do not benefit materially
- used fixed-string matching for task IDs and artifact names to avoid regex expansion

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 26m and 187,898 tokens on this with the user in an interactive session. Overall, 17m since this issue was created.
