### PR TITLE
GH#27541: fix: count repaired Tabby profiles once

### DIFF
--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -526,7 +526,8 @@ def repair_broken_opencode_launch_profiles(config_text: str) -> tuple[str, int]:
         repaired_block, repaired_count = _repair_broken_opencode_launch_profile_block(original_block)
         repaired_block, dynamic_title_changed = _enable_dynamic_title(repaired_block)
         repaired.extend(repaired_block.split("\n"))
-        repairs += max(repaired_count, int(dynamic_title_changed))
+        if repaired_count > 0 or dynamic_title_changed:
+            repairs += 1
         i = block_end
 
     return "\n".join(repaired), repairs

--- a/tests/test-tabby-profile-sync.py
+++ b/tests/test-tabby-profile-sync.py
@@ -301,6 +301,21 @@ class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
         self.assertIn("    disableDynamicTitle: false", repaired)
         self.assertNotIn("    disableDynamicTitle: true", repaired)
 
+    def test_multiple_fixes_count_one_repaired_profile(self):
+        repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(
+            """profiles:
+  - name: repo
+    options:
+      command: /bin/zsh -l -c 'opencode; exec zsh'
+      args: []
+      command: /bin/zsh -l -c 'opencode; exec zsh'
+"""
+        )
+
+        self.assertEqual(repairs, 1)
+        self.assertEqual(repaired.count("      command: /bin/zsh"), 1)
+        self.assertIn("    disableDynamicTitle: false", repaired)
+
     def test_unrelated_profile_preserves_dynamic_title_setting(self):
         original = """profiles:
   - name: shell


### PR DESCRIPTION
## Summary

Count each repaired OpenCode Tabby profile once even when launch repair and dynamic-title changes apply together; add regression coverage for multiple fixes in one profile.

## Files Changed

.agents/scripts/tabby-profile-sync.py, tests/test-tabby-profile-sync.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 -m unittest tests.test-tabby-profile-sync.TestRepairBrokenOpenCodeLaunchProfiles; python3 -m py_compile .agents/scripts/tabby-profile-sync.py tests/test-tabby-profile-sync.py; git diff --check

Resolves #27541


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.101 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 3m and 52,874 tokens on this as a headless worker.