### PR TITLE
GH#27314: let initial tasks call tools before greeting

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
@@ -8,7 +8,10 @@ const instruction = buildSessionStartGreetingInstruction("/missing", () => "");
 
 assert.match(instruction, /greeting is only a required prefix/);
 assert.match(instruction, /SAME assistant turn/);
-assert.match(instruction, /Never stop after acknowledging/);
-assert.match(instruction, /call the appropriate tools immediately/);
+assert.match(instruction, /Tool calls may precede it/);
+assert.match(instruction, /Never emit a greeting-only response/);
+assert.match(instruction, /Call the appropriate tools immediately, before visible text if necessary/);
+assert.match(instruction, /Do not claim that tool access is unavailable without first attempting/);
+assert.doesNotMatch(instruction, /before tool calls, status updates/);
 
 console.log("session-start task execution instruction tests passed");

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -213,10 +213,11 @@ export function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
     "",
     "What would you like to work on?",
     "",
-    "Do this before tool calls, status updates, analysis summaries, or task work.",
+    "This greeting constrains the first visible assistant text, not the first assistant action. Tool calls may precede it when needed to start an initial task, especially when the runtime cannot interleave visible text and tool calls.",
     "Do not include startup status or advisory messages in chat; those are already shown by the OpenCode toast/sidebar surfaces.",
     "If the user launched the session with an initial message, the greeting is only a required prefix: immediately execute or fully answer that message in the SAME assistant turn.",
-    "A task request already authorises task work. Never stop after acknowledging, restating, promising, or asking the user to say continue; call the appropriate tools immediately after the greeting unless genuinely blocked.",
+    "A task request already authorises task work. Never emit a greeting-only response or stop after acknowledging, restating, promising, or asking the user to say continue. Call the appropriate tools immediately, before visible text if necessary, unless genuinely blocked.",
+    "Do not claim that tool access is unavailable without first attempting an appropriate configured tool and reporting concrete failure evidence.",
     "If the initial user message is only a greeting/salutation, do not add any additional salutations, greetings, introductory questions, or equivalent help prompts after the exact greeting above.",
     "Do not repeat the greeting after the first assistant turn, and do not duplicate the framework-status toast/sidebar content.",
   ].join("\n");

