### PR TITLE
GH#27405: prevent recursive shim resolution

### DIFF
--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -38,6 +38,10 @@ READ_ONLY = {
 GLOBAL_VALUE_OPTIONS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
 
 
+class GitProbeError(RuntimeError):
+    """A bounded native-Git repository probe could not complete."""
+
+
 def real_git(explicit: str = "") -> str:
     """Resolve the real Git executable without selecting the sibling shim."""
     if explicit:
@@ -58,14 +62,19 @@ def real_git(explicit: str = "") -> str:
 
 
 def _git_output(real_git_path: str, cwd: str, *args: str) -> str:
-    result = subprocess.run(
-        [real_git_path, *args],
-        cwd=cwd,
-        text=True,
-        capture_output=True,
-        timeout=5,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [real_git_path, *args],
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise GitProbeError("native Git repository probe timed out") from error
+    except OSError as error:
+        raise GitProbeError("native Git repository probe failed to start") from error
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
@@ -247,7 +256,11 @@ def classify_git_argv(
         for value in repo_values
     ):
         return False, "unresolved shell syntax in Git repository target"
-    if not _is_canonical(real_git_path, effective_cwd, prefix):
+    try:
+        is_canonical = _is_canonical(real_git_path, effective_cwd, prefix)
+    except GitProbeError as error:
+        return False, str(error)
+    if not is_canonical:
         return True, "linked worktree or non-repository target"
     if _is_allowed_canonical(subcommand, args):
         return True, "read-only canonical operation or linked-worktree creation"

--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -255,9 +255,12 @@ def classify_git_argv(
     try:
         is_canonical = _is_canonical(real_git_path, effective_cwd, prefix)
     except RuntimeError as error:
-        return False, str(error)
-    if not is_canonical:
-        return True, "linked worktree or non-repository target"
-    if _is_allowed_canonical(subcommand, args):
-        return True, "read-only canonical operation or linked-worktree creation"
-    return False, f"canonical worktree mutation via 'git {subcommand}'"
+        result = False, str(error)
+    else:
+        if not is_canonical:
+            result = True, "linked worktree or non-repository target"
+        elif _is_allowed_canonical(subcommand, args):
+            result = True, "read-only canonical operation or linked-worktree creation"
+        else:
+            result = False, f"canonical worktree mutation via 'git {subcommand}'"
+    return result

--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -38,10 +38,6 @@ READ_ONLY = {
 GLOBAL_VALUE_OPTIONS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
 
 
-class GitProbeError(RuntimeError):
-    """A bounded native-Git repository probe could not complete."""
-
-
 def real_git(explicit: str = "") -> str:
     """Resolve the real Git executable without selecting the sibling shim."""
     if explicit:
@@ -72,9 +68,9 @@ def _git_output(real_git_path: str, cwd: str, *args: str) -> str:
             check=False,
         )
     except subprocess.TimeoutExpired as error:
-        raise GitProbeError("native Git repository probe timed out") from error
+        raise RuntimeError("native Git repository probe timed out") from error
     except OSError as error:
-        raise GitProbeError("native Git repository probe failed to start") from error
+        raise RuntimeError("native Git repository probe failed to start") from error
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
@@ -258,7 +254,7 @@ def classify_git_argv(
         return False, "unresolved shell syntax in Git repository target"
     try:
         is_canonical = _is_canonical(real_git_path, effective_cwd, prefix)
-    except GitProbeError as error:
+    except RuntimeError as error:
         return False, str(error)
     if not is_canonical:
         return True, "linked worktree or non-repository target"

--- a/.agents/scripts/git
+++ b/.agents/scripts/git
@@ -12,23 +12,48 @@ while [[ -L "$SCRIPT_SOURCE" ]]; do
 done
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)" || exit 1
 GUARD="${SCRIPT_DIR}/canonical-git-command-guard.py"
+REENTRY_SENTINEL="AIDEVOPS_CANONICAL_GIT_GUARD_ACTIVE"
+
+if [[ "${!REENTRY_SENTINEL:-}" == "1" ]]; then
+	printf 'BLOCKED: recursive aidevops Git shim invocation\n' >&2
+	exit 126
+fi
+
+is_aidevops_git_shim() {
+	local candidate_real="$1"
+	case "$candidate_real" in
+	*/.aidevops/agents/scripts/git | \
+		*/.aidevops/bin/git | \
+		*/.aidevops/runtime-bundles/*/agents/scripts/git | \
+		*/aidevops/.agents/scripts/git | \
+		*/aidevops/.agents/scripts/safe-bin/git | \
+		*/.agents/scripts/git | \
+		*/.agents/scripts/safe-bin/git) return 0 ;;
+	esac
+	return 1
+}
 
 resolve_real_git() {
 	local candidate=""
+	local candidates=""
+	if command -v xcrun >/dev/null 2>&1; then
+		candidates=$(xcrun --find git 2>/dev/null || true)
+	fi
+	for candidate in /usr/bin/git /usr/local/bin/git /opt/homebrew/bin/git; do
+		[[ -x "$candidate" ]] && candidates="${candidates}${candidates:+$'\n'}${candidate}"
+	done
+	candidates="${candidates}${candidates:+$'\n'}$(which -a git 2>/dev/null || true)"
 	while IFS= read -r candidate; do
 		[[ -n "$candidate" ]] || continue
+		[[ -x "$candidate" ]] || continue
 		[[ "$candidate" -ef "$SCRIPT_SOURCE" ]] && continue
 		local candidate_real=""
 		candidate_real=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$candidate" 2>/dev/null || true)
-		case "$candidate_real" in
-		# Every aidevops runtime bundle contains this wrapper. Reject all of
-		# them, not only the deployed and source-tree paths, or concurrent
-		# runtime bundles can select each other and recurse indefinitely.
-		*/agents/scripts/git | */.agents/scripts/git) continue ;;
-		esac
-		printf '%s' "$candidate"
+		[[ -n "$candidate_real" ]] || continue
+		is_aidevops_git_shim "$candidate_real" && continue
+		printf '%s' "$candidate_real"
 		return 0
-	done < <(which -a git 2>/dev/null)
+	done <<<"$candidates"
 	return 1
 }
 
@@ -42,6 +67,8 @@ if [[ ! -f "$GUARD" ]] || ! command -v python3 >/dev/null 2>&1; then
 	exit 126
 fi
 ARGV_JSON=$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "$@") || exit 1
