### PR TITLE
GH#27457: add evidence-based session efficiency retrospectives

### DIFF
--- a/.agents/reference/context-efficient-output.md
+++ b/.agents/reference/context-efficient-output.md
@@ -78,6 +78,12 @@ Use comparison results to classify a command:
   comparison shows expansion; older RTK versions still use the noisier
   compact-status behavior.
 
+Do not judge an optimisation by token reduction alone. In session review, check
+whether filtered output was sufficient on the first pass, required raw fallback,
+caused repeated discovery, omitted causal evidence, or weakened requirement and
+verification coverage. Compare similar tasks when evidence exists; do not impose
+arbitrary global thresholds. Preserve unexpected outliers for model judgment.
+
 ## Always bypass RTK
 
 - File reads and source inspection.

--- a/.agents/reference/self-improvement.md
+++ b/.agents/reference/self-improvement.md
@@ -66,6 +66,33 @@ Treat valuable session learning as system input, not disposable transcript conte
 - **Route design learning by scope:** durable repo-specific UI patterns belong in that repo's `DESIGN.md`; generic aidevops briefing/verification patterns become aidevops issues with anonymised evidence; uncertain or broad design lessons become worker-ready follow-ups instead of bloating global docs.
 - **Avoid speculative bloat:** capture observed examples and evidence; do not add global guidance for hypothetical failures.
 
+### Session friction and efficiency retrospective
+
+At the end of significant interactive work, review the actual path from request
+to verified outcome. Use `session-introspect-helper.sh patterns`,
+`report-token-use-helper.sh`, RTK comparison/adoption evidence, lifecycle state,
+and the conversation itself; do not create a parallel telemetry plane.
+
+- Record permission prompts, policy false positives, retries, equivalent-command
+  workarounds, duplicate workers/worktrees, manual lifecycle steps, repeated CI
+  output, version drift, and repeated rediscovery.
+- Do not invent universal numeric thresholds. Compare like-for-like sessions and
+  lifecycle stages where useful, but retain unexpected qualitative outliers that
+  do not fit the existing categories.
+- Audit existing token-saving mechanisms before proposing another one. Establish
+  whether filtering, caching, summarisation, subagents, or compaction reduced
+  discarded output and duplicate work, or instead forced raw fallback and
+  reconstruction.
+- Optimise for tokens per verified outcome and human attention returned—not the
+  lowest token count. Extra context is justified when it materially improves
+  correctness, security, review coverage, or durable understanding.
+- Check comprehension explicitly: missed requirements, incorrect assumptions,
+  repeated rediscovery, incomplete review, weak verification, or loss of causal
+  context are regressions even when token use falls.
+- Route only evidence-backed findings: fix safe in-scope defects now; otherwise
+  deduplicate against memory, tasks, issues, merged fixes, and active work before
+  creating one worker-ready improvement brief.
+
 ### Similar-but-different hazards
 
 - When two patterns look related but differ in contract, scope, or trust boundary, do not merge them mentally or create a third near-duplicate pattern.

--- a/.agents/scripts/framework-issue-helper.sh
+++ b/.agents/scripts/framework-issue-helper.sh
@@ -302,8 +302,12 @@ _validate_gh_prereqs() {
 		return 1
 	fi
 
-	if ! gh auth status &>/dev/null; then
-		log_error "GitHub CLI not authenticated — run: gh auth login"
+
+	# `gh auth status` validates stored keyring entries and can fail even when an
+	# active environment/App token successfully serves API requests. Probe the
+	# capability needed by this helper before declaring authentication broken.
+	if ! gh auth status &>/dev/null && ! gh api user --jq .login &>/dev/null; then
+		log_error "GitHub CLI cannot authenticate an API request — run: gh auth login"
 		return 1
 	fi
 

--- a/.agents/scripts/framework-issue-helper.sh
+++ b/.agents/scripts/framework-issue-helper.sh
@@ -306,7 +306,8 @@ _validate_gh_prereqs() {
 	# `gh auth status` validates stored keyring entries and can fail even when an
 	# active environment/App token successfully serves API requests. Probe the
 	# capability needed by this helper before declaring authentication broken.
-	if ! gh auth status &>/dev/null && ! gh api user --jq .login &>/dev/null; then
+	if ! gh auth status &>/dev/null && \
+		! gh api graphql -f 'query={viewer{login}}' --jq '.data.viewer.login' &>/dev/null; then
 		log_error "GitHub CLI cannot authenticate an API request — run: gh auth login"
 		return 1
 	fi

--- a/.agents/scripts/session-introspect-helper.sh
+++ b/.agents/scripts/session-introspect-helper.sh
@@ -98,13 +98,23 @@ _parse_common_flags() {
 			db_override="${2:-}"
 			shift 2
 			;;
-		--json) json_flag=true; shift ;;
+		--json)
+			json_flag=true
+			shift
+			;;
 		--since)
 			since_min="${2:-}"
 			shift 2
 			;;
-		--) shift; positionals+=("$@"); break ;;
-		*) positionals+=("$1"); shift ;;
+		--)
+			shift
+			positionals+=("$@")
+			break
+			;;
+		*)
+			positionals+=("$1")
+			shift
+			;;
 		esac
 	done
 	printf 'SESSION=%s\nDB=%s\nJSON=%s\nSINCE=%s\n' "$session_id" "$db_override" "$json_flag" "$since_min"
