### PR TITLE
GH#27611: Preserve NMR labels on approval API errors

### DIFF
--- a/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#27611: signed-approval and PR-label API failures
+# must not be coerced into authority decisions or label mutations.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/maintainer-gate-reusable.yml"
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+	printf 'FAIL %s' "$test_name"
+	if [[ -n "$detail" ]]; then
+		printf ': %s' "$detail"
+	fi
+	printf '\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT="$(mktemp -d -t maintainer-gate-approval.XXXXXX)"
+	mkdir -p "${TEST_ROOT}/bin"
+	export GH_CALLS="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_CALLS"
+
+	python3 - "$WORKFLOW_FILE" "$TEST_ROOT" <<'PY'
+import pathlib
+import sys
+import yaml
+
+workflow = yaml.safe_load(pathlib.Path(sys.argv[1]).read_text())
+root = pathlib.Path(sys.argv[2])
+for job_name, output_name in (
+    ("protect-labels", "issue-job.sh"),
+    ("protect-pr-labels", "pr-job.sh"),
+):
+    steps = workflow["jobs"][job_name]["steps"]
+    run = next(step["run"] for step in steps if "run" in step)
+    (root / output_name).write_text(run)
+PY
+
+	cat >"${TEST_ROOT}/bin/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$GH_CALLS"
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	case "${GH_SCENARIO:-}" in
+		pr-label-failure) exit 1 ;;
+		pr-*) printf 'external-contributor\n'; exit 0 ;;
+	esac
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == */comments ]]; then
+	case "${GH_SCENARIO:-}" in
+		issue-api-failure|pr-approval-failure) exit 1 ;;
+		issue-invalid|pr-invalid) printf '{"message":"rate limited"}\n'; exit 0 ;;
+		issue-signed|pr-signed) printf '1\n'; exit 0 ;;
+		issue-unsigned|pr-unsigned) printf '0\n'; exit 0 ;;
+	esac
+fi
+
+if [[ "${1:-}" == "issue" && ( "${2:-}" == "edit" || "${2:-}" == "comment" ) ]]; then
+	exit 0
+fi
+if [[ "${1:-}" == "pr" && ( "${2:-}" == "edit" || "${2:-}" == "comment" ) ]]; then
+	exit 0
+fi
+
+printf 'unsupported gh invocation: %s\n' "$*" >&2
+exit 1
+GH_STUB
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+run_issue_job() {
+	local scenario="$1"
+	GH_SCENARIO="$scenario" \
+		ISSUE_NUMBER=42 \
+		ISSUE_AUTHOR=external \
+		ACTOR=maintainer \
+		ACTOR_ASSOCIATION=OWNER \
+		REPO=owner/repo \
+		GH_TOKEN=test-token \
+		PATH="${TEST_ROOT}/bin:${PATH}" \
+		bash -e "${TEST_ROOT}/issue-job.sh"
+}
+
+run_pr_job() {
+	local scenario="$1"
+	GH_SCENARIO="$scenario" \
+		PR_NUMBER=43 \
+		PR_AUTHOR=external \
+		ACTOR=maintainer \
+		REPO=owner/repo \
+		GH_TOKEN=test-token \
+		PATH="${TEST_ROOT}/bin:${PATH}" \
+		bash -e "${TEST_ROOT}/pr-job.sh"
+}
+
+assert_no_mutation() {
+	local test_name="$1"
+	if grep -qE '^(issue|pr) edit ' "$GH_CALLS"; then
+		print_result "$test_name" 1 "unexpected edit: $(grep -E '^(issue|pr) edit ' "$GH_CALLS")"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+assert_job_fails_without_mutation() {
+	local target="$1"
+	local scenario="$2"
+	local test_prefix="$3"
+	: >"$GH_CALLS"
+	if [[ "$target" == "issue" ]]; then
+		if run_issue_job "$scenario" >/dev/null 2>&1; then
+			print_result "$test_prefix fails the job" 1 "expected non-zero exit"
+		else
+			print_result "$test_prefix fails the job" 0
+		fi
+	else
+		if run_pr_job "$scenario" >/dev/null 2>&1; then
+			print_result "$test_prefix fails the job" 1 "expected non-zero exit"
+		else
+			print_result "$test_prefix fails the job" 0
+		fi
+	fi
+	assert_no_mutation "$test_prefix leaves labels unchanged"
+	return 0
+}
+
+test_issue_approval_paths() {
+	assert_job_fails_without_mutation issue issue-api-failure "issue approval API failure"
+	assert_job_fails_without_mutation issue issue-invalid "invalid issue approval response"
+	: >"$GH_CALLS"
+	if run_issue_job issue-signed >/dev/null 2>&1; then
+		print_result "signed issue approval is accepted" 0
+	else
+		print_result "signed issue approval is accepted" 1 "job returned non-zero"
+	fi
+	assert_no_mutation "signed issue approval does not restore NMR"
+	: >"$GH_CALLS"
+	run_issue_job issue-unsigned >/dev/null 2>&1 || true
+	if grep -q '^issue edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then
+		print_result "confirmed unsigned issue restores NMR" 0
+	else
+		print_result "confirmed unsigned issue restores NMR" 1 "expected issue edit"
+	fi
+	return 0
+}
+
+test_pr_approval_paths() {
+	assert_job_fails_without_mutation pr pr-label-failure "PR label API failure"
+	assert_job_fails_without_mutation pr pr-approval-failure "PR approval API failure"
+	assert_job_fails_without_mutation pr pr-invalid "invalid PR approval response"
+	: >"$GH_CALLS"
+	if run_pr_job pr-signed >/dev/null 2>&1; then
+		print_result "signed PR approval is accepted" 0
+	else
+		print_result "signed PR approval is accepted" 1 "job returned non-zero"
+	fi
+	assert_no_mutation "signed PR approval does not restore NMR"
+	: >"$GH_CALLS"
+	run_pr_job pr-unsigned >/dev/null 2>&1 || true
+	if grep -q '^pr edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then
+		print_result "confirmed unsigned external PR restores NMR" 0
+	else
+		print_result "confirmed unsigned external PR restores NMR" 1 "expected PR edit"
+	fi
+	return 0
+}
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+	test_issue_approval_paths
+	test_pr_approval_paths
+	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -217,15 +217,36 @@ jobs:
           # external contributor PRs. Requires cryptographic approval on the
           # PR's comments (same pattern as issue approval).
           # ---------------------------------------------------------------
-          PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-            --json labels --jq '.labels[].name' 2>/dev/null || true)
+          #aidevops:trust-boundary GH#17671/GH#27611: a failed PR-label read
+          # cannot be treated as an empty trusted label set.
+          PR_LABELS=""
+          if ! PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json labels --jq '.labels[].name' 2>/dev/null); then
+            echo "::error::Unable to verify labels for PR #$PR_NUMBER"
+            post_maintainer_gate_status_with_retry failure "Unable to verify PR maintainer-review labels"
+            exit 1
+          fi
 
           if echo "$PR_LABELS" | grep -q 'needs-maintainer-review'; then
             # Check for signed approval comment on the PR itself
