### PR TITLE
GH#27464: target Pulse merge spot checks exactly

### DIFF
--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -173,6 +173,8 @@ PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS="${PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS:-600}
 RUNNER_LOG_FILE="${HOME}/.aidevops/logs/pulse-merge-routine.log"
 LOCK_DIR="${HOME}/.aidevops/.agent-workspace/locks/pulse-merge-routine.lock"
 PULSE_MERGE_ROUTINE_LAST_RUN="${HOME}/.aidevops/logs/pulse-merge-routine-last-run"
+PULSE_MERGE_ROUTINE_TARGET_REPO=""
+PULSE_MERGE_ROUTINE_TARGET_PR=""
 
 mkdir -p "$(dirname "$RUNNER_LOG_FILE")" "$(dirname "$LOCK_DIR")"
 
@@ -351,6 +353,43 @@ _pmr_acquire_lock() {
 # Commands
 # =============================================================================
 
+_pmr_run_merge_scope() {
+	if [[ -z "$PULSE_MERGE_ROUTINE_TARGET_PR" ]]; then
+		merge_ready_prs_all_repos
+		return $?
+	fi
+
+	local process_exit=0
+	process_pr "$PULSE_MERGE_ROUTINE_TARGET_REPO" "$PULSE_MERGE_ROUTINE_TARGET_PR" || process_exit=$?
+	case "$process_exit" in
+	0)
+		if [[ "${DRY_RUN:-0}" == "1" ]]; then
+			_pmr_log INFO "Spot-check result: repo=${PULSE_MERGE_ROUTINE_TARGET_REPO} pr=${PULSE_MERGE_ROUTINE_TARGET_PR} disposition=would-merge"
+		else
+			_pmr_log INFO "Spot-check result: repo=${PULSE_MERGE_ROUTINE_TARGET_REPO} pr=${PULSE_MERGE_ROUTINE_TARGET_PR} disposition=merged"
+		fi
+		;;
+	1)
+		_pmr_log INFO "Spot-check result: repo=${PULSE_MERGE_ROUTINE_TARGET_REPO} pr=${PULSE_MERGE_ROUTINE_TARGET_PR} disposition=skipped reason=merge-gate"
+		;;
+	2)
+		_pmr_log INFO "Spot-check result: repo=${PULSE_MERGE_ROUTINE_TARGET_REPO} pr=${PULSE_MERGE_ROUTINE_TARGET_PR} disposition=closed-conflicting"
+		;;
+	3)
+		_pmr_log ERROR "Spot-check result: repo=${PULSE_MERGE_ROUTINE_TARGET_REPO} pr=${PULSE_MERGE_ROUTINE_TARGET_PR} disposition=merge-failed"
+		return 3
+		;;
+	4)
+		_pmr_log INFO "Spot-check result: repo=${PULSE_MERGE_ROUTINE_TARGET_REPO} pr=${PULSE_MERGE_ROUTINE_TARGET_PR} disposition=deferred"
+		;;
+	*)
+		_pmr_log ERROR "Spot-check result: repo=${PULSE_MERGE_ROUTINE_TARGET_REPO} pr=${PULSE_MERGE_ROUTINE_TARGET_PR} disposition=unexpected exit=${process_exit}"
+		return "$process_exit"
+		;;
+	esac
+	return 0
+}
+
 cmd_run() {
 	_pmr_log INFO "Starting merge routine (pid=$$, timeout=${PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS}s)"
 	if ! _pmr_acquire_lock; then
@@ -366,7 +405,7 @@ cmd_run() {
 	# retry loop, dead-PID wait), the routine cannot exceed this ceiling. On
 	# timeout, _pmr_run_with_timeout returns 124 (matching GNU `timeout`).
 	local merge_exit=0
-	_pmr_run_with_timeout "$PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS" merge_ready_prs_all_repos || merge_exit=$?
+	_pmr_run_with_timeout "$PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS" _pmr_run_merge_scope || merge_exit=$?
 
 	# Always write the last-run marker so pulse-wrapper.sh short-circuit can
 	# compare elapsed time (consistent with DIRTY_PR_SWEEP_LAST_RUN pattern).
@@ -429,7 +468,7 @@ cmd_dry_run() {
 
 	# Same timeout protection as cmd_run (t3041, GH#21708).
 	local merge_exit=0
-	_pmr_run_with_timeout "$PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS" merge_ready_prs_all_repos || merge_exit=$?
+	_pmr_run_with_timeout "$PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS" _pmr_run_merge_scope || merge_exit=$?
 
 	if [[ "$merge_exit" -eq 124 ]]; then
 		_pmr_log ERROR "DRY-RUN merge routine TIMED OUT (exit=124, ceiling=${PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS}s)"
@@ -461,6 +500,10 @@ _pmr_main() {
 			shift
 			;;
 		--repo)
+			if [[ -z "$_next" || "$_next" == --* ]]; then
+				printf '%s\n' 'Option --repo requires a repository slug.' >&2
+				return 2
+			fi
 			_repo_filter="$_next"
 			shift 2
 			;;
@@ -469,6 +512,10 @@ _pmr_main() {
 			shift
 			;;
 		--pr)
+			if [[ -z "$_next" || "$_next" == --* ]]; then
+				printf '%s\n' 'Option --pr requires a pull request number.' >&2
+				return 2
+			fi
 			_pr_filter="$_next"
 			shift 2
 			;;
@@ -488,6 +535,15 @@ _pmr_main() {
 		esac
 	done
 
+	if [[ -n "$_pr_filter" && -z "$_repo_filter" ]]; then
+		printf '%s\n' 'Option --pr requires --repo.' >&2
+		return 2
+	fi
+	if [[ -n "$_pr_filter" && ! "$_pr_filter" =~ ^[1-9][0-9]*$ ]]; then
+		printf 'Invalid pull request number: %s\n' "$_pr_filter" >&2
+		return 2
+	fi
+
 	# Single-repo or single-PR spot mode: override REPOS_JSON with a synthetic
 	# single-entry repo list so merge_ready_prs_all_repos only processes that repo.
 	if [[ -n "$_repo_filter" ]]; then
@@ -500,11 +556,8 @@ _pmr_main() {
 		REPOS_JSON="$_SPOT_REPOS_JSON"
 		if [[ -n "$_pr_filter" ]]; then
 			_pmr_log INFO "Spot-check: --repo=${_repo_filter} --pr=${_pr_filter}"
-			# For single-PR mode, set PULSE_MERGE_BATCH_LIMIT to 1 and let the
-			# function discover and process only that PR. Note: the current
-			# merge_ready_prs_all_repos API processes all open ready PRs for the
-			# repo; single-PR filtering is a best-effort convenience.
-			PULSE_MERGE_BATCH_LIMIT=1
+			PULSE_MERGE_ROUTINE_TARGET_REPO="$_repo_filter"
+			PULSE_MERGE_ROUTINE_TARGET_PR="$_pr_filter"
 		else
 			_pmr_log INFO "Spot-check: --repo=${_repo_filter}"
 		fi

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -325,7 +325,9 @@ _check_pr_merge_gates() {
 	_author_collab_rc=$?
 	local _author_collab_permission="${_PULSE_AUTHOR_PERMISSION_VALUE:-}"
 	if [[ "$_author_collab_rc" -eq 2 ]]; then
-		check_permission_failure_pr "$pr_number" "$repo_slug" "$pr_author" "${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}" || true
+		if [[ "${DRY_RUN:-0}" != "1" ]]; then
+			check_permission_failure_pr "$pr_number" "$repo_slug" "$pr_author" "${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}" || true
+		fi
 		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — permission check failed for author ${pr_author} (HTTP ${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown})" >>"$LOGFILE"
 		return 1
 	fi
@@ -942,6 +944,10 @@ _process_single_ready_pr() {
 	# maintainer review latency by throwing away worker work — see t2116
 	# post-mortem for PR #18988, #19083).
 	if [[ "$pr_mergeable" == "CONFLICTING" && "$PULSE_MERGE_CLOSE_CONFLICTING" == "true" ]]; then
+		if [[ "${DRY_RUN:-0}" == "1" ]]; then
+			echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} is CONFLICTING; would evaluate rebase, repair routing, or protected close" >>"$LOGFILE"
+			return 2
+		fi
 		# Skip CONFLICTING-close entirely for PRs whose linked issue has
 		# needs-maintainer-review — they are parked legitimately waiting for
 		# a human and MUST NOT be auto-closed (t2116). Post the one-time
@@ -1010,6 +1016,10 @@ _process_single_ready_pr() {
 	# above retains precedence, and the helper only routes/skips CHANGES_REQUESTED
 	# via the same origin-label and stale-handover checks used by the later gate.
 	if [[ "$pr_review" == "CHANGES_REQUESTED" ]]; then
+		if [[ "${DRY_RUN:-0}" == "1" ]]; then
+			echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} has CHANGES_REQUESTED; would evaluate review remediation or repair routing" >>"$LOGFILE"
+			return 1
+		fi
 		local _early_review_linked_issue=""
 		local _early_review_dismissed="0"
 		_early_review_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || _early_review_linked_issue=""
@@ -1050,7 +1060,8 @@ _process_single_ready_pr() {
 		return 1
 	fi
 
-	if declare -F _pm_close_superseded_duplicate_pr_if_issue_solved >/dev/null 2>&1 \
+	if [[ "${DRY_RUN:-0}" != "1" ]] \
+		&& declare -F _pm_close_superseded_duplicate_pr_if_issue_solved >/dev/null 2>&1 \
 		&& _pm_close_superseded_duplicate_pr_if_issue_solved "$pr_number" "$repo_slug" "$linked_issue" "$pr_labels"; then
 		return 1
 	fi
@@ -1083,6 +1094,10 @@ _process_single_ready_pr() {
 			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: _pr_required_checks_pass bypassed for origin:worker — branch-protection required contexts all pass (t2922)" >>"$LOGFILE"
 			# Fall through to linked-issue fetch and merge gate checks
 		else
+			if [[ "${DRY_RUN:-0}" == "1" ]]; then
+				echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} has non-passing required checks; would evaluate CI-drift rebase or repair routing" >>"$LOGFILE"
+				return 1
+			fi
 			# t2805: try cheap rebase first if PR is behind base — pre-existing
 			# failures in unrelated tests are often fixed by base advancement.
 			# If rebase succeeds, skip fix-worker routing — next pulse cycle

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -305,10 +305,16 @@ cmd_run() {
 	if [[ -z "${REPOS_JSON:-}" ]]; then
 		return 1
 	fi
-	if grep -q '"slug":"example/repo"' "$REPOS_JSON"; then
-		return 0
+	if ! grep -q '"slug":"example/repo"' "$REPOS_JSON"; then
+		return 1
 	fi
-	return 1
+	if [[ -n "${EXPECT_PR:-}" ]]; then
+		[[ "${PULSE_MERGE_ROUTINE_TARGET_REPO:-}" == "example/repo" ]] || return 1
+		[[ "${PULSE_MERGE_ROUTINE_TARGET_PR:-}" == "$EXPECT_PR" ]] || return 1
+	else
+		[[ -z "${PULSE_MERGE_ROUTINE_TARGET_PR:-}" ]] || return 1
+	fi
+	return 0
 }
 
 # Extract only _pmr_main so this test does not run the real merge routine.
@@ -319,11 +325,11 @@ source <(awk '
 	capture && /^}/ { capture=0 }
 ' "$ROUTINE_FILE")
 
-_pmr_main --repo example/repo
+_pmr_main "$@"
 PARSER_HARNESS_EOF
 
 chmod +x "$PARSER_HARNESS"
-parser_output=$(ROUTINE_FILE="$ROUTINE_FILE" bash "$PARSER_HARNESS" 2>&1)
+parser_output=$(ROUTINE_FILE="$ROUTINE_FILE" bash "$PARSER_HARNESS" --repo example/repo 2>&1)
 parser_rc=$?
 
 if [[ "$parser_rc" -eq 0 ]]; then
@@ -333,10 +339,83 @@ else
 		"harness rc=${parser_rc}, output=${parser_output}"
 fi
 
+parser_output=$(EXPECT_PR=42 ROUTINE_FILE="$ROUTINE_FILE" bash "$PARSER_HARNESS" --repo example/repo --pr 42 2>&1)
+parser_rc=$?
+
+if [[ "$parser_rc" -eq 0 ]]; then
+	pass "13: --pr configures an exact target"
+else
+	fail "13: --pr configures an exact target" \
+		"harness rc=${parser_rc}, output=${parser_output}"
+fi
+
+parser_output=$(ROUTINE_FILE="$ROUTINE_FILE" bash "$PARSER_HARNESS" --pr 42 2>&1)
+parser_rc=$?
+
+if [[ "$parser_rc" -eq 2 && "$parser_output" == *"Option --pr requires --repo."* ]]; then
+	pass "14: --pr rejects a missing --repo"
+else
+	fail "14: --pr rejects a missing --repo" \
+		"harness rc=${parser_rc}, output=${parser_output}"
+fi
+
+if awk '
+	/if \[\[ "\$\{DRY_RUN:-0\}" == "1" \]\]/ { dry_guard=NR }
+	/_attempt_pr_ci_rebase_retry/ && dry_guard > 0 && dry_guard < NR { rebase_guarded=1 }
+	/_route_pr_to_fix_worker .*"ci"/ && dry_guard > 0 && dry_guard < NR { route_guarded=1 }
+	END { exit (rebase_guarded && route_guarded) ? 0 : 1 }
+' "${REPO_ROOT}/.agents/scripts/pulse-merge.sh"; then
+	pass "15: dry-run stops before CI repair writes"
+else
+	fail "15: dry-run stops before CI repair writes" \
+		"DRY_RUN must return before CI update-branch and repair dispatch calls"
+fi
+
+SCOPE_HARNESS=$(mktemp "${TMPDIR:-/tmp}/pmr-scope-harness-XXXXXX")
+trap 'rm -f "$PARSER_HARNESS" "$SCOPE_HARNESS"' EXIT
+
+cat >"$SCOPE_HARNESS" <<'SCOPE_HARNESS_EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+
+PULSE_MERGE_ROUTINE_TARGET_REPO="example/repo"
+PULSE_MERGE_ROUTINE_TARGET_PR="42"
+_pmr_log() { return 0; }
+merge_ready_prs_all_repos() {
+	printf 'all-prs\n'
+	return 0
+}
+process_pr() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	printf 'target:%s:%s\n' "$repo_slug" "$pr_number"
+	return 1
+}
+
+# shellcheck disable=SC1090
+source <(awk '
+	/^_pmr_run_merge_scope\(\)/ { capture=1 }
+	capture { print }
+	capture && /^}/ { capture=0 }
+' "$ROUTINE_FILE")
+
+_pmr_run_merge_scope
+SCOPE_HARNESS_EOF
+
+scope_output=$(ROUTINE_FILE="$ROUTINE_FILE" bash "$SCOPE_HARNESS" 2>&1)
+scope_rc=$?
+
+if [[ "$scope_rc" -eq 0 && "$scope_output" == "target:example/repo:42" ]]; then
+	pass "16: exact spot-check bypasses the all-PR merge pass"
+else
+	fail "16: exact spot-check bypasses the all-PR merge pass" \
+		"harness rc=${scope_rc}, output=${scope_output}"
+fi
+
 printf '\n=== API budget isolation regression guard ===\n'
 
 BUDGET_HARNESS=$(mktemp "${TMPDIR:-/tmp}/pmr-budget-harness-XXXXXX")
-trap 'rm -f "$PARSER_HARNESS" "$BUDGET_HARNESS"' EXIT
+trap 'rm -f "$PARSER_HARNESS" "$SCOPE_HARNESS" "$BUDGET_HARNESS"' EXIT
 
 cat >"$BUDGET_HARNESS" <<'BUDGET_HARNESS_EOF'
 #!/usr/bin/env bash
@@ -368,9 +447,9 @@ budget_output=$(ROUTINE_FILE="$ROUTINE_FILE" bash "$BUDGET_HARNESS" 2>&1)
 budget_rc=$?
 
 if [[ "$budget_rc" -eq 0 ]]; then
-	pass "13: GraphQL budget probe is independent of REST core rate limit"
+	pass "17: GraphQL budget probe is independent of REST core rate limit"
 else
-	fail "13: GraphQL budget probe is independent of REST core rate limit" \
+	fail "17: GraphQL budget probe is independent of REST core rate limit" \
 		"harness rc=${budget_rc}, output=${budget_output}"
 fi
 


### PR DESCRIPTION
## Summary

Make --repo/--pr invoke process_pr for exactly the requested PR, log a concise disposition, validate CLI arguments, and stop dry-runs before conflict/review/CI repair writes.

## Files Changed

.agents/scripts/pulse-merge-routine.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-routine-standalone.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 17/17 focused tests passed; ShellCheck clean; linters-local passed; runtime dry-run classified PR #27370 without dispatching repair.

Resolves #27464


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 with gpt-5.6-sol spent 1h 19m and 688,837 tokens on this with the user in an interactive session.