### PR TITLE
t18096: fix: defer canonical lint policy migration

### DIFF
--- a/.agents/scripts/lint-helper.sh
+++ b/.agents/scripts/lint-helper.sh
@@ -324,14 +324,14 @@ lint_reconcile() {
 		repo_verify_migrate_registration "$repo_root" >/dev/null 2>&1 || registration_status=$?
 		[[ "$registration_status" -eq 0 ]] && registered=$((registered + 1))
 		case "$registration_status" in
-		0 | 2 | 4) ;;
+		0 | 2 | 3 | 4) ;;
 		*) failed=$((failed + 1)) ;;
 		esac
 		migration_status=0
 		repo_verify_migrate_config "$repo_root" >/dev/null 2>&1 || migration_status=$?
 		[[ "$migration_status" -eq 0 ]] && migrated=$((migrated + 1))
 		case "$migration_status" in
-		0 | 2 | 4) ;;
+		0 | 2 | 3 | 4) ;;
 		*) failed=$((failed + 1)) ;;
 		esac
 		feature_state=$(lint_registered_feature_state "$repo_root")

--- a/.agents/scripts/setup/_repo_verify_guard.sh
+++ b/.agents/scripts/setup/_repo_verify_guard.sh
@@ -43,11 +43,11 @@ setup_repo_verify_guard() {
 		registration_status=0
 		repo_verify_migrate_registration "$repo_root" >/dev/null 2>&1 || registration_status=$?
 		[[ "$registration_status" -eq 0 ]] && registered=$((registered + 1))
-		case "$registration_status" in 0 | 2 | 4) ;; *) errors=$((errors + 1)) ;; esac
+		case "$registration_status" in 0 | 2 | 3 | 4) ;; *) errors=$((errors + 1)) ;; esac
 		migration_status=0
 		repo_verify_migrate_config "$repo_root" >/dev/null 2>&1 || migration_status=$?
 		[[ "$migration_status" -eq 0 ]] && migrated=$((migrated + 1))
-		case "$migration_status" in 0 | 2 | 4) ;; *) errors=$((errors + 1)) ;; esac
+		case "$migration_status" in 0 | 2 | 3 | 4) ;; *) errors=$((errors + 1)) ;; esac
 		feature_state=$(repo_verify_feature_state "$repo_root")
 		if [[ "$feature_state" == "false" ]]; then
 			skipped=$((skipped + 1))

