### PR TITLE
GH#27332: make worker launch ownership transactional

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -325,6 +325,32 @@ _stale_recovery_has_unresolved_blocked_by() {
 }
 
 #######################################
+# Verify a stale-recovery status transition before publishing success.
+# Args: issue number, repo slug, target status, stale assignees CSV
+#######################################
+_stale_recovery_verify_transition() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local target_status="$3"
+	local stale_assignees="$4"
+	local issue_meta_json=""
+
+	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state,labels,assignees 2>/dev/null) || return 1
+	printf '%s' "$issue_meta_json" | jq -e --arg target "status:${target_status}" --arg stale "$stale_assignees" '
+		($stale | split(",") | map(select(length > 0))) as $stale_users |
+		([.assignees[].login] // []) as $current_users |
+		.state == "OPEN" and
+		(([.labels[].name] | index("status:queued")) == null) and
+		(([.labels[].name] | index("status:in-progress")) == null) and
+		(([.labels[].name] | index($target)) != null) and
+		([ $stale_users[] as $stale_user |
+			select(($current_users | index($stale_user)) != null) ] | length == 0)
+	' >/dev/null 2>&1 || return 1
+	return 0
+}
+
+#######################################
 # Apply stale recovery as dependency-blocked instead of available.
 # Args mirror _stale_recovery_apply.
 #######################################
