### PR TITLE
GH#27430: cache dependency repository identity

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -29,6 +29,8 @@ _PULSE_DEP_GRAPH_LOADED=1
 [[ -n "${DEP_CACHE_EMPTY_JSON+x}" ]] || DEP_CACHE_EMPTY_JSON='{"use_cache":false,"open_issues":[],"task_to_issue":{}}'
 [[ -n "${DEP_AVAILABLE_STATUS+x}" ]] || DEP_AVAILABLE_STATUS="status:available"
 [[ -n "${DEP_JQ_NONEMPTY_LINES+x}" ]] || DEP_JQ_NONEMPTY_LINES='split("\n") | map(select(length > 0))'
+[[ -n "${_DEP_CACHED_REPO_SLUG+x}" ]] || _DEP_CACHED_REPO_SLUG=""
+[[ -n "${_DEP_CACHED_REPO_ID+x}" ]] || _DEP_CACHED_REPO_ID=""
 
 _pulse_dep_graph_dir="${BASH_SOURCE[0]%/*}"
 [[ "$_pulse_dep_graph_dir" == "${BASH_SOURCE[0]}" ]] && _pulse_dep_graph_dir="."
@@ -550,11 +552,20 @@ _dep_validate_issue_target() {
 	local issue_num="$2"
 	local repository_id="" issue_json="" resolved_num="" issue_id=""
 	[[ "$slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ && "$issue_num" =~ ^[1-9][0-9]*$ ]] || return 1
-	repository_id=$(gh api "repos/${slug}" --jq '.node_id' 2>/dev/null || true)
-	[[ -n "$repository_id" && "$repository_id" != "null" ]] || return 1
+	if [[ "$_DEP_CACHED_REPO_SLUG" == "$slug" && -n "$_DEP_CACHED_REPO_ID" ]]; then
+		repository_id="$_DEP_CACHED_REPO_ID"
+	else
+		repository_id=$(gh api "repos/${slug}" --jq '.node_id // ""' || true)
+		if [[ -n "$repository_id" ]]; then
+			_DEP_CACHED_REPO_SLUG="$slug"
+			_DEP_CACHED_REPO_ID="$repository_id"
+		fi
+	fi
+	[[ -n "$repository_id" ]] || return 1
 	issue_json=$(gh issue view "$issue_num" --repo "$slug" --json id,number 2>/dev/null || true)
-	resolved_num=$(printf '%s' "$issue_json" | jq -r '.number // empty' 2>/dev/null)
-	issue_id=$(printf '%s' "$issue_json" | jq -r '.id // empty' 2>/dev/null)
+	IFS=$'\t' read -r resolved_num issue_id < <(
+		printf '%s' "$issue_json" | jq -r '[.number // "", .id // ""] | @tsv'
+	)
 	[[ "$resolved_num" == "$issue_num" && -n "$issue_id" ]]
 	return $?
 }

--- a/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
@@ -63,6 +63,7 @@ gh() {
 	local top_command="${1:-}"
 	shift || true
 	if [[ "$top_command" == "api" && "${1:-}" == "repos/example/repo" ]]; then
+		printf 'api %s\n' "$*" >>"$GH_LOG"
 		printf '%s\n' R_example
 		return 0
 	fi
@@ -104,6 +105,20 @@ test_unvalidated_repository_fails_closed() {
 	else
 		print_result "unvalidated dependency repository fails closed" 0
 	fi
+	return 0
+}
+
+test_repository_identity_is_cached() {
+	local api_calls=0 line=""
+	_DEP_CACHED_REPO_SLUG=""
+	_DEP_CACHED_REPO_ID=""
+	reset_logs
+	_dep_validate_issue_target "example/repo" "3"
+	_dep_validate_issue_target "example/repo" "4"
+	while IFS= read -r line; do
+		[[ "$line" == api\ * ]] && api_calls=$((api_calls + 1))
+	done <"$GH_LOG"
+	[[ "$api_calls" -eq 1 ]] && print_result "repository identity is cached" 0 || print_result "repository identity is cached" 1 "expected 1 API call; got ${api_calls}"
 	return 0
 }
 
@@ -206,6 +221,7 @@ source "$DEP_GRAPH"
 
 test_label_only_blocker_enters_graph
 test_unvalidated_repository_fails_closed
+test_repository_identity_is_cached
 test_available_issue_stale_label_removed
 test_blocked_issue_label_removed_and_status_available
 test_defer_marker_preserves_label


### PR DESCRIPTION
## Summary

- Cache successful repository node identity lookups during dependency target validation.
- Parse issue number and node ID with one jq process while preserving fail-closed checks.
- Add regression coverage proving repeated validations use one repository API call.

## Testing

- `bash .agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh`
- `shellcheck .agents/scripts/pulse-dep-graph.sh .agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh`

## Runtime Testing

Self-assessed: low-risk shell optimization with mocked API regression coverage.

Resolves #27430

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.73 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 53,100 tokens on this as a headless worker. Overall, 15m since this issue was created.