+export AIDEVOPS_CANONICAL_GIT_GUARD_ACTIVE=1
 python3 "$GUARD" --cwd "$PWD" --argv-json "$ARGV_JSON" --real-git "$REAL_GIT" || exit $?
+unset AIDEVOPS_CANONICAL_GIT_GUARD_ACTIVE
 
 exec "$REAL_GIT" "$@"

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -16,10 +16,22 @@ FAILURES=0
 
 # Fixture setup must bypass the guard under test; policy assertions invoke the
 # shim explicitly below.
-git() { /usr/bin/git "$@"; return $?; }
+git() {
+	/usr/bin/git "$@"
+	return $?
+}
 
-pass() { TESTS=$((TESTS + 1)); printf 'PASS %s\n' "$1"; return 0; }
-fail() { TESTS=$((TESTS + 1)); FAILURES=$((FAILURES + 1)); printf 'FAIL %s\n' "$1"; return 0; }
+pass() {
+	TESTS=$((TESTS + 1))
+	printf 'PASS %s\n' "$1"
+	return 0
+}
+fail() {
+	TESTS=$((TESTS + 1))
+	FAILURES=$((FAILURES + 1))
+	printf 'FAIL %s\n' "$1"
+	return 0
+}
 
 mkdir -p "$REPO"
 git -C "$REPO" init -q -b main
@@ -123,15 +135,40 @@ else
 	[[ "$(/usr/bin/git -C "$REPO" branch --show-current)" == "main" ]] && pass "deployed symlink shim blocks canonical mutation" || fail "symlink shim changed canonical HEAD"
 fi
 
