### PR TITLE
GH#27203: test: relax issue-sync shim assertions

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -101,8 +101,8 @@ JOB_BODY=$(sed -n "${JOB_START},${JOB_END}p" "${WORKFLOW_FILE}")
 # Test 2: PATH shims survive caller-repo workspace cleanup.
 # ============================================================
 # shellcheck disable=SC2016 # Assert literal workflow expressions, not test-shell expansion.
-if printf '%s\n' "${JOB_BODY}" | grep -qE 'SHIM_DIR="\$\{RUNNER_TEMP\}/[^\"]+"' && \
-	printf '%s\n' "${JOB_BODY}" | grep -qE 'echo "\$\{SHIM_DIR\}" >> "\$GITHUB_PATH"'; then
+if printf '%s\n' "${JOB_BODY}" | grep -qE 'SHIM_DIR[[:space:]]*=[[:space:]]*"?\$\{?RUNNER_TEMP\}?/[^"]+"?' && \
+	printf '%s\n' "${JOB_BODY}" | grep -qE 'echo[[:space:]]+"?\$\{?SHIM_DIR\}?"?[[:space:]]*>>[[:space:]]*"?\$\{?GITHUB_PATH\}?"?'; then
 	check 1 "sync-on-pr-merge stages PATH shims outside GITHUB_WORKSPACE" ""
 else
 	check 0 "sync-on-pr-merge stages PATH shims outside GITHUB_WORKSPACE" \


### PR DESCRIPTION
## Summary

Made the issue-sync workflow test tolerate optional parameter braces, quoting, assignment spacing, and redirect spacing while preserving the RUNNER_TEMP and GITHUB_PATH safety requirements.

## Files Changed

.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh (7 passed); shellcheck .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh; git diff --check

Resolves #27203


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 24,681 tokens on this as a headless worker.