### PR TITLE
fix: bound cross-runner worker retries

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -33,7 +33,7 @@ claim loops:
 
 | Signal | Meaning | Expected next evidence |
 |---|---|---|
-| `DISPATCH_CLAIM ...` | A runner entered the cross-runner claim window. | Either `CLAIM_WON` in pulse logs followed by a `Dispatching worker` comment, or a later `CLAIM_DEFERRED` / `CLAIM_LOST` diagnostic. |
+| `DISPATCH_CLAIM ...` | A runner entered the cross-runner claim window. Only the winning/oldest claim remains public; losing claims are removed. | `CLAIM_WON` in pulse logs followed by a `Dispatching worker` comment. `CLAIM_DEFERRED` / `CLAIM_LOST` remain runner-log diagnostics rather than additional issue comments. |
 | `Dispatching worker ...` with no later terminal marker | Active worker ownership. It blocks re-dispatch for the normal dispatch TTL, then for the extended non-terminal worker window (`DISPATCH_ACTIVE_WORKER_MAX_AGE`, default 7200s). | Worker log growth, PR creation, `MERGE_SUMMARY`, `CLAIM_RELEASED`, `Worker failed`, or watchdog output. |
 | Draft/open PR or recent issue/PR timeline event after dispatch | Natural liveness signal. Prefer these durable events over synthetic heartbeat comments. | Continue from the referenced branch/PR if the worker later goes silent. Stale recovery uses the latest visible issue activity and targeted open-PR activity before reclaiming. |
 | `DISPATCH_CLAIM ... reason=stale_worker_takeover prior_dispatch_age_s=<n> no_terminal=true` | A later runner is deliberately taking over after the extended non-terminal worker window expired. This is not a bare duplicate claim. | A fresh `Dispatching worker` comment or a deterministic skip/failure reason. |
@@ -47,10 +47,17 @@ comment. When silence is extraordinary, a signal comment should include only the
 current mode, branch/PR/commit if known, verification state, and the next useful
 recovery step.
 
-A repeated bare `DISPATCH_CLAIM` without `Dispatching worker`, `CLAIM_DEFERRED`,
+A repeated bare `DISPATCH_CLAIM` without `Dispatching worker`,
 `reason=stale_worker_takeover`, or a terminal marker is still a claim lifecycle
 bug. Diagnose with `dispatch-dedup-helper.sh is-assigned <issue> <slug>
 <runner>` and the pulse dispatch stage ledger before attributing a worker outage.
+
+Stale recovery is globally bounded by the GitHub-backed recovery markers. The
+default threshold of two includes silent/phantom assignments: a stale timeout is
+itself terminal no-progress evidence even when a crashed launcher omitted its
+terminal marker. The first recovery emits one combined recovery/tick comment;
+the second applies `needs-maintainer-review`. An open PR is durable progress, so
+stale recovery preserves its ownership and emits no synthetic reset comment.
 
 ## Manual Worker Launch
 
@@ -100,6 +107,9 @@ Safety boundaries:
 - Repair feedback is deduplicated by linked issue + PR + head SHA marker
   (`<!-- ci-feedback:PR...:SHA... -->`) so each stuck head queues at most one
   repair action.
+- Required and advisory terminal failures are unioned into the same feedback
+  dossier. A required failure must not hide a simultaneous advisory failure and
+  force another worker/PR pass.
 - Failed checks from older head SHAs are stale symptoms. Ignore them for repair
   routing and continue monitoring the latest head SHA.
 - Superseded active runs may be cancelled only when the operator/helper can

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -996,9 +996,9 @@ _apply_ignore_filter() {
 }
 
 #######################################
-# t2422: Post a CLAIM_DEFERRED audit comment when losing a close-window race.
-# The comment makes the tiebreaker outcome visible on the issue timeline so
-# operators grepping for coordination decisions can reconstruct the race.
+# Record a close-window loss in runner logs without adding another issue comment.
+# The winning DISPATCH_CLAIM is the durable ownership record; loser comments
+# are deleted below so multi-runner contention cannot inflate issue threads.
 #
 # Args:
 #   $1 = issue number
