### PR TITLE
GH#27495: fix: run releases from detached worktree

### DIFF
--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -33,8 +33,10 @@ main() {
 	trap 'cleanup_release_worktree' EXIT
 
 	local version_manager="${AIDEVOPS_FULL_LOOP_VERSION_MANAGER:-$release_path/.agents/scripts/version-manager.sh}"
+	[[ "$version_manager" = /* ]] || version_manager="$PWD/$version_manager"
 	[[ -f "$version_manager" ]] || return 1
 	(
+		trap - EXIT
 		cd "$release_path" || exit 1
 		AIDEVOPS_RELEASE_INTENT_TRUSTED=1 \
 			AIDEVOPS_TRUSTED_ISSUE_PRIORITY="${AIDEVOPS_TRUSTED_ISSUE_PRIORITY:-}" \

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -34,10 +34,13 @@ main() {
 
 	local version_manager="${AIDEVOPS_FULL_LOOP_VERSION_MANAGER:-$release_path/.agents/scripts/version-manager.sh}"
 	[[ -f "$version_manager" ]] || return 1
-	AIDEVOPS_RELEASE_INTENT_TRUSTED=1 \
-		AIDEVOPS_TRUSTED_ISSUE_PRIORITY="${AIDEVOPS_TRUSTED_ISSUE_PRIORITY:-}" \
-		AIDEVOPS_RELEASE_DEPLOY_SCOPE="$deployment_scope" \
-		bash "$version_manager" release "$release_type" --source-pr "$source_pr"
+	(
+		cd "$release_path" || exit 1
+		AIDEVOPS_RELEASE_INTENT_TRUSTED=1 \
+			AIDEVOPS_TRUSTED_ISSUE_PRIORITY="${AIDEVOPS_TRUSTED_ISSUE_PRIORITY:-}" \
+			AIDEVOPS_RELEASE_DEPLOY_SCOPE="$deployment_scope" \
+			bash "$version_manager" release "$release_type" --source-pr "$source_pr"
+	)
 	return $?
 }
 

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -47,7 +47,7 @@ chmod +x "$ROOT/version-manager.sh"
 		VM_CALL_LOG="$ROOT/vm.log" \
 		FAKE_REPO_ROOT="$ROOT/repo" \
 		AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" \
-		AIDEVOPS_FULL_LOOP_VERSION_MANAGER="$ROOT/version-manager.sh" \
+		AIDEVOPS_FULL_LOOP_VERSION_MANAGER="../../version-manager.sh" \
 		AIDEVOPS_TRUSTED_ISSUE_PRIORITY=critical \
 		bash "$SCRIPT_DIR/full-loop-release-helper.sh" minor 42 full
 )

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
-mkdir -p "$ROOT/bin" "$ROOT/repo" "$ROOT/worktrees"
+mkdir -p "$ROOT/bin" "$ROOT/repo/linked-branch" "$ROOT/worktrees"
 
 cat >"$ROOT/bin/git" <<'STUB'
 #!/usr/bin/env bash
@@ -32,6 +32,7 @@ chmod +x "$ROOT/bin/git"
 cat >"$ROOT/version-manager.sh" <<'STUB'
 #!/usr/bin/env bash
 printf 'args=%s\n' "$*" >"${VM_CALL_LOG:?}"
+printf 'cwd=%s\n' "$PWD" >>"$VM_CALL_LOG"
 printf 'intent=%s\n' "${AIDEVOPS_RELEASE_INTENT_TRUSTED:-}" >>"$VM_CALL_LOG"
 printf 'priority=%s\n' "${AIDEVOPS_TRUSTED_ISSUE_PRIORITY:-}" >>"$VM_CALL_LOG"
 printf 'deploy=%s\n' "${AIDEVOPS_RELEASE_DEPLOY_SCOPE:-}" >>"$VM_CALL_LOG"
@@ -39,18 +40,22 @@ exit 0
 STUB
 chmod +x "$ROOT/version-manager.sh"
 
-PATH="$ROOT/bin:/usr/bin:/bin" \
-	GIT_CALL_LOG="$ROOT/git.log" \
-	VM_CALL_LOG="$ROOT/vm.log" \
-	FAKE_REPO_ROOT="$ROOT/repo" \
-	AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" \
-	AIDEVOPS_FULL_LOOP_VERSION_MANAGER="$ROOT/version-manager.sh" \
-	AIDEVOPS_TRUSTED_ISSUE_PRIORITY=critical \
-	bash "$SCRIPT_DIR/full-loop-release-helper.sh" minor 42 full
+(
+	cd "$ROOT/repo/linked-branch"
+	PATH="$ROOT/bin:/usr/bin:/bin" \
+		GIT_CALL_LOG="$ROOT/git.log" \
+		VM_CALL_LOG="$ROOT/vm.log" \
+		FAKE_REPO_ROOT="$ROOT/repo" \
+		AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" \
+		AIDEVOPS_FULL_LOOP_VERSION_MANAGER="$ROOT/version-manager.sh" \
+		AIDEVOPS_TRUSTED_ISSUE_PRIORITY=critical \
+		bash "$SCRIPT_DIR/full-loop-release-helper.sh" minor 42 full
+)
 
 grep -q 'worktree add --detach' "$ROOT/git.log"
 grep -q 'worktree remove' "$ROOT/git.log"
 grep -qx 'args=release minor --source-pr 42' "$ROOT/vm.log"
+grep -Eq "^cwd=${ROOT}/worktrees/aidevops-release-42-[0-9]+$" "$ROOT/vm.log"
 grep -qx 'intent=1' "$ROOT/vm.log"
 grep -qx 'priority=critical' "$ROOT/vm.log"
 grep -qx 'deploy=full' "$ROOT/vm.log"


### PR DESCRIPTION
## Summary

Runs version-manager.sh from the newly created detached origin/main release worktree and regression-tests a linked branch launch.

## Files Changed

.agents/scripts/full-loop-release-helper.sh, .agents/scripts/tests/test-full-loop-release-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-full-loop-release-helper.sh; shellcheck .agents/scripts/full-loop-release-helper.sh .agents/scripts/tests/test-full-loop-release-helper.sh

Resolves #27495


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.91 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-terra spent 2m and 69,735 tokens on this as a headless worker.