### PR TITLE
GH#27263: fix: bound GitHub write calls

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -724,7 +724,7 @@ _handle_post_merge_actions() {
 			esac
 			set_solved_label "$linked_issue" "$repo_slug" "$_solved_actor" || true
 			clear_terminal_issue_dispatch_labels "$linked_issue" "$repo_slug" "post-merge-pr-${pr_number}" || true
-			gh issue close "$linked_issue" --repo "$repo_slug" 2>/dev/null || true
+			_gh_with_timeout write gh issue close "$linked_issue" --repo "$repo_slug" 2>/dev/null || true
 			# Reset fast-fail counter now that the issue is resolved (GH#2076)
 			fast_fail_reset "$linked_issue" "$repo_slug" || true
 			# t1934: Unlock the issue (locked at dispatch time)
@@ -764,7 +764,7 @@ _handle_post_merge_actions() {
 				esac
 				set_solved_label "$_superseded_original_issue" "$repo_slug" "$_sup_solved_actor" || true
 				clear_terminal_issue_dispatch_labels "$_superseded_original_issue" "$repo_slug" "post-merge-superseded-pr-${pr_number}" || true
-				gh issue close "$_superseded_original_issue" --repo "$repo_slug" 2>/dev/null || true
+				_gh_with_timeout write gh issue close "$_superseded_original_issue" --repo "$repo_slug" 2>/dev/null || true
 				fast_fail_reset "$_superseded_original_issue" "$repo_slug" || true
 				unlock_issue_after_worker "$_superseded_original_issue" "$repo_slug"
 			fi
@@ -853,7 +853,7 @@ _pm_close_superseded_duplicate_pr_if_issue_solved() {
 	superseding_pr=$(_psh_find_merged_closer_for_closed_issue "$repo_slug" "$linked_issue" "$pr_number" 2>/dev/null) || superseding_pr=""
 	[[ "$superseding_pr" =~ ^[0-9]+$ ]] || return 1
 
-	gh pr close "$pr_number" --repo "$repo_slug" \
+	_gh_with_timeout write gh pr close "$pr_number" --repo "$repo_slug" \
 		--comment "Closing as superseded: linked issue #${linked_issue} is already closed by merged PR #${superseding_pr}. This worker PR uses a closing keyword for the same issue, so merging it would duplicate an already-terminal fix.
 
 Intentional follow-ups should use For #${linked_issue} / Ref #${linked_issue} or an explicit follow-up/protection label instead of a closing keyword.

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -549,7 +549,7 @@ _gh_auto_link_sub_issue() {
 
 	# Fire and forget — suppress all errors
 	# shellcheck disable=SC2016 # GraphQL variables are expanded by gh, not Bash.
-	gh api graphql -f query='mutation($p:ID!,$c:ID!){addSubIssue(input:{issueId:$p,subIssueId:$c}){issue{number}}}' \
+	_gh_with_timeout write gh api graphql -f query='mutation($p:ID!,$c:ID!){addSubIssue(input:{issueId:$p,subIssueId:$c}){issue{number}}}' \
 		-f p="$parent_node" -f c="$child_node" >/dev/null 2>&1 || true
 	return 0
 }
@@ -681,7 +681,7 @@ gh_issue_comment() {
 	gh_record_call graphql gh_issue_comment 2>/dev/null || true
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
-	gh issue comment "$@"
+	_gh_with_timeout write gh issue comment "$@"
 	local rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue comment"
@@ -696,7 +696,7 @@ gh_pr_comment() {
 	gh_record_call graphql gh_pr_comment 2>/dev/null || true
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
-	gh pr comment "$@"
+	_gh_with_timeout write gh pr comment "$@"
 	local rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr comment"
@@ -738,13 +738,13 @@ _ensure_origin_labels_for_args() {
 ensure_origin_labels_exist() {
 	local repo="$1"
 	[[ -z "$repo" ]] && return 1
-	gh label create "origin:worker" --repo "$repo" \
+	_gh_with_timeout write gh label create "origin:worker" --repo "$repo" \
 		--description "Created by headless/pulse worker session" \
 		--color "C5DEF5" 2>/dev/null || true
-	gh label create "origin:interactive" --repo "$repo" \
+	_gh_with_timeout write gh label create "origin:interactive" --repo "$repo" \
 		--description "Created by interactive user session" \
 		--color "BFD4F2" 2>/dev/null || true
-	gh label create "origin:worker-takeover" --repo "$repo" \
+	_gh_with_timeout write gh label create "origin:worker-takeover" --repo "$repo" \
 		--description "Worker took over from interactive session" \
 		--color "D4C5F9" 2>/dev/null || true
 	return 0

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -717,9 +717,9 @@ _set_origin_label_rest() {
 	local _label
 	for _label in "${ORIGIN_LABELS[@]}"; do
 		[[ "$_label" == "$new_origin" ]] && continue
-		gh api -X DELETE "/repos/${repo_slug}/issues/${issue_num}/labels/origin:${_label}" >/dev/null 2>&1 || true
+		_gh_with_timeout write gh api -X DELETE "/repos/${repo_slug}/issues/${issue_num}/labels/origin:${_label}" >/dev/null 2>&1 || true
 	done
-	gh api -X POST "/repos/${repo_slug}/issues/${issue_num}/labels" \
+	_gh_with_timeout write gh api -X POST "/repos/${repo_slug}/issues/${issue_num}/labels" \
 		-f "labels[]=origin:${new_origin}" >/dev/null 2>&1 || return 1
 	if [[ $# -gt 0 ]]; then
 		if command -v _rest_issue_edit >/dev/null 2>&1; then
@@ -795,11 +795,11 @@ set_origin_label() {
 
 	local _err_file
 	_err_file=$(mktemp -t aidevops-origin-label.XXXXXX) || {
-		gh "$gh_cmd" edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
+		_gh_with_timeout write gh "$gh_cmd" edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
 		return $?
 	}
 	local _gh_rc=0
-	if gh "$gh_cmd" edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>"$_err_file"; then
+	if _gh_with_timeout write gh "$gh_cmd" edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>"$_err_file"; then
 		rm -f "$_err_file"
 		return 0
 	else
@@ -822,10 +822,10 @@ set_origin_label() {
 ensure_solved_labels_exist() {
 	local repo="$1"
 	[[ -z "$repo" ]] && return 1
-	gh label create "solved:worker" --repo "$repo" \
+	_gh_with_timeout write gh label create "solved:worker" --repo "$repo" \
 		--description "Task was solved by a headless worker" \
 		--color "0E8A16" 2>/dev/null || true
-	gh label create "solved:interactive" --repo "$repo" \
+	_gh_with_timeout write gh label create "solved:interactive" --repo "$repo" \
 		--description "Task was solved by an interactive session" \
 		--color "BFD4F2" 2>/dev/null || true
 	return 0

--- a/.agents/scripts/tests/test-gh-write-timeout-coverage.sh
+++ b/.agents/scripts/tests/test-gh-write-timeout-coverage.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Regression test for GH#27263: write-side gh calls in shared wrappers and the
+# pulse merge close paths must use the bounded timeout helper.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+
+# These are literal source fragments; shell variables must not expand here.
+# shellcheck disable=SC2016
+expected_calls=(
+	'_gh_with_timeout write gh api -X DELETE'
+	'_gh_with_timeout write gh api -X POST'
+	'_gh_with_timeout write gh "$gh_cmd" edit'
+	'_gh_with_timeout write gh label create "solved:worker"'
+	'_gh_with_timeout write gh label create "solved:interactive"'
+	'_gh_with_timeout write gh api graphql -f query='
+	'_gh_with_timeout write gh issue comment "$@"'
+	'_gh_with_timeout write gh pr comment "$@"'
+	'_gh_with_timeout write gh label create "origin:worker"'
+	'_gh_with_timeout write gh label create "origin:interactive"'
+	'_gh_with_timeout write gh label create "origin:worker-takeover"'
+	'_gh_with_timeout write gh issue close "$linked_issue"'
+	'_gh_with_timeout write gh issue close "$_superseded_original_issue"'
+	'_gh_with_timeout write gh pr close "$pr_number"'
+)
+
+combined_sources=(
+	"${SCRIPTS_DIR}/shared-gh-wrappers.sh"
+	"${SCRIPTS_DIR}/shared-gh-wrappers-create.sh"
+	"${SCRIPTS_DIR}/pulse-merge.sh"
+)
+for expected_call in "${expected_calls[@]}"; do
+	if ! grep -Fq -- "$expected_call" "${combined_sources[@]}"; then
+		printf 'FAIL: missing timeout-wrapped call: %s\n' "$expected_call" >&2
+		exit 1
+	fi
+done
+
+printf 'PASS: GH#27263 write-side gh calls use timeout wrappers\n'


### PR DESCRIPTION
## Summary

Route the identified shared wrapper and pulse merge GitHub write calls through _gh_with_timeout, and add regression coverage for all 14 vulnerable call sites.

## Files Changed

.agents/scripts/pulse-merge.sh, .agents/scripts/shared-gh-wrappers-create.sh, .agents/scripts/shared-gh-wrappers.sh, .agents/scripts/tests/test-gh-write-timeout-coverage.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-write-timeout-coverage.sh; bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh; shellcheck changed shell files; .agents/scripts/linters-local.sh

Resolves #27263


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.33 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 52,242 tokens on this as a headless worker.