### PR TITLE
plan: add self-healing worker lifecycle tasks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -111,13 +111,13 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 
 - [x] t18070 Design Secrets interface and repair Vault unlock readiness #bug #enhancement #security #interactive #no-auto-dispatch ~6h tier:thinking ref:GH#26912 started:2026-07-10T00:00:00Z logged:2026-07-10 -> [todo/tasks/t18070-brief.md] pr:#26938 completed:2026-07-10
 
-- [ ] t18098 Prevent worktree infrastructure markers from breaking worker ownership transfer #bug #framework #pulse #reliability #auto-dispatch ~3h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18098-brief.md]
-- [ ] t18099 Make dispatch claim-to-worker handoff an atomic expiring lease #bug #framework #pulse #reliability #auto-dispatch ~6h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18099-brief.md]
-- [ ] t18100 Normalize issue dependencies before dispatch eligibility #bug #framework #pulse #reliability #auto-dispatch ~4h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18100-brief.md]
-- [ ] t18101 Repair terminal CI failures in place on existing PR branches #bug #framework #pulse #reliability #auto-dispatch ~5h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18101-brief.md]
-- [ ] t18102 Deploy CLI, agents, and plugins as one atomic version bundle #bug #framework #reliability #auto-dispatch ~5h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18102-brief.md]
-- [ ] t18103 Reconcile stale objectives with expiring assumptions and durable recovery #enhancement #framework #pulse #reliability #auto-dispatch ~7h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18103-brief.md]
-- [ ] t18104 Automate failure-family remediation and human-gate revalidation #enhancement #framework #pulse #observability #auto-dispatch ~6h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18104-brief.md]
+- [ ] t18098 Prevent worktree infrastructure markers from breaking worker ownership transfer #bug #framework #pulse #reliability #auto-dispatch ~3h tier:thinking ref:GH#27164 logged:2026-07-11 -> [todo/tasks/t18098-brief.md]
+- [ ] t18099 Make dispatch claim-to-worker handoff an atomic expiring lease #bug #framework #pulse #reliability #auto-dispatch ~6h tier:thinking ref:GH#27165 logged:2026-07-11 -> [todo/tasks/t18099-brief.md]
+- [ ] t18100 Normalize issue dependencies before dispatch eligibility #bug #framework #pulse #reliability #auto-dispatch ~4h tier:thinking ref:GH#27166 logged:2026-07-11 -> [todo/tasks/t18100-brief.md]
+- [ ] t18101 Repair terminal CI failures in place on existing PR branches #bug #framework #pulse #reliability #auto-dispatch ~5h tier:thinking ref:GH#27167 logged:2026-07-11 -> [todo/tasks/t18101-brief.md]
+- [ ] t18102 Deploy CLI, agents, and plugins as one atomic version bundle #bug #framework #reliability #auto-dispatch ~5h tier:thinking ref:GH#27168 logged:2026-07-11 -> [todo/tasks/t18102-brief.md]
+- [ ] t18103 Reconcile stale objectives with expiring assumptions and durable recovery #enhancement #framework #pulse #reliability #auto-dispatch ~7h tier:thinking ref:GH#27169 logged:2026-07-11 -> [todo/tasks/t18103-brief.md]
+- [ ] t18104 Automate failure-family remediation and human-gate revalidation #enhancement #framework #pulse #observability #auto-dispatch ~6h tier:thinking ref:GH#27170 logged:2026-07-11 -> [todo/tasks/t18104-brief.md]
 
 - [x] t18066 fix(full-loop): resolve commit-and-pr rebase/counter base from the remote default branch instead of hardcoded `origin/main`. Add a default-branch resolver in `.agents/scripts/full-loop-helper-commit.sh`, use `origin/${base_branch}` for ahead-count, fetch, rebase, operator messages, and `.task-counter` reset, fail actionably when the base cannot be resolved, and cover an `origin/develop` regression path. #bug #framework #full-loop #auto-dispatch ~1h tier:standard ref:GH#26626 logged:2026-07-05 -> [todo/tasks/t18066-brief.md] pr:#26630 completed:2026-07-05
 

--- a/TODO.md
+++ b/TODO.md
@@ -111,6 +111,14 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 
 - [x] t18070 Design Secrets interface and repair Vault unlock readiness #bug #enhancement #security #interactive #no-auto-dispatch ~6h tier:thinking ref:GH#26912 started:2026-07-10T00:00:00Z logged:2026-07-10 -> [todo/tasks/t18070-brief.md] pr:#26938 completed:2026-07-10
 
