### PR TITLE
GH#27340: fix: suppress stale failure family findings

### DIFF
--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -58,7 +58,11 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     auto_dispatch_scan_state: (if $queue_error == "" then "scanned" else $queue_error end),
     graphql_budget_status: ($current.graphql_budget_status // "unknown"),
     runner_health: ($runner.finding // "unknown"),
-    recurrent_failure_families: ([$failure_families[] | select((.count // 0) >= $failure_threshold and (.confidence // "low") == "high" and (.family // "") != "other-failure")] | length)
+    recurrent_failure_families: ([$failure_families[] as $family
+      | (([$recent_failure_families[] | select(.fingerprint == $family.fingerprint)] | first | .count) // 0) as $recent_count
+      | $family
+      | select((.count // 0) >= $failure_threshold and $recent_count >= $failure_threshold and (.confidence // "low") == "high" and (.family // "") != "other-failure")
+    ] | length)
   },
   queue: ($queue.aggregate // {}),
   current_state: {
@@ -92,7 +96,10 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     first_ts,
     last_ts,
     confidence,
-    recovery_outcome,
+    recovery_outcome: ((([$recent_failure_families[] | select(.fingerprint == $family.fingerprint)] | first | .count) // 0) as $recent_count
+      | if $recent_count >= $failure_threshold then "recurring"
+        elif $recent_count > 0 then "improving"
+        else "recovery-candidate" end),
     recent_count: (([$recent_failure_families[] | select(.fingerprint == $family.fingerprint)] | first | .count) // 0)
   })),
   runner_health: $runner,
@@ -198,8 +205,9 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     else empty end
     ,
     ($failure_families[] as $family
+      | (([$recent_failure_families[] | select(.fingerprint == $family.fingerprint)] | first | .count) // 0) as $recent_count
       | $family
-      | select((.count // 0) >= $failure_threshold and (.distinct_sessions // 0) >= 2 and (.confidence // "low") == "high" and (.family // "") != "other-failure")
+      | select((.count // 0) >= $failure_threshold and $recent_count >= $failure_threshold and (.distinct_sessions // 0) >= 2 and (.confidence // "low") == "high" and (.family // "") != "other-failure")
       | finding(
           ("worker-failure-family-" + (.family // "unknown"));
           "high";
@@ -219,7 +227,7 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
           family_fingerprint: (.fingerprint // ""),
           family: (.family // "unknown"),
           family_count: (.count // 0),
-          family_recent_count: (([$recent_failure_families[] | select(.fingerprint == $family.fingerprint)] | first | .count) // 0),
+          family_recent_count: $recent_count,
           family_first_ts: (.first_ts // 0),
           family_last_ts: (.last_ts // 0),
           family_confidence: (.confidence // "unknown")

--- a/.agents/scripts/tests/test-failure-family-remediation.sh
+++ b/.agents/scripts/tests/test-failure-family-remediation.sh
@@ -173,9 +173,15 @@ test_nmr_reason_revalidation() {
 	authority=$(_nmr_reason_metadata_from_comments '[{"body":"<!-- nmr-reason code=billing class=genuine-authority -->"}]')
 	assert_eq "billing reason requires cryptographic authority" "true" "$(printf '%s' "$authority" | jq -r '.requires_crypto')"
 
-	_nmr_reason_metadata() { printf '{"code":"missing_context","class":"temporary","source":"structured-marker","revalidate_after_seconds":1,"requires_crypto":false}\n'; return 0; }
+	_nmr_reason_metadata() {
+		printf '{"code":"missing_context","class":"temporary","source":"structured-marker","revalidate_after_seconds":1,"requires_crypto":false}\n'
+		return 0
+	}
 	_nmr_revalidation_due() { return 0; }
-	_nmr_temporary_assumption_resolved() { printf 'worker guidance restored\n'; return 0; }
+	_nmr_temporary_assumption_resolved() {
+		printf 'worker guidance restored\n'
+		return 0
+	}
 	_nmr_record_revalidation_state() { return 0; }
 	_nmr_evaluate_reason_metadata 42 owner/repo 2000-01-01T00:00:00Z
 	assert_eq "resolved temporary NMR returns to automation" "auto" "$_NMR_REASON_ACTION"

--- a/.agents/scripts/tests/test-failure-family-remediation.sh
+++ b/.agents/scripts/tests/test-failure-family-remediation.sh
@@ -75,6 +75,19 @@ test_threshold_and_privacy() {
 		"$(printf '%s' "$report" | jq -r '.findings[] | select(.id == "worker-failure-family-watchdog-stall") | .autofile')"
 	assert_absent "aggregate report omits repository slug" "private/example" "$report"
 	assert_absent "aggregate report omits local path" "$HOME" "$report"
+
+	local stale_report=""
+	stale_report=$(jq -n --arg window 15m --arg since 24h --arg recent 1h \
+		--argjson threshold 3 --argjson failure_threshold 3 \
+		--argjson current '{}' \
+		--argjson summary "{\"metrics\":{\"failure_families\":[$family]}}" \
+		--argjson recent_summary '{"metrics":{"failure_families":[]}}' \
+		--argjson providers '{}' --argjson runner '{}' --argjson api '{}' \
+		--argjson queue '{"aggregate":{}}' -f "${SCRIPT_DIR}/pulse-check-report.jq")
+	assert_eq "historical-only family is a recovery candidate" "recovery-candidate" \
+		"$(printf '%s' "$stale_report" | jq -r '.failure_family_remediation[0].recovery_outcome')"
+	assert_eq "historical-only family does not trigger a stale finding" "0" \
+		"$(printf '%s' "$stale_report" | jq -r '[.findings[] | select(.id == "worker-failure-family-watchdog-stall")] | length')"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Require failure families to remain recurrent in both historical and recent windows before reporting or autofiling them, and classify historical-only evidence as a recovery candidate. Add regression coverage for historical local-runtime-style failures with zero recent recurrence.

## Files Changed

.agents/scripts/pulse-check-report.jq, .agents/scripts/tests/test-failure-family-remediation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-failure-family-remediation.sh; bash .agents/scripts/tests/test-pulse-check-helper.sh; shellcheck .agents/scripts/tests/test-failure-family-remediation.sh; .agents/scripts/linters-local.sh; .agents/scripts/pulse-check-helper.sh --json (local-runtime-error finding absent, recovery-candidate)

Resolves #27340


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 125,501 tokens on this as a headless worker.