### PR TITLE
GH#27516: keep readable temp artifacts in managed workspace

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -76,7 +76,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 - Prefer exact search first: with Bash use scoped `rg` (or `git grep` for tracked content); use the runtime Grep tool only without Bash or for bounded searches. Then use `osgrep` for semantic search. File discovery with Bash available: `git ls-files '<pattern>'` for tracked files, `fd` for untracked, `rg --files -g '<pattern>'` for file lists. Glob is last resort.
 - Use Read for file reads. Always Read before Edit/Write existing files, re-read after modification before another edit, verify paths first, and include 3+ context lines in edits.
-- Put temporary artifacts that a runtime tool or agent may read under `${AIDEVOPS_TEMP_DIR:-~/.aidevops/.agent-workspace/tmp}`, never host `/tmp`; shell-internal `mktemp` files are exempt.
+- Put temporary artifacts that a runtime tool or agent may read under `${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}`, never host `/tmp`; shell-internal `mktemp` files are exempt.
 - Output text directly; never use Bash `echo` to communicate. Call independent tools in parallel.
 - Slash commands: read `scripts/commands/<command>.md`, then `workflows/<command>.md` fallback.
 - Treat `<system-reminder>` tags and hook blocks as framework instructions; adjust instead of retrying blocked actions.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -76,6 +76,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 - Prefer exact search first: with Bash use scoped `rg` (or `git grep` for tracked content); use the runtime Grep tool only without Bash or for bounded searches. Then use `osgrep` for semantic search. File discovery with Bash available: `git ls-files '<pattern>'` for tracked files, `fd` for untracked, `rg --files -g '<pattern>'` for file lists. Glob is last resort.
 - Use Read for file reads. Always Read before Edit/Write existing files, re-read after modification before another edit, verify paths first, and include 3+ context lines in edits.
+- Put temporary artifacts that a runtime tool or agent may read under `${AIDEVOPS_TEMP_DIR:-~/.aidevops/.agent-workspace/tmp}`, never host `/tmp`; shell-internal `mktemp` files are exempt.
 - Output text directly; never use Bash `echo` to communicate. Call independent tools in parallel.
 - Slash commands: read `scripts/commands/<command>.md`, then `workflows/<command>.md` fallback.
 - Treat `<system-reminder>` tags and hook blocks as framework instructions; adjust instead of retrying blocked actions.

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -19,7 +19,7 @@ git add -A && git commit -m 'feat: <what you just did> (<task-id>)'
 ```bash
 git push -u origin HEAD
 gh_issue=$(grep -E '^\s*- \[.\] <task-id> ' TODO.md 2>/dev/null | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
-PR_BODY_FILE=/tmp/aidevops-pr-body.md
+PR_BODY_FILE="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/aidevops-pr-body.md"
 cat <<'EOF' > "$PR_BODY_FILE"
 WIP - incremental commits
 EOF
@@ -31,7 +31,7 @@ Run the GitHub write in the next Bash tool call so the signature gate can read
 the completed body file before execution:
 
 ```bash
