### PR TITLE
GH#27547: test: clarify postflight slurpfile assertion failure

### DIFF
--- a/.agents/scripts/tests/test-postflight-check-run-dedup.sh
+++ b/.agents/scripts/tests/test-postflight-check-run-dedup.sh
@@ -60,7 +60,10 @@ if grep -Fq -- '--argjson current_runs' "${REPO_ROOT}/.github/workflows/postflig
 	exit 1
 fi
 
-grep -Fq -- '--slurpfile current_run_documents' "${REPO_ROOT}/.github/workflows/postflight.yml"
+if ! grep -Fq -- '--slurpfile current_run_documents' "${REPO_ROOT}/.github/workflows/postflight.yml"; then
+	printf 'FAIL: postflight does not use --slurpfile for current_run_documents\n' >&2
+	exit 1
+fi
 
 printf 'PASS: postflight reconciliation avoids argv size limits\n'
 


### PR DESCRIPTION
## Summary

Wrap the postflight current_run_documents slurpfile assertion in an explicit failure branch so set -e cannot suppress the diagnostic.

## Files Changed

.agents/scripts/tests/test-postflight-check-run-dedup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-postflight-check-run-dedup.sh; shellcheck .agents/scripts/tests/test-postflight-check-run-dedup.sh

Resolves #27547


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.100 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 2m and 25,517 tokens on this as a headless worker.