### PR TITLE
GH#27611: Preserve labels on maintainer-gate API errors

### DIFF
--- a/.agents/scripts/tests/test-maintainer-gate-origin-worker-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-origin-worker-api-failure.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#27611: collaborator permission API failures must
+# not be coerced into external-author remediation and permanent ever-NMR state.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/maintainer-gate-reusable.yml"
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+	printf 'FAIL %s' "$test_name"
+	if [[ -n "$detail" ]]; then
+		printf ': %s' "$detail"
+	fi
+	printf '\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT="$(mktemp -d -t maintainer-gate-origin-worker.XXXXXX)"
+	mkdir -p "${TEST_ROOT}/bin"
+	export GH_CALLS="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_CALLS"
+
+	python3 - "$WORKFLOW_FILE" "${TEST_ROOT}/job.sh" <<'PY'
+import pathlib
+import sys
+import yaml
+
+workflow = yaml.safe_load(pathlib.Path(sys.argv[1]).read_text())
+steps = workflow["jobs"]["protect-origin-worker-label"]["steps"]
+run = next(step["run"] for step in steps if "run" in step)
+pathlib.Path(sys.argv[2]).write_text(run)
+PY
+
+	cat >"${TEST_ROOT}/bin/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$GH_CALLS"
+if [[ "${1:-}" == "api" && "${2:-}" == */collaborators/*/permission ]]; then
+	case "${GH_SCENARIO:-}" in
+		api-failure) exit 1 ;;
+		trusted) printf 'write\n'; exit 0 ;;
+		external|unknown-association) printf 'none\n'; exit 0 ;;
+	esac
+fi
+if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "${2:-}" == */comments ]]; then
+	printf '1\n'
+	exit 0
+fi
+printf 'unsupported gh invocation: %s\n' "$*" >&2
+exit 1
+GH_STUB
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+run_job() {
+	local scenario="$1"
+	local author_association="$2"
+	local action="${3:-labeled}"
+	local issue_author="${4:-runner}"
+	GH_SCENARIO="$scenario" \
+		ISSUE_NUMBER=42 \
+		ACTION="$action" \
+		ACTOR=runner \
+		REPO=owner/repo \
+		REPO_OWNER=owner \
+		ISSUE_AUTHOR="$issue_author" \
+		ISSUE_AUTHOR_ASSOC="$author_association" \
+		GH_TOKEN=test-token \
+		PATH="${TEST_ROOT}/bin:${PATH}" \
+		bash -e "${TEST_ROOT}/job.sh"
+}
+
+assert_no_label_mutation() {
+	local test_name="$1"
+	if grep -q '^issue edit ' "$GH_CALLS"; then
+		print_result "$test_name" 1 "unexpected issue edit: $(grep '^issue edit ' "$GH_CALLS")"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_api_failure_is_non_mutating() {
+	: >"$GH_CALLS"
+	if run_job api-failure COLLABORATOR >/dev/null 2>&1; then
+		print_result "permission API failure fails the protection job" 1 "expected non-zero exit"
+	else
+		print_result "permission API failure fails the protection job" 0
+	fi
+	assert_no_label_mutation "permission API failure leaves labels unchanged"
+	return 0
+}
+
+test_trusted_collaborator_is_allowed() {
+	: >"$GH_CALLS"
+	if run_job trusted COLLABORATOR >/dev/null 2>&1; then
+		print_result "write collaborator is allowed" 0
+	else
+		print_result "write collaborator is allowed" 1 "job returned non-zero"
+	fi
+	assert_no_label_mutation "write collaborator does not trigger remediation"
+	return 0
+}
+
+test_confirmed_external_is_remediated() {
+	: >"$GH_CALLS"
+	if run_job external NONE >/dev/null 2>&1; then
+		print_result "confirmed external actor completes remediation" 0
+	else
+		print_result "confirmed external actor completes remediation" 1 "job returned non-zero"
+	fi
+	if grep -q '^issue edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then
+		print_result "confirmed external actor receives NMR gate" 0
+	else
+		print_result "confirmed external actor receives NMR gate" 1 "expected NMR issue edit"
+	fi
+	return 0
+}
+
+test_unknown_author_association_is_non_mutating() {
+	: >"$GH_CALLS"
+	if run_job unknown-association API_ERROR >/dev/null 2>&1; then
+		print_result "unknown author association fails the protection job" 1 "expected non-zero exit"
+	else
+		print_result "unknown author association fails the protection job" 0
+	fi
+	assert_no_label_mutation "unknown author association leaves labels unchanged"
+	return 0
+}
+
+test_owner_authored_unlabel_is_restored_from_webhook() {
+	: >"$GH_CALLS"
+	if run_job external OWNER unlabeled owner >/dev/null 2>&1; then
+		print_result "owner-authored origin label removal completes restoration" 0
+	else
+		print_result "owner-authored origin label removal completes restoration" 1 "job returned non-zero"
+	fi
+	if grep -q '^issue edit .*--add-label origin:worker' "$GH_CALLS"; then
+		print_result "owner-authored origin label is restored" 0
+	else
+		print_result "owner-authored origin label is restored" 1 "expected origin:worker issue edit"
+	fi
+	if grep -q '^api .*issues/42 ' "$GH_CALLS"; then
+		print_result "owner-authored restoration avoids redundant issue lookup" 1 "unexpected issue metadata API call"
+	else
+		print_result "owner-authored restoration avoids redundant issue lookup" 0
+	fi
+	return 0
+}
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+	test_api_failure_is_non_mutating
+	test_trusted_collaborator_is_allowed
+	test_confirmed_external_is_remediated
+	test_unknown_author_association_is_non_mutating
+	test_owner_authored_unlabel_is_restored_from_webhook
+	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -960,6 +960,8 @@ jobs:
           ACTOR: ${{ github.actor }}
           REPO: ${{ github.repository }}
           REPO_OWNER: ${{ github.repository_owner }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_AUTHOR_ASSOC: ${{ github.event.issue.author_association }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "origin:worker label $ACTION on issue #$ISSUE_NUMBER by $ACTOR (repo owner: $REPO_OWNER)"
@@ -1014,35 +1016,57 @@ jobs:
           # t2691/GH#20311: Check if the actor is a collaborator with write
           # access. The /collaborators/{username}/permission endpoint returns
           # the user's effective permission level. Non-collaborators (external
-          # contributors) return permission=none or HTTP 404; both map to
-          # "none" via the fallback. write/admin/maintain = trusted runner.
-          ACTOR_PERM=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
-            --jq '.permission // "none"' 2>/dev/null || echo "none")
-          if [[ "$ACTOR_PERM" == "write" || "$ACTOR_PERM" == "admin" || "$ACTOR_PERM" == "maintain" ]]; then
-            echo "ALLOWED: collaborator $ACTOR (permission=$ACTOR_PERM) — origin:worker label change accepted (t2691, GH#20311)"
-            exit 0
+          # contributors) return a successful response with permission=none.
+          #
+          # GH#27611: API failures are infrastructure uncertainty, not proof
+          # that an actor is external. The old `... || echo "none"` command
+          # substitution retained GitHub's rate-limit JSON on stdout, then
+          # fell through to destructive external-author remediation. That
+          # incorrectly converted trusted runner issues #27576/#27578 into
+          # permanent ever-NMR authority holds. Fail without mutating labels;
+          # a workflow rerun can re-evaluate once the API recovers.
+          #aidevops:trust-boundary GH#18197/GH#20311/GH#27611
+          ACTOR_PERM=""
+          if ! ACTOR_PERM=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
+            --jq '.permission // "none"' 2>/dev/null); then
+            echo "::error::Unable to verify permission for actor $ACTOR — leaving origin:worker and dispatch labels unchanged"
+            exit 1
           fi
+          case "$ACTOR_PERM" in
+            write|admin|maintain)
+              echo "ALLOWED: collaborator $ACTOR (permission=$ACTOR_PERM) — origin:worker label change accepted (t2691, GH#20311)"
+              exit 0
+              ;;
+            none|read|triage)
+              ;;
+            *)
+              echo "::error::Unexpected collaborator permission value for actor $ACTOR — leaving labels unchanged"
+              exit 1
+              ;;
+          esac
 
           echo "DENIED: $ACTOR is not in the allowlist — reversing origin:worker label $ACTION"
 
           if [[ "$ACTION" == "labeled" ]]; then