-            SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-              --paginate \
-              --jq '[.[] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
-              2>/dev/null || echo "0")
+            #aidevops:trust-boundary GH#17671/GH#27611: an API failure is not
+            # evidence that a signed approval is absent. Fail the check rather
+            # than silently converting infrastructure uncertainty into a trust
+            # verdict.
+            SIGNED_APPROVAL=""
+            if ! SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              --paginate --slurp \
+              --jq '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
+              2>/dev/null); then
+              echo "::error::Unable to verify signed approvals for PR #$PR_NUMBER"
+              post_maintainer_gate_status_with_retry failure "Unable to verify signed maintainer approval"
+              exit 1
+            fi
+            if [[ ! "$SIGNED_APPROVAL" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid signed-approval response for PR #$PR_NUMBER"
+              post_maintainer_gate_status_with_retry failure "Invalid signed maintainer approval response"
+              exit 1
+            fi
 
             if [[ "$SIGNED_APPROVAL" -gt 0 ]]; then
               echo "PR #$PR_NUMBER has needs-maintainer-review but signed approval found — continuing"
@@ -569,10 +590,22 @@ jobs:
           # Even admin/maintainer actors must use the approval command —
           # manual label removal alone is insufficient because it leaves
           # no auditable cryptographic proof of approval.
-          SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
-            --paginate \
-            --jq '[.[] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
-            2>/dev/null || echo "0")
+          #aidevops:trust-boundary GH#1894/GH#27611: comments API failures are
+          # infrastructure uncertainty, not proof that approval is absent.
+          # Never create/recreate an irreversible ever-NMR authority record from
+          # a failed lookup.
+          SIGNED_APPROVAL=""
+          if ! SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            --paginate --slurp \
+            --jq '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
+            2>/dev/null); then
+            echo "::error::Unable to verify signed approvals for issue #$ISSUE_NUMBER — leaving labels unchanged"
+            exit 1
+          fi
+          if [[ ! "$SIGNED_APPROVAL" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid signed-approval response for issue #$ISSUE_NUMBER — leaving labels unchanged"
+            exit 1
+          fi
 
           if [[ "$SIGNED_APPROVAL" -gt 0 ]]; then
             echo "ALLOWED: Signed approval comment found — label removal accepted"
@@ -585,9 +618,14 @@ jobs:
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs-maintainer-review"
 
           # Post a comment explaining why
-          EXISTING=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
-            --paginate \
-            --jq "[.[] | select(.body | test(\"label-protection-notice\"))] | length" 2>/dev/null || echo "0")
+          EXISTING=""
+          if ! EXISTING=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            --paginate --slurp \
+            --jq "[.[][] | select(.body | test(\"label-protection-notice\"))] | length" 2>/dev/null); then
+            echo "::warning::Unable to check for an existing label-protection notice — skipping comment"
+            exit 0
+          fi
+          [[ "$EXISTING" =~ ^[0-9]+$ ]] || exit 0
 
           if [[ "$EXISTING" == "0" ]]; then
             gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "<!-- label-protection-notice -->
