### PR TITLE
GH#27323: allow OpenCode Grep without prompts

### DIFF
--- a/.agents/scripts/lib/agent_config.py
+++ b/.agents/scripts/lib/agent_config.py
@@ -175,8 +175,11 @@ def get_agent_config(display_name, filename, subagents=None, model_tier=None):
     if effective_tier and effective_tier not in WORKLOAD_TIERS and "/" in effective_tier:
         config["model"] = effective_tier
 
-    # All primary agents get external_directory permission
+    # Grep is a read-only search tool. Explicitly allow it when enabled so
+    # OpenCode does not fall back to its interactive permission default.
     config["permission"] = {"external_directory": "allow"}
+    if tools.get("grep") is True:
+        config["permission"]["grep"] = "allow"
 
     # Add subagent filtering via permission.task if subagents specified
     if subagents and isinstance(subagents, list) and len(subagents) > 0:

--- a/.agents/scripts/tests/test-agent-discovery-smoke.sh
+++ b/.agents/scripts/tests/test-agent-discovery-smoke.sh
@@ -187,12 +187,46 @@ PYEOF
 	return 0
 }
 
+test_grep_permission_is_explicit() {
+	local output rc py_out
+	py_out=$(mktemp)
+	SCRIPTS_DIR="$SCRIPTS_DIR" python3 - >"$py_out" 2>&1 <<'PYEOF'
+import os
+import sys
+
+sys.path.insert(0, os.environ["SCRIPTS_DIR"] + "/lib")
+from agent_config import get_agent_config
+
+build = get_agent_config("Build+", "build-plus.md", ["research"])
+assert build["tools"]["grep"] is True
+assert build["permission"]["grep"] == "allow"
+assert build["permission"]["task"] == {"*": "deny", "research": "allow"}
+
+research = get_agent_config("Research", "research.md")
+assert "grep" not in research["tools"]
+assert "grep" not in research["permission"]
+
+print("OK")
+PYEOF
+	rc=$?
+	output=$(cat "$py_out")
+	rm -f "$py_out"
+
+	if [[ $rc -eq 0 && "$output" == *"OK"* ]]; then
+		print_result "enabled Grep tools receive explicit allow permission" 0
+	else
+		print_result "enabled Grep tools receive explicit allow permission" 1 "$output"
+	fi
+	return 0
+}
+
 main() {
 	setup
 	test_agent_discovery_runs
 	test_opencode_agent_discovery_runs
 	test_missing_subagent_warning
 	test_validate_subagent_refs_default_arg
+	test_grep_permission_is_explicit
 
 	echo ""
 	echo "Tests run: $TESTS_RUN, passed: $TESTS_PASSED, failed: $TESTS_FAILED"


### PR DESCRIPTION
## Summary

- Explicitly allow OpenCode's read-only Grep tool when an agent enables it.
- Preserve task permission filtering and agents that intentionally omit Grep.
- Add regression coverage for generated permission behavior.

## Root cause

The shared generator enabled `grep` under `tools` but emitted no matching permission rule, so OpenCode used its interactive default and repeatedly prompted. The built-in Grep tool remains preferable to forcing shell `rg`: it is an optimized search abstraction and remains available to Bash-disabled agents.

## Testing

- `.agents/scripts/tests/test-agent-discovery-smoke.sh` (5/5 passed)
- `python3 -m py_compile .agents/scripts/lib/agent_config.py`
- `shellcheck .agents/scripts/tests/test-agent-discovery-smoke.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

Self-assessed low-risk runtime configuration change with generated-config regression coverage.

Resolves #27323

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.51 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 27,429 tokens on this with the user in an interactive session. Overall, 2m since this issue was created.
