### PR TITLE
GH#27312: preserve divergent canonical tip during recovery

### DIFF
--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -87,10 +87,14 @@ local_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit
 	printf 'BLOCKED: local default branch tip cannot be resolved\n' >&2
 	exit 1
 }
-"$REAL_GIT" -C "$repo_path" merge-base --is-ancestor "$local_ref" "$target_sha" || {
-	printf 'BLOCKED: local default branch has diverged from origin/%s\n' "$default_branch" >&2
-	exit 1
-}
+preservation_ref=""
+if ! "$REAL_GIT" -C "$repo_path" merge-base --is-ancestor "$local_ref" "$target_sha"; then
+	preservation_ref="refs/aidevops/canonical-recovery/issue-${issue_number}/${local_sha}"
+	"$REAL_GIT" check-ref-format "$preservation_ref" >/dev/null || {
+		printf 'BLOCKED: canonical preservation ref is invalid\n' >&2
+		exit 1
+	}
+fi
 
 audit_helper="${SCRIPT_DIR}/audit-log-helper.sh"
 recovery_audit_file="${HOME}/.aidevops/logs/canonical-recovery-audit.jsonl"
@@ -104,7 +108,8 @@ AUDIT_LOG_FILE="$recovery_audit_file" "$audit_helper" verify --quiet || {
 }
 AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log operation.verify "Canonical default-branch recovery authorized" \
 	--detail "issue=${issue_number}" --detail "repo=${repo_path}" \
-	--detail "target=${default_branch}" --detail "target_sha=${target_sha}" >/dev/null || {
+	--detail "target=${default_branch}" --detail "target_sha=${target_sha}" \
+	--detail "local_sha=${local_sha}" --detail "preservation_ref=${preservation_ref:-none}" >/dev/null || {
 	printf 'BLOCKED: recovery audit record could not be written\n' >&2
 	exit 1
 }
@@ -117,9 +122,27 @@ AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log opera
 	printf 'BLOCKED: local default branch tip changed during recovery\n' >&2
 	exit 1
 }
+if [[ -n "$preservation_ref" ]]; then
+	existing_preservation_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${preservation_ref}^{commit}" 2>/dev/null || true)
+	if [[ -n "$existing_preservation_sha" && "$existing_preservation_sha" != "$local_sha" ]]; then
+		printf 'BLOCKED: canonical preservation ref already points elsewhere\n' >&2
+		exit 1
+	fi
+	if [[ -z "$existing_preservation_sha" ]]; then
+		"$REAL_GIT" -C "$repo_path" update-ref "$preservation_ref" "$local_sha" "0000000000000000000000000000000000000000"
+	fi
+	[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${preservation_ref}^{commit}")" == "$local_sha" ]] || {
+		printf 'BLOCKED: divergent canonical commit was not preserved\n' >&2
+		exit 1
+	}
+	"$REAL_GIT" -C "$repo_path" update-ref "$local_ref" "$target_sha" "$local_sha"
+fi
 "$REAL_GIT" -C "$repo_path" switch "$default_branch"
 [[ "$("$REAL_GIT" -C "$repo_path" branch --show-current)" == "$default_branch" ]] || exit 1
 "$REAL_GIT" -C "$repo_path" merge --ff-only "$target_sha"
 [[ "$("$REAL_GIT" -C "$repo_path" rev-parse HEAD)" == "$target_sha" ]] || exit 1
 [[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] || exit 1
+if [[ -n "$preservation_ref" ]]; then
+	printf 'Preserved divergent canonical tip %s at %s\n' "$local_sha" "$preservation_ref"
+fi
 printf 'Restored canonical repository to %s\n' "$default_branch"

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -72,14 +72,15 @@ local_tip=$(/usr/bin/git -C "$REPO" rev-parse main)
 printf 'remote divergence\n' >>"${UPDATER}/README.md"
 /usr/bin/git -C "$UPDATER" commit -q -am 'remote divergence'
 /usr/bin/git -C "$UPDATER" push -q origin main
-if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null 2>&1; then
-	printf 'FAIL recovery accepted divergent default branch\n'
-	exit 1
-fi
-if [[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "safety/test" ]] &&
-	[[ "$(/usr/bin/git -C "$REPO" rev-parse main)" == "$local_tip" ]]; then
-	printf 'PASS recovery refuses divergence without changing refs\n'
+preservation_ref="refs/aidevops/canonical-recovery/issue-27014/${local_tip}"
+remote_tip=$(/usr/bin/git -C "$REMOTE" rev-parse refs/heads/main)
+if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$REPO" --issue 27014 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null &&
+	[[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "main" ]] &&
+	[[ "$(/usr/bin/git -C "$REPO" rev-parse main)" == "$remote_tip" ]] &&
+	[[ "$(/usr/bin/git -C "$REPO" rev-parse "$preservation_ref")" == "$local_tip" ]] &&
+	/usr/bin/git -C "$REPO" merge-base --is-ancestor "$local_tip" "$preservation_ref"; then
+	printf 'PASS recovery preserves divergent tip and restores exact origin default\n'
 else
-	printf 'FAIL divergence refusal changed branch or refs\n'
+	printf 'FAIL divergent recovery did not preserve local tip or restore origin\n'
 	exit 1
 fi


### PR DESCRIPTION
## Summary

- Preserve a clean divergent canonical default-branch tip under a deterministic audited ref before synchronization.
- Restore the canonical default branch to the exact fetched origin tip with compare-and-swap ref updates.
- Cover ahead-and-behind recovery, preservation reachability, and exact remote synchronization.

## Testing

- `shellcheck .agents/scripts/canonical-recovery-helper.sh .agents/scripts/tests/test-canonical-recovery-helper.sh`
- `bash .agents/scripts/tests/test-canonical-recovery-helper.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

Runtime-verified with an isolated Git fixture that creates divergent local and remote commits, executes recovery, and verifies both preserved reachability and exact synchronization.

Resolves #27312

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.46 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 5m and 75,243 tokens on this with the user in an interactive session.
