### PR TITLE
GH#27148: Add dual-read task identity codec

### DIFF
--- a/.agents/reference/task-identity-parser-inventory.md
+++ b/.agents/reference/task-identity-parser-inventory.md
@@ -1,0 +1,26 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Task Identity Parser Inventory
+
+Snapshot for issue #27148. The shared lexical contract is
+`.agents/scripts/task-identity-lib.sh`. This inventory prevents broad regex
+replacement in the codec PR; issue #27149 owns consumer migration and must
+re-scan before changing each group.
+
+| Consumer group | Representative production files | Migration concern |
+|---|---|---|
+| Allocation and counters | `claim-task-id.sh`, `claim-task-id-counter.sh`, `claim-task-id-issue.sh` | Preserve legacy emission until the coordinator gate enables namespaced IDs |
+| TODO parsing and issue sync | `issue-sync-lib-parse.sh`, `issue-sync-lib-ref.sh`, `issue-sync-helper-commands.sh`, `issue-sync-helper-enrich.sh`, `issue-sync-helper-close.sh` | Parse tokens through the codec and require explicit repository context for legacy resolution |
+| Dependency resolution | `pulse-dep-graph.sh`, `issue-sync-relationships.sh`, `parent-status-helper.sh` | Do not strip the `t` prefix or assume the identity body is numeric |
+| Brief and plan lookup | `task-brief-helper.sh`, `verify-brief.sh`, `list-todo-helper.sh`, `todo-ready.sh`, `show-plan-helper.sh` | Use canonical tokens as opaque filename and lookup keys after validation |
+| Worktree and session routing | `worktree-helper-add.sh`, `pre-edit-check.sh`, `interactive-session-helper.sh` | Avoid partial numeric extraction from namespaced branch tokens |
+| PR and dispatch identity | `full-loop-helper-commit.sh`, `dispatch-dedup-helper.sh`, `pulse-dispatch-core.sh`, `pulse-merge-conflict.sh`, `shared-gh-wrappers-create.sh`, `gh` | Preserve complete tokens in titles, markers, dedup keys, and provenance checks |
+| Release and completion | `version-manager-git.sh`, `task-complete-helper.sh`, `pre-commit-hook.sh` | Extract complete validated tokens and retain legacy behavior |
+| Collision guards and CI | `.agents/hooks/task-id-collision-guard.sh`, `install-task-id-guard.sh`, `.github/workflows/task-id-collision-check.yml` | Scope legacy collisions by verified home repository and namespaced collisions globally |
+| Secondary integrations | `beads-sync-helper.sh`, `email-triage-helper.sh`, `self-evolution-helper-todo.sh`, `memory-graduate-helper.sh`, `session_time_common.py` | Replace display-oriented numeric matching only when the integration accepts both forms |
+
+The migration must inventory tests with each production consumer, retain
+numeric-only fixtures, and add namespaced and malformed fixtures. Matches in
+examples, generated patches, vendored content, or unrelated words such as
+`timeout` are not production parsers and must not be mechanically rewritten.

