### PR TITLE
GH#27355: harden optional release checks

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -672,9 +672,9 @@ _full_loop_verify_aidevops_release_deploy() {
 	[[ -n "$repo_root" && -f "${repo_root}/VERSION" ]] && IFS= read -r version <"${repo_root}/VERSION"
 	[[ -n "$version" ]] || return 1
 	local release_sha=""
-	release_sha=$(git ls-remote --exit-code --tags origin "refs/tags/v${version}^{}" 2>/dev/null | cut -f1)
+	release_sha=$(git ls-remote --exit-code --tags origin "refs/tags/v${version}^{}" | cut -f1 || true)
 	if [[ -z "$release_sha" ]]; then
-		release_sha=$(git ls-remote --exit-code --tags origin "refs/tags/v${version}" 2>/dev/null | cut -f1)
+		release_sha=$(git ls-remote --exit-code --tags origin "refs/tags/v${version}" | cut -f1 || true)
 	fi
 	[[ -n "$release_sha" ]] || return 1
 	gh release view "v${version}" --repo "$repo" >/dev/null 2>&1 || return 1

--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -473,7 +473,7 @@ main() {
 			shift
 			;;
 		--sha)
-			if [[ $# -lt 2 || -z "$2" ]]; then
+			if [[ $# -lt 2 || -z "${2:-}" ]]; then
 				echo "--sha requires a commit SHA"
 				return 1
 			fi


### PR DESCRIPTION
## Summary

Keep lightweight-tag fallback reachable under pipefail and safely validate a missing postflight SHA argument.

## Files Changed

.agents/scripts/full-loop-helper-state.sh, .agents/scripts/postflight-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck and bash syntax checks passed; targeted full-loop and postflight tests passed, except test-postflight-scan-scope exceeded its 240-second local bound.

Resolves #27355


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.63 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 8m and 54,276 tokens on this as a headless worker.