### PR TITLE
GH#27199: fix: resolve launcher home under sudo

### DIFF
--- a/bin/aidevops
+++ b/bin/aidevops
@@ -13,9 +13,24 @@
 
 set -euo pipefail
 
-REPO_DIR="$HOME/Git/aidevops"
+REAL_HOME="$HOME"
+if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
+	_tmp_real_home=""
+	if command -v getent &>/dev/null; then
+		_tmp_real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+	elif command -v dscl &>/dev/null; then
+		_tmp_real_home=$(dscl . -read "/Users/${SUDO_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2; exit}' || true)
+	elif [[ -d "/Users/${SUDO_USER}" ]]; then
+		_tmp_real_home="/Users/${SUDO_USER}"
+	fi
+	if [[ -n "$_tmp_real_home" ]]; then
+		REAL_HOME="$_tmp_real_home"
+	fi
+fi
+
+REPO_DIR="${REAL_HOME:+$REAL_HOME/Git/aidevops}"
 REPO_URL="https://github.com/marcusquinn/aidevops.git"
-DEPLOYED_CLI="$HOME/.aidevops/agents/aidevops.sh"
+DEPLOYED_CLI="${REAL_HOME:+$REAL_HOME/.aidevops/agents/aidevops.sh}"
 
 # 1. Prefer the setup-deployed copy. It is released atomically with its modules,
 # so a stale or dirty canonical checkout cannot split the CLI version from them.
@@ -30,7 +45,7 @@ fi
 
 # 3. Git repo not found — bootstrap it automatically
 # This runs once on first use after a package manager install (npm/brew/bun).
-# After this, step 1 will always match and the git repo runs directly.
+# After this, step 1 will always match and the deployed copy runs directly.
 if command -v git >/dev/null 2>&1; then
     echo "[aidevops] First run — cloning git repo to $REPO_DIR for transparent updates..."
     mkdir -p "$(dirname "$REPO_DIR")"

--- a/tests/test-cli-deployment-coherence.sh
+++ b/tests/test-cli-deployment-coherence.sh
@@ -6,7 +6,7 @@ TEST_HOME=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME"' EXIT
 
 # shellcheck disable=SC2016
-grep -q 'DEPLOYED_CLI="$HOME/.aidevops/agents/aidevops.sh"' "$REPO_DIR/bin/aidevops"
+grep -q 'DEPLOYED_CLI="${REAL_HOME:+$REAL_HOME/.aidevops/agents/aidevops.sh}"' "$REPO_DIR/bin/aidevops"
 # shellcheck disable=SC2016
 grep -q '"$convergence_helper" converge "$cli_source" "$orchestrator_source" "$deployed_cli" "$deployed_version"' \
 	"$REPO_DIR/.agents/scripts/setup/modules/config.sh"
@@ -36,5 +36,21 @@ result=$(cd "$TEST_HOME" && HOME="$TEST_HOME" PATH="$TEST_HOME/bin:/usr/bin:/bin
 	printf 'FAIL: real deployed CLI selected %s\n' "$result" >&2
 	exit 1
 }
+
+MOCK_BIN="$TEST_HOME/mock-bin"
+REAL_USER_HOME="$TEST_HOME/real-user"
+mkdir -p "$MOCK_BIN" "$REAL_USER_HOME/.aidevops/agents"
+printf '#!/usr/bin/env bash\nprintf "0\\n"\n' >"$MOCK_BIN/id"
+printf '#!/usr/bin/env bash\nprintf "worker:x:501:20::%s:/bin/bash\\n"\n' "$REAL_USER_HOME" >"$MOCK_BIN/getent"
+chmod +x "$MOCK_BIN/id" "$MOCK_BIN/getent"
+# shellcheck disable=SC2016
+printf '#!/usr/bin/env bash\nprintf "sudo-deployed:%%s\\n" "$1"\n' >"$REAL_USER_HOME/.aidevops/agents/aidevops.sh"
+result=$(PATH="$MOCK_BIN:$PATH" HOME="/root" SUDO_USER="worker" bash "$REPO_DIR/bin/aidevops" version-check)
+[[ "$result" == "sudo-deployed:version-check" ]] || {
+	printf 'FAIL: sudo launcher selected %s\n' "$result" >&2
+	exit 1
+}
+
+grep -q 'After this, step 1 will always match and the deployed copy runs directly.' "$REPO_DIR/bin/aidevops"
 
 printf 'PASS: CLI launcher, orchestrator, and clean update checkout remain coherent\n'


### PR DESCRIPTION
## Summary

Resolve the package-manager launcher home from SUDO_USER before selecting deployed or canonical copies, use empty-safe path expansion, correct the bootstrap comment, and cover sudo routing with a regression test.

## Files Changed

bin/aidevops, tests/test-cli-deployment-coherence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash tests/test-cli-deployment-coherence.sh; shellcheck bin/aidevops tests/test-cli-deployment-coherence.sh; git diff --check

Resolves #27199


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 8m and 41,319 tokens on this as a headless worker.