+- [ ] t18098 Prevent worktree infrastructure markers from breaking worker ownership transfer #bug #framework #pulse #reliability #auto-dispatch ~3h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18098-brief.md]
+- [ ] t18099 Make dispatch claim-to-worker handoff an atomic expiring lease #bug #framework #pulse #reliability #auto-dispatch ~6h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18099-brief.md]
+- [ ] t18100 Normalize issue dependencies before dispatch eligibility #bug #framework #pulse #reliability #auto-dispatch ~4h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18100-brief.md]
+- [ ] t18101 Repair terminal CI failures in place on existing PR branches #bug #framework #pulse #reliability #auto-dispatch ~5h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18101-brief.md]
+- [ ] t18102 Deploy CLI, agents, and plugins as one atomic version bundle #bug #framework #reliability #auto-dispatch ~5h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18102-brief.md]
+- [ ] t18103 Reconcile stale objectives with expiring assumptions and durable recovery #enhancement #framework #pulse #reliability #auto-dispatch ~7h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18103-brief.md]
+- [ ] t18104 Automate failure-family remediation and human-gate revalidation #enhancement #framework #pulse #observability #auto-dispatch ~6h tier:thinking ref:none logged:2026-07-11 -> [todo/tasks/t18104-brief.md]
+
 - [x] t18066 fix(full-loop): resolve commit-and-pr rebase/counter base from the remote default branch instead of hardcoded `origin/main`. Add a default-branch resolver in `.agents/scripts/full-loop-helper-commit.sh`, use `origin/${base_branch}` for ahead-count, fetch, rebase, operator messages, and `.task-counter` reset, fail actionably when the base cannot be resolved, and cover an `origin/develop` regression path. #bug #framework #full-loop #auto-dispatch ~1h tier:standard ref:GH#26626 logged:2026-07-05 -> [todo/tasks/t18066-brief.md] pr:#26630 completed:2026-07-05
 
 - [x] t18060 fix(pulse): harden SIGPIPE-safe pulse emits and LLM retry state for issue 26333. Implement localized broken-pipe-safe stdout handling for pulse helpers that run under `set -euo pipefail`, separate LLM supervisor attempt/success state so failed daily sweeps do not suppress future attempts, and add focused regression tests for early-closing consumers plus failed-run retry semantics. #bug #reliability #auto-dispatch ~4h tier:thinking ref:GH#26333 logged:2026-07-02 -> [todo/tasks/t18060-brief.md] pr:#26359 completed:2026-07-02

