### PR TITLE
GH#27005: Harden parent close-contract repair

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -358,7 +358,8 @@ _parent_close_contract_incomplete() {
 		return 0
 	fi
 
-	if [[ "$parent_body" == *"<!-- parent-close-contract: phase-plan -->"* && -z "$phases_section" ]]; then
+	if [[ "$parent_body" == *"<!-- parent-close-contract: phase-plan -->"* && \
+		"$_PARENT_CLOSE_CONTRACT_DECLARED" -eq 0 ]]; then
 		_PARENT_CLOSE_CONTRACT_REASON="invalid-phase-plan"
 		return 0
 	fi
@@ -516,7 +517,8 @@ _try_close_parent_tracker() {
 				"$_PARENT_CLOSE_CONTRACT_UNFILED" || true
 		else
 			_post_parent_close_contract_nudge "$slug" "$parent_num" \
-				"$_PARENT_CLOSE_CONTRACT_REASON" '<!-- parent-close-contract-incomplete -->' || true
+				"$_PARENT_CLOSE_CONTRACT_REASON" \
+				"<!-- parent-close-contract-incomplete:${_PARENT_CLOSE_CONTRACT_REASON} -->" || true
 		fi
 		_mark_parent_needs_decomposition "$slug" "$parent_num"
 		echo "[pulse-wrapper] Reconcile parent-task: kept #${parent_num} open in ${slug} — incomplete close contract (${_PARENT_CLOSE_CONTRACT_REASON})" >>"${LOGFILE:-/dev/null}"
@@ -827,7 +829,10 @@ _SP_CPT_REOPENED=0
 _repair_recently_closed_parent() {
 	local slug="$1" issue_num="$2" issue_body="$3" known_child_count="$4"
 	local issue_state="$5"
-	[[ "$issue_state" == "CLOSED" ]] || return 1
+	case "$issue_state" in
+	CLOSED | closed) ;;
+	*) return 1 ;;
+	esac
 	if _parent_close_contract_incomplete "$issue_body" "$known_child_count"; then
 		if _repair_closed_parent_contract "$slug" "$issue_num" \
 			"$_PARENT_CLOSE_CONTRACT_REASON"; then

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -233,7 +233,7 @@ _gh_ci_prepare_parent_close_contract() {
 			/^##[[:space:]]+(Children|Child Issues|Sub-issues|Sub-tasks)([[:space:]]|$)/ { in_children=1; next }
 			in_children && /^##[[:space:]]/ { exit }
 			in_children { print }
-		' | grep -oE '#[0-9]+' | sort -u | wc -l | tr -d ' ')
+		' | grep -oE '#[0-9]+' | sort -u | wc -l | tr -d ' ' || true)
 		if [[ "$children_count" =~ ^[0-9]+$ ]] && [[ "$children_count" -gt 0 ]]; then
 			marker="<!-- parent-close-contract: expected-children=${children_count} -->"
 		fi

--- a/.agents/scripts/tests/test-parent-task-lifecycle.sh
+++ b/.agents/scripts/tests/test-parent-task-lifecycle.sh
@@ -438,6 +438,16 @@ contract_args=$(printf '%s\n' "${_GH_CI_CONTRACT_ARGS[@]}")
 assert_not_contains "B10g: non-parent issue body remains unstamped" \
 	'<!-- parent-close-contract:' "$contract_args"
 
+_gh_ci_prepare_parent_close_contract 1 --body $'## Children\n\nNo children filed yet.' --label parent-task
+contract_args=$(printf '%s\n' "${_GH_CI_CONTRACT_ARGS[@]}")
+assert_contains "B10h: empty children section remains safe under pipefail" \
+	'<!-- parent-close-contract: needs-decomposition -->' "$contract_args"
+
+assert_grep_fixed \
+	"B10i: close-contract nudge marker varies with the blocking reason" \
+	'<!-- parent-close-contract-incomplete:${_PARENT_CLOSE_CONTRACT_REASON} -->' \
+	"$ACTIONS_TARGET"
+
 # ============================================================
 echo ""
 echo "${TEST_BLUE}=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed ===${TEST_NC}"

--- a/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
+++ b/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
@@ -207,7 +207,7 @@ set_closed_parent_list() {
 	# Args: issue_num title body
 	local num="$1" title="$2" body="$3"
 	jq -n --argjson n "$num" --arg t "$title" --arg b "$body" \
-		'[{number:$n, title:$t, body:$b, state:"CLOSED"}]' >"${TEST_ROOT}/gh-closed-issue-list.json"
+		'[{number:$n, title:$t, body:$b, state:"closed"}]' >"${TEST_ROOT}/gh-closed-issue-list.json"
 	return 0
 }
 
@@ -496,6 +496,24 @@ if [[ "$reopen_count" -eq 1 ]]; then
 else
 	print_result "closed-parent repair: action is bounded to one reopen per scan" 1 \
 		"(reopen_count=${reopen_count})"
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 13: a stamped phase plan with no parseable phase rows is invalid.
+# Whitespace-only parser output must not bypass the contract and close a parent.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 1600 "t1600: invalid phase plan" $'## Phases\n\n   \n\t\n## Children\n\n- #1601\n\n<!-- parent-close-contract: phase-plan -->'
+set_subissues "1601:CLOSED"
+set_child_states "1601:closed:only-child"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 1600" "$GH_CALLS"; then
+	print_result "invalid phase-plan contract: whitespace-only plan remains open" 1 \
+		"(unexpected close: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+else
+	print_result "invalid phase-plan contract: whitespace-only plan remains open" 0
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Honour lowercase GitHub issue states when repairing prematurely closed parents.
- Keep empty child extraction safe under `set -eo pipefail`.
- Reject phase-plan contracts with no parseable phase rows.
- Key idempotent nudges by their blocking reason so changed failures receive current recovery guidance.

## Root Cause

PR #27128 introduced the systemic parent close contract but merged after its review gate passed and before later inline review findings were acted on. These corrections close the four concrete production gaps identified during the full-loop verification.

## Runtime Testing

- **Risk level:** High (parent lifecycle state machine)
- **Verification:** ShellCheck; parent lifecycle 41/41; native subissue graph 18/18; merge close guard 7/7; wrapper standalone 9/9; issue-create wrapper 5/5; `linters-local.sh --changed --no-cache`.

Resolves #27005

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.26 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 9m and 153,527 tokens on this with the user in an interactive session. Overall, 20h 28m since this issue was created.
