### PR TITLE
Ref #27421: select one forge snapshot across API pages

### DIFF
--- a/.agents/scripts/forge-coordinator-state-helper.sh
+++ b/.agents/scripts/forge-coordinator-state-helper.sh
@@ -10,8 +10,8 @@ restore_state() {
 	local repository_id="$3"
 	local artifact_id="" archive=""
 	mkdir -p "$state_dir"
-	artifact_id=$(gh api --paginate "repos/${repository}/actions/artifacts?per_page=100" \
-		--jq ".artifacts | map(select(.name | startswith(\"forge-coordinator-${repository_id}-\"))) | sort_by(.created_at) | last | .id // empty") || return 1
+	artifact_id=$(gh api --paginate --slurp "repos/${repository}/actions/artifacts?per_page=100" \
+		--jq "[.[].artifacts[] | select(.name | startswith(\"forge-coordinator-${repository_id}-\"))] | sort_by(.created_at) | last | .id // empty") || return 1
 	[[ -n "$artifact_id" ]] || return 0
 	archive="${state_dir}/state.zip"
 	gh api "repos/${repository}/actions/artifacts/${artifact_id}/zip" >"$archive" || return 1

--- a/.agents/scripts/tests/test-forge-event-workflow.sh
+++ b/.agents/scripts/tests/test-forge-event-workflow.sh
@@ -66,7 +66,11 @@ mkdir -p "${test_root}/bin" "${test_root}/state"
 cat >"${test_root}/bin/gh" <<'GH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$GH_CALL_LOG"
-if [[ "$*" == *"actions/artifacts?per_page=100"* ]]; then printf '22\n'; exit 0; fi
+if [[ "$*" == *"actions/artifacts?per_page=100"* ]]; then
+	if [[ "$*" == *"--paginate --slurp"* ]]; then printf '22\n'; else printf '11\n22\n'; fi
+	exit 0
+fi
+[[ "$*" != *$'\n'* ]] || exit 1
 printf 'fixture archive'
 GH
 cat >"${test_root}/bin/unzip" <<'UNZIP'
@@ -78,6 +82,7 @@ chmod +x "${test_root}/bin/gh" "${test_root}/bin/unzip"
 GH_CALL_LOG="${test_root}/api.log" PATH="${test_root}/bin:/usr/bin:/bin" bash "$STATE_HELPER" restore "${test_root}/state" owner/repo R_1
 [[ "$(cat "${test_root}/state/tasks.db")" == "durable-db" ]]
 grep -q 'repos/owner/repo/actions/artifacts?per_page=100' "${test_root}/api.log"
+grep -q -- '--paginate --slurp' "${test_root}/api.log"
 grep -q 'repos/owner/repo/actions/artifacts/22/zip' "${test_root}/api.log"
 
 printf 'PASS forge event workflow is targeted, repository-bound, and repair scans are manual only\n'


### PR DESCRIPTION
## Summary

- Aggregate paginated artifact responses before selecting the latest forge coordinator snapshot.
- Prevent newline-separated artifact IDs from entering the artifact download URL.
- Extend the workflow regression test to require paginated slurping.

## Context

Ref #27421

The v3.32.85 postflight workflow failed in `.agents/scripts/forge-coordinator-state-helper.sh` because `gh api --paginate --jq` evaluated once per response page and emitted multiple IDs. The existing repository-scoped newest-artifact selection remains the reference pattern, now applied after flattening all pages.

## Verification

- `bash .agents/scripts/tests/test-forge-event-workflow.sh`
- `shellcheck .agents/scripts/forge-coordinator-state-helper.sh .agents/scripts/tests/test-forge-event-workflow.sh`
- `bash -n .agents/scripts/forge-coordinator-state-helper.sh .agents/scripts/tests/test-forge-event-workflow.sh`
- `.agents/scripts/linters-local.sh --changed`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.86 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 1h 31m and 1,131,563 tokens on this with the user in an interactive session.
