### PR TITLE
GH#27183: make agent sync test PATH portable

### DIFF
--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -81,8 +81,8 @@ create_fake_repo() {
 	local repo_path="$TEST_DIR/$repo_name"
 
 	mkdir -p "$repo_path"
-	PATH=/usr/bin:/bin git init -q "$repo_path"
-	PATH=/usr/bin:/bin git -C "$repo_path" remote add origin "$remote_url"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git init -q "$repo_path"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" remote add origin "$remote_url"
 	printf '%s\n' "$repo_path"
 	return 0
 }


### PR DESCRIPTION
## Summary

- Extend the isolated Git `PATH` in the agent auto-sync test with common local and Homebrew binary directories.
- Preserve deterministic command lookup while supporting macOS Homebrew installations.

## Testing

- `bash .agents/scripts/tests/test-agent-auto-sync.sh` (5/5 passed)
- `shellcheck .agents/scripts/tests/test-agent-auto-sync.sh`
- `git diff --check`

## Runtime Testing

Self-assessed: low-risk test-only portability change, covered by the regression test suite.

Resolves #27183

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.31 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 41,615 tokens on this as a headless worker.
