### PR TITLE
GH#27514: deduplicate cross-account pulse auto-approvals

### DIFF
--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -628,6 +628,31 @@ _approve_collaborator_runner_has_write() {
 }
 
 #######################################
+# Return the login for a trusted approval on the requested PR head.
+#
+# #aidevops:trust-boundary — GH#17671 defence-in-depth:
+# Never let an external review suppress the guarded pulse approval. GitHub's
+# author_association is returned in the same reviews response, avoiding a
+# per-reviewer permission lookup while restricting the shortcut to repository
+# owners, organisation members, and explicitly invited collaborators.
+#
+# Args: $1=repo_slug, $2=pr_number, $3=PR head SHA (optional)
+# Outputs: approver login, or an empty string
+# Returns: 0 (API failures fail open to the guarded approval path)
+#######################################
+_trusted_existing_approver() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local approval_head_sha="${3:-__any_head__}"
+	local existing_approver=""
+
+	existing_approver=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
+		--jq "[.[] | select(.state == \"APPROVED\" and (\"${approval_head_sha}\" == \"__any_head__\" or .commit_id == \"${approval_head_sha}\") and (.author_association == \"OWNER\" or .author_association == \"MEMBER\" or .author_association == \"COLLABORATOR\")) | .user.login][0] // \"\"" 2>/dev/null) || existing_approver=""
+	printf '%s\n' "$existing_approver"
+	return 0
+}
+
+#######################################
 # Auto-approve a collaborator's PR before merging (GH#10522, t1691)
 #
 # Branch protection requires required_approving_review_count=1.
@@ -663,22 +688,9 @@ approve_collaborator_pr() {
 		return 2
 	fi
 
-	# A trusted approval on this head satisfies the review requirement regardless
-	# of which pulse identity created it. Check this before resolving the current
-	# identity or its permission so already-approved PRs cost one read and no
-	# redundant review write. GitHub marks superseded reviews DISMISSED in repos
-	# that dismiss stale approvals; the explicit head match also protects repos
-	# whose review policy leaves old approvals active.
-	#
-	# #aidevops:trust-boundary — GH#17671 defence-in-depth:
-	# Never let an external review suppress the guarded pulse approval. GitHub's
-	# author_association is returned in the same reviews response, avoiding a
-	# per-reviewer permission lookup while restricting the shortcut to repository
-	# owners, organisation members, and explicitly invited collaborators.
-	local approval_head_sha="${pr_head_sha:-__any_head__}"
+	# Check before identity/permission reads; the head match rejects stale reviews.
 	local existing_approver
-	existing_approver=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
-		--jq "[.[] | select(.state == \"APPROVED\" and (\"${approval_head_sha}\" == \"__any_head__\" or .commit_id == \"${approval_head_sha}\") and (.author_association == \"OWNER\" or .author_association == \"MEMBER\" or .author_association == \"COLLABORATOR\")) | .user.login][0] // \"\"" 2>/dev/null || echo "")
+	existing_approver=$(_trusted_existing_approver "$repo_slug" "$pr_number" "$pr_head_sha")
 	if [[ -n "$existing_approver" ]]; then
 		echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number in $repo_slug already has a trusted approval on ${pr_head_sha:-the active head} from $existing_approver — skipping" >>"$LOGFILE"
 		return 0

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -638,13 +638,14 @@ _approve_collaborator_runner_has_write() {
 # confirmed the PR author is a collaborator (admin/maintain/write).
 # NEVER call this for external contributor PRs.
 #
-# Idempotent — if the PR already has an approving review from the
-# current user, this is a no-op (GitHub ignores duplicate approvals).
+# Idempotent — if the current head already has a trusted approving review,
+# this is a no-op across all pulse identities.
 #
 # Arguments:
 #   $1 - PR number
 #   $2 - repo slug (owner/repo)
 #   $3 - PR author login (for logging only)
+#   $4 - current PR head SHA (optional; callers should provide when available)
 #
 # Exit codes:
 #   0 - PR approved (or already approved)
@@ -655,13 +656,36 @@ approve_collaborator_pr() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local pr_author="${3:-unknown}"
+	local pr_head_sha="${4:-}"
 
 	if [[ -z "$pr_number" || -z "$repo_slug" ]]; then
 		echo "[pulse-wrapper] approve_collaborator_pr: missing arguments" >>"$LOGFILE"
 		return 2
 	fi
 
-	# Check if we already approved (avoid noisy duplicate approvals in the timeline)
+	# A trusted approval on this head satisfies the review requirement regardless
+	# of which pulse identity created it. Check this before resolving the current
+	# identity or its permission so already-approved PRs cost one read and no
+	# redundant review write. GitHub marks superseded reviews DISMISSED in repos
+	# that dismiss stale approvals; the explicit head match also protects repos
+	# whose review policy leaves old approvals active.
+	#
+	# #aidevops:trust-boundary — GH#17671 defence-in-depth:
+	# Never let an external review suppress the guarded pulse approval. GitHub's
+	# author_association is returned in the same reviews response, avoiding a
+	# per-reviewer permission lookup while restricting the shortcut to repository
+	# owners, organisation members, and explicitly invited collaborators.
+	local approval_head_sha="${pr_head_sha:-__any_head__}"
+	local existing_approver
+	existing_approver=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
+		--jq "[.[] | select(.state == \"APPROVED\" and (\"${approval_head_sha}\" == \"__any_head__\" or .commit_id == \"${approval_head_sha}\") and (.author_association == \"OWNER\" or .author_association == \"MEMBER\" or .author_association == \"COLLABORATOR\")) | .user.login][0] // \"\"" 2>/dev/null || echo "")
+	if [[ -n "$existing_approver" ]]; then
+		echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number in $repo_slug already has a trusted approval on ${pr_head_sha:-the active head} from $existing_approver — skipping" >>"$LOGFILE"
+		return 0
+	fi
+
+	# No trusted approval exists, so resolve and validate the pulse identity before
+	# creating one.
 	local current_user
 	current_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
 
