### PR TITLE
GH#27309: govern memory promotion by verified outcomes

### DIFF
--- a/.agents/reference/memory.md
+++ b/.agents/reference/memory.md
@@ -86,13 +86,13 @@ On store: checks exact and near-duplicates (normalized case/punctuation/whitespa
 
 ## Canonical Observations
 
-`observations` is the authoritative additive envelope. It records stable observation, source, and session IDs; kind and owner/subject; user/project/organization/framework scope; explicit versus inferred state; confidence; sensitivity and consent; effective/review/expiry time; destination and lifecycle status. `observation_sources` preserves evidence and provenance with one unique source record per legacy or native source, so replay cannot create independent evidence. `observation_relations` records supersession, debunking, correction, revocation, extension, and derivation. `observation_outcomes` records retrieval usefulness, graduation, and later outcomes.
+`observations` is the authoritative additive envelope. It records stable observation, source, and session IDs; kind and owner/subject; user/project/organization/framework scope; explicit versus inferred state; confidence; sensitivity and consent; effective/review/expiry time; destination and lifecycle status. `observation_sources` preserves evidence and provenance with one unique source record per legacy or native source, so replay cannot create independent evidence. `observation_relations` records supersession, debunking, correction, revocation, extension, and derivation. `observation_outcomes` records retrieval usefulness and operational/review outcomes. Qualifying outcomes require an `outcome_verifications` row naming an independent verifier, an attributable non-learning evidence source, and verification provenance. `observation_promotions` attributes generated guidance to its source and verified outcome, deduplicates each destination, and records correction or revocation without deleting audit evidence.
 
 Existing `learnings` remain the FTS retrieval projection. Database initialization idempotently backfills safely derivable learning, entity-profile, capability-gap, truth/relation, access/usefulness, and graduation history using deterministic IDs such as `obs_learning_<legacy-id>` and `src_learning_<legacy-id>`.
 
 ## Auto-Pruning
 
-Runs on every `store` (at most once per 24h). Removes entries older than 90 days with zero access; frequently accessed memories preserved regardless of age.
+Runs on every `store` (at most once per 24h). The `learnings` FTS retrieval projection is bounded by hard creation age, row count (`AIDEVOPS_MEMORY_MAX_COUNT`, default 10,000), and logical row bytes (`AIDEVOPS_MEMORY_MAX_BYTES`, default 50 MiB). Access cannot exempt a row from the age bound. Logical bytes are the UTF-8 byte lengths of every projected field: `id`, `session_id`, `content`, `type`, `tags`, `confidence`, `created_at`, `event_date`, `project_path`, and `source`. This is not the SQLite file size or canonical audit-table size. Pruning preserves canonical observations, sources, outcomes, relations, verification, and promotion records. Use `--max-count` and `--max-bytes` for explicit maintenance limits.
 
 ## Semantic Search (Opt-in)
 
@@ -119,7 +119,7 @@ Handled by cross-session memory and pulse supervisor outcome observation (Step 2
 
 ## Memory Graduation
 
-Graduate validated, live, unsuperseded local memories (`confidence = "high"` OR `access_count >= 3`) into shared docs. `USER_PREFERENCE` memories remain in their user/project scope and never auto-graduate into all-user guidance. Appends to `.agents/aidevops/graduated-learnings.md`. **Slash command**: `/graduate-memories` or `/graduate-memories --dry-run`. See CLI Reference for commands.
+Graduate live, unsuperseded local memories only after an independently verified `test_passed`, `pr_merged`, `operational_verified`, or `verified_reuse` outcome. The outcome command requires verifier identity, a same-observation `test_result`, `pull_request`, `operation`, or `review` source, and verification provenance; the original learning source and self assertions do not qualify. Access count ranks eligible candidates but never qualifies one. Promotion also requires an allowed privacy classification, consent that is not denied, and no later rejection/correction/privacy escape. Generated destination blocks have exact begin/end markers: revocation removes only that block, and correction additionally records a `corrects` relation while retaining audit evidence.
 
 ## Memory Audit Pulse
 
@@ -191,6 +191,7 @@ memory-helper.sh dedup --exact-only
 memory-helper.sh prune --older-than-days 60 --dry-run
 memory-helper.sh prune --older-than-days 60
 memory-helper.sh prune --older-than-days 180 --include-accessed
+memory-helper.sh prune --older-than-days 90 --max-count 10000 --max-bytes 52428800
 memory-helper.sh log   # Recent auto-captures
 
 # Export
@@ -209,6 +210,9 @@ self-evolution-helper.sh pulse-scan --auto-todo-threshold 3
 memory-graduate-helper.sh candidates
 memory-graduate-helper.sh graduate --dry-run
 memory-graduate-helper.sh graduate
+memory-graduate-helper.sh outcome mem_xxx test_passed --verifier ci-run-123 --source-id src_test_123 --provenance ci:test-suite
+memory-graduate-helper.sh revoke mem_xxx --reason "later evidence disproved guidance"
+memory-graduate-helper.sh revoke mem_old --corrected-by mem_new --reason "replacement verified"
 
 # Embeddings
 memory-embeddings-helper.sh setup --provider local

--- a/.agents/scripts/memory-graduate-helper.sh
+++ b/.agents/scripts/memory-graduate-helper.sh
@@ -8,7 +8,7 @@
 # into the shared codebase (.agents/) so all users benefit from learnings.
 #
 # Graduation criteria (configurable):
-#   - High confidence OR frequently accessed (access_count >= threshold)
+#   - At least one independently verified positive outcome
 #   - Live, unsuperseded, and not a personal USER_PREFERENCE
 #   - Not already graduated
 #   - Content is actionable (not just session metadata)
@@ -16,6 +16,8 @@
 # Usage:
 #   memory-graduate-helper.sh candidates [--limit N] [--min-access N]
 #   memory-graduate-helper.sh graduate [--dry-run] [--limit N] [--min-access N]
+#   memory-graduate-helper.sh outcome <memory-id> <kind> --verifier ID --source-id ID --provenance TEXT
+#   memory-graduate-helper.sh revoke <memory-id> [--corrected-by ID] --reason TEXT
 #   memory-graduate-helper.sh status
 #   memory-graduate-helper.sh help
 #
@@ -39,6 +41,7 @@ readonly DEFAULT_LIMIT=20
 
 # Target file for graduated learnings (relative to repo root)
 readonly GRADUATED_FILE_NAME="graduated-learnings.md"
+readonly GRADUATED_DESTINATION=".agents/aidevops/graduated-learnings.md"
 
 # Logging: uses shared log_* from shared-constants.sh
 
@@ -60,6 +63,10 @@ find_repo_root() {
 # Resolve the graduated learnings file path
 #######################################
 graduated_file_path() {
+	if [[ -n "${AIDEVOPS_GRADUATED_FILE:-}" ]]; then
+		printf '%s\n' "$AIDEVOPS_GRADUATED_FILE"
+		return 0
+	fi
 	local repo_root
 	repo_root=$(find_repo_root)
 	if [[ -z "$repo_root" ]]; then
@@ -231,21 +238,45 @@ SELECT
     l.confidence,
     l.created_at,
     COALESCE(a.access_count, 0) as access_count,
-    COALESCE(a.last_accessed_at, '') as last_accessed_at
+    COALESCE(a.last_accessed_at, '') as last_accessed_at,
+    s.source_id,
+    verified.outcome_id,
+    verified.outcome_kind
 FROM learnings l
 JOIN observations o ON o.observation_id = 'obs_learning_' || l.id
 LEFT JOIN learning_access a ON l.id = a.id
-WHERE (
-    l.confidence = 'high'
-    OR COALESCE(a.access_count, 0) >= $min_access
+JOIN observation_sources s ON s.source_id = (
+    SELECT source_id FROM observation_sources source_pick
+    WHERE source_pick.observation_id = o.observation_id
+      AND NULLIF(TRIM(source_pick.evidence), '') IS NOT NULL
+    ORDER BY captured_at DESC, source_id DESC LIMIT 1
 )
+JOIN observation_outcomes verified ON verified.outcome_id = (
+    SELECT outcome_id FROM observation_outcomes outcome_pick
+    WHERE outcome_pick.observation_id = o.observation_id
+      AND outcome_pick.outcome_kind IN ('test_passed', 'pr_merged', 'operational_verified', 'verified_reuse')
+      AND COALESCE(outcome_pick.outcome_value, 1) > 0
+    ORDER BY recorded_at DESC, outcome_id DESC LIMIT 1
+)
+JOIN outcome_verifications verification ON verification.outcome_id = verified.outcome_id
+WHERE 1=1
 AND l.type != 'USER_PREFERENCE'
 AND o.status = 'active'
 AND (o.expires_at IS NULL OR o.expires_at > datetime('now'))
 AND o.sensitivity IN ('public', 'internal')
+AND o.consent != 'denied'
 AND (a.graduated_at IS NULL OR a.graduated_at = '')
+AND NOT EXISTS (
+    SELECT 1 FROM observation_outcomes negative
+    WHERE negative.observation_id = o.observation_id
+      AND negative.outcome_kind IN ('correction', 'reverted', 'pr_closed', 'rejected', 'stale_escape', 'privacy_escape')
+      AND negative.recorded_at >= verified.recorded_at
+)
+AND NOT EXISTS (
+    SELECT 1 FROM observation_promotions p
+    WHERE p.observation_id = o.observation_id AND p.destination = '$GRADUATED_DESTINATION'
+)
 ORDER BY
-    CASE WHEN l.confidence = 'high' THEN 0 ELSE 1 END,
     COALESCE(a.access_count, 0) DESC,
     l.created_at ASC;
 EOF
@@ -372,7 +403,7 @@ cmd_candidates() {
 
 	if [[ -z "$results" || "$results" == "[]" ]]; then
 		log_info "No graduation candidates found."
-		log_info "Memories qualify when live and shareable, with confidence=high OR access_count >= $min_access"
+		log_info "Memories qualify when live, scoped, shareable, and backed by a verified outcome; access count only ranks candidates"
 		return 0
 	fi
 
@@ -400,12 +431,13 @@ _collect_entries() {
 	local skipped_count=0
 
 	while IFS= read -r entry; do
-		local id type content confidence access_count
+		local id type content confidence access_count outcome_kind
 		id=$(echo "$entry" | jq -r '.id')
 		type=$(echo "$entry" | jq -r '.type')
 		content=$(echo "$entry" | jq -r '.content')
 		confidence=$(echo "$entry" | jq -r '.confidence')
 		access_count=$(echo "$entry" | jq -r '.access_count')
+		outcome_kind=$(echo "$entry" | jq -r '.outcome_kind')
 
 		# Always record the id (actionable or not — both get marked graduated)
 		echo "$id" >>"$tmp_dir/ids"
@@ -424,8 +456,10 @@ _collect_entries() {
 
 		# Append to category file
 		{
+			echo "<!-- aidevops:promotion:$id:begin -->"
 			echo "- **[$type]** $content"
-			echo "  *(confidence: $confidence, validated: ${access_count}x)*"
+			echo "  *(confidence: $confidence, verified outcome: $outcome_kind, recalled: ${access_count}x)*"
+			echo "<!-- aidevops:promotion:$id:end -->"
 			echo ""
 		} >>"$tmp_dir/${safe_category}.entries"
 
@@ -533,10 +567,9 @@ tools:
 Validated, shareable learnings promoted from local memory databases into shared documentation.
 Personal preferences remain scoped to their user/project profiles and never graduate automatically.
 
-**How memories graduate**: Live, unsuperseded, non-personal memories qualify when
-they reach high confidence or are accessed frequently (3+ times). The
-`memory-graduate-helper.sh` script identifies candidates and appends them here.
-Each graduation batch is timestamped.
+**How memories graduate**: Live, unsuperseded, non-personal memories qualify only
+after an independently attributable verified outcome. Recall count affects rank,
+not eligibility. Each generated block is marked for precise correction or revocation.
 
 **Categories**:
 
@@ -716,9 +749,218 @@ mark_graduated() {
 INSERT INTO learning_access (id, last_accessed_at, access_count, graduated_at)
 VALUES ('$escaped_id', datetime('now'), 0, '$timestamp')
 ON CONFLICT(id) DO UPDATE SET graduated_at = '$timestamp';
+INSERT OR IGNORE INTO observation_promotions (
+    promotion_id, observation_id, source_id, outcome_id, destination, status, promoted_at
+)
+SELECT 'promotion_' || l.id, 'obs_learning_' || l.id, s.source_id, verified.outcome_id,
+       '$GRADUATED_DESTINATION', 'active', '$timestamp'
+FROM learnings l
+JOIN observation_sources s ON s.source_id = (
+    SELECT source_id FROM observation_sources WHERE observation_id = 'obs_learning_' || l.id
+    AND NULLIF(TRIM(evidence), '') IS NOT NULL ORDER BY captured_at DESC, source_id DESC LIMIT 1
+)
+JOIN observation_outcomes verified ON verified.outcome_id = (
+    SELECT outcome_id FROM observation_outcomes WHERE observation_id = 'obs_learning_' || l.id
+    AND outcome_kind IN ('test_passed', 'pr_merged', 'operational_verified', 'verified_reuse')
+    AND COALESCE(outcome_value, 1) > 0 ORDER BY recorded_at DESC, outcome_id DESC LIMIT 1
+)
+JOIN outcome_verifications verification ON verification.outcome_id = verified.outcome_id
+WHERE l.id = '$escaped_id';
 EOF
 	done
 
+	return 0
+}
+
+record_outcome() {
+	local memory_id="$1"
+	local outcome_kind="$2"
+	local outcome_value="$3"
+	local details="$4"
+	local verifier_id="${5:-}"
+	local evidence_source_id="${6:-}"
+	local verification_provenance="${7:-}"
+	local escaped_id="${memory_id//"'"/"''"}"
+	local escaped_kind="${outcome_kind//"'"/"''"}"
+	local escaped_details="${details//"'"/"''"}"
+	local exists=""
+	exists=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM observations WHERE observation_id = 'obs_learning_$escaped_id';")
+	if [[ "$exists" != "1" ]]; then
+		log_error "Memory observation not found: $memory_id"
+		return 1
+	fi
+	db "$MEMORY_DB" "INSERT OR IGNORE INTO observation_outcomes (outcome_id, observation_id, outcome_kind, outcome_value, details, recorded_at) VALUES ('out_${escaped_kind}_${escaped_id}_' || strftime('%Y%m%d%H%M%f','now'), 'obs_learning_$escaped_id', '$escaped_kind', $outcome_value, '$escaped_details', strftime('%Y-%m-%dT%H:%M:%fZ','now'));"
+	if [[ -n "$verifier_id" ]]; then
+		local escaped_verifier="${verifier_id//"'"/"''"}"
+		local escaped_source="${evidence_source_id//"'"/"''"}"
+		local escaped_provenance="${verification_provenance//"'"/"''"}"
+		db "$MEMORY_DB" "INSERT OR IGNORE INTO outcome_verifications SELECT outcome_id, '$escaped_verifier', '$escaped_source', '$escaped_provenance', recorded_at FROM observation_outcomes WHERE observation_id='obs_learning_$escaped_id' AND outcome_kind='$escaped_kind' ORDER BY recorded_at DESC, outcome_id DESC LIMIT 1;"
+	fi
+	return 0
+}
+
+cmd_outcome() {
+	local memory_id="${1:-}"
+	local outcome_kind="${2:-}"
+	local outcome_value="1"
+	local details=""
+	local verifier_id=""
+	local evidence_source_id=""
+	local verification_provenance=""
+	[[ -n "$memory_id" && -n "$outcome_kind" ]] || {
+		log_error "Usage: outcome <memory-id> <kind> [--value N] [--details TEXT]"
+		return 1
+	}
+	shift 2
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--value)
+			outcome_value="$2"
+			shift 2
+			;;
+		--details)
+			details="$2"
+			shift 2
+			;;
+		--verifier)
+			verifier_id="$2"
+			shift 2
+			;;
+		--source-id)
+			evidence_source_id="$2"
+			shift 2
+			;;
+		--provenance)
+			verification_provenance="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+	[[ "$outcome_value" =~ ^-?[0-9]+([.][0-9]+)?$ ]] || {
+		log_error "--value must be numeric"
+		return 1
+	}
+	ensure_schema || return 1
+	case "$outcome_kind" in
+	test_passed | pr_merged | operational_verified | verified_reuse)
+		if [[ -z "$verifier_id" || -z "$evidence_source_id" || -z "$verification_provenance" ]]; then
+			log_error "Qualifying outcomes require --verifier, --source-id, and --provenance"
+			return 1
+		fi
+		if [[ "$verifier_id" == "self" ]]; then
+			log_error "Qualifying outcomes reject self-asserted verifier identity"
+			return 1
+		fi
+		local escaped_id="${memory_id//"'"/"''"}"
+		local escaped_source="${evidence_source_id//"'"/"''"}"
+		local escaped_verifier="${verifier_id//"'"/"''"}"
+		local attributable=""
+		attributable=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM observation_sources s JOIN observations o ON o.observation_id=s.observation_id WHERE s.source_id='$escaped_source' AND s.observation_id='obs_learning_$escaped_id' AND s.source_kind IN ('test_result','pull_request','operation','review') AND NULLIF(TRIM(s.evidence),'') IS NOT NULL AND '$escaped_verifier' NOT IN (COALESCE(o.owner_id,''), COALESCE(o.session_id,''));")
+		if [[ "$attributable" != "1" ]]; then
+			log_error "Qualifying outcome evidence must be an independent test_result, pull_request, operation, or review source for this observation"
+			return 1
+		fi
+		;;
+	esac
+	record_outcome "$memory_id" "$outcome_kind" "$outcome_value" "$details" "$verifier_id" "$evidence_source_id" "$verification_provenance"
+	log_success "Outcome recorded: $memory_id $outcome_kind"
+	return 0
+}
+
+remove_promoted_block() {
+	local target_file="$1"
+	local memory_id="$2"
+	local begin_marker="<!-- aidevops:promotion:$memory_id:begin -->"
+	local end_marker="<!-- aidevops:promotion:$memory_id:end -->"
+	local tmp_file=""
+	local skipping=false
+	tmp_file=$(mktemp)
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" == "$begin_marker" ]]; then
+			skipping=true
+			continue
+		fi
+		if [[ "$skipping" == true ]]; then
+			if [[ "$line" == "$end_marker" ]]; then
+				skipping=false
+			fi
+			continue
+		fi
+		printf '%s\n' "$line" >>"$tmp_file"
+	done <"$target_file"
+	if [[ "$skipping" == true ]]; then
+		rm -f "$tmp_file"
+		log_error "Promotion block is missing its end marker: $memory_id"
+		return 1
+	fi
+	mv "$tmp_file" "$target_file"
+	return 0
+}
+
+cmd_revoke() {
+	local memory_id="${1:-}"
+	local reason=""
+	local corrected_by=""
+	[[ -n "$memory_id" ]] || {
+		log_error "Usage: revoke <memory-id> [--corrected-by ID] --reason TEXT"
+		return 1
+	}
+	shift
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--reason)
+			reason="$2"
+			shift 2
+			;;
+		--corrected-by)
+			corrected_by="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+	[[ -n "$reason" ]] || {
+		log_error "Revocation requires --reason"
+		return 1
+	}
+	ensure_schema || return 1
+	local escaped_id="${memory_id//"'"/"''"}"
+	local escaped_reason="${reason//"'"/"''"}"
+	local new_status="revoked"
+	local outcome_kind="reverted"
+	if [[ -n "$corrected_by" ]]; then
+		new_status="corrected"
+		outcome_kind="correction"
+		local escaped_corrected_by="${corrected_by//"'"/"''"}"
+		local correction_exists=""
+		correction_exists=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM observations WHERE observation_id='obs_learning_$escaped_corrected_by' AND status='active';")
+		if [[ "$correction_exists" != "1" ]]; then
+			log_error "Correction observation not found or inactive: $corrected_by"
+			return 1
+		fi
+	fi
+	local current_status=""
+	current_status=$(db "$MEMORY_DB" "SELECT status FROM observation_promotions WHERE observation_id='obs_learning_$escaped_id' AND destination='$GRADUATED_DESTINATION';")
+	if [[ -z "$current_status" ]]; then
+		log_error "Active promotion not found: $memory_id"
+		return 1
+	fi
+	local target_file=""
+	target_file=$(graduated_file_path) || return 1
+	if [[ -f "$target_file" ]]; then
+		remove_promoted_block "$target_file" "$memory_id" || return 1
+	fi
+	if [[ "$current_status" == "$new_status" ]]; then
+		log_info "Promotion already $new_status: $memory_id"
+		return 0
+	fi
+	db "$MEMORY_DB" "UPDATE observation_promotions SET status='$new_status', changed_at=strftime('%Y-%m-%dT%H:%M:%fZ','now'), change_reason='$escaped_reason' WHERE observation_id='obs_learning_$escaped_id' AND status='active'; UPDATE observations SET status='$new_status' WHERE observation_id='obs_learning_$escaped_id';"
+	record_outcome "$memory_id" "$outcome_kind" "-1" "$reason"
+	if [[ -n "$corrected_by" ]]; then
+		db "$MEMORY_DB" "INSERT OR IGNORE INTO observation_relations VALUES ('rel_correction_${escaped_corrected_by}_${escaped_id}', 'obs_learning_$escaped_corrected_by', 'obs_learning_$escaped_id', 'corrects', 'src_learning_$escaped_corrected_by', strftime('%Y-%m-%dT%H:%M:%fZ','now'));"
+	fi
+	log_success "Promotion $new_status: $memory_id"
 	return 0
 }
 
