### PR TITLE
GH#27189: stop review-feedback worker cycle flogging

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -122,7 +122,7 @@ verify_gh_cli() {
 # Common preamble for commands that need project_root, repo, todo_file, gh auth
 _init_cmd() {
 	if [[ -n "$PROJECT_ROOT_ARG" ]]; then
-		_CMD_ROOT=$(cd "$PROJECT_ROOT_ARG" 2>/dev/null && pwd -P) || {
+		_CMD_ROOT=$(cd -- "$PROJECT_ROOT_ARG" 2>/dev/null && pwd -P) || {
 			print_error "Project root is not an accessible directory"
 			return 1
 		}

--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -806,23 +806,31 @@ _detect_self_hosting_task() {
 
 _rf_extract_file_paths_from_text() {
 	local text="$1"
+	local path_text=""
 	local paths=""
 	local dir_paths=""
 	local backtick_files=""
 	local bare_files=""
 
-	dir_paths=$(printf '%s' "$text" | grep -oE '[a-zA-Z0-9._-]+/[a-zA-Z0-9._/-]+\.[a-zA-Z]{1,10}' | sort -u || true)
+	# Generated issue signatures contain a Markdown link whose visible label is
+	# `aidevops.sh`. Treating that footer as an implementation target makes every
+	# later release PR (which commonly touches aidevops.sh) look like a same-file
+	# supersession. URLs and signature metadata are evidence provenance, not files
+	# requested by the finding.
+	path_text=$(printf '%s\n' "$text" | grep -vE '^<!--[[:space:]]*aidevops:sig|^\[aidevops\.sh\]\(https?://|https?://' || true)
+
+	dir_paths=$(printf '%s' "$path_text" | grep -oE '[a-zA-Z0-9._-]+/[a-zA-Z0-9._/-]+\.[a-zA-Z]{1,10}' | sort -u || true)
 	if [[ -n "$dir_paths" ]]; then
 		paths="${paths}${dir_paths}"$'\n'
 	fi
 
 	# shellcheck disable=SC2016 # Literal backtick regex, not shell expansion.
-	backtick_files=$(printf '%s' "$text" | grep -oE '`[a-zA-Z0-9._/-]+\.(sh|ts|js|py|md|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp|cs|dart|jl|kt|m|mm|r|scala|swift)(:[0-9]+(-[0-9]+)?)?`' | tr -d '`' | sed 's/:[0-9]*\(-[0-9]*\)\{0,1\}$//' | sort -u || true)
+	backtick_files=$(printf '%s' "$path_text" | grep -oE '`[a-zA-Z0-9._/-]+\.(sh|ts|js|py|md|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp|cs|dart|jl|kt|m|mm|r|scala|swift)(:[0-9]+(-[0-9]+)?)?`' | tr -d '`' | sed 's/:[0-9]*\(-[0-9]*\)\{0,1\}$//' | sort -u || true)
 	if [[ -n "$backtick_files" ]]; then
 		paths="${paths}${backtick_files}"$'\n'
 	fi
 
-	bare_files=$(printf '%s' "$text" | grep -oE '\b[a-zA-Z0-9_-]+\.(sh|ts|js|py|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp|cs|dart|jl|kt|m|mm|r|scala|swift)\b' | sort -u || true)
+	bare_files=$(printf '%s' "$path_text" | grep -oE '\b[a-zA-Z0-9_-]+\.(sh|ts|js|py|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp|cs|dart|jl|kt|m|mm|r|scala|swift)\b' | sort -u || true)
 	if [[ -n "$bare_files" ]]; then
 		paths="${paths}${bare_files}"$'\n'
 	fi

--- a/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
+++ b/.agents/scripts/tests/test-review-feedback-supersession-validator.sh
@@ -80,6 +80,9 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/issues/* && "$endpoin
 		source-clear | source-ambiguous | source-fetch-failure | duplicate-later | duplicate-canonical | duplicate-lookup-failure)
 			printf '**Source PR**: #50\n\n## Files to modify\n- `.agents/scripts/review-hook.sh`\n\n## Finding\nAdd the event payload guard before worker launch.\n'
 			;;
+		footer-path-noise)
+			printf '**Source PR**: #50\n\n**File**: `.agents/scripts/issue-sync-helper.sh`\n\nAdd an option guard before worker launch.\n\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) automated scan.\n'
+			;;
 		marker-only-duplicate | duplicate-current-absent)
 			printf '<!-- aidevops:generator=review-followup source_pr=50 fingerprint=source-pr-50 -->\n\n## Files to modify\n- `.agents/scripts/review-hook.sh`\n'
 			;;
@@ -135,6 +138,7 @@ if [[ "${1:-}" == "api" && "$endpoint" == "search/issues" ]]; then
 	source-ambiguous) printf '201\n' ;;
 	source-fetch-failure) printf '200\n' ;;
 	no-file) printf '200\n' ;;
+	footer-path-noise) printf '204\n' ;;
 	none) printf '' ;;
 	before) printf '203\n' ;;
 	*) printf '' ;;
@@ -161,6 +165,9 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/pulls/* && "$endpoint
 	203)
 		printf '2026-05-01T09:00:00Z\tfix event payload guard\tAdds a guard for event payload handling.\n'
 		;;
+	204)
+		printf '2026-05-01T11:00:00Z\tfix worker launch guard\tAdds an option guard before worker launch.\n'
+		;;
 	*)
 		printf '\t\t\n'
 		;;
@@ -175,6 +182,7 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/pulls/*/files ]]; the
 	*'.filename'*)
 		case "$pr_number" in
 		200 | 201 | 203) printf '.agents/scripts/review-hook.sh\n' ;;
+		204) printf 'aidevops.sh\n' ;;
 		*) printf '' ;;
 		esac
 		;;
