### PR TITLE
GH#27266: fix atomic bundle verification rollback

### DIFF
--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -240,7 +240,11 @@ _count_deployed_agent_files() {
 	local target_dir="$1"
 	local file_count="0"
 	if [[ -d "$target_dir" ]]; then
-		file_count=$(find "$target_dir" -type f 2>/dev/null | wc -l | tr -d '[:space:]')
+		# Runtime bundle activation makes ~/.aidevops/agents an atomic symlink.
+		# GNU/BSD find do not traverse a command-line symlink unless -L is set,
+		# so the old count returned zero immediately after a successful activation
+		# and rolled the deployment back to the previous bundle.
+		file_count=$(find -L "$target_dir" -type f 2>/dev/null | wc -l | tr -d '[:space:]')
 	fi
 	[[ "$file_count" =~ ^[0-9]+$ ]] || file_count=0
 	printf '%s\n' "$file_count"

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -95,6 +95,8 @@ test_initial_activation_and_manifest() {
 
 	[[ -L "$target_dir" ]] || fail "active agents path is an activation symlink"
 	pass "active agents path is an activation symlink"
+	_verify_deployed_agents_tree "$target_dir" || fail "post-activation verification follows the active bundle symlink"
+	pass "post-activation verification follows the active bundle symlink"
 	assert_eq "2.0.0" "$(tr -d '[:space:]' <"$active_root/VERSION")" "CLI and agents activate at one version"
 	assert_file_contains "$active_root/.bundle-manifest" '^status=validated$' "validated manifest is inside the active bundle"
 	assert_file_contains "$active_root/.bundle-manifest" '^cli_compatibility=2.0.0$' "manifest binds CLI compatibility"


### PR DESCRIPTION
Summary: follow the activated agents symlink when counting deployed files; prevent valid atomic bundles from being falsely rejected and rolled back; add regression coverage at the post-activation boundary. Root cause: atomic deployment changed ~/.aidevops/agents into a symlink, while BSD and GNU find do not traverse a command-line symlink by default. The minimum-file check counted zero and rolled back to stale agents after the CLI advanced. Testing: atomic bundle suite 16 checks passed; agent deploy staging passed; ShellCheck clean; linters-local passed; setup.sh --non-interactive completed with CLI and agents both at 3.32.32. Runtime testing: runtime-verified. Resolves #27266
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.35 with gpt-5.6-sol spent 14m and 401,746 tokens on this with the user in an interactive session.