### PR TITLE
GH#27483: fix pulse merge snapshot gate binding

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -187,11 +187,18 @@ _pmrc_snapshot_review_gate_fresh() {
 	local pr_number="$2"
 	local checks_json="$3"
 	local activity_json="$4"
+	local live_gate_evidence="${5:-}"
 	local gate_at="" activity_at="" gate_epoch="" activity_epoch=""
 
 	gate_at=$(jq -r --arg completed "$PMRC_CHECK_COMPLETED" --arg success "$PMRC_CHECK_SUCCESS" '[.[]? | select((.name == "review-bot-gate" or .name == "gate / review-bot-gate") and .status == $completed and .conclusion == $success) | .observed_at | select(. != "")] | max // ""' <<<"$checks_json") || return 1
 	activity_at=$(jq -r '.latest_at // ""' <<<"$activity_json") || return 1
 	if [[ -z "$gate_at" ]]; then
+		#aidevops:trust-boundary — the live helper ran for this exact PR/head, and
+		# the caller immediately revalidates that head before reaching this check.
+		if [[ -n "$live_gate_evidence" ]]; then
+			echo "[pulse-merge] pre-merge snapshot: accepted live review-bot gate bound to the current head for PR #${pr_number} in ${repo_slug}; no status context is installed (GH#27483)" >>"$LOGFILE"
+			return 0
+		fi
 		echo "[pulse-merge] pre-merge snapshot: no successful review-bot gate is bound to the current head for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
 		return 1
 	fi
@@ -232,6 +239,8 @@ _pulse_merge_preflight_snapshot_gate() {
 	local repo_slug="$1"
 	local pr_number="$2"
 	local expected_head_sha="$3"
+	local expected_gate_evidence="${repo_slug}#${pr_number}@${expected_head_sha}"
+	local live_gate_evidence="${_PULSE_REVIEW_GATE_EVIDENCE:-}"
 	local pr_json="" current_head_sha="" required_contexts="" checks_json="" activity_json=""
 
 	pr_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || return 1
@@ -243,7 +252,8 @@ _pulse_merge_preflight_snapshot_gate() {
 	required_contexts=$(_required_contexts_for_default_branch "$repo_slug") || return 1
 	checks_json=$(_pmrc_snapshot_checks_json "$repo_slug" "$current_head_sha") || return 1
 	activity_json=$(_pmrc_snapshot_bot_activity_json "$repo_slug" "$pr_number") || return 1
-	_pmrc_snapshot_review_gate_fresh "$repo_slug" "$pr_number" "$checks_json" "$activity_json" || return 1
+	[[ "$live_gate_evidence" == "$expected_gate_evidence" ]] || live_gate_evidence=""
+	_pmrc_snapshot_review_gate_fresh "$repo_slug" "$pr_number" "$checks_json" "$activity_json" "$live_gate_evidence" || return 1
 	_pmrc_snapshot_review_threads_clear "$repo_slug" "$pr_number" || return 1
 	_pmrc_snapshot_checks_acceptable "$repo_slug" "$pr_number" "$checks_json" "$required_contexts" || return 1
 	_pmrc_snapshot_quiet_period_passes "$repo_slug" "$pr_number" "$checks_json" "$activity_json" || return 1

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -286,7 +286,8 @@ _handle_changes_requested_review_gate() {
 # Run all merge-eligibility gate checks for a single PR.
 # Returns 0 if all gates pass (PR may proceed to merge).
 # Returns 1 if any gate fails (PR should be skipped).
-# Args: $1=pr_number, $2=repo_slug, $3=pr_author, $4=pr_review, $5=linked_issue, $6=pr_labels (optional)
+# Args: $1=pr_number, $2=repo_slug, $3=pr_author, $4=pr_review, $5=linked_issue,
+#       $6=pr_labels (optional), $7=expected_head_sha (optional)
 #######################################
 _check_pr_merge_gates() {
 	local pr_number="$1"
@@ -295,6 +296,8 @@ _check_pr_merge_gates() {
 	local pr_review="$4"
 	local linked_issue="$5"
 	local pr_labels="${6:-}"
+	local expected_head_sha="${7:-}"
+	_PULSE_REVIEW_GATE_EVIDENCE=""
 
 	# Skip CHANGES_REQUESTED — needs a fix worker, not a merge.
 	#
@@ -433,6 +436,7 @@ _check_pr_merge_gates() {
 	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
 	if [[ -f "$rbg_helper" ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
+			_PULSE_REVIEW_GATE_EVIDENCE="${repo_slug}#${pr_number}@${expected_head_sha}"
 			echo "[pulse-wrapper] Review bot gate: SKIP for trusted Dependabot dependency update PR #${pr_number} in ${repo_slug} (GH#24473)" >>"$LOGFILE"
 			return 0
 		fi
@@ -441,6 +445,7 @@ _check_pr_merge_gates() {
 		rbg_status=$(printf '%s' "$rbg_result" | grep -oE '^(PASS|SKIP|WAITING|PASS_RATE_LIMITED)' | head -1)
 		case "$rbg_status" in
 		PASS | SKIP | PASS_RATE_LIMITED)
+			_PULSE_REVIEW_GATE_EVIDENCE="${repo_slug}#${pr_number}@${expected_head_sha}"
 			echo "[pulse-wrapper] Review bot gate: ${rbg_status} for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
 			;;
 		*)
@@ -1056,7 +1061,7 @@ _process_single_ready_pr() {
 	# maintainer gate, external-contributor gate, review bot gate) before both
 	# merge and CI-repair paths. This preserves the security boundary for PRs
 	# that are red but would not be trusted if green.
-	if ! _check_pr_merge_gates "$pr_number" "$repo_slug" "$pr_author" "$pr_review" "$linked_issue" "$pr_labels"; then
+	if ! _check_pr_merge_gates "$pr_number" "$repo_slug" "$pr_author" "$pr_review" "$linked_issue" "$pr_labels" "$pr_head_ref_oid"; then
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -69,7 +69,11 @@ gh() {
 	*commits/sha-reviewed/status*)
 		local gate_at="2026-01-01T00:01:10Z"
 		[[ "$SNAPSHOT_MODE" == "stale_gate" ]] && gate_at="2026-01-01T00:00:20Z"
-		printf '{"statuses":[{"context":"review-bot-gate","state":"success","updated_at":"%s"}]}\n' "$gate_at"
+		if [[ "$SNAPSHOT_MODE" == "no_status_gate" ]]; then
+			printf '%s\n' '{"statuses":[]}'
+		else
+			printf '{"statuses":[{"context":"review-bot-gate","state":"success","updated_at":"%s"}]}\n' "$gate_at"
+		fi
 		;;
 	*pulls/7/reviews*)
 		printf '%s\n' '[[{"user":{"login":"gemini-code-assist[bot]"},"submitted_at":"2026-01-01T00:00:30Z"}]]'
@@ -124,6 +128,13 @@ main() {
 	assert_gate "unclassified non-required failure blocks merge" unclassified_fail 1
 	assert_gate "unresolved late inline finding blocks merge" unresolved 1
 	assert_gate "late review activity invalidates stale gate success" stale_gate 1
+	_PULSE_REVIEW_GATE_EVIDENCE=""
+	assert_gate "missing status gate fails closed without live evidence" no_status_gate 1
+	_PULSE_REVIEW_GATE_EVIDENCE="owner/repo#7@sha-reviewed"
+	assert_gate "live gate evidence permits repositories without a status context" no_status_gate 0
+	_PULSE_REVIEW_GATE_EVIDENCE="owner/repo#7@sha-other"
+	assert_gate "live gate evidence for another head fails closed" no_status_gate 1
+	_PULSE_REVIEW_GATE_EVIDENCE=""
 	assert_gate "new commit invalidates reviewed head" new_head 1
 	assert_gate "bounded quiet period blocks recent check completion" recent 1
 	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

- Bind successful live review-bot helper evidence to the exact PR head.
- Allow the final pre-merge snapshot when a repository has no `review-bot-gate` status context.
- Preserve fail-closed behavior for missing, stale, or mismatched evidence.

## Testing

- `bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh`
- `shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh`

Resolves #27483

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.88 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 16m and 179,719 tokens on this as a headless worker.