### PR TITLE
GH#27307: unify observation scope and deduplication

### DIFF
--- a/.agents/scripts/memory-embeddings-helper-engine.sh
+++ b/.agents/scripts/memory-embeddings-helper-engine.sh
@@ -250,25 +250,25 @@ _write_python_truth_filter() {
 	cat >>"$PYTHON_SCRIPT" <<'PYEOF'
 
 def _memory_is_live(mem_conn, memory_id: str) -> bool:
-    """Return True only for current memories that have not been retracted."""
+    """Apply the canonical live, privacy, entity, project, type, and age scope."""
+    import os
+    project = os.environ.get("MEMORY_SEARCH_PROJECT", "")
+    entity = os.environ.get("MEMORY_SEARCH_ENTITY", "")
+    mem_type = os.environ.get("MEMORY_SEARCH_TYPE", "")
+    max_age = os.environ.get("MEMORY_SEARCH_MAX_AGE_DAYS", "")
     row = mem_conn.execute(
         """SELECT 1
            FROM learnings l
+           JOIN observations o ON o.observation_id = 'obs_learning_' || l.id
            WHERE l.id = ?
-             AND COALESCE((
-                 SELECT status
-                 FROM learning_truth_events truth_pick
-                 WHERE truth_pick.memory_id = l.id
-                 ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC
-                 LIMIT 1
-             ), 'live') NOT IN ('debunked', 'retracted')
-             AND NOT EXISTS (
-                 SELECT 1
-                 FROM learning_relations superseded_by
-                 WHERE superseded_by.supersedes_id = l.id
-                   AND superseded_by.relation_type = 'updates'
-             )""",
-        (memory_id,)
+              AND o.status = 'active'
+              AND (o.expires_at IS NULL OR o.expires_at > datetime('now'))
+              AND (? = '' OR o.project_scope = ?)
+              AND (? = '' OR o.subject_id = ? OR o.owner_id = ?)
+              AND (? = '' OR l.type = ?)
+              AND (? = '' OR l.created_at >= datetime('now', '-' || ? || ' days'))""",
+        (memory_id, project, project, entity, entity, entity,
+         mem_type, mem_type, max_age, max_age)
     ).fetchone()
     return row is not None
 PYEOF
@@ -415,22 +415,11 @@ def _hybrid_fts5_search(mem_conn, query: str, semantic_limit: int) -> list:
             """SELECT id, bm25(learnings) as score
                FROM learnings
                WHERE learnings MATCH ?
-                 AND COALESCE((
-                     SELECT status FROM learning_truth_events truth_pick
-                     WHERE truth_pick.memory_id = learnings.id
-                     ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC
-                     LIMIT 1
-                 ), 'live') NOT IN ('debunked', 'retracted')
-                 AND NOT EXISTS (
-                     SELECT 1 FROM learning_relations superseded_by
-                     WHERE superseded_by.supersedes_id = learnings.id
-                       AND superseded_by.relation_type = 'updates'
-                 )
                ORDER BY score
                LIMIT ?""",
             (fts_query, semantic_limit)
         ).fetchall()
-        return [(row[0], row[1]) for row in fts_rows]
+        return [(row[0], row[1]) for row in fts_rows if _memory_is_live(mem_conn, row[0])]
     except sqlite3.OperationalError:
         # FTS5 query failed (e.g., special characters) — fall back to semantic only
         return []

--- a/.agents/scripts/memory-graduate-helper.sh
+++ b/.agents/scripts/memory-graduate-helper.sh
@@ -221,7 +221,8 @@ _query_candidates_json() {
 	local limit="$2"
 	local raw_results=""
 
-	raw_results=$(db -json "$MEMORY_DB" <<EOF
+	raw_results=$(
+		db -json "$MEMORY_DB" <<EOF
 SELECT
     l.id,
     l.type,
@@ -232,23 +233,16 @@ SELECT
     COALESCE(a.access_count, 0) as access_count,
     COALESCE(a.last_accessed_at, '') as last_accessed_at
 FROM learnings l
+JOIN observations o ON o.observation_id = 'obs_learning_' || l.id
 LEFT JOIN learning_access a ON l.id = a.id
 WHERE (
     l.confidence = 'high'
     OR COALESCE(a.access_count, 0) >= $min_access
 )
 AND l.type != 'USER_PREFERENCE'
-AND COALESCE((
-    SELECT status FROM learning_truth_events truth_pick
-    WHERE truth_pick.memory_id = l.id
-    ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC
-    LIMIT 1
-), 'live') NOT IN ('debunked', 'retracted')
-AND NOT EXISTS (
-    SELECT 1 FROM learning_relations superseded_by
-    WHERE superseded_by.supersedes_id = l.id
-      AND superseded_by.relation_type = 'updates'
-)
+AND o.status = 'active'
+AND (o.expires_at IS NULL OR o.expires_at > datetime('now'))
+AND o.sensitivity IN ('public', 'internal')
 AND (a.graduated_at IS NULL OR a.graduated_at = '')
 ORDER BY
     CASE WHEN l.confidence = 'high' THEN 0 ELSE 1 END,

--- a/.agents/scripts/memory/maintenance-consolidate.sh
+++ b/.agents/scripts/memory/maintenance-consolidate.sh
@@ -91,6 +91,8 @@ _consolidate_merge_pair() {
 		echo "[WARN] Failed to transfer access history from $newer_id_esc to $older_id_esc" >&2
 
 	# Re-point relations and delete newer entry
+	db "$MEMORY_DB" "UPDATE observation_sources SET observation_id = 'obs_learning_' || '$older_id_esc' WHERE observation_id = 'obs_learning_' || '$newer_id_esc';"
+	db "$MEMORY_DB" "DELETE FROM observations WHERE observation_id = 'obs_learning_' || '$newer_id_esc';"
 	db "$MEMORY_DB" "UPDATE learning_relations SET supersedes_id = '$older_id_esc' WHERE supersedes_id = '$newer_id_esc';"
 	db "$MEMORY_DB" "DELETE FROM learning_relations WHERE id = '$newer_id_esc';"
 	db "$MEMORY_DB" "DELETE FROM learning_access WHERE id = '$newer_id_esc';"
@@ -119,6 +121,17 @@ FROM learnings l1
 JOIN learnings l2 ON l1.type = l2.type
     AND l1.id < l2.id
     AND l1.content != l2.content
+JOIN observations o1 ON o1.observation_id = 'obs_learning_' || l1.id
+JOIN observations o2 ON o2.observation_id = 'obs_learning_' || l2.id
+    AND o1.kind = o2.kind
+    AND COALESCE(o1.owner_id, '') = COALESCE(o2.owner_id, '')
+    AND COALESCE(o1.subject_id, '') = COALESCE(o2.subject_id, '')
+    AND COALESCE(o1.project_scope, '') = COALESCE(o2.project_scope, '')
+    AND COALESCE(o1.organization_scope, '') = COALESCE(o2.organization_scope, '')
+    AND COALESCE(o1.user_scope, '') = COALESCE(o2.user_scope, '')
+    AND o1.framework_scope = o2.framework_scope
+    AND o1.sensitivity = o2.sensitivity
+    AND o1.status = o2.status
 WHERE (
     (SELECT COUNT(*) FROM (
         SELECT value FROM json_each('["' || replace(lower(l1.content), ' ', '","') || '"]')
@@ -129,6 +142,9 @@ WHERE (
         length(l2.content) - length(replace(l2.content, ' ', '')) + 1
     ) > $similarity_threshold
 )
+AND o1.status = 'active'
+AND (o1.expires_at IS NULL OR o1.expires_at > datetime('now'))
+AND (o2.expires_at IS NULL OR o2.expires_at > datetime('now'))
 LIMIT 20;
 EOF
 	return 0

--- a/.agents/scripts/memory/maintenance-dedup.sh
+++ b/.agents/scripts/memory/maintenance-dedup.sh
@@ -51,6 +51,18 @@ _dedup_merge_tags() {
 	return 0
 }
 
+_dedup_merge_observation_evidence() {
+	local keep_id_esc="$1"
+	local remove_id_esc="$2"
+	db "$MEMORY_DB" <<EOF
+UPDATE observation_sources
+SET observation_id = 'obs_learning_' || '$keep_id_esc'
+WHERE observation_id = 'obs_learning_' || '$remove_id_esc';
+DELETE FROM observations WHERE observation_id = 'obs_learning_' || '$remove_id_esc';
+EOF
+	return 0
+}
+
 #######################################
 # Phase 1: Remove exact duplicate entries (same content string)
 # Args: dry_run
@@ -63,9 +75,12 @@ _dedup_exact_phase() {
 	local exact_groups
 	exact_groups=$(
 		db "$MEMORY_DB" <<'EOF'
-SELECT GROUP_CONCAT(id, '|') as ids, content, type, COUNT(*) as cnt
-FROM learnings
-GROUP BY content
+SELECT GROUP_CONCAT(l.id, ',') as ids, COUNT(*) as cnt
+FROM learnings l JOIN observations o ON o.observation_id = 'obs_learning_' || l.id
+WHERE o.status = 'active' AND (o.expires_at IS NULL OR o.expires_at > datetime('now'))
+GROUP BY l.content, o.kind, COALESCE(o.owner_id, ''), COALESCE(o.subject_id, ''),
+         COALESCE(o.project_scope, ''), COALESCE(o.organization_scope, ''),
+         COALESCE(o.user_scope, ''), o.framework_scope, o.sensitivity, o.status
 HAVING cnt > 1
 ORDER BY cnt DESC;
 EOF
@@ -73,14 +88,9 @@ EOF
 
 	[[ -z "$exact_groups" ]] && echo "$exact_removed" && return 0
 
-	local dup_contents
-	dup_contents=$(db "$MEMORY_DB" "SELECT content FROM learnings GROUP BY content HAVING COUNT(*) > 1;")
-
-	while IFS= read -r dup_content; do
-		[[ -z "$dup_content" ]] && continue
-		local escaped_dup="${dup_content//"'"/"''"}"
-		local all_ids
-		all_ids=$(db "$MEMORY_DB" "SELECT id FROM learnings WHERE content = '$escaped_dup' ORDER BY created_at ASC;")
+	while IFS='|' read -r id_list _count; do
+		[[ -z "$id_list" ]] && continue
+		local all_ids="${id_list//,/$'\n'}"
 
 		local keep_id=""
 		while IFS= read -r mem_id; do
@@ -96,6 +106,7 @@ EOF
 				log_info "[DRY RUN] Would remove $mem_id (duplicate of $keep_id)" >&2
 			else
 				_dedup_merge_tags "$escaped_keep" "$escaped_remove"
+				_dedup_merge_observation_evidence "$escaped_keep" "$escaped_remove"
 				# Transfer access history (keep higher count)
 				db "$MEMORY_DB" <<EOF
 INSERT INTO learning_access (id, last_accessed_at, access_count)
@@ -113,7 +124,7 @@ EOF
 			fi
 			exact_removed=$((exact_removed + 1))
 		done <<<"$all_ids"
-	done <<<"$dup_contents"
+	done <<<"$exact_groups"
 
 	echo "$exact_removed"
 	return 0
@@ -135,8 +146,11 @@ SELECT GROUP_CONCAT(id, ',') as ids,
        replace(replace(replace(replace(replace(lower(content),
            '.',''),"'",''),',',''),'!',''),'?','') as norm,
        COUNT(*) as cnt
-FROM learnings
-GROUP BY norm
+FROM learnings l JOIN observations o ON o.observation_id = 'obs_learning_' || l.id
+WHERE o.status = 'active' AND (o.expires_at IS NULL OR o.expires_at > datetime('now'))
+GROUP BY norm, o.kind, COALESCE(o.owner_id, ''), COALESCE(o.subject_id, ''),
+         COALESCE(o.project_scope, ''), COALESCE(o.organization_scope, ''),
+         COALESCE(o.user_scope, ''), o.framework_scope, o.sensitivity, o.status
 HAVING cnt > 1
 ORDER BY cnt DESC;
 EOF
@@ -208,6 +222,7 @@ EOF
 				log_info "[DRY RUN] Would remove near-dup $nid (keep $oldest_id): $preview..." >&2
 			else
 				_dedup_merge_tags "$oldest_esc" "$nid_esc"
+				_dedup_merge_observation_evidence "$oldest_esc" "$nid_esc"
 				db_cleanup "$MEMORY_DB" "UPDATE learning_relations SET supersedes_id = '$oldest_esc' WHERE supersedes_id = '$nid_esc';"
 				db_cleanup "$MEMORY_DB" "DELETE FROM learning_relations WHERE id = '$nid_esc';"
 				db "$MEMORY_DB" "DELETE FROM learning_access WHERE id = '$nid_esc';"
@@ -235,13 +250,14 @@ _dedup_semantic_phase() {
 	log_info "Scanning for semantic duplicates (AI-judged)..." >&2
 
 	local types
-	types=$(db "$MEMORY_DB" "SELECT DISTINCT type FROM learnings;")
+	types=$(db "$MEMORY_DB" "SELECT DISTINCT l.type || '|' || COALESCE(o.owner_id, '') || '|' || COALESCE(o.subject_id, '') || '|' || COALESCE(o.project_scope, '') || '|' || COALESCE(o.organization_scope, '') || '|' || COALESCE(o.user_scope, '') || '|' || o.framework_scope || '|' || o.sensitivity FROM learnings l JOIN observations o ON o.observation_id = 'obs_learning_' || l.id WHERE o.status = 'active' AND (o.expires_at IS NULL OR o.expires_at > datetime('now'));")
 
-	while IFS= read -r check_type; do
+	while IFS='|' read -r check_type owner subject project organization user framework sensitivity; do
 		[[ -z "$check_type" ]] && continue
 		local type_esc="${check_type//"'"/"''"}"
+		local scope_where="AND COALESCE(o.owner_id, '') = '${owner//"'"/"''"}' AND COALESCE(o.subject_id, '') = '${subject//"'"/"''"}' AND COALESCE(o.project_scope, '') = '${project//"'"/"''"}' AND COALESCE(o.organization_scope, '') = '${organization//"'"/"''"}' AND COALESCE(o.user_scope, '') = '${user//"'"/"''"}' AND o.framework_scope = '${framework//"'"/"''"}' AND o.sensitivity = '${sensitivity//"'"/"''"}'"
 		local entries
-		entries=$(db "$MEMORY_DB" "SELECT id, substr(content, 1, 200), created_at FROM learnings WHERE type = '$type_esc' ORDER BY created_at ASC LIMIT 50;")
+		entries=$(db "$MEMORY_DB" "SELECT l.id, substr(l.content, 1, 200), l.created_at FROM learnings l JOIN observations o ON o.observation_id = 'obs_learning_' || l.id WHERE l.type = '$type_esc' $scope_where AND o.status = 'active' AND (o.expires_at IS NULL OR o.expires_at > datetime('now')) ORDER BY l.created_at ASC LIMIT 50;")
 
 		local ids_arr=() contents_arr=()
 		while IFS='|' read -r eid econtent _edate; do
@@ -269,6 +285,7 @@ _dedup_semantic_phase() {
 						log_info "[DRY RUN] Semantic dup: remove $remove_id (keep $keep_id): ${contents_arr[$j]:0:50}..." >&2
 					else
 						_dedup_merge_tags "$keep_esc" "$remove_esc"
+						_dedup_merge_observation_evidence "$keep_esc" "$remove_esc"
 						db_cleanup "$MEMORY_DB" "UPDATE learning_relations SET supersedes_id = '$keep_esc' WHERE supersedes_id = '$remove_esc';"
 						db_cleanup "$MEMORY_DB" "DELETE FROM learning_relations WHERE id = '$remove_esc';"
 						db "$MEMORY_DB" "DELETE FROM learning_access WHERE id = '$remove_esc';"

--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -294,6 +294,7 @@ SELECT
     bm25(learnings) as bm25_score,
     (bm25(learnings) - (COALESCE(learning_access.usefulness_score, 0.0) * 0.3)) as score
 FROM learnings
+INNER JOIN observations observation ON observation.observation_id = 'obs_learning_' || learnings.id
 LEFT JOIN learning_access ON learnings.id = learning_access.id
 LEFT JOIN learning_truth_events latest_truth ON latest_truth.event_id = (
     SELECT event_id FROM learning_truth_events truth_pick
@@ -305,8 +306,8 @@ LEFT JOIN learning_relations superseded_by ON superseded_by.supersedes_id = lear
     AND superseded_by.relation_type = 'updates'
 $entity_fts_join
 WHERE learnings MATCH :query $extra_filters $auto_join_filter $entity_fts_where
-AND COALESCE(latest_truth.status, 'live') NOT IN ('debunked', 'retracted')
-AND superseded_by.id IS NULL
+AND observation.status = 'active'
+AND (observation.expires_at IS NULL OR observation.expires_at > datetime('now'))
 ORDER BY score
 LIMIT $limit;
 EOF
@@ -409,7 +410,7 @@ _recall_recent() {
 	local extra_filters="$7"
 
 	local results
-	results=$(db -json "$db_path" "SELECT l.id, l.content, l.type, l.tags, l.confidence, l.created_at, COALESCE(a.last_accessed_at, '') as last_accessed_at, COALESCE(a.access_count, 0) as access_count, COALESCE(a.auto_captured, 0) as auto_captured, COALESCE(a.usefulness_score, 0.0) as usefulness_score, COALESCE(latest_truth.status, 'live') as truth_status, COALESCE(latest_truth.evidence, '') as truth_evidence, COALESCE(latest_truth.replacement_id, '') as replacement_id, COALESCE(superseded_by.id, '') as superseded_by FROM learnings l LEFT JOIN learning_access a ON l.id = a.id LEFT JOIN learning_truth_events latest_truth ON latest_truth.event_id = (SELECT event_id FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1) LEFT JOIN learning_relations superseded_by ON superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates' $entity_join WHERE 1=1 $entity_where $auto_filter $extra_filters AND COALESCE(latest_truth.status, 'live') NOT IN ('debunked', 'retracted') AND superseded_by.id IS NULL ORDER BY l.created_at DESC LIMIT $limit;")
+	results=$(db -json "$db_path" "SELECT l.id, l.content, l.type, l.tags, l.confidence, l.created_at, COALESCE(a.last_accessed_at, '') as last_accessed_at, COALESCE(a.access_count, 0) as access_count, COALESCE(a.auto_captured, 0) as auto_captured, COALESCE(a.usefulness_score, 0.0) as usefulness_score, o.status as truth_status, '' as truth_evidence, '' as replacement_id, '' as superseded_by FROM learnings l INNER JOIN observations o ON o.observation_id = 'obs_learning_' || l.id LEFT JOIN learning_access a ON l.id = a.id $entity_join WHERE 1=1 $entity_where $auto_filter $extra_filters AND o.status = 'active' AND (o.expires_at IS NULL OR o.expires_at > datetime('now')) ORDER BY l.created_at DESC LIMIT $limit;")
 	if [[ "$format" == "json" ]]; then
 		printf '%s\n' "$results"
 	else
@@ -421,7 +422,7 @@ _recall_recent() {
 
 #######################################
 # Handle --semantic / --hybrid mode: delegate to embeddings helper
-# Usage: _recall_semantic <query> <limit> <hybrid_mode> <format>
+# Usage: _recall_semantic <query> <limit> <hybrid_mode> <format> <project> <entity> <type> <max_age>
 # Returns: exit code from embeddings helper, or 1 if unavailable
 #######################################
 _recall_semantic() {
@@ -429,6 +430,10 @@ _recall_semantic() {
 	local limit="$2"
 	local hybrid_mode="$3"
 	local format="$4"
+	local project_filter="$5"
+	local entity_filter="$6"
+	local type_filter="$7"
+	local max_age_days="$8"
 
 	local embeddings_script
 	embeddings_script="$(dirname "${BASH_SOURCE[0]}")/../memory-embeddings-helper.sh"
@@ -447,7 +452,9 @@ _recall_semantic() {
 	if [[ "$format" == "json" ]]; then
 		semantic_args+=("--json")
 	fi
-	"$embeddings_script" "${semantic_args[@]}"
+	MEMORY_SEARCH_PROJECT="$project_filter" MEMORY_SEARCH_ENTITY="$entity_filter" \
+		MEMORY_SEARCH_TYPE="$type_filter" MEMORY_SEARCH_MAX_AGE_DAYS="$max_age_days" \
+		"$embeddings_script" "${semantic_args[@]}"
 	return $?
 }
 
@@ -639,16 +646,13 @@ cmd_recall() {
 
 	# Handle --semantic or --hybrid mode (delegate to embeddings helper)
 	if [[ "$semantic_mode" == true || "$hybrid_mode" == true ]]; then
-		# Semantic retrieval currently owns truth maintenance but does not yet
-		# implement the keyword path's scope/type/age/capture/shared filters. Fail
-		# closed instead of silently returning out-of-scope memories.
-		if [[ -n "$type_filter" || -n "$max_age_days" || -n "$project_filter" ||
-			-n "$entity_filter" || "$auto_only" == true || "$manual_only" == true ||
+		if [[ "$auto_only" == true || "$manual_only" == true ||
 			"$shared_mode" == true ]]; then
-			log_error "Semantic/hybrid recall does not support scoped filters yet; use keyword recall for --type, --max-age-days, --project, --entity, --auto-only, --manual-only, or --shared"
+			log_error "Semantic/hybrid recall does not support --auto-only, --manual-only, or --shared"
 			return 1
 		fi
-		_recall_semantic "$query" "$limit" "$hybrid_mode" "$format"
+		_recall_semantic "$query" "$limit" "$hybrid_mode" "$format" \
+			"$project_filter" "$entity_filter" "$type_filter" "$max_age_days"
 		return $?
 	fi
 

--- a/.agents/scripts/memory/store.sh
+++ b/.agents/scripts/memory/store.sh
@@ -350,6 +350,38 @@ _store_auto_index() {
 	return 0
 }
 
+_store_check_duplicate() {
+	local escaped_content="${_store_content//"'"/"''"}"
+	local escaped_entity="${_store_entity_id//"'"/"''"}"
+	local existing_id
+	existing_id=$(db "$MEMORY_DB" "SELECT l.id FROM learnings l JOIN observations o ON o.observation_id = 'obs_learning_' || l.id WHERE l.content = '$escaped_content' AND l.type = '$_store_type' AND COALESCE(o.owner_id, '') = '$escaped_entity' AND COALESCE(o.subject_id, '') = '$escaped_entity' AND COALESCE(o.project_scope, '') = '$_store_esc_project' AND o.sensitivity = 'internal' AND o.status = 'active' AND (o.expires_at IS NULL OR o.expires_at > datetime('now')) LIMIT 1;" 2>/dev/null || true)
+	if [[ -n "$existing_id" ]]; then
+		printf '%s\n' "$existing_id"
+		return 0
+	fi
+
+	local normalized
+	normalized=$(normalize_content "$_store_content")
+	local candidates
+	candidates=$(db "$MEMORY_DB" "SELECT l.id, l.content FROM learnings l JOIN observations o ON o.observation_id = 'obs_learning_' || l.id WHERE l.type = '$_store_type' AND COALESCE(o.owner_id, '') = '$escaped_entity' AND COALESCE(o.subject_id, '') = '$escaped_entity' AND COALESCE(o.project_scope, '') = '$_store_esc_project' AND o.sensitivity = 'internal' AND o.status = 'active' AND (o.expires_at IS NULL OR o.expires_at > datetime('now'));" 2>/dev/null || true)
+	while IFS='|' read -r candidate_id candidate_content; do
+		[[ -z "$candidate_id" ]] && continue
+		if [[ "$(normalize_content "$candidate_content")" == "$normalized" ]]; then
+			printf '%s\n' "$candidate_id"
+			return 0
+		fi
+	done <<<"$candidates"
+
+	existing_id=$(MEMORY_SEARCH_PROJECT="$_store_project_path" \
+		MEMORY_SEARCH_ENTITY="$_store_entity_id" MEMORY_SEARCH_TYPE="$_store_type" \
+		check_semantic_duplicate "$_store_content" "$_store_type" || true)
+	if [[ -n "$existing_id" ]]; then
+		printf '%s\n' "$existing_id"
+		return 0
+	fi
+	return 1
+}
+
 #######################################
 # Store a learning
 #######################################
@@ -374,21 +406,14 @@ cmd_store() {
 	fi
 
 	init_db
+	_store_prepare_metadata || return 1
 
-	# Deduplication: skip if content already exists (unless it's a relational update)
+	# Deduplication is restricted to the canonical observation identity and live scope.
 	if [[ -z "$_store_supersedes_id" && -z "$_store_debunks_id" ]]; then
 		local existing_id
-		if existing_id=$(check_duplicate "$_store_content" "$_store_type"); then
+		if existing_id=$(_store_check_duplicate); then
 			log_warn "Duplicate detected (matches $existing_id). Skipping store."
-			# Update access tracking on the existing entry to keep it fresh
-			db "$MEMORY_DB" <<EOF
-INSERT INTO learning_access (id, last_accessed_at, access_count)
-VALUES ('$existing_id', datetime('now'), 1)
-ON CONFLICT(id) DO UPDATE SET 
-    last_accessed_at = datetime('now'),
-    access_count = access_count + 1;
-EOF
-			echo "$existing_id"
+			printf '%s\n' "$existing_id"
 			return 0
 		fi
 	fi
@@ -396,13 +421,15 @@ EOF
 	# Opportunistic auto-prune (runs at most once per 24h)
 	auto_prune
 
-	# Prepare metadata: IDs, timestamps, SQL-escaped values
-	_store_prepare_metadata || return 1
-
 	# Insert all records into the database
 	_store_insert_record || return 1
 	# Canonical observations are authoritative; learnings remain the retrieval projection.
 	_backfill_legacy_observations || return 1
+	if [[ -n "$_store_debunks_id" ]]; then
+		db "$MEMORY_DB" "UPDATE observations SET status = 'debunked' WHERE observation_id = 'obs_learning_' || '$_store_esc_supersedes';"
+	elif [[ -n "$_store_supersedes_id" && "$_store_relation_type" == "updates" ]]; then
+		db "$MEMORY_DB" "UPDATE observations SET status = 'superseded' WHERE observation_id = 'obs_learning_' || '$_store_esc_supersedes';"
+	fi
 
 	log_success "Stored learning: $_store_id"
 

--- a/tests/test-observation-scope-and-dedup.sh
+++ b/tests/test-observation-scope-and-dedup.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	[[ "$actual" == "$expected" ]] || fail "$message (expected $expected, got $actual)"
+	return 0
+}
+
+memory() {
+	AIDEVOPS_MEMORY_DIR="$TEST_DIR" AIDEVOPS_VAULT_DIR="$TEST_DIR/no-vault" "$MEMORY_HELPER" "$@"
+	return $?
+}
+
+store_id() {
+	memory store "$@" | sed -n '$p'
+	return "${PIPESTATUS[0]}"
+}
+
+query() {
+	local sql="$1"
+	sqlite3 "$TEST_DIR/memory.db" "$sql"
+	return $?
+}
+
+id_a=$(store_id --content "Prefers compact audit output" --type USER_PREFERENCE --project /project/a)
+id_b=$(store_id --content "Prefers compact audit output" --type USER_PREFERENCE --project /project/b)
+id_a_repeat=$(store_id --content "Prefers compact audit output" --type USER_PREFERENCE --project /project/a)
+assert_eq "$id_a" "$id_a_repeat" "exact dedup stays within project scope"
+[[ "$id_a" != "$id_b" ]] || fail "cross-project preferences must not deduplicate"
+assert_eq 2 "$(query 'SELECT COUNT(*) FROM observations WHERE kind="preference" AND status="active";')" "both scoped preferences remain live"
+assert_eq 0 "$(query "SELECT COALESCE(access_count, 0) FROM learning_access WHERE id='$id_a' UNION ALL SELECT 0 LIMIT 1;")" "reprocessing one source does not add evidence"
+
+query "UPDATE observations SET status='debunked' WHERE observation_id='obs_learning_$id_a';"
+recent=$(memory recall --recent --project /project/a --json | sed -n '/^\[/,$p')
+assert_eq "" "$recent" "recent recall hides non-live observations"
+keyword=$(memory recall compact --project /project/a --json | sed -n '/^\[/,$p')
+assert_eq "" "$keyword" "keyword recall hides non-live observations"
+
+# Seed an independently sourced duplicate in one scope and verify provenance is retained.
+id_c=$(store_id --content "Scoped duplicate evidence" --type CONTEXT --project /project/c)
+query "INSERT INTO learnings VALUES ('mem_seed','session_seed','Scoped duplicate evidence','CONTEXT','','medium','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z','/project/c','fixture');"
+query "INSERT INTO observations SELECT 'obs_learning_mem_seed',kind,owner_id,subject_id,'session_seed',user_scope,project_scope,organization_scope,framework_scope,state,statement,confidence,sensitivity,consent,effective_at,review_at,expires_at,destination,status,'2026-01-01T00:00:00Z' FROM observations WHERE observation_id='obs_learning_$id_c';"
+query "INSERT INTO observation_sources VALUES ('src_learning_mem_seed','obs_learning_mem_seed','learning','mem_seed','session_seed','Scoped duplicate evidence','fixture','2026-01-01T00:00:00Z');"
+memory dedup --exact-only >/dev/null
+assert_eq 1 "$(query 'SELECT COUNT(*) FROM learnings WHERE content="Scoped duplicate evidence";')" "same-scope exact duplicates merge"
+assert_eq 2 "$(query 'SELECT COUNT(*) FROM observation_sources WHERE evidence="Scoped duplicate evidence";')" "independent source evidence survives merge"
+assert_eq 1 "$(query 'SELECT COUNT(DISTINCT observation_id) FROM observation_sources WHERE evidence="Scoped duplicate evidence";')" "merged evidence points to one observation"
+
+printf 'PASS: observation scope, live retrieval, dedup partitioning, and source evidence\n'


### PR DESCRIPTION
## Summary

- Apply canonical observation live and scope policy across keyword, recent, semantic, and hybrid retrieval
- Partition exact, normalized, and semantic deduplication by observation identity scope
- Preserve source evidence while preventing repeated-source evidence inflation
- Align consolidation and graduation with canonical live state

## Runtime Testing

Self-assessed low-risk shell/data-policy change with focused integration tests.

## Testing

- `bash tests/test-observation-scope-and-dedup.sh`
- focused truth, dedup, consolidation, and graduation tests
- `bash -n`
- ShellCheck
- `.agents/scripts/linters-local.sh`

Resolves #27307

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.46 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 12m and 41,301 tokens on this with the user in an interactive session.
