### PR TITLE
GH#27181: Ignore resolved review threads in quality scans

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -462,6 +462,28 @@ _log_debug_skipped_summaries() {
 }
 
 #######################################
+# Return database IDs for inline comments in resolved review threads.
+# GitHub's REST review-comment response does not expose thread resolution, so
+# use GraphQL as a best-effort supplement. API failures preserve the existing
+# REST-only behaviour rather than aborting the scan.
+# Arguments: $1=repo slug $2=PR number
+# Output: JSON array of numeric comment IDs
+_resolved_review_comment_ids() {
+	local repo_slug="$1"
+	local pr_num="$2"
+	local owner="${repo_slug%%/*}"
+	local repo="${repo_slug#*/}"
+
+	# shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub, not the shell.
+	gh api graphql \
+		-f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved comments(first:100){nodes{databaseId}}}}}}}' \
+		-f owner="$owner" -f repo="$repo" -F pr="$pr_num" \
+		--jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved) | .comments.nodes[].databaseId]' \
+		2>/dev/null || printf '[]\n'
+	return 0
+}
+
+#######################################
 # Scan a single merged PR for review feedback
 #
 # Fetches both inline review comments and review bodies from all
@@ -491,6 +513,10 @@ _scan_single_pr() {
 	local comments
 	comments=$(gh api "repos/${repo_slug}/pulls/${pr_num}/comments" \
 		--paginate --jq '.' | jq -s 'add // []') || comments="[]"
+	local resolved_comment_ids
+	resolved_comment_ids=$(_resolved_review_comment_ids "$repo_slug" "$pr_num")
+	comments=$(printf '%s' "$comments" | jq --argjson resolved "$resolved_comment_ids" \
+		'[.[] | select((.id as $id | $resolved | index($id)) == null)]') || comments="[]"
 
 	# --- Fetch review bodies (top-level reviews) ---
 	local reviews

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -916,6 +916,60 @@ test_scan_single_pr_filters_positive_inline_acknowledgement_reply() {
 	return 0
 }
 
+test_scan_single_pr_filters_resolved_review_threads() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			if [[ "${1:-}" == "graphql" ]]; then
+				# The real gh invocation applies --jq and emits only resolved IDs.
+				echo '[10]'
+				return 0
+			fi
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+				repos/*/pulls/*/comments)
+					echo '[{"id":10,"user":{"login":"gemini-code-assist[bot]"},"path":"src/foo.sh","line":null,"original_line":5,"body":"You should add error handling here.","html_url":"https://github.com/example/repo/pull/1#discussion_r10"},{"id":11,"user":{"login":"gemini-code-assist[bot]"},"path":"src/foo.sh","line":6,"original_line":6,"body":"You should validate this input.","html_url":"https://github.com/example/repo/pull/1#discussion_r11"}]'
+					return 0
+					;;
+				repos/*/pulls/*/reviews)
+					echo '[]'
+					return 0
+					;;
+				repos/*/git/trees/*)
+					echo '["src/foo.sh"]'
+					return 0
+					;;
+				repos/*)
+					echo "main"
+					return 0
+					;;
+				esac
+				shift
+			done
+			return 0
+			;;
+		label | pr) return 0 ;;
+		esac
+		return 1
+	}
+
+	local findings ids
+	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
+	ids=$(printf '%s' "$findings" | jq -r '[.[].url] | join(",")')
+	if [[ "$ids" == *"discussion_r11"* && "$ids" != *"discussion_r10"* ]]; then
+		print_result "resolved review threads are excluded from quality debt" 0
+	else
+		print_result "resolved review threads are excluded from quality debt" 1 "unexpected findings: ${findings}"
+	fi
+
+	_restore_mock_gh
+	return 0
+}
+
 test_scan_single_pr_filters_parent_of_resolution_reply() {
 	reset_mock_state
 

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -205,6 +205,7 @@ run_positive_review_filter_regressions() {
 	test_scan_single_pr_positive_body_with_inline_comments_not_summary_only
 	test_scan_single_pr_filters_positive_inline_acknowledgement_reply
 	test_scan_single_pr_filters_parent_of_resolution_reply
+	test_scan_single_pr_filters_resolved_review_threads
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Exclude inline comments whose GitHub review threads are already resolved.
- Preserve REST-only scan behaviour if the supplemental GraphQL lookup fails.
- Add a regression covering mixed resolved and unresolved inline findings.

The two findings reported in #27181 are already fixed in `session_time_db.py`, and their source review threads are resolved. This change prevents the quality-debt scanner from recreating such stale work.

## Verification

- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh` (79/79 passed)
- `shellcheck .agents/scripts/quality-feedback-findings-lib.sh .agents/scripts/tests/test-quality-feedback-main-verification-scan.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `git diff --check origin/main...HEAD`

Resolves #27181

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.32 plugin for [OpenCode](https://opencode.ai) v1.17.18
