### PR TITLE
GH#27140: Fix profile stats reliability and refresh efficiency

### DIFF
--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -10,6 +10,12 @@ _CONTRIBUTOR_ACTIVITY_SESSION_LIB_LOADED=1
 _SESSION_TIME_LIB_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 SESSION_TIME_INTERVAL_ENGINE="${_SESSION_TIME_LIB_DIR}/session-time-interval-engine.py"
 unset _SESSION_TIME_LIB_DIR
+SESSION_FORMAT_JSON="json"
+SESSION_STATUS_UNAVAILABLE="unavailable"
+SESSION_TOTAL_HUMAN_FIELD="total_human_hours"
+SESSION_TOTAL_MACHINE_FIELD="total_machine_hours"
+SESSION_TOTAL_SESSIONS_FIELD="total_sessions"
+SESSION_WORKER_SESSIONS_FIELD="worker_sessions"
 
 #######################################
 # Format one session-stat object as Markdown.
@@ -24,10 +30,14 @@ _session_time_format_markdown() {
 import json
 import sys
 period = sys.argv[1]
+unavailable = sys.argv[2]
+total_sessions_field = sys.argv[3]
+total_human_field = sys.argv[4]
+total_machine_field = sys.argv[5]
 data = json.load(sys.stdin)
-if data.get("status") == "unavailable":
+if data.get("status") == unavailable:
     print(f"_Session data unavailable for {period}._")
-elif data.get("total_sessions", 0) == 0:
+elif data.get(total_sessions_field, 0) == 0:
     print(f"_No observed sessions for {period}._")
 else:
     print("| Type | Human attention | AI generation | Additive work | Sessions |")
@@ -37,10 +47,10 @@ else:
         machine = data.get(f"{prefix}_machine_hours", 0)
         count = data.get(f"{prefix}_sessions", 0)
         print(f"| {label} | {human}h | {machine}h | {round(human + machine, 1)}h | {count} |")
-    human = data.get("total_human_hours", 0)
-    machine = data.get("total_machine_hours", 0)
-    print(f"| **Total** | **{human}h** | **{machine}h** | **{round(human + machine, 1)}h** | **{data.get('"'"'total_sessions'"'"', 0)}** |")
-' "$period"
+    human = data.get(total_human_field, 0)
+    machine = data.get(total_machine_field, 0)
+    print(f"| **Total** | **{human}h** | **{machine}h** | **{round(human + machine, 1)}h** | **{data.get(total_sessions_field, 0)}** |")
+' "$period" "$SESSION_STATUS_UNAVAILABLE" "$SESSION_TOTAL_SESSIONS_FIELD" "$SESSION_TOTAL_HUMAN_FIELD" "$SESSION_TOTAL_MACHINE_FIELD"
 	return 0
 }
 
@@ -54,17 +64,21 @@ _session_time_format_period_map() {
 	printf '%s\n' "$stats_json" | python3 -c '
 import json
 import sys
+total_sessions_field = sys.argv[1]
+total_human_field = sys.argv[2]
+total_machine_field = sys.argv[3]
+worker_sessions_field = sys.argv[4]
 data = json.load(sys.stdin)
-if not data or all(item.get("total_sessions", 0) == 0 for item in data.values()):
+if not data or all(item.get(total_sessions_field, 0) == 0 for item in data.values()):
     print("_No session data available._")
 else:
     print("| Period | Human attention | AI generation | Additive work | Sessions | Workers |")
     print("| --- | ---: | ---: | ---: | ---: | ---: |")
     for period, item in data.items():
-        human = item.get("total_human_hours", 0)
-        machine = item.get("total_machine_hours", 0)
-        print(f"| {period.capitalize()} | {human}h | {machine}h | {round(human + machine, 1)}h | {item.get('"'"'total_sessions'"'"', 0)} | {item.get('"'"'worker_sessions'"'"', 0)} |")
-'
+        human = item.get(total_human_field, 0)
+        machine = item.get(total_machine_field, 0)
+        print(f"| {period.capitalize()} | {human}h | {machine}h | {round(human + machine, 1)}h | {item.get(total_sessions_field, 0)} | {item.get(worker_sessions_field, 0)} |")
+' "$SESSION_TOTAL_SESSIONS_FIELD" "$SESSION_TOTAL_HUMAN_FIELD" "$SESSION_TOTAL_MACHINE_FIELD" "$SESSION_WORKER_SESSIONS_FIELD"
 	return 0
 }
 
@@ -111,7 +125,7 @@ session_time() {
 		;;
 	esac
 	case "$format" in
-	json | markdown) ;;
+	"$SESSION_FORMAT_JSON" | markdown) ;;
 	*)
 		echo "Error: invalid session format: ${format}" >&2
 		return 1
@@ -131,7 +145,7 @@ session_time() {
 		echo "Error: session aggregation failed" >&2
 		return 1
 	fi
-	if [[ "$format" == "json" ]]; then
+	if [[ "$format" == "$SESSION_FORMAT_JSON" ]]; then
 		printf '%s\n' "$result"
 	elif [[ "$period" == "all" || "$period" == "profile" ]]; then
 		_session_time_format_period_map "$result"
@@ -178,7 +192,7 @@ cross_repo_session_time() {
 			period_stats=$(cross_repo_session_time "${repo_paths[@]}" --period "$period_name" --format json) || return 1
 			period_map=$(printf '%s' "$period_map" | jq --arg name "$period_name" --argjson stats "$period_stats" '. + {($name):$stats}')
 		done
-		if [[ "$format" == "json" ]]; then
+		if [[ "$format" == "$SESSION_FORMAT_JSON" ]]; then
 			printf '%s\n' "$period_map"
 		else
 			_session_time_format_period_map "$period_map"
@@ -198,7 +212,10 @@ cross_repo_session_time() {
 		repo_count=$((repo_count + 1))
 	done
 	local aggregated
-	aggregated=$(printf '%s' "$collected" | jq -s --argjson repo_count "$repo_count" '
+	aggregated=$(printf '%s' "$collected" | jq -s \
+		--argjson repo_count "$repo_count" \
+		--arg total_human_field "$SESSION_TOTAL_HUMAN_FIELD" \
+		--arg total_machine_field "$SESSION_TOTAL_MACHINE_FIELD" '
         def sum_field($name): map(.[$name] // 0) | add // 0;
         {
             interactive_sessions: sum_field("interactive_sessions"),
@@ -207,14 +224,14 @@ cross_repo_session_time() {
             worker_sessions: sum_field("worker_sessions"),
             worker_human_hours: sum_field("worker_human_hours"),
             worker_machine_hours: sum_field("worker_machine_hours"),
-            total_human_hours: sum_field("total_human_hours"),
-            total_machine_hours: sum_field("total_machine_hours"),
+            ($total_human_field): sum_field($total_human_field),
+            ($total_machine_field): sum_field($total_machine_field),
             total_sessions: sum_field("total_sessions"),
             repo_count: $repo_count,
             status: (if length > 0 then "ok" else "unavailable" end)
         }
     ')
-	if [[ "$format" == "json" ]]; then
+	if [[ "$format" == "$SESSION_FORMAT_JSON" ]]; then
 		printf '%s\n' "$aggregated"
 	else
 		_session_time_format_markdown "$aggregated" "$period across ${repo_count} repos"

--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -1,796 +1,57 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# =============================================================================
-# Contributor Activity -- Session Time Tracking
-# =============================================================================
-# Queries AI assistant session databases (OpenCode/Claude Code) to compute
-# human vs machine time, interactive vs worker session classification,
-# and cross-repo aggregation.
-#
-# Usage: source "${SCRIPT_DIR}/contributor-activity-helper-session.sh"
-#
-# Dependencies:
-#   - shared-constants.sh (print_error, print_info, etc.)
-#   - sqlite3 (for database queries)
-#   - python3 (for JSON processing)
-#   - jq (for cross-repo JSON assembly)
-#
-# Part of aidevops framework: https://aidevops.sh
+# Contributor Activity — observed AI session time interface
 
-# Apply strict mode only when executed directly (not when sourced)
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
-
-# Include guard
 [[ -n "${_CONTRIBUTOR_ACTIVITY_SESSION_LIB_LOADED:-}" ]] && return 0
 _CONTRIBUTOR_ACTIVITY_SESSION_LIB_LOADED=1
-
-# Defensive SCRIPT_DIR fallback
-if [[ -z "${SCRIPT_DIR:-}" ]]; then
-	_lib_path="${BASH_SOURCE[0]%/*}"
-	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
-	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
-	unset _lib_path
-fi
 
 _SESSION_TIME_LIB_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 SESSION_TIME_INTERVAL_ENGINE="${_SESSION_TIME_LIB_DIR}/session-time-interval-engine.py"
 unset _SESSION_TIME_LIB_DIR
 
-# --- Functions ---
-
 #######################################
-# Auto-detect AI assistant session database path (t1665.5)
-#
-# Uses runtime registry to find the first available session DB.
-# Falls back to hardcoded paths if registry is not loaded.
-# Output: database path to stdout, or empty string if not found
-#######################################
-_session_time_detect_db() {
-	# Use runtime registry if available (t1665.5)
-	if type rt_list_ids &>/dev/null; then
-		local _db_rt_id _db_path _db_fmt
-		while IFS= read -r _db_rt_id; do
-			_db_path=$(rt_session_db "$_db_rt_id") || continue
-			_db_fmt=$(rt_session_db_format "$_db_rt_id") || continue
-			# Only return SQLite databases (this function is used for SQL queries)
-			if [[ "$_db_fmt" == "sqlite" && -n "$_db_path" && -f "$_db_path" ]]; then
-				echo "$_db_path"
-				return 0
-			fi
-		done < <(rt_list_ids)
-		echo ""
-		return 0
-	fi
-
-	# Fallback: hardcoded paths
-	if [[ -f "${HOME}/.local/share/opencode/opencode.db" ]]; then
-		echo "${HOME}/.local/share/opencode/opencode.db"
-	elif [[ -f "${HOME}/.local/share/claude/Claude.db" ]]; then
-		echo "${HOME}/.local/share/claude/Claude.db"
-	else
-		echo ""
-	fi
-	return 0
-}
-
-#######################################
-# Resolve the OpenCode archive DB associated with a primary session DB.
+# Format one session-stat object as Markdown.
 # Arguments:
-#   $1 - primary db path
-# Output: archive database path to stdout, or empty string if unavailable
+#   $1 - stats JSON
+#   $2 - period label
 #######################################
-_session_time_archive_db_for() {
-	local db_path="$1"
-	local archive_path="${OPENCODE_ARCHIVE_DB_PATH:-${OPENCODE_ARCHIVE_DB:-}}"
-
-	if [[ -z "$archive_path" && "$db_path" == */opencode.db ]]; then
-		archive_path="${db_path%/opencode.db}/opencode-archive.db"
-	fi
-
-	if [[ -n "$archive_path" && "$archive_path" != "$db_path" && -f "$archive_path" ]]; then
-		printf '%s\n' "$archive_path"
-	fi
-	return 0
-}
-
-#######################################
-# Detect aidevops OpenCode wrapper-scoped SQLite session DBs.
-# Output: zero or more database paths, one per line
-#######################################
-_session_time_detect_wrapper_db_paths() {
-	local work_dir="${AIDEVOPS_WORK_DIR:-${HOME}/.aidevops/.agent-workspace/work}"
-	local candidate
-
-	[[ -d "${work_dir}/opencode-interactive" ]] || return 0
-
-	for candidate in "${work_dir}"/opencode-interactive/*/opencode/opencode.db; do
-		[[ -f "$candidate" ]] || continue
-		printf '%s\n' "$candidate"
-	done
-	return 0
-}
-
-#######################################
-# Auto-detect all SQLite session DBs that make up the local history.
-# Output: one database path per line, primary first, archive second if present,
-# followed by aidevops wrapper-scoped OpenCode DBs.
-#######################################
-_session_time_detect_db_paths() {
-	local primary_db
-	primary_db=$(_session_time_detect_db)
-	if [[ -n "$primary_db" ]]; then
-		printf '%s\n' "$primary_db"
-
-		local archive_db
-		archive_db=$(_session_time_archive_db_for "$primary_db")
-		if [[ -n "$archive_db" ]]; then
-			printf '%s\n' "$archive_db"
-		fi
-	fi
-
-	_session_time_detect_wrapper_db_paths
-	return 0
-}
-
-#######################################
-# Handle --period all for session_time
-#
-# Calls session_time for each sub-period and combines into a single table.
-#
-# Arguments:
-#   $1 - repo path
-#   $2 - format: "markdown" or "json"
-#   $3 - db path (may be empty)
-# Output: combined table or JSON to stdout
-#######################################
-_session_time_all_periods() {
-	local repo_path="$1"
-	local format="$2"
-	local db_path="$3"
-
-	# Build base args before the loop. repo_path may be "--all-dirs" (flag),
-	# a real path, or empty. session_time() handles all three cases.
-	local -a base_args=("$repo_path")
-	[[ -n "$db_path" ]] && base_args+=(--db-path "$db_path")
-
-	local all_periods=("day" "week" "month" "quarter" "year")
-	local combined_json="["
-	local first_period=true
-	local p
-	for p in "${all_periods[@]}"; do
-		local p_json
-		p_json=$(session_time "${base_args[@]}" --period "$p" --format json) || p_json="{}"
-		if [[ "$first_period" == "true" ]]; then
-			first_period=false
-		else
-			combined_json+=","
-		fi
-		combined_json+="{\"period\":\"${p}\",\"data\":${p_json}}"
-	done
-	combined_json+="]"
-
-	echo "$combined_json" | python3 -c "
-import sys
+_session_time_format_markdown() {
+	local stats_json="$1"
+	local period="$2"
+	printf '%s\n' "$stats_json" | python3 -c '
 import json
-
-format_type = sys.argv[1]
+import sys
+period = sys.argv[1]
 data = json.load(sys.stdin)
-
-if format_type == 'json':
-    result = {}
-    for entry in data:
-        result[entry['period']] = entry['data']
-    print(json.dumps(result, indent=2))
+if data.get("status") == "unavailable":
+    print(f"_Session data unavailable for {period}._")
+elif data.get("total_sessions", 0) == 0:
+    print(f"_No observed sessions for {period}._")
 else:
-    if not data or all(d['data'].get('total_sessions', 0) == 0 for d in data):
-        print('_No session data available._')
-    else:
-        print('| Period | Human Hours | AI Hours | Total Work | Sessions | Workers |')
-        print('| --- | ---: | ---: | ---: | ---: | ---: |')
-        for entry in data:
-            p = entry['period'].capitalize()
-            d = entry['data']
-            human_h = d.get('total_human_hours', 0)
-            ai_h = d.get('total_machine_hours', 0)
-            total_h = round(human_h + ai_h, 1)
-            i_sess = d.get('interactive_sessions', 0)
-            w_sess = d.get('worker_sessions', 0)
-            print(f'| {p} | {human_h}h | {ai_h}h | {total_h}h | {i_sess} | {w_sess} |')
-" "$format"
+    print("| Type | Human attention | AI generation | Additive work | Sessions |")
+    print("| --- | ---: | ---: | ---: | ---: |")
+    for label, prefix in (("Interactive", "interactive"), ("Workers/Runners", "worker")):
+        human = data.get(f"{prefix}_human_hours", 0)
+        machine = data.get(f"{prefix}_machine_hours", 0)
+        count = data.get(f"{prefix}_sessions", 0)
+        print(f"| {label} | {human}h | {machine}h | {round(human + machine, 1)}h | {count} |")
+    human = data.get("total_human_hours", 0)
+    machine = data.get("total_machine_hours", 0)
+    print(f"| **Total** | **{human}h** | **{machine}h** | **{round(human + machine, 1)}h** | **{data.get('"'"'total_sessions'"'"', 0)}** |")
+' "$period"
 	return 0
 }
 
 #######################################
-# Query session database for time data
-#
+# Format a period map as Markdown.
 # Arguments:
-#   $1 - db path
-#   $2 - abs repo path (for SQL filtering; empty string = all directories)
-#   $3 - since_ms (milliseconds threshold)
-# Output: JSON array of session rows to stdout
+#   $1 - period map JSON
 #######################################
-_session_time_query_db() {
-	local db_path="$1"
-	local abs_repo_path="$2"
-	local since_ms="$3"
-
-	# Query per-session human vs machine time using window functions.
-	# LAG() compares each message with the previous one in the same session:
-	#   human_time = user.created - prev_assistant.completed (reading + thinking + typing)
-	#   machine_time = assistant.completed - assistant.created (AI generating)
-	# Caps human gaps at 1 hour to exclude idle/abandoned sessions.
-	# Worker sessions (headless) have ~0% human time; interactive ~70-85%.
-	local query_result
-	query_result=$(python3 - "$db_path" "$abs_repo_path" "$since_ms" <<'PY' 2>/dev/null
-import json
-import sqlite3
-import sys
-
-db_path = sys.argv[1]
-abs_repo_path = sys.argv[2]
-since_ms = int(float(sys.argv[3] or 0))
-
-where = ["s.parent_id IS NULL", "m.time_created > ?"]
-params = [since_ms]
-if abs_repo_path:
-    like_path = (
-        abs_repo_path
-        .replace('\\', '\\\\')
-        .replace('%', '\\%')
-        .replace('_', '\\_')
-    )
-    where.append("""(s.directory = ?
-        OR s.directory LIKE ? ESCAPE '\\'
-        OR s.directory LIKE ? ESCAPE '\\')""")
-    params.extend([
-        abs_repo_path,
-        f"{like_path}.%",
-        f"{like_path}-%",
-    ])
-
-query = f"""
-    WITH msg_data AS (
-        SELECT
-            s.id AS session_id,
-            s.title,
-            s.directory,
-            json_extract(m.data, '$.role') AS role,
-            m.time_created AS created,
-            json_extract(m.data, '$.time.completed') AS completed,
-            LAG(json_extract(m.data, '$.role'))
-                OVER (PARTITION BY s.id ORDER BY m.time_created) AS prev_role,
-            LAG(json_extract(m.data, '$.time.completed'))
-                OVER (PARTITION BY s.id ORDER BY m.time_created) AS prev_completed
-        FROM session s
-        JOIN message m ON m.session_id = s.id
-        WHERE {' AND '.join(where)}
-    )
-    SELECT
-        session_id,
-        title,
-        directory,
-        MIN(created) AS first_message_ms,
-        MAX(COALESCE(completed, created)) AS last_message_ms,
-        SUM(CASE
-            WHEN role = 'user' AND prev_role = 'assistant'
-                 AND prev_completed IS NOT NULL
-                 AND (created - prev_completed) BETWEEN 1 AND 3600000
-            THEN created - prev_completed
-            ELSE 0
-        END) AS human_ms,
-        SUM(CASE
-            WHEN role = 'assistant' AND completed IS NOT NULL
-                 AND (completed - created) > 0
-            THEN completed - created
-            ELSE 0
-        END) AS machine_ms
-    FROM msg_data
-    GROUP BY session_id
-    HAVING human_ms + machine_ms > 5000
-"""
-
-with sqlite3.connect(db_path, timeout=5) as conn:
-    conn.row_factory = sqlite3.Row
-    rows = [dict(row) for row in conn.execute(query, params)]
-print(json.dumps(rows))
-PY
-	) || query_result="[]"
-
-	# t1427: sqlite3 -json returns "" (not "[]") when no rows match.
-	if [[ "$query_result" != "["* ]]; then
-		query_result="[]"
-	fi
-
-	echo "$query_result"
-	return 0
-}
-
-#######################################
-# Query all detected session databases and de-duplicate copied archive rows.
-# Arguments:
-#   $1 - newline-delimited db paths
-#   $2 - abs repo path (empty string = all directories)
-#   $3 - since_ms (milliseconds threshold)
-# Output: JSON array of session rows to stdout
-#######################################
-_session_time_query_db_paths() {
-	local db_paths="$1"
-	local abs_repo_path="$2"
-	local since_ms="$3"
-	local combined_json=""
-	local db_path
-
-	while IFS= read -r db_path; do
-		[[ -z "$db_path" || ! -f "$db_path" ]] && continue
-
-		local db_json
-		db_json=$(_session_time_query_db "$db_path" "$abs_repo_path" "$since_ms") || db_json="[]"
-		if echo "$db_json" | jq -e . >/dev/null 2>&1; then
-			combined_json="${combined_json}${db_json}"$'\n'
-		fi
-	done <<<"$db_paths"
-
-	if [[ -z "$combined_json" ]]; then
-		echo "[]"
-		return 0
-	fi
-
-	printf '%s' "$combined_json" | jq -s '
-		add
-		| reduce .[] as $row ([];
-			if any(.[]; .session_id == $row.session_id) then . else . + [$row] end
-		)
-	' 2>/dev/null || echo "[]"
-	return 0
-}
-
-#######################################
-# Resolve the shared OpenCode observability database, if available.
-# Output: database path to stdout, or empty string if unavailable
-#######################################
-_session_time_obs_db_path() {
-	local obs_db="${AIDEVOPS_OBS_DB_FILE:-${OBS_DB_FILE:-${HOME}/.aidevops/.agent-workspace/observability/llm-requests.db}}"
-
-	if [[ -f "$obs_db" ]]; then
-		printf '%s\n' "$obs_db"
-	fi
-	return 0
-}
-
-#######################################
-# Query OpenCode plugin observability for total AI generation duration.
-# Arguments:
-#   $1 - abs repo path (empty string = all directories)
-#   $2 - since_ms (milliseconds threshold)
-# Output: JSON object with observability_machine_ms and observability_sessions
-#######################################
-_session_time_query_observability() {
-	local abs_repo_path="$1"
-	local since_ms="$2"
-	local obs_db
-	obs_db=$(_session_time_obs_db_path)
-
-	if [[ -z "$obs_db" ]] || ! sqlite3 -cmd ".timeout 5000" "$obs_db" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='llm_requests' LIMIT 1;" >/dev/null 2>&1; then
-		printf '%s\n' '{"observability_machine_ms":0,"observability_sessions":0}'
-		return 0
-	fi
-
-	local result machine_ms sessions
-	result=$(python3 - "$obs_db" "$abs_repo_path" "$since_ms" <<'PY' 2>/dev/null
-import sqlite3
-import sys
-
-db_path = sys.argv[1]
-abs_repo_path = sys.argv[2]
-since_ms = int(float(sys.argv[3] or 0))
-
-where = ["timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', ? / 1000.0, 'unixepoch')"]
-params = [since_ms]
-if abs_repo_path:
-    like_path = (
-        abs_repo_path
-        .replace('\\', '\\\\')
-        .replace('%', '\\%')
-        .replace('_', '\\_')
-    )
-    where.append("""(project_path = ?
-        OR project_path LIKE ? ESCAPE '\\'
-        OR project_path LIKE ? ESCAPE '\\'
-        OR project_path LIKE ? ESCAPE '\\')""")
-    params.extend([
-        abs_repo_path,
-        f"{like_path}/%",
-        f"{like_path}.%",
-        f"{like_path}-%",
-    ])
-
-query = f"""
-    SELECT
-        COALESCE(SUM(CASE WHEN duration_ms > 0 THEN duration_ms ELSE 0 END), 0),
-        COUNT(DISTINCT session_id)
-    FROM llm_requests
-    WHERE {' AND '.join(where)};
-"""
-
-with sqlite3.connect(db_path, timeout=5) as conn:
-    machine_ms, sessions = conn.execute(query, params).fetchone()
-print(f"{machine_ms or 0}|{sessions or 0}")
-PY
-	) || result="0|0"
-
-	IFS='|' read -r machine_ms sessions <<<"$result"
-	machine_ms="${machine_ms:-0}"
-	sessions="${sessions:-0}"
-	printf '{"observability_machine_ms":%s,"observability_sessions":%s}\n' "$machine_ms" "$sessions"
-	return 0
-}
-
-#######################################
-# Merge observability AI-generation totals into session stats.
-#
-# Session DB timestamps are the best source for attended interactive time and
-# title/directory classification. The plugin observability DB is the durable
-# source for LLM generation duration across isolated headless workers. To avoid
-# double-counting interactive generation already present in session DBs, use
-# observability as a floor for total machine time: worker machine duration is
-# at least (observability total - interactive machine duration).
-#
-# Arguments:
-#   $1 - aggregated session stats JSON
-#   $2 - observability stats JSON
-# Output: merged stats JSON object to stdout
-#######################################
-_session_time_merge_observability_stats() {
+_session_time_format_period_map() {
 	local stats_json="$1"
-	local obs_json="$2"
-
-	python3 -c "
-import sys
-import json
-
-stats = json.loads(sys.argv[1] or '{}')
-obs = json.loads(sys.argv[2] or '{}')
-
-def number(value):
-    try:
-        return float(value or 0)
-    except (TypeError, ValueError):
-        return 0.0
-
-def ms_field(name, hours_name):
-    if name in stats:
-        return int(number(stats.get(name)))
-    return int(round(number(stats.get(hours_name)) * 3600000))
-
-def ms_to_h(ms):
-    return round(ms / 3600000, 1)
-
-interactive_human_ms = ms_field('interactive_human_ms', 'interactive_human_hours')
-interactive_machine_ms = ms_field('interactive_machine_ms', 'interactive_machine_hours')
-worker_human_ms = ms_field('worker_human_ms', 'worker_human_hours')
-worker_machine_ms = ms_field('worker_machine_ms', 'worker_machine_hours')
-obs_machine_ms = int(number(obs.get('observability_machine_ms')))
-obs_sessions = int(number(obs.get('observability_sessions')))
-
-observed_worker_machine_ms = max(0, obs_machine_ms - interactive_machine_ms)
-worker_machine_ms = max(worker_machine_ms, observed_worker_machine_ms)
-
-interactive_sessions = int(number(stats.get('interactive_sessions')))
-worker_sessions = int(number(stats.get('worker_sessions')))
-if worker_machine_ms > 0 and worker_sessions == 0:
-    worker_sessions = max(1, obs_sessions - interactive_sessions)
-
-total_human_ms = interactive_human_ms + worker_human_ms
-total_machine_ms = interactive_machine_ms + worker_machine_ms
-
-stats.update({
-    'interactive_human_ms': interactive_human_ms,
-    'interactive_machine_ms': interactive_machine_ms,
-    'worker_human_ms': worker_human_ms,
-    'worker_machine_ms': worker_machine_ms,
-    'interactive_sessions': interactive_sessions,
-    'worker_sessions': worker_sessions,
-    'interactive_human_hours': ms_to_h(interactive_human_ms),
-    'interactive_machine_hours': ms_to_h(interactive_machine_ms),
-    'worker_human_hours': ms_to_h(worker_human_ms),
-    'worker_machine_hours': ms_to_h(worker_machine_ms),
-    'total_human_hours': ms_to_h(total_human_ms),
-    'total_machine_hours': ms_to_h(total_machine_ms),
-    'total_sessions': interactive_sessions + worker_sessions,
-    'observability_machine_hours': ms_to_h(obs_machine_ms),
-    'observability_sessions': obs_sessions,
-})
-
-print(json.dumps(stats, indent=2))
-" "$stats_json" "$obs_json"
-	return 0
-}
-
-#######################################
-# Classify and aggregate session rows into stats JSON
-#
-# Arguments:
-#   $1 - JSON array of session rows (from stdin via pipe)
-# Input: JSON array on stdin
-# Output: aggregated stats JSON object to stdout
-#######################################
-_session_time_classify_and_aggregate() {
-	python3 -c "
-import sys
-import json
-import re
-
-# Worker session title patterns
-# Matches headless dispatches, PR fix sessions, CI fix sessions, review feedback,
-# task sessions (t123, t123.4, t123-fix:), escalation sessions, health checks
-worker_patterns = [
-    re.compile(r'^Issue #\d+'),
-    re.compile(r'^PR #\d+'),
-    re.compile(r'^Fix PR\b', re.IGNORECASE),
-    re.compile(r'^Review PR\b', re.IGNORECASE),
-    re.compile(r'^Supervisor Pulse'),
-    re.compile(r'/full-loop', re.IGNORECASE),
-    re.compile(r'^dispatch:', re.IGNORECASE),
-    re.compile(r'^Worker:', re.IGNORECASE),
-    re.compile(r'^t\d+[\.\-:]', re.IGNORECASE),
-    re.compile(r'^escalation-', re.IGNORECASE),
-    re.compile(r'^health-check$', re.IGNORECASE),
-    re.compile(r'failing CI\b', re.IGNORECASE),
-    re.compile(r'CI fail', re.IGNORECASE),
-    re.compile(r'CHANGES_REQUESTED', re.IGNORECASE),
-    re.compile(r'CodeRabbit review', re.IGNORECASE),
-    re.compile(r'address review', re.IGNORECASE),
-    re.compile(r'review feedback', re.IGNORECASE),
-    re.compile(r'^Fix qlty\b', re.IGNORECASE),
-    re.compile(r'^Gemini feedback\b', re.IGNORECASE),
-]
-
-runtime_temp_dir_patterns = [
-    re.compile(r'^/private/tmp/opencode(?:[.-].*)?$'),
-    re.compile(r'^/tmp/opencode(?:[.-].*)?$'),
-    re.compile(r'^/var/folders/.*/T/opencode.*$'),
-]
-
-def is_runtime_temp_directory(directory):
-    if not directory:
-        return False
-    for pat in runtime_temp_dir_patterns:
-        if pat.search(directory):
-            return True
-    return False
-
-def classify_session(title, directory):
-    if is_runtime_temp_directory(directory):
-        return 'worker'
-    for pat in worker_patterns:
-        if pat.search(title):
-            return 'worker'
-    return 'interactive'
-
-sessions = json.load(sys.stdin)
-stats = {
-    'interactive': {'count': 0, 'human_ms': 0, 'machine_ms': 0},
-    'worker':      {'count': 0, 'human_ms': 0, 'machine_ms': 0},
-}
-first_seen = []
-last_seen = []
-
-def number_or_zero(value):
-    try:
-        return int(value or 0)
-    except (TypeError, ValueError):
-        return 0
-
-for row in sessions:
-    title = row.get('title') or ''
-    directory = row.get('directory') or ''
-    stype = classify_session(title, directory)
-    stats[stype]['count'] += 1
-    stats[stype]['human_ms'] += number_or_zero(row.get('human_ms'))
-    stats[stype]['machine_ms'] += number_or_zero(row.get('machine_ms'))
-    first_ms = number_or_zero(row.get('first_message_ms'))
-    last_ms = number_or_zero(row.get('last_message_ms'))
-    if first_ms > 0:
-        first_seen.append(first_ms)
-    if last_ms > 0:
-        last_seen.append(last_ms)
-
-def ms_to_h(ms):
-    return round(ms / 3600000, 1)
-
-i = stats['interactive']
-w = stats['worker']
-observed_days = 0
-if first_seen and last_seen:
-    observed_days = round(max(0, max(last_seen) - min(first_seen)) / 86400000, 1)
-
-print(json.dumps({
-    'interactive_sessions': i['count'],
-    'interactive_human_ms': i['human_ms'],
-    'interactive_machine_ms': i['machine_ms'],
-    'interactive_human_hours': ms_to_h(i['human_ms']),
-    'interactive_machine_hours': ms_to_h(i['machine_ms']),
-    'worker_sessions': w['count'],
-    'worker_human_ms': w['human_ms'],
-    'worker_machine_ms': w['machine_ms'],
-    'worker_human_hours': ms_to_h(w['human_ms']),
-    'worker_machine_hours': ms_to_h(w['machine_ms']),
-    'total_human_hours': ms_to_h(i['human_ms'] + w['human_ms']),
-    'total_machine_hours': ms_to_h(i['machine_ms'] + w['machine_ms']),
-    'total_sessions': i['count'] + w['count'],
-    'observed_days': observed_days,
-}, indent=2))
-"
-	return 0
-}
-
-#######################################
-# Format aggregated session stats as table or JSON
-#
-# Arguments:
-#   $1 - aggregated stats JSON object
-#   $2 - format: "markdown" or "json"
-#   $3 - period name (for empty-state messages)
-# Output: formatted table or JSON to stdout
-#######################################
-_session_time_format_stats() {
-	local stats_json="$1"
-	local format="$2"
-	local period="$3"
-
-	echo "$stats_json" | python3 -c "
-import sys
-import json
-
-format_type = sys.argv[1]
-period_name = sys.argv[2]
-result = json.load(sys.stdin)
-
-total_sessions = result.get('total_sessions', 0)
-total_human_h = result.get('total_human_hours', 0)
-total_machine_h = result.get('total_machine_hours', 0)
-i_human_h = result.get('interactive_human_hours', 0)
-i_machine_h = result.get('interactive_machine_hours', 0)
-w_human_h = result.get('worker_human_hours', 0)
-w_machine_h = result.get('worker_machine_hours', 0)
-i_count = result.get('interactive_sessions', 0)
-w_count = result.get('worker_sessions', 0)
-
-if format_type == 'json':
-    print(json.dumps(result, indent=2))
-else:
-    if total_sessions == 0:
-        print(f'_No session data for the last {period_name}._')
-    else:
-        total_work_h = round(total_human_h + total_machine_h, 1)
-        print(f'| Type | Human Hours | AI Hours | Total Work | Sessions |')
-        print(f'| --- | ---: | ---: | ---: | ---: |')
-        print(f'| Interactive | {i_human_h}h | {i_machine_h}h | {round(i_human_h + i_machine_h, 1)}h | {i_count} |')
-        print(f'| Workers/Runners | {w_human_h}h | {w_machine_h}h | {round(w_human_h + w_machine_h, 1)}h | {w_count} |')
-        print(f'| **Total** | **{total_human_h}h** | **{total_machine_h}h** | **{total_work_h}h** | **{total_sessions}** |')
-" "$format" "$period"
-
-	return 0
-}
-
-#######################################
-# Process session query results and format output
-#
-# Arguments:
-#   $1 - JSON array of session rows
-#   $2 - format: "markdown" or "json"
-#   $3 - period name (for empty-state messages)
-#   $4 - abs repo path (empty string = all directories)
-#   $5 - since_ms (milliseconds threshold)
-# Output: formatted table or JSON to stdout
-#######################################
-_session_time_process() {
-	local query_result="$1"
-	local format="$2"
-	local period="$3"
-	local abs_repo_path="${4:-}"
-	local since_ms="${5:-0}"
-
-	local stats_json obs_json
-	stats_json=$(echo "$query_result" | _session_time_classify_and_aggregate)
-	obs_json=$(_session_time_query_observability "$abs_repo_path" "$since_ms")
-	stats_json=$(_session_time_merge_observability_stats "$stats_json" "$obs_json")
-	_session_time_format_stats "$stats_json" "$format" "$period"
-	return 0
-}
-
-#######################################
-# Session time stats from AI assistant database
-#
-# Queries the OpenCode/Claude Code SQLite database to compute time spent
-# in interactive sessions vs headless worker/runner sessions, per repo.
-#
-# Measures ACTUAL human time vs machine time per session using message
-# timestamps: human_time = gap between assistant completing and next user
-# message (reading + thinking + typing). machine_time = gap between
-# assistant message created and completed (AI generating).
-#
-# Session type classification (by title pattern and runtime temp workdir):
-#   - Worker: "Issue #*", "PR #*", "Supervisor Pulse", "/full-loop", "dispatch:", "Worker:"
-#     or runtime temp directories used by classifier/headless sessions
-#   - Interactive: everything else (root sessions only)
-#   - Subagent: sessions with parent_id (excluded — time attributed to parent)
-#
-# Arguments:
-#   $1 - repo path (filters sessions by directory)
-#   --period day|week|month|quarter|year|all (optional, default: month)
-#   --format markdown|json (optional, default: markdown)
-#   --db-path <path> (optional, default: auto-detect)
-#   --all-dirs (optional, skip directory filter — aggregate all sessions)
-# Output: markdown table or JSON. "all" shows every period in one table.
-#######################################
-session_time() {
-	local repo_path=""
-	local period="month"
-	local format="markdown"
-	local db_path=""
-	local all_dirs="false"
-
-	# Parse arguments
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-		--period)
-			period="${2:-month}"
-			shift 2
-			;;
-		--format)
-			format="${2:-markdown}"
-			shift 2
-			;;
-		--db-path)
-			db_path="${2:-}"
-			shift 2
-			;;
-		--all-dirs)
-			all_dirs="true"
-			shift
-			;;
-		*)
-			if [[ -z "$repo_path" ]]; then
-				repo_path="$1"
-			fi
-			shift
-			;;
-		esac
-	done
-
-	if [[ "$all_dirs" != "true" ]]; then
-		repo_path="${repo_path:-.}"
-	fi
-
-	local -a engine_args=(--period "$period")
-	if [[ "$all_dirs" == "true" ]]; then
-		engine_args+=(--all-dirs)
-	else
-		engine_args+=(--repo "$repo_path")
-	fi
-	[[ -n "$db_path" ]] && engine_args+=(--db-path "$db_path")
-
-	local result
-	if ! result=$(python3 "$SESSION_TIME_INTERVAL_ENGINE" "${engine_args[@]}"); then
-		if [[ "$format" == "json" ]]; then
-			printf '%s\n' '{"status":"unavailable","reason":"session-aggregation-failed"}'
-		else
-			printf '%s\n' '_Session data unavailable._'
-		fi
-		return 0
-	fi
-
-	if [[ "$format" == "json" ]]; then
-		printf '%s\n' "$result"
-		return 0
-	fi
-	if [[ "$period" != "all" && "$period" != "profile" ]]; then
-		_session_time_format_stats "$result" "$format" "$period"
-		return 0
-	fi
-	printf '%s\n' "$result" | python3 -c '
+	printf '%s\n' "$stats_json" | python3 -c '
 import json
 import sys
 data = json.load(sys.stdin)
@@ -802,223 +63,101 @@ else:
     for period, item in data.items():
         human = item.get("total_human_hours", 0)
         machine = item.get("total_machine_hours", 0)
-        sessions = item.get("total_sessions", 0)
-        workers = item.get("worker_sessions", 0)
-        print(f"| {period.capitalize()} | {human}h | {machine}h | {round(human + machine, 1)}h | {sessions} | {workers} |")
+        print(f"| {period.capitalize()} | {human}h | {machine}h | {round(human + machine, 1)}h | {item.get('"'"'total_sessions'"'"', 0)} | {item.get('"'"'worker_sessions'"'"', 0)} |")
 '
 	return 0
 }
 
 #######################################
-# Handle --period all for cross_repo_session_time
-#
+# Compute observed AI session time.
 # Arguments:
-#   $1 - format: "markdown" or "json"
-#   $2..N - repo paths
-# Output: combined table or JSON to stdout
+#   repo path and --period/--format/--db-path/--all-dirs options
 #######################################
-_cross_repo_session_time_all_periods() {
-	local format="$1"
-	shift
-	local -a repo_paths=("$@")
-
-	local all_periods=("day" "week" "month" "quarter" "year")
-	local combined_json="["
-	local first_period=true
-	local p
-	for p in "${all_periods[@]}"; do
-		local p_json
-		p_json=$(cross_repo_session_time "${repo_paths[@]}" --period "$p" --format json) || p_json="{}"
-		if [[ "$first_period" == "true" ]]; then
-			first_period=false
-		else
-			combined_json+=","
-		fi
-		combined_json+="{\"period\":\"${p}\",\"data\":${p_json}}"
+session_time() {
+	local repo_path=""
+	local period="month"
+	local format="markdown"
+	local db_path=""
+	local all_dirs="false"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--period)
+			period="${2:-}"
+			shift 2
+			;;
+		--format)
+			format="${2:-}"
+			shift 2
+			;;
+		--db-path)
+			db_path="${2:-}"
+			shift 2
+			;;
+		--all-dirs)
+			all_dirs="true"
+			shift
+			;;
+		*)
+			[[ -z "$repo_path" ]] && repo_path="$1"
+			shift
+			;;
+		esac
 	done
-	combined_json+="]"
+	case "$period" in
+	day | week | 28d | month | quarter | year | profile | all) ;;
+	*)
+		echo "Error: invalid session period: ${period}" >&2
+		return 1
+		;;
+	esac
+	case "$format" in
+	json | markdown) ;;
+	*)
+		echo "Error: invalid session format: ${format}" >&2
+		return 1
+		;;
+	esac
 
-	echo "$combined_json" | python3 -c "
-import sys
-import json
-
-format_type = sys.argv[1]
-data = json.load(sys.stdin)
-
-if format_type == 'json':
-    result = {}
-    for entry in data:
-        result[entry['period']] = entry['data']
-    print(json.dumps(result, indent=2))
-else:
-    repo_count = data[0]['data'].get('repo_count', 0) if data else 0
-    if not data or all(d['data'].get('total_sessions', 0) == 0 for d in data):
-        print(f'_No session data across {repo_count} repos._')
-    else:
-        print(f'_Across {repo_count} managed repos:_')
-        print()
-        print('| Period | Human Hours | AI Hours | Total Work | Sessions | Workers |')
-        print('| --- | ---: | ---: | ---: | ---: | ---: |')
-        for entry in data:
-            p = entry['period'].capitalize()
-            d = entry['data']
-            human_h = d.get('total_human_hours', 0)
-            ai_h = d.get('total_machine_hours', 0)
-            total_h = round(human_h + ai_h, 1)
-            i_sess = d.get('interactive_sessions', 0)
-            w_sess = d.get('worker_sessions', 0)
-            print(f'| {p} | {human_h}h | {ai_h}h | {total_h}h | {i_sess} | {w_sess} |')
-" "$format"
+	local -a engine_args=(--period "$period")
+	if [[ "$all_dirs" == "true" ]]; then
+		engine_args+=(--all-dirs)
+	else
+		repo_path="${repo_path:-.}"
+		engine_args+=(--repo "$repo_path")
+	fi
+	[[ -n "$db_path" ]] && engine_args+=(--db-path "$db_path")
+	local result
+	if ! result=$(python3 "$SESSION_TIME_INTERVAL_ENGINE" "${engine_args[@]}"); then
+		echo "Error: session aggregation failed" >&2
+		return 1
+	fi
+	if [[ "$format" == "json" ]]; then
+		printf '%s\n' "$result"
+	elif [[ "$period" == "all" || "$period" == "profile" ]]; then
+		_session_time_format_period_map "$result"
+	else
+		_session_time_format_markdown "$result" "$period"
+	fi
 	return 0
 }
 
 #######################################
-# Collect and aggregate per-repo session time JSON
-#
+# Aggregate session stats across repository paths.
 # Arguments:
-#   $1 - period
-#   $2..N - repo paths
-# Output: aggregated JSON object to stdout
-#######################################
-_cross_repo_session_time_collect_and_aggregate() {
-	local period="$1"
-	shift
-
-	# Collect JSON from each repo — use jq to assemble a valid JSON array.
-	# This is robust against non-JSON responses from session_time (e.g., error strings).
-	# Skip invalid repo paths to avoid inflating the repo count.
-	local all_json=""
-	local repo_count=0
-	local rp
-	for rp in "$@"; do
-		if [[ ! -d "$rp/.git" && ! -f "$rp/.git" ]]; then
-			echo "Warning: $rp is not a git repository, skipping" >&2
-			continue
-		fi
-		local repo_json
-		repo_json=$(session_time "$rp" --period "$period" --format json) || repo_json="{}"
-		# Only include valid JSON objects in the array
-		if echo "$repo_json" | jq -e . >/dev/null 2>&1; then
-			all_json+="${repo_json}"$'\n'
-		fi
-		repo_count=$((repo_count + 1))
-	done
-	all_json=$(echo -n "$all_json" | jq -s '.')
-
-	echo "$all_json" | python3 -c "
-import sys
-import json
-
-repo_count = int(sys.argv[1])
-
-repos = json.load(sys.stdin)
-
-totals = {
-    'interactive_sessions': 0,
-    'interactive_human_hours': 0,
-    'interactive_machine_hours': 0,
-    'worker_sessions': 0,
-    'worker_human_hours': 0,
-    'worker_machine_hours': 0,
-    'total_human_hours': 0,
-}
-
-for repo in repos:
-    totals['interactive_sessions'] += repo.get('interactive_sessions', 0)
-    totals['interactive_human_hours'] += repo.get('interactive_human_hours', 0)
-    totals['interactive_machine_hours'] += repo.get('interactive_machine_hours', 0)
-    totals['worker_sessions'] += repo.get('worker_sessions', 0)
-    totals['worker_human_hours'] += repo.get('worker_human_hours', 0)
-    totals['worker_machine_hours'] += repo.get('worker_machine_hours', 0)
-    totals['total_human_hours'] += repo.get('total_human_hours', 0)
-
-for k in ['interactive_human_hours', 'interactive_machine_hours', 'worker_human_hours', 'worker_machine_hours', 'total_human_hours']:
-    totals[k] = round(totals[k], 1)
-
-total_machine_h = round(totals['interactive_machine_hours'] + totals['worker_machine_hours'], 1)
-total_sessions = totals['interactive_sessions'] + totals['worker_sessions']
-totals['total_machine_hours'] = total_machine_h
-totals['total_sessions'] = total_sessions
-totals['repo_count'] = repo_count
-
-print(json.dumps(totals, indent=2))
-" "$repo_count"
-
-	return 0
-}
-
-#######################################
-# Format cross-repo session time aggregated JSON
-#
-# Arguments:
-#   $1 - aggregated JSON object
-#   $2 - format: "markdown" or "json"
-#   $3 - period name
-# Output: formatted table or JSON to stdout
-#######################################
-_cross_repo_session_time_format() {
-	local aggregated_json="$1"
-	local format="$2"
-	local period="$3"
-
-	echo "$aggregated_json" | python3 -c "
-import sys
-import json
-
-format_type = sys.argv[1]
-period_name = sys.argv[2]
-
-totals = json.load(sys.stdin)
-repo_count = totals.get('repo_count', 0)
-total_human_h = totals.get('total_human_hours', 0)
-total_machine_h = totals.get('total_machine_hours', 0)
-total_sessions = totals.get('total_sessions', 0)
-
-if format_type == 'json':
-    print(json.dumps(totals, indent=2))
-else:
-    if total_sessions == 0:
-        print(f'_No session data across {repo_count} repos for the last {period_name}._')
-    else:
-        print(f'_Across {repo_count} managed repos:_')
-        print()
-        total_work_h = round(total_human_h + total_machine_h, 1)
-        i_work = round(totals['interactive_human_hours'] + totals['interactive_machine_hours'], 1)
-        w_work = round(totals['worker_human_hours'] + totals['worker_machine_hours'], 1)
-        print(f'| Type | Human Hours | AI Hours | Total Work | Sessions |')
-        print(f'| --- | ---: | ---: | ---: | ---: |')
-        print(f'| Interactive | {totals[\"interactive_human_hours\"]}h | {totals[\"interactive_machine_hours\"]}h | {i_work}h | {totals[\"interactive_sessions\"]} |')
-        print(f'| Workers/Runners | {totals[\"worker_human_hours\"]}h | {totals[\"worker_machine_hours\"]}h | {w_work}h | {totals[\"worker_sessions\"]} |')
-        print(f'| **Total** | **{total_human_h}h** | **{total_machine_h}h** | **{total_work_h}h** | **{total_sessions}** |')
-" "$format" "$period"
-
-	return 0
-}
-
-#######################################
-# Cross-repo session time summary
-#
-# Aggregates session time across multiple repos. Privacy-safe (no repo names).
-#
-# Arguments:
-#   $1..N - repo paths
-#   --period day|week|month|quarter|year (optional, default: month)
-#   --format markdown|json (optional, default: markdown)
-# Output: aggregated table to stdout
+#   repo paths plus --period and --format
 #######################################
 cross_repo_session_time() {
 	local period="month"
 	local format="markdown"
 	local -a repo_paths=()
-
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--period)
-			period="${2:-month}"
+			period="${2:-}"
 			shift 2
 			;;
 		--format)
-			format="${2:-markdown}"
+			format="${2:-}"
 			shift 2
 			;;
 		*)
@@ -1027,21 +166,58 @@ cross_repo_session_time() {
 			;;
 		esac
 	done
-
 	if [[ ${#repo_paths[@]} -eq 0 ]]; then
 		echo "Error: at least one repo path required" >&2
 		return 1
 	fi
-
-	# Handle --period all: call cross_repo_session_time for each period and combine
 	if [[ "$period" == "all" ]]; then
-		_cross_repo_session_time_all_periods "$format" "${repo_paths[@]}"
+		local period_map='{}'
+		local period_name
+		for period_name in day week month quarter year; do
+			local period_stats
+			period_stats=$(cross_repo_session_time "${repo_paths[@]}" --period "$period_name" --format json) || return 1
+			period_map=$(printf '%s' "$period_map" | jq --arg name "$period_name" --argjson stats "$period_stats" '. + {($name):$stats}')
+		done
+		if [[ "$format" == "json" ]]; then
+			printf '%s\n' "$period_map"
+		else
+			_session_time_format_period_map "$period_map"
+		fi
 		return 0
 	fi
-
-	local aggregated_json
-	aggregated_json=$(_cross_repo_session_time_collect_and_aggregate "$period" "${repo_paths[@]}")
-
-	_cross_repo_session_time_format "$aggregated_json" "$format" "$period"
+	local collected=""
+	local repo_count=0
+	local repo_path
+	for repo_path in "${repo_paths[@]}"; do
+		if [[ ! -d "$repo_path/.git" && ! -f "$repo_path/.git" ]]; then
+			continue
+		fi
+		local item
+		item=$(session_time "$repo_path" --period "$period" --format json) || continue
+		collected="${collected}${item}"$'\n'
+		repo_count=$((repo_count + 1))
+	done
+	local aggregated
+	aggregated=$(printf '%s' "$collected" | jq -s --argjson repo_count "$repo_count" '
+        def sum_field($name): map(.[$name] // 0) | add // 0;
+        {
+            interactive_sessions: sum_field("interactive_sessions"),
+            interactive_human_hours: sum_field("interactive_human_hours"),
+            interactive_machine_hours: sum_field("interactive_machine_hours"),
+            worker_sessions: sum_field("worker_sessions"),
+            worker_human_hours: sum_field("worker_human_hours"),
+            worker_machine_hours: sum_field("worker_machine_hours"),
+            total_human_hours: sum_field("total_human_hours"),
+            total_machine_hours: sum_field("total_machine_hours"),
+            total_sessions: sum_field("total_sessions"),
+            repo_count: $repo_count,
+            status: (if length > 0 then "ok" else "unavailable" end)
+        }
+    ')
+	if [[ "$format" == "json" ]]; then
+		printf '%s\n' "$aggregated"
+	else
+		_session_time_format_markdown "$aggregated" "$period across ${repo_count} repos"
+	fi
 	return 0
 }

--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -83,6 +83,21 @@ else:
 }
 
 #######################################
+# Validate that a value-taking option has a following argument.
+# Arguments:
+#   option name and remaining argument count
+#######################################
+_session_require_option_value() {
+	local option_name="$1"
+	local remaining_count="$2"
+	if [[ "$remaining_count" -lt 2 ]]; then
+		echo "Error: ${option_name} requires an argument" >&2
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Compute observed AI session time.
 # Arguments:
 #   repo path and --period/--format/--db-path/--all-dirs options
@@ -96,14 +111,17 @@ session_time() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--period)
+			_session_require_option_value "$1" "$#" || return 1
 			period="${2:-}"
 			shift 2
 			;;
 		--format)
+			_session_require_option_value "$1" "$#" || return 1
 			format="${2:-}"
 			shift 2
 			;;
 		--db-path)
+			_session_require_option_value "$1" "$#" || return 1
 			db_path="${2:-}"
 			shift 2
 			;;
@@ -167,10 +185,12 @@ cross_repo_session_time() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--period)
+			_session_require_option_value "$1" "$#" || return 1
 			period="${2:-}"
 			shift 2
 			;;
 		--format)
+			_session_require_option_value "$1" "$#" || return 1
 			format="${2:-}"
 			shift 2
 			;;

--- a/.agents/scripts/contributor-activity-helper-session.sh
+++ b/.agents/scripts/contributor-activity-helper-session.sh
@@ -33,6 +33,10 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+_SESSION_TIME_LIB_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+SESSION_TIME_INTERVAL_ENGINE="${_SESSION_TIME_LIB_DIR}/session-time-interval-engine.py"
+unset _SESSION_TIME_LIB_DIR
+
 # --- Functions ---
 
 #######################################
@@ -760,61 +764,48 @@ session_time() {
 		repo_path="${repo_path:-.}"
 	fi
 
-	if ! command -v sqlite3 &>/dev/null; then
+	local -a engine_args=(--period "$period")
+	if [[ "$all_dirs" == "true" ]]; then
+		engine_args+=(--all-dirs)
+	else
+		engine_args+=(--repo "$repo_path")
+	fi
+	[[ -n "$db_path" ]] && engine_args+=(--db-path "$db_path")
+
+	local result
+	if ! result=$(python3 "$SESSION_TIME_INTERVAL_ENGINE" "${engine_args[@]}"); then
 		if [[ "$format" == "json" ]]; then
-			echo '{"interactive_sessions":0,"interactive_human_hours":0,"interactive_machine_hours":0,"worker_sessions":0,"worker_machine_hours":0,"total_human_hours":0,"total_machine_hours":0,"total_sessions":0}'
+			printf '%s\n' '{"status":"unavailable","reason":"session-aggregation-failed"}'
 		else
-			echo "_sqlite3 not available._"
+			printf '%s\n' '_Session data unavailable._'
 		fi
 		return 0
 	fi
 
-	# Handle --period all: collect JSON for each period and output combined table
-	if [[ "$period" == "all" ]]; then
-		# Pass "--all-dirs" as repo_path when aggregating all directories;
-		# _session_time_all_periods passes it through to session_time().
-		local all_repo_arg="$repo_path"
-		[[ "$all_dirs" == "true" ]] && all_repo_arg="--all-dirs"
-		_session_time_all_periods "$all_repo_arg" "$format" "$db_path"
+	if [[ "$format" == "json" ]]; then
+		printf '%s\n' "$result"
 		return 0
 	fi
-
-	local db_paths=""
-	if [[ -n "$db_path" ]]; then
-		db_paths="$db_path"
-	else
-		db_paths=$(_session_time_detect_db_paths)
+	if [[ "$period" != "all" && "$period" != "profile" ]]; then
+		_session_time_format_stats "$result" "$format" "$period"
+		return 0
 	fi
-
-	# Determine --since threshold in milliseconds (single Python call)
-	local seconds
-	case "$period" in
-	day) seconds=86400 ;;
-	week) seconds=604800 ;;
-	28d | 28day | 28days) seconds=2419200 ;;
-	month) seconds=2592000 ;;
-	quarter) seconds=7776000 ;;
-	year) seconds=31536000 ;;
-	*) seconds=2592000 ;;
-	esac
-	local since_ms
-	since_ms=$(python3 -c "import time; print(int((time.time() - ${seconds}) * 1000))")
-
-	# Resolve repo_path to absolute for matching against session.directory
-	# When --all-dirs is set, pass empty string to skip directory filtering
-	local abs_repo_path=""
-	if [[ "$all_dirs" != "true" ]]; then
-		abs_repo_path=$(cd "$repo_path" 2>/dev/null && pwd) || abs_repo_path="$repo_path"
-	fi
-
-	local query_result
-	if [[ -n "$db_paths" ]]; then
-		query_result=$(_session_time_query_db_paths "$db_paths" "$abs_repo_path" "$since_ms")
-	else
-		query_result="[]"
-	fi
-
-	_session_time_process "$query_result" "$format" "$period" "$abs_repo_path" "$since_ms"
+	printf '%s\n' "$result" | python3 -c '
+import json
+import sys
+data = json.load(sys.stdin)
+if not data or all(item.get("total_sessions", 0) == 0 for item in data.values()):
+    print("_No session data available._")
+else:
+    print("| Period | Human attention | AI generation | Additive work | Sessions | Workers |")
+    print("| --- | ---: | ---: | ---: | ---: | ---: |")
+    for period, item in data.items():
+        human = item.get("total_human_hours", 0)
+        machine = item.get("total_machine_hours", 0)
+        sessions = item.get("total_sessions", 0)
+        workers = item.get("worker_sessions", 0)
+        print(f"| {period.capitalize()} | {human}h | {machine}h | {round(human + machine, 1)}h | {sessions} | {workers} |")
+'
 	return 0
 }
 

--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -200,6 +200,15 @@ _get_session_time() {
 	return 0
 }
 
+# --- Gather all profile AI-session windows in one database aggregation pass ---
+_get_profile_session_times() {
+	local session_json
+	session_json=$("${SCRIPT_DIR}/contributor-activity-helper.sh" session-time \
+		--all-dirs --period profile --format json 2>/dev/null) || session_json='{"day":{"status":"unavailable"},"week":{"status":"unavailable"},"28d":{"status":"unavailable"},"year":{"status":"unavailable"}}'
+	printf '%s\n' "$session_json"
+	return 0
+}
+
 # --- Compute cost from token counts using _model_cost_rates ---
 # Takes JSON array with model/input_tokens/output_tokens/cache_read_tokens,
 # adds cost_total field computed from pricing table, sorts by cost desc.

--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -408,11 +408,42 @@ _get_model_usage_from_obs_db() {
 	return 0
 }
 
+# --- Gather model usage from the legacy JSONL metrics fallback ---
+# Usage: _get_model_usage_from_jsonl <30d|all>
+_get_model_usage_from_jsonl() {
+	local period="$1"
+	if [[ ! -f "$METRICS_FILE" ]]; then
+		echo "[]"
+		return 0
+	fi
+	local cutoff="1970-01-01"
+	if [[ "$period" != "all" ]]; then
+		cutoff=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d 2>/dev/null || echo "1970-01-01")
+	fi
+	jq -s --arg cutoff "$cutoff" --arg period "$period" '
+		(if $period == "all" then . else [.[] | select(.recorded_at >= $cutoff)] end)
+		| group_by(.model)
+		| map({
+			model: .[0].model,
+			requests: length,
+			input_tokens: ([.[].input_tokens // 0] | add),
+			output_tokens: ([.[].output_tokens // 0] | add),
+			cache_read_tokens: ([.[].cache_read_tokens // 0] | add),
+			cache_write_tokens: ([.[].cache_write_tokens // 0] | add),
+			cost_total: ([.[].cost_total // 0] | add | . * 100 | round / 100)
+		})
+		| sort_by(-.cost_total)
+	' "$METRICS_FILE" 2>/dev/null || echo "[]"
+	return 0
+}
+
 # --- Gather model usage stats ---
-# Usage: _get_model_usage [period]
+# Usage: _get_model_usage [period] [recent-observability-json] [reference-provided]
 #   period: "30d" (default) or "all" (no date filter)
 _get_model_usage() {
 	local period="${1:-30d}"
+	local supplied_recent="${2:-}"
+	local reference_provided="${3:-false}"
 
 	# For "all" period, compare complete local sources and use the one with the
 	# larger request population. This avoids stale OpenCode message JSON causing
@@ -423,7 +454,11 @@ _get_model_usage() {
 		local obs_all_result obs_recent_result oc_result obs_requests oc_requests
 		local recent_filter="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
 		obs_all_result=$(_get_model_usage_from_obs_db "")
-		obs_recent_result=$(_get_model_usage_from_obs_db "$recent_filter")
+		if [[ "$reference_provided" == "true" ]]; then
+			obs_recent_result="$supplied_recent"
+		else
+			obs_recent_result=$(_get_model_usage_from_obs_db "$recent_filter")
+		fi
 		oc_result=$(_get_model_usage_from_opencode)
 		obs_requests=$(_model_usage_request_count "$obs_all_result")
 		oc_requests=$(_model_usage_request_count "$oc_result")
@@ -440,13 +475,12 @@ _get_model_usage() {
 			echo "$oc_result"
 			return 0
 		fi
+		_get_model_usage_from_jsonl "all"
+		return 0
 	fi
 
-	# For 30d or fallback: use observability DB (has accurate cost data).
-	local date_filter=""
-	if [[ "$period" != "all" ]]; then
-		date_filter="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
-	fi
+	# For 30d: use observability DB (has accurate cost data).
+	local date_filter="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
 
 	local obs_result
 	obs_result=$(_get_model_usage_from_obs_db "$date_filter")
@@ -455,46 +489,25 @@ _get_model_usage() {
 		return 0
 	fi
 
-	# Legacy fallback: JSONL metrics file.
-	if [[ ! -f "$METRICS_FILE" ]]; then
-		echo "[]"
-		return 0
-	fi
+	_get_model_usage_from_jsonl "$period"
+	return 0
+}
 
-	if [[ "$period" == "all" ]]; then
-		jq -s '
-			group_by(.model)
-			| map({
-				model: .[0].model,
-				requests: length,
-				input_tokens: ([.[].input_tokens // 0] | add),
-				output_tokens: ([.[].output_tokens // 0] | add),
-				cache_read_tokens: ([.[].cache_read_tokens // 0] | add),
-				cache_write_tokens: ([.[].cache_write_tokens // 0] | add),
-				cost_total: ([.[].cost_total // 0] | add | . * 100 | round / 100)
-			})
-			| sort_by(-.cost_total)
-		' "$METRICS_FILE" 2>/dev/null || echo "[]"
+# --- Select both profile model populations without duplicate source scans ---
+# Output: {recent:[...], all:[...]}
+_get_profile_model_usage_bundle() {
+	local recent_filter="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
+	local obs_recent recent_result all_result
+	obs_recent=$(_get_model_usage_from_obs_db "$recent_filter")
+	if [[ -n "$obs_recent" ]]; then
+		recent_result="$obs_recent"
 	else
-		local cutoff
-		cutoff=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d 2>/dev/null || echo "1970-01-01")
-
-		jq -s --arg cutoff "$cutoff" '
-			[.[] | select(.recorded_at >= $cutoff)]
-			| group_by(.model)
-			| map({
-				model: .[0].model,
-				requests: length,
-				input_tokens: ([.[].input_tokens // 0] | add),
-				output_tokens: ([.[].output_tokens // 0] | add),
-				cache_read_tokens: ([.[].cache_read_tokens // 0] | add),
-				cache_write_tokens: ([.[].cache_write_tokens // 0] | add),
-				cost_total: ([.[].cost_total // 0] | add | . * 100 | round / 100)
-			})
-			| sort_by(-.cost_total)
-		' "$METRICS_FILE" 2>/dev/null || echo "[]"
+		recent_result=$(_get_model_usage_from_jsonl "30d")
 	fi
-
+	[[ -n "$recent_result" ]] || recent_result="[]"
+	all_result=$(_get_model_usage "all" "$obs_recent" "true")
+	[[ -n "$all_result" ]] || all_result="[]"
+	jq -cn --argjson recent "$recent_result" --argjson all "$all_result" '{recent:$recent,all:$all}'
 	return 0
 }
 
@@ -528,6 +541,27 @@ _token_totals_enrich() {
 _token_totals_total_all() {
 	local totals_json="$1"
 	echo "$totals_json" | jq -r '.total_all // 0' 2>/dev/null || printf '0\n'
+	return 0
+}
+
+# --- Derive token totals from an already-selected model usage population ---
+# This keeps table request/cost rows and footer token totals source-consistent.
+_token_totals_from_model_usage() {
+	local model_json="$1"
+	local raw_totals
+	raw_totals=$(printf '%s' "$model_json" | jq -c '
+		if type != "array" then
+			{total_input:0,total_output:0,total_cache_read:0,total_cache_write:0}
+		else
+			{
+				total_input: ([.[].input_tokens // 0] | add // 0),
+				total_output: ([.[].output_tokens // 0] | add // 0),
+				total_cache_read: ([.[].cache_read_tokens // 0] | add // 0),
+				total_cache_write: ([.[].cache_write_tokens // 0] | add // 0)
+			}
+		end
+	' 2>/dev/null || echo '{"total_input":0,"total_output":0,"total_cache_read":0,"total_cache_write":0}')
+	_token_totals_enrich "$raw_totals"
 	return 0
 }
 

--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -37,6 +37,15 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+PROFILE_EPOCH_DATE="1970-01-01"
+PROFILE_RATE_OPUS="15.0|75.0|1.50"
+PROFILE_RATE_SONNET="3.0|15.0|0.30"
+PROFILE_RATE_GPT="2.50|10.0|0.625"
+PROFILE_RATE_FREE="0.0|0.0|0.0"
+PROFILE_RECENT_MODEL_FILTER="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
+PROFILE_JSON_ARRAY_TYPE="array"
+PROFILE_EMPTY_TOKEN_TOTALS='{"total_all":0,"cache_hit_pct":0}'
+
 # =============================================================================
 # Format — Number / Hours / Cost / Token Utilities
 # =============================================================================
@@ -116,14 +125,14 @@ _model_cost_rates() {
 	local ms="${model#*/}"
 	ms="${ms%%-202*}"
 	case "$ms" in
-	*opus-4* | *claude-opus*) echo "15.0|75.0|1.50" ;;
-	*sonnet-4* | *claude-sonnet*) echo "3.0|15.0|0.30" ;;
+	*opus-4* | *claude-opus*) echo "$PROFILE_RATE_OPUS" ;;
+	*sonnet-4* | *claude-sonnet*) echo "$PROFILE_RATE_SONNET" ;;
 	*haiku-4* | *haiku-3* | *claude-haiku*) echo "0.80|4.0|0.08" ;;
-	*gpt-5.4*) echo "2.50|10.0|0.625" ;;
-	*gpt-5.3-codex*) echo "2.50|10.0|0.625" ;;
-	*gpt-5.2-codex* | *gpt-5.2*) echo "2.50|10.0|0.625" ;;
-	*gpt-5.1-codex*) echo "2.50|10.0|0.625" ;;
-	*gpt-5.1-chat*) echo "2.50|10.0|0.625" ;;
+	*gpt-5.4*) echo "$PROFILE_RATE_GPT" ;;
+	*gpt-5.3-codex*) echo "$PROFILE_RATE_GPT" ;;
+	*gpt-5.2-codex* | *gpt-5.2*) echo "$PROFILE_RATE_GPT" ;;
+	*gpt-5.1-codex*) echo "$PROFILE_RATE_GPT" ;;
+	*gpt-5.1-chat*) echo "$PROFILE_RATE_GPT" ;;
 	*gpt-4.1-mini*) echo "0.40|1.60|0.10" ;;
 	*gpt-4.1*) echo "2.0|8.0|0.50" ;;
 	*o3*) echo "10.0|40.0|2.50" ;;
@@ -132,9 +141,9 @@ _model_cost_rates() {
 	*gemini-2.5-flash* | *gemini-3-flash*) echo "0.15|0.60|0.0375" ;;
 	*deepseek-r1*) echo "0.55|2.19|0.14" ;;
 	*deepseek-v3*) echo "0.27|1.10|0.07" ;;
-	*grok*) echo "3.0|15.0|0.30" ;;
-	*kimi* | *minimax* | *big-pickle*) echo "0.0|0.0|0.0" ;;
-	*) echo "3.0|15.0|0.30" ;;
+	*grok*) echo "$PROFILE_RATE_SONNET" ;;
+	*kimi* | *minimax* | *big-pickle*) echo "$PROFILE_RATE_FREE" ;;
+	*) echo "$PROFILE_RATE_SONNET" ;;
 	esac
 	return 0
 }
@@ -159,7 +168,8 @@ _compute_model_row_savings() {
 	local cache="$4"
 
 	# Opus rates used as baseline for model routing savings
-	local opus_input_rate="15.0" opus_output_rate="75.0" opus_cache_rate="1.50"
+	local opus_input_rate opus_output_rate opus_cache_rate
+	IFS='|' read -r opus_input_rate opus_output_rate opus_cache_rate <<<"$PROFILE_RATE_OPUS"
 
 	local rates m_input_rate m_output_rate m_cache_rate
 	rates=$(_model_cost_rates "$model")
@@ -243,7 +253,7 @@ _compute_costs_from_tokens() {
 # --- Count model-usage requests in a JSON array ---
 _model_usage_request_count() {
 	local model_json="$1"
-	echo "$model_json" | jq -r 'if type == "array" then ([.[].requests // 0] | add // 0) else 0 end' 2>/dev/null || printf '0\n'
+	echo "$model_json" | jq -r --arg array_type "$PROFILE_JSON_ARRAY_TYPE" 'if type == $array_type then ([.[].requests // 0] | add // 0) else 0 end' 2>/dev/null || printf '0\n'
 	return 0
 }
 
@@ -251,8 +261,8 @@ _model_usage_request_count() {
 _model_usage_undercuts_reference() {
 	local candidate_json="$1"
 	local reference_json="$2"
-	jq -e -n --argjson candidate "${candidate_json:-[]}" --argjson reference "${reference_json:-[]}" '
-		def rows($a): if ($a | type) == "array" then $a else [] end;
+	jq -e -n --argjson candidate "${candidate_json:-[]}" --argjson reference "${reference_json:-[]}" --arg array_type "$PROFILE_JSON_ARRAY_TYPE" '
+		def rows($a): if ($a | type) == $array_type then $a else [] end;
 		(rows($candidate) | INDEX(.model)) as $candidate_by_model
 		| any(rows($reference)[];
 			.model as $model | ($candidate_by_model[$model] // {}) as $candidate_row
@@ -416,9 +426,9 @@ _get_model_usage_from_jsonl() {
 		echo "[]"
 		return 0
 	fi
-	local cutoff="1970-01-01"
+	local cutoff="$PROFILE_EPOCH_DATE"
 	if [[ "$period" != "all" ]]; then
-		cutoff=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d 2>/dev/null || echo "1970-01-01")
+		cutoff=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d 2>/dev/null || echo "$PROFILE_EPOCH_DATE")
 	fi
 	jq -s --arg cutoff "$cutoff" --arg period "$period" '
 		(if $period == "all" then . else [.[] | select(.recorded_at >= $cutoff)] end)
@@ -452,7 +462,7 @@ _get_model_usage() {
 	# where observability started later.
 	if [[ "$period" == "all" ]]; then
 		local obs_all_result obs_recent_result oc_result obs_requests oc_requests
-		local recent_filter="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
+		local recent_filter="$PROFILE_RECENT_MODEL_FILTER"
 		obs_all_result=$(_get_model_usage_from_obs_db "")
 		if [[ "$reference_provided" == "true" ]]; then
 			obs_recent_result="$supplied_recent"
@@ -480,7 +490,7 @@ _get_model_usage() {
 	fi
 
 	# For 30d: use observability DB (has accurate cost data).
-	local date_filter="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
+	local date_filter="$PROFILE_RECENT_MODEL_FILTER"
 
 	local obs_result
 	obs_result=$(_get_model_usage_from_obs_db "$date_filter")
@@ -496,7 +506,7 @@ _get_model_usage() {
 # --- Select both profile model populations without duplicate source scans ---
 # Output: {recent:[...], all:[...]}
 _get_profile_model_usage_bundle() {
-	local recent_filter="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
+	local recent_filter="$PROFILE_RECENT_MODEL_FILTER"
 	local obs_recent recent_result all_result
 	obs_recent=$(_get_model_usage_from_obs_db "$recent_filter")
 	if [[ -n "$obs_recent" && "$(_model_usage_request_count "$obs_recent")" -gt 0 ]]; then
@@ -530,9 +540,9 @@ _token_totals_enrich() {
 	jq_totals=$(_token_totals_jq_expr)
 
 	if [[ -n "$raw_json" ]]; then
-		echo "$raw_json" | jq -c "$jq_totals" 2>/dev/null || echo '{"total_all":0,"cache_hit_pct":0}'
+		echo "$raw_json" | jq -c "$jq_totals" 2>/dev/null || echo "$PROFILE_EMPTY_TOKEN_TOTALS"
 	else
-		echo '{"total_all":0,"cache_hit_pct":0}'
+		echo "$PROFILE_EMPTY_TOKEN_TOTALS"
 	fi
 	return 0
 }
@@ -549,8 +559,8 @@ _token_totals_total_all() {
 _token_totals_from_model_usage() {
 	local model_json="$1"
 	local raw_totals
-	raw_totals=$(printf '%s' "$model_json" | jq -c '
-		if type != "array" then
+	raw_totals=$(printf '%s' "$model_json" | jq -c --arg array_type "$PROFILE_JSON_ARRAY_TYPE" '
+		if type != $array_type then
 			{total_input:0,total_output:0,total_cache_read:0,total_cache_write:0}
 		else
 			{
@@ -675,7 +685,7 @@ _token_totals_from_jsonl() {
 		' "$METRICS_FILE" 2>/dev/null || { return 1; }
 	else
 		local cutoff
-		cutoff=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d 2>/dev/null || echo "1970-01-01")
+		cutoff=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d 2>/dev/null || echo "$PROFILE_EPOCH_DATE")
 
 		jq -s --arg cutoff "$cutoff" '
 			[.[] | select(.recorded_at >= $cutoff)]
@@ -707,15 +717,15 @@ _get_token_totals() {
 		local best_totals="" best_total=0 candidate_totals candidate_total source
 		for source in obs-db opencode-db jsonl; do
 			case "$source" in
-				obs-db)
-					raw_totals=$(_token_totals_from_obs_db "$period") || continue
-					;;
-				opencode-db)
-					raw_totals=$(_token_totals_from_opencode_db) || continue
-					;;
-				jsonl)
-					raw_totals=$(_token_totals_from_jsonl "$period") || continue
-					;;
+			obs-db)
+				raw_totals=$(_token_totals_from_obs_db "$period") || continue
+				;;
+			opencode-db)
+				raw_totals=$(_token_totals_from_opencode_db) || continue
+				;;
+			jsonl)
+				raw_totals=$(_token_totals_from_jsonl "$period") || continue
+				;;
 			esac
 			candidate_totals=$(_token_totals_enrich "$raw_totals")
 			candidate_total=$(_token_totals_total_all "$candidate_totals")
@@ -743,6 +753,6 @@ _get_token_totals() {
 	}
 
 	# No data source available
-	echo '{"total_all":0,"cache_hit_pct":0}'
+	echo "$PROFILE_EMPTY_TOKEN_TOTALS"
 	return 0
 }

--- a/.agents/scripts/profile-readme-data-lib.sh
+++ b/.agents/scripts/profile-readme-data-lib.sh
@@ -484,7 +484,7 @@ _get_model_usage() {
 
 	local obs_result
 	obs_result=$(_get_model_usage_from_obs_db "$date_filter")
-	if [[ -n "$obs_result" ]]; then
+	if [[ -n "$obs_result" && "$(_model_usage_request_count "$obs_result")" -gt 0 ]]; then
 		echo "$obs_result"
 		return 0
 	fi
@@ -499,7 +499,7 @@ _get_profile_model_usage_bundle() {
 	local recent_filter="AND timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
 	local obs_recent recent_result all_result
 	obs_recent=$(_get_model_usage_from_obs_db "$recent_filter")
-	if [[ -n "$obs_recent" ]]; then
+	if [[ -n "$obs_recent" && "$(_model_usage_request_count "$obs_recent")" -gt 0 ]]; then
 		recent_result="$obs_recent"
 	else
 		recent_result=$(_get_model_usage_from_jsonl "30d")

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -21,6 +21,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=portable-stat.sh
+source "${SCRIPT_DIR}/portable-stat.sh"
 METRICS_FILE="${HOME}/.aidevops/.agent-workspace/observability/metrics.jsonl"
 OBS_DB_FILE="${HOME}/.aidevops/.agent-workspace/observability/llm-requests.db"
 OPENCODE_DB_FILE="${HOME}/.local/share/opencode/opencode.db"
@@ -39,10 +41,7 @@ _profile_update_lock_dir() {
 _profile_lock_mtime() {
 	local lock_dir="$1"
 	local modified=""
-	modified=$(stat -c '%Y' "$lock_dir" 2>/dev/null || true)
-	if [[ ! "$modified" =~ ^[0-9]+$ ]]; then
-		modified=$(stat -f '%m' "$lock_dir" 2>/dev/null || true)
-	fi
+	modified=$(_file_mtime_epoch "$lock_dir" 2>/dev/null || true)
 	[[ "$modified" =~ ^[0-9]+$ ]] || modified=0
 	printf '%s\n' "$modified"
 	return 0

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -27,6 +27,8 @@ OPENCODE_DB_FILE="${HOME}/.local/share/opencode/opencode.db"
 OPENCODE_ARCHIVE_DB_FILE="${HOME}/.local/share/opencode/opencode-archive.db"
 CONTRIBUTIONS_START_MARKER='<!-- CONTRIBUTIONS-START -->'
 CONTRIBUTIONS_END_MARKER='<!-- CONTRIBUTIONS-END -->'
+PROFILE_UPDATE_LOCK_TOKEN=""
+PROFILE_UPDATE_LOCK_GRACE_SECONDS="${AIDEVOPS_PROFILE_LOCK_GRACE_SECONDS:-30}"
 
 # --- Serialize profile refreshes so scheduler overlap cannot duplicate scans/writes ---
 _profile_update_lock_dir() {
@@ -34,28 +36,96 @@ _profile_update_lock_dir() {
 	return 0
 }
 
-_acquire_profile_update_lock() {
-	local lock_dir
-	lock_dir=$(_profile_update_lock_dir)
-	mkdir -p "${lock_dir%/*}" || return 1
-	if ! mkdir "$lock_dir" 2>/dev/null; then
-		local lock_pid=""
-		[[ -f "${lock_dir}/pid" ]] && lock_pid=$(<"${lock_dir}/pid")
-		if [[ "$lock_pid" =~ ^[0-9]+$ ]] && kill -0 "$lock_pid" 2>/dev/null; then
-			echo "Profile README update already running; skipping overlapping refresh" >&2
-			return 1
-		fi
-		rm -rf "$lock_dir"
-		mkdir "$lock_dir" || return 1
+_profile_lock_mtime() {
+	local lock_dir="$1"
+	local modified=""
+	modified=$(stat -c '%Y' "$lock_dir" 2>/dev/null || true)
+	if [[ ! "$modified" =~ ^[0-9]+$ ]]; then
+		modified=$(stat -f '%m' "$lock_dir" 2>/dev/null || true)
 	fi
-	printf '%s\n' "$$" >"${lock_dir}/pid"
+	[[ "$modified" =~ ^[0-9]+$ ]] || modified=0
+	printf '%s\n' "$modified"
+	return 0
+}
+
+_profile_lock_owner() {
+	local lock_dir="$1"
+	local owner_line=""
+	if [[ -f "${lock_dir}/owner" ]]; then
+		IFS= read -r owner_line <"${lock_dir}/owner" || true
+		printf '%s\n' "$owner_line"
+	fi
+	return 0
+}
+
+_acquire_profile_update_lock() {
+	local lock_dir token now
+	lock_dir=$(_profile_update_lock_dir)
+	now=$(date +%s)
+	token="$$.${RANDOM}.${now}.${RANDOM}"
+	mkdir -p "${lock_dir%/*}" || return 1
+	if mkdir "$lock_dir" 2>/dev/null; then
+		local owner_tmp="${lock_dir}/owner.${token}"
+		printf '%s|%s|%s\n' "$token" "$$" "$now" >"$owner_tmp" || return 1
+		mv "$owner_tmp" "${lock_dir}/owner" || return 1
+		PROFILE_UPDATE_LOCK_TOKEN="$token"
+		return 0
+	fi
+
+	local owner_before owner_after lock_pid lock_created mtime_before mtime_after age
+	owner_before=$(_profile_lock_owner "$lock_dir")
+	mtime_before=$(_profile_lock_mtime "$lock_dir")
+	IFS='|' read -r _ lock_pid lock_created <<<"$owner_before"
+	age=$((now - mtime_before))
+	if [[ "$lock_pid" =~ ^[0-9]+$ ]] && kill -0 "$lock_pid" 2>/dev/null; then
+		echo "Profile README update already running; skipping overlapping refresh" >&2
+		return 1
+	fi
+	if [[ -z "$owner_before" || ! "$lock_created" =~ ^[0-9]+$ ]] && [[ "$age" -lt "$PROFILE_UPDATE_LOCK_GRACE_SECONDS" ]]; then
+		echo "Profile README lock is being initialized; skipping overlapping refresh" >&2
+		return 1
+	fi
+
+	# Revalidate immediately before the atomic rename. A changed owner/mtime means
+	# another process repaired or replaced the lock while this process inspected it.
+	owner_after=$(_profile_lock_owner "$lock_dir")
+	mtime_after=$(_profile_lock_mtime "$lock_dir")
+	if [[ "$owner_before" != "$owner_after" || "$mtime_before" != "$mtime_after" ]]; then
+		echo "Profile README lock changed during stale-owner validation" >&2
+		return 1
+	fi
+	local stale_dir="${lock_dir}.stale.${token}"
+	if ! mv "$lock_dir" "$stale_dir" 2>/dev/null; then
+		echo "Profile README lock was claimed by another process" >&2
+		return 1
+	fi
+	rm -rf "$stale_dir"
+	if ! mkdir "$lock_dir" 2>/dev/null; then
+		echo "Profile README update already running; skipping overlapping refresh" >&2
+		return 1
+	fi
+	local owner_tmp="${lock_dir}/owner.${token}"
+	printf '%s|%s|%s\n' "$token" "$$" "$now" >"$owner_tmp" || return 1
+	mv "$owner_tmp" "${lock_dir}/owner" || return 1
+	PROFILE_UPDATE_LOCK_TOKEN="$token"
 	return 0
 }
 
 _release_profile_update_lock() {
 	local lock_dir
 	lock_dir=$(_profile_update_lock_dir)
+	if [[ -z "$PROFILE_UPDATE_LOCK_TOKEN" ]]; then
+		return 0
+	fi
+	local owner token
+	owner=$(_profile_lock_owner "$lock_dir")
+	token="${owner%%|*}"
+	if [[ "$token" != "$PROFILE_UPDATE_LOCK_TOKEN" ]]; then
+		echo "Profile README lock owner changed; refusing non-owner release" >&2
+		return 1
+	fi
 	rm -rf "$lock_dir"
+	PROFILE_UPDATE_LOCK_TOKEN=""
 	return 0
 }
 

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -28,6 +28,37 @@ OPENCODE_ARCHIVE_DB_FILE="${HOME}/.local/share/opencode/opencode-archive.db"
 CONTRIBUTIONS_START_MARKER='<!-- CONTRIBUTIONS-START -->'
 CONTRIBUTIONS_END_MARKER='<!-- CONTRIBUTIONS-END -->'
 
+# --- Serialize profile refreshes so scheduler overlap cannot duplicate scans/writes ---
+_profile_update_lock_dir() {
+	printf '%s\n' "${HOME}/.aidevops/cache/profile-readme-update.lock"
+	return 0
+}
+
+_acquire_profile_update_lock() {
+	local lock_dir
+	lock_dir=$(_profile_update_lock_dir)
+	mkdir -p "${lock_dir%/*}" || return 1
+	if ! mkdir "$lock_dir" 2>/dev/null; then
+		local lock_pid=""
+		[[ -f "${lock_dir}/pid" ]] && lock_pid=$(<"${lock_dir}/pid")
+		if [[ "$lock_pid" =~ ^[0-9]+$ ]] && kill -0 "$lock_pid" 2>/dev/null; then
+			echo "Profile README update already running; skipping overlapping refresh" >&2
+			return 1
+		fi
+		rm -rf "$lock_dir"
+		mkdir "$lock_dir" || return 1
+	fi
+	printf '%s\n' "$$" >"${lock_dir}/pid"
+	return 0
+}
+
+_release_profile_update_lock() {
+	local lock_dir
+	lock_dir=$(_profile_update_lock_dir)
+	rm -rf "$lock_dir"
+	return 0
+}
+
 # --- Resolve profile repo path from repos.json ---
 _resolve_profile_repo() {
 	local repos_json="${HOME}/.config/aidevops/repos.json"
@@ -999,6 +1030,11 @@ cmd_update() {
 	local dry_run=false
 	if [[ "${1:-}" == "--dry-run" ]]; then
 		dry_run=true
+	fi
+	if [[ "${AIDEVOPS_PROFILE_UPDATE_LOCK_HELD:-0}" != "1" ]]; then
+		_acquire_profile_update_lock || return 1
+		export AIDEVOPS_PROFILE_UPDATE_LOCK_HELD=1
+		trap _release_profile_update_lock EXIT
 	fi
 	echo "Profile README update started at $(date -u +%Y-%m-%dT%H:%M:%SZ) (dry_run=${dry_run})"
 

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -34,6 +34,9 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+PROFILE_STATUS_UNAVAILABLE="unavailable"
+PROFILE_BOOLEAN_TRUE="true"
+
 # =============================================================================
 # Apps — App Name Mapping and Screen Time Section
 # =============================================================================
@@ -344,6 +347,77 @@ EOF
 
 # --- Generate the Work with AI markdown table ---
 # Usage: _generate_work_with_ai_table <screen_json> <day_json> <week_json> <month_json> <year_json>
+_generate_screen_time_vars() {
+	local screen_json="$1"
+	local values screen_today screen_week screen_month screen_year screen_status year_estimated screen_source
+	values=$(printf '%s' "$screen_json" | jq -r --arg unavailable "$PROFILE_STATUS_UNAVAILABLE" '
+		[
+			(if .today_hours == null then $unavailable else ((.today_hours * 10 | round / 10 | tostring) + "h") end),
+			(if .week_hours == null then $unavailable else ((.week_hours * 10 | round / 10 | tostring) + "h") end),
+			(if .month_hours == null then $unavailable else ((.month_hours * 10 | round / 10 | tostring) + "h") end),
+			(if .year_hours == null then $unavailable else ((.year_hours | round | tostring) + "h") end),
+			([.periods.day.status, .periods.week.status, .periods.month.status, .periods.year.status] | unique | join(", ")),
+			(.periods.year.estimated // false),
+			(.periods.month.source // $unavailable)
+		] | @tsv
+	' 2>/dev/null) || values=$'unavailable\tunavailable\tunavailable\tunavailable\tunavailable\tfalse\tunavailable'
+	IFS=$'\t' read -r screen_today screen_week screen_month screen_year screen_status year_estimated screen_source <<<"$values"
+	local year_prefix="" year_suffix=""
+	if [[ "$year_estimated" == "$PROFILE_BOOLEAN_TRUE" ]]; then
+		year_prefix="~"
+		year_suffix="*"
+	fi
+	printf 'screen_today=%q screen_week=%q screen_month=%q screen_year=%q screen_status=%q screen_source=%q year_prefix=%q year_suffix=%q\n' \
+		"$screen_today" "$screen_week" "$screen_month" "$screen_year" "$screen_status" "$screen_source" "$year_prefix" "$year_suffix"
+	return 0
+}
+
+_generate_work_count_vars() {
+	local day_interactive="$1" week_interactive="$2" month_interactive="$3" year_interactive="$4"
+	local day_workers="$5" week_workers="$6" month_workers="$7" year_workers="$8"
+	local month_total="$9"
+	shift 9
+	local year_total="$1"
+	printf 'f_day_int=%q f_week_int=%q f_month_int=%q f_year_int=%q f_day_wrk=%q f_week_wrk=%q f_month_wrk=%q f_year_wrk=%q f_month_total=%q f_year_total=%q\n' \
+		"$(_format_number "$day_interactive")" "$(_format_number "$week_interactive")" \
+		"$(_format_number "$month_interactive")" "$(_format_number "$year_interactive")" \
+		"$(_format_number "$day_workers")" "$(_format_number "$week_workers")" \
+		"$(_format_number "$month_workers")" "$(_format_number "$year_workers")" \
+		"$(_format_number "$month_total")" "$(_format_number "$year_total")"
+	return 0
+}
+
+_period_unavailable_assignments() {
+	local period_json="$1"
+	shift
+	if ! printf '%s' "$period_json" | jq -e --arg unavailable "$PROFILE_STATUS_UNAVAILABLE" '(.status // "ok") == $unavailable' >/dev/null 2>&1; then
+		return 0
+	fi
+	local variable_name
+	for variable_name in "$@"; do
+		printf '%s=%q ' "$variable_name" "$PROFILE_STATUS_UNAVAILABLE"
+	done
+	printf '\n'
+	return 0
+}
+
+_format_work_hour_cell() {
+	local value="$1"
+	if [[ "$value" == "$PROFILE_STATUS_UNAVAILABLE" ]]; then
+		printf '%s' "$value"
+	else
+		printf '%sh' "$value"
+	fi
+	return 0
+}
+
+_profile_period_json() {
+	local periods_json="$1"
+	local period_key="$2"
+	printf '%s' "$periods_json" | jq -c --arg key "$period_key" --arg unavailable "$PROFILE_STATUS_UNAVAILABLE" '.[$key] // {status:$unavailable}'
+	return 0
+}
+
 _generate_work_with_ai_table() {
 	local screen_json="$1"
 	local day_json="$2"
@@ -351,21 +425,8 @@ _generate_work_with_ai_table() {
 	local month_json="$4"
 	local year_json="$5"
 
-	# Extract screen time values
-	local screen_today screen_week screen_month screen_year
-	screen_today=$(echo "$screen_json" | jq -r 'if .today_hours == null then "unavailable" else ((.today_hours * 10 | round / 10 | tostring) + "h") end')
-	screen_week=$(echo "$screen_json" | jq -r 'if .week_hours == null then "unavailable" else ((.week_hours * 10 | round / 10 | tostring) + "h") end')
-	screen_month=$(echo "$screen_json" | jq -r 'if .month_hours == null then "unavailable" else ((.month_hours * 10 | round / 10 | tostring) + "h") end')
-	screen_year=$(echo "$screen_json" | jq -r 'if .year_hours == null then "unavailable" else ((.year_hours | round | tostring) + "h") end')
-
-	# Check if year is extrapolated (history file has < 365 days)
-	local year_prefix="" year_suffix=""
-	if [[ "$(echo "$screen_json" | jq -r '.periods.year.estimated // false')" == "true" ]]; then
-		year_prefix="~"
-		year_suffix="*"
-	fi
-	local screen_status
-	screen_status=$(echo "$screen_json" | jq -r '[.periods.day.status, .periods.week.status, .periods.month.status, .periods.year.status] | unique | join(", ")' 2>/dev/null || echo "unavailable")
+	local screen_today screen_week screen_month screen_year screen_status screen_source year_prefix year_suffix
+	eval "$(_generate_screen_time_vars "$screen_json")"
 
 	# Extract and format session time variables for all periods
 	local day_human day_interactive_machine day_worker_human day_worker day_total day_interactive day_workers
@@ -374,80 +435,33 @@ _generate_work_with_ai_table() {
 	local year_human year_interactive_machine year_worker_human year_worker year_total year_interactive year_workers
 	eval "$(_generate_session_time_vars "$day_json" "$week_json" "$month_json" "$year_json")"
 
-	# Format screen time and session counts with commas
 	local f_day_int f_week_int f_month_int f_year_int
-	f_day_int=$(_format_number "$day_interactive")
-	f_week_int=$(_format_number "$week_interactive")
-	f_month_int=$(_format_number "$month_interactive")
-	f_year_int=$(_format_number "$year_interactive")
-
 	local f_day_wrk f_week_wrk f_month_wrk f_year_wrk
-	f_day_wrk=$(_format_number "$day_workers")
-	f_week_wrk=$(_format_number "$week_workers")
-	f_month_wrk=$(_format_number "$month_workers")
-	f_year_wrk=$(_format_number "$year_workers")
-
 	local f_month_total f_year_total
-	f_month_total=$(_format_number "$month_total")
-	f_year_total=$(_format_number "$year_total")
+	eval "$(_generate_work_count_vars "$day_interactive" "$week_interactive" "$month_interactive" "$year_interactive" \
+		"$day_workers" "$week_workers" "$month_workers" "$year_workers" "$month_total" "$year_total")"
 
 	# A failed collector is not a valid zero. Preserve legitimate zero values only
 	# when the corresponding period explicitly reports status=ok.
-	if [[ "$(echo "$day_json" | jq -r '.status // "ok"')" == "unavailable" ]]; then
-		day_human="unavailable"
-		day_interactive_machine="unavailable"
-		day_worker_human="unavailable"
-		day_worker="unavailable"
-		day_total="unavailable"
-		f_day_int="unavailable"
-		f_day_wrk="unavailable"
-	fi
-	if [[ "$(echo "$week_json" | jq -r '.status // "ok"')" == "unavailable" ]]; then
-		week_human="unavailable"
-		week_interactive_machine="unavailable"
-		week_worker_human="unavailable"
-		week_worker="unavailable"
-		week_total="unavailable"
-		f_week_int="unavailable"
-		f_week_wrk="unavailable"
-	fi
-	if [[ "$(echo "$month_json" | jq -r '.status // "ok"')" == "unavailable" ]]; then
-		month_human="unavailable"
-		month_interactive_machine="unavailable"
-		month_worker_human="unavailable"
-		month_worker="unavailable"
-		f_month_total="unavailable"
-		f_month_int="unavailable"
-		f_month_wrk="unavailable"
-	fi
-	if [[ "$(echo "$year_json" | jq -r '.status // "ok"')" == "unavailable" ]]; then
-		year_human="unavailable"
-		year_interactive_machine="unavailable"
-		year_worker_human="unavailable"
-		year_worker="unavailable"
-		f_year_total="unavailable"
-		f_year_int="unavailable"
-		f_year_wrk="unavailable"
-	fi
+	eval "$(_period_unavailable_assignments "$day_json" day_human day_interactive_machine day_worker_human day_worker day_total f_day_int f_day_wrk)"
+	eval "$(_period_unavailable_assignments "$week_json" week_human week_interactive_machine week_worker_human week_worker week_total f_week_int f_week_wrk)"
+	eval "$(_period_unavailable_assignments "$month_json" month_human month_interactive_machine month_worker_human month_worker f_month_total f_month_int f_month_wrk)"
+	eval "$(_period_unavailable_assignments "$year_json" year_human year_interactive_machine year_worker_human year_worker f_year_total f_year_int f_year_wrk)"
 
 	# Determine platform label for screen time row
-	local os_type screen_label screen_source
+	local os_type screen_label
 	os_type="$(uname -s)"
 	case "$os_type" in
 	Darwin)
 		screen_label="Screen time (Mac)"
-		screen_source="macOS display events"
 		;;
 	Linux)
 		screen_label="Screen time (Linux)"
-		screen_source="systemd-logind session events"
 		;;
 	*)
 		screen_label="Screen time"
-		screen_source="system events"
 		;;
 	esac
-	screen_source=$(echo "$screen_json" | jq -r '.periods.month.source // "unavailable"')
 
 	local session_coverage_note=""
 	local session_observed_days
@@ -463,11 +477,11 @@ _generate_work_with_ai_table() {
 | Metric | 24h | 7 Days | 28 Days | 365 Days |
 | --- | ---: | ---: | ---: | ---: |
 | ${screen_label} | ${screen_today} | ${screen_week} | ${screen_month} | ${year_prefix}${screen_year}${year_suffix} |
-| Interactive human attention | ${day_human}$([[ "$day_human" != "unavailable" ]] && echo h) | ${week_human}$([[ "$week_human" != "unavailable" ]] && echo h) | ${month_human}$([[ "$month_human" != "unavailable" ]] && echo h) | ${year_human}$([[ "$year_human" != "unavailable" ]] && echo h) |
-| Interactive AI generation | ${day_interactive_machine}$([[ "$day_interactive_machine" != "unavailable" ]] && echo h) | ${week_interactive_machine}$([[ "$week_interactive_machine" != "unavailable" ]] && echo h) | ${month_interactive_machine}$([[ "$month_interactive_machine" != "unavailable" ]] && echo h) | ${year_interactive_machine}$([[ "$year_interactive_machine" != "unavailable" ]] && echo h) |
-| Worker-classified human attention | ${day_worker_human}$([[ "$day_worker_human" != "unavailable" ]] && echo h) | ${week_worker_human}$([[ "$week_worker_human" != "unavailable" ]] && echo h) | ${month_worker_human}$([[ "$month_worker_human" != "unavailable" ]] && echo h) | ${year_worker_human}$([[ "$year_worker_human" != "unavailable" ]] && echo h) |
-| Worker/headless AI generation | ${day_worker}$([[ "$day_worker" != "unavailable" ]] && echo h) | ${week_worker}$([[ "$week_worker" != "unavailable" ]] && echo h) | ${month_worker}$([[ "$month_worker" != "unavailable" ]] && echo h) | ${year_worker}$([[ "$year_worker" != "unavailable" ]] && echo h) |
-| Additive observed work | ${day_total}$([[ "$day_total" != "unavailable" ]] && echo h) | ${week_total}$([[ "$week_total" != "unavailable" ]] && echo h) | ${f_month_total}$([[ "$f_month_total" != "unavailable" ]] && echo h) | ${f_year_total}$([[ "$f_year_total" != "unavailable" ]] && echo h) |
+| Interactive human attention | $(_format_work_hour_cell "$day_human") | $(_format_work_hour_cell "$week_human") | $(_format_work_hour_cell "$month_human") | $(_format_work_hour_cell "$year_human") |
+| Interactive AI generation | $(_format_work_hour_cell "$day_interactive_machine") | $(_format_work_hour_cell "$week_interactive_machine") | $(_format_work_hour_cell "$month_interactive_machine") | $(_format_work_hour_cell "$year_interactive_machine") |
+| Worker-classified human attention | $(_format_work_hour_cell "$day_worker_human") | $(_format_work_hour_cell "$week_worker_human") | $(_format_work_hour_cell "$month_worker_human") | $(_format_work_hour_cell "$year_worker_human") |
+| Worker/headless AI generation | $(_format_work_hour_cell "$day_worker") | $(_format_work_hour_cell "$week_worker") | $(_format_work_hour_cell "$month_worker") | $(_format_work_hour_cell "$year_worker") |
+| Additive observed work | $(_format_work_hour_cell "$day_total") | $(_format_work_hour_cell "$week_total") | $(_format_work_hour_cell "$f_month_total") | $(_format_work_hour_cell "$f_year_total") |
 | Interactive sessions | ${f_day_int} | ${f_week_int} | ${f_month_int} | ${f_year_int} |
 | Worker sessions | ${f_day_wrk} | ${f_week_wrk} | ${f_month_wrk} | ${f_year_wrk} |
 
@@ -486,10 +500,10 @@ cmd_generate() {
 
 	local session_periods day_json week_json month_json year_json
 	session_periods=$(_get_profile_session_times)
-	day_json=$(echo "$session_periods" | jq -c '.day // {status:"unavailable"}')
-	week_json=$(echo "$session_periods" | jq -c '.week // {status:"unavailable"}')
-	month_json=$(echo "$session_periods" | jq -c '."28d" // {status:"unavailable"}')
-	year_json=$(echo "$session_periods" | jq -c '.year // {status:"unavailable"}')
+	day_json=$(_profile_period_json "$session_periods" "day")
+	week_json=$(_profile_period_json "$session_periods" "week")
+	month_json=$(_profile_period_json "$session_periods" "28d")
+	year_json=$(_profile_period_json "$session_periods" "year")
 
 	local model_usage_bundle model_json_30d model_json_all
 	model_usage_bundle=$(_get_profile_model_usage_bundle)
@@ -507,13 +521,13 @@ cmd_generate() {
 	has_model_usage=$(echo "$model_json_all" | jq -r '((if type == "array" then length else 0 end) // 0) > 0')
 	has_screen_time=$(echo "$screen_json" | jq -r '(.month_hours // 0) > 0')
 
-	if [[ "$has_session_time" == "true" ]] ||
-		[[ "$has_model_usage" == "true" ]] ||
-		[[ "$has_screen_time" == "true" ]]; then
-		has_data=true
+	if [[ "$has_session_time" == "$PROFILE_BOOLEAN_TRUE" ]] ||
+		[[ "$has_model_usage" == "$PROFILE_BOOLEAN_TRUE" ]] ||
+		[[ "$has_screen_time" == "$PROFILE_BOOLEAN_TRUE" ]]; then
+		has_data="$PROFILE_BOOLEAN_TRUE"
 	fi
 
-	if [[ "$has_data" == "false" ]]; then
+	if [[ "$has_data" != "$PROFILE_BOOLEAN_TRUE" ]]; then
 		cat <<'EOF'
 ## Work with AI
 

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -116,21 +116,15 @@ _get_top_apps() {
 	local app_data
 	app_data=$(python3 "${SCRIPT_DIR}/screen-time-interval-engine.py" apps \
 		--os-type Darwin --db "$knowledge_db" 2>/dev/null) || app_data="[]"
-	local json_arr="[]"
-	while IFS= read -r row; do
-		local bundle today_pct week_pct month_pct
-		bundle=$(echo "$row" | jq -r '.bundle')
-		today_pct=$(echo "$row" | jq -r '.today_pct')
-		week_pct=$(echo "$row" | jq -r '.week_pct')
-		month_pct=$(echo "$row" | jq -r '.month_pct')
-		local name
+	local app_rows=""
+	local bundle today_pct week_pct month_pct name
+	while IFS=$'\t' read -r bundle today_pct week_pct month_pct; do
+		[[ -n "$bundle" ]] || continue
 		name=$(_friendly_app_name "$bundle")
-		json_arr=$(echo "$json_arr" | jq --arg app "$name" \
-			--argjson tp "$today_pct" --argjson wp "$week_pct" --argjson mp "$month_pct" \
-			'. + [{app: $app, today_pct: $tp, week_pct: $wp, month_pct: $mp}]')
-	done < <(echo "$app_data" | jq -c '.[]')
+		app_rows="${app_rows}${name}	${today_pct:-0}	${week_pct:-0}	${month_pct:-0}"$'\n'
+	done < <(printf '%s' "$app_data" | jq -r '.[] | [.bundle, .today_pct, .week_pct, .month_pct] | @tsv')
 
-	echo "$json_arr"
+	printf '%s' "$app_rows" | jq -Rn '[inputs | split("\t") | {app: .[0], today_pct: (.[1] | tonumber), week_pct: (.[2] | tonumber), month_pct: (.[3] | tonumber)}]'
 	return 0
 }
 
@@ -310,28 +304,15 @@ _generate_top_apps_section() {
 	local top_apps_json
 	top_apps_json=$(_get_top_apps)
 
-	local app_count
-	app_count=$(echo "$top_apps_json" | jq 'length')
-	if [[ "$app_count" -eq 0 ]]; then
+	if ! printf '%s' "$top_apps_json" | jq -e 'length > 0' >/dev/null 2>&1; then
 		return 0
 	fi
 
-	local app_rows=""
-	while IFS= read -r row; do
-		local app today_pct week_pct month_pct
-		app=$(echo "$row" | jq -r '.app')
-		today_pct=$(echo "$row" | jq -r '.today_pct')
-		week_pct=$(echo "$row" | jq -r '.week_pct')
-		month_pct=$(echo "$row" | jq -r '.month_pct')
-
-		local today_str week_str month_str
-		if [[ "$today_pct" -eq 0 ]]; then today_str="--"; else today_str="${today_pct}%"; fi
-		if [[ "$week_pct" -eq 0 ]]; then week_str="--"; else week_str="${week_pct}%"; fi
-		if [[ "$month_pct" -eq 0 ]]; then month_str="--"; else month_str="${month_pct}%"; fi
-
-		app_rows="${app_rows}| ${app} | ${today_str} | ${week_str} | ${month_str} |
-"
-	done < <(echo "$top_apps_json" | jq -c '.[]')
+	local app_rows
+	app_rows=$(printf '%s' "$top_apps_json" | jq -r '
+		def pct: if . == 0 then "--" else (tostring + "%") end;
+		.[] | "| \(.app) | \(.today_pct | pct) | \(.week_pct | pct) | \(.month_pct | pct) |"
+	')
 
 	cat <<EOF
 
@@ -350,17 +331,23 @@ EOF
 _generate_screen_time_vars() {
 	local screen_json="$1"
 	local values screen_today screen_week screen_month screen_year screen_status year_estimated screen_source
-	values=$(printf '%s' "$screen_json" | jq -r --arg unavailable "$PROFILE_STATUS_UNAVAILABLE" '
+	if ! values=$(printf '%s' "$screen_json" | jq -er --arg unavailable "$PROFILE_STATUS_UNAVAILABLE" '
+		if type != "object" then error("screen payload must be an object") else . end |
 		[
 			(if .today_hours == null then $unavailable else ((.today_hours * 10 | round / 10 | tostring) + "h") end),
 			(if .week_hours == null then $unavailable else ((.week_hours * 10 | round / 10 | tostring) + "h") end),
 			(if .month_hours == null then $unavailable else ((.month_hours * 10 | round / 10 | tostring) + "h") end),
 			(if .year_hours == null then $unavailable else ((.year_hours | round | tostring) + "h") end),
-			([.periods.day.status, .periods.week.status, .periods.month.status, .periods.year.status] | unique | join(", ")),
-			(.periods.year.estimated // false),
-			(.periods.month.source // $unavailable)
+			([.periods?.day?.status // $unavailable, .periods?.week?.status // $unavailable, .periods?.month?.status // $unavailable, .periods?.year?.status // $unavailable] | unique | join(", ")),
+			(.periods?.year?.estimated // false),
+			(.periods?.month?.source // $unavailable)
 		] | @tsv
-	' 2>/dev/null) || values=$'unavailable\tunavailable\tunavailable\tunavailable\tunavailable\tfalse\tunavailable'
+	'); then
+		echo "Warning: screen-time payload is invalid; rendering unavailable values" >&2
+		printf -v values '%s\t%s\t%s\t%s\t%s\tfalse\t%s' \
+			"$PROFILE_STATUS_UNAVAILABLE" "$PROFILE_STATUS_UNAVAILABLE" "$PROFILE_STATUS_UNAVAILABLE" \
+			"$PROFILE_STATUS_UNAVAILABLE" "$PROFILE_STATUS_UNAVAILABLE" "$PROFILE_STATUS_UNAVAILABLE"
+	fi
 	IFS=$'\t' read -r screen_today screen_week screen_month screen_year screen_status year_estimated screen_source <<<"$values"
 	local year_prefix="" year_suffix=""
 	if [[ "$year_estimated" == "$PROFILE_BOOLEAN_TRUE" ]]; then

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -103,88 +103,29 @@ _friendly_app_name() {
 # --- Get top apps by screen time percentage (macOS only) ---
 # Returns JSON array: [{"app":"Name","today_pct":N,"week_pct":N,"month_pct":N}, ...]
 _get_top_apps() {
-	local knowledge_db="${HOME}/Library/Application Support/Knowledge/knowledgeC.db"
+	local knowledge_db="${AIDEVOPS_KNOWLEDGE_DB:-${HOME}/Library/Application Support/Knowledge/knowledgeC.db}"
 
 	if [[ "$(uname -s)" != "Darwin" ]] || [[ ! -f "$knowledge_db" ]]; then
 		echo "[]"
 		return 0
 	fi
 
-	# Query per-app seconds for each period, output as TSV: bundle\ttoday\tweek\tmonth
 	local app_data
-	app_data=$(sqlite3 "$knowledge_db" "
-		SELECT
-			ZVALUESTRING,
-			COALESCE(SUM(CASE WHEN ZSTARTDATE > (strftime('%s', 'now') - 978307200
-				- (CAST(strftime('%H', 'now', 'localtime') AS INTEGER) * 3600
-				+ CAST(strftime('%M', 'now', 'localtime') AS INTEGER) * 60
-				+ CAST(strftime('%S', 'now', 'localtime') AS INTEGER)))
-				THEN ZENDDATE - ZSTARTDATE ELSE 0 END), 0) as today_secs,
-			COALESCE(SUM(CASE WHEN ZSTARTDATE > (strftime('%s', 'now') - 978307200 - 86400*7)
-				THEN ZENDDATE - ZSTARTDATE ELSE 0 END), 0) as week_secs,
-			COALESCE(SUM(ZENDDATE - ZSTARTDATE), 0) as month_secs
-		FROM ZOBJECT
-		WHERE ZSTREAMNAME = '/app/usage'
-			AND ZSTARTDATE > (strftime('%s', 'now') - 978307200 - 86400*28)
-		GROUP BY ZVALUESTRING
-		HAVING month_secs > 0;
-	" 2>/dev/null) || {
-		echo "[]"
-		return 0
-	}
-
-	if [[ -z "$app_data" ]]; then
-		echo "[]"
-		return 0
-	fi
-
-	# Validate and sum totals for each period (reject non-integer values)
-	local total_today=0 total_week=0 total_month=0
-	while IFS='|' read -r _bundle today_s week_s month_s; do
-		# Skip rows with non-integer values (prevents arithmetic injection)
-		[[ "$today_s" =~ ^[0-9]+$ ]] || continue
-		[[ "$week_s" =~ ^[0-9]+$ ]] || continue
-		[[ "$month_s" =~ ^[0-9]+$ ]] || continue
-		total_today=$((total_today + today_s))
-		total_week=$((total_week + week_s))
-		total_month=$((total_month + month_s))
-	done <<<"$app_data"
-
-	# Build JSON array sorted by month_secs descending, top 10
-	# Uses jq for safe JSON construction (prevents injection from special chars)
+	app_data=$(python3 "${SCRIPT_DIR}/screen-time-interval-engine.py" apps \
+		--os-type Darwin --db "$knowledge_db" 2>/dev/null) || app_data="[]"
 	local json_arr="[]"
-	local count=0
-	while IFS='|' read -r bundle today_s week_s month_s; do
-		if [[ $count -ge 10 ]]; then
-			break
-		fi
-
-		# Validate numeric fields
-		[[ "$today_s" =~ ^[0-9]+$ ]] || continue
-		[[ "$week_s" =~ ^[0-9]+$ ]] || continue
-		[[ "$month_s" =~ ^[0-9]+$ ]] || continue
-
+	while IFS= read -r row; do
+		local bundle today_pct week_pct month_pct
+		bundle=$(echo "$row" | jq -r '.bundle')
+		today_pct=$(echo "$row" | jq -r '.today_pct')
+		week_pct=$(echo "$row" | jq -r '.week_pct')
+		month_pct=$(echo "$row" | jq -r '.month_pct')
 		local name
 		name=$(_friendly_app_name "$bundle")
-
-		# Calculate percentages (integer, rounded)
-		local today_pct=0 week_pct=0 month_pct=0
-		if [[ $total_today -gt 0 ]]; then
-			today_pct=$(((today_s * 100 + total_today / 2) / total_today))
-		fi
-		if [[ $total_week -gt 0 ]]; then
-			week_pct=$(((week_s * 100 + total_week / 2) / total_week))
-		fi
-		if [[ $total_month -gt 0 ]]; then
-			month_pct=$(((month_s * 100 + total_month / 2) / total_month))
-		fi
-
-		# Use jq for safe JSON construction (handles special chars in app names)
 		json_arr=$(echo "$json_arr" | jq --arg app "$name" \
 			--argjson tp "$today_pct" --argjson wp "$week_pct" --argjson mp "$month_pct" \
 			'. + [{app: $app, today_pct: $tp, week_pct: $wp, month_pct: $mp}]')
-		count=$((count + 1))
-	done < <(echo "$app_data" | sort -t'|' -k4 -rn)
+	done < <(echo "$app_data" | jq -c '.[]')
 
 	echo "$json_arr"
 	return 0
@@ -309,9 +250,11 @@ _generate_session_time_vars() {
 	local month_json="$3"
 	local year_json="$4"
 
-	local day_human day_worker day_total day_interactive day_workers
+	local day_human day_interactive_machine day_worker_human day_worker day_total day_interactive day_workers
 	day_human=$(_format_hours "$(echo "$day_json" | jq -r '(.interactive_human_hours // 0)')")
-	day_worker=$(_format_hours "$(echo "$day_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
+	day_interactive_machine=$(_format_hours "$(echo "$day_json" | jq -r '(.interactive_machine_hours // 0)')")
+	day_worker_human=$(_format_hours "$(echo "$day_json" | jq -r '(.worker_human_hours // 0)')")
+	day_worker=$(_format_hours "$(echo "$day_json" | jq -r '(.worker_machine_hours // 0)')")
 	day_total=$(_format_hours "$(echo "$day_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	# Keep counts raw here; _generate_work_with_ai_table formats them once.
 	# Pre-formatting creates comma strings that _format_number later rejects as
@@ -319,36 +262,42 @@ _generate_session_time_vars() {
 	day_interactive=$(echo "$day_json" | jq -r '(.interactive_sessions // 0)')
 	day_workers=$(echo "$day_json" | jq -r '(.worker_sessions // 0)')
 
-	local week_human week_worker week_total week_interactive week_workers
+	local week_human week_interactive_machine week_worker_human week_worker week_total week_interactive week_workers
 	week_human=$(_format_hours "$(echo "$week_json" | jq -r '(.interactive_human_hours // 0)')")
-	week_worker=$(_format_hours "$(echo "$week_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
+	week_interactive_machine=$(_format_hours "$(echo "$week_json" | jq -r '(.interactive_machine_hours // 0)')")
+	week_worker_human=$(_format_hours "$(echo "$week_json" | jq -r '(.worker_human_hours // 0)')")
+	week_worker=$(_format_hours "$(echo "$week_json" | jq -r '(.worker_machine_hours // 0)')")
 	week_total=$(_format_hours "$(echo "$week_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	week_interactive=$(echo "$week_json" | jq -r '(.interactive_sessions // 0)')
 	week_workers=$(echo "$week_json" | jq -r '(.worker_sessions // 0)')
 
-	local month_human month_worker month_total month_interactive month_workers
+	local month_human month_interactive_machine month_worker_human month_worker month_total month_interactive month_workers
 	month_human=$(_format_hours "$(echo "$month_json" | jq -r '(.interactive_human_hours // 0)')")
-	month_worker=$(_format_hours "$(echo "$month_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
+	month_interactive_machine=$(_format_hours "$(echo "$month_json" | jq -r '(.interactive_machine_hours // 0)')")
+	month_worker_human=$(_format_hours "$(echo "$month_json" | jq -r '(.worker_human_hours // 0)')")
+	month_worker=$(_format_hours "$(echo "$month_json" | jq -r '(.worker_machine_hours // 0)')")
 	month_total=$(_format_hours "$(echo "$month_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	month_interactive=$(echo "$month_json" | jq -r '(.interactive_sessions // 0)')
 	month_workers=$(echo "$month_json" | jq -r '(.worker_sessions // 0)')
 
-	local year_human year_worker year_total year_interactive year_workers
+	local year_human year_interactive_machine year_worker_human year_worker year_total year_interactive year_workers
 	year_human=$(_format_hours "$(echo "$year_json" | jq -r '(.interactive_human_hours // 0)')")
-	year_worker=$(_format_hours "$(echo "$year_json" | jq -r '(.worker_human_hours // 0) + (.worker_machine_hours // 0)')")
+	year_interactive_machine=$(_format_hours "$(echo "$year_json" | jq -r '(.interactive_machine_hours // 0)')")
+	year_worker_human=$(_format_hours "$(echo "$year_json" | jq -r '(.worker_human_hours // 0)')")
+	year_worker=$(_format_hours "$(echo "$year_json" | jq -r '(.worker_machine_hours // 0)')")
 	year_total=$(_format_hours "$(echo "$year_json" | jq -r '(.total_human_hours // 0) + (.total_machine_hours // 0)')")
 	year_interactive=$(echo "$year_json" | jq -r '(.interactive_sessions // 0)')
 	year_workers=$(echo "$year_json" | jq -r '(.worker_sessions // 0)')
 
 	# Emit as shell variable assignments for eval
-	printf 'day_human=%q day_worker=%q day_total=%q day_interactive=%q day_workers=%q\n' \
-		"$day_human" "$day_worker" "$day_total" "$day_interactive" "$day_workers"
-	printf 'week_human=%q week_worker=%q week_total=%q week_interactive=%q week_workers=%q\n' \
-		"$week_human" "$week_worker" "$week_total" "$week_interactive" "$week_workers"
-	printf 'month_human=%q month_worker=%q month_total=%q month_interactive=%q month_workers=%q\n' \
-		"$month_human" "$month_worker" "$month_total" "$month_interactive" "$month_workers"
-	printf 'year_human=%q year_worker=%q year_total=%q year_interactive=%q year_workers=%q\n' \
-		"$year_human" "$year_worker" "$year_total" "$year_interactive" "$year_workers"
+	printf 'day_human=%q day_interactive_machine=%q day_worker_human=%q day_worker=%q day_total=%q day_interactive=%q day_workers=%q\n' \
+		"$day_human" "$day_interactive_machine" "$day_worker_human" "$day_worker" "$day_total" "$day_interactive" "$day_workers"
+	printf 'week_human=%q week_interactive_machine=%q week_worker_human=%q week_worker=%q week_total=%q week_interactive=%q week_workers=%q\n' \
+		"$week_human" "$week_interactive_machine" "$week_worker_human" "$week_worker" "$week_total" "$week_interactive" "$week_workers"
+	printf 'month_human=%q month_interactive_machine=%q month_worker_human=%q month_worker=%q month_total=%q month_interactive=%q month_workers=%q\n' \
+		"$month_human" "$month_interactive_machine" "$month_worker_human" "$month_worker" "$month_total" "$month_interactive" "$month_workers"
+	printf 'year_human=%q year_interactive_machine=%q year_worker_human=%q year_worker=%q year_total=%q year_interactive=%q year_workers=%q\n' \
+		"$year_human" "$year_interactive_machine" "$year_worker_human" "$year_worker" "$year_total" "$year_interactive" "$year_workers"
 	return 0
 }
 
@@ -404,38 +353,28 @@ _generate_work_with_ai_table() {
 
 	# Extract screen time values
 	local screen_today screen_week screen_month screen_year
-	screen_today=$(echo "$screen_json" | jq -r '.today_hours | . * 10 | round / 10')
-	screen_week=$(echo "$screen_json" | jq -r '.week_hours | . * 10 | round / 10')
-	screen_month=$(echo "$screen_json" | jq -r '.month_hours | . * 10 | round / 10')
-	screen_year=$(echo "$screen_json" | jq -r '.year_hours | round')
+	screen_today=$(echo "$screen_json" | jq -r 'if .today_hours == null then "unavailable" else ((.today_hours * 10 | round / 10 | tostring) + "h") end')
+	screen_week=$(echo "$screen_json" | jq -r 'if .week_hours == null then "unavailable" else ((.week_hours * 10 | round / 10 | tostring) + "h") end')
+	screen_month=$(echo "$screen_json" | jq -r 'if .month_hours == null then "unavailable" else ((.month_hours * 10 | round / 10 | tostring) + "h") end')
+	screen_year=$(echo "$screen_json" | jq -r 'if .year_hours == null then "unavailable" else ((.year_hours | round | tostring) + "h") end')
 
 	# Check if year is extrapolated (history file has < 365 days)
-	local history_file="${HOME}/.aidevops/.agent-workspace/observability/screen-time.jsonl"
 	local year_prefix="" year_suffix=""
-	if [[ -f "$history_file" ]]; then
-		local history_days
-		history_days=$(wc -l <"$history_file" | tr -d ' ')
-		if [[ "$history_days" -lt 365 ]]; then
-			year_prefix="~"
-			year_suffix="*"
-		fi
-	else
+	if [[ "$(echo "$screen_json" | jq -r '.periods.year.estimated // false')" == "true" ]]; then
 		year_prefix="~"
 		year_suffix="*"
 	fi
+	local screen_status
+	screen_status=$(echo "$screen_json" | jq -r '[.periods.day.status, .periods.week.status, .periods.month.status, .periods.year.status] | unique | join(", ")' 2>/dev/null || echo "unavailable")
 
 	# Extract and format session time variables for all periods
-	local day_human day_worker day_total day_interactive day_workers
-	local week_human week_worker week_total week_interactive week_workers
-	local month_human month_worker month_total month_interactive month_workers
-	local year_human year_worker year_total year_interactive year_workers
+	local day_human day_interactive_machine day_worker_human day_worker day_total day_interactive day_workers
+	local week_human week_interactive_machine week_worker_human week_worker week_total week_interactive week_workers
+	local month_human month_interactive_machine month_worker_human month_worker month_total month_interactive month_workers
+	local year_human year_interactive_machine year_worker_human year_worker year_total year_interactive year_workers
 	eval "$(_generate_session_time_vars "$day_json" "$week_json" "$month_json" "$year_json")"
 
 	# Format screen time and session counts with commas
-	local f_screen_month f_screen_year
-	f_screen_month=$(_format_number "$screen_month")
-	f_screen_year=$(_format_number "$screen_year")
-
 	local f_day_int f_week_int f_month_int f_year_int
 	f_day_int=$(_format_number "$day_interactive")
 	f_week_int=$(_format_number "$week_interactive")
@@ -451,6 +390,45 @@ _generate_work_with_ai_table() {
 	local f_month_total f_year_total
 	f_month_total=$(_format_number "$month_total")
 	f_year_total=$(_format_number "$year_total")
+
+	# A failed collector is not a valid zero. Preserve legitimate zero values only
+	# when the corresponding period explicitly reports status=ok.
+	if [[ "$(echo "$day_json" | jq -r '.status // "ok"')" == "unavailable" ]]; then
+		day_human="unavailable"
+		day_interactive_machine="unavailable"
+		day_worker_human="unavailable"
+		day_worker="unavailable"
+		day_total="unavailable"
+		f_day_int="unavailable"
+		f_day_wrk="unavailable"
+	fi
+	if [[ "$(echo "$week_json" | jq -r '.status // "ok"')" == "unavailable" ]]; then
+		week_human="unavailable"
+		week_interactive_machine="unavailable"
+		week_worker_human="unavailable"
+		week_worker="unavailable"
+		week_total="unavailable"
+		f_week_int="unavailable"
+		f_week_wrk="unavailable"
+	fi
+	if [[ "$(echo "$month_json" | jq -r '.status // "ok"')" == "unavailable" ]]; then
+		month_human="unavailable"
+		month_interactive_machine="unavailable"
+		month_worker_human="unavailable"
+		month_worker="unavailable"
+		f_month_total="unavailable"
+		f_month_int="unavailable"
+		f_month_wrk="unavailable"
+	fi
+	if [[ "$(echo "$year_json" | jq -r '.status // "ok"')" == "unavailable" ]]; then
+		year_human="unavailable"
+		year_interactive_machine="unavailable"
+		year_worker_human="unavailable"
+		year_worker="unavailable"
+		f_year_total="unavailable"
+		f_year_int="unavailable"
+		f_year_wrk="unavailable"
+	fi
 
 	# Determine platform label for screen time row
 	local os_type screen_label screen_source
@@ -469,6 +447,7 @@ _generate_work_with_ai_table() {
 		screen_source="system events"
 		;;
 	esac
+	screen_source=$(echo "$screen_json" | jq -r '.periods.month.source // "unavailable"')
 
 	local session_coverage_note=""
 	local session_observed_days
@@ -483,16 +462,18 @@ _generate_work_with_ai_table() {
 
 | Metric | 24h | 7 Days | 28 Days | 365 Days |
 | --- | ---: | ---: | ---: | ---: |
-| ${screen_label} | ${screen_today}h | ${screen_week}h | ${f_screen_month}h | ${year_prefix}${f_screen_year}h${year_suffix} |
-| User AI session hours | ${day_human}h | ${week_human}h | ${month_human}h | ${year_human}h |
-| AI worker hours | ${day_worker}h | ${week_worker}h | ${month_worker}h | ${year_worker}h |
-| AI concurrency hours | ${day_total}h | ${week_total}h | ${f_month_total}h | ${f_year_total}h |
+| ${screen_label} | ${screen_today} | ${screen_week} | ${screen_month} | ${year_prefix}${screen_year}${year_suffix} |
+| Interactive human attention | ${day_human}$([[ "$day_human" != "unavailable" ]] && echo h) | ${week_human}$([[ "$week_human" != "unavailable" ]] && echo h) | ${month_human}$([[ "$month_human" != "unavailable" ]] && echo h) | ${year_human}$([[ "$year_human" != "unavailable" ]] && echo h) |
+| Interactive AI generation | ${day_interactive_machine}$([[ "$day_interactive_machine" != "unavailable" ]] && echo h) | ${week_interactive_machine}$([[ "$week_interactive_machine" != "unavailable" ]] && echo h) | ${month_interactive_machine}$([[ "$month_interactive_machine" != "unavailable" ]] && echo h) | ${year_interactive_machine}$([[ "$year_interactive_machine" != "unavailable" ]] && echo h) |
+| Worker-classified human attention | ${day_worker_human}$([[ "$day_worker_human" != "unavailable" ]] && echo h) | ${week_worker_human}$([[ "$week_worker_human" != "unavailable" ]] && echo h) | ${month_worker_human}$([[ "$month_worker_human" != "unavailable" ]] && echo h) | ${year_worker_human}$([[ "$year_worker_human" != "unavailable" ]] && echo h) |
+| Worker/headless AI generation | ${day_worker}$([[ "$day_worker" != "unavailable" ]] && echo h) | ${week_worker}$([[ "$week_worker" != "unavailable" ]] && echo h) | ${month_worker}$([[ "$month_worker" != "unavailable" ]] && echo h) | ${year_worker}$([[ "$year_worker" != "unavailable" ]] && echo h) |
+| Additive observed work | ${day_total}$([[ "$day_total" != "unavailable" ]] && echo h) | ${week_total}$([[ "$week_total" != "unavailable" ]] && echo h) | ${f_month_total}$([[ "$f_month_total" != "unavailable" ]] && echo h) | ${f_year_total}$([[ "$f_year_total" != "unavailable" ]] && echo h) |
 | Interactive sessions | ${f_day_int} | ${f_week_int} | ${f_month_int} | ${f_year_int} |
 | Worker sessions | ${f_day_wrk} | ${f_week_wrk} | ${f_month_wrk} | ${f_year_wrk} |
 
-_Screen time from ${screen_source}, snapshotted daily.$([ -n "$year_suffix" ] && echo " *365-day extrapolated (accumulating real data).")_
+_Screen time from ${screen_source}; collection status: ${screen_status}.$([ -n "$year_suffix" ] && echo " *365-day estimate uses observed calendar coverage.")_
 
-_User AI session hours are attended interactive time measured from gaps between AI responses and the next user message; AI concurrency hours include attended time, AI generation, and background workers._${session_coverage_note}
+_Human attention is unioned wall-clock time, so overlapping sessions are not double-counted. AI generation is additive machine work across sessions; it is not wall-clock concurrency._${session_coverage_note}
 EOF
 	return 0
 }
@@ -503,13 +484,12 @@ cmd_generate() {
 	local screen_json
 	screen_json=$(_get_screen_time)
 
-	local day_json week_json month_json year_json
-	day_json=$(_get_session_time day)
-	week_json=$(_get_session_time week)
-	# The profile table column is explicitly 28 days; keep AI session windows
-	# aligned with the screen-time window instead of contributor "month" (30d).
-	month_json=$(_get_session_time 28d)
-	year_json=$(_get_session_time year)
+	local session_periods day_json week_json month_json year_json
+	session_periods=$(_get_profile_session_times)
+	day_json=$(echo "$session_periods" | jq -c '.day // {status:"unavailable"}')
+	week_json=$(echo "$session_periods" | jq -c '.week // {status:"unavailable"}')
+	month_json=$(echo "$session_periods" | jq -c '."28d" // {status:"unavailable"}')
+	year_json=$(echo "$session_periods" | jq -c '.year // {status:"unavailable"}')
 
 	local model_json_30d model_json_all
 	model_json_30d=$(_get_model_usage "30d")

--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -491,13 +491,14 @@ cmd_generate() {
 	month_json=$(echo "$session_periods" | jq -c '."28d" // {status:"unavailable"}')
 	year_json=$(echo "$session_periods" | jq -c '.year // {status:"unavailable"}')
 
-	local model_json_30d model_json_all
-	model_json_30d=$(_get_model_usage "30d")
-	model_json_all=$(_get_model_usage "all")
+	local model_usage_bundle model_json_30d model_json_all
+	model_usage_bundle=$(_get_profile_model_usage_bundle)
+	model_json_30d=$(printf '%s' "$model_usage_bundle" | jq -c '.recent // []')
+	model_json_all=$(printf '%s' "$model_usage_bundle" | jq -c '.all // []')
 
 	local token_totals_30d token_totals_all
-	token_totals_30d=$(_get_token_totals "30d")
-	token_totals_all=$(_get_token_totals "all")
+	token_totals_30d=$(_token_totals_from_model_usage "$model_json_30d")
+	token_totals_all=$(_token_totals_from_model_usage "$model_json_all")
 
 	# Detect if there's any meaningful data to display.
 	local has_data=false

--- a/.agents/scripts/screen-time-helper.sh
+++ b/.agents/scripts/screen-time-helper.sh
@@ -32,6 +32,22 @@ OS_TYPE="${AIDEVOPS_SCREEN_TIME_OS_TYPE:-$(uname -s)}"
 
 # macOS-specific paths
 KNOWLEDGE_DB="${AIDEVOPS_KNOWLEDGE_DB:-${HOME}/Library/Application Support/Knowledge/knowledgeC.db}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTERVAL_ENGINE="${SCRIPT_DIR}/screen-time-interval-engine.py"
+
+#######################################
+# Run the shared interval engine with platform and source paths.
+# Arguments:
+#   $1..N - interval engine arguments
+# Returns: engine exit status
+#######################################
+_screen_time_engine() {
+	python3 "$INTERVAL_ENGINE" "$@" \
+		--os-type "$OS_TYPE" \
+		--db "$KNOWLEDGE_DB" \
+		--history "$HISTORY_FILE"
+	return $?
+}
 
 # ============================================================
 # macOS: Knowledge DB queries
@@ -724,14 +740,8 @@ _linux_earliest_date() {
 #######################################
 _query_screen_hours() {
 	local days="$1"
-	case "$OS_TYPE" in
-	Darwin) _macos_query_screen_hours "$days" ;;
-	Linux) _linux_query_screen_hours "$days" ;;
-	*)
-		echo "0"
-		return 0
-		;;
-	esac
+	_screen_time_engine query --days "$days"
+	return $?
 }
 
 #######################################
@@ -742,14 +752,8 @@ _query_screen_hours() {
 #######################################
 _query_screen_hours_for_date() {
 	local target_date="$1"
-	case "$OS_TYPE" in
-	Darwin) _macos_query_screen_hours_for_date "$target_date" ;;
-	Linux) _linux_query_screen_hours_for_date "$target_date" ;;
-	*)
-		echo "0"
-		return 0
-		;;
-	esac
+	_screen_time_engine date --date "$target_date"
+	return $?
 }
 
 #######################################
@@ -757,14 +761,8 @@ _query_screen_hours_for_date() {
 # Returns: 0
 #######################################
 _earliest_date() {
-	case "$OS_TYPE" in
-	Darwin) _macos_earliest_date ;;
-	Linux) _linux_earliest_date ;;
-	*)
-		echo ""
-		return 0
-		;;
-	esac
+	_screen_time_engine earliest
+	return $?
 }
 
 # ============================================================
@@ -825,14 +823,14 @@ cmd_snapshot() {
 		local hours
 		hours=$(_query_screen_hours_for_date "$current_date")
 
-		# Only record days with actual screen time
-		if [[ "$hours" != "0" && "$hours" != "0.0" ]]; then
+		# A legitimate zero is an observation. Only collection failure is omitted.
+		if [[ "$hours" != "unavailable" ]]; then
 			local record
 			record=$(jq -cn \
 				--arg date "$current_date" \
 				--arg hours "$hours" \
 				--arg hostname "$(hostname -s 2>/dev/null || hostname)" \
-				'{date: $date, screen_hours: ($hours | tonumber), hostname: $hostname, recorded_at: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}')
+				'{date: $date, screen_hours: ([($hours | tonumber), 24] | min), status: "observed", hostname: $hostname, recorded_at: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}')
 			echo "$record" >>"$HISTORY_FILE"
 			added=$((added + 1))
 		fi
@@ -900,93 +898,8 @@ cmd_history() {
 # Returns: 0
 #######################################
 cmd_profile_stats() {
-	# Live data — rolling 24h window instead of "today since midnight"
-	local day_hours
-	local week_hours
-	day_hours=$(_query_screen_hours 1)
-	week_hours=$(_query_screen_hours 7)
-
-	# For 28 days: use live query
-	local month_hours
-	month_hours=$(_query_screen_hours 28)
-
-	# Fallback to accumulated history when live queries return 0
-	# This happens when the launchd job runs without Knowledge DB access
-	# (TCC/Full Disk Access not granted in non-interactive context)
-	local history_days=0
-	local history_total=0 hist_1d=0 hist_7d=0 hist_28d=0 hist_365d=0
-	if [[ -f "$HISTORY_FILE" ]]; then
-		history_days=$(wc -l <"$HISTORY_FILE" | tr -d ' ')
-		if [[ "$history_days" -gt 0 ]]; then
-			# Single jq pass for all history stats
-			local history_stats
-			history_stats=$(jq -rs '
-				. as $all |
-				[
-					([$all[].screen_hours] | add // 0),
-					([$all[-1:][].screen_hours] | add // 0 | . * 10 | round / 10),
-					([$all[-7:][].screen_hours] | add // 0 | . * 10 | round / 10),
-					([$all[-28:][].screen_hours] | add // 0 | . * 10 | round / 10),
-					([$all[-365:][].screen_hours] | add // 0 | . * 10 | round / 10)
-				] | @tsv
-			' "$HISTORY_FILE" 2>/dev/null) || true
-			if [[ -n "$history_stats" ]]; then
-				read -r history_total hist_1d hist_7d hist_28d hist_365d <<<"$history_stats"
-			fi
-		fi
-	fi
-
-	# If live queries returned 0 but we have history, use history instead
-	if [[ "$history_days" -gt 0 ]]; then
-		if [[ "$(echo "$day_hours == 0" | bc)" -eq 1 ]]; then
-			day_hours="${hist_1d:-0}"
-		fi
-		if [[ "$(echo "$week_hours == 0" | bc)" -eq 1 ]]; then
-			week_hours="${hist_7d:-0}"
-		fi
-		if [[ "$(echo "$month_hours == 0" | bc)" -eq 1 ]]; then
-			month_hours="${hist_28d:-0}"
-		fi
-	fi
-
-	# For 365 days: use accumulated history if available, else extrapolate
-	local year_hours
-	if [[ "$history_days" -gt 0 ]]; then
-		local daily_avg
-		daily_avg=$(echo "scale=2; ${history_total:-0} / $history_days" | bc)
-		if [[ "$history_days" -ge 365 ]]; then
-			year_hours="${hist_365d:-0}"
-		else
-			# Extrapolate from available data
-			year_hours=$(echo "scale=1; $daily_avg * 365" | bc)
-		fi
-	else
-		# No history — extrapolate from 28-day data
-		year_hours=$(echo "scale=1; $month_hours / 28 * 365" | bc 2>/dev/null || echo "0")
-	fi
-
-	local platform_note
-	case "$OS_TYPE" in
-	Darwin) platform_note="from macOS Knowledge DB (~28 days retention)" ;;
-	Linux) platform_note="from systemd-logind session events" ;;
-	*) platform_note="unsupported platform" ;;
-	esac
-
-	jq -n \
-		--arg day "$day_hours" \
-		--arg week "$week_hours" \
-		--arg month "$month_hours" \
-		--arg year "$year_hours" \
-		--arg note "$platform_note" \
-		'{
-			today_hours: ($day | tonumber),
-			week_hours: ($week | tonumber),
-			month_hours: ($month | tonumber),
-			year_hours: ($year | tonumber),
-			month_note: $note
-		}'
-
-	return 0
+	_screen_time_engine profile
+	return $?
 }
 
 # --- Main dispatch ---

--- a/.agents/scripts/screen-time-helper.sh
+++ b/.agents/scripts/screen-time-helper.sh
@@ -1,44 +1,21 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# screen-time-helper.sh — Query screen time and maintain persistent history
-#
-# Cross-platform: macOS and Linux
-#
-# macOS data source: Knowledge DB (~/Library/Application Support/Knowledge/knowledgeC.db)
-#   - /display/isBacklit events (screen on=1, off=0) — primary
-#   - /app/usage events (per-app active time) — fallback for macOS 26.3+ where
-#     /display/isBacklit was deprecated (March 2026)
-#   - Retains ~28 days of data
-#
-# Linux data source: systemd-logind session events via journalctl
-#   - Session unlock/lock events from systemd-logind
-#   - Retention depends on journald config (typically weeks to months)
-#   - Falls back to wtmp login sessions via 'last' command
-#   - Falls back to /proc/uptime for simple single-user systems
-#   - Works on both X11 and Wayland (no display server dependency)
-#
-# Usage:
-#   screen-time-helper.sh snapshot          # Append today's screen time to history
-#   screen-time-helper.sh query [days]      # Query screen-on hours for last N days
-#   screen-time-helper.sh history           # Show accumulated history
-#   screen-time-helper.sh profile-stats     # Output stats for profile README
-#
+# screen-time-helper.sh — Cross-platform observed screen-time commands
+
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HISTORY_DIR="${HOME}/.aidevops/.agent-workspace/observability"
 HISTORY_FILE="${HISTORY_DIR}/screen-time.jsonl"
 OS_TYPE="${AIDEVOPS_SCREEN_TIME_OS_TYPE:-$(uname -s)}"
-
-# macOS-specific paths
 KNOWLEDGE_DB="${AIDEVOPS_KNOWLEDGE_DB:-${HOME}/Library/Application Support/Knowledge/knowledgeC.db}"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INTERVAL_ENGINE="${SCRIPT_DIR}/screen-time-interval-engine.py"
 
 #######################################
-# Run the shared interval engine with platform and source paths.
+# Invoke the interval engine with common source arguments.
 # Arguments:
-#   $1..N - interval engine arguments
+#   $1..N - engine command and arguments
 # Returns: engine exit status
 #######################################
 _screen_time_engine() {
@@ -49,860 +26,114 @@ _screen_time_engine() {
 	return $?
 }
 
-# ============================================================
-# macOS: Knowledge DB queries
-# ============================================================
-
 #######################################
-# [macOS] Compute screen-on hours from Knowledge DB for a given number of past days
+# Advance an ISO local date by one calendar day.
 # Arguments:
-#   $1 - number of days to look back
-# Returns: 0
-# Outputs: hours as decimal to stdout
-#######################################
-_macos_query_screen_hours() {
-	local days="$1"
-
-	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
-		echo "0"
-		return 0
-	fi
-
-	# Check if /display/isBacklit is still active (deprecated in macOS 26.3+, March 2026).
-	# If the most recent event is older than 3 days, treat the stream as stale and use
-	# /app/usage exclusively to avoid mixing stale isBacklit with missing recent data.
-	local is_backlit_stale=false
-	local latest_backlit_age
-	latest_backlit_age=$(sqlite3 "$KNOWLEDGE_DB" "
-		SELECT CAST((strftime('%s', 'now') - 978307200 - MAX(ZCREATIONDATE)) / 86400.0 AS INTEGER)
-		FROM ZOBJECT WHERE ZSTREAMNAME = '/display/isBacklit';" 2>/dev/null || echo "999")
-	if [[ "$latest_backlit_age" -gt 3 ]]; then
-		is_backlit_stale=true
-	fi
-
-	local hours
-	if [[ "$is_backlit_stale" == "true" ]]; then
-		# Stream is stale — use /app/usage exclusively
-		hours=$(_macos_query_screen_hours_from_app_usage "$days")
-	else
-		# Primary: /display/isBacklit (accurate on/off pair matching)
-		hours=$(sqlite3 "$KNOWLEDGE_DB" "
-		WITH events AS (
-			SELECT
-				ZCREATIONDATE + 978307200 as ts,
-				ZVALUEINTEGER as state
-			FROM ZOBJECT
-			WHERE ZSTREAMNAME = '/display/isBacklit'
-				AND ZCREATIONDATE > (strftime('%s', 'now') - 978307200 - 86400*${days})
-		),
-		pairs AS (
-			SELECT
-				e1.ts as on_time,
-				MIN(e2.ts) as off_time
-			FROM events e1
-			JOIN events e2 ON e2.ts > e1.ts AND e2.state = 0
-			WHERE e1.state = 1
-			GROUP BY e1.ts
-		)
-		SELECT COALESCE(ROUND(SUM(off_time - on_time) / 3600.0, 1), 0) FROM pairs;" 2>/dev/null || echo "0")
-
-		# Fallback: /app/usage when isBacklit returns 0 or has sparse coverage.
-		# macOS can keep emitting occasional /display/isBacklit events after the stream
-		# stops covering every active day. Treat sparse multi-day windows as incomplete
-		# so a single recent backlit day does not undercount 7d/28d profile totals.
-		if [[ "$hours" == "0" || "$hours" == "0.0" ]] || _macos_should_use_app_usage_for_window "$days" "$hours"; then
-			hours=$(_macos_query_screen_hours_from_app_usage "$days")
-		fi
-	fi
-
-	echo "$hours"
-	return 0
-}
-
-#######################################
-# [macOS] Count distinct local dates with events in a Knowledge DB stream window
-# Arguments:
-#   $1 - stream name
-#   $2 - timestamp column name
-#   $3 - number of days to look back
-# Returns: 0
-# Outputs: integer count
-#######################################
-_macos_count_stream_days() {
-	local stream_name="$1"
-	local timestamp_column="$2"
-	local days="$3"
-
-	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
-		echo "0"
-		return 0
-	fi
-
-	case "$timestamp_column" in
-	ZCREATIONDATE | ZSTARTDATE) ;;
-	*)
-		echo "0"
-		return 0
-		;;
-	esac
-
-	local active_days
-	local stream_filter=""
-	if [[ "$stream_name" == "/display/isBacklit" ]]; then
-		stream_filter="AND ZVALUEINTEGER = 1"
-	fi
-	active_days=$(sqlite3 "$KNOWLEDGE_DB" "
-		SELECT COUNT(DISTINCT date(${timestamp_column} + 978307200, 'unixepoch', 'localtime'))
-		FROM ZOBJECT
-		WHERE ZSTREAMNAME = '${stream_name}'
-			AND ${timestamp_column} > (strftime('%s', 'now') - 978307200 - 86400*${days})
-			${stream_filter};" 2>/dev/null || echo "0")
-
-	[[ "$active_days" =~ ^[0-9]+$ ]] || active_days="0"
-	echo "$active_days"
-	return 0
-}
-
-#######################################
-# [macOS] Decide whether /display/isBacklit coverage is too sparse for a window
-# Arguments:
-#   $1 - number of days to look back
-#   $2 - hours computed from /display/isBacklit
-# Returns: 0 when /app/usage should be used, 1 otherwise
-#######################################
-_macos_should_use_app_usage_for_window() {
-	local days="$1"
-	local backlit_hours="$2"
-
-	if [[ "$days" -le 1 ]]; then
-		return 1
-	fi
-
-	local backlit_days
-	local app_days
-	backlit_days=$(_macos_count_stream_days "/display/isBacklit" "ZCREATIONDATE" "$days")
-	app_days=$(_macos_count_stream_days "/app/usage" "ZSTARTDATE" "$days")
-
-	# A multi-day app/usage window with only one backlit event day is the regression
-	# that makes 24h and 7d totals collapse to the same value.
-	if [[ "$backlit_days" -le 1 && "$app_days" -ge 2 ]]; then
-		return 0
-	fi
-
-	# More generally, when app usage covers at least two extra active days and is
-	# materially higher than backlit, prefer the richer source for the whole window.
-	local app_hours
-	app_hours=$(_macos_query_screen_hours_from_app_usage "$days")
-	if awk "BEGIN {exit !(${app_days} >= ${backlit_days} + 1 && ${app_hours} > ${backlit_hours} * 1.25)}"; then
-		return 0
-	fi
-
-	return 1
-}
-
-#######################################
-# [macOS] Compute screen-on hours for a specific date (YYYY-MM-DD)
-# Arguments:
-#   $1 - date string (YYYY-MM-DD)
-# Returns: 0
-# Outputs: hours as decimal to stdout
-#######################################
-_macos_query_screen_hours_for_date() {
-	local target_date="$1"
-
-	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
-		echo "0"
-		return 0
-	fi
-
-	local start_epoch
-	local end_epoch
-	# Convert date to epoch, subtract Core Data epoch offset (978307200)
-	start_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "${target_date} 00:00:00" "+%s" 2>/dev/null || date -d "${target_date} 00:00:00" "+%s" 2>/dev/null)
-	end_epoch=$((start_epoch + 86400))
-	local cd_start=$((start_epoch - 978307200))
-	local cd_end=$((end_epoch - 978307200))
-
-	# Check if isBacklit is stale (deprecated in macOS 26.3+)
-	local is_backlit_stale=false
-	local latest_backlit_age
-	latest_backlit_age=$(sqlite3 "$KNOWLEDGE_DB" "
-		SELECT CAST((strftime('%s', 'now') - 978307200 - MAX(ZCREATIONDATE)) / 86400.0 AS INTEGER)
-		FROM ZOBJECT WHERE ZSTREAMNAME = '/display/isBacklit';" 2>/dev/null || echo "999")
-	if [[ "$latest_backlit_age" -gt 3 ]]; then
-		is_backlit_stale=true
-	fi
-
-	local hours
-	if [[ "$is_backlit_stale" == "true" ]]; then
-		hours=$(_macos_query_screen_hours_for_date_from_app_usage "$target_date")
-	else
-		# Primary: /display/isBacklit (accurate on/off pair matching)
-		hours=$(sqlite3 "$KNOWLEDGE_DB" "
-		WITH events AS (
-			SELECT
-				ZCREATIONDATE + 978307200 as ts,
-				ZVALUEINTEGER as state
-			FROM ZOBJECT
-			WHERE ZSTREAMNAME = '/display/isBacklit'
-				AND ZCREATIONDATE >= ${cd_start}
-				AND ZCREATIONDATE < ${cd_end}
-		),
-		pairs AS (
-			SELECT
-				e1.ts as on_time,
-				MIN(e2.ts) as off_time
-			FROM events e1
-			JOIN events e2 ON e2.ts > e1.ts AND e2.state = 0
-			WHERE e1.state = 1
-			GROUP BY e1.ts
-		)
-		SELECT COALESCE(ROUND(SUM(off_time - on_time) / 3600.0, 1), 0) FROM pairs;" 2>/dev/null || echo "0")
-
-		# Fallback for individual dates where isBacklit has no data
-		if [[ "$hours" == "0" || "$hours" == "0.0" ]]; then
-			hours=$(_macos_query_screen_hours_for_date_from_app_usage "$target_date")
-		fi
-	fi
-
-	echo "$hours"
-	return 0
-}
-
-# ============================================================
-# macOS: /app/usage fallback (for macOS 26.3+ where isBacklit deprecated)
-# ============================================================
-
-#######################################
-# [macOS] Compute screen-on hours from /app/usage for a given number of past days
-# Uses per-app active time as a proxy for screen time. Slightly overcounts due to
-# concurrent app usage, but provides reasonable estimates (~10-15% above actual).
-# Arguments:
-#   $1 - number of days to look back
-# Returns: 0
-# Outputs: hours as decimal to stdout
-#######################################
-_macos_query_screen_hours_from_app_usage() {
-	local days="$1"
-
-	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
-		echo "0"
-		return 0
-	fi
-
-	local hours
-	hours=$(sqlite3 "$KNOWLEDGE_DB" "
-		SELECT COALESCE(ROUND(SUM(ZOBJECT.ZENDDATE - ZOBJECT.ZSTARTDATE) / 3600.0, 1), 0)
-		FROM ZOBJECT
-		WHERE ZSTREAMNAME = '/app/usage'
-			AND ZSTARTDATE > (strftime('%s', 'now') - 978307200 - 86400*${days});" 2>/dev/null || echo "0")
-
-	echo "$hours"
-	return 0
-}
-
-#######################################
-# [macOS] Compute screen-on hours from /app/usage for a specific date (YYYY-MM-DD)
-# Arguments:
-#   $1 - date string (YYYY-MM-DD)
-# Returns: 0
-# Outputs: hours as decimal to stdout
-#######################################
-_macos_query_screen_hours_for_date_from_app_usage() {
-	local target_date="$1"
-
-	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
-		echo "0"
-		return 0
-	fi
-
-	local start_epoch
-	local end_epoch
-	start_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "${target_date} 00:00:00" "+%s" 2>/dev/null || date -d "${target_date} 00:00:00" "+%s" 2>/dev/null)
-	end_epoch=$((start_epoch + 86400))
-	local cd_start=$((start_epoch - 978307200))
-	local cd_end=$((end_epoch - 978307200))
-
-	local hours
-	hours=$(sqlite3 "$KNOWLEDGE_DB" "
-		SELECT COALESCE(ROUND(SUM(ZOBJECT.ZENDDATE - ZOBJECT.ZSTARTDATE) / 3600.0, 1), 0)
-		FROM ZOBJECT
-		WHERE ZSTREAMNAME = '/app/usage'
-			AND ZSTARTDATE >= ${cd_start}
-			AND ZSTARTDATE < ${cd_end};" 2>/dev/null || echo "0")
-
-	echo "$hours"
-	return 0
-}
-
-#######################################
-# [macOS] Get earliest date available in Knowledge DB
-# Checks /display/isBacklit first, then /app/usage as fallback
-# Returns: 0
-# Outputs: YYYY-MM-DD or empty string
-#######################################
-_macos_earliest_date() {
-	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
-		echo ""
-		return 0
-	fi
-
-	local earliest
-	earliest=$(sqlite3 "$KNOWLEDGE_DB" "
-		SELECT date(MIN(ZCREATIONDATE + 978307200), 'unixepoch', 'localtime')
-		FROM ZOBJECT WHERE ZSTREAMNAME = '/display/isBacklit';" 2>/dev/null || echo "")
-
-	# Fallback: check /app/usage if isBacklit has no data or if app/usage has older data
-	local app_earliest
-	app_earliest=$(sqlite3 "$KNOWLEDGE_DB" "
-		SELECT date(MIN(ZSTARTDATE + 978307200), 'unixepoch', 'localtime')
-		FROM ZOBJECT WHERE ZSTREAMNAME = '/app/usage';" 2>/dev/null || echo "")
-
-	if [[ -z "$earliest" || ("$earliest" == "NULL" && -n "$app_earliest" && "$app_earliest" != "NULL") ]]; then
-		earliest="$app_earliest"
-	elif [[ -n "$app_earliest" && "$app_earliest" != "NULL" && "$app_earliest" < "$earliest" ]]; then
-		earliest="$app_earliest"
-	fi
-
-	# Handle NULL results from sqlite
-	if [[ "$earliest" == "NULL" ]]; then
-		echo ""
-		return 0
-	fi
-
-	echo "$earliest"
-	return 0
-}
-
-# ============================================================
-# Linux: systemd-logind session tracking
-# ============================================================
-
-#######################################
-# [Linux] Compute screen-on hours from logind session events for last N days
-#
-# Three methods tried in order:
-#   1. systemd-logind session events via journalctl (most accurate)
-#   2. wtmp login sessions via 'last' command (widely available)
-#   3. /proc/uptime fallback (crude — assumes screen on = system on)
-#
-# Arguments:
-#   $1 - number of days to look back
-# Returns: 0
-# Outputs: hours as decimal to stdout
-#######################################
-_linux_query_screen_hours() {
-	local days="$1"
-
-	# Method 1: journalctl logind session events
-	if command -v journalctl >/dev/null 2>&1; then
-		local hours
-		hours=$(_linux_logind_hours "$days")
-		if [[ "$hours" != "0" && "$hours" != "0.0" ]]; then
-			echo "$hours"
-			return 0
-		fi
-	fi
-
-	# Method 2: wtmp login sessions via 'last'
-	if command -v last >/dev/null 2>&1; then
-		local hours
-		hours=$(_linux_last_hours "$days")
-		if [[ "$hours" != "0" && "$hours" != "0.0" ]]; then
-			echo "$hours"
-			return 0
-		fi
-	fi
-
-	# Method 3: /proc/uptime fallback (system uptime as proxy)
-	# Only useful for "today" or short periods on single-user machines
-	if [[ -f /proc/uptime && "$days" -le 1 ]]; then
-		local uptime_secs
-		uptime_secs=$(awk '{printf "%.0f", $1}' /proc/uptime)
-		local uptime_hours
-		uptime_hours=$(awk "BEGIN {printf \"%.1f\", ${uptime_secs} / 3600}")
-		# Cap at 24h for a single day
-		if awk "BEGIN {exit ($uptime_hours > 24) ? 0 : 1}" 2>/dev/null; then
-			uptime_hours="24.0"
-		fi
-		echo "$uptime_hours"
-		return 0
-	fi
-
-	echo "0"
-	return 0
-}
-
-#######################################
-# [Linux] Parse logind session events from journalctl
-#
-# Looks for session start/stop and lid open/close events from systemd-logind.
-# Session active time = time between session start and session stop/lock.
-#
-# Arguments:
-#   $1 - number of days to look back
-# Returns: 0
-# Outputs: hours as decimal to stdout
-#######################################
-_linux_logind_hours() {
-	local days="$1"
-	local since_date
-	since_date=$(date -d "${days} days ago" "+%Y-%m-%d" 2>/dev/null || echo "")
-
-	if [[ -z "$since_date" ]]; then
-		echo "0"
-		return 0
-	fi
-
-	local current_user
-	current_user=$(whoami)
-
-	# Extract timestamped session events for the current user
-	# Track sessions by ID to avoid matching username in hostname (GH#17551)
-	local events_file
-	events_file=$(mktemp)
-	local tracked_sessions_file
-	tracked_sessions_file=$(mktemp)
-
-	journalctl --since "$since_date" -u systemd-logind.service --no-pager -o short-iso 2>/dev/null |
-		grep -iE "(New session|Removed session|Session .* logged out|Lid closed|Lid opened)" |
-		while IFS= read -r line; do
-			local ts
-			ts=$(echo "$line" | awk '{print $1}')
-			local sid=""
-
-			# Lid events apply globally — no session ID filtering needed
-			if echo "$line" | grep -qi "Lid opened"; then
-				echo "${ts} ON"
-			elif echo "$line" | grep -qi "Lid closed"; then
-				echo "${ts} OFF"
-			# Match "New session <ID> of user <current_user>" exactly
-			elif echo "$line" | grep -qiE "New session [a-z0-9]+ of user ${current_user}([^a-zA-Z0-9]|$)"; then
-				sid=$(echo "$line" | sed -nE 's/.*[Nn]ew session ([a-zA-Z0-9]+) of user .*/\1/p')
-				[[ -n "$sid" ]] && echo "$sid" >>"$tracked_sessions_file" && echo "${ts} ON"
-			# Match "Removed session <ID>" only if ID was tracked
-			elif echo "$line" | grep -qiE "Removed session [a-z0-9]+"; then
-				sid=$(echo "$line" | sed -nE 's/.*[Rr]emoved session ([a-zA-Z0-9]+).*/\1/p')
-				[[ -n "$sid" ]] && grep -qxF "$sid" "$tracked_sessions_file" 2>/dev/null && echo "${ts} OFF"
-			# Match "Session <ID> logged out" only if ID was tracked
-			elif echo "$line" | grep -qiE "Session [a-z0-9]+ logged out"; then
-				sid=$(echo "$line" | sed -nE 's/.*[Ss]ession ([a-zA-Z0-9]+) logged out.*/\1/p')
-				[[ -n "$sid" ]] && grep -qxF "$sid" "$tracked_sessions_file" 2>/dev/null && echo "${ts} OFF"
-			fi
-		done >"$events_file" 2>/dev/null
-
-	rm -f "$tracked_sessions_file"
-
-	local total_seconds=0
-
-	if [[ -s "$events_file" ]]; then
-		# Parse ON/OFF event pairs
-		local last_on_epoch=0
-		while IFS=' ' read -r ts event_type; do
-			local epoch
-			epoch=$(date -d "$ts" "+%s" 2>/dev/null || echo "0")
-			if [[ "$event_type" == "ON" && "$last_on_epoch" -eq 0 ]]; then
-				last_on_epoch=$epoch
-			elif [[ "$event_type" == "OFF" && "$last_on_epoch" -gt 0 ]]; then
-				local duration=$((epoch - last_on_epoch))
-				# Cap individual sessions at 24h (sanity check)
-				if [[ "$duration" -gt 86400 ]]; then
-					duration=86400
-				fi
-				total_seconds=$((total_seconds + duration))
-				last_on_epoch=0
-			fi
-		done <"$events_file"
-
-		# If last event was ON (still active), count time until now
-		if [[ "$last_on_epoch" -gt 0 ]]; then
-			local now_epoch
-			now_epoch=$(date "+%s")
-			local remaining=$((now_epoch - last_on_epoch))
-			if [[ "$remaining" -gt 86400 ]]; then
-				remaining=86400
-			fi
-			total_seconds=$((total_seconds + remaining))
-		fi
-	fi
-
-	rm -f "$events_file"
-
-	local hours
-	hours=$(awk "BEGIN {printf \"%.1f\", ${total_seconds} / 3600}")
-	echo "$hours"
-	return 0
-}
-
-#######################################
-# [Linux] Parse login sessions from 'last' command
-#
-# Uses wtmp records to compute total logged-in time.
-# Less accurate than logind (doesn't track screen lock) but widely available.
-#
-# Arguments:
-#   $1 - number of days to look back
-# Returns: 0
-# Outputs: hours as decimal to stdout
-#######################################
-_linux_last_hours() {
-	local days="$1"
-	local current_user
-	current_user=$(whoami)
-	local total_seconds=0
-
-	# Parse completed sessions with duration
-	while IFS= read -r line; do
-		local duration
-		duration=$(echo "$line" | grep -oE '\(([0-9]+:[0-9]+)\)' | tr -d '()' || echo "")
-		if [[ -n "$duration" ]]; then
-			local dur_hours
-			local dur_mins
-			dur_hours=$(echo "$duration" | cut -d: -f1)
-			dur_mins=$(echo "$duration" | cut -d: -f2)
-			local dur_secs=$(((dur_hours * 3600) + (dur_mins * 60)))
-			total_seconds=$((total_seconds + dur_secs))
-		fi
-	done < <(last -s "-${days}days" "$current_user" 2>/dev/null |
-		grep -v "^$\|wtmp begins\|still logged in\|reboot\|shutdown" || true)
-
-	# Count "still logged in" sessions
-	local still_logged
-	still_logged=$(last -s "-${days}days" "$current_user" 2>/dev/null |
-		grep -c "still logged in" 2>/dev/null || true)
-	if [[ "$still_logged" -gt 0 ]]; then
-		# Estimate current session duration from loginctl
-		local current_session_secs=0
-		if command -v loginctl >/dev/null 2>&1; then
-			local session_id
-			session_id=$(loginctl show-user "$current_user" -p Sessions --value 2>/dev/null | awk '{print $1}')
-			if [[ -n "$session_id" ]]; then
-				local session_since
-				session_since=$(loginctl show-session "$session_id" -p Timestamp --value 2>/dev/null || echo "")
-				if [[ -n "$session_since" ]]; then
-					local session_epoch
-					session_epoch=$(date -d "$session_since" "+%s" 2>/dev/null || echo "0")
-					local now_epoch
-					now_epoch=$(date "+%s")
-					current_session_secs=$((now_epoch - session_epoch))
-				fi
-			fi
-		fi
-		total_seconds=$((total_seconds + current_session_secs))
-	fi
-
-	local hours
-	hours=$(awk "BEGIN {printf \"%.1f\", ${total_seconds} / 3600}")
-	echo "$hours"
-	return 0
-}
-
-#######################################
-# [Linux] Compute screen-on hours for a specific date (YYYY-MM-DD)
-# Arguments:
-#   $1 - date string (YYYY-MM-DD)
-# Returns: 0
-# Outputs: hours as decimal to stdout
-#######################################
-_linux_query_screen_hours_for_date() {
-	local target_date="$1"
-	local current_user
-	current_user=$(whoami)
-	local total_seconds=0
-
-	# Method 1: journalctl for the specific date
-	if command -v journalctl >/dev/null 2>&1; then
-		local next_date
-		next_date=$(date -d "${target_date} + 1 day" "+%Y-%m-%d" 2>/dev/null || echo "")
-
-		if [[ -n "$next_date" ]]; then
-			local events_file
-			events_file=$(mktemp)
-
-			journalctl --since "$target_date" --until "$next_date" \
-				-u systemd-logind.service --no-pager -o short-iso 2>/dev/null |
-				grep -iE "(New session|Removed session|Session .* logged out|Lid closed|Lid opened)" |
-				grep -i "$current_user" |
-				while IFS= read -r line; do
-					local ts
-					local event_type
-					ts=$(echo "$line" | awk '{print $1}')
-					if echo "$line" | grep -qi "New session\|Lid opened"; then
-						event_type="ON"
-					else
-						event_type="OFF"
-					fi
-					echo "${ts} ${event_type}"
-				done >"$events_file" 2>/dev/null
-
-			if [[ -s "$events_file" ]]; then
-				local last_on_epoch=0
-				local day_end
-				day_end=$(date -d "${next_date} 00:00:00" "+%s" 2>/dev/null || echo "0")
-
-				while IFS=' ' read -r ts event_type; do
-					local epoch
-					epoch=$(date -d "$ts" "+%s" 2>/dev/null || echo "0")
-					if [[ "$event_type" == "ON" && "$last_on_epoch" -eq 0 ]]; then
-						last_on_epoch=$epoch
-					elif [[ "$event_type" == "OFF" && "$last_on_epoch" -gt 0 ]]; then
-						local duration=$((epoch - last_on_epoch))
-						total_seconds=$((total_seconds + duration))
-						last_on_epoch=0
-					fi
-				done <"$events_file"
-
-				# If still on at end of day, count until midnight
-				if [[ "$last_on_epoch" -gt 0 && "$day_end" -gt 0 ]]; then
-					local remaining=$((day_end - last_on_epoch))
-					total_seconds=$((total_seconds + remaining))
-				fi
-			fi
-
-			rm -f "$events_file"
-		fi
-	fi
-
-	# Method 2: fallback to 'last' command for the specific date
-	if [[ "$total_seconds" -eq 0 ]] && command -v last >/dev/null 2>&1; then
-		# Match date in 'last' output format (e.g., "Mon Mar  9")
-		local date_pattern
-		date_pattern=$(date -d "$target_date" "+%b %e" 2>/dev/null || echo "NOMATCH")
-
-		while IFS= read -r line; do
-			local duration
-			duration=$(echo "$line" | grep -oE '\(([0-9]+:[0-9]+)\)' | tr -d '()' || echo "")
-			if [[ -n "$duration" ]]; then
-				local dur_hours
-				local dur_mins
-				dur_hours=$(echo "$duration" | cut -d: -f1)
-				dur_mins=$(echo "$duration" | cut -d: -f2)
-				local dur_secs=$(((dur_hours * 3600) + (dur_mins * 60)))
-				total_seconds=$((total_seconds + dur_secs))
-			fi
-		done < <(last "$current_user" 2>/dev/null |
-			grep "$date_pattern" |
-			grep -v "^$\|wtmp begins\|reboot\|shutdown" || true)
-	fi
-
-	local hours
-	hours=$(awk "BEGIN {printf \"%.1f\", ${total_seconds} / 3600}")
-	echo "$hours"
-	return 0
-}
-
-#######################################
-# [Linux] Get earliest date available in journalctl or wtmp
-# Returns: 0
-# Outputs: YYYY-MM-DD or empty string
-#######################################
-_linux_earliest_date() {
-	# Try journalctl first
-	if command -v journalctl >/dev/null 2>&1; then
-		local earliest
-		earliest=$(journalctl -u systemd-logind.service --no-pager -o short-iso 2>/dev/null |
-			head -1 | awk '{print $1}' | cut -dT -f1 || echo "")
-		if [[ -n "$earliest" ]]; then
-			echo "$earliest"
-			return 0
-		fi
-	fi
-
-	# Fallback: use wtmp via last
-	if command -v last >/dev/null 2>&1; then
-		local wtmp_line
-		wtmp_line=$(last -R 2>/dev/null | tail -1 || echo "")
-		if [[ -n "$wtmp_line" ]]; then
-			# Parse "wtmp begins Mon Mar  9 00:00:00 2026" format
-			local earliest
-			earliest=$(echo "$wtmp_line" | grep -oE '[A-Z][a-z]{2} [A-Z][a-z]{2} [ 0-9]{2} [0-9:]{8} [0-9]{4}' |
-				xargs -I{} date -d "{}" "+%Y-%m-%d" 2>/dev/null || echo "")
-			if [[ -n "$earliest" ]]; then
-				echo "$earliest"
-				return 0
-			fi
-		fi
-	fi
-
-	echo ""
-	return 0
-}
-
-# ============================================================
-# Platform dispatcher — routes to OS-specific implementations
-# ============================================================
-
-#######################################
-# Query screen-on hours for last N days (cross-platform)
-# Arguments:
-#   $1 - number of days to look back
-# Returns: 0
-#######################################
-_query_screen_hours() {
-	local days="$1"
-	_screen_time_engine query --days "$days"
-	return $?
-}
-
-#######################################
-# Query screen-on hours for a specific date (cross-platform)
-# Arguments:
-#   $1 - date string (YYYY-MM-DD)
-# Returns: 0
-#######################################
-_query_screen_hours_for_date() {
-	local target_date="$1"
-	_screen_time_engine date --date "$target_date"
-	return $?
-}
-
-#######################################
-# Get earliest available date (cross-platform)
-# Returns: 0
-#######################################
-_earliest_date() {
-	_screen_time_engine earliest
-	return $?
-}
-
-# ============================================================
-# Commands (platform-independent)
-# ============================================================
-
-#######################################
-# Advance a date by one day (cross-platform)
-# Arguments:
-#   $1 - date string (YYYY-MM-DD)
-# Returns: 0
-# Outputs: next date as YYYY-MM-DD
+#   $1 - YYYY-MM-DD
+# Outputs: YYYY-MM-DD
 #######################################
 _next_date() {
-	local current="$1"
-	# macOS date
-	date -j -v+1d -f "%Y-%m-%d" "$current" "+%Y-%m-%d" 2>/dev/null ||
-		date -d "${current} + 1 day" "+%Y-%m-%d" 2>/dev/null ||
-		echo "$current"
+	local current_date="$1"
+	_screen_time_engine next-date --date "$current_date"
+	return $?
+}
+
+#######################################
+# Clamp and validate an observed daily hour value.
+# Arguments:
+#   $1 - candidate numeric value
+# Outputs: decimal in [0,24], or unavailable
+#######################################
+_validated_daily_hours() {
+	local candidate="$1"
+	if [[ ! "$candidate" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+		printf '%s\n' unavailable
+		return 0
+	fi
+	awk -v value="$candidate" 'BEGIN { if (value > 24) value=24; printf "%.1f\n", value }'
 	return 0
 }
 
 #######################################
-# Snapshot: record daily screen time totals to persistent JSONL
-# Snapshots each day available that isn't already in history.
-# Returns: 0
+# Record each previously unseen observed local date.
 #######################################
 cmd_snapshot() {
 	mkdir -p "$HISTORY_DIR"
-
-	local earliest_date
-	earliest_date=$(_earliest_date)
-
+	local earliest_date today existing_dates current_date added
+	earliest_date=$(_screen_time_engine earliest)
 	if [[ -z "$earliest_date" ]]; then
-		echo "No screen time data available"
+		echo "No observed screen-time source data available"
 		return 0
 	fi
-
-	local today
 	today=$(date +%Y-%m-%d)
-
-	# Get dates already in history
-	local existing_dates=""
+	existing_dates=""
 	if [[ -f "$HISTORY_FILE" ]]; then
-		existing_dates=$(jq -r '.date' "$HISTORY_FILE" 2>/dev/null | sort -u || echo "")
+		existing_dates=$(jq -r 'select(type == "object" and (.date | type) == "string") | .date' "$HISTORY_FILE" 2>/dev/null | sort -u || true)
 	fi
-
-	local current_date="$earliest_date"
-	local added=0
-
+	current_date="$earliest_date"
+	added=0
 	while [[ "$current_date" < "$today" ]]; do
-		# Skip if already recorded
-		if echo "$existing_dates" | grep -q "^${current_date}$" 2>/dev/null; then
+		if [[ -n "$existing_dates" ]] && grep -qxF "$current_date" <<<"$existing_dates"; then
 			current_date=$(_next_date "$current_date")
 			continue
 		fi
-
-		local hours
-		hours=$(_query_screen_hours_for_date "$current_date")
-
-		# A legitimate zero is an observation. Only collection failure is omitted.
+		local raw_hours hours record
+		raw_hours=$(_screen_time_engine date --date "$current_date")
+		hours=$(_validated_daily_hours "$raw_hours")
 		if [[ "$hours" != "unavailable" ]]; then
-			local record
 			record=$(jq -cn \
 				--arg date "$current_date" \
 				--arg hours "$hours" \
 				--arg hostname "$(hostname -s 2>/dev/null || hostname)" \
-				'{date: $date, screen_hours: ([($hours | tonumber), 24] | min), status: "observed", hostname: $hostname, recorded_at: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}')
-			echo "$record" >>"$HISTORY_FILE"
+				'{date:$date,screen_hours:($hours|tonumber),status:"observed",source:"interval-engine",hostname:$hostname,recorded_at:(now|strftime("%Y-%m-%dT%H:%M:%SZ"))}')
+			printf '%s\n' "$record" >>"$HISTORY_FILE"
 			added=$((added + 1))
 		fi
-
 		current_date=$(_next_date "$current_date")
 	done
-
-	echo "Snapshot complete: ${added} new day(s) added to ${HISTORY_FILE}"
+	echo "Snapshot complete: ${added} new local-date observation(s) added to ${HISTORY_FILE}"
 	return 0
 }
 
 #######################################
-# Query: show screen-on hours for last N days
+# Query rolling screen-on hours.
 # Arguments:
-#   $1 - number of days (default: 1)
-# Returns: 0
+#   $1 - number of days
 #######################################
 cmd_query() {
 	local days="${1:-1}"
 	local hours
-	hours=$(_query_screen_hours "$days")
-	echo "${hours}h screen-on time in last ${days} day(s)"
+	hours=$(_screen_time_engine query --days "$days")
+	if [[ "$hours" == "unavailable" ]]; then
+		echo "Screen-time source unavailable for last ${days} day(s)"
+	else
+		echo "${hours}h screen-on time in last ${days} day(s)"
+	fi
 	return 0
 }
 
 #######################################
-# History: show accumulated screen time history
-# Returns: 0
+# Show validated history summary and malformed-row count.
 #######################################
 cmd_history() {
 	if [[ ! -f "$HISTORY_FILE" ]]; then
 		echo "No history file found. Run 'snapshot' first."
 		return 0
 	fi
-
-	local total_days
-	total_days=$(wc -l <"$HISTORY_FILE" | tr -d ' ')
-
-	# Single jq pass for all history stats (total_hours, earliest, latest)
-	local total_hours="0"
-	local earliest="unknown"
-	local latest="unknown"
-	if [[ "$total_days" -gt 0 ]]; then
-		local history_stats
-		history_stats=$(jq -rs '
-			[
-				([.[].screen_hours] | add // 0 | . * 10 | round / 10),
-				(min_by(.date) | .date // "unknown"),
-				(max_by(.date) | .date // "unknown")
-			] | @tsv
-		' "$HISTORY_FILE" 2>/dev/null) || true
-		if [[ -n "$history_stats" ]]; then
-			IFS=$'\t' read -r total_hours earliest latest <<<"$history_stats"
-		fi
-	fi
-
-	echo "Screen time history: ${total_days} days, ${total_hours}h total"
-	echo "Range: ${earliest} to ${latest}"
+	local summary
+	summary=$(_screen_time_engine history-summary)
+	printf '%s\n' "$summary" | jq -r '"Screen time history: \(.valid_rows) valid day(s), \(.total_hours)h total\nRange: \(.earliest // "unknown") to \(.latest // "unknown")\nSkipped malformed rows: \(.skipped_rows)"'
 	return 0
 }
 
 #######################################
-# Profile stats: output stats for profile README in JSON
-# Combines live queries with accumulated history
-# Returns: 0
+# Emit profile statistics JSON.
 #######################################
 cmd_profile_stats() {
 	_screen_time_engine profile
 	return $?
 }
 
-# --- Main dispatch ---
 case "${1:-help}" in
 snapshot) cmd_snapshot ;;
 query) cmd_query "${2:-1}" ;;
@@ -910,19 +141,7 @@ history) cmd_history ;;
 profile-stats) cmd_profile_stats ;;
 help | *)
 	echo "Usage: screen-time-helper.sh {snapshot|query [days]|history|profile-stats}"
-	echo ""
-	echo "Commands:"
-	echo "  snapshot       Record daily screen time to persistent history"
-	echo "  query [days]   Query screen-on hours for last N days (default: 1)"
-	echo "  history        Show accumulated history summary"
-	echo "  profile-stats  Output stats for profile README (JSON)"
-	echo ""
 	echo "Platform: ${OS_TYPE}"
-	case "$OS_TYPE" in
-	Darwin) echo "  Source: macOS Knowledge DB (display backlit events, app/usage fallback)" ;;
-	Linux) echo "  Source: systemd-logind (session events) + wtmp (login sessions)" ;;
-	*) echo "  Source: unsupported (will return 0 for all queries)" ;;
-	esac
 	return 0 2>/dev/null || exit 0
 	;;
 esac

--- a/.agents/scripts/screen-time-interval-engine.py
+++ b/.agents/scripts/screen-time-interval-engine.py
@@ -1,602 +1,41 @@
 #!/usr/bin/env python3
-"""Deterministic screen-time interval collection and aggregation."""
+"""CLI entrypoint for deterministic screen-time interval aggregation."""
 
 from __future__ import annotations
 
 import argparse
 import datetime as dt
 import getpass
-import heapq
 import json
-import math
 import os
-import re
-import shutil
-import sqlite3
-import subprocess
 import sys
 import time
 from pathlib import Path
 
-CORE_DATA_EPOCH = 978307200
-DAY = 86400
-WINDOWS = {"day": DAY, "week": 7 * DAY, "month": 28 * DAY, "year": 365 * DAY}
+from screen_time_history import period_payload, profile_payload, read_history
+from screen_time_interval_common import DAY, interval_seconds, local_date, local_day_bounds
+from screen_time_linux import linux_collection
+from screen_time_macos import macos_collection
+from screen_time_macos_apps import macos_app_stats
 
 
-def local_date(timestamp):
-    return dt.datetime.fromtimestamp(timestamp).date()
+def parser():
+    result = argparse.ArgumentParser()
+    result.add_argument("command", choices=("profile", "query", "date", "earliest", "apps", "next-date", "history-summary"))
+    result.add_argument("--os-type", required=True)
+    result.add_argument("--db", default="")
+    result.add_argument("--history", default="")
+    result.add_argument("--days", type=int, default=1)
+    result.add_argument("--date", default="")
+    result.add_argument("--now", type=float, default=float(os.environ.get("AIDEVOPS_SCREEN_TIME_NOW_EPOCH", "0") or 0))
+    result.add_argument("--user", default=os.environ.get("AIDEVOPS_SCREEN_TIME_USER", getpass.getuser()))
+    return result
 
 
-def local_midnight_epoch(date):
-    # Naive datetime.timestamp intentionally uses the host TZ database, including
-    # the offset applicable on this date rather than today's fixed UTC offset.
-    return dt.datetime.combine(date, dt.time.min).timestamp()
-
-
-def local_day_bounds(date):
-    return local_midnight_epoch(date), local_midnight_epoch(date + dt.timedelta(days=1))
-
-
-def union_intervals(intervals, start, end):
-    clipped = sorted((max(start, a), min(end, b)) for a, b in intervals if b > start and a < end)
-    merged = []
-    for left, right in clipped:
-        if right <= left:
-            continue
-        if merged and left <= merged[-1][1]:
-            merged[-1] = (merged[-1][0], max(merged[-1][1], right))
-        else:
-            merged.append((left, right))
-    return merged
-
-
-def interval_seconds(intervals, start, end):
-    return min(end - start, sum(right - left for left, right in union_intervals(intervals, start, end)))
-
-
-def parse_timestamp(value):
-    value = value.strip().replace("Z", "+00:00")
-    try:
-        parsed = dt.datetime.fromisoformat(value)
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=dt.timezone.utc)
-        return parsed.timestamp()
-    except ValueError:
-        return None
-
-
-def state_intervals(events, start, end, initial=False):
-    state = initial
-    opened = start if state else None
-    intervals = []
-    for timestamp, new_state in sorted(events):
-        if timestamp < start:
-            state = new_state
-            opened = start if state else None
-            continue
-        if timestamp > end:
-            break
-        if new_state == state:
-            continue
-        if state and opened is not None:
-            intervals.append((opened, timestamp))
-        state = new_state
-        opened = timestamp if state else None
-    if state and opened is not None and opened < end:
-        intervals.append((opened, end))
-    return union_intervals(intervals, start, end)
-
-
-def macos_collection(db_path, now):
-    if not db_path.exists():
-        return {"status": "unavailable", "source": "macos-knowledge-db", "reason": "database-missing", "intervals": []}
-    try:
-        uri = f"file:{db_path}?mode=ro"
-        with sqlite3.connect(uri, uri=True, timeout=5) as connection:
-            backlit_rows = connection.execute(
-                "SELECT ZCREATIONDATE, ZVALUEINTEGER FROM ZOBJECT "
-                "WHERE ZSTREAMNAME='/display/isBacklit' ORDER BY ZCREATIONDATE"
-            ).fetchall()
-            app_rows = connection.execute(
-                "SELECT ZSTARTDATE, ZENDDATE FROM ZOBJECT "
-                "WHERE ZSTREAMNAME='/app/usage' ORDER BY ZSTARTDATE"
-            ).fetchall()
-    except (OSError, sqlite3.Error) as exc:
-        return {"status": "unavailable", "source": "macos-knowledge-db", "reason": f"database-read-failed:{type(exc).__name__}", "intervals": []}
-
-    backlit = [(float(timestamp) + CORE_DATA_EPOCH, bool(state)) for timestamp, state in backlit_rows if timestamp is not None]
-    apps = [
-        (float(start) + CORE_DATA_EPOCH, float(end) + CORE_DATA_EPOCH)
-        for start, end in app_rows
-        if start is not None and end is not None and float(end) > float(start)
-    ]
-    latest_backlit = max((item[0] for item in backlit), default=None)
-    latest_app = max((item[1] for item in apps), default=None)
-    earliest = now - WINDOWS["year"]
-    backlit_intervals = state_intervals(backlit, earliest, now)
-    app_intervals = union_intervals(apps, earliest, now)
-
-    def active_dates(intervals, window_days=28):
-        dates = set()
-        window_start = now - window_days * DAY
-        for left, right in union_intervals(intervals, window_start, now):
-            cursor = local_date(left)
-            final = local_date(max(left, right - 1))
-            while cursor <= final:
-                dates.add(cursor)
-                cursor += dt.timedelta(days=1)
-        return dates
-
-    backlit_dates = active_dates(backlit_intervals)
-    app_dates = active_dates(app_intervals)
-    backlit_seconds = interval_seconds(backlit_intervals, now - 28 * DAY, now)
-    app_seconds = interval_seconds(app_intervals, now - 28 * DAY, now)
-    app_materially_richer = (
-        len(app_dates) > len(backlit_dates)
-        and (
-            len(app_dates) >= max(len(backlit_dates) + 2, len(backlit_dates) * 2)
-            or app_seconds > max(3600, backlit_seconds * 1.5)
-        )
-    )
-    use_backlit = (
-        latest_backlit is not None
-        and now - latest_backlit <= 3 * DAY
-        and not app_materially_richer
-    )
-    if use_backlit:
-        intervals = backlit_intervals
-        source = "macos-knowledge-db:/display/isBacklit"
-        latest = latest_backlit
-        observations = len(backlit)
-        observation_epochs = [timestamp for timestamp, _ in backlit]
-        coverage_start = min(observation_epochs)
-        coverage_end = max(observation_epochs)
-    elif apps:
-        intervals = app_intervals
-        source = "macos-knowledge-db:/app/usage-union"
-        latest = latest_app
-        observations = len(apps)
-        observation_epochs = []
-        coverage_start = min(start for start, _ in apps)
-        coverage_end = max(end for _, end in apps)
-    elif backlit:
-        intervals = backlit_intervals
-        source = "macos-knowledge-db:/display/isBacklit-stale"
-        latest = latest_backlit
-        observations = len(backlit)
-        observation_epochs = [timestamp for timestamp, _ in backlit]
-        coverage_start = min(observation_epochs)
-        coverage_end = max(observation_epochs)
-    else:
-        return {"status": "unavailable", "source": "macos-knowledge-db:no-observations", "reason": "empty-readable-database", "intervals": [], "observations": 0}
-    freshness = max(0.0, (now - latest) / 3600) if latest is not None else None
-    status = "stale" if freshness is not None and freshness > 72 else "ok"
-    return {
-        "status": status,
-        "source": source,
-        "reason": "source-observations",
-        "intervals": intervals,
-        "observations": observations,
-        "latest_epoch": latest,
-        "earliest_epoch": min((item[0] for item in (backlit if use_backlit or not apps else apps)), default=latest),
-        "freshness_hours": round(freshness, 1) if freshness is not None else None,
-        "observation_epochs": observation_epochs,
-        "coverage_start_epoch": coverage_start,
-        "coverage_end_epoch": coverage_end,
-    }
-
-
-def macos_app_stats(db_path, now):
-    if not db_path.exists():
-        return []
-    try:
-        started_at = time.perf_counter()
-        uri = f"file:{db_path}?mode=ro"
-        with sqlite3.connect(uri, uri=True, timeout=5) as connection:
-            cutoff_cd = now - 28 * DAY - CORE_DATA_EPOCH
-            now_cd = now - CORE_DATA_EPOCH
-            rows = connection.execute(
-                "SELECT ZVALUESTRING, ZSTARTDATE, ZENDDATE FROM ZOBJECT "
-                "WHERE ZSTREAMNAME='/app/usage' AND ZVALUESTRING IS NOT NULL "
-                "AND ZENDDATE > ? AND ZSTARTDATE < ? ORDER BY ZSTARTDATE",
-                (cutoff_cd, now_cd),
-            ).fetchall()
-    except sqlite3.Error:
-        return []
-    month_start = now - 28 * DAY
-    intervals = [
-        (str(bundle), max(month_start, float(start) + CORE_DATA_EPOCH), min(now, float(end) + CORE_DATA_EPOCH), float(start) + CORE_DATA_EPOCH)
-        for bundle, start, end in rows
-        if start is not None and end is not None and float(end) > float(start) and float(end) + CORE_DATA_EPOCH > month_start and float(start) + CORE_DATA_EPOCH < now
-    ]
-    starts = {}
-    ends = {}
-    boundaries = {month_start, now}
-    for interval_id, (bundle, left, right, original_start) in enumerate(intervals):
-        starts.setdefault(left, []).append((interval_id, bundle, original_start))
-        ends.setdefault(right, []).append(interval_id)
-        boundaries.update((left, right))
-    ordered = sorted(boundaries)
-    active = set()
-    latest_start_heap = []
-    totals = {name: {} for name in ("today", "week", "month")}
-    window_starts = {"today": now - DAY, "week": now - 7 * DAY, "month": month_start}
-    attributed_segments = 0
-    max_active = 0
-    for left, right in zip(ordered, ordered[1:]):
-        for interval_id in ends.get(left, []):
-            active.discard(interval_id)
-        for interval_id, bundle, original_start in starts.get(left, []):
-            active.add(interval_id)
-            heapq.heappush(latest_start_heap, (-original_start, -interval_id, interval_id, bundle))
-        while latest_start_heap and latest_start_heap[0][2] not in active:
-            heapq.heappop(latest_start_heap)
-        max_active = max(max_active, len(active))
-        if not latest_start_heap or right <= left:
-            continue
-        bundle = latest_start_heap[0][3]
-        attributed_segments += 1
-        for name, window_start in window_starts.items():
-            overlap = right - max(left, window_start)
-            if overlap > 0:
-                totals[name][bundle] = totals[name].get(bundle, 0) + overlap
-    month_total = sum(totals.get("month", {}).values())
-    result = []
-    for bundle, month_seconds in sorted(totals.get("month", {}).items(), key=lambda item: (-item[1], item[0]))[:10]:
-        row = {"bundle": bundle}
-        for name in ("today", "week", "month"):
-            denominator = sum(totals.get(name, {}).values())
-            row[f"{name}_pct"] = round(totals.get(name, {}).get(bundle, 0) / denominator * 100) if denominator else 0
-        row["month_seconds"] = round(month_seconds)
-        result.append(row)
-    instrument_file = os.environ.get("AIDEVOPS_APP_STATS_INSTRUMENT_FILE")
-    if instrument_file:
-        instrumentation = {
-            "rows_selected": len(rows),
-            "valid_intervals": len(intervals),
-            "boundaries": len(ordered),
-            "attributed_segments": attributed_segments,
-            "max_active": max_active,
-            "elapsed_ms": round((time.perf_counter() - started_at) * 1000, 3),
-        }
-        Path(instrument_file).write_text(json.dumps(instrumentation, sort_keys=True) + "\n", encoding="utf-8")
-    return result if month_total else []
-
-
-SESSION_NEW = re.compile(r"New session ([A-Za-z0-9_.-]+) of user ([^ .]+)", re.I)
-SESSION_END = re.compile(r"(?:Removed session|Session) ([A-Za-z0-9_.-]+)(?: logged out)?", re.I)
-SESSION_ID = re.compile(r"Session ([A-Za-z0-9_.-]+)", re.I)
-
-
-def run_trusted_command(executable_name, arguments):
-    executable = shutil.which(executable_name)
-    if not executable or not os.path.isabs(executable):
-        return None, "executable-not-found"
-    try:
-        # The executable is resolved to an absolute path and callers supply a
-        # fixed argv shape; no command text reaches a shell.
-        result = subprocess.run(  # nosec B603
-            [executable, *arguments],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        return None, f"{type(exc).__name__}"
-    if result.returncode != 0:
-        return None, f"exit-{result.returncode}"
-    return result.stdout.splitlines(), None
-
-
-def journal_lines(now):
-    fixture = os.environ.get("AIDEVOPS_LOGIND_FIXTURE")
-    if fixture:
-        try:
-            return Path(fixture).read_text(encoding="utf-8").splitlines(), None
-        except OSError as exc:
-            return [], f"fixture-read-failed:{type(exc).__name__}"
-    lines, error = run_trusted_command(
-        "journalctl",
-        ["--since", "366 days ago", "-u", "systemd-logind.service", "--no-pager", "-o", "short-iso"],
-    )
-    return (lines or []), f"journal-read-failed:{error}" if error else None
-
-
-def parse_last_local_timestamp(value):
-    for format_string in ("%a %b %d %H:%M:%S %z %Y", "%a %b %d %H:%M:%S %Y"):
-        try:
-            # The no-offset form is intentionally naive: timestamp() applies the
-            # host local timezone and historical DST rules used by GNU last -F.
-            return dt.datetime.strptime(value, format_string).timestamp()
-        except ValueError:
-            continue
-    return None
-
-
-def read_wtmp_lines(user, journal_reason):
-    fixture = os.environ.get("AIDEVOPS_LAST_FIXTURE")
-    if fixture:
-        try:
-            return Path(fixture).read_text(encoding="utf-8").splitlines(), None
-        except OSError as exc:
-            return None, f"fixture-read-failed:{type(exc).__name__}"
-    lines, error = run_trusted_command("last", ["-F", "-s", "-365days", user])
-    return lines, f"{journal_reason};wtmp-read-failed:{error}" if error else None
-
-
-def parse_wtmp_line(line, now):
-    interval = None
-    malformed = False
-    ignored = not line.strip() or "wtmp begins" in line or line.startswith(("reboot", "shutdown"))
-    if not ignored:
-        structured = re.match(r"^([0-9]+)\|([0-9]+)$", line.strip())
-        if structured:
-            interval = (float(structured.group(1)), float(structured.group(2)))
-        else:
-            dates = re.findall(r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2}\s+[0-9]{1,2} [0-9:]{8}(?: [+-][0-9]{4})? [0-9]{4}", line)
-            try:
-                left = parse_last_local_timestamp(dates[0]) if dates else None
-                right = now if "still logged in" in line else parse_last_local_timestamp(dates[1]) if len(dates) >= 2 else None
-                if left is not None and right is not None and right > left:
-                    interval = (left, right)
-                else:
-                    malformed = True
-            except (TypeError, ValueError):
-                malformed = True
-    return interval, malformed
-
-
-def parse_wtmp_lines(lines, now):
-    intervals = []
-    skipped = 0
-    for line in lines:
-        interval, malformed = parse_wtmp_line(line, now)
-        if interval:
-            intervals.append(interval)
-        skipped += int(malformed)
-    return intervals, skipped
-
-
-def wtmp_collection(now, user, journal_reason):
-    lines, error = read_wtmp_lines(user, journal_reason)
-    if error:
-        source = "linux-wtmp" if error.startswith("fixture-read-failed:") else "linux-logind+wtmp"
-        return {"status": "unavailable", "source": source, "reason": error, "intervals": []}
-    intervals, skipped = parse_wtmp_lines(lines, now)
-    if not intervals:
-        return {"status": "unavailable", "source": "linux-logind+wtmp", "reason": f"{journal_reason};no-parseable-wtmp-sessions", "intervals": []}
-    latest = max(right for _, right in intervals)
-    freshness = max(0.0, (now - latest) / 3600)
-    return {
-        "status": "stale" if freshness > 72 else "ok",
-        "source": "linux-wtmp:login-session-proxy",
-        "reason": f"logind-unavailable:{journal_reason}",
-        "intervals": union_intervals(intervals, now - WINDOWS["year"], now),
-        "observations": len(intervals),
-        "latest_epoch": latest,
-        "earliest_epoch": min(left for left, _ in intervals),
-        "freshness_hours": round(freshness, 1),
-        "skipped_rows": skipped,
-        "observation_epochs": [],
-        "coverage_start_epoch": min(left for left, _ in intervals),
-        "coverage_end_epoch": max(right for _, right in intervals),
-    }
-
-
-def linux_is_active(state):
-    return state["lid_open"] and any(not locked for locked in state["sessions"].values())
-
-
-def apply_linux_message(state, message, user):
-    recognized = True
-    match = SESSION_NEW.search(message)
-    if match and match.group(2) == user:
-        state["sessions"][match.group(1).rstrip(".")] = False
-    elif "Lid closed" in message:
-        state["lid_open"] = False
-    elif "Lid opened" in message:
-        state["lid_open"] = True
-    else:
-        lowered = message.lower()
-        lock_match = SESSION_ID.search(message) if "locked" in lowered else None
-        lock_session_id = lock_match.group(1).rstrip(".") if lock_match else ""
-        end_match = SESSION_END.search(message)
-        end_session_id = end_match.group(1).rstrip(".") if end_match else ""
-        if lock_session_id in state["sessions"]:
-            state["sessions"][lock_session_id] = "unlocked" not in lowered
-        elif end_session_id in state["sessions"]:
-            state["sessions"].pop(end_session_id, None)
-        else:
-            recognized = False
-    return recognized
-
-
-def parse_linux_journal_line(line, now):
-    first = line.split(None, 1)
-    timestamp = parse_timestamp(first[0]) if len(first) == 2 else None
-    if timestamp is None or timestamp > now:
-        return None
-    return timestamp, first[1]
-
-
-def debug_linux_event(timestamp, before, after, state, message):
-    if os.environ.get("AIDEVOPS_SCREEN_TIME_DEBUG") == "1":
-        print(
-            f"screen-time event ts={timestamp} before={before} after={after} sessions={state['sessions']} lid_open={state['lid_open']} message={message}",
-            file=sys.stderr,
-        )
-
-
-def apply_linux_event(state, message, user, timestamp, opened, intervals):
-    before = linux_is_active(state)
-    if not apply_linux_message(state, message, user):
-        return opened, before, False
-    after = linux_is_active(state)
-    debug_linux_event(timestamp, before, after, state, message)
-    if before != after:
-        if before and opened is not None:
-            intervals.append((opened, timestamp))
-        opened = timestamp if after else None
-    return opened, after, True
-
-
-def collect_linux_events(lines, now, user):
-    state = {"sessions": {}, "lid_open": True}
-    intervals = []
-    observation_epochs = []
-    opened = None
-    active = False
-    for line in lines:
-        event = parse_linux_journal_line(line, now)
-        if event is None:
-            continue
-        timestamp, message = event
-        opened, active, recognized = apply_linux_event(state, message, user, timestamp, opened, intervals)
-        if recognized:
-            observation_epochs.append(timestamp)
-    if active and opened is not None:
-        intervals.append((opened, now))
-    return union_intervals(intervals, now - WINDOWS["year"], now), observation_epochs
-
-
-def linux_collection(now, user):
-    lines, error = journal_lines(now)
-    if error:
-        return wtmp_collection(now, user, error)
-    intervals, observation_epochs = collect_linux_events(lines, now, user)
-    if not observation_epochs:
-        return wtmp_collection(now, user, "journal-readable-no-user-observations")
-    latest = max(observation_epochs)
-    freshness = max(0.0, (now - latest) / 3600)
-    return {
-        "status": "stale" if freshness > 72 else "ok",
-        "source": "linux-systemd-logind:session-lid-lock-state",
-        "reason": "source-observations",
-        "intervals": intervals,
-        "observations": len(observation_epochs),
-        "latest_epoch": latest,
-        "earliest_epoch": min(observation_epochs),
-        "freshness_hours": round(freshness, 1),
-        "observation_epochs": observation_epochs,
-        "coverage_start_epoch": min(observation_epochs),
-        "coverage_end_epoch": max(observation_epochs),
-    }
-
-
-def coverage(collection, start, end):
-    timestamps = []
-    for left, right in collection.get("intervals", []):
-        if right > start and left < end:
-            timestamps.extend((max(left, start), min(right, end)))
-    latest = collection.get("latest_epoch")
-    if latest is not None and latest >= start:
-        timestamps.append(min(latest, end))
-    if not timestamps:
-        return 0.0, 0.0
-    observed_start = max(start, min(timestamps))
-    observed_end = min(end, max(timestamps))
-    days = min((end - start) / DAY, max(1.0, (observed_end - observed_start) / DAY + 1.0))
-    return round(days, 1), round(days / ((end - start) / DAY) * 100, 1)
-
-
-def period_payload(collection, now, seconds):
-    start = now - seconds
-    observed_days, coverage_pct = coverage(collection, start, now)
-    status = collection.get("status", "unavailable")
-    hours = None if status == "unavailable" else round(interval_seconds(collection.get("intervals", []), start, now) / 3600, 1)
-    return {
-        "hours": hours,
-        "status": status,
-        "source": collection.get("source", "unknown"),
-        "reason": collection.get("reason", "unknown"),
-        "coverage_days": observed_days,
-        "coverage_pct": coverage_pct,
-        "freshness_hours": collection.get("freshness_hours"),
-        "observations": collection.get("observations", 0),
-        "estimated": False,
-    }
-
-
-def read_history(history_path, now):
-    rows = {}
-    skipped = 0
-    if not history_path or not history_path.exists():
-        return rows, skipped
-    try:
-        for line in history_path.read_text(encoding="utf-8").splitlines():
-            try:
-                row = json.loads(line)
-                if not isinstance(row, dict) or isinstance(row.get("screen_hours"), bool):
-                    raise ValueError("invalid history row")
-                date = dt.date.fromisoformat(str(row.get("date")))
-                hours = float(row.get("screen_hours"))
-                if hours < 0 or not math.isfinite(hours):
-                    raise ValueError("invalid history row")
-                rows[date] = (min(24.0, hours), row)
-            except (ValueError, TypeError, json.JSONDecodeError):
-                skipped += 1
-    except OSError:
-        return {}, skipped + 1
-    return rows, skipped
-
-
-def history_period(rows, now, days, skipped_rows=0):
-    end_date = local_date(now)
-    start_date = end_date - dt.timedelta(days=days)
-    selected = [(date, value) for date, value in rows.items() if start_date <= date < end_date]
-    if not selected:
-        return None
-    dates = [item[0] for item in selected]
-    total = round(sum(item[1][0] for item in selected), 1)
-    span = max(1, (max(dates) - min(dates)).days + 1)
-    latest_age = (end_date - max(dates)).days
-    return {
-        "hours": min(days * 24.0, total),
-        "status": "stale" if latest_age > 2 else "ok",
-        "source": "screen-time-history:daily-observations",
-        "reason": "live-source-unavailable",
-        "coverage_days": len(selected),
-        "calendar_span_days": span,
-        "coverage_pct": round(len(selected) / days * 100, 1),
-        "freshness_hours": latest_age * 24,
-        "observations": len(selected),
-        "estimated": False,
-        "skipped_history_rows": skipped_rows,
-    }
-
-
-def profile_payload(collection, history_path, now):
-    periods = {name: period_payload(collection, now, seconds) for name, seconds in WINDOWS.items()}
-    history, skipped_history_rows = read_history(history_path, now)
-    for name, days in (("day", 1), ("week", 7), ("month", 28)):
-        if periods[name]["status"] == "unavailable":
-            fallback = history_period(history, now, days, skipped_history_rows)
-            if fallback:
-                periods[name] = fallback
-    year_history = history_period(history, now, 365, skipped_history_rows)
-    if year_history:
-        span = year_history.get("calendar_span_days", 0)
-        observed = year_history.get("coverage_days", 0)
-        if span >= 330:
-            periods["year"] = year_history
-        elif span > 0 and observed > 0:
-            estimate = min(8760.0, year_history["hours"] / span * 365)
-            periods["year"] = dict(year_history, hours=round(estimate, 1), estimated=True, reason="calendar-span-extrapolation")
-    elif periods["year"]["status"] != "unavailable" and periods["month"]["coverage_days"] > 0:
-        base = periods["month"]
-        estimate = min(8760.0, (base["hours"] or 0) / base["coverage_days"] * 365)
-        periods["year"] = dict(base, hours=round(estimate, 1), estimated=True, reason="observed-calendar-coverage-extrapolation")
-    return {
-        "today_hours": periods["day"]["hours"],
-        "week_hours": periods["week"]["hours"],
-        "month_hours": periods["month"]["hours"],
-        "year_hours": periods["year"]["hours"],
-        "month_note": periods["month"]["source"],
-        "periods": periods,
-        "collection_status": collection.get("status", "unavailable"),
-        "history_skipped_rows": skipped_history_rows,
-    }
+def current_epoch(value):
+    if value:
+        return value
+    return dt.datetime.now(dt.timezone.utc).timestamp()
 
 
 def collect(args):
@@ -607,56 +46,82 @@ def collect(args):
     return {"status": "unavailable", "source": "unsupported-platform", "reason": args.os_type, "intervals": []}
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=("profile", "query", "date", "earliest", "apps", "next-date", "history-summary"))
-    parser.add_argument("--os-type", required=True)
-    parser.add_argument("--db", default="")
-    parser.add_argument("--history", default="")
-    parser.add_argument("--days", type=int, default=1)
-    parser.add_argument("--date", default="")
-    parser.add_argument("--now", type=float, default=float(os.environ.get("AIDEVOPS_SCREEN_TIME_NOW_EPOCH", "0") or 0))
-    parser.add_argument("--user", default=os.environ.get("AIDEVOPS_SCREEN_TIME_USER", getpass.getuser()))
-    args = parser.parse_args()
-    if hasattr(time, "tzset"):
-        time.tzset()
-    if not args.now:
-        args.now = dt.datetime.now(dt.timezone.utc).timestamp()
-    if args.command == "apps":
-        print(json.dumps(macos_app_stats(Path(args.db), args.now), sort_keys=True))
-        return 0
-    if args.command == "next-date":
-        print((dt.date.fromisoformat(args.date) + dt.timedelta(days=1)).isoformat())
-        return 0
-    if args.command == "history-summary":
-        rows, skipped = read_history(Path(args.history) if args.history else None, args.now)
-        print(json.dumps({"valid_rows": len(rows), "skipped_rows": skipped, "earliest": min(rows).isoformat() if rows else None, "latest": max(rows).isoformat() if rows else None, "total_hours": round(sum(value[0] for value in rows.values()), 1)}, sort_keys=True))
-        return 0
+def history_summary(args):
+    path = Path(args.history) if args.history else None
+    rows, skipped = read_history(path, args.now)
+    payload = {
+        "valid_rows": len(rows),
+        "skipped_rows": skipped,
+        "earliest": min(rows).isoformat() if rows else None,
+        "latest": max(rows).isoformat() if rows else None,
+        "total_hours": round(sum(value[0] for value in rows.values()), 1),
+    }
+    print(json.dumps(payload, sort_keys=True))
+
+
+def date_hours(collection, args):
+    try:
+        target = dt.date.fromisoformat(args.date)
+    except ValueError:
+        return None
+    start, end = local_day_bounds(target)
+    if start is None or end is None or collection.get("status") == "unavailable":
+        return None
+    observations = collection.get("observation_epochs", [])
+    intervals = collection.get("intervals", [])
+    explicit_event = any(start <= timestamp < end for timestamp in observations)
+    interval_overlap = any(right > start and left < end for left, right in intervals)
+    coverage_end = collection.get("coverage_end_epoch")
+    within_coverage = coverage_end is not None and start <= coverage_end
+    if not within_coverage or not (explicit_event or interval_overlap):
+        return None
+    return round(min(24 * 3600, interval_seconds(intervals, start, end)) / 3600, 1)
+
+
+def print_earliest(collection):
+    starts = [left for left, _ in collection.get("intervals", [])]
+    earliest = collection.get("earliest_epoch")
+    if earliest is None and starts:
+        earliest = min(starts)
+    date = local_date(earliest) if earliest is not None else None
+    print(date.isoformat() if date is not None else "")
+
+
+def run_collection_command(args):
     collection = collect(args)
     if args.command == "profile":
-        payload = profile_payload(collection, Path(args.history) if args.history else None, args.now)
-        print(json.dumps(payload, sort_keys=True))
+        history = Path(args.history) if args.history else None
+        print(json.dumps(profile_payload(collection, history, args.now), sort_keys=True))
     elif args.command == "query":
         payload = period_payload(collection, args.now, max(1, args.days) * DAY)
         print("unavailable" if payload["hours"] is None else payload["hours"])
     elif args.command == "date":
-        target = dt.date.fromisoformat(args.date)
-        start, end = local_day_bounds(target)
-        observations = collection.get("observation_epochs", [])
-        intervals = collection.get("intervals", [])
-        coverage_end = collection.get("coverage_end_epoch")
-        explicit_event = any(start <= timestamp < end for timestamp in observations)
-        interval_overlap = any(right > start and left < end for left, right in intervals)
-        within_coverage = coverage_end is not None and start <= coverage_end
-        observed_date = within_coverage and (explicit_event or interval_overlap)
-        hours = None if collection.get("status") == "unavailable" or not observed_date else round(min(24 * 3600, interval_seconds(intervals, start, end)) / 3600, 1)
+        hours = date_hours(collection, args)
         print("unavailable" if hours is None else hours)
     else:
-        starts = [left for left, _ in collection.get("intervals", [])]
-        earliest = collection.get("earliest_epoch")
-        if earliest is None and starts:
-            earliest = min(starts)
-        print(local_date(earliest).isoformat() if earliest is not None else "")
+        print_earliest(collection)
+
+
+def run_direct_command(args):
+    if args.command == "apps":
+        print(json.dumps(macos_app_stats(Path(args.db), args.now), sort_keys=True))
+        return True
+    if args.command == "next-date":
+        print((dt.date.fromisoformat(args.date) + dt.timedelta(days=1)).isoformat())
+        return True
+    if args.command == "history-summary":
+        history_summary(args)
+        return True
+    return False
+
+
+def main():
+    args = parser().parse_args()
+    if hasattr(time, "tzset"):
+        time.tzset()
+    args.now = current_epoch(args.now)
+    if not run_direct_command(args):
+        run_collection_command(args)
     return 0
 
 

--- a/.agents/scripts/screen-time-interval-engine.py
+++ b/.agents/scripts/screen-time-interval-engine.py
@@ -11,6 +11,7 @@ import json
 import math
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -267,6 +268,27 @@ SESSION_END = re.compile(r"(?:Removed session|Session) ([A-Za-z0-9_.-]+)(?: logg
 SESSION_ID = re.compile(r"Session ([A-Za-z0-9_.-]+)", re.I)
 
 
+def run_trusted_command(executable_name, arguments):
+    executable = shutil.which(executable_name)
+    if not executable or not os.path.isabs(executable):
+        return None, "executable-not-found"
+    try:
+        # The executable is resolved to an absolute path and callers supply a
+        # fixed argv shape; no command text reaches a shell.
+        result = subprocess.run(  # nosec B603
+            [executable, *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, f"{type(exc).__name__}"
+    if result.returncode != 0:
+        return None, f"exit-{result.returncode}"
+    return result.stdout.splitlines(), None
+
+
 def journal_lines(now):
     fixture = os.environ.get("AIDEVOPS_LOGIND_FIXTURE")
     if fixture:
@@ -274,19 +296,11 @@ def journal_lines(now):
             return Path(fixture).read_text(encoding="utf-8").splitlines(), None
         except OSError as exc:
             return [], f"fixture-read-failed:{type(exc).__name__}"
-    try:
-        result = subprocess.run(
-            ["journalctl", "--since", "366 days ago", "-u", "systemd-logind.service", "--no-pager", "-o", "short-iso"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        return [], f"journal-read-failed:{type(exc).__name__}"
-    if result.returncode != 0:
-        return [], f"journal-read-failed:exit-{result.returncode}"
-    return result.stdout.splitlines(), None
+    lines, error = run_trusted_command(
+        "journalctl",
+        ["--since", "366 days ago", "-u", "systemd-logind.service", "--no-pager", "-o", "short-iso"],
+    )
+    return (lines or []), f"journal-read-failed:{error}" if error else None
 
 
 def parse_last_local_timestamp(value):
@@ -300,49 +314,53 @@ def parse_last_local_timestamp(value):
     return None
 
 
-def wtmp_collection(now, user, journal_reason):
+def read_wtmp_lines(user, journal_reason):
     fixture = os.environ.get("AIDEVOPS_LAST_FIXTURE")
     if fixture:
         try:
-            lines = Path(fixture).read_text(encoding="utf-8").splitlines()
+            return Path(fixture).read_text(encoding="utf-8").splitlines(), None
         except OSError as exc:
-            return {"status": "unavailable", "source": "linux-wtmp", "reason": f"fixture-read-failed:{type(exc).__name__}", "intervals": []}
-    else:
-        try:
-            result = subprocess.run(
-                ["last", "-F", "-s", "-365days", user], check=False, capture_output=True, text=True, timeout=30
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            return {"status": "unavailable", "source": "linux-logind+wtmp", "reason": f"{journal_reason};wtmp-read-failed:{type(exc).__name__}", "intervals": []}
-        if result.returncode != 0:
-            return {"status": "unavailable", "source": "linux-logind+wtmp", "reason": f"{journal_reason};wtmp-read-failed:exit-{result.returncode}", "intervals": []}
-        lines = result.stdout.splitlines()
+            return None, f"fixture-read-failed:{type(exc).__name__}"
+    lines, error = run_trusted_command("last", ["-F", "-s", "-365days", user])
+    return lines, f"{journal_reason};wtmp-read-failed:{error}" if error else None
+
+
+def parse_wtmp_line(line, now):
+    if not line.strip() or "wtmp begins" in line or line.startswith(("reboot", "shutdown")):
+        return None, False
+    structured = re.match(r"^([0-9]+)\|([0-9]+)$", line.strip())
+    if structured:
+        return (float(structured.group(1)), float(structured.group(2))), False
+    dates = re.findall(r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2}\s+[0-9]{1,2} [0-9:]{8}(?: [+-][0-9]{4})? [0-9]{4}", line)
+    if not dates:
+        return None, True
+    try:
+        left = parse_last_local_timestamp(dates[0])
+        right = now if "still logged in" in line else parse_last_local_timestamp(dates[1]) if len(dates) >= 2 else None
+    except (TypeError, ValueError):
+        return None, True
+    if left is None or right is None or right <= left:
+        return None, True
+    return (left, right), False
+
+
+def parse_wtmp_lines(lines, now):
     intervals = []
     skipped = 0
     for line in lines:
-        if not line.strip() or "wtmp begins" in line or line.startswith(("reboot", "shutdown")):
-            continue
-        structured = re.match(r"^([0-9]+)\|([0-9]+)$", line.strip())
-        if structured:
-            intervals.append((float(structured.group(1)), float(structured.group(2))))
-            continue
-        dates = re.findall(r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2}\s+[0-9]{1,2} [0-9:]{8}(?: [+-][0-9]{4})? [0-9]{4}", line)
-        if dates:
-            try:
-                left = parse_last_local_timestamp(dates[0])
-                if "still logged in" in line:
-                    right = now
-                elif len(dates) >= 2:
-                    right = parse_last_local_timestamp(dates[1])
-                else:
-                    skipped += 1
-                    continue
-                if left is not None and right is not None and right > left:
-                    intervals.append((left, right))
-            except (TypeError, ValueError):
-                skipped += 1
-        else:
-            skipped += 1
+        interval, malformed = parse_wtmp_line(line, now)
+        if interval:
+            intervals.append(interval)
+        skipped += int(malformed)
+    return intervals, skipped
+
+
+def wtmp_collection(now, user, journal_reason):
+    lines, error = read_wtmp_lines(user, journal_reason)
+    if error:
+        source = "linux-wtmp" if error.startswith("fixture-read-failed:") else "linux-logind+wtmp"
+        return {"status": "unavailable", "source": source, "reason": error, "intervals": []}
+    intervals, skipped = parse_wtmp_lines(lines, now)
     if not intervals:
         return {"status": "unavailable", "source": "linux-logind+wtmp", "reason": f"{journal_reason};no-parseable-wtmp-sessions", "intervals": []}
     latest = max(right for _, right in intervals)
@@ -363,24 +381,41 @@ def wtmp_collection(now, user, journal_reason):
     }
 
 
-def linux_collection(now, user):
-    lines, error = journal_lines(now)
-    if error:
-        return wtmp_collection(now, user, error)
-    sessions = {}
-    lid_open = True
-    active = False
-    opened = None
+def linux_is_active(state):
+    return state["lid_open"] and any(not locked for locked in state["sessions"].values())
+
+
+def apply_linux_message(state, message, user):
+    match = SESSION_NEW.search(message)
+    if match and match.group(2) == user:
+        state["sessions"][match.group(1).rstrip(".")] = False
+        return True
+    lowered = message.lower()
+    match = SESSION_ID.search(message) if "locked" in lowered else None
+    session_id = match.group(1).rstrip(".") if match else ""
+    if session_id in state["sessions"]:
+        state["sessions"][session_id] = "unlocked" not in lowered
+        return True
+    if "Lid closed" in message:
+        state["lid_open"] = False
+        return True
+    if "Lid opened" in message:
+        state["lid_open"] = True
+        return True
+    match = SESSION_END.search(message)
+    session_id = match.group(1).rstrip(".") if match else ""
+    if session_id in state["sessions"]:
+        state["sessions"].pop(session_id, None)
+        return True
+    return False
+
+
+def collect_linux_events(lines, now, user):
+    state = {"sessions": {}, "lid_open": True}
     intervals = []
-    observations = 0
     observation_epochs = []
-    latest = None
-    earliest_event = None
-    start = now - WINDOWS["year"]
-
-    def is_active():
-        return lid_open and any(not locked for locked in sessions.values())
-
+    opened = None
+    active = False
     for line in lines:
         first = line.split(None, 1)
         if len(first) != 2:
@@ -389,43 +424,16 @@ def linux_collection(now, user):
         if timestamp is None or timestamp > now:
             continue
         message = first[1]
-        before = is_active()
-        recognized = False
-        match = SESSION_NEW.search(message)
-        if match and match.group(2) == user:
-            sessions[match.group(1).rstrip(".")] = False
-            recognized = True
-        else:
-            lowered = message.lower()
-            match = SESSION_ID.search(message) if "locked" in lowered else None
-            session_id = match.group(1).rstrip(".") if match else ""
-            if session_id in sessions:
-                sessions[session_id] = "unlocked" not in lowered
-                recognized = True
-            elif "Lid closed" in message:
-                lid_open = False
-                recognized = True
-            elif "Lid opened" in message:
-                lid_open = True
-                recognized = True
-            else:
-                match = SESSION_END.search(message)
-                session_id = match.group(1).rstrip(".") if match else ""
-                if session_id in sessions:
-                    sessions.pop(session_id, None)
-                    recognized = True
-        if not recognized:
+        before = linux_is_active(state)
+        if not apply_linux_message(state, message, user):
             continue
+        after = linux_is_active(state)
         if os.environ.get("AIDEVOPS_SCREEN_TIME_DEBUG") == "1":
             print(
-                f"screen-time event ts={timestamp} before={before} after={is_active()} sessions={sessions} lid_open={lid_open} message={message}",
+                f"screen-time event ts={timestamp} before={before} after={after} sessions={state['sessions']} lid_open={state['lid_open']} message={message}",
                 file=sys.stderr,
             )
-        observations += 1
         observation_epochs.append(timestamp)
-        latest = timestamp if latest is None else max(latest, timestamp)
-        earliest_event = timestamp if earliest_event is None else min(earliest_event, timestamp)
-        after = is_active()
         if before == after:
             continue
         if before and opened is not None:
@@ -434,18 +442,26 @@ def linux_collection(now, user):
         active = after
     if active and opened is not None:
         intervals.append((opened, now))
-    intervals = union_intervals(intervals, start, now)
-    if observations == 0:
+    return union_intervals(intervals, now - WINDOWS["year"], now), observation_epochs
+
+
+def linux_collection(now, user):
+    lines, error = journal_lines(now)
+    if error:
+        return wtmp_collection(now, user, error)
+    intervals, observation_epochs = collect_linux_events(lines, now, user)
+    if not observation_epochs:
         return wtmp_collection(now, user, "journal-readable-no-user-observations")
+    latest = max(observation_epochs)
     freshness = max(0.0, (now - latest) / 3600)
     return {
         "status": "stale" if freshness > 72 else "ok",
         "source": "linux-systemd-logind:session-lid-lock-state",
         "reason": "source-observations",
         "intervals": intervals,
-        "observations": observations,
+        "observations": len(observation_epochs),
         "latest_epoch": latest,
-        "earliest_epoch": earliest_event,
+        "earliest_epoch": min(observation_epochs),
         "freshness_hours": round(freshness, 1),
         "observation_epochs": observation_epochs,
         "coverage_start_epoch": min(observation_epochs),

--- a/.agents/scripts/screen-time-interval-engine.py
+++ b/.agents/scripts/screen-time-interval-engine.py
@@ -7,16 +7,32 @@ import argparse
 import datetime as dt
 import getpass
 import json
+import math
 import os
 import re
 import sqlite3
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 CORE_DATA_EPOCH = 978307200
 DAY = 86400
 WINDOWS = {"day": DAY, "week": 7 * DAY, "month": 28 * DAY, "year": 365 * DAY}
+
+
+def local_date(timestamp):
+    return dt.datetime.fromtimestamp(timestamp).date()
+
+
+def local_midnight_epoch(date):
+    # Naive datetime.timestamp intentionally uses the host TZ database, including
+    # the offset applicable on this date rather than today's fixed UTC offset.
+    return dt.datetime.combine(date, dt.time.min).timestamp()
+
+
+def local_day_bounds(date):
+    return local_midnight_epoch(date), local_midnight_epoch(date + dt.timedelta(days=1))
 
 
 def union_intervals(intervals, start, end):
@@ -102,8 +118,8 @@ def macos_collection(db_path, now):
         dates = set()
         window_start = now - window_days * DAY
         for left, right in union_intervals(intervals, window_start, now):
-            cursor = dt.datetime.fromtimestamp(left, dt.timezone.utc).date()
-            final = dt.datetime.fromtimestamp(max(left, right - 1), dt.timezone.utc).date()
+            cursor = local_date(left)
+            final = local_date(max(left, right - 1))
             while cursor <= final:
                 dates.add(cursor)
                 cursor += dt.timedelta(days=1)
@@ -111,10 +127,19 @@ def macos_collection(db_path, now):
 
     backlit_dates = active_dates(backlit_intervals)
     app_dates = active_dates(app_intervals)
+    backlit_seconds = interval_seconds(backlit_intervals, now - 28 * DAY, now)
+    app_seconds = interval_seconds(app_intervals, now - 28 * DAY, now)
+    app_materially_richer = (
+        len(app_dates) > len(backlit_dates)
+        and (
+            len(app_dates) >= max(len(backlit_dates) + 2, len(backlit_dates) * 2)
+            or app_seconds > max(3600, backlit_seconds * 1.5)
+        )
+    )
     use_backlit = (
         latest_backlit is not None
         and now - latest_backlit <= 3 * DAY
-        and not (len(backlit_dates) <= 1 and len(app_dates) >= 2)
+        and not app_materially_richer
     )
     if use_backlit:
         intervals = backlit_intervals
@@ -132,7 +157,7 @@ def macos_collection(db_path, now):
         latest = latest_backlit
         observations = len(backlit)
     else:
-        return {"status": "ok", "source": "macos-knowledge-db:no-observations", "reason": "empty-readable-database", "intervals": [], "observations": 0}
+        return {"status": "unavailable", "source": "macos-knowledge-db:no-observations", "reason": "empty-readable-database", "intervals": [], "observations": 0}
     freshness = max(0.0, (now - latest) / 3600) if latest is not None else None
     status = "stale" if freshness is not None and freshness > 72 else "ok"
     return {
@@ -142,6 +167,7 @@ def macos_collection(db_path, now):
         "intervals": intervals,
         "observations": observations,
         "latest_epoch": latest,
+        "earliest_epoch": min((item[0] for item in (backlit if use_backlit or not apps else apps)), default=latest),
         "freshness_hours": round(freshness, 1) if freshness is not None else None,
     }
 
@@ -217,6 +243,17 @@ def journal_lines(now):
     return result.stdout.splitlines(), None
 
 
+def parse_last_local_timestamp(value):
+    for format_string in ("%a %b %d %H:%M:%S %z %Y", "%a %b %d %H:%M:%S %Y"):
+        try:
+            # The no-offset form is intentionally naive: timestamp() applies the
+            # host local timezone and historical DST rules used by GNU last -F.
+            return dt.datetime.strptime(value, format_string).timestamp()
+        except ValueError:
+            continue
+    return None
+
+
 def wtmp_collection(now, user, journal_reason):
     fixture = os.environ.get("AIDEVOPS_LAST_FIXTURE")
     if fixture:
@@ -235,20 +272,31 @@ def wtmp_collection(now, user, journal_reason):
             return {"status": "unavailable", "source": "linux-logind+wtmp", "reason": f"{journal_reason};wtmp-read-failed:exit-{result.returncode}", "intervals": []}
         lines = result.stdout.splitlines()
     intervals = []
+    skipped = 0
     for line in lines:
+        if not line.strip() or "wtmp begins" in line or line.startswith(("reboot", "shutdown")):
+            continue
         structured = re.match(r"^([0-9]+)\|([0-9]+)$", line.strip())
         if structured:
             intervals.append((float(structured.group(1)), float(structured.group(2))))
             continue
-        dates = re.findall(r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2}\s+[0-9]{1,2} [0-9:]{8} [0-9]{4}", line)
-        if len(dates) >= 2:
+        dates = re.findall(r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2}\s+[0-9]{1,2} [0-9:]{8}(?: [+-][0-9]{4})? [0-9]{4}", line)
+        if dates:
             try:
-                left = dt.datetime.strptime(dates[0], "%a %b %d %H:%M:%S %Y").replace(tzinfo=dt.timezone.utc).timestamp()
-                right = dt.datetime.strptime(dates[1], "%a %b %d %H:%M:%S %Y").replace(tzinfo=dt.timezone.utc).timestamp()
-                if right > left:
+                left = parse_last_local_timestamp(dates[0])
+                if "still logged in" in line:
+                    right = now
+                elif len(dates) >= 2:
+                    right = parse_last_local_timestamp(dates[1])
+                else:
+                    skipped += 1
+                    continue
+                if left is not None and right is not None and right > left:
                     intervals.append((left, right))
-            except ValueError:
-                continue
+            except (TypeError, ValueError):
+                skipped += 1
+        else:
+            skipped += 1
     if not intervals:
         return {"status": "unavailable", "source": "linux-logind+wtmp", "reason": f"{journal_reason};no-parseable-wtmp-sessions", "intervals": []}
     latest = max(right for _, right in intervals)
@@ -260,7 +308,9 @@ def wtmp_collection(now, user, journal_reason):
         "intervals": union_intervals(intervals, now - WINDOWS["year"], now),
         "observations": len(intervals),
         "latest_epoch": latest,
+        "earliest_epoch": min(left for left, _ in intervals),
         "freshness_hours": round(freshness, 1),
+        "skipped_rows": skipped,
     }
 
 
@@ -275,6 +325,7 @@ def linux_collection(now, user):
     intervals = []
     observations = 0
     latest = None
+    earliest_event = None
     start = now - WINDOWS["year"]
 
     def is_active():
@@ -322,6 +373,7 @@ def linux_collection(now, user):
             )
         observations += 1
         latest = timestamp if latest is None else max(latest, timestamp)
+        earliest_event = timestamp if earliest_event is None else min(earliest_event, timestamp)
         after = is_active()
         if before == after:
             continue
@@ -333,7 +385,7 @@ def linux_collection(now, user):
         intervals.append((opened, now))
     intervals = union_intervals(intervals, start, now)
     if observations == 0:
-        return {"status": "ok", "source": "linux-systemd-logind", "reason": "no-user-session-observations", "intervals": [], "observations": 0}
+        return wtmp_collection(now, user, "journal-readable-no-user-observations")
     freshness = max(0.0, (now - latest) / 3600)
     return {
         "status": "stale" if freshness > 72 else "ok",
@@ -342,6 +394,7 @@ def linux_collection(now, user):
         "intervals": intervals,
         "observations": observations,
         "latest_epoch": latest,
+        "earliest_epoch": earliest_event,
         "freshness_hours": round(freshness, 1),
     }
 
@@ -382,21 +435,29 @@ def period_payload(collection, now, seconds):
 
 def read_history(history_path, now):
     rows = {}
+    skipped = 0
     if not history_path or not history_path.exists():
-        return rows
+        return rows, skipped
     try:
         for line in history_path.read_text(encoding="utf-8").splitlines():
-            row = json.loads(line)
-            date = dt.date.fromisoformat(str(row.get("date")))
-            hours = max(0.0, min(24.0, float(row.get("screen_hours"))))
-            rows[date] = (hours, row)
-    except (OSError, ValueError, TypeError, json.JSONDecodeError):
-        return {}
-    return rows
+            try:
+                row = json.loads(line)
+                if not isinstance(row, dict) or isinstance(row.get("screen_hours"), bool):
+                    raise ValueError("invalid history row")
+                date = dt.date.fromisoformat(str(row.get("date")))
+                hours = float(row.get("screen_hours"))
+                if hours < 0 or not math.isfinite(hours):
+                    raise ValueError("invalid history row")
+                rows[date] = (min(24.0, hours), row)
+            except (ValueError, TypeError, json.JSONDecodeError):
+                skipped += 1
+    except OSError:
+        return {}, skipped + 1
+    return rows, skipped
 
 
-def history_period(rows, now, days):
-    end_date = dt.datetime.fromtimestamp(now, dt.timezone.utc).date()
+def history_period(rows, now, days, skipped_rows=0):
+    end_date = local_date(now)
     start_date = end_date - dt.timedelta(days=days)
     selected = [(date, value) for date, value in rows.items() if start_date <= date < end_date]
     if not selected:
@@ -416,18 +477,19 @@ def history_period(rows, now, days):
         "freshness_hours": latest_age * 24,
         "observations": len(selected),
         "estimated": False,
+        "skipped_history_rows": skipped_rows,
     }
 
 
 def profile_payload(collection, history_path, now):
     periods = {name: period_payload(collection, now, seconds) for name, seconds in WINDOWS.items()}
-    history = read_history(history_path, now)
+    history, skipped_history_rows = read_history(history_path, now)
     for name, days in (("day", 1), ("week", 7), ("month", 28)):
         if periods[name]["status"] == "unavailable":
-            fallback = history_period(history, now, days)
+            fallback = history_period(history, now, days, skipped_history_rows)
             if fallback:
                 periods[name] = fallback
-    year_history = history_period(history, now, 365)
+    year_history = history_period(history, now, 365, skipped_history_rows)
     if year_history:
         span = year_history.get("calendar_span_days", 0)
         observed = year_history.get("coverage_days", 0)
@@ -448,6 +510,7 @@ def profile_payload(collection, history_path, now):
         "month_note": periods["month"]["source"],
         "periods": periods,
         "collection_status": collection.get("status", "unavailable"),
+        "history_skipped_rows": skipped_history_rows,
     }
 
 
@@ -461,7 +524,7 @@ def collect(args):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=("profile", "query", "date", "earliest", "apps"))
+    parser.add_argument("command", choices=("profile", "query", "date", "earliest", "apps", "next-date", "history-summary"))
     parser.add_argument("--os-type", required=True)
     parser.add_argument("--db", default="")
     parser.add_argument("--history", default="")
@@ -470,10 +533,19 @@ def main():
     parser.add_argument("--now", type=float, default=float(os.environ.get("AIDEVOPS_SCREEN_TIME_NOW_EPOCH", "0") or 0))
     parser.add_argument("--user", default=os.environ.get("AIDEVOPS_SCREEN_TIME_USER", getpass.getuser()))
     args = parser.parse_args()
+    if hasattr(time, "tzset"):
+        time.tzset()
     if not args.now:
         args.now = dt.datetime.now(dt.timezone.utc).timestamp()
     if args.command == "apps":
         print(json.dumps(macos_app_stats(Path(args.db), args.now), sort_keys=True))
+        return 0
+    if args.command == "next-date":
+        print((dt.date.fromisoformat(args.date) + dt.timedelta(days=1)).isoformat())
+        return 0
+    if args.command == "history-summary":
+        rows, skipped = read_history(Path(args.history) if args.history else None, args.now)
+        print(json.dumps({"valid_rows": len(rows), "skipped_rows": skipped, "earliest": min(rows).isoformat() if rows else None, "latest": max(rows).isoformat() if rows else None, "total_hours": round(sum(value[0] for value in rows.values()), 1)}, sort_keys=True))
         return 0
     collection = collect(args)
     if args.command == "profile":
@@ -484,12 +556,15 @@ def main():
         print("unavailable" if payload["hours"] is None else payload["hours"])
     elif args.command == "date":
         target = dt.date.fromisoformat(args.date)
-        start = dt.datetime.combine(target, dt.time.min, tzinfo=dt.timezone.utc).timestamp()
-        hours = None if collection.get("status") == "unavailable" else round(interval_seconds(collection.get("intervals", []), start, start + DAY) / 3600, 1)
+        start, end = local_day_bounds(target)
+        hours = None if collection.get("status") == "unavailable" else round(min(24 * 3600, interval_seconds(collection.get("intervals", []), start, end)) / 3600, 1)
         print("unavailable" if hours is None else hours)
     else:
         starts = [left for left, _ in collection.get("intervals", [])]
-        print(dt.datetime.fromtimestamp(min(starts), dt.timezone.utc).date().isoformat() if starts else "")
+        earliest = collection.get("earliest_epoch")
+        if earliest is None and starts:
+            earliest = min(starts)
+        print(local_date(earliest).isoformat() if earliest is not None else "")
     return 0
 
 

--- a/.agents/scripts/screen-time-interval-engine.py
+++ b/.agents/scripts/screen-time-interval-engine.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import getpass
+import heapq
 import json
 import math
 import os
@@ -146,16 +147,25 @@ def macos_collection(db_path, now):
         source = "macos-knowledge-db:/display/isBacklit"
         latest = latest_backlit
         observations = len(backlit)
+        observation_epochs = [timestamp for timestamp, _ in backlit]
+        coverage_start = min(observation_epochs)
+        coverage_end = max(observation_epochs)
     elif apps:
         intervals = app_intervals
         source = "macos-knowledge-db:/app/usage-union"
         latest = latest_app
         observations = len(apps)
+        observation_epochs = []
+        coverage_start = min(start for start, _ in apps)
+        coverage_end = max(end for _, end in apps)
     elif backlit:
         intervals = backlit_intervals
         source = "macos-knowledge-db:/display/isBacklit-stale"
         latest = latest_backlit
         observations = len(backlit)
+        observation_epochs = [timestamp for timestamp, _ in backlit]
+        coverage_start = min(observation_epochs)
+        coverage_end = max(observation_epochs)
     else:
         return {"status": "unavailable", "source": "macos-knowledge-db:no-observations", "reason": "empty-readable-database", "intervals": [], "observations": 0}
     freshness = max(0.0, (now - latest) / 3600) if latest is not None else None
@@ -169,6 +179,9 @@ def macos_collection(db_path, now):
         "latest_epoch": latest,
         "earliest_epoch": min((item[0] for item in (backlit if use_backlit or not apps else apps)), default=latest),
         "freshness_hours": round(freshness, 1) if freshness is not None else None,
+        "observation_epochs": observation_epochs,
+        "coverage_start_epoch": coverage_start,
+        "coverage_end_epoch": coverage_end,
     }
 
 
@@ -176,34 +189,56 @@ def macos_app_stats(db_path, now):
     if not db_path.exists():
         return []
     try:
+        started_at = time.perf_counter()
         uri = f"file:{db_path}?mode=ro"
         with sqlite3.connect(uri, uri=True, timeout=5) as connection:
+            cutoff_cd = now - 28 * DAY - CORE_DATA_EPOCH
+            now_cd = now - CORE_DATA_EPOCH
             rows = connection.execute(
                 "SELECT ZVALUESTRING, ZSTARTDATE, ZENDDATE FROM ZOBJECT "
-                "WHERE ZSTREAMNAME='/app/usage' AND ZVALUESTRING IS NOT NULL"
+                "WHERE ZSTREAMNAME='/app/usage' AND ZVALUESTRING IS NOT NULL "
+                "AND ZENDDATE > ? AND ZSTARTDATE < ? ORDER BY ZSTARTDATE",
+                (cutoff_cd, now_cd),
             ).fetchall()
     except sqlite3.Error:
         return []
+    month_start = now - 28 * DAY
     intervals = [
-        (str(bundle), float(start) + CORE_DATA_EPOCH, float(end) + CORE_DATA_EPOCH)
+        (str(bundle), max(month_start, float(start) + CORE_DATA_EPOCH), min(now, float(end) + CORE_DATA_EPOCH), float(start) + CORE_DATA_EPOCH)
         for bundle, start, end in rows
-        if start is not None and end is not None and float(end) > float(start)
+        if start is not None and end is not None and float(end) > float(start) and float(end) + CORE_DATA_EPOCH > month_start and float(start) + CORE_DATA_EPOCH < now
     ]
-    totals = {}
-    for name, seconds in (("today", DAY), ("week", 7 * DAY), ("month", 28 * DAY)):
-        window_start = now - seconds
-        relevant = [(bundle, max(start, window_start), min(end, now), start) for bundle, start, end in intervals if end > window_start and start < now]
-        boundaries = sorted({value for _, left, right, _ in relevant for value in (left, right)})
-        per_app = {}
-        for left, right in zip(boundaries, boundaries[1:]):
-            active = [item for item in relevant if item[1] < right and item[2] > left]
-            if not active:
-                continue
-            # Knowledge DB foreground records can overlap or repeat. Attribute a
-            # segment once to the most recently started active record.
-            bundle = max(active, key=lambda item: item[3])[0]
-            per_app[bundle] = per_app.get(bundle, 0) + right - left
-        totals[name] = per_app
+    starts = {}
+    ends = {}
+    boundaries = {month_start, now}
+    for interval_id, (bundle, left, right, original_start) in enumerate(intervals):
+        starts.setdefault(left, []).append((interval_id, bundle, original_start))
+        ends.setdefault(right, []).append(interval_id)
+        boundaries.update((left, right))
+    ordered = sorted(boundaries)
+    active = set()
+    latest_start_heap = []
+    totals = {name: {} for name in ("today", "week", "month")}
+    window_starts = {"today": now - DAY, "week": now - 7 * DAY, "month": month_start}
+    attributed_segments = 0
+    max_active = 0
+    for left, right in zip(ordered, ordered[1:]):
+        for interval_id in ends.get(left, []):
+            active.discard(interval_id)
+        for interval_id, bundle, original_start in starts.get(left, []):
+            active.add(interval_id)
+            heapq.heappush(latest_start_heap, (-original_start, -interval_id, interval_id, bundle))
+        while latest_start_heap and latest_start_heap[0][2] not in active:
+            heapq.heappop(latest_start_heap)
+        max_active = max(max_active, len(active))
+        if not latest_start_heap or right <= left:
+            continue
+        bundle = latest_start_heap[0][3]
+        attributed_segments += 1
+        for name, window_start in window_starts.items():
+            overlap = right - max(left, window_start)
+            if overlap > 0:
+                totals[name][bundle] = totals[name].get(bundle, 0) + overlap
     month_total = sum(totals.get("month", {}).values())
     result = []
     for bundle, month_seconds in sorted(totals.get("month", {}).items(), key=lambda item: (-item[1], item[0]))[:10]:
@@ -213,6 +248,17 @@ def macos_app_stats(db_path, now):
             row[f"{name}_pct"] = round(totals.get(name, {}).get(bundle, 0) / denominator * 100) if denominator else 0
         row["month_seconds"] = round(month_seconds)
         result.append(row)
+    instrument_file = os.environ.get("AIDEVOPS_APP_STATS_INSTRUMENT_FILE")
+    if instrument_file:
+        instrumentation = {
+            "rows_selected": len(rows),
+            "valid_intervals": len(intervals),
+            "boundaries": len(ordered),
+            "attributed_segments": attributed_segments,
+            "max_active": max_active,
+            "elapsed_ms": round((time.perf_counter() - started_at) * 1000, 3),
+        }
+        Path(instrument_file).write_text(json.dumps(instrumentation, sort_keys=True) + "\n", encoding="utf-8")
     return result if month_total else []
 
 
@@ -311,6 +357,9 @@ def wtmp_collection(now, user, journal_reason):
         "earliest_epoch": min(left for left, _ in intervals),
         "freshness_hours": round(freshness, 1),
         "skipped_rows": skipped,
+        "observation_epochs": [],
+        "coverage_start_epoch": min(left for left, _ in intervals),
+        "coverage_end_epoch": max(right for _, right in intervals),
     }
 
 
@@ -324,6 +373,7 @@ def linux_collection(now, user):
     opened = None
     intervals = []
     observations = 0
+    observation_epochs = []
     latest = None
     earliest_event = None
     start = now - WINDOWS["year"]
@@ -372,6 +422,7 @@ def linux_collection(now, user):
                 file=sys.stderr,
             )
         observations += 1
+        observation_epochs.append(timestamp)
         latest = timestamp if latest is None else max(latest, timestamp)
         earliest_event = timestamp if earliest_event is None else min(earliest_event, timestamp)
         after = is_active()
@@ -396,6 +447,9 @@ def linux_collection(now, user):
         "latest_epoch": latest,
         "earliest_epoch": earliest_event,
         "freshness_hours": round(freshness, 1),
+        "observation_epochs": observation_epochs,
+        "coverage_start_epoch": min(observation_epochs),
+        "coverage_end_epoch": max(observation_epochs),
     }
 
 
@@ -557,7 +611,14 @@ def main():
     elif args.command == "date":
         target = dt.date.fromisoformat(args.date)
         start, end = local_day_bounds(target)
-        hours = None if collection.get("status") == "unavailable" else round(min(24 * 3600, interval_seconds(collection.get("intervals", []), start, end)) / 3600, 1)
+        observations = collection.get("observation_epochs", [])
+        intervals = collection.get("intervals", [])
+        coverage_end = collection.get("coverage_end_epoch")
+        explicit_event = any(start <= timestamp < end for timestamp in observations)
+        interval_overlap = any(right > start and left < end for left, right in intervals)
+        within_coverage = coverage_end is not None and start <= coverage_end
+        observed_date = within_coverage and (explicit_event or interval_overlap)
+        hours = None if collection.get("status") == "unavailable" or not observed_date else round(min(24 * 3600, interval_seconds(intervals, start, end)) / 3600, 1)
         print("unavailable" if hours is None else hours)
     else:
         starts = [left for left, _ in collection.get("intervals", [])]

--- a/.agents/scripts/screen-time-interval-engine.py
+++ b/.agents/scripts/screen-time-interval-engine.py
@@ -146,6 +146,50 @@ def macos_collection(db_path, now):
     }
 
 
+def macos_app_stats(db_path, now):
+    if not db_path.exists():
+        return []
+    try:
+        uri = f"file:{db_path}?mode=ro"
+        with sqlite3.connect(uri, uri=True, timeout=5) as connection:
+            rows = connection.execute(
+                "SELECT ZVALUESTRING, ZSTARTDATE, ZENDDATE FROM ZOBJECT "
+                "WHERE ZSTREAMNAME='/app/usage' AND ZVALUESTRING IS NOT NULL"
+            ).fetchall()
+    except sqlite3.Error:
+        return []
+    intervals = [
+        (str(bundle), float(start) + CORE_DATA_EPOCH, float(end) + CORE_DATA_EPOCH)
+        for bundle, start, end in rows
+        if start is not None and end is not None and float(end) > float(start)
+    ]
+    totals = {}
+    for name, seconds in (("today", DAY), ("week", 7 * DAY), ("month", 28 * DAY)):
+        window_start = now - seconds
+        relevant = [(bundle, max(start, window_start), min(end, now), start) for bundle, start, end in intervals if end > window_start and start < now]
+        boundaries = sorted({value for _, left, right, _ in relevant for value in (left, right)})
+        per_app = {}
+        for left, right in zip(boundaries, boundaries[1:]):
+            active = [item for item in relevant if item[1] < right and item[2] > left]
+            if not active:
+                continue
+            # Knowledge DB foreground records can overlap or repeat. Attribute a
+            # segment once to the most recently started active record.
+            bundle = max(active, key=lambda item: item[3])[0]
+            per_app[bundle] = per_app.get(bundle, 0) + right - left
+        totals[name] = per_app
+    month_total = sum(totals.get("month", {}).values())
+    result = []
+    for bundle, month_seconds in sorted(totals.get("month", {}).items(), key=lambda item: (-item[1], item[0]))[:10]:
+        row = {"bundle": bundle}
+        for name in ("today", "week", "month"):
+            denominator = sum(totals.get(name, {}).values())
+            row[f"{name}_pct"] = round(totals.get(name, {}).get(bundle, 0) / denominator * 100) if denominator else 0
+        row["month_seconds"] = round(month_seconds)
+        result.append(row)
+    return result if month_total else []
+
+
 SESSION_NEW = re.compile(r"New session ([A-Za-z0-9_.-]+) of user ([^ .]+)", re.I)
 SESSION_END = re.compile(r"(?:Removed session|Session) ([A-Za-z0-9_.-]+)(?: logged out)?", re.I)
 SESSION_ID = re.compile(r"Session ([A-Za-z0-9_.-]+)", re.I)
@@ -173,10 +217,57 @@ def journal_lines(now):
     return result.stdout.splitlines(), None
 
 
+def wtmp_collection(now, user, journal_reason):
+    fixture = os.environ.get("AIDEVOPS_LAST_FIXTURE")
+    if fixture:
+        try:
+            lines = Path(fixture).read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            return {"status": "unavailable", "source": "linux-wtmp", "reason": f"fixture-read-failed:{type(exc).__name__}", "intervals": []}
+    else:
+        try:
+            result = subprocess.run(
+                ["last", "-F", "-s", "-365days", user], check=False, capture_output=True, text=True, timeout=30
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return {"status": "unavailable", "source": "linux-logind+wtmp", "reason": f"{journal_reason};wtmp-read-failed:{type(exc).__name__}", "intervals": []}
+        if result.returncode != 0:
+            return {"status": "unavailable", "source": "linux-logind+wtmp", "reason": f"{journal_reason};wtmp-read-failed:exit-{result.returncode}", "intervals": []}
+        lines = result.stdout.splitlines()
+    intervals = []
+    for line in lines:
+        structured = re.match(r"^([0-9]+)\|([0-9]+)$", line.strip())
+        if structured:
+            intervals.append((float(structured.group(1)), float(structured.group(2))))
+            continue
+        dates = re.findall(r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2}\s+[0-9]{1,2} [0-9:]{8} [0-9]{4}", line)
+        if len(dates) >= 2:
+            try:
+                left = dt.datetime.strptime(dates[0], "%a %b %d %H:%M:%S %Y").replace(tzinfo=dt.timezone.utc).timestamp()
+                right = dt.datetime.strptime(dates[1], "%a %b %d %H:%M:%S %Y").replace(tzinfo=dt.timezone.utc).timestamp()
+                if right > left:
+                    intervals.append((left, right))
+            except ValueError:
+                continue
+    if not intervals:
+        return {"status": "unavailable", "source": "linux-logind+wtmp", "reason": f"{journal_reason};no-parseable-wtmp-sessions", "intervals": []}
+    latest = max(right for _, right in intervals)
+    freshness = max(0.0, (now - latest) / 3600)
+    return {
+        "status": "stale" if freshness > 72 else "ok",
+        "source": "linux-wtmp:login-session-proxy",
+        "reason": f"logind-unavailable:{journal_reason}",
+        "intervals": union_intervals(intervals, now - WINDOWS["year"], now),
+        "observations": len(intervals),
+        "latest_epoch": latest,
+        "freshness_hours": round(freshness, 1),
+    }
+
+
 def linux_collection(now, user):
     lines, error = journal_lines(now)
     if error:
-        return {"status": "unavailable", "source": "linux-systemd-logind", "reason": error, "intervals": []}
+        return wtmp_collection(now, user, error)
     sessions = {}
     lid_open = True
     active = False
@@ -370,7 +461,7 @@ def collect(args):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=("profile", "query", "date", "earliest"))
+    parser.add_argument("command", choices=("profile", "query", "date", "earliest", "apps"))
     parser.add_argument("--os-type", required=True)
     parser.add_argument("--db", default="")
     parser.add_argument("--history", default="")
@@ -381,6 +472,9 @@ def main():
     args = parser.parse_args()
     if not args.now:
         args.now = dt.datetime.now(dt.timezone.utc).timestamp()
+    if args.command == "apps":
+        print(json.dumps(macos_app_stats(Path(args.db), args.now), sort_keys=True))
+        return 0
     collection = collect(args)
     if args.command == "profile":
         payload = profile_payload(collection, Path(args.history) if args.history else None, args.now)

--- a/.agents/scripts/screen-time-interval-engine.py
+++ b/.agents/scripts/screen-time-interval-engine.py
@@ -326,22 +326,25 @@ def read_wtmp_lines(user, journal_reason):
 
 
 def parse_wtmp_line(line, now):
-    if not line.strip() or "wtmp begins" in line or line.startswith(("reboot", "shutdown")):
-        return None, False
-    structured = re.match(r"^([0-9]+)\|([0-9]+)$", line.strip())
-    if structured:
-        return (float(structured.group(1)), float(structured.group(2))), False
-    dates = re.findall(r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2}\s+[0-9]{1,2} [0-9:]{8}(?: [+-][0-9]{4})? [0-9]{4}", line)
-    if not dates:
-        return None, True
-    try:
-        left = parse_last_local_timestamp(dates[0])
-        right = now if "still logged in" in line else parse_last_local_timestamp(dates[1]) if len(dates) >= 2 else None
-    except (TypeError, ValueError):
-        return None, True
-    if left is None or right is None or right <= left:
-        return None, True
-    return (left, right), False
+    interval = None
+    malformed = False
+    ignored = not line.strip() or "wtmp begins" in line or line.startswith(("reboot", "shutdown"))
+    if not ignored:
+        structured = re.match(r"^([0-9]+)\|([0-9]+)$", line.strip())
+        if structured:
+            interval = (float(structured.group(1)), float(structured.group(2)))
+        else:
+            dates = re.findall(r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2}\s+[0-9]{1,2} [0-9:]{8}(?: [+-][0-9]{4})? [0-9]{4}", line)
+            try:
+                left = parse_last_local_timestamp(dates[0]) if dates else None
+                right = now if "still logged in" in line else parse_last_local_timestamp(dates[1]) if len(dates) >= 2 else None
+                if left is not None and right is not None and right > left:
+                    interval = (left, right)
+                else:
+                    malformed = True
+            except (TypeError, ValueError):
+                malformed = True
+    return interval, malformed
 
 
 def parse_wtmp_lines(lines, now):
@@ -386,28 +389,56 @@ def linux_is_active(state):
 
 
 def apply_linux_message(state, message, user):
+    recognized = True
     match = SESSION_NEW.search(message)
     if match and match.group(2) == user:
         state["sessions"][match.group(1).rstrip(".")] = False
-        return True
-    lowered = message.lower()
-    match = SESSION_ID.search(message) if "locked" in lowered else None
-    session_id = match.group(1).rstrip(".") if match else ""
-    if session_id in state["sessions"]:
-        state["sessions"][session_id] = "unlocked" not in lowered
-        return True
-    if "Lid closed" in message:
+    elif "Lid closed" in message:
         state["lid_open"] = False
-        return True
-    if "Lid opened" in message:
+    elif "Lid opened" in message:
         state["lid_open"] = True
-        return True
-    match = SESSION_END.search(message)
-    session_id = match.group(1).rstrip(".") if match else ""
-    if session_id in state["sessions"]:
-        state["sessions"].pop(session_id, None)
-        return True
-    return False
+    else:
+        lowered = message.lower()
+        lock_match = SESSION_ID.search(message) if "locked" in lowered else None
+        lock_session_id = lock_match.group(1).rstrip(".") if lock_match else ""
+        end_match = SESSION_END.search(message)
+        end_session_id = end_match.group(1).rstrip(".") if end_match else ""
+        if lock_session_id in state["sessions"]:
+            state["sessions"][lock_session_id] = "unlocked" not in lowered
+        elif end_session_id in state["sessions"]:
+            state["sessions"].pop(end_session_id, None)
+        else:
+            recognized = False
+    return recognized
+
+
+def parse_linux_journal_line(line, now):
+    first = line.split(None, 1)
+    timestamp = parse_timestamp(first[0]) if len(first) == 2 else None
+    if timestamp is None or timestamp > now:
+        return None
+    return timestamp, first[1]
+
+
+def debug_linux_event(timestamp, before, after, state, message):
+    if os.environ.get("AIDEVOPS_SCREEN_TIME_DEBUG") == "1":
+        print(
+            f"screen-time event ts={timestamp} before={before} after={after} sessions={state['sessions']} lid_open={state['lid_open']} message={message}",
+            file=sys.stderr,
+        )
+
+
+def apply_linux_event(state, message, user, timestamp, opened, intervals):
+    before = linux_is_active(state)
+    if not apply_linux_message(state, message, user):
+        return opened, before, False
+    after = linux_is_active(state)
+    debug_linux_event(timestamp, before, after, state, message)
+    if before != after:
+        if before and opened is not None:
+            intervals.append((opened, timestamp))
+        opened = timestamp if after else None
+    return opened, after, True
 
 
 def collect_linux_events(lines, now, user):
@@ -417,29 +448,13 @@ def collect_linux_events(lines, now, user):
     opened = None
     active = False
     for line in lines:
-        first = line.split(None, 1)
-        if len(first) != 2:
+        event = parse_linux_journal_line(line, now)
+        if event is None:
             continue
-        timestamp = parse_timestamp(first[0])
-        if timestamp is None or timestamp > now:
-            continue
-        message = first[1]
-        before = linux_is_active(state)
-        if not apply_linux_message(state, message, user):
-            continue
-        after = linux_is_active(state)
-        if os.environ.get("AIDEVOPS_SCREEN_TIME_DEBUG") == "1":
-            print(
-                f"screen-time event ts={timestamp} before={before} after={after} sessions={state['sessions']} lid_open={state['lid_open']} message={message}",
-                file=sys.stderr,
-            )
-        observation_epochs.append(timestamp)
-        if before == after:
-            continue
-        if before and opened is not None:
-            intervals.append((opened, timestamp))
-        opened = timestamp if after else None
-        active = after
+        timestamp, message = event
+        opened, active, recognized = apply_linux_event(state, message, user, timestamp, opened, intervals)
+        if recognized:
+            observation_epochs.append(timestamp)
     if active and opened is not None:
         intervals.append((opened, now))
     return union_intervals(intervals, now - WINDOWS["year"], now), observation_epochs

--- a/.agents/scripts/screen-time-interval-engine.py
+++ b/.agents/scripts/screen-time-interval-engine.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Deterministic screen-time interval collection and aggregation."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import getpass
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+CORE_DATA_EPOCH = 978307200
+DAY = 86400
+WINDOWS = {"day": DAY, "week": 7 * DAY, "month": 28 * DAY, "year": 365 * DAY}
+
+
+def union_intervals(intervals, start, end):
+    clipped = sorted((max(start, a), min(end, b)) for a, b in intervals if b > start and a < end)
+    merged = []
+    for left, right in clipped:
+        if right <= left:
+            continue
+        if merged and left <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], right))
+        else:
+            merged.append((left, right))
+    return merged
+
+
+def interval_seconds(intervals, start, end):
+    return min(end - start, sum(right - left for left, right in union_intervals(intervals, start, end)))
+
+
+def parse_timestamp(value):
+    value = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = dt.datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed.timestamp()
+    except ValueError:
+        return None
+
+
+def state_intervals(events, start, end, initial=False):
+    state = initial
+    opened = start if state else None
+    intervals = []
+    for timestamp, new_state in sorted(events):
+        if timestamp < start:
+            state = new_state
+            opened = start if state else None
+            continue
+        if timestamp > end:
+            break
+        if new_state == state:
+            continue
+        if state and opened is not None:
+            intervals.append((opened, timestamp))
+        state = new_state
+        opened = timestamp if state else None
+    if state and opened is not None and opened < end:
+        intervals.append((opened, end))
+    return union_intervals(intervals, start, end)
+
+
+def macos_collection(db_path, now):
+    if not db_path.exists():
+        return {"status": "unavailable", "source": "macos-knowledge-db", "reason": "database-missing", "intervals": []}
+    try:
+        uri = f"file:{db_path}?mode=ro"
+        with sqlite3.connect(uri, uri=True, timeout=5) as connection:
+            backlit_rows = connection.execute(
+                "SELECT ZCREATIONDATE, ZVALUEINTEGER FROM ZOBJECT "
+                "WHERE ZSTREAMNAME='/display/isBacklit' ORDER BY ZCREATIONDATE"
+            ).fetchall()
+            app_rows = connection.execute(
+                "SELECT ZSTARTDATE, ZENDDATE FROM ZOBJECT "
+                "WHERE ZSTREAMNAME='/app/usage' ORDER BY ZSTARTDATE"
+            ).fetchall()
+    except (OSError, sqlite3.Error) as exc:
+        return {"status": "unavailable", "source": "macos-knowledge-db", "reason": f"database-read-failed:{type(exc).__name__}", "intervals": []}
+
+    backlit = [(float(timestamp) + CORE_DATA_EPOCH, bool(state)) for timestamp, state in backlit_rows if timestamp is not None]
+    apps = [
+        (float(start) + CORE_DATA_EPOCH, float(end) + CORE_DATA_EPOCH)
+        for start, end in app_rows
+        if start is not None and end is not None and float(end) > float(start)
+    ]
+    latest_backlit = max((item[0] for item in backlit), default=None)
+    latest_app = max((item[1] for item in apps), default=None)
+    earliest = now - WINDOWS["year"]
+    backlit_intervals = state_intervals(backlit, earliest, now)
+    app_intervals = union_intervals(apps, earliest, now)
+
+    def active_dates(intervals, window_days=28):
+        dates = set()
+        window_start = now - window_days * DAY
+        for left, right in union_intervals(intervals, window_start, now):
+            cursor = dt.datetime.fromtimestamp(left, dt.timezone.utc).date()
+            final = dt.datetime.fromtimestamp(max(left, right - 1), dt.timezone.utc).date()
+            while cursor <= final:
+                dates.add(cursor)
+                cursor += dt.timedelta(days=1)
+        return dates
+
+    backlit_dates = active_dates(backlit_intervals)
+    app_dates = active_dates(app_intervals)
+    use_backlit = (
+        latest_backlit is not None
+        and now - latest_backlit <= 3 * DAY
+        and not (len(backlit_dates) <= 1 and len(app_dates) >= 2)
+    )
+    if use_backlit:
+        intervals = backlit_intervals
+        source = "macos-knowledge-db:/display/isBacklit"
+        latest = latest_backlit
+        observations = len(backlit)
+    elif apps:
+        intervals = app_intervals
+        source = "macos-knowledge-db:/app/usage-union"
+        latest = latest_app
+        observations = len(apps)
+    elif backlit:
+        intervals = backlit_intervals
+        source = "macos-knowledge-db:/display/isBacklit-stale"
+        latest = latest_backlit
+        observations = len(backlit)
+    else:
+        return {"status": "ok", "source": "macos-knowledge-db:no-observations", "reason": "empty-readable-database", "intervals": [], "observations": 0}
+    freshness = max(0.0, (now - latest) / 3600) if latest is not None else None
+    status = "stale" if freshness is not None and freshness > 72 else "ok"
+    return {
+        "status": status,
+        "source": source,
+        "reason": "source-observations",
+        "intervals": intervals,
+        "observations": observations,
+        "latest_epoch": latest,
+        "freshness_hours": round(freshness, 1) if freshness is not None else None,
+    }
+
+
+SESSION_NEW = re.compile(r"New session ([A-Za-z0-9_.-]+) of user ([^ .]+)", re.I)
+SESSION_END = re.compile(r"(?:Removed session|Session) ([A-Za-z0-9_.-]+)(?: logged out)?", re.I)
+SESSION_ID = re.compile(r"Session ([A-Za-z0-9_.-]+)", re.I)
+
+
+def journal_lines(now):
+    fixture = os.environ.get("AIDEVOPS_LOGIND_FIXTURE")
+    if fixture:
+        try:
+            return Path(fixture).read_text(encoding="utf-8").splitlines(), None
+        except OSError as exc:
+            return [], f"fixture-read-failed:{type(exc).__name__}"
+    try:
+        result = subprocess.run(
+            ["journalctl", "--since", "366 days ago", "-u", "systemd-logind.service", "--no-pager", "-o", "short-iso"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return [], f"journal-read-failed:{type(exc).__name__}"
+    if result.returncode != 0:
+        return [], f"journal-read-failed:exit-{result.returncode}"
+    return result.stdout.splitlines(), None
+
+
+def linux_collection(now, user):
+    lines, error = journal_lines(now)
+    if error:
+        return {"status": "unavailable", "source": "linux-systemd-logind", "reason": error, "intervals": []}
+    sessions = {}
+    lid_open = True
+    active = False
+    opened = None
+    intervals = []
+    observations = 0
+    latest = None
+    start = now - WINDOWS["year"]
+
+    def is_active():
+        return lid_open and any(not locked for locked in sessions.values())
+
+    for line in lines:
+        first = line.split(None, 1)
+        if len(first) != 2:
+            continue
+        timestamp = parse_timestamp(first[0])
+        if timestamp is None or timestamp > now:
+            continue
+        message = first[1]
+        before = is_active()
+        recognized = False
+        match = SESSION_NEW.search(message)
+        if match and match.group(2) == user:
+            sessions[match.group(1).rstrip(".")] = False
+            recognized = True
+        else:
+            lowered = message.lower()
+            match = SESSION_ID.search(message) if "locked" in lowered else None
+            session_id = match.group(1).rstrip(".") if match else ""
+            if session_id in sessions:
+                sessions[session_id] = "unlocked" not in lowered
+                recognized = True
+            elif "Lid closed" in message:
+                lid_open = False
+                recognized = True
+            elif "Lid opened" in message:
+                lid_open = True
+                recognized = True
+            else:
+                match = SESSION_END.search(message)
+                session_id = match.group(1).rstrip(".") if match else ""
+                if session_id in sessions:
+                    sessions.pop(session_id, None)
+                    recognized = True
+        if not recognized:
+            continue
+        if os.environ.get("AIDEVOPS_SCREEN_TIME_DEBUG") == "1":
+            print(
+                f"screen-time event ts={timestamp} before={before} after={is_active()} sessions={sessions} lid_open={lid_open} message={message}",
+                file=sys.stderr,
+            )
+        observations += 1
+        latest = timestamp if latest is None else max(latest, timestamp)
+        after = is_active()
+        if before == after:
+            continue
+        if before and opened is not None:
+            intervals.append((opened, timestamp))
+        opened = timestamp if after else None
+        active = after
+    if active and opened is not None:
+        intervals.append((opened, now))
+    intervals = union_intervals(intervals, start, now)
+    if observations == 0:
+        return {"status": "ok", "source": "linux-systemd-logind", "reason": "no-user-session-observations", "intervals": [], "observations": 0}
+    freshness = max(0.0, (now - latest) / 3600)
+    return {
+        "status": "stale" if freshness > 72 else "ok",
+        "source": "linux-systemd-logind:session-lid-lock-state",
+        "reason": "source-observations",
+        "intervals": intervals,
+        "observations": observations,
+        "latest_epoch": latest,
+        "freshness_hours": round(freshness, 1),
+    }
+
+
+def coverage(collection, start, end):
+    timestamps = []
+    for left, right in collection.get("intervals", []):
+        if right > start and left < end:
+            timestamps.extend((max(left, start), min(right, end)))
+    latest = collection.get("latest_epoch")
+    if latest is not None and latest >= start:
+        timestamps.append(min(latest, end))
+    if not timestamps:
+        return 0.0, 0.0
+    observed_start = max(start, min(timestamps))
+    observed_end = min(end, max(timestamps))
+    days = min((end - start) / DAY, max(1.0, (observed_end - observed_start) / DAY + 1.0))
+    return round(days, 1), round(days / ((end - start) / DAY) * 100, 1)
+
+
+def period_payload(collection, now, seconds):
+    start = now - seconds
+    observed_days, coverage_pct = coverage(collection, start, now)
+    status = collection.get("status", "unavailable")
+    hours = None if status == "unavailable" else round(interval_seconds(collection.get("intervals", []), start, now) / 3600, 1)
+    return {
+        "hours": hours,
+        "status": status,
+        "source": collection.get("source", "unknown"),
+        "reason": collection.get("reason", "unknown"),
+        "coverage_days": observed_days,
+        "coverage_pct": coverage_pct,
+        "freshness_hours": collection.get("freshness_hours"),
+        "observations": collection.get("observations", 0),
+        "estimated": False,
+    }
+
+
+def read_history(history_path, now):
+    rows = {}
+    if not history_path or not history_path.exists():
+        return rows
+    try:
+        for line in history_path.read_text(encoding="utf-8").splitlines():
+            row = json.loads(line)
+            date = dt.date.fromisoformat(str(row.get("date")))
+            hours = max(0.0, min(24.0, float(row.get("screen_hours"))))
+            rows[date] = (hours, row)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        return {}
+    return rows
+
+
+def history_period(rows, now, days):
+    end_date = dt.datetime.fromtimestamp(now, dt.timezone.utc).date()
+    start_date = end_date - dt.timedelta(days=days)
+    selected = [(date, value) for date, value in rows.items() if start_date <= date < end_date]
+    if not selected:
+        return None
+    dates = [item[0] for item in selected]
+    total = round(sum(item[1][0] for item in selected), 1)
+    span = max(1, (max(dates) - min(dates)).days + 1)
+    latest_age = (end_date - max(dates)).days
+    return {
+        "hours": min(days * 24.0, total),
+        "status": "stale" if latest_age > 2 else "ok",
+        "source": "screen-time-history:daily-observations",
+        "reason": "live-source-unavailable",
+        "coverage_days": len(selected),
+        "calendar_span_days": span,
+        "coverage_pct": round(len(selected) / days * 100, 1),
+        "freshness_hours": latest_age * 24,
+        "observations": len(selected),
+        "estimated": False,
+    }
+
+
+def profile_payload(collection, history_path, now):
+    periods = {name: period_payload(collection, now, seconds) for name, seconds in WINDOWS.items()}
+    history = read_history(history_path, now)
+    for name, days in (("day", 1), ("week", 7), ("month", 28)):
+        if periods[name]["status"] == "unavailable":
+            fallback = history_period(history, now, days)
+            if fallback:
+                periods[name] = fallback
+    year_history = history_period(history, now, 365)
+    if year_history:
+        span = year_history.get("calendar_span_days", 0)
+        observed = year_history.get("coverage_days", 0)
+        if span >= 330:
+            periods["year"] = year_history
+        elif span > 0 and observed > 0:
+            estimate = min(8760.0, year_history["hours"] / span * 365)
+            periods["year"] = dict(year_history, hours=round(estimate, 1), estimated=True, reason="calendar-span-extrapolation")
+    elif periods["year"]["status"] != "unavailable" and periods["month"]["coverage_days"] > 0:
+        base = periods["month"]
+        estimate = min(8760.0, (base["hours"] or 0) / base["coverage_days"] * 365)
+        periods["year"] = dict(base, hours=round(estimate, 1), estimated=True, reason="observed-calendar-coverage-extrapolation")
+    return {
+        "today_hours": periods["day"]["hours"],
+        "week_hours": periods["week"]["hours"],
+        "month_hours": periods["month"]["hours"],
+        "year_hours": periods["year"]["hours"],
+        "month_note": periods["month"]["source"],
+        "periods": periods,
+        "collection_status": collection.get("status", "unavailable"),
+    }
+
+
+def collect(args):
+    if args.os_type == "Darwin":
+        return macos_collection(Path(args.db), args.now)
+    if args.os_type == "Linux":
+        return linux_collection(args.now, args.user)
+    return {"status": "unavailable", "source": "unsupported-platform", "reason": args.os_type, "intervals": []}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("profile", "query", "date", "earliest"))
+    parser.add_argument("--os-type", required=True)
+    parser.add_argument("--db", default="")
+    parser.add_argument("--history", default="")
+    parser.add_argument("--days", type=int, default=1)
+    parser.add_argument("--date", default="")
+    parser.add_argument("--now", type=float, default=float(os.environ.get("AIDEVOPS_SCREEN_TIME_NOW_EPOCH", "0") or 0))
+    parser.add_argument("--user", default=os.environ.get("AIDEVOPS_SCREEN_TIME_USER", getpass.getuser()))
+    args = parser.parse_args()
+    if not args.now:
+        args.now = dt.datetime.now(dt.timezone.utc).timestamp()
+    collection = collect(args)
+    if args.command == "profile":
+        payload = profile_payload(collection, Path(args.history) if args.history else None, args.now)
+        print(json.dumps(payload, sort_keys=True))
+    elif args.command == "query":
+        payload = period_payload(collection, args.now, max(1, args.days) * DAY)
+        print("unavailable" if payload["hours"] is None else payload["hours"])
+    elif args.command == "date":
+        target = dt.date.fromisoformat(args.date)
+        start = dt.datetime.combine(target, dt.time.min, tzinfo=dt.timezone.utc).timestamp()
+        hours = None if collection.get("status") == "unavailable" else round(interval_seconds(collection.get("intervals", []), start, start + DAY) / 3600, 1)
+        print("unavailable" if hours is None else hours)
+    else:
+        starts = [left for left, _ in collection.get("intervals", [])]
+        print(dt.datetime.fromtimestamp(min(starts), dt.timezone.utc).date().isoformat() if starts else "")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/scripts/screen_time_history.py
+++ b/.agents/scripts/screen_time_history.py
@@ -1,0 +1,141 @@
+"""Screen-time period payloads and history fallback aggregation."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+
+from screen_time_interval_common import WINDOWS, interval_seconds, local_date
+
+
+def coverage(collection, start, end):
+    timestamps = []
+    for left, right in collection.get("intervals", []):
+        if right > start and left < end:
+            timestamps.extend((max(left, start), min(right, end)))
+    latest = collection.get("latest_epoch")
+    if latest is not None and latest >= start:
+        timestamps.append(min(latest, end))
+    if not timestamps:
+        return 0.0, 0.0
+    observed_start = max(start, min(timestamps))
+    observed_end = min(end, max(timestamps))
+    window_days = (end - start) / 86400
+    days = min(window_days, max(1.0, (observed_end - observed_start) / 86400 + 1.0))
+    return round(days, 1), round(days / window_days * 100, 1)
+
+
+def period_payload(collection, now, seconds):
+    start = now - seconds
+    observed_days, coverage_pct = coverage(collection, start, now)
+    status = collection.get("status", "unavailable")
+    hours = None if status == "unavailable" else round(interval_seconds(collection.get("intervals", []), start, now) / 3600, 1)
+    return {
+        "hours": hours,
+        "status": status,
+        "source": collection.get("source", "unknown"),
+        "reason": collection.get("reason", "unknown"),
+        "coverage_days": observed_days,
+        "coverage_pct": coverage_pct,
+        "freshness_hours": collection.get("freshness_hours"),
+        "observations": collection.get("observations", 0),
+        "estimated": False,
+    }
+
+
+def parse_history_row(line):
+    try:
+        row = json.loads(line)
+        if not isinstance(row, dict) or isinstance(row.get("screen_hours"), bool):
+            return None
+        date = dt.date.fromisoformat(str(row.get("date")))
+        hours = float(row.get("screen_hours"))
+        if hours < 0 or not math.isfinite(hours):
+            return None
+        return date, (min(24.0, hours), row)
+    except (ValueError, TypeError, json.JSONDecodeError):
+        return None
+
+
+def read_history(history_path, _now):
+    rows = {}
+    skipped = 0
+    if history_path is None or not history_path.is_file():
+        return rows, skipped
+    try:
+        lines = history_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}, 1
+    for line in lines:
+        parsed = parse_history_row(line)
+        if parsed is None:
+            skipped += 1
+        else:
+            rows[parsed[0]] = parsed[1]
+    return rows, skipped
+
+
+def history_period(rows, now, days, skipped_rows=0):
+    end_date = local_date(now)
+    if end_date is None:
+        return None
+    start_date = end_date - dt.timedelta(days=days)
+    selected = [(date, value) for date, value in rows.items() if start_date <= date < end_date]
+    if not selected:
+        return None
+    dates = [item[0] for item in selected]
+    total = round(sum(item[1][0] for item in selected), 1)
+    span = max(1, (max(dates) - min(dates)).days + 1)
+    latest_age = (end_date - max(dates)).days
+    return {
+        "hours": min(days * 24.0, total),
+        "status": "stale" if latest_age > 2 else "ok",
+        "source": "screen-time-history:daily-observations",
+        "reason": "live-source-unavailable",
+        "coverage_days": len(selected),
+        "calendar_span_days": span,
+        "coverage_pct": round(len(selected) / days * 100, 1),
+        "freshness_hours": latest_age * 24,
+        "observations": len(selected),
+        "estimated": False,
+        "skipped_history_rows": skipped_rows,
+    }
+
+
+def apply_short_history(periods, history, now, skipped):
+    for name, days in (("day", 1), ("week", 7), ("month", 28)):
+        fallback = history_period(history, now, days, skipped)
+        if periods[name]["status"] == "unavailable" and fallback:
+            periods[name] = fallback
+
+
+def estimated_year(periods, history, now, skipped):
+    year = history_period(history, now, 365, skipped)
+    if year and year.get("calendar_span_days", 0) >= 330:
+        return year
+    if year and year.get("coverage_days", 0) > 0:
+        estimate = min(8760.0, year["hours"] / year["calendar_span_days"] * 365)
+        return dict(year, hours=round(estimate, 1), estimated=True, reason="calendar-span-extrapolation")
+    month = periods["month"]
+    if periods["year"]["status"] != "unavailable" and month["coverage_days"] > 0:
+        estimate = min(8760.0, (month["hours"] or 0) / month["coverage_days"] * 365)
+        return dict(month, hours=round(estimate, 1), estimated=True, reason="observed-calendar-coverage-extrapolation")
+    return periods["year"]
+
+
+def profile_payload(collection, history_path, now):
+    periods = {name: period_payload(collection, now, seconds) for name, seconds in WINDOWS.items()}
+    history, skipped = read_history(history_path, now)
+    apply_short_history(periods, history, now, skipped)
+    periods["year"] = estimated_year(periods, history, now, skipped)
+    return {
+        "today_hours": periods["day"]["hours"],
+        "week_hours": periods["week"]["hours"],
+        "month_hours": periods["month"]["hours"],
+        "year_hours": periods["year"]["hours"],
+        "month_note": periods["month"]["source"],
+        "periods": periods,
+        "collection_status": collection.get("status", "unavailable"),
+        "history_skipped_rows": skipped,
+    }

--- a/.agents/scripts/screen_time_interval_common.py
+++ b/.agents/scripts/screen_time_interval_common.py
@@ -1,0 +1,119 @@
+"""Shared, defensive interval primitives for screen-time collectors."""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+
+CORE_DATA_EPOCH = 978307200
+DAY = 86400
+WINDOWS = {"day": DAY, "week": 7 * DAY, "month": 28 * DAY, "year": 365 * DAY}
+
+
+def safe_float(value):
+    if isinstance(value, bool):
+        return None
+    try:
+        converted = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return converted if math.isfinite(converted) else None
+
+
+def local_date(timestamp):
+    converted = safe_float(timestamp)
+    if converted is None:
+        return None
+    try:
+        return dt.datetime.fromtimestamp(converted).date()
+    except (OSError, OverflowError, ValueError):
+        return None
+
+
+def local_midnight_epoch(date):
+    try:
+        return dt.datetime.combine(date, dt.time.min).timestamp()
+    except (OSError, OverflowError, TypeError, ValueError):
+        return None
+
+
+def local_day_bounds(date):
+    start = local_midnight_epoch(date)
+    end = local_midnight_epoch(date + dt.timedelta(days=1)) if start is not None else None
+    return (start, end) if end is not None else (None, None)
+
+
+def safe_core_epoch(value):
+    converted = safe_float(value)
+    if converted is None:
+        return None
+    epoch = converted + CORE_DATA_EPOCH
+    return epoch if local_date(epoch) is not None else None
+
+
+def clip_interval(interval, start, end):
+    if not isinstance(interval, (tuple, list)) or len(interval) != 2:
+        return None
+    left = safe_float(interval[0])
+    right = safe_float(interval[1])
+    if left is None or right is None or right <= left:
+        return None
+    if right <= start or left >= end:
+        return None
+    return max(start, left), min(end, right)
+
+
+def union_intervals(intervals, start, end):
+    clipped = []
+    for interval in intervals:
+        candidate = clip_interval(interval, start, end)
+        if candidate is not None:
+            clipped.append(candidate)
+    merged = []
+    for left, right in sorted(clipped):
+        if merged and left <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], right))
+        else:
+            merged.append((left, right))
+    return merged
+
+
+def interval_seconds(intervals, start, end):
+    total = sum(right - left for left, right in union_intervals(intervals, start, end))
+    return min(end - start, total)
+
+
+def apply_state_event(state, opened, event, start):
+    timestamp, new_state = event
+    if timestamp < start:
+        return new_state, start if new_state else None, None
+    if new_state == state:
+        return state, opened, None
+    closed = (opened, timestamp) if state and opened is not None else None
+    return new_state, timestamp if new_state else None, closed
+
+
+def state_intervals(events, start, end, initial=False):
+    state = initial
+    opened = start if state else None
+    intervals = []
+    for event in sorted(events):
+        if event[0] > end:
+            break
+        state, opened, closed = apply_state_event(state, opened, event, start)
+        if closed is not None:
+            intervals.append(closed)
+    if state and opened is not None and opened < end:
+        intervals.append((opened, end))
+    return union_intervals(intervals, start, end)
+
+
+def parse_timestamp(value):
+    try:
+        normalized = str(value).strip().replace("Z", "+00:00")
+        parsed = dt.datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed.timestamp()
+    except (OSError, OverflowError, TypeError, ValueError):
+        return None

--- a/.agents/scripts/screen_time_linux.py
+++ b/.agents/scripts/screen_time_linux.py
@@ -1,0 +1,72 @@
+"""Linux screen-time source orchestration and trusted command execution."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from screen_time_linux_logind import collect_linux_events, linux_payload
+from screen_time_linux_wtmp import wtmp_payload
+
+
+def run_trusted_command(executable_name, arguments):
+    executable = shutil.which(executable_name)
+    if not executable or not os.path.isabs(executable):
+        return None, "executable-not-found"
+    try:
+        # The executable is resolved to an absolute path and callers supply a
+        # fixed argv shape; no command text reaches a shell.
+        result = subprocess.run(  # nosec B603
+            [executable, *arguments], check=False, capture_output=True, text=True, timeout=30
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, type(exc).__name__
+    if result.returncode != 0:
+        return None, f"exit-{result.returncode}"
+    return result.stdout.splitlines(), None
+
+
+def fixture_lines(variable):
+    fixture = os.environ.get(variable)
+    if not fixture:
+        return None, None
+    try:
+        return Path(fixture).read_text(encoding="utf-8").splitlines(), None
+    except OSError as exc:
+        return [], f"fixture-read-failed:{type(exc).__name__}"
+
+
+def journal_lines():
+    lines, error = fixture_lines("AIDEVOPS_LOGIND_FIXTURE")
+    if lines is not None or error:
+        return lines or [], error
+    lines, error = run_trusted_command(
+        "journalctl",
+        ["--since", "366 days ago", "-u", "systemd-logind.service", "--no-pager", "-o", "short-iso"],
+    )
+    return lines or [], f"journal-read-failed:{error}" if error else None
+
+
+def read_wtmp_lines(user, journal_reason):
+    lines, error = fixture_lines("AIDEVOPS_LAST_FIXTURE")
+    if lines is not None or error:
+        return lines, error
+    lines, error = run_trusted_command("last", ["-F", "-s", "-365days", user])
+    return lines, f"{journal_reason};wtmp-read-failed:{error}" if error else None
+
+
+def wtmp_collection(now, user, journal_reason):
+    lines, error = read_wtmp_lines(user, journal_reason)
+    return wtmp_payload(lines or [], error, now, journal_reason)
+
+
+def linux_collection(now, user):
+    lines, error = journal_lines()
+    if error:
+        return wtmp_collection(now, user, error)
+    intervals, observations = collect_linux_events(lines, now, user)
+    if not observations:
+        return wtmp_collection(now, user, "journal-readable-no-user-observations")
+    return linux_payload(intervals, observations, now)

--- a/.agents/scripts/screen_time_linux_logind.py
+++ b/.agents/scripts/screen_time_linux_logind.py
@@ -1,0 +1,112 @@
+"""Parse systemd-logind session, lock, and lid state observations."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+from screen_time_interval_common import WINDOWS, parse_timestamp, union_intervals
+
+SESSION_NEW = re.compile(r"New session ([A-Za-z0-9_.-]+) of user ([^ .]+)", re.I)
+SESSION_END = re.compile(r"(?:Removed session|Session) ([A-Za-z0-9_.-]+)(?: logged out)?", re.I)
+SESSION_ID = re.compile(r"Session ([A-Za-z0-9_.-]+)", re.I)
+
+
+def is_active(context):
+    state = context["state"]
+    return state["lid_open"] and any(not locked for locked in state["sessions"].values())
+
+
+def session_message_ids(message):
+    lowered = message.lower()
+    lock_match = SESSION_ID.search(message) if "locked" in lowered else None
+    end_match = SESSION_END.search(message)
+    lock_id = lock_match.group(1).rstrip(".") if lock_match else ""
+    end_id = end_match.group(1).rstrip(".") if end_match else ""
+    return lowered, lock_id, end_id
+
+
+def apply_message(context, message, user):
+    state = context["state"]
+    new_match = SESSION_NEW.search(message)
+    lowered, lock_id, end_id = session_message_ids(message)
+    recognized = True
+    if new_match and new_match.group(2) == user:
+        state["sessions"][new_match.group(1).rstrip(".")] = False
+    elif "Lid closed" in message:
+        state["lid_open"] = False
+    elif "Lid opened" in message:
+        state["lid_open"] = True
+    elif lock_id in state["sessions"]:
+        state["sessions"][lock_id] = "unlocked" not in lowered
+    elif end_id in state["sessions"]:
+        state["sessions"].pop(end_id, None)
+    else:
+        recognized = False
+    return recognized
+
+
+def parse_line(line, now):
+    parts = line.split(None, 1)
+    timestamp = parse_timestamp(parts[0]) if len(parts) == 2 else None
+    if timestamp is None or timestamp > now:
+        return None
+    return timestamp, parts[1]
+
+
+def debug_event(context, event, before, after):
+    if os.environ.get("AIDEVOPS_SCREEN_TIME_DEBUG") != "1":
+        return
+    timestamp, message = event
+    state = context["state"]
+    print(
+        f"screen-time event ts={timestamp} before={before} after={after} "
+        f"sessions={state['sessions']} lid_open={state['lid_open']} message={message}",
+        file=sys.stderr,
+    )
+
+
+def apply_event(context, event, user):
+    before = is_active(context)
+    if not apply_message(context, event[1], user):
+        return False
+    after = is_active(context)
+    debug_event(context, event, before, after)
+    if before and not after and context["opened"] is not None:
+        context["intervals"].append((context["opened"], event[0]))
+    if before != after:
+        context["opened"] = event[0] if after else None
+    context["active"] = after
+    return True
+
+
+def collect_linux_events(lines, now, user):
+    context = {"state": {"sessions": {}, "lid_open": True}, "intervals": [], "opened": None, "active": False}
+    observations = []
+    for line in lines:
+        event = parse_line(line, now)
+        if event is not None and apply_event(context, event, user):
+            observations.append(event[0])
+    if context["active"] and context["opened"] is not None:
+        context["intervals"].append((context["opened"], now))
+    intervals = union_intervals(context["intervals"], now - WINDOWS["year"], now)
+    return intervals, observations
+
+
+def linux_payload(intervals, observations, now):
+    latest = max(observations)
+    freshness = max(0.0, (now - latest) / 3600)
+    return {
+        "status": "stale" if freshness > 72 else "ok",
+        "source": "linux-systemd-logind:session-lid-lock-state",
+        "reason": "source-observations",
+        "intervals": intervals,
+        "observations": len(observations),
+        "latest_epoch": latest,
+        "earliest_epoch": min(observations),
+        "freshness_hours": round(freshness, 1),
+        "observation_epochs": observations,
+        "coverage_start_epoch": min(observations),
+        "coverage_end_epoch": latest,
+    }

--- a/.agents/scripts/screen_time_linux_wtmp.py
+++ b/.agents/scripts/screen_time_linux_wtmp.py
@@ -1,0 +1,88 @@
+"""Parse Linux wtmp login-session proxy observations."""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+
+from screen_time_interval_common import WINDOWS, union_intervals
+
+LAST_DATE = re.compile(r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2}\s+[0-9]{1,2} [0-9:]{8}(?: [+-][0-9]{4})? [0-9]{4}")
+
+
+def parse_last_local_timestamp(value):
+    formats = ("%a %b %d %H:%M:%S %z %Y", "%a %b %d %H:%M:%S %Y")
+    for format_string in formats:
+        try:
+            return dt.datetime.strptime(value, format_string).timestamp()
+        except (OSError, OverflowError, ValueError):
+            pass
+    return None
+
+
+def structured_interval(line):
+    match = re.match(r"^([0-9]+)\|([0-9]+)$", line.strip())
+    if not match:
+        return None
+    left, right = float(match.group(1)), float(match.group(2))
+    return (left, right) if right > left else None
+
+
+def dated_interval(line, now):
+    dates = LAST_DATE.findall(line)
+    if not dates:
+        return None
+    left = parse_last_local_timestamp(dates[0])
+    right = now if "still logged in" in line else parse_last_local_timestamp(dates[1]) if len(dates) >= 2 else None
+    return (left, right) if left is not None and right is not None and right > left else None
+
+
+def parse_wtmp_line(line, now):
+    ignored = not line.strip() or "wtmp begins" in line or line.startswith(("reboot", "shutdown"))
+    if ignored:
+        return None, False
+    interval = structured_interval(line) or dated_interval(line, now)
+    return interval, interval is None
+
+
+def parse_lines(lines, now):
+    intervals, skipped = [], 0
+    for line in lines:
+        interval, malformed = parse_wtmp_line(line, now)
+        if interval is not None:
+            intervals.append(interval)
+        skipped += int(malformed)
+    return intervals, skipped
+
+
+def unavailable(reason):
+    source = "linux-wtmp" if reason.startswith("fixture-read-failed:") else "linux-logind+wtmp"
+    return {"status": "unavailable", "source": source, "reason": reason, "intervals": []}
+
+
+def available(intervals, skipped, now, journal_reason):
+    latest = max(right for _, right in intervals)
+    freshness = max(0.0, (now - latest) / 3600)
+    return {
+        "status": "stale" if freshness > 72 else "ok",
+        "source": "linux-wtmp:login-session-proxy",
+        "reason": f"logind-unavailable:{journal_reason}",
+        "intervals": union_intervals(intervals, now - WINDOWS["year"], now),
+        "observations": len(intervals),
+        "latest_epoch": latest,
+        "earliest_epoch": min(left for left, _ in intervals),
+        "freshness_hours": round(freshness, 1),
+        "skipped_rows": skipped,
+        "observation_epochs": [],
+        "coverage_start_epoch": min(left for left, _ in intervals),
+        "coverage_end_epoch": latest,
+    }
+
+
+def wtmp_payload(lines, error, now, journal_reason):
+    if error:
+        return unavailable(error)
+    intervals, skipped = parse_lines(lines, now)
+    if not intervals:
+        return unavailable(f"{journal_reason};no-parseable-wtmp-sessions")
+    return available(intervals, skipped, now, journal_reason)

--- a/.agents/scripts/screen_time_macos.py
+++ b/.agents/scripts/screen_time_macos.py
@@ -1,0 +1,131 @@
+"""Read-only macOS Knowledge database screen-time collection."""
+
+from __future__ import annotations
+
+import datetime as dt
+import sqlite3
+
+from screen_time_interval_common import DAY, WINDOWS, interval_seconds, local_date, safe_core_epoch, safe_float, state_intervals, union_intervals
+
+
+def unavailable(reason, source="macos-knowledge-db"):
+    return {"status": "unavailable", "source": source, "reason": reason, "intervals": []}
+
+
+def read_knowledge_rows(db_path):
+    if not db_path.is_file():
+        return None, None, "database-missing"
+    try:
+        uri = f"file:{db_path}?mode=ro"
+        with sqlite3.connect(uri, uri=True, timeout=5) as connection:
+            backlit = connection.execute(
+                "SELECT ZCREATIONDATE, ZVALUEINTEGER FROM ZOBJECT "
+                "WHERE ZSTREAMNAME='/display/isBacklit' ORDER BY ZCREATIONDATE"
+            ).fetchall()
+            apps = connection.execute(
+                "SELECT ZSTARTDATE, ZENDDATE FROM ZOBJECT "
+                "WHERE ZSTREAMNAME='/app/usage' ORDER BY ZSTARTDATE"
+            ).fetchall()
+        return backlit, apps, None
+    except (OSError, sqlite3.Error) as exc:
+        return None, None, f"database-read-failed:{type(exc).__name__}"
+
+
+def parse_backlit_rows(rows):
+    parsed = []
+    for timestamp, state in rows:
+        epoch = safe_core_epoch(timestamp)
+        numeric_state = safe_float(state)
+        if epoch is not None and numeric_state is not None:
+            parsed.append((epoch, bool(numeric_state)))
+    return parsed
+
+
+def parse_app_rows(rows):
+    parsed = []
+    for start, end in rows:
+        left = safe_core_epoch(start)
+        right = safe_core_epoch(end)
+        if left is not None and right is not None and right > left:
+            parsed.append((left, right))
+    return parsed
+
+
+def active_dates(intervals, now, window_days=28):
+    dates = set()
+    for left, right in union_intervals(intervals, now - window_days * DAY, now):
+        cursor = local_date(left)
+        final = local_date(max(left, right - 1))
+        if cursor is None or final is None:
+            continue
+        while cursor <= final:
+            dates.add(cursor)
+            cursor += dt.timedelta(days=1)
+    return dates
+
+
+def app_source_is_richer(backlit_intervals, app_intervals, now):
+    backlit_dates = active_dates(backlit_intervals, now)
+    app_dates = active_dates(app_intervals, now)
+    if len(app_dates) <= len(backlit_dates):
+        return False
+    materially_more_days = len(app_dates) >= max(len(backlit_dates) + 2, len(backlit_dates) * 2)
+    backlit_seconds = interval_seconds(backlit_intervals, now - 28 * DAY, now)
+    app_seconds = interval_seconds(app_intervals, now - 28 * DAY, now)
+    materially_more_time = app_seconds > max(3600, backlit_seconds * 1.5)
+    return materially_more_days or materially_more_time
+
+
+def source_payload(selection):
+    raw_intervals = selection["raw_intervals"]
+    latest = selection["latest"]
+    starts = [left for left, _ in raw_intervals]
+    ends = [right for _, right in raw_intervals]
+    return {
+        "source": selection["source"],
+        "intervals": selection["intervals"],
+        "observations": len(raw_intervals),
+        "latest_epoch": latest,
+        "earliest_epoch": min(starts, default=latest),
+        "observation_epochs": selection["observation_epochs"],
+        "coverage_start_epoch": min(starts, default=latest),
+        "coverage_end_epoch": max(ends, default=latest),
+        "freshness_hours": None,
+    }
+
+
+def choose_source(backlit, apps, now):
+    earliest = now - WINDOWS["year"]
+    backlit_intervals = state_intervals(backlit, earliest, now)
+    app_intervals = union_intervals(apps, earliest, now)
+    latest_backlit = max((item[0] for item in backlit), default=None)
+    latest_app = max((item[1] for item in apps), default=None)
+    recent_backlit = latest_backlit is not None and now - latest_backlit <= 3 * DAY
+    use_backlit = recent_backlit and not app_source_is_richer(backlit_intervals, app_intervals, now)
+    if use_backlit:
+        raw = [(timestamp, timestamp) for timestamp, _ in backlit]
+        return source_payload({"source": "macos-knowledge-db:/display/isBacklit", "intervals": backlit_intervals, "raw_intervals": raw, "latest": latest_backlit, "observation_epochs": [item[0] for item in backlit]})
+    if apps:
+        return source_payload({"source": "macos-knowledge-db:/app/usage-union", "intervals": app_intervals, "raw_intervals": apps, "latest": latest_app, "observation_epochs": []})
+    if backlit:
+        raw = [(timestamp, timestamp) for timestamp, _ in backlit]
+        return source_payload({"source": "macos-knowledge-db:/display/isBacklit-stale", "intervals": backlit_intervals, "raw_intervals": raw, "latest": latest_backlit, "observation_epochs": [item[0] for item in backlit]})
+    return None
+
+
+def macos_collection(db_path, now):
+    backlit_rows, app_rows, error = read_knowledge_rows(db_path)
+    if error:
+        return unavailable(error)
+    backlit = parse_backlit_rows(backlit_rows)
+    apps = parse_app_rows(app_rows)
+    selected = choose_source(backlit, apps, now)
+    if selected is None:
+        return unavailable("empty-readable-database", "macos-knowledge-db:no-observations")
+    freshness = max(0.0, (now - selected["latest_epoch"]) / 3600)
+    selected.update({
+        "status": "stale" if freshness > 72 else "ok",
+        "reason": "source-observations",
+        "freshness_hours": round(freshness, 1),
+    })
+    return selected

--- a/.agents/scripts/screen_time_macos_apps.py
+++ b/.agents/scripts/screen_time_macos_apps.py
@@ -1,0 +1,124 @@
+"""Top-app attribution for macOS screen-time observations."""
+
+from __future__ import annotations
+
+import heapq
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+from screen_time_interval_common import CORE_DATA_EPOCH, DAY, safe_core_epoch
+
+
+def read_app_stat_rows(db_path, now):
+    if not db_path.is_file():
+        return [], "database-missing"
+    try:
+        uri = f"file:{db_path}?mode=ro"
+        with sqlite3.connect(uri, uri=True, timeout=5) as connection:
+            rows = connection.execute(
+                "SELECT ZVALUESTRING, ZSTARTDATE, ZENDDATE FROM ZOBJECT "
+                "WHERE ZSTREAMNAME='/app/usage' AND ZVALUESTRING IS NOT NULL "
+                "AND ZENDDATE > ? AND ZSTARTDATE < ? ORDER BY ZSTARTDATE",
+                (now - 28 * DAY - CORE_DATA_EPOCH, now - CORE_DATA_EPOCH),
+            ).fetchall()
+        return rows, None
+    except (OSError, sqlite3.Error) as exc:
+        return [], f"database-read-failed:{type(exc).__name__}"
+
+
+def parse_app_stat_rows(rows, now):
+    month_start = now - 28 * DAY
+    parsed = []
+    for bundle, start, end in rows:
+        original_start = safe_core_epoch(start)
+        original_end = safe_core_epoch(end)
+        if original_start is None or original_end is None or original_end <= original_start:
+            continue
+        left = max(month_start, original_start)
+        right = min(now, original_end)
+        if right > left:
+            parsed.append((str(bundle), left, right, original_start))
+    return parsed
+
+
+def interval_boundaries(intervals, month_start, now):
+    starts, ends, boundaries = {}, {}, {month_start, now}
+    for interval_id, (bundle, left, right, original_start) in enumerate(intervals):
+        starts.setdefault(left, []).append((interval_id, bundle, original_start))
+        ends.setdefault(right, []).append(interval_id)
+        boundaries.update((left, right))
+    return starts, ends, sorted(boundaries)
+
+
+def update_active_apps(context, starting, ending):
+    for interval_id in ending:
+        context["active"].discard(interval_id)
+    for interval_id, bundle, original_start in starting:
+        context["active"].add(interval_id)
+        heapq.heappush(context["latest_heap"], (-original_start, -interval_id, interval_id, bundle))
+    while context["latest_heap"] and context["latest_heap"][0][2] not in context["active"]:
+        heapq.heappop(context["latest_heap"])
+
+
+def attribute_segment(context, left, right):
+    if not context["latest_heap"] or right <= left:
+        return
+    bundle = context["latest_heap"][0][3]
+    context["stats"]["attributed_segments"] += 1
+    now = context["now"]
+    for name, window_start in (("today", now - DAY), ("week", now - 7 * DAY), ("month", now - 28 * DAY)):
+        overlap = right - max(left, window_start)
+        if overlap > 0:
+            totals = context["totals"][name]
+            totals[bundle] = totals.get(bundle, 0) + overlap
+
+
+def attribute_app_totals(intervals, now):
+    starts, ends, ordered = interval_boundaries(intervals, now - 28 * DAY, now)
+    context = {
+        "active": set(),
+        "latest_heap": [],
+        "totals": {name: {} for name in ("today", "week", "month")},
+        "stats": {"boundaries": len(ordered), "attributed_segments": 0, "max_active": 0},
+        "now": now,
+    }
+    for left, right in zip(ordered, ordered[1:]):
+        update_active_apps(context, starts.get(left, []), ends.get(left, []))
+        context["stats"]["max_active"] = max(context["stats"]["max_active"], len(context["active"]))
+        attribute_segment(context, left, right)
+    return context["totals"], context["stats"]
+
+
+def app_result(totals):
+    result = []
+    month_items = sorted(totals["month"].items(), key=lambda item: (-item[1], item[0]))[:10]
+    for bundle, month_seconds in month_items:
+        row = {"bundle": bundle, "month_seconds": round(month_seconds)}
+        for name in ("today", "week", "month"):
+            denominator = sum(totals[name].values())
+            row[f"{name}_pct"] = round(totals[name].get(bundle, 0) / denominator * 100) if denominator else 0
+        result.append(row)
+    return result
+
+
+def write_instrumentation(rows, intervals, stats, started_at):
+    instrument_file = os.environ.get("AIDEVOPS_APP_STATS_INSTRUMENT_FILE")
+    if not instrument_file:
+        return
+    payload = dict(stats, rows_selected=len(rows), valid_intervals=len(intervals))
+    payload["elapsed_ms"] = round((time.perf_counter() - started_at) * 1000, 3)
+    Path(instrument_file).write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def macos_app_stats(db_path, now):
+    started_at = time.perf_counter()
+    rows, error = read_app_stat_rows(db_path, now)
+    if error:
+        return []
+    intervals = parse_app_stat_rows(rows, now)
+    totals, stats = attribute_app_totals(intervals, now)
+    write_instrumentation(rows, intervals, stats, started_at)
+    return app_result(totals)

--- a/.agents/scripts/session-time-interval-engine.py
+++ b/.agents/scripts/session-time-interval-engine.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Aggregate assistant session observations once for multiple time windows."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import glob
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+DAY_MS = 86400000
+WINDOWS = {
+    "day": DAY_MS,
+    "week": 7 * DAY_MS,
+    "28d": 28 * DAY_MS,
+    "month": 30 * DAY_MS,
+    "quarter": 90 * DAY_MS,
+    "year": 365 * DAY_MS,
+}
+WORKER_PATTERNS = [
+    re.compile(pattern, re.I)
+    for pattern in (
+        r"^Issue #\d+", r"^PR #\d+", r"^Fix PR\b", r"^Review PR\b",
+        r"^Supervisor Pulse", r"/full-loop", r"^dispatch:", r"^Worker:",
+        r"^t\d+[.\-:]", r"^escalation-", r"^health-check$", r"failing CI\b",
+        r"CI fail", r"CHANGES_REQUESTED", r"CodeRabbit review", r"address review",
+        r"review feedback", r"^Fix qlty\b", r"^Gemini feedback\b",
+        r"^observability-only headless session$",
+    )
+]
+TEMP_PATHS = (
+    re.compile(r"^/private/tmp/opencode(?:[.-].*)?$"),
+    re.compile(r"^/tmp/opencode(?:[.-].*)?$"),
+    re.compile(r"^/var/folders/.*/T/opencode.*$"),
+)
+
+
+def path_matches(candidate, root):
+    if not root:
+        return True
+    if not candidate:
+        return False
+    return candidate == root or candidate.startswith(root + ".") or candidate.startswith(root + "-") or candidate.startswith(root + "/")
+
+
+def classify(title, directory):
+    if any(pattern.search(directory or "") for pattern in TEMP_PATHS):
+        return "worker"
+    if any(pattern.search(title or "") for pattern in WORKER_PATTERNS):
+        return "worker"
+    return "interactive"
+
+
+def union(intervals, start, end):
+    clipped = sorted((max(start, left), min(end, right)) for left, right in intervals if right > start and left < end)
+    result = []
+    for left, right in clipped:
+        if right <= left:
+            continue
+        if result and left <= result[-1][1]:
+            result[-1] = (result[-1][0], max(result[-1][1], right))
+        else:
+            result.append((left, right))
+    return result
+
+
+def duration(intervals, start, end):
+    return sum(right - left for left, right in union(intervals, start, end))
+
+
+def db_paths(home, explicit):
+    if explicit:
+        return [Path(explicit)]
+    paths = [home / ".local/share/opencode/opencode.db", home / ".local/share/opencode/opencode-archive.db"]
+    work = Path(os.environ.get("AIDEVOPS_WORK_DIR", home / ".aidevops/.agent-workspace/work"))
+    paths.extend(Path(item) for item in glob.glob(str(work / "opencode-interactive/*/opencode/opencode.db")))
+    return [item for item in paths if item.is_file()]
+
+
+def note_scan(db_path):
+    counter = os.environ.get("AIDEVOPS_SESSION_SCAN_COUNTER")
+    if counter:
+        with open(counter, "a", encoding="utf-8") as handle:
+            handle.write(str(db_path) + "\n")
+
+
+def query_session_db(db_path, root, since):
+    note_scan(db_path)
+    query = """
+        SELECT s.id, s.title, s.directory, m.time_created, m.data
+        FROM session s JOIN message m ON m.session_id=s.id
+        WHERE s.parent_id IS NULL AND m.time_created >= ?
+        ORDER BY s.id, m.time_created
+    """
+    sessions = {}
+    try:
+        with sqlite3.connect(db_path, timeout=5) as connection:
+            for session_id, title, directory, created, data in connection.execute(query, (since,)):
+                if not path_matches(directory, root):
+                    continue
+                row = sessions.setdefault(session_id, {
+                    "session_id": session_id, "title": title or "", "directory": directory or "",
+                    "human": [], "machine": [], "first": int(created), "last": int(created), "previous_role": None,
+                    "previous_completed": None,
+                })
+                try:
+                    payload = json.loads(data or "{}")
+                except json.JSONDecodeError:
+                    payload = {}
+                role = payload.get("role")
+                completed = payload.get("time", {}).get("completed")
+                completed = int(completed) if isinstance(completed, (int, float)) else None
+                created = int(created)
+                if role == "user" and row["previous_role"] == "assistant" and row["previous_completed"]:
+                    gap = created - row["previous_completed"]
+                    if 0 < gap <= 3600000:
+                        row["human"].append((row["previous_completed"], created))
+                if role == "assistant" and completed and completed > created:
+                    row["machine"].append((created, completed))
+                row["previous_role"] = role
+                row["previous_completed"] = completed
+                row["first"] = min(row["first"], created)
+                row["last"] = max(row["last"], completed or created)
+    except sqlite3.Error:
+        return [], False
+    for row in sessions.values():
+        row.pop("previous_role", None)
+        row.pop("previous_completed", None)
+    return list(sessions.values()), True
+
+
+def parse_iso_ms(value):
+    try:
+        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return int(parsed.timestamp() * 1000)
+    except ValueError:
+        return None
+
+
+def query_observability(home, root, since, now):
+    db_path = Path(os.environ.get("AIDEVOPS_OBS_DB_FILE", home / ".aidevops/.agent-workspace/observability/llm-requests.db"))
+    if not db_path.is_file():
+        return {}, False
+    rows = {}
+    try:
+        with sqlite3.connect(db_path, timeout=5) as connection:
+            query = "SELECT timestamp, session_id, duration_ms, project_path FROM llm_requests WHERE duration_ms > 0"
+            for timestamp, session_id, duration_ms, project_path in connection.execute(query):
+                if not session_id or not path_matches(project_path, root):
+                    continue
+                end = parse_iso_ms(timestamp)
+                if end is None or end < since:
+                    continue
+                end = min(now, end)
+                start = max(since, end - int(duration_ms))
+                if end <= start:
+                    continue
+                row = rows.setdefault(session_id, {"intervals": [], "directory": project_path or ""})
+                row["intervals"].append((start, end))
+    except sqlite3.Error:
+        return {}, False
+    return rows, True
+
+
+def aggregate(sessions, obs_rows, since, now, sources_ok):
+    population = {}
+    for row in sessions:
+        population[row["session_id"]] = row
+    for session_id, obs in obs_rows.items():
+        if session_id not in population:
+            population[session_id] = {
+                "session_id": session_id, "title": "observability-only headless session",
+                "directory": obs["directory"], "human": [], "machine": [],
+                "first": min(left for left, _ in obs["intervals"]),
+                "last": max(right for _, right in obs["intervals"]),
+            }
+
+    human_by_type = {"interactive": [], "worker": []}
+    machine_by_type = {"interactive": 0, "worker": 0}
+    counts = {"interactive": 0, "worker": 0}
+    first_seen = []
+    last_seen = []
+    for session_id, row in population.items():
+        human = union(row.get("human", []), since, now)
+        machine_source = obs_rows.get(session_id, {}).get("intervals") or row.get("machine", [])
+        machine = union(machine_source, since, now)
+        if not human and not machine and row.get("last", 0) < since:
+            continue
+        session_type = classify(row.get("title", ""), row.get("directory", ""))
+        counts[session_type] += 1
+        human_by_type[session_type].extend(human)
+        machine_by_type[session_type] += sum(right - left for left, right in machine)
+        first_seen.append(max(since, row.get("first", since)))
+        last_seen.append(min(now, row.get("last", now)))
+
+    interactive_human = duration(human_by_type["interactive"], since, now)
+    worker_human = duration(human_by_type["worker"], since, now)
+    total_human = duration(human_by_type["interactive"] + human_by_type["worker"], since, now)
+    interactive_machine = machine_by_type["interactive"]
+    worker_machine = machine_by_type["worker"]
+    observed_days = round(max(0, max(last_seen) - min(first_seen)) / DAY_MS, 1) if first_seen and last_seen else 0
+
+    def hours(milliseconds):
+        return round(milliseconds / 3600000, 1)
+
+    return {
+        "interactive_sessions": counts["interactive"],
+        "interactive_human_hours": hours(interactive_human),
+        "interactive_machine_hours": hours(interactive_machine),
+        "worker_sessions": counts["worker"],
+        "worker_human_hours": hours(worker_human),
+        "worker_machine_hours": hours(worker_machine),
+        "total_human_hours": hours(total_human),
+        "total_machine_hours": hours(interactive_machine + worker_machine),
+        "total_sessions": counts["interactive"] + counts["worker"],
+        "observed_days": observed_days,
+        "status": "ok" if sources_ok else "unavailable",
+        "provenance": "session-message-intervals+observability-request-intervals" if obs_rows else "session-message-intervals",
+        "human_attention_semantics": "unioned wall-clock intervals",
+        "machine_work_semantics": "additive per-session generation intervals",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default="")
+    parser.add_argument("--all-dirs", action="store_true")
+    parser.add_argument("--db-path", default="")
+    parser.add_argument("--period", default="month")
+    parser.add_argument("--now-ms", type=int, default=int(time.time() * 1000))
+    args = parser.parse_args()
+    root = "" if args.all_dirs else os.path.abspath(args.repo or ".")
+    home = Path.home()
+    maximum_since = args.now_ms - WINDOWS["year"]
+    sessions = []
+    source_ok = False
+    seen = set()
+    for db_path in db_paths(home, args.db_path):
+        queried, ok = query_session_db(db_path, root, maximum_since)
+        source_ok = source_ok or ok
+        for row in queried:
+            if row["session_id"] not in seen:
+                sessions.append(row)
+                seen.add(row["session_id"])
+    obs_rows, obs_ok = query_observability(home, root, maximum_since, args.now_ms)
+    source_ok = source_ok or obs_ok
+
+    periods = ["day", "week", "28d", "year"] if args.period == "profile" else (
+        ["day", "week", "month", "quarter", "year"] if args.period == "all" else [args.period]
+    )
+    result = {
+        period: aggregate(sessions, obs_rows, args.now_ms - WINDOWS.get(period, WINDOWS["month"]), args.now_ms, source_ok)
+        for period in periods
+    }
+    print(json.dumps(result if len(periods) > 1 else result[periods[0]], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/scripts/session-time-interval-engine.py
+++ b/.agents/scripts/session-time-interval-engine.py
@@ -39,6 +39,52 @@ TEMP_PATHS = (
     re.compile(r"^/tmp/opencode(?:[.-].*)?$"),
     re.compile(r"^/var/folders/.*/T/opencode.*$"),
 )
+OBSERVABILITY_QUERY = """
+    SELECT timestamp, session_id, duration_ms, project_path
+    FROM llm_requests
+    WHERE timestamp >= ?
+      AND duration_ms > 0
+      AND typeof(duration_ms) IN ('integer','real')
+      AND session_id IS NOT NULL
+      AND session_id != ''
+"""
+OBSERVABILITY_ROOT_QUERY = """
+    SELECT timestamp, session_id, duration_ms, project_path
+    FROM llm_requests
+    WHERE timestamp >= ?
+      AND duration_ms > 0
+      AND typeof(duration_ms) IN ('integer','real')
+      AND session_id IS NOT NULL
+      AND session_id != ''
+      AND (project_path = ?
+           OR project_path LIKE ? ESCAPE '\\'
+           OR project_path LIKE ? ESCAPE '\\'
+           OR project_path LIKE ? ESCAPE '\\')
+"""
+OBSERVABILITY_PLAN_QUERY = """
+    EXPLAIN QUERY PLAN
+    SELECT timestamp, session_id, duration_ms, project_path
+    FROM llm_requests
+    WHERE timestamp >= ?
+      AND duration_ms > 0
+      AND typeof(duration_ms) IN ('integer','real')
+      AND session_id IS NOT NULL
+      AND session_id != ''
+"""
+OBSERVABILITY_ROOT_PLAN_QUERY = """
+    EXPLAIN QUERY PLAN
+    SELECT timestamp, session_id, duration_ms, project_path
+    FROM llm_requests
+    WHERE timestamp >= ?
+      AND duration_ms > 0
+      AND typeof(duration_ms) IN ('integer','real')
+      AND session_id IS NOT NULL
+      AND session_id != ''
+      AND (project_path = ?
+           OR project_path LIKE ? ESCAPE '\\'
+           OR project_path LIKE ? ESCAPE '\\'
+           OR project_path LIKE ? ESCAPE '\\')
+"""
 
 
 def path_matches(candidate, root):
@@ -170,6 +216,14 @@ def parse_iso_ms(value):
         return None
 
 
+def observability_query(root, cutoff):
+    if not root:
+        return OBSERVABILITY_QUERY, OBSERVABILITY_PLAN_QUERY, (cutoff,)
+    like_root = escaped_like(root)
+    params = (cutoff, root, f"{like_root}/%", f"{like_root}.%", f"{like_root}-%")
+    return OBSERVABILITY_ROOT_QUERY, OBSERVABILITY_ROOT_PLAN_QUERY, params
+
+
 def query_observability(home, root, since, now):
     db_path = Path(os.environ.get("AIDEVOPS_OBS_DB_FILE", home / ".aidevops/.agent-workspace/observability/llm-requests.db"))
     if not db_path.is_file():
@@ -179,16 +233,10 @@ def query_observability(home, root, since, now):
     try:
         with sqlite3.connect(db_path, timeout=5) as connection:
             cutoff = dt.datetime.fromtimestamp(since / 1000, dt.timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
-            where = ["timestamp >= ?", "duration_ms > 0", "typeof(duration_ms) IN ('integer','real')", "session_id IS NOT NULL", "session_id != ''"]
-            params = [cutoff]
-            if root:
-                like_root = escaped_like(root)
-                where.append("(project_path = ? OR project_path LIKE ? ESCAPE '\\' OR project_path LIKE ? ESCAPE '\\' OR project_path LIKE ? ESCAPE '\\')")
-                params.extend((root, f"{like_root}/%", f"{like_root}.%", f"{like_root}-%"))
-            query = f"SELECT timestamp, session_id, duration_ms, project_path FROM llm_requests WHERE {' AND '.join(where)}"
+            query, plan_query, params = observability_query(root, cutoff)
             plan_file = os.environ.get("AIDEVOPS_OBS_QUERY_PLAN_FILE")
             if plan_file:
-                plan = connection.execute("EXPLAIN QUERY PLAN " + query, params).fetchall()
+                plan = connection.execute(plan_query, params).fetchall()
                 with open(plan_file, "w", encoding="utf-8") as handle:
                     handle.write("\n".join(str(row[3]) for row in plan) + "\n")
             selected = 0

--- a/.agents/scripts/session-time-interval-engine.py
+++ b/.agents/scripts/session-time-interval-engine.py
@@ -74,6 +74,20 @@ def duration(intervals, start, end):
     return sum(right - left for left, right in union(intervals, start, end))
 
 
+def safe_int(value):
+    if isinstance(value, bool):
+        return None
+    try:
+        converted = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return converted
+
+
+def escaped_like(value):
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def db_paths(home, explicit):
     if explicit:
         return [Path(explicit)]
@@ -99,10 +113,15 @@ def query_session_db(db_path, root, since):
         ORDER BY s.id, m.time_created
     """
     sessions = {}
+    skipped = 0
     try:
         with sqlite3.connect(db_path, timeout=5) as connection:
             for session_id, title, directory, created, data in connection.execute(query, (since,)):
                 if not path_matches(directory, root):
+                    continue
+                created = safe_int(created)
+                if not session_id or created is None:
+                    skipped += 1
                     continue
                 row = sessions.setdefault(session_id, {
                     "session_id": session_id, "title": title or "", "directory": directory or "",
@@ -111,12 +130,18 @@ def query_session_db(db_path, root, since):
                 })
                 try:
                     payload = json.loads(data or "{}")
-                except json.JSONDecodeError:
-                    payload = {}
+                    if not isinstance(payload, dict):
+                        raise ValueError("message payload is not an object")
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    skipped += 1
+                    continue
                 role = payload.get("role")
-                completed = payload.get("time", {}).get("completed")
-                completed = int(completed) if isinstance(completed, (int, float)) else None
-                created = int(created)
+                time_data = payload.get("time", {})
+                if not isinstance(time_data, dict):
+                    skipped += 1
+                    continue
+                completed = time_data.get("completed")
+                completed = safe_int(completed)
                 if role == "user" and row["previous_role"] == "assistant" and row["previous_completed"]:
                     gap = created - row["previous_completed"]
                     if 0 < gap <= 3600000:
@@ -128,11 +153,11 @@ def query_session_db(db_path, root, since):
                 row["first"] = min(row["first"], created)
                 row["last"] = max(row["last"], completed or created)
     except sqlite3.Error:
-        return [], False
+        return [], False, skipped
     for row in sessions.values():
         row.pop("previous_role", None)
         row.pop("previous_completed", None)
-    return list(sessions.values()), True
+    return list(sessions.values()), True, skipped
 
 
 def parse_iso_ms(value):
@@ -141,33 +166,53 @@ def parse_iso_ms(value):
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=dt.timezone.utc)
         return int(parsed.timestamp() * 1000)
-    except ValueError:
+    except (ValueError, TypeError, OverflowError):
         return None
 
 
 def query_observability(home, root, since, now):
     db_path = Path(os.environ.get("AIDEVOPS_OBS_DB_FILE", home / ".aidevops/.agent-workspace/observability/llm-requests.db"))
     if not db_path.is_file():
-        return {}, False
+        return {}, False, 0
     rows = {}
+    skipped = 0
     try:
         with sqlite3.connect(db_path, timeout=5) as connection:
-            query = "SELECT timestamp, session_id, duration_ms, project_path FROM llm_requests WHERE duration_ms > 0"
-            for timestamp, session_id, duration_ms, project_path in connection.execute(query):
-                if not session_id or not path_matches(project_path, root):
-                    continue
+            cutoff = dt.datetime.fromtimestamp(since / 1000, dt.timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+            where = ["timestamp >= ?", "duration_ms > 0", "typeof(duration_ms) IN ('integer','real')", "session_id IS NOT NULL", "session_id != ''"]
+            params = [cutoff]
+            if root:
+                like_root = escaped_like(root)
+                where.append("(project_path = ? OR project_path LIKE ? ESCAPE '\\' OR project_path LIKE ? ESCAPE '\\' OR project_path LIKE ? ESCAPE '\\')")
+                params.extend((root, f"{like_root}/%", f"{like_root}.%", f"{like_root}-%"))
+            query = f"SELECT timestamp, session_id, duration_ms, project_path FROM llm_requests WHERE {' AND '.join(where)}"
+            plan_file = os.environ.get("AIDEVOPS_OBS_QUERY_PLAN_FILE")
+            if plan_file:
+                plan = connection.execute("EXPLAIN QUERY PLAN " + query, params).fetchall()
+                with open(plan_file, "w", encoding="utf-8") as handle:
+                    handle.write("\n".join(str(row[3]) for row in plan) + "\n")
+            selected = 0
+            for timestamp, session_id, duration_ms, project_path in connection.execute(query, params):
+                selected += 1
                 end = parse_iso_ms(timestamp)
-                if end is None or end < since:
+                duration_ms = safe_int(duration_ms)
+                if end is None or duration_ms is None or end < since:
+                    skipped += 1
                     continue
                 end = min(now, end)
-                start = max(since, end - int(duration_ms))
+                start = max(since, end - duration_ms)
                 if end <= start:
+                    skipped += 1
                     continue
                 row = rows.setdefault(session_id, {"intervals": [], "directory": project_path or ""})
                 row["intervals"].append((start, end))
+            counter = os.environ.get("AIDEVOPS_OBS_ROW_COUNTER")
+            if counter:
+                with open(counter, "a", encoding="utf-8") as handle:
+                    handle.write(f"{selected}\n")
     except sqlite3.Error:
-        return {}, False
-    return rows, True
+        return {}, False, skipped
+    return rows, True, skipped
 
 
 def aggregate(sessions, obs_rows, since, now, sources_ok):
@@ -190,7 +235,7 @@ def aggregate(sessions, obs_rows, since, now, sources_ok):
     last_seen = []
     for session_id, row in population.items():
         human = union(row.get("human", []), since, now)
-        machine_source = obs_rows.get(session_id, {}).get("intervals") or row.get("machine", [])
+        machine_source = row.get("machine", []) + obs_rows.get(session_id, {}).get("intervals", [])
         machine = union(machine_source, since, now)
         if not human and not machine and row.get("last", 0) < since:
             continue
@@ -234,7 +279,7 @@ def main():
     parser.add_argument("--repo", default="")
     parser.add_argument("--all-dirs", action="store_true")
     parser.add_argument("--db-path", default="")
-    parser.add_argument("--period", default="month")
+    parser.add_argument("--period", choices=tuple(WINDOWS) + ("profile", "all"), default="month")
     parser.add_argument("--now-ms", type=int, default=int(time.time() * 1000))
     args = parser.parse_args()
     root = "" if args.all_dirs else os.path.abspath(args.repo or ".")
@@ -242,15 +287,18 @@ def main():
     maximum_since = args.now_ms - WINDOWS["year"]
     sessions = []
     source_ok = False
+    skipped_rows = 0
     seen = set()
     for db_path in db_paths(home, args.db_path):
-        queried, ok = query_session_db(db_path, root, maximum_since)
+        queried, ok, skipped = query_session_db(db_path, root, maximum_since)
+        skipped_rows += skipped
         source_ok = source_ok or ok
         for row in queried:
             if row["session_id"] not in seen:
                 sessions.append(row)
                 seen.add(row["session_id"])
-    obs_rows, obs_ok = query_observability(home, root, maximum_since, args.now_ms)
+    obs_rows, obs_ok, obs_skipped = query_observability(home, root, maximum_since, args.now_ms)
+    skipped_rows += obs_skipped
     source_ok = source_ok or obs_ok
 
     periods = ["day", "week", "28d", "year"] if args.period == "profile" else (
@@ -260,6 +308,8 @@ def main():
         period: aggregate(sessions, obs_rows, args.now_ms - WINDOWS.get(period, WINDOWS["month"]), args.now_ms, source_ok)
         for period in periods
     }
+    for item in result.values():
+        item["skipped_malformed_rows"] = skipped_rows
     print(json.dumps(result if len(periods) > 1 else result[periods[0]], indent=2, sort_keys=True))
     return 0
 

--- a/.agents/scripts/session-time-interval-engine.py
+++ b/.agents/scripts/session-time-interval-engine.py
@@ -1,364 +1,76 @@
 #!/usr/bin/env python3
-"""Aggregate assistant session observations once for multiple time windows."""
+"""CLI entrypoint for assistant session interval aggregation."""
 
 from __future__ import annotations
 
 import argparse
-import datetime as dt
-import glob
 import json
 import os
-import re
-import sqlite3
 import sys
 import time
 from pathlib import Path
 
-DAY_MS = 86400000
-WINDOWS = {
-    "day": DAY_MS,
-    "week": 7 * DAY_MS,
-    "28d": 28 * DAY_MS,
-    "month": 30 * DAY_MS,
-    "quarter": 90 * DAY_MS,
-    "year": 365 * DAY_MS,
-}
-WORKER_PATTERNS = [
-    re.compile(pattern, re.I)
-    for pattern in (
-        r"^Issue #\d+", r"^PR #\d+", r"^Fix PR\b", r"^Review PR\b",
-        r"^Supervisor Pulse", r"/full-loop", r"^dispatch:", r"^Worker:",
-        r"^t\d+[.\-:]", r"^escalation-", r"^health-check$", r"failing CI\b",
-        r"CI fail", r"CHANGES_REQUESTED", r"CodeRabbit review", r"address review",
-        r"review feedback", r"^Fix qlty\b", r"^Gemini feedback\b",
-        r"^observability-only headless session$",
-    )
-]
-TEMP_PATHS = (
-    re.compile(r"^/private/tmp/opencode(?:[.-].*)?$"),
-    re.compile(r"^/tmp/opencode(?:[.-].*)?$"),
-    re.compile(r"^/var/folders/.*/T/opencode.*$"),
-)
-OBSERVABILITY_QUERY = """
-    SELECT timestamp, session_id, duration_ms, project_path
-    FROM llm_requests
-    WHERE timestamp >= ?
-      AND duration_ms > 0
-      AND typeof(duration_ms) IN ('integer','real')
-      AND session_id IS NOT NULL
-      AND session_id != ''
-"""
-OBSERVABILITY_ROOT_QUERY = """
-    SELECT timestamp, session_id, duration_ms, project_path
-    FROM llm_requests
-    WHERE timestamp >= ?
-      AND duration_ms > 0
-      AND typeof(duration_ms) IN ('integer','real')
-      AND session_id IS NOT NULL
-      AND session_id != ''
-      AND (project_path = ?
-           OR project_path LIKE ? ESCAPE '\\'
-           OR project_path LIKE ? ESCAPE '\\'
-           OR project_path LIKE ? ESCAPE '\\')
-"""
-OBSERVABILITY_PLAN_QUERY = """
-    EXPLAIN QUERY PLAN
-    SELECT timestamp, session_id, duration_ms, project_path
-    FROM llm_requests
-    WHERE timestamp >= ?
-      AND duration_ms > 0
-      AND typeof(duration_ms) IN ('integer','real')
-      AND session_id IS NOT NULL
-      AND session_id != ''
-"""
-OBSERVABILITY_ROOT_PLAN_QUERY = """
-    EXPLAIN QUERY PLAN
-    SELECT timestamp, session_id, duration_ms, project_path
-    FROM llm_requests
-    WHERE timestamp >= ?
-      AND duration_ms > 0
-      AND typeof(duration_ms) IN ('integer','real')
-      AND session_id IS NOT NULL
-      AND session_id != ''
-      AND (project_path = ?
-           OR project_path LIKE ? ESCAPE '\\'
-           OR project_path LIKE ? ESCAPE '\\'
-           OR project_path LIKE ? ESCAPE '\\')
-"""
+from session_time_aggregate import aggregate
+from session_time_common import WINDOWS
+from session_time_db import db_paths, query_observability, query_session_db
 
 
-def path_matches(candidate, root):
-    if not root:
-        return True
-    if not candidate:
-        return False
-    return candidate == root or candidate.startswith(root + ".") or candidate.startswith(root + "-") or candidate.startswith(root + "/")
-
-
-def classify(title, directory):
-    if any(pattern.search(directory or "") for pattern in TEMP_PATHS):
-        return "worker"
-    if any(pattern.search(title or "") for pattern in WORKER_PATTERNS):
-        return "worker"
-    return "interactive"
-
-
-def union(intervals, start, end):
-    clipped = sorted((max(start, left), min(end, right)) for left, right in intervals if right > start and left < end)
-    result = []
-    for left, right in clipped:
-        if right <= left:
-            continue
-        if result and left <= result[-1][1]:
-            result[-1] = (result[-1][0], max(result[-1][1], right))
-        else:
-            result.append((left, right))
+def parser():
+    result = argparse.ArgumentParser()
+    result.add_argument("--repo", default="")
+    result.add_argument("--all-dirs", action="store_true")
+    result.add_argument("--db-path", default="")
+    result.add_argument("--period", choices=tuple(WINDOWS) + ("profile", "all"), default="month")
+    result.add_argument("--now-ms", type=int, default=int(time.time() * 1000))
     return result
 
 
-def duration(intervals, start, end):
-    return sum(right - left for left, right in union(intervals, start, end))
-
-
-def safe_int(value):
-    if isinstance(value, bool):
-        return None
-    try:
-        converted = int(value)
-    except (TypeError, ValueError, OverflowError):
-        return None
-    return converted
-
-
-def escaped_like(value):
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
-
-def db_paths(home, explicit):
-    if explicit:
-        return [Path(explicit)]
-    paths = [home / ".local/share/opencode/opencode.db", home / ".local/share/opencode/opencode-archive.db"]
-    work = Path(os.environ.get("AIDEVOPS_WORK_DIR", home / ".aidevops/.agent-workspace/work"))
-    paths.extend(Path(item) for item in glob.glob(str(work / "opencode-interactive/*/opencode/opencode.db")))
-    return [item for item in paths if item.is_file()]
-
-
-def note_scan(db_path):
-    counter = os.environ.get("AIDEVOPS_SESSION_SCAN_COUNTER")
-    if counter:
-        with open(counter, "a", encoding="utf-8") as handle:
-            handle.write(str(db_path) + "\n")
-
-
-def query_session_db(db_path, root, since):
-    note_scan(db_path)
-    query = """
-        SELECT s.id, s.title, s.directory, m.time_created, m.data
-        FROM session s JOIN message m ON m.session_id=s.id
-        WHERE s.parent_id IS NULL AND m.time_created >= ?
-        ORDER BY s.id, m.time_created
-    """
-    sessions = {}
-    skipped = 0
-    try:
-        with sqlite3.connect(db_path, timeout=5) as connection:
-            for session_id, title, directory, created, data in connection.execute(query, (since,)):
-                if not path_matches(directory, root):
-                    continue
-                created = safe_int(created)
-                if not session_id or created is None:
-                    skipped += 1
-                    continue
-                row = sessions.setdefault(session_id, {
-                    "session_id": session_id, "title": title or "", "directory": directory or "",
-                    "human": [], "machine": [], "first": int(created), "last": int(created), "previous_role": None,
-                    "previous_completed": None,
-                })
-                try:
-                    payload = json.loads(data or "{}")
-                    if not isinstance(payload, dict):
-                        raise ValueError("message payload is not an object")
-                except (json.JSONDecodeError, TypeError, ValueError):
-                    skipped += 1
-                    continue
-                role = payload.get("role")
-                time_data = payload.get("time", {})
-                if not isinstance(time_data, dict):
-                    skipped += 1
-                    continue
-                completed = time_data.get("completed")
-                completed = safe_int(completed)
-                if role == "user" and row["previous_role"] == "assistant" and row["previous_completed"]:
-                    gap = created - row["previous_completed"]
-                    if 0 < gap <= 3600000:
-                        row["human"].append((row["previous_completed"], created))
-                if role == "assistant" and completed and completed > created:
-                    row["machine"].append((created, completed))
-                row["previous_role"] = role
-                row["previous_completed"] = completed
-                row["first"] = min(row["first"], created)
-                row["last"] = max(row["last"], completed or created)
-    except sqlite3.Error:
-        return [], False, skipped
-    for row in sessions.values():
-        row.pop("previous_role", None)
-        row.pop("previous_completed", None)
-    return list(sessions.values()), True, skipped
-
-
-def parse_iso_ms(value):
-    try:
-        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=dt.timezone.utc)
-        return int(parsed.timestamp() * 1000)
-    except (ValueError, TypeError, OverflowError):
-        return None
-
-
-def observability_query(root, cutoff):
-    if not root:
-        return OBSERVABILITY_QUERY, OBSERVABILITY_PLAN_QUERY, (cutoff,)
-    like_root = escaped_like(root)
-    params = (cutoff, root, f"{like_root}/%", f"{like_root}.%", f"{like_root}-%")
-    return OBSERVABILITY_ROOT_QUERY, OBSERVABILITY_ROOT_PLAN_QUERY, params
-
-
-def query_observability(home, root, since, now):
-    db_path = Path(os.environ.get("AIDEVOPS_OBS_DB_FILE", home / ".aidevops/.agent-workspace/observability/llm-requests.db"))
-    if not db_path.is_file():
-        return {}, False, 0
-    rows = {}
-    skipped = 0
-    try:
-        with sqlite3.connect(db_path, timeout=5) as connection:
-            cutoff = dt.datetime.fromtimestamp(since / 1000, dt.timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
-            query, plan_query, params = observability_query(root, cutoff)
-            plan_file = os.environ.get("AIDEVOPS_OBS_QUERY_PLAN_FILE")
-            if plan_file:
-                plan = connection.execute(plan_query, params).fetchall()
-                with open(plan_file, "w", encoding="utf-8") as handle:
-                    handle.write("\n".join(str(row[3]) for row in plan) + "\n")
-            selected = 0
-            for timestamp, session_id, duration_ms, project_path in connection.execute(query, params):
-                selected += 1
-                end = parse_iso_ms(timestamp)
-                duration_ms = safe_int(duration_ms)
-                if end is None or duration_ms is None or end < since:
-                    skipped += 1
-                    continue
-                end = min(now, end)
-                start = max(since, end - duration_ms)
-                if end <= start:
-                    skipped += 1
-                    continue
-                row = rows.setdefault(session_id, {"intervals": [], "directory": project_path or ""})
-                row["intervals"].append((start, end))
-            counter = os.environ.get("AIDEVOPS_OBS_ROW_COUNTER")
-            if counter:
-                with open(counter, "a", encoding="utf-8") as handle:
-                    handle.write(f"{selected}\n")
-    except sqlite3.Error:
-        return {}, False, skipped
-    return rows, True, skipped
-
-
-def aggregate(sessions, obs_rows, since, now, sources_ok):
-    population = {}
-    for row in sessions:
-        population[row["session_id"]] = row
-    for session_id, obs in obs_rows.items():
-        if session_id not in population:
-            population[session_id] = {
-                "session_id": session_id, "title": "observability-only headless session",
-                "directory": obs["directory"], "human": [], "machine": [],
-                "first": min(left for left, _ in obs["intervals"]),
-                "last": max(right for _, right in obs["intervals"]),
-            }
-
-    human_by_type = {"interactive": [], "worker": []}
-    machine_by_type = {"interactive": 0, "worker": 0}
-    counts = {"interactive": 0, "worker": 0}
-    first_seen = []
-    last_seen = []
-    for session_id, row in population.items():
-        human = union(row.get("human", []), since, now)
-        machine_source = row.get("machine", []) + obs_rows.get(session_id, {}).get("intervals", [])
-        machine = union(machine_source, since, now)
-        if not human and not machine and row.get("last", 0) < since:
-            continue
-        session_type = classify(row.get("title", ""), row.get("directory", ""))
-        counts[session_type] += 1
-        human_by_type[session_type].extend(human)
-        machine_by_type[session_type] += sum(right - left for left, right in machine)
-        first_seen.append(max(since, row.get("first", since)))
-        last_seen.append(min(now, row.get("last", now)))
-
-    interactive_human = duration(human_by_type["interactive"], since, now)
-    worker_human = duration(human_by_type["worker"], since, now)
-    total_human = duration(human_by_type["interactive"] + human_by_type["worker"], since, now)
-    interactive_machine = machine_by_type["interactive"]
-    worker_machine = machine_by_type["worker"]
-    observed_days = round(max(0, max(last_seen) - min(first_seen)) / DAY_MS, 1) if first_seen and last_seen else 0
-
-    def hours(milliseconds):
-        return round(milliseconds / 3600000, 1)
-
-    return {
-        "interactive_sessions": counts["interactive"],
-        "interactive_human_hours": hours(interactive_human),
-        "interactive_machine_hours": hours(interactive_machine),
-        "worker_sessions": counts["worker"],
-        "worker_human_hours": hours(worker_human),
-        "worker_machine_hours": hours(worker_machine),
-        "total_human_hours": hours(total_human),
-        "total_machine_hours": hours(interactive_machine + worker_machine),
-        "total_sessions": counts["interactive"] + counts["worker"],
-        "observed_days": observed_days,
-        "status": "ok" if sources_ok else "unavailable",
-        "provenance": "session-message-intervals+observability-request-intervals" if obs_rows else "session-message-intervals",
-        "human_attention_semantics": "unioned wall-clock intervals",
-        "machine_work_semantics": "additive per-session generation intervals",
-    }
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--repo", default="")
-    parser.add_argument("--all-dirs", action="store_true")
-    parser.add_argument("--db-path", default="")
-    parser.add_argument("--period", choices=tuple(WINDOWS) + ("profile", "all"), default="month")
-    parser.add_argument("--now-ms", type=int, default=int(time.time() * 1000))
-    args = parser.parse_args()
-    root = "" if args.all_dirs else os.path.abspath(args.repo or ".")
-    home = Path.home()
-    maximum_since = args.now_ms - WINDOWS["year"]
+def collect_sessions(home, explicit, root, since):
     sessions = []
+    seen = set()
     source_ok = False
     skipped_rows = 0
-    seen = set()
-    for db_path in db_paths(home, args.db_path):
-        queried, ok, skipped = query_session_db(db_path, root, maximum_since)
+    for db_path in db_paths(home, explicit):
+        queried, ok, skipped = query_session_db(db_path, root, since)
         skipped_rows += skipped
         source_ok = source_ok or ok
         for row in queried:
             if row["session_id"] not in seen:
                 sessions.append(row)
                 seen.add(row["session_id"])
-    obs_rows, obs_ok, obs_skipped = query_observability(home, root, maximum_since, args.now_ms)
-    skipped_rows += obs_skipped
-    source_ok = source_ok or obs_ok
+    return sessions, source_ok, skipped_rows
 
-    periods = ["day", "week", "28d", "year"] if args.period == "profile" else (
-        ["day", "week", "month", "quarter", "year"] if args.period == "all" else [args.period]
-    )
-    result = {
-        period: aggregate(sessions, obs_rows, args.now_ms - WINDOWS.get(period, WINDOWS["month"]), args.now_ms, source_ok)
-        for period in periods
-    }
-    for item in result.values():
-        item["skipped_malformed_rows"] = skipped_rows
-    print(json.dumps(result if len(periods) > 1 else result[periods[0]], indent=2, sort_keys=True))
+
+def requested_periods(period):
+    if period == "profile":
+        return ["day", "week", "28d", "year"]
+    if period == "all":
+        return ["day", "week", "month", "quarter", "year"]
+    return [period]
+
+
+def aggregate_periods(periods, context):
+    result = {}
+    for period in periods:
+        since = context["now"] - WINDOWS.get(period, WINDOWS["month"])
+        result[period] = aggregate(context["sessions"], context["obs_rows"], since, context["now"], context["source_ok"])
+        result[period]["skipped_malformed_rows"] = context["skipped"]
+    return result
+
+
+def main():
+    args = parser().parse_args()
+    root = "" if args.all_dirs else os.path.abspath(args.repo or ".")
+    home = Path.home()
+    maximum_since = args.now_ms - WINDOWS["year"]
+    sessions, session_ok, skipped = collect_sessions(home, args.db_path, root, maximum_since)
+    obs_rows, obs_ok, obs_skipped = query_observability(home, root, maximum_since, args.now_ms)
+    skipped += obs_skipped
+    periods = requested_periods(args.period)
+    context = {"sessions": sessions, "obs_rows": obs_rows, "now": args.now_ms, "source_ok": session_ok or obs_ok, "skipped": skipped}
+    result = aggregate_periods(periods, context)
+    payload = result if len(periods) > 1 else result[periods[0]]
+    print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 

--- a/.agents/scripts/session_time_aggregate.py
+++ b/.agents/scripts/session_time_aggregate.py
@@ -1,0 +1,90 @@
+"""Aggregate normalized session and observability intervals."""
+
+from __future__ import annotations
+
+from session_time_common import DAY_MS, classify, duration, union
+
+
+def population_with_observability(sessions, obs_rows):
+    population = {row["session_id"]: row for row in sessions}
+    for session_id, obs in obs_rows.items():
+        if session_id in population:
+            continue
+        population[session_id] = {
+            "session_id": session_id,
+            "title": "observability-only headless session",
+            "directory": obs["directory"],
+            "human": [],
+            "machine": [],
+            "first": min(left for left, _ in obs["intervals"]),
+            "last": max(right for _, right in obs["intervals"]),
+        }
+    return population
+
+
+def empty_totals():
+    return {
+        "human": {"interactive": [], "worker": []},
+        "machine": {"interactive": 0, "worker": 0},
+        "counts": {"interactive": 0, "worker": 0},
+        "first": [],
+        "last": [],
+    }
+
+
+def accumulate_row(totals, row, obs_rows, since, now):
+    session_id = row["session_id"]
+    human = union(row.get("human", []), since, now)
+    machine_source = row.get("machine", []) + obs_rows.get(session_id, {}).get("intervals", [])
+    machine = union(machine_source, since, now)
+    if not human and not machine and row.get("last", 0) < since:
+        return
+    session_type = classify(row.get("title", ""), row.get("directory", ""))
+    totals["counts"][session_type] += 1
+    totals["human"][session_type].extend(human)
+    totals["machine"][session_type] += sum(right - left for left, right in machine)
+    totals["first"].append(max(since, row.get("first", since)))
+    totals["last"].append(min(now, row.get("last", now)))
+
+
+def observed_days(totals):
+    if not totals["first"] or not totals["last"]:
+        return 0
+    elapsed = max(0, max(totals["last"]) - min(totals["first"]))
+    return round(elapsed / DAY_MS, 1)
+
+
+def hours(milliseconds):
+    return round(milliseconds / 3600000, 1)
+
+
+def totals_payload(totals, obs_rows, since, now, sources_ok):
+    interactive_human = duration(totals["human"]["interactive"], since, now)
+    worker_human = duration(totals["human"]["worker"], since, now)
+    total_human = duration(totals["human"]["interactive"] + totals["human"]["worker"], since, now)
+    interactive_machine = totals["machine"]["interactive"]
+    worker_machine = totals["machine"]["worker"]
+    return {
+        "interactive_sessions": totals["counts"]["interactive"],
+        "interactive_human_hours": hours(interactive_human),
+        "interactive_machine_hours": hours(interactive_machine),
+        "worker_sessions": totals["counts"]["worker"],
+        "worker_human_hours": hours(worker_human),
+        "worker_machine_hours": hours(worker_machine),
+        "total_human_hours": hours(total_human),
+        "total_machine_hours": hours(interactive_machine + worker_machine),
+        "total_sessions": totals["counts"]["interactive"] + totals["counts"]["worker"],
+        "observed_days": observed_days(totals),
+        "status": "ok" if sources_ok else "unavailable",
+        "provenance": "session-message-intervals+observability-request-intervals" if obs_rows else "session-message-intervals",
+        "human_attention_semantics": "unioned wall-clock intervals",
+        "machine_work_semantics": "additive per-session generation intervals",
+    }
+
+
+def aggregate(sessions, obs_rows, since, now, sources_ok):
+    population = population_with_observability(sessions, obs_rows)
+    totals = empty_totals()
+    for row in population.values():
+        accumulate_row(totals, row, obs_rows, since, now)
+    return totals_payload(totals, obs_rows, since, now, sources_ok)

--- a/.agents/scripts/session_time_common.py
+++ b/.agents/scripts/session_time_common.py
@@ -1,0 +1,77 @@
+"""Shared interval and classification primitives for session aggregation."""
+
+from __future__ import annotations
+
+import re
+
+DAY_MS = 86400000
+WINDOWS = {
+    "day": DAY_MS,
+    "week": 7 * DAY_MS,
+    "28d": 28 * DAY_MS,
+    "month": 30 * DAY_MS,
+    "quarter": 90 * DAY_MS,
+    "year": 365 * DAY_MS,
+}
+WORKER_PATTERNS = [
+    re.compile(pattern, re.I)
+    for pattern in (
+        r"^Issue #\d+", r"^PR #\d+", r"^Fix PR\b", r"^Review PR\b",
+        r"^Supervisor Pulse", r"/full-loop", r"^dispatch:", r"^Worker:",
+        r"^t\d+[.\-:]", r"^escalation-", r"^health-check$", r"failing CI\b",
+        r"CI fail", r"CHANGES_REQUESTED", r"CodeRabbit review", r"address review",
+        r"review feedback", r"^Fix qlty\b", r"^Gemini feedback\b",
+        r"^observability-only headless session$",
+    )
+]
+TEMP_PATHS = (
+    re.compile(r"^/private/tmp/opencode(?:[.-].*)?$"),
+    re.compile(r"^/tmp/opencode(?:[.-].*)?$"),
+    re.compile(r"^/var/folders/.*/T/opencode.*$"),
+)
+
+
+def path_matches(candidate, root):
+    if not root:
+        return True
+    if not candidate:
+        return False
+    suffix_match = candidate.startswith(root + ".") or candidate.startswith(root + "-")
+    return candidate == root or candidate.startswith(root + "/") or suffix_match
+
+
+def classify(title, directory):
+    if any(pattern.search(directory or "") for pattern in TEMP_PATHS):
+        return "worker"
+    return "worker" if any(pattern.search(title or "") for pattern in WORKER_PATTERNS) else "interactive"
+
+
+def clip_interval(interval, start, end):
+    left, right = interval
+    if right <= start or left >= end:
+        return None
+    return max(start, left), min(end, right)
+
+
+def union(intervals, start, end):
+    clipped = [candidate for item in intervals if (candidate := clip_interval(item, start, end)) is not None]
+    result = []
+    for left, right in sorted(clipped):
+        if result and left <= result[-1][1]:
+            result[-1] = (result[-1][0], max(result[-1][1], right))
+        else:
+            result.append((left, right))
+    return result
+
+
+def duration(intervals, start, end):
+    return sum(right - left for left, right in union(intervals, start, end))
+
+
+def safe_int(value):
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None

--- a/.agents/scripts/session_time_db.py
+++ b/.agents/scripts/session_time_db.py
@@ -1,0 +1,228 @@
+"""Read-only SQLite collection for session and observability intervals."""
+
+from __future__ import annotations
+
+import datetime as dt
+import glob
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+from session_time_common import path_matches, safe_int
+
+SESSION_QUERY = """
+    SELECT s.id, s.title, s.directory, m.time_created, m.data
+    FROM session s JOIN message m ON m.session_id=s.id
+    WHERE s.parent_id IS NULL AND m.time_created >= ?
+    ORDER BY s.id, m.time_created
+"""
+OBS_QUERY = """
+    SELECT timestamp, session_id, duration_ms, project_path FROM llm_requests
+    WHERE timestamp >= ? AND duration_ms > 0
+      AND typeof(duration_ms) IN ('integer','real')
+      AND session_id IS NOT NULL AND session_id != ''
+"""
+OBS_ROOT_QUERY = """
+    SELECT timestamp, session_id, duration_ms, project_path FROM llm_requests
+    WHERE timestamp >= ? AND duration_ms > 0
+      AND typeof(duration_ms) IN ('integer','real')
+      AND session_id IS NOT NULL AND session_id != ''
+      AND (project_path = ? OR project_path LIKE ? ESCAPE '\\'
+           OR project_path LIKE ? ESCAPE '\\' OR project_path LIKE ? ESCAPE '\\')
+"""
+OBS_PLAN_QUERY = """
+    EXPLAIN QUERY PLAN
+    SELECT timestamp, session_id, duration_ms, project_path FROM llm_requests
+    WHERE timestamp >= ? AND duration_ms > 0
+      AND typeof(duration_ms) IN ('integer','real')
+      AND session_id IS NOT NULL AND session_id != ''
+"""
+OBS_ROOT_PLAN_QUERY = """
+    EXPLAIN QUERY PLAN
+    SELECT timestamp, session_id, duration_ms, project_path FROM llm_requests
+    WHERE timestamp >= ? AND duration_ms > 0
+      AND typeof(duration_ms) IN ('integer','real')
+      AND session_id IS NOT NULL AND session_id != ''
+      AND (project_path = ? OR project_path LIKE ? ESCAPE '\\'
+           OR project_path LIKE ? ESCAPE '\\' OR project_path LIKE ? ESCAPE '\\')
+"""
+
+
+def readonly_connection(db_path):
+    uri = db_path.resolve().as_uri() + "?mode=ro"
+    return sqlite3.connect(uri, uri=True, timeout=5)
+
+
+def db_paths(home, explicit):
+    if explicit:
+        path = Path(explicit)
+        return [path] if path.is_file() else []
+    paths = [home / ".local/share/opencode/opencode.db", home / ".local/share/opencode/opencode-archive.db"]
+    work = Path(os.environ.get("AIDEVOPS_WORK_DIR", home / ".aidevops/.agent-workspace/work"))
+    paths.extend(Path(item) for item in glob.glob(str(work / "opencode-interactive/*/opencode/opencode.db")))
+    return [item for item in paths if item.is_file()]
+
+
+def note_scan(db_path):
+    counter = os.environ.get("AIDEVOPS_SESSION_SCAN_COUNTER")
+    if counter:
+        with open(counter, "a", encoding="utf-8") as handle:
+            handle.write(str(db_path) + "\n")
+
+
+def parse_message(data):
+    try:
+        payload = json.loads(data or "{}")
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("time", {}), dict):
+        return None
+    return payload.get("role"), safe_int(payload.get("time", {}).get("completed"))
+
+
+def session_row(sessions, values):
+    session_id, title, directory, created = values
+    return sessions.setdefault(session_id, {
+        "session_id": session_id,
+        "title": title or "",
+        "directory": directory or "",
+        "human": [],
+        "machine": [],
+        "first": created,
+        "last": created,
+        "previous_role": None,
+        "previous_completed": None,
+    })
+
+
+def apply_message(row, role, created, completed):
+    previous = row["previous_completed"]
+    if role == "user" and row["previous_role"] == "assistant" and previous:
+        gap = created - previous
+        if 0 < gap <= 3600000:
+            row["human"].append((previous, created))
+    if role == "assistant" and completed and completed > created:
+        row["machine"].append((created, completed))
+    row.update(previous_role=role, previous_completed=completed)
+    row["first"] = min(row["first"], created)
+    row["last"] = max(row["last"], completed or created)
+
+
+def consume_session_record(sessions, record, root):
+    session_id, title, directory, raw_created, data = record
+    created = safe_int(raw_created)
+    parsed = parse_message(data)
+    if not path_matches(directory, root) or not session_id or created is None or parsed is None:
+        return 1 if path_matches(directory, root) else 0
+    row = session_row(sessions, (session_id, title, directory, created))
+    apply_message(row, parsed[0], created, parsed[1])
+    return 0
+
+
+def finalized_sessions(sessions):
+    for row in sessions.values():
+        row.pop("previous_role", None)
+        row.pop("previous_completed", None)
+    return list(sessions.values())
+
+
+def query_session_db(db_path, root, since):
+    note_scan(db_path)
+    sessions = {}
+    skipped = 0
+    try:
+        with readonly_connection(db_path) as connection:
+            for record in connection.execute(SESSION_QUERY, (since,)):
+                skipped += consume_session_record(sessions, record, root)
+    except (OSError, sqlite3.Error):
+        return [], False, skipped
+    return finalized_sessions(sessions), True, skipped
+
+
+def parse_iso_ms(value):
+    try:
+        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return int(parsed.timestamp() * 1000)
+    except (OSError, ValueError, TypeError, OverflowError):
+        return None
+
+
+def safe_cutoff(since):
+    try:
+        seconds = float(since) / 1000
+        seconds = min(253402300799.0, max(0.0, seconds))
+        parsed = dt.datetime.fromtimestamp(seconds, dt.timezone.utc)
+    except (OSError, OverflowError, TypeError, ValueError):
+        parsed = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    return parsed.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def escaped_like(value):
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def observability_query(root, cutoff):
+    if not root:
+        return OBS_QUERY, OBS_PLAN_QUERY, (cutoff,)
+    escaped = escaped_like(root)
+    params = (cutoff, root, f"{escaped}/%", f"{escaped}.%", f"{escaped}-%")
+    return OBS_ROOT_QUERY, OBS_ROOT_PLAN_QUERY, params
+
+
+def write_query_plan(connection, query, params):
+    plan_file = os.environ.get("AIDEVOPS_OBS_QUERY_PLAN_FILE")
+    if not plan_file:
+        return
+    plan = connection.execute(query, params).fetchall()
+    Path(plan_file).write_text("\n".join(str(row[3]) for row in plan) + "\n", encoding="utf-8")
+
+
+def observability_interval(record, since, now):
+    timestamp, session_id, duration_ms, project_path = record
+    end = parse_iso_ms(timestamp)
+    duration = safe_int(duration_ms)
+    if end is None or duration is None or end < since:
+        return None
+    end = min(now, end)
+    start = max(since, end - duration)
+    if end <= start:
+        return None
+    return session_id, project_path, start, end
+
+
+def append_observability(rows, interval):
+    session_id, project_path, start, end = interval
+    row = rows.setdefault(session_id, {"intervals": [], "directory": project_path or ""})
+    row["intervals"].append((start, end))
+
+
+def write_selected_count(selected):
+    counter = os.environ.get("AIDEVOPS_OBS_ROW_COUNTER")
+    if counter:
+        with open(counter, "a", encoding="utf-8") as handle:
+            handle.write(f"{selected}\n")
+
+
+def query_observability(home, root, since, now):
+    db_path = Path(os.environ.get("AIDEVOPS_OBS_DB_FILE", home / ".aidevops/.agent-workspace/observability/llm-requests.db"))
+    if not db_path.is_file():
+        return {}, False, 0
+    rows, skipped, selected = {}, 0, 0
+    query, plan_query, params = observability_query(root, safe_cutoff(since))
+    try:
+        with readonly_connection(db_path) as connection:
+            write_query_plan(connection, plan_query, params)
+            for record in connection.execute(query, params):
+                selected += 1
+                interval = observability_interval(record, since, now)
+                if interval is None:
+                    skipped += 1
+                else:
+                    append_observability(rows, interval)
+        write_selected_count(selected)
+    except (OSError, sqlite3.Error):
+        return {}, False, skipped
+    return rows, True, skipped

--- a/.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh
+++ b/.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh
@@ -46,6 +46,7 @@ assert_b603_annotated() {
 assert_b603_annotated ".agents/scripts/session-miner/extract.py" "subprocess.run(  # nosec B603"
 assert_b603_annotated ".agents/scripts/session_tail_query.py" "subprocess.run(  # nosec B603"
 assert_b603_annotated ".agents/scripts/vault-crypto-helper.py" "subprocess.Popen(  # nosec B603"
+assert_b603_annotated ".agents/scripts/screen-time-interval-engine.py" "subprocess.run(  # nosec B603"
 
 printf '\nTests run: %s\n' "$TESTS_RUN"
 if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh
+++ b/.agents/scripts/tests/test-codefactor-bandit-b603-annotations.sh
@@ -46,7 +46,7 @@ assert_b603_annotated() {
 assert_b603_annotated ".agents/scripts/session-miner/extract.py" "subprocess.run(  # nosec B603"
 assert_b603_annotated ".agents/scripts/session_tail_query.py" "subprocess.run(  # nosec B603"
 assert_b603_annotated ".agents/scripts/vault-crypto-helper.py" "subprocess.Popen(  # nosec B603"
-assert_b603_annotated ".agents/scripts/screen-time-interval-engine.py" "subprocess.run(  # nosec B603"
+assert_b603_annotated ".agents/scripts/screen_time_linux.py" "subprocess.run(  # nosec B603"
 
 printf '\nTests run: %s\n' "$TESTS_RUN"
 if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -507,6 +507,97 @@ test_malformed_numeric_rows_and_invalid_period() {
 	return 0
 }
 
+assert_missing_option_fails_cleanly() {
+	local function_name="$1"
+	local option_name="$2"
+	local stderr_file="$3"
+	if "$function_name" "$option_name" >"${stderr_file}.out" 2>"$stderr_file"; then
+		return 1
+	fi
+	if grep -qF "Error: ${option_name} requires an argument" "$stderr_file"; then
+		return 0
+	fi
+	return 1
+}
+
+test_value_options_validate_before_shift() {
+	local test_name="session value options fail cleanly before shift"
+	setup
+	# shellcheck source=../contributor-activity-helper-session.sh
+	source "$SOURCE_SESSION_LIB"
+	local stderr_file="${TEST_DIR}/option-error"
+	local failed=0
+	assert_missing_option_fails_cleanly session_time --period "$stderr_file" || failed=1
+	assert_missing_option_fails_cleanly session_time --format "$stderr_file" || failed=1
+	assert_missing_option_fails_cleanly session_time --db-path "$stderr_file" || failed=1
+	assert_missing_option_fails_cleanly cross_repo_session_time --period "$stderr_file" || failed=1
+	assert_missing_option_fails_cleanly cross_repo_session_time --format "$stderr_file" || failed=1
+	if [[ "$failed" -ne 0 ]]; then
+		print_result "$test_name" 1 "a value-taking option did not return an explicit diagnostic"
+		teardown
+		return 0
+	fi
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
+test_explicit_db_is_existing_read_only_file_and_cutoff_is_safe() {
+	local test_name="explicit session DBs are existing read-only files and cutoffs are bounded"
+	setup
+	# shellcheck source=../contributor-activity-helper-session.sh
+	source "$SOURCE_SESSION_LIB"
+	local db_path="${TEST_DIR}/explicit.db"
+	local missing_path="${TEST_DIR}/must-not-exist.db"
+	create_session_db "$db_path"
+	local now_ms
+	now_ms=$(($(date +%s) * 1000))
+	insert_session_fixture "$db_path" "explicit-session" "Explicit session" "$((now_ms - 60000))" "$TEST_DIR/repo"
+	chmod 444 "$db_path"
+	local output sessions
+	output=$(HOME="${TEST_DIR}/home" session_time --all-dirs --db-path "$db_path" --period day --format json)
+	sessions=$(printf '%s' "$output" | jq -r '.total_sessions')
+	HOME="${TEST_DIR}/home" session_time --all-dirs --db-path "$missing_path" --period day --format json >/dev/null
+	local cutoff_ok=0
+	PYTHONPATH="${SCRIPT_DIR}/.." python3 - <<'PY' || cutoff_ok=1
+from session_time_db import safe_cutoff
+
+epoch = "1970-01-01T00:00:00.000Z"
+assert safe_cutoff(-1) == epoch
+assert safe_cutoff("corrupt") == epoch
+assert safe_cutoff(10**500) == epoch
+PY
+	local missing_created="no"
+	[[ -e "$missing_path" ]] && missing_created="yes"
+	if [[ "$sessions" != "1" || -e "$missing_path" || "$cutoff_ok" -ne 0 ]]; then
+		print_result "$test_name" 1 "read-only explicit DB or safe cutoff contract failed: sessions=${sessions} missing_created=${missing_created}"
+		teardown
+		return 0
+	fi
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
+test_session_engine_sibling_modules_deploy_together() {
+	local test_name="session engine loads deployed sibling modules"
+	setup
+	local deploy_dir="${TEST_DIR}/deployed"
+	mkdir -p "$deploy_dir"
+	cp "${SCRIPT_DIR}/../session-time-interval-engine.py" "${SCRIPT_DIR}/../session_time_common.py" \
+		"${SCRIPT_DIR}/../session_time_db.py" "${SCRIPT_DIR}/../session_time_aggregate.py" "$deploy_dir/"
+	local output
+	output=$(HOME="${TEST_DIR}/home" python3 "${deploy_dir}/session-time-interval-engine.py" --all-dirs --period day)
+	if [[ "$(printf '%s' "$output" | jq -r '.status')" != "unavailable" ]]; then
+		print_result "$test_name" 1 "isolated deployed engine did not load sibling modules: ${output}"
+		teardown
+		return 0
+	fi
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
 main() {
 	if [[ ! -f "$SOURCE_SESSION_LIB" ]]; then
 		echo "Session library not found: ${SOURCE_SESSION_LIB}" >&2
@@ -524,6 +615,9 @@ main() {
 	test_partial_observability_unions_with_message_generation
 	test_observability_sql_filters_old_and_other_roots
 	test_malformed_numeric_rows_and_invalid_period
+	test_value_options_validate_before_shift
+	test_explicit_db_is_existing_read_only_file_and_cutoff_is_safe
+	test_session_engine_sibling_modules_deploy_together
 
 	echo ""
 	echo "Tests run: ${TESTS_RUN}"

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -154,6 +154,28 @@ SQL
 	return 0
 }
 
+insert_overlapping_attention_fixture() {
+	local db_path="$1"
+	local session_id="$2"
+	local start_ms="$3"
+	local directory="$4"
+	local assistant_completed=$((start_ms + 10000))
+	local user_created=$((assistant_completed + 1800000))
+
+	python3 - "$db_path" "$session_id" "$start_ms" "$directory" "$assistant_completed" "$user_created" <<'PY'
+import json
+import sqlite3
+import sys
+
+db_path, session_id, start_ms, directory, completed, user_created = sys.argv[1:]
+with sqlite3.connect(db_path) as conn:
+    conn.execute("INSERT INTO session(id,title,parent_id,directory) VALUES(?,?,NULL,?)", (session_id, "Interactive overlap", directory))
+    conn.execute("INSERT INTO message(session_id,data,time_created) VALUES(?,?,?)", (session_id, json.dumps({"role":"assistant","time":{"completed":int(completed)}}), int(start_ms)))
+    conn.execute("INSERT INTO message(session_id,data,time_created) VALUES(?,?,?)", (session_id, '{"role":"user"}', int(user_created)))
+PY
+	return 0
+}
+
 test_session_time_includes_archive_and_dedupes() {
 	local test_name="session time includes OpenCode archive and dedupes"
 	setup
@@ -262,12 +284,14 @@ test_session_time_uses_observability_machine_floor() {
 	insert_observability_fixture "$obs_db" "current-interactive" 10000 "$TEST_DIR/repo"
 	insert_observability_fixture "$obs_db" "worker-only" 7200000 "$TEST_DIR/repo-feature-auto-20260616-120000-gh123"
 
-	local all_json repo_json worker_machine total_machine repo_worker_machine
+	local all_json repo_json worker_machine total_machine repo_worker_machine total_sessions worker_sessions
 	all_json=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period day --format json)
 	repo_json=$(HOME="${TEST_DIR}/home" session_time "${TEST_DIR}/repo" --period day --format json)
 	worker_machine=$(echo "$all_json" | jq -r '.worker_machine_hours')
 	total_machine=$(echo "$all_json" | jq -r '.total_machine_hours')
 	repo_worker_machine=$(echo "$repo_json" | jq -r '.worker_machine_hours')
+	total_sessions=$(echo "$all_json" | jq -r '.total_sessions')
+	worker_sessions=$(echo "$all_json" | jq -r '.worker_sessions')
 
 	if [[ "$worker_machine" != "2" && "$worker_machine" != "2.0" ]]; then
 		print_result "$test_name" 1 "expected 2.0 worker machine hours from observability, got ${worker_machine}; JSON: ${all_json}"
@@ -284,7 +308,43 @@ test_session_time_uses_observability_machine_floor() {
 		teardown
 		return 0
 	fi
+	if [[ "$total_sessions" != "2" || "$worker_sessions" != "1" ]]; then
+		print_result "$test_name" 1 "observability hours/count population did not reconcile; total=${total_sessions} workers=${worker_sessions}"
+		teardown
+		return 0
+	fi
 
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
+test_profile_periods_scan_once_and_union_attention() {
+	local test_name="profile periods scan once and union overlapping human attention"
+	setup
+	# shellcheck source=../contributor-activity-helper-session.sh
+	source "$SOURCE_SESSION_LIB"
+	local active_db="${TEST_DIR}/home/.local/share/opencode/opencode.db"
+	create_session_db "$active_db"
+	local now_ms start_ms counter output human scans
+	now_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
+	start_ms=$((now_ms - 3600000))
+	insert_overlapping_attention_fixture "$active_db" "overlap-one" "$start_ms" "$TEST_DIR/repo"
+	insert_overlapping_attention_fixture "$active_db" "overlap-two" "$start_ms" "$TEST_DIR/repo"
+	counter="${TEST_DIR}/scan-count"
+	output=$(HOME="${TEST_DIR}/home" AIDEVOPS_SESSION_SCAN_COUNTER="$counter" session_time --all-dirs --period profile --format json)
+	human=$(echo "$output" | jq -r '.day.total_human_hours')
+	scans=$(wc -l <"$counter" | tr -d ' ')
+	if [[ "$human" != "0.5" ]]; then
+		print_result "$test_name" 1 "expected overlapping 0.5h attention intervals to union to 0.5h, got ${human}"
+		teardown
+		return 0
+	fi
+	if [[ "$scans" != "1" ]]; then
+		print_result "$test_name" 1 "expected one session DB scan for four profile windows, got ${scans}"
+		teardown
+		return 0
+	fi
 	print_result "$test_name" 0
 	teardown
 	return 0
@@ -347,6 +407,7 @@ main() {
 	test_session_time_includes_archive_and_dedupes
 	test_session_time_uses_observability_machine_floor
 	test_session_time_repo_filter_treats_path_metacharacters_literally
+	test_profile_periods_scan_once_and_union_attention
 
 	echo ""
 	echo "Tests run: ${TESTS_RUN}"

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -137,7 +137,27 @@ create_observability_db() {
 			duration_ms INTEGER,
 			project_path TEXT
 		);
+		CREATE INDEX idx_llm_requests_timestamp ON llm_requests(timestamp);
 	'
+	return 0
+}
+
+insert_machine_interval_fixture() {
+	local db_path="$1"
+	local session_id="$2"
+	local start_ms="$3"
+	local completed_ms="$4"
+	local directory="$5"
+	python3 - "$db_path" "$session_id" "$start_ms" "$completed_ms" "$directory" <<'PY'
+import json
+import sqlite3
+import sys
+
+db_path, session_id, start_ms, completed_ms, directory = sys.argv[1:]
+with sqlite3.connect(db_path) as conn:
+    conn.execute("INSERT INTO session(id,title,parent_id,directory) VALUES(?,?,NULL,?)", (session_id, "Issue #77: partial observability", directory))
+    conn.execute("INSERT INTO message(session_id,data,time_created) VALUES(?,?,?)", (session_id, json.dumps({"role":"assistant","time":{"completed":int(completed_ms)}}), int(start_ms)))
+PY
 	return 0
 }
 
@@ -394,6 +414,99 @@ test_session_time_repo_filter_treats_path_metacharacters_literally() {
 	return 0
 }
 
+test_partial_observability_unions_with_message_generation() {
+	local test_name="partial observability unions with complete message generation"
+	setup
+	# shellcheck source=../contributor-activity-helper-session.sh
+	source "$SOURCE_SESSION_LIB"
+	local active_db="${TEST_DIR}/home/.local/share/opencode/opencode.db"
+	local obs_db="${TEST_DIR}/home/.aidevops/.agent-workspace/observability/llm-requests.db"
+	create_session_db "$active_db"
+	create_observability_db "$obs_db"
+	local now_ms message_start message_end
+	now_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
+	message_start=$((now_ms - 4 * 3600000))
+	message_end=$((now_ms - 1 * 3600000))
+	insert_machine_interval_fixture "$active_db" "partial-worker" "$message_start" "$message_end" "$TEST_DIR/repo"
+	insert_observability_fixture "$obs_db" "partial-worker" 7200000 "$TEST_DIR/repo"
+	local output machine
+	output=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period day --format json)
+	machine=$(printf '%s' "$output" | jq -r '.worker_machine_hours')
+	if [[ "$machine" != "4" && "$machine" != "4.0" ]]; then
+		print_result "$test_name" 1 "expected 3h message + 2h observability with 1h overlap to union to 4h, got ${machine}; ${output}"
+		teardown
+		return 0
+	fi
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
+test_observability_sql_filters_old_and_other_roots() {
+	local test_name="observability SQL filters timestamp and root before row conversion"
+	setup
+	# shellcheck source=../contributor-activity-helper-session.sh
+	source "$SOURCE_SESSION_LIB"
+	local obs_db="${TEST_DIR}/home/.aidevops/.agent-workspace/observability/llm-requests.db"
+	create_observability_db "$obs_db"
+	python3 - "$obs_db" "$TEST_DIR/repo" <<'PY'
+import datetime as dt
+import sqlite3
+import sys
+
+db_path, root = sys.argv[1:]
+old = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=500)).isoformat().replace("+00:00", "Z")
+now = dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+with sqlite3.connect(db_path) as conn:
+    conn.executemany("INSERT INTO llm_requests VALUES(?,?,?,?)", [(old, f"old-{i}", 1000, root) for i in range(1000)])
+    conn.execute("INSERT INTO llm_requests VALUES(?,?,?,?)", (now, "wanted", 60000, root))
+    conn.execute("INSERT INTO llm_requests VALUES(?,?,?,?)", (now, "other-root", 60000, root + "X"))
+    conn.execute("INSERT INTO llm_requests VALUES(?,?,?,?)", (now, "bad-number", "corrupt", root))
+PY
+	local counter="${TEST_DIR}/obs-selected-count"
+	local plan_file="${TEST_DIR}/obs-query-plan"
+	local output selected sessions
+	output=$(HOME="${TEST_DIR}/home" AIDEVOPS_OBS_ROW_COUNTER="$counter" AIDEVOPS_OBS_QUERY_PLAN_FILE="$plan_file" session_time "$TEST_DIR/repo" --period day --format json)
+	selected=$(awk '{sum += $1} END {print sum + 0}' "$counter")
+	sessions=$(printf '%s' "$output" | jq -r '.total_sessions')
+	if [[ "$selected" != "1" || "$sessions" != "1" ]] || ! grep -qF 'idx_llm_requests_timestamp' "$plan_file"; then
+		print_result "$test_name" 1 "expected indexed SQL range to return one current matching row, selected=${selected} sessions=${sessions} plan=$(<"$plan_file"); ${output}"
+		teardown
+		return 0
+	fi
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
+test_malformed_numeric_rows_and_invalid_period() {
+	local test_name="malformed numeric rows are skipped and invalid periods rejected"
+	setup
+	# shellcheck source=../contributor-activity-helper-session.sh
+	source "$SOURCE_SESSION_LIB"
+	local active_db="${TEST_DIR}/home/.local/share/opencode/opencode.db"
+	create_session_db "$active_db"
+	sqlite3 "$active_db" "
+		INSERT INTO session VALUES('bad-created','Bad created',NULL,'${TEST_DIR}/repo');
+		INSERT INTO message VALUES('bad-created','{\"role\":\"assistant\",\"time\":{\"completed\":\"broken\"}}','not-a-number');"
+	local output skipped
+	output=$(HOME="${TEST_DIR}/home" session_time --all-dirs --period day --format json)
+	skipped=$(printf '%s' "$output" | jq -r '.skipped_malformed_rows')
+	if [[ "$skipped" -lt 1 ]]; then
+		print_result "$test_name" 1 "corrupt numeric row was not counted as skipped: ${output}"
+		teardown
+		return 0
+	fi
+	if HOME="${TEST_DIR}/home" session_time --all-dirs --period nonsense --format json >/dev/null 2>&1; then
+		print_result "$test_name" 1 "invalid period unexpectedly succeeded"
+		teardown
+		return 0
+	fi
+	print_result "$test_name" 0
+	teardown
+	return 0
+}
+
 main() {
 	if [[ ! -f "$SOURCE_SESSION_LIB" ]]; then
 		echo "Session library not found: ${SOURCE_SESSION_LIB}" >&2
@@ -408,6 +521,9 @@ main() {
 	test_session_time_uses_observability_machine_floor
 	test_session_time_repo_filter_treats_path_metacharacters_literally
 	test_profile_periods_scan_once_and_union_attention
+	test_partial_observability_unions_with_message_generation
+	test_observability_sql_filters_old_and_other_roots
+	test_malformed_numeric_rows_and_invalid_period
 
 	echo ""
 	echo "Tests run: ${TESTS_RUN}"

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -909,7 +909,7 @@ test_profile_model_bundle_scans_each_population_once() {
 	_get_model_usage_from_obs_db() {
 		local date_filter="${1:-}"
 		[[ -n "$date_filter" ]] && printf '%s\n' recent-empty >>"$calls_file" || printf '%s\n' all-empty >>"$calls_file"
-		printf '%s\n' ""
+		printf '%s\n' '[]'
 		return 0
 	}
 	_get_model_usage_from_opencode() {
@@ -928,6 +928,20 @@ test_profile_model_bundle_scans_each_population_once() {
 		"$(printf '%s' "$bundle" | jq -r '.all[0].model')" != "fallback-all" || \
 		"$(grep -c '^jsonl-' "$calls_file" || true)" != "2" ]]; then
 		print_result "$test_name" 1 "fallback selection changed: calls=$(tr '\n' ' ' <"$calls_file") bundle=${bundle}"
+		return 0
+	fi
+	: >"$calls_file"
+	_get_model_usage_from_jsonl() {
+		local period="$1"
+		printf 'jsonl-empty-%s\n' "$period" >>"$calls_file"
+		printf '%s\n' '[]'
+		return 0
+	}
+	bundle=$(_get_profile_model_usage_bundle)
+	if [[ "$(printf '%s' "$bundle" | jq -r '.recent | length')" != "0" || \
+		"$(printf '%s' "$bundle" | jq -r '.all | length')" != "0" || \
+		"$(grep -c '^jsonl-empty-' "$calls_file" || true)" != "2" ]]; then
+		print_result "$test_name" 1 "empty fallback should remain empty only after JSONL check: calls=$(tr '\n' ' ' <"$calls_file") bundle=${bundle}"
 		return 0
 	fi
 	print_result "$test_name" 0

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -4,6 +4,14 @@
 
 set -euo pipefail
 
+export GIT_AUTHOR_NAME="Fixture"
+export GIT_AUTHOR_EMAIL="fixture@example.com"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=commit.gpgsign
+export GIT_CONFIG_VALUE_0=false
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 SOURCE_HELPER="${SCRIPT_DIR}/../profile-readme-helper.sh"
 SOURCE_DATA_LIB="${SCRIPT_DIR}/../profile-readme-data-lib.sh"
@@ -70,7 +78,11 @@ EOF
 set -euo pipefail
 
 if [[ "${1:-}" == "session-time" ]]; then
-	printf '%s\n' '{"interactive_human_hours":1.0,"worker_human_hours":2.0,"worker_machine_hours":3.0,"total_human_hours":4.0,"total_machine_hours":5.0,"interactive_sessions":6,"worker_sessions":7}'
+	if [[ " $* " == *" --period profile "* ]]; then
+		printf '%s\n' '{"day":{"interactive_human_hours":1.0,"interactive_machine_hours":1.0,"worker_human_hours":2.0,"worker_machine_hours":3.0,"total_human_hours":3.0,"total_machine_hours":4.0,"interactive_sessions":6,"worker_sessions":7},"week":{"interactive_human_hours":1.0,"interactive_machine_hours":1.0,"worker_human_hours":2.0,"worker_machine_hours":3.0,"total_human_hours":3.0,"total_machine_hours":4.0,"interactive_sessions":6,"worker_sessions":7},"28d":{"interactive_human_hours":1.0,"interactive_machine_hours":1.0,"worker_human_hours":2.0,"worker_machine_hours":3.0,"total_human_hours":3.0,"total_machine_hours":4.0,"interactive_sessions":6,"worker_sessions":7},"year":{"interactive_human_hours":1.0,"interactive_machine_hours":1.0,"worker_human_hours":2.0,"worker_machine_hours":3.0,"total_human_hours":3.0,"total_machine_hours":4.0,"interactive_sessions":6,"worker_sessions":7}}'
+	else
+		printf '%s\n' '{"interactive_human_hours":1.0,"interactive_machine_hours":1.0,"worker_human_hours":2.0,"worker_machine_hours":3.0,"total_human_hours":3.0,"total_machine_hours":4.0,"interactive_sessions":6,"worker_sessions":7}'
+	fi
 else
 	printf '%s\n' '{}'
 fi
@@ -105,9 +117,6 @@ EOF
 
 	git init --bare --initial-branch=main "${remote_repo}" >/dev/null
 	git init -b main "${profile_repo}" >/dev/null
-	git -C "${profile_repo}" config user.name "Fixture"
-	git -C "${profile_repo}" config user.email "fixture@example.com"
-	git -C "${profile_repo}" config commit.gpgsign false
 	git -C "${profile_repo}" remote add origin "${remote_repo}"
 
 	cat >"${profile_repo}/README.md" <<'EOF'
@@ -224,9 +233,6 @@ test_inject_markers_into_existing_readme() {
 	# Create a bare remote and local clone with NO markers
 	git init --bare --initial-branch=main "${fixture_remote}" >/dev/null
 	git init -b main "${fixture_repo}" >/dev/null
-	git -C "${fixture_repo}" config user.name "Fixture"
-	git -C "${fixture_repo}" config user.email "fixture@example.com"
-	git -C "${fixture_repo}" config commit.gpgsign false
 	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
 
 	# Write a user-authored README without any aidevops markers
@@ -310,9 +316,6 @@ test_diverged_history_recovery() {
 	# Create initial remote and local clone with markers
 	git init --bare --initial-branch=main "${fixture_remote}" >/dev/null
 	git init -b main "${fixture_repo}" >/dev/null
-	git -C "${fixture_repo}" config user.name "Fixture"
-	git -C "${fixture_repo}" config user.email "fixture@example.com"
-	git -C "${fixture_repo}" config commit.gpgsign false
 	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
 
 	cat >"${fixture_repo}/README.md" <<'EOF'
@@ -337,9 +340,6 @@ EOF
 	# Push a different initial commit to the new remote (simulating GitHub "Initial commit")
 	local tmp_clone="${TEST_DIR}/tmp-clone"
 	git clone "${fixture_remote}" "${tmp_clone}" 2>/dev/null
-	git -C "${tmp_clone}" config user.name "GitHub"
-	git -C "${tmp_clone}" config user.email "noreply@github.com"
-	git -C "${tmp_clone}" config commit.gpgsign false
 	echo "# fixture" >"${tmp_clone}/README.md"
 	git -C "${tmp_clone}" add README.md
 	git -C "${tmp_clone}" commit -m "Initial commit" >/dev/null
@@ -404,9 +404,6 @@ test_default_template_replaced_with_rich_readme() {
 	# Create a bare remote and local clone with the default GitHub template
 	git init --bare --initial-branch=main "${fixture_remote}" >/dev/null
 	git init -b main "${fixture_repo}" >/dev/null
-	git -C "${fixture_repo}" config user.name "Fixture"
-	git -C "${fixture_repo}" config user.email "fixture@example.com"
-	git -C "${fixture_repo}" config commit.gpgsign false
 	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
 
 	# Write the exact default GitHub profile template
@@ -496,9 +493,6 @@ test_default_template_with_existing_markers_replaced() {
 
 	git init --bare --initial-branch=main "${fixture_remote}" >/dev/null
 	git init -b main "${fixture_repo}" >/dev/null
-	git -C "${fixture_repo}" config user.name "Fixture"
-	git -C "${fixture_repo}" config user.email "fixture@example.com"
-	git -C "${fixture_repo}" config commit.gpgsign false
 	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
 
 	# Simulate Alex's exact case: default GitHub template with markers already
@@ -614,10 +608,10 @@ test_session_time_vars_default_missing_null_values() {
 		return 0
 	fi
 
-	local day_human day_worker day_total day_interactive day_workers
-	local week_human week_worker week_total week_interactive week_workers
-	local month_human month_worker month_total month_interactive month_workers
-	local year_human year_worker year_total year_interactive year_workers
+	local day_human day_interactive_machine day_worker_human day_worker day_total day_interactive day_workers
+	local week_human week_interactive_machine week_worker_human week_worker week_total week_interactive week_workers
+	local month_human month_interactive_machine month_worker_human month_worker month_total month_interactive month_workers
+	local year_human year_interactive_machine year_worker_human year_worker year_total year_interactive year_workers
 	eval "${assignments}"
 	if [[ "${day_human}" != "0.0" || "${day_worker}" != "0.0" || "${day_total}" != "0.0" ]]; then
 		print_result "${test_name}" 1 "missing day hour fields did not default to 0.0"
@@ -627,7 +621,7 @@ test_session_time_vars_default_missing_null_values() {
 		print_result "${test_name}" 1 "missing/null count fields did not default to 0"
 		return 0
 	fi
-	if [[ "${month_human}" != "1.2" || "${month_worker}" != "5.0" || "${month_total}" != "9.0" || "${month_interactive}" != "6" || "${month_workers}" != "7" ]]; then
+	if [[ "${month_human}" != "1.2" || "${month_worker_human}" != "2.0" || "${month_worker}" != "3.0" || "${month_total}" != "9.0" || "${month_interactive}" != "6" || "${month_workers}" != "7" ]]; then
 		print_result "${test_name}" 1 "valid session data rendering changed"
 		return 0
 	fi
@@ -675,17 +669,74 @@ test_work_with_ai_worker_counts_above_thousand() {
 		return 0
 	fi
 
-	if ! grep -qF '| User AI session hours | 1.0h | 10.0h | 100.0h | 100.0h |' "${output_file}"; then
+	if ! grep -qF '| Interactive human attention | 1.0h | 10.0h | 100.0h | 100.0h |' "${output_file}"; then
 		print_result "${test_name}" 1 "user AI session hours were not limited to attended interactive time"
 		return 0
 	fi
 
-	if grep -qF '| User AI session hours | 1.5h | 11.5h | 123.4h | 123.4h |' "${output_file}"; then
+	if grep -qF '| Interactive human attention | 1.5h | 11.5h | 123.4h | 123.4h |' "${output_file}"; then
 		print_result "${test_name}" 1 "user AI session hours still include AI generation time"
 		return 0
 	fi
 
 	print_result "${test_name}" 0
+	return 0
+}
+
+test_work_with_ai_unavailable_is_not_zero() {
+	local test_name="work with AI renders collector failures as unavailable"
+	TEST_DIR=$(mktemp -d)
+	mkdir -p "${TEST_DIR}/home"
+	# shellcheck source=../profile-readme-data-lib.sh
+	source "${SOURCE_DATA_LIB}"
+	# shellcheck source=../profile-readme-render-lib.sh
+	source "${SOURCE_RENDER_LIB}"
+	local screen_json unavailable_json output_file
+	screen_json='{"today_hours":null,"week_hours":null,"month_hours":null,"year_hours":null,"periods":{"day":{"status":"unavailable"},"week":{"status":"unavailable"},"month":{"status":"unavailable"},"year":{"status":"unavailable"}}}'
+	unavailable_json='{"status":"unavailable"}'
+	output_file="${TEST_DIR}/unavailable.md"
+	HOME="${TEST_DIR}/home" _generate_work_with_ai_table "$screen_json" "$unavailable_json" "$unavailable_json" "$unavailable_json" "$unavailable_json" >"$output_file"
+	if ! grep -qF '| Screen time' "$output_file" || ! grep -qF '| unavailable | unavailable | unavailable | unavailable |' "$output_file"; then
+		print_result "$test_name" 1 "unavailable cells were not visibly rendered"
+		return 0
+	fi
+	if grep -qF 'unavailableh' "$output_file"; then
+		print_result "$test_name" 1 "unavailable status was formatted as a numeric hour value"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_profile_update_lock_is_bounded() {
+	local test_name="profile update lock rejects overlap and recovers stale owner"
+	TEST_DIR=$(mktemp -d)
+	local result
+	result=$(
+		set -- help
+		# shellcheck source=../profile-readme-helper.sh
+		source "$SOURCE_HELPER" >/dev/null
+		HOME="${TEST_DIR}/home"
+		export HOME
+		_acquire_profile_update_lock
+		if _acquire_profile_update_lock 2>/dev/null; then
+			printf '%s\n' overlap-accepted
+			return 0
+		fi
+		_release_profile_update_lock
+		local lock_dir
+		lock_dir=$(_profile_update_lock_dir)
+		mkdir -p "$lock_dir"
+		printf '%s\n' 999999 >"${lock_dir}/pid"
+		_acquire_profile_update_lock
+		printf '%s\n' stale-recovered
+		_release_profile_update_lock
+	)
+	if [[ "$result" != "stale-recovered" ]]; then
+		print_result "$test_name" 1 "unexpected lock result: ${result}"
+		return 0
+	fi
+	print_result "$test_name" 0
 	return 0
 }
 
@@ -778,24 +829,31 @@ test_all_time_token_totals_prefers_largest_population() {
 }
 
 main() {
+	local mode="${1:-all}"
 	if [[ ! -x "${SOURCE_HELPER}" ]]; then
 		echo "Helper script not found or not executable: ${SOURCE_HELPER}" >&2
 		return 1
 	fi
 
-	test_update_preserves_manual_sections
-	teardown
-	test_inject_markers_into_existing_readme
-	teardown
-	test_diverged_history_recovery
-	teardown
-	test_default_template_replaced_with_rich_readme
-	teardown
-	test_default_template_with_existing_markers_replaced
-	teardown
+	if [[ "$mode" != "--unit-only" ]]; then
+		test_update_preserves_manual_sections
+		teardown
+		test_inject_markers_into_existing_readme
+		teardown
+		test_diverged_history_recovery
+		teardown
+		test_default_template_replaced_with_rich_readme
+		teardown
+		test_default_template_with_existing_markers_replaced
+		teardown
+	fi
 	test_session_time_vars_default_missing_null_values
 	teardown
 	test_work_with_ai_worker_counts_above_thousand
+	teardown
+	test_work_with_ai_unavailable_is_not_zero
+	teardown
+	test_profile_update_lock_is_bounded
 	teardown
 	test_all_time_model_usage_prefers_larger_complete_source
 	teardown

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -709,7 +709,7 @@ test_work_with_ai_unavailable_is_not_zero() {
 }
 
 test_profile_update_lock_is_bounded() {
-	local test_name="profile update lock is token-owned, race-safe, and stale-recoverable"
+	local test_name="profile update lock uses portable mtime and remains token-owned, race-safe, and stale-recoverable"
 	TEST_DIR=$(mktemp -d)
 	local result
 	result=$(
@@ -718,6 +718,15 @@ test_profile_update_lock_is_bounded() {
 		source "$SOURCE_HELPER" >/dev/null
 		HOME="${TEST_DIR}/home"
 		export HOME
+		local delegated_mtime
+		delegated_mtime=$(
+			_file_mtime_epoch() { printf '%s\n' 1234567890; }
+			_profile_lock_mtime "${TEST_DIR}/delegation-probe"
+		)
+		if [[ "$delegated_mtime" != "1234567890" ]]; then
+			printf '%s\n' portable-mtime-not-used
+			return 0
+		fi
 		_acquire_profile_update_lock
 		local owner_token="$PROFILE_UPDATE_LOCK_TOKEN"
 		if HOME="$HOME" bash -c 'set -- help; source "$1" >/dev/null; _acquire_profile_update_lock' _ "$SOURCE_HELPER" 2>/dev/null; then

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -845,6 +845,95 @@ test_all_time_token_totals_prefers_largest_population() {
 	return 0
 }
 
+test_token_totals_from_selected_model_population_are_equivalent() {
+	local test_name="selected model population derives equivalent token totals"
+	local model_json expected actual
+	model_json='[
+		{"model":"one","requests":2,"input_tokens":100,"output_tokens":20,"cache_read_tokens":300,"cache_write_tokens":10,"cost_total":1},
+		{"model":"two","requests":3,"input_tokens":50,"output_tokens":30,"cache_read_tokens":100,"cache_write_tokens":5,"cost_total":2}
+	]'
+	expected=$(_token_totals_enrich '{"total_input":150,"total_output":50,"total_cache_read":400,"total_cache_write":15}')
+	actual=$(_token_totals_from_model_usage "$model_json")
+	if [[ "$(printf '%s' "$actual" | jq -S -c .)" != "$(printf '%s' "$expected" | jq -S -c .)" ]]; then
+		print_result "$test_name" 1 "expected=${expected} actual=${actual}"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_profile_model_bundle_scans_each_population_once() {
+	local test_name="profile model bundle scans each required population once"
+	TEST_DIR=$(mktemp -d)
+	local calls_file="${TEST_DIR}/model-source-calls"
+	_get_model_usage_from_obs_db() {
+		local date_filter="${1:-}"
+		if [[ -n "$date_filter" ]]; then
+			printf '%s\n' recent >>"$calls_file"
+			printf '%s\n' '[{"model":"obs","requests":2,"input_tokens":20,"output_tokens":2,"cache_read_tokens":200,"cache_write_tokens":1,"cost_total":1}]'
+		else
+			printf '%s\n' all >>"$calls_file"
+			printf '%s\n' '[{"model":"obs","requests":5,"input_tokens":50,"output_tokens":5,"cache_read_tokens":500,"cache_write_tokens":2,"cost_total":2}]'
+		fi
+		return 0
+	}
+	_get_model_usage_from_opencode() {
+		printf '%s\n' opencode >>"$calls_file"
+		printf '%s\n' '[{"model":"obs","requests":4,"input_tokens":40,"output_tokens":4,"cache_read_tokens":400,"cache_write_tokens":2,"cost_total":2}]'
+		return 0
+	}
+	_get_model_usage_from_jsonl() {
+		local period="$1"
+		printf 'jsonl-%s\n' "$period" >>"$calls_file"
+		printf '%s\n' '[]'
+		return 0
+	}
+
+	local bundle recent_total all_total
+	bundle=$(_get_profile_model_usage_bundle)
+	recent_total=$(_token_totals_from_model_usage "$(printf '%s' "$bundle" | jq -c '.recent')")
+	all_total=$(_token_totals_from_model_usage "$(printf '%s' "$bundle" | jq -c '.all')")
+	if [[ "$(grep -c '^recent$' "$calls_file" || true)" != "1" || \
+		"$(grep -c '^all$' "$calls_file" || true)" != "1" || \
+		"$(grep -c '^opencode$' "$calls_file" || true)" != "1" || \
+		"$(grep -c '^jsonl-' "$calls_file" || true)" != "0" ]]; then
+		print_result "$test_name" 1 "unexpected source calls: $(tr '\n' ' ' <"$calls_file")"
+		return 0
+	fi
+	if [[ "$(printf '%s' "$recent_total" | jq -r '.total_all')" != "223" || \
+		"$(printf '%s' "$all_total" | jq -r '.total_all')" != "557" ]]; then
+		print_result "$test_name" 1 "derived totals mismatch recent=${recent_total} all=${all_total}"
+		return 0
+	fi
+	: >"$calls_file"
+	_get_model_usage_from_obs_db() {
+		local date_filter="${1:-}"
+		[[ -n "$date_filter" ]] && printf '%s\n' recent-empty >>"$calls_file" || printf '%s\n' all-empty >>"$calls_file"
+		printf '%s\n' ""
+		return 0
+	}
+	_get_model_usage_from_opencode() {
+		printf '%s\n' opencode-empty >>"$calls_file"
+		printf '%s\n' '[]'
+		return 0
+	}
+	_get_model_usage_from_jsonl() {
+		local period="$1"
+		printf 'jsonl-%s\n' "$period" >>"$calls_file"
+		printf '[{"model":"fallback-%s","requests":1,"input_tokens":1,"output_tokens":1,"cache_read_tokens":1,"cache_write_tokens":0,"cost_total":1}]\n' "$period"
+		return 0
+	}
+	bundle=$(_get_profile_model_usage_bundle)
+	if [[ "$(printf '%s' "$bundle" | jq -r '.recent[0].model')" != "fallback-30d" || \
+		"$(printf '%s' "$bundle" | jq -r '.all[0].model')" != "fallback-all" || \
+		"$(grep -c '^jsonl-' "$calls_file" || true)" != "2" ]]; then
+		print_result "$test_name" 1 "fallback selection changed: calls=$(tr '\n' ' ' <"$calls_file") bundle=${bundle}"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
 main() {
 	local mode="${1:-all}"
 	if [[ ! -x "${SOURCE_HELPER}" ]]; then
@@ -877,6 +966,10 @@ main() {
 	test_model_usage_undercut_handles_missing_candidate_model
 	teardown
 	test_all_time_token_totals_prefers_largest_population
+	teardown
+	test_token_totals_from_selected_model_population_are_equivalent
+	teardown
+	test_profile_model_bundle_scans_each_population_once
 	teardown
 
 	echo ""

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -709,7 +709,7 @@ test_work_with_ai_unavailable_is_not_zero() {
 }
 
 test_profile_update_lock_is_bounded() {
-	local test_name="profile update lock rejects overlap and recovers stale owner"
+	local test_name="profile update lock is token-owned, race-safe, and stale-recoverable"
 	TEST_DIR=$(mktemp -d)
 	local result
 	result=$(
@@ -719,16 +719,33 @@ test_profile_update_lock_is_bounded() {
 		HOME="${TEST_DIR}/home"
 		export HOME
 		_acquire_profile_update_lock
-		if _acquire_profile_update_lock 2>/dev/null; then
+		local owner_token="$PROFILE_UPDATE_LOCK_TOKEN"
+		if HOME="$HOME" bash -c 'set -- help; source "$1" >/dev/null; _acquire_profile_update_lock' _ "$SOURCE_HELPER" 2>/dev/null; then
 			printf '%s\n' overlap-accepted
 			return 0
 		fi
-		_release_profile_update_lock
+		PROFILE_UPDATE_LOCK_TOKEN="not-the-owner"
+		if _release_profile_update_lock 2>/dev/null; then
+			printf '%s\n' non-owner-released
+			return 0
+		fi
 		local lock_dir
 		lock_dir=$(_profile_update_lock_dir)
+		[[ -d "$lock_dir" ]] || { printf '%s\n' lock-lost; return 0; }
+		PROFILE_UPDATE_LOCK_TOKEN="$owner_token"
+		_release_profile_update_lock
+
+		# A fresh PID-less directory receives a grace period rather than deletion.
 		mkdir -p "$lock_dir"
-		printf '%s\n' 999999 >"${lock_dir}/pid"
+		PROFILE_UPDATE_LOCK_GRACE_SECONDS=60
+		if _acquire_profile_update_lock 2>/dev/null; then
+			printf '%s\n' pidless-grace-bypassed
+			return 0
+		fi
+		PROFILE_UPDATE_LOCK_GRACE_SECONDS=0
 		_acquire_profile_update_lock
+		local recovered_token="$PROFILE_UPDATE_LOCK_TOKEN"
+		[[ -n "$recovered_token" && "$recovered_token" != "$owner_token" ]] || { printf '%s\n' token-not-unique; return 0; }
 		printf '%s\n' stale-recovered
 		_release_profile_update_lock
 	)

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -55,6 +55,15 @@ install_helper_with_libs() {
 	chmod +x "${helper_path}"
 	cp "${SOURCE_DATA_LIB}" "${helper_dir}/profile-readme-data-lib.sh"
 	cp "${SOURCE_RENDER_LIB}" "${helper_dir}/profile-readme-render-lib.sh"
+	cp "${SOURCE_HELPER%/*}/portable-stat.sh" \
+		"${SOURCE_HELPER%/*}/screen-time-interval-engine.py" \
+		"${SOURCE_HELPER%/*}/screen_time_interval_common.py" \
+		"${SOURCE_HELPER%/*}/screen_time_macos.py" \
+		"${SOURCE_HELPER%/*}/screen_time_macos_apps.py" \
+		"${SOURCE_HELPER%/*}/screen_time_linux.py" \
+		"${SOURCE_HELPER%/*}/screen_time_linux_logind.py" \
+		"${SOURCE_HELPER%/*}/screen_time_linux_wtmp.py" \
+		"${SOURCE_HELPER%/*}/screen_time_history.py" "$helper_dir/"
 	return 0
 }
 
@@ -708,6 +717,74 @@ test_work_with_ai_unavailable_is_not_zero() {
 	return 0
 }
 
+test_screen_json_paths_are_optional_and_fail_visibly() {
+	local test_name="screen JSON paths are optional and invalid payloads remain visibly unavailable"
+	TEST_DIR=$(mktemp -d)
+	# shellcheck source=../profile-readme-render-lib.sh
+	source "$SOURCE_RENDER_LIB"
+	local assignments screen_today screen_status screen_source
+	assignments=$(_generate_screen_time_vars '{}')
+	eval "$assignments"
+	if [[ "$screen_today" != "$PROFILE_STATUS_UNAVAILABLE" || "$screen_status" != "$PROFILE_STATUS_UNAVAILABLE" || "$screen_source" != "$PROFILE_STATUS_UNAVAILABLE" ]]; then
+		print_result "$test_name" 1 "missing paths were not rendered unavailable: ${assignments}"
+		return 0
+	fi
+	local warning_file="${TEST_DIR}/screen-warning"
+	assignments=$(_generate_screen_time_vars 'not-json' 2>"$warning_file")
+	eval "$assignments"
+	if [[ "$screen_status" != "$PROFILE_STATUS_UNAVAILABLE" || "$screen_source" != "$PROFILE_STATUS_UNAVAILABLE" ]] ||
+		! grep -qF 'screen-time payload is invalid' "$warning_file"; then
+		print_result "$test_name" 1 "malformed screen payload failure was not visible"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_top_apps_batches_jq_processing() {
+	local test_name="top-app rendering batches jq processing"
+	TEST_DIR=$(mktemp -d)
+	# shellcheck source=../profile-readme-render-lib.sh
+	source "$SOURCE_RENDER_LIB"
+	local db_path="${TEST_DIR}/knowledgeC.db"
+	local now core_now
+	now=$(date +%s)
+	core_now=$((now - 978307200))
+	sqlite3 "$db_path" "
+		CREATE TABLE ZOBJECT (ZSTREAMNAME TEXT,ZCREATIONDATE REAL,ZVALUEINTEGER INTEGER,ZSTARTDATE REAL,ZENDDATE REAL,ZVALUESTRING TEXT);
+		WITH RECURSIVE rows(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM rows WHERE i < 10)
+		INSERT INTO ZOBJECT (ZSTREAMNAME,ZSTARTDATE,ZENDDATE,ZVALUESTRING)
+		SELECT '/app/usage', ${core_now} - i*600, ${core_now} - i*600 + 300, 'fixture.app.' || i FROM rows;"
+	local real_jq wrapper_dir count_file
+	real_jq=$(command -v jq)
+	wrapper_dir="${TEST_DIR}/bin"
+	count_file="${TEST_DIR}/jq-count"
+	mkdir -p "$wrapper_dir"
+	cat >"${wrapper_dir}/jq" <<EOF
+#!/usr/bin/env bash
+printf '1\n' >>"${count_file}"
+exec "${real_jq}" "\$@"
+EOF
+	chmod +x "${wrapper_dir}/jq"
+	local result
+	result=$(
+		uname() { printf '%s\n' Darwin; }
+		SCRIPT_DIR="${SOURCE_RENDER_LIB%/*}"
+		PATH="${wrapper_dir}:${PATH}"
+		export SCRIPT_DIR PATH
+		AIDEVOPS_KNOWLEDGE_DB="$db_path" AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" _get_top_apps
+	)
+	local jq_calls app_count
+	jq_calls=$(wc -l <"$count_file" | tr -d ' ')
+	app_count=$(printf '%s' "$result" | "$real_jq" -r 'length')
+	if [[ "$jq_calls" -gt 2 || "$app_count" != "10" ]]; then
+		print_result "$test_name" 1 "expected 10 apps with at most two jq processes, apps=${app_count} jq_calls=${jq_calls}"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
 test_profile_update_lock_is_bounded() {
 	local test_name="profile update lock uses portable mtime and remains token-owned, race-safe, and stale-recoverable"
 	TEST_DIR=$(mktemp -d)
@@ -987,6 +1064,10 @@ main() {
 	test_work_with_ai_worker_counts_above_thousand
 	teardown
 	test_work_with_ai_unavailable_is_not_zero
+	teardown
+	test_screen_json_paths_are_optional_and_fail_visibly
+	teardown
+	test_top_apps_batches_jq_processing
 	teardown
 	test_profile_update_lock_is_bounded
 	teardown

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -731,7 +731,10 @@ test_profile_update_lock_is_bounded() {
 		fi
 		local lock_dir
 		lock_dir=$(_profile_update_lock_dir)
-		[[ -d "$lock_dir" ]] || { printf '%s\n' lock-lost; return 0; }
+		[[ -d "$lock_dir" ]] || {
+			printf '%s\n' lock-lost
+			return 0
+		}
 		PROFILE_UPDATE_LOCK_TOKEN="$owner_token"
 		_release_profile_update_lock
 
@@ -745,7 +748,10 @@ test_profile_update_lock_is_bounded() {
 		PROFILE_UPDATE_LOCK_GRACE_SECONDS=0
 		_acquire_profile_update_lock
 		local recovered_token="$PROFILE_UPDATE_LOCK_TOKEN"
-		[[ -n "$recovered_token" && "$recovered_token" != "$owner_token" ]] || { printf '%s\n' token-not-unique; return 0; }
+		[[ -n "$recovered_token" && "$recovered_token" != "$owner_token" ]] || {
+			printf '%s\n' token-not-unique
+			return 0
+		}
 		printf '%s\n' stale-recovered
 		_release_profile_update_lock
 	)
@@ -893,15 +899,15 @@ test_profile_model_bundle_scans_each_population_once() {
 	bundle=$(_get_profile_model_usage_bundle)
 	recent_total=$(_token_totals_from_model_usage "$(printf '%s' "$bundle" | jq -c '.recent')")
 	all_total=$(_token_totals_from_model_usage "$(printf '%s' "$bundle" | jq -c '.all')")
-	if [[ "$(grep -c '^recent$' "$calls_file" || true)" != "1" || \
-		"$(grep -c '^all$' "$calls_file" || true)" != "1" || \
-		"$(grep -c '^opencode$' "$calls_file" || true)" != "1" || \
-		"$(grep -c '^jsonl-' "$calls_file" || true)" != "0" ]]; then
+	if [[ "$(grep -c '^recent$' "$calls_file" || true)" != "1" ||
+	"$(grep -c '^all$' "$calls_file" || true)" != "1" ||
+	"$(grep -c '^opencode$' "$calls_file" || true)" != "1" ||
+	"$(grep -c '^jsonl-' "$calls_file" || true)" != "0" ]]; then
 		print_result "$test_name" 1 "unexpected source calls: $(tr '\n' ' ' <"$calls_file")"
 		return 0
 	fi
-	if [[ "$(printf '%s' "$recent_total" | jq -r '.total_all')" != "223" || \
-		"$(printf '%s' "$all_total" | jq -r '.total_all')" != "557" ]]; then
+	if [[ "$(printf '%s' "$recent_total" | jq -r '.total_all')" != "223" ||
+	"$(printf '%s' "$all_total" | jq -r '.total_all')" != "557" ]]; then
 		print_result "$test_name" 1 "derived totals mismatch recent=${recent_total} all=${all_total}"
 		return 0
 	fi
@@ -924,9 +930,9 @@ test_profile_model_bundle_scans_each_population_once() {
 		return 0
 	}
 	bundle=$(_get_profile_model_usage_bundle)
-	if [[ "$(printf '%s' "$bundle" | jq -r '.recent[0].model')" != "fallback-30d" || \
-		"$(printf '%s' "$bundle" | jq -r '.all[0].model')" != "fallback-all" || \
-		"$(grep -c '^jsonl-' "$calls_file" || true)" != "2" ]]; then
+	if [[ "$(printf '%s' "$bundle" | jq -r '.recent[0].model')" != "fallback-30d" ||
+	"$(printf '%s' "$bundle" | jq -r '.all[0].model')" != "fallback-all" ||
+	"$(grep -c '^jsonl-' "$calls_file" || true)" != "2" ]]; then
 		print_result "$test_name" 1 "fallback selection changed: calls=$(tr '\n' ' ' <"$calls_file") bundle=${bundle}"
 		return 0
 	fi
@@ -938,9 +944,9 @@ test_profile_model_bundle_scans_each_population_once() {
 		return 0
 	}
 	bundle=$(_get_profile_model_usage_bundle)
-	if [[ "$(printf '%s' "$bundle" | jq -r '.recent | length')" != "0" || \
-		"$(printf '%s' "$bundle" | jq -r '.all | length')" != "0" || \
-		"$(grep -c '^jsonl-empty-' "$calls_file" || true)" != "2" ]]; then
+	if [[ "$(printf '%s' "$bundle" | jq -r '.recent | length')" != "0" ||
+	"$(printf '%s' "$bundle" | jq -r '.all | length')" != "0" ||
+	"$(grep -c '^jsonl-empty-' "$calls_file" || true)" != "2" ]]; then
 		print_result "$test_name" 1 "empty fallback should remain empty only after JSONL check: calls=$(tr '\n' ' ' <"$calls_file") bundle=${bundle}"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-screen-time-helper.sh
+++ b/.agents/scripts/tests/test-screen-time-helper.sh
@@ -74,7 +74,8 @@ create_knowledge_db() {
 			ZCREATIONDATE REAL,
 			ZVALUEINTEGER INTEGER,
 			ZSTARTDATE REAL,
-			ZENDDATE REAL
+			ZENDDATE REAL,
+			ZVALUESTRING TEXT
 		);"
 	return 0
 }
@@ -94,6 +95,11 @@ test_union_clipping_and_failure_status() {
 	local overlap_hours
 	overlap_hours=$(query_hours "$overlap_db" 1)
 	[[ "$overlap_hours" == "5.0" ]] || fail "expected app intervals to union to 5.0h, got ${overlap_hours}"
+	sqlite3 "$overlap_db" "UPDATE ZOBJECT SET ZVALUESTRING='app.one' WHERE ZSTREAMNAME='/app/usage';"
+	local app_json app_seconds
+	app_json=$(AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" python3 "${SCRIPTS_DIR}/screen-time-interval-engine.py" apps --os-type Darwin --db "$overlap_db")
+	app_seconds=$(printf '%s' "$app_json" | jq -r '.[0].month_seconds')
+	[[ "$app_seconds" == "18000" ]] || fail "expected repeated/overlapping top-app intervals to union to 18000s, got ${app_seconds}"
 
 	local clip_db="${tmpdir}/clip.db"
 	create_knowledge_db "$clip_db"
@@ -105,9 +111,9 @@ test_union_clipping_and_failure_status() {
 	local repeated_db="${tmpdir}/repeated.db"
 	create_knowledge_db "$repeated_db"
 	sqlite3 "$repeated_db" "
-		INSERT INTO ZOBJECT VALUES('/display/isBacklit', $(core_data_offset "$((now - one_hour * 3))"), 1, NULL, NULL);
-		INSERT INTO ZOBJECT VALUES('/display/isBacklit', $(core_data_offset "$((now - one_hour * 2))"), 1, NULL, NULL);
-		INSERT INTO ZOBJECT VALUES('/display/isBacklit', $(core_data_offset "$((now - one_hour))"), 0, NULL, NULL);"
+		INSERT INTO ZOBJECT VALUES('/display/isBacklit', $(core_data_offset "$((now - one_hour * 3))"), 1, NULL, NULL, NULL);
+		INSERT INTO ZOBJECT VALUES('/display/isBacklit', $(core_data_offset "$((now - one_hour * 2))"), 1, NULL, NULL, NULL);
+		INSERT INTO ZOBJECT VALUES('/display/isBacklit', $(core_data_offset "$((now - one_hour))"), 0, NULL, NULL, NULL);"
 	local repeated_hours
 	repeated_hours=$(query_hours "$repeated_db" 1)
 	[[ "$repeated_hours" == "2.0" ]] || fail "expected repeated ON events not to double count, got ${repeated_hours}"
@@ -153,6 +159,17 @@ PY
 	[[ "$hours" == "3" || "$hours" == "3.0" ]] || fail "expected lock/lid/session state to produce 3.0h, got ${hours}"
 	[[ "$source" == *"session-lid-lock-state"* ]] || fail "Linux provenance missing state semantics: ${source}"
 	pass "Linux state retains username-less session OFF events and clips active windows"
+
+	local missing_journal="${tmpdir}/missing-journal"
+	local wtmp_fixture="${tmpdir}/wtmp.txt"
+	printf '%s|%s\n' "$((now - 7200))" "$((now - 3600))" >"$wtmp_fixture"
+	local fallback
+	fallback=$(AIDEVOPS_SCREEN_TIME_OS_TYPE=Linux AIDEVOPS_LOGIND_FIXTURE="$missing_journal" \
+		AIDEVOPS_LAST_FIXTURE="$wtmp_fixture" AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" \
+		AIDEVOPS_SCREEN_TIME_USER=fixture "$HELPER" profile-stats)
+	[[ "$(printf '%s' "$fallback" | jq -r '.today_hours')" == "1" || "$(printf '%s' "$fallback" | jq -r '.today_hours')" == "1.0" ]] || fail "wtmp fallback hours were not parsed"
+	[[ "$(printf '%s' "$fallback" | jq -r '.periods.day.source')" == "linux-wtmp:login-session-proxy" ]] || fail "wtmp fallback provenance was not truthful"
+	pass "Linux collection failure falls back to clipped wtmp sessions with proxy provenance"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-screen-time-helper.sh
+++ b/.agents/scripts/tests/test-screen-time-helper.sh
@@ -60,13 +60,14 @@ query_hours() {
 	return 0
 }
 
-main() {
-	local tmpdir
-	tmpdir=$(mktemp -d)
-	TMPDIR_TEST="$tmpdir"
-	trap cleanup EXIT
+profile_stats() {
+	local db="$1"
+	AIDEVOPS_SCREEN_TIME_OS_TYPE=Darwin AIDEVOPS_KNOWLEDGE_DB="$db" "$HELPER" profile-stats
+	return 0
+}
 
-	local db="${tmpdir}/knowledgeC.db"
+create_knowledge_db() {
+	local db="$1"
 	sqlite3 "$db" "
 		CREATE TABLE ZOBJECT (
 			ZSTREAMNAME TEXT,
@@ -75,6 +76,121 @@ main() {
 			ZSTARTDATE REAL,
 			ZENDDATE REAL
 		);"
+	return 0
+}
+
+test_union_clipping_and_failure_status() {
+	local tmpdir="$1"
+	local now="$2"
+	local one_hour=3600
+	local overlap_db="${tmpdir}/overlap.db"
+	create_knowledge_db "$overlap_db"
+
+	# Force app fallback with overlapping/repeated intervals. The union is 5h,
+	# not the additive 9h, and the 30h interval is clipped to the 24h window.
+	insert_app_usage "$overlap_db" "$((now - one_hour * 6))" "$((now - one_hour))"
+	insert_app_usage "$overlap_db" "$((now - one_hour * 5))" "$((now - one_hour * 2))"
+	insert_app_usage "$overlap_db" "$((now - one_hour * 6))" "$((now - one_hour))"
+	local overlap_hours
+	overlap_hours=$(query_hours "$overlap_db" 1)
+	[[ "$overlap_hours" == "5.0" ]] || fail "expected app intervals to union to 5.0h, got ${overlap_hours}"
+
+	local clip_db="${tmpdir}/clip.db"
+	create_knowledge_db "$clip_db"
+	insert_app_usage "$clip_db" "$((now - one_hour * 30))" "$now"
+	local clipped_hours
+	clipped_hours=$(query_hours "$clip_db" 1)
+	[[ "$clipped_hours" == "24.0" ]] || fail "expected one-day result capped by clipping at 24.0h, got ${clipped_hours}"
+
+	local repeated_db="${tmpdir}/repeated.db"
+	create_knowledge_db "$repeated_db"
+	sqlite3 "$repeated_db" "
+		INSERT INTO ZOBJECT VALUES('/display/isBacklit', $(core_data_offset "$((now - one_hour * 3))"), 1, NULL, NULL);
+		INSERT INTO ZOBJECT VALUES('/display/isBacklit', $(core_data_offset "$((now - one_hour * 2))"), 1, NULL, NULL);
+		INSERT INTO ZOBJECT VALUES('/display/isBacklit', $(core_data_offset "$((now - one_hour))"), 0, NULL, NULL);"
+	local repeated_hours
+	repeated_hours=$(query_hours "$repeated_db" 1)
+	[[ "$repeated_hours" == "2.0" ]] || fail "expected repeated ON events not to double count, got ${repeated_hours}"
+
+	local invalid_db="${tmpdir}/invalid.db"
+	printf '%s\n' 'not sqlite' >"$invalid_db"
+	local failure_json
+	failure_json=$(profile_stats "$invalid_db")
+	[[ "$(printf '%s' "$failure_json" | jq -r '.collection_status')" == "unavailable" ]] || fail "database access failure was not surfaced"
+	[[ "$(printf '%s' "$failure_json" | jq -r '.today_hours')" == "null" ]] || fail "database failure was rendered as a zero"
+	pass "macOS intervals union, clip, deduplicate, and surface access failures"
+	return 0
+}
+
+test_linux_state_machine() {
+	local tmpdir="$1"
+	local now=2000000000
+	local fixture="${tmpdir}/logind.txt"
+	python3 - "$fixture" "$now" <<'PY'
+import datetime as dt
+import sys
+
+target = sys.argv[1]
+now = int(sys.argv[2])
+events = [
+    (-6, "New session c1 of user fixture."),
+    (-5, "Session c1 locked."),
+    (-4, "Session c1 unlocked."),
+    (-3, "Lid closed."),
+    (-2, "Lid opened."),
+    (-1, "Removed session c1."),
+]
+with open(target, "w", encoding="utf-8") as handle:
+    for hours, message in events:
+        stamp = dt.datetime.fromtimestamp(now + hours * 3600, dt.timezone.utc).isoformat()
+        handle.write(f"{stamp} host systemd-logind[1]: {message}\n")
+PY
+	local output hours source
+	output=$(AIDEVOPS_SCREEN_TIME_OS_TYPE=Linux AIDEVOPS_LOGIND_FIXTURE="$fixture" \
+		AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" AIDEVOPS_SCREEN_TIME_USER=fixture "$HELPER" profile-stats)
+	hours=$(printf '%s' "$output" | jq -r '.today_hours')
+	source=$(printf '%s' "$output" | jq -r '.periods.day.source')
+	[[ "$hours" == "3" || "$hours" == "3.0" ]] || fail "expected lock/lid/session state to produce 3.0h, got ${hours}"
+	[[ "$source" == *"session-lid-lock-state"* ]] || fail "Linux provenance missing state semantics: ${source}"
+	pass "Linux state retains username-less session OFF events and clips active windows"
+	return 0
+}
+
+test_history_calendar_coverage_and_staleness() {
+	local tmpdir="$1"
+	local fixture_home="${tmpdir}/history-home"
+	mkdir -p "${fixture_home}/.aidevops/.agent-workspace/observability"
+	local history="${fixture_home}/.aidevops/.agent-workspace/observability/screen-time.jsonl"
+	python3 - "$history" <<'PY'
+import datetime as dt
+import json
+import sys
+
+today = dt.datetime.now(dt.timezone.utc).date()
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    for age, hours in ((20, 30), (10, 12), (5, 6)):
+        handle.write(json.dumps({"date": str(today - dt.timedelta(days=age)), "screen_hours": hours}) + "\n")
+PY
+	local output estimate span status
+	output=$(HOME="$fixture_home" AIDEVOPS_SCREEN_TIME_OS_TYPE=Unsupported "$HELPER" profile-stats)
+	estimate=$(printf '%s' "$output" | jq -r '.year_hours')
+	span=$(printf '%s' "$output" | jq -r '.periods.year.calendar_span_days')
+	status=$(printf '%s' "$output" | jq -r '.periods.year.status')
+	[[ "$span" == "16" ]] || fail "expected calendar span 16 rather than active row count 3, got ${span}"
+	[[ "$estimate" == "958.1" ]] || fail "expected clamped 24h rows and calendar-span estimate 958.1h, got ${estimate}"
+	[[ "$status" == "stale" ]] || fail "expected stale history estimate to remain visibly stale"
+	pass "history estimates use calendar coverage, clamp daily values, and expose staleness"
+	return 0
+}
+
+main() {
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	TMPDIR_TEST="$tmpdir"
+	trap cleanup EXIT
+
+	local db="${tmpdir}/knowledgeC.db"
+	create_knowledge_db "$db"
 
 	local now
 	now=$(date +%s)
@@ -97,14 +213,7 @@ main() {
 
 	# Healthy backlit: events on multiple days should remain primary even when app usage exists.
 	local healthy_db="${tmpdir}/healthy-knowledgeC.db"
-	sqlite3 "$healthy_db" "
-		CREATE TABLE ZOBJECT (
-			ZSTREAMNAME TEXT,
-			ZCREATIONDATE REAL,
-			ZVALUEINTEGER INTEGER,
-			ZSTARTDATE REAL,
-			ZENDDATE REAL
-		);"
+	create_knowledge_db "$healthy_db"
 	insert_backlit_pair "$healthy_db" "$((now - one_hour * 8))" "$((now - one_hour))"
 	insert_backlit_pair "$healthy_db" "$((now - one_day * 2))" "$((now - one_day * 2 + one_hour * 4))"
 	insert_app_usage "$healthy_db" "$((now - one_hour * 8))" "$((now - one_hour))"
@@ -115,6 +224,9 @@ main() {
 	[[ "$healthy_week_hours" == "11.0" ]] || fail "expected healthy 7d backlit stream to remain primary at 11.0, got ${healthy_week_hours}"
 
 	pass "screen-time helper falls back only for sparse backlit windows"
+	test_union_clipping_and_failure_status "$tmpdir" "$now"
+	test_linux_state_machine "$tmpdir"
+	test_history_calendar_coverage_and_staleness "$tmpdir"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-screen-time-helper.sh
+++ b/.agents/scripts/tests/test-screen-time-helper.sh
@@ -221,7 +221,7 @@ test_top_apps_sql_and_sweep_are_bounded() {
 	boundaries=$(jq -r '.boundaries' "$instrument")
 	segments=$(jq -r '.attributed_segments' "$instrument")
 	elapsed=$(jq -r '.elapsed_ms' "$instrument")
-	if [[ "$selected" != "200" || "$valid" != "200" || "$boundaries" -gt 402 || "$segments" -gt 401 ]] || \
+	if [[ "$selected" != "200" || "$valid" != "200" || "$boundaries" -gt 402 || "$segments" -gt 401 ]] ||
 		! awk -v elapsed="$elapsed" 'BEGIN {exit !(elapsed < 5000)}'; then
 		fail "top-app query/sweep was unbounded: $(<"$instrument")"
 	fi

--- a/.agents/scripts/tests/test-screen-time-helper.sh
+++ b/.agents/scripts/tests/test-screen-time-helper.sh
@@ -128,6 +128,72 @@ test_union_clipping_and_failure_status() {
 	return 0
 }
 
+test_empty_zero_and_sparse_source_semantics() {
+	local tmpdir="$1"
+	local now="$2"
+	local empty_db="${tmpdir}/empty.db"
+	create_knowledge_db "$empty_db"
+	local empty_json
+	empty_json=$(AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" profile_stats "$empty_db")
+	[[ "$(printf '%s' "$empty_json" | jq -r '.collection_status')" == "unavailable" ]] || fail "readable empty macOS DB was not unavailable"
+	local fallback_home="${tmpdir}/empty-fallback-home"
+	mkdir -p "${fallback_home}/.aidevops/.agent-workspace/observability"
+	python3 - "${fallback_home}/.aidevops/.agent-workspace/observability/screen-time.jsonl" "$now" <<'PY'
+import datetime as dt
+import json
+import sys
+date = dt.datetime.fromtimestamp(int(sys.argv[2])).date() - dt.timedelta(days=1)
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    handle.write(json.dumps({"date": str(date), "screen_hours": 2}) + "\n")
+PY
+	local empty_fallback
+	empty_fallback=$(HOME="$fallback_home" AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" AIDEVOPS_SCREEN_TIME_OS_TYPE=Darwin AIDEVOPS_KNOWLEDGE_DB="$empty_db" "$HELPER" profile-stats)
+	[[ "$(printf '%s' "$empty_fallback" | jq -r '.today_hours')" == "2" || "$(printf '%s' "$empty_fallback" | jq -r '.today_hours')" == "2.0" ]] || fail "empty readable macOS source did not fall back to history: ${empty_fallback}"
+	[[ "$(printf '%s' "$empty_fallback" | jq -r '.periods.day.source')" == "screen-time-history:daily-observations" ]] || fail "empty-source history provenance missing"
+
+	local zero_db="${tmpdir}/observed-zero.db"
+	create_knowledge_db "$zero_db"
+	sqlite3 "$zero_db" "INSERT INTO ZOBJECT (ZSTREAMNAME,ZCREATIONDATE,ZVALUEINTEGER) VALUES('/display/isBacklit',$(core_data_offset "$((now - 3600))"),0);"
+	local zero_json
+	zero_json=$(AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" profile_stats "$zero_db")
+	[[ "$(printf '%s' "$zero_json" | jq -r '.today_hours')" == "0" || "$(printf '%s' "$zero_json" | jq -r '.today_hours')" == "0.0" ]] || fail "explicit OFF observation was not preserved as legitimate zero: ${zero_json}"
+	[[ "$(printf '%s' "$zero_json" | jq -r '.periods.day.status')" == "ok" ]] || fail "explicit zero observation was marked unavailable"
+
+	local sparse_db="${tmpdir}/relative-sparse.db"
+	create_knowledge_db "$sparse_db"
+	insert_backlit_pair "$sparse_db" "$((now - 2 * 86400))" "$((now - 2 * 86400 + 3600))"
+	insert_backlit_pair "$sparse_db" "$((now - 3600))" "$now"
+	local day
+	for day in 1 2 3 4 5 6 7 8; do
+		insert_app_usage "$sparse_db" "$((now - day * 86400))" "$((now - day * 86400 + 4 * 3600))"
+	done
+	local sparse_json
+	sparse_json=$(AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" profile_stats "$sparse_db")
+	[[ "$(printf '%s' "$sparse_json" | jq -r '.periods.month.source')" == "macos-knowledge-db:/app/usage-union" ]] || fail "two sparse backlit days incorrectly beat eight app-usage days"
+	[[ "$(printf '%s' "$sparse_json" | jq -r '.month_hours')" == "32" || "$(printf '%s' "$sparse_json" | jq -r '.month_hours')" == "32.0" ]] || fail "relative app coverage duration was not selected"
+	pass "empty sources, explicit zero, and relative sparse-source selection are distinct"
+	return 0
+}
+
+test_local_midnight_dst_boundaries() {
+	local tmpdir="$1"
+	local db="${tmpdir}/dst.db"
+	create_knowledge_db "$db"
+	local bounds
+	bounds=$(TZ=America/New_York python3 -c 'import datetime as d,time; time.tzset(); dates=(d.date(2026,3,8),d.date(2026,11,1)); print(" ".join(str(int(d.datetime.combine(x,d.time.min).timestamp()))+" "+str(int(d.datetime.combine(x+d.timedelta(days=1),d.time.min).timestamp())) for x in dates))')
+	local spring_start spring_end fall_start fall_end
+	read -r spring_start spring_end fall_start fall_end <<<"$bounds"
+	insert_app_usage "$db" "$spring_start" "$spring_end"
+	insert_app_usage "$db" "$fall_start" "$fall_end"
+	local spring_hours fall_hours
+	spring_hours=$(TZ=America/New_York AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$((fall_end + 3600))" python3 "${SCRIPTS_DIR}/screen-time-interval-engine.py" date --date 2026-03-08 --os-type Darwin --db "$db")
+	fall_hours=$(TZ=America/New_York AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$((fall_end + 3600))" python3 "${SCRIPTS_DIR}/screen-time-interval-engine.py" date --date 2026-11-01 --os-type Darwin --db "$db")
+	[[ "$((spring_end - spring_start))" == "82800" && "$spring_hours" == "23.0" ]] || fail "spring DST local day was not bounded by consecutive midnights"
+	[[ "$((fall_end - fall_start))" == "90000" && "$fall_hours" == "24.0" ]] || fail "fall DST local day was not bounded then capped at 24h"
+	pass "date collection uses host-local consecutive-midnight DST boundaries"
+	return 0
+}
+
 test_linux_state_machine() {
 	local tmpdir="$1"
 	local now=2000000000
@@ -159,6 +225,20 @@ PY
 	[[ "$hours" == "3" || "$hours" == "3.0" ]] || fail "expected lock/lid/session state to produce 3.0h, got ${hours}"
 	[[ "$source" == *"session-lid-lock-state"* ]] || fail "Linux provenance missing state semantics: ${source}"
 	pass "Linux state retains username-less session OFF events and clips active windows"
+	local zero_fixture="${tmpdir}/logind-zero.txt"
+	python3 - "$zero_fixture" "$now" <<'PY'
+import datetime as dt
+import sys
+stamp = dt.datetime.fromtimestamp(int(sys.argv[2]) - 60, dt.timezone.utc).isoformat()
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    handle.write(f"{stamp} host systemd-logind[1]: New session z1 of user fixture.\n")
+    handle.write(f"{stamp} host systemd-logind[1]: Removed session z1.\n")
+PY
+	local zero_output
+	zero_output=$(AIDEVOPS_SCREEN_TIME_OS_TYPE=Linux AIDEVOPS_LOGIND_FIXTURE="$zero_fixture" \
+		AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" AIDEVOPS_SCREEN_TIME_USER=fixture "$HELPER" profile-stats)
+	[[ "$(printf '%s' "$zero_output" | jq -r '.today_hours')" == "0" || "$(printf '%s' "$zero_output" | jq -r '.today_hours')" == "0.0" ]] || fail "explicit zero-duration logind events were not preserved"
+	[[ "$(printf '%s' "$zero_output" | jq -r '.periods.day.status')" == "ok" ]] || fail "explicit logind zero was treated as source failure"
 
 	local missing_journal="${tmpdir}/missing-journal"
 	local wtmp_fixture="${tmpdir}/wtmp.txt"
@@ -170,6 +250,21 @@ PY
 	[[ "$(printf '%s' "$fallback" | jq -r '.today_hours')" == "1" || "$(printf '%s' "$fallback" | jq -r '.today_hours')" == "1.0" ]] || fail "wtmp fallback hours were not parsed"
 	[[ "$(printf '%s' "$fallback" | jq -r '.periods.day.source')" == "linux-wtmp:login-session-proxy" ]] || fail "wtmp fallback provenance was not truthful"
 	pass "Linux collection failure falls back to clipped wtmp sessions with proxy provenance"
+
+	local empty_journal="${tmpdir}/empty-logind.txt"
+	local realistic_last="${tmpdir}/last-F.txt"
+	: >"$empty_journal"
+	cat >"$realistic_last" <<'EOF'
+fixture  pts/0  host  Tue May 17 23:33:20 2033 - Wed May 18 00:33:20 2033  (01:00)
+fixture  pts/1  host  Wed May 18 01:33:20 2033   still logged in
+EOF
+	local empty_fallback
+	empty_fallback=$(TZ=UTC AIDEVOPS_SCREEN_TIME_OS_TYPE=Linux AIDEVOPS_LOGIND_FIXTURE="$empty_journal" \
+		AIDEVOPS_LAST_FIXTURE="$realistic_last" AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" \
+		AIDEVOPS_SCREEN_TIME_USER=fixture "$HELPER" profile-stats)
+	[[ "$(printf '%s' "$empty_fallback" | jq -r '.today_hours')" == "3" || "$(printf '%s' "$empty_fallback" | jq -r '.today_hours')" == "3.0" ]] || fail "real last -F completed+active records were not clipped to now"
+	[[ "$(printf '%s' "$empty_fallback" | jq -r '.periods.day.reason')" == *"journal-readable-no-user-observations"* ]] || fail "empty readable logind did not truthfully fall back"
+	pass "empty logind falls back and parses realistic local last -F records"
 	return 0
 }
 
@@ -187,16 +282,21 @@ today = dt.datetime.now(dt.timezone.utc).date()
 with open(sys.argv[1], "w", encoding="utf-8") as handle:
     for age, hours in ((20, 30), (10, 12), (5, 6)):
         handle.write(json.dumps({"date": str(today - dt.timedelta(days=age)), "screen_hours": hours}) + "\n")
+    handle.write("not-json\n")
+    handle.write(json.dumps({"date": "bad-date", "screen_hours": 5}) + "\n")
+    handle.write(json.dumps({"date": str(today - dt.timedelta(days=4)), "screen_hours": "broken"}) + "\n")
 PY
-	local output estimate span status
+	local output estimate span status skipped
 	output=$(HOME="$fixture_home" AIDEVOPS_SCREEN_TIME_OS_TYPE=Unsupported "$HELPER" profile-stats)
 	estimate=$(printf '%s' "$output" | jq -r '.year_hours')
 	span=$(printf '%s' "$output" | jq -r '.periods.year.calendar_span_days')
 	status=$(printf '%s' "$output" | jq -r '.periods.year.status')
+	skipped=$(printf '%s' "$output" | jq -r '.history_skipped_rows')
 	[[ "$span" == "16" ]] || fail "expected calendar span 16 rather than active row count 3, got ${span}"
 	[[ "$estimate" == "958.1" ]] || fail "expected clamped 24h rows and calendar-span estimate 958.1h, got ${estimate}"
 	[[ "$status" == "stale" ]] || fail "expected stale history estimate to remain visibly stale"
-	pass "history estimates use calendar coverage, clamp daily values, and expose staleness"
+	[[ "$skipped" == "3" ]] || fail "expected three malformed history rows to be skipped individually, got ${skipped}"
+	pass "history skips malformed rows individually and reports provenance"
 	return 0
 }
 
@@ -242,6 +342,8 @@ main() {
 
 	pass "screen-time helper falls back only for sparse backlit windows"
 	test_union_clipping_and_failure_status "$tmpdir" "$now"
+	test_empty_zero_and_sparse_source_semantics "$tmpdir" "$now"
+	test_local_midnight_dst_boundaries "$tmpdir"
 	test_linux_state_machine "$tmpdir"
 	test_history_calendar_coverage_and_staleness "$tmpdir"
 	return 0

--- a/.agents/scripts/tests/test-screen-time-helper.sh
+++ b/.agents/scripts/tests/test-screen-time-helper.sh
@@ -175,6 +175,60 @@ PY
 	return 0
 }
 
+test_snapshot_omits_unobserved_stale_dates() {
+	local tmpdir="$1"
+	local fixture_home="${tmpdir}/snapshot-home"
+	local db="${tmpdir}/snapshot-evidence.db"
+	mkdir -p "$fixture_home"
+	create_knowledge_db "$db"
+	local fixture_values observed_date zero_date observed_start observed_end zero_event
+	fixture_values=$(python3 -c 'import datetime as d; today=d.date.today(); observed=today-d.timedelta(days=5); zero=today-d.timedelta(days=4); epoch=lambda day,h:int(d.datetime.combine(day,d.time(h)).timestamp()); print(observed,zero,epoch(observed,10),epoch(observed,11),epoch(zero,12))')
+	read -r observed_date zero_date observed_start observed_end zero_event <<<"$fixture_values"
+	insert_backlit_pair "$db" "$observed_start" "$observed_end"
+	sqlite3 "$db" "INSERT INTO ZOBJECT (ZSTREAMNAME,ZCREATIONDATE,ZVALUEINTEGER) VALUES('/display/isBacklit',$(core_data_offset "$zero_event"),0);"
+	HOME="$fixture_home" AIDEVOPS_SCREEN_TIME_OS_TYPE=Darwin AIDEVOPS_KNOWLEDGE_DB="$db" "$HELPER" snapshot >/dev/null
+	local history="${fixture_home}/.aidevops/.agent-workspace/observability/screen-time.jsonl"
+	local rows dates zero_hours
+	rows=$(wc -l <"$history" | tr -d ' ')
+	dates=$(jq -r '.date' "$history" | sort | tr '\n' ' ')
+	zero_hours=$(jq -r --arg date "$zero_date" 'select(.date == $date) | .screen_hours' "$history")
+	if [[ "$rows" != "2" || "$dates" != "${observed_date} ${zero_date} " || ("$zero_hours" != "0" && "$zero_hours" != "0.0") ]]; then
+		fail "snapshot fabricated stale gap coverage or lost explicit zero: rows=${rows} dates=${dates} zero=${zero_hours}"
+	fi
+	pass "snapshot omits unobserved stale dates and records explicit zero-event dates"
+	return 0
+}
+
+test_top_apps_sql_and_sweep_are_bounded() {
+	local tmpdir="$1"
+	local now="$2"
+	local db="${tmpdir}/bounded-apps.db"
+	local instrument="${tmpdir}/bounded-apps-instrument.json"
+	create_knowledge_db "$db"
+	local cd_now=$((now - 978307200))
+	sqlite3 "$db" "
+		WITH RECURSIVE old_rows(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM old_rows WHERE i < 5000)
+		INSERT INTO ZOBJECT (ZSTREAMNAME,ZSTARTDATE,ZENDDATE,ZVALUESTRING)
+		SELECT '/app/usage', ${cd_now} - 86400*60 - i*60, ${cd_now} - 86400*60 - i*60 + 30, 'old.app' FROM old_rows;
+		WITH RECURSIVE recent_rows(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM recent_rows WHERE i < 200)
+		INSERT INTO ZOBJECT (ZSTREAMNAME,ZSTARTDATE,ZENDDATE,ZVALUESTRING)
+		SELECT '/app/usage', ${cd_now} - i*300, ${cd_now} - i*300 + 600, 'recent.' || (i % 3) FROM recent_rows;"
+	AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" AIDEVOPS_APP_STATS_INSTRUMENT_FILE="$instrument" \
+		python3 "${SCRIPTS_DIR}/screen-time-interval-engine.py" apps --os-type Darwin --db "$db" >/dev/null
+	local selected valid boundaries segments elapsed
+	selected=$(jq -r '.rows_selected' "$instrument")
+	valid=$(jq -r '.valid_intervals' "$instrument")
+	boundaries=$(jq -r '.boundaries' "$instrument")
+	segments=$(jq -r '.attributed_segments' "$instrument")
+	elapsed=$(jq -r '.elapsed_ms' "$instrument")
+	if [[ "$selected" != "200" || "$valid" != "200" || "$boundaries" -gt 402 || "$segments" -gt 401 ]] || \
+		! awk -v elapsed="$elapsed" 'BEGIN {exit !(elapsed < 5000)}'; then
+		fail "top-app query/sweep was unbounded: $(<"$instrument")"
+	fi
+	pass "top-app SQL excludes 5000 old rows and sweep remains boundary-linear"
+	return 0
+}
+
 test_local_midnight_dst_boundaries() {
 	local tmpdir="$1"
 	local db="${tmpdir}/dst.db"
@@ -343,6 +397,8 @@ main() {
 	pass "screen-time helper falls back only for sparse backlit windows"
 	test_union_clipping_and_failure_status "$tmpdir" "$now"
 	test_empty_zero_and_sparse_source_semantics "$tmpdir" "$now"
+	test_snapshot_omits_unobserved_stale_dates "$tmpdir"
+	test_top_apps_sql_and_sweep_are_bounded "$tmpdir" "$now"
 	test_local_midnight_dst_boundaries "$tmpdir"
 	test_linux_state_machine "$tmpdir"
 	test_history_calendar_coverage_and_staleness "$tmpdir"

--- a/.agents/scripts/tests/test-screen-time-helper.sh
+++ b/.agents/scripts/tests/test-screen-time-helper.sh
@@ -354,6 +354,60 @@ PY
 	return 0
 }
 
+test_corrupt_core_data_and_history_paths_are_safe() {
+	local tmpdir="$1"
+	local now="$2"
+	local db="${tmpdir}/corrupt-core-data.db"
+	create_knowledge_db "$db"
+	insert_app_usage "$db" "$((now - 7200))" "$((now - 3600))"
+	sqlite3 "$db" "
+		UPDATE ZOBJECT SET ZVALUESTRING='valid.app' WHERE ZSTREAMNAME='/app/usage';
+		INSERT INTO ZOBJECT (ZSTREAMNAME,ZCREATIONDATE,ZVALUEINTEGER) VALUES('/display/isBacklit','broken',1);
+		INSERT INTO ZOBJECT (ZSTREAMNAME,ZCREATIONDATE,ZVALUEINTEGER) VALUES('/display/isBacklit',1e999,1);
+		INSERT INTO ZOBJECT (ZSTREAMNAME,ZSTARTDATE,ZENDDATE,ZVALUESTRING) VALUES('/app/usage','broken','also-broken','bad.app');
+		INSERT INTO ZOBJECT (ZSTREAMNAME,ZSTARTDATE,ZENDDATE,ZVALUESTRING) VALUES('/app/usage',1e999,1e999,'infinite.app');"
+	local profile_json app_json
+	profile_json=$(AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" profile_stats "$db")
+	app_json=$(AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" python3 "${SCRIPTS_DIR}/screen-time-interval-engine.py" apps --os-type Darwin --db "$db")
+	local python_ok=0
+	PYTHONPATH="$SCRIPTS_DIR" python3 - <<'PY' || python_ok=1
+from screen_time_interval_common import local_date, safe_core_epoch
+
+assert local_date(10**500) is None
+assert local_date("corrupt") is None
+assert safe_core_epoch("corrupt") is None
+assert safe_core_epoch(float("inf")) is None
+PY
+	local history_json
+	history_json=$(python3 "${SCRIPTS_DIR}/screen-time-interval-engine.py" history-summary --os-type Unsupported --history "$tmpdir")
+	if [[ "$(printf '%s' "$profile_json" | jq -r '.month_hours')" != "1" && "$(printf '%s' "$profile_json" | jq -r '.month_hours')" != "1.0" ]] ||
+		[[ "$(printf '%s' "$app_json" | jq -r 'length')" != "1" ]] ||
+		[[ "$(printf '%s' "$history_json" | jq -r '.valid_rows')" != "0" || "$python_ok" -ne 0 ]]; then
+		fail "corrupt Core Data values or directory history path escaped defensive parsing"
+	fi
+	pass "corrupt Core Data values, local dates, and directory history paths are safe"
+	return 0
+}
+
+test_screen_engine_sibling_modules_deploy_together() {
+	local tmpdir="$1"
+	local deploy_dir="${tmpdir}/deployed-screen-engine"
+	mkdir -p "$deploy_dir"
+	cp "${SCRIPTS_DIR}/screen-time-interval-engine.py" \
+		"${SCRIPTS_DIR}/screen_time_interval_common.py" \
+		"${SCRIPTS_DIR}/screen_time_macos.py" \
+		"${SCRIPTS_DIR}/screen_time_macos_apps.py" \
+		"${SCRIPTS_DIR}/screen_time_linux.py" \
+		"${SCRIPTS_DIR}/screen_time_linux_wtmp.py" \
+		"${SCRIPTS_DIR}/screen_time_linux_logind.py" \
+		"${SCRIPTS_DIR}/screen_time_history.py" "$deploy_dir/"
+	local output
+	output=$(python3 "${deploy_dir}/screen-time-interval-engine.py" history-summary --os-type Unsupported)
+	[[ "$(printf '%s' "$output" | jq -r '.valid_rows')" == "0" ]] || fail "deployed screen engine could not load sibling modules"
+	pass "screen engine loads deployed sibling modules"
+	return 0
+}
+
 main() {
 	local tmpdir
 	tmpdir=$(mktemp -d)
@@ -402,6 +456,8 @@ main() {
 	test_local_midnight_dst_boundaries "$tmpdir"
 	test_linux_state_machine "$tmpdir"
 	test_history_calendar_coverage_and_staleness "$tmpdir"
+	test_corrupt_core_data_and_history_paths_are_safe "$tmpdir" "$now"
+	test_screen_engine_sibling_modules_deploy_together "$tmpdir"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Rebuild screen and assistant metrics around clipped interval observations, explicit coverage/freshness states, source-consistent counts, and one-pass profile aggregation across macOS and Linux.

## Files Changed

.agents/scripts/contributor-activity-helper-session.sh, .agents/scripts/profile-readme-data-lib.sh, .agents/scripts/profile-readme-helper.sh, .agents/scripts/profile-readme-render-lib.sh, .agents/scripts/screen-time-helper.sh, .agents/scripts/screen-time-interval-engine.py, .agents/scripts/session-time-interval-engine.py, .agents/scripts/tests/test-contributor-session-archive.sh, .agents/scripts/tests/test-profile-readme-boundary.sh, .agents/scripts/tests/test-screen-time-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 10 screen-time assertions; 7 session tests; 9 profile/model tests; ShellCheck and Python compilation clean; full local linter passed; live macOS generation verified at 72.6s versus 206s baseline.

Resolves #27140


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 with gpt-5.6-sol spent 1h 37m and 987,467 tokens on this with the user in an interactive session.