### PR TITLE
GH#27418: unblock pre-edit release regression fixture

### DIFF
--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER="${SCRIPT_DIR}/../pre-edit-check.sh"
+GIT_BIN="$(command -p -v git)"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -40,15 +41,15 @@ setup_test_repo() {
 	TEST_ROOT=$(mktemp -d)
 	TEST_REGISTRY_DIR="${TEST_ROOT}/.registry"
 	TEST_REGISTRY_DB="${TEST_REGISTRY_DIR}/worktree-registry.db"
-	git -C "$TEST_ROOT" init -b main >/dev/null 2>&1 || {
-		git -C "$TEST_ROOT" init >/dev/null 2>&1
-		git -C "$TEST_ROOT" checkout -b main >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" init -b main >/dev/null 2>&1 || {
+		"$GIT_BIN" -C "$TEST_ROOT" init >/dev/null 2>&1
+		"$GIT_BIN" -C "$TEST_ROOT" checkout -b main >/dev/null 2>&1
 	}
-	git -C "$TEST_ROOT" config user.name "Aidevops Test"
-	git -C "$TEST_ROOT" config user.email "test@example.com"
+	"$GIT_BIN" -C "$TEST_ROOT" config user.name "Aidevops Test"
+	"$GIT_BIN" -C "$TEST_ROOT" config user.email "test@example.com"
 	printf 'test\n' >"${TEST_ROOT}/README.md"
-	git -C "$TEST_ROOT" add README.md
-	git -C "$TEST_ROOT" commit -m "test: seed repo" >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" add README.md
+	"$GIT_BIN" -C "$TEST_ROOT" commit -m "test: seed repo" >/dev/null 2>&1
 	return 0
 }
 
