### PR TITLE
GH#27359: guard greeting gate without session client

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-session-start-greeting-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-start-greeting-gate.mjs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createSessionStartGreetingGate } from "../ttsr.mjs";
+
+test("session-start greeting gate stays disabled without a session client", async () => {
+  const missingClientGate = createSessionStartGreetingGate();
+  const incompleteClientGate = createSessionStartGreetingGate({ session: {} });
+
+  assert.equal(await missingClientGate({ sessionID: "root" }), false);
+  assert.equal(await incompleteClientGate({ sessionID: "root" }), false);
+});
+
+test("session-start greeting gate uses a valid session client", async () => {
+  let calls = 0;
+  const gate = createSessionStartGreetingGate({
+    session: {
+      get: async ({ path }) => {
+        calls += 1;
+        assert.equal(path.id, "root");
+        return { data: { id: "root" } };
+      },
+    },
+  });
+
+  assert.equal(await gate({ sessionID: "root" }), true);
+  assert.equal(await gate({ sessionID: "root" }), false);
+  assert.equal(calls, 1);
+});

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -232,6 +232,10 @@ export function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
 export function createSessionStartGreetingGate(client, isHeadless = () => false) {
   const attemptedSessions = new Set();
 
+  if (typeof client?.session?.get !== "function") {
+    return async () => false;
+  }
+
   return async function shouldInjectSessionStartGreeting(input) {
     if (isHeadless()) return false;
 


### PR DESCRIPTION
## Summary

Disable startup greeting injection when the OpenCode client lacks the session lookup API, with regression coverage for missing and valid clients.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-session-start-greeting-gate.mjs, .agents/plugins/opencode-aidevops/ttsr.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test tests/test-session-start-greeting-gate.mjs; npm test (359 passing)

Resolves #27359


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.64 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 58,485 tokens on this as a headless worker.