### PR TITLE
GH#27459: make PR policy gates resilient to API exhaustion

### DIFF
--- a/.agents/scripts/tests/test-linked-issue-guidance.sh
+++ b/.agents/scripts/tests/test-linked-issue-guidance.sh
@@ -41,7 +41,15 @@ assert_contains ".github/PULL_REQUEST_TEMPLATE.md" 'Closes #NNN' "PR template cl
 assert_contains ".github/PULL_REQUEST_TEMPLATE.md" 'Ref #NNN' "PR template reference keyword"
 assert_contains ".agents/scripts/commands/log-issue-aidevops.md" 'For #NNN.*Ref #NNN' "command log issue PR reference guidance"
 assert_contains ".agents/workflows/log-issue-aidevops.md" 'For #NNN.*Ref #NNN' "workflow log issue PR reference guidance"
-assert_contains ".github/workflows/linked-issue-check.yml" "state: 'failure'" "linked issue status gate remains blocking"
+assert_contains ".github/workflows/linked-issue-check.yml" "publishStatus\('failure'" "linked issue status gate remains blocking"
 assert_not_contains ".github/workflows/linked-issue-check.yml" 'core\.setFailed' "linked issue policy gate avoids workflow failure"
+assert_contains ".github/workflows/linked-issue-check.yml" "state === 'success' && exhausted" "positive linked issue result tolerates exhausted API quota"
+assert_contains ".github/workflows/linked-issue-check.yml" 'throw error' "negative linked issue result still fails closed"
+
+assert_contains ".github/workflows/review-bot-gate-reusable.yml" 'RESULT="INFRA_RATE_LIMITED"' "review gate classifies API exhaustion truthfully"
+assert_contains ".github/workflows/review-bot-gate-reusable.yml" "result != 'INFRA_RATE_LIMITED'" "review gate avoids follow-up API label lookup during exhaustion"
+assert_contains ".github/workflows/review-bot-gate-reusable.yml" 'skipping immediate status retry' "review gate avoids retry loop during exhaustion"
+assert_contains ".github/workflows/review-bot-gate-reusable.yml" 'infrastructure wait — GitHub API quota exhausted' "review status reports infrastructure wait truthfully"
+assert_not_contains ".github/workflows/review-bot-gate-reusable.yml" 'sleep 5 && gh api' "review gate removed blind status retry"
 
 exit 0

--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -49,34 +49,45 @@ jobs:
             const headSha = pr.head.sha;
             const repo = context.repo;
 
+            // A positive policy result must not become a failed workflow just
+            // because the installation's shared REST quota was exhausted while
+            // publishing the compatibility StatusContext. The workflow check is
+            // itself authoritative; negative policy results still fail closed.
+            const publishStatus = async (state, description) => {
+              try {
+                await github.rest.repos.createCommitStatus({
+                  owner: repo.owner,
+                  repo: repo.repo,
+                  sha: headSha,
+                  state,
+                  context: 'linked-issue-check',
+                  description
+                });
+              } catch (error) {
+                const remaining = error.response?.headers?.['x-ratelimit-remaining'];
+                const exhausted = error.status === 403 && remaining === '0';
+                if (state === 'success' && exhausted) {
+                  core.warning('Linked-issue policy passed, but the compatibility status could not be posted because GitHub API quota is exhausted.');
+                  return;
+                }
+                throw error;
+              }
+            };
+
             // Safety guard: skip if this is an external bot PR from a fork
             // pull_request_target runs in base repo context, but we should not
             // process PRs from non-User accounts in forks
             const isFork = Boolean(pr.head.repo) && pr.head.repo.full_name !== pr.base.repo.full_name;
             if (isFork && pr.user.type === 'Bot') {
               console.log(`External bot PR from fork — skipping linked-issue check`);
-              await github.rest.repos.createCommitStatus({
-                owner: repo.owner,
-                repo: repo.repo,
-                sha: headSha,
-                state: 'success',
-                context: 'linked-issue-check',
-                description: 'External bot PR — skipped'
-              });
+              await publishStatus('success', 'External bot PR — skipped');
               return;
             }
 
             // Bot accounts are exempt
             if (pr.user.type === 'Bot') {
               console.log(`Author ${pr.user.login} is a bot — exempt from linked-issue check`);
-              await github.rest.repos.createCommitStatus({
-                owner: repo.owner,
-                repo: repo.repo,
-                sha: headSha,
-                state: 'success',
-                context: 'linked-issue-check',
-                description: 'Bot PR — exempt from linked-issue requirement'
-              });
+              await publishStatus('success', 'Bot PR — exempt from linked-issue requirement');
               return;
             }
 
