### PR TITLE
GH#27119: fix trusted issue-sync checkout guard lifecycle

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -102,7 +102,7 @@ JOB_BODY=$(sed -n "${JOB_START},${JOB_END}p" "${WORKFLOW_FILE}")
 # Test 2: PATH shims survive caller-repo workspace cleanup.
 # ============================================================
 # shellcheck disable=SC2016 # Assert literal workflow expressions, not test-shell expansion.
-if printf '%s\n' "${JOB_BODY}" | grep -qE 'SHIM_DIR[[:space:]]*=[[:space:]]*"?\$\{?RUNNER_TEMP\}?/[^"]+"?' && \
+if printf '%s\n' "${JOB_BODY}" | grep -qE 'SHIM_DIR[[:space:]]*=[[:space:]]*"?\$\{?RUNNER_TEMP\}?/[^"]+"?' &&
 	printf '%s\n' "${JOB_BODY}" | grep -qE 'echo[[:space:]]+"?\$\{?SHIM_DIR\}?"?[[:space:]]*>>[[:space:]]*"?\$\{?GITHUB_PATH\}?"?'; then
 	check 1 "sync-on-pr-merge stages PATH shims outside GITHUB_WORKSPACE" ""
 else

--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -20,9 +20,10 @@
 #   (b) `clean: false` on the `Checkout repo for TODO.md update` step.
 #
 # Either invariant prevents the regression. The current canonical fix is (a).
-# GH#27119 additionally requires the PATH shims to live outside GITHUB_WORKSPACE:
-# actions/checkout may select `git` before cleaning, so restoring the framework
-# after checkout is too late when the selected executable itself was deleted.
+# GH#27119 additionally requires the PATH shims to live outside GITHUB_WORKSPACE
+# while keeping the canonical Git guard parked until trusted checkout completes.
+# Otherwise actions/checkout either loses its selected executable during cleanup
+# or routes its required init/config/remote/submodule commands through the guard.
 
 set -euo pipefail
 
@@ -110,7 +111,53 @@ else
 fi
 
 # ============================================================
