### PR TITLE
GH#27130: fix: keep CLI updates independent of canonical checkout

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
@@ -27,26 +27,18 @@ fi
 _AIDEVOPS_UPDATE_TRUE=true
 
 _update_fresh_install() {
-	print_warning "Repository not found, performing fresh install..."
-	local tmp_setup
-	# t2997: drop .sh — XXXXXX must be at end for BSD mktemp.
-	tmp_setup=$(mktemp "${TMPDIR:-/tmp}/aidevops-setup-XXXXXX") || {
-		print_error "Failed to create temp file for setup script"
+	print_warning "Repository not found at the active CLI tree, updating from a clean temporary checkout..."
+	local tmp_checkout
+	tmp_checkout=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-update-XXXXXX") || {
+		print_error "Failed to create temporary update checkout"
 		return 1
 	}
-	trap 'rm -f "${tmp_setup:-}"' RETURN
-	if curl -fsSL "https://raw.githubusercontent.com/marcusquinn/aidevops/main/setup.sh" -o "$tmp_setup" 2>/dev/null && [[ -s "$tmp_setup" ]]; then
-		chmod +x "$tmp_setup"
-		bash "$tmp_setup"
-		local setup_exit=$?
-		rm -f "$tmp_setup"
-		[[ $setup_exit -ne 0 ]] && return 1
-	else
-		rm -f "$tmp_setup"
-		print_error "Failed to download setup script"
-		print_info "Try: git clone https://github.com/marcusquinn/aidevops.git $INSTALL_DIR && bash $INSTALL_DIR/setup.sh"
+	trap 'rm -rf "${tmp_checkout:-}"' RETURN
+	if ! git clone --depth 1 --branch main "https://github.com/marcusquinn/aidevops.git" "$tmp_checkout" >/dev/null 2>&1; then
+		print_error "Failed to create clean update checkout"
 		return 1
 	fi
+	bash "$tmp_checkout/setup.sh" --stage ai-session || return $?
 	return 0
 }
 

