### PR TITLE
GH#27387: Keep issue-started interactive sessions local

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -46,6 +46,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 - Use TodoWrite for multi-step work. Mark one task in progress and complete items immediately.
 - Infer task intent: `/full-loop` or "work on this now" means implement now; "background/worker" means create a worker-ready brief and auto-dispatch; "later/save/log" means brief for later and ask numbered dispatch options. Task and issue bodies use `workflows/brief.md`. Details: `reference/task-lifecycle.md`.
+- An issue-started interactive implementation remains local even when run asynchronously; it overrides generic background-worker intent. Details: `reference/task-lifecycle.md` "Issue-start override".
 - Keep interactive subagents off the critical path and bounded; prefix delegated prompts with the lowest sufficient `[effort:simple|standard|thinking]`; details: `reference/agent-routing.md`.
 - When a context-rich session has already established safe, actionable work and the user authorises execution, preserve momentum through implementation and verification in that session; do not defer merely to reduce the current session's scope.
 - Run long checks and waits in the background when the runtime permits; poll at bounded intervals, act on completed gates promptly, and keep the user informed instead of disappearing behind one foreground command. Details: `reference/self-improvement.md`.

--- a/.agents/reference/task-lifecycle.md
+++ b/.agents/reference/task-lifecycle.md
@@ -65,6 +65,14 @@ recovery ladder, terminal exceptions, and completion review:
 
 ## Conversation Intent Routing
 
+**Issue-start override:** Once `interactive-start-helper.sh` starts implementation
+for an issue, that local context is authoritative. It exports
+`AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION=1`, claims with `--implementing`, and
+treats background execution as local asynchronous work. Generic background/worker
+intent must not redispatch that issue; headless and remote-worker routes reject the
+marker. Sessions that only inspect an issue do not set the marker and remain
+eligible for ordinary pulse dispatch.
+
 Natural-language task capture must be as explicit as slash commands. When a user gives work that could become a TODO or issue, first classify the intent:
 
 | User signal | Route | Confirmation |
