### PR TITLE
GH#27472: fix deterministic coordinator artifact restore

### DIFF
--- a/.agents/scripts/forge-coordinator-state-helper.sh
+++ b/.agents/scripts/forge-coordinator-state-helper.sh
@@ -11,8 +11,12 @@ restore_state() {
 	local artifact_id="" archive=""
 	mkdir -p "$state_dir"
 	artifact_id=$(gh api --paginate --slurp "repos/${repository}/actions/artifacts?per_page=100" \
-		--jq "[.[].artifacts[] | select(.name | startswith(\"forge-coordinator-${repository_id}-\"))] | sort_by(.created_at) | last | .id // empty") || return 1
+		--jq "[.[] | .artifacts[]? | select((.name | startswith(\"forge-coordinator-${repository_id}-\")) and ((.expired // false) == false))] | sort_by([.created_at, .id]) | last | .id // empty") || return 1
 	[[ -n "$artifact_id" ]] || return 0
+	if [[ ! "$artifact_id" =~ ^[1-9][0-9]*$ ]]; then
+		printf 'Invalid coordinator artifact ID returned for repository %s: %q\n' "$repository" "$artifact_id" >&2
+		return 1
+	fi
 	archive="${state_dir}/state.zip"
 	gh api "repos/${repository}/actions/artifacts/${artifact_id}/zip" >"$archive" || return 1
 	unzip -oq "$archive" -d "$state_dir" || return 1

--- a/.agents/scripts/tests/test-forge-event-workflow.sh
+++ b/.agents/scripts/tests/test-forge-event-workflow.sh
@@ -67,7 +67,13 @@ cat >"${test_root}/bin/gh" <<'GH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$GH_CALL_LOG"
 if [[ "$*" == *"actions/artifacts?per_page=100"* ]]; then
-	if [[ "$*" == *"--paginate --slurp"* ]]; then printf '22\n'; else printf '11\n22\n'; fi
+	if [[ "${GH_ARTIFACT_FIXTURE:-pages}" == "malformed" ]]; then
+		printf '22\n23\n'
+	else
+		[[ "$*" == *'sort_by([.created_at, .id])'* ]]
+		[[ "$*" == *'.expired // false'* ]]
+		printf '24\n'
+	fi
 	exit 0
 fi
 [[ "$*" != *$'\n'* ]] || exit 1
@@ -83,6 +89,20 @@ GH_CALL_LOG="${test_root}/api.log" PATH="${test_root}/bin:/usr/bin:/bin" bash "$
 [[ "$(cat "${test_root}/state/tasks.db")" == "durable-db" ]]
 grep -q 'repos/owner/repo/actions/artifacts?per_page=100' "${test_root}/api.log"
 grep -q -- '--paginate --slurp' "${test_root}/api.log"
-grep -q 'repos/owner/repo/actions/artifacts/22/zip' "${test_root}/api.log"
+grep -q 'repos/owner/repo/actions/artifacts/24/zip' "${test_root}/api.log"
+[[ "$(grep -c '/zip' "${test_root}/api.log")" -eq 1 ]]
+
+# A malformed multi-line selector result must fail before URL construction.
+: >"${test_root}/api.log"
+if GH_ARTIFACT_FIXTURE=malformed GH_CALL_LOG="${test_root}/api.log" PATH="${test_root}/bin:/usr/bin:/bin" \
+	bash "$STATE_HELPER" restore "${test_root}/state" owner/repo R_1 2>"${test_root}/restore-error"; then
+	printf 'FAIL malformed artifact ID unexpectedly restored\n' >&2
+	exit 1
+fi
+grep -q 'Invalid coordinator artifact ID' "${test_root}/restore-error"
+if grep -q '/zip' "${test_root}/api.log"; then
+	printf 'FAIL malformed artifact ID reached the download endpoint\n' >&2
+	exit 1
+fi
 
 printf 'PASS forge event workflow is targeted, repository-bound, and repair scans are manual only\n'


### PR DESCRIPTION
## Summary

Select one newest non-expired repository-scoped coordinator artifact across all paginated API responses, validate the scalar ID before URL construction, and cover malformed multi-ID output.

## Files Changed

.agents/scripts/forge-coordinator-state-helper.sh, .agents/scripts/tests/test-forge-event-workflow.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused forge-event and postflight dedup tests pass; ShellCheck clean; linters-local.sh --changed passes.

Resolves #27472


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.86 with gpt-5.6-sol spent 20m and 155,544 tokens on this with the user in an interactive session.