### PR TITLE
GH#27357: harden transactional launch verification

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -339,11 +339,11 @@ _stale_recovery_verify_transition() {
 		--json state,labels,assignees 2>/dev/null) || return 1
 	printf '%s' "$issue_meta_json" | jq -e --arg target "status:${target_status}" --arg stale "$stale_assignees" '
 		($stale | split(",") | map(select(length > 0))) as $stale_users |
-		([.assignees[].login] // []) as $current_users |
+		[.assignees[]?.login] as $current_users |
 		.state == "OPEN" and
-		(([.labels[].name] | index("status:queued")) == null) and
-		(([.labels[].name] | index("status:in-progress")) == null) and
-		(([.labels[].name] | index($target)) != null) and
+		(([.labels[]?.name] | index("status:queued")) == null) and
+		(([.labels[]?.name] | index("status:in-progress")) == null) and
+		(([.labels[]?.name] | index($target)) != null) and
 		([ $stale_users[] as $stale_user |
 			select(($current_users | index($stale_user)) != null) ] | length == 0)
 	' >/dev/null 2>&1 || return 1

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -2371,9 +2371,9 @@ _verify_launch_recovery_state() {
 		--json state,labels,assignees 2>/dev/null) || return 1
 	printf '%s' "$issue_meta_json" | jq -e --arg self "$self_login" --arg target "status:${target_status}" '
 		.state == "OPEN" and
-		(([.labels[].name] | index("status:queued")) == null) and
-		(([.labels[].name] | index($target)) != null) and
-		(([.assignees[].login] | index($self)) == null)
+		(([.labels[]?.name] | index("status:queued")) == null) and
+		(([.labels[]?.name] | index($target)) != null) and
+		(([.assignees[]?.login] | index($self)) == null)
 	' >/dev/null 2>&1 || return 1
 	return 0
 }

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1466,8 +1466,8 @@ _rollback_prelaunch_ownership() {
 	local owns_queued=""
 	owns_queued=$(printf '%s' "$issue_meta_json" | jq -r --arg self "$self_login" '
 		(.state == "OPEN") and
-		(([.labels[].name] | index("status:queued")) != null) and
-		(([.assignees[].login] | index($self)) != null)
+		(([.labels[]?.name] | index("status:queued")) != null) and
+		(([.assignees[]?.login] | index($self)) != null)
 	' 2>/dev/null) || return 1
 	[[ "$owns_queued" == "true" ]] || return 0
 
@@ -1484,9 +1484,9 @@ _rollback_prelaunch_ownership() {
 		--json state,labels,assignees,locked 2>/dev/null) || return 1
 	if ! printf '%s' "$issue_meta_json" | jq -e --arg self "$self_login" '
 		.state == "OPEN" and
-		(([.labels[].name] | index("status:queued")) == null) and
-		(([.labels[].name] | index("status:available")) != null) and
-		(([.assignees[].login] | index($self)) == null) and
+		(([.labels[]?.name] | index("status:queued")) == null) and
+		(([.labels[]?.name] | index("status:available")) != null) and
+		(([.assignees[]?.login] | index($self)) == null) and
 		(.locked != true)
 	' >/dev/null 2>&1; then
 		echo "[dispatch_with_dedup] Pre-launch rollback verification failed for #${issue_number}; retaining claim for stale recovery" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-transactional-launch-metadata.sh
+++ b/.agents/scripts/tests/test-transactional-launch-metadata.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#27357 review follow-up findings.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d -t transactional-launch-metadata.XXXXXX)" || exit 1
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+pass() {
+	local name="$1"
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	printf 'FAIL %s\n' "$name" >&2
+	return 1
+}
+
+# shellcheck disable=SC1090
+(
+	SCRIPT_DIR="$SCRIPTS_DIR"
+	source "${SCRIPTS_DIR}/dispatch-dedup-stale.sh"
+	gh() {
+		printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:available"}],"assignees":null}'
+		return 0
+	}
+	_stale_recovery_verify_transition "27357" "owner/repo" "available" "runner-a"
+) || fail "stale recovery accepts null assignees after ownership removal"
+pass "stale recovery accepts null assignees after ownership removal"
+
+# shellcheck disable=SC1090
+(
+	SCRIPT_DIR="$SCRIPTS_DIR"
+	source "${SCRIPTS_DIR}/pulse-cleanup.sh"
+	gh() {
+		printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:available"}],"assignees":null}'
+		return 0
+	}
+	_verify_launch_recovery_state "27357" "owner/repo" "runner-a" "available"
+) || fail "launch recovery accepts null assignees after ownership removal"
+pass "launch recovery accepts null assignees after ownership removal"
+
+# shellcheck disable=SC1090
+(
+	SCRIPT_DIR="$SCRIPTS_DIR"
+	LOGFILE="${TEST_ROOT}/pulse.log"
+	source "${SCRIPTS_DIR}/shared-constants.sh"
+	source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+	source "${SCRIPTS_DIR}/pulse-dispatch-core.sh"
+	gh() {
+		local resource="$1"
+		local action="${2:-}"
+		if [[ "$resource" == "api" ]]; then
+			printf '%s\n' 'claim-27357'
+			return 0
+		fi
+		if [[ "$resource" == "issue" && "$action" == "view" ]]; then
+			printf '%s\n' '{"state":"OPEN","labels":null,"assignees":null,"locked":false}'
+			return 0
+		fi
+		return 1
+	}
+	_rollback_prelaunch_ownership "27357" "owner/repo" "runner-a" "claim-27357"
+) || fail "pre-launch rollback treats null ownership metadata as unowned"
+pass "pre-launch rollback treats null ownership metadata as unowned"
+
+REMOTE="${TEST_ROOT}/remote.git"
+CANONICAL="${TEST_ROOT}/canonical"
+UPDATER="${TEST_ROOT}/updater"
+WORKTREES="${TEST_ROOT}/worktrees"
+git init -q --bare "$REMOTE"
+git clone -q "$REMOTE" "$CANONICAL"
+git -C "$CANONICAL" switch -q -c main
+git -C "$CANONICAL" config user.name Test
+git -C "$CANONICAL" config user.email test@example.invalid
+git -C "$CANONICAL" commit -q --allow-empty -m seed
+git -C "$CANONICAL" push -q -u origin main
+git -C "$REMOTE" symbolic-ref HEAD refs/heads/main
+
+git clone -q "$REMOTE" "$UPDATER"
+git -C "$UPDATER" config user.name Test
+git -C "$UPDATER" config user.email test@example.invalid
+git -C "$UPDATER" switch -q -c feature/remote-only
+printf 'remote branch\n' >"${UPDATER}/remote-only.txt"
+git -C "$UPDATER" add remote-only.txt
+git -C "$UPDATER" commit -q -m remote-only
+git -C "$UPDATER" push -q -u origin feature/remote-only
+REMOTE_ONLY_SHA="$(git -C "$UPDATER" rev-parse HEAD)"
+
+if git -C "$CANONICAL" show-ref --verify --quiet refs/remotes/origin/feature/remote-only; then
+	fail "fixture unexpectedly has the remote-only tracking ref"
+fi
+
+# shellcheck disable=SC1090
+(
+	export AIDEVOPS_WORKTREE_BASE_DIR="$WORKTREES"
+	SCRIPT_DIR="$SCRIPTS_DIR"
+	source "${SCRIPTS_DIR}/worktree-helper-add.sh"
+	cd "$CANONICAL" || exit 1
+	_worktree_refresh_origin_branch "feature/remote-only"
+) || fail "HEAD bootstrap fetches a branch without a local tracking ref"
+
+[[ "$(git -C "$CANONICAL" rev-parse refs/remotes/origin/feature/remote-only)" == "$REMOTE_ONLY_SHA" ]] ||
+	fail "remote-only tracking ref was not refreshed"
+if compgen -G "${WORKTREES}/.canonical-fetch-*" >/dev/null; then
+	fail "temporary HEAD bootstrap worktree was not removed"
+fi
+pass "HEAD bootstrap fetches a branch without a local tracking ref"
+
+exit 0

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -663,8 +663,8 @@ _parse_cmd_add_args() {
 
 # Refresh an origin branch from linked-worktree context so the canonical Git
 # guard remains intact. If no linked worktree exists yet, create a short-lived
-# detached bootstrap worktree from the existing remote-tracking ref, fetch from
-# there, then remove it from that linked context.
+# detached bootstrap worktree from HEAD, fetch from there, then remove it from
+# that linked context. HEAD avoids requiring the target remote ref locally.
 # Args: branch name
 #######################################
 _worktree_refresh_origin_branch() {
@@ -694,7 +694,7 @@ _worktree_refresh_origin_branch() {
 		repo_name=$(basename "$current_root")
 		mkdir -p "$base_dir" || return 1
 		bootstrap_path="${base_dir}/.${repo_name}-fetch-$$"
-		if ! git worktree add --detach "$bootstrap_path" "refs/remotes/origin/${branch}" >/dev/null 2>&1; then
+		if ! git worktree add -q --detach "$bootstrap_path" HEAD; then
 			return 1
 		fi
 		fetch_cwd="$bootstrap_path"


### PR DESCRIPTION
## Summary

- tolerate null or missing issue labels and assignees during transactional recovery verification
- bootstrap origin-branch refreshes from detached `HEAD` when the target remote-tracking ref is not local
- preserve Git diagnostics while keeping temporary worktree creation quiet

## Testing

- `shellcheck .agents/scripts/dispatch-dedup-stale.sh .agents/scripts/pulse-cleanup.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/worktree-helper-add.sh`
- `bash .agents/scripts/tests/test-dispatch-lifecycle-comms.sh`
- `bash .agents/scripts/tests/test-stale-recovery-blocked-by-recheck.sh`

## Runtime Testing

Runtime-verified through focused shell integration tests. The worktree fixture is pending a rerun outside the worker's canonical Git guard shim.

Resolves #27357

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.64 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 115,902 tokens on this as a headless worker.
