### PR TITLE
t18120: Fix exact current-session output-efficiency analysis

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -152,13 +152,16 @@ export function createShellEnvHook(deps) {
       output.env.AIDEVOPS_VERSION = version;
     }
 
-    // Signature helpers need the current OpenCode session, not a session guessed
-    // from the long-lived app process start time (GH#22003). OpenCode hook input
-    // has changed shape across releases, so accept the known variants and keep
-    // this best-effort: absence should not block shell startup.
+    // Shell helpers need the exact current OpenCode conversation, not an ID
+    // inherited from a previous plugin instance or long-lived app process
+    // (GH#22003, GH#27574). AIDEVOPS_SESSION_ID may intentionally name a
+    // framework session, so publish the OpenCode side of that mapping explicitly.
+    // OpenCode hook input has changed shape across releases, so accept the known
+    // variants and keep this best-effort: absence should not block shell startup.
     const sessionId = getSessionId(input);
-    if (sessionId && !output.env.OPENCODE_SESSION_ID) {
+    if (sessionId) {
       output.env.OPENCODE_SESSION_ID = sessionId;
+      output.env.AIDEVOPS_OPENCODE_SESSION_ID = sessionId;
     }
 
     const modelId = getModelId(input);

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -118,6 +118,37 @@ test("headless OpenCode shell stamps worker origin", async () => {
   assert.equal(output.env.AIDEVOPS_SESSION_ORIGIN, "worker");
 });
 
+test("shell env replaces stale OpenCode identity after a plugin update", async () => {
+  const hook = makeHook();
+  const output = {
+    env: {
+      PATH: "/usr/bin:/bin",
+      OPENCODE_SESSION_ID: "stale-opencode-session",
+      AIDEVOPS_OPENCODE_SESSION_ID: "stale-opencode-session",
+    },
+  };
+
+  await hook({ sessionID: "current-opencode-session" }, output);
+
+  assert.equal(output.env.OPENCODE_SESSION_ID, "current-opencode-session");
+  assert.equal(output.env.AIDEVOPS_OPENCODE_SESSION_ID, "current-opencode-session");
+});
+
+test("shell env preserves framework identity and publishes its OpenCode mapping", async () => {
+  const hook = makeHook();
+  const output = {
+    env: {
+      PATH: "/usr/bin:/bin",
+      AIDEVOPS_SESSION_ID: "framework-session",
+    },
+  };
+
+  await hook({ sessionID: "opencode-session" }, output);
+
+  assert.equal(output.env.AIDEVOPS_SESSION_ID, "framework-session");
+  assert.equal(output.env.AIDEVOPS_OPENCODE_SESSION_ID, "opencode-session");
+});
+
 test("headless shell preserves explicit worker lineage", async () => {
   const keys = [
     "AIDEVOPS_WORKER_ID",

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -650,7 +650,8 @@ copy_scoped_opencode_auth() {
 }
 
 run_without_opencode_session_env() {
-	env -u OPENCODE_SESSION_ID \
+	env -u AIDEVOPS_OPENCODE_SESSION_ID \
+		-u OPENCODE_SESSION_ID \
 		-u OPENCODE_PID \
 		-u OPENCODE_RUN_ID \
 		-u OPENCODE_PROCESS_ROLE \
@@ -670,7 +671,7 @@ build_sandbox_passthrough_csv() {
 		case "$name" in
 		# Session-bound OpenCode env makes isolated canary/worker runs attach to
 		# the parent TUI session and fail with "Session not found" (GH#23065).
-		OPENCODE_SESSION_ID | OPENCODE_PID | OPENCODE_RUN_ID | OPENCODE_PROCESS_ROLE | OPENCODE | OPENCODE_SERVER_PASSWORD) ;;
+		AIDEVOPS_OPENCODE_SESSION_ID | OPENCODE_SESSION_ID | OPENCODE_PID | OPENCODE_RUN_ID | OPENCODE_PROCESS_ROLE | OPENCODE | OPENCODE_SERVER_PASSWORD) ;;
 		OPENAI_* | ANTHROPIC_* | GOOGLE_* | CLAUDE_*)
 			if [[ -n "$provider" ]] && ! _headless_provider_env_allowed "$provider" "$name"; then
 				continue

--- a/.agents/scripts/session-output-efficiency-helper.sh
+++ b/.agents/scripts/session-output-efficiency-helper.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 readonly SCRIPT_DIR
+readonly RUNTIME_OPENCODE="opencode"
 
 usage() {
 	cat <<'EOF'
@@ -23,9 +24,19 @@ Options:
   --max-findings N                Limit aggregate findings (default: 5)
 
 Without --input or --db, the helper resolves the runtime history path through
-the Vault-managed session-history read gate. Raw tool inputs and outputs are
-never emitted.
+the Vault-managed session-history read gate. An active OpenCode conversation is
+read through an exact-ID export so its completed tool results are available
+before session close. Raw tool inputs and outputs are never emitted.
 EOF
+	return 0
+}
+
+active_opencode_session() {
+	if [[ -n "${AIDEVOPS_OPENCODE_SESSION_ID:-}" ]]; then
+		printf '%s\n' "$AIDEVOPS_OPENCODE_SESSION_ID"
+	else
+		printf '%s\n' "${OPENCODE_SESSION_ID:-}"
+	fi
 	return 0
 }
 
@@ -35,8 +46,8 @@ resolve_runtime() {
 		printf '%s\n' "$requested"
 		return 0
 	fi
-	if [[ -n "${OPENCODE_SESSION_ID:-}" ]]; then
-		printf '%s\n' "opencode"
+	if [[ -n "${AIDEVOPS_OPENCODE_SESSION_ID:-}${OPENCODE_SESSION_ID:-}" ]]; then
+		printf '%s\n' "$RUNTIME_OPENCODE"
 		return 0
 	fi
 	if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
@@ -51,11 +62,15 @@ resolve_session() {
 	local runtime="$1"
 	local requested="$2"
 	if [[ -n "$requested" ]]; then
+		if [[ "$runtime" == "$RUNTIME_OPENCODE" && -n "${AIDEVOPS_SESSION_ID:-}" && "$requested" == "$AIDEVOPS_SESSION_ID" ]]; then
+			active_opencode_session
+			return $?
+		fi
 		printf '%s\n' "$requested"
 		return 0
 	fi
 	case "$runtime" in
-	opencode) printf '%s\n' "${OPENCODE_SESSION_ID:-}" ;;
+	"$RUNTIME_OPENCODE") active_opencode_session ;;
 	claude-code) printf '%s\n' "${CLAUDE_SESSION_ID:-}" ;;
 	*) printf '\n' ;;
 	esac
@@ -127,7 +142,7 @@ main() {
 
 	runtime=$(resolve_runtime "$runtime") || return $?
 	case "$runtime" in
-	opencode | claude-code | normalized) ;;
+	"$RUNTIME_OPENCODE" | claude-code | normalized) ;;
 	*)
 		printf '%s\n' "Error: unsupported runtime: $runtime" >&2
 		return 2
