### PR TITLE
GH#27151: persist repository-bound task and issue mappings

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -291,6 +291,7 @@ _reopen_mark_if_completed() {
 
 _do_close() {
 	local task_id="$1" issue_number="$2" todo_file="$3" repo="$4"
+	require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$issue_number" || return 1
 	local task_id_ere
 	task_id_ere=$(_escape_ere "$task_id")
 	local task_with_notes task_line pr_info pr_num="" pr_url=""
@@ -534,6 +535,10 @@ cmd_reopen() {
 		# the shim layer.
 		local reopen_comment_body
 		reopen_comment_body=$(_reopen_comment "$repo" "$ref_num")
+		if ! require_task_issue_mapping "$tid" "$todo_file" "$repo" "$ref_num"; then
+			skipped=$((skipped + 1))
+			continue
+		fi
 		gh issue reopen "$ref_num" --repo "$repo" \
 			--comment "$reopen_comment_body" 2>/dev/null && {
 			reopened=$((reopened + 1))

--- a/.agents/scripts/issue-sync-helper-commands.sh
+++ b/.agents/scripts/issue-sync-helper-commands.sh
@@ -90,7 +90,7 @@ cmd_pull() {
 						add_gh_ref_to_todo "$tid" "$num" "$todo_file"
 					fi
 					local updated_ref=""
-					updated_ref=$(resolve_task_gh_number "$tid" "$todo_file")
+					updated_ref=$(resolve_task_gh_number "$tid" "$todo_file" "$repo" || true)
 					if [[ "$updated_ref" == "$num" ]]; then
 						print_success "Added ref:GH#$num to $tid"
 						synced=$((synced + 1))

--- a/.agents/scripts/issue-sync-helper-push.sh
+++ b/.agents/scripts/issue-sync-helper-push.sh
@@ -174,6 +174,11 @@ _push_create_issue() {
 			print_warning "gh create exited $gh_exit but issue found via recovery: #$recovery"
 			log_verbose "gh output: ${combined:0:200}"
 			_PUSH_CREATED_NUM="$recovery"
+			add_gh_ref_to_todo "$task_id" "$recovery" "$todo_file"
+			if ! require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$recovery"; then
+				print_error "Recovered #${recovery}, but immutable mapping validation failed"
+				return 2
+			fi
 			return 0
 		fi
 		print_error "Failed to create issue for $task_id (exit $gh_exit): ${combined:0:200}"
@@ -183,6 +188,13 @@ _push_create_issue() {
 	local num
 	num=$(echo "$url" | grep -oE '[0-9]+$' || echo "")
 	[[ -n "$num" ]] && _PUSH_CREATED_NUM="$num"
+	if [[ -n "$num" ]]; then
+		add_gh_ref_to_todo "$task_id" "$num" "$todo_file"
+		if ! require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$num"; then
+			print_error "Created #${num}, but immutable mapping validation failed"
+			return 2
+		fi
+	fi
 
 	# t1970/t1984/t2157: auto-assign interactive origin issues (not auto-dispatch).
 	# Worker issues follow status:claimed + pulse-managed assignment instead.

--- a/.agents/scripts/issue-sync-helper-push.sh
+++ b/.agents/scripts/issue-sync-helper-push.sh
@@ -102,6 +102,20 @@ _push_create_issue_without_labels() {
 	return $?
 }
 
+_push_lock_created_issue() {
+	local num="$1"
+	local repo="$2"
+	local origin_label="$3"
+	local lock_owner="${repo%%/*}"
+	local lock_user="${AIDEVOPS_SESSION_USER:-}"
+	[[ -z "$lock_user" ]] && lock_user=$(gh api user --jq '.login // ""' 2>/dev/null || echo "")
+	if [[ -n "$lock_user" && "$lock_user" == "$lock_owner" ]] ||
+		[[ "$origin_label" == "origin:worker" ]]; then
+		gh issue lock "$num" --repo "$repo" --reason "resolved" >/dev/null 2>&1 || true
+	fi
+	return 0
+}
+
 # _push_create_issue: create a GitHub issue for task_id with race-condition guard.
 # Sets _PUSH_CREATED_NUM on success (empty on failure/skip).
 # Returns 0=created, 1=skipped (race), 2=error.
@@ -201,17 +215,8 @@ _push_create_issue() {
 	[[ -n "$num" && -z "$assignee" && "$origin_label" == "origin:interactive" ]] &&
 		_push_auto_assign_interactive "$num" "$repo" "$all_labels"
 
-	# Lock maintainer/worker-created issues at creation to prevent
-	# comment prompt-injection across the entire issue lifecycle.
-	if [[ -n "$num" ]]; then
-		local _lock_owner="${repo%%/*}"
-		local _lock_user="${AIDEVOPS_SESSION_USER:-}"
-		[[ -z "$_lock_user" ]] && _lock_user=$(gh api user --jq '.login // ""' 2>/dev/null || echo "")
-		if [[ -n "$_lock_user" && "$_lock_user" == "$_lock_owner" ]] ||
-			[[ "$origin_label" == "origin:worker" ]]; then
-			gh issue lock "$num" --repo "$repo" --reason "resolved" >/dev/null 2>&1 || true
-		fi
-	fi
+	# Mapping validation above must precede this lock mutation.
+	[[ -n "$num" ]] && _push_lock_created_issue "$num" "$repo" "$origin_label"
 	return 0
 }
 

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -172,6 +172,27 @@ _build_title() {
 # via stdout tokens "CREATED" or "SKIPPED" for the caller to count.
 # GH#18041 (t1957): Collision detection — warn if a merged PR already uses
 # this task ID.
+# Complete post-create writes after the create helper has already established
+# the immutable mapping.
+_push_finalize_task_creation() {
+	local task_id="$1" repo="$2" todo_file="$3" title="$4"
+	local tier_label="$5" labels="$6" body="$7"
+	print_success "Created #${_PUSH_CREATED_NUM}: $title"
+	add_gh_ref_to_todo "$task_id" "$_PUSH_CREATED_NUM" "$todo_file"
+	if ! require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$_PUSH_CREATED_NUM"; then
+		print_error "Created #${_PUSH_CREATED_NUM}, but immutable mapping validation failed; skipping post-create writes"
+		return 1
+	fi
+	[[ -n "$tier_label" ]] && _apply_tier_label_replace "$repo" "$_PUSH_CREATED_NUM" "$tier_label"
+	sync_relationships_for_task "$task_id" "$todo_file" "$repo"
+	if [[ ",${labels}," == *",parent-task,"* ]] &&
+		! _parent_body_has_phase_markers "$body"; then
+		_post_parent_task_no_markers_warning "$repo" "$_PUSH_CREATED_NUM" || true
+	fi
+	echo "CREATED"
+	return 0
+}
+
 # IDENTITY KEY: (issue-sync-helper.sh, _push_process_task) — do NOT move.
 _push_process_task() {
 	local task_id="$1" repo="$2" todo_file="$3" project_root="$4"
@@ -246,27 +267,8 @@ _push_process_task() {
 	_push_create_issue "$task_id" "$repo" "$todo_file" "$title" "$body" "$labels" "$assignee"
 	rc=$?
 	if [[ $rc -eq 0 && -n "$_PUSH_CREATED_NUM" ]]; then
-		print_success "Created #${_PUSH_CREATED_NUM}: $title"
-		add_gh_ref_to_todo "$task_id" "$_PUSH_CREATED_NUM" "$todo_file"
-		if ! require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$_PUSH_CREATED_NUM"; then
-			print_error "Created #${_PUSH_CREATED_NUM}, but immutable mapping validation failed; skipping post-create writes"
-			return 1
-		fi
-		# Apply tier label via the replace-not-append helper so any existing
-		# tier:* label is removed first (t2012). Done after creation so the
-		# newly-created issue has a number to address.
-		if [[ -n "$tier_label" ]]; then
-			_apply_tier_label_replace "$repo" "$_PUSH_CREATED_NUM" "$tier_label"
-		fi
-		# Sync relationships (blocked-by, sub-issues) after creation (t1889)
-		sync_relationships_for_task "$task_id" "$todo_file" "$repo"
-		# t2442: if the applied labels include `parent-task` AND the body
-		# has no decomposition markers, post a one-time warning.
-		if [[ ",${labels}," == *",parent-task,"* ]] && \
-			! _parent_body_has_phase_markers "$body"; then
-			_post_parent_task_no_markers_warning "$repo" "$_PUSH_CREATED_NUM" || true
-		fi
-		echo "CREATED"
+		_push_finalize_task_creation "$task_id" "$repo" "$todo_file" "$title" \
+			"$tier_label" "$labels" "$body" || return 1
 	elif [[ $rc -eq 1 ]]; then
 		echo "SKIPPED"
 	else

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -247,13 +247,17 @@ _push_process_task() {
 	rc=$?
 	if [[ $rc -eq 0 && -n "$_PUSH_CREATED_NUM" ]]; then
 		print_success "Created #${_PUSH_CREATED_NUM}: $title"
+		add_gh_ref_to_todo "$task_id" "$_PUSH_CREATED_NUM" "$todo_file"
+		if ! require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$_PUSH_CREATED_NUM"; then
+			print_error "Created #${_PUSH_CREATED_NUM}, but immutable mapping validation failed; skipping post-create writes"
+			return 1
+		fi
 		# Apply tier label via the replace-not-append helper so any existing
 		# tier:* label is removed first (t2012). Done after creation so the
 		# newly-created issue has a number to address.
 		if [[ -n "$tier_label" ]]; then
 			_apply_tier_label_replace "$repo" "$_PUSH_CREATED_NUM" "$tier_label"
 		fi
-		add_gh_ref_to_todo "$task_id" "$_PUSH_CREATED_NUM" "$todo_file"
 		# Sync relationships (blocked-by, sub-issues) after creation (t1889)
 		sync_relationships_for_task "$task_id" "$todo_file" "$repo"
 		# t2442: if the applied labels include `parent-task` AND the body
@@ -290,6 +294,9 @@ _enrich_process_task() {
 		print_warning "$task_id: no issue found"
 		return 0
 	}
+	if [[ "$DRY_RUN" != "true" ]]; then
+		add_gh_ref_to_todo "$task_id" "$num" "$todo_file"
+	fi
 
 	local parsed
 	parsed=$(parse_task_line "$task_line")
@@ -333,6 +340,7 @@ _enrich_process_task() {
 		echo "ENRICHED"
 		return 0
 	fi
+	require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$num" || return 1
 
 	# t2165: fetch title, body, and labels in a single gh issue view call and
 	# forward to helpers.

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -214,22 +214,53 @@ add_pr_ref_to_todo() {
 # These mutations are NOT idempotent — duplicates return validation errors.
 # All functions suppress "already taken" / "duplicate sub-issues" errors.
 
-# Resolve a task ID to its GitHub issue number from TODO.md.
-# Looks up the ref:GH#NNN field for the given task ID.
+# Resolve a task ID to a repository-validated GitHub issue mapping. The
+# coordinator is authoritative; ref:GH remains a migration projection that is
+# backfilled only after both repository and issue node identities are fetched.
 # Arguments:
 #   $1 - task_id (e.g. t1873.1)
 #   $2 - todo_file path
+#   $3 - repo slug (owner/repo)
 # Returns: issue number on stdout, or empty string if not found
 resolve_task_gh_number() {
 	local task_id="$1"
 	local todo_file="$2"
+	local repo="${3:-}"
+	[[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 1
+	local repository_id="" mapping="" coordinator="${SCRIPT_DIR}/task-coordinator.mjs"
+	repository_id=$(gh api "repos/${repo}" --jq '.node_id' 2>/dev/null || true)
+	[[ -n "$repository_id" && "$repository_id" != "null" ]] || return 1
+	if [[ -x "$coordinator" ]]; then
+		mapping=$(node "$coordinator" resolve-issue --task-id "$task_id" --forge github \
+			--repository-id "$repository_id" 2>/dev/null || true)
+		if [[ -n "$mapping" ]]; then
+			printf '%s\n' "$mapping" | jq -r '.displayNumber'
+			return 0
+		fi
+	fi
 	local task_id_ere
 	task_id_ere=$(_escape_ere "$task_id")
 
-	local ref
+	local ref="" issue_json="" issue_id="" issue_number="" issue_state="" issue_cursor=""
 	ref=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 |
 		grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
-	echo "$ref"
+	[[ "$ref" =~ ^[1-9][0-9]*$ ]] || return 1
+	issue_json=$(gh issue view "$ref" --repo "$repo" --json id,number,state,updatedAt 2>/dev/null || true)
+	issue_id=$(printf '%s' "$issue_json" | jq -r '.id // empty' 2>/dev/null)
+	issue_number=$(printf '%s' "$issue_json" | jq -r '.number // empty' 2>/dev/null)
+	issue_state=$(printf '%s' "$issue_json" | jq -r '.state // empty' 2>/dev/null)
+	issue_cursor=$(printf '%s' "$issue_json" | jq -r '.updatedAt // empty' 2>/dev/null)
+	[[ -n "$issue_id" && "$issue_number" == "$ref" ]] || return 1
+	if [[ -x "$coordinator" ]]; then
+		local bind_args=()
+		[[ -n "$issue_cursor" ]] && bind_args+=(--state-cursor "$issue_cursor")
+		node "$coordinator" bind-issue --task-id "$task_id" --forge github \
+			--repository-id "$repository_id" --repository-slug "$repo" --role home \
+			--issue-id "$issue_id" --display-number "$issue_number" \
+			"${bind_args[@]}" \
+			--sync-metadata "$(jq -cn --arg state "$issue_state" --arg source ref-gh-backfill '{state:$state,source:$source}')" >/dev/null 2>&1 || return 1
+	fi
+	printf '%s\n' "$issue_number"
 	return 0
 }
 

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -281,6 +281,22 @@ resolve_task_gh_number() {
 	return 0
 }
 
+# Validate that a task's repository-scoped immutable mapping resolves to the
+# exact display number a caller intends to mutate.
+require_task_issue_mapping() {
+	local task_id="$1"
+	local todo_file="$2"
+	local repo="$3"
+	local issue_number="$4"
+	local resolved=""
+	resolved=$(resolve_task_gh_number "$task_id" "$todo_file" "$repo" || true)
+	if [[ ! "$issue_number" =~ ^[1-9][0-9]*$ || "$resolved" != "$issue_number" ]]; then
+		print_error "Refusing issue write for ${task_id}: #${issue_number} is not validated for ${repo}"
+		return 1
+	fi
+	return 0
+}
+
 # Resolve a GitHub issue number to its GraphQL node ID.
 # Arguments:
 #   $1 - issue_number

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -230,10 +230,27 @@ resolve_task_gh_number() {
 	local repository_id="" mapping="" coordinator="${SCRIPT_DIR}/task-coordinator.mjs"
 	repository_id=$(gh api "repos/${repo}" --jq '.node_id' 2>/dev/null || true)
 	[[ -n "$repository_id" && "$repository_id" != "null" ]] || return 1
-	if [[ -x "$coordinator" ]]; then
+	if [[ -f "$coordinator" ]]; then
 		mapping=$(node "$coordinator" resolve-issue --task-id "$task_id" --forge github \
 			--repository-id "$repository_id" 2>/dev/null || true)
 		if [[ -n "$mapping" ]]; then
+			local mapped_slug="" mapped_role="" mapped_issue_id="" mapped_number="" mapped_project="" mapped_cursor="" mapped_metadata=""
+			mapped_slug=$(printf '%s' "$mapping" | jq -r '.repositorySlug')
+			mapped_role=$(printf '%s' "$mapping" | jq -r '.role')
+			mapped_issue_id=$(printf '%s' "$mapping" | jq -r '.issueId')
+			mapped_number=$(printf '%s' "$mapping" | jq -r '.displayNumber')
+			mapped_project=$(printf '%s' "$mapping" | jq -r '.projectId // empty')
+			mapped_cursor=$(printf '%s' "$mapping" | jq -r '.stateCursor // empty')
+			mapped_metadata=$(printf '%s' "$mapping" | jq -c '.syncMetadata')
+			if [[ "$mapped_slug" != "$repo" ]]; then
+				local refresh_args=()
+				[[ -n "$mapped_project" ]] && refresh_args+=(--project-id "$mapped_project")
+				[[ -n "$mapped_cursor" ]] && refresh_args+=(--state-cursor "$mapped_cursor")
+				node "$coordinator" bind-issue --task-id "$task_id" --forge github \
+					--repository-id "$repository_id" --repository-slug "$repo" --role "$mapped_role" \
+					--issue-id "$mapped_issue_id" --display-number "$mapped_number" \
+					"${refresh_args[@]}" --sync-metadata "$mapped_metadata" >/dev/null 2>&1 || return 1
+			fi
 			printf '%s\n' "$mapping" | jq -r '.displayNumber'
 			return 0
 		fi
@@ -251,7 +268,7 @@ resolve_task_gh_number() {
 	issue_state=$(printf '%s' "$issue_json" | jq -r '.state // empty' 2>/dev/null)
 	issue_cursor=$(printf '%s' "$issue_json" | jq -r '.updatedAt // empty' 2>/dev/null)
 	[[ -n "$issue_id" && "$issue_number" == "$ref" ]] || return 1
-	if [[ -x "$coordinator" ]]; then
+	if [[ -f "$coordinator" ]]; then
 		local bind_args=()
 		[[ -n "$issue_cursor" ]] && bind_args+=(--state-cursor "$issue_cursor")
 		node "$coordinator" bind-issue --task-id "$task_id" --forge github \

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -386,7 +386,7 @@ _sync_declared_blocked_by_edges() {
 				continue
 			fi
 			local dep_gh_num
-			dep_gh_num=$(resolve_task_gh_number "$dep_task_id" "$todo_file")
+			dep_gh_num=$(resolve_task_gh_number "$dep_task_id" "$todo_file" "$repo" || true)
 			[[ -z "$dep_gh_num" ]] && {
 				log_verbose "$task_id: blocked-by $dep_task_id has no ref:GH#"
 				retryable_errors=$((retryable_errors + 1))
@@ -440,7 +440,7 @@ _sync_declared_blocks_edges() {
 				continue
 			fi
 			local dep_gh_num
-			dep_gh_num=$(resolve_task_gh_number "$dep_task_id" "$todo_file")
+			dep_gh_num=$(resolve_task_gh_number "$dep_task_id" "$todo_file" "$repo" || true)
 			[[ -z "$dep_gh_num" ]] && {
 				log_verbose "$task_id: blocks $dep_task_id has no ref:GH#"
 				retryable_errors=$((retryable_errors + 1))
@@ -497,7 +497,7 @@ _sync_blocked_by_for_task() {
 		esac
 	done <<<"$parsed"
 	[[ -z "$blocked_by" && -z "$blocks" ]] && return 0
-	this_gh_num=$(resolve_task_gh_number "$task_id" "$todo_file")
+	this_gh_num=$(resolve_task_gh_number "$task_id" "$todo_file" "$repo" || true)
 	[[ -z "$this_gh_num" ]] && { log_verbose "$task_id: no ref:GH# — skipping relationships"; return 0; }
 	this_node_id=$(_cached_node_id "$this_gh_num" "$repo")
 	if [[ -z "$this_node_id" ]]; then
@@ -537,13 +537,13 @@ _link_sub_issue_pair() {
 	local child_id="$1" parent_id="$2" todo_file="$3" repo="$4"
 
 	local child_gh_num
-	child_gh_num=$(resolve_task_gh_number "$child_id" "$todo_file")
+	child_gh_num=$(resolve_task_gh_number "$child_id" "$todo_file" "$repo" || true)
 	[[ -z "$child_gh_num" ]] && {
 		log_verbose "$child_id: no ref:GH# — skipping sub-issue"
 		return 1
 	}
 	local parent_gh_num
-	parent_gh_num=$(resolve_task_gh_number "$parent_id" "$todo_file")
+	parent_gh_num=$(resolve_task_gh_number "$parent_id" "$todo_file" "$repo" || true)
 	[[ -z "$parent_gh_num" ]] && {
 		log_verbose "$child_id: parent $parent_id has no ref:GH# — skipping sub-issue"
 		return 1

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -543,6 +543,22 @@ _dep_labels_has_active_status() {
 	return $?
 }
 
+# Resolve a numeric dependency target only after GitHub proves both the
+# repository node and issue node identities for the supplied slug/number pair.
+_dep_validate_issue_target() {
+	local slug="$1"
+	local issue_num="$2"
+	local repository_id="" issue_json="" resolved_num="" issue_id=""
+	[[ "$slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ && "$issue_num" =~ ^[1-9][0-9]*$ ]] || return 1
+	repository_id=$(gh api "repos/${slug}" --jq '.node_id' 2>/dev/null || true)
+	[[ -n "$repository_id" && "$repository_id" != "null" ]] || return 1
+	issue_json=$(gh issue view "$issue_num" --repo "$slug" --json id,number 2>/dev/null || true)
+	resolved_num=$(printf '%s' "$issue_json" | jq -r '.number // empty' 2>/dev/null)
+	issue_id=$(printf '%s' "$issue_json" | jq -r '.id // empty' 2>/dev/null)
+	[[ "$resolved_num" == "$issue_num" && -n "$issue_id" ]]
+	return $?
+}
+
 #######################################
 # Atomically move an issue advertised as available to blocked when dependency
 # evidence is unresolved. Re-read labels immediately before the write so a
@@ -555,6 +571,7 @@ _refresh_ensure_unresolved_is_blocked() {
 	local slug="$1"
 	local issue_num="$2"
 	local current_labels=""
+	_dep_validate_issue_target "$slug" "$issue_num" || return 1
 
 	current_labels=$(gh issue view "$issue_num" --repo "$slug" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || return 1
@@ -598,6 +615,7 @@ _refresh_cleanup_resolved_blocker_labels() {
 	local issue_num="$2"
 	local entry_json="$3"
 	local current_labels="$4"
+	_dep_validate_issue_target "$slug" "$issue_num" || return 1
 
 	local removed_count=0
 	local blocker_nums="" blocker_num="" stale_label=""
@@ -638,6 +656,7 @@ _refresh_try_unblock_issue() {
 	local issue_num="$2"
 	local entry_json="$3"
 	local defer_flags_json="$4"
+	_dep_validate_issue_target "$slug" "$issue_num" || return 1
 
 	local current_labels
 	current_labels=$(gh issue view "$issue_num" --repo "$slug" \

--- a/.agents/scripts/task-coordinator.mjs
+++ b/.agents/scripts/task-coordinator.mjs
@@ -15,7 +15,7 @@ const EVIDENCE_MAX_BYTES = 64 * 1024;
 const CROCKFORD = "0123456789abcdefghjkmnpqrstvwxyz";
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const LEGACY_ID = /^t[1-9][0-9]{0,17}$/;
-const TASK_ID = /^(?:t[1-9][0-9]{0,17}|to[0-7][0-9a-hjkmnp-tv-z]{25}-[1-9][0-9]{0,17})$/;
+const TASK_ID = /^(?:t[1-9][0-9]{0,17}(?:\.[1-9][0-9]{0,17})*|to[0-7][0-9a-hjkmnp-tv-z]{25}-[1-9][0-9]{0,17}(?:\.[1-9][0-9]{0,17})*)$/;
 const STATES = new Set(["active", "read-only", "redirected", "retired", "quarantined"]);
 const RESULTS = new Set(["published", "retryable", "indeterminate", "terminal", "conflict"]);
 const MAPPING_ROLES = new Set(["home", "implementation", "upstream"]);
@@ -180,7 +180,7 @@ INSERT INTO migration_history SELECT ${SCHEMA_VERSION},${sqlEscape(timestamp)},N
 function initialise(path = dbPath()) {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   chmodSync(dirname(path), 0o700);
-  bootstrap(path);
+  if (!existsSync(path)) bootstrap(path);
   secureFile(path);
   const version = Number(sqlite(path, "SELECT value FROM coordinator_meta WHERE key='schema_version';\n"));
   if (!Number.isSafeInteger(version) || version < 1 || version > SCHEMA_VERSION) throw new Error(`unsupported coordinator schema ${version}`);
@@ -308,22 +308,30 @@ function issueMappingInput(input) {
   const projectId = input.projectId ? validId(input.projectId, "project_id") : null;
   const displayNumber = Number(input.displayNumber);
   if (!Number.isSafeInteger(displayNumber) || displayNumber < 1) throw new TypeError("display_number must be a positive integer");
-  const stateCursor = input.stateCursor ? validId(input.stateCursor, "state_cursor") : null;
+  const stateCursor = input.stateCursor || null;
+  if (stateCursor && (typeof stateCursor !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(stateCursor) || !Number.isFinite(Date.parse(stateCursor)))) {
+    throw new TypeError("state_cursor must be a canonical UTC RFC3339 timestamp");
+  }
   const syncMetadataText = jsonText(input.syncMetadata || {}, "sync_metadata");
   return { taskId, forge, repositoryId, repositorySlug, role, issueId, projectId, displayNumber, stateCursor, syncMetadataText };
 }
 function bindIssue(input, path = initialise()) {
   const value = issueMappingInput(input);
   const timestamp = now();
-  const existing = rows(path, `SELECT * FROM issue_mappings WHERE task_id=${sqlEscape(value.taskId)} AND forge=${sqlEscape(value.forge)} AND repository_id=${sqlEscape(value.repositoryId)};`)[0];
-  if (existing && (existing.issue_id !== value.issueId || Number(existing.display_number) !== value.displayNumber || existing.role !== value.role)) {
-    throw new Error("issue mapping conflict");
-  }
-  sqlite(path, `BEGIN IMMEDIATE;
+  try {
+    sqlite(path, `BEGIN IMMEDIATE;
 INSERT INTO issue_mappings(task_id,forge,repository_id,repository_slug,role,issue_id,project_id,display_number,state_cursor,sync_metadata_json,created_at,updated_at)
 VALUES (${sqlEscape(value.taskId)},${sqlEscape(value.forge)},${sqlEscape(value.repositoryId)},${sqlEscape(value.repositorySlug)},${sqlEscape(value.role)},${sqlEscape(value.issueId)},${sqlEscape(value.projectId)},${value.displayNumber},${sqlEscape(value.stateCursor)},${sqlEscape(value.syncMetadataText)},${sqlEscape(timestamp)},${sqlEscape(timestamp)})
-ON CONFLICT(task_id,forge,repository_id) DO UPDATE SET repository_slug=excluded.repository_slug,project_id=COALESCE(excluded.project_id,issue_mappings.project_id),state_cursor=COALESCE(excluded.state_cursor,issue_mappings.state_cursor),sync_metadata_json=excluded.sync_metadata_json,updated_at=excluded.updated_at;
+ON CONFLICT(task_id,forge,repository_id) DO UPDATE SET repository_slug=excluded.repository_slug,project_id=COALESCE(excluded.project_id,issue_mappings.project_id),state_cursor=COALESCE(excluded.state_cursor,issue_mappings.state_cursor),sync_metadata_json=CASE WHEN excluded.state_cursor>issue_mappings.state_cursor OR issue_mappings.state_cursor IS NULL THEN excluded.sync_metadata_json ELSE issue_mappings.sync_metadata_json END,updated_at=excluded.updated_at
+WHERE issue_mappings.issue_id=excluded.issue_id AND issue_mappings.display_number=excluded.display_number AND issue_mappings.role=excluded.role
+AND ((issue_mappings.state_cursor IS NULL AND excluded.state_cursor IS NULL AND issue_mappings.sync_metadata_json=excluded.sync_metadata_json)
+  OR excluded.state_cursor>issue_mappings.state_cursor
+  OR (excluded.state_cursor=issue_mappings.state_cursor AND issue_mappings.sync_metadata_json=excluded.sync_metadata_json));
+CREATE TEMP TABLE assert_mapping_change(value INTEGER CHECK(value=1)); INSERT INTO assert_mapping_change VALUES(changes()); DROP TABLE assert_mapping_change;
 COMMIT;`);
+  } catch (error) {
+    throw new Error("issue mapping conflict or stale state cursor", { cause: error });
+  }
   return resolveIssue({ taskId: value.taskId, forge: value.forge, repositoryId: value.repositoryId }, path);
 }
 function resolveIssue({ taskId, forge = "github", repositoryId }, path = initialise()) {

--- a/.agents/scripts/task-coordinator.mjs
+++ b/.agents/scripts/task-coordinator.mjs
@@ -308,10 +308,11 @@ function issueMappingInput(input) {
   const projectId = input.projectId ? validId(input.projectId, "project_id") : null;
   const displayNumber = Number(input.displayNumber);
   if (!Number.isSafeInteger(displayNumber) || displayNumber < 1) throw new TypeError("display_number must be a positive integer");
-  const stateCursor = input.stateCursor || null;
-  if (stateCursor && (typeof stateCursor !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(stateCursor) || !Number.isFinite(Date.parse(stateCursor)))) {
+  const rawStateCursor = input.stateCursor || null;
+  if (rawStateCursor && (typeof rawStateCursor !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(rawStateCursor) || !Number.isFinite(Date.parse(rawStateCursor)))) {
     throw new TypeError("state_cursor must be a canonical UTC RFC3339 timestamp");
   }
+  const stateCursor = rawStateCursor ? new Date(rawStateCursor).toISOString() : null;
   const syncMetadataText = jsonText(input.syncMetadata || {}, "sync_metadata");
   return { taskId, forge, repositoryId, repositorySlug, role, issueId, projectId, displayNumber, stateCursor, syncMetadataText };
 }

--- a/.agents/scripts/task-coordinator.mjs
+++ b/.agents/scripts/task-coordinator.mjs
@@ -9,7 +9,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { canonicalizeSqliteDbPath, sqlEscape } from "./sqlite-process.mjs";
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 const PAYLOAD_MAX_BYTES = 64 * 1024;
 const EVIDENCE_MAX_BYTES = 64 * 1024;
 const CROCKFORD = "0123456789abcdefghjkmnpqrstvwxyz";
@@ -18,6 +18,7 @@ const LEGACY_ID = /^t[1-9][0-9]{0,17}$/;
 const TASK_ID = /^(?:t[1-9][0-9]{0,17}|to[0-7][0-9a-hjkmnp-tv-z]{25}-[1-9][0-9]{0,17})$/;
 const STATES = new Set(["active", "read-only", "redirected", "retired", "quarantined"]);
 const RESULTS = new Set(["published", "retryable", "indeterminate", "terminal", "conflict"]);
+const MAPPING_ROLES = new Set(["home", "implementation", "upstream"]);
 
 const SCHEMA = `
 PRAGMA foreign_keys=ON;
@@ -67,6 +68,17 @@ CREATE TABLE IF NOT EXISTS restore_controls (
   new_epoch INTEGER NOT NULL, fencing_token TEXT NOT NULL UNIQUE,
   registry_evidence_json TEXT NOT NULL CHECK(json_valid(registry_evidence_json)), backup_integrity TEXT NOT NULL,
   backup_high_water INTEGER NOT NULL, published_high_water INTEGER NOT NULL, restored_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS issue_mappings (
+  task_id TEXT NOT NULL, forge TEXT NOT NULL, repository_id TEXT NOT NULL,
+  repository_slug TEXT NOT NULL, role TEXT NOT NULL, issue_id TEXT NOT NULL,
+  project_id TEXT, display_number INTEGER NOT NULL CHECK(display_number > 0),
+  state_cursor TEXT, sync_metadata_json TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(sync_metadata_json)),
+  created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+  PRIMARY KEY(task_id, forge, repository_id),
+  UNIQUE(forge, repository_id, issue_id),
+  UNIQUE(forge, repository_id, display_number),
+  CHECK(forge IN ('github')), CHECK(role IN ('home','implementation','upstream'))
 );
 CREATE TRIGGER IF NOT EXISTS tasks_immutable_update BEFORE UPDATE ON tasks BEGIN SELECT RAISE(ABORT, 'tasks are immutable'); END;
 CREATE TRIGGER IF NOT EXISTS tasks_immutable_delete BEFORE DELETE ON tasks BEGIN SELECT RAISE(ABORT, 'tasks are immutable'); END;
@@ -137,8 +149,20 @@ INSERT INTO migration_history(version,applied_at,backup_path,integrity_result) V
 COMMIT;`);
   if (sqlite(path, "PRAGMA integrity_check;\n") !== "ok") throw new Error("migration integrity verification failed");
 }
+function migrateV2ToV3(path) {
+  const copy = backup(path, "pre-migrate-v3");
+  sqlite(path, `BEGIN IMMEDIATE;
+${SCHEMA}
+UPDATE coordinator_meta SET value='3' WHERE key='schema_version';
+INSERT INTO migration_history(version,applied_at,backup_path,integrity_result) VALUES (3,${sqlEscape(now())},${sqlEscape(copy)},'ok');
+COMMIT;`);
+  if (sqlite(path, "PRAGMA integrity_check;\n") !== "ok") throw new Error("migration integrity verification failed");
+}
 function migrate(path, version) {
-  if (version === 1) migrateV1ToV2(path);
+  if (version === 1) {
+    migrateV1ToV2(path);
+    migrateV2ToV3(path);
+  } else if (version === 2) migrateV2ToV3(path);
   else if (version !== SCHEMA_VERSION) throw new Error(`unsupported coordinator schema ${version}`);
 }
 function bootstrap(path) {
@@ -270,6 +294,45 @@ CREATE TEMP TABLE assert_change(value INTEGER CHECK(value=1)); INSERT INTO asser
 INSERT INTO origin_transitions(origin_id,from_state,to_state,ownership_epoch,fencing_token,evidence_json,occurred_at) VALUES (${sqlEscape(origin.origin_id)},${sqlEscape(origin.state)},${sqlEscape(state)},${origin.ownership_epoch},${sqlEscape(fencingToken)},${sqlEscape(evidenceText)},${sqlEscape(timestamp)}); COMMIT;`);
   return { originId: origin.origin_id, state };
 }
+function issueMappingInput(input) {
+  const taskId = input.taskId;
+  if (!TASK_ID.test(taskId)) throw new TypeError("task_id is not canonical");
+  const forge = input.forge || "github";
+  if (forge !== "github") throw new TypeError("unsupported forge");
+  const repositoryId = validId(input.repositoryId, "repository_id");
+  const repositorySlug = input.repositorySlug;
+  if (typeof repositorySlug !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(repositorySlug)) throw new TypeError("repository_slug is not canonical");
+  const role = input.role || "home";
+  if (!MAPPING_ROLES.has(role)) throw new TypeError("invalid issue mapping role");
+  const issueId = validId(input.issueId, "issue_id");
+  const projectId = input.projectId ? validId(input.projectId, "project_id") : null;
+  const displayNumber = Number(input.displayNumber);
+  if (!Number.isSafeInteger(displayNumber) || displayNumber < 1) throw new TypeError("display_number must be a positive integer");
+  const stateCursor = input.stateCursor ? validId(input.stateCursor, "state_cursor") : null;
+  const syncMetadataText = jsonText(input.syncMetadata || {}, "sync_metadata");
+  return { taskId, forge, repositoryId, repositorySlug, role, issueId, projectId, displayNumber, stateCursor, syncMetadataText };
+}
+function bindIssue(input, path = initialise()) {
+  const value = issueMappingInput(input);
+  const timestamp = now();
+  const existing = rows(path, `SELECT * FROM issue_mappings WHERE task_id=${sqlEscape(value.taskId)} AND forge=${sqlEscape(value.forge)} AND repository_id=${sqlEscape(value.repositoryId)};`)[0];
+  if (existing && (existing.issue_id !== value.issueId || Number(existing.display_number) !== value.displayNumber || existing.role !== value.role)) {
+    throw new Error("issue mapping conflict");
+  }
+  sqlite(path, `BEGIN IMMEDIATE;
+INSERT INTO issue_mappings(task_id,forge,repository_id,repository_slug,role,issue_id,project_id,display_number,state_cursor,sync_metadata_json,created_at,updated_at)
+VALUES (${sqlEscape(value.taskId)},${sqlEscape(value.forge)},${sqlEscape(value.repositoryId)},${sqlEscape(value.repositorySlug)},${sqlEscape(value.role)},${sqlEscape(value.issueId)},${sqlEscape(value.projectId)},${value.displayNumber},${sqlEscape(value.stateCursor)},${sqlEscape(value.syncMetadataText)},${sqlEscape(timestamp)},${sqlEscape(timestamp)})
+ON CONFLICT(task_id,forge,repository_id) DO UPDATE SET repository_slug=excluded.repository_slug,project_id=COALESCE(excluded.project_id,issue_mappings.project_id),state_cursor=COALESCE(excluded.state_cursor,issue_mappings.state_cursor),sync_metadata_json=excluded.sync_metadata_json,updated_at=excluded.updated_at;
+COMMIT;`);
+  return resolveIssue({ taskId: value.taskId, forge: value.forge, repositoryId: value.repositoryId }, path);
+}
+function resolveIssue({ taskId, forge = "github", repositoryId }, path = initialise()) {
+  if (!TASK_ID.test(taskId)) throw new TypeError("task_id is not canonical");
+  validId(repositoryId, "repository_id");
+  const matches = rows(path, `SELECT task_id AS taskId,forge,repository_id AS repositoryId,repository_slug AS repositorySlug,role,issue_id AS issueId,project_id AS projectId,display_number AS displayNumber,state_cursor AS stateCursor,sync_metadata_json AS syncMetadataJson FROM issue_mappings WHERE task_id=${sqlEscape(taskId)} AND forge=${sqlEscape(forge)} AND repository_id=${sqlEscape(repositoryId)};`);
+  if (matches.length !== 1) throw new Error("issue mapping not found");
+  return { ...matches[0], syncMetadata: JSON.parse(matches[0].syncMetadataJson) };
+}
 function validateRestoreEvidence(evidence, fencingToken) {
   const text = jsonText(evidence, "registry_evidence", EVIDENCE_MAX_BYTES);
   if (evidence.cas !== "winner" || evidence.prior_revoked !== true || evidence.fencing_token !== fencingToken || !validId(evidence.transfer_record_id, "transfer_record_id")) {
@@ -321,13 +384,15 @@ function parseJson(value = "{}") { return JSON.parse(value); }
 function option(args, name, fallback = "") { const index = args.indexOf(name); return index >= 0 && index + 1 < args.length ? args[index + 1] : fallback; }
 export function run(args = process.argv.slice(2)) {
   const command = args[0] || "help";
-  if (["help", "--help", "-h"].includes(command)) { process.stdout.write("Usage: task-coordinator.mjs allocate|publication-intent|attempt|transition|restore|verify|status\n"); return 0; }
+  if (["help", "--help", "-h"].includes(command)) { process.stdout.write("Usage: task-coordinator.mjs allocate|publication-intent|attempt|transition|bind-issue|resolve-issue|restore|verify|status\n"); return 0; }
   const path = initialise();
   let result;
   if (command === "allocate") result = allocate({ operationId: option(args, "--operation-id") || randomUUID(), count: Number(option(args, "--count", "1")), legacyId: option(args, "--legacy-id"), payload: parseJson(option(args, "--payload", "{}")) }, path);
   else if (command === "publication-intent") result = publication({ operationId: option(args, "--operation-id"), taskId: option(args, "--task-id"), payload: parseJson(option(args, "--payload", "{}")) }, path);
   else if (command === "attempt") result = attempt({ intentId: option(args, "--intent-id"), status: option(args, "--status"), evidence: parseJson(option(args, "--evidence", "{}")) }, path);
   else if (command === "transition") result = transition({ state: option(args, "--state"), fencingToken: option(args, "--fencing-token"), evidence: parseJson(option(args, "--evidence", "{}")) }, path);
+  else if (command === "bind-issue") result = bindIssue({ taskId: option(args, "--task-id"), forge: option(args, "--forge", "github"), repositoryId: option(args, "--repository-id"), repositorySlug: option(args, "--repository-slug"), role: option(args, "--role", "home"), issueId: option(args, "--issue-id"), projectId: option(args, "--project-id"), displayNumber: option(args, "--display-number"), stateCursor: option(args, "--state-cursor"), syncMetadata: parseJson(option(args, "--sync-metadata", "{}")) }, path);
+  else if (command === "resolve-issue") result = resolveIssue({ taskId: option(args, "--task-id"), forge: option(args, "--forge", "github"), repositoryId: option(args, "--repository-id") }, path);
   else if (command === "restore") result = restore({ backupPath: option(args, "--backup"), registryEvidence: parseJson(option(args, "--registry-evidence", "{}")), priorEpoch: Number(option(args, "--prior-epoch")), newEpoch: Number(option(args, "--new-epoch")), fencingToken: option(args, "--fencing-token"), publishedHighWater: Number(option(args, "--published-high-water", "0")) }, path);
   else if (command === "verify") result = verify(path);
   else if (command === "status") result = { ...activeOrigin(path), dbPath: path };
@@ -340,4 +405,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   try { process.exitCode = run(); } catch (error) { process.stderr.write(`task-coordinator: ${error.message}\n`); process.exitCode = 1; }
 }
 
-export { allocate, backup, hashPayload, initialise, restore, verify };
+export { allocate, backup, bindIssue, hashPayload, initialise, resolveIssue, restore, verify };

--- a/.agents/scripts/tests/test-dependency-readiness-normalization.sh
+++ b/.agents/scripts/tests/test-dependency-readiness-normalization.sh
@@ -76,7 +76,11 @@ assert_eq "active lifecycle wins blocked available conflict" "in-review" "$(_pic
 status_write=""
 current_status="status:available"
 gh() {
-	if [[ "$1 $2" == "issue view" ]]; then
+	if [[ "$1 $2" == "api repos/owner/repo" ]]; then
+		printf 'R_owner_repo\n'
+	elif [[ "$1 $2" == "issue view" && "$*" == *"--json id,number"* ]]; then
+		printf '{"id":"I_20","number":20}\n'
+	elif [[ "$1 $2" == "issue view" ]]; then
 		printf '%s\n' "$current_status"
 	elif [[ "$1 $2" == "issue edit" ]]; then
 		status_write="$*"
@@ -91,7 +95,11 @@ assert_eq "available issue normalized blocked" "issue edit 20 --repo owner/repo 
 status_write=""
 current_status="status:available,status:queued"
 gh() {
-	if [[ "$1 $2" == "issue view" ]]; then
+	if [[ "$1 $2" == "api repos/owner/repo" ]]; then
+		printf 'R_owner_repo\n'
+	elif [[ "$1 $2" == "issue view" && "$*" == *"--json id,number"* ]]; then
+		printf '{"id":"I_20","number":20}\n'
+	elif [[ "$1 $2" == "issue view" ]]; then
 		printf '%s\n' "$current_status"
 	fi
 	return 0
@@ -104,7 +112,11 @@ status_write=""
 view_counter_file="${TMP_ROOT}/view-count"
 printf '0\n' >"$view_counter_file"
 gh() {
-	if [[ "$1 $2" == "issue view" ]]; then
+	if [[ "$1 $2" == "api repos/owner/repo" ]]; then
+		printf 'R_owner_repo\n'
+	elif [[ "$1 $2" == "issue view" && "$*" == *"--json id,number"* ]]; then
+		printf '{"id":"I_20","number":20}\n'
+	elif [[ "$1 $2" == "issue view" ]]; then
 		local view_count=""
 		view_count=$(<"$view_counter_file")
 		view_count=$((view_count + 1))
@@ -216,7 +228,11 @@ status_write=""
 view_counter_file="${TMP_ROOT}/unblock-view-count"
 printf '0\n' >"$view_counter_file"
 gh() {
-	if [[ "$1 $2" == "issue view" ]]; then
+	if [[ "$1 $2" == "api repos/owner/repo" ]]; then
+		printf 'R_owner_repo\n'
+	elif [[ "$1 $2" == "issue view" && "$*" == *"--json id,number"* ]]; then
+		printf '{"id":"I_20","number":20}\n'
+	elif [[ "$1 $2" == "issue view" ]]; then
 		local view_count=""
 		view_count=$(<"$view_counter_file")
 		view_count=$((view_count + 1))

--- a/.agents/scripts/tests/test-issue-mapping-isolation.sh
+++ b/.agents/scripts/tests/test-issue-mapping-isolation.sh
@@ -9,11 +9,12 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export AIDEVOPS_TASK_COORDINATOR_DB="${TEST_ROOT}/coordinator.db"
 TODO_FILE="${TEST_ROOT}/TODO.md"
-printf '%s\n' '- [ ] t101 first repository task ref:GH#42' '- [ ] t102 second repository task ref:GH#42' >"$TODO_FILE"
+printf '%s\n' '- [ ] t101 first repository task ref:GH#42' '- [ ] t102 second repository task ref:GH#42' '- [ ] t1873.1 dotted task ref:GH#73' >"$TODO_FILE"
 
 _escape_ere() { printf '%s' "$1"; return 0; }
 strip_code_fences() { command cat; return 0; }
 log_verbose() { return 0; }
+print_error() { return 0; }
 
 gh() {
 	local group="$1"
@@ -23,18 +24,21 @@ gh() {
 		case "$endpoint" in
 			repos/owner/one | repos/owner/renamed-one) printf '%s\n' R_one ;;
 			repos/owner/two) printf '%s\n' R_two ;;
+			repos/owner/dotted) printf '%s\n' R_dotted ;;
 			*) return 1 ;;
 		esac
 		return 0
 	fi
 	if [[ "$group" == "issue" && "$1" == "view" ]]; then
+		local issue_number="$2"
 		local repo=""
 		while [[ $# -gt 0 ]]; do
 			if [[ "$1" == "--repo" ]]; then repo="$2"; shift 2; else shift; fi
 		done
 		case "$repo" in
-			owner/one | owner/renamed-one) printf '%s\n' '{"id":"I_one_42","number":42,"state":"OPEN","updatedAt":"2026-07-12T10:00:00Z"}' ;;
+			owner/one | owner/renamed-one) [[ "$issue_number" == "42" ]] && printf '%s\n' '{"id":"I_one_42","number":42,"state":"OPEN","updatedAt":"2026-07-12T10:00:00Z"}' || return 1 ;;
 			owner/two) printf '%s\n' '{"id":"I_two_42","number":42,"state":"CLOSED","updatedAt":"2026-07-12T11:00:00Z"}' ;;
+			owner/dotted) printf '%s\n' '{"id":"I_dotted_73","number":73,"state":"OPEN","updatedAt":"2026-07-12T12:00:00Z"}' ;;
 			*) return 1 ;;
 		esac
 		return 0
@@ -47,8 +51,14 @@ source "${SCRIPT_DIR}/issue-sync-lib-ref.sh"
 
 [[ "$(resolve_task_gh_number t101 "$TODO_FILE" owner/one)" == "42" ]]
 [[ "$(resolve_task_gh_number t102 "$TODO_FILE" owner/two)" == "42" ]]
+[[ "$(resolve_task_gh_number t1873.1 "$TODO_FILE" owner/dotted)" == "73" ]]
 [[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t101 --repository-id R_one | jq -r '.issueId')" == "I_one_42" ]]
 [[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t102 --repository-id R_two | jq -r '.issueId')" == "I_two_42" ]]
+require_task_issue_mapping t1873.1 "$TODO_FILE" owner/dotted 73
+if require_task_issue_mapping t1873.1 "$TODO_FILE" owner/dotted 74; then
+	printf 'FAIL mismatched display number passed the issue write gate\n' >&2
+	exit 1
+fi
 
 # A renamed remote resolves through immutable repository identity and refreshes
 # only the mutable slug. A local-only/unvalidated target cannot resolve.

--- a/.agents/scripts/tests/test-issue-mapping-isolation.sh
+++ b/.agents/scripts/tests/test-issue-mapping-isolation.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export AIDEVOPS_TASK_COORDINATOR_DB="${TEST_ROOT}/coordinator.db"
+TODO_FILE="${TEST_ROOT}/TODO.md"
+printf '%s\n' '- [ ] t101 first repository task ref:GH#42' '- [ ] t102 second repository task ref:GH#42' >"$TODO_FILE"
+
+_escape_ere() { printf '%s' "$1"; return 0; }
+strip_code_fences() { command cat; return 0; }
+log_verbose() { return 0; }
+
+gh() {
+	local group="$1"
+	shift
+	if [[ "$group" == "api" ]]; then
+		local endpoint="$1"
+		case "$endpoint" in
+			repos/owner/one | repos/owner/renamed-one) printf '%s\n' R_one ;;
+			repos/owner/two) printf '%s\n' R_two ;;
+			*) return 1 ;;
+		esac
+		return 0
+	fi
+	if [[ "$group" == "issue" && "$1" == "view" ]]; then
+		local repo=""
+		while [[ $# -gt 0 ]]; do
+			if [[ "$1" == "--repo" ]]; then repo="$2"; shift 2; else shift; fi
+		done
+		case "$repo" in
+			owner/one | owner/renamed-one) printf '%s\n' '{"id":"I_one_42","number":42,"state":"OPEN","updatedAt":"2026-07-12T10:00:00Z"}' ;;
+			owner/two) printf '%s\n' '{"id":"I_two_42","number":42,"state":"CLOSED","updatedAt":"2026-07-12T11:00:00Z"}' ;;
+			*) return 1 ;;
+		esac
+		return 0
+	fi
+	return 1
+}
+
+# shellcheck source=../issue-sync-lib-ref.sh
+source "${SCRIPT_DIR}/issue-sync-lib-ref.sh"
+
+[[ "$(resolve_task_gh_number t101 "$TODO_FILE" owner/one)" == "42" ]]
+[[ "$(resolve_task_gh_number t102 "$TODO_FILE" owner/two)" == "42" ]]
+[[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t101 --repository-id R_one | jq -r '.issueId')" == "I_one_42" ]]
+[[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t102 --repository-id R_two | jq -r '.issueId')" == "I_two_42" ]]
+
+# A renamed remote resolves through immutable repository identity and refreshes
+# only the mutable slug. A local-only/unvalidated target cannot resolve.
+[[ "$(resolve_task_gh_number t101 "$TODO_FILE" owner/renamed-one)" == "42" ]]
+[[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t101 --repository-id R_one | jq -r '.repositorySlug')" == "owner/renamed-one" ]]
+if resolve_task_gh_number t101 "$TODO_FILE" local/only >/dev/null 2>&1; then
+	printf 'FAIL local-only repository resolved an issue write target\n' >&2
+	exit 1
+fi
+
+# A conflicting projection for the same immutable task/repository fails closed.
+printf '%s\n' '- [ ] t101 conflicting task projection ref:GH#43' >"$TODO_FILE"
+if AIDEVOPS_TASK_COORDINATOR_DB="${TEST_ROOT}/conflict.db" resolve_task_gh_number t101 "$TODO_FILE" owner/one >/dev/null 2>&1; then
+	printf 'FAIL unresolved issue projection was accepted\n' >&2
+	exit 1
+fi
+
+printf 'PASS repository-scoped issue mapping isolation and fail-closed backfill\n'

--- a/.agents/scripts/tests/test-issue-sync-push-failures.sh
+++ b/.agents/scripts/tests/test-issue-sync-push-failures.sh
@@ -25,6 +25,7 @@ _init_cmd() {
 }
 
 gh_create_label() { return 0; }
+ensure_labels_exist() { return 0; }
 _push_build_task_list() { printf 't999\n'; return 0; }
 
 _push_process_task() {
@@ -61,3 +62,40 @@ fallback_output=$(_push_create_issue_without_labels "example/repo" "t999: title"
 	fail "degraded issue creation helper failed"
 [[ "$fallback_output" == *"/issues/123"* ]] || fail "degraded issue creation helper lost issue URL"
 pass "degraded issue creation without labels preserves durable tracker creation"
+
+# Post-create assignment and locking must remain behind immutable mapping
+# validation, including the hard-failure path after GitHub created the issue.
+WRITE_LOG="$TMPDIR_TEST/write-order.log"
+: >"$WRITE_LOG"
+session_origin_label() { printf 'origin:interactive\n'; return 0; }
+gh_find_issue_by_title() { return 0; }
+add_gh_ref_to_todo() { return 0; }
+log_verbose() { return 0; }
+_push_auto_assign_interactive() { printf 'ASSIGN\n' >>"$WRITE_LOG"; return 0; }
+gh() {
+	if [[ "$1 $2" == "issue create" ]]; then
+		printf 'https://github.com/example/repo/issues/123\n'
+		return 0
+	fi
+	if [[ "$1 $2" == "issue lock" ]]; then
+		printf 'LOCK\n' >>"$WRITE_LOG"
+		return 0
+	fi
+	return 1
+}
+require_task_issue_mapping() { printf 'VALIDATE\n' >>"$WRITE_LOG"; return 1; }
+AIDEVOPS_SESSION_USER=example
+if _push_create_issue t999 example/repo /tmp/todo.md 't999: title' body enhancement ''; then
+	fail "create helper succeeded after mapping validation failed"
+fi
+[[ "$(<"$WRITE_LOG")" == "VALIDATE" ]] || fail "assignment or lock ran before failed mapping validation"
+pass "mapping failure prevents post-create assignment and lock writes"
+
+: >"$WRITE_LOG"
+require_task_issue_mapping() { printf 'VALIDATE\n' >>"$WRITE_LOG"; return 0; }
+_push_create_issue t999 example/repo /tmp/todo.md 't999: title' body enhancement '' || \
+	fail "create helper failed after successful mapping validation"
+[[ "$(sed -n '1p' "$WRITE_LOG")" == "VALIDATE" ]] || fail "mapping validation was not the first post-create operation"
+grep -q '^ASSIGN$' "$WRITE_LOG" || fail "assignment did not run after mapping validation"
+grep -q '^LOCK$' "$WRITE_LOG" || fail "lock did not run after mapping validation"
+pass "mapping validation precedes post-create assignment and lock writes"

--- a/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
@@ -62,6 +62,10 @@ teardown_test() {
 gh() {
 	local top_command="${1:-}"
 	shift || true
+	if [[ "$top_command" == "api" && "${1:-}" == "repos/example/repo" ]]; then
+		printf '%s\n' R_example
+		return 0
+	fi
 	if [[ "$top_command" == "issue" ]]; then
 		local issue_command="${1:-}"
 		shift || true
@@ -69,6 +73,10 @@ gh() {
 		view)
 			local issue_num="${1:-}"
 			shift || true
+			if [[ "$*" == *"--json id,number"* ]]; then
+				printf '{"id":"I_%s","number":%s}\n' "$issue_num" "$issue_num"
+				return 0
+			fi
 			if [[ "$*" == *"--json labels"* ]]; then
 				printf '%s\n' "$GH_LABELS_CSV"
 				return 0
@@ -88,6 +96,15 @@ gh() {
 	fi
 	printf 'unsupported gh %s %s\n' "$top_command" "$*" >&2
 	return 1
+}
+
+test_unvalidated_repository_fails_closed() {
+	if _dep_validate_issue_target "local/only" "3"; then
+		print_result "unvalidated dependency repository fails closed" 1
+	else
+		print_result "unvalidated dependency repository fails closed" 0
+	fi
+	return 0
 }
 
 set_issue_status() {
@@ -188,6 +205,7 @@ trap teardown_test EXIT
 source "$DEP_GRAPH"
 
 test_label_only_blocker_enters_graph
+test_unvalidated_repository_fails_closed
 test_available_issue_stale_label_removed
 test_blocked_issue_label_removed_and_status_available
 test_defer_marker_preserves_label

--- a/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
@@ -179,7 +179,7 @@ test_blocked_issue_label_removed_and_status_available() {
 	reset_logs
 	_refresh_try_unblock_issue "example/repo" "3" "$entry_json" '{}' >/dev/null
 	assert_log_contains "blocked issue removes stale label" "$GH_LOG" "--remove-label blocked-by:#2"
-	assert_log_contains "blocked issue status set available" "$STATUS_LOG" "set_issue_status 3 example/repo available"
+	assert_log_contains "blocked issue status set available" "$GH_LOG" "--remove-label status:blocked --add-label status:available"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-task-coordinator.sh
+++ b/.agents/scripts/tests/test-task-coordinator.sh
@@ -121,11 +121,20 @@ AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/nu
 [[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v2.db)" ]]
 [[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v3.db)" ]]
 
+# An untouched v2 database is backed up before any v3 table is applied.
+v2_db="${TEST_ROOT}/v2.db"
+AIDEVOPS_TASK_COORDINATOR_DB="$v2_db" node "$COORDINATOR" status >/dev/null
+sqlite3 "$v2_db" "DROP TABLE issue_mappings; UPDATE coordinator_meta SET value='2' WHERE key='schema_version'; DELETE FROM migration_history WHERE version=3; INSERT OR IGNORE INTO migration_history VALUES(2,'2026-01-01T00:00:00Z',NULL,'ok');"
+AIDEVOPS_TASK_COORDINATOR_DB="$v2_db" node "$COORDINATOR" status >/dev/null
+v2_backup=$(ls "${TEST_ROOT}"/v2.db-backup-*-pre-migrate-v3.db)
+[[ "$(sqlite3 "$v2_backup" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='issue_mappings';")" == "0" ]]
+[[ "$(sqlite3 "$v2_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "3" ]]
+
 # Immutable task/repository identities isolate equal display numbers and allow
 # one task to retain home, implementation, and upstream issue projections.
 mapping_task=$(node "$COORDINATOR" allocate --operation-id mapping-task --payload '{}' | jq -r '.tasks[0].taskId')
 node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug owner/home \
-	--role home --issue-id I_home --project-id P_home --display-number 42 --state-cursor cursor-home \
+	--role home --issue-id I_home --project-id P_home --display-number 42 --state-cursor 2026-07-12T10:00:00Z \
 	--sync-metadata '{"state":"OPEN","source":"backfill"}' >/dev/null
 node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_impl --repository-slug owner/implementation \
 	--role implementation --issue-id I_impl --display-number 42 --sync-metadata '{"state":"OPEN"}' >/dev/null
@@ -138,13 +147,56 @@ node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_upstr
 # A renamed slug updates display metadata without changing repository identity;
 # conflicting issue identity or an unvalidated repository fails closed.
 node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug renamed/home \
-	--role home --issue-id I_home --display-number 42 >/dev/null
+	--role home --issue-id I_home --display-number 42 --state-cursor 2026-07-12T10:00:00Z \
+	--sync-metadata '{"state":"OPEN","source":"backfill"}' >/dev/null
 [[ "$(node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_home | jq -r '.repositorySlug')" == "renamed/home" ]]
 if node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug renamed/home \
 	--role home --issue-id I_conflict --display-number 42 >/dev/null 2>&1; then
 	printf 'FAIL conflicting issue mapping was accepted\n' >&2
 	exit 1
 fi
+
+# Dotted legacy task identities bind and resolve through the same codec.
+node "$COORDINATOR" bind-issue --task-id t1873.1 --repository-id R_dotted --repository-slug owner/dotted \
+	--role home --issue-id I_dotted --display-number 73 --state-cursor 2026-07-12T10:00:00Z >/dev/null
+[[ "$(node "$COORDINATOR" resolve-issue --task-id t1873.1 --repository-id R_dotted | jq -r '.displayNumber')" == "73" ]]
+
+# State cursors are monotonic. Newer state advances, equal state is idempotent,
+# and stale or cursor-dropping updates cannot regress synchronization metadata.
+node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug renamed/home \
+	--role home --issue-id I_home --display-number 42 --state-cursor 2026-07-12T11:00:00Z \
+	--sync-metadata '{"state":"CLOSED","source":"webhook"}' >/dev/null
+node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug renamed/home \
+	--role home --issue-id I_home --display-number 42 --state-cursor 2026-07-12T11:00:00Z \
+	--sync-metadata '{"state":"CLOSED","source":"webhook"}' >/dev/null
+if node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug renamed/home \
+	--role home --issue-id I_home --display-number 42 --state-cursor 2026-07-12T10:30:00Z \
+	--sync-metadata '{"state":"OPEN"}' >/dev/null 2>&1; then
+	printf 'FAIL stale synchronization metadata was accepted\n' >&2
+	exit 1
+fi
+if node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug renamed/home \
+	--role home --issue-id I_home --display-number 42 --sync-metadata '{"state":"OPEN"}' >/dev/null 2>&1; then
+	printf 'FAIL synchronization cursor regression was accepted\n' >&2
+	exit 1
+fi
+[[ "$(node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_home | jq -r '.syncMetadata.state')" == "CLOSED" ]]
+
+# Concurrent conflicting first binds are serialized in SQLite: exactly one
+# identity wins and every competing identity fails without overwriting it.
+for i in $(seq 1 12); do
+	(
+		if node "$COORDINATOR" bind-issue --task-id t1999.1 --repository-id R_race --repository-slug owner/race \
+			--role home --issue-id "I_race_${i}" --display-number "$i" --state-cursor 2026-07-12T12:00:00Z >/dev/null 2>&1; then
+			printf '0\n' >"${TEST_ROOT}/race-${i}.rc"
+		else
+			printf '1\n' >"${TEST_ROOT}/race-${i}.rc"
+		fi
+	) &
+done
+wait
+[[ "$(grep -hxc '0' "${TEST_ROOT}"/race-*.rc | awk '{s+=$1} END {print s}')" == "1" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(*) FROM issue_mappings WHERE task_id='t1999.1' AND repository_id='R_race';")" == "1" ]]
 if node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_missing >/dev/null 2>&1; then
 	printf 'FAIL missing repository mapping resolved\n' >&2
 	exit 1

--- a/.agents/scripts/tests/test-task-coordinator.sh
+++ b/.agents/scripts/tests/test-task-coordinator.sh
@@ -111,14 +111,44 @@ node "$COORDINATOR" restore --backup "$backup" --registry-evidence '{"cas":"winn
 [[ "$(node "$COORDINATOR" status | jq -r '.sequence')" == "100" ]]
 [[ -n "$(ls "${TEST_ROOT}"/coordinator.db-backup-*-pre-restore.db)" ]]
 
-# A real v1 schema migrates to v2 only after a verified backup.
+# A real v1 schema migrates through v2 to v3 only after verified backups.
 migration_db="${TEST_ROOT}/migration.db"
 AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/null
-sqlite3 "$migration_db" "ALTER TABLE operations DROP COLUMN result_hash; ALTER TABLE restore_controls DROP COLUMN backup_high_water; UPDATE coordinator_meta SET value='1' WHERE key='schema_version'; UPDATE migration_history SET version=1 WHERE version=2;"
+sqlite3 "$migration_db" "DROP TABLE issue_mappings; ALTER TABLE operations DROP COLUMN result_hash; ALTER TABLE restore_controls DROP COLUMN backup_high_water; UPDATE coordinator_meta SET value='1' WHERE key='schema_version'; UPDATE migration_history SET version=1 WHERE version=3;"
 AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/null
-[[ "$(sqlite3 "$migration_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "2" ]]
+[[ "$(sqlite3 "$migration_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "3" ]]
 [[ "$(sqlite3 "$migration_db" "SELECT COUNT(*) FROM pragma_table_info('operations') WHERE name='result_hash';")" == "1" ]]
 [[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v2.db)" ]]
+[[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v3.db)" ]]
+
+# Immutable task/repository identities isolate equal display numbers and allow
+# one task to retain home, implementation, and upstream issue projections.
+mapping_task=$(node "$COORDINATOR" allocate --operation-id mapping-task --payload '{}' | jq -r '.tasks[0].taskId')
+node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug owner/home \
+	--role home --issue-id I_home --project-id P_home --display-number 42 --state-cursor cursor-home \
+	--sync-metadata '{"state":"OPEN","source":"backfill"}' >/dev/null
+node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_impl --repository-slug owner/implementation \
+	--role implementation --issue-id I_impl --display-number 42 --sync-metadata '{"state":"OPEN"}' >/dev/null
+node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_upstream --repository-slug upstream/project \
+	--role upstream --issue-id I_upstream --display-number 42 >/dev/null
+[[ "$(node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_home | jq -r '.issueId')" == "I_home" ]]
+[[ "$(node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_impl | jq -r '.issueId')" == "I_impl" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(*) FROM issue_mappings WHERE task_id='${mapping_task}';")" == "3" ]]
+
+# A renamed slug updates display metadata without changing repository identity;
+# conflicting issue identity or an unvalidated repository fails closed.
+node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug renamed/home \
+	--role home --issue-id I_home --display-number 42 >/dev/null
+[[ "$(node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_home | jq -r '.repositorySlug')" == "renamed/home" ]]
+if node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug renamed/home \
+	--role home --issue-id I_conflict --display-number 42 >/dev/null 2>&1; then
+	printf 'FAIL conflicting issue mapping was accepted\n' >&2
+	exit 1
+fi
+if node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_missing >/dev/null 2>&1; then
+	printf 'FAIL missing repository mapping resolved\n' >&2
+	exit 1
+fi
 
 # Integration defaults to legacy, shadow is additive, and emission needs two gates.
 if AIDEVOPS_TASK_COORDINATOR_MODE=namespaced bash "$CLAIM" --no-issue --title test >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Add immutable repository-scoped coordinator mappings for task/issue identity.
- Require validated repository and issue-node identities before issue-sync and dependency writes.
- Add atomic conflict handling, monotonic synchronization cursors, migration backfill, and two-repository isolation tests.

## Runtime Testing

- **Risk:** High (issue synchronization and dependency state machines)
- **Result:** runtime-verified through coordinator, issue-sync, relationship, dependency readiness, and pulse dependency test suites.

## Testing

- `test-task-coordinator.sh`
- `test-issue-mapping-isolation.sh`
- `test-dependency-readiness-normalization.sh` (21/21)
- `test-backfill-sub-issues.sh` (23/23)
- Issue-sync close/reopen/push suites
- Pulse dependency parse, drift, stale-label, and non-dependency suites
- ShellCheck, Node syntax check, `git diff --check`, and local preflight

## Decisions

- Key mappings by immutable task identity, forge, and immutable repository node ID.
- Preserve `ref:GH` only as migration input; all writes require repository validation.
- Reject conflicting binds and stale synchronization cursors.

Resolves #27151

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.63 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1h 31m and 110,421 tokens on this with the user in an interactive session.
