### PR TITLE
GH#27306: add canonical observation contract

### DIFF
--- a/.agents/reference/entity-memory-architecture.md
+++ b/.agents/reference/entity-memory-architecture.md
@@ -27,7 +27,7 @@ Cross-channel relationship continuity for agents on Matrix, SimpleX, email, CLI,
 
 | Decision | Why |
 |----------|-----|
-| Same `memory.db`, new tables | Enables cross-queries without cross-DB joins |
+| Same `memory.db`, canonical observations | Enables cross-queries without cross-DB joins and gives every derived fact provenance |
 | Three layers, not two | Layer 0 raw data is primary; summaries and profiles are derived |
 | Versioned profiles via `supersedes_id` | Never update in place; mirrors `learning_relations` |
 | Identity resolution requires confirmation | Never auto-link across channels |
@@ -43,11 +43,11 @@ Cross-channel relationship continuity for agents on Matrix, SimpleX, email, CLI,
 | **1: Conversation context** | Active threads, immutable summaries, tone profile, pending actions | conversations, conversation_summaries | `conversation-helper.sh` |
 | **0: Raw interaction log** | Immutable source of truth; FTS5 indexed; privacy-filtered on write | interactions, interactions_fts | `entity-helper.sh log-interaction` |
 
-**Immutability:** Layer 0 is INSERT-only (except privacy deletion). Layers 1-2 use `supersedes_id` chains — new rows supersede old, never edit in place. Current record = row whose `id` is not referenced by another row's `supersedes_id`. Preserves full audit trail; avoids concurrent-write conflicts.
+**Immutability:** Layer 0 and canonical `observations`/`observation_sources` are INSERT-only (except privacy deletion). Layers 1-2 use `supersedes_id` chains that project to `observation_relations`; new rows supersede old, never edit in place. Deterministic source IDs prevent replay from inflating evidence. Current record = row whose `id` is not referenced by another row's `supersedes_id`. Preserves full audit trail; avoids concurrent-write conflicts.
 
 ## Database Schema
 
-All tables live in `~/.aidevops/.agent-workspace/memory/memory.db` alongside `learnings`, `learning_access`, and `learning_relations`.
+All tables live in `~/.aidevops/.agent-workspace/memory/memory.db`. `observations` is canonical, `observation_sources` holds evidence/provenance, `observation_relations` holds truth and version transitions, and `observation_outcomes` holds usefulness/results. `learnings` remains the compatible FTS retrieval projection.
 
 ### Layer 0: `interactions` + `interactions_fts`
 

--- a/.agents/reference/memory.md
+++ b/.agents/reference/memory.md
@@ -17,7 +17,7 @@ tools:
 
 # Memory System
 
-Cross-session memory using SQLite FTS5. **Requires**: `sqlite3` CLI (`brew install sqlite3` / `sudo apt install sqlite3`).
+Cross-session memory using a canonical observation contract with SQLite FTS5 as its retrieval projection. **Requires**: `sqlite3` CLI (`brew install sqlite3` / `sudo apt install sqlite3`).
 
 **Motto**: "Compound, then clear" — sessions build on each other.
 
@@ -84,6 +84,12 @@ audit chain.
 
 On store: checks exact and near-duplicates (normalized case/punctuation/whitespace). Increments access count on match instead of creating new entry.
 
+## Canonical Observations
+
+`observations` is the authoritative additive envelope. It records stable observation, source, and session IDs; kind and owner/subject; user/project/organization/framework scope; explicit versus inferred state; confidence; sensitivity and consent; effective/review/expiry time; destination and lifecycle status. `observation_sources` preserves evidence and provenance with one unique source record per legacy or native source, so replay cannot create independent evidence. `observation_relations` records supersession, debunking, correction, revocation, extension, and derivation. `observation_outcomes` records retrieval usefulness, graduation, and later outcomes.
+
+Existing `learnings` remain the FTS retrieval projection. Database initialization idempotently backfills safely derivable learning, entity-profile, capability-gap, truth/relation, access/usefulness, and graduation history using deterministic IDs such as `obs_learning_<legacy-id>` and `src_learning_<legacy-id>`.
+
 ## Auto-Pruning
 
 Runs on every `store` (at most once per 24h). Removes entries older than 90 days with zero access; frequently accessed memories preserved regardless of age.
