### PR TITLE
GH#27435: isolate merge GraphQL budget probe

### DIFF
--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -205,7 +205,13 @@ _pmr_graphql_remaining() {
 		printf '%s\n' "$remaining"
 		return 0
 	fi
-	remaining=$(_pmr_gh_read gh api rate_limit --jq '.resources.graphql.remaining // 0' 2>/dev/null) || remaining="0"
+	# Query the GraphQL budget through GraphQL itself. The REST /rate_limit
+	# endpoint consumes the independent core budget and returns 403 when core is
+	# exhausted, even while GraphQL still has capacity. Treating that failure as
+	# zero falsely disabled every standalone merge pass (GH#24904 regression).
+	remaining=$(_pmr_gh_read gh api graphql \
+		-f 'query=query { rateLimit { remaining } }' \
+		--jq '.data.rateLimit.remaining // 0' 2>/dev/null) || remaining="0"
 	[[ "$remaining" =~ ^[0-9]+$ ]] || remaining=0
 	printf '%s\n' "$remaining"
 	return 0

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -112,7 +112,10 @@ printf '\n=== Bootstrap tests (PULSE_START_EPOCH unset) ===\n'
 unset PULSE_START_EPOCH PULSE_MERGE_BATCH_LIMIT
 
 help_stderr=$(LC_ALL=C timeout 30 "$ROUTINE_FILE" --help 2>&1 >/dev/null) || true
-help_exit=$(LC_ALL=C timeout 30 "$ROUTINE_FILE" --help >/dev/null 2>&1; printf '%s' "$?")
+help_exit=$(
+	LC_ALL=C timeout 30 "$ROUTINE_FILE" --help >/dev/null 2>&1
+	printf '%s' "$?"
+)
 
 if [[ "$help_exit" == "0" ]]; then
 	pass "1: --help exits 0 with PULSE_START_EPOCH unset"

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -42,6 +42,7 @@
 #   10. merge LaunchAgent uses normal spawn priority with explicit KeepAlive=false
 #   11. standalone PATH repair keeps the framework gh shim first
 #   12. leading --repo defaults to the run subcommand (GH#25698)
+#   13. GraphQL budget probing does not depend on the REST core budget
 
 set -uo pipefail
 
@@ -327,6 +328,47 @@ if [[ "$parser_rc" -eq 0 ]]; then
 else
 	fail "12: leading --repo defaults to run subcommand" \
 		"harness rc=${parser_rc}, output=${parser_output}"
+fi
+
+printf '\n=== API budget isolation regression guard ===\n'
+
+BUDGET_HARNESS=$(mktemp "${TMPDIR:-/tmp}/pmr-budget-harness-XXXXXX")
+trap 'rm -f "$PARSER_HARNESS" "$BUDGET_HARNESS"' EXIT
+
+cat >"$BUDGET_HARNESS" <<'BUDGET_HARNESS_EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+
+gh() {
+	if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+		printf '700\n'
+		return 0
+	fi
+	return 22
+}
+
+# Extract the production read wrapper and budget probe without executing the
+# routine entry point. The mock deliberately rejects every non-GraphQL call.
+# shellcheck disable=SC1090
+source <(awk '
+	/^_pmr_gh_read\(\)/ { capture=1 }
+	capture { print }
+	capture && /^}/ { closures++; if (closures == 2) exit }
+' "$ROUTINE_FILE")
+
+unset AIDEVOPS_PULSE_GRAPHQL_BUDGET_REMAINING
+[[ "$(_pmr_graphql_remaining)" == "700" ]]
+BUDGET_HARNESS_EOF
+
+chmod +x "$BUDGET_HARNESS"
+budget_output=$(ROUTINE_FILE="$ROUTINE_FILE" bash "$BUDGET_HARNESS" 2>&1)
+budget_rc=$?
+
+if [[ "$budget_rc" -eq 0 ]]; then
+	pass "13: GraphQL budget probe is independent of REST core rate limit"
+else
+	fail "13: GraphQL budget probe is independent of REST core rate limit" \
+		"harness rc=${budget_rc}, output=${budget_output}"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- query GraphQL rate-limit capacity through GraphQL instead of REST core
- prevent REST core exhaustion from falsely reporting zero GraphQL capacity
- add a regression harness that rejects REST calls while returning GraphQL capacity

## Root cause

The standalone merge routine used the REST `/rate_limit` endpoint to discover GraphQL capacity. When REST core was exhausted, that endpoint returned 403; the routine converted the read failure to `0` and deferred every merge pass even though GraphQL still had capacity.

## Verification

- `bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh`
- `shellcheck .agents/scripts/pulse-merge-routine.sh .agents/scripts/tests/test-pulse-merge-routine-standalone.sh`

## Runtime Testing

Runtime-verified by deploying the changed helper, confirming the GraphQL query returned live capacity while REST core was exhausted, and observing the scheduled merge routine proceed past its budget gate.

Resolves #27435

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.72 plugin for [OpenCode](https://opencode.ai) v1.17.18
