### PR TITLE
t18096: fix: preserve unmanaged lint hooks during reconciliation

### DIFF
--- a/.agents/scripts/lint-helper.sh
+++ b/.agents/scripts/lint-helper.sh
@@ -345,7 +345,7 @@ lint_reconcile() {
 			continue
 		fi
 		hook_status=$(repo_verify_hook_status "$repo_root" 2>/dev/null || printf 'unavailable')
-		if [[ "$hook_status" == "installed" ]]; then
+		if [[ "$hook_status" == "installed" || "$hook_status" == "unmanaged-conflict" ]]; then
 			skipped=$((skipped + 1))
 			continue
 		fi

--- a/.agents/scripts/tests/test-lint-helper.sh
+++ b/.agents/scripts/tests/test-lint-helper.sh
@@ -75,11 +75,17 @@ main() {
 	assert_equal "true" "$(jq -r 'length > 0' "$plan_path")" "all-repo mode writes worker-ready PR plans"
 	assert_equal "600" "$(stat -f '%Lp' "$plan_path" 2>/dev/null || stat -c '%a' "$plan_path")" "PR plan protects private repository paths"
 	rm -f "$plan_stderr"
+	local repo_two_common
+	repo_two_common=$(/usr/bin/git -C "$repo_two" rev-parse --git-common-dir)
+	mkdir -p "${repo_two}/${repo_two_common}/hooks"
+	printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${repo_two}/${repo_two_common}/hooks/pre-push"
+	chmod +x "${repo_two}/${repo_two_common}/hooks/pre-push"
 
 	HOME="$fake_home" bash "$HELPER" reconcile --all >/dev/null
 	assert_equal "3" "$(jq '[.initialized_repos[] | select((.features // []) | index("code-quality"))] | length' "${fake_home}/.config/aidevops/repos.json")" "update reconciliation seeds every non-opted-out registration"
 	assert_equal "true" "$(jq -r '.features.code_quality' "$repo_two/.aidevops.json")" "update reconciliation migrates existing repo config"
 	assert_equal "false" "$(jq -r '.features.code_quality // false' "$canonical/.aidevops.json")" "update reconciliation defers tracked canonical policy"
+	assert_equal "0" "$(grep -c '# guard:repo-verify' "${repo_two}/${repo_two_common}/hooks/pre-push" 2>/dev/null || true)" "update reconciliation preserves unmanaged hook conflicts"
 
 	local repo_three="${TEST_TMP_DIR}/repo-three"
 	make_repo "$repo_three"


### PR DESCRIPTION
## Summary

Implementation for issue #27139.

## Files Changed

.agents/scripts/lint-helper.sh, .agents/scripts/tests/test-lint-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #27139


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.29 with gpt-5.6-sol spent 15h 29m and 8,105,716 tokens on this with the user in an interactive session.