### PR TITLE
GH#27448: fix: bootstrap remote refresh from HEAD

### DIFF
--- a/.agents/scripts/tests/test-worktree-fresh-base.sh
+++ b/.agents/scripts/tests/test-worktree-fresh-base.sh
@@ -36,6 +36,14 @@ git -C "$UPDATER" commit -q -m remote-tip
 git -C "$UPDATER" push -q origin main
 REMOTE_SHA=$(git -C "$UPDATER" rev-parse HEAD)
 
+# Simulate a remote branch that has not been fetched into the canonical repo.
+# The bootstrap worktree must not depend on the missing remote-tracking ref.
+git -C "$CANONICAL" update-ref -d refs/remotes/origin/main
+if git -C "$CANONICAL" show-ref --verify --quiet refs/remotes/origin/main; then
+	printf 'FAIL origin/main still exists before bootstrap test\n'
+	exit 1
+fi
+
 # Optional integration mode: prepend the repository Git shim after fixture
 # setup so worktree creation exercises the canonical guard without blocking
 # the fixture's intentional canonical branch/bootstrap mutations.

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -663,8 +663,9 @@ _parse_cmd_add_args() {
 
 # Refresh an origin branch from linked-worktree context so the canonical Git
 # guard remains intact. If no linked worktree exists yet, create a short-lived
-# detached bootstrap worktree from the existing remote-tracking ref, fetch from
-# there, then remove it from that linked context.
+# detached bootstrap worktree from HEAD, fetch from there, then remove it from
+# that linked context. HEAD remains available when the remote-tracking ref has
+# not been created locally yet.
 # Args: branch name
 #######################################
 _worktree_refresh_origin_branch() {
@@ -694,7 +695,7 @@ _worktree_refresh_origin_branch() {
 		repo_name=$(basename "$current_root")
 		mkdir -p "$base_dir" || return 1
 		bootstrap_path="${base_dir}/.${repo_name}-fetch-$$"
-		if ! git worktree add --detach "$bootstrap_path" "refs/remotes/origin/${branch}" >/dev/null 2>&1; then
+		if ! git worktree add -q --detach "$bootstrap_path" HEAD; then
 			return 1
 		fi
 		fetch_cwd="$bootstrap_path"


### PR DESCRIPTION
## Summary

Bootstrap canonical-guard fetch worktrees from HEAD so missing local remote-tracking refs can be fetched, while preserving Git stderr and adding regression coverage.

## Files Changed

.agents/scripts/tests/test-worktree-fresh-base.sh, .agents/scripts/worktree-helper-add.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worktree-helper-add.sh .agents/scripts/tests/test-worktree-fresh-base.sh; PATH=/opt/homebrew/bin:/usr/bin:/bin .agents/scripts/tests/test-worktree-fresh-base.sh

Resolves #27448


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.81 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 42,245 tokens on this as a headless worker.