### PR TITLE
GH#27429: perf: reduce issue mapping jq processes

### DIFF
--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -263,6 +263,7 @@ resolve_task_gh_number() {
 		grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
 	[[ "$ref" =~ ^[1-9][0-9]*$ ]] || return 1
 	issue_json=$(_gh_with_timeout read gh issue view "$ref" --repo "$repo" --json id,number,state,updatedAt 2>/dev/null || true)
+	[[ -n "$issue_json" ]] || return 1
 	if ! IFS=$'\034' read -r issue_id issue_number issue_state issue_cursor < <(
 		printf '%s' "$issue_json" | jq -r \
 			'[.id // "", (.number // "" | tostring), .state // "", .updatedAt // ""] | join("\u001c")'

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -251,7 +251,7 @@ resolve_task_gh_number() {
 					--issue-id "$mapped_issue_id" --display-number "$mapped_number" \
 					"${refresh_args[@]}" --sync-metadata "$mapped_metadata" >/dev/null 2>&1 || return 1
 			fi
-			printf '%s\n' "$mapping" | jq -r '.displayNumber'
+			printf '%s\n' "$mapped_number"
 			return 0
 		fi
 	fi
@@ -263,10 +263,12 @@ resolve_task_gh_number() {
 		grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
 	[[ "$ref" =~ ^[1-9][0-9]*$ ]] || return 1
 	issue_json=$(_gh_with_timeout read gh issue view "$ref" --repo "$repo" --json id,number,state,updatedAt 2>/dev/null || true)
-	issue_id=$(printf '%s' "$issue_json" | jq -r '.id // empty' 2>/dev/null)
-	issue_number=$(printf '%s' "$issue_json" | jq -r '.number // empty' 2>/dev/null)
-	issue_state=$(printf '%s' "$issue_json" | jq -r '.state // empty' 2>/dev/null)
-	issue_cursor=$(printf '%s' "$issue_json" | jq -r '.updatedAt // empty' 2>/dev/null)
+	if ! IFS=$'\034' read -r issue_id issue_number issue_state issue_cursor < <(
+		printf '%s' "$issue_json" | jq -r \
+			'[.id // "", (.number // "" | tostring), .state // "", .updatedAt // ""] | join("\u001c")'
+	); then
+		return 1
+	fi
 	[[ -n "$issue_id" && "$issue_number" == "$ref" ]] || return 1
 	if [[ -f "$coordinator" ]]; then
 		local bind_args=()

--- a/.agents/scripts/tests/test-issue-mapping-isolation.sh
+++ b/.agents/scripts/tests/test-issue-mapping-isolation.sh
@@ -21,6 +21,12 @@ strip_code_fences() {
 }
 log_verbose() { return 0; }
 print_error() { return 0; }
+JQ_CALL_LOG="${TEST_ROOT}/jq-calls.log"
+jq() {
+	printf 'call\n' >>"$JQ_CALL_LOG"
+	command jq "$@"
+	return $?
+}
 _gh_with_timeout() {
 	local _class="$1"
 	shift
@@ -64,7 +70,12 @@ gh() {
 # shellcheck source=../issue-sync-lib-ref.sh
 source "${SCRIPT_DIR}/issue-sync-lib-ref.sh"
 
+: >"$JQ_CALL_LOG"
 [[ "$(resolve_task_gh_number t101 "$TODO_FILE" owner/one)" == "42" ]]
+if [[ "$(wc -l <"$JQ_CALL_LOG")" != "2" ]]; then
+	printf 'FAIL issue backfill did not parse fields with one jq process\n' >&2
+	exit 1
+fi
 [[ "$(resolve_task_gh_number t102 "$TODO_FILE" owner/two)" == "42" ]]
 [[ "$(resolve_task_gh_number t1873.1 "$TODO_FILE" owner/dotted)" == "73" ]]
 [[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t101 --repository-id R_one | jq -r '.issueId')" == "I_one_42" ]]

--- a/.agents/scripts/tests/test-issue-mapping-isolation.sh
+++ b/.agents/scripts/tests/test-issue-mapping-isolation.sh
@@ -72,7 +72,7 @@ source "${SCRIPT_DIR}/issue-sync-lib-ref.sh"
 
 : >"$JQ_CALL_LOG"
 [[ "$(resolve_task_gh_number t101 "$TODO_FILE" owner/one)" == "42" ]]
-if [[ "$(wc -l <"$JQ_CALL_LOG")" != "2" ]]; then
+if [[ "$(wc -l <"$JQ_CALL_LOG" | tr -d ' ')" != "2" ]]; then
 	printf 'FAIL issue backfill did not parse fields with one jq process\n' >&2
 	exit 1
 fi


### PR DESCRIPTION
## Summary

Reuse the parsed display number and decode issue metadata with one jq invocation while preserving field boundaries and parser errors.

## Files Changed

.agents/scripts/issue-sync-lib-ref.sh, .agents/scripts/tests/test-issue-mapping-isolation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n and ShellCheck on both changed shell files; bash .agents/scripts/tests/test-issue-mapping-isolation.sh

Resolves #27429


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.95 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 66,129 tokens on this as a headless worker.