### PR TITLE
GH#27377: guard pulse merge cursor under strict mode

### DIFF
--- a/.agents/scripts/pulse-merge-pass.sh
+++ b/.agents/scripts/pulse-merge-pass.sh
@@ -353,7 +353,7 @@ _pmp_process_merge_repo_for_pass() {
 	_pmp_add_elapsed_seconds _mr_repo_total_s "$_mr_repo_start"
 	_pmp_log_repo_timing_summary "$repo_slug" "$_mr_repo_total_s" "$_mr_repo_list_s" "$_mr_repo_mergeability_s" "$_mr_repo_ruleset_s" "$_mr_repo_branch_protection_s" "$_mr_repo_stuck_detector_s" "$repo_merged" "$repo_closed" "$repo_failed" "$_mr_repo_pr_count"
 	_pmp_write_merge_checkpoint "$checkpoint_file" "$repo_slug"
-	_pmp_clear_merge_pr_cursor "$PULSE_MERGE_PR_CURSOR_FILE"
+	_pmp_clear_merge_pr_cursor "${PULSE_MERGE_PR_CURSOR_FILE:-}"
 
 	if [[ -f "$stop_flag" ]]; then
 		echo "[pulse-wrapper] Deterministic merge pass: stop flag appeared mid-run" >>"$logfile"

--- a/.agents/tests/test-pulse-merge-pass-strict-mode.sh
+++ b/.agents/tests/test-pulse-merge-pass-strict-mode.sh
@@ -41,4 +41,18 @@ else
 fi
 [[ "$status" -eq 5 ]]
 
+repo_allows_pulse_write_actions() { return 0; }
+_merge_ready_prs_for_repo() { return 0; }
+_pmp_now_epoch() { printf '0\n'; return 0; }
+_pmp_add_elapsed_seconds() { return 0; }
+_pmp_log_repo_timing_summary() { return 0; }
+
+total_merged=0
+total_closed=0
+total_failed=0
+total_eligible=0
+completed_all=1
+_pmp_process_merge_repo_for_pass "owner/repo" "${tmp_dir}/process-checkpoint" "${tmp_dir}/process.log" \
+	"${tmp_dir}/stop" total_merged total_closed total_failed total_eligible completed_all
+
 printf 'pulse merge-pass strict-mode regression checks passed\n'


### PR DESCRIPTION
## Summary

- Guard repository-level merge cursor cleanup when `PULSE_MERGE_PR_CURSOR_FILE` is unset under `set -u`.
- Exercise the direct repository-processing path in the strict-mode regression test.
- Keep the patch scoped to the remaining verified review finding; the other cited paths are already guarded on the current base.

## Testing

- `bash .agents/tests/test-pulse-merge-pass-strict-mode.sh`
- `shellcheck .agents/scripts/pulse-merge-pass.sh .agents/tests/test-pulse-merge-pass-strict-mode.sh`

## Runtime Testing

Runtime-verified through the focused strict-mode execution path.

Resolves #27377

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 10m and 73,307 tokens on this as a headless worker.
