### PR TITLE
GH#27247: fix: harden pulse timing unset variables

### DIFF
--- a/.agents/scripts/pulse-merge-timing.sh
+++ b/.agents/scripts/pulse-merge-timing.sh
@@ -42,7 +42,7 @@ _pmp_add_elapsed_seconds() {
 	[[ "$elapsed" =~ ^[0-9]+$ ]] || elapsed=0
 
 	if declare -p "$dest_var" >/dev/null 2>&1; then
-		current_value="${!dest_var}"
+		current_value="${!dest_var:-}"
 	else
 		current_value=0
 	fi
@@ -54,6 +54,7 @@ _pmp_add_elapsed_seconds() {
 
 _pmp_log_repo_timing_summary() {
 	local repo_slug="$1"
+	local logfile="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
 	local total_s="${2:-0}"
 	local list_s="${3:-0}"
 	local mergeability_s="${4:-0}"
@@ -65,6 +66,6 @@ _pmp_log_repo_timing_summary() {
 	local failed="${10:-0}"
 	local pr_count="${11:-0}"
 
-	echo "[pulse-wrapper] deterministic_merge_pass timing: repo=${repo_slug} total_s=${total_s} list_s=${list_s} mergeability_s=${mergeability_s} ruleset_s=${ruleset_s} branch_protection_s=${branch_protection_s} stuck_detector_s=${stuck_detector_s} merged=${merged} closed=${closed} failed=${failed} prs=${pr_count}" >>"$LOGFILE"
+	echo "[pulse-wrapper] deterministic_merge_pass timing: repo=${repo_slug} total_s=${total_s} list_s=${list_s} mergeability_s=${mergeability_s} ruleset_s=${ruleset_s} branch_protection_s=${branch_protection_s} stuck_detector_s=${stuck_detector_s} merged=${merged} closed=${closed} failed=${failed} prs=${pr_count}" >>"$logfile"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-timing-summary.sh
+++ b/.agents/scripts/tests/test-pulse-merge-timing-summary.sh
@@ -22,6 +22,7 @@ export REPOS_JSON="${TEST_ROOT}/repos.json"
 export PULSE_MERGE_BATCH_LIMIT=1
 
 mkdir -p "${HOME}/.config/aidevops"
+mkdir -p "${HOME}/.aidevops/logs"
 
 cat >"$REPOS_JSON" <<'JSON'
 {"initialized_repos":[
@@ -123,6 +124,25 @@ done
 if ! grep -q 'deterministic_merge_pass timing: total_s=' "$LOGFILE"; then
   printf 'FAIL: missing overall deterministic_merge_pass timing summary\n'
   cat "$LOGFILE"
+  exit 1
+fi
+
+unset_accumulator_regression() {
+  local elapsed_total
+  _pmp_add_elapsed_seconds elapsed_total "$(_pmp_now_epoch)"
+  [[ "$elapsed_total" =~ ^[0-9]+$ ]]
+  return $?
+}
+
+if ! unset_accumulator_regression; then
+  printf 'FAIL: declared-but-unset timing accumulator was not initialized safely\n'
+  exit 1
+fi
+
+unset LOGFILE
+_pmp_log_repo_timing_summary "owner/fallback"
+if ! grep -q 'deterministic_merge_pass timing: repo=owner/fallback' "${HOME}/.aidevops/logs/pulse.log"; then
+  printf 'FAIL: unset LOGFILE did not use the standard pulse log path\n'
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Safely initialize declared-but-unset timing accumulators, fall back to the standard pulse log when LOGFILE is unset, and add regression coverage for both set -u paths.

## Files Changed

.agents/scripts/pulse-merge-timing.sh, .agents/scripts/tests/test-pulse-merge-timing-summary.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-timing-summary.sh; shellcheck .agents/scripts/pulse-merge-timing.sh .agents/scripts/tests/test-pulse-merge-timing-summary.sh; .agents/scripts/linters-local.sh

Resolves #27247


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 38,808 tokens on this as a headless worker.