### PR TITLE
GH#27185: fix: guard unset release repo root

### DIFF
--- a/.agents/scripts/tests/test-version-manager-release-repo-root.sh
+++ b/.agents/scripts/tests/test-version-manager-release-repo-root.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression test for unset REPO_ROOT handling in hotfix tag creation.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+RELEASE_HELPER="${SCRIPT_DIR}/../version-manager-release.sh"
+
+print_error() {
+	local message="$1"
+	printf '%s\n' "$message"
+	return 0
+}
+
+# shellcheck source=../version-manager-release.sh
+source "$RELEASE_HELPER"
+unset REPO_ROOT
+
+output="$(_create_hotfix_tag "1.2.3" 2>&1)"
+status=$?
+
+if [[ "$status" -ne 1 ]]; then
+	printf 'FAIL: expected status 1 with unset REPO_ROOT, got %s\n' "$status"
+	exit 1
+fi
+
+if [[ "$output" != *"REPO_ROOT is not set"* ]]; then
+	printf 'FAIL: expected missing REPO_ROOT diagnostic, got: %s\n' "$output"
+	exit 1
+fi
+
+printf 'PASS: unset REPO_ROOT returns a controlled error under set -u\n'
+exit 0

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -291,8 +291,13 @@ _verify_maintainer_identity() {
 _create_hotfix_tag() {
 	local version="$1"
 	local hotfix_tag="hotfix-v${version}"
+	local repo_root="${REPO_ROOT:-}"
 
-	cd "$REPO_ROOT" || return 1
+	if [[ -z "$repo_root" ]]; then
+		print_error "Cannot create hotfix tag: REPO_ROOT is not set"
+		return 1
+	fi
+	cd "$repo_root" || return 1
 
 	local remote_tag_exit=0
 	git ls-remote -q --exit-code --tags origin "refs/tags/$hotfix_tag" >/dev/null 2>&1 || remote_tag_exit=$?


### PR DESCRIPTION
## Summary

Guard hotfix tag creation against an unset REPO_ROOT and add a nounset regression test.

## Files Changed

.agents/scripts/tests/test-version-manager-release-repo-root.sh, .agents/scripts/version-manager-release.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-version-manager-release-repo-root.sh; shellcheck .agents/scripts/version-manager-release.sh .agents/scripts/tests/test-version-manager-release-repo-root.sh; .agents/scripts/linters-local.sh

Resolves #27185


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 7m and 38,502 tokens on this as a headless worker.