### PR TITLE
GH#27534: tolerate stale postflight advisories and renew worker leases

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -67,6 +67,7 @@ DISPATCH_CLAIM_SELF_RECLAIM_AGE="${DISPATCH_CLAIM_SELF_RECLAIM_AGE:-30}"
 CLAIM_MARKER="DISPATCH_CLAIM"
 LEGACY_DEVICE_MARKER="legacy"
 JSON_NULL_MARKER="null"
+LEASE_PHASE_PRELAUNCH="prelaunch"
 
 _issue_comments_endpoint() {
 	local repo_slug="$1"
@@ -1206,10 +1207,14 @@ cmd_claim() {
 cmd_transition() {
 	local phase="${1:-}" issue_number="${2:-}" repo_slug="${3:-}" lease_token="${4:-}" session_key="${5:-}"
 	local ttl="${6:-}"
-	case "$phase" in prelaunch | ready | terminal) ;; *) echo "Error: transition phase must be prelaunch, ready, or terminal" >&2; return 1 ;; esac
+	case "$phase" in "$LEASE_PHASE_PRELAUNCH" | ready | terminal) ;; *)
+		echo "Error: transition phase must be prelaunch, ready, or terminal" >&2
+		return 1
+		;;
+	esac
 	[[ "$issue_number" =~ ^[0-9]+$ && -n "$repo_slug" && -n "$lease_token" ]] || return 1
 	if [[ ! "$ttl" =~ ^[0-9]+$ ]]; then
-		if [[ "$phase" == "prelaunch" ]]; then
+		if [[ "$phase" == "$LEASE_PHASE_PRELAUNCH" ]]; then
 			ttl="$DISPATCH_CLAIM_ORPHAN_GRACE"
 		else
 			ttl="$DISPATCH_READY_LEASE_TTL"
@@ -1227,7 +1232,7 @@ cmd_transition() {
 	current_device=$(_resolve_device_id)
 	[[ -n "$claim_author" && "$current_login" == "$claim_author" ]] || return 1
 	[[ "$current_device" == "$claim_device" && "${session_key:-issue-${issue_number}}" == "$claim_session" ]] || return 1
-	if [[ ( "$phase" == "prelaunch" || "$phase" == "ready" ) && "$current_phase" != "prelaunch" ]]; then
+	if [[ ("$phase" == "$LEASE_PHASE_PRELAUNCH" || "$phase" == "ready") && "$current_phase" != "$LEASE_PHASE_PRELAUNCH" ]]; then
 		return 1
 	fi
 	local expires_at="0" now_epoch="" body=""

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -1205,10 +1205,16 @@ cmd_claim() {
 
 cmd_transition() {
 	local phase="${1:-}" issue_number="${2:-}" repo_slug="${3:-}" lease_token="${4:-}" session_key="${5:-}"
-	local ttl="${6:-$DISPATCH_READY_LEASE_TTL}"
-	case "$phase" in ready | terminal) ;; *) echo "Error: transition phase must be ready or terminal" >&2; return 1 ;; esac
+	local ttl="${6:-}"
+	case "$phase" in prelaunch | ready | terminal) ;; *) echo "Error: transition phase must be prelaunch, ready, or terminal" >&2; return 1 ;; esac
 	[[ "$issue_number" =~ ^[0-9]+$ && -n "$repo_slug" && -n "$lease_token" ]] || return 1
-	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl="$DISPATCH_READY_LEASE_TTL"
+	if [[ ! "$ttl" =~ ^[0-9]+$ ]]; then
+		if [[ "$phase" == "prelaunch" ]]; then
+			ttl="$DISPATCH_CLAIM_ORPHAN_GRACE"
+		else
+			ttl="$DISPATCH_READY_LEASE_TTL"
+		fi
+	fi
 	local active_claims="" current_phase="" claim_record="" claim_author="" claim_device="" claim_session="" current_login="" current_device=""
 	active_claims=$(_fetch_claims "$issue_number" "$repo_slug") || return 1
 	claim_record=$(printf '%s' "$active_claims" | jq -c --arg token "$lease_token" '[.[] | select(.lease_token == $token)] | last // empty' 2>/dev/null) || claim_record=""
