### PR TITLE
GH#27518: Verify worktree metadata pruning

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -239,3 +239,64 @@ remove_worktree_path_permanently() {
 
 	return 1
 }
+
+# Resolve native Git without selecting the canonical mutation-guard shim. This
+# helper is the audited exception for pruning metadata after a guarded removal
+# has already moved a linked worktree directory to trash.
+_worktree_cleanup_real_git() {
+	local candidate="${AIDEVOPS_REAL_GIT_BIN:-}"
+
+	if [[ -n "$candidate" && -x "$candidate" ]]; then
+		printf '%s\n' "$candidate"
+		return 0
+	fi
+
+	for candidate in /usr/bin/git /usr/local/bin/git /opt/homebrew/bin/git; do
+		if [[ -x "$candidate" ]]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+# Return 0 when Git still lists the exact worktree path in its shared metadata.
+_worktree_metadata_contains_path() {
+	local real_git="$1"
+	local repo_context="$2"
+	local wt_path="$3"
+	local listed_path=""
+
+	while IFS= read -r listed_path; do
+		[[ "$listed_path" == "worktree $wt_path" ]] && return 0
+	done < <("$real_git" -C "$repo_context" worktree list --porcelain 2>/dev/null || true)
+
+	return 1
+}
+
+# Prune a missing linked worktree through the narrowly scoped native-Git
+# primitive, then verify its exact metadata entry disappeared. The target must
+# already be absent so this cannot remove a live worktree directory.
+# Args: $1=repository context, $2=missing worktree path
+# Returns 0 only when the target metadata is absent after pruning.
+prune_missing_worktree_metadata() {
+	local repo_context="$1"
+	local wt_path="$2"
+	local real_git=""
+
+	[[ -n "$repo_context" && -d "$repo_context" && -n "$wt_path" ]] || return 1
+	[[ ! -e "$wt_path" ]] || return 1
+	real_git=$(_worktree_cleanup_real_git) || return 1
+
+	if ! _worktree_metadata_contains_path "$real_git" "$repo_context" "$wt_path"; then
+		return 0
+	fi
+
+	"$real_git" -C "$repo_context" worktree prune >/dev/null 2>&1 || return 1
+	if _worktree_metadata_contains_path "$real_git" "$repo_context" "$wt_path"; then
+		return 1
+	fi
+
+	return 0
+}

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -266,11 +266,21 @@ _worktree_metadata_contains_path() {
 	local real_git="$1"
 	local repo_context="$2"
 	local wt_path="$3"
+	local clean_wt_path="$wt_path"
+	local list_output=""
 	local listed_path=""
 
+	while [[ "$clean_wt_path" != "/" && "$clean_wt_path" == */ ]]; do
+		clean_wt_path="${clean_wt_path%/}"
+	done
+	if ! list_output=$("$real_git" -C "$repo_context" worktree list --porcelain); then
+		return 2
+	fi
+
 	while IFS= read -r listed_path; do
-		[[ "$listed_path" == "worktree $wt_path" ]] && return 0
-	done < <("$real_git" -C "$repo_context" worktree list --porcelain 2>/dev/null || true)
+		listed_path="${listed_path%$'\r'}"
+		[[ "$listed_path" == "worktree $clean_wt_path" ]] && return 0
+	done <<<"$list_output"
 
 	return 1
 }
@@ -284,19 +294,31 @@ prune_missing_worktree_metadata() {
 	local repo_context="$1"
 	local wt_path="$2"
 	local real_git=""
+	local metadata_status=0
 
 	[[ -n "$repo_context" && -d "$repo_context" && -n "$wt_path" ]] || return 1
 	[[ ! -e "$wt_path" ]] || return 1
 	real_git=$(_worktree_cleanup_real_git) || return 1
+	[[ -n "$real_git" ]] || return 1
 
-	if ! _worktree_metadata_contains_path "$real_git" "$repo_context" "$wt_path"; then
-		return 0
-	fi
-
-	"$real_git" -C "$repo_context" worktree prune >/dev/null 2>&1 || return 1
 	if _worktree_metadata_contains_path "$real_git" "$repo_context" "$wt_path"; then
+		metadata_status=0
+	else
+		metadata_status=$?
+	fi
+	if [[ "$metadata_status" -eq 1 ]]; then
+		return 0
+	elif [[ "$metadata_status" -ne 0 ]]; then
 		return 1
 	fi
+
+	"$real_git" -C "$repo_context" worktree prune >/dev/null || return 1
+	if _worktree_metadata_contains_path "$real_git" "$repo_context" "$wt_path"; then
+		metadata_status=0
+	else
+		metadata_status=$?
+	fi
+	[[ "$metadata_status" -eq 1 ]] || return 1
 
 	return 0
 }

--- a/.agents/scripts/tests/test-worktree-metadata-prune.sh
+++ b/.agents/scripts/tests/test-worktree-metadata-prune.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+GIT_SHIM="${SCRIPT_DIR}/git"
+TEST_ROOT=$(mktemp -d)
+REPO="${TEST_ROOT}/repo"
+LINKED="${TEST_ROOT}/linked"
+FAILED_LINKED="${TEST_ROOT}/failed-linked"
+SHIM_BIN="${TEST_ROOT}/bin"
+FAILING_GIT="${TEST_ROOT}/failing-git"
+
+teardown() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap teardown EXIT
+
+mkdir -p "$REPO" "$SHIM_BIN"
+/usr/bin/git -C "$REPO" init -q -b main
+/usr/bin/git -C "$REPO" config user.name Test
+/usr/bin/git -C "$REPO" config user.email test@example.invalid
+/usr/bin/git -C "$REPO" config commit.gpgsign false
+printf 'seed\n' >"${REPO}/README.md"
+/usr/bin/git -C "$REPO" add README.md
+/usr/bin/git -C "$REPO" commit -q -m seed
+/usr/bin/git -C "$REPO" worktree add -q -b feature/prune-test "$LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/prune-failure "$FAILED_LINKED"
+ln -s "$GIT_SHIM" "${SHIM_BIN}/git"
+
+if PATH="${SHIM_BIN}:/usr/bin:/bin" git -C "$REPO" worktree prune >/dev/null 2>&1; then
+	printf 'FAIL canonical Git shim unexpectedly allowed direct metadata prune\n'
+	exit 1
+fi
+
+mkdir -p "${TEST_ROOT}/home"
+if ! output=$(
+	cd "$REPO" || exit 1
+	HOME="${TEST_ROOT}/home" PATH="${SHIM_BIN}:/usr/bin:/bin" \
+		bash "${SCRIPT_DIR}/worktree-helper.sh" remove "$LINKED" 2>&1
+); then
+	printf 'FAIL worktree-helper removal failed with canonical Git shim active: %s\n' "$output"
+	exit 1
+fi
+
+if /usr/bin/git -C "$REPO" worktree list --porcelain | grep -Fqx "worktree $LINKED"; then
+	printf 'FAIL linked worktree metadata remains after helper removal\n'
+	exit 1
+fi
+
+printf 'PASS worktree-helper prunes metadata with canonical Git shim active\n'
+
+cat >"$FAILING_GIT" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree prune"* ]]; then
+	exit 1
+fi
+if [[ "$*" == *"worktree list --porcelain"* ]]; then
+	/usr/bin/git "$@" || exit 1
+	printf 'worktree %s\n\n' "${FAILED_LINKED_FOR_TEST:?}"
+	exit 0
+fi
+exec /usr/bin/git "$@"
+EOF
+chmod +x "$FAILING_GIT"
+
+if output=$(
+	cd "$REPO" || exit 1
+	HOME="${TEST_ROOT}/home" PATH="${SHIM_BIN}:/usr/bin:/bin" AIDEVOPS_REAL_GIT_BIN="$FAILING_GIT" \
+		FAILED_LINKED_FOR_TEST="$FAILED_LINKED" \
+		bash "${SCRIPT_DIR}/worktree-helper.sh" remove "$FAILED_LINKED" 2>&1
+); then
+	printf 'FAIL worktree-helper reported success when metadata prune failed\n'
+	exit 1
+fi
+if [[ "$output" != *"Partial cleanup:"* || "$output" != *"Recovery:"* ]]; then
+	printf 'FAIL prune failure omitted partial-cleanup recovery guidance: %s\n' "$output"
+	exit 1
+fi
+printf 'PASS worktree-helper returns partial-cleanup guidance when metadata prune fails\n'

--- a/.agents/scripts/tests/test-worktree-metadata-prune.sh
+++ b/.agents/scripts/tests/test-worktree-metadata-prune.sh
@@ -12,6 +12,7 @@ LINKED="${TEST_ROOT}/linked"
 FAILED_LINKED="${TEST_ROOT}/failed-linked"
 SHIM_BIN="${TEST_ROOT}/bin"
 FAILING_GIT="${TEST_ROOT}/failing-git"
+QUERY_FAILING_GIT="${TEST_ROOT}/query-failing-git"
 
 teardown() {
 	rm -rf "$TEST_ROOT"
@@ -81,3 +82,20 @@ if [[ "$output" != *"Partial cleanup:"* || "$output" != *"Recovery:"* ]]; then
 	exit 1
 fi
 printf 'PASS worktree-helper returns partial-cleanup guidance when metadata prune fails\n'
+
+cat >"$QUERY_FAILING_GIT" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree list --porcelain"* ]]; then
+	exit 1
+fi
+exec /usr/bin/git "$@"
+EOF
+chmod +x "$QUERY_FAILING_GIT"
+# shellcheck source=../audit-worktree-removal-helper.sh
+source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
+if AIDEVOPS_REAL_GIT_BIN="$QUERY_FAILING_GIT" \
+	prune_missing_worktree_metadata "$REPO" "${TEST_ROOT}/missing-query-target"; then
+	printf 'FAIL metadata query failure was treated as successful cleanup\n'
+	exit 1
+fi
+printf 'PASS metadata query failure cannot report cleanup success\n'

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -154,6 +154,8 @@ _remove_validate_path() {
 # Returns 0 on success, 1 on failure.
 _remove_cleanup_and_execute() {
 	local path_to_remove="$1"
+	local repo_context=""
+	repo_context=$(get_repo_root) || return 1
 
 	# Clean up aidevops runtime files before removal (prevents "contains untracked files" error)
 	# Use trash_path for recoverable deletion; fall back to rm -rf if trash unavailable.
@@ -178,7 +180,12 @@ _remove_cleanup_and_execute() {
 		# trash unavailable or failed — fall back to git worktree remove
 		git worktree remove "$path_to_remove" || return 1
 	else
-		git worktree prune 2>/dev/null || true
+		if ! prune_missing_worktree_metadata "$repo_context" "$path_to_remove"; then
+			echo -e "${YELLOW}Partial cleanup: worktree files moved to trash, but Git metadata remains.${NC}"
+			echo "Recovery: resolve Git metadata permissions or locks, then prune the missing worktree from a linked worktree and verify it is absent from 'git worktree list --porcelain'."
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$path_to_remove" "metadata-prune-failed" "partial-cleanup"
+			return 1
+		fi
 	fi
 
 	# Unregister ownership (t189)

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -181,8 +181,8 @@ _remove_cleanup_and_execute() {
 		git worktree remove "$path_to_remove" || return 1
 	else
 		if ! prune_missing_worktree_metadata "$repo_context" "$path_to_remove"; then
-			echo -e "${YELLOW}Partial cleanup: worktree files moved to trash, but Git metadata remains.${NC}"
-			echo "Recovery: resolve Git metadata permissions or locks, then prune the missing worktree from a linked worktree and verify it is absent from 'git worktree list --porcelain'."
+			printf '%b\n' "${YELLOW}Partial cleanup: worktree files moved to trash, but Git metadata remains.${NC}"
+			printf '%s\n' "Recovery: resolve Git metadata permissions or locks, then prune the missing worktree from a linked worktree and verify it is absent from 'git worktree list --porcelain'."
 			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$path_to_remove" "metadata-prune-failed" "partial-cleanup"
 			return 1
 		fi


### PR DESCRIPTION
## Summary

Route missing-worktree metadata pruning through a narrow native-Git cleanup primitive, verify the target entry is gone before success, and report partial cleanup with recovery guidance on failure.

## Files Changed

.agents/scripts/audit-worktree-removal-helper.sh, .agents/scripts/tests/test-worktree-metadata-prune.sh, .agents/scripts/worktree-helper-cmds.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worktree-metadata-prune.sh; bash .agents/scripts/tests/test-worktree-removal-audit.sh; ShellCheck; git diff --check

Resolves #27518


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.99 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 5m and 104,258 tokens on this as a headless worker.