### PR TITLE
GH#27289: reconcile superseded postflight cancellations

### DIFF
--- a/.agents/scripts/tests/test-postflight-check-run-dedup.sh
+++ b/.agents/scripts/tests/test-postflight-check-run-dedup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 FILTER="${REPO_ROOT}/.github/scripts/effective-check-runs.jq"
+RECONCILE_FILTER="${REPO_ROOT}/.github/scripts/reconcile-superseded-cancellations.jq"
 FIXTURE="${SCRIPT_DIR}/fixtures/postflight-check-runs.json"
 
 RESULT=$(jq --arg self_name "Verify Release Health" -f "$FILTER" "$FIXTURE")
@@ -18,3 +19,26 @@ jq -e '
 ' <<<"$RESULT" >/dev/null
 
 printf 'PASS: postflight selects the latest completed check run per name and app\n'
+
+CURRENT_RUNS='[
+  {"id":10,"name":"Shell portability scan","status":"completed","conclusion":"cancelled","app":{"slug":"github-actions"}},
+  {"id":11,"name":"Framework Validation","status":"completed","conclusion":"failure","app":{"slug":"github-actions"}},
+  {"id":12,"name":"Security Validation","status":"completed","conclusion":"cancelled","app":{"slug":"github-actions"}}
+]'
+DESCENDANT_RUNS='[
+  {"id":20,"name":"Shell portability scan","status":"completed","conclusion":"success","app":{"slug":"github-actions"}},
+  {"id":21,"name":"Framework Validation","status":"completed","conclusion":"success","app":{"slug":"github-actions"}},
+  {"id":22,"name":"Security Validation","status":"completed","conclusion":"failure","app":{"slug":"github-actions"}}
+]'
+RECONCILED=$(jq -cn \
+  --argjson current_runs "$CURRENT_RUNS" \
+  --argjson descendant_runs "$DESCENDANT_RUNS" \
+  -f "$RECONCILE_FILTER")
+
+jq -e '
+  any(.[]; .name == "Shell portability scan" and .conclusion == "success" and .superseded_by_check_run_id == 20) and
+  any(.[]; .name == "Framework Validation" and .conclusion == "failure") and
+  any(.[]; .name == "Security Validation" and .conclusion == "cancelled")
+' <<<"$RECONCILED" >/dev/null
+
+printf 'PASS: postflight accepts only cancelled checks superseded by descendant success\n'

