### PR TITLE
t18099: Make dispatch handoff an atomic expiring lease

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -49,6 +49,8 @@ DISPATCH_CLAIM_MAX_AGE="${DISPATCH_CLAIM_MAX_AGE:-1800}"
 # issue still has no assignee and no later "Dispatching worker" comment, treat
 # it as a pre-launch orphan instead of blocking retries for the full TTL.
 DISPATCH_CLAIM_ORPHAN_GRACE="${DISPATCH_CLAIM_ORPHAN_GRACE:-120}"
+DISPATCH_READY_LEASE_TTL="${DISPATCH_READY_LEASE_TTL:-7200}"
+AIDEVOPS_DEVICE_ID_FILE="${AIDEVOPS_DEVICE_ID_FILE:-${HOME}/.aidevops/state/device-id}"
 
 # Number of issue comments to request per GitHub REST page when reading claim
 # markers. GitHub defaults to the oldest 30 comments, which misses fresh claims
@@ -63,6 +65,15 @@ DISPATCH_CLAIM_SELF_RECLAIM_AGE="${DISPATCH_CLAIM_SELF_RECLAIM_AGE:-30}"
 # Claim comment marker — used as both the posting format and the search pattern.
 # Plain text format: visible in rendered GitHub issue view.
 CLAIM_MARKER="DISPATCH_CLAIM"
+LEGACY_DEVICE_MARKER="legacy"
+JSON_NULL_MARKER="null"
+
+_issue_comments_endpoint() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	printf 'repos/%s/issues/%s/comments' "$repo_slug" "$issue_number"
+	return 0
+}
 
 # t2399/t2401: Runtime override for cross-runner dispatch coordination.
 #
