### PR TITLE
GH#27152: publish planning changes without checkout mutation

### DIFF
--- a/.agents/scripts/dependency-event-reconciler.sh
+++ b/.agents/scripts/dependency-event-reconciler.sh
@@ -4,7 +4,7 @@
 
 [[ -n "${_DEPENDENCY_EVENT_RECONCILER_LOADED:-}" ]] && return 0
 _DEPENDENCY_EVENT_RECONCILER_LOADED=1
-DER_SEARCH_QUOTE='"'
+DER_SEARCH_QUOTE=$(printf '\042')
 DER_STATE_CLOSED="CLOSED"
 
 _der_dir="${BASH_SOURCE[0]%/*}"
@@ -44,6 +44,12 @@ _der_labels_has() {
 	local labels="$1"
 	local expected="$2"
 	[[ ",${labels}," == *",${expected},"* ]]
+	return $?
+}
+
+_der_json_pages_valid() {
+	local pages="$1"
+	printf '%s' "$pages" | jq -e 'type == "array" and all(.[]; type == "array")' >/dev/null 2>&1
 	return $?
 }
 
@@ -266,7 +272,7 @@ _der_try_unblock() {
 	_der_labels_has "$labels" status:blocked || return 0
 	_der_has_active_status "$labels" && return 0
 	comments_json=$(gh api --paginate --slurp "repos/${repo}/issues/${issue_number}/comments?per_page=100" 2>/dev/null) || return 1
-	printf '%s' "$comments_json" | jq -e 'type == "array" and all(.[]; type == "array")' >/dev/null 2>&1 || return 1
+	_der_json_pages_valid "$comments_json" || return 1
 	comments=$(printf '%s' "$comments_json" | jq -r '.[][] | .body // ""' 2>/dev/null) || return 1
 	_der_has_hold "$body" "$comments" "$labels" && return 0
 	_der_native_blockers_closed "$repo" "$issue_number" || return 1
@@ -305,4 +311,34 @@ reconcile_dependants_after_verified_closure() {
 		_der_try_unblock "$repo" "$issue_number" "$candidate" || return 1
 	done <<<"$candidates"
 	return 0
+}
+
+# Periodically recover status:blocked issues whose close event was missed.
+# REST pagination is consumed in full, then bounded before any mutation.
+reconcile_stale_blocked_issues() {
+	local repo="$1"
+	local max_candidates="${DER_STALE_BLOCKED_MAX_CANDIDATES:-500}"
+	local pages candidates candidate issue_number
+	local total=0 reconciled=0 failed=0
+	[[ "$repo" == */* ]] || return 1
+	[[ "$max_candidates" =~ ^[1-9][0-9]*$ ]] || max_candidates=500
+	pages=$(gh api --paginate --slurp "repos/${repo}/issues?state=open&labels=status%3Ablocked&per_page=100" 2>/dev/null) || return 1
+	_der_json_pages_valid "$pages" || return 1
+	total=$(printf '%s' "$pages" | jq '[.[][] | select(.pull_request == null)] | length') || return 1
+	candidates=$(printf '%s' "$pages" | jq -c --arg repo "$repo" --argjson limit "$max_candidates" '[.[][] | select(.pull_request == null)][: $limit][] | {number,state,title,body,repository:{nameWithOwner:$repo},labels:{nodes:[.labels[] | {name:.name}],pageInfo:{hasNextPage:false}}}') || return 1
+	while IFS= read -r candidate; do
+		[[ -n "$candidate" ]] || continue
+		issue_number=$(printf '%s' "$candidate" | jq -r '.number') || {
+			failed=$((failed + 1))
+			continue
+		}
+		if _der_try_unblock "$repo" "$issue_number" "$candidate"; then
+			reconciled=$((reconciled + 1))
+		else
+			failed=$((failed + 1))
+		fi
+	done <<<"$candidates"
+	printf '[dependency-reconciler] stale sweep repo=%s candidates=%s checked=%s failed=%s batch_limit=%s remaining=%s\n' "$repo" "$total" "$reconciled" "$failed" "$max_candidates" "$((total > max_candidates ? total - max_candidates : 0))" >&2
+	[[ "$failed" -eq 0 ]]
+	return $?
 }

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -221,8 +221,8 @@ _merge_linked_issue_numbers() {
 }
 
 # Return every repository-bound issue that GitHub confirms this merged PR
-# closed. A truncated or internally inconsistent connection is ambiguous and
-# fails closed so callers perform no partial dependency reconciliation.
+# closed. A truncated, internally inconsistent, or not-yet-closed connection is
+# ambiguous and fails closed so callers perform no partial reconciliation.
 _merge_confirmed_closing_issue_numbers() {
 	local pr_number="$1"
 	local repo="$2"
@@ -252,9 +252,35 @@ query($owner:String!,$name:String!,$number:Int!) {
         and (($refs.totalCount | type) == "number" and $refs.totalCount <= 100)
         and $refs.pageInfo.hasNextPage == false
         and (($refs.nodes | length) == $refs.totalCount)
-        and all($refs.nodes[]; .repository.nameWithOwner == $repo)' >/dev/null 2>&1 || return 1
-	printf '%s' "$result" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[]? | select(.state == "CLOSED") | .number' 2>/dev/null || return 1
+        and all($refs.nodes[]; .repository.nameWithOwner == $repo and .state == "CLOSED")' >/dev/null 2>&1 || return 1
+	printf '%s' "$result" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[]?.number' 2>/dev/null || return 1
 	return 0
+}
+
+_merge_reconcile_closing_issues() {
+	local pr_number="$1"
+	local repo="$2"
+	local max_attempts="${FULL_LOOP_CLOSING_RECONCILE_ATTEMPTS:-4}"
+	local retry_delay="${FULL_LOOP_CLOSING_RECONCILE_DELAY_SECONDS:-2}"
+	local attempt=1 closing_issues="" closing_issue=""
+	[[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] || max_attempts=4
+	[[ "$retry_delay" =~ ^[0-9]+$ ]] || retry_delay=2
+
+	while [[ "$attempt" -le "$max_attempts" ]]; do
+		if closing_issues=$(_merge_confirmed_closing_issue_numbers "$pr_number" "$repo"); then
+			while IFS= read -r closing_issue; do
+				[[ "$closing_issue" =~ ^[0-9]+$ ]] || continue
+				reconcile_dependants_after_verified_closure "$repo" "$closing_issue" || true
+			done <<<"$closing_issues"
+			print_info "CLOSING_ISSUE_RECONCILIATION=converged pr=${pr_number} attempts=${attempt} references=$(printf '%s\n' "$closing_issues" | grep -cE '^[0-9]+$' || true)"
+			return 0
+		fi
+		print_warning "CLOSING_ISSUE_RECONCILIATION=pending pr=${pr_number} attempt=${attempt}/${max_attempts}"
+		[[ "$attempt" -lt "$max_attempts" && "$retry_delay" -gt 0 ]] && sleep "$retry_delay"
+		attempt=$((attempt + 1))
+	done
+	print_warning "CLOSING_ISSUE_RECONCILIATION=deferred pr=${pr_number} attempts=${max_attempts}; periodic pulse reconciliation will recover stale blocked dependants"
+	return 1
 }
 
 _merge_issue_requires_maintainer_review() {
@@ -739,7 +765,6 @@ _merge_finalize_post_merge() {
 	local has_auto="$3"
 	local cleanup_plan="$4"
 	local linked_issue=""
-	local closing_issues="" closing_issue=""
 	linked_issue=$(gh pr view "$pr_number" --repo "$repo" --json body \
 		--jq '.body' 2>/dev/null |
 		grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' |
@@ -747,11 +772,7 @@ _merge_finalize_post_merge() {
 	if [[ -n "$linked_issue" ]]; then
 		release_interactive_claim_on_merge "$pr_number" "$repo" "$linked_issue" || true
 	fi
-	closing_issues=$(_merge_confirmed_closing_issue_numbers "$pr_number" "$repo") || closing_issues=""
-	while IFS= read -r closing_issue; do
-		[[ "$closing_issue" =~ ^[0-9]+$ ]] || continue
-		reconcile_dependants_after_verified_closure "$repo" "$closing_issue" || true
-	done <<<"$closing_issues"
+	_merge_reconcile_closing_issues "$pr_number" "$repo" || true
 	if [[ "$has_auto" -eq 0 && -n "$linked_issue" ]]; then
 		auto_file_next_phase "$linked_issue" "$repo" || true
 	fi

--- a/.agents/scripts/planning-commit-helper.sh
+++ b/.agents/scripts/planning-commit-helper.sh
@@ -20,6 +20,8 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=./planning-publisher.sh
+source "${SCRIPT_DIR}/planning-publisher.sh"
 
 set -euo pipefail
 
@@ -536,8 +538,7 @@ next_task_id() {
 }
 
 # Main commit function
-# Uses todo_commit_push() from shared-constants.sh for serialized locking
-# to prevent race conditions when multiple actors push to TODO.md on main.
+# Publishes from a temporary index and retries bounded fast-forward contention.
 commit_planning_files() {
 	local commit_msg="${1:-plan: update planning files}"
 
@@ -558,14 +559,20 @@ commit_planning_files() {
 	local repo_root
 	repo_root=$(git rev-parse --show-toplevel)
 
-	# Use serialized commit+push (flock + pull-rebase-retry)
+	# Publish through a temporary index so caller HEAD/index/files stay untouched.
 	log_info "Committing: $commit_msg"
-	if todo_commit_push "$repo_root" "$commit_msg" "TODO.md todo/"; then
-		if [[ "${TODO_COMMIT_PUSH_RESULT:-}" == "pr" ]]; then
-			log_success "Planning files submitted via planning PR: ${TODO_COMMIT_PUSH_PR_URL:-created}"
-		else
-			log_success "Planning files committed and pushed" # nice
-		fi
+	local current_branch=""
+	current_branch=$(git -C "$repo_root" symbolic-ref --short HEAD 2>/dev/null) || return 1
+	local default_branch=""
+	default_branch=$(_todo_default_branch "$repo_root")
+	if [[ "$current_branch" == "$default_branch" ]] && _todo_branch_requires_planning_pr "$repo_root" "$default_branch"; then
+		todo_commit_push "$repo_root" "$commit_msg" "TODO.md todo/"
+		return $?
+	fi
+	local changed_paths=""
+	changed_paths=$(_planning_publish_changed_paths "$repo_root")
+	if planning_publish "$repo_root" "$commit_msg" origin "$current_branch" "$changed_paths"; then
+		log_success "Planning files published without changing local Git state"
 	else
 		log_error "Planning file publication failed; no successful direct push or planning PR was created"
 		return 1

--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Checkout-free publication of TODO.md and todo/** changes.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ -n "${_PLANNING_PUBLISHER_LOADED:-}" ]] && return 0
+_PLANNING_PUBLISHER_LOADED=1
+
+PLANNING_PUBLISH_MAX_RETRIES="${PLANNING_PUBLISH_MAX_RETRIES:-3}"
+PLANNING_PUBLISH_RESULT=""
+PLANNING_PUBLICATION_ID=""
+
+_planning_publish_log() {
+	local level="$1"
+	local message="$2"
+	if command -v "log_${level}" >/dev/null 2>&1; then
+		"log_${level}" "$message"
+	else
+		printf '[planning-publisher][%s] %s\n' "$level" "$message" >&2
+	fi
+	return 0
+}
+
+_planning_publish_path_allowed() {
+	local path="$1"
+	case "$path" in
+	TODO.md | todo/*)
+		[[ "$path" != *'..'* && "$path" != *'//'* && "$path" != */ ]]
+		return $?
+		;;
+	*) return 1 ;;
+	esac
+}
+
+_planning_publish_changed_paths() {
+	local repo_path="$1"
+	{
+		git -C "$repo_path" diff --name-only HEAD -- TODO.md todo/ 2>/dev/null || true
+		git -C "$repo_path" diff --name-only --cached -- TODO.md todo/ 2>/dev/null || true
+		git -C "$repo_path" ls-files --others --exclude-standard -- TODO.md todo/ 2>/dev/null || true
+	} | LC_ALL=C sort -u | grep -v '^$' || true
+	return 0
+}
+
+_planning_publish_snapshot() {
+	local repo_path="$1"
+	local paths="$2"
+	local snapshot_file="$3"
+	local path=""
+	: >"$snapshot_file" || return 1
+	while IFS= read -r path; do
+		[[ -n "$path" ]] || continue
+		_planning_publish_path_allowed "$path" || {
+			_planning_publish_log error "Unauthorized planning path: $path"
+			return 1
+		}
+		if [[ -L "${repo_path}/${path}" ]] || [[ -d "${repo_path}/${path}" ]]; then
+			_planning_publish_log error "Planning paths must be regular files: $path"
+			return 1
+		fi
+		if [[ -f "${repo_path}/${path}" ]]; then
+			local blob_sha=""
+			blob_sha=$(git -C "$repo_path" hash-object -w -- "${repo_path}/${path}") || return 1
+			printf 'file\t%s\t%s\n' "$blob_sha" "$path" >>"$snapshot_file" || return 1
+		else
+			printf 'delete\t-\t%s\n' "$path" >>"$snapshot_file" || return 1
+		fi
+	done <<<"$paths"
+	return 0
+}
+
+_planning_publish_build_index() {
+	local repo_path="$1"
+	local parent_sha="$2"
+	local snapshot_file="$3"
+	local index_file="$4"
+	local operation="" blob_sha="" path=""
+	rm -f "$index_file" || return 1
+	GIT_INDEX_FILE="$index_file" git -C "$repo_path" read-tree "$parent_sha" || return 1
+	while IFS=$'\t' read -r operation blob_sha path; do
+		[[ -n "$path" ]] || continue
+		if [[ "$operation" == "file" ]]; then
+			GIT_INDEX_FILE="$index_file" git -C "$repo_path" update-index --add --cacheinfo "100644,${blob_sha},${path}" || return 1
+		else
+			GIT_INDEX_FILE="$index_file" git -C "$repo_path" update-index --force-remove -- "$path" || return 1
+		fi
+	done <"$snapshot_file"
+	return 0
+}
+
+_planning_publish_verify_index() {
+	local repo_path="$1"
+	local parent_sha="$2"
+	local snapshot_file="$3"
+	local index_file="$4"
+	local changed_path="" operation="" expected_sha="" path="" staged_sha=""
+	while IFS= read -r changed_path; do
+		[[ -n "$changed_path" ]] || continue
+		_planning_publish_path_allowed "$changed_path" || return 1
+	done < <(GIT_INDEX_FILE="$index_file" git -C "$repo_path" diff --cached --name-only "$parent_sha")
+	while IFS=$'\t' read -r operation expected_sha path; do
+		if [[ "$operation" == "file" ]]; then
+			staged_sha=$(GIT_INDEX_FILE="$index_file" git -C "$repo_path" rev-parse ":${path}" 2>/dev/null) || return 1
+			[[ "$staged_sha" == "$expected_sha" ]] || return 1
+		elif GIT_INDEX_FILE="$index_file" git -C "$repo_path" rev-parse ":${path}" >/dev/null 2>&1; then
+			return 1
+		fi
+	done <"$snapshot_file"
+	return 0
+}
+
+_planning_publish_validate() {
+	local repo_path="$1"
+	local parent_sha="$2"
+	local candidate_sha="$3"
+	local index_file="$4"
+	local validator="${AIDEVOPS_PLANNING_VALIDATOR:-}"
+	if [[ -n "$validator" ]]; then
+		GIT_INDEX_FILE="$index_file" "$validator" "$repo_path" "$parent_sha" "$candidate_sha"
+		return $?
+	fi
+	local hook="${SCRIPT_DIR:-${repo_path}/.agents/scripts}/pre-commit-hook.sh"
+	if [[ -x "$hook" ]]; then
+		(cd "$repo_path" && GIT_INDEX_FILE="$index_file" HOOK_MODE=pre-commit "$hook" >/dev/null) || return 1
+	fi
+	local privacy_lib="${SCRIPT_DIR:-${repo_path}/.agents/scripts}/privacy-guard-helper.sh"
+	if [[ -f "$privacy_lib" ]]; then
+		# shellcheck disable=SC1090
+		source "$privacy_lib"
+		local privacy_hits="" slugs_file=""
+		slugs_file=$(mktemp "${TMPDIR:-/tmp}/planning-private-slugs.XXXXXX") || return 1
+		privacy_enumerate_private_slugs "$slugs_file" >/dev/null 2>&1 || true
+		privacy_hits=$(cd "$repo_path" && {
+			privacy_scan_secret_material_diff "$parent_sha" "$candidate_sha" 2>/dev/null || true
+			privacy_scan_diff "$parent_sha" "$candidate_sha" "$slugs_file" 2>/dev/null || true
+		})
+		rm -f "$slugs_file"
+		[[ -z "$privacy_hits" ]] || return 1
+	fi
+	return 0
+}
+
+_planning_publish_parent_conflicts() {
+	local repo_path="$1"
+	local old_parent="$2"
+	local new_parent="$3"
+	local snapshot_file="$4"
+	local operation="" blob_sha="" path=""
+	while IFS=$'\t' read -r operation blob_sha path; do
+		if ! git -C "$repo_path" diff --quiet "$old_parent" "$new_parent" -- "$path"; then
+			return 0
+		fi
+	done <"$snapshot_file"
+	return 1
+}
+
+planning_publish() {
+	local repo_path="$1"
+	local commit_msg="$2"
+	local remote_name="${3:-origin}"
+	local branch_name="${4:-}"
+	local paths="${5:-}"
+	local temp_dir="" snapshot_file="" index_file="" parent_sha="" tree_sha="" candidate_sha=""
+	local publication_id="" attempt=0 push_rc=0 latest_sha=""
+
+	[[ -n "$branch_name" ]] || branch_name=$(git -C "$repo_path" symbolic-ref --short HEAD 2>/dev/null) || return 1
+	[[ -n "$paths" ]] || paths=$(_planning_publish_changed_paths "$repo_path")
+	if [[ -z "$paths" ]]; then
+		PLANNING_PUBLISH_RESULT="noop"
+		return 0
+	fi
+	temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/planning-publisher.XXXXXX") || return 1
+	snapshot_file="${temp_dir}/snapshot"
+	index_file="${temp_dir}/index"
+	_planning_publish_snapshot "$repo_path" "$paths" "$snapshot_file" || {
+		rm -rf "$temp_dir"
+		return 1
+	}
+	publication_id=$(git -C "$repo_path" hash-object "$snapshot_file") || {
+		rm -rf "$temp_dir"
+		return 1
+	}
+	PLANNING_PUBLICATION_ID="$publication_id"
+
+	while [[ $attempt -lt $PLANNING_PUBLISH_MAX_RETRIES ]]; do
+		attempt=$((attempt + 1))
+		git -C "$repo_path" fetch -q "$remote_name" "$branch_name" || {
+			rm -rf "$temp_dir"
+			return 1
+		}
+		latest_sha=$(git -C "$repo_path" rev-parse FETCH_HEAD) || {
+			rm -rf "$temp_dir"
+			return 1
+		}
+		if [[ -n "$parent_sha" ]] && _planning_publish_parent_conflicts "$repo_path" "$parent_sha" "$latest_sha" "$snapshot_file"; then
+			_planning_publish_log warning "AIDEVOPS_PLANNING_PUBLISH_STATUS=retryable_conflict publication_id=${publication_id}"
+			rm -rf "$temp_dir"
+			return 2
+		fi
+		parent_sha="$latest_sha"
+		_planning_publish_build_index "$repo_path" "$parent_sha" "$snapshot_file" "$index_file" || {
+			rm -rf "$temp_dir"
+			return 1
+		}
+		_planning_publish_verify_index "$repo_path" "$parent_sha" "$snapshot_file" "$index_file" || {
+			rm -rf "$temp_dir"
+			return 1
+		}
+		tree_sha=$(GIT_INDEX_FILE="$index_file" git -C "$repo_path" write-tree) || {
+			rm -rf "$temp_dir"
+			return 1
+		}
+		if [[ "$tree_sha" == "$(git -C "$repo_path" rev-parse "${parent_sha}^{tree}")" ]]; then
+			PLANNING_PUBLISH_RESULT="noop"
+			rm -rf "$temp_dir"
+			return 0
+		fi
+		candidate_sha=$(printf '%s\n\nPlanning-Publication-ID: %s\n' "$commit_msg" "$publication_id" | git -C "$repo_path" commit-tree "$tree_sha" -p "$parent_sha") || {
+			rm -rf "$temp_dir"
+			return 1
+		}
+		if ! _planning_publish_validate "$repo_path" "$parent_sha" "$candidate_sha" "$index_file"; then
+			_planning_publish_log error "Planning publication validation failed; nothing pushed"
+			rm -rf "$temp_dir"
+			return 1
+		fi
+		if [[ -n "${AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK:-}" ]]; then
+			"$AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK" "$repo_path" "$remote_name" "$branch_name" "$parent_sha" "$candidate_sha" "$attempt" || {
+				rm -rf "$temp_dir"
+				return 1
+			}
+		fi
+		push_rc=0
+		git -C "$repo_path" push -q "$remote_name" "${candidate_sha}:refs/heads/${branch_name}" || push_rc=$?
+		if [[ $push_rc -eq 0 ]]; then
+			PLANNING_PUBLISH_RESULT="published"
+			_planning_publish_log success "Published planning files (${publication_id})"
+			rm -rf "$temp_dir"
+			return 0
+		fi
+	done
+	_planning_publish_log warning "AIDEVOPS_PLANNING_PUBLISH_STATUS=retryable_conflict publication_id=${publication_id}"
+	rm -rf "$temp_dir"
+	return 2
+}

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -157,8 +157,8 @@ _pulse_refresh_repo() {
 		# advisory issue and we proceed with the current checkout.
 		echo "[pulse-wrapper] _pulse_refresh_repo: git pull --ff-only failed for ${repo_path} — attempting canonical-recovery" >>"$LOGFILE"
 		if declare -F pulse_canonical_recover >/dev/null 2>&1; then
-			pulse_canonical_recover "$repo_path" >>"$LOGFILE" 2>&1 \
-				|| echo "[pulse-wrapper] _pulse_refresh_repo: canonical-recovery did not heal ${repo_path} — proceeding with current checkout (advisory filed)" >>"$LOGFILE"
+			pulse_canonical_recover "$repo_path" >>"$LOGFILE" 2>&1 ||
+				echo "[pulse-wrapper] _pulse_refresh_repo: canonical-recovery did not heal ${repo_path} — proceeding with current checkout (advisory filed)" >>"$LOGFILE"
 		else
 			echo "[pulse-wrapper] _pulse_refresh_repo: pulse_canonical_recover unavailable — proceeding with current checkout" >>"$LOGFILE"
 		fi
@@ -394,7 +394,7 @@ _pulse_prime_caches_if_stale() {
 		local _now_epoch="" _stamp_epoch="" _age_s=""
 		_now_epoch=$(date +%s 2>/dev/null)
 		_stamp_epoch=$(_file_mtime_epoch "$_prime_sentinel")
-		_age_s=$(( ${_now_epoch:-0} - ${_stamp_epoch:-0} ))
+		_age_s=$((${_now_epoch:-0} - ${_stamp_epoch:-0}))
 		[[ "$_age_s" -gt "$_prime_max_age" ]] && _should_prime=1
 	fi
 
@@ -436,7 +436,7 @@ _pulse_check_runaway_log() {
 		local _now_epoch="" _stamp_epoch="" _age_s=""
 		_now_epoch=$(date +%s 2>/dev/null)
 		_stamp_epoch=$(_file_mtime_epoch "$_detector_sentinel")
-		_age_s=$(( ${_now_epoch:-0} - ${_stamp_epoch:-0} ))
+		_age_s=$((${_now_epoch:-0} - ${_stamp_epoch:-0}))
 		[[ "$_age_s" -gt "$_detector_max_age" ]] && _should_check=1
 	fi
 
@@ -445,6 +445,30 @@ _pulse_check_runaway_log() {
 		# Touch sentinel regardless of outcome (fail-open)
 		touch "$_detector_sentinel" 2>/dev/null || true
 	fi
+	return 0
+}
+
+_pulse_reconcile_stale_blocked_if_due() {
+	[[ "${AIDEVOPS_SKIP_STALE_BLOCKED_RECONCILE:-0}" == "1" ]] && return 0
+	local sentinel="${HOME}/.aidevops/cache/pulse-stale-blocked-reconcile-last-run"
+	local interval="${PULSE_STALE_BLOCKED_RECONCILE_INTERVAL:-1800}"
+	local now_epoch="" stamp_epoch="" age_s="" repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+	local repo_slug="" failures=0
+	[[ "$interval" =~ ^[0-9]+$ ]] || interval=1800
+	[[ -f "$repos_json" ]] || return 0
+	if [[ -f "$sentinel" ]]; then
+		now_epoch=$(date +%s 2>/dev/null) || return 0
+		stamp_epoch=$(_file_mtime_epoch "$sentinel")
+		age_s=$((now_epoch - ${stamp_epoch:-0}))
+		[[ "$age_s" -ge "$interval" ]] || return 0
+	fi
+	mkdir -p "${sentinel%/*}" 2>/dev/null || return 0
+	while IFS= read -r repo_slug; do
+		[[ -n "$repo_slug" ]] || continue
+		reconcile_stale_blocked_issues "$repo_slug" 2>>"$LOGFILE" || failures=$((failures + 1))
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null || true)
+	touch "$sentinel" 2>/dev/null || true
+	echo "[pulse-wrapper] stale-blocked reconciliation completed failures=${failures} cadence=${interval}s" >>"$LOGFILE"
 	return 0
 }
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -215,7 +215,7 @@ if [[ "$_pulse_skip_jitter" -eq 0 ]]; then
 			# Use lockdir mtime as lock-acquired timestamp (mkdir is atomic).
 			_pw_ffjit_mtime=$(_file_mtime_epoch "$_pw_ffjit_lockdir")
 			_pw_ffjit_now=$(date +%s)
-			_pw_ffjit_age=$(( _pw_ffjit_now - _pw_ffjit_mtime ))
+			_pw_ffjit_age=$((_pw_ffjit_now - _pw_ffjit_mtime))
 			if [[ "$_pw_ffjit_age" -le "${PULSE_LOCK_MAX_AGE_S:-1800}" ]]; then
 				printf '[pulse-wrapper] another instance running (PID %s, age %ss), skipping\n' \
 					"$_pw_ffjit_pid" "$_pw_ffjit_age" \
@@ -494,12 +494,12 @@ _pulse_should_defer_budget_priority_stage() {
 	local _stage="$1"
 	[[ "${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS:-normal}" == "reserve" ]] || return 1
 	case "$_stage" in
-		cache_prime|fix_the_fixer_detector|coderabbit_review|post_merge_scanner|pr_review_thread_response|auto_decomposer_scanner|dedup_cleanup|fast_fail_prune_expired|evaluate_routines|dependabot_alert_monitor|canonical_maintenance|dashboard_freshness_check|llm_supervisor)
-			return 0
-			;;
-		*)
-			return 1
-			;;
+	cache_prime | fix_the_fixer_detector | coderabbit_review | post_merge_scanner | pr_review_thread_response | auto_decomposer_scanner | dedup_cleanup | fast_fail_prune_expired | evaluate_routines | dependabot_alert_monitor | canonical_maintenance | dashboard_freshness_check | llm_supervisor)
+		return 0
+		;;
+	*)
+		return 1
+		;;
 	esac
 }
 
