### PR TITLE
GH#27284: align top-app fixture with completed days

### DIFF
--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -761,7 +761,9 @@ test_top_apps_batches_jq_processing() {
 	local db_path="${TEST_DIR}/knowledgeC.db"
 	local now core_now
 	now=$(date +%s)
-	core_now=$((now - 978307200))
+	# Production reports completed calendar days and excludes today. Place the
+	# fixture one day back so it remains inside the prior-day windows.
+	core_now=$((now - 978307200 - 86400))
 	sqlite3 "$db_path" "
 		CREATE TABLE ZOBJECT (ZSTREAMNAME TEXT,ZCREATIONDATE REAL,ZVALUEINTEGER INTEGER,ZSTARTDATE REAL,ZENDDATE REAL,ZVALUESTRING TEXT);
 		WITH RECURSIVE rows(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM rows WHERE i < 10)


### PR DESCRIPTION
## Summary

Resolves #27284

- move top-app test fixtures into the previous day
- align the regression test with production's completed-calendar-day windows
- retain the ten-app and maximum-two-jq-process assertions

## Testing

- `shellcheck .agents/scripts/tests/test-profile-readme-boundary.sh`
- GitHub Framework Validation is the authoritative Linux runtime check; the local full script's temporary Git remotes are blocked by the canonical Git safety guard

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.35 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 25m and 200,000 tokens on this with the user in an interactive session.
