### PR TITLE
GH#27361: fix: harden launcher home resolution

### DIFF
--- a/bin/aidevops
+++ b/bin/aidevops
@@ -13,11 +13,11 @@
 
 set -euo pipefail
 
-REAL_HOME="$HOME"
+REAL_HOME="${HOME:-}"
 if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
 	_tmp_real_home=""
 	if command -v getent &>/dev/null; then
-		_tmp_real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+		_tmp_real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6 || true)
 	elif command -v dscl &>/dev/null; then
 		_tmp_real_home=$(dscl . -read "/Users/${SUDO_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2; exit}' || true)
 	elif [[ -d "/Users/${SUDO_USER}" ]]; then

--- a/tests/test-cli-deployment-coherence.sh
+++ b/tests/test-cli-deployment-coherence.sh
@@ -61,6 +61,18 @@ result=$(PATH="$MOCK_BIN:$PATH" HOME="/root" SUDO_USER="worker" bash "$REPO_DIR/
 	exit 1
 }
 
+# A failed passwd lookup must preserve the HOME fallback under pipefail.
+printf '#!/usr/bin/env bash\nexit 2\n' >"$MOCK_BIN/getent"
+result=$(PATH="$MOCK_BIN:$PATH" HOME="$TEST_HOME" SUDO_USER="missing-worker" bash "$REPO_DIR/bin/aidevops" --version)
+[[ "$result" == "aidevops 9.8.7" ]] || {
+	printf 'FAIL: failed passwd lookup did not preserve HOME fallback: %s\n' "$result" >&2
+	exit 1
+}
+
+# The launcher must remain nounset-safe when an environment omits HOME.
+# shellcheck disable=SC2016
+grep -q 'REAL_HOME="${HOME:-}"' "$REPO_DIR/bin/aidevops"
+
 grep -q 'After this, step 1 will always match and the deployed copy runs directly.' "$REPO_DIR/bin/aidevops"
 
 printf 'PASS: CLI launcher, orchestrator, and clean update checkout remain coherent\n'


### PR DESCRIPTION
## Summary

- Guard the launcher HOME fallback under `set -u`.
- Keep sudo passwd lookup failures from terminating under `set -o pipefail`.
- Add regression coverage for failed passwd resolution.

## Testing

- `bash tests/test-cli-deployment-coherence.sh`
- `shellcheck bin/aidevops tests/test-cli-deployment-coherence.sh`

Resolves #27361

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.64 plugin for [OpenCode](https://opencode.ai) v1.17.18
