### PR TITLE
t18121: Remove false blocked-by dependency from brief

### DIFF
--- a/todo/tasks/t18121-brief.md
+++ b/todo/tasks/t18121-brief.md
@@ -16,7 +16,7 @@
 - **Session:** `opencode:ses_0a27e6418ffe3GdgcFDjIf8u7z`
 - **Created by:** AI DevOps (ai-interactive)
 - **Parent task:** none; standalone leaf follow-up from #27529
-- **Blocked by:** none; PR #27535 is merged and the helper is available
+- **Blocked by:** none; the prerequisite helper is merged and available
 - **Conversation context:** Session analysis found that a raw required-check watch produced 151,357 bytes and 1,427 lines, including 1,317 duplicate non-empty line occurrences and 27 unchanged refresh snapshots, even though the delta-aware wait helper had already shipped.
 
 ## What


### PR DESCRIPTION
## Summary

- remove a merged PR reference from the brief's `Blocked by` field
- prevent dependency parsing from treating PR #27535 as an unresolved issue blocker
- restore issue #27585 to verified worker-dispatchable state

## Evidence

- pulse diagnostics reported `blocked-by-unresolved-reference #27535`
- issue #27585 now has zero `Blocked by ... #NNN` references
- issue labels are `auto-dispatch`, `status:available`, and `tier:simple` with no assignee

## Verification

- `.agents/scripts/verify-brief-helper.sh check-readiness todo/tasks/t18121-brief.md`
- `.agents/scripts/linters-local.sh --changed`
- `.agents/scripts/brief-readiness-helper.sh check 27585 marcusquinn/aidevops`
- `.agents/scripts/task-dispatchability-helper.sh check --task-id t18121 --issue 27585 --body-file todo/tasks/t18121-brief.md`

Ref #27585

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.105 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 6h 37m and 952,279 tokens on this with the user in an interactive session.