-RUNTIME_A="${TEST_ROOT}/runtime-a/agents/scripts"
-RUNTIME_B="${TEST_ROOT}/runtime-b/agents/scripts"
-mkdir -p "$RUNTIME_A" "$RUNTIME_B"
-ln -s "$SHIM" "${RUNTIME_A}/git"
-ln -s "$SHIM" "${RUNTIME_B}/git"
-if (cd "$REPO" && env PATH="${RUNTIME_A}:${RUNTIME_B}:/usr/bin:/bin" "${RUNTIME_A}/git" status --short >/dev/null); then
-	pass "runtime bundle shim skips other runtime bundle wrappers"
+OLD_BUNDLE="${TEST_ROOT}/.aidevops/runtime-bundles/old/agents/scripts"
+NEW_BUNDLE="${TEST_ROOT}/.aidevops/runtime-bundles/new/agents/scripts"
+mkdir -p "$OLD_BUNDLE" "$NEW_BUNDLE"
+cp "$SHIM" "${OLD_BUNDLE}/git"
+cp "$SHIM" "${NEW_BUNDLE}/git"
+ln -s "$GUARD" "${OLD_BUNDLE}/canonical-git-command-guard.py"
+ln -s "$GUARD" "${NEW_BUNDLE}/canonical-git-command-guard.py"
+ln -s "${SCRIPT_DIR}/canonical_git_policy.py" "${OLD_BUNDLE}/canonical_git_policy.py"
+ln -s "${SCRIPT_DIR}/canonical_git_policy.py" "${NEW_BUNDLE}/canonical_git_policy.py"
+ln -s "${SCRIPT_DIR}/canonical_shell_parser.py" "${OLD_BUNDLE}/canonical_shell_parser.py"
+ln -s "${SCRIPT_DIR}/canonical_shell_parser.py" "${NEW_BUNDLE}/canonical_shell_parser.py"
+if (cd "$REPO" && env PATH="${OLD_BUNDLE}:${NEW_BUNDLE}:/usr/bin:/bin" "${OLD_BUNDLE}/git" status --short >/dev/null); then
+	pass "runtime-bundle shim skips every aidevops shim generation"
 else
-	fail "runtime bundle shim skips other runtime bundle wrappers"
+	fail "runtime-bundle shim skips every aidevops shim generation"
+fi
+
+REENTRY_OUTPUT=$(env AIDEVOPS_CANONICAL_GIT_GUARD_ACTIVE=1 "$SHIM" status 2>&1)
+REENTRY_RC=$?
+if [[ "$REENTRY_RC" -eq 126 && "$REENTRY_OUTPUT" == *"recursive aidevops Git shim invocation"* ]]; then
+	pass "recursive shim re-entry fails immediately with bounded diagnostic"
+else
+	fail "recursive shim re-entry is blocked (rc=$REENTRY_RC output=$REENTRY_OUTPUT)"
+fi
+
+SLOW_GIT="${TEST_ROOT}/slow-git"
+printf '#!/usr/bin/env bash\nsleep 6\n' >"$SLOW_GIT"
+chmod +x "$SLOW_GIT"
+TIMEOUT_OUTPUT=$(python3 "$GUARD" --cwd "$REPO" --argv-json '["status"]' --real-git "$SLOW_GIT" 2>&1)
+TIMEOUT_RC=$?
+if [[ "$TIMEOUT_RC" -eq 42 && "$TIMEOUT_OUTPUT" == *"native Git repository probe timed out"* && "$TIMEOUT_OUTPUT" != *"Traceback"* ]]; then
+	pass "native Git probe timeout fails closed without traceback"
+else
+	fail "native Git probe timeout is bounded (rc=$TIMEOUT_RC output=$TIMEOUT_OUTPUT)"
 fi
 
 LITERAL_REPO="${TEST_ROOT}/repo[1]"


### PR DESCRIPTION
## Summary

Resolve a trusted native executable ahead of PATH shims, reject all aidevops shim identities, block recursive guard entry, and fail closed on bounded probe errors.

## Files Changed

.agents/scripts/canonical_git_policy.py, .agents/scripts/git, .agents/scripts/tests/test-canonical-git-command-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 34 canonical guard tests pass; ShellCheck clean; Python compile clean; changed-file local linters pass.

Resolves #27405


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.65 with gpt-5.6-sol spent 10m and 52,576 tokens on this with the user in an interactive session.