### PR TITLE
GH#27294: Prevent pmset overnight screen overcount

### DIFF
--- a/.agents/scripts/screen_time_history.py
+++ b/.agents/scripts/screen_time_history.py
@@ -119,8 +119,16 @@ def apply_short_history(periods, history, now, skipped):
         if not fallback:
             continue
         live_coverage = periods[name].get("coverage_pct", 0) or 0
-        if periods[name]["status"] == "unavailable" or fallback["coverage_pct"] > live_coverage:
-            reason = "live-source-unavailable" if periods[name]["status"] == "unavailable" else "richer-calendar-coverage"
+        permission_free_proxy = periods[name].get("source") == "macos-pmset-display-assertions"
+        better_coverage = fallback["coverage_pct"] > live_coverage
+        equal_higher_confidence = permission_free_proxy and fallback["coverage_pct"] >= live_coverage
+        if periods[name]["status"] == "unavailable" or better_coverage or equal_higher_confidence:
+            if periods[name]["status"] == "unavailable":
+                reason = "live-source-unavailable"
+            elif equal_higher_confidence and not better_coverage:
+                reason = "higher-confidence-observed-history"
+            else:
+                reason = "richer-calendar-coverage"
             periods[name] = dict(fallback, reason=reason)
 
 

--- a/.agents/scripts/screen_time_macos_pmset.py
+++ b/.agents/scripts/screen_time_macos_pmset.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import datetime as dt
 import os
+import re
 import subprocess
 from pathlib import Path
 
-from screen_time_interval_common import WINDOWS, state_intervals
+from screen_time_interval_common import WINDOWS, union_intervals
+
+DISPLAY_ASSERTION = re.compile(
+    r'"Powerd - Prevent sleep while display is on"\s+(\d{2}):(\d{2}):(\d{2})\s+id:'
+)
 
 
 def read_pmset_log():
@@ -28,43 +33,43 @@ def read_pmset_log():
     return result.stdout, None
 
 
-def parse_pmset_events(output):
-    events = []
+def parse_pmset_assertion_intervals(output, now):
+    intervals = []
     for line in output.splitlines():
-        if "Display is turned on" in line:
-            state = True
-        elif "Display is turned off" in line:
-            state = False
-        else:
+        match = DISPLAY_ASSERTION.search(line)
+        if not match:
             continue
         try:
-            timestamp = dt.datetime.strptime(line[:25], "%Y-%m-%d %H:%M:%S %z").timestamp()
+            end = dt.datetime.strptime(line[:25], "%Y-%m-%d %H:%M:%S %z").timestamp()
         except (ValueError, OverflowError, OSError):
             continue
-        events.append((timestamp, state))
-    return sorted(set(events))
+        hours, minutes, seconds = (int(value) for value in match.groups())
+        duration = hours * 3600 + minutes * 60 + seconds
+        if duration > 0 and end <= now:
+            intervals.append((end - duration, end))
+    return union_intervals(intervals, now - WINDOWS["year"], now)
 
 
 def pmset_collection(now):
     output, error = read_pmset_log()
     if error:
-        return {"status": "unavailable", "source": "macos-pmset-display-log", "reason": error, "intervals": []}
-    events = parse_pmset_events(output)
-    if not events:
-        return {"status": "unavailable", "source": "macos-pmset-display-log", "reason": "no-display-events", "intervals": []}
-    intervals = state_intervals(events, now - WINDOWS["year"], now)
-    latest = events[-1][0]
+        return {"status": "unavailable", "source": "macos-pmset-display-assertions", "reason": error, "intervals": []}
+    intervals = parse_pmset_assertion_intervals(output, now)
+    if not intervals:
+        return {"status": "unavailable", "source": "macos-pmset-display-assertions", "reason": "no-display-assertions", "intervals": []}
+    latest = max(right for _, right in intervals)
+    earliest = min(left for left, _ in intervals)
     freshness = max(0.0, (now - latest) / 3600)
     return {
         "status": "stale" if freshness > 72 else "ok",
-        "source": "macos-pmset-display-log",
-        "reason": "permission-free-display-state-events",
+        "source": "macos-pmset-display-assertions",
+        "reason": "permission-free-duration-bearing-display-assertions",
         "intervals": intervals,
-        "observations": len(events),
+        "observations": len(intervals),
         "latest_epoch": latest,
-        "earliest_epoch": events[0][0],
-        "observation_epochs": [timestamp for timestamp, _ in events],
-        "coverage_start_epoch": events[0][0],
-        "coverage_end_epoch": now if events[-1][1] else latest,
+        "earliest_epoch": earliest,
+        "observation_epochs": [right for _, right in intervals],
+        "coverage_start_epoch": earliest,
+        "coverage_end_epoch": latest,
         "freshness_hours": round(freshness, 1),
     }

