### PR TITLE
GH#27504: fix: make manual dispatch guidance tier-based

### DIFF
--- a/.agents/reference/configuration.md
+++ b/.agents/reference/configuration.md
@@ -137,28 +137,26 @@ Model routing, tiers, provider configuration, rate limits, fallback chains, and 
 
 #### models.tiers
 
-Each tier maps to an ordered list of models. First available model is used; optional `fallback` tier is tried if all are unavailable.
+Each workload tier maps to an ordered list of models. Runtime routing chooses
+the preferred available provider and model, applies any provider-specific
+reasoning level, and then follows the configured fallback chain.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `models.tiers.<name>.models` | string[] | (see defaults) | Ordered list of model identifiers. |
 | `models.tiers.<name>.fallback` | string | (none) | Tier to fall back to if all models unavailable. |
 
-**Default tiers:**
+**Canonical workload tiers:**
 
-| Tier | Models | Fallback | Purpose |
-|------|--------|----------|---------|
-| `local` | `local/llama.cpp` | `haiku` | Offline / privacy-first tasks |
-| `haiku` | `anthropic/claude-haiku-4-5` | -- | Fast, low-cost (primary name) |
-| `flash` | `anthropic/claude-haiku-4-5` | -- | Alias for `haiku` |
-| `sonnet` | `anthropic/claude-sonnet-4-6` | -- | Balanced capability/cost (primary name) |
-| `pro` | `anthropic/claude-sonnet-4-6` | -- | Alias for `sonnet` |
-| `opus` | `anthropic/claude-opus-4-6` | -- | Highest capability, highest cost |
-| `coding` | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6` | -- | Code tasks: opus first, sonnet fallback |
-| `eval` | `anthropic/claude-sonnet-4-6` | -- | Evaluation and grading |
-| `health` | `anthropic/claude-sonnet-4-6` | -- | Health/wellness domain |
+| Tier | Purpose |
+|------|---------|
+| `simple` | Bounded classification, search, and formatting work |
+| `standard` | General implementation and review work; the default |
+| `thinking` | Architecture, novel problems, and other complex work |
 
-> `haiku`/`flash` and `sonnet`/`pro` are aliases — they resolve to the same model. Changing one automatically applies to the other.
+The exact provider/model order and reasoning preferences live in
+`configs/model-routing-table.json`; installations can override that table
+without changing the workload-tier interface.
 
 **Example — add a custom tier:**
 
@@ -210,7 +208,10 @@ Provider endpoint and authentication configuration.
 
 #### models.fallback_chains
 
-Per-tier fallback chains for model-level failover. Each key is a tier name; value is an ordered list of model identifiers. By default, each tier's chain matches its `models.tiers` model list (e.g., `coding` chain = `[claude-opus-4-6, claude-sonnet-4-6]`). The `default` chain resolves to `anthropic/claude-sonnet-4-6`.
+Per-tier fallback chains for model-level failover. Each key is a tier name;
+value is an ordered list of model identifiers. By default, the `simple`,
+`standard`, and `thinking` chains match their `models.tiers` model lists, and
+the `default` chain follows `standard`.
 
 #### models.fallback_triggers
 

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -67,16 +67,21 @@ worker launch instead of waiting for the next pulse cycle. Common cases:
 - Smoke-test a newly filed issue.
 - Retry after fixing a dispatch blocker.
 - Validate worker-readiness for a brief.
-- Start a small batch with an explicit model.
+- Start a small batch with an explicit workload tier.
 
 Examples:
 
 ```bash
 aidevops launch-worker 22259 marcusquinn/aidevops --dry-run
