### PR TITLE
GH#27145: preserve roadmap and first-turn progress

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { buildSessionStartGreetingInstruction } from "../ttsr.mjs";
+
+const instruction = buildSessionStartGreetingInstruction("/missing", () => "");
+
+assert.match(instruction, /greeting is only a required prefix/);
+assert.match(instruction, /SAME assistant turn/);
+assert.match(instruction, /Never stop after acknowledging/);
+assert.match(instruction, /call the appropriate tools immediately/);
+
+console.log("session-start task execution instruction tests passed");

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -190,7 +190,7 @@ function buildCorrectionMessage(violations, sessionID) {
 // Hook implementations (module-level, accept state + deps as parameters)
 // ---------------------------------------------------------------------------
 
-function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
+export function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
   const cachePath = join(agentsDir, "..", "cache", "session-greeting.txt");
   const cacheLines = readIfExists(cachePath).split("\n").map((line) => line.trim()).filter(Boolean);
   const cacheLine = cacheLines[0] || "";
@@ -215,7 +215,8 @@ function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
     "",
     "Do this before tool calls, status updates, analysis summaries, or task work.",
     "Do not include startup status or advisory messages in chat; those are already shown by the OpenCode toast/sidebar surfaces.",
-    "If the user launched the session with an initial message, greet first in the assistant response, then answer that message.",
+    "If the user launched the session with an initial message, the greeting is only a required prefix: immediately execute or fully answer that message in the SAME assistant turn.",
+    "A task request already authorises task work. Never stop after acknowledging, restating, promising, or asking the user to say continue; call the appropriate tools immediately after the greeting unless genuinely blocked.",
     "If the initial user message is only a greeting/salutation, do not add any additional salutations, greetings, introductory questions, or equivalent help prompts after the exact greeting above.",
     "Do not repeat the greeting after the first assistant turn, and do not duplicate the framework-status toast/sidebar content.",
   ].join("\n");

--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -18,6 +18,7 @@
 #   _fetch_subissue_numbers       — fetch child issue numbers via GraphQL
 #   _extract_children_section     — extract ## Children / ## Sub-tasks section
 #   _extract_children_from_prose  — extract children from narrow prose patterns
+#   _fetch_children_from_trusted_roadmap_comments — extract trusted roadmap refs
 #   _compute_parent_nudge_age_hours — compute age of decomposition nudge comment
 #   _post_parent_phases_unfiled_nudge — nudge when declared phases > filed children
 #   _try_close_parent_tracker     — close parent if all children are resolved
@@ -191,6 +192,38 @@ _extract_children_from_prose() {
 	# Extract the trailing #NNNN from each matched phrase, strip the `#`,
 	# drop anything that isn't a clean positive integer, deduplicate.
 	printf '%s' "$all_matches" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -un
+	return 0
+}
+
+#######################################
+# Extract child issue numbers from trusted roadmap comments.
+#
+# Parent creation can publish a dependency roadmap as a maintainer comment
+# while leaving the immutable original body unchanged. Reconciliation used to
+# ignore that durable declaration and falsely report zero children. Restrict
+# this source to trusted author associations and an explicit roadmap/children
+# heading so arbitrary prose references cannot affect parent closure.
+#
+# Arguments:
+#   arg1 - repository slug
+#   arg2 - parent issue number
+# Outputs: one child issue number per line, deduplicated and sorted.
+# Returns: 0, including on API failure (no comment evidence).
+#######################################
+_fetch_children_from_trusted_roadmap_comments() {
+	local slug="$1"
+	local issue_num="$2"
+	[[ -n "$slug" ]] || return 0
+	[[ "$issue_num" =~ ^[0-9]+$ ]] || return 0
+
+	gh api --paginate "repos/${slug}/issues/${issue_num}/comments" \
+		--jq '.[] | select((.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR") and (.body | test("(?im)^##[[:space:]]+(Dispatch roadmap|Children|Child issues|Sub-tasks)[[:space:]]*$"))) | .body' \
+		2>/dev/null | awk '
+		BEGIN { in_section = 0 }
+		/^##[[:space:]]+(Dispatch roadmap|Children|Child [Ii]ssues|Sub-?[Tt]asks)[[:space:]]*$/ { in_section = 1; next }
+		in_section && /^##[[:space:]]/ { in_section = 0 }
+		in_section { print }
+	' | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -un || true
 	return 0
 }
 
