### PR TITLE
GH#27418: keep Tabby and OpenCode session titles synchronized

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-fallback.mjs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import { readAidevopsVersion, withAidevopsTitleSuffix } from "./session-title-suffix.mjs";
+import { emitTerminalTitle as defaultEmitTerminalTitle } from "./terminal-title.mjs";
 
 const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
 const DEFAULT_SESSION_TITLE_RE = /^New session - /;
@@ -134,6 +135,7 @@ async function applyFallbackTitle(deps, sessionID, prompt) {
   const version = readAidevopsVersion(deps.agentsDir);
   const title = withAidevopsTitleSuffix(deriveFallbackTitleFromPrompt(prompt), version);
   await updateSessionTitle(deps.client, sessionID, title);
+  deps.emitTerminalTitle(title);
   deps.sessionTitles.set(sessionID, title);
   deps.fallbackDone.add(sessionID);
 }
@@ -150,7 +152,12 @@ function scheduleFallback(input, deps) {
   deps.pendingFallbacks.set(sessionID, timer);
 }
 
-export function createSessionTitleFallbackHandler({ agentsDir, client, fallbackDelayMs = FALLBACK_DELAY_MS }) {
+export function createSessionTitleFallbackHandler({
+  agentsDir,
+  client,
+  fallbackDelayMs = FALLBACK_DELAY_MS,
+  emitTerminalTitle = defaultEmitTerminalTitle,
+}) {
   const sessionTitles = new Map();
   const userMessagesBySession = new Map();
   const fallbackDone = new Set();
@@ -163,6 +170,14 @@ export function createSessionTitleFallbackHandler({ agentsDir, client, fallbackD
     rememberUserMessage(input, userMessagesBySession);
     if (!shouldApplyFallback(input, sessionTitles, userMessagesBySession, fallbackDone)) return;
 
-    scheduleFallback(input, { agentsDir, client, fallbackDelayMs, fallbackDone, pendingFallbacks, sessionTitles });
+    scheduleFallback(input, {
+      agentsDir,
+      client,
+      emitTerminalTitle,
+      fallbackDelayMs,
+      fallbackDone,
+      pendingFallbacks,
+      sessionTitles,
+    });
   };
 }

--- a/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
@@ -3,6 +3,7 @@
 
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
+import { emitTerminalTitle as defaultEmitTerminalTitle } from "./terminal-title.mjs";
 
 const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/;
 const DEFAULT_SESSION_TITLE_RE = /^New session - /;
@@ -89,7 +90,7 @@ async function updateSessionTitle(client, sessionID, title) {
   }
 }
 
-export function createSessionTitleSuffixHandler({ agentsDir, client }) {
+export function createSessionTitleSuffixHandler({ agentsDir, client, emitTerminalTitle = defaultEmitTerminalTitle }) {
   const inFlight = new Set();
 
   return async function sessionTitleSuffixHandler(input) {
@@ -107,6 +108,7 @@ export function createSessionTitleSuffixHandler({ agentsDir, client }) {
     inFlight.add(update.sessionID);
     try {
       await updateSessionTitle(client, update.sessionID, suffixedTitle);
+      emitTerminalTitle(suffixedTitle);
     } finally {
       inFlight.delete(update.sessionID);
     }

--- a/.agents/plugins/opencode-aidevops/terminal-title.mjs
+++ b/.agents/plugins/opencode-aidevops/terminal-title.mjs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { closeSync, openSync, writeSync } from "node:fs";
+
+const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/g;
+
+export function terminalTitleSequence(title) {
+  const sanitizedTitle = String(title || "").replace(CONTROL_CHAR_RE, " ").trim();
+  return `\u001B]0;${sanitizedTitle}\u0007`;
+}
+
+export function emitTerminalTitle(title) {
+  if (process.env.TERMINAL_TITLE_ENABLED === "false" || process.env.AIDEVOPS_TABBY_ENABLED === "false") return;
+
+  let ttyFd;
+  try {
+    ttyFd = openSync("/dev/tty", "w");
+    writeSync(ttyFd, terminalTitleSequence(title));
+  } catch {
+    // Terminal title synchronization is best-effort and must not affect sessions.
+  } finally {
+    if (ttyFd !== undefined) closeSync(ttyFd);
+  }
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -113,7 +113,12 @@ test("session.updated handler appends suffix through OpenCode session update API
         },
       };
 
-      const handler = createSessionTitleSuffixHandler({ agentsDir, client });
+      const terminalTitles = [];
+      const handler = createSessionTitleSuffixHandler({
+        agentsDir,
+        client,
+        emitTerminalTitle: (title) => terminalTitles.push(title),
+      });
       await handler({
         event: {
           type: "session.updated",
@@ -130,6 +135,7 @@ test("session.updated handler appends suffix through OpenCode session update API
           body: { title: "Work on live title fix · AIDevOps 3.20.103" },
         },
       ]);
+      assert.deepEqual(terminalTitles, ["Work on live title fix · AIDevOps 3.20.103"]);
     }),
   );
 });
@@ -244,8 +250,14 @@ test("message part fallback replaces stuck New session title", async () => {
     withTempAgentsDir(async (agentsDir) => {
       writeFileSync(join(agentsDir, "VERSION"), "3.21.2\n");
       const calls = [];
+      const terminalTitles = [];
       const client = { session: { update: async (payload) => calls.push(payload) } };
-      const handler = createSessionTitleFallbackHandler({ agentsDir, client, fallbackDelayMs: 1 });
+      const handler = createSessionTitleFallbackHandler({
+        agentsDir,
+        client,
+        fallbackDelayMs: 1,
+        emitTerminalTitle: (title) => terminalTitles.push(title),
+      });
 
       await handler({
         event: {
@@ -285,6 +297,7 @@ test("message part fallback replaces stuck New session title", async () => {
         path: { id: "ses_test" },
         body: { title: "Study the newsjack repository capabilities · AIDevOps 3.21.2" },
       });
+      assert.deepEqual(terminalTitles, ["Study the newsjack repository capabilities · AIDevOps 3.21.2"]);
     }),
   );
 });

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -764,19 +764,20 @@ if [[ "$git_dir" == "$git_common_dir" ]] || [[ "$git_dir" == ".git" ]]; then
 	is_main_worktree=true
 fi
 
-# Sync terminal tab title with repo/branch (silent, non-blocking)
+# Keep the OpenCode session title authoritative while OpenCode is active.
+# Outside OpenCode, retain the repo/branch shell-title fallback.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
-if [[ -x "$SCRIPT_DIR/terminal-title-helper.sh" ]]; then
-	"$SCRIPT_DIR/terminal-title-helper.sh" sync 2>/dev/null || true
-fi
-
-# Sync OpenCode session title with current branch (silent, non-blocking).
-# Only runs inside OpenCode sessions; helper resolves target session by cwd.
 if [[ "${OPENCODE:-}" == "1" ]] && [[ -x "$SCRIPT_DIR/session-rename-helper.sh" ]]; then
-	"$SCRIPT_DIR/session-rename-helper.sh" sync-branch >/dev/null 2>&1 || true
+	"$SCRIPT_DIR/session-rename-helper.sh" sync-branch "${OPENCODE_SESSION_ID:-}" >/dev/null 2>&1 || true
+	effective_title="$("$SCRIPT_DIR/session-rename-helper.sh" effective-title "${OPENCODE_SESSION_ID:-}" 2>/dev/null || true)"
+	if [[ -n "$effective_title" ]] && [[ -x "$SCRIPT_DIR/terminal-title-helper.sh" ]]; then
+		"$SCRIPT_DIR/terminal-title-helper.sh" rename "$effective_title" 2>/dev/null || true
+	fi
+elif [[ -x "$SCRIPT_DIR/terminal-title-helper.sh" ]]; then
+	"$SCRIPT_DIR/terminal-title-helper.sh" sync 2>/dev/null || true
 fi
 
 # Linked worktree ownership gate (GH#14413 hardening):

--- a/.agents/scripts/session-rename-helper.sh
+++ b/.agents/scripts/session-rename-helper.sh
@@ -10,6 +10,7 @@
 # Usage:
 #   session-rename-helper.sh rename <session-id> <new-title>
 #   session-rename-helper.sh sync-branch [session-id]
+#   session-rename-helper.sh effective-title [session-id]
 #   session-rename-helper.sh list [--limit N]
 #   session-rename-helper.sh current
 #   session-rename-helper.sh help
@@ -17,6 +18,7 @@
 # Commands:
 #   rename <session-id> <title>   Rename a specific session by ID
 #   sync-branch [session-id]      Rename session to match current git branch
+#   effective-title [session-id]  Print the authoritative current session title
 #   list [--limit N]              List recent sessions (default: 10)
 #   current                       Show the most recent session ID and title
 #   help                          Show this help
@@ -322,6 +324,28 @@ cmd_sync_branch() {
 	return $?
 }
 
+# Print the authoritative title for the relevant OpenCode session.
+# Arguments:
+#   $1 - session ID (optional; defaults to current-directory session)
+# Returns: 0 on success, 1 on failure
+cmd_effective_title() {
+	local session_id="${1:-}"
+	_require_sqlite3 || return 1
+
+	local db_path
+	db_path="$(_get_db_path)" || return 1
+	session_id="$(_resolve_sync_session_id "$db_path" "$session_id")" || return 1
+
+	local escaped_session_id
+	escaped_session_id="$(_sql_escape "$session_id")"
+	local title
+	title="$(sqlite3 "$db_path" \
+		"SELECT COALESCE(title, '') FROM session WHERE id = '${escaped_session_id}';" 2>/dev/null || echo "")"
+	[[ -n "$title" ]] || return 1
+	printf '%s' "$title"
+	return 0
+}
+
 # List recent sessions from the database.
 # Arguments:
 #   --limit N   Number of sessions to show (default: 10)
@@ -404,6 +428,7 @@ main() {
 	case "$command" in
 	rename) cmd_rename "$@" ;;
 	sync-branch) cmd_sync_branch "$@" ;;
+	effective-title) cmd_effective_title "$@" ;;
 	list) cmd_list "$@" ;;
 	current) cmd_current ;;
 	help | -h | --help) cmd_help ;;

