### PR TITLE
t18090: feat: enforce worker process-tree egress contract

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -216,9 +216,9 @@ _invoke_opencode() {
 			# a temp file and replays it after exit — the watchdog sees nothing
 			# and kills every sandboxed worker at ~93s.
 			if [[ -n "$passthrough_csv" ]]; then
-				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --passthrough "$passthrough_csv" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
+				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --egress-mode "${AIDEVOPS_WORKER_EGRESS_MODE:-auto}" --worker-id "${AIDEVOPS_WORKER_ID:-${_invoke_session_key:-headless}}" --passthrough "$passthrough_csv" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			else
-				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
+				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --egress-mode "${AIDEVOPS_WORKER_EGRESS_MODE:-auto}" --worker-id "${AIDEVOPS_WORKER_ID:-${_invoke_session_key:-headless}}" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			fi
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		else

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -189,6 +189,8 @@ _invoke_opencode() {
 	# way to separate tee output from the exit code in a single $()).
 	(
 		set +e
+		local egress_mode="${AIDEVOPS_WORKER_EGRESS_MODE:-auto}"
+		local egress_worker_id="${AIDEVOPS_WORKER_ID:-${_invoke_session_key:-headless}}"
 		# Inject --print-logs for headless workers so opencode's internal Go logs
 		# (API errors, model resolution, DB writes) appear in the worker log.
 		# This is critical for diagnosing silent exits — the JSON event stream
@@ -216,12 +218,17 @@ _invoke_opencode() {
 			# a temp file and replays it after exit — the watchdog sees nothing
 			# and kills every sandboxed worker at ~93s.
 			if [[ -n "$passthrough_csv" ]]; then
-				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --egress-mode "${AIDEVOPS_WORKER_EGRESS_MODE:-auto}" --worker-id "${AIDEVOPS_WORKER_ID:-${_invoke_session_key:-headless}}" --passthrough "$passthrough_csv" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
+				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --egress-mode "$egress_mode" --worker-id "$egress_worker_id" --passthrough "$passthrough_csv" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			else
-				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --egress-mode "${AIDEVOPS_WORKER_EGRESS_MODE:-auto}" --worker-id "${AIDEVOPS_WORKER_ID:-${_invoke_session_key:-headless}}" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
+				run_without_opencode_session_env "$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --stream-stdout --egress-mode "$egress_mode" --worker-id "$egress_worker_id" -- "${_oc_cmd[@]}" 2>&1 | tee "$output_file"
 			fi
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		else
+			if [[ "$egress_mode" == "required" ]]; then
+				print_error "Whole-process worker egress is required, but the sandbox launcher is disabled or unavailable"
+				printf '%s' "126" >"$exit_code_file"
+				exit 126
+			fi
 			if [[ "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" == "1" ]]; then
 				print_info "AIDEVOPS_HEADLESS_SANDBOX_DISABLED=1 — using bare timeout (no privilege isolation) (GH#20146 audit)"
 			fi

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -241,6 +241,8 @@ _invoke_claude() {
 
 	(
 		set +e
+		local egress_mode="${AIDEVOPS_WORKER_EGRESS_MODE:-auto}"
+		local egress_worker_id="${AIDEVOPS_WORKER_ID:-${_invoke_session_key:-headless}}"
 		# Set child cwd via shell since claude CLI has no flag for it.
 		if [[ -n "$work_dir" ]]; then
 			if ! cd "$work_dir"; then
@@ -254,19 +256,24 @@ _invoke_claude() {
 			passthrough_csv="$(build_sandbox_passthrough_csv)"
 			if [[ -n "$passthrough_csv" ]]; then
 				if [[ -n "${_HEADLESS_CLAUDE_STDIN_FILE:-}" && -f "${_HEADLESS_CLAUDE_STDIN_FILE:-}" ]]; then
-					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" <"$_HEADLESS_CLAUDE_STDIN_FILE" 2>&1 | tee "$output_file"
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --egress-mode "$egress_mode" --worker-id "$egress_worker_id" --passthrough "$passthrough_csv" -- "${cmd[@]}" <"$_HEADLESS_CLAUDE_STDIN_FILE" 2>&1 | tee "$output_file"
 				else
-					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --egress-mode "$egress_mode" --worker-id "$egress_worker_id" --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
 				fi
 			else
 				if [[ -n "${_HEADLESS_CLAUDE_STDIN_FILE:-}" && -f "${_HEADLESS_CLAUDE_STDIN_FILE:-}" ]]; then
-					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" <"$_HEADLESS_CLAUDE_STDIN_FILE" 2>&1 | tee "$output_file"
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --egress-mode "$egress_mode" --worker-id "$egress_worker_id" -- "${cmd[@]}" <"$_HEADLESS_CLAUDE_STDIN_FILE" 2>&1 | tee "$output_file"
 				else
-					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" 2>&1 | tee "$output_file"
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --egress-mode "$egress_mode" --worker-id "$egress_worker_id" -- "${cmd[@]}" 2>&1 | tee "$output_file"
 				fi
 			fi
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		else
+			if [[ "$egress_mode" == "required" ]]; then
+				print_error "Whole-process worker egress is required, but the sandbox launcher is disabled or unavailable"
+				printf '%s' "126" >"$exit_code_file"
+				exit 126
+			fi
 			if [[ "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" == "1" ]]; then
 				print_info "AIDEVOPS_HEADLESS_SANDBOX_DISABLED=1 — using bare exec (no privilege isolation) (GH#20146 audit)"
 			fi

--- a/.agents/scripts/network-tier-helper.sh
+++ b/.agents/scripts/network-tier-helper.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # network-tier-helper.sh — Network domain tiering for worker sandboxing (t1412.3)
-# Commands: classify | check | check-argv | check-command | log-access | report | init | help
+# Commands: classify | check | check-argv | check-command | export-policy | log-access | report | init | help
 #
 # Implements a 4-tier graduated trust model for headless worker network access:
 #   Tier 1: Always allowed, no logging (core infrastructure: github.com)
@@ -32,6 +32,7 @@
 #                                                   # Session-aware check (t1428.3)
 #   network-tier-helper.sh check-command 'curl https://example.com' --worker-id worker-123
 #   network-tier-helper.sh check-argv '["curl","https://example.com"]' --worker-id worker-123
+#   network-tier-helper.sh export-policy             # Normalized backend policy JSON
 #   network-tier-helper.sh log-access example.com worker-123 200
 #   network-tier-helper.sh report [--last N] [--flagged-only]
 #   network-tier-helper.sh init                     # Create log dirs and validate config
@@ -234,6 +235,62 @@ _tier_count() {
 
 	safe_grep_count "^${type_prefix}:" "$_TIER_LOOKUP_FILE"
 	return 0
+}
+
+# Export the authoritative tier configuration as a deterministic backend policy.
+# The process-containment backend consumes this output instead of parsing the
+# source files itself, so default and user override precedence stays centralized.
+# Output: aidevops.worker-egress-policy.v1 JSON on stdout.
+export_backend_policy() {
+	_load_tier_data || return 1
+	if ! command -v python3 >/dev/null 2>&1; then
+		log_error "python3 is required to export worker egress policy"
+		return 1
+	fi
+
+	python3 - "$_TIER_LOOKUP_FILE" <<'PY'
+import json
+import sys
+
+lookup_path = sys.argv[1]
+rules = {}
+with open(lookup_path, "r", encoding="utf-8") as handle:
+    for raw_line in handle:
+        key, tier_text = raw_line.rstrip("\n").rsplit(" ", 1)
+        match_type, pattern = key.split(":", 1)
+        tier = int(tier_text)
+        rules[(match_type, pattern)] = tier
+
+def action_for_tier(tier):
+    if tier == 1:
+        return "allow"
+    if tier in (2, 3):
+        return "allow-log"
+    if tier == 4:
+        return "allow-flag"
+    return "deny"
+
+normalized_rules = []
+for (match_type, pattern), tier in sorted(rules.items()):
+    normalized_rules.append({
+        "match": match_type,
+        "pattern": pattern,
+        "tier": tier,
+        "action": action_for_tier(tier),
+    })
+
+policy = {
+    "schema": "aidevops.worker-egress-policy.v1",
+    "default_tier": 4,
+    "default_action": "allow-flag",
+    "raw_ip_action": "deny",
+    "private_network_action": "deny",
+    "loopback_action": "deny",
+    "rules": normalized_rules,
+}
+print(json.dumps(policy, sort_keys=True, separators=(",", ":")))
+PY
+	return $?
 }
 
 # =============================================================================
@@ -922,6 +979,7 @@ Commands:
                              Enforce exact-argv worker network policy
   check-command <command> [--worker-id ID]
                              Compatibility shell-string entry point
+  export-policy              Emit normalized process-backend policy JSON
   check-session <domain> [--session-id ID]
                              Session-aware check — elevates tier if session
                              is tainted (t1428.3). Falls back to check if
@@ -963,6 +1021,9 @@ Examples:
 
   network-tier-helper.sh check-command 'curl https://requestbin.com' --worker-id worker-abc
   # Exit 1 (Tier 5 command denied)
+
+  network-tier-helper.sh export-policy
+  # Output schema: aidevops.worker-egress-policy.v1
 
   network-tier-helper.sh log-access pypi.org worker-abc 200 /simple/requests/
   network-tier-helper.sh report --flagged-only --last 20
@@ -1033,6 +1094,10 @@ main() {
 			return 1
 		fi
 		check_domain_session "$@"
+		return $?
+		;;
+	export-policy)
+		export_backend_policy
 		return $?
 		;;
 	log-access | log)

--- a/.agents/scripts/network-tier-helper.sh
+++ b/.agents/scripts/network-tier-helper.sh
@@ -254,6 +254,7 @@ import sys
 
 lookup_path = sys.argv[1]
 rules = {}
+DENY_ACTION = "deny"
 with open(lookup_path, "r", encoding="utf-8") as handle:
     for raw_line in handle:
         key, tier_text = raw_line.rstrip("\n").rsplit(" ", 1)
@@ -268,7 +269,7 @@ def action_for_tier(tier):
         return "allow-log"
     if tier == 4:
         return "allow-flag"
-    return "deny"
+    return DENY_ACTION
 
 normalized_rules = []
 for (match_type, pattern), tier in sorted(rules.items()):
@@ -283,9 +284,9 @@ policy = {
     "schema": "aidevops.worker-egress-policy.v1",
     "default_tier": 4,
     "default_action": "allow-flag",
-    "raw_ip_action": "deny",
-    "private_network_action": "deny",
-    "loopback_action": "deny",
+    "raw_ip_action": DENY_ACTION,
+    "private_network_action": DENY_ACTION,
+    "loopback_action": DENY_ACTION,
     "rules": normalized_rules,
 }
 print(json.dumps(policy, sort_keys=True, separators=(",", ":")))

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -47,6 +47,7 @@ readonly SANDBOX_DEFAULT_TIMEOUT=120
 readonly SANDBOX_MAX_TIMEOUT=3600
 readonly SANDBOX_MAX_OUTPUT_BYTES=10485760 # 10MB per stream
 readonly SECRET_IO_GUARD_DEFAULT="true"
+readonly SANDBOX_ERROR_LEVEL="ERROR"
 
 # Minimal environment passthrough — only what's needed for basic operation
 readonly DEFAULT_PASSTHROUGH="PATH HOME USER LANG TERM SHELL"
@@ -273,7 +274,7 @@ _sandbox_check_command_policy() {
 	local reason=""
 
 	if [[ ! -f "$COMMAND_POLICY_HELPER" ]]; then
-		log_sandbox "ERROR" "Required command policy helper is unavailable: ${COMMAND_POLICY_HELPER}"
+		log_sandbox "$SANDBOX_ERROR_LEVEL" "Required command policy helper is unavailable: ${COMMAND_POLICY_HELPER}"
 		return 1
 	fi
 	result="$(python3 "$COMMAND_POLICY_HELPER" check-command --worker --worker-id "$worker_id" --cwd "$PWD" --argv-json "$argv_json")" || status=$?
@@ -283,7 +284,7 @@ _sandbox_check_command_policy() {
 	if [[ "$status" -eq 0 && "$decision" == "allow" ]]; then
 		return 0
 	fi
-	log_sandbox "ERROR" "Command policy denied execution (${decision:-forbid}, ${rule_id}): ${reason}"
+	log_sandbox "$SANDBOX_ERROR_LEVEL" "Command policy denied execution (${decision:-forbid}, ${rule_id}): ${reason}"
 	return 1
 }
 
@@ -438,12 +439,13 @@ _sandbox_pgkill_cleanup() {
 	fi
 
 	if [[ -n "$cleanup_child_pgid" ]]; then
+		local cleanup_group_target="-${cleanup_child_pgid}"
 		# SIGTERM first — allow graceful shutdown
-		kill -- "-${cleanup_child_pgid}" 2>/dev/null || true
+		kill -- "$cleanup_group_target" 2>/dev/null || true
 		# Brief grace period, then SIGKILL any survivors
 		sleep 0.5
-		kill -0 -- "-${cleanup_child_pgid}" 2>/dev/null &&
-			kill -9 -- "-${cleanup_child_pgid}" 2>/dev/null || true
+		kill -0 -- "$cleanup_group_target" 2>/dev/null &&
+			kill -9 -- "$cleanup_group_target" 2>/dev/null || true
 	elif [[ -n "$cleanup_child_pid" ]]; then
 		# Fallback: setsid unavailable — kill direct child process only
 		kill "$cleanup_child_pid" 2>/dev/null || true
@@ -838,10 +840,11 @@ _sandbox_spawn_watchdog() {
 		touch "$wd_marker" 2>/dev/null || true
 
 		if [[ -n "$wd_pgid" ]]; then
-			kill -- "-${wd_pgid}" 2>/dev/null || true
+			local wd_group_target="-${wd_pgid}"
+			kill -- "$wd_group_target" 2>/dev/null || true
 			sleep 1
-			kill -0 -- "-${wd_pgid}" 2>/dev/null &&
-				kill -9 -- "-${wd_pgid}" 2>/dev/null || true
+			kill -0 -- "$wd_group_target" 2>/dev/null &&
+				kill -9 -- "$wd_group_target" 2>/dev/null || true
 		else
 			kill "$wd_pid" 2>/dev/null || true
 			sleep 1
@@ -987,7 +990,7 @@ _sandbox_prepare_worker_egress() {
 
 	if ! candidate="$(_sandbox_resolve_egress_backend)"; then
 		if [[ "$mode" == "required" ]]; then
-			log_sandbox "ERROR" "Whole-process worker egress is required but AIDEVOPS_WORKER_EGRESS_BACKEND is not an executable absolute path"
+			log_sandbox "$SANDBOX_ERROR_LEVEL" "Whole-process worker egress is required but AIDEVOPS_WORKER_EGRESS_BACKEND is not an executable absolute path"
 			return 1
 		fi
 		log_sandbox "WARN" "Whole-process worker egress backend unavailable; state=command-policy-only"
@@ -996,7 +999,7 @@ _sandbox_prepare_worker_egress() {
 
 	if [[ ! -x "$NETWORK_TIER_HELPER" ]]; then
 		if [[ "$mode" == "required" ]]; then
-			log_sandbox "ERROR" "Required network policy authority is unavailable: ${NETWORK_TIER_HELPER}"
+			log_sandbox "$SANDBOX_ERROR_LEVEL" "Required network policy authority is unavailable: ${NETWORK_TIER_HELPER}"
 			return 1
 		fi
 		log_sandbox "WARN" "Network policy export unavailable; state=command-policy-only"
@@ -1004,20 +1007,20 @@ _sandbox_prepare_worker_egress() {
 	fi
 	if ! "$NETWORK_TIER_HELPER" export-policy >"$policy_file"; then
 		if [[ "$mode" == "required" ]]; then
-			log_sandbox "ERROR" "Required worker egress policy export failed"
+			log_sandbox "$SANDBOX_ERROR_LEVEL" "Required worker egress policy export failed"
 			return 1
 		fi
 		log_sandbox "WARN" "Worker egress policy export failed; state=command-policy-only"
 		return 0
 	fi
 	expected_policy_sha256="$(_sandbox_file_sha256 "$policy_file")" || {
-		log_sandbox "ERROR" "Unable to digest normalized worker egress policy"
+		log_sandbox "$SANDBOX_ERROR_LEVEL" "Unable to digest normalized worker egress policy"
 		return 1
 	}
 
 	if ! probe_output="$("$candidate" probe --policy "$policy_file" 2>/dev/null)"; then
 		if [[ "$mode" == "required" ]]; then
-			log_sandbox "ERROR" "Required worker egress backend probe failed"
+			log_sandbox "$SANDBOX_ERROR_LEVEL" "Required worker egress backend probe failed"
 			return 1
 		fi
 		log_sandbox "WARN" "Worker egress backend probe failed; state=command-policy-only"
@@ -1028,7 +1031,7 @@ _sandbox_prepare_worker_egress() {
 		'.schema == "aidevops.worker-egress-backend.v1" and .ready == true and .scope == "process-tree" and (.enforcement == "kernel" or .enforcement == "equivalent") and .policy_sha256 == $policy_sha256 and (.backend_id | type == "string") and .cleanup == "automatic" and (["direct-socket-deny", "hostname-policy", "private-network-deny"] - .capabilities | length == 0)' \
 		>/dev/null 2>&1; then
 		if [[ "$mode" == "required" ]]; then
-			log_sandbox "ERROR" "Required worker egress backend returned an invalid readiness contract"
+			log_sandbox "$SANDBOX_ERROR_LEVEL" "Required worker egress backend returned an invalid readiness contract"
 			return 1
 		fi
 		log_sandbox "WARN" "Worker egress backend readiness contract invalid; state=command-policy-only"
@@ -1037,7 +1040,7 @@ _sandbox_prepare_worker_egress() {
 
 	egress_backend_id="$(printf '%s' "$probe_output" | jq -r '.backend_id')"
 	if [[ ! "$egress_backend_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
-		log_sandbox "ERROR" "Worker egress backend_id contains unsupported characters"
+		log_sandbox "$SANDBOX_ERROR_LEVEL" "Worker egress backend_id contains unsupported characters"
 		return 1
 	fi
 	egress_backend="$candidate"
@@ -1100,7 +1103,7 @@ _sandbox_run_dispatch() {
 			"${d_exec_args[@]}" || dispatch_exit=$?
 	else
 		if [[ "$block_network" == true ]]; then
-			log_sandbox "ERROR" "Network blocking requested but no enforcing deny-all backend is available"
+			log_sandbox "$SANDBOX_ERROR_LEVEL" "Network blocking requested but no enforcing deny-all backend is available"
 			return 126
 		fi
 		_sandbox_exec_with_pgkill "$timeout_secs" "$stdout_file" "$stderr_file" \
@@ -1180,8 +1183,8 @@ _sandbox_run_check_secret_guard() {
 	if [[ "$secret_io_guard" == "true" ]] && [[ "$allow_secret_io" != "true" ]]; then
 		local block_reason
 		if block_reason="$(_sandbox_secret_block_reason "$cmd_str")"; then
-			log_sandbox "ERROR" "Blocked command due to secret leak risk: ${block_reason}"
-			log_sandbox "ERROR" "Use --allow-secret-io only for explicit user-approved local operations"
+			log_sandbox "$SANDBOX_ERROR_LEVEL" "Blocked command due to secret leak risk: ${block_reason}"
+			log_sandbox "$SANDBOX_ERROR_LEVEL" "Use --allow-secret-io only for explicit user-approved local operations"
 			log_execution "$cmd_str" 126 0 "$timeout_secs" "$block_network" "$extra_passthrough"
 			return 126
 		fi
@@ -1300,13 +1303,13 @@ sandbox_run() {
 	_sandbox_run_parse_args "$@"
 
 	if [[ ${#cmd_args[@]} -eq 0 ]]; then
-		log_sandbox "ERROR" "No command provided"
+		log_sandbox "$SANDBOX_ERROR_LEVEL" "No command provided"
 		return 1
 	fi
 	case "$egress_mode" in
 	off | auto | required) ;;
 	*)
-		log_sandbox "ERROR" "Invalid worker egress mode '${egress_mode}' (expected off, auto, or required)"
+		log_sandbox "$SANDBOX_ERROR_LEVEL" "Invalid worker egress mode '${egress_mode}' (expected off, auto, or required)"
 		return 2
 		;;
 	esac
@@ -1506,7 +1509,7 @@ main() {
 	config) sandbox_config "$@" || status=$? ;;
 	help) sandbox_help || status=$? ;;
 	*)
-		log_sandbox "ERROR" "Unknown command: ${cmd}"
+		log_sandbox "$SANDBOX_ERROR_LEVEL" "Unknown command: ${cmd}"
 		sandbox_help
 		return 1
 		;;

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -962,7 +962,9 @@ PY
 #   probe --policy FILE
 #     emits {"schema":"aidevops.worker-egress-backend.v1","ready":true,
 #            "scope":"process-tree","enforcement":"kernel",
-#            "policy_sha256":"...","backend_id":"safe-id"}
+#            "policy_sha256":"...","backend_id":"safe-id",
+#            "capabilities":["direct-socket-deny","hostname-policy",
+#            "private-network-deny"],"cleanup":"automatic"}
 #   run --policy FILE --worker-id ID -- COMMAND [ARG...]
 #     binds COMMAND and all descendants to the policy before exec.
 # Arguments: $1=mode (off|auto|required), $2=policy file, $3=worker ID.
@@ -1023,7 +1025,7 @@ _sandbox_prepare_worker_egress() {
 	fi
 	if ! printf '%s' "$probe_output" | jq -e \
 		--arg policy_sha256 "$expected_policy_sha256" \
-		'.schema == "aidevops.worker-egress-backend.v1" and .ready == true and .scope == "process-tree" and (.enforcement == "kernel" or .enforcement == "equivalent") and .policy_sha256 == $policy_sha256 and (.backend_id | type == "string")' \
+		'.schema == "aidevops.worker-egress-backend.v1" and .ready == true and .scope == "process-tree" and (.enforcement == "kernel" or .enforcement == "equivalent") and .policy_sha256 == $policy_sha256 and (.backend_id | type == "string") and .cleanup == "automatic" and (["direct-socket-deny", "hostname-policy", "private-network-deny"] - .capabilities | length == 0)' \
 		>/dev/null 2>&1; then
 		if [[ "$mode" == "required" ]]; then
 			log_sandbox "ERROR" "Required worker egress backend returned an invalid readiness contract"
@@ -1353,6 +1355,7 @@ sandbox_run() {
 		"$block_network" "$timeout_secs" "$stdout_file" "$stderr_file" \
 		"$egress_backend" "$egress_policy_file" "$worker_id" \
 		"${env_args[@]}" "--" "${cmd_args[@]}" || exit_code=$?
+	rm -f "$egress_policy_file"
 
 	local end_time duration
 	end_time="$(date +%s)"

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -53,6 +53,7 @@ readonly DEFAULT_PASSTHROUGH="PATH HOME USER LANG TERM SHELL"
 
 # Runtime-neutral shell-command policy helper
 readonly COMMAND_POLICY_HELPER="${AIDEVOPS_COMMAND_POLICY_HELPER:-${SCRIPT_DIR}/command-policy-helper.py}"
+readonly NETWORK_TIER_HELPER="${AIDEVOPS_NETWORK_TIER_HELPER:-${SCRIPT_DIR}/network-tier-helper.sh}"
 
 # =============================================================================
 # Helpers
@@ -74,6 +75,8 @@ log_execution() {
 	local timeout_used="$4"
 	local network_blocked="${5:-false}"
 	local passthrough_vars="${6:-}"
+	local egress_state="${7:-not-evaluated}"
+	local egress_backend="${8:-none}"
 	local timestamp
 	timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -93,7 +96,9 @@ log_execution() {
 		--argjson timeout "$timeout_used" \
 		--argjson network_blocked "$network_blocked" \
 		--arg passthrough "$passthrough_vars" \
-		'{ts: $ts, cmd: $cmd, exit: $exit, duration_s: $duration, timeout: $timeout, network_blocked: $network_blocked, passthrough: $passthrough}')
+		--arg egress_state "$egress_state" \
+		--arg egress_backend "$egress_backend" \
+		'{ts: $ts, cmd: $cmd, exit: $exit, duration_s: $duration, timeout: $timeout, network_blocked: $network_blocked, passthrough: $passthrough, egress_state: $egress_state, egress_backend: $egress_backend}')
 
 	printf '%s\n' "$log_entry" >>"$SANDBOX_LOG"
 	return 0
@@ -928,6 +933,117 @@ _sandbox_build_env_args() {
 	return 0
 }
 
+# Resolve the trusted whole-process egress backend configured by the operator.
+# The path must be absolute so a worker-controlled PATH cannot select a backend.
+# Output: absolute executable path. Returns 1 when no usable backend is set.
+_sandbox_resolve_egress_backend() {
+	local configured_backend="${AIDEVOPS_WORKER_EGRESS_BACKEND:-}"
+	[[ -n "$configured_backend" && "$configured_backend" == /* && -x "$configured_backend" ]] || return 1
+	printf '%s' "$configured_backend"
+	return 0
+}
+
+# Calculate a portable SHA-256 digest for backend policy binding.
+# Arguments: $1=file path. Output: lowercase hex digest.
+_sandbox_file_sha256() {
+	local input_file="$1"
+	python3 - "$input_file" <<'PY'
+import hashlib
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    print(hashlib.sha256(handle.read()).hexdigest())
+PY
+	return $?
+}
+
+# Prepare and verify process-tree egress containment.
+# Backend contract:
+#   probe --policy FILE
+#     emits {"schema":"aidevops.worker-egress-backend.v1","ready":true,
+#            "scope":"process-tree","enforcement":"kernel",
+#            "policy_sha256":"...","backend_id":"safe-id"}
+#   run --policy FILE --worker-id ID -- COMMAND [ARG...]
+#     binds COMMAND and all descendants to the policy before exec.
+# Arguments: $1=mode (off|auto|required), $2=policy file, $3=worker ID.
+# Sets caller-scoped: egress_state, egress_backend, egress_backend_id.
+_sandbox_prepare_worker_egress() {
+	local mode="$1"
+	local policy_file="$2"
+	local worker_id_value="$3"
+	local candidate=""
+	local probe_output=""
+	local expected_policy_sha256=""
+
+	egress_state="command-policy-only"
+	egress_backend=""
+	egress_backend_id="none"
+	if [[ "$mode" == "off" ]]; then
+		egress_state="off"
+		return 0
+	fi
+
+	if ! candidate="$(_sandbox_resolve_egress_backend)"; then
+		if [[ "$mode" == "required" ]]; then
+			log_sandbox "ERROR" "Whole-process worker egress is required but AIDEVOPS_WORKER_EGRESS_BACKEND is not an executable absolute path"
+			return 1
+		fi
+		log_sandbox "WARN" "Whole-process worker egress backend unavailable; state=command-policy-only"
+		return 0
+	fi
+
+	if [[ ! -x "$NETWORK_TIER_HELPER" ]]; then
+		if [[ "$mode" == "required" ]]; then
+			log_sandbox "ERROR" "Required network policy authority is unavailable: ${NETWORK_TIER_HELPER}"
+			return 1
+		fi
+		log_sandbox "WARN" "Network policy export unavailable; state=command-policy-only"
+		return 0
+	fi
+	if ! "$NETWORK_TIER_HELPER" export-policy >"$policy_file"; then
+		if [[ "$mode" == "required" ]]; then
+			log_sandbox "ERROR" "Required worker egress policy export failed"
+			return 1
+		fi
+		log_sandbox "WARN" "Worker egress policy export failed; state=command-policy-only"
+		return 0
+	fi
+	expected_policy_sha256="$(_sandbox_file_sha256 "$policy_file")" || {
+		log_sandbox "ERROR" "Unable to digest normalized worker egress policy"
+		return 1
+	}
+
+	if ! probe_output="$("$candidate" probe --policy "$policy_file" 2>/dev/null)"; then
+		if [[ "$mode" == "required" ]]; then
+			log_sandbox "ERROR" "Required worker egress backend probe failed"
+			return 1
+		fi
+		log_sandbox "WARN" "Worker egress backend probe failed; state=command-policy-only"
+		return 0
+	fi
+	if ! printf '%s' "$probe_output" | jq -e \
+		--arg policy_sha256 "$expected_policy_sha256" \
+		'.schema == "aidevops.worker-egress-backend.v1" and .ready == true and .scope == "process-tree" and (.enforcement == "kernel" or .enforcement == "equivalent") and .policy_sha256 == $policy_sha256 and (.backend_id | type == "string")' \
+		>/dev/null 2>&1; then
+		if [[ "$mode" == "required" ]]; then
+			log_sandbox "ERROR" "Required worker egress backend returned an invalid readiness contract"
+			return 1
+		fi
+		log_sandbox "WARN" "Worker egress backend readiness contract invalid; state=command-policy-only"
+		return 0
+	fi
+
+	egress_backend_id="$(printf '%s' "$probe_output" | jq -r '.backend_id')"
+	if [[ ! "$egress_backend_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
+		log_sandbox "ERROR" "Worker egress backend_id contains unsupported characters"
+		return 1
+	fi
+	egress_backend="$candidate"
+	egress_state="enforced"
+	log_sandbox "INFO" "Whole-process worker egress ready (backend=${egress_backend_id}, worker=${worker_id_value})"
+	return 0
+}
+
 # Dispatch the sandboxed command via _sandbox_exec_with_pgkill.
 # Handles optional macOS seatbelt network blocking.
 # Arguments:
@@ -935,6 +1051,9 @@ _sandbox_build_env_args() {
 #   $2 - timeout_secs
 #   $3 - stdout_file
 #   $4 - stderr_file
+#   $5 - egress backend path (empty for none)
+#   $6 - normalized egress policy file
+#   $7 - worker ID
 # Remaining args: env_args elements followed by "--" followed by cmd_args elements.
 # Caller passes: "${env_args[@]}" "--" "${cmd_args[@]}"
 _sandbox_run_dispatch() {
@@ -942,7 +1061,10 @@ _sandbox_run_dispatch() {
 	local timeout_secs="$2"
 	local stdout_file="$3"
 	local stderr_file="$4"
-	shift 4
+	local egress_backend_path="$5"
+	local egress_policy_file="$6"
+	local dispatch_worker_id="$7"
+	shift 7
 	local dispatch_exit=0
 
 	# Split remaining args into env_args and cmd_args at the "--" separator
@@ -960,21 +1082,27 @@ _sandbox_run_dispatch() {
 		fi
 	done
 
+	local -a d_exec_args=()
+	if [[ -n "$egress_backend_path" ]]; then
+		d_exec_args=("$egress_backend_path" run --policy "$egress_policy_file" --worker-id "$dispatch_worker_id" -- "${d_env_args[@]}" "${d_cmd_args[@]}")
+	else
+		d_exec_args=("${d_env_args[@]}" "${d_cmd_args[@]}")
+	fi
+
 	if [[ "$block_network" == true ]] && command -v sandbox-exec &>/dev/null; then
 		# macOS seatbelt: deny network access.
 		# sandbox-exec accepts program + args directly (no shell wrapper needed).
 		local seatbelt_profile="(version 1)(allow default)(deny network*)"
 		_sandbox_exec_with_pgkill "$timeout_secs" "$stdout_file" "$stderr_file" \
 			sandbox-exec -p "$seatbelt_profile" \
-			"${d_env_args[@]}" \
-			"${d_cmd_args[@]}" || dispatch_exit=$?
+			"${d_exec_args[@]}" || dispatch_exit=$?
 	else
 		if [[ "$block_network" == true ]]; then
-			log_sandbox "WARN" "Network blocking requested but sandbox-exec not available (non-macOS); proceeding without"
+			log_sandbox "ERROR" "Network blocking requested but no enforcing deny-all backend is available"
+			return 126
 		fi
 		_sandbox_exec_with_pgkill "$timeout_secs" "$stdout_file" "$stderr_file" \
-			"${d_env_args[@]}" \
-			"${d_cmd_args[@]}" || dispatch_exit=$?
+			"${d_exec_args[@]}" || dispatch_exit=$?
 	fi
 
 	return "$dispatch_exit"
@@ -991,6 +1119,8 @@ _sandbox_run_dispatch() {
 #   $7 - duration (seconds)
 #   $8 - block_network (true|false)
 #   $9 - extra_passthrough
+#   $10 - egress_state
+#   $11 - egress_backend_id
 _sandbox_run_post_exec() {
 	local exit_code="$1"
 	local timeout_secs="$2"
@@ -1001,6 +1131,8 @@ _sandbox_run_post_exec() {
 	local duration="$7"
 	local block_network="$8"
 	local extra_passthrough="$9"
+	local egress_state_value="${10}"
+	local egress_backend_value="${11}"
 
 	# Handle timeout (exit code 124 from _sandbox_exec_with_pgkill)
 	if [[ $exit_code -eq 124 ]]; then
@@ -1016,7 +1148,7 @@ _sandbox_run_post_exec() {
 	_sandbox_emit_redacted_output "$stderr_file" "stderr" "$command_tainted"
 
 	# Audit log
-	log_execution "$cmd_str" "$exit_code" "$duration" "$timeout_secs" "$block_network" "$extra_passthrough"
+	log_execution "$cmd_str" "$exit_code" "$duration" "$timeout_secs" "$block_network" "$extra_passthrough" "$egress_state_value" "$egress_backend_value"
 
 	# Async cleanup of old temp dirs (older than 60 minutes).
 	# stderr is not suppressed so permission errors or other persistent failures
@@ -1063,14 +1195,18 @@ _sandbox_run_check_secret_guard() {
 #   $3 - block_network (true|false)
 #   $4 - network_tiering (true|false)
 #   $5 - heuristic-only command text
+#   $6 - egress state
+#   $7 - egress backend ID
 _sandbox_run_pre_exec() {
 	local cmd_str="$1"
 	local timeout_secs="$2"
 	local block_network="$3"
 	local network_tiering="$4"
 	local heuristic_text="$5"
+	local egress_state_value="$6"
+	local egress_backend_value="$7"
 
-	log_sandbox "INFO" "Executing (timeout=${timeout_secs}s, network_blocked=${block_network}, tiering=${network_tiering}): ${cmd_str:0:200}"
+	log_sandbox "INFO" "Executing (timeout=${timeout_secs}s, network_blocked=${block_network}, tiering=${network_tiering}, egress=${egress_state_value}, backend=${egress_backend_value}): ${cmd_str:0:200}"
 
 	local command_tainted=false
 	if _sandbox_is_secret_tainted_command "$heuristic_text"; then
@@ -1083,7 +1219,7 @@ _sandbox_run_pre_exec() {
 # Parse sandbox_run flags into caller-scoped variables (bash dynamic scoping).
 # Caller must declare all target variables as local before calling this function:
 #   timeout_secs, block_network, network_tiering, allow_secret_io,
-#   worker_id, extra_passthrough, stream_stdout, cmd_args (array).
+#   worker_id, extra_passthrough, stream_stdout, egress_mode, cmd_args (array).
 # Returns 0 on success, 1 if no command was provided after flag parsing.
 _sandbox_run_parse_args() {
 	while [[ $# -gt 0 ]]; do
@@ -1103,6 +1239,10 @@ _sandbox_run_parse_args() {
 		--network-tiering)
 			network_tiering=true
 			shift
+			;;
+		--egress-mode)
+			egress_mode="$2"
+			shift 2
 			;;
 		--allow-secret-io)
 			allow_secret_io=true
@@ -1141,6 +1281,10 @@ sandbox_run() {
 	local allow_secret_io=false
 	local worker_id="sandbox-$$"
 	local extra_passthrough=""
+	local egress_mode="${AIDEVOPS_WORKER_EGRESS_MODE:-auto}"
+	local egress_state="command-policy-only"
+	local egress_backend=""
+	local egress_backend_id="none"
 	local secret_io_guard="${AIDEVOPS_BLOCK_SECRET_IO:-$SECRET_IO_GUARD_DEFAULT}"
 	# Stream stdout mode (GH#15180 bug #4): when true, child stdout flows to
 	# the caller's stdout in real-time instead of being captured to a file and
@@ -1157,6 +1301,13 @@ sandbox_run() {
 		log_sandbox "ERROR" "No command provided"
 		return 1
 	fi
+	case "$egress_mode" in
+	off | auto | required) ;;
+	*)
+		log_sandbox "ERROR" "Invalid worker egress mode '${egress_mode}' (expected off, auto, or required)"
+		return 2
+		;;
+	esac
 
 	local argv_json=""
 	argv_json="$(_sandbox_argv_json "${cmd_args[@]}")" || return 126
@@ -1181,18 +1332,26 @@ sandbox_run() {
 
 	local -a env_args=()
 	_sandbox_build_env_args "$exec_tmpdir" "$extra_passthrough"
+	local egress_policy_file="${exec_tmpdir}/egress-policy.json"
+	if ! _sandbox_prepare_worker_egress "$egress_mode" "$egress_policy_file" "$worker_id"; then
+		log_execution "$cmd_str" 126 0 "$timeout_secs" "$block_network" "$extra_passthrough" "unavailable" "none"
+		rm -rf "$exec_tmpdir"
+		return 126
+	fi
 
 	local stdout_file="${exec_tmpdir}/stdout"
 	local stderr_file="${exec_tmpdir}/stderr"
 	local command_tainted
 	command_tainted="$(_sandbox_run_pre_exec \
-		"$cmd_str" "$timeout_secs" "$block_network" "$network_tiering" "$heuristic_text")"
+		"$cmd_str" "$timeout_secs" "$block_network" "$network_tiering" "$heuristic_text" \
+		"$egress_state" "$egress_backend_id")"
 
 	local start_time exit_code=0
 	start_time="$(date +%s)"
 
 	_sandbox_run_dispatch \
 		"$block_network" "$timeout_secs" "$stdout_file" "$stderr_file" \
+		"$egress_backend" "$egress_policy_file" "$worker_id" \
 		"${env_args[@]}" "--" "${cmd_args[@]}" || exit_code=$?
 
 	local end_time duration
@@ -1201,7 +1360,8 @@ sandbox_run() {
 
 	_sandbox_run_post_exec \
 		"$exit_code" "$timeout_secs" "$stdout_file" "$stderr_file" \
-		"$command_tainted" "$cmd_str" "$duration" "$block_network" "$extra_passthrough"
+		"$command_tainted" "$cmd_str" "$duration" "$block_network" "$extra_passthrough" \
+		"$egress_state" "$egress_backend_id"
 
 	return "$exit_code"
 }
@@ -1258,6 +1418,8 @@ sandbox_config() {
 	echo "  Secret guard: ${AIDEVOPS_BLOCK_SECRET_IO:-$SECRET_IO_GUARD_DEFAULT}"
 	echo "  Passthrough:  ${DEFAULT_PASSTHROUGH}"
 	echo "  Net tiering:  enforced by shared worker command policy"
+	echo "  Egress mode:  ${AIDEVOPS_WORKER_EGRESS_MODE:-auto}"
+	echo "  Egress backend: $([[ -n "${AIDEVOPS_WORKER_EGRESS_BACKEND:-}" ]] && echo configured || echo none)"
 	echo ""
 	if [[ -f "$SANDBOX_LOG" ]]; then
 		local count
@@ -1287,6 +1449,7 @@ Run options:
   --timeout N                Timeout in seconds (default: 120, max: 3600)
   --no-network               Block network access (macOS only, uses seatbelt)
   --network-tiering          Compatibility flag; enforcement is enabled by default
+  --egress-mode MODE         Whole-process backend mode: off|auto|required
   --allow-secret-io          Bypass secret-output guard for this command only
   --worker-id ID             Worker identifier for network tier logs
   --passthrough "VAR1,VAR2"  Additional env vars to pass through
@@ -1311,9 +1474,16 @@ Security model:
   - Secret-output command guard blocks likely credential leakage patterns
   - Optional network blocking (macOS seatbelt)
   - Recognized direct network clients block Tier 5 and DNS-exfiltration targets
-  - Interpreter/custom-binary traffic requires lower-layer egress containment
+  - Configured backends wrap the complete process tree before command execution
+  - required mode fails closed when no verified process-tree backend is ready
+  - auto mode reports command-policy-only when containment is unavailable
   - All executions logged to JSONL audit trail (jq-safe JSON, injection-proof)
   - Output capped at 10MB per stream
+
+Backend contract:
+  Set AIDEVOPS_WORKER_EGRESS_BACKEND to an absolute executable path. The backend
+  must implement `probe --policy FILE` and `run --policy FILE --worker-id ID --
+  COMMAND...` using the v1 JSON contracts documented in this script.
 HELP
 	return 0
 }

--- a/.agents/scripts/tests/test-worker-network-egress.sh
+++ b/.agents/scripts/tests/test-worker-network-egress.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+SANDBOX_HELPER="${SCRIPT_DIR}/sandbox-exec-helper.sh"
+NETWORK_HELPER="${SCRIPT_DIR}/network-tier-helper.sh"
+HEADLESS_HELPER="${SCRIPT_DIR}/headless-runtime-helper.sh"
+TEST_ROOT="$(mktemp -d)"
+TEST_HOME="${TEST_ROOT}/home"
+BACKEND="${TEST_ROOT}/egress-backend"
+TARGET="${TEST_ROOT}/adversary"
+MARKER="${TEST_ROOT}/target-ran"
+CHILD_MARKER="${TEST_ROOT}/child-ran"
+BACKEND_LOG="${TEST_ROOT}/backend-argv"
+CUSTOM_POLICY="${TEST_ROOT}/network-tiers-custom.conf"
+TESTS=0
+FAILURES=0
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_HOME"
+
+pass() {
+	local name="$1"
+	TESTS=$((TESTS + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS=$((TESTS + 1))
+	FAILURES=$((FAILURES + 1))
+	printf 'FAIL %s: %s\n' "$name" "$detail"
+	return 0
+}
+
+write_fixtures() {
+	cat >"$TARGET" <<EOF
+#!/usr/bin/env bash
+printf 'target' >"$MARKER"
+(printf 'child' >"$CHILD_MARKER") &
+wait
+exit 0
+EOF
+	chmod +x "$TARGET"
+
+	cat >"$BACKEND" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+
+case "${1:-}" in
+probe)
+	if [[ "${FAKE_BACKEND_MODE:-ready}" == "invalid" ]]; then
+		printf '{"ready":true}'
+		exit 0
+	fi
+	policy_file="${3:?}"
+	policy_sha256="$(python3 - "$policy_file" <<'PY'
+import hashlib
+import sys
+with open(sys.argv[1], "rb") as handle:
+    print(hashlib.sha256(handle.read()).hexdigest())
+PY
+)"
+	printf '{"schema":"aidevops.worker-egress-backend.v1","ready":true,"scope":"process-tree","enforcement":"kernel","policy_sha256":"%s","backend_id":"fixture-backend"}' "$policy_sha256"
+	exit 0
+	;;
+run)
+	shift
+	while [[ $# -gt 0 && "$1" != "--" ]]; do
+		shift
+	done
+	[[ "${1:-}" == "--" ]] && shift
+	printf '%s\n' "$@" >"${FAKE_BACKEND_LOG:?}"
+	if [[ "${FAKE_BACKEND_MODE:-ready}" == "deny" ]]; then
+		exit 77
+	fi
+	exec "$@"
+	;;
+*)
+	exit 64
+	;;
+esac
+EOF
+	chmod +x "$BACKEND"
+	return 0
+}
+
+test_policy_export_is_normalized() {
+	local output=""
+	output="$(HOME="$TEST_HOME" "$NETWORK_HELPER" export-policy)" || {
+		fail "exports normalized backend policy" "export failed"
+		return 0
+	}
+	if printf '%s' "$output" | jq -e \
+		'.schema == "aidevops.worker-egress-policy.v1" and .raw_ip_action == "deny" and .private_network_action == "deny" and ([.rules[] | select(.tier == 5)] | length > 0) and ([.rules[] | select(.match == "exact" and .pattern == "github.com" and .action == "allow")] | length == 1) and ([.rules[] | select(.pattern == "api.openai.com" and (.action | startswith("allow")))] | length == 1)' \
+		>/dev/null 2>&1; then
+		pass "exports normalized backend policy"
+	else
+		fail "exports normalized backend policy" "invalid contract"
+	fi
+	return 0
+}
+
+test_policy_export_applies_user_override() {
+	cat >"$CUSTOM_POLICY" <<'EOF'
+[tier5]
+github.com
+EOF
+	local output=""
+	output="$(HOME="$TEST_HOME" AIDEVOPS_NETWORK_TIER_USER_POLICY="$CUSTOM_POLICY" "$NETWORK_HELPER" export-policy)" || {
+		fail "normalized policy applies user overrides" "export failed"
+		return 0
+	}
+	if printf '%s' "$output" | jq -e \
+		'[.rules[] | select(.match == "exact" and .pattern == "github.com" and .tier == 5 and .action == "deny")] | length == 1' \
+		>/dev/null 2>&1; then
+		pass "normalized policy applies user overrides"
+	else
+		fail "normalized policy applies user overrides" "override missing"
+	fi
+	return 0
+}
+
+test_required_mode_fails_closed_without_backend() {
+	rm -f "$MARKER" "$CHILD_MARKER"
+	local status=0
+	HOME="$TEST_HOME" AIDEVOPS_WORKER_EGRESS_BACKEND="" \
+		"$SANDBOX_HELPER" run --egress-mode required -- "$TARGET" >/dev/null 2>&1 || status=$?
+	if [[ "$status" -eq 126 && ! -e "$MARKER" && ! -e "$CHILD_MARKER" ]]; then
+		pass "required mode fails closed without backend"
+	else
+		fail "required mode fails closed without backend" "status=${status} marker=$([[ -e "$MARKER" ]] && printf yes || printf no)"
+	fi
+	return 0
+}
+
+test_required_mode_rejects_invalid_probe() {
+	rm -f "$MARKER" "$CHILD_MARKER"
+	local status=0
+	HOME="$TEST_HOME" AIDEVOPS_WORKER_EGRESS_BACKEND="$BACKEND" \
+		FAKE_BACKEND_MODE=invalid FAKE_BACKEND_LOG="$BACKEND_LOG" \
+		"$SANDBOX_HELPER" run --egress-mode required -- "$TARGET" >/dev/null 2>&1 || status=$?
+	if [[ "$status" -eq 126 && ! -e "$MARKER" ]]; then
+		pass "required mode rejects invalid backend readiness"
+	else
+		fail "required mode rejects invalid backend readiness" "status=${status}"
+	fi
+	return 0
+}
+
+test_backend_wraps_process_tree() {
+	rm -f "$MARKER" "$CHILD_MARKER" "$BACKEND_LOG"
+	local status=0
+	HOME="$TEST_HOME" AIDEVOPS_WORKER_EGRESS_BACKEND="$BACKEND" \
+		FAKE_BACKEND_MODE=ready FAKE_BACKEND_LOG="$BACKEND_LOG" \
+		"$SANDBOX_HELPER" run --egress-mode required --worker-id fixture-worker -- "$TARGET" >/dev/null 2>&1 || status=$?
+	if [[ "$status" -eq 0 && -e "$MARKER" && -e "$CHILD_MARKER" && -s "$BACKEND_LOG" ]] && \
+		grep -F "$TARGET" "$BACKEND_LOG" >/dev/null 2>&1; then
+		pass "verified backend wraps command and descendants"
+	else
+		fail "verified backend wraps command and descendants" "status=${status}"
+	fi
+	return 0
+}
+
+test_backend_denial_blocks_arbitrary_binary() {
+	rm -f "$MARKER" "$CHILD_MARKER" "$BACKEND_LOG"
+	local status=0
+	HOME="$TEST_HOME" AIDEVOPS_WORKER_EGRESS_BACKEND="$BACKEND" \
+		FAKE_BACKEND_MODE=deny FAKE_BACKEND_LOG="$BACKEND_LOG" \
+		"$SANDBOX_HELPER" run --egress-mode required --worker-id fixture-worker -- "$TARGET" >/dev/null 2>&1 || status=$?
+	if [[ "$status" -eq 77 && ! -e "$MARKER" && ! -e "$CHILD_MARKER" ]]; then
+		pass "backend denial blocks arbitrary binary and descendants"
+	else
+		fail "backend denial blocks arbitrary binary and descendants" "status=${status}"
+	fi
+	return 0
+}
+
+test_auto_mode_reports_non_containment() {
+	rm -f "$MARKER" "$CHILD_MARKER"
+	local output=""
+	local status=0
+	output="$(HOME="$TEST_HOME" AIDEVOPS_WORKER_EGRESS_BACKEND="" \
+		"$SANDBOX_HELPER" run --egress-mode auto -- "$TARGET" 2>&1)" || status=$?
+	if [[ "$status" -eq 0 && -e "$MARKER" && "$output" == *"state=command-policy-only"* && "$output" == *"egress=command-policy-only"* ]]; then
+		pass "auto mode reports command-policy-only state"
+	else
+		fail "auto mode reports command-policy-only state" "status=${status} output=${output}"
+	fi
+	return 0
+}
+
+test_headless_runtime_binds_egress_contract() {
+	local egress_count=0
+	local worker_count=0
+	egress_count="$(grep -cF -- '--egress-mode' "$HEADLESS_HELPER")"
+	worker_count="$(grep -cF -- '--worker-id' "$HEADLESS_HELPER")"
+	if [[ "$egress_count" -eq 2 && "$worker_count" -eq 2 ]]; then
+		pass "headless runtime binds egress mode and worker identity"
+	else
+		fail "headless runtime binds egress mode and worker identity" "egress=${egress_count} worker=${worker_count}"
+	fi
+	return 0
+}
+
+main() {
+	write_fixtures
+	test_policy_export_is_normalized
+	test_policy_export_applies_user_override
+	test_required_mode_fails_closed_without_backend
+	test_required_mode_rejects_invalid_probe
+	test_backend_wraps_process_tree
+	test_backend_denial_blocks_arbitrary_binary
+	test_auto_mode_reports_non_containment
+	test_headless_runtime_binds_egress_contract
+	printf '\nTests: %d, Failures: %d\n' "$TESTS" "$FAILURES"
+	[[ "$FAILURES" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-worker-network-egress.sh
+++ b/.agents/scripts/tests/test-worker-network-egress.sh
@@ -15,6 +15,7 @@ BACKEND="${TEST_ROOT}/egress-backend"
 TARGET="${TEST_ROOT}/adversary"
 MARKER="${TEST_ROOT}/target-ran"
 CHILD_MARKER="${TEST_ROOT}/child-ran"
+INTERPRETER_MARKER="${TEST_ROOT}/interpreter-ran"
 BACKEND_LOG="${TEST_ROOT}/backend-argv"
 CUSTOM_POLICY="${TEST_ROOT}/network-tiers-custom.conf"
 TESTS=0
@@ -98,7 +99,7 @@ test_policy_export_is_normalized() {
 		return 0
 	}
 	if printf '%s' "$output" | jq -e \
-		'.schema == "aidevops.worker-egress-policy.v1" and .raw_ip_action == "deny" and .private_network_action == "deny" and ([.rules[] | select(.tier == 5)] | length > 0) and ([.rules[] | select(.match == "exact" and .pattern == "github.com" and .action == "allow")] | length == 1) and ([.rules[] | select(.pattern == "api.openai.com" and (.action | startswith("allow")))] | length == 1)' \
+		'.schema == "aidevops.worker-egress-policy.v1" and .raw_ip_action == "deny" and .private_network_action == "deny" and .loopback_action == "deny" and ([.rules[] | select(.tier == 5)] | length > 0) and ([.rules[] | select(.match == "exact" and .pattern == "github.com" and .action == "allow")] | length == 1) and ([.rules[] | select(.pattern == "api.openai.com" and (.action | startswith("allow")))] | length == 1)' \
 		>/dev/null 2>&1; then
 		pass "exports normalized backend policy"
 	else
@@ -183,6 +184,22 @@ test_backend_denial_blocks_arbitrary_binary() {
 	return 0
 }
 
+test_backend_denial_blocks_interpreter() {
+	rm -f "$INTERPRETER_MARKER" "$BACKEND_LOG"
+	local status=0
+	HOME="$TEST_HOME" INTERPRETER_MARKER="$INTERPRETER_MARKER" AIDEVOPS_WORKER_EGRESS_BACKEND="$BACKEND" \
+		FAKE_BACKEND_MODE=deny FAKE_BACKEND_LOG="$BACKEND_LOG" \
+		"$SANDBOX_HELPER" run --egress-mode required --worker-id fixture-worker --passthrough INTERPRETER_MARKER -- \
+		python3 -c 'from pathlib import Path; import os; Path(os.environ["INTERPRETER_MARKER"]).write_text("ran")' \
+		>/dev/null 2>&1 || status=$?
+	if [[ "$status" -eq 77 && ! -e "$INTERPRETER_MARKER" ]]; then
+		pass "backend denial blocks arbitrary interpreter execution"
+	else
+		fail "backend denial blocks arbitrary interpreter execution" "status=${status}"
+	fi
+	return 0
+}
+
 test_auto_mode_reports_non_containment() {
 	rm -f "$MARKER" "$CHILD_MARKER"
 	local output=""
@@ -224,6 +241,7 @@ main() {
 	test_required_mode_rejects_invalid_probe
 	test_backend_wraps_process_tree
 	test_backend_denial_blocks_arbitrary_binary
+	test_backend_denial_blocks_interpreter
 	test_auto_mode_reports_non_containment
 	test_headless_runtime_binds_egress_contract
 	printf '\nTests: %d, Failures: %d\n' "$TESTS" "$FAILURES"

--- a/.agents/scripts/tests/test-worker-network-egress.sh
+++ b/.agents/scripts/tests/test-worker-network-egress.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
 SANDBOX_HELPER="${SCRIPT_DIR}/sandbox-exec-helper.sh"
 NETWORK_HELPER="${SCRIPT_DIR}/network-tier-helper.sh"
 HEADLESS_HELPER="${SCRIPT_DIR}/headless-runtime-helper.sh"
+HEADLESS_WORKER="${SCRIPT_DIR}/headless-runtime-worker.sh"
 TEST_ROOT="$(mktemp -d)"
 TEST_HOME="${TEST_ROOT}/home"
 BACKEND="${TEST_ROOT}/egress-backend"
@@ -66,7 +67,7 @@ with open(sys.argv[1], "rb") as handle:
     print(hashlib.sha256(handle.read()).hexdigest())
 PY
 )"
-	printf '{"schema":"aidevops.worker-egress-backend.v1","ready":true,"scope":"process-tree","enforcement":"kernel","policy_sha256":"%s","backend_id":"fixture-backend"}' "$policy_sha256"
+	printf '{"schema":"aidevops.worker-egress-backend.v1","ready":true,"scope":"process-tree","enforcement":"kernel","policy_sha256":"%s","backend_id":"fixture-backend","capabilities":["direct-socket-deny","hostname-policy","private-network-deny"],"cleanup":"automatic"}' "$policy_sha256"
 	exit 0
 	;;
 run)
@@ -197,14 +198,20 @@ test_auto_mode_reports_non_containment() {
 }
 
 test_headless_runtime_binds_egress_contract() {
-	local egress_count=0
-	local worker_count=0
-	egress_count="$(grep -cF -- '--egress-mode' "$HEADLESS_HELPER")"
-	worker_count="$(grep -cF -- '--worker-id' "$HEADLESS_HELPER")"
-	if [[ "$egress_count" -eq 2 && "$worker_count" -eq 2 ]]; then
-		pass "headless runtime binds egress mode and worker identity"
+	local opencode_egress_count=0
+	local claude_egress_count=0
+	local required_guard_count=0
+	# Literal source patterns intentionally retain the runtime variable names.
+	# shellcheck disable=SC2016
+	opencode_egress_count="$(grep -cF -- '--egress-mode "$egress_mode" --worker-id "$egress_worker_id"' "$HEADLESS_HELPER")"
+	# shellcheck disable=SC2016
+	claude_egress_count="$(grep -cF -- '--egress-mode "$egress_mode" --worker-id "$egress_worker_id"' "$HEADLESS_WORKER")"
+	# shellcheck disable=SC2016
+	required_guard_count="$(grep -h -cF -- '[[ "$egress_mode" == "required" ]]' "$HEADLESS_HELPER" "$HEADLESS_WORKER" | awk '{ total += $1 } END { print total + 0 }')"
+	if [[ "$opencode_egress_count" -eq 2 && "$claude_egress_count" -eq 4 && "$required_guard_count" -eq 2 ]]; then
+		pass "all headless runtimes bind egress and guard required mode"
 	else
-		fail "headless runtime binds egress mode and worker identity" "egress=${egress_count} worker=${worker_count}"
+		fail "all headless runtimes bind egress and guard required mode" "opencode=${opencode_egress_count} claude=${claude_egress_count} guards=${required_guard_count}"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Export normalized policy from the network-tier authority, verify a runtime-neutral enforcing backend before launch, bind OpenCode and Claude worker process trees to it, fail closed in required mode, and add custom-binary/interpreter adversarial coverage.

## Files Changed

.agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/network-tier-helper.sh, .agents/scripts/sandbox-exec-helper.sh, .agents/scripts/tests/test-worker-network-egress.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worker-network-egress.sh; bash .agents/scripts/tests/test-sandbox-command-policy.sh; shellcheck .agents/scripts/sandbox-exec-helper.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-worker.sh .agents/scripts/network-tier-helper.sh .agents/scripts/tests/test-worker-network-egress.sh; .agents/scripts/linters-local.sh

Resolves #27056


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2h 20m and 1,119,041 tokens on this as a headless worker.