### PR TITLE
GH#26945: dispatch subagent test suites through commands

### DIFF
--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -179,6 +179,7 @@ check_opencode_server() {
 #   $2 - agent name (optional)
 #   $3 - model override (optional)
 #   $4 - timeout in seconds (optional)
+#   $5 - slash command (optional; required for subagent suites)
 # Returns:
 #   Response text on stdout
 #######################################
@@ -187,10 +188,11 @@ run_prompt() {
 	local agent="${2:-}"
 	local model="${3:-${AGENT_TEST_MODEL:-}}"
 	local timeout="${4:-$DEFAULT_TIMEOUT}"
+	local command="${5:-}"
 
 	case "$AI_CLI" in
 	opencode)
-		run_prompt_opencode "$prompt" "$agent" "$model" "$timeout"
+		run_prompt_opencode "$prompt" "$agent" "$model" "$timeout" "$command"
 		;;
 	*)
 		log_fail "No AI CLI available. Install opencode: https://opencode.ai"
@@ -208,12 +210,16 @@ run_prompt_opencode() {
 	local agent="$2"
 	local model="$3"
 	local timeout="$4"
+	local command="${5:-}"
 
-	# Try server mode first (attach to running server), fall back to standalone CLI
-	if check_opencode_server; then
+	# Slash commands are a CLI dispatch contract; the server message endpoint does
+	# not accept a command selector.
+	if [[ -n "$command" ]]; then
+		run_prompt_opencode_cli "$prompt" "$agent" "$model" "$timeout" "$command"
+	elif check_opencode_server; then
 		run_prompt_opencode_server "$prompt" "$agent" "$model" "$timeout"
 	else
-		run_prompt_opencode_cli "$prompt" "$agent" "$model" "$timeout"
+		run_prompt_opencode_cli "$prompt" "$agent" "$model" "$timeout" ""
 	fi
 }
 
