### PR TITLE
GH#27179: test: cover empty profile screen payload

### DIFF
--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -730,6 +730,13 @@ test_screen_json_paths_are_optional_and_fail_visibly() {
 		return 0
 	fi
 	local warning_file="${TEST_DIR}/screen-warning"
+	assignments=$(_generate_screen_time_vars '' 2>"$warning_file")
+	eval "$assignments"
+	if [[ "$screen_today" != "$PROFILE_STATUS_UNAVAILABLE" || "$screen_status" != "$PROFILE_STATUS_UNAVAILABLE" || "$screen_source" != "$PROFILE_STATUS_UNAVAILABLE" ]] ||
+		! grep -qF 'screen-time payload is invalid' "$warning_file"; then
+		print_result "$test_name" 1 "empty screen payload failure was not visible"
+		return 0
+	fi
 	assignments=$(_generate_screen_time_vars 'not-json' 2>"$warning_file")
 	eval "$assignments"
 	if [[ "$screen_status" != "$PROFILE_STATUS_UNAVAILABLE" || "$screen_source" != "$PROFILE_STATUS_UNAVAILABLE" ]] ||


### PR DESCRIPTION
## Summary

Confirmed the renderer already uses optional jq paths for missing period data and added an exact empty-payload regression assertion that verifies unavailable fallback values and a visible warning.

## Files Changed

.agents/scripts/tests/test-profile-readme-boundary.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-profile-readme-boundary.sh --unit-only; shellcheck .agents/scripts/tests/test-profile-readme-boundary.sh .agents/scripts/profile-readme-render-lib.sh; .agents/scripts/linters-local.sh

Resolves #27179


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 49,170 tokens on this as a headless worker.