### PR TITLE
GH#27191: fix: handle unset HOME in repo verify hook

### DIFF
--- a/.agents/hooks/repo-verify-pre-push.sh
+++ b/.agents/hooks/repo-verify-pre-push.sh
@@ -85,7 +85,7 @@ _resolve_self() {
 
 HOOK_DIR=$(_resolve_self)
 VERIFY_LIB_REPO="${HOOK_DIR}/../scripts/repo-verify-config-lib.sh"
-VERIFY_LIB_DEPLOYED="${HOME}/.aidevops/agents/scripts/repo-verify-config-lib.sh"
+VERIFY_LIB_DEPLOYED="${HOME:+$HOME/.aidevops/agents/scripts/repo-verify-config-lib.sh}"
 if [[ -f "$VERIFY_LIB_REPO" ]]; then
 	# shellcheck source=../scripts/repo-verify-config-lib.sh
 	source "$VERIFY_LIB_REPO"

--- a/.agents/scripts/tests/test-repo-verify-pre-push-hook.sh
+++ b/.agents/scripts/tests/test-repo-verify-pre-push-hook.sh
@@ -9,6 +9,7 @@
 #   1. AIDEVOPS_PREPUSH_REPO_VERIFY=0 short-circuits to exit 0
 #   2. GITHUB_ACTIONS=true short-circuits to exit 0
 #   3. Outside a git repo: exit 0 (no-op)
+#  3b. HOME unset does not trigger a set -u failure
 #   4. No verify config anywhere: silent skip (exit 0)
 #   5. .aidevops.json `.verify.enabled=false` opts out (exit 0)
 #   6. .aidevops.json with a passing format command: exit 0
@@ -157,6 +158,18 @@ echo "${TEST_BLUE}=== test-repo-verify-pre-push-hook.sh (t3224) ===${TEST_NC}"
 	ec=$(printf '%s' "$out" | head -n 1)
 	assert_eq '3. outside git repo → exit 0' '0' "$ec"
 	rm -rf "$non_repo"
+}
+
+# Test 3b: HOME may be absent in restricted hook environments
+{
+	repo=$(_mk_repo)
+	(
+		cd "$repo" || exit 1
+		env -u HOME PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" bash "$HOOK" </dev/null
+	) >/dev/null 2>&1
+	ec=$?
+	assert_eq '3b. HOME unset → exit 0' '0' "$ec"
+	rm -rf "$repo"
 }
 
 # Test 4: no verify config of any kind


### PR DESCRIPTION
## Summary

Guard the deployed verification-library path when HOME is unset and add a regression test for restricted hook environments.

## Files Changed

.agents/hooks/repo-verify-pre-push.sh, .agents/scripts/tests/test-repo-verify-pre-push-hook.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-repo-verify-pre-push-hook.sh; shellcheck .agents/hooks/repo-verify-pre-push.sh .agents/scripts/tests/test-repo-verify-pre-push-hook.sh

Resolves #27191


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 15m and 33,204 tokens on this as a headless worker.