### PR TITLE
GH#27463: prevent REST issue-list ARG_MAX overflow

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -1442,8 +1442,8 @@ _rest_issue_list() {
 			return 1
 		fi
 		raw_count=$(printf '%s' "$raw_page" | jq 'length' 2>/dev/null) || return 1
-		combined=$(jq -cn --argjson prior "$combined" --argjson next "$raw_page" \
-			'$prior + [$next[] | select(.pull_request == null)]') || return 1
+		combined=$(printf '%s\n%s\n' "$combined" "$raw_page" | jq -sc \
+			'.[0] + [.[1][] | select(.pull_request == null)]') || return 1
 		issue_count=$(printf '%s' "$combined" | jq 'length' 2>/dev/null) || return 1
 		if [[ "$raw_count" -lt "$page_size" ]]; then
 			break

--- a/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
@@ -28,6 +28,7 @@
 #   8. _rest_issue_list → applies --jq expression
 #   9. _rest_issue_list → filters pull requests returned by REST /issues
 #  10. _rest_issue_list → includes --assignee in query string
+#  11. _rest_issue_list → handles response bodies larger than ARG_MAX
 #  11. _rest_issue_list → returns error when --repo is missing
 #  12. gh_issue_view falls back to REST when primary fails AND GraphQL exhausted
 #  13. gh_issue_view does NOT fall back when primary succeeds
@@ -110,6 +111,10 @@ stub_rest_list_result() {
 	fi
 	if [[ "${STUB_REST_PAGINATED:-0}" == "1" ]]; then
 		printf '%s\n' '[{"number":27154,"title":"Blocked issue","labels":[]}]'
+		return 0
+	fi
+	if [[ "${STUB_REST_LARGE_BODY:-0}" == "1" ]]; then
+		jq -cn '[{number:27463, title:"Large issue", body:("x" * 3000000), labels:[]}]'
 		return 0
 	fi
 	if [[ -n "${STUB_REST_LIST_RESULT:-}" ]]; then
@@ -388,7 +393,23 @@ fi
 unset STUB_REST_PAGINATED
 
 # =============================================================================
-# Test 11: _rest_issue_list includes --assignee in query string
+# Test 11: _rest_issue_list handles a REST response larger than ARG_MAX
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_REST_LARGE_BODY=1
+
+result=$(_rest_issue_list --repo "owner/repo" --state open --limit 1 --json number --jq '.[0].number' 2>/dev/null)
+
+if [[ "$result" == "27463" ]]; then
+	pass "_rest_issue_list streams large REST pages to jq without argv overflow"
+else
+	fail "_rest_issue_list streams large REST pages to jq without argv overflow" \
+		"expected issue 27463, got '${result}'"
+fi
+unset STUB_REST_LARGE_BODY
+
+# =============================================================================
+# Test 12: _rest_issue_list includes --assignee in query string
 # =============================================================================
 : >"$GH_CALLS"
 


### PR DESCRIPTION
## Summary

Stream accumulated and incoming REST issue pages through jq stdin instead of passing multi-megabyte JSON via --argjson, with a 3 MB regression fixture.

## Files Changed

.agents/scripts/shared-gh-wrappers-rest-fallback.sh, .agents/scripts/tests/test-gh-issue-read-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused REST fallback test: new large-page and pagination assertions pass; ShellCheck clean. Six pre-existing routing assertions remain environment-sensitive under the host REST-first cooldown.

Resolves #27463


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.53 with gpt-5.6-sol spent 12m and 90,445 tokens on this with the user in an interactive session.