### PR TITLE
GH#27177: fix: harden setup agents path fallback

### DIFF
--- a/.agents/scripts/tests/test-setup-aidevops-cli-install.sh
+++ b/.agents/scripts/tests/test-setup-aidevops-cli-install.sh
@@ -17,9 +17,8 @@ print_warning() { return 0; }
 # shellcheck source=../setup/modules/config.sh
 source "$CONFIG_LIB"
 
-# Exercise setup.sh itself with its default environment, rather than only
-# injecting globals before sourcing the config module. The trace proves the
-# default agents root exists and is exported before setup modules are loaded.
+# Exercise setup.sh itself with both its normal default and an unset HOME.
+# The latter must not synthesize the privileged root-level /.aidevops path.
 setup_home="$TEST_DIR/setup-home"
 mkdir -p "$setup_home"
 setup_trace=$(env -u AGENTS_DIR -u AIDEVOPS_AGENTS_DIR HOME="$setup_home" \
@@ -29,7 +28,13 @@ if [[ "$setup_trace" != *"AGENTS_DIR=$setup_home/.aidevops/agents"* ||
 	printf 'FAIL: setup.sh did not define and export the default AGENTS_DIR\n' >&2
 	exit 1
 fi
-printf 'PASS: setup.sh defines and exports its default AGENTS_DIR before module use\n'
+unset_home_trace=$(env -u AGENTS_DIR -u AIDEVOPS_AGENTS_DIR -u HOME \
+	bash -x "$REPO_ROOT/setup.sh" --help 2>&1)
+if [[ "$unset_home_trace" != *"AGENTS_DIR="* || "$unset_home_trace" == *"AGENTS_DIR=/.aidevops/agents"* ]]; then
+	printf 'FAIL: setup.sh synthesized a root-level AGENTS_DIR with HOME unset\n' >&2
+	exit 1
+fi
+printf 'PASS: setup.sh exports a safe default AGENTS_DIR\n'
 
 source_cli="$TEST_DIR/source-cli"
 target_cli="$TEST_DIR/bin/aidevops"

--- a/setup.sh
+++ b/setup.sh
@@ -68,7 +68,7 @@ REPO_URL="https://github.com/marcusquinn/aidevops.git"
 # INSTALL_DIR: resolve from the directory where setup.sh is executed (supports worktrees)
 # For bootstrap (curl install), this will be /dev/fd/NN and trigger re-exec after clone
 INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}"
+AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-${HOME:+$HOME/.aidevops/agents}}"
 export REPO_URL INSTALL_DIR AGENTS_DIR
 
 # Source modular setup functions (t316.2)


### PR DESCRIPTION
## Summary

Use HOME's alternate-value expansion for setup's default AGENTS_DIR so an unset or empty HOME cannot resolve to the root-level /.aidevops/agents path. Extend the setup regression test to cover unset HOME while retaining normal default-path and export assertions.

## Files Changed

.agents/scripts/tests/test-setup-aidevops-cli-install.sh, setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-setup-aidevops-cli-install.sh; bash -n setup.sh .agents/scripts/tests/test-setup-aidevops-cli-install.sh; shellcheck setup.sh .agents/scripts/tests/test-setup-aidevops-cli-install.sh; git diff --check

Resolves #27177


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 6m and 58,041 tokens on this as a headless worker.