### PR TITLE
GH#27545: guard session ID discovery

### DIFF
--- a/.agents/workflows/session-analysis.md
+++ b/.agents/workflows/session-analysis.md
@@ -57,7 +57,8 @@ available diagnostics. Obtain the current runtime ID with
 `printenv OPENCODE_SESSION_ID || printenv CLAUDE_SESSION_ID || true`, then
 substitute the returned literal for `<session-id>`; this remains successful when
 neither variable is set and avoids expansion that command-policy parsing may
-reject.
+reject. If the command returns no literal, mark session-specific diagnostics
+unavailable and skip every command requiring `<session-id>`.
 
 | Evidence | Command or source | Run when |
 |---|---|---|

--- a/.agents/workflows/session-analysis.md
+++ b/.agents/workflows/session-analysis.md
@@ -54,9 +54,10 @@ dependencies; do not silently expand into a whole-repository audit.
 
 Use the conversation and existing tool results first. Run only relevant,
 available diagnostics. Obtain the current runtime ID with
-`printenv OPENCODE_SESSION_ID` or `printenv CLAUDE_SESSION_ID`, then substitute
-the returned literal for `<session-id>`; command-policy parsing may reject shell
-variable expansion.
+`printenv OPENCODE_SESSION_ID || printenv CLAUDE_SESSION_ID || true`, then
+substitute the returned literal for `<session-id>`; this remains successful when
+neither variable is set and avoids expansion that command-policy parsing may
+reject.
 
 | Evidence | Command or source | Run when |
 |---|---|---|


### PR DESCRIPTION
## Summary

Guard runtime session ID lookup across OpenCode, Claude Code, and missing-variable environments without shell expansion

## Files Changed

.agents/workflows/session-analysis.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified guarded command under bash -e with neither variable, Claude-only, and both-variable environments; git diff --check

Resolves #27545


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.101 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 4m and 47,524 tokens on this as a headless worker.