### PR TITLE
GH#27576: clarify session diagnostic ID guard

### DIFF
--- a/.agents/workflows/session-analysis.md
+++ b/.agents/workflows/session-analysis.md
@@ -55,10 +55,11 @@ dependencies; do not silently expand into a whole-repository audit.
 Use the conversation and existing tool results first. Run only relevant,
 available diagnostics. Obtain the current runtime ID with
 `printenv OPENCODE_SESSION_ID || printenv CLAUDE_SESSION_ID || true`, then
-substitute the returned literal for `<session-id>`; this remains successful when
-neither variable is set and avoids expansion that command-policy parsing may
-reject. If the command returns no literal, mark session-specific diagnostics
-unavailable and skip every command requiring `<session-id>`.
+substitute the returned literal for `<session-id>` only when it is non-empty;
+this remains successful when neither variable is set and avoids expansion that
+command-policy parsing may reject. If the command returns no literal, mark
+session-specific diagnostics unavailable and skip every command requiring
+`<session-id>`.
 
 | Evidence | Command or source | Run when |
 |---|---|---|


### PR DESCRIPTION
## Summary

Require a non-empty runtime session ID before substituting it into session-specific diagnostics, and explicitly skip those commands when no ID is available.

## Files Changed

.agents/workflows/session-analysis.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 .agents/workflows/session-analysis.md; git diff --check

Resolves #27576


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.111 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 2m and 31,407 tokens on this as a headless worker.