@@ -140,7 +148,7 @@ Do not end a save flow with only "start anytime" when the task is worker-ready; 
 
 **`origin:interactive` also skips pulse dispatch (GH#18352)**: When an issue carries `origin:interactive` AND has any human assignee, the pulse's deterministic dedup guard (`dispatch-dedup-helper.sh is-assigned`) treats the assignee as blocking — even if that assignee is the repo owner or maintainer, and regardless of the current `status:*` label. This closes the race where an interactive session claimed a task via `claim-task-id.sh` (applying `status:claimed` + owner assignment) and the pulse dispatched a duplicate worker before the session could open its PR. The full active lifecycle is now recognised: `status:queued`, `status:in-progress`, `status:in-review`, and `status:claimed` all keep owner/maintainer assignees in the blocking set.
 
-**Implementing a `#auto-dispatch` task interactively (MANDATORY):** Start with `interactive-start-helper.sh --issue N --repo owner/repo --task "description" --auto-dispatch`. It claims with `--implementing`, runs the pre-edit loop check, and starts full-loop before any code is written.
+**Implementing a `#auto-dispatch` task interactively (MANDATORY):** Start with `interactive-start-helper.sh --issue N --repo owner/repo --task "description" --auto-dispatch`. All issue-started implementations claim with `--implementing`, export the local-only implementation marker, run the pre-edit loop check, and start full-loop before any code is written. External repositories skip managed issue mutations but still continue local implementation and the normal contribution PR flow.
 
 **General dedup rule — combined signal (t1996):** The dispatch dedup signal is `(active status label) AND (non-self assignee)` — both required, neither sufficient alone. Every code path that emits a dispatch claim must consult `dispatch-dedup-helper.sh is-assigned` (or apply an equivalent combined check inline) before assigning a worker. Label-only or assignee-only filters are not safe in multi-operator conditions. Specifically:
 - A status label without an assignee = degraded state (worker died mid-claim) — safe to reclaim after `normalize_active_issue_assignments` / stale recovery.

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -481,7 +481,7 @@ _parse_start_options() {
 	return 0
 }
 
-# Launch the loop in the background via nohup.
+# Launch the loop asynchronously in the local session via nohup.
 # Arguments: $1 — prompt string.
 _launch_background() {
 	local prompt="$1"
@@ -502,6 +502,11 @@ cmd_start() {
 
 	_init_start_defaults
 	_parse_start_options "$@" || return 1
+
+	if [[ "${AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION:-0}" == "1" ]] && is_headless; then
+		print_error "Interactive issue implementation cannot enter headless/remote worker routing"
+		return 1
+	fi
 
 	[[ -z "$prompt" ]] && {
 		print_error "Usage: full-loop-helper.sh start \"<prompt>\" [options]"

--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -157,6 +157,11 @@ _isc_cmd_claim() {
 		return 2
 	fi
 
+	if [[ "${AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION:-0}" == "1" && $implementing -eq 0 ]]; then
+		_isc_err "claim: interactive issue implementation requires --implementing; refusing worker-claim routing"
+		return 2
+	fi
+
 	local user
 	if ! user=$(_isc_resolve_manageable_user "claim" "$issue" "$slug" \
 		"gh offline or not authenticated — skipping claim on #$issue ($slug)" \

--- a/.agents/scripts/interactive-start-helper.sh
+++ b/.agents/scripts/interactive-start-helper.sh
@@ -25,12 +25,42 @@ main() {
 		local arg="$1"
 		shift
 		case "$arg" in
-			--issue) [[ $# -gt 0 ]] || { printf 'ERROR: --issue requires a value\n' >&2; return 2; }; local value="$1"; issue="$value"; shift ;;
-			--repo) [[ $# -gt 0 ]] || { printf 'ERROR: --repo requires a value\n' >&2; return 2; }; local value="$1"; repo="$value"; shift ;;
-			--task) [[ $# -gt 0 ]] || { printf 'ERROR: --task requires a value\n' >&2; return 2; }; local value="$1"; task="$value"; shift ;;
-			--auto-dispatch) auto_dispatch=1 ;;
-			--help|-h) _usage; return 0 ;;
-			*) printf 'ERROR: unknown option: %s\n' "$arg" >&2; return 2 ;;
+		--issue)
+			[[ $# -gt 0 ]] || {
+				printf 'ERROR: --issue requires a value\n' >&2
+				return 2
+			}
+			local value="$1"
+			issue="$value"
+			shift
+			;;
+		--repo)
+			[[ $# -gt 0 ]] || {
+				printf 'ERROR: --repo requires a value\n' >&2
+				return 2
+			}
+			local value="$1"
+			repo="$value"
+			shift
+			;;
+		--task)
+			[[ $# -gt 0 ]] || {
+				printf 'ERROR: --task requires a value\n' >&2
+				return 2
+			}
+			local value="$1"
+			task="$value"
+			shift
+			;;
+		--auto-dispatch) auto_dispatch=1 ;;
+		--help | -h)
+			_usage
+			return 0
+			;;
+		*)
+			printf 'ERROR: unknown option: %s\n' "$arg" >&2
+			return 2
+			;;
 		esac
 	done
 	if [[ -z "$issue" || -z "$repo" || -z "$task" ]]; then

--- a/.agents/scripts/interactive-start-helper.sh
+++ b/.agents/scripts/interactive-start-helper.sh
@@ -37,10 +37,12 @@ main() {
 		_usage >&2
 		return 2
 	fi
-	local claim_args=(claim "$issue" "$repo")
-	if [[ $auto_dispatch -eq 1 ]]; then
-		claim_args+=(--implementing)
-	fi
+	# Reaching this entrypoint means the issue is being implemented locally.
+	# Export the marker so asynchronous local children inherit that authority.
+	export AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION=1
+	local claim_args=(claim "$issue" "$repo" --implementing)
+	# Retain --auto-dispatch for CLI compatibility; takeover is now unconditional.
+	: "$auto_dispatch"
 	interactive-session-helper.sh "${claim_args[@]}"
 	pre-edit-check.sh --loop-mode --task "$task"
 	full-loop-helper.sh start "GH#${issue} ${task}" --background

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -840,6 +840,9 @@ fi
 # Test 23 — GH#21805: release on an OPEN issue applies status:available
 # (existing behaviour preserved).
 # =============================================================================
+export STUB_PERMISSION_FAIL=0
+export STUB_PERMISSION=admin
+export STUB_GH_MODE=online
 _isc_cmd_claim 70001 testowner/testrepo --worktree /tmp/wt-fake >/dev/null 2>&1
 : >"$STUB_LOG"
 export STUB_ISSUE_HAS_IN_REVIEW=1
@@ -879,6 +882,20 @@ fi
 
 # Reset stub state
 export STUB_ISSUE_HAS_IN_REVIEW=0
+
+# =============================================================================
+# Test 25 — issue-start marker fails closed without explicit takeover
+# =============================================================================
+marker_out=$(AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION=1 \
+	_isc_cmd_claim 70003 testowner/testrepo --worktree /tmp/wt-fake 2>&1)
+marker_rc=$?
+
+if [[ $marker_rc -eq 2 ]] && printf '%s' "$marker_out" | grep -q 'requires --implementing'; then
+	print_result "issue-start marker rejects worker-style claim routing" 0
+else
+	print_result "issue-start marker rejects worker-style claim routing" 1 \
+		"(rc=$marker_rc, out=${marker_out:0:200})"
+fi
 
 # =============================================================================
 # Summary

--- a/.agents/scripts/tests/test-interactive-start-helper.sh
+++ b/.agents/scripts/tests/test-interactive-start-helper.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+scripts_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helper="${scripts_dir}/interactive-start-helper.sh"
+full_loop_helper="${scripts_dir}/full-loop-helper.sh"
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+stub_dir="${test_root}/bin"
+call_log="${test_root}/calls"
+mkdir -p "$stub_dir"
+: >"$call_log"
+export CALL_LOG="$call_log"
+
+headless_out=$(AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION=1 \
+	"$full_loop_helper" start "GH#42 local fix" --headless 2>&1)
+headless_rc=$?
+if [[ $headless_rc -eq 0 ]] || [[ "$headless_out" != *"cannot enter headless/remote worker routing"* ]]; then
+	printf 'FAIL interactive issue marker entered headless routing\n' >&2
+	exit 1
+fi
+
+for command_name in interactive-session-helper.sh pre-edit-check.sh full-loop-helper.sh; do
+	cat >"${stub_dir}/${command_name}" <<'STUB'
+#!/usr/bin/env bash
+printf '%s marker=%s args=%s\n' "${0##*/}" "${AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION:-0}" "$*" >>"$CALL_LOG"
+exit 0
+STUB
+	chmod +x "${stub_dir}/${command_name}"
+done
+
+PATH="${stub_dir}:$PATH" "$helper" --issue 42 --repo owner/repo --task "local fix" || exit 1
+
+if ! grep -Fq 'interactive-session-helper.sh marker=1 args=claim 42 owner/repo --implementing' "$call_log"; then
+	printf 'FAIL ordinary issue start did not claim as local implementation\n' >&2
+	exit 1
+fi
+if ! grep -Fq 'full-loop-helper.sh marker=1 args=start GH#42 local fix --background' "$call_log"; then
+	printf 'FAIL local asynchronous loop did not inherit implementation marker\n' >&2
+	exit 1
+fi
+
+: >"$call_log"
+PATH="${stub_dir}:$PATH" "$helper" --issue 43 --repo owner/repo --task "queued fix" --auto-dispatch || exit 1
+if ! grep -Fq 'interactive-session-helper.sh marker=1 args=claim 43 owner/repo --implementing' "$call_log"; then
+	printf 'FAIL auto-dispatch issue was not taken over locally\n' >&2
+	exit 1
+fi
+
+printf 'PASS interactive issue starts remain local\n'
+exit 0

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -54,7 +54,7 @@ Exit 0 means structural linked-worktree checks passed. A worker environment vari
 
 **Operation Verification (t1364.3):** `verify-operation-helper.sh check/verify`. Critical/high → block or verify.
 
-Start: `~/.aidevops/agents/scripts/full-loop-helper.sh start "$ARGUMENTS" --background`. `--headless` / `FULL_LOOP_HEADLESS=true`: no prompts, no TODO.md edits.
+Start: `~/.aidevops/agents/scripts/full-loop-helper.sh start "$ARGUMENTS" --background`. Here `--background` means local asynchronous execution, not remote worker dispatch. Issue-started interactive sessions preserve their local-only marker through that child and reject headless/remote-worker routing. `--headless` / `FULL_LOOP_HEADLESS=true`: no prompts, no TODO.md edits.
 
 ---
 
@@ -192,7 +192,7 @@ Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$R
 
 | Option | Description |
 |--------|-------------|
-| `--background`, `--bg` | Run in background (recommended) |
+| `--background`, `--bg` | Run asynchronously in this local session (recommended; never dispatches a worker) |
 | `--headless` | Fully headless worker mode |
 | `--dry-run` | Simulate without making changes |
 | `--max-task-iterations N` | Max task iterations (default: 50) |

--- a/.agents/workflows/save-todo.md
+++ b/.agents/workflows/save-todo.md
@@ -17,6 +17,11 @@ All TODOs, plans, and issues created by this workflow MUST use `workflows/brief.
 
 ## Intent Routing
 
+An issue-started interactive implementation context overrides generic
+"background" wording: continue implementation locally and interpret background
+only as local asynchronous execution. Never create or dispatch a worker for that
+issue from the active interactive implementation session.
+
 | Signal | Action |
 |--------|--------|
 | `/full-loop`, "work on this now", "fix/implement/do this in this session" | Start `/full-loop $ARGUMENTS`; do not ask whether to begin |


### PR DESCRIPTION
## Summary

- Keep issue-started interactive implementation local, including asynchronous execution.
- Reject headless/worker claim routing when the local implementation marker is active.
- Add focused entrypoint and claim regression coverage.

## Testing

- `bash .agents/scripts/tests/test-interactive-start-helper.sh`
- `shellcheck` on modified shell files

## Runtime Testing

- Runtime-verified with stubbed entrypoint and routing execution.

Resolves #27387

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.65 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 6m and 146,310 tokens on this as a headless worker.
