### PR TITLE
GH#27401: align shipped defaults with config schema

### DIFF
--- a/.agents/configs/aidevops-config.schema.json
+++ b/.agents/configs/aidevops-config.schema.json
@@ -123,6 +123,21 @@
           "default": true,
           "description": "Enable daily git pull --ff-only on clean repos. Env: AIDEVOPS_REPO_SYNC"
         },
+        "repo_aidevops_health": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable daily repository aidevops metadata health checks. Env: AIDEVOPS_REPO_HEALTH"
+        },
+        "contribution_watch": {
+          "type": "boolean",
+          "default": true,
+          "description": "Monitor external contributions for activity needing a reply. Env: AIDEVOPS_CONTRIBUTION_WATCH"
+        },
+        "draft_responses": {
+          "type": "boolean",
+          "default": true,
+          "description": "Create private draft-response issues for contribution watch items. Env: AIDEVOPS_DRAFT_RESPONSES"
+        },
         "max_workers_cap": {
           "type": "integer",
           "default": 8,
@@ -160,6 +175,18 @@
           "deprecated": true,
           "description": "DEPRECATED (v3.7+, GH#17769): Model routing is now derived from pool + routing table. This field is ignored. Remove from config."
         },
+        "llm_stall_threshold": {
+          "type": "integer",
+          "default": 3600,
+          "minimum": 1,
+          "description": "Seconds of unchanged backlog before triggering an LLM supervisor session. Env: PULSE_LLM_STALL_THRESHOLD"
+        },
+        "pulse_stale_threshold": {
+          "type": "integer",
+          "default": 900,
+          "minimum": 1,
+          "description": "Hard ceiling in seconds for a single pulse cycle. Env: PULSE_STALE_THRESHOLD"
+        },
         "peak_hours_enabled": {
           "type": "boolean",
           "default": false,
@@ -190,6 +217,31 @@
           "minimum": 0.01,
           "maximum": 1.0,
           "description": "Fraction of off-peak MAX_WORKERS allowed during peak hours (0.2 = 20%). Result is rounded up, minimum 1. Env: AIDEVOPS_PEAK_HOURS_WORKER_FRACTION"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "foss": {
+      "type": "object",
+      "description": "FOSS contribution budget and concurrency controls.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable FOSS contribution activity. Env: AIDEVOPS_FOSS_ENABLED"
+        },
+        "max_daily_tokens": {
+          "type": "integer",
+          "default": 200000,
+          "minimum": 0,
+          "description": "Daily token ceiling across all FOSS repositories. Env: AIDEVOPS_FOSS_MAX_DAILY_TOKENS"
+        },
+        "max_concurrent_contributions": {
+          "type": "integer",
+          "default": 2,
+          "minimum": 1,
+          "description": "Maximum simultaneous FOSS contribution workers. Env: AIDEVOPS_FOSS_MAX_CONCURRENT"
         }
       },
       "additionalProperties": false

--- a/.agents/scripts/tests/test-config-schema-defaults.sh
+++ b/.agents/scripts/tests/test-config-schema-defaults.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression test for GH#27401: shipped defaults must satisfy the shipped schema.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+DEFAULTS_FILE="${SCRIPT_DIR}/../../configs/aidevops.defaults.jsonc"
+SCHEMA_FILE="${SCRIPT_DIR}/../../configs/aidevops-config.schema.json"
+
+node - "$DEFAULTS_FILE" "$SCHEMA_FILE" <<'JS'
+const fs = require("node:fs");
+const Ajv2020 = require("ajv/dist/2020").default;
+
+function stripJsoncComments(source) {
+  let output = "";
+  let index = 0;
+  let inString = false;
+  let escaped = false;
+
+  while (index < source.length) {
+    const char = source[index];
+    const nextChar = source[index + 1] || "";
+
+    if (inString) {
+      output += char;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      index += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      output += char;
+      index += 1;
+    } else if (char === "/" && nextChar === "/") {
+      index += 2;
+      while (index < source.length && !"\r\n".includes(source[index])) index += 1;
+    } else if (char === "/" && nextChar === "*") {
+      const commentEnd = source.indexOf("*/", index + 2);
+      if (commentEnd === -1) throw new Error("Unterminated JSONC block comment");
+      index = commentEnd + 2;
+    } else {
+      output += char;
+      index += 1;
+    }
+  }
+
+  return output;
+}
+
+const [, , defaultsPath, schemaPath] = process.argv;
+const defaults = JSON.parse(stripJsoncComments(fs.readFileSync(defaultsPath, "utf8")));
+const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+const validate = new Ajv2020({ allErrors: true, strict: false, validateFormats: false }).compile(schema);
+
+function assertValid(config, label) {
+  if (validate(config)) return;
+  for (const error of validate.errors || []) {
+    console.error(`${label} ${error.instancePath || "<root>"}: ${error.message}`);
+  }
+  process.exit(1);
+}
+
+assertValid(defaults, "defaults");
+console.log("PASS: complete shipped defaults satisfy the shipped config schema");
+
+const validOverride = {
+  ...defaults,
+  foss: { enabled: true, max_daily_tokens: 0, max_concurrent_contributions: 1 },
+};
+assertValid(validOverride, "valid override");
+console.log("PASS: valid FOSS overrides satisfy the shipped config schema");
+
+for (const invalidFoss of [
+  { enabled: "yes", max_daily_tokens: 1, max_concurrent_contributions: 1 },
+  { enabled: true, max_daily_tokens: -1, max_concurrent_contributions: 1 },
+  { enabled: true, max_daily_tokens: 1, max_concurrent_contributions: 0 },
+  { enabled: true, max_daily_tokens: 1, max_concurrent_contributions: 1, unknown: true },
+]) {
+  if (validate({ ...defaults, foss: invalidFoss })) {
+    console.error(`invalid FOSS config unexpectedly passed: ${JSON.stringify(invalidFoss)}`);
+    process.exit(1);
+  }
+}
+console.log("PASS: malformed and unknown FOSS settings are rejected");
+JS


### PR DESCRIPTION
## Summary

- add a strict schema for all shipped `foss` settings
- align the remaining shipped orchestration defaults with the strict schema
- validate the complete JSONC defaults against the complete schema in a regression test
- verify valid FOSS overrides pass while malformed and unknown settings fail

## Testing

- `bash .agents/scripts/tests/test-config-schema-defaults.sh`
- `shellcheck .agents/scripts/tests/test-config-schema-defaults.sh`
- `.agents/scripts/linters-local.sh --changed`

## Runtime Testing

- Self-assessed: low-risk schema and regression-test change.

Resolves #27401

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.65 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 11m and 91,288 tokens on this with the user in an interactive session.
