### PR TITLE
Ref #27421: paginate postflight check-run evidence

### DIFF
--- a/.agents/scripts/tests/test-postflight-check-run-dedup.sh
+++ b/.agents/scripts/tests/test-postflight-check-run-dedup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 FILTER="${REPO_ROOT}/.github/scripts/effective-check-runs.jq"
+PAGINATION_FILTER="${REPO_ROOT}/.github/scripts/flatten-check-run-pages.jq"
 RECONCILE_FILTER="${REPO_ROOT}/.github/scripts/reconcile-superseded-cancellations.jq"
 FIXTURE="${SCRIPT_DIR}/fixtures/postflight-check-runs.json"
 
@@ -31,9 +32,9 @@ DESCENDANT_RUNS='[
   {"id":22,"name":"Security Validation","status":"completed","conclusion":"failure","app":{"slug":"github-actions"}}
 ]'
 RECONCILED=$(jq -cn \
-  --argjson current_runs "$CURRENT_RUNS" \
-  --argjson descendant_runs "$DESCENDANT_RUNS" \
-  -f "$RECONCILE_FILTER")
+	--argjson current_runs "$CURRENT_RUNS" \
+	--argjson descendant_runs "$DESCENDANT_RUNS" \
+	-f "$RECONCILE_FILTER")
 
 jq -e '
   any(.[]; .name == "Shell portability scan" and .conclusion == "success" and .superseded_by_check_run_id == 20) and
@@ -42,3 +43,21 @@ jq -e '
 ' <<<"$RECONCILED" >/dev/null
 
 printf 'PASS: postflight accepts only cancelled checks superseded by descendant success\n'
+
+PAGINATED_RESPONSE=$(jq -cn '
+  [
+    {check_runs: [range(1; 101) | {id: ., name: "Historical", status: "completed", conclusion: "success"}]},
+    {check_runs: [{id: 101, name: "Framework Validation", status: "completed", conclusion: "success"}]}
+  ]
+')
+FLATTENED=$(jq -c -f "$PAGINATION_FILTER" <<<"$PAGINATED_RESPONSE")
+
+jq -e '
+  (.check_runs | length) == 101 and
+  any(.check_runs[]; .id == 101 and .name == "Framework Validation")
+' <<<"$FLATTENED" >/dev/null
+
+grep -Fq 'gh api --paginate --slurp' "${REPO_ROOT}/.github/workflows/postflight.yml"
+grep -Fq 'flatten-check-run-pages.jq' "${REPO_ROOT}/.github/workflows/postflight.yml"
+
+printf 'PASS: postflight retains check-run evidence beyond the first API page\n'

--- a/.github/scripts/flatten-check-run-pages.jq
+++ b/.github/scripts/flatten-check-run-pages.jq
@@ -1,0 +1,3 @@
+{
+  check_runs: [.[] | .check_runs[]?]
+}

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -53,8 +53,12 @@ jobs:
         # Poll for completion, excluding this workflow to avoid circular dependency
         SELF_NAME="Verify Release Health"
         for i in {1..20}; do
-          PENDING=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
-            --jq "[.check_runs[] | select(.status != \"completed\" and .name != \"$SELF_NAME\")] | length")
+          CHECK_RUNS_RESPONSE=$(gh api --paginate --slurp \
+            "repos/${REPO}/commits/${COMMIT_SHA}/check-runs?per_page=100" \
+            | jq -c -f .github/scripts/flatten-check-run-pages.jq)
+          PENDING=$(jq --arg self_name "$SELF_NAME" \
+            '[.check_runs[] | select(.status != "completed" and .name != $self_name)] | length' \
+            <<<"$CHECK_RUNS_RESPONSE")
           
           if [[ "$PENDING" == "0" ]]; then
             echo "All check runs completed (excluding self)"
@@ -63,13 +67,18 @@ jobs:
           
           # Show which workflows are still pending
           echo "Waiting for $PENDING check runs... (attempt $i/20)"
-          gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
-            --jq ".check_runs[] | select(.status != \"completed\" and .name != \"$SELF_NAME\") | \"  - \(.name): \(.status)\"" || true
+          jq -r --arg self_name "$SELF_NAME" \
+            '.check_runs[] | select(.status != "completed" and .name != $self_name) | "  - \(.name): \(.status)"' \
+            <<<"$CHECK_RUNS_RESPONSE" || true
           sleep 30
         done
 