@@ -1142,7 +1142,7 @@ is_no_work_rate_acceptable() {
 		for ts in ${window_timestamps[@]+"${window_timestamps[@]}"}; do
 			printf '%s\n' "$ts"
 		done
-	} > "$tmp_state" 2>/dev/null && mv "$tmp_state" "$state_file" 2>/dev/null || rm -f "$tmp_state" 2>/dev/null || true
+	} >"$tmp_state" 2>/dev/null && mv "$tmp_state" "$state_file" 2>/dev/null || rm -f "$tmp_state" 2>/dev/null || true
 
 	# Check threshold.
 	if [[ "$window_count" -ge "$max_events" ]]; then
@@ -1602,16 +1602,16 @@ main() {
 		_rl_now=$(date +%s)
 		_rl_last=0
 		if [[ -f "$_rl_ts_file" ]]; then
-			read -r _rl_last < "$_rl_ts_file" || _rl_last=0
+			read -r _rl_last <"$_rl_ts_file" || _rl_last=0
 			# Treat corrupt/non-numeric content as 0 (stale) — continue normally
 			[[ "$_rl_last" =~ ^[0-9]+$ ]] || _rl_last=0
 		fi
-		_rl_elapsed=$(( _rl_now - _rl_last ))
-		if (( _rl_elapsed < PULSE_MIN_INTERVAL_S )); then
+		_rl_elapsed=$((_rl_now - _rl_last))
+		if ((_rl_elapsed < PULSE_MIN_INTERVAL_S)); then
 			# t3018: peek at instance lock. No live holder = stale stamp.
 			local _rl_lock_pid=""
 			if [[ -f "${LOCKDIR}/pid" ]]; then
-				read -r _rl_lock_pid < "${LOCKDIR}/pid" 2>/dev/null || _rl_lock_pid=""
+				read -r _rl_lock_pid <"${LOCKDIR}/pid" 2>/dev/null || _rl_lock_pid=""
 			fi
 			if [[ "$_rl_lock_pid" =~ ^[0-9]+$ ]] && kill -0 "$_rl_lock_pid" 2>/dev/null; then
 				echo "[pulse-wrapper] Rate-limited: last run ${_rl_elapsed}s ago < ${PULSE_MIN_INTERVAL_S}s threshold — skipping cycle (GH#20578)" >>"$WRAPPER_LOGFILE"
@@ -1623,10 +1623,10 @@ main() {
 			# cost of a false-proceed (occasional tighter cycle interval)
 			# is far smaller than the cost of false-skip (the bug being fixed).
 			echo "[pulse-wrapper] Rate-limit stamp ${_rl_elapsed}s old but no live lock holder (pid='${_rl_lock_pid:-<missing>}') — clearing stale stamp and proceeding (GH#21570 self-heal)" >>"$WRAPPER_LOGFILE"
-			: > "$_rl_ts_file" 2>/dev/null || true
-			_rl_elapsed=$(( _rl_now - 0 ))
+			: >"$_rl_ts_file" 2>/dev/null || true
+			_rl_elapsed=$((_rl_now - 0))
 		fi
-		printf '%s\n' "$_rl_now" > "$_rl_ts_file" || true
+		printf '%s\n' "$_rl_now" >"$_rl_ts_file" || true
 	fi
 
 	# GH#4513: Acquire exclusive instance lock FIRST — before any other
@@ -1785,6 +1785,10 @@ main() {
 	# Fail-open: never blocks the pulse cycle.
 	_pulse_check_runaway_log || true
 
+	# Recover dependency close events missed by async merge/issue-close races.
+	# Sentinel-gated to bound API use; the reconciler itself fails closed.
+	_pulse_reconcile_stale_blocked_if_due || true
+
 	# t3077: LLM-driven fix-the-fixer detector. Classifies new auto-dispatch
 	# issues — when the work itself touches the worker dispatch system,
 	# applies the `fix-the-fixer` label so the dispatcher can enable extra
@@ -1883,10 +1887,10 @@ main() {
 	if [[ "${AIDEVOPS_SKIP_SOURCE_REEXEC:-0}" != "1" ]]; then
 		local _pw_mtime_now
 		_pw_mtime_now=$(_file_mtime_epoch "$_pw_self")
-		if [[ "$_pw_mtime_now" =~ ^[0-9]+$ ]] \
-			&& [[ "$_pw_mtime_loaded" =~ ^[0-9]+$ ]] \
-			&& [[ "$_pw_mtime_now" -gt 0 ]] \
-			&& [[ "$_pw_mtime_now" != "$_pw_mtime_loaded" ]]; then
+		if [[ "$_pw_mtime_now" =~ ^[0-9]+$ ]] &&
+			[[ "$_pw_mtime_loaded" =~ ^[0-9]+$ ]] &&
+			[[ "$_pw_mtime_now" -gt 0 ]] &&
+			[[ "$_pw_mtime_now" != "$_pw_mtime_loaded" ]]; then
 			echo "[pulse-wrapper] t3033: source modified (${_pw_mtime_loaded} -> ${_pw_mtime_now}) — releasing lock and re-execing for fresh code" >>"$WRAPPER_LOGFILE"
 			release_instance_lock
 			exec "$_pw_self" "$@"

--- a/.agents/scripts/tests/test-dependency-event-reconciler.sh
+++ b/.agents/scripts/tests/test-dependency-event-reconciler.sh
@@ -101,7 +101,11 @@ gh() {
 		return 0
 		;;
 	"api --paginate")
-		printf '%s\n' "$COMMENTS"
+		if [[ "$*" == *"/issues?state=open"* ]]; then
+			jq -cn --arg body "$BODY20" '[[{number:20,state:"open",title:"t20: direct",body:$body,labels:[{name:"status:blocked"},{name:"blocked-by:#10"}]}]]'
+		else
+			printf '%s\n' "$COMMENTS"
+		fi
 		return 0
 		;;
 	esac
@@ -145,13 +149,20 @@ assert_eq "$namespaced" "$(_der_task_refs "Blocked by: ${namespaced}")" "namespa
 NATIVE_DIRECT=true CLOSED_TITLE="${namespaced}: blocker" BODY20="blocked-by:${namespaced}" EDIT_COUNT=0 REREAD_LABELS="status:blocked"
 assert_eq 1 "$(run_reconcile)" "namespaced task declaration resolves through exact title lookup"
 
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20="Blocked by #10" COMMENTS='[[]]'
+reconcile_stale_blocked_issues owner/repo >/dev/null 2>&1 || true
+assert_eq 1 "$EDIT_COUNT" "periodic stale sweep releases issue after missed close event"
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20="Blocked by #10 and #11"
+reconcile_stale_blocked_issues owner/repo >/dev/null 2>&1 || true
+assert_eq 0 "$EDIT_COUNT" "periodic stale sweep preserves another open blocker"
+
 if grep -q 'issues(first:100,states:' "${SCRIPTS_DIR}/dependency-event-reconciler.sh"; then
 	fail "reconciler must not enumerate latest repository issues"
 else
 	pass "reconciler avoids broad repository issue enumeration"
 fi
 if grep -A25 'if ! _merge_verify_completed_state' "${SCRIPTS_DIR}/full-loop-helper-merge.sh" | grep -q '_merge_finalize_post_merge' &&
-	grep -A18 '^_merge_finalize_post_merge()' "${SCRIPTS_DIR}/full-loop-helper-merge.sh" | grep -q 'reconcile_dependants_after_verified_closure'; then
+	grep -A30 '^_merge_reconcile_closing_issues()' "${SCRIPTS_DIR}/full-loop-helper-merge.sh" | grep -q 'reconcile_dependants_after_verified_closure'; then
 	pass "full-loop hook follows verified merge state"
 else
 	fail "full-loop hook follows verified merge state"

--- a/.agents/scripts/tests/test-full-loop-closing-reconciliation.sh
+++ b/.agents/scripts/tests/test-full-loop-closing-reconciliation.sh
@@ -14,6 +14,7 @@ FAIL=0
 RECONCILED=""
 RELEASED=""
 FINALIZED=0
+WARNINGS=""
 
 pass() {
 	printf 'PASS: %s\n' "$1"
@@ -57,11 +58,39 @@ reconcile_dependants_after_verified_closure() {
 }
 auto_file_next_phase() { return 0; }
 _merge_unlock_resources() { return 0; }
+print_info() { return 0; }
+print_warning() {
+	WARNINGS="${WARNINGS}${WARNINGS:+ }$1"
+	return 0
+}
 
 # shellcheck disable=SC2218  # The test intentionally replaces this function below.
 _merge_finalize_post_merge 77 owner/repo 0 ""
 assert_eq "10" "$RELEASED" "primary body-linked issue retains claim-release semantics"
 assert_eq "10 11" "$RECONCILED" "all confirmed closing references are reconciled"
+
+ATTEMPT_FILE=$(mktemp)
+printf '0\n' >"$ATTEMPT_FILE"
+RECONCILED=""
+gh() {
+	local command="$1"
+	shift
+	if [[ "$command $1" == "api graphql" ]]; then
+		local graphql_attempts=""
+		graphql_attempts=$(<"$ATTEMPT_FILE")
+		graphql_attempts=$((graphql_attempts + 1))
+		printf '%s\n' "$graphql_attempts" >"$ATTEMPT_FILE"
+		local state="OPEN"
+		[[ "$graphql_attempts" -ge 2 ]] && state="CLOSED"
+		printf '{"data":{"repository":{"nameWithOwner":"owner/repo","pullRequest":{"state":"MERGED","merged":true,"closingIssuesReferences":{"totalCount":1,"pageInfo":{"hasNextPage":false},"nodes":[{"number":12,"state":"%s","repository":{"nameWithOwner":"owner/repo"}}]}}}}}\n' "$state"
+		return 0
+	fi
+	return 1
+}
+FULL_LOOP_CLOSING_RECONCILE_ATTEMPTS=3 FULL_LOOP_CLOSING_RECONCILE_DELAY_SECONDS=0 _merge_reconcile_closing_issues 77 owner/repo
+assert_eq "2" "$(<"$ATTEMPT_FILE")" "temporarily open closing reference is retried"
+assert_eq "12" "$RECONCILED" "closing reference converges after GitHub closes issue"
+rm -f "$ATTEMPT_FILE"
 
 gh() {
 	local command="$1"
@@ -84,7 +113,6 @@ cmd_pre_merge_gate() { return 0; }
 _retarget_stacked_children_interactive() { return 0; }
 _merge_execute() { return 0; }
 _merge_verify_completed_state() { return 1; }
-print_info() { return 0; }
 print_error() { return 0; }
 print_success() { return 0; }
 _merge_finalize_post_merge() {

--- a/.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh
+++ b/.agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh
@@ -10,6 +10,18 @@
 
 set -u
 
+# Isolate fixture repositories from the developer's global hooksPath and
+# signing policy; the test installs its own bare-remote protection hook.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
+# Fixture setup uses disposable repositories; helper subprocesses still resolve
+# the guarded Git shim from PATH because shell functions are not exported.
+git() {
+	/usr/bin/git "$@"
+	return $?
+}
+
 SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "${SCRIPT_DIR_TEST}/../../.." && pwd)" || exit 1
 PLANNING_HELPER="${REPO_ROOT}/.agents/scripts/planning-commit-helper.sh"
@@ -38,27 +50,32 @@ setup_repo() {
 	local tmpdir="$1"
 	local protected_default="$2"
 	local bare_dir="${tmpdir}/remote.git"
+	local local_dir="${tmpdir}/local.git"
 	local work_dir="${tmpdir}/work"
+	local blob_sha tree_sha commit_sha
 
-	git init --bare --initial-branch=main "$bare_dir" >/dev/null 2>&1 || git init --bare "$bare_dir" >/dev/null 2>&1 || return 1
-	git clone "$bare_dir" "$work_dir" >/dev/null 2>&1 || return 1
-	git -C "$work_dir" config user.email "test@test.local" >/dev/null 2>&1 || return 1
-	git -C "$work_dir" config user.name "Test" >/dev/null 2>&1 || return 1
-	git -C "$work_dir" config commit.gpgsign false >/dev/null 2>&1 || true
-	printf '# Tasks\n\n' >"${work_dir}/TODO.md"
+	git init --bare --initial-branch=fixture-default "$bare_dir" >/dev/null 2>&1 || return 1
+	git init --bare --initial-branch=fixture-default "$local_dir" >/dev/null 2>&1 || return 1
+	printf '# Tasks\n\n' >"${tmpdir}/TODO.md"
+	blob_sha=$(git --git-dir="$local_dir" hash-object -w "${tmpdir}/TODO.md") || return 1
+	tree_sha=$(printf '100644 blob %s\tTODO.md\n' "$blob_sha" | git --git-dir="$local_dir" mktree) || return 1
+	commit_sha=$(printf 'chore: seed planning files\n' | GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="test@test.local" \
+		GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="test@test.local" \
+		git --git-dir="$local_dir" commit-tree "$tree_sha") || return 1
+	git --git-dir="$local_dir" update-ref refs/heads/fixture-default "$commit_sha" || return 1
+	printf '[remote "origin"]\n\turl = %s\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n[user]\n\tname = Test\n\temail = test@test.local\n[commit]\n\tgpgsign = false\n' "$bare_dir" >>"${local_dir}/config" || return 1
+	git --git-dir="$local_dir" worktree add "$work_dir" fixture-default >/dev/null 2>&1 || return 1
 	mkdir -p "${work_dir}/todo/tasks" || return 1
-	git -C "$work_dir" add TODO.md >/dev/null 2>&1 || return 1
-	git -C "$work_dir" commit -m "chore: seed planning files" >/dev/null 2>&1 || return 1
-	git -C "$work_dir" push origin main >/dev/null 2>&1 || return 1
-	git -C "$work_dir" fetch origin main >/dev/null 2>&1 || return 1
-	git -C "$work_dir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main >/dev/null 2>&1 || return 1
+	git -C "$work_dir" push origin fixture-default >/dev/null 2>&1 || return 1
+	git -C "$work_dir" fetch origin fixture-default >/dev/null 2>&1 || return 1
+	git -C "$work_dir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/fixture-default >/dev/null 2>&1 || return 1
 
 	if [[ "$protected_default" == "true" ]]; then
 		mkdir -p "${bare_dir}/hooks" || return 1
 		cat >"${bare_dir}/hooks/pre-receive" <<'HOOK'
 #!/usr/bin/env bash
 while read -r _old _new ref; do
-	if [[ "$ref" == "refs/heads/main" ]]; then
+		if [[ "$ref" == "refs/heads/fixture-default" ]]; then
 		printf 'remote: error: GH006: Protected branch update failed for %s.\n' "$ref" >&2
 		printf 'remote: error: Changes must be made through a pull request.\n' >&2
 		exit 1
@@ -155,16 +172,28 @@ append_planning_change() {
 test_protected_default_creates_planning_pr() {
 	local name="protected default branch creates planning PR and cleans source"
 	local tmpdir fake_bin work_dir body_file head_file title_file log_file output rc status head_branch remote_todo pr_body
-	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+	tmpdir=$(mktemp -d) || {
+		fail "$name" "mktemp failed"
+		return 0
+	}
 	fake_bin="${tmpdir}/bin"
 	log_file="${tmpdir}/gh.log"
 	body_file="${tmpdir}/body.md"
 	head_file="${tmpdir}/head.txt"
 	title_file="${tmpdir}/title.txt"
 	: >"$log_file"
-	write_fake_gh "$fake_bin" || { fail "$name" "fake gh setup failed"; return 0; }
-	work_dir=$(setup_repo "$tmpdir" true) || { fail "$name" "repo setup failed"; return 0; }
-	append_planning_change "$work_dir" "t999" || { fail "$name" "planning change failed"; return 0; }
+	write_fake_gh "$fake_bin" || {
+		fail "$name" "fake gh setup failed"
+		return 0
+	}
+	work_dir=$(setup_repo "$tmpdir" true) || {
+		fail "$name" "repo setup failed"
+		return 0
+	}
+	append_planning_change "$work_dir" "t999" || {
+		fail "$name" "planning change failed"
+		return 0
+	}
 
 	rc=0
 	output=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" \
@@ -189,12 +218,15 @@ test_protected_default_creates_planning_pr() {
 		fail "$name" "unexpected PR head: ${head_branch:-<empty>}"
 		return 0
 	fi
-	remote_todo=$(git -C "$work_dir" show "origin/main:TODO.md" 2>/dev/null || true)
+	remote_todo=$(git -C "$work_dir" show "origin/fixture-default:TODO.md" 2>/dev/null || true)
 	if [[ "$remote_todo" == *"t999"* ]]; then
 		fail "$name" "protected default branch was updated directly"
 		return 0
 	fi
-	git -C "$work_dir" fetch origin "$head_branch" >/dev/null 2>&1 || { fail "$name" "PR branch not pushed"; return 0; }
+	git -C "$work_dir" fetch origin "$head_branch" >/dev/null 2>&1 || {
+		fail "$name" "PR branch not pushed"
+		return 0
+	}
 	remote_todo=$(git -C "$work_dir" show FETCH_HEAD:TODO.md 2>/dev/null || true)
 	if [[ "$remote_todo" != *"t999"* ]]; then
 		fail "$name" "PR branch does not contain TODO change"
@@ -217,13 +249,25 @@ test_protected_default_creates_planning_pr() {
 test_unprotected_default_keeps_direct_push() {
 	local name="unprotected default branch keeps direct planning push"
 	local tmpdir fake_bin work_dir log_file output rc status remote_todo
-	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+	tmpdir=$(mktemp -d) || {
+		fail "$name" "mktemp failed"
+		return 0
+	}
 	fake_bin="${tmpdir}/bin"
 	log_file="${tmpdir}/gh.log"
 	: >"$log_file"
-	write_fake_gh "$fake_bin" || { fail "$name" "fake gh setup failed"; return 0; }
-	work_dir=$(setup_repo "$tmpdir" false) || { fail "$name" "repo setup failed"; return 0; }
-	append_planning_change "$work_dir" "t1000" || { fail "$name" "planning change failed"; return 0; }
+	write_fake_gh "$fake_bin" || {
+		fail "$name" "fake gh setup failed"
+		return 0
+	}
+	work_dir=$(setup_repo "$tmpdir" false) || {
+		fail "$name" "repo setup failed"
+		return 0
+	}
+	append_planning_change "$work_dir" "t1000" || {
+		fail "$name" "planning change failed"
+		return 0
+	}
 	rc=0
 	output=$(cd "$work_dir" && PATH="${fake_bin}:$PATH" GH_STUB_LOG="$log_file" GH_STUB_BODY="${tmpdir}/body" GH_STUB_HEAD="${tmpdir}/head" GH_STUB_TITLE="${tmpdir}/title" \
 		"$PLANNING_HELPER" "plan: add t1000 direct planning" 2>&1) || rc=$?
@@ -232,12 +276,12 @@ test_unprotected_default_keeps_direct_push() {
 		return 0
 	fi
 	status=$(git -C "$work_dir" status --short 2>/dev/null)
-	if [[ -n "$status" ]]; then
-		fail "$name" "source worktree dirty after direct push: $status"
+	if [[ "$status" != *"TODO.md"* ]] || [[ "$status" != *"todo/"* ]]; then
+		fail "$name" "source planning edits were not preserved after checkout-free push: $status"
 		return 0
 	fi
-	git -C "$work_dir" fetch origin main >/dev/null 2>&1 || true
-	remote_todo=$(git -C "$work_dir" show origin/main:TODO.md 2>/dev/null || true)
+	git -C "$work_dir" fetch origin fixture-default >/dev/null 2>&1 || true
+	remote_todo=$(git -C "$work_dir" show origin/fixture-default:TODO.md 2>/dev/null || true)
 	if [[ "$remote_todo" != *"t1000"* ]]; then
 		fail "$name" "direct push did not update origin/main"
 		return 0
@@ -254,17 +298,33 @@ test_unprotected_default_keeps_direct_push() {
 test_pr_unavailable_fails_before_commit() {
 	local name="PR fallback unavailable fails before local commit"
 	local tmpdir work_dir before_head after_head output rc status
-	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
-	work_dir=$(setup_repo "$tmpdir" true) || { fail "$name" "repo setup failed"; return 0; }
-	append_planning_change "$work_dir" "t1001" || { fail "$name" "planning change failed"; return 0; }
-	before_head=$(git -C "$work_dir" rev-parse HEAD 2>/dev/null) || { fail "$name" "missing initial HEAD"; return 0; }
+	tmpdir=$(mktemp -d) || {
+		fail "$name" "mktemp failed"
+		return 0
+	}
+	work_dir=$(setup_repo "$tmpdir" true) || {
+		fail "$name" "repo setup failed"
+		return 0
+	}
+	append_planning_change "$work_dir" "t1001" || {
+		fail "$name" "planning change failed"
+		return 0
+	}
+	before_head=$(git -C "$work_dir" rev-parse HEAD 2>/dev/null) || {
+		fail "$name" "missing initial HEAD"
+		return 0
+	}
 	rc=0
-	output=$(cd "$work_dir" && AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1 "$PLANNING_HELPER" "plan: add t1001 unavailable pr" 2>&1) || rc=$?
+	output=$(cd "$work_dir" && PATH="${REPO_ROOT}/.agents/scripts:/usr/bin:/bin" \
+		AIDEVOPS_PLANNING_FORCE_PR_FALLBACK=1 "$PLANNING_HELPER" "plan: add t1001 unavailable pr" 2>&1) || rc=$?
 	if [[ $rc -eq 0 ]]; then
 		fail "$name" "helper unexpectedly succeeded: $output"
 		return 0
 	fi
-	after_head=$(git -C "$work_dir" rev-parse HEAD 2>/dev/null) || { fail "$name" "missing final HEAD"; return 0; }
+	after_head=$(git -C "$work_dir" rev-parse HEAD 2>/dev/null) || {
+		fail "$name" "missing final HEAD"
+		return 0
+	}
 	if [[ "$after_head" != "$before_head" ]]; then
 		fail "$name" "local HEAD changed before PR availability was proven"
 		return 0

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -u
+# Fixture repositories are disposable; bypass interactive canonical-repo guards.
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+PUBLISHER="${SCRIPT_DIR_TEST}/../planning-publisher.sh"
+PASS=0
+FAIL=0
+
+pass() {
+	local name="$1"
+	printf 'PASS %s\n' "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf 'FAIL %s: %s\n' "$name" "$detail"
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+setup_repo() {
+	local root="$1"
+	git init --bare --initial-branch=main "${root}/remote.git" >/dev/null 2>&1 || git init --bare "${root}/remote.git" >/dev/null 2>&1 || return 1
+	git clone "${root}/remote.git" "${root}/work" >/dev/null 2>&1 || return 1
+	printf '# Tasks\n' >"${root}/work/TODO.md"
+	mkdir -p "${root}/work/todo/tasks" || return 1
+	printf 'base\n' >"${root}/work/README.md"
+	git -C "${root}/work" add TODO.md README.md || return 1
+	GIT_AUTHOR_NAME=Test GIT_AUTHOR_EMAIL=test@example.invalid GIT_COMMITTER_NAME=Test GIT_COMMITTER_EMAIL=test@example.invalid \
+		git -C "${root}/work" commit -m seed >/dev/null || return 1
+	git -C "${root}/work" push origin main >/dev/null 2>&1 || return 1
+	return 0
+}
+
+state_digest() {
+	local repo="$1"
+	{
+		git -C "$repo" rev-parse HEAD
+		git -C "$repo" ls-files -s
+		git -C "$repo" diff --binary
+		git -C "$repo" diff --cached --binary
+	} | git hash-object --stdin
+	return 0
+}
+
+run_publish() {
+	local repo="$1"
+	local validator="${2:-/usr/bin/true}"
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_VALIDATOR="$validator" planning_publish "$repo" "plan: test publication" origin main
+	)
+	return $?
+}
+
+test_state_allowlist_and_idempotence() {
+	local name="preserves local state, publishes only allowlisted bytes, and is idempotent"
+	local root="" repo="" before="" after="" first_remote="" second_remote="" count=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	printf '%s\n' '- [ ] t001 test ref:GH#1' >>"${repo}/TODO.md"
+	printf 'brief\n' >"${repo}/todo/tasks/t001.md"
+	printf 'local-only\n' >>"${repo}/README.md"
+	git -C "$repo" add README.md
+	before=$(state_digest "$repo")
+	run_publish "$repo" || {
+		fail "$name" publish
+		return 0
+	}
+	after=$(state_digest "$repo")
+	first_remote=$(git --git-dir="${root}/remote.git" rev-parse main)
+	run_publish "$repo" || {
+		fail "$name" replay
+		return 0
+	}
+	second_remote=$(git --git-dir="${root}/remote.git" rev-parse main)
+	count=$(git --git-dir="${root}/remote.git" log --format=%B main | grep -c 'Planning-Publication-ID:' || true)
+	if [[ "$before" == "$after" && "$first_remote" == "$second_remote" && "$count" -eq 1 ]] &&
+		git --git-dir="${root}/remote.git" show main:TODO.md | grep -q t001 &&
+		[[ "$(git --git-dir="${root}/remote.git" show main:README.md)" == "base" ]]; then pass "$name"; else fail "$name" invariant; fi
+	rm -rf "$root"
+	return 0
+}
+
+test_validation_failure_pushes_nothing() {
+	local name="validator failure pushes nothing"
+	local root="" repo="" before="" rc=0
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	printf '%s\n' '- [ ] t002 rejected ref:GH#2' >>"${repo}/TODO.md"
+	before=$(git --git-dir="${root}/remote.git" rev-parse main)
+	run_publish "$repo" /usr/bin/false || rc=$?
+	if [[ $rc -ne 0 && "$before" == "$(git --git-dir="${root}/remote.git" rev-parse main)" ]]; then pass "$name"; else fail "$name" "rc=$rc"; fi
+	rm -rf "$root"
+	return 0
+}
+
+test_contention_replay_and_conflict() {
+	local name="replays unrelated contention"
+	local root="" repo="" hook="" rc=0
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	printf '%s\n' '- [ ] t003 replay ref:GH#3' >>"${repo}/TODO.md"
+	hook="${root}/contend.sh"
+	cat >"$hook" <<'HOOK'
+#!/usr/bin/env bash
+repo="$1"; remote="$2"; branch="$3"; attempt="$6"
+[[ "$attempt" == "1" ]] || exit 0
+tmp=$(mktemp -d)
+git clone -q "$(git -C "$repo" remote get-url "$remote")" "$tmp/work"
+printf 'upstream\n' >>"$tmp/work/README.md"
+git -C "$tmp/work" add README.md
+GIT_AUTHOR_NAME=Rival GIT_AUTHOR_EMAIL=rival@example.invalid GIT_COMMITTER_NAME=Rival GIT_COMMITTER_EMAIL=rival@example.invalid git -C "$tmp/work" commit -qm rival
+git -C "$tmp/work" push -q origin "$branch"
+rm -rf "$tmp"
+exit 0
+HOOK
+	chmod +x "$hook"
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK="$hook" planning_publish "$repo" "plan: contention" origin main
+	) || rc=$?
+	if [[ $rc -eq 0 ]] && git --git-dir="${root}/remote.git" show main:README.md | grep -q upstream && git --git-dir="${root}/remote.git" show main:TODO.md | grep -q t003; then pass "$name"; else fail "$name" "replay rc=$rc"; fi
+	rm -rf "$root"
+	return 0
+}
+
+test_crash_replay_is_single_publication() {
+	local name="crash before push replays once"
+	local root="" repo="" rc=0 count=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	printf '%s\n' '- [ ] t004 crash replay ref:GH#4' >>"${repo}/TODO.md"
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK=/usr/bin/false planning_publish "$repo" "plan: crash" origin main
+	) || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		fail "$name" "simulated crash succeeded"
+		rm -rf "$root"
+		return 0
+	fi
+	run_publish "$repo" || {
+		fail "$name" replay
+		rm -rf "$root"
+		return 0
+	}
+	run_publish "$repo" || {
+		fail "$name" idempotence
+		rm -rf "$root"
+		return 0
+	}
+	count=$(git --git-dir="${root}/remote.git" log --format=%B main | grep -c 'Planning-Publication-ID:' || true)
+	if [[ $count -eq 1 ]]; then pass "$name"; else fail "$name" "publication count=$count"; fi
+	rm -rf "$root"
+	return 0
+}
+
+test_same_path_contention_is_retryable() {
+	local name="same-path contention returns retryable conflict"
+	local root="" repo="" hook="" rc=0 remote_todo=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	printf '%s\n' '- [ ] t005 local ref:GH#5' >>"${repo}/TODO.md"
+	hook="${root}/same-path.sh"
+	cat >"$hook" <<'HOOK'
+#!/usr/bin/env bash
+repo="$1"; remote="$2"; branch="$3"; attempt="$6"
+[[ "$attempt" == "1" ]] || exit 0
+tmp=$(mktemp -d)
+git clone -q "$(git -C "$repo" remote get-url "$remote")" "$tmp/work"
+printf '%s\n' '- [ ] t999 rival ref:GH#999' >>"$tmp/work/TODO.md"
+git -C "$tmp/work" add TODO.md
+GIT_AUTHOR_NAME=Rival GIT_AUTHOR_EMAIL=rival@example.invalid GIT_COMMITTER_NAME=Rival GIT_COMMITTER_EMAIL=rival@example.invalid git -C "$tmp/work" commit -qm rival
+git -C "$tmp/work" push -q origin "$branch"
+rm -rf "$tmp"
+exit 0
+HOOK
+	chmod +x "$hook"
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK="$hook" planning_publish "$repo" "plan: conflict" origin main
+	) || rc=$?
+	remote_todo=$(git --git-dir="${root}/remote.git" show main:TODO.md)
+	if [[ $rc -eq 2 && "$remote_todo" == *"t999"* && "$remote_todo" != *"t005"* ]]; then pass "$name"; else fail "$name" "rc=$rc"; fi
+	rm -rf "$root"
+	return 0
+}
+
+main() {
+	test_state_allowlist_and_idempotence
+	test_validation_failure_pushes_nothing
+	test_contention_replay_and_conflict
+	test_crash_replay_is_single_publication
+	test_same_path_contention_is_retryable
+	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
+	[[ $FAIL -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-stale-blocked-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-stale-blocked-reconcile.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="${TEST_DIR}/.."
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+HOME="$ROOT/home"
+LOGFILE="$ROOT/pulse.log"
+REPOS_JSON="$ROOT/repos.json"
+mkdir -p "$HOME/.aidevops/cache"
+printf '%s\n' '{"initialized_repos":[{"slug":"owner/one","pulse":true},{"slug":"owner/two","pulse":true},{"slug":"owner/local","pulse":true,"local_only":true}]}' >"$REPOS_JSON"
+# shellcheck source=../pulse-wrapper-cycle.sh
+source "${SCRIPT_DIR}/pulse-wrapper-cycle.sh"
+
+CALLS=""
+reconcile_stale_blocked_issues() {
+	local repo="$1"
+	CALLS="${CALLS}${CALLS:+ }$repo"
+	return 0
+}
+_file_mtime_epoch() {
+	printf '0\n'
+	return 0
+}
+
+PULSE_STALE_BLOCKED_RECONCILE_INTERVAL=1800 _pulse_reconcile_stale_blocked_if_due
+[[ "$CALLS" == "owner/one owner/two" ]] || {
+	printf 'FAIL: expected both remote pulse repos, got %s\n' "$CALLS"
+	exit 1
+}
+CALLS=""
+_file_mtime_epoch() {
+	date +%s
+	return 0
+}
+_pulse_reconcile_stale_blocked_if_due
+[[ -z "$CALLS" ]] || {
+	printf 'FAIL: fresh cadence sentinel did not suppress reconciliation\n'
+	exit 1
+}
+printf 'PASS: stale blocked reconciliation is pulse-wired and cadence bounded\n'


### PR DESCRIPTION
## Summary

Add an allowlisted checkout-free planning publisher and make blocked-by release converge after asynchronous or missed closure events.

## Files Changed

.agents/scripts/dependency-event-reconciler.sh, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/planning-commit-helper.sh, .agents/scripts/planning-publisher.sh, .agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/pulse-wrapper.sh, .agents/scripts/tests/test-dependency-event-reconciler.sh, .agents/scripts/tests/test-full-loop-closing-reconciliation.sh, .agents/scripts/tests/test-planning-commit-helper-protected-default-pr.sh, .agents/scripts/tests/test-planning-publisher.sh, .agents/scripts/tests/test-pulse-stale-blocked-reconcile.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Planning publisher 5/5; planning helper 4/4; closing reconciliation 8/8; dependency reconciler 16/16; pulse stale sweep; ShellCheck; changed-file local lint.

Resolves #27152


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 with gpt-5.6-sol spent 59m and 143,967 tokens on this with the user in an interactive session.