### PR TITLE
GH#27325: make session titles longer and more descriptive

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
@@ -6,7 +6,6 @@ import { readAidevopsVersion, withAidevopsTitleSuffix } from "./session-title-su
 const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
 const DEFAULT_SESSION_TITLE_RE = /^New session - /;
 const URL_RE = /https?:\/\/\S+/g;
-const TITLE_MAX_LENGTH = 72;
 const FALLBACK_DELAY_MS = 12000;
 
 export function isDefaultSessionTitle(title) {
@@ -37,12 +36,8 @@ function titleCaseFirstWord(text) {
   return text.replace(/^([a-z])/, (letter) => letter.toUpperCase());
 }
 
-function trimTitle(text) {
-  return text.length <= TITLE_MAX_LENGTH ? text : `${text.slice(0, TITLE_MAX_LENGTH - 1).trimEnd()}…`;
-}
-
 export function deriveFallbackTitleFromPrompt(prompt) {
-  return trimTitle(titleCaseFirstWord(cleanedTitleLine(firstPromptLine(prompt))));
+  return titleCaseFirstWord(cleanedTitleLine(firstPromptLine(prompt)));
 }
 
 function getEventType(input) {

--- a/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
@@ -6,7 +6,6 @@ import { readAidevopsVersion, withAidevopsTitleSuffix } from "./session-title-su
 const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
 const DEFAULT_SESSION_TITLE_RE = /^New session - /;
 const URL_RE = /https?:\/\/\S+/g;
-const TITLE_MAX_LENGTH = 256;
 const FALLBACK_DELAY_MS = 12000;
 
 export function isDefaultSessionTitle(title) {
@@ -37,12 +36,8 @@ function titleCaseFirstWord(text) {
   return text.replace(/^([a-z])/, (letter) => letter.toUpperCase());
 }
 
-function trimTitle(text) {
-  return text.length <= TITLE_MAX_LENGTH ? text : `${text.slice(0, TITLE_MAX_LENGTH - 1).trimEnd()}…`;
-}
-
 export function deriveFallbackTitleFromPrompt(prompt) {
-  return trimTitle(titleCaseFirstWord(cleanedTitleLine(firstPromptLine(prompt))));
+  return titleCaseFirstWord(cleanedTitleLine(firstPromptLine(prompt)));
 }
 
 function getEventType(input) {

--- a/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
@@ -6,6 +6,7 @@ import { readAidevopsVersion, withAidevopsTitleSuffix } from "./session-title-su
 const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
 const DEFAULT_SESSION_TITLE_RE = /^New session - /;
 const URL_RE = /https?:\/\/\S+/g;
+const TITLE_MAX_LENGTH = 256;
 const FALLBACK_DELAY_MS = 12000;
 
 export function isDefaultSessionTitle(title) {
@@ -36,8 +37,12 @@ function titleCaseFirstWord(text) {
   return text.replace(/^([a-z])/, (letter) => letter.toUpperCase());
 }
 
+function trimTitle(text) {
+  return text.length <= TITLE_MAX_LENGTH ? text : `${text.slice(0, TITLE_MAX_LENGTH - 1).trimEnd()}…`;
+}
+
 export function deriveFallbackTitleFromPrompt(prompt) {
-  return titleCaseFirstWord(cleanedTitleLine(firstPromptLine(prompt)));
+  return trimTitle(titleCaseFirstWord(cleanedTitleLine(firstPromptLine(prompt))));
 }
 
 function getEventType(input) {

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -3,7 +3,7 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { copyFileSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -143,6 +143,9 @@ test("fails closed when required policy is malformed", () => {
   mkdirSync(isolatedConfigs);
   try {
     copyFileSync(join(scriptsDir, "command-policy-helper.py"), join(isolatedScripts, "command-policy-helper.py"));
+    for (const moduleName of readdirSync(scriptsDir).filter((name) => /^command_policy_.*\.py$/.test(name))) {
+      copyFileSync(join(scriptsDir, moduleName), join(isolatedScripts, moduleName));
+    }
     copyFileSync(join(scriptsDir, "canonical-git-command-guard.py"), join(isolatedScripts, "canonical-git-command-guard.py"));
     writeFileSync(join(isolatedConfigs, "command-policy.json"), "{not-json\n");
     assert.throws(

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -86,6 +86,9 @@ i'd like to add the capabilities this repo offers. there may be overlap`),
     deriveFallbackTitleFromPrompt(longPrompt),
     "Improve aidevops session title renaming so issue and PR sessions remain descriptive in OpenCode history without arbitrary truncation",
   );
+  const oversizedTitle = deriveFallbackTitleFromPrompt("a".repeat(300));
+  assert.equal(oversizedTitle.length, 256);
+  assert.equal(oversizedTitle, `${"A".padEnd(255, "a")}…`);
 });
 
 test("version reader prefers deployed agents VERSION", async () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -72,7 +72,7 @@ test("default session title detection ignores AIDevOps suffix", () => {
   assert.equal(isDefaultSessionTitle("Study newsjack repository capabilities · AIDevOps 3.21.2"), false);
 });
 
-test("fallback title derives concise title from first meaningful prompt line", () => {
+test("fallback title derives a descriptive title from the complete first meaningful prompt line", () => {
   assert.equal(
     deriveFallbackTitleFromPrompt(`https://github.com/elvisun/newsjack
 
@@ -80,6 +80,12 @@ i'd like to add the capabilities this repo offers. there may be overlap`),
     "Add the capabilities this repo offers. there may be overlap",
   );
   assert.equal(deriveFallbackTitleFromPrompt("please review PR #123"), "Review PR #123");
+  const longPrompt =
+    "please improve aidevops session title renaming so issue and PR sessions remain descriptive in OpenCode history without arbitrary truncation";
+  assert.equal(
+    deriveFallbackTitleFromPrompt(longPrompt),
+    "Improve aidevops session title renaming so issue and PR sessions remain descriptive in OpenCode history without arbitrary truncation",
+  );
 });
 
 test("version reader prefers deployed agents VERSION", async () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -86,9 +86,6 @@ i'd like to add the capabilities this repo offers. there may be overlap`),
     deriveFallbackTitleFromPrompt(longPrompt),
     "Improve aidevops session title renaming so issue and PR sessions remain descriptive in OpenCode history without arbitrary truncation",
   );
-  const oversizedTitle = deriveFallbackTitleFromPrompt("a".repeat(300));
-  assert.equal(oversizedTitle.length, 256);
-  assert.equal(oversizedTitle, `${"A".padEnd(255, "a")}…`);
 });
 
 test("version reader prefers deployed agents VERSION", async () => {

--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -41,7 +41,7 @@ Context compaction drops operational state unless written to disk. Use `/checkpo
 ## Git Workflow Detail
 
 - Before edits: run the pre-edit check from `AGENTS.md`.
-- After branch creation: check `TODO.md` for matching tasks, record `started:`, set the session title as `Issue #123: succinct description` or `PR #456: succinct description` when issue/PR context exists; otherwise call `session-rename_sync_branch`. Then read `workflows/git-workflow.md`.
+- After branch creation: check `TODO.md` for matching tasks, record `started:`, and set a long, descriptive session title. With issue/PR context, use `Issue #123: <complete issue title> — <action context>` or `PR #456: <complete PR title> — <action context>`; never use a bare number or impose an arbitrary character limit. Otherwise use a full task summary, then read `workflows/git-workflow.md`. Use `session-rename_sync_branch` only when no meaningful task context exists.
 - Dirty canonical `main`/`master` that appears unrelated to your task: preserve with `dirty-worktree-backup-helper.sh backup`, notify via mailbox/checkpoint if possible, then continue only from a clean linked worktree or wait for owner cleanup. Details: `reference/dirty-worktree-preservation.md`.
 
 Worktrees are preferred for parallel work:

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -56,7 +56,7 @@ User-facing instructions must say "create a safe linked worktree for ...". Treat
 
 Non-git artifacts (`.venv/`, `node_modules/`, `dist/`, `.env`) don't transfer between worktrees — recreate in each. See `workflows/worktree.md`.
 
-**Session-Worktree Tracking**: After creating a worktree for issue/PR work, title the session with the work item first (`Issue #123: succinct description` or `PR #456: succinct description`) so Tabby tabs and OpenCode search group by number. Use `session-rename_sync_branch` only when there is no issue/PR context or no meaningful title yet.
+**Session-Worktree Tracking**: After creating a worktree for issue/PR work, give the session a long, descriptive title with the work item first (`Issue #123: <complete issue title> — <action context>` or `PR #456: <complete PR title> — <action context>`) so Tabby tabs and OpenCode search group by number while remaining distinguishable. Never use a bare issue/PR number or impose an arbitrary character limit. Use `session-rename_sync_branch` only when there is no issue/PR context or meaningful task title.
 
 **Scope Monitoring**: When work evolves significantly from the worktree ref/purpose, offer to create a safe linked worktree for the new scope, continue on current, or pause and preserve changes.
 

--- a/.opencode/tool/session-rename.ts
+++ b/.opencode/tool/session-rename.ts
@@ -96,11 +96,11 @@ function syncSessionWithBranch(
 
 export default tool({
   description:
-    "Rename the current session to a meaningful new title. For issue/PR work, start with the issue or PR marker and include the issue/PR title or a recognizable shortened form (for example, 'Issue #123: Fix dispatch title prefix' or 'PR #456: Refresh auth workflow tests') so tabs and session search remain distinguishable. The AIDevOps version suffix is appended automatically and should remain present.",
+    "Rename the current session to a long, descriptive title. For issue/PR work, start with the issue or PR marker and include the complete issue/PR title plus useful action context (for example, 'Issue #123: Fix dispatch title prefix — implementation and release' or 'PR #456: Refresh auth workflow tests — review thread'). Never use only an issue/PR number and do not impose an arbitrary character limit; OpenCode can display long titles. The AIDevOps version suffix is appended automatically and should remain present.",
   args: {
     title: tool.schema
       .string()
-      .describe("New meaningful title for the session (for issue/PR work, prefer 'Issue #123: <issue title>' or 'PR #456: <PR title>'; add a short action suffix like '— review thread' only when helpful; otherwise use a meaningful branch/task summary; keep the automatically appended AIDevOps version suffix)"),
+      .describe("Long, descriptive session title (for issue/PR work, use 'Issue #123: <complete issue title> — <action context>' or 'PR #456: <complete PR title> — <action context>'; never use a bare issue/PR number or an arbitrary character limit; otherwise summarize the task fully; keep the automatically appended AIDevOps version suffix)"),
   },
   async execute(args, context) {
     const { sessionID } = context


### PR DESCRIPTION
## Summary

- remove the 72-character fallback session-title limit
- require complete issue/PR titles plus useful action context instead of bare numbers
- align session workflow guidance and add regression coverage for long prompts

Resolves #27325

## Runtime Testing

- `node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs`
- `bun run .agents/scripts/tests/test-session-rename-ts.mjs`
- `.agents/scripts/linters-local.sh`

## Decisions

- preserve the complete first meaningful prompt line because OpenCode supports long titles
- retain issue/PR prefixes for search grouping while prioritising distinguishable descriptions

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.51 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 67,996 tokens on this with the user in an interactive session.
