### PR TITLE
GH#27469: fix: report markdown applicability accurately

### DIFF
--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -967,11 +967,11 @@ _check_dry_run() {
 # Scan base+head via worktrees, compute diff, optionally write report.
 # Exits 0 (no regression), 1 (regression), or 2 (error).
 #
-# Diff-scoped optimisation (t2827): computes the list of .sh/.py files that
+# Diff-scoped optimisation (t2827): computes the list of .sh/.py/.md files that
 # changed between base and head and passes it to scan_dir so each worktree
 # scan covers only those files instead of the full repo. This reduces
 # wall-clock time from ~98s to <10s for a 2-file diff (949 .sh files → 2).
-# If no .sh/.py files changed, exits 0 immediately without creating worktrees.
+# If no .sh/.py/.md files changed, exits 0 immediately without creating worktrees.
 # The `scan` subcommand (CI full-repo path) is unaffected.
 # ---------------------------------------------------------------------------
 _check_regression() {
@@ -996,7 +996,7 @@ _check_regression() {
 	if [ -z "$_changed_source" ]; then
 		log "[$_metric] no applicable changes between ${_base_sha:0:7}..${_head_sha:0:7} — skipping"
 		# Write a clean "no applicable changes" report so any previously-posted
-		# stale report (from a prior run with .sh/.py changes that were later
+		# stale report (from a prior run with .sh/.py/.md changes that were later
 		# reverted back to doc-only) is replaced via the CI upsert path.
 		if [ -n "$_output_md" ]; then
 			local _title_str
@@ -1004,7 +1004,7 @@ _check_regression() {
 			{
 				printf '## %s Regression Gate\n\n' "$_title_str"
 				# shellcheck disable=SC2016
-				printf '✅ **No applicable changes** — no `.sh`/`.py` files changed in this PR.\n\n'
+				printf '✅ **No applicable changes** — no `.sh`/`.py`/`.md` files changed in this PR.\n\n'
 				printf '<!-- complexity-regression-gate:%s -->\n' "$_metric"
 			} >"$_output_md"
 			log "[$_metric] wrote no-changes report to $_output_md"

--- a/.agents/scripts/tests/test-complexity-regression-helper.sh
+++ b/.agents/scripts/tests/test-complexity-regression-helper.sh
@@ -596,10 +596,10 @@ test_diff_scoped_timing() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 15: diff-scoped skip — doc-only diff (no .sh/.py changes) exits 0 (t2827)
+# Test 15: diff-scoped skip — non-source diff exits 0 (t2827)
 #
-# When the diff between base and head contains no .sh or .py files, the check
-# subcommand should exit 0 immediately without creating any worktrees.
+# When the diff between base and head contains no .sh, .py, or .md files, the
+# check subcommand should exit 0 immediately and report the applicable types.
 # ---------------------------------------------------------------------------
 test_diff_scoped_skip_no_sh_changes() {
 	setup
@@ -618,20 +618,23 @@ test_diff_scoped_skip_no_sh_changes() {
 	local _base_sha
 	_base_sha=$(git -C "$_repo" rev-parse HEAD)
 
-	# Head commit: only a doc file changed (no .sh/.py)
-	printf 'hello\n' >"$_repo/README.md"
-	git -C "$_repo" add README.md
-	git -C "$_repo" commit -q -m "head: docs only"
+	# Head commit: only a non-source file changed (no .sh/.py/.md)
+	printf 'hello\n' >"$_repo/fixture.txt"
+	git -C "$_repo" add fixture.txt
+	git -C "$_repo" commit -q -m "head: fixture only"
 
 	local _rc=0
-	(cd "$_repo" && "$HELPER" check --base "$_base_sha" --metric function-complexity) \
-		>/dev/null 2>&1 || _rc=$?
+	local _report="$_repo/report.md"
+	(cd "$_repo" && "$HELPER" check --base "$_base_sha" --metric function-complexity \
+		--output-md "$_report") >/dev/null 2>&1 || _rc=$?
 
-	if [ "$_rc" -eq 0 ]; then
-		print_result "diff-scoped skip: doc-only diff exits 0 (no .sh changes)" 0
+	# Literal Markdown backticks are intentional.
+	# shellcheck disable=SC2016
+	if [ "$_rc" -eq 0 ] && grep -Fq 'no `.sh`/`.py`/`.md` files changed' "$_report"; then
+		print_result "diff-scoped skip: non-source diff reports all applicable types" 0
 	else
-		print_result "diff-scoped skip: doc-only diff exits 0 (no .sh changes)" 1 \
-			"expected exit 0, got exit $_rc"
+		print_result "diff-scoped skip: non-source diff reports all applicable types" 1 \
+			"expected exit 0 and .sh/.py/.md report text, got exit $_rc"
 	fi
 	teardown
 	return 0


### PR DESCRIPTION
## Summary

Update the complexity regression no-applicable-changes report to include Markdown and add regression coverage for the complete extension list.

## Files Changed

.agents/scripts/complexity-regression-helper.sh, .agents/scripts/tests/test-complexity-regression-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/complexity-regression-helper.sh .agents/scripts/tests/test-complexity-regression-helper.sh; bash -n .agents/scripts/complexity-regression-helper.sh .agents/scripts/tests/test-complexity-regression-helper.sh

Resolves #27469


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.86 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 52,339 tokens on this as a headless worker.