--- a/todo/tasks/t18098-brief.md
+++ b/todo/tasks/t18098-brief.md
@@ -1,0 +1,81 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18098: Prevent worktree infrastructure markers from breaking worker ownership transfer
+
+## Pre-flight
+
+- [x] Memory recall: `worktree ownership metadata marker` → no relevant memories returned; direct incident evidence retained in the originating session.
+- [x] Discovery pass: no matching open issue/PR; recent worktree/runtime changes reviewed.
+- [x] File refs verified: `worktree-exclusions-helper.sh`, `worktree-helper-add.sh`, `headless-runtime-worker.sh`, and focused worktree tests exist at HEAD.
+- [x] Tier: `tier:thinking` — cross-lifecycle safety semantics and recovery behavior span more than two files.
+- [x] Seeded draft PR decision recorded: skipped — the correct marker-storage contract requires implementation judgment.
+
+## Origin
+
+- **Created:** 2026-07-11
+- **Created by:** ai-interactive
+- **Blocked by:** none
+- **Conversation context:** Two manual worker launches failed because macOS exclusion setup created an unignored `.metadata_never_index`, making a dispatcher-precreated worktree dirty before ownership transfer. Exit recovery then committed the marker and opened duplicate PRs containing only that file.
+
+## What
+
+Make OS indexing/backup exclusions compatible with the clean-worktree ownership contract so infrastructure metadata can never block worker startup, become a WIP commit, or generate a recovery PR.
+
+## Why
+
+One local-only marker caused two failed launches, two duplicate PRs, wasted CI, and a false impression that the implementation issue lacked a worker. This class of metadata must be invisible to task Git state by construction.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** The worker must choose between out-of-tree metadata, repository-local excludes, or a narrowly proven cleanliness exemption without weakening dirty-work preservation.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** Multiple safe designs exist; tests must prove no real task edit is ignored.
+- **Status:** not-created
+- **Freshness evidence:** Incident reproduced against current deployed/runtime paths and target files verified at HEAD.
+- **Verification run:** UNVERIFIED — issue composition only.
+- **Stale-assumption warning:** Re-check whether newer worktree code already relocated or ignores the marker.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/worktree-exclusions-helper.sh` — prevent exclusion artifacts from appearing as task changes.
+- `EDIT: .agents/scripts/worktree-helper-add.sh` — preserve exclusion behavior without dirtying a fresh worktree.
+- `EDIT: .agents/scripts/headless-runtime-worker.sh` — retain fail-closed ownership transfer for genuine changes and avoid recovery PRs for verified infrastructure-only state.
+- `NEW/EDIT: .agents/scripts/tests/test-worktree-exclusion-owner-transfer.sh` — reproduce macOS marker creation through launch readiness and abnormal-exit recovery.
+
+### Implementation Steps
+
+1. Reproduce the clean-worktree → exclusion application → ownership transfer sequence with a fixture.
+2. Select one canonical contract that keeps exclusion metadata outside tracked task state or makes it ignored before creation.
+3. Keep `git status` cleanliness strict for every non-infrastructure path; do not broadly ignore dotfiles or untracked files.
+4. Ensure abnormal exit cannot commit/push an exclusion marker or create a PR when no task work exists.
+5. Cover reused worktrees and non-macOS no-op behavior.
+6. Create a WIP commit after focused tests pass, then run broad shell/framework gates.
+
+### Verification
+
+```bash
+bash .agents/scripts/tests/test-worktree-exclusion-owner-transfer.sh
+bash .agents/scripts/tests/test-worktree-registry-session-claim.sh
+bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh
+shellcheck .agents/scripts/worktree-exclusions-helper.sh .agents/scripts/worktree-helper-add.sh .agents/scripts/headless-runtime-worker.sh
+.agents/scripts/linters-local.sh
+```
+
+## Acceptance Criteria
+
+- [ ] A fresh macOS worker worktree remains clean through exclusion setup and ownership transfer.
+- [ ] Genuine dirty task state still blocks unsafe ownership takeover.
+- [ ] Infrastructure-only markers never produce commits, pushes, or recovery PRs.
+- [ ] Reused worktrees and Linux behavior retain current safety semantics.
+- [ ] Focused tests and repository lint pass.
+
+## Recovery Checkpoint
+
+If broad gates or runtime limits interrupt work, push a focused-test-passing WIP commit and record the selected marker contract, remaining platforms, and next verification command.

--- a/todo/tasks/t18099-brief.md
+++ b/todo/tasks/t18099-brief.md
@@ -1,0 +1,85 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18099: Make dispatch claim-to-worker handoff an atomic expiring lease
+
+## Pre-flight
+
+- [x] Memory recall: `dispatch lease claim-only machine heartbeat` → no relevant memories returned.
+- [x] Discovery pass: no matching open issue/PR; current claim, ledger, worker lifecycle, and stale-dispatch tests verified.
+- [x] File refs verified: dispatch claim/ledger and worker lifecycle paths exist at HEAD.
+- [x] Tier: `tier:thinking` — cross-machine concurrency and failure recovery require protocol design.
+- [x] Seeded draft PR decision recorded: skipped — protocol changes need test-driven design.
+
+## Origin
+
+- **Created:** 2026-07-11
+- **Created by:** ai-interactive
+- **Blocked by:** none
+- **Conversation context:** Several issues remained assigned and `status:queued` after only a claim comment was posted, while no worker existed. GitHub usernames could not distinguish separate machines using the same account.
+
+## What
+
+Replace the claim/assignment/start gap with an atomic, expiring dispatch lease that records machine identity and transitions to active ownership only after worker readiness is proven.
+
+## Why
+
+Claim-only assignments can suppress all other runners for hours. Human inspection should not be required to determine whether a remote worker exists or whether takeover is safe.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** Requires a backward-compatible cross-runner lease protocol, machine identity, readiness acknowledgment, takeover rules, and race tests.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** The durable source of truth and transition ordering require design judgment.
+- **Status:** not-created
+- **Freshness evidence:** Current dispatch claim, ledger, lifecycle, and stale-recovery paths inspected.
+- **Verification run:** UNVERIFIED — issue composition only.
+- **Stale-assumption warning:** Re-check any task-coordinator work merged after filing.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/dispatch-claim-helper.sh` — issue a bounded pre-launch lease and deterministic takeover markers.
+- `EDIT: .agents/scripts/dispatch-ledger-helper.sh` — persist runner device, session, lease phase, expiry, and readiness evidence.
+- `EDIT: .agents/scripts/worker-lifecycle-common.sh` — acknowledge readiness and emit terminal lease evidence.
+- `EDIT: .agents/scripts/dispatch-dedup-stale.sh` — reverify expired assumptions before takeover.
+- `NEW/EDIT: .agents/scripts/tests/test-dispatch-atomic-lease.sh` — concurrent runners, same-login devices, launch crash, readiness, expiry, and takeover.
+
+### Implementation Steps
+
+1. Define lease phases: pre-launch, ready/active, terminal/released, each with explicit expiry semantics.
+2. Add a stable non-secret machine/device identifier distinct from GitHub login.
+3. Delay durable assignment/queued ownership until readiness, or make pre-launch state automatically reclaimable after a short grace period.
+4. On expiry, recheck process/PR/branch/timeline evidence before takeover; never infer completion from process exit.
+5. Preserve interoperability with older runners and fail closed only for the unsafe action, not the objective.
+6. Add multi-process and same-user/different-device fixtures.
+7. Create a focused-test-passing WIP commit before broad gates.
+
+### Verification
+
+```bash
+bash .agents/scripts/tests/test-dispatch-atomic-lease.sh
+bash .agents/scripts/tests/test-dispatch-claim-helper.sh
+bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+bash .agents/scripts/tests/test-dispatch-ledger-helper.sh
+shellcheck .agents/scripts/dispatch-claim-helper.sh .agents/scripts/dispatch-ledger-helper.sh .agents/scripts/worker-lifecycle-common.sh .agents/scripts/dispatch-dedup-stale.sh
+.agents/scripts/linters-local.sh
+```
+
+## Acceptance Criteria
+
+- [ ] Claim-only launch failures self-release without waiting for human discovery.
+- [ ] Same-login machines are distinguishable in lease and recovery evidence.
+- [ ] Active remote workers remain protected from duplicate dispatch.
+- [ ] Expired leases trigger evidence-based takeover or a scheduled retry, never silent abandonment.
+- [ ] Legacy runner markers remain readable during rollout.
+- [ ] Focused concurrency tests and lint pass.
+
+## Recovery Checkpoint
+
+If interrupted, push protocol fixtures and the documented transition table before broad integration so later workers can resume without guessing lease semantics.

