### PR TITLE
GH#27289: Ignore superseded postflight check cancellations

### DIFF
--- a/.agents/scripts/tests/fixtures/postflight-check-runs.json
+++ b/.agents/scripts/tests/fixtures/postflight-check-runs.json
@@ -1,0 +1,60 @@
+{
+  "check_runs": [
+    {
+      "id": 101,
+      "name": "Framework Validation",
+      "status": "completed",
+      "conclusion": "cancelled",
+      "completed_at": "2026-07-12T01:00:00Z",
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 102,
+      "name": "Framework Validation",
+      "status": "completed",
+      "conclusion": "success",
+      "completed_at": "2026-07-12T02:00:00Z",
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 201,
+      "name": "Security Validation",
+      "status": "completed",
+      "conclusion": "success",
+      "completed_at": "2026-07-12T01:00:00Z",
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 202,
+      "name": "Security Validation",
+      "status": "completed",
+      "conclusion": "failure",
+      "completed_at": "2026-07-12T02:00:00Z",
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 301,
+      "name": "Shared Name",
+      "status": "completed",
+      "conclusion": "success",
+      "completed_at": "2026-07-12T02:00:00Z",
+      "app": { "slug": "app-one" }
+    },
+    {
+      "id": 302,
+      "name": "Shared Name",
+      "status": "completed",
+      "conclusion": "failure",
+      "completed_at": "2026-07-12T02:00:00Z",
+      "app": { "slug": "app-two" }
+    },
+    {
+      "id": 401,
+      "name": "Verify Release Health",
+      "status": "completed",
+      "conclusion": "failure",
+      "completed_at": "2026-07-12T03:00:00Z",
+      "app": { "slug": "github-actions" }
+    }
+  ]
+}

--- a/.agents/scripts/tests/test-postflight-check-run-dedup.sh
+++ b/.agents/scripts/tests/test-postflight-check-run-dedup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+FILTER="${REPO_ROOT}/.github/scripts/effective-check-runs.jq"
+FIXTURE="${SCRIPT_DIR}/fixtures/postflight-check-runs.json"
+
+RESULT=$(jq --arg self_name "Verify Release Health" -f "$FILTER" "$FIXTURE")
+
+jq -e '
+  length == 4 and
+  any(.[]; .name == "Framework Validation" and .conclusion == "success") and
+  any(.[]; .name == "Security Validation" and .conclusion == "failure") and
+  ([.[] | select(.name == "Shared Name")] | length == 2) and
+  all(.[]; .name != "Verify Release Health")
+' <<<"$RESULT" >/dev/null
+
+printf 'PASS: postflight selects the latest completed check run per name and app\n'

--- a/.github/scripts/effective-check-runs.jq
+++ b/.github/scripts/effective-check-runs.jq
@@ -1,0 +1,13 @@
+def run_key: [(.name // ""), (.app.slug // .app.name // "")];
+
+def run_time:
+  .completed_at // .started_at // .created_at // .updated_at // "";
+
+[
+  .check_runs[]
+  | select(.status == "completed")
+  | select(.name != $self_name)
+]
+| sort_by(run_key)
+| group_by(run_key)
+| map(max_by([run_time, (.id // 0)]))

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -74,10 +74,14 @@ jobs:
         echo "## CI/CD Pipeline Status" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        # Get all check runs, excluding self to avoid counting our own status
+        # Select the latest completed run for each check name/app pair. GitHub
+        # retains superseded runs on a commit, so counting every historical
+        # cancellation can incorrectly fail an otherwise healthy release.
         SELF_NAME="Verify Release Health"
-        CHECK_RUNS=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
-          --jq ".check_runs[] | select(.name != \"$SELF_NAME\") | {name, status, conclusion}")
+        CHECK_RUNS_RESPONSE=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs?per_page=100")
+        CHECK_RUNS=$(echo "$CHECK_RUNS_RESPONSE" \
+          | jq -c --arg self_name "$SELF_NAME" -f .github/scripts/effective-check-runs.jq \
+          | jq -c '.[] | {name, status, conclusion, app: (.app.slug // .app.name // "unknown")}')
         
         # Count results (excluding self)
         TOTAL=$(echo "$CHECK_RUNS" | jq -s 'length')
@@ -88,12 +92,11 @@ jobs:
         echo "| Check | Status | Conclusion |" >> $GITHUB_STEP_SUMMARY
         echo "|-------|--------|------------|" >> $GITHUB_STEP_SUMMARY
         
-        # Show all check runs including self for transparency
-        gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
-          --jq '.check_runs[] | "| \(.name) | \(.status) | \(.conclusion // "pending") |"' >> $GITHUB_STEP_SUMMARY
+        # Show the effective check runs used for pass/fail decisions.
+        echo "$CHECK_RUNS" | jq -rs '.[] | "| \(.name) | \(.status) | \(.conclusion // "pending") |"' >> $GITHUB_STEP_SUMMARY
         
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "*Note: 'Verify Release Health' (this workflow) is excluded from pass/fail counts*" >> $GITHUB_STEP_SUMMARY
+        echo "*Note: latest completed run per check name/app is used; 'Verify Release Health' is excluded*" >> $GITHUB_STEP_SUMMARY
         
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Total**: $TOTAL | **Passed**: $PASSED | **Skipped**: $SKIPPED | **Failed**: $FAILED" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Select the latest completed check run for each name/app pair before classifying release health, with fixtures covering superseded cancellations and current failures.

## Files Changed

.agents/scripts/tests/fixtures/postflight-check-runs.json, .agents/scripts/tests/test-postflight-check-run-dedup.sh, .github/scripts/effective-check-runs.jq, .github/workflows/postflight.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Regression fixture test, ShellCheck, actionlint, git diff --check, and .agents/scripts/linters-local.sh passed.

Resolves #27289


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.38 with gpt-5.6-sol spent 9m and 47,792 tokens on this with the user in an interactive session.