--- a/.agents/scripts/tests/test-session-rename-helper.sh
+++ b/.agents/scripts/tests/test-session-rename-helper.sh
@@ -169,6 +169,10 @@ run_sync_on_branch "feature/auto-20260413-025423"
 rc=$?
 assert_exit "exit 0 preserve branch" "0" "$rc"
 assert_eq "meaningful title preserved" "investigating the session rename bug" "$(get_title)"
+assert_eq \
+	"effective title returns preserved title for terminal synchronization" \
+	"investigating the session rename bug" \
+	"$(cd "$REPO_DIR" && OPENCODE_DB="$DB_PATH" "$HELPER" effective-title "$SESSION_ID")"
 
 # Test 5: empty title gets renamed (initial sync still works)
 echo ""


### PR DESCRIPTION
## Summary

- make the meaningful OpenCode session title authoritative during pre-edit checks
- emit the exact committed plugin-generated title to Tabby via sanitized OSC 0
- retain repository/branch terminal titles only outside OpenCode
- cover preserved titles plus suffix and fallback synchronization

## Root cause

`pre-edit-check.sh` independently changed Tabby to `repo/branch`, then the guarded OpenCode branch sync preserved the meaningful user/task title. Plugin suffix and fallback updates also changed OpenCode without emitting a terminal title. Competing title authorities therefore diverged deterministically mid-session.

## Testing

- `npm test` in `.agents/plugins/opencode-aidevops` — 361 passing
- `PATH="/usr/bin:/bin:/usr/sbin:/sbin" /bin/bash .agents/scripts/tests/test-session-rename-helper.sh` — 23 passing
- `shellcheck .agents/scripts/session-rename-helper.sh .agents/scripts/pre-edit-check.sh .agents/scripts/tests/test-session-rename-helper.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

Runtime-verified through the shell session fixture and plugin event-handler integration tests. The real pre-edit path also reproduced the prior branch-title overwrite before this fix.

## Decisions

OpenCode owns the title while active; Git-derived titles remain the fallback for ordinary shells. OSC emission is best-effort and occurs only after the OpenCode API title update succeeds.

Resolves #27418

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.71 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 10m and 286,740 tokens on this with the user in an interactive session.
