### PR TITLE
GH#27418: unblock session title release preflight

### DIFF
--- a/.agents/scripts/tests/test-session-rename-helper.sh
+++ b/.agents/scripts/tests/test-session-rename-helper.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../session-rename-helper.sh"
+GIT_BIN="$(command -p -v git)"
 export AIDEVOPS_VERSION="9.8.7"
 ROOT_VERSION="$(tr -d '[:space:]' <"${SCRIPT_DIR}/../../../VERSION")"
 
@@ -71,10 +72,9 @@ setup_fixture() {
 
 	# Create a minimal git repo so `git rev-parse --abbrev-ref HEAD` works.
 	mkdir -p "$REPO_DIR"
-	git -C "$REPO_DIR" init -q -b main
-	git -C "$REPO_DIR" config user.email "test@aidevops.sh"
-	git -C "$REPO_DIR" config user.name "Test"
-	git -C "$REPO_DIR" commit --allow-empty -q -m "init"
+	"$GIT_BIN" -C "$REPO_DIR" init -q -b main
+	"$GIT_BIN" -C "$REPO_DIR" -c user.email="test@aidevops.sh" -c user.name="Test" \
+		commit --allow-empty -q -m "init"
 
 	# Create a session table matching the OpenCode schema subset the helper touches.
 	sqlite3 "$DB_PATH" <<-'SQL'
@@ -119,7 +119,7 @@ run_sync_on_branch() {
 	local branch="$1"
 	(
 		cd "$REPO_DIR"
-		git checkout -q -B "$branch"
+		"$GIT_BIN" checkout -q -B "$branch"
 		OPENCODE_DB="$DB_PATH" "$HELPER" sync-branch "$SESSION_ID" >/dev/null 2>&1
 	)
 	return $?


### PR DESCRIPTION
## Summary

- make the session-title shell fixture invoke the platform Git binary instead of the aidevops mutation guard shim
- avoid persistent fixture config writes by supplying identity only to the fixture commit
- unblock release preflight for the title synchronization fix

## Testing

- `bash .agents/scripts/tests/test-session-rename-helper.sh` — 23 passing through the normal guarded PATH
- `shellcheck .agents/scripts/tests/test-session-rename-helper.sh`
- `git diff --check`

## Runtime Testing

Runtime-verified by executing the previously blocked release-preflight fixture through the normal aidevops shell environment.

Ref #27418

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.72 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 23m and 66,689 tokens on this with the user in an interactive session. Overall, 11m since this issue was created.
