### PR TITLE
GH#27330: keep ripgrep current across supported platforms

### DIFF
--- a/.agents/scripts/tests/test-tool-version-check-ripgrep.sh
+++ b/.agents/scripts/tests/test-tool-version-check-ripgrep.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Ensure aidevops update keeps the ripgrep executable used by shell and
+# OpenCode native Grep current through supported system package managers.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TOOL_VERSION_CHECK="$REPO_ROOT/.agents/scripts/tool-version-check.sh"
+
+python3 - "$TOOL_VERSION_CHECK" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+content = Path(sys.argv[1]).read_text()
+entry = re.search(
+    r'"brew\|ripgrep\|rg\|--version\|ripgrep\|\$\(_brew_upgrade_cmd ripgrep\)"',
+    content,
+)
+assert entry, "BREW_TOOLS must manage ripgrep through _brew_upgrade_cmd"
+
+assert 'ripgrep) get_public_release_tag "BurntSushi/ripgrep" ;;' in content, (
+    "Linux without Homebrew must resolve the latest ripgrep release"
+)
+
+helper = content[content.index("_brew_upgrade_cmd() {"):content.index("# PEP 668-safe")]
+for manager_command in (
+    "brew upgrade",
+    "apt-get install --only-upgrade",
+    "dnf upgrade",
+    "yum upgrade",
+):
+    assert manager_command in helper, f"missing package-manager path: {manager_command}"
+
+print("PASS: ripgrep participates in cross-platform tool updates")
+PY
+
+exit 0

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -156,6 +156,7 @@ BREW_TOOLS=(
 	"brew|Worktrunk|wt|--version|max-sixty/worktrunk/wt|$(_brew_upgrade_cmd max-sixty/worktrunk/wt)"
 	"brew|Beads CLI|bd|version|steveyegge/beads/bd|$(_brew_upgrade_cmd steveyegge/beads/bd)"
 	"brew|jq|jq|--version|jq|$(_brew_upgrade_cmd jq)"
+	"brew|ripgrep|rg|--version|ripgrep|$(_brew_upgrade_cmd ripgrep)"
 	"brew|ShellCheck|shellcheck|--version|shellcheck|$(_brew_upgrade_cmd shellcheck)"
 )
 
@@ -383,6 +384,7 @@ get_brew_latest() {
 		glab) get_public_release_tag "gitlab-org/cli" ;;
 		wt) get_public_release_tag "max-sixty/worktrunk" ;;
 		jq) get_public_release_tag "jqlang/jq" ;;
+		ripgrep) get_public_release_tag "BurntSushi/ripgrep" ;;
 		shellcheck) get_public_release_tag "koalaman/shellcheck" ;;
 		*) echo "unknown" ;;
 		esac

--- a/.agents/tools/terminal/terminal-optimization.md
+++ b/.agents/tools/terminal/terminal-optimization.md
@@ -83,7 +83,7 @@ done | tr '\n' ':' | sed 's/:$//')
 | Classic | Modern | Speedup | Install |
 |---------|--------|---------|---------|
 | `find` | `fd` | 5-10x | `brew install fd` |
-| `grep` | `rg` (ripgrep) | 5-20x | `brew install ripgrep` |
+| shell `grep` | shell `rg` (ripgrep) | 5-20x | `brew install ripgrep` |
 | `grep` (PDFs/docs) | `rga` (ripgrep-all) | new capability | `brew install ripgrep-all` |
 | `cat` | `bat` | Syntax highlighting | `brew install bat` |
 | `ls` | `eza` | Better output | `brew install eza` |
@@ -95,6 +95,12 @@ done | tr '\n' ':' | sed 's/:$//')
 | `man` | `tldr` | Quick examples | `brew install tldr` |
 
 `fd`/`rg`/`rga` share the same ecosystem and `.gitignore` awareness: `fd` = files by metadata, `rg` = text content, `rga` = inside non-text files (PDF, DOCX/XLSX/PPTX, ODT, SQLite, zip/tar/gz).
+
+For AI-agent searches, distinguish the runtime tool from the shell command:
+
+- Use the runtime's native Grep tool for bounded, structured content searches. OpenCode's native Grep invokes ripgrep and adds permission checks, output limits, path normalization, and concise previews.
+- Use shell `rg` when Bash is already available and the task needs advanced ripgrep flags, exact match counts, file-list output, or pipelines.
+- Do not replace native Grep with shell `rg` solely for performance; both use ripgrep, while native Grep also works for agents without Bash access.
 
 ### 4. Shell Aliases
 
@@ -162,12 +168,12 @@ Issues Found:
 1. [SLOW] nvm init adds 180ms - suggest lazy-load
 2. [DUP] /usr/local/bin appears 3x in PATH
 3. [MISSING] /opt/homebrew/bin not in PATH but Homebrew installed
-4. [TOOL] Using grep instead of ripgrep (5-20x slower)
+4. [TOOL] Shell scripts use POSIX grep for repository-wide searches where ripgrep is available
 
 Recommendations:
 1. Lazy-load nvm (saves ~180ms)
 2. Deduplicate PATH (saves ~5ms lookup)
-3. Install: fd, ripgrep, bat, eza
+3. Install or update: fd, ripgrep, bat, eza
 4. Add fzf for fuzzy history search
 ```
 


### PR DESCRIPTION
## Summary

- Add ripgrep to aidevops tool version checks and automatic update handling.
- Resolve latest ripgrep releases on Linux systems without Homebrew.
- Clarify when agents should use native Grep versus shell `rg`.
- Add focused cross-platform regression coverage.

## Decisions

OpenCode native Grep already invokes ripgrep and provides structured permissions and bounded output. Shell `rg` remains recommended for advanced flags, exact counts, file-list output, and pipelines. Updating the PATH `rg` benefits both native Grep's preferred executable and direct shell usage.

## Testing

- `.agents/scripts/tests/test-tool-version-check-ripgrep.sh`
- `.agents/scripts/tests/test-tool-version-check-classify.sh`
- `.agents/scripts/tests/test-tool-version-check-opencode.sh`
- ShellCheck and Markdownlint on changed files
- `.agents/scripts/linters-local.sh`

## Runtime Testing

Self-assessed medium-risk package-manager configuration change with isolated cross-platform command assertions; no package upgrade was executed during tests.

Resolves #27330

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.54 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1h 5m and 36,691 tokens on this with the user in an interactive session. Overall, 4m since this issue was created.
