### PR TITLE
t18104: feat: automate failure remediation and NMR revalidation

### DIFF
--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -535,4 +535,6 @@ _main() {
 	return 0
 }
 
-_main "$@"
+if [[ "${PULSE_CHECK_SOURCE_ONLY:-0}" != "1" ]]; then
+	_main "$@"
+fi

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -39,6 +39,7 @@ OLD_AVAILABLE_MINUTES="${PULSE_CHECK_OLD_AVAILABLE_MINUTES:-30}"
 FAILURE_FAMILY_THRESHOLD="${PULSE_CHECK_FAILURE_FAMILY_THRESHOLD:-3}"
 FAILURE_FAMILY_RECOVERY_SECONDS="${PULSE_CHECK_FAILURE_FAMILY_RECOVERY_SECONDS:-86400}"
 FAILURE_FAMILY_STATE_FILE="${PULSE_CHECK_FAILURE_FAMILY_STATE_FILE:-${HOME}/.aidevops/cache/failure-family-remediation.json}"
+FAILURE_FAMILY_STATUS_RECURRING="recurring"
 
 _usage() {
 	cat <<EOF
@@ -272,7 +273,7 @@ ${recommendation}
 Privacy note: this issue intentionally uses aggregate counts only; do not add private repo names, private basenames, local paths, or issue titles.
 EOF
 	if [[ -n "$family_fingerprint" ]]; then
-		_failure_family_state_section "$family_fingerprint" "$family_count" "$family_recent_count" "recurring"
+		_failure_family_state_section "$family_fingerprint" "$family_count" "$family_recent_count" "$FAILURE_FAMILY_STATUS_RECURRING"
 	fi
 	return 0
 }
@@ -305,7 +306,7 @@ _refresh_failure_family_issue() {
 	local slug="$1"
 	local issue_number="$2"
 	local finding_json="$3"
-	local outcome_status="${4:-recurring}"
+	local outcome_status="${4:-$FAILURE_FAMILY_STATUS_RECURRING}"
 	local fingerprint=""
 	local count="0"
 	local recent_count="0"
@@ -376,7 +377,7 @@ _apply_finding() {
 		local existing_number=""
 		local existing_url=""
 		IFS=$'\t' read -r existing_number existing_url <<<"$existing"
-		_refresh_failure_family_issue "$slug" "$existing_number" "$finding_json" "recurring"
+		_refresh_failure_family_issue "$slug" "$existing_number" "$finding_json" "$FAILURE_FAMILY_STATUS_RECURRING"
 		print_info "pulse-check: finding=${finding_id} already tracked by #${existing_number} (${existing_url})"
 		return 0
 	fi
@@ -455,7 +456,7 @@ _reconcile_failure_family_remediations() {
 		local recent_count="0"
 		current_count=$(printf '%s' "$family_json" | jq -r '.family_count // 0')
 		recent_count=$(printf '%s' "$family_json" | jq -r '.family_recent_count // 0')
-		local outcome_status="recurring"
+		local outcome_status="$FAILURE_FAMILY_STATUS_RECURRING"
 		if [[ "$current_count" -eq 0 && "$recent_count" -eq 0 ]]; then
 			outcome_status="recovery-candidate"
 		elif [[ "$current_count" -lt "$baseline_count" ]]; then

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -36,6 +36,9 @@ APPLY_MODE=0
 MAX_ISSUES_PER_REPO="${PULSE_CHECK_MAX_ISSUES_PER_REPO:-100}"
 AVAILABLE_THRESHOLD="${PULSE_CHECK_AVAILABLE_THRESHOLD:-3}"
 OLD_AVAILABLE_MINUTES="${PULSE_CHECK_OLD_AVAILABLE_MINUTES:-30}"
+FAILURE_FAMILY_THRESHOLD="${PULSE_CHECK_FAILURE_FAMILY_THRESHOLD:-3}"
+FAILURE_FAMILY_RECOVERY_SECONDS="${PULSE_CHECK_FAILURE_FAMILY_RECOVERY_SECONDS:-86400}"
+FAILURE_FAMILY_STATE_FILE="${PULSE_CHECK_FAILURE_FAMILY_STATE_FILE:-${HOME}/.aidevops/cache/failure-family-remediation.json}"
 
 _usage() {
 	cat <<EOF
@@ -49,6 +52,7 @@ Options:
   --max-issues <N>           Per-repo auto-dispatch issue scan limit (default: ${MAX_ISSUES_PER_REPO})
   --available-threshold <N>  Queue depth threshold for underfill findings (default: ${AVAILABLE_THRESHOLD})
   --old-available-minutes <N> Age threshold for stale available queue counts (default: ${OLD_AVAILABLE_MINUTES})
+  --failure-family-threshold <N> Distinct recurrent family threshold (default: ${FAILURE_FAMILY_THRESHOLD})
   --json                     Emit JSON report
   --apply                    File deduplicated self-improvement issues for autofile findings
   --help                     Show this help
@@ -76,6 +80,7 @@ _parse_args() {
 		--max-issues) MAX_ISSUES_PER_REPO="$next"; shift 2 ;;
 		--available-threshold) AVAILABLE_THRESHOLD="$next"; shift 2 ;;
 		--old-available-minutes) OLD_AVAILABLE_MINUTES="$next"; shift 2 ;;
+		--failure-family-threshold) FAILURE_FAMILY_THRESHOLD="$next"; shift 2 ;;
 		--json) JSON_OUTPUT=1; shift ;;
 		--apply) APPLY_MODE=1; shift ;;
 		help|--help|-h) _usage; exit 0 ;;
@@ -89,6 +94,8 @@ _validate_numeric_options() {
 	[[ "$MAX_ISSUES_PER_REPO" =~ ^[0-9]+$ ]] || MAX_ISSUES_PER_REPO=100
 	[[ "$AVAILABLE_THRESHOLD" =~ ^[0-9]+$ ]] || AVAILABLE_THRESHOLD=3
 	[[ "$OLD_AVAILABLE_MINUTES" =~ ^[0-9]+$ ]] || OLD_AVAILABLE_MINUTES=30
+	[[ "$FAILURE_FAMILY_THRESHOLD" =~ ^[0-9]+$ ]] || FAILURE_FAMILY_THRESHOLD=3
+	[[ "$FAILURE_FAMILY_RECOVERY_SECONDS" =~ ^[0-9]+$ ]] || FAILURE_FAMILY_RECOVERY_SECONDS=86400
 	return 0
 }
 
