### PR TITLE
GH#27158: fix deployed CLI version root

### DIFF
--- a/.agents/scripts/tests/test-setup-aidevops-cli-install.sh
+++ b/.agents/scripts/tests/test-setup-aidevops-cli-install.sh
@@ -17,6 +17,20 @@ print_warning() { return 0; }
 # shellcheck source=../setup/modules/config.sh
 source "$CONFIG_LIB"
 
+# Exercise setup.sh itself with its default environment, rather than only
+# injecting globals before sourcing the config module. The trace proves the
+# default agents root exists and is exported before setup modules are loaded.
+setup_home="$TEST_DIR/setup-home"
+mkdir -p "$setup_home"
+setup_trace=$(env -u AGENTS_DIR -u AIDEVOPS_AGENTS_DIR HOME="$setup_home" \
+	bash -x "$REPO_ROOT/setup.sh" --help 2>&1)
+if [[ "$setup_trace" != *"AGENTS_DIR=$setup_home/.aidevops/agents"* ||
+	"$setup_trace" != *"export REPO_URL INSTALL_DIR AGENTS_DIR"* ]]; then
+	printf 'FAIL: setup.sh did not define and export the default AGENTS_DIR\n' >&2
+	exit 1
+fi
+printf 'PASS: setup.sh defines and exports its default AGENTS_DIR before module use\n'
+
 source_cli="$TEST_DIR/source-cli"
 target_cli="$TEST_DIR/bin/aidevops"
 old_target="$TEST_DIR/old-target"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -54,8 +54,18 @@ if [[ -n "$_AIDEVOPS_SOURCE_DIR" && -L "$_AIDEVOPS_SOURCE_PATH" ]]; then
 		[[ -n "$_AIDEVOPS_LINK_DIR" ]] && _AIDEVOPS_SOURCE_DIR="$_AIDEVOPS_LINK_DIR"
 	fi
 fi
+_AIDEVOPS_CLI_ROOT="$INSTALL_DIR"
+_AIDEVOPS_CLI_MODULES_SUBDIR=".agents/scripts/aidevops-cli"
 if [[ -n "$_AIDEVOPS_SOURCE_DIR" && -f "$_AIDEVOPS_SOURCE_DIR/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh" ]]; then
 	INSTALL_DIR="$_AIDEVOPS_SOURCE_DIR"
+	_AIDEVOPS_CLI_ROOT="$_AIDEVOPS_SOURCE_DIR"
+elif [[ -n "$_AIDEVOPS_SOURCE_DIR" && -f "$_AIDEVOPS_SOURCE_DIR/scripts/aidevops-cli/aidevops-repos-lib.sh" ]]; then
+	# setup.sh deploys the orchestrator at the agents root and its modules under
+	# scripts/. Keep repository operations pointed at INSTALL_DIR, but load the
+	# CLI and VERSION from this coherent atomic deployment instead of a stale
+	# canonical checkout.
+	_AIDEVOPS_CLI_ROOT="$_AIDEVOPS_SOURCE_DIR"
+	_AIDEVOPS_CLI_MODULES_SUBDIR="scripts/aidevops-cli"
 fi
 unset _AIDEVOPS_SOURCE_PATH _AIDEVOPS_SOURCE_DIR _AIDEVOPS_LINK_TARGET _AIDEVOPS_LINK_DIR
 AGENTS_DIR="$_AIDEVOPS_REAL_HOME/.aidevops/agents"
@@ -63,7 +73,7 @@ CONFIG_DIR="$_AIDEVOPS_REAL_HOME/.config/aidevops"
 REPOS_FILE="$CONFIG_DIR/repos.json"
 # shellcheck disable=SC2034  # Used in fresh install fallback
 REPO_URL="https://github.com/marcusquinn/aidevops.git"
-VERSION_FILE="$INSTALL_DIR/VERSION"
+VERSION_FILE="$_AIDEVOPS_CLI_ROOT/VERSION"
 
 # Portable sed in-place edit (macOS BSD sed vs GNU sed)
 sed_inplace() { if [[ "$(uname)" == "Darwin" ]]; then sed -i '' "$@"; else sed -i "$@"; fi; }
@@ -181,12 +191,11 @@ ensure_trailing_newline() {
 	return 0
 }
 