@@ -138,7 +144,7 @@ Tracks relationships with people, agents, and services across communication chan
 | Layer 2 | Entity relationship model (strategic profiles) | `entity-helper.sh` | `entities`, `entity_channels`, `entity_profiles`, `capability_gaps` |
 | Loop | Self-evolution (gap detection → TODO → upgrade) | `self-evolution-helper.sh` | `capability_gaps`, `gap_evidence` |
 
-**Key concepts:** Entities are people/agents/services. Cross-channel identity links Matrix/SimpleX/email/CLI to the same entity (confidence: confirmed/suggested/inferred). Profiles versioned via `supersedes_id` chain — never updated in place. Layer 0 is append-only; all other layers derived from it.
+**Key concepts:** Entities are people/agents/services. Cross-channel identity links Matrix/SimpleX/email/CLI to the same entity (confidence: confirmed/suggested/inferred). Profiles versioned via `supersedes_id` chain and project into canonical observations; they are never updated in place. Layer 0 is append-only; all other layers are derived from observations and source evidence.
 
 ## Namespaces (Per-Runner Isolation)
 

--- a/.agents/scripts/memory/_common.sh
+++ b/.agents/scripts/memory/_common.sh
@@ -560,6 +560,175 @@ _migrate_learning_truth_events() {
 }
 
 #######################################
