### PR TITLE
GH#27365: resolve portable git path in sync test

### DIFF
--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -79,10 +79,22 @@ create_fake_repo() {
 	local repo_name="$1"
 	local remote_url="$2"
 	local repo_path="$TEST_DIR/$repo_name"
+	local git_bin=""
+	local git_bin_dir
+	local git_candidate
+	while IFS= read -r git_candidate; do
+		case "$git_candidate" in
+		*/.aidevops/*) continue ;;
+		esac
+		git_bin="$git_candidate"
+		break
+	done < <(type -aP git)
+	[[ -n "$git_bin" ]] || return 1
+	git_bin_dir=$(dirname "$git_bin")
 
 	mkdir -p "$repo_path"
-	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git init -q "$repo_path"
-	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" remote add origin "$remote_url"
+	PATH="$git_bin_dir:/usr/bin:/bin" git init -q "$repo_path"
+	PATH="$git_bin_dir:/usr/bin:/bin" git -C "$repo_path" remote add origin "$remote_url"
 	printf '%s\n' "$repo_path"
 	return 0
 }


### PR DESCRIPTION
## Summary

Resolve the real git executable directory dynamically instead of hardcoding Homebrew locations, while skipping aidevops command guards in this isolated regression fixture.

## Files Changed

.agents/scripts/tests/test-agent-auto-sync.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-agent-auto-sync.sh; PATH=/opt/homebrew/bin:/usr/bin:/bin bash .agents/scripts/tests/test-agent-auto-sync.sh (5/5 passed)

Resolves #27365


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 12m and 54,794 tokens on this as a headless worker.