### PR TITLE
GH#27174: respect systemd pulse ownership

### DIFF
--- a/.agents/scripts/pulse-watchdog-tick.sh
+++ b/.agents/scripts/pulse-watchdog-tick.sh
@@ -46,6 +46,7 @@ _LOG_DIR="${HOME}/.aidevops/logs"
 _WATCHDOG_LOG="${_LOG_DIR}/pulse-watchdog.log"
 _LAST_RUN_FILE="${_LOG_DIR}/pulse-wrapper-last-run.ts"
 _SETTINGS_FILE="${HOME}/.config/aidevops/settings.json"
+_SYSTEMD_PULSE_UNIT="aidevops-supervisor-pulse.service"
 
 mkdir -p "$_LOG_DIR" 2>/dev/null || true
 
@@ -78,14 +79,45 @@ _read_pulse_interval() {
 	return 0
 }
 
-# Bail early if the lifecycle helper is missing — nothing to revive with.
-if [[ ! -x "$_LIFECYCLE_HELPER" ]]; then
+# Return 0 when the supervisor pulse is owned by a loaded systemd user unit.
+# A command check alone is insufficient because cron fallback hosts can have
+# systemctl installed without a usable pulse unit.
+_systemd_owns_pulse() {
+	command -v systemctl >/dev/null 2>&1 || return 1
+	local _load_state=""
+	_load_state=$(systemctl --user show "$_SYSTEMD_PULSE_UNIT" --property=LoadState --value 2>/dev/null) || return 1
+	[[ "$_load_state" == "loaded" ]]
+}
+
+# Return 0 while systemd owns an active or starting oneshot cycle.
+_systemd_pulse_alive() {
+	local _active_state=""
+	_active_state=$(systemctl --user show "$_SYSTEMD_PULSE_UNIT" --property=ActiveState --value 2>/dev/null) || return 1
+	[[ "$_active_state" == "active" || "$_active_state" == "activating" ]]
+}
+
+_revive_pulse() {
+	if _systemd_owns_pulse; then
+		systemctl --user start "$_SYSTEMD_PULSE_UNIT" >>"$_WATCHDOG_LOG" 2>&1 || _wd_log "systemd revival exit=$?"
+		return 0
+	fi
+	"$_LIFECYCLE_HELPER" start >>"$_WATCHDOG_LOG" 2>&1 || _wd_log "revival exit=$?"
+	return 0
+}
+
+# A systemd-owned pulse does not need the generic lifecycle helper. Other
+# backends still require it for process discovery and revival.
+if ! _systemd_owns_pulse && [[ ! -x "$_LIFECYCLE_HELPER" ]]; then
 	_wd_log "lifecycle-helper missing or non-executable: $_LIFECYCLE_HELPER"
 	exit 0
 fi
 
-# Fast path: pulse alive → no work.
-if "$_LIFECYCLE_HELPER" is-running >/dev/null 2>&1; then
+# Fast path: ask the owning scheduler before falling back to process discovery.
+if _systemd_owns_pulse; then
+	if _systemd_pulse_alive; then
+		exit 0
+	fi
+elif "$_LIFECYCLE_HELPER" is-running >/dev/null 2>&1; then
 	exit 0
 fi
 
@@ -114,16 +146,16 @@ _AGE=$((_NOW - _LAST_RUN))
 # fires before the pulse has ever recorded a timestamp.
 if [[ "$_LAST_RUN" -eq 0 ]]; then
 	_wd_log "no last-run timestamp — reviving pulse"
-	"$_LIFECYCLE_HELPER" start >>"$_WATCHDOG_LOG" 2>&1 || _wd_log "revival exit=$?"
+	_revive_pulse
 	exit 0
 fi
 
-# Within grace window — let launchd's own StartInterval fire on its schedule.
+# Within grace window — let the owning scheduler fire on its schedule.
 if [[ "$_AGE" -lt "$_THRESHOLD" ]]; then
 	exit 0
 fi
 
 # Past grace window — revive.
 _wd_log "pulse dead for ${_AGE}s (threshold ${_THRESHOLD}s = interval ${_INTERVAL} + grace ${_GRACE}) — reviving"
-"$_LIFECYCLE_HELPER" start >>"$_WATCHDOG_LOG" 2>&1 || _wd_log "revival exit=$?"
+_revive_pulse
 exit 0

--- a/.agents/scripts/tests/test-pulse-defense-restart.sh
+++ b/.agents/scripts/tests/test-pulse-defense-restart.sh
@@ -209,6 +209,30 @@ STUB
 	return 0
 }
 
