### PR TITLE
GH#27272: fix agent bundle deploy verification

### DIFF
--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -239,8 +239,12 @@ _set_script_permissions_and_report() {
 _count_deployed_agent_files() {
 	local target_dir="$1"
 	local file_count="0"
+	local resolved_dir=""
 	if [[ -d "$target_dir" ]]; then
-		file_count=$(find "$target_dir" -type f 2>/dev/null | wc -l | tr -d '[:space:]')
+		resolved_dir=$(cd "$target_dir" 2>/dev/null && pwd -P) || resolved_dir=""
+		if [[ -n "$resolved_dir" ]]; then
+			file_count=$(find "$resolved_dir" -type f 2>/dev/null | wc -l | tr -d '[:space:]')
+		fi
 	fi
 	[[ "$file_count" =~ ^[0-9]+$ ]] || file_count=0
 	printf '%s\n' "$file_count"

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -95,6 +95,10 @@ test_initial_activation_and_manifest() {
 
 	[[ -L "$target_dir" ]] || fail "active agents path is an activation symlink"
 	pass "active agents path is an activation symlink"
+	[[ "$(_count_deployed_agent_files "$target_dir")" -gt 0 ]] || fail "deploy verifier counts files through the activation symlink"
+	pass "deploy verifier counts files through the activation symlink"
+	_verify_deployed_agents_tree "$target_dir" || fail "deployed activation symlink passes completeness verification"
+	pass "deployed activation symlink passes completeness verification"
 	assert_eq "2.0.0" "$(tr -d '[:space:]' <"$active_root/VERSION")" "CLI and agents activate at one version"
 	assert_file_contains "$active_root/.bundle-manifest" '^status=validated$' "validated manifest is inside the active bundle"
 	assert_file_contains "$active_root/.bundle-manifest" '^cli_compatibility=2.0.0$' "manifest binds CLI compatibility"


### PR DESCRIPTION
## Summary

- Resolves #27272.
- Resolve the active atomic runtime bundle before counting deployed files.
- Add regression coverage proving symlink-based agent activation passes completeness verification.

## Testing

- `bash .agents/scripts/tests/test-agent-deploy-staging.sh`
- `shellcheck .agents/scripts/setup/modules/agent-deploy.sh .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh`
- `./.agents/scripts/linters-local.sh --full`

## Runtime Testing

Runtime failure reproduced three times during `setup.sh --non-interactive`: deployment copied over 2,180 files but verification counted zero through the activation symlink. The focused test now exercises that exact topology. A post-merge setup run will provide final runtime verification.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.35 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2h 39m and 798,070 tokens on this with the user in an interactive session.
