### PR TITLE
GH#27491: keep interactive full loops in their authorizing session

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -40,15 +40,15 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Every prompt, issue, PR, comment, and brief is mentorship: include file, pattern, and verification context.
 - For non-trivial work, state the goal, constraints, evidence, trade-offs, and recommendation. Ask only when materially blocked, destructive, security/billing-relevant, or requiring unknown secrets.
 - Capture worker-dispatchable fixable findings as tasks immediately. Worker triage and advisory-trap details: `reference/worker-discipline.md`.
-- Preserve valuable session learning: apply relevant lessons now; otherwise capture worker-ready tasks, memory, or reference updates for failures, outliers, duplicate patterns, and "similar but different" hazards. Details: `reference/self-improvement.md`.
+- Treat observed failures, efficiency losses, and productivity lessons as same-session work: fix them now when safe and in scope; if materially larger, deduplicate and file a dedicated issue with evidence, files, and verification. Preserve non-actionable learning in memory or references. Details: `reference/self-improvement.md`.
 
 ### Task and completion discipline
 
 - Use TodoWrite for multi-step work. Mark one task in progress and complete items immediately.
 - Infer task intent: `/full-loop` or "work on this now" means implement now; "background/worker" means create a worker-ready brief and auto-dispatch; "later/save/log" means brief for later and ask numbered dispatch options. Task and issue bodies use `workflows/brief.md`. Details: `reference/task-lifecycle.md`.
-- In an interactive session, full-loop authorisation means continue through implementation, verification, PR, review, merge, release/deploy when applicable, and cleanup without pausing between stages unless materially blocked. Report the exact verified stage; never describe the loop as running or underway unless a live loop process/job was verified.
+- In an interactive session, full-loop authorisation belongs to the primary conversation from that user turn through implementation, verification, PR, review, merge, authorized release/deploy, and cleanup. Do not delegate the critical path or launch a background worker unless the user explicitly requests background execution. Pause only when materially blocked; report exact verified stages.
 - Full-loop and merge consent do not authorize publication. Release requires explicit trusted intent; worker release also requires trusted high/critical priority and brief scope. Defaults and lifecycle states: `workflows/full-loop.md`.
-- An issue-started interactive implementation remains local even when run asynchronously; it overrides generic background-worker intent. Details: `reference/task-lifecycle.md` "Issue-start override".
+- An issue-started interactive implementation remains owned by its primary session; explicit asynchronous execution stays local and never implies worker delegation. Details: `reference/task-lifecycle.md` "Issue-start override".
 - Keep interactive subagents off the critical path and bounded; prefix delegated prompts with the lowest sufficient `[effort:simple|standard|thinking]`; details: `reference/agent-routing.md`.
 - When a context-rich session has already established safe, actionable work and the user authorises execution, preserve momentum through implementation and verification in that session; do not defer merely to reduce the current session's scope.
 - Run long checks and waits in the background when the runtime permits; poll at bounded intervals, act on completed gates promptly, and keep the user informed instead of disappearing behind one foreground command. Details: `reference/self-improvement.md`.

--- a/.agents/reference/self-improvement.md
+++ b/.agents/reference/self-improvement.md
@@ -59,9 +59,9 @@ Use `framework-issue-helper.sh`, not `claim-task-id.sh`:
 
 Treat valuable session learning as system input, not disposable transcript context. Outliers are expensive to find intentionally; when one appears during normal work, convert it into reusable system knowledge before it evaporates.
 
-- **Apply now** when the lesson directly improves the user's requested aim without widening risk.
+- **Apply now by default:** repair an observed failure, efficiency loss, or productivity gap in the current session when it is safe, authorized, and in scope; verify the repair before moving on.
 - **Preserve context momentum:** when the session has enough evidence, authorization, and safe execution paths, continue through implementation and verification instead of handing reconstruction cost to a future session. Defer only for a real dependency, safety boundary, resource fuse, or explicit user choice.
