### PR TITLE
GH#27427: test: tolerate formatted brew helper declarations

### DIFF
--- a/.agents/scripts/tests/test-tool-version-check-ripgrep.sh
+++ b/.agents/scripts/tests/test-tool-version-check-ripgrep.sh
@@ -26,7 +26,13 @@ assert 'ripgrep) get_public_release_tag "BurntSushi/ripgrep" ;;' in content, (
     "Linux without Homebrew must resolve the latest ripgrep release"
 )
 
-helper_start = content.index("_brew_upgrade_cmd() {")
+helper_match = re.search(
+    r"^(?:function\s+)?_brew_upgrade_cmd\s*(?:\(\s*\))?\s*\{",
+    content,
+    re.MULTILINE,
+)
+assert helper_match, "Could not find _brew_upgrade_cmd function definition"
+helper_start = helper_match.start()
 helper_end = content.index("\n}", helper_start)
 helper = content[helper_start:helper_end]
 for manager_command in (


### PR DESCRIPTION
## Summary

Use an anchored regular expression to locate _brew_upgrade_cmd across supported shell declaration formatting before asserting package-manager paths.

## Files Changed

.agents/scripts/tests/test-tool-version-check-ripgrep.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-tool-version-check-ripgrep.sh; shellcheck .agents/scripts/tests/test-tool-version-check-ripgrep.sh

Resolves #27427


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.76 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1m and 32,750 tokens on this as a headless worker.