### PR TITLE
GH#27561: keep opening issue reviews in parent sessions

### DIFF
--- a/.agents/scripts/generate-opencode-commands-quality.sh
+++ b/.agents/scripts/generate-opencode-commands-quality.sh
@@ -45,7 +45,7 @@ BODY
 
 	create_command "review-issue-pr" \
 		"Review external issue or PR - validate problem and evaluate solution" \
-		"$AGENT_BUILD" "true" <<'BODY'
+		"$AGENT_BUILD" "" <<'BODY'
 Read ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/workflows/review-issue-pr.md and follow its instructions.
 
 Review this issue or PR: $ARGUMENTS

--- a/.agents/scripts/generate-runtime-config-commands.sh
+++ b/.agents/scripts/generate-runtime-config-commands.sh
@@ -442,28 +442,28 @@ _generate_commands_for_runtime() {
 	return 0
 }
 
-# Write a hardcoded command if not already present from auto-discovery.
-# Writes using the appropriate format for the given runtime.
+# Write a canonical hardcoded command using the appropriate runtime format.
+# These names are owned by the generator, so replace stale legacy output on
+# every uncached generation rather than preserving obsolete routing metadata.
 # Arguments:
 #   $1 - runtime_id
 #   $2 - cmd_dir
 #   $3 - command name
 #   $4 - description
 #   $5 - body content
-# Returns: 0 if written, 1 if skipped (already exists)
+#   $6 - OpenCode subtask flag (optional, defaults to true)
+# Returns: 0 when written
 _maybe_write_hardcoded_command() {
 	local runtime_id="$1"
 	local cmd_dir="$2"
 	local name="$3"
 	local description="$4"
 	local body="$5"
-
-	# Skip if already exists from auto-discovery
-	[[ -f "${cmd_dir}/${name}.md" ]] && return 1
+	local subtask="${6:-true}"
 
 	case "$runtime_id" in
 	opencode)
-		_write_opencode_command "$cmd_dir" "$name" "$description" "Build+" "true" "$body"
+		_write_opencode_command "$cmd_dir" "$name" "$description" "Build+" "$subtask" "$body"
 		;;
 	*)
 		_write_claude_command "$cmd_dir" "$name" "$description" "$body"
@@ -472,7 +472,7 @@ _maybe_write_hardcoded_command() {
 	return 0
 }
 
