### PR TITLE
GH#27445: preserve bounded offline issue context

### DIFF
--- a/.agents/scripts/issue-body-snapshot-helper.sh
+++ b/.agents/scripts/issue-body-snapshot-helper.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNAPSHOT_SCHEMA_VERSION=1
+
+snapshot_error() {
+	local message="$1"
+	printf 'issue snapshot unavailable: %s\n' "$message" >&2
+	return 1
+}
+
+snapshot_hash() {
+	local body_file="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$body_file" | cut -d' ' -f1
+		return $?
+	fi
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$body_file" | cut -d' ' -f1
+		return $?
+	fi
+	snapshot_error "SHA-256 tool is missing"
+	return 1
+}
+
+snapshot_epoch_from_iso() {
+	local timestamp="$1"
+	local epoch=""
+	epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$timestamp" '+%s' 2>/dev/null) || \
+		epoch=$(date -u -d "$timestamp" '+%s' 2>/dev/null) || epoch=""
+	[[ "$epoch" =~ ^[0-9]+$ ]] || return 1
+	printf '%s' "$epoch"
+	return 0
+}
+
+snapshot_path() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local safe_repo=""
+	safe_repo=$(printf '%s' "$repo_slug" | tr -c 'A-Za-z0-9._-' '_')
+	printf '%s/%s-%s.json' "${ISSUE_BODY_SNAPSHOT_DIR:-${HOME}/.aidevops/cache/issue-body-snapshots}" "$safe_repo" "$issue_number"
+	return 0
+}
+
+snapshot_scan_body() {
+	local body_file="$1"
+	local scanner="${ISSUE_BODY_SNAPSHOT_SCANNER:-${SCRIPT_DIR}/prompt-guard-helper.sh}"
+	[[ -x "$scanner" ]] || { snapshot_error "prompt-injection scanner is unavailable"; return 1; }
+	PROMPT_GUARD_POLICY="${ISSUE_BODY_SNAPSHOT_SCANNER_POLICY:-moderate}" \
+		PROMPT_GUARD_QUIET=true "$scanner" check-file "$body_file" >/dev/null 2>&1 || {
+		snapshot_error "prompt-injection scanner blocked the issue body"
+		return 1
+	}
+	return 0
+}
+
+snapshot_validate() {
+	local snapshot_file="$1"
+	local repo_slug="$2"
+	local issue_number="$3"
+	local max_bytes="$4"
+	local ttl_seconds="$5"
+	local mode="" body_file="" expected_hash="" actual_hash="" captured_at="" captured_epoch="" now_epoch=""
+
+	[[ -f "$snapshot_file" ]] || { snapshot_error "no durable fallback exists"; return 1; }
+	mode=$(stat -f '%Lp' "$snapshot_file" 2>/dev/null || stat -c '%a' "$snapshot_file" 2>/dev/null || true)
+	[[ "$mode" == "600" ]] || { snapshot_error "snapshot permissions are ${mode:-unknown}, expected 600"; return 1; }
+	jq -e --arg repo "$repo_slug" --argjson issue "$issue_number" --argjson schema "$SNAPSHOT_SCHEMA_VERSION" \
+		'type == "object" and .schemaVersion == $schema and .repo == $repo and .issue == $issue and
+		 (.title | type == "string") and (.body | type == "string") and
+		 (.sourceUpdatedAt | type == "string") and (.capturedAt | type == "string") and
+		 (.bodyHash | test("^[0-9a-f]{64}$"))' "$snapshot_file" >/dev/null 2>&1 || {
+		snapshot_error "schema or issue identity validation failed"
+		return 1
+	}
+	body_file=$(mktemp "${TMPDIR:-/tmp}/issue-snapshot-body-XXXXXX") || return 1
+	trap 'rm -f "$body_file"' RETURN
+	jq -rj '.body' "$snapshot_file" >"$body_file" || { snapshot_error "body extraction failed"; return 1; }
+	[[ $(wc -c <"$body_file" | tr -d '[:space:]') -le "$max_bytes" ]] || { snapshot_error "body exceeds ${max_bytes}-byte limit"; return 1; }
+	expected_hash=$(jq -r '.bodyHash' "$snapshot_file")
+	actual_hash=$(snapshot_hash "$body_file") || return 1
+	[[ "$actual_hash" == "$expected_hash" ]] || { snapshot_error "body hash validation failed"; return 1; }
+	captured_at=$(jq -r '.capturedAt' "$snapshot_file")
+	captured_epoch=$(snapshot_epoch_from_iso "$captured_at") || { snapshot_error "capture time is invalid"; return 1; }
+	now_epoch=$(date -u '+%s')
+	[[ "$captured_epoch" -le "$now_epoch" && $((now_epoch - captured_epoch)) -le "$ttl_seconds" ]] || {
+		snapshot_error "snapshot is stale or has a future capture time"
+		return 1
+	}
+	snapshot_scan_body "$body_file" || return 1
+	trap - RETURN
+	rm -f "$body_file"
+	return 0
+}
+
+snapshot_write() {
+	local live_json="$1"
+	local repo_slug="$2"
+	local issue_number="$3"
+	local snapshot_file="$4"
+	local max_bytes="$5"
+	local snapshot_dir="" body_file="" body_hash="" captured_at="" temp_file=""
+
+	snapshot_dir="${snapshot_file%/*}"
+	mkdir -p "$snapshot_dir" || return 1
+	chmod 700 "$snapshot_dir" || return 1
+	body_file=$(mktemp "${TMPDIR:-/tmp}/issue-live-body-XXXXXX") || return 1
+	trap 'rm -f "$body_file" "${temp_file:-}"' RETURN
+	jq -rj '.body' <<<"$live_json" >"$body_file" || return 1
+	[[ $(wc -c <"$body_file" | tr -d '[:space:]') -le "$max_bytes" ]] || { snapshot_error "live body exceeds ${max_bytes}-byte limit"; return 1; }
+	snapshot_scan_body "$body_file" || return 1
+	body_hash=$(snapshot_hash "$body_file") || return 1
+	captured_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+	temp_file=$(mktemp "${snapshot_dir}/.snapshot-XXXXXX") || return 1
+	umask 077
+	jq -c --argjson schema "$SNAPSHOT_SCHEMA_VERSION" --arg repo "$repo_slug" --argjson issue "$issue_number" \
+		--arg captured "$captured_at" --arg hash "$body_hash" \
+		'{schemaVersion: $schema, repo: $repo, issue: $issue, title: .title, body: .body,
+		 sourceUpdatedAt: .updatedAt, capturedAt: $captured, bodyHash: $hash}' <<<"$live_json" >"$temp_file" || return 1
+	chmod 600 "$temp_file" || return 1
+	mv -f "$temp_file" "$snapshot_file" || return 1
+	trap - RETURN
+	rm -f "$body_file"
+	return 0
+}
+
+snapshot_fetch() {
+	local repo_slug="$1"
+	local issue_number="$2"
+	local max_bytes="${ISSUE_BODY_SNAPSHOT_MAX_BYTES:-65536}"
+	local ttl_seconds="${ISSUE_BODY_SNAPSHOT_TTL_SECONDS:-86400}"
+	local snapshot_file="" live_json=""
+	[[ "$repo_slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || { snapshot_error "repository identity is invalid"; return 1; }
+	[[ "$issue_number" =~ ^[1-9][0-9]*$ ]] || { snapshot_error "issue identity is invalid"; return 1; }
+	[[ "$max_bytes" =~ ^[1-9][0-9]*$ ]] || { snapshot_error "body limit is invalid"; return 1; }
+	[[ "$ttl_seconds" =~ ^[1-9][0-9]*$ ]] || { snapshot_error "TTL is invalid"; return 1; }
+	snapshot_file=$(snapshot_path "$repo_slug" "$issue_number")
+
+	live_json=$(gh issue view "$issue_number" --repo "$repo_slug" --json number,title,body,updatedAt 2>/dev/null) && {
+		jq -e --argjson issue "$issue_number" '.number == $issue and (.title | type == "string") and (.body | type == "string") and (.updatedAt | type == "string")' \
+			<<<"$live_json" >/dev/null 2>&1 || { snapshot_error "live response validation failed"; return 1; }
+		if [[ "${ISSUE_BODY_SNAPSHOT_ENABLED:-1}" == "1" ]]; then
+			snapshot_write "$live_json" "$repo_slug" "$issue_number" "$snapshot_file" "$max_bytes" || return 1
+		else
+			local live_body_file=""
+			live_body_file=$(mktemp "${TMPDIR:-/tmp}/issue-live-body-XXXXXX") || return 1
+			jq -rj '.body' <<<"$live_json" >"$live_body_file"
+			[[ $(wc -c <"$live_body_file" | tr -d '[:space:]') -le "$max_bytes" ]] && snapshot_scan_body "$live_body_file" || { rm -f "$live_body_file"; return 1; }
+			rm -f "$live_body_file"
+		fi
+		printf '%s' "$live_json"
+		return 0
+	}
+
+	[[ "${ISSUE_BODY_SNAPSHOT_ENABLED:-1}" == "1" ]] || { snapshot_error "live GitHub read failed and snapshots are disabled"; return 1; }
+	snapshot_validate "$snapshot_file" "$repo_slug" "$issue_number" "$max_bytes" "$ttl_seconds" || return 1
+	jq -c '{number: .issue, title, body, updatedAt: .sourceUpdatedAt, snapshotFallback: true}' "$snapshot_file"
+	return 0
+}
+
+snapshot_cleanup() {
+	local snapshot_dir="${ISSUE_BODY_SNAPSHOT_DIR:-${HOME}/.aidevops/cache/issue-body-snapshots}"
+	local ttl_seconds="${ISSUE_BODY_SNAPSHOT_TTL_SECONDS:-86400}"
+	local file="" captured_at="" captured_epoch="" now_epoch=""
+	[[ -d "$snapshot_dir" ]] || return 0
+	now_epoch=$(date -u '+%s')
+	for file in "$snapshot_dir"/*.json; do
+		[[ -f "$file" ]] || continue
+		captured_at=$(jq -r '.capturedAt // empty' "$file" 2>/dev/null || true)
+		captured_epoch=$(snapshot_epoch_from_iso "$captured_at" 2>/dev/null || true)
+		if [[ ! "$captured_epoch" =~ ^[0-9]+$ || $((now_epoch - captured_epoch)) -gt "$ttl_seconds" ]]; then
+			rm -f "$file"
+		fi
+	done
+	return 0
+}
+
+main() {
+	local command="${1:-}"
+	case "$command" in
+	fetch)
+		[[ $# -eq 3 ]] || { snapshot_error "usage: $0 fetch OWNER/REPO ISSUE"; return 1; }
+		snapshot_fetch "$2" "$3"
+		return $?
+		;;
+	cleanup)
+		snapshot_cleanup
+		return $?
+		;;
+	*)
+		snapshot_error "expected fetch or cleanup"
+		return 1
+		;;
+	esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+	exit $?
+fi

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -459,11 +459,13 @@ _dlw_comment_bloat_requires_clean_room() {
 _dlw_fetch_issue_body_for_clean_room() {
 	local issue_number="$1"
 	local repo_slug="$2"
+	local snapshot_helper="${ISSUE_BODY_SNAPSHOT_HELPER:-${BASH_SOURCE[0]%/*}/issue-body-snapshot-helper.sh}"
+	local issue_json=""
 
-	local issue_body=""
-	issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body --jq '.body // ""' 2>/dev/null) || issue_body=""
-	printf '%s' "$issue_body"
-	return 0
+	[[ -x "$snapshot_helper" ]] || return 1
+	issue_json=$("$snapshot_helper" fetch "$repo_slug" "$issue_number") || return 1
+	jq -rj '.body' <<<"$issue_json"
+	return $?
 }
 
 _dlw_clean_room_prompt() {
@@ -524,6 +526,14 @@ _dlw_zero_output_fallback_prompt() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local issue_title="$3"
+	local snapshot_ready="${4:-0}"
+	local snapshot_instruction=""
+
+	if [[ "$snapshot_ready" == "1" ]]; then
+		snapshot_instruction="2. If that live read is unavailable, read the bounded validated snapshot with: ~/.aidevops/agents/scripts/issue-body-snapshot-helper.sh fetch ${repo_slug} ${issue_number}"
+	else
+		snapshot_instruction="2. No validated snapshot was captured. If the live read fails, stop and report that implementation is not authorized without trusted issue context."
+	fi
 
 	cat <<EOF
 You are assigned to work on issue #${issue_number} in ${repo_slug}.
@@ -532,9 +542,10 @@ Previous dispatch attempts for this issue launched a worker but produced zero se
 
 First actions:
 1. Read the issue directly with: gh issue view ${issue_number} --repo ${repo_slug}
-2. Ignore ops/provenance/audit comments as implementation context.
-3. Summarize the actionable task, files, and verification before editing.
-4. If the issue brief is malformed, too broad, or not worker-ready, rewrite the brief or split it into smaller worker-ready issues instead of attempting a speculative implementation.
+${snapshot_instruction}
+3. Ignore ops/provenance/audit comments as implementation context.
+4. Summarize the actionable task, files, and verification before editing.
+5. If the issue brief is malformed, too broad, or not worker-ready, rewrite the brief or split it into smaller worker-ready issues instead of attempting a speculative implementation.
 
 Issue title: ${issue_title:-Issue #${issue_number}}
 EOF
@@ -576,7 +587,11 @@ _dlw_prepare_prompt_for_launch() {
 
 	if _dlw_comment_bloat_requires_clean_room "$issue_number" "$repo_slug" "$comment_metrics"; then
 		local issue_body=""
-		issue_body=$(_dlw_fetch_issue_body_for_clean_room "$issue_number" "$repo_slug")
+		if ! issue_body=$(_dlw_fetch_issue_body_for_clean_room "$issue_number" "$repo_slug"); then
+			echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: clean-room issue body unavailable; implementation is not authorized" >>"$LOGFILE"
+			_dlw_clean_room_prompt "$issue_number" "$repo_slug" "$issue_title" "BLOCKER: The live issue body and its validated durable snapshot are unavailable. Do not implement from this prompt. Retry the live gh issue view command and report the snapshot validation error if it remains unavailable."
+			return 0
+		fi
 		_dlw_clean_room_prompt "$issue_number" "$repo_slug" "$issue_title" "$issue_body"
 		_dlw_first_pass_completion_contract
 		return 0
@@ -589,8 +604,13 @@ _dlw_prepare_prompt_for_launch() {
 	[[ "$fallback_threshold" =~ ^[0-9]+$ ]] || fallback_threshold=2
 
 	if [[ "$zero_count" -ge "$fallback_threshold" ]]; then
+		local snapshot_helper="${ISSUE_BODY_SNAPSHOT_HELPER:-${BASH_SOURCE[0]%/*}/issue-body-snapshot-helper.sh}"
+		local snapshot_ready=0
+		if [[ -x "$snapshot_helper" ]] && "$snapshot_helper" fetch "$repo_slug" "$issue_number" >/dev/null 2>&1; then
+			snapshot_ready=1
+		fi
 		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: using URL-only bootstrap prompt after ${zero_count} zero-output launches" >>"$LOGFILE"
-		_dlw_zero_output_fallback_prompt "$issue_number" "$repo_slug" "$issue_title"
+		_dlw_zero_output_fallback_prompt "$issue_number" "$repo_slug" "$issue_title" "$snapshot_ready"
 		_dlw_first_pass_completion_contract
 		return 0
 	fi

--- a/.agents/scripts/tests/test-issue-body-snapshot-helper.sh
+++ b/.agents/scripts/tests/test-issue-body-snapshot-helper.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../issue-body-snapshot-helper.sh"
+TEST_TMP="$(mktemp -d "${TMPDIR:-/tmp}/issue-snapshot-test-XXXXXX")"
+FAKE_BIN="${TEST_TMP}/bin"
+mkdir -p "$FAKE_BIN"
+
+cleanup() {
+	rm -rf "$TEST_TMP"
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+}
+
+cat >"${FAKE_BIN}/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${GH_FAIL:-0}" == "1" ]]; then exit 1; fi
+printf '%s' '{"number":45,"title":"Bounded context","body":"Implement focused tests.","updatedAt":"2026-07-12T10:00:00Z"}'
+EOF
+cat >"${FAKE_BIN}/scanner" <<'EOF'
+#!/usr/bin/env bash
+[[ "${SCANNER_BLOCK:-0}" != "1" ]]
+EOF
+chmod +x "${FAKE_BIN}/gh" "${FAKE_BIN}/scanner"
+
+export PATH="${FAKE_BIN}:${PATH}"
+export ISSUE_BODY_SNAPSHOT_DIR="${TEST_TMP}/snapshots"
+export ISSUE_BODY_SNAPSHOT_SCANNER="${FAKE_BIN}/scanner"
+
+live=$("$HELPER" fetch owner/repo 45) || fail "live fetch failed"
+[[ "$live" == *'"body":"Implement focused tests."'* ]] || fail "live body was not returned"
+snapshot="${ISSUE_BODY_SNAPSHOT_DIR}/owner_repo-45.json"
+[[ -f "$snapshot" ]] || fail "snapshot was not written"
+mode=$(stat -f '%Lp' "$snapshot" 2>/dev/null || stat -c '%a' "$snapshot")
+[[ "$mode" == "600" ]] || fail "snapshot mode is ${mode}"
+jq -e '.repo == "owner/repo" and .issue == 45 and .title and .body and .sourceUpdatedAt and .capturedAt and .bodyHash' "$snapshot" >/dev/null || fail "snapshot schema is incomplete"
+
+fallback=$(GH_FAIL=1 "$HELPER" fetch owner/repo 45) || fail "validated fallback failed"
+[[ "$fallback" == *'"snapshotFallback":true'* ]] || fail "fallback was not identified"
+
+if GH_FAIL=1 ISSUE_BODY_SNAPSHOT_ENABLED=0 "$HELPER" fetch owner/repo 45 2>"${TEST_TMP}/error"; then fail "disabled snapshot fallback was accepted"; fi
+[[ "$(<"${TEST_TMP}/error")" == *"snapshots are disabled"* ]] || fail "rollback flag blocker was not precise"
+
+jq '.repo = "other/repo"' "$snapshot" >"${snapshot}.tmp" && chmod 600 "${snapshot}.tmp" && mv "${snapshot}.tmp" "$snapshot"
+if GH_FAIL=1 "$HELPER" fetch owner/repo 45 2>"${TEST_TMP}/error"; then fail "identity-mismatched snapshot was accepted"; fi
+[[ "$(<"${TEST_TMP}/error")" == *"identity validation failed"* ]] || fail "identity blocker was not precise"
+
+GH_FAIL=0 "$HELPER" fetch owner/repo 45 >/dev/null || fail "snapshot refresh failed"
+jq '.capturedAt = "2020-01-01T00:00:00Z"' "$snapshot" >"${snapshot}.tmp" && chmod 600 "${snapshot}.tmp" && mv "${snapshot}.tmp" "$snapshot"
+if GH_FAIL=1 "$HELPER" fetch owner/repo 45 2>"${TEST_TMP}/error"; then fail "stale snapshot was accepted"; fi
+[[ "$(<"${TEST_TMP}/error")" == *"snapshot is stale"* ]] || fail "stale blocker was not precise"
+
+"$HELPER" cleanup || fail "cleanup failed"
+[[ ! -e "$snapshot" ]] || fail "cleanup retained an expired snapshot"
+GH_FAIL=0 "$HELPER" fetch owner/repo 45 >/dev/null || fail "snapshot recreation failed"
+
+jq '.body = "tampered"' "$snapshot" >"${snapshot}.tmp" && chmod 600 "${snapshot}.tmp" && mv "${snapshot}.tmp" "$snapshot"
+if GH_FAIL=1 "$HELPER" fetch owner/repo 45 2>"${TEST_TMP}/error"; then fail "tampered snapshot was accepted"; fi
+[[ "$(<"${TEST_TMP}/error")" == *"body hash validation failed"* ]] || fail "tamper blocker was not precise"
+
+GH_FAIL=0 "$HELPER" fetch owner/repo 45 >/dev/null || fail "snapshot refresh failed"
+chmod 644 "$snapshot"
+if GH_FAIL=1 "$HELPER" fetch owner/repo 45 2>"${TEST_TMP}/error"; then fail "unsafe permissions were accepted"; fi
+[[ "$(<"${TEST_TMP}/error")" == *"expected 600"* ]] || fail "permission blocker was not precise"
+
+chmod 600 "$snapshot"
+if GH_FAIL=1 SCANNER_BLOCK=1 "$HELPER" fetch owner/repo 45 2>"${TEST_TMP}/error"; then fail "scanner-blocked snapshot was accepted"; fi
+[[ "$(<"${TEST_TMP}/error")" == *"scanner blocked"* ]] || fail "scanner blocker was not precise"
+
+if ISSUE_BODY_SNAPSHOT_MAX_BYTES=5 "$HELPER" fetch owner/repo 45 2>"${TEST_TMP}/error"; then fail "oversized live body was accepted"; fi
+[[ "$(<"${TEST_TMP}/error")" == *"exceeds 5-byte limit"* ]] || fail "size blocker was not precise"
+
+printf 'PASS: issue body snapshots are bounded, validated, fallback-only, and mode 0600\n'
+exit 0

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
@@ -62,6 +62,7 @@ LOGFILE="${TEST_TMP}/pulse.log" \
 	CLEAN_ROOM_COMMENT_CHARS_THRESHOLD=50000 \
 	ZERO_OUTPUT_URL_FALLBACK_THRESHOLD=1 \
 	FAST_FAIL_STATE_FILE="" \
+	ISSUE_BODY_SNAPSHOT_HELPER="/usr/bin/true" \
 	_dlw_prepare_prompt_for_launch "123" "owner/repo" "Metric test" "original prompt" >"${TEST_TMP}/prompt"
 
 if [[ "$(<"${TEST_TMP}/prompt")" != *"Previous dispatch attempts"* ]]; then
@@ -77,6 +78,18 @@ if [[ "$_DLW_ZERO_OUTPUT_EVIDENCE_PATTERN" != *"worker_noop_zero_output"* || "$_
 	fail "shared zero-output evidence pattern lost expected alternatives"
 fi
 
+LOGFILE="${TEST_TMP}/pulse.log" \
+	ISSUE_BODY_SNAPSHOT_HELPER="/usr/bin/false" \
+	CLEAN_ROOM_COMMENT_THRESHOLD=1 \
+	_dlw_prepare_prompt_for_launch "123" "owner/repo" "Metric test" "original composed prompt" $'1\t0\t0\t1' >"${TEST_TMP}/blocked-prompt"
+if [[ "$(<"${TEST_TMP}/blocked-prompt")" != *"Do not implement from this prompt"* ]]; then
+	fail "invalid clean-room snapshot did not produce a non-authorizing blocker"
+fi
+if [[ "$(<"${TEST_TMP}/blocked-prompt")" == *"original composed prompt"* ]]; then
+	fail "clean-room blocker leaked the original composed prompt"
+fi
+
 printf 'PASS: dispatch prompt reuses comment metrics for zero-output fallback\n'
 printf 'PASS: zero-output evidence detection uses one shared pattern\n'
+printf 'PASS: invalid clean-room snapshots cannot authorize implementation\n'
 exit 0

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -72,13 +72,26 @@ write_state() {
 
 write_state 2
 GH_COMMENT_METRICS=""
+ISSUE_BODY_SNAPSHOT_HELPER="/usr/bin/true"
+export ISSUE_BODY_SNAPSHOT_HELPER
 fallback_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
 if printf '%s' "$fallback_prompt" | grep -q 'gh issue view 123 --repo owner/repo' \
+	&& printf '%s' "$fallback_prompt" | grep -q 'issue-body-snapshot-helper.sh fetch owner/repo 123' \
 	&& ! printf '%s' "$fallback_prompt" | grep -q 'FULL EMBEDDED BRIEF'; then
 	pass "repeated zero-output launches switch to URL-only bootstrap prompt"
 else
 	fail "repeated zero-output launches switch to URL-only bootstrap prompt" "$fallback_prompt"
 fi
+
+ISSUE_BODY_SNAPSHOT_HELPER="/usr/bin/false"
+fallback_without_snapshot=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
+if [[ "$fallback_without_snapshot" == *"implementation is not authorized"* ]] \
+	&& [[ "$fallback_without_snapshot" != *"issue-body-snapshot-helper.sh fetch"* ]]; then
+	pass "URL-only fallback refuses implementation when snapshot capture fails"
+else
+	fail "URL-only fallback refuses implementation when snapshot capture fails" "$fallback_without_snapshot"
+fi
+ISSUE_BODY_SNAPSHOT_HELPER="/usr/bin/true"
 
 write_state 1
 GH_COMMENT_ZERO_COUNT=0
@@ -120,6 +133,12 @@ write_state 1
 GH_COMMENT_ZERO_COUNT=0
 GH_COMMENT_METRICS=$'275\t260\t87\t81500'
 GH_ISSUE_BODY="Clean body only: change app notifications query usage."
+cat >"${TMP}/snapshot-helper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '{"body":"Clean body only: change app notifications query usage."}'
+EOF
+chmod +x "${TMP}/snapshot-helper"
+ISSUE_BODY_SNAPSHOT_HELPER="${TMP}/snapshot-helper"
 clean_room_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF WITH COMMENTS")
 if printf '%s' "$clean_room_prompt" | grep -q 'clean-room brief mode' \
 	&& printf '%s' "$clean_room_prompt" | grep -q 'Clean body only' \


### PR DESCRIPTION
## Summary

- Capture bounded issue-body snapshots for URL-only worker recovery.
- Validate identity, schema, size, SHA-256, age, permissions, and prompt-injection policy before fallback use.
- Keep live GitHub authoritative and refuse implementation when no trusted context is available.

## Runtime Testing

- Runtime-verified through focused shell integration tests covering live success, fallback, tampering, staleness, identity mismatch, permissions, scanner rejection, size limits, cleanup, and rollback.

## Testing

- `.agents/scripts/tests/test-issue-body-snapshot-helper.sh`
- `.agents/scripts/tests/test-zero-output-url-fallback.sh` (12 tests)
- `bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh`
- ShellCheck on all changed shell files
- `.agents/scripts/linters-local.sh`

Resolves #27445

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 31m and 74,024 tokens on this with the user in an interactive session.
