### PR TITLE
GH#27154: convert issue sync to targeted idempotent events

### DIFF
--- a/.agents/scripts/issue-sync-event-helper.mjs
+++ b/.agents/scripts/issue-sync-event-helper.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { ingestForgeEvent, recordRepositoryForgeEvent } from "./task-coordinator.mjs";
+
+const TARGETED_ACTIONS = new Set(["opened", "edited", "assigned", "closed", "reopened"]);
+
+function option(args, name, fallback = "") {
+  const index = args.indexOf(name);
+  return index >= 0 && index + 1 < args.length ? args[index + 1] : fallback;
+}
+function required(value, label) {
+  if (!value) throw new TypeError(`${label} is required`);
+  return value;
+}
+function readJsonFile(path) {
+  const canonical = resolve(required(path, "event file"));
+  const value = JSON.parse(readFileSync(canonical, "utf8"));
+  if (!value || typeof value !== "object") throw new TypeError("event file must contain a JSON object or array");
+  return value;
+}
+function canonicalTimestamp(value, label) {
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) throw new TypeError(`${label} must contain a timestamp`);
+  return new Date(value).toISOString();
+}
+function deterministicDelivery(normalized) {
+  return `d${createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 40)}`;
+}
+function assertTrustedRepository(payload, repositoryId, repositorySlug) {
+  const eventRepository = payload.repository || {};
+  const payloadSlug = eventRepository.full_name;
+  const payloadId = eventRepository.node_id || (eventRepository.id === undefined ? "" : String(eventRepository.id));
+  if (payloadSlug && payloadSlug !== repositorySlug) throw new Error("event payload repository slug does not match trusted workflow context");
+  if (payloadId && payloadId !== repositoryId) throw new Error("event payload repository identity does not match trusted workflow context");
+}
+function issueProjection(issue, action) {
+  return {
+    action,
+    assignees: Array.isArray(issue.assignees) ? issue.assignees.map((assignee) => String(assignee.login || "")).filter(Boolean).sort() : [],
+    state: String(issue.state || "").toLowerCase(),
+  };
+}
+function pullRequestProjection(pullRequest) {
+  return {
+    action: "merged",
+    merged: pullRequest.merged === true || Boolean(pullRequest.merged_at),
+    mergeCommitSha: typeof pullRequest.merge_commit_sha === "string" ? pullRequest.merge_commit_sha : "",
+    state: String(pullRequest.state || "").toLowerCase(),
+  };
+}
+function normalizeTargetedEvent({ eventName, action, payload, repositoryId, repositorySlug, repositoryPath, deliveryId = "" }) {
+  assertTrustedRepository(payload, repositoryId, repositorySlug);
+  let eventKind = "";
+  let object = null;
+  let normalizedAction = action;
+  let projection = {};
+  let eventCursor = "";
+  if (eventName === "issues") {
+    if (!TARGETED_ACTIONS.has(action)) throw new TypeError(`unsupported issues action: ${action}`);
+    eventKind = "issue";
+    object = payload.issue;
+    projection = issueProjection(object || {}, action);
+    eventCursor = canonicalTimestamp(object?.updated_at, "issue.updated_at");
+  } else if (["pull_request", "pull_request_target"].includes(eventName)) {
+    object = payload.pull_request;
+    if (action !== "closed" || !(object?.merged === true || object?.merged_at)) throw new TypeError("only merged pull request events are targeted");
+    eventKind = "pull_request";
+    normalizedAction = "merged";
+    projection = pullRequestProjection(object);
+    eventCursor = canonicalTimestamp(object.merged_at || object.updated_at, "pull_request merge cursor");
+  } else {
+    throw new TypeError(`unsupported targeted event name: ${eventName}`);
+  }
+  if (!object || object.number === undefined || (!object.node_id && object.id === undefined)) throw new TypeError("targeted event is missing immutable object identity");
+  const normalized = {
+    action: normalizedAction,
+    eventCursor,
+    eventKind,
+    objectId: String(object.node_id || object.id),
+    objectNumber: Number(object.number),
+    projection,
+    repositoryId,
+    repositoryPath,
+    repositorySlug,
+  };
+  return { ...normalized, deliveryId: deliveryId || deterministicDelivery(normalized) };
+}
+function ingestEvent(input) {
+  const { eventName, action, payload, repositoryId, repositorySlug, repositoryPath, deliveryId = "" } = input;
+  if (["issues", "pull_request", "pull_request_target"].includes(eventName)) {
+    return ingestForgeEvent(normalizeTargetedEvent(input));
+  }
+  if (!["push", "workflow_dispatch"].includes(eventName)) throw new TypeError(`unsupported repository event name: ${eventName}`);
+  assertTrustedRepository(payload, repositoryId, repositorySlug);
+  const eventKind = eventName === "push" ? "push" : "manual";
+  const eventCursor = canonicalTimestamp(
+    eventName === "push" ? (payload.head_commit?.timestamp || payload.repository?.updated_at) : required(input.eventCursor, "manual event cursor"),
+    `${eventKind} event cursor`,
+  );
+  const projection = eventName === "push" ? { after: String(payload.after || ""), changedPaths: [] } : { command: action || "reconcile" };
+  const normalized = { action: action || eventKind, eventCursor, eventKind, projection, repositoryId, repositorySlug };
+  return recordRepositoryForgeEvent({ ...normalized, deliveryId: deliveryId || deterministicDelivery(normalized) });
+}
+function reconcileEvents({ events, maxEvents, trusted }) {
+  if (!Array.isArray(events)) throw new TypeError("reconciliation file must contain an event array");
+  if (!Number.isSafeInteger(maxEvents) || maxEvents < 1 || maxEvents > 100) throw new TypeError("max-events must be 1..100");
+  const selected = events.slice(0, maxEvents).map((entry) => ({
+    ...trusted,
+    action: required(entry.action, "reconciliation event action"),
+    deliveryId: entry.delivery_id || "",
+    eventName: required(entry.event_name, "reconciliation event name"),
+    payload: required(entry.payload, "reconciliation event payload"),
+  }));
+  selected.sort((left, right) => {
+    const leftObject = left.payload.issue || left.payload.pull_request || left.payload.head_commit || {};
+    const rightObject = right.payload.issue || right.payload.pull_request || right.payload.head_commit || {};
+    return String(leftObject.updated_at || leftObject.merged_at || leftObject.timestamp || "").localeCompare(String(rightObject.updated_at || rightObject.merged_at || rightObject.timestamp || ""));
+  });
+  const results = selected.map(ingestEvent);
+  return { bounded: true, processed: results.length, results };
+}
+
+export function run(args = process.argv.slice(2)) {
+  const command = args[0] || "ingest";
+  const trusted = {
+    repositoryId: required(option(args, "--repository-id"), "repository-id"),
+    repositoryPath: required(option(args, "--repository-path"), "repository-path"),
+    repositorySlug: required(option(args, "--repository-slug"), "repository-slug"),
+  };
+  if (command === "ingest") {
+    const payload = readJsonFile(option(args, "--event-file"));
+    const result = ingestEvent({
+      ...trusted,
+      action: option(args, "--action"),
+      deliveryId: option(args, "--delivery-id"),
+      eventCursor: option(args, "--event-cursor"),
+      eventName: required(option(args, "--event-name"), "event-name"),
+      payload,
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+  if (command === "reconcile") {
+    const result = reconcileEvents({ events: readJsonFile(option(args, "--events-file")), maxEvents: Number(option(args, "--max-events", "50")), trusted });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+  throw new TypeError(`unknown issue-sync event command: ${command}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try { process.exitCode = run(); } catch (error) { process.stderr.write(`issue-sync-event: ${error.message}\n`); process.exitCode = 1; }
+}
+
+export { ingestEvent, normalizeTargetedEvent, reconcileEvents };

--- a/.agents/scripts/task-coordinator.mjs
+++ b/.agents/scripts/task-coordinator.mjs
@@ -9,7 +9,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { canonicalizeSqliteDbPath, sqlEscape } from "./sqlite-process.mjs";
 
-const SCHEMA_VERSION = 4;
+const SCHEMA_VERSION = 5;
 const PAYLOAD_MAX_BYTES = 64 * 1024;
 const EVIDENCE_MAX_BYTES = 64 * 1024;
 const CROCKFORD = "0123456789abcdefghjkmnpqrstvwxyz";
@@ -19,6 +19,7 @@ const TASK_ID = /^(?:t[1-9][0-9]{0,17}(?:\.[1-9][0-9]{0,17})*|to[0-7][0-9a-hjkmn
 const STATES = new Set(["active", "read-only", "redirected", "retired", "quarantined"]);
 const RESULTS = new Set(["published", "retryable", "indeterminate", "terminal", "conflict"]);
 const MAPPING_ROLES = new Set(["home", "implementation", "upstream"]);
+const FORGE_EVENT_ACTIONS = new Set(["opened", "edited", "assigned", "closed", "reopened", "merged"]);
 
 const SCHEMA = `
 PRAGMA foreign_keys=ON;
@@ -91,12 +92,27 @@ CREATE TABLE IF NOT EXISTS issue_mappings (
   UNIQUE(forge, repository_id, display_number),
   CHECK(forge IN ('github')), CHECK(role IN ('home','implementation','upstream'))
 );
+CREATE TABLE IF NOT EXISTS forge_event_deliveries (
+  delivery_id TEXT PRIMARY KEY, operation_id TEXT NOT NULL UNIQUE REFERENCES operations(operation_id),
+  payload_hash TEXT NOT NULL, forge TEXT NOT NULL, repository_id TEXT NOT NULL,
+  task_id TEXT, object_id TEXT, object_number INTEGER, event_kind TEXT NOT NULL,
+  action TEXT NOT NULL, event_cursor TEXT NOT NULL, outcome TEXT NOT NULL,
+  projection_json TEXT NOT NULL CHECK(json_valid(projection_json)), created_at TEXT NOT NULL,
+  CHECK(forge IN ('github')), CHECK(outcome IN ('applied','stale','conflict','recorded'))
+);
+CREATE TABLE IF NOT EXISTS forge_reconciliation_cursors (
+  forge TEXT NOT NULL, repository_id TEXT NOT NULL, task_id TEXT NOT NULL,
+  object_id TEXT NOT NULL, event_cursor TEXT NOT NULL, updated_at TEXT NOT NULL,
+  PRIMARY KEY(forge,repository_id,object_id), CHECK(forge IN ('github'))
+);
 CREATE TRIGGER IF NOT EXISTS tasks_immutable_update BEFORE UPDATE ON tasks BEGIN SELECT RAISE(ABORT, 'tasks are immutable'); END;
 CREATE TRIGGER IF NOT EXISTS tasks_immutable_delete BEFORE DELETE ON tasks BEGIN SELECT RAISE(ABORT, 'tasks are immutable'); END;
 CREATE TRIGGER IF NOT EXISTS origin_transitions_append_only_update BEFORE UPDATE ON origin_transitions BEGIN SELECT RAISE(ABORT, 'origin transitions are append-only'); END;
 CREATE TRIGGER IF NOT EXISTS origin_transitions_append_only_delete BEFORE DELETE ON origin_transitions BEGIN SELECT RAISE(ABORT, 'origin transitions are append-only'); END;
 CREATE TRIGGER IF NOT EXISTS terminal_evidence_append_only_update BEFORE UPDATE ON terminal_evidence BEGIN SELECT RAISE(ABORT, 'terminal evidence is append-only'); END;
 CREATE TRIGGER IF NOT EXISTS terminal_evidence_append_only_delete BEFORE DELETE ON terminal_evidence BEGIN SELECT RAISE(ABORT, 'terminal evidence is append-only'); END;
+CREATE TRIGGER IF NOT EXISTS forge_event_deliveries_append_only_update BEFORE UPDATE ON forge_event_deliveries BEGIN SELECT RAISE(ABORT, 'forge event deliveries are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS forge_event_deliveries_append_only_delete BEFORE DELETE ON forge_event_deliveries BEGIN SELECT RAISE(ABORT, 'forge event deliveries are append-only'); END;
 `;
 
 function now() { return new Date().toISOString(); }
@@ -179,15 +195,29 @@ INSERT INTO migration_history(version,applied_at,backup_path,integrity_result) V
 COMMIT;`);
   if (sqlite(path, "PRAGMA integrity_check;\n") !== "ok") throw new Error("migration integrity verification failed");
 }
+function migrateV4ToV5(path) {
+  const copy = backup(path, "pre-migrate-v5");
+  sqlite(path, `BEGIN IMMEDIATE;
+${SCHEMA}
+UPDATE coordinator_meta SET value='5' WHERE key='schema_version';
+INSERT INTO migration_history(version,applied_at,backup_path,integrity_result) VALUES (5,${sqlEscape(now())},${sqlEscape(copy)},'ok');
+COMMIT;`);
+  if (sqlite(path, "PRAGMA integrity_check;\n") !== "ok") throw new Error("migration integrity verification failed");
+}
 function migrate(path, version) {
   if (version === 1) {
     migrateV1ToV2(path);
     migrateV2ToV3(path);
     migrateV3ToV4(path);
+    migrateV4ToV5(path);
   } else if (version === 2) {
     migrateV2ToV3(path);
     migrateV3ToV4(path);
-  } else if (version === 3) migrateV3ToV4(path);
+    migrateV4ToV5(path);
+  } else if (version === 3) {
+    migrateV3ToV4(path);
+    migrateV4ToV5(path);
+  } else if (version === 4) migrateV4ToV5(path);
   else if (version !== SCHEMA_VERSION) throw new Error(`unsupported coordinator schema ${version}`);
 }
 function bootstrap(path) {
@@ -523,6 +553,88 @@ function resolveIssue({ taskId, forge = "github", repositoryId }, path = initial
   if (matches.length !== 1) throw new Error("issue mapping not found");
   return { ...matches[0], syncMetadata: JSON.parse(matches[0].syncMetadataJson) };
 }
+function canonicalEventCursor(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value) || !Number.isFinite(Date.parse(value))) {
+    throw new TypeError("event_cursor must be a canonical UTC RFC3339 timestamp");
+  }
+  return new Date(value).toISOString();
+}
+function eventMapping({ forge = "github", repositoryId, objectId, objectNumber }, path) {
+  if (forge !== "github") throw new TypeError("unsupported forge");
+  validId(repositoryId, "repository_id");
+  validId(objectId, "object_id");
+  const displayNumber = Number(objectNumber);
+  if (!Number.isSafeInteger(displayNumber) || displayNumber < 1) throw new TypeError("object_number must be a positive integer");
+  const matches = rows(path, `SELECT task_id AS taskId,repository_slug AS repositorySlug,role,issue_id AS objectId,display_number AS objectNumber,state_cursor AS stateCursor,sync_metadata_json AS syncMetadataJson FROM issue_mappings WHERE forge=${sqlEscape(forge)} AND repository_id=${sqlEscape(repositoryId)} AND issue_id=${sqlEscape(objectId)} AND display_number=${displayNumber};`);
+  if (matches.length !== 1) throw new Error("explicit forge object mapping not found");
+  return { ...matches[0], syncMetadata: JSON.parse(matches[0].syncMetadataJson) };
+}
+function ingestForgeEvent({ deliveryId, forge = "github", repositoryId, repositorySlug, repositoryPath, eventKind, action, objectId, objectNumber, eventCursor, projection = {} }, path = initialise()) {
+  validId(deliveryId, "delivery_id");
+  validId(repositoryId, "repository_id");
+  if (typeof repositorySlug !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(repositorySlug)) throw new TypeError("repository_slug is not canonical");
+  if (typeof repositoryPath !== "string" || !repositoryPath.startsWith("/") || repositoryPath.includes("\0")) throw new TypeError("repository_path must be absolute");
+  if (!["issue", "pull_request"].includes(eventKind)) throw new TypeError("unsupported targeted forge event kind");
+  if (!FORGE_EVENT_ACTIONS.has(action) || (eventKind === "pull_request" && action !== "merged")) throw new TypeError("unsupported targeted forge event action");
+  const cursor = canonicalEventCursor(eventCursor);
+  const mapping = eventMapping({ forge, repositoryId, objectId, objectNumber }, path);
+  if (mapping.repositorySlug !== repositorySlug) throw new Error("forge event repository does not match the bound repository");
+  const projectionText = jsonText(projection, "event projection");
+  const eventPayload = { action, eventCursor: cursor, eventKind, forge, objectId, objectNumber: Number(objectNumber), projection, repositoryId, repositorySlug, taskId: mapping.taskId };
+  const payloadText = jsonText(eventPayload, "forge event");
+  const payloadHash = hashText(payloadText);
+  const operationId = `forge.${deliveryId}`;
+  const prior = operationResult(path, operationId, payloadHash);
+  if (prior) return prior;
+  const priorCursor = mapping.stateCursor ? new Date(mapping.stateCursor).toISOString() : null;
+  const comparison = priorCursor ? cursor.localeCompare(priorCursor) : 1;
+  const priorProjectionText = JSON.stringify(mapping.syncMetadata?.projection || {});
+  const outcome = comparison < 0 ? "stale" : (comparison === 0 && priorProjectionText !== projectionText ? "conflict" : (comparison === 0 ? "stale" : "applied"));
+  const status = outcome === "applied" ? "retryable" : (outcome === "conflict" ? "conflict" : "terminal");
+  const timestamp = now();
+  const intentId = outcome === "applied" ? randomUUID() : null;
+  const result = { action, deliveryId, eventCursor: cursor, eventKind, intentId, objectNumber: Number(objectNumber), operationId, outcome, repositoryId, status, taskId: mapping.taskId };
+  const resultText = JSON.stringify(result);
+  const publicationBehavior = outcome === "applied" ? jsonText({ branchName: "main", coalesceKey: `forge-${mapping.taskId}`, maxAttempts: 5, payload: { event: eventPayload, paths: ["TODO.md"] }, remoteName: "origin", repositoryId, repositoryPath, taskId: mapping.taskId }, "publication behavior") : null;
+  const publicationHash = publicationBehavior ? hashText(publicationBehavior) : null;
+  try {
+    sqlite(path, `PRAGMA foreign_keys=ON; BEGIN IMMEDIATE;
+INSERT INTO operations VALUES (${sqlEscape(operationId)},'forge.event',${sqlEscape(mapping.taskId)},${sqlEscape(payloadHash)},${sqlEscape(payloadText)},${sqlEscape(status)},${sqlEscape(resultText)},'sha3-256:'||lower(hex(sha3(${sqlEscape(resultText)},256))),${sqlEscape(timestamp)},${sqlEscape(timestamp)});
+INSERT INTO forge_event_deliveries VALUES (${sqlEscape(deliveryId)},${sqlEscape(operationId)},${sqlEscape(payloadHash)},${sqlEscape(forge)},${sqlEscape(repositoryId)},${sqlEscape(mapping.taskId)},${sqlEscape(objectId)},${Number(objectNumber)},${sqlEscape(eventKind)},${sqlEscape(action)},${sqlEscape(cursor)},${sqlEscape(outcome)},${sqlEscape(projectionText)},${sqlEscape(timestamp)});
+${outcome === "applied" ? `UPDATE issue_mappings SET state_cursor=${sqlEscape(cursor)},sync_metadata_json=${sqlEscape(jsonText({ ...mapping.syncMetadata, action, projection, source: "forge-event" }, "sync metadata"))},updated_at=${sqlEscape(timestamp)} WHERE task_id=${sqlEscape(mapping.taskId)} AND forge=${sqlEscape(forge)} AND repository_id=${sqlEscape(repositoryId)} AND issue_id=${sqlEscape(objectId)} AND (state_cursor IS NULL OR state_cursor<${sqlEscape(cursor)});
+INSERT INTO publication_intents VALUES (${sqlEscape(intentId)},${sqlEscape(operationId)},${sqlEscape(mapping.taskId)},${sqlEscape(publicationHash)},${sqlEscape(publicationBehavior)},'retryable',${sqlEscape(timestamp)});
+INSERT INTO publication_queue(intent_id,repository_id,repository_path,remote_name,branch_name,coalesce_key,sequence,available_at,max_attempts) SELECT ${sqlEscape(intentId)},${sqlEscape(repositoryId)},${sqlEscape(repositoryPath)},'origin','main',${sqlEscape(`forge-${mapping.taskId}`)},COALESCE(MAX(sequence),0)+1,unixepoch(),5 FROM publication_queue;` : `INSERT INTO terminal_evidence(operation_id,result_state,evidence_json,occurred_at) VALUES (${sqlEscape(operationId)},${sqlEscape(status)},${sqlEscape(jsonText({ eventCursor: cursor, outcome }, "event evidence"))},${sqlEscape(timestamp)});`}
+INSERT INTO forge_reconciliation_cursors(forge,repository_id,task_id,object_id,event_cursor,updated_at) VALUES (${sqlEscape(forge)},${sqlEscape(repositoryId)},${sqlEscape(mapping.taskId)},${sqlEscape(objectId)},${sqlEscape(cursor)},${sqlEscape(timestamp)}) ON CONFLICT(forge,repository_id,object_id) DO UPDATE SET event_cursor=excluded.event_cursor,updated_at=excluded.updated_at WHERE excluded.event_cursor>forge_reconciliation_cursors.event_cursor;
+COMMIT;`);
+  } catch (error) {
+    const raced = operationResult(path, operationId, payloadHash);
+    if (!raced) throw error;
+    return raced;
+  }
+  return result;
+}
+function recordRepositoryForgeEvent({ deliveryId, forge = "github", repositoryId, repositorySlug, eventKind, action, eventCursor, projection = {} }, path = initialise()) {
+  validId(deliveryId, "delivery_id"); validId(repositoryId, "repository_id");
+  if (forge !== "github") throw new TypeError("unsupported forge");
+  if (typeof repositorySlug !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(repositorySlug)) throw new TypeError("repository_slug is not canonical");
+  if (!["push", "manual"].includes(eventKind)) throw new TypeError("unsupported repository forge event kind");
+  const cursor = canonicalEventCursor(eventCursor);
+  const payload = { action, eventCursor: cursor, eventKind, forge, projection, repositoryId, repositorySlug };
+  const payloadText = jsonText(payload, "repository forge event");
+  const payloadHash = hashText(payloadText);
+  const operationId = `forge.${deliveryId}`;
+  const prior = operationResult(path, operationId, payloadHash);
+  if (prior) return prior;
+  const timestamp = now();
+  const result = { deliveryId, eventCursor: cursor, eventKind, operationId, outcome: "recorded", repositoryId, status: "terminal", taskId: null };
+  const resultText = JSON.stringify(result);
+  sqlite(path, `BEGIN IMMEDIATE;
+INSERT INTO operations VALUES (${sqlEscape(operationId)},'forge.repository-event',NULL,${sqlEscape(payloadHash)},${sqlEscape(payloadText)},'terminal',${sqlEscape(resultText)},'sha3-256:'||lower(hex(sha3(${sqlEscape(resultText)},256))),${sqlEscape(timestamp)},${sqlEscape(timestamp)});
+INSERT INTO forge_event_deliveries VALUES (${sqlEscape(deliveryId)},${sqlEscape(operationId)},${sqlEscape(payloadHash)},${sqlEscape(forge)},${sqlEscape(repositoryId)},NULL,NULL,NULL,${sqlEscape(eventKind)},${sqlEscape(action)},${sqlEscape(cursor)},'recorded',${sqlEscape(jsonText(projection, "event projection"))},${sqlEscape(timestamp)});
+INSERT INTO terminal_evidence VALUES (NULL,${sqlEscape(operationId)},'terminal',${sqlEscape(jsonText({ outcome: "recorded" }, "event evidence"))},${sqlEscape(timestamp)});
+COMMIT;`);
+  return result;
+}
 function validateRestoreEvidence(evidence, fencingToken) {
   const text = jsonText(evidence, "registry_evidence", EVIDENCE_MAX_BYTES);
   if (evidence.cas !== "winner" || evidence.prior_revoked !== true || evidence.fencing_token !== fencingToken || !validId(evidence.transfer_record_id, "transfer_record_id")) {
@@ -584,13 +696,15 @@ const COMMAND_HANDLERS = {
   transition: (args, path) => transition({ state: option(args, "--state"), fencingToken: option(args, "--fencing-token"), evidence: parseJson(option(args, "--evidence", "{}")) }, path),
   "bind-issue": (args, path) => bindIssue({ taskId: option(args, "--task-id"), forge: option(args, "--forge", "github"), repositoryId: option(args, "--repository-id"), repositorySlug: option(args, "--repository-slug"), role: option(args, "--role", "home"), issueId: option(args, "--issue-id"), projectId: option(args, "--project-id"), displayNumber: option(args, "--display-number"), stateCursor: option(args, "--state-cursor"), syncMetadata: parseJson(option(args, "--sync-metadata", "{}")) }, path),
   "resolve-issue": (args, path) => resolveIssue({ taskId: option(args, "--task-id"), forge: option(args, "--forge", "github"), repositoryId: option(args, "--repository-id") }, path),
+  "ingest-forge-event": (args, path) => ingestForgeEvent({ deliveryId: option(args, "--delivery-id"), forge: option(args, "--forge", "github"), repositoryId: option(args, "--repository-id"), repositorySlug: option(args, "--repository-slug"), repositoryPath: option(args, "--repository-path"), eventKind: option(args, "--event-kind"), action: option(args, "--action"), objectId: option(args, "--object-id"), objectNumber: option(args, "--object-number"), eventCursor: option(args, "--event-cursor"), projection: parseJson(option(args, "--projection", "{}")) }, path),
+  "record-repository-event": (args, path) => recordRepositoryForgeEvent({ deliveryId: option(args, "--delivery-id"), forge: option(args, "--forge", "github"), repositoryId: option(args, "--repository-id"), repositorySlug: option(args, "--repository-slug"), eventKind: option(args, "--event-kind"), action: option(args, "--action"), eventCursor: option(args, "--event-cursor"), projection: parseJson(option(args, "--projection", "{}")) }, path),
   restore: (args, path) => restore({ backupPath: option(args, "--backup"), registryEvidence: parseJson(option(args, "--registry-evidence", "{}")), priorEpoch: Number(option(args, "--prior-epoch")), newEpoch: Number(option(args, "--new-epoch")), fencingToken: option(args, "--fencing-token"), publishedHighWater: Number(option(args, "--published-high-water", "0")) }, path),
   verify: (_args, path) => verify(path),
   status: (_args, path) => ({ ...activeOrigin(path), dbPath: path }),
 };
 export function run(args = process.argv.slice(2)) {
   const command = args[0] || "help";
-  if (["help", "--help", "-h"].includes(command)) { process.stdout.write("Usage: task-coordinator.mjs allocate|publication-intent|lease-next|lease-check|lease-renew|lease-finish|publication-metrics|attempt|transition|bind-issue|resolve-issue|restore|verify|status\n"); return 0; }
+  if (["help", "--help", "-h"].includes(command)) { process.stdout.write("Usage: task-coordinator.mjs allocate|publication-intent|lease-next|lease-check|lease-renew|lease-finish|publication-metrics|attempt|transition|bind-issue|resolve-issue|ingest-forge-event|record-repository-event|restore|verify|status\n"); return 0; }
   const handler = COMMAND_HANDLERS[command];
   const path = initialise();
   if (!handler) throw new TypeError(`unknown task-coordinator command: ${command}`);
@@ -603,4 +717,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   try { process.exitCode = run(); } catch (error) { process.stderr.write(`task-coordinator: ${error.message}\n`); process.exitCode = 1; }
 }
 
-export { allocate, backup, bindIssue, hashPayload, initialise, leaseNext, publicationMetrics, resolveIssue, restore, verify };
+export { allocate, backup, bindIssue, hashPayload, ingestForgeEvent, initialise, leaseNext, publicationMetrics, recordRepositoryForgeEvent, resolveIssue, restore, verify };

--- a/.agents/scripts/tests/fixtures/issue-sync-events/cross-repository.json
+++ b/.agents/scripts/tests/fixtures/issue-sync-events/cross-repository.json
@@ -1,0 +1,10 @@
+{
+  "repository": {"node_id": "R_other", "full_name": "attacker/other"},
+  "issue": {
+    "node_id": "I_fixture_42",
+    "number": 42,
+    "state": "closed",
+    "updated_at": "2026-07-12T12:00:00Z",
+    "assignees": []
+  }
+}

--- a/.agents/scripts/tests/fixtures/issue-sync-events/issue-assigned.json
+++ b/.agents/scripts/tests/fixtures/issue-sync-events/issue-assigned.json
@@ -1,0 +1,10 @@
+{
+  "repository": {"node_id": "R_fixture", "full_name": "owner/repo"},
+  "issue": {
+    "node_id": "I_fixture_42",
+    "number": 42,
+    "state": "open",
+    "updated_at": "2026-07-12T10:20:00Z",
+    "assignees": [{"login": "fixture-user"}]
+  }
+}

--- a/.agents/scripts/tests/fixtures/issue-sync-events/issue-closed.json
+++ b/.agents/scripts/tests/fixtures/issue-sync-events/issue-closed.json
@@ -1,0 +1,10 @@
+{
+  "repository": {"node_id": "R_fixture", "full_name": "owner/repo"},
+  "issue": {
+    "node_id": "I_fixture_42",
+    "number": 42,
+    "state": "closed",
+    "updated_at": "2026-07-12T10:30:00Z",
+    "assignees": [{"login": "fixture-user"}]
+  }
+}

--- a/.agents/scripts/tests/fixtures/issue-sync-events/issue-edited.json
+++ b/.agents/scripts/tests/fixtures/issue-sync-events/issue-edited.json
@@ -1,0 +1,10 @@
+{
+  "repository": {"node_id": "R_fixture", "full_name": "owner/repo"},
+  "issue": {
+    "node_id": "I_fixture_42",
+    "number": 42,
+    "state": "open",
+    "updated_at": "2026-07-12T10:10:00Z",
+    "assignees": []
+  }
+}

--- a/.agents/scripts/tests/fixtures/issue-sync-events/issue-opened.json
+++ b/.agents/scripts/tests/fixtures/issue-sync-events/issue-opened.json
@@ -1,0 +1,10 @@
+{
+  "repository": {"node_id": "R_fixture", "full_name": "owner/repo"},
+  "issue": {
+    "node_id": "I_fixture_42",
+    "number": 42,
+    "state": "open",
+    "updated_at": "2026-07-12T10:00:00Z",
+    "assignees": []
+  }
+}

--- a/.agents/scripts/tests/fixtures/issue-sync-events/issue-reopened.json
+++ b/.agents/scripts/tests/fixtures/issue-sync-events/issue-reopened.json
@@ -1,0 +1,10 @@
+{
+  "repository": {"node_id": "R_fixture", "full_name": "owner/repo"},
+  "issue": {
+    "node_id": "I_fixture_42",
+    "number": 42,
+    "state": "open",
+    "updated_at": "2026-07-12T10:40:00Z",
+    "assignees": [{"login": "fixture-user"}]
+  }
+}

--- a/.agents/scripts/tests/fixtures/issue-sync-events/pr-merged.json
+++ b/.agents/scripts/tests/fixtures/issue-sync-events/pr-merged.json
@@ -1,0 +1,12 @@
+{
+  "repository": {"node_id": "R_fixture", "full_name": "owner/repo"},
+  "pull_request": {
+    "node_id": "PR_fixture_7",
+    "number": 7,
+    "state": "closed",
+    "merged": true,
+    "merged_at": "2026-07-12T11:00:00Z",
+    "updated_at": "2026-07-12T11:00:00Z",
+    "merge_commit_sha": "0123456789abcdef0123456789abcdef01234567"
+  }
+}

--- a/.agents/scripts/tests/fixtures/issue-sync-events/reconcile-events.json
+++ b/.agents/scripts/tests/fixtures/issue-sync-events/reconcile-events.json
@@ -1,0 +1,20 @@
+[
+  {
+    "event_name": "issues",
+    "action": "reopened",
+    "delivery_id": "reconcile-reopened",
+    "payload": {
+      "repository": {"node_id": "R_fixture", "full_name": "owner/repo"},
+      "issue": {"node_id": "I_fixture_88", "number": 88, "state": "open", "updated_at": "2026-07-12T09:20:00Z", "assignees": []}
+    }
+  },
+  {
+    "event_name": "issues",
+    "action": "closed",
+    "delivery_id": "reconcile-closed",
+    "payload": {
+      "repository": {"node_id": "R_fixture", "full_name": "owner/repo"},
+      "issue": {"node_id": "I_fixture_88", "number": 88, "state": "closed", "updated_at": "2026-07-12T09:10:00Z", "assignees": []}
+    }
+  }
+]

--- a/.agents/scripts/tests/test-issue-sync-events.sh
+++ b/.agents/scripts/tests/test-issue-sync-events.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+COORDINATOR="${SCRIPT_DIR}/../task-coordinator.mjs"
+EVENT_HELPER="${SCRIPT_DIR}/../issue-sync-event-helper.mjs"
+FIXTURES="${SCRIPT_DIR}/fixtures/issue-sync-events"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export AIDEVOPS_TASK_COORDINATOR_DB="${TEST_ROOT}/coordinator.db"
+
+issue_task=$(node "$COORDINATOR" allocate --operation-id fixture-issue-task --legacy-id t4101 | jq -r '.tasks[0].taskId')
+pr_task=$(node "$COORDINATOR" allocate --operation-id fixture-pr-task --legacy-id t4102 | jq -r '.tasks[0].taskId')
+other_task=$(node "$COORDINATOR" allocate --operation-id fixture-other-task --legacy-id t4103 | jq -r '.tasks[0].taskId')
+reconcile_task=$(node "$COORDINATOR" allocate --operation-id fixture-reconcile-task --legacy-id t4104 | jq -r '.tasks[0].taskId')
+node "$COORDINATOR" bind-issue --task-id "$issue_task" --repository-id R_fixture --repository-slug owner/repo --issue-id I_fixture_42 --display-number 42 >/dev/null
+node "$COORDINATOR" bind-issue --task-id "$pr_task" --repository-id R_fixture --repository-slug owner/repo --role implementation --issue-id PR_fixture_7 --display-number 7 >/dev/null
+node "$COORDINATOR" bind-issue --task-id "$other_task" --repository-id R_other --repository-slug owner/other --issue-id I_other_42 --display-number 42 >/dev/null
+node "$COORDINATOR" bind-issue --task-id "$reconcile_task" --repository-id R_fixture --repository-slug owner/repo --issue-id I_fixture_88 --display-number 88 >/dev/null
+
+ingest() {
+	local event_name="$1"
+	local action="$2"
+	local fixture="$3"
+	local delivery_id="${4:-}"
+	local delivery_args=()
+	if [[ -n "$delivery_id" ]]; then delivery_args=(--delivery-id "$delivery_id"); fi
+	node "$EVENT_HELPER" ingest --event-name "$event_name" --action "$action" \
+		--event-file "${FIXTURES}/${fixture}" --repository-id R_fixture \
+		--repository-slug owner/repo --repository-path "$TEST_ROOT" "${delivery_args[@]}"
+	return $?
+}
+
+opened=$(ingest issues opened issue-opened.json)
+[[ "$(jq -r '.outcome' <<<"$opened")" == "applied" ]]
+[[ "$(ingest issues opened issue-opened.json)" == "$opened" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" 'SELECT COUNT(*) FROM forge_event_deliveries;')" == "1" ]]
+
+for event in edited assigned closed reopened; do
+	result=$(ingest issues "$event" "issue-${event}.json")
+	[[ "$(jq -r '.taskId' <<<"$result")" == "$issue_task" ]]
+	[[ "$(jq -r '.outcome' <<<"$result")" == "applied" ]]
+done
+merged=$(ingest pull_request closed pr-merged.json)
+[[ "$(jq -r '.taskId' <<<"$merged")" == "$pr_task" ]]
+[[ "$(jq -r '.action' <<<"$merged")" == "merged" ]]
+
+# A late delivery is durable but cannot overwrite the newer reopened state.
+late=$(ingest issues assigned issue-assigned.json late-assigned-delivery)
+[[ "$(jq -r '.outcome' <<<"$late")" == "stale" ]]
+[[ "$(node "$COORDINATOR" resolve-issue --task-id "$issue_task" --repository-id R_fixture | jq -r '.syncMetadata.projection.state')" == "open" ]]
+[[ "$(node "$COORDINATOR" resolve-issue --task-id "$other_task" --repository-id R_other | jq -r '.syncMetadata | length')" == "0" ]]
+
+# The immutable workflow repository context wins over every payload field.
+if ingest issues closed cross-repository.json >/dev/null 2>&1; then
+	printf 'FAIL cross-repository payload selected a target\n' >&2
+	exit 1
+fi
+
+# Reusing one delivery ID with changed intent fails instead of mutating state.
+ingest issues opened issue-opened.json fixed-delivery >/dev/null
+if ingest issues edited issue-edited.json fixed-delivery >/dev/null 2>&1; then
+	printf 'FAIL changed payload reused a delivery ID\n' >&2
+	exit 1
+fi
+
+# Repair mode is explicit and bounded. It orders missed deliveries by cursor so
+# the final projection converges even when the forge returns events out of order.
+reconciled=$(node "$EVENT_HELPER" reconcile --events-file "${FIXTURES}/reconcile-events.json" \
+	--max-events 10 --repository-id R_fixture --repository-slug owner/repo --repository-path "$TEST_ROOT")
+[[ "$(jq -r '.bounded' <<<"$reconciled")" == "true" ]]
+[[ "$(jq -r '.processed' <<<"$reconciled")" == "2" ]]
+[[ "$(node "$COORDINATOR" resolve-issue --task-id "$reconcile_task" --repository-id R_fixture | jq -r '.syncMetadata.projection.state')" == "open" ]]
+
+# Applied issue/PR events flow through the serialized publication outbox; stale
+# events and repository mismatches do not enqueue work.
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(*) FROM publication_queue;")" == "8" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(DISTINCT task_id) FROM publication_intents;")" == "3" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT event_cursor FROM forge_reconciliation_cursors WHERE repository_id='R_fixture' AND object_id='I_fixture_42';")" == "2026-07-12T10:40:00.000Z" ]]
+
+# The normal workflow job fetches only framework code and invokes no issue-list,
+# checkout mutation, commit, or reset path. Bulk sync remains a manual repair.
+python3 - "$REPO_ROOT/.github/workflows/issue-sync-reusable.yml" <<'PY'
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+section = text.split("  targeted-event:\n", 1)[1].split("  sync-on-push:\n", 1)[0]
+for forbidden in ("gh issue list", "issue-sync-helper.sh", "git commit", "git reset", "ref: main"):
+    if forbidden in section:
+        raise SystemExit(f"normal targeted event job contains forbidden path: {forbidden}")
+if "issue-sync-event-helper.mjs ingest" not in section:
+    raise SystemExit("targeted event helper is not wired into the reusable workflow")
+PY
+
+printf 'PASS targeted idempotent issue-sync event ingestion\n'

--- a/.agents/scripts/tests/test-task-coordinator.sh
+++ b/.agents/scripts/tests/test-task-coordinator.sh
@@ -226,9 +226,18 @@ printf '%s' "$namespaced" | grep -q '^task_count=3$'
 # Shadow mode records the legacy identity but never replaces CAS output.
 (
 	SCRIPT_DIR="${SCRIPT_DIR}/.."
-	log_info() { :; return 0; }
-	log_warn() { :; return 0; }
-	log_error() { :; return 0; }
+	log_info() {
+		:
+		return 0
+	}
+	log_warn() {
+		:
+		return 0
+	}
+	log_error() {
+		:
+		return 0
+	}
 	# shellcheck source=../claim-task-id-counter.sh
 	source "${SCRIPT_DIR}/claim-task-id-counter.sh"
 	AIDEVOPS_TASK_COORDINATOR_MODE=shadow AIDEVOPS_TASK_COORDINATOR_SHADOW_ENABLED=1 _task_coordinator_shadow_legacy 321 1

--- a/.agents/scripts/tests/test-task-coordinator.sh
+++ b/.agents/scripts/tests/test-task-coordinator.sh
@@ -114,9 +114,9 @@ node "$COORDINATOR" restore --backup "$backup" --registry-evidence '{"cas":"winn
 # A real v1 schema migrates through every version only after verified backups.
 migration_db="${TEST_ROOT}/migration.db"
 AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/null
-sqlite3 "$migration_db" "DROP TABLE issue_mappings; ALTER TABLE operations DROP COLUMN result_hash; ALTER TABLE restore_controls DROP COLUMN backup_high_water; UPDATE coordinator_meta SET value='1' WHERE key='schema_version'; UPDATE migration_history SET version=1 WHERE version=4;"
+sqlite3 "$migration_db" "DROP TABLE forge_event_deliveries; DROP TABLE forge_reconciliation_cursors; DROP TABLE issue_mappings; ALTER TABLE operations DROP COLUMN result_hash; ALTER TABLE restore_controls DROP COLUMN backup_high_water; UPDATE coordinator_meta SET value='1' WHERE key='schema_version'; UPDATE migration_history SET version=1 WHERE version=5;"
 AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/null
-[[ "$(sqlite3 "$migration_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "4" ]]
+[[ "$(sqlite3 "$migration_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "5" ]]
 [[ "$(sqlite3 "$migration_db" "SELECT COUNT(*) FROM pragma_table_info('operations') WHERE name='result_hash';")" == "1" ]]
 [[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v2.db)" ]]
 [[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v3.db)" ]]
@@ -124,11 +124,11 @@ AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/nu
 # An untouched v2 database is backed up before any v3 table is applied.
 v2_db="${TEST_ROOT}/v2.db"
 AIDEVOPS_TASK_COORDINATOR_DB="$v2_db" node "$COORDINATOR" status >/dev/null
-sqlite3 "$v2_db" "DROP TABLE issue_mappings; UPDATE coordinator_meta SET value='2' WHERE key='schema_version'; DELETE FROM migration_history WHERE version=4; INSERT OR IGNORE INTO migration_history VALUES(2,'2026-01-01T00:00:00Z',NULL,'ok');"
+sqlite3 "$v2_db" "DROP TABLE forge_event_deliveries; DROP TABLE forge_reconciliation_cursors; DROP TABLE issue_mappings; UPDATE coordinator_meta SET value='2' WHERE key='schema_version'; DELETE FROM migration_history WHERE version=5; INSERT OR IGNORE INTO migration_history VALUES(2,'2026-01-01T00:00:00Z',NULL,'ok');"
 AIDEVOPS_TASK_COORDINATOR_DB="$v2_db" node "$COORDINATOR" status >/dev/null
 v2_backup=$(ls "${TEST_ROOT}"/v2.db-backup-*-pre-migrate-v3.db)
 [[ "$(sqlite3 "$v2_backup" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='issue_mappings';")" == "0" ]]
-[[ "$(sqlite3 "$v2_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "4" ]]
+[[ "$(sqlite3 "$v2_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "5" ]]
 
 # Immutable task/repository identities isolate equal display numbers and allow
 # one task to retain home, implementation, and upstream issue projections.

--- a/.agents/templates/workflows/issue-sync-caller.yml
+++ b/.agents/templates/workflows/issue-sync-caller.yml
@@ -36,7 +36,7 @@ on:
   pull_request:
     types: [closed]
   issues:
-    types: [opened, closed]
+    types: [opened, edited, assigned, closed, reopened]
   workflow_dispatch:
     inputs:
       command:

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: 'main'
+      legacy_event_sync:
+        description: 'Emergency rollback: run checkout-based event synchronization'
+        required: false
+        type: boolean
+        default: false
       runner:
         description: 'Runner label override (e.g. ubicloud-standard-2). Defaults to ubuntu-latest.'
         required: false
@@ -33,9 +38,52 @@ on:
         description: 'Fine-grained PAT with Contents:read/write, bypasses branch protection on TODO.md push'
 
 jobs:
+  targeted-event:
+    name: Ingest targeted repository event
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'issues' ||
+      ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
+       github.event.pull_request.merged == true)
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 3
+    concurrency:
+      group: issue-sync-event-${{ github.repository_id }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      # Only framework code is checked out. The caller repository, its default
+      # branch, and human worktrees remain untouched by normal event handling.
+      - name: Checkout event ingestion helper
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: marcusquinn/aidevops
+          path: __aidevops
+          ref: ${{ inputs.aidevops_ref || 'main' }}
+          fetch-depth: 1
+
+      - name: Ingest mapped event and queue projection
+        env:
+          EVENT_ACTION: ${{ github.event.action || 'push' }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PATH: ${{ github.event_path }}
+          REPOSITORY_ID: ${{ github.event.repository.node_id || github.repository_id }}
+          REPOSITORY_PATH: ${{ github.workspace }}
+          REPOSITORY_SLUG: ${{ github.repository }}
+        run: |
+          node __aidevops/.agents/scripts/issue-sync-event-helper.mjs ingest \
+            --event-name "$EVENT_NAME" --action "$EVENT_ACTION" --event-file "$EVENT_PATH" \
+            --repository-id "$REPOSITORY_ID" --repository-slug "$REPOSITORY_SLUG" \
+            --repository-path "$REPOSITORY_PATH"
+
   sync-on-push:
     name: Sync TODO.md → GitHub Issues
-    if: github.event_name == 'push'
+    # Legacy bulk scan is an explicit rollback only. Normal push delivery is
+    # recorded by targeted-event without scanning every task.
+    if: github.event_name == 'push' && inputs.legacy_event_sync == true
     runs-on: ${{ inputs.runner }}
     # t2165: bumped 10 → 20 as an independent safety net alongside the
     # issue-sync-helper.sh enrich optimisation. At ~145 open ref:GH# tasks the
@@ -179,7 +227,9 @@ jobs:
 
   sync-on-issue:
     name: Sync GitHub Issue → TODO.md
-    if: github.event_name == 'issues'
+    # Superseded by targeted-event. Kept temporarily as rollback-readable code;
+    # it cannot execute during normal issue delivery.
+    if: github.event_name == 'issues' && inputs.legacy_event_sync == true
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     concurrency:
@@ -567,7 +617,12 @@ jobs:
   # hygiene treatment — previously only the TODO.md push path ran issue-sync.
   sync-on-pr-merge:
     name: Sync Issue Hygiene on PR Merge
-    if: (github.event_name == 'pull_request_target' || github.event_name == 'pull_request') && github.event.pull_request.merged == true
+    # Superseded by targeted-event. It remains available only as an explicit,
+    # non-advertised rollback path while coordinator event state rolls out.
+    if: >-
+      (github.event_name == 'pull_request_target' || github.event_name == 'pull_request') &&
+      github.event.pull_request.merged == true &&
+      inputs.legacy_event_sync == true
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     concurrency:

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -19,7 +19,7 @@ on:
     branches: [main]
     types: [closed, opened, edited]
   issues:
-    types: [opened, closed]
+    types: [opened, edited, assigned, closed, reopened]
   workflow_dispatch:
     inputs:
       command:


### PR DESCRIPTION
## Summary

- Add repository-scoped, cursor-ordered forge event ingestion to the task coordinator.
- Queue mapped task projections through the serialized publication outbox.
- Switch normal issue, push, and merged pull-request delivery to the targeted handler while retaining legacy bulk synchronization behind an explicit rollback gate.
- Add event fixtures covering duplicate, stale, edited, assigned, closed, reopened, merged, reconciliation, and cross-repository delivery.

## Runtime Testing

- **Risk level:** High (event state machine and workflow handler)
- **Verification:** focused event suite, coordinator recovery suite, workflow structure tests, ShellCheck, Node syntax checks

Resolves #27154


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.73 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 13m and 200,820 tokens on this as a headless worker.
