### PR TITLE
GH#27546: guard progressive-load fixture cleanup

### DIFF
--- a/.agents/scripts/tests/test-progressive-load-check.sh
+++ b/.agents/scripts/tests/test-progressive-load-check.sh
@@ -11,7 +11,11 @@ TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/progressive-load-check.XXXXXX")
 FIXTURE_DIR="$TEST_ROOT/agents"
 
 cleanup() {
-	rm -rf "$TEST_ROOT"
+	local test_root="${TEST_ROOT:-}"
+
+	if [[ -n "$test_root" ]]; then
+		rm -rf "$test_root"
+	fi
 	return 0
 }
 trap cleanup EXIT


### PR DESCRIPTION
## Summary

Guard the progressive-load test cleanup against an unset TEST_ROOT under nounset mode.

## Files Changed

.agents/scripts/tests/test-progressive-load-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-progressive-load-check.sh; bash .agents/scripts/tests/test-progressive-load-check.sh

Resolves #27546


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.101 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 6m and 35,624 tokens on this as a headless worker.