@@ -156,6 +163,7 @@ _collect_report_json() {
 		--arg since "$SINCE" \
 		--arg recent "$RECENT_SINCE" \
 		--argjson threshold "$AVAILABLE_THRESHOLD" \
+		--argjson failure_threshold "$FAILURE_FAMILY_THRESHOLD" \
 		--argjson current "$current_state" \
 		--argjson summary "$worker_summary" \
 		--argjson recent_summary "$worker_recent" \
@@ -221,6 +229,9 @@ _finding_issue_body() {
 	local severity="$3"
 	local evidence_markdown="$4"
 	local recommendation="$5"
+	local family_fingerprint="${6:-}"
+	local family_count="${7:-0}"
+	local family_recent_count="${8:-0}"
 
 	cat <<EOF
 <!-- aidevops:generator=pulse-check finding=${finding_id} -->
@@ -260,6 +271,87 @@ ${recommendation}
 
 Privacy note: this issue intentionally uses aggregate counts only; do not add private repo names, private basenames, local paths, or issue titles.
 EOF
+	if [[ -n "$family_fingerprint" ]]; then
+		_failure_family_state_section "$family_fingerprint" "$family_count" "$family_recent_count" "recurring"
+	fi
+	return 0
+}
+
+_failure_family_state_section() {
+	local fingerprint="$1"
+	local count="$2"
+	local recent_count="$3"
+	local status="$4"
+	local observed_at=""
+	observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+	cat <<EOF
+
+<!-- failure-family-state:start -->
+<!-- failure-family-state fingerprint=${fingerprint} count=${count} recent_count=${recent_count} status=${status} observed_at=${observed_at} -->
+## Remediation outcome
+
+- Stable fingerprint: ${fingerprint}
+- Historical-window failures: ${count}
+- Recent-window failures: ${recent_count}
+- Outcome: ${status}
+
+This bounded aggregate is refreshed in place; pulse does not post recurrence comments.
+<!-- failure-family-state:end -->
+EOF
+	return 0
+}
+
+_refresh_failure_family_issue() {
+	local slug="$1"
+	local issue_number="$2"
+	local finding_json="$3"
+	local outcome_status="${4:-recurring}"
+	local fingerprint=""
+	local count="0"
+	local recent_count="0"
+	fingerprint=$(printf '%s' "$finding_json" | jq -r '.family_fingerprint // ""')
+	count=$(printf '%s' "$finding_json" | jq -r '.family_count // 0')
+	recent_count=$(printf '%s' "$finding_json" | jq -r '.family_recent_count // 0')
+	[[ -n "$fingerprint" ]] || return 0
+
+	local body=""
+	body=$(gh api "repos/${slug}/issues/${issue_number}" --jq '.body // ""' 2>/dev/null) || return 0
+	local current_marker="fingerprint=${fingerprint} count=${count} recent_count=${recent_count} status=${outcome_status}"
+	if [[ "$body" == *"${current_marker}"* ]]; then
+		return 0
+	fi
+
+	local section=""
+	section=$(_failure_family_state_section "$fingerprint" "$count" "$recent_count" "$outcome_status")
+	local start_marker='<!-- failure-family-state:start -->'
+	local end_marker='<!-- failure-family-state:end -->'
+	local updated_body=""
+	updated_body=$(jq -nr \
+		--arg body "$body" --arg section "$section" --arg start "$start_marker" --arg end "$end_marker" '
+		if (($body | contains($start)) and ($body | contains($end))) then
+			($body | split($start) | .[0]) + $section + ($body | split($end) | .[1])
+		else $body + "\n\n" + $section end') || return 0
+
+	local body_file=""
+	body_file=$(mktemp "${TMPDIR:-/tmp}/pulse-check-refresh.XXXXXX") || return 0
+	printf '%s\n' "$updated_body" >"$body_file"
+	gh issue edit "$issue_number" --repo "$slug" --body-file "$body_file" >/dev/null 2>&1 || true
+	rm -f "$body_file"
+	return 0
+}
+
+_record_failure_family_state() {
+	local report_json="$1"
+	local state_dir="${FAILURE_FAMILY_STATE_FILE%/*}"
+	[[ "$state_dir" != "$FAILURE_FAMILY_STATE_FILE" ]] || return 0
+	mkdir -p "$state_dir" 2>/dev/null || return 0
+	local tmp_file=""
+	tmp_file=$(mktemp "${state_dir}/.failure-family-remediation.XXXXXX") || return 0
+	printf '%s' "$report_json" | jq '{
+		updated_at: now,
+		families: [.failure_family_remediation[]? | {fingerprint, family, count, recent_count, confidence, recovery_outcome}]
+	}' >"$tmp_file" 2>/dev/null || { rm -f "$tmp_file"; return 0; }
+	mv "$tmp_file" "$FAILURE_FAMILY_STATE_FILE" 2>/dev/null || rm -f "$tmp_file"
 	return 0
 }
 
@@ -284,6 +376,7 @@ _apply_finding() {
 		local existing_number=""
 		local existing_url=""
 		IFS=$'\t' read -r existing_number existing_url <<<"$existing"
+		_refresh_failure_family_issue "$slug" "$existing_number" "$finding_json" "recurring"
 		print_info "pulse-check: finding=${finding_id} already tracked by #${existing_number} (${existing_url})"
 		return 0
 	fi
@@ -297,7 +390,14 @@ _apply_finding() {
 
 	local body_file=""
 	body_file=$(mktemp "${TMPDIR:-/tmp}/pulse-check-issue.XXXXXX") || return 1
-	_finding_issue_body "$finding_id" "$title" "$severity" "$evidence_markdown" "$recommendation" >"$body_file"
+	local family_fingerprint=""
+	local family_count="0"
+	local family_recent_count="0"
+	family_fingerprint=$(printf '%s' "$finding_json" | jq -r '.family_fingerprint // ""')
+	family_count=$(printf '%s' "$finding_json" | jq -r '.family_count // 0')
+	family_recent_count=$(printf '%s' "$finding_json" | jq -r '.family_recent_count // 0')
+	_finding_issue_body "$finding_id" "$title" "$severity" "$evidence_markdown" "$recommendation" \
+		"$family_fingerprint" "$family_count" "$family_recent_count" >"$body_file"
 
 	local labels="auto-dispatch,tier:standard,bug,framework,pulse,self-improvement,source:pulse-check"
 	local issue_output=""
@@ -312,6 +412,77 @@ _apply_finding() {
 	return 0
 }
 
+_failure_family_writes_allowed() {
+	local report_json="$1"
+	if printf '%s' "$report_json" | jq -e '
+		(.current_state.dispatch_api_blocked // false) == true
+		or ((.api_budget.secondary_cooldown_state // "") | contains("active=yes"))
+	' >/dev/null 2>&1; then
+		return 1
+	fi
+	return 0
+}
+
+_reconcile_failure_family_remediations() {
+	local slug="$1"
+	local report_json="$2"
+	local tracked_json="[]"
+	tracked_json=$(gh issue list --repo "$slug" --state open \
+		--search 'in:body "failure-family-state:start"' --limit 100 \
+		--json number,body,createdAt,url 2>/dev/null) || tracked_json="[]"
+	printf '%s' "$tracked_json" | jq empty >/dev/null 2>&1 || tracked_json="[]"
+
+	while IFS= read -r issue_json; do
+		[[ -n "$issue_json" ]] || continue
+		local issue_number=""
+		local body=""
+		local created_at=""
+		local fingerprint=""
+		local baseline_count="0"
+		issue_number=$(printf '%s' "$issue_json" | jq -r '.number // ""')
+		body=$(printf '%s' "$issue_json" | jq -r '.body // ""')
+		created_at=$(printf '%s' "$issue_json" | jq -r '.createdAt // ""')
+		fingerprint=$(jq -nr --arg body "$body" '$body | try capture("failure-family-state fingerprint=(?<value>[^ ]+)").value catch ""')
+		baseline_count=$(jq -nr --arg body "$body" '$body | try (capture("failure-family-state fingerprint=[^ ]+ count=(?<value>[0-9]+)").value | tonumber) catch 0')
+		[[ "$issue_number" =~ ^[0-9]+$ && -n "$fingerprint" ]] || continue
+
+		local family_json=""
+		family_json=$(printf '%s' "$report_json" | jq -c --arg fingerprint "$fingerprint" '
+			([.failure_family_remediation[]? | select(.fingerprint == $fingerprint)] | first)
+			// {fingerprint:$fingerprint, family:($fingerprint | sub("^ff-v1:"; "")), count:0, recent_count:0, confidence:"none", recovery_outcome:"not-observed"}
+			| {family_fingerprint:.fingerprint, family:.family, family_count:(.count // 0), family_recent_count:(.recent_count // 0), family_confidence:(.confidence // "none")}')
+		local current_count="0"
+		local recent_count="0"
+		current_count=$(printf '%s' "$family_json" | jq -r '.family_count // 0')
+		recent_count=$(printf '%s' "$family_json" | jq -r '.family_recent_count // 0')
+		local outcome_status="recurring"
+		if [[ "$current_count" -eq 0 && "$recent_count" -eq 0 ]]; then
+			outcome_status="recovery-candidate"
+		elif [[ "$current_count" -lt "$baseline_count" ]]; then
+			outcome_status="improving"
+		fi
+
+		local created_epoch="0"
+		local age_seconds="0"
+		created_epoch=$(jq -nr --arg value "$created_at" 'try ($value | fromdateiso8601) catch 0')
+		[[ "$created_epoch" =~ ^[0-9]+$ ]] || created_epoch=0
+		if [[ "$created_epoch" -gt 0 ]]; then
+			age_seconds=$(( $(date +%s) - created_epoch ))
+		fi
+		if [[ "$outcome_status" == "recovery-candidate" && "$age_seconds" -ge "$FAILURE_FAMILY_RECOVERY_SECONDS" ]]; then
+			outcome_status="eliminated"
+		fi
+		_refresh_failure_family_issue "$slug" "$issue_number" "$family_json" "$outcome_status"
+
+		if [[ "$outcome_status" == "eliminated" ]]; then
+			gh issue close "$issue_number" --repo "$slug" \
+				--comment "<!-- failure-family-recovery --> Stable aggregate ${fingerprint} recorded zero failures in both the ${SINCE} historical and ${RECENT_SINCE} recent windows after a ${age_seconds}s observation period. Closing with measured recovery evidence." \
+				>/dev/null 2>&1 || true
+		fi
+	done < <(printf '%s' "$tracked_json" | jq -c '.[]')
+	return 0
+}
+
 _apply_findings() {
 	local report_json="$1"
 	local slug=""
@@ -319,6 +490,10 @@ _apply_findings() {
 	if [[ -z "$slug" ]]; then
 		print_error "pulse-check: --apply requires --repo <owner/repo> or a gh repo context"
 		return 1
+	fi
+	if ! _failure_family_writes_allowed "$report_json"; then
+		print_warning "pulse-check: skipping issue writes while GitHub API cooldown or dispatch API block is active"
+		return 0
 	fi
 
 	local applied_count=0
@@ -331,6 +506,7 @@ _apply_findings() {
 	if [[ "$applied_count" -eq 0 ]]; then
 		print_info "pulse-check: no autofile findings above thresholds"
 	fi
+	_reconcile_failure_family_remediations "$slug" "$report_json"
 	return 0
 }
 
@@ -345,6 +521,7 @@ _main() {
 
 	local report_json=""
 	report_json=$(_collect_report_json)
+	_record_failure_family_state "$report_json"
 
 	if [[ "$APPLY_MODE" -eq 1 ]]; then
 		_apply_findings "$report_json"

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -27,6 +27,8 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
 ($summary.metrics.total // 0 | number_or_zero) as $hist_total |
 ($summary.metrics.terminal_session_total // $summary.metrics.total // 0 | number_or_zero) as $hist_terminal_total |
 ($summary.metrics.succeeded // 0 | number_or_zero) as $hist_success |
+($summary.metrics.failure_families // []) as $failure_families |
+($recent_summary.metrics.failure_families // []) as $recent_failure_families |
 ($api.graphql_circuit_breaker_trips // 0 | number_or_zero) as $graphql_trips |
 {
   generated_at: (now | todateiso8601),
@@ -53,7 +55,8 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     auto_dispatch_scan_errors: $gh_errors,
     auto_dispatch_scan_state: (if $queue_error == "" then "scanned" else $queue_error end),
     graphql_budget_status: ($current.graphql_budget_status // "unknown"),
-    runner_health: ($runner.finding // "unknown")
+    runner_health: ($runner.finding // "unknown"),
+    recurrent_failure_families: ([$failure_families[] | select((.count // 0) >= $failure_threshold and (.confidence // "low") == "high" and (.family // "") != "other-failure")] | length)
   },
   queue: ($queue.aggregate // {}),
   current_state: {
@@ -79,6 +82,17 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     },
     providers: ($providers.provider_diagnostics // {})
   },
+  failure_family_remediation: ($failure_families | map(. as $family | {
+    fingerprint,
+    family,
+    count,
+    distinct_sessions,
+    first_ts,
+    last_ts,
+    confidence,
+    recovery_outcome,
+    recent_count: (([$recent_failure_families[] | select(.fingerprint == $family.fingerprint)] | first | .count) // 0)
+  })),
   runner_health: $runner,
   api_budget: {
     graphql_circuit_breaker_trips: ($api.graphql_circuit_breaker_trips // 0),
@@ -170,5 +184,33 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
         false
       )
     else empty end
+    ,
+    ($failure_families[] as $family
+      | $family
+      | select((.count // 0) >= $failure_threshold and (.distinct_sessions // 0) >= 2 and (.confidence // "low") == "high" and (.family // "") != "other-failure")
+      | finding(
+          ("worker-failure-family-" + (.family // "unknown"));
+          "high";
+          ("Remediate recurrent worker failure family: " + (.family // "unknown"));
+          [
+            ("fingerprint=" + (.fingerprint // "unknown")),
+            ("family=" + (.family // "unknown")),
+            ("failures_in_window=" + ((.count // 0) | tostring)),
+            ("distinct_sessions=" + ((.distinct_sessions // 0) | tostring)),
+            ("confidence=" + (.confidence // "unknown")),
+            ("first_observed_epoch=" + ((.first_ts // 0) | tostring)),
+            ("last_observed_epoch=" + ((.last_ts // 0) | tostring))
+          ];
+          "Fix or reclassify this stable failure family, add a fixture for its canonical metric shape, and verify that its recurrence count falls below threshold in both recent and historical windows.";
+          true
+        ) + {
+          family_fingerprint: (.fingerprint // ""),
+          family: (.family // "unknown"),
+          family_count: (.count // 0),
+          family_recent_count: (([$recent_failure_families[] | select(.fingerprint == $family.fingerprint)] | first | .count) // 0),
+          family_first_ts: (.first_ts // 0),
+          family_last_ts: (.last_ts // 0),
+          family_confidence: (.confidence // "unknown")
+        })
   ])
 }

--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -28,6 +28,48 @@ _seconds() {
 	return 0
 }
 
+_state_file_json() {
+	local path="$1"
+	if [[ -f "$path" ]]; then
+		local content=""
+		content=$(cat "$path" 2>/dev/null) || content="{}"
+		if printf '%s' "$content" | jq empty >/dev/null 2>&1; then
+			printf '%s\n' "$content"
+			return 0
+		fi
+	fi
+	printf '{}\n'
+	return 0
+}
+
+_observability_overlay_json() {
+	local nmr_state_file="${AIDEVOPS_NMR_REVALIDATION_STATE_FILE:-${HOME}/.aidevops/cache/nmr-revalidation-state.json}"
+	local family_state_file="${PULSE_CHECK_FAILURE_FAMILY_STATE_FILE:-${HOME}/.aidevops/cache/failure-family-remediation.json}"
+	local nmr_state="{}"
+	local family_state="{}"
+	nmr_state=$(_state_file_json "$nmr_state_file")
+	family_state=$(_state_file_json "$family_state_file")
+	jq -n --argjson nmr "$nmr_state" --argjson families "$family_state" '
+		($nmr.entries // {} | [.[]]) as $entries
+		| {
+			nmr_revalidation: {
+				total: ($entries | length),
+				reason_counts: (reduce $entries[] as $entry ({}; .[$entry.code // "authority"] += 1)),
+				status_counts: (reduce $entries[] as $entry ({}; .[$entry.status // "unknown"] += 1)),
+				temporary_count: ([$entries[] | select(.class == "temporary")] | length),
+				genuine_authority_count: ([$entries[] | select(.class == "genuine-authority")] | length),
+				oldest_age_seconds: ([$entries[] | try (now - (.label_at | fromdateiso8601) | floor) catch empty] | if length > 0 then max else 0 end)
+			},
+			failure_family_remediation: {
+				updated_at: ($families.updated_at // null),
+				families: [($families.families // [])[] | {fingerprint, family, count, recent_count, confidence, recovery_outcome}],
+				recurrent_count: ([($families.families // [])[] | select((.count // 0) >= 3)] | length),
+				recovery_candidate_count: ([($families.families // [])[] | select((.count // 0) == 0 and (.recent_count // 0) == 0)] | length)
+			}
+		}'
+	return 0
+}
+
 main() {
 	local window="15m"
 	local repo_path="${AIDEVOPS_REPO_PATH:-$HOME/Git/aidevops}"
@@ -72,15 +114,40 @@ main() {
 	fi
 	runtime_state_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-pulse-runtime-state.XXXXXX") || runtime_state_file=""
 	local projection_status=0
+	local projection_output=""
 	AIDEVOPS_ACTIVE_WORKER_PROCESSES="$active_worker_processes" \
 		AIDEVOPS_WORKER_WORKTREE_COUNT="$worker_worktree_count" \
 		AIDEVOPS_GRAPHQL_BUDGET_STATUS="$graphql_budget_status" \
 		AIDEVOPS_OBJECTIVE_STATE_FILE="$objective_state_file" \
 		AIDEVOPS_RUNTIME_STATE_OUTPUT="$runtime_state_file" \
-		python3 "${SCRIPT_DIR}/pulse-current-state.py" \
+		projection_output=$(python3 "${SCRIPT_DIR}/pulse-current-state.py" \
 			"$log_dir" "$repo_path" "$window_s" "$as_json" "$SCRIPT_DIR" \
-			"$review_thread_state_dir" || projection_status=$?
+			"$review_thread_state_dir") || projection_status=$?
+	local overlay_json="{}"
+	overlay_json=$(_observability_overlay_json)
+	if [[ "$projection_status" -eq 0 && "$as_json" -eq 1 ]] && printf '%s' "$projection_output" | jq empty >/dev/null 2>&1; then
+		projection_output=$(jq -n --argjson base "$projection_output" --argjson overlay "$overlay_json" '$base + $overlay')
+	elif [[ "$projection_status" -eq 0 ]]; then
+		projection_output+=$'\n'
+		projection_output+="NMR revalidation: $(printf '%s' "$overlay_json" | jq -c '.nmr_revalidation')"
+		projection_output+=$'\n'
+		projection_output+="Failure-family remediation: $(printf '%s' "$overlay_json" | jq -c '.failure_family_remediation')"
+	fi
+	printf '%s\n' "$projection_output"
 	if [[ "$projection_status" -eq 0 && -s "$runtime_state_file" ]] && command -v node >/dev/null 2>&1; then
+		local runtime_tmp=""
+		runtime_tmp=$(mktemp "${TMPDIR:-/tmp}/aidevops-pulse-runtime-overlay.XXXXXX") || runtime_tmp=""
+		if [[ -n "$runtime_tmp" ]] && jq --argjson overlay "$overlay_json" '. + {
+			nmr_revalidation: $overlay.nmr_revalidation,
+			failure_family_remediation: {
+				recurrent_count: $overlay.failure_family_remediation.recurrent_count,
+				recovery_candidate_count: $overlay.failure_family_remediation.recovery_candidate_count
+			}
+		}' "$runtime_state_file" >"$runtime_tmp" 2>/dev/null; then
+			mv "$runtime_tmp" "$runtime_state_file"
+		else
+			rm -f "$runtime_tmp" 2>/dev/null || true
+		fi
 		node "${SCRIPT_DIR}/runtime-events.mjs" state auto "pulse:current" - <"$runtime_state_file" \
 			>/dev/null 2>&1 || true
 	fi

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -979,6 +979,61 @@ Automation will preserve this gate and will not treat elapsed time as approval."
 	return 0
 }
 
+_nmr_latest_event_json() {
+	local issue_num="$1"
+	local slug="$2"
+	gh api "repos/${slug}/issues/${issue_num}/timeline" --paginate --slurp \
+		2>/dev/null | jq -c '
+			(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+			elif type == "array" then .
+			else [] end)
+			| [.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")]
+			| last
+			| {actor:(.actor.login // ""),at:(.created_at // "")}' 2>/dev/null
+	return $?
+}
+
+_nmr_evaluate_reason_metadata() {
+	local issue_num="$1"
+	local slug="$2"
+	local nmr_at="$3"
+	_NMR_REASON_ACTION="continue"
+	_NMR_REASON_OVERRIDE=""
+	[[ -n "$nmr_at" ]] || return 0
+
+	local reason_metadata=""
+	local reason_code=""
+	local reason_class=""
+	local reason_source=""
+	reason_metadata=$(_nmr_reason_metadata "$issue_num" "$slug")
+	reason_code=$(printf '%s' "$reason_metadata" | jq -r '.code // "authority"' 2>/dev/null) || reason_code="authority"
+	reason_class=$(printf '%s' "$reason_metadata" | jq -r '.class // "genuine-authority"' 2>/dev/null) || reason_class="genuine-authority"
+	reason_source=$(printf '%s' "$reason_metadata" | jq -r '.source // "default"' 2>/dev/null) || reason_source="default"
+	if [[ "$reason_class" == "temporary" ]]; then
+		_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "scheduled" || true
+		if _nmr_revalidation_due "$reason_metadata" "$nmr_at"; then
+			local resolved_reason=""
+			resolved_reason=$(_nmr_temporary_assumption_resolved "$issue_num" "$slug" "$reason_code" "$nmr_at") || resolved_reason=""
+			if [[ -n "$resolved_reason" ]]; then
+				#aidevops:trust-boundary -- only trusted markers and existing breaker checks can release temporary NMR
+				_NMR_REASON_ACTION="auto"
+				_NMR_REASON_OVERRIDE="temporary NMR revalidated (${reason_code}): ${resolved_reason}"
+				_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "automatable" || true
+				return 0
+			fi
+			_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "rechecked-unresolved" || true
+		fi
+		_NMR_REASON_ACTION="preserve"
+		return 0
+	fi
+	if [[ "$reason_source" != "default" ]]; then
+		_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "human-authority-required" || true
+		_nmr_emit_decision_packet "$issue_num" "$slug" "$reason_code" || true
+		_NMR_REASON_ACTION="preserve"
+	fi
+	return 0
+}
+
 #######################################
 # Check if the needs-maintainer-review label was most recently applied
 # by the maintainer themselves (indicating a manual hold), OR by a
@@ -1020,54 +1075,25 @@ _nmr_applied_by_maintainer() {
 	[[ -n "$issue_num" && -n "$slug" && -n "$maintainer" ]] || return 1
 
 	# Fetch both actor and creation timestamp of the latest NMR label event.
-	# Use --slurp for paginated timeline reads, then flatten page arrays before
-	# selecting the latest event. Without this, long timelines emit one result per
-	# page and can pass malformed multi-line timestamps into the breaker checks.
-	local nmr_event_json
-	nmr_event_json=$(gh api "repos/${slug}/issues/${issue_num}/timeline" --paginate --slurp \
-		2>/dev/null | jq -c '
-			(if type == "array" and (.[0]? | type) == "array" then [.[][]]
-			elif type == "array" then .
-			else [] end)
-			| [.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")]
-			| last
-			| {actor:(.actor.login // ""),at:(.created_at // "")}' \
-		2>/dev/null) || nmr_event_json=""
+	local nmr_event_json=""
+	nmr_event_json=$(_nmr_latest_event_json "$issue_num" "$slug") || nmr_event_json=""
 
 	local nmr_actor nmr_at
 	nmr_actor=$(printf '%s' "$nmr_event_json" | jq -r '.actor // ""' 2>/dev/null) || nmr_actor=""
 	nmr_at=$(printf '%s' "$nmr_event_json" | jq -r '.at // ""' 2>/dev/null) || nmr_at=""
 
-	if [[ -n "$nmr_at" ]]; then
-		local reason_metadata=""
-		local reason_code=""
-		local reason_class=""
-		local reason_source=""
-		reason_metadata=$(_nmr_reason_metadata "$issue_num" "$slug")
-		reason_code=$(printf '%s' "$reason_metadata" | jq -r '.code // "authority"' 2>/dev/null) || reason_code="authority"
-		reason_class=$(printf '%s' "$reason_metadata" | jq -r '.class // "genuine-authority"' 2>/dev/null) || reason_class="genuine-authority"
-		reason_source=$(printf '%s' "$reason_metadata" | jq -r '.source // "default"' 2>/dev/null) || reason_source="default"
-		if [[ "$reason_class" == "temporary" ]]; then
-			_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "scheduled" || true
-			if _nmr_revalidation_due "$reason_metadata" "$nmr_at"; then
-				local resolved_reason=""
-				resolved_reason=$(_nmr_temporary_assumption_resolved "$issue_num" "$slug" "$reason_code" "$nmr_at") || resolved_reason=""
-				if [[ -n "$resolved_reason" ]]; then
-					_NMR_AUTO_APPROVAL_REASON_OVERRIDE="temporary NMR revalidated (${reason_code}): ${resolved_reason}"
-					_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "automatable" || true
-					echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — temporary reason=${reason_code} revalidated; allowing trusted maintainer-authored retry" >>"$LOGFILE"
-					return 1
-				fi
-				_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "rechecked-unresolved" || true
-			fi
-			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — temporary reason=${reason_code} remains unresolved; preserving NMR until scheduled revalidation" >>"$LOGFILE"
+	_nmr_evaluate_reason_metadata "$issue_num" "$slug" "$nmr_at"
+	case "$_NMR_REASON_ACTION" in
+		auto)
+			_NMR_AUTO_APPROVAL_REASON_OVERRIDE="$_NMR_REASON_OVERRIDE"
+			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — temporary NMR revalidated; allowing trusted maintainer-authored retry" >>"$LOGFILE"
+			return 1
+			;;
+		preserve)
+			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — reason-coded NMR remains gated" >>"$LOGFILE"
 			return 0
-		elif [[ "$reason_source" != "default" ]]; then
-			_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "human-authority-required" || true
-			_nmr_emit_decision_packet "$issue_num" "$slug" "$reason_code" || true
-			return 0
-		fi
-	fi
+			;;
+	esac
 
 	# Breaker signatures are authoritative regardless of the token actor. Pulse can
 	# run under any trusted maintainer/member account, so actor-gating this check

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -37,6 +37,7 @@
 # Include guard — prevent double-sourcing.
 [[ -n "${_PULSE_NMR_APPROVAL_LOADED:-}" ]] && return 0
 _PULSE_NMR_APPROVAL_LOADED=1
+NMR_SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)" || return 1
 
 if ! declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
 	_PULSE_NMR_APPROVAL_DIR="${BASH_SOURCE[0]%/*}"
@@ -57,6 +58,35 @@ fi
 
 NMR_REVALIDATION_STATE_FILE="${AIDEVOPS_NMR_REVALIDATION_STATE_FILE:-${HOME}/.aidevops/cache/nmr-revalidation-state.json}"
 NMR_TEMPORARY_REVALIDATE_SECONDS="${AIDEVOPS_NMR_TEMPORARY_REVALIDATE_SECONDS:-3600}"
+NMR_REASON_FILTER="${NMR_SCRIPT_DIR}/pulse-nmr-reason.jq"
+NMR_TRUSTED_RESOLUTION_FILTER="${NMR_SCRIPT_DIR}/pulse-nmr-trusted-resolution.jq"
+NMR_STATE_RECORD_FILTER="${NMR_SCRIPT_DIR}/pulse-nmr-state-record.jq"
+NMR_LATEST_EVENT_FILTER="${NMR_SCRIPT_DIR}/pulse-nmr-latest-event.jq"
+NMR_API_COMMENTS_SUFFIX="/comments"
+NMR_REASON_AUTHORITY="authority"
+NMR_CLASS_GENUINE_AUTHORITY="genuine-authority"
+NMR_CLASS_TEMPORARY="temporary"
+NMR_SOURCE_DEFAULT="default"
+NMR_STATUS_HUMAN_AUTHORITY="human-authority-required"
+
+_nmr_metadata_json() {
+	local code="$1"
+	local reason_class="$2"
+	local source="$3"
+	local requires_crypto="$4"
+	jq -cn --arg code "$code" --arg class "$reason_class" --arg source "$source" \
+		--argjson requires_crypto "$requires_crypto" \
+		'{code:$code,class:$class,source:$source,revalidate_after_seconds:null,requires_crypto:$requires_crypto}'
+	return 0
+}
+
+_nmr_issue_api_path() {
+	local issue_num="$1"
+	local slug="$2"
+	local suffix="${3:-}"
+	printf 'repos/%s/issues/%s%s\n' "$slug" "$issue_num" "$suffix"
+	return 0
+}
 
 #######################################
 # Cached ever-NMR provenance helpers (GH#17458)
@@ -847,28 +877,9 @@ _nmr_reason_metadata_from_comments() {
 	local comments_json="$1"
 	local revalidate_seconds="$NMR_TEMPORARY_REVALIDATE_SECONDS"
 	[[ "$revalidate_seconds" =~ ^[0-9]+$ ]] || revalidate_seconds=3600
-	printf '%s' "$comments_json" | jq -c --argjson revalidate "$revalidate_seconds" '
-		def metadata($code; $class; $source): {
-			code:$code,
-			class:$class,
-			source:$source,
-			revalidate_after_seconds:(if $class == "temporary" then $revalidate else null end),
-			requires_crypto:($class == "genuine-authority")
-		};
-		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
-		 elif type == "array" then . else [] end) as $comments
-		| ([$comments[].body // "" | try capture("nmr-reason code=(?<code>[a-z_-]+) class=(?<class>genuine-authority|temporary)") catch empty] | last) as $explicit
-		| ($comments | map(.body // "") | join("\n") | ascii_downcase) as $text
-		| if $explicit != null then metadata($explicit.code; $explicit.class; "structured-marker")
-		  elif ($text | test("secret|required credential|credential access")) then metadata("secret"; "genuine-authority"; "legacy-marker")
-		  elif ($text | test("destructive|data deletion|irreversible")) then metadata("destructive"; "genuine-authority"; "legacy-marker")
-		  elif ($text | test("billing|cost-circuit-breaker|spend approval")) then metadata("billing"; "genuine-authority"; "legacy-marker")
-		  elif ($text | test("security-sensitive|supply.chain|auth boundary")) then metadata("security"; "genuine-authority"; "legacy-marker")
-		  elif ($text | test("rate_limit_nmr|dispatch-infrastructure-failure|local runtime|launch failure")) then metadata("transient_infrastructure"; "temporary"; "legacy-marker")
-		  elif ($text | test("missing implementation context|missing context")) then metadata("missing_context"; "temporary"; "legacy-marker")
-		  elif ($text | test("stale-recovery|worker_recovery_loop|diagnostic ambiguity")) then metadata("diagnostic_ambiguity"; "temporary"; "legacy-marker")
-		  else metadata("authority"; "genuine-authority"; "default") end
-	' 2>/dev/null || printf '{"code":"authority","class":"genuine-authority","source":"default","revalidate_after_seconds":null,"requires_crypto":true}\n'
+	printf '%s' "$comments_json" | jq -c --argjson revalidate "$revalidate_seconds" \
+		-f "$NMR_REASON_FILTER" 2>/dev/null || \
+		_nmr_metadata_json "$NMR_REASON_AUTHORITY" "$NMR_CLASS_GENUINE_AUTHORITY" "$NMR_SOURCE_DEFAULT" true
 	return 0
 }
 
@@ -876,7 +887,9 @@ _nmr_reason_metadata() {
 	local issue_num="$1"
 	local slug="$2"
 	local comments_json="[]"
-	comments_json=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate --slurp 2>/dev/null) || comments_json="[]"
+	local comments_path=""
+	comments_path=$(_nmr_issue_api_path "$issue_num" "$slug" "$NMR_API_COMMENTS_SUFFIX")
+	comments_json=$(gh api "$comments_path" --paginate --slurp 2>/dev/null) || comments_json="[]"
 	_nmr_reason_metadata_from_comments "$comments_json"
 	return 0
 }
@@ -910,7 +923,9 @@ _nmr_temporary_assumption_resolved() {
 	fi
 
 	local issue_json="{}"
-	issue_json=$(gh api "repos/${slug}/issues/${issue_num}" 2>/dev/null) || issue_json="{}"
+	local issue_path=""
+	issue_path=$(_nmr_issue_api_path "$issue_num" "$slug")
+	issue_json=$(gh api "$issue_path" 2>/dev/null) || issue_json="{}"
 	if [[ "$code" == "missing_context" ]] && printf '%s' "$issue_json" | jq -e '
 		((.body // "") | contains("## Worker Guidance")) and
 		((.body // "") | contains("### Verification"))
@@ -920,12 +935,10 @@ _nmr_temporary_assumption_resolved() {
 	fi
 
 	local comments_json="[]"
-	comments_json=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate --slurp 2>/dev/null) || comments_json="[]"
-	if printf '%s' "$comments_json" | jq -e '
-		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
-		 elif type == "array" then . else [] end)
-		| any(.[]; ((.author_association // "") | IN("OWNER", "MEMBER", "COLLABORATOR")) and ((.body // "") | contains("<!-- nmr-revalidation resolved=true")))
-	' >/dev/null 2>&1; then
+	local comments_path=""
+	comments_path=$(_nmr_issue_api_path "$issue_num" "$slug" "$NMR_API_COMMENTS_SUFFIX")
+	comments_json=$(gh api "$comments_path" --paginate --slurp 2>/dev/null) || comments_json="[]"
+	if printf '%s' "$comments_json" | jq -e -f "$NMR_TRUSTED_RESOLUTION_FILTER" >/dev/null 2>&1; then
 		printf 'trusted revalidation evidence resolved the temporary assumption\n'
 		return 0
 	fi
@@ -949,11 +962,9 @@ _nmr_record_revalidation_state() {
 	local key="${slug}#${issue_num}"
 	local tmp_file=""
 	tmp_file=$(mktemp "${state_dir}/.nmr-revalidation.XXXXXX") || return 0
-	printf '%s' "$current" | jq --arg key "$key" --arg label_at "$label_at" --arg status "$status" --argjson metadata "$metadata_json" '
-		.entries = (.entries // {})
-		| .entries[$key] = ($metadata + {label_at:$label_at, status:$status, checked_at:now})
-		| .updated_at = now
-	' >"$tmp_file" 2>/dev/null || { rm -f "$tmp_file"; return 0; }
+	printf '%s' "$current" | jq --arg key "$key" --arg label_at "$label_at" --arg status "$status" \
+		--argjson metadata "$metadata_json" -f "$NMR_STATE_RECORD_FILTER" \
+		>"$tmp_file" 2>/dev/null || { rm -f "$tmp_file"; return 0; }
 	mv "$tmp_file" "$NMR_REVALIDATION_STATE_FILE" 2>/dev/null || rm -f "$tmp_file"
 	return 0
 }
@@ -964,7 +975,9 @@ _nmr_emit_decision_packet() {
 	local reason_code="$3"
 	local marker="nmr-decision-packet reason=${reason_code}"
 	local prior_count="0"
-	prior_count=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate \
+	local comments_path=""
+	comments_path=$(_nmr_issue_api_path "$issue_num" "$slug" "$NMR_API_COMMENTS_SUFFIX")
+	prior_count=$(gh api "$comments_path" --paginate \
 		--jq "[.[] | select((.body // \"\") | contains(\"${marker}\"))] | length" 2>/dev/null) || prior_count=0
 	[[ "$prior_count" =~ ^[0-9]+$ ]] || prior_count=0
 	[[ "$prior_count" -eq 0 ]] || return 0
@@ -982,14 +995,10 @@ Automation will preserve this gate and will not treat elapsed time as approval."
 _nmr_latest_event_json() {
 	local issue_num="$1"
 	local slug="$2"
-	gh api "repos/${slug}/issues/${issue_num}/timeline" --paginate --slurp \
-		2>/dev/null | jq -c '
-			(if type == "array" and (.[0]? | type) == "array" then [.[][]]
-			elif type == "array" then .
-			else [] end)
-			| [.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")]
-			| last
-			| {actor:(.actor.login // ""),at:(.created_at // "")}' 2>/dev/null
+	local timeline_path=""
+	timeline_path=$(_nmr_issue_api_path "$issue_num" "$slug" "/timeline")
+	gh api "$timeline_path" --paginate --slurp \
+		2>/dev/null | jq -c -f "$NMR_LATEST_EVENT_FILTER" 2>/dev/null
 	return $?
 }
 
@@ -1006,10 +1015,10 @@ _nmr_evaluate_reason_metadata() {
 	local reason_class=""
 	local reason_source=""
 	reason_metadata=$(_nmr_reason_metadata "$issue_num" "$slug")
-	reason_code=$(printf '%s' "$reason_metadata" | jq -r '.code // "authority"' 2>/dev/null) || reason_code="authority"
-	reason_class=$(printf '%s' "$reason_metadata" | jq -r '.class // "genuine-authority"' 2>/dev/null) || reason_class="genuine-authority"
-	reason_source=$(printf '%s' "$reason_metadata" | jq -r '.source // "default"' 2>/dev/null) || reason_source="default"
-	if [[ "$reason_class" == "temporary" ]]; then
+	reason_code=$(printf '%s' "$reason_metadata" | jq -r --arg fallback "$NMR_REASON_AUTHORITY" '.code // $fallback' 2>/dev/null) || reason_code="$NMR_REASON_AUTHORITY"
+	reason_class=$(printf '%s' "$reason_metadata" | jq -r --arg fallback "$NMR_CLASS_GENUINE_AUTHORITY" '.class // $fallback' 2>/dev/null) || reason_class="$NMR_CLASS_GENUINE_AUTHORITY"
+	reason_source=$(printf '%s' "$reason_metadata" | jq -r --arg fallback "$NMR_SOURCE_DEFAULT" '.source // $fallback' 2>/dev/null) || reason_source="$NMR_SOURCE_DEFAULT"
+	if [[ "$reason_class" == "$NMR_CLASS_TEMPORARY" ]]; then
 		_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "scheduled" || true
 		if _nmr_revalidation_due "$reason_metadata" "$nmr_at"; then
 			local resolved_reason=""
@@ -1026,8 +1035,8 @@ _nmr_evaluate_reason_metadata() {
 		_NMR_REASON_ACTION="preserve"
 		return 0
 	fi
-	if [[ "$reason_source" != "default" ]]; then
-		_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "human-authority-required" || true
+	if [[ "$reason_source" != "$NMR_SOURCE_DEFAULT" ]]; then
+		_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "$NMR_STATUS_HUMAN_AUTHORITY" || true
 		_nmr_emit_decision_packet "$issue_num" "$slug" "$reason_code" || true
 		_NMR_REASON_ACTION="preserve"
 	fi
@@ -1133,8 +1142,9 @@ _nmr_applied_by_maintainer() {
 	fi
 
 	if _nmr_application_is_security_sensitive "$issue_num" "$slug"; then
-		local security_metadata='{"code":"security","class":"genuine-authority","source":"security-label","revalidate_after_seconds":null,"requires_crypto":true}'
-		_nmr_record_revalidation_state "$issue_num" "$slug" "$security_metadata" "$nmr_at" "human-authority-required" || true
+		local security_metadata=""
+		security_metadata=$(_nmr_metadata_json "security" "$NMR_CLASS_GENUINE_AUTHORITY" "security-label" true)
+		_nmr_record_revalidation_state "$issue_num" "$slug" "$security_metadata" "$nmr_at" "$NMR_STATUS_HUMAN_AUTHORITY" || true
 		_nmr_emit_decision_packet "$issue_num" "$slug" "security" || true
 		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — security-sensitive label present — PRESERVING NMR, requires 'sudo aidevops approve issue ${issue_num} ${slug}'" >>"$LOGFILE"
 		return 0
@@ -1155,9 +1165,10 @@ _nmr_applied_by_maintainer() {
 		fi
 	fi
 
-	local authority_metadata='{"code":"authority","class":"genuine-authority","source":"manual-hold","revalidate_after_seconds":null,"requires_crypto":true}'
-	_nmr_record_revalidation_state "$issue_num" "$slug" "$authority_metadata" "$nmr_at" "human-authority-required" || true
-	_nmr_emit_decision_packet "$issue_num" "$slug" "authority" || true
+	local authority_metadata=""
+	authority_metadata=$(_nmr_metadata_json "$NMR_REASON_AUTHORITY" "$NMR_CLASS_GENUINE_AUTHORITY" "manual-hold" true)
+	_nmr_record_revalidation_state "$issue_num" "$slug" "$authority_metadata" "$nmr_at" "$NMR_STATUS_HUMAN_AUTHORITY" || true
+	_nmr_emit_decision_packet "$issue_num" "$slug" "$NMR_REASON_AUTHORITY" || true
 	return 0
 }
 

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -55,6 +55,9 @@ if ! declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
 	unset _PULSE_NMR_APPROVAL_DIR
 fi
 
+NMR_REVALIDATION_STATE_FILE="${AIDEVOPS_NMR_REVALIDATION_STATE_FILE:-${HOME}/.aidevops/cache/nmr-revalidation-state.json}"
+NMR_TEMPORARY_REVALIDATE_SECONDS="${AIDEVOPS_NMR_TEMPORARY_REVALIDATE_SECONDS:-3600}"
+
 #######################################
 # Cached ever-NMR provenance helpers (GH#17458)
 #
@@ -836,6 +839,147 @@ _nmr_breaker_release_retry_reason() {
 }
 
 #######################################
+# Classify an NMR episode into a stable reason code. Explicit structured
+# markers win; legacy breaker text is mapped without copying prose or paths.
+# Stdout: {code,class,source,revalidate_after_seconds,requires_crypto}
+#######################################
+_nmr_reason_metadata_from_comments() {
+	local comments_json="$1"
+	local revalidate_seconds="$NMR_TEMPORARY_REVALIDATE_SECONDS"
+	[[ "$revalidate_seconds" =~ ^[0-9]+$ ]] || revalidate_seconds=3600
+	printf '%s' "$comments_json" | jq -c --argjson revalidate "$revalidate_seconds" '
+		def metadata($code; $class; $source): {
+			code:$code,
+			class:$class,
+			source:$source,
+			revalidate_after_seconds:(if $class == "temporary" then $revalidate else null end),
+			requires_crypto:($class == "genuine-authority")
+		};
+		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+		 elif type == "array" then . else [] end) as $comments
+		| ([$comments[].body // "" | try capture("nmr-reason code=(?<code>[a-z_-]+) class=(?<class>genuine-authority|temporary)") catch empty] | last) as $explicit
+		| ($comments | map(.body // "") | join("\n") | ascii_downcase) as $text
+		| if $explicit != null then metadata($explicit.code; $explicit.class; "structured-marker")
+		  elif ($text | test("secret|required credential|credential access")) then metadata("secret"; "genuine-authority"; "legacy-marker")
+		  elif ($text | test("destructive|data deletion|irreversible")) then metadata("destructive"; "genuine-authority"; "legacy-marker")
+		  elif ($text | test("billing|cost-circuit-breaker|spend approval")) then metadata("billing"; "genuine-authority"; "legacy-marker")
+		  elif ($text | test("security-sensitive|supply.chain|auth boundary")) then metadata("security"; "genuine-authority"; "legacy-marker")
+		  elif ($text | test("rate_limit_nmr|dispatch-infrastructure-failure|local runtime|launch failure")) then metadata("transient_infrastructure"; "temporary"; "legacy-marker")
+		  elif ($text | test("missing implementation context|missing context")) then metadata("missing_context"; "temporary"; "legacy-marker")
+		  elif ($text | test("stale-recovery|worker_recovery_loop|diagnostic ambiguity")) then metadata("diagnostic_ambiguity"; "temporary"; "legacy-marker")
+		  else metadata("authority"; "genuine-authority"; "default") end
+	' 2>/dev/null || printf '{"code":"authority","class":"genuine-authority","source":"default","revalidate_after_seconds":null,"requires_crypto":true}\n'
+	return 0
+}
+
+_nmr_reason_metadata() {
+	local issue_num="$1"
+	local slug="$2"
+	local comments_json="[]"
+	comments_json=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate --slurp 2>/dev/null) || comments_json="[]"
+	_nmr_reason_metadata_from_comments "$comments_json"
+	return 0
+}
+
+_nmr_revalidation_due() {
+	local metadata_json="$1"
+	local label_at="$2"
+	local now_epoch=""
+	local label_epoch=""
+	local after_seconds=""
+	now_epoch=$(date +%s 2>/dev/null || true)
+	label_epoch=$(date -u -d "$label_at" '+%s' 2>/dev/null || TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$label_at" '+%s' 2>/dev/null || true)
+	after_seconds=$(printf '%s' "$metadata_json" | jq -r '.revalidate_after_seconds // 0' 2>/dev/null) || after_seconds=0
+	[[ "$now_epoch" =~ ^[0-9]+$ && "$label_epoch" =~ ^[0-9]+$ && "$after_seconds" =~ ^[0-9]+$ ]] || return 1
+	[[ $((now_epoch - label_epoch)) -ge "$after_seconds" ]]
+	return $?
+}
+
+_nmr_temporary_assumption_resolved() {
+	local issue_num="$1"
+	local slug="$2"
+	local code="$3"
+	local label_at="$4"
+	if [[ "$code" == "transient_infrastructure" ]]; then
+		local retry_reason=""
+		retry_reason=$(_nmr_breaker_release_retry_reason "$issue_num" "$slug" "$label_at") || retry_reason=""
+		if [[ -n "$retry_reason" ]]; then
+			printf '%s\n' "$retry_reason"
+			return 0
+		fi
+	fi
+
+	local issue_json="{}"
+	issue_json=$(gh api "repos/${slug}/issues/${issue_num}" 2>/dev/null) || issue_json="{}"
+	if [[ "$code" == "missing_context" ]] && printf '%s' "$issue_json" | jq -e '
+		((.body // "") | contains("## Worker Guidance")) and
+		((.body // "") | contains("### Verification"))
+	' >/dev/null 2>&1; then
+		printf 'worker guidance and verification are now present\n'
+		return 0
+	fi
+
+	local comments_json="[]"
+	comments_json=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate --slurp 2>/dev/null) || comments_json="[]"
+	if printf '%s' "$comments_json" | jq -e '
+		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+		 elif type == "array" then . else [] end)
+		| any(.[]; ((.author_association // "") | IN("OWNER", "MEMBER", "COLLABORATOR")) and ((.body // "") | contains("<!-- nmr-revalidation resolved=true")))
+	' >/dev/null 2>&1; then
+		printf 'trusted revalidation evidence resolved the temporary assumption\n'
+		return 0
+	fi
+	return 1
+}
+
+_nmr_record_revalidation_state() {
+	local issue_num="$1"
+	local slug="$2"
+	local metadata_json="$3"
+	local label_at="$4"
+	local status="$5"
+	local state_dir="${NMR_REVALIDATION_STATE_FILE%/*}"
+	[[ "$state_dir" != "$NMR_REVALIDATION_STATE_FILE" ]] || return 0
+	mkdir -p "$state_dir" 2>/dev/null || return 0
+	local current="{}"
+	if [[ -f "$NMR_REVALIDATION_STATE_FILE" ]]; then
+		current=$(cat "$NMR_REVALIDATION_STATE_FILE" 2>/dev/null) || current="{}"
+	fi
+	printf '%s' "$current" | jq empty >/dev/null 2>&1 || current="{}"
+	local key="${slug}#${issue_num}"
+	local tmp_file=""
+	tmp_file=$(mktemp "${state_dir}/.nmr-revalidation.XXXXXX") || return 0
+	printf '%s' "$current" | jq --arg key "$key" --arg label_at "$label_at" --arg status "$status" --argjson metadata "$metadata_json" '
+		.entries = (.entries // {})
+		| .entries[$key] = ($metadata + {label_at:$label_at, status:$status, checked_at:now})
+		| .updated_at = now
+	' >"$tmp_file" 2>/dev/null || { rm -f "$tmp_file"; return 0; }
+	mv "$tmp_file" "$NMR_REVALIDATION_STATE_FILE" 2>/dev/null || rm -f "$tmp_file"
+	return 0
+}
+
+_nmr_emit_decision_packet() {
+	local issue_num="$1"
+	local slug="$2"
+	local reason_code="$3"
+	local marker="nmr-decision-packet reason=${reason_code}"
+	local prior_count="0"
+	prior_count=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate \
+		--jq "[.[] | select((.body // \"\") | contains(\"${marker}\"))] | length" 2>/dev/null) || prior_count=0
+	[[ "$prior_count" =~ ^[0-9]+$ ]] || prior_count=0
+	[[ "$prior_count" -eq 0 ]] || return 0
+	gh_issue_comment "$issue_num" --repo "$slug" --body "<!-- ${marker} -->
+## Maintainer decision required
+
+- Reason: ${reason_code}
+- Evidence: the current NMR reason is classified as genuine authority, not a transient diagnostic or infrastructure condition.
+- Options: approve with \`sudo aidevops approve issue ${issue_num} ${slug}\`, or document the rejected/alternative direction.
+
+Automation will preserve this gate and will not treat elapsed time as approval." 2>/dev/null || true
+	return 0
+}
+
+#######################################
 # Check if the needs-maintainer-review label was most recently applied
 # by the maintainer themselves (indicating a manual hold), OR by a
 # circuit breaker trip (which must be treated as a hold even though
@@ -894,6 +1038,37 @@ _nmr_applied_by_maintainer() {
 	nmr_actor=$(printf '%s' "$nmr_event_json" | jq -r '.actor // ""' 2>/dev/null) || nmr_actor=""
 	nmr_at=$(printf '%s' "$nmr_event_json" | jq -r '.at // ""' 2>/dev/null) || nmr_at=""
 
+	if [[ -n "$nmr_at" ]]; then
+		local reason_metadata=""
+		local reason_code=""
+		local reason_class=""
+		local reason_source=""
+		reason_metadata=$(_nmr_reason_metadata "$issue_num" "$slug")
+		reason_code=$(printf '%s' "$reason_metadata" | jq -r '.code // "authority"' 2>/dev/null) || reason_code="authority"
+		reason_class=$(printf '%s' "$reason_metadata" | jq -r '.class // "genuine-authority"' 2>/dev/null) || reason_class="genuine-authority"
+		reason_source=$(printf '%s' "$reason_metadata" | jq -r '.source // "default"' 2>/dev/null) || reason_source="default"
+		if [[ "$reason_class" == "temporary" ]]; then
+			_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "scheduled" || true
+			if _nmr_revalidation_due "$reason_metadata" "$nmr_at"; then
+				local resolved_reason=""
+				resolved_reason=$(_nmr_temporary_assumption_resolved "$issue_num" "$slug" "$reason_code" "$nmr_at") || resolved_reason=""
+				if [[ -n "$resolved_reason" ]]; then
+					_NMR_AUTO_APPROVAL_REASON_OVERRIDE="temporary NMR revalidated (${reason_code}): ${resolved_reason}"
+					_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "automatable" || true
+					echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — temporary reason=${reason_code} revalidated; allowing trusted maintainer-authored retry" >>"$LOGFILE"
+					return 1
+				fi
+				_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "rechecked-unresolved" || true
+			fi
+			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — temporary reason=${reason_code} remains unresolved; preserving NMR until scheduled revalidation" >>"$LOGFILE"
+			return 0
+		elif [[ "$reason_source" != "default" ]]; then
+			_nmr_record_revalidation_state "$issue_num" "$slug" "$reason_metadata" "$nmr_at" "human-authority-required" || true
+			_nmr_emit_decision_packet "$issue_num" "$slug" "$reason_code" || true
+			return 0
+		fi
+	fi
+
 	# Breaker signatures are authoritative regardless of the token actor. Pulse can
 	# run under any trusted maintainer/member account, so actor-gating this check
 	# lets a peer runner's dispatch-infrastructure/no_work breaker be auto-cleared
@@ -932,6 +1107,9 @@ _nmr_applied_by_maintainer() {
 	fi
 
 	if _nmr_application_is_security_sensitive "$issue_num" "$slug"; then
+		local security_metadata='{"code":"security","class":"genuine-authority","source":"security-label","revalidate_after_seconds":null,"requires_crypto":true}'
+		_nmr_record_revalidation_state "$issue_num" "$slug" "$security_metadata" "$nmr_at" "human-authority-required" || true
+		_nmr_emit_decision_packet "$issue_num" "$slug" "security" || true
 		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — security-sensitive label present — PRESERVING NMR, requires 'sudo aidevops approve issue ${issue_num} ${slug}'" >>"$LOGFILE"
 		return 0
 	fi
@@ -951,6 +1129,9 @@ _nmr_applied_by_maintainer() {
 		fi
 	fi
 
+	local authority_metadata='{"code":"authority","class":"genuine-authority","source":"manual-hold","revalidate_after_seconds":null,"requires_crypto":true}'
+	_nmr_record_revalidation_state "$issue_num" "$slug" "$authority_metadata" "$nmr_at" "human-authority-required" || true
+	_nmr_emit_decision_packet "$issue_num" "$slug" "authority" || true
 	return 0
 }
 

--- a/.agents/scripts/pulse-nmr-latest-event.jq
+++ b/.agents/scripts/pulse-nmr-latest-event.jq
@@ -1,0 +1,5 @@
+(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+ else if type == "array" then . else [] end end)
+| [.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")]
+| last
+| {actor: (.actor.login // ""), at: (.created_at // "")}

--- a/.agents/scripts/pulse-nmr-reason.jq
+++ b/.agents/scripts/pulse-nmr-reason.jq
@@ -1,0 +1,20 @@
+def metadata($code; $class; $source): {
+  code: $code,
+  class: $class,
+  source: $source,
+  revalidate_after_seconds: (if $class == "temporary" then $revalidate else null end),
+  requires_crypto: ($class == "genuine-authority")
+};
+(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+ else if type == "array" then . else [] end end) as $comments
+| ([$comments[].body // "" | try capture("nmr-reason code=(?<code>[a-z_-]+) class=(?<class>genuine-authority|temporary)") catch empty] | last) as $explicit
+| ($comments | map(.body // "") | join("\n") | ascii_downcase) as $text
+| if $explicit != null then metadata($explicit.code; $explicit.class; "structured-marker")
+  elif ($text | test("secret|required credential|credential access")) then metadata("secret"; "genuine-authority"; "legacy-marker")
+  elif ($text | test("destructive|data deletion|irreversible")) then metadata("destructive"; "genuine-authority"; "legacy-marker")
+  elif ($text | test("billing|cost-circuit-breaker|spend approval")) then metadata("billing"; "genuine-authority"; "legacy-marker")
+  elif ($text | test("security-sensitive|supply.chain|auth boundary")) then metadata("security"; "genuine-authority"; "legacy-marker")
+  elif ($text | test("rate_limit_nmr|dispatch-infrastructure-failure|local runtime|launch failure")) then metadata("transient_infrastructure"; "temporary"; "legacy-marker")
+  elif ($text | test("missing implementation context|missing context")) then metadata("missing_context"; "temporary"; "legacy-marker")
+  elif ($text | test("stale-recovery|worker_recovery_loop|diagnostic ambiguity")) then metadata("diagnostic_ambiguity"; "temporary"; "legacy-marker")
+  else metadata("authority"; "genuine-authority"; "default") end

--- a/.agents/scripts/pulse-nmr-state-record.jq
+++ b/.agents/scripts/pulse-nmr-state-record.jq
@@ -1,0 +1,3 @@
+.entries = (.entries // {})
+| .entries[$key] = ($metadata + {label_at: $label_at, status: $status, checked_at: now})
+| .updated_at = now

--- a/.agents/scripts/pulse-nmr-trusted-resolution.jq
+++ b/.agents/scripts/pulse-nmr-trusted-resolution.jq
@@ -1,0 +1,6 @@
+(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+ else if type == "array" then . else [] end end)
+| any(.[];
+    ((.author_association // "") | IN("OWNER", "MEMBER", "COLLABORATOR"))
+    and ((.body // "") | contains("<!-- nmr-revalidation resolved=true"))
+  )

--- a/.agents/scripts/tests/test-failure-family-remediation.sh
+++ b/.agents/scripts/tests/test-failure-family-remediation.sh
@@ -110,14 +110,14 @@ WRAPPERS
 	gh() {
 		if [[ "$1 $2" == "issue list" && "$*" == *"failure-family-state:start"* ]]; then
 			if [[ -s "$TEST_ISSUE_BODY" ]]; then
-				jq -n --rawfile body "$TEST_ISSUE_BODY" '[{number:42,body:$body,createdAt:"2000-01-01T00:00:00Z",url:"https://example.invalid/42"}]'
+				jq -n --rawfile body "$TEST_ISSUE_BODY" '[{number:42,body:$body,createdAt:"2000-01-01T00:00:00Z",url:"fixture-url"}]'
 			else
 				printf '[]\n'
 			fi
 			return 0
 		fi
 		if [[ "$1 $2" == "issue list" ]]; then
-			[[ -s "$TEST_CREATED" ]] && printf '[{"number":42,"url":"https://example.invalid/42"}]\n' || printf '[]\n'
+			[[ -s "$TEST_CREATED" ]] && printf '[{"number":42,"url":"fixture-url"}]\n' || printf '[]\n'
 			return 0
 		fi
 		if [[ "$1" == "api" && "$2" == *"/issues/42" ]]; then

--- a/.agents/scripts/tests/test-failure-family-remediation.sh
+++ b/.agents/scripts/tests/test-failure-family-remediation.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d -t failure-family-remediation.XXXXXX)"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local label="$1"
+	local expected="$2"
+	local actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		printf 'PASS %s\n' "$label"
+		return 0
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s: expected=%s actual=%s\n' "$label" "$expected" "$actual"
+	return 0
+}
+
+assert_absent() {
+	local label="$1"
+	local needle="$2"
+	local haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$haystack" != *"$needle"* ]]; then
+		printf 'PASS %s\n' "$label"
+		return 0
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s: found private value %s\n' "$label" "$needle"
+	return 0
+}
+
+test_stable_failure_fingerprint() {
+	local metrics="${TEST_ROOT}/metrics.jsonl"
+	local now=""
+	now=$(date +%s)
+	printf '%s\n' \
+		"{\"ts\":$((now - 30)),\"repo_slug\":\"private/example\",\"session_key\":\"one\",\"result\":\"watchdog_stall_killed\",\"exit_code\":79}" \
+		"{\"ts\":$((now - 20)),\"repo_slug\":\"private/example\",\"session_key\":\"two\",\"result\":\"watchdog_stall_killed\",\"exit_code\":79}" \
+		"{\"ts\":$((now - 10)),\"repo_slug\":\"private/example\",\"session_key\":\"three\",\"result\":\"watchdog_stall_killed\",\"exit_code\":79}" >"$metrics"
+	local output=""
+	output=$(WAH_METRICS_FILE="$metrics" WAH_PULSE_STATS_FILE="${TEST_ROOT}/missing-stats" \
+		"${SCRIPT_DIR}/worker-activity-helper.sh" summary --since 1h --json --no-pr-check)
+	assert_eq "watchdog family uses stable fingerprint" "ff-v1:watchdog-stall" \
+		"$(printf '%s' "$output" | jq -r '.metrics.failure_families[0].fingerprint')"
+	assert_eq "three distinct sessions produce high confidence" "high" \
+		"$(printf '%s' "$output" | jq -r '.metrics.failure_families[0].confidence')"
+	return 0
+}
+
+test_threshold_and_privacy() {
+	local family='{"fingerprint":"ff-v1:watchdog-stall","family":"watchdog-stall","count":3,"distinct_sessions":3,"first_ts":1,"last_ts":2,"confidence":"high","recovery_outcome":"recurring"}'
+	local report=""
+	report=$(jq -n --arg window 15m --arg since 24h --arg recent 1h \
+		--argjson threshold 3 --argjson failure_threshold 3 \
+		--argjson current '{}' \
+		--argjson summary "{\"metrics\":{\"failure_families\":[$family]}}" \
+		--argjson recent_summary "{\"metrics\":{\"failure_families\":[$family]}}" \
+		--argjson providers '{}' --argjson runner '{}' --argjson api '{}' \
+		--argjson queue '{"aggregate":{}}' -f "${SCRIPT_DIR}/pulse-check-report.jq")
+	assert_eq "high-confidence recurrence crosses autofile threshold" "true" \
+		"$(printf '%s' "$report" | jq -r '.findings[] | select(.id == "worker-failure-family-watchdog-stall") | .autofile')"
+	assert_absent "aggregate report omits repository slug" "private/example" "$report"
+	assert_absent "aggregate report omits local path" "$HOME" "$report"
+	return 0
+}
+
+test_dedup_and_recovery_closure() {
+	local created="${TEST_ROOT}/created"
+	local issue_body="${TEST_ROOT}/issue-body"
+	local edited_body="${TEST_ROOT}/edited-body"
+	local closed="${TEST_ROOT}/closed"
+	local wrappers="${TEST_ROOT}/wrappers.sh"
+	local family='{"id":"worker-failure-family-watchdog-stall","title":"Remediate recurrent worker failure family: watchdog-stall","severity":"high","evidence":["fingerprint=ff-v1:watchdog-stall","failures_in_window=3"],"recommendation":"Repair the aggregate family.","family_fingerprint":"ff-v1:watchdog-stall","family_count":3,"family_recent_count":3}'
+	local increased_family='{"id":"worker-failure-family-watchdog-stall","title":"Remediate recurrent worker failure family: watchdog-stall","severity":"high","evidence":["fingerprint=ff-v1:watchdog-stall","failures_in_window=4"],"recommendation":"Repair the aggregate family.","family_fingerprint":"ff-v1:watchdog-stall","family_count":4,"family_recent_count":4}'
+
+	cat >"$wrappers" <<'WRAPPERS'
+gh_create_issue() {
+	local body_file=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--body-file) body_file="$2"; shift 2 ;;
+			*) shift ;;
+		esac
+	done
+	printf '1\n' >>"$TEST_CREATED"
+	cp "$body_file" "$TEST_ISSUE_BODY"
+	printf 'created-42\n'
+	return 0
+}
+WRAPPERS
+	export TEST_CREATED="$created" TEST_ISSUE_BODY="$issue_body"
+	export PULSE_CHECK_SOURCE_ONLY=1 PULSE_CHECK_GH_WRAPPERS="$wrappers"
+	# shellcheck source=../pulse-check-helper.sh
+	source "${SCRIPT_DIR}/pulse-check-helper.sh"
+
+	gh() {
+		if [[ "$1 $2" == "issue list" && "$*" == *"failure-family-state:start"* ]]; then
+			if [[ -s "$TEST_ISSUE_BODY" ]]; then
+				jq -n --rawfile body "$TEST_ISSUE_BODY" '[{number:42,body:$body,createdAt:"2000-01-01T00:00:00Z",url:"https://example.invalid/42"}]'
+			else
+				printf '[]\n'
+			fi
+			return 0
+		fi
+		if [[ "$1 $2" == "issue list" ]]; then
+			[[ -s "$TEST_CREATED" ]] && printf '[{"number":42,"url":"https://example.invalid/42"}]\n' || printf '[]\n'
+			return 0
+		fi
+		if [[ "$1" == "api" && "$2" == *"/issues/42" ]]; then
+			jq -n --rawfile body "$TEST_ISSUE_BODY" '{body:$body}' | jq -r '.body'
+			return 0
+		fi
+		if [[ "$1 $2" == "issue edit" ]]; then
+			local previous=""
+			while [[ $# -gt 0 ]]; do
+				if [[ "$1" == "--body-file" ]]; then cp "$2" "$edited_body"; cp "$2" "$TEST_ISSUE_BODY"; return 0; fi
+				previous="$1"
+				shift
+			done
+			: "$previous"
+			return 0
+		fi
+		if [[ "$1 $2" == "issue close" ]]; then
+			printf 'closed\n' >"$closed"
+			return 0
+		fi
+		return 1
+	}
+
+	_apply_finding "owner/repo" "$family"
+	_apply_finding "owner/repo" "$increased_family"
+	assert_eq "recurrence creates one deduplicated task" "1" "$(wc -l <"$created" | tr -d ' ')"
+	assert_absent "worker-ready issue body omits private slug" "private/example" "$(<"$issue_body")"
+	assert_eq "dedup refreshes existing evidence in place" "yes" "$([[ -s "$edited_body" ]] && printf yes || printf no)"
+
+	_reconcile_failure_family_remediations "owner/repo" '{"failure_family_remediation":[]}'
+	assert_eq "zero recurrence after observation closes remediation" "yes" "$([[ -s "$closed" ]] && printf yes || printf no)"
+	return 0
+}
+
+test_nmr_reason_revalidation() {
+	# shellcheck source=../pulse-nmr-approval.sh
+	source "${SCRIPT_DIR}/pulse-nmr-approval.sh"
+	local authority=""
+	authority=$(_nmr_reason_metadata_from_comments '[{"body":"<!-- nmr-reason code=billing class=genuine-authority -->"}]')
+	assert_eq "billing reason requires cryptographic authority" "true" "$(printf '%s' "$authority" | jq -r '.requires_crypto')"
+
+	_nmr_reason_metadata() { printf '{"code":"missing_context","class":"temporary","source":"structured-marker","revalidate_after_seconds":1,"requires_crypto":false}\n'; return 0; }
+	_nmr_revalidation_due() { return 0; }
+	_nmr_temporary_assumption_resolved() { printf 'worker guidance restored\n'; return 0; }
+	_nmr_record_revalidation_state() { return 0; }
+	_nmr_evaluate_reason_metadata 42 owner/repo 2000-01-01T00:00:00Z
+	assert_eq "resolved temporary NMR returns to automation" "auto" "$_NMR_REASON_ACTION"
+	assert_eq "temporary NMR never claims cryptographic approval" "temporary NMR revalidated (missing_context): worker guidance restored" "$_NMR_REASON_OVERRIDE"
+	return 0
+}
+
+main() {
+	test_stable_failure_fingerprint
+	test_threshold_and_privacy
+	test_dedup_and_recovery_closure
+	test_nmr_reason_revalidation
+	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/worker-activity-failure-families.jq
+++ b/.agents/scripts/worker-activity-failure-families.jq
@@ -1,0 +1,39 @@
+def _wah_empty_if_null: if . == null then "" else . end;
+def _wah_failure_family:
+  if ((.result // "") | test("rate_limit"))
+    or ((.failure_reason // "") | test("rate_limit"))
+    or (.provider_status == "429") then "rate-limit"
+  elif ((.result // "") | test("watchdog_stall"))
+    or (.launch_failure_cause == "stall_hard_killed")
+    or (.kill_reason == "hard_kill_stall") then "watchdog-stall"
+  elif ((.result // "") | test("recovery"))
+    or ((.failure_reason // "") | test("recovery"))
+    or ((.next_action // "") | test("recovery")) then "recovery-failure"
+  elif (.result == $local_kill_result)
+    or (.launch_failure_cause == $local_kill_result)
+    or ((.kill_reason // "") | test("kill")) then "local-kill"
+  elif (.failure_reason == "local_error")
+    or (.launch_failure_cause == "local_runtime_error")
+    or ((.runtime_error_type | _wah_empty_if_null) != "") then "local-runtime-error"
+  elif ((.launch_failure_cause // "") != "")
+    or ((.result // "") | test("launch")) then "launch-failure"
+  else "other-failure" end;
+def _wah_failure_family_summary:
+  map(. + {failure_family: _wah_failure_family})
+  | group_by(.failure_family)
+  | map({
+    fingerprint: ("ff-v1:" + .[0].failure_family),
+    family: .[0].failure_family,
+    launch_failure_cause: ([.[].launch_failure_cause // empty | select(length > 0)][0] // "unknown"),
+    kill_reason: ([.[].kill_reason // empty | select(length > 0)][0] // ""),
+    next_action: ([.[].next_action // empty | select(length > 0)][0] // ""),
+    count: length,
+    distinct_sessions: (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length),
+    first_ts: (map(.ts // 0) | min),
+    last_ts: (map(.ts // 0) | max),
+    confidence: (if length >= 3 and (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length) >= 2 then "high" elif length >= 2 then "medium" else "low" end),
+    recovery_outcome: (if length >= 3 then "recurring" else "observed" end),
+    results: (reduce .[] as $row ({}; .[$row.result // "unknown"] += 1)),
+    examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, result, exit_code, launch_failure_cause, kill_reason, next_action}))
+  })
+  | sort_by(.count) | reverse | .[0:10];

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -48,6 +48,7 @@ WAH_PR_CACHE_TTL="${WAH_PR_CACHE_TTL:-60}" # seconds
 WAH_SERVICE_INTERRUPTION_RESULT="service_interruption_continue"
 WAH_RESULT_WATCHDOG_STALL_KILLED="watchdog_stall_killed"
 WAH_RESULT_LOCAL_KILL="local_kill"
+WAH_FAILURE_FAMILY_FILTER="${SCRIPT_DIR}/worker-activity-failure-families.jq"
 
 # Shared jq definitions keep terminal-session semantics identical in the scalar
 # and rich aggregators without duplicating a long filter in both functions.
@@ -85,48 +86,10 @@ WAH_SESSION_OUTCOME_JQ='
 
 # Keep failure-family classification outside the shell function body so the
 # rich metric aggregator stays below the function-complexity gate.
-# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
-WAH_FAILURE_FAMILY_JQ='
-	def _wah_empty_if_null: if . == null then "" else . end;
-	def _wah_failure_family:
-		if ((.result // "") | test("rate_limit"))
-			or ((.failure_reason // "") | test("rate_limit"))
-			or (.provider_status == "429") then "rate-limit"
-		elif ((.result // "") | test("watchdog_stall"))
-			or (.launch_failure_cause == "stall_hard_killed")
-			or (.kill_reason == "hard_kill_stall") then "watchdog-stall"
-		elif ((.result // "") | test("recovery"))
-			or ((.failure_reason // "") | test("recovery"))
-			or ((.next_action // "") | test("recovery")) then "recovery-failure"
-		elif (.result == $local_kill_result)
-			or (.launch_failure_cause == $local_kill_result)
-			or ((.kill_reason // "") | test("kill")) then "local-kill"
-		elif (.failure_reason == "local_error")
-			or (.launch_failure_cause == "local_runtime_error")
-			or ((.runtime_error_type | _wah_empty_if_null) != "") then "local-runtime-error"
-		elif ((.launch_failure_cause // "") != "")
-			or ((.result // "") | test("launch")) then "launch-failure"
-		else "other-failure" end;
-	def _wah_failure_family_summary:
-		map(. + {failure_family: _wah_failure_family})
-		| group_by(.failure_family)
-		| map({
-			fingerprint: ("ff-v1:" + .[0].failure_family),
-			family: .[0].failure_family,
-			launch_failure_cause: ([.[].launch_failure_cause // empty | select(length > 0)][0] // "unknown"),
-			kill_reason: ([.[].kill_reason // empty | select(length > 0)][0] // ""),
-			next_action: ([.[].next_action // empty | select(length > 0)][0] // ""),
-			count: length,
-			distinct_sessions: (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length),
-			first_ts: (map(.ts // 0) | min),
-			last_ts: (map(.ts // 0) | max),
-			confidence: (if length >= 3 and (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length) >= 2 then "high" elif length >= 2 then "medium" else "low" end),
-			recovery_outcome: (if length >= 3 then "recurring" else "observed" end),
-			results: (reduce .[] as $row ({}; .[$row.result // "unknown"] += 1)),
-			examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, result, exit_code, launch_failure_cause, kill_reason, next_action}))
-		})
-		| sort_by(.count) | reverse | .[0:10];
-'
+WAH_FAILURE_FAMILY_JQ=""
+if [[ -f "$WAH_FAILURE_FAMILY_FILTER" ]]; then
+	WAH_FAILURE_FAMILY_JQ=$(<"$WAH_FAILURE_FAMILY_FILTER")
+fi
 
 #######################################
 # Convert short window spec to seconds. Caller owns the cutoff math.

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -83,6 +83,51 @@ WAH_SESSION_OUTCOME_JQ='
 		| map(select(_wah_nonterminal | not));
 '
 
+# Keep failure-family classification outside the shell function body so the
+# rich metric aggregator stays below the function-complexity gate.
+# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
+WAH_FAILURE_FAMILY_JQ='
+	def _wah_empty_if_null: if . == null then "" else . end;
+	def _wah_failure_family:
+		if ((.result // "") | test("rate_limit"))
+			or ((.failure_reason // "") | test("rate_limit"))
+			or (.provider_status == "429") then "rate-limit"
+		elif ((.result // "") | test("watchdog_stall"))
+			or (.launch_failure_cause == "stall_hard_killed")
+			or (.kill_reason == "hard_kill_stall") then "watchdog-stall"
+		elif ((.result // "") | test("recovery"))
+			or ((.failure_reason // "") | test("recovery"))
+			or ((.next_action // "") | test("recovery")) then "recovery-failure"
+		elif (.result == $local_kill_result)
+			or (.launch_failure_cause == $local_kill_result)
+			or ((.kill_reason // "") | test("kill")) then "local-kill"
+		elif (.failure_reason == "local_error")
+			or (.launch_failure_cause == "local_runtime_error")
+			or ((.runtime_error_type | _wah_empty_if_null) != "") then "local-runtime-error"
+		elif ((.launch_failure_cause // "") != "")
+			or ((.result // "") | test("launch")) then "launch-failure"
+		else "other-failure" end;
+	def _wah_failure_family_summary:
+		map(. + {failure_family: _wah_failure_family})
+		| group_by(.failure_family)
+		| map({
+			fingerprint: ("ff-v1:" + .[0].failure_family),
+			family: .[0].failure_family,
+			launch_failure_cause: ([.[].launch_failure_cause // empty | select(length > 0)][0] // "unknown"),
+			kill_reason: ([.[].kill_reason // empty | select(length > 0)][0] // ""),
+			next_action: ([.[].next_action // empty | select(length > 0)][0] // ""),
+			count: length,
+			distinct_sessions: (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length),
+			first_ts: (map(.ts // 0) | min),
+			last_ts: (map(.ts // 0) | max),
+			confidence: (if length >= 3 and (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length) >= 2 then "high" elif length >= 2 then "medium" else "low" end),
+			recovery_outcome: (if length >= 3 then "recurring" else "observed" end),
+			results: (reduce .[] as $row ({}; .[$row.result // "unknown"] += 1)),
+			examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, result, exit_code, launch_failure_cause, kill_reason, next_action}))
+		})
+		| sort_by(.count) | reverse | .[0:10];
+'
+
 #######################################
 # Convert short window spec to seconds. Caller owns the cutoff math.
 # $1 — one of 1h | 6h | 24h | 48h | 7d
@@ -187,27 +232,7 @@ _wah_metric_details_json() {
 
 	local jq_program
 	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
-	jq_program=$WAH_SESSION_OUTCOME_JQ'
-		def _wah_empty_if_null: if . == null then "" else . end;
-		def _wah_failure_family:
-			if ((.result // "") | test("rate_limit"))
-				or ((.failure_reason // "") | test("rate_limit"))
-				or (.provider_status == "429") then "rate-limit"
-			elif ((.result // "") | test("watchdog_stall"))
-				or (.launch_failure_cause == "stall_hard_killed")
-				or (.kill_reason == "hard_kill_stall") then "watchdog-stall"
-			elif ((.result // "") | test("recovery"))
-				or ((.failure_reason // "") | test("recovery"))
-				or ((.next_action // "") | test("recovery")) then "recovery-failure"
-			elif (.result == $local_kill_result)
-				or (.launch_failure_cause == $local_kill_result)
-				or ((.kill_reason // "") | test("kill")) then "local-kill"
-			elif (.failure_reason == "local_error")
-				or (.launch_failure_cause == "local_runtime_error")
-				or ((.runtime_error_type | _wah_empty_if_null) != "") then "local-runtime-error"
-			elif ((.launch_failure_cause // "") != "")
-				or ((.result // "") | test("launch")) then "launch-failure"
-			else "other-failure" end;
+	jq_program=$WAH_SESSION_OUTCOME_JQ$WAH_FAILURE_FAMILY_JQ'
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
 		| ($events | _wah_session_outcomes) as $w
 		| ($w | map(.duration_ms // 0)) as $durations
@@ -276,26 +301,7 @@ _wah_metric_details_json() {
 					examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, session_id, work_dir, output_file, exit_code, duration_ms, provider_error_type, provider_status, runtime_error_type, classification_source, classification_pattern, launch_failure_cause, kill_reason, next_action}))
 				})
 				| sort_by(.count) | reverse | .[0:10]),
-			failure_families: (
-				$failures
-				| map(. + {failure_family: _wah_failure_family})
-				| group_by(.failure_family)
-				| map({
-					fingerprint: ("ff-v1:" + .[0].failure_family),
-					family: .[0].failure_family,
-					launch_failure_cause: ([.[].launch_failure_cause // empty | select(length > 0)][0] // "unknown"),
-					kill_reason: ([.[].kill_reason // empty | select(length > 0)][0] // ""),
-					next_action: ([.[].next_action // empty | select(length > 0)][0] // ""),
-					count: length,
-					distinct_sessions: (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length),
-					first_ts: (map(.ts // 0) | min),
-					last_ts: (map(.ts // 0) | max),
-					confidence: (if length >= 3 and (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length) >= 2 then "high" elif length >= 2 then "medium" else "low" end),
-					recovery_outcome: (if length >= 3 then "recurring" else "observed" end),
-					results: (reduce .[] as $row ({}; .[$row.result // "unknown"] += 1)),
-					examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, result, exit_code, launch_failure_cause, kill_reason, next_action}))
-				})
-				| sort_by(.count) | reverse | .[0:10])
+			failure_families: ($failures | _wah_failure_family_summary)
 		}'
 	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" "$jq_program" <"$metrics" 2>/dev/null || \
 		printf '{"result_counts":{},"diagnostic_focus":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[],"failure_groups":[],"failure_families":[]}'

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -189,6 +189,25 @@ _wah_metric_details_json() {
 	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
 	jq_program=$WAH_SESSION_OUTCOME_JQ'
 		def _wah_empty_if_null: if . == null then "" else . end;
+		def _wah_failure_family:
+			if ((.result // "") | test("rate_limit"))
+				or ((.failure_reason // "") | test("rate_limit"))
+				or (.provider_status == "429") then "rate-limit"
+			elif ((.result // "") | test("watchdog_stall"))
+				or (.launch_failure_cause == "stall_hard_killed")
+				or (.kill_reason == "hard_kill_stall") then "watchdog-stall"
+			elif ((.result // "") | test("recovery"))
+				or ((.failure_reason // "") | test("recovery"))
+				or ((.next_action // "") | test("recovery")) then "recovery-failure"
+			elif (.result == $local_kill_result)
+				or (.launch_failure_cause == $local_kill_result)
+				or ((.kill_reason // "") | test("kill")) then "local-kill"
+			elif (.failure_reason == "local_error")
+				or (.launch_failure_cause == "local_runtime_error")
+				or ((.runtime_error_type | _wah_empty_if_null) != "") then "local-runtime-error"
+			elif ((.launch_failure_cause // "") != "")
+				or ((.result // "") | test("launch")) then "launch-failure"
+			else "other-failure" end;
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
 		| ($events | _wah_session_outcomes) as $w
 		| ($w | map(.duration_ms // 0)) as $durations
@@ -259,14 +278,22 @@ _wah_metric_details_json() {
 				| sort_by(.count) | reverse | .[0:10]),
 			failure_families: (
 				$failures
-				| group_by([.launch_failure_cause // "unknown", .kill_reason // "", .next_action // ""])
+				| map(. + {failure_family: _wah_failure_family})
+				| group_by(.failure_family)
 				| map({
-					launch_failure_cause: (.[0].launch_failure_cause // "unknown"),
-					kill_reason: (.[0].kill_reason // ""),
-					next_action: (.[0].next_action // ""),
+					fingerprint: ("ff-v1:" + .[0].failure_family),
+					family: .[0].failure_family,
+					launch_failure_cause: ([.[].launch_failure_cause // empty | select(length > 0)][0] // "unknown"),
+					kill_reason: ([.[].kill_reason // empty | select(length > 0)][0] // ""),
+					next_action: ([.[].next_action // empty | select(length > 0)][0] // ""),
 					count: length,
+					distinct_sessions: (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length),
+					first_ts: (map(.ts // 0) | min),
+					last_ts: (map(.ts // 0) | max),
+					confidence: (if length >= 3 and (map((.repo_slug // "legacy") + "|" + (.session_key // (.session_id // "unknown"))) | unique | length) >= 2 then "high" elif length >= 2 then "medium" else "low" end),
+					recovery_outcome: (if length >= 3 then "recurring" else "observed" end),
 					results: (reduce .[] as $row ({}; .[$row.result // "unknown"] += 1)),
-					examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, session_key, issue_number, repo_slug, result, exit_code, output_file, launch_failure_cause, kill_reason, next_action}))
+					examples: (sort_by(.ts // 0) | reverse | .[0:3] | map({ts, result, exit_code, launch_failure_cause, kill_reason, next_action}))
 				})
 				| sort_by(.count) | reverse | .[0:10])
 		}'


### PR DESCRIPTION
## Summary

Add privacy-safe recurring failure-family fingerprints, deduplicated remediation lifecycle tracking, reason-coded NMR revalidation, and current-state observability with focused regression coverage.

## Files Changed

.agents/scripts/pulse-check-helper.sh, .agents/scripts/pulse-check-report.jq, .agents/scripts/pulse-current-state-helper.sh, .agents/scripts/pulse-nmr-approval.sh, .agents/scripts/pulse-nmr-latest-event.jq, .agents/scripts/pulse-nmr-reason.jq, .agents/scripts/pulse-nmr-state-record.jq, .agents/scripts/pulse-nmr-trusted-resolution.jq, .agents/scripts/tests/test-failure-family-remediation.sh, .agents/scripts/worker-activity-failure-families.jq, .agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused failure-family, pulse-check, worker-activity, and NMR tests; ShellCheck; complexity regression gate; .agents/scripts/linters-local.sh

Resolves #27170


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.31 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1h 40m and 527,309 tokens on this as a headless worker.