### PR TITLE
GH#27542: allow read-only canonical symbolic-ref queries

### DIFF
--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -210,18 +210,10 @@ def _tag_is_read_only(args: list[str]) -> bool:
 
 def _symbolic_ref_is_read_only(args: list[str]) -> bool:
     read_flags = {"-q", "--quiet", "--short", "--recurse", "--no-recurse"}
-    refs: list[str] = []
-    parse_options = True
-    for arg in args:
-        if parse_options and arg == "--":
-            parse_options = False
-        elif parse_options and arg in read_flags:
-            continue
-        elif parse_options and arg.startswith("-"):
-            return False
-        else:
-            refs.append(arg)
-    return len(refs) == 1
+    return (
+        sum(arg not in read_flags for arg in args) == 1
+        and all(arg in read_flags or not arg.startswith("-") for arg in args)
+    )
 
 
 CANONICAL_CHECKS: dict[str, Callable[[list[str]], bool]] = {

--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -208,11 +208,28 @@ def _tag_is_read_only(args: list[str]) -> bool:
     )
 
 
+def _symbolic_ref_is_read_only(args: list[str]) -> bool:
+    read_flags = {"-q", "--quiet", "--short", "--recurse", "--no-recurse"}
+    refs: list[str] = []
+    parse_options = True
+    for arg in args:
+        if parse_options and arg == "--":
+            parse_options = False
+        elif parse_options and arg in read_flags:
+            continue
+        elif parse_options and arg.startswith("-"):
+            return False
+        else:
+            refs.append(arg)
+    return len(refs) == 1
+
+
 CANONICAL_CHECKS: dict[str, Callable[[list[str]], bool]] = {
     "branch": _branch_is_read_only,
     "config": _config_is_read_only,
     "clean": _clean_is_read_only,
     "remote": _remote_is_read_only,
+    "symbolic-ref": _symbolic_ref_is_read_only,
     "worktree": _worktree_is_allowed,
     "tag": _tag_is_read_only,
 }

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -100,6 +100,7 @@ assert_blocked "blocks canonical symbolic-ref short deletion" "git symbolic-ref 
 assert_blocked "blocks canonical symbolic-ref combined deletion flags" "git symbolic-ref -qd refs/remotes/origin/HEAD"
 assert_blocked "blocks canonical symbolic-ref unknown options" "git symbolic-ref --bogus refs/remotes/origin/HEAD"
 assert_blocked "blocks canonical symbolic-ref without a ref" "git symbolic-ref --short"
+assert_blocked "blocks canonical symbolic-ref option terminator" "git symbolic-ref -- refs/remotes/origin/HEAD"
 assert_blocked "blocks canonical symbolic-ref second ref after option terminator" "git symbolic-ref -- HEAD refs/heads/safety/example"
 
 if [[ "$(git -C "$REPO" symbolic-ref --short HEAD)" == "main" ]] &&
@@ -118,7 +119,6 @@ assert_allowed "allows canonical symbolic-ref query" "$REPO" "git symbolic-ref r
 assert_allowed "allows canonical short symbolic-ref query" "$REPO" "git symbolic-ref --short refs/remotes/origin/HEAD"
 assert_allowed "allows reordered canonical symbolic-ref query flags" "$REPO" "git symbolic-ref refs/remotes/origin/HEAD --quiet --short"
 assert_allowed "allows canonical non-recursive symbolic-ref query" "$REPO" "git symbolic-ref --no-recurse refs/remotes/origin/HEAD"
-assert_allowed "allows canonical symbolic-ref query with option terminator" "$REPO" "git symbolic-ref -- refs/remotes/origin/HEAD"
 assert_allowed "allows canonical worktree creation" "$REPO" "git worktree add '$LINKED' -b feature/example"
 git -C "$REPO" worktree add -q -b feature/example "$LINKED"
 assert_allowed "allows normal Git mutation in linked worktree" "$LINKED" "git switch -c feature/linked-child"

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -93,6 +93,14 @@ assert_blocked "blocks chained canonical mutation" "git status && git branch -M 
 assert_blocked "blocks canonical update-ref plumbing" "/usr/bin/git update-ref refs/heads/main HEAD"
 assert_blocked "blocks destructive clean with exclude containing n" "git clean --force --exclude=nope"
 assert_blocked "blocks interactive clean" "git clean --interactive"
