### PR TITLE
GH#27202: fix: harden issue sync test cleanup

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-pr-identity.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-identity.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELPER="${SCRIPT_DIR}/../issue-sync-pr-identity-helper.sh"
 TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
+trap 'rm -rf "${TMP_DIR:-}"' EXIT
 TODO_FILE="${TMP_DIR}/TODO.md"
 PASS=0
 FAIL=0


### PR DESCRIPTION
## Summary

Made the issue-sync identity test cleanup trap safe under set -u by using a default expansion for TMP_DIR.

## Files Changed

.agents/scripts/tests/test-issue-sync-pr-identity.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-issue-sync-pr-identity.sh; shellcheck .agents/scripts/tests/test-issue-sync-pr-identity.sh

Resolves #27202


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 20,748 tokens on this as a headless worker.