-gh pr create --draft --title '<task-id>: <description>' --body-file /tmp/aidevops-pr-body.md
+gh pr create --draft --title '<task-id>: <description>' --body-file "$PR_BODY_FILE"
 ```
 
 - **ShellCheck before push for `.sh` files (t234).** Do not push violations. If `shellcheck` is missing, skip and note it in the PR body.

--- a/.agents/scripts/browser-qa-worker.sh
+++ b/.agents/scripts/browser-qa-worker.sh
@@ -15,7 +15,7 @@
 #   --url <url>            Base URL of the application to test
 #
 # Options:
-#   --output-dir <dir>     Screenshot/report directory (default: /tmp/browser-qa-{timestamp})
+#   --output-dir <dir>     Screenshot/report directory (default: managed aidevops temp workspace)
 #   --flows <json>         JSON array of URLs or {url, name} objects to visit
 #   --flows-file <path>    File containing flows JSON (one per line or JSON array)
 #   --mission-file <path>  Read acceptance criteria from mission file for flow generation
@@ -211,7 +211,7 @@ parse_args() {
 
 	# Set default output dir if not specified
 	if [[ -z "$OUTPUT_DIR" ]]; then
-		OUTPUT_DIR="/tmp/browser-qa-$(date +%Y%m%d-%H%M%S)"
+		OUTPUT_DIR="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}/browser-qa-$(date +%Y%m%d-%H%M%S)"
 	fi
 
 	return 0

--- a/.agents/scripts/browser-qa/browser-qa.mjs
+++ b/.agents/scripts/browser-qa/browser-qa.mjs
@@ -10,7 +10,7 @@
 // Usage: node browser-qa.mjs <base-url> [options]
 //
 // Options:
-//   --output-dir <dir>     Directory for screenshots and report (default: /tmp/browser-qa)
+//   --output-dir <dir>     Directory for screenshots and report (default: managed aidevops temp workspace)
 //   --flows <json>         JSON array of flow definitions (URLs or {url, actions} objects)
 //   --timeout <ms>         Page load timeout (default: 30000)
 //   --viewport <WxH>       Viewport size (default: 1280x720)
@@ -21,6 +21,7 @@
 //   --help                 Show help
 
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { chromium } from 'playwright';
 
@@ -31,7 +32,7 @@ import { chromium } from 'playwright';
 /** Default option values for parseArgs. */
 const DEFAULT_OPTIONS = {
   baseUrl: null,
-  outputDir: '/tmp/browser-qa',
+  outputDir: join(process.env.AIDEVOPS_TEMP_DIR || join(homedir(), '.aidevops', '.agent-workspace', 'tmp'), 'browser-qa'),
   flows: null,
   timeout: 30000,
   viewportWidth: 1280,
@@ -96,7 +97,7 @@ function printUsage() {
   console.log(`Usage: node browser-qa.mjs <base-url> [options]
 
 Options:
-  --output-dir <dir>     Screenshot/report directory (default: /tmp/browser-qa)
+  --output-dir <dir>     Screenshot/report directory (default: managed aidevops temp workspace)
   --flows <json>         JSON array of URLs or {url, name, actions} objects
   --timeout <ms>         Page load timeout (default: 30000)
   --viewport <WxH>       Viewport size (default: 1280x720)

--- a/.agents/scripts/milestone-validation-worker.sh
+++ b/.agents/scripts/milestone-validation-worker.sh
@@ -894,7 +894,7 @@ run_browser_qa() {
 	if [[ -d "$mission_dir" ]]; then
 		qa_output_dir="${mission_dir}/assets/qa"
 	else
-		qa_output_dir="/tmp/browser-qa-$(date +%Y%m%d-%H%M%S)"
+		qa_output_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}/browser-qa-$(date +%Y%m%d-%H%M%S)"
 	fi
 
 	# Build arguments

--- a/.agents/scripts/shared-temp-workspace.sh
+++ b/.agents/scripts/shared-temp-workspace.sh
@@ -15,5 +15,6 @@ aidevops_init_temp_workspace() {
 	export TMPDIR="$temp_root"
 	export TMP="$temp_root"
 	export TEMP="$temp_root"
+	export AIDEVOPS_TEMP_DIR="$temp_root"
 	return 0
 }

--- a/.agents/scripts/tests/test-managed-temp-workspace.sh
+++ b/.agents/scripts/tests/test-managed-temp-workspace.sh
@@ -54,7 +54,7 @@ runtime_artifact_files=(
 	"$SCRIPTS_DIR/../workflows/ui-verification.md"
 )
 assert "agent guidance directs readable artifacts to the managed workspace" grep -q 'temporary artifacts.*AIDEVOPS_TEMP_DIR.*never host `/tmp`' "$SCRIPTS_DIR/../AGENTS.md"
