### PR TITLE
GH#27517: harden draft-checkpoint lifecycle

### DIFF
--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -58,9 +58,9 @@ _ddpr_superseded_issue_refs() {
 # Redispatch should not create another worker when an existing sibling PR for
 # the same issue is already approved or mergeable. This catches PRs that are
 # ready for the merge path but do not use a closing keyword in the body (for
-# example parent/phase work using `For #NNN`), while still allowing dispatch
-# when only draft, changes-requested, conflicting, or explicitly blocked
-# candidates exist.
+# example parent/phase work using `For #NNN`). Drafts are durable checkpoints:
+# worker drafts must be continued/escalated, while interactive/held/NMR drafts
+# must remain untouched. Both kinds block competing ordinary dispatch.
 #
 # Args: $1 = issue number, $2 = repo slug
 # Returns: exit 0 if a healthy sibling PR matches, exit 1 if none
@@ -69,7 +69,7 @@ _has_open_pr_check_healthy_sibling() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
-	local pr_json match_pr
+	local pr_json match_pr draft_pr
 	pr_json=$(gh pr list --repo "$repo_slug" --state open \
 		--search "#${issue_number}" --limit 20 \
 		--json number,title,body,isDraft,reviewDecision,mergeStateStatus,mergeable 2>/dev/null) || pr_json="[]"
@@ -78,6 +78,19 @@ _has_open_pr_check_healthy_sibling() {
 	issue_ref_pattern="([^[:alnum:]_]|^)((close[sd]?|fix(e[sd])?|resolve[sd]?|for|refs?):?[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}|GH#${issue_number}|#${issue_number})([^[:alnum:]_]|$)"
 	healthy_state_pattern="^(CLEAN|HAS_HOOKS|UNSTABLE|BEHIND)$"
 	blocked_state_pattern="^(DIRTY|BLOCKED|CONFLICTING)$"
+
+	draft_pr=$(printf '%s' "$pr_json" | jq -r \
+		--arg issue_pattern "$issue_ref_pattern" '
+		[
+			.[] | select(
+				(.isDraft == true) and
+				([.title?, .body?] | map(strings) | any(test($issue_pattern; "i")))
+			)
+		] | .[0].number // empty' 2>/dev/null) || draft_pr=""
+	if [[ -n "$draft_pr" ]]; then
+		printf 'draft PR #%s is a durable checkpoint for issue #%s; ordinary redispatch is blocked\n' "$draft_pr" "$issue_number"
+		return 0
+	fi
 
 	match_pr=$(printf '%s' "$pr_json" | jq -r \
 		--arg issue_pattern "$issue_ref_pattern" \

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -21,6 +21,10 @@
 # 28 min of dispatch capacity per crash.
 #######################################
 STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-${DISPATCH_COMMENT_MAX_AGE:-600}}"
+_DDS_NMR_LABEL="needs-maintainer-review"
+_DDS_KIND_DRAFT="draft_checkpoint"
+_DDS_KIND_READY="ready"
+_DDS_KIND_READY_FAILED="ready_failed"
 
 #######################################
 # t2132: Separate threshold for interactive claims.
@@ -188,25 +192,137 @@ _stale_recovery_has_terminal_evidence_since() {
 }
 
 #######################################
-# Look up any open PR referencing this issue while preserving draft state.
-# Ready PRs reset stale recovery; draft checkpoints escalate instead of being
-# treated as either completion or permission for a competing implementation.
+# Classify an open PR referencing this issue for stale recovery.
+# Output: "number|ready|ready_failed|draft_checkpoint|protected_draft".
 # Args: $1 = issue number, $2 = repo slug
 # Output: PR number (or empty) on stdout
 #######################################
 _stale_recovery_find_open_pr() {
 	local issue_number="$1"
 	local repo_slug="$2"
-	local _open_pr
-	# shellcheck disable=SC2016 # $ready is a jq variable, not a shell variable.
-	_open_pr=$(gh pr list --repo "$repo_slug" --state open \
+	local _open_pr _open_pr_json
+	_open_pr_json=$(gh pr list --repo "$repo_slug" --state open \
 		--search "#${issue_number} in:body" --limit 20 \
-		--json number,isDraft --jq '
-			([.[] | select(.isDraft != true)][0]) as $ready
-			| if $ready != null then "ready|\($ready.number)"
-			elif .[0] != null then "draft|\(.[0].number)"
-			else "" end' 2>/dev/null) || _open_pr=""
+		--json number,isDraft,labels,statusCheckRollup 2>/dev/null) || _open_pr_json="[]"
+	_open_pr=$(printf '%s' "$_open_pr_json" | jq -r \
+		--arg ready_failed "$_DDS_KIND_READY_FAILED" \
+		--arg ready "$_DDS_KIND_READY" \
+		--arg draft "$_DDS_KIND_DRAFT" '
+			def names: [.labels[]?.name];
+			def protected: names | any(
+				. == "origin:interactive" or . == "hold-for-review" or
+				. == "no-auto-dispatch" or . == "needs-maintainer-review"
+			);
+			def worker_owned: names | any(. == "origin:worker" or . == "origin:worker-takeover");
+			def terminal_failure:
+				[.statusCheckRollup[]? | (.conclusion // .status // .state // empty) | ascii_upcase] |
+				any(. == "FAILURE" or . == "ERROR" or . == "CANCELLED" or
+					. == "TIMED_OUT" or . == "ACTION_REQUIRED" or . == "STALE");
+			def kind:
+				if (.isDraft != true) and terminal_failure then $ready_failed
+				elif .isDraft != true then $ready
+				elif worker_owned and (protected | not) then $draft
+				else "protected_draft" end;
+			map(. + {lifecycle_kind: kind}) |
+			sort_by(if .lifecycle_kind == $ready_failed then 0
+				elif .lifecycle_kind == $ready then 1
+				elif .lifecycle_kind == $draft then 2 else 3 end) |
+			.[0] | if . then "\(.number)|\(.lifecycle_kind)" else "" end' \
+		2>/dev/null) || _open_pr=""
 	printf '%s' "$_open_pr"
+	return 0
+}
+
+#######################################
+# Verify that a blocking NMR transition is visible before releasing ownership.
+# Args: issue number, repo slug, stale assignees CSV
+#######################################
+_stale_recovery_verify_blocking_transition() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local stale_assignees="$3"
+	local issue_json=""
+
+	issue_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state,labels,assignees 2>/dev/null) || return 1
+	printf '%s' "$issue_json" | jq -e --arg nmr "$_DDS_NMR_LABEL" --arg stale "$stale_assignees" '
+		($stale | split(",") | map(select(length > 0))) as $stale_users |
+		([.labels[]?.name]) as $labels |
+		([.assignees[]?.login]) as $current_users |
+		.state == "OPEN" and
+		($labels | index($nmr)) != null and
+		($labels | index("status:queued")) == null and
+		($labels | index("status:in-progress")) == null and
+		([ $stale_users[] as $user | select(($current_users | index($user)) != null) ] | length == 0)
+	' >/dev/null 2>&1 || return 1
+	return 0
+}
+
+#######################################
+# Escalate an exhausted worker draft or terminally failed ready PR. Protected
+# drafts never call this path. Ownership is retained unless the blocking label
+# and assignee/status transition can be read back from GitHub.
+# Args: issue, repo, stale assignees, reason, PR number, dispatch ts, kind
+#######################################
+_stale_recovery_escalate_pr_checkpoint() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local stale_assignees="$3"
+	local reason="$4"
+	local pr_number="$5"
+	local expected_dispatch_ts="${6:-}"
+	local checkpoint_kind="${7:-$_DDS_KIND_DRAFT}"
+	local description="worker draft PR"
+	local event="STALE_DRAFT_ESCALATED"
+	local old_ifs="${IFS-}"
+	local ifs_was_set=0
+	local assignee=""
+	local -a assignees=()
+	local -a transition_args=(--add-label "$_DDS_NMR_LABEL" --remove-label "auto-dispatch")
+
+	if [[ "$checkpoint_kind" == "$_DDS_KIND_READY_FAILED" ]]; then
+		description="ready PR with terminally failed checks"
+		event="STALE_READY_FAILED_ESCALATED"
+	fi
+	if ! _stale_recovery_final_evidence_recheck "$issue_number" "$repo_slug" "$expected_dispatch_ts"; then
+		printf 'STALE_RECHECK_BLOCKED: issue #%s in %s — evidence changed before PR escalation\n' "$issue_number" "$repo_slug"
+		return 0
+	fi
+
+	[[ -n "${IFS+x}" ]] && ifs_was_set=1
+	IFS=',' read -ra assignees <<<"$stale_assignees"
+	if [[ "$ifs_was_set" -eq 1 ]]; then
+		IFS="$old_ifs"
+	else
+		unset IFS
+	fi
+	for assignee in "${assignees[@]}"; do
+		[[ -n "$assignee" ]] && transition_args+=(--remove-assignee "$assignee")
+	done
+
+	if ! set_issue_status "$issue_number" "$repo_slug" "" "${transition_args[@]}"; then
+		printf 'STALE_PR_ESCALATION_FAILED: issue #%s in %s — blocking transition failed; ownership retained\n' "$issue_number" "$repo_slug"
+		return 1
+	fi
+	if ! _stale_recovery_verify_blocking_transition "$issue_number" "$repo_slug" "$stale_assignees"; then
+		printf 'STALE_PR_ESCALATION_FAILED: issue #%s in %s — blocking transition not visible; ownership retained\n' "$issue_number" "$repo_slug"
+		return 1
+	fi
+
+	gh_issue_comment "$issue_number" --repo "$repo_slug" \
+		--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+<!-- stale-pr-checkpoint:escalated pr=${pr_number} kind=${checkpoint_kind} -->
+**PR checkpoint requires continuation review**
+
+The ${description} #${pr_number} preserves committed progress but is not completion evidence. Ordinary redispatch remains blocked to avoid a competing implementation.
+
+Previously assigned to: ${stale_assignees}
+Stale reason: ${reason}
+
+Applied \`${_DDS_NMR_LABEL}\`. Continue or repair the existing PR before re-enabling dispatch.
+<!-- ops:end -->" 2>/dev/null || true
+	printf '%s: issue #%s in %s — PR #%s preserved, applied %s\n' \
+		"$event" "$issue_number" "$repo_slug" "$pr_number" "$_DDS_NMR_LABEL"
 	return 0
 }
 
@@ -270,7 +386,7 @@ _stale_recovery_escalate() {
 	# otherwise a racing recovery can restore status:available and make the
 	# held issue look runnable to idle-backoff even though dispatch rejects it.
 	local -a _esc_extra=(
-		--add-label "needs-maintainer-review"
+		--add-label "$_DDS_NMR_LABEL"
 		--remove-label "auto-dispatch"
 	)
 	for _esc_assignee in "${_esc_assignee_arr[@]}"; do
@@ -519,23 +635,33 @@ _recover_stale_assignment() {
 	# resetting to status:available and apply needs-maintainer-review instead.
 	# Counter is stored as structured comment markers for cross-runner correctness.
 	# Config: .agents/configs/dispatch-stale-recovery.conf
-	local _threshold _prior_ticks _open_pr _comments_pages _latest_dispatch_ts _next_tick
+	local _threshold _prior_ticks _open_pr _open_pr_number _open_pr_kind _comments_pages _latest_dispatch_ts _next_tick
 	_threshold=$(_stale_recovery_load_threshold)
 	_comments_pages=$(_stale_recovery_fetch_comments_pages "$issue_number" "$repo_slug")
 	_prior_ticks=$(_stale_recovery_count_ticks_from_pages "$_comments_pages")
 	_latest_dispatch_ts=$(_stale_recovery_latest_dispatch_ts_from_pages "$_comments_pages")
 	_open_pr=$(_stale_recovery_find_open_pr "$issue_number" "$repo_slug")
 	if [[ -n "$_open_pr" ]]; then
-		if [[ "$_open_pr" == draft\|* ]]; then
-			_next_tick=$((_prior_ticks + 1))
-			_stale_recovery_escalate "$issue_number" "$repo_slug" "$stale_assignees" \
-				"terminal worker left incomplete draft PR #${_open_pr#*|}: ${reason}" \
-				"$_threshold" "$_next_tick" "$_latest_dispatch_ts"
+		_open_pr_number="${_open_pr%%|*}"
+		_open_pr_kind="${_open_pr#*|}"
+		if [[ "$_open_pr_kind" == "$_DDS_KIND_DRAFT" || "$_open_pr_kind" == "$_DDS_KIND_READY_FAILED" ]]; then
+			if printf '%s' "$_comments_pages" | jq -e --arg marker "stale-pr-checkpoint:escalated pr=${_open_pr_number} kind=${_open_pr_kind}" \
+				'any(.[] | .[]?; (.body // "") | contains($marker))' >/dev/null 2>&1; then
+				printf 'STALE_PR_ESCALATED: issue #%s in %s — PR #%s already escalated\n' \
+					"$issue_number" "$repo_slug" "$_open_pr_number"
+				return 0
+			fi
+			_stale_recovery_escalate_pr_checkpoint "$issue_number" "$repo_slug" "$stale_assignees" \
+				"$reason" "$_open_pr_number" "$_latest_dispatch_ts" "$_open_pr_kind" || return 1
 			return 0
 		fi
-		_open_pr="${_open_pr#ready|}"
+		if [[ "$_open_pr_kind" == "protected_draft" ]]; then
+			printf 'STALE_DRAFT_PROTECTED: issue #%s in %s — draft PR #%s is held or not worker-owned; no automated mutation\n' \
+				"$issue_number" "$repo_slug" "$_open_pr_number"
+			return 0
+		fi
 		printf 'STALE_PROGRESS_PRESERVED: issue #%s in %s — open PR #%s is durable progress\n' \
-			"$issue_number" "$repo_slug" "$_open_pr"
+			"$issue_number" "$repo_slug" "$_open_pr_number"
 		return 0
 	fi
 	_next_tick=$((_prior_ticks + 1))

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -26,17 +26,24 @@ _HEADLESS_RUNTIME_WORKER_LIB_LOADED=1
 
 # Module-local string constants (avoid ratchet repeated-literal violations)
 _HRW_STATUS_FAIL="fail"
+_HRW_STATUS_FAILED="failed"
+_HRW_STATUS_ESCALATED="escalated"
 _HRW_STATUS_UNKNOWN="unknown"
 _HRW_GIT_HEAD="HEAD"
 _HRW_CRASH_NO_WORK="no_work"
+_HRW_CRASH_OVERWHELMED="overwhelmed"
 _HRW_REASON_WORKER_COMPLETE="worker_complete"
 _HRW_TELEMETRY_SUCCESS="success"
 _HRW_TELEMETRY_FAILED="failed"
 _HRW_TELEMETRY_DEFERRED="deferred"
 _HRW_REASON_DRAFT_CHECKPOINT="worker_draft_checkpoint"
-_HRW_EVENT_DEFERRED="worker.deferred"
-_HRW_PR_SCOPE_HEAD_ONLY="head-only"
+_HRW_REASON_DRAFT_ESCALATION_FAILED="worker_draft_checkpoint_escalation_failed"
+_HRW_REASON_READY_FAILED="worker_ready_failed"
+_HRW_REASON_CLOSED_UNMERGED="worker_closed_unmerged_pr"
+_HRW_EVENT_FAILED="worker.failed"
+_HRW_NMR_LABEL="needs-maintainer-review"
 _HRW_SPOTLIGHT_MARKER=".metadata_never_index"
+_HRW_RECOVERY_CLASSIFICATION=""
 
 # Defensive SCRIPT_DIR fallback (test harnesses may not set it)
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -448,12 +455,17 @@ _hrw_resolve_default_branch() {
 #######################################
 # _worker_produced_output — classify worker output quality (GH#20819)
 #
-# Returns one of four classification strings via stdout:
+# Returns a concrete lifecycle/output classification via stdout:
 #   "pr_exists"             — PR confirmed, or fail-open (cannot evaluate signals)
 #   "branch_orphan"         — branch pushed + commits exist BUT no PR found
 #                             (requires DISPATCH_REPO_SLUG + gh to confirm absence)
 #   "local_branch_unpushed" — local branch has commits but no remote branch or PR
 #   "dirty_worktree"        — uncommitted/untracked edits exist after a crash
+#   "draft_checkpoint"      — exact-head worker draft (durable, incomplete)
+#   "protected_draft"       — interactive/held/NMR/non-worker draft
+#   "ready_failed"          — exact-head ready PR has terminal failed checks
+#   "closed_unmerged"       — exact-head PR closed without merge
+#   "unverified_open_pr"    — issue-search fallback cannot prove exact head
 #   "noop"                  — no commits, no pushed branch, no PR
 #
 # Fail-open semantics are preserved: any condition that prevents confident
@@ -542,20 +554,20 @@ _worker_produced_output() {
 		return 0
 	fi
 
-	# Signal 3 (t3195 / GH#21889): PR linked to this branch/issue. Helper
-	# uses --head primary (no search-index lag), --search fallback. Full
-	# rationale: shared-claim-lifecycle.sh::_pr_exists_for_branch_or_issue.
+	# Signal 3: exact-head lifecycle first; issue search is inconclusive fallback.
 	local issue_number=""
 	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
 	local repo_slug="${DISPATCH_REPO_SLUG:-}"
-	local pr_existence=""
-	if _worker_pr_is_draft_checkpoint "$branch_name" "$issue_number" "$repo_slug"; then
-		printf 'draft_checkpoint'
-		return 0
-	fi
-	pr_existence=$(_pr_exists_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")
-	case "$pr_existence" in
-		found) printf 'pr_exists'; return 0 ;;
+	local pr_handoff="unknown|"
+	local pr_state="unknown"
+	pr_handoff=$(_pr_handoff_state_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")
+	pr_state="${pr_handoff%%|*}"
+	case "$pr_state" in
+		ready | merged) printf 'pr_exists'; return 0 ;;
+		draft_checkpoint | protected_draft | ready_failed | closed_unmerged | unverified_open_pr)
+			printf '%s' "$pr_state"
+			return 0
+			;;
 		absent)
 			if [[ "$has_pushed_branch" -eq 1 ]]; then
 				printf 'branch_orphan'
@@ -568,43 +580,61 @@ _worker_produced_output() {
 	esac
 }
 
-_worker_pr_is_draft_checkpoint() {
-	local branch_name="$1"
-	local issue_number="$2"
-	local repo_slug="$3"
-	local pr_handoff=""
+#######################################
+# Escalate an exhausted draft or terminally failed ready PR. The claim is only
+# released after the blocking NMR label is applied and read back. Failed or
+# invisible transitions retain ownership so ordinary dispatch cannot race.
+# Args: $1=session key, $2=repo slug, $3=lifecycle state, $4=release reason
+#######################################
+_escalate_worker_pr_checkpoint() {
+	local session_key="$1"
+	local repo_slug="$2"
+	local lifecycle_state="$3"
+	local release_reason="${4:-$_HRW_REASON_DRAFT_CHECKPOINT}"
+	local issue_number=""
+	local runner_login=""
+	local -a transition_args=(--add-label "$_HRW_NMR_LABEL" --remove-label "auto-dispatch")
 
-	declare -F _pr_handoff_state_for_branch_or_issue >/dev/null 2>&1 || return 1
-	pr_handoff=$(_pr_handoff_state_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug" "$_HRW_PR_SCOPE_HEAD_ONLY")
-	[[ "${pr_handoff%%|*}" == "draft" ]] || return 1
+	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
+	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
+		_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_ESCALATION_FAILED"
+		print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — issue/repo unavailable; retaining claim"
+		return 0
+	fi
+	if declare -F _hrff_resolve_release_runner_login >/dev/null 2>&1; then
+		runner_login=$(_hrff_resolve_release_runner_login)
+		[[ -n "$runner_login" ]] && transition_args+=(--remove-assignee "$runner_login")
+	fi
+	if declare -F set_issue_status >/dev/null 2>&1; then
+		if ! set_issue_status "$issue_number" "$repo_slug" "" "${transition_args[@]}"; then
+			_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_ESCALATION_FAILED"
+			print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — blocking transition failed; retaining claim"
+			return 0
+		fi
+	elif ! gh issue edit "$issue_number" --repo "$repo_slug" \
+		--add-label "$_HRW_NMR_LABEL" --remove-label "auto-dispatch" >/dev/null 2>&1; then
+		_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_ESCALATION_FAILED"
+		print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — blocking transition failed; retaining claim"
+		return 0
+	fi
+	if ! _worker_pr_checkpoint_block_visible "$issue_number" "$repo_slug"; then
+		_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_ESCALATION_FAILED"
+		print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — blocking label not visible; retaining claim"
+		return 0
+	fi
+
+	_release_dispatch_claim "$session_key" "$release_reason"
+	_HRW_RECOVERY_CLASSIFICATION="$release_reason"
+	print_warning "[lifecycle] worker_pr_checkpoint_escalated session=${session_key} state=${lifecycle_state} — maintainer review required"
 	return 0
 }
 
-#######################################
-# Preserve an incomplete draft checkpoint and move it to explicit escalation.
-# Args: $1=session key, $2=issue number, $3=repo slug, $4=branch, $5=PR number
-#######################################
-_handle_worker_draft_checkpoint() {
-	local session_key="$1"
-	local issue_number="$2"
-	local repo_slug="$3"
-	local branch_name="$4"
-	local pr_number="$5"
-
-	print_info "[lifecycle] ${_HRW_REASON_DRAFT_CHECKPOINT} session=${session_key} branch=${branch_name:-unknown} pr=${pr_number:-unknown}"
-	if [[ -n "$issue_number" && -n "$repo_slug" ]]; then
-		if gh issue edit "$issue_number" --repo "$repo_slug" \
-			--add-label "needs-maintainer-review" \
-			--remove-label "status:queued" \
-			--remove-label "status:in-progress" >/dev/null 2>&1; then
-			_release_dispatch_claim "$session_key" "$_HRW_REASON_DRAFT_CHECKPOINT"
-			return 0
-		fi
-		print_warning "[lifecycle] draft checkpoint escalation write failed; preserving claim session=${session_key}"
-		return 0
-	fi
-	print_warning "[lifecycle] draft checkpoint escalation lacks issue/repo context; preserving claim session=${session_key}"
-	return 0
+_worker_pr_checkpoint_block_visible() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	gh issue view "$issue_number" --repo "$repo_slug" --json labels 2>/dev/null \
+		| jq -e --arg nmr "$_HRW_NMR_LABEL" '([.labels[]?.name] | index($nmr)) != null' >/dev/null 2>&1
+	return $?
 }
 
 # =============================================================================
@@ -928,25 +958,29 @@ _recover_worker_output_on_failure() {
 	default_branch=$(_hrw_resolve_default_branch "$work_dir")
 	[[ -z "$default_branch" ]] && default_branch="${DISPATCH_REPO_DEFAULT_BRANCH:-main}"
 
+	_HRW_RECOVERY_CLASSIFICATION=""
 	if [[ -n "$repo_slug" && -n "$issue_number" && -n "$branch_name" && "$branch_name" != "$_HRW_GIT_HEAD" && "$branch_name" != "$default_branch" ]] && \
 		declare -F _pr_handoff_state_for_branch_or_issue >/dev/null 2>&1; then
 		local pr_handoff="unknown|"
-		if declare -F _pr_handoff_state_for_branch_or_issue >/dev/null 2>&1; then
-			pr_handoff=$(_pr_handoff_state_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug" "$_HRW_PR_SCOPE_HEAD_ONLY")
-		fi
+		pr_handoff=$(_pr_handoff_state_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")
 		local pr_state="${pr_handoff%%|*}"
-		local pr_number="${pr_handoff#*|}"
 		if [[ "$pr_state" == "ready" || "$pr_state" == "merged" ]]; then
 			print_info "[lifecycle] worker_failure_recovered_existing_pr session=${session_key} branch=${branch_name}"
 			_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
+			_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_WORKER_COMPLETE"
 			return 0
 		fi
-		if [[ "$pr_state" == "draft" ]]; then
-			# A draft proves durability, not completion. Stop automatic dispatch so
-			# the incomplete exact-head checkpoint cannot race another implementation.
-			# This runs only after the bounded runtime continuation loop is exhausted.
-			_handle_worker_draft_checkpoint "$session_key" "$issue_number" "$repo_slug" "$branch_name" "$pr_number"
-			_HRW_FAILURE_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_CHECKPOINT"
+		if [[ "$pr_state" == "draft_checkpoint" ]]; then
+			_escalate_worker_pr_checkpoint "$session_key" "$repo_slug" "$pr_state"
+			return 0
+		fi
+		if [[ "$pr_state" == "ready_failed" ]]; then
+			_escalate_worker_pr_checkpoint "$session_key" "$repo_slug" "$pr_state" "$_HRW_REASON_READY_FAILED"
+			return 0
+		fi
+		if [[ "$pr_state" == "protected_draft" || "$pr_state" == "unverified_open_pr" ]]; then
+			_HRW_RECOVERY_CLASSIFICATION="worker_${pr_state}"
+			print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — not completion evidence; retaining claim"
 			return 0
 		fi
 	fi
@@ -1242,7 +1276,7 @@ _hrw_run_finish_crash_type() {
 		# Model attempted real work (read files, created worktree) but couldn't
 		# produce commits/PR. This is "overwhelmed" — the model tried and failed
 		# due to task complexity, not infra issues.
-		printf '%s\n' "overwhelmed"
+		printf '%s\n' "$_HRW_CRASH_OVERWHELMED"
 		;;
 	no_activity)
 		# No LLM output at all — infra/setup failure.
@@ -1270,22 +1304,24 @@ _hrw_finish_failed_run() {
 	else
 		_release_dispatch_claim "$session_key" "worker_failed"
 	fi
-	if [[ "$failure_recovered" -eq 1 ]]; then
-		if [[ "${_HRW_FAILURE_RECOVERY_CLASSIFICATION:-}" == "$_HRW_REASON_DRAFT_CHECKPOINT" ]]; then
-			_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
-			_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
-			_HRW_FINAL_RUNTIME_STATUS="escalated"
-			_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_REASON_DRAFT_CHECKPOINT"
-		else
-			_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
-			_HRW_FINAL_RUNTIME_EVENT="worker.completed"
-			_HRW_FINAL_RUNTIME_STATUS="recovered"
-			_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_REASON_WORKER_COMPLETE"
+	if [[ "$failure_recovered" -eq 1 && "${_HRW_RECOVERY_CLASSIFICATION:-$_HRW_REASON_WORKER_COMPLETE}" == "$_HRW_REASON_WORKER_COMPLETE" ]]; then
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
+		_HRW_FINAL_RUNTIME_EVENT="worker.completed"
+		_HRW_FINAL_RUNTIME_STATUS="recovered"
+		_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_REASON_WORKER_COMPLETE"
+	elif [[ -n "${_HRW_RECOVERY_CLASSIFICATION:-}" ]]; then
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
+		_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_FAILED"
+		_HRW_FINAL_RUNTIME_STATUS="$_HRW_STATUS_FAILED"
+		if [[ "$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_DRAFT_CHECKPOINT" || \
+			"$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_READY_FAILED" ]]; then
+			_HRW_FINAL_RUNTIME_STATUS="$_HRW_STATUS_ESCALATED"
 		fi
+		_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_RECOVERY_CLASSIFICATION"
 	else
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
-		_HRW_FINAL_RUNTIME_EVENT="worker.failed"
-		_HRW_FINAL_RUNTIME_STATUS="$_HRW_TELEMETRY_FAILED"
+		_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_FAILED"
+		_HRW_FINAL_RUNTIME_STATUS="$_HRW_STATUS_FAILED"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="${_run_failure_reason:-worker_failed}"
 	fi
 
@@ -1340,13 +1376,24 @@ _hrw_record_terminal_outcome() {
 	return 0
 }
 
+_hrw_mark_failed_terminal_state() {
+	local status="$1"
+	local classification="$2"
+	_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_FAILED"
+	_HRW_FINAL_RUNTIME_STATUS="$status"
+	_HRW_FINAL_RUNTIME_CLASSIFICATION="$classification"
+	_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
+	return 0
+}
+
 _hrw_finish_success_run() {
 	local session_key="$1"
 	local work_dir="$2"
 	local release_needed=1
 
 	# GH#20721 + GH#20819: Classify worker output quality.
-	# _worker_produced_output echoes one of six classifications:
+	# _worker_produced_output distinguishes exact-head completion from drafts,
+	# failed checks, closed PRs, and inconclusive issue-search matches.
 	#   noop                  — no commits, no branch, no PR → fast-fail
 	#   branch_orphan         — branch pushed but no PR → auto-recover
 	#   local_branch_unpushed — local commits but no remote branch/PR → push+recover
@@ -1366,10 +1413,7 @@ _hrw_finish_success_run() {
 			_release_dispatch_claim "$session_key" "worker_noop"
 			_report_failure_to_fast_fail "$session_key" "worker_noop_zero_output" "$_HRW_CRASH_NO_WORK"
 			release_needed=0
-			_HRW_FINAL_RUNTIME_EVENT="worker.failed"
-			_HRW_FINAL_RUNTIME_STATUS="$_HRW_TELEMETRY_FAILED"
-			_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_CRASH_NO_WORK"
-			_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
+			_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_CRASH_NO_WORK"
 			;;
 		branch_orphan)
 			_handle_worker_branch_orphan "$session_key" "$work_dir"
@@ -1384,17 +1428,35 @@ _hrw_finish_success_run() {
 			release_needed=0
 			;;
 		draft_checkpoint)
-			local draft_issue_number=""
-			local draft_branch_name=""
-			local draft_handoff="draft|"
-			draft_issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
-			draft_branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-			draft_handoff=$(_pr_handoff_state_for_branch_or_issue "$draft_branch_name" "$draft_issue_number" "${DISPATCH_REPO_SLUG:-}" "$_HRW_PR_SCOPE_HEAD_ONLY")
-			_handle_worker_draft_checkpoint "$session_key" "$draft_issue_number" "${DISPATCH_REPO_SLUG:-}" "$draft_branch_name" "${draft_handoff#*|}"
+			_escalate_worker_pr_checkpoint "$session_key" "${DISPATCH_REPO_SLUG:-}" "$output_class"
 			release_needed=0
-			_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
-			_HRW_FINAL_RUNTIME_STATUS="escalated"
-			_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_REASON_DRAFT_CHECKPOINT"
+			if [[ "$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_DRAFT_CHECKPOINT" ]]; then
+				_hrw_mark_failed_terminal_state "$_HRW_STATUS_ESCALATED" "$_HRW_RECOVERY_CLASSIFICATION"
+			else
+				_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_RECOVERY_CLASSIFICATION"
+			fi
+			;;
+		ready_failed)
+			_escalate_worker_pr_checkpoint "$session_key" "${DISPATCH_REPO_SLUG:-}" "$output_class" "$_HRW_REASON_READY_FAILED"
+			release_needed=0
+			if [[ "$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_READY_FAILED" ]]; then
+				_hrw_mark_failed_terminal_state "$_HRW_STATUS_ESCALATED" "$_HRW_RECOVERY_CLASSIFICATION"
+			else
+				_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_RECOVERY_CLASSIFICATION"
+			fi
+			;;
+		closed_unmerged)
+			print_warning "[lifecycle] ${_HRW_REASON_CLOSED_UNMERGED} session=${session_key} — closed PR is not completion evidence"
+			_release_dispatch_claim "$session_key" "$_HRW_REASON_CLOSED_UNMERGED"
+			_report_failure_to_fast_fail "$session_key" "$_HRW_REASON_CLOSED_UNMERGED" "$_HRW_CRASH_OVERWHELMED"
+			release_needed=0
+			_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_REASON_CLOSED_UNMERGED"
+			;;
+		protected_draft | unverified_open_pr)
+			local noncomplete_reason="worker_${output_class}"
+			print_warning "[lifecycle] ${noncomplete_reason} session=${session_key} — protected/inconclusive PR state is not completion evidence; retaining claim"
+			release_needed=0
+			_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$noncomplete_reason"
 			;;
 		esac
 	fi
@@ -1436,6 +1498,7 @@ _cmd_run_finish() {
 	_HRW_FINAL_RUNTIME_STATUS="${_run_result_label:-$ledger_status}"
 	_HRW_FINAL_RUNTIME_CLASSIFICATION="${_run_failure_reason:-}"
 	_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
+	_HRW_RECOVERY_CLASSIFICATION=""
 
 	# Release the dispatch claim so the issue is immediately available for
 	# re-dispatch (next 2-min pulse cycle) instead of waiting for the
@@ -1455,7 +1518,7 @@ _cmd_run_finish() {
 		_hrw_finish_failed_run "$session_key" "$work_dir"
 	elif [[ "$ledger_status" == "rate_limit_fast" ]]; then
 		_hrw_finish_rate_limit_fast_run "$session_key"
-		_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
+		_HRW_FINAL_RUNTIME_EVENT="worker.deferred"
 		_HRW_FINAL_RUNTIME_STATUS="rate_limit_fast"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="rate_limit"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -147,7 +147,7 @@ _release_interactive_claim_on_merge() {
 }
 
 #######################################
-# _pr_exists_for_branch_or_issue — Probe for an existing PR (t3195 / GH#21889)
+# Classify the lifecycle state of an exact-head PR or an issue-search fallback.
 #
 # Determines whether a PR exists for a given head branch and/or linked issue.
 # Uses `gh_pr_list --head <branch> --state all` as the PRIMARY signal because
@@ -169,89 +169,38 @@ _release_interactive_claim_on_merge() {
 #   $2 = issue_number  (may be empty)
 #   $3 = repo_slug     (e.g. "owner/repo")
 #
-# Echoes one of:
-#   "found"   — at least one PR exists for the head branch (or issue match)
-#   "absent"  — definitive zero matches (caller may classify as branch_orphan)
-#   "unknown" — cannot evaluate (no inputs / repo_slug missing) — fail-open
-#
-# Always returns 0. gh CLI failures on either probe are silently treated as
-# zero matches for that probe — the helper continues to the fallback or
-# returns "absent" (callers fail-open via "unknown" only when no probe ran).
-#######################################
-_pr_exists_for_branch_or_issue() {
-	local branch_name="$1"
-	local issue_number="$2"
-	local repo_slug="$3"
-
-	if [[ -z "$repo_slug" ]]; then
-		printf 'unknown'
-		return 0
-	fi
-
-	# Primary: --head match (no search-index lag, hits pulls API directly).
-	if [[ -n "$branch_name" ]]; then
-		local pr_count_head=0
-		pr_count_head=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" \
-			--state all --json number --jq 'length' 2>/dev/null || true)
-		[[ "$pr_count_head" =~ ^[0-9]+$ ]] || pr_count_head=0
-		if [[ "$pr_count_head" -gt 0 ]]; then
-			printf 'found'
-			return 0
-		fi
-	fi
-
-	# Fallback: --search by issue_number when --head missed (or branch unknown).
-	# Search-index lag is acceptable here because the primary --head probe
-	# already returned zero — this is the second-chance covering cases where
-	# the actual pushed branch differs from the detected branch_name.
-	if [[ -n "$issue_number" ]]; then
-		local pr_count_search=0
-		pr_count_search=$(gh_pr_list --repo "$repo_slug" --search "$issue_number" \
-			--json number --jq 'length' 2>/dev/null || true)
-		[[ "$pr_count_search" =~ ^[0-9]+$ ]] || pr_count_search=0
-		if [[ "$pr_count_search" -gt 0 ]]; then
-			printf 'found'
-			return 0
-		fi
-	fi
-
-	# Both probes returned zero (or only one ran and returned zero) — definitive
-	# absence. Distinct from "unknown" because we DID actually query.
-	if [[ -n "$branch_name" || -n "$issue_number" ]]; then
-		printf 'absent'
-		return 0
-	fi
-
-	# No usable inputs — fail-open with "unknown".
-	printf 'unknown'
-	return 0
-}
-
-#######################################
-# Resolve the lifecycle state of the PR for a worker branch or issue.
-#
-# Unlike _pr_exists_for_branch_or_issue, this helper preserves the distinction
-# between a durable draft checkpoint and a completed handoff. The live head
-# query remains primary so newly-created PRs are not hidden by search lag.
-#
-# Args: $1=branch name, $2=issue number, $3=repo slug,
-#       $4=scope (optional: "head-only" disables issue-search fallback)
-# Output: "draft|N", "ready|N", "merged|N", "closed|N", "absent|", or
-#         "unknown|". Returns 0 always.
+# Exact-head output states:
+#   ready | ready_failed | merged | closed_unmerged | draft_checkpoint |
+#   protected_draft
+# Issue-search matches are deliberately `unverified_open_pr`: search can return
+# a sibling or stale index hit and therefore proves dedup, never completion.
+# Every state is emitted as "state|PR_NUMBER"; absent/unknown have no number.
 #######################################
 _pr_handoff_state_from_json() {
 	local pr_json="$1"
-	printf '%s' "$pr_json" | jq -r --arg closed "CLO""SED" '
+	printf '%s' "$pr_json" | jq -r '
+		def label_names: [.labels[]?.name];
+		def worker_owned: label_names | any(. == "origin:worker" or . == "origin:worker-takeover");
+		def protected: label_names | any(
+			. == "origin:interactive" or . == "hold-for-review" or
+			. == "no-auto-dispatch" or . == "needs-maintainer-review"
+		);
+		def terminal_failure:
+			[.statusCheckRollup[]? |
+				(.conclusion // .status // .state // empty) | ascii_upcase] |
+			any(. == "FAILURE" or . == "ERROR" or . == "CANCELLED" or
+				. == "TIMED_OUT" or . == "ACTION_REQUIRED" or . == "STALE");
 		def rank:
-			if .state == "OPEN" and (.isDraft // false | not) then 0
-			elif .state == "OPEN" then 1
-			elif .state == "MERGED" then 2
-			else 3 end;
+			if .state == "OPEN" then 0
+			elif .state == "MERGED" or ((.mergedAt // "") | length) > 0 then 1
+			else 2 end;
 		sort_by(rank) | .[0]
 		| if . == null then ""
-		elif .state == "MERGED" then "merged|\(.number)"
-		elif .state == $closed then "closed|\(.number)"
-		elif (.isDraft // false) then "draft|\(.number)"
+		elif .state == "MERGED" or ((.mergedAt // "") | length) > 0 then "merged|\(.number)"
+		elif .state != "OPEN" then "closed_unmerged|\(.number)"
+		elif (.isDraft // false) and worker_owned and (protected | not) then "draft_checkpoint|\(.number)"
+		elif (.isDraft // false) then "protected_draft|\(.number)"
+		elif terminal_failure then "ready_failed|\(.number)"
 		else "ready|\(.number)" end' 2>/dev/null || true
 	return 0
 }
@@ -264,6 +213,7 @@ _pr_handoff_state_for_branch_or_issue() {
 	local pr_json=""
 	local pr_state=""
 	local queried=0
+	local probe_failed=0
 
 	if [[ -z "$repo_slug" ]]; then
 		printf 'unknown|'
@@ -272,33 +222,57 @@ _pr_handoff_state_for_branch_or_issue() {
 
 	if [[ -n "$branch_name" ]]; then
 		if pr_json=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state all \
-			--limit 10 --json number,state,isDraft 2>/dev/null); then
+			--limit 10 --json number,state,isDraft,mergedAt,labels,statusCheckRollup 2>/dev/null); then
 			queried=1
 			pr_state=$(_pr_handoff_state_from_json "$pr_json")
 			if [[ -n "$pr_state" ]]; then
 				printf '%s' "$pr_state"
 				return 0
 			fi
+		else
+			probe_failed=1
 		fi
 	fi
 
 	if [[ -n "$issue_number" && "$match_scope" != "head-only" ]]; then
-		if pr_json=$(gh_pr_list --repo "$repo_slug" --search "$issue_number" --state all \
-			--limit 10 --json number,state,isDraft 2>/dev/null); then
+		if pr_json=$(gh_pr_list --repo "$repo_slug" --search "#${issue_number} in:body" --state open \
+			--limit 10 --json number 2>/dev/null); then
 			queried=1
-			pr_state=$(_pr_handoff_state_from_json "$pr_json")
+			pr_state=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null || true)
 			if [[ -n "$pr_state" ]]; then
-				printf '%s' "$pr_state"
+				printf 'unverified_open_pr|%s' "$pr_state"
 				return 0
 			fi
+		else
+			probe_failed=1
 		fi
 	fi
 
-	if [[ "$queried" -eq 1 ]]; then
+	if [[ "$queried" -eq 1 && "$probe_failed" -eq 0 ]]; then
 		printf 'absent|'
 	else
 		printf 'unknown|'
 	fi
+	return 0
+}
+
+#######################################
+# Compatibility existence probe for dedup/orphan recovery callers.
+# Any lifecycle evidence blocks creation of a competing PR, but only an exact
+# ready/merged state may be interpreted as completion by richer callers.
+#######################################
+_pr_exists_for_branch_or_issue() {
+	local branch_name="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	local handoff_state=""
+
+	handoff_state=$(_pr_handoff_state_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")
+	case "${handoff_state%%|*}" in
+	absent) printf 'absent' ;;
+	unknown) printf 'unknown' ;;
+	*) printf 'found' ;;
+	esac
 	return 0
 }
 
@@ -381,11 +355,14 @@ _ensure_orphan_recovery_branch_remote() {
 		return 1
 	fi
 
-	local pr_existence=""
-	pr_existence=$(_pr_exists_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")
-	if [[ "$pr_existence" == "found" ]]; then
+	local pr_handoff=""
+	pr_handoff=$(_pr_handoff_state_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")
+	if [[ "${pr_handoff%%|*}" == "ready" || "${pr_handoff%%|*}" == "merged" ]]; then
 		printf 'pr_found'
 		return 0
+	fi
+	if [[ "${pr_handoff%%|*}" != "absent" ]]; then
+		return 1
 	fi
 	printf 'published'
 	return 0
@@ -503,10 +480,13 @@ _attempt_orphan_recovery_pr() {
 	#     path. Note: after PR #21902 fixed signal-3 to use --head primary, the
 	#     original search-index-lag motivation no longer applies; race-condition
 	#     defense is now the primary justification for this check.
-	local pr_existence=""
-	pr_existence=$(_pr_exists_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")
-	if [[ "$pr_existence" == "found" ]]; then
+	local pr_handoff=""
+	pr_handoff=$(_pr_handoff_state_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")
+	if [[ "${pr_handoff%%|*}" == "ready" || "${pr_handoff%%|*}" == "merged" ]]; then
 		return 0
+	fi
+	if [[ "${pr_handoff%%|*}" != "absent" ]]; then
+		return 1
 	fi
 
 	# Past this point recovery needs a branch to create a PR. Existing PRs were

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -288,16 +288,22 @@ test_has_open_pr_detects_open_body_closing_keyword() {
 	return 0
 }
 
-test_has_open_pr_ignores_draft_body_closing_keyword() {
-	set_gh_fixtures 'marcusquinn/aidevops|open|#18779 in:body|[{"number":18906,"body":"Resolves #18779. Incomplete worker checkpoint.","isDraft":true}]'
+test_has_open_pr_blocks_draft_body_closing_keyword() {
+	set_gh_fixtures 'marcusquinn/aidevops|open|#18779|[{"number":18906,"title":"Worker checkpoint for #18779","body":"Resolves #18779. Incomplete worker checkpoint.","isDraft":true,"reviewDecision":"REVIEW_REQUIRED","mergeStateStatus":"UNKNOWN"}]
+marcusquinn/aidevops|open|#18779 in:body|[{"number":18906,"body":"Resolves #18779. Incomplete worker checkpoint.","isDraft":true}]'
 
-	if "$HELPER_SCRIPT" has-open-pr 18779 marcusquinn/aidevops 't2071: incomplete checkpoint'; then
-		print_result "has-open-pr ignores draft checkpoint closing keyword" 1 \
-			"Expected draft checkpoint not to count as a completed handoff"
+	local output=""
+	if output=$("$HELPER_SCRIPT" has-open-pr 18779 marcusquinn/aidevops 't2071: incomplete checkpoint'); then
+		if [[ "$output" == *"draft PR #18906 is a durable checkpoint"* ]]; then
+			print_result "has-open-pr blocks competing dispatch for draft checkpoint" 0
+			return 0
+		fi
+		print_result "has-open-pr blocks competing dispatch for draft checkpoint" 1 "Unexpected output: ${output}"
 		return 0
 	fi
 
-	print_result "has-open-pr ignores draft checkpoint closing keyword" 0
+	print_result "has-open-pr blocks competing dispatch for draft checkpoint" 1 \
+		"Expected durable draft checkpoint to block ordinary redispatch"
 	return 0
 }
 
@@ -451,15 +457,13 @@ test_has_open_pr_blocks_behind_healthy_sibling() {
 }
 
 test_has_open_pr_allows_when_no_healthy_sibling() {
-	# Blocked siblings (draft, changes-requested, conflicting, or unknown without
-	# approval) must not hold the issue forever. They are not candidates the merge
-	# path can finish safely, so redispatch remains allowed when no other PR
-	# evidence exists.
-	set_gh_fixtures 'marcusquinn/aidevops|open|#23251|[{"number":23289,"title":"Draft sibling","body":"For #23251.","isDraft":true,"reviewDecision":"APPROVED","mergeStateStatus":"CLEAN"},{"number":23290,"title":"Needs changes","body":"For #23251.","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","mergeStateStatus":"CLEAN"},{"number":23291,"title":"Conflicting sibling","body":"For #23251.","isDraft":false,"reviewDecision":"APPROVED","mergeStateStatus":"DIRTY"},{"number":23297,"title":"Unknown sibling","body":"For #23251.","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","mergeStateStatus":"UNKNOWN"}]'
+	# Changes-requested, conflicting, or unknown ready siblings are not durable
+	# draft checkpoints and are not candidates the merge path can finish safely.
+	set_gh_fixtures 'marcusquinn/aidevops|open|#23251|[{"number":23290,"title":"Needs changes","body":"For #23251.","isDraft":false,"reviewDecision":"CHANGES_REQUESTED","mergeStateStatus":"CLEAN"},{"number":23291,"title":"Conflicting sibling","body":"For #23251.","isDraft":false,"reviewDecision":"APPROVED","mergeStateStatus":"DIRTY"},{"number":23297,"title":"Unknown sibling","body":"For #23251.","isDraft":false,"reviewDecision":"REVIEW_REQUIRED","mergeStateStatus":"UNKNOWN"}]'
 
 	if "$HELPER_SCRIPT" has-open-pr 23251 marcusquinn/aidevops 't3501: allow unhealthy sibling recovery'; then
 		print_result "has-open-pr allows dispatch when no healthy sibling exists" 1 \
-			"Expected exit 1: draft/changes-requested/conflicting/unknown siblings must not block redispatch"
+			"Expected exit 1: changes-requested/conflicting/unknown ready siblings must not block redispatch"
 		return 0
 	fi
 
@@ -567,7 +571,7 @@ main() {
 	test_has_open_pr_requires_close_keyword_for_our_issue
 	test_has_open_pr_allows_dispatch_on_task_id_collision
 	test_has_open_pr_detects_open_body_closing_keyword
-	test_has_open_pr_ignores_draft_body_closing_keyword
+	test_has_open_pr_blocks_draft_body_closing_keyword
 	test_has_open_pr_ignores_open_body_planning_for_reference
 	test_has_open_pr_requires_open_close_keyword_for_our_issue
 	test_has_open_pr_blocks_approved_mergeable_sibling

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh
@@ -102,6 +102,20 @@ _stale_recovery_escalate() {
 	return 0
 }
 
+_stale_recovery_escalate_pr_checkpoint() {
+	local _issue_number="$1"
+	local _repo_slug="$2"
+	local _stale_assignees="$3"
+	local _reason="$4"
+	local _pr_number="$5"
+	local _dispatch_ts="$6"
+	local _kind="$7"
+	: "$_issue_number" "$_repo_slug" "$_stale_assignees" "$_dispatch_ts"
+	ESCALATED=1
+	ESCALATION_REASON="${_kind}:${_pr_number}:${_reason}"
+	return 0
+}
+
 _stale_recovery_apply() {
 	local _issue_number="$1"
 	local _repo_slug="$2"
@@ -130,14 +144,14 @@ fi
 ESCALATED=0
 RECOVERED=0
 ESCALATION_REASON=""
-OPEN_PR_STATE="draft|456"
+OPEN_PR_STATE="456|draft_checkpoint"
 COMMENTS_JSON='[[
   {"created_at":"2026-05-04T12:43:16Z","body":"DISPATCH_CLAIM nonce=fresh runner=runner ts=2026-05-04T12:43:16Z"}
 ]]'
 
 _recover_stale_assignment 3978 owner/repo runner "worker lease expired"
 
-if [[ "$ESCALATED" -eq 1 && "$RECOVERED" -eq 0 && "$ESCALATION_REASON" == *"incomplete draft PR #456"* ]]; then
+if [[ "$ESCALATED" -eq 1 && "$RECOVERED" -eq 0 && "$ESCALATION_REASON" == "draft_checkpoint:456:worker lease expired" ]]; then
 	pass "stale draft checkpoint escalates without competing redispatch"
 else
 	fail "stale draft checkpoint escalates without competing redispatch" \

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -12,6 +12,13 @@ readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
 readonly TEST_RESET='\033[0m'
 
+# Bypass the aidevops git policy shim for disposable repositories created under
+# this test's isolated temporary HOME.
+git() {
+	command -p git "$@"
+	return $?
+}
+
 TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
@@ -2051,7 +2058,14 @@ test_worker_produced_output_branch_with_pr_returns_pr_exists() {
 	_setup_test_git_repo "$work_dir" 1
 	git -C "$work_dir" push -q origin "feature/auto-test-issue-99999"
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
-	gh() { printf '1'; return 0; }  # Stub gh: 1 PR found
+	gh() {
+		if [[ "${*}" == *"--head"* && "${*}" == *"statusCheckRollup"* ]]; then
+			printf '%s\n' '[{"number":123,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]'
+		else
+			printf '%s\n' '[]'
+		fi
+		return 0
+	}
 
 	local classification
 	classification=$(_worker_produced_output "issue-99999" "$work_dir")
@@ -2391,18 +2405,19 @@ test_cmd_run_finish_local_unpushed_pushes_and_recovers_pr() {
 	return 0
 }
 
-test_handle_worker_branch_orphan_empty_branch_existing_pr_releases_complete() {
+test_handle_worker_branch_orphan_empty_branch_issue_search_is_not_complete() {
 	local work_dir="${TEST_ROOT}/repo-finish-orphan-cleaned"
 	mkdir -p "$work_dir"
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
 
-	# Stub gh: empty branch skips --head and falls back to issue search; existing PR found.
+	# Empty branch forces issue-search fallback, which is dedup evidence but cannot
+	# prove an exact-head completed handoff.
 	gh() {
-		if [[ "${*}" == *"pr list"* && "${*}" == *"--search 99999"* ]]; then
-			printf '1'
+		if [[ "${*}" == *"pr list"* && "${*}" == *"--search #99999 in:body"* ]]; then
+			printf '%s\n' '[{"number":123}]'
 			return 0
 		fi
-		printf '0'
+		printf '%s\n' '[]'
 		return 0
 	}
 
@@ -2415,11 +2430,11 @@ test_handle_worker_branch_orphan_empty_branch_existing_pr_releases_complete() {
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 
-	if [[ "$released_reason" == "worker_complete" ]]; then
-		print_result "_handle_worker_branch_orphan treats empty-branch existing PR as complete" 0
+	if [[ "$released_reason" == "worker_branch_orphan" ]]; then
+		print_result "_handle_worker_branch_orphan does not complete from issue-search fallback" 0
 	else
-		print_result "_handle_worker_branch_orphan treats empty-branch existing PR as complete" 1 \
-			"Expected worker_complete (existing PR found by issue search), got '${released_reason}'"
+		print_result "_handle_worker_branch_orphan does not complete from issue-search fallback" 1 \
+			"Expected worker_branch_orphan for inconclusive issue search, got '${released_reason}'"
 	fi
 	return 0
 }
@@ -2731,22 +2746,122 @@ test_failed_worker_draft_checkpoint_escalates_without_completion() {
 				return 0
 			}
 			_hrw_resolve_default_branch() { printf 'main'; return 0; }
-			_pr_handoff_state_for_branch_or_issue() { printf 'draft|456'; return 0; }
+			_pr_handoff_state_for_branch_or_issue() { printf 'draft_checkpoint|456'; return 0; }
 			_release_dispatch_claim() { printf 'release=%s\n' "$2"; return 0; }
+			set_issue_status() { : >"$escalation_marker"; return 0; }
 			gh() {
-				if [[ "${*}" == *"issue edit 99999"* && "${*}" == *"needs-maintainer-review"* ]]; then
-					: >"$escalation_marker"
+				if [[ "${*}" == *"issue view 99999"* ]]; then
+					printf '%s\n' '{"labels":[{"name":"needs-maintainer-review"}]}'
 				fi
 				return 0
 			}
 			_recover_worker_output_on_failure "issue-99999" "${TEST_ROOT}"
-			printf 'classification=%s\n' "${_HRW_FAILURE_RECOVERY_CLASSIFICATION:-}"
+			printf 'classification=%s\n' "${_HRW_RECOVERY_CLASSIFICATION:-}"
 		)
 	)
 	if [[ "$result" == *"release=worker_draft_checkpoint"* && -f "$escalation_marker" && "$result" == *"classification=worker_draft_checkpoint"* ]]; then
 		print_result "failed worker draft checkpoint escalates without worker_complete" 0
 	else
 		print_result "failed worker draft checkpoint escalates without worker_complete" 1 "$result"
+	fi
+	return 0
+}
+
+test_failed_worker_draft_retains_claim_when_block_not_visible() {
+	local result=""
+	result=$(
+		(
+			DISPATCH_REPO_SLUG="test-owner/test-repo"
+			git() {
+				[[ "${*}" == *"rev-parse --abbrev-ref HEAD"* ]] && printf 'feature/auto-test-issue-99999'
+				return 0
+			}
+			_hrw_resolve_default_branch() { printf 'main'; return 0; }
+			_pr_handoff_state_for_branch_or_issue() { printf 'draft_checkpoint|456'; return 0; }
+			set_issue_status() { return 0; }
+			gh() { printf '%s\n' '{"labels":[]}'; return 0; }
+			_release_dispatch_claim() { printf 'unexpected-release=%s\n' "$2"; return 0; }
+			_recover_worker_output_on_failure "issue-99999" "${TEST_ROOT}"
+			printf 'classification=%s\n' "${_HRW_RECOVERY_CLASSIFICATION:-}"
+		)
+	)
+	if [[ "$result" == *"classification=worker_draft_checkpoint_escalation_failed"* && "$result" != *"unexpected-release="* ]]; then
+		print_result "draft checkpoint retains claim when blocking label read-back fails" 0
+	else
+		print_result "draft checkpoint retains claim when blocking label read-back fails" 1 "$result"
+	fi
+	return 0
+}
+
+test_protected_draft_is_not_mutated_or_completed() {
+	local result=""
+	result=$(
+		(
+			DISPATCH_REPO_SLUG="test-owner/test-repo"
+			git() {
+				[[ "${*}" == *"rev-parse --abbrev-ref HEAD"* ]] && printf 'feature/auto-test-issue-99999'
+				return 0
+			}
+			_hrw_resolve_default_branch() { printf 'main'; return 0; }
+			_pr_handoff_state_for_branch_or_issue() { printf 'protected_draft|458'; return 0; }
+			set_issue_status() { printf 'unexpected-mutation\n'; return 0; }
+			_release_dispatch_claim() { printf 'unexpected-release=%s\n' "$2"; return 0; }
+			_recover_worker_output_on_failure "issue-99999" "${TEST_ROOT}"
+			printf 'classification=%s\n' "${_HRW_RECOVERY_CLASSIFICATION:-}"
+		)
+	)
+	if [[ "$result" == *"classification=worker_protected_draft"* && "$result" != *"unexpected-mutation"* && "$result" != *"unexpected-release="* ]]; then
+		print_result "protected draft is neither mutated nor reported complete" 0
+	else
+		print_result "protected draft is neither mutated nor reported complete" 1 "$result"
+	fi
+	return 0
+}
+
+test_checkpoint_terminal_telemetry_is_failed_escalated() {
+	local fixture_class result expected_reason
+	for fixture_class in draft_checkpoint ready_failed; do
+		if [[ "$fixture_class" == "draft_checkpoint" ]]; then
+			expected_reason="worker_draft_checkpoint"
+		else
+			expected_reason="worker_ready_failed"
+		fi
+		result=$(
+			(
+				_worker_produced_output() { printf '%s' "$fixture_class"; return 0; }
+				_escalate_worker_pr_checkpoint() { _HRW_RECOVERY_CLASSIFICATION="$expected_reason"; return 0; }
+				_hrw_finish_success_run "issue-99999" "${TEST_ROOT}"
+				printf '%s|%s|%s|%s' "$_HRW_TERMINAL_OUTCOME" "$_HRW_FINAL_RUNTIME_EVENT" \
+					"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
+			)
+		)
+		if [[ "$result" == "failed|worker.failed|escalated|${expected_reason}" ]]; then
+			print_result "${fixture_class} records failed/escalated terminal telemetry" 0
+		else
+			print_result "${fixture_class} records failed/escalated terminal telemetry" 1 "$result"
+		fi
+	done
+	return 0
+}
+
+test_closed_unmerged_pr_is_failed_not_completed() {
+	local result=""
+	result=$(
+		(
+			_worker_produced_output() { printf 'closed_unmerged'; return 0; }
+			_release_dispatch_claim() { printf 'release=%s\n' "$2"; return 0; }
+			_report_failure_to_fast_fail() { return 0; }
+			_hrw_finish_success_run "issue-99999" "${TEST_ROOT}"
+			printf 'terminal=%s|%s|%s|%s\n' "$_HRW_TERMINAL_OUTCOME" "$_HRW_FINAL_RUNTIME_EVENT" \
+				"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
+		)
+	)
+	if [[ "$result" == *"release=worker_closed_unmerged_pr"* && \
+		"$result" == *"terminal=failed|worker.failed|failed|worker_closed_unmerged_pr"* && \
+		"$result" != *"release=worker_complete"* ]]; then
+		print_result "closed-unmerged PR records failure and never worker_complete" 0
+	else
+		print_result "closed-unmerged PR records failure and never worker_complete" 1 "$result"
 	fi
 	return 0
 }
@@ -2856,6 +2971,17 @@ test_completion_infrastructure_resumes_without_implementation_penalty() {
 	return 0
 }
 
+test_pr_checkpoint_lifecycle_cases() {
+	test_post_pr_handoff_detects_open_pending_pr
+	test_failed_worker_draft_checkpoint_escalates_without_completion
+	test_failed_worker_draft_retains_claim_when_block_not_visible
+	test_protected_draft_is_not_mutated_or_completed
+	test_checkpoint_terminal_telemetry_is_failed_escalated
+	test_closed_unmerged_pr_is_failed_not_completed
+	test_failed_worker_ready_pr_remains_completed_handoff
+	return 0
+}
+
 main() {
 	setup_test_env
 	test_appends_escalation_contract
@@ -2895,9 +3021,7 @@ main() {
 	test_failure_classifier_distinguishes_anthropic_credit_exhaustion
 	test_service_interruption_candidate_uses_separate_path
 	test_service_interruption_exhausted_metric_preserves_context
-	test_post_pr_handoff_detects_open_pending_pr
-	test_failed_worker_draft_checkpoint_escalates_without_completion
-	test_failed_worker_ready_pr_remains_completed_handoff
+	test_pr_checkpoint_lifecycle_cases
 	test_post_pr_handoff_rejects_pre_pr_stall
 	test_post_pr_handoff_overrides_watchdog_next_action
 	test_completion_infrastructure_resumes_without_implementation_penalty
@@ -2940,7 +3064,7 @@ main() {
 	test_build_orphan_recovery_pr_body_tolerates_missing_publish_flag
 	test_cmd_run_finish_orphan_recovery_success_emits_worker_complete
 	test_cmd_run_finish_local_unpushed_pushes_and_recovers_pr
-	test_handle_worker_branch_orphan_empty_branch_existing_pr_releases_complete
+	test_handle_worker_branch_orphan_empty_branch_issue_search_is_not_complete
 	test_cmd_run_finish_orphan_recovery_failure_emits_branch_orphan
 	test_cmd_run_finish_local_unpushed_push_failure_emits_distinct_reason
 	test_cmd_run_finish_fail_recovers_branch_orphan_output

--- a/.agents/scripts/tests/test-stale-recovery-escalation.sh
+++ b/.agents/scripts/tests/test-stale-recovery-escalation.sh
@@ -71,6 +71,9 @@ GH_CALLS_FILE="${TEST_ROOT}/gh_calls.log"
 write_stub_gh() {
 	local tick_count="${1:-0}"
 	local open_pr="${2:-}"
+	local transition_visible="${3:-1}"
+	local open_pr_number="${open_pr%%|*}"
+	local open_pr_kind="${open_pr#*|}"
 	: >"$GH_CALLS_FILE"
 
 	cat >"${STUB_DIR}/gh" <<STUBEOF
@@ -103,7 +106,13 @@ fi
 # gh pr list --state open ...
 # Returns open PR number if configured, empty if not
 if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
-	printf '%s\n' "${open_pr}"
+	case "${open_pr_kind}" in
+	ready) printf '%s\n' '[{"number":${open_pr_number},"isDraft":false,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' ;;
+	ready_failed) printf '%s\n' '[{"number":${open_pr_number},"isDraft":false,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"FAILURE"}]}]' ;;
+	draft_checkpoint) printf '%s\n' '[{"number":${open_pr_number},"isDraft":true,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' ;;
+	protected_draft) printf '%s\n' '[{"number":${open_pr_number},"isDraft":true,"labels":[{"name":"origin:interactive"}],"statusCheckRollup":[]}]' ;;
+	*) printf '%s\n' '[]' ;;
+	esac
 	exit 0
 fi
 
@@ -111,7 +120,15 @@ fi
 # remain silent successes.
 if [[ "\$1" == "issue" ]]; then
 	if [[ "\$2" == "view" && "\$*" == *"--json state,labels,assignees"* ]]; then
-		printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:available"}],"assignees":[]}'
+		if [[ "${open_pr}" == *"draft_checkpoint"* || "${open_pr}" == *"ready_failed"* ]]; then
+			if [[ "${transition_visible}" == "1" ]]; then
+				printf '%s\n' '{"state":"OPEN","labels":[{"name":"needs-maintainer-review"}],"assignees":[]}'
+			else
+				printf '%s\n' '{"state":"OPEN","labels":[],"assignees":[{"login":"stale-runner"}]}'
+			fi
+		else
+			printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:available"}],"assignees":[]}'
+		fi
 	fi
 	exit 0
 fi
@@ -136,7 +153,8 @@ rc=0
 run_recover() {
 	local tick_count="${1:-0}"
 	local open_pr="${2:-}"
-	write_stub_gh "$tick_count" "$open_pr"
+	local transition_visible="${3:-1}"
+	write_stub_gh "$tick_count" "$open_pr" "$transition_visible"
 	set +e
 	output=$(
 		STALE_ASSIGNMENT_THRESHOLD_SECONDS=0
@@ -228,7 +246,7 @@ fi
 # =============================================================================
 
 # 2 prior ticks, but open PR #42 is durable progress and must be preserved
-run_recover 2 "42"
+run_recover 2 "42|ready"
 
 if echo "$output" | grep -q "STALE_PROGRESS_PRESERVED"; then
 	print_result "Open PR path preserves durable progress without stale recovery" 0
@@ -259,6 +277,46 @@ if echo "$output" | grep -q "STALE_ESCALATED"; then
 	print_result "Above-threshold (3 prior ticks >= threshold 2): STALE_ESCALATED emitted" 0
 else
 	print_result "Above-threshold (3 prior ticks >= threshold 2): STALE_ESCALATED emitted" 1 "(got: '$output')"
+fi
+
+# =============================================================================
+# Test 6 — Worker draft escalates only after verified blocking transition
+# =============================================================================
+
+run_recover 0 "77|draft_checkpoint" 1
+if echo "$output" | grep -q "STALE_DRAFT_ESCALATED" && grep -q "needs-maintainer-review" "$GH_CALLS_FILE"; then
+	print_result "Worker draft checkpoint escalates after verified NMR read-back" 0
+else
+	print_result "Worker draft checkpoint escalates after verified NMR read-back" 1 "(got: '$output')"
+fi
+
+run_recover 0 "77|draft_checkpoint" 0
+if [[ "$rc" -ne 0 ]] && echo "$output" | grep -q "STALE_PR_ESCALATION_FAILED"; then
+	print_result "Worker draft retains ownership when NMR transition is invisible" 0
+else
+	print_result "Worker draft retains ownership when NMR transition is invisible" 1 "(rc=$rc got: '$output')"
+fi
+
+# =============================================================================
+# Test 7 — Protected drafts are never mutated
+# =============================================================================
+
+run_recover 0 "78|protected_draft"
+if echo "$output" | grep -q "STALE_DRAFT_PROTECTED" && ! grep -q "^issue edit" "$GH_CALLS_FILE"; then
+	print_result "Protected draft blocks recovery without automated mutation" 0
+else
+	print_result "Protected draft blocks recovery without automated mutation" 1 "(got: '$output')"
+fi
+
+# =============================================================================
+# Test 8 — Terminally failed ready PR escalates explicitly
+# =============================================================================
+
+run_recover 0 "79|ready_failed" 1
+if echo "$output" | grep -q "STALE_READY_FAILED_ESCALATED"; then
+	print_result "Ready PR with terminal failed checks escalates explicitly" 0
+else
+	print_result "Ready PR with terminal failed checks escalates explicitly" 1 "(got: '$output')"
 fi
 
 export PATH="$OLD_PATH"

--- a/.agents/scripts/tests/test-worker-output-classification-head-vs-search.sh
+++ b/.agents/scripts/tests/test-worker-output-classification-head-vs-search.sh
@@ -48,6 +48,13 @@
 
 set -uo pipefail
 
+# Bypass the aidevops git policy shim for disposable repositories created under
+# this test's isolated temporary HOME.
+git() {
+	command -p git "$@"
+	return $?
+}
+
 TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)" || exit 1
 LIB_SCRIPT="${TEST_SCRIPTS_DIR}/shared-claim-lifecycle.sh"
 
@@ -83,8 +90,8 @@ ORIGINAL_HOME="$HOME"
 export HOME="${TEST_ROOT}/home"
 mkdir -p "${HOME}/.aidevops/logs"
 
-# `gh` stub: we partition counts by probe type using STUB_HEAD_COUNT and
-# STUB_SEARCH_COUNT. Any other gh invocation prints empty JSON {} and exits 0
+# `gh` stub: lifecycle probes return real gh JSON shapes from STUB_HEAD_JSON and
+# STUB_SEARCH_JSON. Any other gh invocation prints empty JSON {} and exits 0
 # so source-time `gh api user` calls in dependent helpers don't crash.
 GH_STUB_DIR="${TEST_ROOT}/stubs"
 mkdir -p "$GH_STUB_DIR"
@@ -115,12 +122,19 @@ case "${1:-}" in
 	pr)
 		case "${2:-}" in
 			list)
-				if [[ "$json_fields" == "number,state,isDraft" ]]; then
+				if [[ "$mode" == "head" && "${STUB_HEAD_FAIL:-0}" == "1" ]]; then
+					exit 1
+				fi
+				if [[ "$json_fields" == "number,state,isDraft,mergedAt,labels,statusCheckRollup" ]]; then
 					if [[ "$mode" == "head" ]]; then
 						printf '%s\n' "${STUB_HEAD_JSON:-[]}"
 					else
 						printf '%s\n' "${STUB_SEARCH_JSON:-[]}"
 					fi
+					exit 0
+				fi
+				if [[ "$json_fields" == "number" && "$mode" == "search" ]]; then
+					printf '%s\n' "${STUB_SEARCH_JSON:-[]}"
 					exit 0
 				fi
 				if [[ "$mode" == "head" ]]; then
@@ -195,8 +209,8 @@ gh_pr_list() {
 # Case A: search-lag survival. --head returns 1, --search returns 0.
 # This is the regression case from t3195 / GH#21889.
 test_case_a_head_wins_over_search_lag() {
-	export STUB_HEAD_COUNT=1
-	export STUB_SEARCH_COUNT=0
+	export STUB_HEAD_JSON='[{"number":21885,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]'
+	export STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_pr_exists_for_branch_or_issue "feature/auto-foo" "21870" "owner/repo")
 	if [[ "$got" == "found" ]]; then
@@ -210,8 +224,8 @@ test_case_a_head_wins_over_search_lag() {
 
 # Case B: definitive absence. Both probes return 0.
 test_case_b_definitive_absence() {
-	export STUB_HEAD_COUNT=0
-	export STUB_SEARCH_COUNT=0
+	export STUB_HEAD_JSON='[]'
+	export STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_pr_exists_for_branch_or_issue "feature/real-orphan" "99999" "owner/repo")
 	if [[ "$got" == "absent" ]]; then
@@ -225,8 +239,8 @@ test_case_b_definitive_absence() {
 
 # Case C: search fallback when branch_name empty.
 test_case_c_search_fallback_empty_branch() {
-	export STUB_HEAD_COUNT=0  # never queried — branch is empty
-	export STUB_SEARCH_COUNT=1
+	export STUB_HEAD_JSON='[]'  # never queried — branch is empty
+	export STUB_SEARCH_JSON='[{"number":21885}]'
 	local got
 	got=$(_pr_exists_for_branch_or_issue "" "21870" "owner/repo")
 	if [[ "$got" == "found" ]]; then
@@ -240,8 +254,8 @@ test_case_c_search_fallback_empty_branch() {
 
 # Case D: no usable inputs → unknown.
 test_case_d_no_inputs_unknown() {
-	export STUB_HEAD_COUNT=0
-	export STUB_SEARCH_COUNT=0
+	export STUB_HEAD_JSON='[]'
+	export STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_pr_exists_for_branch_or_issue "" "" "owner/repo")
 	if [[ "$got" == "unknown" ]]; then
@@ -255,8 +269,8 @@ test_case_d_no_inputs_unknown() {
 
 # Case D2: empty repo_slug → unknown regardless of probes.
 test_case_d2_empty_repo_unknown() {
-	export STUB_HEAD_COUNT=1
-	export STUB_SEARCH_COUNT=1
+	export STUB_HEAD_JSON='[{"number":1}]'
+	export STUB_SEARCH_JSON='[{"number":1}]'
 	local got
 	got=$(_pr_exists_for_branch_or_issue "feature/foo" "21870" "")
 	if [[ "$got" == "unknown" ]]; then
@@ -268,12 +282,27 @@ test_case_d2_empty_repo_unknown() {
 	return 0
 }
 
+test_case_d3_failed_head_probe_is_unknown() {
+	export STUB_HEAD_FAIL=1
+	export STUB_HEAD_JSON='[]'
+	export STUB_SEARCH_JSON='[]'
+	local got
+	got=$(_pr_handoff_state_for_branch_or_issue "feature/api-failure" "21870" "owner/repo")
+	unset STUB_HEAD_FAIL
+	if [[ "$got" == "unknown|" ]]; then
+		print_result "failed exact-head probe plus empty search remains unknown" 0
+	else
+		print_result "failed exact-head probe plus empty search remains unknown" 1 "got: '$got'"
+	fi
+	return 0
+}
+
 test_case_draft_state_is_preserved() {
-	export STUB_HEAD_JSON='[{"number":321,"state":"OPEN","isDraft":true}]'
+	export STUB_HEAD_JSON='[{"number":321,"state":"OPEN","isDraft":true,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]'
 	export STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_pr_handoff_state_for_branch_or_issue "feature/checkpoint" "27501" "owner/repo")
-	if [[ "$got" == "draft|321" ]]; then
+	if [[ "$got" == "draft_checkpoint|321" ]]; then
 		print_result "draft PR is classified as durable checkpoint, not completed handoff" 0
 	else
 		print_result "draft PR is classified as durable checkpoint, not completed handoff" 1 "got: '$got'"
@@ -284,13 +313,13 @@ test_case_draft_state_is_preserved() {
 test_case_ready_and_terminal_states_are_preserved() {
 	local fixture expected got
 	for fixture in \
-		'[{"number":322,"state":"OPEN","isDraft":false}]' \
-		'[{"number":323,"state":"MERGED","isDraft":false}]' \
-		'[{"number":324,"state":"CLOSED","isDraft":false}]'; do
+		'[{"number":322,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[],"statusCheckRollup":[]}]' \
+		'[{"number":323,"state":"MERGED","isDraft":false,"mergedAt":"2026-07-13T00:00:00Z","labels":[],"statusCheckRollup":[]}]' \
+		'[{"number":324,"state":"CLOSED","isDraft":false,"mergedAt":null,"labels":[],"statusCheckRollup":[]}]'; do
 		case "$fixture" in
 			*322*) expected="ready|322" ;;
 			*323*) expected="merged|323" ;;
-			*) expected="closed|324" ;;
+			*) expected="closed_unmerged|324" ;;
 		esac
 		export STUB_HEAD_JSON="$fixture"
 		got=$(_pr_handoff_state_for_branch_or_issue "feature/checkpoint" "27501" "owner/repo")
@@ -307,20 +336,20 @@ test_case_head_only_does_not_capture_unrelated_issue_draft() {
 	export STUB_HEAD_JSON='[]'
 	export STUB_SEARCH_JSON='[{"number":325,"state":"OPEN","isDraft":true}]'
 	local got
-	got=$(_pr_handoff_state_for_branch_or_issue "feature/worker" "27501" "owner/repo" "head-only")
-	if [[ "$got" == "absent|" ]]; then
-		print_result "head-only worker lookup ignores unrelated issue-search draft" 0
+	got=$(_pr_handoff_state_for_branch_or_issue "feature/worker" "27501" "owner/repo")
+	if [[ "$got" == "unverified_open_pr|325" ]]; then
+		print_result "issue-search fallback remains inconclusive, not complete" 0
 	else
-		print_result "head-only worker lookup ignores unrelated issue-search draft" 1 "got: '$got'"
+		print_result "issue-search fallback remains inconclusive, not complete" 1 "got: '$got'"
 	fi
 	return 0
 }
 
 test_case_active_pr_wins_over_historical_pr() {
-	export STUB_HEAD_JSON='[{"number":326,"state":"CLOSED","isDraft":false},{"number":327,"state":"OPEN","isDraft":true}]'
+	export STUB_HEAD_JSON='[{"number":326,"state":"CLOSED","isDraft":false,"mergedAt":null,"labels":[],"statusCheckRollup":[]},{"number":327,"state":"OPEN","isDraft":true,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]'
 	local got
-	got=$(_pr_handoff_state_for_branch_or_issue "feature/reopened" "27501" "owner/repo" "head-only")
-	if [[ "$got" == "draft|327" ]]; then
+	got=$(_pr_handoff_state_for_branch_or_issue "feature/reopened" "27501" "owner/repo")
+	if [[ "$got" == "draft_checkpoint|327" ]]; then
 		print_result "active draft wins over historical closed PR on same head" 0
 	else
 		print_result "active draft wins over historical closed PR on same head" 1 "got: '$got'"
@@ -328,11 +357,47 @@ test_case_active_pr_wins_over_historical_pr() {
 	return 0
 }
 
+test_case_real_checkrun_and_statuscontext_failures() {
+	local fixture expected got
+	for fixture in \
+		'[{"number":328,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"__typename":"CheckRun","name":"tests","status":"COMPLETED","conclusion":"FAILURE"}]}]' \
+		'[{"number":329,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"__typename":"StatusContext","context":"ci/test","state":"ERROR"}]}]'; do
+		case "$fixture" in
+			*328*) expected="ready_failed|328" ;;
+			*) expected="ready_failed|329" ;;
+		esac
+		export STUB_HEAD_JSON="$fixture"
+		export STUB_SEARCH_JSON='[]'
+		got=$(_pr_handoff_state_for_branch_or_issue "feature/failed-checks" "27517" "owner/repo")
+		if [[ "$got" == "$expected" ]]; then
+			print_result "real CheckRun/StatusContext failure shape classifies ${expected}" 0
+		else
+			print_result "real CheckRun/StatusContext failure shape classifies ${expected}" 1 "got: '$got'"
+		fi
+	done
+	return 0
+}
+
+test_case_protected_draft_labels_are_preserved() {
+	local label got
+	for label in origin:interactive hold-for-review no-auto-dispatch needs-maintainer-review; do
+		export STUB_HEAD_JSON="[{\"number\":330,\"state\":\"OPEN\",\"isDraft\":true,\"mergedAt\":null,\"labels\":[{\"name\":\"origin:worker\"},{\"name\":\"${label}\"}],\"statusCheckRollup\":[]}]"
+		export STUB_SEARCH_JSON='[]'
+		got=$(_pr_handoff_state_for_branch_or_issue "feature/protected" "27517" "owner/repo")
+		if [[ "$got" == "protected_draft|330" ]]; then
+			print_result "draft carrying ${label} is protected" 0
+		else
+			print_result "draft carrying ${label} is protected" 1 "got: '$got'"
+		fi
+	done
+	return 0
+}
+
 # Case E: orphan recovery pre-check. When a PR exists for the branch
 # (--head=1), recovery returns 0 with NO `gh pr create` attempt.
 test_case_e_orphan_recovery_skips_when_pr_exists() {
-	export STUB_HEAD_COUNT=1
-	export STUB_SEARCH_COUNT=0
+	export STUB_HEAD_JSON='[{"number":21885,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]'
+	export STUB_SEARCH_JSON='[]'
 	local pr_log="${TEST_ROOT}/pr-create.log"
 	: >"$pr_log"
 	export STUB_PR_CREATE_LOG="$pr_log"
@@ -359,8 +424,8 @@ test_case_e_orphan_recovery_skips_when_pr_exists() {
 # does NOT block legitimate recovery when the absence is real. We allow the
 # stub `gh pr create` to "succeed" so we can observe it being called.
 test_case_f_orphan_recovery_proceeds_when_no_pr() {
-	export STUB_HEAD_COUNT=0
-	export STUB_SEARCH_COUNT=0
+	export STUB_HEAD_JSON='[]'
+	export STUB_SEARCH_JSON='[]'
 	local pr_log="${TEST_ROOT}/pr-create-2.log"
 	: >"$pr_log"
 	export STUB_PR_CREATE_LOG="$pr_log"
@@ -404,10 +469,13 @@ test_case_b_definitive_absence
 test_case_c_search_fallback_empty_branch
 test_case_d_no_inputs_unknown
 test_case_d2_empty_repo_unknown
+test_case_d3_failed_head_probe_is_unknown
 test_case_draft_state_is_preserved
 test_case_ready_and_terminal_states_are_preserved
 test_case_head_only_does_not_capture_unrelated_issue_draft
 test_case_active_pr_wins_over_historical_pr
+test_case_real_checkrun_and_statuscontext_failures
+test_case_protected_draft_labels_are_preserved
 test_case_e_orphan_recovery_skips_when_pr_exists
 test_case_f_orphan_recovery_proceeds_when_no_pr
 

--- a/.agents/scripts/tests/test-worker-output-classification.sh
+++ b/.agents/scripts/tests/test-worker-output-classification.sh
@@ -48,6 +48,13 @@
 
 set -uo pipefail
 
+# Bypass the aidevops git policy shim for disposable repositories created under
+# this test's isolated temporary HOME.
+git() {
+	command -p git "$@"
+	return $?
+}
+
 TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)" || exit 1
 HELPER_SCRIPT="${TEST_SCRIPTS_DIR}/headless-runtime-helper.sh"
 
@@ -110,6 +117,8 @@ case "${1:-}" in
 			list)
 				case " $* " in
 					*".[].number"*) printf '%s\n' "${STUB_PR_NUMBERS:-}" ;;
+					*"number,state,isDraft,mergedAt,labels,statusCheckRollup"*) printf '%s\n' "${STUB_PR_JSON:-[]}" ;;
+					*"--json number "*) printf '%s\n' "${STUB_SEARCH_JSON:-[]}" ;;
 					*) printf '%s\n' "${STUB_PR_COUNT:-0}" ;;
 				esac
 				;;
@@ -196,6 +205,7 @@ test_main_no_commits_no_pr_returns_noop() {
 		return 0
 	}
 	export STUB_PR_COUNT=0
+	export STUB_PR_JSON='[]' STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_worker_produced_output "issue-1001" "$WORK_DIR")
 	if [[ "$got" == "noop" ]]; then
@@ -226,6 +236,7 @@ test_main_with_local_commits_no_pr_returns_noop_t2899() {
 		return 0
 	}
 	export STUB_PR_COUNT=0
+	export STUB_PR_JSON='[]' STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_worker_produced_output "issue-1002" "$WORK_DIR")
 	if [[ "$got" == "noop" ]]; then
@@ -254,6 +265,7 @@ test_feature_branch_pushed_no_pr_returns_branch_orphan() {
 		return 0
 	}
 	export STUB_PR_COUNT=0
+	export STUB_PR_JSON='[]' STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_worker_produced_output "issue-1003" "$WORK_DIR")
 	if [[ "$got" == "branch_orphan" ]]; then
@@ -281,6 +293,7 @@ test_feature_branch_with_pr_returns_pr_exists() {
 		return 0
 	}
 	export STUB_PR_COUNT=1
+	export STUB_PR_JSON='[{"number":77,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_worker_produced_output "issue-1004" "$WORK_DIR")
 	if [[ "$got" == "pr_exists" ]]; then
@@ -306,6 +319,7 @@ test_failure_recovery_ignores_default_branch_pr_match() {
 		return 0
 	}
 	export STUB_PR_COUNT=1
+	export STUB_PR_JSON='[{"number":77,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' STUB_SEARCH_JSON='[]'
 	local got="recovered"
 	if _recover_worker_output_on_failure "issue-1005" "$WORK_DIR" >/dev/null 2>&1; then
 		got="recovered"
@@ -354,6 +368,7 @@ test_feature_branch_without_default_ref_returns_branch_orphan() {
 		return 0
 	}
 	export STUB_PR_COUNT=0
+	export STUB_PR_JSON='[]' STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_worker_produced_output "issue-1006" "$WORK_DIR")
 	if [[ "$got" == "branch_orphan" ]]; then
@@ -430,6 +445,7 @@ test_dirty_feature_worktree_preserved() {
 		return 0
 	}
 	export STUB_PR_COUNT=0
+	export STUB_PR_JSON='[]' STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_worker_produced_output "issue-1009" "$WORK_DIR")
 	if [[ "$got" == "dirty_worktree" ]]; then


### PR DESCRIPTION
## Summary

- classify exact-head PR lifecycle states, including protected drafts, failed-ready PRs, closed-unmerged PRs, absent PRs, and inconclusive search results
- retain claims until draft or failed-check escalation labels are applied and verified by read-back
- prevent non-merged lifecycle states from emitting false worker-completion telemetry
- add regression coverage for deduplication, stale recovery, protected drafts, API failures, and terminal evidence

## Testing

- 120-case headless runtime helper suite
- focused lifecycle, output-classification, stale-recovery, and deduplication suites
- ShellCheck on changed shell scripts
- local repository linters
- diff hygiene and function-complexity regression gates

## Decisions

- issue-search matches remain deduplication evidence only; they cannot prove exact-head terminal state
- protected interactive, held, no-auto-dispatch, and needs-maintainer-review drafts are never mutated by stale recovery
- ownership is retained whenever a blocking transition cannot be verified

Resolves #27517

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.105 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 26m and 553,862 tokens on this with the user in an interactive session.
