### PR TITLE
t18107: scope startup greeting to interactive root sessions

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -423,6 +423,31 @@ async function emitToast(client, body) {
 // The caller MUST NOT await runGreetingAsync — doing so would restore the
 // blocking behaviour this change is meant to fix.
 
+function refreshGreetingIfStale({ cached, now, refreshTtlMs, lockDir, lockStaleMs, scriptsDir, client, cacheFile, execGreeting, maintenanceNoticeFn }) {
+  if (cached && now() - cached.mtimeMs <= refreshTtlMs) return;
+
+  const lockToken = acquireRefreshLock(lockDir, lockStaleMs, now());
+  if (lockToken) {
+    runGreetingAsync({
+      scriptsDir,
+      client,
+      cacheFile,
+      lockDir,
+      lockToken,
+      execGreeting,
+      maintenanceNoticeFn,
+    });
+    return;
+  }
+
+  if (!cached) {
+    observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now });
+  }
+  if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+    console.error("[aidevops] greeting: refresh already running in another process");
+  }
+}
+
 /**
  * Create a handler that fires the greeting once per plugin init. The
  * returned function matches the plugin `event` hook contract so it can be
@@ -485,31 +510,18 @@ export function createGreetingHandler({
     const cached = readGreetingCache(cacheFile);
     emitCachedGreeting(client, cached);
 
-    if (!cached || now() - cached.mtimeMs > refreshTtlMs) {
-      const lockToken = acquireRefreshLock(lockDir, lockStaleMs, now());
-      if (lockToken) {
-        // t2729: fire-and-forget — do NOT await. The handler resolves immediately;
-        // the toast arrives whenever the subprocess finishes.
-        runGreetingAsync({
-          scriptsDir,
-          client,
-          cacheFile,
-          lockDir,
-          lockToken,
-          execGreeting,
-          maintenanceNoticeFn,
-        });
-      } else {
-        if (!cached) {
-          // A cold-cache follower still gets the owner's completed greeting;
-          // polling is bounded by the same crashed-lock recovery interval.
-          observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now });
-        }
-        if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
-          console.error("[aidevops] greeting: refresh already running in another process");
-        }
-      }
-    }
+    refreshGreetingIfStale({
+      cached,
+      now,
+      refreshTtlMs,
+      lockDir,
+      lockStaleMs,
+      scriptsDir,
+      client,
+      cacheFile,
+      execGreeting,
+      maintenanceNoticeFn,
+    });
 
     if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
       console.error("[aidevops] greeting: handler-completed");

--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -448,6 +448,7 @@ export function createGreetingHandler({
   execGreeting = execAsync,
   maintenanceNoticeFn = getOpenCodeMaintenanceNotice,
   now = Date.now,
+  isHeadless = () => false,
 }) {
   let fired = false;
   const initTime = now();
@@ -456,7 +457,14 @@ export function createGreetingHandler({
 
   return async ({ event }) => {
     if (fired) return;
+    if (isHeadless()) return;
     if (!event || !event.type) return;
+
+    // OpenCode includes session metadata on lifecycle events. A parentID marks
+    // a subagent/subtask session, which must not consume or display the main
+    // interactive session's startup toast.
+    const sessionInfo = event.properties?.info;
+    if (sessionInfo?.parentID) return;
 
     const isPrimary = event.type === "session.created";
     const isFallback =

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -35,7 +35,6 @@ import { createShellEnvHook } from "./shell-env.mjs";
 import { compactingHook } from "./compaction.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
 import { createGreetingHandler } from "./greeting.mjs";
-import { createSessionStartGreetingGate } from "./ttsr.mjs";
 import { applyImageSizeGuard } from "./quality-hooks-image.mjs";
 import { createSessionTitleFallbackHandler } from "./session-title-fallback.mjs";
 import { createSessionTitleSuffixHandler } from "./session-title-suffix.mjs";
@@ -46,7 +45,7 @@ import { createSessionContinuationGuard } from "./session-continuation-guard.mjs
 // Existing modules
 import { createTools } from "./tools.mjs";
 import { initObservability, handleEvent } from "./observability.mjs";
-import { createTtsrHooks } from "./ttsr.mjs";
+import { createSessionStartGreetingGate, createTtsrHooks } from "./ttsr.mjs";
 import { createPoolAuthHook, createPoolTool, initPoolAuth, getAccounts } from "./oauth-pool.mjs";
 import { createProviderAuthHook } from "./provider-auth.mjs";
 import { installOpenAIProviderFetchRotation } from "./openai-provider-auth.mjs";

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -35,6 +35,7 @@ import { createShellEnvHook } from "./shell-env.mjs";
 import { compactingHook } from "./compaction.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
 import { createGreetingHandler } from "./greeting.mjs";
+import { createSessionStartGreetingGate } from "./ttsr.mjs";
 import { applyImageSizeGuard } from "./quality-hooks-image.mjs";
 import { createSessionTitleFallbackHandler } from "./session-title-fallback.mjs";
 import { createSessionTitleSuffixHandler } from "./session-title-suffix.mjs";
@@ -247,6 +248,7 @@ export async function AidevopsPlugin({ directory, client }) {
     join(AGENTS_DIR, "configs", "model-routing-table.json"),
   ]);
   const subagentEffortHooks = createSubagentEffortHooks(client, { tierReasoning });
+  const shouldInjectGreeting = createSessionStartGreetingGate(client, isHeadless);
 
   // TTSR hooks
   const {
@@ -261,6 +263,7 @@ export async function AidevopsPlugin({ directory, client }) {
     run,
     intentField: INTENT_FIELD,
     isHeadless,
+    shouldInjectGreeting,
   });
 
   // Lazy-start dispatch table for local proxies. Keys are OpenCode
@@ -324,6 +327,7 @@ export async function AidevopsPlugin({ directory, client }) {
   const greetingHandler = createGreetingHandler({
     scriptsDir: SCRIPTS_DIR,
     client,
+    isHeadless,
   });
   const sessionTitleSuffixHandler = createSessionTitleSuffixHandler({
     agentsDir: AGENTS_DIR,

--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
@@ -107,6 +107,38 @@ test("fresh cache emits immediately without spawning a refresh", async (t) => {
   assert.equal(f.clients[0].length, 1);
 });
 
+test("headless sessions never emit or refresh a greeting", async (t) => {
+  const f = fixture();
+  t.after(() => f.cleanup());
+  writeFileSync(f.cacheFile, `${OLD_GREETING}\n`);
+  let spawnCount = 0;
+  const handler = createGreetingHandler({
+    ...handlerOptions(f, f.client(), async () => {
+      spawnCount += 1;
+      return { stdout: NEW_GREETING };
+    }),
+    isHeadless: () => true,
+  });
+
+  await handler({ event: { type: "session.created" } });
+
+  assert.equal(spawnCount, 0);
+  assert.equal(f.clients[0].length, 0);
+});
+
+test("subagent session events do not consume or emit the root greeting", async (t) => {
+  const f = fixture();
+  t.after(() => f.cleanup());
+  writeFileSync(f.cacheFile, `${OLD_GREETING}\n`);
+  const handler = createGreetingHandler(handlerOptions(f, f.client(), async () => ({ stdout: NEW_GREETING })));
+
+  await handler({ event: { type: "session.created", properties: { info: { id: "child", parentID: "root" } } } });
+  await handler({ event: { type: "session.created", properties: { info: { id: "root" } } } });
+
+  assert.equal(f.clients[0].length, 1);
+  assert.match(f.clients[0][0].message, /aidevops v1\.0\.0/);
+});
+
 test("stale lock is recovered within the configured bound", async (t) => {
   const f = fixture();
   t.after(() => f.cleanup());

--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -11,7 +11,7 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createTtsrHooks } from "../ttsr.mjs";
+import { createSessionStartGreetingGate, createTtsrHooks } from "../ttsr.mjs";
 
 function createHooks(options = {}) {
   const logs = [];
@@ -132,6 +132,49 @@ describe("token cost advisory threshold", () => {
     const output = { system: ["base system prompt"] };
 
     await hooks.systemTransformHook({ model: { providerID: "openai" } }, output);
+
+    assert.equal(output.system[0], "base system prompt");
+  });
+
+  test("injects the greeting only on the first request of an interactive root session", async () => {
+    const client = { session: { get: async () => ({ data: { id: "root-session" } }) } };
+    const shouldInjectGreeting = createSessionStartGreetingGate(client);
+    const { hooks } = createHooks();
+    const first = { system: ["base system prompt"] };
+    const later = { system: ["base system prompt"] };
+    hooks.systemTransformHook = createTtsrHooks({
+      agentsDir: join(tmpdir(), "greeting-once-agents"),
+      scriptsDir: join(tmpdir(), "greeting-once-scripts"),
+      readIfExists: () => "",
+      qualityLog: () => {},
+      run: () => "",
+      intentField: "agent__intent",
+      shouldInjectGreeting,
+    }).systemTransformHook;
+
+    await hooks.systemTransformHook({ sessionID: "root-session", model: { providerID: "openai" } }, first);
+    await hooks.systemTransformHook({ sessionID: "root-session", model: { providerID: "openai" } }, later);
+
+    assert.match(first.system[0], /Session-start greeting order/);
+    assert.equal(later.system[0], "base system prompt");
+  });
+
+  test("does not inject the greeting into subagent sessions", async () => {
+    const client = { session: { get: async () => ({ data: { id: "child-session", parentID: "root-session" } }) } };
+    const shouldInjectGreeting = createSessionStartGreetingGate(client);
+    const { hooks } = createHooks();
+    const output = { system: ["base system prompt"] };
+    const scopedHooks = createTtsrHooks({
+      agentsDir: join(tmpdir(), "greeting-child-agents"),
+      scriptsDir: join(tmpdir(), "greeting-child-scripts"),
+      readIfExists: () => "",
+      qualityLog: () => {},
+      run: () => "",
+      intentField: "agent__intent",
+      shouldInjectGreeting,
+    });
+
+    await scopedHooks.systemTransformHook({ sessionID: "child-session", model: { providerID: "openai" } }, output);
 
     assert.equal(output.system[0], "base system prompt");
   });

--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -24,6 +24,7 @@ function createHooks(options = {}) {
     run: () => "",
     intentField: "agent__intent",
     isHeadless: options.isHeadless || (() => false),
+    shouldInjectGreeting: options.shouldInjectGreeting,
   });
   return { hooks, logs };
 }
@@ -139,18 +140,9 @@ describe("token cost advisory threshold", () => {
   test("injects the greeting only on the first request of an interactive root session", async () => {
     const client = { session: { get: async () => ({ data: { id: "root-session" } }) } };
     const shouldInjectGreeting = createSessionStartGreetingGate(client);
-    const { hooks } = createHooks();
+    const { hooks } = createHooks({ shouldInjectGreeting });
     const first = { system: ["base system prompt"] };
     const later = { system: ["base system prompt"] };
-    hooks.systemTransformHook = createTtsrHooks({
-      agentsDir: join(tmpdir(), "greeting-once-agents"),
-      scriptsDir: join(tmpdir(), "greeting-once-scripts"),
-      readIfExists: () => "",
-      qualityLog: () => {},
-      run: () => "",
-      intentField: "agent__intent",
-      shouldInjectGreeting,
-    }).systemTransformHook;
 
     await hooks.systemTransformHook({ sessionID: "root-session", model: { providerID: "openai" } }, first);
     await hooks.systemTransformHook({ sessionID: "root-session", model: { providerID: "openai" } }, later);
@@ -162,19 +154,10 @@ describe("token cost advisory threshold", () => {
   test("does not inject the greeting into subagent sessions", async () => {
     const client = { session: { get: async () => ({ data: { id: "child-session", parentID: "root-session" } }) } };
     const shouldInjectGreeting = createSessionStartGreetingGate(client);
-    const { hooks } = createHooks();
+    const { hooks } = createHooks({ shouldInjectGreeting });
     const output = { system: ["base system prompt"] };
-    const scopedHooks = createTtsrHooks({
-      agentsDir: join(tmpdir(), "greeting-child-agents"),
-      scriptsDir: join(tmpdir(), "greeting-child-scripts"),
-      readIfExists: () => "",
-      qualityLog: () => {},
-      run: () => "",
-      intentField: "agent__intent",
-      shouldInjectGreeting,
-    });
 
-    await scopedHooks.systemTransformHook({ sessionID: "child-session", model: { providerID: "openai" } }, output);
+    await hooks.systemTransformHook({ sessionID: "child-session", model: { providerID: "openai" } }, output);
 
     assert.equal(output.system[0], "base system prompt");
   });

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -224,17 +224,45 @@ export function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
 }
 
 /**
+ * Allow the greeting instruction exactly once for each interactive root
+ * session. Child sessions are subagents/subtasks and must never inherit a
+ * startup greeting; otherwise a late child request can reproduce the greeting
+ * immediately before the parent session's summary.
+ */
+export function createSessionStartGreetingGate(client, isHeadless = () => false) {
+  const attemptedSessions = new Set();
+
+  return async function shouldInjectSessionStartGreeting(input) {
+    if (isHeadless()) return false;
+
+    const sessionID = input?.sessionID;
+    if (!sessionID || attemptedSessions.has(sessionID)) return false;
+    // Claim the one startup opportunity before the asynchronous lookup. A
+    // metadata failure must not allow a later turn to inject a stale greeting.
+    attemptedSessions.add(sessionID);
+
+    try {
+      const response = await client.session.get({ path: { id: sessionID } });
+      const session = response?.data ?? response ?? {};
+      return !session.parentID;
+    } catch {
+      return false;
+    }
+  };
+}
+
+/**
  * system.transform hook: prepend session-start greeting order, identity prefix,
  * and quality rules.
  */
