### PR TITLE
GH#27119: fix: preserve issue-sync shims across checkout

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -20,6 +20,9 @@
 #   (b) `clean: false` on the `Checkout repo for TODO.md update` step.
 #
 # Either invariant prevents the regression. The current canonical fix is (a).
+# GH#27119 additionally requires the PATH shims to live outside GITHUB_WORKSPACE:
+# actions/checkout may select `git` before cleaning, so restoring the framework
+# after checkout is too late when the selected executable itself was deleted.
 
 set -euo pipefail
 
@@ -92,12 +95,24 @@ if [[ "${JOB_START}" == "0" ]]; then
 	exit 1
 fi
 check 1 "sync-on-pr-merge job present" ""
+JOB_BODY=$(sed -n "${JOB_START},${JOB_END}p" "${WORKFLOW_FILE}")
 
 # ============================================================
-# Test 2: job has merged == true guard (defends against #22607
+# Test 2: PATH shims survive caller-repo workspace cleanup.
+# ============================================================
+# shellcheck disable=SC2016 # Assert literal workflow expressions, not test-shell expansion.
+if printf '%s\n' "${JOB_BODY}" | grep -qE 'SHIM_DIR="\$\{RUNNER_TEMP\}/[^\"]+"' && \
+	printf '%s\n' "${JOB_BODY}" | grep -qE 'echo "\$\{SHIM_DIR\}" >> "\$GITHUB_PATH"'; then
+	check 1 "sync-on-pr-merge stages PATH shims outside GITHUB_WORKSPACE" ""
+else
+	check 0 "sync-on-pr-merge stages PATH shims outside GITHUB_WORKSPACE" \
+		"GITHUB_PATH must reference a RUNNER_TEMP shim directory so actions/checkout cannot delete its selected git executable"
+fi
+
+# ============================================================
+# Test 3: job has merged == true guard (defends against #22607
 #         which falsely claimed the guard was missing)
 # ============================================================
-JOB_BODY=$(sed -n "${JOB_START},${JOB_END}p" "${WORKFLOW_FILE}")
 if printf '%s\n' "${JOB_BODY}" | grep -qE 'github\.event\.pull_request\.merged[[:space:]]*==[[:space:]]*true'; then
 	check 1 "sync-on-pr-merge has merged == true guard" ""
 else
@@ -105,7 +120,7 @@ else
 fi
 
 # ============================================================
-# Test 3: job preserves __aidevops/ across the second checkout.
+# Test 4: job preserves __aidevops/ across the second checkout.
 #         Either via Option A (clean: false on caller checkout)
 #         or Option B (re-checkout framework after caller checkout).
 #         At least ONE must hold.
@@ -143,7 +158,7 @@ else
 fi
 
 # ============================================================
-# Test 4: Update TODO.md proof-log step still references __aidevops/
+# Test 5: Update TODO.md proof-log step still references __aidevops/
 #         (sanity check — if this changes, the test premise needs updating)
 # ============================================================
 if printf '%s\n' "${JOB_BODY}" | grep -qE 'bash[[:space:]]+__aidevops/\.agents/scripts/issue-sync-git-push-helper\.sh'; then

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -618,10 +618,19 @@ jobs:
 
       - name: Setup gh shim (auto-inject signature footer on writes)
         run: |
-          chmod +x __aidevops/.agents/scripts/gh \
-                   __aidevops/.agents/scripts/gh-signature-helper.sh \
+          # GH#27119: actions/checkout resolves every executable once, then
+          # cleans the workspace. Keep the selected git/gh shims and their
+          # sibling dependencies outside that deletion boundary so the later
+          # caller-repo checkout cannot remove an executable while using it.
+          SHIM_DIR="${RUNNER_TEMP}/aidevops-issue-sync-shims"
+          rm -rf "${SHIM_DIR}"
+          mkdir -p "${SHIM_DIR}"
+          cp -R __aidevops/.agents/scripts/. "${SHIM_DIR}/"
+          chmod +x "${SHIM_DIR}/gh" \
+                   "${SHIM_DIR}/gh-signature-helper.sh" \
+                   "${SHIM_DIR}/git" \
                    2>/dev/null || true
-          echo "${GITHUB_WORKSPACE}/__aidevops/.agents/scripts" >> "$GITHUB_PATH"
+          echo "${SHIM_DIR}" >> "$GITHUB_PATH"
 
       - name: Extract task ID and collect linked issues
         id: extract


### PR DESCRIPTION
## Summary

Stage the issue-sync git and gh shims with their sibling dependencies under RUNNER_TEMP before adding them to GITHUB_PATH, preventing the downstream checkout from deleting its selected git executable. Extend the checkout-order regression test to enforce the external shim path.

## Files Changed

.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh; shellcheck .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh; actionlint .github/workflows/issue-sync-reusable.yml

Resolves #27119


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.25 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 50,031 tokens on this as a headless worker.