### PR TITLE
GH#27408: prevent cross-runtime Git wrapper recursion

### DIFF
--- a/.agents/scripts/git
+++ b/.agents/scripts/git
@@ -21,7 +21,10 @@ resolve_real_git() {
 		local candidate_real=""
 		candidate_real=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$candidate" 2>/dev/null || true)
 		case "$candidate_real" in
-		*/.aidevops/agents/scripts/git | */.agents/scripts/git) continue ;;
+		# Every aidevops runtime bundle contains this wrapper. Reject all of
+		# them, not only the deployed and source-tree paths, or concurrent
+		# runtime bundles can select each other and recurse indefinitely.
+		*/agents/scripts/git | */.agents/scripts/git) continue ;;
 		esac
 		printf '%s' "$candidate"
 		return 0

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -123,6 +123,17 @@ else
 	[[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "main" ]] && pass "deployed symlink shim blocks canonical mutation" || fail "symlink shim changed canonical HEAD"
 fi
 
+RUNTIME_A="${TEST_ROOT}/runtime-a/agents/scripts"
+RUNTIME_B="${TEST_ROOT}/runtime-b/agents/scripts"
+mkdir -p "$RUNTIME_A" "$RUNTIME_B"
+ln -s "$SHIM" "${RUNTIME_A}/git"
+ln -s "$SHIM" "${RUNTIME_B}/git"
+if (cd "$REPO" && env PATH="${RUNTIME_A}:${RUNTIME_B}:/usr/bin:/bin" "${RUNTIME_A}/git" status --short >/dev/null); then
+	pass "runtime bundle shim skips other runtime bundle wrappers"
+else
+	fail "runtime bundle shim skips other runtime bundle wrappers"
+fi
+
 LITERAL_REPO="${TEST_ROOT}/repo[1]"
 mkdir -p "$LITERAL_REPO"
 /usr/bin/git -C "$LITERAL_REPO" init -q -b main


### PR DESCRIPTION
## Summary

- prevent one aidevops runtime bundle's Git shim from selecting another runtime bundle's shim as the real Git binary
- reject every `agents/scripts/git` framework wrapper during real-Git resolution
- cover concurrent runtime bundles with a regression test

## Root cause

The resolver excluded source and deployed shim paths, but not immutable runtime-bundle paths. With multiple runtime versions on `PATH`, bundle A selected bundle B's shim and bundle B selected bundle A's shim, producing an unbounded Bash/Python process storm.

## Verification

- `bash .agents/scripts/tests/test-canonical-git-command-guard.sh` (32 tests, 0 failures)
- `shellcheck .agents/scripts/git .agents/scripts/tests/test-canonical-git-command-guard.sh`

Resolves #27408

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.65 plugin for [OpenCode](https://opencode.ai) v1.17.18
