### PR TITLE
GH#27505: synchronize OpenCode, Tabby, and release-version titles

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -329,11 +329,12 @@ export async function AidevopsPlugin({ directory, client }) {
     isHeadless,
   });
   const sessionTitleSuffixHandler = createSessionTitleSuffixHandler({
+    activeAgentsDir: ACTIVE_AGENTS_DIR,
     agentsDir: AGENTS_DIR,
     client,
   });
   const sessionTitleFallbackHandler = createSessionTitleFallbackHandler({
-    agentsDir: AGENTS_DIR,
+    agentsDir: ACTIVE_AGENTS_DIR,
     client,
   });
 

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -238,6 +238,7 @@ export async function AidevopsPlugin({ directory, client }) {
   });
 
   const shellEnvHook = createShellEnvHook({
+    activeAgentsDir: ACTIVE_AGENTS_DIR,
     agentsDir: AGENTS_DIR,
     scriptsDir: SCRIPTS_DIR,
     workspaceDir: WORKSPACE_DIR,

--- a/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
@@ -20,11 +20,15 @@ function readIfExists(filepath) {
   return "";
 }
 
-export function readAidevopsVersion(agentsDir) {
+export function readAidevopsVersion(activeAgentsDir, runtimeAgentsDir = activeAgentsDir) {
+  const activeVersion = readIfExists(join(activeAgentsDir, "VERSION"));
+  if (activeVersion) return activeVersion;
+  if (process.env.AIDEVOPS_VERSION?.trim()) return process.env.AIDEVOPS_VERSION.trim();
+
   const candidates = [
-    join(agentsDir, "VERSION"),
-    join(agentsDir, "..", "VERSION"),
-    join(agentsDir, "..", "version"),
+    join(runtimeAgentsDir, "VERSION"),
+    join(runtimeAgentsDir, "..", "VERSION"),
+    join(runtimeAgentsDir, "..", "version"),
   ];
 
   for (const candidate of candidates) {
@@ -50,8 +54,8 @@ function isDefaultSessionTitle(title) {
   return DEFAULT_SESSION_TITLE_RE.test(baseTitle) || baseTitle === "New Session";
 }
 
-function shouldSuffixSessionTitle(update) {
-  if (update.eventType !== "session.updated") return false;
+function shouldSynchronizeSessionTitle(update) {
+  if (update.eventType !== "session.created" && update.eventType !== "session.updated") return false;
   if (!update.title) return false;
   return !isDefaultSessionTitle(update.title);
 }
@@ -90,20 +94,26 @@ async function updateSessionTitle(client, sessionID, title) {
   }
 }
 
-export function createSessionTitleSuffixHandler({ agentsDir, client, emitTerminalTitle = defaultEmitTerminalTitle }) {
+export function createSessionTitleSuffixHandler({
+  activeAgentsDir,
+  agentsDir = activeAgentsDir,
+  client,
+  emitTerminalTitle = defaultEmitTerminalTitle,
+}) {
   const inFlight = new Set();
 
   return async function sessionTitleSuffixHandler(input) {
-    if (typeof client?.session?.update !== "function") return;
-
     const update = getSessionUpdate(input);
-    if (!shouldSuffixSessionTitle(update)) return;
+    if (!shouldSynchronizeSessionTitle(update)) return;
 
-    const version = readAidevopsVersion(agentsDir);
+    const version = readAidevopsVersion(activeAgentsDir || agentsDir, agentsDir);
     const suffixedTitle = withAidevopsTitleSuffix(update.title, version);
-    if (suffixedTitle === update.title) return;
-
     if (!update.sessionID || inFlight.has(update.sessionID)) return;
+    if (suffixedTitle === update.title) {
+      emitTerminalTitle(suffixedTitle);
+      return;
+    }
+    if (typeof client?.session?.update !== "function") return;
 
     inFlight.add(update.sessionID);
     try {

--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -105,11 +105,11 @@ function shellSessionOrigin(env) {
 
 /**
  * Create the shell environment hook.
- * @param {object} deps - { agentsDir, scriptsDir, workspaceDir, version? }
+ * @param {object} deps - { activeAgentsDir?, agentsDir, scriptsDir, workspaceDir, version? }
  * @returns {Function} Shell env hook function
  */
 export function createShellEnvHook(deps) {
-  const { agentsDir = "", scriptsDir = "", workspaceDir = "", version } = deps || {};
+  const { activeAgentsDir = "", agentsDir = "", scriptsDir = "", workspaceDir = "", version } = deps || {};
   const precomputedVersion = typeof version === "string" ? version.trim() : "";
 
   /**
@@ -127,6 +127,7 @@ export function createShellEnvHook(deps) {
 
     // Set aidevops workspace directory
     output.env.AIDEVOPS_AGENTS_DIR = agentsDir;
+    if (hasAgentsDir(activeAgentsDir)) output.env.AIDEVOPS_ACTIVE_AGENTS_DIR = activeAgentsDir;
     output.env.AIDEVOPS_WORKSPACE_DIR = workspaceDir;
     const sessionOrigin = shellSessionOrigin(output.env);
     output.env.AIDEVOPS_SESSION_ORIGIN = sessionOrigin;
@@ -141,6 +142,7 @@ export function createShellEnvHook(deps) {
     // Set aidevops version if available. Prefer the deployed framework version
     // source; ~/.aidevops/version is a legacy/stale compatibility fallback.
     const version = precomputedVersion ||
+      (hasAgentsDir(activeAgentsDir) ? readIfExists(join(activeAgentsDir, "VERSION")) : "") ||
       (hasAgentsDir(agentsDir)
         ? readIfExists(join(agentsDir, "VERSION")) ||
           readIfExists(join(agentsDir, "..", "VERSION")) ||

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -89,14 +89,21 @@ i'd like to add the capabilities this repo offers. there may be overlap`),
 });
 
 test("version reader prefers deployed agents VERSION", async () => {
-  await withoutEnvVersion(() =>
-    withTempAgentsDir((agentsDir) => {
-      writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");
-      writeFileSync(join(agentsDir, "..", "version"), "2.44.2\n");
+  await withTempAgentsDir((activeAgentsDir) => {
+    const runtimeAgentsDir = join(activeAgentsDir, "..", "runtime-agents");
+    mkdirSync(runtimeAgentsDir);
+    writeFileSync(join(activeAgentsDir, "VERSION"), "3.20.102\n");
+    writeFileSync(join(runtimeAgentsDir, "VERSION"), "3.20.101\n");
+    const saved = process.env.AIDEVOPS_VERSION;
+    process.env.AIDEVOPS_VERSION = "3.20.100";
 
-      assert.equal(readAidevopsVersion(agentsDir), "3.20.102");
-    }),
-  );
+    try {
+      assert.equal(readAidevopsVersion(activeAgentsDir, runtimeAgentsDir), "3.20.102");
+    } finally {
+      if (saved === undefined) delete process.env.AIDEVOPS_VERSION;
+      else process.env.AIDEVOPS_VERSION = saved;
+    }
+  });
 });
 
 test("session.updated handler appends suffix through OpenCode session update API", async () => {
@@ -144,8 +151,13 @@ test("session.updated handler is idempotent when suffix already exists", async (
   await withTempAgentsDir(async (agentsDir) => {
     writeFileSync(join(agentsDir, "VERSION"), "3.20.103\n");
     const calls = [];
+    const terminalTitles = [];
     const client = { session: { update: async (payload) => calls.push(payload) } };
-    const handler = createSessionTitleSuffixHandler({ agentsDir, client });
+    const handler = createSessionTitleSuffixHandler({
+      agentsDir,
+      client,
+      emitTerminalTitle: (title) => terminalTitles.push(title),
+    });
 
     await handler({
       event: {
@@ -158,6 +170,31 @@ test("session.updated handler is idempotent when suffix already exists", async (
     });
 
     assert.deepEqual(calls, []);
+    assert.deepEqual(terminalTitles, ["Work · AIDevOps 3.20.103"]);
+  });
+});
+
+test("session.created handler reasserts a restored session title to the terminal", async () => {
+  await withTempAgentsDir(async (agentsDir) => {
+    writeFileSync(join(agentsDir, "VERSION"), "3.20.103\n");
+    const terminalTitles = [];
+    const handler = createSessionTitleSuffixHandler({
+      agentsDir,
+      client: { session: {} },
+      emitTerminalTitle: (title) => terminalTitles.push(title),
+    });
+
+    await handler({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: "ses_restored",
+          info: { id: "ses_restored", title: "Restored work · AIDevOps 3.20.103" },
+        },
+      },
+    });
+
+    assert.deepEqual(terminalTitles, ["Restored work · AIDevOps 3.20.103"]);
   });
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -168,6 +168,29 @@ test("shell env version prefers deployed agents VERSION over legacy version", as
   });
 });
 
+test("shell env version follows active deployment instead of pinned runtime bundle", async () => {
+  await withTempAgentsDir(async (activeAgentsDir) => {
+    const runtimeAgentsDir = join(activeAgentsDir, "..", "runtime-agents");
+    mkdirSync(runtimeAgentsDir);
+    writeFileSync(join(activeAgentsDir, "VERSION"), "3.20.103\n");
+    writeFileSync(join(runtimeAgentsDir, "VERSION"), "3.20.102\n");
+
+    const hook = createShellEnvHook({
+      activeAgentsDir,
+      agentsDir: runtimeAgentsDir,
+      scriptsDir: join(runtimeAgentsDir, "scripts"),
+      workspaceDir: "/tmp/aidevops-workspace",
+    });
+    const output = { env: { PATH: "/usr/bin:/bin", AIDEVOPS_VERSION: "3.20.101" } };
+
+    await hook({ sessionID: "interactive-session" }, output);
+
+    assert.equal(output.env.AIDEVOPS_ACTIVE_AGENTS_DIR, activeAgentsDir);
+    assert.equal(output.env.AIDEVOPS_AGENTS_DIR, runtimeAgentsDir);
+    assert.equal(output.env.AIDEVOPS_VERSION, "3.20.103");
+  });
+});
+
 test("shell env version uses precomputed dependency before filesystem fallbacks", async () => {
   await withTempAgentsDir(async (agentsDir) => {
     writeFileSync(join(agentsDir, "VERSION"), "3.20.102\n");

--- a/.agents/scripts/session-rename-helper.sh
+++ b/.agents/scripts/session-rename-helper.sh
@@ -87,29 +87,25 @@ _sql_escape() {
 # Read the currently deployed aidevops version.
 # Output: version on stdout, or empty string if unavailable.
 _get_aidevops_version() {
+	local active_agents_dir="${AIDEVOPS_ACTIVE_AGENTS_DIR:-${HOME:-}/.aidevops/agents}"
+	local version_file="${active_agents_dir}/VERSION"
+	if [[ -f "$version_file" ]]; then
+		tr -d '[:space:]' <"$version_file"
+		return 0
+	fi
+
 	if [[ -n "${AIDEVOPS_VERSION:-}" ]]; then
 		printf '%s' "$AIDEVOPS_VERSION"
 		return 0
 	fi
 
-	local version_file="${SCRIPT_DIR}/../../VERSION"
+	version_file="${SCRIPT_DIR}/../../VERSION"
 	if [[ -f "$version_file" ]]; then
 		tr -d '[:space:]' <"$version_file"
 		return 0
 	fi
 
 	version_file="${SCRIPT_DIR}/../VERSION"
-	if [[ -f "$version_file" ]]; then
-		tr -d '[:space:]' <"$version_file"
-		return 0
-	fi
-
-	local home_dir="${HOME:-}"
-	if [[ -z "$home_dir" ]]; then
-		return 0
-	fi
-
-	version_file="${home_dir}/.aidevops/agents/VERSION"
 	if [[ -f "$version_file" ]]; then
 		tr -d '[:space:]' <"$version_file"
 		return 0

--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -142,6 +142,7 @@ def build_profile_yaml(
     color: '{tab_colour}'
     id: {profile_id}
     group: {group_id}
+    disableDynamicTitle: false
     type: local"""
 
     return profile
@@ -327,6 +328,26 @@ def _profile_block_end(lines: list[str], start: int) -> int:
     return _block_end(lines, start, 2)
 
 
+def _enable_dynamic_title(profile_text: str) -> tuple[str, bool]:
+    """Allow OSC title updates for one aidevops-managed OpenCode profile."""
+    lines = profile_text.split("\n")
+    for index, line in enumerate(lines):
+        if re.match(r"^    disableDynamicTitle:\s*", line):
+            replacement = "    disableDynamicTitle: false"
+            if line == replacement:
+                return profile_text, False
+            lines[index] = replacement
+            return "\n".join(lines), True
+
+    insert_at = len(lines)
+    for index, line in enumerate(lines):
+        if re.match(r"^    type:\s*", line):
+            insert_at = index
+            break
+    lines.insert(insert_at, "    disableDynamicTitle: false")
+    return "\n".join(lines), True
+
+
 def _repair_broken_opencode_launch_profile_block(config_text: str) -> tuple[str, int]:
     """Repair fragile Tabby OpenCode launch profiles inside one profile block.
 
@@ -501,11 +522,11 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
             i = block_end
             continue
 
-        repaired_block, repaired_count = _repair_broken_opencode_launch_profile_block(
-            "\n".join(profile_lines)
-        )
+        original_block = "\n".join(profile_lines)
+        repaired_block, repaired_count = _repair_broken_opencode_launch_profile_block(original_block)
+        repaired_block, dynamic_title_changed = _enable_dynamic_title(repaired_block)
         repaired.extend(repaired_block.split("\n"))
-        repairs += repaired_count
+        repairs += max(repaired_count, int(dynamic_title_changed))
         i = block_end
 
     return "\n".join(repaired), repairs

--- a/.agents/scripts/tests/test-session-rename-helper.sh
+++ b/.agents/scripts/tests/test-session-rename-helper.sh
@@ -69,6 +69,9 @@ setup_fixture() {
 	TMPDIR_ROOT="$(mktemp -d)"
 	REPO_DIR="${TMPDIR_ROOT}/fake-repo"
 	DB_PATH="${TMPDIR_ROOT}/opencode.db"
+	export AIDEVOPS_ACTIVE_AGENTS_DIR="${TMPDIR_ROOT}/active-agents"
+	mkdir -p "$AIDEVOPS_ACTIVE_AGENTS_DIR"
+	printf '%s\n' "9.8.7" >"${AIDEVOPS_ACTIVE_AGENTS_DIR}/VERSION"
 
 	# Create a minimal git repo so `git rev-parse --abbrev-ref HEAD` works.
 	mkdir -p "$REPO_DIR"
@@ -236,10 +239,20 @@ assert_eq "issue prefix preserved before suffix" "Issue #456: preserve prefix ·
 echo ""
 echo "Test 11: repo-root VERSION fallback works"
 seed_session "New Session"
-env -u AIDEVOPS_VERSION OPENCODE_DB="$DB_PATH" "$HELPER" rename "$SESSION_ID" "Issue #789: root version" >/dev/null 2>&1
+env -u AIDEVOPS_VERSION AIDEVOPS_ACTIVE_AGENTS_DIR="${TMPDIR_ROOT}/missing-agents" OPENCODE_DB="$DB_PATH" "$HELPER" rename "$SESSION_ID" "Issue #789: root version" >/dev/null 2>&1
 rc=$?
 assert_exit "exit 0 root version fallback" "0" "$rc"
 assert_eq "root VERSION suffix used" "Issue #789: root version · AIDevOps ${ROOT_VERSION}" "$(get_title)"
+
+# Test 12: live deployed VERSION wins over a stale process environment value.
+echo ""
+echo "Test 12: active deployed VERSION wins over stale environment"
+seed_session "New Session"
+printf '%s\n' "9.8.8" >"${AIDEVOPS_ACTIVE_AGENTS_DIR}/VERSION"
+AIDEVOPS_VERSION="9.8.7" OPENCODE_DB="$DB_PATH" "$HELPER" rename "$SESSION_ID" "Issue #790: deployed version" >/dev/null 2>&1
+rc=$?
+assert_exit "exit 0 deployed version precedence" "0" "$rc"
+assert_eq "active deployed version used" "Issue #790: deployed version · AIDevOps 9.8.8" "$(get_title)"
 
 # -----------------------------------------------------------------------------
 # Summary

--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -201,9 +201,26 @@ assertEq(
   "Fix title renaming · AIDevOps 9.8.7",
   withAidevopsTitleSuffix("[Image 1] Fix title renaming", "9.8.7"),
 );
-process.env.AIDEVOPS_VERSION = "7.6.5";
-assertEq("env version override is read", "7.6.5", getAidevopsVersion());
-delete process.env.AIDEVOPS_VERSION;
+const versionRoot = mkdtempSync(join(tmpdir(), "title-version-"));
+try {
+  const activeAgentsDir = join(versionRoot, "active-agents");
+  const missingAgentsDir = join(versionRoot, "missing-agents");
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  mkdirSync(activeAgentsDir);
+  writeFileSync(join(activeAgentsDir, "VERSION"), "7.6.6\n");
+  assertEq(
+    "active deployed version wins over stale env",
+    "7.6.6",
+    getAidevopsVersion({ AIDEVOPS_ACTIVE_AGENTS_DIR: activeAgentsDir, AIDEVOPS_VERSION: "7.6.5" }),
+  );
+  assertEq(
+    "env version remains a fallback",
+    "7.6.5",
+    getAidevopsVersion({ AIDEVOPS_ACTIVE_AGENTS_DIR: missingAgentsDir, AIDEVOPS_VERSION: "7.6.5" }),
+  );
+} finally {
+  rmSync(versionRoot, { recursive: true, force: true });
+}
 
 // --- OpenCode DB path helpers ------------------------------------------------
 console.log("\nGroup 5: OpenCode DB path helpers");

--- a/.opencode/lib/session-title-suffix.ts
+++ b/.opencode/lib/session-title-suffix.ts
@@ -14,14 +14,16 @@ function readVersionFile(path: string): string {
   }
 }
 
-export function getAidevopsVersion(): string {
-  if (process.env.AIDEVOPS_VERSION) return process.env.AIDEVOPS_VERSION.trim()
-
+export function getAidevopsVersion(env: NodeJS.ProcessEnv = process.env): string {
   const here = dirname(fileURLToPath(import.meta.url))
+  const activeAgentsDir = env.AIDEVOPS_ACTIVE_AGENTS_DIR || join(env.HOME || "", ".aidevops", "agents")
+  const activeVersion = readVersionFile(join(activeAgentsDir, "VERSION"))
+  if (activeVersion) return activeVersion
+  if (env.AIDEVOPS_VERSION?.trim()) return env.AIDEVOPS_VERSION.trim()
+
   const candidates = [
     join(here, "..", "..", "VERSION"),
     join(here, "..", "..", ".agents", "VERSION"),
-    join(process.env.HOME || "", ".aidevops", "agents", "VERSION"),
   ]
 
   for (const candidate of candidates) {

--- a/tests/test-tabby-profile-sync.py
+++ b/tests/test-tabby-profile-sync.py
@@ -278,8 +278,41 @@ class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
             group_id="group-1",
         )
 
-        self.assertIn("        - 'opencode; exec zsh'", profile)
-        self.assertNotIn("        - opencode; exec zsh", profile)
+        self.assertIn("        - 'aidevops opencode; exec zsh'", profile)
+        self.assertNotIn("        - aidevops opencode; exec zsh", profile)
+        self.assertIn("    disableDynamicTitle: false", profile)
+
+    def test_existing_opencode_profile_enables_dynamic_title(self):
+        repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(
+            """profiles:
+  - name: repo
+    options:
+      command: /bin/zsh
+      args:
+        - '-l'
+        - '-c'
+        - 'aidevops opencode; exec zsh'
+    disableDynamicTitle: true
+    type: local
+"""
+        )
+
+        self.assertEqual(repairs, 1)
+        self.assertIn("    disableDynamicTitle: false", repaired)
+        self.assertNotIn("    disableDynamicTitle: true", repaired)
+
+    def test_unrelated_profile_preserves_dynamic_title_setting(self):
+        original = """profiles:
+  - name: shell
+    options:
+      command: /bin/zsh
+    disableDynamicTitle: true
+    type: local
+"""
+        repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(original)
+
+        self.assertEqual(repairs, 0)
+        self.assertEqual(repaired, original)
 
     def test_command_field_with_trailing_comment_is_repaired(self):
         repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(
@@ -293,7 +326,7 @@ class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
 
         self.assertEqual(repairs, 1)
         self.assertIn("      command: /bin/zsh", repaired)
-        self.assertIn("        - 'opencode; exec zsh'", repaired)
+        self.assertIn("        - 'aidevops opencode; exec zsh'", repaired)
 
     def test_inline_args_blank_line_before_env_does_not_duplicate_env(self):
         repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(
@@ -309,7 +342,7 @@ class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
 
         self.assertEqual(repairs, 1)
         self.assertEqual(repaired.count("      env:"), 1)
-        self.assertIn("        - 'opencode; exec zsh'", repaired)
+        self.assertIn("        - 'aidevops opencode; exec zsh'", repaired)
 
     def test_block_args_comment_before_env_does_not_duplicate_env(self):
         repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(


### PR DESCRIPTION
## Summary

Use the active deployment as the live title-version source, reassert authoritative titles on session create/update events, and repair managed OpenCode Tabby profiles to allow dynamic titles.

## Files Changed

.agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/session-title-suffix.mjs, .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs, .agents/scripts/session-rename-helper.sh, .agents/scripts/tabby-profile-sync.py, .agents/scripts/tests/test-session-rename-helper.sh, .agents/scripts/tests/test-session-rename-ts.mjs, .opencode/lib/session-title-suffix.ts, tests/test-tabby-profile-sync.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 14 Node title tests, 40 Bun session-title assertions, 25 shell helper assertions, 7 targeted Python profile tests, ShellCheck, TypeScript typecheck, and diff-scoped local linters passed. Full broad lint also ran and reported only pre-existing repository-wide Markdown/complexity debt.

Resolves #27505


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.88 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 16m and 234,809 tokens on this with the user in an interactive session.