### PR TITLE
For #27154: paginate REST issue-list fallback

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -1372,6 +1372,7 @@ _rest_issue_list() {
 	local state="open"
 	local limit=30
 	local jq_expr=""
+	local user_jq=""
 	local json_fields=""
 	local assignee=""
 	local -a labels
@@ -1402,13 +1403,18 @@ _rest_issue_list() {
 		*) shift ;;
 		esac
 	done
+	user_jq="$jq_expr"
 
 	if [[ -z "$repo" ]]; then
 		printf '_rest_issue_list: --repo is required\n' >&2
 		return 1
 	fi
 
-	local _query="state=${state}&per_page=${limit}"
+	local page_size="$limit"
+	if [[ "$page_size" -gt 100 ]]; then
+		page_size=100
+	fi
+	local _query="state=${state}&per_page=${page_size}"
 	if [[ ${#labels[@]} -gt 0 ]]; then
 		local _labels_encoded=""
 		local _label
@@ -1425,13 +1431,38 @@ _rest_issue_list() {
 		_query="${_query}&assignee=${_assignee_encoded}"
 	fi
 
-	local _path="/repos/${repo}/issues?${_query}"
-	local _gh_cmd=(gh api "$_path")
+	local page=1
+	local raw_page=""
+	local raw_count=0
+	local issue_count=0
+	local combined='[]'
+	while [[ "$issue_count" -lt "$limit" ]]; do
+		local _path="/repos/${repo}/issues?${_query}&page=${page}"
+		if ! raw_page=$(_rest_api_call read gh api "$_path"); then
+			return 1
+		fi
+		raw_count=$(printf '%s' "$raw_page" | jq 'length' 2>/dev/null) || return 1
+		combined=$(jq -cn --argjson prior "$combined" --argjson next "$raw_page" \
+			'$prior + [$next[] | select(.pull_request == null)]') || return 1
+		issue_count=$(printf '%s' "$combined" | jq 'length' 2>/dev/null) || return 1
+		if [[ "$raw_count" -lt "$page_size" ]]; then
+			break
+		fi
+		page=$((page + 1))
+	done
+
 	if [[ -n "$json_fields" ]]; then
-		jq_expr="$(_rest_issue_list_json_jq "$json_fields" "$jq_expr")"
+		jq_expr="$(_rest_issue_list_json_jq "$json_fields" "")"
+	else
+		jq_expr='[.[] | select(.pull_request == null)]'
 	fi
-	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
-	_rest_api_call read "${_gh_cmd[@]}"
+	local result=""
+	result=$(printf '%s' "$combined" | jq -c "${jq_expr} | .[:${limit}]") || return 1
+	if [[ -n "$user_jq" ]]; then
+		printf '%s' "$result" | jq -r "$user_jq"
+	else
+		printf '%s\n' "$result"
+	fi
 	return $?
 }
 

--- a/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
@@ -102,6 +102,24 @@ export -f print_info print_warning print_error print_success log_verbose
 export AIDEVOPS_SESSION_ORIGIN=interactive
 export AIDEVOPS_SESSION_USER=testuser
 
+stub_rest_list_result() {
+	local path="$1"
+	if [[ "${STUB_REST_PAGINATED:-0}" == "1" && "$path" == *"page=1" ]]; then
+		jq -cn '[range(1; 101) | {number:., title:"PR", pull_request:{url:"stub"}}]'
+		return 0
+	fi
+	if [[ "${STUB_REST_PAGINATED:-0}" == "1" ]]; then
+		printf '%s\n' '[{"number":27154,"title":"Blocked issue","labels":[]}]'
+		return 0
+	fi
+	if [[ -n "${STUB_REST_LIST_RESULT:-}" ]]; then
+		printf '%s\n' "$STUB_REST_LIST_RESULT"
+		return 0
+	fi
+	printf '%s\n' '[{"number":1,"title":"Issue one","labels":[]},{"number":2,"title":"Issue two","labels":[]}]'
+	return 0
+}
+
 # shellcheck source=../shared-constants.sh
 source "${SCRIPTS_DIR}/shared-constants.sh" >/dev/null 2>&1 || true
 
@@ -163,17 +181,8 @@ gh() {
 			fi
 			_i=$((_i + 1))
 		done
-		local _result='[{"number":1,"title":"Issue one","labels":[]},{"number":2,"title":"Issue two","labels":[]}]'
-		if [[ -n "${STUB_REST_LIST_RESULT:-}" ]]; then
-			_result="$STUB_REST_LIST_RESULT"
-		fi
-		if [[ "${STUB_REST_PAGINATED:-0}" == "1" ]]; then
-			if [[ "$2" == *"page=1" ]]; then
-				_result=$(jq -cn '[range(1; 101) | {number:., title:"PR", pull_request:{url:"stub"}}]')
-			else
-				_result='[{"number":27154,"title":"Blocked issue","labels":[]}]'
-			fi
-		fi
+		local _result=""
+		_result=$(stub_rest_list_result "$2")
 		if [[ -n "$_jq_expr" ]]; then
 			printf '%s\n' "$_result" | jq -r "$_jq_expr" 2>/dev/null
 		else

--- a/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
@@ -163,7 +163,17 @@ gh() {
 			fi
 			_i=$((_i + 1))
 		done
-		local _result="${STUB_REST_LIST_RESULT:-[{\"number\":1,\"title\":\"Issue one\",\"labels\":[]},{\"number\":2,\"title\":\"Issue two\",\"labels\":[]}]}"
+		local _result='[{"number":1,"title":"Issue one","labels":[]},{"number":2,"title":"Issue two","labels":[]}]'
+		if [[ -n "${STUB_REST_LIST_RESULT:-}" ]]; then
+			_result="$STUB_REST_LIST_RESULT"
+		fi
+		if [[ "${STUB_REST_PAGINATED:-0}" == "1" ]]; then
+			if [[ "$2" == *"page=1" ]]; then
+				_result=$(jq -cn '[range(1; 101) | {number:., title:"PR", pull_request:{url:"stub"}}]')
+			else
+				_result='[{"number":27154,"title":"Blocked issue","labels":[]}]'
+			fi
+		fi
 		if [[ -n "$_jq_expr" ]]; then
 			printf '%s\n' "$_result" | jq -r "$_jq_expr" 2>/dev/null
 		else
@@ -313,7 +323,7 @@ fi
 
 _rest_issue_list --repo "owner/repo" --label "supervisor" --label "alice" >/dev/null 2>&1 || true
 
-if grep -qE 'labels=supervisor,alice' "$GH_CALLS" 2>/dev/null; then
+if grep -qE 'labels=supervisor(%2C|,)alice' "$GH_CALLS" 2>/dev/null; then
 	pass "_rest_issue_list joins multiple --label flags as comma-separated"
 else
 	fail "_rest_issue_list joins multiple --label flags as comma-separated" \
@@ -353,7 +363,23 @@ fi
 unset STUB_REST_LIST_RESULT
 
 # =============================================================================
-# Test 10: _rest_issue_list includes --assignee in query string
+# Test 10: _rest_issue_list paginates beyond a PR-only first REST page
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_REST_PAGINATED=1
+
+result=$(_rest_issue_list --repo "owner/repo" --state all --limit 500 --json number --jq 'map(.number) | join(",")' 2>/dev/null)
+
+if [[ "$result" == "27154" ]] && grep -q 'page=2' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list paginates past PR-only REST pages"
+else
+	fail "_rest_issue_list paginates past PR-only REST pages" \
+		"expected issue 27154 from page 2; got '${result}'; calls=$(cat "$GH_CALLS")"
+fi
+unset STUB_REST_PAGINATED
+
+# =============================================================================
+# Test 11: _rest_issue_list includes --assignee in query string
 # =============================================================================
 : >"$GH_CALLS"
 


### PR DESCRIPTION
## Summary

- paginate the REST issue-list fallback rather than relying on GitHub's 100-item page cap
- filter pull requests on every page and stop after the requested issue count or repository end
- cover dependency-cache retrieval when the first REST page contains only pull requests

For #27154

## Testing

- `.agents/scripts/linters-local.sh`
- `shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh .agents/scripts/tests/test-gh-issue-read-rest-fallback.sh`
- `bash .agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh`
- `bash .agents/scripts/tests/test-pulse-dep-graph-todo-drift.sh`
- pagination-specific assertions in `test-gh-issue-read-rest-fallback.sh` pass; six pre-existing routing assertions remain environment-sensitive while the host is in REST-first cooldown

## Runtime Testing

- runtime-verified through the REST pagination fixture reproducing a PR-only first page and issue #27154 on page 2

## Key decision

- keep the correction in the shared REST fallback so every high-limit issue-list caller receives complete issue-only results

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.73 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2h 29m and 1,098,414 tokens on this with the user in an interactive session.
