### PR TITLE
GH#27188: filter deferred review acknowledgements

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -39,6 +39,7 @@ _build_inline_findings() {
 				"(?s:\\bthank you for the update\\b.*?\\busing\\b.*?\\bconsistently\\b.*?\\bcorrect approach\\b.*?\\bverification steps\\b.*?\\bconfidence\\b)|" +
 				"(?s:\\bthank you for the clarification\\b.*?\\byou are (absolutely )?correct\\b.*?\\bproperly managed\\b.*?\\bcleanup routines?\\b)|" +
 				"(?s:\\bthank you for the clarification\\b.*?\\byou are (absolutely )?correct\\b.*?\\bissue is (indeed )?resolved\\b)|" +
+				"(?s:\\bi agree\\b.*?\\bcan be deferred\\b.*?\\brefrain from further comments?\\b)|" +
 				"\\bno further concerns?\\b|" +
 				"\\bno further feedback\\b|" +
 				"\\bno further recommendations?\\b|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -873,6 +873,10 @@ test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
 	_assert_scan_single_pr_has_no_findings "1" \
 		"issue #26770 positive inline guard-check acknowledgement is filtered"
 
+	acknowledgement_body="I understand your point regarding the scope of this PR. Since the test fixture setup is isolated and currently functioning as intended in your environment, I agree that further hardening of the path normalization can be deferred to a dedicated task. I will refrain from further comments on this thread."
+	_assert_scan_single_pr_has_no_findings "1" \
+		"issue #27188 deferred-scope acknowledgement is filtered"
+
 	gh() {
 		local command="$1"
 		shift


### PR DESCRIPTION
## Summary

- Treat explicit agreement to defer scope followed by a no-more-comments statement as review-thread closure.
- Add the exact PR #27157 acknowledgement as a regression fixture.

## Testing

- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh` (79/79)
- `shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-scan.sh`
- `git diff --check`

## Runtime Testing

- Self-assessed: low-risk scanner filter and regression-test change.

## Key decision

The filter requires agreement, explicit deferral, and reviewer closure together so actionable deferral proposals are not broadly suppressed.

Resolves #27188

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.31 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 61,085 tokens on this as a headless worker.
