### PR TITLE
GH#27526: keep temp workspace assertion shellcheck-clean

### DIFF
--- a/.agents/scripts/tests/test-managed-temp-workspace.sh
+++ b/.agents/scripts/tests/test-managed-temp-workspace.sh
@@ -53,7 +53,7 @@ runtime_artifact_files=(
 	"$SCRIPTS_DIR/../workflows/runners.md"
 	"$SCRIPTS_DIR/../workflows/ui-verification.md"
 )
-assert "agent guidance directs readable artifacts to the managed workspace" grep -q 'temporary artifacts.*AIDEVOPS_TEMP_DIR.*never host `/tmp`' "$SCRIPTS_DIR/../AGENTS.md"
+assert "agent guidance directs readable artifacts to the managed workspace" grep -q "temporary artifacts.*AIDEVOPS_TEMP_DIR.*never host \`/tmp\`" "$SCRIPTS_DIR/../AGENTS.md"
 assert "runtime-visible artifact defaults avoid host /tmp paths" test -z "$(grep -El '/tmp/(browser-qa|aidevops-(pr-body|merge-summary|issue-body)|ui-verify|worker-)' "${runtime_artifact_files[@]}" || true)"
 
 print_info() { return 0; }


### PR DESCRIPTION
## Summary

Verified all three source-review suggestions were incorporated before PR #27519 merged, and made the managed-temp guidance assertion ShellCheck-clean by escaping its literal Markdown backticks in a double-quoted regex.

## Files Changed

.agents/scripts/tests/test-managed-temp-workspace.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-managed-temp-workspace.sh (12 passed); shellcheck .agents/scripts/tests/test-managed-temp-workspace.sh; markdownlint-cli2 on .agents/AGENTS.md and .agents/workflows/ui-verification.md

Resolves #27526


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.98 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 58,357 tokens on this as a headless worker.