--- a/todo/tasks/t18100-brief.md
+++ b/todo/tasks/t18100-brief.md
@@ -1,0 +1,84 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18100: Normalize issue dependencies before dispatch eligibility
+
+## Pre-flight
+
+- [x] Memory recall: `dependency normalization dispatch eligibility` → no relevant memories returned.
+- [x] Discovery pass: prior dependency fixes reviewed; no matching open issue/PR.
+- [x] File refs verified: issue relationship, dependency graph, and reconcile paths exist at HEAD.
+- [x] Tier: `tier:thinking` — native relationships, textual fallbacks, and status invariants span multiple modules.
+- [x] Seeded draft PR decision recorded: skipped — safest normalization boundary needs design judgment.
+
+## Origin
+
+- **Created:** 2026-07-11
+- **Created by:** ai-interactive
+- **Blocked by:** none
+- **Conversation context:** Eight roadmap children explicitly said `Blocked by #...` but were labelled available and presented as dispatchable. Three workers launched before independently rediscovering the blockers.
+
+## What
+
+Guarantee that unresolved issue dependencies are normalized into native relationships and `status:blocked` before any queue scanner or dispatcher can advertise the issue as available.
+
+## Why
+
+False availability wastes workers and can produce out-of-order implementation against missing contracts. The dependency statement already existed; automation failed to convert it into enforceable state.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** The solution must reconcile native GitHub relationships, body markers, TODO edges, status labels, and eventual unblocking without creating deadlocks.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** Existing relationship paths have several prior edge-case fixes; implementation should select one canonical normalization point after current-code inspection.
+- **Status:** not-created
+- **Freshness evidence:** Target paths and prior dependency issues reviewed.
+- **Verification run:** UNVERIFIED — issue composition only.
+- **Stale-assumption warning:** Re-check recently merged issue-sync and dependency-graph changes.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/issue-sync-relationships.sh` — materialize textual/TODO dependencies as native issue relationships.
+- `EDIT: .agents/scripts/pulse-dep-graph.sh` — fail eligibility closed on positively unresolved dependencies and clear stale blocks only with proof.
+- `EDIT: .agents/scripts/pulse-issue-reconcile-normalize.sh` — enforce mutually exclusive blocked/available state before dispatch scans.
+- `EDIT: .agents/scripts/pulse-check-queue-scan.py` — report dependency-inconsistent availability separately.
+- `NEW/EDIT: .agents/scripts/tests/test-dependency-readiness-normalization.sh` — ordered roadmap fixture and native/text fallback cases.
+
+### Implementation Steps
+
+1. Define precedence: native relationship first, structured marker/TODO edge as repair input, free prose only as bounded compatibility fallback.
+2. Normalize relationships and status before queue eligibility is computed.
+3. Keep the issue blocked when relationship writes fail; record a retryable reason rather than silently exposing it as available.
+4. Automatically unblock only after every declared dependency is positively closed/resolved.
+5. Cover parent-task, missing issue, circular/self-reference, closed native relationship, and concurrent runner cases.
+6. Ensure queue diagnostics distinguish genuinely available from dependency-inconsistent items.
+
+### Verification
+
+```bash
+bash .agents/scripts/tests/test-dependency-readiness-normalization.sh
+bash .agents/scripts/tests/test-pulse-dep-graph-parse.sh
+bash .agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh
+bash .agents/scripts/tests/test-pulse-issue-reconcile.sh
+python3 .agents/scripts/pulse-check-queue-scan.py
+.agents/scripts/linters-local.sh
+```
+
+## Acceptance Criteria
+
+- [ ] An issue with any open declared dependency cannot appear in the available queue.
+- [ ] Missing native relationships are repaired or held with a retryable blocker.
+- [ ] Resolved dependencies unblock automatically without human relabelling.
+- [ ] Textual and native evidence cannot create circular/self-match deadlocks.
+- [ ] Queue diagnostics expose inconsistent state explicitly.
+- [ ] Focused tests and lint pass.
+
+## Recovery Checkpoint
+
+If API or broad-test limits interrupt work, preserve the normalization precedence table, fixtures, and a focused-test-passing WIP commit.

--- a/todo/tasks/t18101-brief.md
+++ b/todo/tasks/t18101-brief.md
@@ -1,0 +1,84 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18101: Repair terminal CI failures in place on existing PR branches
+
+## Pre-flight
+
+- [x] Memory recall: `terminal CI repair existing PR` → no relevant memories returned.
+- [x] Discovery pass: prior CI-routing fix #26045 and current merge feedback paths reviewed; no matching open issue/PR.
+- [x] File refs verified: merge process/feedback and CI repair tests exist at HEAD.
+- [x] Tier: `tier:thinking` — repair routing, trust gates, branch ownership, and dedup require coordinated changes.
+- [x] Seeded draft PR decision recorded: skipped — current failure path must be reproduced before selecting the repair handoff.
+
+## Origin
+
+- **Created:** 2026-07-11
+- **Created by:** ai-interactive
+- **Blocked by:** none
+- **Conversation context:** An approved worker PR had terminal required Lint/Typecheck failures for about an hour, but no CI repair feedback or repair worker was routed. The issue was incorrectly available, inviting duplicate implementation workers.
+
+## What
+
+Route terminal required-check failures to a bounded worker that repairs the existing trusted PR branch, preserving reviews, discussion, and branch context through successful verification and merge.
+
+## Why
+
+Recreating or redispatching the original issue loses context and generates duplicate PRs. Pending checks must remain pending, while terminal failures need immediate autonomous ownership.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** Requires exact failure-state classification, trust checks, branch-scoped dispatch, deduplication, and fallback behavior.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** The existing repair machinery should be repaired rather than bypassed with a speculative seed.
+- **Status:** not-created
+- **Freshness evidence:** Existing merge repair code and tests verified; live incident supplied terminal required-check evidence.
+- **Verification run:** UNVERIFIED — issue composition only.
+- **Stale-assumption warning:** Re-check whether a newer pulse release already routed in-place repairs for interactive-origin worker PRs.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/pulse-merge-process.sh` — classify latest-head required checks and invoke repair exactly once per failing SHA.
+- `EDIT: .agents/scripts/pulse-merge-feedback.sh` — create an in-place PR repair handoff before issue-level close/redispatch fallback.
+- `EDIT: .agents/scripts/worker-lifecycle-common.sh` — support PR-branch-scoped repair sessions and terminal evidence.
+- `EDIT: .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh` — interactive/worker origins, latest SHA, pending vs terminal, dedup, and fallback.
+
+### Implementation Steps
+
+1. Reproduce a trusted approved PR with terminal required failures and no active repair action.
+2. Treat queued/in-progress checks as pending; route only latest-head terminal failures.
+3. Dispatch a bounded worker against the existing PR branch with failed check names/log evidence and verification commands.
+4. Deduplicate by repository, PR, head SHA, and failure fingerprint.
+5. Preserve external-contributor, NMR, workflow-file, and permission trust gates.
+6. Fall back to issue-level routing only when branch repair is impossible, with durable reason and retry path.
+7. Verify successful repair updates the same PR and returns to normal merge processing.
+
+### Verification
+
+```bash
+bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+bash .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+bash .agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
+shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/pulse-merge-feedback.sh .agents/scripts/worker-lifecycle-common.sh
+.agents/scripts/linters-local.sh
+```
+
+## Acceptance Criteria
+
+- [ ] Latest-head terminal required failures receive one in-place repair worker.
+- [ ] Pending checks never trigger duplicate repair.
+- [ ] Reviews, branch, and PR discussion are preserved through repair.
+- [ ] Trust/NMR/external-contributor gates remain fail closed.
+- [ ] Impossible branch repairs fall back with a durable scheduled next action.
+- [ ] Focused tests and lint pass.
+
+## Recovery Checkpoint
+
+Push failure-state fixtures and a WIP commit after focused routing tests pass; record any unverified provider/GitHub behavior separately.

