### PR TITLE
GH#27588: fix: classify observability tool outcomes precisely

### DIFF
--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -36,6 +36,7 @@ import {
   enrichActiveSpan,
   runtimeEventOtelAttributes,
 } from "./otel-enrichment.mjs";
+import { toolOutcomeFailed } from "./session-continuation-guard.mjs";
 
 const HOME = homedir();
 const DEFAULT_OBS_DIR = join(HOME, ".aidevops", ".agent-workspace", "observability");
@@ -876,6 +877,10 @@ export function buildToolCallInsertSql({ sessionID, callID, toolName, intent, is
  * @param {string | undefined} intent - LLM-provided intent string (from agent__intent field)
  * @param {number | null | undefined} [durationMs] - Elapsed milliseconds from tool.execute.before (t2184)
  */
+export function toolCallSucceeded(output) {
+  return !toolOutcomeFailed(output);
+}
+
 export function recordToolCall(input, output, intent, durationMs) {
   if (!dbReady) return;
 
@@ -901,11 +906,7 @@ export function recordToolCall(input, output, intent, durationMs) {
     }
   }
 
-  // Determine success from output (heuristic: no error indicators)
-  const outputText = output.output || "";
-  const isSuccess = !outputText.includes("error") &&
-    !outputText.includes("FAILED") &&
-    !outputText.includes("Error:") ? 1 : 0;
+  const isSuccess = toolCallSucceeded(output) ? 1 : 0;
 
   const sql = buildToolCallInsertSql({
     sessionID,

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
@@ -22,7 +22,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { buildToolCallInsertSql } from "../observability.mjs";
+import { buildToolCallInsertSql, toolCallSucceeded } from "../observability.mjs";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -71,6 +71,39 @@ function extractValues(sql) {
   if (buf.trim()) values.push(buf.trim());
   return values;
 }
+
+describe("toolCallSucceeded", () => {
+  test("accepts ordinary output containing error vocabulary", () => {
+    assert.equal(toolCallSucceeded({
+      output: "The parser handles error values, Error: fixtures, and FAILED states.",
+      metadata: { status: "completed", exitCode: 0 },
+    }), true);
+  });
+
+  test("accepts empty and ordinary successful output", () => {
+    assert.equal(toolCallSucceeded({ output: "" }), true);
+    assert.equal(toolCallSucceeded({ output: "File read successfully" }), true);
+  });
+
+  test("rejects structured failure statuses", () => {
+    assert.equal(toolCallSucceeded({ output: "", metadata: { status: "failed" } }), false);
+    assert.equal(toolCallSucceeded({ output: "", status: "timeout" }), false);
+  });
+
+  test("rejects explicit error fields", () => {
+    assert.equal(toolCallSucceeded({ output: "", error: "read failed" }), false);
+    assert.equal(toolCallSucceeded({ output: "", metadata: { error: "read failed" } }), false);
+  });
+
+  test("rejects non-zero metadata exit codes", () => {
+    assert.equal(toolCallSucceeded({ output: "", metadata: { exitCode: 1 } }), false);
+  });
+
+  test("rejects leading terminal failure markers without structured status", () => {
+    assert.equal(toolCallSucceeded({ output: "Error: file not found" }), false);
+    assert.equal(toolCallSucceeded({ output: "FAILED to read file" }), false);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Schema alignment


### PR DESCRIPTION
## Summary

Reuse the structured-first tool outcome classifier so successful output containing error vocabulary remains successful while structured failures, explicit errors, non-zero exits, and leading terminal markers remain failures. Adds focused classifier regression coverage without changing observability schemas.

## Files Changed

.agents/plugins/opencode-aidevops/observability.mjs, .agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs; node --test .agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs; node --check .agents/plugins/opencode-aidevops/observability.mjs; .agents/scripts/linters-local.sh --changed

Resolves #27588


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.109 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 2m and 37,229 tokens on this as a headless worker.