### PR TITLE
GH#27544: fix: guard optional patch failure IDs

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -163,7 +163,7 @@ gh() {
 	done
 	if [[ "$1" == "api" && "$api_path" == *"/issues/comments/"* && "$*" == *"--method PATCH"* ]]; then
 		comment_id="${api_path##*/}"
-		if [[ ",${TEST_FAIL_PATCH_IDS}," == *",${comment_id},"* ]]; then
+		if [[ ",${TEST_FAIL_PATCH_IDS:-}," == *",${comment_id},"* ]]; then
 			return 1
 		fi
 		state_tmp="${TEST_PR_COMMENTS_FILE}.tmp"


### PR DESCRIPTION
## Summary

Guard the optional TEST_FAIL_PATCH_IDS test control with a nounset-safe default so the gh stub remains valid when the variable is absent.

## Files Changed

.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh; bash .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh (32 tests, 0 failures)

Resolves #27544


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.101 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 3m and 60,757 tokens on this as a headless worker.