@@ -744,53 +986,9 @@ cmd_status() {
 		2>/dev/null || echo "0")
 	echo "Already graduated: $graduated"
 
-	# Candidates (high confidence)
-	local high_conf
-	high_conf=$(
-		db "$MEMORY_DB" <<EOF
-SELECT COUNT(*) FROM learnings l
-LEFT JOIN learning_access a ON l.id = a.id
-WHERE l.confidence = 'high'
-AND l.type != 'USER_PREFERENCE'
-AND COALESCE((SELECT status FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1), 'live') NOT IN ('debunked', 'retracted')
-AND NOT EXISTS (SELECT 1 FROM learning_relations superseded_by WHERE superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates')
-AND (a.graduated_at IS NULL OR a.graduated_at = '');
-EOF
-	)
-	echo "High confidence (pending): ${high_conf:-0}"
-
-	# Candidates (frequently accessed)
-	local freq_accessed
-	freq_accessed=$(
-		db "$MEMORY_DB" <<EOF
-SELECT COUNT(*) FROM learnings l
-LEFT JOIN learning_access a ON l.id = a.id
-WHERE COALESCE(a.access_count, 0) >= $DEFAULT_MIN_ACCESS
-AND l.type != 'USER_PREFERENCE'
-AND COALESCE((SELECT status FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1), 'live') NOT IN ('debunked', 'retracted')
-AND NOT EXISTS (SELECT 1 FROM learning_relations superseded_by WHERE superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates')
-AND (a.graduated_at IS NULL OR a.graduated_at = '');
-EOF
-	)
-	echo "Frequently accessed (pending): ${freq_accessed:-0}"
-
-	# Total candidates (union)
 	local total_candidates
-	total_candidates=$(
-		db "$MEMORY_DB" <<EOF
-SELECT COUNT(*) FROM learnings l
-LEFT JOIN learning_access a ON l.id = a.id
-WHERE (
-    l.confidence = 'high'
-    OR COALESCE(a.access_count, 0) >= $DEFAULT_MIN_ACCESS
-)
-AND l.type != 'USER_PREFERENCE'
-AND COALESCE((SELECT status FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1), 'live') NOT IN ('debunked', 'retracted')
-AND NOT EXISTS (SELECT 1 FROM learning_relations superseded_by WHERE superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates')
-AND (a.graduated_at IS NULL OR a.graduated_at = '');
-EOF
-	)
-	echo "Total candidates: ${total_candidates:-0}"
+	total_candidates=$(_query_candidates_json "$DEFAULT_MIN_ACCESS" 100000 | jq 'length')
+	echo "Verified outcome candidates: ${total_candidates:-0}"
 
 	# Check if graduated-learnings.md exists
 	local target_file
@@ -826,27 +1024,27 @@ USAGE:
 COMMANDS:
     candidates  List memories eligible for graduation
     graduate    Promote eligible memories to shared docs
+    outcome     Record an attributable operational or review outcome
+    revoke      Revoke or correct generated shared guidance
     status      Show graduation statistics
     help        Show this help
 
 CANDIDATE OPTIONS:
     --limit N       Max candidates to show (default: 20)
-    --min-access N  Min access count threshold (default: 3)
     --json          Output as JSON
 
 GRADUATE OPTIONS:
     --dry-run       Preview without writing changes
     --limit N       Max memories to graduate (default: 20)
-    --min-access N  Min access count threshold (default: 3)
 
 GRADUATION CRITERIA:
-    A memory qualifies for graduation when ANY of:
-    - confidence = "high" (manually marked as high-value)
-    - access_count >= 3 (frequently recalled, proving usefulness)
-
-    AND:
+    A memory qualifies when:
+    - A test_passed, pr_merged, operational_verified, or verified_reuse outcome exists
+    - The evidence source is live, scoped, non-empty, and privacy-classified
+    - No correction, revert, rejection, stale escape, or privacy escape follows it
     - Not already graduated (tracked via graduated_at timestamp)
     - Content is actionable (not session metadata or batch logs)
+    Access count only ranks eligible candidates; it never proves usefulness.
 
 CATEGORIES:
     Memories are auto-categorized by type:
@@ -877,9 +1075,6 @@ EXAMPLES:
     # Preview graduation output
     memory-graduate-helper.sh graduate --dry-run
 
-    # Graduate with lower threshold
-    memory-graduate-helper.sh graduate --min-access 2
-
     # Check status
     memory-graduate-helper.sh status
 EOF
@@ -896,6 +1091,8 @@ main() {
 	case "$command" in
 	candidates | list) cmd_candidates "$@" ;;
 	graduate | promote) cmd_graduate "$@" ;;
+	outcome) cmd_outcome "$@" ;;
+	revoke | correct) cmd_revoke "$@" ;;
 	status | stats) cmd_status ;;
 	help | --help | -h) cmd_help ;;
 	*)

