### PR TITLE
GH#27480: harden memory maintenance input handling

### DIFF
--- a/.agents/scripts/memory/maintenance-prune.sh
+++ b/.agents/scripts/memory/maintenance-prune.sh
@@ -179,9 +179,9 @@ _prune_ai_judged() {
 
 	local candidates
 	if [[ "$keep_accessed" == true ]]; then
-		candidates=$(db "$MEMORY_DB" "SELECT l.id, l.type, l.confidence, substr(l.content, 1, 300), CAST(julianday('now') - julianday(l.created_at) AS INTEGER) FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.created_at < datetime('now', '-$min_age days') AND a.id IS NULL;")
+		candidates=$(db "$MEMORY_DB" "SELECT l.id, l.type, l.confidence, replace(replace(replace(substr(l.content, 1, 300), char(10), ' '), char(13), ' '), '|', ' '), CAST(julianday('now') - julianday(l.created_at) AS INTEGER) FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.created_at < datetime('now', '-$min_age days') AND a.id IS NULL;")
 	else
-		candidates=$(db "$MEMORY_DB" "SELECT l.id, l.type, l.confidence, substr(l.content, 1, 300), CAST(julianday('now') - julianday(l.created_at) AS INTEGER), CASE WHEN a.id IS NOT NULL THEN 'true' ELSE 'false' END FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.created_at < datetime('now', '-$min_age days');")
+		candidates=$(db "$MEMORY_DB" "SELECT l.id, l.type, l.confidence, replace(replace(replace(substr(l.content, 1, 300), char(10), ' '), char(13), ' '), '|', ' '), CAST(julianday('now') - julianday(l.created_at) AS INTEGER), CASE WHEN a.id IS NOT NULL THEN 'true' ELSE 'false' END FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.created_at < datetime('now', '-$min_age days');")
 	fi
 
 	if [[ -z "$candidates" ]]; then

--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -915,6 +915,14 @@ _feedback_parse_args() {
 		log_error "--value must be numeric"
 		return 1
 	fi
+	case "$_FEEDBACK_SIGNAL" in
+	"" | cited | edited | led_to_new | reused | dead_end | false | debunked) ;;
+	*)
+		log_error "Unknown signal type: $_FEEDBACK_SIGNAL"
+		log_error "Valid signals: cited, edited, led_to_new, reused, dead_end, false, debunked"
+		return 1
+		;;
+	esac
 	return 0
 }
 

--- a/tests/test-memory-observation-contract.sh
+++ b/tests/test-memory-observation-contract.sh
@@ -62,6 +62,9 @@ assert_eq 1 "$(db_query 'SELECT COUNT(*) FROM observation_relations WHERE relati
 if run_memory feedback mem_new --value "0); DROP TABLE learnings; --" >/dev/null 2>&1; then
 	fail "feedback accepted a non-numeric custom reward"
 fi
+if run_memory feedback mem_new --value 1.0 --signal "'; DROP TABLE learnings; --" >/dev/null 2>&1; then
+	fail "feedback accepted a malicious signal with custom value"
+fi
 if run_memory feedback mem_new --value >/dev/null 2>&1; then
 	fail "feedback accepted a missing custom reward"
 fi

--- a/tests/test-memory-retention-bounds.sh
+++ b/tests/test-memory-retention-bounds.sh
@@ -51,4 +51,13 @@ AIDEVOPS_AI_THRESHOLD_JUDGE="$judge_stub" memory prune --older-than-days 90 --ai
 grep -F "judge-prune-relevance" "$judge_log" >/dev/null
 [[ "$(sqlite3 "$db" "SELECT COUNT(*) FROM learnings WHERE id='$ai_id';")" == "1" ]]
 
+: >"$judge_log"
+memory store --content $'AI fixture with pipe|and\na newline' --type CONTEXT >/dev/null
+delimited_id=$(sqlite3 "$db" "SELECT id FROM learnings ORDER BY rowid DESC LIMIT 1;")
+sqlite3 "$db" "UPDATE learnings SET created_at=datetime('now', '-70 days') WHERE id='$delimited_id';"
+AIDEVOPS_AI_THRESHOLD_JUDGE="$judge_stub" memory prune --older-than-days 90 --ai-judged --max-count 100 --max-bytes 100000 >/dev/null
+grep -F -- "--content AI fixture with pipe and a newline" "$judge_log" >/dev/null
+[[ "$(grep -c 'judge-prune-relevance' "$judge_log")" == "2" ]]
+[[ "$(sqlite3 "$db" "SELECT COUNT(*) FROM learnings WHERE id='$delimited_id';")" == "1" ]]
+
 printf 'PASS: age, count, and byte retention bounds preserve canonical audit evidence\n'


### PR DESCRIPTION
## Summary

Sanitize AI-prune candidate delimiters and reject invalid feedback signals even when a custom reward is supplied

## Files Changed

.agents/scripts/memory/maintenance-prune.sh, .agents/scripts/memory/recall.sh, tests/test-memory-observation-contract.sh, tests/test-memory-retention-bounds.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused memory observation and retention tests pass; ShellCheck and local changed-file linters pass

Resolves #27480


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.88 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 70,883 tokens on this as a headless worker.