### PR TITLE
GH#27182: fix: harden CLI convergence paths without HOME

### DIFF
--- a/.agents/scripts/aidevops-cli-converge-helper.sh
+++ b/.agents/scripts/aidevops-cli-converge-helper.sh
@@ -16,8 +16,20 @@ _cli_log() {
 	return 0
 }
 
+_cli_aidevops_path() {
+	local relative_path="$1"
+	local aidevops_dir="${AIDEVOPS_DIR:-${HOME:+$HOME/.aidevops}}"
+	[[ -n "$aidevops_dir" ]] || return 1
+	printf '%s/%s\n' "$aidevops_dir" "$relative_path"
+	return 0
+}
+
 _cli_warning_file() {
-	printf '%s\n' "${AIDEVOPS_CLI_WARNING_FILE:-${AIDEVOPS_DIR:-$HOME/.aidevops}/logs/cli-convergence-warning.txt}"
+	if [[ -n "${AIDEVOPS_CLI_WARNING_FILE:-}" ]]; then
+		printf '%s\n' "$AIDEVOPS_CLI_WARNING_FILE"
+		return 0
+	fi
+	_cli_aidevops_path "logs/cli-convergence-warning.txt" || return 1
 	return 0
 }
 
@@ -44,7 +56,8 @@ _cli_clear_warning() {
 }
 
 _cli_release_lock() {
-	local lock_dir="${AIDEVOPS_CLI_LOCK_DIR:-${AIDEVOPS_DIR:-$HOME/.aidevops}/locks/cli-launcher.lock}"
+	local lock_dir="${AIDEVOPS_CLI_LOCK_DIR:-}"
+	[[ -n "$lock_dir" ]] || lock_dir=$(_cli_aidevops_path "locks/cli-launcher.lock") || return 0
 	local owner_pid=""
 	local owner_token=""
 	if [[ "$_CLI_LOCK_OWNED" == "true" && -r "$lock_dir/initialized" ]]; then
@@ -215,7 +228,8 @@ _cli_try_reclaim_lock() {
 }
 
 _cli_acquire_lock() {
-	local lock_dir="${AIDEVOPS_CLI_LOCK_DIR:-${AIDEVOPS_DIR:-$HOME/.aidevops}/locks/cli-launcher.lock}"
+	local lock_dir="${AIDEVOPS_CLI_LOCK_DIR:-}"
+	[[ -n "$lock_dir" ]] || lock_dir=$(_cli_aidevops_path "locks/cli-launcher.lock") || return 1
 	local lock_parent="${lock_dir%/*}"
 	local wait_seconds="${AIDEVOPS_CLI_LOCK_WAIT_SECONDS:-30}"
 	local incomplete_grace="${AIDEVOPS_CLI_INCOMPLETE_GRACE_SECONDS:-2}"
@@ -346,7 +360,7 @@ _cli_converge_locked() {
 	local orchestrator_target="$3"
 	local version_file="$4"
 	local global_target="${AIDEVOPS_CLI_GLOBAL_TARGET:-/usr/local/bin/aidevops}"
-	local user_target="${AIDEVOPS_CLI_USER_TARGET:-$HOME/.local/bin/aidevops}"
+	local user_target="${AIDEVOPS_CLI_USER_TARGET:-${HOME:+$HOME/.local/bin/aidevops}}"
 	local global_dir="${global_target%/*}"
 	local non_interactive="${AIDEVOPS_CLI_NON_INTERACTIVE:-true}"
 

--- a/.agents/scripts/tests/test-aidevops-cli-convergence.sh
+++ b/.agents/scripts/tests/test-aidevops-cli-convergence.sh
@@ -292,6 +292,23 @@ EOF
 	return 0
 }
 
+test_unset_home_does_not_resolve_root_paths() {
+	local fixture="$TEST_ROOT/unset-home"
+	local output=""
+	make_fixture "$fixture"
+	if output=$(env -u HOME -u AIDEVOPS_DIR -u AIDEVOPS_CLI_WARNING_FILE \
+		-u AIDEVOPS_CLI_LOCK_DIR -u AIDEVOPS_CLI_USER_TARGET \
+		"$HELPER" converge "$fixture/launcher" "$fixture/orchestrator-source" \
+		"$fixture/orchestrator-target" "$fixture/home/.aidevops/agents/VERSION" 2>&1); then
+		fail "unset HOME does not resolve root paths" "unexpected convergence success"
+	elif [[ "$output" == *"unbound variable"* || "$output" == /* ]]; then
+		fail "unset HOME does not resolve root paths" "$output"
+	else
+		pass "unset HOME does not resolve root paths"
+	fi
+	return 0
+}
+
 main() {
 	test_already_current
 	test_lock_covers_orchestrator_copy
@@ -305,6 +322,7 @@ main() {
 	test_non_executable_targets_repaired
 	test_lock_contention_and_idempotency
 	test_user_fallback_shadowed
+	test_unset_home_does_not_resolve_root_paths
 	printf 'Results: %s passed, %s failed\n' "$PASS_COUNT" "$FAIL_COUNT"
 	[[ "$FAIL_COUNT" -eq 0 ]]
 	return $?


### PR DESCRIPTION
## Summary

Prevent CLI warning, lock, and user launcher defaults from resolving beneath the filesystem root when HOME is unset; add regression coverage for the unset-HOME execution path.

## Files Changed

.agents/scripts/aidevops-cli-converge-helper.sh, .agents/scripts/tests/test-aidevops-cli-convergence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-aidevops-cli-convergence.sh; shellcheck .agents/scripts/aidevops-cli-converge-helper.sh .agents/scripts/tests/test-aidevops-cli-convergence.sh; git diff --check

Resolves #27182


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 8m and 54,735 tokens on this as a headless worker.