### PR TITLE
GH#27281: complete GPT-5.6 model limits

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -17,6 +17,7 @@ import {
   CLAUDE_MODEL_LIMITS,
   GPT56_CONTEXT_DEFAULT,
   GPT56_MODEL_IDS,
+  GPT56_OUTPUT_DEFAULT,
 } from "./model-limits.mjs";
 
 /**
@@ -141,7 +142,8 @@ export function gpt56ContextCapEnabled() {
 
 /**
  * Override built-in OpenAI GPT-5.6 model metadata without replacing any other
- * model fields. Sparse provider model entries are merged by OpenCode.
+ * model fields. OpenCode validates plugin-added model entries before merging
+ * built-in registry metadata, so every limit must include required fields.
  * @param {object} config - OpenCode Config object (mutable)
  * @returns {number} number of model limits applied
  */
@@ -155,7 +157,11 @@ export function registerGpt56ContextLimits(config) {
     const existing = config.provider.openai.models[id] || {};
     config.provider.openai.models[id] = {
       ...existing,
-      limit: { ...existing.limit, context: GPT56_CONTEXT_DEFAULT },
+      limit: {
+        output: GPT56_OUTPUT_DEFAULT,
+        ...existing.limit,
+        context: GPT56_CONTEXT_DEFAULT,
+      },
     };
   }
   return GPT56_MODEL_IDS.length;

--- a/.agents/plugins/opencode-aidevops/model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/model-limits.mjs
@@ -31,6 +31,9 @@ export const OPUS_47_CONTEXT_MAX = 1000000;
  */
 export const GPT56_CONTEXT_DEFAULT = 300000;
 
+/** Maximum GPT-5.6 response size advertised by OpenCode's model registry. */
+export const GPT56_OUTPUT_DEFAULT = 128000;
+
 /** GPT-5.6 model IDs currently exposed by the OpenAI provider. */
 export const GPT56_MODEL_IDS = [
   "gpt-5.6-sol",

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs
@@ -42,7 +42,21 @@ test("GPT-5.6 cap defaults on and applies 300K without losing model fields", () 
   assert.equal(registerGpt56ContextLimits(config), 4);
   assert.equal(config.provider.openai.models["gpt-5.6-sol"].name, "Sol");
   assert.equal(config.provider.openai.models["gpt-5.6-sol"].limit.context, 300000);
+  assert.equal(config.provider.openai.models["gpt-5.6-sol"].limit.output, 128000);
   assert.equal(config.provider.openai.models["gpt-5.6-terra"].limit.context, 300000);
+  assert.equal(config.provider.openai.models["gpt-5.6-terra"].limit.output, 128000);
+});
+
+test("GPT-5.6 cap preserves an explicit output limit", () => {
+  settingsFile(undefined);
+  const config = {
+    provider: { openai: { models: { "gpt-5.6-sol": { limit: { output: 64000 } } } } },
+  };
+  registerGpt56ContextLimits(config);
+  assert.deepEqual(config.provider.openai.models["gpt-5.6-sol"].limit, {
+    output: 64000,
+    context: 300000,
+  });
 });
 
 test("GPT-5.6 cap opt-out leaves OpenAI model metadata untouched", () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
@@ -22,10 +22,12 @@ import {
   CLAUDE_MODEL_LIMITS,
   GPT56_CONTEXT_DEFAULT,
   GPT56_MODEL_IDS,
+  GPT56_OUTPUT_DEFAULT,
 } from "../model-limits.mjs";
 
 test("GPT-5.6 context metadata targets 300K for 240K auto-compaction", () => {
   assert.equal(GPT56_CONTEXT_DEFAULT, 300000);
+  assert.equal(GPT56_OUTPUT_DEFAULT, 128000);
   assert.deepEqual(GPT56_MODEL_IDS, [
     "gpt-5.6-sol",
     "gpt-5.6-sol-pro",


### PR DESCRIPTION
## Summary

Resolves #27281

- complete aidevops-added GPT-5.6 model limits with OpenCode's required `output` field
- preserve explicit user output-limit overrides while enforcing the 300K context cap
- add regression coverage for schema-complete limits and override preservation

## Root cause

OpenCode validates plugin-added provider models before merging its built-in model registry. The recently added sparse `limit: { context: 300000 }` entries therefore failed schema validation because `limit.output` was absent.

## Runtime Testing

- `node --test .agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs .agents/plugins/opencode-aidevops/tests/test-model-limits.mjs` — 26 passed
- `.agents/scripts/linters-local.sh --full` — passed
- deployed the patched plugin and ran `opencode models openai` successfully; GPT-5.6 models load without the previous startup error

## Key decision

Use the `128000` output limit advertised by OpenCode's local model registry, while retaining an explicitly configured output limit when present.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.35 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 12m and 172,016 tokens on this with the user in an interactive session.
