### PR TITLE
t18108: fix GPT 5.6 interactive compaction threshold

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -16,6 +16,7 @@ import { checkOpenCodeVersionDriftAsync } from "./version-tracking.mjs";
 import {
   CLAUDE_MODEL_LIMITS,
   GPT56_CONTEXT_DEFAULT,
+  GPT56_INPUT_DEFAULT,
   GPT56_MODEL_IDS,
   GPT56_OUTPUT_DEFAULT,
 } from "./model-limits.mjs";
@@ -161,6 +162,7 @@ export function registerGpt56ContextLimits(config) {
         output: GPT56_OUTPUT_DEFAULT,
         ...existing.limit,
         context: GPT56_CONTEXT_DEFAULT,
+        input: GPT56_INPUT_DEFAULT,
       },
     };
   }

--- a/.agents/plugins/opencode-aidevops/model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/model-limits.mjs
@@ -26,10 +26,17 @@ export const OPUS_47_CONTEXT_DEFAULT = 250000;
 export const OPUS_47_CONTEXT_MAX = 1000000;
 
 /**
- * Advertised GPT-5.6 context used by OpenCode. Its 80% compaction threshold
- * therefore fires near 240K, before OpenAI's long-context pricing boundary.
+ * Advertised GPT-5.6 context used by OpenCode.
  */
 export const GPT56_CONTEXT_DEFAULT = 300000;
+
+/**
+ * GPT-5.6 input budget used by OpenCode. OpenCode compacts at
+ * `limit.input - compaction.reserved`; its default 20K reserve therefore
+ * triggers compaction at 240K. Setting context alone does not control the
+ * current compaction threshold when built-in metadata supplies input=380K.
+ */
+export const GPT56_INPUT_DEFAULT = 260000;
 
 /** Maximum GPT-5.6 response size advertised by OpenCode's model registry. */
 export const GPT56_OUTPUT_DEFAULT = 128000;

--- a/.agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-gpt56-context-config.mjs
@@ -33,7 +33,7 @@ function settingsFile(value) {
   return file;
 }
 
-test("GPT-5.6 cap defaults on and applies 300K without losing model fields", () => {
+test("GPT-5.6 cap defaults on and applies a 240K compaction threshold without losing model fields", () => {
   settingsFile(undefined);
   const config = {
     provider: { openai: { models: { "gpt-5.6-sol": { name: "Sol" } } } },
@@ -42,20 +42,24 @@ test("GPT-5.6 cap defaults on and applies 300K without losing model fields", () 
   assert.equal(registerGpt56ContextLimits(config), 4);
   assert.equal(config.provider.openai.models["gpt-5.6-sol"].name, "Sol");
   assert.equal(config.provider.openai.models["gpt-5.6-sol"].limit.context, 300000);
+  assert.equal(config.provider.openai.models["gpt-5.6-sol"].limit.input, 260000);
   assert.equal(config.provider.openai.models["gpt-5.6-sol"].limit.output, 128000);
   assert.equal(config.provider.openai.models["gpt-5.6-terra"].limit.context, 300000);
+  assert.equal(config.provider.openai.models["gpt-5.6-terra"].limit.input, 260000);
   assert.equal(config.provider.openai.models["gpt-5.6-terra"].limit.output, 128000);
+  assert.equal(config.provider.openai.models["gpt-5.6-sol"].limit.input - 20000, 240000);
 });
 
-test("GPT-5.6 cap preserves an explicit output limit", () => {
+test("GPT-5.6 cap preserves an explicit output limit but owns context and input budgets", () => {
   settingsFile(undefined);
   const config = {
-    provider: { openai: { models: { "gpt-5.6-sol": { limit: { output: 64000 } } } } },
+    provider: { openai: { models: { "gpt-5.6-sol": { limit: { context: 400000, input: 380000, output: 64000 } } } } },
   };
   registerGpt56ContextLimits(config);
   assert.deepEqual(config.provider.openai.models["gpt-5.6-sol"].limit, {
     output: 64000,
     context: 300000,
+    input: 260000,
   });
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
@@ -21,13 +21,16 @@ import {
   OPUS_47_CONTEXT_MAX,
   CLAUDE_MODEL_LIMITS,
   GPT56_CONTEXT_DEFAULT,
+  GPT56_INPUT_DEFAULT,
   GPT56_MODEL_IDS,
   GPT56_OUTPUT_DEFAULT,
 } from "../model-limits.mjs";
 
 test("GPT-5.6 context metadata targets 300K for 240K auto-compaction", () => {
   assert.equal(GPT56_CONTEXT_DEFAULT, 300000);
+  assert.equal(GPT56_INPUT_DEFAULT, 260000);
   assert.equal(GPT56_OUTPUT_DEFAULT, 128000);
+  assert.equal(GPT56_INPUT_DEFAULT - 20000, 240000);
   assert.deepEqual(GPT56_MODEL_IDS, [
     "gpt-5.6-sol",
     "gpt-5.6-sol-pro",

--- a/TODO.md
+++ b/TODO.md
@@ -1137,6 +1137,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18096 Treat canonical lint policy deferrals as safe skips #auto-dispatch #bug ref:GH#27139
 
+- [ ] t18108 Fix GPT-5.6 interactive auto-compaction threshold #bug ref:GH#27335
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/TODO.md
+++ b/TODO.md
@@ -1137,8 +1137,6 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18096 Treat canonical lint policy deferrals as safe skips #auto-dispatch #bug ref:GH#27139
 
-- [ ] t18108 Fix GPT-5.6 interactive auto-compaction threshold #bug ref:GH#27335
-
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Set an authoritative 260K GPT-5.6 input budget so OpenCode compacts at 240K after its 20K reserve, across every GPT-5.6 variant.

## Files Changed

- `.agents/plugins/opencode-aidevops/model-limits.mjs`
- `.agents/plugins/opencode-aidevops/config-hook.mjs`
- GPT-5.6 model-limit tests

## Runtime Testing

- 26 targeted tests passed
- all 353 OpenCode plugin tests passed
- hot-deployed metadata reports `context=300000 input=260000 output=128000 threshold=240000`
- full repository lint ran; only pre-existing repository-wide debt failed

Resolves #27335

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh)
