### PR TITLE
GH#27005: Harden parent contract fallbacks

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -827,7 +827,10 @@ _SP_CPT_REOPENED=0
 _repair_recently_closed_parent() {
 	local slug="$1" issue_num="$2" issue_body="$3" known_child_count="$4"
 	local issue_state="$5"
-	[[ "$issue_state" == "CLOSED" ]] || return 1
+	case "$issue_state" in
+	[Cc][Ll][Oo][Ss][Ee][Dd]) ;;
+	*) return 1 ;;
+	esac
 	if _parent_close_contract_incomplete "$issue_body" "$known_child_count"; then
 		if _repair_closed_parent_contract "$slug" "$issue_num" \
 			"$_PARENT_CLOSE_CONTRACT_REASON"; then

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -233,7 +233,7 @@ _gh_ci_prepare_parent_close_contract() {
 			/^##[[:space:]]+(Children|Child Issues|Sub-issues|Sub-tasks)([[:space:]]|$)/ { in_children=1; next }
 			in_children && /^##[[:space:]]/ { exit }
 			in_children { print }
-		' | grep -oE '#[0-9]+' | sort -u | wc -l | tr -d ' ')
+		' | grep -oE '#[0-9]+' | sort -u | wc -l | tr -d ' ' || true)
 		if [[ "$children_count" =~ ^[0-9]+$ ]] && [[ "$children_count" -gt 0 ]]; then
 			marker="<!-- parent-close-contract: expected-children=${children_count} -->"
 		fi

--- a/.agents/scripts/tests/test-parent-task-lifecycle.sh
+++ b/.agents/scripts/tests/test-parent-task-lifecycle.sh
@@ -433,9 +433,27 @@ contract_args=$(printf '%s\n' "${_GH_CI_CONTRACT_ARGS[@]}")
 assert_contains "B10f: children body records expected child count" \
 	'<!-- parent-close-contract: expected-children=2 -->' "$contract_args"
 
+# Parent creation runs inside strict-mode callers. A prose-only Children
+# section must produce the conservative needs-decomposition marker rather than
+# aborting when grep finds no issue references under pipefail.
+strict_contract_args=""
+if strict_contract_args=$(bash -c '
+	set -euo pipefail
+	source "$1"
+	_gh_ci_prepare_parent_close_contract 1 --body "$2" --label parent-task
+	printf "%s\n" "${_GH_CI_CONTRACT_ARGS[@]}"
+' _ "$WRAPPER_TARGET" $'## Children\n\nChild issues have not been filed yet.'); then
+	assert_contains "B10g: no-ref Children section remains safe under strict mode" \
+		'<!-- parent-close-contract: needs-decomposition -->' "$strict_contract_args"
+else
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: B10g: no-ref Children section aborted under strict mode"
+fi
+
 _gh_ci_prepare_parent_close_contract 0 --body 'ordinary leaf issue' --label bug
 contract_args=$(printf '%s\n' "${_GH_CI_CONTRACT_ARGS[@]}")
-assert_not_contains "B10g: non-parent issue body remains unstamped" \
+assert_not_contains "B10h: non-parent issue body remains unstamped" \
 	'<!-- parent-close-contract:' "$contract_args"
 
 # ============================================================

--- a/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
+++ b/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
@@ -204,10 +204,10 @@ set_parent_list() {
 }
 
 set_closed_parent_list() {
-	# Args: issue_num title body
-	local num="$1" title="$2" body="$3"
-	jq -n --argjson n "$num" --arg t "$title" --arg b "$body" \
-		'[{number:$n, title:$t, body:$b, state:"CLOSED"}]' >"${TEST_ROOT}/gh-closed-issue-list.json"
+	# Args: issue_num title body [state]
+	local num="$1" title="$2" body="$3" state="${4:-CLOSED}"
+	jq -n --argjson n "$num" --arg t "$title" --arg b "$body" --arg s "$state" \
+		'[{number:$n, title:$t, body:$b, state:$s}]' >"${TEST_ROOT}/gh-closed-issue-list.json"
 	return 0
 }
 
@@ -496,6 +496,24 @@ if [[ "$reopen_count" -eq 1 ]]; then
 else
 	print_result "closed-parent repair: action is bounded to one reopen per scan" 1 \
 		"(reopen_count=${reopen_count})"
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 13: REST-search fallback returns lowercase issue states. The repair
+# path must treat that shape the same as gh issue list's uppercase GraphQL enum.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_closed_parent_list 1600 "t1600: REST-state premature close" $'## Phases\n\n- Phase 1 - shipped #1601\n- Phase 2 - still unfiled' closed
+set_subissues "1601:CLOSED"
+set_child_states "1601:closed:phase-one"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue reopen 1600" "$GH_CALLS"; then
+	print_result "closed-parent repair: accepts lowercase REST state" 0
+else
+	print_result "closed-parent repair: accepts lowercase REST state" 1 \
+		"(calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Accept both GraphQL uppercase and REST-search lowercase closed states when repairing incomplete parent roadmaps.
- Prevent strict-mode parent creation from aborting when a `## Children` section has no issue references.
- Add regressions for both production fallback shapes.

## Files Changed

- `.agents/scripts/pulse-issue-reconcile-actions.sh`
- `.agents/scripts/shared-gh-wrappers-create.sh`
- `.agents/scripts/tests/test-parent-task-lifecycle.sh`
- `.agents/scripts/tests/test-pulse-reconcile-parent-*graph.sh`

## Verification

- ShellCheck passed for the affected lifecycle scripts and tests.
- Parent lifecycle: 40/40 passed.
- Parent subissue graph: 18/18 passed.
- Parent merge close guard: 7/7 passed.
- Shared GitHub wrapper standalone: 9/9 passed.
- `.agents/scripts/linters-local.sh --changed --no-cache` passed.

## Decisions

- Retain the static one-time nudge marker to preserve bounded idempotency.
- No whitespace-only phase-parser change is needed because the canonical parser already emits no phase rows for that input.

Resolves #27005

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.26 plugin for [OpenCode](https://opencode.ai) v1.17.18
