### PR TITLE
GH#27350: Repair token-refresh LaunchAgent setup failure

### DIFF
--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -802,10 +802,15 @@ _install_token_refresh_launchd() {
 TR_PLIST
 	)
 
-	if _launchd_install_if_changed "$tr_label" "$tr_plist" "$tr_plist_content"; then
+	if [[ -f "$tr_plist" ]] && [[ "$(<"$tr_plist")" == "$tr_plist_content" ]] && _launchd_has_agent "$tr_label"; then
+		# An interval job that is already registered does not need launchd recovery
+		# during every setup run. In particular, transient xpcproxy state at the
+		# instant setup runs does not mean that launchd lost the schedule.
+		print_info "OAuth token refresh enabled (launchd, every 30 min)"
+	elif _launchd_install_if_changed "$tr_label" "$tr_plist" "$tr_plist_content"; then
 		print_info "OAuth token refresh enabled (launchd, every 30 min)"
 	else
-		print_warning "Failed to load token refresh LaunchAgent"
+		print_warning "Failed to load token refresh LaunchAgent (${tr_label}); retry with: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/${tr_label}.plist"
 	fi
 	return 0
 }

--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -810,6 +810,7 @@ TR_PLIST
 	elif _launchd_install_if_changed "$tr_label" "$tr_plist" "$tr_plist_content"; then
 		print_info "OAuth token refresh enabled (launchd, every 30 min)"
 	else
+		# shell-portability: ignore next -- recovery text is emitted only from the macOS installer
 		print_warning "Failed to load token refresh LaunchAgent (${tr_label}); retry with: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/${tr_label}.plist"
 	fi
 	return 0

--- a/.agents/scripts/tests/test-launchd-install-if-changed.sh
+++ b/.agents/scripts/tests/test-launchd-install-if-changed.sh
@@ -949,6 +949,74 @@ test_interval_jobs_skip_unchanged_loaded_recovery() {
 	return 0
 }
 
+test_token_refresh_launchd_lifecycle() {
+	local fake_home="$TEST_DIR/home_token_refresh"
+	local plist="$fake_home/Library/LaunchAgents/sh.aidevops.token-refresh.plist"
+	local stderr_file="$TEST_DIR/token-refresh-stderr.log"
+	local install_count=0
+	local captured_content=""
+	mkdir -p "$fake_home/Library/LaunchAgents"
+
+	_launchd_has_agent() { return 0; }
+	_launchd_install_if_changed() {
+		local _label="$1"
+		local _path="$2"
+		local content="$3"
+		install_count=$((install_count + 1))
+		captured_content="$content"
+		return 0
+	}
+
+	local orig_home="$HOME"
+	HOME="$fake_home"
+	_install_token_refresh_launchd "sh.aidevops.token-refresh" "/fake/oauth-pool-helper.sh" 2>"$stderr_file"
+	printf '%s\n' "$captured_content" >"$plist"
+	_install_token_refresh_launchd "sh.aidevops.token-refresh" "/fake/oauth-pool-helper.sh" 2>>"$stderr_file"
+	HOME="$orig_home"
+	unset -f _launchd_has_agent _launchd_install_if_changed
+
+	if [[ "$install_count" -ne 1 ]]; then
+		print_result "token_refresh_launchd_lifecycle" 1 "expected one install and an idempotent second run, got $install_count installs"
+		return 0
+	fi
+	if grep -q '\[WARN\]' "$stderr_file"; then
+		print_result "token_refresh_launchd_lifecycle" 1 "healthy token refresh install emitted a warning"
+		return 0
+	fi
+	if [[ "$captured_content" != *"$(_resolve_modern_bash)"* ]] ||
+		[[ "$captured_content" != *"refresh anthropic;"* ]] ||
+		[[ "$captured_content" != *"refresh openai"* ]] ||
+		[[ "$captured_content" != *"<key>HOME</key>"* ]] ||
+		[[ "$captured_content" != *"<key>PATH</key>"* ]]; then
+		print_result "token_refresh_launchd_lifecycle" 1 "rendered plist is missing the expected runtime or refresh commands"
+		return 0
+	fi
+
+	print_result "token_refresh_launchd_lifecycle" 0
+	return 0
+}
+
+test_token_refresh_failure_is_actionable() {
+	local fake_home="$TEST_DIR/home_token_refresh_failure"
+	local stderr_file="$TEST_DIR/token-refresh-failure-stderr.log"
+	mkdir -p "$fake_home/Library/LaunchAgents"
+
+	_launchd_has_agent() { return 1; }
+	_launchd_install_if_changed() { return 1; }
+	local orig_home="$HOME"
+	HOME="$fake_home"
+	_install_token_refresh_launchd "sh.aidevops.token-refresh" "/fake/oauth-pool-helper.sh" 2>"$stderr_file"
+	HOME="$orig_home"
+	unset -f _launchd_has_agent _launchd_install_if_changed
+
+	if ! grep -q 'launchctl bootstrap gui/' "$stderr_file" || ! grep -q 'sh.aidevops.token-refresh.plist' "$stderr_file"; then
+		print_result "token_refresh_failure_is_actionable" 1 "failure warning omitted the recovery command"
+		return 0
+	fi
+	print_result "token_refresh_failure_is_actionable" 0
+	return 0
+}
+
 _install_complexity_scan_launchd_render_fixture() {
 	local cs_label="$1"
 	local cs_script="$2"
@@ -1077,6 +1145,8 @@ main() {
 	_load_schedulers_platform_functions
 	test_profile_readme_install_does_not_kickstart
 	test_interval_jobs_skip_unchanged_loaded_recovery
+	test_token_refresh_launchd_lifecycle
+	test_token_refresh_failure_is_actionable
 
 	# Test (b) needs _install_pulse_launchd from schedulers.sh
 	_load_schedulers_functions


### PR DESCRIPTION
## Summary

- avoid unnecessary launchd recovery for an unchanged, loaded token-refresh interval job
- include an actionable bootstrap recovery command when installation genuinely fails
- verify plist runtime configuration, both provider refreshes, and second-run idempotency

## Testing

- `bash .agents/scripts/tests/test-launchd-install-if-changed.sh` (13 passed)
- `bash -n .agents/scripts/setup/modules/schedulers-platform.sh .agents/scripts/tests/test-launchd-install-if-changed.sh`
- `shellcheck .agents/scripts/setup/modules/schedulers-platform.sh .agents/scripts/tests/test-launchd-install-if-changed.sh`

Resolves #27350