--- a/.agents/scripts/setup/modules/config.sh
+++ b/.agents/scripts/setup/modules/config.sh
@@ -60,13 +60,18 @@ install_aidevops_cli() {
 
 	# Use INSTALL_DIR (repo root, exported by setup.sh) — not BASH_SOURCE[0]
 	# which resolves to .agents/scripts/setup/modules/ when sourced from setup.sh.
-	local cli_source="${INSTALL_DIR:?INSTALL_DIR not set}/aidevops.sh"
+	local cli_source="${INSTALL_DIR:?INSTALL_DIR not set}/bin/aidevops"
+	local deployed_cli="${AGENTS_DIR:?AGENTS_DIR not set}/aidevops.sh"
 	local cli_target="/usr/local/bin/aidevops"
 
-	if [[ ! -f "$cli_source" ]]; then
-		print_warning "aidevops.sh not found at $cli_source - skipping CLI installation"
+	if [[ ! -f "$cli_source" || ! -f "$INSTALL_DIR/aidevops.sh" ]]; then
+		print_warning "aidevops CLI sources not found under $INSTALL_DIR - skipping CLI installation"
 		return 0
 	fi
+
+	# Keep the orchestrator beside the already-deployed VERSION and CLI modules.
+	# The public command is only a durable launcher into this coherent tree.
+	_install_aidevops_cli_copy "$INSTALL_DIR/aidevops.sh" "$deployed_cli" || return 1
 
 	# Check if we can write to /usr/local/bin
 	if [[ -w "/usr/local/bin" ]]; then

--- a/bin/aidevops
+++ b/bin/aidevops
@@ -3,24 +3,32 @@
 # This wrapper handles npm/brew/bun global installs and local development.
 #
 # Priority order (highest to lowest):
-#   1. ~/Git/aidevops/aidevops.sh  — git repo, always current via 'aidevops update'
-#   2. Auto-clone the git repo     — first-run bootstrap for package manager installs
-#   3. npm-bundled aidevops.sh     — snapshot at npm publish time, may be stale
+#   1. ~/.aidevops/agents/aidevops.sh — coherent setup-deployed CLI and modules
+#   2. ~/Git/aidevops/aidevops.sh     — bootstrap/development checkout
+#   3. Auto-clone the git repo         — first-run bootstrap
+#   4. npm-bundled aidevops.sh         — snapshot at publish time
 #
-# The repo copy is preferred so that 'aidevops update' (git pull) immediately
-# takes effect without requiring 'npm update -g aidevops'.
+# Setup's deployed copy is preferred so updates take effect without requiring a
+# package-manager refresh or reading a stale canonical checkout.
 
 set -euo pipefail
 
 REPO_DIR="$HOME/Git/aidevops"
 REPO_URL="https://github.com/marcusquinn/aidevops.git"
+DEPLOYED_CLI="$HOME/.aidevops/agents/aidevops.sh"
 
-# 1. Prefer the git repo copy — always current via 'aidevops update'
+# 1. Prefer the setup-deployed copy. It is released atomically with its modules,
+# so a stale or dirty canonical checkout cannot split the CLI version from them.
+if [[ -f "$DEPLOYED_CLI" ]]; then
+    exec bash "$DEPLOYED_CLI" "$@"
+fi
+
+# 2. Use the git repo for bootstrap and local development.
 if [[ -f "$REPO_DIR/aidevops.sh" ]]; then
     exec bash "$REPO_DIR/aidevops.sh" "$@"
 fi
 
-# 2. Git repo not found — bootstrap it automatically
+# 3. Git repo not found — bootstrap it automatically
 # This runs once on first use after a package manager install (npm/brew/bun).
 # After this, step 1 will always match and the git repo runs directly.
 if command -v git >/dev/null 2>&1; then

--- a/tests/test-cli-deployment-coherence.sh
+++ b/tests/test-cli-deployment-coherence.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+# shellcheck disable=SC2016
+grep -q 'DEPLOYED_CLI="$HOME/.aidevops/agents/aidevops.sh"' "$REPO_DIR/bin/aidevops"
+# shellcheck disable=SC2016
+grep -q '_install_aidevops_cli_copy "$INSTALL_DIR/aidevops.sh" "$deployed_cli"' \
+	"$REPO_DIR/.agents/scripts/setup/modules/config.sh"
+grep -q 'git clone --depth 1 --branch main' \
+	"$REPO_DIR/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
+
+mkdir -p "$TEST_HOME/.aidevops/agents" "$TEST_HOME/Git/aidevops"
+# shellcheck disable=SC2016
+printf '#!/usr/bin/env bash\nprintf "deployed:%%s\\n" "$1"\n' >"$TEST_HOME/.aidevops/agents/aidevops.sh"
+printf '#!/usr/bin/env bash\nprintf "canonical\\n"\n' >"$TEST_HOME/Git/aidevops/aidevops.sh"
+result=$(HOME="$TEST_HOME" bash "$REPO_DIR/bin/aidevops" version-check)
+[[ "$result" == "deployed:version-check" ]] || {
+	printf 'FAIL: launcher selected %s\n' "$result" >&2
+	exit 1
+}
+
+printf 'PASS: CLI launcher, orchestrator, and clean update checkout remain coherent\n'


### PR DESCRIPTION
## Summary

Deploy the CLI orchestrator beside its released agents/modules, make package-manager launchers prefer that coherent tree, and update from a clean temporary clone instead of mutating a dirty canonical checkout.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-update-lib.sh, .agents/scripts/setup/modules/config.sh, bin/aidevops, tests/test-cli-deployment-coherence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash tests/test-cli-deployment-coherence.sh; bash tests/test-update-fallbacks.sh; bash tests/test-setup-completion-sentinel.sh; shellcheck bin/aidevops .agents/scripts/setup/modules/config.sh .agents/scripts/aidevops-cli/aidevops-update-lib.sh tests/test-cli-deployment-coherence.sh

Resolves #27130


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.26 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 79,299 tokens on this as a headless worker.