-            # Non-allowlisted actor added the label. Fetch the issue author's
-            # association to decide the remediation (t2450). For external
+            # Non-allowlisted actor added the label. Use immutable webhook
+            # metadata for the issue author's association (t2450). For external
             # contributors, stripping `origin:worker` alone isn't enough —
             # the `tier:*` label the labelless-backfill applies alongside it
             # (pulse-issue-reconcile.sh::reconcile_labelless_aidevops_issues)
             # is what actually makes the issue dispatchable. We must also
             # strip `tier:*` and apply `needs-maintainer-review` to close
             # the full gating gap. Reference: #20180, #20184.
-            ISSUE_AUTHOR_ASSOC=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" \
-              --jq '.author_association // "NONE"' 2>/dev/null || echo "NONE")
-
             # External-contributor classes. Fail-closed: unknown values are
-            # treated as external. The cost of false-positive external is
-            # one NMR review; the cost of the opposite is the #20180 bug.
+            # infrastructure uncertainty, so preserve current labels and fail
+            # visibly instead of creating an irreversible ever-NMR record.
             EXTERNAL_AUTHOR="true"
             case "$ISSUE_AUTHOR_ASSOC" in
               OWNER|MEMBER|COLLABORATOR) EXTERNAL_AUTHOR="false" ;;
