### PR TITLE
GH#27520: fix: safely parse trusted approval reviews

### DIFF
--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -646,8 +646,8 @@ _trusted_existing_approver() {
 	local approval_head_sha="${3:-__any_head__}"
 	local existing_approver=""
 
-	existing_approver=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
-		--jq "[.[] | select(.state == \"APPROVED\" and (\"${approval_head_sha}\" == \"__any_head__\" or .commit_id == \"${approval_head_sha}\") and (.author_association == \"OWNER\" or .author_association == \"MEMBER\" or .author_association == \"COLLABORATOR\")) | .user.login][0] // \"\"" 2>/dev/null) || existing_approver=""
+	existing_approver=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" |
+		jq -r --arg head "$approval_head_sha" '[.[]? | select(.state == "APPROVED" and ($head == "__any_head__" or .commit_id == $head) and (.author_association == "OWNER" or .author_association == "MEMBER" or .author_association == "COLLABORATOR")) | .user.login][0] // ""') || existing_approver=""
 	printf '%s\n' "$existing_approver"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -115,7 +115,7 @@ if [[ "${1:-}" == "api" && "$*" == *"/collaborators/"*"/permission"* && "$*" == 
 fi
 
 if [[ "${1:-}" == "api" && "$*" == *"/pulls/"*"/reviews"* ]]; then
-	printf '\n'
+	printf '[]\n'
 	exit 0
 fi
 


### PR DESCRIPTION
## Summary

Pass the approval head SHA to jq with --arg and return valid empty review JSON from the Dependabot test stub.

## Files Changed

.agents/scripts/pulse-merge-gates.sh, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-gates.sh .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bash .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh; bash .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh

Resolves #27520


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.97 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 44,822 tokens on this as a headless worker.