### PR TITLE
GH#27575: Fix active OpenCode session output lookup

### DIFF
--- a/.agents/scripts/session-output-efficiency-helper.sh
+++ b/.agents/scripts/session-output-efficiency-helper.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 readonly SCRIPT_DIR
+readonly OPENCODE_RUNTIME="opencode"
 
 usage() {
 	cat <<'EOF'
@@ -36,7 +37,7 @@ resolve_runtime() {
 		return 0
 	fi
 	if [[ -n "${OPENCODE_SESSION_ID:-}" ]]; then
-		printf '%s\n' "opencode"
+		printf '%s\n' "$OPENCODE_RUNTIME"
 		return 0
 	fi
 	if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
@@ -77,35 +78,84 @@ resolve_history_source() {
 	return $?
 }
 
+resolve_opencode_history_source() {
+	local session_id="$1"
+	local configured_source active_source
+	configured_source=$(resolve_history_source "$OPENCODE_RUNTIME") || return $?
+	if [[ -z "$session_id" || -z "${XDG_DATA_HOME:-}" || "${AIDEVOPS_VAULT_MANAGED_SESSION_HISTORY:-}" == "1" || "${AIDEVOPS_VAULT_MANAGED_SESSION_HISTORY:-}" == "true" ]]; then
+		printf '%s\n' "$configured_source"
+		return 0
+	fi
+	active_source="${XDG_DATA_HOME}/opencode/opencode.db"
+	if [[ "$active_source" == "$configured_source" || ! -f "$active_source" ]]; then
+		printf '%s\n' "$configured_source"
+		return 0
+	fi
+	if python3 - "$active_source" "$session_id" <<'PY' >/dev/null 2>&1; then
+import sqlite3
+import sys
+from pathlib import Path
+
+database_path = Path(sys.argv[1]).absolute()
+session_id = sys.argv[2]
+uri = f"{database_path.as_uri()}?mode=ro"
+with sqlite3.connect(uri, uri=True) as connection:
+    row = connection.execute(
+        "SELECT 1 FROM session WHERE id = ? LIMIT 1", (session_id,)
+    ).fetchone()
+raise SystemExit(0 if row else 1)
+PY
+		printf '%s\n' "$active_source"
+		return 0
+	fi
+	printf '%s\n' "$configured_source"
+	return 0
+}
+
 main() {
 	local runtime="" session_id="" source="" source_mode=""
 	local -a analyzer_args=()
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--runtime)
-			[[ $# -gt 1 ]] || { printf '%s\n' "Error: --runtime requires a value" >&2; return 2; }
+			[[ $# -gt 1 ]] || {
+				printf '%s\n' "Error: --runtime requires a value" >&2
+				return 2
+			}
 			runtime="$2"
 			shift 2
 			;;
 		--session)
-			[[ $# -gt 1 ]] || { printf '%s\n' "Error: --session requires a value" >&2; return 2; }
+			[[ $# -gt 1 ]] || {
+				printf '%s\n' "Error: --session requires a value" >&2
+				return 2
+			}
 			session_id="$2"
 			shift 2
 			;;
 		--input)
-			[[ $# -gt 1 ]] || { printf '%s\n' "Error: --input requires a path" >&2; return 2; }
+			[[ $# -gt 1 ]] || {
+				printf '%s\n' "Error: --input requires a path" >&2
+				return 2
+			}
 			source="$2"
 			source_mode="input"
 			shift 2
 			;;
 		--db)
-			[[ $# -gt 1 ]] || { printf '%s\n' "Error: --db requires a path" >&2; return 2; }
+			[[ $# -gt 1 ]] || {
+				printf '%s\n' "Error: --db requires a path" >&2
+				return 2
+			}
 			source="$2"
 			source_mode="db"
 			shift 2
 			;;
 		--min-repeat-bytes | --oversized-bytes | --max-findings)
-			[[ $# -gt 1 ]] || { printf '%s\n' "Error: $1 requires a value" >&2; return 2; }
+			[[ $# -gt 1 ]] || {
+				printf '%s\n' "Error: $1 requires a value" >&2
+				return 2
+			}
 			analyzer_args+=("$1" "$2")
 			shift 2
 			;;
@@ -127,7 +177,7 @@ main() {
 
 	runtime=$(resolve_runtime "$runtime") || return $?
 	case "$runtime" in
-	opencode | claude-code | normalized) ;;
+	"$OPENCODE_RUNTIME" | claude-code | normalized) ;;
 	*)
 		printf '%s\n' "Error: unsupported runtime: $runtime" >&2
 		return 2
@@ -136,12 +186,16 @@ main() {
 	session_id=$(resolve_session "$runtime" "$session_id") || return $?
 
 	if [[ -z "$source" ]]; then
-		source=$(resolve_history_source "$runtime") || return $?
+		if [[ "$runtime" == "$OPENCODE_RUNTIME" ]]; then
+			source=$(resolve_opencode_history_source "$session_id") || return $?
+		else
+			source=$(resolve_history_source "$runtime") || return $?
+		fi
 	elif [[ "$source_mode" == "db" && "$runtime" == "normalized" ]]; then
-		runtime="opencode"
+		runtime="$OPENCODE_RUNTIME"
 	fi
 	local source_format="transcript"
-	if [[ "$source_mode" == "db" || ( -z "$source_mode" && "$runtime" == "opencode" ) ]]; then
+	if [[ "$source_mode" == "db" || (-z "$source_mode" && "$runtime" == "$OPENCODE_RUNTIME") ]]; then
 		source_format="database"
 	fi
 

--- a/.agents/scripts/session_output_opencode.py
+++ b/.agents/scripts/session_output_opencode.py
@@ -35,6 +35,14 @@ def extract_opencode_db(path: Path, session_id: str) -> tuple[list[ToolResult], 
                 result = result_from_opencode_part(part)
                 if result is not None:
                     results.append(result)
-    if row_count == 0:
-        raise ValueError("session transcript was not found")
+        if row_count == 0:
+            try:
+                session_exists = connection.execute(
+                    "SELECT 1 FROM session WHERE id = ? LIMIT 1", (session_id,)
+                ).fetchone()
+            except sqlite3.OperationalError:
+                session_exists = None
+            if session_exists:
+                raise ValueError("session transcript is not ready")
+            raise ValueError("session transcript was not found")
     return results, parse_errors

--- a/.agents/scripts/tests/test-session-output-efficiency.sh
+++ b/.agents/scripts/tests/test-session-output-efficiency.sh
@@ -55,13 +55,16 @@ assert_omits() {
 normalized_fixture="${TMPDIR_TEST}/normalized.jsonl"
 claude_fixture="${TMPDIR_TEST}/claude.jsonl"
 opencode_db="${TMPDIR_TEST}/opencode history?#.db"
+active_data_home="${TMPDIR_TEST}/active-data"
+active_opencode_db="${active_data_home}/opencode/opencode.db"
+mkdir -p "${active_data_home}/opencode"
 
-python3 - "$normalized_fixture" "$claude_fixture" "$opencode_db" <<'PY'
+python3 - "$normalized_fixture" "$claude_fixture" "$opencode_db" "$active_opencode_db" <<'PY'
 import json
 import sqlite3
 import sys
 
-normalized_path, claude_path, database_path = sys.argv[1:]
+normalized_path, claude_path, database_path, active_database_path = sys.argv[1:]
 repeated = "unchanged status snapshot SECRET-MARKER " + ("x" * 100)
 oversized = "large setup output " + ("y" * 9000)
 duplicate = "duplicate tool result " + ("d" * 100)
@@ -122,6 +125,24 @@ for index in range(2):
     )
 connection.commit()
 connection.close()
+
+connection = sqlite3.connect(active_database_path)
+connection.execute("CREATE TABLE session (id TEXT PRIMARY KEY)")
+connection.execute("CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT)")
+connection.execute("INSERT INTO session (id) VALUES ('active-session')")
+connection.execute("INSERT INTO session (id) VALUES ('not-ready-session')")
+for index in range(2):
+    part = {
+        "type": "tool",
+        "tool": "bash",
+        "state": {"status": "completed", "input": {"command": "poll"}, "output": repeated},
+    }
+    connection.execute(
+        "INSERT INTO part (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+        (f"active-part-{index}", "active-session", index, json.dumps(part)),
+    )
+connection.commit()
+connection.close()
 PY
 
 text_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --input "$normalized_fixture")
@@ -147,14 +168,25 @@ assert_contains "Claude JSONL tool results are correlated" "Repeated unchanged s
 database_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime opencode --db "$opencode_db" --session session-test)
 assert_contains "OpenCode database tool parts are analysed" "Repeated unchanged snapshots: 1 groups, 1 redundant results" "$database_output"
 
+active_output=$(XDG_DATA_HOME="$active_data_home" OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime opencode --session active-session --json)
+if python3 -c 'import json,sys; report=json.load(sys.stdin); assert report["session"] == "active-session"; assert report["stats"]["completed_tool_results"] == 2' <<<"$active_output"; then
+	pass "active OpenCode store resolves the exact current session"
+else
+	fail "active OpenCode store resolves the exact current session"
+fi
+
 set +e
 missing_session_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime opencode --db "$opencode_db" --session absent-session 2>&1)
 missing_session_rc=$?
 invalid_session_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime opencode --db "$opencode_db" --session '../*' 2>&1)
 invalid_session_rc=$?
+not_ready_output=$(XDG_DATA_HOME="$active_data_home" OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime opencode --session not-ready-session --json 2>&1)
+not_ready_rc=$?
 set -e
 [[ "$missing_session_rc" -eq 2 ]] && pass "missing database session is unavailable" || fail "missing database session is unavailable" "got ${missing_session_rc}"
 [[ "$invalid_session_rc" -eq 2 ]] && pass "unsafe session filter is rejected" || fail "unsafe session filter is rejected" "got ${invalid_session_rc}"
+[[ "$not_ready_rc" -eq 2 ]] && pass "active session without parts is not reported as zero activity" || fail "active session without parts is not reported as zero activity" "got ${not_ready_rc}"
+assert_contains "active session without parts reports not-ready state" "session transcript is not ready" "$not_ready_output"
 assert_omits "session errors do not expose database path" "$opencode_db" "${missing_session_output}${invalid_session_output}"
 
 review_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$REVIEW_HELPER" output-efficiency --input "$normalized_fixture" --json)


### PR DESCRIPTION
## Summary

Resolve exact active OpenCode sessions from the runtime XDG data store while preserving configured history, Vault boundaries, and explicit missing-session behavior.

## Files Changed

.agents/scripts/session-output-efficiency-helper.sh, .agents/scripts/session_output_opencode.py, .agents/scripts/tests/test-session-output-efficiency.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 20 focused assertions pass; Python compilation, ShellCheck, changed-scope linters, and literal active-session runtime verification pass.

Resolves #27575


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.105 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 5m and 94,987 tokens on this with the user in an interactive session.