@@ -675,15 +699,6 @@ approve_collaborator_pr() {
 		fi
 
 		if ! _approve_collaborator_runner_has_write "$current_user" "$repo_slug"; then
-			return 0
-		fi
-
-		local existing_approval
-		existing_approval=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
-			--jq "[.[] | select(.user.login == \"${current_user}\" and .state == \"APPROVED\")] | length" 2>/dev/null || echo "0")
-
-		if [[ "$existing_approval" -gt 0 ]]; then
-			echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number in $repo_slug already approved by $current_user — skipping" >>"$LOGFILE"
 			return 0
 		fi
 	fi

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1353,7 +1353,7 @@ _process_single_ready_pr() {
 	fi
 
 	# Approve (satisfies REVIEW_REQUIRED for collaborator PRs)
-	approve_collaborator_pr "$pr_number" "$repo_slug" "$pr_author" 2>/dev/null || true
+	approve_collaborator_pr "$pr_number" "$repo_slug" "$pr_author" "$pr_head_ref_oid" 2>/dev/null || true
 	[[ -n "$timing_prefix" ]] && _ruleset_start=$(_pmp_now_epoch)
 	if ! _check_ruleset_required_reviews_passing "$repo_slug" "$pr_number" "$pr_author"; then
 		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}ruleset_s" "$_ruleset_start"