--- a/.agents/scripts/memory/_common.sh
+++ b/.agents/scripts/memory/_common.sh
@@ -623,6 +623,33 @@ CREATE TABLE IF NOT EXISTS observation_outcomes (
     recorded_at TEXT NOT NULL,
     UNIQUE(observation_id, outcome_kind, recorded_at)
 );
+
+CREATE TABLE IF NOT EXISTS outcome_verifications (
+    outcome_id TEXT PRIMARY KEY,
+    verifier_id TEXT NOT NULL,
+    evidence_source_id TEXT NOT NULL,
+    verification_provenance TEXT NOT NULL,
+    verified_at TEXT NOT NULL,
+    FOREIGN KEY (outcome_id) REFERENCES observation_outcomes(outcome_id),
+    FOREIGN KEY (evidence_source_id) REFERENCES observation_sources(source_id)
+);
+
+CREATE TABLE IF NOT EXISTS observation_promotions (
+    promotion_id TEXT PRIMARY KEY,
+    observation_id TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    outcome_id TEXT NOT NULL,
+    destination TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'corrected', 'revoked')),
+    promoted_at TEXT NOT NULL,
+    changed_at TEXT,
+    change_reason TEXT,
+    UNIQUE(observation_id, destination),
+    FOREIGN KEY (observation_id) REFERENCES observations(observation_id),
+    FOREIGN KEY (source_id) REFERENCES observation_sources(source_id),
+    FOREIGN KEY (outcome_id) REFERENCES observation_outcomes(outcome_id)
+);
+CREATE INDEX IF NOT EXISTS idx_observation_promotions_status ON observation_promotions(status, destination);
 EOF
 	local rc=$?
 	return "$rc"

