### PR TITLE
GH#27343: reuse scoped release quality evidence

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -84,7 +84,7 @@ Subagents are advisory, never the active critical path. Mark each delegated prom
 - Conversation starters: `workflows/conversation-starter.md`. Implementation: `workflows/branch.md`.
 - Git safety: stash before destructive ops. NEVER auto-commit (only when user requests).
 - Context: rg/fd → Augment (semantic) → Context7 (library docs). TOON for data serialization.
-- Quality: pre-commit `linters-local.sh` (`preflight → commit → push`), `tools/code-review/best-practices.md`. Pre-implementation: check existing quality.
+- Quality: targeted tests plus changed-file/affected-package lint (`linters-local.sh --changed`) before commit. Use full-repository gates only for evidenced shared contracts/root tooling/release infrastructure; never as generic completion proof. See `workflows/full-loop.md` and `tools/code-review/best-practices.md`.
 - Draft agents: `~/.aidevops/agents/draft/` with `status: draft`. See `tools/build-agent/build-agent.md`.
 - File reading: re-read only before a second edit or if another tool may have modified the file.
 - Style: clear, direct, casual-professional. Bullet points and code blocks. Write code to files directly — don't display unless asked.
@@ -100,7 +100,7 @@ Subagents are advisory, never the active critical path. Mark each delegated prom
 5. **Plan**: Create a TodoWrite checklist. Check off steps as completed. Don't end turn between steps.
 6. **Code**: Read files before editing. Small, incremental changes. Retry failed patches. Check for `.env` needs.
 7. **Debug**: Root-cause only — don't address symptoms. Use logs/print statements to inspect state.
-8. **Test**: Narrow-to-broad. Add tests if codebase has them. Iterate until all pass. UI changes: `workflows/ui-verification.md` (Playwright screenshots, DevTools console, accessibility). Never self-assess visual changes.
+8. **Test**: Narrow-to-broad. Start with targeted tests and changed-file/affected-package checks. Run full-repository gates only when blast-radius evidence requires them. Add tests if codebase has them. Iterate until all required gates pass. UI changes: `workflows/ui-verification.md` (Playwright screenshots, DevTools console, accessibility). Never self-assess visual changes.
 9. **Validate**: Verify against original intent. Hierarchy: tools (tests/lint/build) → browser (UI) → primary sources → self-review → ask user.
 
 ### External Content Lookup

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -179,8 +179,7 @@ _issue_thread_is_trusted_maintainer_only() {
 
 	[[ -n "$issue_num" && -n "$repo" ]] || return 1
 	case "$issue_author_association" in
-	OWNER | MEMBER)
-		;;
+	OWNER | MEMBER) ;;
 	*)
 		return 1
 		;;
@@ -672,14 +671,19 @@ _full_loop_verify_aidevops_release_deploy() {
 	local version=""
 	[[ -n "$repo_root" && -f "${repo_root}/VERSION" ]] && IFS= read -r version <"${repo_root}/VERSION"
 	[[ -n "$version" ]] || return 1
-	git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>&1 || return 1
+	local release_sha=""
+	release_sha=$(git ls-remote --exit-code --tags origin "refs/tags/v${version}^{}" 2>/dev/null | cut -f1)
+	if [[ -z "$release_sha" ]]; then
+		release_sha=$(git ls-remote --exit-code --tags origin "refs/tags/v${version}" 2>/dev/null | cut -f1)
+	fi
+	[[ -n "$release_sha" ]] || return 1
 	gh release view "v${version}" --repo "$repo" >/dev/null 2>&1 || return 1
 	local deployed_version=""
 	[[ -f "${HOME}/.aidevops/agents/VERSION" ]] && IFS= read -r deployed_version <"${HOME}/.aidevops/agents/VERSION"
 	[[ "$deployed_version" == "$version" ]] || return 1
 	local postflight="${SCRIPT_DIR}/postflight-check.sh"
 	[[ -x "$postflight" ]] || return 1
-	bash "$postflight" --quick >/dev/null 2>&1 || return 1
+	bash "$postflight" --quick --sha "$release_sha" >/dev/null 2>&1 || return 1
 	return 0
 }
 