@@ -1221,7 +1227,7 @@ cmd_transition() {
 	current_device=$(_resolve_device_id)
 	[[ -n "$claim_author" && "$current_login" == "$claim_author" ]] || return 1
 	[[ "$current_device" == "$claim_device" && "${session_key:-issue-${issue_number}}" == "$claim_session" ]] || return 1
-	if [[ "$phase" == "ready" && "$current_phase" != "prelaunch" ]]; then
+	if [[ ( "$phase" == "prelaunch" || "$phase" == "ready" ) && "$current_phase" != "prelaunch" ]]; then
 		return 1
 	fi
 	local expires_at="0" now_epoch="" body=""

--- a/.agents/scripts/dispatch-lease-claims.jq
+++ b/.agents/scripts/dispatch-lease-claims.jq
@@ -30,6 +30,8 @@ map(. as $claim |
     (reduce $transitions[] as $event
       ({phase:"prelaunch", expires:$claim.lease_expires_at};
        if .phase == "terminal" or .expires < $event.transition_epoch then .
+       elif $event.transition_phase == "prelaunch" and .phase == "prelaunch" and $event.transition_expires >= $event.transition_epoch
+         then {phase:"prelaunch", expires:$event.transition_expires}
        elif $event.transition_phase == "ready" and .phase == "prelaunch" and $event.transition_expires >= $event.transition_epoch
          then {phase:"ready", expires:$event.transition_expires}
        elif $event.transition_phase == "terminal" and (.phase == "prelaunch" or .phase == "ready")

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1475,6 +1475,13 @@ cmd_run() {
 		local AIDEVOPS_HEADLESS
 		AIDEVOPS_HEADLESS="$_worker_headless_marker"
 		export AIDEVOPS_HEADLESS
+		print_info "[lifecycle] prelaunch_lease_renew_start session=$session_key pid=$$"
+		if ! _hrw_renew_dispatch_prelaunch_lease "$session_key"; then
+			print_warning "Dispatch prelaunch lease expired before worker startup — deferring session $session_key"
+			_hrw_record_terminal_outcome "$session_key" "deferred" "prelaunch_lease_renewal_failed"
+			return 1
+		fi
+		print_info "[lifecycle] prelaunch_lease_renew_done session=$session_key pid=$$"
 	fi
 
 	print_info "[lifecycle] pre_model_select session=$session_key role=$role tier=${tier_override:-auto} pid=$$"

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1478,7 +1478,7 @@ cmd_run() {
 		print_info "[lifecycle] prelaunch_lease_renew_start session=$session_key pid=$$"
 		if ! _hrw_renew_dispatch_prelaunch_lease "$session_key"; then
 			print_warning "Dispatch prelaunch lease expired before worker startup — deferring session $session_key"
-			_hrw_record_terminal_outcome "$session_key" "deferred" "prelaunch_lease_renewal_failed"
+			_hrw_record_terminal_outcome "$session_key" "$_HRW_TELEMETRY_DEFERRED" "prelaunch_lease_renewal_failed"
 			return 1
 		fi
 		print_info "[lifecycle] prelaunch_lease_renew_done session=$session_key pid=$$"

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1260,6 +1260,18 @@ _hrw_claim_worker_worktree() {
 	return 0
 }
 
+_hrw_renew_dispatch_prelaunch_lease() {
+	local session_key="$1"
+
+	if [[ -z "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" || -z "${WORKER_ISSUE_NUMBER:-}" || -z "${WORKER_REPO_SLUG:-}" ]]; then
+		return 0
+	fi
+	"${SCRIPT_DIR}/dispatch-claim-helper.sh" transition prelaunch "$WORKER_ISSUE_NUMBER" \
+		"$WORKER_REPO_SLUG" "$AIDEVOPS_DISPATCH_LEASE_TOKEN" "$session_key" \
+		"${AIDEVOPS_DISPATCH_CLAIM_ORPHAN_GRACE:-120}" 2>/dev/null || return 1
+	return 0
+}
+
 _hrw_release_worker_worktree() {
 	local work_dir="$1"
 

--- a/.agents/scripts/tests/fixtures/postflight-release-owned-check-runs.json
+++ b/.agents/scripts/tests/fixtures/postflight-release-owned-check-runs.json
@@ -5,6 +5,7 @@
       "name": "Framework Validation",
       "status": "completed",
       "conclusion": "success",
+      "completed_at": "2026-07-13T20:00:00Z",
       "check_suite": { "id": 501 },
       "app": { "slug": "github-actions" }
     },
@@ -13,6 +14,7 @@
       "name": "Publish npm package",
       "status": "completed",
       "conclusion": "success",
+      "completed_at": "2026-07-13T20:01:00Z",
       "check_suite": { "id": 502 },
       "app": { "slug": "github-actions" }
     },
@@ -38,6 +40,32 @@
       "status": "completed",
       "conclusion": "failure",
       "check_suite": { "id": 505 },
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 1999,
+      "name": "Framework Validation",
+      "status": "in_progress",
+      "conclusion": null,
+      "started_at": "2026-07-13T19:00:00Z",
+      "check_suite": { "id": 501 },
+      "app": { "slug": "github-actions" }
+    },
+    {
+      "id": 2006,
+      "name": "Socket Security: Project Report",
+      "status": "in_progress",
+      "conclusion": null,
+      "started_at": "2026-07-13T20:03:39Z",
+      "check_suite": { "id": 506 },
+      "app": { "slug": "socket-security" }
+    },
+    {
+      "id": 2007,
+      "name": "Verify Release Health",
+      "status": "in_progress",
+      "conclusion": null,
+      "check_suite": { "id": 501 },
       "app": { "slug": "github-actions" }
     }
   ]

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -196,6 +196,29 @@ PY
 	return 0
 }
 
+test_prelaunch_renewal_covers_slow_startup() {
+	local root="${TMP_DIR}/renewal" token="" renewal_call=""
+	create_mock_gh "$root"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		DISPATCH_CLAIM_WINDOW=0 DISPATCH_CLAIM_ORPHAN_GRACE=3 \
+		"$CLAIM" claim 47 owner/repo shared-login >"$root/renew.out" 2>&1
+	token=$(claim_token "$root/renew.out")
+	[[ -n "$token" ]] || fail "renewal claim token missing"
+	sleep 2
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		"$CLAIM" transition prelaunch 47 owner/repo "$token" issue-47 3
+	sleep 2
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		"$CLAIM" transition ready 47 owner/repo "$token" issue-47 30 \
+		|| fail "renewed prelaunch lease did not survive slow startup"
+	# shellcheck disable=SC2016 # Match the literal runtime variable in the helper source.
+	renewal_call='_hrw_renew_dispatch_prelaunch_lease "$session_key"'
+	grep -Fq "$renewal_call" "${SCRIPTS_DIR}/headless-runtime-helper.sh" \
+		|| fail "worker does not renew its prelaunch lease before canary"
+	pass "worker prelaunch renewal covers slow startup before ready transition"
+	return 0
+}
+
 test_takeover_recheck_precedes_mutation() {
 	local root="${TMP_DIR}/takeover"
 	create_mock_gh "$root"
@@ -225,6 +248,7 @@ test_invalid_device_not_public() {
 test_local_ledger_guards
 test_concurrent_same_login_devices
 test_launch_crash_ready_terminal_race
+test_prelaunch_renewal_covers_slow_startup
 test_invalid_device_not_public
 test_takeover_recheck_precedes_mutation
 printf '\nAtomic lease concurrency tests passed\n'

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -209,12 +209,12 @@ test_prelaunch_renewal_covers_slow_startup() {
 		"$CLAIM" transition prelaunch 47 owner/repo "$token" issue-47 3
 	sleep 2
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
-		"$CLAIM" transition ready 47 owner/repo "$token" issue-47 30 \
-		|| fail "renewed prelaunch lease did not survive slow startup"
+		"$CLAIM" transition ready 47 owner/repo "$token" issue-47 30 ||
+		fail "renewed prelaunch lease did not survive slow startup"
 	# shellcheck disable=SC2016 # Match the literal runtime variable in the helper source.
 	renewal_call='_hrw_renew_dispatch_prelaunch_lease "$session_key"'
-	grep -Fq "$renewal_call" "${SCRIPTS_DIR}/headless-runtime-helper.sh" \
-		|| fail "worker does not renew its prelaunch lease before canary"
+	grep -Fq "$renewal_call" "${SCRIPTS_DIR}/headless-runtime-helper.sh" ||
+		fail "worker does not renew its prelaunch lease before canary"
 	pass "worker prelaunch renewal covers slow startup before ready transition"
 	return 0
 }

--- a/.agents/scripts/tests/test-postflight-release-owned-checks.sh
+++ b/.agents/scripts/tests/test-postflight-release-owned-checks.sh
@@ -22,10 +22,15 @@ SCOPED=$(scope_checks <"$CHECK_FIXTURE")
 jq -e '
   (.check_runs | length) == 2 and
   all(.check_runs[]; .check_suite.id == 501 or .check_suite.id == 502) and
-  all(.check_runs[]; .status == "completed" and .conclusion == "success")
+  all(.check_runs[]; .status == "completed" and .conclusion == "success") and
+  (.advisory_check_runs | length) == 1 and
+  .advisory_check_runs[0].name == "Socket Security: Project Report" and
+  .advisory_check_runs[0].status == "in_progress" and
+  (all((.check_runs + .advisory_check_runs)[]; .name != "Verify Release Health"))
 ' <<<"$SCOPED" >/dev/null
 
-printf 'PASS: unrelated queued issue checks do not delay successful release checks\n'
+printf 'PASS: superseded, self, and unrelated checks do not delay successful release checks\n'
+printf 'PASS: pending external checks are classified as non-required advisories\n'
 
 PAGINATED_SCOPED=$(jq -c \
 	--arg release_sha "release-sha" \
@@ -52,5 +57,6 @@ printf 'PASS: terminal release-quality failures remain blocking\n'
 grep -Fq "actions/runs?head_sha=\${COMMIT_SHA}&per_page=100" "${REPO_ROOT}/.github/workflows/postflight.yml"
 grep -Fq 'release-owned-check-runs.jq' "${REPO_ROOT}/.github/workflows/postflight.yml"
 grep -Fq -- '--slurpfile release_run_documents' "${REPO_ROOT}/.github/workflows/postflight.yml"
+grep -Fq 'non-required advisory check(s) remain non-terminal' "${REPO_ROOT}/.github/workflows/postflight.yml"
 
-printf 'PASS: postflight keeps paginated exact-SHA release-run classification\n'
+printf 'PASS: postflight keeps paginated exact-SHA classification and advisory warnings\n'

--- a/.github/scripts/release-owned-check-runs.jq
+++ b/.github/scripts/release-owned-check-runs.jq
@@ -1,3 +1,13 @@
+def run_key: [(.name // ""), (.app.slug // .app.name // "")];
+
+def run_time:
+  .completed_at // .started_at // .created_at // .updated_at // "";
+
+def latest_by_key:
+  sort_by(run_key)
+  | group_by(run_key)
+  | map(max_by([run_time, (.id // 0)]));
+
 ($release_run_documents
  | flatten
  | map(.workflow_runs // [])
@@ -11,9 +21,21 @@
  | unique) as $release_suite_ids
 |
 {
-  check_runs: [
-    .check_runs[]?
-    | select(.name != $self_name)
-    | select(.check_suite.id as $suite_id | $release_suite_ids | index($suite_id))
-  ]
+  check_runs: (
+    [
+      .check_runs[]?
+      | select(.name != $self_name)
+      | select(.check_suite.id as $suite_id | $release_suite_ids | index($suite_id))
+    ]
+    | latest_by_key
+  ),
+  advisory_check_runs: (
+    [
+      .check_runs[]?
+      | select(.name != $self_name)
+      | select(.check_suite.id as $suite_id | $release_suite_ids | index($suite_id) | not)
+      | select((.app.slug // "") != "github-actions")
+    ]
+    | latest_by_key
+  )
 }

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -94,6 +94,13 @@ jobs:
           <<<"$CHECK_RUNS_RESPONSE")
         REMAINING=$(jq '[.check_runs[] | select(.status != "completed")] | length' \
           <<<"$RELEASE_CHECK_RUNS")
+        ADVISORY_PENDING=$(jq '[.advisory_check_runs[]? | select(.status != "completed")] | length' \
+          <<<"$RELEASE_CHECK_RUNS")
+        if [[ "$ADVISORY_PENDING" != "0" ]]; then
+          echo "::warning::$ADVISORY_PENDING non-required advisory check(s) remain non-terminal"
+          jq -r '.advisory_check_runs[] | select(.status != "completed") | "  - Advisory: \(.name): \(.status)"' \
+            <<<"$RELEASE_CHECK_RUNS" || true
+        fi
         if [[ "$REMAINING" != "0" ]]; then
           echo "::error::$REMAINING release-owned check runs remained non-terminal after timeout"
           jq -r '.check_runs[] | select(.status != "completed") | "  - \(.name): \(.status)"' \


### PR DESCRIPTION
## Summary

Scope postflight waits to the latest release-owned checks, report stale external integrations as warnings, and renew worker prelaunch leases before canary startup.

## Worker failure diagnosis

- The affected worker exited before model invocation with `worker_prepare_failed` and zero model output.
- Its prelaunch lease had spent nearly the full 120-second orphan window in dispatch/setup before the worker attempted the ready transition.
- The fix renews the authenticated prelaunch lease before model selection and canary work, while preserving expiry and terminal-state safeguards.

## Files Changed

`.agents/scripts/dispatch-claim-helper.sh`, `.agents/scripts/dispatch-lease-claims.jq`, `.agents/scripts/headless-runtime-helper.sh`, `.agents/scripts/headless-runtime-worker.sh`, focused fixtures/tests, `.github/scripts/release-owned-check-runs.jq`, and `.github/workflows/postflight.yml`.

## Runtime Testing

- **Risk level:** High (worker lease state machine)
- **Verification:** Runtime-verified atomic lease lifecycle test; postflight required/advisory/superseded fixtures; 58 dispatch-claim tests; actionlint; ShellCheck; changed-scope linters; version validation.
- **Broad preflight note:** changed-scope gates pass. Full-repository mode reports pre-existing CHANGELOG formatting, complexity, nesting, and layout debt unrelated to this PR.

## Decisions

- Exact-SHA push, release, and workflow-dispatch suites remain blocking.
- External check apps are explicit non-required advisories and cannot extend the release wait indefinitely.
- A prelaunch renewal is accepted only for the original author/device/session/token before expiry; terminal leases cannot be resurrected.

Resolves #27534

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.109 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 23m and 286,825 tokens on this with the user in an interactive session. Overall, 8h 24m since this issue was created.