--- a/.agents/scripts/memory/maintenance-prune.sh
+++ b/.agents/scripts/memory/maintenance-prune.sh
@@ -39,8 +39,9 @@ fi
 #######################################
 cmd_prune() {
 	local older_than_days=$DEFAULT_MAX_AGE_DAYS
+	local max_count="${AIDEVOPS_MEMORY_MAX_COUNT:-10000}"
+	local max_bytes="${AIDEVOPS_MEMORY_MAX_BYTES:-52428800}"
 	local dry_run=false
-	local keep_accessed=true
 	local ai_judged=false
 
 	while [[ $# -gt 0 ]]; do
@@ -49,12 +50,19 @@ cmd_prune() {
 			older_than_days="$2"
 			shift 2
 			;;
+		--max-count)
+			max_count="$2"
+			shift 2
+			;;
+		--max-bytes)
+			max_bytes="$2"
+			shift 2
+			;;
 		--dry-run)
 			dry_run=true
 			shift
 			;;
 		--include-accessed)
-			keep_accessed=false
 			shift
 			;;
 		--ai-judged)
@@ -72,13 +80,73 @@ cmd_prune() {
 		log_error "--older-than-days must be a positive integer"
 		return 1
 	fi
-
-	if [[ "$ai_judged" == true ]]; then
-		_prune_ai_judged "$older_than_days" "$dry_run" "$keep_accessed"
-	else
-		_prune_flat_threshold "$older_than_days" "$dry_run" "$keep_accessed"
+	if ! [[ "$max_count" =~ ^[0-9]+$ && "$max_bytes" =~ ^[0-9]+$ ]]; then
+		log_error "--max-count and --max-bytes must be non-negative integers"
+		return 1
 	fi
 
+	if [[ "$ai_judged" == true ]]; then
+		log_info "Hard age retention applies before relevance judgment; accessed records cannot escape the age bound"
+	fi
+	_prune_flat_threshold "$older_than_days" "$dry_run"
+	_enforce_retention_budgets "$max_count" "$max_bytes" "$dry_run"
+
+	return 0
+}
+
+#######################################
+# Enforce retrieval-projection count and byte budgets. Canonical observation,
+# source, outcome, relation, and promotion rows remain as immutable audit data.
+#######################################
+_enforce_retention_budgets() {
+	local max_count="$1"
+	local max_bytes="$2"
+	local dry_run="$3"
+	local over_count=""
+	db "$MEMORY_DB" <<EOF
+DROP TABLE IF EXISTS retention_prune_ids;
+CREATE TABLE retention_prune_ids (id TEXT PRIMARY KEY);
+INSERT OR IGNORE INTO retention_prune_ids
+SELECT id FROM learnings ORDER BY created_at DESC, id DESC LIMIT -1 OFFSET $max_count;
+INSERT OR IGNORE INTO retention_prune_ids
+SELECT id FROM (
+    SELECT id, SUM(
+        length(CAST(COALESCE(id, '') AS BLOB)) +
+        length(CAST(COALESCE(session_id, '') AS BLOB)) +
+        length(CAST(COALESCE(content, '') AS BLOB)) +
+        length(CAST(COALESCE(type, '') AS BLOB)) +
+        length(CAST(COALESCE(tags, '') AS BLOB)) +
+        length(CAST(COALESCE(confidence, '') AS BLOB)) +
+        length(CAST(COALESCE(created_at, '') AS BLOB)) +
+        length(CAST(COALESCE(event_date, '') AS BLOB)) +
+        length(CAST(COALESCE(project_path, '') AS BLOB)) +
+        length(CAST(COALESCE(source, '') AS BLOB))
+    )
+        OVER (ORDER BY created_at DESC, id DESC) AS cumulative_bytes
+    FROM learnings
+) WHERE cumulative_bytes > $max_bytes;
+EOF
+	over_count=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM retention_prune_ids;")
+	if [[ "$over_count" -eq 0 ]]; then
+		db "$MEMORY_DB" "DROP TABLE retention_prune_ids;"
+		return 0
+	fi
+	if [[ "$dry_run" == true ]]; then
+		log_info "[DRY RUN] Would prune $over_count entries to satisfy count=$max_count and bytes=$max_bytes budgets"
+		db "$MEMORY_DB" "DROP TABLE retention_prune_ids;"
+		return 0
+	fi
+	local prune_backup=""
+	prune_backup=$(backup_sqlite_db "$MEMORY_DB" "pre-retention-budget") || true
+	[[ -n "$prune_backup" ]] || log_warn "Backup failed before retention budget prune -- proceeding cautiously"
+	db "$MEMORY_DB" <<'EOF'
+DELETE FROM learning_relations WHERE id IN (SELECT id FROM retention_prune_ids) OR supersedes_id IN (SELECT id FROM retention_prune_ids);
+DELETE FROM learning_access WHERE id IN (SELECT id FROM retention_prune_ids);
+DELETE FROM learnings WHERE id IN (SELECT id FROM retention_prune_ids);
+INSERT INTO learnings(learnings) VALUES('rebuild');
+DROP TABLE retention_prune_ids;
+EOF
+	log_success "Pruned $over_count retrieval entries to satisfy count and byte budgets; canonical audit evidence retained"
 	return 0
 }
 