@@ -182,6 +190,7 @@ if [[ "${1:-}" == "api" && "$endpoint" == repos/owner/repo/pulls/*/files ]]; the
 		case "$pr_number" in
 		200 | 203) printf '.agents/scripts/review-hook.sh\n+ add event payload guard before dispatch\n' ;;
 		201) printf '.agents/scripts/review-hook.sh\n+ rename log_context to context_label\n' ;;
+		204) printf 'aidevops.sh\n+ add option guard before worker launch\n' ;;
 		*) printf '' ;;
 		esac
 		;;
@@ -312,6 +321,12 @@ test_no_file_finding_skips_supersession() {
 	return 0
 }
 
+test_signature_footer_path_is_not_target_file() {
+	run_validator_case "footer-path-noise" 0 "signature footer path is ignored"
+	assert_log_not_contains "signature footer does not create false supersession" "issue close 100 --repo owner/repo --reason not planned"
+	return 0
+}
+
 test_no_matching_pr() {
 	run_validator_case "none" 0 "no matching merged PR"
 	assert_log_not_contains "no matching PR does not close" "issue close 100 --repo owner/repo --reason not planned"
@@ -413,6 +428,7 @@ main() {
 	test_source_pr_window_ambiguous_fails_open
 	test_source_pr_fetch_failure_falls_back
 	test_no_file_finding_skips_supersession
+	test_signature_footer_path_is_not_target_file
 	test_no_matching_pr
 	test_merged_pr_before_issue_creation
 	test_precreation_source_pr_window


### PR DESCRIPTION
## Summary

- Exclude generated signature/URL lines from review-feedback target-file extraction.
- Add a regression proving the `aidevops.sh` footer cannot match unrelated release PRs.
- Apply the valid `cd --` hardening from #27189.

## Root cause

Each issue had six 8-34 second setup failures on v3.32.31/v3.32.32, then an inappropriate tier escalation. The mixed-runtime deployment path was independently repaired by merged PR #27250 with atomic runtime bundles. The supersession validator then parsed the generated `[aidevops.sh](...)` footer as a target file and falsely treated #27250 as resolving both issues, although it touched neither cited file.

## Testing

- issue-sync project-root behavioural test
- pre-dispatch validator suite
- review-feedback supersession suite (36 assertions)
- ShellCheck on changed scripts
- `.agents/scripts/linters-local.sh`

## Runtime Testing

Runtime-verified with behavioural fixtures and PR #27250 changed-file evidence.

## Decisions

Keep #27180 closed because current defensive Python modules already handle all three findings. Reopen and resolve #27189 because its cited call remained unchanged.

Resolves #27189
Ref #27180

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.21 with gpt-5.6-sol spent 6m and 96,282 tokens on this with the user in an interactive session.
