### PR TITLE
GH#27500: record correlated terminal dispatch telemetry

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -106,11 +106,18 @@ _lease_expiry() {
 }
 
 _append_tier_telemetry() {
-	local issue_number="$1" repo_slug="$2" dispatch_tier="$3" dispatch_model="$4" now="$5"
+	local issue_number="$1"
+	local repo_slug="$2"
+	local dispatch_tier="$3"
+	local dispatch_model="$4"
+	local now="$5"
+	local session_key="$6"
+	local attempt_id="$7"
 	local telemetry_file="${LEDGER_DIR}/tier-telemetry.jsonl"
 	jq -cn --arg inum "$issue_number" --arg slug "$repo_slug" \
 		--arg tier "$dispatch_tier" --arg model "$dispatch_model" --arg ts "$now" \
-		'{issue: $inum, repo: $slug, tier: $tier, model: $model, dispatched_at: $ts, outcome: "pending"}' \
+		--arg sk "$session_key" --arg aid "$attempt_id" \
+		'{schema: 2, attempt_id: $aid, session_key: $sk, issue: $inum, repo: $slug, tier: $tier, model: $model, dispatched_at: $ts, outcome: "pending"}' \
 		>>"$telemetry_file" 2>/dev/null || true
 	return 0
 }
@@ -424,6 +431,7 @@ cmd_register() {
 	[[ "$lease_ttl" =~ ^[0-9]+$ ]] || lease_ttl="$PRELAUNCH_TTL"
 	local lease_expires_at=""
 	lease_expires_at=$(_lease_expiry "$lease_ttl")
+	local attempt_id="${lease_token:-${session_key}:${now}:${dispatch_pid}}"
 
 	# Append new entry — use jq for safe JSON construction (handles special chars)
 	jq -cn \
@@ -436,12 +444,13 @@ cmd_register() {
 		--arg model "$dispatch_model" \
 		--arg worktree "$worktree_path" \
 		--arg token "$lease_token" \
+		--arg attempt "$attempt_id" \
 		--arg device "$runner_device" \
 		--argjson expires "$lease_expires_at" \
 		--arg status "$LEDGER_STATUS_ACTIVE" \
-		'{session_key: $sk, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: $status, updated_at: $ts, tier: $tier, model: $model, worktree_path: $worktree, lease_token:$token, runner_device:$device, lease_phase:"prelaunch", lease_expires_at:$expires}' \
+		'{session_key: $sk, attempt_id: $attempt, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: $status, updated_at: $ts, tier: $tier, model: $model, worktree_path: $worktree, lease_token:$token, runner_device:$device, lease_phase:"prelaunch", lease_expires_at:$expires}' \
 		>>"$LEDGER_FILE"
-	_append_tier_telemetry "$issue_number" "$repo_slug" "$dispatch_tier" "$dispatch_model" "$now"
+	_append_tier_telemetry "$issue_number" "$repo_slug" "$dispatch_tier" "$dispatch_model" "$now" "$session_key" "$attempt_id"
 
 	_release_lock
 	return 0
@@ -800,8 +809,8 @@ cmd_fail() {
 #######################################
 # Record dispatch outcome in the tier telemetry log
 #
-# Appends outcome to the append-only tier-telemetry.jsonl.
-# Called by workers on completion or by the escalation function on failure.
+# Appends one correlated terminal outcome to tier-telemetry.jsonl. The first
+# terminal event for an attempt wins, making retries and repeated cleanup safe.
 #
 # Args:
 #   --issue NUM          issue number
@@ -810,6 +819,9 @@ cmd_fail() {
 #   --reason REASON      escalation reason code (optional)
 #   --tokens NUM         tokens used (optional)
 #   --tier TIER          tier at dispatch time (optional, for context)
+#   --session-key KEY    worker session key (preferred correlation fallback)
+#   --lease-token TOKEN  dispatch lease token (preferred exact correlation)
+#   --attempt-id ID      explicit telemetry attempt ID
 #
 # Exit codes: 0 always (best-effort, never fatal)
 #######################################
@@ -820,6 +832,9 @@ cmd_record_outcome() {
 	local reason=""
 	local tokens="0"
 	local tier=""
+	local session_key=""
+	local lease_token=""
+	local attempt_id=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -847,26 +862,91 @@ cmd_record_outcome() {
 			tier="${2:-}"
 			shift 2
 			;;
+		--session-key)
+			session_key="${2:-}"
+			shift 2
+			;;
+		--lease-token)
+			lease_token="${2:-}"
+			shift 2
+			;;
+		--attempt-id)
+			attempt_id="${2:-}"
+			shift 2
+			;;
 		*) shift ;;
 		esac
 	done
 
 	[[ -n "$outcome" ]] || return 0
+	[[ "$tokens" =~ ^[0-9]+$ ]] || tokens=0
 
 	local telemetry_file="${LEDGER_DIR}/tier-telemetry.jsonl"
+	_ensure_ledger
+	touch "$telemetry_file" 2>/dev/null || return 0
+	if ! _acquire_lock; then
+		return 0
+	fi
+
+	[[ -n "$attempt_id" ]] || attempt_id="$lease_token"
+	local pending=""
+	pending=$(jq -sc \
+		--arg aid "$attempt_id" --arg sk "$session_key" \
+		--arg inum "$issue_number" --arg slug "$repo_slug" '
+		def attempt_key:
+			if ((.attempt_id // "") != "") then .attempt_id
+			else "legacy:\(.repo // ""):\(.issue // ""):\(.dispatched_at // ""):\(.tier // ""):\(.model // "")"
+			end;
+		. as $rows |
+		[.[] | select(.outcome == "pending") |
+			select(($aid == "" or attempt_key == $aid) and
+				($sk == "" or (.session_key // "") == $sk) and
+				($inum == "" or (.issue // "") == $inum) and
+				($slug == "" or (.repo // "") == $slug)) |
+			select(attempt_key as $key |
+				([$rows[] | select(.outcome != "pending" and (.attempt_id // "") == $key)] | length) == 0)] |
+		last // empty' "$telemetry_file" 2>/dev/null || true)
+
+	if [[ -n "$pending" ]]; then
+		attempt_id=$(printf '%s' "$pending" | jq -r '
+			if ((.attempt_id // "") != "") then .attempt_id
+			else "legacy:\(.repo // ""):\(.issue // ""):\(.dispatched_at // ""):\(.tier // ""):\(.model // "")"
+			end')
+		[[ -n "$session_key" ]] || session_key=$(printf '%s' "$pending" | jq -r '.session_key // ""')
+		[[ -n "$issue_number" ]] || issue_number=$(printf '%s' "$pending" | jq -r '.issue // ""')
+		[[ -n "$repo_slug" ]] || repo_slug=$(printf '%s' "$pending" | jq -r '.repo // ""')
+		tier=$(printf '%s' "$pending" | jq -r '.tier // ""')
+		local model=""
+		model=$(printf '%s' "$pending" | jq -r '.model // ""')
+	else
+		local model=""
+	fi
+
+	if [[ -n "$attempt_id" ]] && jq -e --arg aid "$attempt_id" \
+		'select(.outcome != "pending" and (.attempt_id // "") == $aid)' \
+		"$telemetry_file" >/dev/null 2>&1; then
+		_release_lock
+		return 0
+	fi
+
 	local now
 	now=$(_now_utc)
 
 	jq -cn \
+		--argjson schema 2 \
+		--arg aid "$attempt_id" \
+		--arg sk "$session_key" \
 		--arg inum "$issue_number" \
 		--arg slug "$repo_slug" \
 		--arg tier "$tier" \
+		--arg model "$model" \
 		--arg outcome "$outcome" \
 		--arg reason "$reason" \
 		--argjson tokens "${tokens:-0}" \
 		--arg ts "$now" \
-		'{issue: $inum, repo: $slug, tier: $tier, outcome: $outcome, reason: $reason, tokens: $tokens, completed_at: $ts}' \
+		'{schema: $schema, attempt_id: $aid, session_key: $sk, issue: $inum, repo: $slug, tier: $tier, model: $model, outcome: $outcome, reason: $reason, tokens: $tokens, completed_at: $ts}' \
 		>>"$telemetry_file" 2>/dev/null || true
+	_release_lock
 
 	return 0
 }
@@ -887,35 +967,43 @@ cmd_tier_report() {
 		return 0
 	fi
 
-	local total success escalated failed
-	total=$(wc -l <"$telemetry_file" | tr -d ' ')
-	success=$(grep -c '"outcome":"success"' "$telemetry_file" 2>/dev/null) || success=0
-	escalated=$(grep -c '"outcome":"escalated"' "$telemetry_file" 2>/dev/null) || escalated=0
-	failed=$(grep -c "\"outcome\":\"${LEDGER_STATUS_FAILED}\"" "$telemetry_file" 2>/dev/null) || failed=0
+	local total success escalated failed terminal pending_unknown
+	total=$(jq -s '[.[] | select(.outcome == "pending")] | length' "$telemetry_file" 2>/dev/null) || total=0
+	success=$(jq -s '[.[] | select(.outcome == "success")] | length' "$telemetry_file" 2>/dev/null) || success=0
+	escalated=$(jq -s '[.[] | select(.outcome == "escalated")] | length' "$telemetry_file" 2>/dev/null) || escalated=0
+	failed=$(jq -s --arg failed "$LEDGER_STATUS_FAILED" '[.[] | select(.outcome == $failed)] | length' "$telemetry_file" 2>/dev/null) || failed=0
+	terminal=$(jq -s '[.[] | select(.outcome != "pending")] | length' "$telemetry_file" 2>/dev/null) || terminal=0
+	pending_unknown=$((total - terminal))
+	[[ "$pending_unknown" -ge 0 ]] || pending_unknown=0
 
 	echo "=== Tier Dispatch Telemetry ==="
 	echo "Total dispatches: $total"
 	echo "Success: $success"
 	echo "Escalated: $escalated"
 	echo "Failed: $failed"
+	echo "Pending/unknown: $pending_unknown"
 	echo ""
 	echo "By tier:"
-	jq -r '.tier' "$telemetry_file" 2>/dev/null | sort | uniq -c | sort -rn
+	jq -r 'select(.outcome == "pending") | .tier' "$telemetry_file" 2>/dev/null | sort | uniq -c | sort -rn
 	echo ""
 	echo "Escalation reasons:"
 	jq -r 'select(.reason != "" and .reason != null) | .reason' "$telemetry_file" 2>/dev/null | sort | uniq -c | sort -rn
 	echo ""
 	echo "Pass rate by tier:"
-	for t in simple standard reasoning; do
+	local tiers=""
+	tiers=$(jq -r 'select(.outcome == "pending" and (.tier // "") != "") | .tier' "$telemetry_file" 2>/dev/null | sort -u)
+	local t=""
+	while IFS= read -r t; do
+		[[ -n "$t" ]] || continue
 		local t_total t_success
-		t_total=$(grep -c "\"tier\":\"$t\"" "$telemetry_file" 2>/dev/null) || t_total=0
-		t_success=$(jq -r "select(.tier == \"$t\" and .outcome == \"success\") | .tier" "$telemetry_file" 2>/dev/null | wc -l | tr -d ' ') || t_success=0
+		t_total=$(jq -s --arg tier "$t" '[.[] | select(.tier == $tier and .outcome == "pending")] | length' "$telemetry_file" 2>/dev/null) || t_total=0
+		t_success=$(jq -s --arg tier "$t" '[.[] | select(.tier == $tier and .outcome == "success")] | length' "$telemetry_file" 2>/dev/null) || t_success=0
 		if [[ "$t_total" -gt 0 ]]; then
 			local pct
 			pct=$(awk "BEGIN {printf \"%.1f\", ${t_success}/${t_total}*100}")
 			echo "  tier:$t — $t_success/$t_total ($pct%)"
 		fi
-	done
+	done <<<"$tiers"
 
 	return 0
 }

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -903,8 +903,20 @@ cmd_record_outcome() {
 				($sk == "" or (.session_key // "") == $sk) and
 				($inum == "" or (.issue // "") == $inum) and
 				($slug == "" or (.repo // "") == $slug)) |
-			select(attempt_key as $key |
-				([$rows[] | select(.outcome != "pending" and (.attempt_id // "") == $key)] | length) == 0)] |
+			. as $pending |
+			select(if (($pending.attempt_id // "") != "") then
+				attempt_key as $key |
+				([$rows[] | select(.outcome != "pending" and (.attempt_id // "") == $key)] | length) == 0
+			else
+				([$rows[] | select(.outcome != "pending" and
+					(.repo // "") == ($pending.repo // "") and
+					(.issue // "") == ($pending.issue // "") and
+					(.tier // "") == ($pending.tier // ""))] | length) <
+				([$rows[] | select(.outcome == "pending" and (.attempt_id // "") == "" and
+					(.repo // "") == ($pending.repo // "") and
+					(.issue // "") == ($pending.issue // "") and
+					(.tier // "") == ($pending.tier // ""))] | length)
+			end)] |
 		last // empty' "$telemetry_file" 2>/dev/null || true)
 
 	if [[ -n "$pending" ]]; then
@@ -920,6 +932,10 @@ cmd_record_outcome() {
 		model=$(printf '%s' "$pending" | jq -r '.model // ""')
 	else
 		local model=""
+		if [[ -z "$attempt_id" ]]; then
+			_release_lock
+			return 0
+		fi
 	fi
 
 	if [[ -n "$attempt_id" ]] && jq -e --arg aid "$attempt_id" \
@@ -967,43 +983,80 @@ cmd_tier_report() {
 		return 0
 	fi
 
-	local total success escalated failed terminal pending_unknown
-	total=$(jq -s '[.[] | select(.outcome == "pending")] | length' "$telemetry_file" 2>/dev/null) || total=0
-	success=$(jq -s '[.[] | select(.outcome == "success")] | length' "$telemetry_file" 2>/dev/null) || success=0
-	escalated=$(jq -s '[.[] | select(.outcome == "escalated")] | length' "$telemetry_file" 2>/dev/null) || escalated=0
-	failed=$(jq -s --arg failed "$LEDGER_STATUS_FAILED" '[.[] | select(.outcome == $failed)] | length' "$telemetry_file" 2>/dev/null) || failed=0
-	terminal=$(jq -s '[.[] | select(.outcome != "pending")] | length' "$telemetry_file" 2>/dev/null) || terminal=0
-	pending_unknown=$((total - terminal))
-	[[ "$pending_unknown" -ge 0 ]] || pending_unknown=0
+	local summary=""
+	summary=$(jq -sc '
+		def dispatch_key:
+			if ((.attempt_id // "") != "") then .attempt_id
+			else "legacy:\(.repo // ""):\(.issue // ""):\(.dispatched_at // ""):\(.tier // ""):\(.model // "")"
+			end;
+		. as $rows |
+		[$rows[] | select(.outcome == "pending")] |
+			group_by(dispatch_key) | map(last) as $dispatches |
+		[$rows[] | select(.outcome != "pending") | . as $terminal |
+			if (($terminal.attempt_id // "") != "") then $terminal
+			else
+				[$dispatches[] | select(
+					(.attempt_id // "") == "" and
+					(.repo // "") == ($terminal.repo // "") and
+					(.issue // "") == ($terminal.issue // "") and
+					(.tier // "") == ($terminal.tier // ""))] as $matches |
+				if ($matches | length) == 1 then $terminal + {attempt_id: ($matches[0] | dispatch_key)} else $terminal end
+			end] as $resolved_terminals |
+		[$resolved_terminals[] | select((.attempt_id // "") != "")] |
+			group_by(.attempt_id) | map(first) as $identified_terminals |
+		[$resolved_terminals[] | select((.attempt_id // "") == "")] as $legacy_terminals |
+		[$identified_terminals[] | select(.attempt_id as $id | any($dispatches[]; dispatch_key == $id))] as $paired |
+		[$paired[] | select(.outcome != "deferred" and .outcome != "timeout")] as $completed |
+		($identified_terminals + $legacy_terminals) as $terminals |
+		{
+			total: ($dispatches | length),
+			success: ([$paired[] | select(.outcome == "success")] | length),
+			escalated: ([$paired[] | select(.outcome == "escalated")] | length),
+			failed: ([$paired[] | select(.outcome == "failed")] | length),
+			deferred: ([$paired[] | select(.outcome == "deferred" or .outcome == "timeout")] | length),
+			pending_unknown: (($dispatches | length) - ($paired | length)),
+			unmatched: (($terminals | length) - ($paired | length)),
+			by_tier: ($dispatches | group_by(.tier // "") | map({tier: (.[0].tier // ""), count: length}) | sort_by(-.count)),
+			reasons: ($terminals | map(select((.reason // "") != "")) | group_by(.reason) | map({reason: .[0].reason, count: length}) | sort_by(-.count)),
+			pass_rates: ($completed | group_by(.tier // "") | map(
+				.[0].tier as $tier | {
+					tier: ($tier // ""),
+					total: length,
+					success: ([.[] | select(.outcome == "success")] | length)
+				}) | sort_by(.tier))
+		}' "$telemetry_file" 2>/dev/null) || summary='{}'
+
+	local total success escalated failed deferred pending_unknown unmatched
+	total=$(printf '%s' "$summary" | jq -r '.total // 0')
+	success=$(printf '%s' "$summary" | jq -r '.success // 0')
+	escalated=$(printf '%s' "$summary" | jq -r '.escalated // 0')
+	failed=$(printf '%s' "$summary" | jq -r '.failed // 0')
+	deferred=$(printf '%s' "$summary" | jq -r '.deferred // 0')
+	pending_unknown=$(printf '%s' "$summary" | jq -r '.pending_unknown // 0')
+	unmatched=$(printf '%s' "$summary" | jq -r '.unmatched // 0')
 
 	echo "=== Tier Dispatch Telemetry ==="
 	echo "Total dispatches: $total"
 	echo "Success: $success"
 	echo "Escalated: $escalated"
 	echo "Failed: $failed"
+	echo "Deferred/timeout: $deferred"
 	echo "Pending/unknown: $pending_unknown"
+	echo "Legacy/unmatched terminal events: $unmatched"
 	echo ""
 	echo "By tier:"
-	jq -r 'select(.outcome == "pending") | .tier' "$telemetry_file" 2>/dev/null | sort | uniq -c | sort -rn
+	printf '%s' "$summary" | jq -r '.by_tier[] | "\(.count | tostring | if length < 6 then (" " * (6 - length)) + . else . end) \(.tier)"'
 	echo ""
 	echo "Escalation reasons:"
-	jq -r 'select(.reason != "" and .reason != null) | .reason' "$telemetry_file" 2>/dev/null | sort | uniq -c | sort -rn
+	printf '%s' "$summary" | jq -r '.reasons[] | "\(.count | tostring | if length < 6 then (" " * (6 - length)) + . else . end) \(.reason)"'
 	echo ""
 	echo "Pass rate by tier:"
-	local tiers=""
-	tiers=$(jq -r 'select(.outcome == "pending" and (.tier // "") != "") | .tier' "$telemetry_file" 2>/dev/null | sort -u)
-	local t=""
-	while IFS= read -r t; do
-		[[ -n "$t" ]] || continue
-		local t_total t_success
-		t_total=$(jq -s --arg tier "$t" '[.[] | select(.tier == $tier and .outcome == "pending")] | length' "$telemetry_file" 2>/dev/null) || t_total=0
-		t_success=$(jq -s --arg tier "$t" '[.[] | select(.tier == $tier and .outcome == "success")] | length' "$telemetry_file" 2>/dev/null) || t_success=0
-		if [[ "$t_total" -gt 0 ]]; then
-			local pct
-			pct=$(awk "BEGIN {printf \"%.1f\", ${t_success}/${t_total}*100}")
-			echo "  tier:$t — $t_success/$t_total ($pct%)"
-		fi
-	done <<<"$tiers"
+	printf '%s' "$summary" | jq -r '.pass_rates[] | select(.tier != "" and .total > 0) | [.tier, .success, .total] | @tsv' |
+		while IFS=$'\t' read -r tier_name tier_success tier_total; do
+			local pct=""
+			pct=$(awk "BEGIN {printf \"%.1f\", ${tier_success}/${tier_total}*100}")
+			printf '  tier:%s — %s/%s (%s%%)\n' "$tier_name" "$tier_success" "$tier_total" "$pct"
+		done
 
 	return 0
 }
@@ -1424,6 +1477,12 @@ Usage:
 
   dispatch-ledger-helper.sh fail --session-key KEY
     Mark dispatch as failed (worker errored or timed out).
+
+  dispatch-ledger-helper.sh record-outcome --outcome OUTCOME [--session-key KEY]
+    Record one correlated terminal tier-telemetry event. First outcome wins.
+
+  dispatch-ledger-helper.sh tier-report
+    Report logical dispatch attempts, terminal outcomes, and pass rates by tier.
 
   dispatch-ledger-helper.sh expire [--ttl SECONDS]
     Expire stale in-flight entries (default TTL: 3600s / 60 min).

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -53,6 +53,7 @@ _dlh_dir="${BASH_SOURCE[0]%/*}"
 LEDGER_DIR="${AIDEVOPS_DISPATCH_LEDGER_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
 LEDGER_FILE="${LEDGER_DIR}/dispatch-ledger.jsonl"
 LEDGER_LOCK="${LEDGER_DIR}/dispatch-ledger.lock"
+TIER_TELEMETRY_FILTER="${_dlh_dir}/dispatch-tier-telemetry.jq"
 DEFAULT_TTL="${AIDEVOPS_DISPATCH_LEDGER_TTL:-3600}" # 60 minutes
 PRELAUNCH_TTL="${AIDEVOPS_DISPATCH_PRELAUNCH_LEASE_TTL:-120}"
 READY_TTL="${AIDEVOPS_DISPATCH_READY_LEASE_TTL:-7200}"
@@ -417,7 +418,6 @@ cmd_register() {
 		echo "Error: register requires --session-key" >&2
 		return 1
 	fi
-
 	_ensure_ledger
 	if ! _acquire_lock; then
 		echo "Error: register aborted — could not acquire lock" >&2
@@ -433,7 +433,6 @@ cmd_register() {
 	lease_expires_at=$(_lease_expiry "$lease_ttl")
 	local attempt_id="${lease_token:-${session_key}:${now}:${dispatch_pid}}"
 
-	# Append new entry — use jq for safe JSON construction (handles special chars)
 	jq -cn \
 		--arg sk "$session_key" \
 		--arg inum "$issue_number" \
@@ -451,7 +450,6 @@ cmd_register() {
 		'{session_key: $sk, attempt_id: $attempt, issue_number: $inum, repo_slug: $slug, pid: $pid, dispatched_at: $ts, status: $status, updated_at: $ts, tier: $tier, model: $model, worktree_path: $worktree, lease_token:$token, runner_device:$device, lease_phase:"prelaunch", lease_expires_at:$expires}' \
 		>>"$LEDGER_FILE"
 	_append_tier_telemetry "$issue_number" "$repo_slug" "$dispatch_tier" "$dispatch_model" "$now" "$session_key" "$attempt_id"
-
 	_release_lock
 	return 0
 }
@@ -825,6 +823,42 @@ cmd_fail() {
 #
 # Exit codes: 0 always (best-effort, never fatal)
 #######################################
+_find_pending_telemetry_attempt() {
+	local telemetry_file="$1"
+	local attempt_id="$2"
+	local session_key="$3"
+	local issue_number="$4"
+	local repo_slug="$5"
+
+	jq -sc -f "$TIER_TELEMETRY_FILTER" --arg operation find \
+		--arg aid "$attempt_id" --arg sk "$session_key" \
+		--arg inum "$issue_number" --arg slug "$repo_slug" "$telemetry_file" 2>/dev/null
+	return 0
+}
+
+_append_terminal_telemetry() {
+	local telemetry_file="$1"
+	local attempt_id="$2"
+	local session_key="$3"
+	local issue_number="$4"
+	local repo_slug="$5"
+	local tier="$6"
+	local model="$7"
+	local outcome="$8"
+	local reason="$9"
+	local tokens="${10}"
+	local now=""
+	now=$(_now_utc)
+
+	jq -cn --argjson schema 2 --arg aid "$attempt_id" --arg sk "$session_key" \
+		--arg inum "$issue_number" --arg slug "$repo_slug" --arg tier "$tier" \
+		--arg model "$model" --arg outcome "$outcome" --arg reason "$reason" \
+		--argjson tokens "$tokens" --arg ts "$now" \
+		'{schema: $schema, attempt_id: $aid, session_key: $sk, issue: $inum, repo: $slug, tier: $tier, model: $model, outcome: $outcome, reason: $reason, tokens: $tokens, completed_at: $ts}' \
+		>>"$telemetry_file" 2>/dev/null || true
+	return 0
+}
+
 cmd_record_outcome() {
 	local issue_number=""
 	local repo_slug=""
@@ -890,40 +924,11 @@ cmd_record_outcome() {
 
 	[[ -n "$attempt_id" ]] || attempt_id="$lease_token"
 	local pending=""
-	pending=$(jq -sc \
-		--arg aid "$attempt_id" --arg sk "$session_key" \
-		--arg inum "$issue_number" --arg slug "$repo_slug" '
-		def attempt_key:
-			if ((.attempt_id // "") != "") then .attempt_id
-			else "legacy:\(.repo // ""):\(.issue // ""):\(.dispatched_at // ""):\(.tier // ""):\(.model // "")"
-			end;
-		. as $rows |
-		[.[] | select(.outcome == "pending") |
-			select(($aid == "" or attempt_key == $aid) and
-				($sk == "" or (.session_key // "") == $sk) and
-				($inum == "" or (.issue // "") == $inum) and
-				($slug == "" or (.repo // "") == $slug)) |
-			. as $pending |
-			select(if (($pending.attempt_id // "") != "") then
-				attempt_key as $key |
-				([$rows[] | select(.outcome != "pending" and (.attempt_id // "") == $key)] | length) == 0
-			else
-				([$rows[] | select(.outcome != "pending" and
-					(.repo // "") == ($pending.repo // "") and
-					(.issue // "") == ($pending.issue // "") and
-					(.tier // "") == ($pending.tier // ""))] | length) <
-				([$rows[] | select(.outcome == "pending" and (.attempt_id // "") == "" and
-					(.repo // "") == ($pending.repo // "") and
-					(.issue // "") == ($pending.issue // "") and
-					(.tier // "") == ($pending.tier // ""))] | length)
-			end)] |
-		last // empty' "$telemetry_file" 2>/dev/null || true)
+	pending=$(_find_pending_telemetry_attempt "$telemetry_file" "$attempt_id" \
+		"$session_key" "$issue_number" "$repo_slug" || true)
 
 	if [[ -n "$pending" ]]; then
-		attempt_id=$(printf '%s' "$pending" | jq -r '
-			if ((.attempt_id // "") != "") then .attempt_id
-			else "legacy:\(.repo // ""):\(.issue // ""):\(.dispatched_at // ""):\(.tier // ""):\(.model // "")"
-			end')
+		attempt_id=$(printf '%s' "$pending" | jq -r '.attempt_id')
 		[[ -n "$session_key" ]] || session_key=$(printf '%s' "$pending" | jq -r '.session_key // ""')
 		[[ -n "$issue_number" ]] || issue_number=$(printf '%s' "$pending" | jq -r '.issue // ""')
 		[[ -n "$repo_slug" ]] || repo_slug=$(printf '%s' "$pending" | jq -r '.repo // ""')
@@ -945,23 +950,8 @@ cmd_record_outcome() {
 		return 0
 	fi
 
-	local now
-	now=$(_now_utc)
-
-	jq -cn \
-		--argjson schema 2 \
-		--arg aid "$attempt_id" \
-		--arg sk "$session_key" \
-		--arg inum "$issue_number" \
-		--arg slug "$repo_slug" \
-		--arg tier "$tier" \
-		--arg model "$model" \
-		--arg outcome "$outcome" \
-		--arg reason "$reason" \
-		--argjson tokens "${tokens:-0}" \
-		--arg ts "$now" \
-		'{schema: $schema, attempt_id: $aid, session_key: $sk, issue: $inum, repo: $slug, tier: $tier, model: $model, outcome: $outcome, reason: $reason, tokens: $tokens, completed_at: $ts}' \
-		>>"$telemetry_file" 2>/dev/null || true
+	_append_terminal_telemetry "$telemetry_file" "$attempt_id" "$session_key" \
+		"$issue_number" "$repo_slug" "$tier" "$model" "$outcome" "$reason" "$tokens"
 	_release_lock
 
 	return 0
@@ -984,47 +974,9 @@ cmd_tier_report() {
 	fi
 
 	local summary=""
-	summary=$(jq -sc '
-		def dispatch_key:
-			if ((.attempt_id // "") != "") then .attempt_id
-			else "legacy:\(.repo // ""):\(.issue // ""):\(.dispatched_at // ""):\(.tier // ""):\(.model // "")"
-			end;
-		. as $rows |
-		[$rows[] | select(.outcome == "pending")] |
-			group_by(dispatch_key) | map(last) as $dispatches |
-		[$rows[] | select(.outcome != "pending") | . as $terminal |
-			if (($terminal.attempt_id // "") != "") then $terminal
-			else
-				[$dispatches[] | select(
-					(.attempt_id // "") == "" and
-					(.repo // "") == ($terminal.repo // "") and
-					(.issue // "") == ($terminal.issue // "") and
-					(.tier // "") == ($terminal.tier // ""))] as $matches |
-				if ($matches | length) == 1 then $terminal + {attempt_id: ($matches[0] | dispatch_key)} else $terminal end
-			end] as $resolved_terminals |
-		[$resolved_terminals[] | select((.attempt_id // "") != "")] |
-			group_by(.attempt_id) | map(first) as $identified_terminals |
-		[$resolved_terminals[] | select((.attempt_id // "") == "")] as $legacy_terminals |
-		[$identified_terminals[] | select(.attempt_id as $id | any($dispatches[]; dispatch_key == $id))] as $paired |
-		[$paired[] | select(.outcome != "deferred" and .outcome != "timeout")] as $completed |
-		($identified_terminals + $legacy_terminals) as $terminals |
-		{
-			total: ($dispatches | length),
-			success: ([$paired[] | select(.outcome == "success")] | length),
-			escalated: ([$paired[] | select(.outcome == "escalated")] | length),
-			failed: ([$paired[] | select(.outcome == "failed")] | length),
-			deferred: ([$paired[] | select(.outcome == "deferred" or .outcome == "timeout")] | length),
-			pending_unknown: (($dispatches | length) - ($paired | length)),
-			unmatched: (($terminals | length) - ($paired | length)),
-			by_tier: ($dispatches | group_by(.tier // "") | map({tier: (.[0].tier // ""), count: length}) | sort_by(-.count)),
-			reasons: ($terminals | map(select((.reason // "") != "")) | group_by(.reason) | map({reason: .[0].reason, count: length}) | sort_by(-.count)),
-			pass_rates: ($completed | group_by(.tier // "") | map(
-				.[0].tier as $tier | {
-					tier: ($tier // ""),
-					total: length,
-					success: ([.[] | select(.outcome == "success")] | length)
-				}) | sort_by(.tier))
-		}' "$telemetry_file" 2>/dev/null) || summary='{}'
+	summary=$(jq -sc -f "$TIER_TELEMETRY_FILTER" --arg operation report \
+		--arg aid "" --arg sk "" --arg inum "" --arg slug "" \
+		"$telemetry_file" 2>/dev/null) || summary='{}'
 
 	local total success escalated failed deferred pending_unknown unmatched
 	total=$(printf '%s' "$summary" | jq -r '.total // 0')

--- a/.agents/scripts/dispatch-tier-telemetry.jq
+++ b/.agents/scripts/dispatch-tier-telemetry.jq
@@ -1,0 +1,71 @@
+def attempt_key:
+  if ((.attempt_id // "") != "") then .attempt_id
+  else ["legacy", (.repo // ""), (.issue // ""), (.dispatched_at // ""), (.tier // ""), (.model // "")] | join(":")
+  end;
+
+def find_pending:
+  . as $rows |
+  [.[] | select(.outcome == "pending") |
+    select(($aid == "" or attempt_key == $aid) and
+      ($sk == "" or (.session_key // "") == $sk) and
+      ($inum == "" or (.issue // "") == $inum) and
+      ($slug == "" or (.repo // "") == $slug)) |
+    . as $pending |
+    select(if (($pending.attempt_id // "") != "") then
+      attempt_key as $key |
+      ([$rows[] | select(.outcome != "pending" and (.attempt_id // "") == $key)] | length) == 0
+    else
+      ([$rows[] | select(.outcome != "pending" and
+        (.repo // "") == ($pending.repo // "") and
+        (.issue // "") == ($pending.issue // "") and
+        (.tier // "") == ($pending.tier // ""))] | length) <
+      ([$rows[] | select(.outcome == "pending" and (.attempt_id // "") == "" and
+        (.repo // "") == ($pending.repo // "") and
+        (.issue // "") == ($pending.issue // "") and
+        (.tier // "") == ($pending.tier // ""))] | length)
+    end)] |
+  last // empty |
+  . + {attempt_id: attempt_key};
+
+def report:
+  . as $rows |
+  [$rows[] | select(.outcome == "pending")] |
+    group_by(attempt_key) | map(last) as $dispatches |
+  [$rows[] | select(.outcome != "pending") | . as $terminal |
+    if (($terminal.attempt_id // "") != "") then $terminal
+    else
+      [$dispatches[] | select(
+        (.attempt_id // "") == "" and
+        (.repo // "") == ($terminal.repo // "") and
+        (.issue // "") == ($terminal.issue // "") and
+        (.tier // "") == ($terminal.tier // ""))] as $matches |
+      if ($matches | length) == 1 then $terminal + {attempt_id: ($matches[0] | attempt_key)} else $terminal end
+    end] as $resolved_terminals |
+  [$resolved_terminals[] | select((.attempt_id // "") != "")] |
+    group_by(.attempt_id) | map(first) as $identified_terminals |
+  [$resolved_terminals[] | select((.attempt_id // "") == "")] as $legacy_terminals |
+  [$identified_terminals[] | select(.attempt_id as $id | any($dispatches[]; attempt_key == $id))] as $paired |
+  [$paired[] | select(.outcome != "deferred" and .outcome != "timeout")] as $completed |
+  ($identified_terminals + $legacy_terminals) as $terminals |
+  {
+    total: ($dispatches | length),
+    success: ([$paired[] | select(.outcome == "success")] | length),
+    escalated: ([$paired[] | select(.outcome == "escalated")] | length),
+    failed: ([$paired[] | select(.outcome == "failed")] | length),
+    deferred: ([$paired[] | select(.outcome == "deferred" or .outcome == "timeout")] | length),
+    pending_unknown: (($dispatches | length) - ($paired | length)),
+    unmatched: (($terminals | length) - ($paired | length)),
+    by_tier: ($dispatches | group_by(.tier // "") | map({tier: (.[0].tier // ""), count: length}) | sort_by(-.count)),
+    reasons: ($terminals | map(select((.reason // "") != "")) | group_by(.reason) | map({reason: .[0].reason, count: length}) | sort_by(-.count)),
+    pass_rates: ($completed | group_by(.tier // "") | map(
+      .[0].tier as $tier | {
+        tier: ($tier // ""),
+        total: length,
+        success: ([.[] | select(.outcome == "success")] | length)
+      }) | sort_by(.tier))
+  };
+
+if $operation == "find" then find_pending
+elif $operation == "report" then report
+else error("unknown telemetry operation")
+end

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -955,7 +955,8 @@ _exit_trap_handler() {
 	fi
 	if declare -F _hrw_record_terminal_outcome >/dev/null 2>&1; then
 		local terminal_outcome="failed"
-		[[ "$reason" == "worker_complete" ]] && terminal_outcome="success"
+		local complete_reason="${_HRW_REASON_WORKER_COMPLETE:-worker_complete}"
+		[[ "$reason" == "$complete_reason" ]] && terminal_outcome="success"
 		_hrw_record_terminal_outcome "$session_key" "$terminal_outcome" "$reason"
 	fi
 	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -953,6 +953,11 @@ _exit_trap_handler() {
 			_emit_worker_runtime_event "worker.failed" "failed" "$reason"
 		fi
 	fi
+	if declare -F _hrw_record_terminal_outcome >/dev/null 2>&1; then
+		local terminal_outcome="failed"
+		[[ "$reason" == "worker_complete" ]] && terminal_outcome="success"
+		_hrw_record_terminal_outcome "$session_key" "$terminal_outcome" "$reason"
+	fi
 	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
 		_cleanup_headless_runtime_temp_paths
 	fi

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1502,6 +1502,7 @@ cmd_run() {
 	print_info "[lifecycle] pre_canary session=$session_key model=$selected_model pid=$$"
 	if ! _run_canary_test "$selected_model"; then
 		print_warning "Canary failed — aborting dispatch for session $session_key (no claim posted)"
+		_hrw_record_terminal_outcome "$session_key" "deferred" "canary_failed"
 		return 1
 	fi
 	print_info "[lifecycle] post_canary session=$session_key model=$selected_model pid=$$"
@@ -1519,9 +1520,11 @@ cmd_run() {
 	print_info "[lifecycle] pre_worker_prepare session=$session_key work_dir=$work_dir pid=$$"
 	_cmd_run_prepare "$session_key" "$work_dir" || prepare_exit=$?
 	if [[ "$prepare_exit" -eq 2 ]]; then
+		_hrw_record_terminal_outcome "$session_key" "deferred" "duplicate_session"
 		return 0
 	fi
 	if [[ "$prepare_exit" -ne 0 ]]; then
+		_hrw_record_terminal_outcome "$session_key" "failed" "worker_prepare_failed"
 		return "$prepare_exit"
 	fi
 	print_info "[lifecycle] post_worker_prepare session=$session_key work_dir=$work_dir pid=$$"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1355,6 +1355,8 @@ _register_dispatch_ledger() {
 	[[ -n "$ledger_issue" ]] && ledger_args+=(--issue "$ledger_issue")
 	[[ -n "$ledger_repo" ]] && ledger_args+=(--repo "$ledger_repo")
 	[[ -n "$ledger_work_dir" ]] && ledger_args+=(--worktree "$ledger_work_dir")
+	[[ -n "${AIDEVOPS_DISPATCH_TIER:-}" ]] && ledger_args+=(--tier "$AIDEVOPS_DISPATCH_TIER")
+	[[ -n "${AIDEVOPS_DISPATCH_MODEL:-}" ]] && ledger_args+=(--model "$AIDEVOPS_DISPATCH_MODEL")
 
 	"$DISPATCH_LEDGER_HELPER" "${ledger_args[@]}" 2>/dev/null || true
 	return 0

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -30,6 +30,9 @@ _HRW_STATUS_UNKNOWN="unknown"
 _HRW_GIT_HEAD="HEAD"
 _HRW_CRASH_NO_WORK="no_work"
 _HRW_REASON_WORKER_COMPLETE="worker_complete"
+_HRW_TELEMETRY_SUCCESS="success"
+_HRW_TELEMETRY_FAILED="failed"
+_HRW_TELEMETRY_DEFERRED="deferred"
 _HRW_SPOTLIGHT_MARKER=".metadata_never_index"
 
 # Defensive SCRIPT_DIR fallback (test harnesses may not set it)
@@ -651,11 +654,11 @@ _handle_worker_branch_orphan() {
 	if _attempt_orphan_recovery_pr "$session_key" "$work_dir" "$branch_name" "$repo_slug"; then
 		print_info "[lifecycle] Orphan PR auto-created for session=${session_key}"
 		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
-		_HRW_TERMINAL_OUTCOME="success"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 	else
 		print_info "[lifecycle] Orphan recovery failed for session=${session_key}"
 		_release_dispatch_claim "$session_key" "worker_branch_orphan"
-		_HRW_TERMINAL_OUTCOME="failed"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
 		# Post structured ops comment so the next dispatch knows what happened
 		if [[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]]; then
 			local _ops_comment
@@ -723,11 +726,11 @@ _handle_worker_local_branch_unpushed() {
 		print_info "[lifecycle] Local branch pushed and recovery PR auto-created for session=${session_key}"
 		local complete_reason="worker_"
 		_release_dispatch_claim "$session_key" "${complete_reason}complete"
-		_HRW_TERMINAL_OUTCOME="success"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 	else
 		print_info "[lifecycle] Local branch recovery failed for session=${session_key}"
 		_release_dispatch_claim "$session_key" "worker_local_branch_unpushed"
-		_HRW_TERMINAL_OUTCOME="failed"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
 		if [[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]]; then
 			local _ops_comment
 			local _local_key="${repo_slug}#${issue_number}#${branch_name}#worker_local_branch_unpushed"
@@ -820,13 +823,13 @@ _handle_worker_dirty_worktree() {
 				--recoverability "checkpointed" 2>/dev/null || true
 		fi
 		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
-		_HRW_TERMINAL_OUTCOME="success"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 		print_info "[lifecycle] worker_dirty_worktree_checkpointed session=${session_key} branch=${branch_name:-<none>}"
 		return 0
 	fi
 
 	_release_dispatch_claim "$session_key" "worker_dirty_worktree"
-	_HRW_TERMINAL_OUTCOME="failed"
+	_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
 
 	if [[ -n "$issue_number" && -n "$repo_slug" ]]; then
 		local _ops_comment
@@ -1210,14 +1213,14 @@ _hrw_finish_failed_run() {
 		_release_dispatch_claim "$session_key" "worker_failed"
 	fi
 	if [[ "$failure_recovered" -eq 1 ]]; then
-		_HRW_TERMINAL_OUTCOME="success"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 		_HRW_FINAL_RUNTIME_EVENT="worker.completed"
 		_HRW_FINAL_RUNTIME_STATUS="recovered"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_REASON_WORKER_COMPLETE"
 	else
-		_HRW_TERMINAL_OUTCOME="failed"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
 		_HRW_FINAL_RUNTIME_EVENT="worker.failed"
-		_HRW_FINAL_RUNTIME_STATUS="failed"
+		_HRW_FINAL_RUNTIME_STATUS="$_HRW_TELEMETRY_FAILED"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="${_run_failure_reason:-worker_failed}"
 	fi
 
@@ -1298,9 +1301,9 @@ _hrw_finish_success_run() {
 			_report_failure_to_fast_fail "$session_key" "worker_noop_zero_output" "$_HRW_CRASH_NO_WORK"
 			release_needed=0
 			_HRW_FINAL_RUNTIME_EVENT="worker.failed"
-			_HRW_FINAL_RUNTIME_STATUS="failed"
+			_HRW_FINAL_RUNTIME_STATUS="$_HRW_TELEMETRY_FAILED"
 			_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_CRASH_NO_WORK"
-			_HRW_TERMINAL_OUTCOME="failed"
+			_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
 			;;
 		branch_orphan)
 			_handle_worker_branch_orphan "$session_key" "$work_dir"
@@ -1322,7 +1325,7 @@ _hrw_finish_success_run() {
 		# reason=worker_complete so the audit trail shows the full lifecycle even
 		# when no PR was created.
 		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
-		_HRW_TERMINAL_OUTCOME="success"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 	fi
 
 	return 0
@@ -1353,7 +1356,7 @@ _cmd_run_finish() {
 	_HRW_FINAL_RUNTIME_EVENT="worker.completed"
 	_HRW_FINAL_RUNTIME_STATUS="${_run_result_label:-$ledger_status}"
 	_HRW_FINAL_RUNTIME_CLASSIFICATION="${_run_failure_reason:-}"
-	_HRW_TERMINAL_OUTCOME="success"
+	_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 
 	# Release the dispatch claim so the issue is immediately available for
 	# re-dispatch (next 2-min pulse cycle) instead of waiting for the
@@ -1376,7 +1379,7 @@ _cmd_run_finish() {
 		_HRW_FINAL_RUNTIME_EVENT="worker.deferred"
 		_HRW_FINAL_RUNTIME_STATUS="rate_limit_fast"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="rate_limit"
-		_HRW_TERMINAL_OUTCOME="deferred"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
 	else
 		_hrw_finish_success_run "$session_key" "$work_dir"
 	fi

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -651,9 +651,11 @@ _handle_worker_branch_orphan() {
 	if _attempt_orphan_recovery_pr "$session_key" "$work_dir" "$branch_name" "$repo_slug"; then
 		print_info "[lifecycle] Orphan PR auto-created for session=${session_key}"
 		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
+		_HRW_TERMINAL_OUTCOME="success"
 	else
 		print_info "[lifecycle] Orphan recovery failed for session=${session_key}"
 		_release_dispatch_claim "$session_key" "worker_branch_orphan"
+		_HRW_TERMINAL_OUTCOME="failed"
 		# Post structured ops comment so the next dispatch knows what happened
 		if [[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]]; then
 			local _ops_comment
@@ -721,9 +723,11 @@ _handle_worker_local_branch_unpushed() {
 		print_info "[lifecycle] Local branch pushed and recovery PR auto-created for session=${session_key}"
 		local complete_reason="worker_"
 		_release_dispatch_claim "$session_key" "${complete_reason}complete"
+		_HRW_TERMINAL_OUTCOME="success"
 	else
 		print_info "[lifecycle] Local branch recovery failed for session=${session_key}"
 		_release_dispatch_claim "$session_key" "worker_local_branch_unpushed"
+		_HRW_TERMINAL_OUTCOME="failed"
 		if [[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]]; then
 			local _ops_comment
 			local _local_key="${repo_slug}#${issue_number}#${branch_name}#worker_local_branch_unpushed"
@@ -816,11 +820,13 @@ _handle_worker_dirty_worktree() {
 				--recoverability "checkpointed" 2>/dev/null || true
 		fi
 		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
+		_HRW_TERMINAL_OUTCOME="success"
 		print_info "[lifecycle] worker_dirty_worktree_checkpointed session=${session_key} branch=${branch_name:-<none>}"
 		return 0
 	fi
 
 	_release_dispatch_claim "$session_key" "worker_dirty_worktree"
+	_HRW_TERMINAL_OUTCOME="failed"
 
 	if [[ -n "$issue_number" && -n "$repo_slug" ]]; then
 		local _ops_comment
@@ -1204,10 +1210,12 @@ _hrw_finish_failed_run() {
 		_release_dispatch_claim "$session_key" "worker_failed"
 	fi
 	if [[ "$failure_recovered" -eq 1 ]]; then
+		_HRW_TERMINAL_OUTCOME="success"
 		_HRW_FINAL_RUNTIME_EVENT="worker.completed"
 		_HRW_FINAL_RUNTIME_STATUS="recovered"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_REASON_WORKER_COMPLETE"
 	else
+		_HRW_TERMINAL_OUTCOME="failed"
 		_HRW_FINAL_RUNTIME_EVENT="worker.failed"
 		_HRW_FINAL_RUNTIME_STATUS="failed"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="${_run_failure_reason:-worker_failed}"
@@ -1247,6 +1255,23 @@ _hrw_finish_rate_limit_fast_run() {
 	return 0
 }
 
+_hrw_record_terminal_outcome() {
+	local session_key="$1"
+	local outcome="$2"
+	local reason="$3"
+	local ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
+
+	[[ -x "$ledger_helper" && -n "$outcome" ]] || return 0
+	"$ledger_helper" record-outcome \
+		--session-key "$session_key" \
+		--lease-token "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" \
+		--issue "${WORKER_ISSUE_NUMBER:-}" \
+		--repo "${DISPATCH_REPO_SLUG:-}" \
+		--outcome "$outcome" \
+		--reason "$reason" 2>/dev/null || true
+	return 0
+}
+
 _hrw_finish_success_run() {
 	local session_key="$1"
 	local work_dir="$2"
@@ -1275,6 +1300,7 @@ _hrw_finish_success_run() {
 			_HRW_FINAL_RUNTIME_EVENT="worker.failed"
 			_HRW_FINAL_RUNTIME_STATUS="failed"
 			_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_CRASH_NO_WORK"
+			_HRW_TERMINAL_OUTCOME="failed"
 			;;
 		branch_orphan)
 			_handle_worker_branch_orphan "$session_key" "$work_dir"
@@ -1296,6 +1322,7 @@ _hrw_finish_success_run() {
 		# reason=worker_complete so the audit trail shows the full lifecycle even
 		# when no PR was created.
 		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
+		_HRW_TERMINAL_OUTCOME="success"
 	fi
 
 	return 0
@@ -1326,6 +1353,7 @@ _cmd_run_finish() {
 	_HRW_FINAL_RUNTIME_EVENT="worker.completed"
 	_HRW_FINAL_RUNTIME_STATUS="${_run_result_label:-$ledger_status}"
 	_HRW_FINAL_RUNTIME_CLASSIFICATION="${_run_failure_reason:-}"
+	_HRW_TERMINAL_OUTCOME="success"
 
 	# Release the dispatch claim so the issue is immediately available for
 	# re-dispatch (next 2-min pulse cycle) instead of waiting for the
@@ -1348,9 +1376,12 @@ _cmd_run_finish() {
 		_HRW_FINAL_RUNTIME_EVENT="worker.deferred"
 		_HRW_FINAL_RUNTIME_STATUS="rate_limit_fast"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="rate_limit"
+		_HRW_TERMINAL_OUTCOME="deferred"
 	else
 		_hrw_finish_success_run "$session_key" "$work_dir"
 	fi
+	_hrw_record_terminal_outcome "$session_key" "$_HRW_TERMINAL_OUTCOME" \
+		"$_HRW_FINAL_RUNTIME_CLASSIFICATION"
 	_emit_worker_runtime_event "$_HRW_FINAL_RUNTIME_EVENT" \
 		"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
 

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1266,7 +1266,7 @@ _hrw_record_terminal_outcome() {
 		--session-key "$session_key" \
 		--lease-token "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" \
 		--issue "${WORKER_ISSUE_NUMBER:-}" \
-		--repo "${DISPATCH_REPO_SLUG:-}" \
+		--repo "${DISPATCH_REPO_SLUG:-${WORKER_REPO_SLUG:-}}" \
 		--outcome "$outcome" \
 		--reason "$reason" 2>/dev/null || true
 	return 0

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1736,7 +1736,6 @@ _dlw_nohup_launch() {
 		worker_cmd+=(--agent "$bundle_agent")
 	fi
 
-	# t2757: Detach worker via setsid (extracted to helper)
 	_dlw_exec_detached "$worker_log" "$issue_number" "${worker_cmd[@]}"
 	return 0
 }

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1693,6 +1693,8 @@ _dlw_nohup_launch() {
 		WORKER_GITHUB_LOGIN="$self_login"
 		AIDEVOPS_DISPATCH_LEASE_TOKEN="${_claim_lease_token:-}"
 		AIDEVOPS_DISPATCH_LEASE_DEVICE="${_claim_lease_device:-}"
+		AIDEVOPS_DISPATCH_TIER="$dispatch_model_tier"
+		AIDEVOPS_DISPATCH_MODEL="$selected_model"
 		AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1
 	)
 	_dlw_append_trusted_release_env

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -153,6 +153,10 @@ test_tier_telemetry_correlates_terminal_outcomes() {
 		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome success
 	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
 		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome failed
+	# Raw duplicate and unmatched rows model pre-v2 data or manual corruption.
+	# The report must normalize the known attempt and keep unmatched data separate.
+	printf '%s\n' '{"schema":2,"attempt_id":"attempt-42","issue":"42","repo":"owner/repo","tier":"simple","outcome":"success","completed_at":"2026-01-01T00:00:00Z"}' >>"${AIDEVOPS_DISPATCH_LEDGER_DIR}/tier-telemetry.jsonl"
+	printf '%s\n' '{"issue":"999","repo":"owner/repo","tier":"simple","outcome":"success","completed_at":"2026-01-01T00:00:00Z"}' >>"${AIDEVOPS_DISPATCH_LEDGER_DIR}/tier-telemetry.jsonl"
 
 	local telemetry_file="${AIDEVOPS_DISPATCH_LEDGER_DIR}/tier-telemetry.jsonl"
 	local result=0
@@ -160,12 +164,13 @@ test_tier_telemetry_correlates_terminal_outcomes() {
 	pending_count=$(jq -s '[.[] | select(.outcome == "pending")] | length' "$telemetry_file")
 	success_count=$(jq -s '[.[] | select(.outcome == "success")] | length' "$telemetry_file")
 	terminal_count=$(jq -s '[.[] | select(.outcome != "pending")] | length' "$telemetry_file")
-	terminal_tier=$(jq -r 'select(.outcome == "success") | .tier' "$telemetry_file")
+	terminal_tier=$(jq -rs 'first(.[] | select(.attempt_id == "attempt-42" and .outcome == "success") | .tier)' "$telemetry_file")
 	report=$("$LEDGER_HELPER" tier-report)
-	[[ "$pending_count" == "2" && "$success_count" == "1" && "$terminal_count" == "1" ]] || result=1
+	[[ "$pending_count" == "2" && "$success_count" == "3" && "$terminal_count" == "3" ]] || result=1
 	[[ "$terminal_tier" == "simple" ]] || result=1
 	[[ "$report" == *"Total dispatches: 2"* && "$report" == *"Pending/unknown: 1"* ]] || result=1
-	[[ "$report" == *"tier:simple — 1/1 (100.0%)"* && "$report" == *"tier:standard — 0/1 (0.0%)"* ]] || result=1
+	[[ "$report" == *"Success: 1"* && "$report" == *"Legacy/unmatched terminal events: 1"* ]] || result=1
+	[[ "$report" == *"tier:simple — 1/1 (100.0%)"* && "$report" != *"tier:standard"* ]] || result=1
 	print_result "tier telemetry correlates and idempotently reports terminal outcomes" "$result" \
 		"pending=${pending_count}, success=${success_count}, terminal=${terminal_count}, tier=${terminal_tier}"
 	teardown_test_env
@@ -176,17 +181,22 @@ test_tier_telemetry_handles_retries_and_legacy_pending() {
 	setup_test_env
 	local telemetry_file="${AIDEVOPS_DISPATCH_LEDGER_DIR}/tier-telemetry.jsonl"
 	printf '%s\n' '{"issue":"7","repo":"owner/repo","tier":"simple","model":"legacy-model","dispatched_at":"2026-01-01T00:00:00Z","outcome":"pending"}' >"$telemetry_file"
+	printf '%s\n' '{"issue":"7","repo":"owner/repo","tier":"simple","outcome":"failed","reason":"legacy_failure","completed_at":"2026-01-01T01:00:00Z"}' >>"$telemetry_file"
 	run_helper "$LEDGER_HELPER" register --session-key "issue-7" --issue 7 \
 		--repo "owner/repo" --pid $$ --tier thinking --model model-new --lease-token retry-7
 	run_helper "$LEDGER_HELPER" record-outcome --issue 7 --repo "owner/repo" --outcome success
 	run_helper "$LEDGER_HELPER" record-outcome --issue 7 --repo "owner/repo" --outcome failed
 
 	local result=0
-	local success_tier="" failed_tier="" legacy_pending=""
+	local success_tier="" failed_tier="" legacy_pending="" terminal_count="" report=""
 	success_tier=$(jq -r 'select(.outcome == "success") | .tier' "$telemetry_file")
 	failed_tier=$(jq -r 'select(.outcome == "failed") | .tier' "$telemetry_file")
 	legacy_pending=$(jq -s '[.[] | select(.outcome == "pending" and .model == "legacy-model")] | length' "$telemetry_file")
-	[[ "$success_tier" == "thinking" && "$failed_tier" == "simple" && "$legacy_pending" == "1" ]] || result=1
+	terminal_count=$(jq -s '[.[] | select(.outcome != "pending")] | length' "$telemetry_file")
+	report=$("$LEDGER_HELPER" tier-report)
+	[[ "$success_tier" == "thinking" && "$failed_tier" == "simple" && "$legacy_pending" == "1" && "$terminal_count" == "2" ]] || result=1
+	[[ "$report" == *"Success: 1"* && "$report" == *"Failed: 1"* && "$report" == *"Pending/unknown: 0"* ]] || result=1
+	[[ "$report" == *"Legacy/unmatched terminal events: 0"* ]] || result=1
 	print_result "tier telemetry pairs retries newest-first and supports legacy pending rows" "$result" \
 		"success_tier=${success_tier}, failed_tier=${failed_tier}, legacy=${legacy_pending}"
 	teardown_test_env

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -139,6 +139,60 @@ test_record_recovery_rejects_missing_option_values() {
 	return 0
 }
 
+test_tier_telemetry_correlates_terminal_outcomes() {
+	setup_test_env
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
+		--repo "owner/repo" --pid $$ --tier simple --model model-a --lease-token attempt-42
+	run_helper "$LEDGER_HELPER" register --session-key "issue-43" --issue 43 \
+		--repo "owner/repo" --pid $$ --tier standard --model model-b --lease-token attempt-43
+	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
+		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome success
+	# Repeated cleanup and a conflicting late event must not create or replace the
+	# first terminal result for this attempt.
+	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
+		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome success
+	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
+		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome failed
+
+	local telemetry_file="${AIDEVOPS_DISPATCH_LEDGER_DIR}/tier-telemetry.jsonl"
+	local result=0
+	local pending_count="" success_count="" terminal_count="" terminal_tier="" report=""
+	pending_count=$(jq -s '[.[] | select(.outcome == "pending")] | length' "$telemetry_file")
+	success_count=$(jq -s '[.[] | select(.outcome == "success")] | length' "$telemetry_file")
+	terminal_count=$(jq -s '[.[] | select(.outcome != "pending")] | length' "$telemetry_file")
+	terminal_tier=$(jq -r 'select(.outcome == "success") | .tier' "$telemetry_file")
+	report=$("$LEDGER_HELPER" tier-report)
+	[[ "$pending_count" == "2" && "$success_count" == "1" && "$terminal_count" == "1" ]] || result=1
+	[[ "$terminal_tier" == "simple" ]] || result=1
+	[[ "$report" == *"Total dispatches: 2"* && "$report" == *"Pending/unknown: 1"* ]] || result=1
+	[[ "$report" == *"tier:simple — 1/1 (100.0%)"* && "$report" == *"tier:standard — 0/1 (0.0%)"* ]] || result=1
+	print_result "tier telemetry correlates and idempotently reports terminal outcomes" "$result" \
+		"pending=${pending_count}, success=${success_count}, terminal=${terminal_count}, tier=${terminal_tier}"
+	teardown_test_env
+	return 0
+}
+
+test_tier_telemetry_handles_retries_and_legacy_pending() {
+	setup_test_env
+	local telemetry_file="${AIDEVOPS_DISPATCH_LEDGER_DIR}/tier-telemetry.jsonl"
+	printf '%s\n' '{"issue":"7","repo":"owner/repo","tier":"simple","model":"legacy-model","dispatched_at":"2026-01-01T00:00:00Z","outcome":"pending"}' >"$telemetry_file"
+	run_helper "$LEDGER_HELPER" register --session-key "issue-7" --issue 7 \
+		--repo "owner/repo" --pid $$ --tier thinking --model model-new --lease-token retry-7
+	run_helper "$LEDGER_HELPER" record-outcome --issue 7 --repo "owner/repo" --outcome success
+	run_helper "$LEDGER_HELPER" record-outcome --issue 7 --repo "owner/repo" --outcome failed
+
+	local result=0
+	local success_tier="" failed_tier="" legacy_pending=""
+	success_tier=$(jq -r 'select(.outcome == "success") | .tier' "$telemetry_file")
+	failed_tier=$(jq -r 'select(.outcome == "failed") | .tier' "$telemetry_file")
+	legacy_pending=$(jq -s '[.[] | select(.outcome == "pending" and .model == "legacy-model")] | length' "$telemetry_file")
+	[[ "$success_tier" == "thinking" && "$failed_tier" == "simple" && "$legacy_pending" == "1" ]] || result=1
+	print_result "tier telemetry pairs retries newest-first and supports legacy pending rows" "$result" \
+		"success_tier=${success_tier}, failed_tier=${failed_tier}, legacy=${legacy_pending}"
+	teardown_test_env
+	return 0
+}
+
 #######################################
 # Test: check detects in-flight entry
 #######################################
@@ -800,6 +854,8 @@ main() {
 	test_register_creates_entry
 	test_record_recovery_is_idempotent
 	test_record_recovery_rejects_missing_option_values
+	test_tier_telemetry_correlates_terminal_outcomes
+	test_tier_telemetry_handles_retries_and_legacy_pending
 	test_check_detects_inflight
 	test_check_returns_1_for_unknown
 	test_check_issue_detects_inflight

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -2102,11 +2102,12 @@ test_cmd_run_finish_emits_noop_for_zero_output() {
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
 
 	# Stub lifecycle functions to capture what was called
-	local released_reason="" fast_fail_reason="" fast_fail_crash=""
+	local released_reason="" fast_fail_reason="" fast_fail_crash="" recorded_outcome=""
 	_release_dispatch_claim() { released_reason="$2"; return 0; }
 	_report_failure_to_fast_fail() { fast_fail_reason="$2"; fast_fail_crash="$3"; return 0; }
 	_update_dispatch_ledger() { return 0; }
 	_release_session_lock() { return 0; }
+	_hrw_record_terminal_outcome() { recorded_outcome="$2"; return 0; }
 
 	_cmd_run_finish "issue-99999" "complete" "$work_dir"
 
@@ -2123,6 +2124,12 @@ test_cmd_run_finish_emits_noop_for_zero_output() {
 		print_result "_cmd_run_finish increments fast-fail on noop" 1 \
 			"Expected fast_fail reason=worker_noop_zero_output/crash=no_work, got '${fast_fail_reason}'/'${fast_fail_crash}'"
 	fi
+	if [[ "$recorded_outcome" == "failed" ]]; then
+		print_result "_cmd_run_finish records failed telemetry for zero-output exit" 0
+	else
+		print_result "_cmd_run_finish records failed telemetry for zero-output exit" 1 \
+			"Expected failed telemetry, got '${recorded_outcome}'"
+	fi
 	return 0
 }
 
@@ -2131,11 +2138,12 @@ test_cmd_run_finish_emits_complete_for_real_output() {
 	_setup_test_git_repo "$work_dir" 1
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
 
-	local released_reason="" fast_fail_called=0
+	local released_reason="" fast_fail_called=0 recorded_outcome=""
 	_release_dispatch_claim() { released_reason="$2"; return 0; }
 	_report_failure_to_fast_fail() { fast_fail_called=1; return 0; }
 	_update_dispatch_ledger() { return 0; }
 	_release_session_lock() { return 0; }
+	_hrw_record_terminal_outcome() { recorded_outcome="$2"; return 0; }
 
 	_cmd_run_finish "issue-99999" "complete" "$work_dir"
 
@@ -2151,6 +2159,12 @@ test_cmd_run_finish_emits_complete_for_real_output() {
 	else
 		print_result "_cmd_run_finish does NOT increment fast-fail for real output" 1 \
 			"fast-fail should not be called when worker produced real output"
+	fi
+	if [[ "$recorded_outcome" == "success" ]]; then
+		print_result "_cmd_run_finish records success telemetry for real output" 0
+	else
+		print_result "_cmd_run_finish records success telemetry for real output" 1 \
+			"Expected success telemetry, got '${recorded_outcome}'"
 	fi
 	return 0
 }
@@ -2535,7 +2549,7 @@ test_cmd_run_finish_local_unpushed_push_failure_emits_distinct_reason() {
 
 test_cmd_run_finish_fail_recovers_branch_orphan_output() {
 	local work_dir="${TEST_ROOT}/repo-fail-orphan-ok"
-	local released_reason="" fast_fail_called=0
+	local released_reason="" fast_fail_called=0 recorded_outcome=""
 	_setup_test_git_repo "$work_dir" 1
 	git -C "$work_dir" push -q origin "feature/auto-test-issue-99999"
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
@@ -2551,6 +2565,7 @@ test_cmd_run_finish_fail_recovers_branch_orphan_output() {
 	_update_dispatch_ledger() { return 0; }
 	_release_session_lock() { return 0; }
 	_increment_orphan_count_stat() { return 0; }
+	_hrw_record_terminal_outcome() { recorded_outcome="$2"; return 0; }
 	_cmd_run_finish "issue-99999" "fail" "$work_dir"
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
@@ -2560,12 +2575,18 @@ test_cmd_run_finish_fail_recovers_branch_orphan_output() {
 		print_result "_cmd_run_finish fail recovers branch-orphan output" 1 \
 			"Expected worker_complete and no fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"
 	fi
+	if [[ "$recorded_outcome" == "success" ]]; then
+		print_result "_cmd_run_finish records success for recovered failed run" 0
+	else
+		print_result "_cmd_run_finish records success for recovered failed run" 1 \
+			"Expected success telemetry, got '${recorded_outcome}'"
+	fi
 	return 0
 }
 
 test_cmd_run_finish_fail_closed_issue_without_merged_pr_fails() {
 	local work_dir="${TEST_ROOT}/repo-fail-issue-closed"
-	local released_reason="" fast_fail_called=0
+	local released_reason="" fast_fail_called=0 recorded_outcome=""
 	_setup_test_git_repo "$work_dir" 0
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
 	gh() {
@@ -2579,6 +2600,7 @@ test_cmd_run_finish_fail_closed_issue_without_merged_pr_fails() {
 	_update_dispatch_ledger() { return 0; }
 	_release_session_lock() { return 0; }
 	_increment_orphan_count_stat() { return 0; }
+	_hrw_record_terminal_outcome() { recorded_outcome="$2"; return 0; }
 
 	_cmd_run_finish "issue-99999" "fail" "$work_dir"
 
@@ -2589,6 +2611,12 @@ test_cmd_run_finish_fail_closed_issue_without_merged_pr_fails() {
 	else
 		print_result "_cmd_run_finish fail requires merged PR beyond closed issue" 1 \
 			"Expected worker_failed and fast-fail, got reason='${released_reason}' fast_fail=${fast_fail_called}"
+	fi
+	if [[ "$recorded_outcome" == "failed" ]]; then
+		print_result "_cmd_run_finish records failed telemetry for genuine failure" 0
+	else
+		print_result "_cmd_run_finish records failed telemetry for genuine failure" 1 \
+			"Expected failed telemetry, got '${recorded_outcome}'"
 	fi
 	return 0
 }

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -1642,6 +1642,7 @@ _Automated by \`escalate_issue_tier()\` cascade dispatch in worker-lifecycle-com
 	if [[ -x "$ledger_helper" ]]; then
 		"$ledger_helper" record-outcome \
 			--issue "$issue_number" --repo "$repo_slug" \
+			--session-key "issue-${issue_number}" \
 			--outcome "escalated" --tier "$current_tier" \
 			--reason "$safe_reason" 2>/dev/null || true
 	fi


### PR DESCRIPTION
## Summary

- add schema-v2 dispatch attempt IDs and idempotent terminal outcome recording
- preserve original tier/model attribution across worker/dispatcher registration races
- record normal, recovered, orphan, failure, deferred, and abnormal-exit outcomes
- aggregate paired attempts without double-counting append-only event rows
- preserve legacy telemetry while surfacing unmatched events explicitly

## Testing

- `.agents/scripts/linters-local.sh`
- `bash .agents/scripts/tests/test-dispatch-ledger-helper.sh` (27/27)
- `bash .agents/scripts/tests/test-dispatch-lifecycle-comms.sh` (16/16)
- `bash .agents/scripts/tests/test-canonical-tier-routing.sh` (10/10)
- `bash .agents/scripts/tests/test-worker-reliability-self-heal.sh` (16/16)
- `test-headless-runtime-helper.sh`: all telemetry/lifecycle assertions pass; 112/113 overall, with the existing environment-specific canary stub failure

## Runtime Testing

Runtime-verified through synthetic worker completion, recovery, orphan, no-op, failure, retry, duplicate-terminal, and legacy telemetry fixtures. Telemetry remains best-effort and does not alter claim-release or worker exit status.

## Decisions

- Lease tokens are the primary stable dispatch-attempt identity.
- Legacy rows use deterministic fallback correlation only when unambiguous.
- Deferred/time-out outcomes are reported but excluded from completed pass-rate denominators.
- Aggregation lives in a jq filter to keep shell functions below complexity gates.

Resolves #27500

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.95 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 48m and 467,316 tokens on this with the user in an interactive session.
