### PR TITLE
t18111: Resolve SonarCloud weak-hash finding in session ID fallback

### DIFF
--- a/.agents/scripts/session-distill-helper.sh
+++ b/.agents/scripts/session-distill-helper.sh
@@ -32,7 +32,31 @@ readonly WORKSPACE_DIR="${AIDEVOPS_WORKSPACE:-$HOME/.aidevops/.agent-workspace}"
 readonly SESSION_DIR="$WORKSPACE_DIR/sessions"
 # shellcheck disable=SC2034  # Reserved for future use
 readonly DISTILL_OUTPUT="$SESSION_DIR/distill-output.json"
-readonly SESSION_ID="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-$(git rev-parse --show-toplevel 2>/dev/null | shasum | cut -c1-12)-$(git branch --show-current 2>/dev/null || printf 'unknown')}}}"
+
+# Build a private, deterministic local identifier when the runtime provides no
+# session ID. This is collision isolation, not authentication; SHA-256 prevents
+# the repository path from being exposed while avoiding weak-hash scanners.
+_distill_fallback_session_id() {
+	local repository_root=""
+	local branch=""
+	local root_hash=""
+	repository_root=$(git rev-parse --show-toplevel 2>/dev/null) || repository_root=$(pwd -P)
+	branch=$(git branch --show-current 2>/dev/null) || branch=""
+	[[ -n "$branch" ]] || branch="unknown"
+
+	if command -v shasum >/dev/null 2>&1; then
+		root_hash=$(printf '%s' "$repository_root" | shasum -a 256 | cut -c1-12)
+	elif command -v sha256sum >/dev/null 2>&1; then
+		root_hash=$(printf '%s' "$repository_root" | sha256sum | cut -c1-12)
+	else
+		root_hash=$(ROOT_PATH="$repository_root" python3 -c 'import hashlib, os; print(hashlib.sha256(os.environ["ROOT_PATH"].encode()).hexdigest()[:12])')
+	fi
+
+	printf '%s-%s' "$root_hash" "$branch"
+	return 0
+}
+
+readonly SESSION_ID="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-$(_distill_fallback_session_id)}}}"
 readonly SAFE_SESSION_ID="${SESSION_ID//[^a-zA-Z0-9_.-]/_}"
 readonly SESSION_STATE_DIR="$SESSION_DIR/$SAFE_SESSION_ID"
 readonly PROPOSALS_FILE="$SESSION_STATE_DIR/observation-proposals.json"
@@ -479,4 +503,6 @@ main() {
 	return 0
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-session-distill-session-id.sh
+++ b/.agents/scripts/tests/test-session-distill-session-id.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../session-distill-helper.sh"
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+resolve_ids() {
+	local directory="$1"
+	shift
+	(
+		cd "$directory"
+		# shellcheck disable=SC2016 # Variables intentionally expand in the child shell after sourcing.
+		env "$@" bash -c 'source "$1"; printf "%s|%s\n" "$SESSION_ID" "$SAFE_SESSION_ID"' bash "$HELPER"
+	)
+	return 0
+}
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/repository"
+git -C "$tmp_dir/repository" init -q -b 'feature/private-path'
+
+first=$(resolve_ids "$tmp_dir/repository" -u AIDEVOPS_SESSION_ID -u OPENCODE_SESSION_ID -u CLAUDE_SESSION_ID)
+second=$(resolve_ids "$tmp_dir/repository" -u AIDEVOPS_SESSION_ID -u OPENCODE_SESSION_ID -u CLAUDE_SESSION_ID)
+[[ "$first" == "$second" ]] || fail "fallback ID is not deterministic"
+[[ "$first" =~ ^[0-9a-f]{12}-feature/private-path\|[0-9a-f]{12}-feature_private-path$ ]] || fail "fallback ID format or sanitization changed: $first"
+[[ "$first" != *"$tmp_dir"* ]] || fail "fallback ID exposes the repository path"
+
+outside_first=$(resolve_ids "$tmp_dir" -u AIDEVOPS_SESSION_ID -u OPENCODE_SESSION_ID -u CLAUDE_SESSION_ID)
+outside_second=$(resolve_ids "$tmp_dir" -u AIDEVOPS_SESSION_ID -u OPENCODE_SESSION_ID -u CLAUDE_SESSION_ID)
+[[ "$outside_first" == "$outside_second" ]] || fail "non-repository fallback ID is not deterministic"
+[[ "$outside_first" =~ ^[0-9a-f]{12}-unknown\|[0-9a-f]{12}-unknown$ ]] || fail "non-repository fallback ID format changed: $outside_first"
+[[ "$outside_first" != *"$tmp_dir"* ]] || fail "non-repository fallback ID exposes the working path"
+
+[[ "$(resolve_ids "$tmp_dir" AIDEVOPS_SESSION_ID='aidevops/id' OPENCODE_SESSION_ID='opencode/id' CLAUDE_SESSION_ID='claude/id')" == 'aidevops/id|aidevops_id' ]] || fail "AIDEVOPS_SESSION_ID did not take precedence"
+[[ "$(resolve_ids "$tmp_dir" -u AIDEVOPS_SESSION_ID OPENCODE_SESSION_ID='opencode/id' CLAUDE_SESSION_ID='claude/id')" == 'opencode/id|opencode_id' ]] || fail "OPENCODE_SESSION_ID did not take precedence"
+[[ "$(resolve_ids "$tmp_dir" -u AIDEVOPS_SESSION_ID -u OPENCODE_SESSION_ID CLAUDE_SESSION_ID='claude/id')" == 'claude/id|claude_id' ]] || fail "CLAUDE_SESSION_ID did not take precedence"
+
+printf 'PASS: session distill session ID fallback\n'


### PR DESCRIPTION
## Summary

- derive fallback session IDs with portable SHA-256
- preserve explicit runtime ID precedence and filesystem-safe normalization
- cover deterministic, private behavior inside and outside Git repositories

## Testing

- `bash .agents/scripts/tests/test-session-distill-session-id.sh`
- `bash -n .agents/scripts/session-distill-helper.sh .agents/scripts/tests/test-session-distill-session-id.sh`
- `shellcheck .agents/scripts/session-distill-helper.sh .agents/scripts/tests/test-session-distill-session-id.sh`

Resolves #27349
