### PR TITLE
GH#27537: short-circuit absent fixture Git

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -158,7 +158,7 @@ cp "${REPO_ROOT}/.agents/scripts/git" "${FIXTURE_SHIM_DIR}/aidevops-git-guard"
 if (
 	export HOME="${FIXTURE_HOME}"
 	export PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin"
-	FIXTURE_GIT=$(command -v git)
+	FIXTURE_GIT=$(command -v git) &&
 	[[ "${FIXTURE_GIT}" != "${FIXTURE_SHIM_DIR}/git" ]] &&
 		git config --global --add safe.directory "${FIXTURE_REPO}" &&
 		git init -q "${FIXTURE_REPO}" &&


### PR DESCRIPTION
## Summary

Short-circuit the trusted-checkout fixture when command -v cannot locate Git, preventing follow-on command-not-found errors in restricted PATH environments.

## Files Changed

.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh; bash .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh (12 passed)

Resolves #27537


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.101 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 2m and 48,178 tokens on this as a headless worker.