### PR TITLE
GH#27197: test: harden task resolver ordering assertion

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-pr-task-resolver.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-task-resolver.sh
@@ -76,9 +76,9 @@ else
 	FAIL=$((FAIL + 1))
 fi
 
-resolve_line=$(grep -n 'id: resolve-tasks' "$WORKFLOW" | cut -d: -f1)
-hygiene_line=$(grep -n 'name: Apply closing hygiene' "$WORKFLOW" | cut -d: -f1)
-if [[ "$resolve_line" -lt "$hygiene_line" ]]; then
+resolve_line=$(grep -n 'id: resolve-tasks' "$WORKFLOW" | cut -d: -f1 || true)
+hygiene_line=$(grep -n 'name: Apply closing hygiene' "$WORKFLOW" | cut -d: -f1 || true)
+if [[ -n "$resolve_line" && -n "$hygiene_line" && "$resolve_line" -lt "$hygiene_line" ]]; then
 	printf 'PASS: task mapping validates before closing hygiene\n'
 	PASS=$((PASS + 1))
 else


### PR DESCRIPTION
## Summary

Allow missing workflow markers to reach the test's explicit failure branch by tolerating empty grep results and guarding the numeric comparison.

## Files Changed

.agents/scripts/tests/test-issue-sync-pr-task-resolver.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-issue-sync-pr-task-resolver.sh (14 passed); shellcheck .agents/scripts/tests/test-issue-sync-pr-task-resolver.sh; git diff --check

Resolves #27197


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 9m and 22,400 tokens on this as a headless worker.