### PR TITLE
GH#27210: fix: guard unset headless launch state

### DIFF
--- a/.agents/scripts/headless-runtime-launch.sh
+++ b/.agents/scripts/headless-runtime-launch.sh
@@ -65,7 +65,7 @@ _cleanup_headless_runtime_temp_paths() {
 			;;
 		esac
 	done <<EOF
-$_HEADLESS_RUNTIME_TEMP_PATHS
+${_HEADLESS_RUNTIME_TEMP_PATHS:-}
 EOF
 	_HEADLESS_RUNTIME_TEMP_PATHS=""
 	return 0
@@ -191,26 +191,26 @@ _parse_run_args() {
 # _validate_run_args: check required fields and resolve prompt from file if needed.
 # Operates on caller-scoped variables set by _parse_run_args.
 _validate_run_args() {
-	[[ -n "$session_key" ]] || {
+	[[ -n "${session_key:-}" ]] || {
 		print_error "run requires --session-key"
 		return 1
 	}
-	[[ -n "$work_dir" ]] || {
+	[[ -n "${work_dir:-}" ]] || {
 		print_error "run requires --dir"
 		return 1
 	}
-	[[ -n "$title" ]] || {
+	[[ -n "${title:-}" ]] || {
 		print_error "run requires --title"
 		return 1
 	}
-	if [[ -z "$prompt" && -n "$prompt_file" ]]; then
-		[[ -f "$prompt_file" ]] || {
-			print_error "Prompt file not found: $prompt_file"
+	if [[ -z "${prompt:-}" && -n "${prompt_file:-}" ]]; then
+		[[ -f "${prompt_file:-}" ]] || {
+			print_error "Prompt file not found: ${prompt_file:-}"
 			return 1
 		}
-		prompt=$(<"$prompt_file")
+		prompt=$(<"${prompt_file:-}")
 	fi
-	[[ -n "$prompt" ]] || {
+	[[ -n "${prompt:-}" ]] || {
 		print_error "run requires --prompt or --prompt-file"
 		return 1
 	}

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1846,6 +1846,20 @@ test_registered_prompt_temp_cleanup_removes_dir() {
 	return 0
 }
 
+test_launch_helpers_tolerate_unset_state() {
+	unset _HEADLESS_RUNTIME_TEMP_PATHS session_key work_dir title prompt prompt_file
+
+	if _cleanup_headless_runtime_temp_paths &&
+		! _validate_run_args >/dev/null 2>&1; then
+		print_result "launch helpers tolerate unset state under nounset" 0
+		return 0
+	fi
+
+	print_result "launch helpers tolerate unset state under nounset" 1 \
+		"Expected cleanup to succeed and validation to report missing arguments"
+	return 0
+}
+
 # Helper: create a bare git repo and a feature branch with optional commits.
 # Each call uses work_dir-derived remote path to avoid inter-test collisions.
 # Args: $1 = work_dir path, $2 = 1 to add a commit (0 for none)
@@ -2769,6 +2783,7 @@ main() {
 	test_large_opencode_prompt_uses_file_attachment
 	test_large_claude_prompt_uses_stdin_file
 	test_registered_prompt_temp_cleanup_removes_dir
+	test_launch_helpers_tolerate_unset_state
 	test_worker_produced_output_no_commits_returns_noop
 	test_worker_produced_output_with_commits_returns_pr_exists_failopen
 	test_worker_produced_output_non_worker_session_returns_pr_exists


### PR DESCRIPTION
## Summary

Guard headless runtime cleanup and argument validation against unset shell variables under nounset, with regression coverage.

## Files Changed

.agents/scripts/headless-runtime-launch.sh, .agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/headless-runtime-launch.sh .agents/scripts/tests/test-headless-runtime-helper.sh; full helper suite reached existing canonical Git guard after initial passes

Resolves #27210


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 5m and 32,268 tokens on this as a headless worker.