### PR TITLE
t18116: Harden quality-debt dispatch recovery

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -259,9 +259,14 @@ _stale_recovery_escalate() {
 	IFS=',' read -ra _esc_assignee_arr <<<"$stale_assignees"
 	IFS="$_esc_ifs"
 	# t2033: build remove-assignee flags and clear all core status labels
-	# in one atomic edit via set_issue_status (empty target = clear only,
-	# pass-through --add-label "needs-maintainer-review").
-	local -a _esc_extra=(--add-label "needs-maintainer-review")
+	# in one atomic edit via set_issue_status (empty target = clear only).
+	# NMR is a dispatch hold, so remove auto-dispatch in the same mutation;
+	# otherwise a racing recovery can restore status:available and make the
+	# held issue look runnable to idle-backoff even though dispatch rejects it.
+	local -a _esc_extra=(
+		--add-label "needs-maintainer-review"
+		--remove-label "auto-dispatch"
+	)
 	for _esc_assignee in "${_esc_assignee_arr[@]}"; do
 		_esc_extra+=(--remove-assignee "$_esc_assignee")
 	done

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1788,7 +1788,11 @@ dispatch_with_dedup() {
 		"$model_override" "$issue_meta_json" || _launch_rc=$?
 	_ds_record "$issue_number" "$repo_slug" "worker_launch_total" "$_ds_t0"
 	if [[ "$_launch_rc" -ne 0 ]]; then
-		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "worker_launch_rc_${_launch_rc}"
+		local _launch_abort_reason="worker_launch_rc_${_launch_rc}"
+		if [[ -n "${_DLW_LAST_PRE_RUNTIME_FAILURE:-}" ]]; then
+			_launch_abort_reason="${_launch_abort_reason}:${_DLW_LAST_PRE_RUNTIME_FAILURE}"
+		fi
+		_release_dispatch_claim_on_abort "$issue_number" "$repo_slug" "$self_login" "$_launch_abort_reason"
 	fi
 
 	# t3034: record total ceremony time

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -2168,6 +2168,26 @@ _dlw_preclaim_state_refresh_or_skip() {
 }
 
 #######################################
+# Record why dispatch stopped before the canonical worker runtime started.
+# Canonical runtime metrics must not include attempts that never crossed the
+# runtime boundary, so this evidence remains in the issue-correlated dispatch
+# stage stream and pulse log.
+# Args: issue number, repo slug, low-cardinality reason, return code
+#######################################
+_dlw_pre_runtime_failure() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local reason="$3"
+	local return_code="${4:-2}"
+	_DLW_LAST_PRE_RUNTIME_FAILURE="$reason"
+	local failure_started_ns=""
+	failure_started_ns=$(_ds_now_ns)
+	_ds_record "$issue_number" "$repo_slug" "pre_runtime_failure:${reason}" "$failure_started_ns"
+	echo "[dispatch_with_dedup] PRE_RUNTIME_FAILURE issue=${issue_number} repo=${repo_slug} reason=${reason}" >>"$LOGFILE"
+	return "$return_code"
+}
+
+#######################################
 # Thin orchestrator for worker launch. Delegates each distinct concern
 # (assignment + labels, log files, model resolution, issue lock, repo pull,
 # worktree pre-creation, nohup launch, post-launch bookkeeping) to dedicated
@@ -2197,6 +2217,7 @@ _dispatch_launch_worker() {
 	local session_key="$8"
 	local model_override="$9"
 	local issue_meta_json="${10}"
+	_DLW_LAST_PRE_RUNTIME_FAILURE=""
 
 	# t3034: per-stage timing for launch sub-stages
 	local _ds_t0
@@ -2205,7 +2226,8 @@ _dispatch_launch_worker() {
 	worker_log=$(_dlw_setup_worker_log "$repo_slug" "$issue_number")
 
 	if ! _dlw_prebootstrap_gates "$issue_number" "$repo_slug" "$issue_meta_json" "$repo_path"; then
-		return 2
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "prebootstrap_gate" 2
+		return $?
 	fi
 
 	_ds_t0=$(_ds_now_ns)
@@ -2217,27 +2239,34 @@ _dispatch_launch_worker() {
 	if ! _dlw_canary_preflight "$issue_number" "$repo_slug" "$worker_log" \
 		"$dispatch_model_tier" "$selected_model"; then
 		_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
-		return 2
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "canary_preflight" 2
+		return $?
 	fi
 	_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
 
-	_dlw_preclaim_state_refresh_or_skip "$issue_number" "$repo_slug" || return 2
+	if ! _dlw_preclaim_state_refresh_or_skip "$issue_number" "$repo_slug"; then
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "preclaim_state_changed" 2
+		return $?
+	fi
 
 	if ! _dlw_claim_lock_after_canary "$issue_number" "$repo_slug" "$self_login"; then
-		return 2
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "claim_lock_failed" 2
+		return $?
 	fi
 
 	_ds_t0=$(_ds_now_ns)
 	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json" || {
 		_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
-		return 2
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "assignment_failed" 2
+		return $?
 	}
 	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
 
 	local zero_output_comment_metrics=""
 	zero_output_comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
 	if _dlw_hold_repeated_zero_output "$issue_number" "$repo_slug" "$zero_output_comment_metrics"; then
-		return 2
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "repeated_zero_output_hold" 2
+		return $?
 	fi
 
 	# t1894/t1934: Lock issue and linked PRs during worker execution
@@ -2252,14 +2281,16 @@ _dispatch_launch_worker() {
 		_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
 		pulse_stats_increment "worktree_precreation_failed_count" 2>/dev/null || true
 		echo "[dispatch_with_dedup] Skipping #${issue_number} — pre-creation failed; will retry next cycle" >>"$LOGFILE"
-		return 2
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worktree_precreation_failed" 2
+		return $?
 	fi
 	_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
 	local worker_worktree_path="$_DLW_WORKTREE_PATH"
 	local worker_worktree_branch="$_DLW_WORKTREE_BRANCH"
 	local worker_worktree_reused="${_DLW_WORKTREE_REUSED:-0}"
 	if _dlw_check_worker_branch_orphan_loop "$issue_number" "$repo_slug" "$worker_worktree_branch" "$worker_worktree_reused" "${repo_path}/TODO.md" "$worker_worktree_path"; then
-		return 2
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worker_branch_orphan_hold" 2
+		return $?
 	fi
 
 	_ds_t0=$(_ds_now_ns)

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -2187,6 +2187,8 @@ _dlw_pre_runtime_failure() {
 	return "$return_code"
 }
 
+DLW_STAGE_CANARY_PREFLIGHT="canary_preflight"
+
 #######################################
 # Thin orchestrator for worker launch. Delegates each distinct concern
 # (assignment + labels, log files, model resolution, issue lock, repo pull,
@@ -2226,8 +2228,7 @@ _dispatch_launch_worker() {
 	worker_log=$(_dlw_setup_worker_log "$repo_slug" "$issue_number")
 
 	if ! _dlw_prebootstrap_gates "$issue_number" "$repo_slug" "$issue_meta_json" "$repo_path"; then
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "prebootstrap_gate" 2
-		return $?
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "prebootstrap_gate" 2 || return $?
 	fi
 
 	_ds_t0=$(_ds_now_ns)
@@ -2238,35 +2239,30 @@ _dispatch_launch_worker() {
 	_ds_t0=$(_ds_now_ns)
 	if ! _dlw_canary_preflight "$issue_number" "$repo_slug" "$worker_log" \
 		"$dispatch_model_tier" "$selected_model"; then
-		_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "canary_preflight" 2
-		return $?
+		_ds_record "$issue_number" "$repo_slug" "$DLW_STAGE_CANARY_PREFLIGHT" "$_ds_t0"
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "$DLW_STAGE_CANARY_PREFLIGHT" 2 || return $?
 	fi
-	_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
+	_ds_record "$issue_number" "$repo_slug" "$DLW_STAGE_CANARY_PREFLIGHT" "$_ds_t0"
 
 	if ! _dlw_preclaim_state_refresh_or_skip "$issue_number" "$repo_slug"; then
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "preclaim_state_changed" 2
-		return $?
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "preclaim_state_changed" 2 || return $?
 	fi
 
 	if ! _dlw_claim_lock_after_canary "$issue_number" "$repo_slug" "$self_login"; then
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "claim_lock_failed" 2
-		return $?
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "claim_lock_failed" 2 || return $?
 	fi
 
 	_ds_t0=$(_ds_now_ns)
 	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json" || {
 		_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "assignment_failed" 2
-		return $?
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "assignment_failed" 2 || return $?
 	}
 	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
 
 	local zero_output_comment_metrics=""
 	zero_output_comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
 	if _dlw_hold_repeated_zero_output "$issue_number" "$repo_slug" "$zero_output_comment_metrics"; then
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "repeated_zero_output_hold" 2
-		return $?
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "repeated_zero_output_hold" 2 || return $?
 	fi
 
 	# t1894/t1934: Lock issue and linked PRs during worker execution
@@ -2281,16 +2277,14 @@ _dispatch_launch_worker() {
 		_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
 		pulse_stats_increment "worktree_precreation_failed_count" 2>/dev/null || true
 		echo "[dispatch_with_dedup] Skipping #${issue_number} — pre-creation failed; will retry next cycle" >>"$LOGFILE"
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worktree_precreation_failed" 2
-		return $?
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worktree_precreation_failed" 2 || return $?
 	fi
 	_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
 	local worker_worktree_path="$_DLW_WORKTREE_PATH"
 	local worker_worktree_branch="$_DLW_WORKTREE_BRANCH"
 	local worker_worktree_reused="${_DLW_WORKTREE_REUSED:-0}"
 	if _dlw_check_worker_branch_orphan_loop "$issue_number" "$repo_slug" "$worker_worktree_branch" "$worker_worktree_reused" "${repo_path}/TODO.md" "$worker_worktree_path"; then
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worker_branch_orphan_hold" 2
-		return $?
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worker_branch_orphan_hold" 2 || return $?
 	fi
 
 	_ds_t0=$(_ds_now_ns)

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -1682,9 +1682,20 @@ auto_approve_maintainer_issues() {
 Auto-approved: ${approval_reason}. Stale recovery tick reset." \
 					2>/dev/null || true
 
-				gh issue edit "$issue_num" --repo "$slug" \
-					--remove-label "needs-maintainer-review" \
-					--add-label "auto-dispatch" >/dev/null 2>&1
+				# Restore the complete dispatchable state in one status mutation.
+				# Stale escalation removes both core status labels and auto-dispatch;
+				# approval must therefore restore status:available as well as the
+				# routing label, rather than depending on a racing recovery writer.
+				if declare -F set_issue_status >/dev/null 2>&1; then
+					set_issue_status "$issue_num" "$slug" "available" \
+						--remove-label "needs-maintainer-review" \
+						--add-label "auto-dispatch" >/dev/null 2>&1
+				else
+					gh issue edit "$issue_num" --repo "$slug" \
+						--remove-label "needs-maintainer-review" \
+						--add-label "status:available" \
+						--add-label "auto-dispatch" >/dev/null 2>&1
+				fi
 				local edit_exit=$?
 				if [[ "$edit_exit" -eq 0 ]]; then
 					echo "[pulse-wrapper] Auto-approved #${issue_num} in ${slug} — ${approval_reason} (locked + approval marker + tick reset)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -1592,6 +1592,28 @@ Knowledge source \`${source_id}\` promoted from staging to \`sources/\` after cr
 }
 
 #######################################
+# Restore the complete dispatchable state after trusted NMR approval.
+# Stale escalation removes both core status labels and auto-dispatch, so the
+# approval transition must not depend on a racing recovery writer.
+# Args: issue number, repo slug
+#######################################
+_nmr_restore_dispatchable_state() {
+	local issue_num="$1"
+	local slug="$2"
+	if declare -F set_issue_status >/dev/null 2>&1; then
+		set_issue_status "$issue_num" "$slug" "available" \
+			--remove-label "needs-maintainer-review" \
+			--add-label "auto-dispatch" >/dev/null 2>&1
+		return $?
+	fi
+	gh issue edit "$issue_num" --repo "$slug" \
+		--remove-label "needs-maintainer-review" \
+		--add-label "status:available" \
+		--add-label "auto-dispatch" >/dev/null 2>&1
+	return $?
+}
+
+#######################################
 # Auto-approve needs-maintainer-review issues using cryptographic
 # signature verification (t1894, replaces GH#16842 comment-based check).
 #
@@ -1682,20 +1704,7 @@ auto_approve_maintainer_issues() {
 Auto-approved: ${approval_reason}. Stale recovery tick reset." \
 					2>/dev/null || true
 
-				# Restore the complete dispatchable state in one status mutation.
-				# Stale escalation removes both core status labels and auto-dispatch;
-				# approval must therefore restore status:available as well as the
-				# routing label, rather than depending on a racing recovery writer.
-				if declare -F set_issue_status >/dev/null 2>&1; then
-					set_issue_status "$issue_num" "$slug" "available" \
-						--remove-label "needs-maintainer-review" \
-						--add-label "auto-dispatch" >/dev/null 2>&1
-				else
-					gh issue edit "$issue_num" --repo "$slug" \
-						--remove-label "needs-maintainer-review" \
-						--add-label "status:available" \
-						--add-label "auto-dispatch" >/dev/null 2>&1
-				fi
+				_nmr_restore_dispatchable_state "$issue_num" "$slug"
 				local edit_exit=$?
 				if [[ "$edit_exit" -eq 0 ]]; then
 					echo "[pulse-wrapper] Auto-approved #${issue_num} in ${slug} — ${approval_reason} (locked + approval marker + tick reset)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -56,7 +56,7 @@ _pulse_available_auto_dispatch_work_exists() {
 		[[ -n "$_slug" ]] || continue
 		local _count=""
 		_count=$(gh api -X GET search/issues \
-			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available no:assignee" \
+			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:needs-maintainer-review no:assignee" \
 			-f per_page=1 \
 			--jq '.total_count // 0' 2>/dev/null) || _count=""
 		[[ "$_count" =~ ^[0-9]+$ ]] || _count=0

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -509,6 +509,13 @@ else
 	fail "dispatch skip returns explicit no-op rc=2" "got rc=$launch_rc"
 fi
 
+if [[ "${_DLW_LAST_PRE_RUNTIME_FAILURE:-}" == "worktree_precreation_failed" ]] && \
+	grep -q "PRE_RUNTIME_FAILURE issue=77777 repo=owner/repo reason=worktree_precreation_failed" "$LOGFILE" 2>/dev/null; then
+	pass "pre-runtime failure records issue-correlated worktree reason"
+else
+	fail "pre-runtime failure records issue-correlated worktree reason" "reason=${_DLW_LAST_PRE_RUNTIME_FAILURE:-unset}; log=$(cat "$LOGFILE")"
+fi
+
 if grep -q '^77777$' "$CLAIM_LOCK_CALLS_FILE" 2>/dev/null; then
 	pass "pre-creation failure happens after claim lock"
 else

--- a/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
@@ -35,12 +35,14 @@ setup_test_env() {
 	export LOGFILE="${TEST_ROOT}/pulse.log"
 	export REPOS_JSON="${TEST_ROOT}/repos.json"
 	export POSTED_COMMENT="${TEST_ROOT}/posted-comment.txt"
+	export STATUS_CALLS_FILE="${TEST_ROOT}/status-calls.txt"
 	export ISSUE_ASSOC="OWNER"
 	export ISSUE_API_AUTHOR="maintainer"
 	export ISSUE_LIST_AUTHOR="maintainer"
 	export ACTOR_PERMISSION="write"
 	: >"$LOGFILE"
 	: >"$POSTED_COMMENT"
+	: >"$STATUS_CALLS_FILE"
 	printf '{"initialized_repos":[{"slug":"owner/repo","maintainer":"maintainer","pulse":true}]}' >"$REPOS_JSON"
 	cat >"${TEST_ROOT}/bin/gh" <<'GH_STUB'
 #!/usr/bin/env bash
@@ -126,6 +128,12 @@ gh_issue_comment() {
 }
 export -f gh_issue_comment
 
+set_issue_status() {
+	printf '%s\n' "$*" >"$STATUS_CALLS_FILE"
+	return 0
+}
+export -f set_issue_status
+
 run_auto_approve() {
 	# shellcheck disable=SC1090
 	source "$NMR_SCRIPT"
@@ -184,6 +192,11 @@ test_allows_owner_author_with_write_permission() {
 		print_result "auto-approval allows upstream OWNER author and write-capable runner" 0
 	else
 		print_result "auto-approval allows upstream OWNER author and write-capable runner" 1 "approval comment missing"
+	fi
+	if grep -q -- '^24479 owner/repo available --remove-label needs-maintainer-review --add-label auto-dispatch$' "$STATUS_CALLS_FILE" 2>/dev/null; then
+		print_result "auto-approval atomically restores complete dispatchable state" 0
+	else
+		print_result "auto-approval atomically restores complete dispatchable state" 1 "status call: $(cat "$STATUS_CALLS_FILE")"
 	fi
 	teardown_test_env
 	return 0

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TMP=$(mktemp -d -t pulse-cycle-gates.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s %s\n' "$name" "$detail"
+	return 0
+}
+
+export SCRIPT_DIR="${TMP}/scripts"
+export WRAPPER_LOGFILE="${TMP}/wrapper.log"
+export PULSE_SCOPE_REPOS="owner/repo"
+mkdir -p "$SCRIPT_DIR"
+: >"$WRAPPER_LOGFILE"
+
+GH_QUERY_FILE="${TMP}/query.txt"
+export GH_QUERY_FILE
+gh() {
+	printf '%s\n' "$*" >"$GH_QUERY_FILE"
+	printf '0\n'
+	return 0
+}
+
+SOURCE_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/pulse-wrapper-cycle-gates.sh"
+# shellcheck disable=SC1090
+source "$SOURCE_SCRIPT"
+
+if _pulse_available_auto_dispatch_work_exists; then
+	fail "zero eligible issues does not bypass idle backoff"
+else
+	pass "zero eligible issues does not bypass idle backoff"
+fi
+
+if grep -q -- '-label:needs-maintainer-review' "$GH_QUERY_FILE"; then
+	pass "idle-work query excludes NMR-held issues"
+else
+	fail "idle-work query excludes NMR-held issues" "query=$(cat "$GH_QUERY_FILE")"
+fi
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0

--- a/.agents/scripts/tests/test-stale-recovery-escalation.sh
+++ b/.agents/scripts/tests/test-stale-recovery-escalation.sh
@@ -215,6 +215,14 @@ else
 	print_result "Escalation: status:available NOT added (correct; only removed if present)" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null))"
 fi
 
+# auto-dispatch must be removed in the same escalation mutation so a later
+# status recovery cannot make this NMR-held issue appear runnable.
+if grep -q -- "--remove-label auto-dispatch" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "Escalation: auto-dispatch removed with NMR hold" 0
+else
+	print_result "Escalation: auto-dispatch removed with NMR hold" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null))"
+fi
+
 # =============================================================================
 # Test 4 — Reset path: open PR detected → counter reset, STALE_RECOVERED
 # =============================================================================

--- a/TODO.md
+++ b/TODO.md
@@ -1143,6 +1143,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18114 Fix CI repair infrastructure classification and dead lease recovery #bug #priority:high ref:GH#27487
 
+- [ ] t18116 Fix quality-debt dispatch recovery state and pre-runtime telemetry #bug #priority:high ref:GH#27503
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Keep NMR-held issues out of idle dispatch accounting, make stale escalation remove auto-dispatch, restore complete dispatchable state only after trusted approval, and retain issue-correlated pre-runtime failure reasons.

## Files Changed

.agents/scripts/dispatch-dedup-stale.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/pulse-nmr-approval.sh, .agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/tests/test-precreation-failure-skip.sh, .agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh, .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh, .agents/scripts/tests/test-stale-recovery-escalation.sh, TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused dispatch, NMR, stale-recovery, lifecycle, and no-work tests; ShellCheck on changed shell files; git diff --check; function-complexity regression gate; .agents/scripts/linters-local.sh.

Resolves #27503


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.88 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 24m and 359,133 tokens on this with the user in an interactive session.