### PR TITLE
GH#27487: harden CI repair infrastructure classification and leases

### DIFF
--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -301,15 +301,15 @@ _build_ci_feedback_section() {
 
 #######################################
 # Return whether a failed check URL points at a GitHub Actions job whose failed
-# log is an infrastructure timeout/kill rather than actionable code feedback.
+# log is an infrastructure failure rather than actionable code feedback.
 #
 # Args:
 #   $1 - repo_slug
 #   $2 - check URL
 #
-# Returns: 0=infra timeout/kill detected, 1=not detected or unavailable.
+# Returns: 0=infrastructure failure detected, 1=not detected or unavailable.
 #######################################
-_ci_check_url_has_infra_timeout_log() {
+_ci_check_url_has_infra_failure_log() {
 	local repo_slug="$1"
 	local check_url="$2"
 
@@ -333,7 +333,7 @@ _ci_check_url_has_infra_timeout_log() {
 	failed_log=$(gh run view "$run_id" --repo "$repo_slug" --job "$job_id" --log-failed 2>/dev/null) || failed_log=""
 	[[ -n "$failed_log" ]] || return 1
 
-	if printf '%s\n' "$failed_log" | grep -Eiq '(Process completed with exit code (124|137|143)|timed out after|[[:space:]]Killed[[:space:]]+timeout|timeout --kill-after|The operation was canceled|cancelled due to timeout)'; then
+	if printf '%s\n' "$failed_log" | grep -Eiq '(Process completed with exit code (124|137|143)|timed out after|[[:space:]]Killed[[:space:]]+timeout|timeout --kill-after|The operation was canceled|cancelled due to timeout|toomanyrequests:[[:space:]]*Rate exceeded|Error response from daemon:.*(429|Too Many Requests|Rate exceeded)|(failed to pull image|failed to resolve source metadata|failed to authorize).*(429|Too Many Requests|Rate exceeded|TLS handshake timeout|i/o timeout|connection reset by peer|Service Unavailable)|(public\.ecr\.aws|docker\.io|ghcr\.io|registry[^[:space:]]*).*(429|Too Many Requests|Rate exceeded|TLS handshake timeout|i/o timeout|connection reset by peer|Service Unavailable))'; then
 		return 0
 	fi
 	return 1
@@ -341,7 +341,7 @@ _ci_check_url_has_infra_timeout_log() {
 
 #######################################
 # Filter required failed checks down to actionable code failures by excluding
-# GitHub Actions jobs whose logs show timeout/kill infrastructure signatures.
+# GitHub Actions jobs whose logs show infrastructure-failure signatures.
 #
 # Args:
 #   $1 - pr_number
@@ -365,8 +365,8 @@ _ci_actionable_failed_checks_markdown() {
 		name=$(printf '%s' "$checks_json" | jq -r --argjson i "$idx" '.[$i].name // empty' 2>/dev/null) || name=""
 		conclusion=$(printf '%s' "$checks_json" | jq -r --argjson i "$idx" '.[$i].conclusion // empty' 2>/dev/null) || conclusion=""
 		link=$(printf '%s' "$checks_json" | jq -r --argjson i "$idx" '.[$i].link // empty' 2>/dev/null) || link=""
-		if _ci_check_url_has_infra_timeout_log "$repo_slug" "$link"; then
-			echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} check '${name}' classified as infra-timeout from failed log — skipping code redispatch" >>"$LOGFILE"
+		if _ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
+			echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} check '${name}' classified as infrastructure failure from failed log — skipping code redispatch" >>"$LOGFILE"
 		else
 			printf -- '- **%s**: %s — [check URL](%s)\n' "$name" "$conclusion" "$link"
 		fi
@@ -488,12 +488,18 @@ _dispatch_ci_fix_worker() {
 		fallback_reason="the PR head is in a fork and is not an owned repair branch"
 	elif ! declare -F _pulse_merge_repo_path_for_slug >/dev/null 2>&1; then
 		fallback_reason="the repository-path resolver is unavailable"
-	elif ! _dispatch_ci_repair_session "$pr_number" "$repo_slug" "$linked_issue" \
+	elif _dispatch_ci_repair_session "$pr_number" "$repo_slug" "$linked_issue" \
 		"$pr_head_sha" "$pr_head_ref" "$failure_fingerprint" "$failing_checks"; then
-		fallback_reason="the bounded PR-branch repair session could not be launched"
-	else
-		echo "[pulse-wrapper] _dispatch_ci_fix_worker: dispatched in-place CI repair for PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint} in ${repo_slug}" >>"$LOGFILE"
+		if [[ "${_CI_REPAIR_DISPATCH_RESULT:-}" == "active" ]]; then
+			echo "[pulse-wrapper] _dispatch_ci_fix_worker: in-place CI repair already active for PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint} in ${repo_slug}" >>"$LOGFILE"
+		else
+			echo "[pulse-wrapper] _dispatch_ci_fix_worker: dispatched in-place CI repair for PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint} in ${repo_slug}" >>"$LOGFILE"
+		fi
 		return 0
+	elif [[ "${_CI_REPAIR_DISPATCH_RESULT:-}" == "exhausted" ]]; then
+		fallback_reason="the bounded PR-branch repair session exhausted its retry budget"
+	else
+		fallback_reason="the bounded PR-branch repair session could not be launched"
 	fi
 
 	_route_ci_repair_fallback "$pr_number" "$repo_slug" "$linked_issue" "$pr_head_sha" \
@@ -559,35 +565,485 @@ _Closed by deterministic merge pass (pulse-merge.sh)._" \
 }
 
 #######################################
-# Launch one bounded repair session for a repository/PR/head/failure tuple.
-# The atomic state directory is the cross-pulse dedup lease. Failed launches
-# remove the lease so a later pulse can retry or take the durable fallback.
+# Write one CI repair state transition atomically.
 #######################################
-_dispatch_ci_repair_session() {
-	local pr_number="$1"
+_ci_repair_write_state() {
+	local state_file="$1"
 	local repo_slug="$2"
-	local linked_issue="$3"
+	local pr_number="$3"
 	local pr_head_sha="$4"
 	local pr_head_ref="$5"
 	local failure_fingerprint="$6"
-	local failing_checks="$7"
-	local repo_path="" helper="" state_root="" state_key="" lease_dir="" prompt_file="" session_key=""
+	local worktree_path="$7"
+	local worker_pid="$8"
+	local pid_start="$9"
+	local attempt="${10:-1}"
+	local status="${11:-preparing}"
+	local session_key="${12:-}"
+	local tmp_file="${state_file}.tmp.$$"
 
-	repo_path=$(_pulse_merge_repo_path_for_slug "$repo_slug" 2>/dev/null) || repo_path=""
-	helper="${AIDEVOPS_HEADLESS_RUNTIME_HELPER:-${_PULSE_MERGE_DIR:-${BASH_SOURCE[0]%/*}}/headless-runtime-helper.sh}"
-	[[ -n "$repo_path" && -d "$repo_path" ]] || return 1
-	[[ -x "$helper" ]] || return 1
+	jq -nc \
+		--arg repo "$repo_slug" --argjson pr "$pr_number" --arg head "$pr_head_sha" \
+		--arg branch "$pr_head_ref" --arg fingerprint "$failure_fingerprint" \
+		--arg worktree "$worktree_path" --argjson pid "$worker_pid" --arg pid_start "$pid_start" \
+		--argjson attempt "$attempt" --arg status "$status" --arg session "$session_key" \
+		'{repo:$repo,pr:$pr,head:$head,branch:$branch,fingerprint:$fingerprint,
+		worktree:$worktree,pid:$pid,pid_start:$pid_start,attempt:$attempt,status:$status,session:$session}' \
+		>"$tmp_file" 2>/dev/null || {
+		rm -f "$tmp_file"
+		return 1
+	}
+	if ! mv "$tmp_file" "$state_file" 2>/dev/null; then
+		rm -f "$tmp_file"
+		return 1
+	fi
+	return 0
+}
 
-	state_root="${AIDEVOPS_CI_REPAIR_STATE_DIR:-${HOME}/.aidevops/.agent-workspace/ci-pr-repair}"
-	state_key=$(printf '%s-%s-%s-%s' "$repo_slug" "$pr_number" "$pr_head_sha" "$failure_fingerprint" | tr '/:' '__')
-	lease_dir="${state_root}/${state_key}"
-	mkdir -p "$state_root" 2>/dev/null || return 1
-	if ! mkdir "$lease_dir" 2>/dev/null; then
-		echo "[pulse-wrapper] _dispatch_ci_repair_session: repair already dispatched for ${repo_slug} PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint}" >>"$LOGFILE"
+#######################################
+# Return the stable process-start token used to reject reused PIDs.
+#######################################
+_ci_repair_process_start() {
+	local worker_pid="$1"
+	ps -p "$worker_pid" -o lstart= 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Return whether a recorded process identity is still live.
+#######################################
+_ci_repair_pid_is_live() {
+	local worker_pid="$1"
+	local expected_start="$2"
+	local current_start=""
+
+	[[ "$worker_pid" =~ ^[0-9]+$ ]] || return 1
+	[[ -n "$expected_start" ]] || return 1
+	kill -0 "$worker_pid" 2>/dev/null || return 1
+	current_start=$(_ci_repair_process_start "$worker_pid")
+	[[ -n "$current_start" && "$current_start" == "$expected_start" ]] || return 1
+	return 0
+}
+
+#######################################
+# Publish ownership for a newly acquired transition lock.
+#######################################
+_ci_repair_publish_lock_owner() {
+	local lock_dir="$1"
+	local owner_file="${lock_dir}/owner.json"
+	local owner_tmp="${lock_dir}/owner.json.tmp.$$"
+	local current_start=""
+
+	current_start=$(_ci_repair_process_start "$$")
+	[[ -n "$current_start" ]] || return 1
+	jq -nc --argjson pid "$$" --arg pid_start "$current_start" \
+		'{pid:$pid,pid_start:$pid_start}' >"$owner_tmp" 2>/dev/null || return 1
+	mv "$owner_tmp" "$owner_file" 2>/dev/null || {
+		rm -f "$owner_tmp"
+		return 1
+	}
+	return 0
+}
+
+#######################################
+# Return whether a lock is old enough to recover when ownership is unreadable.
+#######################################
+_ci_repair_lock_is_stale() {
+	local lock_dir="$1"
+	local grace_seconds="${AIDEVOPS_CI_REPAIR_LOCK_GRACE_SECONDS:-2}"
+	local now="" lock_mtime="" lock_age=""
+
+	[[ "$grace_seconds" =~ ^[0-9]+$ ]] || grace_seconds=2
+	now=$(date +%s 2>/dev/null) || now=0
+	lock_mtime=$(stat -f '%m' "$lock_dir" 2>/dev/null) || lock_mtime=$(stat -c '%Y' "$lock_dir" 2>/dev/null) || lock_mtime="$now"
+	[[ "$lock_mtime" =~ ^[0-9]+$ ]] || lock_mtime="$now"
+	lock_age=$((now - lock_mtime))
+	[[ "$lock_age" -ge "$grace_seconds" ]]
+	return $?
+}
+
+#######################################
+# Acquire a crash-recoverable directory lock for one lease transition.
+#######################################
+_ci_repair_acquire_lock() {
+	local lock_dir="$1"
+	local owner_file="${lock_dir}/owner.json"
+	local reclaim_dir="${lock_dir}.reclaim"
+	local owner_pid="" owner_start="" acquire_result=1
+
+	if mkdir "$lock_dir" 2>/dev/null; then
+		_ci_repair_publish_lock_owner "$lock_dir" || {
+			rmdir "$lock_dir" 2>/dev/null || true
+			return 1
+		}
 		return 0
 	fi
+	[[ -d "$lock_dir" ]] || return 1
+	if [[ -f "$owner_file" ]]; then
+		owner_pid=$(jq -r '.pid // empty' "$owner_file" 2>/dev/null) || owner_pid=""
+		owner_start=$(jq -r '.pid_start // empty' "$owner_file" 2>/dev/null) || owner_start=""
+		if [[ "$owner_pid" =~ ^[0-9]+$ && -n "$owner_start" ]]; then
+			_ci_repair_pid_is_live "$owner_pid" "$owner_start" && return 1
+		else
+			_ci_repair_lock_is_stale "$lock_dir" || return 1
+		fi
+	else
+		_ci_repair_lock_is_stale "$lock_dir" || return 1
+	fi
+	# Serialize stale-owner replacement. A contender that did not acquire this
+	# mutex must not delete a lock that another contender may have replaced.
+	mkdir "$reclaim_dir" 2>/dev/null || return 1
+	owner_pid=$(jq -r '.pid // empty' "$owner_file" 2>/dev/null) || owner_pid=""
+	owner_start=$(jq -r '.pid_start // empty' "$owner_file" 2>/dev/null) || owner_start=""
+	if [[ "$owner_pid" =~ ^[0-9]+$ && -n "$owner_start" ]] \
+		&& _ci_repair_pid_is_live "$owner_pid" "$owner_start"; then
+		rmdir "$reclaim_dir" 2>/dev/null || true
+		return 1
+	fi
+	rm -f "$owner_file" "${lock_dir}"/owner.json.tmp.* 2>/dev/null || true
+	if rmdir "$lock_dir" 2>/dev/null && mkdir "$lock_dir" 2>/dev/null; then
+		if _ci_repair_publish_lock_owner "$lock_dir"; then
+			acquire_result=0
+		else
+			rm -f "${lock_dir}/owner.json" 2>/dev/null || true
+			rmdir "$lock_dir" 2>/dev/null || true
+		fi
+	fi
+	rmdir "$reclaim_dir" 2>/dev/null || true
+	return "$acquire_result"
+}
 
-	prompt_file="${lease_dir}/prompt.md"
+_ci_repair_release_lock() {
+	local lock_dir="$1"
+	local owner_file="${lock_dir}/owner.json"
+	local owner_pid="" owner_start="" current_start=""
+
+	[[ -f "$owner_file" ]] || return 1
+	owner_pid=$(jq -r '.pid // empty' "$owner_file" 2>/dev/null) || owner_pid=""
+	owner_start=$(jq -r '.pid_start // empty' "$owner_file" 2>/dev/null) || owner_start=""
+	current_start=$(_ci_repair_process_start "$$")
+	[[ "$owner_pid" == "$$" && -n "$owner_start" && "$owner_start" == "$current_start" ]] || return 1
+	rm -f "${lock_dir}/owner.json" 2>/dev/null || true
+	rmdir "$lock_dir" 2>/dev/null || true
+	return 0
+}
+
+_ci_repair_status_preparing() {
+	printf 'preparing'
+	return 0
+}
+
+_ci_repair_status_dispatched() {
+	printf 'dispatched'
+	return 0
+}
+
+_ci_repair_result_active() {
+	printf 'active'
+	return 0
+}
+
+#######################################
+# Return the latest archived attempt and its preserved worktree.
+#######################################
+_ci_repair_latest_archive() {
+	local lease_dir="$1"
+	local archived_state=""
+	local archived_attempt="0"
+	local candidate_attempt="0"
+	local worktree_path=""
+
+	for archived_state in "${lease_dir}"/state-attempt-*.json; do
+		[[ -f "$archived_state" ]] || continue
+		candidate_attempt=$(jq -r '.attempt // 0' "$archived_state" 2>/dev/null) || candidate_attempt="0"
+		[[ "$candidate_attempt" =~ ^[0-9]+$ ]] || candidate_attempt=0
+		if [[ "$candidate_attempt" -ge "$archived_attempt" ]]; then
+			archived_attempt="$candidate_attempt"
+			worktree_path=$(jq -r '.worktree // empty' "$archived_state" 2>/dev/null) || worktree_path=""
+		fi
+	done
+	printf '%s|%s' "$archived_attempt" "$worktree_path"
+	return 0
+}
+
+#######################################
+# Publish dispatcher ownership for one attempt while the transition lock is held.
+#######################################
+_ci_repair_prepare_attempt() {
+	local state_file="$1"
+	local repo_slug="$2"
+	local pr_number="$3"
+	local pr_head_sha="$4"
+	local pr_head_ref="$5"
+	local failure_fingerprint="$6"
+	local worktree_path="$7"
+	local attempt="$8"
+	local session_key="$9"
+	local process_start=""
+	local preparing_status=""
+
+	process_start=$(_ci_repair_process_start "$$")
+	preparing_status=$(_ci_repair_status_preparing)
+	_ci_repair_write_state "$state_file" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
+		"$failure_fingerprint" "$worktree_path" "$$" "$process_start" "$attempt" "$preparing_status" "$session_key"
+	return $?
+}
+
+#######################################
+# Adopt a live native headless session after an interrupted dispatcher handoff.
+#######################################
+_ci_repair_adopt_live_session() {
+	local state_file="$1"
+	local repo_slug="$2"
+	local pr_number="$3"
+	local pr_head_sha="$4"
+	local pr_head_ref="$5"
+	local failure_fingerprint="$6"
+	local worktree_path="$7"
+	local attempt="$8"
+	local session_key="$9"
+	local session_identity=""
+	local worker_pid=""
+	local process_start=""
+	local dispatched_status=""
+
+	session_identity=$(_ci_repair_session_identity "$session_key" 2>/dev/null) || return 1
+	worker_pid="${session_identity%%|*}"
+	process_start="${session_identity#*|}"
+	dispatched_status=$(_ci_repair_status_dispatched)
+	_ci_repair_write_state "$state_file" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
+		"$failure_fingerprint" "$worktree_path" "$worker_pid" "$process_start" "$attempt" "$dispatched_status" "$session_key" || return 1
+	echo "[pulse-wrapper] _dispatch_ci_repair_session: adopted live native session ${session_key} after interrupted lease handoff (pid ${worker_pid})" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
+# Claim or recover the durable lease for one CI repair tuple.
+#
+# Output: "launch|ATTEMPT|WORKTREE", "active", or "exhausted".
+#######################################
+_ci_repair_claim_lease() {
+	local lease_dir="$1"
+	local repo_slug="$2"
+	local pr_number="$3"
+	local pr_head_sha="$4"
+	local failure_fingerprint="$5"
+	local max_attempts="$6"
+	local pr_head_ref="$7"
+	local session_key="$8"
+	local state_file="${lease_dir}/state.json"
+	local existing_pid="" existing_pid_start="" existing_attempt="1"
+	local existing_worktree="" next_attempt="" archive_payload="" archived_attempt="0"
+	local active_result=""
+
+	active_result=$(_ci_repair_result_active)
+	[[ "$max_attempts" =~ ^[0-9]+$ ]] || max_attempts=2
+	[[ "$max_attempts" -gt 0 ]] || max_attempts=2
+	[[ -d "$lease_dir" ]] || return 1
+
+	if [[ ! -f "$state_file" ]]; then
+		archive_payload=$(_ci_repair_latest_archive "$lease_dir")
+		archived_attempt="${archive_payload%%|*}"
+		existing_worktree="${archive_payload#*|}"
+		if [[ "$archived_attempt" -ge "$max_attempts" ]]; then
+			printf 'exhausted'
+			return 0
+		fi
+		next_attempt=$((archived_attempt + 1))
+		if _ci_repair_adopt_live_session "$state_file" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
+			"$failure_fingerprint" "$existing_worktree" "$next_attempt" "$session_key"; then
+			printf '%s' "$active_result"
+			return 0
+		fi
+		_ci_repair_prepare_attempt "$state_file" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
+			"$failure_fingerprint" "$existing_worktree" "$next_attempt" "$session_key" || return 1
+		echo "[pulse-wrapper] _dispatch_ci_repair_session: recovered incomplete lease state for ${repo_slug} PR #${pr_number} as attempt ${next_attempt}/${max_attempts}" >>"$LOGFILE"
+		printf 'launch|%s|%s' "$next_attempt" "$existing_worktree"
+		return 0
+	fi
+	existing_pid=$(jq -r '.pid // empty' "$state_file" 2>/dev/null) || existing_pid=""
+	existing_pid_start=$(jq -r '.pid_start // empty' "$state_file" 2>/dev/null) || existing_pid_start=""
+	existing_attempt=$(jq -r '.attempt // 1' "$state_file" 2>/dev/null) || existing_attempt="1"
+	[[ "$existing_attempt" =~ ^[0-9]+$ ]] || existing_attempt=1
+	if _ci_repair_pid_is_live "$existing_pid" "$existing_pid_start"; then
+		echo "[pulse-wrapper] _dispatch_ci_repair_session: repair already active for ${repo_slug} PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint} (pid ${existing_pid}, attempt ${existing_attempt})" >>"$LOGFILE"
+		printf '%s' "$active_result"
+		return 0
+	fi
+	existing_worktree=$(jq -r '.worktree // empty' "$state_file" 2>/dev/null) || existing_worktree=""
+	if _ci_repair_adopt_live_session "$state_file" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
+		"$failure_fingerprint" "$existing_worktree" "$existing_attempt" "$session_key"; then
+		printf '%s' "$active_result"
+		return 0
+	fi
+	if [[ "$existing_attempt" -ge "$max_attempts" ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_repair_session: stale repair exhausted ${max_attempts} attempts for ${repo_slug} PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint}" >>"$LOGFILE"
+		printf 'exhausted'
+		return 0
+	fi
+	next_attempt=$((existing_attempt + 1))
+	if ! mv "$state_file" "${lease_dir}/state-attempt-${existing_attempt}.json" 2>/dev/null; then
+		printf '%s' "$active_result"
+		return 0
+	fi
+	_ci_repair_prepare_attempt "$state_file" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
+		"$failure_fingerprint" "$existing_worktree" "$next_attempt" "$session_key" || return 1
+	echo "[pulse-wrapper] _dispatch_ci_repair_session: recovering stale repair for ${repo_slug} PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint} as attempt ${next_attempt}/${max_attempts}" >>"$LOGFILE"
+	printf 'launch|%s|%s' "$next_attempt" "$existing_worktree"
+	return 0
+}
+
+#######################################
+# Create a linked repair worktree at the exact PR head SHA.
+#
+# Output: absolute worktree path.
+#######################################
+_ci_repair_create_worktree() {
+	local repo_path="$1"
+	local linked_issue="$2"
+	local pr_number="$3"
+	local pr_head_sha="$4"
+	local pr_head_ref="$5"
+	local failure_fingerprint="$6"
+	local attempt="$7"
+	local worktree_helper="${AIDEVOPS_WORKTREE_HELPER:-${_PULSE_MERGE_DIR:-${BASH_SOURCE[0]%/*}}/worktree-helper.sh}"
+	local worktree_base="${AIDEVOPS_CI_REPAIR_WORKTREE_BASE_DIR:-${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}}"
+	local repo_name=""
+	local repair_branch=""
+	local worktree_path=""
+	local actual_head=""
+
+	[[ -x "$worktree_helper" ]] || return 1
+	[[ "$pr_head_sha" =~ ^[0-9a-fA-F]{7,64}$ ]] || return 1
+	[[ -n "$pr_head_ref" ]] || return 1
+	if ! git -C "$repo_path" cat-file -e "${pr_head_sha}^{commit}" 2>/dev/null; then
+		git -C "$repo_path" fetch --no-tags --quiet origin "$pr_head_ref" >/dev/null 2>&1 || return 1
+	fi
+	git -C "$repo_path" cat-file -e "${pr_head_sha}^{commit}" 2>/dev/null || return 1
+
+	repo_name=$(basename "$repo_path")
+	repair_branch="repair/pr-${pr_number}-${pr_head_sha:0:12}-${failure_fingerprint:0:12}-a${attempt}"
+	worktree_path="${worktree_base}/${repo_name}-ci-repair-pr${pr_number}-${pr_head_sha:0:12}-${failure_fingerprint:0:12}-a${attempt}"
+	mkdir -p "$worktree_base" 2>/dev/null || return 1
+	if ! (cd "$repo_path" && AIDEVOPS_SKIP_AUTO_CLAIM=1 "$worktree_helper" add "$repair_branch" "$worktree_path" \
+		--base "$pr_head_sha" --issue "$linked_issue") >>"$LOGFILE" 2>&1; then
+		return 1
+	fi
+	actual_head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null) || actual_head=""
+	if [[ "$actual_head" != "$pr_head_sha" ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_repair_session: repair worktree head mismatch for PR #${pr_number}: expected ${pr_head_sha}, got ${actual_head:-unknown}" >>"$LOGFILE"
+		(cd "$repo_path" && "$worktree_helper" remove "$worktree_path" --force) >>"$LOGFILE" 2>&1 || true
+		return 1
+	fi
+	printf '%s' "$worktree_path"
+	return 0
+}
+
+#######################################
+# Return a live headless runtime session lock as PID|process-start.
+#######################################
+_ci_repair_session_identity() {
+	local session_key="$1"
+	local state_dir="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
+	local safe_key=""
+	local lock_file=""
+	local lock_value=""
+	local worker_pid=""
+	local process_start=""
+	local process_command=""
+
+	safe_key=$(printf '%s' "$session_key" | tr '/ ' '__')
+	lock_file="${state_dir}/locks/${safe_key}.pid"
+	[[ -f "$lock_file" ]] || return 1
+	lock_value=$(sed -n '1p' "$lock_file" 2>/dev/null) || lock_value=""
+	worker_pid="${lock_value%%|*}"
+	[[ "$worker_pid" =~ ^[0-9]+$ ]] || return 1
+	kill -0 "$worker_pid" 2>/dev/null || return 1
+	process_command=$(ps -p "$worker_pid" -o command= 2>/dev/null) || process_command=""
+	case "$process_command" in
+	*headless-runtime-helper* | *opencode* | *claude*) ;;
+	*) return 1 ;;
+	esac
+	process_start=$(_ci_repair_process_start "$worker_pid")
+	[[ -n "$process_start" ]] || return 1
+	printf '%s|%s' "$worker_pid" "$process_start"
+	return 0
+}
+
+#######################################
+# Launch through the runtime's native detach path and publish its process identity.
+#######################################
+_ci_repair_launch_worker() {
+	local lease_dir="$1"
+	local helper="$2"
+	local repo_slug="$3"
+	local pr_number="$4"
+	local linked_issue="$5"
+	local pr_head_sha="$6"
+	local pr_head_ref="$7"
+	local failure_fingerprint="$8"
+	local worktree_path="$9"
+	local attempt="${10:-1}"
+	local session_key="${11:-}"
+	local prompt_file="${12:-}"
+	local launch_output=""
+	local worker_pid=""
+	local process_start=""
+	local session_identity=""
+	local dispatched_status=""
+	local wait_count=0
+	local wait_max="${AIDEVOPS_CI_REPAIR_SESSION_LOCK_WAIT_STEPS:-200}"
+
+	[[ "$wait_max" =~ ^[0-9]+$ ]] || wait_max=200
+	launch_output=$(env \
+		HEADLESS=1 WORKER_ISSUE_NUMBER="$linked_issue" WORKER_REPO_SLUG="$repo_slug" \
+		WORKER_WORKTREE_PATH="$worktree_path" GITHUB_REPOSITORY="$repo_slug" \
+		WORKER_NO_EXIT_PUSH=1 AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1 \
+		AIDEVOPS_PR_REPAIR_NUMBER="$pr_number" AIDEVOPS_PR_REPAIR_HEAD_SHA="$pr_head_sha" \
+		AIDEVOPS_PR_REPAIR_HEAD_REF="$pr_head_ref" AIDEVOPS_PR_REPAIR_FINGERPRINT="$failure_fingerprint" \
+		"$helper" run --role worker --session-key "$session_key" --dir "$worktree_path" \
+		--title "PR #${pr_number}: CI repair" --prompt-file "$prompt_file" --detach \
+		</dev/null 2>&1) || {
+		printf '%s\n' "$launch_output" >>"$LOGFILE"
+		return 1
+	}
+	printf '%s\n' "$launch_output" >>"$LOGFILE"
+	worker_pid=$(printf '%s\n' "$launch_output" | sed -n 's/.*Dispatched PID: \([0-9][0-9]*\).*/\1/p' | sed -n '$p')
+	while [[ "$wait_count" -lt "$wait_max" ]]; do
+		session_identity=$(_ci_repair_session_identity "$session_key" 2>/dev/null) || session_identity=""
+		[[ -n "$session_identity" ]] && break
+		sleep 0.05
+		wait_count=$((wait_count + 1))
+	done
+	if [[ -n "$session_identity" ]]; then
+		worker_pid="${session_identity%%|*}"
+		process_start="${session_identity#*|}"
+	else
+		[[ "$worker_pid" =~ ^[0-9]+$ ]] || return 1
+		process_start=$(_ci_repair_process_start "$worker_pid")
+		_ci_repair_pid_is_live "$worker_pid" "$process_start" || return 1
+	fi
+	dispatched_status=$(_ci_repair_status_dispatched)
+	if ! _ci_repair_write_state "${lease_dir}/state.json" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
+		"$failure_fingerprint" "$worktree_path" "$worker_pid" "$process_start" "$attempt" "$dispatched_status" "$session_key"; then
+		return 1
+	fi
+	return 0
+}
+
+#######################################
+# Write the bounded repair prompt for the existing PR branch.
+#######################################
+_ci_repair_write_prompt() {
+	local prompt_file="$1"
+	local repo_slug="$2"
+	local pr_number="$3"
+	local linked_issue="$4"
+	local pr_head_sha="$5"
+	local pr_head_ref="$6"
+	local failure_fingerprint="$7"
+	local failing_checks="$8"
+
 	cat >"$prompt_file" <<-EOF
 		[effort:thinking] Repair terminal CI failures on the existing PR branch.
 
@@ -601,23 +1057,118 @@ _dispatch_ci_repair_session() {
 		Terminal failed checks:
 		${failing_checks}
 
-		Verify PR #${pr_number} still has head SHA ${pr_head_sha} before editing. If it changed,
-		stop without pushing. Check out the existing remote branch ${pr_head_ref} in a linked
-		worktree, diagnose the cited check logs, make only the CI repair, run focused checks,
-		commit, and push back to that same branch. Do not open or close a PR, do not create a
-		new implementation branch, do not merge, and do not bypass trust or required checks.
+		Your linked worktree was created from the expected PR head SHA and may contain preserved
+		changes from an interrupted repair attempt. Inspect and continue valuable existing work.
+		Verify PR #${pr_number} still has remote head SHA ${pr_head_sha} before editing; if it
+		changed, stop without pushing. Diagnose the cited logs, make only the CI repair, run focused
+		checks, commit, and push HEAD back to remote branch ${pr_head_ref}. Do not open or close a
+		PR, create another implementation branch, merge, or bypass trust or required checks.
 	EOF
+	return 0
+}
+
+#######################################
+# Launch one bounded repair session for a repository/PR/head/failure tuple.
+# The state directory is the cross-pulse dedup lease. A dead worker may be
+# retried once; repeated terminal attempts take the durable fallback.
+#######################################
+_dispatch_ci_repair_session() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local pr_head_sha="$4"
+	local pr_head_ref="$5"
+	local failure_fingerprint="$6"
+	local failing_checks="$7"
+	local repo_path="" helper="" state_root="" state_key="" lease_dir="" prompt_file="" session_key="" transition_lock=""
+	local lease_action=""
+	local max_attempts="${AIDEVOPS_CI_REPAIR_MAX_ATTEMPTS:-2}"
+	local attempt=""
+	local worktree_path=""
+	local launch_payload=""
+	local active_result=""
+	local dispatched_status=""
+	_CI_REPAIR_DISPATCH_RESULT="failed"
+	active_result=$(_ci_repair_result_active)
+	dispatched_status=$(_ci_repair_status_dispatched)
+
+	repo_path=$(_pulse_merge_repo_path_for_slug "$repo_slug" 2>/dev/null) || repo_path=""
+	helper="${AIDEVOPS_HEADLESS_RUNTIME_HELPER:-${_PULSE_MERGE_DIR:-${BASH_SOURCE[0]%/*}}/headless-runtime-helper.sh}"
+	[[ -n "$repo_path" && -d "$repo_path" ]] || return 1
+	[[ -x "$helper" ]] || return 1
+
+	state_root="${AIDEVOPS_CI_REPAIR_STATE_DIR:-${HOME}/.aidevops/.agent-workspace/ci-pr-repair}"
+	state_key=$(printf '%s-%s-%s-%s' "$repo_slug" "$pr_number" "$pr_head_sha" "$failure_fingerprint" | tr '/:' '__')
+	lease_dir="${state_root}/${state_key}"
 	session_key="ci-repair-${pr_number}-${pr_head_sha:0:12}-${failure_fingerprint:0:12}"
-	WORKER_ISSUE_NUMBER="$linked_issue" WORKER_REPO_SLUG="$repo_slug" GITHUB_REPOSITORY="$repo_slug" \
-		AIDEVOPS_PR_REPAIR_NUMBER="$pr_number" AIDEVOPS_PR_REPAIR_HEAD_SHA="$pr_head_sha" \
-		AIDEVOPS_PR_REPAIR_HEAD_REF="$pr_head_ref" AIDEVOPS_PR_REPAIR_FINGERPRINT="$failure_fingerprint" \
-		"$helper" run --role worker --session-key "$session_key" --dir "$repo_path" \
-		--title "PR #${pr_number}: CI repair" --prompt-file "$prompt_file" \
-		</dev/null >>"$LOGFILE" 2>&1 &
-	local worker_pid=""
-	worker_pid=$!
-	printf '{"repo":"%s","pr":%s,"head":"%s","branch":"%s","fingerprint":"%s","pid":%s,"status":"dispatched"}\n' \
-		"$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" "$failure_fingerprint" "$worker_pid" >"${lease_dir}/state.json"
+	transition_lock="${lease_dir}/transition.lock"
+	mkdir -p "$lease_dir" 2>/dev/null || return 1
+	if ! _ci_repair_acquire_lock "$transition_lock"; then
+		_CI_REPAIR_DISPATCH_RESULT="$active_result"
+		return 0
+	fi
+	lease_action=$(_ci_repair_claim_lease "$lease_dir" "$repo_slug" "$pr_number" "$pr_head_sha" \
+		"$failure_fingerprint" "$max_attempts" "$pr_head_ref" "$session_key") || {
+		_ci_repair_release_lock "$transition_lock" || true
+		return 1
+	}
+	case "$lease_action" in
+	"$active_result")
+		_CI_REPAIR_DISPATCH_RESULT="$active_result"
+		_ci_repair_release_lock "$transition_lock" || true
+		return 0
+		;;
+	exhausted)
+		_CI_REPAIR_DISPATCH_RESULT="exhausted"
+		_ci_repair_release_lock "$transition_lock" || true
+		return 1
+		;;
+	launch\|*)
+		launch_payload="${lease_action#launch|}"
+		attempt="${launch_payload%%|*}"
+		worktree_path="${launch_payload#*|}"
+		if [[ ! "$attempt" =~ ^[0-9]+$ ]]; then
+			_ci_repair_release_lock "$transition_lock" || true
+			return 1
+		fi
+		;;
+	*)
+		_ci_repair_release_lock "$transition_lock" || true
+		return 1
+		;;
+	esac
+
+	if [[ -n "$worktree_path" && -d "$worktree_path" ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_repair_session: resuming stale repair worktree ${worktree_path} for ${repo_slug} PR #${pr_number} attempt ${attempt}/${max_attempts}" >>"$LOGFILE"
+	else
+		worktree_path=$(_ci_repair_create_worktree "$repo_path" "$linked_issue" "$pr_number" "$pr_head_sha" \
+			"$pr_head_ref" "$failure_fingerprint" "$attempt") || worktree_path=""
+	fi
+	if [[ -z "$worktree_path" || ! -d "$worktree_path" ]]; then
+		_ci_repair_write_state "${lease_dir}/state.json" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
+			"$failure_fingerprint" "" "0" "" "$attempt" "worktree_failed" "$session_key" || true
+		_ci_repair_release_lock "$transition_lock" || true
+		return 1
+	fi
+	_ci_repair_prepare_attempt "${lease_dir}/state.json" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
+		"$failure_fingerprint" "$worktree_path" "$attempt" "$session_key" || {
+		_ci_repair_release_lock "$transition_lock" || true
+		return 1
+	}
+
+	prompt_file="${lease_dir}/prompt.md"
+	_ci_repair_write_prompt "$prompt_file" "$repo_slug" "$pr_number" "$linked_issue" "$pr_head_sha" \
+		"$pr_head_ref" "$failure_fingerprint" "$failing_checks" || {
+		_ci_repair_release_lock "$transition_lock" || true
+		return 1
+	}
+	if ! _ci_repair_launch_worker "$lease_dir" "$helper" "$repo_slug" "$pr_number" "$linked_issue" \
+		"$pr_head_sha" "$pr_head_ref" "$failure_fingerprint" "$worktree_path" "$attempt" "$session_key" "$prompt_file"; then
+		_ci_repair_release_lock "$transition_lock" || true
+		return 1
+	fi
+	_ci_repair_release_lock "$transition_lock" || true
+	_CI_REPAIR_DISPATCH_RESULT="$dispatched_status"
 	return 0
 }
 

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -581,14 +581,16 @@ _ci_repair_write_state() {
 	local status="${11:-preparing}"
 	local session_key="${12:-}"
 	local tmp_file="${state_file}.tmp.$$"
+	local updated_at=""
 
+	updated_at=$(date +%s 2>/dev/null) || updated_at=0
 	jq -nc \
 		--arg repo "$repo_slug" --argjson pr "$pr_number" --arg head "$pr_head_sha" \
 		--arg branch "$pr_head_ref" --arg fingerprint "$failure_fingerprint" \
 		--arg worktree "$worktree_path" --argjson pid "$worker_pid" --arg pid_start "$pid_start" \
-		--argjson attempt "$attempt" --arg status "$status" --arg session "$session_key" \
+		--argjson attempt "$attempt" --arg status "$status" --arg session "$session_key" --argjson updated_at "$updated_at" \
 		'{repo:$repo,pr:$pr,head:$head,branch:$branch,fingerprint:$fingerprint,
-		worktree:$worktree,pid:$pid,pid_start:$pid_start,attempt:$attempt,status:$status,session:$session}' \
+		worktree:$worktree,pid:$pid,pid_start:$pid_start,attempt:$attempt,status:$status,session:$session,updated_at:$updated_at}' \
 		>"$tmp_file" 2>/dev/null || {
 		rm -f "$tmp_file"
 		return 1
@@ -646,7 +648,7 @@ _ci_repair_publish_lock_owner() {
 }
 
 #######################################
-# Return whether a lock is old enough to recover when ownership is unreadable.
+# Return whether a claim is old enough to treat missing ownership as abandoned.
 #######################################
 _ci_repair_lock_is_stale() {
 	local lock_dir="$1"
@@ -663,68 +665,21 @@ _ci_repair_lock_is_stale() {
 }
 
 #######################################
-# Acquire a crash-recoverable directory lock for one lease transition.
+# Return whether an append-only attempt claim is still active.
 #######################################
-_ci_repair_acquire_lock() {
-	local lock_dir="$1"
-	local owner_file="${lock_dir}/owner.json"
-	local reclaim_dir="${lock_dir}.reclaim"
-	local owner_pid="" owner_start="" acquire_result=1
+_ci_repair_claim_dir_is_active() {
+	local claim_dir="$1"
+	local owner_file="${claim_dir}/owner.json"
+	local owner_pid="" owner_start=""
 
-	if mkdir "$lock_dir" 2>/dev/null; then
-		_ci_repair_publish_lock_owner "$lock_dir" || {
-			rmdir "$lock_dir" 2>/dev/null || true
-			return 1
-		}
-		return 0
-	fi
-	[[ -d "$lock_dir" ]] || return 1
 	if [[ -f "$owner_file" ]]; then
 		owner_pid=$(jq -r '.pid // empty' "$owner_file" 2>/dev/null) || owner_pid=""
 		owner_start=$(jq -r '.pid_start // empty' "$owner_file" 2>/dev/null) || owner_start=""
-		if [[ "$owner_pid" =~ ^[0-9]+$ && -n "$owner_start" ]]; then
-			_ci_repair_pid_is_live "$owner_pid" "$owner_start" && return 1
-		else
-			_ci_repair_lock_is_stale "$lock_dir" || return 1
-		fi
-	else
-		_ci_repair_lock_is_stale "$lock_dir" || return 1
-	fi
-	# Serialize stale-owner replacement. A contender that did not acquire this
-	# mutex must not delete a lock that another contender may have replaced.
-	mkdir "$reclaim_dir" 2>/dev/null || return 1
-	owner_pid=$(jq -r '.pid // empty' "$owner_file" 2>/dev/null) || owner_pid=""
-	owner_start=$(jq -r '.pid_start // empty' "$owner_file" 2>/dev/null) || owner_start=""
-	if [[ "$owner_pid" =~ ^[0-9]+$ && -n "$owner_start" ]] \
-		&& _ci_repair_pid_is_live "$owner_pid" "$owner_start"; then
-		rmdir "$reclaim_dir" 2>/dev/null || true
-		return 1
-	fi
-	rm -f "$owner_file" "${lock_dir}"/owner.json.tmp.* 2>/dev/null || true
-	if rmdir "$lock_dir" 2>/dev/null && mkdir "$lock_dir" 2>/dev/null; then
-		if _ci_repair_publish_lock_owner "$lock_dir"; then
-			acquire_result=0
-		else
-			rm -f "${lock_dir}/owner.json" 2>/dev/null || true
-			rmdir "$lock_dir" 2>/dev/null || true
+		if _ci_repair_pid_is_live "$owner_pid" "$owner_start"; then
+			return 0
 		fi
 	fi
-	rmdir "$reclaim_dir" 2>/dev/null || true
-	return "$acquire_result"
-}
-
-_ci_repair_release_lock() {
-	local lock_dir="$1"
-	local owner_file="${lock_dir}/owner.json"
-	local owner_pid="" owner_start="" current_start=""
-
-	[[ -f "$owner_file" ]] || return 1
-	owner_pid=$(jq -r '.pid // empty' "$owner_file" 2>/dev/null) || owner_pid=""
-	owner_start=$(jq -r '.pid_start // empty' "$owner_file" 2>/dev/null) || owner_start=""
-	current_start=$(_ci_repair_process_start "$$")
-	[[ "$owner_pid" == "$$" && -n "$owner_start" && "$owner_start" == "$current_start" ]] || return 1
-	rm -f "${lock_dir}/owner.json" 2>/dev/null || true
-	rmdir "$lock_dir" 2>/dev/null || true
+	_ci_repair_lock_is_stale "$claim_dir" && return 1
 	return 0
 }
 
@@ -740,6 +695,40 @@ _ci_repair_status_dispatched() {
 
 _ci_repair_result_active() {
 	printf 'active'
+	return 0
+}
+
+_ci_repair_result_exhausted() {
+	printf 'exhausted'
+	return 0
+}
+
+#######################################
+# Atomically claim the first unconsumed bounded repair attempt.
+#######################################
+_ci_repair_claim_next_attempt() {
+	local lease_dir="$1"
+	local first_attempt="$2"
+	local max_attempts="$3"
+	local attempt="$first_attempt"
+	local claim_dir="" active_result="" exhausted_result=""
+
+	active_result=$(_ci_repair_result_active)
+	exhausted_result=$(_ci_repair_result_exhausted)
+	while [[ "$attempt" -le "$max_attempts" ]]; do
+		claim_dir="${lease_dir}/attempt-${attempt}.claim"
+		if mkdir "$claim_dir" 2>/dev/null; then
+			_ci_repair_publish_lock_owner "$claim_dir" || return 1
+			printf '%s' "$attempt"
+			return 0
+		fi
+		if _ci_repair_claim_dir_is_active "$claim_dir"; then
+			printf '%s' "$active_result"
+			return 0
+		fi
+		attempt=$((attempt + 1))
+	done
+	printf '%s' "$exhausted_result"
 	return 0
 }
 
@@ -833,28 +822,38 @@ _ci_repair_claim_lease() {
 	local session_key="$8"
 	local state_file="${lease_dir}/state.json"
 	local existing_pid="" existing_pid_start="" existing_attempt="1"
-	local existing_worktree="" next_attempt="" archive_payload="" archived_attempt="0"
-	local active_result=""
+	local existing_worktree="" next_attempt="" archive_payload="" archived_attempt="0" claim_result=""
+	local existing_status="" updated_at="0" now="0" launch_grace="${AIDEVOPS_CI_REPAIR_LAUNCH_GRACE_SECONDS:-}"
+	local canary_timeout="${CANARY_TIMEOUT_SECONDS:-180}"
+	local active_result="" exhausted_result=""
 
 	active_result=$(_ci_repair_result_active)
+	exhausted_result=$(_ci_repair_result_exhausted)
 	[[ "$max_attempts" =~ ^[0-9]+$ ]] || max_attempts=2
 	[[ "$max_attempts" -gt 0 ]] || max_attempts=2
+	[[ "$canary_timeout" =~ ^[0-9]+$ ]] || canary_timeout=180
+	[[ "$launch_grace" =~ ^[0-9]+$ ]] || launch_grace=$((canary_timeout + 60))
 	[[ -d "$lease_dir" ]] || return 1
 
 	if [[ ! -f "$state_file" ]]; then
 		archive_payload=$(_ci_repair_latest_archive "$lease_dir")
 		archived_attempt="${archive_payload%%|*}"
 		existing_worktree="${archive_payload#*|}"
-		if [[ "$archived_attempt" -ge "$max_attempts" ]]; then
-			printf 'exhausted'
-			return 0
-		fi
 		next_attempt=$((archived_attempt + 1))
 		if _ci_repair_adopt_live_session "$state_file" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
 			"$failure_fingerprint" "$existing_worktree" "$next_attempt" "$session_key"; then
 			printf '%s' "$active_result"
 			return 0
 		fi
+		claim_result=$(_ci_repair_claim_next_attempt "$lease_dir" "$next_attempt" "$max_attempts") || return 1
+		case "$claim_result" in
+		"$active_result" | "$exhausted_result")
+			printf '%s' "$claim_result"
+			return 0
+			;;
+		*) [[ "$claim_result" =~ ^[0-9]+$ ]] || return 1 ;;
+		esac
+		next_attempt="$claim_result"
 		_ci_repair_prepare_attempt "$state_file" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
 			"$failure_fingerprint" "$existing_worktree" "$next_attempt" "$session_key" || return 1
 		echo "[pulse-wrapper] _dispatch_ci_repair_session: recovered incomplete lease state for ${repo_slug} PR #${pr_number} as attempt ${next_attempt}/${max_attempts}" >>"$LOGFILE"
@@ -864,7 +863,10 @@ _ci_repair_claim_lease() {
 	existing_pid=$(jq -r '.pid // empty' "$state_file" 2>/dev/null) || existing_pid=""
 	existing_pid_start=$(jq -r '.pid_start // empty' "$state_file" 2>/dev/null) || existing_pid_start=""
 	existing_attempt=$(jq -r '.attempt // 1' "$state_file" 2>/dev/null) || existing_attempt="1"
+	existing_status=$(jq -r '.status // empty' "$state_file" 2>/dev/null) || existing_status=""
+	updated_at=$(jq -r '.updated_at // 0' "$state_file" 2>/dev/null) || updated_at="0"
 	[[ "$existing_attempt" =~ ^[0-9]+$ ]] || existing_attempt=1
+	[[ "$updated_at" =~ ^[0-9]+$ ]] || updated_at=0
 	if _ci_repair_pid_is_live "$existing_pid" "$existing_pid_start"; then
 		echo "[pulse-wrapper] _dispatch_ci_repair_session: repair already active for ${repo_slug} PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint} (pid ${existing_pid}, attempt ${existing_attempt})" >>"$LOGFILE"
 		printf '%s' "$active_result"
@@ -876,12 +878,24 @@ _ci_repair_claim_lease() {
 		printf '%s' "$active_result"
 		return 0
 	fi
-	if [[ "$existing_attempt" -ge "$max_attempts" ]]; then
-		echo "[pulse-wrapper] _dispatch_ci_repair_session: stale repair exhausted ${max_attempts} attempts for ${repo_slug} PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint}" >>"$LOGFILE"
-		printf 'exhausted'
+	now=$(date +%s 2>/dev/null) || now=0
+	if [[ "$existing_status" == "$(_ci_repair_status_preparing)" && $((now - updated_at)) -lt "$launch_grace" ]]; then
+		printf '%s' "$active_result"
 		return 0
 	fi
 	next_attempt=$((existing_attempt + 1))
+	claim_result=$(_ci_repair_claim_next_attempt "$lease_dir" "$next_attempt" "$max_attempts") || return 1
+	if [[ "$claim_result" == "$active_result" ]]; then
+		printf '%s' "$active_result"
+		return 0
+	fi
+	if [[ "$claim_result" == "$exhausted_result" ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_repair_session: stale repair exhausted ${max_attempts} attempts for ${repo_slug} PR #${pr_number} head ${pr_head_sha} fingerprint ${failure_fingerprint}" >>"$LOGFILE"
+		printf '%s' "$exhausted_result"
+		return 0
+	fi
+	[[ "$claim_result" =~ ^[0-9]+$ ]] || return 1
+	next_attempt="$claim_result"
 	if ! mv "$state_file" "${lease_dir}/state-attempt-${existing_attempt}.json" 2>/dev/null; then
 		printf '%s' "$active_result"
 		return 0
@@ -949,21 +963,20 @@ _ci_repair_session_identity() {
 	local lock_file=""
 	local lock_value=""
 	local worker_pid=""
+	local stored_hash=""
 	local process_start=""
-	local process_command=""
+	local process_pattern="${WORKER_PROCESS_PATTERN:-opencode|claude|Claude}|headless-runtime-helper"
 
 	safe_key=$(printf '%s' "$session_key" | tr '/ ' '__')
 	lock_file="${state_dir}/locks/${safe_key}.pid"
 	[[ -f "$lock_file" ]] || return 1
 	lock_value=$(sed -n '1p' "$lock_file" 2>/dev/null) || lock_value=""
 	worker_pid="${lock_value%%|*}"
+	stored_hash="${lock_value#*|}"
+	[[ "$stored_hash" == "$worker_pid" ]] && stored_hash=""
 	[[ "$worker_pid" =~ ^[0-9]+$ ]] || return 1
-	kill -0 "$worker_pid" 2>/dev/null || return 1
-	process_command=$(ps -p "$worker_pid" -o command= 2>/dev/null) || process_command=""
-	case "$process_command" in
-	*headless-runtime-helper* | *opencode* | *claude*) ;;
-	*) return 1 ;;
-	esac
+	declare -F _is_process_alive_and_matches >/dev/null 2>&1 || return 1
+	_is_process_alive_and_matches "$worker_pid" "$process_pattern" "$stored_hash" || return 1
 	process_start=$(_ci_repair_process_start "$worker_pid")
 	[[ -n "$process_start" ]] || return 1
 	printf '%s|%s' "$worker_pid" "$process_start"
@@ -993,12 +1006,13 @@ _ci_repair_launch_worker() {
 	local dispatched_status=""
 	local wait_count=0
 	local wait_max="${AIDEVOPS_CI_REPAIR_SESSION_LOCK_WAIT_STEPS:-200}"
+	local process_pattern="${WORKER_PROCESS_PATTERN:-opencode|claude|Claude}|headless-runtime-helper"
 
 	[[ "$wait_max" =~ ^[0-9]+$ ]] || wait_max=200
 	launch_output=$(env \
 		HEADLESS=1 WORKER_ISSUE_NUMBER="$linked_issue" WORKER_REPO_SLUG="$repo_slug" \
 		WORKER_WORKTREE_PATH="$worktree_path" GITHUB_REPOSITORY="$repo_slug" \
-		WORKER_NO_EXIT_PUSH=1 AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1 \
+		WORKER_NO_EXIT_PUSH=1 WORKER_PROCESS_PATTERN="$process_pattern" AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1 \
 		AIDEVOPS_PR_REPAIR_NUMBER="$pr_number" AIDEVOPS_PR_REPAIR_HEAD_SHA="$pr_head_sha" \
 		AIDEVOPS_PR_REPAIR_HEAD_REF="$pr_head_ref" AIDEVOPS_PR_REPAIR_FINGERPRINT="$failure_fingerprint" \
 		"$helper" run --role worker --session-key "$session_key" --dir "$worktree_path" \
@@ -1080,16 +1094,18 @@ _dispatch_ci_repair_session() {
 	local pr_head_ref="$5"
 	local failure_fingerprint="$6"
 	local failing_checks="$7"
-	local repo_path="" helper="" state_root="" state_key="" lease_dir="" prompt_file="" session_key="" transition_lock=""
+	local repo_path="" helper="" state_root="" state_key="" lease_dir="" prompt_file="" session_key=""
 	local lease_action=""
 	local max_attempts="${AIDEVOPS_CI_REPAIR_MAX_ATTEMPTS:-2}"
 	local attempt=""
 	local worktree_path=""
 	local launch_payload=""
 	local active_result=""
+	local exhausted_result=""
 	local dispatched_status=""
 	_CI_REPAIR_DISPATCH_RESULT="failed"
 	active_result=$(_ci_repair_result_active)
+	exhausted_result=$(_ci_repair_result_exhausted)
 	dispatched_status=$(_ci_repair_status_dispatched)
 
 	repo_path=$(_pulse_merge_repo_path_for_slug "$repo_slug" 2>/dev/null) || repo_path=""
@@ -1101,26 +1117,16 @@ _dispatch_ci_repair_session() {
 	state_key=$(printf '%s-%s-%s-%s' "$repo_slug" "$pr_number" "$pr_head_sha" "$failure_fingerprint" | tr '/:' '__')
 	lease_dir="${state_root}/${state_key}"
 	session_key="ci-repair-${pr_number}-${pr_head_sha:0:12}-${failure_fingerprint:0:12}"
-	transition_lock="${lease_dir}/transition.lock"
 	mkdir -p "$lease_dir" 2>/dev/null || return 1
-	if ! _ci_repair_acquire_lock "$transition_lock"; then
-		_CI_REPAIR_DISPATCH_RESULT="$active_result"
-		return 0
-	fi
 	lease_action=$(_ci_repair_claim_lease "$lease_dir" "$repo_slug" "$pr_number" "$pr_head_sha" \
-		"$failure_fingerprint" "$max_attempts" "$pr_head_ref" "$session_key") || {
-		_ci_repair_release_lock "$transition_lock" || true
-		return 1
-	}
+		"$failure_fingerprint" "$max_attempts" "$pr_head_ref" "$session_key") || return 1
 	case "$lease_action" in
 	"$active_result")
 		_CI_REPAIR_DISPATCH_RESULT="$active_result"
-		_ci_repair_release_lock "$transition_lock" || true
 		return 0
 		;;
-	exhausted)
-		_CI_REPAIR_DISPATCH_RESULT="exhausted"
-		_ci_repair_release_lock "$transition_lock" || true
+	"$exhausted_result")
+		_CI_REPAIR_DISPATCH_RESULT="$exhausted_result"
 		return 1
 		;;
 	launch\|*)
@@ -1128,12 +1134,10 @@ _dispatch_ci_repair_session() {
 		attempt="${launch_payload%%|*}"
 		worktree_path="${launch_payload#*|}"
 		if [[ ! "$attempt" =~ ^[0-9]+$ ]]; then
-			_ci_repair_release_lock "$transition_lock" || true
 			return 1
 		fi
 		;;
 	*)
-		_ci_repair_release_lock "$transition_lock" || true
 		return 1
 		;;
 	esac
@@ -1147,27 +1151,18 @@ _dispatch_ci_repair_session() {
 	if [[ -z "$worktree_path" || ! -d "$worktree_path" ]]; then
 		_ci_repair_write_state "${lease_dir}/state.json" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
 			"$failure_fingerprint" "" "0" "" "$attempt" "worktree_failed" "$session_key" || true
-		_ci_repair_release_lock "$transition_lock" || true
 		return 1
 	fi
 	_ci_repair_prepare_attempt "${lease_dir}/state.json" "$repo_slug" "$pr_number" "$pr_head_sha" "$pr_head_ref" \
-		"$failure_fingerprint" "$worktree_path" "$attempt" "$session_key" || {
-		_ci_repair_release_lock "$transition_lock" || true
-		return 1
-	}
+		"$failure_fingerprint" "$worktree_path" "$attempt" "$session_key" || return 1
 
 	prompt_file="${lease_dir}/prompt.md"
 	_ci_repair_write_prompt "$prompt_file" "$repo_slug" "$pr_number" "$linked_issue" "$pr_head_sha" \
-		"$pr_head_ref" "$failure_fingerprint" "$failing_checks" || {
-		_ci_repair_release_lock "$transition_lock" || true
-		return 1
-	}
+		"$pr_head_ref" "$failure_fingerprint" "$failing_checks" || return 1
 	if ! _ci_repair_launch_worker "$lease_dir" "$helper" "$repo_slug" "$pr_number" "$linked_issue" \
 		"$pr_head_sha" "$pr_head_ref" "$failure_fingerprint" "$worktree_path" "$attempt" "$session_key" "$prompt_file"; then
-		_ci_repair_release_lock "$transition_lock" || true
 		return 1
 	fi
-	_ci_repair_release_lock "$transition_lock" || true
 	_CI_REPAIR_DISPATCH_RESULT="$dispatched_status"
 	return 0
 }

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -333,7 +333,7 @@ _ci_check_url_has_infra_failure_log() {
 	failed_log=$(gh run view "$run_id" --repo "$repo_slug" --job "$job_id" --log-failed 2>/dev/null) || failed_log=""
 	[[ -n "$failed_log" ]] || return 1
 
-	if printf '%s\n' "$failed_log" | grep -Eiq '(Process completed with exit code (124|137|143)|timed out after|[[:space:]]Killed[[:space:]]+timeout|timeout --kill-after|The operation was canceled|cancelled due to timeout|toomanyrequests:[[:space:]]*Rate exceeded|Error response from daemon:.*(429|Too Many Requests|Rate exceeded)|(failed to pull image|failed to resolve source metadata|failed to authorize).*(429|Too Many Requests|Rate exceeded|TLS handshake timeout|i/o timeout|connection reset by peer|Service Unavailable)|(public\.ecr\.aws|docker\.io|ghcr\.io|registry[^[:space:]]*).*(429|Too Many Requests|Rate exceeded|TLS handshake timeout|i/o timeout|connection reset by peer|Service Unavailable))'; then
+	if printf '%s\n' "$failed_log" | grep -Eiq '(Process completed with exit code (124|137|143)|timed out after|[[:space:]]Killed[[:space:]]+timeout|timeout --kill-after|The operation was canceled|cancelled due to timeout|toomanyrequests:.*(Rate exceeded|pull rate limit|reached your.*rate limit)|Error response from daemon:.*(429|Too Many Requests|Rate exceeded)|(failed to pull image|failed to resolve source metadata|failed to authorize).*(429|Too Many Requests|Rate exceeded|TLS handshake timeout|i/o timeout|connection reset by peer|Service Unavailable)|(public\.ecr\.aws|docker\.io|ghcr\.io|registry[^[:space:]]*).*(429|Too Many Requests|Rate exceeded|TLS handshake timeout|i/o timeout|connection reset by peer|Service Unavailable))'; then
 		return 0
 	fi
 	return 1
@@ -411,9 +411,9 @@ _ci_merge_check_sets() {
 # cannot be repaired in place.
 #
 # The repair worker sees failing check names, URLs, and current-head context.
-# Its durable lease is keyed by repo + PR + head SHA + failure fingerprint so
-# repeated pulse cycles do not duplicate work, while a newly-pushed head can
-# enter repair independently if it is still red.
+# Its durable lease is keyed by repo + PR + head SHA so reordered or changing
+# check evidence cannot launch overlapping workers against one branch head. A
+# newly-pushed head can enter repair independently if it is still red.
 #
 # Same pattern as _dispatch_pr_fix_worker (t2093) but for CI failures
 # instead of review CHANGES_REQUESTED.
@@ -429,6 +429,12 @@ _dispatch_ci_fix_worker() {
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 0
 	[[ -n "$repo_slug" ]] || return 0
 	[[ "$linked_issue" =~ ^[0-9]+$ ]] || return 0
+	local initial_head_sha=""
+	initial_head_sha=$(gh pr view "$pr_number" --repo "$repo_slug" --json headRefOid --jq '.headRefOid // ""' 2>/dev/null) || initial_head_sha=""
+	if [[ -z "$initial_head_sha" ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} head snapshot unavailable before collecting CI evidence — deferring repair routing" >>"$LOGFILE"
+		return 0
+	fi
 
 	# Collect actionable failed required checks first. Pending/queued/in-progress
 	# checks are not actionable repair evidence and must not be routed into the
@@ -472,9 +478,13 @@ _dispatch_ci_fix_worker() {
 		--json headRefOid,headRefName,isCrossRepository,maintainerCanModify \
 		--jq '[(.headRefOid // ""),(.headRefName // ""),(.isCrossRepository // false),(.maintainerCanModify // false)] | @tsv' 2>/dev/null) || pr_info=""
 	IFS=$'\t' read -r pr_head_sha pr_head_ref is_cross_repo maintainer_can_modify <<<"$pr_info"
+	if [[ -n "$initial_head_sha" && "$pr_head_sha" != "$initial_head_sha" ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} head changed while collecting CI evidence (${initial_head_sha} -> ${pr_head_sha:-unknown}) — deferring repair routing" >>"$LOGFILE"
+		return 0
+	fi
 
 	local failure_fingerprint=""
-	failure_fingerprint=$(printf '%s\n' "$failing_checks_json" | jq -cS '.' 2>/dev/null | shasum -a 256 2>/dev/null | cut -d ' ' -f 1) || failure_fingerprint=""
+	failure_fingerprint=$(_ci_repair_hash_text "$(printf '%s\n' "$failing_checks_json" | jq -cS '.' 2>/dev/null)") || failure_fingerprint=""
 	[[ -n "$failure_fingerprint" ]] || failure_fingerprint="unknown"
 
 	# Build the CI Failure Feedback section (with optional pattern guidance).
@@ -520,8 +530,10 @@ _route_ci_repair_fallback() {
 	local fallback_reason="$7"
 	local feedback_section="$8"
 	local failing_checks="$9"
-	local marker="<!-- ci-feedback-fallback:PR${pr_number}:SHA${pr_head_sha:-unknown}:FP${failure_fingerprint} -->"
+	local marker_prefix="<!-- ci-feedback-fallback:PR${pr_number}:SHA${pr_head_sha:-unknown}"
+	local marker="${marker_prefix} -->"
 	local current_body=""
+	: "$failure_fingerprint"
 
 	gh label create "ci-feedback-routed" --repo "$repo_slug" --color "E4E669" \
 		--description "Worker PR with failing CI routed to linked issue for re-dispatch" \
@@ -531,7 +543,9 @@ _route_ci_repair_fallback() {
 		--force >/dev/null 2>&1 || true
 	current_body=$(gh issue view "$linked_issue" --repo "$repo_slug" \
 		--json body --jq '.body // ""' 2>/dev/null) || current_body=""
-	if [[ -n "$current_body" ]] && printf '%s' "$current_body" | grep -qF "$marker"; then
+	# Match both the PR/head marker and the legacy marker that appended :FP...
+	# so an upgrade cannot replay an already-routed fallback.
+	if [[ -n "$current_body" ]] && printf '%s' "$current_body" | grep -qF "$marker_prefix"; then
 		echo "[pulse-wrapper] _dispatch_ci_fix_worker: issue #${linked_issue} already has CI repair fallback marker for PR #${pr_number} head ${pr_head_sha:-unknown} — skipping duplicate fallback" >>"$LOGFILE"
 		return 0
 	fi
@@ -914,15 +928,17 @@ _ci_repair_claim_lease() {
 #######################################
 _ci_repair_create_worktree() {
 	local repo_path="$1"
-	local linked_issue="$2"
-	local pr_number="$3"
-	local pr_head_sha="$4"
-	local pr_head_ref="$5"
-	local failure_fingerprint="$6"
-	local attempt="$7"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local pr_number="$4"
+	local pr_head_sha="$5"
+	local pr_head_ref="$6"
+	local failure_fingerprint="$7"
+	local attempt="$8"
 	local worktree_helper="${AIDEVOPS_WORKTREE_HELPER:-${_PULSE_MERGE_DIR:-${BASH_SOURCE[0]%/*}}/worktree-helper.sh}"
 	local worktree_base="${AIDEVOPS_CI_REPAIR_WORKTREE_BASE_DIR:-${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}}"
 	local repo_name=""
+	local repo_hash=""
 	local repair_branch=""
 	local worktree_path=""
 	local actual_head=""
@@ -936,10 +952,11 @@ _ci_repair_create_worktree() {
 	git -C "$repo_path" cat-file -e "${pr_head_sha}^{commit}" 2>/dev/null || return 1
 
 	repo_name=$(basename "$repo_path")
-	repair_branch="repair/pr-${pr_number}-${pr_head_sha:0:12}-${failure_fingerprint:0:12}-a${attempt}"
-	worktree_path="${worktree_base}/${repo_name}-ci-repair-pr${pr_number}-${pr_head_sha:0:12}-${failure_fingerprint:0:12}-a${attempt}"
+	repo_hash=$(_ci_repair_hash_text "$repo_slug") || return 1
+	repair_branch="repair/${repo_hash}-pr-${pr_number}-${pr_head_sha:0:12}-${failure_fingerprint:0:12}-a${attempt}"
+	worktree_path="${worktree_base}/${repo_name}-${repo_hash}-ci-repair-pr${pr_number}-${pr_head_sha:0:12}-${failure_fingerprint:0:12}-a${attempt}"
 	mkdir -p "$worktree_base" 2>/dev/null || return 1
-	if ! (cd "$repo_path" && AIDEVOPS_SKIP_AUTO_CLAIM=1 "$worktree_helper" add "$repair_branch" "$worktree_path" \
+	if ! (cd "$repo_path" && AIDEVOPS_SKIP_AUTO_CLAIM=1 AIDEVOPS_WORKTREE_BASE_DIR="$worktree_base" "$worktree_helper" add "$repair_branch" "$worktree_path" \
 		--base "$pr_head_sha" --issue "$linked_issue") >>"$LOGFILE" 2>&1; then
 		return 1
 	fi
@@ -1082,7 +1099,57 @@ _ci_repair_write_prompt() {
 }
 
 #######################################
-# Launch one bounded repair session for a repository/PR/head/failure tuple.
+# Return whether a legacy fingerprint-scoped lease still owns a live worker.
+#######################################
+_ci_repair_legacy_lease_is_active() {
+	local legacy_dir="$1"
+	local expected_repo="$2"
+	local expected_pr="$3"
+	local expected_head="$4"
+	local state_file="${legacy_dir}/state.json"
+	local state_identity="" state_repo="" state_pr="" state_head="" state_fingerprint="" state_status=""
+	local legacy_session_key="" legacy_session_identity=""
+
+	[[ -f "$state_file" ]] || return 1
+	state_identity=$(jq -r '[.repo // "", (.pr // "" | tostring), .head // "", .fingerprint // "", .status // ""] | @tsv' "$state_file" 2>/dev/null) || return 1
+	IFS=$'\t' read -r state_repo state_pr state_head state_fingerprint state_status <<<"$state_identity"
+	[[ "$state_repo" == "$expected_repo" && "$state_pr" == "$expected_pr" && "$state_head" == "$expected_head" ]] || return 1
+	[[ "$state_status" == "$(_ci_repair_status_dispatched)" && -n "$state_fingerprint" ]] || return 1
+	legacy_session_key="ci-repair-${expected_pr}-${expected_head:0:12}-${state_fingerprint:0:12}"
+	legacy_session_identity=$(_ci_repair_session_identity "$legacy_session_key" 2>/dev/null) || return 1
+	[[ -n "$legacy_session_identity" ]]
+	return $?
+}
+
+_ci_repair_hash_text() {
+	local input_text="$1"
+	local content_hash=""
+
+	if command -v sha256sum >/dev/null 2>&1; then
+		content_hash=$(printf '%s' "$input_text" | sha256sum 2>/dev/null | cut -d ' ' -f 1) || return 1
+	elif command -v shasum >/dev/null 2>&1; then
+		content_hash=$(printf '%s' "$input_text" | shasum -a 256 2>/dev/null | cut -d ' ' -f 1) || return 1
+	else
+		return 1
+	fi
+	[[ "$content_hash" =~ ^[0-9a-f]{64}$ ]] || return 1
+	printf '%s' "$content_hash"
+	return 0
+}
+
+_ci_repair_session_key() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local pr_head_sha="$3"
+	local repo_hash=""
+
+	repo_hash=$(_ci_repair_hash_text "$repo_slug") || return 1
+	printf 'ci-repair-%s-%s-%s' "$repo_hash" "$pr_number" "${pr_head_sha:0:12}"
+	return 0
+}
+
+#######################################
+# Launch one bounded repair session for a repository/PR/head tuple.
 # The state directory is the cross-pulse dedup lease. A dead worker may be
 # retried once; repeated terminal attempts take the durable fallback.
 #######################################
@@ -1094,7 +1161,7 @@ _dispatch_ci_repair_session() {
 	local pr_head_ref="$5"
 	local failure_fingerprint="$6"
 	local failing_checks="$7"
-	local repo_path="" helper="" state_root="" state_key="" lease_dir="" prompt_file="" session_key=""
+	local repo_path="" helper="" state_root="" state_key="" legacy_state_key="" lease_dir="" prompt_file="" session_key="" legacy_dir="" repo_hash=""
 	local lease_action=""
 	local max_attempts="${AIDEVOPS_CI_REPAIR_MAX_ATTEMPTS:-2}"
 	local attempt=""
@@ -1114,9 +1181,19 @@ _dispatch_ci_repair_session() {
 	[[ -x "$helper" ]] || return 1
 
 	state_root="${AIDEVOPS_CI_REPAIR_STATE_DIR:-${HOME}/.aidevops/.agent-workspace/ci-pr-repair}"
-	state_key=$(printf '%s-%s-%s-%s' "$repo_slug" "$pr_number" "$pr_head_sha" "$failure_fingerprint" | tr '/:' '__')
+	repo_hash=$(_ci_repair_hash_text "$repo_slug") || return 1
+	state_key="${repo_hash}-${pr_number}-${pr_head_sha}"
+	legacy_state_key=$(printf '%s-%s-%s' "$repo_slug" "$pr_number" "$pr_head_sha" | tr '/:' '__')
 	lease_dir="${state_root}/${state_key}"
-	session_key="ci-repair-${pr_number}-${pr_head_sha:0:12}-${failure_fingerprint:0:12}"
+	for legacy_dir in "${state_root}/${legacy_state_key}-"*; do
+		[[ -d "$legacy_dir" ]] || continue
+		if _ci_repair_legacy_lease_is_active "$legacy_dir" "$repo_slug" "$pr_number" "$pr_head_sha"; then
+			echo "[pulse-wrapper] _dispatch_ci_repair_session: legacy repair lease remains active for ${repo_slug} PR #${pr_number} head ${pr_head_sha}" >>"$LOGFILE"
+			_CI_REPAIR_DISPATCH_RESULT="$active_result"
+			return 0
+		fi
+	done
+	session_key=$(_ci_repair_session_key "$repo_slug" "$pr_number" "$pr_head_sha")
 	mkdir -p "$lease_dir" 2>/dev/null || return 1
 	lease_action=$(_ci_repair_claim_lease "$lease_dir" "$repo_slug" "$pr_number" "$pr_head_sha" \
 		"$failure_fingerprint" "$max_attempts" "$pr_head_ref" "$session_key") || return 1
@@ -1145,7 +1222,7 @@ _dispatch_ci_repair_session() {
 	if [[ -n "$worktree_path" && -d "$worktree_path" ]]; then
 		echo "[pulse-wrapper] _dispatch_ci_repair_session: resuming stale repair worktree ${worktree_path} for ${repo_slug} PR #${pr_number} attempt ${attempt}/${max_attempts}" >>"$LOGFILE"
 	else
-		worktree_path=$(_ci_repair_create_worktree "$repo_path" "$linked_issue" "$pr_number" "$pr_head_sha" \
+		worktree_path=$(_ci_repair_create_worktree "$repo_path" "$repo_slug" "$linked_issue" "$pr_number" "$pr_head_sha" \
 			"$pr_head_ref" "$failure_fingerprint" "$attempt") || worktree_path=""
 	fi
 	if [[ -z "$worktree_path" || ! -d "$worktree_path" ]]; then

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -671,7 +671,7 @@ _ci_repair_lock_is_stale() {
 
 	[[ "$grace_seconds" =~ ^[0-9]+$ ]] || grace_seconds=2
 	now=$(date +%s 2>/dev/null) || now=0
-	lock_mtime=$(stat -f '%m' "$lock_dir" 2>/dev/null) || lock_mtime=$(stat -c '%Y' "$lock_dir" 2>/dev/null) || lock_mtime="$now"
+	lock_mtime=$(_file_mtime_epoch "$lock_dir" 2>/dev/null) || lock_mtime="$now"
 	[[ "$lock_mtime" =~ ^[0-9]+$ ]] || lock_mtime="$now"
 	lock_age=$((now - lock_mtime))
 	[[ "$lock_age" -ge "$grace_seconds" ]]

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -363,6 +363,7 @@ EOF
 	_classify_ci_failures_by_pattern() { local failing_names="$1"; printf '%s' "$failing_names" >"${TEST_ROOT}/classified-names.txt"; return 0; }
 	_pulse_merge_repo_path_for_slug() { local repo_slug="$1"; [[ -n "$repo_slug" ]]; printf '%s\n' "${TEST_ROOT}/repo"; return 0; }
 	_is_process_alive_and_matches() { local process_pid="$1"; local process_pattern="$2"; local stored_hash="$3"; [[ -n "$process_pattern" || -n "$stored_hash" ]]; kill -0 "$process_pid" 2>/dev/null; return $?; }
+	_file_mtime_epoch() { local file_path="$1"; [[ -e "$file_path" ]] || return 1; date +%s; return 0; }
 	for fn in "${fns[@]}"; do
 		fn_src=$(extract_function "$fn" "$FEEDBACK_SCRIPT")
 		[[ -n "$fn_src" ]] || return 1

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -21,6 +21,7 @@ TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
 GH_LOG=""
+TEST_PR_HEAD_SHA=""
 
 print_result() {
 	local test_name="$1"
@@ -47,15 +48,58 @@ setup_test_env() {
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
 	export TEST_CHECK_SCENARIO="terminal_failure"
+	export TEST_WORKER_SLEEP_SECONDS="2"
 	export AIDEVOPS_CI_REPAIR_STATE_DIR="${TEST_ROOT}/repair-state"
+	export AIDEVOPS_CI_REPAIR_WORKTREE_BASE_DIR="${TEST_ROOT}/worktrees"
+	export AIDEVOPS_HEADLESS_RUNTIME_DIR="${TEST_ROOT}/headless-runtime"
+	export AIDEVOPS_CI_REPAIR_SESSION_LOCK_WAIT_STEPS="0"
 	mkdir -p "${TEST_ROOT}/repo"
+	TEST_PR_HEAD_SHA="abcdef0123456789abcdef0123456789abcdef01"
+	export TEST_PR_HEAD_SHA
 	cat >"${TEST_ROOT}/bin/headless-runtime-helper.sh" <<'EOF'
 #!/usr/bin/env bash
-printf '%s|%s|%s|%s|%s\n' "${AIDEVOPS_PR_REPAIR_NUMBER:-}" "${AIDEVOPS_PR_REPAIR_HEAD_SHA:-}" "${AIDEVOPS_PR_REPAIR_HEAD_REF:-}" "${AIDEVOPS_PR_REPAIR_FINGERPRINT:-}" "$*" >>"${GH_LOG}"
-sleep 1
+printf '%s|%s|%s|%s|%s|%s|%s\n' "${AIDEVOPS_PR_REPAIR_NUMBER:-}" "${AIDEVOPS_PR_REPAIR_HEAD_SHA:-}" "${AIDEVOPS_PR_REPAIR_HEAD_REF:-}" "${AIDEVOPS_PR_REPAIR_FINGERPRINT:-}" "${WORKER_WORKTREE_PATH:-}" "${WORKER_NO_EXIT_PUSH:-}" "$*" >>"${GH_LOG}"
+if [[ "$*" == *"--detach"* ]]; then
+	sleep "${TEST_WORKER_SLEEP_SECONDS:-2}" >/dev/null 2>&1 &
+	printf 'Dispatched PID: %s\n' "$!"
+	exit 0
+fi
+sleep "${TEST_WORKER_SLEEP_SECONDS:-2}"
 EOF
 	chmod +x "${TEST_ROOT}/bin/headless-runtime-helper.sh"
 	export AIDEVOPS_HEADLESS_RUNTIME_HELPER="${TEST_ROOT}/bin/headless-runtime-helper.sh"
+	cat >"${TEST_ROOT}/bin/worktree-helper.sh" <<'EOF'
+#!/usr/bin/env bash
+action="${1:-}"
+shift || true
+case "$action" in
+add)
+	branch="${1:-}"
+	path="${2:-}"
+	shift 2
+	base=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--base)
+			base="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+	printf 'worktree add %s %s %s\n' "$branch" "$path" "$base" >>"${GH_LOG}"
+	mkdir -p "$path"
+	;;
+remove)
+	path="${1:-}"
+	printf 'worktree remove %s\n' "$path" >>"${GH_LOG}"
+	rm -rf "$path"
+	;;
+*) exit 1 ;;
+esac
+EOF
+	chmod +x "${TEST_ROOT}/bin/worktree-helper.sh"
+	export AIDEVOPS_WORKTREE_HELPER="${TEST_ROOT}/bin/worktree-helper.sh"
 	printf 'Original issue body.\n' >"${TEST_ROOT}/issue-body.txt"
 	write_gh_mock
 	return 0
@@ -69,7 +113,7 @@ printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
 
 if [[ "${1:-} ${2:-}" == "pr view" ]]; then
 	if [[ "$*" == *"headRefOid,headRefName,isCrossRepository,maintainerCanModify"* ]]; then
-		printf 'abc123\tfeature/repair\tfalse\ttrue\n'
+		printf '%s\tfeature/repair\tfalse\ttrue\n' "${TEST_PR_HEAD_SHA}"
 		exit 0
 	fi
 	if [[ "$*" == *"--json labels"* ]]; then
@@ -77,7 +121,7 @@ if [[ "${1:-} ${2:-}" == "pr view" ]]; then
 		exit 0
 	fi
 	if [[ "$*" == *"--json headRefOid"* ]]; then
-		printf 'abc123\n'
+		printf '%s\n' "${TEST_PR_HEAD_SHA}"
 		exit 0
 	fi
 	exit 0
@@ -87,6 +131,9 @@ if [[ "${1:-} ${2:-}" == "run view" ]]; then
 	case "${TEST_CHECK_SCENARIO:-terminal_failure}" in
 	infra_timeout)
 		printf '%s\n' 'Lint Run timed out after 10m'
+		;;
+	infra_registry_rate_limit)
+		printf '%s\n' 'Error response from daemon: toomanyrequests: Rate exceeded while pulling public.ecr.aws/docker/library/postgres:18'
 		;;
 	log_exit_143)
 		printf '%s\n' 'Lint Run ##[error]Process completed with exit code 143.'
@@ -107,7 +154,7 @@ fi
 		fi
 		if [[ "$*" == *"name,bucket,state,link"* ]]; then
 			case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
-				terminal_failure:1 | log_exit_143:1 | required_and_advisory:1)
+				terminal_failure:1 | log_exit_143:1 | required_and_advisory:1 | infra_registry_rate_limit:1)
 					printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
 					;;
 				required_and_advisory:0)
@@ -159,6 +206,16 @@ GHEOF
 
 teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		local state_file="" worker_pid="" worker_status=""
+		while IFS= read -r state_file; do
+			worker_pid=$(jq -r '.pid // empty' "$state_file" 2>/dev/null) || worker_pid=""
+			worker_status=$(jq -r '.status // empty' "$state_file" 2>/dev/null) || worker_status=""
+			if [[ "$worker_status" == "dispatched" && "$worker_pid" =~ ^[0-9]+$ && "$worker_pid" != "$$" ]] \
+				&& kill -0 "$worker_pid" 2>/dev/null; then
+				kill "$worker_pid" 2>/dev/null || true
+				wait "$worker_pid" 2>/dev/null || true
+			fi
+		done < <(find "${AIDEVOPS_CI_REPAIR_STATE_DIR:-$TEST_ROOT}" -name state.json -type f 2>/dev/null)
 		rm -rf "$TEST_ROOT"
 	fi
 	return 0
@@ -214,6 +271,14 @@ define_process_helper() {
 	_pulse_merge_changes_requested_thread_remediation_first_enabled() { return 1; }
 	_pulse_merge_preflight_snapshot_gate() { return 0; }
 	_attempt_pr_update_branch() { return 1; }
+	_attempt_existing_auto_merge_behind_update_branch() { return 1; }
+	_attempt_green_behind_update_branch() { return 1; }
+	approve_collaborator_pr() { return 0; }
+	_check_ruleset_required_reviews_passing() { return 0; }
+	_extract_merge_summary() { printf 'test summary'; return 0; }
+	_retarget_stacked_children() { return 0; }
+	_pulse_merge_admin_safety_check() { return 0; }
+	_set_native_auto_merge_or_skip() { return 0; }
 	_pulse_merge_changes_requested_thread_remediation_first_enabled() { return 1; }
 	_pulse_merge_preflight_snapshot_gate() { return 0; }
 	_close_conflicting_pr() { return 0; }
@@ -230,18 +295,48 @@ define_process_helper() {
 define_feedback_helpers() {
 	local fns=(
 		_build_ci_feedback_section
-		_ci_check_url_has_infra_timeout_log
+		_ci_check_url_has_infra_failure_log
 		_ci_actionable_failed_checks_markdown
 		_ci_terminal_failed_check_results
 		_ci_merge_check_sets
 		_append_feedback_to_issue
 		_transition_issue_for_redispatch
 		_close_and_label_feedback_pr
+		_ci_repair_write_state
+		_ci_repair_process_start
+		_ci_repair_pid_is_live
+		_ci_repair_publish_lock_owner
+		_ci_repair_lock_is_stale
+		_ci_repair_acquire_lock
+		_ci_repair_release_lock
+		_ci_repair_status_preparing
+		_ci_repair_status_dispatched
+		_ci_repair_result_active
+		_ci_repair_latest_archive
+		_ci_repair_prepare_attempt
+		_ci_repair_adopt_live_session
+		_ci_repair_claim_lease
+		_ci_repair_create_worktree
+		_ci_repair_session_identity
+		_ci_repair_launch_worker
+		_ci_repair_write_prompt
 		_dispatch_ci_repair_session
 		_route_ci_repair_fallback
 		_dispatch_ci_fix_worker
 	)
 	local fn fn_src
+	cat >"${TEST_ROOT}/bin/git" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"cat-file -e"* ]]; then
+	exit 0
+fi
+if [[ "$*" == *"rev-parse HEAD"* ]]; then
+	printf '%s\n' "${TEST_PR_HEAD_SHA}"
+	exit 0
+fi
+exit 0
+EOF
+	chmod +x "${TEST_ROOT}/bin/git"
 	gh_issue_edit_safe() { gh issue edit "$@"; return $?; }
 	_emit_ci_failure_guidance_blocks() { return 0; }
 	_classify_ci_failures_by_pattern() { local failing_names="$1"; printf '%s' "$failing_names" >"${TEST_ROOT}/classified-names.txt"; return 0; }
@@ -343,13 +438,13 @@ test_coderabbit_nits_ok_dismissed_once_before_late_gate() {
 	define_process_helper || { print_result "defines process helper for coderabbit review routing" 1 "could not extract _process_single_ready_pr or review gate"; teardown_test_env; return 0; }
 
 	local pr_object rc=0
-	DRY_RUN=1
+	DRY_RUN=0
 	PR_REQUIRED_CHECKS_RC=0
 	printf -v pr_object '%s' '{"number":555,"mergeable":"UNKNOWN","reviewDecision":"CHANGES_REQUESTED","author":{"login":"worker-bot"},"title":"GH#501: fix","updatedAt":"2026-06-21T00:00:00Z","headRefOid":"sha555","headRefName":"fix/nits","baseRefName":"main","labels":[{"name":"origin:worker"},{"name":"status:in-review"},{"name":"coderabbit-nits-ok"}],"isDraft":false}'
 	_process_single_ready_pr "owner/repo" "$pr_object" || rc=$?
 
-	if [[ "$rc" -ne 0 ]]; then
-		print_result "coderabbit-nits-ok dismissal is not reprocessed by late gate" 1 "Expected dry-run success return 0, got ${rc}"
+	if [[ "$rc" -ne 4 ]]; then
+		print_result "coderabbit-nits-ok dismissal is not reprocessed by late gate" 1 "Expected native-auto defer return 4, got ${rc}"
 	elif [[ "$DISMISS_CALLS" -ne 1 ]]; then
 		print_result "coderabbit-nits-ok dismissal is not reprocessed by late gate" 1 "dismiss_calls=${DISMISS_CALLS}"
 	elif [[ "$GATE_CALLS" -ne 1 || "$GATE_REVIEW_ARG" != "NONE" ]]; then
@@ -391,15 +486,20 @@ test_ci_repair_dedupes_by_repo_pr_head_and_fingerprint() {
 	_dispatch_ci_fix_worker "100" "owner/repo" "42"
 	_dispatch_ci_fix_worker "100" "owner/repo" "42"
 
-	local edit_count state_count
+	local edit_count state_count worktree_count dispatch_count active_count
 	edit_count=$(grep -c 'gh issue edit .*--body' "$GH_LOG" || true)
 	[[ "$edit_count" =~ ^[0-9]+$ ]] || edit_count=0
 	state_count=$(find "$AIDEVOPS_CI_REPAIR_STATE_DIR" -name state.json -type f | wc -l | tr -d ' ')
+	worktree_count=$(grep -c '^worktree add ' "$GH_LOG" || true)
+	dispatch_count=$(grep -c 'dispatched in-place CI repair' "$LOGFILE" || true)
+	active_count=$(grep -c 'in-place CI repair already active' "$LOGFILE" || true)
 
-	if [[ "$edit_count" -ne 0 || "$state_count" -ne 1 ]]; then
-		print_result "CI repair dedupes by repo/PR/head/fingerprint" 1 "issue_edits=${edit_count}, states=${state_count}"
+	if [[ "$edit_count" -ne 0 || "$state_count" -ne 1 || "$worktree_count" -ne 1 ]]; then
+		print_result "CI repair dedupes by repo/PR/head/fingerprint" 1 "issue_edits=${edit_count}, states=${state_count}, worktrees=${worktree_count}"
+	elif [[ "$dispatch_count" -ne 1 || "$active_count" -ne 1 ]]; then
+		print_result "CI repair distinguishes dispatch from a live lease" 1 "dispatches=${dispatch_count}, active=${active_count}"
 	else
-		print_result "CI repair dedupes by repo/PR/head/fingerprint" 0
+		print_result "CI repair dedupes and reports a live lease without false dispatch" 0
 	fi
 	teardown_test_env
 	return 0
@@ -451,6 +551,8 @@ test_ci_feedback_emits_terminal_failure_with_conclusion_and_url() {
 	prompt_file=$(find "$AIDEVOPS_CI_REPAIR_STATE_DIR" -name prompt.md -type f -print -quit)
 	if [[ -z "$prompt_file" ]] || ! grep -qF '**Lint**: failure — [check URL](https://github.com/owner/repo/actions/runs/123/job/456)' "$prompt_file"; then
 		print_result "terminal failure dispatch includes conclusion and check URL" 1 "Dispatch log: $(cat "$GH_LOG")"
+	elif ! grep -q "${TEST_ROOT}/worktrees/.*|1|run --role worker.*--dir ${TEST_ROOT}/worktrees/" "$GH_LOG"; then
+		print_result "terminal failure dispatch uses matching worker worktree env and directory" 1 "Dispatch log: $(cat "$GH_LOG")"
 	elif grep -qF 'gh pr close 100' "$GH_LOG"; then
 		print_result "terminal failure preserves existing PR" 1 "Unexpected close: $(cat "$GH_LOG")"
 	else
@@ -485,10 +587,88 @@ test_ci_feedback_skips_failed_check_with_exit_143_log() {
 
 	if grep -qF 'CI Repair Feedback' "${TEST_ROOT}/issue-body.txt"; then
 		print_result "failed check with exit 143 log does not emit CI repair feedback" 1 "Body: $(cat "${TEST_ROOT}/issue-body.txt")"
-	elif ! grep -qF 'classified as infra-timeout' "$LOGFILE"; then
-		print_result "failed check with exit 143 log records infra-timeout classification" 1 "Log: $(cat "$LOGFILE")"
+	elif ! grep -qF 'classified as infrastructure failure' "$LOGFILE"; then
+		print_result "failed check with exit 143 log records infrastructure classification" 1 "Log: $(cat "$LOGFILE")"
 	else
 		print_result "failed check with exit 143 log does not emit CI repair feedback" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_feedback_skips_registry_rate_limit_failure() {
+	setup_test_env
+	TEST_CHECK_SCENARIO="infra_registry_rate_limit"
+	define_feedback_helpers || { print_result "defines feedback helpers for registry rate limit" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+
+	if grep -qF 'PR #100: CI repair' "$GH_LOG"; then
+		print_result "registry rate limit does not dispatch a code repair" 1 "Dispatch log: $(cat "$GH_LOG")"
+	elif ! grep -qF 'classified as infrastructure failure' "$LOGFILE"; then
+		print_result "registry rate limit records infrastructure classification" 1 "Log: $(cat "$LOGFILE")"
+	else
+		print_result "registry rate limit is classified as infrastructure" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_recovers_one_stale_lease_then_exhausts() {
+	setup_test_env
+	export TEST_WORKER_SLEEP_SECONDS="0.2"
+	define_feedback_helpers || { print_result "defines feedback helpers for stale repair lease" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+	sleep 1
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+	sleep 1
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+
+	local worktree_count=0 current_attempt=""
+	worktree_count=$(grep -c '^worktree add ' "$GH_LOG" || true)
+	current_attempt=$(find "$AIDEVOPS_CI_REPAIR_STATE_DIR" -name state.json -type f -exec jq -r '.attempt // empty' {} \;)
+	if [[ "$worktree_count" -ne 1 || "$current_attempt" != "2" ]]; then
+		print_result "stale CI repair lease resumes one worktree for a bounded retry" 1 "worktrees=${worktree_count}, attempt=${current_attempt}"
+	elif ! grep -qF 'recovering stale repair' "$LOGFILE"; then
+		print_result "stale CI repair retry is observable" 1 "Log: $(cat "$LOGFILE")"
+	elif ! grep -qF 'resuming stale repair worktree' "$LOGFILE"; then
+		print_result "stale CI repair preserves prior worktree evidence" 1 "Log: $(cat "$LOGFILE")"
+	elif ! grep -qF 'exhausted 2 attempts' "$LOGFILE"; then
+		print_result "exhausted CI repair lease is observable" 1 "Log: $(cat "$LOGFILE")"
+	elif ! grep -qF 'gh pr close 100' "$GH_LOG"; then
+		print_result "exhausted CI repair lease takes durable fallback" 1 "GH log: $(cat "$GH_LOG")"
+	else
+		print_result "stale CI repair lease retries once then takes durable fallback" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_recovers_incomplete_state_and_dead_lock() {
+	setup_test_env
+	export AIDEVOPS_CI_REPAIR_STATE_GRACE_SECONDS="0"
+	define_feedback_helpers || { print_result "defines feedback helpers for incomplete lease" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	local lease_dir="${AIDEVOPS_CI_REPAIR_STATE_DIR}/incomplete"
+	local action=""
+	mkdir -p "${lease_dir}/transition.lock"
+	printf '{"pid":999999,"pid_start":"stale"}\n' >"${lease_dir}/transition.lock/owner.json"
+	_ci_repair_acquire_lock "${lease_dir}/transition.lock" || {
+		print_result "dead CI repair transition lock is reclaimed" 1 "could not acquire stale lock"
+		teardown_test_env
+		return 0
+	}
+	action=$(_ci_repair_claim_lease "$lease_dir" "owner/repo" "100" "$TEST_PR_HEAD_SHA" \
+		"fingerprint" "2" "feature/repair" "ci-repair-test")
+	_ci_repair_release_lock "${lease_dir}/transition.lock" || true
+
+	if [[ "$action" != "launch|1|" ]]; then
+		print_result "incomplete CI repair lease is reclaimed" 1 "action=${action}"
+	elif ! jq -e '.status == "preparing" and .attempt == 1 and .session == "ci-repair-test"' "${lease_dir}/state.json" >/dev/null; then
+		print_result "reclaimed CI repair state is complete JSON" 1 "State: $(cat "${lease_dir}/state.json")"
+	else
+		print_result "incomplete CI repair state and dead lock are reclaimed atomically" 0
 	fi
 	teardown_test_env
 	return 0
@@ -540,6 +720,9 @@ main() {
 	test_ci_feedback_emits_terminal_failure_with_conclusion_and_url
 	test_ci_feedback_skips_infra_timeout_checks
 	test_ci_feedback_skips_failed_check_with_exit_143_log
+	test_ci_feedback_skips_registry_rate_limit_failure
+	test_ci_repair_recovers_one_stale_lease_then_exhausts
+	test_ci_repair_recovers_incomplete_state_and_dead_lock
 	test_ci_feedback_skips_advisory_failure_when_required_clean
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -49,6 +49,8 @@ setup_test_env() {
 	export TEST_ROOT GH_LOG
 	export TEST_CHECK_SCENARIO="terminal_failure"
 	export TEST_WORKER_SLEEP_SECONDS="2"
+	unset TEST_INITIAL_PR_HEAD_SHA
+	unset TEST_INITIAL_PR_HEAD_EMPTY
 	export AIDEVOPS_CI_REPAIR_STATE_DIR="${TEST_ROOT}/repair-state"
 	export AIDEVOPS_CI_REPAIR_WORKTREE_BASE_DIR="${TEST_ROOT}/worktrees"
 	export AIDEVOPS_HEADLESS_RUNTIME_DIR="${TEST_ROOT}/headless-runtime"
@@ -87,7 +89,7 @@ add)
 		*) shift ;;
 		esac
 	done
-	printf 'worktree add %s %s %s\n' "$branch" "$path" "$base" >>"${GH_LOG}"
+	printf 'worktree add %s %s %s %s\n' "$branch" "$path" "$base" "${AIDEVOPS_WORKTREE_BASE_DIR:-}" >>"${GH_LOG}"
 	mkdir -p "$path"
 	;;
 remove)
@@ -121,7 +123,11 @@ if [[ "${1:-} ${2:-}" == "pr view" ]]; then
 		exit 0
 	fi
 	if [[ "$*" == *"--json headRefOid"* ]]; then
-		printf '%s\n' "${TEST_PR_HEAD_SHA}"
+		if [[ "${TEST_INITIAL_PR_HEAD_EMPTY:-0}" == "1" ]]; then
+			printf '\n'
+		else
+			printf '%s\n' "${TEST_INITIAL_PR_HEAD_SHA:-${TEST_PR_HEAD_SHA}}"
+		fi
 		exit 0
 	fi
 	exit 0
@@ -135,6 +141,9 @@ if [[ "${1:-} ${2:-}" == "run view" ]]; then
 	infra_registry_rate_limit)
 		printf '%s\n' 'Error response from daemon: toomanyrequests: Rate exceeded while pulling public.ecr.aws/docker/library/postgres:18'
 		;;
+	infra_dockerhub_rate_limit)
+		printf '%s\n' 'toomanyrequests: You have reached your unauthenticated pull rate limit.'
+		;;
 	log_exit_143)
 		printf '%s\n' 'Lint Run ##[error]Process completed with exit code 143.'
 		;;
@@ -144,7 +153,14 @@ if [[ "${1:-} ${2:-}" == "run view" ]]; then
 	esac
 	exit 0
 fi
+GHEOF
+	_append_gh_mock_routes
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
 
+_append_gh_mock_routes() {
+	cat >>"${TEST_ROOT}/bin/gh" <<'GHEOF'
 	if [[ "${1:-} ${2:-}" == "pr checks" ]]; then
 		_is_required=0
 		[[ "$*" == *" --required "* || "$*" == *" --required"* ]] && _is_required=1
@@ -154,7 +170,7 @@ fi
 		fi
 		if [[ "$*" == *"name,bucket,state,link"* ]]; then
 			case "${TEST_CHECK_SCENARIO:-terminal_failure}:${_is_required}" in
-				terminal_failure:1 | log_exit_143:1 | required_and_advisory:1 | infra_registry_rate_limit:1)
+				terminal_failure:1 | log_exit_143:1 | required_and_advisory:1 | infra_registry_rate_limit:1 | infra_dockerhub_rate_limit:1)
 					printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
 					;;
 				required_and_advisory:0)
@@ -200,18 +216,19 @@ fi
 
 exit 0
 GHEOF
-	chmod +x "${TEST_ROOT}/bin/gh"
 	return 0
 }
 
 teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
-		local state_file="" worker_pid="" worker_status=""
+		local state_file="" worker_pid="" worker_start="" worker_status=""
 		while IFS= read -r state_file; do
 			worker_pid=$(jq -r '.pid // empty' "$state_file" 2>/dev/null) || worker_pid=""
+			worker_start=$(jq -r '.pid_start // empty' "$state_file" 2>/dev/null) || worker_start=""
 			worker_status=$(jq -r '.status // empty' "$state_file" 2>/dev/null) || worker_status=""
 			if [[ "$worker_status" == "dispatched" && "$worker_pid" =~ ^[0-9]+$ && "$worker_pid" != "$$" ]] \
-				&& kill -0 "$worker_pid" 2>/dev/null; then
+				&& declare -F _ci_repair_pid_is_live >/dev/null 2>&1 \
+				&& _ci_repair_pid_is_live "$worker_pid" "$worker_start"; then
 				kill "$worker_pid" 2>/dev/null || true
 				wait "$worker_pid" 2>/dev/null || true
 			fi
@@ -321,6 +338,9 @@ define_feedback_helpers() {
 		_ci_repair_session_identity
 		_ci_repair_launch_worker
 		_ci_repair_write_prompt
+		_ci_repair_legacy_lease_is_active
+		_ci_repair_hash_text
+		_ci_repair_session_key
 		_dispatch_ci_repair_session
 		_route_ci_repair_fallback
 		_dispatch_ci_fix_worker
@@ -342,6 +362,7 @@ EOF
 	_emit_ci_failure_guidance_blocks() { return 0; }
 	_classify_ci_failures_by_pattern() { local failing_names="$1"; printf '%s' "$failing_names" >"${TEST_ROOT}/classified-names.txt"; return 0; }
 	_pulse_merge_repo_path_for_slug() { local repo_slug="$1"; [[ -n "$repo_slug" ]]; printf '%s\n' "${TEST_ROOT}/repo"; return 0; }
+	_is_process_alive_and_matches() { local process_pid="$1"; local process_pattern="$2"; local stored_hash="$3"; [[ -n "$process_pattern" || -n "$stored_hash" ]]; kill -0 "$process_pid" 2>/dev/null; return $?; }
 	for fn in "${fns[@]}"; do
 		fn_src=$(extract_function "$fn" "$FEEDBACK_SCRIPT")
 		[[ -n "$fn_src" ]] || return 1
@@ -480,7 +501,7 @@ test_changes_requested_explicit_empty_labels_skip_refetch() {
 	return 0
 }
 
-test_ci_repair_dedupes_by_repo_pr_head_and_fingerprint() {
+test_ci_repair_dedupes_identical_evidence_for_same_head() {
 	setup_test_env
 	define_feedback_helpers || { print_result "defines feedback helpers" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
 
@@ -496,11 +517,98 @@ test_ci_repair_dedupes_by_repo_pr_head_and_fingerprint() {
 	active_count=$(grep -c 'in-place CI repair already active' "$LOGFILE" || true)
 
 	if [[ "$edit_count" -ne 0 || "$state_count" -ne 1 || "$worktree_count" -ne 1 ]]; then
-		print_result "CI repair dedupes by repo/PR/head/fingerprint" 1 "issue_edits=${edit_count}, states=${state_count}, worktrees=${worktree_count}"
+		print_result "CI repair dedupes identical evidence by repo/PR/head" 1 "issue_edits=${edit_count}, states=${state_count}, worktrees=${worktree_count}"
 	elif [[ "$dispatch_count" -ne 1 || "$active_count" -ne 1 ]]; then
 		print_result "CI repair distinguishes dispatch from a live lease" 1 "dispatches=${dispatch_count}, active=${active_count}"
 	else
 		print_result "CI repair dedupes and reports a live lease without false dispatch" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_dedupes_changed_evidence_for_same_head() {
+	setup_test_env
+	define_feedback_helpers || { print_result "defines feedback helpers for changed evidence" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_repair_session "100" "owner/repo" "42" "$TEST_PR_HEAD_SHA" "feature/repair" \
+		"fingerprint-one" "- **Lint**: failure — [check URL](https://github.com/owner/repo/actions/runs/123/job/456)"
+	_dispatch_ci_repair_session "100" "owner/repo" "42" "$TEST_PR_HEAD_SHA" "feature/repair" \
+		"fingerprint-two" "- **Unit**: failure — [check URL](https://github.com/owner/repo/actions/runs/124/job/789)"
+
+	local state_count=0 worktree_count=0
+	state_count=$(find "$AIDEVOPS_CI_REPAIR_STATE_DIR" -name state.json -type f | wc -l | tr -d ' ')
+	worktree_count=$(grep -c '^worktree add ' "$GH_LOG" || true)
+	if [[ "$state_count" -ne 1 || "$worktree_count" -ne 1 ]]; then
+		print_result "changed CI evidence shares one PR/head lease" 1 "states=${state_count}, worktrees=${worktree_count}"
+	else
+		print_result "changed CI evidence cannot overlap repair workers for one head" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_respects_live_legacy_lease() {
+	setup_test_env
+	define_feedback_helpers || { print_result "defines feedback helpers for legacy lease" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	local legacy_key="owner_repo-100-${TEST_PR_HEAD_SHA}-legacyfingerprint"
+	local legacy_dir="${AIDEVOPS_CI_REPAIR_STATE_DIR}/${legacy_key}"
+	local legacy_pid=""
+	sleep 30 &
+	legacy_pid=$!
+	mkdir -p "$legacy_dir"
+	printf '{"repo":"owner/repo","pr":100,"head":"%s","fingerprint":"legacyfingerprint","pid":%s,"status":"dispatched"}\n' \
+		"$TEST_PR_HEAD_SHA" "$legacy_pid" >"${legacy_dir}/state.json"
+	mkdir -p "${AIDEVOPS_HEADLESS_RUNTIME_DIR}/locks"
+	printf '%s|\n' "$legacy_pid" >"${AIDEVOPS_HEADLESS_RUNTIME_DIR}/locks/ci-repair-100-${TEST_PR_HEAD_SHA:0:12}-legacyfinger.pid"
+	_dispatch_ci_repair_session "100" "owner/repo" "42" "$TEST_PR_HEAD_SHA" "feature/repair" \
+		"new-fingerprint" "- **Lint**: failure — [check URL](https://github.com/owner/repo/actions/runs/123/job/456)"
+	kill "$legacy_pid" 2>/dev/null || true
+	wait "$legacy_pid" 2>/dev/null || true
+
+	local worktree_count=0
+	worktree_count=$(grep -c '^worktree add ' "$GH_LOG" || true)
+	if [[ "$worktree_count" -ne 0 || "${_CI_REPAIR_DISPATCH_RESULT:-}" != "active" ]]; then
+		print_result "live legacy CI lease blocks migrated overlap" 1 "worktrees=${worktree_count}, result=${_CI_REPAIR_DISPATCH_RESULT:-unset}"
+	else
+		print_result "live legacy fingerprint lease remains exclusive during migration" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_session_keys_are_repository_scoped() {
+	setup_test_env
+	define_feedback_helpers || { print_result "defines feedback helpers for repository session keys" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	local first_key="" second_key=""
+	first_key=$(_ci_repair_session_key "acme/foo_bar" "100" "$TEST_PR_HEAD_SHA")
+	second_key=$(_ci_repair_session_key "acme_foo/bar" "100" "$TEST_PR_HEAD_SHA")
+	if [[ "$first_key" == "$second_key" ]]; then
+		print_result "CI repair session keys include repository identity" 1 "first=${first_key}, second=${second_key}"
+	else
+		print_result "flattening-collision repository slugs have isolated session keys" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_worktree_paths_are_repository_scoped() {
+	setup_test_env
+	define_feedback_helpers || { print_result "defines feedback helpers for repository worktrees" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	local first_path="" second_path=""
+	first_path=$(_ci_repair_create_worktree "${TEST_ROOT}/repo" "first/repo" "42" "100" "$TEST_PR_HEAD_SHA" \
+		"feature/repair" "fingerprint" "1")
+	second_path=$(_ci_repair_create_worktree "${TEST_ROOT}/repo" "second/repo" "42" "100" "$TEST_PR_HEAD_SHA" \
+		"feature/repair" "fingerprint" "1")
+	if [[ "$first_path" == "$second_path" || -z "$first_path" || -z "$second_path" ]]; then
+		print_result "CI repair worktree paths include repository identity" 1 "first=${first_path}, second=${second_path}"
+	elif ! grep -q " ${AIDEVOPS_CI_REPAIR_WORKTREE_BASE_DIR}$" "$GH_LOG"; then
+		print_result "CI-specific worktree base reaches worktree helper validation" 1 "Log: $(cat "$GH_LOG")"
+	else
+		print_result "same-basename repositories have isolated repair worktrees" 0
 	fi
 	teardown_test_env
 	return 0
@@ -563,6 +671,40 @@ test_ci_feedback_emits_terminal_failure_with_conclusion_and_url() {
 	return 0
 }
 
+test_ci_feedback_defers_when_head_changes_during_collection() {
+	setup_test_env
+	export TEST_INITIAL_PR_HEAD_SHA="1111111111111111111111111111111111111111"
+	define_feedback_helpers || { print_result "defines feedback helpers for moving head" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+	if grep -q '^worktree add ' "$GH_LOG"; then
+		print_result "moving PR head defers stale CI evidence" 1 "Dispatch log: $(cat "$GH_LOG")"
+	elif ! grep -qF 'head changed while collecting CI evidence' "$LOGFILE"; then
+		print_result "moving PR head records repair deferral" 1 "Log: $(cat "$LOGFILE")"
+	else
+		print_result "CI evidence is not bound to a concurrently changed head" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_feedback_defers_without_initial_head_snapshot() {
+	setup_test_env
+	export TEST_INITIAL_PR_HEAD_EMPTY="1"
+	define_feedback_helpers || { print_result "defines feedback helpers for missing head snapshot" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+	if grep -q '^worktree add ' "$GH_LOG"; then
+		print_result "missing PR head snapshot defers CI repair" 1 "Dispatch log: $(cat "$GH_LOG")"
+	elif ! grep -qF 'head snapshot unavailable' "$LOGFILE"; then
+		print_result "missing PR head snapshot records repair deferral" 1 "Log: $(cat "$LOGFILE")"
+	else
+		print_result "CI repair fails closed without an initial head snapshot" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_ci_feedback_skips_infra_timeout_checks() {
 	setup_test_env
 	TEST_CHECK_SCENARIO="infra_timeout"
@@ -610,6 +752,23 @@ test_ci_feedback_skips_registry_rate_limit_failure() {
 		print_result "registry rate limit records infrastructure classification" 1 "Log: $(cat "$LOGFILE")"
 	else
 		print_result "registry rate limit is classified as infrastructure" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_feedback_skips_dockerhub_pull_rate_limit_failure() {
+	setup_test_env
+	TEST_CHECK_SCENARIO="infra_dockerhub_rate_limit"
+	define_feedback_helpers || { print_result "defines feedback helpers for Docker Hub rate limit" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+	if grep -qF 'PR #100: CI repair' "$GH_LOG"; then
+		print_result "Docker Hub pull rate limit does not dispatch code repair" 1 "Dispatch log: $(cat "$GH_LOG")"
+	elif ! grep -qF 'classified as infrastructure failure' "$LOGFILE"; then
+		print_result "Docker Hub pull rate limit records infrastructure classification" 1 "Log: $(cat "$LOGFILE")"
+	else
+		print_result "Docker Hub unauthenticated pull limit is classified as infrastructure" 0
 	fi
 	teardown_test_env
 	return 0
@@ -740,13 +899,20 @@ main() {
 	test_rest_missing_review_decision_refreshes_before_ci_route
 	test_coderabbit_nits_ok_dismissed_once_before_late_gate
 	test_changes_requested_explicit_empty_labels_skip_refetch
-	test_ci_repair_dedupes_by_repo_pr_head_and_fingerprint
+	test_ci_repair_dedupes_identical_evidence_for_same_head
+	test_ci_repair_dedupes_changed_evidence_for_same_head
+	test_ci_repair_respects_live_legacy_lease
+	test_ci_repair_session_keys_are_repository_scoped
+	test_ci_repair_worktree_paths_are_repository_scoped
 	test_ci_feedback_skips_pending_only_checks
 	test_ci_feedback_skips_mixed_pending_pass_checks
 	test_ci_feedback_emits_terminal_failure_with_conclusion_and_url
+	test_ci_feedback_defers_when_head_changes_during_collection
+	test_ci_feedback_defers_without_initial_head_snapshot
 	test_ci_feedback_skips_infra_timeout_checks
 	test_ci_feedback_skips_failed_check_with_exit_143_log
 	test_ci_feedback_skips_registry_rate_limit_failure
+	test_ci_feedback_skips_dockerhub_pull_rate_limit_failure
 	test_ci_repair_recovers_one_stale_lease_then_exhausts
 	test_ci_repair_consumes_abandoned_append_only_claim
 	test_ci_repair_waits_for_prelock_startup_before_retry

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -307,11 +307,12 @@ define_feedback_helpers() {
 		_ci_repair_pid_is_live
 		_ci_repair_publish_lock_owner
 		_ci_repair_lock_is_stale
-		_ci_repair_acquire_lock
-		_ci_repair_release_lock
+		_ci_repair_claim_dir_is_active
 		_ci_repair_status_preparing
 		_ci_repair_status_dispatched
 		_ci_repair_result_active
+		_ci_repair_result_exhausted
+		_ci_repair_claim_next_attempt
 		_ci_repair_latest_archive
 		_ci_repair_prepare_attempt
 		_ci_repair_adopt_live_session
@@ -645,30 +646,55 @@ test_ci_repair_recovers_one_stale_lease_then_exhausts() {
 	return 0
 }
 
-test_ci_repair_recovers_incomplete_state_and_dead_lock() {
+test_ci_repair_consumes_abandoned_append_only_claim() {
 	setup_test_env
-	export AIDEVOPS_CI_REPAIR_STATE_GRACE_SECONDS="0"
+	export AIDEVOPS_CI_REPAIR_LOCK_GRACE_SECONDS="0"
 	define_feedback_helpers || { print_result "defines feedback helpers for incomplete lease" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
 
 	local lease_dir="${AIDEVOPS_CI_REPAIR_STATE_DIR}/incomplete"
 	local action=""
-	mkdir -p "${lease_dir}/transition.lock"
-	printf '{"pid":999999,"pid_start":"stale"}\n' >"${lease_dir}/transition.lock/owner.json"
-	_ci_repair_acquire_lock "${lease_dir}/transition.lock" || {
-		print_result "dead CI repair transition lock is reclaimed" 1 "could not acquire stale lock"
-		teardown_test_env
-		return 0
-	}
+	mkdir -p "${lease_dir}/attempt-1.claim"
+	printf '{"pid":999999,"pid_start":"stale"}\n' >"${lease_dir}/attempt-1.claim/owner.json"
 	action=$(_ci_repair_claim_lease "$lease_dir" "owner/repo" "100" "$TEST_PR_HEAD_SHA" \
 		"fingerprint" "2" "feature/repair" "ci-repair-test")
-	_ci_repair_release_lock "${lease_dir}/transition.lock" || true
 
-	if [[ "$action" != "launch|1|" ]]; then
-		print_result "incomplete CI repair lease is reclaimed" 1 "action=${action}"
-	elif ! jq -e '.status == "preparing" and .attempt == 1 and .session == "ci-repair-test"' "${lease_dir}/state.json" >/dev/null; then
+	if [[ "$action" != "launch|2|" ]]; then
+		print_result "abandoned CI repair attempt advances safely" 1 "action=${action}"
+	elif ! jq -e '.status == "preparing" and .attempt == 2 and .session == "ci-repair-test"' "${lease_dir}/state.json" >/dev/null; then
 		print_result "reclaimed CI repair state is complete JSON" 1 "State: $(cat "${lease_dir}/state.json")"
 	else
-		print_result "incomplete CI repair state and dead lock are reclaimed atomically" 0
+		print_result "abandoned append-only claim is consumed without lock replacement" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_waits_for_prelock_startup_before_retry() {
+	setup_test_env
+	export AIDEVOPS_CI_REPAIR_LOCK_GRACE_SECONDS="0"
+	export AIDEVOPS_CI_REPAIR_LAUNCH_GRACE_SECONDS="240"
+	define_feedback_helpers || { print_result "defines feedback helpers for startup grace" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	local lease_dir="${AIDEVOPS_CI_REPAIR_STATE_DIR}/startup-grace"
+	local state_file="${lease_dir}/state.json"
+	local action="" expired_action=""
+	mkdir -p "${lease_dir}/attempt-1.claim"
+	printf '{"pid":999999,"pid_start":"stale"}\n' >"${lease_dir}/attempt-1.claim/owner.json"
+	_ci_repair_write_state "$state_file" "owner/repo" "100" "$TEST_PR_HEAD_SHA" "feature/repair" \
+		"fingerprint" "${TEST_ROOT}/worktrees/preserved" "999999" "stale" "1" "preparing" "ci-repair-test"
+	action=$(_ci_repair_claim_lease "$lease_dir" "owner/repo" "100" "$TEST_PR_HEAD_SHA" \
+		"fingerprint" "2" "feature/repair" "ci-repair-test")
+	jq '.updated_at = 0' "$state_file" >"${state_file}.tmp"
+	mv "${state_file}.tmp" "$state_file"
+	expired_action=$(_ci_repair_claim_lease "$lease_dir" "owner/repo" "100" "$TEST_PR_HEAD_SHA" \
+		"fingerprint" "2" "feature/repair" "ci-repair-test")
+
+	if [[ "$action" != "active" ]]; then
+		print_result "pre-lock startup grace suppresses duplicate launch" 1 "action=${action}"
+	elif [[ "$expired_action" != "launch|2|${TEST_ROOT}/worktrees/preserved" ]]; then
+		print_result "expired startup grace permits bounded retry" 1 "expired_action=${expired_action}"
+	else
+		print_result "pre-lock startup grace blocks overlap then permits bounded retry" 0
 	fi
 	teardown_test_env
 	return 0
@@ -722,7 +748,8 @@ main() {
 	test_ci_feedback_skips_failed_check_with_exit_143_log
 	test_ci_feedback_skips_registry_rate_limit_failure
 	test_ci_repair_recovers_one_stale_lease_then_exhausts
-	test_ci_repair_recovers_incomplete_state_and_dead_lock
+	test_ci_repair_consumes_abandoned_append_only_claim
+	test_ci_repair_waits_for_prelock_startup_before_retry
 	test_ci_feedback_skips_advisory_failure_when_required_clean
 
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -225,7 +225,7 @@ define_helpers_under_test() {
 		_append_feedback_to_issue
 		_transition_issue_for_redispatch
 		_close_and_label_feedback_pr
-		_ci_check_url_has_infra_timeout_log
+		_ci_check_url_has_infra_failure_log
 		_ci_actionable_failed_checks_markdown
 		_ci_terminal_failed_check_results
 		_build_ci_feedback_section

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -230,6 +230,7 @@ define_helpers_under_test() {
 		_ci_terminal_failed_check_results
 		_build_ci_feedback_section
 		_route_ci_repair_fallback
+		_ci_repair_hash_text
 		_dispatch_ci_fix_worker
 		_dispatch_pr_fix_worker
 	)
@@ -541,6 +542,8 @@ test_ci_dispatch_dedupes_by_pr_head_marker() {
 
 	_dispatch_ci_fix_worker "100" "owner/repo" "42"
 	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+	_route_ci_repair_fallback "100" "owner/repo" "42" "abc123repairsha" "feature/worker" \
+		"changed-fingerprint" "retry budget exhausted" "## CI Failure Feedback" "- **Unit**: failure"
 
 	local body_edit_count pr_close_count
 	body_edit_count=$(grep -cE 'gh issue edit 42 --repo owner/repo --body' "$GH_LOG" 2>/dev/null || true)
@@ -558,8 +561,8 @@ test_ci_dispatch_dedupes_by_pr_head_marker() {
 			"Expected 1 PR close, got ${pr_close_count}. Log: $(cat "$GH_LOG")"
 		return 0
 	fi
-	if ! grep -qF '<!-- ci-feedback-fallback:PR100:SHAabc123repairsha:FP' "${TEST_ROOT}/issue-body.txt"; then
-		print_result "CI repair fallback stores PR/head/fingerprint marker" 1 \
+	if ! grep -qF '<!-- ci-feedback-fallback:PR100:SHAabc123repairsha -->' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "CI repair fallback stores PR/head marker" 1 \
 			"Expected fallback marker in issue body. Body: $(cat "${TEST_ROOT}/issue-body.txt")"
 		return 0
 	fi
@@ -568,7 +571,7 @@ test_ci_dispatch_dedupes_by_pr_head_marker() {
 			"Expected duplicate skip log. Log: $(cat "$LOGFILE")"
 		return 0
 	fi
-	print_result "CI repair fallback dedupes per PR/head/fingerprint" 0
+	print_result "CI repair fallback dedupes changed evidence per PR/head" 0
 	return 0
 }
 

--- a/TODO.md
+++ b/TODO.md
@@ -1141,6 +1141,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18113 Harden pulse throughput and full-loop continuity #type:bug ref:GH#27452
 
+- [ ] t18114 Fix CI repair infrastructure classification and dead lease recovery #bug #priority:high ref:GH#27487
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Classify transient registry failures without code redispatch; bind repair workers to exact PR heads in dedicated worktrees; recover stale leases with bounded, PR/head-scoped retries and collision-safe session identity.

## Files Changed

.agents/scripts/pulse-merge-feedback.sh, .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh, TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 24 CI repair routing tests and 9 fallback dispatch tests pass; ShellCheck and local quality gates pass.

Resolves #27487


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.88 with gpt-5.6-sol spent 1h 55m and 1,248,870 tokens on this with the user in an interactive session.