-assert "runtime-visible artifact defaults avoid host /tmp paths" test "$(grep -El '/tmp/(browser-qa|aidevops-(pr-body|merge-summary|issue-body)|ui-verify|worker-)' "${runtime_artifact_files[@]}" 2>/dev/null | wc -l | tr -d ' ')" -eq 0
+assert "runtime-visible artifact defaults avoid host /tmp paths" test -z "$(grep -El '/tmp/(browser-qa|aidevops-(pr-body|merge-summary|issue-body)|ui-verify|worker-)' "${runtime_artifact_files[@]}" || true)"
 
 print_info() { return 0; }
 print_warning() { return 0; }

--- a/.agents/scripts/tests/test-managed-temp-workspace.sh
+++ b/.agents/scripts/tests/test-managed-temp-workspace.sh
@@ -37,7 +37,24 @@ expected=$(cd "$HOME/.aidevops/.agent-workspace/tmp" && pwd -P)
 assert "initializer overrides TMPDIR" test "$TMPDIR" = "$expected"
 assert "initializer aligns TMP" test "$TMP" = "$expected"
 assert "initializer aligns TEMP" test "$TEMP" = "$expected"
+assert "initializer exports the canonical aidevops temp directory" test "$AIDEVOPS_TEMP_DIR" = "$expected"
 assert "managed temp directory exists" test -d "$expected"
+managed_temp_file=$(mktemp "$AIDEVOPS_TEMP_DIR/aidevops-test.XXXXXX")
+assert "canonical temp directory supports managed artifacts" test "${managed_temp_file#"$expected"/}" != "$managed_temp_file"
+
+runtime_artifact_files=(
+	"$SCRIPTS_DIR/../AGENTS.md"
+	"$SCRIPTS_DIR/browser-qa-worker.sh"
+	"$SCRIPTS_DIR/browser-qa/browser-qa.mjs"
+	"$SCRIPTS_DIR/milestone-validation-worker.sh"
+	"$SCRIPTS_DIR/../prompts/worker-efficiency-protocol.md"
+	"$SCRIPTS_DIR/../workflows/full-loop.md"
+	"$SCRIPTS_DIR/../workflows/log-issue-aidevops.md"
+	"$SCRIPTS_DIR/../workflows/runners.md"
+	"$SCRIPTS_DIR/../workflows/ui-verification.md"
+)
+assert "agent guidance directs readable artifacts to the managed workspace" grep -q 'temporary artifacts.*AIDEVOPS_TEMP_DIR.*never host `/tmp`' "$SCRIPTS_DIR/../AGENTS.md"
+assert "runtime-visible artifact defaults avoid host /tmp paths" test "$(grep -El '/tmp/(browser-qa|aidevops-(pr-body|merge-summary|issue-body)|ui-verify|worker-)' "${runtime_artifact_files[@]}" 2>/dev/null | wc -l | tr -d ' ')" -eq 0
 
 print_info() { return 0; }
 print_warning() { return 0; }

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -150,7 +150,7 @@ Create and sign the merge-summary body in one Bash tool call, then post it with
 blocked by the signature gate.
 
 ```bash
-MERGE_SUMMARY_FILE=/tmp/aidevops-merge-summary.md
+MERGE_SUMMARY_FILE="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/aidevops-merge-summary.md"
 cat <<'EOF' > "$MERGE_SUMMARY_FILE"
 <!-- MERGE_SUMMARY -->
 ## Completion Summary
@@ -165,7 +165,7 @@ EOF
 ```
 
 ```bash
-gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/aidevops-merge-summary.md
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$MERGE_SUMMARY_FILE"
 ```
 
 Verify it posted: `gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[] | select(.body | test("MERGE_SUMMARY"))] | length'` must return `1`.

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -300,7 +300,7 @@ documented in GH#20322. Do not skip it even if Step 3 returned no results.
 First Bash tool call: create and sign an absolute body file.
 
 ```bash
-BODY_FILE=/tmp/aidevops-issue-body.md
+BODY_FILE="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/aidevops-issue-body.md"
 cat <<'EOF' > "$BODY_FILE"
 BODY_CONTENT
 EOF
@@ -313,7 +313,7 @@ creation and the `gh issue create` write in the same Bash tool call.
 ```bash
 gh issue create -R marcusquinn/aidevops \
   --title "TITLE" \
