### PR TITLE
GH#27345: allow OpenCode access to managed aidevops directories

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -49,7 +49,7 @@ export function registerManagedDirectoryPermissions(config) {
 
   const rules = typeof existing === "string"
     ? { "*": existing }
-    : { ...(existing || {}) };
+    : { ...existing };
   let count = 0;
   for (const path of MANAGED_EXTERNAL_DIRECTORIES) {
     if (rules[path] !== "allow") count++;

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -21,6 +21,47 @@ import {
   GPT56_OUTPUT_DEFAULT,
 } from "./model-limits.mjs";
 
+const MANAGED_EXTERNAL_DIRECTORIES = [
+  "~/.aidevops",
+  "~/.aidevops/**",
+  "~/.config/aidevops",
+  "~/.config/aidevops/**",
+  "~/Git/_worktrees",
+  "~/Git/_worktrees/**",
+];
+
+/**
+ * Allow OpenCode to use aidevops-managed state and linked worktrees without
+ * repeatedly asking for external-directory approval. Keep the exception
+ * narrow: unrelated paths retain the user's existing permission policy.
+ * @param {object} config - OpenCode Config object (mutable)
+ * @returns {number} number of managed allow rules added or corrected
+ */
+export function registerManagedDirectoryPermissions(config) {
+  if (typeof config.permission === "string") {
+    config.permission = { external_directory: { "*": config.permission } };
+  } else if (!config.permission) {
+    config.permission = {};
+  }
+
+  const existing = config.permission.external_directory;
+  if (existing === "allow") return 0;
+
+  const rules = typeof existing === "string"
+    ? { "*": existing }
+    : { ...(existing || {}) };
+  let count = 0;
+  for (const path of MANAGED_EXTERNAL_DIRECTORIES) {
+    if (rules[path] !== "allow") count++;
+    // OpenCode uses the last matching rule, so managed exceptions must follow
+    // broad user defaults such as `"*": "ask"`.
+    delete rules[path];
+    rules[path] = "allow";
+  }
+  config.permission.external_directory = rules;
+  return count;
+}
+
 /**
  * Shared model definition template for Claude models managed by aidevops.
  * @param {object} overrides
@@ -309,6 +350,7 @@ function logConfigSummary(counts) {
     [counts.agents, "agents"],
     [counts.mcps, "MCPs"],
     [counts.agentTools, "agent tool perms"],
+    [counts.directories, "managed directory perms"],
     [counts.poolCleaned, `cleaned ${counts.poolCleaned} stale pool provider${counts.poolCleaned === 1 ? "" : "s"}`],
     [counts.anthropic, "anthropic models"],
     [counts.openai, "OpenAI context limits"],
@@ -356,6 +398,7 @@ export function createConfigHook(deps) {
 
     const mcps = registerMcpServers(config);
     const agentTools = applyAgentMcpTools(config);
+    const directories = registerManagedDirectoryPermissions(config);
     const poolCleaned = registerPoolProvider(config);
     const anthropic = registerAnthropicModels(config);
     const openai = registerGpt56ContextLimits(config);
@@ -393,7 +436,7 @@ export function createConfigHook(deps) {
     const claude = registerClaudeCliModels(config);
 
     logConfigSummary(
-      { agents, mcps, agentTools, poolCleaned, anthropic, openai, cursor, google, claude },
+      { agents, mcps, agentTools, directories, poolCleaned, anthropic, openai, cursor, google, claude },
     );
     logVersionDriftAsync(pluginDir);
   };

--- a/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerManagedDirectoryPermissions } from "../config-hook.mjs";
+
+const managedRules = {
+  "~/.aidevops": "allow",
+  "~/.aidevops/**": "allow",
+  "~/.config/aidevops": "allow",
+  "~/.config/aidevops/**": "allow",
+  "~/Git/_worktrees": "allow",
+  "~/Git/_worktrees/**": "allow",
+};
+
+test("adds narrow managed-directory exceptions after a broad ask rule", () => {
+  const config = {
+    permission: {
+      external_directory: {
+        "*": "ask",
+        "~/Documents/**": "deny",
+      },
+    },
+  };
+
+  assert.equal(registerManagedDirectoryPermissions(config), 6);
+  assert.deepEqual(config.permission.external_directory, {
+    "*": "ask",
+    "~/Documents/**": "deny",
+    ...managedRules,
+  });
+});
+
+test("converts a top-level default without allowing unrelated directories", () => {
+  const config = { permission: "ask" };
+
+  assert.equal(registerManagedDirectoryPermissions(config), 6);
+  assert.deepEqual(config.permission.external_directory, {
+    "*": "ask",
+    ...managedRules,
+  });
+});
+
+test("leaves an existing global external-directory allow unchanged", () => {
+  const config = { permission: { external_directory: "allow", read: "ask" } };
+
+  assert.equal(registerManagedDirectoryPermissions(config), 0);
+  assert.deepEqual(config.permission, { external_directory: "allow", read: "ask" });
+});
+
+test("is idempotent and keeps managed rules last", () => {
+  const config = { permission: { external_directory: { "*": "ask" } } };
+
+  assert.equal(registerManagedDirectoryPermissions(config), 6);
+  assert.equal(registerManagedDirectoryPermissions(config), 0);
+  assert.deepEqual(Object.keys(config.permission.external_directory).slice(-6), Object.keys(managedRules));
+});


### PR DESCRIPTION
## Summary

Register narrow OpenCode external-directory allow rules for aidevops state, aidevops config, and linked worktrees while preserving the existing policy for unrelated paths.

## Files Changed

.agents/plugins/opencode-aidevops/config-hook.mjs, .agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** OpenCode plugin test suite: 357 passing; local linters passed; git diff --check passed.

Resolves #27345


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 6m and 95,803 tokens on this with the user in an interactive session.