### PR TITLE
GH#27540: prevent duplicate terminal telemetry outcomes

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -943,9 +943,9 @@ cmd_record_outcome() {
 		fi
 	fi
 
-	if [[ -n "$attempt_id" ]] && jq -e --arg aid "$attempt_id" \
-		'select(.outcome != "pending" and (.attempt_id // "") == $aid)' \
-		"$telemetry_file" >/dev/null 2>&1; then
+	if [[ -n "$attempt_id" ]] && jq -es --arg aid "$attempt_id" \
+		'any(.[]; .outcome != "pending" and (.attempt_id // "") == $aid)' \
+		"$telemetry_file" >/dev/null; then
 		_release_lock
 		return 0
 	fi

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -943,8 +943,8 @@ cmd_record_outcome() {
 		fi
 	fi
 
-	if [[ -n "$attempt_id" ]] && jq -es --arg aid "$attempt_id" \
-		'any(.[]; .outcome != "pending" and (.attempt_id // "") == $aid)' \
+	if [[ -n "$attempt_id" ]] && jq -ne --arg aid "$attempt_id" \
+		'any(inputs; .outcome != "pending" and (.attempt_id // "") == $aid)' \
 		"$telemetry_file" >/dev/null; then
 		_release_lock
 		return 0

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -147,8 +147,8 @@ test_tier_telemetry_correlates_terminal_outcomes() {
 		--repo "owner/repo" --pid $$ --tier standard --model model-b --lease-token attempt-43
 	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
 		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome success
-	# A later unrelated record must not hide the existing terminal outcome. jq -e
-	# reports only its final streamed result unless the JSONL input is slurped.
+	# Aggregate the streamed records so a later unrelated row cannot hide an
+	# existing terminal outcome for this attempt.
 	run_helper "$LEDGER_HELPER" register --session-key "issue-44" --issue 44 \
 		--repo "owner/repo" --pid $$ --tier standard --model model-c --lease-token attempt-44
 	# Repeated cleanup and a conflicting late event must not create or replace the

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -147,6 +147,10 @@ test_tier_telemetry_correlates_terminal_outcomes() {
 		--repo "owner/repo" --pid $$ --tier standard --model model-b --lease-token attempt-43
 	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
 		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome success
+	# A later unrelated record must not hide the existing terminal outcome. jq -e
+	# reports only its final streamed result unless the JSONL input is slurped.
+	run_helper "$LEDGER_HELPER" register --session-key "issue-44" --issue 44 \
+		--repo "owner/repo" --pid $$ --tier standard --model model-c --lease-token attempt-44
 	# Repeated cleanup and a conflicting late event must not create or replace the
 	# first terminal result for this attempt.
 	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
@@ -166,9 +170,9 @@ test_tier_telemetry_correlates_terminal_outcomes() {
 	terminal_count=$(jq -s '[.[] | select(.outcome != "pending")] | length' "$telemetry_file")
 	terminal_tier=$(jq -rs 'first(.[] | select(.attempt_id == "attempt-42" and .outcome == "success") | .tier)' "$telemetry_file")
 	report=$("$LEDGER_HELPER" tier-report)
-	[[ "$pending_count" == "2" && "$success_count" == "3" && "$terminal_count" == "3" ]] || result=1
+	[[ "$pending_count" == "3" && "$success_count" == "3" && "$terminal_count" == "3" ]] || result=1
 	[[ "$terminal_tier" == "simple" ]] || result=1
-	[[ "$report" == *"Total dispatches: 2"* && "$report" == *"Pending/unknown: 1"* ]] || result=1
+	[[ "$report" == *"Total dispatches: 3"* && "$report" == *"Pending/unknown: 2"* ]] || result=1
 	[[ "$report" == *"Success: 1"* && "$report" == *"Legacy/unmatched terminal events: 1"* ]] || result=1
 	[[ "$report" == *"tier:simple — 1/1 (100.0%)"* && "$report" != *"tier:standard"* ]] || result=1
 	print_result "tier telemetry correlates and idempotently reports terminal outcomes" "$result" \


### PR DESCRIPTION
## Summary

- aggregate streamed tier telemetry records before checking whether an attempt already has a terminal outcome
- preserve first-outcome-wins when unrelated records appear later in the telemetry stream
- keep jq parser errors visible and add a regression fixture for a trailing pending attempt

## Testing

- `bash .agents/scripts/tests/test-dispatch-ledger-helper.sh` (27 passed)
- `shellcheck .agents/scripts/dispatch-ledger-helper.sh .agents/scripts/tests/test-dispatch-ledger-helper.sh`

## Runtime Testing

- self-assessed: low-risk shell correctness fix covered by the focused runtime test suite

Resolves #27540

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.100 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 80,858 tokens on this as a headless worker. Overall, 10m since this issue was created.
