### PR TITLE
GH#27278: Align profile stats to completed calendar days

### DIFF
--- a/.agents/scripts/profile-readme-render-lib.sh
+++ b/.agents/scripts/profile-readme-render-lib.sh
@@ -318,10 +318,10 @@ _generate_top_apps_section() {
 
 ## Top Apps by Screen Time
 
-| App | 24h | 7 Days | 28 Days |
+| App | Yesterday | Prior 7 Days | Prior 28 Days |
 | --- | ---: | ---: | ---: |
 ${app_rows}
-_Top 10 apps by foreground time share. Mac only._
+_Top 10 apps by foreground time share across completed local calendar days. Mac only._
 EOF
 	return 0
 }
@@ -461,7 +461,7 @@ _generate_work_with_ai_table() {
 	cat <<EOF
 ## Work with AI
 
-| Metric | 24h | 7 Days | 28 Days | 365 Days |
+| Metric | Yesterday | Prior 7 Days | Prior 28 Days | Prior 365 Days |
 | --- | ---: | ---: | ---: | ---: |
 | ${screen_label} | ${screen_today} | ${screen_week} | ${screen_month} | ${year_prefix}${screen_year}${year_suffix} |
 | Interactive human attention | $(_format_work_hour_cell "$day_human") | $(_format_work_hour_cell "$week_human") | $(_format_work_hour_cell "$month_human") | $(_format_work_hour_cell "$year_human") |
@@ -473,6 +473,8 @@ _generate_work_with_ai_table() {
 | Worker sessions | ${f_day_wrk} | ${f_week_wrk} | ${f_month_wrk} | ${f_year_wrk} |
 
 _Screen time from ${screen_source}; collection status: ${screen_status}.$([ -n "$year_suffix" ] && echo " *365-day estimate uses observed calendar coverage.")_
+
+_Periods are completed local calendar days ending at midnight; today is excluded._
 
 _Human attention is unioned wall-clock time, so overlapping sessions are not double-counted. AI generation is additive machine work across sessions; it is not wall-clock concurrency._${session_coverage_note}
 EOF

--- a/.agents/scripts/screen_time_history.py
+++ b/.agents/scripts/screen_time_history.py
@@ -6,7 +6,7 @@ import datetime as dt
 import json
 import math
 
-from screen_time_interval_common import WINDOWS, interval_seconds, local_date
+from screen_time_interval_common import WINDOWS, completed_day_window, interval_seconds, local_date
 
 
 def coverage(collection, start, end):
@@ -26,11 +26,10 @@ def coverage(collection, start, end):
     return round(days, 1), round(days / window_days * 100, 1)
 
 
-def period_payload(collection, now, seconds):
-    start = now - seconds
-    observed_days, coverage_pct = coverage(collection, start, now)
+def bounded_period_payload(collection, start, end, semantics="rolling-clock-window"):
+    observed_days, coverage_pct = coverage(collection, start, end)
     status = collection.get("status", "unavailable")
-    hours = None if status == "unavailable" else round(interval_seconds(collection.get("intervals", []), start, now) / 3600, 1)
+    hours = None if status == "unavailable" else round(interval_seconds(collection.get("intervals", []), start, end) / 3600, 1)
     return {
         "hours": hours,
         "status": status,
@@ -41,7 +40,14 @@ def period_payload(collection, now, seconds):
         "freshness_hours": collection.get("freshness_hours"),
         "observations": collection.get("observations", 0),
         "estimated": False,
+        "period_start_epoch": start,
+        "period_end_epoch": end,
+        "period_semantics": semantics,
     }
+
+
+def period_payload(collection, now, seconds):
+    return bounded_period_payload(collection, now - seconds, now)
 
 
 def parse_history_row(line):
@@ -88,6 +94,7 @@ def history_period(rows, now, days, skipped_rows=0):
     total = round(sum(item[1][0] for item in selected), 1)
     span = max(1, (max(dates) - min(dates)).days + 1)
     latest_age = (end_date - max(dates)).days
+    start_epoch, end_epoch = completed_day_window(now, days)
     return {
         "hours": min(days * 24.0, total),
         "status": "stale" if latest_age > 2 else "ok",
@@ -100,6 +107,9 @@ def history_period(rows, now, days, skipped_rows=0):
         "observations": len(selected),
         "estimated": False,
         "skipped_history_rows": skipped_rows,
+        "period_start_epoch": start_epoch,
+        "period_end_epoch": end_epoch,
+        "period_semantics": "completed-local-calendar-days",
     }
 
 
@@ -125,7 +135,11 @@ def estimated_year(periods, history, now, skipped):
 
 
 def profile_payload(collection, history_path, now):
-    periods = {name: period_payload(collection, now, seconds) for name, seconds in WINDOWS.items()}
+    day_counts = {"day": 1, "week": 7, "month": 28, "year": 365}
+    periods = {}
+    for name in WINDOWS:
+        start, end = completed_day_window(now, day_counts[name])
+        periods[name] = bounded_period_payload(collection, start, end, "completed-local-calendar-days")
     history, skipped = read_history(history_path, now)
     apply_short_history(periods, history, now, skipped)
     periods["year"] = estimated_year(periods, history, now, skipped)

--- a/.agents/scripts/screen_time_interval_common.py
+++ b/.agents/scripts/screen_time_interval_common.py
@@ -43,6 +43,16 @@ def local_day_bounds(date):
     return (start, end) if end is not None else (None, None)
 
 
+def completed_day_window(now, days):
+    """Return the previous N completed local calendar days as epoch bounds."""
+    end_date = local_date(now)
+    if end_date is None or days < 1:
+        return None, None
+    start = local_midnight_epoch(end_date - dt.timedelta(days=days))
+    end = local_midnight_epoch(end_date)
+    return (start, end) if start is not None and end is not None else (None, None)
+
+
 def safe_core_epoch(value):
     converted = safe_float(value)
     if converted is None:

--- a/.agents/scripts/screen_time_macos_apps.py
+++ b/.agents/scripts/screen_time_macos_apps.py
@@ -9,7 +9,7 @@ import sqlite3
 import time
 from pathlib import Path
 
-from screen_time_interval_common import CORE_DATA_EPOCH, DAY, safe_core_epoch
+from screen_time_interval_common import CORE_DATA_EPOCH, completed_day_window, safe_core_epoch
 
 
 def read_app_stat_rows(db_path, now):
@@ -17,12 +17,13 @@ def read_app_stat_rows(db_path, now):
         return [], "database-missing"
     try:
         uri = f"file:{db_path}?mode=ro"
+        month_start, period_end = completed_day_window(now, 28)
         with sqlite3.connect(uri, uri=True, timeout=5) as connection:
             rows = connection.execute(
                 "SELECT ZVALUESTRING, ZSTARTDATE, ZENDDATE FROM ZOBJECT "
                 "WHERE ZSTREAMNAME='/app/usage' AND ZVALUESTRING IS NOT NULL "
                 "AND ZENDDATE > ? AND ZSTARTDATE < ? ORDER BY ZSTARTDATE",
-                (now - 28 * DAY - CORE_DATA_EPOCH, now - CORE_DATA_EPOCH),
+                (month_start - CORE_DATA_EPOCH, period_end - CORE_DATA_EPOCH),
             ).fetchall()
         return rows, None
     except (OSError, sqlite3.Error) as exc:
@@ -30,7 +31,7 @@ def read_app_stat_rows(db_path, now):
 
 
 def parse_app_stat_rows(rows, now):
-    month_start = now - 28 * DAY
+    month_start, period_end = completed_day_window(now, 28)
     parsed = []
     for bundle, start, end in rows:
         original_start = safe_core_epoch(start)
@@ -38,7 +39,7 @@ def parse_app_stat_rows(rows, now):
         if original_start is None or original_end is None or original_end <= original_start:
             continue
         left = max(month_start, original_start)
-        right = min(now, original_end)
+        right = min(period_end, original_end)
         if right > left:
             parsed.append((str(bundle), left, right, original_start))
     return parsed
@@ -68,8 +69,7 @@ def attribute_segment(context, left, right):
         return
     bundle = context["latest_heap"][0][3]
     context["stats"]["attributed_segments"] += 1
-    now = context["now"]
-    for name, window_start in (("today", now - DAY), ("week", now - 7 * DAY), ("month", now - 28 * DAY)):
+    for name, window_start in context["window_starts"].items():
         overlap = right - max(left, window_start)
         if overlap > 0:
             totals = context["totals"][name]
@@ -77,13 +77,15 @@ def attribute_segment(context, left, right):
 
 
 def attribute_app_totals(intervals, now):
-    starts, ends, ordered = interval_boundaries(intervals, now - 28 * DAY, now)
+    window_starts = {name: completed_day_window(now, days)[0] for name, days in (("today", 1), ("week", 7), ("month", 28))}
+    period_end = completed_day_window(now, 1)[1]
+    starts, ends, ordered = interval_boundaries(intervals, window_starts["month"], period_end)
     context = {
         "active": set(),
         "latest_heap": [],
         "totals": {name: {} for name in ("today", "week", "month")},
         "stats": {"boundaries": len(ordered), "attributed_segments": 0, "max_active": 0},
-        "now": now,
+        "window_starts": window_starts,
     }
     for left, right in zip(ordered, ordered[1:]):
         update_active_apps(context, starts.get(left, []), ends.get(left, []))

--- a/.agents/scripts/session-time-interval-engine.py
+++ b/.agents/scripts/session-time-interval-engine.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 
 from session_time_aggregate import aggregate
-from session_time_common import WINDOWS
+from session_time_common import DAY_MS, WINDOWS, completed_day_window
 from session_time_db import db_paths, query_observability, query_session_db
 
 
@@ -49,12 +49,21 @@ def requested_periods(period):
     return [period]
 
 
-def aggregate_periods(periods, context):
+def aggregate_periods(periods, context, completed_days=False):
     result = {}
     for period in periods:
-        since = context["now"] - WINDOWS.get(period, WINDOWS["month"])
-        result[period] = aggregate(context["sessions"], context["obs_rows"], since, context["now"], context["source_ok"])
+        if completed_days:
+            days = WINDOWS.get(period, WINDOWS["month"]) // DAY_MS
+            since, end = completed_day_window(context["now"], days)
+            semantics = "completed-local-calendar-days"
+        else:
+            since, end = context["now"] - WINDOWS.get(period, WINDOWS["month"]), context["now"]
+            semantics = "rolling-clock-window"
+        result[period] = aggregate(context["sessions"], context["obs_rows"], since, end, context["source_ok"])
         result[period]["skipped_malformed_rows"] = context["skipped"]
+        result[period]["period_start_ms"] = since
+        result[period]["period_end_ms"] = end
+        result[period]["period_semantics"] = semantics
     return result
 
 
@@ -62,13 +71,13 @@ def main():
     args = parser().parse_args()
     root = "" if args.all_dirs else os.path.abspath(args.repo or ".")
     home = Path.home()
-    maximum_since = args.now_ms - WINDOWS["year"]
+    maximum_since = args.now_ms - WINDOWS["year"] - 2 * DAY_MS
     sessions, session_ok, skipped = collect_sessions(home, args.db_path, root, maximum_since)
     obs_rows, obs_ok, obs_skipped = query_observability(home, root, maximum_since, args.now_ms)
     skipped += obs_skipped
     periods = requested_periods(args.period)
     context = {"sessions": sessions, "obs_rows": obs_rows, "now": args.now_ms, "source_ok": session_ok or obs_ok, "skipped": skipped}
-    result = aggregate_periods(periods, context)
+    result = aggregate_periods(periods, context, args.period == "profile")
     payload = result if len(periods) > 1 else result[periods[0]]
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0

--- a/.agents/scripts/session_time_common.py
+++ b/.agents/scripts/session_time_common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import re
 
 DAY_MS = 86400000
@@ -13,6 +14,15 @@ WINDOWS = {
     "quarter": 90 * DAY_MS,
     "year": 365 * DAY_MS,
 }
+
+
+def completed_day_window(now_ms, days):
+    """Return millisecond bounds for the previous N completed local days."""
+    end_date = dt.datetime.fromtimestamp(now_ms / 1000).date()
+    start_date = end_date - dt.timedelta(days=days)
+    start = dt.datetime.combine(start_date, dt.time.min).timestamp()
+    end = dt.datetime.combine(end_date, dt.time.min).timestamp()
+    return int(start * 1000), int(end * 1000)
 WORKER_PATTERNS = [
     re.compile(pattern, re.I)
     for pattern in (

--- a/.agents/scripts/tests/test-contributor-session-archive.sh
+++ b/.agents/scripts/tests/test-contributor-session-archive.sh
@@ -346,15 +346,18 @@ test_profile_periods_scan_once_and_union_attention() {
 	source "$SOURCE_SESSION_LIB"
 	local active_db="${TEST_DIR}/home/.local/share/opencode/opencode.db"
 	create_session_db "$active_db"
-	local now_ms start_ms counter output human scans
+	local now_ms start_ms counter output human scans semantics start_bound end_bound
 	now_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
-	start_ms=$((now_ms - 3600000))
+	start_ms=$(python3 -c 'import datetime as d,time; today=d.datetime.now().date(); print(int(d.datetime.combine(today-d.timedelta(days=1),d.time(12)).timestamp()*1000))')
 	insert_overlapping_attention_fixture "$active_db" "overlap-one" "$start_ms" "$TEST_DIR/repo"
 	insert_overlapping_attention_fixture "$active_db" "overlap-two" "$start_ms" "$TEST_DIR/repo"
 	counter="${TEST_DIR}/scan-count"
 	output=$(HOME="${TEST_DIR}/home" AIDEVOPS_SESSION_SCAN_COUNTER="$counter" session_time --all-dirs --period profile --format json)
 	human=$(echo "$output" | jq -r '.day.total_human_hours')
 	scans=$(wc -l <"$counter" | tr -d ' ')
+	semantics=$(echo "$output" | jq -r '.day.period_semantics')
+	start_bound=$(echo "$output" | jq -r '.day.period_start_ms')
+	end_bound=$(echo "$output" | jq -r '.day.period_end_ms')
 	if [[ "$human" != "0.5" ]]; then
 		print_result "$test_name" 1 "expected overlapping 0.5h attention intervals to union to 0.5h, got ${human}"
 		teardown
@@ -362,6 +365,11 @@ test_profile_periods_scan_once_and_union_attention() {
 	fi
 	if [[ "$scans" != "1" ]]; then
 		print_result "$test_name" 1 "expected one session DB scan for four profile windows, got ${scans}"
+		teardown
+		return 0
+	fi
+	if [[ "$semantics" != "completed-local-calendar-days" || "$start_bound" -ge "$start_ms" || "$end_bound" -le "$start_ms" ]]; then
+		print_result "$test_name" 1 "profile day did not expose completed local-calendar-day bounds"
 		teardown
 		return 0
 	fi

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -672,6 +672,11 @@ test_work_with_ai_worker_counts_above_thousand() {
 		print_result "${test_name}" 1 "four-digit worker session counts were not preserved and comma-formatted"
 		return 0
 	fi
+	if ! grep -qF '| Metric | Yesterday | Prior 7 Days | Prior 28 Days | Prior 365 Days |' "${output_file}" ||
+		! grep -qF 'Periods are completed local calendar days ending at midnight; today is excluded.' "${output_file}"; then
+		print_result "${test_name}" 1 "completed-calendar-day labels or disclosure were not rendered"
+		return 0
+	fi
 
 	if grep -qF '| Worker sessions | 55 | 0 | 0 | 0 |' "${output_file}"; then
 		print_result "${test_name}" 1 "worker session counts regressed to zero after double-formatting"

--- a/.agents/scripts/tests/test-screen-time-helper.sh
+++ b/.agents/scripts/tests/test-screen-time-helper.sh
@@ -34,6 +34,14 @@ core_data_offset() {
 	return 0
 }
 
+local_day_epoch() {
+	local now="$1"
+	local days_ago="$2"
+	local hour="$3"
+	python3 -c 'import datetime as d,sys; day=d.datetime.fromtimestamp(int(sys.argv[1])).date()-d.timedelta(days=int(sys.argv[2])); print(int(d.datetime.combine(day,d.time(int(sys.argv[3]))).timestamp()))' "$now" "$days_ago" "$hour"
+	return 0
+}
+
 insert_backlit_pair() {
 	local db="$1"
 	local on_epoch="$2"
@@ -89,9 +97,11 @@ test_union_clipping_and_failure_status() {
 
 	# Force app fallback with overlapping/repeated intervals. The union is 5h,
 	# not the additive 9h, and the 30h interval is clipped to the 24h window.
-	insert_app_usage "$overlap_db" "$((now - one_hour * 6))" "$((now - one_hour))"
-	insert_app_usage "$overlap_db" "$((now - one_hour * 5))" "$((now - one_hour * 2))"
-	insert_app_usage "$overlap_db" "$((now - one_hour * 6))" "$((now - one_hour))"
+	local previous_noon
+	previous_noon=$(local_day_epoch "$now" 1 12)
+	insert_app_usage "$overlap_db" "$previous_noon" "$((previous_noon + one_hour * 5))"
+	insert_app_usage "$overlap_db" "$((previous_noon + one_hour))" "$((previous_noon + one_hour * 4))"
+	insert_app_usage "$overlap_db" "$previous_noon" "$((previous_noon + one_hour * 5))"
 	local overlap_hours
 	overlap_hours=$(query_hours "$overlap_db" 1)
 	[[ "$overlap_hours" == "5.0" ]] || fail "expected app intervals to union to 5.0h, got ${overlap_hours}"
@@ -221,7 +231,7 @@ test_top_apps_sql_and_sweep_are_bounded() {
 	boundaries=$(jq -r '.boundaries' "$instrument")
 	segments=$(jq -r '.attributed_segments' "$instrument")
 	elapsed=$(jq -r '.elapsed_ms' "$instrument")
-	if [[ "$selected" != "200" || "$valid" != "200" || "$boundaries" -gt 402 || "$segments" -gt 401 ]] ||
+	if [[ "$selected" -lt 1 || "$selected" -gt 200 || "$valid" != "$selected" || "$boundaries" -gt 402 || "$segments" -gt 401 ]] ||
 		! awk -v elapsed="$elapsed" 'BEGIN {exit !(elapsed < 5000)}'; then
 		fail "top-app query/sweep was unbounded: $(<"$instrument")"
 	fi
@@ -248,9 +258,30 @@ test_local_midnight_dst_boundaries() {
 	return 0
 }
 
+test_profile_completed_day_dst_semantics() {
+	local tmpdir="$1"
+	local db="${tmpdir}/profile-dst.db"
+	create_knowledge_db "$db"
+	local values spring_start spring_end spring_now fall_start fall_end fall_now
+	values=$(TZ=America/New_York python3 -c 'import datetime as d,time; time.tzset(); epoch=lambda x:int(x.timestamp()); s=d.date(2026,3,8); f=d.date(2026,11,1); print(epoch(d.datetime.combine(s,d.time.min)),epoch(d.datetime.combine(s+d.timedelta(days=1),d.time.min)),epoch(d.datetime(2026,3,9,12)),epoch(d.datetime.combine(f,d.time.min)),epoch(d.datetime.combine(f+d.timedelta(days=1),d.time.min)),epoch(d.datetime(2026,11,2,12)))')
+	read -r spring_start spring_end spring_now fall_start fall_end fall_now <<<"$values"
+	insert_app_usage "$db" "$spring_start" "$spring_end"
+	insert_app_usage "$db" "$fall_start" "$fall_end"
+	local spring_json fall_json
+	spring_json=$(TZ=America/New_York AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$spring_now" profile_stats "$db")
+	fall_json=$(TZ=America/New_York AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$fall_now" profile_stats "$db")
+	[[ "$(printf '%s' "$spring_json" | jq -r '.today_hours')" == "23" || "$(printf '%s' "$spring_json" | jq -r '.today_hours')" == "23.0" ]] || fail "spring profile day was not the completed 23-hour local day"
+	[[ "$(printf '%s' "$fall_json" | jq -r '.today_hours')" == "25" || "$(printf '%s' "$fall_json" | jq -r '.today_hours')" == "25.0" ]] || fail "fall profile day was not the completed 25-hour local day"
+	[[ "$(printf '%s' "$spring_json" | jq -r '.periods.day.period_semantics')" == "completed-local-calendar-days" ]] || fail "screen profile omitted completed-day semantics"
+	[[ "$(printf '%s' "$spring_json" | jq -r '.periods.day.period_start_epoch | floor')" == "$spring_start" && "$(printf '%s' "$spring_json" | jq -r '.periods.day.period_end_epoch | floor')" == "$spring_end" ]] || fail "screen profile exposed incorrect completed-day bounds"
+	pass "profile screen periods use completed local days across DST"
+	return 0
+}
+
 test_linux_state_machine() {
 	local tmpdir="$1"
-	local now=2000000000
+	local now
+	now=$(python3 -c 'import datetime as d; print(int(d.datetime(2033,5,19,12).timestamp()))')
 	local fixture="${tmpdir}/logind.txt"
 	python3 - "$fixture" "$now" <<'PY'
 import datetime as dt
@@ -259,12 +290,12 @@ import sys
 target = sys.argv[1]
 now = int(sys.argv[2])
 events = [
-    (-6, "New session c1 of user fixture."),
-    (-5, "Session c1 locked."),
-    (-4, "Session c1 unlocked."),
-    (-3, "Lid closed."),
-    (-2, "Lid opened."),
-    (-1, "Removed session c1."),
+    (-30, "New session c1 of user fixture."),
+    (-29, "Session c1 locked."),
+    (-28, "Session c1 unlocked."),
+    (-27, "Lid closed."),
+    (-26, "Lid opened."),
+    (-25, "Removed session c1."),
 ]
 with open(target, "w", encoding="utf-8") as handle:
     for hours, message in events:
@@ -283,7 +314,7 @@ PY
 	python3 - "$zero_fixture" "$now" <<'PY'
 import datetime as dt
 import sys
-stamp = dt.datetime.fromtimestamp(int(sys.argv[2]) - 60, dt.timezone.utc).isoformat()
+stamp = dt.datetime.fromtimestamp(int(sys.argv[2]) - 30 * 3600, dt.timezone.utc).isoformat()
 with open(sys.argv[1], "w", encoding="utf-8") as handle:
     handle.write(f"{stamp} host systemd-logind[1]: New session z1 of user fixture.\n")
     handle.write(f"{stamp} host systemd-logind[1]: Removed session z1.\n")
@@ -296,7 +327,7 @@ PY
 
 	local missing_journal="${tmpdir}/missing-journal"
 	local wtmp_fixture="${tmpdir}/wtmp.txt"
-	printf '%s|%s\n' "$((now - 7200))" "$((now - 3600))" >"$wtmp_fixture"
+	printf '%s|%s\n' "$((now - 30 * 3600))" "$((now - 29 * 3600))" >"$wtmp_fixture"
 	local fallback
 	fallback=$(AIDEVOPS_SCREEN_TIME_OS_TYPE=Linux AIDEVOPS_LOGIND_FIXTURE="$missing_journal" \
 		AIDEVOPS_LAST_FIXTURE="$wtmp_fixture" AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" \
@@ -309,14 +340,14 @@ PY
 	local realistic_last="${tmpdir}/last-F.txt"
 	: >"$empty_journal"
 	cat >"$realistic_last" <<'EOF'
-fixture  pts/0  host  Tue May 17 23:33:20 2033 - Wed May 18 00:33:20 2033  (01:00)
-fixture  pts/1  host  Wed May 18 01:33:20 2033   still logged in
+fixture  pts/0  host  Wed May 18 01:00:00 2033 - Wed May 18 02:00:00 2033  (01:00)
+fixture  pts/1  host  Wed May 18 03:00:00 2033   still logged in
 EOF
 	local empty_fallback
 	empty_fallback=$(TZ=UTC AIDEVOPS_SCREEN_TIME_OS_TYPE=Linux AIDEVOPS_LOGIND_FIXTURE="$empty_journal" \
 		AIDEVOPS_LAST_FIXTURE="$realistic_last" AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" \
 		AIDEVOPS_SCREEN_TIME_USER=fixture "$HELPER" profile-stats)
-	[[ "$(printf '%s' "$empty_fallback" | jq -r '.today_hours')" == "3" || "$(printf '%s' "$empty_fallback" | jq -r '.today_hours')" == "3.0" ]] || fail "real last -F completed+active records were not clipped to now"
+	[[ "$(printf '%s' "$empty_fallback" | jq -r '.today_hours')" == "22" || "$(printf '%s' "$empty_fallback" | jq -r '.today_hours')" == "22.0" ]] || fail "real last -F completed+active records were not clipped to the completed day"
 	[[ "$(printf '%s' "$empty_fallback" | jq -r '.periods.day.reason')" == *"journal-readable-no-user-observations"* ]] || fail "empty readable logind did not truthfully fall back"
 	pass "empty logind falls back and parses realistic local last -F records"
 	return 0
@@ -359,7 +390,9 @@ test_corrupt_core_data_and_history_paths_are_safe() {
 	local now="$2"
 	local db="${tmpdir}/corrupt-core-data.db"
 	create_knowledge_db "$db"
-	insert_app_usage "$db" "$((now - 7200))" "$((now - 3600))"
+	local previous_noon
+	previous_noon=$(local_day_epoch "$now" 1 12)
+	insert_app_usage "$db" "$previous_noon" "$((previous_noon + 3600))"
 	sqlite3 "$db" "
 		UPDATE ZOBJECT SET ZVALUESTRING='valid.app' WHERE ZSTREAMNAME='/app/usage';
 		INSERT INTO ZOBJECT (ZSTREAMNAME,ZCREATIONDATE,ZVALUEINTEGER) VALUES('/display/isBacklit','broken',1);
@@ -454,6 +487,7 @@ main() {
 	test_snapshot_omits_unobserved_stale_dates "$tmpdir"
 	test_top_apps_sql_and_sweep_are_bounded "$tmpdir" "$now"
 	test_local_midnight_dst_boundaries "$tmpdir"
+	test_profile_completed_day_dst_semantics "$tmpdir"
 	test_linux_state_machine "$tmpdir"
 	test_history_calendar_coverage_and_staleness "$tmpdir"
 	test_corrupt_core_data_and_history_paths_are_safe "$tmpdir" "$now"


### PR DESCRIPTION
## Summary

Use identical completed local-calendar-day boundaries for profile screen, session, and app metrics; expose bounds and semantics; replace rolling labels; preserve direct rolling queries.

## Files Changed

.agents/scripts/profile-readme-render-lib.sh, .agents/scripts/screen_time_history.py, .agents/scripts/screen_time_interval_common.py, .agents/scripts/screen_time_macos_apps.py, .agents/scripts/session-time-interval-engine.py, .agents/scripts/session_time_common.py, .agents/scripts/tests/test-contributor-session-archive.sh, .agents/scripts/tests/test-profile-readme-boundary.sh, .agents/scripts/tests/test-screen-time-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Screen-time suite, session archive suite, ShellCheck, Python compile, local linters, runtime profile generation, and DST boundary assertions pass.

Resolves #27278


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.35 with gpt-5.6-sol spent 9h 11m and 3,787,630 tokens on this with the user in an interactive session.