### PR TITLE
GH#27570: prevent workload tiers becoming OpenCode model IDs

### DIFF
--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -140,6 +140,20 @@ define_automation_commands
 # Each file should have frontmatter with description and agent
 # This prevents needing to manually add new commands to this script
 
+copy_discovered_command() {
+	local src="$1"
+	local dest="$2"
+
+	# OpenCode treats model values as concrete IDs, not workload tiers.
+	awk '
+		NR == 1 && /^---$/ { in_fm = 1; print; next }
+		in_fm && /^---$/ { in_fm = 0; print; next }
+		in_fm && /^model: (simple|standard|thinking)$/ { next }
+		{ print }
+	' "$src" >"$dest" || return 1
+	return 0
+}
+
 discover_commands() {
 	local commands_dir="${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/commands"
 
@@ -157,8 +171,8 @@ discover_commands() {
 		# Skip if already manually defined (avoid duplicates)
 		[[ -f "$OPENCODE_COMMAND_DIR/$cmd_name.md" ]] && continue
 
-		# Copy command file directly (it already has proper frontmatter)
-		if cp "$cmd_file" "$OPENCODE_COMMAND_DIR/$cmd_name.md"; then
+		# Preserve OpenCode frontmatter while removing provider-neutral tiers.
+		if copy_discovered_command "$cmd_file" "$OPENCODE_COMMAND_DIR/$cmd_name.md"; then
 			((++command_count))
 			echo -e "  ${GREEN}✓${NC} Auto-discovered /$cmd_name command"
 		elif [[ ! -f "$cmd_file" ]]; then

--- a/.agents/scripts/generate-runtime-config-commands.sh
+++ b/.agents/scripts/generate-runtime-config-commands.sh
@@ -90,6 +90,22 @@ _copy_cmd_strip_opencode_fields() {
 	sed -E '/^---$/,/^---$/{/^(agent|subtask|mode):/d;}' "$src" >"$dest"
 }
 
+# OpenCode requires model fields to contain concrete provider/model IDs. Source
+# commands may instead carry canonical workload tiers for other orchestrators;
+# strip only those tier values and inherit the active session model.
+_copy_cmd_for_opencode() {
+	local src="$1"
+	local dest="$2"
+
+	awk '
+		NR == 1 && /^---$/ { in_fm = 1; print; next }
+		in_fm && /^---$/ { in_fm = 0; print; next }
+		in_fm && /^model: (simple|standard|thinking)$/ { next }
+		{ print }
+	' "$src" >"$dest" || return 1
+	return 0
+}
+
 # Helper: Cursor command files -- Cursor Commands (1.6+) do not support
 # YAML frontmatter at all. Strip the entire leading frontmatter block
 # and emit only the markdown body.
@@ -287,9 +303,9 @@ _deploy_one_command() {
 
 	case "$runtime_id" in
 	opencode)
-		# OpenCode is the source format -- copy as-is.
+		# Canonical workload tiers are routing intent, not OpenCode model IDs.
 		dest="${cmd_dir}/${name}.md"
-		cp "$src" "$dest" || return 1
+		_copy_cmd_for_opencode "$src" "$dest" || return 1
 		;;
 	claude-code | codex | droid | amp | qwen)
 		# Markdown + YAML frontmatter clients: strip opencode-only fields

--- a/.agents/scripts/tests/test-opencode-command-model-tiers.sh
+++ b/.agents/scripts/tests/test-opencode-command-model-tiers.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+COMMAND_DIR="$TEST_ROOT/commands"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+mkdir -p "$COMMAND_DIR"
+
+# shellcheck source=../generate-runtime-config-commands.sh
+source "$REPO_ROOT/.agents/scripts/generate-runtime-config-commands.sh"
+
+cat >"$TEST_ROOT/tier.md" <<'EOF_TIER'
+---
+description: Tier-routed command
+model: standard
+mode: subagent
+---
+
+Keep this body example: model: standard
+EOF_TIER
+
+cat >"$TEST_ROOT/concrete.md" <<'EOF_CONCRETE'
+---
+description: Concrete-model command
+model: openai/gpt-5.6-sol
+mode: subagent
+---
+
+Concrete command body
+EOF_CONCRETE
+
+_deploy_one_command opencode "$TEST_ROOT/tier.md" tier "$COMMAND_DIR"
+_deploy_one_command opencode "$TEST_ROOT/concrete.md" concrete "$COMMAND_DIR"
+
+if grep -q '^model: standard$' "$COMMAND_DIR/tier.md"; then
+	printf '%s\n' 'FAIL: workload tier leaked into OpenCode command model field' >&2
+	exit 1
+fi
+grep -Fq 'Keep this body example: model: standard' "$COMMAND_DIR/tier.md"
+grep -Fq 'model: openai/gpt-5.6-sol' "$COMMAND_DIR/concrete.md"
+grep -Fq 'mode: subagent' "$COMMAND_DIR/concrete.md"
+
+mkdir -p "$TEST_ROOT/agents/scripts/commands" "$TEST_ROOT/home"
+cp "$TEST_ROOT/tier.md" "$TEST_ROOT/agents/scripts/commands/tier.md"
+HOME="$TEST_ROOT/home" AIDEVOPS_DIR="$TEST_ROOT" \
+	bash "$REPO_ROOT/.agents/scripts/generate-opencode-commands.sh" >/dev/null
+legacy_command="$TEST_ROOT/home/.config/opencode/command/tier.md"
+if grep -q '^model: standard$' "$legacy_command"; then
+	printf '%s\n' 'FAIL: workload tier leaked through legacy OpenCode command generator' >&2
+	exit 1
+fi
+grep -Fq 'Keep this body example: model: standard' "$legacy_command"
+
+printf '%s\n' 'PASS: OpenCode commands inherit tier-routed models and preserve concrete IDs'
+exit 0


### PR DESCRIPTION
## Summary

Strip canonical simple/standard/thinking workload tiers from deployed OpenCode command model fields in both current and fallback generators while preserving explicit provider/model IDs and body text.

## Files Changed

.agents/scripts/generate-opencode-commands.sh, .agents/scripts/generate-runtime-config-commands.sh, .agents/scripts/tests/test-opencode-command-model-tiers.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused current/fallback generator regression test passed; OpenCode subagent tier guard passed; ShellCheck passed; changed-file repository linters passed. Full repository mode exposed only pre-existing broad CHANGELOG/complexity/nesting debt outside this three-file diff.

Resolves #27570


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.106 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 11m and 240,255 tokens on this with the user in an interactive session.