### PR TITLE
GH#27298: Preserve bundles pinned by live OpenCode sessions

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -23,8 +23,8 @@
 //   - google-proxy.mjs    — Google auth-translating proxy
 // ---------------------------------------------------------------------------
 
-import { existsSync, readFileSync, realpathSync } from "fs";
-import { join } from "path";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "fs";
+import { basename, dirname, join } from "path";
 import { homedir } from "os";
 import { execSync } from "child_process";
 
@@ -73,6 +73,31 @@ const SCRIPTS_DIR = join(AGENTS_DIR, "scripts");
 const PLUGIN_DIR = join(AGENTS_DIR, "plugins", "opencode-aidevops");
 const WORKSPACE_DIR = join(HOME, ".aidevops", ".agent-workspace");
 const LOGS_DIR = join(HOME, ".aidevops", "logs");
+
+// Keep the immutable bundle backing this process until OpenCode exits. Setup
+// also applies an age floor for sessions started before lease support existed.
+const RUNTIME_BUNDLE_LEASE = (() => {
+  const bundleDir = dirname(AGENTS_DIR);
+  if (basename(dirname(bundleDir)) !== "runtime-bundles") return "";
+  const lease = join(dirname(bundleDir), ".leases", basename(bundleDir), String(process.pid));
+  try {
+    mkdirSync(dirname(lease), { recursive: true });
+    writeFileSync(lease, `${AGENTS_DIR}\n`, { mode: 0o600 });
+    return lease;
+  } catch {
+    return "";
+  }
+})();
+
+if (RUNTIME_BUNDLE_LEASE) {
+  process.once("exit", () => {
+    try {
+      rmSync(RUNTIME_BUNDLE_LEASE, { force: true });
+    } catch {
+      // Dead-process lease cleanup is also performed by setup.
+    }
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Utility helpers

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -703,12 +703,49 @@ _runtime_bundle_prune() {
 	local active_root="$2"
 	local previous_root="$3"
 	local candidate_dir=""
+	local bundle_id=""
+	local lease_dir=""
+	local lease_file=""
+	local lease_pid=""
+	local has_live_lease=false
+	local retention_seconds="${AIDEVOPS_RUNTIME_BUNDLE_RETENTION_SECONDS:-2592000}"
+	local now=""
+	local modified=""
+
+	case "$retention_seconds" in
+	'' | *[!0-9]*) retention_seconds=2592000 ;;
+	esac
+	now=$(date +%s) || return 1
 
 	for candidate_dir in "$bundles_dir"/*; do
 		[[ -d "$candidate_dir/agents" ]] || continue
 		[[ "$candidate_dir/agents" == "$active_root" || "$candidate_dir/agents" == "$previous_root" ]] && continue
+		bundle_id="${candidate_dir##*/}"
+		lease_dir="$bundles_dir/.leases/$bundle_id"
+		has_live_lease=false
+		if [[ -d "$lease_dir" ]]; then
+			for lease_file in "$lease_dir"/*; do
+				[[ -f "$lease_file" ]] || continue
+				lease_pid="${lease_file##*/}"
+				case "$lease_pid" in
+				'' | *[!0-9]*) rm -f "$lease_file" ;;
+				*)
+					if kill -0 "$lease_pid" 2>/dev/null; then
+						has_live_lease=true
+					else
+						rm -f "$lease_file"
+					fi
+					;;
+				esac
+			done
+			rmdir "$lease_dir" 2>/dev/null || true
+		fi
+		[[ "$has_live_lease" == "true" ]] && continue
+		modified=$(stat -f '%m' "$candidate_dir" 2>/dev/null || stat -c '%Y' "$candidate_dir" 2>/dev/null || printf '%s' "$now")
+		[[ $((now - modified)) -lt "$retention_seconds" ]] && continue
 		rm -rf "$candidate_dir"
 	done
