### PR TITLE
t18113: Improve pulse capacity and full-loop continuity

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -46,6 +46,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 - Use TodoWrite for multi-step work. Mark one task in progress and complete items immediately.
 - Infer task intent: `/full-loop` or "work on this now" means implement now; "background/worker" means create a worker-ready brief and auto-dispatch; "later/save/log" means brief for later and ask numbered dispatch options. Task and issue bodies use `workflows/brief.md`. Details: `reference/task-lifecycle.md`.
+- In an interactive session, full-loop authorisation means continue through implementation, verification, PR, review, merge, release/deploy when applicable, and cleanup without pausing between stages unless materially blocked. Report the exact verified stage; never describe the loop as running or underway unless a live loop process/job was verified.
 - An issue-started interactive implementation remains local even when run asynchronously; it overrides generic background-worker intent. Details: `reference/task-lifecycle.md` "Issue-start override".
 - Keep interactive subagents off the critical path and bounded; prefix delegated prompts with the lowest sufficient `[effort:simple|standard|thinking]`; details: `reference/agent-routing.md`.
 - When a context-rich session has already established safe, actionable work and the user authorises execution, preserve momentum through implementation and verification in that session; do not defer merely to reduce the current session's scope.

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -1151,6 +1151,12 @@ _report_failure_to_fast_fail() {
 			return 0
 		fi
 	fi
+	if declare -F _worker_failure_reason_is_completion_infrastructure >/dev/null 2>&1; then
+		if _worker_failure_reason_is_completion_infrastructure "$reason"; then
+			print_info "[fast-fail] skipped completion infrastructure failure #${issue_number} (${repo_slug}) reason=${reason}"
+			return 0
+		fi
+	fi
 
 	local state_file="${HOME}/.aidevops/.agent-workspace/supervisor/fast-fail-counter.json"
 	local state_dir

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -793,6 +793,14 @@ _derive_worker_failure_evidence() {
 	local launch_failure_cause=""
 	local next_action="inspect_failure_excerpt"
 
+	if declare -F _worker_failure_reason_is_completion_infrastructure >/dev/null 2>&1 && \
+		_worker_failure_reason_is_completion_infrastructure "$failure_reason"; then
+		launch_failure_cause="$failure_reason"
+		next_action="resume_session_with_completion_contract"
+		printf '%s\t%s\n' "$launch_failure_cause" "$next_action"
+		return 0
+	fi
+
 	case "$result_label" in
 	no_activity | watchdog_startup_continue)
 		launch_failure_cause="startup_no_model_activity"

--- a/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
+++ b/.agents/scripts/pulse-dispatch-current-state-guardrails.sh
@@ -11,9 +11,51 @@
 _PULSE_DISPATCH_CURRENT_STATE_GUARDRAILS_LOADED=1
 
 #######################################
+# Filter ordinary candidates when their repository has reached its open-PR cap.
+#
+# Args:
+#   $1 - repository slug
+#   $2 - candidate JSON array
+# Stdout: filtered candidate JSON array.
+#######################################
+_dispatch_filter_repo_pr_backlog_candidates() {
+	local repo_slug="$1"
+	local candidates_json="$2"
+	local pr_threshold="${PULSE_DISPATCH_GUARDRAIL_OPEN_PR_THRESHOLD:-12}"
+	[[ "$pr_threshold" =~ ^[0-9]+$ ]] || pr_threshold=12
+	if [[ "$pr_threshold" -eq 0 ]] || ! command -v jq >/dev/null 2>&1 || ! declare -F pulse_pr_list_get >/dev/null 2>&1; then
+		printf '%s\n' "$candidates_json"
+		return 0
+	fi
+
+	local pr_json="" open_prs=0 filtered_json="" candidate_count=0 filtered_count=0
+	pr_json=$(pulse_pr_list_get --repo "$repo_slug" --state open --json number --limit "$pr_threshold" 2>/dev/null) || {
+		printf '%s\n' "$candidates_json"
+		return 0
+	}
+	open_prs=$(jq 'if type == "array" then length else 0 end' <<<"$pr_json" 2>/dev/null) || open_prs=0
+	[[ "$open_prs" =~ ^[0-9]+$ ]] || open_prs=0
+	if ((open_prs < pr_threshold)); then
+		printf '%s\n' "$candidates_json"
+		return 0
+	fi
+
+	filtered_json=$(jq -c '[.[] | select(
+		((.labels // []) | map(.name? // .)) as $labels |
+		(($labels | index("quality-debt")) != null and ($labels | index("source:review-feedback")) != null)
+	)]' <<<"$candidates_json" 2>/dev/null) || filtered_json="$candidates_json"
+	candidate_count=$(jq 'length' <<<"$candidates_json" 2>/dev/null) || candidate_count=0
+	filtered_count=$(jq 'length' <<<"$filtered_json" 2>/dev/null) || filtered_count="$candidate_count"
+	echo "[pulse-wrapper] Repository PR backlog guardrail: repo=${repo_slug} open_prs=${open_prs} threshold=${pr_threshold} ordinary_candidates_suppressed=$((candidate_count - filtered_count)) exempt_candidates=${filtered_count}" >>"$LOGFILE"
+	_dispatch_stats_increment "pulse_dispatch_repo_pr_backlog_guardrail_applied"
+	printf '%s\n' "$filtered_json"
+	return 0
+}
+
+#######################################
 # Count recent current-state signals that should shape launch capacity.
 #
-# Stdout: "<successes> <failures> <rate_limits> <healthy_prs> <no_dispatchable>".
+# Stdout: "<successes> <failures> <rate_limits> <no_dispatchable>".
 #######################################
 _dispatch_recent_current_state_counts() {
 	local override_line="${PULSE_DISPATCH_CURRENT_STATE_COUNTS:-}"
@@ -23,10 +65,10 @@ _dispatch_recent_current_state_counts() {
 	fi
 
 	local metrics_file="${AIDEVOPS_HEADLESS_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
-	local log_file="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
 	local window_seconds="${PULSE_DISPATCH_CURRENT_STATE_WINDOW_SECONDS:-900}"
 	[[ "$window_seconds" =~ ^[0-9]+$ ]] || window_seconds=900
-	python3 - "$metrics_file" "$log_file" "$window_seconds" <<'PY'
+	local metrics_counts=""
+	metrics_counts=$(python3 - "$metrics_file" "${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}" "$window_seconds" <<'PY'
 import json
 import sys
 import time
@@ -59,23 +101,23 @@ try:
 except (OSError, ValueError):
     pass
 
-healthy_prs = no_dispatchable = 0
+no_dispatchable = 0
 try:
-    # pulse.log lines usually do not carry machine timestamps, so use the recent tail
-    # as a bounded local current-state proxy rather than issuing API reads.
     with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
         lines = deque(handle, 2000)
     for raw in lines:
         line = raw.lower()
-        if "pr opened" in line or "opened pr" in line or "pr merged" in line or "merged pr" in line:
-            healthy_prs += 1
         if "no ranked candidates" in line or "no eligible candidates" in line or "no dispatchable" in line:
             no_dispatchable += 1
 except OSError:
     pass
 
-print(f"{successes} {failures} {rate_limits} {healthy_prs} {no_dispatchable}")
+print(f"{successes} {failures} {rate_limits} {no_dispatchable}")
 PY
+	) || metrics_counts="0 0 0 0"
+	local successes="" failures="" rate_limits="" no_dispatchable=""
+	read -r successes failures rate_limits no_dispatchable <<<"$metrics_counts"
+	printf '%s %s %s %s\n' "$successes" "$failures" "$rate_limits" "$no_dispatchable"
 	return 0
 }
 
@@ -105,27 +147,23 @@ _dispatch_apply_current_state_guardrails() {
 		return 0
 	fi
 
-	local counts_line="" successes="" failures="" rate_limits="" healthy_prs="" no_dispatchable=""
-	counts_line=$(_dispatch_recent_current_state_counts) || counts_line="0 0 0 0 0"
-	read -r successes failures rate_limits healthy_prs no_dispatchable <<<"$counts_line"
+	local counts_line="" successes="" failures="" rate_limits="" no_dispatchable=""
+	counts_line=$(_dispatch_recent_current_state_counts) || counts_line="0 0 0 0"
+	read -r successes failures rate_limits no_dispatchable <<<"$counts_line"
 	[[ "$successes" =~ ^[0-9]+$ ]] || successes=0
 	[[ "$failures" =~ ^[0-9]+$ ]] || failures=0
 	[[ "$rate_limits" =~ ^[0-9]+$ ]] || rate_limits=0
-	[[ "$healthy_prs" =~ ^[0-9]+$ ]] || healthy_prs=0
 	[[ "$no_dispatchable" =~ ^[0-9]+$ ]] || no_dispatchable=0
 	_dispatch_stats_gauge "pulse_dispatch_guardrail_successes" "$successes"
 	_dispatch_stats_gauge "pulse_dispatch_guardrail_failures" "$failures"
 	_dispatch_stats_gauge "pulse_dispatch_guardrail_rate_limits" "$rate_limits"
-	_dispatch_stats_gauge "pulse_dispatch_guardrail_healthy_prs" "$healthy_prs"
 	_dispatch_stats_gauge "pulse_dispatch_guardrail_no_dispatchable" "$no_dispatchable"
 
 	local rl_threshold="${PULSE_DISPATCH_GUARDRAIL_RATE_LIMIT_THRESHOLD:-4}"
 	local failure_threshold="${PULSE_DISPATCH_GUARDRAIL_FAILURE_THRESHOLD:-6}"
-	local pr_threshold="${PULSE_DISPATCH_GUARDRAIL_HEALTHY_PR_THRESHOLD:-3}"
 	local empty_threshold="${PULSE_DISPATCH_GUARDRAIL_NO_DISPATCHABLE_THRESHOLD:-2}"
 	[[ "$rl_threshold" =~ ^[0-9]+$ ]] || rl_threshold=4
 	[[ "$failure_threshold" =~ ^[0-9]+$ ]] || failure_threshold=6
-	[[ "$pr_threshold" =~ ^[0-9]+$ ]] || pr_threshold=3
 	[[ "$empty_threshold" =~ ^[0-9]+$ ]] || empty_threshold=2
 
 	local capped_slots="$available_slots" reason=""
@@ -153,18 +191,15 @@ _dispatch_apply_current_state_guardrails() {
 	elif ((failure_threshold > 0 && failures >= failure_threshold && capped_slots > 1)); then
 		capped_slots=1
 		reason="repeated_failure_pressure"
-	elif ((pr_threshold > 0 && healthy_prs >= pr_threshold && failures > successes && capped_slots > 1)); then
-		capped_slots=1
-		reason="healthy_pr_backlog"
 	fi
 
 	if ((capped_slots < available_slots)); then
 		max_workers=$((active_workers + capped_slots))
-		echo "[pulse-wrapper] Dispatch current-state guardrail: reason=${reason} capped_available=${capped_slots}/${available_slots} successes=${successes} failures=${failures} rate_limits=${rate_limits} healthy_prs=${healthy_prs} no_dispatchable=${no_dispatchable} min_worker_floor_active=${min_worker_floor_active}" >>"$LOGFILE"
+		echo "[pulse-wrapper] Dispatch current-state guardrail: reason=${reason} capped_available=${capped_slots}/${available_slots} successes=${successes} failures=${failures} rate_limits=${rate_limits} no_dispatchable=${no_dispatchable} min_worker_floor_active=${min_worker_floor_active}" >>"$LOGFILE"
 		_dispatch_stats_increment "pulse_dispatch_current_state_guardrail_applied"
 		_dispatch_stats_increment_candidate_failed "$reason"
 	elif [[ "$reason" == "no_dispatchable_floor_bypass" ]]; then
-		echo "[pulse-wrapper] Dispatch current-state guardrail: reason=${reason} preserved_available=${available_slots} successes=${successes} failures=${failures} rate_limits=${rate_limits} healthy_prs=${healthy_prs} no_dispatchable=${no_dispatchable} min_worker_floor_active=${min_worker_floor_active}" >>"$LOGFILE"
+		echo "[pulse-wrapper] Dispatch current-state guardrail: reason=${reason} preserved_available=${available_slots} successes=${successes} failures=${failures} rate_limits=${rate_limits} no_dispatchable=${no_dispatchable} min_worker_floor_active=${min_worker_floor_active}" >>"$LOGFILE"
 	fi
 	_dispatch_stats_gauge "pulse_dispatch_guardrail_available_slots" "$capped_slots"
 

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -309,7 +309,7 @@ build_ranked_dispatch_candidates_json() {
 			continue
 		fi
 
-		printf '%s' "$repo_candidates_json" | jq -c --arg slug "$repo_slug" --arg path "$repo_path" --arg priority "$repo_priority" '
+		printf '%s' "$repo_candidates_json" | jq -c --arg slug "$repo_slug" --arg path "$repo_path" --arg priority "$repo_priority" --arg debt_label "${QUALITY_DEBT_LABEL:-quality-debt}" '
 			.[] |
 			. + {
 				repo_slug: $slug,
@@ -329,13 +329,13 @@ build_ranked_dispatch_candidates_json() {
 					(if ($labels | index("auto-dispatch")) != null then 300 else 0 end) -
 					(if ($labels | index("tier:thinking")) != null then 1200 else 0 end) -
 					(if (($labels | index("research")) != null or ($labels | index("needs-design")) != null) then 800 else 0 end) +
-					(if (($labels | index("quality-debt")) != null and ($labels | index("security")) != null) then 500 else 0 end) +
+					(if (($labels | index($debt_label)) != null and ($labels | index("security")) != null) then 500 else 0 end) +
 					(if ($labels | index("priority:critical")) != null then 10000
 					 elif ($labels | index("priority:high")) != null then 9000
 					 elif ($labels | index("priority:medium")) != null then 8000
 					 elif ($labels | index("bug")) != null then 7000
 					 elif ($labels | index("enhancement")) != null then 6000
-					 elif ($labels | index("quality-debt")) != null then 5000
+					 elif ($labels | index($debt_label)) != null then 5000
 					 elif (($labels | index("file-size-debt")) != null or ($labels | index("function-complexity-debt")) != null) then 4000
 					 elif ($labels | index("priority:low")) != null then 3500
 					 else 3000 end)
@@ -396,9 +396,9 @@ _dispatch_order_idle_borrowing_candidates() {
 		debt_cap_pct=100
 	fi
 
-	printf '%s' "$candidates_json" | jq -c --argjson cap "$((available_slots * debt_cap_pct / 100))" '
+	printf '%s' "$candidates_json" | jq -c --argjson cap "$((available_slots * debt_cap_pct / 100))" --arg debt_label "${QUALITY_DEBT_LABEL:-quality-debt}" '
 		def trusted_review_debt:
-			((.labels // []) | index("quality-debt")) != null and
+			((.labels // []) | index($debt_label)) != null and
 			((.labels // []) | index("source:review-feedback")) != null;
 		[.[] | select(trusted_review_debt)] as $debt |
 		[.[] | select(trusted_review_debt | not)] as $ordinary |

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -304,6 +304,7 @@ build_ranked_dispatch_candidates_json() {
 		update_repo_pulse_timestamp "$repo_slug"
 		local repo_candidates_json
 		repo_candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$per_repo_limit") || repo_candidates_json='[]'
+		repo_candidates_json=$(_dispatch_filter_repo_pr_backlog_candidates "$repo_slug" "$repo_candidates_json")
 		if [[ -z "$repo_candidates_json" || "$repo_candidates_json" == "[]" ]]; then
 			continue
 		fi
@@ -371,6 +372,38 @@ build_ranked_dispatch_candidates_json() {
 
 	jq -cs 'sort_by([-.score, (.updatedAt // "")])' "$tmp_candidates" 2>/dev/null || printf '[]\n'
 	rm -f "$tmp_candidates"
+	return 0
+}
+
+#######################################
+# Keep trusted review-feedback debt within its fairness share while ordinary
+# candidates remain. Excess debt stays at the tail so it can borrow capacity
+# only after ordinary candidates have been attempted by the existing gates.
+#
+# Arguments:
+#   $1 - ranked candidate JSON array
+#   $2 - available implementation slots
+# Returns: reordered JSON array
+#######################################
+_dispatch_order_idle_borrowing_candidates() {
+	local candidates_json="$1"
+	local available_slots="$2"
+	local debt_cap_pct="${QUALITY_DEBT_CAP_PCT:-30}"
+
+	[[ "$available_slots" =~ ^[0-9]+$ ]] || available_slots=0
+	[[ "$debt_cap_pct" =~ ^[0-9]+$ ]] || debt_cap_pct=30
+	if [[ "$debt_cap_pct" -gt 100 ]]; then
+		debt_cap_pct=100
+	fi
+
+	printf '%s' "$candidates_json" | jq -c --argjson cap "$((available_slots * debt_cap_pct / 100))" '
+		def trusted_review_debt:
+			((.labels // []) | index("quality-debt")) != null and
+			((.labels // []) | index("source:review-feedback")) != null;
+		[.[] | select(trusted_review_debt)] as $debt |
+		[.[] | select(trusted_review_debt | not)] as $ordinary |
+		($debt[0:$cap] + $ordinary + $debt[$cap:])
+	' 2>/dev/null || printf '%s\n' "$candidates_json"
 	return 0
 }
 
@@ -442,6 +475,7 @@ dispatch_max() {
 	[[ "$available_slots" =~ ^[0-9]+$ ]] || available_slots=0
 	[[ "$triage_dispatched" =~ ^[0-9]+$ ]] || triage_dispatched=0
 	pulse_dispatch_debug_log "post-prepasses available_slots=${available_slots} triage_dispatched=${triage_dispatched}"
+	candidates_json=$(_dispatch_order_idle_borrowing_candidates "$candidates_json" "$available_slots")
 
 	# Reset module-level round state before the dispatch loop (t1959).
 	_DISPATCH_ROUND_DISPATCHED=0

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1587,6 +1587,17 @@ _dlw_prepare_worker_lineage() {
 	return 0
 }
 
+_dlw_validate_worktree_for_launch() {
+	local issue_number="$1"
+	local worker_worktree_path="$2"
+	if [[ -n "$worker_worktree_path" && -d "$worker_worktree_path" ]]; then
+		return 0
+	fi
+	printf '[pulse-dispatch] worker launch skipped: worktree unavailable for #%s path=%s\n' \
+		"$issue_number" "${worker_worktree_path:-missing}" >>"$LOGFILE"
+	return 1
+}
+
 #######################################
 # Launch a worker process detached from the pulse process group.
 # Stdout: worker PID
@@ -1612,14 +1623,7 @@ _dlw_nohup_launch() {
 	local root_event_id=""
 	_dlw_prepare_worker_lineage "$session_key"
 
-	# The worktree can disappear after pre-creation but before the detached
-	# runtime starts. Reject that race here rather than spending a model launch
-	# on a path OpenCode cannot resolve.
-	if [[ -z "$worker_worktree_path" || ! -d "$worker_worktree_path" ]]; then
-		printf '[pulse-dispatch] worker launch skipped: worktree unavailable for #%s path=%s\n' \
-			"$issue_number" "${worker_worktree_path:-missing}" >>"$LOGFILE"
-		return 1
-	fi
+	_dlw_validate_worktree_for_launch "$issue_number" "$worker_worktree_path" || return 1
 
 	# Use issue title as session title for searchable history, but keep the
 	# issue marker at the beginning so Tabby tabs and OpenCode session search

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1612,6 +1612,15 @@ _dlw_nohup_launch() {
 	local root_event_id=""
 	_dlw_prepare_worker_lineage "$session_key"
 
+	# The worktree can disappear after pre-creation but before the detached
+	# runtime starts. Reject that race here rather than spending a model launch
+	# on a path OpenCode cannot resolve.
+	if [[ -z "$worker_worktree_path" || ! -d "$worker_worktree_path" ]]; then
+		printf '[pulse-dispatch] worker launch skipped: worktree unavailable for #%s path=%s\n' \
+			"$issue_number" "${worker_worktree_path:-missing}" >>"$LOGFILE"
+		return 1
+	fi
+
 	# Use issue title as session title for searchable history, but keep the
 	# issue marker at the beginning so Tabby tabs and OpenCode session search
 	# group worker sessions by issue number.

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -495,6 +495,13 @@ _fast_fail_record_locked() {
 			return 0
 		fi
 	fi
+	if declare -F _worker_failure_reason_is_completion_infrastructure >/dev/null 2>&1; then
+		if _worker_failure_reason_is_completion_infrastructure "$reason"; then
+			printf '[pulse-wrapper] fast_fail_record: #%s (%s) skipped completion infrastructure reason=%s\n' \
+				"$issue_number" "$repo_slug" "$reason" >>"$LOGFILE"
+			return 0
+		fi
+	fi
 
 	local key="" now="" state=""
 	key=$(_ff_key "$issue_number" "$repo_slug")

--- a/.agents/scripts/task-identity-lib.sh
+++ b/.agents/scripts/task-identity-lib.sh
@@ -189,7 +189,9 @@ task_identity_escape_ere() {
 # canonical ID. Callers use this to distinguish invalid input from no marker.
 task_identity_has_malformed_candidate() {
 	local text="${1:-}"
-	local candidate_ere='(^|[^[:alnum:].])([tT][0-9A-Z][[:alnum:].-]*|[tT][oO][[:alnum:]]{26}-[[:alnum:].-]+)($|[^[:alnum:].])'
+	# Spell out the uppercase set: locale collation can make A-Z match lowercase
+	# letters, falsely classifying ordinary words such as "throughput" as IDs.
+	local candidate_ere='(^|[^[:alnum:].])([tT][0123456789][[:alnum:].-]*|t[ABCDEFGHIJKLMNOPQRSTUVWXYZ][[:alnum:].-]*|[tT][oO][[:alnum:]]{26}-[[:alnum:].-]+)($|[^[:alnum:].])'
 	local candidate=""
 	local remaining="$text"
 	local matched=""

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -2751,6 +2751,26 @@ test_post_pr_handoff_overrides_watchdog_next_action() {
 	return 0
 }
 
+test_completion_infrastructure_resumes_without_implementation_penalty() {
+	local reason="" evidence_fields="" launch_failure_cause="" next_action=""
+	for reason in github_api_timeout command_policy_timeout prepared_commit_push_blocked completed_locally_remote_completion_blocked; do
+		if ! _worker_failure_reason_is_completion_infrastructure "$reason"; then
+			print_result "completion infrastructure class ${reason}" 1 "Reason was not classified"
+			continue
+		fi
+		evidence_fields=$(_derive_worker_failure_evidence "blocked" "1" "1" "natural" "$reason")
+		launch_failure_cause="${evidence_fields%%$'\t'*}"
+		next_action="${evidence_fields#*$'\t'}"
+		if [[ "$launch_failure_cause" == "$reason" && "$next_action" == "resume_session_with_completion_contract" ]]; then
+			print_result "completion infrastructure class ${reason}" 0
+		else
+			print_result "completion infrastructure class ${reason}" 1 \
+				"cause='${launch_failure_cause}' next='${next_action}'"
+		fi
+	done
+	return 0
+}
+
 main() {
 	setup_test_env
 	test_appends_escalation_contract
@@ -2793,6 +2813,7 @@ main() {
 	test_post_pr_handoff_detects_open_pending_pr
 	test_post_pr_handoff_rejects_pre_pr_stall
 	test_post_pr_handoff_overrides_watchdog_next_action
+	test_completion_infrastructure_resumes_without_implementation_penalty
 	test_canary_pins_vanilla_agent_with_isolated_plugin_config
 	test_opencode_session_env_wrapper_strips_session_vars_only
 	test_worker_opencode_exec_paths_strip_session_env

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -547,6 +547,22 @@ else
 fi
 
 # =============================================================================
+# Test 11: a worktree deleted after precreation is rejected at launch boundary
+# =============================================================================
+: >"${TMP}/setsid-calls.txt"
+missing_worktree="${TMP}/deleted-after-precreation"
+_dlw_nohup_launch "88888" "owner/repo" "Dispatch" "Issue" "issue-88888" \
+	"${TMP}/worker.log" "/full-loop test" "$FAKE_REPO" "standard" "" \
+	"$missing_worktree" "feature/auto-88888"
+launch_rc=$?
+if [[ "$launch_rc" -eq 1 && ! -s "${TMP}/setsid-calls.txt" ]] && \
+	grep -q "worktree unavailable for #88888" "$LOGFILE"; then
+	pass "launch boundary rejects a missing worker worktree before setsid"
+else
+	fail "launch boundary rejects a missing worker worktree before setsid" "rc=$launch_rc"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 printf '\n%s\n' "--- Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed ---"

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -70,7 +70,7 @@ reset_guardrail_env() {
 	unset AIDEVOPS_SKIP_PULSE_CURRENT_STATE_GUARDRAILS 2>/dev/null || true
 	export PULSE_DISPATCH_GUARDRAIL_RATE_LIMIT_THRESHOLD=4
 	export PULSE_DISPATCH_GUARDRAIL_FAILURE_THRESHOLD=6
-	export PULSE_DISPATCH_GUARDRAIL_HEALTHY_PR_THRESHOLD=3
+	export PULSE_DISPATCH_GUARDRAIL_OPEN_PR_THRESHOLD=12
 	export PULSE_DISPATCH_GUARDRAIL_NO_DISPATCHABLE_THRESHOLD=2
 	return 0
 }
@@ -87,7 +87,7 @@ guardrail_slots() {
 test_provider_rate_limits_pause_without_success() {
 	reset_guardrail_env
 	local slots
-	slots=$(guardrail_slots "0 4 4 0 0" 8)
+	slots=$(guardrail_slots "0 4 4 0" 8)
 	if [[ "$slots" == "0" ]] && grep -q 'provider_rate_limit_pressure' "$LOGFILE"; then
 		print_result "guardrail: provider-wide rate limits pause launches when no success evidence exists" 0
 	else
@@ -99,7 +99,7 @@ test_provider_rate_limits_pause_without_success() {
 test_provider_rate_limits_keep_probe_slot_with_success() {
 	reset_guardrail_env
 	local slots
-	slots=$(guardrail_slots "2 6 5 0 0" 8)
+	slots=$(guardrail_slots "2 6 5 0" 8)
 	if [[ "$slots" == "1" ]]; then
 		print_result "guardrail: provider pressure keeps one safe probe slot when successes exist" 0
 	else
@@ -111,7 +111,7 @@ test_provider_rate_limits_keep_probe_slot_with_success() {
 test_repeated_failures_pause_without_success() {
 	reset_guardrail_env
 	local slots
-	slots=$(guardrail_slots "0 6 0 0 0" 8)
+	slots=$(guardrail_slots "0 6 0 0" 8)
 	if [[ "$slots" == "0" ]] && grep -q 'repeated_failure_pressure' "$LOGFILE"; then
 		print_result "guardrail: repeated failures pause raw concurrency without success evidence" 0
 	else
@@ -120,14 +120,78 @@ test_repeated_failures_pause_without_success() {
 	return 0
 }
 
-test_healthy_pr_backlog_rations_new_launches() {
+test_open_pr_backlog_is_repo_scoped_with_debt_exemption() {
 	reset_guardrail_env
-	local slots
-	slots=$(guardrail_slots "1 3 0 3 0" 8)
-	if [[ "$slots" == "1" ]] && grep -q 'healthy_pr_backlog' "$LOGFILE"; then
-		print_result "guardrail: active healthy PR evidence rations new issue launches" 0
+	local repos_file="${TEST_ROOT}/repos-pr-backlog.json"
+	cat >"$repos_file" <<'JSON'
+{"initialized_repos":[
+  {"slug":"owner/repo-a","path":"/tmp/repo-a","pulse":true,"priority":"tooling"},
+  {"slug":"owner/repo-b","path":"/tmp/repo-b","pulse":true,"priority":"tooling"}
+]}
+JSON
+	export REPOS_JSON="$repos_file"
+	check_repo_pulse_schedule() {
+		return 0
+	}
+	check_repo_pulse_interval() {
+		return 0
+	}
+	update_repo_pulse_timestamp() {
+		return 0
+	}
+	pulse_pr_list_get() {
+		local repo_slug="" previous_arg=""
+		local arg=""
+		for arg in "$@"; do
+			if [[ "$previous_arg" == "--repo" ]]; then
+				repo_slug="$arg"
+				break
+			fi
+			previous_arg="$arg"
+		done
+		case "$repo_slug" in
+			owner/repo-a) jq -n '[range(0; 12) | {number: .}]' ;;
+			*) printf '[]\n' ;;
+		esac
+		return 0
+	}
+	list_dispatchable_issue_candidates_json() {
+		local repo_slug="$1"
+		local limit="$2"
+		printf '%s' "$limit" >/dev/null
+		case "$repo_slug" in
+			owner/repo-a) printf '%s\n' '[{"number":1,"labels":[{"name":"bug"}]},{"number":2,"labels":[{"name":"quality-debt"},{"name":"source:review-feedback"}]}]' ;;
+			owner/repo-b) printf '%s\n' '[{"number":3,"labels":[{"name":"bug"}]}]' ;;
+			*) printf '[]\n' ;;
+		esac
+		return 0
+	}
+
+	local ranked="" repo_a_numbers="" repo_b_numbers=""
+	ranked=$(build_ranked_dispatch_candidates_json 10)
+	repo_a_numbers=$(jq -r '[.[] | select(.repo_slug == "owner/repo-a") | .number] | join(",")' <<<"$ranked")
+	repo_b_numbers=$(jq -r '[.[] | select(.repo_slug == "owner/repo-b") | .number] | join(",")' <<<"$ranked")
+	if [[ "$repo_a_numbers" == "2" && "$repo_b_numbers" == "3" ]]; then
+		print_result "guardrail: repo A backlog does not throttle repo B and trusted review debt is exempt" 0
 	else
-		print_result "guardrail: active healthy PR evidence rations new issue launches" 1 "slots=${slots}"
+		print_result "guardrail: repo A backlog does not throttle repo B and trusted review debt is exempt" 1 "repo_a=${repo_a_numbers} repo_b=${repo_b_numbers}"
+	fi
+	return 0
+}
+
+test_historical_pr_events_cannot_throttle() {
+	reset_guardrail_env
+	printf '%s\n' 'PR opened #1' 'PR merged #1' 'merged PR #2' 'opened PR #3' >>"$LOGFILE"
+	pulse_pr_list_get() {
+		printf '[]\n'
+		return 0
+	}
+	local counts=""
+	counts=$(_dispatch_recent_current_state_counts)
+	if [[ "$counts" == "0 0 0 0" ]]; then
+		print_result "guardrail: merged and historical PR log events cannot throttle dispatch" 0
+	else
+		print_result "guardrail: merged and historical PR log events cannot throttle dispatch" 1 "counts=${counts}"
 	fi
 	return 0
 }
@@ -135,7 +199,7 @@ test_healthy_pr_backlog_rations_new_launches() {
 test_no_dispatchable_evidence_keeps_probe_slot() {
 	reset_guardrail_env
 	local slots
-	slots=$(guardrail_slots "0 0 0 0 2" 8)
+	slots=$(guardrail_slots "0 0 0 2" 8)
 	if [[ "$slots" == "1" ]] && grep -q 'no_dispatchable_evidence' "$LOGFILE"; then
 		print_result "guardrail: no-dispatchable evidence keeps one probe slot" 0
 	else
@@ -147,7 +211,7 @@ test_no_dispatchable_evidence_keeps_probe_slot() {
 test_no_dispatchable_evidence_preserves_min_floor_slots() {
 	reset_guardrail_env
 	local slots
-	slots=$(guardrail_slots "0 0 0 0 2" 8 1)
+	slots=$(guardrail_slots "0 0 0 2" 8 1)
 	if [[ "$slots" == "8" ]] && grep -q 'no_dispatchable_floor_bypass' "$LOGFILE"; then
 		print_result "guardrail: no-dispatchable evidence preserves minimum floor slots" 0
 	else
@@ -159,7 +223,7 @@ test_no_dispatchable_evidence_preserves_min_floor_slots() {
 test_clean_state_preserves_available_slots() {
 	reset_guardrail_env
 	local slots
-	slots=$(guardrail_slots "3 1 0 0 0" 8)
+	slots=$(guardrail_slots "3 1 0 0" 8)
 	if [[ "$slots" == "8" ]] && grep -q '^pulse_dispatch_guardrail_available_slots=8$' "$STATS_GAUGE_FILE" && grep -q '^pulse_dispatch_guardrail_successes=3$' "$STATS_GAUGE_FILE"; then
 		print_result "guardrail: clean current state preserves safe slots" 0
 	else
@@ -172,7 +236,7 @@ test_disabled_guardrail_still_updates_available_slots_gauge() {
 	reset_guardrail_env
 	export AIDEVOPS_SKIP_PULSE_CURRENT_STATE_GUARDRAILS=1
 	local slots
-	slots=$(guardrail_slots "0 0 0 0 0" 5)
+	slots=$(guardrail_slots "0 0 0 0" 5)
 	if [[ "$slots" == "5" ]] && grep -q '^pulse_dispatch_guardrail_available_slots=5$' "$STATS_GAUGE_FILE"; then
 		print_result "guardrail: disabled current-state path still refreshes slot gauge" 0
 	else
@@ -432,7 +496,8 @@ JSON
 test_provider_rate_limits_pause_without_success
 test_provider_rate_limits_keep_probe_slot_with_success
 test_repeated_failures_pause_without_success
-test_healthy_pr_backlog_rations_new_launches
+test_open_pr_backlog_is_repo_scoped_with_debt_exemption
+test_historical_pr_events_cannot_throttle
 test_no_dispatchable_evidence_keeps_probe_slot
 test_no_dispatchable_evidence_preserves_min_floor_slots
 test_clean_state_preserves_available_slots

--- a/.agents/scripts/tests/test-pulse-dispatch-idle-debt-borrowing.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-idle-debt-borrowing.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export SCRIPT_DIR
+export HOME="${TMPDIR:-/tmp}/aidevops-idle-debt-borrowing.$$"
+mkdir -p "$HOME/.aidevops/logs"
+trap 'rm -rf "$HOME"' EXIT
+
+# shellcheck source=../pulse-dispatch-engine.sh
+source "$SCRIPT_DIR/pulse-dispatch-engine.sh"
+
+failures=0
+
+assert_order() {
+	local name="$1"
+	local slots="$2"
+	local expected="$3"
+	local actual=""
+
+	actual=$(_dispatch_order_idle_borrowing_candidates "$CANDIDATES" "$slots" | jq -r '[.[].number] | join(",")')
+	if [[ "$actual" == "$expected" ]]; then
+		printf 'PASS: %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL: %s (expected %s, got %s)\n' "$name" "$expected" "$actual" >&2
+	failures=$((failures + 1))
+	return 0
+}
+
+CANDIDATES='[
+  {"number":1,"labels":["quality-debt","source:review-feedback"]},
+  {"number":2,"labels":["quality-debt","source:review-feedback"]},
+  {"number":3,"labels":["quality-debt","source:review-feedback"]},
+  {"number":4,"labels":["bug"]},
+  {"number":5,"labels":["enhancement"]},
+  {"number":6,"labels":["quality-debt","source:quality-sweep"]}
+]'
+
+QUALITY_DEBT_CAP_PCT=30
+assert_order "caps trusted review debt while ordinary candidates wait" 10 "1,2,3,4,5,6"
+assert_order "moves excess trusted review debt behind ordinary candidates" 6 "1,4,5,6,2,3"
+assert_order "retains excess debt for idle-capacity borrowing" 1 "4,5,6,1,2,3"
+
+QUALITY_DEBT_CAP_PCT=100
+assert_order "honours an explicit full debt share" 2 "1,2,4,5,6,3"
+
+if [[ "$failures" -ne 0 ]]; then
+	exit 1
+fi
+printf 'All idle debt borrowing tests passed.\n'
+exit 0

--- a/.agents/scripts/tests/test-task-identity-lib.sh
+++ b/.agents/scripts/tests/test-task-identity-lib.sh
@@ -286,6 +286,21 @@ test_structured_helpers() {
 		return 1
 	fi
 	pass "malformed detector accepts valid marker"
+	if task_identity_has_malformed_candidate "truthful throughput testing"; then
+		fail "malformed detector treated ordinary lowercase t-words as task IDs"
+		return 1
+	fi
+	pass "malformed detector ignores ordinary lowercase t-words"
+	if task_identity_has_malformed_candidate "t18113: Improve pulse capacity and full-loop continuity"; then
+		fail "malformed detector rejected a valid task-prefixed title"
+		return 1
+	fi
+	pass "malformed detector accepts a valid task-prefixed title"
+	if task_identity_has_malformed_candidate "TODO.md and Testing evidence"; then
+		fail "malformed detector treated ordinary uppercase T-words as task IDs"
+		return 1
+	fi
+	pass "malformed detector ignores ordinary uppercase T-words"
 
 	parsed=$(task_identity_parse_list "t7, ${namespaced} t9.1") || return 1
 	assert_equal $'t7\n'"${namespaced}"$'\nt9.1' "$parsed" "parse mixed structured list" || return 1

--- a/.agents/scripts/tests/test-worker-completion-infrastructure.sh
+++ b/.agents/scripts/tests/test-worker-completion-infrastructure.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+scripts_dir="$(cd "${test_dir}/.." && pwd)" || exit 1
+failures=0
+
+# shellcheck source=../worker-lifecycle-common.sh
+source "${scripts_dir}/worker-lifecycle-common.sh"
+
+# Load the self-contained evidence mapper without running the helper entrypoint.
+eval "$(sed -n '/^_derive_worker_failure_evidence() {/,/^}/p' "${scripts_dir}/headless-runtime-helper.sh")"
+
+for reason in github_api_timeout command_policy_timeout prepared_commit_push_blocked completed_locally_remote_completion_blocked; do
+	if ! _worker_failure_reason_is_completion_infrastructure "$reason"; then
+		printf 'FAIL: %s was not classified as completion infrastructure\n' "$reason"
+		failures=$((failures + 1))
+		continue
+	fi
+
+	evidence=$(_derive_worker_failure_evidence blocked 1 1 natural "$reason")
+	cause="${evidence%%$'\t'*}"
+	next_action="${evidence#*$'\t'}"
+	if [[ "$cause" != "$reason" || "$next_action" != "resume_session_with_completion_contract" ]]; then
+		printf 'FAIL: %s mapped to cause=%s action=%s\n' "$reason" "$cause" "$next_action"
+		failures=$((failures + 1))
+	else
+		printf 'PASS: %s resumes the completion contract\n' "$reason"
+	fi
+done
+
+if _worker_failure_reason_is_completion_infrastructure worker_noop_zero_output; then
+	printf 'FAIL: implementation no-work was misclassified as infrastructure\n'
+	failures=$((failures + 1))
+else
+	printf 'PASS: implementation no-work remains outside infrastructure classification\n'
+fi
+
+exit "$failures"

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -1186,6 +1186,30 @@ _worker_failure_reason_is_launch_preflight() {
 	esac
 }
 
+#######################################
+# Detect completion-path infrastructure failures where implementation may be
+# checkpointed locally and the correct action is resume/completion, not an
+# issue-level implementation fast-fail penalty.
+# Args: $1=reason
+# Returns: 0 for completion infrastructure failures, 1 otherwise.
+#######################################
+_worker_failure_reason_is_completion_infrastructure() {
+	local reason="${1:-}"
+
+	case "$reason" in
+	github_api_timeout | command_policy_timeout | prepared_commit_push_blocked | completed_locally_remote_completion_blocked | \
+		*"GitHub API timeout"* | *"github api timeout"* | \
+		*"command-policy timeout"* | *"command policy timeout"* | \
+		*"prepared commit"*"push"*"blocked"* | \
+		*"completed locally"*"remote completion"*"blocked"*)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
 _no_work_reason_is_prelaunch_skip() {
 	local reason="${1:-}"
 	_worker_failure_reason_is_launch_preflight "$reason"

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -15,6 +15,8 @@ Task/Prompt: $ARGUMENTS
 
 Fatal modes: **GH#5317** (exits without PR), **GH#5096** (exits after PR). Do NOT skip any step:
 
+**Interactive continuity (MANDATORY):** A user's full-loop instruction authorises this entire lifecycle. Continue autonomously from the current stage through `FULL_LOOP_COMPLETE`; do not stop after setup, implementation, PR creation, merge, or release merely to report progress. Pause only for a material blocker requiring user input under the framework rules. Progress reports must name the last verified stage and current action. Say a loop is "running" or "underway" only after verifying a live loop process/job; a worktree, plan, or completed discovery alone is not a running loop.
+
 | # | Step | Signal |
 |---|------|--------|
 | 0 | Commit+PR gate — all changes committed, PR exists | `TASK_COMPLETE` |

--- a/TODO.md
+++ b/TODO.md
@@ -1139,6 +1139,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18109 Trigger dependency-chain unblocking when blockers close #bug ref:GH#27338
 
+- [ ] t18113 Harden pulse throughput and full-loop continuity #type:bug ref:GH#27452
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Use live per-repository 12-PR limits, let trusted review debt borrow idle capacity, reject vanished worktrees before runtime launch, resume checkpointed completion failures without issue fast-fail, and require truthful uninterrupted interactive full-loop execution.

## Files Changed

.agents/AGENTS.md, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/headless-runtime-helper.sh, .agents/scripts/pulse-dispatch-current-state-guardrails.sh, .agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/pulse-fast-fail.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-precreation-failure-skip.sh, .agents/scripts/tests/test-pulse-current-state-guardrails.sh, .agents/scripts/tests/test-pulse-dispatch-idle-debt-borrowing.sh, .agents/scripts/tests/test-worker-completion-infrastructure.sh, .agents/scripts/worker-lifecycle-common.sh, .agents/workflows/full-loop.md, TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused pulse/worker regression suites passed; ShellCheck passed; .agents/scripts/linters-local.sh passed.

Resolves #27452


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 with gpt-5.6-sol spent 1h 1m and 333,022 tokens on this with the user in an interactive session.