### PR TITLE
GH#27416: bound relationship sync and harden deployment

### DIFF
--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -228,7 +228,7 @@ resolve_task_gh_number() {
 	local repo="${3:-}"
 	[[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 1
 	local repository_id="" mapping="" coordinator="${SCRIPT_DIR}/task-coordinator.mjs"
-	repository_id=$(gh api "repos/${repo}" --jq '.node_id' 2>/dev/null || true)
+	repository_id=$(_gh_with_timeout read gh api "repos/${repo}" --jq '.node_id' 2>/dev/null || true)
 	[[ -n "$repository_id" && "$repository_id" != "null" ]] || return 1
 	if [[ -f "$coordinator" ]]; then
 		mapping=$(node "$coordinator" resolve-issue --task-id "$task_id" --forge github \
@@ -262,7 +262,7 @@ resolve_task_gh_number() {
 	ref=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 |
 		grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
 	[[ "$ref" =~ ^[1-9][0-9]*$ ]] || return 1
-	issue_json=$(gh issue view "$ref" --repo "$repo" --json id,number,state,updatedAt 2>/dev/null || true)
+	issue_json=$(_gh_with_timeout read gh issue view "$ref" --repo "$repo" --json id,number,state,updatedAt 2>/dev/null || true)
 	issue_id=$(printf '%s' "$issue_json" | jq -r '.id // empty' 2>/dev/null)
 	issue_number=$(printf '%s' "$issue_json" | jq -r '.number // empty' 2>/dev/null)
 	issue_state=$(printf '%s' "$issue_json" | jq -r '.state // empty' 2>/dev/null)
@@ -310,7 +310,7 @@ resolve_gh_node_id() {
 
 	local node_id
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
-	node_id=$(gh api graphql \
+	node_id=$(_gh_with_timeout read gh api graphql \
 		-f query='query($owner:String!,$name:String!,$num:Int!){repository(owner:$owner,name:$name){issue(number:$num){id}}}' \
 		-f owner="$owner" -f name="$name" -F num="$issue_number" \
 		--jq '.data.repository.issue.id' 2>/dev/null || echo "")

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -103,7 +103,7 @@ _cached_node_id() {
 	# Uses the same core-pool 5000/hr budget that the t2574 write-path fallbacks use.
 	if _rest_should_fallback; then
 		local rest_nid
-		rest_nid=$(gh api "/repos/${repo}/issues/${num}" --jq '.node_id // ""' 2>/dev/null || echo "")
+		rest_nid=$(_gh_with_timeout read gh api "/repos/${repo}/issues/${num}" --jq '.node_id // ""' 2>/dev/null || echo "")
 		if [[ -n "$rest_nid" ]]; then
 			echo "${num}=${rest_nid}" >>"$_NODE_ID_CACHE_FILE"
 			echo "$rest_nid"
@@ -125,7 +125,7 @@ _cached_node_id() {
 _gh_add_blocked_by() {
 	local blocked_id="$1" blocking_id="$2"
 	local result
-	result=$(gh api graphql -f query='
+	result=$(_gh_with_timeout write gh api graphql -f query='
 mutation($blocked:ID!,$blocking:ID!) {
   addBlockedBy(input: {issueId:$blocked, blockingIssueId:$blocking}) {
     issue { number }
@@ -151,7 +151,7 @@ _gh_native_blocked_by_contains() {
 	local blocked_id="$1"
 	local blocking_id="$2"
 	local payload="" has_next="" contains=""
-	payload=$(gh api graphql -f query='
+	payload=$(_gh_with_timeout read gh api graphql -f query='
 query($blocked:ID!) {
   node(id:$blocked) {
     ... on Issue {
@@ -179,7 +179,7 @@ _gh_remove_blocked_by() {
 		1) return 0 ;;
 		2) return 1 ;;
 	esac
-	result=$(gh api graphql -f query='
+	result=$(_gh_with_timeout write gh api graphql -f query='
 mutation($blocked:ID!,$blocking:ID!) {
   removeBlockedBy(input: {issueId:$blocked, blockingIssueId:$blocking}) {
     issue { number }
@@ -221,25 +221,25 @@ _hold_dependency_sync_retry() {
 	local current_labels=""
 
 	[[ "$issue_num" =~ ^[0-9]+$ && "$repo" == */* ]] || return 1
-	current_labels=$(gh issue view "$issue_num" --repo "$repo" \
+	current_labels=$(_gh_with_timeout read gh issue view "$issue_num" --repo "$repo" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || {
 		log_verbose "$issue_num: dependency_relationship_sync_retryable reason=${reason}_status_read_failed"
 		return 1
 	}
 	[[ ",${current_labels}," == *",status:available,"* ]] || return 0
 	_dependency_sync_has_active_status "$current_labels" && return 0
-	if ! gh issue edit "$issue_num" --repo "$repo" \
+	if ! _gh_with_timeout write gh issue edit "$issue_num" --repo "$repo" \
 		--remove-label "status:available" --add-label "status:blocked" >/dev/null 2>&1; then
 		log_verbose "$issue_num: dependency_relationship_sync_retryable reason=${reason}_status_write_failed"
 		return 1
 	fi
 	# A dispatcher may have advanced state between the read and edit. Repair any
 	# resulting sibling conflict immediately; active lifecycle state wins.
-	current_labels=$(gh issue view "$issue_num" --repo "$repo" \
+	current_labels=$(_gh_with_timeout read gh issue view "$issue_num" --repo "$repo" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || current_labels=""
 	if _dependency_sync_has_active_status "$current_labels" && \
 		[[ ",${current_labels}," == *",status:blocked,"* ]]; then
-		gh issue edit "$issue_num" --repo "$repo" --remove-label "status:blocked" >/dev/null 2>&1 || true
+		_gh_with_timeout write gh issue edit "$issue_num" --repo "$repo" --remove-label "status:blocked" >/dev/null 2>&1 || true
 	fi
 	log_verbose "$issue_num: dependency_relationship_sync_retryable reason=${reason}"
 	return 0
@@ -354,7 +354,7 @@ _dependency_cycle_should_skip_edge() {
 _gh_add_sub_issue() {
 	local parent_id="$1" child_id="$2"
 	local result
-	result=$(gh api graphql -f query='
+	result=$(_gh_with_timeout write gh api graphql -f query='
 mutation($parent:ID!,$child:ID!) {
   addSubIssue(input: {issueId:$parent, subIssueId:$child}) {
     issue { number }
@@ -798,7 +798,7 @@ _issue_has_parent_task_label() {
 	[[ -z "$num" || -z "$repo" ]] && return 1
 
 	local has
-	has=$(gh issue view "$num" --repo "$repo" --json labels \
+	has=$(_gh_with_timeout read gh issue view "$num" --repo "$repo" --json labels \
 		--jq '[.labels[].name] | any(. == "parent-task")' 2>/dev/null || echo "${REL_FALSE}")
 	[[ "$has" == "true" ]] && return 0
 	return 1
@@ -916,7 +916,7 @@ _backfill_one_issue() {
 		body="$prefetched_body"
 	else
 		local meta
-		meta=$(gh issue view "$num" --repo "$repo" --json title,body 2>/dev/null || echo "{}")
+		meta=$(_gh_with_timeout read gh issue view "$num" --repo "$repo" --json title,body 2>/dev/null || echo "{}")
 		title=$(printf '%s' "$meta" | jq -r '.title // ""' 2>/dev/null)
 		body=$(printf '%s' "$meta" | jq -r '.body // ""' 2>/dev/null)
 	fi
@@ -1164,7 +1164,7 @@ _backfill_fetch_issue_numbers() {
 		print_error "backfill-sub-issues: mktemp failed"
 		return 1
 	}
-	list_json=$(gh issue list --repo "$repo" --state open --limit 500 \
+	list_json=$(_gh_with_timeout read gh issue list --repo "$repo" --state open --limit 500 \
 		--json number 2>"$list_err")
 	list_rc=$?
 	if [[ "$list_rc" -ne 0 ]]; then
@@ -1217,7 +1217,7 @@ _backfill_process_loop() {
 
 		# Pre-fetch issue data (title, body, labels) for routing (GH#19942).
 		# A single API call per issue avoids double-fetch in both paths.
-		meta=$(gh issue view "$_num" --repo "$repo" --json title,body,labels 2>/dev/null || echo "{}")
+		meta=$(_gh_with_timeout read gh issue view "$_num" --repo "$repo" --json title,body,labels 2>/dev/null || echo "{}")
 		_title=$(printf '%s' "$meta" | jq -r '.title // ""' 2>/dev/null)
 		_body=$(printf '%s' "$meta" | jq -r '.body // ""' 2>/dev/null)
 		_has_parent=$(printf '%s' "$meta" | jq -r '[.labels[].name] | any(. == "parent-task")' 2>/dev/null || echo "${REL_FALSE}")
@@ -1526,7 +1526,7 @@ cmd_backfill_cross_phase_blocked_by() {
 
 	# Fetch the parent issue body
 	local body
-	body=$(gh issue view "$target_issue" --repo "$repo" \
+	body=$(_gh_with_timeout read gh issue view "$target_issue" --repo "$repo" \
 		--json body --jq '.body // ""' 2>/dev/null) || body=""
 
 	if [[ -z "$body" ]]; then

--- a/.agents/scripts/portable-stat.sh
+++ b/.agents/scripts/portable-stat.sh
@@ -43,10 +43,14 @@ _PORTABLE_STAT_FATAL="FATAL: portable-stat.sh: unsupported stat variant (neither
 _PORTABLE_STAT_UNKNOWN="unknown"
 
 _STAT_VARIANT="$_PORTABLE_STAT_UNKNOWN"
-if _ps_test_val=$(stat -c %Y / 2>/dev/null) && [[ "$_ps_test_val" =~ ^[0-9]+$ ]]; then
+_ps_test_val=$(stat -c %Y / 2>/dev/null || true)
+if [[ "$_ps_test_val" =~ ^[0-9]+$ ]]; then
 	_STAT_VARIANT="gnu"
-elif _ps_test_val=$(stat -f %m / 2>/dev/null) && [[ "$_ps_test_val" =~ ^[0-9]+$ ]]; then
-	_STAT_VARIANT="bsd"
+else
+	_ps_test_val=$(stat -f %m / 2>/dev/null || true)
+	if [[ "$_ps_test_val" =~ ^[0-9]+$ ]]; then
+		_STAT_VARIANT="bsd"
+	fi
 fi
 unset _ps_test_val
 

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -1132,8 +1132,14 @@ deploy_aidevops_agents() {
 	_validate_agent_source_dir "$source_dir" || return 1
 	_collect_deploy_agent_plugin_namespaces "$plugins_file"
 	_prepare_agents_deploy_target "$repo_dir" "$source_dir" "$target_dir"
-	_runtime_bundle_stage "$repo_dir" "$source_dir" "$target_dir" "$plugins_file" \
-		"${_deploy_agent_plugin_namespaces[@]}" || return 1
+	# Bash 3.2 with nounset treats an empty array expansion as unbound. Avoid
+	# expanding it when no plugin namespaces are configured.
+	if [[ ${#_deploy_agent_plugin_namespaces[@]} -gt 0 ]]; then
+		_runtime_bundle_stage "$repo_dir" "$source_dir" "$target_dir" "$plugins_file" \
+			"${_deploy_agent_plugin_namespaces[@]}" || return 1
+	else
+		_runtime_bundle_stage "$repo_dir" "$source_dir" "$target_dir" "$plugins_file" || return 1
+	fi
 	_runtime_bundle_activate "$target_dir" "$_AIDEVOPS_STAGED_BUNDLE_DIR" || return 1
 	_verify_agents_deploy_or_restore "$source_dir" "$target_dir" || return 1
 

--- a/.agents/scripts/tests/test-stale-process-deploy-hardening.sh
+++ b/.agents/scripts/tests/test-stale-process-deploy-hardening.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for bounded relationship sync and Bash 3.2-safe deploys.
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${TEST_DIR}/.."
+DEPLOY_FILE="${SCRIPTS_DIR}/setup/modules/agent-deploy.sh"
+REL_FILE="${SCRIPTS_DIR}/issue-sync-relationships.sh"
+REF_FILE="${SCRIPTS_DIR}/issue-sync-lib-ref.sh"
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+if ! grep -A8 '_collect_deploy_agent_plugin_namespaces "$plugins_file"' "$DEPLOY_FILE" |
+	grep -q 'if \[\[ ${#_deploy_agent_plugin_namespaces\[@\]} -gt 0 \]\]'; then
+	fail "empty plugin namespace arrays are not guarded before expansion"
+fi
+
+if rg -n '^\s*(result|payload|current_labels|has|meta|list_json|body|rest_nid|repository_id|issue_json|node_id)=\$\(gh |^\s*(if ! )?gh issue (edit|view)' \
+	"$REL_FILE" "$REF_FILE" >/dev/null; then
+	fail "relationship sync contains an unbounded GitHub CLI call"
+fi
+
+read_wrapped=$(rg -c '_gh_with_timeout read gh ' "$REL_FILE" "$REF_FILE" | awk -F: '{ total += $2 } END { print total + 0 }')
+write_wrapped=$(rg -c '_gh_with_timeout write gh ' "$REL_FILE" "$REF_FILE" | awk -F: '{ total += $2 } END { print total + 0 }')
+[[ "$read_wrapped" -ge 10 ]] || fail "expected at least 10 bounded relationship reads, got $read_wrapped"
+[[ "$write_wrapped" -ge 5 ]] || fail "expected at least 5 bounded relationship writes, got $write_wrapped"
+
+printf 'PASS: stale process and deploy hardening invariants\n'
+exit 0


### PR DESCRIPTION
## Summary

Bound every relationship-sync GitHub operation with the shared timeout wrapper, guard empty Bash 3.2 plugin arrays during deployment, and silence expected stat capability-probe failures.

## Files Changed

.agents/scripts/issue-sync-lib-ref.sh, .agents/scripts/issue-sync-relationships.sh, .agents/scripts/portable-stat.sh, .agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/tests/test-stale-process-deploy-hardening.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck clean; targeted hardening test passed; portable-stat 29/29; issue-sync library passed; local linter suite passed.

Resolves #27416


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.69 with gpt-5.6-sol spent 1h 2m and 836,952 tokens on this with the user in an interactive session.