### PR TITLE
GH#27604: fix: trust pinned deployed full-loop wrapper alias

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
@@ -2,11 +2,19 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import { execFileSync } from "child_process";
-import { existsSync } from "fs";
+import { existsSync, realpathSync } from "fs";
 import { homedir } from "os";
 import { join, resolve } from "path";
 
-function isTrustedFullLoopCommitAndPr(command, scriptsDir, cwd) {
+function resolvesTo(candidatePath, expectedPath) {
+  try {
+    return realpathSync(candidatePath) === realpathSync(expectedPath);
+  } catch {
+    return false;
+  }
+}
+
+function isTrustedFullLoopCommitAndPr(command, scriptsDir, cwd, activeScriptsDir) {
   const wrapperMatch = command.match(
     /(?:^|[($;|&\s])(?<wrapper>[^\s'";$|&()]*full-loop-helper\.sh)\s+commit-and-pr(?:\s|$)/,
   );
@@ -14,13 +22,15 @@ function isTrustedFullLoopCommitAndPr(command, scriptsDir, cwd) {
 
   const wrapper = wrapperMatch.groups.wrapper;
   const deployedPath = resolve(scriptsDir, "full-loop-helper.sh");
+  const activeDeployedPath = resolve(activeScriptsDir, "full-loop-helper.sh");
   const repositoryPath = resolve(cwd, ".agents", "scripts", "full-loop-helper.sh");
   let candidatePath;
   if (wrapper === "full-loop-helper.sh") candidatePath = deployedPath;
   else if (wrapper.startsWith("~/")) candidatePath = resolve(homedir(), wrapper.slice(2));
   else if (wrapper.startsWith("$PWD/")) candidatePath = resolve(cwd, wrapper.slice(5));
   else candidatePath = resolve(cwd, wrapper);
-  return [deployedPath, repositoryPath].includes(candidatePath) && existsSync(candidatePath);
+  if ([deployedPath, repositoryPath].includes(candidatePath)) return existsSync(candidatePath);
+  return candidatePath === activeDeployedPath && resolvesTo(candidatePath, deployedPath);
 }
 
 function isWorkerContext(env = process.env) {
@@ -39,7 +49,14 @@ export function checkCommandSafetyGate(command, scriptsDir, cwd = process.cwd(),
     throw new Error("BLOCKED: required command policy helper is missing");
   }
   const namesFullLoopCommitAndPr = /full-loop-helper\.sh\s+commit-and-pr(?:\s|$)/.test(command);
-  const trustedFullLoopCommitAndPr = isTrustedFullLoopCommitAndPr(command, scriptsDir, cwd);
+  const activeScriptsDir = options.activeScriptsDir
+    ?? join(homedir(), ".aidevops", "agents", "scripts");
+  const trustedFullLoopCommitAndPr = isTrustedFullLoopCommitAndPr(
+    command,
+    scriptsDir,
+    cwd,
+    activeScriptsDir,
+  );
   if (namesFullLoopCommitAndPr && !trustedFullLoopCommitAndPr) {
     throw new Error("BLOCKED: unclassified nested Git invocation from an untrusted full-loop wrapper");
   }

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -102,7 +102,7 @@ test("allows the repository full-loop commit-and-pr wrapper only from a linked w
     );
     const activeWrapper = join(activeScriptsDir, "full-loop-helper.sh");
     assert.doesNotThrow(() => checkCanonicalGitSafetyGate(
-      `${activeWrapper} commit-and-pr --issue 123`,
+      `PR_NUMBER=$(${activeWrapper} commit-and-pr --issue 123 --message 'fix: example')`,
       scriptsDir,
       linked,
       { activeScriptsDir },
@@ -141,6 +141,14 @@ test("does not trust similarly named full-loop wrappers", () => {
   try {
     assert.throws(
       () => checkCanonicalGitSafetyGate("./tmp/full-loop-helper.sh commit-and-pr --testing 'git tests pass'", scriptsDir, linked),
+      /unclassified nested Git invocation/,
+    );
+    assert.throws(
+      () => checkCanonicalGitSafetyGate(
+        "$HOME/.aidevops/agents/scripts/full-loop-helper.sh commit-and-pr --issue 123",
+        scriptsDir,
+        linked,
+      ),
       /unclassified nested Git invocation/,
     );
     const unrelatedScripts = join(root, "unrelated", "scripts");

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -3,7 +3,15 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { copyFileSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -59,6 +67,7 @@ test("allows read-only canonical commands and linked-worktree mutation", () => {
 test("allows the repository full-loop commit-and-pr wrapper only from a linked worktree", () => {
   const { root, repo, linked } = setupRepo();
   const wrapperCommand = "PR_NUMBER=$(full-loop-helper.sh commit-and-pr --issue 123 --testing 'git tests pass')";
+  const activeScriptsDir = join(root, "active", "agents", "scripts");
   try {
     mkdirSync(join(repo, ".agents", "scripts"), { recursive: true });
     writeFileSync(join(repo, ".agents", "scripts", "full-loop-helper.sh"), "#!/bin/sh\n");
@@ -69,12 +78,44 @@ test("allows the repository full-loop commit-and-pr wrapper only from a linked w
 
     mkdirSync(join(linked, ".agents", "scripts"), { recursive: true });
     writeFileSync(join(linked, ".agents", "scripts", "full-loop-helper.sh"), "#!/bin/sh\n");
+    mkdirSync(dirname(activeScriptsDir), { recursive: true });
+    symlinkSync(scriptsDir, activeScriptsDir, "dir");
     assert.doesNotThrow(() => checkCanonicalGitSafetyGate(wrapperCommand, scriptsDir, linked));
     assert.doesNotThrow(() => checkCanonicalGitSafetyGate(
       "./.agents/scripts/full-loop-helper.sh commit-and-pr --issue 123 --testing 'git tests pass'",
       scriptsDir,
       linked,
     ));
+    const repositoryWrapper = join(linked, ".agents", "scripts", "full-loop-helper.sh");
+    assert.doesNotThrow(() => checkCanonicalGitSafetyGate(
+      `${repositoryWrapper} commit-and-pr --issue 123`,
+      scriptsDir,
+      linked,
+    ));
+    assert.throws(
+      () => checkCanonicalGitSafetyGate(
+        `${join(repo, ".agents", "scripts", "full-loop-helper.sh")} commit-and-pr --issue 123`,
+        scriptsDir,
+        repo,
+      ),
+      /canonical worktree mutation/,
+    );
+    const activeWrapper = join(activeScriptsDir, "full-loop-helper.sh");
+    assert.doesNotThrow(() => checkCanonicalGitSafetyGate(
+      `${activeWrapper} commit-and-pr --issue 123`,
+      scriptsDir,
+      linked,
+      { activeScriptsDir },
+    ));
+    assert.throws(
+      () => checkCanonicalGitSafetyGate(
+        `${activeWrapper} commit-and-pr --issue 123`,
+        scriptsDir,
+        repo,
+        { activeScriptsDir },
+      ),
+      /canonical worktree mutation/,
+    );
     assert.doesNotThrow(() => checkCanonicalGitSafetyGate(
       `${join(scriptsDir, "full-loop-helper.sh")} commit-and-pr --issue 123 --testing 'git tests pass'`,
       scriptsDir,
@@ -100,6 +141,18 @@ test("does not trust similarly named full-loop wrappers", () => {
   try {
     assert.throws(
       () => checkCanonicalGitSafetyGate("./tmp/full-loop-helper.sh commit-and-pr --testing 'git tests pass'", scriptsDir, linked),
+      /unclassified nested Git invocation/,
+    );
+    const unrelatedScripts = join(root, "unrelated", "scripts");
+    mkdirSync(unrelatedScripts, { recursive: true });
+    writeFileSync(join(unrelatedScripts, "full-loop-helper.sh"), "#!/bin/sh\n");
+    assert.throws(
+      () => checkCanonicalGitSafetyGate(
+        `${join(unrelatedScripts, "full-loop-helper.sh")} commit-and-pr --issue 123`,
+        scriptsDir,
+        linked,
+        { activeScriptsDir: unrelatedScripts },
+      ),
       /unclassified nested Git invocation/,
     );
   } finally {


### PR DESCRIPTION
## Summary

Allow the stable deployed full-loop-helper path only when it resolves to the OpenCode process's pinned runtime bundle; add linked/canonical and alias-identity regression coverage.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs, .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs; bash .agents/scripts/tests/test-canonical-git-command-guard.sh

Resolves #27604


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.110 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 3m and 79,561 tokens on this as a headless worker.