### PR TITLE
GH#27172: test: guard deployed CLI from stale canonical modules

### DIFF
--- a/tests/test-cli-deployment-coherence.sh
+++ b/tests/test-cli-deployment-coherence.sh
@@ -13,7 +13,8 @@ grep -q '"$convergence_helper" converge "$cli_source" "$orchestrator_source" "$d
 grep -q 'git clone --depth 1 --branch main' \
 	"$REPO_DIR/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
 
-mkdir -p "$TEST_HOME/.aidevops/agents/scripts" "$TEST_HOME/Git/aidevops" "$TEST_HOME/bin"
+mkdir -p "$TEST_HOME/.aidevops/agents/scripts" \
+	"$TEST_HOME/Git/aidevops/.agents/scripts/aidevops-cli" "$TEST_HOME/bin"
 # shellcheck disable=SC2016
 printf '#!/usr/bin/env bash\nprintf "deployed:%%s\\n" "$1"\n' >"$TEST_HOME/.aidevops/agents/aidevops.sh"
 printf '#!/usr/bin/env bash\nprintf "canonical\\n"\n' >"$TEST_HOME/Git/aidevops/aidevops.sh"
@@ -29,11 +30,20 @@ cp "$REPO_DIR/aidevops.sh" "$TEST_HOME/.aidevops/agents/aidevops.sh"
 cp -R "$REPO_DIR/.agents/scripts/." "$TEST_HOME/.aidevops/agents/scripts/"
 printf '9.8.7\n' >"$TEST_HOME/.aidevops/agents/VERSION"
 printf '1.2.3\n' >"$TEST_HOME/Git/aidevops/VERSION"
+cat >"$TEST_HOME/Git/aidevops/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'FAIL: stale canonical CLI module was sourced\n' >&2
+exit 42
+EOF
 printf '#!/usr/bin/env bash\nexit 1\n' >"$TEST_HOME/bin/curl"
 chmod +x "$TEST_HOME/bin/curl"
 result=$(cd "$TEST_HOME" && HOME="$TEST_HOME" PATH="$TEST_HOME/bin:/usr/bin:/bin" bash "$REPO_DIR/bin/aidevops" --version)
 [[ "$result" == "aidevops 9.8.7" ]] || {
 	printf 'FAIL: real deployed CLI selected %s\n' "$result" >&2
+	exit 1
+}
+[[ "$(tr -d '\n' <"$TEST_HOME/Git/aidevops/VERSION")" == "1.2.3" ]] || {
+	printf 'FAIL: canonical VERSION was mutated during deployed CLI execution\n' >&2
 	exit 1
 }
 


### PR DESCRIPTION
## Summary

Extended CLI deployment coherence coverage so a stale canonical module tree fails loudly if selected, while verifying deployed version selection leaves the canonical VERSION untouched. Existing fixes initialize AGENTS_DIR in setup and resolve deployed CLI modules and VERSION from the deployed agents root.

## Files Changed

tests/test-cli-deployment-coherence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash tests/test-cli-deployment-coherence.sh; bash .agents/scripts/tests/test-setup-aidevops-cli-install.sh; bash .agents/scripts/tests/test-aidevops-sh-portability.sh; shellcheck tests/test-cli-deployment-coherence.sh setup.sh aidevops.sh .agents/scripts/setup/modules/config.sh; .agents/scripts/linters-local.sh

Resolves #27172


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 16m and 55,823 tokens on this as a headless worker.