### PR TITLE
t18105: validate causal evidence in bug reports

### DIFF
--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -317,6 +317,14 @@ that captured this failure will be gone after this conversation ends.
 <paste terminal output here>
 ```
 
+For hang, timeout, rate-limit, API-budget, or transport-cause claims, also include:
+
+- **Blocked command**: the exact child command and arguments shown by the process tree or trace
+- **Backend state**: direct rate-limit/API-budget/transport evidence captured during the failure
+
+If those facts are unavailable, frame the report as an investigation and label the suspected
+cause as unconfirmed rather than asserting that it caused the symptom.
+
 **Expected output** (what should have happened instead):
 
 ```
@@ -342,39 +350,76 @@ EOF
 
 # -----------------------------------------------------------------------------
 # Brief Validator (t2410)
-# Checks if an issue body contains the required sections for a framework-bug
-# brief. Returns 0 if valid, 1 if sections are missing.
+# Checks if an issue body contains substantive reproducer evidence for a
+# framework-bug brief. Returns 0 if valid, 1 if evidence is missing.
 #
 # Usage: validate_brief <body-text-or-file>
 #   - Pass a filename if the body is in a file
 #   - Pass body text directly via stdin when called as: validate_brief -
 # -----------------------------------------------------------------------------
 
+_brief_has_placeholder() {
+	local body="$1"
+	if grep -Eqi '<(paste|describe|command|output|provide)[^>]*>|(^|[[:space:]])(TODO|TBD)([[:space:]]|$)' <<<"$body"; then
+		return 0
+	fi
+	return 1
+}
+
+_brief_is_causal_investigation() {
+	local body="$1"
+	if grep -Eqi 'investigation|candidate cause|suspected cause|cause (is )?unconfirmed|causality (is )?not established' <<<"$body"; then
+		return 0
+	fi
+	return 1
+}
+
+_brief_asserts_transport_cause() {
+	local body="$1"
+	local failure='hang|hung|timeout|timed out|rate.?limit|API.?budget|transport'
+	local causal='because|due to|root cause|cause(d|s)?|results? in|leads? to|triggers?'
+	if grep -Eqi "(${causal}).{0,120}(${failure})|(${failure}).{0,120}(${causal})|rate.?limit.{0,120}(hang|hung|timeout)|[→]" <<<"$body"; then
+		return 0
+	fi
+	return 1
+}
+
+_brief_has_transport_evidence() {
+	local body="$1"
+	if grep -Eqi '\*\*Blocked command\*\*[^[:alnum:]]*.{4,}' <<<"$body" &&
+		grep -Eqi '\*\*Backend state\*\*[^[:alnum:]]*.{4,}' <<<"$body"; then
+		return 0
+	fi
+	return 1
+}
+
 validate_brief_has_reproducer() {
 	local body="$1"
-	local missing_sections=()
 
 	# Read from file if body is a file path
 	if [[ -f "$body" ]]; then
-		body=$(cat "$body")
+		body=$(<"$body")
 	fi
 
-	# Check for required sections
-	if ! echo "$body" | grep -qi "## Reproducer"; then
-		missing_sections+=("## Reproducer")
-	fi
-
-	if [[ ${#missing_sections[@]} -eq 0 ]]; then
-		echo "OK: Brief contains all required sections"
-		return 0
-	else
-		echo "ERROR: Brief is missing required sections: ${missing_sections[*]}" >&2
-		echo "Framework-bug briefs MUST include a ## Reproducer section with:" >&2
-		echo "  - Symptom command + actual output" >&2
-		echo "  - Expected output" >&2
-		echo "  - (optional) Causal code / commit SHA" >&2
+	if ! grep -Eqi '^## Reproducer[[:space:]]*$' <<<"$body"; then
+		echo "ERROR: Brief is missing ## Reproducer" >&2
 		return 1
 	fi
+	if ! grep -Eqi '\*\*Symptom command\*\*' <<<"$body" || ! grep -Eqi '\*\*Actual output\*\*' <<<"$body"; then
+		echo "ERROR: Reproducer requires **Symptom command** and **Actual output**" >&2
+		return 1
+	fi
+	if _brief_has_placeholder "$body"; then
+		echo "ERROR: Reproducer still contains placeholder evidence" >&2
+		return 1
+	fi
+	if _brief_asserts_transport_cause "$body" && ! _brief_is_causal_investigation "$body" && ! _brief_has_transport_evidence "$body"; then
+		echo "ERROR: Confirmed hang/timeout/rate-limit/API-budget/transport claims require **Blocked command** and **Backend state** evidence; otherwise frame this as an investigation with an unconfirmed cause" >&2
+		return 1
+	fi
+
+	echo "OK: Brief contains substantive reproducer evidence"
+	return 0
 }
 
 # -----------------------------------------------------------------------------

--- a/.agents/tests/log-issue-helper.bats
+++ b/.agents/tests/log-issue-helper.bats
@@ -124,6 +124,47 @@ _source_helper() {
 # check_recent_filing / record_filing round-trip
 # =============================================================================
 
+@test "validate brief rejects a heading-only reproducer" {
+	_source_helper
+	run validate_brief_has_reproducer "## Reproducer"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"requires **Symptom command**"* ]]
+}
+
+@test "validate brief rejects placeholder reproducer evidence" {
+	_source_helper
+	local body
+	body="$(printf '## Reproducer\n**Symptom command**\n```\n<paste command here>\n```\n**Actual output**\n```\n<paste terminal output here>\n```')"
+	run validate_brief_has_reproducer "$body"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"placeholder evidence"* ]]
+}
+
+@test "validate brief rejects unsupported confirmed rate-limit attribution" {
+	_source_helper
+	local body
+	body="$(printf '## Reproducer\n**Symptom command**\n```\nps -ef\n```\n**Actual output**\n```\npulse parent ran for 26 minutes\n```\nThe raw gh call hung because the API rate limit was exhausted.')"
+	run validate_brief_has_reproducer "$body"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"require **Blocked command** and **Backend state**"* ]]
+}
+
+@test "validate brief accepts investigation framing without causal proof" {
+	_source_helper
+	local body
+	body="$(printf '## Reproducer\n**Symptom command**\n```\nps -ef\n```\n**Actual output**\n```\npulse parent ran for 26 minutes\n```\nInvestigation: an untimed gh call is a candidate cause; causality is not established.')"
+	run validate_brief_has_reproducer "$body"
+	[ "$status" -eq 0 ]
+}
+
+@test "validate brief accepts confirmed transport claim with direct evidence" {
+	_source_helper
+	local body
+	body="$(printf '## Reproducer\n**Symptom command**\n```\nps -ef --forest\n```\n**Actual output**\n```\npulse -> gh api rate_limit remained blocked\n```\n**Blocked command**: gh api rate_limit (PID 42)\n**Backend state**: x-ratelimit-remaining=0 captured at the same timestamp\nThe exhausted rate limit caused the probe to hang.')"
+	run validate_brief_has_reproducer "$body"
+	[ "$status" -eq 0 ]
+}
+
 @test "check_recent_filing returns OK when no state file" {
 	_source_helper
 	local result

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -103,6 +103,14 @@ This outputs the section template. Collect and include in the issue body:
 3. **Causal code**: `git blame <file> -L <line>,<line>` output or commit SHA suspected to have introduced the regression
 4. **Call-site sweep**: `rg "<function-or-pattern>" .agents/scripts/` to enumerate all affected locations
 
+For hang, timeout, rate-limit, API-budget, or transport claims, distinguish the
+observed symptom from its cause. A long-running parent process proves only the
+symptom. A confirmed-cause report also needs the exact blocked child command and
+direct backend-state evidence captured during the failure. Without both, file an
+investigation and describe candidate causes as unconfirmed. If the report says
+"all calls" or equivalent, generate and include the complete executable call-site
+inventory; otherwise narrow the claim to the enumerated locations.
+
 Store the collected data under a `## Reproducer` section in the issue body (included in the compose template in Step 4).
 
 A brief filed without a Reproducer section forces the worker to spend 30-60 min reconstructing the failure mode from scratch — the exact time cost described in GH#20008.
@@ -146,7 +154,15 @@ Before filing, check whether this is a customization need rather than a framewor
 
 If the need is customization, explain the `custom/` directory and link to `reference/customization.md`. Do not file an issue.
 
-### Step 3.6: Performance Issue Validation (MANDATORY for performance/optimization claims)
+### Step 3.6: Performance and Causal Attribution Validation
+
+For every hang, timeout, rate-limit, API-budget, or transport-cause claim—even
+when it is not a performance report—require the blocked command/process-tree
+evidence and backend state described in Step 2.5. If either is unavailable, do
+not assert the cause: file an investigation brief with the suspected cause marked
+unconfirmed.
+
+The remaining checks are mandatory for performance/optimization claims:
 
 If the issue involves performance, optimization, O(n^2) claims, or "hot path" assertions:
 

--- a/TODO.md
+++ b/TODO.md
@@ -1137,8 +1137,6 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18096 Treat canonical lint policy deferrals as safe skips #auto-dispatch #bug ref:GH#27139
 
-- [ ] t18105 Validate causal evidence in framework bug reports #bug ref:GH#27271
-
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/TODO.md
+++ b/TODO.md
@@ -1137,6 +1137,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18096 Treat canonical lint policy deferrals as safe skips #auto-dispatch #bug ref:GH#27139
 
+- [ ] t18105 Validate causal evidence in framework bug reports #bug ref:GH#27271
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Require substantive reproducer fields and direct blocked-command/backend-state evidence before framework reports assert hang, timeout, rate-limit, API-budget, or transport causes; otherwise require investigation framing.

## Files Changed

.agents/scripts/log-issue-helper.sh, .agents/tests/log-issue-helper.bats, .agents/workflows/log-issue-aidevops.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck and bash syntax passed; changed/full local linter suites passed; five Bats regression cases added (local bats executable unavailable, delegated to CI).

Resolves #27271


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.35 with gpt-5.6-sol spent 28m and 495,211 tokens on this with the user in an interactive session.