### PR TITLE
GH#27155: enforce read-only canonical automation

### DIFF
--- a/.agents/scripts/onboarding-helper.sh
+++ b/.agents/scripts/onboarding-helper.sh
@@ -507,8 +507,8 @@ configure_dirs() {
 	echo -e "${BLUE}Configure Git Parent Directories for Repo Sync${NC}"
 	echo "================================================"
 	echo ""
-	echo "Repo sync scans parent directories for git repos and runs"
-	echo "git pull --ff-only daily on clean repos on their default branch."
+	echo "Repo sync scans parent directories and reports remote drift daily"
+	echo "without modifying human canonical checkouts."
 	echo ""
 
 	if ! command -v jq &>/dev/null; then

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -16,12 +16,11 @@
 #
 # Main-branch write protection (t1712):
 #   Pass --file <path> for path-based enforcement (preferred).
-#   Allowlisted paths (writable on main without a worktree): README.md, TODO.md, todo/**
-#   All other paths require a linked worktree.
+#   Every path on canonical main/master requires a linked worktree.
 #   --task description heuristics are a fallback when --file is not provided.
 #
 # Exit codes:
-#   0 - OK to proceed (in a linked worktree, or allowlisted path on main)
+#   0 - OK to proceed (in a linked worktree)
 #   1 - STOP (on protected main/master, interactive mode)
 #   2 - Create worktree (loop mode detected non-allowlisted path on main)
 #   3 - Reserved legacy code (canonical invalid states now block)
@@ -57,9 +56,8 @@ source "${SCRIPT_DIR}/task-identity-lib.sh"
 # =============================================================================
 # Loop Mode Support
 # =============================================================================
-# When --loop-mode is passed, the script auto-decides based on file path or task description:
-# - Allowlisted paths (README.md, TODO.md, todo/**) -> stay on main (exit 0)
-# - All other paths -> signal worktree needed (exit 2)
+# When --loop-mode is passed on canonical main/master, the script creates or
+# requests a linked worktree for every edit.
 #
 # Pass --file <path> for path-based enforcement (preferred, harder to bypass).
 # Fall back to --task description heuristics only when no --file is provided.
@@ -164,76 +162,11 @@ PYEOF
 # Canonicalizes the path to a repo-relative form before evaluating the allowlist,
 # preventing path traversal bypasses (e.g. todo/../secret.py).
 #
-# t1990: Interactive sessions have NO main-branch planning exception — every
-# edit on main (including TODO.md, todo/**, README.md) requires a linked
-# worktree. Headless sessions (pulse, CI workers, routines) keep the
-# allowlist so they can continue to write routine state and dispatch
-# bookkeeping directly on main without PR ceremony.
-#
-# Session-origin detection is inlined here (rather than calling
-# detect_session_origin from shared-constants.sh) to avoid any source-order
-# dependency — this function may be called before shared-constants.sh is
-# sourced in the execution flow.
+# Canonical checkouts are read-only to automation. Historical planning and
+# issue-sync allowlists are intentionally retained nowhere.
 is_main_allowlisted_path() {
 	local file_path="$1"
-
-	# t1990: short-circuit FALSE for interactive sessions. A session is
-	# interactive unless one of the known headless env vars is set. This
-	# mirrors detect_session_origin() in shared-constants.sh — keep in sync.
-	if [[ "${FULL_LOOP_HEADLESS:-}" != "true" ]] &&
-		[[ "${AIDEVOPS_HEADLESS:-}" != "true" ]] &&
-		[[ "${OPENCODE_HEADLESS:-}" != "true" ]] &&
-		[[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
-		# Interactive session: no allowlist, always require a worktree.
-		return 1
-	fi
-
-	# Resolve repo root for canonicalization
-	local repo_root
-	repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
-
-	local normalised
-	if [[ -n "$repo_root" ]]; then
-		# Canonicalize: resolve ./ and ../ segments, reject paths outside repo root
-		normalised="$(_canonicalize_repo_relative_path "$file_path" "$repo_root")"
-		# Reject paths that escape the repo root
-		if [[ "$normalised" == "OUTSIDE_REPO" ]]; then
-			return 1
-		fi
-	else
-		# No git repo context: fall back to simple normalization
-		# Strip leading ./ to get a repo-relative path
-		normalised=$(echo "$file_path" | sed 's|^\./||')
-
-		# Reject path traversal: any path containing .. segments is not allowlisted.
-		case "$normalised" in
-		*..*)
-			return 1
-			;;
-		esac
-
-		# Reject absolute paths
-		case "$normalised" in
-		/*)
-			return 1
-			;;
-		esac
-	fi
-
-	# Exact matches
-	case "$normalised" in
-	README.md | TODO.md)
-		return 0
-		;;
-	esac
-
-	# Prefix matches (todo/ subtree)
-	case "$normalised" in
-	todo/*)
-		return 0
-		;;
-	esac
-
+	: "$file_path"
 	return 1
 }
 
@@ -304,13 +237,7 @@ is_docs_only() {
 # Unified main-branch write check: path-based when --file provided, else task heuristic.
 # Returns: 0 if write is allowed on main, 1 if worktree required
 is_main_write_allowed() {
-	if [[ -n "$TARGET_FILE" ]]; then
-		is_main_allowlisted_path "$TARGET_FILE"
-		return $?
-	fi
-	# Fallback: task-description heuristic (backward compat)
-	is_docs_only "$TASK_DESC"
-	return $?
+	return 1
 }
 
 # =============================================================================
@@ -492,16 +419,6 @@ _is_explicit_headless_flow() {
 
 _handle_loop_mode_on_protected() {
 	local branch="$1"
-
-	if _is_explicit_headless_flow && is_main_write_allowed; then
-		if [[ -n "$TARGET_FILE" ]]; then
-			echo -e "${YELLOW}LOOP-AUTO${NC}: Allowlisted path '$TARGET_FILE', staying on $branch"
-		else
-			echo -e "${YELLOW}LOOP-AUTO${NC}: Docs-only task detected, staying on $branch"
-		fi
-		echo "LOOP_DECISION=stay"
-		exit 0
-	fi
 
 	if [[ -n "$TARGET_FILE" ]] && is_unsafe_main_target_path "$TARGET_FILE"; then
 		echo -e "${RED}BLOCKED${NC}: unsafe target path '$TARGET_FILE' on protected '$branch'"
@@ -726,14 +643,6 @@ fi
 if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
 	# Loop mode: auto-decide based on file path (preferred) or task description
 	[[ "$LOOP_MODE" == "true" ]] && _handle_loop_mode_on_protected "$current_branch"
-
-	# Short-circuit only for explicitly identified headless bookkeeping flows.
-	# Interactive sessions never gain a canonical write exemption (t1712).
-	if _is_explicit_headless_flow && [[ -n "$TARGET_FILE" ]] && is_main_allowlisted_path "$TARGET_FILE"; then
-		echo -e "${GREEN}OK${NC} - Allowlisted path '$TARGET_FILE' on $current_branch"
-		echo "MAIN_ALLOWLISTED=true"
-		exit 0
-	fi
 
 	# Detect headless mode (GH#4400): workers dispatched without --loop-mode
 	# get the interactive prompt and loop forever trying to edit. Detect

--- a/.agents/scripts/pulse-canonical-maintenance.sh
+++ b/.agents/scripts/pulse-canonical-maintenance.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# pulse-canonical-maintenance.sh — Periodic canonical-repo fast-forward and stale worktree sweep.
+# pulse-canonical-maintenance.sh — Periodic canonical diagnostics and stale worktree sweep.
 #
 # GH#19949: consolidated pulse stage combining two housekeeping tasks:
-#   1. Fast-forward canonical repos to origin/main (avoids stale main)
+#   1. Diagnose canonical repos that differ from origin/main without modifying them
 #   2. Sweep stale worktrees whose branches are merged or PRs are closed
 #
 # Cadence: ~30 min (1800s), not per-cycle. Both operations are deterministic
@@ -230,46 +230,30 @@ _canonical_ff_single_repo() {
 		return 1
 	fi
 
-	# Fetch origin
+	# Human canonical checkouts are diagnostic-only. Query the remote without
+	# updating refs, HEAD, index, tracked files, or untracked files.
 	if [[ "$dry_run" == "1" ]]; then
-		echo "[DRY_RUN] Would fetch origin for ${repo_path}"
+		echo "[DRY_RUN] Would diagnose origin for ${repo_path}"
 	else
-		_canonical_maintenance_run_with_timeout "$CANONICAL_MAINTENANCE_TIMEOUT" git -C "$repo_path" fetch origin --prune --quiet 2>/dev/null || {
-			echo "[pulse-canonical-maintenance] Fetch failed/timed out for ${repo_path}" >>"${LOGFILE:-/dev/null}"
+		local remote_sha=""
+		remote_sha=$(_canonical_maintenance_run_with_timeout "$CANONICAL_MAINTENANCE_TIMEOUT" git -C "$repo_path" ls-remote origin "refs/heads/${main_branch}" 2>/dev/null | awk 'NR == 1 {print $1}') || {
+			echo "[pulse-canonical-maintenance] Remote diagnostic failed/timed out for ${repo_path}" >>"${LOGFILE:-/dev/null}"
 			return 1
 		}
-		# Verify the remote ref exists after fetch — guard against repos where
-		# origin/<branch> was never fetched or the remote branch was renamed.
-		# Without this, rev-list below emits `fatal: ambiguous argument` to stderr.
-		if ! git -C "$repo_path" rev-parse --verify "origin/${main_branch}" >/dev/null 2>&1; then
-			echo "[pulse-canonical-maintenance] Skipping ${repo_path} — origin/${main_branch} not found after fetch" >>"${LOGFILE:-/dev/null}"
+		if [[ -z "$remote_sha" ]]; then
+			echo "[pulse-canonical-maintenance] Skipping ${repo_path} — remote ${main_branch} not found" >>"${LOGFILE:-/dev/null}"
 			return 1
 		fi
-	fi
-
-	# Check commits behind
-	local behind_count=0
-	behind_count=$(git -C "$repo_path" rev-list --count "HEAD..origin/${main_branch}" 2>/dev/null) || behind_count=0
-	[[ "$behind_count" =~ ^[0-9]+$ ]] || behind_count=0
-	if [[ "$behind_count" -eq 0 ]]; then
-		echo "[pulse-canonical-maintenance] ${repo_path} — already up to date" >>"${LOGFILE:-/dev/null}"
-		return 1
-	fi
-
-	# Fast-forward
-	if [[ "$dry_run" == "1" ]]; then
-		echo "[DRY_RUN] Would fast-forward ${repo_path} (${behind_count} commits behind)"
+		local local_sha=""
+		local_sha=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null || true)
+		if [[ "$local_sha" == "$remote_sha" ]]; then
+			echo "[pulse-canonical-maintenance] ${repo_path} — already up to date" >>"${LOGFILE:-/dev/null}"
+			return 1
+		fi
+		echo "[pulse-canonical-maintenance] Diagnostic: ${repo_path} differs from origin/${main_branch}; human checkout left unchanged" >>"${LOGFILE:-/dev/null}"
 		return 0
 	fi
-
-	if _canonical_maintenance_run_with_timeout "$CANONICAL_MAINTENANCE_TIMEOUT" git -C "$repo_path" pull --ff-only "origin" "$main_branch" 2>/dev/null; then
-		echo "[pulse-canonical-maintenance] Fast-forwarded ${repo_path} by ${behind_count} commits" >>"${LOGFILE:-/dev/null}"
-		_canonical_maintenance_audit_log "canonical-maintenance: fast-forwarded ${repo_path} by ${behind_count} commits"
-		return 0
-	fi
-
-	echo "[pulse-canonical-maintenance] Fast-forward failed for ${repo_path} (non-ff divergence?)" >>"${LOGFILE:-/dev/null}"
-	return 1
+	return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -303,7 +287,7 @@ _canonical_fast_forward() {
 		fi
 	done
 
-	echo "[pulse-canonical-maintenance] Fast-forward pass: ${ff_count} repos updated, ${skip_count} skipped" >>"${LOGFILE:-/dev/null}"
+	echo "[pulse-canonical-maintenance] Diagnostic pass: ${ff_count} repos stale/diverged, ${skip_count} skipped" >>"${LOGFILE:-/dev/null}"
 	return 0
 }
 

--- a/.agents/scripts/pulse-canonical-recovery.sh
+++ b/.agents/scripts/pulse-canonical-recovery.sh
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# pulse-canonical-recovery.sh — auto-recover canonical worktree from pull
-# conflicts (t2865, GH#20922).
+# pulse-canonical-recovery.sh — diagnose canonical worktree conflicts.
 #
-# When pulse calls `git pull --ff-only` on a canonical repo path, two failure
-# modes leave that repo silently un-refreshed:
+# Pulse may observe two canonical states that require human review:
 #
 #   1. Unmerged files: `error: Pulling is not possible because you have
 #      unmerged files` — usually leftover `UU` state from a prior crash or
-#      mid-rebase abort.
-#   2. Local uncommitted changes: `error: Your local changes to the following
-#      files would be overwritten by merge` — typically a concurrent
-#      issue-sync push that left TODO.md modified vs origin during a rebase.
+#      an interrupted human Git operation.
+#   2. Local uncommitted changes, including human work or stale generated
+#      metadata from an older writer.
 #
-# Recovery strategy: optionally `git merge --abort` (for unmerged state) →
-# stash → retry pull → pop. Stash-and-pop is content-safe (no `-X theirs`
-# auto-resolve). On persistent failure, write a LOCAL advisory file
+# Recovery is diagnostic-only for human canonical checkouts. It never changes
+# HEAD, refs, the index, tracked files, untracked files, or stashes. On dirty
+# state, write a LOCAL advisory file
 # (`~/.aidevops/advisories/canonical-recovery-<basename>.advisory`) with
 # the exact remediation commands the user can run. The local file is
 # surfaced in the session-start greeting via aidevops-update-check.sh —
@@ -184,135 +181,6 @@ _pcr_detect_state() {
 	return 0
 }
 
-_pcr_only_todo_dirty() {
-	local repo_path="$1"
-	local status_line path
-	while IFS= read -r status_line; do
-		[[ -n "$status_line" ]] || continue
-		path="${status_line#?? }"
-		case "$path" in
-			TODO.md)
-				;;
-			*)
-				return 1
-				;;
-		esac
-	done < <(git -C "$repo_path" status --porcelain --untracked-files=all 2>/dev/null)
-	return 0
-}
-
-_pcr_normalise_todo_sync_line() {
-	local line="$1"
-	local normalised="$line"
-	local field=""
-
-	case "$normalised" in
-		'- [ ] '*) normalised="- [?] ${normalised#'- [ ] '}" ;;
-		'- [x] '*) normalised="- [?] ${normalised#'- [x] '}" ;;
-		'- [X] '*) normalised="- [?] ${normalised#'- [X] '}" ;;
-	esac
-
-	for field in assignee started completed logged pr actual dispatched origin status; do
-		while [[ "$normalised" =~ ^(.*)[[:space:]]${field}:[^[:space:]]+(.*)$ ]]; do
-			normalised="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
-		done
-	done
-
-	# Keep this hot-path normalisation pure Bash: TODO sync diffs can contain
-	# many task lines, and spawning sed/awk here would multiply process churn.
-	normalised="${normalised//$'\t'/ }"
-	while [[ "$normalised" == *"  "* ]]; do
-		normalised="${normalised//  / }"
-	done
-	while [[ "$normalised" == " "* ]]; do
-		normalised="${normalised# }"
-	done
-	while [[ "$normalised" == *" " ]]; do
-		normalised="${normalised% }"
-	done
-
-	printf '%s\n' "$normalised"
-	return 0
-}
-
-_pcr_todo_line_is_task() {
-	local line="$1"
-	if [[ "$line" =~ ^-\ \[[xX\ ]\]\ [tr][0-9] ]]; then
-		return 0
-	fi
-	return 1
-}
-
-_pcr_todo_diff_is_generated_sync() {
-	local repo_path="$1"
-	local old_tmp new_tmp diff_line content saw_change=0 ok=1
-	old_tmp=$(mktemp "${TMPDIR:-/tmp}/pcr-todo-old.XXXXXX") || return 1
-	new_tmp=$(mktemp "${TMPDIR:-/tmp}/pcr-todo-new.XXXXXX") || { rm -f "$old_tmp"; return 1; }
-
-	while IFS= read -r diff_line; do
-		case "$diff_line" in
-			---*|+++*|@@*)
-				continue
-				;;
-			-*)
-				content="${diff_line#-}"
-				if ! _pcr_todo_line_is_task "$content"; then
-					ok=0
-					break
-				fi
-				_pcr_normalise_todo_sync_line "$content" >>"$old_tmp"
-				saw_change=1
-				;;
-			+*)
-				content="${diff_line#+}"
-				if ! _pcr_todo_line_is_task "$content"; then
-					ok=0
-					break
-				fi
-				_pcr_normalise_todo_sync_line "$content" >>"$new_tmp"
-				saw_change=1
-				;;
-		esac
-	done < <({ git -C "$repo_path" diff -- TODO.md; git -C "$repo_path" diff --cached -- TODO.md; } 2>/dev/null)
-
-	if [[ "$ok" -eq 1 && "$saw_change" -eq 1 ]] && cmp -s "$old_tmp" "$new_tmp"; then
-		rm -f "$old_tmp" "$new_tmp"
-		return 0
-	fi
-	rm -f "$old_tmp" "$new_tmp"
-	return 1
-}
-
-_pcr_recover_todo_sync_dirty_state() {
-	local repo_path="$1"
-	if ! _pcr_only_todo_dirty "$repo_path"; then
-		return 1
-	fi
-	if ! _pcr_todo_diff_is_generated_sync "$repo_path"; then
-		_pcr_audit "todo-dirty-blocked" "$repo_path" "advisory:human-or-unknown"
-		_pcr_log "TODO.md is dirty but does not match generated sync metadata — filing advisory without stashing"
-		_pcr_file_advisory "$repo_path" "todo-dirty-blocked"
-		return 2
-	fi
-
-	_pcr_audit "todo-sync-reset" "$repo_path" "ok:generated-metadata-only"
-	_pcr_log "discarding generated TODO.md sync metadata before canonical refresh"
-	if ! git -C "$repo_path" reset -q -- TODO.md || ! git -C "$repo_path" checkout -- TODO.md; then
-		_pcr_audit "todo-sync-reset-failed" "$repo_path" "advisory:reset-failed"
-		_pcr_log "failed to reset TODO.md sync metadata — filing advisory"
-		_pcr_file_advisory "$repo_path" "todo-sync-reset-failed"
-		return 2
-	fi
-	if git -C "$repo_path" fetch --quiet origin >>"${LOGFILE:-/dev/null}" 2>&1 \
-		&& git -C "$repo_path" pull --ff-only --no-rebase >>"${LOGFILE:-/dev/null}" 2>&1; then
-		_pcr_audit "todo-sync-refresh" "$repo_path" "ok:no-stash"
-		return 0
-	fi
-	_pcr_audit "todo-sync-refresh-failed" "$repo_path" "advisory:no-stash"
-	_pcr_file_advisory "$repo_path" "todo-sync-refresh-failed"
-	return 2
-}
-
 # Count attempts in the hot window for this repo. Echoes integer.
 # When jq is missing, returns MAX_ATTEMPTS so the caller's threshold check
 # trips and we escalate straight to advisory rather than silently looping
@@ -460,36 +328,24 @@ _pcr_advisory_body() {
 	local sanitised
 	sanitised=$(_pcr_sanitise_path "$repo_path")
 	cat <<EOF
-[CANONICAL RECOVERY] ${repo_basename} stash conflict — manual intervention required
+[CANONICAL DIAGNOSTIC] ${repo_basename} requires manual review
 
-  Pulse cannot \`git pull --ff-only\` your canonical repo at:
+  Pulse found a human canonical checkout requiring review at:
       ${sanitised}
 
   Failure mode: ${failure_mode}
   Effect:       PR processing, CI failure routing, and completion sweep are
                 paused for this repo until the working tree is clean.
 
-  Recovery commands (run in a SEPARATE terminal, not in AI chat):
+  Inspection (run in a SEPARATE terminal, not in AI chat):
 
     cd ${sanitised}
     git status
-    # If you see UU/AA/DD entries (unmerged):
-    git merge --abort 2>/dev/null || true
+    git diff
+    git diff --cached
+    git ls-files --others --exclude-standard
 
-    # Inspect the auto-stash if one was retained:
-    git stash list | grep pulse-auto-stash
-
-    # Restore the stash (resolve conflicts if any):
-    git stash pop          # or: git stash drop  (if the stash content is obsolete)
-
-    # Then refresh:
-    git fetch origin
-    git pull --ff-only
-
-  Acceptance:
-  - \`git status\` shows nothing to commit, working tree clean
-  - \`git pull --ff-only\` succeeds without intervention
-  - Pulse resumes processing PRs/issues for this repo on the next cycle
+  Resolve or preserve this state manually. Pulse will not mutate this checkout.
 
   Dismiss after fixing:  aidevops security dismiss canonical-recovery-${repo_basename}
 EOF
@@ -568,108 +424,6 @@ _pcr_hot_loop_guard_allows_recovery() {
 	return 0
 }
 
-_pcr_try_todo_sync_recovery() {
-	local repo_path="$1"
-	local todo_recovery_rc=0
-	_pcr_recover_todo_sync_dirty_state "$repo_path"
-	todo_recovery_rc=$?
-	case "$todo_recovery_rc" in
-		0)
-			return 0
-			;;
-		2)
-			return 2
-			;;
-	esac
-	return 1
-}
-
-_pcr_has_active_git_operation() {
-	local repo_path="$1"
-	if [[ -e "${repo_path}/.git/MERGE_HEAD" \
-	   || -e "${repo_path}/.git/CHERRY_PICK_HEAD" \
-	   || -e "${repo_path}/.git/REBASE_HEAD" ]]; then
-		return 0
-	fi
-	return 1
-}
-
-_pcr_clear_stale_unmerged_state() {
-	local repo_path="$1"
-	_pcr_log "stale-UU detected (no active merge/cherry-pick/rebase) for $repo_path"
-	_pcr_audit "stale-uu-detect" "$repo_path" "attempting"
-	# merge --abort is a no-op without an active merge but is safe to try — it
-	# may succeed in edge cases where the HEAD file was manually removed. If it
-	# fails, reset --merge HEAD is the definitive fix for stale index conflict
-	# entries.
-	git -C "$repo_path" merge --abort 2>/dev/null \
-		|| git -C "$repo_path" reset --merge HEAD 2>/dev/null \
-		|| true
-	return 0
-}
-
-_pcr_clear_unmerged_state() {
-	local repo_path="$1"
-	local is_stale_uu=0
-	local state=""
-
-	if ! _pcr_has_active_git_operation "$repo_path"; then
-		is_stale_uu=1
-		_pcr_clear_stale_unmerged_state "$repo_path"
-	else
-		# Active merge / cherry-pick / rebase — abort it cleanly.
-		git -C "$repo_path" merge --abort 2>/dev/null || true
-	fi
-
-	state=$(_pcr_detect_state "$repo_path")
-	if [[ "$state" == "clean" ]]; then
-		if [[ "$is_stale_uu" -eq 1 ]]; then
-			_pcr_audit "stale-uu-recover" "$repo_path" "ok:index-reset"
-			_pcr_log "stale-UU cleared via index reset for $repo_path"
-		else
-			_pcr_audit "merge-abort" "$repo_path" "success"
-			_pcr_log "merge --abort cleaned working tree for $repo_path"
-		fi
-		return 0
-	fi
-	return 1
-}
-
-_pcr_stash_refresh_pop() {
-	local repo_path="$1"
-	local stash_message
-	stash_message="pulse-auto-stash-$(date +%s)"
-	if ! git -C "$repo_path" stash push -u -m "$stash_message" >>"${LOGFILE:-/dev/null}" 2>&1; then
-		_pcr_audit "stash-push-failed" "$repo_path" "advisory"
-		_pcr_log "git stash push failed; filing advisory"
-		_pcr_file_advisory "$repo_path" "stash-push-failed"
-		return 1
-	fi
-	_pcr_log "stashed: ${stash_message}"
-	_pcr_audit "stash-push" "$repo_path" "ok:${stash_message}"
-
-	if ! git -C "$repo_path" fetch --quiet origin >>"${LOGFILE:-/dev/null}" 2>&1 \
-		|| ! git -C "$repo_path" pull --ff-only --no-rebase >>"${LOGFILE:-/dev/null}" 2>&1; then
-		# Pull still failed after stashing — leave stash for content safety.
-		_pcr_audit "pull-failed-after-stash" "$repo_path" "advisory:stash-retained:${stash_message}"
-		_pcr_log "pull --ff-only failed after stash — stash retained, filing advisory"
-		_pcr_file_advisory "$repo_path" "pull-failed-after-stash"
-		return 1
-	fi
-
-	# Pop the stash. Conflict on pop → leave stash + advise.
-	if ! git -C "$repo_path" stash pop --quiet >>"${LOGFILE:-/dev/null}" 2>&1; then
-		_pcr_audit "stash-pop-conflict" "$repo_path" "advisory:stash-retained:${stash_message}"
-		_pcr_log "git stash pop conflict — stash retained, filing advisory"
-		_pcr_file_advisory "$repo_path" "stash-pop-conflict"
-		return 1
-	fi
-
-	_pcr_audit "success" "$repo_path" "stash-pull-pop-clean"
-	_pcr_log "recovered cleanly: $repo_path"
-	return 0
-}
-
 # -----------------------------------------------------------------------------
 # Public entry point
 # -----------------------------------------------------------------------------
@@ -692,49 +446,17 @@ pulse_canonical_recover() {
 		return 0
 	fi
 
-	# Hot-loop guard — escalate to advisory after repeated failures.
-	if ! _pcr_hot_loop_guard_allows_recovery "$repo_path" "$state"; then
-		return 1
-	fi
-
 	if _pcr_is_dry_run; then
-		_pcr_log "[dry-run] would recover state=${state} on $repo_path"
+		_pcr_log "[dry-run] would report state=${state} on $repo_path"
 		_pcr_audit "dry-run" "$repo_path" "state:${state}"
 		return 0
 	fi
 
 	_pcr_record_attempt "$repo_path"
-	_pcr_log "recovering ${repo_path} (state=${state})"
-
-	# Generated TODO.md sync metadata can appear in the canonical checkout while
-	# a worker is cleaning up from a linked worktree. Do not create a long-lived
-	# stash for that bookkeeping diff: either reset metadata-only generated state
-	# and refresh, or fail closed with a local advisory when TODO.md looks
-	# human-authored/unknown (GH#22664).
-	if [[ "$state" == "uncommitted" ]]; then
-		local todo_recovery_rc=0
-		_pcr_try_todo_sync_recovery "$repo_path"
-		todo_recovery_rc=$?
-		case "$todo_recovery_rc" in
-			0)
-				return 0
-				;;
-			2)
-				return 1
-				;;
-		esac
-	fi
-
-	# Step 1: clear unmerged state if present.
-	if [[ "$state" == "unmerged" ]]; then
-		if _pcr_clear_unmerged_state "$repo_path"; then
-			return 0
-		fi
-	fi
-
-	# Step 2: stash uncommitted changes (-u includes untracked), refresh, then pop.
-	_pcr_stash_refresh_pop "$repo_path"
-	return $?
+	_pcr_log "diagnostic-only canonical state: ${repo_path} (state=${state})"
+	_pcr_audit "diagnose" "$repo_path" "advisory:${state}"
+	_pcr_file_advisory "$repo_path" "$state"
+	return 1
 }
 
 # -----------------------------------------------------------------------------
@@ -743,7 +465,7 @@ pulse_canonical_recover() {
 
 _pcr_print_help() {
 	cat <<'EOF'
-pulse-canonical-recovery.sh — auto-recover canonical worktree from pull conflicts
+pulse-canonical-recovery.sh — diagnose canonical worktree conflicts
 
 Usage:
   pulse-canonical-recovery.sh [--dry-run] <repo-path>
@@ -754,8 +476,8 @@ Options:
   --help, -h    Show this message.
 
 Exit codes:
-  0  No recovery needed, or recovery succeeded.
-  1  Persistent failure — advisory issue filed (or would be in dry-run).
+  0  No diagnostic needed, or dry-run completed.
+  1  Canonical state needs human review; local advisory filed.
   2  Usage error (missing or extra arguments).
 
 Environment:

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -133,7 +133,7 @@ _pulse_refresh_repo() {
 	if [[ "${_PULSE_REFRESHED_THIS_CYCLE[$repo_path]+_}" ]]; then
 		return 0
 	fi
-	# Mark immediately so concurrent callers in the same process don't double-pull.
+	# Mark immediately so concurrent callers in the same process don't duplicate diagnostics.
 	_PULSE_REFRESHED_THIS_CYCLE[$repo_path]=1
 
 	if ! git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -144,24 +144,16 @@ _pulse_refresh_repo() {
 		return 0
 	fi
 
-	git -C "$repo_path" fetch --quiet origin >>"$LOGFILE" 2>&1 || {
-		echo "[pulse-wrapper] _pulse_refresh_repo: git fetch failed for ${repo_path} — proceeding with current checkout" >>"$LOGFILE"
-		return 0
-	}
-	if ! git -C "$repo_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1; then
-		# t2865 (GH#20922): pull may fail because of unmerged files (UU state)
-		# or local uncommitted changes that would be overwritten. Try
-		# canonical-recovery (stash + retry pull + pop) before giving up so the
-		# repo doesn't silently degrade across pulse cycles. Recovery is
-		# content-safe (no auto-resolve); on persistent failure it files an
-		# advisory issue and we proceed with the current checkout.
-		echo "[pulse-wrapper] _pulse_refresh_repo: git pull --ff-only failed for ${repo_path} — attempting canonical-recovery" >>"$LOGFILE"
-		if declare -F pulse_canonical_recover >/dev/null 2>&1; then
-			pulse_canonical_recover "$repo_path" >>"$LOGFILE" 2>&1 ||
-				echo "[pulse-wrapper] _pulse_refresh_repo: canonical-recovery did not heal ${repo_path} — proceeding with current checkout (advisory filed)" >>"$LOGFILE"
-		else
-			echo "[pulse-wrapper] _pulse_refresh_repo: pulse_canonical_recover unavailable — proceeding with current checkout" >>"$LOGFILE"
-		fi
+	local remote_sha="" local_sha=""
+	remote_sha=$(git -C "$repo_path" ls-remote origin "refs/heads/${default_branch}" 2>/dev/null | awk 'NR == 1 {print $1}') || remote_sha=""
+	local_sha=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null || true)
+	if [[ -z "$remote_sha" ]]; then
+		echo "[pulse-wrapper] _pulse_refresh_repo: remote diagnostic failed for ${repo_path} — canonical checkout unchanged" >>"$LOGFILE"
+	elif [[ "$local_sha" != "$remote_sha" ]]; then
+		echo "[pulse-wrapper] _pulse_refresh_repo: diagnostic: ${repo_path} differs from origin/${default_branch}; canonical checkout unchanged" >>"$LOGFILE"
+	fi
+	if declare -F pulse_canonical_recover >/dev/null 2>&1; then
+		pulse_canonical_recover "$repo_path" >>"$LOGFILE" 2>&1 || true
 	fi
 	return 0
 }

--- a/.agents/scripts/repo-sync-helper.sh
+++ b/.agents/scripts/repo-sync-helper.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# repo-sync-helper.sh - Daily git pull for repos in configured parent directories
+# repo-sync-helper.sh - Daily read-only diagnostics for human canonical repos
 #
 # Scans configured parent directories for git repos cloned from a remote and
-# runs `git pull --ff-only` on repos where:
+# reports remote drift for repos where:
 #   - The working tree is clean (no uncommitted changes)
 #   - The current branch is the default branch (main or master)
 #   - The repo has a configured remote
@@ -510,35 +510,26 @@ sync_repo() {
 		return 0
 	fi
 
-	# Fetch and pull --ff-only
-	log_info "SYNC $repo_name: fetching from $remote..."
-	if ! run_git_with_auth_fallback "$repo_path" "$repo_name" "$remote" "fetch" \
-		fetch "$remote" "$default_branch" --quiet; then
-		log_error "FAIL $repo_name: git fetch failed"
+	# Query the remote without updating any canonical Git or worktree state.
+	log_info "CHECK $repo_name: reading $remote/$default_branch..."
+	local remote_output=""
+	if ! remote_output=$(run_git_with_auth_fallback "$repo_path" "$repo_name" "$remote" "ls-remote" \
+		ls-remote "$remote" "refs/heads/$default_branch"); then
+		log_error "FAIL $repo_name: git ls-remote failed"
 		return 1
 	fi
 
-	# Check if there are upstream changes
 	local local_sha upstream_sha
 	local_sha=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null || true)
-	upstream_sha=$(git -C "$repo_path" rev-parse "${remote}/${default_branch}" 2>/dev/null || true)
+	upstream_sha=$(printf '%s\n' "$remote_output" | awk 'NR == 1 {print $1}')
 
 	if [[ "$local_sha" == "$upstream_sha" ]]; then
 		log_info "OK $repo_name: already up to date"
 		return 0
 	fi
 
-	# Pull with ff-only (safe: never creates merge commits)
-	if run_git_with_auth_fallback "$repo_path" "$repo_name" "$remote" "pull" \
-		pull --ff-only "$remote" "$default_branch" --quiet; then
-		local new_sha
-		new_sha=$(git -C "$repo_path" rev-parse --short HEAD 2>/dev/null || true)
-		log_info "PULLED $repo_name: updated to $new_sha"
-		return 0
-	else
-		log_error "FAIL $repo_name: git pull --ff-only failed (diverged?)"
-		return 1
-	fi
+	log_warn "STALE $repo_name: differs from $remote/$default_branch; human checkout left unchanged"
+	return 0
 }
 
 #######################################
@@ -1422,7 +1413,7 @@ CONFIGURATION:
     Default: ~/Git
 
 SAFETY:
-    - Only runs git pull --ff-only (never creates merge commits)
+    - Never fetches, pulls, or updates human canonical checkouts
     - Skips repos with dirty working trees (uncommitted changes)
     - Skips repos not on their default branch (main/master)
     - Skips repos with no remote configured
@@ -1441,8 +1432,8 @@ HOW IT WORKS:
     4. For each repo:
        a. Skips if no remote, detached HEAD, or not on default branch
        b. Skips if working tree is dirty
-       c. Fetches from remote
-       d. Pulls with --ff-only if upstream has new commits
+       c. Reads the remote ref with ls-remote
+       d. Reports stale/diverged state without changing the checkout
     5. Logs results (pulled/skipped/failed) to ~/.aidevops/logs/repo-sync.log
 
 LOGS:

--- a/.agents/scripts/repo-verify-config-lib.sh
+++ b/.agents/scripts/repo-verify-config-lib.sh
@@ -25,10 +25,19 @@ REPO_VERIFY_LOCK_PID=""
 
 _repo_verify_lock_acquire() {
 	local target_file="$1"
-	local attempts=0 owner_pid=""
+	local attempts=0 owner_pid="" common_dir="" lock_dir="" lock_key=""
 	command -v python3 >/dev/null 2>&1 || return 1
-	REPO_VERIFY_LOCK_FILE="${target_file}.aidevops-lock"
-	REPO_VERIFY_LOCK_TOKEN=$(mktemp "${target_file}.aidevops-ready.XXXXXX") || return 1
+	common_dir=$(git -C "$(dirname "$target_file")" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+	if [[ -n "$common_dir" ]]; then
+		lock_dir="${common_dir}/aidevops-locks/repo-verify"
+	else
+		lock_dir="${AIDEVOPS_LOCK_DIR:-${HOME:?HOME is required}/.aidevops/locks}/repo-verify"
+	fi
+	mkdir -p "$lock_dir" || return 1
+	lock_key=$(printf '%s' "$target_file" | cksum | awk '{print $1 "-" $2}') || return 1
+	REPO_VERIFY_LOCK_FILE="${lock_dir}/${lock_key}.lock"
+	: >"$REPO_VERIFY_LOCK_FILE" || return 1
+	REPO_VERIFY_LOCK_TOKEN=$(mktemp "${lock_dir}/${lock_key}.ready.XXXXXX") || return 1
 	rm -f "$REPO_VERIFY_LOCK_TOKEN"
 	owner_pid=$(sh -c 'printf "%s\n" "$PPID"') || return 1
 	python3 "${REPO_VERIFY_LIB_DIR}/repo-verify-lock.py" "$REPO_VERIFY_LOCK_FILE" "$REPO_VERIFY_LOCK_TOKEN" "$owner_pid" &

--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -408,15 +408,15 @@ $(_scheduler_row_calendar "$os" "StartCalendarInterval: Hour=19, Minute=0" "sh.a
 ## What it does
 
 1. Reads all repos from \`~/.config/aidevops/repos.json\`
-2. For each repo: \`git fetch --all --prune\`
-3. For repos on default branch: \`git pull --ff-only\`
-4. Reports repos that have diverged or have conflicts
+2. Reads each default remote branch with \`git ls-remote\`
+3. Reports repos that differ from their remote default branch
+4. Leaves canonical HEAD, index, refs, tracked and untracked files unchanged
 5. Skips repos with uncommitted changes (safety)
 
 ## What to check
 
 $(_diag_commands "$os" "sh.aidevops.repo-sync" "sh.aidevops.repo-sync")
-- \`git -C <repo> log --oneline -3\` — recent changes pulled
+- \`git -C <repo> status --short --branch\` — local state and reported drift
 - \`~/.config/aidevops/repos.json\` — registered repos
 - Repos with \`local_only: true\` are still synced locally (no fetch)
 $(_platform_footnote "$os")

--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -1043,8 +1043,8 @@ setup_repo_sync() {
 			print_info "Repo sync enabled (daily). Disable: aidevops repo-sync disable"
 		else
 			echo ""
-			echo "Repo sync keeps your local git repos up to date by running"
-			echo "git pull --ff-only daily on clean repos on their default branch."
+			echo "Repo sync reports remote drift daily without modifying"
+			echo "human canonical checkouts."
 			echo ""
 			setup_prompt enable_repo_sync "Enable daily repo sync? [Y/n]: " "Y"
 			if [[ "$enable_repo_sync" =~ ^[Yy]?$ || -z "$enable_repo_sync" ]]; then

--- a/.agents/scripts/tests/fixtures/repo-sync-fake-git.sh
+++ b/.agents/scripts/tests/fixtures/repo-sync-fake-git.sh
@@ -85,6 +85,24 @@ fetch)
 		;;
 	esac
 	;;
+ls-remote)
+	case "${FAKE_FETCH_MODE:-success}" in
+	success) printf '%s\trefs/heads/main\n' "${FAKE_UPSTREAM_SHA:-aaaa}"; exit 0 ;;
+	auth_then_success)
+		if [[ "$helper_used" == "1" ]]; then
+			printf '%s\trefs/heads/main\n' "${FAKE_UPSTREAM_SHA:-aaaa}"
+			exit 0
+		fi
+		printf "fatal: could not read Password for 'https://x-access-token:%s@github.com': terminal prompts disabled\n" "${FAKE_TOKEN:-SECRET_TOKEN}" >&2
+		exit 1
+		;;
+	auth_always_fail)
+		printf "fatal: Authentication failed for 'https://x-access-token:%s@github.com/example/repo.git'\n" "${FAKE_TOKEN:-SECRET_TOKEN}" >&2
+		exit 1
+		;;
+	*) exit 1 ;;
+	esac
+	;;
 pull)
 	if [[ "${FAKE_PULL_MODE:-success}" == "diverged" ]]; then
 		printf 'fatal: Not possible to fast-forward, aborting.\n' >&2

--- a/.agents/scripts/tests/test-canonical-readonly-diagnostics.sh
+++ b/.agents/scripts/tests/test-canonical-readonly-diagnostics.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="$TEST_ROOT/home"
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:${PATH}"
+mkdir -p "$HOME/.aidevops/advisories" "$HOME/.aidevops/.agent-workspace/supervisor"
+
+repo="$TEST_ROOT/repo"
+git init -q -b main "$repo" 2>/dev/null || {
+	git init -q "$repo"
+	git -C "$repo" checkout -q -b main
+}
+git -C "$repo" config user.name Test
+git -C "$repo" config user.email test@example.com
+printf 'base\n' >"$repo/tracked.txt"
+git -C "$repo" add tracked.txt
+git -C "$repo" commit -q -m base
+printf 'human change\n' >>"$repo/tracked.txt"
+printf 'untracked\n' >"$repo/untracked.txt"
+
+snapshot() {
+	local target_repo="$1"
+	printf '%s\n' "$(git -C "$target_repo" rev-parse HEAD)"
+	cksum <"$target_repo/.git/index"
+	cksum <"$target_repo/tracked.txt"
+	cksum <"$target_repo/untracked.txt"
+	git -C "$target_repo" status --porcelain=v1 --untracked-files=all
+	return 0
+}
+
+before=$(snapshot "$repo")
+export PULSE_CANONICAL_RECOVERY_ADVISORY_DIR="$HOME/.aidevops/advisories"
+export PULSE_CANONICAL_RECOVERY_STATE="$HOME/.aidevops/.agent-workspace/supervisor/state.json"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/pulse-canonical-recovery.sh"
+rc=0
+pulse_canonical_recover "$repo" >/dev/null 2>&1 || rc=$?
+after=$(snapshot "$repo")
+
+if [[ "$rc" -ne 1 || "$before" != "$after" ]]; then
+	printf 'FAIL canonical recovery diagnostic changed checkout state (rc=%s)\n' "$rc" >&2
+	exit 1
+fi
+if [[ ! -f "$HOME/.aidevops/advisories/canonical-recovery-repo.advisory" ]]; then
+	printf 'FAIL canonical recovery diagnostic did not write local advisory\n' >&2
+	exit 1
+fi
+
+printf 'PASS canonical recovery preserves exact HEAD, index, tracked, untracked, and status bytes\n'

--- a/.agents/scripts/tests/test-canonical-recovery.sh
+++ b/.agents/scripts/tests/test-canonical-recovery.sh
@@ -1,839 +1,154 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-#
-# test-canonical-recovery.sh — Regression tests for pulse-canonical-recovery.sh
-# (t2865 / GH#20922).
-#
-# Covers the recovery decision tree and cross-cutting safety gates:
-#
-#   1. State detection — clean / uncommitted / unmerged / not-a-repo are
-#      classified correctly by `_pcr_detect_state`.
-#   2. Clean no-op    — `pulse_canonical_recover` on a clean repo returns 0
-#                       without touching state.
-#   3. Recovery path  — uncommitted local changes blocking pull are stashed,
-#                       the pull replays, and the stash is popped clean.
-#                       Repo ends up at origin HEAD with local changes restored.
-#   4. Unmerged path  — `git merge --abort` clears UU state and the repo
-#                       lands clean without needing a stash.
-#   5. Failure path   — pull fails after stash (divergent history);
-#                       advisory is filed via `gh issue create`. The call
-#                       MUST go through the real `gh_create_issue` wrapper
-#                       so the gh-wrapper-guard contract holds.
-#   6. Hot-loop guard — exceeding MAX_ATTEMPTS in the window short-circuits
-#                       to advisory without re-attempting recovery.
-#   7. Dry-run        — DRY_RUN=1 leaves the repo state untouched.
-#   8. Audit log      — every recovery attempt records ≥1 operation.verify
-#                       entry via audit-log-helper.sh.
-#
-# `gh` and `audit-log-helper.sh` are stubbed via PATH so no real network
-# calls or audit log entries are made.
+# Regression coverage for diagnostic-only canonical recovery.
 
-set -uo pipefail
+set -euo pipefail
 
-TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-
-TEST_RED=$'\033[0;31m'
-TEST_GREEN=$'\033[0;32m'
-TEST_RESET=$'\033[0m'
-
-TESTS_RUN=0
-TESTS_FAILED=0
-
-print_result() {
-	local name="$1" rc="$2" extra="${3:-}"
-	TESTS_RUN=$((TESTS_RUN + 1))
-	if [[ "$rc" -eq 0 ]]; then
-		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
-	else
-		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
-		TESTS_FAILED=$((TESTS_FAILED + 1))
-	fi
-	return 0
-}
-
-# Sandbox HOME and stub directories.
+TEST_SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+SYSTEM_GIT="$(command -p -v git)"
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
-export HOME="${TEST_ROOT}/home"
-mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor"
+export HOME="$TEST_ROOT/home"
+export PULSE_CANONICAL_RECOVERY_ADVISORY_DIR="$TEST_ROOT/advisories"
+export PULSE_CANONICAL_RECOVERY_STATE="$TEST_ROOT/state/recovery.json"
+mkdir -p "$HOME" "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR" "$(dirname "$PULSE_CANONICAL_RECOVERY_STATE")"
 
-# Stub `gh` to capture invocations instead of hitting GitHub.
-GH_STUB_DIR="${TEST_ROOT}/stubs"
-mkdir -p "$GH_STUB_DIR"
-GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
-cat >"${GH_STUB_DIR}/gh" <<'STUB'
-#!/usr/bin/env bash
-# Record the invocation, return empty for issue list (no existing advisory),
-# and succeed for issue create.
-#
-# NOTE: real `gh` with `--jq '.[0].number // empty'` against an empty list
-# emits empty output. Our stub returns empty (NOT '[]') for `issue list` so
-# the helper's idempotency check correctly proceeds to `gh issue create`
-# when no prior advisory exists. Returning '[]' here would make the helper
-# treat the literal '[]' as an existing issue number and short-circuit.
-printf '%s\n' "$*" >>"${GH_CALL_LOG:-/dev/null}"
-case "$1" in
-	issue)
-		case "${2:-}" in
-			list) ;; # empty stdout — matches gh --jq filter on []
-			create) ;; # silent success
-			*) ;;
-		esac
-		;;
-	label)
-		case "${2:-}" in
-			list) ;; # empty
-			*) ;;  # create / set / etc — no-op
-		esac
-		;;
-	api)
-		# `_gh_wrapper_auto_sig` and others may call `gh api user --jq .login`.
-		# Return a minimal JSON object so callers that consume stdout don't
-		# break. Real gh with --jq applies the filter; here we just emit
-		# `{}` and let the caller handle empty filter results.
-		printf '{}\n'
-		;;
-esac
-exit 0
-STUB
-chmod +x "${GH_STUB_DIR}/gh"
+passed=0
+failed=0
 
-# Stub audit-log-helper.sh to capture invocations into a log.
-AUDIT_CALL_LOG="${TEST_ROOT}/audit-calls.log"
-mkdir -p "${TEST_SCRIPTS_DIR}-stubs"
-AUDIT_STUB="${TEST_ROOT}/stubs/audit-log-helper.sh"
-cat >"$AUDIT_STUB" <<STUB
-#!/usr/bin/env bash
-printf '%s\n' "\$*" >>"$AUDIT_CALL_LOG"
-exit 0
-STUB
-chmod +x "$AUDIT_STUB"
-
-# Activate stubs.
-export GH_CALL_LOG AUDIT_CALL_LOG
-export PATH="${GH_STUB_DIR}:${PATH}"
-
-# Override the audit-helper resolution via the helper's `_PCR_AUDIT_HELPER`
-# env hook. Leaving SCRIPT_DIR pointing at the real script directory means
-# `shared-gh-wrappers.sh` sources cleanly and `gh_create_issue` is defined,
-# which is what makes the advisory-creation path actually exercisable.
-# Without this hook, the previous test setup overrode SCRIPT_DIR to the
-# stubs/ dir, which broke the wrapper source and short-circuited the test
-# through the "wrapper unavailable" no-op branch — the assertions claimed
-# coverage that wasn't real.
-export _PCR_AUDIT_HELPER="${TEST_ROOT}/stubs/audit-log-helper.sh"
-
-# Override the advisory directory to point at the sandbox BEFORE sourcing
-# the helper, so the helper picks up the sandboxed default. (The helper
-# uses parameter expansion `:-` so the env var wins over the in-script
-# default at source time.)
-PULSE_CANONICAL_RECOVERY_ADVISORY_DIR="${TEST_ROOT}/advisories"
-export PULSE_CANONICAL_RECOVERY_ADVISORY_DIR
-mkdir -p "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR"
-
-# Source the recovery helper. shellcheck disable=SC1091
-# shellcheck source=../pulse-canonical-recovery.sh
-source "${TEST_SCRIPTS_DIR}/pulse-canonical-recovery.sh" || {
-	echo "FAIL: sourcing pulse-canonical-recovery.sh failed" >&2
-	exit 1
-}
-
-# Override state file to point at the sandbox.
-PULSE_CANONICAL_RECOVERY_STATE="${HOME}/.aidevops/.agent-workspace/supervisor/canonical-recovery-state.json"
-export PULSE_CANONICAL_RECOVERY_STATE
-PULSE_CANONICAL_RECOVERY_HOT_WINDOW=3600
-PULSE_CANONICAL_RECOVERY_MAX_ATTEMPTS=3
-
-# Helper for advisory-file assertions. After t2871, advisories are written
-# to a local file rather than filed as GitHub issues. Mirror the production
-# safe-basename derivation in `_pcr_file_advisory` exactly — `printf '%s'`
-# avoids the trailing newline that `basename` would otherwise produce
-# (which `tr -c` would convert to `_`, breaking the filename match).
-advisory_file_for() {
-	local repo_path="$1"
-	local raw safe
-	raw=$(basename "$repo_path")
-	safe=$(printf '%s' "$raw" | tr -c 'A-Za-z0-9._-' '_')
-	printf '%s/canonical-recovery-%s.advisory' "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR" "$safe"
+pass() {
+	local name="$1"
+	printf 'PASS %s\n' "$name"
+	passed=$((passed + 1))
 	return 0
 }
 
-# -----------------------------------------------------------------------------
-# Helpers: synthetic git fixtures
-# -----------------------------------------------------------------------------
-
-# Create an "origin" bare-style clone and a working canonical clone.
-# Outputs:
-#   ORIGIN_DIR — path to non-bare repo serving as origin
-#   CANON_DIR  — path to the canonical clone
-make_repo_pair() {
-	local label="$1"
-	ORIGIN_DIR="${TEST_ROOT}/origin-${label}"
-	CANON_DIR="${TEST_ROOT}/canon-${label}"
-	rm -rf "$ORIGIN_DIR" "$CANON_DIR"
-	mkdir -p "$ORIGIN_DIR"
-	(
-		cd "$ORIGIN_DIR" || exit 1
-		git init -q -b main
-		git config user.email "test@example.com"
-		git config user.name "tester"
-		git config commit.gpgsign false
-		printf 'v1\n' >foo.txt
-		git add foo.txt
-		git commit -qm "init"
-	)
-	git clone -q "$ORIGIN_DIR" "$CANON_DIR"
-	(
-		cd "$CANON_DIR" || exit 1
-		git config user.email "test@example.com"
-		git config user.name "tester"
-		git config commit.gpgsign false
-	)
+fail() {
+	local name="$1"
+	local detail="$2"
+	printf 'FAIL %s: %s\n' "$name" "$detail" >&2
+	failed=$((failed + 1))
 	return 0
 }
 
-# Advance origin by one commit so the canonical clone is one commit behind.
-advance_origin() {
-	local origin="$1"
-	(
-		cd "$origin" || exit 1
-		printf 'v2\n' >foo.txt
-		git add foo.txt
-		git commit -qm "advance"
-	)
+new_repo() {
+	local repo="$1"
+	"$SYSTEM_GIT" init -q -b main "$repo" 2>/dev/null || {
+		"$SYSTEM_GIT" init -q "$repo"
+		"$SYSTEM_GIT" -C "$repo" checkout -q -b main
+	}
+	"$SYSTEM_GIT" -C "$repo" config user.name Test
+	"$SYSTEM_GIT" -C "$repo" config user.email test@example.com
+	printf 'base\n' >"$repo/tracked.txt"
+	"$SYSTEM_GIT" -C "$repo" add tracked.txt
+	"$SYSTEM_GIT" -C "$repo" commit -q -m base
 	return 0
 }
 
-add_todo_to_origin_and_pull() {
-	local origin="$1" canon="$2"
-	(
-		cd "$origin" || exit 1
-		printf '%s\n' '- [ ] t123 sync metadata fixture #auto-dispatch logged:2026-01-01' >TODO.md
-		git add TODO.md
-		git commit -qm "add TODO"
-	)
-	git -C "$canon" pull --ff-only --no-rebase >/dev/null 2>&1
+snapshot_repo() {
+	local repo="$1"
+	printf 'HEAD %s\n' "$("$SYSTEM_GIT" -C "$repo" rev-parse HEAD)"
+	printf 'INDEX '
+	cksum <"$repo/.git/index"
+	printf 'STATUS\n'
+	"$SYSTEM_GIT" -C "$repo" status --porcelain=v1 --untracked-files=all
+	printf 'STASH %s\n' "$("$SYSTEM_GIT" -C "$repo" rev-parse -q --verify refs/stash 2>/dev/null || true)"
+	local path=""
+	while IFS= read -r path; do
+		printf 'FILE %s ' "$path"
+		cksum <"$repo/$path"
+	done < <("$SYSTEM_GIT" -C "$repo" ls-files --cached --others --exclude-standard | LC_ALL=C sort)
 	return 0
 }
 
-reset_call_logs() {
-	: >"$GH_CALL_LOG"
-	: >"$AUDIT_CALL_LOG"
-	rm -f "$PULSE_CANONICAL_RECOVERY_STATE" 2>/dev/null || true
-	# Clear any advisory files from prior tests so per-test assertions are
-	# independent. Bash 3.2-safe glob expansion.
-	if [[ -d "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR" ]]; then
-		rm -f "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR"/*.advisory 2>/dev/null || true
+advisory_for() {
+	local repo="$1"
+	local raw="" name=""
+	raw=$(basename "$repo")
+	name=$(printf '%s' "$raw" | tr -c 'A-Za-z0-9._-' '_')
+	printf '%s/canonical-recovery-%s.advisory\n' "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR" "$name"
+	return 0
+}
+
+assert_diagnostic_preserves() {
+	local repo="$1"
+	local expected_state="$2"
+	local name="$3"
+	local before="" after="" output="" rc=0 advisory=""
+	before=$(snapshot_repo "$repo")
+	output=$(pulse_canonical_recover "$repo" 2>&1) || rc=$?
+	after=$(snapshot_repo "$repo")
+	advisory=$(advisory_for "$repo")
+
+	if [[ "$rc" -ne 1 ]]; then
+		fail "$name" "expected diagnostic exit 1, got $rc"
+		return 0
 	fi
+	if [[ "$before" != "$after" ]]; then
+		fail "$name" "HEAD/index/status/stash/file bytes changed"
+		return 0
+	fi
+	if [[ ! -f "$advisory" ]] || ! grep -Fq "Failure mode: ${expected_state}" "$advisory"; then
+		fail "$name" "missing local ${expected_state} advisory"
+		return 0
+	fi
+	if [[ "$output" != *"diagnostic-only canonical state"* ]]; then
+		fail "$name" "missing diagnostic-only log"
+		return 0
+	fi
+	pass "$name"
 	return 0
 }
 
-# =============================================================================
-# Test 1: state detection
-# =============================================================================
-
-make_repo_pair "state"
-
-state=$(_pcr_detect_state "$CANON_DIR")
-[[ "$state" == "clean" ]] \
-	&& print_result "state detection: clean repo" 0 \
-	|| print_result "state detection: clean repo" 1 "got: $state"
-
-# Uncommitted change.
-echo "local-edit" >>"${CANON_DIR}/foo.txt"
-state=$(_pcr_detect_state "$CANON_DIR")
-[[ "$state" == "uncommitted" ]] \
-	&& print_result "state detection: uncommitted" 0 \
-	|| print_result "state detection: uncommitted" 1 "got: $state"
-
-# Reset.
-git -C "$CANON_DIR" checkout -- foo.txt 2>/dev/null
-
-# Not-a-repo.
-state=$(_pcr_detect_state "${TEST_ROOT}/nonexistent")
-[[ "$state" == "not-a-repo" ]] \
-	&& print_result "state detection: not-a-repo" 0 \
-	|| print_result "state detection: not-a-repo" 1 "got: $state"
-
-# Unmerged: simulate by manually staging conflict markers.
-make_repo_pair "unmerged"
-(
-	cd "$CANON_DIR" || exit 1
-	# Create two divergent branches and force a merge conflict.
-	git checkout -qb feature
-	printf 'feature-edit\n' >foo.txt
-	git commit -qam "feature"
-	git checkout -q main
-	printf 'main-edit\n' >foo.txt
-	git commit -qam "main-divergent"
-	git merge feature --no-edit 2>/dev/null || true
-)
-state=$(_pcr_detect_state "$CANON_DIR")
-[[ "$state" == "unmerged" ]] \
-	&& print_result "state detection: unmerged (UU)" 0 \
-	|| print_result "state detection: unmerged (UU)" 1 "got: $state"
-
-# =============================================================================
-# Test 2: clean no-op
-# =============================================================================
-
-make_repo_pair "clean-noop"
-reset_call_logs
-
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "clean repo: pulse_canonical_recover returns 0" 0
-else
-	print_result "clean repo: pulse_canonical_recover returns 0" 1 "exit nonzero"
-fi
-[[ ! -s "$AUDIT_CALL_LOG" ]] \
-	&& print_result "clean repo: no audit calls" 0 \
-	|| print_result "clean repo: no audit calls" 1 "log: $(cat "$AUDIT_CALL_LOG")"
-
-# =============================================================================
-# Test 3: recovery path — uncommitted local change on a non-overlapping file
-# stashes, replays the upstream advance, and pops the stash cleanly.
-# =============================================================================
-
-make_repo_pair "recover"
-# Origin advances foo.txt; we leave local-only.txt untracked locally.
-advance_origin "$ORIGIN_DIR"
-echo "local-only-line" >"${CANON_DIR}/local-only.txt"
-reset_call_logs
-
-# Pre-condition: with `-u` the stash captures the untracked file. Without
-# stashing, `git pull --ff-only` succeeds in this scenario (no overlap), but
-# `_pcr_detect_state` still returns "uncommitted" so recovery exercises the
-# full stash → pull → pop path. This validates the conflict-free success
-# branch of the decision tree.
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "recover: pulse_canonical_recover returns 0 on success" 0
-else
-	print_result "recover: pulse_canonical_recover returns 0 on success" 1
-fi
-
-# Verify repo is now up-to-date with origin AND local file is restored.
-canon_head=$(git -C "$CANON_DIR" rev-parse HEAD)
-origin_head=$(git -C "$ORIGIN_DIR" rev-parse HEAD)
-[[ "$canon_head" == "$origin_head" ]] \
-	&& print_result "recover: HEAD matches origin after recovery" 0 \
-	|| print_result "recover: HEAD matches origin after recovery" 1 "canon=$canon_head origin=$origin_head"
-
-[[ -f "${CANON_DIR}/local-only.txt" ]] && grep -q "local-only-line" "${CANON_DIR}/local-only.txt" \
-	&& print_result "recover: local change restored after stash pop" 0 \
-	|| print_result "recover: local change restored after stash pop" 1
-
-# Stash list should be empty after a clean pop.
-stash_count=$(git -C "$CANON_DIR" stash list 2>/dev/null | wc -l | tr -d ' ')
-[[ "$stash_count" == "0" ]] \
-	&& print_result "recover: stash consumed (no leftover entries)" 0 \
-	|| print_result "recover: stash consumed (no leftover entries)" 1 "count: $stash_count"
-
-# Audit log should contain at least one operation.verify entry.
-grep -q "operation.verify" "$AUDIT_CALL_LOG" \
-	&& print_result "recover: audit log records ≥1 operation.verify entry" 0 \
-	|| print_result "recover: audit log records ≥1 operation.verify entry" 1 "log: $(cat "$AUDIT_CALL_LOG")"
-
-# Verify a "success" outcome was recorded.
-grep -q "canonical-recovery.success" "$AUDIT_CALL_LOG" \
-	&& print_result "recover: audit log records canonical-recovery.success" 0 \
-	|| print_result "recover: audit log records canonical-recovery.success" 1
-
-# =============================================================================
-# Test 3b: generated TODO.md sync metadata is reset before refresh without stash.
-# =============================================================================
-
-make_repo_pair "todo-generated"
-add_todo_to_origin_and_pull "$ORIGIN_DIR" "$CANON_DIR"
-advance_origin "$ORIGIN_DIR"
-printf '%s\n' '- [x] t123 sync metadata fixture #auto-dispatch logged:2026-01-01 pr:#42 completed:2026-01-02' >"${CANON_DIR}/TODO.md"
-reset_call_logs
-
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "todo sync: generated metadata recovers without stash" 0
-else
-	print_result "todo sync: generated metadata recovers without stash" 1 "exit nonzero"
-fi
-stash_count=$(git -C "$CANON_DIR" stash list 2>/dev/null | wc -l | tr -d ' ')
-[[ "$stash_count" == "0" ]] \
-	&& print_result "todo sync: no stash created" 0 \
-	|| print_result "todo sync: no stash created" 1 "count: $stash_count"
-git -C "$CANON_DIR" diff --quiet -- TODO.md \
-	&& print_result "todo sync: TODO.md returned to clean HEAD" 0 \
-	|| print_result "todo sync: TODO.md returned to clean HEAD" 1
-[[ "$(git -C "$CANON_DIR" rev-parse HEAD)" == "$(git -C "$ORIGIN_DIR" rev-parse HEAD)" ]] \
-	&& print_result "todo sync: canonical refreshed to origin HEAD" 0 \
-	|| print_result "todo sync: canonical refreshed to origin HEAD" 1
-
-# =============================================================================
-# Test 3c: generated TODO.md reset failure files advisory with diagnostics.
-# =============================================================================
-
-make_repo_pair "todo-reset-failure"
-add_todo_to_origin_and_pull "$ORIGIN_DIR" "$CANON_DIR"
-advance_origin "$ORIGIN_DIR"
-printf '%s\n' '- [x] t123 sync metadata fixture #auto-dispatch logged:2026-01-01 pr:#42 completed:2026-01-02' >"${CANON_DIR}/TODO.md"
-reset_call_logs
-reset_stderr="${TEST_ROOT}/todo-reset-failure.stderr"
-
-REAL_GIT_BIN=$(command -v git)
-GIT_STUB_DIR="${TEST_ROOT}/git-reset-failure-stub"
-mkdir -p "$GIT_STUB_DIR"
-cat >"${GIT_STUB_DIR}/git" <<STUB
-#!/usr/bin/env bash
-if [[ "\${1:-}" == "-C" && "\${2:-}" == "$CANON_DIR" && "\${3:-}" == "reset" && "\${4:-}" == "-q" ]]; then
-	printf '%s\n' 'simulated reset failure' >&2
-	exit 1
-fi
-exec "$REAL_GIT_BIN" "\$@"
-STUB
-chmod +x "${GIT_STUB_DIR}/git"
-OLD_PATH="$PATH"
-PATH="${GIT_STUB_DIR}:${PATH}"
-
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>"$reset_stderr"; then
-	print_result "todo reset failure: recovery blocks" 1 "unexpected success"
-else
-	print_result "todo reset failure: recovery blocks" 0
-fi
-PATH="$OLD_PATH"
-grep -q 'simulated reset failure' "$reset_stderr" \
-	&& print_result "todo reset failure: stderr remains visible" 0 \
-	|| print_result "todo reset failure: stderr remains visible" 1
-grep -q 'todo-sync-reset-failed' "$AUDIT_CALL_LOG" \
-	&& print_result "todo reset failure: audit records failure" 0 \
-	|| print_result "todo reset failure: audit records failure" 1
-[[ -f "$(advisory_file_for "$CANON_DIR")" ]] \
-	&& print_result "todo reset failure: advisory filed" 0 \
-	|| print_result "todo reset failure: advisory filed" 1
-
-# =============================================================================
-# Test 3d: human/unknown TODO.md edits block without stashing or discarding.
-# =============================================================================
-
-make_repo_pair "todo-human"
-add_todo_to_origin_and_pull "$ORIGIN_DIR" "$CANON_DIR"
-printf '%s\n' '- [ ] t123 human-edited task description #auto-dispatch logged:2026-01-01' >"${CANON_DIR}/TODO.md"
-reset_call_logs
-
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "todo human: recovery blocks unknown TODO edit" 1 "unexpected success"
-else
-	print_result "todo human: recovery blocks unknown TODO edit" 0
-fi
-stash_count=$(git -C "$CANON_DIR" stash list 2>/dev/null | wc -l | tr -d ' ')
-[[ "$stash_count" == "0" ]] \
-	&& print_result "todo human: no stash created" 0 \
-	|| print_result "todo human: no stash created" 1 "count: $stash_count"
-grep -q 'human-edited task description' "${CANON_DIR}/TODO.md" \
-	&& print_result "todo human: edit preserved" 0 \
-	|| print_result "todo human: edit preserved" 1
-[[ -f "$(advisory_file_for "$CANON_DIR")" ]] \
-	&& print_result "todo human: advisory filed" 0 \
-	|| print_result "todo human: advisory filed" 1
-
-# =============================================================================
-# Test 4: unmerged path — merge --abort suffices
-# =============================================================================
-
-make_repo_pair "unmerged-recover"
-(
-	cd "$CANON_DIR" || exit 1
-	git checkout -qb feature
-	printf 'feature-edit\n' >foo.txt
-	git commit -qam "feature"
-	git checkout -q main
-	printf 'main-edit\n' >foo.txt
-	git commit -qam "main-divergent"
-	git merge feature --no-edit 2>/dev/null || true
-)
-reset_call_logs
-
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "unmerged: recovery returns 0 after merge --abort" 0
-else
-	print_result "unmerged: recovery returns 0 after merge --abort" 1
-fi
-
-state=$(_pcr_detect_state "$CANON_DIR")
-[[ "$state" == "clean" ]] \
-	&& print_result "unmerged: working tree clean after merge --abort" 0 \
-	|| print_result "unmerged: working tree clean after merge --abort" 1 "state: $state"
-
-# =============================================================================
-# Test 5: failure path — pull fails after stash → local advisory file + return 1
-# =============================================================================
-
-make_repo_pair "fail-pull"
-# Diverge canonical history vs origin so pull --ff-only must fail even after
-# stashing (the issue isn't local changes — it's a non-fast-forward).
-(
-	cd "$CANON_DIR" || exit 1
-	# Create a divergent commit on canonical's main.
-	printf 'canonical-side\n' >foo.txt
-	git commit -qam "canonical-divergent"
-)
-advance_origin "$ORIGIN_DIR"
-# Add an uncommitted change so recovery enters the stash path.
-echo "extra-line" >>"${CANON_DIR}/foo.txt"
-reset_call_logs
-
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "fail-pull: persistent failure returns 1" 1 "expected nonzero"
-else
-	print_result "fail-pull: persistent failure returns 1" 0
-fi
-
-# Local advisory file MUST be created and MUST NOT trigger any gh call.
-adv_file=$(advisory_file_for "$CANON_DIR")
-[[ -f "$adv_file" ]] \
-	&& print_result "fail-pull: local advisory file created" 0 \
-	|| print_result "fail-pull: local advisory file created" 1 "expected: $adv_file"
-
-[[ ! -s "$GH_CALL_LOG" ]] \
-	&& print_result "fail-pull: NO gh call (privacy: t2871)" 0 \
-	|| print_result "fail-pull: NO gh call (privacy: t2871)" 1 "log: $(cat "$GH_CALL_LOG")"
-
-grep -q "operation.verify" "$AUDIT_CALL_LOG" \
-	&& print_result "fail-pull: audit log records failure entry" 0 \
-	|| print_result "fail-pull: audit log records failure entry" 1
-
-# =============================================================================
-# Test 6: hot-loop guard
-# =============================================================================
-
-make_repo_pair "hot-loop"
-echo "uncommitted" >>"${CANON_DIR}/foo.txt"
-reset_call_logs
-
-# Pre-populate state file with MAX_ATTEMPTS recent entries.
-now=$(date +%s)
-mkdir -p "$(dirname "$PULSE_CANONICAL_RECOVERY_STATE")"
-printf '{"%s":[%d,%d,%d]}' "$CANON_DIR" "$now" "$now" "$now" \
-	>"$PULSE_CANONICAL_RECOVERY_STATE"
-
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "hot-loop: returns 1 after MAX_ATTEMPTS exhausted" 1 "expected nonzero"
-else
-	print_result "hot-loop: returns 1 after MAX_ATTEMPTS exhausted" 0
-fi
-
-# Local advisory file is the new escalation channel (t2871).
-adv_file=$(advisory_file_for "$CANON_DIR")
-[[ -f "$adv_file" ]] \
-	&& print_result "hot-loop: local advisory file created on escalation" 0 \
-	|| print_result "hot-loop: local advisory file created on escalation" 1 "expected: $adv_file"
-
-[[ ! -s "$GH_CALL_LOG" ]] \
-	&& print_result "hot-loop: NO gh call (privacy: t2871)" 0 \
-	|| print_result "hot-loop: NO gh call (privacy: t2871)" 1 "log: $(cat "$GH_CALL_LOG")"
-
-# Verify recovery did NOT actually try to stash (escalation short-circuit).
-state=$(_pcr_detect_state "$CANON_DIR")
-[[ "$state" == "uncommitted" ]] \
-	&& print_result "hot-loop: state preserved (no stash attempted)" 0 \
-	|| print_result "hot-loop: state preserved (no stash attempted)" 1 "state: $state"
-
-# =============================================================================
-# Test 7: dry-run is read-only
-# =============================================================================
-
-make_repo_pair "dry-run"
-echo "dry-run-edit" >>"${CANON_DIR}/foo.txt"
-reset_call_logs
-_PULSE_CANONICAL_RECOVERY_DRY_RUN=1
-
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "dry-run: returns 0 without acting" 0
-else
-	print_result "dry-run: returns 0 without acting" 1
-fi
-
-state=$(_pcr_detect_state "$CANON_DIR")
-[[ "$state" == "uncommitted" ]] \
-	&& print_result "dry-run: repo state untouched" 0 \
-	|| print_result "dry-run: repo state untouched" 1 "state: $state"
-
-# Stash list must be empty.
-stash_count=$(git -C "$CANON_DIR" stash list 2>/dev/null | wc -l | tr -d ' ')
-[[ "$stash_count" == "0" ]] \
-	&& print_result "dry-run: no stash created" 0 \
-	|| print_result "dry-run: no stash created" 1 "count: $stash_count"
-
-# gh must NOT have been invoked.
-[[ ! -s "$GH_CALL_LOG" ]] \
-	&& print_result "dry-run: no gh advisory call" 0 \
-	|| print_result "dry-run: no gh advisory call" 1 "log: $(cat "$GH_CALL_LOG")"
-
-# No local advisory file written either.
-adv_file=$(advisory_file_for "$CANON_DIR")
-[[ ! -e "$adv_file" ]] \
-	&& print_result "dry-run: no local advisory file written" 0 \
-	|| print_result "dry-run: no local advisory file written" 1 "found: $adv_file"
-
-_PULSE_CANONICAL_RECOVERY_DRY_RUN=0
-
-# =============================================================================
-# Test 8: standalone invocation honours --dry-run + --help
-# =============================================================================
-
-make_repo_pair "standalone"
-echo "standalone-edit" >>"${CANON_DIR}/foo.txt"
-
-# --help exits 0 with usage text.
-help_out=$("${TEST_SCRIPTS_DIR}/pulse-canonical-recovery.sh" --help 2>&1)
-echo "$help_out" | grep -q "Usage:" \
-	&& print_result "standalone: --help renders usage" 0 \
-	|| print_result "standalone: --help renders usage" 1
-
-# --dry-run on dirty repo → exit 0, no state change.
-"${TEST_SCRIPTS_DIR}/pulse-canonical-recovery.sh" --dry-run "$CANON_DIR" \
-	>/dev/null 2>&1
-rc=$?
-[[ "$rc" -eq 0 ]] \
-	&& print_result "standalone: --dry-run on dirty repo exits 0" 0 \
-	|| print_result "standalone: --dry-run on dirty repo exits 0" 1 "rc: $rc"
-
-# Missing argument → exit 2.
-"${TEST_SCRIPTS_DIR}/pulse-canonical-recovery.sh" >/dev/null 2>&1
-rc=$?
-[[ "$rc" -eq 2 ]] \
-	&& print_result "standalone: missing repo-path exits 2" 0 \
-	|| print_result "standalone: missing repo-path exits 2" 1 "rc: $rc"
-
-# =============================================================================
-# Test 9: jq-missing fail-closed escalation
-# =============================================================================
-#
-# When jq is missing, the helper cannot maintain the persistent attempt
-# counter that backs the hot-loop guard. Pre-fix behaviour: silent no-op
-# (could loop forever if a transient pull failure recurred). Post-fix
-# behaviour: fail-closed — every call escalates straight to advisory so
-# the user is alerted instead of silently degrading. We simulate jq-missing
-# by shadowing `_pcr_jq_required` in this scope.
-#
-# This test is at the end of the suite because the override leaks into
-# the surrounding scope; subsequent in-process tests would see the stub.
-
-make_repo_pair "no-jq"
-echo "uncommitted-no-jq" >>"${CANON_DIR}/foo.txt"
-reset_call_logs
-
-# Override the jq-availability gate in this scope.
-_pcr_jq_required() { return 1; }
-
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "no-jq: fail-closed returns 1 on first call" 1 "expected nonzero"
-else
-	print_result "no-jq: fail-closed returns 1 on first call" 0
-fi
-
-# Local advisory still files even with jq missing — escalation path is
-# unchanged by t2871; only the channel changed.
-adv_file=$(advisory_file_for "$CANON_DIR")
-[[ -f "$adv_file" ]] \
-	&& print_result "no-jq: local advisory file created" 0 \
-	|| print_result "no-jq: local advisory file created" 1 "expected: $adv_file"
-
-[[ ! -s "$GH_CALL_LOG" ]] \
-	&& print_result "no-jq: NO gh call (privacy: t2871)" 0 \
-	|| print_result "no-jq: NO gh call (privacy: t2871)" 1 "log: $(cat "$GH_CALL_LOG")"
-
-# Repo state must be preserved — fail-closed does not stash, pull, or pop.
-state=$(_pcr_detect_state "$CANON_DIR")
-[[ "$state" == "uncommitted" ]] \
-	&& print_result "no-jq: repo state preserved (no stash attempted)" 0 \
-	|| print_result "no-jq: repo state preserved (no stash attempted)" 1 "state: $state"
-
-# =============================================================================
-# Test 10: privacy regression (t2871) — advisory body contains no raw
-# absolute paths that would leak username, drive topology, or repo prefix.
-# =============================================================================
-#
-# This test replaces the no-op repo path with a representative leaky path
-# and asserts the composed advisory body never contains:
-#   - the raw username segment (e.g. /home/dave/, /Users/dave/)
-#   - the drive/mount segment in the form that exposes user identity
-#   - the legacy "Auto-filed by `pulse-canonical-recovery.sh` after exhausting
-#     auto-recovery attempts for canonical repo `<absolute path>`" preamble
-#
-# `_pcr_advisory_body` is sourced from the helper and we call it directly —
-# no need to fully simulate a failure. This is a pure body-composition test.
-
-# Restore the real jq gate (if still overridden from Test 9 — it's a function
-# definition leak, not actually used in this synthetic path, but be tidy).
-unset -f _pcr_jq_required 2>/dev/null || true
-
-# Synthetic "user paths" — these never touch a real filesystem.
-declare -a leak_test_paths=(
-	"/home/dave/Git/request-handler"
-	"/Users/marcusquinn/Git/example-repo"
-	"/mnt/data/dave/Git/php-src"
-)
-
-for raw_path in "${leak_test_paths[@]}"; do
-	body=$(_pcr_advisory_body "$raw_path" "stash-push-failed")
-
-	# Username segment must not appear verbatim. We test the leaf segment
-	# right after the home/users/mount root.
-	case "$raw_path" in
-		/home/*) leaked_user="/home/dave/" ;;
-		/Users/*) leaked_user="/Users/marcusquinn/" ;;
-		/mnt/*) leaked_user="/mnt/data/dave/" ;;
-		*) leaked_user="" ;;
-	esac
-
-	if [[ -n "$leaked_user" ]]; then
-		if printf '%s' "$body" | grep -qF "$leaked_user"; then
-			print_result "privacy: '${raw_path}' — username segment NOT in advisory body" 1 "leaked: $leaked_user"
-		else
-			print_result "privacy: '${raw_path}' — username segment NOT in advisory body" 0
-		fi
-	fi
-
-	# Sanity: the basename SHOULD appear (it identifies the affected repo
-	# for the user — that's the whole point of the advisory) AND a
-	# sanitised <user> placeholder SHOULD appear.
-	basename=$(basename "$raw_path")
-	printf '%s' "$body" | grep -qF "$basename" \
-		&& print_result "privacy: '${raw_path}' — basename '$basename' present (identifies affected repo)" 0 \
-		|| print_result "privacy: '${raw_path}' — basename '$basename' present (identifies affected repo)" 1
-done
-
-# Direct unit test of _pcr_sanitise_path — exercise each substitution rule.
-# /Users/<name>/<rest>
-got=$(_pcr_sanitise_path "/Users/dave/Git/php-src")
-[[ "$got" == "/Users/<user>/Git/php-src" ]] \
-	&& print_result "sanitise: /Users/<name>/ → /Users/<user>/" 0 \
-	|| print_result "sanitise: /Users/<name>/ → /Users/<user>/" 1 "got: $got"
-
-# /home/<name>/<rest>
-got=$(_pcr_sanitise_path "/home/dave/Git/request-handler")
-[[ "$got" == "/home/<user>/Git/request-handler" ]] \
-	&& print_result "sanitise: /home/<name>/ → /home/<user>/" 0 \
-	|| print_result "sanitise: /home/<name>/ → /home/<user>/" 1 "got: $got"
-
-# /mnt/<volume>/<name>/<rest> — keep volume label, strip user
-got=$(_pcr_sanitise_path "/mnt/data/dave/Git/php-src")
-[[ "$got" == "/mnt/data/<user>/Git/php-src" ]] \
-	&& print_result "sanitise: /mnt/<volume>/<name>/ → /mnt/<volume>/<user>/" 0 \
-	|| print_result "sanitise: /mnt/<volume>/<name>/ → /mnt/<volume>/<user>/" 1 "got: $got"
-
-# $HOME-prefixed → ~ (uses sandbox HOME from this test setup). The helper
-# deliberately emits a literal `~` byte rather than a shell-expandable
-# tilde, so SC2088 is the right warning to silence here — there is no
-# expansion semantics involved, the test asserts the exact byte sequence
-# the helper writes into the advisory file.
-# shellcheck disable=SC2088
-expected_home_subst='~/Git/example-repo'
-got=$(_pcr_sanitise_path "${HOME}/Git/example-repo")
-[[ "$got" == "$expected_home_subst" ]] \
-	&& print_result "sanitise: \$HOME/ → ~/" 0 \
-	|| print_result "sanitise: \$HOME/ → ~/" 1 "got: $got"
-
-# Unknown root → fallback to <repo>/<basename>
-got=$(_pcr_sanitise_path "/some/weird/place/myrepo")
-[[ "$got" == "<repo>/myrepo" ]] \
-	&& print_result "sanitise: unknown root → <repo>/basename" 0 \
-	|| print_result "sanitise: unknown root → <repo>/basename" 1 "got: $got"
-
-# =============================================================================
-# Test 11: stale-UU recovery — UU state without MERGE_HEAD is cleared via
-# reset --merge HEAD without stashing (GH#20935)
-# =============================================================================
-#
-# Scenario: git crashes mid-merge-resolve, leaving UU index entries (stages
-# 1, 2, 3) but no .git/MERGE_HEAD sentinel.  The prior code called `merge
-# --abort` (which exits 1 with "no merge to abort" — swallowed by `|| true`)
-# leaving state still "unmerged", then attempted `stash push` which also
-# fails on unresolved conflicts, and escalated to an advisory unnecessarily.
-#
-# The new path detects the stale-UU case (unmerged + no merge head files),
-# runs `merge --abort || reset --merge HEAD`, re-checks state, and returns 0
-# if clean — with a distinct `stale-uu-recover` audit event.
-#
-# Test 10 used `unset -f _pcr_jq_required` to clean up after Test 9's
-# override.  We redefine it here so the hot-loop guard's jq-availability
-# check works correctly in Test 11 instead of fail-closing on every call.
-# shellcheck disable=SC2317
-_pcr_jq_required() {
-	command -v jq >/dev/null 2>&1
-	return $?
+make_unmerged_repo() {
+	local repo="$1"
+	new_repo "$repo"
+	"$SYSTEM_GIT" -C "$repo" checkout -q -b conflict
+	printf 'branch\n' >"$repo/tracked.txt"
+	"$SYSTEM_GIT" -C "$repo" add tracked.txt
+	"$SYSTEM_GIT" -C "$repo" commit -q -m branch
+	"$SYSTEM_GIT" -C "$repo" checkout -q main
+	printf 'main\n' >"$repo/tracked.txt"
+	"$SYSTEM_GIT" -C "$repo" add tracked.txt
+	"$SYSTEM_GIT" -C "$repo" commit -q -m main
+	"$SYSTEM_GIT" -C "$repo" merge conflict >/dev/null 2>&1 || true
+	return 0
 }
 
-# We simulate the crash by starting a real merge (which produces the correct
-# index conflict state: stages 1/2/3, no stage 0, working tree with markers)
-# and then removing .git/MERGE_HEAD to mimic git crashing mid-resolve.  This
-# is more reliable than direct index manipulation with --index-info because
-# it produces exactly the index layout git itself creates.
-make_repo_pair "stale-uu"
-reset_call_logs
-(
-	cd "$CANON_DIR" || exit 1
-	git checkout -qb feature-stale
-	printf 'feature-edit\n' >foo.txt
-	git commit -qam "feature"
-	git checkout -q main
-	printf 'main-edit\n' >foo.txt
-	git commit -qam "main-divergent"
-	# Trigger a real merge conflict so git creates MERGE_HEAD + index stages.
-	git merge feature-stale --no-edit 2>/dev/null || true
-	# Simulate git crashing mid-resolution by removing MERGE_HEAD.
-	rm -f .git/MERGE_HEAD
-)
+# shellcheck source=/dev/null
+source "$TEST_SCRIPTS_DIR/pulse-canonical-recovery.sh"
 
-# Pre-condition: state is "unmerged" and no MERGE_HEAD file exists.
-stale_pre_state=$(_pcr_detect_state "$CANON_DIR")
-[[ "$stale_pre_state" == "unmerged" ]] \
-	&& print_result "stale-UU: pre-condition: state is 'unmerged'" 0 \
-	|| print_result "stale-UU: pre-condition: state is 'unmerged'" 1 "got: $stale_pre_state"
+dirty_repo="$TEST_ROOT/dirty"
+new_repo "$dirty_repo"
+printf 'human edit\n' >>"$dirty_repo/tracked.txt"
+printf 'human untracked\n' >"$dirty_repo/untracked.txt"
+assert_diagnostic_preserves "$dirty_repo" uncommitted "dirty canonical is byte-identical and advised"
 
-[[ ! -e "${CANON_DIR}/.git/MERGE_HEAD" ]] \
-	&& print_result "stale-UU: pre-condition: no MERGE_HEAD present" 0 \
-	|| print_result "stale-UU: pre-condition: no MERGE_HEAD present" 1 "MERGE_HEAD found"
+todo_repo="$TEST_ROOT/generated-todo"
+new_repo "$todo_repo"
+printf '%s\n' '- [ ] t123 generated fixture logged:2026-01-01 assignee:worker' >"$todo_repo/TODO.md"
+"$SYSTEM_GIT" -C "$todo_repo" add TODO.md
+"$SYSTEM_GIT" -C "$todo_repo" commit -q -m todo
+printf '%s\n' '- [x] t123 generated fixture logged:2026-01-02 assignee:worker completed:2026-01-02' >"$todo_repo/TODO.md"
+assert_diagnostic_preserves "$todo_repo" uncommitted "generated TODO metadata is preserved and advised"
 
-# Run recovery — should succeed via stale-UU path (merge --abort fails for
-# no active merge, reset --merge HEAD clears the stale index entries).
-if pulse_canonical_recover "$CANON_DIR" >/dev/null 2>&1; then
-	print_result "stale-UU: recovery returns 0" 0
+unmerged_repo="$TEST_ROOT/unmerged"
+make_unmerged_repo "$unmerged_repo"
+assert_diagnostic_preserves "$unmerged_repo" unmerged "unmerged canonical is byte-identical and advised"
+
+clean_repo="$TEST_ROOT/clean"
+new_repo "$clean_repo"
+clean_before=$(snapshot_repo "$clean_repo")
+clean_rc=0
+pulse_canonical_recover "$clean_repo" >/dev/null 2>&1 || clean_rc=$?
+clean_after=$(snapshot_repo "$clean_repo")
+if [[ "$clean_rc" -eq 0 && "$clean_before" == "$clean_after" && ! -e "$(advisory_for "$clean_repo")" ]]; then
+	pass "clean canonical remains a no-op"
 else
-	print_result "stale-UU: recovery returns 0" 1 "got nonzero"
+	fail "clean canonical remains a no-op" "unexpected mutation, status, or advisory"
 fi
 
-# State must be clean after recovery.
-stale_post_state=$(_pcr_detect_state "$CANON_DIR")
-[[ "$stale_post_state" == "clean" ]] \
-	&& print_result "stale-UU: working tree clean after recovery" 0 \
-	|| print_result "stale-UU: working tree clean after recovery" 1 "state: $stale_post_state"
-
-# No stash should have been created — the index-reset path bypasses stash.
-stale_stash_count=$(git -C "$CANON_DIR" stash list 2>/dev/null | wc -l | tr -d ' ')
-[[ "$stale_stash_count" == "0" ]] \
-	&& print_result "stale-UU: no stash created (index reset path)" 0 \
-	|| print_result "stale-UU: no stash created (index reset path)" 1 "stash count: $stale_stash_count"
-
-# No advisory file — recovery succeeded, nothing to surface.
-stale_adv_file=$(advisory_file_for "$CANON_DIR")
-[[ ! -e "$stale_adv_file" ]] \
-	&& print_result "stale-UU: no advisory file on success" 0 \
-	|| print_result "stale-UU: no advisory file on success" 1 "found: $stale_adv_file"
-
-# Audit log MUST record a stale-uu-recover entry — distinct from merge-abort.
-# The outcome is "ok:index-reset" (not "success") to keep the repeated
-# string literal count below the linter threshold.
-grep -q "canonical-recovery.stale-uu-recover" "$AUDIT_CALL_LOG" \
-	&& print_result "stale-UU: audit log records stale-uu-recover event" 0 \
-	|| print_result "stale-UU: audit log records stale-uu-recover event" 1 "log: $(cat "$AUDIT_CALL_LOG")"
-
-# No gh call — stale-UU success uses the local advisory channel (same as
-# all other paths in t2871).
-[[ ! -s "$GH_CALL_LOG" ]] \
-	&& print_result "stale-UU: no gh call (local advisory channel)" 0 \
-	|| print_result "stale-UU: no gh call (local advisory channel)" 1 "log: $(cat "$GH_CALL_LOG")"
-
-# =============================================================================
-# Summary
-# =============================================================================
-
-printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
-[[ "$TESTS_FAILED" -eq 0 ]] && exit 0 || exit 1
+printf '\nRan %d tests, %d failed.\n' "$((passed + failed))" "$failed"
+[[ "$failed" -eq 0 ]] || exit 1
+exit 0

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -255,7 +255,7 @@ test_allows_same_opencode_session_pid_rollover() {
 	return 0
 }
 
-test_allowlisted_path_allows_edit_on_main() {
+test_headless_planning_path_requires_worktree() {
 	# Ensure repo is on main for this test
 	"$GIT_BIN" -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
 
@@ -263,12 +263,12 @@ test_allowlisted_path_allows_edit_on_main() {
 	local exit_code=0
 	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --file "README.md" 2>&1) || exit_code=$?
 
-	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"LOOP_DECISION=stay"* ]]; then
-		print_result "allowlisted path (README.md) allows edit on main in loop mode" 0
+	if [[ "$exit_code" -ne 0 || "$output" == *"LOOP_DECISION=worktree"* || "$output" == *"LOOP_DECISION=worktree_created"* ]]; then
+		print_result "headless planning path requires a linked worktree" 0
 		return 0
 	fi
 
-	print_result "allowlisted path (README.md) allows edit on main in loop mode" 1 "exit=${exit_code} output=${output}"
+	print_result "headless planning path requires a linked worktree" 1 "exit=${exit_code} output=${output}"
 	return 0
 }
 
@@ -321,7 +321,7 @@ test_absolute_path_outside_repo_blocked_on_main() {
 	return 0
 }
 
-test_todo_subdir_path_allows_edit_on_main() {
+test_todo_subdir_path_requires_worktree() {
 	# Ensure repo is on main for this test
 	"$GIT_BIN" -C "$TEST_ROOT" switch main >/dev/null 2>&1 || true
 	mkdir -p "${TEST_ROOT}/todo"
@@ -330,12 +330,12 @@ test_todo_subdir_path_allows_edit_on_main() {
 	local exit_code=0
 	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --file "todo/tasks/t001-brief.md" 2>&1) || exit_code=$?
 
-	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"LOOP_DECISION=stay"* ]]; then
-		print_result "todo/ subdir path allows edit on main in loop mode" 0
+	if [[ "$exit_code" -ne 0 || "$output" == *"LOOP_DECISION=worktree"* || "$output" == *"LOOP_DECISION=worktree_created"* ]]; then
+		print_result "todo/ subdir path requires a linked worktree" 0
 		return 0
 	fi
 
-	print_result "todo/ subdir path allows edit on main in loop mode" 1 "exit=${exit_code} output=${output}"
+	print_result "todo/ subdir path requires a linked worktree" 1 "exit=${exit_code} output=${output}"
 	return 0
 }
 
@@ -380,11 +380,11 @@ main() {
 	test_warns_when_canonical_repo_is_off_main
 	test_blocks_when_linked_worktree_owned_by_another_live_process
 	test_allows_same_opencode_session_pid_rollover
-	test_allowlisted_path_allows_edit_on_main
+	test_headless_planning_path_requires_worktree
 	test_interactive_allowlisted_path_still_requires_worktree
 	test_path_traversal_blocked_on_main
 	test_absolute_path_outside_repo_blocked_on_main
-	test_todo_subdir_path_allows_edit_on_main
+	test_todo_subdir_path_requires_worktree
 	test_auto_creates_git_path_worktree_from_ansi_helper_output
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-canonical-maintenance.sh
+++ b/.agents/scripts/tests/test-pulse-canonical-maintenance.sh
@@ -17,6 +17,7 @@
 # fast-forward behaviour without touching real repos.
 
 set -uo pipefail
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:${PATH}"
 
 TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_RED=$'\033[0;31m'
@@ -235,7 +236,7 @@ EOF
 }
 
 # =============================================================================
-# Test 6: Successful fast-forward
+# Test 6: Stale canonical is diagnosed without mutation
 # =============================================================================
 test_fast_forward_success() {
 	local clone_dir
@@ -247,13 +248,20 @@ test_fast_forward_success() {
 	# Reset cadence
 	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
 
+	local before_head before_index before_tree
+	before_head=$(git -C "$clone_dir" rev-parse HEAD)
+	before_index=$(cksum <"$clone_dir/.git/index")
+	before_tree=$(cksum <"$clone_dir/file.txt")
 	true > "$LOGFILE"
 	_canonical_fast_forward "0"
 
-	if grep -q "Fast-forwarded" "$LOGFILE"; then
-		print_result "fast-forward-success" 0
+	if grep -q "Diagnostic:.*differs from origin/main" "$LOGFILE" &&
+		[[ "$before_head" == "$(git -C "$clone_dir" rev-parse HEAD)" ]] &&
+		[[ "$before_index" == "$(cksum <"$clone_dir/.git/index")" ]] &&
+		[[ "$before_tree" == "$(cksum <"$clone_dir/file.txt")" ]]; then
+		print_result "canonical-stale-diagnostic-byte-identity" 0
 	else
-		print_result "fast-forward-success" 1 "(expected 'Fast-forwarded' in log, got: $(cat "$LOGFILE"))"
+		print_result "canonical-stale-diagnostic-byte-identity" 1 "(canonical changed or diagnostic missing: $(cat "$LOGFILE"))"
 	fi
 	return 0
 }
@@ -295,7 +303,7 @@ test_dry_run() {
 	local output
 	output=$(run_canonical_maintenance --dry-run 2>&1)
 
-	if echo "$output" | grep -q "DRY_RUN"; then
+	if echo "$output" | grep -q "DRY_RUN.*diagnose"; then
 		print_result "dry-run-output" 0
 	else
 		print_result "dry-run-output" 1 "(expected DRY_RUN in output)"

--- a/.agents/scripts/tests/test-repo-sync-helper-gh-auth.sh
+++ b/.agents/scripts/tests/test-repo-sync-helper-gh-auth.sh
@@ -107,7 +107,7 @@ assert_file_not_contains "${LAST_CASE_DIR}/gh.log" "auth status" "plain fetch su
 run_case github_fallback FAKE_FETCH_MODE=auth_then_success FAKE_REMOTE_URL=https://github.com/example/repo.git
 assert_rc 0 "$LAST_CASE_RC" "GitHub auth failure retries successfully"
 assert_file_contains "${LAST_CASE_DIR}/git.log" "credential.helper=!gh auth git-credential" "GitHub auth fallback uses transient gh credential helper"
-assert_file_contains "${LAST_CASE_DIR}/home/.aidevops/logs/repo-sync.log" "retrying git fetch with gh credential helper" "GitHub auth fallback is logged without credentials"
+assert_file_contains "${LAST_CASE_DIR}/home/.aidevops/logs/repo-sync.log" "retrying git ls-remote with gh credential helper" "GitHub auth fallback is logged without credentials"
 assert_file_not_contains "${LAST_CASE_DIR}/home/.aidevops/logs/repo-sync.log" "SECRET_TOKEN_github_fallback" "GitHub auth fallback log does not contain token"
 assert_file_not_contains "${LAST_CASE_DIR}/git.log" "SECRET_TOKEN_github_fallback" "GitHub auth fallback command line does not contain token"
 
@@ -117,12 +117,12 @@ assert_file_not_contains "${LAST_CASE_DIR}/git.log" "credential.helper=!gh auth 
 
 run_case dirty_skip FAKE_DIRTY=1 FAKE_FETCH_MODE=auth_then_success
 assert_rc 0 "$LAST_CASE_RC" "dirty worktree remains skipped"
-assert_file_not_contains "${LAST_CASE_DIR}/git.log" "fetch origin main" "dirty worktree skips fetch before auth fallback"
+assert_file_not_contains "${LAST_CASE_DIR}/git.log" "ls-remote origin" "dirty worktree skips remote diagnostic before auth fallback"
 
-run_case diverged_pull FAKE_FETCH_MODE=success FAKE_LOCAL_SHA=aaaa FAKE_UPSTREAM_SHA=bbbb FAKE_PULL_MODE=diverged
-assert_rc 1 "$LAST_CASE_RC" "diverged pull still fails"
-assert_file_not_contains "${LAST_CASE_DIR}/git.log" "credential.helper=!gh auth git-credential" "diverged pull does not use auth fallback"
-assert_file_contains "${LAST_CASE_DIR}/home/.aidevops/logs/repo-sync.log" "git pull --ff-only failed (diverged?)" "diverged pull keeps existing failure message"
+run_case diverged_pull FAKE_FETCH_MODE=success FAKE_LOCAL_SHA=aaaa FAKE_UPSTREAM_SHA=bbbb
+assert_rc 0 "$LAST_CASE_RC" "diverged canonical is diagnostic-only"
+assert_file_not_contains "${LAST_CASE_DIR}/git.log" " pull " "diverged canonical is never pulled"
+assert_file_contains "${LAST_CASE_DIR}/home/.aidevops/logs/repo-sync.log" "human checkout left unchanged" "diverged canonical reports read-only result"
 
 run_case github_fallback_failure_redacts FAKE_FETCH_MODE=auth_always_fail FAKE_REMOTE_URL=https://github.com/example/repo.git
 assert_rc 1 "$LAST_CASE_RC" "failed GitHub fallback exits with failure"

--- a/.agents/scripts/tests/test-repo-verify-config-lib.sh
+++ b/.agents/scripts/tests/test-repo-verify-config-lib.sh
@@ -179,7 +179,6 @@ test_concurrent_registration_writes() {
 	/usr/bin/git -C "$root_a" add package.json
 	/usr/bin/git -C "$root_b" add package.json
 	jq -n --arg a "$root_a" --arg b "$root_b" '{initialized_repos:[{path:$a,features:[]},{path:$b,features:[]}]}' >"$repos_file"
-	printf '%s\n' '99999999' >"${repos_file}.aidevops-lock"
 	(AIDEVOPS_REPOS_FILE="$repos_file" repo_verify_migrate_registration "$root_a") &
 	local pid_a=$!
 	(AIDEVOPS_REPOS_FILE="$repos_file" repo_verify_migrate_registration "$root_b") &
@@ -187,6 +186,7 @@ test_concurrent_registration_writes() {
 	wait "$pid_a"
 	wait "$pid_b"
 	assert_equal "2" "$(jq '[.initialized_repos[] | select((.features // []) | index("code-quality"))] | length' "$repos_file")" "concurrent registration migrations preserve both updates"
+	assert_equal "0" "$(find "$1" -maxdepth 1 -name '*.aidevops-lock' -o -name '*.aidevops-ready.*' | wc -l | tr -d ' ')" "repo verify leaves no lock or readiness artifacts beside targets"
 	return 0
 }
 

--- a/.agents/workflows/pr.md
+++ b/.agents/workflows/pr.md
@@ -124,7 +124,7 @@ Report structure: `## PR Review: #NNN - Title` with sections: **Quality Checks**
 1. Add `pr:NNN` to task line, move to `## In Review`; on merge mark `[x]`, add `completed:` timestamp, move to `## Done`
 2. Sync: `~/.aidevops/agents/scripts/beads-sync-helper.sh push`
 3. Delete branch: `git branch -d feature/xyz && git push origin --delete feature/xyz`
-4. Update local main: `git checkout main && git pull origin main`
+4. Leave the human canonical checkout unchanged; create the next linked worktree from freshly fetched `origin/main`.
 5. Create release if applicable: see `workflows/release.md`
 
 ## Fork Workflow (Non-Owner Repositories)

--- a/.agents/workflows/worktree-cleanup.md
+++ b/.agents/workflows/worktree-cleanup.md
@@ -18,7 +18,7 @@ BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 CANONICAL_DIR="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
 
 cd "$CANONICAL_DIR" || cd "$HOME"
-git pull origin main 2>/dev/null || true
+git fetch origin main 2>/dev/null || true
 
 HELPER="$HOME/.aidevops/agents/scripts/worktree-helper.sh"
 if [[ -x "$HELPER" ]]; then
@@ -43,7 +43,7 @@ gh pr merge --squash
 # Return to canonical repo and pull
 CANONICAL_DIR="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
 cd "$CANONICAL_DIR"
-git pull origin main
+git fetch origin main
 
 # Remove merged worktrees
 wt prune


### PR DESCRIPTION
## Summary

Make canonical maintenance, recovery, repository sync, and pre-edit policy diagnostic-only; move repository verification locks outside worktrees; add byte-identity regression coverage.

## Files Changed

.agents/scripts/onboarding-helper.sh, .agents/scripts/pre-edit-check.sh, .agents/scripts/pulse-canonical-maintenance.sh, .agents/scripts/pulse-canonical-recovery.sh, .agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/repo-sync-helper.sh, .agents/scripts/repo-verify-config-lib.sh, .agents/scripts/routines/core-routines.sh, .agents/scripts/setup/modules/schedulers-platform.sh, .agents/scripts/tests/fixtures/repo-sync-fake-git.sh, .agents/scripts/tests/test-canonical-readonly-diagnostics.sh, .agents/scripts/tests/test-canonical-recovery.sh, .agents/scripts/tests/test-pre-edit-check.sh, .agents/scripts/tests/test-pulse-canonical-maintenance.sh, .agents/scripts/tests/test-repo-sync-helper-gh-auth.sh, .agents/scripts/tests/test-repo-verify-config-lib.sh, .agents/workflows/pr.md, .agents/workflows/worktree-cleanup.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused canonical recovery, pre-edit, pulse maintenance, repo-sync, and repo-verify suites pass; ShellCheck and local linters pass. Full broad lint reports pre-existing repository-wide markdown/complexity debt and a pulse canary timeout.

Resolves #27155


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.75 with gpt-5.6-sol spent 25m and 135,936 tokens on this with the user in an interactive session.