### PR TITLE
GH#27557: fix: scope postflight to release-owned checks

### DIFF
--- a/.agents/scripts/tests/fixtures/postflight-release-owned-check-runs.json
+++ b/.agents/scripts/tests/fixtures/postflight-release-owned-check-runs.json
@@ -1,0 +1,44 @@
+{
+  "check_runs": [
+    {
+      "id": 2001,
+      "name": "Framework Validation",
+      "status": "completed",
+      "conclusion": "success",
+      "check_suite": { "id": 501 },
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 2002,
+      "name": "Publish npm package",
+      "status": "completed",
+      "conclusion": "success",
+      "check_suite": { "id": 502 },
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 2003,
+      "name": "Security Validation",
+      "status": "queued",
+      "conclusion": null,
+      "check_suite": { "id": 503 },
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 2004,
+      "name": "gate / Re-evaluate PR Gate on Issue Change",
+      "status": "in_progress",
+      "conclusion": null,
+      "check_suite": { "id": 504 },
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 2005,
+      "name": "Historical Framework Validation",
+      "status": "completed",
+      "conclusion": "failure",
+      "check_suite": { "id": 505 },
+      "app": { "slug": "github-actions" }
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/postflight-release-workflow-runs.json
+++ b/.agents/scripts/tests/fixtures/postflight-release-workflow-runs.json
@@ -1,0 +1,39 @@
+{
+  "workflow_runs": [
+    {
+      "id": 1001,
+      "name": "Code Quality Analysis",
+      "event": "push",
+      "head_sha": "release-sha",
+      "check_suite_id": 501
+    },
+    {
+      "id": 1002,
+      "name": "Publish Packages",
+      "event": "release",
+      "head_sha": "release-sha",
+      "check_suite_id": 502
+    },
+    {
+      "id": 1003,
+      "name": "Issue Triage Gate",
+      "event": "issues",
+      "head_sha": "release-sha",
+      "check_suite_id": 503
+    },
+    {
+      "id": 1004,
+      "name": "Review Bot Gate",
+      "event": "issue_comment",
+      "head_sha": "release-sha",
+      "check_suite_id": 504
+    },
+    {
+      "id": 1005,
+      "name": "Old Code Quality Analysis",
+      "event": "push",
+      "head_sha": "other-sha",
+      "check_suite_id": 505
+    }
+  ]
+}

--- a/.agents/scripts/tests/test-postflight-release-owned-checks.sh
+++ b/.agents/scripts/tests/test-postflight-release-owned-checks.sh
@@ -27,6 +27,16 @@ jq -e '
 
 printf 'PASS: unrelated queued issue checks do not delay successful release checks\n'
 
+PAGINATED_SCOPED=$(jq -c \
+	--arg release_sha "release-sha" \
+	--arg self_name "Verify Release Health" \
+	--slurpfile release_run_documents <(jq -s '.' "$WORKFLOW_FIXTURE") \
+	-f "$FILTER" \
+	"$CHECK_FIXTURE")
+jq -e '(.check_runs | length) == 2' <<<"$PAGINATED_SCOPED" >/dev/null
+
+printf 'PASS: paginated workflow-run response retains release-owned suites\n'
+
 PENDING_INPUT=$(jq '(.check_runs[] | select(.id == 2001)) |= (.status = "in_progress" | .conclusion = null)' "$CHECK_FIXTURE")
 PENDING=$(scope_checks <<<"$PENDING_INPUT")
 jq -e '[.check_runs[] | select(.status != "completed")] | length == 1' <<<"$PENDING" >/dev/null

--- a/.agents/scripts/tests/test-postflight-release-owned-checks.sh
+++ b/.agents/scripts/tests/test-postflight-release-owned-checks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+FILTER="${REPO_ROOT}/.github/scripts/release-owned-check-runs.jq"
+WORKFLOW_FIXTURE="${SCRIPT_DIR}/fixtures/postflight-release-workflow-runs.json"
+CHECK_FIXTURE="${SCRIPT_DIR}/fixtures/postflight-release-owned-check-runs.json"
+
+scope_checks() {
+	jq -c \
+		--arg release_sha "release-sha" \
+		--arg self_name "Verify Release Health" \
+		--slurpfile release_run_documents "$WORKFLOW_FIXTURE" \
+		-f "$FILTER"
+	return 0
+}
+
+SCOPED=$(scope_checks <"$CHECK_FIXTURE")
+
+jq -e '
+  (.check_runs | length) == 2 and
+  all(.check_runs[]; .check_suite.id == 501 or .check_suite.id == 502) and
+  all(.check_runs[]; .status == "completed" and .conclusion == "success")
+' <<<"$SCOPED" >/dev/null
+
+printf 'PASS: unrelated queued issue checks do not delay successful release checks\n'
+
+PENDING_INPUT=$(jq '(.check_runs[] | select(.id == 2001)) |= (.status = "in_progress" | .conclusion = null)' "$CHECK_FIXTURE")
+PENDING=$(scope_checks <<<"$PENDING_INPUT")
+jq -e '[.check_runs[] | select(.status != "completed")] | length == 1' <<<"$PENDING" >/dev/null
+
+printf 'PASS: pending release-quality checks remain pending\n'
+
+FAILED_INPUT=$(jq '(.check_runs[] | select(.id == 2001)) |= (.conclusion = "failure")' "$CHECK_FIXTURE")
+FAILED=$(scope_checks <<<"$FAILED_INPUT")
+jq -e '[.check_runs[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required"))] | length == 1' <<<"$FAILED" >/dev/null
+
+printf 'PASS: terminal release-quality failures remain blocking\n'
+
+grep -Fq "actions/runs?head_sha=\${COMMIT_SHA}&per_page=100" "${REPO_ROOT}/.github/workflows/postflight.yml"
+grep -Fq 'release-owned-check-runs.jq' "${REPO_ROOT}/.github/workflows/postflight.yml"
+grep -Fq -- '--slurpfile release_run_documents' "${REPO_ROOT}/.github/workflows/postflight.yml"
+
+printf 'PASS: postflight keeps paginated exact-SHA release-run classification\n'

--- a/.github/scripts/release-owned-check-runs.jq
+++ b/.github/scripts/release-owned-check-runs.jq
@@ -1,4 +1,5 @@
 ($release_run_documents
+ | flatten
  | map(.workflow_runs // [])
  | add
  | map(

--- a/.github/scripts/release-owned-check-runs.jq
+++ b/.github/scripts/release-owned-check-runs.jq
@@ -1,0 +1,18 @@
+($release_run_documents
+ | map(.workflow_runs // [])
+ | add
+ | map(
+     select(.head_sha == $release_sha)
+     | select(.event == "push" or .event == "release" or .event == "workflow_dispatch")
+     | .check_suite_id
+   )
+ | map(select(. != null))
+ | unique) as $release_suite_ids
+|
+{
+  check_runs: [
+    .check_runs[]?
+    | select(.name != $self_name)
+    | select(.check_suite.id as $suite_id | $release_suite_ids | index($suite_id))
+  ]
+}

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -46,8 +46,8 @@ jobs:
         REPO: ${{ github.repository }}
         COMMIT_SHA: ${{ steps.release_commit.outputs.sha }}
       run: |
-        echo "Waiting for all check runs to complete..."
-        echo "Note: Excluding this workflow (Verify Release Health) to avoid circular dependency"
+        echo "Waiting for release-owned check runs to complete..."
+        echo "Note: Excluding issue/comment workflows and this workflow to avoid unrelated waits"
         sleep 60  # Initial wait for workflows to start
         
         # Poll for completion, excluding this workflow to avoid circular dependency
@@ -56,31 +56,48 @@ jobs:
           CHECK_RUNS_RESPONSE=$(gh api --paginate --slurp \
             "repos/${REPO}/commits/${COMMIT_SHA}/check-runs?per_page=100" \
             | jq -c -f .github/scripts/flatten-check-run-pages.jq)
-          PENDING=$(jq --arg self_name "$SELF_NAME" \
-            '[.check_runs[] | select(.status != "completed" and .name != $self_name)] | length' \
+          RELEASE_RUNS_RESPONSE=$(gh api --paginate --slurp \
+            "repos/${REPO}/actions/runs?head_sha=${COMMIT_SHA}&per_page=100")
+          RELEASE_CHECK_RUNS=$(jq -c \
+            --arg release_sha "$COMMIT_SHA" \
+            --arg self_name "$SELF_NAME" \
+            --slurpfile release_run_documents <(printf '%s\n' "$RELEASE_RUNS_RESPONSE") \
+            -f .github/scripts/release-owned-check-runs.jq \
             <<<"$CHECK_RUNS_RESPONSE")
+          PENDING=$(jq --arg self_name "$SELF_NAME" \
+            '[.check_runs[] | select(.status != "completed")] | length' \
+            <<<"$RELEASE_CHECK_RUNS")
           
           if [[ "$PENDING" == "0" ]]; then
-            echo "All check runs completed (excluding self)"
+            echo "All release-owned check runs completed"
             break
           fi
           
           # Show which workflows are still pending
           echo "Waiting for $PENDING check runs... (attempt $i/20)"
           jq -r --arg self_name "$SELF_NAME" \
-            '.check_runs[] | select(.status != "completed" and .name != $self_name) | "  - \(.name): \(.status)"' \
-            <<<"$CHECK_RUNS_RESPONSE" || true
+            '.check_runs[] | select(.status != "completed") | "  - \(.name): \(.status)"' \
+            <<<"$RELEASE_CHECK_RUNS" || true
           sleep 30
         done
 
         CHECK_RUNS_RESPONSE=$(gh api --paginate --slurp \
           "repos/${REPO}/commits/${COMMIT_SHA}/check-runs?per_page=100" \
           | jq -c -f .github/scripts/flatten-check-run-pages.jq)
-        REMAINING=$(jq --arg self_name "$SELF_NAME" \
-          '[.check_runs[] | select(.status != "completed" and .name != $self_name)] | length' \
+        RELEASE_RUNS_RESPONSE=$(gh api --paginate --slurp \
+          "repos/${REPO}/actions/runs?head_sha=${COMMIT_SHA}&per_page=100")
+        RELEASE_CHECK_RUNS=$(jq -c \
+          --arg release_sha "$COMMIT_SHA" \
+          --arg self_name "$SELF_NAME" \
+          --slurpfile release_run_documents <(printf '%s\n' "$RELEASE_RUNS_RESPONSE") \
+          -f .github/scripts/release-owned-check-runs.jq \
           <<<"$CHECK_RUNS_RESPONSE")
+        REMAINING=$(jq '[.check_runs[] | select(.status != "completed")] | length' \
+          <<<"$RELEASE_CHECK_RUNS")
         if [[ "$REMAINING" != "0" ]]; then
-          echo "::error::$REMAINING check runs remained non-terminal after timeout"
+          echo "::error::$REMAINING release-owned check runs remained non-terminal after timeout"
+          jq -r '.check_runs[] | select(.status != "completed") | "  - \(.name): \(.status)"' \
+            <<<"$RELEASE_CHECK_RUNS" || true
           exit 1
         fi
     
@@ -101,7 +118,15 @@ jobs:
         CHECK_RUNS_RESPONSE=$(gh api --paginate --slurp \
           "repos/${REPO}/commits/${COMMIT_SHA}/check-runs?per_page=100" \
           | jq -c -f .github/scripts/flatten-check-run-pages.jq)
-        EFFECTIVE_CHECK_RUNS=$(echo "$CHECK_RUNS_RESPONSE" \
+        RELEASE_RUNS_RESPONSE=$(gh api --paginate --slurp \
+          "repos/${REPO}/actions/runs?head_sha=${COMMIT_SHA}&per_page=100")
+        RELEASE_CHECK_RUNS=$(jq -c \
+          --arg release_sha "$COMMIT_SHA" \
+          --arg self_name "$SELF_NAME" \
+          --slurpfile release_run_documents <(printf '%s\n' "$RELEASE_RUNS_RESPONSE") \
+          -f .github/scripts/release-owned-check-runs.jq \
+          <<<"$CHECK_RUNS_RESPONSE")
+        EFFECTIVE_CHECK_RUNS=$(echo "$RELEASE_CHECK_RUNS" \
           | jq -c --arg self_name "$SELF_NAME" -f .github/scripts/effective-check-runs.jq)
 
         # A later push to the default branch can cancel checks on the release


### PR DESCRIPTION
## Summary

Scope postflight polling and final CI evaluation to exact-SHA push, release, and workflow-dispatch check suites so issue and issue-comment automation cannot delay releases; add focused jq fixtures for pending, failed, and successful release checks.

## Files Changed

.agents/scripts/tests/fixtures/postflight-release-owned-check-runs.json, .agents/scripts/tests/fixtures/postflight-release-workflow-runs.json, .agents/scripts/tests/test-postflight-release-owned-checks.sh, .github/scripts/release-owned-check-runs.jq, .github/workflows/postflight.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-postflight-release-owned-checks.sh; bash .agents/scripts/tests/test-postflight-check-run-dedup.sh; shellcheck .agents/scripts/tests/test-postflight-release-owned-checks.sh; git diff --check

Resolves #27557


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.101 plugin for [OpenCode](https://opencode.ai) v1.17.19 with gpt-5.6-sol spent 4m and 64,753 tokens on this as a headless worker.