+	rmdir "$bundles_dir/.leases" 2>/dev/null || true
 	return 0
 }
 

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -741,7 +741,7 @@ _runtime_bundle_prune() {
 			rmdir "$lease_dir" 2>/dev/null || true
 		fi
 		[[ "$has_live_lease" == "true" ]] && continue
-		modified=$(stat -f '%m' "$candidate_dir" 2>/dev/null || stat -c '%Y' "$candidate_dir" 2>/dev/null || printf '%s' "$now")
+		modified=$(_file_mtime_epoch "$candidate_dir")
 		[[ $((now - modified)) -lt "$retention_seconds" ]] && continue
 		rm -rf "$candidate_dir"
 	done

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -152,6 +152,40 @@ test_process_pin_survives_activation() {
 	return 0
 }
 
+test_live_bundle_lease_survives_three_updates() {
+	local target_dir="$HOME/.aidevops/agents"
+	local leased_root=""
+	local leased_bundle=""
+	local version=""
+	leased_root=$(_runtime_bundle_resolve_root "$target_dir")
+	leased_bundle="${leased_root%/agents}"
+	mkdir -p "$HOME/.aidevops/runtime-bundles/.leases/${leased_bundle##*/}"
+	printf '%s\n' "$leased_root" >"$HOME/.aidevops/runtime-bundles/.leases/${leased_bundle##*/}/$$"
+
+	for version in 5.0.0 6.0.0 7.0.0; do
+		write_fake_revision "$version" "update-$version"
+		stage_revision "$target_dir"
+		AIDEVOPS_RUNTIME_BUNDLE_RETENTION_SECONDS=0 _runtime_bundle_activate "$target_dir" "$_AIDEVOPS_STAGED_BUNDLE_DIR"
+	done
+	[[ -x "$leased_root/scripts/helper.sh" ]] || fail "live first bundle helper survives three updates"
+	pass "live first bundle helper survives three updates"
+	return 0
+}
+
+test_stale_lease_and_old_bundle_are_pruned() {
+	local target_dir="$HOME/.aidevops/agents"
+	local stale_bundle="$HOME/.aidevops/runtime-bundles/stale-crash"
+	local stale_pid="99999999"
+	mkdir -p "$stale_bundle/agents/scripts" "$HOME/.aidevops/runtime-bundles/.leases/stale-crash"
+	printf '#!/usr/bin/env bash\n' >"$stale_bundle/agents/scripts/helper.sh"
+	printf '%s\n' "$stale_bundle/agents" >"$HOME/.aidevops/runtime-bundles/.leases/stale-crash/$stale_pid"
+	AIDEVOPS_RUNTIME_BUNDLE_RETENTION_SECONDS=0 _runtime_bundle_prune \
+		"$HOME/.aidevops/runtime-bundles" "$(_runtime_bundle_resolve_root "$target_dir")" ""
+	[[ ! -d "$stale_bundle" ]] || fail "crashed process lease does not retain an old bundle"
+	pass "crashed process lease does not retain an old bundle"
+	return 0
+}
+
 test_macos_and_linux_link_paths() {
 	local os_name=""
 	local os_root=""
@@ -206,6 +240,8 @@ main() {
 	test_interrupted_staging_preserves_active
 	test_failed_activation_rolls_back
 	test_process_pin_survives_activation
+	test_live_bundle_lease_survives_three_updates
+	test_stale_lease_and_old_bundle_are_pruned
 	test_macos_and_linux_link_paths
 
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -18,6 +18,8 @@ print_skip() { local message="$1"; : "$message"; return 0; }
 setup_track_deferred() { return 0; }
 create_backup_with_rotation() { return 0; }
 
+# shellcheck source=../portable-stat.sh
+source "$REPO_ROOT/.agents/scripts/portable-stat.sh"
 # shellcheck source=../setup/modules/plugins.sh
 source "$REPO_ROOT/.agents/scripts/setup/modules/plugins.sh"
 # shellcheck source=../setup/modules/agent-deploy.sh


### PR DESCRIPTION
## Summary

- create a per-process lease for the immutable agents bundle resolved at OpenCode plugin load
- preserve bundles with live PID leases and clean invalid or crashed-process leases
- retain unleased bundles for 30 days by default so pre-fix sessions and restored compatibility paths survive updates
- test three consecutive updates with the first bundle live, plus stale crash cleanup

## Verification

- `bash .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh` (18 checks)
- `shellcheck .agents/scripts/setup/modules/agent-deploy.sh .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh`
- `node --check .agents/plugins/opencode-aidevops/index.mjs`
- `.agents/scripts/linters-local.sh`

Resolves #27298
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.40 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 9m and 171,921 tokens on this with the user in an interactive session.