-- **Brief for workers** when the lesson exposes a fixable bug, missing validator, missing doc, recurring failure mode, or automation gap. Use worker-ready context: files, pattern, evidence, verification, and an explicit note when paths are unknown.
+- **File larger work separately** when the repair would materially widen scope or delay the active objective. Deduplicate first, then create a dedicated issue with files, pattern, evidence, verification, and an explicit note when paths are unknown; do not leave an actionable lesson only in chat or memory.
 - **Store memory/reference** when the lesson is reusable but not immediately dispatchable, especially diagnostics, edge cases, duplicate patterns, and "similar but different" hazards.
 - **Route design learning by scope:** durable repo-specific UI patterns belong in that repo's `DESIGN.md`; generic aidevops briefing/verification patterns become aidevops issues with anonymised evidence; uncertain or broad design lessons become worker-ready follow-ups instead of bloating global docs.
 - **Avoid speculative bloat:** capture observed examples and evidence; do not add global guidance for hypothetical failures.

--- a/.agents/reference/task-lifecycle.md
+++ b/.agents/reference/task-lifecycle.md
@@ -65,19 +65,22 @@ recovery ladder, terminal exceptions, and completion review:
 
 ## Conversation Intent Routing
 
-**Issue-start override:** Once `interactive-start-helper.sh` starts implementation
-for an issue, that local context is authoritative. It exports
-`AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION=1`, claims with `--implementing`, and
-treats background execution as local asynchronous work. Generic background/worker
-intent must not redispatch that issue; headless and remote-worker routes reject the
-marker. Sessions that only inspect an issue do not set the marker and remain
-eligible for ordinary pulse dispatch.
+**Issue-start override:** A user's interactive implementation or `/full-loop` turn
+makes that primary conversation authoritative through completion. Do not move its
+critical path to a subagent, headless worker, or background executor unless the
+user explicitly requests background execution. `interactive-start-helper.sh`
+exports `AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION=1`, claims with
+`--implementing`, and starts in the foreground by default; explicit `--background`
+remains local asynchronous work. Generic background/worker intent must not
+redispatch that issue; headless and remote-worker routes reject the marker.
+Sessions that only inspect an issue do not set the marker and remain eligible for
+ordinary pulse dispatch.
 
 Natural-language task capture must be as explicit as slash commands. When a user gives work that could become a TODO or issue, first classify the intent:
 
 | User signal | Route | Confirmation |
 |-------------|-------|--------------|
-| `/full-loop ...`, issue/task number after `/full-loop`, "do/work/fix/implement this now", "in this session" | Start `/full-loop` with the instruction or resolved issue/task | Do not ask whether to start; proceed unless blocked by safety/secret/destructive gates |
+| `/full-loop ...`, issue/task number after `/full-loop`, "do/work/fix/implement this now", "in this session" | Execute `/full-loop` in the primary conversation | Do not ask whether to start or delegate; proceed unless blocked by safety/secret/destructive gates |
 | "background", "worker", "auto-dispatch", "have an agent do this" | Compose with `workflows/brief.md`, create TODO/issue with `#auto-dispatch` when readiness passes, and queue/dispatch | Ask only for missing secrets, destructive approval, unknown repo, or unavailable verification |
 | "save", "log", "for later", `/save-todo`, `/aidevops-save-todo` | Compose with `workflows/brief.md`; save as TODO/plan/issue for later | After saving, ask numbered dispatch options |
 | Ambiguous "we need to...", "should add...", "can you note..." | Ask a numbered intent question before creating or executing | Use the shortest option set that disambiguates now/later/background |
