### PR TITLE
GH#27204: fix: harden workflow legacy manifest parsing

### DIFF
--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -91,7 +91,7 @@ readonly _KNOWN_WORKFLOWS=(
 # Detection is warning-only: modified or repository-specific files are never
 # removed automatically.
 _resolve_legacy_artifact_manifest() {
-	local _deployed="$HOME/.aidevops/agents/configs/workflow-legacy-artifacts.tsv"
+	local _deployed="${HOME:-}/.aidevops/agents/configs/workflow-legacy-artifacts.tsv"
 	local _repo_local="$SELF_DIR/../configs/workflow-legacy-artifacts.tsv"
 	if [[ -f "$_deployed" ]]; then
 		printf '%s\n' "$_deployed"
@@ -113,7 +113,8 @@ _legacy_artifacts_for_repo() {
 	_manifest=$(_resolve_legacy_artifact_manifest) || return 0
 	local _manifest_workflow _artifact_path _superseded_by _introduced_in
 	local _found=""
-	while IFS=$'\t' read -r _manifest_workflow _artifact_path _superseded_by _introduced_in; do
+	while IFS=$'\t' read -r _manifest_workflow _artifact_path _superseded_by _introduced_in ||
+		[[ -n "$_manifest_workflow" ]]; do
 		[[ -z "$_manifest_workflow" || "$_manifest_workflow" == \#* ]] && continue
 		[[ "$_manifest_workflow" != "$_workflow_name" ]] && continue
 		[[ -f "$_path/$_artifact_path" ]] || continue
@@ -134,7 +135,7 @@ _legacy_artifacts_for_repo() {
 # e.g. _resolve_canonical_template "issue-sync-caller.yml"
 _resolve_canonical_template() {
 	local _template_filename="$1"
-	local _deployed="$HOME/.aidevops/agents/templates/workflows/${_template_filename}"
+	local _deployed="${HOME:-}/.aidevops/agents/templates/workflows/${_template_filename}"
 	local _repo_local="$SELF_DIR/../templates/workflows/${_template_filename}"
 
 	if [[ -f "$_deployed" ]]; then
@@ -160,7 +161,7 @@ _resolve_canonical_reusable() {
 	return 1
 }
 
-REPOS_JSON="$HOME/.config/aidevops/repos.json"
+REPOS_JSON="${HOME:-}/.config/aidevops/repos.json"
 
 # ─── Logging ────────────────────────────────────────────────────────────────
 

--- a/.agents/scripts/tests/test-check-workflows-helper.sh
+++ b/.agents/scripts/tests/test-check-workflows-helper.sh
@@ -18,6 +18,8 @@
 #  10. --repo filter narrows to one row
 #  11. --json output parses as JSON
 #  16. Current caller plus obsolete framework scripts → legacy-artifact warning
+#  17. Legacy-artifact manifest without a trailing newline processes its final row
+#  18. Unset HOME exits cleanly instead of raising an unbound-variable error
 #
 # Strategy: Each scenario writes a temporary repos.json + temporary repo trees
 # under a per-test TMPDIR, points HOME at it, and invokes the helper. No
@@ -408,6 +410,35 @@ else
 		"classification: $result; note: $note"
 fi
 rm -rf "$TMPDIR_16"
+
+# Test 17: The final manifest row must be processed without a trailing newline.
+TMPDIR_17="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_17"
+_make_repo_with_workflow "$TMPDIR_17/repos/no-trailing-newline"
+cp "$CANONICAL_TEMPLATE" "$TMPDIR_17/repos/no-trailing-newline/.github/workflows/issue-sync.yml"
+mkdir -p "$TMPDIR_17/repos/no-trailing-newline/.agents/scripts"
+printf '%s\n' '# legacy helper' >"$TMPDIR_17/repos/no-trailing-newline/.agents/scripts/issue-sync-helper.sh"
+mkdir -p "$TMPDIR_17/.aidevops/agents/configs"
+printf '%s' $'issue-sync\t.agents/scripts/issue-sync-helper.sh\tissue-sync-reusable.yml\tv3.32.31' > \
+	"$TMPDIR_17/.aidevops/agents/configs/workflow-legacy-artifacts.tsv"
+_write_repos_json "$TMPDIR_17" \
+	"$(jq -n --arg path "$TMPDIR_17/repos/no-trailing-newline" '{initialized_repos: [{slug: "x/no-trailing-newline", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_17" --repo "x/no-trailing-newline" --workflow issue-sync)
+if [[ "$result" == "CURRENT/CALLER + LEGACY_ARTIFACTS" ]]; then
+	_pass "manifest final row without trailing newline → LEGACY_ARTIFACTS warning"
+else
+	_fail "manifest final row without trailing newline → LEGACY_ARTIFACTS warning" "got: $result"
+fi
+rm -rf "$TMPDIR_17"
+
+# Test 18: HOME is not guaranteed in constrained execution environments.
+unset_home_output=$(env -u HOME bash "$HELPER" --json 2>&1 || true)
+if [[ "$unset_home_output" == *"repos.json not found"* ]] &&
+	[[ "$unset_home_output" != *"unbound variable"* ]]; then
+	_pass "unset HOME → clean missing-config error"
+else
+	_fail "unset HOME → clean missing-config error" "got: $unset_home_output"
+fi
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Guard workflow path resolution when HOME is unset and process a final legacy-artifact TSV row without a trailing newline. Add regression coverage for both cases.

## Files Changed

.agents/scripts/check-workflows-helper.sh, .agents/scripts/tests/test-check-workflows-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-check-workflows-helper.sh (18 passed); shellcheck target files; .agents/scripts/linters-local.sh

Resolves #27204


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 53,498 tokens on this as a headless worker.