-aidevops launch-worker 22259 marcusquinn/aidevops --model anthropic/claude-opus-4-7
+aidevops launch-worker 22259 marcusquinn/aidevops
 aidevops launch-worker --batch 22259,22260 marcusquinn/aidevops --agent Build+
 aidevops launch-worker status 22259 marcusquinn/aidevops
 ```
+
+For normal routing, label each issue `tier:simple`, `tier:standard`, or
+`tier:thinking` before launch. Runtime routing selects the preferred available
+provider, model, and reasoning level. The underlying helper retains `--model`
+only as an advanced compatibility override for exact model IDs.
 
 The command wraps `dispatch-single-issue-helper.sh dispatch`, so it preserves the
 manual-dispatch ceremony: open-issue validation, parent-task block, fail-closed

--- a/.agents/scripts/commands/dispatch-issue.md
+++ b/.agents/scripts/commands/dispatch-issue.md
@@ -9,6 +9,10 @@ mode: subagent
 
 Args: `$ARGUMENTS` — `<issue_number> <owner/repo> [--model <id>] [--dry-run]`
 
+Use the issue's `tier:simple`, `tier:standard`, or `tier:thinking` label for
+normal routing. `--model` is an advanced compatibility override for operators
+who must pin an exact runtime model ID.
+
 ## What this does
 
 Bypasses the pulse loop and launches one worker against one issue. The same
@@ -43,17 +47,19 @@ helper deliberately does not.
      refuse to dispatch, exit 1.
    - Dry-run: surface all three states as info, still print the planned dispatch.
 4. Resolve tier/model (mirrors `pulse-model-routing.sh::resolve_dispatch_model_for_labels`):
-   - `--model <id>` wins (operator explicit intent, highest priority).
-   - Tier labels request workload complexity; runtime routing chooses the exact model and reasoning level.
-   - Else tier labels: `tier:thinking` → opus, `tier:standard` → sonnet,
-     `tier:simple` → haiku. Default = `standard` / sonnet.
-   - Other `model:*` labels (e.g. `model:sonnet-4-6`) map to the named model.
+   - Tier labels request workload complexity: `tier:simple`, `tier:standard`,
+     or `tier:thinking`. Default = `standard`.
+   - Runtime routing chooses the preferred available provider, model, and
+     reasoning level for that workload tier.
+   - `--model <id>` wins only when an operator intentionally uses the advanced
+     compatibility override to pin an exact runtime model ID.
    - **Known divergence from pulse (t2839):** the pulse applies a dispatch-path
      safety net (t2819) that auto-elevates issues touching self-hosting files
-     (pulse-wrapper.sh, headless-runtime-helper.sh, etc.) to `opus-4-7`. This
+     (pulse-wrapper.sh, headless-runtime-helper.sh, etc.) to `thinking`. This
      CLI does NOT apply that check — it would require parsing the issue body and
-     brief file scope. If you're manually dispatching a dispatch-path issue, pass
-     `--model anthropic/claude-opus-4-7` explicitly to match pulse behaviour.
+     brief file scope. If you're manually dispatching a dispatch-path issue,
+     apply the `tier:thinking` label before dispatch so runtime routing can
+     select the preferred available provider, model, and reasoning level.
 5. Dispatch (real path):
    - Pre-create worktree via `worktree-helper.sh add` (`auto-<ts>-gh<N>`),
      resolve actual path back from `git worktree list` (worktree-helper has
@@ -76,12 +82,11 @@ helper deliberately does not.
 # Smoke-test (preview only, no worker launched)
 dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --dry-run
 
-# Real dispatch — model inferred from labels
+# Real dispatch — tier inferred from the issue's tier:* label
 dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops
 
-# Force a specific model (bypasses label inference)
-dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops \
-    --model anthropic/claude-opus-4-7
+# Recommended for complex work: apply tier:thinking to the issue, then dispatch
+dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops
 
 # Check active dispatch state
 dispatch-single-issue-helper.sh status 20882 marcusquinn/aidevops

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -12,6 +12,8 @@
 #
 # Subcommands:
 #   dispatch <issue_number> <owner/repo> [--model <id>] [--dry-run] [--no-ceremony]
+#   Normal routing uses the issue's tier:simple, tier:standard, or tier:thinking
+#   label. --model is an advanced compatibility override for exact model IDs.
 #   status <issue_number> <owner/repo>
 #   help
 #
@@ -926,7 +928,7 @@ _dsi_parse_dispatch_args() {
 			# ${...} braced form keeps the positional-parameter ratchet
 			# (which matches bare \$[1-9]) happy.
 			if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
-				_dsi_err "--model requires a model id (e.g. anthropic/claude-opus-4-7)"
+				_dsi_err "--model requires an exact model id; prefer a tier:simple, tier:standard, or tier:thinking issue label for normal routing"
 				return 2
 			fi
 			_DSI_ARG_MODEL="${2}"
@@ -1477,8 +1479,10 @@ _dispatch_usage() {
 Usage: dispatch-single-issue-helper.sh dispatch <issue_number> <owner/repo> [options]
 
 Options:
-  --model <id>    Override model (e.g. anthropic/claude-opus-4-7).
-                  Default: inferred from tier:* and model:* labels.
+  --model <id>    Advanced compatibility override for an exact model ID.
+                  Prefer a tier:simple, tier:standard, or tier:thinking issue
+                  label; runtime routing selects the preferred available
+                  provider, model, and reasoning level. Default: standard.
   --agent <name>  Worker agent name. Default: Build+.
   --base <ref>    Worktree base branch/ref. Default: repo dispatch/PR base
                   policy from config, falling back to origin/HEAD.
@@ -1490,7 +1494,6 @@ Options:
 
 Examples:
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops
-  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --model anthropic/claude-opus-4-7
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --agent Build+
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --base origin/develop
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --dry-run
@@ -1512,11 +1515,11 @@ Examples:
   # Smoke-test a newly-filed issue
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --dry-run
 
-  # Real dispatch (model inferred from labels)
+  # Real dispatch (tier inferred from tier:simple, tier:standard, or tier:thinking)
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops
 
-  # Force a specific model
-  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --model anthropic/claude-opus-4-7
+  # Runtime routing selects the preferred provider, model, and reasoning level
+  # for that workload tier. --model remains an advanced compatibility override.
 
   # Force an agent name (default: Build+)
   dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --agent Build+

--- a/.agents/scripts/tests/test-canonical-model-tiers.sh
+++ b/.agents/scripts/tests/test-canonical-model-tiers.sh
@@ -15,12 +15,41 @@ check_absent() {
 	local description="$1"
 	local pattern="$2"
 	shift 2
-	if rg -n "$pattern" "$@"; then
+	local matches=""
+	local rc=0
+	matches=$(rg -n -e "$pattern" "$@" 2>&1) || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%s\n' "$matches"
 		printf 'FAIL: %s\n' "$description" >&2
 		failures=$((failures + 1))
 		return 0
 	fi
+	if [[ "$rc" -ne 1 ]]; then
+		printf 'FAIL: %s (rg exited %d: %s)\n' "$description" "$rc" "$matches" >&2
+		failures=$((failures + 1))
+		return 0
+	fi
 	printf 'PASS: %s\n' "$description"
+	return 0
+}
+
+check_present() {
+	local description="$1"
+	local pattern="$2"
+	shift 2
+	local rc=0
+	rg -q -e "$pattern" "$@" || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS: %s\n' "$description"
+		return 0
+	fi
+	if [[ "$rc" -ne 1 ]]; then
+		printf 'FAIL: %s (rg exited %d)\n' "$description" "$rc" >&2
+		failures=$((failures + 1))
+		return 0
+	fi
+	printf 'FAIL: %s\n' "$description" >&2
+	failures=$((failures + 1))
 	return 0
 }
 
@@ -54,6 +83,36 @@ check_absent \
 	"legacy tier-specific reasoning environment variables are absent" \
 	'AIDEVOPS_HEADLESS_VARIANT_(HAIKU|SONNET|OPUS|FLASH|PRO)' \
 	.agents --glob '*.{md,sh,py,mjs,json,jsonc,toon}'
+
+manual_dispatch_surfaces=(
+	.agents/scripts/commands/dispatch-issue.md
+	.agents/scripts/dispatch-single-issue-helper.sh
+)
+check_absent \
+	"manual dispatch command surfaces do not recommend a provider-specific model pin" \
+	'--model[[:space:]]+[[:alnum:]_.-]+/[[:alnum:]_.-]+' \
+	"${manual_dispatch_surfaces[@]}"
+
+check_absent \
+	"launch-worker examples do not recommend a provider-specific model pin" \
+	'aidevops launch-worker[^\r\n]*--model[[:space:]]+[[:alnum:]_.-]+/[[:alnum:]_.-]+' \
+	.agents/reference/worker-diagnostics.md
+
+check_present \
+	"manual dispatch command guidance recommends canonical workload tiers" \
+	'tier:simple.*tier:standard.*tier:thinking' \
+	.agents/scripts/commands/dispatch-issue.md
+
+check_present \
+	"manual dispatch help recommends canonical workload tiers" \
+	'tier:simple.*tier:standard.*tier:thinking' \
+	.agents/scripts/dispatch-single-issue-helper.sh
+
+check_present \
+	"exact model overrides are marked as advanced compatibility behavior" \
+	'[Aa]dvanced compatibility override' \
+	.agents/scripts/commands/dispatch-issue.md \
+	.agents/scripts/dispatch-single-issue-helper.sh
 
 actual_tiers=$(jq -r '.tiers | keys | sort | join(",")' .agents/configs/model-routing-table.json)
 if [[ "$actual_tiers" == "simple,standard,thinking" ]]; then

--- a/.agents/scripts/tests/test-canonical-model-tiers.sh
+++ b/.agents/scripts/tests/test-canonical-model-tiers.sh
@@ -109,12 +109,16 @@ check_present \
 	.agents/scripts/dispatch-single-issue-helper.sh
 
 check_present \
-	"exact model overrides are marked as advanced compatibility behavior" \
+	"command docs mark exact model overrides as advanced compatibility behavior" \
 	'[Aa]dvanced compatibility override' \
-	.agents/scripts/commands/dispatch-issue.md \
+	.agents/scripts/commands/dispatch-issue.md
+
+check_present \
+	"CLI help marks exact model overrides as advanced compatibility behavior" \
+	'[Aa]dvanced compatibility override' \
 	.agents/scripts/dispatch-single-issue-helper.sh
 
-actual_tiers=$(jq -r '.tiers | keys | sort | join(",")' .agents/configs/model-routing-table.json)
+actual_tiers=$(jq -r '.tiers | keys | sort | join(",")' .agents/configs/model-routing-table.json || true)
 if [[ "$actual_tiers" == "simple,standard,thinking" ]]; then
 	printf 'PASS: routing table exposes exactly three workload tiers\n'
 else

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -444,6 +444,49 @@ test_no_ceremony_flag_parses_correctly() {
 	return 0
 }
 
+test_model_override_guidance_is_provider_neutral() {
+	reset_test_state
+
+	local rc=0
+	_dsi_parse_dispatch_args 12345 owner/repo --model compatibility/model-id >/dev/null 2>&1 || rc=$?
+	local override_check=1
+	[[ "$rc" -eq 0 && "$_DSI_ARG_MODEL" == "compatibility/model-id" ]] && override_check=0
+	print_result "advanced --model compatibility override still parses" "$override_check" \
+		"rc=$rc model=$_DSI_ARG_MODEL"
+
+	local help_out
+	help_out=$(_dispatch_usage)
+	local help_check=1
+	if [[ "$help_out" == *"Advanced compatibility override"* &&
+		"$help_out" == *"tier:simple"* &&
+		"$help_out" == *"tier:standard"* &&
+		"$help_out" == *"tier:thinking"* &&
+		"$help_out" != *"anthropic/"* &&
+		"$help_out" != *"openai/"* &&
+		"$help_out" != *"google/"* ]]; then
+		help_check=0
+	fi
+	print_result "dispatch help recommends tiers without a provider pin" "$help_check" "$help_out"
+
+	rc=0
+	local error_out
+	error_out=$(_dsi_parse_dispatch_args 12345 owner/repo --model --dry-run 2>&1) || rc=$?
+	local error_check=1
+	if [[ "$rc" -eq 2 &&
+		"$error_out" == *"tier:simple"* &&
+		"$error_out" == *"tier:standard"* &&
+		"$error_out" == *"tier:thinking"* &&
+		"$error_out" != *"anthropic/"* &&
+		"$error_out" != *"openai/"* &&
+		"$error_out" != *"google/"* ]]; then
+		error_check=0
+	fi
+	print_result "missing --model error recommends tiers without a provider pin" "$error_check" \
+		"rc=$rc output=$error_out"
+
+	return 0
+}
+
 test_load_issue_meta_accepts_lowercase_open() {
 	MOCK_GH_FAIL="0"
 	MOCK_GH_ISSUE_STATE="open"
@@ -1121,6 +1164,7 @@ _run_tests() {
 	test_ceremony_handles_empty_self_login
 	test_ceremony_handles_set_issue_status_failure
 	test_no_ceremony_flag_parses_correctly
+	test_model_override_guidance_is_provider_neutral
 	test_load_issue_meta_accepts_lowercase_open
 	test_load_issue_meta_blocks_lowercase_closed
 	test_pr_target_guard_detects_pull_request


### PR DESCRIPTION
## Summary

- replace provider-specific manual dispatch recommendations with canonical `simple`, `standard`, and `thinking` workload-tier guidance
- keep exact model IDs as an advanced compatibility override while leaving provider/model/reasoning selection to runtime routing
- add regression coverage for provider-neutral help, errors, examples, and override compatibility

## Verification

- `bash .agents/scripts/tests/test-dispatch-single-issue-helper.sh`
- `bash .agents/scripts/tests/test-canonical-model-tiers.sh`
- `shellcheck .agents/scripts/dispatch-single-issue-helper.sh .agents/scripts/tests/test-dispatch-single-issue-helper.sh .agents/scripts/tests/test-canonical-model-tiers.sh`
- `git diff --check`
- `npm run typecheck` could not run locally because dependencies are not installed; remote CI is authoritative

Resolves #27504

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.93 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 10m and 132,673 tokens on this as a headless worker.