-# Test 3: job has merged == true guard (defends against #22607
+# Test 3: trusted checkouts cannot select the canonical Git guard. The guard is
+# parked before the caller checkout and enabled only after framework restore.
+# ============================================================
+PARK_GUARD_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'mv[[:space:]]+"?\$\{SHIM_DIR\}/git"?[[:space:]]+"?\$\{SHIM_DIR\}/aidevops-git-guard"?' | cut -d: -f1 || true)
+CALLER_CHECKOUT_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Checkout repo before closing-hygiene validation' | cut -d: -f1 || true)
+RESTORE_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Restore framework scripts before task resolution' | cut -d: -f1 || true)
+ENABLE_GUARD_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Enable canonical Git guard after trusted checkouts' | cut -d: -f1 || true)
+RESOLVE_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Resolve task-backed closing issues' | cut -d: -f1 || true)
+
+if [[ -n "${PARK_GUARD_REL_LINE}" && -n "${CALLER_CHECKOUT_REL_LINE}" &&
+	"${PARK_GUARD_REL_LINE}" -lt "${CALLER_CHECKOUT_REL_LINE}" ]]; then
+	check 1 "canonical Git guard is parked before trusted checkout" ""
+else
+	check 0 "canonical Git guard is parked before trusted checkout" "actions/checkout could select the canonical guard"
+fi
+
+if [[ -n "${RESTORE_REL_LINE}" && -n "${ENABLE_GUARD_REL_LINE}" && -n "${RESOLVE_REL_LINE}" &&
+	"${RESTORE_REL_LINE}" -lt "${ENABLE_GUARD_REL_LINE}" &&
+	"${ENABLE_GUARD_REL_LINE}" -lt "${RESOLVE_REL_LINE}" ]]; then
+	check 1 "canonical Git guard is enabled after trusted checkouts" ""
+else
+	check 0 "canonical Git guard is enabled after trusted checkouts" "guard activation must follow framework restore and precede shell mutation steps"
+fi
+
+# Exercise the command sequence used by actions/checkout while the shim is
+# parked. This fixture catches any future change that republishes `git` early.
+FIXTURE_ROOT=$(mktemp -d)
+FIXTURE_SHIM_DIR="${FIXTURE_ROOT}/shim"
+FIXTURE_HOME="${FIXTURE_ROOT}/home"
+FIXTURE_REPO="${FIXTURE_ROOT}/repo"
+mkdir -p "${FIXTURE_SHIM_DIR}" "${FIXTURE_HOME}"
+cp "${REPO_ROOT}/.agents/scripts/git" "${FIXTURE_SHIM_DIR}/aidevops-git-guard"
+FIXTURE_GIT=$(PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" command -v git)
+if [[ "${FIXTURE_GIT}" != "${FIXTURE_SHIM_DIR}/git" ]] &&
+	HOME="${FIXTURE_HOME}" PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" git config --global --add safe.directory "${FIXTURE_REPO}" &&
+	HOME="${FIXTURE_HOME}" PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" git init "${FIXTURE_REPO}" >/dev/null &&
+	HOME="${FIXTURE_HOME}" PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" git -C "${FIXTURE_REPO}" remote add origin "${FIXTURE_ROOT}/upstream.git" &&
+	HOME="${FIXTURE_HOME}" PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" git -C "${FIXTURE_REPO}" config --local gc.auto 0 &&
+	HOME="${FIXTURE_HOME}" PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" git -C "${FIXTURE_REPO}" submodule foreach --recursive true; then
+	check 1 "trusted checkout init/config/remote/submodule fixture bypasses parked guard" ""
+else
+	check 0 "trusted checkout init/config/remote/submodule fixture bypasses parked guard" "trusted actions/checkout commands did not use the runner Git binary"
+fi
+rm -rf "${FIXTURE_ROOT}"
+
+# ============================================================
+# Test 4: job has merged == true guard (defends against #22607
 #         which falsely claimed the guard was missing)
 # ============================================================
 if printf '%s\n' "${JOB_BODY}" | grep -qE 'github\.event\.pull_request\.merged[[:space:]]*==[[:space:]]*true'; then
@@ -120,13 +167,10 @@ else
 fi
 
 # ============================================================
-# Test 4: a single caller checkout establishes the validated TODO snapshot,
+# Test 5: a single caller checkout establishes the validated TODO snapshot,
 # followed by framework restoration and resolution. No later caller checkout
 # may replace that snapshot before proof-log mutation.
 # ============================================================
-CALLER_CHECKOUT_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Checkout repo before closing-hygiene validation' | cut -d: -f1 || true)
-RESTORE_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Restore framework scripts before task resolution' | cut -d: -f1 || true)
-RESOLVE_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Resolve task-backed closing issues' | cut -d: -f1 || true)
 PROOF_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Update TODO\.md proof-log' | cut -d: -f1 || true)
 CALLER_CHECKOUT_COUNT=$(printf '%s\n' "${JOB_BODY}" | grep -cE 'name:[[:space:]]+Checkout repo (before closing-hygiene validation|for TODO\.md update)' || true)
 
@@ -152,7 +196,7 @@ else
 fi
 
 # ============================================================
-# Test 5: Update TODO.md proof-log step still references __aidevops/
+# Test 6: Update TODO.md proof-log step still references __aidevops/
 #         (sanity check — if this changes, the test premise needs updating)
 # ============================================================
 if printf '%s\n' "${JOB_BODY}" | grep -qE 'bash[[:space:]]+__aidevops/\.agents/scripts/issue-sync-git-push-helper\.sh'; then

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -719,17 +719,18 @@ jobs:
 
       - name: Setup gh shim (auto-inject signature footer on writes)
         run: |
-          # GH#27119: actions/checkout resolves every executable once, then
-          # cleans the workspace. Keep the selected git/gh shims and their
-          # sibling dependencies outside that deletion boundary so the later
-          # caller-repo checkout cannot remove an executable while using it.
+          # GH#27119: keep the gh shim and its sibling dependencies outside the
+          # workspace deletion boundary, but park the canonical Git guard under
+          # a non-command name. The trusted actions/checkout steps must select
+          # the runner Git binary for their init/config/remote/submodule work.
           SHIM_DIR="${RUNNER_TEMP}/aidevops-issue-sync-shims"
           rm -rf "${SHIM_DIR}"
           mkdir -p "${SHIM_DIR}"
           cp -R __aidevops/.agents/scripts/. "${SHIM_DIR}/"
+          mv "${SHIM_DIR}/git" "${SHIM_DIR}/aidevops-git-guard"
           chmod +x "${SHIM_DIR}/gh" \
                    "${SHIM_DIR}/gh-signature-helper.sh" \
-                   "${SHIM_DIR}/git" \
+                   "${SHIM_DIR}/aidevops-git-guard" \
                    2>/dev/null || true
           echo "${SHIM_DIR}" >> "$GITHUB_PATH"
 
@@ -802,6 +803,14 @@ jobs:
           path: __aidevops
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
+
+      - name: Enable canonical Git guard after trusted checkouts
+        run: |
+          # The shim directory is already on PATH. Publishing the parked guard
+          # now protects every later shell step without affecting checkout's
+          # own repository initialization or its post-job cleanup.
+          mv "${RUNNER_TEMP}/aidevops-issue-sync-shims/aidevops-git-guard" \
+             "${RUNNER_TEMP}/aidevops-issue-sync-shims/git"
 
       - name: Resolve task-backed closing issues
         id: resolve-tasks


### PR DESCRIPTION
## Summary

Park the canonical Git guard while trusted actions/checkout steps initialize the caller and framework repositories, then enable it before later shell steps; add an executable regression fixture for checkout's config, init, remote, and submodule command sequence.

## Files Changed

.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 10 focused issue-sync assertions passed; 34 canonical Git guard tests passed; 13 Git safety tests passed; ShellCheck, shfmt, actionlint, bash syntax, git diff checks, secret scanning, portability, and changed-file local linters passed.

Resolves #27119


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.97 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 7m and 105,461 tokens on this with the user in an interactive session.