@@ -298,10 +304,13 @@ run_prompt_opencode_cli() {
 	local agent="$2"
 	local model="$3"
 	local timeout="$4"
+	local command="${5:-}"
 
 	local cmd=(opencode run --format json)
 
-	if [[ -n "$agent" ]]; then
+	if [[ -n "$command" ]]; then
+		cmd+=(--command "$command")
+	elif [[ -n "$agent" ]]; then
 		cmd+=(--agent "$agent")
 	fi
 
@@ -309,13 +318,15 @@ run_prompt_opencode_cli() {
 		cmd+=(-m "$model")
 	fi
 
-	local stderr_file raw_output
+	local stderr_file raw_output json_output
 	stderr_file=$(mktemp)
 	raw_output=$(mktemp)
+	json_output=$(mktemp)
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
 	push_cleanup "rm -f '${stderr_file}'"
 	push_cleanup "rm -f '${raw_output}'"
+	push_cleanup "rm -f '${json_output}'"
 
 	local exit_code=0
 	timeout_sec "${timeout}" "${cmd[@]}" "$prompt" >"$raw_output" 2>"$stderr_file" || {
@@ -325,33 +336,44 @@ run_prompt_opencode_cli() {
 		elif [[ -s "$stderr_file" ]]; then
 			echo "[ERROR: $(cat "$stderr_file")]"
 		fi
-		rm -f "$stderr_file" "$raw_output"
+		rm -f "$stderr_file" "$raw_output" "$json_output"
 		return $exit_code
 	}
+
+	if [[ -z "$command" && -n "$agent" ]] &&
+		grep -Eqi 'subagent|fall(ing)? back.*(default|primary)|default.*agent' "$stderr_file"; then
+		echo "[ERROR: requested agent '${agent}' was not dispatched; use a suite command for subagents]"
+		rm -f "$stderr_file" "$raw_output" "$json_output"
+		return 1
+	fi
+
+	# OpenCode may mix ANSI warnings with NDJSON on stdout. Keep only complete
+	# JSON events so one warning cannot trigger a jq parse-error cascade.
+	jq -Rrc 'fromjson?' "$raw_output" >"$json_output"
 
 	# Check for error events in the JSON stream
 	local error_msg
 	error_msg=$(jq -r 'select(.type == "error") | .error.data.message // .error.message // empty' \
-		"$raw_output" 2>/dev/null | head -1)
+		"$json_output" 2>/dev/null | head -1)
 
 	if [[ -n "$error_msg" ]]; then
 		echo "[ERROR: ${error_msg}]"
-		rm -f "$stderr_file" "$raw_output"
+		rm -f "$stderr_file" "$raw_output" "$json_output"
 		return 1
 	fi
 
 	# Extract text from JSON event stream
 	# Each line is a JSON event; text content has type="text" with .part.text
 	local result
-	result=$(jq -r 'select(.type == "text") | .part.text // empty' "$raw_output" 2>/dev/null |
+	result=$(jq -r 'select(.type == "text") | .part.text // empty' "$json_output" 2>/dev/null |
 		tr -d '\0')
 
 	if [[ -z "$result" ]]; then
-		# Fallback: try to extract any text-like content
-		result=$(cat "$raw_output")
+		# Fallback: try other structured text-like content.
+		result=$(jq -r '.part.text // .content // .text // empty' "$json_output" 2>/dev/null)
 	fi
 
-	rm -f "$stderr_file" "$raw_output"
+	rm -f "$stderr_file" "$raw_output" "$json_output"
 	echo "$result"
 	return 0
 }
@@ -470,9 +492,10 @@ _cmd_run_print_header() {
 #   $2  - test index (0-based)
 #   $3  - test count (total)
 #   $4  - suite agent (default)
-#   $5  - suite model (default)
-#   $6  - suite timeout (default)
-#   $7  - current results JSON array
+#   $5  - suite command (optional)
+#   $6  - suite model (default)
+#   $7  - suite timeout (default)
+#   $8  - current results JSON array
 # Outputs:
 #   File descriptor 3: updated results JSON array followed by outcome
 #   Standard output: human-readable progress and validation diagnostics
@@ -482,9 +505,10 @@ _cmd_run_execute_test() {
 	local i="$2"
 	local test_count="$3"
 	local suite_agent="$4"
-	local suite_model="$5"
-	local suite_timeout="$6"
-	local results="$7"
+	local suite_command="$5"
+	local suite_model="$6"
+	local suite_timeout="$7"
+	local results="$8"
 
 	local test_id
 	test_id=$(echo "$test_json" | jq -r '.id // "test-'"$i"'"')
@@ -522,7 +546,7 @@ _cmd_run_execute_test() {
 	local response=""
 	local run_status="pass"
 
-	response=$(run_prompt "$test_prompt" "$test_agent" "$test_model" "$test_timeout" 2>&1) || {
+	response=$(run_prompt "$test_prompt" "$test_agent" "$test_model" "$test_timeout" "$suite_command" 2>&1) || {
 		run_status="error"
 	}
 
@@ -793,8 +817,8 @@ _cmd_run_emit_json_metrics() {
 #######################################
 # Capture one test's machine result while routing human output separately
 # Arguments:
-#   $1-$7 - forwarded to _cmd_run_execute_test
-#   $8    - whether JSON-only output is enabled
+#   $1-$8 - forwarded to _cmd_run_execute_test
+#   $9    - whether JSON-only output is enabled
 # Outputs:
 #   Updated results JSON array followed by outcome on stdout
 #######################################
@@ -804,10 +828,11 @@ _cmd_run_capture_test() {
 		local test_index="$2"
 		local test_count="$3"
 		local suite_agent="$4"
-		local suite_model="$5"
-		local suite_timeout="$6"
-		local results="$7"
-		local json_output="$8"
+		local suite_command="$5"
+		local suite_model="$6"
+		local suite_timeout="$7"
+		local results="$8"
+		local json_output="$9"
 
 		exec 3>&1
 		if [[ "$json_output" == "false" ]]; then
@@ -817,7 +842,7 @@ _cmd_run_capture_test() {
 		fi
 		_cmd_run_execute_test \
 			"$test_json" "$test_index" "$test_count" \
-			"$suite_agent" "$suite_model" "$suite_timeout" \
+			"$suite_agent" "$suite_command" "$suite_model" "$suite_timeout" \
 			"$results"
 	)
 	return $?
@@ -855,10 +880,11 @@ cmd_run() {
 	local suite
 	suite=$(cat "$test_file")
 
-	local suite_name suite_desc suite_agent suite_model suite_timeout test_count
+	local suite_name suite_desc suite_agent suite_command suite_model suite_timeout test_count
 	suite_name=$(echo "$suite" | jq -r '.name // "unnamed"')
 	suite_desc=$(echo "$suite" | jq -r '.description // ""')
 	suite_agent=$(echo "$suite" | jq -r '.agent // ""')
+	suite_command=$(echo "$suite" | jq -r '.command // ""')
 	suite_model=$(echo "$suite" | jq -r '.model // ""')
 	suite_timeout=$(echo "$suite" | jq -r '.timeout // 120')
 	test_count=$(echo "$suite" | jq '.tests | length')
@@ -885,7 +911,7 @@ cmd_run() {
 		local exec_output outcome
 		exec_output=$(_cmd_run_capture_test \
 			"$test_json" "$i" "$test_count" \
-			"$suite_agent" "$suite_model" "$suite_timeout" \
+			"$suite_agent" "$suite_command" "$suite_model" "$suite_timeout" \
 			"$results" "$json_output")
 		results=$(echo "$exec_output" | sed '$d')
 		outcome=$(echo "$exec_output" | tail -n 1)

--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -212,10 +212,12 @@ run_prompt_opencode() {
 	local timeout="$4"
 	local command="${5:-}"
 
-	# Slash commands are a CLI dispatch contract; the server message endpoint does
-	# not accept a command selector.
+	# Agent and slash-command selectors are CLI dispatch contracts; the server
+	# message endpoint accepts neither selector.
 	if [[ -n "$command" ]]; then
 		run_prompt_opencode_cli "$prompt" "$agent" "$model" "$timeout" "$command"
+	elif [[ -n "$agent" ]]; then
+		run_prompt_opencode_cli "$prompt" "$agent" "$model" "$timeout" ""
 	elif check_opencode_server; then
 		run_prompt_opencode_server "$prompt" "$agent" "$model" "$timeout"
 	else
@@ -341,7 +343,8 @@ run_prompt_opencode_cli() {
 	}
 
 	if [[ -z "$command" && -n "$agent" ]] &&
-		grep -Eqi 'subagent|fall(ing)? back.*(default|primary)|default.*agent' "$stderr_file"; then
+		grep -Eqi 'subagent|fall(ing)? back.*(default|primary)|default.*agent' \
+			"$stderr_file" "$raw_output"; then
 		echo "[ERROR: requested agent '${agent}' was not dispatched; use a suite command for subagents]"
 		rm -f "$stderr_file" "$raw_output" "$json_output"
 		return 1

--- a/.agents/scripts/tests/test-agent-test-command-dispatch.sh
+++ b/.agents/scripts/tests/test-agent-test-command-dispatch.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$TEST_SCRIPT_DIR/../../.." && pwd)" || exit
+TEST_ROOT=$(mktemp -d)
+export HOME="$TEST_ROOT/home"
+export AGENT_TEST_CLI="opencode"
+mkdir -p "$HOME" "$TEST_ROOT/bin"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+cat >"$TEST_ROOT/bin/opencode" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$OPENCODE_INVOCATIONS"
+if [[ " $* " == *" --agent subagent-only "* ]]; then
+  printf '%s\n' 'Warning: requested agent is a subagent; falling back to default agent' >&2
+fi
+printf '\033[33mwarning before json\033[0m\n'
+printf '%s\n' '{"type":"text","part":{"text":"DISPATCH_OK=yes"}}'
+exit 0
+MOCK
+chmod +x "$TEST_ROOT/bin/opencode"
+export PATH="$TEST_ROOT/bin:$PATH"
+export OPENCODE_INVOCATIONS="$TEST_ROOT/invocations"
+
+# shellcheck source=../agent-test-helper.sh
+source "$REPO_ROOT/.agents/scripts/agent-test-helper.sh"
+check_opencode_server() { return 1; }
+_cmd_run_sync_pattern_tracker() { return 0; }
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+command_suite="$TEST_ROOT/command-suite.json"
+cat >"$command_suite" <<'JSON'
+{"name":"command-dispatch","agent":"subagent-only","command":"aidevops-specialist","tests":[{"id":"dispatch","prompt":"test prompt","expect_contains":["DISPATCH_OK=yes"]}]}
+JSON
+cmd_run "$command_suite" >/dev/null 2>&1 || fail "command-dispatched suite failed"
+grep -q -- '--command aidevops-specialist' "$OPENCODE_INVOCATIONS" ||
+	fail "suite command did not reach opencode"
+if grep -q -- '--agent subagent-only' "$OPENCODE_INVOCATIONS"; then
+	fail "command dispatch also passed the subagent selector"
+fi
+
+primary_response=$(run_prompt_opencode_cli "primary prompt" "Build+" "" 10 "")
+[[ "$primary_response" == "DISPATCH_OK=yes" ]] || fail "mixed output was not reduced to text events"
+grep -q -- '--agent Build+' "$OPENCODE_INVOCATIONS" || fail "primary agent behavior changed"
+
+subagent_status=0
+subagent_response=$(run_prompt_opencode_cli "subagent prompt" "subagent-only" "" 10 "") || subagent_status=$?
+[[ $subagent_status -ne 0 ]] || fail "subagent fallback was silently accepted"
+[[ "$subagent_response" == *"use a suite command"* ]] || fail "subagent rejection lacked actionable guidance"
+
+printf '%s\n' "PASS: agent test command dispatch is explicit and warning-safe"

--- a/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
+++ b/.agents/scripts/tests/test-agent-test-helper-output-channel.sh
@@ -20,7 +20,8 @@ run_prompt() {
 	local agent="$2"
 	local model="$3"
 	local timeout="$4"
-	: "$agent" "$model" "$timeout"
+	local command="${5:-}"
+	: "$agent" "$model" "$timeout" "$command"
 
 	case "$prompt" in
 	timeout)
@@ -48,7 +49,7 @@ direct_stdout="$TEST_ROOT/direct.stdout"
 direct_stderr="$TEST_ROOT/direct.stderr"
 direct_test='{"id":"direct-call","prompt":"direct","expect_contains":["mock response"]}'
 {
-	_cmd_run_capture_test "$direct_test" 0 1 "" "" 1 "[]" false
+	_cmd_run_capture_test "$direct_test" 0 1 "" "" "" 1 "[]" false
 	printf '%s\n' "stdout-still-open"
 } >"$direct_stdout" 2>"$direct_stderr"
 grep -q '^stdout-still-open$' "$direct_stdout" ||
@@ -61,7 +62,7 @@ propagated_status=0
 	_cmd_run_execute_test() {
 		return 7
 	}
-	_cmd_run_capture_test "$direct_test" 0 1 "" "" 1 "[]" true
+	_cmd_run_capture_test "$direct_test" 0 1 "" "" "" 1 "[]" true
 ) || propagated_status=$?
 [[ $propagated_status -eq 7 ]] ||
 	fail "capture helper did not propagate the execution status"
@@ -77,7 +78,7 @@ TEST_AGENT_HELPER="$REPO_ROOT/.agents/scripts/agent-test-helper.sh" bash -c '
 		printf "%s\n" "unexpected-continuation" >&3
 		return 0
 	}
-	_cmd_run_capture_test "{}" 0 1 "" "" 1 "[]" true
+	_cmd_run_capture_test "{}" 0 1 "" "" "" 1 "[]" true
 	printf "%s\n" "errexit-survived"
 ' >"$errexit_stdout" 2>&1
 errexit_status=$?

--- a/.agents/tools/build-agent/agent-testing.md
+++ b/.agents/tools/build-agent/agent-testing.md
@@ -27,7 +27,8 @@ tools:
 - **User suites**: `~/.aidevops/.agent-workspace/agent-tests/suites/`
 - **Results/Baselines**: `~/.aidevops/.agent-workspace/agent-tests/{results,baselines}/`
 - **CLI**: Auto-detects `opencode` (override with `AGENT_TEST_CLI`)
-- **Flow**: Loads JSON suite → sends prompts via `opencode run --format json` (CLI) or `opencode serve` (HTTP) → validates responses
+- **Flow**: Loads JSON suite → sends primary-agent prompts via `opencode run --format json` (CLI) or `opencode serve` (HTTP) → validates responses
+- **Subagent suites**: Set suite-level `"command": "aidevops-<name>"`; each prompt runs through `opencode run --command`. Do not use `agent` alone for a `mode: subagent` target because OpenCode falls back to its primary agent.
 - **Server mode**: `POST /session` → `POST /session/:id/message` → extract text → delete. Override host/port with `OPENCODE_HOST`/`OPENCODE_PORT`
 - **When to use**: Validate agent changes before merging, regression-test after AGENTS.md/subagent edits, compare behavior across models, smoke-test after framework updates
 
@@ -54,6 +55,7 @@ tools:
 ```
 
 Per-test `agent`, `model`, `timeout` override suite-level defaults.
+`command` is suite-level and takes precedence over `agent` for dispatch.
 
 ### Validation Fields
 


### PR DESCRIPTION
## Summary

- Honor suite-level `command` selectors through `opencode run --command`.
- Reject requested subagents when OpenCode attempts primary-agent fallback.
- Parse mixed warning and NDJSON output without cascading `jq` errors.
- Add deterministic fake-CLI coverage and document primary-agent versus subagent suites.

## Testing

- `shellcheck .agents/scripts/agent-test-helper.sh .agents/scripts/tests/test-agent-test-command-dispatch.sh .agents/scripts/tests/test-agent-test-helper-output-channel.sh`
- `bash .agents/scripts/tests/test-agent-test-command-dispatch.sh`
- `bash .agents/scripts/tests/test-agent-test-helper-output-channel.sh`
- Live `agent-test-helper.sh run macos-activity-cleaner` reached command dispatch; OpenCode then returned upstream `Unexpected server error` events.

## Runtime Testing

Runtime dispatch path exercised; deterministic fake-CLI tests verify selector and parser behavior.

Resolves #26945

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.40 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 37m and 244,334 tokens on this with the user in an interactive session.