-# Source CLI implementation modules from the namespaced module tree.
-# INSTALL_DIR is the canonical location of aidevops.sh (set above). Using
-# INSTALL_DIR rather than BASH_SOURCE[0] preserves installed symlink support:
-# /usr/local/bin/aidevops → $INSTALL_DIR/aidevops.sh would otherwise resolve
-# BASH_SOURCE[0] to /usr/local/bin instead of the checkout/deployed tree.
-AIDEVOPS_CLI_MODULES_DIR="${INSTALL_DIR}/.agents/scripts/aidevops-cli"
+# Source CLI implementation modules from the coherent canonical or deployed
+# tree selected above. The launcher executes the deployed orchestrator as a
+# regular file, while local development and package snapshots use .agents/.
+AIDEVOPS_CLI_MODULES_DIR="${_AIDEVOPS_CLI_ROOT}/${_AIDEVOPS_CLI_MODULES_SUBDIR}"
+unset _AIDEVOPS_CLI_ROOT _AIDEVOPS_CLI_MODULES_SUBDIR
 # shellcheck source=.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
 # shellcheck disable=SC1091  # module path resolved at runtime via $INSTALL_DIR
 source "${AIDEVOPS_CLI_MODULES_DIR}/aidevops-repos-lib.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -68,7 +68,8 @@ REPO_URL="https://github.com/marcusquinn/aidevops.git"
 # INSTALL_DIR: resolve from the directory where setup.sh is executed (supports worktrees)
 # For bootstrap (curl install), this will be /dev/fd/NN and trigger re-exec after clone
 INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-export REPO_URL INSTALL_DIR
+AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}"
+export REPO_URL INSTALL_DIR AGENTS_DIR
 
 # Source modular setup functions (t316.2)
 # These modules are sourced only when setup.sh is run from the repo directory

--- a/tests/test-cli-deployment-coherence.sh
+++ b/tests/test-cli-deployment-coherence.sh
@@ -13,13 +13,27 @@ grep -q '"$convergence_helper" converge "$cli_source" "$orchestrator_source" "$d
 grep -q 'git clone --depth 1 --branch main' \
 	"$REPO_DIR/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
 
-mkdir -p "$TEST_HOME/.aidevops/agents" "$TEST_HOME/Git/aidevops"
+mkdir -p "$TEST_HOME/.aidevops/agents/scripts" "$TEST_HOME/Git/aidevops" "$TEST_HOME/bin"
 # shellcheck disable=SC2016
 printf '#!/usr/bin/env bash\nprintf "deployed:%%s\\n" "$1"\n' >"$TEST_HOME/.aidevops/agents/aidevops.sh"
 printf '#!/usr/bin/env bash\nprintf "canonical\\n"\n' >"$TEST_HOME/Git/aidevops/aidevops.sh"
 result=$(HOME="$TEST_HOME" bash "$REPO_DIR/bin/aidevops" version-check)
 [[ "$result" == "deployed:version-check" ]] || {
 	printf 'FAIL: launcher selected %s\n' "$result" >&2
+	exit 1
+}
+
+# Exercise the real orchestrator and real module tree in setup's deployed
+# layout. A deliberately stale canonical VERSION must not leak into output.
+cp "$REPO_DIR/aidevops.sh" "$TEST_HOME/.aidevops/agents/aidevops.sh"
+cp -R "$REPO_DIR/.agents/scripts/." "$TEST_HOME/.aidevops/agents/scripts/"
+printf '9.8.7\n' >"$TEST_HOME/.aidevops/agents/VERSION"
+printf '1.2.3\n' >"$TEST_HOME/Git/aidevops/VERSION"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$TEST_HOME/bin/curl"
+chmod +x "$TEST_HOME/bin/curl"
+result=$(cd "$TEST_HOME" && HOME="$TEST_HOME" PATH="$TEST_HOME/bin:/usr/bin:/bin" bash "$REPO_DIR/bin/aidevops" --version)
+[[ "$result" == "aidevops 9.8.7" ]] || {
+	printf 'FAIL: real deployed CLI selected %s\n' "$result" >&2
 	exit 1
 }
 


### PR DESCRIPTION
## Summary

- initialize and export the default agents deployment directory before setup modules load
- detect the deployed `scripts/` module layout in `aidevops.sh`
- read the deployed `VERSION` rather than a stale canonical checkout
- add real-layout setup and launcher regressions

## Testing

- CLI convergence: 13 passed
- setup mutex contract: passed
- deployment coherence: passed
- setup default environment: passed
- setup completion sentinel: passed
- ShellCheck, Bash syntax, local linters, and diff checks

Ref #27158

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2h 27m and 1,784,412 tokens on this with the user in an interactive session.