--- a/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
@@ -190,6 +190,7 @@ define_helpers_under_test() {
 	local approve_src
 	local runner_src
 	local crypto_src
+	local trusted_approval_src
 	approve_src=$(awk '
 		/^approve_collaborator_pr\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
@@ -199,6 +200,9 @@ define_helpers_under_test() {
 	# _has_maintainer_crypto_approval was added in t3063
 	crypto_src=$(awk '
 		/^_has_maintainer_crypto_approval\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	trusted_approval_src=$(awk '
+		/^_trusted_existing_approver\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 
 	if [[ -z "$approve_src" ]]; then
@@ -211,6 +215,10 @@ define_helpers_under_test() {
 	fi
 	if [[ -z "$crypto_src" ]]; then
 		printf 'ERROR: could not extract _has_maintainer_crypto_approval from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	if [[ -z "$trusted_approval_src" ]]; then
+		printf 'ERROR: could not extract _trusted_existing_approver from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
 	fi
 
@@ -231,6 +239,8 @@ define_helpers_under_test() {
 	eval "$runner_src"
 	# shellcheck disable=SC1090
 	eval "$crypto_src"
+	# shellcheck disable=SC1090
+	eval "$trusted_approval_src"
 	# shellcheck disable=SC1090
 	eval "$approve_src"
 	return 0

--- a/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
@@ -81,8 +81,8 @@ pulse-runner
 EOF
 	# Default authenticated user is the pulse runner.
 	echo "pulse-runner" >"${TEST_ROOT}/current-user.txt"
-	# Default: no prior reviews (count 0).
-	echo "0" >"${TEST_ROOT}/existing-approval-count.txt"
+	# Default: no prior reviews.
+	printf '[]\n' >"${TEST_ROOT}/reviews.json"
 	# Default: no crypto-approval markers in comments (count 0).
 	# Controls the mock gh comments endpoint response for _has_maintainer_crypto_approval.
 	echo "0" >"${TEST_ROOT}/crypto-comment-count.txt"
@@ -146,9 +146,9 @@ if [[ "${1:-}" == "api" && "$*" == *"/collaborators/"*"/permission"* && "$*" == 
 	exit 0
 fi
 
-# `gh api repos/SLUG/pulls/N/reviews --jq ...` — existing-approval count
+# `gh api repos/SLUG/pulls/N/reviews --jq ...` — existing trusted approval
 if [[ "${1:-}" == "api" && "$*" == *"/pulls/"*"/reviews"* ]]; then
-	cat "${TEST_ROOT}/existing-approval-count.txt"
+	jq -r "${4:-.}" "${TEST_ROOT}/reviews.json"
 	exit 0
 fi
 
@@ -392,6 +392,79 @@ EOF
 }
 
 # =============================================================================
+# Case E (GH#27514): another trusted pulse identity already approved this head.
+#                    Skip before identity/permission reads and review writes.
+# =============================================================================
+
+test_case_e_cross_account_approval_short_circuits() {
+	reset_mock_state
+	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
+[{"state":"APPROVED","commit_id":"head-500","author_association":"COLLABORATOR","user":{"login":"other-pulse-runner"}}]
+EOF
+
+	local result=0
+	approve_collaborator_pr "500" "owner/repo" "trusted-contributor" "head-500" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case E: cross-account approval — function returns 0" 1 \
+			"Expected exit 0, got ${result}. Log: $(cat "$LOGFILE")"
+		return 0
+	fi
+	if [[ "$(count_approve_calls)" -ne 0 ]]; then
+		print_result "Case E: cross-account approval — no duplicate review write" 1 \
+			"Expected zero approve calls. Calls: $(cat "$GH_LOG")"
+		return 0
+	fi
+	if grep -qF "gh api user" "$GH_LOG" || grep -qF "/collaborators/" "$GH_LOG"; then
+		print_result "Case E: cross-account approval — avoids redundant identity reads" 1 \
+			"Expected only the reviews read. Calls: $(cat "$GH_LOG")"
+		return 0
+	fi
+	if ! grep -qF "already has a trusted approval" "$LOGFILE"; then
+		print_result "Case E: cross-account approval — skip is auditable" 1 \
+			"Expected trusted-approval skip log. Log: $(cat "$LOGFILE")"
+		return 0
+	fi
+	print_result "Case E: cross-account approval — skips duplicate write with one read" 0
+	return 0
+}
+
+# =============================================================================
+# Case F (GH#27514 trust boundary): external or stale approvals do not suppress
+# the guarded pulse approval for the current head.
+# =============================================================================
+
+test_case_f_untrusted_or_stale_approval_does_not_short_circuit() {
+	reset_mock_state
+	cat >"${TEST_ROOT}/collaborators.txt" <<'EOF'
+pulse-runner
+trusted-contributor
+EOF
+	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
+[
+  {"state":"APPROVED","commit_id":"head-600","author_association":"CONTRIBUTOR","user":{"login":"external-reviewer"}},
+  {"state":"APPROVED","commit_id":"old-head","author_association":"OWNER","user":{"login":"trusted-but-stale"}}
+]
+EOF
+
+	local result=0
+	approve_collaborator_pr "600" "owner/repo" "trusted-contributor" "head-600" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case F: untrusted/stale approvals — function returns 0" 1 \
+			"Expected exit 0, got ${result}. Log: $(cat "$LOGFILE")"
+		return 0
+	fi
+	if [[ "$(count_approve_calls)" -ne 1 ]]; then
+		print_result "Case F: untrusted/stale approvals — guarded review still posts" 1 \
+			"Expected one approve call. Calls: $(cat "$GH_LOG")"
+		return 0
+	fi
+	print_result "Case F: untrusted/stale approvals — do not bypass guarded approval" 0
+	return 0
+}
+
+# =============================================================================
 # Case N (t3063): CONTRIBUTOR author + crypto-approval on PR itself → approves.
 # The crypto-approval bypass in approve_collaborator_pr should allow approval
 # even though the PR author is not a collaborator.
@@ -517,6 +590,8 @@ main() {
 	test_case_b_non_collaborator_author_refused
 	test_case_c_self_authored_skipped
 	test_case_d_runner_lacks_write_access_skipped
+	test_case_e_cross_account_approval_short_circuits
+	test_case_f_untrusted_or_stale_approval_does_not_short_circuit
 	test_case_n_contributor_with_crypto_on_pr
 	test_case_o_contributor_with_crypto_on_linked_issue
 	test_case_p_contributor_no_crypto_still_refused

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -140,6 +140,7 @@ define_helpers_under_test() {
 	local dependabot_src=""
 	local approve_src=""
 	local runner_src=""
+	local trusted_approval_src=""
 	dependabot_src=$(awk '
 		/^_trusted_dependabot_updates_conf\(\) \{/,/^}$/ { print }
 		/^_trusted_dependabot_dependency_allowed\(\) \{/,/^}$/ { print }
@@ -148,7 +149,8 @@ define_helpers_under_test() {
 	' "$GATES_SCRIPT")
 	approve_src=$(awk '/^approve_collaborator_pr\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
 	runner_src=$(awk '/^_approve_collaborator_runner_has_write\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
-	[[ -n "$dependabot_src" && -n "$approve_src" && -n "$runner_src" ]] || return 1
+	trusted_approval_src=$(awk '/^_trusted_existing_approver\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
+	[[ -n "$dependabot_src" && -n "$approve_src" && -n "$runner_src" && -n "$trusted_approval_src" ]] || return 1
 
 	_has_maintainer_crypto_approval() { return 1; }
 	# shellcheck source=../pulse-merge-author-checks.sh
@@ -157,6 +159,8 @@ define_helpers_under_test() {
 	eval "$runner_src"
 	# shellcheck disable=SC1090
 	eval "$dependabot_src"
+	# shellcheck disable=SC1090
+	eval "$trusted_approval_src"
 	# shellcheck disable=SC1090
 	eval "$approve_src"
 	return 0

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -115,7 +115,7 @@ if [[ "${1:-}" == "api" && "$*" == *"/collaborators/"*"/permission"* && "$*" == 
 fi
 
 if [[ "${1:-}" == "api" && "$*" == *"/pulls/"*"/reviews"* ]]; then
-	printf '0\n'
+	printf '\n'
 	exit 0
 fi
 


### PR DESCRIPTION
## Summary

Short-circuit pulse auto-approval when the current PR head already has a trusted approval from any pulse identity, eliminating duplicate timeline reviews and reducing the approval gate to one read with no write.

## Files Changed

.agents/scripts/pulse-merge-gates.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted approval-guard and trusted-Dependabot suites pass; ShellCheck passes for all changed shell files; linters-local.sh --changed --strict passes.

Resolves #27514


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.88 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 11m and 177,549 tokens on this with the user in an interactive session.