### PR TITLE
GH#27358: make ripgrep helper test extraction robust

### DIFF
--- a/.agents/scripts/tests/test-tool-version-check-ripgrep.sh
+++ b/.agents/scripts/tests/test-tool-version-check-ripgrep.sh
@@ -26,7 +26,9 @@ assert 'ripgrep) get_public_release_tag "BurntSushi/ripgrep" ;;' in content, (
     "Linux without Homebrew must resolve the latest ripgrep release"
 )
 
-helper = content[content.index("_brew_upgrade_cmd() {"):content.index("# PEP 668-safe")]
+helper_start = content.index("_brew_upgrade_cmd() {")
+helper_end = content.index("\n}", helper_start)
+helper = content[helper_start:helper_end]
 for manager_command in (
     "brew upgrade",
     "apt-get install --only-upgrade",


### PR DESCRIPTION
## Summary

- bound the ripgrep helper assertion to `_brew_upgrade_cmd`'s closing brace
- remove the test's dependency on a comment belonging to the following function

## Testing

- `bash .agents/scripts/tests/test-tool-version-check-ripgrep.sh`
- `shellcheck .agents/scripts/tests/test-tool-version-check-ripgrep.sh`
- `git diff --check`

Resolves #27358

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.64 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 46,049 tokens on this as a headless worker. Overall, 14m since this issue was created.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.64 plugin for [OpenCode](https://opencode.ai) v1.17.18