--- a/.agents/scripts/tests/test-lint-helper.sh
+++ b/.agents/scripts/tests/test-lint-helper.sh
@@ -40,11 +40,16 @@ main() {
 	trap 'rm -rf "$TEST_TMP_DIR"' EXIT
 	local repo_one="${TEST_TMP_DIR}/repo-one"
 	local repo_two="${TEST_TMP_DIR}/repo-two"
+	local canonical="${TEST_TMP_DIR}/canonical"
 	local fake_home="${TEST_TMP_DIR}/home"
 	make_repo "$repo_one"
 	make_repo "$repo_two"
+	make_repo "$canonical"
+	/usr/bin/git -C "$canonical" add .aidevops.json
+	/usr/bin/git -C "$canonical" commit -q -m fixture
 	mkdir -p "${fake_home}/.config/aidevops"
-	jq -n --arg one "$repo_one" --arg two "$repo_two" '{initialized_repos:[{path:$one,features:[]},{path:$two,features:[]}]}' >"${fake_home}/.config/aidevops/repos.json"
+	jq -n --arg one "$repo_one" --arg two "$repo_two" --arg canonical "$canonical" \
+		'{initialized_repos:[{path:$one,features:[]},{path:$two,features:[]},{path:$canonical,features:["code-quality"]}]}' >"${fake_home}/.config/aidevops/repos.json"
 
 	local output classification before after
 	output=$(HOME="$fake_home" bash "$HELPER" audit --repo "$repo_one" --json)
@@ -72,8 +77,9 @@ main() {
 	rm -f "$plan_stderr"
 
 	HOME="$fake_home" bash "$HELPER" reconcile --all >/dev/null
-	assert_equal "2" "$(jq '[.initialized_repos[] | select((.features // []) | index("code-quality"))] | length' "${fake_home}/.config/aidevops/repos.json")" "update reconciliation seeds every non-opted-out registration"
+	assert_equal "3" "$(jq '[.initialized_repos[] | select((.features // []) | index("code-quality"))] | length' "${fake_home}/.config/aidevops/repos.json")" "update reconciliation seeds every non-opted-out registration"
 	assert_equal "true" "$(jq -r '.features.code_quality' "$repo_two/.aidevops.json")" "update reconciliation migrates existing repo config"
+	assert_equal "false" "$(jq -r '.features.code_quality // false' "$canonical/.aidevops.json")" "update reconciliation defers tracked canonical policy"
 
 	local repo_three="${TEST_TMP_DIR}/repo-three"
 	make_repo "$repo_three"

--- a/.agents/scripts/tests/test-repo-verify-guard-setup.sh
+++ b/.agents/scripts/tests/test-repo-verify-guard-setup.sh
@@ -44,16 +44,22 @@ main() {
 	trap 'rm -rf "$TEST_TMP_DIR"' EXIT
 	local eligible="${TEST_TMP_DIR}/eligible"
 	local disabled="${TEST_TMP_DIR}/disabled"
+	local canonical="${TEST_TMP_DIR}/canonical"
 	local fake_home="${TEST_TMP_DIR}/home"
 	make_repo "$eligible"
 	make_repo "$disabled"
+	make_repo "$canonical"
 	printf '%s\n' '{"scripts":{"lint":"eslint ."}}' >"$eligible/package.json"
 	/usr/bin/git -C "$eligible" add package.json
 	printf '%s\n' '{"version":"old","features":{"planning":true}}' >"$eligible/.aidevops.json"
 	printf '%s\n' '{"verify":{"enabled":false}}' >"$disabled/.aidevops.json"
+	printf '%s\n' '{"features":{"planning":true}}' >"$canonical/.aidevops.json"
+	printf '%s\n' '{"scripts":{"lint":"eslint ."}}' >"$canonical/package.json"
+	/usr/bin/git -C "$canonical" add .aidevops.json package.json
+	/usr/bin/git -C "$canonical" commit -q -m fixture
 	mkdir -p "${fake_home}/.config/aidevops"
-	jq -n --arg eligible "$eligible" --arg disabled "$disabled" \
-		'{initialized_repos:[{path:$eligible,features:["code-quality"]},{path:$disabled,features:["code-quality"]}]}' >"${fake_home}/.config/aidevops/repos.json"
+	jq -n --arg eligible "$eligible" --arg disabled "$disabled" --arg canonical "$canonical" \
+		'{initialized_repos:[{path:$eligible,features:["code-quality"]},{path:$disabled,features:["code-quality"]},{path:$canonical,features:["code-quality"]}]}' >"${fake_home}/.config/aidevops/repos.json"
 
 	HOME="$fake_home" setup_repo_verify_guard
 	assert_equal "true" "$(jq -r --arg path "$eligible" '.initialized_repos[] | select(.path == $path) | (.features | index("code-quality") != null)' "${fake_home}/.config/aidevops/repos.json")" "setup seeds code-quality registration"
@@ -68,6 +74,7 @@ main() {
 		assert_equal "0" "0" "setup preserves explicit opt-out"
 	fi
 	assert_equal "false" "$(jq -r '.features.code_quality // false' "$disabled/.aidevops.json")" "verify opt-out does not gain code-quality true"
+	assert_equal "false" "$(jq -r '.features.code_quality // false' "$canonical/.aidevops.json")" "setup defers tracked canonical policy without failing"
 	local setup_status=0
 	REPO_VERIFY_INSTALLER="${TEST_TMP_DIR}/missing-installer" HOME="$fake_home" setup_repo_verify_guard || setup_status=$?
 	assert_equal "1" "$setup_status" "setup reports hook rollout failures"

--- a/TODO.md
+++ b/TODO.md
@@ -1127,6 +1127,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18094 Provision repository lint configuration through init and update #feat ref:GH#27123
 
+- [ ] t18096 Treat canonical lint policy deferrals as safe skips #auto-dispatch #bug ref:GH#27139
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Implementation for issue #27139.

## Files Changed

.agents/scripts/lint-helper.sh, .agents/scripts/setup/_repo_verify_guard.sh, .agents/scripts/tests/test-lint-helper.sh, .agents/scripts/tests/test-repo-verify-guard-setup.sh, TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #27139


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 with gpt-5.6-sol spent 15h 7m and 7,444,692 tokens on this with the user in an interactive session.