+assert_blocked "blocks canonical symbolic-ref update" "git symbolic-ref HEAD refs/heads/safety/example"
+assert_blocked "blocks canonical symbolic-ref update with reflog reason" "git symbolic-ref -m reason HEAD refs/heads/safety/example"
+assert_blocked "blocks canonical symbolic-ref deletion" "git symbolic-ref --delete refs/remotes/origin/HEAD"
+assert_blocked "blocks canonical symbolic-ref short deletion" "git symbolic-ref -d refs/remotes/origin/HEAD"
+assert_blocked "blocks canonical symbolic-ref combined deletion flags" "git symbolic-ref -qd refs/remotes/origin/HEAD"
+assert_blocked "blocks canonical symbolic-ref unknown options" "git symbolic-ref --bogus refs/remotes/origin/HEAD"
+assert_blocked "blocks canonical symbolic-ref without a ref" "git symbolic-ref --short"
+assert_blocked "blocks canonical symbolic-ref second ref after option terminator" "git symbolic-ref -- HEAD refs/heads/safety/example"
 
 if [[ "$(git -C "$REPO" symbolic-ref --short HEAD)" == "main" ]] &&
 	[[ "$(git -C "$REPO" rev-parse HEAD)" == "$INITIAL_HEAD" ]] &&
@@ -106,9 +114,37 @@ assert_allowed "allows canonical status" "$REPO" "git status --short"
 assert_allowed "allows canonical branch listing" "$REPO" "git branch -vv --no-abbrev"
 assert_allowed "allows canonical branch pattern listing" "$REPO" "git branch --list 'feature/*'"
 assert_allowed "allows canonical branch containment query" "$REPO" "git branch --contains main"
+assert_allowed "allows canonical symbolic-ref query" "$REPO" "git symbolic-ref refs/remotes/origin/HEAD"
+assert_allowed "allows canonical short symbolic-ref query" "$REPO" "git symbolic-ref --short refs/remotes/origin/HEAD"
+assert_allowed "allows reordered canonical symbolic-ref query flags" "$REPO" "git symbolic-ref refs/remotes/origin/HEAD --quiet --short"
+assert_allowed "allows canonical non-recursive symbolic-ref query" "$REPO" "git symbolic-ref --no-recurse refs/remotes/origin/HEAD"
+assert_allowed "allows canonical symbolic-ref query with option terminator" "$REPO" "git symbolic-ref -- refs/remotes/origin/HEAD"
 assert_allowed "allows canonical worktree creation" "$REPO" "git worktree add '$LINKED' -b feature/example"
 git -C "$REPO" worktree add -q -b feature/example "$LINKED"
 assert_allowed "allows normal Git mutation in linked worktree" "$LINKED" "git switch -c feature/linked-child"
+
+git -C "$REPO" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+DEFAULT_BRANCH=$(
+	unset -f git
+	export PATH="${SCRIPT_DIR}:/usr/bin:/bin"
+	# shellcheck source=/dev/null
+	source "${SCRIPT_DIR}/pulse-canonical-maintenance.sh"
+	_get_default_branch_for_repo "$REPO"
+)
+if [[ "$DEFAULT_BRANCH" == "develop" ]]; then
+	pass "deployed shim lets pulse resolve a non-main default branch"
+else
+	fail "deployed shim lets pulse resolve a non-main default branch (output=$DEFAULT_BRANCH)"
+fi
+
+if (cd "$REPO" && PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/unsafe >/dev/null 2>&1) ||
+	(cd "$REPO" && PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" symbolic-ref --delete refs/remotes/origin/HEAD >/dev/null 2>&1); then
+	fail "PATH shim blocks symbolic-ref mutation before execution"
+elif [[ "$(git -C "$REPO" symbolic-ref --short refs/remotes/origin/HEAD)" == "origin/develop" ]]; then
+	pass "PATH shim blocks symbolic-ref mutation before execution"
+else
+	fail "PATH shim left canonical symbolic ref changed"
+fi
 
 if (cd "$REPO" && PATH="${SCRIPT_DIR}:$PATH" "$SHIM" switch --detach main >/dev/null 2>&1); then
 	fail "PATH shim blocks canonical detached switch"


### PR DESCRIPTION
## Summary

Add an argument-aware symbolic-ref policy that permits exactly one-ref read queries while rejecting mutation, deletion, unknown-option, and ambiguous forms; extend guard tests through the deployed shim and pulse resolver.

## Files Changed

.agents/scripts/canonical_git_policy.py, .agents/scripts/tests/test-canonical-git-command-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Runtime-verified: canonical guard suite 49/49; git safety suite 13/13; pulse canonical maintenance suite 12/12; scoped linters passed; py_compile and ShellCheck passed.

Resolves #27542


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.98 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 29m and 130,794 tokens on this with the user in an interactive session.