### PR TITLE
GH#27240: fix: harden simplification logfile scope

### DIFF
--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -725,6 +725,7 @@ _create_simplification_issues() {
 	local repo_slug="$1"
 	local sarif_json="$2"
 	local smell_threshold="${3:-0}"
+	local LOGFILE="${LOGFILE:-/dev/null}"
 	local max_issues_per_sweep=5
 	local total_open_cap=30
 	local issues_created=0
@@ -815,7 +816,7 @@ _smell_files_from_sarif() {
 	local sarif_json="$1"
 
 	printf '%s\n' "$sarif_json" | jq -r '
-		[.runs[0].results[]? | .locations[0]?.physicalLocation.artifactLocation.uri? |
+		[.runs[0].results[]? | .locations[0].physicalLocation.artifactLocation.uri? |
 		 select(type == "string" and length > 0)] |
 		group_by(.) | map({file: .[0], count: length}) |
 		sort_by([-.count, .file]) |

--- a/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh
@@ -165,7 +165,7 @@ fi
 
 printf '\n[a.2] optional logfile is nounset-safe\n'
 if (unset LOGFILE; _create_simplification_issues "test/repo" '{}' >/dev/null) &&
-	(unset LOGFILE; _create_simplification_issues "test/repo" "$(make_sarif)" 3 >/dev/null); then
+	(unset LOGFILE; _create_simplification_issues "test/repo" "$(make_sarif)" 0 >/dev/null); then
 	pass "optional-logfile-nounset-safe"
 else
 	fail "optional-logfile-nounset-safe" "LOGFILE fallback failed under set -u"


### PR DESCRIPTION
## Summary

Define an optional LOGFILE fallback at the simplification issue call-tree root, exercise the deficit path under nounset, and simplify the SARIF jq path.

## Files Changed

.agents/scripts/stats-quality-sweep.sh, .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh; shellcheck .agents/scripts/stats-quality-sweep.sh .agents/scripts/tests/test-stats-quality-sweep-simplification-nmr.sh; git diff --check

Resolves #27240


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 35,589 tokens on this as a headless worker.