--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -32,6 +32,7 @@ PASSED=0
 FAILED=0
 WARNINGS=0
 SKIPPED=0
+POSTFLIGHT_COMMIT_SHA=""
 
 print_header() {
 	echo -e "${BLUE}========================================${NC}"
@@ -125,13 +126,17 @@ check_cicd_status() {
 
 	print_info "Repository: $repo"
 
-	# Get latest workflow run
+	# Get the latest workflow run for the exact release commit when supplied.
 	local latest_run
-	latest_run=$(gh run list --repo "$repo" --limit=1 --json databaseId,status,conclusion,name 2>/dev/null || echo "")
+	if [[ -n "$POSTFLIGHT_COMMIT_SHA" ]]; then
+		latest_run=$(gh run list --repo "$repo" --commit "$POSTFLIGHT_COMMIT_SHA" --limit=1 --json databaseId,status,conclusion,name 2>/dev/null || echo "")
+	else
+		latest_run=$(gh run list --repo "$repo" --limit=1 --json databaseId,status,conclusion,name 2>/dev/null || echo "")
+	fi
 
 	if [[ -z "$latest_run" || "$latest_run" == "[]" ]]; then
-		print_warning "No workflow runs found"
-		return 0
+		print_error "No workflow runs found for release evidence"
+		return 1
 	fi
 
 	local run_id status conclusion name
@@ -189,7 +194,11 @@ check_cicd_status() {
 	# Check all recent workflows
 	print_info "Checking all recent workflows..."
 	local all_runs
-	all_runs=$(gh run list --repo "$repo" --limit=5 --json name,conclusion,status 2>/dev/null || echo "[]")
+	if [[ -n "$POSTFLIGHT_COMMIT_SHA" ]]; then
+		all_runs=$(gh run list --repo "$repo" --commit "$POSTFLIGHT_COMMIT_SHA" --limit=5 --json name,conclusion,status 2>/dev/null || echo "[]")
+	else
+		all_runs=$(gh run list --repo "$repo" --limit=5 --json name,conclusion,status 2>/dev/null || echo "[]")
+	fi
 
 	local failed_count
 	failed_count=$(echo "$all_runs" | jq '[.[] | select(.conclusion == "failure")] | length')
@@ -383,28 +392,6 @@ check_npm_audit() {
 	return 0
 }
 
-# Run local quality checks
-check_local_quality() {
-	print_section "Local Quality Checks"
-
-	local quality_script="$REPO_ROOT/.agents/scripts/linters-local.sh"
-
-	if [[ -f "$quality_script" ]]; then
-		print_info "Running linters-local.sh --full..."
-
-		if bash "$quality_script" --full &>/dev/null; then
-			print_success "Local quality checks passed"
-		else
-			print_warning "Local quality checks reported issues"
-			print_info "Run: bash $quality_script --full (for details)"
-		fi
-	else
-		print_skip "linters-local.sh not found"
-	fi
-
-	return 0
-}
-
 # Print summary
 print_summary() {
 	echo ""
@@ -447,6 +434,7 @@ show_usage() {
 	echo "  --full          Run all checks (default)"
 	echo "  --ci-only       Run CI/CD checks only"
 	echo "  --security-only Run security checks only"
+	echo "  --sha SHA       Verify CI evidence for this exact release commit"
 	echo "  --help          Show this help message"
 	echo ""
 	echo "Examples:"
@@ -479,6 +467,14 @@ main() {
 		--security-only)
 			mode="security-only"
 			shift
+			;;
+		--sha)
+			if [[ $# -lt 2 || -z "$2" ]]; then
+				echo "--sha requires a commit SHA"
+				return 1
+			fi
+			POSTFLIGHT_COMMIT_SHA="$2"
+			shift 2
 			;;
 		--help | -h)
 			show_usage
@@ -513,10 +509,6 @@ main() {
 		check_cicd_status || true
 		check_sonarcloud || true
 		check_codacy || true
-		check_snyk || true
-		check_secrets || true
-		check_npm_audit || true
-		check_local_quality || true
 		;;
 	*)
 		print_error "Unknown mode: $mode"

--- a/.agents/scripts/tests/test-postflight-no-source-rescan.sh
+++ b/.agents/scripts/tests/test-postflight-no-source-rescan.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Regression guard: routine postflight observes release evidence and must not
+# duplicate source scans already owned by development, CI, and release preflight.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+POSTFLIGHT="$ROOT_DIR/.agents/scripts/postflight-check.sh"
+WORKFLOW="$ROOT_DIR/.github/workflows/postflight.yml"
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+assert_absent() {
+	local pattern="$1"
+	local file="$2"
+	local description="$3"
+	if grep -Eq -- "$pattern" "$file"; then
+		fail "$description"
+		return 1
+	fi
+	return 0
+}
+
+full_mode_body() {
+	awk '
+		/^[[:space:]]*full\)/ { in_full = 1; next }
+		in_full && /^[[:space:]]*;;/ { exit }
+		in_full { print }
+	' "$POSTFLIGHT"
+	return 0
+}
+
+main() {
+	assert_absent 'linters-local\.sh.*--full|check_local_quality' "$POSTFLIGHT" \
+		'postflight must not invoke full local lint'
+	local full_body=""
+	full_body=$(full_mode_body)
+	if grep -Eq 'check_(snyk|secrets|npm_audit|local_quality)' <<<"$full_body"; then
+		fail 'routine postflight must not invoke local source scans'
+		return 1
+	fi
+	assert_absent 'bun install -g snyk|bunx --no-install secretlint|name: Security Scan with Snyk|name: Check for Secrets' "$WORKFLOW" \
+		'automated postflight must not reinstall scanners or rescan source'
+	grep -Fq -- "--commit \"\$POSTFLIGHT_COMMIT_SHA\"" "$POSTFLIGHT" ||
+		fail 'local postflight must query exact-SHA workflow evidence'
+	grep -Fq 'steps.release_commit.outputs.sha' "$WORKFLOW" ||
+		fail 'automated postflight must bind checks and reports to the checked-out release SHA'
+	grep -Fq 'remained non-terminal after timeout' "$WORKFLOW" ||
+		fail 'automated postflight must fail when check runs remain pending'
+	grep -Fq 'No terminal check-run evidence exists' "$WORKFLOW" ||
+		fail 'automated postflight must fail when release evidence is absent'
+	printf 'PASS: postflight reuses terminal release evidence without source rescans\n'
+	return 0
+}
+
+main "$@"

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -365,8 +365,12 @@ from `_parse_phases_section` — then add new logic to the slimmed parent functi
       a follow-up. -->
 
 ```bash
-{Command(s) to confirm the implementation works — e.g., shellcheck, grep, test run}
+{Focused test(s) covering the changed behaviour}
+{Changed-file or affected-package lint/typecheck/build; for aidevops use .agents/scripts/linters-local.sh --changed}
 ```
+
+- **Broad verification trigger:** {Not required | exact evidence that shared config, root tooling, dependency graph, cross-package contracts, or release infrastructure requires a full-repository gate}
+- **Broad verification command:** {Delete when not triggered; never add `linters-local.sh --full` merely as generic completion evidence}
 
 ### Recoverability Checkpoint
 
@@ -378,7 +382,7 @@ from `_parse_phases_section` — then add new logic to the slimmed parent functi
 
 - [ ] Focused tests pass: `{command}`
 - [ ] WIP commit created before broad gates: `wip: {short description}`
-- [ ] Broad verification then run: `{command}`
+- [ ] Evidence-triggered broad verification then run: `{command or not required — reason}`
 
 ### Safety-Stop Recovery
 
@@ -471,8 +475,8 @@ that defines how to machine-check the criterion. See `.agents/scripts/verify-bri
     prompt: "{what the human should check}"
   ```
 
-- [ ] Tests pass (`npm test` / `bun test` / project-specific)
-- [ ] Lint clean (`eslint` / `shellcheck` / project-specific; React/TypeScript ESLint warnings such as `react-hooks/exhaustive-deps` count as actionable even when lint exits `0`)
+- [ ] Task-relevant tests pass (`npm test -- <target>` / `bun test <target>` / project-specific affected test command)
+- [ ] Changed-file or affected-package lint is clean (`linters-local.sh --changed` / scoped `eslint` / `shellcheck`; React/TypeScript ESLint warnings such as `react-hooks/exhaustive-deps` count as actionable even when lint exits `0`)
 - [ ] UI changes cite the checked/updated DESIGN.md source or a follow-up issue; layout changes include mobile/tablet/desktop responsive evidence and named accessibility checks.
 - [ ] Qlty smells resolved (for `#simplification` tasks): `~/.qlty/bin/qlty smells --all 2>&1 | grep '<target_file>' | grep -c . | grep -q '^0$'`
 

--- a/.agents/templates/tasks-template.md
+++ b/.agents/templates/tasks-template.md
@@ -58,7 +58,7 @@ Update after completing each sub-task, not just parent tasks.
 
 - [ ] 4.0 Testing ~{Xh} (ai:{Xm} test:{Xh})
   - [ ] 4.1 Write unit tests for new functionality ~{Xm}
-  - [ ] 4.2 Run full test suite and fix failures ~{Xm}
+  - [ ] 4.2 Run targeted and affected-package tests; broaden only when change evidence requires it ~{Xm}
   - [ ] 4.3 Manual testing of feature ~{Xm}
 
 - [ ] 5.0 Documentation ~{Xm} (ai:{Xm} read:{Xm})
@@ -67,7 +67,7 @@ Update after completing each sub-task, not just parent tasks.
   - [ ] 5.3 Update CHANGELOG.md ~{Xm}
 
 - [ ] 6.0 Quality & Review ~{Xm} (ai:{Xm} test:{Xm})
-  - [ ] 6.1 Run linters: `.agents/scripts/linters-local.sh` ~{Xm}
+  - [ ] 6.1 Run changed-file/affected lint: `.agents/scripts/linters-local.sh --changed` ~{Xm}
   - [ ] 6.2 Self-review code changes ~{Xm}
   - [ ] 6.3 Commit with descriptive message ~{Xm}
   - [ ] 6.4 Push worktree ref and create PR ~{Xm}

--- a/.agents/workflows/branch/release.md
+++ b/.agents/workflows/branch/release.md
@@ -42,8 +42,10 @@ ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add release/1
 version-manager.sh bump {patch|minor|major}
 # Edit CHANGELOG.md
 
-# 2. Run final checks
-linters-local.sh --full
+# 2. Reuse terminal CI/lint evidence for the exact release SHA. Run a broad
+# gate only when SHA-matched evidence is unavailable or shared/root contracts
+# were not covered by affected checks:
+# linters-local.sh --full
 
 # 3. After implementation PRs merge, release from a fresh detached linked worktree
 git worktree add --detach "$AIDEVOPS_WORKTREE_BASE_DIR/repo-release-1-2-0" origin/main

--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -170,6 +170,14 @@ Every piece of GitHub-written content mentors the next reader. Apply these check
 
 A dispatch comment that says "implement issue #42" teaches nothing. One that says "edit `src/auth.ts:45` — replace `([^0-9]|$)` with `\b` — verify with `shellcheck src/auth.ts`" enables tier:simple dispatch.
 
+Verification commands must also mentor efficient execution. Brief ordinary code
+work with focused tests plus changed-file or affected-package lint/typecheck.
+Include a full-repository gate only when named blast-radius evidence requires it
+(shared config, root tooling, dependency graph, cross-package contracts, or
+release infrastructure); never use `linters-local.sh --full` as generic
+completion evidence. Release and postflight reuse terminal evidence for the
+exact SHA instead of duplicating source scans.
+
 ## How to Use This Agent
 
 - **Routing**: See `brief/routing.md` for when to use this agent (work item creation, comments, PR descriptions)

--- a/.agents/workflows/bug-fixing.md
+++ b/.agents/workflows/bug-fixing.md
@@ -38,14 +38,17 @@ Identify root cause before writing code. Document findings in the commit message
 ## 3. Test
 
 - [ ] Bug is fixed, no regression in related functionality
-- [ ] Automated test suite and quality checks pass
+- [ ] Regression and affected-package tests and quality checks pass
 - [ ] Tested on latest and minimum supported versions
 
 ```bash
-# Project-specific test runner (npm test, composer test, pytest, etc.)
-# Then framework quality checks:
-~/.aidevops/agents/scripts/linters-local.sh
+# Project-specific regression test, then affected-package tests when needed
+~/.aidevops/agents/scripts/linters-local.sh --changed
 ```
+
+Do not run a full-repository gate for generic completion evidence. Broaden only
+when the fix changes shared config, root tooling, the dependency graph,
+cross-package contracts, or release infrastructure.
 
 **Frontend bugs (CRITICAL):** HTTP 200 does NOT verify frontend fixes — server returns 200 even when React crashes client-side. Use browser screenshot via `dev-browser-helper.sh start`. See `tools/ui/frontend-debugging.md`.
 
@@ -105,6 +108,6 @@ Standard bugs use the normal worktree + PR flow via `/full-loop`.
 
 - [ ] Root cause identified and documented in commit
 - [ ] Fix is minimal and focused — no unrelated changes
-- [ ] Regression test added, all tests pass
-- [ ] Quality checks pass (`linters-local.sh`)
+- [ ] Regression test added; targeted and affected-package tests pass
+- [ ] Changed-file/affected quality checks pass (`linters-local.sh --changed` for aidevops)
 - [ ] CHANGELOG updated, docs updated if user-facing

--- a/.agents/workflows/feature-development.md
+++ b/.agents/workflows/feature-development.md
@@ -68,9 +68,13 @@ Do NOT update version numbers during development. Version bump happens after the
 - [ ] Accessibility requirements met (if UI)
 
 ```bash
-npm test          # or: composer test
-bash ~/.aidevops/agents/scripts/linters-local.sh
+npm test -- <affected-test> # or the project-specific targeted test command
+bash ~/.aidevops/agents/scripts/linters-local.sh --changed
 ```
+
+Broaden to affected packages next. Run a full-repository gate only when the
+feature changes shared config, root tooling, the dependency graph,
+cross-package contracts, or release infrastructure; record that trigger.
 
 ### 7. Commit
 
@@ -97,4 +101,4 @@ Closes #123"
 1. **TODO.md**: Move task to Done section with date
 2. **todo/PLANS.md**: Update status and outcomes (if applicable)
 3. **CHANGELOG.md**: Add entry following `workflows/changelog.md` format
-4. Quality checks pass (`linters-local.sh`)
+4. Targeted tests and changed-file/affected quality checks pass (`linters-local.sh --changed` for aidevops)

--- a/.agents/workflows/postflight.md
+++ b/.agents/workflows/postflight.md
@@ -61,22 +61,24 @@ Check both `main` and tag refs: `gh run list --branch=main --limit=5` and `gh ru
 | CodeRabbit | No blocking issues |
 | Qlty | No new violations |
 
-### 3. Security Scanning
+### 3. Security Evidence
 
 | Tool | Threshold |
 |------|-----------|
-| Snyk | No new high/critical vulnerabilities |
-| Secretlint | No exposed secrets |
-| npm audit | No high/critical issues |
+| Required CI security checks | Terminal success for the released SHA |
 | Dependabot | No new alerts |
 
 ## Running Postflight
 
 Wait for `postflight.yml` GH Actions workflow to complete before running locally. Only declare success if ALL workflows passed.
 
-**Local**: `.agents/scripts/postflight-check.sh` — runs CI/CD wait, SonarCloud gate, Snyk, and Secretlint checks with proper timeouts and error handling.
+**Local**: `.agents/scripts/postflight-check.sh` — verifies CI/CD and external
+quality-gate state. It does not rescan source: targeted/affected checks belong to
+development and PR CI, while release preflight owns any evidence-triggered broad
+gate. Use `--security-only` only for explicit diagnostics, not routine release
+completion.
 
-**Automated**: `.github/workflows/postflight.yml` — triggers on `release: published` and `workflow_dispatch`. Runs the same checks in CI with step summary reporting.
+**Automated**: `.github/workflows/postflight.yml` — triggers on `release: published` and `workflow_dispatch`. Reports terminal CI and external quality evidence without reinstalling scanners or duplicating source analysis.
 
 Do not duplicate these scripts inline — they are the source of truth. Read them directly when implementation details are needed.
 
@@ -108,7 +110,9 @@ ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add hotfix/v{
 # git add <changed-files> && git commit -m "fix: resolve critical issue" && ./.agents/scripts/version-manager.sh release patch
 ```
 
-Post-rollback: `gh run list --limit=5 && .agents/scripts/linters-local.sh`
+Post-rollback: verify terminal CI and deployment health for the rollback SHA. A
+hotfix returns through targeted development checks and normal release preflight;
+postflight does not rerun source lint.
 
 ## Handling SonarCloud Quality Gate Failures
 

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -33,8 +33,14 @@ Requires a fresh detached release worktree at synchronized `origin/main`, verifi
 
 ## Manual Release (Non-aidevops Repos)
 
+Reuse terminal-success CI and lint evidence for the exact release SHA. Do not
+repeat a full source scan merely because release follows every merge. Run the
+repository's broad gate only when no trustworthy SHA-matched evidence exists or
+the release changes shared/root contracts that were not covered by affected
+checks.
+
 ```bash
-./.agents/scripts/linters-local.sh --full
+# Conditional only: ./.agents/scripts/linters-local.sh --full
 git add -A && git commit -m "chore(release): prepare v{MAJOR}.{MINOR}.{PATCH}"
 ./.agents/scripts/version-manager.sh tag
 git push origin main && git push origin --tags
@@ -54,7 +60,10 @@ git push origin main && git push origin --tags
 .agents/scripts/version-manager.sh auto-mark-tasks  # Run manually
 ```
 
-**Postflight**: `./.agents/scripts/postflight-check.sh` — see `workflows/postflight.md`.
+**Postflight**: `./.agents/scripts/postflight-check.sh` verifies terminal CI,
+external quality gates, publication, and deployment health. It does not rerun
+source lint/security scans already owned by development, CI, and release
+preflight. See `workflows/postflight.md`.
 
 **Follow-up**: Verify artifacts/download links, update docs site, notify stakeholders, close milestone.
 

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -30,6 +30,10 @@ jobs:
       with:
         ref: ${{ github.event.inputs.tag || github.ref }}
         fetch-depth: 0
+
+    - name: Resolve release commit
+      id: release_commit
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
     
     - name: Setup Bun
       uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
@@ -40,7 +44,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
-        COMMIT_SHA: ${{ github.sha }}
+        COMMIT_SHA: ${{ steps.release_commit.outputs.sha }}
       run: |
         echo "Waiting for all check runs to complete..."
         echo "Note: Excluding this workflow (Verify Release Health) to avoid circular dependency"
@@ -63,13 +67,20 @@ jobs:
             --jq ".check_runs[] | select(.status != \"completed\" and .name != \"$SELF_NAME\") | \"  - \(.name): \(.status)\"" || true
           sleep 30
         done
+
+        REMAINING=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
+          --jq "[.check_runs[] | select(.status != \"completed\" and .name != \"$SELF_NAME\")] | length")
+        if [[ "$REMAINING" != "0" ]]; then
+          echo "::error::$REMAINING check runs remained non-terminal after timeout"
+          exit 1
+        fi
     
     - name: Verify CI/CD Status
       id: cicd
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
-        COMMIT_SHA: ${{ github.sha }}
+        COMMIT_SHA: ${{ steps.release_commit.outputs.sha }}
       run: |
         echo "## CI/CD Pipeline Status" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -110,6 +121,11 @@ jobs:
         PASSED=$(echo "$CHECK_RUNS" | jq -s '[.[] | select(.conclusion == "success")] | length')
         SKIPPED=$(echo "$CHECK_RUNS" | jq -s '[.[] | select(.conclusion == "skipped")] | length')
         FAILED=$(echo "$CHECK_RUNS" | jq -s '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length')
+
+        if [[ "$TOTAL" == "0" ]]; then
+          echo "::error::No terminal check-run evidence exists for release commit ${COMMIT_SHA}"
+          exit 1
+        fi
         
         echo "| Check | Status | Conclusion |" >> $GITHUB_STEP_SUMMARY
         echo "|-------|--------|------------|" >> $GITHUB_STEP_SUMMARY
@@ -191,82 +207,14 @@ jobs:
         fi
       continue-on-error: true
     
-    - name: Security Scan with Snyk
-      if: always()
-      id: snyk
-      run: |
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## Security Scan (Snyk)" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        
-        # Install Snyk (Bun for faster install)
-        bun install -g snyk
-        
-        # Authenticate if token available
-        if [[ -n "$SNYK_TOKEN" ]]; then
-          snyk auth "$SNYK_TOKEN"
-          
-          # Run security scan
-          if snyk test --severity-threshold=high --json > snyk-results.json 2>/dev/null; then
-            echo "**Status**: No high/critical vulnerabilities found" >> $GITHUB_STEP_SUMMARY
-            echo "snyk_status=passed" >> $GITHUB_OUTPUT
-          else
-            VULN_COUNT=$(jq '.vulnerabilities | length // 0' snyk-results.json)
-            echo "**Status**: $VULN_COUNT vulnerabilities found" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Severity | Package | Title |" >> $GITHUB_STEP_SUMMARY
-            echo "|----------|---------|-------|" >> $GITHUB_STEP_SUMMARY
-            jq -r '.vulnerabilities[:5][] | "| \(.severity) | \(.packageName) | \(.title) |"' snyk-results.json >> $GITHUB_STEP_SUMMARY 2>/dev/null || true
-            echo "snyk_status=issues" >> $GITHUB_OUTPUT
-          fi
-        else
-          echo "**Status**: Skipped (SNYK_TOKEN not configured)" >> $GITHUB_STEP_SUMMARY
-          echo "snyk_status=skipped" >> $GITHUB_OUTPUT
-        fi
-      env:
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      continue-on-error: true
-    
-    - name: Check for Secrets
-      if: always()
-      id: secrets
-      run: |
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## Secret Detection (Secretlint)" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        
-        # Install the repo-pinned secretlint stack. Using the latest global
-        # secretlint can add release-only rules that trip intentional fixture
-        # strings before the repository has opted in to the new major version.
-        bun install --frozen-lockfile
-        
-        # Run scan. Keep intentional credential-scrubber fixtures out of the
-        # release gate while scanning every other production/source path.
-        SECRET_LINT_TARGETS=(
-          "**/*"
-          "!.agents/scripts/tests/test-credential-sanitizer.sh"
-          "!.agents/scripts/tests/test-credential-transcript-scrub.sh"
-        )
-        if bunx --no-install secretlint "${SECRET_LINT_TARGETS[@]}" --secretlintrc .secretlintrc.json --secretlintignore .secretlintignore --format compact 2>/dev/null; then
-          echo "**Status**: No secrets detected" >> $GITHUB_STEP_SUMMARY
-          echo "secrets_status=passed" >> $GITHUB_OUTPUT
-        else
-          echo "**Status**: Potential secrets detected" >> $GITHUB_STEP_SUMMARY
-          echo "::error::Potential secrets detected in codebase"
-          echo "secrets_status=failed" >> $GITHUB_OUTPUT
-        fi
-      continue-on-error: true
-    
     - name: Generate Final Report
       id: report
       if: always()
       env:
         CICD_STATUS: ${{ steps.cicd.outputs.cicd_status }}
         SONAR_STATUS: ${{ steps.sonarcloud.outputs.sonar_status }}
-        SNYK_STATUS: ${{ steps.snyk.outputs.snyk_status }}
-        SECRETS_STATUS: ${{ steps.secrets.outputs.secrets_status }}
         RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
-        COMMIT_SHA: ${{ github.sha }}
+        COMMIT_SHA: ${{ steps.release_commit.outputs.sha }}
       run: |
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "---" >> $GITHUB_STEP_SUMMARY
@@ -277,15 +225,11 @@ jobs:
         # Default unset outputs to 'skipped' (step didn't produce output)
         CICD="${CICD_STATUS:-skipped}"
         SONAR="${SONAR_STATUS:-skipped}"
-        SNYK="${SNYK_STATUS:-skipped}"
-        SECRETS="${SECRETS_STATUS:-skipped}"
         
         echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
         echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
         echo "| CI/CD Pipelines | ${CICD} |" >> $GITHUB_STEP_SUMMARY
         echo "| SonarCloud | ${SONAR} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Snyk Security | ${SNYK} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Secret Detection | ${SECRETS} |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Release**: ${RELEASE_TAG}" >> $GITHUB_STEP_SUMMARY
         echo "**Commit**: ${COMMIT_SHA}" >> $GITHUB_STEP_SUMMARY
@@ -294,19 +238,15 @@ jobs:
         echo "*Generated by AI DevOps Framework Postflight Verification*" >> $GITHUB_STEP_SUMMARY
         
         # Determine overall result
-        # Critical failures: CI/CD hard failures or secrets detected
+        # Critical failures: terminal CI/CD hard failures.
         HAS_CRITICAL=false
         HAS_WARNING=false
         
         if [[ "$CICD" == "failed" ]]; then
           HAS_CRITICAL=true
         fi
-        if [[ "$SECRETS" == "failed" ]]; then
-          HAS_CRITICAL=true
-        fi
-        
-        # Warnings: advisory failures, SonarCloud issues, Snyk issues
-        if [[ "$CICD" == "warning" || "$SONAR" == "failed" || "$SNYK" == "issues" ]]; then
+        # Warnings: advisory failures or SonarCloud issues.
+        if [[ "$CICD" == "warning" || "$SONAR" == "failed" ]]; then
           HAS_WARNING=true
         fi
         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- make coding briefs and release postflight reuse scoped, exact-SHA quality evidence instead of repeating full source scans
+
 ## [3.32.61] - 2026-07-12
 
 ### Added


### PR DESCRIPTION
## Summary

Make briefing and coding agents prescribe targeted plus changed/affected checks, remove duplicate postflight source scans, and bind release evidence to the exact SHA.

## Files Changed

.agents/build-plus.md, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/postflight-check.sh, .agents/scripts/tests/test-postflight-no-source-rescan.sh, .agents/templates/brief-template.md, .agents/templates/tasks-template.md, .agents/workflows/branch/release.md, .agents/workflows/brief.md, .agents/workflows/bug-fixing.md, .agents/workflows/feature-development.md, .agents/workflows/postflight.md, .agents/workflows/release.md, .github/workflows/postflight.yml, CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Changed-file lint, ShellCheck, shfmt, postflight regression tests, full-loop completion evidence tests, and workflow YAML parsing passed.

Resolves #27343


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 with gpt-5.6-sol spent 1h 5m and 180,417 tokens on this with the user in an interactive session.