+_setup_systemctl_stub() {
+	local stub_home="$1"
+	local active_state="$2"
+	local mock_bin="$stub_home/mock-bin"
+	mkdir -p "$mock_bin"
+	cat >"$mock_bin/systemctl" <<STUB
+#!/usr/bin/env bash
+printf 'systemctl:%s\n' "\$*" >>"$stub_home/.aidevops/logs/systemctl-invocations.log"
+if [[ "\$*" == *"--property=LoadState"* ]]; then
+	printf 'loaded\n'
+	exit 0
+fi
+if [[ "\$*" == *"--property=ActiveState"* ]]; then
+	printf '%s\n' "$active_state"
+	exit 0
+fi
+[[ "\$*" == *" start "* || "\$*" == *" start"* ]] && exit 0
+exit 1
+STUB
+	chmod +x "$mock_bin/systemctl"
+	printf '%s' "$mock_bin"
+	return 0
+}
+
 test_tick_alive_fast_exit() {
 	local stub_home="$TEST_DIR/alive"
 	_setup_tick_env "$stub_home" "alive"
@@ -307,6 +331,47 @@ test_tick_disable_flag() {
 	return 0
 }
 
+test_tick_systemd_active_states_no_revive() {
+	local active_state="" stub_home="" mock_bin="" invocations="" helper_invocations=""
+	for active_state in active activating; do
+		stub_home="$TEST_DIR/systemd-$active_state"
+		_setup_tick_env "$stub_home" "dead"
+		mock_bin=$(_setup_systemctl_stub "$stub_home" "$active_state")
+		PATH="$mock_bin:$PATH" HOME="$stub_home" AIDEVOPS_AGENTS_DIR="$stub_home/.aidevops/agents" \
+			bash "$TICK_SH"
+		invocations=$(cat "$stub_home/.aidevops/logs/systemctl-invocations.log" 2>/dev/null || echo "")
+		helper_invocations=$(cat "$stub_home/.aidevops/logs/stub-helper-invocations.log" 2>/dev/null || echo "")
+		if [[ "$invocations" != *"--property=ActiveState"* ]] || [[ "$invocations" == *" start "* ]] || [[ -n "$helper_invocations" ]]; then
+			print_result "test_tick_systemd_${active_state}_no_revive" 1 \
+				"expected state query only; systemctl='$invocations' helper='$helper_invocations'"
+			continue
+		fi
+		print_result "test_tick_systemd_${active_state}_no_revive" 0
+	done
+	return 0
+}
+
+test_tick_systemd_dead_states_revive_via_systemctl() {
+	local active_state="" stub_home="" mock_bin="" rc=0 invocations="" helper_invocations=""
+	for active_state in inactive failed; do
+		stub_home="$TEST_DIR/systemd-$active_state"
+		_setup_tick_env "$stub_home" "dead"
+		mock_bin=$(_setup_systemctl_stub "$stub_home" "$active_state")
+		rc=0
+		PATH="$mock_bin:$PATH" HOME="$stub_home" AIDEVOPS_AGENTS_DIR="$stub_home/.aidevops/agents" \
+			bash "$TICK_SH" || rc=$?
+		invocations=$(cat "$stub_home/.aidevops/logs/systemctl-invocations.log" 2>/dev/null || echo "")
+		helper_invocations=$(cat "$stub_home/.aidevops/logs/stub-helper-invocations.log" 2>/dev/null || echo "")
+		if [[ "$rc" -eq 0 ]] && [[ "$invocations" == *"start aidevops-supervisor-pulse.service"* ]] && [[ -z "$helper_invocations" ]]; then
+			print_result "test_tick_systemd_${active_state}_revives_via_systemctl" 0
+			continue
+		fi
+		print_result "test_tick_systemd_${active_state}_revives_via_systemctl" 1 \
+			"expected systemctl start only; rc=$rc systemctl='$invocations' helper='$helper_invocations'"
+	done
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
@@ -331,6 +396,8 @@ main() {
 	test_tick_dead_past_grace_revives
 	test_tick_no_last_run_revives
 	test_tick_disable_flag
+	test_tick_systemd_active_states_no_revive
+	test_tick_systemd_dead_states_revive_via_systemctl
 
 	echo
 	echo "Tests run:    $TESTS_RUN"


### PR DESCRIPTION
## Summary

- Query the loaded systemd user unit before using process-shape discovery.
- Preserve active and activating oneshot cycles.
- Revive inactive or failed systemd units through `systemctl --user start`.
- Retain lifecycle-helper behavior for launchd, cron fallback, and manual operation.

Resolves #27174

## Testing

- `bash .agents/scripts/tests/test-pulse-defense-restart.sh` — 14 passed
- `shellcheck .agents/scripts/pulse-watchdog-tick.sh .agents/scripts/tests/test-pulse-defense-restart.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

Self-assessed with mocked systemd user-unit states because this macOS development host does not expose a systemd user manager. Regression coverage exercises active, activating, inactive, failed, and non-systemd fallback paths.

## Decisions

Detect a loaded systemd user unit rather than changing pulse PPID classification. This keeps scheduler ownership authoritative without changing launchd or fallback process behavior.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.31 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 13m and 95,385 tokens on this with the user in an interactive session.
