### PR TITLE
GH#27502: fix: deduplicate pulse merge closeouts

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -499,6 +499,131 @@ _Merged by deterministic merge pass (pulse-wrapper.sh). Neither MERGE_SUMMARY co
 }
 
 #######################################
+# Return the preferred comment ID for a PR merge closeout upsert.
+#
+# Prefer an existing deterministic closeout marker. Otherwise reuse the
+# worker's canonical MERGE_SUMMARY comment so post-merge handling transforms
+# that singleton instead of appending a second completion summary.
+#
+# Args: $1=comments JSON (gh --paginate --slurp shape), $2=PR number
+# Stdout: comment ID, or empty
+# Returns: 0 always
+#######################################
+_pm_select_pr_closeout_comment_id() {
+	local comments_json="$1"
+	local pr_number="$2"
+	local closeout_marker="<!-- PULSE_MERGE_CLOSEOUT:PR#${pr_number} -->"
+
+	printf '%s' "$comments_json" | jq -r \
+		--arg closeout_marker "$closeout_marker" \
+		--arg summary_marker '<!-- MERGE_SUMMARY -->' '
+		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+		elif type == "array" then .
+		else [] end)
+		| [ .[]
+			| select(
+				((.body // "") | contains($closeout_marker)) or
+				((.body // "") | contains($summary_marker))
+			)
+			| {
+				id: .id,
+				created_at: (.created_at // ""),
+				rank: (if ((.body // "") | contains($closeout_marker)) then 0 else 1 end)
+			} ]
+		| sort_by(.rank, .created_at, .id)
+		| first
+		| .id // empty
+	' 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Converge deterministic PR closeout comments to one marker-bearing comment.
+#
+# Each concurrent runner performs reconciliation after its own write. The
+# later writer therefore observes the earlier marker and removes every newer
+# duplicate while preserving the oldest canonical closeout.
+#
+# Args: $1=PR number, $2=repo slug
+# Returns: 0 always (best-effort post-merge hygiene)
+#######################################
+_pm_reconcile_pr_closeout_comments() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local comments_json="" closeout_ids="" keep_id="" comment_id=""
+	local closeout_marker="<!-- PULSE_MERGE_CLOSEOUT:PR#${pr_number} -->"
+
+	comments_json=$(gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
+		--paginate --slurp 2>/dev/null) || comments_json=""
+	[[ -n "$comments_json" ]] || return 0
+
+	closeout_ids=$(printf '%s' "$comments_json" | jq -r \
+		--arg closeout_marker "$closeout_marker" '
+		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+		elif type == "array" then .
+		else [] end)
+		| [ .[]
+			| select((.body // "") | contains($closeout_marker))
+			| {id: .id, created_at: (.created_at // "")} ]
+		| sort_by(.created_at, .id)
+		| .[].id
+	' 2>/dev/null) || closeout_ids=""
+
+	while IFS= read -r comment_id; do
+		[[ -n "$comment_id" ]] || continue
+		if [[ -z "$keep_id" ]]; then
+			keep_id="$comment_id"
+			continue
+		fi
+		gh api "repos/${repo_slug}/issues/comments/${comment_id}" \
+			--method DELETE >/dev/null 2>&1 || true
+		echo "[pulse-wrapper] Deterministic merge: removed duplicate PR closeout comment ${comment_id} for ${repo_slug}#${pr_number} (GH#27502)" >>"$LOGFILE"
+	done <<<"$closeout_ids"
+	return 0
+}
+
+#######################################
+# Upsert the deterministic PR merge closeout without duplicate summaries.
+#
+# The normal path patches the existing MERGE_SUMMARY comment. The fallback
+# posts one marker-bearing comment, then reconciles concurrent fallback writes.
+# This is cross-runner safe; local pulse locks only coordinate one machine.
+#
+# Args: $1=PR number, $2=repo slug, $3=closing comment body
+# Returns: 0 always (best-effort post-merge hygiene)
+#######################################
+_pm_upsert_pr_closing_comment() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local closing_comment="$3"
+	local comments_json="" existing_comment_id="" marked_comment=""
+
+	marked_comment="<!-- PULSE_MERGE_CLOSEOUT:PR#${pr_number} -->
+${closing_comment}"
+	comments_json=$(gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
+		--paginate --slurp 2>/dev/null) || comments_json=""
+	if [[ -n "$comments_json" ]]; then
+		existing_comment_id=$(_pm_select_pr_closeout_comment_id "$comments_json" "$pr_number")
+	fi
+
+	if [[ -n "$existing_comment_id" ]] && gh api \
+		"repos/${repo_slug}/issues/comments/${existing_comment_id}" \
+		--method PATCH --field body="$marked_comment" >/dev/null 2>&1; then
+		echo "[pulse-wrapper] Deterministic merge: upserted PR closeout comment ${existing_comment_id} for ${repo_slug}#${pr_number} (GH#27502)" >>"$LOGFILE"
+		_pm_reconcile_pr_closeout_comments "$pr_number" "$repo_slug"
+		return 0
+	fi
+
+	gh_pr_comment "$pr_number" --repo "$repo_slug" \
+		--body "$marked_comment" 2>/dev/null || true
+	# Give GitHub's comments listing a bounded visibility window before the
+	# post-write convergence pass. The later concurrent writer also reconciles.
+	sleep 1
+	_pm_reconcile_pr_closeout_comments "$pr_number" "$repo_slug"
+	return 0
+}
+
+#######################################
 # Resolve the original issue behind a superseded PR reference.
 #
 # When PR B resolves PR A, GitHub treats PR A as an issue number. The normal
@@ -675,9 +800,9 @@ _handle_post_merge_actions() {
 	closing_comment=$(_pm_build_closing_comment "$pr_number" "$repo_slug" \
 		"$linked_issue" "$merge_summary" "$pr_base_ref_name")
 
-	# Post closing comment on PR; unlock the merged PR (t1934)
-	gh_pr_comment "$pr_number" --repo "$repo_slug" \
-		--body "$closing_comment" 2>/dev/null || true
+	# Upsert one canonical PR closeout across concurrent runner accounts, then
+	# unlock the merged PR (t1934, GH#27502).
+	_pm_upsert_pr_closing_comment "$pr_number" "$repo_slug" "$closing_comment"
 	unlock_issue_after_worker "$pr_number" "$repo_slug"
 
 	# Close linked issue with the same closing comment

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -515,10 +515,11 @@ _pm_select_pr_closeout_comment_id() {
 	local closeout_marker="<!-- PULSE_MERGE_CLOSEOUT:PR#${pr_number} -->"
 
 	printf '%s' "$comments_json" | jq -r \
+		--arg array_type 'array' \
 		--arg closeout_marker "$closeout_marker" \
 		--arg summary_marker '<!-- MERGE_SUMMARY -->' '
-		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
-		elif type == "array" then .
+		(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
+		elif type == $array_type then .
 		else [] end)
 		| [ .[]
 			| select(
@@ -558,9 +559,10 @@ _pm_reconcile_pr_closeout_comments() {
 	[[ -n "$comments_json" ]] || return 0
 
 	closeout_ids=$(printf '%s' "$comments_json" | jq -r \
+		--arg array_type 'array' \
 		--arg closeout_marker "$closeout_marker" '
-		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
-		elif type == "array" then .
+		(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
+		elif type == $array_type then .
 		else [] end)
 		| [ .[]
 			| select((.body // "") | contains($closeout_marker))

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -513,10 +513,15 @@ _pm_select_pr_closeout_comment_id() {
 	local comments_json="$1"
 	local pr_number="$2"
 	local closeout_marker="<!-- PULSE_MERGE_CLOSEOUT:PR#${pr_number} -->"
+	local legacy_merge_text="Merged via PR #${pr_number} to"
+	local legacy_generic_text="Completed via PR #${pr_number}, merged to"
 
 	printf '%s' "$comments_json" | jq -r \
 		--arg array_type 'array' \
 		--arg closeout_marker "$closeout_marker" \
+		--arg legacy_generic_text "$legacy_generic_text" \
+		--arg legacy_merge_text "$legacy_merge_text" \
+		--arg merge_attribution 'Merged by deterministic merge pass (pulse-wrapper.sh).' \
 		--arg summary_marker '<!-- MERGE_SUMMARY -->' '
 		(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
 		elif type == $array_type then .
@@ -524,14 +529,21 @@ _pm_select_pr_closeout_comment_id() {
 		| [ .[]
 			| select(
 				((.body // "") | contains($closeout_marker)) or
-				((.body // "") | contains($summary_marker))
+				((.body // "") | contains($summary_marker)) or
+				(
+					((.body // "") | contains($legacy_merge_text)) and
+					((.body // "") | contains($merge_attribution))
+				) or
+				(
+					((.body // "") | contains($legacy_generic_text)) and
+					((.body // "") | contains($merge_attribution))
+				)
 			)
 			| {
 				id: .id,
-				created_at: (.created_at // ""),
-				rank: (if ((.body // "") | contains($closeout_marker)) then 0 else 1 end)
+				created_at: (.created_at // "")
 			} ]
-		| sort_by(.rank, .created_at, .id)
+		| sort_by(.created_at, .id)
 		| first
 		| .id // empty
 	' 2>/dev/null || true
@@ -542,45 +554,110 @@ _pm_select_pr_closeout_comment_id() {
 # Converge deterministic PR closeout comments to one marker-bearing comment.
 #
 # Each concurrent runner performs reconciliation after its own write. The
-# later writer therefore observes the earlier marker and removes every newer
-# duplicate while preserving the oldest canonical closeout.
+# later writer therefore observes the earlier candidate, updates the same
+# deterministic oldest winner, and removes every newer duplicate.
 #
-# Args: $1=PR number, $2=repo slug
+# Args: $1=PR number, $2=repo slug, $3=desired marked comment body
 # Returns: 0 always (best-effort post-merge hygiene)
 #######################################
 _pm_reconcile_pr_closeout_comments() {
 	local pr_number="$1"
 	local repo_slug="$2"
-	local comments_json="" closeout_ids="" keep_id="" comment_id=""
+	local marked_comment="$3"
+	local comments_json="" closeout_ids="" keep_id="" previous_singleton_id="" comment_id=""
+	local candidate_count=0 stable_observations=0 attempt=0 max_attempts=4
 	local closeout_marker="<!-- PULSE_MERGE_CLOSEOUT:PR#${pr_number} -->"
+	local legacy_merge_text="Merged via PR #${pr_number} to"
+	local legacy_generic_text="Completed via PR #${pr_number}, merged to"
 
-	comments_json=$(gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
-		--paginate --slurp 2>/dev/null) || comments_json=""
-	[[ -n "$comments_json" ]] || return 0
-
-	closeout_ids=$(printf '%s' "$comments_json" | jq -r \
-		--arg array_type 'array' \
-		--arg closeout_marker "$closeout_marker" '
-		(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
-		elif type == $array_type then .
-		else [] end)
-		| [ .[]
-			| select((.body // "") | contains($closeout_marker))
-			| {id: .id, created_at: (.created_at // "")} ]
-		| sort_by(.created_at, .id)
-		| .[].id
-	' 2>/dev/null) || closeout_ids=""
-
-	while IFS= read -r comment_id; do
-		[[ -n "$comment_id" ]] || continue
-		if [[ -z "$keep_id" ]]; then
-			keep_id="$comment_id"
+	while ((attempt < max_attempts)); do
+		attempt=$((attempt + 1))
+		comments_json=$(gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
+			--paginate --slurp 2>/dev/null) || comments_json=""
+		if [[ -z "$comments_json" ]]; then
+			((attempt < max_attempts)) && sleep 1
 			continue
 		fi
-		gh api "repos/${repo_slug}/issues/comments/${comment_id}" \
-			--method DELETE >/dev/null 2>&1 || true
-		echo "[pulse-wrapper] Deterministic merge: removed duplicate PR closeout comment ${comment_id} for ${repo_slug}#${pr_number} (GH#27502)" >>"$LOGFILE"
-	done <<<"$closeout_ids"
+
+		closeout_ids=$(printf '%s' "$comments_json" | jq -r \
+			--arg array_type 'array' \
+			--arg closeout_marker "$closeout_marker" \
+			--arg legacy_generic_text "$legacy_generic_text" \
+			--arg legacy_merge_text "$legacy_merge_text" \
+			--arg merge_attribution 'Merged by deterministic merge pass (pulse-wrapper.sh).' \
+			--arg summary_marker '<!-- MERGE_SUMMARY -->' '
+			(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
+			elif type == $array_type then .
+			else [] end)
+			| [ .[]
+				| select(
+					((.body // "") | contains($closeout_marker)) or
+					((.body // "") | contains($summary_marker)) or
+					(
+						((.body // "") | contains($legacy_merge_text)) and
+						((.body // "") | contains($merge_attribution))
+					) or
+					(
+						((.body // "") | contains($legacy_generic_text)) and
+						((.body // "") | contains($merge_attribution))
+					)
+				)
+				| {id: .id, created_at: (.created_at // "")} ]
+			| sort_by(.created_at, .id)
+			| .[].id
+		' 2>/dev/null) || closeout_ids=""
+		candidate_count=$(printf '%s\n' "$closeout_ids" | grep -c '.') || candidate_count=0
+		if [[ "$candidate_count" -eq 0 ]]; then
+			stable_observations=0
+			previous_singleton_id=""
+			((attempt < max_attempts)) && sleep 1
+			continue
+		fi
+
+		keep_id=$(printf '%s\n' "$closeout_ids" | sed -n '1p')
+		if gh api "repos/${repo_slug}/issues/comments/${keep_id}" \
+			--method PATCH --field body="$marked_comment" >/dev/null 2>&1; then
+			:
+		else
+			echo "[pulse-wrapper] Deterministic merge: failed to refresh canonical PR closeout comment ${keep_id} for ${repo_slug}#${pr_number} (attempt ${attempt}/${max_attempts}, GH#27502)" >>"$LOGFILE"
+			stable_observations=0
+			previous_singleton_id=""
+			((attempt < max_attempts)) && sleep 1
+			continue
+		fi
+
+		if [[ "$candidate_count" -eq 1 ]]; then
+			if [[ "$keep_id" == "$previous_singleton_id" ]]; then
+				stable_observations=$((stable_observations + 1))
+			else
+				stable_observations=1
+				previous_singleton_id="$keep_id"
+			fi
+			if [[ "$stable_observations" -ge 2 ]]; then
+				return 0
+			fi
+			((attempt < max_attempts)) && sleep 1
+			continue
+		fi
+		stable_observations=0
+		previous_singleton_id=""
+
+		while IFS= read -r comment_id; do
+			[[ -n "$comment_id" && "$comment_id" != "$keep_id" ]] || continue
+			if gh api "repos/${repo_slug}/issues/comments/${comment_id}" \
+				--method DELETE >/dev/null 2>&1; then
+				echo "[pulse-wrapper] Deterministic merge: removed duplicate PR closeout comment ${comment_id} for ${repo_slug}#${pr_number} (GH#27502)" >>"$LOGFILE"
+			else
+				if [[ "$attempt" -lt "$max_attempts" ]]; then
+					echo "[pulse-wrapper] Deterministic merge: failed to remove duplicate PR closeout comment ${comment_id} for ${repo_slug}#${pr_number}; retrying reconciliation (attempt ${attempt}/${max_attempts}, GH#27502)" >>"$LOGFILE"
+				else
+					echo "[pulse-wrapper] Deterministic merge: duplicate PR closeout comment ${comment_id} remains after ${max_attempts} reconciliation attempts for ${repo_slug}#${pr_number} (GH#27502)" >>"$LOGFILE"
+				fi
+			fi
+		done <<<"$closeout_ids"
+		((attempt < max_attempts)) && sleep 1
+	done
+	echo "[pulse-wrapper] Deterministic merge: PR closeout reconciliation did not reach two stable singleton observations for ${repo_slug}#${pr_number} after ${max_attempts} attempts (GH#27502)" >>"$LOGFILE"
 	return 0
 }
 
@@ -598,7 +675,7 @@ _pm_upsert_pr_closing_comment() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local closing_comment="$3"
-	local comments_json="" existing_comment_id="" marked_comment=""
+	local comments_json="" existing_comment_id="" created_comment_id="" marked_comment=""
 
 	marked_comment="<!-- PULSE_MERGE_CLOSEOUT:PR#${pr_number} -->
 ${closing_comment}"
@@ -612,16 +689,17 @@ ${closing_comment}"
 		"repos/${repo_slug}/issues/comments/${existing_comment_id}" \
 		--method PATCH --field body="$marked_comment" >/dev/null 2>&1; then
 		echo "[pulse-wrapper] Deterministic merge: upserted PR closeout comment ${existing_comment_id} for ${repo_slug}#${pr_number} (GH#27502)" >>"$LOGFILE"
-		_pm_reconcile_pr_closeout_comments "$pr_number" "$repo_slug"
+		_pm_reconcile_pr_closeout_comments "$pr_number" "$repo_slug" "$marked_comment"
 		return 0
 	fi
 
-	gh_pr_comment "$pr_number" --repo "$repo_slug" \
-		--body "$marked_comment" 2>/dev/null || true
-	# Give GitHub's comments listing a bounded visibility window before the
-	# post-write convergence pass. The later concurrent writer also reconciles.
-	sleep 1
-	_pm_reconcile_pr_closeout_comments "$pr_number" "$repo_slug"
+	created_comment_id=$(gh api "repos/${repo_slug}/issues/${pr_number}/comments" \
+		--method POST --field body="$marked_comment" --jq '.id // empty' 2>/dev/null) || created_comment_id=""
+	if [[ -z "$created_comment_id" ]]; then
+		echo "[pulse-wrapper] Deterministic merge: failed to create PR closeout for merged ${repo_slug}#${pr_number}; post-merge publication ended without a canonical PR comment (GH#27502)" >>"$LOGFILE"
+		return 0
+	fi
+	_pm_reconcile_pr_closeout_comments "$pr_number" "$repo_slug" "$marked_comment"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# test-pulse-merge-post-merge-label-fetch.sh — GH#22219 regression guard.
+# test-pulse-merge-post-merge-label-fetch.sh — GH#22219/GH#27502 regression guard.
 #
 # Verifies _handle_post_merge_actions behaviour around optional PR labels:
 # a provided empty 5th argument is authoritative and must not refetch, while an
 # omitted 5th argument falls back to fetching PR labels before setting solved
-# attribution.
+# attribution. It also verifies that repeated or concurrent post-merge handling
+# converges on one marker-bearing PR completion summary.
 
 set -euo pipefail
 
@@ -71,6 +72,9 @@ define_function_under_test() {
 	fn_src=$(awk '
 		/^_pm_issue_api\(\) \{/,/^}$/ { print }
 		/^_pm_build_closing_comment\(\) \{/,/^}$/ { print }
+		/^_pm_select_pr_closeout_comment_id\(\) \{/,/^}$/ { print }
+		/^_pm_reconcile_pr_closeout_comments\(\) \{/,/^}$/ { print }
+		/^_pm_upsert_pr_closing_comment\(\) \{/,/^}$/ { print }
 		/^_pm_resolve_superseded_original_issue\(\) \{/,/^}$/ { print }
 		/^_handle_post_merge_actions\(\) \{/,/^}$/ { print }
 		/^_extract_linked_issue\(\) \{/,/^}$/ { print }
@@ -85,6 +89,7 @@ define_function_under_test() {
 }
 
 install_helper_stubs() {
+	export TEST_PR_COMMENTS_JSON='[[]]'
 	gh() {
 		printf '%s\n' "$*" >>"$GH_CALL_LOG"
 		if [[ "$1" == "api" && "$2" == "repos/marcusquinn/aidevops/pulls/33333" ]]; then
@@ -93,6 +98,10 @@ install_helper_stubs() {
 		fi
 		if [[ "$1" == "api" && "$2" == "repos/marcusquinn/aidevops/pulls/"* ]]; then
 			return 1
+		fi
+		if [[ "$1" == "api" && "$2" == *"/comments?per_page=100" ]]; then
+			printf '%s\n' "$TEST_PR_COMMENTS_JSON"
+			return 0
 		fi
 		if [[ "$1" == "api" && "$*" == *"/comments"* ]]; then
 			printf '[]\n'
@@ -107,6 +116,13 @@ install_helper_stubs() {
 	gh_issue_comment() {
 		gh issue comment "$@"
 		return 0
+	}
+	_gh_with_timeout() {
+		local access_mode="$1"
+		shift
+		: "$access_mode"
+		"$@"
+		return $?
 	}
 	gh_pr_view() {
 		printf 'pr view %s\n' "$*" >>"$GH_CALL_LOG"
@@ -137,10 +153,12 @@ install_helper_stubs() {
 	}
 	unlock_issue_after_worker() { return 0; }
 	fast_fail_reset() { return 0; }
+	reconcile_dependants_after_verified_closure() { return 0; }
 	_release_interactive_claim_on_merge() { return 0; }
 	auto_file_next_phase() { return 0; }
 	_unblock_circuit_breaker_meta_pr() { return 0; }
 	_pm_handle_partial_parent_closeout() { return 0; }
+	sleep() { return 0; }
 	return 0
 }
 
@@ -242,6 +260,61 @@ test_closing_comment_defaults_to_main_for_legacy_callers() {
 	return 0
 }
 
+test_pr_closeout_reuses_merge_summary_comment() {
+	: >"$GH_CALL_LOG"
+	export TEST_PR_COMMENTS_JSON='[[{"id":101,"created_at":"2026-07-13T16:00:00Z","body":"<!-- MERGE_SUMMARY --> original"}]]'
+
+	_handle_post_merge_actions "755" "marcusquinn/aidevops" "" "merged" "origin:worker"
+
+	assert_log_contains "$GH_CALL_LOG" "issues/comments/101 --method PATCH" \
+		"PR closeout patches the canonical MERGE_SUMMARY comment"
+	assert_log_contains "$GH_CALL_LOG" "PULSE_MERGE_CLOSEOUT:PR#755" \
+		"patched PR closeout receives the deterministic singleton marker"
+	assert_log_not_contains "$GH_CALL_LOG" "pr comment 755" \
+		"PR closeout does not append when MERGE_SUMMARY exists"
+	return 0
+}
+
+test_pr_closeout_reuses_existing_closeout_comment() {
+	: >"$GH_CALL_LOG"
+	export TEST_PR_COMMENTS_JSON='[[{"id":201,"created_at":"2026-07-13T16:00:00Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#756 --> existing"}]]'
+
+	_handle_post_merge_actions "756" "marcusquinn/aidevops" "" "merged" "origin:worker"
+	_handle_post_merge_actions "756" "marcusquinn/aidevops" "" "merged" "origin:worker"
+
+	assert_log_contains "$GH_CALL_LOG" "issues/comments/201 --method PATCH" \
+		"repeated PR closeout handling updates the existing singleton"
+	assert_log_not_contains "$GH_CALL_LOG" "pr comment 756" \
+		"repeated PR closeout handling never appends another summary"
+	return 0
+}
+
+test_pr_closeout_reconciles_concurrent_duplicates() {
+	: >"$GH_CALL_LOG"
+	export TEST_PR_COMMENTS_JSON='[[{"id":301,"created_at":"2026-07-13T16:00:00Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#757 --> first"},{"id":302,"created_at":"2026-07-13T16:00:08Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#757 --> duplicate"}]]'
+
+	_handle_post_merge_actions "757" "marcusquinn/aidevops" "" "merged" "origin:worker"
+
+	assert_log_contains "$GH_CALL_LOG" "issues/comments/301 --method PATCH" \
+		"concurrent closeout reconciliation preserves the oldest singleton"
+	assert_log_contains "$GH_CALL_LOG" "issues/comments/302 --method DELETE" \
+		"concurrent closeout reconciliation deletes the newer duplicate"
+	return 0
+}
+
+test_pr_closeout_fallback_posts_marked_comment() {
+	: >"$GH_CALL_LOG"
+	export TEST_PR_COMMENTS_JSON='[[]]'
+
+	_handle_post_merge_actions "758" "marcusquinn/aidevops" "" "merged" "origin:worker"
+
+	assert_log_contains "$GH_CALL_LOG" "pr comment 758" \
+		"PR closeout fallback posts when no reusable comment exists"
+	assert_log_contains "$GH_CALL_LOG" "PULSE_MERGE_CLOSEOUT:PR#758" \
+		"PR closeout fallback is marked for post-write convergence"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -253,6 +326,10 @@ main() {
 	test_superseded_pr_closes_original_issue
 	test_closing_comment_uses_pr_base_ref
 	test_closing_comment_defaults_to_main_for_legacy_callers
+	test_pr_closeout_reuses_merge_summary_comment
+	test_pr_closeout_reuses_existing_closeout_comment
+	test_pr_closeout_reconciles_concurrent_duplicates
+	test_pr_closeout_fallback_posts_marked_comment
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -eq 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -43,9 +43,13 @@ setup_test_env() {
 	export LOGFILE="${TEST_ROOT}/pulse.log"
 	export GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
 	export SOLVED_LABEL_LOG="${TEST_ROOT}/solved-labels.log"
+	export TEST_PR_COMMENTS_FILE="${TEST_ROOT}/pr-comments.json"
+	export TEST_PR_SNAPSHOT_QUEUE_FILE="${TEST_ROOT}/pr-comment-snapshots.ndjson"
 	: >"$LOGFILE"
 	: >"$GH_CALL_LOG"
 	: >"$SOLVED_LABEL_LOG"
+	: >"$TEST_PR_SNAPSHOT_QUEUE_FILE"
+	printf '[]\n' >"$TEST_PR_COMMENTS_FILE"
 
 	export AGENTS_DIR="${TEST_ROOT}"
 	mkdir -p "${AGENTS_DIR}/scripts"
@@ -63,6 +67,49 @@ EOF
 teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+set_pr_comments() {
+	local comments_json="$1"
+	printf '%s\n' "$comments_json" >"$TEST_PR_COMMENTS_FILE"
+	return 0
+}
+
+set_comment_snapshots() {
+	local snapshots="$1"
+	printf '%s\n' "$snapshots" >"$TEST_PR_SNAPSHOT_QUEUE_FILE"
+	return 0
+}
+
+assert_completion_candidate_count() {
+	local expected_count="$1"
+	local pr_number="$2"
+	local label="$3"
+	local actual_count
+	actual_count=$(jq --arg closeout_marker "<!-- PULSE_MERGE_CLOSEOUT:PR#${pr_number} -->" \
+		--arg legacy_generic_text "Completed via PR #${pr_number}, merged to" \
+		--arg legacy_merge_text "Merged via PR #${pr_number} to" \
+		--arg merge_attribution 'Merged by deterministic merge pass (pulse-wrapper.sh).' \
+		--arg summary_marker '<!-- MERGE_SUMMARY -->' '
+		[ .[] | select(
+			((.body // "") | contains($closeout_marker)) or
+			((.body // "") | contains($summary_marker)) or
+			(
+				((.body // "") | contains($legacy_merge_text)) and
+				((.body // "") | contains($merge_attribution))
+			) or
+			(
+				((.body // "") | contains($legacy_generic_text)) and
+				((.body // "") | contains($merge_attribution))
+			)
+		) ] | length
+	' "$TEST_PR_COMMENTS_FILE")
+	if [[ "$actual_count" == "$expected_count" ]]; then
+		pass "$label"
+	else
+		fail "$label" "Expected ${expected_count} completion candidate(s), found ${actual_count}"
 	fi
 	return 0
 }
@@ -88,27 +135,71 @@ define_function_under_test() {
 	return 0
 }
 
-install_helper_stubs() {
-	export TEST_PR_COMMENTS_JSON='[[]]'
-	gh() {
-		printf '%s\n' "$*" >>"$GH_CALL_LOG"
-		if [[ "$1" == "api" && "$2" == "repos/marcusquinn/aidevops/pulls/33333" ]]; then
-			printf '{"number":33333}\n'
+gh() {
+	local api_path="${2:-}" arg="" body="" comment_id="" next_id="" snapshot="" state_tmp=""
+	printf '%s\n' "$*" >>"$GH_CALL_LOG"
+	if [[ "$1" == "api" && "$api_path" == "repos/marcusquinn/aidevops/pulls/33333" ]]; then
+		printf '{"number":33333}\n'
+		return 0
+	fi
+	if [[ "$1" == "api" && "$api_path" == "repos/marcusquinn/aidevops/pulls/"* ]]; then
+		return 1
+	fi
+	if [[ "$1" == "api" && "$api_path" == *"/comments?per_page=100" ]]; then
+		if IFS= read -r snapshot <"$TEST_PR_SNAPSHOT_QUEUE_FILE" && [[ -n "$snapshot" ]]; then
+			printf '%s\n' "$snapshot"
+			state_tmp="${TEST_PR_SNAPSHOT_QUEUE_FILE}.tmp"
+			sed '1d' "$TEST_PR_SNAPSHOT_QUEUE_FILE" >"$state_tmp"
+			mv "$state_tmp" "$TEST_PR_SNAPSHOT_QUEUE_FILE"
 			return 0
 		fi
-		if [[ "$1" == "api" && "$2" == "repos/marcusquinn/aidevops/pulls/"* ]]; then
+		jq -c '[.]' "$TEST_PR_COMMENTS_FILE"
+		return 0
+	fi
+	for arg in "$@"; do
+		case "$arg" in
+		body=*) body="${arg#body=}" ;;
+		esac
+	done
+	if [[ "$1" == "api" && "$api_path" == *"/issues/comments/"* && "$*" == *"--method PATCH"* ]]; then
+		comment_id="${api_path##*/}"
+		if [[ ",${TEST_FAIL_PATCH_IDS}," == *",${comment_id},"* ]]; then
 			return 1
 		fi
-		if [[ "$1" == "api" && "$2" == *"/comments?per_page=100" ]]; then
-			printf '%s\n' "$TEST_PR_COMMENTS_JSON"
-			return 0
-		fi
-		if [[ "$1" == "api" && "$*" == *"/comments"* ]]; then
-			printf '[]\n'
-		fi
+		state_tmp="${TEST_PR_COMMENTS_FILE}.tmp"
+		jq --argjson id "$comment_id" --arg body "$body" \
+			'map(if .id == $id then .body = $body else . end)' \
+			"$TEST_PR_COMMENTS_FILE" >"$state_tmp"
+		mv "$state_tmp" "$TEST_PR_COMMENTS_FILE"
 		return 0
-	}
+	fi
+	if [[ "$1" == "api" && "$api_path" == *"/issues/comments/"* && "$*" == *"--method DELETE"* ]]; then
+		comment_id="${api_path##*/}"
+		state_tmp="${TEST_PR_COMMENTS_FILE}.tmp"
+		jq --argjson id "$comment_id" 'map(select(.id != $id))' \
+			"$TEST_PR_COMMENTS_FILE" >"$state_tmp"
+		mv "$state_tmp" "$TEST_PR_COMMENTS_FILE"
+		return 0
+	fi
+	if [[ "$1" == "api" && "$api_path" == *"/issues/"*"/comments" && "$*" == *"--method POST"* ]]; then
+		next_id=$(jq '[.[].id] | max // 400' "$TEST_PR_COMMENTS_FILE")
+		next_id=$((next_id + 1))
+		state_tmp="${TEST_PR_COMMENTS_FILE}.tmp"
+		jq --argjson id "$next_id" --arg body "$body" \
+			'. + [{id: $id, created_at: "2026-07-13T17:00:00Z", body: $body}]' \
+			"$TEST_PR_COMMENTS_FILE" >"$state_tmp"
+		mv "$state_tmp" "$TEST_PR_COMMENTS_FILE"
+		printf '%s\n' "$next_id"
+		return 0
+	fi
+	if [[ "$1" == "api" && "$*" == *"/comments"* ]]; then
+		printf '[]\n'
+	fi
+	return 0
+}
 
+install_helper_stubs() {
+	export TEST_FAIL_PATCH_IDS=""
 	gh_pr_comment() {
 		gh pr comment "$@"
 		return 0
@@ -262,7 +353,7 @@ test_closing_comment_defaults_to_main_for_legacy_callers() {
 
 test_pr_closeout_reuses_merge_summary_comment() {
 	: >"$GH_CALL_LOG"
-	export TEST_PR_COMMENTS_JSON='[[{"id":101,"created_at":"2026-07-13T16:00:00Z","body":"<!-- MERGE_SUMMARY --> original"}]]'
+	set_pr_comments '[{"id":101,"created_at":"2026-07-13T16:00:00Z","body":"<!-- MERGE_SUMMARY --> original"}]'
 
 	_handle_post_merge_actions "755" "marcusquinn/aidevops" "" "merged" "origin:worker"
 
@@ -270,48 +361,93 @@ test_pr_closeout_reuses_merge_summary_comment() {
 		"PR closeout patches the canonical MERGE_SUMMARY comment"
 	assert_log_contains "$GH_CALL_LOG" "PULSE_MERGE_CLOSEOUT:PR#755" \
 		"patched PR closeout receives the deterministic singleton marker"
-	assert_log_not_contains "$GH_CALL_LOG" "pr comment 755" \
+	assert_log_not_contains "$GH_CALL_LOG" "issues/755/comments --method POST" \
 		"PR closeout does not append when MERGE_SUMMARY exists"
+	assert_completion_candidate_count 1 755 \
+		"MERGE_SUMMARY upsert leaves exactly one completion candidate"
 	return 0
 }
 
 test_pr_closeout_reuses_existing_closeout_comment() {
 	: >"$GH_CALL_LOG"
-	export TEST_PR_COMMENTS_JSON='[[{"id":201,"created_at":"2026-07-13T16:00:00Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#756 --> existing"}]]'
+	set_pr_comments '[{"id":201,"created_at":"2026-07-13T16:00:00Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#756 --> existing"}]'
 
 	_handle_post_merge_actions "756" "marcusquinn/aidevops" "" "merged" "origin:worker"
 	_handle_post_merge_actions "756" "marcusquinn/aidevops" "" "merged" "origin:worker"
 
 	assert_log_contains "$GH_CALL_LOG" "issues/comments/201 --method PATCH" \
 		"repeated PR closeout handling updates the existing singleton"
-	assert_log_not_contains "$GH_CALL_LOG" "pr comment 756" \
+	assert_log_not_contains "$GH_CALL_LOG" "issues/756/comments --method POST" \
 		"repeated PR closeout handling never appends another summary"
+	assert_completion_candidate_count 1 756 \
+		"repeated PR closeout handling leaves exactly one completion candidate"
 	return 0
 }
 
 test_pr_closeout_reconciles_concurrent_duplicates() {
 	: >"$GH_CALL_LOG"
-	export TEST_PR_COMMENTS_JSON='[[{"id":301,"created_at":"2026-07-13T16:00:00Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#757 --> first"},{"id":302,"created_at":"2026-07-13T16:00:08Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#757 --> duplicate"}]]'
+	set_pr_comments '[{"id":301,"created_at":"2026-07-13T16:00:00Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#757 --> first"},{"id":302,"created_at":"2026-07-13T16:00:04Z","body":"<!-- MERGE_SUMMARY --> duplicate source"},{"id":303,"created_at":"2026-07-13T16:00:08Z","body":"duplicate closeout\nMerged via PR #757 to develop.\n_Merged by deterministic merge pass (pulse-wrapper.sh)._"},{"id":304,"created_at":"2026-07-13T16:00:12Z","body":"Completed via PR #757, merged to develop.\n_Merged by deterministic merge pass (pulse-wrapper.sh)._"}]'
 
 	_handle_post_merge_actions "757" "marcusquinn/aidevops" "" "merged" "origin:worker"
 
 	assert_log_contains "$GH_CALL_LOG" "issues/comments/301 --method PATCH" \
 		"concurrent closeout reconciliation preserves the oldest singleton"
 	assert_log_contains "$GH_CALL_LOG" "issues/comments/302 --method DELETE" \
-		"concurrent closeout reconciliation deletes the newer duplicate"
+		"concurrent closeout reconciliation deletes duplicate MERGE_SUMMARY comments"
+	assert_log_contains "$GH_CALL_LOG" "issues/comments/303 --method DELETE" \
+		"concurrent closeout reconciliation deletes legacy unmarked duplicates"
+	assert_log_contains "$GH_CALL_LOG" "issues/comments/304 --method DELETE" \
+		"concurrent closeout reconciliation deletes legacy generic duplicates"
+	assert_completion_candidate_count 1 757 \
+		"concurrent closeout reconciliation converges to one completion candidate"
+	return 0
+}
+
+test_pr_closeout_rechecks_delayed_visibility() {
+	: >"$GH_CALL_LOG"
+	set_pr_comments '[{"id":401,"created_at":"2026-07-13T16:00:00Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#759 --> first"},{"id":402,"created_at":"2026-07-13T16:00:08Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#759 --> delayed duplicate"}]'
+	set_comment_snapshots '[[{"id":402,"created_at":"2026-07-13T16:00:08Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#759 --> delayed duplicate"}]]'
+
+	_pm_reconcile_pr_closeout_comments "759" "marcusquinn/aidevops" \
+		'<!-- PULSE_MERGE_CLOSEOUT:PR#759 --> canonical'
+
+	assert_log_contains "$GH_CALL_LOG" "issues/comments/402 --method DELETE" \
+		"reconciliation rechecks after an apparently clean delayed snapshot"
+	assert_completion_candidate_count 1 759 \
+		"delayed visibility reconciliation converges to one candidate"
+	return 0
+}
+
+test_pr_closeout_preserves_duplicates_when_canonical_refresh_fails() {
+	: >"$GH_CALL_LOG"
+	export TEST_FAIL_PATCH_IDS="501"
+	set_pr_comments '[{"id":501,"created_at":"2026-07-13T16:00:00Z","body":"<!-- MERGE_SUMMARY --> stale source"},{"id":502,"created_at":"2026-07-13T16:00:08Z","body":"<!-- PULSE_MERGE_CLOSEOUT:PR#760 --> valid fallback"}]'
+
+	_pm_reconcile_pr_closeout_comments "760" "marcusquinn/aidevops" \
+		'<!-- PULSE_MERGE_CLOSEOUT:PR#760 --> canonical'
+
+	assert_log_not_contains "$GH_CALL_LOG" "--method DELETE" \
+		"failed canonical refresh never deletes the valid fallback"
+	assert_log_contains "$LOGFILE" "did not reach two stable singleton observations" \
+		"failed canonical refresh reports exhausted convergence"
+	assert_completion_candidate_count 2 760 \
+		"failed canonical refresh preserves both recoverable candidates"
+	export TEST_FAIL_PATCH_IDS=""
 	return 0
 }
 
 test_pr_closeout_fallback_posts_marked_comment() {
 	: >"$GH_CALL_LOG"
-	export TEST_PR_COMMENTS_JSON='[[]]'
+	set_pr_comments '[]'
 
 	_handle_post_merge_actions "758" "marcusquinn/aidevops" "" "merged" "origin:worker"
 
-	assert_log_contains "$GH_CALL_LOG" "pr comment 758" \
+	assert_log_contains "$GH_CALL_LOG" "issues/758/comments --method POST" \
 		"PR closeout fallback posts when no reusable comment exists"
 	assert_log_contains "$GH_CALL_LOG" "PULSE_MERGE_CLOSEOUT:PR#758" \
 		"PR closeout fallback is marked for post-write convergence"
+	assert_completion_candidate_count 1 758 \
+		"PR closeout fallback leaves exactly one completion candidate"
 	return 0
 }
 
@@ -329,6 +465,8 @@ main() {
 	test_pr_closeout_reuses_merge_summary_comment
 	test_pr_closeout_reuses_existing_closeout_comment
 	test_pr_closeout_reconciles_concurrent_duplicates
+	test_pr_closeout_rechecks_delayed_visibility
+	test_pr_closeout_preserves_duplicates_when_canonical_refresh_fails
 	test_pr_closeout_fallback_posts_marked_comment
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Convert deterministic PR merge closeouts into a marker-based singleton upsert, converge cross-runner races on the oldest comment, and reconcile MERGE_SUMMARY plus legacy duplicate forms.

## Files Changed

.agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 32 focused post-merge tests passed; ShellCheck and bash syntax passed; changed-file local linters passed; pulse canary, standalone merge routine, and strict-mode tests passed.

Resolves #27502


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.88 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 24m and 232,075 tokens on this with the user in an interactive session.