### PR TITLE
GH#27489: stream postflight check-run payloads

### DIFF
--- a/.agents/scripts/tests/test-postflight-check-run-dedup.sh
+++ b/.agents/scripts/tests/test-postflight-check-run-dedup.sh
@@ -32,8 +32,8 @@ DESCENDANT_RUNS='[
   {"id":22,"name":"Security Validation","status":"completed","conclusion":"failure","app":{"slug":"github-actions"}}
 ]'
 RECONCILED=$(jq -cn \
-	--argjson current_runs "$CURRENT_RUNS" \
-	--argjson descendant_runs "$DESCENDANT_RUNS" \
+	--slurpfile current_run_documents <(printf '%s\n' "$CURRENT_RUNS") \
+	--slurpfile descendant_run_documents <(printf '%s\n' "$DESCENDANT_RUNS") \
 	-f "$RECONCILE_FILTER")
 
 jq -e '
@@ -43,6 +43,26 @@ jq -e '
 ' <<<"$RECONCILED" >/dev/null
 
 printf 'PASS: postflight accepts only cancelled checks superseded by descendant success\n'
+
+LARGE_TEXT=$(printf '%*s' 300000 '' | tr ' ' x)
+LARGE_CURRENT_RUNS=$(jq --rawfile output <(printf '%s' "$LARGE_TEXT") \
+	'.[0].output = {text: $output}' <<<"$CURRENT_RUNS")
+LARGE_RECONCILED=$(jq -cn \
+	--slurpfile current_run_documents <(printf '%s\n' "$LARGE_CURRENT_RUNS") \
+	--slurpfile descendant_run_documents <(printf '%s\n' "$DESCENDANT_RUNS") \
+	-f "$RECONCILE_FILTER")
+
+jq -e 'length == 3 and (.[0].output.text | length) == 300000' \
+	<<<"$LARGE_RECONCILED" >/dev/null
+
+if grep -Fq -- '--argjson current_runs' "${REPO_ROOT}/.github/workflows/postflight.yml"; then
+	printf 'FAIL: postflight passes check-run payloads through argv\n' >&2
+	exit 1
+fi
+
+grep -Fq -- '--slurpfile current_run_documents' "${REPO_ROOT}/.github/workflows/postflight.yml"
+
+printf 'PASS: postflight reconciliation avoids argv size limits\n'
 
 PAGINATED_RESPONSE=$(jq -cn '
   [

--- a/.github/scripts/reconcile-superseded-cancellations.jq
+++ b/.github/scripts/reconcile-superseded-cancellations.jq
@@ -1,15 +1,19 @@
 def run_key: [(.name // ""), (.app.slug // .app.name // "")];
 
+def current_runs: $current_run_documents[0] // [];
+
+def descendant_runs: $descendant_run_documents[0] // [];
+
 def successful_descendant($key):
   [
-    $descendant_runs[]
+    descendant_runs[]
     | select(run_key == $key)
     | select(.status == "completed" and .conclusion == "success")
   ]
   | last // null;
 
 [
-  $current_runs[]
+  current_runs[]
   | if .conclusion == "cancelled" then
       run_key as $key
       | successful_descendant($key) as $replacement

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -123,9 +123,11 @@ jobs:
             fi
           fi
         fi
+        # Stream large API responses through file descriptors instead of argv.
+        # Check-run output payloads can exceed the runner's ARG_MAX limit.
         CHECK_RUNS=$(jq -cn \
-          --argjson current_runs "$EFFECTIVE_CHECK_RUNS" \
-          --argjson descendant_runs "$DESCENDANT_CHECK_RUNS" \
+          --slurpfile current_run_documents <(printf '%s\n' "$EFFECTIVE_CHECK_RUNS") \
+          --slurpfile descendant_run_documents <(printf '%s\n' "$DESCENDANT_CHECK_RUNS") \
           -f .github/scripts/reconcile-superseded-cancellations.jq \
           | jq -c '.[] | {name, status, conclusion, app: (.app.slug // .app.name // "unknown"), superseded_by_check_run_id}')
         


### PR DESCRIPTION
## Summary

Resolves #27489

- stream effective and descendant check-run documents to jq through file descriptors
- avoid passing paginated GitHub check-run payloads through argv
- add a 300 KB regression fixture that exceeds typical hosted-runner argument limits

## Evidence

The v3.32.89 postflight run failed in `Verify CI/CD Status` with `/usr/bin/jq: Argument list too long` after paginated check collection exposed full check-run output payloads.

## Verification

- `bash .agents/scripts/tests/test-postflight-check-run-dedup.sh`
- `bash .agents/scripts/tests/test-postflight-no-source-rescan.sh`
- `shellcheck .agents/scripts/tests/test-postflight-check-run-dedup.sh`
- `bash -n .agents/scripts/tests/test-postflight-check-run-dedup.sh`
- `shfmt -d .agents/scripts/tests/test-postflight-check-run-dedup.sh`
- `actionlint .github/workflows/postflight.yml`
- `.agents/scripts/linters-local.sh --changed`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.89 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 14h 16m and 1,755,309 tokens on this with the user in an interactive session.