### PR TITLE
GH#27194: fix: harden repository config detection

### DIFF
--- a/.agents/scripts/repo-verify-config-lib.sh
+++ b/.agents/scripts/repo-verify-config-lib.sh
@@ -275,7 +275,8 @@ _repo_verify_predicate_matches() {
 		local section_line=""
 		[[ -f "${repo_root}/${section_path}" ]] || return 1
 		_repo_verify_evidence_is_tracked "$repo_root" "$section_path" || return 1
-		while IFS= read -r section_line; do
+		while IFS= read -r section_line || [[ -n "$section_line" ]]; do
+			[[ -n "$section_line" ]] || continue
 			section_line="${section_line%%#*}"
 			while [[ "$section_line" == *[[:space:]] ]]; do
 				section_line="${section_line%?}"
@@ -405,7 +406,7 @@ repo_verify_install_hook() {
 
 repo_verify_registration_has_feature() {
 	local repo_root="$1"
-	local repos_file="${AIDEVOPS_REPOS_FILE:-${HOME}/.config/aidevops/repos.json}"
+	local repos_file="${AIDEVOPS_REPOS_FILE:-${HOME:+$HOME/.config/aidevops/repos.json}}"
 	[[ -f "$repos_file" ]] || return 1
 	jq -e --arg path "$repo_root" '.initialized_repos[]? | select(.path == $path) | (.features // []) | index("code-quality") != null' "$repos_file" >/dev/null 2>&1 || return 1
 	return 0
@@ -429,7 +430,7 @@ repo_verify_feature_state() {
 
 repo_verify_migrate_registration() {
 	local repo_root="$1"
-	local repos_file="${AIDEVOPS_REPOS_FILE:-${HOME}/.config/aidevops/repos.json}"
+	local repos_file="${AIDEVOPS_REPOS_FILE:-${HOME:+$HOME/.config/aidevops/repos.json}}"
 	[[ -f "$repos_file" ]] || return 2
 	local config_file
 	config_file=$(_repo_verify_config_path "$repo_root")

--- a/.agents/scripts/tests/test-repo-verify-config-lib.sh
+++ b/.agents/scripts/tests/test-repo-verify-config-lib.sh
@@ -96,6 +96,31 @@ test_python_evidence() {
 	repo_verify_detect "$root" || true
 	assert_equal "defaults(PYTHON_RUFF)" "$REPO_VERIFY_SOURCE" "committed Ruff config is exact evidence"
 	assert_equal "ruff check ." "$REPO_VERIFY_LINT" "Ruff lint command is seeded"
+
+	root="$1/python-ruff-no-newline"
+	new_repo "$root"
+	printf '%s' '[tool.ruff]' >"$root/pyproject.toml"
+	/usr/bin/git -C "$root" add pyproject.toml
+	repo_verify_detect "$root" || true
+	assert_equal "defaults(PYTHON_RUFF)" "$REPO_VERIFY_SOURCE" "section on final unterminated line is detected"
+	return 0
+}
+
+test_unset_home_registration_lookup() {
+	local root="$1/unset-home"
+	new_repo "$root"
+	local status=0
+	(
+		unset HOME AIDEVOPS_REPOS_FILE
+		repo_verify_registration_has_feature "$root"
+	) || status=$?
+	assert_equal "1" "$status" "registration lookup handles HOME being unset"
+	status=0
+	(
+		unset HOME AIDEVOPS_REPOS_FILE
+		repo_verify_migrate_registration "$root"
+	) || status=$?
+	assert_equal "2" "$status" "registration migration handles HOME being unset"
 	return 0
 }
 
@@ -188,6 +213,7 @@ main() {
 	test_package_manager_declaration_conflict "$TEST_TMP_DIR"
 	test_untracked_evidence_rejected "$TEST_TMP_DIR"
 	test_python_evidence "$TEST_TMP_DIR"
+	test_unset_home_registration_lookup "$TEST_TMP_DIR"
 	test_explicit_opt_out "$TEST_TMP_DIR"
 	test_feature_opt_out "$TEST_TMP_DIR"
 	test_config_merge "$TEST_TMP_DIR"


### PR DESCRIPTION
## Summary

Process unterminated final configuration lines and safely handle an unset HOME during repository registration lookups. Added regressions for both cases.

## Files Changed

.agents/scripts/repo-verify-config-lib.sh, .agents/scripts/tests/test-repo-verify-config-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-repo-verify-config-lib.sh; shellcheck .agents/scripts/repo-verify-config-lib.sh .agents/scripts/tests/test-repo-verify-config-lib.sh

Resolves #27194


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 16m and 34,282 tokens on this as a headless worker.