--- a/.agents/scripts/task-identity-lib.sh
+++ b/.agents/scripts/task-identity-lib.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Shared lexical codec for legacy and origin-namespaced task identifiers.
+
+[[ -n "${_AIDEVOPS_TASK_IDENTITY_LIB_LOADED:-}" ]] && return 0
+_AIDEVOPS_TASK_IDENTITY_LIB_LOADED=1
+
+readonly TASK_IDENTITY_MAX_BYTES=199
+readonly TASK_IDENTITY_MAX_DECIMAL_DIGITS=18
+readonly TASK_IDENTITY_MAX_SUBTASK_DEPTH=8
+readonly TASK_IDENTITY_LEGACY_ERE='^t[1-9][0-9]{0,17}(\.[1-9][0-9]{0,17}){0,8}$'
+readonly TASK_IDENTITY_NAMESPACED_ERE='^to[0-7][0-9a-hjkmnp-tv-z]{25}-[1-9][0-9]{0,17}(\.[1-9][0-9]{0,17}){0,8}$'
+readonly TASK_IDENTITY_ANY_ERE='^(t[1-9][0-9]{0,17}(\.[1-9][0-9]{0,17}){0,8}|to[0-7][0-9a-hjkmnp-tv-z]{25}-[1-9][0-9]{0,17}(\.[1-9][0-9]{0,17}){0,8})$'
+
+TASK_IDENTITY_KIND=""
+TASK_IDENTITY_CANONICAL_ID=""
+TASK_IDENTITY_ORIGIN_ID=""
+TASK_IDENTITY_SEQUENCE=""
+TASK_IDENTITY_SUBTASK_PATH=""
+TASK_IDENTITY_PARENT_ID=""
+
+task_identity_reset() {
+	TASK_IDENTITY_KIND=""
+	TASK_IDENTITY_CANONICAL_ID=""
+	TASK_IDENTITY_ORIGIN_ID=""
+	TASK_IDENTITY_SEQUENCE=""
+	TASK_IDENTITY_SUBTASK_PATH=""
+	TASK_IDENTITY_PARENT_ID=""
+	return 0
+}
+
+_task_identity_parent_for() {
+	local base_id="$1"
+	local subtask_path="$2"
+	if [[ -z "$subtask_path" ]]; then
+		printf '%s' ""
+	elif [[ "$subtask_path" == *.* ]]; then
+		printf '%s.%s' "$base_id" "${subtask_path%.*}"
+	else
+		printf '%s' "$base_id"
+	fi
+	return 0
+}
+
+_task_identity_set_fields() {
+	local kind="$1"
+	local canonical_id="$2"
+	local origin_id="$3"
+	local sequence="$4"
+	local suffix="$5"
+	local base_id=""
+
+	TASK_IDENTITY_KIND="$kind"
+	TASK_IDENTITY_CANONICAL_ID="$canonical_id"
+	TASK_IDENTITY_ORIGIN_ID="$origin_id"
+	TASK_IDENTITY_SEQUENCE="$sequence"
+	TASK_IDENTITY_SUBTASK_PATH="${suffix#.}"
+	if [[ "$kind" == "legacy" ]]; then
+		base_id="t${sequence}"
+	else
+		base_id="t${origin_id}-${sequence}"
+	fi
+	TASK_IDENTITY_PARENT_ID=$(_task_identity_parent_for "$base_id" "$TASK_IDENTITY_SUBTASK_PATH")
+	return 0
+}
+
+task_identity_parse() {
+	local input="${1:-}"
+	local legacy_capture_ere='^t([1-9][0-9]{0,17})((\.[1-9][0-9]{0,17}){0,8})$'
+	local namespaced_capture_ere='^t(o[0-7][0-9a-hjkmnp-tv-z]{25})-([1-9][0-9]{0,17})((\.[1-9][0-9]{0,17}){0,8})$'
+
+	task_identity_reset
+	[[ -n "$input" && "${#input}" -le "$TASK_IDENTITY_MAX_BYTES" ]] || return 1
+	if [[ "$input" =~ $legacy_capture_ere ]]; then
+		_task_identity_set_fields "legacy" "$input" "" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+		return 0
+	fi
+	if [[ "$input" =~ $namespaced_capture_ere ]]; then
+		_task_identity_set_fields "namespaced" "$input" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+		return 0
+	fi
+	return 1
+}
+
+task_identity_validate() {
+	local input="${1:-}"
+	# Validation runs in a subshell so it never changes or clears parsed fields.
+	if (task_identity_parse "$input"); then
+		return 0
+	fi
+	return 1
+}
+
+task_identity_format() {
+	local kind="${1:-}"
+	local origin_id="${2:-}"
+	local sequence="${3:-}"
+	local subtask_path="${4:-}"
+	local candidate=""
+
+	case "$kind" in
+	legacy)
+		[[ -z "$origin_id" ]] || return 1
+		candidate="t${sequence}"
+		;;
+	namespaced)
+		[[ -n "$origin_id" ]] || return 1
+		candidate="t${origin_id}-${sequence}"
+		;;
+	*)
+		return 1
+		;;
+	esac
+	[[ -z "$subtask_path" ]] || candidate="${candidate}.${subtask_path}"
+	task_identity_validate "$candidate" || return 1
+	printf '%s\n' "$candidate"
+	return 0
+}
+
+task_identity_ere() {
+	local kind="${1:-any}"
+	case "$kind" in
+	legacy) printf '%s\n' "$TASK_IDENTITY_LEGACY_ERE" ;;
+	namespaced) printf '%s\n' "$TASK_IDENTITY_NAMESPACED_ERE" ;;
+	any) printf '%s\n' "$TASK_IDENTITY_ANY_ERE" ;;
+	*) return 1 ;;
+	esac
+	return 0
+}