@@ -84,14 +95,7 @@ jobs:
             // These are already tracked via the task system / maintainer-gate title lookup
             if (/^(t\d+(\.\d+)*|GH#\d+)[:\s]/.test(title)) {
               console.log(`PR "${title}" has task-ID prefix — exempt from linked-issue check`);
-              await github.rest.repos.createCommitStatus({
-                owner: repo.owner,
-                repo: repo.repo,
-                sha: headSha,
-                state: 'success',
-                context: 'linked-issue-check',
-                description: 'Task-ID prefix detected — issue linkage via task system'
-              });
+              await publishStatus('success', 'Task-ID prefix detected — issue linkage via task system');
               return;
             }
 
@@ -105,14 +109,7 @@ jobs:
               const match = body.match(/(closes?|fixes?|resolves?|for|ref)[:\s]+#(\d+)/i);
               const issueNum = match ? match[2] : 'unknown';
               console.log(`Found linked issue reference — #${issueNum}`);
-              await github.rest.repos.createCommitStatus({
-                owner: repo.owner,
-                repo: repo.repo,
-                sha: headSha,
-                state: 'success',
-                context: 'linked-issue-check',
-                description: `Linked issue found — #${issueNum}`
-              });
+              await publishStatus('success', `Linked issue found — #${issueNum}`);
               return;
             }
 
@@ -120,14 +117,7 @@ jobs:
             // Keep the workflow job green so CI-failure mining does not treat
             // an intentional policy gate as a systemic workflow failure.
             console.log(`No linked issue reference found in PR body`);
-            await github.rest.repos.createCommitStatus({
-              owner: repo.owner,
-              repo: repo.repo,
-              sha: headSha,
-              state: 'failure',
-              context: 'linked-issue-check',
-              description: 'No linked issue — add Closes/Fixes/Resolves/For #NNN to PR body'
-            });
+            await publishStatus('failure', 'No linked issue — add Closes/Fixes/Resolves/For #NNN to PR body');
 
             core.warning(
               'PR body must reference a linked issue.\n' +

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -119,7 +119,18 @@ jobs:
           HELPER="${GITHUB_WORKSPACE}/__aidevops/.agents/scripts/review-bot-gate-helper.sh"
           RESULT=""
           HELPER_EXIT=0
-          RESULT=$(bash "${HELPER}" check "${PR_NUMBER}" "${REPO}") || HELPER_EXIT=$?
+          HELPER_STDERR=$(mktemp)
+          RESULT=$(bash "${HELPER}" check "${PR_NUMBER}" "${REPO}" 2>"${HELPER_STDERR}") || HELPER_EXIT=$?
+          cat "${HELPER_STDERR}" >&2
+
+          # API exhaustion is an infrastructure condition, not evidence that a
+          # bot failed to review. Preserve fail-closed behavior while reporting
+          # the truthful reason and avoiding more API calls in this run.
+          if grep -qiE 'API rate limit exceeded|x-ratelimit-remaining[^0-9]*0' "${HELPER_STDERR}"; then
+            RESULT="INFRA_RATE_LIMITED"
+            HELPER_EXIT=2
+          fi
+          rm -f "${HELPER_STDERR}"
 
           echo ""
           echo "Helper result: ${RESULT:-<empty>} (exit: ${HELPER_EXIT})"
@@ -142,7 +153,7 @@ jobs:
 
       - name: Check for skip label
         id: skip
-        if: steps.check.outputs.gate_passed != 'true'
+        if: steps.check.outputs.gate_passed != 'true' && steps.check.outputs.result != 'INFRA_RATE_LIMITED'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
@@ -170,12 +181,19 @@ jobs:
         env:
           RESULT: ${{ steps.check.outputs.result }}
         run: |
-          if [[ "${RESULT}" == "WAITING" || -z "${RESULT}" ]]; then
+          if [[ "${RESULT}" == "INFRA_RATE_LIMITED" ]]; then
+            echo "::error::Review state could not be evaluated because GitHub API quota is exhausted."
+          elif [[ "${RESULT}" == "WAITING" || -z "${RESULT}" ]]; then
             echo "::error::No AI review bots have posted a real, settled review on this PR yet."
           else
             echo "::error::Review bot gate blocked (helper result: ${RESULT})."
           fi
           echo ""
+          if [[ "${RESULT}" == "INFRA_RATE_LIMITED" ]]; then
+            echo "This is an infrastructure wait, not a missing-review finding."
+            echo "Re-run after the GitHub API reset; do not retry-loop before then."
+            exit 1
+          fi
           echo "This PR cannot be merged until at least one AI code review bot"
           echo "(CodeRabbit, Gemini Code Assist, etc.) has posted a real review."
           echo ""
@@ -216,31 +234,39 @@ jobs:
           if [[ "${GATE_PASSED}" == "true" ]] || [[ "${SKIP_GATE}" == "true" ]]; then
             STATE=success
             DESC="Review bot gate passed (${RESULT:-SKIP})"
+          elif [[ "${RESULT}" == "INFRA_RATE_LIMITED" ]]; then
+            STATE=failure
+            DESC="Review bot gate infrastructure wait — GitHub API quota exhausted"
           else
             STATE=failure
             DESC="Review bot gate WAITING — no real bot review yet"
           fi
 
           STATUS_EXIT=0
+          STATUS_ERROR=$(mktemp)
           gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
             --method POST \
             -f state="${STATE}" \
             -f context="review-bot-gate" \
             -f description="${DESC}" \
-            2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-            --method POST \
-            -f state="${STATE}" \
-            -f context="review-bot-gate" \
-            -f description="${DESC}"; } || STATUS_EXIT=$?
+            2>"${STATUS_ERROR}" || STATUS_EXIT=$?
 
           if [[ "${STATUS_EXIT}" -ne 0 ]]; then
+            cat "${STATUS_ERROR}" >&2
+            if grep -qi 'API rate limit exceeded' "${STATUS_ERROR}"; then
+              echo "::warning::GitHub API quota is exhausted; skipping immediate status retry until a later workflow run."
+              rm -f "${STATUS_ERROR}"
+              exit 0
+            fi
+            rm -f "${STATUS_ERROR}"
             if [[ "${STATE}" == "success" ]]; then
               echo "::warning::Review bot gate passed, but commit-status posting is unavailable in this token context; continuing with the workflow check as the gate signal."
               exit 0
             fi
-            echo "::error::Failed to post review-bot-gate commit status after retry"
+            echo "::error::Failed to post review-bot-gate commit status"
             exit 1
           fi
+          rm -f "${STATUS_ERROR}"
           echo "Posted review-bot-gate status: ${STATE} (${DESC})"
 
       - name: Summary
@@ -268,6 +294,11 @@ jobs:
               echo "At least one AI review bot has posted a real, settled review."
             elif [[ "${SKIP_GATE}" == "true" ]]; then
               echo "**Status**: SKIPPED (skip-review-gate label)"
+            elif [[ "${RESULT}" == "INFRA_RATE_LIMITED" ]]; then
+              echo "**Status**: INFRASTRUCTURE WAIT (GitHub API quota exhausted)"
+              echo ""
+              echo "Review policy was not evaluated. Re-run after quota reset;"
+              echo "the gate did not infer that review feedback was missing."
             else
               echo "**Status**: WAITING"
               echo ""


### PR DESCRIPTION
## Summary

Classify GitHub API exhaustion as an infrastructure wait, prevent misleading missing-review diagnostics, avoid blind status retries, and let positive linked-issue policy checks remain green when only compatibility status publication is quota-blocked.

## Files Changed

.agents/scripts/tests/test-linked-issue-guidance.sh, .github/workflows/linked-issue-check.yml, .github/workflows/review-bot-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused linked-issue guidance tests, review-bot completion suite, actionlint, ShellCheck, git diff checks, and .agents/scripts/linters-local.sh passed.

Resolves #27459


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.81 with gpt-5.6-sol spent 14m and 293,136 tokens on this with the user in an interactive session.