--- a/.agents/scripts/generate-runtime-config-agents.sh
+++ b/.agents/scripts/generate-runtime-config-agents.sh
@@ -117,9 +117,9 @@ turn. Raw output is cached at \`${cache_path}\`. The
 user has already seen it — do NOT re-run \`aidevops-update-check.sh\` and do
 NOT repeat toast content in the chat.
 
-**On interactive conversation start** (skip for headless sessions like \`/pulse\`, \`/full-loop\`):
+**On interactive conversation start** (skip only when the runtime is actually headless; a slash-command name such as \`/full-loop\` does not make an interactive session headless):
 
-1. If an earlier system instruction declares itself the authoritative plugin-injected greeting block and supplies exact version values, follow it before any tool call or task work. Do not read the cache or VERSION first.
+1. If an earlier system instruction declares itself the authoritative plugin-injected greeting block and supplies exact version values, follow it. Its first-visible-text requirement does not prevent task tool calls from running first. Do not read the cache or VERSION first.
 2. Otherwise, the plugin injection is unavailable. Read line 1 of \`${cache_path}\`. Format: \`aidevops v{X} running in ${display_name} v{Y} | ...\`. Extract \`{X}\` and \`{Y}\`, then make the first visible text in your first assistant response exactly this template — no extra prose, no status dump:
 
        Hi!
@@ -129,7 +129,7 @@ NOT repeat toast content in the chat.
        What would you like to work on?
 
 3. In that fallback path, if the cache file is missing, read \`~/.aidevops/agents/VERSION\` for \`{X}\` and greet: "Hi!\n\nWe're running aidevops v{X}.\n\nWhat would you like to work on?"
-4. Then respond to the user's actual message. If the user launched the session with an initial message, that user message may appear first in the transcript; still put the greeting first in your assistant response. Never emit both the injected greeting and the fallback greeting.
+4. Then respond to the user's actual message. If the user launched the session with an initial task, start its tool work immediately (before visible text when the runtime cannot interleave text and tools), then prefix the first visible response with the greeting. Never emit a greeting-only response. Never emit both the injected greeting and the fallback greeting.
 
 If the user later asks about aidevops updates, direct them to run \`aidevops update\` in a terminal session (or type \`!aidevops update\` below). Do not announce updates unprompted — the toast already did.
 

--- a/.agents/scripts/tests/test-greeting-precedence.sh
+++ b/.agents/scripts/tests/test-greeting-precedence.sh
@@ -43,6 +43,11 @@ grep -q 'plugin injection is unavailable' "$GENERATED_FILE"
 # shellcheck disable=SC2016
 grep -q 'if the cache file is missing, read `~/.aidevops/agents/VERSION`' "$GENERATED_FILE"
 grep -q 'Never emit both the injected greeting and the fallback greeting' "$GENERATED_FILE"
+grep -q 'first-visible-text requirement does not prevent task tool calls from running first' "$GENERATED_FILE"
+grep -q 'Never emit a greeting-only response' "$GENERATED_FILE"
+if grep -q 'follow it before any tool call or task work' "$GENERATED_FILE"; then
+	exit 1
+fi
 # shellcheck disable=SC2016
 grep -q 'do NOT re-run `aidevops-update-check.sh`' "$GENERATED_FILE"
 if grep -q 'Run .*aidevops-update-check.sh' "$GENERATED_FILE"; then
@@ -55,6 +60,11 @@ grep -q 'plugin injection is unavailable' "$TEMPLATE_FILE"
 # shellcheck disable=SC2016
 grep -q 'if the cache file is missing, read `~/.aidevops/agents/VERSION`' "$TEMPLATE_FILE"
 grep -q 'Never emit both the injected greeting and the fallback greeting' "$TEMPLATE_FILE"
+grep -q 'first-visible-text requirement does not prevent task tool calls from running first' "$TEMPLATE_FILE"
+grep -q 'Never emit a greeting-only response' "$TEMPLATE_FILE"
+if grep -q 'follow it before any tool call or task work' "$TEMPLATE_FILE"; then
+	exit 1
+fi
 # shellcheck disable=SC2016
 grep -q 'do NOT re-run `aidevops-update-check.sh`' "$TEMPLATE_FILE"
 if grep -q 'Run .*aidevops-update-check.sh' "$TEMPLATE_FILE"; then

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -11,9 +11,9 @@ turn. Raw output is cached at `~/.aidevops/cache/session-greeting.txt`. The
 user has already seen it — do NOT re-run `aidevops-update-check.sh` and do
 NOT repeat toast content in the chat.
 
-**On interactive conversation start** (skip for headless sessions like `/pulse` and `/full-loop`):
+**On interactive conversation start** (skip only when the runtime is actually headless; a slash-command name such as `/full-loop` does not make an interactive session headless):
 
-1. If an earlier system instruction declares itself the authoritative plugin-injected greeting block and supplies exact version values, follow it before any tool call or task work. Do not read the cache or VERSION first.
+1. If an earlier system instruction declares itself the authoritative plugin-injected greeting block and supplies exact version values, follow it. Its first-visible-text requirement does not prevent task tool calls from running first. Do not read the cache or VERSION first.
 2. Otherwise, the plugin injection is unavailable. Read line 1 of `~/.aidevops/cache/session-greeting.txt`. Format: `aidevops v{X} running in OpenCode v{Y} | ...`. Extract `{X}` and `{Y}`, then make the first visible text in your first assistant response exactly this template — no extra prose or status dump:
 
    ```text
@@ -25,7 +25,7 @@ NOT repeat toast content in the chat.
    ```
 
 3. In that fallback path, if the cache file is missing, read `~/.aidevops/agents/VERSION` for `{X}` and greet: "Hi!\n\nWe're running aidevops v{X}.\n\nWhat would you like to work on?"
-4. Then respond to the user's actual message. If the user launched the session with an initial message, put the greeting first. Never emit both the injected greeting and the fallback greeting.
+4. Then respond to the user's actual message. If the user launched the session with an initial task, start its tool work immediately (before visible text when the runtime cannot interleave text and tools), then prefix the first visible response with the greeting. Never emit a greeting-only response. Never emit both the injected greeting and the fallback greeting.
 
 If the user later asks about aidevops updates, direct them to run `aidevops update` in a terminal session (or type `!aidevops update` below). Do not announce updates unprompted — the toast already did.
 


### PR DESCRIPTION
## Summary

- Remove the session-start ordering contradiction that required visible greeting text before task tool calls.
- Clarify that interactive `/full-loop` remains interactive unless the runtime is actually headless.
- Add regression coverage for plugin-injected and generated fallback guidance.

## Root cause

The greeting policy required text before tools while also requiring initial tasks to execute in the same turn. Providers that cannot interleave visible text and tool calls could satisfy only one side, leading to a tool-less refusal. The earlier prompt mitigation strengthened execution wording but retained this ordering deadlock.

## Runtime Testing

- `npm test` in `.agents/plugins/opencode-aidevops`: 349/349 passed.
- `bash .agents/scripts/tests/test-greeting-precedence.sh`: passed.
- `bash .agents/scripts/linters-local.sh`: passed.
- `shellcheck` on changed shell files: passed.

## Decisions

Keep the greeting as the first visible assistant text while allowing silent task tool calls to precede it. This preserves branding without blocking execution on runtimes that cannot mix text and tools.

Resolves #27314

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.46 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 8m and 140,115 tokens on this with the user in an interactive session.
