### PR TITLE
GH#27572: regenerate runtime config after incremental deploy

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -233,8 +233,55 @@ detect_changes() {
 	return 0
 }
 
+# Rebuild derived runtime files after synchronizing their source tree. The
+# generator's per-runtime source hash keeps unrelated deployments fast while
+# ensuring command, agent, prompt, and MCP outputs cannot remain stale.
+regenerate_runtime_config() {
+	local generator="$TARGET_DIR/scripts/generate-runtime-config.sh"
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "[dry-run] Would regenerate derived runtime configuration"
+		return 0
+	fi
+	if [[ ! -f "$generator" ]]; then
+		log_error "Runtime config generator not found after deployment: $generator"
+		return 1
+	fi
+
+	log_info "Regenerating derived runtime configuration..."
+	if ! bash "$generator" all; then
+		log_error "Derived runtime configuration regeneration failed"
+		return 1
+	fi
+	log_success "Derived runtime configuration regenerated"
+	return 0
+}
+
+runtime_config_changes_detected() {
+	local changed_files="${1:-}"
+	local file
+
+	# Explicit --scripts-only deployments do not provide a diff; regenerate to
+	# preserve correctness. Diff-based deployment can retain the fast path.
+	[[ -z "$changed_files" ]] && return 0
+	while IFS= read -r file; do
+		case "$file" in
+		.agents/scripts/commands/* | \
+			.agents/scripts/generate-runtime-config*.sh | \
+			.agents/scripts/generate-opencode-*.sh | \
+			.agents/scripts/generate-claude-*.sh | \
+			.agents/scripts/runtime-registry.sh | \
+			.agents/scripts/mcp-config-adapter.sh | \
+			.agents/scripts/prompt-injection-adapter.sh | \
+			.agents/scripts/lib/agent_config.py) return 0 ;;
+		esac
+	done <<<"$changed_files"
+	return 1
+}
+
 # Deploy scripts only (fastest path)
 deploy_scripts_only() {
+	local changed_files="${1:-}"
 	local source_dir="$REPO_DIR/.agents/scripts"
 	local target_scripts_dir="$TARGET_DIR/scripts"
 
@@ -274,6 +321,9 @@ deploy_scripts_only() {
 	count=$(find "$target_scripts_dir" -name "*.sh" -type f | wc -l | tr -d ' ')
 	log_success "Deployed $count scripts"
 
+	if runtime_config_changes_detected "$changed_files"; then
+		regenerate_runtime_config || return 1
+	fi
 	return 0
 }
 
@@ -402,6 +452,7 @@ deploy_all_agents() {
 	script_count=$(find "$TARGET_DIR/scripts" -name "*.sh" -type f 2>/dev/null | wc -l | tr -d ' ')
 	log_success "Deployed $agent_count agent files and $script_count scripts"
 
+	regenerate_runtime_config || return 1
 	return 0
 }
 
@@ -500,6 +551,7 @@ deploy_changed_files() {
 	fi
 
 	log_success "Deployed $deployed changed files"
+	regenerate_runtime_config || return 1
 	return 0
 }
 
@@ -563,7 +615,7 @@ main() {
 		fi
 		if [[ "$non_script_changes" -eq 0 ]]; then
 			log_info "Only scripts changed — using fast scripts-only deploy"
-			deploy_scripts_only
+			deploy_scripts_only "$changed"
 			return $?
 		fi
 
@@ -585,4 +637,6 @@ main() {
 	return $?
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-incremental-deploy-runtime-config.sh
+++ b/.agents/scripts/tests/test-incremental-deploy-runtime-config.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+FIXTURE_REPO="$TEST_ROOT/repo"
+TEST_HOME="$TEST_ROOT/home"
+MARKER="$TEST_ROOT/runtime-config-generated"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+mkdir -p "$FIXTURE_REPO/.agents/scripts" "$TEST_HOME/.aidevops/agents"
+git -C "$FIXTURE_REPO" init -q
+printf '%s\n' 'ref: refs/heads/fixture' >"$FIXTURE_REPO/.git/HEAD"
+printf '%s\n' '3.32.107' >"$FIXTURE_REPO/VERSION"
+cat >"$FIXTURE_REPO/.agents/scripts/generate-runtime-config.sh" <<EOF_GENERATOR
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >"$MARKER"
+exit 0
+EOF_GENERATOR
+cat >"$FIXTURE_REPO/.agents/scripts/example-helper.sh" <<'EOF_HELPER'
+#!/usr/bin/env bash
+exit 0
+EOF_HELPER
+
+HOME="$TEST_HOME" bash "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh" \
+	--repo "$FIXTURE_REPO" --scripts-only --quiet
+grep -Fxq 'all' "$MARKER"
+
+if bash -c 'source "$1"; runtime_config_changes_detected ".agents/scripts/example-helper.sh"' \
+	_ "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh"; then
+	printf '%s\n' 'FAIL: unrelated script was classified as a runtime config source' >&2
+	exit 1
+fi
+if ! bash -c 'source "$1"; runtime_config_changes_detected ".agents/scripts/generate-runtime-config-commands.sh"' \
+	_ "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh"; then
+	printf '%s\n' 'FAIL: runtime config generator change was not classified for regeneration' >&2
+	exit 1
+fi
+
+cat >"$FIXTURE_REPO/.agents/scripts/generate-runtime-config.sh" <<'EOF_FAILURE'
+#!/usr/bin/env bash
+exit 9
+EOF_FAILURE
+if HOME="$TEST_HOME" bash "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh" \
+	--repo "$FIXTURE_REPO" --scripts-only --quiet; then
+	printf '%s\n' 'FAIL: incremental deploy ignored runtime config regeneration failure' >&2
+	exit 1
+fi
+
+printf '%s\n' 'PASS: incremental deployment regenerates derived runtime config and propagates failures'
+exit 0


### PR DESCRIPTION
## Summary

Make incremental agent deployment rebuild derived runtime configuration after relevant script changes, full agent syncs, and targeted non-script syncs; retain the fast path for unrelated script-only diffs and fail deployment when regeneration fails.

## Files Changed

.agents/scripts/deploy-agents-on-merge.sh, .agents/scripts/tests/test-incremental-deploy-runtime-config.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused incremental deployment regression passed; agent auto-sync suite passed 7/7; ShellCheck passed; changed-file repository linters passed.

Resolves #27572


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.107 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 29m and 483,362 tokens on this with the user in an interactive session.