@@ -148,7 +151,7 @@ Do not end a save flow with only "start anytime" when the task is worker-ready; 
 
 **`origin:interactive` also skips pulse dispatch (GH#18352)**: When an issue carries `origin:interactive` AND has any human assignee, the pulse's deterministic dedup guard (`dispatch-dedup-helper.sh is-assigned`) treats the assignee as blocking — even if that assignee is the repo owner or maintainer, and regardless of the current `status:*` label. This closes the race where an interactive session claimed a task via `claim-task-id.sh` (applying `status:claimed` + owner assignment) and the pulse dispatched a duplicate worker before the session could open its PR. The full active lifecycle is now recognised: `status:queued`, `status:in-progress`, `status:in-review`, and `status:claimed` all keep owner/maintainer assignees in the blocking set.
 
-**Implementing a `#auto-dispatch` task interactively (MANDATORY):** Start with `interactive-start-helper.sh --issue N --repo owner/repo --task "description" --auto-dispatch`. All issue-started implementations claim with `--implementing`, export the local-only implementation marker, run the pre-edit loop check, and start full-loop before any code is written. External repositories skip managed issue mutations but still continue local implementation and the normal contribution PR flow.
+**Implementing a `#auto-dispatch` task interactively (MANDATORY):** Start with `interactive-start-helper.sh --issue N --repo owner/repo --task "description" --auto-dispatch`. Add `--background` only when the user explicitly requested it. All issue-started implementations claim with `--implementing`, export the local-only implementation marker, run the pre-edit loop check, and start full-loop before any code is written. External repositories skip managed issue mutations but still continue local implementation and the normal contribution PR flow.
 
 **General dedup rule — combined signal (t1996):** The dispatch dedup signal is `(active status label) AND (non-self assignee)` — both required, neither sufficient alone. Every code path that emits a dispatch claim must consult `dispatch-dedup-helper.sh is-assigned` (or apply an equivalent combined check inline) before assigning a worker. Label-only or assignee-only filters are not safe in multi-operator conditions. Specifically:
 - A status label without an assignee = degraded state (worker died mid-claim) — safe to reclaim after `normalize_active_issue_assignments` / stale recovery.

--- a/.agents/scripts/interactive-start-helper.sh
+++ b/.agents/scripts/interactive-start-helper.sh
@@ -8,10 +8,11 @@ set -euo pipefail
 
 _usage() {
 	cat <<'EOF'
-Usage: interactive-start-helper.sh --issue N --repo owner/repo --task "description" [--auto-dispatch]
+Usage: interactive-start-helper.sh --issue N --repo owner/repo --task "description" [--auto-dispatch] [--background]
 
 Claims the issue for interactive implementation, runs the pre-edit loop check,
-and starts full-loop in the current repo/worktree.
+and starts full-loop in the current repo/worktree. Foreground is the default;
+--background requires explicit user background intent.
 EOF
 	return 0
 }
@@ -21,6 +22,7 @@ main() {
 	local repo=""
 	local task=""
 	local auto_dispatch=0
+	local background=0
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		shift
@@ -53,6 +55,7 @@ main() {
 			shift
 			;;
 		--auto-dispatch) auto_dispatch=1 ;;
+		--background | --bg) background=1 ;;
 		--help | -h)
 			_usage
 			return 0
@@ -75,7 +78,11 @@ main() {
 	: "$auto_dispatch"
 	interactive-session-helper.sh "${claim_args[@]}"
 	pre-edit-check.sh --loop-mode --task "$task"
-	full-loop-helper.sh start "GH#${issue} ${task}" --background
+	local start_args=(start "GH#${issue} ${task}")
+	if [[ $background -eq 1 ]]; then
+		start_args+=(--background)
+	fi
+	full-loop-helper.sh "${start_args[@]}"
 	return 0
 }
 

