### PR TITLE
GH#27193: fix: harden lint paths when HOME is unset

### DIFF
--- a/.agents/scripts/lint-helper.sh
+++ b/.agents/scripts/lint-helper.sh
@@ -179,7 +179,7 @@ lint_audit_record() {
 
 lint_repo_list() {
 	if [[ "$LINT_ALL" == "$LINT_TRUE" ]]; then
-		local repos_file="${AIDEVOPS_REPOS_FILE:-${HOME}/.config/aidevops/repos.json}"
+		local repos_file="${AIDEVOPS_REPOS_FILE:-${HOME:+$HOME/.config/aidevops/repos.json}}"
 		[[ -f "$repos_file" ]] || return 1
 		jq -r '.initialized_repos[]?.path // empty' "$repos_file"
 		return 0
@@ -228,7 +228,7 @@ lint_audit() {
 
 lint_write_dispatch_plan() {
 	local records_file="$1"
-	local plan_dir="${HOME}/.aidevops/.agent-workspace/work"
+	local plan_dir="${HOME:+$HOME/.aidevops/.agent-workspace/work}"
 	local temp_file plan_file
 	mkdir -p "$plan_dir"
 	temp_file=$(mktemp "${plan_dir}/lint-configure-pr-plan.XXXXXX") || return 1

--- a/.agents/scripts/tests/test-lint-helper.sh
+++ b/.agents/scripts/tests/test-lint-helper.sh
@@ -29,6 +29,7 @@ make_repo() {
 	/usr/bin/git -C "$repo_root" init -q
 	/usr/bin/git -C "$repo_root" config user.email test@example.com
 	/usr/bin/git -C "$repo_root" config user.name Test
+	/usr/bin/git -C "$repo_root" config commit.gpgsign false
 	printf '%s\n' '{"scripts":{"lint":"eslint .","lint:fix":"eslint --fix .","typecheck":"tsc --noEmit"}}' >"$repo_root/package.json"
 	printf '%s\n' '{"version":"0.0.1","features":{"planning":true}}' >"$repo_root/.aidevops.json"
 	/usr/bin/git -C "$repo_root" add package.json
@@ -102,6 +103,15 @@ main() {
 	local missing_status=0
 	HOME="$fake_home" AIDEVOPS_REPOS_FILE="${TEST_TMP_DIR}/missing.json" bash "$HELPER" audit --all >/dev/null 2>&1 || missing_status=$?
 	assert_equal "1" "$missing_status" "all-repo audit fails when registry is unavailable"
+
+	local unset_home_output unset_home_status=0
+	unset_home_output=$(env -u HOME bash "$HELPER" audit --all 2>&1) || unset_home_status=$?
+	assert_equal "1" "$unset_home_status" "all-repo audit fails cleanly when HOME is unset"
+	assert_equal "0" "$(printf '%s' "$unset_home_output" | grep -c 'unbound variable' || true)" "unset HOME does not trigger nounset"
+
+	local unset_plan_status=0
+	env -u HOME AIDEVOPS_REPOS_FILE="${fake_home}/.config/aidevops/repos.json" bash "$HELPER" configure --all --write-pr-plan --json >/dev/null 2>&1 || unset_plan_status=$?
+	assert_equal "1" "$unset_plan_status" "PR plan fails without resolving an unset HOME to the filesystem root"
 
 	printf '\nRan %d tests, %d failed.\n' "$((passed + failed))" "$failed"
 	[[ "$failed" -eq 0 ]] || return 1


### PR DESCRIPTION
## Summary

Use nounset-safe HOME expansions for the lint repository registry and PR-plan directory, with regression coverage for unset HOME behavior.

## Files Changed

.agents/scripts/lint-helper.sh, .agents/scripts/tests/test-lint-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-lint-helper.sh; shellcheck .agents/scripts/lint-helper.sh .agents/scripts/tests/test-lint-helper.sh; git diff HEAD^ --check

Resolves #27193


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 22m and 85,002 tokens on this as a headless worker.