@@ -138,11 +153,18 @@ main() {
 	if [[ -z "$source" ]]; then
 		source=$(resolve_history_source "$runtime") || return $?
 	elif [[ "$source_mode" == "db" && "$runtime" == "normalized" ]]; then
-		runtime="opencode"
+		runtime="$RUNTIME_OPENCODE"
 	fi
 	local source_format="transcript"
-	if [[ "$source_mode" == "db" || ( -z "$source_mode" && "$runtime" == "opencode" ) ]]; then
+	if [[ "$source_mode" == "db" || ( -z "$source_mode" && "$runtime" == "$RUNTIME_OPENCODE" ) ]]; then
 		source_format="database"
+	fi
+	if [[ -z "$source_mode" && "$runtime" == "$RUNTIME_OPENCODE" ]]; then
+		local active_session=""
+		active_session=$(active_opencode_session) || return $?
+		if [[ -n "$active_session" && "$session_id" == "$active_session" ]]; then
+			source_format="opencode-export"
+		fi
 	fi
 
 	local analyzer="${SCRIPT_DIR}/session-output-efficiency.py"

--- a/.agents/scripts/session-output-efficiency.py
+++ b/.agents/scripts/session-output-efficiency.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from session_output_metrics import AnalysisConfig, analyse
-from session_output_opencode import extract_opencode_db
+from session_output_opencode import extract_opencode_db, extract_opencode_export
 from session_output_transcript import extract_jsonl, resolve_jsonl
 
 
@@ -80,7 +80,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--runtime", choices=("opencode", "claude-code", "normalized"), default="normalized")
     parser.add_argument("--source", required=True, help="SQLite database, JSONL file, or JSONL directory")
-    parser.add_argument("--source-format", choices=("auto", "database", "transcript"), default="auto")
+    parser.add_argument(
+        "--source-format",
+        choices=("auto", "database", "opencode-export", "transcript"),
+        default="auto",
+    )
     parser.add_argument("--session", default="")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--min-repeat-bytes", type=int, default=80)
@@ -107,7 +111,10 @@ def use_database_source(args: argparse.Namespace, source: Path) -> bool:
 
 def build_report(args: argparse.Namespace) -> dict[str, Any]:
     source = Path(args.source).expanduser()
-    if use_database_source(args, source):
+    if args.source_format == "opencode-export":
+        results, parse_errors = extract_opencode_export(source, args.session)
+        source_kind = "opencode-export"
+    elif use_database_source(args, source):
         results, parse_errors = extract_opencode_db(source, args.session)
         source_kind = "database"
     else:

--- a/.agents/scripts/session-review-helper.sh
+++ b/.agents/scripts/session-review-helper.sh
@@ -993,7 +993,7 @@ run_output_efficiency() {
 
 gather_output_efficiency() {
 	local session_filter="${1:-}"
-	if [[ -z "$session_filter" && -z "${OPENCODE_SESSION_ID:-}" && -z "${CLAUDE_SESSION_ID:-}" ]]; then
+	if [[ -z "$session_filter" && -z "${AIDEVOPS_OPENCODE_SESSION_ID:-}" && -z "${OPENCODE_SESSION_ID:-}" && -z "${CLAUDE_SESSION_ID:-}" ]]; then
 		return 0
 	fi
 	local -a args=()

--- a/.agents/scripts/session_output_opencode.py
+++ b/.agents/scripts/session_output_opencode.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import subprocess
+import tempfile
 from pathlib import Path
 
 from session_output_transcript import ToolResult, result_from_opencode_part
@@ -37,4 +40,65 @@ def extract_opencode_db(path: Path, session_id: str) -> tuple[list[ToolResult], 
                     results.append(result)
     if row_count == 0:
         raise ValueError("session transcript was not found")
+    return results, parse_errors
+
+
+def extract_opencode_export(path: Path, session_id: str) -> tuple[list[ToolResult], int]:
+    """Read the exact active session through OpenCode without a recent-session fallback."""
+    if not session_id:
+        raise ValueError("--session is required for an active OpenCode export")
+    if not path.is_file():
+        raise ValueError("OpenCode database is unavailable")
+
+    temp_dir = Path(
+        os.environ.get(
+            "AIDEVOPS_TEMP_DIR",
+            Path.home() / ".aidevops" / ".agent-workspace" / "tmp",
+        )
+    )
+    if not temp_dir.is_dir():
+        raise ValueError("active OpenCode transcript was unavailable")
+
+    try:
+        with tempfile.TemporaryFile(mode="w+b", dir=temp_dir) as export_file:
+            completed = subprocess.run(
+                ["opencode", "export", session_id, "--pure"],
+                stdout=export_file,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=30,
+            )
+            if completed.returncode != 0:
+                raise ValueError("active OpenCode transcript was unavailable")
+            export_file.seek(0)
+            document = json.load(export_file)
+    except (FileNotFoundError, json.JSONDecodeError, OSError, subprocess.TimeoutExpired) as error:
+        raise ValueError("active OpenCode transcript was unavailable") from error
+
+    if not isinstance(document, dict):
+        raise ValueError("active OpenCode transcript was malformed")
+    info = document.get("info")
+    if not isinstance(info, dict) or info.get("id") != session_id:
+        raise ValueError("active OpenCode transcript did not match the requested session")
+    messages = document.get("messages")
+    if not isinstance(messages, list):
+        raise ValueError("active OpenCode transcript was malformed")
+
+    results: list[ToolResult] = []
+    parse_errors = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            parse_errors += 1
+            continue
+        parts = message.get("parts", [])
+        if not isinstance(parts, list):
+            parse_errors += 1
+            continue
+        for part in parts:
+            if not isinstance(part, dict):
+                parse_errors += 1
+                continue
+            result = result_from_opencode_part(part)
+            if result is not None:
+                results.append(result)
     return results, parse_errors

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1093,7 +1093,7 @@ if [[ "${1:-}" == "--version" ]]; then
 	printf '1.14.31\n'
 	exit 0
 fi
-if [[ -n "${OPENCODE_SESSION_ID:-}${OPENCODE_PID:-}${OPENCODE_RUN_ID:-}${OPENCODE_PROCESS_ROLE:-}${OPENCODE:-}${OPENCODE_SERVER_PASSWORD:-}" ]]; then
+if [[ -n "${AIDEVOPS_OPENCODE_SESSION_ID:-}${OPENCODE_SESSION_ID:-}${OPENCODE_PID:-}${OPENCODE_RUN_ID:-}${OPENCODE_PROCESS_ROLE:-}${OPENCODE:-}${OPENCODE_SERVER_PASSWORD:-}" ]]; then
 	printf 'leaked session env\n' >"$AIDEVOPS_CANARY_ENV_FILE"
 	exit 42
 fi
@@ -1114,6 +1114,7 @@ EOF
 		HOME="${canary_root}/home" \
 		OPENCODE_BIN="${fake_bin_dir}/opencode" \
 		OPENCODE_DB="${canary_root}/opencode.db" \
+		AIDEVOPS_OPENCODE_SESSION_ID="ses_parent" \
 		OPENCODE_SESSION_ID="ses_parent" \
 		OPENCODE_PID="12345" \
 		OPENCODE_RUN_ID="run_parent" \
@@ -1156,6 +1157,7 @@ test_opencode_session_env_wrapper_strips_session_vars_only() {
 	local output
 	# shellcheck disable=SC2016 # Inner bash expands these after env stripping.
 	output=$(
+		AIDEVOPS_OPENCODE_SESSION_ID="ses_parent" \
 		OPENCODE_SESSION_ID="ses_parent" \
 		OPENCODE_PID="12345" \
 		OPENCODE_RUN_ID="run_parent" \
@@ -1165,14 +1167,14 @@ test_opencode_session_env_wrapper_strips_session_vars_only() {
 		OPENCODE_BIN="opencode" \
 		OPENCODE_DB="/tmp/opencode.db" \
 		run_without_opencode_session_env bash -c '
-			printf "%s|%s|%s|%s|%s|%s|%s|%s" \
-				"${OPENCODE_SESSION_ID:-}" "${OPENCODE_PID:-}" "${OPENCODE_RUN_ID:-}" \
+			printf "%s|%s|%s|%s|%s|%s|%s|%s|%s" \
+				"${AIDEVOPS_OPENCODE_SESSION_ID:-}" "${OPENCODE_SESSION_ID:-}" "${OPENCODE_PID:-}" "${OPENCODE_RUN_ID:-}" \
 				"${OPENCODE_PROCESS_ROLE:-}" "${OPENCODE:-}" "${OPENCODE_SERVER_PASSWORD:-}" \
 				"${OPENCODE_BIN:-}" "${OPENCODE_DB:-}"
 		'
 	)
 
-	if [[ "$output" == "||||||opencode|/tmp/opencode.db" ]]; then
+	if [[ "$output" == "|||||||opencode|/tmp/opencode.db" ]]; then
 		print_result "OpenCode session env wrapper strips only session-bound vars" 0
 		return 0
 	fi
@@ -1214,6 +1216,7 @@ test_sandbox_passthrough_scopes_provider_env() {
 		GOOGLE_API_KEY='google-test' \
 		OPENCODE_BIN='opencode' \
 		OPENCODE_DB='/tmp/opencode.db' \
+		AIDEVOPS_OPENCODE_SESSION_ID='ses_parent' \
 		OPENCODE_SESSION_ID='ses_parent' \
 		OPENCODE_PID='12345' \
 		OPENCODE_RUN_ID='run_parent' \
@@ -1228,6 +1231,7 @@ test_sandbox_passthrough_scopes_provider_env() {
 		[[ "$csv" != *"GOOGLE_API_KEY"* ]] &&
 		[[ "$csv" == *"OPENCODE_BIN"* ]] &&
 		[[ "$csv" == *"OPENCODE_DB"* ]] &&
+		[[ "$csv" != *"AIDEVOPS_OPENCODE_SESSION_ID"* ]] &&
 		[[ "$csv" != *"OPENCODE_SESSION_ID"* ]] &&
 		[[ "$csv" != *"OPENCODE_PID"* ]] &&
 		[[ "$csv" != *"OPENCODE_RUN_ID"* ]] &&

--- a/.agents/scripts/tests/test-session-output-efficiency.sh
+++ b/.agents/scripts/tests/test-session-output-efficiency.sh
@@ -55,13 +55,26 @@ assert_omits() {
 normalized_fixture="${TMPDIR_TEST}/normalized.jsonl"
 claude_fixture="${TMPDIR_TEST}/claude.jsonl"
 opencode_db="${TMPDIR_TEST}/opencode history?#.db"
+active_home="${TMPDIR_TEST}/active-home"
+active_export_fixture="${TMPDIR_TEST}/active-export.json"
+mismatched_export_fixture="${TMPDIR_TEST}/mismatched-export.json"
+fake_opencode_bin="${TMPDIR_TEST}/bin"
 
-python3 - "$normalized_fixture" "$claude_fixture" "$opencode_db" <<'PY'
+python3 - "$normalized_fixture" "$claude_fixture" "$opencode_db" "$active_home" "$active_export_fixture" "$mismatched_export_fixture" "$fake_opencode_bin" <<'PY'
 import json
+import os
 import sqlite3
 import sys
 
-normalized_path, claude_path, database_path = sys.argv[1:]
+(
+    normalized_path,
+    claude_path,
+    database_path,
+    active_home,
+    active_export_path,
+    mismatched_export_path,
+    fake_opencode_bin,
+) = sys.argv[1:]
 repeated = "unchanged status snapshot SECRET-MARKER " + ("x" * 100)
 oversized = "large setup output " + ("y" * 9000)
 duplicate = "duplicate tool result " + ("d" * 100)
@@ -122,6 +135,65 @@ for index in range(2):
     )
 connection.commit()
 connection.close()
+
+active_database_path = os.path.join(active_home, ".local", "share", "opencode", "opencode.db")
+os.makedirs(os.path.dirname(active_database_path), exist_ok=True)
+active_connection = sqlite3.connect(active_database_path)
+active_connection.execute("CREATE TABLE session (id TEXT PRIMARY KEY)")
+active_connection.execute("CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT)")
+active_connection.execute("INSERT INTO session (id) VALUES (?)", ("session-active",))
+unrelated_part = {
+    "type": "tool",
+    "tool": "read",
+    "state": {"status": "completed", "input": {}, "output": "UNRELATED-RECENT-SESSION"},
+}
+active_connection.execute(
+    "INSERT INTO part (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+    ("unrelated-part", "unrelated-recent-session", 1, json.dumps(unrelated_part)),
+)
+active_connection.commit()
+active_connection.close()
+
+active_output = "active exact output ACTIVE-SECRET-MARKER " + ("q" * 100)
+active_document = {
+    "info": {"id": "session-active"},
+    "messages": [{
+        "info": {"role": "assistant"},
+        "parts": [
+            {
+                "type": "tool",
+                "tool": "bash",
+                "state": {"status": "completed", "input": {"command": "poll"}, "output": active_output},
+            },
+            {
+                "type": "tool",
+                "tool": "bash",
+                "state": {"status": "completed", "input": {"command": "poll"}, "output": active_output},
+            },
+        ],
+    }],
+}
+with open(active_export_path, "w", encoding="utf-8") as handle:
+    json.dump(active_document, handle)
+active_document["info"]["id"] = "different-session"
+with open(mismatched_export_path, "w", encoding="utf-8") as handle:
+    json.dump(active_document, handle)
+
+os.makedirs(fake_opencode_bin, exist_ok=True)
+fake_opencode = os.path.join(fake_opencode_bin, "opencode")
+with open(fake_opencode, "w", encoding="utf-8") as handle:
+    handle.write("""#!/usr/bin/env python3
+import os
+import sys
+
+if os.environ.get("AIDEVOPS_TEST_EXPORT_FAIL"):
+    raise SystemExit(1)
+if len(sys.argv) != 4 or sys.argv[1] != "export" or sys.argv[3] != "--pure":
+    raise SystemExit(2)
+with open(os.environ["AIDEVOPS_TEST_EXPORT_FIXTURE"], "rb") as source:
+    sys.stdout.buffer.write(source.read())
+""")
+os.chmod(fake_opencode, 0o755)
 PY
 
 text_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --input "$normalized_fixture")
@@ -146,6 +218,66 @@ assert_contains "Claude JSONL tool results are correlated" "Repeated unchanged s
 
 database_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime opencode --db "$opencode_db" --session session-test)
 assert_contains "OpenCode database tool parts are analysed" "Repeated unchanged snapshots: 1 groups, 1 redundant results" "$database_output"
+
+active_output=$(
+	HOME="$active_home" \
+		AIDEVOPS_TEMP_DIR="$TMPDIR_TEST" \
+		PATH="${fake_opencode_bin}:$PATH" \
+		OPENCODE_SESSION_ID="session-active" \
+		AIDEVOPS_OPENCODE_SESSION_ID="session-active" \
+		AIDEVOPS_TEST_EXPORT_FIXTURE="$active_export_fixture" \
+		"$HELPER" --runtime opencode --session session-active --json
+)
+if python3 -c 'import json,sys; report=json.load(sys.stdin); assert report["session"] == "session-active"; assert report["source"] == "opencode-export"; assert report["stats"]["completed_tool_results"] == 2; assert report["stats"]["redundant_tool_results"] == 1' <<<"$active_output"; then
+	pass "active exact OpenCode session is analysed before close"
+else
+	fail "active exact OpenCode session is analysed before close"
+fi
+assert_omits "active aggregate report omits raw output" "ACTIVE-SECRET-MARKER" "$active_output"
+assert_omits "active analysis does not substitute an unrelated recent session" "UNRELATED-RECENT-SESSION" "$active_output"
+
+mapped_output=$(
+	HOME="$active_home" \
+		AIDEVOPS_TEMP_DIR="$TMPDIR_TEST" \
+		PATH="${fake_opencode_bin}:$PATH" \
+		AIDEVOPS_SESSION_ID="framework-session" \
+		OPENCODE_SESSION_ID="stale-opencode-session" \
+		AIDEVOPS_OPENCODE_SESSION_ID="session-active" \
+		AIDEVOPS_TEST_EXPORT_FIXTURE="$active_export_fixture" \
+		"$HELPER" --runtime opencode --session framework-session --json
+)
+if python3 -c 'import json,sys; report=json.load(sys.stdin); assert report["session"] == "session-active"; assert report["stats"]["completed_tool_results"] == 2' <<<"$mapped_output"; then
+	pass "explicit framework-to-OpenCode identity mapping is honoured"
+else
+	fail "explicit framework-to-OpenCode identity mapping is honoured"
+fi
+
+set +e
+missing_active_output=$(
+	HOME="$active_home" \
+		AIDEVOPS_TEMP_DIR="$TMPDIR_TEST" \
+		PATH="${fake_opencode_bin}:$PATH" \
+		OPENCODE_SESSION_ID="session-active" \
+		AIDEVOPS_OPENCODE_SESSION_ID="session-active" \
+		AIDEVOPS_TEST_EXPORT_FIXTURE="$active_export_fixture" \
+		AIDEVOPS_TEST_EXPORT_FAIL=1 \
+		"$HELPER" --runtime opencode --session session-active --json 2>&1
+)
+missing_active_rc=$?
+mismatched_active_output=$(
+	HOME="$active_home" \
+		AIDEVOPS_TEMP_DIR="$TMPDIR_TEST" \
+		PATH="${fake_opencode_bin}:$PATH" \
+		OPENCODE_SESSION_ID="session-active" \
+		AIDEVOPS_OPENCODE_SESSION_ID="session-active" \
+		AIDEVOPS_TEST_EXPORT_FIXTURE="$mismatched_export_fixture" \
+		"$HELPER" --runtime opencode --session session-active --json 2>&1
+)
+mismatched_active_rc=$?
+set -e
+[[ "$missing_active_rc" -eq 2 ]] && pass "missing active export remains unavailable" || fail "missing active export remains unavailable" "got ${missing_active_rc}"
+[[ "$mismatched_active_rc" -eq 2 ]] && pass "mismatched active export is rejected" || fail "mismatched active export is rejected" "got ${mismatched_active_rc}"
+assert_omits "active export errors do not expose unrelated transcript data" "UNRELATED-RECENT-SESSION" "${missing_active_output}${mismatched_active_output}"
 
 set +e
 missing_session_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime opencode --db "$opencode_db" --session absent-session 2>&1)

--- a/.agents/workflows/session-analysis.md
+++ b/.agents/workflows/session-analysis.md
@@ -53,12 +53,17 @@ dependencies; do not silently expand into a whole-repository audit.
 ## 2. Gather Minimum Sufficient Evidence
 
 Use the conversation and existing tool results first. Run only relevant,
-available diagnostics. Obtain the current runtime ID with
-`printenv OPENCODE_SESSION_ID || printenv CLAUDE_SESSION_ID || true`, then
-substitute the returned literal for `<session-id>`; this remains successful when
-neither variable is set and avoids expansion that command-policy parsing may
-reject. If the command returns no literal, mark session-specific diagnostics
-unavailable and skip every command requiring `<session-id>`.
+available diagnostics. For OpenCode, the authoritative conversation identity is
+`AIDEVOPS_OPENCODE_SESSION_ID`, stamped from each `shell.env` hook input; the
+legacy-compatible fallback is `OPENCODE_SESSION_ID`. `AIDEVOPS_SESSION_ID` may be
+a different framework identity, and the output-efficiency helper maps it only
+when the same shell explicitly provides `AIDEVOPS_OPENCODE_SESSION_ID`. Obtain
+the current runtime ID with `printenv AIDEVOPS_OPENCODE_SESSION_ID || printenv
+OPENCODE_SESSION_ID || printenv CLAUDE_SESSION_ID || true`, then substitute the
+returned literal for `<session-id>`. This remains successful when neither
+variable is set and avoids expansion that command-policy parsing may reject. If
+the command returns no literal, mark session-specific diagnostics unavailable
+and skip every command requiring `<session-id>`.
 
 | Evidence | Command or source | Run when |
 |---|---|---|
@@ -76,6 +81,12 @@ session has no record, mark the metric unavailable; never fall back to another
 recent session or a broad daily report. A missing data source is not a reason to
 add telemetry. Avoid broad logs, generated reports, remote lookups, or repeated
 reads unless a specific finding cannot otherwise be proved.
+
+For an active OpenCode conversation, output-efficiency analysis passes the
+Vault-managed history read gate and invokes an exact-ID, plugin-free OpenCode
+export. The export's embedded session ID must match before aggregate analysis;
+missing, malformed, mismatched, or unavailable exports fail closed and never
+select a title-, timestamp-, or recency-based substitute.
 
 Treat output-efficiency fingerprints as aggregate leads. Correlate a repeated
 snapshot or oversized result with the chronological tool calls before proposing


### PR DESCRIPTION
## Summary

- analyse completed tool results from the exact active OpenCode conversation via a plugin-free, exact-ID export after the existing Vault read gate
- stamp the authoritative OpenCode conversation ID on every shell hook and map a distinct framework session ID only through explicit environment evidence
- reject missing, malformed, or mismatched active exports instead of selecting another recent session
- strip the new session-bound identity from isolated headless child environments

## Implementation

- `.agents/scripts/session-output-efficiency-helper.sh` selects the live export path only for the explicitly active OpenCode ID
- `.agents/scripts/session_output_opencode.py` captures the exact export in an unlinked protected temporary file, validates its embedded ID, and emits only normalized tool results to the aggregate metrics layer
- `.agents/plugins/opencode-aidevops/shell-env.mjs` replaces stale inherited IDs after plugin reloads and publishes `AIDEVOPS_OPENCODE_SESSION_ID`
- focused fixtures cover active results, explicit framework/OpenCode mapping, update continuity, missing/mismatched evidence, unrelated recent sessions, and aggregate-only output

## Verification

- `bash .agents/scripts/tests/test-session-output-efficiency.sh` — 24 passed
- `node --test .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs` — 12 passed
- `python3 -m py_compile .agents/scripts/session-output-efficiency.py .agents/scripts/session_output_opencode.py .agents/scripts/session_output_metrics.py .agents/scripts/session_output_transcript.py`
- `shellcheck .agents/scripts/session-output-efficiency-helper.sh .agents/scripts/session-review-helper.sh .agents/scripts/tests/test-session-output-efficiency.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `.agents/scripts/linters-local.sh --changed`
- `.agents/scripts/linters-local.sh`
- live active-session smoke test: `aidevops.session-output-efficiency/v1`, source `opencode-export`, 83 completed results, no raw fields
- local package typecheck was unavailable because dependencies are not installed (`tsc: command not found`); required CI remains the authoritative typecheck gate

Resolves #27574

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.108 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 42m and 644,878 tokens on this as a headless worker.