### PR TITLE
GH#27242: test: document safe BASH_SOURCE fallback

### DIFF
--- a/.agents/scripts/tests/test-version-manager-release-repo-root.sh
+++ b/.agents/scripts/tests/test-version-manager-release-repo-root.sh
@@ -5,6 +5,8 @@
 
 set -uo pipefail
 
+# BASH_SOURCE is a Bash special array and cannot be unset; the indexed form is
+# the repository-standard fallback that also remains safe when invoked by zsh.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
 RELEASE_HELPER="${SCRIPT_DIR}/../version-manager-release.sh"
 


### PR DESCRIPTION
## Summary

Document why the indexed BASH_SOURCE fallback is safe under Bash set -u and remains the repository-standard zsh-compatible form, resolving the review finding without applying an unsafe pattern divergence.

## Files Changed

.agents/scripts/tests/test-version-manager-release-repo-root.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** /bin/bash .agents/scripts/tests/test-version-manager-release-repo-root.sh; shellcheck .agents/scripts/tests/test-version-manager-release-repo-root.sh; git diff --check

Resolves #27242


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1m and 28,075 tokens on this as a headless worker.