--- a/.agents/scripts/tests/test-screen-time-helper.sh
+++ b/.agents/scripts/tests/test-screen-time-helper.sh
@@ -293,15 +293,19 @@ import datetime as dt
 import sys
 
 target, start = sys.argv[1], int(sys.argv[2])
-def row(offset, state):
+def display_row(offset, state):
     stamp = dt.datetime.fromtimestamp(start + offset).astimezone().strftime("%Y-%m-%d %H:%M:%S %z")
     return f"{stamp} Notification         Display is turned {state}"
+def assertion_row(offset, duration):
+    stamp = dt.datetime.fromtimestamp(start + offset).astimezone().strftime("%Y-%m-%d %H:%M:%S %z")
+    return f'{stamp} Assertions PID 592(powerd) Released PreventUserIdleSystemSleep "Powerd - Prevent sleep while display is on" {duration}  id:0x1'
 with open(target, "w", encoding="utf-8") as handle:
-    handle.write(row(8 * 3600, "on") + "\n")
+    # This unmatched state event previously remained open across the overnight
+    # gap and inflated the completed day. Assertion durations are authoritative.
+    handle.write(display_row(-2 * 3600, "on") + "\n")
     handle.write("malformed Display is turned on\n")
-    handle.write(row(12 * 3600, "off") + "\n")
-    handle.write(row(13 * 3600, "on") + "\n")
-    handle.write(row(15 * 3600, "off") + "\n")
+    handle.write(assertion_row(12 * 3600, "04:00:00") + "\n")
+    handle.write(assertion_row(15 * 3600, "02:00:00") + "\n")
 PY
 	local fixture_home="${tmpdir}/pmset-home"
 	mkdir -p "${fixture_home}/.aidevops/.agent-workspace/observability"
@@ -312,13 +316,13 @@ import sys
 
 today = dt.datetime.fromtimestamp(int(sys.argv[2])).date()
 with open(sys.argv[1], "w", encoding="utf-8") as handle:
-    for age in range(1, 29):
+    for age in range(2, 30):
         handle.write(json.dumps({"date": str(today - dt.timedelta(days=age)), "screen_hours": 1}) + "\n")
 PY
 	local output
 	output=$(HOME="$fixture_home" AIDEVOPS_PMSET_FIXTURE="$fixture" AIDEVOPS_SCREEN_TIME_NOW_EPOCH="$now" profile_stats "$db")
 	[[ "$(printf '%s' "$output" | jq -r '.today_hours')" == "6" || "$(printf '%s' "$output" | jq -r '.today_hours')" == "6.0" ]] || fail "pmset fallback did not union completed-day display intervals"
-	[[ "$(printf '%s' "$output" | jq -r '.periods.day.source')" == "macos-pmset-display-log" ]] || fail "pmset fallback provenance missing"
+	[[ "$(printf '%s' "$output" | jq -r '.periods.day.source')" == "macos-pmset-display-assertions" ]] || fail "pmset fallback provenance missing"
 	[[ "$(printf '%s' "$output" | jq -r '.periods.day.period_semantics')" == "completed-local-calendar-days" ]] || fail "pmset fallback changed profile period semantics"
 	[[ "$(printf '%s' "$output" | jq -r '.periods.month.source')" == "screen-time-history:daily-observations" ]] || fail "short pmset coverage displaced richer month history"
 	[[ "$(printf '%s' "$output" | jq -r '.periods.month.reason')" == "richer-calendar-coverage" ]] || fail "richer history selection reason missing"


### PR DESCRIPTION
## Summary

Replace open-ended pmset display-state reconstruction with duration-bearing power assertion intervals and prefer observed daily history over the proxy when coverage ties.

## Files Changed

.agents/scripts/screen_time_history.py, .agents/scripts/screen_time_macos_pmset.py, .agents/scripts/tests/test-screen-time-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Screen-time suite, overnight-gap regression, Python compilation, ShellCheck, local linters, and real source comparison pass; fallback changes from 21.5h to 11.4h while observed history remains 14.0h.

Resolves #27294


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.38 with gpt-5.6-sol spent 11h 57m and 4,288,982 tokens on this with the user in an interactive session.