+# Create the canonical observation envelope and provenance tables.
+# Learnings remain the FTS retrieval projection; observations are authoritative.
+#######################################
+_create_observation_schema() {
+	db "$MEMORY_DB" <<'EOF'
+CREATE TABLE IF NOT EXISTS observations (
+    observation_id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    owner_id TEXT,
+    subject_id TEXT,
+    session_id TEXT,
+    user_scope TEXT,
+    project_scope TEXT,
+    organization_scope TEXT,
+    framework_scope TEXT NOT NULL DEFAULT 'aidevops',
+    state TEXT NOT NULL CHECK(state IN ('explicit', 'inferred')),
+    statement TEXT NOT NULL,
+    confidence TEXT NOT NULL CHECK(confidence IN ('high', 'medium', 'low')),
+    sensitivity TEXT NOT NULL DEFAULT 'internal' CHECK(sensitivity IN ('public', 'internal', 'confidential', 'restricted')),
+    consent TEXT NOT NULL DEFAULT 'unspecified' CHECK(consent IN ('granted', 'denied', 'unspecified', 'not_applicable')),
+    effective_at TEXT,
+    review_at TEXT,
+    expires_at TEXT,
+    destination TEXT NOT NULL DEFAULT 'memory',
+    status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'superseded', 'debunked', 'corrected', 'revoked', 'expired')),
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_observations_scope ON observations(user_scope, project_scope, organization_scope, framework_scope);
+CREATE INDEX IF NOT EXISTS idx_observations_subject_kind ON observations(subject_id, kind, status);
+
+CREATE TABLE IF NOT EXISTS observation_sources (
+    source_id TEXT PRIMARY KEY,
+    observation_id TEXT NOT NULL,
+    source_kind TEXT NOT NULL,
+    source_record_id TEXT NOT NULL,
+    source_session_id TEXT,
+    evidence TEXT,
+    provenance TEXT NOT NULL,
+    captured_at TEXT NOT NULL,
+    UNIQUE(source_kind, source_record_id),
+    FOREIGN KEY (observation_id) REFERENCES observations(observation_id)
+);
+CREATE INDEX IF NOT EXISTS idx_observation_sources_observation ON observation_sources(observation_id);
+
+CREATE TABLE IF NOT EXISTS observation_relations (
+    relation_id TEXT PRIMARY KEY,
+    observation_id TEXT NOT NULL,
+    target_observation_id TEXT NOT NULL,
+    relation_type TEXT NOT NULL CHECK(relation_type IN ('supersedes', 'debunks', 'corrects', 'revokes', 'extends', 'derives')),
+    evidence_source_id TEXT,
+    created_at TEXT NOT NULL,
+    UNIQUE(observation_id, target_observation_id, relation_type)
+);
+
+CREATE TABLE IF NOT EXISTS observation_outcomes (
+    outcome_id TEXT PRIMARY KEY,
+    observation_id TEXT NOT NULL,
+    outcome_kind TEXT NOT NULL,
+    outcome_value REAL,
+    details TEXT,
+    recorded_at TEXT NOT NULL,
+    UNIQUE(observation_id, outcome_kind, recorded_at)
+);
+EOF
+	local rc=$?
+	return "$rc"
+}
+
+#######################################
+# Losslessly project safely derivable legacy history into observations.
+# Deterministic IDs and uniqueness constraints make repeated runs idempotent.
+#######################################
+_backfill_legacy_observations() {
+	db "$MEMORY_DB" <<'EOF'
+BEGIN TRANSACTION;
+INSERT OR IGNORE INTO observations (
+    observation_id, kind, owner_id, subject_id, session_id, user_scope,
+    project_scope, organization_scope, framework_scope, state, statement,
+    confidence, sensitivity, consent, effective_at, destination, status, created_at
+)
+SELECT 'obs_learning_' || l.id,
+       CASE l.type
+           WHEN 'USER_PREFERENCE' THEN 'preference'
+           WHEN 'DECISION' THEN 'decision'
+           WHEN 'FAILURE' THEN 'failure'
+           WHEN 'SUCCESS' THEN 'success'
+           WHEN 'DIRECTIVE' THEN 'directive'
+           WHEN 'HYPOTHESIS' THEN 'hypothesis'
+           ELSE 'fact'
+       END,
+       NULL, le.entity_id, l.session_id,
+       CASE WHEN l.type = 'USER_PREFERENCE' THEN COALESCE(le.entity_id, 'unknown-user') END,
+       NULLIF(l.project_path, ''), NULL, 'aidevops',
+       CASE WHEN l.type IN ('USER_PREFERENCE', 'DECISION', 'CONTEXT') THEN 'explicit' ELSE 'inferred' END,
+       l.content, COALESCE(NULLIF(l.confidence, ''), 'medium'), 'internal', 'unspecified',
+       COALESCE(NULLIF(l.event_date, ''), l.created_at), 'learnings',
+       CASE COALESCE((SELECT status FROM learning_truth_events t WHERE t.memory_id = l.id ORDER BY t.created_at DESC, t.event_id DESC LIMIT 1), 'live')
+           WHEN 'debunked' THEN 'debunked' WHEN 'retracted' THEN 'revoked'
+           ELSE CASE WHEN EXISTS (SELECT 1 FROM learning_relations r WHERE r.supersedes_id = l.id AND r.relation_type = 'updates') THEN 'superseded' ELSE 'active' END
+       END,
+       l.created_at
+FROM learnings l
+LEFT JOIN learning_entities le ON le.learning_id = l.id;
+
+INSERT OR IGNORE INTO observation_sources (
+    source_id, observation_id, source_kind, source_record_id, source_session_id,
+    evidence, provenance, captured_at
+)
+SELECT 'src_learning_' || id, 'obs_learning_' || id, 'learning', id, session_id,
+       content, 'legacy:learnings', created_at FROM learnings;
+
+INSERT OR IGNORE INTO observations (
+    observation_id, kind, owner_id, subject_id, framework_scope, state, statement,
+    confidence, sensitivity, consent, effective_at, destination, status, created_at
+)
+SELECT 'obs_profile_' || id, 'preference', entity_id, entity_id, 'aidevops', 'inferred',
+       profile_key || ': ' || profile_value, confidence, 'confidential', 'unspecified',
+       created_at, 'entity_profile',
+       CASE WHEN EXISTS (SELECT 1 FROM entity_profiles n WHERE n.supersedes_id = p.id) THEN 'superseded' ELSE 'active' END,
+       created_at FROM entity_profiles p;
+INSERT OR IGNORE INTO observation_sources
+SELECT 'src_profile_' || id, 'obs_profile_' || id, 'entity_profile', id, NULL,
+       evidence, 'legacy:entity_profiles', created_at FROM entity_profiles;
+
+INSERT OR IGNORE INTO observations (
+    observation_id, kind, owner_id, subject_id, project_scope, framework_scope,
+    state, statement, confidence, sensitivity, consent, effective_at,
+    destination, status, created_at
+)
+SELECT 'obs_gap_' || id, 'gap', entity_id, entity_id, NULL, 'aidevops',
+       'inferred', description, 'medium', 'internal', 'not_applicable', created_at,
+       COALESCE(NULLIF(todo_ref, ''), 'memory'),
+       CASE status WHEN 'resolved' THEN 'corrected' WHEN 'wont_fix' THEN 'revoked' ELSE 'active' END,
+       created_at FROM capability_gaps;
+INSERT OR IGNORE INTO observation_sources
+SELECT 'src_gap_' || id, 'obs_gap_' || id, 'capability_gap', id, NULL,
+       evidence, 'legacy:capability_gaps', created_at FROM capability_gaps;
+
+INSERT OR IGNORE INTO observation_relations
+SELECT 'rel_learning_' || r.id || '_' || r.supersedes_id || '_' || r.relation_type,
+       'obs_learning_' || r.id, 'obs_learning_' || r.supersedes_id,
+       CASE r.relation_type WHEN 'updates' THEN 'supersedes' ELSE r.relation_type END,
+       'src_learning_' || r.id, r.created_at FROM learning_relations r;
+INSERT OR IGNORE INTO observation_relations
+SELECT 'rel_profile_' || p.id || '_' || p.supersedes_id,
+       'obs_profile_' || p.id, 'obs_profile_' || p.supersedes_id, 'supersedes',
+       'src_profile_' || p.id, p.created_at FROM entity_profiles p WHERE p.supersedes_id IS NOT NULL;
+
+INSERT OR IGNORE INTO observation_outcomes
+SELECT 'out_access_' || a.id, 'obs_learning_' || a.id, 'retrieval_usefulness',
+       COALESCE(a.usefulness_score, 0.0), 'access_count=' || COALESCE(a.access_count, 0),
+       COALESCE(a.last_accessed_at, '1970-01-01T00:00:00Z') FROM learning_access a;
+INSERT OR IGNORE INTO observation_outcomes
+SELECT 'out_graduated_' || a.id, 'obs_learning_' || a.id, 'graduated', 1.0,
+       'Promoted to shared guidance', a.graduated_at FROM learning_access a
+WHERE a.graduated_at IS NOT NULL AND a.graduated_at != '';
+COMMIT;
+EOF
+	local rc=$?
+	return "$rc"
+}
+
+_migrate_observations() {
+	_create_observation_schema || return 1
+	_backfill_legacy_observations || return 1
+	return 0
+}
+
+#######################################
 # Migrate existing database to new schema
 # With backup-before-modify pattern (t188)
 # Note: t311.4 resolved duplicate migrate_db() — this is the single
