### PR TITLE
GH#27244: fix: guard null GraphQL review responses

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -110,7 +110,7 @@ _pmrc_snapshot_review_threads_clear() {
 			}
 		}
 	' 2>/dev/null) || return 1
-	if ! printf '%s' "$response" | jq -e '.data.repository.pullRequest != null' >/dev/null; then
+	if ! printf '%s' "$response" | jq -e 'try (.data.repository.pullRequest != null) catch false' >/dev/null; then
 		return 1
 	fi
 	has_next=$(printf '%s' "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false') || return 1

--- a/.agents/tests/test-pulse-merge-required-checks.sh
+++ b/.agents/tests/test-pulse-merge-required-checks.sh
@@ -79,6 +79,8 @@ test_ruleset_ref_patterns_fail_closed_on_malformed_schema() {
 test_snapshot_review_threads_fail_closed_on_missing_pr_data() {
 	printf '\n=== snapshot review thread fail-closed parsing ===\n'
 	_assert_contains_literal "review threads validate pull request data" \
+		"jq -e 'try (.data.repository.pullRequest != null) catch false' >/dev/null"
+	_assert_not_contains_literal "missing pull request data does not emit jq indexing errors" \
 		"jq -e '.data.repository.pullRequest != null' >/dev/null"
 	_assert_not_contains_literal "review thread pagination does not hide jq diagnostics" \
 		"jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null"


### PR DESCRIPTION
## Summary

Guard pre-merge review-thread validation against GraphQL responses with null or missing data, while preserving diagnostics for malformed JSON; update the regression assertion.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/tests/test-pulse-merge-required-checks.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-pulse-merge-required-checks.sh; bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh; shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/tests/test-pulse-merge-required-checks.sh

Resolves #27244


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 24,917 tokens on this as a headless worker.