### PR TITLE
GH#26948: normalize release work-item prefixes

### DIFF
--- a/.agents/scripts/tests/test-version-manager-changelog-id-prefix.sh
+++ b/.agents/scripts/tests/test-version-manager-changelog-id-prefix.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+REPO_ROOT="$(mktemp -d)"
+VERSION_FILE="${REPO_ROOT}/VERSION"
+trap 'rm -rf "$REPO_ROOT"' EXIT
+
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/version-manager-changelog.sh"
+
+assert_classification() {
+	local name="$1"
+	local subject="$2"
+	local expected="$3"
+	local actual=""
+	actual=$(_classify_commit_to_category "$subject")
+	if [[ "$actual" != "$expected" ]]; then
+		printf 'FAIL %s: expected [%s], got [%s]\n' "$name" "$expected" "$actual" >&2
+		return 1
+	fi
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+assert_classification 'bracketed feature prefix' \
+	'[t18079] feat: add macOS activity cleaner audit' \
+	$'added\t- add macOS activity cleaner audit'
+assert_classification 'bracketed dotted fix prefix' \
+	'[t18080.3] fix: preserve dotted task IDs' \
+	$'fixed\t- preserve dotted task IDs'
+assert_classification 'colon task prefix' \
+	't18081: feat: preserve legacy ID-leading subjects' \
+	$'added\t- preserve legacy ID-leading subjects'
+assert_classification 'GitHub issue prefix' \
+	'GH#26948: fix: classify issue-leading subjects' \
+	$'fixed\t- classify issue-leading subjects'
+assert_classification 'plain conventional subject' \
+	'feat: retain ordinary conventional output' \
+	$'added\t- retain ordinary conventional output'
+assert_classification 'embedded ID-like text remains unclassified' \
+	'at18079] feat: do not normalize embedded text' \
+	''

--- a/.agents/scripts/tests/test-version-manager-task-id-extraction.sh
+++ b/.agents/scripts/tests/test-version-manager-task-id-extraction.sh
@@ -85,6 +85,18 @@ printf 'multi-before-keyword\n' >>work.txt
 git add work.txt
 git commit -q -m 'chore: t126 complete and t127 done'
 
+printf 'bracketed-prefix\n' >>work.txt
+git add work.txt
+git commit -q -m '[t18079] feat: add bracketed release subject support'
+
+printf 'bracketed-dotted-prefix\n' >>work.txt
+git add work.txt
+git commit -q -m '[t18080.3] fix: preserve dotted release subject IDs'
+
+printf 'embedded-prefix\n' >>work.txt
+git add work.txt
+git commit -q -m 'at18081] feat: do not extract embedded ID-like text'
+
 SCRIPT_DIR="$TEST_SCRIPTS_DIR"
 REPO_ROOT="$REPO_DIR"
 VERSION_FILE="${REPO_DIR}/VERSION"
@@ -92,7 +104,7 @@ VERSION_FILE="${REPO_DIR}/VERSION"
 source "${TEST_SCRIPTS_DIR}/version-manager-git.sh"
 
 actual=$(extract_task_ids_from_commits)
-expected=$'t123\nt124\nt125\nt126\nt127\nt3375\nt3376\nt3377.2'
+expected=$'t123\nt124\nt125\nt126\nt127\nt18079\nt18080.3\nt3375\nt3376\nt3377.2'
 assert_lines_equal 'extract_task_ids_from_commits: supports four digit and dotted task IDs' "$expected" "$actual"
 
 if [[ "$actual" != *$'t337\n'* && "$actual" != "t337" ]]; then
@@ -105,6 +117,12 @@ if [[ "$actual" != *"t9876"* ]]; then
 	print_result 'extract_task_ids_from_commits: requires leading boundary before Pattern 4 task ID' 0
 else
 	print_result 'extract_task_ids_from_commits: requires leading boundary before Pattern 4 task ID' 1 "got [$actual]"
+fi
+
+if [[ "$actual" != *"t18081"* ]]; then
+	print_result 'extract_task_ids_from_commits: rejects embedded bracket-like task IDs' 0
+else
+	print_result 'extract_task_ids_from_commits: rejects embedded bracket-like task IDs' 1 "got [$actual]"
 fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/version-manager-changelog.sh
+++ b/.agents/scripts/version-manager-changelog.sh
@@ -146,6 +146,20 @@ generate_changelog_preview() {
 	return 0
 }
 
+# Remove a complete framework work-item prefix from a release squash subject.
+_normalize_commit_work_item_prefix() {
+	local commit="$1"
+	if [[ "$commit" =~ ^\[t[0-9]+(\.[0-9]+)*\][[:space:]]+(.+)$ ]]; then
+		commit="${BASH_REMATCH[2]}"
+	elif [[ "$commit" =~ ^t[0-9]+(\.[0-9]+)*:[[:space:]]+(.+)$ ]]; then
+		commit="${BASH_REMATCH[2]}"
+	elif [[ "$commit" =~ ^GH\#[0-9]+:[[:space:]]+(.+)$ ]]; then
+		commit="${BASH_REMATCH[1]}"
+	fi
+	printf '%s\n' "$commit"
+	return 0
+}
+
 # Classify a single commit message into a changelog category.
 # Appends the formatted entry to the appropriate category variable (passed by name).
 # Arguments: commit message
@@ -156,13 +170,7 @@ _classify_commit_to_category() {
 	# Release squash subjects may begin with the framework work-item ID. Strip
 	# only a complete leading ID token so embedded strings such as "at123" are
 	# left untouched. Dotted task IDs remain valid.
-	if [[ "$commit" =~ ^\[t[0-9]+(\.[0-9]+)*\][[:space:]]+(.+)$ ]]; then
-		commit="${BASH_REMATCH[2]}"
-	elif [[ "$commit" =~ ^t[0-9]+(\.[0-9]+)*:[[:space:]]+(.+)$ ]]; then
-		commit="${BASH_REMATCH[2]}"
-	elif [[ "$commit" =~ ^GH\#[0-9]+:[[:space:]]+(.+)$ ]]; then
-		commit="${BASH_REMATCH[1]}"
-	fi
+	commit=$(_normalize_commit_work_item_prefix "$commit")
 	local clean_msg="$commit"
 
 	case "$commit" in

--- a/.agents/scripts/version-manager-changelog.sh
+++ b/.agents/scripts/version-manager-changelog.sh
@@ -153,6 +153,16 @@ generate_changelog_preview() {
 # Returns category:entry on stdout as "CATEGORY\tentry" for the caller to accumulate.
 _classify_commit_to_category() {
 	local commit="$1"
+	# Release squash subjects may begin with the framework work-item ID. Strip
+	# only a complete leading ID token so embedded strings such as "at123" are
+	# left untouched. Dotted task IDs remain valid.
+	if [[ "$commit" =~ ^\[t[0-9]+(\.[0-9]+)*\][[:space:]]+(.+)$ ]]; then
+		commit="${BASH_REMATCH[2]}"
+	elif [[ "$commit" =~ ^t[0-9]+(\.[0-9]+)*:[[:space:]]+(.+)$ ]]; then
+		commit="${BASH_REMATCH[2]}"
+	elif [[ "$commit" =~ ^GH\#[0-9]+:[[:space:]]+(.+)$ ]]; then
+		commit="${BASH_REMATCH[1]}"
+	fi
 	local clean_msg="$commit"
 
 	case "$commit" in

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -210,6 +210,13 @@ extract_task_ids_from_commits() {
 	while IFS= read -r commit; do
 		[[ -z "$commit" ]] && continue
 
+		# Pattern 0: Framework squash subjects with a complete leading task ID.
+		# Brackets provide an explicit boundary and avoid matching ID-like text
+		# embedded in unrelated words. Dotted task IDs remain supported.
+		if [[ "$commit" =~ ^\[(t[0-9]+(\.[0-9]+)*)\]([[:space:]]|$) ]]; then
+			task_ids+=("${BASH_REMATCH[1]}")
+		fi
+
 		# Pattern 1: Conventional commits with task ID in scope
 		# e.g., feat(t001):, fix(t3375):, docs(t003.1):, refactor(t004):
 		if [[ "$commit" =~ ^(feat|fix|docs|refactor|perf|test|chore|style|build|ci)\((t[0-9]+(\.[0-9]+)*)\): ]]; then


### PR DESCRIPTION
## Summary

- Normalize complete bracketed, dotted, and GitHub issue work-item prefixes before conventional-commit changelog classification.
- Extract complete bracketed task IDs for release completion without matching embedded ID-like text.
- Add focused regression coverage for prefixed and plain conventional subjects.

## Testing

- `bash .agents/scripts/tests/test-version-manager-task-id-extraction.sh`
- `bash .agents/scripts/tests/test-version-manager-changelog-id-prefix.sh`
- `shellcheck .agents/scripts/version-manager-changelog.sh .agents/scripts/version-manager-git.sh .agents/scripts/tests/test-version-manager-task-id-extraction.sh .agents/scripts/tests/test-version-manager-changelog-id-prefix.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

- Self-assessed: low-risk release parsing and test changes.

Resolves #26948

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.39 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 13m and 85,152 tokens on this with the user in an interactive session. Overall, 1d 11h since this issue was created.