-  --body-file /tmp/aidevops-issue-body.md \
+  --body-file "$BODY_FILE" \
   --label "LABEL"
 ```
 

--- a/.agents/workflows/runners.md
+++ b/.agents/workflows/runners.md
@@ -58,7 +58,7 @@ $HELPER run \
 # Returns immediately with: "Dispatched PID: 12345"
 ```
 
-**Legacy (no `--detach`):** redirect at caller level: `$HELPER run ... </dev/null >>/tmp/worker-${session_key}.log 2>&1 &`
+**Legacy (no `--detach`):** redirect at caller level: `$HELPER run ... </dev/null >>"${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/worker-${session_key}.log" 2>&1 &`
 
 ### Dispatch Rules
 

--- a/.agents/workflows/ui-verification.md
+++ b/.agents/workflows/ui-verification.md
@@ -41,6 +41,10 @@ Capture `before-` baseline before changes, `after-` after. **Responsive-critical
 
 ```typescript
 import { chromium, devices } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+const artifactRoot = join(process.env.AIDEVOPS_TEMP_DIR || join(process.env.HOME!, '.aidevops', '.agent-workspace', 'tmp'), 'ui-verify');
+await mkdir(artifactRoot, { recursive: true });
 const standardDevices = [
   { name: 'mobile-sm',  config: { viewport: { width: 320, height: 568 }, isMobile: true, hasTouch: true } },
   { name: 'mobile',     config: devices['iPhone 14'] },           // 390x844
@@ -59,7 +63,7 @@ for (const { name, config } of standardDevices) {
   page.on('requestfailed', r => failed.push({ url: r.url(), err: r.failure()?.errorText }));
   await page.goto(targetUrl);
   await page.waitForLoadState('networkidle');
-  await page.screenshot({ path: `/tmp/ui-verify/before-${name}.png` });
+  await page.screenshot({ path: join(artifactRoot, `before-${name}.png`) });
   if (errors.length) console.error(`[${name}] errors:`, errors);
   if (failed.length) console.error(`[${name}] failed:`, failed);
   await ctx.close();

--- a/.agents/workflows/ui-verification.md
+++ b/.agents/workflows/ui-verification.md
@@ -42,8 +42,9 @@ Capture `before-` baseline before changes, `after-` after. **Responsive-critical
 ```typescript
 import { chromium, devices } from 'playwright';
 import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
-const artifactRoot = join(process.env.AIDEVOPS_TEMP_DIR || join(process.env.HOME!, '.aidevops', '.agent-workspace', 'tmp'), 'ui-verify');
+const artifactRoot = join(process.env.AIDEVOPS_TEMP_DIR || join(homedir(), '.aidevops', '.agent-workspace', 'tmp'), 'ui-verify');
 await mkdir(artifactRoot, { recursive: true });
 const standardDevices = [
   { name: 'mobile-sm',  config: { viewport: { width: 320, height: 568 }, isMobile: true, hasTouch: true } },


### PR DESCRIPTION
## Summary

Exports a canonical AIDEVOPS_TEMP_DIR, teaches agents to keep runtime-readable artifacts out of host /tmp, migrates Browser QA and operational workflow defaults, and adds regression coverage.

## Files Changed

.agents/AGENTS.md, .agents/prompts/worker-efficiency-protocol.md, .agents/scripts/browser-qa-worker.sh, .agents/scripts/browser-qa/browser-qa.mjs, .agents/scripts/milestone-validation-worker.sh, .agents/scripts/shared-temp-workspace.sh, .agents/scripts/tests/test-managed-temp-workspace.sh, .agents/workflows/full-loop.md, .agents/workflows/log-issue-aidevops.md, .agents/workflows/runners.md, .agents/workflows/ui-verification.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Managed-temp regression: 12 passed; changed-shell ShellCheck clean; OpenCode plugin suite: 363 passed; local and full linters completed; Node syntax and complexity gates clean.

Resolves #27516


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.97 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 16m and 276,402 tokens on this with the user in an interactive session.