### PR TITLE
GH#27267: add GPT-5.6 context cap toggle

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------------------
 
 import { existsSync, readFileSync, appendFileSync } from "fs";
+import { homedir } from "os";
 import { join } from "path";
 import { loadAgentIndex, applyAgentMcpTools } from "./agent-loader.mjs";
 import { registerMcpServers } from "./mcp-registry.mjs";
@@ -12,7 +13,11 @@ import { getCursorProxyPort, registerCursorProvider } from "./cursor-proxy.mjs";
 import { getGoogleProxyPort, registerGoogleProvider } from "./google-proxy.mjs";
 import { getClaudeProxyPort, registerClaudeProvider } from "./claude-proxy.mjs";
 import { checkOpenCodeVersionDriftAsync } from "./version-tracking.mjs";
-import { CLAUDE_MODEL_LIMITS } from "./model-limits.mjs";
+import {
+  CLAUDE_MODEL_LIMITS,
+  GPT56_CONTEXT_DEFAULT,
+  GPT56_MODEL_IDS,
+} from "./model-limits.mjs";
 
 /**
  * Shared model definition template for Claude models managed by aidevops.
@@ -114,6 +119,46 @@ function registerAnthropicModels(config) {
   }
 
   return count;
+}
+
+/**
+ * Return whether aidevops should advertise a cost-aware 300K GPT-5.6 window.
+ * The feature defaults on; users can opt out with `aidevops gpt56-context
+ * disable`, which writes the durable preference consumed here on startup.
+ * @returns {boolean}
+ */
+export function gpt56ContextCapEnabled() {
+  const settingsPath = process.env.AIDEVOPS_SETTINGS_FILE ||
+    join(homedir(), ".config", "aidevops", "settings.json");
+  try {
+    if (!existsSync(settingsPath)) return true;
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    return settings?.runtime?.opencode?.gpt56_context_cap !== false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Override built-in OpenAI GPT-5.6 model metadata without replacing any other
+ * model fields. Sparse provider model entries are merged by OpenCode.
+ * @param {object} config - OpenCode Config object (mutable)
+ * @returns {number} number of model limits applied
+ */
+export function registerGpt56ContextLimits(config) {
+  if (!gpt56ContextCapEnabled()) return 0;
+  if (!config.provider) config.provider = {};
+  if (!config.provider.openai) config.provider.openai = {};
+  if (!config.provider.openai.models) config.provider.openai.models = {};
+
+  for (const id of GPT56_MODEL_IDS) {
+    const existing = config.provider.openai.models[id] || {};
+    config.provider.openai.models[id] = {
+      ...existing,
+      limit: { ...existing.limit, context: GPT56_CONTEXT_DEFAULT },
+    };
+  }
+  return GPT56_MODEL_IDS.length;
 }
 
 /**
@@ -249,7 +294,7 @@ function registerClaudeCliModels(config) {
 
 /**
  * Log a summary of config hook changes (silent when nothing changed).
- * @param {object} counts - { agents, mcps, agentTools, poolCleaned, anthropic, openai, cursor, google, claude }
+ * @param {object} counts - config registration counts
  */
 function logConfigSummary(counts) {
   const labels = [
@@ -258,6 +303,7 @@ function logConfigSummary(counts) {
     [counts.agentTools, "agent tool perms"],
     [counts.poolCleaned, `cleaned ${counts.poolCleaned} stale pool provider${counts.poolCleaned === 1 ? "" : "s"}`],
     [counts.anthropic, "anthropic models"],
+    [counts.openai, "OpenAI context limits"],
     [counts.cursor, "Cursor models"],
     [counts.google, "Google models"],
     [counts.claude, "Claude CLI models"],
@@ -304,6 +350,7 @@ export function createConfigHook(deps) {
     const agentTools = applyAgentMcpTools(config);
     const poolCleaned = registerPoolProvider(config);
     const anthropic = registerAnthropicModels(config);
+    const openai = registerGpt56ContextLimits(config);
     // Discover and register proxy provider models only when a proxy listener is
     // already active. The normal startup path intentionally leaves these ports
     // null until first use, so unconditional imports/discovery here made config
@@ -338,7 +385,7 @@ export function createConfigHook(deps) {
     const claude = registerClaudeCliModels(config);
 
     logConfigSummary(
-      { agents, mcps, agentTools, poolCleaned, anthropic, cursor, google, claude },
+      { agents, mcps, agentTools, poolCleaned, anthropic, openai, cursor, google, claude },
     );
     logVersionDriftAsync(pluginDir);
   };

--- a/.agents/plugins/opencode-aidevops/model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/model-limits.mjs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 //
 // model-limits.mjs — single source of truth for aidevops-managed model
-// context/output limits, with optional user override for the opus-4-7 context
-// window.
+// context/output limits, including the cost-aware GPT-5.6 context cap and the
+// optional user override for the opus-4-7 context window.
 //
 // Why this module exists (t2435):
 //   The opus-4-7 context window is intentionally capped at 250K (not the 1M
@@ -24,6 +24,20 @@ export const OPUS_47_CONTEXT_DEFAULT = 250000;
 
 /** Hard upper bound — Anthropic's API ceiling for opus-4-7. */
 export const OPUS_47_CONTEXT_MAX = 1000000;
+
+/**
+ * Advertised GPT-5.6 context used by OpenCode. Its 80% compaction threshold
+ * therefore fires near 240K, before OpenAI's long-context pricing boundary.
+ */
+export const GPT56_CONTEXT_DEFAULT = 300000;
+
+/** GPT-5.6 model IDs currently exposed by the OpenAI provider. */
+export const GPT56_MODEL_IDS = [
+  "gpt-5.6-sol",
+  "gpt-5.6-sol-pro",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+];
 
 /**
  * Resolve the opus-4-7 context window from env, falling back to the default.

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { afterEach, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  gpt56ContextCapEnabled,
+  registerGpt56ContextLimits,
+} from "../config-hook.mjs";
+
+const originalSettingsFile = process.env.AIDEVOPS_SETTINGS_FILE;
+const tempDirs = [];
+
+afterEach(() => {
+  if (originalSettingsFile === undefined) {
+    delete process.env.AIDEVOPS_SETTINGS_FILE;
+  } else {
+    process.env.AIDEVOPS_SETTINGS_FILE = originalSettingsFile;
+  }
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function settingsFile(value) {
+  const dir = mkdtempSync(join(tmpdir(), "aidevops-gpt56-"));
+  tempDirs.push(dir);
+  const file = join(dir, "settings.json");
+  if (value !== undefined) writeFileSync(file, JSON.stringify(value));
+  process.env.AIDEVOPS_SETTINGS_FILE = file;
+  return file;
+}
+
+test("GPT-5.6 cap defaults on and applies 300K without losing model fields", () => {
+  settingsFile(undefined);
+  const config = {
+    provider: { openai: { models: { "gpt-5.6-sol": { name: "Sol" } } } },
+  };
+  assert.equal(gpt56ContextCapEnabled(), true);
+  assert.equal(registerGpt56ContextLimits(config), 4);
+  assert.equal(config.provider.openai.models["gpt-5.6-sol"].name, "Sol");
+  assert.equal(config.provider.openai.models["gpt-5.6-sol"].limit.context, 300000);
+  assert.equal(config.provider.openai.models["gpt-5.6-terra"].limit.context, 300000);
+});
+
+test("GPT-5.6 cap opt-out leaves OpenAI model metadata untouched", () => {
+  settingsFile({ runtime: { opencode: { gpt56_context_cap: false } } });
+  const config = { provider: { openai: { models: {} } } };
+  assert.equal(gpt56ContextCapEnabled(), false);
+  assert.equal(registerGpt56ContextLimits(config), 0);
+  assert.deepEqual(config.provider.openai.models, {});
+});
+
+test("malformed settings fail open to the cost-aware default", () => {
+  const file = settingsFile({});
+  writeFileSync(file, "not-json");
+  assert.equal(gpt56ContextCapEnabled(), true);
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
@@ -20,7 +20,19 @@ import {
   OPUS_47_CONTEXT_DEFAULT,
   OPUS_47_CONTEXT_MAX,
   CLAUDE_MODEL_LIMITS,
+  GPT56_CONTEXT_DEFAULT,
+  GPT56_MODEL_IDS,
 } from "../model-limits.mjs";
+
+test("GPT-5.6 context metadata targets 300K for 240K auto-compaction", () => {
+  assert.equal(GPT56_CONTEXT_DEFAULT, 300000);
+  assert.deepEqual(GPT56_MODEL_IDS, [
+    "gpt-5.6-sol",
+    "gpt-5.6-sol-pro",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+  ]);
+});
 
 // ---------------------------------------------------------------------------
 // resolveOpus47Context — input → output matrix

--- a/.agents/scripts/gpt56-context-helper.sh
+++ b/.agents/scripts/gpt56-context-helper.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SETTINGS_FILE="${AIDEVOPS_SETTINGS_FILE:-${HOME}/.config/aidevops/settings.json}"
+
+usage() {
+	cat <<'EOF'
+Usage: aidevops gpt56-context [enable|disable|status]
+
+Controls the aidevops GPT-5.6 context cap in OpenCode.
+  enable   Advertise a 300K context window (default), causing OpenCode's 80%
+           auto-compaction to run near 240K and avoid long-context pricing.
+  disable  Use OpenCode/OpenAI's native GPT-5.6 context metadata.
+  status   Show the current setting.
+
+Restart OpenCode after changing this setting.
+EOF
+	return 0
+}
+
+require_jq() {
+	if ! command -v jq >/dev/null 2>&1; then
+		printf '%s\n' "Error: jq is required to update ${SETTINGS_FILE}" >&2
+		return 1
+	fi
+	return 0
+}
+
+is_enabled() {
+	local enabled="true"
+	if [[ ! -f "$SETTINGS_FILE" ]]; then
+		return 0
+	fi
+	enabled=$(jq -r 'if .runtime.opencode.gpt56_context_cap == false then false else true end' "$SETTINGS_FILE" 2>/dev/null) || enabled="true"
+	[[ "$enabled" == "true" ]]
+}
+
+show_status() {
+	if is_enabled; then
+		printf '%s\n' "GPT-5.6 OpenCode context cap: enabled (300K; auto-compaction near 240K)"
+	else
+		printf '%s\n' "GPT-5.6 OpenCode context cap: disabled (native provider limit)"
+	fi
+	return 0
+}
+
+set_enabled() {
+	local enabled="$1"
+	local settings_dir temp_file source_file
+	settings_dir="${SETTINGS_FILE%/*}"
+	mkdir -p "$settings_dir"
+	temp_file=$(mktemp "${settings_dir}/settings.json.XXXXXX")
+	source_file="$SETTINGS_FILE"
+	if [[ ! -f "$source_file" ]]; then
+		printf '%s\n' '{}' >"$temp_file"
+		source_file="$temp_file"
+	fi
+	if ! jq --argjson enabled "$enabled" \
+		'.runtime = (.runtime // {}) | .runtime.opencode = (.runtime.opencode // {}) | .runtime.opencode.gpt56_context_cap = $enabled' \
+		"$source_file" >"${temp_file}.new"; then
+		rm -f "$temp_file" "${temp_file}.new"
+		return 1
+	fi
+	mv "${temp_file}.new" "$SETTINGS_FILE"
+	rm -f "$temp_file"
+	chmod 600 "$SETTINGS_FILE"
+	show_status
+	printf '%s\n' "Restart OpenCode to apply the change."
+	return 0
+}
+
+main() {
+	local action="${1:-status}"
+	require_jq || return 1
+	case "$action" in
+	enable | on) set_enabled true ;;
+	disable | off) set_enabled false ;;
+	status) show_status ;;
+	help | --help | -h) usage ;;
+	*)
+		printf '%s\n' "Unknown action: $action" >&2
+		usage >&2
+		return 2
+		;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/gpt56-context-helper.sh
+++ b/.agents/scripts/gpt56-context-helper.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 SETTINGS_FILE="${AIDEVOPS_SETTINGS_FILE:-${HOME}/.config/aidevops/settings.json}"
+BOOLEAN_TRUE="true"
 
 usage() {
 	cat <<'EOF'
@@ -30,12 +31,12 @@ require_jq() {
 }
 
 is_enabled() {
-	local enabled="true"
+	local enabled="$BOOLEAN_TRUE"
 	if [[ ! -f "$SETTINGS_FILE" ]]; then
 		return 0
 	fi
-	enabled=$(jq -r 'if .runtime.opencode.gpt56_context_cap == false then false else true end' "$SETTINGS_FILE" 2>/dev/null) || enabled="true"
-	[[ "$enabled" == "true" ]]
+	enabled=$(jq -r 'if .runtime.opencode.gpt56_context_cap == false then false else true end' "$SETTINGS_FILE" 2>/dev/null) || enabled="$BOOLEAN_TRUE"
+	[[ "$enabled" == "$BOOLEAN_TRUE" ]]
 }
 
 show_status() {

--- a/.agents/scripts/tests/test-gpt56-context-helper.sh
+++ b/.agents/scripts/tests/test-gpt56-context-helper.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../gpt56-context-helper.sh"
+TEST_HOME="$(mktemp -d)"
+trap 'rm -rf "$TEST_HOME"' EXIT
+export HOME="$TEST_HOME"
+
+assert_contains() {
+	local haystack="$1"
+	local needle="$2"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		printf 'Expected output to contain: %s\nActual: %s\n' "$needle" "$haystack" >&2
+		return 1
+	fi
+	return 0
+}
+
+output=$(bash "$HELPER" status)
+assert_contains "$output" "enabled (300K"
+
+bash "$HELPER" disable >/dev/null
+[[ "$(jq -r '.runtime.opencode.gpt56_context_cap' "$HOME/.config/aidevops/settings.json")" == "false" ]]
+output=$(bash "$HELPER" status)
+assert_contains "$output" "disabled"
+
+bash "$HELPER" enable >/dev/null
+[[ "$(jq -r '.runtime.opencode.gpt56_context_cap' "$HOME/.config/aidevops/settings.json")" == "true" ]]
+
+printf '%s\n' "PASS: gpt56 context helper"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.24] - 2026-07-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ the required notices and preferred credit text.
 - `aidevops init` - Initialize in any project
 - `aidevops update` - Update framework
 - `aidevops auto-update` - Automatic update polling (enable/disable/status)
+- `aidevops gpt56-context [enable|disable|status]` - Keep GPT-5.6 at a 300K advertised context window in OpenCode (enabled by default), so 80% auto-compaction runs near 240K before long-context pricing; disable to use native provider limits
 - `aidevops secret` - Manage secrets (gopass encrypted, AI-safe)
 - `aidevops security` - Full security assessment (posture, secrets, supply chain)
 - `aidevops lint audit` - Audit native lint/format/typecheck commands and repo-verify hooks

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -879,6 +879,7 @@ _help_commands() {
 	echo "  design <cmd>       DESIGN.md detection, scaffolding, and brand guideline exports"
 	echo "  cleanup <cmd>      Cleanup helpers (remote branch audit/delete)"
 	echo "  model-accounts-pool OAuth account pool (list/check/diagnose/add/rotate/reset-cooldowns)"
+	echo "  gpt56-context <cmd> Manage the 300K GPT-5.6 OpenCode context cap (enable/disable/status)"
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
 	echo "  opencode-db <cmd>  OpenCode SQLite maintenance/session lookup (check/report/sessions/maintain/window/status/install)"
 	echo "  opencode [args]    Launch OpenCode with aidevops per-session DB isolation"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1124,6 +1124,7 @@ cmd_help() {
 	echo "  aidevops doctor              # Find duplicate/conflicting installs"
 	echo "  aidevops doctor --fix        # Interactively remove duplicates"
 	echo "  aidevops update              # Update framework + check projects"
+	echo "  aidevops gpt56-context       # Manage the 300K GPT-5.6 OpenCode context cap"
 	echo "  aidevops repos               # List registered projects"
 	echo "  aidevops launch-worker 22259 marcusquinn/aidevops --dry-run"
 	echo "  aidevops repos add           # Register current project"
@@ -1648,6 +1649,7 @@ main() {
 	detect | scan) cmd_detect ;;
 	ip-check | ip_check) _dispatch_helper "ip-reputation-helper.sh" "ip-reputation-helper.sh" "$@" ;;
 	model-accounts-pool | map) _dispatch_helper "oauth-pool-helper.sh" "oauth-pool-helper.sh" "$@" ;;
+	gpt56-context | gpt56_context) _dispatch_helper "gpt56-context-helper.sh" "gpt56-context-helper.sh" "$@" ;;
 	cleanup)
 		local _cleanup_sub="${1:-help}"
 		case "$_cleanup_sub" in


### PR DESCRIPTION
## Summary

- Resolves #27267.
- Cap aidevops-managed OpenCode GPT-5.6 model metadata at 300K by default, causing 80% auto-compaction near 240K.
- Add `aidevops gpt56-context enable|disable|status` with a durable user opt-out.
- Document the command in the README and CLI help.

## Testing

- `node --test .agents/plugins/opencode-aidevops/tests/test-model-limits.mjs .agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs`
- `bash .agents/scripts/tests/test-gpt56-context-helper.sh`
- `shellcheck .agents/scripts/gpt56-context-helper.sh .agents/scripts/tests/test-gpt56-context-helper.sh`
- `./.agents/scripts/linters-local.sh --full`
- Runtime CLI enable/disable/status smoke test with isolated settings.

## Runtime Testing

Runtime-verified: OpenCode config mutation and the CLI preference flow were exercised with isolated settings. The cap defaults on, opt-out leaves native metadata untouched, and malformed settings safely retain the default.

## Decisions

The preference lives in `~/.config/aidevops/settings.json`; the plugin reads it at OpenCode startup. Disabling the cap avoids writing replacement limits, preserving provider-native metadata.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.31 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2h 22m and 187,118 tokens on this with the user in an interactive session.