@@ -882,7 +915,7 @@ _action_cpt_single() {
 	# union step below regardless of whether children_section is
 	# non-empty. Without init, an issue body with no children-section
 	# triggers `_b_nums: unbound variable` and aborts the function.
-	local _g_nums="" _b_nums="" _p_nums="" child_nums=""
+	local _g_nums="" _b_nums="" _p_nums="" _c_nums="" child_nums=""
 	local _src_parts=""
 	_g_nums=$(_fetch_subissue_numbers "$slug" "$issue_num" | sort -un | grep -v "^${issue_num}$" | grep -v '^$' || true)
 	[[ -n "$_g_nums" ]] && _src_parts="${_src_parts:+${_src_parts}+}graph"
@@ -897,8 +930,11 @@ _action_cpt_single() {
 	_p_nums=$(_extract_children_from_prose "$issue_body" | grep -v "^${issue_num}$" || true)
 	[[ -n "$_p_nums" ]] && _src_parts="${_src_parts:+${_src_parts}+}prose"
 
+	_c_nums=$(_fetch_children_from_trusted_roadmap_comments "$slug" "$issue_num" | grep -v "^${issue_num}$" || true)
+	[[ -n "$_c_nums" ]] && _src_parts="${_src_parts:+${_src_parts}+}comments"
+
 	# Union: concatenate, keep numeric lines, dedupe, drop self-reference
-	child_nums=$(printf '%s\n%s\n%s\n' "$_g_nums" "$_b_nums" "$_p_nums" \
+	child_nums=$(printf '%s\n%s\n%s\n%s\n' "$_g_nums" "$_b_nums" "$_p_nums" "$_c_nums" \
 		| grep -E '^[0-9]+$' | sort -un | grep -v "^${issue_num}$" || true)
 	local child_source="${_src_parts:-none}"
 	local known_child_count=0

--- a/.agents/scripts/tests/test-parent-prose-child-detection.sh
+++ b/.agents/scripts/tests/test-parent-prose-child-detection.sh
@@ -215,11 +215,11 @@ fi
 # --- Source wiring assertion — the helper is actually called in reconcile ---
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TARGET="$SCRIPT_DIR/pulse-issue-reconcile.sh"
+TARGET="$SCRIPT_DIR/pulse-issue-reconcile-actions.sh"
 
 TESTS_RUN=$((TESTS_RUN + 1))
 if grep -qF '_extract_children_from_prose' "$TARGET" 2>/dev/null &&
-	grep -qE 'prose_children=\$\(_extract_children_from_prose' "$TARGET" 2>/dev/null; then
+	grep -qF '_p_nums=$(_extract_children_from_prose' "$TARGET" 2>/dev/null; then
 	echo "${TEST_GREEN}PASS${TEST_NC}: 12: _extract_children_from_prose wired in reconcile_completed_parent_tasks"
 else
 	TESTS_FAILED=$((TESTS_FAILED + 1))

--- a/.agents/scripts/tests/test-parent-roadmap-comment-children.sh
+++ b/.agents/scripts/tests/test-parent-roadmap-comment-children.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC2016 # source assertions intentionally match literal shell expressions
+
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+target="${script_dir}/pulse-issue-reconcile-actions.sh"
+failures=0
+
+assert_source() {
+	local description="$1"
+	local pattern="$2"
+	if grep -qF "$pattern" "$target"; then
+		printf 'PASS: %s\n' "$description"
+	else
+		printf 'FAIL: %s\n' "$description"
+		failures=$((failures + 1))
+	fi
+	return 0
+}
+
+assert_source "trusted roadmap comment extractor exists" '_fetch_children_from_trusted_roadmap_comments()'
+assert_source "extractor requires an explicit roadmap heading" 'Dispatch roadmap|Children|Child issues|Sub-tasks'
+assert_source "extractor restricts comments to trusted associations" '.author_association == "OWNER"'
+assert_source "reconciler includes trusted comment children" '_c_nums=$(_fetch_children_from_trusted_roadmap_comments'
+assert_source "comment children participate in the union" '"$_p_nums" "$_c_nums"'
+
+if [[ "$failures" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -766,7 +766,7 @@ test_top_apps_batches_jq_processing() {
 		CREATE TABLE ZOBJECT (ZSTREAMNAME TEXT,ZCREATIONDATE REAL,ZVALUEINTEGER INTEGER,ZSTARTDATE REAL,ZENDDATE REAL,ZVALUESTRING TEXT);
 		WITH RECURSIVE rows(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM rows WHERE i < 10)
 		INSERT INTO ZOBJECT (ZSTREAMNAME,ZSTARTDATE,ZENDDATE,ZVALUESTRING)
-		SELECT '/app/usage', ${core_now} - i*600, ${core_now} - i*600 + 300, 'fixture.app.' || i FROM rows;"
+		SELECT '/app/usage', ${core_now} - 86400 - i*600, ${core_now} - 86400 - i*600 + 300, 'fixture.app.' || i FROM rows;"
 	local real_jq wrapper_dir count_file
 	real_jq=$(command -v jq)
 	wrapper_dir="${TEST_DIR}/bin"


### PR DESCRIPTION
## Summary

- recognise maintainer-authored `## Dispatch roadmap` comments as trusted parent-child declarations
- keep roadmap comment references in the parent reconciliation union without trusting arbitrary comments
- strengthen the injected startup greeting contract so an initial task executes in the same turn instead of stopping at acknowledgement
- repair the extracted parent-reconcile regression test target

For #27145

## Testing

- `.agents/scripts/linters-local.sh`
- `test-session-start-task-execution.mjs`
- `test-parent-roadmap-comment-children.sh`
- `test-parent-prose-child-detection.sh`
- `test-pulse-reconcile-parent-task-subissue-graph.sh`
- ShellCheck and Node syntax checks

## Runtime Testing

Runtime-verified with the parent reconciliation fixture suites; startup instruction output is asserted directly.

## Decisions

Comment discovery is restricted to OWNER/MEMBER/COLLABORATOR authors and explicit roadmap/children headings to avoid treating arbitrary issue references as children. The roadmap parent remains open while its dependency-ordered children execute.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.35 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 7m and 127,244 tokens on this with the user in an interactive session. Overall, 7h 53m since this issue was created.
