### PR TITLE
GH#27354: fix: preserve global OpenCode permission defaults

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -39,7 +39,11 @@ const MANAGED_EXTERNAL_DIRECTORIES = [
  */
 export function registerManagedDirectoryPermissions(config) {
   if (typeof config.permission === "string") {
-    config.permission = { external_directory: { "*": config.permission } };
+    const defaultPermission = config.permission;
+    config.permission = {
+      "*": defaultPermission,
+      external_directory: { "*": defaultPermission },
+    };
   } else if (!config.permission) {
     config.permission = {};
   }

--- a/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
@@ -37,6 +37,7 @@ test("converts a top-level default without allowing unrelated directories", () =
   const config = { permission: "ask" };
 
   assert.equal(registerManagedDirectoryPermissions(config), 6);
+  assert.equal(config.permission["*"], "ask");
   assert.deepEqual(config.permission.external_directory, {
     "*": "ask",
     ...managedRules,


### PR DESCRIPTION
## Summary

Preserve a top-level OpenCode permission string as the wildcard default while adding narrow managed external-directory exceptions, with regression coverage.

## Files Changed

.agents/plugins/opencode-aidevops/config-hook.mjs, .agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm test -- --test-name-pattern='managed|permission|directory' (357 passed)

Resolves #27354


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.64 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 45,264 tokens on this as a headless worker.