--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -749,7 +749,7 @@ _triage_write_prompt_file() {
 
 You are a sandboxed triage review agent. Follow these rules exactly:
 
-1. The VERY FIRST LINE of your response MUST be \`## Review: <Approved|Needs Changes|Decline>\`. No preamble, no meta-commentary, no "I'll analyze this…".
+1. The VERY FIRST LINE of your response MUST be \`## Review: Recommendation: <Approve|Request Changes|Decline>\`. This is an assessment recommendation, not an exercised approval action. No preamble or meta-commentary.
 2. DO NOT use Read, Glob, Grep, Bash, Write, Edit, or any other tools. ALL context you need is in this prompt. Tool use will be detected and your output discarded.
 3. Maximum 800 words total. Stop writing immediately after the final bullet.
 4. Use the OUTPUT TEMPLATE below EXACTLY — same headings, same tables, same order.
@@ -758,7 +758,7 @@ You are a sandboxed triage review agent. Follow these rules exactly:
 ## OUTPUT TEMPLATE (copy this structure verbatim)
 
 \`\`\`
-## Review: <Approved|Needs Changes|Decline>
+## Review: Recommendation: <Approve|Request Changes|Decline>
 
 ### Issue Validation
 
@@ -784,7 +784,7 @@ You are a sandboxed triage review agent. Follow these rules exactly:
 
 - **Scope creep:** Low/Medium/High
 - **Complexity tier:** \\\`tier:simple\\\` / \\\`tier:standard\\\` / \\\`tier:thinking\\\`
-- **Decision:** APPROVE / REQUEST CHANGES / DECLINE
+- **Recommendation:** APPROVE / REQUEST CHANGES / DECLINE
 - **Recommended labels:** <comma-separated>
 - **Implementation guidance:** <1-3 bullets for the worker who will implement this>
 \`\`\`

--- a/.agents/scripts/tests/test-interactive-start-helper.sh
+++ b/.agents/scripts/tests/test-interactive-start-helper.sh
@@ -38,15 +38,19 @@ if ! grep -Fq 'interactive-session-helper.sh marker=1 args=claim 42 owner/repo -
 	printf 'FAIL ordinary issue start did not claim as local implementation\n' >&2
 	exit 1
 fi
-if ! grep -Fq 'full-loop-helper.sh marker=1 args=start GH#42 local fix --background' "$call_log"; then
-	printf 'FAIL local asynchronous loop did not inherit implementation marker\n' >&2
+if ! grep -Fxq 'full-loop-helper.sh marker=1 args=start GH#42 local fix' "$call_log"; then
+	printf 'FAIL interactive issue start was not foreground by default\n' >&2
 	exit 1
 fi
 
 : >"$call_log"
-PATH="${stub_dir}:$PATH" "$helper" --issue 43 --repo owner/repo --task "queued fix" --auto-dispatch || exit 1
+PATH="${stub_dir}:$PATH" "$helper" --issue 43 --repo owner/repo --task "queued fix" --auto-dispatch --background || exit 1
 if ! grep -Fq 'interactive-session-helper.sh marker=1 args=claim 43 owner/repo --implementing' "$call_log"; then
 	printf 'FAIL auto-dispatch issue was not taken over locally\n' >&2
+	exit 1
+fi
+if ! grep -Fxq 'full-loop-helper.sh marker=1 args=start GH#43 queued fix --background' "$call_log"; then
+	printf 'FAIL explicit background start did not remain local\n' >&2
 	exit 1
 fi
 

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -17,9 +17,9 @@ Release is conditional. Generic full-loop, merge, or "ship the PR" consent is no
 
 Fatal modes: **GH#5317** (exits without PR), **GH#5096** (exits after PR). Do NOT skip any step:
 
-**Interactive continuity (MANDATORY):** A user's full-loop instruction authorises this entire lifecycle. Continue autonomously from the current stage through `FULL_LOOP_COMPLETE`; do not stop after setup, implementation, PR creation, merge, or release merely to report progress. Pause only for a material blocker requiring user input under the framework rules. Progress reports must name the last verified stage and current action. Say a loop is "running" or "underway" only after verifying a live loop process/job; a worktree, plan, or completed discovery alone is not a running loop.
+**Interactive continuity (MANDATORY):** A user's full-loop instruction assigns this entire lifecycle to the primary conversation that received it. Keep the critical path in that session through `FULL_LOOP_COMPLETE`; do not launch a background worker or delegate completion unless the user explicitly requests background execution. Continue autonomously from the current stage and do not stop after setup, implementation, PR creation, merge, or release merely to report progress. Pause only for a material blocker requiring user input. Progress reports must name the last verified stage and current action.
 
-**Dual-mode executor contract:** Interactive and headless runs share the persisted lifecycle transitions and terminal evidence. Mode changes interaction policy only: interactive keeps the primary responsive and surfaces safe resume actions; headless never prompts and autonomously resumes within its brief and budgets. `start --background` reports `FULL_LOOP_START_RESULT=running` only for a live executor, otherwise `FULL_LOOP_START_RESULT=initialized-only`. Custom executor adapters receive `AIDEVOPS_FULL_LOOP_RUN_ID` and `AIDEVOPS_FULL_LOOP_HEARTBEAT_FILE`; they must refresh that file as `<run-id> <UTC-ISO-timestamp>`. `status --json` is the authoritative machine-readable observation.
+**Dual-mode executor contract:** Interactive and headless runs share persisted lifecycle transitions and terminal evidence. Foreground is the interactive default. Explicit `start --background` stays local to the authorizing session and reports `FULL_LOOP_START_RESULT=running` only for a live executor, otherwise `FULL_LOOP_START_RESULT=initialized-only`; it is not permission for remote/headless dispatch. Headless runs never prompt and resume within their brief and budgets. Custom adapters receive `AIDEVOPS_FULL_LOOP_RUN_ID` and `AIDEVOPS_FULL_LOOP_HEARTBEAT_FILE`; `status --json` is authoritative.
 
 | # | Step | Signal |
 |---|------|--------|
@@ -60,7 +60,7 @@ Exit 0 means structural linked-worktree checks passed. A worker environment vari
 
 **Operation Verification (t1364.3):** `verify-operation-helper.sh check/verify`. Critical/high → block or verify.
 
-Start: `~/.aidevops/agents/scripts/full-loop-helper.sh start "$ARGUMENTS" --background`. Here `--background` means local asynchronous execution, not remote worker dispatch. Issue-started interactive sessions preserve their local-only marker through that child and reject headless/remote-worker routing. `--headless` / `FULL_LOOP_HEADLESS=true`: no prompts, no TODO.md edits.
+Start: `~/.aidevops/agents/scripts/full-loop-helper.sh start "$ARGUMENTS"`. Add `--background` only after explicit user background intent; it means local asynchronous execution, never remote worker dispatch. Issue-started interactive sessions preserve their local-only marker through that child and reject headless/remote-worker routing. `--headless` / `FULL_LOOP_HEADLESS=true`: no prompts, no TODO.md edits.
 
 ---
 

--- a/.agents/workflows/review-issue-pr.md
+++ b/.agents/workflows/review-issue-pr.md
@@ -219,12 +219,14 @@ For interactive maintainer review, complete the full checklist and post the stru
 1. Verify checkout freshness and report provenance.
 2. Complete duplicate, temporal, root-cause, safety, and dispatchability checks.
 3. Post the review using the format below so the decision has durable evidence.
-4. Only after an `APPROVE` verdict is posted, state that cryptographic approval is appropriate and provide the approval command if the user requests it.
+4. Only after an `Approve` recommendation is posted, state that cryptographic approval is appropriate and provide the approval command if the user requests it.
 
 Do not expose an approval command as the next action merely because a dispatch helper reports `needs-maintainer-review`; that gate identifies missing authority, not review quality. If review evidence is incomplete, recommend investigation rather than approval.
 
+Assessment language describes a recommendation, not an exercised authority action. Use `Recommendation: Approve`, never `Approved`, until a trusted maintainer actually performs the approval step. Apply the same distinction in the task-tool result and user-facing summary.
+
 ```markdown
-## Review: Approved / Needs Changes / Decline
+## Review: Recommendation: Approve / Request Changes / Decline
 
 ### Pre-Review Context
 
@@ -272,7 +274,7 @@ Do not expose an approval command as the next action merely because a dispatch h
 
 - Scope creep: Low/Medium/High
 - Complexity: Low (`tier:simple`) / Medium (`tier:standard`) / High (`tier:thinking`)
-- **Decision**: APPROVE / REQUEST CHANGES / DECLINE
+- **Recommendation**: APPROVE / REQUEST CHANGES / DECLINE
 - **Labels**: [e.g., `tier:simple`, `bug`, `status:available`]
 - **Implementation guidance**: [key steps, test cases to add]
 
@@ -297,10 +299,10 @@ After a verdict is reached, the reporter must always be informed — regardless 
 
 | Outcome | Action |
 |---------|--------|
-| APPROVE → internal task created | Comment on source issue: thank reporter, link to internal task/PR, set expectation on timeline |
-| APPROVE → PR merged same session | Comment on source issue: thank reporter, link to merged PR, close issue |
-| REQUEST CHANGES | Comment explaining what needs to change before the fix can proceed |
-| DECLINE | Comment explaining why (out of scope, by design, duplicate) and close issue |
+| Recommend APPROVE → internal task created | Comment on source issue: thank reporter, link to internal task/PR, set expectation on timeline |
+| Recommend APPROVE → PR merged same session | Comment on source issue: thank reporter, link to merged PR, close issue |
+| Recommend REQUEST CHANGES | Comment explaining what needs to change before the fix can proceed |
+| Recommend DECLINE | Comment explaining why (out of scope, by design, duplicate) and close issue |
 
 **Template — issue converted to internal task:**
 

--- a/.agents/workflows/triage-review.md
+++ b/.agents/workflows/triage-review.md
@@ -27,7 +27,7 @@ Security-sandboxed triage agent for external contributor issues. Read-only acces
 
 t2019 fixed a recurring failure mode (#18482, #18428) where the worker produced 60-80KB of narrative or tool-exploration output with no detectable review header. The pulse safety filter correctly suppressed those outputs, but every suppression cost opus tokens and latency. These rules exist to prevent that failure mode from recurring:
 
-1. **Your response MUST begin with the literal line `## Review: <Approved|Needs Changes|Decline>`.** No preamble. No "I'll analyze this…". No "Let me think about…". No meta-commentary.
+1. **Your response MUST begin with the literal line `## Review: Recommendation: <Approve|Request Changes|Decline>`.** This is an assessment recommendation, not an exercised approval action. No preamble, process narration, or meta-commentary.
 2. **Do NOT use tools to explore the codebase.** The dispatch code pre-fetches every piece of context you need (issue body, comments, PR diff, PR files, recent closed issues, git log) and injects it into your prompt. Using Read/Glob/Grep to hunt for extra context is forbidden — the token cost is not justified for a triage review, and long tool trajectories cause the output to overflow and be suppressed.
 3. **Maximum 800 words total.** Stop writing immediately after the final bullet of the "Scope & Recommendation" section. A good triage review is 300-600 words; anything approaching 1000 is a sign of drift.
 4. **Use the OUTPUT TEMPLATE below EXACTLY.** Same headings, same tables, same order.
@@ -79,7 +79,7 @@ Analyze issue/PR using ONLY the pre-fetched context above. Do not explore the co
 ## OUTPUT TEMPLATE (copy this structure verbatim)
 
 ```markdown
-## Review: <Approved|Needs Changes|Decline>
+## Review: Recommendation: <Approve|Request Changes|Decline>
 
 ### Issue Validation
 
@@ -105,7 +105,7 @@ Analyze issue/PR using ONLY the pre-fetched context above. Do not explore the co
 
 - **Scope creep:** Low/Medium/High
 - **Complexity tier:** `tier:simple` / `tier:standard` / `tier:thinking`
-- **Decision:** APPROVE / REQUEST CHANGES / DECLINE
+- **Recommendation:** APPROVE / REQUEST CHANGES / DECLINE
 - **Recommended labels:** <comma-separated>
 - **Implementation guidance:** <1-3 bullets for the worker who will implement this>
 ```


### PR DESCRIPTION
## Summary

Make review outputs recommendations, keep interactive full-loop ownership in the primary conversation by default, require explicit background opt-in, and strengthen same-session learning repair.

## Files Changed

.agents/AGENTS.md, .agents/reference/self-improvement.md, .agents/reference/task-lifecycle.md, .agents/scripts/interactive-start-helper.sh, .agents/scripts/pulse-ancillary-dispatch.sh, .agents/scripts/tests/test-interactive-start-helper.sh, .agents/workflows/full-loop.md, .agents/workflows/review-issue-pr.md, .agents/workflows/triage-review.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Interactive-start regression test passed; triage output-shape suite passed (19/19); ShellCheck clean; changed-file local linters passed. Progressive-load check has four identical pre-existing main failures tracked in #27492.

Resolves #27491


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.89 with gpt-5.6-sol spent 39m and 320,820 tokens on this with the user in an interactive session.