### PR TITLE
GH#27454: prevent interactive managed-directory permission prompts

### DIFF
--- a/.agents/scripts/agent-discovery.py
+++ b/.agents/scripts/agent-discovery.py
@@ -82,6 +82,40 @@ def _enable_prompt_caching(config):
     config['provider']['anthropic']['options']['setCacheKey'] = True
 
 
+def _persist_managed_external_directories(config):
+    """Persist managed path allows for built-in agents and live config reloads.
+
+    The plugin applies the same rules at startup, including per-agent overrides.
+    Persisting the top-level rules also covers OpenCode's built-in delegated
+    agents and lets a running process observe updated policy when config reload
+    is available. Keep this list aligned with config-hook.mjs.
+    """
+    permission = config.get('permission')
+    if isinstance(permission, str):
+        permission = {'*': permission, 'external_directory': {'*': permission}}
+        config['permission'] = permission
+    elif not isinstance(permission, dict):
+        permission = {}
+        config['permission'] = permission
+
+    existing = permission.get('external_directory')
+    if existing == 'allow':
+        return
+    rules = {'*': existing} if isinstance(existing, str) else dict(existing or {})
+    managed_paths = (
+        '~/.aidevops',
+        '~/.aidevops/**',
+        '~/.config/aidevops',
+        '~/.config/aidevops/**',
+        '~/Git/_worktrees',
+        '~/Git/_worktrees/**',
+    )
+    for path in managed_paths:
+        rules.pop(path, None)
+        rules[path] = 'allow'
+    permission['external_directory'] = rules
+
+
 def output_opencode_json():
     """Write agent config to opencode.json."""
     import shutil
@@ -100,6 +134,7 @@ def output_opencode_json():
     _merge_instructions(config)
     _ensure_plugin_registered(config)
     _enable_prompt_caching(config)
+    _persist_managed_external_directories(config)
 
     config.setdefault('mcp', {})
     config.setdefault('tools', {})

--- a/.agents/scripts/tests/test-agent-discovery-smoke.sh
+++ b/.agents/scripts/tests/test-agent-discovery-smoke.sh
@@ -120,6 +120,44 @@ test_agent_discovery_runs() {
 	return 0
 }
 
+test_opencode_config_persists_managed_directory_permissions() {
+	local fake_home="$TEST_DIR/fake-home"
+	local config_path="$fake_home/.config/opencode/opencode.json"
+	local output
+	if ! output=$(run_discovery_script "$SCRIPTS_DIR/agent-discovery.py" \
+		dummy opencode-json 2>&1); then
+		print_result "OpenCode config persists managed external directories" 1 "$output"
+		return 0
+	fi
+
+	if HOME="$fake_home" python3 - "$config_path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    config = json.load(handle)
+
+rules = config["permission"]["external_directory"]
+expected = (
+    "~/.aidevops",
+    "~/.aidevops/**",
+    "~/.config/aidevops",
+    "~/.config/aidevops/**",
+    "~/Git/_worktrees",
+    "~/Git/_worktrees/**",
+)
+assert all(rules.get(path) == "allow" for path in expected)
+assert "~/.config/opencode" not in rules
+PY
+	then
+		print_result "OpenCode config persists managed external directories" 0
+	else
+		print_result "OpenCode config persists managed external directories" 1 \
+			"managed rules missing or sensitive OpenCode config was over-allowed"
+	fi
+	return 0
+}
+
 test_opencode_agent_discovery_runs() {
 	local output
 	if output=$(run_discovery_script \
@@ -223,6 +261,7 @@ PYEOF
 main() {
 	setup
 	test_agent_discovery_runs
+	test_opencode_config_persists_managed_directory_permissions
 	test_opencode_agent_discovery_runs
 	test_missing_subagent_warning
 	test_validate_subagent_refs_default_arg

--- a/.agents/scripts/tests/test-agent-discovery-smoke.sh
+++ b/.agents/scripts/tests/test-agent-discovery-smoke.sh
@@ -130,7 +130,7 @@ test_opencode_config_persists_managed_directory_permissions() {
 		return 0
 	fi
 
-	if HOME="$fake_home" python3 - "$config_path" <<'PY'
+	if HOME="$fake_home" python3 - "$config_path" <<'PY'; then
 import json
 import sys
 
@@ -149,7 +149,6 @@ expected = (
 assert all(rules.get(path) == "allow" for path in expected)
 assert "~/.config/opencode" not in rules
 PY
-	then
 		print_result "OpenCode config persists managed external directories" 0
 	else
 		print_result "OpenCode config persists managed external directories" 1 \


### PR DESCRIPTION
## Summary

Persist narrow managed external-directory allows in opencode.json so built-in delegated agents and live config reloads receive the same worktree policy as plugin-managed agents.

## Files Changed

.agents/scripts/agent-discovery.py, .agents/scripts/tests/test-agent-discovery-smoke.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** agent-discovery smoke tests (6/6), ShellCheck, py_compile, and local linter suite passed

Resolves #27454


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 12m and 141,458 tokens on this with the user in an interactive session.