### PR TITLE
GH#27538: fix: verify review snippets embedded in prose

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -163,6 +163,9 @@ _check_write_permission() {
 _extract_snippet_from_inline_code() {
 	local body_full="$1"
 	local line=""
+	local inline_code_pattern="\`([^\`]+)\`"
+	local remaining=""
+	local snippet=""
 
 	while IFS= read -r line; do
 		case "$line" in
@@ -179,6 +182,18 @@ _extract_snippet_from_inline_code() {
 			line="${line//\`/}"
 			;;
 		*)
+			# Reviewers commonly embed the stale problem snippet in prose, for
+			# example "Using `<problem>` is unsafe". Inspect each inline code
+			# span rather than requiring the line to begin with a backtick.
+			remaining="$line"
+			while [[ "$remaining" =~ $inline_code_pattern ]]; do
+				snippet=$(_trim_whitespace "${BASH_REMATCH[1]}")
+				if [[ -n "$snippet" && ${#snippet} -ge 12 ]]; then
+					echo "$snippet"
+					return 0
+				fi
+				remaining="${remaining#*\`"${BASH_REMATCH[1]}"\`}"
+			done
 			continue
 			;;
 		esac

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-verification.sh
@@ -52,6 +52,33 @@ test_skips_resolved_finding_when_snippet_missing() {
 	return 0
 }
 
+test_skips_resolved_embedded_inline_problem_snippet() {
+	reset_mock_state
+	GH_RAW_CONTENT='- Put artifacts under `${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}`.'
+
+	local findings
+	findings='[{"file":".agents/AGENTS.md","line":79,"body_full":"Using `~` inside `${AIDEVOPS_TEMP_DIR:-~/.aidevops/.agent-workspace/tmp}` is unsafe. Use `$HOME` instead of `~`.","reviewer":"gemini","reviewer_login":"gemini-code-assist[bot]","severity":"medium","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
+
+	if [[ "$created" == "0" && "$created_count" -eq 0 ]]; then
+		print_result "skip resolved problem snippet embedded in review prose" 0
+	else
+		print_result "skip resolved problem snippet embedded in review prose" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
 test_creates_issue_when_snippet_still_exists() {
 	reset_mock_state
 	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nverification marker present\nreturn 1\n'

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -220,6 +220,7 @@ main() {
 
 	echo "Running quality-feedback main-branch verification tests"
 	test_skips_resolved_finding_when_snippet_missing
+	test_skips_resolved_embedded_inline_problem_snippet
 	test_creates_issue_when_snippet_still_exists
 	test_skips_deleted_file
 	test_handles_diff_fence_without_false_positive


### PR DESCRIPTION
## Summary

Teach quality-feedback verification to extract stale inline-code snippets embedded in reviewer prose, preventing already-fixed feedback from generating quality-debt issues. Add a regression matching PR #27519's tilde fallback review.

## Files Changed

.agents/scripts/quality-feedback-helper.sh, .agents/scripts/tests/test-quality-feedback-main-verification-verification.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/quality-feedback-helper.sh .agents/scripts/tests/test-quality-feedback-main-verification-verification.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh; bash .agents/scripts/tests/test-quality-feedback-main-verification.sh

Resolves #27538


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.101 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 8m and 96,901 tokens on this as a headless worker.