### PR TITLE
GH#27239: fix: reject invalid HOME during setup

### DIFF
--- a/.agents/scripts/tests/test-setup-aidevops-cli-install.sh
+++ b/.agents/scripts/tests/test-setup-aidevops-cli-install.sh
@@ -17,8 +17,8 @@ print_warning() { return 0; }
 # shellcheck source=../setup/modules/config.sh
 source "$CONFIG_LIB"
 
-# Exercise setup.sh itself with both its normal default and an unset HOME.
-# The latter must not synthesize the privileged root-level /.aidevops path.
+# Exercise setup.sh itself with its normal default and invalid HOME values.
+# Invalid values must fail before setup can derive or write any user paths.
 setup_home="$TEST_DIR/setup-home"
 mkdir -p "$setup_home"
 setup_trace=$(env -u AGENTS_DIR -u AIDEVOPS_AGENTS_DIR HOME="$setup_home" \
@@ -28,13 +28,23 @@ if [[ "$setup_trace" != *"AGENTS_DIR=$setup_home/.aidevops/agents"* ||
 	printf 'FAIL: setup.sh did not define and export the default AGENTS_DIR\n' >&2
 	exit 1
 fi
-unset_home_trace=$(env -u AGENTS_DIR -u AIDEVOPS_AGENTS_DIR -u HOME \
-	bash -x "$REPO_ROOT/setup.sh" --help 2>&1)
-if [[ "$unset_home_trace" != *"AGENTS_DIR="* || "$unset_home_trace" == *"AGENTS_DIR=/.aidevops/agents"* ]]; then
-	printf 'FAIL: setup.sh synthesized a root-level AGENTS_DIR with HOME unset\n' >&2
-	exit 1
-fi
-printf 'PASS: setup.sh exports a safe default AGENTS_DIR\n'
+for home_state in unset empty; do
+	invalid_home_status=0
+	if [[ "$home_state" == "unset" ]]; then
+		invalid_home_trace=$(env -u AGENTS_DIR -u AIDEVOPS_AGENTS_DIR -u HOME \
+			bash "$REPO_ROOT/setup.sh" --help 2>&1) || invalid_home_status=$?
+	else
+		invalid_home_trace=$(env -u AGENTS_DIR -u AIDEVOPS_AGENTS_DIR HOME= \
+			bash "$REPO_ROOT/setup.sh" --help 2>&1) || invalid_home_status=$?
+	fi
+	if [[ "$invalid_home_status" -ne 1 ||
+		"$invalid_home_trace" != *"HOME environment variable is unset or empty"* ||
+		"$invalid_home_trace" == *"/.aidevops"* ]]; then
+		printf 'FAIL: setup.sh did not fail safely with HOME %s\n' "$home_state" >&2
+		exit 1
+	fi
+done
+printf 'PASS: setup.sh rejects unset and empty HOME values\n'
 
 source_cli="$TEST_DIR/source-cli"
 target_cli="$TEST_DIR/bin/aidevops"

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,11 @@ IFS=$'\n\t'
 trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
 shopt -s inherit_errexit 2>/dev/null || true
 
+if [[ -z "${HOME:-}" ]]; then
+	printf '%s\n' '[ERROR] HOME environment variable is unset or empty. setup.sh requires a valid HOME directory.' >&2
+	exit 1
+fi
+
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
@@ -68,7 +73,7 @@ REPO_URL="https://github.com/marcusquinn/aidevops.git"
 # INSTALL_DIR: resolve from the directory where setup.sh is executed (supports worktrees)
 # For bootstrap (curl install), this will be /dev/fd/NN and trigger re-exec after clone
 INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-${HOME:+$HOME/.aidevops/agents}}"
+AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-$HOME/.aidevops/agents}"
 export REPO_URL INSTALL_DIR AGENTS_DIR
 
 # Source modular setup functions (t316.2)


### PR DESCRIPTION
## Summary

Fail setup immediately when HOME is unset or empty, preventing derived root-level paths, and cover both invalid states with regression tests.

## Files Changed

.agents/scripts/tests/test-setup-aidevops-cli-install.sh, setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-setup-aidevops-cli-install.sh; shellcheck setup.sh .agents/scripts/tests/test-setup-aidevops-cli-install.sh; .agents/scripts/linters-local.sh

Resolves #27239


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 46,710 tokens on this as a headless worker.