### PR TITLE
GH#27479: fix: prevent cross-generation gh shim recursion

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -113,10 +113,16 @@ _shim_canonical_path() {
 	local candidate="$1"
 	local candidate_dir=""
 	local candidate_name=""
+	local link_dir=""
 	if command -v python3 >/dev/null 2>&1; then
 		python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$candidate" 2>/dev/null
 		return $?
 	fi
+	while [[ -L "$candidate" ]]; do
+		link_dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
+		candidate=$(readlink "$candidate") || return 1
+		[[ "$candidate" == /* ]] || candidate="${link_dir}/${candidate}"
+	done
 	candidate_dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
 	candidate_name=$(basename "$candidate")
 	printf '%s/%s\n' "$candidate_dir" "$candidate_name"

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -77,7 +77,91 @@
 #   .agents/scripts/shared-gh-wrappers.sh _gh_wrapper_auto_sig — reference impl
 # =============================================================================
 
-_SHIM_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)" || _SHIM_DIR=""
+_SHIM_SOURCE="${BASH_SOURCE[0]:-$0}"
+while [[ -L "$_SHIM_SOURCE" ]]; do
+	_SHIM_LINK_DIR="$(cd "$(dirname "$_SHIM_SOURCE")" 2>/dev/null && pwd)" || exit 127
+	_SHIM_SOURCE=$(readlink "$_SHIM_SOURCE") || exit 127
+	[[ "$_SHIM_SOURCE" == /* ]] || _SHIM_SOURCE="${_SHIM_LINK_DIR}/${_SHIM_SOURCE}"
+done
+_SHIM_DIR="$(cd "$(dirname "$_SHIM_SOURCE")" 2>/dev/null && pwd)" || _SHIM_DIR=""
+_SHIM_SOURCE="${_SHIM_DIR}/$(basename "$_SHIM_SOURCE")"
+
+# Reject recursive entry rather than forwarding to another shim generation.
+# The resolver below prevents normal cross-generation selection; this sentinel
+# bounds any unexpected re-entry caused by a child process or stale shim.
+if [[ -n "${_AIDEVOPS_GH_SHIM_ACTIVE:-}" ]]; then
+	printf '[aidevops] gh shim: recursive aidevops gh shim invocation blocked\n' >&2
+	exit 126
+fi
+
+_shim_is_aidevops_gh() {
+	local candidate_real="$1"
+	case "$candidate_real" in
+	*/.aidevops/agents/scripts/gh | \
+		*/.aidevops/bin/gh | \
+		*/.aidevops/runtime-bundles/*/agents/scripts/gh | \
+		*/runtime-bundles/*/agents/scripts/gh | \
+		*/aidevops/.agents/scripts/gh | \
+		*/.agents/scripts/gh | \
+		*/.agents/scripts/safe-bin/gh | \
+		*/agents/scripts/gh) return 0 ;;
+	esac
+	return 1
+}
+
+_shim_canonical_path() {
+	local candidate="$1"
+	local candidate_dir=""
+	local candidate_name=""
+	if command -v python3 >/dev/null 2>&1; then
+		python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$candidate" 2>/dev/null
+		return $?
+	fi
+	candidate_dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
+	candidate_name=$(basename "$candidate")
+	printf '%s/%s\n' "$candidate_dir" "$candidate_name"
+	return 0
+}
+
+# Resolve a trusted native gh executable. Merely excluding this shim's own
+# directory is insufficient: hot deployment can leave several aidevops shim
+# generations on PATH, each of which would otherwise select the next one.
+_find_real_gh() {
+	local path_dir=""
+	local candidate=""
+	local candidate_real=""
+	local IFS=:
+	for path_dir in $PATH; do
+		[[ -n "$path_dir" ]] || path_dir="."
+		candidate="${path_dir}/gh"
+		[[ -x "$candidate" ]] || continue
+		candidate_real=$(_shim_canonical_path "$candidate" 2>/dev/null || true)
+		[[ -n "$candidate_real" ]] || continue
+		[[ "$candidate_real" -ef "$_SHIM_SOURCE" ]] && continue
+		_shim_is_aidevops_gh "$candidate_real" && continue
+		printf '%s\n' "$candidate_real"
+		return 0
+	done
+	for candidate in /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh; do
+		[[ -x "$candidate" ]] || continue
+		candidate_real=$(_shim_canonical_path "$candidate" 2>/dev/null || true)
+		[[ -n "$candidate_real" ]] || continue
+		_shim_is_aidevops_gh "$candidate_real" && continue
+		printf '%s\n' "$candidate_real"
+		return 0
+	done
+	return 1
+}
+
+# The documented emergency bypass must avoid instrumentation and all normal
+# shim policy while still rejecting every other aidevops-managed gh wrapper.
+if [[ "${AIDEVOPS_GH_SHIM_DISABLE:-0}" == "1" ]]; then
+	_real_gh="$(_find_real_gh)" || {
+		printf '[aidevops] gh shim: native gh binary not found on PATH\n' >&2
+		exit 127
+	}
+	exec "$_real_gh" "$@"
+fi
 
 # -----------------------------------------------------------------------------
 # Source instrumentation helper for gh_record_call (GH#21857 — full visibility).
@@ -156,29 +240,6 @@ _shim_caller_label() {
 	*) printf 'gh_%s%s' "${sub1:-unknown}" "${sub2:+_${sub2}}" ;;
 	esac
 	return 0
-}
-
-# -----------------------------------------------------------------------------
-# Locate the REAL gh binary, excluding our own shim directory from PATH lookup
-# so we never recurse into ourselves even if PATH is unusual.
-# -----------------------------------------------------------------------------
-_find_real_gh() {
-	local p
-	local IFS=:
-	for p in $PATH; do
-		[[ -n "$_SHIM_DIR" && "$p" == "$_SHIM_DIR" ]] && continue
-		[[ -x "$p/gh" ]] || continue
-		printf '%s\n' "$p/gh"
-		return 0
-	done
-	# Fallback: well-known install locations
-	for p in /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh; do
-		[[ -x "$p" ]] && {
-			printf '%s\n' "$p"
-			return 0
-		}
-	done
-	return 1
 }
 
 # -----------------------------------------------------------------------------