@@ -103,7 +104,7 @@ test_blocks_headless_edits_on_main_with_worktree_guidance() {
 
 test_allows_linked_worktree_edits() {
 	local worktree_path="${TEST_ROOT}/linked-worktree"
-	git -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/test-linked-worktree >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/test-linked-worktree >/dev/null 2>&1
 
 	local output=""
 	local exit_code=0
@@ -121,10 +122,10 @@ test_allows_linked_worktree_edits() {
 test_namespaced_task_assignee_lookup() {
 	local task_id="to01j2abc3def4gh5jkm6npq7rst-42.3"
 	printf '%s\n' "- [ ] ${task_id} Namespaced assignee fixture assignee:other@example" >"${TEST_ROOT}/TODO.md"
-	git -C "$TEST_ROOT" add TODO.md
-	git -C "$TEST_ROOT" commit -m "test: add namespaced assignee fixture" >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" add TODO.md
+	"$GIT_BIN" -C "$TEST_ROOT" commit -m "test: add namespaced assignee fixture" >/dev/null 2>&1
 	local worktree_path="${TEST_ROOT}/namespaced-assignee-worktree"
-	git -C "$TEST_ROOT" worktree add "$worktree_path" -b "feature/${task_id}-migration" >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" worktree add "$worktree_path" -b "feature/${task_id}-migration" >/dev/null 2>&1
 
 	local output=""
 	local exit_code=0
@@ -140,10 +141,10 @@ test_namespaced_task_assignee_lookup() {
 
 test_malformed_task_assignee_fails_closed() {
 	printf '%s\n' "- [ ] t7 Prefix task assignee:other@example" >>"${TEST_ROOT}/TODO.md"
-	git -C "$TEST_ROOT" add TODO.md
-	git -C "$TEST_ROOT" commit -m "test: add malformed-prefix fixture" >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" add TODO.md
+	"$GIT_BIN" -C "$TEST_ROOT" commit -m "test: add malformed-prefix fixture" >/dev/null 2>&1
 	local worktree_path="${TEST_ROOT}/malformed-assignee-worktree"
-	git -C "$TEST_ROOT" worktree add "$worktree_path" -b "feature/t7.0-malformed" >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" worktree add "$worktree_path" -b "feature/t7.0-malformed" >/dev/null 2>&1
 
 	local output=""
 	local exit_code=0
@@ -173,7 +174,7 @@ test_worker_env_does_not_bypass_canonical_guard() {
 }
 
 test_warns_when_canonical_repo_is_off_main() {
-	git -C "$TEST_ROOT" switch -c bugfix/off-main >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" switch -c bugfix/off-main >/dev/null 2>&1
 
 	local output=""
 	local exit_code=0
@@ -190,7 +191,7 @@ test_warns_when_canonical_repo_is_off_main() {
 
 test_blocks_when_linked_worktree_owned_by_another_live_process() {
 	local worktree_path="${TEST_ROOT}/owned-worktree"
-	git -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/owned-worktree >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/owned-worktree >/dev/null 2>&1
 
 	ensure_registry_schema
 	sqlite3 "$TEST_REGISTRY_DB" "
@@ -223,7 +224,7 @@ test_blocks_when_linked_worktree_owned_by_another_live_process() {
 
 test_allows_same_opencode_session_pid_rollover() {
 	local worktree_path="${TEST_ROOT}/same-session-worktree"
-	git -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/same-session-worktree >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/same-session-worktree >/dev/null 2>&1
 
 	ensure_registry_schema
 	local original_pid=""
@@ -256,7 +257,7 @@ test_allows_same_opencode_session_pid_rollover() {
 
 test_allowlisted_path_allows_edit_on_main() {
 	# Ensure repo is on main for this test
-	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+	"$GIT_BIN" -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
 
 	local output=""
 	local exit_code=0
@@ -272,7 +273,7 @@ test_allowlisted_path_allows_edit_on_main() {
 }
 
 test_interactive_allowlisted_path_still_requires_worktree() {
-	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+	"$GIT_BIN" -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
 	local output=""
 	local exit_code=0
 	output=$(run_helper "$TEST_ROOT" --file "README.md" 2>&1) || exit_code=$?
@@ -288,7 +289,7 @@ test_interactive_allowlisted_path_still_requires_worktree() {
 
 test_path_traversal_blocked_on_main() {
 	# Ensure repo is on main for this test
-	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+	"$GIT_BIN" -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
 
 	local output=""
 	local exit_code=0
@@ -305,7 +306,7 @@ test_path_traversal_blocked_on_main() {
 
 test_absolute_path_outside_repo_blocked_on_main() {
 	# Ensure repo is on main for this test
-	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+	"$GIT_BIN" -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
 
 	local output=""
 	local exit_code=0
@@ -322,7 +323,7 @@ test_absolute_path_outside_repo_blocked_on_main() {
 
 test_todo_subdir_path_allows_edit_on_main() {
 	# Ensure repo is on main for this test
-	git -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
+	"$GIT_BIN" -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
 	mkdir -p "${TEST_ROOT}/todo"
 
 	local output=""
@@ -342,15 +343,15 @@ test_auto_creates_git_path_worktree_from_ansi_helper_output() {
 	local repo_parent="${TEST_ROOT}/ansi-case/Git"
 	local repo_path="${repo_parent}/aidevops"
 	mkdir -p "$repo_path"
-	git -C "$repo_path" init -b main >/dev/null 2>&1 || {
-		git -C "$repo_path" init >/dev/null 2>&1
-		git -C "$repo_path" checkout -b main >/dev/null 2>&1
+	"$GIT_BIN" -C "$repo_path" init -b main >/dev/null 2>&1 || {
+		"$GIT_BIN" -C "$repo_path" init >/dev/null 2>&1
+		"$GIT_BIN" -C "$repo_path" checkout -b main >/dev/null 2>&1
 	}
-	git -C "$repo_path" config user.name "Aidevops Test"
-	git -C "$repo_path" config user.email "test@example.com"
+	"$GIT_BIN" -C "$repo_path" config user.name "Aidevops Test"
+	"$GIT_BIN" -C "$repo_path" config user.email "test@example.com"
 	printf 'test\n' >"${repo_path}/README.md"
-	git -C "$repo_path" add README.md
-	git -C "$repo_path" commit -m "test: seed ansi repo" >/dev/null 2>&1
+	"$GIT_BIN" -C "$repo_path" add README.md
+	"$GIT_BIN" -C "$repo_path" commit -m "test: seed ansi repo" >/dev/null 2>&1
 
 	local output=""
 	local exit_code=0


### PR DESCRIPTION
## Summary

- resolve the platform Git binary once for isolated pre-edit fixture repositories
- keep production PATH shim enforcement intact while allowing fixture branch/worktree mutations
- unblock release preflight for the Tabby/OpenCode title synchronization change

## Testing

- `bash .agents/scripts/tests/test-pre-edit-check.sh` — 14 passing through the guarded runtime PATH
- `shellcheck .agents/scripts/tests/test-pre-edit-check.sh`
- `git diff --check`

## Runtime Testing

Runtime-verified by executing the exact release-preflight regression test that previously stopped at the Git safety shim.

Ref #27418

<!-- MERGE_SUMMARY -->
## Completion Summary

- **What**: Isolated pre-edit test fixture Git operations from the production Git guard shim.
- **Issue**: Ref #27418
- **Files changed**: `.agents/scripts/tests/test-pre-edit-check.sh`
- **Testing**: 14 fixture tests, ShellCheck, whitespace validation
- **Key decisions**: Only test fixture setup uses `command -p`; code under test retains guarded PATH behavior.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.72 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 46m and 237,947 tokens on this with the user in an interactive session. Overall, 34m since this issue was created.