--- a/.github/scripts/reconcile-superseded-cancellations.jq
+++ b/.github/scripts/reconcile-superseded-cancellations.jq
@@ -1,0 +1,24 @@
+def run_key: [(.name // ""), (.app.slug // .app.name // "")];
+
+def successful_descendant($key):
+  [
+    $descendant_runs[]
+    | select(run_key == $key)
+    | select(.status == "completed" and .conclusion == "success")
+  ]
+  | last // null;
+
+[
+  $current_runs[]
+  | if .conclusion == "cancelled" then
+      run_key as $key
+      | successful_descendant($key) as $replacement
+      | if $replacement == null then .
+        else .
+          | .status = "completed"
+          | .conclusion = "success"
+          | .superseded_by_check_run_id = ($replacement.id // null)
+        end
+    else .
+    end
+]

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -79,9 +79,31 @@ jobs:
         # cancellation can incorrectly fail an otherwise healthy release.
         SELF_NAME="Verify Release Health"
         CHECK_RUNS_RESPONSE=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs?per_page=100")
-        CHECK_RUNS=$(echo "$CHECK_RUNS_RESPONSE" \
-          | jq -c --arg self_name "$SELF_NAME" -f .github/scripts/effective-check-runs.jq \
-          | jq -c '.[] | {name, status, conclusion, app: (.app.slug // .app.name // "unknown")}')
+        EFFECTIVE_CHECK_RUNS=$(echo "$CHECK_RUNS_RESPONSE" \
+          | jq -c --arg self_name "$SELF_NAME" -f .github/scripts/effective-check-runs.jq)
+
+        # A later push to the default branch can cancel checks on the release
+        # commit via cancel-in-progress. Accept only a successful check with the
+        # same name/app on a descendant default-branch commit; real failures and
+        # cancellations without descendant proof remain blocking.
+        DESCENDANT_CHECK_RUNS='[]'
+        DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch // empty' 2>/dev/null || true)
+        DEFAULT_SHA=$(gh api "repos/${REPO}/commits/${DEFAULT_BRANCH}" --jq '.sha // empty' 2>/dev/null || true)
+        if [[ -n "$DEFAULT_SHA" && "$DEFAULT_SHA" != "$COMMIT_SHA" ]]; then
+          COMPARE_STATUS=$(gh api "repos/${REPO}/compare/${COMMIT_SHA}...${DEFAULT_SHA}" --jq '.status // empty' 2>/dev/null || true)
+          if [[ "$COMPARE_STATUS" == "ahead" || "$COMPARE_STATUS" == "identical" ]]; then
+            DESCENDANT_RESPONSE=$(gh api "repos/${REPO}/commits/${DEFAULT_SHA}/check-runs?per_page=100" 2>/dev/null || true)
+            if [[ -n "$DESCENDANT_RESPONSE" ]]; then
+              DESCENDANT_CHECK_RUNS=$(echo "$DESCENDANT_RESPONSE" \
+                | jq -c --arg self_name "$SELF_NAME" -f .github/scripts/effective-check-runs.jq)
+            fi
+          fi
+        fi
+        CHECK_RUNS=$(jq -cn \
+          --argjson current_runs "$EFFECTIVE_CHECK_RUNS" \
+          --argjson descendant_runs "$DESCENDANT_CHECK_RUNS" \
+          -f .github/scripts/reconcile-superseded-cancellations.jq \
+          | jq -c '.[] | {name, status, conclusion, app: (.app.slug // .app.name // "unknown"), superseded_by_check_run_id}')
         
         # Count results (excluding self)
         TOTAL=$(echo "$CHECK_RUNS" | jq -s 'length')
@@ -96,7 +118,7 @@ jobs:
         echo "$CHECK_RUNS" | jq -rs '.[] | "| \(.name) | \(.status) | \(.conclusion // "pending") |"' >> $GITHUB_STEP_SUMMARY
         
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "*Note: latest completed run per check name/app is used; 'Verify Release Health' is excluded*" >> $GITHUB_STEP_SUMMARY
+        echo "*Note: latest completed run per check name/app is used; descendant success may replace a superseded cancellation; 'Verify Release Health' is excluded*" >> $GITHUB_STEP_SUMMARY
         
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Total**: $TOTAL | **Passed**: $PASSED | **Skipped**: $SKIPPED | **Failed**: $FAILED" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- reconcile a cancelled release-commit check only when the repository default branch is a proven descendant
- require a successful completed check with the same name and GitHub App on that descendant commit
- retain real failures, timed-out checks, and cancellations without descendant-success evidence as blocking

## Evidence

Postflight run `29180143284` for v3.32.43 failed solely on `Shell portability scan (cancelled)`. The release commit was already contained in newer `main`, where the same check completed successfully after GitHub Actions `cancel-in-progress` superseded the release-SHA run.

## Implementation

- `.github/workflows/postflight.yml` verifies default-branch ancestry through the compare API before loading descendant checks.
- `.github/scripts/reconcile-superseded-cancellations.jq` replaces only matching cancelled checks with proven descendant success.
- `.agents/scripts/tests/test-postflight-check-run-dedup.sh` covers successful replacement and fail-closed mismatch/failure cases.

## Testing

- `bash .agents/scripts/tests/test-postflight-check-run-dedup.sh`
- `bash .agents/scripts/tests/test-postflight-scan-scope.sh`
- `actionlint .github/workflows/postflight.yml`
- `.agents/scripts/linters-local.sh`

All passed.

## Runtime Testing

`runtime-verified`: v3.32.43 reproduced the exact cancellation pattern; the jq fixture executes the descendant-success reconciliation while preserving unmatched cancellations and current failures.

Resolves #27289

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.41 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1h 19m and 741,647 tokens on this with the user in an interactive session.
