### PR TITLE
GH#27474: fix: restore coordinator state across artifact pages

### DIFF
--- a/.agents/scripts/forge-coordinator-state-helper.sh
+++ b/.agents/scripts/forge-coordinator-state-helper.sh
@@ -10,7 +10,7 @@ restore_state() {
 	local repository_id="$3"
 	local artifact_id="" archive=""
 	mkdir -p "$state_dir"
-	artifact_id=$(gh api --paginate --slurp "repos/${repository}/actions/artifacts?per_page=100" | \
+	artifact_id=$(gh api --paginate --slurp "repos/${repository}/actions/artifacts?per_page=100" |
 		jq -r "[.[].artifacts[] | select(.name | startswith(\"forge-coordinator-${repository_id}-\"))] | sort_by(.created_at, .id) | last | .id // empty") || return 1
 	[[ -n "$artifact_id" ]] || return 0
 	archive="${state_dir}/state.zip"

--- a/.agents/scripts/forge-coordinator-state-helper.sh
+++ b/.agents/scripts/forge-coordinator-state-helper.sh
@@ -10,8 +10,8 @@ restore_state() {
 	local repository_id="$3"
 	local artifact_id="" archive=""
 	mkdir -p "$state_dir"
-	artifact_id=$(gh api --paginate --slurp "repos/${repository}/actions/artifacts?per_page=100" \
-		--jq "[.[].artifacts[] | select(.name | startswith(\"forge-coordinator-${repository_id}-\"))] | sort_by(.created_at) | last | .id // empty") || return 1
+	artifact_id=$(gh api --paginate --slurp "repos/${repository}/actions/artifacts?per_page=100" | \
+		jq -r "[.[].artifacts[] | select(.name | startswith(\"forge-coordinator-${repository_id}-\"))] | sort_by(.created_at, .id) | last | .id // empty") || return 1
 	[[ -n "$artifact_id" ]] || return 0
 	archive="${state_dir}/state.zip"
 	gh api "repos/${repository}/actions/artifacts/${artifact_id}/zip" >"$archive" || return 1

--- a/.agents/scripts/tests/test-forge-event-workflow.sh
+++ b/.agents/scripts/tests/test-forge-event-workflow.sh
@@ -67,7 +67,11 @@ cat >"${test_root}/bin/gh" <<'GH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$GH_CALL_LOG"
 if [[ "$*" == *"actions/artifacts?per_page=100"* ]]; then
-	if [[ "$*" == *"--paginate --slurp"* ]]; then printf '22\n'; else printf '11\n22\n'; fi
+	if [[ "$*" == *"--paginate --slurp"* && "$*" != *"--jq"* ]]; then
+		printf '%s\n' '[{"artifacts":[{"id":11,"name":"forge-coordinator-R_1-old","created_at":"2026-07-12T10:00:00Z"}]},{"artifacts":[{"id":22,"name":"forge-coordinator-R_1-new","created_at":"2026-07-12T11:00:00Z"},{"id":99,"name":"other-artifact","created_at":"2026-07-12T12:00:00Z"}]}]'
+	else
+		printf '11\n22\n'
+	fi
 	exit 0
 fi
 [[ "$*" != *$'\n'* ]] || exit 1


### PR DESCRIPTION
## Summary

Pipe slurped artifact pages through jq so GitHub CLI compatibility does not produce multiple IDs or reject combined formatting flags; select newest artifact deterministically and cover multi-page IDs.

## Files Changed

.agents/scripts/forge-coordinator-state-helper.sh, .agents/scripts/tests/test-forge-event-workflow.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-forge-event-workflow.sh; shellcheck .agents/scripts/forge-coordinator-state-helper.sh .agents/scripts/tests/test-forge-event-workflow.sh; bash -n .agents/scripts/forge-coordinator-state-helper.sh .agents/scripts/tests/test-forge-event-workflow.sh

Resolves #27474


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.86 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 5m and 73,668 tokens on this as a headless worker.