### PR TITLE
GH#27005: Keep incomplete parent roadmaps open

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -824,6 +824,19 @@ _SP_CPT_NUDGED=0
 _SP_CPT_ESCALATED=0
 _SP_CPT_REOPENED=0
 
+_repair_recently_closed_parent() {
+	local slug="$1" issue_num="$2" issue_body="$3" known_child_count="$4"
+	local issue_state="$5"
+	[[ "$issue_state" == "CLOSED" ]] || return 1
+	if _parent_close_contract_incomplete "$issue_body" "$known_child_count"; then
+		if _repair_closed_parent_contract "$slug" "$issue_num" \
+			"$_PARENT_CLOSE_CONTRACT_REASON"; then
+			_SP_CPT_REOPENED=1
+		fi
+	fi
+	return 0
+}
+
 #######################################
 # Stage 4 action: reconcile a parent-task issue (close/nudge/escalate).
 # (Per-issue body of reconcile_completed_parent_tasks — no slug loop.)
@@ -889,13 +902,8 @@ _action_cpt_single() {
 
 	# Recently closed parents are repair candidates only when deterministic
 	# body evidence proves that the close contract remains incomplete.
-	if [[ "$issue_state" == "CLOSED" ]]; then
-		if _parent_close_contract_incomplete "$issue_body" "$known_child_count"; then
-			if _repair_closed_parent_contract "$slug" "$issue_num" \
-				"$_PARENT_CLOSE_CONTRACT_REASON"; then
-				_SP_CPT_REOPENED=1
-			fi
-		fi
+	if _repair_recently_closed_parent "$slug" "$issue_num" "$issue_body" \
+		"$known_child_count" "$issue_state"; then
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -299,51 +299,158 @@ _Detected by \`_try_close_parent_tracker\` (pulse-issue-reconcile.sh, t2786). Po
 	return 0
 }
 
+# Machine-readable parent close-contract result. The predicate below resets
+# these globals on every call so callers can explain and repair an incomplete
+# contract without reparsing the body.
+_PARENT_CLOSE_CONTRACT_REASON=""
+_PARENT_CLOSE_CONTRACT_DECLARED=0
+_PARENT_CLOSE_CONTRACT_UNFILED=""
+
+_parent_comments_api_path() {
+	local slug="$1" parent_num="$2"
+	printf 'repos/%s/issues/%s/comments\n' "$slug" "$parent_num"
+	return 0
+}
+
 #######################################
-# t2786 / GH#20871 / t3544: compose the unfiled-phases note that the
-# parent-close path appends to its closing comment. Returns "" on
-# stdout when there is no `## Phases` section, no parent body, or no
-# unfiled rows. Otherwise returns a multi-line note listing each
-# unfiled phase and a count.
+# Decide whether deterministic parent-body evidence blocks closure.
+# Backward compatibility is deliberate: legacy parents with no contract and
+# no unchecked criteria remain closable once every known child is terminal.
 #
-# Counting is over the structured parser's row output (see
-# _parse_phases_section in shared-phase-filing.sh). Each row is
-# `phase_num\tdescription\tmarker\tchild_ref`. Rows whose 4th tab
-# field (child_ref) is empty are unfiled.
+# Recognised contracts:
+#   - canonical ## Phases rows (every row must contain a child reference)
+#   - <!-- parent-close-contract: expected-children=N -->
+#   - <!-- parent-close-contract: complete -->
+#   - <!-- parent-close-contract: needs-decomposition|keep-open -->
+# Unchecked Markdown task-list criteria also block closure.
 #
-# IMPORTANT: do NOT compute unfiled count as `_declared_count - child_count`.
-# child_count is a union over graph + body + prose extractors and may
-# include children sourced outside `## Phases`. Counting unfiled rows
-# directly from the phases section keeps the count and the listed
-# phases in sync (Gemini review of PR #22605, t3544).
-#
-# Args: $1=parent_body, $2=parent_num, $3=slug, $4=child_count (for log)
-# Output: composed note (possibly empty) on stdout
-# Returns: 0 always
+# Args: $1=parent_body, $2=known_child_count
+# Returns: 0=incomplete, 1=complete or legacy-unknown
 #######################################
-_compose_unfiled_phases_note() {
-	local parent_body="$1" parent_num="$2" slug="$3" child_count="$4"
-	[[ -n "$parent_body" ]] || return 0
+_parent_close_contract_incomplete() {
+	local parent_body="$1"
+	local known_child_count="${2:-0}"
+	_PARENT_CLOSE_CONTRACT_REASON=""
+	_PARENT_CLOSE_CONTRACT_DECLARED=0
+	_PARENT_CLOSE_CONTRACT_UNFILED=""
+	[[ -n "$parent_body" ]] || return 1
 
-	local _phases_section
-	_phases_section=$(_parse_phases_section "$parent_body")
-	[[ -n "$_phases_section" ]] || return 0
+	local phases_section="" unfiled_count=0
+	phases_section=$(_parse_phases_section "$parent_body")
+	if [[ -n "$phases_section" ]]; then
+		_PARENT_CLOSE_CONTRACT_DECLARED=$(printf '%s\n' "$phases_section" | \
+			awk -F'\t' '$1 ~ /^[0-9]+$/ { c++ } END { print c+0 }')
+		_PARENT_CLOSE_CONTRACT_UNFILED=$(printf '%s\n' "$phases_section" | \
+			awk -F'\t' '$1 ~ /^[0-9]+$/ && $4 == "" { printf "Phase %s: %s\n", $1, $2 }')
+		unfiled_count=$(printf '%s\n' "$phases_section" | \
+			awk -F'\t' '$1 ~ /^[0-9]+$/ && $4 == "" { c++ } END { print c+0 }')
+		if [[ "$unfiled_count" -gt 0 ]]; then
+			_PARENT_CLOSE_CONTRACT_REASON="unfiled-phases"
+			return 0
+		fi
+	fi
 
-	local _declared_count="" _unfiled_phases="" _unfiled_count=""
-	_declared_count=$(printf '%s\n' "$_phases_section" | safe_grep_count -E '^[0-9]+	')
-	_unfiled_phases=$(printf '%s\n' "$_phases_section" | \
-		awk -F'\t' '$1 ~ /^[0-9]+$/ && $4 == "" { printf "- Phase %s: %s\n", $1, $2 }')
-	_unfiled_count=$(printf '%s\n' "$_phases_section" | \
-		awk -F'\t' '$1 ~ /^[0-9]+$/ && $4 == "" { c++ } END { print c+0 }')
-	[[ "$_unfiled_count" -gt 0 ]] || return 0
+	local expected_children=""
+	expected_children=$(printf '%s\n' "$parent_body" | \
+		sed -nE 's/.*<!-- parent-close-contract: expected-children=([0-9]+) -->.*/\1/p' | head -n1)
+	if [[ "$expected_children" =~ ^[0-9]+$ ]] && [[ "$known_child_count" -lt "$expected_children" ]]; then
+		_PARENT_CLOSE_CONTRACT_REASON="expected-children:${expected_children}"
+		return 0
+	fi
 
-	# shellcheck disable=SC2016
-	# Single quotes intentional: literal markdown backticks around `## Phases`
-	# must be preserved in the output — no shell expansion is intended.
-	printf '\n\n**Note:** %s declared phase(s) remain unfiled:\n\n%s\nRe-open this parent and file additional phase children if more work is planned. The `## Phases` section is a roadmap, not a contract — closing here reflects that all *filed* children are done.' \
-		"$_unfiled_count" "$_unfiled_phases"
+	if [[ "$parent_body" == *"<!-- parent-close-contract: phase-plan -->"* && -z "$phases_section" ]]; then
+		_PARENT_CLOSE_CONTRACT_REASON="invalid-phase-plan"
+		return 0
+	fi
+	if [[ "$parent_body" == *"<!-- parent-close-contract: needs-decomposition -->"* || \
+		"$parent_body" == *"<!-- parent-close-contract: keep-open -->"* ]]; then
+		_PARENT_CLOSE_CONTRACT_REASON="needs-decomposition"
+		return 0
+	fi
+	if printf '%s\n' "$parent_body" | grep -qE '^[[:space:]]*[-*][[:space:]]+\[[[:space:]]\]'; then
+		_PARENT_CLOSE_CONTRACT_REASON="unchecked-criteria"
+		return 0
+	fi
 
-	echo "[pulse-wrapper] Reconcile parent-task: closing #${parent_num} in ${slug} with unfiled-phases note — declared ${_declared_count} phases, ${_unfiled_count} unfiled, ${child_count} children counted (t3544)" >>"${LOGFILE:-/dev/null}"
+	return 1
+}
+
+#######################################
+# Post a one-time worker-ready explanation for a non-phase close-contract
+# failure. The caller supplies the marker so open-parent nudges and closed-
+# parent repairs each remain independently idempotent.
+# Args: $1=slug, $2=parent_num, $3=reason, $4=marker
+# Returns: 0=posted, 1=already present or API/comment failure
+#######################################
+_post_parent_close_contract_nudge() {
+	local slug="$1" parent_num="$2" reason="$3" marker="$4"
+	local existing="" comments_api=""
+	comments_api=$(_parent_comments_api_path "$slug" "$parent_num")
+	existing=$(gh api --paginate "$comments_api" \
+		--jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
+		2>/dev/null | wc -l | tr -d ' ') || existing=""
+	[[ "$existing" =~ ^[0-9]+$ ]] || return 1
+	[[ "$existing" -eq 0 ]] || return 1
+
+	local guidance="Complete the declared decomposition and update the parent close contract before closure."
+	case "$reason" in
+	expected-children:*)
+		guidance="Link all ${reason#expected-children:} expected child issues, then rerun reconciliation."
+		;;
+	unchecked-criteria)
+		guidance="Resolve or check every remaining parent acceptance criterion, then rerun reconciliation."
+		;;
+	invalid-phase-plan)
+		guidance="Rewrite the phase plan in canonical list or bold phase form and link each filed child."
+		;;
+	esac
+
+	local comment_body="${marker}
+## Parent Tracker: Close Contract Incomplete
+
+Reconciliation found deterministic evidence that this parent objective is not complete (${reason}). The parent remains open so declared work is not lost.
+
+**Recovery:** ${guidance}
+
+_Posted once by parent close-contract reconciliation._"
+	gh_issue_comment "$parent_num" --repo "$slug" --body "$comment_body" >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_mark_parent_needs_decomposition() {
+	local slug="$1" parent_num="$2"
+	if declare -F gh_issue_edit_safe >/dev/null 2>&1; then
+		gh_issue_edit_safe "$parent_num" --repo "$slug" \
+			--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
+	else
+		gh issue edit "$parent_num" --repo "$slug" \
+			--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
+	fi
+	return 0
+}
+
+#######################################
+# Reopen a recently closed parent only when deterministic close-contract
+# evidence proves that closure was premature. The repair marker makes retries
+# no-ops even if another automation closes the parent again.
+# Args: $1=slug, $2=parent_num, $3=reason
+# Returns: 0=reopened, 1=already repaired or API failure
+#######################################
+_repair_closed_parent_contract() {
+	local slug="$1" parent_num="$2" reason="$3"
+	local marker='<!-- parent-close-contract-repaired -->'
+	local existing="" comments_api=""
+	comments_api=$(_parent_comments_api_path "$slug" "$parent_num")
+	existing=$(gh api --paginate "$comments_api" \
+		--jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
+		2>/dev/null | wc -l | tr -d ' ') || existing=""
+	[[ "$existing" =~ ^[0-9]+$ ]] || return 1
+	[[ "$existing" -eq 0 ]] || return 1
+
+	gh issue reopen "$parent_num" --repo "$slug" >/dev/null 2>&1 || return 1
+	_post_parent_close_contract_nudge "$slug" "$parent_num" "$reason" "$marker" || true
+	_mark_parent_needs_decomposition "$slug" "$parent_num"
+	echo "[pulse-wrapper] Reconcile parent-task: reopened #${parent_num} in ${slug} — incomplete close contract (${reason})" >>"${LOGFILE:-/dev/null}"
 	return 0
 }
 
