### PR TITLE
t18119: allow OpenCode access to generated global commands

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -26,6 +26,8 @@ const MANAGED_EXTERNAL_DIRECTORIES = [
   "~/.aidevops/**",
   "~/.config/aidevops",
   "~/.config/aidevops/**",
+  "~/.config/opencode/command",
+  "~/.config/opencode/command/**",
   "~/Git/_worktrees",
   "~/Git/_worktrees/**",
 ];

--- a/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
@@ -11,6 +11,8 @@ const managedRules = {
   "~/.aidevops/**": "allow",
   "~/.config/aidevops": "allow",
   "~/.config/aidevops/**": "allow",
+  "~/.config/opencode/command": "allow",
+  "~/.config/opencode/command/**": "allow",
   "~/Git/_worktrees": "allow",
   "~/Git/_worktrees/**": "allow",
 };
@@ -25,7 +27,7 @@ test("adds narrow managed-directory exceptions after a broad ask rule", () => {
     },
   };
 
-  assert.equal(registerManagedDirectoryPermissions(config), 6);
+  assert.equal(registerManagedDirectoryPermissions(config), 8);
   assert.deepEqual(config.permission.external_directory, {
     "*": "ask",
     "~/Documents/**": "deny",
@@ -36,7 +38,7 @@ test("adds narrow managed-directory exceptions after a broad ask rule", () => {
 test("converts a top-level default without allowing unrelated directories", () => {
   const config = { permission: "ask" };
 
-  assert.equal(registerManagedDirectoryPermissions(config), 6);
+  assert.equal(registerManagedDirectoryPermissions(config), 8);
   assert.equal(config.permission["*"], "ask");
   assert.deepEqual(config.permission.external_directory, {
     "*": "ask",
@@ -54,9 +56,9 @@ test("leaves an existing global external-directory allow unchanged", () => {
 test("is idempotent and keeps managed rules last", () => {
   const config = { permission: { external_directory: { "*": "ask" } } };
 
-  assert.equal(registerManagedDirectoryPermissions(config), 6);
+  assert.equal(registerManagedDirectoryPermissions(config), 8);
   assert.equal(registerManagedDirectoryPermissions(config), 0);
-  assert.deepEqual(Object.keys(config.permission.external_directory).slice(-6), Object.keys(managedRules));
+  assert.deepEqual(Object.keys(config.permission.external_directory).slice(-8), Object.keys(managedRules));
 });
 
 test("adds managed rules to per-agent permissions that override top-level defaults", () => {
@@ -68,7 +70,7 @@ test("adds managed rules to per-agent permissions that override top-level defaul
     },
   };
 
-  assert.equal(registerManagedDirectoryPermissions(config), 18);
+  assert.equal(registerManagedDirectoryPermissions(config), 24);
   assert.deepEqual(config.agent["Build+"].permission.external_directory, {
     "*": "ask",
     ...managedRules,

--- a/.agents/scripts/agent-discovery.py
+++ b/.agents/scripts/agent-discovery.py
@@ -107,6 +107,8 @@ def _persist_managed_external_directories(config):
         '~/.aidevops/**',
         '~/.config/aidevops',
         '~/.config/aidevops/**',
+        '~/.config/opencode/command',
+        '~/.config/opencode/command/**',
         '~/Git/_worktrees',
         '~/Git/_worktrees/**',
     )

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -260,6 +260,8 @@ _write_permissive_stub() {
 			'    "~/.aidevops/**": allow' \
 			'    "~/.config/aidevops": allow' \
 			'    "~/.config/aidevops/**": allow' \
+			'    "~/.config/opencode/command": allow' \
+			'    "~/.config/opencode/command/**": allow' \
 			'    "~/Git/_worktrees": allow' \
 			'    "~/Git/_worktrees/**": allow' \
 			"tools:" \

--- a/.agents/scripts/generate-runtime-config-agents.sh
+++ b/.agents/scripts/generate-runtime-config-agents.sh
@@ -372,6 +372,8 @@ _write_subagent_stub() {
 			'    "~/.aidevops/**": allow' \
 			'    "~/.config/aidevops": allow' \
 			'    "~/.config/aidevops/**": allow' \
+			'    "~/.config/opencode/command": allow' \
+			'    "~/.config/opencode/command/**": allow' \
 			'    "~/Git/_worktrees": allow' \
 			'    "~/Git/_worktrees/**": allow' \
 			"tools:" \

--- a/.agents/scripts/lib/agent_config.py
+++ b/.agents/scripts/lib/agent_config.py
@@ -183,6 +183,8 @@ def get_agent_config(display_name, filename, subagents=None, model_tier=None):
             "~/.aidevops/**": "allow",
             "~/.config/aidevops": "allow",
             "~/.config/aidevops/**": "allow",
+            "~/.config/opencode/command": "allow",
+            "~/.config/opencode/command/**": "allow",
             "~/Git/_worktrees": "allow",
             "~/Git/_worktrees/**": "allow",
         }

--- a/.agents/scripts/tests/test-agent-discovery-smoke.sh
+++ b/.agents/scripts/tests/test-agent-discovery-smoke.sh
@@ -143,6 +143,8 @@ expected = (
     "~/.aidevops/**",
     "~/.config/aidevops",
     "~/.config/aidevops/**",
+    "~/.config/opencode/command",
+    "~/.config/opencode/command/**",
     "~/Git/_worktrees",
     "~/Git/_worktrees/**",
 )

--- a/TODO.md
+++ b/TODO.md
@@ -1147,6 +1147,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [>] t18117 Add token-efficient output receipts and delta-aware waits #feat #framework #interactive ref:GH#27529 started:2026-07-13
 
+- [ ] t18119 Allow OpenCode access to generated global commands #bug ref:GH#27564
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Allow the exact aidevops-managed OpenCode command directory and descendants across runtime, persisted, primary-agent, and subagent permission layers while preserving unrelated user policy.

## Files Changed

.agents/plugins/opencode-aidevops/config-hook.mjs, .agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs, .agents/scripts/agent-discovery.py, .agents/scripts/generate-opencode-agents.sh, .agents/scripts/generate-runtime-config-agents.sh, .agents/scripts/lib/agent_config.py, .agents/scripts/tests/test-agent-discovery-smoke.sh, TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Plugin suite: 363 passed; agent-discovery smoke: 6 passed; ShellCheck and Python compile clean; changed-file local linters passed. Full-repo mode also ran and reported only pre-existing failures in untouched CHANGELOG.md and historical complexity/nesting baselines.

Resolves #27564


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.98 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 10m and 121,422 tokens on this with the user in an interactive session.