### PR TITLE
GH#27353: preserve systemd worker startup failure evidence

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -148,6 +148,9 @@ _pulse_worker_log_prelaunch_failure_reason() {
 	[[ -f "$log_path" ]] || { printf '\n'; return 0; }
 
 	reason=$(awk '
+		/\[systemd-launch\] classification=crash_during_startup/ {
+			systemd_startup_failure = 1
+		}
 		/\[exit-trap\] using prelaunch failure reason:/ {
 			line = $0
 			sub(/^.*\[exit-trap\] using prelaunch failure reason:[[:space:]]*/, "", line)
@@ -160,11 +163,14 @@ _pulse_worker_log_prelaunch_failure_reason() {
 			split(line, parts, /[[:space:]]+/)
 			reason = parts[1]
 		}
-		END { if (reason != "") { print reason } }
+		END {
+			if (systemd_startup_failure) { print "crash_during_startup" }
+			else if (reason != "") { print reason }
+		}
 	' "$log_path" 2>/dev/null) || reason=""
 
 	case "$reason" in
-	worker_worktree_live_owner)
+	worker_worktree_live_owner|crash_during_startup)
 		printf '%s\n' "$reason"
 		;;
 	*)
@@ -1413,18 +1419,15 @@ _compute_initial_underfill() {
 _run_early_exit_recycle_loop() {
 	local pulse_duration="$1"
 	local recycle_attempt=0
-
 	while [[ "$recycle_attempt" -lt "$PULSE_BACKFILL_MAX_ATTEMPTS" ]]; do
 		# Only recycle if the pulse ran for less than 5 minutes
 		if [[ "$pulse_duration" -ge 300 ]]; then
 			break
 		fi
-
 		if [[ -f "$STOP_FLAG" ]]; then
 			echo "[pulse-wrapper] Stop flag set — skipping early-exit recycle" >>"$LOGFILE"
 			break
 		fi
-
 		# GH#6453: Wait for newly-dispatched workers to appear in the process list
 		# before re-counting. Workers dispatched by the LLM pulse take up to
 		# PULSE_LAUNCH_GRACE_SECONDS to start (sandbox-exec + opencode startup).

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1184,6 +1184,33 @@ _dlw_exec_systemd_user_service() {
 	return $?
 }
 
+_dlw_handle_systemd_launch_failure() {
+	local systemd_rc="$1"
+	local systemd_state_file="$2"
+	local worker_log="$3"
+	local issue_number="$4"
+
+	if [[ "$systemd_rc" -ne 2 && "$systemd_rc" -ne 3 ]]; then
+		echo "[dispatch_worker_launch] WARNING: systemd-run worker launch unresolved for #${issue_number}; falling back to setsid/nohup" >>"$LOGFILE"
+		return 0
+	fi
+
+	if [[ -f "$systemd_state_file" ]]; then
+		{
+			if [[ "$systemd_rc" -eq 2 ]]; then
+				printf '[systemd-launch] classification=crash_during_startup\n'
+			else
+				printf '[systemd-launch] classification=readiness_unconfirmed\n'
+			fi
+			while IFS= read -r state_line || [[ -n "$state_line" ]]; do
+				printf '%s\n' "$state_line"
+			done <"$systemd_state_file"
+		} >>"$worker_log"
+	fi
+	echo "[dispatch_worker_launch] ERROR: systemd worker for #${issue_number} did not reach durable readiness (rc=${systemd_rc}); duplicate fallback suppressed" >>"$LOGFILE"
+	return 1
+}
+
 # Execute a worker command via systemd-run (Linux user services) or setsid +
 # nohup fallback, detaching it from the pulse's process group (t2757) and, on
 # systemd, from the pulse oneshot cgroup (GH#23073). Without this, workers
@@ -1236,23 +1263,9 @@ _dlw_exec_detached() {
 			echo "[dispatch_worker_launch] Issue #${issue_number}: worker PID=$worker_pid launched via systemd-run transient user service outside pulse cgroup" >>"$LOGFILE"
 		else
 			systemd_rc=$?
-			if [[ "$systemd_rc" -eq 2 || "$systemd_rc" -eq 3 ]]; then
-				if [[ -f "$systemd_state_file" ]]; then
-					{
-						if [[ "$systemd_rc" -eq 2 ]]; then
-							printf '[systemd-launch] classification=crash_during_startup\n'
-						else
-							printf '[systemd-launch] classification=readiness_unconfirmed\n'
-						fi
-						while IFS= read -r state_line || [[ -n "$state_line" ]]; do
-							printf '%s\n' "$state_line"
-						done <"$systemd_state_file"
-					} >>"$worker_log"
-				fi
-				echo "[dispatch_worker_launch] ERROR: systemd worker for #${issue_number} did not reach durable readiness (rc=${systemd_rc}); duplicate fallback suppressed" >>"$LOGFILE"
+			if ! _dlw_handle_systemd_launch_failure "$systemd_rc" "$systemd_state_file" "$worker_log" "$issue_number"; then
 				return 1
 			fi
-			echo "[dispatch_worker_launch] WARNING: systemd-run worker launch unresolved for #${issue_number}; falling back to setsid/nohup" >>"$LOGFILE"
 		fi
 	fi
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1069,7 +1069,7 @@ _dlw_systemd_wait_stable() {
 	done
 
 	printf 'LaunchState=pid_observed\n' >>"$state_file"
-	return 1
+	return 3
 }
 
 _dlw_systemd_resolve_main_pid() {
@@ -1236,16 +1236,20 @@ _dlw_exec_detached() {
 			echo "[dispatch_worker_launch] Issue #${issue_number}: worker PID=$worker_pid launched via systemd-run transient user service outside pulse cgroup" >>"$LOGFILE"
 		else
 			systemd_rc=$?
-			if [[ "$systemd_rc" -eq 2 ]]; then
+			if [[ "$systemd_rc" -eq 2 || "$systemd_rc" -eq 3 ]]; then
 				if [[ -f "$systemd_state_file" ]]; then
 					{
-						printf '[systemd-launch] classification=crash_during_startup\n'
+						if [[ "$systemd_rc" -eq 2 ]]; then
+							printf '[systemd-launch] classification=crash_during_startup\n'
+						else
+							printf '[systemd-launch] classification=readiness_unconfirmed\n'
+						fi
 						while IFS= read -r state_line || [[ -n "$state_line" ]]; do
 							printf '%s\n' "$state_line"
 						done <"$systemd_state_file"
 					} >>"$worker_log"
 				fi
-				echo "[dispatch_worker_launch] ERROR: systemd worker for #${issue_number} failed before durable readiness; duplicate fallback suppressed" >>"$LOGFILE"
+				echo "[dispatch_worker_launch] ERROR: systemd worker for #${issue_number} did not reach durable readiness (rc=${systemd_rc}); duplicate fallback suppressed" >>"$LOGFILE"
 				return 1
 			fi
 			echo "[dispatch_worker_launch] WARNING: systemd-run worker launch unresolved for #${issue_number}; falling back to setsid/nohup" >>"$LOGFILE"

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1009,13 +1009,77 @@ _dlw_systemd_unit_name() {
 	return 0
 }
 
+_dlw_systemd_snapshot() {
+	local unit_name="$1"
+	local state_file="$2"
+	local snapshot=""
+
+	snapshot=$(systemctl --user show "$unit_name" \
+		-p Id -p MainPID -p ActiveState -p SubState \
+		-p ExecMainCode -p ExecMainStatus -p Result 2>/dev/null || true)
+	printf 'Unit=%s\n%s\n' "$unit_name" "$snapshot" >"$state_file"
+	printf '%s\n' "$snapshot"
+	return 0
+}
+
+_dlw_systemd_wait_stable() {
+	local unit_name="$1"
+	local issue_number="$2"
+	local state_file="$3"
+	local expected_pid="$4"
+	local attempts="${DLW_SYSTEMD_STABILITY_ATTEMPTS:-3}"
+	local wait_i=0 stable_count=0 snapshot="" main_pid="" active_state="" sub_state=""
+	local exec_main_code="" exec_main_status="" result="" key="" value=""
+
+	[[ "$attempts" =~ ^[1-9][0-9]*$ ]] || attempts=3
+	while [[ "$wait_i" -lt "$attempts" ]]; do
+		snapshot=$(_dlw_systemd_snapshot "$unit_name" "$state_file")
+		main_pid=""
+		active_state=""
+		sub_state=""
+		exec_main_code="" exec_main_status="" result=""
+		while IFS='=' read -r key value || [[ -n "$key" ]]; do
+			case "$key" in
+				MainPID) main_pid="$value" ;;
+				ActiveState) active_state="$value" ;;
+				SubState) sub_state="$value" ;;
+				ExecMainCode) exec_main_code="$value" ;;
+				ExecMainStatus) exec_main_status="$value" ;;
+				Result) result="$value" ;;
+			esac
+		done <<<"$snapshot"
+
+		if [[ "$active_state" == "failed" || "$active_state" == "inactive" ]]; then
+			printf 'LaunchState=startup_failed\n' >>"$state_file"
+			echo "[dispatch_worker_launch] systemd startup_failed unit=${unit_name} issue=${issue_number} MainPID=${main_pid:-0} ExecMainCode=${exec_main_code:-unknown} ExecMainStatus=${exec_main_status:-unknown} Result=${result:-unknown} state=${active_state:-unknown}/${sub_state:-unknown}" >>"$LOGFILE"
+			return 2
+		fi
+
+		if [[ "$main_pid" == "$expected_pid" && "$active_state" == "active" && "$sub_state" == "running" ]]; then
+			stable_count=$((stable_count + 1))
+		else
+			stable_count=0
+		fi
+		wait_i=$((wait_i + 1))
+		[[ "$stable_count" -ge "$attempts" ]] && {
+			printf 'LaunchState=worker_ready\n' >>"$state_file"
+			return 0
+		}
+		sleep "${DLW_SYSTEMD_STABILITY_POLL_SECONDS:-0.2}"
+	done
+
+	printf 'LaunchState=pid_observed\n' >>"$state_file"
+	return 1
+}
+
 _dlw_systemd_resolve_main_pid() {
 	local unit_name="$1"
 	local issue_number="$2"
+	local state_file="${3:-${TMPDIR:-/tmp}/aidevops-systemd-state.$$}"
 	local wait_i=0 snapshot="" main_pid="" active_state="" sub_state="" key="" value=""
 
 	while [[ "$wait_i" -lt 15 ]]; do
-		snapshot=$(systemctl --user show "$unit_name" -p MainPID -p ActiveState -p SubState 2>/dev/null || true)
+		snapshot=$(_dlw_systemd_snapshot "$unit_name" "$state_file")
 		main_pid=""
 		active_state=""
 		sub_state=""
@@ -1035,8 +1099,14 @@ _dlw_systemd_resolve_main_pid() {
 
 		if [[ "$main_pid" =~ ^[1-9][0-9]*$ ]]; then
 			echo "[dispatch_worker_launch] WARNING: systemd worker PID handoff missing for unit ${unit_name}; resolved MainPID=${main_pid} state=${active_state:-unknown}/${sub_state:-unknown} via systemctl, not launching fallback" >>"$LOGFILE"
-			printf '%s\n' "$main_pid"
-			return 0
+			local stable_rc=0
+			if _dlw_systemd_wait_stable "$unit_name" "$issue_number" "$state_file" "$main_pid"; then
+				printf '%s\n' "$main_pid"
+				return 0
+			else
+				stable_rc=$?
+			fi
+			return "$stable_rc"
 		fi
 
 		case "${active_state:-unknown}" in
@@ -1059,6 +1129,7 @@ _dlw_exec_systemd_user_service() {
 	local worker_log="$2"
 	local issue_number="$3"
 	shift 3
+	local state_file="${_DLW_SYSTEMD_STATE_FILE:-${TMPDIR:-/tmp}/aidevops-systemd-state.$$}"
 
 	local pid_file=""
 	pid_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-systemd-worker.XXXXXX") || return 1
@@ -1099,11 +1170,17 @@ _dlw_exec_systemd_user_service() {
 
 	if [[ "$service_pid" =~ ^[0-9]+$ ]]; then
 		echo "[dispatch_worker_launch] systemd unit ${unit_name} reported child PID=${service_pid} for #${issue_number}" >>"$LOGFILE"
-		printf '%s\n' "$service_pid"
-		return 0
+		local stable_rc=0
+		if _dlw_systemd_wait_stable "$unit_name" "$issue_number" "$state_file" "$service_pid"; then
+			printf '%s\n' "$service_pid"
+			return 0
+		else
+			stable_rc=$?
+		fi
+		return "$stable_rc"
 	fi
 
-	_dlw_systemd_resolve_main_pid "$unit_name" "$issue_number"
+	_dlw_systemd_resolve_main_pid "$unit_name" "$issue_number" "$state_file"
 	return $?
 }
 
@@ -1152,12 +1229,26 @@ _dlw_exec_detached() {
 	# `exec` re-opens, or `coproc`. Higher FDs (10+) are rare in this
 	# codebase and can be added if measurement justifies it.
 
-	local worker_pid
+	local worker_pid systemd_rc=1
+	local systemd_state_file="${worker_log}.systemd-launch"
 	if _dlw_systemd_user_service_available; then
-		if worker_pid=$(_dlw_exec_systemd_user_service "aidevops-worker" "$worker_log" "$issue_number" "${worker_command[@]}"); then
+		if worker_pid=$(_DLW_SYSTEMD_STATE_FILE="$systemd_state_file" _dlw_exec_systemd_user_service "aidevops-worker" "$worker_log" "$issue_number" "${worker_command[@]}"); then
 			echo "[dispatch_worker_launch] Issue #${issue_number}: worker PID=$worker_pid launched via systemd-run transient user service outside pulse cgroup" >>"$LOGFILE"
 		else
-			echo "[dispatch_worker_launch] WARNING: systemd-run worker launch failed for #${issue_number}; falling back to setsid/nohup" >>"$LOGFILE"
+			systemd_rc=$?
+			if [[ "$systemd_rc" -eq 2 ]]; then
+				if [[ -f "$systemd_state_file" ]]; then
+					{
+						printf '[systemd-launch] classification=crash_during_startup\n'
+						while IFS= read -r state_line || [[ -n "$state_line" ]]; do
+							printf '%s\n' "$state_line"
+						done <"$systemd_state_file"
+					} >>"$worker_log"
+				fi
+				echo "[dispatch_worker_launch] ERROR: systemd worker for #${issue_number} failed before durable readiness; duplicate fallback suppressed" >>"$LOGFILE"
+				return 1
+			fi
+			echo "[dispatch_worker_launch] WARNING: systemd-run worker launch unresolved for #${issue_number}; falling back to setsid/nohup" >>"$LOGFILE"
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -661,6 +661,27 @@ test_prelaunch_reason_parser_preserves_explicit_reason() {
 	return 0
 }
 
+test_prelaunch_reason_parser_systemd_startup_failure() {
+	local sandbox helper_extract log_file reason
+	sandbox=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-systemd-prelaunch-test.XXXXXX")
+	# shellcheck disable=SC2064
+	trap "rm -rf '$sandbox' 2>/dev/null || true" RETURN
+	helper_extract="${sandbox}/helper.sh"
+	log_file="${sandbox}/worker.log"
+
+	awk '/^_pulse_worker_log_prelaunch_failure_reason\(\) \{/,/^\}/' "$PULSE_ENGINE" >"$helper_extract"
+	printf '[systemd-launch] classification=crash_during_startup\nExecMainStatus=1\nResult=exit-code\n[exit-trap] session=abc reason=worker_noop_zero_output status=0\n' >"$log_file"
+	reason=$(bash -c "source '$helper_extract'; _pulse_worker_log_prelaunch_failure_reason '$log_file'" 2>/dev/null)
+
+	if [[ "$reason" == "crash_during_startup" ]]; then
+		print_result "invariant: systemd status-1 evidence is a startup failure" 0
+		return 0
+	fi
+	print_result "invariant: systemd status-1 evidence is a startup failure" 1 \
+		"Expected crash_during_startup, got '${reason:-<empty>}'"
+	return 0
+}
+
 test_nohup_launch_passes_repo_slug_contract() {
 	# shellcheck disable=SC2016  # literal source snippets — no expansion intended
 	if grep -q 'WORKER_REPO_SLUG="$repo_slug"' "$WORKER_LAUNCH" \
@@ -733,6 +754,7 @@ main_test() {
 	test_worker_worktree_live_owner_skips_fast_fail_state
 	test_prelaunch_reason_parser_behavioural
 	test_prelaunch_reason_parser_preserves_explicit_reason
+	test_prelaunch_reason_parser_systemd_startup_failure
 	test_nohup_launch_passes_repo_slug_contract
 	test_claim_lock_errors_fail_closed
 

--- a/tests/test-systemd-worker-service-launch.sh
+++ b/tests/test-systemd-worker-service-launch.sh
@@ -188,6 +188,8 @@ export STUB_SYSTEMD_RUN_WRITE_PID=1
 export STUB_SYSTEMD_RUN_PID=626262
 export STUB_SYSTEMCTL_MAINPID=626262
 export STUB_SYSTEMCTL_SEQUENCE=active_then_failed
+export STUB_SETSID_LOG="${TMP_DIR}/setsid-status-1.log"
+: >"$STUB_SETSID_LOG"
 if _dlw_exec_detached "${TMP_DIR}/worker-status-1.log" "27353" /bin/false >/dev/null; then
 	printf 'FAIL expected active-then-status-1 launch to fail\n' >&2
 	exit 1
@@ -199,6 +201,19 @@ assert_contains "${TMP_DIR}/worker-status-1.log" 'Unit=aidevops-worker-27353-' '
 assert_empty_file "$STUB_SETSID_LOG" 'setsid must not duplicate an active-then-failed systemd worker'
 
 reset_logs
+export STUB_SYSTEMD_RUN_PID=737373
+export STUB_SYSTEMCTL_MAINPID=838383
+export STUB_SETSID_LOG="${TMP_DIR}/setsid-unconfirmed.log"
+: >"$STUB_SETSID_LOG"
+if _dlw_exec_detached "${TMP_DIR}/worker-unconfirmed.log" "27355" /bin/true >/dev/null; then
+	printf 'FAIL expected mismatched provisional PID launch to remain unconfirmed\n' >&2
+	exit 1
+fi
+assert_contains "${TMP_DIR}/worker-unconfirmed.log" 'classification=readiness_unconfirmed' 'expected provisional PID evidence'
+assert_empty_file "$STUB_SETSID_LOG" 'setsid must not duplicate a provisional systemd worker'
+
+reset_logs
+export STUB_SETSID_LOG="${TMP_DIR}/setsid.log"
 export AIDEVOPS_SKIP_SYSTEMD_WORKER_SERVICE=1
 pid="$(_dlw_exec_detached "${TMP_DIR}/worker-non-systemd.log" "27354" /bin/true)"
 if [[ ! "$pid" =~ ^[0-9]+$ ]]; then

--- a/tests/test-systemd-worker-service-launch.sh
+++ b/tests/test-systemd-worker-service-launch.sh
@@ -22,9 +22,29 @@ if [[ "${1:-}" == "--user" && "${2:-}" == "status" ]]; then
 fi
 
 if [[ "${1:-}" == "--user" && "${2:-}" == "show" ]]; then
-	printf '%s\n' "MainPID=${STUB_SYSTEMCTL_MAINPID:-0}"
-	printf '%s\n' "ActiveState=${STUB_SYSTEMCTL_ACTIVE_STATE:-active}"
-	printf '%s\n' "SubState=${STUB_SYSTEMCTL_SUB_STATE:-running}"
+	count=0
+	[[ -f "${STUB_SYSTEMCTL_COUNT_FILE:?}" ]] && read -r count <"$STUB_SYSTEMCTL_COUNT_FILE"
+	count=$((count + 1))
+	printf '%s\n' "$count" >"$STUB_SYSTEMCTL_COUNT_FILE"
+	active_state="${STUB_SYSTEMCTL_ACTIVE_STATE:-active}"
+	sub_state="${STUB_SYSTEMCTL_SUB_STATE:-running}"
+	main_pid="${STUB_SYSTEMCTL_MAINPID:-0}"
+	exec_status="${STUB_SYSTEMCTL_EXEC_STATUS:-0}"
+	result="${STUB_SYSTEMCTL_RESULT:-success}"
+	if [[ "${STUB_SYSTEMCTL_SEQUENCE:-stable}" == "active_then_failed" && "$count" -ge 2 ]]; then
+		active_state="failed"
+		sub_state="failed"
+		main_pid=0
+		exec_status=1
+		result="exit-code"
+	fi
+	printf '%s\n' "Id=${3:-unknown}.service"
+	printf '%s\n' "MainPID=$main_pid"
+	printf '%s\n' "ActiveState=$active_state"
+	printf '%s\n' "SubState=$sub_state"
+	printf '%s\n' "ExecMainCode=exited"
+	printf '%s\n' "ExecMainStatus=$exec_status"
+	printf '%s\n' "Result=$result"
 	exit 0
 fi
 
@@ -71,6 +91,7 @@ chmod +x "${TMP_DIR}/bin/setsid"
 export PATH="${TMP_DIR}/bin:${PATH}"
 export STUB_SYSTEMD_RUN_LOG="${TMP_DIR}/systemd-run.log"
 export STUB_SETSID_LOG="${TMP_DIR}/setsid.log"
+export STUB_SYSTEMCTL_COUNT_FILE="${TMP_DIR}/systemctl.count"
 export LOGFILE="${TMP_DIR}/pulse.log"
 export AIDEVOPS_SKIP_SYSTEMD_WORKER_SERVICE=0
 
@@ -81,6 +102,12 @@ reset_logs() {
 	: >"$STUB_SYSTEMD_RUN_LOG"
 	: >"$STUB_SETSID_LOG"
 	: >"$LOGFILE"
+	: >"$STUB_SYSTEMCTL_COUNT_FILE"
+	export STUB_SYSTEMCTL_SEQUENCE=stable
+	export STUB_SYSTEMCTL_ACTIVE_STATE=active
+	export STUB_SYSTEMCTL_SUB_STATE=running
+	export STUB_SYSTEMCTL_EXEC_STATUS=0
+	export STUB_SYSTEMCTL_RESULT=success
 	return 0
 }
 
@@ -108,6 +135,7 @@ assert_empty_file() {
 reset_logs
 export STUB_SYSTEMD_RUN_WRITE_PID=1
 export STUB_SYSTEMD_RUN_PID=424242
+export STUB_SYSTEMCTL_MAINPID=424242
 pid="$(_dlw_exec_detached "${TMP_DIR}/worker-happy.log" "23073" /bin/true)"
 
 if [[ "$pid" != "424242" ]]; then
@@ -116,6 +144,8 @@ if [[ "$pid" != "424242" ]]; then
 fi
 
 assert_contains "$STUB_SYSTEMD_RUN_LOG" '--unit=aidevops-worker-23073-' 'expected worker transient unit launch'
+assert_contains "$STUB_SYSTEMD_RUN_LOG" '--unit=aidevops-worker-monitor-23073-' 'expected monitor transient unit launch'
+assert_contains "$STUB_SYSTEMD_RUN_LOG" '--unit=aidevops-worker-observer-23073-' 'expected observer transient unit launch'
 assert_contains "$LOGFILE" 'systemd-run transient user service outside pulse cgroup' 'expected systemd launch diagnostic in pulse log'
 assert_contains "$LOGFILE" 'systemd unit aidevops-worker-23073-' 'expected systemd unit in launch diagnostic'
 assert_empty_file "$STUB_SETSID_LOG" 'setsid should not be used on pid-file systemd success'
@@ -133,6 +163,8 @@ if [[ "$pid" != "525252" ]]; then
 fi
 
 assert_contains "$LOGFILE" 'resolved MainPID=525252' 'expected MainPID recovery diagnostic in pulse log'
+assert_contains "$LOGFILE" 'aidevops-worker-monitor-23524-' 'expected monitor MainPID handoff fallback coverage'
+assert_contains "$LOGFILE" 'aidevops-worker-observer-23524-' 'expected observer MainPID handoff fallback coverage'
 assert_empty_file "$STUB_SETSID_LOG" 'setsid should not be used when systemctl resolves MainPID'
 
 reset_logs
@@ -149,6 +181,32 @@ fi
 
 assert_contains "$LOGFILE" 'falling back to setsid/nohup' 'expected fallback diagnostic when unit has no MainPID'
 assert_contains "$LOGFILE" 'systemd unit aidevops-worker-23524-' 'expected systemd unit in fallback diagnostic'
-assert_contains "$STUB_SETSID_LOG" 'nohup /bin/true' 'expected setsid fallback when unit has no MainPID'
+assert_contains "$STUB_SETSID_LOG" '/bin/true' 'expected setsid fallback when unit has no MainPID'
 
-printf 'PASS %s\n' "worker launch resolves systemd MainPID before setsid fallback"
+reset_logs
+export STUB_SYSTEMD_RUN_WRITE_PID=1
+export STUB_SYSTEMD_RUN_PID=626262
+export STUB_SYSTEMCTL_MAINPID=626262
+export STUB_SYSTEMCTL_SEQUENCE=active_then_failed
+if _dlw_exec_detached "${TMP_DIR}/worker-status-1.log" "27353" /bin/false >/dev/null; then
+	printf 'FAIL expected active-then-status-1 launch to fail\n' >&2
+	exit 1
+fi
+assert_contains "${TMP_DIR}/worker-status-1.log" 'classification=crash_during_startup' 'expected startup failure classification evidence'
+assert_contains "${TMP_DIR}/worker-status-1.log" 'ExecMainStatus=1' 'expected authoritative systemd exit status evidence'
+assert_contains "${TMP_DIR}/worker-status-1.log" 'Result=exit-code' 'expected authoritative systemd result evidence'
+assert_contains "${TMP_DIR}/worker-status-1.log" 'Unit=aidevops-worker-27353-' 'expected transient unit identity evidence'
+assert_empty_file "$STUB_SETSID_LOG" 'setsid must not duplicate an active-then-failed systemd worker'
+
+reset_logs
+export AIDEVOPS_SKIP_SYSTEMD_WORKER_SERVICE=1
+pid="$(_dlw_exec_detached "${TMP_DIR}/worker-non-systemd.log" "27354" /bin/true)"
+if [[ ! "$pid" =~ ^[0-9]+$ ]]; then
+	printf 'FAIL expected numeric non-systemd fallback pid, got %s\n' "$pid" >&2
+	exit 1
+fi
+assert_empty_file "$STUB_SYSTEMD_RUN_LOG" 'non-systemd path must not invoke systemd-run'
+assert_contains "$STUB_SETSID_LOG" '/bin/true' 'non-systemd path should retain setsid semantics'
+export AIDEVOPS_SKIP_SYSTEMD_WORKER_SERVICE=0
+
+printf 'PASS %s\n' "systemd launch readiness, evidence, handoff, and fallback semantics"

--- a/tests/test-systemd-worker-service-launch.sh
+++ b/tests/test-systemd-worker-service-launch.sh
@@ -122,6 +122,22 @@ assert_contains() {
 	return 0
 }
 
+assert_eventually_contains() {
+	local file_path="$1"
+	local expected="$2"
+	local message="$3"
+	local attempt=0
+	while ((attempt < 20)); do
+		if grep -q -- "$expected" "$file_path"; then
+			return 0
+		fi
+		sleep 0.05
+		attempt=$((attempt + 1))
+	done
+	printf 'FAIL %s\n' "$message" >&2
+	exit 1
+}
+
 assert_empty_file() {
 	local file_path="$1"
 	local message="$2"
@@ -181,7 +197,7 @@ fi
 
 assert_contains "$LOGFILE" 'falling back to setsid/nohup' 'expected fallback diagnostic when unit has no MainPID'
 assert_contains "$LOGFILE" 'systemd unit aidevops-worker-23524-' 'expected systemd unit in fallback diagnostic'
-assert_contains "$STUB_SETSID_LOG" '/bin/true' 'expected setsid fallback when unit has no MainPID'
+assert_eventually_contains "$STUB_SETSID_LOG" '/bin/true' 'expected setsid fallback when unit has no MainPID'
 
 reset_logs
 export STUB_SYSTEMD_RUN_WRITE_PID=1
@@ -221,7 +237,7 @@ if [[ ! "$pid" =~ ^[0-9]+$ ]]; then
 	exit 1
 fi
 assert_empty_file "$STUB_SYSTEMD_RUN_LOG" 'non-systemd path must not invoke systemd-run'
-assert_contains "$STUB_SETSID_LOG" '/bin/true' 'non-systemd path should retain setsid semantics'
+assert_eventually_contains "$STUB_SETSID_LOG" '/bin/true' 'non-systemd path should retain setsid semantics'
 export AIDEVOPS_SKIP_SYSTEMD_WORKER_SERVICE=0
 
 printf 'PASS %s\n' "systemd launch readiness, evidence, handoff, and fallback semantics"


### PR DESCRIPTION
## Summary

- Add bounded systemd launch readiness instead of accepting a momentary MainPID.
- Preserve transient-unit identity, ExecMainCode, ExecMainStatus, and Result before collection.
- Classify authoritative pre-session failures as crash_during_startup and suppress duplicate setsid fallback.
- Preserve non-systemd launch behavior and genuine exit-0/no-session classification.

## Testing

- Systemd launch regression test passed.
- Worker launch lock checks passed.
- No-worker-process suite: 28/28 passed.
- Worker exit classifier: 16/16 passed.
- Runtime failure classifier: 57/57 passed.
- Local linters and ShellCheck passed.

## Runtime Testing

- Self-assessed with deterministic systemd command stubs because the active host is macOS; Linux behavior is exercised in CI.

Resolves #27353

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 31m and 73,212 tokens on this with the user in an interactive session. Overall, 43m since this issue was created.
