### PR TITLE
GH#27138: recover dirty worker worktrees before redispatch

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -380,14 +380,20 @@ cmd_record_recovery() {
 
 	while [[ $# -gt 0 ]]; do
 		local option="${1:-}"
-		local option_value="${2:-}"
 		case "$option" in
-		--session-key) session_key="$option_value"; shift 2 ;;
-		--runner-key) runner_key="$option_value"; shift 2 ;;
-		--worktree) worktree_path="$option_value"; shift 2 ;;
-		--branch) branch_name="$option_value"; shift 2 ;;
-		--changed-paths) changed_paths="$option_value"; shift 2 ;;
-		--recoverability) recoverability="$option_value"; shift 2 ;;
+		--session-key | --runner-key | --worktree | --branch | --changed-paths | --recoverability)
+			[[ $# -ge 2 ]] || { echo "Error: $option requires an argument" >&2; return 1; }
+			local option_value="$2"
+			case "$option" in
+			--session-key) session_key="$option_value" ;;
+			--runner-key) runner_key="$option_value" ;;
+			--worktree) worktree_path="$option_value" ;;
+			--branch) branch_name="$option_value" ;;
+			--changed-paths) changed_paths="$option_value" ;;
+			--recoverability) recoverability="$option_value" ;;
+			esac
+			shift 2
+			;;
 		*) echo "Error: Unknown option for record-recovery: $option" >&2; return 1 ;;
 		esac
 	done

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -38,6 +38,7 @@
 #   dispatch-ledger-helper.sh check-issue NUM [SLUG]
 #   dispatch-ledger-helper.sh complete --session-key KEY
 #   dispatch-ledger-helper.sh fail --session-key KEY
+#   dispatch-ledger-helper.sh record-recovery --session-key KEY --runner-key KEY --worktree PATH --branch BRANCH --changed-paths TEXT --recoverability STATE
 #   dispatch-ledger-helper.sh expire [--ttl SECONDS]
 #   dispatch-ledger-helper.sh count
 #   dispatch-ledger-helper.sh status
@@ -360,6 +361,63 @@ cmd_register() {
 		'{issue: $inum, repo: $slug, tier: $tier, model: $model, dispatched_at: $ts, outcome: "pending"}' \
 		>>"$telemetry_file" 2>/dev/null || true
 
+	_release_lock
+	return 0
+}
+
+#######################################
+# Persist runner-local dirty-worktree recovery metadata.
+# Repeated updates replace the same session entry, making dirty markers
+# idempotent while retaining the private worktree path off public threads.
+#######################################
+cmd_record_recovery() {
+	local session_key=""
+	local runner_key=""
+	local worktree_path=""
+	local branch_name=""
+	local changed_paths=""
+	local recoverability=""
+
+	while [[ $# -gt 0 ]]; do
+		local option="${1:-}"
+		local option_value="${2:-}"
+		case "$option" in
+		--session-key) session_key="$option_value"; shift 2 ;;
+		--runner-key) runner_key="$option_value"; shift 2 ;;
+		--worktree) worktree_path="$option_value"; shift 2 ;;
+		--branch) branch_name="$option_value"; shift 2 ;;
+		--changed-paths) changed_paths="$option_value"; shift 2 ;;
+		--recoverability) recoverability="$option_value"; shift 2 ;;
+		*) echo "Error: Unknown option for record-recovery: $option" >&2; return 1 ;;
+		esac
+	done
+
+	[[ -n "$session_key" ]] || { echo "Error: record-recovery requires --session-key" >&2; return 1; }
+	_ensure_ledger
+	_acquire_lock || return 1
+	local now=""
+	now=$(_now_utc)
+	local tmp_file=""
+	tmp_file=$(mktemp "${LEDGER_DIR}/dispatch-ledger.XXXXXX") || { _release_lock; return 1; }
+	jq -c \
+		--arg sk "$session_key" \
+		--arg runner "$runner_key" \
+		--arg worktree "$worktree_path" \
+		--arg branch "$branch_name" \
+		--arg paths "$changed_paths" \
+		--arg recovery "$recoverability" \
+		--arg ts "$now" \
+		'if .session_key == $sk then
+			.runner_key = $runner |
+			.worktree_path = $worktree |
+			.branch = $branch |
+			.changed_paths = ($paths | split("\n") | map(select(length > 0))) |
+			.recoverability = $recovery |
+			.recovery_attempts = ((.recovery_attempts // 0) + 1) |
+			.status = (if $recovery == "checkpointed" then "checkpointed" else "dirty-recovery" end) |
+			.updated_at = $ts
+		else . end' "$LEDGER_FILE" >"$tmp_file" 2>/dev/null || cp "$LEDGER_FILE" "$tmp_file"
+	mv "$tmp_file" "$LEDGER_FILE"
 	_release_lock
 	return 0
 }
@@ -1176,6 +1234,9 @@ main() {
 		;;
 	fail)
 		cmd_fail "$@"
+		;;
+	record-recovery)
+		cmd_record_recovery "$@"
 		;;
 	record-outcome)
 		cmd_record_outcome "$@"

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -974,7 +974,7 @@ _recover_dirty_worker_pr() {
 	HEAD | main | master | "") return 1 ;;
 	esac
 	if declare -F _attempt_orphan_recovery_pr >/dev/null 2>&1; then
