### PR TITLE
GH#27390: bypass stale session runtime pins during release deployment

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -59,7 +59,7 @@ log_error() {
 
 # Defaults
 REPO_DIR="${HOME}/Git/aidevops"
-TARGET_DIR="${HOME}/.aidevops/agents"
+TARGET_DIR="${AIDEVOPS_DEPLOY_TARGET:-${HOME}/.aidevops/agents}"
 PLUGINS_FILE="${HOME}/.config/aidevops/plugins.json"
 SCRIPTS_ONLY=false
 FULL_DEPLOY=false
@@ -161,6 +161,20 @@ validate_repo() {
 		return 1
 	fi
 
+	return 0
+}
+
+validate_stable_target() {
+	if [[ -z "${HOME:-}" || "$HOME" != /* ]]; then
+		log_error "Cannot resolve stable agents target: HOME must be a non-empty absolute path"
+		return 1
+	fi
+
+	local stable_target="$HOME/.aidevops/agents"
+	if [[ "$TARGET_DIR" != "$stable_target" ]]; then
+		log_error "Refusing deployment outside the stable agents target: $TARGET_DIR"
+		return 1
+	fi
 	return 0
 }
 
@@ -492,6 +506,7 @@ deploy_changed_files() {
 main() {
 	parse_args "$@" || return 1
 	validate_repo || return 1
+	validate_stable_target || return 1
 	collect_plugin_namespaces || return 1
 
 	# Full deploy: delegate to setup.sh
@@ -501,7 +516,10 @@ main() {
 			log_info "[dry-run] Would run: AIDEVOPS_NON_INTERACTIVE=true $REPO_DIR/setup.sh --non-interactive"
 			return 0
 		fi
-		AIDEVOPS_NON_INTERACTIVE=true bash "$REPO_DIR/setup.sh" --non-interactive
+		env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR \
+			AIDEVOPS_NON_INTERACTIVE=true \
+			AIDEVOPS_DEPLOY_TARGET="$TARGET_DIR" \
+			bash "$REPO_DIR/setup.sh" --non-interactive
 		local _full_rc=$?
 		if [[ "$_full_rc" -eq 75 ]]; then
 			log_warn "setup.sh --non-interactive is locked by another process (exit 75). The lightweight deploy path (deploy-agents-on-merge.sh without --full) is unaffected — re-run without --full for an immediate agent sync while the full setup completes."

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -37,14 +37,17 @@ setup() {
 	TEST_DIR=$(mktemp -d)
 	trap teardown EXIT
 	mkdir -p "$TEST_DIR/repo/.agents/scripts"
-	cat >"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" <<'EOF'
+cat >"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+printf 'AIDEVOPS_AGENTS_DIR=%s\n' "${AIDEVOPS_AGENTS_DIR-unset}" >>"${SYNC_ENV_LOG_PATH:?SYNC_ENV_LOG_PATH must be set}"
+printf 'AGENTS_DIR=%s\n' "${AGENTS_DIR-unset}" >>"$SYNC_ENV_LOG_PATH"
 printf '%s\n' "$*" >>"${SYNC_LOG_PATH:?SYNC_LOG_PATH must be set}"
 exit "${MOCK_DEPLOY_EXIT_CODE:-0}"
 EOF
 	chmod +x "$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh"
 	: >"$TEST_DIR/sync.log"
+	: >"$TEST_DIR/sync-env.log"
 	return 0
 }
 
@@ -60,6 +63,7 @@ invoke_github_sync() {
 	AIDEVOPS_SYNC_REPO_PATH="$TEST_DIR/repo" \
 		AIDEVOPS_SYNC_DEPLOY_SCRIPT="$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" \
 		SYNC_LOG_PATH="$TEST_DIR/sync.log" \
+		SYNC_ENV_LOG_PATH="$TEST_DIR/sync-env.log" \
 		MOCK_DEPLOY_EXIT_CODE="${MOCK_DEPLOY_EXIT_CODE:-0}" \
 		bash -c 'source "$1" && trigger_aidevops_post_merge_sync "$2"' _ "$GITHUB_HELPER" "$repo_slug"
 	return 0
@@ -70,6 +74,7 @@ invoke_release_sync() {
 	AIDEVOPS_SYNC_REPO_ROOT="$repo_root" \
 		AIDEVOPS_SYNC_DEPLOY_SCRIPT="$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" \
 		SYNC_LOG_PATH="$TEST_DIR/sync.log" \
+		SYNC_ENV_LOG_PATH="$TEST_DIR/sync-env.log" \
 		MOCK_DEPLOY_EXIT_CODE="${MOCK_DEPLOY_EXIT_CODE:-0}" \
 		bash -c 'source "$1" && run_post_release_agent_sync' _ "$VERSION_HELPER"
 	return $?
@@ -83,6 +88,7 @@ create_fake_repo() {
 	mkdir -p "$repo_path"
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git init -q "$repo_path"
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" remote add origin "$remote_url"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"$repo_path/setup.sh"
 	printf '%s\n' "$repo_path"
 	return 0
 }
@@ -151,6 +157,23 @@ test_release_sync_propagates_deploy_failure() {
 	return 0
 }
 
+test_release_sync_unsets_session_pins() {
+	: >"$TEST_DIR/sync-env.log"
+	local repo_path
+	repo_path=$(create_fake_repo "release-pinned" "https://github.com/marcusquinn/aidevops.git")
+	AIDEVOPS_AGENTS_DIR="$TEST_DIR/.aidevops/runtime-bundles/old/agents" \
+		AGENTS_DIR="$TEST_DIR/.aidevops/runtime-bundles/old/agents" \
+		invoke_release_sync "$repo_path"
+
+	if grep -q '^AIDEVOPS_AGENTS_DIR=unset$' "$TEST_DIR/sync-env.log" && \
+		grep -q '^AGENTS_DIR=unset$' "$TEST_DIR/sync-env.log"; then
+		print_result "release sync isolates inherited runtime pins" 0
+	else
+		print_result "release sync isolates inherited runtime pins" 1 "Deployment child inherited a session pin"
+	fi
+	return 0
+}
+
 main() {
 	echo "Running agent auto-sync regression tests"
 	setup
@@ -160,6 +183,7 @@ main() {
 	test_release_sync_triggers_for_aidevops_remote
 	test_release_sync_skips_other_remotes
 	test_release_sync_propagates_deploy_failure
+	test_release_sync_unsets_session_pins
 
 	teardown
 	trap - EXIT

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -330,6 +330,31 @@ _create_hotfix_tag() {
 	return 0
 }
 
+validate_release_deployment_readiness() {
+	local sync_repo_root="${AIDEVOPS_SYNC_REPO_ROOT:-$REPO_ROOT}"
+	local remote_url
+	remote_url=$(git -C "$sync_repo_root" remote get-url origin 2>/dev/null || echo "")
+	if [[ "$remote_url" != *"marcusquinn/aidevops"* ]]; then
+		return 0
+	fi
+
+	if [[ -z "${HOME:-}" || "$HOME" != /* ]]; then
+		print_error "Release deployment cannot resolve the stable agents target: HOME must be a non-empty absolute path"
+		return 1
+	fi
+
+	local deploy_script="${AIDEVOPS_SYNC_DEPLOY_SCRIPT:-$sync_repo_root/.agents/scripts/deploy-agents-on-merge.sh}"
+	if [[ ! -f "$deploy_script" || ! -r "$deploy_script" ]]; then
+		print_error "Release deployment helper is unavailable: $deploy_script"
+		return 1
+	fi
+	if [[ ! -f "$sync_repo_root/setup.sh" || ! -r "$sync_repo_root/setup.sh" ]]; then
+		print_error "Release setup helper is unavailable: $sync_repo_root/setup.sh"
+		return 1
+	fi
+	return 0
+}
+
 run_post_release_agent_sync() {
 	local sync_repo_root="${AIDEVOPS_SYNC_REPO_ROOT:-$REPO_ROOT}"
 	local remote_url
@@ -344,11 +369,14 @@ run_post_release_agent_sync() {
 		print_error "Post-release deployment gate cannot run: deploy script not found at $deploy_script"
 		return 1
 	fi
+	validate_release_deployment_readiness || return 1
 
 	print_info "Running post-release aidevops agent sync..."
 	local sync_output=""
 	local sync_exit=0
-	sync_output=$(bash "$deploy_script" --repo "$sync_repo_root" --full --quiet 2>&1) || sync_exit=$?
+	sync_output=$(env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR \
+		AIDEVOPS_DEPLOY_TARGET="$HOME/.aidevops/agents" \
+		bash "$deploy_script" --repo "$sync_repo_root" --full --quiet 2>&1) || sync_exit=$?
 
 	if [[ "$sync_exit" -eq 0 ]]; then
 		print_success "Post-release aidevops deployment and CLI convergence completed"

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -379,6 +379,10 @@ _release_execute() {
 	print_info "Validating version consistency..."
 	if validate_version_consistency "$new_version"; then
 		print_success "Version validation passed"
+		if ! validate_release_deployment_readiness; then
+			print_error "Aborting release before publication: local deployment prerequisites are unsafe"
+			_release_abort_after_mutation
+		fi
 
 		# t2437/GH#20073: commit the bump, verify HEAD is the bump commit.
 		if ! _release_commit_and_verify_bump "$new_version" "$bump_type"; then

--- a/tests/test-deploy-agents-on-merge.sh
+++ b/tests/test-deploy-agents-on-merge.sh
@@ -142,6 +142,31 @@ set -e
 assert_eq "$changed_status" "0" "Changed script deploy exits with status 0"
 assert_contains "$changed_output" "using fast scripts-only deploy" "Changed script deploy selects scripts-only path"
 
+# Test 4: Full deploy must isolate immutable session pins from setup.sh
+TEST_REPO_FULL="$TMP_DIR/repo-full"
+create_base_repo "$TEST_REPO_FULL"
+cat >"$TEST_REPO_FULL/setup.sh" <<'EOF'
+#!/usr/bin/env bash
+[[ -z "${AIDEVOPS_AGENTS_DIR+x}" && -z "${AGENTS_DIR+x}" ]]
+EOF
+chmod +x "$TEST_REPO_FULL/setup.sh"
+
+set +e
+full_output="$(HOME="$TMP_DIR/home" AIDEVOPS_AGENTS_DIR="$TMP_DIR/home/.aidevops/runtime-bundles/old/agents" AGENTS_DIR="$TMP_DIR/home/.aidevops/runtime-bundles/old/agents" run_script "$TEST_REPO_FULL" --full)"
+full_status=$?
+set -e
+
+assert_eq "$full_status" "0" "Full deploy unsets inherited runtime pins"
+
+# Test 5: Invalid stable HOME fails before setup mutation
+set +e
+invalid_home_output="$(HOME='' AIDEVOPS_AGENTS_DIR="/tmp/runtime-bundles/old/agents" run_script "$TEST_REPO_FULL" --full)"
+invalid_home_status=$?
+set -e
+
+assert_eq "$invalid_home_status" "1" "Full deploy rejects an empty HOME"
+assert_contains "$invalid_home_output" "stable agents target" "Invalid HOME reports stable-target failure"
+
 printf "\nRan %d tests, %d failed.\n" "$TOTAL_COUNT" "$FAIL_COUNT"
 
 if [[ "$FAIL_COUNT" -ne 0 ]]; then


### PR DESCRIPTION
Summary: validates stable deployment prerequisites before durable publication, unsets inherited runtime-bundle pins only for deployment child processes, and constrains direct deployment to the stable HOME agents target. Testing: test-agent-auto-sync.sh; test-atomic-runtime-bundle-deploy.sh; test-setup-cli-convergence-mutex.sh; ShellCheck on changed shell files. Runtime testing: self-assessed shell deployment boundary with regression fixtures. Resolves #27390. <!-- aidevops:sig --> --- [aidevops.sh](https://aidevops.sh) v3.32.64 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 5m and 94,040 tokens on this as a headless worker.