### PR TITLE
t18097: Enforce evidence-backed full-loop lifecycle

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -40,6 +40,55 @@ fi
 #
 # Usage: full-loop-helper.sh pre-merge-gate <PR_NUMBER> [REPO]
 # Exit codes: 0 = safe to merge, 1 = gate failed (do NOT merge)
+_full_loop_verify_pr_readiness() {
+	local pr_number="$1"
+	local repo="$2"
+	local pr_json=""
+
+	pr_json=$(gh pr view "$pr_number" --repo "$repo" \
+		--json state,isDraft,reviewDecision,statusCheckRollup,headRefOid,headRefName 2>/dev/null) || {
+		print_error "Cannot read PR #${pr_number} readiness evidence"
+		return 1
+	}
+
+	if ! printf '%s' "$pr_json" | jq -e '
+		def up(v): (v // "" | ascii_upcase);
+		def passish:
+			(up(.conclusion) == "SUCCESS") or
+			(up(.conclusion) == "NEUTRAL") or
+			(up(.conclusion) == "SKIPPED") or
+			(up(.state) == "SUCCESS");
+		(.state == "OPEN")
+		and (.isDraft != true)
+		and (up(.reviewDecision) != "CHANGES_REQUESTED")
+		and ((.headRefOid // "") != "")
+		and ([.statusCheckRollup[]? | select(passish | not)] | length) == 0
+	' >/dev/null; then
+		print_error "PR #${pr_number} is not remotely verified: require OPEN, non-draft, no changes requested, and terminal-success checks"
+		return 1
+	fi
+
+	local verified_head=""
+	verified_head=$(printf '%s' "$pr_json" | jq -r '.headRefOid // empty')
+	local pr_head_ref=""
+	pr_head_ref=$(printf '%s' "$pr_json" | jq -r '.headRefName // empty')
+	local local_branch=""
+	local_branch=$(git branch --show-current 2>/dev/null || true)
+	if [[ -n "$local_branch" && "$local_branch" == "$pr_head_ref" ]]; then
+		local local_head=""
+		local_head=$(git rev-parse HEAD 2>/dev/null || true)
+		if [[ -z "$local_head" || "$local_head" != "$verified_head" ]]; then
+			print_error "PR #${pr_number} head drifted from the current worktree; push or refresh review evidence before merge"
+			return 1
+		fi
+	fi
+
+	FULL_LOOP_VERIFIED_PR_HEAD_SHA="$verified_head"
+	export FULL_LOOP_VERIFIED_PR_HEAD_SHA
+	print_success "Remote PR evidence verified at head ${verified_head}"
+	return 0
+}
+
 cmd_pre_merge_gate() {
 	local pr_number="${1:-}"
 	local repo="${2:-}"
@@ -58,6 +107,8 @@ cmd_pre_merge_gate() {
 		fi
 	fi
 
+	_full_loop_verify_pr_readiness "$pr_number" "$repo" || return 1
+
 	local rbg_helper="${SCRIPT_DIR}/review-bot-gate-helper.sh"
 	if [[ ! -f "$rbg_helper" ]]; then
 		# Fallback to deployed location
@@ -65,8 +116,8 @@ cmd_pre_merge_gate() {
 	fi
 
 	if [[ ! -f "$rbg_helper" ]]; then
-		print_warning "review-bot-gate-helper.sh not found — skipping gate (degraded mode)"
-		return 0
+		print_error "review-bot-gate-helper.sh not found — refusing an unreviewed merge"
+		return 1
 	fi
 
 	print_info "Running review bot gate for PR #${pr_number} in ${repo}..."

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -46,25 +46,31 @@ _full_loop_verify_pr_readiness() {
 	local pr_json=""
 
 	pr_json=$(gh pr view "$pr_number" --repo "$repo" \
-		--json state,isDraft,reviewDecision,statusCheckRollup,headRefOid,headRefName 2>/dev/null) || {
+		--json state,isDraft,reviewDecision,headRefOid,headRefName 2>/dev/null) || {
 		print_error "Cannot read PR #${pr_number} readiness evidence"
 		return 1
 	}
 
 	if ! printf '%s' "$pr_json" | jq -e '
 		def up(v): (v // "" | ascii_upcase);
-		def passish:
-			(up(.conclusion) == "SUCCESS") or
-			(up(.conclusion) == "NEUTRAL") or
-			(up(.conclusion) == "SKIPPED") or
-			(up(.state) == "SUCCESS");
 		(.state == "OPEN")
 		and (.isDraft != true)
 		and (up(.reviewDecision) != "CHANGES_REQUESTED")
 		and ((.headRefOid // "") != "")
-		and ([.statusCheckRollup[]? | select(passish | not)] | length) == 0
 	' >/dev/null; then
-		print_error "PR #${pr_number} is not remotely verified: require OPEN, non-draft, no changes requested, and terminal-success checks"
+		print_error "PR #${pr_number} is not remotely verified: require OPEN, non-draft, no changes requested, and a stable head"
+		return 1
+	fi
+
+	local required_checks=""
+	local required_rc=0
+	required_checks=$(gh pr checks "$pr_number" --repo "$repo" \
+		--required --json name,state,bucket 2>/dev/null) || required_rc=$?
+	if [[ -z "$required_checks" ]] || ! printf '%s' "$required_checks" | jq -e '
+		(type == "array")
+		and ([.[] | select((.bucket // "") != "pass")] | length) == 0
+	' >/dev/null; then
+		print_error "PR #${pr_number} required checks are not terminal-success (gh exit ${required_rc})"
 		return 1
 	fi
 
@@ -85,7 +91,7 @@ _full_loop_verify_pr_readiness() {
 
 	FULL_LOOP_VERIFIED_PR_HEAD_SHA="$verified_head"
 	export FULL_LOOP_VERIFIED_PR_HEAD_SHA
-	print_success "Remote PR evidence verified at head ${verified_head}"
+	print_success "Remote PR evidence verified at head ${verified_head}; required checks are terminal-success"
 	return 0
 }
 

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -577,21 +577,22 @@ _merge_refresh_canonical_for_cleanup() {
 	local default_branch="$2"
 	[[ -d "$canonical_dir" && -n "$default_branch" ]] || return 1
 
+	if ! git fetch --quiet origin "$default_branch" >/dev/null 2>&1; then
+		print_warning "CANONICAL_SYNC_PENDING=true reason=origin_fetch_failed"
+		return 1
+	fi
 	local current_canonical_branch=""
 	current_canonical_branch=$(git -C "$canonical_dir" branch --show-current 2>/dev/null || true)
-
-	# Pull only when the canonical worktree is already on the default branch. If a
-	# user has another active branch checked out there, update the local default
-	# branch ref via fetch instead so cleanup never merges default into that branch.
-	if [[ "$current_canonical_branch" == "$default_branch" ]]; then
-		if git -C "$canonical_dir" pull --ff-only origin "$default_branch" >/dev/null 2>&1; then
-			return 0
-		fi
-	elif git -C "$canonical_dir" fetch origin "$default_branch:$default_branch" >/dev/null 2>&1; then
+	local canonical_head=""
+	canonical_head=$(git -C "$canonical_dir" rev-parse HEAD 2>/dev/null || true)
+	local remote_head=""
+	remote_head=$(git rev-parse "origin/${default_branch}" 2>/dev/null || true)
+	if [[ "$current_canonical_branch" == "$default_branch" && -n "$remote_head" && "$canonical_head" == "$remote_head" ]]; then
+		print_success "LIFECYCLE_STATE=CANONICAL_SYNCED sha=${remote_head}"
 		return 0
 	fi
-	print_warning "Post-merge worktree cleanup: canonical pull/fetch skipped/failed for ${canonical_dir}; continuing cleanup"
-	return 0
+	print_warning "CANONICAL_SYNC_PENDING=true canonical=${canonical_dir} branch=${current_canonical_branch:-detached}"
+	return 1
 }
 
 _merge_resolve_worktree_helper() {
@@ -632,7 +633,7 @@ _merge_cleanup_linked_worktree() {
 	print_info "Post-merge worktree cleanup: removing linked worktree ${worktree_path} for ${branch_name} in ${repo}"
 	local default_branch=""
 	default_branch=$(_merge_default_branch_for_cleanup "$canonical_dir")
-	_merge_refresh_canonical_for_cleanup "$canonical_dir" "$default_branch"
+	_merge_refresh_canonical_for_cleanup "$canonical_dir" "$default_branch" || true
 
 	if ! cd "$canonical_dir" 2>/dev/null; then
 		print_warning "Post-merge worktree cleanup: could not cd to canonical repo ${canonical_dir}"

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -452,9 +452,10 @@ _merge_verify_completed_state() {
 		--json state,mergedAt,mergeCommit 2>/dev/null) || return 1
 
 	if ! printf '%s' "$pr_json" | jq -e '
+		def present: ((. // "") | length > 0);
 		(.state == "MERGED")
-		and ((.mergedAt // "") != "")
-		and ((.mergeCommit.oid // "") != "")
+		and (.mergedAt | present)
+		and (.mergeCommit.oid | present)
 	' >/dev/null; then
 		return 1
 	fi

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -806,6 +806,9 @@ cmd_merge() {
 		return 1
 	fi
 	print_success "LIFECYCLE_STATE=MERGED merge_sha=${FULL_LOOP_MERGE_SHA}"
+	if declare -F is_loop_active >/dev/null 2>&1 && is_loop_active && load_state; then
+		save_state "postflight" "$SAVED_PROMPT" "$pr_number" "$STARTED_AT"
+	fi
 	_merge_finalize_post_merge "$pr_number" "$repo" "$has_auto" "$_cleanup_plan"
 
 	return 0

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -364,11 +364,13 @@ _merge_execute() {
 	print_info "Merging PR #${pr_number} in ${repo} (${merge_desc})..."
 
 	local pre_merge_head_sha=""
-	if [[ "$has_auto" -eq 0 ]]; then
-		pre_merge_head_sha=$(_merge_fetch_head_sha_rest "$pr_number" "$repo" || true)
-		if [[ -z "$pre_merge_head_sha" ]]; then
-			print_warning "Could not verify PR head SHA before merge; REST rate-limit fallback will be unavailable"
-		fi
+	pre_merge_head_sha=$(_merge_fetch_head_sha_rest "$pr_number" "$repo" || true)
+	if [[ -n "${FULL_LOOP_VERIFIED_PR_HEAD_SHA:-}" && "$pre_merge_head_sha" != "$FULL_LOOP_VERIFIED_PR_HEAD_SHA" ]]; then
+		print_error "PR #${pr_number} head changed after remote verification; refusing merge"
+		return 1
+	fi
+	if [[ -z "$pre_merge_head_sha" && "$has_auto" -eq 0 ]]; then
+		print_warning "Could not verify PR head SHA before merge; REST rate-limit fallback will be unavailable"
 	fi
 
 	# Capture output AND exit code under set -e. A bare assignment `out=$(cmd)`
@@ -439,6 +441,26 @@ ${_merge_retry_out}"
 	else
 		print_success "PR #${pr_number} merged successfully"
 	fi
+	return 0
+}
+
+_merge_verify_completed_state() {
+	local pr_number="$1"
+	local repo="$2"
+	local pr_json=""
+	pr_json=$(gh pr view "$pr_number" --repo "$repo" \
+		--json state,mergedAt,mergeCommit 2>/dev/null) || return 1
+
+	if ! printf '%s' "$pr_json" | jq -e '
+		(.state == "MERGED")
+		and ((.mergedAt // "") != "")
+		and ((.mergeCommit.oid // "") != "")
+	' >/dev/null; then
+		return 1
+	fi
+
+	FULL_LOOP_MERGE_SHA=$(printf '%s' "$pr_json" | jq -r '.mergeCommit.oid')
+	export FULL_LOOP_MERGE_SHA
 	return 0
 }
 
@@ -773,6 +795,16 @@ cmd_merge() {
 	_retarget_stacked_children_interactive "$pr_number" "$repo"
 
 	_merge_execute "$pr_number" "$repo" "$merge_method" "$has_admin" "$has_auto" || return 1
+	if ! _merge_verify_completed_state "$pr_number" "$repo"; then
+		if [[ "$has_auto" -eq 1 ]]; then
+			print_info "LIFECYCLE_STATE=REMOTE_VERIFIED"
+			print_info "AUTO_MERGE_QUEUED=true"
+			return 0
+		fi
+		print_error "Merge command returned success, but GitHub has not reported PR #${pr_number} as MERGED with a merge SHA"
+		return 1
+	fi
+	print_success "LIFECYCLE_STATE=MERGED merge_sha=${FULL_LOOP_MERGE_SHA}"
 	_merge_finalize_post_merge "$pr_number" "$repo" "$has_auto" "$_cleanup_plan"
 
 	return 0

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -596,6 +596,21 @@ _merge_refresh_canonical_for_cleanup() {
 	return 1
 }
 
+_merge_report_canonical_sync_state() {
+	local cleanup_plan="$1"
+	if [[ -z "$cleanup_plan" ]]; then
+		print_warning "CANONICAL_SYNC_PENDING=true reason=canonical_path_unavailable"
+		return 1
+	fi
+	local worktree_path branch_name canonical_dir
+	IFS=$'\t' read -r worktree_path branch_name canonical_dir <<<"$cleanup_plan"
+	: "$worktree_path" "$branch_name"
+	local default_branch
+	default_branch=$(_merge_default_branch_for_cleanup "$canonical_dir")
+	_merge_refresh_canonical_for_cleanup "$canonical_dir" "$default_branch"
+	return $?
+}
+
 _merge_resolve_worktree_helper() {
 	if [[ -x "${SCRIPT_DIR}/worktree-helper.sh" ]]; then
 		printf '%s\n' "${SCRIPT_DIR}/worktree-helper.sh"
@@ -807,6 +822,7 @@ cmd_merge() {
 		return 1
 	fi
 	print_success "LIFECYCLE_STATE=MERGED merge_sha=${FULL_LOOP_MERGE_SHA}"
+	_merge_report_canonical_sync_state "$_cleanup_plan" || true
 	if declare -F is_loop_active >/dev/null 2>&1 && is_loop_active && load_state; then
 		save_state "postflight" "$SAVED_PROMPT" "$pr_number" "$STARTED_AT"
 	fi

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -624,11 +624,91 @@ cmd_logs() {
 }
 
 cmd_complete() {
-	load_state 2>/dev/null || true
+	load_state 2>/dev/null || {
+		print_error "Cannot complete full loop without persisted lifecycle state"
+		return 1
+	}
+	if [[ ! "${PR_NUMBER:-}" =~ ^[0-9]+$ ]]; then
+		print_error "Cannot complete full loop without a verified PR number"
+		return 1
+	fi
+	local current_root=""
+	current_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+	print_warning "LIFECYCLE_STATE=DEPLOYED cleanup remains pending for ${current_root:-unknown-worktree}"
+	print_info "After guarded cleanup, run: full-loop-helper.sh complete-after-cleanup ${PR_NUMBER} '${current_root}'"
+	return 1
+}
+
+_full_loop_resolve_repo() {
+	local repo_arg="${1:-}"
+	if [[ -n "$repo_arg" ]]; then
+		printf '%s\n' "$repo_arg"
+		return 0
+	fi
+	repo_arg=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)
+	[[ -n "$repo_arg" ]] || return 1
+	printf '%s\n' "$repo_arg"
+	return 0
+}
+
+_full_loop_verify_merged_pr() {
+	local pr_number="$1"
+	local repo="$2"
+	local pr_json=""
+	pr_json=$(gh pr view "$pr_number" --repo "$repo" --json state,mergedAt,mergeCommit 2>/dev/null) || return 1
+	printf '%s' "$pr_json" | jq -e '
+		(.state == "MERGED")
+		and ((.mergedAt // "") != "")
+		and ((.mergeCommit.oid // "") != "")
+	' >/dev/null
+	return $?
+}
+
+_full_loop_verify_aidevops_release_deploy() {
+	local repo="$1"
+	[[ "$repo" == "marcusquinn/aidevops" ]] || return 0
+	local repo_root=""
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+	local version=""
+	[[ -n "$repo_root" && -f "${repo_root}/VERSION" ]] && IFS= read -r version <"${repo_root}/VERSION"
+	[[ -n "$version" ]] || return 1
+	git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>&1 || return 1
+	gh release view "v${version}" --repo "$repo" >/dev/null 2>&1 || return 1
+	local deployed_version=""
+	[[ -f "${HOME}/.aidevops/agents/VERSION" ]] && IFS= read -r deployed_version <"${HOME}/.aidevops/agents/VERSION"
+	[[ "$deployed_version" == "$version" ]] || return 1
+	local postflight="${SCRIPT_DIR}/postflight-check.sh"
+	[[ -x "$postflight" ]] || return 1
+	bash "$postflight" --quick >/dev/null 2>&1 || return 1
+	return 0
+}
+
+cmd_complete_after_cleanup() {
+	local pr_number="${1:-}"
+	local removed_worktree="${2:-}"
+	local repo=""
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$removed_worktree" ]] || {
+		print_error "Usage: full-loop-helper.sh complete-after-cleanup <PR> <removed-worktree-path> [REPO]"
+		return 1
+	}
+	repo=$(_full_loop_resolve_repo "${3:-}") || {
+		print_error "Cannot resolve repository for completion evidence"
+		return 1
+	}
+	if [[ -e "$removed_worktree" ]] || git worktree list --porcelain 2>/dev/null | grep -Fq "worktree ${removed_worktree}"; then
+		print_error "LIFECYCLE_STATE=CLEANUP_PENDING worktree=${removed_worktree}"
+		return 1
+	fi
+	_full_loop_verify_merged_pr "$pr_number" "$repo" || {
+		print_error "Completion blocked: PR #${pr_number} lacks merged evidence"
+		return 1
+	}
+	_full_loop_verify_aidevops_release_deploy "$repo" || {
+		print_error "Completion blocked: release, deployment, or postflight evidence is missing"
+		return 1
+	}
 	printf "\n${BOLD}${GREEN}=== FULL DEVELOPMENT LOOP - COMPLETE ===${NC}\n"
-	printf "Task: done | Preflight: passed | PR: #%s | Postflight: healthy" "${PR_NUMBER:-unknown}"
-	is_aidevops_repo && printf " | Deploy: done"
-	printf "\n\n"
-	rm -f "$STATE_FILE"
+	printf "PR: #%s | Lifecycle: CLEANED\n\n" "$pr_number"
 	echo "<promise>FULL_LOOP_COMPLETE</promise>"
-} # nice — entire dev lifecycle in one pass
+	return 0
+}

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -683,6 +683,14 @@ _full_loop_verify_aidevops_release_deploy() {
 	return 0
 }
 
+_full_loop_verify_cleanup_audit() {
+	local removed_worktree="$1"
+	local cleanup_log="${AIDEVOPS_CLEANUP_LOG:-${HOME}/.aidevops/logs/cleanup_worktrees.log}"
+	[[ -f "$cleanup_log" ]] || return 1
+	grep -Fq "worktree-removed: ${removed_worktree} —" "$cleanup_log"
+	return $?
+}
+
 cmd_complete_after_cleanup() {
 	local pr_number="${1:-}"
 	local removed_worktree="${2:-}"
@@ -699,6 +707,10 @@ cmd_complete_after_cleanup() {
 		print_error "LIFECYCLE_STATE=CLEANUP_PENDING worktree=${removed_worktree}"
 		return 1
 	fi
+	_full_loop_verify_cleanup_audit "$removed_worktree" || {
+		print_error "Completion blocked: no removal audit evidence for ${removed_worktree}"
+		return 1
+	}
 	_full_loop_verify_merged_pr "$pr_number" "$repo" || {
 		print_error "Completion blocked: PR #${pr_number} lacks merged evidence"
 		return 1

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -182,6 +182,9 @@ Worker aborted PR creation: issue #${issue_number} was already closed by the tim
 	_post_merge_summary "$pr_number" "$repo" "$issue_number" "$summary_what" "$files_changed" "$summary_testing" "$summary_decisions"
 	_label_issue_in_review "$issue_number" "$repo"
 	_label_pr_in_review "$pr_number" "$repo"
+	if is_loop_active && load_state; then
+		save_state "pr-review" "$SAVED_PROMPT" "$pr_number" "$STARTED_AT"
+	fi
 
 	# Output PR number for caller to pass to `merge`
 	printf '%s\n' "$pr_number"
@@ -211,7 +214,9 @@ Commands:
                                 for branch-protected personal-account repos (GH#18731).
                                 --admin and --auto are mutually exclusive at the
                                 gh CLI level; if both are given, --admin wins and
-                                --auto is dropped (GH#19310).
+                                 --auto is dropped (GH#19310).
+  complete-after-cleanup <PR> <removed-worktree-path> [REPO]
+                                 Verify merged, released/deployed, and cleaned evidence.
   help                          Show this help
 Options: --max-task-iterations N (50) | --max-preflight-iterations N (5)
   --max-pr-iterations N (20) | --skip-preflight | --skip-postflight
@@ -241,6 +246,7 @@ main() {
 	commit-and-pr | create-pr) cmd_commit_and_pr "$@" ;;
 	pre-merge-gate) cmd_pre_merge_gate "$@" ;;
 	merge) cmd_merge "$@" ;;
+	complete-after-cleanup) cmd_complete_after_cleanup "$@" ;;
 	help | --help | -h) show_help ;;
 	*)
 		print_error "Unknown command: $command"

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -53,21 +53,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 [[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # =============================================================================
-# Fast-path for headless workers with pre-created worktrees
-# =============================================================================
-# When the dispatcher pre-creates a worktree and passes WORKER_WORKTREE_PATH,
-# the worker is already in a safe linked worktree. Skip all detection logic.
-if [[ -n "${WORKER_WORKTREE_PATH:-}" && -d "${WORKER_WORKTREE_PATH:-}" ]]; then
-	# Verify we're actually in the worktree (or the worker's --dir points here)
-	_current_dir="$(pwd -P 2>/dev/null || pwd)"
-	_wt_real="$(cd "$WORKER_WORKTREE_PATH" 2>/dev/null && pwd -P)"
-	if [[ "$_current_dir" == "$_wt_real"* ]]; then
-		echo "OK - Pre-created worktree: ${WORKER_WORKTREE_BRANCH:-unknown branch}"
-		exit 0
-	fi
-fi
-
-# =============================================================================
 # Loop Mode Support
 # =============================================================================
 # When --loop-mode is passed, the script auto-decides based on file path or task description:
@@ -530,7 +515,7 @@ _handle_loop_mode_on_protected() {
 
 	# Derive branch name from --task description or fall back to generic
 	local _wt_branch_name=""
-	local _wt_task_desc="${TASK_DESCRIPTION:-}"
+	local _wt_task_desc="${TASK_DESC:-}"
 	if [[ -n "$_wt_task_desc" ]]; then
 		# Extract issue number if present (e.g., "Implement issue #17642")
 		local _wt_issue_num=""

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -481,10 +481,17 @@ run_operation_verification() {
 
 # Handle loop-mode decision on a protected (main/master) branch.
 # Outputs LOOP_DECISION and exits 0 (stay) or 2 (worktree needed).
+_is_explicit_headless_flow() {
+	case "${FULL_LOOP_HEADLESS:-}${AIDEVOPS_HEADLESS:-}${OPENCODE_HEADLESS:-}${CLAUDE_HEADLESS:-}${Claude_HEADLESS:-}${GITHUB_ACTIONS:-}" in
+	*true* | *1*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
 _handle_loop_mode_on_protected() {
 	local branch="$1"
 
-	if is_main_write_allowed; then
+	if _is_explicit_headless_flow && is_main_write_allowed; then
 		if [[ -n "$TARGET_FILE" ]]; then
 			echo -e "${YELLOW}LOOP-AUTO${NC}: Allowlisted path '$TARGET_FILE', staying on $branch"
 		else
@@ -716,9 +723,9 @@ if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
 	# Loop mode: auto-decide based on file path (preferred) or task description
 	[[ "$LOOP_MODE" == "true" ]] && _handle_loop_mode_on_protected "$current_branch"
 
-	# Short-circuit: explicit --file on an allowlisted path is always allowed,
-	# regardless of loop-mode or headless state (t1712).
-	if [[ -n "$TARGET_FILE" ]] && is_main_allowlisted_path "$TARGET_FILE"; then
+	# Short-circuit only for explicitly identified headless bookkeeping flows.
+	# Interactive sessions never gain a canonical write exemption (t1712).
+	if _is_explicit_headless_flow && [[ -n "$TARGET_FILE" ]] && is_main_allowlisted_path "$TARGET_FILE"; then
 		echo -e "${GREEN}OK${NC} - Allowlisted path '$TARGET_FILE' on $current_branch"
 		echo "MAIN_ALLOWLISTED=true"
 		exit 0

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -32,12 +32,11 @@ DEFAULT_MAX_TASK_ITERATIONS=50
 DEFAULT_MAX_PREFLIGHT_ITERATIONS=5
 DEFAULT_MAX_PR_ITERATIONS=20
 HEADLESS=false
-BOLD=''
-GREEN=''
-NC=''
 print_error() { return 0; }
 print_info() { return 0; }
 print_warning() { return 0; }
+source '${SCRIPTS_DIR}/shared-constants.sh'
+[[ -z "\${BOLD+x}" ]] && BOLD=''
 source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
 cmd_complete_after_cleanup "\$@"
 RUNNER

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -44,24 +44,32 @@ RUNNER
 chmod +x "$runner"
 
 removed_path="${ROOT}/removed-worktree"
-PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null || {
+cleanup_log="${ROOT}/cleanup.log"
+printf '[2026-07-11T00:00:01Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' "$removed_path" >"$cleanup_log"
+AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null || {
 	printf 'FAIL complete merged and cleaned evidence was rejected\n'
 	exit 1
 }
 printf 'PASS merged and cleaned evidence completes lifecycle\n'
 
 mkdir -p "$removed_path"
-if PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
+if AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
 	printf 'FAIL existing worktree was accepted as cleaned\n'
 	exit 1
 fi
 printf 'PASS existing worktree keeps cleanup pending\n'
 rm -rf "$removed_path"
 
-if COMPLETION_PR_STATE=OPEN PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
+if COMPLETION_PR_STATE=OPEN AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
 	printf 'FAIL open PR was accepted as complete\n'
 	exit 1
 fi
 printf 'PASS open PR blocks lifecycle completion\n'
+
+if AIDEVOPS_CLEANUP_LOG="${ROOT}/missing.log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
+	printf 'FAIL absent cleanup audit was accepted as complete\n'
+	exit 1
+fi
+printf 'PASS absent cleanup audit blocks lifecycle completion\n'
 
 exit 0

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+mkdir -p "${ROOT}/bin"
+
+cat >"${ROOT}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${COMPLETION_PR_STATE:-MERGED}" == "MERGED" ]]; then
+	printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","mergeCommit":{"oid":"merge123"}}'
+else
+	printf '%s\n' '{"state":"OPEN","mergedAt":null,"mergeCommit":null}'
+fi
+exit 0
+STUB
+chmod +x "${ROOT}/bin/gh"
+
+runner="${ROOT}/runner.sh"
+cat >"$runner" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${SCRIPTS_DIR}'
+STATE_DIR='${ROOT}/state'
+STATE_FILE='${ROOT}/state/full-loop.state'
+DEFAULT_MAX_TASK_ITERATIONS=50
+DEFAULT_MAX_PREFLIGHT_ITERATIONS=5
+DEFAULT_MAX_PR_ITERATIONS=20
+HEADLESS=false
+BOLD=''
+GREEN=''
+NC=''
+print_error() { return 0; }
+print_info() { return 0; }
+print_warning() { return 0; }
+source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
+cmd_complete_after_cleanup "\$@"
+RUNNER
+chmod +x "$runner"
+
+removed_path="${ROOT}/removed-worktree"
+PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null || {
+	printf 'FAIL complete merged and cleaned evidence was rejected\n'
+	exit 1
+}
+printf 'PASS merged and cleaned evidence completes lifecycle\n'
+
+mkdir -p "$removed_path"
+if PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
+	printf 'FAIL existing worktree was accepted as cleaned\n'
+	exit 1
+fi
+printf 'PASS existing worktree keeps cleanup pending\n'
+rm -rf "$removed_path"
+
+if COMPLETION_PR_STATE=OPEN PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
+	printf 'FAIL open PR was accepted as complete\n'
+	exit 1
+fi
+printf 'PASS open PR blocks lifecycle completion\n'
+
+exit 0

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -38,6 +38,10 @@ gh() {
 	local subcommand="${2:-}"
 	local args="$*"
 	if [[ "$command" == "pr" && "$subcommand" == "view" ]]; then
+		if [[ "$args" == *"state,mergedAt,mergeCommit"* ]]; then
+			printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","mergeCommit":{"oid":"merge123"}}'
+			return 0
+		fi
 		if [[ "$args" == *"headRefName"* ]]; then
 			printf '%s\n' "feature/full-loop-cleanup"
 			return 0
@@ -251,7 +255,7 @@ test_cmd_merge_defers_cleanup_for_live_process_cwd() {
 	return 0
 }
 
-test_refresh_canonical_pulls_when_default_checked_out() {
+test_refresh_canonical_reports_pending_without_mutation() {
 	local canonical_repo="${TEST_ROOT}/repo-default"
 	local origin_repo="${TEST_ROOT}/origin-default.git"
 	local updater_repo="${TEST_ROOT}/updater-default"
@@ -273,22 +277,26 @@ test_refresh_canonical_pulls_when_default_checked_out() {
 	git -C "$updater_repo" commit -q -m 'advance main'
 	git -C "$updater_repo" push -q origin main
 
-	_merge_refresh_canonical_for_cleanup "$canonical_repo" "main"
+	local output=""
+	local refresh_rc=0
+	output=$(_merge_refresh_canonical_for_cleanup "$canonical_repo" "main" 2>&1) || refresh_rc=$?
 
 	local rc=0
+	[[ "$refresh_rc" -ne 0 ]] || rc=1
+	[[ "$output" == *"CANONICAL_SYNC_PENDING=true"* ]] || rc=1
 	if [[ "$(git -C "$canonical_repo" branch --show-current)" != "main" ]]; then
 		rc=1
 	fi
-	if [[ "$(git -C "$canonical_repo" rev-parse main)" != "$(git -C "$updater_repo" rev-parse main)" ]]; then
+	if [[ "$(git -C "$canonical_repo" rev-parse main)" == "$(git -C "$updater_repo" rev-parse main)" ]]; then
 		rc=1
 	fi
-	print_result "refresh canonical pulls when default branch checked out" "$rc"
+	print_result "canonical drift is explicit pending without unaudited mutation" "$rc"
 	return 0
 }
 
 main() {
 	setup_subject
-	test_refresh_canonical_pulls_when_default_checked_out
+	test_refresh_canonical_reports_pending_without_mutation
 	test_cmd_merge_defers_current_linked_worktree
 	test_cmd_merge_defers_cleanup_for_live_process_cwd
 	printf '\n%d/%d tests passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -144,6 +144,10 @@ write_gh_stub_pr_issue_views() {
 	cat >>"${TEST_ROOT}/bin/gh" <<GHSTUB
 
 	if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "view" ]]; then
+	if [[ "\$*" == *"--json state,mergedAt,mergeCommit"* ]]; then
+		echo '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","mergeCommit":{"oid":"merged123sha"}}'
+		exit 0
+	fi
 	if [[ "\$*" == *"--json isDraft,reviewDecision,statusCheckRollup"* ]]; then
 		if [[ "$mode" == "auto-review-required" ]]; then
 			echo '{"isDraft":false,"reviewDecision":"","statusCheckRollup":[{"name":"ci","conclusion":"SUCCESS","status":"COMPLETED"}]}'
@@ -516,7 +520,10 @@ test_graphql_rate_limit_auto_no_rest_fallback() {
 	print_result "GraphQL rate-limit with --auto: merge fails without immediate REST merge" "$((exit_code == 0 ? 1 : 0))"
 
 	local rest_called=0
-	[[ -f "${TEST_ROOT}/logs/gh-api-calls.txt" ]] && rest_called=1
+	if [[ -f "${TEST_ROOT}/logs/gh-api-calls.txt" ]] &&
+		grep -q "repos/testorg/testrepo/pulls/42/merge" "${TEST_ROOT}/logs/gh-api-calls.txt"; then
+		rest_called=1
+	fi
 	print_result "GraphQL rate-limit with --auto: REST fallback not called" "$rest_called"
 
 	return 0

--- a/.agents/scripts/tests/test-full-loop-remote-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-remote-evidence.sh
@@ -19,9 +19,17 @@ chmod +x "${ROOT}/helpers/review-bot-gate-helper.sh"
 
 cat >"${ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "pr" && "${2:-}" == "checks" ]]; then
+	if [[ "${GH_TEST_MODE:-pass}" == "pending" ]]; then
+		printf '%s\n' '[{"name":"required-ci","state":"IN_PROGRESS","bucket":"pending"}]'
+		exit 1
+	fi
+	printf '%s\n' '[{"name":"required-ci","state":"SUCCESS","bucket":"pass"}]'
+	exit 0
+fi
 case "${GH_TEST_MODE:-pass}" in
 	draft) printf '%s\n' '{"state":"OPEN","isDraft":true,"reviewDecision":"","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[]}' ;;
-	pending) printf '%s\n' '{"state":"OPEN","isDraft":false,"reviewDecision":"","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[{"status":"IN_PROGRESS","conclusion":""}]}' ;;
+	optional-cancelled) printf '%s\n' '{"state":"OPEN","isDraft":false,"reviewDecision":"APPROVED","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[{"name":"old-optional","status":"COMPLETED","conclusion":"CANCELLED"}]}' ;;
 	changes) printf '%s\n' '{"state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[]}' ;;
 	closed) printf '%s\n' '{"state":"CLOSED","isDraft":false,"reviewDecision":"","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[]}' ;;
 	*) printf '%s\n' '{"state":"OPEN","isDraft":false,"reviewDecision":"APPROVED","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}' ;;
@@ -51,6 +59,9 @@ RUNNER
 
 run_gate pass || { printf 'FAIL terminal remote evidence was rejected\n'; exit 1; }
 printf 'PASS terminal remote evidence is accepted\n'
+
+run_gate optional-cancelled || { printf 'FAIL cancelled optional history blocked passing required checks\n'; exit 1; }
+printf 'PASS cancelled optional history does not override passing required checks\n'
 
 for mode in draft pending changes closed; do
 	if run_gate "$mode"; then

--- a/.agents/scripts/tests/test-full-loop-remote-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-remote-evidence.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+mkdir -p "${ROOT}/bin" "${ROOT}/helpers"
+
+cat >"${ROOT}/helpers/review-bot-gate-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'PASS\n'
+exit 0
+STUB
+chmod +x "${ROOT}/helpers/review-bot-gate-helper.sh"
+
+cat >"${ROOT}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+case "${GH_TEST_MODE:-pass}" in
+	draft) printf '%s\n' '{"state":"OPEN","isDraft":true,"reviewDecision":"","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[]}' ;;
+	pending) printf '%s\n' '{"state":"OPEN","isDraft":false,"reviewDecision":"","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[{"status":"IN_PROGRESS","conclusion":""}]}' ;;
+	changes) printf '%s\n' '{"state":"OPEN","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[]}' ;;
+	closed) printf '%s\n' '{"state":"CLOSED","isDraft":false,"reviewDecision":"","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[]}' ;;
+	*) printf '%s\n' '{"state":"OPEN","isDraft":false,"reviewDecision":"APPROVED","headRefOid":"abc123","headRefName":"remote-branch","statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}' ;;
+esac
+exit 0
+STUB
+chmod +x "${ROOT}/bin/gh"
+
+run_gate() {
+	local mode="$1"
+	local runner="${ROOT}/runner-${mode}.sh"
+	cat >"$runner" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${ROOT}/helpers'
+print_error() { printf 'ERROR %s\n' "\$*"; return 0; }
+print_info() { return 0; }
+print_warning() { return 0; }
+print_success() { return 0; }
+source '${SCRIPTS_DIR}/full-loop-helper-commit.sh'
+cmd_pre_merge_gate 42 testorg/testrepo
+RUNNER
+	chmod +x "$runner"
+	GH_TEST_MODE="$mode" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" >/dev/null 2>&1
+	return $?
+}
+
+run_gate pass || { printf 'FAIL terminal remote evidence was rejected\n'; exit 1; }
+printf 'PASS terminal remote evidence is accepted\n'
+
+for mode in draft pending changes closed; do
+	if run_gate "$mode"; then
+		printf 'FAIL unsafe remote state was accepted: %s\n' "$mode"
+		exit 1
+	fi
+	printf 'PASS unsafe remote state is blocked: %s\n' "$mode"
+done
+
+exit 0

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -118,6 +118,21 @@ test_allows_linked_worktree_edits() {
 	return 0
 }
 
+test_worker_env_does_not_bypass_canonical_guard() {
+	local output=""
+	local exit_code=0
+	output=$(WORKER_WORKTREE_PATH="$TEST_ROOT" WORKER_WORKTREE_BRANCH="forged/worker" \
+		FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"HEADLESS_BLOCKED=true"* ]]; then
+		print_result "worker environment cannot bypass canonical worktree guard" 0
+		return 0
+	fi
+
+	print_result "worker environment cannot bypass canonical worktree guard" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
 test_warns_when_canonical_repo_is_off_main() {
 	git -C "$TEST_ROOT" switch -c bugfix/off-main >/dev/null 2>&1
 
@@ -304,6 +319,7 @@ main() {
 
 	test_blocks_headless_edits_on_main_with_worktree_guidance
 	test_allows_linked_worktree_edits
+	test_worker_env_does_not_bypass_canonical_guard
 	test_warns_when_canonical_repo_is_off_main
 	test_blocks_when_linked_worktree_owned_by_another_live_process
 	test_allows_same_opencode_session_pid_rollover

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -232,6 +232,21 @@ test_allowlisted_path_allows_edit_on_main() {
 	return 0
 }
 
+test_interactive_allowlisted_path_still_requires_worktree() {
+	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+	local output=""
+	local exit_code=0
+	output=$(run_helper "$TEST_ROOT" --file "README.md" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"ACTION_REQUIRED=create_worktree"* ]]; then
+		print_result "interactive allowlisted path still requires a linked worktree" 0
+		return 0
+	fi
+
+	print_result "interactive allowlisted path still requires a linked worktree" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
 test_path_traversal_blocked_on_main() {
 	# Ensure repo is on main for this test
 	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
@@ -324,6 +339,7 @@ main() {
 	test_blocks_when_linked_worktree_owned_by_another_live_process
 	test_allows_same_opencode_session_pid_rollover
 	test_allowlisted_path_allows_edit_on_main
+	test_interactive_allowlisted_path_still_requires_worktree
 	test_path_traversal_blocked_on_main
 	test_absolute_path_outside_repo_blocked_on_main
 	test_todo_subdir_path_allows_edit_on_main

--- a/.agents/scripts/tests/test-version-manager-release-provenance.sh
+++ b/.agents/scripts/tests/test-version-manager-release-provenance.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+REMOTE="${ROOT}/remote.git"
+REPO="${ROOT}/repo"
+LINKED="${ROOT}/release"
+BIN="${ROOT}/bin"
+mkdir -p "$BIN"
+
+git init -q --bare "$REMOTE"
+git clone -q "$REMOTE" "$REPO"
+git -C "$REPO" switch -q -c main
+git -C "$REPO" config user.name Test
+git -C "$REPO" config user.email test@example.invalid
+git -C "$REPO" commit -q --allow-empty -m seed
+git -C "$REPO" push -q -u origin main
+git -C "$REPO" remote set-head origin main
+MERGE_SHA=$(git -C "$REPO" rev-parse HEAD)
+git -C "$REPO" worktree add -q --detach "$LINKED" origin/main
+
+cat >"${BIN}/gh" <<STUB
+#!/usr/bin/env bash
+case "\${PROVENANCE_MODE:-merged}" in
+	open) printf '%s\n' '{"state":"OPEN","mergedAt":null,"baseRefName":"main","headRefOid":"head123","mergeCommit":null}' ;;
+	stale) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","baseRefName":"main","headRefOid":"head123","mergeCommit":{"oid":"0000000000000000000000000000000000000000"}}' ;;
+	*) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","baseRefName":"main","headRefOid":"head123","mergeCommit":{"oid":"${MERGE_SHA}"}}' ;;
+esac
+exit 0
+STUB
+chmod +x "${BIN}/gh"
+
+print_error() { return 0; }
+print_info() { return 0; }
+print_warning() { return 0; }
+print_success() { return 0; }
+export SCRIPT_DIR REPO_ROOT="$LINKED"
+source "${SCRIPT_DIR}/version-manager-git.sh"
+
+PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin" verify_release_source_pr 42 main testorg/aidevops || {
+	printf 'FAIL merged source PR provenance was rejected\n'
+	exit 1
+}
+printf 'PASS merged source PR provenance is accepted\n'
+
+if PROVENANCE_MODE=open PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin" verify_release_source_pr 42 main testorg/aidevops; then
+	printf 'FAIL open source PR was accepted\n'
+	exit 1
+fi
+printf 'PASS open source PR is rejected\n'
+
+if PROVENANCE_MODE=stale PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin" verify_release_source_pr 42 main testorg/aidevops; then
+	printf 'FAIL unreachable merge SHA was accepted\n'
+	exit 1
+fi
+printf 'PASS unreachable merge SHA is rejected\n'
+
+verify_canonical_default_synced main || {
+	printf 'FAIL synchronized canonical main was rejected\n'
+	exit 1
+}
+printf 'PASS synchronized canonical main is accepted\n'
+
+git -C "$REPO" switch -q -c safety/release-test
+if verify_canonical_default_synced main; then
+	printf 'FAIL off-main canonical worktree was accepted\n'
+	exit 1
+fi
+printf 'PASS off-main canonical worktree blocks release\n'
+
+exit 0

--- a/.agents/scripts/tests/test-worktree-fresh-base.sh
+++ b/.agents/scripts/tests/test-worktree-fresh-base.sh
@@ -50,4 +50,13 @@ if (cd "$CANONICAL" && "$HELPER" add test/fetch-failure >/dev/null 2>&1); then
 fi
 printf 'PASS worktree creation fails closed when origin/main cannot refresh\n'
 
+PINNED_SHA=$(git -C "$CANONICAL" rev-parse main)
+(cd "$CANONICAL" && "$HELPER" add test/pinned-base --base "$PINNED_SHA" >/dev/null)
+PINNED_PATH="${WORKTREES}/canonical-test-pinned-base"
+[[ "$(git -C "$PINNED_PATH" rev-parse HEAD)" == "$PINNED_SHA" ]] || {
+	printf 'FAIL immutable explicit base was not preserved\n'
+	exit 1
+}
+printf 'PASS immutable explicit base permits audited offline recovery\n'
+
 exit 0

--- a/.agents/scripts/tests/test-worktree-fresh-base.sh
+++ b/.agents/scripts/tests/test-worktree-fresh-base.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../worktree-helper.sh"
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+
+REMOTE="${ROOT}/remote.git"
+CANONICAL="${ROOT}/canonical"
+UPDATER="${ROOT}/updater"
+WORKTREES="${ROOT}/worktrees"
+HOME="${ROOT}/home"
+export HOME AIDEVOPS_WORKTREE_BASE_DIR="$WORKTREES"
+
+git init -q --bare "$REMOTE"
+git clone -q "$REMOTE" "$CANONICAL"
+git -C "$CANONICAL" switch -q -c main
+git -C "$CANONICAL" config user.name Test
+git -C "$CANONICAL" config user.email test@example.invalid
+git -C "$CANONICAL" commit -q --allow-empty -m seed
+git -C "$CANONICAL" push -q -u origin main
+git -C "$CANONICAL" remote set-head origin main
+
+git clone -q "$REMOTE" "$UPDATER"
+git -C "$UPDATER" switch -q main
+git -C "$UPDATER" config user.name Test
+git -C "$UPDATER" config user.email test@example.invalid
+printf 'remote tip\n' >"${UPDATER}/remote.txt"
+git -C "$UPDATER" add remote.txt
+git -C "$UPDATER" commit -q -m remote-tip
+git -C "$UPDATER" push -q origin main
+REMOTE_SHA=$(git -C "$UPDATER" rev-parse HEAD)
+
+(cd "$CANONICAL" && "$HELPER" add test/fresh-base >/dev/null)
+FRESH_PATH="${WORKTREES}/canonical-test-fresh-base"
+[[ "$(git -C "$FRESH_PATH" rev-parse HEAD)" == "$REMOTE_SHA" ]] || {
+	printf 'FAIL worktree did not start at freshly fetched origin/main\n'
+	exit 1
+}
+printf 'PASS worktree starts at freshly fetched origin/main\n'
+
+git -C "$CANONICAL" remote set-url origin "${ROOT}/missing.git"
+if (cd "$CANONICAL" && "$HELPER" add test/fetch-failure >/dev/null 2>&1); then
+	printf 'FAIL worktree creation accepted an unrefreshable remote base\n'
+	exit 1
+fi
+printf 'PASS worktree creation fails closed when origin/main cannot refresh\n'
+
+exit 0

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -102,6 +102,96 @@ verify_remote_sync() {
 	return 0
 }
 
+_release_repo_slug() {
+	local remote_url=""
+	remote_url=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
+	case "$remote_url" in
+	*github.com/*) remote_url="${remote_url#*github.com/}" ;;
+	*github.com:*) remote_url="${remote_url#*github.com:}" ;;
+	*) return 1 ;;
+	esac
+	printf '%s\n' "${remote_url%.git}"
+	return 0
+}
+
+release_source_pr_required() {
+	local repo_slug=""
+	repo_slug=$(_release_repo_slug 2>/dev/null || true)
+	if [[ "$repo_slug" == "marcusquinn/aidevops" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+verify_canonical_default_synced() {
+	local branch="${1:-main}"
+	local canonical_path=""
+	canonical_path=$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -1)
+	[[ -n "$canonical_path" && -d "$canonical_path" ]] || {
+		print_error "Cannot resolve canonical worktree for release"
+		return 1
+	}
+	local canonical_branch=""
+	canonical_branch=$(git -C "$canonical_path" branch --show-current 2>/dev/null || true)
+	local canonical_head=""
+	canonical_head=$(git -C "$canonical_path" rev-parse HEAD 2>/dev/null || true)
+	local remote_head=""
+	remote_head=$(git -C "$REPO_ROOT" rev-parse "origin/${branch}" 2>/dev/null || true)
+	if [[ "$canonical_branch" != "$branch" || -z "$canonical_head" || "$canonical_head" != "$remote_head" ]]; then
+		print_error "Canonical repository is not synchronized to origin/${branch}"
+		print_info "Run canonical-recovery-helper.sh with the linked issue, then recreate the detached release worktree"
+		return 1
+	fi
+	print_success "Canonical repository is synchronized to origin/${branch}"
+	return 0
+}
+
+verify_release_source_pr() {
+	local source_pr="$1"
+	local branch="${2:-main}"
+	local repo_slug="${3:-}"
+	[[ "$source_pr" =~ ^[0-9]+$ ]] || {
+		print_error "Release source PR must be a numeric GitHub pull request"
+		return 1
+	}
+	if [[ -z "$repo_slug" ]]; then
+		repo_slug=$(_release_repo_slug 2>/dev/null || true)
+	fi
+	[[ -n "$repo_slug" ]] || {
+		print_error "Cannot resolve GitHub repository for release provenance"
+		return 1
+	}
+
+	local pr_json=""
+	pr_json=$(gh pr view "$source_pr" --repo "$repo_slug" \
+		--json state,mergedAt,mergeCommit,baseRefName,headRefOid 2>/dev/null) || {
+		print_error "Cannot read source PR #${source_pr}"
+		return 1
+	}
+	if ! printf '%s' "$pr_json" | jq -e --arg branch "$branch" '
+		(.state == "MERGED")
+		and ((.mergedAt // "") != "")
+		and (.baseRefName == $branch)
+		and ((.headRefOid // "") != "")
+		and ((.mergeCommit.oid // "") != "")
+	' >/dev/null; then
+		print_error "Source PR #${source_pr} lacks verified MERGED provenance for ${branch}"
+		return 1
+	fi
+
+	local merge_sha=""
+	merge_sha=$(printf '%s' "$pr_json" | jq -r '.mergeCommit.oid')
+	if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$merge_sha" "origin/${branch}" 2>/dev/null; then
+		print_error "Source PR #${source_pr} merge SHA is not reachable from origin/${branch}"
+		return 1
+	fi
+	VERSION_MANAGER_SOURCE_PR="$source_pr"
+	VERSION_MANAGER_SOURCE_MERGE_SHA="$merge_sha"
+	export VERSION_MANAGER_SOURCE_PR VERSION_MANAGER_SOURCE_MERGE_SHA
+	print_success "Release provenance verified: PR #${source_pr}, merge ${merge_sha}"
+	return 0
+}
+
 # Function to check for uncommitted changes
 check_working_tree_clean() {
 	local uncommitted

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -169,11 +169,12 @@ verify_release_source_pr() {
 		return 1
 	}
 	if ! printf '%s' "$pr_json" | jq -e --arg branch "$branch" '
+		def present: ((. // "") | length > 0);
 		(.state == "MERGED")
-		and ((.mergedAt // "") != "")
+		and (.mergedAt | present)
 		and (.baseRefName == $branch)
-		and ((.headRefOid // "") != "")
-		and ((.mergeCommit.oid // "") != "")
+		and (.headRefOid | present)
+		and (.mergeCommit.oid | present)
 	' >/dev/null; then
 		print_error "Source PR #${source_pr} lacks verified MERGED provenance for ${branch}"
 		return 1

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -225,6 +225,10 @@ create_github_release() {
 		fi
 	else
 		# GitHub CLI not available
+		if release_source_pr_required; then
+			print_error "GitHub release publication cannot be verified without authenticated gh CLI access"
+			return 1
+		fi
 		print_warning "GitHub release creation skipped - GitHub CLI not available"
 		print_info "To enable GitHub releases:"
 		print_info "1. Install GitHub CLI: brew install gh (macOS)"

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -445,17 +445,7 @@ _release_dry_run() {
 
 # Handle the "release" action: full release pipeline.
 # Arguments: bump_type [flags...] (all positional args from main, starting at $1=bump_type)
-_main_release() {
-	local bump_type="$1"
-	shift
-
-	if [[ -z "$bump_type" ]]; then
-		print_error "Bump type required. Usage: $0 release [major|minor|patch]"
-		exit 1
-	fi
-
-	# Parse flags (can be in any order after bump_type)
-	local force_flag=0 skip_preflight=0 allow_dirty=0 hotfix_flag=0 dry_run=0 source_pr=""
+_parse_release_args() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--force) force_flag=1; shift ;;
@@ -471,6 +461,21 @@ _main_release() {
 		*) print_error "Unknown release option: $1"; return 1 ;;
 		esac
 	done
+	return 0
+}
+
+_main_release() {
+	local bump_type="$1"
+	shift
+
+	if [[ -z "$bump_type" ]]; then
+		print_error "Bump type required. Usage: $0 release [major|minor|patch]"
+		exit 1
+	fi
+
+	# Parse flags (can be in any order after bump_type)
+	local force_flag=0 skip_preflight=0 allow_dirty=0 hotfix_flag=0 dry_run=0 source_pr=""
+	_parse_release_args "$@" || return 1
 
 	# Hotfix releases are restricted to patch bumps and require maintainer identity
 	if [[ "$hotfix_flag" -eq 1 ]]; then

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -455,15 +455,20 @@ _main_release() {
 	fi
 
 	# Parse flags (can be in any order after bump_type)
-	local force_flag=0 skip_preflight=0 allow_dirty=0 hotfix_flag=0 dry_run=0
-	for arg in "$@"; do
-		case "$arg" in
-		"--force") force_flag=1 ;;
-		"--skip-preflight") skip_preflight=1 ;;
-		"--allow-dirty") allow_dirty=1 ;;
-		"--hotfix") hotfix_flag=1 ;;
-		"--dry-run") dry_run=1 ;;
-		*) ;; # Ignore unknown flags
+	local force_flag=0 skip_preflight=0 allow_dirty=0 hotfix_flag=0 dry_run=0 source_pr=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--force) force_flag=1; shift ;;
+		--skip-preflight) skip_preflight=1; shift ;;
+		--allow-dirty) allow_dirty=1; shift ;;
+		--hotfix) hotfix_flag=1; shift ;;
+		--dry-run) dry_run=1; shift ;;
+		--source-pr)
+			source_pr="${2:-}"
+			[[ -n "$source_pr" ]] || { print_error "--source-pr requires a PR number"; return 1; }
+			shift 2
+			;;
+		*) print_error "Unknown release option: $1"; return 1 ;;
 		esac
 	done
 
@@ -488,17 +493,20 @@ _main_release() {
 	# Structural safety is never bypassable by --force. Canonical releases can
 	# corrupt every parallel session sharing that repository.
 	assert_release_linked_worktree || exit 1
+	if release_source_pr_required && [[ -z "$source_pr" ]]; then
+		print_error "aidevops releases require --source-pr <merged-pr-number>"
+		exit 1
+	fi
 
 	# Verify local branch is in sync with remote
 	if ! verify_remote_sync "main"; then
-		if [[ "$force_flag" -eq 0 ]]; then
-			print_error "Cannot release when local/remote are out of sync."
-			print_info "Use --force to bypass (not recommended)"
-			exit 1
-		else
-			print_warning "Bypassing remote sync check with --force"
-		fi
+		print_error "Cannot release when local/remote are out of sync; --force cannot bypass structural provenance"
+		exit 1
 	fi
+	if [[ -n "$source_pr" ]]; then
+		verify_release_source_pr "$source_pr" "main" || exit 1
+	fi
+	verify_canonical_default_synced "main" || exit 1
 
 	# Check for uncommitted changes
 	if [[ "$allow_dirty" -eq 0 ]]; then
@@ -553,7 +561,8 @@ _main_usage() {
 	echo "  tag                           Create git tag for current version"
 	echo "  github-release                Create GitHub release for current version"
 	echo "  post-release [--hotfix]       Retry post-publication propagation and deployment gates"
-	echo "  release [major|minor|patch]   Bump version, update files, create tag and GitHub release"
+	echo "  release [major|minor|patch] --source-pr N"
+	echo "                                 Bump version, tag, publish, and deploy from a verified merged PR"
 	echo "  release patch --hotfix       Patch release with hotfix signal for immediate runner propagation"
 	echo "  preflight [major|minor|patch] Run release preflight checks only"
 	echo "  validate                      Validate version consistency across all files"

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -662,8 +662,8 @@ _parse_cmd_add_args() {
 # Precedence:
 #   1. Explicit --base <ref> (or AIDEVOPS_WORKTREE_BASE env var) — caller intent wins.
 #   2. origin/<default_branch> — safe, matches what the server will merge into.
-#   3. Local <default_branch> — fallback when remote-tracking ref missing.
-#   4. Empty string — fall through to git's default (HEAD). Caller logs a warning.
+#   3. Local <default_branch> — local-only repositories without an origin.
+#   4. Empty string — fail closed; never inherit an arbitrary current HEAD.
 #
 # Rationale: the pulse calls `worktree-helper.sh add <branch>` from the canonical
 # repo's cwd. If the canonical's HEAD is stale (long-lived feature branch,
@@ -691,10 +691,18 @@ _resolve_worktree_base_ref() {
 		return 0
 	fi
 
-	# 2. origin/<default>
+	# 2. origin/<default>. Refresh the remote-tracking ref before resolving it;
+	# worktree provenance must reflect the server tip observed at creation time.
 	local default_branch
 	default_branch=$(get_default_branch 2>/dev/null) || default_branch=""
 	if [[ -n "$default_branch" ]]; then
+		if git remote get-url origin >/dev/null 2>&1; then
+			if ! git fetch --no-tags --quiet origin \
+				"+refs/heads/${default_branch}:refs/remotes/origin/${default_branch}"; then
+				echo "Error: could not refresh origin/${default_branch}; refusing stale worktree base" >&2
+				return 1
+			fi
+		fi
 		if git rev-parse --verify --quiet "refs/remotes/origin/${default_branch}" >/dev/null 2>&1; then
 			printf 'origin/%s' "$default_branch"
 			return 0
@@ -706,7 +714,7 @@ _resolve_worktree_base_ref() {
 		fi
 	fi
 
-	# 4. No safe base resolved — caller falls back to HEAD and warns.
+	# 4. No safe base resolved — caller fails closed.
 	printf ''
 	return 0
 }
@@ -738,22 +746,16 @@ _cmd_add_create_worktree() {
 	# to prevent scope-leak PRs when canonical HEAD is stale. Canonical
 	# failure: example-repo#2716 (PR #2733, 100-file diff for a 2-line fix).
 	local _base_ref
-	_base_ref=$(_resolve_worktree_base_ref "$_explicit_base")
+	_base_ref=$(_resolve_worktree_base_ref "$_explicit_base") || return 1
 	if [[ -n "$_base_ref" ]]; then
 		echo -e "${BLUE}Creating worktree with new branch '$_branch' based on '$_base_ref'...${NC}"
 		git worktree add -b "$_branch" "$_path" "$_base_ref"
 		return 0
 	fi
 
-	# No remote default and no local default resolved. Surface the
-	# degradation loudly — the resulting branch will be based on the
-	# canonical's current HEAD which may be stale or unrelated.
-	echo -e "${YELLOW}Warning: could not resolve origin/<default> or a local default branch.${NC}" >&2
-	echo -e "${YELLOW}  Falling back to canonical HEAD. If this creates an oversized PR,${NC}" >&2
-	echo -e "${YELLOW}  re-create the worktree with '--base <ref>' or set AIDEVOPS_WORKTREE_BASE.${NC}" >&2
-	echo -e "${BLUE}Creating worktree with new branch '$_branch' (base: HEAD)...${NC}"
-	git worktree add -b "$_branch" "$_path"
-	return 0
+	echo -e "${RED}Error: could not resolve a safe worktree base.${NC}" >&2
+	echo "Fetch origin/<default>, or pass an explicit immutable commit SHA with --base." >&2
+	return 1
 }
 
 # --- cmd_add ---

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -681,13 +681,25 @@ _resolve_worktree_base_ref() {
 	local explicit_base="$1"
 	local env_base="${AIDEVOPS_WORKTREE_BASE:-}"
 
-	# 1. Explicit override (flag preferred, env as fallback).
-	if [[ -n "$explicit_base" ]]; then
-		printf '%s' "$explicit_base"
-		return 0
-	fi
-	if [[ -n "$env_base" ]]; then
-		printf '%s' "$env_base"
+	# 1. Explicit override (flag preferred, env as fallback). Resolve caller
+	# intent to an immutable commit SHA. Remote refs are refreshed first.
+	local requested_base="${explicit_base:-$env_base}"
+	if [[ -n "$requested_base" ]]; then
+		if [[ "$requested_base" == origin/* ]]; then
+			local requested_branch="${requested_base#origin/}"
+			if ! git fetch --no-tags --quiet origin \
+				"+refs/heads/${requested_branch}:refs/remotes/origin/${requested_branch}"; then
+				echo "Error: could not refresh ${requested_base}; refusing stale explicit base" >&2
+				return 1
+			fi
+		fi
+		local requested_sha=""
+		requested_sha=$(git rev-parse --verify "${requested_base}^{commit}" 2>/dev/null || true)
+		if [[ -z "$requested_sha" ]]; then
+			echo "Error: explicit worktree base is not a resolvable commit: ${requested_base}" >&2
+			return 1
+		fi
+		printf '%s' "$requested_sha"
 		return 0
 	fi
 

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -11,7 +11,7 @@ Task/Prompt: $ARGUMENTS
 
 ## Lifecycle Gate (t5096 + GH#5317 — MANDATORY)
 
-`Claim → Worktree → Develop → Preflight → PR → Review → Merge → Release → Close → Cleanup`
+`WORKTREE → LOCAL_VERIFIED → PR_OPEN → REMOTE_VERIFIED → MERGED → CANONICAL_SYNCED → RELEASED → DEPLOYED → CLEANED`
 
 Fatal modes: **GH#5317** (exits without PR), **GH#5096** (exits after PR). Do NOT skip any step:
 
@@ -23,8 +23,8 @@ Fatal modes: **GH#5317** (exits without PR), **GH#5096** (exits after PR). Do NO
 | 3 | Merge — `full-loop-helper.sh merge` (enforces gate + squash, no `--delete-branch`) | |
 | 4 | Auto-release — bump patch + GitHub release (aidevops repo only) | |
 | 5 | Issue closing comment — structured comment on every linked issue | |
-| 6 | Postflight + deploy — verify release health, run setup.sh | `FULL_LOOP_COMPLETE` |
-| 7 | Worktree cleanup — return to main, pull, prune | |
+| 6 | Postflight + deploy — verify release health and deployed version | |
+| 7 | Guarded worktree cleanup after the owner exits | `FULL_LOOP_COMPLETE` |
 
 ---
 
@@ -50,7 +50,7 @@ Extract first positional arg; if ` -- ` present, use suffix (t158). Resolve `t\d
 ~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "$ARGUMENTS"
 ```
 
-Exit 0: already in a safe linked worktree or approved pre-created worker worktree. Exit 2: canonical `main` checkout → create a safe linked worktree for the task before editing.
+Exit 0 means structural linked-worktree checks passed. A worker environment variable never bypasses those checks. From the canonical checkout, create a fresh safe linked worktree; the helper refreshes `origin/main` and fails closed rather than inheriting stale local `main` or current `HEAD`.
 
 **Operation Verification (t1364.3):** `verify-operation-helper.sh check/verify`. Critical/high → block or verify.
 
@@ -172,19 +172,19 @@ Verify it posted: `gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[
 full-loop-helper.sh merge "$PR_NUMBER" "$REPO"
 ```
 
-Calls `review-bot-gate-helper.sh wait` (polls every 60s, up to 10 min) then `gh pr merge --squash`. Gate failure blocks merge. Do NOT call `gh pr merge` directly — the wrapper is the only sanctioned merge path. After an immediate successful merge, the wrapper defers current-worktree removal because the parent AI runtime may still use it as its logical `--dir` without exposing an OS process cwd. The safety-net sweep removes it after runtime exit. `--auto` also leaves cleanup to the safety-net sweep. In interactive admin/maintainer sessions, the wrapper may use `--admin` automatically when branch policy only blocks self-review/review count after checks and NMR gates pass; do not ask the user to approve their own PR. For self-modifying full-loop helper fixes, call the committed worktree path instead: `"$PWD/.agents/scripts/full-loop-helper.sh" merge "$PR_NUMBER" "$REPO"`.
+Verifies the exact PR head is open, non-draft, free of changes-requested reviews, and has only terminal-success checks before running `review-bot-gate-helper.sh wait`. It then invokes `gh pr merge --squash` and requires GitHub to report `MERGED`, `mergedAt`, and a merge SHA before finalization. Gate failure or head drift blocks merge. Do NOT call `gh pr merge` directly. `--auto` records a queue request only; it does not claim merge, release, or cleanup completion until GitHub reports merged evidence. For self-modifying fixes, call the committed worktree helper: `"$PWD/.agents/scripts/full-loop-helper.sh" merge "$PR_NUMBER" "$REPO"`.
 
 Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$REPO"`.
 
-**4.5 Merge (via wrapper only):** Workers MUST use `full-loop-helper.sh merge`. Direct `gh pr merge --squash` bypasses the review bot gate (GH#17541). Wrapper enforces: (1) review-bot-gate wait, (2) squash merge, (3) no `--delete-branch` from inside worktree, (4) deferred current-worktree cleanup after parent runtime exit. `--auto` queues only; scheduled cleanup handles it later.
+**4.5 Merge (via wrapper only):** Workers MUST use `full-loop-helper.sh merge`. Direct `gh pr merge --squash` bypasses exact-head, terminal-check, review-bot, and observed-merge gates. The wrapper never equates a successful queue command with a merged PR.
 
-**4.6 Auto-Release (aidevops only):** `version-manager.sh bump patch`, tag, push, `gh release create`, `setup.sh --non-interactive`.
+**4.6 Canonical Sync + Release (aidevops only):** First synchronize the clean canonical checkout through `canonical-recovery-helper.sh` when the merge wrapper reports `CANONICAL_SYNC_PENDING`. Then create a fresh detached release worktree at `origin/main` and run one command: `version-manager.sh release patch --source-pr "$PR_NUMBER"`. The version manager requires the source PR's observed merge SHA to be reachable from synchronized `origin/main`; `--force` cannot bypass this provenance. It publishes the tag/GitHub release and runs post-release deploy sync.
 
 **4.7 Closing Comments (MANDATORY):** Post structured closing comment on **both** issue AND PR: What done, Testing Evidence, Key decisions, Files changed, Blockers, Follow-up, Released in. PR comment: `Resolves #NNN`. Issue comment: `PR #NNN`. **Pre-close verification (GH#17372):** Only close if your session created the fixing PR. Never close citing someone else's PR without `verify-issue-close-helper.sh check`.
 
-**4.8 Postflight + Deploy:** verify release health; `setup.sh --non-interactive`. Emit: `<promise>FULL_LOOP_COMPLETE</promise>`.
+**4.8 Postflight + Deploy:** verify the release tag, GitHub release, required checks, and deployed agent version. A publication or deploy-sync failure keeps the lifecycle open.
 
-**4.9 Worktree Cleanup (GH#6740 — MANDATORY):** immediate merges through `full-loop-helper.sh merge` defer current-worktree removal to the scheduled safety-net after parent runtime exit. This protects runtimes that use the worktree as a logical `--dir` without changing OS cwd. Never force-remove an actively owned worktree; after the owner exits, use guarded `worktree-helper.sh remove "$BRANCH_NAME"` if scheduled cleanup has not run.
+**4.9 Worktree Cleanup (GH#6740 — MANDATORY):** immediate merges defer current-worktree removal until the parent runtime exits. Never force-remove an actively owned worktree. Confirm guarded cleanup succeeded exactly once, then emit `<promise>FULL_LOOP_COMPLETE</promise>`.
 
 ---
 
@@ -196,11 +196,8 @@ Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$R
 | `--headless` | Fully headless worker mode |
 | `--dry-run` | Simulate without making changes |
 | `--max-task-iterations N` | Max task iterations (default: 50) |
-| `--skip-preflight` | Skip preflight checks |
-| `--skip-postflight` | Skip postflight monitoring |
 | `--no-auto-pr` | Pause for manual PR creation |
 | `--no-auto-deploy` | Don't auto-run setup.sh |
-| `--skip-runtime-testing` | Skip runtime testing gate (emergency hotfixes only) |
 
 `full-loop-helper.sh {status|resume|logs [N]|cancel|help}`
 

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -172,7 +172,7 @@ Verify it posted: `gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[
 full-loop-helper.sh merge "$PR_NUMBER" "$REPO"
 ```
 
-Verifies the exact PR head is open, non-draft, free of changes-requested reviews, and has only terminal-success checks before running `review-bot-gate-helper.sh wait`. It then invokes `gh pr merge --squash` and requires GitHub to report `MERGED`, `mergedAt`, and a merge SHA before finalization. Gate failure or head drift blocks merge. Do NOT call `gh pr merge` directly. `--auto` records a queue request only; it does not claim merge, release, or cleanup completion until GitHub reports merged evidence. For self-modifying fixes, call the committed worktree helper: `"$PWD/.agents/scripts/full-loop-helper.sh" merge "$PR_NUMBER" "$REPO"`.
+Verifies the exact PR head is open, non-draft, free of changes-requested reviews, and has terminal-success required checks before running `review-bot-gate-helper.sh wait`. Historical cancelled optional jobs do not override the current required-check set. It then invokes `gh pr merge --squash` and requires GitHub to report `MERGED`, `mergedAt`, and a merge SHA before finalization. Gate failure or head drift blocks merge. Do NOT call `gh pr merge` directly. `--auto` records a queue request only; it does not claim merge, release, or cleanup completion until GitHub reports merged evidence. For self-modifying fixes, call the committed worktree helper: `"$PWD/.agents/scripts/full-loop-helper.sh" merge "$PR_NUMBER" "$REPO"`.
 
 Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$REPO"`.
 

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -30,16 +30,16 @@ tools:
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/pre-edit-check.sh  # Verifies branch and canonical-checkout safety
 ```
 
-If the gate reports the canonical checkout: STOP and create a safe linked worktree for the task before editing. This technical gate checks both branch and worktree location; `git status` alone cannot prove the checkout is canonical versus linked. For releases, create a detached linked worktree at `origin/main`; the version manager refuses canonical execution and atomically pushes detached `HEAD` to `main`.
+If the gate reports the canonical checkout: STOP and create a safe linked worktree for the task before editing. This technical gate checks both branch and worktree location; `git status` alone cannot prove the checkout is canonical versus linked. For releases, first verify the canonical checkout is clean and synchronized, then create a fresh detached linked worktree at `origin/main`; the version manager refuses canonical execution and requires source-PR merge provenance.
 
 **First Actions** (before any code changes):
 
 ```bash
-git fetch origin && git status --short
+git status --short
 git log --oneline HEAD..origin/$(git branch --show-current) 2>/dev/null
 ```
 
-Remote has new commits → pull/rebase first. Uncommitted local changes → stash or commit first.
+Inside an existing linked worktree, refresh and rebase before editing. From the canonical checkout, let `worktree-helper.sh add` refresh `origin/<default>` while creating the linked worktree. Preserve unrelated uncommitted work; never stash/reset/clean another session's changes.
 
 **Worktrees** (DEFAULT for all feature work):
 
@@ -48,6 +48,7 @@ Main repo (`~/Git/{repo}/` or grouped `~/Git/{ecosystem}/{repo}/`) ALWAYS stays 
 ```bash
 ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/my-feature
 # Creates e.g. ~/Git/_worktrees/{repo}-feature-my-feature/
+# Fetches origin/<default> first and fails closed if freshness cannot be verified.
 # Then cd into the printed linked worktree path before editing.
 ```
 

--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -36,8 +36,8 @@ All other paths and all interactive edits require a linked worktree. `pre-edit-c
 |------|---------|--------|
 | `0` | Safe to edit | Proceed |
 | `1` | On `main`/`master` | STOP — present prompt below, WAIT for reply |
-| `2` | Loop mode needs worktree | Auto-create worktree |
-| `3` | Feature branch in main repo | Present exit-3 options below |
+| `2` | Worktree required or ownership conflict | Create a fresh linked worktree |
+| `3` | Reserved legacy code | Treat as blocked and re-run the current helper |
 
 **Exit 1 prompt** (non-allowlisted path on `main`, interactive mode only):
 > On `main`. Suggested branch: `{type}/{suggested-name}`
@@ -45,12 +45,6 @@ All other paths and all interactive edits require a linked worktree. `pre-edit-c
 > 2. Use different branch name
 
 Note: only qualifying headless flows can short-circuit to exit `0` for allowlisted paths (`README.md`, `TODO.md`, `todo/**`). Interactive sessions still receive this prompt and move every edit to a linked worktree.
-
-**Exit 3 prompt:**
-> On branch: `{branch}` (main repo, not worktree)
-> 1. Create worktree for this task (recommended)
-> 2. Continue on current branch
-> 3. Switch to `main`, then create worktree
 
 ## Loop Mode
 
@@ -78,6 +72,8 @@ Continue on current branch only when: task matches branch purpose, finishes this
 wt switch -c {type}/{name}
 ~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{name}
 ```
+
+The helper refreshes `origin/<default>` before creating a new branch. Fetch failure blocks creation; it never silently falls back to stale local state or arbitrary `HEAD`. An explicit immutable base SHA remains available for audited recovery.
 
 After creating, set the session title with the work item first: `Issue #123: succinct description` or `PR #456: succinct description`. If there is no issue/PR context, call `session-rename_sync_branch`. Branch types: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
 

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -20,14 +20,14 @@ tools:
 **MANDATORY**: Use this single command for ALL aidevops releases:
 
 ```bash
-./.agents/scripts/version-manager.sh release [major|minor|patch] --skip-preflight
+./.agents/scripts/version-manager.sh release [major|minor|patch] --source-pr <merged-pr-number>
 ```
 
-**Flags**: `--skip-preflight` (faster), `--force` (bypass empty changelog), `--allow-dirty` (not recommended)
+**Flags**: `--force` bypasses only the empty-changelog check. It cannot bypass linked-worktree, canonical-sync, source-PR, or remote-SHA provenance. `--skip-preflight` and `--allow-dirty` are recovery flags and do not satisfy a standard full-loop release.
 
-Atomically: checks uncommitted changes → bumps version in all 6 files (VERSION, README.md, setup.sh, sonar-project.properties, package.json, .claude-plugin/marketplace.json) → auto-generates CHANGELOG.md → validates consistency → commits → tags → pushes → creates GitHub release.
+Requires a fresh detached release worktree at synchronized `origin/main`, verifies the source PR is merged and its merge SHA is reachable, then atomically checks the tree → bumps and validates version files → commits → tags → pushes → creates the GitHub release → runs deploy sync. Publication or deployment failure is a failed release, not warning-only success.
 
-**DO NOT** run separate bump/tag/push commands. **Prerequisites**: `gh auth login` (needs `repo` scope), all changes committed, CHANGELOG.md has unreleased content (or `--force`).
+**DO NOT** run separate bump/tag/push commands. **Prerequisites**: terminal-success PR checks/reviews, observed merged state/SHA, clean synchronized canonical `main`, fresh detached release worktree, authenticated `gh`, and unreleased changelog content (or changelog-only `--force`).
 
 **Related**: `workflows/version-bump.md` · `workflows/changelog.md` · `workflows/postflight.md` · `.agents/scripts/validate-version-consistency.sh`
 
@@ -45,7 +45,7 @@ git push origin main && git push origin --tags
 
 ## Post-Release
 
-**Deploy** (aidevops only): `cd ~/Git/aidevops && ./setup.sh`
+**Deploy** (aidevops only): the release command runs post-release deploy sync and fails if it cannot verify that step. Run postflight afterward; do not manually mutate the canonical checkout.
 
 **Task completion** (automatic): Release script scans commits for task IDs and auto-marks them complete in TODO.md.
 


### PR DESCRIPTION
## Summary

Supersedes #27161 after `main` advanced and the audited verifier correctly blocked rewriting its published head.

- require freshly fetched `origin/<default>` worktree provenance and remove worker-environment/canonical write bypasses
- require exact-head terminal PR evidence, review-bot approval, and observed `MERGED` state before finalization
- make canonical drift explicit, bind releases to reachable source-PR merge provenance, and fail on publication/deploy gaps
- require observed merged, released/deployed, postflight, removed-worktree, and cleanup-audit evidence before `FULL_LOOP_COMPLETE`
- align the full-loop, Git, pre-edit, and release workflows with the enforced lifecycle

## Testing

- `test-pre-edit-check.sh`: 12 passed
- `test-full-loop-completion-evidence.sh`: 4 passed
- `test-full-loop-merge.sh`: 36 passed
- `test-full-loop-merge-worktree-cleanup.sh`: 3 passed
- `test-full-loop-remote-evidence.sh`: 5 passed
- `test-worktree-fresh-base.sh`: 3 passed
- `test-version-manager-release-provenance.sh`: 5 passed
- version-manager linked-release, rollback, and REST-fallback suites passed
- changed-file `linters-local.sh`: passed ShellCheck, secretlint, Markdown, Bash 3.2, portability, complexity, file-size, and string-literal gates
- SonarCloud quality gate passed with 0 issues
- full repository sweep also ran; only pre-existing broad complexity/nesting debt, an unrelated `CHANGELOG.md` style issue already on `main`, and a pulse-canary infrastructure timeout remained

## Runtime Testing

`runtime-verified`: temporary bare remotes, canonical checkouts, linked worktrees, exact Git refs, JSON-backed GitHub shims, owner/deferred-cleanup markers, and removal audit records exercise positive and adversarial state transitions.

## Key Decisions

- `--auto` is queued, never merged, until GitHub reports terminal merge evidence.
- canonical drift is `CANONICAL_SYNC_PENDING`; audited recovery remains the only mutation path.
- `--force` may bypass changelog policy but never structural release provenance.
- cleanup completion requires an actual removal audit record, not merely an absent path.

Resolves #27144

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.30 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1d 14h and 1,250,828 tokens on this with the user in an interactive session. Overall, 33m since this issue was created.
