### PR TITLE
GH#27190: fix: harden pulse merge snapshot parsing

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -110,13 +110,16 @@ _pmrc_snapshot_review_threads_clear() {
 			}
 		}
 	' 2>/dev/null) || return 1
-	has_next=$(printf '%s' "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null) || return 1
+	if ! printf '%s' "$response" | jq -e '.data.repository.pullRequest != null' >/dev/null; then
+		return 1
+	fi
+	has_next=$(printf '%s' "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false') || return 1
 	[[ "$has_next" == "false" ]] || return 1
 	count=$(printf '%s' "$response" | jq -r --arg bots "$bot_re" '[
 		.data.repository.pullRequest.reviewThreads.nodes[]?
 		| select((.isResolved // false) == false)
 		| select((.comments.nodes[0].author.login // "") | test($bots; "i"))
-	] | length' 2>/dev/null) || return 1
+	] | length') || return 1
 	[[ "$count" =~ ^[0-9]+$ ]] || return 1
 	if [[ "$count" -gt 0 ]]; then
 		echo "[pulse-merge] pre-merge snapshot: PR #${pr_number} in ${repo_slug} has ${count} unresolved review-bot thread(s) — merge blocked until resolved or classified (GH#27137)" >>"$LOGFILE"
@@ -214,6 +217,7 @@ _pmrc_snapshot_quiet_period_passes() {
 	latest_at=$(jq -nr --argjson checks "$checks_json" --argjson activity "$activity_json" '[
 		($checks[]?.observed_at // ""), ($activity.latest_at // "")
 	] | map(select(. != "")) | max // ""') || return 1
+	[[ -n "$latest_at" ]] || return 0
 	latest_epoch=$(_pmrc_iso_to_epoch "$latest_at") || return 1
 	[[ "$now_epoch" =~ ^[0-9]+$ ]] || return 1
 	age=$((now_epoch - latest_epoch))

--- a/.agents/tests/test-pulse-merge-required-checks.sh
+++ b/.agents/tests/test-pulse-merge-required-checks.sh
@@ -76,9 +76,29 @@ test_ruleset_ref_patterns_fail_closed_on_malformed_schema() {
 	return 0
 }
 
+test_snapshot_review_threads_fail_closed_on_missing_pr_data() {
+	printf '\n=== snapshot review thread fail-closed parsing ===\n'
+	_assert_contains_literal "review threads validate pull request data" \
+		"jq -e '.data.repository.pullRequest != null' >/dev/null"
+	_assert_not_contains_literal "review thread pagination does not hide jq diagnostics" \
+		"jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null"
+	_assert_contains_literal "review thread count preserves jq diagnostics" \
+		"] | length') || return 1"
+	return 0
+}
+
+test_snapshot_quiet_period_allows_no_activity() {
+	printf '\n=== snapshot quiet period without activity ===\n'
+	_assert_contains_literal "empty snapshot activity passes without date parsing" \
+		"[[ -n \"\$latest_at\" ]] || return 0"
+	return 0
+}
+
 main() {
 	test_ruleset_jq_diagnostics_have_safe_log_fallback
 	test_ruleset_ref_patterns_fail_closed_on_malformed_schema
+	test_snapshot_review_threads_fail_closed_on_missing_pr_data
+	test_snapshot_quiet_period_allows_no_activity
 
 	printf '\nSummary: %d passed, %d failed\n' "$TESTS_PASSED" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Fail closed when GraphQL review-thread data is missing, preserve jq parser diagnostics, and allow snapshots with no timestamped activity to pass the quiet-period check. Added regression assertions for both review findings.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/tests/test-pulse-merge-required-checks.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-pulse-merge-required-checks.sh; shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/tests/test-pulse-merge-required-checks.sh; git diff --check

Resolves #27190


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 7m and 46,579 tokens on this as a headless worker.