-		_attempt_orphan_recovery_pr "$session_key" "$work_dir" "$branch_name" "$repo_slug"
+		_attempt_orphan_recovery_pr "$session_key" "$work_dir" "$branch_name" "$repo_slug" "draft"
 		return $?
 	fi
 	return 1

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1351,6 +1351,7 @@ _register_dispatch_ledger() {
 	local ledger_args=(register --session-key "$ledger_session_key" --pid "$$")
 	[[ -n "$ledger_issue" ]] && ledger_args+=(--issue "$ledger_issue")
 	[[ -n "$ledger_repo" ]] && ledger_args+=(--repo "$ledger_repo")
+	[[ -n "$ledger_work_dir" ]] && ledger_args+=(--worktree "$ledger_work_dir")
 
 	"$DISPATCH_LEDGER_HELPER" "${ledger_args[@]}" 2>/dev/null || true
 	return 0

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -39,6 +39,9 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+# shellcheck source=shared-runner-identity.sh
+source "${SCRIPT_DIR}/shared-runner-identity.sh"
+
 # =============================================================================
 # Runtime invocation support — auth rotation & rate-limit monitoring
 # =============================================================================
@@ -750,10 +753,60 @@ _handle_worker_dirty_worktree() {
 	local branch_name=""
 	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 	local status_summary=""
-	status_summary=$(git -C "$work_dir" status --short 2>/dev/null | sed -n '1,20p' || true)
+	status_summary=$(git -C "$work_dir" status --short 2>/dev/null | sed -n '1,50p' || true)
 	[[ -n "$status_summary" ]] || status_summary="<dirty state unavailable>"
+	local runner_key=""
+	runner_key=$(runner_identity_key)
+
+	# Persist the full runner-local recovery context before any GitHub write.
+	# The ledger retains the private worktree path; the public marker below uses
+	# only a non-identifying runner key and repository-relative changed paths.
+	if [[ -x "${DISPATCH_LEDGER_HELPER:-}" ]]; then
+		"$DISPATCH_LEDGER_HELPER" record-recovery \
+			--session-key "$session_key" \
+			--runner-key "$runner_key" \
+			--worktree "$work_dir" \
+			--branch "$branch_name" \
+			--changed-paths "$status_summary" \
+			--recoverability "same-runner" 2>/dev/null || true
+	fi
 
 	print_info "[lifecycle] worker_dirty_worktree session=${session_key} branch=${branch_name:-<none>} work_dir_present=$([[ -d "$work_dir" ]] && printf 1 || printf 0)"
+
+	# The finish path can classify dirty work before the EXIT trap runs. Give the
+	# owning runner two bounded opportunities to checkpoint, push, and open the
+	# recovery PR now instead of globally pausing all dispatchers.
+	local previous_worktree_path="${_WORKER_WORKTREE_PATH:-}"
+	local recovered=0
+	_WORKER_WORKTREE_PATH="$work_dir"
+	if declare -F _push_wip_commits_on_exit >/dev/null 2>&1 && declare -F _recover_dirty_worker_pr >/dev/null 2>&1; then
+		local recovery_attempt=1
+		while [[ "$recovery_attempt" -le 2 ]]; do
+			_push_wip_commits_on_exit
+			if _recover_dirty_worker_pr "$session_key"; then
+				recovered=1
+				break
+			fi
+			recovery_attempt=$((recovery_attempt + 1))
+		done
+	fi
+	_WORKER_WORKTREE_PATH="$previous_worktree_path"
+
+	if [[ "$recovered" -eq 1 ]]; then
+		if [[ -x "${DISPATCH_LEDGER_HELPER:-}" ]]; then
+			"$DISPATCH_LEDGER_HELPER" record-recovery \
+				--session-key "$session_key" \
+				--runner-key "$runner_key" \
+				--worktree "$work_dir" \
+				--branch "$branch_name" \
+				--changed-paths "$status_summary" \
+				--recoverability "checkpointed" 2>/dev/null || true
+		fi
+		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
+		print_info "[lifecycle] worker_dirty_worktree_checkpointed session=${session_key} branch=${branch_name:-<none>}"
+		return 0
+	fi
+
 	_release_dispatch_claim "$session_key" "worker_dirty_worktree"
 
 	if [[ -n "$issue_number" && -n "$repo_slug" ]]; then
@@ -761,14 +814,18 @@ _handle_worker_dirty_worktree() {
 		local _dirty_key="${repo_slug}#${issue_number}#${branch_name:-unknown}#worker_dirty_worktree"
 		local _comments_endpoint="repos/${repo_slug}/issues/${issue_number}/com""ments"
 		# shellcheck disable=SC2016 # backticks are literal markdown, not command substitution
-		_ops_comment=$(printf '<!-- ops:start -->\n<!-- worker-dirty-worktree:key=%s -->\nWORKER_DIRTY_WORKTREE branch=%s session=%s ts=%s\n\nThis worker exited after local file edits but before a commit/PR could be confirmed. Pause redispatch and inspect the runner-local worker metrics/logs for the worktree path, then either recover the edits into a PR or clear this marker after confirming the edits are disposable.\n\nChanged paths reported by git status on the runner:\n\n```\n%s\n```\n<!-- ops:end -->' \
+		_ops_comment=$(printf '<!-- ops:start -->\n<!-- worker-dirty-worktree:key=%s -->\nWORKER_DIRTY_WORKTREE branch=%s session=%s runner_key=%s recoverability=same-runner ts=%s\n\nThe owning runner could not create a pushed checkpoint during bounded teardown recovery. Its dispatch ledger retains the private worktree path. Prefer same-runner resume while that worktree exists; cross-runner takeover is allowed only after the bounded recovery hold expires.\n\nChanged paths reported by git status on the owning runner:\n\n```\n%s\n```\n<!-- ops:end -->' \
 			"$_dirty_key" \
-			"${branch_name:-unknown}" "$session_key" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			"${branch_name:-unknown}" "$session_key" "$runner_key" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 			"$status_summary")
-		gh api "$_comments_endpoint" \
-			--method POST \
-			--field body="$_ops_comment" \
-			>/dev/null 2>&1 || true
+		local existing_marker_count="0"
+		existing_marker_count=$(gh api "${_comments_endpoint}?per_page=100" 2>/dev/null | jq -r --arg key "worker-dirty-worktree:key=${_dirty_key}" '[.[] | select((.body // "") | contains($key))] | length' 2>/dev/null || printf '0')
+		if [[ "$existing_marker_count" == "0" ]]; then
+			gh api "$_comments_endpoint" \
+				--method POST \
+				--field body="$_ops_comment" \
+				>/dev/null 2>&1 || true
+		fi
 	fi
 	return 0
 }

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -30,6 +30,11 @@
 [[ -n "${_PULSE_DISPATCH_FILL_FLOOR_LIB_LOADED:-}" ]] && return 0
 _PULSE_DISPATCH_FILL_FLOOR_LIB_LOADED=1
 
+_PULSE_DISPATCH_LIB_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$_PULSE_DISPATCH_LIB_DIR" == "${BASH_SOURCE[0]}" ]] && _PULSE_DISPATCH_LIB_DIR="."
+# shellcheck source=shared-runner-identity.sh
+source "${_PULSE_DISPATCH_LIB_DIR}/shared-runner-identity.sh"
+
 # --- Helper functions and module-level round-state vars (extracted) ---
 
 # -----------------------------------------------------------------------------
@@ -217,9 +222,10 @@ _dispatch_candidate_benign_block_reason() {
 _dispatch_recent_dirty_worktree_marker_active() {
 	local issue_number="$1"
 	local repo_slug="$2"
-	local hold_seconds="${DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS:-21600}"
+	local hold_seconds="${DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS:-900}"
+	_DISPATCH_DIRTY_MARKER_STATE="clear"
 
-	[[ "$hold_seconds" =~ ^[0-9]+$ ]] || hold_seconds="21600"
+	[[ "$hold_seconds" =~ ^[0-9]+$ ]] || hold_seconds="900"
 	[[ "$hold_seconds" -gt 0 ]] || return 1
 
 	local comments_json=""
@@ -258,6 +264,7 @@ except ValueError:
 
 latest_marker_ts = None
 latest_resolution_ts = None
+latest_marker_body = ""
 resolution_tokens = (
     "worker-dirty-worktree:resolved",
     "WORKER_DIRTY_WORKTREE_RESOLVED",
@@ -274,6 +281,7 @@ for comment in comments:
         latest_resolution_ts = created
     elif "WORKER_DIRTY_WORKTREE" in body:
         latest_marker_ts = created
+        latest_marker_body = body
 
 if latest_marker_ts is None:
     print(clear_state)
@@ -283,12 +291,18 @@ if latest_resolution_ts is not None and latest_resolution_ts >= latest_marker_ts
     sys.exit(0)
 
 age = max(0, int(now_epoch - latest_marker_ts))
+runner_key = ""
+for token in latest_marker_body.split():
+    if token.startswith("runner_key="):
+        runner_key = token.split("=", 1)[1]
+        break
 if age <= hold_seconds:
-    print(f"block:age={age}")
+    print(f"block:age={age}:runner_key={runner_key}")
 else:
-    print(clear_state)
+    print(f"expired:age={age}:runner_key={runner_key}")
 PY
 ) || marker_state=""
+	_DISPATCH_DIRTY_MARKER_STATE="${marker_state:-clear}"
 
 	[[ "$marker_state" == block:* ]] || return 1
 	return 0
@@ -1027,9 +1041,29 @@ _dispatch_skip_for_dirty_worktree_recovery() {
 	local repo_slug="$2"
 
 	if _dispatch_recent_dirty_worktree_marker_active "$issue_number" "$repo_slug"; then
+		local marker_runner_key=""
+		marker_runner_key="${_DISPATCH_DIRTY_MARKER_STATE##*runner_key=}"
+		local local_runner_key=""
+		if declare -F runner_identity_key >/dev/null 2>&1; then
+			local_runner_key=$(runner_identity_key)
+		fi
+		if [[ -n "$marker_runner_key" && "$marker_runner_key" == "$local_runner_key" ]]; then
+			echo "[pulse-wrapper] Dispatch_max: resuming #${issue_number} (${repo_slug}) on owning runner with preserved dirty worktree" >>"$LOGFILE"
+			_dispatch_stats_increment "dispatch_candidate_dirty_worktree_same_runner_resume"
+			return 1
+		fi
 		echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — recent worker dirty-worktree recovery marker is unresolved" >>"$LOGFILE"
 		_dispatch_stats_increment "dispatch_candidate_skipped_dirty_worktree_recovery"
 		return 0
+	fi
+	if [[ "${_DISPATCH_DIRTY_MARKER_STATE:-}" == expired:* ]]; then
+		local resolution_body=""
+		resolution_body=$(printf '<!-- ops:start -->\n<!-- worker-dirty-worktree:resolved -->\nWORKER_DIRTY_WORKTREE_RESOLVED reason=owning-runner-window-expired ts=%s\n\nThe bounded same-runner recovery window expired without a pushed checkpoint. The runner-local ledger/archive remains the audit record; this marker is cleared once so cross-runner redispatch can proceed deterministically.\n<!-- ops:end -->' "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+		gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+			--method POST \
+			--field body="$resolution_body" >/dev/null 2>&1 || true
+		echo "[pulse-wrapper] Dispatch_max: cleared expired dirty-worktree marker for #${issue_number} (${repo_slug}); cross-runner takeover may proceed" >>"$LOGFILE"
+		_dispatch_stats_increment "dispatch_candidate_dirty_worktree_recovery_expired"
 	fi
 	return 1
 }

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -797,6 +797,27 @@ _dlw_restore_worktree_deps() {
 	return 0
 }
 
+_dlw_prepare_existing_worktree() {
+	local existing_path="$1"
+	local repo_path="$2"
+	local existing_status=""
+	existing_status=$(git -C "$existing_path" status --porcelain 2>/dev/null || true)
+	if [[ -n "$existing_status" ]]; then
+		# A same-runner retry must resume staged, unstaged, and untracked edits.
+		# Resetting here destroyed the only useful copy before GH#27138.
+		echo "[dispatch_with_dedup] Preserving dirty existing worktree for same-runner resume: ${existing_path}" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Clean retries restart from the latest default branch.
+	git -C "$existing_path" checkout -- . 2>/dev/null || true
+	git -C "$existing_path" clean -fd 2>/dev/null || true
+	local main_branch=""
+	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch="main"
+	git -C "$existing_path" reset --hard "origin/${main_branch}" 2>/dev/null || true
+	return 0
+}
+
 _dlw_precreate_worktree() {
 	local issue_number="$1"
 	local repo_path="$2"
@@ -829,20 +850,7 @@ _dlw_precreate_worktree() {
 	done < <(git -C "$repo_path" worktree list 2>/dev/null)
 
 	if [[ -n "$_existing_path" ]]; then
-		local _existing_status=""
-		_existing_status=$(git -C "$_existing_path" status --porcelain 2>/dev/null || true)
-		if [[ -z "$_existing_status" ]]; then
-			# Clean retries restart from the latest default branch.
-			git -C "$_existing_path" checkout -- . 2>/dev/null || true
-			git -C "$_existing_path" clean -fd 2>/dev/null || true
-			local _main_branch=""
-			_main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || _main_branch="main"
-			git -C "$_existing_path" reset --hard "origin/${_main_branch}" 2>/dev/null || true
-		else
-			# A same-runner retry must resume staged, unstaged, and untracked edits.
-			# Resetting here destroyed the only useful copy before GH#27138.
-			echo "[dispatch_with_dedup] Preserving dirty existing worktree for same-runner resume: ${_existing_path}" >>"$LOGFILE"
-		fi
+		_dlw_prepare_existing_worktree "$_existing_path" "$repo_path"
 		_DLW_WORKTREE_PATH="$_existing_path"
 		_DLW_WORKTREE_BRANCH="$_existing_branch"
 		_DLW_WORKTREE_REUSED=1

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -829,12 +829,20 @@ _dlw_precreate_worktree() {
 	done < <(git -C "$repo_path" worktree list 2>/dev/null)
 
 	if [[ -n "$_existing_path" ]]; then
-		# Reset to latest main so the worker starts from a clean base
-		git -C "$_existing_path" checkout -- . 2>/dev/null || true
-		git -C "$_existing_path" clean -fd 2>/dev/null || true
-		local _main_branch=""
-		_main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || _main_branch="main"
-		git -C "$_existing_path" reset --hard "origin/${_main_branch}" 2>/dev/null || true
+		local _existing_status=""
+		_existing_status=$(git -C "$_existing_path" status --porcelain 2>/dev/null || true)
+		if [[ -z "$_existing_status" ]]; then
+			# Clean retries restart from the latest default branch.
+			git -C "$_existing_path" checkout -- . 2>/dev/null || true
+			git -C "$_existing_path" clean -fd 2>/dev/null || true
+			local _main_branch=""
+			_main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || _main_branch="main"
+			git -C "$_existing_path" reset --hard "origin/${_main_branch}" 2>/dev/null || true
+		else
+			# A same-runner retry must resume staged, unstaged, and untracked edits.
+			# Resetting here destroyed the only useful copy before GH#27138.
+			echo "[dispatch_with_dedup] Preserving dirty existing worktree for same-runner resume: ${_existing_path}" >>"$LOGFILE"
+		fi
 		_DLW_WORKTREE_PATH="$_existing_path"
 		_DLW_WORKTREE_BRANCH="$_existing_branch"
 		_DLW_WORKTREE_REUSED=1

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -343,6 +343,29 @@ _build_orphan_recovery_pr_body() {
 	return 0
 }
 
+_create_orphan_recovery_pr() {
+	local repo_slug="$1"
+	local branch_name="$2"
+	local base_branch="$3"
+	local pr_title="$4"
+	local pr_body="$5"
+	local recovery_mode="$6"
+	local create_args=(
+		--repo "$repo_slug"
+		--head "$branch_name"
+		--base "$base_branch"
+		--title "$pr_title"
+		--body "$pr_body"
+		--label "origin:worker-takeover"
+		--label "status:in-review"
+	)
+	if [[ "$recovery_mode" == "draft" ]]; then
+		create_args+=(--draft)
+	fi
+	gh pr create "${create_args[@]}" >/dev/null 2>&1 # aidevops-allow: raw-gh-wrapper
+	return $?
+}
+
 #######################################
 # _attempt_orphan_recovery_pr — auto-recover a worker_branch_orphan (GH#20819)
 #
@@ -469,19 +492,7 @@ _attempt_orphan_recovery_pr() {
 	# NOT a line continuation in bash (`\` escapes the space, `#` starts a
 	# comment, the line terminates), so the args were silently dropped and
 	# this entire orphan-recovery path never produced a PR. SC2215 caught it.
-	local create_args=(
-		--repo "$repo_slug"
-		--head "$branch_name"
-		--base "$base_branch"
-		--title "$pr_title"
-		--body "$pr_body"
-		--label "origin:worker-takeover"
-		--label "status:in-review"
-	)
-	if [[ "$recovery_mode" == "draft" ]]; then
-		create_args+=(--draft)
-	fi
-	gh pr create "${create_args[@]}" >/dev/null 2>&1 # aidevops-allow: raw-gh-wrapper
+	_create_orphan_recovery_pr "$repo_slug" "$branch_name" "$base_branch" "$pr_title" "$pr_body" "$recovery_mode"
 	return $?
 }
 

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -372,6 +372,7 @@ _build_orphan_recovery_pr_body() {
 #   $2 = work_dir     (path to git worktree; unused after branch_name extracted)
 #   $3 = branch_name  (feature branch to set as PR head)
 #   $4 = repo_slug    (owner/repo)
+#   $5 = recovery_mode (optional; "draft" for dirty-worktree checkpoints)
 #
 # Non-fatal guard: issues in CLOSED state skip recovery rather than
 # creating a PR nobody will review (edge case: worker closed issue as
@@ -382,6 +383,7 @@ _attempt_orphan_recovery_pr() {
 	local work_dir="$2"
 	local branch_name="$3"
 	local repo_slug="$4"
+	local recovery_mode="${5:-ready}"
 
 	# Cannot query or build a PR without repo context.
 	if [[ -z "$repo_slug" ]]; then
@@ -448,6 +450,9 @@ _attempt_orphan_recovery_pr() {
 		pr_title="auto-recover: orphaned worker branch for #${issue_number}"
 		closing_line="Resolves #${issue_number}"
 	fi
+	if [[ "$recovery_mode" == "draft" ]]; then
+		pr_title="checkpoint: recover dirty worker worktree for #${issue_number}"
+	fi
 
 	local pr_body
 	pr_body=$(_build_orphan_recovery_pr_body "$session_key" "$branch_name" "$closing_line" "$published_local_branch")
@@ -473,6 +478,9 @@ _attempt_orphan_recovery_pr() {
 		--label "origin:worker-takeover"
 		--label "status:in-review"
 	)
+	if [[ "$recovery_mode" == "draft" ]]; then
+		create_args+=(--draft)
+	fi
 	gh pr create "${create_args[@]}" >/dev/null 2>&1 # aidevops-allow: raw-gh-wrapper
 	return $?
 }

--- a/.agents/scripts/shared-runner-identity.sh
+++ b/.agents/scripts/shared-runner-identity.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Return a stable, non-identifying key for the current runner. The raw hostname
+# stays in runner-local metadata; public recovery markers carry only this key.
+runner_identity_key() {
+	if [[ -n "${AIDEVOPS_RUNNER_IDENTITY_KEY:-}" ]]; then
+		printf '%s\n' "$AIDEVOPS_RUNNER_IDENTITY_KEY"
+		return 0
+	fi
+
+	local runner_identity="${AIDEVOPS_RUNNER_IDENTITY:-}"
+	[[ -n "$runner_identity" ]] || runner_identity=$(hostname 2>/dev/null || printf 'unknown')
+	local identity_hash=""
+	identity_hash=$(printf '%s' "$runner_identity" | git hash-object --stdin 2>/dev/null || true)
+	if [[ -n "$identity_hash" ]]; then
+		printf 'runner-%s\n' "${identity_hash:0:12}"
+		return 0
+	fi
+
+	local identity_checksum=""
+	identity_checksum=$(printf '%s' "$runner_identity" | cksum 2>/dev/null | cut -d ' ' -f 1 || true)
+	printf 'runner-%s\n' "${identity_checksum:-unknown}"
+	return 0
+}

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -122,6 +122,23 @@ test_record_recovery_is_idempotent() {
 	return 0
 }
 
+test_record_recovery_rejects_missing_option_values() {
+	setup_test_env
+	local result=0
+	local option=""
+	local error_file="${TEST_ROOT}/error.log"
+	for option in --session-key --runner-key --worktree --branch --changed-paths --recoverability; do
+		run_helper "$LEDGER_HELPER" record-recovery "$option" 2>"$error_file"
+		if [[ "$LAST_EXIT" -eq 0 ]] || ! grep -Fq "Error: $option requires an argument" "$error_file"; then
+			result=1
+			break
+		fi
+	done
+	print_result "record-recovery rejects missing option values cleanly" "$result" "option=${option} exit=${LAST_EXIT}"
+	teardown_test_env
+	return 0
+}
+
 #######################################
 # Test: check detects in-flight entry
 #######################################
@@ -781,6 +798,7 @@ main() {
 
 	test_register_creates_entry
 	test_record_recovery_is_idempotent
+	test_record_recovery_rejects_missing_option_values
 	test_check_detects_inflight
 	test_check_returns_1_for_unknown
 	test_check_issue_detects_inflight

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -103,6 +103,25 @@ test_register_creates_entry() {
 	return 0
 }
 
+test_record_recovery_is_idempotent() {
+	setup_test_env
+	run_helper "$LEDGER_HELPER" register --session-key "issue-27138" --issue 27138 --repo "owner/repo" --pid $$ --worktree "/private/worker/path"
+	run_helper "$LEDGER_HELPER" record-recovery --session-key "issue-27138" --runner-key "runner-test" --worktree "/private/worker/path" --branch "feature/gh27138" --changed-paths $'M  staged.txt\n M unstaged.txt\n?? new.txt' --recoverability "same-runner"
+	run_helper "$LEDGER_HELPER" record-recovery --session-key "issue-27138" --runner-key "runner-test" --worktree "/private/worker/path" --branch "feature/gh27138" --changed-paths $'M  staged.txt\n M unstaged.txt\n?? new.txt' --recoverability "same-runner"
+
+	local result=0
+	local entry_count=""
+	local attempts=""
+	local changed_count=""
+	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
+	attempts=$(jq -r '.recovery_attempts' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl")
+	changed_count=$(jq -r '.changed_paths | length' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl")
+	[[ "$entry_count" == "1" && "$attempts" == "2" && "$changed_count" == "3" ]] || result=1
+	print_result "dirty recovery metadata updates one durable ledger entry" "$result" "entries=${entry_count}, attempts=${attempts}, changed=${changed_count}"
+	teardown_test_env
+	return 0
+}
+
 #######################################
 # Test: check detects in-flight entry
 #######################################
@@ -761,6 +780,7 @@ main() {
 	fi
 
 	test_register_creates_entry
+	test_record_recovery_is_idempotent
 	test_check_detects_inflight
 	test_check_returns_1_for_unknown
 	test_check_issue_detects_inflight

--- a/.agents/scripts/tests/test-orphan-recovery-pr-base.sh
+++ b/.agents/scripts/tests/test-orphan-recovery-pr-base.sh
@@ -133,6 +133,23 @@ test_orphan_recovery_uses_configured_pr_base() {
 	return 0
 }
 
+test_dirty_recovery_creates_draft_checkpoint() {
+	rm -f "${TEST_ROOT}/calls/pr-create.argv"
+	if ! _attempt_orphan_recovery_pr "issue-27138" "$TEST_ROOT" "feature/auto-gh27138" "owner/repo" "draft"; then
+		print_result "dirty recovery creates draft checkpoint PR" 1 "_attempt_orphan_recovery_pr failed"
+		return 0
+	fi
+
+	local argv=""
+	argv=$(<"${TEST_ROOT}/calls/pr-create.argv")
+	if [[ "$argv" == *"--draft"* && "$argv" == *"checkpoint: recover dirty worker worktree for #27138"* ]]; then
+		print_result "dirty recovery creates draft checkpoint PR" 0
+		return 0
+	fi
+	print_result "dirty recovery creates draft checkpoint PR" 1 "argv=${argv}"
+	return 0
+}
+
 test_configured_pr_base_overrides_default_branch() {
 	local resolved=""
 	resolved=$(_resolve_orphan_recovery_base_branch "exampleorg/examplerepo" "$TEST_ROOT")
@@ -175,6 +192,7 @@ test_unconfigured_repo_falls_back_to_github_default_branch() {
 main() {
 	setup_test_env
 	test_orphan_recovery_uses_configured_pr_base
+	test_dirty_recovery_creates_draft_checkpoint
 	test_configured_pr_base_overrides_default_branch
 	test_explicit_dispatch_pr_base_overrides_repo_config
 	test_unconfigured_repo_falls_back_to_github_default_branch

--- a/.agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh
@@ -16,6 +16,7 @@ readonly TEST_RESET='\033[0m'
 
 TESTS_RUN=0
 TESTS_FAILED=0
+TEST_GH_POST_COUNT=0
 
 print_result() {
 	local test_name="$1"
@@ -39,6 +40,10 @@ print_result() {
 gh() {
 	local subcommand="$1"
 	local endpoint="${2:-}"
+	if [[ "$subcommand" == "api" && "$endpoint" == "repos/marcusquinn/aidevops/issues/26635/comments" && "$*" == *"--method POST"* ]]; then
+		TEST_GH_POST_COUNT=$((TEST_GH_POST_COUNT + 1))
+		return 0
+	fi
 	if [[ "$subcommand" != "api" || "$endpoint" != "repos/marcusquinn/aidevops/issues/26635/comments?per_page=100" ]]; then
 		printf 'unexpected gh call: %s\n' "$*" >&2
 		return 1
@@ -180,6 +185,32 @@ test_expired_marker_does_not_block() {
 	return 0
 }
 
+test_expired_marker_clears_once_with_audit() {
+	local marker='{"created_at":"2026-07-05T22:22:12Z","body":"WORKER_DIRTY_WORKTREE branch=feature/auto-20260706-000537-gh26635 runner_key=runner-other"}'
+	TEST_GH_POST_COUNT=0
+	set +e
+	TEST_GH_COMMENTS_JSON="[${marker}]" \
+		AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH="1783377432" \
+		DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS="21600" \
+		_dispatch_skip_for_dirty_worktree_recovery "26635" "marcusquinn/aidevops"
+	local first_rc=$?
+	set -e
+	local resolution='{"created_at":"2026-07-07T22:40:00Z","body":"<!-- worker-dirty-worktree:resolved --> WORKER_DIRTY_WORKTREE_RESOLVED"}'
+	set +e
+	TEST_GH_COMMENTS_JSON="[${marker},${resolution}]" \
+		AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH="1783377432" \
+		DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS="21600" \
+		_dispatch_skip_for_dirty_worktree_recovery "26635" "marcusquinn/aidevops"
+	local second_rc=$?
+	set -e
+	if [[ "$first_rc" -eq 1 && "$second_rc" -eq 1 && "$TEST_GH_POST_COUNT" -eq 1 ]]; then
+		print_result "expired unrecoverable marker clears once with audit evidence" 0
+		return 0
+	fi
+	print_result "expired unrecoverable marker clears once with audit evidence" 1 "first=${first_rc} second=${second_rc} posts=${TEST_GH_POST_COUNT}"
+	return 0
+}
+
 main() {
 	load_lib
 	test_recent_marker_blocks_dispatch
@@ -188,6 +219,7 @@ main() {
 	test_dirty_worktree_reuse_preserves_edits
 	test_later_resolution_clears_marker
 	test_expired_marker_does_not_block
+	test_expired_marker_clears_once_with_audit
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 LIB_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-lib.sh"
+WORKER_LAUNCH_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-worker-launch.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -51,11 +52,14 @@ load_lib() {
 	: >"$LOGFILE"
 	# shellcheck disable=SC1090 # test sources the library under test by path.
 	source "$LIB_SCRIPT"
+	# shellcheck disable=SC1090 # test sources the worker launch helper by path.
+	source "$WORKER_LAUNCH_SCRIPT"
+	_dispatch_stats_increment() { return 0; }
 	return 0
 }
 
 test_recent_marker_blocks_dispatch() {
-	local comments_json='[{"created_at":"2026-07-05T22:22:12Z","body":"WORKER_DIRTY_WORKTREE branch=feature/auto-20260706-000537-gh26635"}]'
+	local comments_json='[{"created_at":"2026-07-05T22:22:12Z","body":"WORKER_DIRTY_WORKTREE branch=feature/auto-20260706-000537-gh26635 runner_key=runner-other"}]'
 	TEST_GH_COMMENTS_JSON="$comments_json" \
 		AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH="1783291032" \
 		DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS="21600" \
@@ -66,6 +70,79 @@ test_recent_marker_blocks_dispatch() {
 		return 0
 	fi
 	print_result "recent dirty marker blocks dispatch" 1 "expected active marker to block"
+	return 0
+}
+
+test_same_runner_marker_allows_resume() {
+	local comments_json='[{"created_at":"2026-07-05T22:22:12Z","body":"WORKER_DIRTY_WORKTREE branch=feature/auto-20260706-000537-gh26635 runner_key=runner-test"}]'
+	AIDEVOPS_RUNNER_IDENTITY_KEY="runner-test" \
+		TEST_GH_COMMENTS_JSON="$comments_json" \
+		AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH="1783291032" \
+		DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS="21600" \
+		_dispatch_recent_dirty_worktree_marker_active "26635" "marcusquinn/aidevops"
+	local rc=$?
+	local marker_runner_key="${_DISPATCH_DIRTY_MARKER_STATE##*runner_key=}"
+	if [[ "$rc" -eq 0 && "$marker_runner_key" == "runner-test" ]]; then
+		print_result "active marker identifies owning runner for resume" 0
+		return 0
+	fi
+	print_result "active marker identifies owning runner for resume" 1 "state=${_DISPATCH_DIRTY_MARKER_STATE} rc=${rc}"
+	return 0
+}
+
+test_same_runner_skip_gate_proceeds() {
+	local comments_json='[{"created_at":"2026-07-05T22:22:12Z","body":"WORKER_DIRTY_WORKTREE branch=feature/auto-20260706-000537-gh26635 runner_key=runner-test"}]'
+	set +e
+	AIDEVOPS_RUNNER_IDENTITY_KEY="runner-test" \
+		TEST_GH_COMMENTS_JSON="$comments_json" \
+		AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH="1783291032" \
+		DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS="21600" \
+		_dispatch_skip_for_dirty_worktree_recovery "26635" "marcusquinn/aidevops"
+	local rc=$?
+	set -e
+	if [[ "$rc" -eq 1 ]]; then
+		print_result "same-runner dirty marker proceeds to worker resume" 0
+		return 0
+	fi
+	print_result "same-runner dirty marker proceeds to worker resume" 1 "rc=${rc}"
+	return 0
+}
+
+test_dirty_worktree_reuse_preserves_edits() {
+	git() { /usr/bin/git "$@"; }
+	local fixture_root=""
+	fixture_root=$(mktemp -d)
+	local origin_dir="${fixture_root}/origin.git"
+	local repo_dir="${fixture_root}/repo"
+	local worktree_dir="${fixture_root}/dirty-worktree"
+	git init --bare "$origin_dir" >/dev/null 2>&1
+	git clone "$origin_dir" "$repo_dir" >/dev/null 2>&1
+	git -C "$repo_dir" config user.email "worker@example.invalid"
+	git -C "$repo_dir" config user.name "Worker Test"
+	git -C "$repo_dir" checkout -b main >/dev/null 2>&1
+	printf 'base\n' >"${repo_dir}/tracked.txt"
+	git -C "$repo_dir" add tracked.txt
+	git -C "$repo_dir" commit -m "test: seed" >/dev/null 2>&1
+	git -C "$repo_dir" push -u origin main >/dev/null 2>&1
+	git -C "$repo_dir" worktree add -b "feature/auto-test-gh26635" "$worktree_dir" main >/dev/null 2>&1
+	printf 'staged\n' >"${worktree_dir}/tracked.txt"
+	git -C "$worktree_dir" add tracked.txt
+	printf 'unstaged\n' >>"${worktree_dir}/tracked.txt"
+	printf 'untracked\n' >"${worktree_dir}/new.txt"
+	local status_before=""
+	status_before=$(git -C "$worktree_dir" status --porcelain)
+
+	local test_script_dir="$SCRIPT_DIR"
+	SCRIPT_DIR="${test_script_dir}/.."
+	_dlw_precreate_worktree "26635" "$repo_dir"
+	SCRIPT_DIR="$test_script_dir"
+	local status_after=""
+	status_after=$(git -C "$worktree_dir" status --porcelain)
+	local result=0
+	[[ "$_DLW_WORKTREE_REUSED" == "1" && "$_DLW_WORKTREE_PATH" == "$worktree_dir" && "$status_after" == "$status_before" ]] || result=1
+	print_result "same-runner worktree reuse preserves staged, unstaged, and untracked edits" "$result" "before='${status_before}' after='${status_after}' reused=${_DLW_WORKTREE_REUSED}"
+	rm -rf "$fixture_root"
+	unset -f git
 	return 0
 }
 
@@ -106,6 +183,9 @@ test_expired_marker_does_not_block() {
 main() {
 	load_lib
 	test_recent_marker_blocks_dispatch
+	test_same_runner_marker_allows_resume
+	test_same_runner_skip_gate_proceeds
+	test_dirty_worktree_reuse_preserves_edits
 	test_later_resolution_clears_marker
 	test_expired_marker_does_not_block
 

--- a/.agents/scripts/tests/test-worker-exit-classifier.sh
+++ b/.agents/scripts/tests/test-worker-exit-classifier.sh
@@ -328,6 +328,8 @@ test_no_start_time_with_sessions() {
 }
 
 test_exit_push_preserves_dirty_worktree() {
+	# Bypass the production canonical-repository guard for this disposable fixture.
+	git() { /usr/bin/git "$@"; }
 	local case_dir="${TMPDIR_TEST}/dirty-preserve"
 	local origin_dir="${case_dir}/origin.git"
 	local repo_dir="${case_dir}/repo"
@@ -344,6 +346,8 @@ test_exit_push_preserves_dirty_worktree() {
 	git -C "$repo_dir" push -u origin main >/dev/null 2>&1
 	git -C "$repo_dir" checkout -b feature/dirty-preserve >/dev/null 2>&1
 	printf 'base\nchanged\n' >"${repo_dir}/tracked.txt"
+	git -C "$repo_dir" add tracked.txt >/dev/null 2>&1
+	printf 'changed after staging\n' >>"${repo_dir}/tracked.txt"
 	printf 'new\n' >"${repo_dir}/new-file.txt"
 
 	_WORKER_WORKTREE_PATH="$repo_dir"
@@ -357,12 +361,15 @@ test_exit_push_preserves_dirty_worktree() {
 	status=$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)
 	local pushed_count=""
 	pushed_count=$(git -C "$repo_dir" rev-list --count origin/main..origin/feature/dirty-preserve 2>/dev/null || printf '0')
-	if [[ "$preserved" == "1" && -z "$status" && "$pushed_count" == "1" ]]; then
-		print_result "exit push preserves dirty tracked and untracked work" 0
+	local tracked_content=""
+	tracked_content=$(git -C "$repo_dir" show "origin/feature/dirty-preserve:tracked.txt" 2>/dev/null || true)
+	if [[ "$preserved" == "1" && -z "$status" && "$pushed_count" == "1" && "$tracked_content" == *"changed after staging"* ]]; then
+		print_result "exit push preserves staged, unstaged, and untracked work" 0
 	else
-		print_result "exit push preserves dirty tracked and untracked work" 1 \
-			"preserved=${preserved} status='${status}' pushed_count=${pushed_count}"
+		print_result "exit push preserves staged, unstaged, and untracked work" 1 \
+			"preserved=${preserved} status='${status}' pushed_count=${pushed_count} tracked='${tracked_content}'"
 	fi
+	unset -f git
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Persist runner-local dirty recovery metadata, checkpoint dirty exits into draft PRs, resume preserved worktrees on the owning runner, and bound cross-runner takeover with idempotent audit markers.

## Files Changed

.agents/scripts/dispatch-ledger-helper.sh, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/shared-claim-lifecycle.sh, .agents/scripts/shared-runner-identity.sh, .agents/scripts/tests/test-dispatch-ledger-helper.sh, .agents/scripts/tests/test-orphan-recovery-pr-base.sh, .agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh, .agents/scripts/tests/test-worker-exit-classifier.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** linters-local.sh; ShellCheck on 12 changed scripts; 16 worker exit tests; 7 dirty-marker/resume tests; 24 dispatch-ledger tests; 5 orphan recovery tests; 9 worker output classification tests; runtime-events CLI test.

Resolves #27138


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.30 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1h 4m and 614,098 tokens on this as a headless worker.