@@ -389,25 +450,6 @@ api:*)
 	;;
 esac
 
-# -----------------------------------------------------------------------------
-# Emergency bypass — matches the escape hatch documented in build.txt.
-# -----------------------------------------------------------------------------
-if [[ "${AIDEVOPS_GH_SHIM_DISABLE:-0}" == "1" ]]; then
-	_real_gh="$(_find_real_gh)" || {
-		echo "[aidevops] gh shim: real gh binary not found on PATH" >&2
-		exit 127
-	}
-	exec "$_real_gh" "$@"
-fi
-
-# -----------------------------------------------------------------------------
-# Recursion guard. If a subprocess somehow re-invokes us (e.g., PATH inherited
-# by a child that also has us first), short-circuit to the real gh.
-# -----------------------------------------------------------------------------
-if [[ -n "${_AIDEVOPS_GH_SHIM_ACTIVE:-}" ]]; then
-	_real_gh="$(_find_real_gh)" || exit 127
-	exec "$_real_gh" "$@"
-fi
 export _AIDEVOPS_GH_SHIM_ACTIVE=1
 
 REAL_GH="$(_find_real_gh)" || {

--- a/.agents/scripts/tests/test-gh-shim-native-resolution.sh
+++ b/.agents/scripts/tests/test-gh-shim-native-resolution.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+SHIM="${REPO_DIR}/.agents/scripts/gh"
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t gh-shim-native-resolution)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+	local message="$1"
+	printf 'PASS: %s\n' "$message"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+mkdir -p \
+	"$TMP/runtime-bundles/old/agents/scripts" \
+	"$TMP/home/.aidevops/agents/scripts" \
+	"$TMP/repo/.agents/scripts" \
+	"$TMP/home/.aidevops/bin" \
+	"$TMP/native-linux" \
+	"$TMP/native-homebrew"
+
+for shim_path in \
+	"$TMP/runtime-bundles/old/agents/scripts/gh" \
+	"$TMP/home/.aidevops/agents/scripts/gh" \
+	"$TMP/repo/.agents/scripts/gh"; do
+	cp "$SHIM" "$shim_path"
+	chmod +x "$shim_path"
+done
+ln -s "$TMP/home/.aidevops/agents/scripts/gh" "$TMP/home/.aidevops/bin/gh"
+
+cat >"$TMP/native-linux/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >>"$NATIVE_GH_LOG"
+exit 0
+EOF
+chmod +x "$TMP/native-linux/gh"
+cp "$TMP/native-linux/gh" "$TMP/native-homebrew/gh"
+
+run_case() {
+	local name="$1"
+	local entry="$2"
+	local command_one="$3"
+	local command_two="${4:-}"
+	local expected_one="$command_one"
+	local count=0
+	: >"$TMP/native.log"
+	if NATIVE_GH_LOG="$TMP/native.log" PATH="$TMP/runtime-bundles/old/agents/scripts:$TMP/home/.aidevops/agents/scripts:$TMP/repo/.agents/scripts:$TMP/home/.aidevops/bin:$TMP/native-linux:/usr/bin:/bin" \
+		"$entry" "$command_one" ${command_two:+"$command_two"}; then
+		count=$(wc -l <"$TMP/native.log" | tr -d ' ')
+		if [[ $count -ge 1 ]] && [[ "$(sed -n '1p' "$TMP/native.log")" == "$expected_one" ]]; then
+			pass "$name reaches native gh without selecting another shim"
+		else
+			fail "$name expected native invocation, log=$(tr '\n' ';' <"$TMP/native.log")"
+		fi
+	else
+		fail "$name returned non-zero"
+	fi
+	return 0
+}
+
+run_case "runtime-bundle ordinary passthrough" "$TMP/runtime-bundles/old/agents/scripts/gh" "--version"
+run_case "installed ordinary passthrough" "$TMP/home/.aidevops/agents/scripts/gh" "--version"
+run_case "repository intercepted command" "$TMP/repo/.agents/scripts/gh" "issue" "view"
+
+: >"$TMP/native.log"
+if NATIVE_GH_LOG="$TMP/native.log" AIDEVOPS_GH_SHIM_DISABLE=1 \
+	PATH="$TMP/runtime-bundles/old/agents/scripts:$TMP/home/.aidevops/agents/scripts:$TMP/repo/.agents/scripts:$TMP/home/.aidevops/bin:$TMP/native-linux:/usr/bin:/bin" \
+	"$TMP/runtime-bundles/old/agents/scripts/gh" --version; then
+	if [[ $(wc -l <"$TMP/native.log" | tr -d ' ') -eq 1 ]]; then
+		pass "bypass reaches native gh exactly once"
+	else
+		fail "bypass did not invoke native gh exactly once"
+	fi
+else
+	fail "bypass returned non-zero"
+fi
+
+: >"$TMP/native.log"
+if NATIVE_GH_LOG="$TMP/native.log" PATH="$TMP/runtime-bundles/old/agents/scripts:$TMP/native-homebrew:/usr/bin:/bin" \
+	"$TMP/runtime-bundles/old/agents/scripts/gh" --version && [[ -s "$TMP/native.log" ]]; then
+	pass "Homebrew-style native fixture resolves after managed shim"
+else
+	fail "Homebrew-style native fixture was not resolved"
+fi
+
+: >"$TMP/native.log"
+workers=0
+while [[ $workers -lt 8 ]]; do
+	NATIVE_GH_LOG="$TMP/native.log" PATH="$TMP/runtime-bundles/old/agents/scripts:$TMP/home/.aidevops/agents/scripts:$TMP/native-linux:/usr/bin:/bin" \
+		"$TMP/runtime-bundles/old/agents/scripts/gh" --version &
+	workers=$((workers + 1))
+done
+wait
+if [[ $(wc -l <"$TMP/native.log" | tr -d ' ') -eq 8 ]]; then
+	pass "concurrent hot-deployment fixture has one native exec per invocation"
+else
+	fail "concurrent fixture produced an unexpected native invocation count"
+fi
+
+printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/.agents/scripts/tests/test-gh-shim-native-resolution.sh
+++ b/.agents/scripts/tests/test-gh-shim-native-resolution.sh
@@ -33,7 +33,10 @@ mkdir -p \
 	"$TMP/repo/.agents/scripts" \
 	"$TMP/home/.aidevops/bin" \
 	"$TMP/native-linux" \