@@ -140,7 +150,8 @@ _escape_sql() {
 # =============================================================================
 
 cmd_recent() {
-	local parsed; parsed=$(_parse_common_flags "$@")
+	local parsed
+	parsed=$(_parse_common_flags "$@")
 	local session_id db_override json_flag since_min limit=""
 	session_id=$(echo "$parsed" | awk -F= '/^SESSION=/{sub(/^SESSION=/,"");print;exit}')
 	db_override=$(echo "$parsed" | awk -F= '/^DB=/{sub(/^DB=/,"");print;exit}')
@@ -148,16 +159,26 @@ cmd_recent() {
 	since_min=$(echo "$parsed" | awk -F= '/^SINCE=/{sub(/^SINCE=/,"");print;exit}')
 	limit=$(echo "$parsed" | awk -F= '/^POS=/{sub(/^POS=/,"");print;exit}')
 	[[ -z "$limit" ]] && limit="$DEFAULT_RECENT_N"
-	[[ "$limit" =~ ^[0-9]+$ ]] || { print_error "N must be a positive integer"; return 1; }
+	[[ "$limit" =~ ^[0-9]+$ ]] || {
+		print_error "N must be a positive integer"
+		return 1
+	}
 
-	local db; db=$(_resolve_db_path "$db_override")
+	local db
+	db=$(_resolve_db_path "$db_override")
 	_require_db "$db" || return 1
 
-	local sid; sid=$(_resolve_session_id "$db" "$session_id")
-	[[ -z "$sid" ]] && { print_warning "no sessions found in $db"; return 0; }
+	local sid
+	sid=$(_resolve_session_id "$db" "$session_id")
+	[[ -z "$sid" ]] && {
+		print_warning "no sessions found in $db"
+		return 0
+	}
 
-	local since; since=$(_since_clause "$since_min") || return 1
-	local sid_esc; sid_esc=$(_escape_sql "$sid")
+	local since
+	since=$(_since_clause "$since_min") || return 1
+	local sid_esc
+	sid_esc=$(_escape_sql "$sid")
 
 	local query="
 		SELECT timestamp, tool_name, COALESCE(intent,''), COALESCE(duration_ms,0), success
@@ -193,8 +214,12 @@ _recent_table() {
 
 _recent_json() {
 	local db="$1" sid="$2" query="$3"
-	command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
-	local rows; rows=$(sqlite3 -separator '|' "$db" "$query" || true)
+	command -v jq >/dev/null 2>&1 || {
+		print_error "jq required with --json"
+		return 1
+	}
+	local rows
+	rows=$(sqlite3 -separator '|' "$db" "$query" || true)
 	printf '%s' "$rows" | jq -R -s --arg session "$sid" '
 		split("\n") | map(select(length > 0) | split("|") | {
 			timestamp: .[0],
@@ -208,20 +233,28 @@ _recent_json() {
 }
 
 cmd_patterns() {
-	local parsed; parsed=$(_parse_common_flags "$@")
+	local parsed
+	parsed=$(_parse_common_flags "$@")
 	local session_id db_override json_flag since_min
 	session_id=$(echo "$parsed" | awk -F= '/^SESSION=/{sub(/^SESSION=/,"");print;exit}')
 	db_override=$(echo "$parsed" | awk -F= '/^DB=/{sub(/^DB=/,"");print;exit}')
 	json_flag=$(echo "$parsed" | awk -F= '/^JSON=/{sub(/^JSON=/,"");print;exit}')
 	since_min=$(echo "$parsed" | awk -F= '/^SINCE=/{sub(/^SINCE=/,"");print;exit}')
 
-	local db; db=$(_resolve_db_path "$db_override")
+	local db
+	db=$(_resolve_db_path "$db_override")
 	_require_db "$db" || return 1
-	local sid; sid=$(_resolve_session_id "$db" "$session_id")
-	[[ -z "$sid" ]] && { print_warning "no sessions found in $db"; return 0; }
+	local sid
+	sid=$(_resolve_session_id "$db" "$session_id")
+	[[ -z "$sid" ]] && {
+		print_warning "no sessions found in $db"
+		return 0
+	}
 
-	local since; since=$(_since_clause "$since_min") || return 1
-	local sid_esc; sid_esc=$(_escape_sql "$sid")
+	local since
+	since=$(_since_clause "$since_min") || return 1
+	local sid_esc
+	sid_esc=$(_escape_sql "$sid")
 
 	# Aggregate stats for the session.
 	local stats
@@ -321,7 +354,10 @@ _patterns_table() {
 _patterns_json() {
 	local sid="$1" total="$2" errors="$3" first_ts="$4" last_ts="$5"
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
-	command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
+	command -v jq >/dev/null 2>&1 || {
+		print_error "jq required with --json"
+		return 1
+	}
 	local by_tool_json
 	by_tool_json=$(printf '%s' "$by_tool" | jq -R -s '
 		split("\n") | map(select(length > 0) | split("|") | {
@@ -358,7 +394,8 @@ _patterns_json() {
 }
 
 cmd_errors() {
-	local parsed; parsed=$(_parse_common_flags "$@")
+	local parsed
+	parsed=$(_parse_common_flags "$@")
 	local session_id db_override json_flag since_min limit=""
 	session_id=$(echo "$parsed" | awk -F= '/^SESSION=/{sub(/^SESSION=/,"");print;exit}')
 	db_override=$(echo "$parsed" | awk -F= '/^DB=/{sub(/^DB=/,"");print;exit}')
@@ -366,15 +403,25 @@ cmd_errors() {
 	since_min=$(echo "$parsed" | awk -F= '/^SINCE=/{sub(/^SINCE=/,"");print;exit}')
 	limit=$(echo "$parsed" | awk -F= '/^POS=/{sub(/^POS=/,"");print;exit}')
 	[[ -z "$limit" ]] && limit="$DEFAULT_ERRORS_N"
-	[[ "$limit" =~ ^[0-9]+$ ]] || { print_error "N must be a positive integer"; return 1; }
+	[[ "$limit" =~ ^[0-9]+$ ]] || {
+		print_error "N must be a positive integer"
+		return 1
+	}
 
-	local db; db=$(_resolve_db_path "$db_override")
+	local db
+	db=$(_resolve_db_path "$db_override")
 	_require_db "$db" || return 1
-	local sid; sid=$(_resolve_session_id "$db" "$session_id")
-	[[ -z "$sid" ]] && { print_warning "no sessions found in $db"; return 0; }
+	local sid
+	sid=$(_resolve_session_id "$db" "$session_id")
+	[[ -z "$sid" ]] && {
+		print_warning "no sessions found in $db"
+		return 0
+	}
 
-	local since; since=$(_since_clause "$since_min") || return 1
-	local sid_esc; sid_esc=$(_escape_sql "$sid")
+	local since
+	since=$(_since_clause "$since_min") || return 1
+	local sid_esc
+	sid_esc=$(_escape_sql "$sid")
 
 	local query="
 		SELECT timestamp, tool_name, COALESCE(intent,''), COALESCE(duration_ms,0)
@@ -384,7 +431,10 @@ cmd_errors() {
 		LIMIT ${limit};
 	"
 	if [[ "$json_flag" == "true" ]]; then
-		command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
+		command -v jq >/dev/null 2>&1 || {
+			print_error "jq required with --json"
+			return 1
+		}
 		sqlite3 -separator '|' "$db" "$query" | jq -R -s --arg sid "$sid" '
 			split("\n") | map(select(length > 0) | split("|") | {
 				timestamp: .[0], tool: .[1], intent: .[2],
@@ -406,15 +456,20 @@ cmd_errors() {
 }
 
 cmd_sessions() {
-	local parsed; parsed=$(_parse_common_flags "$@")
+	local parsed
+	parsed=$(_parse_common_flags "$@")
 	local db_override json_flag limit=""
 	db_override=$(echo "$parsed" | awk -F= '/^DB=/{sub(/^DB=/,"");print;exit}')
 	json_flag=$(echo "$parsed" | awk -F= '/^JSON=/{sub(/^JSON=/,"");print;exit}')
 	limit=$(echo "$parsed" | awk -F= '/^POS=/{sub(/^POS=/,"");print;exit}')
 	[[ -z "$limit" ]] && limit="$DEFAULT_SESSIONS_N"
-	[[ "$limit" =~ ^[0-9]+$ ]] || { print_error "N must be a positive integer"; return 1; }
+	[[ "$limit" =~ ^[0-9]+$ ]] || {
+		print_error "N must be a positive integer"
+		return 1
+	}
 
-	local db; db=$(_resolve_db_path "$db_override")
+	local db
+	db=$(_resolve_db_path "$db_override")
 	_require_db "$db" || return 1
 
 	local query="
@@ -425,7 +480,10 @@ cmd_sessions() {
 		LIMIT ${limit};
 	"
 	if [[ "$json_flag" == "true" ]]; then
-		command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
+		command -v jq >/dev/null 2>&1 || {
+			print_error "jq required with --json"
+			return 1
+		}
 		sqlite3 -separator '|' "$db" "$query" | jq -R -s '
 			split("\n") | map(select(length > 0) | split("|") | {
 				session: .[0],

--- a/.agents/scripts/session-introspect-helper.sh
+++ b/.agents/scripts/session-introspect-helper.sh
@@ -98,23 +98,13 @@ _parse_common_flags() {
 			db_override="${2:-}"
 			shift 2
 			;;
-		--json)
-			json_flag=true
-			shift
-			;;
+		--json) json_flag=true; shift ;;
 		--since)
 			since_min="${2:-}"
 			shift 2
 			;;
-		--)
-			shift
-			positionals+=("$@")
-			break
-			;;
-		*)
-			positionals+=("$1")
-			shift
-			;;
+		--) shift; positionals+=("$@"); break ;;
+		*) positionals+=("$1"); shift ;;
 		esac
 	done
 	printf 'SESSION=%s\nDB=%s\nJSON=%s\nSINCE=%s\n' "$session_id" "$db_override" "$json_flag" "$since_min"
@@ -150,8 +140,7 @@ _escape_sql() {
 # =============================================================================
 
 cmd_recent() {
-	local parsed
-	parsed=$(_parse_common_flags "$@")
+	local parsed; parsed=$(_parse_common_flags "$@")
 	local session_id db_override json_flag since_min limit=""
 	session_id=$(echo "$parsed" | awk -F= '/^SESSION=/{sub(/^SESSION=/,"");print;exit}')
 	db_override=$(echo "$parsed" | awk -F= '/^DB=/{sub(/^DB=/,"");print;exit}')
@@ -159,26 +148,16 @@ cmd_recent() {
 	since_min=$(echo "$parsed" | awk -F= '/^SINCE=/{sub(/^SINCE=/,"");print;exit}')
 	limit=$(echo "$parsed" | awk -F= '/^POS=/{sub(/^POS=/,"");print;exit}')
 	[[ -z "$limit" ]] && limit="$DEFAULT_RECENT_N"
-	[[ "$limit" =~ ^[0-9]+$ ]] || {
-		print_error "N must be a positive integer"
-		return 1
-	}
+	[[ "$limit" =~ ^[0-9]+$ ]] || { print_error "N must be a positive integer"; return 1; }
 
-	local db
-	db=$(_resolve_db_path "$db_override")
+	local db; db=$(_resolve_db_path "$db_override")
 	_require_db "$db" || return 1
 
-	local sid
-	sid=$(_resolve_session_id "$db" "$session_id")
-	[[ -z "$sid" ]] && {
-		print_warning "no sessions found in $db"
-		return 0
-	}
+	local sid; sid=$(_resolve_session_id "$db" "$session_id")
+	[[ -z "$sid" ]] && { print_warning "no sessions found in $db"; return 0; }
 
-	local since
-	since=$(_since_clause "$since_min") || return 1
-	local sid_esc
-	sid_esc=$(_escape_sql "$sid")
+	local since; since=$(_since_clause "$since_min") || return 1
+	local sid_esc; sid_esc=$(_escape_sql "$sid")
 
 	local query="
 		SELECT timestamp, tool_name, COALESCE(intent,''), COALESCE(duration_ms,0), success
@@ -214,12 +193,8 @@ _recent_table() {
 
 _recent_json() {
 	local db="$1" sid="$2" query="$3"
-	command -v jq >/dev/null 2>&1 || {
-		print_error "jq required with --json"
-		return 1
-	}
-	local rows
-	rows=$(sqlite3 -separator '|' "$db" "$query" || true)
+	command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
+	local rows; rows=$(sqlite3 -separator '|' "$db" "$query" || true)
 	printf '%s' "$rows" | jq -R -s --arg session "$sid" '
 		split("\n") | map(select(length > 0) | split("|") | {
 			timestamp: .[0],
@@ -233,28 +208,20 @@ _recent_json() {
 }
 
 cmd_patterns() {
-	local parsed
-	parsed=$(_parse_common_flags "$@")
+	local parsed; parsed=$(_parse_common_flags "$@")
 	local session_id db_override json_flag since_min
 	session_id=$(echo "$parsed" | awk -F= '/^SESSION=/{sub(/^SESSION=/,"");print;exit}')
 	db_override=$(echo "$parsed" | awk -F= '/^DB=/{sub(/^DB=/,"");print;exit}')
 	json_flag=$(echo "$parsed" | awk -F= '/^JSON=/{sub(/^JSON=/,"");print;exit}')
 	since_min=$(echo "$parsed" | awk -F= '/^SINCE=/{sub(/^SINCE=/,"");print;exit}')
 
-	local db
-	db=$(_resolve_db_path "$db_override")
+	local db; db=$(_resolve_db_path "$db_override")
 	_require_db "$db" || return 1
-	local sid
-	sid=$(_resolve_session_id "$db" "$session_id")
-	[[ -z "$sid" ]] && {
-		print_warning "no sessions found in $db"
-		return 0
-	}
+	local sid; sid=$(_resolve_session_id "$db" "$session_id")
+	[[ -z "$sid" ]] && { print_warning "no sessions found in $db"; return 0; }
 
-	local since
-	since=$(_since_clause "$since_min") || return 1
-	local sid_esc
-	sid_esc=$(_escape_sql "$sid")
+	local since; since=$(_since_clause "$since_min") || return 1
+	local sid_esc; sid_esc=$(_escape_sql "$sid")
 
 	# Aggregate stats for the session.
 	local stats
@@ -354,10 +321,7 @@ _patterns_table() {
 _patterns_json() {
 	local sid="$1" total="$2" errors="$3" first_ts="$4" last_ts="$5"
 	local avg_dur="$6" rate="$7" by_tool="$8" rereads="$9"
-	command -v jq >/dev/null 2>&1 || {
-		print_error "jq required with --json"
-		return 1
-	}
+	command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
 	local by_tool_json
 	by_tool_json=$(printf '%s' "$by_tool" | jq -R -s '
 		split("\n") | map(select(length > 0) | split("|") | {
@@ -394,8 +358,7 @@ _patterns_json() {
 }
 
 cmd_errors() {
-	local parsed
-	parsed=$(_parse_common_flags "$@")
+	local parsed; parsed=$(_parse_common_flags "$@")
 	local session_id db_override json_flag since_min limit=""
 	session_id=$(echo "$parsed" | awk -F= '/^SESSION=/{sub(/^SESSION=/,"");print;exit}')
 	db_override=$(echo "$parsed" | awk -F= '/^DB=/{sub(/^DB=/,"");print;exit}')
@@ -403,25 +366,15 @@ cmd_errors() {
 	since_min=$(echo "$parsed" | awk -F= '/^SINCE=/{sub(/^SINCE=/,"");print;exit}')
 	limit=$(echo "$parsed" | awk -F= '/^POS=/{sub(/^POS=/,"");print;exit}')
 	[[ -z "$limit" ]] && limit="$DEFAULT_ERRORS_N"
-	[[ "$limit" =~ ^[0-9]+$ ]] || {
-		print_error "N must be a positive integer"
-		return 1
-	}
+	[[ "$limit" =~ ^[0-9]+$ ]] || { print_error "N must be a positive integer"; return 1; }
 
-	local db
-	db=$(_resolve_db_path "$db_override")
+	local db; db=$(_resolve_db_path "$db_override")
 	_require_db "$db" || return 1
-	local sid
-	sid=$(_resolve_session_id "$db" "$session_id")
-	[[ -z "$sid" ]] && {
-		print_warning "no sessions found in $db"
-		return 0
-	}
+	local sid; sid=$(_resolve_session_id "$db" "$session_id")
+	[[ -z "$sid" ]] && { print_warning "no sessions found in $db"; return 0; }
 
-	local since
-	since=$(_since_clause "$since_min") || return 1
-	local sid_esc
-	sid_esc=$(_escape_sql "$sid")
+	local since; since=$(_since_clause "$since_min") || return 1
+	local sid_esc; sid_esc=$(_escape_sql "$sid")
 
 	local query="
 		SELECT timestamp, tool_name, COALESCE(intent,''), COALESCE(duration_ms,0)
@@ -431,10 +384,7 @@ cmd_errors() {
 		LIMIT ${limit};
 	"
 	if [[ "$json_flag" == "true" ]]; then
-		command -v jq >/dev/null 2>&1 || {
-			print_error "jq required with --json"
-			return 1
-		}
+		command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
 		sqlite3 -separator '|' "$db" "$query" | jq -R -s --arg sid "$sid" '
 			split("\n") | map(select(length > 0) | split("|") | {
 				timestamp: .[0], tool: .[1], intent: .[2],
@@ -456,20 +406,15 @@ cmd_errors() {
 }
 
 cmd_sessions() {
-	local parsed
-	parsed=$(_parse_common_flags "$@")
+	local parsed; parsed=$(_parse_common_flags "$@")
 	local db_override json_flag limit=""
 	db_override=$(echo "$parsed" | awk -F= '/^DB=/{sub(/^DB=/,"");print;exit}')
 	json_flag=$(echo "$parsed" | awk -F= '/^JSON=/{sub(/^JSON=/,"");print;exit}')
 	limit=$(echo "$parsed" | awk -F= '/^POS=/{sub(/^POS=/,"");print;exit}')
 	[[ -z "$limit" ]] && limit="$DEFAULT_SESSIONS_N"
-	[[ "$limit" =~ ^[0-9]+$ ]] || {
-		print_error "N must be a positive integer"
-		return 1
-	}
+	[[ "$limit" =~ ^[0-9]+$ ]] || { print_error "N must be a positive integer"; return 1; }
 
-	local db
-	db=$(_resolve_db_path "$db_override")
+	local db; db=$(_resolve_db_path "$db_override")
 	_require_db "$db" || return 1
 
 	local query="
@@ -480,10 +425,7 @@ cmd_sessions() {
 		LIMIT ${limit};
 	"
 	if [[ "$json_flag" == "true" ]]; then
-		command -v jq >/dev/null 2>&1 || {
-			print_error "jq required with --json"
-			return 1
-		}
+		command -v jq >/dev/null 2>&1 || { print_error "jq required with --json"; return 1; }
 		sqlite3 -separator '|' "$db" "$query" | jq -R -s '
 			split("\n") | map(select(length > 0) | split("|") | {
 				session: .[0],

--- a/.agents/scripts/session-introspect-helper.sh
+++ b/.agents/scripts/session-introspect-helper.sh
@@ -39,7 +39,7 @@ readonly DEFAULT_OBS_DB="${HOME}/.aidevops/.agent-workspace/observability/llm-re
 readonly DEFAULT_RECENT_N=20
 readonly DEFAULT_SESSIONS_N=10
 readonly DEFAULT_ERRORS_N=10
-readonly FILE_REREAD_THRESHOLD=3
+readonly REPEATED_PATH_MIN_COUNT=2
 
 # =============================================================================
 # Helpers
@@ -250,7 +250,9 @@ cmd_patterns() {
 		ORDER BY n DESC;
 	")
 
-	# File-reread detection — parse filePath from metadata JSON.
+	# Repeated-path evidence — parse filePath from metadata JSON. Two accesses is
+	# the semantic minimum for repetition, not a heuristic problem threshold.
+	# Report the evidence and leave interpretation to the retrospective.
 	# metadata column is an opaque JSON blob; we extract .args.filePath or
 	# .args.file_path where present. Works with both Read and Edit args.
 	local rereads
@@ -263,7 +265,7 @@ cmd_patterns() {
 		WHERE session_id='${sid_esc}' ${since}
 		  AND tool_name IN ('Read','read','Edit','edit','Write','write')
 		GROUP BY fp
-		HAVING fp<>'' AND n >= ${FILE_REREAD_THRESHOLD}
+		HAVING fp<>'' AND n >= ${REPEATED_PATH_MIN_COUNT}
 		ORDER BY n DESC
 		LIMIT 10;
 	")
@@ -303,14 +305,13 @@ _patterns_table() {
 		printf '  (none)\n'
 	fi
 
-	printf '\nFile reread loops (same path read/edited >=%d times):\n' "$FILE_REREAD_THRESHOLD"
+	printf '\nRepeated file access evidence:\n'
 	if [[ -n "$rereads" ]]; then
 		while IFS='|' read -r path n; do
 			[[ -z "$path" ]] && continue
 			printf '  %4sx  %s\n' "$n" "$path"
 		done <<<"$rereads"
-		printf '\nHint: a re-read loop suggests you may be stuck.\n'
-		printf '      Try: git diff, git status, or break out of the loop.\n'
+		printf '\nInterpret in context: verification rereads may be useful; unexplained rediscovery may indicate friction or lost understanding.\n'
 	else
 		printf '  (none detected)\n'
 	fi
@@ -341,13 +342,17 @@ _patterns_json() {
 		--argjson total "${total:-0}" --argjson errors "${errors:-0}" \
 		--argjson avg_dur "${avg_dur:-0}" --arg rate "$rate" \
 		--argjson by_tool "$by_tool_json" --argjson rereads "$rereads_json" \
-		--argjson threshold "$FILE_REREAD_THRESHOLD" '
+		--argjson minimum_repeat_count "$REPEATED_PATH_MIN_COUNT" '
 		{
 			session: $sid,
 			window: { first: $first_ts, last: $last_ts },
 			calls: { total: $total, errors: $errors, rate_per_min: ($rate|tonumber), avg_ms: $avg_dur },
 			by_tool: $by_tool,
-			file_rereads: { threshold: $threshold, hot: $rereads }
+			repeated_file_access: {
+				semantic_minimum: $minimum_repeat_count,
+				evidence: $rereads,
+				classification: "context_required"
+			}
 		}'
 	return 0
 }
@@ -453,7 +458,7 @@ USAGE:
 
 COMMANDS:
     recent [N]       Last N tool calls in the current session (default 20)
-    patterns         Tool distribution, file-reread loops, error rate, calls/min
+    patterns         Tool distribution, repeated-path evidence, errors, calls/min
     errors [N]       Last N failed tool calls with intent (default 10)
     sessions [N]     Recent N sessions with request/cost summary (default 10)
     help             This message
@@ -471,7 +476,7 @@ EXAMPLES:
     # "What have I been doing in the last 5 minutes?"
     session-introspect-helper.sh recent 30 --since 5
 
-    # "Am I stuck in a file-reread loop?"
+    # "Where did repeated access occur, and was it verification or rediscovery?"
     session-introspect-helper.sh patterns
 
     # "Show me my session's error history"
@@ -480,10 +485,10 @@ EXAMPLES:
     # "Summary of the last 5 sessions"
     session-introspect-helper.sh sessions 5 --json | jq '.[].tool_calls'
 
-STUCK-WORKER SIGNALS:
-    - calls/min > 30         Excessive tool chatter
-    - same file read > 3x    Re-read loop (see patterns output)
-    - errors cluster         Recent failures on the same tool (errors output)
+INTERPRETATION:
+    This helper reports evidence, not universal problem thresholds. Compare the
+    task's intent, peer sessions, verification needs, and comprehension outcomes.
+    Preserve unexpected outliers even when they do not fit a known category.
 EOF
 	return 0
 }

--- a/.agents/scripts/tests/test-framework-issue-helper.sh
+++ b/.agents/scripts/tests/test-framework-issue-helper.sh
@@ -68,6 +68,7 @@ if [[ -n "${TEST_GH_TRACE:-}" ]]; then
 fi
 
 if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+	[[ "${TEST_AUTH_STATUS_FAIL:-0}" == "1" ]] && exit 1
 	exit 0
 fi
 
@@ -177,6 +178,13 @@ run_case "not-a-number" "https://github.com/marcusquinn/aidevops/issues/9002" "$
 malformed_text=$(<"$malformed_output")
 assert_contains "$malformed_text" "status=created" "malformed duplicate result continues to issue creation"
 assert_not_contains "$malformed_text" "status=duplicate" "malformed duplicate result is not duplicate"
+
+api_auth_output="${TMP_DIR}/api-auth.out"
+TEST_AUTH_STATUS_FAIL=1 run_case "[]" \
+	"https://github.com/marcusquinn/aidevops/issues/9004" "${TMP_DIR}" "$api_auth_output"
+api_auth_text=$(<"$api_auth_output")
+assert_contains "$api_auth_text" "status=created" \
+	"working API token overrides stale keyring auth status"
 
 valid_output="${TMP_DIR}/valid.out"
 run_case "12345" "https://github.com/marcusquinn/aidevops/issues/9003" "${TMP_DIR}" "$valid_output"

--- a/.agents/scripts/tests/test-framework-issue-helper.sh
+++ b/.agents/scripts/tests/test-framework-issue-helper.sh
@@ -82,7 +82,7 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
 	exit 0
 fi
 
-if [[ "${1:-}" == "api" && "${2:-}" == "user" ]]; then
+if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
 	printf '"testuser"\n'
 	exit 0
 fi

--- a/.agents/scripts/tests/test-session-introspect.sh
+++ b/.agents/scripts/tests/test-session-introspect.sh
@@ -111,9 +111,9 @@ assert_contains() {
 
 printf '\n%s=== recent (default session = sess-A, most recent) ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" recent 2>&1) || true
-assert_contains "recent: shows current session ID"    "$out" "sess-A"
-assert_contains "recent: shows Edit tool call"        "$out" "Edit"
-assert_contains "recent: shows Bash error (✗)"        "$out" "✗"
+assert_contains "recent: shows current session ID" "$out" "sess-A"
+assert_contains "recent: shows Edit tool call" "$out" "Edit"
+assert_contains "recent: shows Bash error (✗)" "$out" "✗"
 
 printf '\n%s=== recent with limit ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" recent 3 2>&1) || true
@@ -126,22 +126,22 @@ fi
 
 printf '\n%s=== patterns ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" patterns 2>&1) || true
-assert_contains "patterns: shows session ID"         "$out" "sess-A"
-assert_contains "patterns: shows total calls"        "$out" "9 total"
-assert_contains "patterns: shows error count"        "$out" "2 error"
+assert_contains "patterns: shows session ID" "$out" "sess-A"
+assert_contains "patterns: shows total calls" "$out" "9 total"
+assert_contains "patterns: shows error count" "$out" "2 error"
 assert_contains "patterns: reports repeated-path evidence" "$out" "/repo/b.sh"
 assert_contains "patterns: requires contextual interpretation" "$out" "Interpret in context"
 
 printf '\n%s=== errors ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" errors 2>&1) || true
-assert_contains "errors: shows failed Bash call"     "$out" "shellcheck"
-assert_contains "errors: excludes succeeded calls"   "$out" "2 error"
+assert_contains "errors: shows failed Bash call" "$out" "shellcheck"
+assert_contains "errors: excludes succeeded calls" "$out" "2 error"
 
 printf '\n%s=== sessions ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" sessions 2>&1) || true
-assert_contains "sessions: shows sess-A"             "$out" "sess-A"
-assert_contains "sessions: shows sess-B"             "$out" "sess-B"
-assert_contains "sessions: shows cost column"        "$out" "0.0184"
+assert_contains "sessions: shows sess-A" "$out" "sess-A"
+assert_contains "sessions: shows sess-B" "$out" "sess-B"
+assert_contains "sessions: shows cost column" "$out" "0.0184"
 
 printf '\n%s=== explicit --session flag ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" recent --session sess-B 2>&1) || true

--- a/.agents/scripts/tests/test-session-introspect.sh
+++ b/.agents/scripts/tests/test-session-introspect.sh
@@ -129,8 +129,8 @@ out=$("$HELPER" patterns 2>&1) || true
 assert_contains "patterns: shows session ID"         "$out" "sess-A"
 assert_contains "patterns: shows total calls"        "$out" "9 total"
 assert_contains "patterns: shows error count"        "$out" "2 error"
-assert_contains "patterns: flags file-reread loop"   "$out" "/repo/b.sh"
-assert_contains "patterns: hint on reread loops"     "$out" "re-read loop"
+assert_contains "patterns: reports repeated-path evidence" "$out" "/repo/b.sh"
+assert_contains "patterns: requires contextual interpretation" "$out" "Interpret in context"
 
 printf '\n%s=== errors ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" errors 2>&1) || true
@@ -162,10 +162,10 @@ if command -v jq >/dev/null 2>&1; then
 	fi
 
 	out=$("$HELPER" patterns --json 2>&1) || true
-	if printf '%s' "$out" | jq -e '.file_rereads.hot | length > 0' >/dev/null 2>&1; then
-		pass "patterns --json: surfaces hot reread paths"
+	if printf '%s' "$out" | jq -e '.repeated_file_access.evidence | length > 0' >/dev/null 2>&1; then
+		pass "patterns --json: surfaces repeated-path evidence"
 	else
-		fail "patterns --json: missing file_rereads.hot" "$out"
+		fail "patterns --json: missing repeated_file_access.evidence" "$out"
 	fi
 
 	out=$("$HELPER" sessions --json 2>&1) || true

--- a/.agents/scripts/tests/test-session-introspect.sh
+++ b/.agents/scripts/tests/test-session-introspect.sh
@@ -111,9 +111,9 @@ assert_contains() {
 
 printf '\n%s=== recent (default session = sess-A, most recent) ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" recent 2>&1) || true
-assert_contains "recent: shows current session ID" "$out" "sess-A"
-assert_contains "recent: shows Edit tool call" "$out" "Edit"
-assert_contains "recent: shows Bash error (✗)" "$out" "✗"
+assert_contains "recent: shows current session ID"    "$out" "sess-A"
+assert_contains "recent: shows Edit tool call"        "$out" "Edit"
+assert_contains "recent: shows Bash error (✗)"        "$out" "✗"
 
 printf '\n%s=== recent with limit ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" recent 3 2>&1) || true
@@ -126,22 +126,22 @@ fi
 
 printf '\n%s=== patterns ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" patterns 2>&1) || true
-assert_contains "patterns: shows session ID" "$out" "sess-A"
-assert_contains "patterns: shows total calls" "$out" "9 total"
-assert_contains "patterns: shows error count" "$out" "2 error"
+assert_contains "patterns: shows session ID"         "$out" "sess-A"
+assert_contains "patterns: shows total calls"        "$out" "9 total"
+assert_contains "patterns: shows error count"        "$out" "2 error"
 assert_contains "patterns: reports repeated-path evidence" "$out" "/repo/b.sh"
 assert_contains "patterns: requires contextual interpretation" "$out" "Interpret in context"
 
 printf '\n%s=== errors ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" errors 2>&1) || true
-assert_contains "errors: shows failed Bash call" "$out" "shellcheck"
-assert_contains "errors: excludes succeeded calls" "$out" "2 error"
+assert_contains "errors: shows failed Bash call"     "$out" "shellcheck"
+assert_contains "errors: excludes succeeded calls"   "$out" "2 error"
 
 printf '\n%s=== sessions ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" sessions 2>&1) || true
-assert_contains "sessions: shows sess-A" "$out" "sess-A"
-assert_contains "sessions: shows sess-B" "$out" "sess-B"
-assert_contains "sessions: shows cost column" "$out" "0.0184"
+assert_contains "sessions: shows sess-A"             "$out" "sess-A"
+assert_contains "sessions: shows sess-B"             "$out" "sess-B"
+assert_contains "sessions: shows cost column"        "$out" "0.0184"
 
 printf '\n%s=== explicit --session flag ===%s\n' "$GREEN" "$NC"
 out=$("$HELPER" recent --session sess-B 2>&1) || true

--- a/.agents/workflows/session-review.md
+++ b/.agents/workflows/session-review.md
@@ -20,7 +20,7 @@ tools:
 
 **Purpose**: Review current session for completeness, workflow adherence, and knowledge capture.
 **Trigger**: `/session-review [focus]` — focus: `objectives | workflow | knowledge | all` (default). Run at end of significant work, before ending session, or after Ralph loop completion.
-**Output**: Completion score (0-100%), outstanding items, value extraction report, knowledge capture recommendations, session continuation advice.
+**Output**: Completion score (0-100%), outstanding items, value extraction report, evidence-based friction/efficiency retrospective, knowledge capture recommendations, session continuation advice.
 
 <!-- AI-CONTEXT-END -->
 
@@ -96,6 +96,26 @@ Output: practices followed, practices missed with recommendations.
 Output: newly captured items with locations, already-captured items, unfinished threads with created TODOs/issues.
 
 ### Step 6: Session Health Assessment
+
+Before assessing whether to end, run an evidence-based efficiency retrospective:
+
+```bash
+session-introspect-helper.sh patterns
+report-token-use-helper.sh --help
+rtk-helper.sh --adoption-report
+```
+
+Use only the commands relevant and available for the current runtime. Review:
+
+1. lifecycle friction (prompts, policy blocks, retries, duplicate work, manual steps, noisy waits, version drift);
+2. token-use mechanisms already active (narrow queries, RTK, caches, compaction, subagents, summaries) and whether each avoided work or caused fallback;
+3. comprehension safeguards (requirements retained, causal context understood, review and verification complete, no unexplained rediscovery);
+4. unexpected outliers, including useful or harmful behaviour outside known categories.
+
+Do not assign arbitrary problem thresholds or optimise for minimum tokens. Compare
+similar sessions/stages only when the comparison is meaningful. Output evidence,
+interpretation, trade-offs, and at most one deduplicated systemic recommendation
+per mechanism; route it through the existing self-improvement workflow.
 
 | Signal | Recommendation |
 |--------|----------------|


### PR DESCRIPTION
## Summary

Extend session review and self-improvement guidance to audit lifecycle friction, existing token optimisations, unexpected outliers, and comprehension regressions without arbitrary thresholds. Session introspection now reports repeated-path evidence for contextual judgment, and framework issue filing accepts a working GraphQL token when keyring status or REST capacity is stale.

## Files Changed

.agents/reference/context-efficient-output.md, .agents/reference/self-improvement.md, .agents/scripts/framework-issue-helper.sh, .agents/scripts/session-introspect-helper.sh, .agents/scripts/tests/test-framework-issue-helper.sh, .agents/scripts/tests/test-session-introspect.sh, .agents/workflows/session-review.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 21 session-introspection tests and 30 framework-issue tests passed; ShellCheck and local linter suite passed

Resolves #27457


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 with gpt-5.6-sol spent 51m and 648,294 tokens on this with the user in an interactive session.