-        REMAINING=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
-          --jq "[.check_runs[] | select(.status != \"completed\" and .name != \"$SELF_NAME\")] | length")
+        CHECK_RUNS_RESPONSE=$(gh api --paginate --slurp \
+          "repos/${REPO}/commits/${COMMIT_SHA}/check-runs?per_page=100" \
+          | jq -c -f .github/scripts/flatten-check-run-pages.jq)
+        REMAINING=$(jq --arg self_name "$SELF_NAME" \
+          '[.check_runs[] | select(.status != "completed" and .name != $self_name)] | length' \
+          <<<"$CHECK_RUNS_RESPONSE")
         if [[ "$REMAINING" != "0" ]]; then
           echo "::error::$REMAINING check runs remained non-terminal after timeout"
           exit 1
@@ -89,7 +98,9 @@ jobs:
         # retains superseded runs on a commit, so counting every historical
         # cancellation can incorrectly fail an otherwise healthy release.
         SELF_NAME="Verify Release Health"
-        CHECK_RUNS_RESPONSE=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs?per_page=100")
+        CHECK_RUNS_RESPONSE=$(gh api --paginate --slurp \
+          "repos/${REPO}/commits/${COMMIT_SHA}/check-runs?per_page=100" \
+          | jq -c -f .github/scripts/flatten-check-run-pages.jq)
         EFFECTIVE_CHECK_RUNS=$(echo "$CHECK_RUNS_RESPONSE" \
           | jq -c --arg self_name "$SELF_NAME" -f .github/scripts/effective-check-runs.jq)
 
@@ -103,7 +114,9 @@ jobs:
         if [[ -n "$DEFAULT_SHA" && "$DEFAULT_SHA" != "$COMMIT_SHA" ]]; then
           COMPARE_STATUS=$(gh api "repos/${REPO}/compare/${COMMIT_SHA}...${DEFAULT_SHA}" --jq '.status // empty' 2>/dev/null || true)
           if [[ "$COMPARE_STATUS" == "ahead" || "$COMPARE_STATUS" == "identical" ]]; then
-            DESCENDANT_RESPONSE=$(gh api "repos/${REPO}/commits/${DEFAULT_SHA}/check-runs?per_page=100" 2>/dev/null || true)
+            DESCENDANT_RESPONSE=$(gh api --paginate --slurp \
+              "repos/${REPO}/commits/${DEFAULT_SHA}/check-runs?per_page=100" 2>/dev/null \
+              | jq -c -f .github/scripts/flatten-check-run-pages.jq || true)
             if [[ -n "$DESCENDANT_RESPONSE" ]]; then
               DESCENDANT_CHECK_RUNS=$(echo "$DESCENDANT_RESPONSE" \
                 | jq -c --arg self_name "$SELF_NAME" -f .github/scripts/effective-check-runs.jq)


### PR DESCRIPTION
## Summary

- Fetch every check-run API page before postflight wait and verification decisions.
- Normalize slurped GitHub API responses through a reusable jq filter.
- Add regression coverage proving evidence after the first 100 check runs remains visible.

## Context

Ref #27421

The v3.32.88 postflight run timed out while new check runs repeatedly displaced earlier evidence, then reported no terminal release evidence. The workflow queried only one check-run page. This change uses the same portable `gh api --paginate --slurp | jq` pattern verified for coordinator artifacts.

## Runtime Testing

- Queried the v3.32.88 release commit with the new pagination pipeline and normalized its complete response.
- Synthetic two-page coverage verifies a terminal check at position 101 survives flattening.

## Verification

- `bash .agents/scripts/tests/test-postflight-check-run-dedup.sh`
- `bash .agents/scripts/tests/test-postflight-no-source-rescan.sh`
- `shellcheck .agents/scripts/tests/test-postflight-check-run-dedup.sh`
- `actionlint .github/workflows/postflight.yml`
- `.agents/scripts/linters-local.sh --changed`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.88 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 13h 51m and 1,569,044 tokens on this with the user in an interactive session.
