### PR TITLE
GH#27187: fix: harden quality sweep SARIF parsing

### DIFF
--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -734,7 +734,7 @@ _create_simplification_issues() {
 	[[ "$smell_threshold" =~ ^[0-9]+$ ]] || smell_threshold=0
 	actual_count=$(printf '%s\n' "$sarif_json" | jq -r '.runs[0].results | length' 2>/dev/null || true)
 	[[ "$actual_count" =~ ^[0-9]+$ ]] || {
-		echo "[stats] Qlty remediation: invalid SARIF count for ${repo_slug}; skipping" >>"$LOGFILE"
+		echo "[stats] Qlty remediation: invalid SARIF count for ${repo_slug}; skipping" >>"${LOGFILE:-/dev/null}"
 		printf '%s' "$issues_created"
 		return 0
 	}
@@ -744,7 +744,7 @@ _create_simplification_issues() {
 		smell_deficit=$((actual_count - smell_threshold))
 	fi
 	if [[ "$smell_deficit" -le 0 ]]; then
-		echo "[stats] Qlty remediation: actual=${actual_count} threshold=${smell_threshold} deficit=0; no repair required" >>"$LOGFILE"
+		echo "[stats] Qlty remediation: actual=${actual_count} threshold=${smell_threshold} deficit=0; no repair required" >>"${LOGFILE:-/dev/null}"
 		printf '%s' "$issues_created"
 		return 0
 	fi
@@ -782,7 +782,7 @@ _create_simplification_issues() {
 		fi
 	done <<<"$smell_files"
 
-	echo "[stats] Qlty remediation: actual=${actual_count} threshold=${smell_threshold} deficit=${smell_deficit} issues_created=${issues_created} smells_scheduled=${smells_scheduled}" >>"$LOGFILE"
+	echo "[stats] Qlty remediation: actual=${actual_count} threshold=${smell_threshold} deficit=${smell_deficit} issues_created=${issues_created} smells_scheduled=${smells_scheduled}" >>"${LOGFILE:-/dev/null}"
 	printf '%s' "$issues_created"
 	return 0
 }
@@ -815,7 +815,7 @@ _smell_files_from_sarif() {
 	local sarif_json="$1"
 
 	printf '%s\n' "$sarif_json" | jq -r '
-		[.runs[0].results[] | .locations[0].physicalLocation.artifactLocation.uri |
+		[.runs[0].results[]? | .locations[0]?.physicalLocation.artifactLocation.uri? |
 		 select(type == "string" and length > 0)] |
 		group_by(.) | map({file: .[0], count: length}) |
 		sort_by([-.count, .file]) |

--- a/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
@@ -110,6 +110,17 @@ JSON
 	return 0
 }
 
+make_partially_unlocated_sarif() {
+	cat <<'JSON'
+{"runs":[{"results":[
+{"ruleId":"metadata-only"},
+{"ruleId":"empty-locations","locations":[]},
+{"ruleId":"complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/foo.py"}}}]}
+]}]}
+JSON
+	return 0
+}
+
 printf '\n[a] trusted repo writer skips NMR\n'
 true >"$CREATE_CALLS"
 true >"$COUNT_FILE"
@@ -142,6 +153,22 @@ if [[ "${qlty_section:-}" == "caller-owned-section" ]]; then
 	pass "simplification-no-caller-qlty-section-mutation"
 else
 	fail "simplification-no-caller-qlty-section-mutation" "caller qlty_section mutated to: ${qlty_section:-<unset>}"
+fi
+
+printf '\n[a.1] incomplete SARIF locations are ignored\n'
+smell_files=$(_smell_files_from_sarif "$(make_partially_unlocated_sarif)")
+if [[ "$smell_files" == $'1\tsrc/foo.py' ]]; then
+	pass "incomplete-sarif-locations-ignored"
+else
+	fail "incomplete-sarif-locations-ignored" "expected only src/foo.py, got: ${smell_files:-<empty>}"
+fi
+
+printf '\n[a.2] optional logfile is nounset-safe\n'
+if (unset LOGFILE; _create_simplification_issues "test/repo" '{}' >/dev/null) &&
+	(unset LOGFILE; _create_simplification_issues "test/repo" "$(make_sarif)" 3 >/dev/null); then
+	pass "optional-logfile-nounset-safe"
+else
+	fail "optional-logfile-nounset-safe" "LOGFILE fallback failed under set -u"
 fi
 
 printf '\n[b] unverified identity keeps NMR\n'


### PR DESCRIPTION
## Summary

Ignore SARIF results without physical locations, make remediation logging safe when LOGFILE is unset, and add regression coverage for both cases.

## Files Changed

.agents/scripts/stats-quality-sweep.sh, .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh; shellcheck .agents/scripts/stats-quality-sweep.sh .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh; .agents/scripts/linters-local.sh

Resolves #27187


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 7m and 45,164 tokens on this as a headless worker.