-async function ttsrSystemTransform(input, output, state, intentField, isHeadless, agentsDir, readIfExists) {
+async function ttsrSystemTransform(input, output, state, intentField, shouldInjectGreeting, agentsDir, readIfExists) {
   if (input.model?.providerID === "anthropic") {
     const prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
     output.system.unshift(prefix);
     if (output.system[1]) output.system[1] = prefix + "\n\n" + output.system[1];
   }
 
-  if (!isHeadless()) {
+  if (await shouldInjectGreeting(input)) {
     output.system.unshift(buildSessionStartGreetingInstruction(agentsDir, readIfExists));
   }
 
@@ -350,13 +378,14 @@ async function ttsrTextComplete(input, output, state, execDeps, qualityLog) {
 export function createTtsrHooks(deps) {
   const { agentsDir, scriptsDir, readIfExists, qualityLog, run, intentField } = deps;
   const isHeadless = deps.isHeadless || (() => false);
+  const shouldInjectGreeting = deps.shouldInjectGreeting || (async () => !isHeadless());
   const ttsrRulesPath = join(agentsDir, "configs", "ttsr-rules.json");
   const state = createTtsrState(ttsrRulesPath, readIfExists);
   const execDeps = { scriptsDir, run };
 
   return {
     loadTtsrRules: () => loadTtsrRules(state),
-    systemTransformHook: (input, output) => ttsrSystemTransform(input, output, state, intentField, isHeadless, agentsDir, readIfExists),
+    systemTransformHook: (input, output) => ttsrSystemTransform(input, output, state, intentField, shouldInjectGreeting, agentsDir, readIfExists),
     messagesTransformHook: (_input, output) => ttsrMessagesTransform(_input, output, state, qualityLog, isHeadless),
     textCompleteHook: (input, output) => ttsrTextComplete(input, output, state, execDeps, qualityLog),
   };

--- a/TODO.md
+++ b/TODO.md
@@ -1137,6 +1137,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18096 Treat canonical lint policy deferrals as safe skips #auto-dispatch #bug ref:GH#27139
 
+- [ ] t18107 Scope startup greeting to interactive root sessions #bug ref:GH#27328
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/TODO.md
+++ b/TODO.md
@@ -1137,8 +1137,6 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18096 Treat canonical lint policy deferrals as safe skips #auto-dispatch #bug ref:GH#27139
 
-- [ ] t18107 Scope startup greeting to interactive root sessions #bug ref:GH#27328
-
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22
@@ -4526,3 +4524,5 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [ ] t18105 Validate causal evidence in framework bug reports #bug ref:GH#27271
 
 - [ ] t18106 Fix agent deployment verification for symlinked runtime bundles #auto-dispatch #bug ref:GH#27275
+
+- [ ] t18107 Scope startup greeting to interactive root sessions #bug ref:GH#27328

--- a/TODO.md
+++ b/TODO.md
@@ -4526,5 +4526,3 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [ ] t18105 Validate causal evidence in framework bug reports #bug ref:GH#27271
 
 - [ ] t18106 Fix agent deployment verification for symlinked runtime bundles #auto-dispatch #bug ref:GH#27275
-
-- [ ] t18107 Scope startup greeting to interactive root sessions #bug ref:GH#27328


### PR DESCRIPTION
## Summary

Gate greeting prompt injection to the first request of interactive root sessions and suppress greeting toasts for headless and child sessions.

## Files Changed

.agents/plugins/opencode-aidevops/greeting.mjs, .agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs, .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs, .agents/plugins/opencode-aidevops/ttsr.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 34 targeted OpenCode plugin tests passed; changed-file local linter suite passed. Full repository lint was also run and surfaced pre-existing SonarCloud, CHANGELOG markdown, and broad shell complexity debt unrelated to these files.

Resolves #27328


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.54 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 9m and 107,211 tokens on this with the user in an interactive session.