@@ -353,11 +460,7 @@ _compose_unfiled_phases_note() {
 # threshold and makes the close decision independently testable.
 #
 # Returns 0 if the parent was closed, 1 if skipped (no known children,
-# any child still open, or close call failed). When the parent body
-# declares more phases in `## Phases` than have been filed, the closing
-# comment is augmented with an unfiled-phases note instead of blocking
-# the close (t3544 — pre-t3544 behaviour silently rotted single-filed
-# parents like #22371 / #22372).
+# any child still open, incomplete close contract, or close call failed).
 _try_close_parent_tracker() {
 	local slug="$1" parent_num="$2" child_nums="$3" child_source="$4" parent_body="${5:-}"
 	local all_closed="true" child_summary="" child_count=0
@@ -406,19 +509,26 @@ _try_close_parent_tracker() {
 	# one real child issue (Gemini review of PR #22605, t3544).
 	[[ "$all_closed" == "true" && "$child_count" -gt 0 ]] || return 1
 
-	# t2786 / GH#20871 / t3544: declared-vs-filed augmentation —
-	# delegated to _compose_unfiled_phases_note to keep this function
-	# under the 100-line shell-complexity gate. Returns "" when there
-	# is no `## Phases` section, no parent body, or no unfiled rows.
-	local _unfiled_note=""
-	_unfiled_note=$(_compose_unfiled_phases_note "$parent_body" "$parent_num" "$slug" "$child_count")
+	if _parent_close_contract_incomplete "$parent_body" "$child_count"; then
+		if [[ "$_PARENT_CLOSE_CONTRACT_REASON" == "unfiled-phases" ]]; then
+			_post_parent_phases_unfiled_nudge "$slug" "$parent_num" \
+				"$_PARENT_CLOSE_CONTRACT_DECLARED" "$child_count" \
+				"$_PARENT_CLOSE_CONTRACT_UNFILED" || true
+		else
+			_post_parent_close_contract_nudge "$slug" "$parent_num" \
+				"$_PARENT_CLOSE_CONTRACT_REASON" '<!-- parent-close-contract-incomplete -->' || true
+		fi
+		_mark_parent_needs_decomposition "$slug" "$parent_num"
+		echo "[pulse-wrapper] Reconcile parent-task: kept #${parent_num} open in ${slug} — incomplete close contract (${_PARENT_CLOSE_CONTRACT_REASON})" >>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
 
 	gh issue close "$parent_num" --repo "$slug" \
-		--comment "## All filed child tasks completed — closing parent tracker
+		--comment "## All declared child tasks completed — closing parent tracker
 
 ${child_summary}
 
-All ${child_count} filed child issue(s) are resolved. Parent tracker closed automatically.${_unfiled_note}
+All ${child_count} declared child issue(s) are resolved and the parent close contract is complete. Parent tracker closed automatically.
 
 _Detected by reconcile_completed_parent_tasks (pulse-issue-reconcile.sh)._" \
 		>/dev/null 2>&1 || return 1
@@ -712,27 +822,31 @@ _action_oimp_single() {
 _SP_CPT_CLOSED=0
 _SP_CPT_NUDGED=0
 _SP_CPT_ESCALATED=0
+_SP_CPT_REOPENED=0
 
 #######################################
 # Stage 4 action: reconcile a parent-task issue (close/nudge/escalate).
 # (Per-issue body of reconcile_completed_parent_tasks — no slug loop.)
 #
-# Sets _SP_CPT_CLOSED / _SP_CPT_NUDGED / _SP_CPT_ESCALATED globals (each 0|1)
+# Sets _SP_CPT_CLOSED / _SP_CPT_NUDGED / _SP_CPT_ESCALATED /
+# _SP_CPT_REOPENED globals (each 0|1)
 # to communicate which actions were taken. Caller reads and resets these.
 #
 # Args:
 #   $1=slug, $2=issue_num, $3=issue_title, $4=issue_body
 #   $5=can_close (1|0), $6=can_nudge (1|0), $7=can_escalate (1|0)
-#   $8=escalation_threshold_hours
+#   $8=escalation_threshold_hours, $9=issue_state (OPEN|CLOSED)
 # Returns: 0 always (action outcomes via globals)
 #######################################
 _action_cpt_single() {
 	local slug="$1" issue_num="$2" issue_title="$3" issue_body="$4"
 	local can_close="${5:-0}" can_nudge="${6:-0}" can_escalate="${7:-0}"
 	local escalation_threshold_hours="${8:-168}"
+	local issue_state="${9:-OPEN}"
 	_SP_CPT_CLOSED=0
 	_SP_CPT_NUDGED=0
 	_SP_CPT_ESCALATED=0
+	_SP_CPT_REOPENED=0
 
 	# Child detection (GH#20872): UNION of (graph, body, prose) sources, not
 	# first-non-empty-wins (the pre-GH#20872 behaviour). Real-world parent
@@ -769,6 +883,21 @@ _action_cpt_single() {
 	child_nums=$(printf '%s\n%s\n%s\n' "$_g_nums" "$_b_nums" "$_p_nums" \
 		| grep -E '^[0-9]+$' | sort -un | grep -v "^${issue_num}$" || true)
 	local child_source="${_src_parts:-none}"
+	local known_child_count=0
+	known_child_count=$(printf '%s\n' "$child_nums" | \
+		awk '$0 ~ /^[0-9]+$/ { c++ } END { print c+0 }')
+
+	# Recently closed parents are repair candidates only when deterministic
+	# body evidence proves that the close contract remains incomplete.
+	if [[ "$issue_state" == "CLOSED" ]]; then
+		if _parent_close_contract_incomplete "$issue_body" "$known_child_count"; then
+			if _repair_closed_parent_contract "$slug" "$issue_num" \
+				"$_PARENT_CLOSE_CONTRACT_REASON"; then
+				_SP_CPT_REOPENED=1
+			fi
+		fi
+		return 0
+	fi
 
 	if [[ -z "$child_nums" ]]; then
 		# No children — try phase extractor, then nudge/escalate (t2771/t2388/t2442)

--- a/.agents/scripts/pulse-issue-reconcile-parent.sh
+++ b/.agents/scripts/pulse-issue-reconcile-parent.sh
@@ -300,6 +300,25 @@ _Automated by \`_post_parent_decomposition_escalation\` in \`pulse-issue-reconci
 #          or comment call failed).
 #######################################
 
+_recent_closed_parent_cutoff() {
+	if date --version >/dev/null 2>&1; then
+		date -u -d '7 days ago' +%Y-%m-%d
+	else
+		date -u -v-7d +%Y-%m-%d
+	fi
+	return 0
+}
+
+_fetch_recently_closed_parent_tasks() {
+	local slug="$1" parent_label="$2"
+	local cutoff=""
+	cutoff=$(_recent_closed_parent_cutoff) || return 1
+	gh_issue_list --repo "$slug" --state closed \
+		--label "$parent_label" --search "closed:>=${cutoff}" \
+		--json number,title,body,state --limit 10 2>/dev/null || return 1
+	return 0
+}
+
 reconcile_completed_parent_tasks() {
 	local repos_json="$REPOS_JSON"
 	[[ -f "$repos_json" ]] || return 0
@@ -312,6 +331,9 @@ reconcile_completed_parent_tasks() {
 	# is enough to avoid review-queue spam while still making progress.
 	local total_escalated=0
 	local max_escalations=3
+	local total_reopened=0
+	local max_reopens=5
+	local _open_state="OPEN"
 	# t2442: parent-task escalation threshold — nudge must have sat for
 	# at least this many hours with zero children before we escalate.
 	# 7 days = 168 hours. Override via env for tests / incident response.
@@ -319,22 +341,25 @@ reconcile_completed_parent_tasks() {
 
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
-		[[ "$total_closed" -lt "$max_closes" || "$total_nudged" -lt "$max_nudges" || "$total_escalated" -lt "$max_escalations" ]] || break
+		[[ "$total_closed" -lt "$max_closes" || "$total_nudged" -lt "$max_nudges" || "$total_escalated" -lt "$max_escalations" || "$total_reopened" -lt "$max_reopens" ]] || break
 
 		# t2773: prefer prefetch cache (now includes body field); fall back to gh_issue_list.
 		# Use module-level _PIR_PT_LABEL to avoid a second literal (string-literal ratchet).
 		local _cpt_lbl="$_PIR_PT_LABEL"
-		local issues_json _cache_issues_cpt
+		local issues_json open_issues_json closed_issues_json _cache_issues_cpt
 		if _cache_issues_cpt=$(_read_cache_issues_for_slug "$slug" 2>/dev/null); then
-			issues_json=$(printf '%s' "$_cache_issues_cpt" | \
-				jq -c --arg lbl "$_cpt_lbl" \
-				'[.[] | select(.labels | map(.name) | index($lbl))] | .[0:10]' \
-				2>/dev/null) || issues_json="[]"
+			open_issues_json=$(printf '%s' "$_cache_issues_cpt" | \
+				jq -c --arg lbl "$_cpt_lbl" --arg state "$_open_state" \
+				'[.[] | select(.labels | map(.name) | index($lbl)) | . + {state:$state}] | .[0:10]' \
+				2>/dev/null) || open_issues_json="[]"
 		else
-			issues_json=$(gh_issue_list --repo "$slug" --state open \
+			open_issues_json=$(gh_issue_list --repo "$slug" --state open \
 				--label "$_cpt_lbl" \
-				--json number,title,body --limit 10 2>/dev/null) || issues_json="[]"
+				--json number,title,body,state --limit 10 2>/dev/null) || open_issues_json="[]"
 		fi
+		closed_issues_json=$(_fetch_recently_closed_parent_tasks "$slug" "$_cpt_lbl") || closed_issues_json="[]"
+		issues_json=$(printf '%s\n%s\n' "$open_issues_json" "$closed_issues_json" | \
+			jq -sc 'add | unique_by(.number) | .[0:20]' 2>/dev/null) || issues_json="[]"
 		[[ -n "$issues_json" && "$issues_json" != "null" ]] || continue
 
 		local issue_count
@@ -342,11 +367,13 @@ reconcile_completed_parent_tasks() {
 		[[ "$issue_count" -gt 0 ]] || continue
 
 		local i=0
-		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" || "$total_nudged" -lt "$max_nudges" || "$total_escalated" -lt "$max_escalations" ]]; do
-			local issue_num issue_body issue_title
+		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" || "$total_nudged" -lt "$max_nudges" || "$total_escalated" -lt "$max_escalations" || "$total_reopened" -lt "$max_reopens" ]]; do
+			local issue_num issue_body issue_title issue_state
 			issue_num=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].number // ""') || true
 			issue_body=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].body // ""') || true
 			issue_title=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].title // ""') || true
+			issue_state=$(printf '%s' "$issues_json" | \
+				jq -r --argjson i "$i" --arg state "$_open_state" '.[$i].state // $state') || issue_state="$_open_state"
 			i=$((i + 1))
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
@@ -359,15 +386,16 @@ reconcile_completed_parent_tasks() {
 			[[ $((_can_close + _can_nudge + _can_escalate)) -gt 0 ]] || continue
 
 			_action_cpt_single "$slug" "$issue_num" "$issue_title" "$issue_body" \
-				"$_can_close" "$_can_nudge" "$_can_escalate" "$escalation_threshold_hours"
+				"$_can_close" "$_can_nudge" "$_can_escalate" "$escalation_threshold_hours" "$issue_state"
 			[[ "$_SP_CPT_CLOSED" -eq 1 ]] && total_closed=$((total_closed + 1))
 			[[ "$_SP_CPT_NUDGED" -eq 1 ]] && total_nudged=$((total_nudged + 1))
 			[[ "$_SP_CPT_ESCALATED" -eq 1 ]] && total_escalated=$((total_escalated + 1))
+			[[ "$_SP_CPT_REOPENED" -eq 1 ]] && total_reopened=$((total_reopened + 1))
 		done
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
-	if [[ "$total_closed" -gt 0 || "$total_nudged" -gt 0 || "$total_escalated" -gt 0 ]]; then
-		echo "[pulse-wrapper] Reconcile completed parent tasks: closed=${total_closed} nudged=${total_nudged} escalated=${total_escalated}" >>"$LOGFILE"
+	if [[ "$total_closed" -gt 0 || "$total_nudged" -gt 0 || "$total_escalated" -gt 0 || "$total_reopened" -gt 0 ]]; then
+		echo "[pulse-wrapper] Reconcile completed parent tasks: closed=${total_closed} reopened=${total_reopened} nudged=${total_nudged} escalated=${total_escalated}" >>"$LOGFILE"
 	fi
 
 	return 0

--- a/.agents/scripts/pulse-issue-reconcile-parent.sh
+++ b/.agents/scripts/pulse-issue-reconcile-parent.sh
@@ -346,7 +346,7 @@ reconcile_completed_parent_tasks() {
 		# t2773: prefer prefetch cache (now includes body field); fall back to gh_issue_list.
 		# Use module-level _PIR_PT_LABEL to avoid a second literal (string-literal ratchet).
 		local _cpt_lbl="$_PIR_PT_LABEL"
-		local issues_json open_issues_json closed_issues_json _cache_issues_cpt
+		local issues_json="" open_issues_json="" closed_issues_json="" _cache_issues_cpt=""
 		if _cache_issues_cpt=$(_read_cache_issues_for_slug "$slug" 2>/dev/null); then
 			open_issues_json=$(printf '%s' "$_cache_issues_cpt" | \
 				jq -c --arg lbl "$_cpt_lbl" --arg state "$_open_state" \
@@ -368,7 +368,7 @@ reconcile_completed_parent_tasks() {
 
 		local i=0
 		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" || "$total_nudged" -lt "$max_nudges" || "$total_escalated" -lt "$max_escalations" || "$total_reopened" -lt "$max_reopens" ]]; do
-			local issue_num issue_body issue_title issue_state
+			local issue_num="" issue_body="" issue_title="" issue_state=""
 			issue_num=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].number // ""') || true
 			issue_body=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].body // ""') || true
 			issue_title=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].title // ""') || true

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -264,6 +264,18 @@ ${marker}"
 	return 0
 }
 
+_GH_CI_READY_ARGS=()
+_gh_ci_prepare_parent_contract_and_signature() {
+	local is_parent_task=0
+	if _gh_wrapper_args_have_label "parent-task" "$@" "${_GH_CI_TODO_LABEL_ARGS[@]}"; then
+		is_parent_task=1
+	fi
+	_gh_ci_prepare_parent_close_contract "$is_parent_task" "$@"
+	_gh_wrapper_auto_sig "${_GH_CI_CONTRACT_ARGS[@]}"
+	_GH_CI_READY_ARGS=("${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}")
+	return 0
+}
+
 gh_create_issue() {
 	_gh_wrapper_enter_cleanup_scope
 	gh_record_call graphql gh_create_issue 2>/dev/null || true
@@ -296,19 +308,9 @@ gh_create_issue() {
 		_todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]}")
 	fi
 
-	# Stamp every newly created parent-task with a deterministic close contract.
-	# The contract is added before the signature so the signature remains the
-	# final body footer. Derived TODO labels participate in parent detection.
-	local _is_parent_task=0
-	if _gh_wrapper_args_have_label "parent-task" "$@" "${_todo_label_args[@]}"; then
-		_is_parent_task=1
-	fi
-	_gh_ci_prepare_parent_close_contract "$_is_parent_task" "$@"
-	set -- "${_GH_CI_CONTRACT_ARGS[@]}"
-
-	# t2115: auto-append signature footer when body lacks one
-	_gh_wrapper_auto_sig "$@"
-	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
+	# Stamp parent close contracts before the signature so it remains the footer.
+	_gh_ci_prepare_parent_contract_and_signature "$@"
+	set -- "${_GH_CI_READY_ARGS[@]}"
 
 	if [[ ${#_todo_label_args[@]} -gt 0 ]]; then
 		_gh_ci_prepare_status_label "$@" "${_todo_label_args[@]}"

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -186,6 +186,84 @@ _gh_ci_prepare_status_label() {
 	return 0
 }
 
+_GH_CI_CONTRACT_ARGS=()
+_gh_ci_prepare_parent_close_contract() {
+	local is_parent_task="$1"
+	shift
+	_GH_CI_CONTRACT_ARGS=("$@")
+	[[ "$is_parent_task" -eq 1 ]] || return 0
+
+	local i=0 body_idx=-1 body="" body_file_idx=-1 body_file=""
+	local body_eq=0 body_file_eq=0
+	while [[ "$i" -lt ${#_GH_CI_CONTRACT_ARGS[@]} ]]; do
+		case "${_GH_CI_CONTRACT_ARGS[i]}" in
+		--body)
+			body_idx=$i
+			body="${_GH_CI_CONTRACT_ARGS[i + 1]:-}"
+			;;
+		--body=*)
+			body_idx=$i
+			body="${_GH_CI_CONTRACT_ARGS[i]#--body=}"
+			body_eq=1
+			;;
+		--body-file)
+			body_file_idx=$i
+			body_file="${_GH_CI_CONTRACT_ARGS[i + 1]:-}"
+			;;
+		--body-file=*)
+			body_file_idx=$i
+			body_file="${_GH_CI_CONTRACT_ARGS[i]#--body-file=}"
+			body_file_eq=1
+			;;
+		esac
+		i=$((i + 1))
+	done
+	if [[ -z "$body" && -n "$body_file" && -r "$body_file" ]]; then
+		body=$(<"$body_file")
+	fi
+	[[ -n "$body" ]] || return 0
+	[[ "$body" == *"<!-- parent-close-contract:"* ]] && return 0
+
+	local marker='<!-- parent-close-contract: needs-decomposition -->'
+	if printf '%s\n' "$body" | grep -qE '^##[[:space:]]+Phases([[:space:]]|$)'; then
+		marker='<!-- parent-close-contract: phase-plan -->'
+	else
+		local children_count=0
+		children_count=$(printf '%s\n' "$body" | awk '
+			/^##[[:space:]]+(Children|Child Issues|Sub-issues|Sub-tasks)([[:space:]]|$)/ { in_children=1; next }
+			in_children && /^##[[:space:]]/ { exit }
+			in_children { print }
+		' | grep -oE '#[0-9]+' | sort -u | wc -l | tr -d ' ')
+		if [[ "$children_count" =~ ^[0-9]+$ ]] && [[ "$children_count" -gt 0 ]]; then
+			marker="<!-- parent-close-contract: expected-children=${children_count} -->"
+		fi
+	fi
+	local contracted_body="${body}
+
+${marker}"
+
+	if [[ "$body_idx" -ge 0 ]]; then
+		if [[ "$body_eq" -eq 1 ]]; then
+			_GH_CI_CONTRACT_ARGS[body_idx]="--body=${contracted_body}"
+		else
+			_GH_CI_CONTRACT_ARGS[body_idx + 1]="$contracted_body"
+		fi
+		return 0
+	fi
+	if [[ "$body_file_idx" -ge 0 ]]; then
+		local contracted_body_file=""
+		contracted_body_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-parent-body.XXXXXX") || return 0
+		push_cleanup "rm -f \"$contracted_body_file\""
+		printf '%s\n' "$contracted_body" >"$contracted_body_file" || return 0
+		if [[ "$body_file_eq" -eq 1 ]]; then
+			_GH_CI_CONTRACT_ARGS[body_file_idx]="--body-file=${contracted_body_file}"
+		else
+			_GH_CI_CONTRACT_ARGS[body_file_idx + 1]="$contracted_body_file"
+		fi
+	fi
+	return 0
+}
+
 gh_create_issue() {
 	_gh_wrapper_enter_cleanup_scope
 	gh_record_call graphql gh_create_issue 2>/dev/null || true
@@ -205,10 +283,6 @@ gh_create_issue() {
 	# Ensure labels exist on the target repo (once per repo per process)
 	_ensure_origin_labels_for_args "$@"
 
-	# t2115: auto-append signature footer when body lacks one
-	_gh_wrapper_auto_sig "$@"
-	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
-
 	# t2436: Derive creation-time labels from TODO.md tags + filter --todo-task-id.
 	# Helper writes _GH_CI_FILTERED_ARGS and _GH_CI_TODO_LABEL_ARGS globals.
 	_gh_ci_prepare_todo_labels "$@"
@@ -221,6 +295,20 @@ gh_create_issue() {
 	if [[ ${#_GH_CI_TODO_LABEL_ARGS[@]} -gt 0 ]]; then
 		_todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]}")
 	fi
+
+	# Stamp every newly created parent-task with a deterministic close contract.
+	# The contract is added before the signature so the signature remains the
+	# final body footer. Derived TODO labels participate in parent detection.
+	local _is_parent_task=0
+	if _gh_wrapper_args_have_label "parent-task" "$@" "${_todo_label_args[@]}"; then
+		_is_parent_task=1
+	fi
+	_gh_ci_prepare_parent_close_contract "$_is_parent_task" "$@"
+	set -- "${_GH_CI_CONTRACT_ARGS[@]}"
+
+	# t2115: auto-append signature footer when body lacks one
+	_gh_wrapper_auto_sig "$@"
+	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 
 	if [[ ${#_todo_label_args[@]} -gt 0 ]]; then
 		_gh_ci_prepare_status_label "$@" "${_todo_label_args[@]}"

--- a/.agents/scripts/tests/test-parent-task-lifecycle.sh
+++ b/.agents/scripts/tests/test-parent-task-lifecycle.sh
@@ -419,6 +419,25 @@ assert_grep_fixed \
 	'<!-- parent-close-contract: needs-decomposition -->' \
 	"$WRAPPER_TARGET"
 
+# Exercise inline-body mutation directly. Sourcing defines the helper without
+# invoking any GitHub operations; body-file cleanup is covered by wrapper tests.
+# shellcheck source=/dev/null
+source "$WRAPPER_TARGET"
+_gh_ci_prepare_parent_close_contract 1 --body $'## Phases\n\n- Phase 1 - deliver #101' --label parent-task
+contract_args=$(printf '%s\n' "${_GH_CI_CONTRACT_ARGS[@]}")
+assert_contains "B10e: canonical phase body receives phase-plan contract" \
+	'<!-- parent-close-contract: phase-plan -->' "$contract_args"
+
+_gh_ci_prepare_parent_close_contract 1 --body $'## Children\n\n- #101\n- #102' --label parent-task
+contract_args=$(printf '%s\n' "${_GH_CI_CONTRACT_ARGS[@]}")
+assert_contains "B10f: children body records expected child count" \
+	'<!-- parent-close-contract: expected-children=2 -->' "$contract_args"
+
+_gh_ci_prepare_parent_close_contract 0 --body 'ordinary leaf issue' --label bug
+contract_args=$(printf '%s\n' "${_GH_CI_CONTRACT_ARGS[@]}")
+assert_not_contains "B10g: non-parent issue body remains unstamped" \
+	'<!-- parent-close-contract:' "$contract_args"
+
 # ============================================================
 echo ""
 echo "${TEST_BLUE}=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed ===${TEST_NC}"

--- a/.agents/scripts/tests/test-parent-task-lifecycle.sh
+++ b/.agents/scripts/tests/test-parent-task-lifecycle.sh
@@ -33,7 +33,8 @@
 #   B4. Guard queries existing comments for idempotency
 #   B5. Guard posts via gh_issue_comment wrapper
 #   B6. _try_close_parent_tracker accepts parent_body as 5th parameter
-#   B7. Guard skips close when declared_count > child_count
+#   B7. Close contract blocks declared/unfiled work while preserving legacy
+#       complete single-child closure
 #   B8. _action_cpt_single passes issue_body to _try_close_parent_tracker
 #   B9. _action_cpt_single bootstraps phase-only parents before advisory nudges
 
@@ -156,6 +157,7 @@ _parse_phases_section() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TARGET="$SCRIPT_DIR/pulse-issue-reconcile.sh"
 ACTIONS_TARGET="$SCRIPT_DIR/pulse-issue-reconcile-actions.sh"
+WRAPPER_TARGET="$SCRIPT_DIR/shared-gh-wrappers-create.sh"
 
 if [[ ! -f "$TARGET" || ! -f "$ACTIONS_TARGET" ]]; then
 	echo "${TEST_RED}FATAL${TEST_NC}: reconcile source files not found"
@@ -337,49 +339,31 @@ assert_grep_fixed \
 	'local slug="$1" parent_num="$2" child_nums="$3" child_source="$4" parent_body="${5:-}"' \
 	"$ACTIONS_TARGET"
 
-# B7: declared-vs-filed mismatch composes a closing-comment note
-# instead of blocking close (t3544). Pre-t3544 behaviour returned 1
-# and posted a one-time nudge that produced no follow-on action; this
-# left single-filed-child parents (#22371, #22372) silently rotting
-# with all filed children closed and the parent still OPEN.
-#
-# B7a (post-Gemini-review of PR #22605): note composition is delegated
-# to _compose_unfiled_phases_note. The helper computes _unfiled_count
-# directly from phases-section rows (not _declared_count - child_count)
-# so the count always agrees with the listed unfiled phases even when
-# child_count includes non-Phases-section children.
+# B7: deterministic close contract separates "known children terminal" from
+# "parent objective complete". Legacy parents without deterministic blockers
+# remain compatible, including genuine single-child trackers.
 assert_grep_fixed \
-	'B7a: unfiled-phases helper exists and gates on _unfiled_count > 0' \
-	'_compose_unfiled_phases_note() {' \
+	'B7a: close-contract predicate exists' \
+	'_parent_close_contract_incomplete() {' \
 	"$ACTIONS_TARGET"
 assert_grep_fixed \
-	'B7b: _try_close_parent_tracker captures helper output as _unfiled_note' \
-	'_unfiled_note=$(_compose_unfiled_phases_note "$parent_body" "$parent_num" "$slug" "$child_count")' \
+	'B7b: close path checks the contract after child terminality' \
+	'if _parent_close_contract_incomplete "$parent_body" "$child_count"; then' \
 	"$ACTIONS_TARGET"
 assert_grep_fixed \
-	'B7c: closing comment template embeds the unfiled-phases note' \
-	'${_unfiled_note}' \
+	'B7c: incomplete canonical phases post the idempotent phase nudge' \
+	'_post_parent_phases_unfiled_nudge "$slug" "$parent_num"' \
 	"$ACTIONS_TARGET"
-# B7c-vacuous: t3544 + Gemini — close path requires child_count > 0
+# B7d-vacuous: close path requires child_count > 0
 # alongside all_closed. Pre-fix, a parent referencing only PRs/external
 # refs would skip the per-child loop, leave child_count=0, all_closed
-# defaulting to "true", and produce "All 0 filed child task(s) are
+# defaulting to "true", and produce "All 0 declared child task(s) are
 # resolved." Verify the guard is in place.
 assert_grep_fixed \
-	'B7c-vacuous: close gate requires child_count > 0 (no vacuous-truth close)' \
+	'B7d: close gate requires child_count > 0 (no vacuous-truth close)' \
 	'[[ "$all_closed" == "true" && "$child_count" -gt 0 ]] || return 1' \
 	"$ACTIONS_TARGET"
-# B7c-direct-count: helper computes _unfiled_count from phases-section
-# rows directly, NOT by subtracting child_count from _declared_count.
-TESTS_RUN=$((TESTS_RUN + 1))
-if grep -qE '_unfiled_count=\$\(\(_declared_count[[:space:]]*-[[:space:]]*child_count\)\)' "$ACTIONS_TARGET" 2>/dev/null; then
-	TESTS_FAILED=$((TESTS_FAILED + 1))
-	echo "${TEST_RED}FAIL${TEST_NC}: B7c-direct-count: _unfiled_count must not be derived as _declared_count - child_count (Gemini review of PR #22605)"
-else
-	echo "${TEST_GREEN}PASS${TEST_NC}: B7c-direct-count: _unfiled_count computed directly from phases-section rows"
-fi
-
-# B7d: t3544 — the `child_count >= 2` short-circuit MUST be removed.
+# B7e: the `child_count >= 2` short-circuit MUST remain removed.
 # Single-filed-child parents are legitimate (incremental phase rollout);
 # the prior `[[ "$child_count" -ge 2 ]] || return 1` blocked them from
 # both closing AND from receiving the declared-vs-filed nudge, causing
@@ -387,17 +371,18 @@ fi
 TESTS_RUN=$((TESTS_RUN + 1))
 if grep -qE '\[\[[[:space:]]+"\$child_count"[[:space:]]+-ge[[:space:]]+2[[:space:]]+\]\][[:space:]]+\|\|[[:space:]]+return[[:space:]]+1' "$ACTIONS_TARGET" 2>/dev/null; then
 	TESTS_FAILED=$((TESTS_FAILED + 1))
-	echo "${TEST_RED}FAIL${TEST_NC}: B7d: t3544 — child_count >= 2 short-circuit must be removed from $ACTIONS_TARGET"
+	echo "${TEST_RED}FAIL${TEST_NC}: B7e: child_count >= 2 short-circuit must be removed from $ACTIONS_TARGET"
 else
-	echo "${TEST_GREEN}PASS${TEST_NC}: B7d: t3544 — child_count >= 2 short-circuit removed (single-filed-child parents can close)"
+	echo "${TEST_GREEN}PASS${TEST_NC}: B7e: child_count >= 2 short-circuit removed (complete single-child parents can close)"
 fi
 
-# B7e: closing comment heading reflects "filed" semantics so maintainers
-# understand the close is scoped to currently-filed children, not all
-# declared phases.
 assert_grep_fixed \
-	'B7e: closing-comment heading uses "filed child tasks" wording' \
-	'## All filed child tasks completed' \
+	'B7f: closing-comment heading reflects declared child completion' \
+	'## All declared child tasks completed' \
+	"$ACTIONS_TARGET"
+assert_grep_fixed \
+	'B7g: unchecked parent criteria are deterministic close blockers' \
+	'_PARENT_CLOSE_CONTRACT_REASON="unchecked-criteria"' \
 	"$ACTIONS_TARGET"
 
 # B8: call site passes issue_body as 5th arg
@@ -415,6 +400,24 @@ assert_grep_fixed \
 	"B9b: shared phase bootstrap helper is defined" \
 	'auto_file_next_unfiled_parent_phase() {' \
 	"$SHARED_TARGET"
+
+# B10: parent creation stamps a machine-readable contract before signing.
+assert_grep_fixed \
+	"B10a: parent creation contract helper is defined" \
+	'_gh_ci_prepare_parent_close_contract() {' \
+	"$WRAPPER_TARGET"
+assert_grep_fixed \
+	"B10b: phase-plan contract marker is generated" \
+	'<!-- parent-close-contract: phase-plan -->' \
+	"$WRAPPER_TARGET"
+assert_grep_fixed \
+	"B10c: child-count contract marker is generated" \
+	'<!-- parent-close-contract: expected-children=${children_count} -->' \
+	"$WRAPPER_TARGET"
+assert_grep_fixed \
+	"B10d: undecomposed parents receive a fail-closed marker" \
+	'<!-- parent-close-contract: needs-decomposition -->' \
+	"$WRAPPER_TARGET"
 
 # ============================================================
 echo ""

--- a/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
@@ -105,7 +105,11 @@ EOF
 	_release_interactive_claim_on_merge() { return 0; }
 	set_solved_label() { return 0; }
 	auto_file_next_phase() { return 0; }
-	export -f unlock_issue_after_worker fast_fail_reset _release_interactive_claim_on_merge set_solved_label auto_file_next_phase 2>/dev/null || true
+	_pm_handle_partial_parent_closeout() { return 0; }
+	clear_terminal_issue_dispatch_labels() { return 0; }
+	export -f unlock_issue_after_worker fast_fail_reset _release_interactive_claim_on_merge \
+		set_solved_label auto_file_next_phase _pm_handle_partial_parent_closeout \
+		clear_terminal_issue_dispatch_labels 2>/dev/null || true
 
 	# Shim shared-gh-wrappers.sh wrappers → gh binary stub. The function was
 	# refactored post-GH#21595 to use gh_pr_comment / gh_issue_comment instead

--- a/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
+++ b/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
@@ -10,8 +10,9 @@
 #   2. Uses the graph result (authoritative) when non-empty, even if body has
 #      no #NNN references.
 #   3. Falls back to body-regex for legacy parents whose graph is empty.
-#   4. Still requires >=2 children (single-reference guard preserved).
+#   4. Allows a complete legacy single-child parent to close.
 #   5. Still requires ALL children closed (partial-open no-close preserved).
+#   6. Keeps declared/unfiled phase plans open and repairs premature closes.
 #
 # Primary motivating case: #19222 (t2126 parent with 5 closed children wired
 # via GraphQL, zero #NNN in body). Without this fix the parent stays open
@@ -127,7 +128,9 @@ case "$1" in
 	issue)
 		case "${2:-}" in
 			list)
-				if [[ -f "${TEST_ROOT}/gh-issue-list.json" ]]; then
+				if [[ -f "${TEST_ROOT}/gh-closed-issue-list.json" ]]; then
+					cat "${TEST_ROOT}/gh-closed-issue-list.json"
+				elif [[ -f "${TEST_ROOT}/gh-issue-list.json" ]]; then
 					cat "${TEST_ROOT}/gh-issue-list.json"
 				else
 					echo "[]"
@@ -136,6 +139,9 @@ case "$1" in
 				;;
 			close)
 				# Record the close call; always succeed
+				exit 0
+				;;
+			reopen | comment | edit)
 				exit 0
 				;;
 		esac
@@ -162,13 +168,32 @@ export REPOS_JSON="$REPOS_JSON_FILE"
 # shellcheck source=/dev/null
 source "${TEST_SCRIPTS_DIR}/pulse-issue-reconcile.sh" >/dev/null 2>&1
 
+# Keep this harness deterministic regardless of the host's REST-first/rate-limit
+# wrapper state. Production still exercises the shared wrappers; the test sends
+# their final command shape directly to the local gh stub.
+gh_issue_list() {
+	gh issue list "$@" && return 0
+	return 1
+}
+
+gh_issue_comment() {
+	gh issue comment "$@" && return 0
+	return 1
+}
+
+gh_issue_edit_safe() {
+	gh issue edit "$@" && return 0
+	return 1
+}
+
 # -----------------------------------------------------------------------------
 # Scenario helpers
 # -----------------------------------------------------------------------------
 reset_scenario() {
 	: >"$GH_CALLS"
 	: >"$LOGFILE"
-	rm -f "${TEST_ROOT}/gh-subissues.json" "${TEST_ROOT}/gh-child-states.env" "${TEST_ROOT}/gh-issue-list.json"
+	rm -f "${TEST_ROOT}/gh-subissues.json" "${TEST_ROOT}/gh-child-states.env" \
+		"${TEST_ROOT}/gh-issue-list.json" "${TEST_ROOT}/gh-closed-issue-list.json"
 }
 
 set_parent_list() {
@@ -176,6 +201,14 @@ set_parent_list() {
 	local num="$1" title="$2" body="$3"
 	jq -n --argjson n "$num" --arg t "$title" --arg b "$body" \
 		'[{number:$n, title:$t, body:$b}]' >"${TEST_ROOT}/gh-issue-list.json"
+}
+
+set_closed_parent_list() {
+	# Args: issue_num title body
+	local num="$1" title="$2" body="$3"
+	jq -n --argjson n "$num" --arg t "$title" --arg b "$body" \
+		'[{number:$n, title:$t, body:$b, state:"CLOSED"}]' >"${TEST_ROOT}/gh-closed-issue-list.json"
+	return 0
 }
 
 set_subissues() {
@@ -239,7 +272,7 @@ fi
 # -----------------------------------------------------------------------------
 reset_scenario
 set_parent_list 500 "t500: legacy parent" \
-	"Tracks #501 and #502 as children."
+	$'## Children\n\n- #501\n- #502'
 printf '[]\n' >"${TEST_ROOT}/gh-subissues.json"
 set_child_states "501:closed:child-A" "502:closed:child-B"
 
@@ -278,8 +311,8 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# Scenario 4: graph has only 1 child (below min-2 threshold).
-# MUST NOT close, even if it's closed — single-reference guard.
+# Scenario 4: complete legacy parent has one real closed child and no
+# deterministic incomplete contract. Backward compatibility MUST close it.
 # -----------------------------------------------------------------------------
 reset_scenario
 set_parent_list 700 "t700: single-ref" "Only references #701."
@@ -289,10 +322,10 @@ set_child_states "701:closed:lone-child"
 reconcile_completed_parent_tasks >/dev/null 2>&1
 
 if grep -q "issue close 700" "$GH_CALLS"; then
-	print_result "single-child guard: does NOT close parent with 1 subissue" 1 \
-		"(unexpected close: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+	print_result "single-child compatibility: closes complete legacy parent" 0
 else
-	print_result "single-child guard: does NOT close parent with 1 subissue" 0
+	print_result "single-child compatibility: closes complete legacy parent" 1 \
+		"(calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
 fi
 
 # -----------------------------------------------------------------------------
@@ -336,7 +369,7 @@ fi
 # -----------------------------------------------------------------------------
 reset_scenario
 set_parent_list 1000 "t1000: graphql-failure" \
-	"Body has #1001 and #1002 — graph is temporarily broken."
+	$'Graph is temporarily broken.\n\n## Children\n\n- #1001\n- #1002'
 set_child_states "1001:closed:child-x" "1002:closed:child-y"
 
 GH_GRAPHQL_EXIT_CODE=1 reconcile_completed_parent_tasks >/dev/null 2>&1
@@ -362,7 +395,7 @@ fi
 # -----------------------------------------------------------------------------
 reset_scenario
 set_parent_list 1100 "t1100: paginated" \
-	"Body has #1101 and #1102 as backstop refs."
+	$'## Children\n\n- #1101\n- #1102'
 set_child_states "1101:closed:a" "1102:closed:b"
 
 GH_GRAPHQL_HAS_NEXT_PAGE=true reconcile_completed_parent_tasks >/dev/null 2>&1
@@ -396,6 +429,73 @@ if grep -q "issue close 1200" "$GH_CALLS"; then
 		"(unexpected close with paginated graph + empty body; calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
 else
 	print_result "pagination fail-closed: no body refs = parent stays open" 0
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 10: one filed closed child does not complete a two-phase contract.
+# The parent stays open and receives an idempotent decomposition nudge.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 1300 "t1300: declared roadmap" $'## Phases\n\n- Phase 1 - shipped #1301\n- Phase 2 - still unfiled\n\n## Children\n\n- #1301'
+set_subissues "1301:CLOSED"
+set_child_states "1301:closed:phase-one"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 1300" "$GH_CALLS"; then
+	print_result "unfiled phase contract: parent remains open" 1 \
+		"(unexpected close: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+else
+	print_result "unfiled phase contract: parent remains open" 0
+fi
+if grep -q "issue comment 1300" "$GH_CALLS"; then
+	print_result "unfiled phase contract: posts recovery nudge" 0
+else
+	print_result "unfiled phase contract: posts recovery nudge" 1 \
+		"(calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 11: all canonical phases are filed and terminal, so the close
+# contract is complete and the parent closes normally.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 1400 "t1400: complete roadmap" $'## Phases\n\n- Phase 1 - shipped #1401\n- Phase 2 - shipped #1402\n\n## Children\n\n- #1401\n- #1402'
+set_subissues "1401:CLOSED" "1402:CLOSED"
+set_child_states "1401:closed:phase-one" "1402:closed:phase-two"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 1400" "$GH_CALLS"; then
+	print_result "complete phase contract: closes parent" 0
+else
+	print_result "complete phase contract: closes parent" 1 \
+		"(calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 12: bounded recently-closed scan repairs a premature close only
+# when canonical unfiled phase evidence exists.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_closed_parent_list 1500 "t1500: prematurely closed" $'## Phases\n\n- Phase 1 - shipped #1501\n- Phase 2 - still unfiled'
+set_subissues "1501:CLOSED"
+set_child_states "1501:closed:phase-one"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue reopen 1500" "$GH_CALLS"; then
+	print_result "closed-parent repair: reopens deterministic incomplete roadmap" 0
+else
+	print_result "closed-parent repair: reopens deterministic incomplete roadmap" 1 \
+		"(calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+reopen_count=$(grep -c "issue reopen 1500" "$GH_CALLS" 2>/dev/null || true)
+if [[ "$reopen_count" -eq 1 ]]; then
+	print_result "closed-parent repair: action is bounded to one reopen per scan" 0
+else
+	print_result "closed-parent repair: action is bounded to one reopen per scan" 1 \
+		"(reopen_count=${reopen_count})"
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add machine-readable close contracts to newly created parent tasks.
- Keep parents open when canonical phases, expected children, or unchecked criteria remain.
- Reopen recently closed incomplete roadmaps through a bounded idempotent repair pass.

## Files Changed

- `.agents/scripts/pulse-issue-reconcile-actions.sh`
- `.agents/scripts/pulse-issue-reconcile-parent.sh`
- `.agents/scripts/shared-gh-wrappers-create.sh`
- Parent lifecycle and reconciliation regression tests

## Runtime Testing

- **Risk level:** High (parent lifecycle state machine)
- **Verification:** Reconciliation harnesses exercised open, close, nudge, single-child compatibility, and closed-parent repair paths; changed-file lint and ShellCheck passed.

Resolves #27005

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.24 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 19h 54m and 1,255,139 tokens on this as a headless worker.