### PR TITLE
GH#27120: fix: resolve TODO tasks from closing issue refs

### DIFF
--- a/.agents/scripts/issue-sync-pr-identity-helper.sh
+++ b/.agents/scripts/issue-sync-pr-identity-helper.sh
@@ -9,20 +9,20 @@ set -euo pipefail
 
 extract_linked_issues() {
 	local pr_body="$1"
-	printf '%s' "$pr_body" \
-		| grep -ioE '\b(close[ds]?|fix(es|ed)?|resolve[ds]?)\b[[:space:]]+#[0-9]+' \
-		| grep -oE '[0-9]+' \
-		| sort -u \
-		| tr '\n' ' ' || true
+	printf '%s' "$pr_body" |
+		grep -ioE '\b(close[ds]?|fix(es|ed)?|resolve[ds]?)\b[[:space:]]+#[0-9]+' |
+		grep -oE '[0-9]+' |
+		sort -u |
+		tr '\n' ' ' || true
 	return 0
 }
 
 task_ids_for_issue() {
 	local issue_number="$1"
 	local todo_file="$2"
-	grep -E "^[[:space:]]*- \[[ x]\] t[0-9]+(\.[0-9]+)* .*ref:GH#${issue_number}([^0-9]|\$)" "$todo_file" 2>/dev/null \
-		| sed -E 's/^[[:space:]]*- \[[ x]\] (t[0-9]+(\.[0-9]+)*).*/\1/' \
-		| sort -u || true
+	grep -E "^[[:space:]]*- \[[ x]\] t[0-9]+(\.[0-9]+)* .*ref:GH#${issue_number}([^0-9]|\$)" "$todo_file" 2>/dev/null |
+		sed -E 's/^[[:space:]]*- \[[ x]\] (t[0-9]+(\.[0-9]+)*).*/\1/' |
+		sort -u || true
 	return 0
 }
 

