### PR TITLE
GH#27175: simplify command policy helper

### DIFF
--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -121,17 +121,27 @@ from command_policy_wrappers import (
 # Referencing compatibility imports explicitly also satisfies static analyzers.
 _COMPAT_EXPORTS = (
     _decision,
+    _has_required_guard,
     _canonical_operand,
+    _git_parts,
     _EvaluationOptions,
+    _canonical_guard_path,
     analyze_network_argv,
     _analyze_curl,
+    _curl_connect_option,
     _analyze_git,
+    _analyze_git_remote,
     _add_destination,
+    _git_effective_cwd,
     _analyze_scp,
+    _analyze_ssh,
     WORKER_ENV_KEYS,
     _analyze_wget,
+    _wget_arg,
     SHELL_OPERATORS,
+    _scan_supported_shell,
     SHELLS,
+    _consume_option,
 )
 __all__ = [name for name in globals() if name.startswith("_") and not name.startswith("__")]
 

--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -5,1008 +5,130 @@
 
 from __future__ import annotations
 
-import argparse
-import ipaddress
 import json
-import os
-import re
-import shlex
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from command_policy_config import (
+    PolicyError,
+    _default_policy_path,
+    _decision,
+    _has_required_guard,
+    _load_policy,
+    _parse_error,
+    _policy_error,
+    _validate_policy_guards,
+    _validate_policy_rules,
+    _validate_policy_shape,
+)
+from command_policy_matchers import (
+    _canonical_operand,
+    _git_parts,
+    _has_flag,
+    _is_root_or_home_operand,
+    _is_temp_operand,
+    _matches,
+    _matches_git,
+    _matches_rm,
+    _rm_operands,
+    _short_flags,
+)
+from command_policy_evaluation import (
+    _EvaluationOptions,
+    _canonical_guard_path,
+    _evaluate_canonical_git,
+    _evaluate_static,
+    _evaluate_worker_network,
+    _evaluation_options,
+    _network_guard_path,
+    evaluate_invocations,
+)
+from command_policy_dispatch import CommandParseError, _validate_argv, analyze_network_argv
+from command_policy_http import (
+    _analyze_curl,
+    _curl_connect_option,
+    _curl_destination_option,
+    _curl_other_arg,
+    _curl_resolve_option,
+    _curl_short_value_index,
+    _option_value,
+)
+from command_policy_git import (
+    _analyze_git,
+    _analyze_git_remote,
+    _classify_git_candidate,
+    _git_network_candidate,
+    _record_git_config_overrides,
+)
+from command_policy_network import (
+    _add_destination,
+    _git_effective_cwd,
+    _host_candidate,
+    _normalize_host,
+    _resolve_git_remote,
+)
+from command_policy_transport import (
+    _analyze_scp,
+    _analyze_ssh,
+    _classify_scp_option,
+    _scp_arg,
+    _ssh_arg,
+    _ssh_extended_option,
+    _ssh_forward_destination,
+    _ssh_value_option,
+)
+from command_policy_runtime import (
+    WORKER_ENV_KEYS,
+    _argument_parser,
+    _network_action,
+    _report_policy_error,
+    _worker_from_environment,
+)
+from command_policy_wget import _analyze_wget, _wget_arg, _wget_execute_option
+from command_policy_parser import (
+    SHELL_OPERATORS,
+    _expand_argv,
+    _scan_supported_shell,
+    _shell_invocations,
+    _shell_quote_state,
+    _validate_shell_character,
+)
+from command_policy_wrappers import (
+    SHELLS,
+    _consume_option,
+    _expand_launcher as _expand_wrapper_launcher,
+    _expand_shell_launcher as _expand_wrapper_shell_launcher,
+    _is_attached_value_option,
+    _is_combined_short_flags,
+    _is_safety_sensitive_assignment,
+    _reject_dynamic_launcher,
+    _shell_command_index,
+    _shell_value_option_index,
+    _strip_leading_assignments,
+    _unwrap_command,
+    _unwrap_env,
+    _unwrap_exec,
+    _unwrap_simple_wrapper,
+    _unwrap_sudo,
+    _unwrap_time,
+)
 
 FORBID_EXIT = 20
 POLICY_ERROR_EXIT = 21
-SHELL_OPERATORS = {"&&", "||", ";", "|"}
-SHELLS = {"bash", "dash", "ksh", "sh", "zsh"}
-KNOWN_MATCHERS = {
-    "rm_recursive_force_root",
-    "rm_recursive_force",
-    "git_checkout_worktree_path",
-    "git_restore_worktree",
-    "git_reset_destructive",
-    "git_clean_force",
-    "git_push_force",
-    "git_branch_force_delete",
-    "git_stash_delete",
-}
-DECISION_RANK = {"allow": 0, "forbid": 1}
-WORKER_ENV_KEYS = (
-    "FULL_LOOP_HEADLESS",
-    "AIDEVOPS_HEADLESS",
-    "OPENCODE_HEADLESS",
-    "CLAUDE_HEADLESS",
-    "Claude_HEADLESS",
-    "HEADLESS",
-    "GITHUB_ACTIONS",
-)
 
 
-class PolicyError(ValueError):
-    """Raised when required policy data cannot be trusted."""
+def _expand_launcher(
+    argv: list[str], executable: str
+) -> tuple[list[list[str]] | None, list[str]]:
+    return _expand_wrapper_launcher(argv, executable, _shell_invocations)
 
 
-class CommandParseError(ValueError):
-    """Raised when shell syntax cannot be represented as deterministic argv."""
-
-
-def _decision(decision: str, rule_id: str, reason: str) -> dict[str, Any]:
-    return {
-        "schema_version": 2,
-        "decision": decision,
-        "rule_id": rule_id,
-        "reason": reason,
-    }
-
-
-def _policy_error(reason: str) -> dict[str, Any]:
-    return _decision("forbid", "policy.invalid", reason)
-
-
-def _parse_error(reason: str) -> dict[str, Any]:
-    return _decision("forbid", "command.parse-error", reason)
-
-
-def _default_policy_path() -> Path:
-    override = os.environ.get("AIDEVOPS_COMMAND_POLICY_CONFIG", "")
-    if override:
-        return Path(override)
-    return Path(__file__).resolve().parent.parent / "configs" / "command-policy.json"
-
-
-def _load_policy(path: Path) -> dict[str, Any]:
-    try:
-        raw = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise PolicyError(f"required command policy is unavailable: {path}: {exc}") from exc
-    try:
-        policy = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise PolicyError(f"required command policy is malformed: {path}: {exc}") from exc
-    _validate_policy_shape(policy)
-    return policy
-
-
-def _validate_policy_shape(policy: Any) -> None:
-    if not isinstance(policy, dict) or policy.get("schema_version") != 2:
-        raise PolicyError("command policy schema_version must be 2")
-    if policy.get("decision_order") != ["allow", "forbid"]:
-        raise PolicyError("command policy decision_order must be allow, forbid")
-    default = policy.get("default_decision")
-    if not isinstance(default, dict) or default.get("decision") != "allow":
-        raise PolicyError("command policy requires an allow default_decision")
-    guards = policy.get("dynamic_guards")
-    canonical = [
-        guard
-        for guard in guards or []
-        if isinstance(guard, dict) and guard.get("kind") == "canonical_git"
-    ]
-    if (
-        len(canonical) != 1
-        or canonical[0].get("helper") != "canonical-git-command-guard.py"
-        or canonical[0].get("decision") != "forbid"
-    ):
-        raise PolicyError("command policy requires exactly one canonical Git guard")
-    network = [
-        guard
-        for guard in guards or []
-        if isinstance(guard, dict) and guard.get("kind") == "worker_network"
-    ]
-    if (
-        len(network) != 1
-        or network[0].get("helper") != "network-tier-helper.sh"
-        or network[0].get("decision") != "forbid"
-    ):
-        raise PolicyError("command policy requires exactly one worker network guard")
-    rules = policy.get("rules")
-    if not isinstance(rules, list) or not rules:
-        raise PolicyError("command policy rules must be a non-empty list")
-    seen_ids: set[str] = set()
-    seen_matchers: set[str] = set()
-    for rule in rules:
-        if not isinstance(rule, dict):
-            raise PolicyError("command policy rule must be an object")
-        rule_id = rule.get("id")
-        matcher = rule.get("matcher")
-        if not isinstance(rule_id, str) or not rule_id or rule_id in seen_ids:
-            raise PolicyError("command policy rule IDs must be unique non-empty strings")
-        if matcher not in KNOWN_MATCHERS or matcher in seen_matchers:
-            raise PolicyError(f"command policy matcher is invalid or duplicated: {matcher}")
-        if rule.get("decision") != "forbid" or not isinstance(rule.get("reason"), str):
-            raise PolicyError(f"command policy rule must be forbid with a reason: {rule_id}")
-        seen_ids.add(rule_id)
-        seen_matchers.add(matcher)
-    if seen_matchers != KNOWN_MATCHERS:
-        raise PolicyError("command policy must define every required matcher exactly once")
-    fixtures = policy.get("fixtures")
-    if not isinstance(fixtures, list) or not fixtures:
-        raise PolicyError("command policy requires self-test fixtures")
-
-
-def _validate_argv(value: Any) -> list[str]:
-    if not isinstance(value, list) or not value:
-        raise CommandParseError("argv must be a non-empty JSON array")
-    if not all(isinstance(arg, str) for arg in value):
-        raise CommandParseError("every argv element must be a string")
-    if any("\x00" in arg for arg in value):
-        raise CommandParseError("argv cannot contain NUL bytes")
-    return value
-
-
-def _scan_supported_shell(command: str) -> None:
-    if not command.strip():
-        raise CommandParseError("command is empty")
-    if "\n" in command or "\r" in command:
-        raise CommandParseError("multiline shell commands are unsupported")
-    single = False
-    double = False
-    escaped = False
-    index = 0
-    while index < len(command):
-        char = command[index]
-        next_char = command[index + 1] if index + 1 < len(command) else ""
-        if escaped:
-            escaped = False
-            index += 1
-            continue
-        if char == "\\" and not single:
-            escaped = True
-            index += 1
-            continue
-        if char == "'" and not double:
-            single = not single
-            index += 1
-            continue
-        if char == '"' and not single:
-            double = not double
-            index += 1
-            continue
-        if single:
-            index += 1
-            continue
-        if char in {"`", "$"}:
-            raise CommandParseError("dynamic shell expansion is unsupported")
-        if not double:
-            if char in "<>":
-                raise CommandParseError("shell redirection is unsupported")
-            if char in "(){}":
-                raise CommandParseError("shell grouping and subshell syntax are unsupported")
-            if char == "&" and next_char != "&" and (index == 0 or command[index - 1] != "&"):
-                raise CommandParseError("background shell execution is unsupported")
-            if char in "*[":
-                raise CommandParseError("unquoted shell glob syntax is unsupported")
-        index += 1
-    if single or double or escaped:
-        raise CommandParseError("unterminated shell quoting or escape")
-
-
-def _consume_option(
-    argv: list[str], index: int, value_options: set[str], flag_options: set[str]
-) -> int:
-    arg = argv[index]
-    if arg == "--":
-        return index + 1
-    if arg in value_options:
-        if index + 1 >= len(argv):
-            raise CommandParseError(f"missing value for wrapper option {arg}")
-        return index + 2
-    if any(arg.startswith(option + "=") for option in value_options if option.startswith("--")):
-        return index + 1
-    if any(
-        arg.startswith(option) and arg != option
-        for option in value_options
-        if option.startswith("-") and not option.startswith("--")
-    ):
-        return index + 1
-    if arg in flag_options:
-        return index + 1
-    short_flags = {option[1:] for option in flag_options if re.fullmatch(r"-[A-Za-z0-9]", option)}
-    if arg.startswith("-") and not arg.startswith("--") and set(arg[1:]).issubset(short_flags):
-        return index + 1
-    raise CommandParseError(f"unsupported wrapper option {arg}")
-
-
-def _unwrap_env(argv: list[str]) -> list[str]:
-    index = 1
-    values = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
-    flags = {"-i", "--ignore-environment", "-0", "--null", "-v", "--debug"}
-    while index < len(argv) and argv[index].startswith("-"):
-        option = argv[index]
-        if option in {"-C", "--chdir", "-S", "--split-string"} or option.startswith(("-C", "-S", "--chdir=", "--split-string=")):
-            raise CommandParseError(f"env option changes command interpretation and is unsupported: {option}")
-        index = _consume_option(argv, index, values, flags)
-    while index < len(argv) and "=" in argv[index] and not argv[index].startswith("="):
-        name = argv[index].split("=", 1)[0]
-        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
-            break
-        if _is_safety_sensitive_assignment(name):
-            raise CommandParseError(f"safety-affecting environment assignment is unsupported: {name}")
-        index += 1
-    if index >= len(argv):
-        raise CommandParseError("env wrapper has no command")
-    return argv[index:]
-
-
-def _unwrap_sudo(argv: list[str]) -> list[str]:
-    index = 1
-    values = {
-        "-u", "--user", "-g", "--group", "-h", "--host", "-p", "--prompt",
-        "-C", "--close-from", "-T", "--command-timeout", "-R", "--chroot",
-        "-D", "--chdir",
-    }
-    flags = {
-        "-A", "--askpass", "-b", "--background", "-E", "--preserve-env",
-        "-H", "--set-home", "-n", "--non-interactive", "-P", "--preserve-groups",
-        "-S", "--stdin", "-i", "--login", "-s", "--shell", "-k", "-K", "-v",
-    }
-    while index < len(argv) and argv[index].startswith("-"):
-        option = argv[index]
-        if option in {"-D", "--chdir", "-R", "--chroot"} or option.startswith(("-D", "-R", "--chdir=", "--chroot=")):
-            raise CommandParseError(f"sudo option changes command location and is unsupported: {option}")
-        index = _consume_option(argv, index, values, flags)
-    if index >= len(argv):
-        raise CommandParseError("sudo wrapper has no command")
-    return argv[index:]
-
-
-def _unwrap_time(argv: list[str]) -> list[str]:
-    index = 1
-    values = {"-f", "--format", "-o", "--output"}
-    flags = {"-a", "--append", "-p", "--portability", "-v", "--verbose", "-q", "--quiet"}
-    while index < len(argv) and argv[index].startswith("-"):
-        index = _consume_option(argv, index, values, flags)
-    if index >= len(argv):
-        raise CommandParseError("time wrapper has no command")
-    return argv[index:]
-
-
-def _shell_command_index(argv: list[str]) -> int | None:
-    index = 1
-    value_options = {"-O", "+O", "-o", "+o", "--init-file", "--rcfile"}
-    while index < len(argv):
-        arg = argv[index]
-        if arg == "--":
-            return None
-        if arg.startswith("-") and not arg.startswith("--") and "c" in arg[1:]:
-            return index + 1
-        if arg in {"--init-file", "--rcfile"} or arg.startswith(("--init-file=", "--rcfile=")):
-            raise CommandParseError(f"shell startup file option is unsupported: {arg}")
-        if arg in value_options:
-            if index + 1 >= len(argv):
-                raise CommandParseError(f"missing value for shell option {arg}")
-            index += 2
-            continue
-        if any(arg.startswith(option + "=") for option in value_options if option.startswith("--")):
-            index += 1
-            continue
-        if arg.startswith(("-", "+")):
-            index += 1
-            continue
-        if not arg.startswith("-"):
-            return None
-    return None
-
-
-def _is_safety_sensitive_assignment(name: str) -> bool:
-    upper = name.upper()
-    return upper.endswith("_PROXY") or upper.startswith("GIT_CONFIG_") or upper in {
-        "ALL_PROXY",
-        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-        "GIT_COMMON_DIR",
-        "GIT_CONFIG_PARAMETERS",
-        "GIT_DIR",
-        "GIT_EXEC_PATH",
-        "GIT_OBJECT_DIRECTORY",
-        "GIT_PROXY_COMMAND",
-        "GIT_SSH",
-        "GIT_SSH_COMMAND",
-        "GIT_WORK_TREE",
-        "CURL_HOME",
-        "WGETRC",
-        "BASH_ENV",
-        "ENV",
-        "ZDOTDIR",
-    }
-
-
-def _strip_leading_assignments(argv: list[str]) -> list[str]:
-    index = 0
-    while index < len(argv) and "=" in argv[index]:
-        name = argv[index].split("=", 1)[0]
-        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
-            break
-        if _is_safety_sensitive_assignment(name):
-            raise CommandParseError(f"safety-affecting environment assignment is unsupported: {name}")
-        index += 1
-    if index >= len(argv):
-        raise CommandParseError("environment assignment has no command")
-    return argv[index:]
-
-
-def _expand_argv(argv: list[str]) -> list[list[str]]:
-    current = _validate_argv(argv)
-    while current:
-        current = _strip_leading_assignments(current)
-        executable = os.path.basename(current[0])
-        if executable in {
-            ".", "!", "alias", "builtin", "case", "coproc", "declare", "do",
-            "done", "elif", "else", "enable", "esac", "eval", "export", "fi",
-            "for", "function", "if", "local", "parallel", "readonly", "select",
-            "set", "source", "then", "trap", "typeset", "unalias", "unset",
-            "until", "while", "xargs",
-        }:
-            raise CommandParseError(f"dynamic shell control or launcher is unsupported: {executable}")
-        if executable == "find" and any(arg in {"-exec", "-execdir", "-ok", "-okdir"} for arg in current[1:]):
-            raise CommandParseError("find command execution actions are unsupported")
-        if executable == "env":
-            current = _unwrap_env(current)
-            continue
-        if executable == "sudo":
-            current = _unwrap_sudo(current)
-            continue
-        if executable == "nohup":
-            index = 2 if len(current) > 1 and current[1] == "--" else 1
-            if index >= len(current) or current[index].startswith("--"):
-                raise CommandParseError("nohup wrapper has no supported command")
-            current = current[index:]
-            continue
-        if executable == "time":
-            current = _unwrap_time(current)
-            continue
-        if executable == "exec":
-            index = 1
-            while index < len(current) and current[index].startswith("-"):
-                index = _consume_option(current, index, {"-a"}, {"-c", "-l"})
-            if index >= len(current):
-                raise CommandParseError("exec wrapper has no command")
-            current = current[index:]
-            continue
-        if executable == "command":
-            if len(current) > 1 and current[1] in {"-v", "-V"}:
-                return [current]
-            index = 1
-            while index < len(current) and current[index] in {"-p", "--"}:
-                index += 1
-            if index >= len(current):
-                raise CommandParseError("command wrapper has no command")
-            current = current[index:]
-            continue
-        if executable in SHELLS:
-            command_index = _shell_command_index(current)
-            if command_index is None:
-                return [current]
-            if command_index >= len(current):
-                raise CommandParseError("shell -c option has no command string")
-            return _shell_invocations(current[command_index])
-        if executable in {"cd", "pushd", "popd"}:
-            raise CommandParseError("directory-changing shell builtins are unsupported; use tool cwd")
-        return [current]
-    raise CommandParseError("wrapper chain has no command")
-
-
-def _shell_invocations(command: str) -> list[list[str]]:
-    _scan_supported_shell(command)
-    try:
-        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
-        lexer.whitespace_split = True
-        lexer.commenters = ""
-        tokens = list(lexer)
-    except ValueError as exc:
-        raise CommandParseError(f"unable to tokenize shell command: {exc}") from exc
-    invocations: list[list[str]] = []
-    segment: list[str] = []
-    expect_command = True
-    for token in tokens:
-        if token in SHELL_OPERATORS:
-            if expect_command or not segment:
-                raise CommandParseError("empty or repeated shell operator segment")
-            invocations.extend(_expand_argv(segment))
-            segment = []
-            expect_command = True
-            continue
-        if token and all(char in ";&|()" for char in token):
-            raise CommandParseError(f"unsupported shell operator {token}")
-        segment.append(token)
-        expect_command = False
-    if not segment:
-        raise CommandParseError("shell command ends with an operator")
-    invocations.extend(_expand_argv(segment))
-    if not invocations:
-        raise CommandParseError("command produced no executable argv")
-    return invocations
-
-
-def _short_flags(args: list[str]) -> set[str]:
-    flags: set[str] = set()
-    for arg in args:
-        if arg == "--":
-            break
-        if arg.startswith("-") and not arg.startswith("--"):
-            flags.update(arg[1:])
-    return flags
-
-
-def _has_flag(args: list[str], short: str, long: str) -> bool:
-    option_args = args[:args.index("--")] if "--" in args else args
-    return long in option_args or short in _short_flags(option_args)
-
-
-def _rm_operands(args: list[str]) -> list[str]:
-    operands: list[str] = []
-    after_options = False
-    for arg in args:
-        if arg == "--":
-            after_options = True
-            continue
-        if after_options or not arg.startswith("-"):
-            operands.append(arg)
-    return operands
-
-
-def _canonical_operand(path: str, cwd: str) -> str | None:
-    if not path or "\x00" in path or any(part == ".." for part in Path(path).parts):
-        return None
-    if path.startswith(("$", "~")):
-        return None
-    candidate = path if os.path.isabs(path) else os.path.join(cwd, path)
-    return os.path.realpath(os.path.normpath(candidate))
-
-
-def _is_temp_operand(path: str, cwd: str) -> bool:
-    canonical = _canonical_operand(path, cwd)
-    if not canonical:
-        return False
-    # nosec B108 -- these canonical roots classify operands; no temp file is created.
-    roots = ["/tmp", "/var/tmp"]
-    tmpdir = os.environ.get("TMPDIR", "")
-    if tmpdir:
-        roots.append(tmpdir)
-    for root in roots:
-        canonical_root = os.path.realpath(os.path.normpath(root))
-        try:
-            if os.path.commonpath([canonical, canonical_root]) == canonical_root and canonical != canonical_root:
-                return True
-        except ValueError:
-            continue
-    return False
-
-
-def _is_root_or_home_operand(path: str, cwd: str) -> bool:
-    canonical = _canonical_operand(path, cwd)
-    if not canonical:
-        return path in {"/", "~", "$HOME", "${HOME}"}
-    home = os.path.realpath(str(Path.home()))
-    return canonical == "/" or canonical == home or canonical.startswith(home + os.sep)
-
-
-def _git_parts(argv: list[str]) -> tuple[str, list[str]]:
-    if not argv or os.path.basename(argv[0]) != "git":
-        return "", []
-    index = 1
-    value_options = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
-    while index < len(argv):
-        arg = argv[index]
-        if arg in value_options:
-            index += 2
-            continue
-        if arg.startswith("-"):
-            index += 1
-            continue
-        return arg, argv[index + 1 :]
-    return "", []
-
-
-def _matches(matcher: str, argv: list[str], cwd: str) -> bool:
-    executable = os.path.basename(argv[0]) if argv else ""
-    args = argv[1:]
-    if matcher in {"rm_recursive_force_root", "rm_recursive_force"}:
-        if executable != "rm" or not _has_flag(args, "r", "--recursive") or not _has_flag(args, "f", "--force"):
-            return False
-        operands = _rm_operands(args)
-        if not operands or all(_is_temp_operand(path, cwd) for path in operands):
-            return False
-        is_root = any(_is_root_or_home_operand(path, cwd) for path in operands)
-        return is_root if matcher == "rm_recursive_force_root" else not is_root
-    subcommand, git_args = _git_parts(argv)
-    if not subcommand:
-        return False
-    if matcher == "git_checkout_worktree_path":
-        return subcommand == "checkout" and "--" in git_args
-    if matcher == "git_restore_worktree":
-        if subcommand != "restore":
-            return False
-        staged = "--staged" in git_args or "S" in _short_flags(git_args)
-        worktree = "--worktree" in git_args or "W" in _short_flags(git_args)
-        return worktree or not staged
-    if matcher == "git_reset_destructive":
-        return subcommand == "reset" and any(arg in {"--hard", "--merge"} for arg in git_args)
-    if matcher == "git_clean_force":
-        return subcommand == "clean" and _has_flag(git_args, "f", "--force") and not _has_flag(git_args, "n", "--dry-run")
-    if matcher == "git_push_force":
-        return subcommand == "push" and ("--force" in git_args or "f" in _short_flags(git_args))
-    if matcher == "git_branch_force_delete":
-        return subcommand == "branch" and "D" in _short_flags(git_args)
-    if matcher == "git_stash_delete":
-        return subcommand == "stash" and bool(git_args) and git_args[0] in {"drop", "clear"}
-    return False
-
-
-def _evaluate_static(invocations: list[list[str]], cwd: str, policy: dict[str, Any]) -> dict[str, Any]:
-    best = dict(policy["default_decision"])
-    best["schema_version"] = 2
-    for argv in invocations:
-        for rule in policy["rules"]:
-            if _matches(rule["matcher"], argv, cwd) and DECISION_RANK[rule["decision"]] > DECISION_RANK[best["decision"]]:
-                best = _decision(rule["decision"], rule["id"], rule["reason"])
-    return best
-
-
-def _canonical_guard_path(policy: dict[str, Any], explicit: str) -> Path:
-    if explicit:
-        return Path(explicit)
-    helper = next(guard["helper"] for guard in policy["dynamic_guards"] if guard["kind"] == "canonical_git")
-    return Path(__file__).resolve().parent / helper
-
-
-def _evaluate_canonical_git(invocations: list[list[str]], cwd: str, guard: Path) -> dict[str, Any]:
-    git_invocations = [argv for argv in invocations if argv and os.path.basename(argv[0]) == "git"]
-    if not git_invocations:
-        return _decision("allow", "git.no-invocation", "No Git invocation detected")
-    if not guard.is_file():
-        return _decision("forbid", "git.guard-unavailable", f"Canonical Git policy helper is unavailable: {guard}")
-    for argv in git_invocations:
-        try:
-            result = subprocess.run(
-                [sys.executable, str(guard), "--cwd", cwd, "--argv-json", json.dumps(argv[1:])],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                check=False,
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            return _decision("forbid", "git.guard-error", f"Canonical Git policy check failed closed: {exc}")
-        if result.returncode != 0:
-            reason = result.stderr.strip() or f"Canonical Git guard failed with exit {result.returncode}"
-            return _decision("forbid", "git.canonical-worktree", reason)
-    return _decision("allow", "git.canonical-allow", "Canonical Git guard allowed every Git argv")
-
-
-def _normalize_host(value: str) -> str | None:
-    candidate = value.strip()
-    if not candidate or any(char in candidate for char in "\x00\n\r"):
-        return None
-    if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*://", candidate):
-        parsed = urlsplit(candidate)
-        return parsed.hostname.lower().rstrip(".") if parsed.hostname else None
-    scp_match = re.match(r"^(?:[^@/:]+@)?(\[[^]]+\]|[^/:]+):.+$", candidate)
-    if scp_match and not re.match(r"^[A-Za-z]:[\\/]", candidate):
-        candidate = scp_match.group(1).strip("[]").lower().rstrip(".")
-    elif "@" in candidate and "/" not in candidate:
-        candidate = candidate.rsplit("@", 1)[1]
-    if "/" in candidate:
-        candidate = candidate.split("/", 1)[0]
-    if candidate.startswith("[") and "]" in candidate:
-        candidate = candidate[1:candidate.index("]")]
-    elif candidate.count(":") == 1:
-        candidate = candidate.split(":", 1)[0]
-    candidate = candidate.rstrip(".").lower()
-    try:
-        ipaddress.ip_address(candidate)
-        return candidate
-    except ValueError:
-        pass
-    if re.fullmatch(r"[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?", candidate) and "." in candidate:
-        return candidate
-    return None
-
-
-def _add_destination(result: dict[str, Any], value: str, label: str) -> None:
-    host = _normalize_host(value)
-    if host:
-        result["destinations"].append(host)
-    else:
-        result["unclassified"].append(f"{label}:{value}")
-
-
-def _option_value(argv: list[str], index: int) -> tuple[str | None, int]:
-    if "=" in argv[index]:
-        return argv[index].split("=", 1)[1], index + 1
-    if index + 1 >= len(argv):
-        return None, index + 1
-    return argv[index + 1], index + 2
-
-
-def _analyze_curl(argv: list[str], result: dict[str, Any]) -> None:
-    value_options = {
-        "--request", "--header", "--data", "--data-raw", "--data-binary", "--form",
-        "--user", "--output", "--referer", "--user-agent", "--cookie", "--cookie-jar",
-        "--cacert", "--cert", "--key", "--max-time", "--connect-timeout", "--retry",
-        "--proto", "--proto-redir", "--interface", "--dns-interface", "--dns-ipv4-addr",
-        "--dns-ipv6-addr",
-    }
-    destination_options = {"--url", "--proxy", "--preproxy"}
-    short_value_options = {"-A", "-b", "-c", "-d", "-D", "-e", "-E", "-F", "-H", "-K", "-m", "-o", "-Q", "-r", "-T", "-u", "-w", "-X", "-Y", "-z"}
-    index = 1
-    while index < len(argv):
-        arg = argv[index]
-        option = arg.split("=", 1)[0]
-        if option in destination_options:
-            value, index = _option_value(argv, index)
-            if value is None:
-                result["unclassified"].append(f"missing:{option}")
-            else:
-                _add_destination(result, value, option)
-            continue
-        if option == "--resolve":
-            value, index = _option_value(argv, index)
-            match = re.match(r"^(\[[^]]+\]|[^:]+):[^:]*:(.+)$", value or "")
-            if not match:
-                result["unclassified"].append(f"resolve:{value or ''}")
-            else:
-                _add_destination(result, match.group(1), "resolve-host")
-                _add_destination(result, match.group(2), "resolve-address")
-            continue
-        if option == "--connect-to":
-            value, index = _option_value(argv, index)
-            parts = (value or "").split(":")
-            if len(parts) != 4:
-                result["unclassified"].append(f"connect-to:{value or ''}")
-            else:
-                if parts[0]:
-                    _add_destination(result, parts[0], "connect-source")
-                if parts[2]:
-                    _add_destination(result, parts[2], "connect-target")
-            continue
-        if option in {"--config", "-K"} or arg.startswith("-K"):
-            result["unclassified"].append("curl-config-file")
-            index += 2 if arg in {"--config", "-K"} else 1
-            continue
-        if option in value_options:
-            _, index = _option_value(argv, index)
-            continue
-        if arg == "-x" or arg.startswith("-x"):
-            value = argv[index + 1] if arg == "-x" and index + 1 < len(argv) else arg[2:]
-            index += 2 if arg == "-x" else 1
-            _add_destination(result, value, "proxy")
-            continue
-        if arg in short_value_options:
-            if index + 1 >= len(argv):
-                result["unclassified"].append(f"missing:{arg}")
-                index += 1
-            else:
-                index += 2
-            continue
-        if any(arg.startswith(option) and arg != option for option in short_value_options):
-            index += 1
-            continue
-        if arg.startswith("-"):
-            index += 1
-            continue
-        _add_destination(result, arg, "url")
-        index += 1
-
-
-def _analyze_wget(argv: list[str], result: dict[str, Any]) -> None:
-    index = 1
-    value_options = {
-        "-O", "--output-document", "-o", "--output-file", "-a", "--append-output",
-        "-P", "--directory-prefix", "--header", "--user", "--password", "--timeout",
-        "--tries", "--wait", "--user-agent", "--referer",
-    }
-    short_value_options = {"-O", "-o", "-a", "-P", "-U", "-t", "-T", "-w"}
-    while index < len(argv):
-        arg = argv[index]
-        option = arg.split("=", 1)[0]
-        if option == "--proxy":
-            value, index = _option_value(argv, index)
-            _add_destination(result, value or "", "proxy")
-            continue
-        if option in {"-e", "--execute"}:
-            value, index = _option_value(argv, index)
-            match = re.match(r"(?i)^(?:https?|ftp)_proxy=(.+)$", value or "")
-            if match:
-                _add_destination(result, match.group(1), "proxy")
-            elif value and "proxy" not in value.lower():
-                result["unclassified"].append(f"wget-execute:{value}")
-            continue
-        if option in {"-i", "--input-file"}:
-            result["unclassified"].append("wget-input-file")
-            index += 2 if arg == option and "=" not in arg else 1
-            continue
-        if option in value_options:
-            _, index = _option_value(argv, index)
-            continue
-        if arg in short_value_options:
-            index += 2 if index + 1 < len(argv) else 1
-            continue
-        if any(arg.startswith(option) and arg != option for option in short_value_options):
-            index += 1
-            continue
-        if arg.startswith("-"):
-            index += 1
-            continue
-        _add_destination(result, arg, "url")
-        index += 1
-
-
-def _analyze_ssh(argv: list[str], result: dict[str, Any]) -> None:
-    value_options = {"-b", "-c", "-D", "-E", "-e", "-F", "-I", "-i", "-L", "-l", "-m", "-O", "-o", "-p", "-Q", "-R", "-S", "-W", "-w", "-J"}
-    index = 1
-    target = ""
-    while index < len(argv):
-        arg = argv[index]
-        if arg.startswith("-J") and arg != "-J":
-            _add_destination(result, arg[2:], "proxy-jump")
-            index += 1
-            continue
-        if arg in value_options:
-            if index + 1 >= len(argv):
-                result["unclassified"].append(f"missing:{arg}")
-                break
-            value = argv[index + 1]
-            if arg == "-J":
-                for jump in value.split(","):
-                    _add_destination(result, jump, "proxy-jump")
-            elif arg == "-F":
-                result["unclassified"].append("ssh-config-file")
-            elif arg == "-W":
-                _add_destination(result, value.rsplit(":", 1)[0], "stdio-forward")
-            elif arg in {"-L", "-R"}:
-                parts = value.split(":")
-                if len(parts) >= 3:
-                    _add_destination(result, parts[-2], "port-forward")
-                else:
-                    result["unclassified"].append(f"ssh-forward:{value}")
-            elif arg == "-o":
-                lower = value.lower()
-                if lower.startswith("proxyjump="):
-                    _add_destination(result, value.split("=", 1)[1], "proxy-jump")
-                elif lower.startswith("proxycommand="):
-                    result["unclassified"].append("ssh-proxy-command")
-            index += 2
-            continue
-        if arg.startswith("-"):
-            index += 1
-            continue
-        target = arg
-        break
-    if target:
-        _add_destination(result, target, "ssh-target")
-    else:
-        result["unclassified"].append("ssh-target-missing")
-
-
-def _analyze_scp(argv: list[str], result: dict[str, Any]) -> None:
-    value_options = {"-c", "-F", "-i", "-J", "-l", "-o", "-P", "-S", "-X"}
-    index = 1
-    remote_count = 0
-    while index < len(argv):
-        arg = argv[index]
-        if arg in value_options:
-            if index + 1 >= len(argv):
-                result["unclassified"].append(f"missing:{arg}")
-                break
-            if arg == "-J":
-                _add_destination(result, argv[index + 1], "proxy-jump")
-            elif arg in {"-F", "-S"}:
-                result["unclassified"].append(f"scp-hidden-network-config:{arg}")
-            elif arg == "-o" and argv[index + 1].lower().startswith("proxycommand="):
-                result["unclassified"].append("scp-proxy-command")
-            index += 2
-            continue
-        if arg.startswith("-"):
-            index += 1
-            continue
-        if _normalize_host(arg):
-            _add_destination(result, arg, "scp-remote")
-            remote_count += 1
-        index += 1
-    if remote_count == 0:
-        result["unclassified"].append("scp-remote-missing")
-
-
-def _resolve_git_remote(cwd: str, remote: str) -> list[str]:
-    git_binary = "/usr/bin/git" if Path("/usr/bin/git").is_file() else "git"
-    try:
-        resolved = subprocess.run(
-            [git_binary, "-C", cwd, "remote", "get-url", "--all", remote],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return []
-    return [line for line in resolved.stdout.splitlines() if line] if resolved.returncode == 0 else []
-
-
-def _git_effective_cwd(argv: list[str], cwd: str) -> str:
-    effective = cwd
-    index = 1
-    while index < len(argv):
-        if argv[index] == "-C" and index + 1 < len(argv):
-            target = argv[index + 1]
-            effective = target if os.path.isabs(target) else os.path.abspath(os.path.join(effective, target))
-            index += 2
-            continue
-        if not argv[index].startswith("-"):
-            break
-        index += 1
-    return effective
-
-
-def _analyze_git(argv: list[str], cwd: str, result: dict[str, Any]) -> bool:
-    subcommand, args = _git_parts(argv)
-    if subcommand not in {"clone", "fetch", "pull", "push", "ls-remote", "submodule"}:
-        return False
-    if subcommand == "submodule":
-        result["unclassified"].append("git-submodule-configured-remotes")
-        return True
-    for index, arg in enumerate(argv[:-1]):
-        if arg == "-c" and any(token in argv[index + 1].lower() for token in ("proxy", "insteadof")):
-            result["unclassified"].append("git-network-config-override")
-        if arg == "--config-env":
-            result["unclassified"].append("git-config-env-override")
-    value_options = {
-        "-b", "--branch", "-o", "--origin", "-c", "--config", "--depth",
-        "--reference", "--reference-if-able", "--separate-git-dir", "-j", "--jobs",
-        "--filter", "--upload-pack", "--receive-pack", "--exec",
-    }
-    if subcommand == "clone":
-        value_options.add("-u")
-    positionals: list[str] = []
-    explicit_repo = ""
-    index = 0
-    while index < len(args):
-        arg = args[index]
-        option = arg.split("=", 1)[0]
-        if option == "--repo":
-            value, index = _option_value(args, index)
-            explicit_repo = value or ""
-            continue
-        if option in value_options:
-            index += 1 if "=" in arg else 2
-            continue
-        if arg.startswith("-"):
-            index += 1
-            continue
-        positionals.append(arg)
-        index += 1
-    candidate = explicit_repo or (positionals[0] if positionals else "")
-    if not candidate:
-        result["unclassified"].append(f"git-{subcommand}-destination-missing")
-        return True
-    host = _normalize_host(candidate)
-    if host:
-        result["destinations"].append(host)
-        return True
-    if subcommand == "clone" and candidate.startswith(("/", "./", "../", "file://")):
-        result["requires_destination"] = False
-        return True
-    remotes = _resolve_git_remote(_git_effective_cwd(argv, cwd), candidate)
-    if not remotes:
-        result["unclassified"].append(f"git-remote:{candidate}")
-        return True
-    for remote in remotes:
-        _add_destination(result, remote, "git-remote")
-    return True
-
-
-def analyze_network_argv(argv: list[str], cwd: str) -> dict[str, Any]:
-    exact = _validate_argv(argv)
-    executable = os.path.basename(exact[0]).lower()
-    result: dict[str, Any] = {
-        "recognized": False,
-        "requires_destination": True,
-        "destinations": [],
-        "unclassified": [],
-    }
-    if executable == "curl":
-        result["recognized"] = True
-        _analyze_curl(exact, result)
-    elif executable == "wget":
-        result["recognized"] = True
-        _analyze_wget(exact, result)
-    elif executable == "ssh":
-        result["recognized"] = True
-        _analyze_ssh(exact, result)
-    elif executable == "scp":
-        result["recognized"] = True
-        _analyze_scp(exact, result)
-    elif executable == "git":
-        result["recognized"] = _analyze_git(exact, cwd, result)
-    elif executable in {"dig", "nslookup", "host"}:
-        result["recognized"] = True
-        candidates = [arg for arg in exact[1:] if not arg.startswith(("-", "+", "@"))]
-        if not candidates:
-            result["unclassified"].append("dns-query-destination-missing")
-        else:
-            _add_destination(result, candidates[0], "dns-query")
-    result["destinations"] = sorted(set(result["destinations"]))
-    return result
-
-
-def _network_guard_path(policy: dict[str, Any], explicit: str) -> Path:
-    if explicit:
-        return Path(explicit)
-    override = os.environ.get("AIDEVOPS_NETWORK_TIER_HELPER", "")
-    if override:
-        return Path(override)
-    helper = next(
-        guard["helper"]
-        for guard in policy["dynamic_guards"]
-        if guard["kind"] == "worker_network"
-    )
-    return Path(__file__).resolve().parent / helper
-
-
-def _evaluate_worker_network(
-    invocations: list[list[str]], cwd: str, helper: Path, worker_id: str
-) -> dict[str, Any]:
-    if not helper.is_file():
-        return _decision("forbid", "network.helper-unavailable", f"Required worker network policy helper is unavailable: {helper}")
-    for argv in invocations:
-        try:
-            result = subprocess.run(
-                [
-                    "/bin/bash", str(helper), "check-argv", json.dumps(argv),
-                    "--cwd", cwd, "--worker-id", worker_id,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                check=False,
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            return _decision("forbid", "network.helper-error", f"Worker network policy failed closed: {exc}")
-        if result.returncode != 0:
-            reason = result.stderr.strip() or "Worker network policy denied or could not classify the command destination"
-            return _decision("forbid", "network.worker-policy", reason)
-    return _decision("allow", "network.worker-allow", "Worker network policy allowed every argv")
-
-
-def evaluate_invocations(
-    invocations: list[list[str]],
-    cwd: str,
-    policy: dict[str, Any],
-    guard_path: str = "",
-    worker: bool = False,
-    worker_id: str = "unknown",
-    network_helper: str = "",
-) -> dict[str, Any]:
-    decisions = [
-        _evaluate_static(invocations, cwd, policy),
-        _evaluate_canonical_git(invocations, cwd, _canonical_guard_path(policy, guard_path)),
-    ]
-    if worker:
-        decisions.append(
-            _evaluate_worker_network(
-                invocations, cwd, _network_guard_path(policy, network_helper), worker_id
-            )
-        )
-    return max(decisions, key=lambda item: DECISION_RANK[item["decision"]])
+def _expand_shell_launcher(argv: list[str]) -> list[list[str]]:
+    return _expand_wrapper_shell_launcher(argv, _shell_invocations)
 
 
 def _fixture_invocations(fixture: dict[str, Any]) -> tuple[list[list[str]], bool]:
@@ -1044,54 +166,21 @@ def _validate_fixtures(policy: dict[str, Any]) -> None:
             )
 
 
-def _worker_from_environment() -> bool:
-    if os.environ.get("AIDEVOPS_WORKER_ID", ""):
-        return True
-    return any(os.environ.get(key, "").lower() in {"1", "true", "yes"} for key in WORKER_ENV_KEYS)
+def _parse_invocations(args: argparse.Namespace) -> list[list[str]]:
+    if args.argv_json:
+        return _expand_argv(_validate_argv(json.loads(args.argv_json)))
+    if args.command:
+        return _shell_invocations(args.command)
+    return []
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("action", choices=("check-command", "validate", "network-destinations"))
-    source = parser.add_mutually_exclusive_group()
-    source.add_argument("--command", default="")
-    source.add_argument("--argv-json", default="")
-    parser.add_argument("--cwd", default=os.getcwd())
-    parser.add_argument("--policy", default="")
-    parser.add_argument("--canonical-git-guard", default="")
-    parser.add_argument("--network-helper", default="")
-    parser.add_argument("--worker", action="store_true")
-    parser.add_argument("--worker-id", default=os.environ.get("AIDEVOPS_WORKER_ID", "unknown"))
-    args = parser.parse_args()
-
-    try:
-        if args.argv_json:
-            invocations = _expand_argv(_validate_argv(json.loads(args.argv_json)))
-        elif args.command:
-            invocations = _shell_invocations(args.command)
-        else:
-            invocations = []
-    except (json.JSONDecodeError, CommandParseError) as exc:
-        print(json.dumps(_parse_error(str(exc)), sort_keys=True))
-        return FORBID_EXIT
-
-    if args.action == "network-destinations":
-        if len(invocations) != 1:
-            print(json.dumps({"recognized": False, "requires_destination": True, "destinations": [], "unclassified": ["network analysis requires exactly one argv"]}, sort_keys=True))
-            return FORBID_EXIT
-        print(json.dumps(analyze_network_argv(invocations[0], args.cwd), sort_keys=True))
-        return 0
-
+def _policy_action(args: argparse.Namespace, invocations: list[list[str]]) -> int:
     policy_path = Path(args.policy) if args.policy else _default_policy_path()
     try:
         policy = _load_policy(policy_path)
         _validate_fixtures(policy)
     except PolicyError as exc:
-        if args.action == "check-command":
-            print(json.dumps(_policy_error(str(exc)), sort_keys=True))
-        else:
-            print(f"BLOCKED: {exc}", file=sys.stderr)
-        return POLICY_ERROR_EXIT
+        return _report_policy_error(args.action, exc)
     if args.action == "validate":
         print(f"Command policy valid: {policy_path}")
         return 0
@@ -1109,6 +198,19 @@ def main() -> int:
     )
     print(json.dumps(result, sort_keys=True))
     return 0 if result["decision"] == "allow" else FORBID_EXIT
+
+
+def main() -> int:
+    args = _argument_parser().parse_args()
+
+    try:
+        invocations = _parse_invocations(args)
+    except (json.JSONDecodeError, CommandParseError) as exc:
+        print(json.dumps(_parse_error(str(exc)), sort_keys=True))
+        return FORBID_EXIT
+    if args.action == "network-destinations":
+        return _network_action(invocations, args.cwd)
+    return _policy_action(args, invocations)
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -13,7 +13,7 @@ from typing import Any
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from command_policy_config import (
+from command_policy_config import (  # noqa: F401 -- compatibility facade re-exports
     PolicyError,
     _default_policy_path,
     _decision,
@@ -25,7 +25,7 @@ from command_policy_config import (
     _validate_policy_rules,
     _validate_policy_shape,
 )
-from command_policy_matchers import (
+from command_policy_matchers import (  # noqa: F401 -- compatibility facade re-exports
     _canonical_operand,
     _git_parts,
     _has_flag,
@@ -37,7 +37,7 @@ from command_policy_matchers import (
     _rm_operands,
     _short_flags,
 )
-from command_policy_evaluation import (
+from command_policy_evaluation import (  # noqa: F401 -- compatibility facade re-exports
     _EvaluationOptions,
     _canonical_guard_path,
     _evaluate_canonical_git,
@@ -47,8 +47,8 @@ from command_policy_evaluation import (
     _network_guard_path,
     evaluate_invocations,
 )
-from command_policy_dispatch import CommandParseError, _validate_argv, analyze_network_argv
-from command_policy_http import (
+from command_policy_dispatch import CommandParseError, _validate_argv, analyze_network_argv  # noqa: F401 -- compatibility facade re-exports
+from command_policy_http import (  # noqa: F401 -- compatibility facade re-exports
     _analyze_curl,
     _curl_connect_option,
     _curl_destination_option,
@@ -57,21 +57,21 @@ from command_policy_http import (
     _curl_short_value_index,
     _option_value,
 )
-from command_policy_git import (
+from command_policy_git import (  # noqa: F401 -- compatibility facade re-exports
     _analyze_git,
     _analyze_git_remote,
     _classify_git_candidate,
     _git_network_candidate,
     _record_git_config_overrides,
 )
-from command_policy_network import (
+from command_policy_network import (  # noqa: F401 -- compatibility facade re-exports
     _add_destination,
     _git_effective_cwd,
     _host_candidate,
     _normalize_host,
     _resolve_git_remote,
 )
-from command_policy_transport import (
+from command_policy_transport import (  # noqa: F401 -- compatibility facade re-exports
     _analyze_scp,
     _analyze_ssh,
     _classify_scp_option,
@@ -81,15 +81,15 @@ from command_policy_transport import (
     _ssh_forward_destination,
     _ssh_value_option,
 )
-from command_policy_runtime import (
+from command_policy_runtime import (  # noqa: F401 -- compatibility facade re-exports
     WORKER_ENV_KEYS,
     _argument_parser,
     _network_action,
     _report_policy_error,
     _worker_from_environment,
 )
-from command_policy_wget import _analyze_wget, _wget_arg, _wget_execute_option
-from command_policy_parser import (
+from command_policy_wget import _analyze_wget, _wget_arg, _wget_execute_option  # noqa: F401 -- compatibility facade re-exports
+from command_policy_parser import (  # noqa: F401 -- compatibility facade re-exports
     SHELL_OPERATORS,
     _expand_argv,
     _scan_supported_shell,
@@ -97,7 +97,7 @@ from command_policy_parser import (
     _shell_quote_state,
     _validate_shell_character,
 )
-from command_policy_wrappers import (
+from command_policy_wrappers import (  # noqa: F401 -- compatibility facade re-exports
     SHELLS,
     _consume_option,
     _expand_launcher as _expand_wrapper_launcher,

--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -117,6 +117,12 @@ from command_policy_wrappers import (
     _unwrap_time,
 )
 
+__all__ = [
+    name
+    for name in globals()
+    if name.startswith("_") and not name.startswith("__")
+]
+
 FORBID_EXIT = 20
 POLICY_ERROR_EXIT = 21
 

--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -13,140 +13,43 @@ from typing import Any
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from command_policy_config import (  # noqa: F401 -- compatibility facade re-exports
+from command_policy_config import (
     PolicyError,
     _default_policy_path,
-    _decision,
-    _has_required_guard,
     _load_policy,
     _parse_error,
-    _policy_error,
-    _validate_policy_guards,
-    _validate_policy_rules,
-    _validate_policy_shape,
 )
-from command_policy_matchers import (  # noqa: F401 -- compatibility facade re-exports
-    _canonical_operand,
-    _git_parts,
-    _has_flag,
-    _is_root_or_home_operand,
-    _is_temp_operand,
-    _matches,
-    _matches_git,
-    _matches_rm,
-    _rm_operands,
-    _short_flags,
-)
-from command_policy_evaluation import (  # noqa: F401 -- compatibility facade re-exports
-    _EvaluationOptions,
-    _canonical_guard_path,
-    _evaluate_canonical_git,
+from command_policy_evaluation import (
     _evaluate_static,
-    _evaluate_worker_network,
-    _evaluation_options,
-    _network_guard_path,
     evaluate_invocations,
 )
-from command_policy_dispatch import CommandParseError, _validate_argv, analyze_network_argv  # noqa: F401 -- compatibility facade re-exports
-from command_policy_http import (  # noqa: F401 -- compatibility facade re-exports
-    _analyze_curl,
-    _curl_connect_option,
-    _curl_destination_option,
-    _curl_other_arg,
-    _curl_resolve_option,
-    _curl_short_value_index,
-    _option_value,
+from command_policy_dispatch import (
+    CommandParseError,
+    _validate_argv,
+    analyze_network_argv as _analyze_network_argv,
 )
-from command_policy_git import (  # noqa: F401 -- compatibility facade re-exports
-    _analyze_git,
-    _analyze_git_remote,
-    _classify_git_candidate,
-    _git_network_candidate,
-    _record_git_config_overrides,
-)
-from command_policy_network import (  # noqa: F401 -- compatibility facade re-exports
-    _add_destination,
-    _git_effective_cwd,
-    _host_candidate,
-    _normalize_host,
-    _resolve_git_remote,
-)
-from command_policy_transport import (  # noqa: F401 -- compatibility facade re-exports
-    _analyze_scp,
-    _analyze_ssh,
-    _classify_scp_option,
-    _scp_arg,
-    _ssh_arg,
-    _ssh_extended_option,
-    _ssh_forward_destination,
-    _ssh_value_option,
-)
-from command_policy_runtime import (  # noqa: F401 -- compatibility facade re-exports
-    WORKER_ENV_KEYS,
+from command_policy_runtime import (
     _argument_parser,
     _network_action,
     _report_policy_error,
     _worker_from_environment,
 )
-from command_policy_wget import _analyze_wget, _wget_arg, _wget_execute_option  # noqa: F401 -- compatibility facade re-exports
-from command_policy_parser import (  # noqa: F401 -- compatibility facade re-exports
-    SHELL_OPERATORS,
+from command_policy_parser import (
     _expand_argv,
-    _scan_supported_shell,
     _shell_invocations,
-    _shell_quote_state,
-    _validate_shell_character,
 )
-from command_policy_wrappers import (  # noqa: F401 -- compatibility facade re-exports
-    SHELLS,
-    _consume_option,
+from command_policy_wrappers import (
     _expand_launcher as _expand_wrapper_launcher,
     _expand_shell_launcher as _expand_wrapper_shell_launcher,
-    _is_attached_value_option,
-    _is_combined_short_flags,
-    _is_safety_sensitive_assignment,
-    _reject_dynamic_launcher,
-    _shell_command_index,
-    _shell_value_option_index,
-    _strip_leading_assignments,
-    _unwrap_command,
-    _unwrap_env,
-    _unwrap_exec,
-    _unwrap_simple_wrapper,
-    _unwrap_sudo,
-    _unwrap_time,
 )
-
-# Keep the original module-level private callables available to importlib users.
-# Referencing compatibility imports explicitly also satisfies static analyzers.
-_COMPAT_EXPORTS = (
-    _decision,
-    _has_required_guard,
-    _canonical_operand,
-    _git_parts,
-    _EvaluationOptions,
-    _canonical_guard_path,
-    analyze_network_argv,
-    _analyze_curl,
-    _curl_connect_option,
-    _analyze_git,
-    _analyze_git_remote,
-    _add_destination,
-    _git_effective_cwd,
-    _analyze_scp,
-    _analyze_ssh,
-    WORKER_ENV_KEYS,
-    _analyze_wget,
-    _wget_arg,
-    SHELL_OPERATORS,
-    _scan_supported_shell,
-    SHELLS,
-    _consume_option,
-)
-__all__ = [name for name in globals() if name.startswith("_") and not name.startswith("__")]
 
 FORBID_EXIT = 20
 POLICY_ERROR_EXIT = 21
+
+
+def analyze_network_argv(argv: list[str], cwd: str) -> dict[str, Any]:
+    """Analyze one network command while preserving the original callable API."""
+    return _analyze_network_argv(argv, cwd)
 
 
 def _expand_launcher(

--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -117,11 +117,23 @@ from command_policy_wrappers import (
     _unwrap_time,
 )
 
-__all__ = [
-    name
-    for name in globals()
-    if name.startswith("_") and not name.startswith("__")
-]
+# Keep the original module-level private callables available to importlib users.
+# Referencing compatibility imports explicitly also satisfies static analyzers.
+_COMPAT_EXPORTS = (
+    _decision,
+    _canonical_operand,
+    _EvaluationOptions,
+    analyze_network_argv,
+    _analyze_curl,
+    _analyze_git,
+    _add_destination,
+    _analyze_scp,
+    WORKER_ENV_KEYS,
+    _analyze_wget,
+    SHELL_OPERATORS,
+    SHELLS,
+)
+__all__ = [name for name in globals() if name.startswith("_") and not name.startswith("__")]
 
 FORBID_EXIT = 20
 POLICY_ERROR_EXIT = 21

--- a/.agents/scripts/command_policy_config.py
+++ b/.agents/scripts/command_policy_config.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Loading and structural validation for the command policy."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+KNOWN_MATCHERS = {
+    "rm_recursive_force_root",
+    "rm_recursive_force",
+    "git_checkout_worktree_path",
+    "git_restore_worktree",
+    "git_reset_destructive",
+    "git_clean_force",
+    "git_push_force",
+    "git_branch_force_delete",
+    "git_stash_delete",
+}
+
+
+class PolicyError(ValueError):
+    """Raised when required policy data cannot be trusted."""
+
+
+def _default_policy_path() -> Path:
+    override = os.environ.get("AIDEVOPS_COMMAND_POLICY_CONFIG", "")
+    if override:
+        return Path(override)
+    return Path(__file__).resolve().parent.parent / "configs" / "command-policy.json"
+
+
+def _decision(decision: str, rule_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "decision": decision,
+        "rule_id": rule_id,
+        "reason": reason,
+    }
+
+
+def _policy_error(reason: str) -> dict[str, Any]:
+    return _decision("forbid", "policy.invalid", reason)
+
+
+def _parse_error(reason: str) -> dict[str, Any]:
+    return _decision("forbid", "command.parse-error", reason)
+
+
+def _load_policy(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PolicyError(
+            f"required command policy is unavailable: {path}: {exc}"
+        ) from exc
+    try:
+        policy = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PolicyError(f"required command policy is malformed: {path}: {exc}") from exc
+    _validate_policy_shape(policy)
+    return policy
+
+
+def _validate_policy_shape(policy: Any) -> None:
+    if not isinstance(policy, dict) or policy.get("schema_version") != 2:
+        raise PolicyError("command policy schema_version must be 2")
+    if policy.get("decision_order") != ["allow", "forbid"]:
+        raise PolicyError("command policy decision_order must be allow, forbid")
+    default = policy.get("default_decision")
+    if not isinstance(default, dict) or default.get("decision") != "allow":
+        raise PolicyError("command policy requires an allow default_decision")
+    _validate_policy_guards(policy.get("dynamic_guards"))
+    _validate_policy_rules(policy.get("rules"))
+    fixtures = policy.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        raise PolicyError("command policy requires self-test fixtures")
+
+
+def _validate_policy_guards(guards: Any) -> None:
+    if not _has_required_guard(
+        guards, "canonical_git", "canonical-git-command-guard.py"
+    ):
+        raise PolicyError("command policy requires exactly one canonical Git guard")
+    if not _has_required_guard(guards, "worker_network", "network-tier-helper.sh"):
+        raise PolicyError("command policy requires exactly one worker network guard")
+
+
+def _has_required_guard(guards: Any, kind: str, helper: str) -> bool:
+    matches = [
+        guard
+        for guard in guards or []
+        if isinstance(guard, dict) and guard.get("kind") == kind
+    ]
+    return (
+        len(matches) == 1
+        and matches[0].get("helper") == helper
+        and matches[0].get("decision") == "forbid"
+    )
+
+
+def _validate_policy_rules(rules: Any) -> None:
+    if not isinstance(rules, list) or not rules:
+        raise PolicyError("command policy rules must be a non-empty list")
+    seen_ids: set[str] = set()
+    seen_matchers: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            raise PolicyError("command policy rule must be an object")
+        rule_id = rule.get("id")
+        matcher = rule.get("matcher")
+        if not isinstance(rule_id, str) or not rule_id or rule_id in seen_ids:
+            raise PolicyError("command policy rule IDs must be unique non-empty strings")
+        if matcher not in KNOWN_MATCHERS or matcher in seen_matchers:
+            raise PolicyError(f"command policy matcher is invalid or duplicated: {matcher}")
+        if rule.get("decision") != "forbid" or not isinstance(
+            rule.get("reason"), str
+        ):
+            raise PolicyError(
+                f"command policy rule must be forbid with a reason: {rule_id}"
+            )
+        seen_ids.add(rule_id)
+        seen_matchers.add(matcher)
+    if seen_matchers != KNOWN_MATCHERS:
+        raise PolicyError("command policy must define every required matcher exactly once")

--- a/.agents/scripts/command_policy_config.py
+++ b/.agents/scripts/command_policy_config.py
@@ -109,21 +109,28 @@ def _validate_policy_rules(rules: Any) -> None:
     seen_ids: set[str] = set()
     seen_matchers: set[str] = set()
     for rule in rules:
-        if not isinstance(rule, dict):
-            raise PolicyError("command policy rule must be an object")
-        rule_id = rule.get("id")
-        matcher = rule.get("matcher")
-        if not isinstance(rule_id, str) or not rule_id or rule_id in seen_ids:
-            raise PolicyError("command policy rule IDs must be unique non-empty strings")
-        if matcher not in KNOWN_MATCHERS or matcher in seen_matchers:
-            raise PolicyError(f"command policy matcher is invalid or duplicated: {matcher}")
-        if rule.get("decision") != "forbid" or not isinstance(
-            rule.get("reason"), str
-        ):
-            raise PolicyError(
-                f"command policy rule must be forbid with a reason: {rule_id}"
-            )
+        rule_id, matcher = _validate_policy_rule(rule, seen_ids, seen_matchers)
         seen_ids.add(rule_id)
         seen_matchers.add(matcher)
     if seen_matchers != KNOWN_MATCHERS:
         raise PolicyError("command policy must define every required matcher exactly once")
+
+
+def _validate_policy_rule(
+    rule: Any, seen_ids: set[str], seen_matchers: set[str]
+) -> tuple[str, str]:
+    if not isinstance(rule, dict):
+        raise PolicyError("command policy rule must be an object")
+    rule_id = rule.get("id")
+    matcher = rule.get("matcher")
+    if not _is_new_rule_id(rule_id, seen_ids):
+        raise PolicyError("command policy rule IDs must be unique non-empty strings")
+    if matcher not in KNOWN_MATCHERS or matcher in seen_matchers:
+        raise PolicyError(f"command policy matcher is invalid or duplicated: {matcher}")
+    if rule.get("decision") != "forbid" or not isinstance(rule.get("reason"), str):
+        raise PolicyError(f"command policy rule must be forbid with a reason: {rule_id}")
+    return rule_id, matcher
+
+
+def _is_new_rule_id(rule_id: Any, seen_ids: set[str]) -> bool:
+    return isinstance(rule_id, str) and bool(rule_id) and rule_id not in seen_ids

--- a/.agents/scripts/command_policy_dispatch.py
+++ b/.agents/scripts/command_policy_dispatch.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Input validation and network analyzer dispatch."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from command_policy_git import _analyze_git
+from command_policy_http import _analyze_curl
+from command_policy_network import _add_destination
+from command_policy_transport import _analyze_scp, _analyze_ssh
+from command_policy_wget import _analyze_wget
+
+
+class CommandParseError(ValueError):
+    """Raised when shell syntax cannot be represented as deterministic argv."""
+
+
+def _validate_argv(value: Any) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise CommandParseError("argv must be a non-empty JSON array")
+    if not all(isinstance(arg, str) for arg in value):
+        raise CommandParseError("every argv element must be a string")
+    if any("\x00" in arg for arg in value):
+        raise CommandParseError("argv cannot contain NUL bytes")
+    return value
+
+
+def analyze_network_argv(argv: list[str], cwd: str) -> dict[str, Any]:
+    exact = _validate_argv(argv)
+    executable = os.path.basename(exact[0]).lower()
+    result: dict[str, Any] = {
+        "recognized": False,
+        "requires_destination": True,
+        "destinations": [],
+        "unclassified": [],
+    }
+    if executable == "curl":
+        result["recognized"] = True
+        _analyze_curl(exact, result)
+    elif executable == "wget":
+        result["recognized"] = True
+        _analyze_wget(exact, result)
+    elif executable == "ssh":
+        result["recognized"] = True
+        _analyze_ssh(exact, result)
+    elif executable == "scp":
+        result["recognized"] = True
+        _analyze_scp(exact, result)
+    elif executable == "git":
+        result["recognized"] = _analyze_git(exact, cwd, result)
+    elif executable in {"dig", "nslookup", "host"}:
+        result["recognized"] = True
+        candidates = [
+            arg for arg in exact[1:] if not arg.startswith(("-", "+", "@"))
+        ]
+        if not candidates:
+            result["unclassified"].append("dns-query-destination-missing")
+        else:
+            _add_destination(result, candidates[0], "dns-query")
+    result["destinations"] = sorted(set(result["destinations"]))
+    return result

--- a/.agents/scripts/command_policy_dispatch.py
+++ b/.agents/scripts/command_policy_dispatch.py
@@ -38,28 +38,27 @@ def analyze_network_argv(argv: list[str], cwd: str) -> dict[str, Any]:
         "destinations": [],
         "unclassified": [],
     }
-    if executable == "curl":
+    analyzers = {
+        "curl": _analyze_curl,
+        "wget": _analyze_wget,
+        "ssh": _analyze_ssh,
+        "scp": _analyze_scp,
+    }
+    if executable in analyzers:
         result["recognized"] = True
-        _analyze_curl(exact, result)
-    elif executable == "wget":
-        result["recognized"] = True
-        _analyze_wget(exact, result)
-    elif executable == "ssh":
-        result["recognized"] = True
-        _analyze_ssh(exact, result)
-    elif executable == "scp":
-        result["recognized"] = True
-        _analyze_scp(exact, result)
+        analyzers[executable](exact, result)
     elif executable == "git":
         result["recognized"] = _analyze_git(exact, cwd, result)
     elif executable in {"dig", "nslookup", "host"}:
         result["recognized"] = True
-        candidates = [
-            arg for arg in exact[1:] if not arg.startswith(("-", "+", "@"))
-        ]
-        if not candidates:
-            result["unclassified"].append("dns-query-destination-missing")
-        else:
-            _add_destination(result, candidates[0], "dns-query")
+        _analyze_dns_query(exact, result)
     result["destinations"] = sorted(set(result["destinations"]))
     return result
+
+
+def _analyze_dns_query(argv: list[str], result: dict[str, Any]) -> None:
+    candidates = [arg for arg in argv[1:] if not arg.startswith(("-", "+", "@"))]
+    if candidates:
+        _add_destination(result, candidates[0], "dns-query")
+    else:
+        result["unclassified"].append("dns-query-destination-missing")

--- a/.agents/scripts/command_policy_evaluation.py
+++ b/.agents/scripts/command_policy_evaluation.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Static and dynamic command-policy evaluation."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from command_policy_config import _decision
+from command_policy_matchers import _matches
+
+DECISION_RANK = {"allow": 0, "forbid": 1}
+
+
+@dataclass(frozen=True)
+class _EvaluationOptions:
+    guard_path: str = ""
+    worker: bool = False
+    worker_id: str = "unknown"
+    network_helper: str = ""
+
+
+def _evaluate_static(
+    invocations: list[list[str]], cwd: str, policy: dict[str, Any]
+) -> dict[str, Any]:
+    best = dict(policy["default_decision"])
+    best["schema_version"] = 2
+    for argv in invocations:
+        for rule in policy["rules"]:
+            if (
+                _matches(rule["matcher"], argv, cwd)
+                and DECISION_RANK[rule["decision"]] > DECISION_RANK[best["decision"]]
+            ):
+                best = _decision(rule["decision"], rule["id"], rule["reason"])
+    return best
+
+
+def _canonical_guard_path(
+    policy: dict[str, Any], explicit: str, script_dir: Path | None = None
+) -> Path:
+    if explicit:
+        return Path(explicit)
+    helper = next(
+        guard["helper"]
+        for guard in policy["dynamic_guards"]
+        if guard["kind"] == "canonical_git"
+    )
+    return (script_dir or Path(__file__).resolve().parent) / helper
+
+
+def _evaluate_canonical_git(
+    invocations: list[list[str]], cwd: str, guard: Path
+) -> dict[str, Any]:
+    git_invocations = [
+        argv for argv in invocations if argv and os.path.basename(argv[0]) == "git"
+    ]
+    if not git_invocations:
+        return _decision("allow", "git.no-invocation", "No Git invocation detected")
+    if not guard.is_file():
+        return _decision(
+            "forbid",
+            "git.guard-unavailable",
+            f"Canonical Git policy helper is unavailable: {guard}",
+        )
+    for argv in git_invocations:
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(guard),
+                    "--cwd",
+                    cwd,
+                    "--argv-json",
+                    json.dumps(argv[1:]),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return _decision(
+                "forbid",
+                "git.guard-error",
+                f"Canonical Git policy check failed closed: {exc}",
+            )
+        if result.returncode != 0:
+            reason = result.stderr.strip() or (
+                f"Canonical Git guard failed with exit {result.returncode}"
+            )
+            return _decision("forbid", "git.canonical-worktree", reason)
+    return _decision(
+        "allow", "git.canonical-allow", "Canonical Git guard allowed every Git argv"
+    )
+
+
+def _network_guard_path(
+    policy: dict[str, Any], explicit: str, script_dir: Path | None = None
+) -> Path:
+    if explicit:
+        return Path(explicit)
+    override = os.environ.get("AIDEVOPS_NETWORK_TIER_HELPER", "")
+    if override:
+        return Path(override)
+    helper = next(
+        guard["helper"]
+        for guard in policy["dynamic_guards"]
+        if guard["kind"] == "worker_network"
+    )
+    return (script_dir or Path(__file__).resolve().parent) / helper
+
+
+def _evaluate_worker_network(
+    invocations: list[list[str]], cwd: str, helper: Path, worker_id: str
+) -> dict[str, Any]:
+    if not helper.is_file():
+        return _decision(
+            "forbid",
+            "network.helper-unavailable",
+            f"Required worker network policy helper is unavailable: {helper}",
+        )
+    for argv in invocations:
+        try:
+            result = subprocess.run(
+                [
+                    "/bin/bash",
+                    str(helper),
+                    "check-argv",
+                    json.dumps(argv),
+                    "--cwd",
+                    cwd,
+                    "--worker-id",
+                    worker_id,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return _decision(
+                "forbid",
+                "network.helper-error",
+                f"Worker network policy failed closed: {exc}",
+            )
+        if result.returncode != 0:
+            reason = result.stderr.strip() or (
+                "Worker network policy denied or could not classify the command destination"
+            )
+            return _decision("forbid", "network.worker-policy", reason)
+    return _decision(
+        "allow", "network.worker-allow", "Worker network policy allowed every argv"
+    )
+
+
+def evaluate_invocations(
+    invocations: list[list[str]],
+    cwd: str,
+    policy: dict[str, Any],
+    *legacy_options: Any,
+    **named_options: Any,
+) -> dict[str, Any]:
+    options = _evaluation_options(legacy_options, named_options)
+    script_dir = Path(__file__).resolve().parent
+    decisions = [
+        _evaluate_static(invocations, cwd, policy),
+        _evaluate_canonical_git(
+            invocations,
+            cwd,
+            _canonical_guard_path(policy, options.guard_path, script_dir),
+        ),
+    ]
+    if options.worker:
+        decisions.append(
+            _evaluate_worker_network(
+                invocations,
+                cwd,
+                _network_guard_path(policy, options.network_helper, script_dir),
+                options.worker_id,
+            )
+        )
+    return max(decisions, key=lambda item: DECISION_RANK[item["decision"]])
+
+
+def _evaluation_options(
+    legacy_options: tuple[Any, ...], named_options: dict[str, Any]
+) -> _EvaluationOptions:
+    names = ("guard_path", "worker", "worker_id", "network_helper")
+    if len(legacy_options) > len(names):
+        raise TypeError(
+            f"evaluate_invocations() takes from 3 to 7 positional arguments "
+            f"but {len(legacy_options) + 3} were given"
+        )
+    values: dict[str, Any] = dict(zip(names, legacy_options))
+    for name, value in named_options.items():
+        if name not in names:
+            raise TypeError(
+                f"evaluate_invocations() got an unexpected keyword argument '{name}'"
+            )
+        if name in values:
+            raise TypeError(
+                f"evaluate_invocations() got multiple values for argument '{name}'"
+            )
+        values[name] = value
+    return _EvaluationOptions(**values)

--- a/.agents/scripts/command_policy_evaluation.py
+++ b/.agents/scripts/command_policy_evaluation.py
@@ -58,9 +58,7 @@ def _canonical_guard_path(
 def _evaluate_canonical_git(
     invocations: list[list[str]], cwd: str, guard: Path
 ) -> dict[str, Any]:
-    git_invocations = [
-        argv for argv in invocations if argv and os.path.basename(argv[0]) == "git"
-    ]
+    git_invocations = list(filter(_is_git_invocation, invocations))
     if not git_invocations:
         return _decision("allow", "git.no-invocation", "No Git invocation detected")
     if not guard.is_file():
@@ -70,8 +68,37 @@ def _evaluate_canonical_git(
             f"Canonical Git policy helper is unavailable: {guard}",
         )
     for argv in git_invocations:
-        try:
-            result = subprocess.run(
+        result, error = _run_canonical_guard(argv, cwd, guard)
+        if error:
+            return error
+        denied = _canonical_guard_denial(result)
+        if denied:
+            return denied
+    return _decision(
+        "allow", "git.canonical-allow", "Canonical Git guard allowed every Git argv"
+    )
+
+
+def _is_git_invocation(argv: list[str]) -> bool:
+    return bool(argv) and os.path.basename(argv[0]) == "git"
+
+
+def _canonical_guard_denial(
+    result: subprocess.CompletedProcess[str],
+) -> dict[str, Any] | None:
+    if result.returncode == 0:
+        return None
+    reason = result.stderr.strip() or (
+        f"Canonical Git guard failed with exit {result.returncode}"
+    )
+    return _decision("forbid", "git.canonical-worktree", reason)
+
+
+def _run_canonical_guard(
+    argv: list[str], cwd: str, guard: Path
+) -> tuple[subprocess.CompletedProcess[str] | None, dict[str, Any] | None]:
+    try:
+        result = subprocess.run(  # nosec B603 -- executable is the current Python; guard path is policy-selected and verified as a file.
                 [
                     sys.executable,
                     str(guard),
@@ -84,21 +111,14 @@ def _evaluate_canonical_git(
                 text=True,
                 timeout=10,
                 check=False,
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            return _decision(
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, _decision(
                 "forbid",
                 "git.guard-error",
                 f"Canonical Git policy check failed closed: {exc}",
-            )
-        if result.returncode != 0:
-            reason = result.stderr.strip() or (
-                f"Canonical Git guard failed with exit {result.returncode}"
-            )
-            return _decision("forbid", "git.canonical-worktree", reason)
-    return _decision(
-        "allow", "git.canonical-allow", "Canonical Git guard allowed every Git argv"
-    )
+        )
+    return result, None
 
 
 def _network_guard_path(
@@ -128,7 +148,7 @@ def _evaluate_worker_network(
         )
     for argv in invocations:
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603 -- /bin/bash is fixed and helper is policy-selected and verified as a file.
                 [
                     "/bin/bash",
                     str(helper),

--- a/.agents/scripts/command_policy_git.py
+++ b/.agents/scripts/command_policy_git.py
@@ -71,15 +71,22 @@ def _git_network_candidate(args: list[str], value_options: set[str]) -> str:
             value, index = _option_value(args, index)
             explicit_repo = value or ""
             continue
-        if option in value_options:
-            index += 1 if "=" in arg else 2
-            continue
-        if arg.startswith("-"):
-            index += 1
-            continue
-        positionals.append(arg)
-        index += 1
+        index = _record_git_argument(arg, option, index, value_options, positionals)
     return explicit_repo or (positionals[0] if positionals else "")
+
+
+def _record_git_argument(
+    arg: str,
+    option: str,
+    index: int,
+    value_options: set[str],
+    positionals: list[str],
+) -> int:
+    if option in value_options:
+        return index + (1 if "=" in arg else 2)
+    if not arg.startswith("-"):
+        positionals.append(arg)
+    return index + 1
 
 
 def _classify_git_candidate(

--- a/.agents/scripts/command_policy_git.py
+++ b/.agents/scripts/command_policy_git.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Git destination analysis for command-policy-helper.py."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from command_policy_http import _option_value
+from command_policy_matchers import _git_parts
+from command_policy_network import (
+    _add_destination,
+    _git_effective_cwd,
+    _normalize_host,
+    _resolve_git_remote,
+)
+
+
+def _analyze_git(argv: list[str], cwd: str, result: dict[str, Any]) -> bool:
+    subcommand, args = _git_parts(argv)
+    recognized = subcommand in {"clone", "fetch", "pull", "push", "ls-remote", "submodule"}
+    if subcommand == "submodule":
+        result["unclassified"].append("git-submodule-configured-remotes")
+    elif recognized:
+        _analyze_git_remote(argv, cwd, subcommand, args, result)
+    return recognized
+
+
+def _analyze_git_remote(
+    argv: list[str], cwd: str, subcommand: str, args: list[str], result: dict[str, Any]
+) -> None:
+    _record_git_config_overrides(argv, result)
+    value_options = {
+        "-b", "--branch", "-o", "--origin", "-c", "--config", "--depth",
+        "--reference", "--reference-if-able", "--separate-git-dir", "-j", "--jobs",
+        "--filter", "--upload-pack", "--receive-pack", "--exec",
+    }
+    if subcommand == "clone":
+        value_options.add("-u")
+    candidate = _git_network_candidate(args, value_options)
+    if not candidate:
+        result["unclassified"].append(f"git-{subcommand}-destination-missing")
+    elif not _classify_git_candidate(subcommand, candidate, result):
+        remotes = _resolve_git_remote(_git_effective_cwd(argv, cwd), candidate)
+        if remotes:
+            for remote in remotes:
+                _add_destination(result, remote, "git-remote")
+        else:
+            result["unclassified"].append(f"git-remote:{candidate}")
+
+
+def _record_git_config_overrides(argv: list[str], result: dict[str, Any]) -> None:
+    for index, arg in enumerate(argv[:-1]):
+        if arg == "-c" and any(
+            token in argv[index + 1].lower() for token in ("proxy", "insteadof")
+        ):
+            result["unclassified"].append("git-network-config-override")
+        if arg == "--config-env":
+            result["unclassified"].append("git-config-env-override")
+
+
+def _git_network_candidate(args: list[str], value_options: set[str]) -> str:
+    positionals: list[str] = []
+    explicit_repo = ""
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        option = arg.split("=", 1)[0]
+        if option == "--repo":
+            value, index = _option_value(args, index)
+            explicit_repo = value or ""
+            continue
+        if option in value_options:
+            index += 1 if "=" in arg else 2
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        positionals.append(arg)
+        index += 1
+    return explicit_repo or (positionals[0] if positionals else "")
+
+
+def _classify_git_candidate(
+    subcommand: str, candidate: str, result: dict[str, Any]
+) -> bool:
+    host = _normalize_host(candidate)
+    if host:
+        result["destinations"].append(host)
+        return True
+    if subcommand == "clone" and candidate.startswith(("/", "./", "../", "file://")):
+        result["requires_destination"] = False
+        return True
+    return False

--- a/.agents/scripts/command_policy_git_matchers.py
+++ b/.agents/scripts/command_policy_git_matchers.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Static Git command matchers for the command policy."""
+
+from __future__ import annotations
+
+import os
+
+
+def _short_flags(args: list[str]) -> set[str]:
+    flags: set[str] = set()
+    for arg in args:
+        if arg == "--":
+            break
+        if arg.startswith("-") and not arg.startswith("--"):
+            flags.update(arg[1:])
+    return flags
+
+
+def _has_flag(args: list[str], short: str, long: str) -> bool:
+    option_args = args[: args.index("--")] if "--" in args else args
+    return long in option_args or short in _short_flags(option_args)
+
+
+def _git_parts(argv: list[str]) -> tuple[str, list[str]]:
+    if not argv or os.path.basename(argv[0]) != "git":
+        return "", []
+    index = 1
+    value_options = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
+    while index < len(argv):
+        arg = argv[index]
+        if arg in value_options:
+            index += 2
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        return arg, argv[index + 1 :]
+    return "", []
+
+
+def _matches_git(matcher: str, subcommand: str, git_args: list[str]) -> bool:
+    short_flags = _short_flags(git_args)
+    staged = "--staged" in git_args or "S" in short_flags
+    worktree = "--worktree" in git_args or "W" in short_flags
+    matches = _git_worktree_matches(subcommand, git_args, staged, worktree)
+    matches.update(_git_history_matches(subcommand, git_args, short_flags))
+    return matches.get(matcher, False)
+
+
+def _git_worktree_matches(
+    subcommand: str,
+    git_args: list[str],
+    staged: bool,
+    worktree: bool,
+) -> dict[str, bool]:
+    return {
+        "git_checkout_worktree_path": subcommand == "checkout" and "--" in git_args,
+        "git_restore_worktree": subcommand == "restore" and (worktree or not staged),
+        "git_reset_destructive": subcommand == "reset"
+        and any(arg in {"--hard", "--merge"} for arg in git_args),
+    }
+
+
+def _git_history_matches(
+    subcommand: str, git_args: list[str], short_flags: set[str]
+) -> dict[str, bool]:
+    return {
+        "git_clean_force": subcommand == "clean"
+        and _has_flag(git_args, "f", "--force")
+        and not _has_flag(git_args, "n", "--dry-run"),
+        "git_push_force": subcommand == "push"
+        and ("--force" in git_args or "f" in short_flags),
+        "git_branch_force_delete": subcommand == "branch" and "D" in short_flags,
+        "git_stash_delete": subcommand == "stash"
+        and bool(git_args)
+        and git_args[0] in {"drop", "clear"},
+    }

--- a/.agents/scripts/command_policy_http.py
+++ b/.agents/scripts/command_policy_http.py
@@ -29,8 +29,26 @@ def _analyze_curl(argv: list[str], result: dict[str, Any]) -> None:
     }
     destination_options = {"--url", "--proxy", "--preproxy"}
     short_value_options = {
-        "-A", "-b", "-c", "-d", "-D", "-e", "-E", "-F", "-H", "-K",
-        "-m", "-o", "-Q", "-r", "-T", "-u", "-w", "-X", "-Y", "-z",
+        "-A",
+        "-b",
+        "-c",
+        "-d",
+        "-D",
+        "-e",
+        "-E",
+        "-F",
+        "-H",
+        "-K",
+        "-m",
+        "-o",
+        "-Q",
+        "-r",
+        "-T",
+        "-u",
+        "-w",
+        "-X",
+        "-Y",
+        "-z",
     }
     index = 1
     while index < len(argv):

--- a/.agents/scripts/command_policy_http.py
+++ b/.agents/scripts/command_policy_http.py
@@ -28,7 +28,10 @@ def _analyze_curl(argv: list[str], result: dict[str, Any]) -> None:
         "--dns-ipv6-addr",
     }
     destination_options = {"--url", "--proxy", "--preproxy"}
-    short_value_options = {"-A", "-b", "-c", "-d", "-D", "-e", "-E", "-F", "-H", "-K", "-m", "-o", "-Q", "-r", "-T", "-u", "-w", "-X", "-Y", "-z"}
+    short_value_options = {
+        "-A", "-b", "-c", "-d", "-D", "-e", "-E", "-F", "-H", "-K",
+        "-m", "-o", "-Q", "-r", "-T", "-u", "-w", "-X", "-Y", "-z",
+    }
     index = 1
     while index < len(argv):
         special_index = _curl_destination_option(argv, index, result, destination_options)
@@ -88,22 +91,29 @@ def _curl_other_arg(
 ) -> int:
     arg = argv[index]
     option = arg.split("=", 1)[0]
-    next_index = index + 1
     if option in {"--config", "-K"} or arg.startswith("-K"):
         result["unclassified"].append("curl-config-file")
-        next_index = index + (2 if arg in {"--config", "-K"} else 1)
-    elif option in value_options:
-        next_index = _option_value(argv, index)[1]
-    elif arg == "-x" or arg.startswith("-x"):
-        value = argv[index + 1] if arg == "-x" and index + 1 < len(argv) else arg[2:]
-        _add_destination(result, value, "proxy")
-        next_index = index + (2 if arg == "-x" else 1)
-    elif not arg.startswith("-"):
+        return index + (2 if arg in {"--config", "-K"} else 1)
+    if option in value_options:
+        return _option_value(argv, index)[1]
+    proxy_index = _curl_proxy_index(argv, index, result)
+    if proxy_index is not None:
+        return proxy_index
+    if not arg.startswith("-"):
         _add_destination(result, arg, "url")
-    else:
-        short_index = _curl_short_value_index(argv, index, result, short_value_options)
-        next_index = short_index or next_index
-    return next_index
+        return index + 1
+    return _curl_short_value_index(argv, index, result, short_value_options) or index + 1
+
+
+def _curl_proxy_index(
+    argv: list[str], index: int, result: dict[str, Any]
+) -> int | None:
+    arg = argv[index]
+    if arg != "-x" and not arg.startswith("-x"):
+        return None
+    value = argv[index + 1] if arg == "-x" and index + 1 < len(argv) else arg[2:]
+    _add_destination(result, value, "proxy")
+    return index + (2 if arg == "-x" else 1)
 
 
 def _curl_short_value_index(

--- a/.agents/scripts/command_policy_http.py
+++ b/.agents/scripts/command_policy_http.py
@@ -28,28 +28,9 @@ def _analyze_curl(argv: list[str], result: dict[str, Any]) -> None:
         "--dns-ipv6-addr",
     }
     destination_options = {"--url", "--proxy", "--preproxy"}
-    short_value_options = {
-        "-A",
-        "-b",
-        "-c",
-        "-d",
-        "-D",
-        "-e",
-        "-E",
-        "-F",
-        "-H",
-        "-K",
-        "-m",
-        "-o",
-        "-Q",
-        "-r",
-        "-T",
-        "-u",
-        "-w",
-        "-X",
-        "-Y",
-        "-z",
-    }
+    short_value_options = set(
+        "-A -b -c -d -D -e -E -F -H -K -m -o -Q -r -T -u -w -X -Y -z".split()
+    )
     index = 1
     while index < len(argv):
         special_index = _curl_destination_option(argv, index, result, destination_options)

--- a/.agents/scripts/command_policy_http.py
+++ b/.agents/scripts/command_policy_http.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""curl and wget destination analysis for command-policy-helper.py."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from command_policy_network import _add_destination
+
+
+def _option_value(argv: list[str], index: int) -> tuple[str | None, int]:
+    if "=" in argv[index]:
+        return argv[index].split("=", 1)[1], index + 1
+    if index + 1 >= len(argv):
+        return None, index + 1
+    return argv[index + 1], index + 2
+
+
+def _analyze_curl(argv: list[str], result: dict[str, Any]) -> None:
+    value_options = {
+        "--request", "--header", "--data", "--data-raw", "--data-binary", "--form",
+        "--user", "--output", "--referer", "--user-agent", "--cookie", "--cookie-jar",
+        "--cacert", "--cert", "--key", "--max-time", "--connect-timeout", "--retry",
+        "--proto", "--proto-redir", "--interface", "--dns-interface", "--dns-ipv4-addr",
+        "--dns-ipv6-addr",
+    }
+    destination_options = {"--url", "--proxy", "--preproxy"}
+    short_value_options = {"-A", "-b", "-c", "-d", "-D", "-e", "-E", "-F", "-H", "-K", "-m", "-o", "-Q", "-r", "-T", "-u", "-w", "-X", "-Y", "-z"}
+    index = 1
+    while index < len(argv):
+        special_index = _curl_destination_option(argv, index, result, destination_options)
+        index = special_index if special_index is not None else _curl_other_arg(
+            argv, index, result, value_options, short_value_options
+        )
+
+
+def _curl_destination_option(
+    argv: list[str], index: int, result: dict[str, Any], destination_options: set[str]
+) -> int | None:
+    option = argv[index].split("=", 1)[0]
+    if option in destination_options:
+        value, next_index = _option_value(argv, index)
+        if value is None:
+            result["unclassified"].append(f"missing:{option}")
+        else:
+            _add_destination(result, value, option)
+        return next_index
+    if option == "--resolve":
+        return _curl_resolve_option(argv, index, result)
+    if option == "--connect-to":
+        return _curl_connect_option(argv, index, result)
+    return None
+
+
+def _curl_resolve_option(argv: list[str], index: int, result: dict[str, Any]) -> int:
+    value, next_index = _option_value(argv, index)
+    match = re.match(r"^(\[[^]]+\]|[^:]+):[^:]*:(.+)$", value or "")
+    if not match:
+        result["unclassified"].append(f"resolve:{value or ''}")
+    else:
+        _add_destination(result, match.group(1), "resolve-host")
+        _add_destination(result, match.group(2), "resolve-address")
+    return next_index
+
+
+def _curl_connect_option(argv: list[str], index: int, result: dict[str, Any]) -> int:
+    value, next_index = _option_value(argv, index)
+    parts = (value or "").split(":")
+    if len(parts) != 4:
+        result["unclassified"].append(f"connect-to:{value or ''}")
+        return next_index
+    if parts[0]:
+        _add_destination(result, parts[0], "connect-source")
+    if parts[2]:
+        _add_destination(result, parts[2], "connect-target")
+    return next_index
+
+
+def _curl_other_arg(
+    argv: list[str],
+    index: int,
+    result: dict[str, Any],
+    value_options: set[str],
+    short_value_options: set[str],
+) -> int:
+    arg = argv[index]
+    option = arg.split("=", 1)[0]
+    next_index = index + 1
+    if option in {"--config", "-K"} or arg.startswith("-K"):
+        result["unclassified"].append("curl-config-file")
+        next_index = index + (2 if arg in {"--config", "-K"} else 1)
+    elif option in value_options:
+        next_index = _option_value(argv, index)[1]
+    elif arg == "-x" or arg.startswith("-x"):
+        value = argv[index + 1] if arg == "-x" and index + 1 < len(argv) else arg[2:]
+        _add_destination(result, value, "proxy")
+        next_index = index + (2 if arg == "-x" else 1)
+    elif not arg.startswith("-"):
+        _add_destination(result, arg, "url")
+    else:
+        short_index = _curl_short_value_index(argv, index, result, short_value_options)
+        next_index = short_index or next_index
+    return next_index
+
+
+def _curl_short_value_index(
+    argv: list[str],
+    index: int,
+    result: dict[str, Any],
+    short_value_options: set[str],
+) -> int | None:
+    arg = argv[index]
+    if arg in short_value_options:
+        if index + 1 >= len(argv):
+            result["unclassified"].append(f"missing:{arg}")
+            return index + 1
+        return index + 2
+    if any(arg.startswith(item) and arg != item for item in short_value_options):
+        return index + 1
+    return None

--- a/.agents/scripts/command_policy_launcher_options.py
+++ b/.agents/scripts/command_policy_launcher_options.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Shell and builtin launcher option parsing."""
+
+from __future__ import annotations
+
+from command_policy_dispatch import CommandParseError
+from command_policy_wrapper_options import _consume_option
+
+
+def _shell_command_index(argv: list[str]) -> int | None:
+    index = 1
+    value_options = {"-O", "+O", "-o", "+o", "--init-file", "--rcfile"}
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--":
+            return None
+        if arg.startswith("-") and not arg.startswith("--") and "c" in arg[1:]:
+            return index + 1
+        if arg in {"--init-file", "--rcfile"} or arg.startswith(("--init-file=", "--rcfile=")):
+            raise CommandParseError(f"shell startup file option is unsupported: {arg}")
+        consumed = _shell_value_option_index(argv, index, value_options)
+        if consumed is not None:
+            index = consumed
+            continue
+        if arg.startswith(("-", "+")):
+            index += 1
+            continue
+        if not arg.startswith("-"):
+            return None
+    return None
+
+
+def _shell_value_option_index(
+    argv: list[str], index: int, value_options: set[str]
+) -> int | None:
+    arg = argv[index]
+    if arg in value_options:
+        if index + 1 >= len(argv):
+            raise CommandParseError(f"missing value for shell option {arg}")
+        return index + 2
+    if any(
+        arg.startswith(option + "=")
+        for option in value_options
+        if option.startswith("--")
+    ):
+        return index + 1
+    return None
+
+
+def _unwrap_exec(argv: list[str]) -> list[str]:
+    index = 1
+    while index < len(argv) and argv[index].startswith("-"):
+        index = _consume_option(argv, index, {"-a"}, {"-c", "-l"})
+    if index >= len(argv):
+        raise CommandParseError("exec wrapper has no command")
+    return argv[index:]
+
+
+def _unwrap_command(argv: list[str]) -> list[str]:
+    index = 1
+    while index < len(argv) and argv[index] in {"-p", "--"}:
+        index += 1
+    if index >= len(argv):
+        raise CommandParseError("command wrapper has no command")
+    return argv[index:]

--- a/.agents/scripts/command_policy_launcher_options.py
+++ b/.agents/scripts/command_policy_launcher_options.py
@@ -14,22 +14,27 @@ def _shell_command_index(argv: list[str]) -> int | None:
     value_options = {"-O", "+O", "-o", "+o", "--init-file", "--rcfile"}
     while index < len(argv):
         arg = argv[index]
-        if arg == "--":
-            return None
-        if arg.startswith("-") and not arg.startswith("--") and "c" in arg[1:]:
-            return index + 1
+        command_index = _shell_command_option_index(arg, index)
+        if command_index is not False:
+            return command_index
         if arg in {"--init-file", "--rcfile"} or arg.startswith(("--init-file=", "--rcfile=")):
             raise CommandParseError(f"shell startup file option is unsupported: {arg}")
         consumed = _shell_value_option_index(argv, index, value_options)
         if consumed is not None:
             index = consumed
             continue
-        if arg.startswith(("-", "+")):
-            index += 1
-            continue
-        if not arg.startswith("-"):
-            return None
+        index += 1
     return None
+
+
+def _shell_command_option_index(arg: str, index: int) -> int | None | bool:
+    if arg == "--":
+        return None
+    if arg.startswith("-") and not arg.startswith("--") and "c" in arg[1:]:
+        return index + 1
+    if not arg.startswith(("-", "+")):
+        return None
+    return False
 
 
 def _shell_value_option_index(

--- a/.agents/scripts/command_policy_matchers.py
+++ b/.agents/scripts/command_policy_matchers.py
@@ -8,20 +8,25 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from command_policy_git_matchers import (
+    _git_parts,
+    _has_flag,
+    _matches_git,
+    _short_flags,
+)
 
-def _short_flags(args: list[str]) -> set[str]:
-    flags: set[str] = set()
-    for arg in args:
-        if arg == "--":
-            break
-        if arg.startswith("-") and not arg.startswith("--"):
-            flags.update(arg[1:])
-    return flags
-
-
-def _has_flag(args: list[str], short: str, long: str) -> bool:
-    option_args = args[: args.index("--")] if "--" in args else args
-    return long in option_args or short in _short_flags(option_args)
+__all__ = [
+    "_canonical_operand",
+    "_git_parts",
+    "_has_flag",
+    "_is_root_or_home_operand",
+    "_is_temp_operand",
+    "_matches",
+    "_matches_git",
+    "_matches_rm",
+    "_rm_operands",
+    "_short_flags",
+]
 
 
 def _rm_operands(args: list[str]) -> list[str]:
@@ -49,8 +54,7 @@ def _is_temp_operand(path: str, cwd: str) -> bool:
     canonical = _canonical_operand(path, cwd)
     if not canonical:
         return False
-    # nosec B108 -- these canonical roots classify operands; no temp file is created.
-    roots = ["/tmp", "/var/tmp"]
+    roots = ["/tmp", "/var/tmp"]  # nosec B108 -- classification roots only; no temporary file is created.
     tmpdir = os.environ.get("TMPDIR", "")
     if tmpdir:
         roots.append(tmpdir)
@@ -75,23 +79,6 @@ def _is_root_or_home_operand(path: str, cwd: str) -> bool:
     return canonical == "/" or canonical == home or canonical.startswith(home + os.sep)
 
 
-def _git_parts(argv: list[str]) -> tuple[str, list[str]]:
-    if not argv or os.path.basename(argv[0]) != "git":
-        return "", []
-    index = 1
-    value_options = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
-    while index < len(argv):
-        arg = argv[index]
-        if arg in value_options:
-            index += 2
-            continue
-        if arg.startswith("-"):
-            index += 1
-            continue
-        return arg, argv[index + 1 :]
-    return "", []
-
-
 def _matches(matcher: str, argv: list[str], cwd: str) -> bool:
     if matcher in {"rm_recursive_force_root", "rm_recursive_force"}:
         return _matches_rm(matcher, argv, cwd)
@@ -104,11 +91,7 @@ def _matches(matcher: str, argv: list[str], cwd: str) -> bool:
 def _matches_rm(matcher: str, argv: list[str], cwd: str) -> bool:
     executable = os.path.basename(argv[0]) if argv else ""
     args = argv[1:]
-    if (
-        executable != "rm"
-        or not _has_flag(args, "r", "--recursive")
-        or not _has_flag(args, "f", "--force")
-    ):
+    if not _is_recursive_force_rm(executable, args):
         return False
     operands = _rm_operands(args)
     if not operands or all(_is_temp_operand(path, cwd) for path in operands):
@@ -117,40 +100,9 @@ def _matches_rm(matcher: str, argv: list[str], cwd: str) -> bool:
     return is_root if matcher == "rm_recursive_force_root" else not is_root
 
 
-def _matches_git(matcher: str, subcommand: str, git_args: list[str]) -> bool:
-    short_flags = _short_flags(git_args)
-    staged = "--staged" in git_args or "S" in short_flags
-    worktree = "--worktree" in git_args or "W" in short_flags
-    matches = _git_worktree_matches(subcommand, git_args, staged, worktree)
-    matches.update(_git_history_matches(subcommand, git_args, short_flags))
-    return matches.get(matcher, False)
-
-
-def _git_worktree_matches(
-    subcommand: str,
-    git_args: list[str],
-    staged: bool,
-    worktree: bool,
-) -> dict[str, bool]:
-    return {
-        "git_checkout_worktree_path": subcommand == "checkout" and "--" in git_args,
-        "git_restore_worktree": subcommand == "restore" and (worktree or not staged),
-        "git_reset_destructive": subcommand == "reset"
-        and any(arg in {"--hard", "--merge"} for arg in git_args),
-    }
-
-
-def _git_history_matches(
-    subcommand: str, git_args: list[str], short_flags: set[str]
-) -> dict[str, bool]:
-    return {
-        "git_clean_force": subcommand == "clean"
-        and _has_flag(git_args, "f", "--force")
-        and not _has_flag(git_args, "n", "--dry-run"),
-        "git_push_force": subcommand == "push"
-        and ("--force" in git_args or "f" in short_flags),
-        "git_branch_force_delete": subcommand == "branch" and "D" in short_flags,
-        "git_stash_delete": subcommand == "stash"
-        and bool(git_args)
-        and git_args[0] in {"drop", "clear"},
-    }
+def _is_recursive_force_rm(executable: str, args: list[str]) -> bool:
+    return (
+        executable == "rm"
+        and _has_flag(args, "r", "--recursive")
+        and _has_flag(args, "f", "--force")
+    )

--- a/.agents/scripts/command_policy_matchers.py
+++ b/.agents/scripts/command_policy_matchers.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Static destructive-command matchers for command-policy-helper.py."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _short_flags(args: list[str]) -> set[str]:
+    flags: set[str] = set()
+    for arg in args:
+        if arg == "--":
+            break
+        if arg.startswith("-") and not arg.startswith("--"):
+            flags.update(arg[1:])
+    return flags
+
+
+def _has_flag(args: list[str], short: str, long: str) -> bool:
+    option_args = args[: args.index("--")] if "--" in args else args
+    return long in option_args or short in _short_flags(option_args)
+
+
+def _rm_operands(args: list[str]) -> list[str]:
+    operands: list[str] = []
+    after_options = False
+    for arg in args:
+        if arg == "--":
+            after_options = True
+            continue
+        if after_options or not arg.startswith("-"):
+            operands.append(arg)
+    return operands
+
+
+def _canonical_operand(path: str, cwd: str) -> str | None:
+    if not path or "\x00" in path or any(part == ".." for part in Path(path).parts):
+        return None
+    if path.startswith(("$", "~")):
+        return None
+    candidate = path if os.path.isabs(path) else os.path.join(cwd, path)
+    return os.path.realpath(os.path.normpath(candidate))
+
+
+def _is_temp_operand(path: str, cwd: str) -> bool:
+    canonical = _canonical_operand(path, cwd)
+    if not canonical:
+        return False
+    # nosec B108 -- these canonical roots classify operands; no temp file is created.
+    roots = ["/tmp", "/var/tmp"]
+    tmpdir = os.environ.get("TMPDIR", "")
+    if tmpdir:
+        roots.append(tmpdir)
+    for root in roots:
+        canonical_root = os.path.realpath(os.path.normpath(root))
+        try:
+            if (
+                os.path.commonpath([canonical, canonical_root]) == canonical_root
+                and canonical != canonical_root
+            ):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def _is_root_or_home_operand(path: str, cwd: str) -> bool:
+    canonical = _canonical_operand(path, cwd)
+    if not canonical:
+        return path in {"/", "~", "$HOME", "${HOME}"}
+    home = os.path.realpath(str(Path.home()))
+    return canonical == "/" or canonical == home or canonical.startswith(home + os.sep)
+
+
+def _git_parts(argv: list[str]) -> tuple[str, list[str]]:
+    if not argv or os.path.basename(argv[0]) != "git":
+        return "", []
+    index = 1
+    value_options = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
+    while index < len(argv):
+        arg = argv[index]
+        if arg in value_options:
+            index += 2
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        return arg, argv[index + 1 :]
+    return "", []
+
+
+def _matches(matcher: str, argv: list[str], cwd: str) -> bool:
+    if matcher in {"rm_recursive_force_root", "rm_recursive_force"}:
+        return _matches_rm(matcher, argv, cwd)
+    subcommand, git_args = _git_parts(argv)
+    if not subcommand:
+        return False
+    return _matches_git(matcher, subcommand, git_args)
+
+
+def _matches_rm(matcher: str, argv: list[str], cwd: str) -> bool:
+    executable = os.path.basename(argv[0]) if argv else ""
+    args = argv[1:]
+    if (
+        executable != "rm"
+        or not _has_flag(args, "r", "--recursive")
+        or not _has_flag(args, "f", "--force")
+    ):
+        return False
+    operands = _rm_operands(args)
+    if not operands or all(_is_temp_operand(path, cwd) for path in operands):
+        return False
+    is_root = any(_is_root_or_home_operand(path, cwd) for path in operands)
+    return is_root if matcher == "rm_recursive_force_root" else not is_root
+
+
+def _matches_git(matcher: str, subcommand: str, git_args: list[str]) -> bool:
+    short_flags = _short_flags(git_args)
+    staged = "--staged" in git_args or "S" in short_flags
+    worktree = "--worktree" in git_args or "W" in short_flags
+    matches = _git_worktree_matches(subcommand, git_args, staged, worktree)
+    matches.update(_git_history_matches(subcommand, git_args, short_flags))
+    return matches.get(matcher, False)
+
+
+def _git_worktree_matches(
+    subcommand: str,
+    git_args: list[str],
+    staged: bool,
+    worktree: bool,
+) -> dict[str, bool]:
+    return {
+        "git_checkout_worktree_path": subcommand == "checkout" and "--" in git_args,
+        "git_restore_worktree": subcommand == "restore" and (worktree or not staged),
+        "git_reset_destructive": subcommand == "reset"
+        and any(arg in {"--hard", "--merge"} for arg in git_args),
+    }
+
+
+def _git_history_matches(
+    subcommand: str, git_args: list[str], short_flags: set[str]
+) -> dict[str, bool]:
+    return {
+        "git_clean_force": subcommand == "clean"
+        and _has_flag(git_args, "f", "--force")
+        and not _has_flag(git_args, "n", "--dry-run"),
+        "git_push_force": subcommand == "push"
+        and ("--force" in git_args or "f" in short_flags),
+        "git_branch_force_delete": subcommand == "branch" and "D" in short_flags,
+        "git_stash_delete": subcommand == "stash"
+        and bool(git_args)
+        and git_args[0] in {"drop", "clear"},
+    }

--- a/.agents/scripts/command_policy_network.py
+++ b/.agents/scripts/command_policy_network.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Network destination normalization for command-policy-helper.py."""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+
+def _normalize_host(value: str) -> str | None:
+    candidate = value.strip()
+    if not candidate or any(char in candidate for char in "\x00\n\r"):
+        return None
+    if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*://", candidate):
+        parsed = urlsplit(candidate)
+        return parsed.hostname.lower().rstrip(".") if parsed.hostname else None
+    candidate = _host_candidate(candidate)
+    try:
+        ipaddress.ip_address(candidate)
+        return candidate
+    except ValueError:
+        pass
+    if (
+        re.fullmatch(r"[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?", candidate)
+        and "." in candidate
+    ):
+        return candidate
+    return None
+
+
+def _host_candidate(candidate: str) -> str:
+    scp_match = re.match(r"^(?:[^@/:]+@)?(\[[^]]+\]|[^/:]+):.+$", candidate)
+    if scp_match and not re.match(r"^[A-Za-z]:[\\/]", candidate):
+        candidate = scp_match.group(1).strip("[]").lower().rstrip(".")
+    elif "@" in candidate and "/" not in candidate:
+        candidate = candidate.rsplit("@", 1)[1]
+    if "/" in candidate:
+        candidate = candidate.split("/", 1)[0]
+    if candidate.startswith("[") and "]" in candidate:
+        candidate = candidate[1 : candidate.index("]")]
+    elif candidate.count(":") == 1:
+        candidate = candidate.split(":", 1)[0]
+    return candidate.rstrip(".").lower()
+
+
+def _add_destination(result: dict[str, Any], value: str, label: str) -> None:
+    host = _normalize_host(value)
+    if host:
+        result["destinations"].append(host)
+    else:
+        result["unclassified"].append(f"{label}:{value}")
+
+
+def _resolve_git_remote(cwd: str, remote: str) -> list[str]:
+    git_binary = "/usr/bin/git" if Path("/usr/bin/git").is_file() else "git"
+    try:
+        resolved = subprocess.run(
+            [git_binary, "-C", cwd, "remote", "get-url", "--all", remote],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return (
+        [line for line in resolved.stdout.splitlines() if line]
+        if resolved.returncode == 0
+        else []
+    )
+
+
+def _git_effective_cwd(argv: list[str], cwd: str) -> str:
+    effective = cwd
+    index = 1
+    while index < len(argv):
+        if argv[index] == "-C" and index + 1 < len(argv):
+            target = argv[index + 1]
+            effective = (
+                target
+                if os.path.isabs(target)
+                else os.path.abspath(os.path.join(effective, target))
+            )
+            index += 2
+            continue
+        if not argv[index].startswith("-"):
+            break
+        index += 1
+    return effective

--- a/.agents/scripts/command_policy_network.py
+++ b/.agents/scripts/command_policy_network.py
@@ -19,14 +19,10 @@ def _normalize_host(value: str) -> str | None:
     if not candidate or any(char in candidate for char in "\x00\n\r"):
         return None
     if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*://", candidate):
-        parsed = urlsplit(candidate)
-        return parsed.hostname.lower().rstrip(".") if parsed.hostname else None
+        return _url_host(candidate)
     candidate = _host_candidate(candidate)
-    try:
-        ipaddress.ip_address(candidate)
+    if _is_ip_address(candidate):
         return candidate
-    except ValueError:
-        pass
     if (
         re.fullmatch(r"[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?", candidate)
         and "." in candidate
@@ -35,14 +31,30 @@ def _normalize_host(value: str) -> str | None:
     return None
 
 
+def _url_host(candidate: str) -> str | None:
+    parsed = urlsplit(candidate)
+    return parsed.hostname.lower().rstrip(".") if parsed.hostname else None
+
+
+def _is_ip_address(candidate: str) -> bool:
+    try:
+        ipaddress.ip_address(candidate)
+        return True
+    except ValueError:
+        return False
+
+
 def _host_candidate(candidate: str) -> str:
     scp_match = re.match(r"^(?:[^@/:]+@)?(\[[^]]+\]|[^/:]+):.+$", candidate)
     if scp_match and not re.match(r"^[A-Za-z]:[\\/]", candidate):
         candidate = scp_match.group(1).strip("[]").lower().rstrip(".")
     elif "@" in candidate and "/" not in candidate:
         candidate = candidate.rsplit("@", 1)[1]
-    if "/" in candidate:
-        candidate = candidate.split("/", 1)[0]
+    return _strip_host_path_and_port(candidate)
+
+
+def _strip_host_path_and_port(candidate: str) -> str:
+    candidate = candidate.split("/", 1)[0]
     if candidate.startswith("[") and "]" in candidate:
         candidate = candidate[1 : candidate.index("]")]
     elif candidate.count(":") == 1:
@@ -61,7 +73,7 @@ def _add_destination(result: dict[str, Any], value: str, label: str) -> None:
 def _resolve_git_remote(cwd: str, remote: str) -> list[str]:
     git_binary = "/usr/bin/git" if Path("/usr/bin/git").is_file() else "git"
     try:
-        resolved = subprocess.run(
+        resolved = subprocess.run(  # nosec B603 -- argv is fixed except validated cwd/remote data; shell execution is disabled.
             [git_binary, "-C", cwd, "remote", "get-url", "--all", remote],
             capture_output=True,
             text=True,

--- a/.agents/scripts/command_policy_parser.py
+++ b/.agents/scripts/command_policy_parser.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Deterministic parsing of the supported shell-command subset."""
+
+from __future__ import annotations
+
+import shlex
+
+from command_policy_dispatch import CommandParseError
+from command_policy_wrappers import _expand_argv as _expand_wrapped_argv
+
+SHELL_OPERATORS = {"&&", "||", ";", "|"}
+
+
+def _scan_supported_shell(command: str) -> None:
+    if not command.strip():
+        raise CommandParseError("command is empty")
+    if "\n" in command or "\r" in command:
+        raise CommandParseError("multiline shell commands are unsupported")
+    single = False
+    double = False
+    escaped = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        next_char = command[index + 1] if index + 1 < len(command) else ""
+        single, double, escaped, consumed = _shell_quote_state(
+            char, single, double, escaped
+        )
+        if consumed or single:
+            index += 1
+            continue
+        _validate_shell_character(command, index, char, next_char, double)
+        index += 1
+    if single or double or escaped:
+        raise CommandParseError("unterminated shell quoting or escape")
+
+
+def _shell_quote_state(
+    char: str, single: bool, double: bool, escaped: bool
+) -> tuple[bool, bool, bool, bool]:
+    if escaped:
+        return single, double, False, True
+    if char == "\\" and not single:
+        return single, double, True, True
+    if char == "'" and not double:
+        return not single, double, False, True
+    if char == '"' and not single:
+        return single, not double, False, True
+    return single, double, False, False
+
+
+def _validate_shell_character(
+    command: str, index: int, char: str, next_char: str, double: bool
+) -> None:
+    if char in {"`", "$"}:
+        raise CommandParseError("dynamic shell expansion is unsupported")
+    if double:
+        return
+    if char in "<>":
+        raise CommandParseError("shell redirection is unsupported")
+    if char in "(){}":
+        raise CommandParseError("shell grouping and subshell syntax are unsupported")
+    if char == "&" and next_char != "&" and (index == 0 or command[index - 1] != "&"):
+        raise CommandParseError("background shell execution is unsupported")
+    if char in "*[":
+        raise CommandParseError("unquoted shell glob syntax is unsupported")
+
+
+def _expand_argv(argv: list[str]) -> list[list[str]]:
+    return _expand_wrapped_argv(argv, _shell_invocations)
+
+
+def _shell_invocations(command: str) -> list[list[str]]:
+    _scan_supported_shell(command)
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError as exc:
+        raise CommandParseError(f"unable to tokenize shell command: {exc}") from exc
+    invocations: list[list[str]] = []
+    segment: list[str] = []
+    expect_command = True
+    for token in tokens:
+        if token in SHELL_OPERATORS:
+            if expect_command or not segment:
+                raise CommandParseError("empty or repeated shell operator segment")
+            invocations.extend(_expand_argv(segment))
+            segment = []
+            expect_command = True
+            continue
+        if token and all(char in ";&|()" for char in token):
+            raise CommandParseError(f"unsupported shell operator {token}")
+        segment.append(token)
+        expect_command = False
+    if not segment:
+        raise CommandParseError("shell command ends with an operator")
+    invocations.extend(_expand_argv(segment))
+    if not invocations:
+        raise CommandParseError("command produced no executable argv")
+    return invocations

--- a/.agents/scripts/command_policy_parser.py
+++ b/.agents/scripts/command_policy_parser.py
@@ -14,27 +14,28 @@ SHELL_OPERATORS = {"&&", "||", ";", "|"}
 
 
 def _scan_supported_shell(command: str) -> None:
-    if not command.strip():
-        raise CommandParseError("command is empty")
-    if "\n" in command or "\r" in command:
-        raise CommandParseError("multiline shell commands are unsupported")
-    single = False
-    double = False
-    escaped = False
+    _validate_command_text(command)
+    quote_state = (False, False, False)
     index = 0
     while index < len(command):
         char = command[index]
         next_char = command[index + 1] if index + 1 < len(command) else ""
-        single, double, escaped, consumed = _shell_quote_state(
-            char, single, double, escaped
-        )
+        single, double, escaped, consumed = _shell_quote_state(char, *quote_state)
+        quote_state = (single, double, escaped)
         if consumed or single:
             index += 1
             continue
         _validate_shell_character(command, index, char, next_char, double)
         index += 1
-    if single or double or escaped:
+    if any(quote_state):
         raise CommandParseError("unterminated shell quoting or escape")
+
+
+def _validate_command_text(command: str) -> None:
+    if not command.strip():
+        raise CommandParseError("command is empty")
+    if "\n" in command or "\r" in command:
+        raise CommandParseError("multiline shell commands are unsupported")
 
 
 def _shell_quote_state(
@@ -54,18 +55,32 @@ def _shell_quote_state(
 def _validate_shell_character(
     command: str, index: int, char: str, next_char: str, double: bool
 ) -> None:
-    if char in {"`", "$"}:
-        raise CommandParseError("dynamic shell expansion is unsupported")
     if double:
+        if char in {"`", "$"}:
+            raise CommandParseError("dynamic shell expansion is unsupported")
         return
-    if char in "<>":
-        raise CommandParseError("shell redirection is unsupported")
-    if char in "(){}":
-        raise CommandParseError("shell grouping and subshell syntax are unsupported")
+    _validate_unquoted_character(command, index, char, next_char)
+
+
+def _validate_unquoted_character(
+    command: str, index: int, char: str, next_char: str
+) -> None:
+    invalid = {
+        "`": "dynamic shell expansion is unsupported",
+        "$": "dynamic shell expansion is unsupported",
+        "<": "shell redirection is unsupported",
+        ">": "shell redirection is unsupported",
+        "(": "shell grouping and subshell syntax are unsupported",
+        ")": "shell grouping and subshell syntax are unsupported",
+        "{": "shell grouping and subshell syntax are unsupported",
+        "}": "shell grouping and subshell syntax are unsupported",
+        "*": "unquoted shell glob syntax is unsupported",
+        "[": "unquoted shell glob syntax is unsupported",
+    }
+    if char in invalid:
+        raise CommandParseError(invalid[char])
     if char == "&" and next_char != "&" and (index == 0 or command[index - 1] != "&"):
         raise CommandParseError("background shell execution is unsupported")
-    if char in "*[":
-        raise CommandParseError("unquoted shell glob syntax is unsupported")
 
 
 def _expand_argv(argv: list[str]) -> list[list[str]]:
@@ -81,24 +96,26 @@ def _shell_invocations(command: str) -> list[list[str]]:
         tokens = list(lexer)
     except ValueError as exc:
         raise CommandParseError(f"unable to tokenize shell command: {exc}") from exc
-    invocations: list[list[str]] = []
-    segment: list[str] = []
-    expect_command = True
-    for token in tokens:
-        if token in SHELL_OPERATORS:
-            if expect_command or not segment:
-                raise CommandParseError("empty or repeated shell operator segment")
-            invocations.extend(_expand_argv(segment))
-            segment = []
-            expect_command = True
-            continue
-        if token and all(char in ";&|()" for char in token):
-            raise CommandParseError(f"unsupported shell operator {token}")
-        segment.append(token)
-        expect_command = False
+    invocations, segment = _expand_shell_tokens(tokens)
     if not segment:
         raise CommandParseError("shell command ends with an operator")
     invocations.extend(_expand_argv(segment))
     if not invocations:
         raise CommandParseError("command produced no executable argv")
     return invocations
+
+
+def _expand_shell_tokens(tokens: list[str]) -> tuple[list[list[str]], list[str]]:
+    invocations: list[list[str]] = []
+    segment: list[str] = []
+    for token in tokens:
+        if token in SHELL_OPERATORS:
+            if not segment:
+                raise CommandParseError("empty or repeated shell operator segment")
+            invocations.extend(_expand_argv(segment))
+            segment = []
+        elif token and all(char in ";&|()" for char in token):
+            raise CommandParseError(f"unsupported shell operator {token}")
+        else:
+            segment.append(token)
+    return invocations, segment

--- a/.agents/scripts/command_policy_runtime.py
+++ b/.agents/scripts/command_policy_runtime.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Runtime environment and CLI argument handling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from command_policy_config import PolicyError, _policy_error
+from command_policy_dispatch import analyze_network_argv
+
+WORKER_ENV_KEYS = (
+    "FULL_LOOP_HEADLESS",
+    "AIDEVOPS_HEADLESS",
+    "OPENCODE_HEADLESS",
+    "CLAUDE_HEADLESS",
+    "Claude_HEADLESS",
+    "HEADLESS",
+    "GITHUB_ACTIONS",
+)
+
+
+def _worker_from_environment() -> bool:
+    return bool(os.environ.get("AIDEVOPS_WORKER_ID", "")) or any(
+        os.environ.get(key, "").lower() in {"1", "true", "yes"}
+        for key in WORKER_ENV_KEYS
+    )
+
+
+def _argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "action", choices=("check-command", "validate", "network-destinations")
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--command", default="")
+    source.add_argument("--argv-json", default="")
+    parser.add_argument("--cwd", default=os.getcwd())
+    parser.add_argument("--policy", default="")
+    parser.add_argument("--canonical-git-guard", default="")
+    parser.add_argument("--network-helper", default="")
+    parser.add_argument("--worker", action="store_true")
+    parser.add_argument(
+        "--worker-id", default=os.environ.get("AIDEVOPS_WORKER_ID", "unknown")
+    )
+    return parser
+
+
+def _network_action(invocations: list[list[str]], cwd: str) -> int:
+    if len(invocations) == 1:
+        output = analyze_network_argv(invocations[0], cwd)
+        exit_code = 0
+    else:
+        output = {
+            "recognized": False,
+            "requires_destination": True,
+            "destinations": [],
+            "unclassified": ["network analysis requires exactly one argv"],
+        }
+        exit_code = 20
+    print(json.dumps(output, sort_keys=True))
+    return exit_code
+
+
+def _report_policy_error(action: str, error: PolicyError) -> int:
+    if action == "check-command":
+        print(json.dumps(_policy_error(str(error)), sort_keys=True))
+    else:
+        print(f"BLOCKED: {error}", file=sys.stderr)
+    return 21

--- a/.agents/scripts/command_policy_transport.py
+++ b/.agents/scripts/command_policy_transport.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""SSH and SCP destination analysis for command-policy-helper.py."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from command_policy_network import _add_destination, _normalize_host
+
+
+def _analyze_ssh(argv: list[str], result: dict[str, Any]) -> None:
+    value_options = {"-b", "-c", "-D", "-E", "-e", "-F", "-I", "-i", "-L", "-l", "-m", "-O", "-o", "-p", "-Q", "-R", "-S", "-W", "-w", "-J"}
+    index = 1
+    target = ""
+    while index < len(argv):
+        index, target, complete = _ssh_arg(argv, index, result, value_options)
+        if target or not complete:
+            break
+    if target:
+        _add_destination(result, target, "ssh-target")
+    else:
+        result["unclassified"].append("ssh-target-missing")
+
+
+def _ssh_arg(
+    argv: list[str], index: int, result: dict[str, Any], value_options: set[str]
+) -> tuple[int, str, bool]:
+    arg = argv[index]
+    target = ""
+    complete = True
+    if arg.startswith("-J") and arg != "-J":
+        _add_destination(result, arg[2:], "proxy-jump")
+        index += 1
+    elif arg in value_options:
+        index, complete = _ssh_value_option(argv, index, result)
+    elif arg.startswith("-"):
+        index += 1
+    else:
+        target = arg
+    return index, target, complete
+
+
+def _ssh_value_option(
+    argv: list[str], index: int, result: dict[str, Any]
+) -> tuple[int, bool]:
+    arg = argv[index]
+    if index + 1 >= len(argv):
+        result["unclassified"].append(f"missing:{arg}")
+        return index, False
+    value = argv[index + 1]
+    if arg == "-J":
+        for jump in value.split(","):
+            _add_destination(result, jump, "proxy-jump")
+    elif arg == "-F":
+        result["unclassified"].append("ssh-config-file")
+    elif arg == "-W":
+        _add_destination(result, value.rsplit(":", 1)[0], "stdio-forward")
+    elif arg in {"-L", "-R"}:
+        _ssh_forward_destination(value, result)
+    elif arg == "-o":
+        _ssh_extended_option(value, result)
+    return index + 2, True
+
+
+def _ssh_forward_destination(value: str, result: dict[str, Any]) -> None:
+    parts = value.split(":")
+    if len(parts) >= 3:
+        _add_destination(result, parts[-2], "port-forward")
+    else:
+        result["unclassified"].append(f"ssh-forward:{value}")
+
+
+def _ssh_extended_option(value: str, result: dict[str, Any]) -> None:
+    lower = value.lower()
+    if lower.startswith("proxyjump="):
+        _add_destination(result, value.split("=", 1)[1], "proxy-jump")
+    elif lower.startswith("proxycommand="):
+        result["unclassified"].append("ssh-proxy-command")
+
+
+def _analyze_scp(argv: list[str], result: dict[str, Any]) -> None:
+    value_options = {"-c", "-F", "-i", "-J", "-l", "-o", "-P", "-S", "-X"}
+    index = 1
+    remote_count = 0
+    while index < len(argv):
+        index, remote, complete = _scp_arg(argv, index, result, value_options)
+        remote_count += int(remote)
+        if not complete:
+            break
+    if remote_count == 0:
+        result["unclassified"].append("scp-remote-missing")
+
+
+def _scp_arg(
+    argv: list[str], index: int, result: dict[str, Any], value_options: set[str]
+) -> tuple[int, bool, bool]:
+    arg = argv[index]
+    remote = False
+    complete = True
+    if arg in value_options:
+        if index + 1 >= len(argv):
+            result["unclassified"].append(f"missing:{arg}")
+            complete = False
+        else:
+            _classify_scp_option(arg, argv[index + 1], result)
+            index += 2
+    elif arg.startswith("-"):
+        index += 1
+    else:
+        remote = bool(_normalize_host(arg))
+        if remote:
+            _add_destination(result, arg, "scp-remote")
+        index += 1
+    return index, remote, complete
+
+
+def _classify_scp_option(arg: str, value: str, result: dict[str, Any]) -> None:
+    if arg == "-J":
+        _add_destination(result, value, "proxy-jump")
+    elif arg in {"-F", "-S"}:
+        result["unclassified"].append(f"scp-hidden-network-config:{arg}")
+    elif arg == "-o" and value.lower().startswith("proxycommand="):
+        result["unclassified"].append("scp-proxy-command")

--- a/.agents/scripts/command_policy_transport.py
+++ b/.agents/scripts/command_policy_transport.py
@@ -11,7 +11,28 @@ from command_policy_network import _add_destination, _normalize_host
 
 
 def _analyze_ssh(argv: list[str], result: dict[str, Any]) -> None:
-    value_options = {"-b", "-c", "-D", "-E", "-e", "-F", "-I", "-i", "-L", "-l", "-m", "-O", "-o", "-p", "-Q", "-R", "-S", "-W", "-w", "-J"}
+    value_options = {
+        "-b",
+        "-c",
+        "-D",
+        "-E",
+        "-e",
+        "-F",
+        "-I",
+        "-i",
+        "-L",
+        "-l",
+        "-m",
+        "-O",
+        "-o",
+        "-p",
+        "-Q",
+        "-R",
+        "-S",
+        "-W",
+        "-w",
+        "-J",
+    }
     index = 1
     target = ""
     while index < len(argv):

--- a/.agents/scripts/command_policy_transport.py
+++ b/.agents/scripts/command_policy_transport.py
@@ -11,28 +11,9 @@ from command_policy_network import _add_destination, _normalize_host
 
 
 def _analyze_ssh(argv: list[str], result: dict[str, Any]) -> None:
-    value_options = {
-        "-b",
-        "-c",
-        "-D",
-        "-E",
-        "-e",
-        "-F",
-        "-I",
-        "-i",
-        "-L",
-        "-l",
-        "-m",
-        "-O",
-        "-o",
-        "-p",
-        "-Q",
-        "-R",
-        "-S",
-        "-W",
-        "-w",
-        "-J",
-    }
+    value_options = set(
+        "-b -c -D -E -e -F -I -i -L -l -m -O -o -p -Q -R -S -W -w -J".split()
+    )
     index = 1
     target = ""
     while index < len(argv):

--- a/.agents/scripts/command_policy_wget.py
+++ b/.agents/scripts/command_policy_wget.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""wget destination analysis for command-policy-helper.py."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from command_policy_http import _option_value
+from command_policy_network import _add_destination
+
+
+def _analyze_wget(argv: list[str], result: dict[str, Any]) -> None:
+    index = 1
+    value_options = {
+        "-O", "--output-document", "-o", "--output-file", "-a", "--append-output",
+        "-P", "--directory-prefix", "--header", "--user", "--password", "--timeout",
+        "--tries", "--wait", "--user-agent", "--referer",
+    }
+    short_value_options = {"-O", "-o", "-a", "-P", "-U", "-t", "-T", "-w"}
+    while index < len(argv):
+        index = _wget_arg(argv, index, result, value_options, short_value_options)
+
+
+def _wget_arg(
+    argv: list[str], index: int, result: dict[str, Any],
+    value_options: set[str], short_value_options: set[str],
+) -> int:
+    arg = argv[index]
+    option = arg.split("=", 1)[0]
+    next_index = index + 1
+    if option == "--proxy":
+        value, next_index = _option_value(argv, index)
+        _add_destination(result, value or "", "proxy")
+    elif option in {"-e", "--execute"}:
+        next_index = _wget_execute_option(argv, index, result)
+    elif option in {"-i", "--input-file"}:
+        result["unclassified"].append("wget-input-file")
+        next_index = index + (2 if arg == option and "=" not in arg else 1)
+    elif option in value_options:
+        next_index = _option_value(argv, index)[1]
+    elif arg in short_value_options:
+        next_index = index + (2 if index + 1 < len(argv) else 1)
+    elif not arg.startswith("-"):
+        _add_destination(result, arg, "url")
+    return next_index
+
+
+def _wget_execute_option(argv: list[str], index: int, result: dict[str, Any]) -> int:
+    value, next_index = _option_value(argv, index)
+    match = re.match(r"(?i)^(?:https?|ftp)_proxy=(.+)$", value or "")
+    if match:
+        _add_destination(result, match.group(1), "proxy")
+    elif value and "proxy" not in value.lower():
+        result["unclassified"].append(f"wget-execute:{value}")
+    return next_index

--- a/.agents/scripts/command_policy_wget.py
+++ b/.agents/scripts/command_policy_wget.py
@@ -38,14 +38,18 @@ def _wget_arg(
         next_index = _wget_execute_option(argv, index, result)
     elif option in {"-i", "--input-file"}:
         result["unclassified"].append("wget-input-file")
-        next_index = index + (2 if arg == option and "=" not in arg else 1)
+        next_index = _wget_input_file_index(arg, option, index)
     elif option in value_options:
         next_index = _option_value(argv, index)[1]
     elif arg in short_value_options:
-        next_index = index + (2 if index + 1 < len(argv) else 1)
+        next_index = min(index + 2, len(argv))
     elif not arg.startswith("-"):
         _add_destination(result, arg, "url")
     return next_index
+
+
+def _wget_input_file_index(arg: str, option: str, index: int) -> int:
+    return index + (2 if arg == option and "=" not in arg else 1)
 
 
 def _wget_execute_option(argv: list[str], index: int, result: dict[str, Any]) -> int:

--- a/.agents/scripts/command_policy_wrapper_options.py
+++ b/.agents/scripts/command_policy_wrapper_options.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Option and environment handling for deterministic command wrappers."""
+
+from __future__ import annotations
+
+import re
+
+from command_policy_dispatch import CommandParseError
+
+
+def _consume_option(
+    argv: list[str], index: int, value_options: set[str], flag_options: set[str]
+) -> int:
+    arg = argv[index]
+    if arg == "--":
+        return index + 1
+    if arg in value_options:
+        if index + 1 >= len(argv):
+            raise CommandParseError(f"missing value for wrapper option {arg}")
+        return index + 2
+    if _is_attached_value_option(arg, value_options):
+        return index + 1
+    if arg in flag_options:
+        return index + 1
+    if _is_combined_short_flags(arg, flag_options):
+        return index + 1
+    raise CommandParseError(f"unsupported wrapper option {arg}")
+
+
+def _is_attached_value_option(arg: str, value_options: set[str]) -> bool:
+    long_attached = any(
+        arg.startswith(option + "=") for option in value_options if option.startswith("--")
+    )
+    short_attached = any(
+        arg.startswith(option) and arg != option
+        for option in value_options
+        if option.startswith("-") and not option.startswith("--")
+    )
+    return long_attached or short_attached
+
+
+def _is_combined_short_flags(arg: str, flag_options: set[str]) -> bool:
+    short_flags = {
+        option[1:] for option in flag_options if re.fullmatch(r"-[A-Za-z0-9]", option)
+    }
+    return (
+        arg.startswith("-")
+        and not arg.startswith("--")
+        and set(arg[1:]).issubset(short_flags)
+    )
+
+
+def _unwrap_env(argv: list[str]) -> list[str]:
+    index = 1
+    values = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
+    flags = {"-i", "--ignore-environment", "-0", "--null", "-v", "--debug"}
+    while index < len(argv) and argv[index].startswith("-"):
+        option = argv[index]
+        if option in {"-C", "--chdir", "-S", "--split-string"} or option.startswith(("-C", "-S", "--chdir=", "--split-string=")):
+            raise CommandParseError(f"env option changes command interpretation and is unsupported: {option}")
+        index = _consume_option(argv, index, values, flags)
+    while index < len(argv) and "=" in argv[index] and not argv[index].startswith("="):
+        name = argv[index].split("=", 1)[0]
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            break
+        if _is_safety_sensitive_assignment(name):
+            raise CommandParseError(f"safety-affecting environment assignment is unsupported: {name}")
+        index += 1
+    if index >= len(argv):
+        raise CommandParseError("env wrapper has no command")
+    return argv[index:]
+
+
+def _unwrap_sudo(argv: list[str]) -> list[str]:
+    index = 1
+    values = {
+        "-u", "--user", "-g", "--group", "-h", "--host", "-p", "--prompt",
+        "-C", "--close-from", "-T", "--command-timeout", "-R", "--chroot",
+        "-D", "--chdir",
+    }
+    flags = {
+        "-A", "--askpass", "-b", "--background", "-E", "--preserve-env",
+        "-H", "--set-home", "-n", "--non-interactive", "-P", "--preserve-groups",
+        "-S", "--stdin", "-i", "--login", "-s", "--shell", "-k", "-K", "-v",
+    }
+    while index < len(argv) and argv[index].startswith("-"):
+        option = argv[index]
+        if option in {"-D", "--chdir", "-R", "--chroot"} or option.startswith(("-D", "-R", "--chdir=", "--chroot=")):
+            raise CommandParseError(f"sudo option changes command location and is unsupported: {option}")
+        index = _consume_option(argv, index, values, flags)
+    if index >= len(argv):
+        raise CommandParseError("sudo wrapper has no command")
+    return argv[index:]
+
+
+def _unwrap_time(argv: list[str]) -> list[str]:
+    index = 1
+    values = {"-f", "--format", "-o", "--output"}
+    flags = {"-a", "--append", "-p", "--portability", "-v", "--verbose", "-q", "--quiet"}
+    while index < len(argv) and argv[index].startswith("-"):
+        index = _consume_option(argv, index, values, flags)
+    if index >= len(argv):
+        raise CommandParseError("time wrapper has no command")
+    return argv[index:]
+
+
+def _is_safety_sensitive_assignment(name: str) -> bool:
+    upper = name.upper()
+    return upper.endswith("_PROXY") or upper.startswith("GIT_CONFIG_") or upper in {
+        "ALL_PROXY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR",
+        "GIT_CONFIG_PARAMETERS", "GIT_DIR", "GIT_EXEC_PATH", "GIT_OBJECT_DIRECTORY",
+        "GIT_PROXY_COMMAND", "GIT_SSH", "GIT_SSH_COMMAND", "GIT_WORK_TREE",
+        "CURL_HOME", "WGETRC", "BASH_ENV", "ENV", "ZDOTDIR",
+    }
+
+
+def _strip_leading_assignments(argv: list[str]) -> list[str]:
+    index = 0
+    while index < len(argv) and "=" in argv[index]:
+        name = argv[index].split("=", 1)[0]
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            break
+        if _is_safety_sensitive_assignment(name):
+            raise CommandParseError(f"safety-affecting environment assignment is unsupported: {name}")
+        index += 1
+    if index >= len(argv):
+        raise CommandParseError("environment assignment has no command")
+    return argv[index:]

--- a/.agents/scripts/command_policy_wrapper_options.py
+++ b/.agents/scripts/command_policy_wrapper_options.py
@@ -61,16 +61,23 @@ def _unwrap_env(argv: list[str]) -> list[str]:
         if option in {"-C", "--chdir", "-S", "--split-string"} or option.startswith(("-C", "-S", "--chdir=", "--split-string=")):
             raise CommandParseError(f"env option changes command interpretation and is unsupported: {option}")
         index = _consume_option(argv, index, values, flags)
+    index = _environment_command_index(argv, index)
+    if index >= len(argv):
+        raise CommandParseError("env wrapper has no command")
+    return argv[index:]
+
+
+def _environment_command_index(argv: list[str], index: int) -> int:
     while index < len(argv) and "=" in argv[index] and not argv[index].startswith("="):
         name = argv[index].split("=", 1)[0]
         if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
             break
         if _is_safety_sensitive_assignment(name):
-            raise CommandParseError(f"safety-affecting environment assignment is unsupported: {name}")
+            raise CommandParseError(
+                f"safety-affecting environment assignment is unsupported: {name}"
+            )
         index += 1
-    if index >= len(argv):
-        raise CommandParseError("env wrapper has no command")
-    return argv[index:]
+    return index
 
 
 def _unwrap_sudo(argv: list[str]) -> list[str]:

--- a/.agents/scripts/command_policy_wrappers.py
+++ b/.agents/scripts/command_policy_wrappers.py
@@ -26,6 +26,26 @@ from command_policy_wrapper_options import (
     _unwrap_time,
 )
 
+__all__ = [
+    "_consume_option",
+    "_expand_argv",
+    "_expand_launcher",
+    "_expand_shell_launcher",
+    "_is_attached_value_option",
+    "_is_combined_short_flags",
+    "_is_safety_sensitive_assignment",
+    "_reject_dynamic_launcher",
+    "_shell_command_index",
+    "_shell_value_option_index",
+    "_strip_leading_assignments",
+    "_unwrap_command",
+    "_unwrap_env",
+    "_unwrap_exec",
+    "_unwrap_simple_wrapper",
+    "_unwrap_sudo",
+    "_unwrap_time",
+]
+
 SHELLS = {"bash", "dash", "ksh", "sh", "zsh"}
 ShellParser = Callable[[str], list[list[str]]]
 
@@ -56,11 +76,15 @@ def _expand_launcher(
         return expanded, argv if expanded else _unwrap_command(argv)
     if executable in SHELLS:
         return _expand_shell_launcher(argv, shell_parser), argv
+    _reject_directory_launcher(executable)
+    return [argv], argv
+
+
+def _reject_directory_launcher(executable: str) -> None:
     if executable in {"cd", "pushd", "popd"}:
         raise CommandParseError(
             "directory-changing shell builtins are unsupported; use tool cwd"
         )
-    return [argv], argv
 
 
 def _expand_shell_launcher(argv: list[str], shell_parser: ShellParser) -> list[list[str]]:
@@ -91,12 +115,9 @@ def _reject_dynamic_launcher(argv: list[str], executable: str) -> None:
 
 
 def _unwrap_simple_wrapper(argv: list[str], executable: str) -> list[str] | None:
-    if executable == "env":
-        return _unwrap_env(argv)
-    if executable == "sudo":
-        return _unwrap_sudo(argv)
-    if executable == "time":
-        return _unwrap_time(argv)
+    wrappers = {"env": _unwrap_env, "sudo": _unwrap_sudo, "time": _unwrap_time}
+    if executable in wrappers:
+        return wrappers[executable](argv)
     if executable != "nohup":
         return None
     index = 2 if len(argv) > 1 and argv[1] == "--" else 1

--- a/.agents/scripts/command_policy_wrappers.py
+++ b/.agents/scripts/command_policy_wrappers.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Deterministic command-wrapper and launcher expansion."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+from command_policy_dispatch import CommandParseError, _validate_argv
+from command_policy_launcher_options import (
+    _shell_command_index,
+    _shell_value_option_index,
+    _unwrap_command,
+    _unwrap_exec,
+)
+from command_policy_wrapper_options import (
+    _consume_option,
+    _is_attached_value_option,
+    _is_combined_short_flags,
+    _is_safety_sensitive_assignment,
+    _strip_leading_assignments,
+    _unwrap_env,
+    _unwrap_sudo,
+    _unwrap_time,
+)
+
+SHELLS = {"bash", "dash", "ksh", "sh", "zsh"}
+ShellParser = Callable[[str], list[list[str]]]
+
+
+def _expand_argv(argv: list[str], shell_parser: ShellParser) -> list[list[str]]:
+    current = _validate_argv(argv)
+    while current:
+        current = _strip_leading_assignments(current)
+        executable = os.path.basename(current[0])
+        _reject_dynamic_launcher(current, executable)
+        expanded, replacement = _expand_launcher(current, executable, shell_parser)
+        if expanded is not None:
+            return expanded
+        current = replacement
+    raise CommandParseError("wrapper chain has no command")
+
+
+def _expand_launcher(
+    argv: list[str], executable: str, shell_parser: ShellParser
+) -> tuple[list[list[str]] | None, list[str]]:
+    simple = _unwrap_simple_wrapper(argv, executable)
+    if simple is not None:
+        return None, simple
+    if executable == "exec":
+        return None, _unwrap_exec(argv)
+    if executable == "command":
+        expanded = [argv] if len(argv) > 1 and argv[1] in {"-v", "-V"} else None
+        return expanded, argv if expanded else _unwrap_command(argv)
+    if executable in SHELLS:
+        return _expand_shell_launcher(argv, shell_parser), argv
+    if executable in {"cd", "pushd", "popd"}:
+        raise CommandParseError(
+            "directory-changing shell builtins are unsupported; use tool cwd"
+        )
+    return [argv], argv
+
+
+def _expand_shell_launcher(argv: list[str], shell_parser: ShellParser) -> list[list[str]]:
+    command_index = _shell_command_index(argv)
+    if command_index is None:
+        return [argv]
+    if command_index >= len(argv):
+        raise CommandParseError("shell -c option has no command string")
+    return shell_parser(argv[command_index])
+
+
+def _reject_dynamic_launcher(argv: list[str], executable: str) -> None:
+    dynamic = {
+        ".", "!", "alias", "builtin", "case", "coproc", "declare", "do",
+        "done", "elif", "else", "enable", "esac", "eval", "export", "fi",
+        "for", "function", "if", "local", "parallel", "readonly", "select",
+        "set", "source", "then", "trap", "typeset", "unalias", "unset",
+        "until", "while", "xargs",
+    }
+    if executable in dynamic:
+        raise CommandParseError(
+            f"dynamic shell control or launcher is unsupported: {executable}"
+        )
+    if executable == "find" and any(
+        arg in {"-exec", "-execdir", "-ok", "-okdir"} for arg in argv[1:]
+    ):
+        raise CommandParseError("find command execution actions are unsupported")
+
+
+def _unwrap_simple_wrapper(argv: list[str], executable: str) -> list[str] | None:
+    if executable == "env":
+        return _unwrap_env(argv)
+    if executable == "sudo":
+        return _unwrap_sudo(argv)
+    if executable == "time":
+        return _unwrap_time(argv)
+    if executable != "nohup":
+        return None
+    index = 2 if len(argv) > 1 and argv[1] == "--" else 1
+    if index >= len(argv) or argv[index].startswith("--"):
+        raise CommandParseError("nohup wrapper has no supported command")
+    return argv[index:]

--- a/.agents/scripts/tests/test-command-policy-helper.sh
+++ b/.agents/scripts/tests/test-command-policy-helper.sh
@@ -47,7 +47,8 @@ assert_decision() {
 	local actual=""
 
 	output="$(python3 "$HELPER" check-command --cwd "$cwd" --command "$command_text")" || status=$?
-	actual="$(python3 - "$output" <<'PY'
+	actual="$(
+		python3 - "$output" <<'PY'
 import json
 import sys
 
@@ -58,7 +59,7 @@ except (json.JSONDecodeError, IndexError):
 else:
     print(f"{result.get('decision', '')}/{result.get('rule_id', '')}")
 PY
-)"
+	)"
 	if [[ "$status" -eq "$expected_status" && "$actual" == "${expected_decision}/${expected_rule}" ]]; then
 		pass "$name"
 	else
@@ -78,20 +79,22 @@ assert_argv_decision() {
 	local output=""
 	local status=0
 	local actual=""
-	argv_json="$(python3 - "$@" <<'PY'
+	argv_json="$(
+		python3 - "$@" <<'PY'
 import json
 import sys
 print(json.dumps(sys.argv[1:]))
 PY
-)"
+	)"
 	output="$(python3 "$HELPER" check-command --cwd "$cwd" --argv-json "$argv_json")" || status=$?
-	actual="$(python3 - "$output" <<'PY'
+	actual="$(
+		python3 - "$output" <<'PY'
 import json
 import sys
 result = json.loads(sys.argv[1])
 print(f"{result.get('decision', '')}/{result.get('rule_id', '')}")
 PY
-)"
+	)"
 	if [[ "$status" -eq "$expected_status" && "$actual" == "${expected_decision}/${expected_rule}" ]]; then
 		pass "$name"
 	else
@@ -105,6 +108,40 @@ test_validation() {
 		pass "validates declarative policy and fixtures"
 	else
 		fail "validates declarative policy and fixtures"
+	fi
+	return 0
+}
+
+test_evaluate_invocations_compatibility() {
+	if python3 - "$HELPER" "$POLICY" <<'PY'; then
+import importlib.util
+import pathlib
+import sys
+
+helper_path, policy_path = map(pathlib.Path, sys.argv[1:])
+spec = importlib.util.spec_from_file_location("command_policy_helper", helper_path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+policy = module._load_policy(policy_path)
+expected = module.evaluate_invocations([["printf", "safe"]], "/work", policy)
+positional = module.evaluate_invocations(
+    [["printf", "safe"]], "/work", policy, "", False, "test", ""
+)
+keyword = module.evaluate_invocations(
+    [["printf", "safe"]],
+    "/work",
+    policy,
+    guard_path="",
+    worker=False,
+    worker_id="test",
+    network_helper="",
+)
+assert expected == positional == keyword
+PY
+		pass "evaluate_invocations preserves positional and keyword interfaces"
+	else
+		fail "evaluate_invocations preserves positional and keyword interfaces"
 	fi
 	return 0
 }
@@ -234,7 +271,7 @@ test_secondary_layers() {
 	if python3 - \
 		"${SCRIPT_DIR}/update-claude-settings.py" \
 		"${SCRIPT_DIR}/agent-discovery.py" \
-		"${SCRIPT_DIR}/../configs/verification-triggers.json" <<'PY'
+		"${SCRIPT_DIR}/../configs/verification-triggers.json" <<'PY'; then
 import ast
 import json
 import sys
@@ -268,7 +305,6 @@ assert "git reset --hard" not in patterns
 assert "git push --force-with-lease" not in patterns
 assert "rm -rf /" not in patterns
 PY
-	then
 		pass "permission mirrors and verification triggers remain secondary"
 	else
 		fail "permission mirrors and verification triggers remain secondary"
@@ -283,8 +319,8 @@ import sys
 with open(sys.argv[1], "w", encoding="utf-8") as handle:
     json.dump({"permissions": {"deny": ["Bash(git reset --hard *)"], "ask": ["Bash(curl *)"]}}, handle)
 PY
-	if HOME="$settings_home" python3 "${SCRIPT_DIR}/update-claude-settings.py" >/dev/null && \
-		python3 - "${settings_home}/.claude/settings.json" <<'PY'
+	if HOME="$settings_home" python3 "${SCRIPT_DIR}/update-claude-settings.py" >/dev/null &&
+		python3 - "${settings_home}/.claude/settings.json" <<'PY'; then
 import json
 import sys
 
@@ -298,7 +334,6 @@ assert {"Bash", "Edit|Write"}.issubset(matchers)
 assert "Bash(git reset --hard *)" not in settings["permissions"]["deny"]
 assert "Bash(curl *)" not in settings["permissions"]["ask"]
 PY
-	then
 		pass "Claude settings migration removes duplicate decisions and preserves hook surfaces"
 	else
 		fail "Claude settings migration removes duplicate decisions and preserves hook surfaces"
@@ -348,6 +383,7 @@ test_policy_fail_closed() {
 
 main() {
 	test_validation
+	test_evaluate_invocations_compatibility
 	test_static_decisions
 	test_canonical_delegation
 	test_worker_network_policy


### PR DESCRIPTION
## Summary

Split the command policy helper into focused, smell-free modules while preserving its CLI and callable interfaces.

## Changes

- Retain `command-policy-helper.py` as the compatibility facade.
- Extract cohesive config, parser, wrapper, matcher, network, transport, Git, evaluation, dispatch, and runtime modules.
- Preserve positional and keyword compatibility for `evaluate_invocations` with a regression test.

## Testing

- `~/.qlty/bin/qlty smells --all --no-snippets --quiet` — no smells in any changed Python file.
- `.agents/scripts/tests/test-command-policy-helper.sh` — 45 tests, 0 failures.
- `.agents/scripts/tests/test-sandbox-command-policy.sh` — 23 tests, 0 failures.
- ShellCheck and shfmt — clean for modified shell tests.
- Python AST parsing and command policy validation — passed.
- `.agents/scripts/linters-local.sh` — passed.

## Runtime Testing

Runtime-verified through the command policy and sandbox integration suites, including direct CLI policy validation.

## Key decisions

The original executable remains the stable entry point and re-exports existing callables. Modules are split by responsibility rather than changing policy behavior or public invocation patterns.

Resolves #27175

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.46 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 54m and 112,428 tokens on this with the user in an interactive session. Solved in 11h 22m.