@@ -1009,8 +1009,7 @@ _apply_ignore_filter() {
 #   $6 = winner nonce
 #   $7 = |delta| in seconds between claim timestamps
 # Returns:
-#   exit 0 on success (comment posted or skipped intentionally)
-#   exit 1 on post failure (non-fatal — loser still backs off regardless)
+#   exit 0 after the local audit record is emitted
 #######################################
 _post_deferred() {
 	local issue_number="$1"
@@ -1021,17 +1020,18 @@ _post_deferred() {
 	local winner_nonce="$6"
 	local delta_s="$7"
 
-	local ts body
+	local ts
 	ts=$(_now_utc)
-	body="CLAIM_DEFERRED runner=${our_runner} nonce=${our_nonce} ts=${ts} deferring_to_runner=${winner_runner} deferring_to_nonce=${winner_nonce} delta_s=${delta_s}"
+	printf 'CLAIM_DEFERRED runner=%s nonce=%s ts=%s deferring_to_runner=%s deferring_to_nonce=%s delta_s=%s issue=#%s repo=%s\n' \
+		"$our_runner" "$our_nonce" "$ts" "$winner_runner" "$winner_nonce" "$delta_s" "$issue_number" "$repo_slug" >&2
+	return 0
+}
 
-	# Uses `gh issue comment` rather than `gh api repos/.../comments` to
-	# avoid duplicating the pre-existing comments-API literal (t2422 was
-	# flagged by the string-literal ratchet).
-	if ! gh issue comment "$issue_number" --repo "$repo_slug" --body "$body" >/dev/null 2>&1; then
-		echo "Warning: failed to post CLAIM_DEFERRED comment on #${issue_number} in ${repo_slug} (non-fatal)" >&2
-		return 1
-	fi
+_delete_losing_claim_comment() {
+	local repo_slug="$1"
+	local comment_id="$2"
+	[[ "$comment_id" =~ ^[0-9]+$ ]] || return 0
+	gh api "repos/${repo_slug}/issues/comments/${comment_id}" --method DELETE >/dev/null 2>&1 || true
 	return 0
 }
 
@@ -1093,7 +1093,7 @@ _resolve_claim_race_result() {
 	local claim_count=""
 	claim_count=$(printf '%s' "$claims" | jq 'length' 2>/dev/null) || claim_count=0
 	if [[ "$claim_count" -eq 0 ]]; then
-		echo "CLAIM_ERROR: no claims found after posting — proceeding (fail-open)" >&2
+		echo "CLAIM_ERROR: no claims found after posting — blocking dispatch (fail-closed)" >&2
 		return 2
 	fi
 
@@ -1111,13 +1111,15 @@ _resolve_claim_race_result() {
 		return 0
 	fi
 	if [[ "$oldest_runner" == "$runner" && ( "$oldest_device" == "$LEGACY_DEVICE_MARKER" || "$oldest_device" == "$our_device" ) && "$oldest_nonce" != "$nonce" ]]; then
-		printf 'CLAIM_STALE_SELF: runner=%s found own prior claim on issue #%s (age=%ss) — backing off (claim retained for audit)\n' \
+		_delete_losing_claim_comment "$repo_slug" "$comment_id"
+		printf 'CLAIM_STALE_SELF: runner=%s found own prior claim on issue #%s (age=%ss) — backing off (new claim removed)\n' \
 			"$runner" "$issue_number" "$oldest_age_seconds"
 		return 1
 	fi
 	_handle_close_window_loss "$issue_number" "$repo_slug" "$runner" "$nonce" \
 		"$oldest_runner" "$claims" || true
-	printf 'CLAIM_LOST: runner=%s lost to %s on issue #%s — backing off (both claims retained for audit)\n' \
+	_delete_losing_claim_comment "$repo_slug" "$comment_id"
+	printf 'CLAIM_LOST: runner=%s lost to %s on issue #%s — backing off (losing claim removed)\n' \
 		"$runner" "$oldest_runner" "$issue_number"
 	return 1
 }
@@ -1130,8 +1132,8 @@ _resolve_claim_race_result() {
 #   2. Sleep consensus window
 #   3. Fetch all claim comments (sorted by [created_at, nonce] — t2422 tiebreaker)
 #   4. If this runner's claim is the oldest active claim → won
-#   5. If another runner's claim is older → lost; if delta <= TIEBREAKER_WINDOW,
-#      post CLAIM_DEFERRED audit comment
+#   5. If another runner's claim is older → remove our losing claim and back off;
+#      record close-window contention only in runner logs.
 #
 # Args:
 #   $1 = issue number
@@ -1140,7 +1142,7 @@ _resolve_claim_race_result() {
 # Returns:
 #   exit 0 = claim won (safe to dispatch)
 #   exit 1 = claim lost (do NOT dispatch)
-#   exit 2 = error (fail-open — caller should proceed)
+#   exit 2 = coordination error (fail closed; caller must not dispatch)
 #######################################
 cmd_claim() {
 	local issue_number="${1:-}"
@@ -1183,7 +1185,7 @@ cmd_claim() {
 	claim_reason=$(_detect_stale_worker_takeover_reason "$issue_number" "$repo_slug")
 
 	comment_id=$(_post_claim "$issue_number" "$repo_slug" "$runner" "$nonce" "$ts" "$claim_reason") || {
-		echo "CLAIM_ERROR: failed to post claim — proceeding (fail-open)" >&2
+		echo "CLAIM_ERROR: failed to post claim — blocking dispatch (fail-closed)" >&2
 		return 2
 	}
 
@@ -1193,7 +1195,7 @@ cmd_claim() {
 	# Step 3: Fetch all claims
 	local claims
 	claims=$(_fetch_claims "$issue_number" "$repo_slug" "$runner") || {
-		echo "CLAIM_ERROR: failed to fetch claims — proceeding (fail-open)" >&2
+		echo "CLAIM_ERROR: failed to fetch claims — blocking dispatch (fail-closed)" >&2
 		return 2
 	}
 
@@ -1293,7 +1295,7 @@ _handle_close_window_loss() {
 # Returns:
 #   exit 0 = active claim exists (do NOT dispatch — someone is already claiming)
 #   exit 1 = no active claim (safe to proceed to claim step)
-#   exit 2 = error (fail-open — proceed)
+#   exit 2 = coordination error (caller must fail closed)
 #######################################
 cmd_check() {
 	local issue_number="${1:-}"
@@ -1314,7 +1316,7 @@ cmd_check() {
 
 	local claims
 	claims=$(_fetch_claims "$issue_number" "$repo_slug") || {
-		# Fail-open on API error
+		# Callers treat coordination read errors as a dispatch block.
 		return 2
 	}
 
@@ -1349,13 +1351,13 @@ Usage:
     Attempt to claim an issue for dispatch.
     Exit 0 = claim won (safe to dispatch)
     Exit 1 = claim lost (do NOT dispatch)
-    Exit 2 = error (fail-open — proceed with dispatch)
+    Exit 2 = coordination error (fail closed; do NOT dispatch)
 
   dispatch-claim-helper.sh check <issue-number> <repo-slug>
     Query whether an active claim exists on this issue.
     Exit 0 = active claim exists (do NOT dispatch)
     Exit 1 = no active claim (safe to proceed to claim step)
-    Exit 2 = error (fail-open — proceed)
+    Exit 2 = coordination error (fail closed; do NOT dispatch)
 
   dispatch-claim-helper.sh help
     Show this help.
@@ -1373,7 +1375,7 @@ Protocol:
   2. Waits DISPATCH_CLAIM_WINDOW seconds to allow other runners to post
   3. Fetches all claim comments on the issue
   4. Oldest active claim wins (claims older than DISPATCH_CLAIM_MAX_AGE are ignored)
-     — others back off; ALL claim comments are retained as audit trail (GH#17503)
+     — others back off and remove their losing claim comments
   5. Winner proceeds with dispatch; claim blocks re-dispatch until TTL expires
 
 Examples:
@@ -1382,7 +1384,7 @@ Examples:
   #   dispatch-claim-helper.sh claim 42 owner/repo "\$RUNNER"
   #   Exit 0 → won claim, proceed with dispatch
   #   Exit 1 → lost claim, back off
-  #   Exit 2 → error, proceed (fail-open)
+  #   Exit 2 → coordination error, block this dispatch cycle
 HELP
 	return 0
 }

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -391,6 +391,8 @@ _stale_recovery_apply() {
 	local stale_assignees="$3"
 	local reason="$4"
 	local expected_dispatch_ts="${5:-}"
+	local recovery_tick="${6:-}"
+	local recovery_threshold="${7:-}"
 
 	local saved_ifs="${IFS:-}"
 	local -a assignee_arr=()
@@ -417,11 +419,13 @@ _stale_recovery_apply() {
 	gh_issue_comment "$issue_number" --repo "$repo_slug" \
 		--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
 <!-- WORKER_SUPERSEDED runners=${stale_assignees} ts=${_now_ts} -->
+<!-- stale-recovery-tick:${recovery_tick:-1} -->
 **Stale assignment recovered** (GH#15060)
 
 Previously assigned to: ${stale_assignees}
 Reason: ${reason}
 Threshold: ${STALE_ASSIGNMENT_THRESHOLD_SECONDS}s
+Global recovery attempt: ${recovery_tick:-1}/${recovery_threshold:-unknown}
 
 The assigned runner had no active worker process and produced no progress within the threshold. Unassigned and relabeled \`status:available\` for re-dispatch.
 
@@ -439,15 +443,12 @@ _This recovery prevents the orphaned-assignment deadlock where offline runners p
 # Decision flow (t2008 escalation check):
 #   1. Load threshold from config (default 2).
 #   2. Count prior non-reset tick comments from the GitHub issue comment log.
-#   3. Find the latest dispatch marker and terminal worker evidence in that same
-#      GitHub comment log (the cross-machine coordination source).
+#   3. Find the latest dispatch marker in that same GitHub comment log.
 #   4. Look up any open PR referencing this issue.
-#      - If an open PR exists: reset tick counter (progress is being made),
-#        continue to normal recovery.
-#      - Else if prior_ticks >= threshold and the latest dispatch attempt has
-#        terminal evidence: escalate to needs-maintainer-review and return
-#        immediately (no normal recovery).
-#      - Else: increment the tick counter and continue to normal recovery.
+#      - If an open PR exists: preserve ownership and stop; the PR is progress.
+#      - Else increment the global recovery count. At the threshold, escalate
+#        immediately. A stale assignment is itself terminal no-progress evidence.
+#      - Under threshold, record the tick inside the single recovery comment.
 #   5. Normal recovery: unassign stale users, set status:available, post audit.
 #
 # Args:
@@ -467,43 +468,25 @@ _recover_stale_assignment() {
 	# resetting to status:available and apply needs-maintainer-review instead.
 	# Counter is stored as structured comment markers for cross-runner correctness.
 	# Config: .agents/configs/dispatch-stale-recovery.conf
-	local _threshold _prior_ticks _open_pr _comments_pages _latest_dispatch_ts _terminal_evidence=false
+	local _threshold _prior_ticks _open_pr _comments_pages _latest_dispatch_ts _next_tick
 	_threshold=$(_stale_recovery_load_threshold)
 	_comments_pages=$(_stale_recovery_fetch_comments_pages "$issue_number" "$repo_slug")
 	_prior_ticks=$(_stale_recovery_count_ticks_from_pages "$_comments_pages")
 	_latest_dispatch_ts=$(_stale_recovery_latest_dispatch_ts_from_pages "$_comments_pages")
-	if _stale_recovery_has_terminal_evidence_since "$_comments_pages" "$_latest_dispatch_ts"; then
-		_terminal_evidence=true
-	fi
 	_open_pr=$(_stale_recovery_find_open_pr "$issue_number" "$repo_slug")
 	if [[ -n "$_open_pr" ]]; then
-		# Open PR exists — counter resets; post a reset marker and allow normal recovery
-		gh_issue_comment "$issue_number" --repo "$repo_slug" \
-			--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
-<!-- stale-recovery-tick:0 (reset: open PR #${_open_pr} detected) -->
-Stale recovery tick reset — open PR #${_open_pr} detected (t2008)
-<!-- ops:end -->" \
-			2>/dev/null || true
-	elif [[ "$_prior_ticks" -ge "$_threshold" && "$_terminal_evidence" == "true" ]]; then
-		# Threshold reached with explicit worker terminal evidence — escalate and
-		# bail out (no normal recovery). GH#22780: Do not suspend a fresh multi-runner
-		# dispatch solely because GitHub has been quiet for one stale window.
-		_stale_recovery_escalate "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_threshold" "$_prior_ticks" "$_latest_dispatch_ts"
+		printf 'STALE_PROGRESS_PRESERVED: issue #%s in %s — open PR #%s is durable progress\n' \
+			"$issue_number" "$repo_slug" "$_open_pr"
 		return 0
-	else
-		# Under threshold, or over threshold without terminal worker evidence —
-		# increment the GitHub-backed counter and continue normal recovery.
-		local _next_tick=$((_prior_ticks + 1))
-		gh_issue_comment "$issue_number" --repo "$repo_slug" \
-			--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
-<!-- stale-recovery-tick:${_next_tick} -->
-Stale recovery tick ${_next_tick}/${_threshold} (t2008)
-<!-- ops:end -->" \
-			2>/dev/null || true
+	fi
+	_next_tick=$((_prior_ticks + 1))
+	if [[ "$_next_tick" -ge "$_threshold" ]]; then
+		_stale_recovery_escalate "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_threshold" "$_next_tick" "$_latest_dispatch_ts"
+		return 0
 	fi
 	# ── End stale-recovery escalation check ──────────────────────────────
 
-	_stale_recovery_apply "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_latest_dispatch_ts"
+	_stale_recovery_apply "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_latest_dispatch_ts" "$_next_tick" "$_threshold"
 	return 0
 }
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -538,6 +538,19 @@ EOF
 	return 0
 }
 
+_dlw_first_pass_completion_contract() {
+	cat <<'EOF'
+
+First-pass completion contract:
+1. Before editing, verify the issue is still open and not already satisfied by the default branch, an open/closed PR, or a pushed issue branch. Reuse salvageable commits instead of restarting.
+2. Treat prior structured CI/review feedback in the issue body as cumulative evidence. Address every terminal failing check, including advisory checks, not only the first required failure.
+3. Validate the stated target files and verification commands against the current dependency/runtime versions before implementation.
+4. After the first coherent commit, push and create a draft PR early so progress is durable and visible to every runner; continue on that PR through local and remote verification.
+5. Do not post routine dispatch, stale, or progress comments. Prefer commits, the PR, check runs, and one final completion or blocker dossier.
+EOF
+	return 0
+}
+
 _dlw_prepare_prompt_for_launch() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -562,6 +575,7 @@ _dlw_prepare_prompt_for_launch() {
 		local issue_body=""
 		issue_body=$(_dlw_fetch_issue_body_for_clean_room "$issue_number" "$repo_slug")
 		_dlw_clean_room_prompt "$issue_number" "$repo_slug" "$issue_title" "$issue_body"
+		_dlw_first_pass_completion_contract
 		return 0
 	fi
 
@@ -574,10 +588,12 @@ _dlw_prepare_prompt_for_launch() {
 	if [[ "$zero_count" -ge "$fallback_threshold" ]]; then
 		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: using URL-only bootstrap prompt after ${zero_count} zero-output launches" >>"$LOGFILE"
 		_dlw_zero_output_fallback_prompt "$issue_number" "$repo_slug" "$issue_title"
+		_dlw_first_pass_completion_contract
 		return 0
 	fi
 
 	printf '%s' "$original_prompt"
+	_dlw_first_pass_completion_contract
 	return 0
 }
 

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -289,10 +289,10 @@ _build_ci_feedback_section() {
 	cat <<-EOF
 		### Worker guidance
 
-		1. Check out a fresh branch from \`origin/main\` (do NOT reuse the old branch)
-		2. Read the terminal check URLs above for specific error messages
-		3. Fix the issues in the code, not in the CI config
-		4. Ensure all checks pass locally before pushing
+		1. Recover the previous PR branch/commits and continue that work; do not restart from scratch.
+		2. Read every terminal check URL above and preserve the accumulated evidence.
+		3. Rebase the recovered work onto current \`origin/main\`, then fix the code rather than weakening CI.
+		4. Run every listed local check and create the replacement PR from the recovered branch.
 
 		_Routed by deterministic merge pass (pulse-merge.sh)._
 	EOF
@@ -437,36 +437,28 @@ _dispatch_ci_fix_worker() {
 	# usually reflect CI capacity, superseded runs, or job-budget kills; routing
 	# those as code-fix feedback creates duplicate PR churn instead of retrying or
 	# escalating CI infrastructure. If required checks contain no actionable
-	# failures and the caller did not provide precomputed checks, fall back to the
-	# full check set so advisory-only terminal failures can still carry
-	# pattern-specific repair guidance.
+	# failures, merge in the full check set as well. This prevents a required
+	# failure from hiding a simultaneous advisory failure from the replacement
+	# worker, which otherwise causes one CI redispatch per omitted check.
 	local terminal_failed_check_filter
 	terminal_failed_check_filter='(.bucket == "fail" or .bucket == "cancel") and (((.conclusion // .state // "") | ascii_downcase) | test("^(failure|action_required)$")) and ((.link // "") != "")'
-	local checks_json="$supplied_checks_json" result_marker=$'\n__AIDEVOPS_CHECK_NAMES__'
+	local checks_json="$supplied_checks_json" all_checks_json="[]" result_marker=$'\n__AIDEVOPS_CHECK_NAMES__'
 	local check_results="" failing_checks_json="" failing_checks="" failing_names="" classification_output=""
 	if [[ -z "$checks_json" ]]; then
 		checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required \
 			--json name,bucket,state,link \
 			2>/dev/null) || checks_json="[]"
 	fi
+	all_checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" \
+		--json name,bucket,state,link 2>/dev/null) || all_checks_json="[]"
+	checks_json=$(printf '%s\n%s\n' "$checks_json" "$all_checks_json" | \
+		jq -sc 'add | unique_by([.name, .link])' 2>/dev/null) || checks_json="${checks_json:-[]}"
 	check_results=$(_ci_terminal_failed_check_results "$checks_json" "$terminal_failed_check_filter")
 	failing_checks_json="${check_results%%"$result_marker"*}"
 	failing_names="${check_results#*"$result_marker"}"
 	[[ "$failing_names" != "$check_results" ]] || failing_names=""
 	failing_names="${failing_names#$'\n'}"
 	failing_checks=$(_ci_actionable_failed_checks_markdown "$pr_number" "$repo_slug" "$failing_checks_json")
-
-	if [[ -z "$failing_checks" && -z "$supplied_checks_json" ]]; then
-		checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" \
-			--json name,bucket,state,link \
-			2>/dev/null) || checks_json="[]"
-		check_results=$(_ci_terminal_failed_check_results "$checks_json" "$terminal_failed_check_filter")
-		failing_checks_json="${check_results%%"$result_marker"*}"
-		failing_names="${check_results#*"$result_marker"}"
-		[[ "$failing_names" != "$check_results" ]] || failing_names=""
-		failing_names="${failing_names#$'\n'}"
-		failing_checks=$(_ci_actionable_failed_checks_markdown "$pr_number" "$repo_slug" "$failing_checks_json")
-	fi
 
 	if [[ -z "$failing_checks" ]]; then
 		echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} in ${repo_slug} has no actionable failed checks with URLs — skipping CI repair routing" >>"$LOGFILE"

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -398,6 +398,13 @@ _ci_terminal_failed_check_results() {
 	return 0
 }
 
+_ci_merge_check_sets() {
+	local primary_checks="$1"
+	local all_checks="$2"
+	printf '%s\n%s\n' "$primary_checks" "$all_checks" | jq -sc 'add | unique_by([.name, .link])' 2>/dev/null || printf '%s' "${primary_checks:-[]}"
+	return 0
+}
+
 #######################################
 # Route CI failure feedback from a worker/trusted PR to its linked issue, close
 # the PR, and set the issue to status:available for re-dispatch.
@@ -451,8 +458,7 @@ _dispatch_ci_fix_worker() {
 	fi
 	all_checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" \
 		--json name,bucket,state,link 2>/dev/null) || all_checks_json="[]"
-	checks_json=$(printf '%s\n%s\n' "$checks_json" "$all_checks_json" | \
-		jq -sc 'add | unique_by([.name, .link])' 2>/dev/null) || checks_json="${checks_json:-[]}"
+	checks_json=$(_ci_merge_check_sets "$checks_json" "$all_checks_json")
 	check_results=$(_ci_terminal_failed_check_results "$checks_json" "$terminal_failed_check_filter")
 	failing_checks_json="${check_results%%"$result_marker"*}"
 	failing_names="${check_results#*"$result_marker"}"

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -1115,16 +1115,15 @@ test_claim_rejects_stale_same_runner_claim() {
 		print_result "stale same-runner claim emits CLAIM_STALE_SELF" 1 "output: $output"
 	fi
 
-	# GH#17503: claim comments are retained for audit; stale same-runner claims
-	# are rejected without deleting either the old or the fresh comment.
-	if [[ ! -f "${tmp_dir}/delete_ids.log" ]]; then
-		print_result "stale self-claim retains audit comments" 0
+	# Keep only the winning/oldest claim; the fresh losing claim is noise.
+	if [[ -f "${tmp_dir}/delete_ids.log" ]] && grep -qx '999' "${tmp_dir}/delete_ids.log"; then
+		print_result "stale self-claim removes fresh losing comment" 0
 	else
 		local delete_log=""
 		if [[ -f "${tmp_dir}/delete_ids.log" ]]; then
 			delete_log=$(<"${tmp_dir}/delete_ids.log")
 		fi
-		print_result "stale self-claim retains audit comments" 1 "deleted: ${delete_log:-none}"
+		print_result "stale self-claim removes fresh losing comment" 1 "deleted: ${delete_log:-none}"
 	fi
 
 	rm -rf "$tmp_dir"
@@ -1173,16 +1172,14 @@ test_claim_rejects_fresh_same_runner_claim() {
 		print_result "fresh same-runner claim emits CLAIM_STALE_SELF" 1 "output: $output"
 	fi
 
-	# GH#17503: claim comments are retained for audit; duplicate same-runner
-	# claims are rejected without deleting either comment.
-	if [[ ! -f "${tmp_dir}/delete_ids.log" ]]; then
-		print_result "fresh same-runner retains audit comments" 0
+	if [[ -f "${tmp_dir}/delete_ids.log" ]] && grep -qx '999' "${tmp_dir}/delete_ids.log"; then
+		print_result "fresh same-runner removes duplicate losing comment" 0
 	else
 		local delete_log=""
 		if [[ -f "${tmp_dir}/delete_ids.log" ]]; then
 			delete_log=$(<"${tmp_dir}/delete_ids.log")
 		fi
-		print_result "fresh same-runner retains audit comments" 1 "deleted: ${delete_log:-none}"
+		print_result "fresh same-runner removes duplicate losing comment" 1 "deleted: ${delete_log:-none}"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression guard: stale-recovery escalation must use GitHub comments as the
-# multi-runner source of truth, but it must not suspend a freshly dispatched
-# worker from historical stale ticks unless the current attempt has terminal
-# worker-failure evidence in the issue comment stream.
+# Regression guard: stale-recovery escalation uses GitHub comments as the
+# multi-runner source of truth and treats a completed stale timeout as terminal
+# no-progress evidence even when a crashed launcher omitted its terminal marker.
 
 set -uo pipefail
 
@@ -118,10 +117,10 @@ COMMENTS_JSON='[[
 
 _recover_stale_assignment 3978 owner/repo runner "dispatch claim 620s old, last activity 620s old (threshold=600s, interactive=false)"
 
-if [[ "$ESCALATED" -eq 0 && "$RECOVERED" -eq 1 ]]; then
-	pass "fresh dispatch without terminal evidence does not escalate"
+if [[ "$ESCALATED" -eq 1 && "$RECOVERED" -eq 0 ]]; then
+	pass "threshold escalation does not require a launcher terminal marker"
 else
-	fail "fresh dispatch without terminal evidence does not escalate" "ESCALATED=${ESCALATED} RECOVERED=${RECOVERED}"
+	fail "threshold escalation does not require a launcher terminal marker" "ESCALATED=${ESCALATED} RECOVERED=${RECOVERED}"
 fi
 
 ESCALATED=0
@@ -136,9 +135,9 @@ COMMENTS_JSON='[[
 _recover_stale_assignment 3978 owner/repo runner "dispatch claim 620s old, last activity 620s old (threshold=600s, interactive=false)"
 
 if [[ "$ESCALATED" -eq 1 && "$RECOVERED" -eq 0 ]]; then
-	pass "terminal evidence allows threshold escalation"
+	pass "terminal evidence remains compatible with threshold escalation"
 else
-	fail "terminal evidence allows threshold escalation" "ESCALATED=${ESCALATED} RECOVERED=${RECOVERED}"
+	fail "terminal evidence remains compatible with threshold escalation" "ESCALATED=${ESCALATED} RECOVERED=${RECOVERED}"
 fi
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -218,6 +218,7 @@ define_feedback_helpers() {
 		_ci_check_url_has_infra_timeout_log
 		_ci_actionable_failed_checks_markdown
 		_ci_terminal_failed_check_results
+		_ci_merge_check_sets
 		_append_feedback_to_issue
 		_transition_issue_for_redispatch
 		_close_and_label_feedback_pr

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -94,8 +94,11 @@ fi
 		fi
 		if [[ "$*" == *"name,bucket,state,link"* ]]; then
 			case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
-				terminal_failure:1 | log_exit_143:1)
+				terminal_failure:1 | log_exit_143:1 | required_and_advisory:1)
 					printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
+					;;
+				required_and_advisory:0)
+					printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"},{"name":"Qlty","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/124/job/790"}]'
 					;;
 				pending_only:*|mixed_pending_pass:*)
 					printf '[]\n'
@@ -196,6 +199,8 @@ define_process_helper() {
 	_route_pr_to_fix_worker() { local pr_number="$1" repo_slug="$2" linked_issue="$3" mode="$4" pr_labels="${5:-}"; ROUTE_CALLS=$((ROUTE_CALLS + 1)); ROUTE_ARGS="${pr_number}|${repo_slug}|${linked_issue}|${mode}"; ROUTE_LABELS="$pr_labels"; return 0; }
 	_pulse_merge_dismiss_coderabbit_nits() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; DISMISS_CALLS=$((DISMISS_CALLS + 1)); if [[ "${DISMISS_NITS_RC:-0}" -eq 0 ]]; then return 0; fi; return 1; }
 	_attempt_pr_update_branch() { return 1; }
+	_pulse_merge_changes_requested_thread_remediation_first_enabled() { return 1; }
+	_pulse_merge_preflight_snapshot_gate() { return 0; }
 	_close_conflicting_pr() { return 0; }
 	_pmp_normalize_mergeable_state_into() { return 0; }
 	printf -v PR_OBJECT '%s' '{"number":100,"mergeable":"MERGEABLE","reviewDecision":"","author":{"login":"worker-bot"},"title":"t1: fix"}'
@@ -484,6 +489,24 @@ test_ci_feedback_emits_advisory_failure_when_required_clean() {
 	return 0
 }
 
+test_ci_feedback_includes_required_and_advisory_failures_together() {
+	setup_test_env
+	TEST_CHECK_SCENARIO="required_and_advisory"
+	define_feedback_helpers || { print_result "defines feedback helpers for combined failures" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+
+	if ! grep -qF '**Lint**: failure' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "combined CI feedback retains required failure" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	elif ! grep -qF '**Qlty**: failure' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "combined CI feedback includes advisory failure" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
+	else
+		print_result "combined CI feedback includes every terminal failure in one pass" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
 main() {
 	test_red_pr_passes_gates_before_repair_route
 	test_rebase_success_defers_ci_repair_route
@@ -498,6 +521,7 @@ main() {
 	test_ci_feedback_skips_infra_timeout_checks
 	test_ci_feedback_skips_failed_check_with_exit_143_log
 	test_ci_feedback_emits_advisory_failure_when_required_clean
+	test_ci_feedback_includes_required_and_advisory_failures_together
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/tests/test-stale-recovery-escalation.sh
+++ b/.agents/scripts/tests/test-stale-recovery-escalation.sh
@@ -81,7 +81,22 @@ printf '%s\n' "\$*" >> "${GH_CALLS_FILE}"
 # gh api .../comments --jq '... | length'
 # Returns the pre-computed tick count directly (t2008 test shim)
 if [[ "\$1" == "api" && "\$2" == *"/comments" ]]; then
-	printf '%s\n' "${tick_count}"
+	python3 - "${tick_count}" <<'PY'
+import json
+import sys
+
+count = int(sys.argv[1])
+comments = []
+for index in range(1, count + 1):
+    comments.append({"created_at": f"2026-01-01T00:00:{index:02d}Z", "body": f"<!-- stale-recovery-tick:{index} -->"})
+comments.append({
+    "created_at": "2026-01-01T00:01:00Z",
+    "body": "DISPATCH_CLAIM nonce=test runner=stale-runner ts=2026-01-01T00:01:00Z max_age_s=1 lease_token=test device=test session=issue-99999 phase=prelaunch expires_at=1",
+    "user": {"login": "stale-runner"},
+    "author_association": "MEMBER",
+})
+print(json.dumps([comments]))
+PY
 	exit 0
 fi
 
@@ -151,15 +166,15 @@ else
 fi
 
 # =============================================================================
-# Test 2 — Second recovery (1 prior tick → tick:2 comment, STALE_RECOVERED)
+# Test 2 — Second recovery reaches the global threshold and escalates
 # =============================================================================
 
 run_recover 1 ""
 
-if echo "$output" | grep -q "STALE_RECOVERED"; then
-	print_result "Tick 2 (1 prior tick): STALE_RECOVERED emitted, not escalated" 0
+if echo "$output" | grep -q "STALE_ESCALATED"; then
+	print_result "Tick 2 (1 prior tick): STALE_ESCALATED emitted" 0
 else
-	print_result "Tick 2 (1 prior tick): STALE_RECOVERED emitted, not escalated" 1 "(got: '$output')"
+	print_result "Tick 2 (1 prior tick): STALE_ESCALATED emitted" 1 "(got: '$output')"
 fi
 
 # =============================================================================
@@ -200,13 +215,13 @@ fi
 # Test 4 — Reset path: open PR detected → counter reset, STALE_RECOVERED
 # =============================================================================
 
-# 2 prior ticks (above threshold), but open PR #42 detected → should NOT escalate
+# 2 prior ticks, but open PR #42 is durable progress and must be preserved
 run_recover 2 "42"
 
-if echo "$output" | grep -q "STALE_RECOVERED"; then
-	print_result "Reset path (PR #42 detected, 2 ticks): STALE_RECOVERED emitted (no escalation)" 0
+if echo "$output" | grep -q "STALE_PROGRESS_PRESERVED"; then
+	print_result "Open PR path preserves durable progress without stale recovery" 0
 else
-	print_result "Reset path (PR #42 detected, 2 ticks): STALE_RECOVERED emitted (no escalation)" 1 "(got: '$output')"
+	print_result "Open PR path preserves durable progress without stale recovery" 1 "(got: '$output')"
 fi
 
 if ! echo "$output" | grep -q "STALE_ESCALATED"; then
@@ -215,11 +230,11 @@ else
 	print_result "Reset path: STALE_ESCALATED NOT emitted" 1 "(got: '$output')"
 fi
 
-# A reset tick comment should have been posted
-if grep -q "^issue comment" "$GH_CALLS_FILE" 2>/dev/null; then
-	print_result "Reset path: reset comment call made" 0
+# Durable PR activity replaces synthetic reset comments.
+if ! grep -q "^issue comment" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "Open PR path posts no synthetic reset comment" 0
 else
-	print_result "Reset path: reset comment call made" 1 "(gh calls: $(head -5 "$GH_CALLS_FILE" 2>/dev/null))"
+	print_result "Open PR path posts no synthetic reset comment" 1 "(gh calls: $(head -5 "$GH_CALLS_FILE" 2>/dev/null))"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -84,7 +84,8 @@ write_state 1
 GH_COMMENT_ZERO_COUNT=0
 GH_COMMENT_METRICS=""
 normal_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
-if [[ "$normal_prompt" == "FULL EMBEDDED BRIEF" ]]; then
+if [[ "$normal_prompt" == *"FULL EMBEDDED BRIEF"* ]] \
+	&& [[ "$normal_prompt" == *"First-pass completion contract"* ]]; then
 	pass "below fallback threshold keeps embedded prompt"
 else
 	fail "below fallback threshold keeps embedded prompt" "$normal_prompt"


### PR DESCRIPTION
## Summary

- bound stale assignment recovery globally across maintainer machines instead of allowing silent/phantom launches to recycle indefinitely
- remove losing cross-runner claim comments while retaining the winning lease and local race diagnostics
- preserve open PRs as durable progress and inject a first-pass completion contract into every worker launch mode
- include required and advisory terminal CI failures in one cumulative repair dossier

## Root cause

The five referenced issues exposed one shared lifecycle defect rather than five model-quality failures: coordination was split between GitHub comments and machine-local counters. Silent pre-launch exits did not count as terminal globally, stale recovery required a narrow terminal marker, losing claims and synthetic reset ticks accumulated publicly, open PR/branch progress could be discarded, and CI routing omitted advisory failures whenever one required check had already failed. Mixed aidevops versions across maintainers amplified these races.

## Changes

- `.agents/scripts/dispatch-claim-helper.sh`: fail closed on coordination ambiguity; remove losing claim comments; keep defer evidence in runner logs.
- `.agents/scripts/dispatch-dedup-stale.sh`: treat a stale timeout as no-progress evidence, cap the default cycle at two global recoveries, combine tick/recovery output, and preserve open PR ownership.
- `.agents/scripts/pulse-dispatch-worker-launch.sh`: require solution dedup, salvage, full verification, early durable draft PRs, and minimal comments on every prompt path.
- `.agents/scripts/pulse-merge-feedback.sh`: union required and advisory terminal failures and tell repair workers to recover prior commits instead of restarting.
- regression tests and worker diagnostics updated for the new contracts.

## Testing

- `bash .agents/scripts/tests/test-dispatch-claim-helper.sh`
- `bash .agents/scripts/tests/test-dispatch-atomic-lease.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh`
- `bash .agents/scripts/tests/test-stale-recovery-escalation.sh`
- `bash .agents/scripts/tests/test-zero-output-url-fallback.sh`
- `bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh`
- `bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh`
- `.agents/scripts/linters-local.sh`

All passed after rebasing onto current `origin/main`; ShellCheck, secret scanning, Bash 3.2 compatibility, portability, complexity, nesting, and diff gates are clean.

## Runtime Testing

`runtime-verified`: mocked multi-device claim races, lease transitions, stale takeovers, open-PR preservation, zero-output prompt modes, and combined CI failure routing execute the changed state-machine paths.

## Trade-offs

GitHub issue comments remain the compatibility coordination substrate for mixed-version fleets, so this does not claim a mathematically linearizable distributed lock. The safety policy instead fails closed on ambiguous reads, removes loser noise, preserves durable PR progress, and globally stops repeated no-progress recovery after two attempts.

For #27166
Refs #27175
Refs #27275
Refs #27277
Refs #27289

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.40 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 40m and 617,931 tokens on this with the user in an interactive session.