--- a/.agents/scripts/issue-sync-pr-identity-helper.sh
+++ b/.agents/scripts/issue-sync-pr-identity-helper.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Resolve a merged PR's task identity from its canonical title or, when the
+# title has no tNNN prefix, from one explicit closing issue's unique TODO.md
+# ref:GH#NNN mapping. Conflicting and ambiguous identities fail closed.
+set -euo pipefail
+
+extract_linked_issues() {
+	local pr_body="$1"
+	printf '%s' "$pr_body" \
+		| grep -ioE '\b(close[ds]?|fix(es|ed)?|resolve[ds]?)\b[[:space:]]+#[0-9]+' \
+		| grep -oE '[0-9]+' \
+		| sort -u \
+		| tr '\n' ' ' || true
+	return 0
+}
+
+task_ids_for_issue() {
+	local issue_number="$1"
+	local todo_file="$2"
+	grep -E "^[[:space:]]*- \[[ x]\] t[0-9]+(\.[0-9]+)* .*ref:GH#${issue_number}([^0-9]|\$)" "$todo_file" 2>/dev/null \
+		| sed -E 's/^[[:space:]]*- \[[ x]\] (t[0-9]+(\.[0-9]+)*).*/\1/' \
+		| sort -u || true
+	return 0
+}
+
+resolve_pr_identity() {
+	local pr_title="$1"
+	local pr_body="$2"
+	local todo_file="$3"
+	local title_task_id=""
+	local linked_issues=""
+	local task_id=""
+	local issue_number=""
+	local mapped_ids=""
+	local mapped_count=0
+
+	title_task_id=$(printf '%s\n' "$pr_title" | grep -oE '^t[0-9]+(\.[0-9]+)*' || true)
+	linked_issues=$(extract_linked_issues "$pr_body")
+	task_id="$title_task_id"
+
+	if [[ -f "$todo_file" ]]; then
+		for issue_number in $linked_issues; do
+			mapped_ids=$(task_ids_for_issue "$issue_number" "$todo_file")
+			mapped_count=$(printf '%s\n' "$mapped_ids" | grep -cE '^t[0-9]+(\.[0-9]+)*$' || true)
+			if [[ "$mapped_count" -gt 1 ]]; then
+				printf 'ERROR: ref:GH#%s maps to multiple TODO tasks: %s\n' "$issue_number" "$(printf '%s' "$mapped_ids" | tr '\n' ' ')" >&2
+				return 1
+			fi
+			if [[ "$mapped_count" -eq 1 && -n "$title_task_id" && "$mapped_ids" != "$title_task_id" ]]; then
+				printf 'ERROR: PR title task %s conflicts with ref:GH#%s mapping to %s\n' "$title_task_id" "$issue_number" "$mapped_ids" >&2
+				return 1
+			fi
+		done
+	fi
+
+	if [[ -z "$task_id" && -n "$linked_issues" ]]; then
+		local linked_count=0
+		linked_count=$(printf '%s\n' "$linked_issues" | grep -oE '[0-9]+' | wc -l | tr -d ' ')
+		if [[ "$linked_count" -ne 1 ]]; then
+			printf 'ERROR: PR without a canonical task title has %s closing issues; refusing ambiguous TODO identity\n' "$linked_count" >&2
+			return 1
+		fi
+		issue_number=${linked_issues%% *}
+		mapped_ids=$(task_ids_for_issue "$issue_number" "$todo_file")
+		mapped_count=$(printf '%s\n' "$mapped_ids" | grep -cE '^t[0-9]+(\.[0-9]+)*$' || true)
+		if [[ "$mapped_count" -eq 1 ]]; then
+			task_id="$mapped_ids"
+			printf 'Resolved %s from unique ref:GH#%s TODO mapping\n' "$task_id" "$issue_number" >&2
+		fi
+	fi
+
+	printf 'task_id=%s\n' "$task_id"
+	printf 'linked_issues=%s\n' "$linked_issues"
+	return 0
+}
+
+main() {
+	local command="${1:-}"
+	local pr_title="${2:-}"
+	local pr_body="${3:-}"
+	local todo_file="${4:-TODO.md}"
+
+	if [[ "$command" != "resolve" ]]; then
+		printf 'Usage: %s resolve <pr-title> <pr-body> [todo-file]\n' "${0##*/}" >&2
+		return 1
+	fi
+	resolve_pr_identity "$pr_title" "$pr_body" "$todo_file"
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-issue-sync-pr-identity.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-identity.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#27120 PR-to-TODO task identity resolution.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../issue-sync-pr-identity-helper.sh"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+TODO_FILE="${TMP_DIR}/TODO.md"
+PASS=0
+FAIL=0
+
+pass() {
+	local message="$1"
+	PASS=$((PASS + 1))
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: %s\n' "$message"
+	return 0
+}
+
+expect_task() {
+	local title="$1"
+	local body="$2"
+	local expected="$3"
+	local description="$4"
+	local output=""
+	local actual=""
+	if output=$(bash "$HELPER" resolve "$title" "$body" "$TODO_FILE" 2>/dev/null); then
+		actual=$(printf '%s\n' "$output" | sed -n 's/^task_id=//p')
+		if [[ "$actual" == "$expected" ]]; then
+			pass "$description"
+			return 0
+		fi
+	fi
+	fail "$description (expected $expected, got ${actual:-error})"
+	return 0
+}
+
+expect_failure() {
+	local title="$1"
+	local body="$2"
+	local description="$3"
+	if bash "$HELPER" resolve "$title" "$body" "$TODO_FILE" >/dev/null 2>&1; then
+		fail "$description"
+	else
+		pass "$description"
+	fi
+	return 0
+}
+
+cat >"$TODO_FILE" <<'EOF'
+- [ ] t4001 canonical task ref:GH#101
+- [ ] t4002 recovery task ref:GH#102
+- [ ] t4003 conflict task ref:GH#103
+EOF
+
+expect_task "t4001: canonical completion" "Resolves #101" "t4001" "canonical title remains authoritative"
+expect_task "GH#102: recovery completion" "Fixes #102" "t4002" "GH-prefixed title falls back to unique issue reference"
+expect_task "auto-recover: completion" "Closes #102" "t4002" "recovery title falls back to unique issue reference"
+expect_task "renamed descriptive title" "Resolved #102" "t4002" "renamed title falls back to unique issue reference"
+expect_failure "t4001: wrong identity" "Resolves #103" "title and issue-reference conflict fails closed"
+expect_failure "auto-recover: multiple" $'Resolves #101\nResolves #102' "multiple closing issues without title identity fail closed"
+
+printf '%s\n' '- [ ] t4999 duplicate ref ref:GH#102' >>"$TODO_FILE"
+expect_failure "GH#102: ambiguous" "Resolves #102" "duplicate issue-reference mappings fail closed"
+
+printf 'Summary: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -632,6 +632,16 @@ jobs:
                    2>/dev/null || true
           echo "${SHIM_DIR}" >> "$GITHUB_PATH"
 
+      # GH#27120: task identity may need the caller's TODO.md before the main
+      # checkout. Keep this metadata checkout isolated so the early framework
+      # checkout and gh shim remain available to closing hygiene.
+      - name: Checkout caller TODO metadata
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: __caller
+          ref: main
+          fetch-depth: 1
+
       - name: Extract task ID and collect linked issues
         id: extract
         env:
@@ -639,23 +649,15 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Extract task ID from PR title (e.g., "t1329: Cross-review judge pipeline")
-          TASK_ID=""
-          if echo "$PR_TITLE" | grep -qE '^t[0-9]+'; then
-            TASK_ID=$(echo "$PR_TITLE" | grep -oE '^t[0-9]+(\.[0-9]+)*')
-          fi
+          # Prefer a canonical title task ID. When absent, GH#27120 permits a
+          # fallback only for one closing issue with one unique ref:GH#NNN
+          # mapping in TODO.md. Ambiguous/conflicting identities fail closed.
+          IDENTITY=$(bash __aidevops/.agents/scripts/issue-sync-pr-identity-helper.sh \
+            resolve "$PR_TITLE" "$PR_BODY" __caller/TODO.md)
+          TASK_ID=$(printf '%s\n' "$IDENTITY" | sed -n 's/^task_id=//p')
+          LINKED_ISSUES=$(printf '%s\n' "$IDENTITY" | sed -n 's/^linked_issues=//p')
           echo "task_id=$TASK_ID" >> "$GITHUB_OUTPUT"
 
-          # Collect linked issue numbers from PR body (Closes #NNN, Fixes #NNN, Resolves #NNN).
-          # GH#20807: Use canonical closing-keyword-only regex from pulse-merge.sh::_extract_linked_issue.
-          # Changes from prior regex:
-          #   1. \b word-boundary anchors prevent substring matches (e.g. "discloses #NNN" → "closes")
-          #   2. close[ds]?  / fix(es|ed)? / resolve[ds]? match all grammatical forms (closed, fixed, etc.)
-          #   3. [[:space:]]+ (mandatory) instead of [[:space:]]* (zero-or-more) prevents "closes#NNN"
-          LINKED_ISSUES=""
-          if [[ -n "$PR_BODY" ]]; then
-            LINKED_ISSUES=$(printf '%s' "$PR_BODY" | grep -ioE '\b(close[ds]?|fix(es|ed)?|resolve[ds]?)\b[[:space:]]+#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
-          fi
           echo "linked_issues=$LINKED_ISSUES" >> "$GITHUB_OUTPUT"
 
           # t2219: Collect 'For #NNN' and 'Ref #NNN' references (planning convention t2046)


### PR DESCRIPTION
## Summary

Resolve merged PR task identity from a canonical title or a unique closing-issue ref:GH# mapping; fail closed on ambiguous and conflicting mappings; add regression coverage.

## Files Changed

.agents/scripts/issue-sync-pr-identity-helper.sh, .agents/scripts/tests/test-issue-sync-pr-identity.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-issue-sync-pr-identity.sh; .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh; shellcheck; .agents/scripts/linters-local.sh

Resolves #27120


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.25 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 128,266 tokens on this as a headless worker.