### PR TITLE
GH#27338: reconcile dependency chains on issue closure

### DIFF
--- a/.agents/scripts/dependency-event-reconciler.sh
+++ b/.agents/scripts/dependency-event-reconciler.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+[[ -n "${_DEPENDENCY_EVENT_RECONCILER_LOADED:-}" ]] && return 0
+_DEPENDENCY_EVENT_RECONCILER_LOADED=1
+
+_der_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_der_dir" == "${BASH_SOURCE[0]}" ]] && _der_dir="."
+# shellcheck source=./task-identity-lib.sh
+source "${_der_dir}/task-identity-lib.sh"
+unset _der_dir
+
+_der_dependency_text() {
+	local body="$1"
+	printf '%s' "$body" | grep -ioE 'blocked[- ][Bb]y[^[:cntrl:]]*' || true
+	return 0
+}
+
+_der_issue_refs() {
+	local text="$1"
+	_der_dependency_text "$text" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -u || true
+	return 0
+}
+
+_der_task_refs() {
+	local text="$1"
+	task_identity_extract_all "$(_der_dependency_text "$text")" | sort -u || true
+	return 0
+}
+
+_der_has_hold() {
+	local body="$1"
+	local comments="$2"
+	local labels="$3"
+	printf '%s\n%s\n%s\n' "$body" "$comments" "$labels" |
+		grep -qiE 'defer until|do[-[:space:]]not[-[:space:]]dispatch|on[-[:space:]]hold|HUMAN_UNBLOCK_REQUIRED|hold for |paused[[:space:]:]|worker[_ -]blocked|terminal[_ -]blocker|needs-maintainer-review'
+	return $?
+}
+
+_der_has_active_status() {
+	local labels="$1"
+	[[ ",${labels}," == *",status:queued,"* || ",${labels}," == *",status:claimed,"* ||
+		",${labels}," == *",status:in-progress,"* || ",${labels}," == *",status:in-review,"* ||
+		",${labels}," == *",status:done,"* ]]
+	return $?
+}
+
+_der_fetch_closed_context() {
+	local owner="$1"
+	local name="$2"
+	local closed_number="$3"
+	# shellcheck disable=SC2016
+	gh api graphql -f query='
+query($owner:String!,$name:String!,$number:Int!) {
+  repository(owner:$owner,name:$name) {
+    nameWithOwner
+    issue(number:$number) {
+      number state title
+      blocking(first:100) {
+        nodes { number state title body repository { nameWithOwner } labels(first:100) { nodes { name } pageInfo { hasNextPage } } }
+        pageInfo { hasNextPage }
+      }
+    }
+  }
+}' -F owner="$owner" -F name="$name" -F number="$closed_number" 2>/dev/null
+	return $?
+}
+
+# Search is deliberately capped. More than 100 matches, another page, malformed
+# nodes, or a repository mismatch is ambiguity and therefore blocks mutation.
+_der_search_issues() {
+	local repo="$1"
+	local search_query="$2"
+	local result=""
+	# shellcheck disable=SC2016
+	result=$(gh api graphql -f query='
+query($query:String!) {
+  search(query:$query,type:ISSUE,first:100) {
+    issueCount pageInfo { hasNextPage }
+    nodes {
+      __typename
+      ... on Issue {
+        number state title body repository { nameWithOwner }
+        labels(first:100) { nodes { name } pageInfo { hasNextPage } }
+      }
+    }
+  }
+}' -F query="$search_query" 2>/dev/null) || return 1
+	printf '%s' "$result" | jq -ce --arg repo "$repo" '
+      .data.search
+      | select((.issueCount | type) == "number" and .issueCount <= 100)
+      | select(.pageInfo.hasNextPage == false)
+      | select(all(.nodes[];
+          .__typename == "Issue"
+          and .repository.nameWithOwner == $repo
+          and .labels.pageInfo.hasNextPage == false))
+      | .nodes' 2>/dev/null
+	return $?
+}
+
+_der_candidate_declares() {
+	local candidate_json="$1"
+	local closed_number="$2"
+	local closed_task_id="$3"
+	local text="" ref=""
+	text=$(printf '%s' "$candidate_json" | jq -r '(.body // "") + "\n" + ([.labels.nodes[].name] | join("\n"))') || return 1
+	while IFS= read -r ref; do
+		[[ "$ref" == "$closed_number" ]] && return 0
+	done < <(_der_issue_refs "$text")
+	if [[ -n "$closed_task_id" ]]; then
+		while IFS= read -r ref; do
+			[[ "$ref" == "$closed_task_id" ]] && return 0
+		done < <(_der_task_refs "$text")
+	fi
+	return 1
+}
+
+_der_collect_candidates() {
+	local repo="$1"
+	local closed_number="$2"
+	local closed_task_id="$3"
+	local context="$4"
+	local query="" result="" candidate="" number="" seen=","
+	local native_numbers=""
+	native_numbers=$(printf '%s' "$context" | jq -r '.data.repository.issue.blocking.nodes[].number' 2>/dev/null) || return 1
+
+	for query in \
+		"repo:${repo} is:issue is:open in:body \"#${closed_number}\"" \
+		"repo:${repo} is:issue is:open label:\"blocked-by:#${closed_number}\""; do
+		result=$(_der_search_issues "$repo" "$query") || return 1
+		while IFS= read -r candidate; do
+			[[ -n "$candidate" ]] || continue
+			_der_candidate_declares "$candidate" "$closed_number" "$closed_task_id" || continue
+			number=$(printf '%s' "$candidate" | jq -r '.number') || return 1
+			[[ "$seen" == *",${number},"* ]] && continue
+			printf '%s\n' "$candidate"
+			seen="${seen}${number},"
+		done < <(printf '%s' "$result" | jq -c '.[]')
+	done
+
+	if [[ -n "$closed_task_id" ]]; then
+		for query in \
+			"repo:${repo} is:issue is:open in:body \"${closed_task_id}\"" \
+			"repo:${repo} is:issue is:open label:\"blocked-by:${closed_task_id}\""; do
+			result=$(_der_search_issues "$repo" "$query") || return 1
+			while IFS= read -r candidate; do
+				[[ -n "$candidate" ]] || continue
+				_der_candidate_declares "$candidate" "$closed_number" "$closed_task_id" || continue
+				number=$(printf '%s' "$candidate" | jq -r '.number') || return 1
+				[[ "$seen" == *",${number},"* ]] && continue
+				printf '%s\n' "$candidate"
+				seen="${seen}${number},"
+			done < <(printf '%s' "$result" | jq -c '.[]')
+		done
+	fi
+
+	while IFS= read -r candidate; do
+		[[ -n "$candidate" ]] || continue
+		number=$(printf '%s' "$candidate" | jq -r '.number') || return 1
+		[[ "$seen" == *",${number},"* ]] && continue
+		printf '%s\n' "$candidate"
+		seen="${seen}${number},"
+	done < <(printf '%s' "$context" | jq -c '.data.repository.issue.blocking.nodes[]')
+	# Empty native relationships are valid; ensure malformed extraction did not
+	# silently turn a non-empty connection into no candidates.
+	[[ -z "$native_numbers" || "$native_numbers" =~ ^[0-9] ]] || return 1
+	return 0
+}
+
+_der_live_issue_closed() {
+	local repo="$1"
+	local issue_number="$2"
+	local state=""
+	state=$(gh issue view "$issue_number" --repo "$repo" --json state --jq '.state' 2>/dev/null) || return 1
+	[[ "$state" == "CLOSED" || "$state" == "closed" ]]
+	return $?
+}
+
+_der_find_task_issue() {
+	local repo="$1"
+	local task_id="$2"
+	local result="" candidate="" parsed="" number="" match="" count=0
+	task_identity_validate "$task_id" || return 1
+	result=$(_der_search_issues "$repo" "repo:${repo} is:issue in:title \"${task_id}:\"") || return 1
+	while IFS= read -r candidate; do
+		[[ -n "$candidate" ]] || continue
+		parsed=$(task_identity_parse_title_prefix "$(printf '%s' "$candidate" | jq -r '.title')" || true)
+		[[ "$parsed" == "$task_id" ]] || continue
+		number=$(printf '%s' "$candidate" | jq -r '.number') || return 1
+		match="$number"
+		count=$((count + 1))
+	done < <(printf '%s' "$result" | jq -c '.[]')
+	[[ "$count" -eq 1 && "$match" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$match"
+	return 0
+}
+
+_der_all_declared_blockers_closed() {
+	local repo="$1"
+	local candidate_json="$2"
+	local blocker="" task_id="" issue_number="" text=""
+	text=$(printf '%s' "$candidate_json" | jq -r '(.body // "") + "\n" + ([.labels.nodes[].name] | join("\n"))') || return 1
+	while IFS= read -r blocker; do
+		[[ -n "$blocker" ]] || continue
+		_der_live_issue_closed "$repo" "$blocker" || return 1
+	done < <(_der_issue_refs "$text")
+	while IFS= read -r task_id; do
+		[[ -n "$task_id" ]] || continue
+		issue_number=$(_der_find_task_issue "$repo" "$task_id") || return 1
+		_der_live_issue_closed "$repo" "$issue_number" || return 1
+	done < <(_der_task_refs "$text")
+	return 0
+}
+
+_der_native_blockers_closed() {
+	local repo="$1"
+	local issue_number="$2"
+	local owner="${repo%%/*}"
+	local name="${repo#*/}"
+	local result="" blocker=""
+	# shellcheck disable=SC2016
+	result=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){blockedBy(first:100){nodes{number state repository{nameWithOwner}}pageInfo{hasNextPage}}}}}' -F o="$owner" -F r="$name" -F n="$issue_number" 2>/dev/null) || return 1
+	printf '%s' "$result" | jq -e --arg repo "$repo" '.data.repository.issue.blockedBy | .pageInfo.hasNextPage == false and all(.nodes[]; .repository.nameWithOwner == $repo)' >/dev/null 2>&1 || return 1
+	while IFS= read -r blocker; do
+		[[ -n "$blocker" ]] || continue
+		[[ "${blocker#*:}" == "CLOSED" ]] || return 1
+	done < <(printf '%s' "$result" | jq -r '.data.repository.issue.blockedBy.nodes[]? | "\(.number):\(.state)"' 2>/dev/null)
+	return 0
+}
+
+_der_try_unblock() {
+	local repo="$1"
+	local issue_number="$2"
+	local candidate_json="$3"
+	local labels="" body="" comments_json="" comments=""
+	labels=$(printf '%s' "$candidate_json" | jq -r '[.labels.nodes[].name] | join(",")') || return 1
+	body=$(printf '%s' "$candidate_json" | jq -r '.body // ""') || return 1
+	[[ ",${labels}," == *",status:blocked,"* ]] || return 0
+	_der_has_active_status "$labels" && return 0
+	comments_json=$(gh api --paginate --slurp "repos/${repo}/issues/${issue_number}/comments?per_page=100" 2>/dev/null) || return 1
+	printf '%s' "$comments_json" | jq -e 'type == "array" and all(.[]; type == "array")' >/dev/null 2>&1 || return 1
+	comments=$(printf '%s' "$comments_json" | jq -r '.[][] | .body // ""' 2>/dev/null) || return 1
+	_der_has_hold "$body" "$comments" "$labels" && return 0
+	_der_native_blockers_closed "$repo" "$issue_number" || return 1
+	_der_all_declared_blockers_closed "$repo" "$candidate_json" || return 1
+	labels=$(gh issue view "$issue_number" --repo "$repo" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || return 1
+	[[ ",${labels}," == *",status:blocked,"* ]] || return 0
+	_der_has_active_status "$labels" && return 0
+	gh issue edit "$issue_number" --repo "$repo" --remove-label status:blocked --add-label status:available >/dev/null 2>&1 || return 1
+	return 0
+}
+
+# Reconcile only direct dependants after the named issue is positively closed.
+reconcile_dependants_after_verified_closure() {
+	local repo="$1"
+	local closed_number="$2"
+	local owner="${repo%%/*}"
+	local name="${repo#*/}"
+	local context="" closed_task_id="" candidates="" candidate="" issue_number=""
+	[[ "$repo" == */* && "$closed_number" =~ ^[0-9]+$ ]] || return 1
+	[[ -n "$owner" && -n "$name" ]] || return 1
+	_der_live_issue_closed "$repo" "$closed_number" || return 1
+	context=$(_der_fetch_closed_context "$owner" "$name" "$closed_number") || return 1
+	printf '%s' "$context" | jq -e --arg repo "$repo" '
+      .data.repository.nameWithOwner == $repo
+      and .data.repository.issue.state == "CLOSED"
+      and .data.repository.issue.blocking.pageInfo.hasNextPage == false
+      and all(.data.repository.issue.blocking.nodes[];
+          .repository.nameWithOwner == $repo and .labels.pageInfo.hasNextPage == false)' >/dev/null 2>&1 || return 1
+	closed_task_id=$(task_identity_parse_title_prefix "$(printf '%s' "$context" | jq -r '.data.repository.issue.title')" || true)
+	candidates=$(_der_collect_candidates "$repo" "$closed_number" "$closed_task_id" "$context") || return 1
+	while IFS= read -r candidate; do
+		[[ -n "$candidate" ]] || continue
+		issue_number=$(printf '%s' "$candidate" | jq -r '.number') || return 1
+		[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+		_der_try_unblock "$repo" "$issue_number" "$candidate" || return 1
+	done <<<"$candidates"
+	return 0
+}

--- a/.agents/scripts/dependency-event-reconciler.sh
+++ b/.agents/scripts/dependency-event-reconciler.sh
@@ -4,6 +4,8 @@
 
 [[ -n "${_DEPENDENCY_EVENT_RECONCILER_LOADED:-}" ]] && return 0
 _DEPENDENCY_EVENT_RECONCILER_LOADED=1
+DER_SEARCH_QUOTE='"'
+DER_STATE_CLOSED="CLOSED"
 
 _der_dir="${BASH_SOURCE[0]%/*}"
 [[ "$_der_dir" == "${BASH_SOURCE[0]}" ]] && _der_dir="."
@@ -38,11 +40,32 @@ _der_has_hold() {
 	return $?
 }
 
+_der_labels_has() {
+	local labels="$1"
+	local expected="$2"
+	[[ ",${labels}," == *",${expected},"* ]]
+	return $?
+}
+
+_der_seen_has() {
+	local seen="$1"
+	local issue_number="$2"
+	[[ "$seen" == *",${issue_number},"* ]]
+	return $?
+}
+
+_der_seen_add() {
+	local seen="$1"
+	local issue_number="$2"
+	printf '%s%s,' "$seen" "$issue_number"
+	return 0
+}
+
 _der_has_active_status() {
 	local labels="$1"
-	[[ ",${labels}," == *",status:queued,"* || ",${labels}," == *",status:claimed,"* ||
-		",${labels}," == *",status:in-progress,"* || ",${labels}," == *",status:in-review,"* ||
-		",${labels}," == *",status:done,"* ]]
+	_der_labels_has "$labels" status:queued || _der_labels_has "$labels" status:claimed ||
+		_der_labels_has "$labels" status:in-progress || _der_labels_has "$labels" status:in-review ||
+		_der_labels_has "$labels" status:done
 	return $?
 }
 
@@ -121,36 +144,38 @@ _der_collect_candidates() {
 	local closed_number="$2"
 	local closed_task_id="$3"
 	local context="$4"
-	local query="" result="" candidate="" number="" seen=","
+	local query="" result="" number="" seen=","
+	local candidate
 	local native_numbers=""
+	local quote="$DER_SEARCH_QUOTE"
 	native_numbers=$(printf '%s' "$context" | jq -r '.data.repository.issue.blocking.nodes[].number' 2>/dev/null) || return 1
 
 	for query in \
-		"repo:${repo} is:issue is:open in:body \"#${closed_number}\"" \
-		"repo:${repo} is:issue is:open label:\"blocked-by:#${closed_number}\""; do
+		"repo:${repo} is:issue is:open in:body ${quote}#${closed_number}${quote}" \
+		"repo:${repo} is:issue is:open label:${quote}blocked-by:#${closed_number}${quote}"; do
 		result=$(_der_search_issues "$repo" "$query") || return 1
 		while IFS= read -r candidate; do
 			[[ -n "$candidate" ]] || continue
 			_der_candidate_declares "$candidate" "$closed_number" "$closed_task_id" || continue
 			number=$(printf '%s' "$candidate" | jq -r '.number') || return 1
-			[[ "$seen" == *",${number},"* ]] && continue
+			_der_seen_has "$seen" "$number" && continue
 			printf '%s\n' "$candidate"
-			seen="${seen}${number},"
+			seen=$(_der_seen_add "$seen" "$number")
 		done < <(printf '%s' "$result" | jq -c '.[]')
 	done
 
 	if [[ -n "$closed_task_id" ]]; then
 		for query in \
-			"repo:${repo} is:issue is:open in:body \"${closed_task_id}\"" \
-			"repo:${repo} is:issue is:open label:\"blocked-by:${closed_task_id}\""; do
+			"repo:${repo} is:issue is:open in:body ${quote}${closed_task_id}${quote}" \
+			"repo:${repo} is:issue is:open label:${quote}blocked-by:${closed_task_id}${quote}"; do
 			result=$(_der_search_issues "$repo" "$query") || return 1
 			while IFS= read -r candidate; do
 				[[ -n "$candidate" ]] || continue
 				_der_candidate_declares "$candidate" "$closed_number" "$closed_task_id" || continue
 				number=$(printf '%s' "$candidate" | jq -r '.number') || return 1
-				[[ "$seen" == *",${number},"* ]] && continue
+				_der_seen_has "$seen" "$number" && continue
 				printf '%s\n' "$candidate"
-				seen="${seen}${number},"
+				seen=$(_der_seen_add "$seen" "$number")
 			done < <(printf '%s' "$result" | jq -c '.[]')
 		done
 	fi
@@ -158,9 +183,9 @@ _der_collect_candidates() {
 	while IFS= read -r candidate; do
 		[[ -n "$candidate" ]] || continue
 		number=$(printf '%s' "$candidate" | jq -r '.number') || return 1
-		[[ "$seen" == *",${number},"* ]] && continue
+		_der_seen_has "$seen" "$number" && continue
 		printf '%s\n' "$candidate"
-		seen="${seen}${number},"
+		seen=$(_der_seen_add "$seen" "$number")
 	done < <(printf '%s' "$context" | jq -c '.data.repository.issue.blocking.nodes[]')
 	# Empty native relationships are valid; ensure malformed extraction did not
 	# silently turn a non-empty connection into no candidates.
@@ -173,16 +198,18 @@ _der_live_issue_closed() {
 	local issue_number="$2"
 	local state=""
 	state=$(gh issue view "$issue_number" --repo "$repo" --json state --jq '.state' 2>/dev/null) || return 1
-	[[ "$state" == "CLOSED" || "$state" == "closed" ]]
+	[[ "$state" == "$DER_STATE_CLOSED" || "$state" == "closed" ]]
 	return $?
 }
 
 _der_find_task_issue() {
 	local repo="$1"
 	local task_id="$2"
-	local result="" candidate="" parsed="" number="" match="" count=0
+	local result="" parsed="" number="" match="" count=0
+	local candidate
+	local quote="$DER_SEARCH_QUOTE"
 	task_identity_validate "$task_id" || return 1
-	result=$(_der_search_issues "$repo" "repo:${repo} is:issue in:title \"${task_id}:\"") || return 1
+	result=$(_der_search_issues "$repo" "repo:${repo} is:issue in:title ${quote}${task_id}:${quote}") || return 1
 	while IFS= read -r candidate; do
 		[[ -n "$candidate" ]] || continue
 		parsed=$(task_identity_parse_title_prefix "$(printf '%s' "$candidate" | jq -r '.title')" || true)
@@ -224,7 +251,7 @@ _der_native_blockers_closed() {
 	printf '%s' "$result" | jq -e --arg repo "$repo" '.data.repository.issue.blockedBy | .pageInfo.hasNextPage == false and all(.nodes[]; .repository.nameWithOwner == $repo)' >/dev/null 2>&1 || return 1
 	while IFS= read -r blocker; do
 		[[ -n "$blocker" ]] || continue
-		[[ "${blocker#*:}" == "CLOSED" ]] || return 1
+		[[ "${blocker#*:}" == "$DER_STATE_CLOSED" ]] || return 1
 	done < <(printf '%s' "$result" | jq -r '.data.repository.issue.blockedBy.nodes[]? | "\(.number):\(.state)"' 2>/dev/null)
 	return 0
 }
@@ -236,7 +263,7 @@ _der_try_unblock() {
 	local labels="" body="" comments_json="" comments=""
 	labels=$(printf '%s' "$candidate_json" | jq -r '[.labels.nodes[].name] | join(",")') || return 1
 	body=$(printf '%s' "$candidate_json" | jq -r '.body // ""') || return 1
-	[[ ",${labels}," == *",status:blocked,"* ]] || return 0
+	_der_labels_has "$labels" status:blocked || return 0
 	_der_has_active_status "$labels" && return 0
 	comments_json=$(gh api --paginate --slurp "repos/${repo}/issues/${issue_number}/comments?per_page=100" 2>/dev/null) || return 1
 	printf '%s' "$comments_json" | jq -e 'type == "array" and all(.[]; type == "array")' >/dev/null 2>&1 || return 1
@@ -245,7 +272,7 @@ _der_try_unblock() {
 	_der_native_blockers_closed "$repo" "$issue_number" || return 1
 	_der_all_declared_blockers_closed "$repo" "$candidate_json" || return 1
 	labels=$(gh issue view "$issue_number" --repo "$repo" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || return 1
-	[[ ",${labels}," == *",status:blocked,"* ]] || return 0
+	_der_labels_has "$labels" status:blocked || return 0
 	_der_has_active_status "$labels" && return 0
 	gh issue edit "$issue_number" --repo "$repo" --remove-label status:blocked --add-label status:available >/dev/null 2>&1 || return 1
 	return 0
@@ -257,14 +284,15 @@ reconcile_dependants_after_verified_closure() {
 	local closed_number="$2"
 	local owner="${repo%%/*}"
 	local name="${repo#*/}"
-	local context="" closed_task_id="" candidates="" candidate="" issue_number=""
+	local context="" closed_task_id="" candidates="" issue_number=""
+	local candidate
 	[[ "$repo" == */* && "$closed_number" =~ ^[0-9]+$ ]] || return 1
 	[[ -n "$owner" && -n "$name" ]] || return 1
 	_der_live_issue_closed "$repo" "$closed_number" || return 1
 	context=$(_der_fetch_closed_context "$owner" "$name" "$closed_number") || return 1
-	printf '%s' "$context" | jq -e --arg repo "$repo" '
+	printf '%s' "$context" | jq -e --arg repo "$repo" --arg closed "$DER_STATE_CLOSED" '
       .data.repository.nameWithOwner == $repo
-      and .data.repository.issue.state == "CLOSED"
+      and .data.repository.issue.state == $closed
       and .data.repository.issue.blocking.pageInfo.hasNextPage == false
       and all(.data.repository.issue.blocking.nodes[];
           .repository.nameWithOwner == $repo and .labels.pageInfo.hasNextPage == false)' >/dev/null 2>&1 || return 1

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -220,6 +220,43 @@ _merge_linked_issue_numbers() {
 	return 0
 }
 
+# Return every repository-bound issue that GitHub confirms this merged PR
+# closed. A truncated or internally inconsistent connection is ambiguous and
+# fails closed so callers perform no partial dependency reconciliation.
+_merge_confirmed_closing_issue_numbers() {
+	local pr_number="$1"
+	local repo="$2"
+	local owner="${repo%%/*}"
+	local name="${repo#*/}"
+	local result=""
+	[[ "$repo" == */* && "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	# shellcheck disable=SC2016
+	result=$(gh api graphql -f query='
+query($owner:String!,$name:String!,$number:Int!) {
+  repository(owner:$owner,name:$name) {
+    nameWithOwner
+    pullRequest(number:$number) {
+      state merged
+      closingIssuesReferences(first:100) {
+        totalCount pageInfo { hasNextPage }
+        nodes { number state repository { nameWithOwner } }
+      }
+    }
+  }
+}' -F owner="$owner" -F name="$name" -F number="$pr_number" 2>/dev/null) || return 1
+	printf '%s' "$result" | jq -e --arg repo "$repo" '
+      .data.repository as $r
+      | $r.pullRequest.closingIssuesReferences as $refs
+      | $r.nameWithOwner == $repo
+        and $r.pullRequest.state == "MERGED" and $r.pullRequest.merged == true
+        and (($refs.totalCount | type) == "number" and $refs.totalCount <= 100)
+        and $refs.pageInfo.hasNextPage == false
+        and (($refs.nodes | length) == $refs.totalCount)
+        and all($refs.nodes[]; .repository.nameWithOwner == $repo)' >/dev/null 2>&1 || return 1
+	printf '%s' "$result" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[]? | select(.state == "CLOSED") | .number' 2>/dev/null || return 1
+	return 0
+}
+
 _merge_issue_requires_maintainer_review() {
 	local issue_number="$1"
 	local repo="$2"
@@ -702,14 +739,19 @@ _merge_finalize_post_merge() {
 	local has_auto="$3"
 	local cleanup_plan="$4"
 	local linked_issue=""
+	local closing_issues="" closing_issue=""
 	linked_issue=$(gh pr view "$pr_number" --repo "$repo" --json body \
 		--jq '.body' 2>/dev/null |
 		grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' |
 		grep -oE '[0-9]+' | head -1) || linked_issue=""
 	if [[ -n "$linked_issue" ]]; then
 		release_interactive_claim_on_merge "$pr_number" "$repo" "$linked_issue" || true
-		reconcile_dependants_after_verified_closure "$repo" "$linked_issue" || true
 	fi
+	closing_issues=$(_merge_confirmed_closing_issue_numbers "$pr_number" "$repo") || closing_issues=""
+	while IFS= read -r closing_issue; do
+		[[ "$closing_issue" =~ ^[0-9]+$ ]] || continue
+		reconcile_dependants_after_verified_closure "$repo" "$closing_issue" || true
+	done <<<"$closing_issues"
 	if [[ "$has_auto" -eq 0 && -n "$linked_issue" ]]; then
 		auto_file_next_phase "$linked_issue" "$repo" || true
 	fi

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -708,6 +708,7 @@ _merge_finalize_post_merge() {
 		grep -oE '[0-9]+' | head -1) || linked_issue=""
 	if [[ -n "$linked_issue" ]]; then
 		release_interactive_claim_on_merge "$pr_number" "$repo" "$linked_issue" || true
+		reconcile_dependants_after_verified_closure "$repo" "$linked_issue" || true
 	fi
 	if [[ "$has_auto" -eq 0 && -n "$linked_issue" ]]; then
 		auto_file_next_phase "$linked_issue" "$repo" || true

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -17,6 +17,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 source "${SCRIPT_DIR}/shared-claim-lifecycle.sh"
+# shellcheck source=./dependency-event-reconciler.sh
+source "${SCRIPT_DIR}/dependency-event-reconciler.sh"
 
 readonly SCRIPT_DIR
 readonly STATE_DIR=".agents/loop-state"

--- a/.agents/scripts/github-cli-helper.sh
+++ b/.agents/scripts/github-cli-helper.sh
@@ -352,6 +352,12 @@ close_issue() {
 	print_info "Closing issue #$issue_number in $owner/$repo_name"
 
 	if gh issue close --repo "$owner/$repo_name" "$issue_number"; then
+		local reconciler="${SCRIPT_DIR}/dependency-event-reconciler.sh"
+		if [[ -r "$reconciler" ]]; then
+			# shellcheck source=./dependency-event-reconciler.sh
+			source "$reconciler"
+			reconcile_dependants_after_verified_closure "$owner/$repo_name" "$issue_number" || true
+		fi
 		print_success "$SUCCESS_ISSUE_CLOSED"
 	else
 		print_error "Failed to close issue"

--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -32,6 +32,8 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
 	unset _lib_path
 fi
+# shellcheck source=./dependency-event-reconciler.sh
+source "${SCRIPT_DIR}/dependency-event-reconciler.sh"
 
 # =============================================================================
 # Close Helpers
@@ -354,6 +356,7 @@ _do_close() {
 		fi
 		_mark_issue_done "$repo" "$issue_number"
 		_mark_todo_done "$task_id" "$todo_file"
+		reconcile_dependants_after_verified_closure "$repo" "$issue_number" || true
 		print_success "Closed #$issue_number ($task_id)"
 	else
 		print_error "Failed to close #$issue_number ($task_id)"

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -724,7 +724,9 @@ _handle_post_merge_actions() {
 			esac
 			set_solved_label "$linked_issue" "$repo_slug" "$_solved_actor" || true
 			clear_terminal_issue_dispatch_labels "$linked_issue" "$repo_slug" "post-merge-pr-${pr_number}" || true
-			_gh_with_timeout write gh issue close "$linked_issue" --repo "$repo_slug" 2>/dev/null || true
+			if _gh_with_timeout write gh issue close "$linked_issue" --repo "$repo_slug" 2>/dev/null; then
+				reconcile_dependants_after_verified_closure "$repo_slug" "$linked_issue" || true
+			fi
 			# Reset fast-fail counter now that the issue is resolved (GH#2076)
 			fast_fail_reset "$linked_issue" "$repo_slug" || true
 			# t1934: Unlock the issue (locked at dispatch time)
@@ -764,7 +766,9 @@ _handle_post_merge_actions() {
 				esac
 				set_solved_label "$_superseded_original_issue" "$repo_slug" "$_sup_solved_actor" || true
 				clear_terminal_issue_dispatch_labels "$_superseded_original_issue" "$repo_slug" "post-merge-superseded-pr-${pr_number}" || true
-				_gh_with_timeout write gh issue close "$_superseded_original_issue" --repo "$repo_slug" 2>/dev/null || true
+				if _gh_with_timeout write gh issue close "$_superseded_original_issue" --repo "$repo_slug" 2>/dev/null; then
+					reconcile_dependants_after_verified_closure "$repo_slug" "$_superseded_original_issue" || true
+				fi
 				fast_fail_reset "$_superseded_original_issue" "$repo_slug" || true
 				unlock_issue_after_worker "$_superseded_original_issue" "$repo_slug"
 			fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -294,6 +294,8 @@ source "${SCRIPT_DIR}/pulse-queue-governor.sh"
 source "${SCRIPT_DIR}/pulse-nmr-approval.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-dep-graph.sh"
+# shellcheck source=./dependency-event-reconciler.sh
+source "${SCRIPT_DIR}/dependency-event-reconciler.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-fast-fail.sh"
 # Phase 3 (t1971, GH#18372): 4 operational plumbing clusters extracted from this file.

--- a/.agents/scripts/tests/test-dependency-event-reconciler.sh
+++ b/.agents/scripts/tests/test-dependency-event-reconciler.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+# shellcheck source=../dependency-event-reconciler.sh
+source "${SCRIPTS_DIR}/dependency-event-reconciler.sh"
+
+PASS=0
+FAIL=0
+EDIT_COUNT=0
+REREAD_LABELS="status:blocked"
+COMMENTS='[[]]'
+NATIVE_STATE="CLOSED"
+NATIVE_DIRECT=true
+SEARCH_AMBIGUOUS=false
+EXPLICIT_LABEL=true
+BODY20="Blocked by #10"
+CLOSED_TITLE="t10: blocker"
+
+pass() {
+	printf 'PASS: %s\n' "$1"
+	PASS=$((PASS + 1))
+	return 0
+}
+fail() {
+	printf 'FAIL: %s\n' "$1"
+	FAIL=$((FAIL + 1))
+	return 0
+}
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local name="$3"
+	[[ "$expected" == "$actual" ]] && pass "$name" || fail "$name (expected $expected, got $actual)"
+	return 0
+}
+
+candidate() {
+	local number="$1"
+	local state="$2"
+	local title="$3"
+	local body="$4"
+	local labels="$5"
+	printf '%s' "$labels" | jq -Rsc --argjson number "$number" --arg state "$state" --arg title "$title" --arg body "$body" '
+      split("\n") | map(select(length > 0) | {name:.})
+      | {__typename:"Issue",number:$number,state:$state,title:$title,body:$body,
+          repository:{nameWithOwner:"owner/repo"},labels:{nodes:.,pageInfo:{hasNextPage:false}}}'
+	return 0
+}
+
+_der_fetch_closed_context() {
+	local native='[]'
+	if [[ "$NATIVE_DIRECT" == "true" ]]; then
+		native=$(candidate 20 OPEN "t20: direct" "$BODY20" $'status:blocked\nblocked-by:#10' | jq -sc '.')
+	fi
+	jq -cn --arg title "$CLOSED_TITLE" --argjson native "$native" '
+      {data:{repository:{nameWithOwner:"owner/repo",issue:{number:10,state:"CLOSED",title:$title,
+        blocking:{nodes:$native,pageInfo:{hasNextPage:false}}}}}}'
+	return 0
+}
+
+_der_search_issues() {
+	local repo="$1"
+	local query="$2"
+	local labels="status:blocked"
+	[[ "$EXPLICIT_LABEL" == "true" ]] && labels=$'status:blocked\nblocked-by:#10'
+	[[ "$repo" == "owner/repo" ]] || return 1
+	[[ "$SEARCH_AMBIGUOUS" == "false" ]] || return 1
+	if [[ "$query" == *"in:title"* ]]; then
+		candidate 10 CLOSED "$CLOSED_TITLE" "" "" | jq -sc '.'
+	elif [[ "$query" == *"#10"* || "$query" == *"t10"* ]]; then
+		candidate 20 OPEN "t20: direct" "$BODY20" "$labels" | jq -sc '.'
+	else
+		printf '[]\n'
+	fi
+	return 0
+}
+
+gh() {
+	local command="$1"
+	shift
+	case "$command $1" in
+	"issue view")
+		if [[ "$*" == *"--json state"* ]]; then
+			[[ "$*" == "view 11 "* ]] && printf 'OPEN\n' || printf 'CLOSED\n'
+		else
+			printf '%s\n' "$REREAD_LABELS"
+		fi
+		return 0
+		;;
+	"issue edit")
+		EDIT_COUNT=$((EDIT_COUNT + 1))
+		REREAD_LABELS="status:available"
+		return 0
+		;;
+	"api graphql")
+		jq -cn --arg state "$NATIVE_STATE" '{data:{repository:{issue:{blockedBy:{nodes:[{number:10,state:$state,repository:{nameWithOwner:"owner/repo"}}],pageInfo:{hasNextPage:false}}}}}}'
+		return 0
+		;;
+	"api --paginate")
+		printf '%s\n' "$COMMENTS"
+		return 0
+		;;
+	esac
+	return 1
+}
+
+run_reconcile() {
+	local before="$EDIT_COUNT"
+	reconcile_dependants_after_verified_closure "owner/repo" 10 >/dev/null 2>&1 || true
+	printf '%s\n' "$((EDIT_COUNT - before))"
+	return 0
+}
+
+assert_eq 1 "$(run_reconcile)" "repository with 27000 unrelated issues still reconciles targeted child"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20="Blocked by #10 and #11"
+assert_eq 0 "$(run_reconcile)" "multiple blockers remain blocked when one is open"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20="Blocked by #10" SEARCH_AMBIGUOUS=true
+assert_eq 0 "$(run_reconcile)" "targeted search count or pagination ambiguity fails closed"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" SEARCH_AMBIGUOUS=false BODY20=$'Blocked by: **#10**\nOn hold for maintainer'
+assert_eq 0 "$(run_reconcile)" "markdown dependency variant is found while non-dependency hold is preserved"
+
+EDIT_COUNT=0 REREAD_LABELS="status:done,status:blocked" BODY20="Blocked by #10"
+assert_eq 0 "$(run_reconcile)" "status done is preserved"
+
+EDIT_COUNT=0 REREAD_LABELS="status:available"
+assert_eq 0 "$(run_reconcile)" "already reconciled state is idempotent"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" COMMENTS='not-json'
+assert_eq 0 "$(run_reconcile)" "comment API ambiguity fails closed"
+
+COMMENTS='[[]]' EDIT_COUNT=0 REREAD_LABELS="status:blocked" NATIVE_DIRECT=false EXPLICIT_LABEL=false BODY20="Reference #10 without a dependency declaration"
+assert_eq 0 "$(run_reconcile)" "search hit without dependency ownership is not mutated"
+
+EXPLICIT_LABEL=true
+namespaced="to01j2abc3def4gh5jkm6npq7rst-42.3"
+assert_eq "$namespaced" "$(_der_task_refs "Blocked by: ${namespaced}")" "namespaced hierarchical task ID uses canonical codec"
+
+NATIVE_DIRECT=true CLOSED_TITLE="${namespaced}: blocker" BODY20="blocked-by:${namespaced}" EDIT_COUNT=0 REREAD_LABELS="status:blocked"
+assert_eq 1 "$(run_reconcile)" "namespaced task declaration resolves through exact title lookup"
+
+if grep -q 'issues(first:100,states:' "${SCRIPTS_DIR}/dependency-event-reconciler.sh"; then
+	fail "reconciler must not enumerate latest repository issues"
+else
+	pass "reconciler avoids broad repository issue enumeration"
+fi
+if grep -A25 'if ! _merge_verify_completed_state' "${SCRIPTS_DIR}/full-loop-helper-merge.sh" | grep -q '_merge_finalize_post_merge' &&
+	grep -A18 '^_merge_finalize_post_merge()' "${SCRIPTS_DIR}/full-loop-helper-merge.sh" | grep -q 'reconcile_dependants_after_verified_closure'; then
+	pass "full-loop hook follows verified merge state"
+else
+	fail "full-loop hook follows verified merge state"
+fi
+if grep -A4 'if _gh_with_timeout write gh issue close' "${SCRIPTS_DIR}/pulse-merge.sh" | grep -q 'reconcile_dependants_after_verified_closure'; then
+	pass "pulse hook runs only after close command success"
+else
+	fail "pulse hook runs only after close command success"
+fi
+if grep -A8 "if gh \"\${close_args\[\@\]}\"" "${SCRIPTS_DIR}/issue-sync-helper-close.sh" | grep -q 'reconcile_dependants_after_verified_closure'; then
+	pass "managed direct-close hook runs only after close success"
+else
+	fail "managed direct-close hook runs only after close success"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]
+exit $?

--- a/.agents/scripts/tests/test-full-loop-closing-reconciliation.sh
+++ b/.agents/scripts/tests/test-full-loop-closing-reconciliation.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+SCRIPT_DIR="$SCRIPTS_DIR"
+# shellcheck source=../full-loop-helper-merge.sh
+source "${SCRIPTS_DIR}/full-loop-helper-merge.sh"
+
+PASS=0
+FAIL=0
+RECONCILED=""
+RELEASED=""
+FINALIZED=0
+
+pass() {
+	printf 'PASS: %s\n' "$1"
+	PASS=$((PASS + 1))
+	return 0
+}
+fail() {
+	printf 'FAIL: %s\n' "$1"
+	FAIL=$((FAIL + 1))
+	return 0
+}
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local name="$3"
+	[[ "$expected" == "$actual" ]] && pass "$name" || fail "$name (expected '$expected', got '$actual')"
+	return 0
+}
+
+gh() {
+	local command="$1"
+	shift
+	if [[ "$command $1" == "pr view" ]]; then
+		printf 'Resolves #10 and closes #11\n'
+		return 0
+	fi
+	if [[ "$command $1" == "api graphql" ]]; then
+		printf '%s\n' '{"data":{"repository":{"nameWithOwner":"owner/repo","pullRequest":{"state":"MERGED","merged":true,"closingIssuesReferences":{"totalCount":2,"pageInfo":{"hasNextPage":false},"nodes":[{"number":10,"state":"CLOSED","repository":{"nameWithOwner":"owner/repo"}},{"number":11,"state":"CLOSED","repository":{"nameWithOwner":"owner/repo"}}]}}}}}'
+		return 0
+	fi
+	return 1
+}
+
+release_interactive_claim_on_merge() {
+	RELEASED="$3"
+	return 0
+}
+reconcile_dependants_after_verified_closure() {
+	RECONCILED="${RECONCILED}${RECONCILED:+ }$2"
+	return 0
+}
+auto_file_next_phase() { return 0; }
+_merge_unlock_resources() { return 0; }
+
+# shellcheck disable=SC2218  # The test intentionally replaces this function below.
+_merge_finalize_post_merge 77 owner/repo 0 ""
+assert_eq "10" "$RELEASED" "primary body-linked issue retains claim-release semantics"
+assert_eq "10 11" "$RECONCILED" "all confirmed closing references are reconciled"
+
+gh() {
+	local command="$1"
+	shift
+	[[ "$command $1" == "api graphql" ]] || return 1
+	printf '%s\n' '{"data":{"repository":{"nameWithOwner":"owner/repo","pullRequest":{"state":"MERGED","merged":true,"closingIssuesReferences":{"totalCount":101,"pageInfo":{"hasNextPage":true},"nodes":[]}}}}}'
+	return 0
+}
+if _merge_confirmed_closing_issue_numbers 77 owner/repo >/dev/null 2>&1; then
+	fail "truncated closing-reference connection fails closed"
+else
+	pass "truncated closing-reference connection fails closed"
+fi
+
+_merge_resolve_repo() {
+	printf 'owner/repo\n'
+	return 0
+}
+cmd_pre_merge_gate() { return 0; }
+_retarget_stacked_children_interactive() { return 0; }
+_merge_execute() { return 0; }
+_merge_verify_completed_state() { return 1; }
+print_info() { return 0; }
+print_error() { return 0; }
+print_success() { return 0; }
+_merge_finalize_post_merge() {
+	FINALIZED=$((FINALIZED + 1))
+	return 0
+}
+
+cmd_merge 77 owner/repo --auto
+assert_eq "0" "$FINALIZED" "queued auto-merge does not invoke closure reconciliation"
+
+if grep -A10 'if gh issue close --repo' "${SCRIPTS_DIR}/github-cli-helper.sh" | grep -q 'reconcile_dependants_after_verified_closure'; then
+	pass "independent github helper close command invokes shared reconciler after success"
+else
+	fail "independent github helper close command invokes shared reconciler after success"
+fi
+if grep -A3 '"close-issue")' "${SCRIPTS_DIR}/github-cli-helper.sh" | grep -q 'close_issue'; then
+	pass "github helper close command remains an independently exposed managed path"
+else
+	fail "github helper close command remains an independently exposed managed path"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]
+exit $?

--- a/TODO.md
+++ b/TODO.md
@@ -1137,6 +1137,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18096 Treat canonical lint policy deferrals as safe skips #auto-dispatch #bug ref:GH#27139
 
+- [ ] t18109 Trigger dependency-chain unblocking when blockers close #bug ref:GH#27338
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

- Reconcile direct dependants immediately after verified issue closure instead of waiting for periodic pulse cache repair.
- Discover repository-bound dependants through native relationships and targeted exact body/label searches.
- Require live positive evidence that every blocker is closed; preserve active statuses and human/non-dependency holds.
- Integrate closure events from full-loop merges, pulse merges, issue sync, and the managed GitHub close helper.
- Reconcile every confirmed `closingIssuesReferences` entry for merged PRs while failing closed on pagination or repository ambiguity.

## Root Cause

#27150 closed at 13:10:06 UTC, but no closure lifecycle hook refreshed dependency readiness. #27151 stayed `status:blocked` until the periodic pulse successfully rebuilt stale dependency data and unblocked it at 13:30:08 UTC. Cache-fetch failures intentionally preserve prior state, extending the delay.

## Runtime Testing

- `bash .agents/scripts/tests/test-dependency-event-reconciler.sh`
- `bash .agents/scripts/tests/test-full-loop-closing-reconciliation.sh`
- `bash .agents/scripts/tests/test-full-loop-merge.sh`
- `bash .agents/scripts/tests/test-issue-sync-close-signature.sh`
- `bash .agents/scripts/tests/test-task-identity-lib.sh`
- ShellCheck across all changed shell files
- `.agents/scripts/linters-local.sh --untracked`

## Decisions

- Closure events reconcile direct children only; periodic pulse remains the eventual-repair fallback.
- API, pagination, mapping, repository, comment, or blocker-state ambiguity leaves dependency state unchanged.
- Only dependency-owned `status:blocked` is changed; active lifecycle states and explicit holds are preserved.

Resolves #27338

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.61 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1h on this with the user in an interactive session.