@@ -892,8 +930,15 @@ jobs:
           # Only protect PRs that were labelled external-contributor.
           # Internal PRs (from collaborators) should never have had NMR in
           # the first place — don't fight a manual correction on those.
-          PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-            --json labels --jq '.labels[].name' 2>/dev/null || true)
+          #aidevops:trust-boundary GH#17671/GH#27611: a failed label lookup
+          # must not make an external PR appear internal and permit an NMR
+          # removal without approval.
+          PR_LABELS=""
+          if ! PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json labels --jq '.labels[].name' 2>/dev/null); then
+            echo "::error::Unable to verify labels for PR #$PR_NUMBER — leaving labels unchanged"
+            exit 1
+          fi
 
           if ! echo "$PR_LABELS" | grep -q 'external-contributor'; then
             echo "ALLOWED: PR #$PR_NUMBER is not an external-contributor PR — label removal accepted"
@@ -902,10 +947,18 @@ jobs:
 
           # Check for a cryptographic signed approval comment on the PR.
           # PRs use the same issues API endpoint for comments.
-          SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --paginate \
-            --jq '[.[] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
-            2>/dev/null || echo "0")
+          SIGNED_APPROVAL=""
+          if ! SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --slurp \
+            --jq '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
+            2>/dev/null); then
+            echo "::error::Unable to verify signed approvals for PR #$PR_NUMBER — leaving labels unchanged"
+            exit 1
+          fi
+          if [[ ! "$SIGNED_APPROVAL" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid signed-approval response for PR #$PR_NUMBER — leaving labels unchanged"
+            exit 1
+          fi
 
           if [[ "$SIGNED_APPROVAL" -gt 0 ]]; then
             echo "ALLOWED: Signed approval comment found — label removal accepted"
@@ -918,9 +971,14 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "needs-maintainer-review"
 
           # Post a comment explaining why (only once)
-          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --paginate \
-            --jq "[.[] | select(.body | test(\"pr-label-protection-notice\"))] | length" 2>/dev/null || echo "0")
+          EXISTING=""
+          if ! EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --slurp \
+            --jq "[.[][] | select(.body | test(\"pr-label-protection-notice\"))] | length" 2>/dev/null); then
+            echo "::warning::Unable to check for an existing PR label-protection notice — skipping comment"
+            exit 0
+          fi
+          [[ "$EXISTING" =~ ^[0-9]+$ ]] || exit 0
 
           if [[ "$EXISTING" == "0" ]]; then
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body "<!-- pr-label-protection-notice -->


### PR DESCRIPTION
## Summary

Complete the systemic fix by making issue/PR approval and PR-label lookups fail without label mutation on API uncertainty, flatten paginated comment results, and retain confirmed unsigned-remediation behavior.

## Files Changed

.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh, .github/workflows/maintainer-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 16 focused approval execution-path assertions; 11 origin-worker assertions; trusted-origin, label-invariant, and workflow-cascade suites; ShellCheck; actionlint; linters-local.sh.

Resolves #27611


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.110 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 37m and 232,538 tokens on this with the user in an interactive session.