@@ -161,6 +172,20 @@ _now_utc() {
 #######################################
 _now_epoch() {
 	date -u '+%s'
+	return 0
+}
+
+_resolve_device_id() {
+	local device_id="${AIDEVOPS_DEVICE_ID:-}"
+	if [[ -z "$device_id" && -r "$AIDEVOPS_DEVICE_ID_FILE" ]]; then
+		device_id=$(tr -cd 'a-zA-Z0-9._-' <"$AIDEVOPS_DEVICE_ID_FILE" 2>/dev/null || true)
+	fi
+	if [[ -z "$device_id" ]]; then
+		device_id="device-$(_now_epoch)-$$-${RANDOM:-0}"
+		mkdir -p "${AIDEVOPS_DEVICE_ID_FILE%/*}" 2>/dev/null || true
+		(umask 077; printf '%s\n' "$device_id" >"$AIDEVOPS_DEVICE_ID_FILE") 2>/dev/null || true
+	fi
+	printf '%s' "$device_id"
 	return 0
 }
 
@@ -282,7 +307,11 @@ _post_claim() {
 		opencode_version="${opencode_version:-$AIDEVOPS_UNKNOWN_VERSION}"
 	fi
 
-	local machine_readable_part="${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE} version=${version} opencode_version=${opencode_version}"
+	local device_id="" expires_at="" now_epoch=""
+	device_id=$(_resolve_device_id)
+	now_epoch=$(_now_epoch)
+	expires_at="$((now_epoch + DISPATCH_CLAIM_ORPHAN_GRACE))"
+	local machine_readable_part="${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE} version=${version} opencode_version=${opencode_version} lease_token=${nonce} device=${device_id} session=issue-${issue_number} phase=prelaunch expires_at=${expires_at}"
 	if [[ -n "$reason_fields" ]]; then
 		machine_readable_part+=" ${reason_fields}"
 	fi
@@ -303,7 +332,7 @@ ${machine_readable_part}
 	local comment_id="" attempt=1 post_err_file="" post_error_summary=""
 	post_err_file=$(mktemp 2>/dev/null || _claim_post_error_fallback_path) || return 1
 	while [[ "$attempt" -le "$attempts" ]]; do
-		comment_id=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		comment_id=$(gh api "$(_issue_comments_endpoint "$repo_slug" "$issue_number")" \
 			--method POST \
 			--field body="$body" \
 			--jq '.id' 2>"$post_err_file") && break
@@ -322,7 +351,7 @@ ${machine_readable_part}
 		return 1
 	fi
 
-	if [[ -z "$comment_id" || "$comment_id" == "null" ]]; then
+	if [[ -z "$comment_id" || "$comment_id" == "$JSON_NULL_MARKER" ]]; then
 		echo "Error: claim comment posted but no ID returned" >&2
 		return 1
 	fi
@@ -357,15 +386,15 @@ _detect_stale_worker_takeover_reason() {
 		printf '%s' ""
 		return 0
 	}
-	comments_json=$(printf '%s' "$raw_comments" | jq -c '[ (
-		if (type == "array" and ((.[0]? | type) == "array")) then
+	comments_json=$(printf '%s' "$raw_comments" | jq -c --arg array_type array '[ (
+		if (type == $array_type and ((.[0]? | type) == $array_type)) then
 			.[]
 		else
 			.
 		end
 	)[] | {body_start: ((.body // "")[:300]), created_at: .created_at}]' 2>/dev/null) || comments_json="[]"
 
-	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
+	if [[ -z "$comments_json" || "$comments_json" == "$JSON_NULL_MARKER" || "$comments_json" == "[]" ]]; then
 		printf '%s' ""
 		return 0
 	fi
@@ -375,7 +404,7 @@ _detect_stale_worker_takeover_reason() {
 		[.[] | select((.body_start // "") | test("(^|\\n)Dispatching worker"))]
 		| sort_by(.created_at) | reverse | first // empty
 	' 2>/dev/null) || last_dispatch_json=""
-	if [[ -z "$last_dispatch_json" || "$last_dispatch_json" == "null" ]]; then
+	if [[ -z "$last_dispatch_json" || "$last_dispatch_json" == "$JSON_NULL_MARKER" ]]; then
 		printf '%s' ""
 		return 0
 	fi
@@ -465,15 +494,15 @@ _fetch_claim_marker_comments() {
 		return 1
 	}
 
-	printf '%s' "$raw_comments" | jq -c --arg marker "${CLAIM_MARKER}" '
+	printf '%s' "$raw_comments" | jq -c --arg marker "${CLAIM_MARKER}" --arg array_type array '
 		[ (
-			if (type == "array" and ((.[0]? | type) == "array")) then
+			if (type == $array_type and ((.[0]? | type) == $array_type)) then
 				.[]
 			else
 				.
 			end
 		)[]
-		| select((.body // "" | ascii_downcase) | (contains(($marker | ascii_downcase) + " nonce=") or contains("claim_released") or contains("dispatching worker")))
+		| select((.body // "" | ascii_downcase) | (contains(($marker | ascii_downcase) + " nonce=") or contains("dispatch_lease") or contains("claim_released") or contains("dispatching worker")))
 		| {id: .id, body: .body, created_at: .created_at} ]
 	' || {
 		echo "Error: failed to parse comments for #${issue_number} in ${repo_slug}" >&2
@@ -505,7 +534,7 @@ _fetch_claims() {
 	local comments_json
 	comments_json=$(_fetch_claim_marker_comments "$issue_number" "$repo_slug") || return 1
 
-	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
+	if [[ -z "$comments_json" || "$comments_json" == "$JSON_NULL_MARKER" || "$comments_json" == "[]" ]]; then
 		printf '[]'
 		return 0
 	fi
@@ -538,29 +567,9 @@ _fetch_claims() {
 	# t2401: version is an optional trailing field; legacy pre-t2401 claims
 	# lack it and parse as "unknown".
 	local parsed
-	parsed=$(printf '%s' "$claims_only" | jq -c --argjson now "$now_epoch" --argjson max_age "$DISPATCH_CLAIM_MAX_AGE" '
-		[.[] |
-			(.body | capture("nonce=(?<nonce>[^ ]+) runner=(?<runner>[^ ]+) ts=(?<ts>[^ ]+)(?: max_age_s=[^ ]+)?(?: version=(?<version>[^ ]+))?")) as $fields |
-			{
-				id: .id,
-				nonce: $fields.nonce,
-				runner: $fields.runner,
-				ts: $fields.ts,
-				version: ($fields.version // "unknown"),
-				created_at: .created_at,
-				created_epoch: (.created_at | fromdateiso8601? // 0)
-			}
-		] |
-		map(. + {age_seconds: ($now - .created_epoch)}) |
-		map(select(.age_seconds >= 0 and .age_seconds <= $max_age)) |
-		# t2422: Sort primarily by created_at (GitHub timestamp, 1-second
-		# granularity) with nonce as lexicographic tiebreaker. Two runners that
-		# post claims within the same wall-clock second need a deterministic
-		# winner that both observers agree on — nonce is UUID-uniform random,
-		# so lex order is effectively a fair coin flip that is stable across
-		# any runner reading the same comment list.
-		sort_by([.created_at, .nonce])
-	' 2>/dev/null) || {
+	parsed=$(printf '%s' "$claims_only" | jq -c --argjson now "$now_epoch" \
+		--argjson max_age "$DISPATCH_CLAIM_MAX_AGE" --argjson comments "$comments_json" \
+		-f "${DISPATCH_CLAIM_HELPER_DIR}/dispatch-lease-claims.jq" 2>/dev/null) || {
 		echo "Error: failed to parse claim comments" >&2
 		return 1
 	}
@@ -663,7 +672,7 @@ _post_orphan_claim_release() {
 	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
 CLAIM_RELEASED reason=claim_only_no_worker runner=${runner} ts=$(_now_utc) removed_claims=${removed_count}
 <!-- ops:end -->"
-	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+	gh api "$(_issue_comments_endpoint "$repo_slug" "$issue_number")" \
 		--method POST \
 		--field body="$body" >/dev/null 2>&1 || return 1
 	return 0
@@ -1154,15 +1163,19 @@ cmd_claim() {
 	fi
 
 	# Step 4: Check if our claim is the oldest
-	local oldest_nonce oldest_runner oldest_age_seconds
+	local oldest_nonce oldest_runner oldest_age_seconds oldest_device our_device lease_expires_at now_epoch
 	oldest_nonce=$(printf '%s' "$claims" | jq -r '.[0].nonce // ""' 2>/dev/null) || oldest_nonce=""
 	oldest_runner=$(printf '%s' "$claims" | jq -r '.[0].runner // "unknown"' 2>/dev/null) || oldest_runner="unknown"
 	oldest_age_seconds=$(printf '%s' "$claims" | jq -r '.[0].age_seconds // 0' 2>/dev/null) || oldest_age_seconds=0
+	oldest_device=$(printf '%s' "$claims" | jq -r --arg fallback "$LEGACY_DEVICE_MARKER" '.[0].device // $fallback' 2>/dev/null) || oldest_device="$LEGACY_DEVICE_MARKER"
+	our_device=$(_resolve_device_id)
+	now_epoch=$(_now_epoch)
+	lease_expires_at="$((now_epoch + DISPATCH_CLAIM_ORPHAN_GRACE))"
 
 	if [[ "$oldest_nonce" == "$nonce" ]]; then
 		# We won — our claim is the oldest
-		printf 'CLAIM_WON: runner=%s nonce=%s issue=#%s comment_id=%s\n' \
-			"$runner" "$nonce" "$issue_number" "$comment_id"
+		printf 'CLAIM_WON: runner=%s nonce=%s issue=#%s comment_id=%s lease_token=%s device=%s phase=prelaunch expires_at=%s\n' \
+			"$runner" "$nonce" "$issue_number" "$comment_id" "$nonce" "$our_device" "$lease_expires_at"
 		return 0
 	fi
 
@@ -1173,7 +1186,7 @@ cmd_claim() {
 	#
 	# Same-runner stale claim: another claim from this runner already exists.
 	# The existing claim is still blocking (within TTL), so back off.
-	if [[ "$oldest_runner" == "$runner" && "$oldest_nonce" != "$nonce" ]]; then
+	if [[ "$oldest_runner" == "$runner" && ( "$oldest_device" == "$LEGACY_DEVICE_MARKER" || "$oldest_device" == "$our_device" ) && "$oldest_nonce" != "$nonce" ]]; then
 		printf 'CLAIM_STALE_SELF: runner=%s found own prior claim on issue #%s (age=%ss) — backing off (claim retained for audit)\n' \
 			"$runner" "$issue_number" "$oldest_age_seconds"
 		return 1
@@ -1189,6 +1202,22 @@ cmd_claim() {
 		"$runner" "$oldest_runner" "$issue_number"
 
 	return 1
+}
+
+cmd_transition() {
+	local phase="${1:-}" issue_number="${2:-}" repo_slug="${3:-}" lease_token="${4:-}" session_key="${5:-}"
+	local ttl="${6:-$DISPATCH_READY_LEASE_TTL}"
+	case "$phase" in ready | terminal) ;; *) echo "Error: transition phase must be ready or terminal" >&2; return 1 ;; esac
+	[[ "$issue_number" =~ ^[0-9]+$ && -n "$repo_slug" && -n "$lease_token" ]] || return 1
+	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl="$DISPATCH_READY_LEASE_TTL"
+	local expires_at="0" now_epoch="" body=""
+	now_epoch=$(_now_epoch)
+	[[ "$phase" == "terminal" ]] || expires_at="$((now_epoch + ttl))"
+	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+DISPATCH_LEASE phase=${phase} lease_token=${lease_token} device=$(_resolve_device_id) session=${session_key:-issue-${issue_number}} expires_at=${expires_at} ts=$(_now_utc)
+<!-- ops:end -->"
+	gh api "$(_issue_comments_endpoint "$repo_slug" "$issue_number")" --method POST --field body="$body" >/dev/null 2>&1 || return 1
+	return 0
 }
 
 #######################################
@@ -1359,6 +1388,9 @@ main() {
 		;;
 	check)
 		cmd_check "$@"
+		;;
+	transition)
+		cmd_transition "$@"
 		;;
 	help | --help | -h)
 		show_help

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -1083,6 +1083,45 @@ _guard_no_active_assignment_before_claim() {
 	esac
 }
 
+_resolve_claim_race_result() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local runner="$3"
+	local nonce="$4"
+	local comment_id="$5"
+	local claims="$6"
+	local claim_count=""
+	claim_count=$(printf '%s' "$claims" | jq 'length' 2>/dev/null) || claim_count=0
+	if [[ "$claim_count" -eq 0 ]]; then
+		echo "CLAIM_ERROR: no claims found after posting — proceeding (fail-open)" >&2
+		return 2
+	fi
+
+	local oldest_nonce oldest_runner oldest_age_seconds oldest_device our_device lease_expires_at now_epoch
+	oldest_nonce=$(printf '%s' "$claims" | jq -r '.[0].nonce // ""' 2>/dev/null) || oldest_nonce=""
+	oldest_runner=$(printf '%s' "$claims" | jq -r '.[0].runner // "unknown"' 2>/dev/null) || oldest_runner="unknown"
+	oldest_age_seconds=$(printf '%s' "$claims" | jq -r '.[0].age_seconds // 0' 2>/dev/null) || oldest_age_seconds=0
+	oldest_device=$(printf '%s' "$claims" | jq -r --arg fallback "$LEGACY_DEVICE_MARKER" '.[0].device // $fallback' 2>/dev/null) || oldest_device="$LEGACY_DEVICE_MARKER"
+	our_device=$(_resolve_device_id)
+	now_epoch=$(_now_epoch)
+	lease_expires_at="$((now_epoch + DISPATCH_CLAIM_ORPHAN_GRACE))"
+	if [[ "$oldest_nonce" == "$nonce" ]]; then
+		printf 'CLAIM_WON: runner=%s nonce=%s issue=#%s comment_id=%s lease_token=%s device=%s phase=prelaunch expires_at=%s\n' \
+			"$runner" "$nonce" "$issue_number" "$comment_id" "$nonce" "$our_device" "$lease_expires_at"
+		return 0
+	fi
+	if [[ "$oldest_runner" == "$runner" && ( "$oldest_device" == "$LEGACY_DEVICE_MARKER" || "$oldest_device" == "$our_device" ) && "$oldest_nonce" != "$nonce" ]]; then
+		printf 'CLAIM_STALE_SELF: runner=%s found own prior claim on issue #%s (age=%ss) — backing off (claim retained for audit)\n' \
+			"$runner" "$issue_number" "$oldest_age_seconds"
+		return 1
+	fi
+	_handle_close_window_loss "$issue_number" "$repo_slug" "$runner" "$nonce" \
+		"$oldest_runner" "$claims" || true
+	printf 'CLAIM_LOST: runner=%s lost to %s on issue #%s — backing off (both claims retained for audit)\n' \
+		"$runner" "$oldest_runner" "$issue_number"
+	return 1
+}
+
 #######################################
 # Attempt to claim an issue for dispatch.
 #
@@ -1158,55 +1197,8 @@ cmd_claim() {
 		return 2
 	}
 
-	local claim_count
-	claim_count=$(printf '%s' "$claims" | jq 'length' 2>/dev/null) || claim_count=0
-
-	if [[ "$claim_count" -eq 0 ]]; then
-		# No claims found (including ours) — something went wrong, fail-open
-		echo "CLAIM_ERROR: no claims found after posting — proceeding (fail-open)" >&2
-		return 2
-	fi
-
-	# Step 4: Check if our claim is the oldest
-	local oldest_nonce oldest_runner oldest_age_seconds oldest_device our_device lease_expires_at now_epoch
-	oldest_nonce=$(printf '%s' "$claims" | jq -r '.[0].nonce // ""' 2>/dev/null) || oldest_nonce=""
-	oldest_runner=$(printf '%s' "$claims" | jq -r '.[0].runner // "unknown"' 2>/dev/null) || oldest_runner="unknown"
-	oldest_age_seconds=$(printf '%s' "$claims" | jq -r '.[0].age_seconds // 0' 2>/dev/null) || oldest_age_seconds=0
-	oldest_device=$(printf '%s' "$claims" | jq -r --arg fallback "$LEGACY_DEVICE_MARKER" '.[0].device // $fallback' 2>/dev/null) || oldest_device="$LEGACY_DEVICE_MARKER"
-	our_device=$(_resolve_device_id)
-	now_epoch=$(_now_epoch)
-	lease_expires_at="$((now_epoch + DISPATCH_CLAIM_ORPHAN_GRACE))"
-
-	if [[ "$oldest_nonce" == "$nonce" ]]; then
-		# We won — our claim is the oldest
-		printf 'CLAIM_WON: runner=%s nonce=%s issue=#%s comment_id=%s lease_token=%s device=%s phase=prelaunch expires_at=%s\n' \
-			"$runner" "$nonce" "$issue_number" "$comment_id" "$nonce" "$our_device" "$lease_expires_at"
-		return 0
-	fi
-
-	# GH#17503: Claim comments are NEVER deleted — they form the audit trail
-	# of every dispatch attempt. The claim TTL (DISPATCH_CLAIM_MAX_AGE=1800s)
-	# controls how long a claim blocks re-dispatch; after expiry the comment
-	# stays but no longer locks the issue.
-	#
-	# Same-runner stale claim: another claim from this runner already exists.
-	# The existing claim is still blocking (within TTL), so back off.
-	if [[ "$oldest_runner" == "$runner" && ( "$oldest_device" == "$LEGACY_DEVICE_MARKER" || "$oldest_device" == "$our_device" ) && "$oldest_nonce" != "$nonce" ]]; then
-		printf 'CLAIM_STALE_SELF: runner=%s found own prior claim on issue #%s (age=%ss) — backing off (claim retained for audit)\n' \
-			"$runner" "$issue_number" "$oldest_age_seconds"
-		return 1
-	fi
-
-	# Step 5: We lost — another runner's claim is older.
-	# t2422: If this was a close-window race (delta <= DISPATCH_TIEBREAKER_WINDOW),
-	# _handle_close_window_loss emits a CLAIM_DEFERRED audit comment.
-	_handle_close_window_loss "$issue_number" "$repo_slug" "$runner" "$nonce" \
-		"$oldest_runner" "$claims" || true
-
-	printf 'CLAIM_LOST: runner=%s lost to %s on issue #%s — backing off (both claims retained for audit)\n' \
-		"$runner" "$oldest_runner" "$issue_number"
-
-	return 1
+	_resolve_claim_race_result "$issue_number" "$repo_slug" "$runner" "$nonce" "$comment_id" "$claims"
+	return $?
 }
 
 cmd_transition() {

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -177,8 +177,13 @@ _now_epoch() {
 
 _resolve_device_id() {
 	local device_id="${AIDEVOPS_DEVICE_ID:-}"
+	if [[ -n "$device_id" && ! "$device_id" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$ ]]; then
+		printf 'Warning: invalid AIDEVOPS_DEVICE_ID ignored\n' >&2
+		device_id=""
+	fi
 	if [[ -z "$device_id" && -r "$AIDEVOPS_DEVICE_ID_FILE" ]]; then
-		device_id=$(tr -cd 'a-zA-Z0-9._-' <"$AIDEVOPS_DEVICE_ID_FILE" 2>/dev/null || true)
+		device_id=$(tr -d '[:space:]' <"$AIDEVOPS_DEVICE_ID_FILE" 2>/dev/null || true)
+		[[ "$device_id" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$ ]] || device_id=""
 	fi
 	if [[ -z "$device_id" ]]; then
 		device_id="device-$(_now_epoch)-$$-${RANDOM:-0}"
@@ -1210,6 +1215,14 @@ cmd_transition() {
 	case "$phase" in ready | terminal) ;; *) echo "Error: transition phase must be ready or terminal" >&2; return 1 ;; esac
 	[[ "$issue_number" =~ ^[0-9]+$ && -n "$repo_slug" && -n "$lease_token" ]] || return 1
 	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl="$DISPATCH_READY_LEASE_TTL"
+	local active_claims="" current_phase=""
+	active_claims=$(_fetch_claims "$issue_number" "$repo_slug") || return 1
+	current_phase=$(printf '%s' "$active_claims" | jq -r --arg token "$lease_token" \
+		'[.[] | select(.lease_token == $token)] | last | .lease_phase // ""' 2>/dev/null) || current_phase=""
+	[[ -n "$current_phase" ]] || return 1
+	if [[ "$phase" == "ready" && "$current_phase" != "prelaunch" ]]; then
+		return 1
+	fi
 	local expires_at="0" now_epoch="" body=""
 	now_epoch=$(_now_epoch)
 	[[ "$phase" == "terminal" ]] || expires_at="$((now_epoch + ttl))"

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -508,7 +508,7 @@ _fetch_claim_marker_comments() {
 			end
 		)[]
 		| select((.body // "" | ascii_downcase) | (contains(($marker | ascii_downcase) + " nonce=") or contains("dispatch_lease") or contains("claim_released") or contains("dispatching worker")))
-		| {id: .id, body: .body, created_at: .created_at} ]
+		| {id: .id, body: .body, created_at: .created_at, author: (.user.login // ""), author_association: (.author_association // "")} ]
 	' || {
 		echo "Error: failed to parse comments for #${issue_number} in ${repo_slug}" >&2
 		return 1
@@ -655,7 +655,7 @@ _filter_claims_with_launch_evidence() {
 			| select((.created_at // "") > ($claim.created_at // ""))
 			| select((.body // "" | ascii_downcase) | contains("dispatching worker"))
 		  ] | length) as $launch_count
-		| select((.age_seconds // 0) <= $orphan_grace or $launch_count > 0)
+		| select(.lease_phase == "ready" or (.age_seconds // 0) <= $orphan_grace or $launch_count > 0)
 		]
 		| sort_by([.created_at, .nonce])
 	' 2>/dev/null || printf '%s' "$parsed_claims"
@@ -1215,11 +1215,18 @@ cmd_transition() {
 	case "$phase" in ready | terminal) ;; *) echo "Error: transition phase must be ready or terminal" >&2; return 1 ;; esac
 	[[ "$issue_number" =~ ^[0-9]+$ && -n "$repo_slug" && -n "$lease_token" ]] || return 1
 	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl="$DISPATCH_READY_LEASE_TTL"
-	local active_claims="" current_phase=""
+	local active_claims="" current_phase="" claim_record="" claim_author="" claim_device="" claim_session="" current_login="" current_device=""
 	active_claims=$(_fetch_claims "$issue_number" "$repo_slug") || return 1
-	current_phase=$(printf '%s' "$active_claims" | jq -r --arg token "$lease_token" \
-		'[.[] | select(.lease_token == $token)] | last | .lease_phase // ""' 2>/dev/null) || current_phase=""
+	claim_record=$(printf '%s' "$active_claims" | jq -c --arg token "$lease_token" '[.[] | select(.lease_token == $token)] | last // empty' 2>/dev/null) || claim_record=""
+	current_phase=$(printf '%s' "$claim_record" | jq -r '.lease_phase // ""' 2>/dev/null) || current_phase=""
 	[[ -n "$current_phase" ]] || return 1
+	claim_author=$(printf '%s' "$claim_record" | jq -r '.claim_author // ""') || return 1
+	claim_device=$(printf '%s' "$claim_record" | jq -r '.device // ""') || return 1
+	claim_session=$(printf '%s' "$claim_record" | jq -r '.session // ""') || return 1
+	current_login=$(_resolve_runner "") || return 1
+	current_device=$(_resolve_device_id)
+	[[ -n "$claim_author" && "$current_login" == "$claim_author" ]] || return 1
+	[[ "$current_device" == "$claim_device" && "${session_key:-issue-${issue_number}}" == "$claim_session" ]] || return 1
 	if [[ "$phase" == "ready" && "$current_phase" != "prelaunch" ]]; then
 		return 1
 	fi

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -141,6 +141,26 @@ _stale_recovery_latest_dispatch_ts_from_pages() {
 	return 0
 }
 
+_stale_recovery_final_evidence_recheck() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local expected_dispatch_ts="$3"
+	local pages="" latest_dispatch_ts="" now_epoch=""
+	pages=$(_stale_recovery_fetch_comments_pages "$issue_number" "$repo_slug")
+	[[ -n "$pages" ]] || return 1
+	latest_dispatch_ts=$(_stale_recovery_latest_dispatch_ts_from_pages "$pages")
+	[[ "$latest_dispatch_ts" == "$expected_dispatch_ts" ]] || return 1
+	now_epoch=$(date +%s)
+	if printf '%s' "$pages" | jq -e --argjson now "$now_epoch" '
+		[.[] | .[]? | select((.body // "") | contains("DISPATCH_LEASE phase=ready"))
+		 | (.body | capture("lease_token=(?<token>[^ ]+).*expires_at=(?<expires>[0-9]+)"))
+		 | select((.expires | tonumber) >= $now)] | length > 0' >/dev/null 2>&1; then
+		return 1
+	fi
+	# PID exit is deliberately absent: remote completion requires durable evidence.
+	return 0
+}
+
 #######################################
 # Check for terminal worker-failure evidence after a dispatch timestamp.
 # Stale escalation should not infer failure from GitHub silence alone; in a
@@ -439,6 +459,12 @@ _recover_stale_assignment() {
 		_terminal_evidence=true
 	fi
 	_open_pr=$(_stale_recovery_find_open_pr "$issue_number" "$repo_slug")
+	# Re-read the durable evidence immediately before any takeover mutation. A
+	# worker may have become ready or published progress after the first read.
+	if ! _stale_recovery_final_evidence_recheck "$issue_number" "$repo_slug" "$_latest_dispatch_ts"; then
+		printf 'STALE_RECHECK_BLOCKED: issue #%s in %s — evidence changed or active ready lease found\n' "$issue_number" "$repo_slug"
+		return 0
+	fi
 
 	if [[ -n "$_open_pr" ]]; then
 		# Open PR exists — counter resets; post a reset marker and allow normal recovery

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -151,10 +151,12 @@ _stale_recovery_final_evidence_recheck() {
 	latest_dispatch_ts=$(_stale_recovery_latest_dispatch_ts_from_pages "$pages")
 	[[ "$latest_dispatch_ts" == "$expected_dispatch_ts" ]] || return 1
 	now_epoch=$(date +%s)
-	if printf '%s' "$pages" | jq -e --argjson now "$now_epoch" '
-		[.[] | .[]? | select((.body // "") | contains("DISPATCH_LEASE phase=ready"))
-		 | (.body | capture("lease_token=(?<token>[^ ]+).*expires_at=(?<expires>[0-9]+)"))
-		 | select((.expires | tonumber) >= $now)] | length > 0' >/dev/null 2>&1; then
+	local comments="" claims="" parsed=""
+	comments=$(printf '%s' "$pages" | jq -c '[.[] | .[]?]' 2>/dev/null) || return 1
+	claims=$(printf '%s' "$comments" | jq -c '[.[] | select((.body // "") | contains("DISPATCH_CLAIM nonce="))]' 2>/dev/null) || return 1
+	parsed=$(printf '%s' "$claims" | jq -c --argjson now "$now_epoch" --argjson max_age 2147483647 \
+		--argjson comments "$comments" -f "${SCRIPT_DIR}/dispatch-lease-claims.jq" 2>/dev/null) || return 1
+	if printf '%s' "$parsed" | jq -e 'any(.lease_phase == "ready")' >/dev/null 2>&1; then
 		return 1
 	fi
 	# PID exit is deliberately absent: remote completion requires durable evidence.
@@ -245,6 +247,11 @@ _stale_recovery_escalate() {
 	local reason="$4"
 	local _threshold="$5"
 	local _prior_ticks="$6"
+	local expected_dispatch_ts="${7:-}"
+	if ! _stale_recovery_final_evidence_recheck "$issue_number" "$repo_slug" "$expected_dispatch_ts"; then
+		printf 'STALE_RECHECK_BLOCKED: issue #%s in %s — evidence changed before escalation\n' "$issue_number" "$repo_slug"
+		return 0
+	fi
 
 	# Unassign stale workers (still needed to clean up the assignment)
 	local _esc_ifs="${IFS:-}"
@@ -326,9 +333,14 @@ _stale_recovery_apply_blocked_by_hold() {
 	local repo_slug="$2"
 	local stale_assignees="$3"
 	local reason="$4"
-	shift 4
+	local expected_dispatch_ts="$5"
+	shift 5
 	local -a recov_extra=("$@")
 
+	if ! _stale_recovery_final_evidence_recheck "$issue_number" "$repo_slug" "$expected_dispatch_ts"; then
+		printf 'STALE_RECHECK_BLOCKED: issue #%s in %s — evidence changed before blocked takeover\n' "$issue_number" "$repo_slug"
+		return 0
+	fi
 	set_issue_status "$issue_number" "$repo_slug" "blocked" "${recov_extra[@]}" || true
 
 	local _now_ts=""
@@ -378,6 +390,7 @@ _stale_recovery_apply() {
 	local repo_slug="$2"
 	local stale_assignees="$3"
 	local reason="$4"
+	local expected_dispatch_ts="${5:-}"
 
 	local saved_ifs="${IFS:-}"
 	local -a assignee_arr=()
@@ -390,7 +403,11 @@ _stale_recovery_apply() {
 		[[ -n "$assignee" ]] && _recov_extra+=(--remove-assignee "$assignee")
 	done
 	if _stale_recovery_has_unresolved_blocked_by "$issue_number" "$repo_slug"; then
-		_stale_recovery_apply_blocked_by_hold "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "${_recov_extra[@]}"
+		_stale_recovery_apply_blocked_by_hold "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$expected_dispatch_ts" "${_recov_extra[@]}"
+		return 0
+	fi
+	if ! _stale_recovery_final_evidence_recheck "$issue_number" "$repo_slug" "$expected_dispatch_ts"; then
+		printf 'STALE_RECHECK_BLOCKED: issue #%s in %s — evidence changed before takeover\n' "$issue_number" "$repo_slug"
 		return 0
 	fi
 	set_issue_status "$issue_number" "$repo_slug" "available" "${_recov_extra[@]}" || true
@@ -459,13 +476,6 @@ _recover_stale_assignment() {
 		_terminal_evidence=true
 	fi
 	_open_pr=$(_stale_recovery_find_open_pr "$issue_number" "$repo_slug")
-	# Re-read the durable evidence immediately before any takeover mutation. A
-	# worker may have become ready or published progress after the first read.
-	if ! _stale_recovery_final_evidence_recheck "$issue_number" "$repo_slug" "$_latest_dispatch_ts"; then
-		printf 'STALE_RECHECK_BLOCKED: issue #%s in %s — evidence changed or active ready lease found\n' "$issue_number" "$repo_slug"
-		return 0
-	fi
-
 	if [[ -n "$_open_pr" ]]; then
 		# Open PR exists — counter resets; post a reset marker and allow normal recovery
 		gh_issue_comment "$issue_number" --repo "$repo_slug" \
@@ -478,7 +488,7 @@ Stale recovery tick reset — open PR #${_open_pr} detected (t2008)
 		# Threshold reached with explicit worker terminal evidence — escalate and
 		# bail out (no normal recovery). GH#22780: Do not suspend a fresh multi-runner
 		# dispatch solely because GitHub has been quiet for one stale window.
-		_stale_recovery_escalate "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_threshold" "$_prior_ticks"
+		_stale_recovery_escalate "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_threshold" "$_prior_ticks" "$_latest_dispatch_ts"
 		return 0
 	else
 		# Under threshold, or over threshold without terminal worker evidence —
@@ -493,7 +503,7 @@ Stale recovery tick ${_next_tick}/${_threshold} (t2008)
 	fi
 	# ── End stale-recovery escalation check ──────────────────────────────
 
-	_stale_recovery_apply "$issue_number" "$repo_slug" "$stale_assignees" "$reason"
+	_stale_recovery_apply "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_latest_dispatch_ts"
 	return 0
 }
 

--- a/.agents/scripts/dispatch-lease-claims.jq
+++ b/.agents/scripts/dispatch-lease-claims.jq
@@ -1,0 +1,21 @@
+[.[] |
+    (.body | capture("nonce=(?<nonce>[^ ]+) runner=(?<runner>[^ ]+) ts=(?<ts>[^ ]+)(?: max_age_s=[^ ]+)?(?: version=(?<version>[^ ]+))?")) as $fields |
+    ((.body | try capture("lease_token=(?<value>[^ ]+)").value catch "") // "") as $token |
+    ((.body | try capture("device=(?<value>[^ ]+)").value catch "") // "") as $device |
+    ((.body | try capture("expires_at=(?<value>[0-9]+)").value catch "0") // "0") as $expires |
+    {
+        id: .id, nonce: $fields.nonce, runner: $fields.runner, ts: $fields.ts,
+        version: ($fields.version // "unknown"),
+        lease_token: (if $token == "" then $fields.nonce else $token end),
+        device: (if $device == "" then "legacy" else $device end),
+        lease_expires_at: ($expires | tonumber? // 0),
+        created_at: .created_at,
+        created_epoch: (.created_at | fromdateiso8601? // 0)
+    }
+] |
+map(. + {age_seconds: ($now - .created_epoch)}) |
+map(. as $claim | ([ $comments[] | select((.body // "") | contains("lease_token=" + $claim.lease_token)) | select((.body // "") | contains("DISPATCH_LEASE")) ] | sort_by(.created_at) | last // null) as $transition |
+    if $transition then . + (($transition.body | capture("phase=(?<phase>[^ ]+).*expires_at=(?<expires>[0-9]+)")) as $t | {lease_phase:$t.phase, lease_expires_at:($t.expires|tonumber)}) else . + {lease_phase:"prelaunch"} end) |
+map(select(.age_seconds >= 0 and .age_seconds <= $max_age)) |
+map(select(.lease_phase != "terminal" and ((.lease_expires_at // 0) == 0 or .lease_expires_at >= $now))) |
+sort_by([.created_at, .nonce])

--- a/.agents/scripts/dispatch-lease-claims.jq
+++ b/.agents/scripts/dispatch-lease-claims.jq
@@ -14,8 +14,22 @@
     }
 ] |
 map(. + {age_seconds: ($now - .created_epoch)}) |
-map(. as $claim | ([ $comments[] | select((.body // "") | contains("lease_token=" + $claim.lease_token)) | select((.body // "") | contains("DISPATCH_LEASE")) ] | sort_by(.created_at) | last // null) as $transition |
-    if $transition then . + (($transition.body | capture("phase=(?<phase>[^ ]+).*expires_at=(?<expires>[0-9]+)")) as $t | {lease_phase:$t.phase, lease_expires_at:($t.expires|tonumber)}) else . + {lease_phase:"prelaunch"} end) |
+map(. as $claim |
+    ([ $comments[]
+       | select((.body // "") | contains("lease_token=" + $claim.lease_token))
+       | select((.body // "") | contains("DISPATCH_LEASE"))
+       | . + ((.body | capture("phase=(?<phase>[^ ]+).*expires_at=(?<expires>[0-9]+)")) as $t
+              | {transition_phase:$t.phase, transition_expires:($t.expires|tonumber), transition_epoch:(.created_at | fromdateiso8601? // 0)})
+     ] | sort_by(.created_at, .id)) as $transitions |
+    (reduce $transitions[] as $event
+      ({phase:"prelaunch", expires:$claim.lease_expires_at};
+       if .phase == "terminal" or .expires < $event.transition_epoch then .
+       elif $event.transition_phase == "ready" and .phase == "prelaunch" and $event.transition_expires >= $event.transition_epoch
+         then {phase:"ready", expires:$event.transition_expires}
+       elif $event.transition_phase == "terminal" and (.phase == "prelaunch" or .phase == "ready")
+         then {phase:"terminal", expires:0}
+       else . end)) as $state |
+    $claim + {lease_phase:$state.phase, lease_expires_at:$state.expires}) |
 map(select(.age_seconds >= 0 and .age_seconds <= $max_age)) |
 map(select(.lease_phase != "terminal" and ((.lease_expires_at // 0) == 0 or .lease_expires_at >= $now))) |
 sort_by([.created_at, .nonce])

--- a/.agents/scripts/dispatch-lease-claims.jq
+++ b/.agents/scripts/dispatch-lease-claims.jq
@@ -2,12 +2,15 @@
     (.body | capture("nonce=(?<nonce>[^ ]+) runner=(?<runner>[^ ]+) ts=(?<ts>[^ ]+)(?: max_age_s=[^ ]+)?(?: version=(?<version>[^ ]+))?")) as $fields |
     ((.body | try capture("lease_token=(?<value>[^ ]+)").value catch "") // "") as $token |
     ((.body | try capture("device=(?<value>[^ ]+)").value catch "") // "") as $device |
+    ((.body | try capture("session=(?<value>[^ ]+)").value catch "") // "") as $session |
     ((.body | try capture("expires_at=(?<value>[0-9]+)").value catch "0") // "0") as $expires |
     {
         id: .id, nonce: $fields.nonce, runner: $fields.runner, ts: $fields.ts,
         version: ($fields.version // "unknown"),
         lease_token: (if $token == "" then $fields.nonce else $token end),
         device: (if $device == "" then "legacy" else $device end),
+        session: $session,
+        claim_author: (.author // .user.login // ""),
         lease_expires_at: ($expires | tonumber? // 0),
         created_at: .created_at,
         created_epoch: (.created_at | fromdateiso8601? // 0)
@@ -18,8 +21,11 @@ map(. as $claim |
     ([ $comments[]
        | select((.body // "") | contains("lease_token=" + $claim.lease_token))
        | select((.body // "") | contains("DISPATCH_LEASE"))
-       | . + ((.body | capture("phase=(?<phase>[^ ]+).*expires_at=(?<expires>[0-9]+)")) as $t
-              | {transition_phase:$t.phase, transition_expires:($t.expires|tonumber), transition_epoch:(.created_at | fromdateiso8601? // 0)})
+       | select(($claim.claim_author != "") and ((.author // .user.login // "") == $claim.claim_author))
+       | . + ((.body | capture("phase=(?<phase>[^ ]+) lease_token=[^ ]+ device=(?<device>[^ ]+) session=(?<session>[^ ]+) expires_at=(?<expires>[0-9]+)")) as $t
+              | {transition_phase:$t.phase, transition_device:$t.device, transition_session:$t.session,
+                 transition_expires:($t.expires|tonumber), transition_epoch:(.created_at | fromdateiso8601? // 0)})
+       | select(.transition_device == $claim.device and .transition_session == $claim.session)
      ] | sort_by(.created_at, .id)) as $transitions |
     (reduce $transitions[] as $event
       ({phase:"prelaunch", expires:$claim.lease_expires_at};
@@ -30,6 +36,6 @@ map(. as $claim |
          then {phase:"terminal", expires:0}
        else . end)) as $state |
     $claim + {lease_phase:$state.phase, lease_expires_at:$state.expires}) |
-map(select(.age_seconds >= 0 and .age_seconds <= $max_age)) |
+map(select(.age_seconds >= 0 and (.age_seconds <= $max_age or (.lease_phase == "ready" and .lease_expires_at >= $now)))) |
 map(select(.lease_phase != "terminal" and ((.lease_expires_at // 0) == 0 or .lease_expires_at >= $now))) |
 sort_by([.created_at, .nonce])

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -315,6 +315,16 @@ _iso_to_epoch() {
 	return 0
 }
 
+_lease_registration_exists() {
+	local session_key="$1"
+	local lease_token="$2"
+	[[ -n "$lease_token" && -s "$LEDGER_FILE" ]] || return 1
+	local existing="" existing_token=""
+	existing=$(_lease_latest_entry "$session_key") || return 1
+	existing_token=$(printf '%s' "$existing" | jq -r '.lease_token // ""' 2>/dev/null) || return 1
+	[[ -n "$existing" && "$existing_token" == "$lease_token" ]]
+}
+
 #######################################
 # Register a new dispatch in the ledger
 #
@@ -400,7 +410,7 @@ cmd_register() {
 		echo "Error: register aborted — could not acquire lock" >&2
 		return 1
 	fi
-
+	if _lease_registration_exists "$session_key" "$lease_token"; then _release_lock; return 0; fi
 	local now
 	now=$(_now_utc)
 

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -318,11 +318,17 @@ _iso_to_epoch() {
 _lease_registration_exists() {
 	local session_key="$1"
 	local lease_token="$2"
-	[[ -n "$lease_token" && -s "$LEDGER_FILE" ]] || return 1
-	local existing="" existing_token=""
+	[[ -s "$LEDGER_FILE" ]] || return 1
+	local existing="" existing_token="" existing_status=""
 	existing=$(_lease_latest_entry "$session_key") || return 1
 	existing_token=$(printf '%s' "$existing" | jq -r '.lease_token // ""' 2>/dev/null) || return 1
-	[[ -n "$existing" && "$existing_token" == "$lease_token" ]]
+	existing_status=$(printf '%s' "$existing" | jq -r '.status // ""' 2>/dev/null) || return 1
+	if [[ -n "$lease_token" ]]; then
+		[[ -n "$existing" && "$existing_token" == "$lease_token" ]]
+		return $?
+	fi
+	[[ -n "$existing" && -z "$existing_token" && "$existing_status" == "$LEDGER_STATUS_ACTIVE" ]]
+	return $?
 }
 
 #######################################

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -56,12 +56,18 @@ LEDGER_LOCK="${LEDGER_DIR}/dispatch-ledger.lock"
 DEFAULT_TTL="${AIDEVOPS_DISPATCH_LEDGER_TTL:-3600}" # 60 minutes
 PRELAUNCH_TTL="${AIDEVOPS_DISPATCH_PRELAUNCH_LEASE_TTL:-120}"
 READY_TTL="${AIDEVOPS_DISPATCH_READY_LEASE_TTL:-7200}"
+LEDGER_STATUS_ACTIVE="in-flight"
+LEDGER_STATUS_FAILED="failed"
 
 _lease_device_id() {
 	local id_file="${AIDEVOPS_DEVICE_ID_FILE:-${HOME}/.aidevops/state/device-id}"
 	local id="${AIDEVOPS_DEVICE_ID:-}"
+	if [[ -n "$id" && ! "$id" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$ ]]; then
+		id=""
+	fi
 	if [[ -z "$id" && -r "$id_file" ]]; then
-		id=$(tr -cd 'a-zA-Z0-9._-' <"$id_file" 2>/dev/null || true)
+		id=$(tr -d '[:space:]' <"$id_file" 2>/dev/null || true)
+		[[ "$id" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$ ]] || id=""
 	fi
 	if [[ -z "$id" ]]; then
 		id="device-$(_now_epoch)-$$-${RANDOM:-0}"
@@ -69,6 +75,24 @@ _lease_device_id() {
 		(umask 077; printf '%s\n' "$id" >"$id_file") 2>/dev/null || true
 	fi
 	printf '%s' "$id"
+	return 0
+}
+
+_lease_latest_entry() {
+	local session_key="$1"
+	jq -sc --arg sk "$session_key" '[.[] | select(.session_key == $sk)] | last // empty' "$LEDGER_FILE" 2>/dev/null
+	return $?
+}
+
+_lease_entry_is_active() {
+	local entry="$1"
+	local now_epoch="" expires_at="" phase="" status=""
+	now_epoch=$(_now_epoch)
+	expires_at=$(printf '%s' "$entry" | jq -r '.lease_expires_at // 0') || return 1
+	phase=$(printf '%s' "$entry" | jq -r '.lease_phase // ""') || return 1
+	status=$(printf '%s' "$entry" | jq -r '.status // ""') || return 1
+	[[ "$status" == "$LEDGER_STATUS_ACTIVE" && "$phase" != "terminal" ]] || return 1
+	[[ "$expires_at" =~ ^[0-9]+$ && "$expires_at" -ge "$now_epoch" ]] || return 1
 	return 0
 }
 
@@ -398,9 +422,9 @@ cmd_register() {
 		--arg token "$lease_token" \
 		--arg device "$runner_device" \
 		--argjson expires "$lease_expires_at" \
-		'{session_key: $sk, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: "in-flight", updated_at: $ts, tier: $tier, model: $model, worktree_path: $worktree, lease_token:$token, runner_device:$device, lease_phase:"prelaunch", lease_expires_at:$expires}' \
+		--arg status "$LEDGER_STATUS_ACTIVE" \
+		'{session_key: $sk, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: $status, updated_at: $ts, tier: $tier, model: $model, worktree_path: $worktree, lease_token:$token, runner_device:$device, lease_phase:"prelaunch", lease_expires_at:$expires}' \
 		>>"$LEDGER_FILE"
-
 	_append_tier_telemetry "$issue_number" "$repo_slug" "$dispatch_tier" "$dispatch_model" "$now"
 
 	_release_lock
@@ -418,7 +442,7 @@ cmd_ready() {
 		esac
 	done
 	[[ -n "$session_key" && -n "$lease_token" ]] || { echo "Error: ready requires --session-key and --lease-token" >&2; return 1; }
-	_lease_append_transition "$session_key" "$lease_token" "ready" "in-flight" "$lease_ttl"
+	_lease_append_transition "$session_key" "$lease_token" "ready" "$LEDGER_STATUS_ACTIVE" "$lease_ttl"
 	return $?
 }
 
@@ -431,8 +455,22 @@ _lease_append_transition() {
 	_ensure_ledger
 	_acquire_lock || return 1
 	local current=""
-	current=$(jq -sc --arg sk "$session_key" '[.[] | select(.session_key == $sk)] | last // empty' "$LEDGER_FILE" 2>/dev/null) || current=""
+	current=$(_lease_latest_entry "$session_key") || current=""
 	if [[ -z "$current" || "$(printf '%s' "$current" | jq -r '.lease_token // ""')" != "$lease_token" ]]; then
+		_release_lock
+		return 1
+	fi
+	local current_phase=""
+	current_phase=$(printf '%s' "$current" | jq -r '.lease_phase // ""') || current_phase=""
+	if ! _lease_entry_is_active "$current"; then
+		_release_lock
+		return 1
+	fi
+	if [[ "$lease_phase" == "ready" && "$current_phase" != "prelaunch" ]]; then
+		_release_lock
+		return 1
+	fi
+	if [[ "$lease_phase" == "terminal" && "$current_phase" != "prelaunch" && "$current_phase" != "ready" ]]; then
 		_release_lock
 		return 1
 	fi
@@ -547,9 +585,13 @@ cmd_check() {
 	fi
 
 	local match
-	match=$(jq -sc --arg sk "$session_key" '[.[] | select(.session_key == $sk)] | last | select(.status == "in-flight")' "$LEDGER_FILE" 2>/dev/null) || match=""
+	match=$(_lease_latest_entry "$session_key") || match=""
 
 	if [[ -z "$match" ]]; then
+		return 1
+	fi
+	[[ "$(printf '%s' "$match" | jq -r '.status // ""')" == "$LEDGER_STATUS_ACTIVE" ]] || return 1
+	if [[ -n "$(printf '%s' "$match" | jq -r '.lease_token // ""')" ]] && ! _lease_entry_is_active "$match"; then
 		return 1
 	fi
 
@@ -627,16 +669,19 @@ cmd_check_issue() {
 
 	local match
 	if [[ -n "$repo_slug" ]]; then
-		match=$(jq -sc --arg inum "$issue_number" --arg slug "$repo_slug" \
-			'[.[] | select(.issue_number == $inum and .repo_slug == $slug)] | last | select(.status == "in-flight")' \
+		match=$(jq -sc --arg inum "$issue_number" --arg slug "$repo_slug" --arg active "$LEDGER_STATUS_ACTIVE" \
+			'[.[] | select(.issue_number == $inum and .repo_slug == $slug)] | last | select(.status == $active)' \
 			"$LEDGER_FILE" 2>/dev/null) || match=""
 	else
-		match=$(jq -sc --arg inum "$issue_number" \
-			'[.[] | select(.issue_number == $inum)] | last | select(.status == "in-flight")' \
+		match=$(jq -sc --arg inum "$issue_number" --arg active "$LEDGER_STATUS_ACTIVE" \
+			'[.[] | select(.issue_number == $inum)] | last | select(.status == $active)' \
 			"$LEDGER_FILE" 2>/dev/null) || match=""
 	fi
 
 	if [[ -z "$match" ]]; then
+		return 1
+	fi
+	if [[ -n "$(printf '%s' "$match" | jq -r '.lease_token // ""')" ]] && ! _lease_entry_is_active "$match"; then
 		return 1
 	fi
 
@@ -732,7 +777,7 @@ cmd_fail() {
 		return 1
 	fi
 
-	_update_status "$session_key" "failed" "$lease_token"
+	_update_status "$session_key" "$LEDGER_STATUS_FAILED" "$lease_token"
 	return 0
 }
 
@@ -830,7 +875,7 @@ cmd_tier_report() {
 	total=$(wc -l <"$telemetry_file" | tr -d ' ')
 	success=$(grep -c '"outcome":"success"' "$telemetry_file" 2>/dev/null) || success=0
 	escalated=$(grep -c '"outcome":"escalated"' "$telemetry_file" 2>/dev/null) || escalated=0
-	failed=$(grep -c '"outcome":"failed"' "$telemetry_file" 2>/dev/null) || failed=0
+	failed=$(grep -c "\"outcome\":\"${LEDGER_STATUS_FAILED}\"" "$telemetry_file" 2>/dev/null) || failed=0
 
 	echo "=== Tier Dispatch Telemetry ==="
 	echo "Total dispatches: $total"
@@ -891,8 +936,8 @@ _update_status() {
 	# Only transition entries that are still "in-flight" — terminal statuses
 	# ("completed", "failed") are immutable. A late fail from dead-PID cleanup
 	# must not overwrite a genuinely completed dispatch.
-	jq -c --arg sk "$session_key" --arg st "$new_status" --arg ts "$now" \
-		'if .session_key == $sk and .status == "in-flight"
+	jq -c --arg sk "$session_key" --arg st "$new_status" --arg ts "$now" --arg active "$LEDGER_STATUS_ACTIVE" \
+		'if .session_key == $sk and .status == $active
 			then .status = $st | .updated_at = $ts
 			else .
 		end' \
@@ -968,7 +1013,7 @@ _cmd_expire_collect_indices() {
 
 	while IFS=$'\t' read -r idx status dispatched_at entry_pid; do
 		[[ -z "$idx" ]] && continue
-		[[ "$status" != "in-flight" ]] && continue
+		[[ "$status" != "$LEDGER_STATUS_ACTIVE" ]] && continue
 
 		should_expire=0
 		if [[ -n "$dispatched_at" ]]; then
@@ -1011,11 +1056,11 @@ _cmd_expire_rewrite_failed() {
 	#      `$exp | index(.key)` evaluates `.key` against $exp (an array)
 	#      and jq raises "Cannot index array with string 'key'", which
 	#      `2>/dev/null` would swallow into the cp fallback path.
-	jq -nc --arg ts "$now_ts" --argjson exp "[${indices_csv}]" '
+	jq -nc --arg ts "$now_ts" --arg failed "$LEDGER_STATUS_FAILED" --argjson exp "[${indices_csv}]" '
 		[inputs] | to_entries[]
 		| .key as $k
 		| if (($exp | index($k)) != null)
-		  then .value | .status = "failed" | .updated_at = $ts
+		  then .value | .status = $failed | .updated_at = $ts
 		  else .value
 		  end
 	' "$LEDGER_FILE" >"$tmp_file" 2>/dev/null
@@ -1112,7 +1157,7 @@ cmd_count() {
 	# pid. On a 1200-entry synthetic ledger that made `count` take ~2.4s.
 	# A single jq pass emits just the PIDs; bash keeps the kill -0 liveness
 	# checks because jq cannot query process state.
-	inflight_pids=$(jq -r 'select(.status == "in-flight") | (.pid // 0)' "$LEDGER_FILE" 2>/dev/null) || inflight_pids=""
+	inflight_pids=$(jq -r --arg active "$LEDGER_STATUS_ACTIVE" 'select(.status == $active) | (.pid // 0)' "$LEDGER_FILE" 2>/dev/null) || inflight_pids=""
 
 	if [[ -z "$inflight_pids" ]]; then
 		printf '%s\n' "0"
@@ -1154,11 +1199,11 @@ cmd_status() {
 	# GH#22289: compute all status counts in one jq process instead of three
 	# jq+wc pipelines. The win is modest compared with cmd_count, but this is
 	# still a hot diagnostic path and preserves the single-pass ledger pattern.
-	status_counts=$(jq -nr '
+	status_counts=$(jq -nr --arg active "$LEDGER_STATUS_ACTIVE" '
 		[inputs.status // ""] as $statuses
 		| [
 			($statuses | length),
-			($statuses | map(select(. == "in-flight")) | length),
+			($statuses | map(select(. == $active)) | length),
 			($statuses | map(select(. == "completed")) | length),
 			($statuses | map(select(. == "failed")) | length)
 		]
@@ -1179,7 +1224,7 @@ cmd_status() {
 
 	if [[ "$inflight" -gt 0 ]]; then
 		echo "In-flight entries:"
-		jq -r 'select(.status == "in-flight") | "  \(.session_key) | issue=\(.issue_number) | repo=\(.repo_slug) | pid=\(.pid) | since=\(.dispatched_at)"' "$LEDGER_FILE" 2>/dev/null || true
+		jq -r --arg active "$LEDGER_STATUS_ACTIVE" 'select(.status == $active) | "  \(.session_key) | issue=\(.issue_number) | repo=\(.repo_slug) | pid=\(.pid) | since=\(.dispatched_at)"' "$LEDGER_FILE" 2>/dev/null || true
 	fi
 
 	return 0
@@ -1222,9 +1267,9 @@ cmd_prune() {
 	# fromdateiso8601 in jq parses RFC 3339 / ISO 8601 with the 'Z' suffix
 	# directly; the try/catch falls back to "$now" so unparseable timestamps
 	# keep the entry rather than dropping it.
-	if ! jq -c --argjson now "$now_epoch" --argjson threshold "$prune_threshold" '
+	if ! jq -c --argjson now "$now_epoch" --argjson threshold "$prune_threshold" --arg active "$LEDGER_STATUS_ACTIVE" '
 		select(
-			(.status == "in-flight")
+			(.status == $active)
 			or
 			(((.updated_at // "") | length) == 0)
 			or

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -54,6 +54,42 @@ LEDGER_DIR="${AIDEVOPS_DISPATCH_LEDGER_DIR:-${HOME}/.aidevops/.agent-workspace/t
 LEDGER_FILE="${LEDGER_DIR}/dispatch-ledger.jsonl"
 LEDGER_LOCK="${LEDGER_DIR}/dispatch-ledger.lock"
 DEFAULT_TTL="${AIDEVOPS_DISPATCH_LEDGER_TTL:-3600}" # 60 minutes
+PRELAUNCH_TTL="${AIDEVOPS_DISPATCH_PRELAUNCH_LEASE_TTL:-120}"
+READY_TTL="${AIDEVOPS_DISPATCH_READY_LEASE_TTL:-7200}"
+
+_lease_device_id() {
+	local id_file="${AIDEVOPS_DEVICE_ID_FILE:-${HOME}/.aidevops/state/device-id}"
+	local id="${AIDEVOPS_DEVICE_ID:-}"
+	if [[ -z "$id" && -r "$id_file" ]]; then
+		id=$(tr -cd 'a-zA-Z0-9._-' <"$id_file" 2>/dev/null || true)
+	fi
+	if [[ -z "$id" ]]; then
+		id="device-$(_now_epoch)-$$-${RANDOM:-0}"
+		mkdir -p "${id_file%/*}" 2>/dev/null || true
+		(umask 077; printf '%s\n' "$id" >"$id_file") 2>/dev/null || true
+	fi
+	printf '%s' "$id"
+	return 0
+}
+
+_lease_expiry() {
+	local ttl="$1"
+	local now_epoch=""
+	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=120
+	now_epoch=$(_now_epoch)
+	printf '%s' "$((now_epoch + ttl))"
+	return 0
+}
+
+_append_tier_telemetry() {
+	local issue_number="$1" repo_slug="$2" dispatch_tier="$3" dispatch_model="$4" now="$5"
+	local telemetry_file="${LEDGER_DIR}/tier-telemetry.jsonl"
+	jq -cn --arg inum "$issue_number" --arg slug "$repo_slug" \
+		--arg tier "$dispatch_tier" --arg model "$dispatch_model" --arg ts "$now" \
+		'{issue: $inum, repo: $slug, tier: $tier, model: $model, dispatched_at: $ts, outcome: "pending"}' \
+		>>"$telemetry_file" 2>/dev/null || true
+	return 0
+}
 
 #######################################
 # Ensure ledger directory and file exist
@@ -277,6 +313,9 @@ cmd_register() {
 	local dispatch_tier=""
 	local dispatch_model=""
 	local worktree_path=""
+	local lease_token=""
+	local runner_device=""
+	local lease_ttl="$PRELAUNCH_TTL"
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -308,6 +347,18 @@ cmd_register() {
 			dispatch_model="${2:-}"
 			shift 2
 			;;
+		--lease-token)
+			lease_token="${2:-}"
+			shift 2
+			;;
+		--device-id)
+			runner_device="${2:-}"
+			shift 2
+			;;
+		--lease-ttl)
+			lease_ttl="${2:-}"
+			shift 2
+			;;
 		*)
 			echo "Error: Unknown option for register: $1" >&2
 			return 1
@@ -329,13 +380,10 @@ cmd_register() {
 	local now
 	now=$(_now_utc)
 
-	# Remove any existing entry for this session_key (idempotent re-register)
-	if [[ -s "$LEDGER_FILE" ]]; then
-		local tmp_file
-		tmp_file=$(mktemp "${LEDGER_DIR}/dispatch-ledger.XXXXXX")
-		jq -c --arg sk "$session_key" 'select(.session_key != $sk)' "$LEDGER_FILE" >"$tmp_file" 2>/dev/null || true
-		mv "$tmp_file" "$LEDGER_FILE"
-	fi
+	[[ -n "$runner_device" ]] || runner_device=$(_lease_device_id)
+	[[ "$lease_ttl" =~ ^[0-9]+$ ]] || lease_ttl="$PRELAUNCH_TTL"
+	local lease_expires_at=""
+	lease_expires_at=$(_lease_expiry "$lease_ttl")
 
 	# Append new entry — use jq for safe JSON construction (handles special chars)
 	jq -cn \
@@ -347,20 +395,52 @@ cmd_register() {
 		--arg tier "$dispatch_tier" \
 		--arg model "$dispatch_model" \
 		--arg worktree "$worktree_path" \
-		'{session_key: $sk, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: "in-flight", updated_at: $ts, tier: $tier, model: $model, worktree_path: $worktree}' \
+		--arg token "$lease_token" \
+		--arg device "$runner_device" \
+		--argjson expires "$lease_expires_at" \
+		'{session_key: $sk, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: "in-flight", updated_at: $ts, tier: $tier, model: $model, worktree_path: $worktree, lease_token:$token, runner_device:$device, lease_phase:"prelaunch", lease_expires_at:$expires}' \
 		>>"$LEDGER_FILE"
 
-	# Append to tier telemetry log (append-only, never pruned)
-	local telemetry_file="${LEDGER_DIR}/tier-telemetry.jsonl"
-	jq -cn \
-		--arg inum "$issue_number" \
-		--arg slug "$repo_slug" \
-		--arg tier "$dispatch_tier" \
-		--arg model "$dispatch_model" \
-		--arg ts "$now" \
-		'{issue: $inum, repo: $slug, tier: $tier, model: $model, dispatched_at: $ts, outcome: "pending"}' \
-		>>"$telemetry_file" 2>/dev/null || true
+	_append_tier_telemetry "$issue_number" "$repo_slug" "$dispatch_tier" "$dispatch_model" "$now"
 
+	_release_lock
+	return 0
+}
+
+cmd_ready() {
+	local session_key="" lease_token="" lease_ttl="$READY_TTL"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--session-key) session_key="${2:-}"; shift 2 ;;
+		--lease-token) lease_token="${2:-}"; shift 2 ;;
+		--lease-ttl) lease_ttl="${2:-}"; shift 2 ;;
+		*) echo "Error: Unknown option for ready: $1" >&2; return 1 ;;
+		esac
+	done
+	[[ -n "$session_key" && -n "$lease_token" ]] || { echo "Error: ready requires --session-key and --lease-token" >&2; return 1; }
+	_lease_append_transition "$session_key" "$lease_token" "ready" "in-flight" "$lease_ttl"
+	return $?
+}
+
+_lease_append_transition() {
+	local session_key="$1"
+	local lease_token="$2"
+	local lease_phase="$3"
+	local status="$4"
+	local lease_ttl="$5"
+	_ensure_ledger
+	_acquire_lock || return 1
+	local current=""
+	current=$(jq -sc --arg sk "$session_key" '[.[] | select(.session_key == $sk)] | last // empty' "$LEDGER_FILE" 2>/dev/null) || current=""
+	if [[ -z "$current" || "$(printf '%s' "$current" | jq -r '.lease_token // ""')" != "$lease_token" ]]; then
+		_release_lock
+		return 1
+	fi
+	local now="" expires=""
+	now=$(_now_utc)
+	expires=$(_lease_expiry "$lease_ttl")
+	printf '%s' "$current" | jq -c --arg phase "$lease_phase" --arg status "$status" --arg ts "$now" --argjson expires "$expires" \
+		'.lease_phase=$phase | .status=$status | .updated_at=$ts | .lease_expires_at=$expires' >>"$LEDGER_FILE"
 	_release_lock
 	return 0
 }
@@ -467,17 +547,18 @@ cmd_check() {
 	fi
 
 	local match
-	match=$(jq -c --arg sk "$session_key" 'select(.session_key == $sk and .status == "in-flight")' "$LEDGER_FILE" 2>/dev/null | head -1) || match=""
+	match=$(jq -sc --arg sk "$session_key" '[.[] | select(.session_key == $sk)] | last | select(.status == "in-flight")' "$LEDGER_FILE" 2>/dev/null) || match=""
 
 	if [[ -z "$match" ]]; then
 		return 1
 	fi
 
-	# Verify PID is still alive (stale entry detection)
+	# PID exit is only a local hint. Lease-aware entries remain protected until
+	# explicit terminal evidence or expiry; legacy entries retain old behaviour.
 	local entry_pid
 	entry_pid=$(printf '%s' "$match" | jq -r '.pid // 0') || entry_pid=0
 	if [[ "$entry_pid" =~ ^[0-9]+$ ]] && [[ "$entry_pid" -gt 0 ]]; then
-		if ! kill -0 "$entry_pid" 2>/dev/null; then
+		if ! kill -0 "$entry_pid" 2>/dev/null && [[ "$(printf '%s' "$match" | jq -r '.lease_token // ""')" == "" ]]; then
 			# PID is dead — mark as failed and return "safe to dispatch"
 			cmd_fail --session-key "$session_key" 2>/dev/null || true
 			return 1
@@ -546,13 +627,13 @@ cmd_check_issue() {
 
 	local match
 	if [[ -n "$repo_slug" ]]; then
-		match=$(jq -c --arg inum "$issue_number" --arg slug "$repo_slug" \
-			'select(.issue_number == $inum and .repo_slug == $slug and .status == "in-flight")' \
-			"$LEDGER_FILE" 2>/dev/null | head -1) || match=""
+		match=$(jq -sc --arg inum "$issue_number" --arg slug "$repo_slug" \
+			'[.[] | select(.issue_number == $inum and .repo_slug == $slug)] | last | select(.status == "in-flight")' \
+			"$LEDGER_FILE" 2>/dev/null) || match=""
 	else
-		match=$(jq -c --arg inum "$issue_number" \
-			'select(.issue_number == $inum and .status == "in-flight")' \
-			"$LEDGER_FILE" 2>/dev/null | head -1) || match=""
+		match=$(jq -sc --arg inum "$issue_number" \
+			'[.[] | select(.issue_number == $inum)] | last | select(.status == "in-flight")' \
+			"$LEDGER_FILE" 2>/dev/null) || match=""
 	fi
 
 	if [[ -z "$match" ]]; then
@@ -563,7 +644,7 @@ cmd_check_issue() {
 	local entry_pid
 	entry_pid=$(printf '%s' "$match" | jq -r '.pid // 0') || entry_pid=0
 	if [[ "$entry_pid" =~ ^[0-9]+$ ]] && [[ "$entry_pid" -gt 0 ]]; then
-		if ! kill -0 "$entry_pid" 2>/dev/null; then
+		if ! kill -0 "$entry_pid" 2>/dev/null && [[ "$(printf '%s' "$match" | jq -r '.lease_token // ""')" == "" ]]; then
 			local sk
 			sk=$(printf '%s' "$match" | jq -r '.session_key // ""') || sk=""
 			if [[ -n "$sk" ]]; then
@@ -588,11 +669,16 @@ cmd_check_issue() {
 #######################################
 cmd_complete() {
 	local session_key=""
+	local lease_token=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--session-key)
 			session_key="${2:-}"
+			shift 2
+			;;
+		--lease-token)
+			lease_token="${2:-}"
 			shift 2
 			;;
 		*)
@@ -607,7 +693,7 @@ cmd_complete() {
 		return 1
 	fi
 
-	_update_status "$session_key" "completed"
+	_update_status "$session_key" "completed" "$lease_token"
 	return 0
 }
 
@@ -622,11 +708,16 @@ cmd_complete() {
 #######################################
 cmd_fail() {
 	local session_key=""
+	local lease_token=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--session-key)
 			session_key="${2:-}"
+			shift 2
+			;;
+		--lease-token)
+			lease_token="${2:-}"
 			shift 2
 			;;
 		*)
@@ -641,7 +732,7 @@ cmd_fail() {
 		return 1
 	fi
 
-	_update_status "$session_key" "failed"
+	_update_status "$session_key" "failed" "$lease_token"
 	return 0
 }
 
@@ -775,6 +866,11 @@ cmd_tier_report() {
 _update_status() {
 	local session_key="$1"
 	local new_status="$2"
+	local lease_token="${3:-}"
+	if [[ -n "$lease_token" ]]; then
+		_lease_append_transition "$session_key" "$lease_token" "terminal" "$new_status" "0"
+		return $?
+	fi
 
 	_ensure_ledger
 	if ! _acquire_lock; then
@@ -1228,6 +1324,9 @@ main() {
 	case "$command" in
 	register)
 		cmd_register "$@"
+		;;
+	ready)
+		cmd_ready "$@"
 		;;
 	check)
 		cmd_check "$@"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1349,6 +1349,9 @@ _register_dispatch_ledger() {
 	fi
 
 	local ledger_args=(register --session-key "$ledger_session_key" --pid "$$")
+	if [[ -n "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" ]]; then
+		ledger_args+=(--lease-token "$AIDEVOPS_DISPATCH_LEASE_TOKEN" --device-id "${AIDEVOPS_DISPATCH_LEASE_DEVICE:-}")
+	fi
 	[[ -n "$ledger_issue" ]] && ledger_args+=(--issue "$ledger_issue")
 	[[ -n "$ledger_repo" ]] && ledger_args+=(--repo "$ledger_repo")
 	[[ -n "$ledger_work_dir" ]] && ledger_args+=(--worktree "$ledger_work_dir")
@@ -1365,7 +1368,9 @@ _update_dispatch_ledger() {
 
 	[[ -x "$DISPATCH_LEDGER_HELPER" ]] || return 0
 
-	"$DISPATCH_LEDGER_HELPER" "$ledger_status" --session-key "$ledger_session_key" 2>/dev/null || true
+	local -a ledger_args=("$ledger_status" --session-key "$ledger_session_key")
+	[[ -n "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" ]] && ledger_args+=(--lease-token "$AIDEVOPS_DISPATCH_LEASE_TOKEN")
+	"$DISPATCH_LEDGER_HELPER" "${ledger_args[@]}" 2>/dev/null || true
 	return 0
 }
 

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1419,6 +1419,13 @@ _cmd_run_prepare() {
 	# can detect workers that haven't created PRs yet. The ledger bridges
 	# the 10-15 minute gap between dispatch and PR creation.
 	_register_dispatch_ledger "$session_key" "$work_dir"
+	if [[ -n "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" && -n "${WORKER_ISSUE_NUMBER:-}" && -n "${DISPATCH_REPO_SLUG:-}" ]]; then
+		"${SCRIPT_DIR}/dispatch-ledger-helper.sh" ready --session-key "$session_key" \
+			--lease-token "$AIDEVOPS_DISPATCH_LEASE_TOKEN" 2>/dev/null || return 1
+		"${SCRIPT_DIR}/dispatch-claim-helper.sh" transition ready "$WORKER_ISSUE_NUMBER" \
+			"$DISPATCH_REPO_SLUG" "$AIDEVOPS_DISPATCH_LEASE_TOKEN" "$session_key" \
+			"${AIDEVOPS_DISPATCH_READY_LEASE_TTL:-7200}" 2>/dev/null || return 1
+	fi
 	return 0
 }
 

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -320,6 +320,8 @@ _dedup_layer7_claim_lock() {
 	# so the dispatch_with_dedup caller always sees a fresh value. Do NOT
 	# declare local here — see function header.
 	_claim_comment_id=""
+	_claim_lease_token=""
+	_claim_lease_device=""
 	if [[ -x "$dedup_helper" ]] && [[ "$issue_number" =~ ^[0-9]+$ ]]; then
 		# GH#17590: Pre-check for existing claims BEFORE posting our own.
 		# Without this, two runners both post claims within seconds, then
@@ -352,6 +354,8 @@ _dedup_layer7_claim_lock() {
 		fi
 		# Extract claim comment_id for post-dispatch cleanup (GH#15317)
 		_claim_comment_id=$(printf '%s' "$claim_output" | sed -n 's/.*comment_id=\([0-9]*\).*/\1/p')
+		_claim_lease_token=$(printf '%s' "$claim_output" | sed -n 's/.*lease_token=\([^ ]*\).*/\1/p')
+		_claim_lease_device=$(printf '%s' "$claim_output" | sed -n 's/.*device=\([^ ]*\).*/\1/p')
 		# claim_exit 0 = won, proceed to dispatch
 	fi
 	return 1

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1515,6 +1515,8 @@ _dlw_nohup_launch() {
 		WORKER_ISSUE_NUMBER="$issue_number"
 		WORKER_REPO_SLUG="$repo_slug"
 		WORKER_GITHUB_LOGIN="$self_login"
+		AIDEVOPS_DISPATCH_LEASE_TOKEN="${_claim_lease_token:-}"
+		AIDEVOPS_DISPATCH_LEASE_DEVICE="${_claim_lease_device:-}"
 		AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1
 	)
 	if _dlw_min_worker_floor_active; then
@@ -1606,7 +1608,8 @@ _dlw_post_launch_hooks() {
 		"$ledger_helper" register --session-key "$session_key" \
 			--issue "$issue_number" --repo "$repo_slug" \
 			--pid "$worker_pid" --tier "$dispatch_tier" \
-			--model "$selected_model" 2>/dev/null || true
+			--model "$selected_model" --lease-token "${_claim_lease_token:-}" \
+			--device-id "${_claim_lease_device:-}" 2>/dev/null || true
 	fi
 
 	local dispatch_comment_body

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -6,59 +6,191 @@ set -euo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="${TEST_DIR}/.."
+CLAIM="${SCRIPTS_DIR}/dispatch-claim-helper.sh"
 LEDGER="${SCRIPTS_DIR}/dispatch-ledger-helper.sh"
+SCRIPT_DIR="$SCRIPTS_DIR"
+# shellcheck source=../dispatch-dedup-stale.sh
+source "${SCRIPTS_DIR}/dispatch-dedup-stale.sh"
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
-export AIDEVOPS_DISPATCH_LEDGER_DIR="${TMP_DIR}/ledger"
-export AIDEVOPS_DEVICE_ID="device-fixture-a"
-mkdir -p "$AIDEVOPS_DISPATCH_LEDGER_DIR"
+export AIDEVOPS_TEST_MODE=1
+export AIDEVOPS_REPO_STATE_GUARD_TEST_BYPASS=1
 
 fail() { printf 'FAIL %s\n' "$1" >&2; return 1; }
 pass() { printf 'PASS %s\n' "$1"; return 0; }
 
-"$LEDGER" register --session-key issue-27165 --issue 27165 --repo owner/repo \
-	--pid 99999999 --lease-token token-a --device-id device-fixture-a --lease-ttl 60
-[[ $(jq -r 'select(.session_key=="issue-27165") | .lease_phase' "$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl") == prelaunch ]] \
-	|| fail "prelaunch lease is persisted"
-pass "prelaunch lease is persisted"
-
-if "$LEDGER" ready --session-key issue-27165 --lease-token wrong-token >/dev/null 2>&1; then
-	fail "wrong token cannot transition lease"
+create_mock_gh() {
+	local root="$1"
+	mkdir -p "$root/bin"
+	cat >"$root/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+state="${MOCK_GH_STATE:?}"
+comments="$state/comments.jsonl"
+mkdir -p "$state"
+touch "$comments"
+if [[ "${1:-}" == api && "${2:-}" == user ]]; then printf 'shared-login\n'; exit 0; fi
+if [[ "${1:-}" == issue && "${2:-}" == comment ]]; then exit 0; fi
+[[ "${1:-}" == api ]] || exit 1
+endpoint="${2:-}"
+shift 2
+if [[ "$endpoint" == repos/*/issues/[0-9]* && "$endpoint" != */comments* ]]; then
+	printf '{"assignees":[]}\n'
+	exit 0
 fi
-pass "wrong token cannot transition lease"
-
-"$LEDGER" ready --session-key issue-27165 --lease-token token-a --lease-ttl 60
-latest=$(jq -sc '[.[] | select(.session_key=="issue-27165")] | last' "$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl")
-[[ $(printf '%s' "$latest" | jq -r '.lease_phase') == ready ]] || fail "token-qualified ready transition"
-[[ $(printf '%s' "$latest" | jq -r '.runner_device') == device-fixture-a ]] || fail "device identity survives transition"
-pass "token-qualified ready transition preserves device identity"
-
-# A dead local PID must not imply remote completion for a lease-aware record.
-"$LEDGER" check --session-key issue-27165 >/dev/null || fail "ready lease survives local PID exit"
-pass "ready lease survives local PID exit"
-
-"$LEDGER" complete --session-key issue-27165 --lease-token token-a
-latest=$(jq -sc '[.[] | select(.session_key=="issue-27165")] | last' "$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl")
-[[ $(printf '%s' "$latest" | jq -r '.lease_phase + ":" + .status') == terminal:completed ]] \
-	|| fail "terminal transition is append-only"
-[[ $(wc -l <"$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl" | tr -d ' ') -eq 3 ]] \
-	|| fail "lease history contains prelaunch ready terminal records"
-pass "terminal transition appends immutable evidence"
-
-# Backward compatibility: legacy records remain readable and retain their
-# historical dead-PID cleanup semantics.
-now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-printf '{"session_key":"legacy","issue_number":"1","repo_slug":"owner/repo","pid":99999999,"dispatched_at":"%s","status":"in-flight","updated_at":"%s"}\n' "$now" "$now" >>"$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl"
-if "$LEDGER" check --session-key legacy >/dev/null 2>&1; then
-	fail "legacy dead-PID marker remains readable"
+[[ "$endpoint" == repos/*/issues/*/comments* ]] || exit 1
+method=GET
+body=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--method) method="$2"; shift 2 ;;
+	--field) [[ "$2" == body=* ]] && body="${2#body=}"; shift 2 ;;
+	--jq) shift 2 ;;
+	*) shift ;;
+	esac
+done
+if [[ "$method" == POST ]]; then
+	lock="$state/lock"
+	while ! mkdir "$lock" 2>/dev/null; do sleep 0.01; done
+	id=$(($(wc -l <"$comments" | tr -d ' ') + 1))
+	created=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	jq -cn --argjson id "$id" --arg body "$body" --arg created "$created" \
+		'{id:$id,body:$body,created_at:$created}' >>"$comments"
+	rmdir "$lock"
+	printf '%s\n' "$id"
+	exit 0
 fi
-pass "legacy markers remain readable"
+jq -sc '[.]' "$comments"
+MOCK
+	chmod +x "$root/bin/gh"
+	return 0
+}
 
-grep -Fq 'AIDEVOPS_DISPATCH_LEASE_TOKEN=' "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh" || fail "launch token wiring"
-grep -Fq 'transition ready' "${SCRIPTS_DIR}/headless-runtime-worker.sh" || fail "readiness wiring"
-grep -Fq 'transition terminal' "${SCRIPTS_DIR}/worker-lifecycle-common.sh" || fail "terminal wiring"
-grep -Fq '_stale_recovery_final_evidence_recheck' "${SCRIPTS_DIR}/dispatch-dedup-stale.sh" || fail "takeover recheck wiring"
-pass "launch readiness terminal and takeover wiring is present"
+claim_token() {
+	local output_file="$1"
+	sed -n 's/.*lease_token=\([^ ]*\).*/\1/p' "$output_file"
+	return 0
+}
 
-printf '\nAtomic lease tests passed\n'
+test_local_ledger_guards() {
+	local ledger_dir="${TMP_DIR}/ledger"
+	export AIDEVOPS_DISPATCH_LEDGER_DIR="$ledger_dir"
+	export AIDEVOPS_DEVICE_ID=device-fixture-a
+	mkdir -p "$ledger_dir"
+	"$LEDGER" register --session-key issue-local --issue 1 --repo owner/repo --pid 99999999 \
+		--lease-token token-a --device-id device-fixture-a --lease-ttl 1
+	sleep 2
+	if "$LEDGER" check --session-key issue-local >/dev/null 2>&1; then fail "expired prelaunch ledger lease blocks"; fi
+	if "$LEDGER" check-issue --issue 1 --repo owner/repo >/dev/null 2>&1; then fail "expired issue ledger lease blocks"; fi
+	if "$LEDGER" ready --session-key issue-local --lease-token token-a >/dev/null 2>&1; then fail "expired ledger lease transitions ready"; fi
+	pass "ledger checks enforce expiry without maintenance"
+
+	"$LEDGER" register --session-key issue-ready --issue 2 --repo owner/repo --pid 99999999 \
+		--lease-token token-b --device-id device-fixture-a --lease-ttl 30
+	"$LEDGER" ready --session-key issue-ready --lease-token token-b --lease-ttl 30
+	"$LEDGER" check --session-key issue-ready >/dev/null || fail "ready lease not protected"
+	"$LEDGER" complete --session-key issue-ready --lease-token token-b
+	if "$LEDGER" ready --session-key issue-ready --lease-token token-b >/dev/null 2>&1; then fail "late ready overwrote terminal"; fi
+	if "$LEDGER" fail --session-key issue-ready --lease-token token-b >/dev/null 2>&1; then fail "terminal lease mutated twice"; fi
+	pass "ledger enforces transition order and terminal immutability"
+	return 0
+}
+
+test_concurrent_same_login_devices() {
+	local root="${TMP_DIR}/race" rc_a=0 rc_b=0
+	create_mock_gh "$root"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		DISPATCH_CLAIM_WINDOW=1 "$CLAIM" claim 42 owner/repo shared-login >"$root/a.out" 2>&1 &
+	local pid_a=$!
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-b \
+		DISPATCH_CLAIM_WINDOW=1 "$CLAIM" claim 42 owner/repo shared-login >"$root/b.out" 2>&1 &
+	local pid_b=$!
+	wait "$pid_a" || rc_a=$?
+	wait "$pid_b" || rc_b=$?
+	if ! { [[ "$rc_a" -eq 0 && "$rc_b" -eq 1 ]] || [[ "$rc_a" -eq 1 && "$rc_b" -eq 0 ]]; }; then
+		printf 'runner-a: %s\nrunner-b: %s\n' "$(tr '\n' ' ' <"$root/a.out")" "$(tr '\n' ' ' <"$root/b.out")" >&2
+		fail "concurrent claims did not elect one winner: a=$rc_a b=$rc_b"
+	fi
+	grep -Fq 'device=device-a' "$root/state/comments.jsonl" || fail "device-a absent"
+	grep -Fq 'device=device-b' "$root/state/comments.jsonl" || fail "device-b absent"
+	pass "mock GitHub elects one same-login different-device winner"
+	return 0
+}
+
+test_launch_crash_ready_terminal_race() {
+	local root="${TMP_DIR}/lifecycle" token="" terminal_rc=0 ready_rc=0
+	create_mock_gh "$root"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		DISPATCH_CLAIM_WINDOW=0 DISPATCH_CLAIM_ORPHAN_GRACE=1 \
+		"$CLAIM" claim 43 owner/repo shared-login >"$root/crash.out" 2>&1
+	sleep 2
+	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 43 owner/repo >/dev/null 2>&1; then
+		fail "launch crash lease did not expire"
+	fi
+	pass "launch crash expires and becomes reclaimable"
+
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		DISPATCH_CLAIM_WINDOW=0 DISPATCH_CLAIM_ORPHAN_GRACE=30 \
+		"$CLAIM" claim 44 owner/repo shared-login >"$root/ready.out" 2>&1
+	token=$(claim_token "$root/ready.out")
+	[[ -n "$token" ]] || fail "ready claim token missing"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		"$CLAIM" transition ready 44 owner/repo "$token" issue-44 30
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null || fail "ready lease not protected"
+	local dispatch_ts=""
+	dispatch_ts=$(jq -sr '[.[] | select(.body | contains("session=issue-44 phase=prelaunch"))] | first.created_at' "$root/state/comments.jsonl")
+	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" _stale_recovery_final_evidence_recheck 44 owner/repo "$dispatch_ts"; then
+		fail "stale recovery ignored active ready lease"
+	fi
+	pass "ready transition protects active worker"
+
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		"$CLAIM" transition terminal 44 owner/repo "$token" issue-44 0 >/dev/null 2>&1 &
+	local terminal_pid=$!
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		"$CLAIM" transition ready 44 owner/repo "$token" issue-44 30 >/dev/null 2>&1 &
+	local ready_pid=$!
+	wait "$terminal_pid" || terminal_rc=$?
+	wait "$ready_pid" || ready_rc=$?
+	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null 2>&1; then
+		fail "terminal was resurrected by late ready: terminal=$terminal_rc ready=$ready_rc"
+	fi
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" _stale_recovery_final_evidence_recheck 44 owner/repo "$dispatch_ts" \
+		|| fail "terminal did not cancel ready for stale recovery"
+	pass "terminal transition defeats concurrent or late ready"
+	return 0
+}
+
+test_takeover_recheck_precedes_mutation() {
+	local root="${TMP_DIR}/takeover"
+	create_mock_gh "$root"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		DISPATCH_CLAIM_WINDOW=0 "$CLAIM" claim 46 owner/repo shared-login >/dev/null
+	MUTATION_CALLED=0
+	set_issue_status() { MUTATION_CALLED=1; return 0; }
+	_stale_recovery_has_unresolved_blocked_by() { return 1; }
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		_stale_recovery_apply 46 owner/repo shared-login stale "2000-01-01T00:00:00Z" >/dev/null
+	[[ "$MUTATION_CALLED" -eq 0 ]] || fail "takeover mutation ran after evidence changed"
+	pass "final evidence recheck blocks takeover mutation"
+	return 0
+}
+
+test_invalid_device_not_public() {
+	local root="${TMP_DIR}/device"
+	create_mock_gh "$root"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=$'bad device\nINJECTED' \
+		AIDEVOPS_DEVICE_ID_FILE="$root/device-id" DISPATCH_CLAIM_WINDOW=0 \
+		"$CLAIM" claim 45 owner/repo shared-login >/dev/null 2>&1
+	if grep -Fq 'INJECTED' "$root/state/comments.jsonl"; then fail "invalid device reached public marker"; fi
+	pass "invalid device IDs are rejected before public output"
+	return 0
+}
+
+test_local_ledger_guards
+test_concurrent_same_login_devices
+test_launch_crash_ready_terminal_race
+test_invalid_device_not_public
+test_takeover_recheck_precedes_mutation
+printf '\nAtomic lease concurrency tests passed\n'
 exit 0

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -55,7 +55,8 @@ if [[ "$method" == POST ]]; then
 	id=$(($(wc -l <"$comments" | tr -d ' ') + 1))
 	created=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	jq -cn --argjson id "$id" --arg body "$body" --arg created "$created" \
-		'{id:$id,body:$body,created_at:$created}' >>"$comments"
+		--arg login "${MOCK_GH_LOGIN:-shared-login}" \
+		'{id:$id,body:$body,created_at:$created,user:{login:$login},author_association:"MEMBER"}' >>"$comments"
 	rmdir "$lock"
 	printf '%s\n' "$id"
 	exit 0
@@ -89,10 +90,17 @@ test_local_ledger_guards() {
 		--lease-token token-b --device-id device-fixture-a --lease-ttl 30
 	"$LEDGER" ready --session-key issue-ready --lease-token token-b --lease-ttl 30
 	"$LEDGER" check --session-key issue-ready >/dev/null || fail "ready lease not protected"
+	local before_register="" after_register="" effective_phase=""
+	before_register=$(wc -l <"$ledger_dir/dispatch-ledger.jsonl" | tr -d ' ')
+	"$LEDGER" register --session-key issue-ready --issue 2 --repo owner/repo --pid $$ \
+		--lease-token token-b --device-id device-fixture-a --lease-ttl 30
+	after_register=$(wc -l <"$ledger_dir/dispatch-ledger.jsonl" | tr -d ' ')
+	effective_phase=$(jq -sr '[.[] | select(.session_key == "issue-ready")] | last.lease_phase' "$ledger_dir/dispatch-ledger.jsonl")
+	[[ "$before_register" == "$after_register" && "$effective_phase" == ready ]] || fail "parent register regressed ready lease"
 	"$LEDGER" complete --session-key issue-ready --lease-token token-b
 	if "$LEDGER" ready --session-key issue-ready --lease-token token-b >/dev/null 2>&1; then fail "late ready overwrote terminal"; fi
 	if "$LEDGER" fail --session-key issue-ready --lease-token token-b >/dev/null 2>&1; then fail "terminal lease mutated twice"; fi
-	pass "ledger enforces transition order and terminal immutability"
+	pass "ledger registration is phase-monotonic and terminal is immutable"
 	return 0
 }
 
@@ -128,6 +136,7 @@ test_launch_crash_ready_terminal_race() {
 		fail "launch crash lease did not expire"
 	fi
 	pass "launch crash expires and becomes reclaimable"
+	: >"$root/state/comments.jsonl"
 
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
 		DISPATCH_CLAIM_WINDOW=0 DISPATCH_CLAIM_ORPHAN_GRACE=30 \
@@ -137,6 +146,31 @@ test_launch_crash_ready_terminal_race() {
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
 		"$CLAIM" transition ready 44 owner/repo "$token" issue-44 30
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null || fail "ready lease not protected"
+	local old_created=""
+	old_created=$(python3 - <<'PY'
+from datetime import datetime, timedelta, timezone
+print((datetime.now(timezone.utc) - timedelta(seconds=1900)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+PY
+)
+	jq -c --arg old "$old_created" 'if (.body | contains("session=issue-44 phase=prelaunch")) then .created_at=$old else . end' \
+		"$root/state/comments.jsonl" >"$root/state/comments.next"
+	mv "$root/state/comments.next" "$root/state/comments.jsonl"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null \
+		|| fail "ready lease older than legacy max age was dropped"
+	pass "ready lease survives legacy max age until explicit expiry"
+
+	local forged_body=""
+	forged_body="DISPATCH_LEASE phase=terminal lease_token=${token} device=device-a session=issue-44 expires_at=0 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=attacker \
+		gh api repos/owner/repo/issues/44/comments --method POST --field body="$forged_body" >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null \
+		|| fail "untrusted commenter terminated ready lease"
+	forged_body="DISPATCH_LEASE phase=terminal lease_token=${token} device=wrong-device session=issue-44 expires_at=0 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=shared-login \
+		gh api repos/owner/repo/issues/44/comments --method POST --field body="$forged_body" >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null \
+		|| fail "device-mismatched transition terminated ready lease"
+	pass "remote transitions require claim author device and session"
 	local dispatch_ts=""
 	dispatch_ts=$(jq -sr '[.[] | select(.body | contains("session=issue-44 phase=prelaunch"))] | first.created_at' "$root/state/comments.jsonl")
 	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" _stale_recovery_final_evidence_recheck 44 owner/repo "$dispatch_ts"; then
@@ -155,8 +189,9 @@ test_launch_crash_ready_terminal_race() {
 	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null 2>&1; then
 		fail "terminal was resurrected by late ready: terminal=$terminal_rc ready=$ready_rc"
 	fi
-	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" _stale_recovery_final_evidence_recheck 44 owner/repo "$dispatch_ts" \
-		|| fail "terminal did not cancel ready for stale recovery"
+	if ! PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" _stale_recovery_final_evidence_recheck 44 owner/repo "$dispatch_ts"; then
+		fail "terminal did not cancel ready for stale recovery"
+	fi
 	pass "terminal transition defeats concurrent or late ready"
 	return 0
 }

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${TEST_DIR}/.."
+LEDGER="${SCRIPTS_DIR}/dispatch-ledger-helper.sh"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+export AIDEVOPS_DISPATCH_LEDGER_DIR="${TMP_DIR}/ledger"
+export AIDEVOPS_DEVICE_ID="device-fixture-a"
+mkdir -p "$AIDEVOPS_DISPATCH_LEDGER_DIR"
+
+fail() { printf 'FAIL %s\n' "$1" >&2; return 1; }
+pass() { printf 'PASS %s\n' "$1"; return 0; }
+
+"$LEDGER" register --session-key issue-27165 --issue 27165 --repo owner/repo \
+	--pid 99999999 --lease-token token-a --device-id device-fixture-a --lease-ttl 60
+[[ $(jq -r 'select(.session_key=="issue-27165") | .lease_phase' "$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl") == prelaunch ]] \
+	|| fail "prelaunch lease is persisted"
+pass "prelaunch lease is persisted"
+
+if "$LEDGER" ready --session-key issue-27165 --lease-token wrong-token >/dev/null 2>&1; then
+	fail "wrong token cannot transition lease"
+fi
+pass "wrong token cannot transition lease"
+
+"$LEDGER" ready --session-key issue-27165 --lease-token token-a --lease-ttl 60
+latest=$(jq -sc '[.[] | select(.session_key=="issue-27165")] | last' "$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl")
+[[ $(printf '%s' "$latest" | jq -r '.lease_phase') == ready ]] || fail "token-qualified ready transition"
+[[ $(printf '%s' "$latest" | jq -r '.runner_device') == device-fixture-a ]] || fail "device identity survives transition"
+pass "token-qualified ready transition preserves device identity"
+
+# A dead local PID must not imply remote completion for a lease-aware record.
+"$LEDGER" check --session-key issue-27165 >/dev/null || fail "ready lease survives local PID exit"
+pass "ready lease survives local PID exit"
+
+"$LEDGER" complete --session-key issue-27165 --lease-token token-a
+latest=$(jq -sc '[.[] | select(.session_key=="issue-27165")] | last' "$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl")
+[[ $(printf '%s' "$latest" | jq -r '.lease_phase + ":" + .status') == terminal:completed ]] \
+	|| fail "terminal transition is append-only"
+[[ $(wc -l <"$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl" | tr -d ' ') -eq 3 ]] \
+	|| fail "lease history contains prelaunch ready terminal records"
+pass "terminal transition appends immutable evidence"
+
+# Backward compatibility: legacy records remain readable and retain their
+# historical dead-PID cleanup semantics.
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+printf '{"session_key":"legacy","issue_number":"1","repo_slug":"owner/repo","pid":99999999,"dispatched_at":"%s","status":"in-flight","updated_at":"%s"}\n' "$now" "$now" >>"$AIDEVOPS_DISPATCH_LEDGER_DIR/dispatch-ledger.jsonl"
+if "$LEDGER" check --session-key legacy >/dev/null 2>&1; then
+	fail "legacy dead-PID marker remains readable"
+fi
+pass "legacy markers remain readable"
+
+grep -Fq 'AIDEVOPS_DISPATCH_LEASE_TOKEN=' "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh" || fail "launch token wiring"
+grep -Fq 'transition ready' "${SCRIPTS_DIR}/headless-runtime-worker.sh" || fail "readiness wiring"
+grep -Fq 'transition terminal' "${SCRIPTS_DIR}/worker-lifecycle-common.sh" || fail "terminal wiring"
+grep -Fq '_stale_recovery_final_evidence_recheck' "${SCRIPTS_DIR}/dispatch-dedup-stale.sh" || fail "takeover recheck wiring"
+pass "launch readiness terminal and takeover wiring is present"
+
+printf '\nAtomic lease tests passed\n'
+exit 0

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -146,7 +146,7 @@ if [[ "$endpoint" == repos/*/issues/*/comments* ]]; then
 		--arg new_body "$new_body" \
 		--arg new_ts "${MOCK_NEW_CLAIM_CREATED_AT:?}" \
 		'[
-			{id: 1, body: ("DISPATCH_CLAIM nonce=old-nonce runner=" + $runner + " ts=" + $old_ts + " max_age_s=120"), created_at: $old_ts},
+			{id: 1, body: ("DISPATCH_CLAIM nonce=old-nonce runner=" + $runner + " ts=" + $old_ts + " max_age_s=120" + (if env.MOCK_OLD_CLAIM_DEVICE then " lease_token=old-nonce device=" + env.MOCK_OLD_CLAIM_DEVICE + " session=issue-42 phase=prelaunch expires_at=4102444800" else "" end)), created_at: $old_ts},
 			{id: 999, body: $new_body, created_at: $new_ts}
 		]'
 	exit 0
@@ -1187,6 +1187,29 @@ test_claim_rejects_fresh_same_runner_claim() {
 	return 0
 }
 
+test_claim_allows_same_login_on_different_device_after_expiry_protocol() {
+	local tmp_dir mock_path old_created_at new_created_at output exit_code
+	tmp_dir=$(mktemp -d)
+	mock_path=$(create_mock_gh "$tmp_dir")
+	old_created_at="$(iso_seconds_ago 10)"
+	new_created_at="$(iso_seconds_ago 1)"
+	set +e
+	output=$(PATH="${mock_path}:$PATH" MOCK_GH_STATE_DIR="$tmp_dir" \
+		MOCK_OLD_CLAIM_CREATED_AT="$old_created_at" MOCK_NEW_CLAIM_CREATED_AT="$new_created_at" \
+		MOCK_OLD_CLAIM_RUNNER="shared-login" MOCK_OLD_CLAIM_DEVICE="device-b" \
+		AIDEVOPS_DEVICE_ID="device-a" DISPATCH_CLAIM_WINDOW=0 \
+		"$CLAIM_HELPER" claim 42 owner/repo shared-login 2>&1)
+	exit_code=$?
+	set -e
+	if [[ "$exit_code" -eq 1 && "$output" != *"CLAIM_STALE_SELF"* ]]; then
+		print_result "same-login different devices are distinguished" 0
+	else
+		print_result "same-login different devices are distinguished" 1 "exit=${exit_code} output=${output}"
+	fi
+	rm -rf "$tmp_dir"
+	return 0
+}
+
 #######################################
 # Test: long issue threads still see active claims beyond the first REST page.
 #######################################
@@ -1577,6 +1600,7 @@ main() {
 	test_check_preserves_claim_with_launch_evidence
 	test_claim_rejects_stale_same_runner_claim
 	test_claim_rejects_fresh_same_runner_claim
+	test_claim_allows_same_login_on_different_device_after_expiry_protocol
 	test_claim_reads_paginated_comment_tail
 	test_claim_reads_lowercase_paginated_claim_marker
 	test_claim_ignore_filter_preserves_self_claim

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -319,7 +319,7 @@ test_terminal_state_immutability() {
 }
 
 #######################################
-# Test: register retries append audit evidence; readers use the latest entry.
+# Test: legacy tokenless register retries remain idempotent.
 #######################################
 test_register_idempotent() {
 	setup_test_env
@@ -327,15 +327,16 @@ test_register_idempotent() {
 	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
 	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 --repo "owner/repo" --pid $$
 
-	local entry_count
+	local entry_count active_count
 	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
+	active_count=$("$LEDGER_HELPER" count)
 
 	local result=0
-	if [[ "$entry_count" -ne 2 ]]; then
+	if [[ "$entry_count" -ne 1 || "$active_count" -ne 1 ]]; then
 		result=1
 	fi
 
-	print_result "register retry is append-only" "$result" "count=${entry_count}"
+	print_result "tokenless register retry does not duplicate active entry" "$result" "entries=${entry_count}, active=${active_count}"
 	teardown_test_env
 	return 0
 }

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -319,7 +319,7 @@ test_terminal_state_immutability() {
 }
 
 #######################################
-# Test: register is idempotent (re-register overwrites)
+# Test: register retries append audit evidence; readers use the latest entry.
 #######################################
 test_register_idempotent() {
 	setup_test_env
@@ -331,11 +331,11 @@ test_register_idempotent() {
 	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
 
 	local result=0
-	if [[ "$entry_count" -ne 1 ]]; then
+	if [[ "$entry_count" -ne 2 ]]; then
 		result=1
 	fi
 
-	print_result "register is idempotent (re-register overwrites)" "$result" "count=${entry_count}"
+	print_result "register retry is append-only" "$result" "count=${entry_count}"
 	teardown_test_env
 	return 0
 }

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -128,6 +128,16 @@ _emit_worker_runtime_event() {
 	local runtime_events="${BASH_SOURCE[0]%/*}/runtime-events.mjs"
 	[[ -n "${AIDEVOPS_WORKER_ID:-}" ]] || return 0
 	_emit_objective_recovery_evidence "$event_type" "$status" "$classification"
+	case "$event_type" in
+	worker.completed | worker.failed | worker.deferred)
+		if [[ -n "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" && "${WORKER_ISSUE_NUMBER:-}" =~ ^[0-9]+$ && -n "${DISPATCH_REPO_SLUG:-${WORKER_REPO_SLUG:-}}" ]]; then
+			local lease_helper="${BASH_SOURCE[0]%/*}/dispatch-claim-helper.sh"
+			"$lease_helper" transition terminal "$WORKER_ISSUE_NUMBER" \
+				"${DISPATCH_REPO_SLUG:-$WORKER_REPO_SLUG}" "$AIDEVOPS_DISPATCH_LEASE_TOKEN" \
+				"${_invoke_session_key:-issue-${WORKER_ISSUE_NUMBER}}" 0 >/dev/null 2>&1 || true
+		fi
+		;;
+	esac
 	[[ -f "$runtime_events" ]] || return 0
 	command -v node >/dev/null 2>&1 || return 0
 	local -a event_cmd=(node "$runtime_events" emit "$event_type" --source worker_self_reported)


### PR DESCRIPTION
## Summary

- add token-qualified, append-only dispatch lease phases (`prelaunch`, `ready`, `terminal`)
- distinguish same-login runners with validated opaque device IDs
- enforce explicit expiry, transition ordering, terminal immutability, and evidence-based takeover
- preserve legacy claim and ledger compatibility while preventing duplicate tokenless registrations
- add concurrent mocked-GitHub race, crash, expiry, forgery, and takeover coverage

## Testing

- `bash .agents/scripts/tests/test-dispatch-atomic-lease.sh` (10 scenarios passed)
- `bash .agents/scripts/tests/test-dispatch-claim-helper.sh` (58 passed)
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh` (4 passed)
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh` (2 passed)
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh` (5 passed)
- `bash .agents/scripts/tests/test-dispatch-ledger-helper.sh` (25 passed)
- focused ShellCheck passed
- `.agents/scripts/linters-local.sh` passed

## Runtime Testing

Runtime-verified through concurrent process fixtures and mocked append-only GitHub timelines covering claim election, launch crash, readiness, expiry, terminal races, forged transitions, and final takeover rechecks.

## Decisions

- use GitHub comments as the append-only distributed coordination record rather than adding a new service
- retain existing assignment ordering, but make abandoned prelaunch ownership safely reclaimable
- trust remote transitions only when author, token, device, and session match the originating claim

Resolves #27165

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.35 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 41m and 88,852 tokens on this with the user in an interactive session.
