### PR TITLE
GH#27145: advance dependency-blocked roadmaps

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -763,6 +763,68 @@ refresh_blocked_status_from_graph() {
 }
 
 #######################################
+# Rebuild and normalize dependency readiness for one repository on demand.
+#
+# Candidate sweeps normally consume the cycle cache built by pulse-wrapper.
+# When every remaining roadmap child is status:blocked, however, the shared
+# candidate selector has no issue on which to run its dispatch-time dependency
+# guard. Daily/worker sweeps can also call that selector without running the
+# full pulse preflight. This repository-scoped fallback provides a fresh view
+# when a candidate snapshot contains dependency-blocked work, so the next
+# dependency-ready child can become available without rebuilding every
+# configured repository.
+#
+# Args: $1=repo slug
+# Returns: 0 when normalization ran, 1 when fresh repository data was unavailable.
+#######################################
+normalize_repo_dependency_readiness() {
+	local slug="$1"
+	local repo_data=""
+	[[ -n "$slug" ]] || return 1
+
+	repo_data=$(_dep_graph_build_repo_data "$slug") || return 1
+	local graph_json=""
+	graph_json=$(jq -cn --arg slug "$slug" --argjson data "$repo_data" \
+		'{repos:{($slug):$data}}' 2>/dev/null) || return 1
+
+	local previous_cache_file="${DEP_GRAPH_CACHE_FILE}"
+	local scoped_cache_file=""
+	scoped_cache_file=$(mktemp 2>/dev/null || true)
+	[[ -n "$scoped_cache_file" ]] || return 1
+	if ! printf '%s\n' "$graph_json" >"$scoped_cache_file"; then
+		rm -f "$scoped_cache_file"
+		return 1
+	fi
+	DEP_GRAPH_CACHE_FILE="$scoped_cache_file"
+	refresh_blocked_status_from_graph
+	DEP_GRAPH_CACHE_FILE="$previous_cache_file"
+	rm -f "$scoped_cache_file"
+	return 0
+}
+
+normalize_repo_dependency_readiness_if_due() {
+	local slug="$1"
+	local ttl_secs="${PULSE_DEP_NORMALIZE_TTL_SECS:-60}"
+	local marker_dir="${HOME}/.aidevops/cache/dependency-normalization"
+	local marker_file=""
+	local marker_age=0
+	[[ -n "$slug" ]] || return 1
+	[[ "$ttl_secs" =~ ^[0-9]+$ ]] || ttl_secs=60
+	marker_file="${marker_dir}/${slug//\//_}"
+
+	if [[ -f "$marker_file" ]]; then
+		marker_age=$(($(date +%s) - $(date -r "$marker_file" +%s 2>/dev/null || echo 0)))
+		[[ "$marker_age" -lt "$ttl_secs" ]] && return 0
+	fi
+	mkdir -p "$marker_dir" 2>/dev/null || return 1
+	if normalize_repo_dependency_readiness "$slug"; then
+		: >"$marker_file"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Extract blocked-by task IDs and issue numbers from an issue body.
 #
 # (GH#18693 refactor helper — keeps is_blocked_by_unresolved under 100 lines.)

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -261,6 +261,26 @@ list_dispatchable_issue_candidates_json() {
 	fi
 	rm -f "$issue_dispatch_err"
 
+	local candidates_json=""
+	candidates_json=$(_filter_dispatchable_issue_candidates_json "$issue_json")
+
+	# Dependency-blocked children are filtered before ranking, so they cannot
+	# reach the dispatch-time readiness guard. Normalize once per bounded TTL
+	# whenever the fetched snapshot contains blocked work; this also covers a
+	# roadmap alongside unrelated runnable candidates.
+	if printf '%s' "$issue_json" | jq -e 'any(.[]; any(.labels[]?; .name == "status:blocked"))' >/dev/null 2>&1 &&
+		declare -F normalize_repo_dependency_readiness_if_due >/dev/null 2>&1; then
+		normalize_repo_dependency_readiness_if_due "$repo_slug" >/dev/null 2>&1 || true
+		issue_json=$(gh_issue_list --repo "$repo_slug" --state open --json number,title,url,assignees,labels,updatedAt --limit "$limit" 2>/dev/null) || issue_json='[]'
+		candidates_json=$(_filter_dispatchable_issue_candidates_json "$issue_json")
+	fi
+
+	printf '%s\n' "$candidates_json"
+	return 0
+}
+
+_filter_dispatchable_issue_candidates_json() {
+	local issue_json="$1"
 	printf '%s' "$issue_json" | jq -c --arg auto_dispatch_label 'auto-dispatch' '
 		[
 			.[] |

--- a/.agents/scripts/tests/test-dependency-readiness-normalization.sh
+++ b/.agents/scripts/tests/test-dependency-readiness-normalization.sh
@@ -178,6 +178,40 @@ built_graph=$(_dep_graph_build_repo_data "owner/repo")
 assert_eq "repo graph build prunes circular dependency" '[]' \
 	"$(printf '%s' "$built_graph" | jq -c '.blocked_by["10"].issue_nums')"
 
+# The shared candidate selector must recover an all-blocked roadmap even when
+# called directly by a workers sweep without the full pulse preflight.
+# shellcheck disable=SC1090
+source "${SCRIPTS_DIR}/pulse-repo-meta.sh"
+candidate_fetch_file="${TMP_ROOT}/candidate-fetch-count"
+normalization_file="${TMP_ROOT}/normalization-count"
+printf '0\n' >"$candidate_fetch_file"
+printf '0\n' >"$normalization_file"
+export candidate_fetch_file normalization_file
+gh_issue_list() {
+	local candidate_fetch_count=""
+	candidate_fetch_count=$(<"$candidate_fetch_file")
+	candidate_fetch_count=$((candidate_fetch_count + 1))
+	printf '%s\n' "$candidate_fetch_count" >"$candidate_fetch_file"
+	if [[ "$candidate_fetch_count" -eq 1 ]]; then
+		printf '%s\n' '[{"number":20,"title":"next child","url":"","updatedAt":"2026-07-11T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:blocked"}]},{"number":30,"title":"unrelated work","url":"","updatedAt":"2026-07-11T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]}]'
+	else
+		printf '%s\n' '[{"number":20,"title":"next child","url":"","updatedAt":"2026-07-11T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]},{"number":30,"title":"unrelated work","url":"","updatedAt":"2026-07-11T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]}]'
+	fi
+	return 0
+}
+normalize_repo_dependency_readiness_if_due() {
+	local normalization_count=""
+	normalization_count=$(<"$normalization_file")
+	normalization_count=$((normalization_count + 1))
+	printf '%s\n' "$normalization_count" >"$normalization_file"
+	return 0
+}
+export -f gh_issue_list normalize_repo_dependency_readiness_if_due
+recovered_candidates=$(list_dispatchable_issue_candidates_json "owner/repo" 100)
+assert_eq "all-blocked roadmap triggers dependency normalization" "1" "$(<"$normalization_file")"
+assert_eq "next dependency-ready child reaches shared candidate stream" "20" \
+	"$(printf '%s' "$recovered_candidates" | jq -r 'map(select(.number == 20))[0].number')"
+
 status_write=""
 view_counter_file="${TMP_ROOT}/unblock-view-count"
 printf '0\n' >"$view_counter_file"


### PR DESCRIPTION
## Summary

Normalize repository dependency readiness from the shared issue-candidate selector used by deterministic pulse and daily worker sweeps. Fresh repository-scoped graph data relabels the next dependency-ready child, while a 60-second marker bounds API cost and existing non-dependency/active-state guards remain authoritative.

## Files Changed

.agents/scripts/pulse-dep-graph.sh, .agents/scripts/pulse-repo-meta.sh, .agents/scripts/tests/test-dependency-readiness-normalization.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dependency-readiness-normalization.sh; bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh; shellcheck on all changed shell files; changed-file and full local lint suites

For #27145


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.52 with gpt-5.6-sol spent 16m and 117,631 tokens on this with the user in an interactive session.