--- a/.agents/scripts/tests/test-task-identity-lib.sh
+++ b/.agents/scripts/tests/test-task-identity-lib.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${TEST_SCRIPT_DIR}/../../.." && pwd)"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+# shellcheck source=../task-identity-lib.sh
+source "${REPO_ROOT}/.agents/scripts/task-identity-lib.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+ORIGIN_ID="o01j2abc3def4gh5jkm6npq7rst"
+
+pass() {
+	local message="$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	printf 'PASS %s\n' "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	printf 'FAIL %s\n' "$message" >&2
+	return 0
+}
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$message"
+		return 0
+	fi
+	fail "${message}: expected '${expected}', got '${actual}'"
+	return 1
+}
+
+assert_valid() {
+	local task_id="$1"
+	local message="$2"
+	if task_identity_validate "$task_id"; then
+		pass "$message"
+		return 0
+	fi
+	fail "${message}: rejected '${task_id}'"
+	return 1
+}
+
+assert_invalid() {
+	local task_id="$1"
+	local message="$2"
+	if task_identity_validate "$task_id"; then
+		fail "${message}: accepted '${task_id}'"
+		return 1
+	fi
+	pass "$message"
+	return 0
+}
+
+test_valid_forms_and_fields() {
+	task_identity_parse "t18097" || return 1
+	assert_equal "legacy" "$TASK_IDENTITY_KIND" "legacy kind" || return 1
+	assert_equal "t18097" "$TASK_IDENTITY_CANONICAL_ID" "legacy canonical ID" || return 1
+	assert_equal "" "$TASK_IDENTITY_ORIGIN_ID" "legacy origin empty" || return 1
+	assert_equal "18097" "$TASK_IDENTITY_SEQUENCE" "legacy sequence" || return 1
+	assert_equal "" "$TASK_IDENTITY_SUBTASK_PATH" "legacy top-level subtask path" || return 1
+	assert_equal "" "$TASK_IDENTITY_PARENT_ID" "legacy top-level parent" || return 1
+
+	task_identity_parse "t18097.2.1" || return 1
+	assert_equal "2.1" "$TASK_IDENTITY_SUBTASK_PATH" "legacy subtask path" || return 1
+	assert_equal "t18097.2" "$TASK_IDENTITY_PARENT_ID" "legacy nested parent" || return 1
+
+	task_identity_parse "t${ORIGIN_ID}-42.3" || return 1
+	assert_equal "namespaced" "$TASK_IDENTITY_KIND" "namespaced kind" || return 1
+	assert_equal "$ORIGIN_ID" "$TASK_IDENTITY_ORIGIN_ID" "namespaced origin" || return 1
+	assert_equal "42" "$TASK_IDENTITY_SEQUENCE" "namespaced sequence" || return 1
+	assert_equal "3" "$TASK_IDENTITY_SUBTASK_PATH" "namespaced subtask path" || return 1
+	assert_equal "t${ORIGIN_ID}-42" "$TASK_IDENTITY_PARENT_ID" "namespaced parent" || return 1
+	return 0
+}
+
+test_boundary_forms() {
+	local decimal_max="999999999999999999"
+	local deepest="1.2.3.4.5.6.7.8"
+	local max_path="${decimal_max}.${decimal_max}.${decimal_max}.${decimal_max}.${decimal_max}.${decimal_max}.${decimal_max}.${decimal_max}"
+	local max_token="t${ORIGIN_ID}-${decimal_max}.${max_path}"
+	local oversized=""
+	printf -v oversized 't%0200d' 1
+
+	assert_equal "199" "$TASK_IDENTITY_MAX_BYTES" "published byte limit" || return 1
+	assert_equal "18" "$TASK_IDENTITY_MAX_DECIMAL_DIGITS" "published decimal limit" || return 1
+	assert_equal "8" "$TASK_IDENTITY_MAX_SUBTASK_DEPTH" "published subtask limit" || return 1
+	assert_valid "t${decimal_max}.${deepest}" "legacy maximum digits and depth" || return 1
+	assert_valid "$max_token" "namespaced exact maximum shape" || return 1
+	assert_equal "199" "${#max_token}" "namespaced maximum is 199 bytes" || return 1
+	assert_invalid "$oversized" "reject token over 199 bytes" || return 1
+	assert_invalid "t1000000000000000000" "reject 19-digit sequence" || return 1
+	assert_invalid "t1.1.2.3.4.5.6.7.8.9" "reject ninth subtask component" || return 1
+	return 0
+}
+
+test_invalid_forms() {
+	local invalid=""
+	local invalid_values=(
+		"" "t0" "t01" "T1" "t-1" "t1." "t1..2" "t1.0"
+		"t${ORIGIN_ID}" "t${ORIGIN_ID}-0" "t${ORIGIN_ID}-01"
+		"to81j2abc3def4gh5jkm6npq7rst-1" "to01j2abc3def4gh5jkm6npq7rso-1"
+		"TO01J2ABC3DEF4GH5JKM6NPQ7RST-1" "t1/../../2" "t1 2" "t1;true"
+		" t1" "t1 " $'t1\t2' $'t1\n2' $'t1\r2' $'t1\0012'
+	)
+	for invalid in "${invalid_values[@]}"; do
+		assert_invalid "$invalid" "reject invalid form" || return 1
+	done
+	return 0
+}
+
+test_formatter_round_trip() {
+	local formatted=""
+	formatted=$(task_identity_format "legacy" "" "18097" "2.1") || return 1
+	assert_equal "t18097.2.1" "$formatted" "format legacy" || return 1
+	task_identity_parse "$formatted" || return 1
+	assert_equal "$formatted" "$TASK_IDENTITY_CANONICAL_ID" "legacy round trip" || return 1
+
+	formatted=$(task_identity_format "namespaced" "$ORIGIN_ID" "42" "3") || return 1
+	assert_equal "t${ORIGIN_ID}-42.3" "$formatted" "format namespaced" || return 1
+	task_identity_parse "$formatted" || return 1
+	assert_equal "$formatted" "$TASK_IDENTITY_CANONICAL_ID" "namespaced round trip" || return 1
+
+	if task_identity_format "legacy" "$ORIGIN_ID" "1" "" >/dev/null; then
+		fail "legacy formatter accepted origin"
+		return 1
+	fi
+	pass "legacy formatter rejects origin"
+	if task_identity_format "namespaced" "" "1" "" >/dev/null; then
+		fail "namespaced formatter accepted missing origin"
+		return 1
+	fi
+	pass "namespaced formatter rejects missing origin"
+	return 0
+}
+
+test_failure_clears_fields() {
+	task_identity_parse "t7.2" || return 1
+	if task_identity_parse "invalid"; then
+		fail "invalid parse unexpectedly succeeded"
+		return 1
+	fi
+	assert_equal "" "$TASK_IDENTITY_KIND" "failed parse clears kind" || return 1
+	assert_equal "" "$TASK_IDENTITY_CANONICAL_ID" "failed parse clears canonical ID" || return 1
+	assert_equal "" "$TASK_IDENTITY_ORIGIN_ID" "failed parse clears origin" || return 1
+	assert_equal "" "$TASK_IDENTITY_SEQUENCE" "failed parse clears sequence" || return 1
+	assert_equal "" "$TASK_IDENTITY_SUBTASK_PATH" "failed parse clears subtask path" || return 1
+	assert_equal "" "$TASK_IDENTITY_PARENT_ID" "failed parse clears parent" || return 1
+	return 0
+}
+
+test_validator_preserves_parsed_fields() {
+	task_identity_parse "t${ORIGIN_ID}-42.3" || return 1
+	task_identity_validate "t9" || return 1
+	assert_equal "t${ORIGIN_ID}-42.3" "$TASK_IDENTITY_CANONICAL_ID" "valid validation preserves parsed state" || return 1
+	if task_identity_validate "invalid"; then
+		fail "invalid validation unexpectedly succeeded"
+		return 1
+	fi
+	assert_equal "t${ORIGIN_ID}-42.3" "$TASK_IDENTITY_CANONICAL_ID" "invalid validation preserves parsed state" || return 1
+	return 0
+}
+
+test_cwd_independence_and_regex_contract() {
+	local original_pwd="$PWD"
+	local legacy_ere=""
+	local namespaced_ere=""
+	local any_ere=""
+	legacy_ere=$(task_identity_ere legacy) || return 1
+	namespaced_ere=$(task_identity_ere namespaced) || return 1
+	any_ere=$(task_identity_ere any) || return 1
+	cd "$TEST_ROOT" || return 1
+	task_identity_parse "t9.1" || return 1
+	cd "$original_pwd" || return 1
+	assert_equal "legacy" "$TASK_IDENTITY_KIND" "parse independent of cwd" || return 1
+	[[ "t9.1" =~ $legacy_ere ]] || {
+		fail "legacy ERE rejects valid token"
+		return 1
+	}
+	[[ "t${ORIGIN_ID}-9.1" =~ $namespaced_ere ]] || {
+		fail "namespaced ERE rejects valid token"
+		return 1
+	}
+	[[ "t9.1" =~ $any_ere && "t${ORIGIN_ID}-9.1" =~ $any_ere ]] || {
+		fail "any ERE rejects valid token"
+		return 1
+	}
+	if [[ "t${ORIGIN_ID}-9.1" =~ $legacy_ere ]] || [[ "t9.1" =~ $namespaced_ere ]] ||
+		[[ "xt9.1" =~ $any_ere ]] || [[ "t9.0" =~ $any_ere ]]; then
+		fail "published ERE accepted wrong or invalid form"
+		return 1
+	fi
+	if task_identity_ere unknown >/dev/null; then
+		fail "ERE API accepted unknown kind"
+		return 1
+	fi
+	pass "published ERE constants match valid tokens"
+	return 0
+}
+
+main() {
+	test_valid_forms_and_fields || return 1
+	test_boundary_forms || return 1
+	test_invalid_forms || return 1
+	test_formatter_round_trip || return 1
+	test_failure_clears_fields || return 1
+	test_validator_preserves_parsed_fields || return 1
+	test_cwd_independence_and_regex_contract || return 1
+	if [[ "$FAIL_COUNT" -ne 0 ]]; then
+		printf '%d test(s) failed\n' "$FAIL_COUNT" >&2
+		return 1
+	fi
+	printf '%d assertions passed\n' "$PASS_COUNT"
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add the shared Bash 3.2 lexical codec for legacy and approved origin-namespaced task identifiers, exposing canonical validation, parsing, formatting, ERE contracts, structured fields, and parent derivation without repository-cwd dependence or new-ID emission. Add a focused migration inventory for #27149.

## Files Changed

.agents/reference/task-identity-parser-inventory.md, .agents/scripts/task-identity-lib.sh, .agents/scripts/tests/test-task-identity-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 61 table-driven assertions pass across legacy and namespaced forms, exact 199-byte and hierarchy limits, malformed/control/whitespace inputs, Crockford constraints, formatter round trips, field reset/preservation semantics, exported ERE behavior, and cwd independence. Bash syntax, shfmt, ShellCheck, changed-file lint, Secretlint, Markdown, portability, complexity, and architecture/code reviews pass. Full lint was also run; only pre-existing origin/main CHANGELOG.md:33 MD012 debt blocked its aggregate exit.

Resolves #27148


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.36 with gpt-5.6-sol spent 1d 23h and 9,485,184 tokens on this with the user in an interactive session.