### PR TITLE
GH#27246: fix: harden pulse merge pass strict mode

### DIFF
--- a/.agents/scripts/pulse-merge-pass.sh
+++ b/.agents/scripts/pulse-merge-pass.sh
@@ -204,16 +204,18 @@ _pmp_pause_merge_pr_cursor() {
 	local required_contexts_cache_dir="${11:-}"
 	local author_permission_cache_dir="${12:-}"
 	local next_pr="" last_pr=""
+	local cursor_file="${PULSE_MERGE_PR_CURSOR_FILE:-}"
+	local logfile="${LOGFILE:-/dev/null}"
 
 	next_pr=$(_pmp_pr_number_at_index "$pr_json" "$cursor_index") || next_pr=""
-	_pmp_read_merge_pr_cursor_last "$PULSE_MERGE_PR_CURSOR_FILE" "$repo_slug" last_pr || last_pr=""
-	_pmp_write_merge_pr_cursor "$PULSE_MERGE_PR_CURSOR_FILE" "$repo_slug" "$cursor_index" "$last_pr" "$next_pr"
+	_pmp_read_merge_pr_cursor_last "$cursor_file" "$repo_slug" last_pr || last_pr=""
+	_pmp_write_merge_pr_cursor "$cursor_file" "$repo_slug" "$cursor_index" "$last_pr" "$next_pr"
 	case "$pause_reason" in
 	budget)
-		echo "[pulse-wrapper] Merge pass: graceful time budget exhausted for ${repo_slug}; pausing at PR cursor index=${cursor_index} next_pr=${next_pr:-none}" >>"$LOGFILE"
+		echo "[pulse-wrapper] Merge pass: graceful time budget exhausted for ${repo_slug}; pausing at PR cursor index=${cursor_index} next_pr=${next_pr:-none}" >>"$logfile"
 		;;
 	cooldown)
-		echo "[pulse-wrapper] Merge pass: GitHub cooldown active for ${repo_slug}; pausing remaining PR processing" >>"$LOGFILE"
+		echo "[pulse-wrapper] Merge pass: GitHub cooldown active for ${repo_slug}; pausing remaining PR processing" >>"$logfile"
 		;;
 	stop) ;;
 	esac
@@ -254,7 +256,7 @@ _pmp_prepare_merge_checkpoint_resume() {
 	[[ "$resumed_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
 
 	if [[ -n "$checkpoint_file" && -f "$checkpoint_file" ]]; then
-		IFS= read -r checkpoint <"$checkpoint_file" || [[ -n "$checkpoint" ]]
+		IFS= read -r checkpoint <"$checkpoint_file" || [[ -n "$checkpoint" ]] || true
 		if [[ -n "$checkpoint" ]]; then
 			if _pmp_repo_rows_contain_slug "$repo_rows" "$checkpoint"; then
 				resume_pending=1
@@ -281,7 +283,7 @@ _pmp_checkpoint_resume_skip_repo() {
 	local resume_pending=""
 
 	[[ "$resume_pending_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
-	resume_pending="${!resume_pending_var}"
+	resume_pending="${!resume_pending_var:-}"
 	[[ "$resume_pending" -eq 1 ]] || return 1
 	if [[ "$repo_slug" == "$checkpoint" ]]; then
 		printf -v "$resume_pending_var" '%s' '0'
@@ -295,7 +297,7 @@ _pmp_add_counter_var() {
 	local current=""
 
 	[[ "$counter_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
-	current="${!counter_var}"
+	current="${!counter_var:-}"
 	[[ "$current" =~ ^[0-9]+$ ]] || current=0
 	[[ "$increment" =~ ^[0-9]+$ ]] || increment=0
 	printf -v "$counter_var" '%s' "$((current + increment))"

--- a/.agents/tests/test-pulse-merge-pass-strict-mode.sh
+++ b/.agents/tests/test-pulse-merge-pass-strict-mode.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression checks for pulse merge-pass helpers under strict shell mode.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=../scripts/pulse-merge-pass.sh
+source "${SCRIPT_DIR}/../scripts/pulse-merge-pass.sh"
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-pmp-strict.XXXXXX")
+trap 'rm -rf -- "$tmp_dir"' EXIT
+checkpoint_file="${tmp_dir}/checkpoint"
+logfile="${tmp_dir}/resume.log"
+: >"$checkpoint_file"
+
+checkpoint_result="sentinel"
+resume_pending_result=1
+resumed_result=1
+_pmp_prepare_merge_checkpoint_resume "owner/repo|/tmp/repo" "$checkpoint_file" "$logfile" \
+	checkpoint_result resume_pending_result resumed_result
+[[ -z "$checkpoint_result" && "$resume_pending_result" -eq 0 && "$resumed_result" -eq 0 ]]
+
+unset missing_resume missing_counter PULSE_MERGE_PR_CURSOR_FILE LOGFILE
+if _pmp_checkpoint_resume_skip_repo "owner/repo" "owner/repo" missing_resume; then
+	printf 'unset resume flag unexpectedly requested a skip\n' >&2
+	exit 1
+fi
+_pmp_add_counter_var missing_counter 2
+# shellcheck disable=SC2154 # Assigned indirectly by _pmp_add_counter_var.
+[[ "$missing_counter" -eq 2 ]]
+
+merged=0
+closed=0
+failed=0
+if _pmp_pause_merge_pr_cursor "owner/repo" '[]' 0 budget merged closed failed 0 0 0; then
+	printf 'pause helper unexpectedly returned success\n' >&2
+	exit 1
+else
+	status=$?
+fi
+[[ "$status" -eq 5 ]]
+
+printf 'pulse merge-pass strict-mode regression checks passed\n'


### PR DESCRIPTION
## Summary

Guard empty checkpoints and unset indirect variables under strict shell mode, and add regression coverage for checkpoint, counter, and pause helpers.

## Files Changed

.agents/scripts/pulse-merge-pass.sh, .agents/tests/test-pulse-merge-pass-strict-mode.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-pulse-merge-pass-strict-mode.sh; bash .agents/tests/test-pulse-merge-cycle-cache.sh; bash .agents/tests/test-pulse-merge-conflict.sh; .agents/scripts/linters-local.sh

Resolves #27246


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 48,181 tokens on this as a headless worker.