@@ -96,7 +164,7 @@ _prune_ai_judged() {
 
 	if [[ ! -x "$threshold_judge" ]]; then
 		log_warn "ai-threshold-judge.sh not found -- falling back to flat threshold"
-		_prune_flat_threshold "$older_than_days" "$dry_run" "$keep_accessed"
+		_prune_flat_threshold "$older_than_days" "$dry_run"
 		return 0
 	fi
 
@@ -185,15 +253,9 @@ _prune_ai_judged() {
 _prune_flat_threshold() {
 	local older_than_days="$1"
 	local dry_run="$2"
-	local keep_accessed="$3"
 
-	# Build query to find stale entries
 	local count
-	if [[ "$keep_accessed" == true ]]; then
-		count=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.created_at < datetime('now', '-$older_than_days days') AND a.id IS NULL;")
-	else
-		count=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE created_at < datetime('now', '-$older_than_days days');")
-	fi
+	count=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE created_at < datetime('now', '-$older_than_days days');")
 
 	if [[ "$count" -eq 0 ]]; then
 		log_success "No entries to prune"
@@ -203,22 +265,12 @@ _prune_flat_threshold() {
 	if [[ "$dry_run" == true ]]; then
 		log_info "[DRY RUN] Would delete $count entries"
 		echo ""
-		if [[ "$keep_accessed" == true ]]; then
-			db "$MEMORY_DB" <<EOF
-SELECT l.id, l.type, substr(l.content, 1, 50) || '...' as preview, l.created_at
-FROM learnings l
-LEFT JOIN learning_access a ON l.id = a.id
-WHERE l.created_at < datetime('now', '-$older_than_days days') AND a.id IS NULL
-LIMIT 20;
-EOF
-		else
-			db "$MEMORY_DB" <<EOF
+		db "$MEMORY_DB" <<EOF
 SELECT id, type, substr(content, 1, 50) || '...' as preview, created_at
-FROM learnings 
+FROM learnings
 WHERE created_at < datetime('now', '-$older_than_days days')
 LIMIT 20;
 EOF
-		fi
 		return 0
 	fi
 
@@ -229,13 +281,7 @@ EOF
 		log_warn "Backup failed before prune -- proceeding cautiously"
 	fi
 
-	# Use efficient single DELETE with subquery
-	local subquery
-	if [[ "$keep_accessed" == true ]]; then
-		subquery="SELECT l.id FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.created_at < datetime('now', '-$older_than_days days') AND a.id IS NULL"
-	else
-		subquery="SELECT id FROM learnings WHERE created_at < datetime('now', '-$older_than_days days')"
-	fi
+	local subquery="SELECT id FROM learnings WHERE created_at < datetime('now', '-$older_than_days days')"
 
 	# Delete from all tables using the subquery (much faster than loop)
 	# Clean up relations first to avoid orphaned references

--- a/.agents/scripts/memory/maintenance.sh
+++ b/.agents/scripts/memory/maintenance.sh
@@ -91,6 +91,19 @@ SELECT 'High confidence', COUNT(*) FROM learnings WHERE confidence = 'high';
 EOF
 
 	echo ""
+	echo "Learning outcome metrics:"
+	db "$MEMORY_DB" <<'EOF'
+SELECT '  Capture precision (%)', printf('%.1f', 100.0 * SUM(CASE WHEN outcome_kind NOT IN ('rejected', 'correction', 'reverted', 'pr_closed') THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0)) FROM observation_outcomes
+UNION ALL SELECT '  Helpful recall', COUNT(*) FROM observation_outcomes WHERE outcome_kind = 'helpful_recall'
+UNION ALL SELECT '  Corrections', COUNT(*) FROM observation_outcomes WHERE outcome_kind = 'correction'
+UNION ALL SELECT '  Verified reuse', COUNT(*) FROM observation_outcomes WHERE outcome_kind = 'verified_reuse'
+UNION ALL SELECT '  Rejections', COUNT(*) FROM observation_outcomes WHERE outcome_kind IN ('rejected', 'pr_closed')
+UNION ALL SELECT '  Stale/privacy escapes', COUNT(*) FROM observation_outcomes WHERE outcome_kind IN ('stale_escape', 'privacy_escape')
+UNION ALL SELECT '  Interruptions', COUNT(*) FROM observation_outcomes WHERE outcome_kind = 'interruption'
+UNION ALL SELECT '  Human time saved (minutes)', printf('%.1f', COALESCE(SUM(outcome_value), 0)) FROM observation_outcomes WHERE outcome_kind = 'human_time_saved';
+EOF
+
+	echo ""
 
 	# Show relation statistics
 	echo "Relational versioning:"

--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -943,6 +943,22 @@ INSERT INTO learning_access (id, last_accessed_at, access_count, usefulness_scor
 VALUES ('$escaped_id', datetime('now'), 0, MAX(-5.0, $reward))
 ON CONFLICT(id) DO UPDATE SET
     usefulness_score = MAX(-5.0, COALESCE(usefulness_score, 0.0) + $reward);
+INSERT OR IGNORE INTO observation_outcomes (
+    outcome_id, observation_id, outcome_kind, outcome_value, details, recorded_at
+)
+VALUES (
+    'out_feedback_${escaped_id}_' || strftime('%Y%m%d%H%M%f', 'now'),
+    'obs_learning_$escaped_id',
+    CASE '$signal'
+        WHEN 'cited' THEN 'helpful_recall'
+        WHEN 'reused' THEN 'verified_reuse'
+        WHEN 'dead_end' THEN 'rejected'
+        WHEN 'false' THEN 'correction'
+        WHEN 'debunked' THEN 'correction'
+        ELSE 'retrieval_feedback'
+    END,
+    $reward, 'signal=${signal:-custom}', strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+);
 EOF
 
 	local new_score

--- a/tests/test-memory-graduation-safety.sh
+++ b/tests/test-memory-graduation-safety.sh
@@ -17,11 +17,30 @@ cleanup() {
 }
 trap cleanup EXIT
 
+memory() {
+	AIDEVOPS_MEMORY_DIR="$TEST_DIR" AIDEVOPS_VAULT_DIR="$TEST_DIR/no-vault" "$MEMORY_HELPER" "$@"
+	return $?
+}
+
+graduate() {
+	AIDEVOPS_MEMORY_DIR="$TEST_DIR" AIDEVOPS_VAULT_DIR="$TEST_DIR/no-vault" "$GRADUATE_HELPER" "$@"
+	return $?
+}
+
+record_verified_outcome() {
+	local memory_id="$1"
+	local outcome_kind="$2"
+	local source_id="verify_$memory_id"
+	sqlite3 "$TEST_DIR/memory.db" "INSERT INTO observation_sources VALUES ('$source_id','obs_learning_$memory_id','test_result','result_$memory_id','ci-verifier','independent regression evidence','ci:test-suite',strftime('%Y-%m-%dT%H:%M:%fZ','now'));"
+	graduate outcome "$memory_id" "$outcome_kind" --verifier "ci-verifier" --source-id "$source_id" --provenance "ci:test-suite" --details "independent verification" >/dev/null
+	return 0
+}
+
 store_memory_id() {
 	local output=""
 	local line=""
 	local memory_id=""
-	output=$(AIDEVOPS_MEMORY_DIR="$TEST_DIR" "$MEMORY_HELPER" store "$@")
+	output=$(memory store "$@")
 	while IFS= read -r line; do
 		if [[ "$line" == mem_* ]]; then
 			memory_id="$line"
@@ -36,7 +55,7 @@ candidate_json() {
 	local line=""
 	local json=""
 	local capturing=0
-	output=$(AIDEVOPS_MEMORY_DIR="$TEST_DIR" "$GRADUATE_HELPER" candidates --json --limit 50)
+	output=$(graduate candidates --json --limit 50)
 	while IFS= read -r line; do
 		if [[ "$line" == \[* ]]; then
 			capturing=1
@@ -50,7 +69,7 @@ candidate_json() {
 }
 
 graduation_preview() {
-	AIDEVOPS_MEMORY_DIR="$TEST_DIR" "$GRADUATE_HELPER" graduate --dry-run --limit 50 2>&1
+	graduate graduate --dry-run --limit 50 2>&1
 	return $?
 }
 
@@ -60,12 +79,15 @@ test_legacy_schema_migration() {
 	local truth_table_count=""
 	legacy_dir=$(mktemp -d)
 
-	AIDEVOPS_MEMORY_DIR="$legacy_dir" "$MEMORY_HELPER" store \
+	local legacy_id=""
+	legacy_id=$(AIDEVOPS_MEMORY_DIR="$legacy_dir" AIDEVOPS_VAULT_DIR="$legacy_dir/no-vault" "$MEMORY_HELPER" store \
 		--content "Legacy schema graduation remains safely migratable" \
-		--type WORKING_SOLUTION --confidence high >/dev/null
+		--type WORKING_SOLUTION --confidence high | sed -n '$p')
+	sqlite3 "$legacy_dir/memory.db" "INSERT INTO observation_sources VALUES ('verify_$legacy_id','obs_learning_$legacy_id','test_result','result_$legacy_id','ci-verifier','legacy migration regression passed','ci:test-suite',strftime('%Y-%m-%dT%H:%M:%fZ','now'));"
+	AIDEVOPS_MEMORY_DIR="$legacy_dir" AIDEVOPS_VAULT_DIR="$legacy_dir/no-vault" "$GRADUATE_HELPER" outcome "$legacy_id" test_passed --verifier ci-verifier --source-id "verify_$legacy_id" --provenance ci:test-suite >/dev/null
 	sqlite3 "$legacy_dir/memory.db" "DROP TABLE learning_truth_events; DROP TABLE learning_relations;"
 
-	output=$(AIDEVOPS_MEMORY_DIR="$legacy_dir" "$GRADUATE_HELPER" candidates --json --limit 10)
+	output=$(AIDEVOPS_MEMORY_DIR="$legacy_dir" AIDEVOPS_VAULT_DIR="$legacy_dir/no-vault" "$GRADUATE_HELPER" candidates --json --limit 10)
 	truth_table_count=$(sqlite3 "$legacy_dir/memory.db" \
 		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('learning_truth_events', 'learning_relations');")
 	rm -rf "$legacy_dir"
@@ -89,6 +111,7 @@ main() {
 	local secret_value=""
 	local service_secret=""
 	local gitlab_secret=""
+	local access_only_id=""
 
 	preference_id=$(store_memory_id --content "User prefers terse status summaries in personal sessions" --type USER_PREFERENCE --confidence high)
 	live_id=$(store_memory_id --content "Portable privacy filters use POSIX extended regular expressions" --type WORKING_SOLUTION --confidence high)
@@ -97,6 +120,11 @@ main() {
 	store_memory_id --content "Evidence disproves the obsolete privacy graduation claim" --type ERROR_FIX --confidence high --debunks "$myth_id" --replacement "$replacement_id" --evidence "Regression test" >/dev/null
 	old_id=$(store_memory_id --content "Old deployment guidance uses the retired memory path" --type TOOL_CONFIG --confidence high)
 	new_id=$(store_memory_id --content "Current deployment guidance uses the supported memory path" --type TOOL_CONFIG --confidence high --supersedes "$old_id" --relation updates)
+	access_only_id=$(store_memory_id --content "Frequently recalled but operationally unverified guidance" --type WORKING_SOLUTION --confidence high)
+	record_verified_outcome "$live_id" test_passed
+	record_verified_outcome "$replacement_id" operational_verified
+	record_verified_outcome "$new_id" pr_merged
+	sqlite3 "$TEST_DIR/memory.db" "INSERT INTO learning_access(id,last_accessed_at,access_count) VALUES ('$access_only_id',datetime('now'),99) ON CONFLICT(id) DO UPDATE SET access_count=99;"
 	store_memory_id --content "Contact private.person@example.test before publishing this workflow" --type CONTEXT --confidence high >/dev/null
 	store_memory_id --content "Local evidence is stored at /Users/private-user/secret-project/report.md" --type TOOL_CONFIG --confidence high >/dev/null
 	store_memory_id --content "Safe-looking content with private metadata must remain local" --type CONTEXT --confidence high --tags "owner.private@example.test,/Users/private-user/project" >/dev/null
@@ -128,6 +156,7 @@ EOF
 	jq -e --arg id "$preference_id" 'map(.id) | index($id) | not' <<<"$results" >/dev/null
 	jq -e --arg id "$myth_id" 'map(.id) | index($id) | not' <<<"$results" >/dev/null
 	jq -e --arg id "$old_id" 'map(.id) | index($id) | not' <<<"$results" >/dev/null
+	jq -e --arg id "$access_only_id" 'map(.id) | index($id) | not' <<<"$results" >/dev/null
 
 	preview=$(graduation_preview)
 	if [[ "$preview" == *"private.person@example.test"* || "$preview" == *"/Users/private-user/"* ||
@@ -138,7 +167,7 @@ EOF
 	fi
 	test_legacy_schema_migration
 
-	printf 'PASS: graduation includes live shareable memories and excludes personal, private, debunked, and superseded records\n'
+	printf 'PASS: verified outcomes govern graduation while access count remains ranking-only\n'
 	return 0
 }
 

--- a/tests/test-memory-promotion-revocation.sh
+++ b/tests/test-memory-promotion-revocation.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+GRADUATE_HELPER="$REPO_ROOT/.agents/scripts/memory-graduate-helper.sh"
+TEST_DIR="$(mktemp -d)"
+DESTINATION="$TEST_DIR/graduated.md"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+memory() {
+	AIDEVOPS_MEMORY_DIR="$TEST_DIR" AIDEVOPS_VAULT_DIR="$TEST_DIR/no-vault" "$MEMORY_HELPER" "$@"
+	return $?
+}
+
+graduate() {
+	AIDEVOPS_MEMORY_DIR="$TEST_DIR" AIDEVOPS_VAULT_DIR="$TEST_DIR/no-vault" AIDEVOPS_GRADUATED_FILE="$DESTINATION" "$GRADUATE_HELPER" "$@"
+	return $?
+}
+
+store_id() {
+	local content="$1"
+	memory store --content "$content" --type WORKING_SOLUTION --confidence high | sed -n '$p'
+	return "${PIPESTATUS[0]}"
+}
+
+add_verification_source() {
+	local memory_id="$1"
+	local source_id="verify_$memory_id"
+	sqlite3 "$TEST_DIR/memory.db" "INSERT INTO observation_sources VALUES ('$source_id','obs_learning_$memory_id','test_result','result_$memory_id','ci-verifier','independent targeted test passed','ci:test-suite',strftime('%Y-%m-%dT%H:%M:%fZ','now'));"
+	printf '%s\n' "$source_id"
+	return 0
+}
+
+first_id=$(store_id "First verified promotion is removable without touching manual guidance")
+second_id=$(store_id "Second verified promotion remains when the first promotion is revoked")
+correction_id=$(store_id "Corrected guidance replaces the first verified promotion")
+first_source=$(add_verification_source "$first_id")
+second_source=$(add_verification_source "$second_id")
+
+if graduate outcome "$first_id" test_passed --details self-claim >/dev/null 2>&1; then
+	printf 'FAIL: qualifying outcome accepted missing attribution\n' >&2
+	exit 1
+fi
+if graduate outcome "$first_id" test_passed --verifier self --source-id "src_learning_$first_id" --provenance manual >/dev/null 2>&1; then
+	printf 'FAIL: qualifying outcome accepted self-asserted evidence\n' >&2
+	exit 1
+fi
+graduate outcome "$first_id" test_passed --verifier ci-verifier --source-id "$first_source" --provenance ci:test-suite >/dev/null
+graduate outcome "$second_id" operational_verified --verifier ci-verifier --source-id "$second_source" --provenance ci:test-suite >/dev/null
+graduate graduate --limit 10 >/dev/null
+printf '\nManual guidance must survive generated block removal.\n' >>"$DESTINATION"
+
+db="$TEST_DIR/memory.db"
+[[ "$(sqlite3 "$db" "SELECT COUNT(*) FROM outcome_verifications WHERE verifier_id='ci-verifier';")" == "2" ]]
+[[ "$(sqlite3 "$db" "SELECT COUNT(*) FROM observation_promotions WHERE status='active';")" == "2" ]]
+grep -F "First verified promotion" "$DESTINATION" >/dev/null
+grep -F "Second verified promotion" "$DESTINATION" >/dev/null
+
+graduate revoke "$first_id" --reason "later regression disproved guidance" >/dev/null
+if grep -F "First verified promotion" "$DESTINATION" >/dev/null; then
+	printf 'FAIL: revoked generated guidance remains in destination\n' >&2
+	exit 1
+fi
+grep -F "Second verified promotion" "$DESTINATION" >/dev/null
+grep -F "Manual guidance must survive" "$DESTINATION" >/dev/null
+content_after_first_revoke=$(cksum "$DESTINATION")
+graduate revoke "$first_id" --reason "later regression disproved guidance" >/dev/null
+[[ "$(cksum "$DESTINATION")" == "$content_after_first_revoke" ]]
+[[ "$(sqlite3 "$db" "SELECT COUNT(*) FROM observation_outcomes WHERE observation_id='obs_learning_$first_id' AND outcome_kind='reverted';")" == "1" ]]
+
+# Re-activate a fixture promotion to exercise correction separately.
+sqlite3 "$db" "UPDATE observation_promotions SET status='active' WHERE observation_id='obs_learning_$first_id'; UPDATE observations SET status='active' WHERE observation_id='obs_learning_$first_id';"
+graduate revoke "$first_id" --corrected-by "$correction_id" --reason "replacement guidance verified" >/dev/null
+[[ "$(sqlite3 "$db" "SELECT status FROM observation_promotions WHERE observation_id='obs_learning_$first_id';")" == "corrected" ]]
+[[ "$(sqlite3 "$db" "SELECT COUNT(*) FROM observation_relations WHERE observation_id='obs_learning_$correction_id' AND target_observation_id='obs_learning_$first_id' AND relation_type='corrects';")" == "1" ]]
+[[ "$(sqlite3 "$db" "SELECT COUNT(*) FROM observation_outcomes WHERE observation_id='obs_learning_$first_id' AND outcome_kind='correction';")" == "1" ]]
+
+printf 'PASS: independently verified promotion, exact idempotent revocation, and correction audit behavior\n'

--- a/tests/test-memory-retention-bounds.sh
+++ b/tests/test-memory-retention-bounds.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+memory() {
+	AIDEVOPS_MEMORY_DIR="$TEST_DIR" AIDEVOPS_VAULT_DIR="$TEST_DIR/no-vault" "$MEMORY_HELPER" "$@"
+	return $?
+}
+
+for number in 1 2 3 4; do
+	memory store --content "Retention fixture $number with enough bytes to exercise hard storage budgets" --type CONTEXT >/dev/null
+done
+db="$TEST_DIR/memory.db"
+old_id=$(sqlite3 "$db" "SELECT id FROM learnings WHERE rowid=(SELECT MIN(rowid) FROM learnings);")
+sqlite3 "$db" "UPDATE learnings SET created_at='2020-01-01T00:00:00Z' WHERE id='$old_id'; INSERT INTO learning_access(id,last_accessed_at,access_count) VALUES ('$old_id',datetime('now'),99) ON CONFLICT(id) DO UPDATE SET access_count=99;"
+
+memory prune --older-than-days 1 --max-count 2 --max-bytes 100000 >/dev/null
+[[ "$(sqlite3 "$db" 'SELECT COUNT(*) FROM learnings;')" -le 2 ]]
+[[ "$(sqlite3 "$db" "SELECT COUNT(*) FROM learnings WHERE id='$old_id';")" == "0" ]]
+[[ "$(sqlite3 "$db" 'SELECT COUNT(*) FROM observations;')" == "4" ]]
+[[ "$(sqlite3 "$db" 'SELECT COUNT(*) FROM observation_sources;')" == "4" ]]
+
+memory prune --older-than-days 99999 --max-count 100 --max-bytes 300 >/dev/null
+projection_bytes=$(sqlite3 "$db" "SELECT COALESCE(SUM(length(CAST(COALESCE(id,'') AS BLOB))+length(CAST(COALESCE(session_id,'') AS BLOB))+length(CAST(COALESCE(content,'') AS BLOB))+length(CAST(COALESCE(type,'') AS BLOB))+length(CAST(COALESCE(tags,'') AS BLOB))+length(CAST(COALESCE(confidence,'') AS BLOB))+length(CAST(COALESCE(created_at,'') AS BLOB))+length(CAST(COALESCE(event_date,'') AS BLOB))+length(CAST(COALESCE(project_path,'') AS BLOB))+length(CAST(COALESCE(source,'') AS BLOB))),0) FROM learnings;")
+[[ "$projection_bytes" -le 300 ]]
+memory prune --older-than-days 99999 --max-count 100 --max-bytes 1 >/dev/null
+[[ "$(sqlite3 "$db" 'SELECT COUNT(*) FROM learnings;')" == "0" ]]
+[[ "$(sqlite3 "$db" 'SELECT COUNT(*) FROM observations;')" == "4" ]]
+[[ "$(sqlite3 "$db" 'SELECT COUNT(*) FROM observation_sources;')" == "4" ]]
+
+printf 'PASS: age, count, and byte retention bounds preserve canonical audit evidence\n'


### PR DESCRIPTION
## Summary

Require independently verified outcomes and attributable evidence for promotion, add exact revocation/correction markers and audit records, enforce hard age/count/logical-byte retrieval bounds, and expose outcome-derived learning metrics.

## Files Changed

.agents/reference/memory.md, .agents/scripts/memory-graduate-helper.sh, .agents/scripts/memory/_common.sh, .agents/scripts/memory/maintenance-prune.sh, .agents/scripts/memory/maintenance.sh, .agents/scripts/memory/recall.sh, tests/test-memory-graduation-safety.sh, tests/test-memory-promotion-revocation.sh, tests/test-memory-retention-bounds.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Graduation, promotion-revocation, retention, truth-maintenance, observation-contract, and scope/dedup tests pass; bash -n, ShellCheck, git diff --check, and linters-local.sh pass.

Resolves #27309


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.59 with gpt-5.6-sol spent 42m and 82,851 tokens on this with the user in an interactive session.