-	"$TMP/native-homebrew"
+	"$TMP/native-homebrew" \
+	"$TMP/fallback-tools" \
+	"$TMP/fallback-bin" \
+	"$TMP/fallback-native"
 
 for shim_path in \
 	"$TMP/runtime-bundles/old/agents/scripts/gh" \
@@ -51,6 +54,13 @@ exit 0
 EOF
 chmod +x "$TMP/native-linux/gh"
 cp "$TMP/native-linux/gh" "$TMP/native-homebrew/gh"
+cp "$TMP/native-linux/gh" "$TMP/fallback-native/gh"
+
+for tool in bash dirname readlink basename; do
+	tool_path=$(command -v "$tool")
+	ln -s "$tool_path" "$TMP/fallback-tools/$tool"
+done
+ln -s "$TMP/home/.aidevops/agents/scripts/gh" "$TMP/fallback-bin/gh"
 
 run_case() {
 	local name="$1"
@@ -97,6 +107,14 @@ if NATIVE_GH_LOG="$TMP/native.log" PATH="$TMP/runtime-bundles/old/agents/scripts
 	pass "Homebrew-style native fixture resolves after managed shim"
 else
 	fail "Homebrew-style native fixture was not resolved"
+fi
+
+: >"$TMP/native.log"
+if NATIVE_GH_LOG="$TMP/native.log" PATH="$TMP/fallback-tools:$TMP/fallback-bin:$TMP/fallback-native" \
+	"$TMP/runtime-bundles/old/agents/scripts/gh" --version && [[ $(wc -l <"$TMP/native.log" | tr -d ' ') -eq 1 ]]; then
+	pass "shell fallback resolves a symlinked managed shim without python3"
+else
+	fail "shell fallback selected a symlinked managed shim"
 fi
 
 : >"$TMP/native.log"

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -12,7 +12,7 @@
 #   5. `gh issue comment --body-file` with marker passes through
 #   6. `gh pr create --body` without marker gets sig appended
 #   7. `AIDEVOPS_GH_SHIM_DISABLE=1` bypasses the shim entirely
-#   8. Recursion guard: `_AIDEVOPS_GH_SHIM_ACTIVE=1` triggers pass-through
+#   8. Recursion guard: `_AIDEVOPS_GH_SHIM_ACTIVE=1` fails closed immediately
 #
 # Strategy: run the shim against a stub `gh` binary that logs its args, and
 # a stub `gh-signature-helper.sh` that emits a predictable footer. Assert
@@ -344,12 +344,16 @@ fi
 echo ""
 echo "Test 8: recursion guard"
 _reset_log
-_AIDEVOPS_GH_SHIM_ACTIVE=1 "$SHIM_RUN" issue comment 111 --repo owner/repo --body "recursive" 2>/dev/null
-argv=$(_read_argv)
-if [[ "$argv" != *"<!-- aidevops:sig -->"* ]]; then
-	_pass "recursion guard skips injection"
+if _AIDEVOPS_GH_SHIM_ACTIVE=1 "$SHIM_RUN" issue comment 111 --repo owner/repo --body "recursive" 2>"$TMP/recursive.err"; then
+	_fail "recursion guard" "recursive invocation unexpectedly passed"
 else
-	_fail "recursion guard" "sig was injected despite guard; argv: $argv"
+	rc=$?
+	argv=$(_read_argv)
+	if [[ $rc -eq 126 && -z "$argv" ]] && grep -q "recursive aidevops gh shim invocation blocked" "$TMP/recursive.err"; then
+		_pass "recursion guard fails closed before native gh exec"
+	else
+		_fail "recursion guard" "rc=$rc argv: $argv err: $(cat "$TMP/recursive.err" 2>/dev/null || true)"
+	fi
 fi
 
 # =============================================================================
@@ -444,7 +448,7 @@ rm -f "$AIDEVOPS_GH_API_LOG"
 output=$(STUB_RATE_LIMIT_REMAINING=0 "$SHIM_RUN" issue list --repo owner/repo \
 	--state open --json number,title,url,assignees,labels,updatedAt --jq '.[0].title' 2>/dev/null || true)
 argv=$(_read_argv)
-if [[ "$output" == '"Reduce GraphQL list-call pressure"' ]] &&
+if [[ "$output" == "Reduce GraphQL list-call pressure" ]] &&
 	[[ "$argv" == *"/repos/owner/repo/issues?state=open&per_page=30"* ]] &&
 	grep -q $'\tgh_issue_list\trest' "$AIDEVOPS_GH_API_LOG"; then
 	_pass "gh issue list --json uses REST fallback with compact issue fields"


### PR DESCRIPTION
## Summary

Resolve native gh by canonical identity, reject all aidevops-managed shim candidates, move the bypass ahead of instrumentation, and fail closed on recursive re-entry.

## Files Changed

.agents/scripts/gh, .agents/scripts/tests/test-gh-shim-native-resolution.sh, .agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/gh .agents/scripts/tests/test-gh-shim.sh .agents/scripts/tests/test-gh-shim-native-resolution.sh; bash .agents/scripts/tests/test-gh-shim.sh; bash .agents/scripts/tests/test-gh-shim-native-resolution.sh

Resolves #27479


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.89 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 7m and 86,868 tokens on this as a headless worker.