-# Generate quality/review hardcoded commands (agent-review, preflight, postflight).
+# Generate quality/review hardcoded commands.
 # Arguments: $1 - runtime_id, $2 - cmd_dir
 # Returns: count of generated commands via exit code
 _generate_hardcoded_quality_commands() {
@@ -496,6 +496,29 @@ If no specific file is provided, review the agents used in this session and prop
 5. Duplicate detection across agents
 
 Follow the improvement proposal format from the agent-review instructions.'; then
+		count=$((count + 1))
+	fi
+
+	# --- Issue / PR Review ---
+	# Opening-message reviews must remain in the primary conversation so the
+	# evidence trail and maintainer decisions stay visible in the parent session.
+	# shellcheck disable=SC2016
+	if _maybe_write_hardcoded_command "$runtime_id" "$cmd_dir" "review-issue-pr" \
+		"Review external issue or PR - validate problem and evaluate solution" \
+		'Read ~/.aidevops/agents/workflows/review-issue-pr.md and follow its instructions.
+
+Review this issue or PR: $ARGUMENTS
+
+**Usage:**
+- `/review-issue-pr 123` - Review issue or PR by number
+- `/review-issue-pr https://github.com/owner/repo/issues/123` - Review by URL
+- `/review-issue-pr https://github.com/owner/repo/pull/456` - Review PR by URL
+
+**Core questions to answer:**
+1. Is the issue real? (reproducible, not duplicate, actually a bug)
+2. Is this the best solution? (simplest approach, fixes root cause)
+3. Is the scope appropriate? (minimal changes, no scope creep)' \
+		"false"; then
 		count=$((count + 1))
 	fi
 

--- a/.agents/scripts/tests/test-review-issue-pr-command-routing.sh
+++ b/.agents/scripts/tests/test-review-issue-pr-command-routing.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for parent-session /review-issue-pr routing.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+COMMAND_LIB="${SCRIPT_DIR}/../generate-runtime-config-commands.sh"
+LEGACY_LIB="${SCRIPT_DIR}/../generate-opencode-commands-quality.sh"
+TMP_DIR=$(mktemp -d -t aidevops-review-command.XXXXXX) || exit 1
+COMMAND_DIR="${TMP_DIR}/commands"
+CALL_LOG="${TMP_DIR}/legacy-calls"
+
+cleanup() {
+	local tmp_dir="$TMP_DIR"
+	local tmp_base="${tmp_dir##*/}"
+	[[ "$tmp_base" == aidevops-review-command.* ]] || return 1
+	rm -rf "$tmp_dir"
+	return 0
+}
+trap cleanup EXIT
+
+mkdir -p "$COMMAND_DIR" || exit 1
+
+# shellcheck source=../generate-runtime-config-commands.sh
+source "$COMMAND_LIB"
+
+# A previous generator left this command permanently routed to a child session.
+printf '%s\n' '---' 'agent: Build+' 'subtask: true' '---' 'stale body' >"${COMMAND_DIR}/review-issue-pr.md"
+
+set +e
+_generate_hardcoded_quality_commands "opencode" "$COMMAND_DIR"
+quality_count=$?
+set -e
+
+[[ "$quality_count" -eq 4 ]] || {
+	printf 'FAIL expected four generated quality commands, got %s\n' "$quality_count" >&2
+	exit 1
+}
+grep -Fq 'agent: Build+' "${COMMAND_DIR}/review-issue-pr.md" || {
+	printf 'FAIL review command does not target Build+\n' >&2
+	exit 1
+}
+if grep -Fq 'subtask: true' "${COMMAND_DIR}/review-issue-pr.md"; then
+	printf 'FAIL review command still forces a child session\n' >&2
+	exit 1
+fi
+grep -Fq 'workflows/review-issue-pr.md' "${COMMAND_DIR}/review-issue-pr.md" || {
+	printf 'FAIL stale review command body was not refreshed\n' >&2
+	exit 1
+}
+grep -Fq 'subtask: true' "${COMMAND_DIR}/agent-review.md" || {
+	printf 'FAIL unrelated subtask routing was removed\n' >&2
+	exit 1
+}
+
+# The one-release fallback generator must preserve the same routing contract.
+create_command() {
+	local name="$1"
+	local description="$2"
+	local agent="$3"
+	local subtask="$4"
+	local body
+	body=$(cat)
+	printf '%s|%s|%s|%s|%s\n' "$name" "$description" "$agent" "$subtask" "$body" >>"$CALL_LOG"
+	return 0
+}
+AGENT_BUILD="Build+"
+# shellcheck source=../generate-opencode-commands-quality.sh
+source "$LEGACY_LIB"
+define_review_commands
+
+grep -Fq 'review-issue-pr|Review external issue or PR - validate problem and evaluate solution|Build+||' "$CALL_LOG" || {
+	printf 'FAIL fallback generator still marks review-issue-pr as a subtask\n' >&2
+	exit 1
+}
+grep -Fq 'agent-review|Systematic review and improvement of agent instructions|Build+|true|' "$CALL_LOG" || {
+	printf 'FAIL fallback generator changed unrelated subtask routing\n' >&2
+	exit 1
+}
+
+printf 'PASS review-issue-pr command routing stays in the parent session\n'
+exit 0


### PR DESCRIPTION
## Summary

Generate /review-issue-pr as a parent-session OpenCode command, refresh stale hardcoded command output deterministically, and keep the fallback generator aligned.

## Files Changed

.agents/scripts/generate-opencode-commands-quality.sh, .agents/scripts/generate-runtime-config-commands.sh, .agents/scripts/tests/test-review-issue-pr-command-routing.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused routing regression test, ShellCheck, bash syntax, git diff checks, and changed-file linters pass. Full repository lint also ran; only pre-existing broad Markdown/complexity debt and a pulse-canary timeout were reported.

Resolves #27561


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.98 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 23m and 146,525 tokens on this with the user in an interactive session.