@@ -341,7 +367,14 @@ _stale_recovery_apply_blocked_by_hold() {
 		printf 'STALE_RECHECK_BLOCKED: issue #%s in %s — evidence changed before blocked takeover\n' "$issue_number" "$repo_slug"
 		return 0
 	fi
-	set_issue_status "$issue_number" "$repo_slug" "blocked" "${recov_extra[@]}" || true
+	if ! set_issue_status "$issue_number" "$repo_slug" "blocked" "${recov_extra[@]}"; then
+		printf 'STALE_RECOVERY_UNCERTAIN: issue #%s in %s — blocked transition failed\n' "$issue_number" "$repo_slug"
+		return 1
+	fi
+	if ! _stale_recovery_verify_transition "$issue_number" "$repo_slug" "blocked" "$stale_assignees"; then
+		printf 'STALE_RECOVERY_UNCERTAIN: issue #%s in %s — blocked transition verification failed\n' "$issue_number" "$repo_slug"
+		return 1
+	fi
 
 	local _now_ts=""
 	_now_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -412,7 +445,14 @@ _stale_recovery_apply() {
 		printf 'STALE_RECHECK_BLOCKED: issue #%s in %s — evidence changed before takeover\n' "$issue_number" "$repo_slug"
 		return 0
 	fi
-	set_issue_status "$issue_number" "$repo_slug" "available" "${_recov_extra[@]}" || true
+	if ! set_issue_status "$issue_number" "$repo_slug" "available" "${_recov_extra[@]}"; then
+		printf 'STALE_RECOVERY_UNCERTAIN: issue #%s in %s — available transition failed\n' "$issue_number" "$repo_slug"
+		return 1
+	fi
+	if ! _stale_recovery_verify_transition "$issue_number" "$repo_slug" "available" "$stale_assignees"; then
+		printf 'STALE_RECOVERY_UNCERTAIN: issue #%s in %s — available transition verification failed\n' "$issue_number" "$repo_slug"
+		return 1
+	fi
 
 	local _now_ts
 	_now_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -486,7 +526,7 @@ _recover_stale_assignment() {
 	fi
 	# ── End stale-recovery escalation check ──────────────────────────────
 
-	_stale_recovery_apply "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_latest_dispatch_ts" "$_next_tick" "$_threshold"
+	_stale_recovery_apply "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_latest_dispatch_ts" "$_next_tick" "$_threshold" || return 1
 	return 0
 }
 

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -2354,6 +2354,29 @@ Dispatch cooldown active until ${iso} following a no_worker_process launch failu
 	return 0
 }
 
+#######################################
+# Confirm launch recovery removed this runner's queued ownership and applied
+# the intended replacement status before publishing any success receipt.
+# Args: issue number, repo slug, runner login, target status
+#######################################
+_verify_launch_recovery_state() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="$3"
+	local target_status="$4"
+	local issue_meta_json=""
+
+	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state,labels,assignees 2>/dev/null) || return 1
+	printf '%s' "$issue_meta_json" | jq -e --arg self "$self_login" --arg target "status:${target_status}" '
+		.state == "OPEN" and
+		(([.labels[].name] | index("status:queued")) == null) and
+		(([.labels[].name] | index($target)) != null) and
+		(([.assignees[].login] | index($self)) == null)
+	' >/dev/null 2>&1 || return 1
+	return 0
+}
+
 recover_failed_launch_state() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -2415,12 +2438,16 @@ recover_failed_launch_state() {
 	# t2033: atomic transitions via set_issue_status. The blocked branch
 	# preserves status:blocked (target = "blocked"); the normal branch
 	# transitions to status:available.
-	if [[ "$is_blocked" == "true" ]]; then
-		set_issue_status "$issue_number" "$repo_slug" "blocked" \
-			--remove-assignee "$self_login" >/dev/null 2>&1 || true
-	else
-		set_issue_status "$issue_number" "$repo_slug" "available" \
-			--remove-assignee "$self_login" >/dev/null 2>&1 || true
+	local target_status="available"
+	[[ "$is_blocked" == "true" ]] && target_status="blocked"
+	if ! set_issue_status "$issue_number" "$repo_slug" "$target_status" \
+		--remove-assignee "$self_login" >/dev/null 2>&1; then
+		echo "[pulse-wrapper] Launch recovery uncertain for #${issue_number} (${repo_slug}): ownership mutation failed" >>"$LOGFILE"
+		return 1
+	fi
+	if ! _verify_launch_recovery_state "$issue_number" "$repo_slug" "$self_login" "$target_status"; then
+		echo "[pulse-wrapper] Launch recovery uncertain for #${issue_number} (${repo_slug}): post-mutation verification failed" >>"$LOGFILE"
+		return 1
 	fi
 
 	# t2394: Invalidate stale cross-runner claims immediately (see helper below).

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -48,6 +48,7 @@
 # Include guard — prevent double-sourcing.
 [[ -n "${_PULSE_CLEANUP_LOADED:-}" ]] && return 0
 _PULSE_CLEANUP_LOADED=1
+_PULSE_CLEANUP_FALSE="false"
 
 # t2559: canonical-guard-helper.sh provides is_registered_canonical and
 # assert_git_available, used by guarded removal helpers and
@@ -735,7 +736,7 @@ _evaluate_worktree_removal() {
 				has_open_pr=true
 			fi
 		fi
-		if [[ "$has_open_pr" == "false" ]]; then
+		if [[ "$has_open_pr" == "$_PULSE_CLEANUP_FALSE" ]]; then
 			echo "0 commits, clean, no open PR, age $((wt_age_secs / 60))m (crashed worker)"
 			return 0
 		fi
@@ -755,7 +756,7 @@ _evaluate_worktree_removal() {
 				has_pr=true
 			fi
 		fi
-		if [[ "$has_pr" == "false" ]]; then
+		if [[ "$has_pr" == "$_PULSE_CLEANUP_FALSE" ]]; then
 			echo "${commits_ahead} commits, no PR, age $((wt_age_secs / 3600))h"
 			return 0
 		fi
@@ -2427,9 +2428,9 @@ recover_failed_launch_state() {
 	has_queued=$(echo "$issue_meta_json" | jq -r '([.labels[].name] | index("status:queued")) != null' 2>/dev/null)
 	is_blocked=$(echo "$issue_meta_json" | jq -r '([.labels[].name] | index("status:blocked")) != null' 2>/dev/null)
 
-	[[ "$assigned_to_self" == "true" || "$assigned_to_self" == "false" ]] || assigned_to_self="false"
-	[[ "$has_queued" == "true" || "$has_queued" == "false" ]] || has_queued="false"
-	[[ "$is_blocked" == "true" || "$is_blocked" == "false" ]] || is_blocked="false"
+	[[ "$assigned_to_self" == "true" || "$assigned_to_self" == "$_PULSE_CLEANUP_FALSE" ]] || assigned_to_self=""
+	[[ "$has_queued" == "true" || "$has_queued" == "$_PULSE_CLEANUP_FALSE" ]] || has_queued=""
+	[[ "$is_blocked" == "true" || "$is_blocked" == "$_PULSE_CLEANUP_FALSE" ]] || is_blocked=""
 
 	if [[ "$issue_state" != "OPEN" ]] || [[ "$assigned_to_self" != "true" ]] || [[ "$has_queued" != "true" ]]; then
 		return 0

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -56,6 +56,8 @@
 
 [[ -n "${_PULSE_DISPATCH_CORE_LOADED:-}" ]] && return 0
 _PULSE_DISPATCH_CORE_LOADED=1
+_PULSE_DISPATCH_FALSE="false"
+_PULSE_DISPATCH_ELIGIBILITY_STAGE="eligibility_gate"
 
 # t2863: Module-level variable defaults (set -u guards).
 # Ensures LOGFILE is safe to dereference in all functions when this module
@@ -349,7 +351,7 @@ _count_impl_commits() {
 				;;
 			esac
 		done < <(git -C "$repo_path_inner" diff-tree --no-commit-id --name-only -r "$commit_hash_inner" 2>/dev/null)
-		if [[ "$is_planning_only_inner" == "false" ]]; then
+		if [[ "$is_planning_only_inner" == "$_PULSE_DISPATCH_FALSE" ]]; then
 			match_count_inner=$((match_count_inner + 1))
 		fi
 	done
@@ -666,7 +668,7 @@ _check_nmr_approval_gate() {
 	# GH#18648: bot-generated cleanup exemption. See
 	# _is_bot_generated_cleanup_issue() doc for full rationale.
 	if [[ "$known_ever_nmr" != "true" ]] && _is_bot_generated_cleanup_issue "$issue_meta_json"; then
-		known_ever_nmr="false"
+		known_ever_nmr="$_PULSE_DISPATCH_FALSE"
 		echo "[pulse-wrapper] dispatch_with_dedup: review-followup exemption for #${issue_number} in ${repo_slug} — skipping historical ever-NMR check (GH#18648)" >>"$LOGFILE"
 	fi
 
@@ -971,7 +973,7 @@ _dispatch_target_is_pull_request() {
 	if [[ "$has_pull_request" == "true" ]]; then
 		return 0
 	fi
-	if [[ "$has_pull_request" == "false" ]]; then
+	if [[ "$has_pull_request" == "$_PULSE_DISPATCH_FALSE" ]]; then
 		return 1
 	fi
 	return 2
@@ -1461,7 +1463,7 @@ _rollback_prelaunch_ownership() {
 	local issue_meta_json=""
 	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
 		--json state,labels,assignees,locked 2>/dev/null) || return 1
-	local owns_queued="false"
+	local owns_queued=""
 	owns_queued=$(printf '%s' "$issue_meta_json" | jq -r --arg self "$self_login" '
 		(.state == "OPEN") and
 		(([.labels[].name] | index("status:queued")) != null) and
@@ -1771,11 +1773,11 @@ dispatch_with_dedup() {
 	# t2424/GH#20030: Generic eligibility gate — final check BEFORE worker spawn.
 	_ds_t0=$(_ds_now_ns)
 	if ! _run_eligibility_gate_or_abort "$issue_number" "$repo_slug" "$issue_meta_json"; then
-		_ds_record "$issue_number" "$repo_slug" "eligibility_gate" "$_ds_t0"
-		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "eligibility_gate"
+		_ds_record "$issue_number" "$repo_slug" "$_PULSE_DISPATCH_ELIGIBILITY_STAGE" "$_ds_t0"
+		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "$_PULSE_DISPATCH_ELIGIBILITY_STAGE"
 		return 1
 	fi
-	_ds_record "$issue_number" "$repo_slug" "eligibility_gate" "$_ds_t0"
+	_ds_record "$issue_number" "$repo_slug" "$_PULSE_DISPATCH_ELIGIBILITY_STAGE" "$_ds_t0"
 
 	# All checks passed — launch the worker.
 	_ds_t0=$(_ds_now_ns)

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1437,6 +1437,65 @@ _run_eligibility_gate_or_abort() {
 }
 
 #######################################
+# Verify and roll back queued ownership created by this exact pre-launch claim.
+# The claim comment remains present while this runs, providing a lease identity
+# that prevents an older abort from clearing a newer dispatch attempt.
+# Args: issue number, repo slug, runner login, claim comment id
+# Returns: 0 when ownership is absent or verified rolled back; 1 on uncertainty.
+#######################################
+_rollback_prelaunch_ownership() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="$3"
+	local claim_comment_id="$4"
+	local comments_endpoint="repos/${repo_slug}/issues/${issue_number}/comments"
+	local latest_claim_id=""
+
+	latest_claim_id=$(gh api "$comments_endpoint" --paginate --jq \
+		'[.[] | select((.body // "") | contains("DISPATCH_CLAIM nonce="))] | last | (.id // "")' 2>/dev/null) || return 1
+	if [[ -z "$latest_claim_id" || "$latest_claim_id" != "$claim_comment_id" ]]; then
+		echo "[dispatch_with_dedup] Pre-launch rollback skipped for #${issue_number}: claim ${claim_comment_id} is no longer current (latest=${latest_claim_id:-unknown})" >>"$LOGFILE"
+		return 1
+	fi
+
+	local issue_meta_json=""
+	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state,labels,assignees,locked 2>/dev/null) || return 1
+	local owns_queued="false"
+	owns_queued=$(printf '%s' "$issue_meta_json" | jq -r --arg self "$self_login" '
+		(.state == "OPEN") and
+		(([.labels[].name] | index("status:queued")) != null) and
+		(([.assignees[].login] | index($self)) != null)
+	' 2>/dev/null) || return 1
+	[[ "$owns_queued" == "true" ]] || return 0
+
+	if ! set_issue_status "$issue_number" "$repo_slug" "available" \
+		--remove-assignee "$self_login" >/dev/null 2>&1; then
+		echo "[dispatch_with_dedup] Pre-launch rollback failed for #${issue_number}: unable to restore available ownership" >>"$LOGFILE"
+		return 1
+	fi
+	if declare -F unlock_issue_after_worker >/dev/null 2>&1; then
+		unlock_issue_after_worker "$issue_number" "$repo_slug" || return 1
+	fi
+
+	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state,labels,assignees,locked 2>/dev/null) || return 1
+	if ! printf '%s' "$issue_meta_json" | jq -e --arg self "$self_login" '
+		.state == "OPEN" and
+		(([.labels[].name] | index("status:queued")) == null) and
+		(([.labels[].name] | index("status:available")) != null) and
+		(([.assignees[].login] | index($self)) == null) and
+		(.locked != true)
+	' >/dev/null 2>&1; then
+		echo "[dispatch_with_dedup] Pre-launch rollback verification failed for #${issue_number}; retaining claim for stale recovery" >>"$LOGFILE"
+		return 1
+	fi
+
+	echo "[dispatch_with_dedup] Pre-launch rollback verified for #${issue_number}: queued ownership removed and issue unlocked" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
 # Release a dispatch claim when a post-claim pre-launch step aborts.
 #
 # dispatch-claim-helper.sh posts DISPATCH_CLAIM before later gates and launch
@@ -1483,6 +1542,11 @@ _release_dispatch_claim_on_abort() {
 	esac
 
 	if [[ "$_is_pre_launch_abort" == "1" ]]; then
+		if [[ "$reason" == worker_launch_rc_* ]] &&
+			! _rollback_prelaunch_ownership "$issue_number" "$repo_slug" "$self_login" "$_claim_comment_id"; then
+			echo "[dispatch_with_dedup] Retaining dispatch claim ${_claim_comment_id} after uncertain pre-launch rollback for #${issue_number} (${reason})" >>"$LOGFILE"
+			return 1
+		fi
 		local _claim_helper="${SCRIPT_DIR}/dispatch-claim-helper.sh"
 		if [[ -x "$_claim_helper" ]]; then
 			# Use the helper's _delete_comment if exposed via subcommand,

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -130,7 +130,10 @@ _dlw_assign_and_label() {
 		[[ -n "$_prev_login" && "$_prev_login" != "$self_login" ]] && _extra_flags+=(--remove-assignee "$_prev_login")
 	done < <(printf '%s' "$issue_meta_json" | jq -r '.assignees[].login' 2>/dev/null)
 
-	set_issue_status "$issue_number" "$repo_slug" "queued" "${_extra_flags[@]}" || true
+	if ! set_issue_status "$issue_number" "$repo_slug" "queued" "${_extra_flags[@]}"; then
+		echo "[dispatch_with_dedup] Failed to assign queued ownership for #${issue_number} in ${repo_slug}; aborting before lock/worktree/spawn" >>"$LOGFILE"
+		return 1
+	fi
 	return 0
 }
 
@@ -2067,7 +2070,10 @@ _dispatch_launch_worker() {
 	fi
 
 	_ds_t0=$(_ds_now_ns)
-	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json"
+	if ! _dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json"; then
+		_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
+		return 2
+	fi
 	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
 
 	local zero_output_comment_metrics=""

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -2070,10 +2070,10 @@ _dispatch_launch_worker() {
 	fi
 
 	_ds_t0=$(_ds_now_ns)
-	if ! _dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json"; then
+	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json" || {
 		_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
 		return 2
-	fi
+	}
 	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
 
 	local zero_output_comment_metrics=""

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -2087,15 +2087,6 @@ _dispatch_launch_worker() {
 	lock_issue_for_worker "$issue_number" "$repo_slug"
 	_ds_record "$issue_number" "$repo_slug" "lock_issue" "$_ds_t0"
 
-	# GH#17584 / t2433: The git pull that was here has been moved earlier in
-	# the dispatch path to _pulse_refresh_repo (pulse-wrapper.sh), which is
-	# called once per (repo, cycle) before any gate evaluation — including the
-	# large-file gate at pulse-dispatch-core.sh:867. Moving it earlier ensures
-	# the large-file simplification gate measures the post-split line count,
-	# preventing false-positive file-size-debt issues after a split PR merges.
-	# The pull still happens before the worker starts; it now also happens before
-	# the gate that decides whether to dispatch at all. See GH#20071.
-
 	# t2981: capture pre-creation return code — skip dispatch on failure
 	# instead of falling back to canonical repo on the default branch.
 	_ds_t0=$(_ds_now_ns)

--- a/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
+++ b/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
@@ -69,10 +69,12 @@ GH_COMMENT_LOG="${TMP_HOME}/gh-comment.log"
 GH_API_COMMENTS_RESPONSE="${TMP_HOME}/gh-api-comments.json"
 GH_PR_LIST_RESPONSE="${TMP_HOME}/gh-pr-list.json"
 GH_API_BRANCHES_RESPONSE="${TMP_HOME}/gh-api-branches.json"
+GH_ISSUE_RESPONSE="${TMP_HOME}/gh-issue.json"
 : >"$GH_COMMENT_LOG"
 printf '[]' >"$GH_API_COMMENTS_RESPONSE"
 printf '[]' >"$GH_PR_LIST_RESPONSE"
 printf '[]' >"$GH_API_BRANCHES_RESPONSE"
+printf '{}' >"$GH_ISSUE_RESPONSE"
 
 # Helper: extract the value of --jq from an argv list, if present.
 _extract_jq_filter() {
@@ -184,8 +186,7 @@ gh() {
 			done
 			;;
 		view)
-			# Used by some helpers to fetch issue body/labels — return empty
-			echo "{}"
+			cat "$GH_ISSUE_RESPONSE"
 			;;
 		*) ;;
 		esac
@@ -223,6 +224,21 @@ count_gh_comments() {
 
 sleep() {
 	printf '%s\n' 'SLEEP_CALLED' >>"$GH_COMMENT_LOG"
+	return 0
+}
+
+STATUS_MUTATION_FAIL=0
+set_issue_status() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local status_name="$3"
+	: "$issue_number" "$repo_slug" "$status_name"
+	[[ "$STATUS_MUTATION_FAIL" -eq 0 ]] || return 1
+	printf '{"state":"OPEN","labels":[{"name":"status:available"}],"assignees":[],"locked":false}' >"$GH_ISSUE_RESPONSE"
+	return 0
+}
+
+unlock_issue_after_worker() {
 	return 0
 }
 
@@ -324,6 +340,8 @@ fi
 
 reset_gh_state
 _claim_comment_id="claim-123"
+printf '[{"id":"claim-123","body":"DISPATCH_CLAIM nonce=test runner=runner-a"}]' >"$GH_API_COMMENTS_RESPONSE"
+printf '{"state":"OPEN","labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":true}' >"$GH_ISSUE_RESPONSE"
 _release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"
 count_abort_release=$(count_gh_comments)
 if [[ "$count_abort_release" -eq 0 ]] &&
@@ -338,6 +356,39 @@ if [[ -z "${_claim_comment_id:-}" ]]; then
 else
 	print_result "Fix C: release helper clears retained claim id" 1 "claim id still set: ${_claim_comment_id}"
 fi
+
+if grep -q 'Pre-launch rollback verified' "$LOGFILE"; then
+	print_result "Fix C: pre-launch abort verifies queued ownership rollback" 0
+else
+	print_result "Fix C: pre-launch abort verifies queued ownership rollback" 1 "log: $(cat "$LOGFILE")"
+fi
+
+reset_gh_state
+_claim_comment_id="claim-old"
+printf '[{"id":"claim-old","body":"DISPATCH_CLAIM nonce=old runner=runner-a"},{"id":"claim-new","body":"DISPATCH_CLAIM nonce=new runner=runner-a"}]' >"$GH_API_COMMENTS_RESPONSE"
+printf '{"state":"OPEN","labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":true}' >"$GH_ISSUE_RESPONSE"
+if _release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"; then
+	print_result "Fix C: older abort cannot clear a newer claim" 1 "rollback unexpectedly succeeded"
+else
+	print_result "Fix C: older abort cannot clear a newer claim" 0
+fi
+if [[ "$_claim_comment_id" == "claim-old" ]] && ! grep -q '^DELETE_COMMENT$' "$GH_COMMENT_LOG"; then
+	print_result "Fix C: uncertain rollback retains claim for stale recovery" 0
+else
+	print_result "Fix C: uncertain rollback retains claim for stale recovery" 1 "claim=${_claim_comment_id}; log=$(cat "$GH_COMMENT_LOG")"
+fi
+
+reset_gh_state
+_claim_comment_id="claim-failed-mutation"
+printf '[{"id":"claim-failed-mutation","body":"DISPATCH_CLAIM nonce=failed runner=runner-a"}]' >"$GH_API_COMMENTS_RESPONSE"
+printf '{"state":"OPEN","labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":true}' >"$GH_ISSUE_RESPONSE"
+STATUS_MUTATION_FAIL=1
+if _release_dispatch_claim_on_abort "12345" "owner/repo" "runner-a" "worker_launch_rc_2"; then
+	print_result "Fix C: failed ownership mutation blocks claim deletion" 1 "rollback unexpectedly succeeded"
+else
+	print_result "Fix C: failed ownership mutation blocks claim deletion" 0
+fi
+STATUS_MUTATION_FAIL=0
 
 # --- Fix D: dispatch comment is posted before the stagger window ---
 

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -202,6 +202,8 @@ _dlw_resolve_tier_and_model() {
 	return 0
 }
 _dlw_canary_preflight() { return 0; }
+_dlw_prebootstrap_gates() { return 0; }
+_dlw_assign_and_label() { return 0; }
 STUB_REFRESH_STATE="OPEN"
 
 gh() {
@@ -445,6 +447,32 @@ else
 fi
 
 STUB_REFRESH_STATE="OPEN"
+
+# =============================================================================
+# Test 8: assignment failure aborts before lock, worktree, and spawn
+# =============================================================================
+: >"${TMP}/lock-calls.txt"
+: >"${TMP}/precreate-calls.txt"
+: >"${TMP}/setsid-calls.txt"
+_dlw_assign_and_label() { return 1; }
+lock_issue_for_worker() { printf 'lock\n' >>"${TMP}/lock-calls.txt"; return 0; }
+_dlw_precreate_worktree() { printf 'precreate\n' >>"${TMP}/precreate-calls.txt"; return 0; }
+
+assignment_failure_rc=0
+_dispatch_launch_worker "77779" "owner/repo" "test-dispatch" "Test Issue" \
+	"testuser" "$FAKE_REPO" "test prompt" "session-key-assignment-failure" "" "{}" || assignment_failure_rc=$?
+if [[ "$assignment_failure_rc" -eq 2 ]]; then
+	pass "assignment failure returns explicit no-op rc=2"
+else
+	fail "assignment failure returns explicit no-op rc=2" "got rc=$assignment_failure_rc"
+fi
+if [[ ! -s "${TMP}/lock-calls.txt" && ! -s "${TMP}/precreate-calls.txt" && ! -s "${TMP}/setsid-calls.txt" ]]; then
+	pass "assignment failure prevents lock, worktree creation, and spawn"
+else
+	fail "assignment failure prevents lock, worktree creation, and spawn"
+fi
+_dlw_assign_and_label() { return 0; }
+lock_issue_for_worker() { return 0; }
 
 # =============================================================================
 # Test 8: _dispatch_launch_worker skips dispatch when pre-creation fails

--- a/.agents/scripts/tests/test-stale-recovery-blocked-by-recheck.sh
+++ b/.agents/scripts/tests/test-stale-recovery-blocked-by-recheck.sh
@@ -18,6 +18,8 @@ LOGFILE="${TEST_ROOT}/pulse.log"
 STATUS_LOG="${TEST_ROOT}/status.log"
 COMMENT_LOG="${TEST_ROOT}/comments.log"
 TEST_ISSUE_BODY=""
+TEST_STATUS="available"
+TEST_STATUS_MUTATION_FAIL=0
 TESTS_RUN=0
 TESTS_FAILED=0
 
@@ -48,8 +50,16 @@ reset_logs() {
 gh() {
 	local resource="${1:-}"
 	local action="${2:-}"
+	if [[ "$resource" == "api" ]]; then
+		printf '[[]]\n'
+		return 0
+	fi
 	if [[ "$resource" == "issue" && "$action" == "view" ]]; then
-		printf '%s\n' "$TEST_ISSUE_BODY"
+		if [[ "$*" == *"--json body"* ]]; then
+			printf '%s\n' "$TEST_ISSUE_BODY"
+		else
+			printf '{"state":"OPEN","labels":[{"name":"status:%s"}],"assignees":[]}\n' "$TEST_STATUS"
+		fi
 		return 0
 	fi
 	return 0
@@ -65,6 +75,8 @@ set_issue_status() {
 	local repo_slug="$2"
 	local status="$3"
 	shift 3
+	[[ "$TEST_STATUS_MUTATION_FAIL" -eq 0 ]] || return 1
+	TEST_STATUS="$status"
 	printf '%s|%s|%s|%s\n' "$issue_number" "$repo_slug" "$status" "$*" >>"$STATUS_LOG"
 	return 0
 }
@@ -84,6 +96,7 @@ source "${SCRIPT_DIR}/dispatch-dedup-stale.sh"
 test_blocked_by_dependency_keeps_issue_blocked() {
 	reset_logs
 	TEST_ISSUE_BODY="blocked-by:t1000"
+	TEST_STATUS="blocked"
 	local output=""
 	output=$(_stale_recovery_apply "123" "owner/repo" "runner-a" "no_work")
 
@@ -108,6 +121,7 @@ test_blocked_by_dependency_keeps_issue_blocked() {
 test_clear_dependency_state_requeues_available() {
 	reset_logs
 	TEST_ISSUE_BODY="No blockers here"
+	TEST_STATUS="available"
 	local output=""
 	output=$(_stale_recovery_apply "124" "owner/repo" "runner-a" "stale_timeout")
 
@@ -124,8 +138,31 @@ test_clear_dependency_state_requeues_available() {
 	return 0
 }
 
+test_failed_transition_emits_no_recovery_success() {
+	reset_logs
+	TEST_ISSUE_BODY="No blockers here"
+	TEST_STATUS="queued"
+	TEST_STATUS_MUTATION_FAIL=1
+	local output=""
+	output=$(_stale_recovery_apply "125" "owner/repo" "runner-a" "stale_timeout")
+	TEST_STATUS_MUTATION_FAIL=0
+
+	if [[ "$output" == *"STALE_RECOVERY_UNCERTAIN"* && "$output" != *"STALE_RECOVERED"* ]]; then
+		pass "failed stale transition emits uncertainty without recovery success"
+	else
+		fail "failed stale transition emits uncertainty without recovery success" "output=${output}"
+	fi
+	if [[ ! -s "$COMMENT_LOG" ]]; then
+		pass "failed stale transition posts no success comment"
+	else
+		fail "failed stale transition posts no success comment" "comments=$(tr '\n' ' ' <"$COMMENT_LOG")"
+	fi
+	return 0
+}
+
 test_blocked_by_dependency_keeps_issue_blocked
 test_clear_dependency_state_requeues_available
+test_failed_transition_emits_no_recovery_success
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1

--- a/.agents/scripts/tests/test-stale-recovery-escalation.sh
+++ b/.agents/scripts/tests/test-stale-recovery-escalation.sh
@@ -107,8 +107,12 @@ if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
 	exit 0
 fi
 
-# gh issue edit, gh issue comment — silent success (write operations)
+# gh issue view returns the verified post-transition state; edits/comments
+# remain silent successes.
 if [[ "\$1" == "issue" ]]; then
+	if [[ "\$2" == "view" && "\$*" == *"--json state,labels,assignees"* ]]; then
+		printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:available"}],"assignees":[]}'
+	fi
 	exit 0
 fi
 

--- a/.agents/scripts/tests/test-worktree-fresh-base.sh
+++ b/.agents/scripts/tests/test-worktree-fresh-base.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER="${SCRIPT_DIR}/../worktree-helper.sh"
+REAL_GIT=$(command -v git)
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
 
@@ -35,6 +36,14 @@ git -C "$UPDATER" commit -q -m remote-tip
 git -C "$UPDATER" push -q origin main
 REMOTE_SHA=$(git -C "$UPDATER" rev-parse HEAD)
 
+# Optional integration mode: prepend the repository Git shim after fixture
+# setup so worktree creation exercises the canonical guard without blocking
+# the fixture's intentional canonical branch/bootstrap mutations.
+if [[ -n "${AIDEVOPS_TEST_GIT_SHIM:-}" ]]; then
+	PATH="$(dirname "$AIDEVOPS_TEST_GIT_SHIM"):${PATH}"
+	export PATH
+fi
+
 (cd "$CANONICAL" && "$HELPER" add test/fresh-base >/dev/null)
 FRESH_PATH="${WORKTREES}/canonical-test-fresh-base"
 [[ "$(git -C "$FRESH_PATH" rev-parse HEAD)" == "$REMOTE_SHA" ]] || {
@@ -42,8 +51,13 @@ FRESH_PATH="${WORKTREES}/canonical-test-fresh-base"
 	exit 1
 }
 printf 'PASS worktree starts at freshly fetched origin/main\n'
+if compgen -G "${WORKTREES}/.canonical-fetch-*" >/dev/null; then
+	printf 'FAIL temporary fetch worktree was not removed\n'
+	exit 1
+fi
+printf 'PASS canonical-guard bootstrap fetch worktree is removed\n'
 
-git -C "$CANONICAL" remote set-url origin "${ROOT}/missing.git"
+"$REAL_GIT" -C "$CANONICAL" remote set-url origin "${ROOT}/missing.git"
 if (cd "$CANONICAL" && "$HELPER" add test/fetch-failure >/dev/null 2>&1); then
 	printf 'FAIL worktree creation accepted an unrefreshable remote base\n'
 	exit 1

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -661,6 +661,55 @@ _parse_cmd_add_args() {
 	return 0
 }
 
+# Refresh an origin branch from linked-worktree context so the canonical Git
+# guard remains intact. If no linked worktree exists yet, create a short-lived
+# detached bootstrap worktree from the existing remote-tracking ref, fetch from
+# there, then remove it from that linked context.
+# Args: branch name
+#######################################
+_worktree_refresh_origin_branch() {
+	local branch="$1"
+	local fetch_cwd=""
+	local current_root=""
+	local git_dir="" common_dir=""
+	local bootstrap_path=""
+
+	current_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+	git_dir=$(git rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 1
+	common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	if [[ "$git_dir" != "$common_dir" ]]; then
+		fetch_cwd="$current_root"
+	else
+		local worktree_path=""
+		while IFS= read -r worktree_path; do
+			[[ -n "$worktree_path" && "$worktree_path" != "$current_root" && -d "$worktree_path" ]] || continue
+			fetch_cwd="$worktree_path"
+			break
+		done < <(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
+	fi
+
+	if [[ -z "$fetch_cwd" ]]; then
+		local base_dir="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"
+		local repo_name=""
+		repo_name=$(basename "$current_root")
+		mkdir -p "$base_dir" || return 1
+		bootstrap_path="${base_dir}/.${repo_name}-fetch-$$"
+		if ! git worktree add --detach "$bootstrap_path" "refs/remotes/origin/${branch}" >/dev/null 2>&1; then
+			return 1
+		fi
+		fetch_cwd="$bootstrap_path"
+	fi
+
+	local fetch_rc=0
+	git -C "$fetch_cwd" fetch --no-tags --quiet origin \
+		"+refs/heads/${branch}:refs/remotes/origin/${branch}" || fetch_rc=$?
+	if [[ -n "$bootstrap_path" ]]; then
+		git -C "$fetch_cwd" worktree remove --force "$bootstrap_path" >/dev/null 2>&1 || true
+	fi
+	return "$fetch_rc"
+}
+
+#######################################
 # Resolve the base ref for a new worktree branch (t2802).
 # Precedence:
 #   1. Explicit --base <ref> (or AIDEVOPS_WORKTREE_BASE env var) — caller intent wins.
@@ -679,7 +728,8 @@ _parse_cmd_add_args() {
 #   $1 - explicit_base: value of --base (may be empty)
 # Outputs:
 #   Resolved ref on stdout, empty string if no safe base could be resolved.
-# Returns: always 0.
+# Returns: 0 on resolution/no-origin fallback, 1 when an explicit refresh fails.
+#######################################
 _resolve_worktree_base_ref() {
 	local explicit_base="$1"
 	local env_base="${AIDEVOPS_WORKTREE_BASE:-}"
@@ -690,8 +740,7 @@ _resolve_worktree_base_ref() {
 	if [[ -n "$requested_base" ]]; then
 		if [[ "$requested_base" == origin/* ]]; then
 			local requested_branch="${requested_base#origin/}"
-			if ! git fetch --no-tags --quiet origin \
-				"+refs/heads/${requested_branch}:refs/remotes/origin/${requested_branch}"; then
+			if ! _worktree_refresh_origin_branch "$requested_branch"; then
 				echo "Error: could not refresh ${requested_base}; refusing stale explicit base" >&2
 				return 1
 			fi
@@ -712,8 +761,7 @@ _resolve_worktree_base_ref() {
 	default_branch=$(get_default_branch 2>/dev/null) || default_branch=""
 	if [[ -n "$default_branch" ]]; then
 		if git remote get-url origin >/dev/null 2>&1; then
-			if ! git fetch --no-tags --quiet origin \
-				"+refs/heads/${default_branch}:refs/remotes/origin/${default_branch}"; then
+			if ! _worktree_refresh_origin_branch "$default_branch"; then
 				echo "Error: could not refresh origin/${default_branch}; refusing stale worktree base" >&2
 				return 1
 			fi


### PR DESCRIPTION
## Summary

- refresh worktree bases from linked-worktree context without weakening the canonical Git guard
- fail closed when queued ownership cannot be applied
- roll back only the exact current pre-launch claim, then verify labels, assignee, and lock state before deleting it
- make launch and stale recovery suppress success receipts when mutation or verification is uncertain

## Testing

- `.agents/scripts/linters-local.sh`
- focused dispatch lifecycle and pre-creation suites
- stale-recovery and atomic-lease suites
- canonical-guard integration test with a bootstrap linked worktree
- ShellCheck on all changed shell files

## Runtime Testing

Runtime-verified with the repository Git shim: a canonical fixture fetched a newer remote tip through a temporary detached linked worktree, created the intended worktree at that exact tip, removed the bootstrap worktree, and failed closed when the remote became unavailable.

## Key decisions

- Retain the dispatch claim whenever rollback identity or post-mutation verification is uncertain, allowing conservative stale recovery instead of emitting false terminal evidence.
- Preserve the canonical Git guard rather than exempting `git fetch`; remote-tracking refresh executes from linked-worktree context.

Resolves #27332
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 28m and 405,269 tokens on this with the user in an interactive session.