+              CONTRIBUTOR|FIRST_TIME_CONTRIBUTOR|FIRST_TIMER|MANNEQUIN|NONE) ;;
+              *)
+                echo "::error::Unexpected author association for issue #$ISSUE_NUMBER (author=$ISSUE_AUTHOR) — leaving labels unchanged"
+                exit 1
+                ;;
             esac
 
             if [[ "$EXTERNAL_AUTHOR" == "true" ]]; then
@@ -1067,8 +1091,8 @@ jobs:
           else
             # Non-allowlisted actor removed the label — re-apply it only if
             # the issue was authored by the bot OR the repo owner (both
-            # valid pulse authorship paths).
-            ISSUE_AUTHOR=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.user.login' 2>/dev/null || echo "unknown")
+            # valid pulse authorship paths). Reuse webhook metadata rather than
+            # introducing another API-failure-to-identity fallback.
             if [[ "$ISSUE_AUTHOR" == "github-actions[bot]" ]] || [[ "$ISSUE_AUTHOR" == "$REPO_OWNER" ]]; then
               gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "origin:worker"
               NOTICE="The \`origin:worker\` label was re-applied automatically. This issue was created by the automation pipeline and its provenance label cannot be removed by non-maintainer contributors."


### PR DESCRIPTION
## Summary

Prevent GitHub API failures from coercing trusted origin:worker events into external-author NMR remediation; reuse validated webhook author metadata and add executable workflow regression coverage.

## Files Changed

.agents/scripts/tests/test-maintainer-gate-origin-worker-api-failure.sh, .github/workflows/maintainer-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 11 focused execution-path assertions; maintainer-gate trusted-origin, label invariant, and workflow cascade tests; ShellCheck; actionlint; YAML parse; linters-local.sh.

Resolves #27611


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.109 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 9m and 140,151 tokens on this with the user in an interactive session.