### PR TITLE
GH#27606: classify zero-diff worker branches against develop bases

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -432,6 +432,27 @@ _hrw_resolve_default_branch() {
 }
 
 #######################################
+# Resolve the comparison base and count commits beyond it.
+# Output: <default-branch>|<count|unknown>
+# Args: $1=work_dir
+#######################################
+_hrw_worker_base_commit_state() {
+	local work_dir="$1"
+	local default_branch=""
+	local commit_count=""
+
+	default_branch=$(_hrw_resolve_default_branch "$work_dir")
+	[[ -z "$default_branch" ]] && default_branch="${DISPATCH_REPO_DEFAULT_BRANCH:-main}"
+	if commit_count=$(git -C "$work_dir" rev-list --count "origin/${default_branch}..${_HRW_GIT_HEAD}" 2>/dev/null) && \
+		[[ "$commit_count" =~ ^[0-9]+$ ]]; then
+		printf '%s|%s' "$default_branch" "$commit_count"
+	else
+		printf '%s|unknown' "$default_branch"
+	fi
+	return 0
+}
+
+#######################################
 # Detect whether a worker produced any tangible output.
 #
 # Checks three independent signals. Returns 0 (true — has output) if ANY
@@ -495,34 +516,22 @@ _worker_produced_output() {
 		return 0
 	fi
 
-	# Resolve the default branch once for both commit comparison and the pushed-
-	# branch guard. Repositories may integrate through develop or another branch;
-	# comparing those workers to origin/main invents commits that cannot produce a
-	# PR against the configured base.
+	# Compare against the resolved default, not an assumed main/master base.
+	local base_commit_state=""
 	local default_branch=""
-	default_branch=$(_hrw_resolve_default_branch "$work_dir")
-	[[ -z "$default_branch" ]] && default_branch="${DISPATCH_REPO_DEFAULT_BRANCH:-main}"
-
-	# Signal 1: commits on the feature branch beyond the resolved remote default.
-	# Preserve an explicit known/unknown distinction: a missing base ref must fail
-	# open rather than collapsing potentially real worker output to noop.
+	local commit_count=""
 	local has_commits=0
 	local commit_comparison_known=0
-	local commit_count=""
-	if commit_count=$(git -C "$work_dir" rev-list --count "origin/${default_branch}..${_HRW_GIT_HEAD}" 2>/dev/null) && \
-		[[ "$commit_count" =~ ^[0-9]+$ ]]; then
+	base_commit_state=$(_hrw_worker_base_commit_state "$work_dir")
+	default_branch="${base_commit_state%%|*}"
+	commit_count="${base_commit_state#*|}"
+	if [[ "$commit_count" =~ ^[0-9]+$ ]]; then
 		commit_comparison_known=1
 		[[ "$commit_count" -gt 0 ]] && has_commits=1
 	fi
 
-	# Signal 2: branch pushed to remote
-	# Default-branch guard (t2899): when HEAD ends on the repo's default branch
-	# (main/master), Signal 2 ALWAYS matches because the default branch exists
-	# on the remote — every worker that exits without checking out a feature
-	# branch was previously misclassified as branch_orphan. Resolve the default
-	# branch via origin/HEAD and common branch fallbacks, and skip
-	# Signal 2 entirely when branch_name matches it. The signal is meaningless
-	# on default branches: there is no orphan branch to recover.
+	# Signal 2: a remote feature ref is output evidence only off the resolved
+	# default branch (t2899).
 	local has_pushed_branch=0
 	local branch_name=""
 	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -442,8 +442,8 @@ _hrw_resolve_default_branch() {
 #   $2 - work_dir    (worktree root; must be a git repo)
 #
 # Signals checked (in order of cheapness):
-#   1. Commits on feature branch beyond remote default branch
-#      (git rev-list --count origin/main..HEAD > 0; falls back to origin/master)
+#   1. Commits on feature branch beyond the resolved remote default branch
+#      (git rev-list --count origin/<default>..HEAD > 0)
 #   2. Branch pushed to remote
 #      (git ls-remote origin refs/heads/<branch> is non-empty)
 #   3. PR linked to this issue via gh
@@ -495,17 +495,23 @@ _worker_produced_output() {
 		return 0
 	fi
 
-	# Signal 1: commits on feature branch beyond origin/main (fallback: master)
+	# Resolve the default branch once for both commit comparison and the pushed-
+	# branch guard. Repositories may integrate through develop or another branch;
+	# comparing those workers to origin/main invents commits that cannot produce a
+	# PR against the configured base.
+	local default_branch=""
+	default_branch=$(_hrw_resolve_default_branch "$work_dir")
+	[[ -z "$default_branch" ]] && default_branch="${DISPATCH_REPO_DEFAULT_BRANCH:-main}"
+
+	# Signal 1: commits on the feature branch beyond the resolved remote default.
+	# Preserve an explicit known/unknown distinction: a missing base ref must fail
+	# open rather than collapsing potentially real worker output to noop.
 	local has_commits=0
-	local commit_count=0
-	commit_count=$(git -C "$work_dir" rev-list --count "origin/main..HEAD" 2>/dev/null || true)
-	[[ "$commit_count" =~ ^[0-9]+$ ]] || commit_count=0
-	if [[ "$commit_count" -gt 0 ]]; then
-		has_commits=1
-	else
-		# Signal 1b: fallback for origin/master default branch
-		commit_count=$(git -C "$work_dir" rev-list --count "origin/master..HEAD" 2>/dev/null || true)
-		[[ "$commit_count" =~ ^[0-9]+$ ]] || commit_count=0
+	local commit_comparison_known=0
+	local commit_count=""
+	if commit_count=$(git -C "$work_dir" rev-list --count "origin/${default_branch}..${_HRW_GIT_HEAD}" 2>/dev/null) && \
+		[[ "$commit_count" =~ ^[0-9]+$ ]]; then
+		commit_comparison_known=1
 		[[ "$commit_count" -gt 0 ]] && has_commits=1
 	fi
 
@@ -519,20 +525,17 @@ _worker_produced_output() {
 	# on default branches: there is no orphan branch to recover.
 	local has_pushed_branch=0
 	local branch_name=""
-	local default_branch=""
 	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-	default_branch=$(_hrw_resolve_default_branch "$work_dir")
-	[[ -z "$default_branch" ]] && default_branch="${DISPATCH_REPO_DEFAULT_BRANCH:-main}"
 	if [[ -n "$branch_name" && "$branch_name" != "$_HRW_GIT_HEAD" && "$branch_name" != "$default_branch" ]]; then
 		local remote_ref=""
 		remote_ref=$(git -C "$work_dir" ls-remote origin "refs/heads/$branch_name" 2>/dev/null || true)
 		[[ -n "$remote_ref" ]] && has_pushed_branch=1
 	fi
 
-	# Early exit: no commits, no pushed branch → definitely noop (no PR check needed)
-	# Also covers the t2899 default-branch case: HEAD on main with no/any commits
-	# but no feature branch pushed → noop, not branch_orphan.
-	if [[ "$has_commits" -eq 0 && "$has_pushed_branch" -eq 0 ]]; then
+	# A successful zero-count comparison proves the branch has no PR-able output,
+	# even when a same-SHA feature ref already exists remotely. Check for dirty
+	# edits first so crash recovery still preserves uncommitted work.
+	if [[ "$has_commits" -eq 0 ]]; then
 		local task_status=""
 		if ! task_status=$(_hrw_worktree_task_status "$work_dir"); then
 			printf 'pr_exists' # fail-open: cannot safely classify local state
@@ -542,8 +545,14 @@ _worker_produced_output() {
 			printf 'dirty_worktree'
 			return 0
 		fi
-		printf 'noop'
-		return 0
+		if [[ "$commit_comparison_known" -eq 1 ]]; then
+			printf 'noop'
+			return 0
+		fi
+		if [[ "$has_pushed_branch" -eq 0 ]]; then
+			printf 'pr_exists' # fail-open: resolved base ref could not be compared
+			return 0
+		fi
 	fi
 	# t2899: HEAD on default branch with commits ahead but no feature branch pushed.
 	# This is "worker landed on main with local commits" — not an orphan branch.

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1990,8 +1990,9 @@ test_worker_produced_output_invalid_workdir_returns_pr_exists() {
 	return 0
 }
 
-test_worker_produced_output_pushed_branch_no_slug_returns_pr_exists() {
-	# Pushed branch but DISPATCH_REPO_SLUG unset → cannot check PR → fail-open (pr_exists)
+test_worker_produced_output_zero_diff_pushed_branch_returns_noop() {
+	# A successful zero-count comparison proves no PR can exist for this head,
+	# even when the feature ref was pushed and repo slug context is unavailable.
 	local work_dir="${TEST_ROOT}/repo-pushed-noslug"
 	_setup_test_git_repo "$work_dir" 0
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
@@ -1999,11 +2000,11 @@ test_worker_produced_output_pushed_branch_no_slug_returns_pr_exists() {
 
 	local classification
 	classification=$(_worker_produced_output "issue-99999" "$work_dir")
-	if [[ "$classification" == "pr_exists" ]]; then
-		print_result "_worker_produced_output returns 'pr_exists' for pushed branch (no slug, fail-open)" 0
+	if [[ "$classification" == "noop" ]]; then
+		print_result "_worker_produced_output returns 'noop' for a zero-diff pushed branch" 0
 	else
-		print_result "_worker_produced_output returns 'pr_exists' for pushed branch (no slug, fail-open)" 1 \
-			"Expected 'pr_exists' (fail-open, no DISPATCH_REPO_SLUG), got '${classification}'"
+		print_result "_worker_produced_output returns 'noop' for a zero-diff pushed branch" 1 \
+			"Expected 'noop' after a successful zero-count base comparison, got '${classification}'"
 	fi
 	return 0
 }
@@ -3051,7 +3052,7 @@ main() {
 	test_worker_produced_output_with_commits_returns_pr_exists_failopen
 	test_worker_produced_output_non_worker_session_returns_pr_exists
 	test_worker_produced_output_invalid_workdir_returns_pr_exists
-	test_worker_produced_output_pushed_branch_no_slug_returns_pr_exists
+	test_worker_produced_output_zero_diff_pushed_branch_returns_noop
 	test_worker_produced_output_branch_no_pr_returns_branch_orphan
 	test_worker_produced_output_local_branch_no_remote_returns_local_branch_unpushed
 	test_worker_produced_output_branch_with_pr_returns_pr_exists

--- a/.agents/scripts/tests/test-worker-output-classification.sh
+++ b/.agents/scripts/tests/test-worker-output-classification.sh
@@ -42,6 +42,10 @@
 #      (The default-branch resolver must not fall back to the current checkout
 #      and mistake the feature branch for the default branch.)
 #
+#   10-13. default=develop, zero/real commits, local/pushed → expected lifecycle
+#      (Commit detection must compare against origin/develop. Comparing against
+#      origin/main invents output for zero-diff branches and starts an orphan loop.)
+#
 # `gh` is stubbed via PATH to return a controllable PR-list count without
 # touching the network. `git` is real — each case spins up its own
 # disposable origin+clone pair so the classifier sees authentic refs.
@@ -188,6 +192,33 @@ make_repo_pair() {
 	git -C "$WORK_DIR" config user.name "Test"
 	# Push origin/HEAD so symbolic-ref refs/remotes/origin/HEAD resolves.
 	git -C "$WORK_DIR" remote set-head origin main >/dev/null 2>&1 || true
+	return 0
+}
+
+# make_develop_repo_pair <label>
+# Creates a repository where develop is the remote default and is one commit
+# ahead of main. This reproduces the cross-base false positive from GH#27606.
+make_develop_repo_pair() {
+	local label="$1"
+	ORIGIN_DIR="${TEST_ROOT}/origin-${label}"
+	WORK_DIR="${TEST_ROOT}/work-${label}"
+	rm -rf "$ORIGIN_DIR" "$WORK_DIR"
+	mkdir -p "$ORIGIN_DIR"
+	(
+		cd "$ORIGIN_DIR" || exit 1
+		git init -q -b main
+		git config user.email "test@example.com"
+		git config user.name "Test"
+		git commit --allow-empty -q -m "main init"
+		git checkout -q -b develop
+		printf '%s\n' "develop base" >develop.txt
+		git add develop.txt
+		git commit -q -m "develop base"
+	) || return 1
+	git clone -q --branch develop "$ORIGIN_DIR" "$WORK_DIR" || return 1
+	git -C "$WORK_DIR" config user.email "test@example.com"
+	git -C "$WORK_DIR" config user.name "Test"
+	git -C "$WORK_DIR" remote set-head origin develop >/dev/null 2>&1 || return 1
 	return 0
 }
 
@@ -456,6 +487,103 @@ test_dirty_feature_worktree_preserved() {
 	return 0
 }
 
+test_develop_zero_diff_local_branch_returns_noop() {
+	make_develop_repo_pair "case10" || {
+		print_result "case 10: develop zero-diff local branch → noop" 1 "fixture setup failed"
+		return 0
+	}
+	git -C "$WORK_DIR" checkout -q -b feature/t1010-zero-local || {
+		print_result "case 10: develop zero-diff local branch → noop" 1 "branch setup failed"
+		return 0
+	}
+	export STUB_PR_JSON='[]' STUB_SEARCH_JSON='[]'
+	local got
+	got=$(_worker_produced_output "issue-1010" "$WORK_DIR")
+	if [[ "$got" == "noop" ]]; then
+		print_result "case 10: develop zero-diff local branch → noop" 0
+	else
+		print_result "case 10: develop zero-diff local branch → noop" 1 "got: $got"
+	fi
+	return 0
+}
+
+test_develop_zero_diff_pushed_branch_returns_noop() {
+	make_develop_repo_pair "case11" || {
+		print_result "case 11: develop zero-diff pushed branch → noop" 1 "fixture setup failed"
+		return 0
+	}
+	(
+		cd "$WORK_DIR" || exit 1
+		git checkout -q -b feature/t1011-zero-pushed
+		git push -q origin feature/t1011-zero-pushed
+	) || {
+		print_result "case 11: develop zero-diff pushed branch → noop" 1 "branch setup failed"
+		return 0
+	}
+	export STUB_PR_JSON='[]' STUB_SEARCH_JSON='[]'
+	local got
+	got=$(_worker_produced_output "issue-1011" "$WORK_DIR")
+	if [[ "$got" == "noop" ]]; then
+		print_result "case 11: develop zero-diff pushed branch → noop" 0
+	else
+		print_result "case 11: develop zero-diff pushed branch → noop" 1 "got: $got"
+	fi
+	return 0
+}
+
+test_develop_real_commit_local_branch_remains_unpushed() {
+	make_develop_repo_pair "case12" || {
+		print_result "case 12: develop real local commit → local_branch_unpushed" 1 "fixture setup failed"
+		return 0
+	}
+	(
+		cd "$WORK_DIR" || exit 1
+		git checkout -q -b feature/t1012-real-local
+		printf '%s\n' "worker output" >worker.txt
+		git add worker.txt
+		git commit -q -m "worker output"
+	) || {
+		print_result "case 12: develop real local commit → local_branch_unpushed" 1 "commit setup failed"
+		return 0
+	}
+	export STUB_PR_JSON='[]' STUB_SEARCH_JSON='[]'
+	local got
+	got=$(_worker_produced_output "issue-1012" "$WORK_DIR")
+	if [[ "$got" == "local_branch_unpushed" ]]; then
+		print_result "case 12: develop real local commit → local_branch_unpushed" 0
+	else
+		print_result "case 12: develop real local commit → local_branch_unpushed" 1 "got: $got"
+	fi
+	return 0
+}
+
+test_develop_real_commit_pushed_branch_remains_orphan() {
+	make_develop_repo_pair "case13" || {
+		print_result "case 13: develop real pushed commit → branch_orphan" 1 "fixture setup failed"
+		return 0
+	}
+	(
+		cd "$WORK_DIR" || exit 1
+		git checkout -q -b feature/t1013-real-pushed
+		printf '%s\n' "worker output" >worker.txt
+		git add worker.txt
+		git commit -q -m "worker output"
+		git push -q origin feature/t1013-real-pushed
+	) || {
+		print_result "case 13: develop real pushed commit → branch_orphan" 1 "commit setup failed"
+		return 0
+	}
+	export STUB_PR_JSON='[]' STUB_SEARCH_JSON='[]'
+	local got
+	got=$(_worker_produced_output "issue-1013" "$WORK_DIR")
+	if [[ "$got" == "branch_orphan" ]]; then
+		print_result "case 13: develop real pushed commit → branch_orphan" 0
+	else
+		print_result "case 13: develop real pushed commit → branch_orphan" 1 "got: $got"
+	fi
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Run
 # -----------------------------------------------------------------------------
@@ -469,6 +597,10 @@ test_feature_branch_without_default_ref_returns_branch_orphan
 test_external_terminal_complete_uses_trailing_issue_digits
 test_external_terminal_complete_guards_before_github_calls
 test_dirty_feature_worktree_preserved
+test_develop_zero_diff_local_branch_returns_noop
+test_develop_zero_diff_pushed_branch_returns_noop
+test_develop_real_commit_local_branch_remains_unpushed
+test_develop_real_commit_pushed_branch_remains_orphan
 
 printf '\nRan %d test(s), %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 


### PR DESCRIPTION
## Summary

Resolve worker commit counts against the repository default branch and classify confirmed same-SHA feature refs as no-op instead of orphaned output.

## Files Changed

.agents/scripts/headless-runtime-worker.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-worker-output-classification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 13 classifier regressions pass; 120 headless-runtime lifecycle tests pass; related output/ownership tests pass; ShellCheck clean; local linter gate passes.

Resolves #27606


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.109 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 22m and 260,896 tokens on this with the user in an interactive session.