--- a/todo/tasks/t18102-brief.md
+++ b/todo/tasks/t18102-brief.md
@@ -1,0 +1,85 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18102: Deploy CLI, agents, and plugins as one atomic version bundle
+
+## Pre-flight
+
+- [x] Memory recall: `atomic deploy CLI agents version mismatch` → no relevant memories returned.
+- [x] Discovery pass: recent agent deploy and auto-update commits reviewed; no matching open issue/PR.
+- [x] File refs verified: auto-update and setup deploy modules exist at HEAD.
+- [x] Tier: `tier:thinking` — atomic rollout and rollback span installer/runtime boundaries.
+- [x] Seeded draft PR decision recorded: skipped — bundle layout and compatibility window require design judgment.
+
+## Origin
+
+- **Created:** 2026-07-11
+- **Created by:** ai-interactive
+- **Blocked by:** none
+- **Conversation context:** During a batch dispatch the deployed agents changed versions while the CLI remained older. The running command recalculated an invalid nested scripts path and dropped the remaining dispatches.
+
+## What
+
+Deploy the CLI, agents, plugins, generated runtime config, and version metadata as one validated bundle switched atomically, with rollback to the prior complete bundle on failure.
+
+## Why
+
+Hot updates currently expose mixed-version states to long-running pulse and interactive processes. A partial update can break command paths in the middle of a batch and leave work silently unstarted.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** Requires transactional filesystem design, process compatibility, rollback, and cross-platform tests.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** The safest versioned-directory/symlink or manifest approach must be selected after tracing current installers.
+- **Status:** not-created
+- **Freshness evidence:** Current update and deploy module paths verified at HEAD.
+- **Verification run:** UNVERIFIED — issue composition only.
+- **Stale-assumption warning:** Re-check any task-coordinator or setup changes merged after filing.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/auto-update-helper.sh` — stage, validate, atomically activate, and roll back complete bundles.
+- `EDIT: .agents/scripts/setup/modules/agent-deploy.sh` — deploy into a versioned staging target rather than mutating live files piecemeal.
+- `EDIT: .agents/scripts/setup/modules/plugins.sh` — bind plugin generation/activation to the same bundle manifest.
+- `EDIT: .agents/scripts/setup/modules/agent-runtime.sh` — resolve one immutable bundle root per process/session.
+- `NEW/EDIT: .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh` — interrupted deploy, mixed-version prevention, active process, and rollback fixtures.
+
+### Implementation Steps
+
+1. Trace every file/runtime path changed by update and setup.
+2. Define a bundle manifest containing framework, CLI compatibility, agents, plugin/config generation, and integrity evidence.
+3. Stage and validate the complete bundle before one atomic activation operation.
+4. Pin each running pulse/worker/interactive command to its resolved bundle root for its lifetime.
+5. Retain a bounded previous bundle and roll back automatically on validation or activation failure.
+6. Test interruption after every stage and ensure no command observes a partially activated tree.
+7. Create a WIP commit after focused transactional tests pass.
+
+### Verification
+
+```bash
+bash .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+bash .agents/scripts/tests/test-agent-deploy-staging.sh
+bash .agents/scripts/tests/test-agent-auto-sync.sh
+bash .agents/scripts/tests/test-setup-scoped-dispatch.sh
+shellcheck .agents/scripts/auto-update-helper.sh .agents/scripts/setup/modules/agent-deploy.sh .agents/scripts/setup/modules/plugins.sh .agents/scripts/setup/modules/agent-runtime.sh
+.agents/scripts/linters-local.sh
+```
+
+## Acceptance Criteria
+
+- [ ] No process can resolve CLI, agents, or plugins from different activated bundle versions.
+- [ ] Interrupted staging leaves the active bundle unchanged.
+- [ ] Failed activation automatically returns to the last validated bundle.
+- [ ] Long-running workers continue using their original immutable bundle root.
+- [ ] macOS and Linux activation paths are covered.
+- [ ] Focused tests and lint pass.
+
+## Recovery Checkpoint
+
+Before broad setup tests, push the manifest/activation fixtures and document the rollback command and active-bundle resolution contract.

--- a/todo/tasks/t18103-brief.md
+++ b/todo/tasks/t18103-brief.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18103: Reconcile stale objectives with expiring assumptions and durable recovery
+
+## Pre-flight
+
+- [x] Memory recall: `stale objective assumption expiry recovery` → no relevant memories returned.
+- [x] Discovery pass: existing stale dispatch and current-state helpers reviewed; no matching open issue/PR.
+- [x] File refs verified: pulse reconcile, current-state, lifecycle, and stale-dispatch tests exist at HEAD.
+- [x] Tier: `tier:thinking` — introduces a cross-state objective invariant and recovery controller.
+- [x] Seeded draft PR decision recorded: skipped — state model must be designed from current evidence sources.
+
+## Origin
+
+- **Created:** 2026-07-11
+- **Created by:** ai-interactive
+- **Blocked by:** none
+- **Conversation context:** GitHub states repeatedly implied workers or blockers existed when current evidence contradicted them. Recovery depended on a human correlating process, PR, branch, comments, labels, and worktrees.
+
+## What
+
+Add a deterministic objective reconciliation controller that guarantees every open actionable objective has a verified state, bounded assumption, durable next action, and scheduled recovery until completion, cancellation, or demonstrated impossibility.
+
+## Why
+
+Failing closed on one unsafe action must not strand the objective. Dashboards should audit autonomous recovery, not be the primary mechanism by which neglected work is discovered.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** Requires a new state model across issues, workers, PRs, branches, worktrees, dependencies, and recovery evidence.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** A speculative implementation would prematurely choose evidence precedence and recovery semantics.
+- **Status:** not-created
+- **Freshness evidence:** Existing reconcile/current-state/lifecycle paths verified at HEAD.
+- **Verification run:** UNVERIFIED — issue composition only.
+- **Stale-assumption warning:** Coordinate with any task-coordinator or lease protocol merged after filing.
+
+## How (Approach)
+
+### Files to Modify
+
+- `NEW: .agents/scripts/objective-reconciliation-helper.sh` — derive objective state, expiring assumptions, and next actions from durable evidence.
+- `EDIT: .agents/scripts/pulse-issue-reconcile.sh` — invoke bounded reconciliation and apply idempotent repairs.
+- `EDIT: .agents/scripts/pulse-current-state-helper.sh` — expose objectives without next actions and oldest unverified assumptions.
+- `EDIT: .agents/scripts/worker-lifecycle-common.sh` — emit the minimum terminal/recovery evidence required by reconciliation.
+- `NEW: .agents/scripts/tests/test-objective-reconciliation.sh` — exhaustive state-transition fixtures.
+
+### Implementation Steps
+
+1. Define objective states separately from execution-path states: actionable, actively owned, under review, dependency-blocked, authority-blocked, completed, cancelled, impossible.
+2. Require each nonterminal objective to carry evidence timestamp, assumption expiry, next action, trigger/retry time, and responsible automation component.
+3. Reconcile queued issues without leases, leases without processes, review states without PRs, failing PRs without repair, resolved blockers, merged PR/open issue drift, and recovery comments without subsequent action.
+4. Apply a bounded recovery ladder: retry infrastructure, resume worktree/session, recover branch, repair PR, narrow redispatch, model escalation, diagnostic worker, then decision-ready human packet only for true authority blockers.
+5. Preserve commits/logs/verification before cleanup or takeover.
+6. Ensure each repair is idempotent and API-budget bounded.
+7. Add a WIP checkpoint after fixtures pass before live integration tests.
+
+### Verification
+
+```bash
+bash .agents/scripts/tests/test-objective-reconciliation.sh
+bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+bash .agents/scripts/tests/test-pulse-issue-reconcile.sh
+bash .agents/scripts/tests/test-pulse-current-state-helper.sh
+shellcheck .agents/scripts/objective-reconciliation-helper.sh .agents/scripts/pulse-issue-reconcile.sh .agents/scripts/pulse-current-state-helper.sh .agents/scripts/worker-lifecycle-common.sh
+.agents/scripts/linters-local.sh
+```
+
+## Acceptance Criteria
+
+- [ ] Every open actionable objective has a machine-readable next action and retry/trigger.
+- [ ] Assumptions about workers, PRs, dependencies, and human need expire and are reverified.
+- [ ] Safety stops pause only unsafe paths while preserving objective recovery.
+- [ ] Recovery preserves task artifacts before cleanup or takeover.
+- [ ] Repeated reconciliation is idempotent and bounded.
+- [ ] Current-state diagnostics show zero unattended actionable objectives when healthy.
+- [ ] Focused tests and lint pass.
+
+## Recovery Checkpoint
+
+Push the state table, fixtures, and focused-test-passing WIP before wiring live writes; record unresolved evidence-precedence decisions explicitly.

--- a/todo/tasks/t18104-brief.md
+++ b/todo/tasks/t18104-brief.md
@@ -1,0 +1,87 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18104: Automate failure-family remediation and human-gate revalidation
+
+## Pre-flight
+
+- [x] Memory recall: `failure family remediation human gate revalidation` → no relevant memories returned.
+- [x] Discovery pass: pulse-check diagnostics and NMR automation tests reviewed; no matching open issue/PR.
+- [x] File refs verified: pulse-check, worker activity, current state, and NMR paths exist at HEAD.
+- [x] Tier: `tier:thinking` — combines evidence thresholds, deduplicated issue generation, and authority-safe gate revalidation.
+- [x] Seeded draft PR decision recorded: skipped — thresholds and NMR reason schema require design judgment.
+
+## Origin
+
+- **Created:** 2026-07-11
+- **Created by:** ai-interactive
+- **Blocked by:** none
+- **Conversation context:** Worker success was 65% with repeated stall/local-runtime families, while some NMR and blocked states risked becoming passive human queues even when automation could diagnose or repair them.
+
+## What
+
+Continuously cluster worker/pulse failure families into deduplicated worker-ready remediation tasks and periodically revalidate human gates so only genuine authority decisions remain assigned to people.
+
+## Why
+
+Repeated infrastructure failures should improve the system rather than recur indefinitely. Humans should be interrupted only for consequential authority, secrets, destructive actions, billing, or irreducible decisions—not missing diagnostics or automation gaps.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** Requires reliable evidence thresholds, privacy-safe issue generation, reason-coded NMR semantics, and cryptographic-gate preservation.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** The worker must derive thresholds from current metrics and preserve existing trust boundaries.
+- **Status:** not-created
+- **Freshness evidence:** Current diagnostics and NMR files/tests verified at HEAD.
+- **Verification run:** UNVERIFIED — issue composition only.
+- **Stale-assumption warning:** Re-check current failure distribution and any new pulse-check autofile findings.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/worker-activity-helper.sh` — emit stable failure-family fingerprints and recovery outcomes.
+- `EDIT: .agents/scripts/pulse-check-helper.sh` — threshold, deduplicate, and file worker-ready infrastructure remediation issues.
+- `EDIT: .agents/scripts/pulse-nmr-approval.sh` — require reason-coded human authority and schedule revalidation of temporary assumptions.
+- `EDIT: .agents/scripts/pulse-current-state-helper.sh` — expose NMR age/reason and failure-family remediation status.
+- `NEW/EDIT: .agents/scripts/tests/test-failure-family-remediation.sh` — recurrence, dedup, privacy, recovery closure, and NMR revalidation.
+
+### Implementation Steps
+
+1. Define stable privacy-safe fingerprints for watchdog stalls, local runtime errors, launch failures, rate limits, and recovery failures.
+2. File one worker-ready task only when recurrence/confidence thresholds pass; update existing evidence instead of comment-storming.
+3. Track whether the remediation task reduced or eliminated the family and close/supersede it only with outcome evidence.
+4. Add structured NMR reasons separating authority/secret/destructive/billing decisions from transient infrastructure, missing context, or diagnostic ambiguity.
+5. Periodically reverify temporary NMR assumptions; automatically return automatable cases to diagnostic or implementation workers without bypassing cryptographic approvals.
+6. Preserve human gates for genuine authority and emit a concise decision packet with options/evidence.
+7. Add API-budget, rate-limit, and privacy guards.
+
+### Verification
+
+```bash
+bash .agents/scripts/tests/test-failure-family-remediation.sh
+bash .agents/scripts/tests/test-pulse-check-helper.sh
+bash .agents/scripts/tests/test-worker-activity-helper.sh
+bash .agents/scripts/tests/test-pulse-nmr-approval.sh
+bash .agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
+shellcheck .agents/scripts/worker-activity-helper.sh .agents/scripts/pulse-check-helper.sh .agents/scripts/pulse-nmr-approval.sh .agents/scripts/pulse-current-state-helper.sh
+.agents/scripts/linters-local.sh
+```
+
+## Acceptance Criteria
+
+- [ ] Recurrent high-confidence failure families create one deduplicated worker-ready remediation issue.
+- [ ] Remediation outcome is measured before the family is considered solved.
+- [ ] NMR states carry a structured genuine-authority reason or are automatically re-evaluated.
+- [ ] Cryptographic approval and trust boundaries cannot be bypassed by automation.
+- [ ] Humans receive decision-ready packets only for irreducible authority blockers.
+- [ ] Public issues contain aggregate/privacy-safe evidence only.
+- [ ] Focused tests and lint pass.
+
+## Recovery Checkpoint
+
+Before broad gates, push fingerprint/NMR fixtures and a focused-test-passing WIP; record chosen thresholds and any unresolved privacy constraints.


### PR DESCRIPTION
## Summary

- add seven worker-ready self-healing task briefs
- link each TODO entry to its GitHub tracker
- queue all seven tasks for AI-first auto-dispatch at `tier:thinking`

## Verification

- `verify-brief.sh` passed pre-flight completeness for all seven briefs
- `task-dispatchability-helper.sh` reports all seven tasks dispatchable
- issue labels, unassigned state, worker guidance, verification commands, and acceptance criteria verified on GitHub

## Tracking

For #27164
For #27165
For #27166
For #27167
For #27168
For #27169
For #27170

This planning-only PR does not implement or close the leaf issues.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18