@@ -578,6 +747,7 @@ migrate_db() {
 	_migrate_usefulness_score
 	_migrate_learning_relations_debunks
 	_migrate_learning_truth_events
+	_migrate_observations
 	return 0
 }
 
@@ -715,6 +885,9 @@ CREATE TABLE IF NOT EXISTS memory_consolidations (
 CREATE INDEX IF NOT EXISTS idx_consolidations_created ON memory_consolidations(created_at DESC);
 EOF
 	local rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		_create_observation_schema || return 1
+	fi
 	return "$rc"
 }
 
@@ -759,6 +932,9 @@ init_db() {
 
 	if [[ ! -f "$MEMORY_DB" ]]; then
 		_create_memory_db || return 1
+		# Use the same additive migration path for fresh and legacy databases so
+		# every safely derivable source table exists before observation backfill.
+		migrate_db || return 1
 	else
 		# Migrate existing database if needed
 		migrate_db || return 1

--- a/.agents/scripts/memory/store.sh
+++ b/.agents/scripts/memory/store.sh
@@ -401,6 +401,8 @@ EOF
 
 	# Insert all records into the database
 	_store_insert_record || return 1
+	# Canonical observations are authoritative; learnings remain the retrieval projection.
+	_backfill_legacy_observations || return 1
 
 	log_success "Stored learning: $_store_id"
 

--- a/tests/test-memory-observation-contract.sh
+++ b/tests/test-memory-observation-contract.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	[[ "$actual" == "$expected" ]] || fail "$message (expected $expected, got $actual)"
+	return 0
+}
+
+run_memory() {
+	AIDEVOPS_MEMORY_DIR="$TEST_DIR" "$MEMORY_HELPER" "$@"
+	return $?
+}
+
+db_query() {
+	local sql="$1"
+	sqlite3 "$TEST_DIR/memory.db" "$sql"
+	return $?
+}
+
+# Seed a pre-observation database and verify lossless additive migration.
+sqlite3 "$TEST_DIR/memory.db" <<'EOF'
+CREATE VIRTUAL TABLE learnings USING fts5(id UNINDEXED, session_id UNINDEXED, content, type, tags, confidence UNINDEXED, created_at UNINDEXED, event_date UNINDEXED, project_path UNINDEXED, source UNINDEXED, tokenize='porter unicode61');
+CREATE TABLE learning_access (id TEXT PRIMARY KEY, last_accessed_at TEXT, access_count INTEGER DEFAULT 0, auto_captured INTEGER DEFAULT 0, usefulness_score REAL DEFAULT 0.0, graduated_at TEXT);
+CREATE TABLE learning_relations (id TEXT NOT NULL, supersedes_id TEXT, relation_type TEXT CHECK(relation_type IN ('updates','extends','derives','debunks')), created_at TEXT, PRIMARY KEY(id,supersedes_id,relation_type));
+INSERT INTO learnings VALUES ('mem_old','session_stable','Prefers terse output','USER_PREFERENCE','preference','high','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z','/project/a','manual');
+INSERT INTO learnings VALUES ('mem_new','session_stable','Prefers detailed output for audits','USER_PREFERENCE','preference','high','2026-02-01T00:00:00Z','2026-02-01T00:00:00Z','/project/b','manual');
+INSERT INTO learning_access VALUES ('mem_new','2026-02-02T00:00:00Z',3,0,1.5,'2026-02-03T00:00:00Z');
+INSERT INTO learning_relations VALUES ('mem_new','mem_old','updates','2026-02-01T00:00:00Z');
+EOF
+
+run_memory stats >/dev/null
+assert_eq 2 "$(db_query 'SELECT COUNT(*) FROM observations WHERE observation_id LIKE "obs_learning_%";')" "old schema rows migrate"
+assert_eq session_stable "$(db_query 'SELECT session_id FROM observations WHERE observation_id="obs_learning_mem_old";')" "stable session ID retained"
+assert_eq 2 "$(db_query 'SELECT COUNT(DISTINCT project_scope) FROM observations WHERE kind="preference";')" "cross-project preferences remain scoped"
+assert_eq superseded "$(db_query 'SELECT status FROM observations WHERE observation_id="obs_learning_mem_old";')" "supersession state maps"
+assert_eq unspecified "$(db_query 'SELECT consent FROM observations WHERE observation_id="obs_learning_mem_new";')" "privacy consent is explicit"
+assert_eq internal "$(db_query 'SELECT sensitivity FROM observations WHERE observation_id="obs_learning_mem_new";')" "privacy sensitivity is explicit"
+assert_eq 1 "$(db_query 'SELECT COUNT(*) FROM observation_outcomes WHERE observation_id="obs_learning_mem_new" AND outcome_kind="graduated";')" "graduation history maps"
+
+run_memory stats >/dev/null
+assert_eq 2 "$(db_query 'SELECT COUNT(*) FROM observation_sources WHERE source_kind="learning";')" "repeat migration does not fabricate evidence"
+assert_eq 1 "$(db_query 'SELECT COUNT(*) FROM observation_relations WHERE relation_type="supersedes";')" "repeat migration keeps one relation"
+
+printf 'PASS: canonical observation migration, idempotency, scope, supersession, and privacy metadata\n'


### PR DESCRIPTION
## Summary

Add an additive canonical observation envelope, deterministic legacy backfill, source evidence, truth relations, outcomes, tests, and architecture documentation.

## Files Changed

.agents/reference/entity-memory-architecture.md, .agents/reference/memory.md, .agents/scripts/memory/_common.sh, .agents/scripts/memory/store.sh, tests/test-memory-observation-contract.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused observation contract test passed; bash -n and ShellCheck passed; local linter suite passed. Existing truth-maintenance integration test is blocked by the locked local Vault.

Resolves #27306


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.44 with gpt-5.6-sol spent 1h 4m and 341,551 tokens on this with the user in an interactive session.