### PR TITLE
GH#27119: park Git guard before checkout cleanup

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -168,7 +168,7 @@ fi
 mv "${FIXTURE_SHIM_DIR}/aidevops-git-guard" "${FIXTURE_SHIM_DIR}/git"
 ACTIVE_GIT=$(PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" command -v git)
 mv "${FIXTURE_SHIM_DIR}/git" "${FIXTURE_SHIM_DIR}/aidevops-git-guard"
-CLEANUP_GIT=$(PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" command -v git)
+CLEANUP_GIT=$(PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" command -v git || true)
 if [[ "${ACTIVE_GIT}" == "${FIXTURE_SHIM_DIR}/git" && "${CLEANUP_GIT}" != "${FIXTURE_SHIM_DIR}/git" ]]; then
 	check 1 "guard activation is bounded to workflow shell steps" ""
 else

--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -112,13 +112,16 @@ fi
 
 # ============================================================
 # Test 3: trusted checkouts cannot select the canonical Git guard. The guard is
-# parked before the caller checkout and enabled only after framework restore.
+# parked before the caller checkout, enabled only after framework restore, and
+# parked again before actions/checkout performs its post-job cleanup.
 # ============================================================
-PARK_GUARD_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'mv[[:space:]]+"?\$\{SHIM_DIR\}/git"?[[:space:]]+"?\$\{SHIM_DIR\}/aidevops-git-guard"?' | cut -d: -f1 || true)
+PARK_GUARD_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'mv[[:space:]]+"?\$\{SHIM_DIR\}/git"?[[:space:]]+"?\$\{SHIM_DIR\}/aidevops-git-guard"?' | cut -d: -f1 | head -1 || true)
 CALLER_CHECKOUT_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Checkout repo before closing-hygiene validation' | cut -d: -f1 || true)
 RESTORE_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Restore framework scripts before task resolution' | cut -d: -f1 || true)
 ENABLE_GUARD_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Enable canonical Git guard after trusted checkouts' | cut -d: -f1 || true)
 RESOLVE_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Resolve task-backed closing issues' | cut -d: -f1 || true)
+PLANS_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Sync PLANS\.md status from TODO\.md completions' | cut -d: -f1 || true)
+PARK_CLEANUP_REL_LINE=$(printf '%s\n' "${JOB_BODY}" | grep -nE 'name:[[:space:]]+Park canonical Git guard before action cleanup' | cut -d: -f1 || true)
 
 if [[ -n "${PARK_GUARD_REL_LINE}" && -n "${CALLER_CHECKOUT_REL_LINE}" &&
 	"${PARK_GUARD_REL_LINE}" -lt "${CALLER_CHECKOUT_REL_LINE}" ]]; then
@@ -133,6 +136,14 @@ if [[ -n "${RESTORE_REL_LINE}" && -n "${ENABLE_GUARD_REL_LINE}" && -n "${RESOLVE
 	check 1 "canonical Git guard is enabled after trusted checkouts" ""
 else
 	check 0 "canonical Git guard is enabled after trusted checkouts" "guard activation must follow framework restore and precede shell mutation steps"
+fi
+
+if [[ -n "${PLANS_REL_LINE}" && -n "${PARK_CLEANUP_REL_LINE}" &&
+	"${PLANS_REL_LINE}" -lt "${PARK_CLEANUP_REL_LINE}" ]] &&
+	printf '%s\n' "${JOB_BODY}" | grep -A1 -E 'name:[[:space:]]+Park canonical Git guard before action cleanup' | grep -qE 'if:[[:space:]]+always\(\)'; then
+	check 1 "canonical Git guard is always parked before action cleanup" ""
+else
+	check 0 "canonical Git guard is always parked before action cleanup" "final guard parking must follow every guarded shell mutation and run even after failures"
 fi
 
 # Exercise the command sequence used by actions/checkout while the shim is
@@ -153,6 +164,15 @@ if [[ "${FIXTURE_GIT}" != "${FIXTURE_SHIM_DIR}/git" ]] &&
 	check 1 "trusted checkout init/config/remote/submodule fixture bypasses parked guard" ""
 else
 	check 0 "trusted checkout init/config/remote/submodule fixture bypasses parked guard" "trusted actions/checkout commands did not use the runner Git binary"
+fi
+mv "${FIXTURE_SHIM_DIR}/aidevops-git-guard" "${FIXTURE_SHIM_DIR}/git"
+ACTIVE_GIT=$(PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" command -v git)
+mv "${FIXTURE_SHIM_DIR}/git" "${FIXTURE_SHIM_DIR}/aidevops-git-guard"
+CLEANUP_GIT=$(PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin" command -v git)
+if [[ "${ACTIVE_GIT}" == "${FIXTURE_SHIM_DIR}/git" && "${CLEANUP_GIT}" != "${FIXTURE_SHIM_DIR}/git" ]]; then
+	check 1 "guard activation is bounded to workflow shell steps" ""
+else
+	check 0 "guard activation is bounded to workflow shell steps" "post-job cleanup could still resolve the canonical guard"
 fi
 rm -rf "${FIXTURE_ROOT}"
 

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -1455,6 +1455,17 @@ jobs:
             fi
           fi
 
+      - name: Park canonical Git guard before action cleanup
+        if: always()
+        run: |
+          # actions/checkout resolves Git again in its post-job phase. Remove
+          # the command name after all workflow shell mutations so checkout's
+          # config/submodule cleanup uses the runner Git binary too.
+          SHIM_DIR="${RUNNER_TEMP}/aidevops-issue-sync-shims"
+          if [[ -x "${SHIM_DIR}/git" ]]; then
+            mv "${SHIM_DIR}/git" "${SHIM_DIR}/aidevops-git-guard"
+          fi
+
   # =========================================================================
   # t1339: Apply conventional-commit labels to PRs
   # t3851: Fixed — uses pull_request_target for fork PR write permissions


### PR DESCRIPTION
## Summary

Complete the trusted-checkout lifecycle by parking the canonical Git shim in an always-run final step before actions/checkout post-job cleanup, while retaining guard enforcement for all intervening workflow shell mutations.

## Files Changed

.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 12 focused lifecycle assertions passed; 34 canonical Git guard tests passed; ShellCheck, shfmt, actionlint, bash syntax, secret scanning, portability, complexity regression checks, and changed-file local linters passed.

Resolves #27119


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.99 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 25m and 295,265 tokens on this with the user in an interactive session.