### PR TITLE
t18120: fix: preserve exact OpenCode session identity

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -152,13 +152,16 @@ export function createShellEnvHook(deps) {
       output.env.AIDEVOPS_VERSION = version;
     }
 
-    // Signature helpers need the current OpenCode session, not a session guessed
-    // from the long-lived app process start time (GH#22003). OpenCode hook input
-    // has changed shape across releases, so accept the known variants and keep
-    // this best-effort: absence should not block shell startup.
+    // Shell helpers need the exact current OpenCode conversation, not an ID
+    // inherited from a previous plugin instance or long-lived app process
+    // (GH#22003, GH#27574). AIDEVOPS_SESSION_ID may intentionally name a
+    // framework session, so publish the OpenCode side of that mapping explicitly.
+    // OpenCode hook input has changed shape across releases, so accept the known
+    // variants and keep this best-effort: absence should not block shell startup.
     const sessionId = getSessionId(input);
-    if (sessionId && !output.env.OPENCODE_SESSION_ID) {
+    if (sessionId) {
       output.env.OPENCODE_SESSION_ID = sessionId;
+      output.env.AIDEVOPS_OPENCODE_SESSION_ID = sessionId;
     }
 
     const modelId = getModelId(input);

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -118,6 +118,37 @@ test("headless OpenCode shell stamps worker origin", async () => {
   assert.equal(output.env.AIDEVOPS_SESSION_ORIGIN, "worker");
 });
 
+test("shell env replaces stale OpenCode identity after a plugin update", async () => {
+  const hook = makeHook();
+  const output = {
+    env: {
+      PATH: "/usr/bin:/bin",
+      OPENCODE_SESSION_ID: "stale-opencode-session",
+      AIDEVOPS_OPENCODE_SESSION_ID: "stale-opencode-session",
+    },
+  };
+
+  await hook({ sessionID: "current-opencode-session" }, output);
+
+  assert.equal(output.env.OPENCODE_SESSION_ID, "current-opencode-session");
+  assert.equal(output.env.AIDEVOPS_OPENCODE_SESSION_ID, "current-opencode-session");
+});
+
+test("shell env preserves framework identity and publishes its OpenCode mapping", async () => {
+  const hook = makeHook();
+  const output = {
+    env: {
+      PATH: "/usr/bin:/bin",
+      AIDEVOPS_SESSION_ID: "framework-session",
+    },
+  };
+
+  await hook({ sessionID: "opencode-session" }, output);
+
+  assert.equal(output.env.AIDEVOPS_SESSION_ID, "framework-session");
+  assert.equal(output.env.AIDEVOPS_OPENCODE_SESSION_ID, "opencode-session");
+});
+
 test("headless shell preserves explicit worker lineage", async () => {
   const keys = [
     "AIDEVOPS_WORKER_ID",

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -650,7 +650,8 @@ copy_scoped_opencode_auth() {
 }
 
 run_without_opencode_session_env() {
-	env -u OPENCODE_SESSION_ID \
+	env -u AIDEVOPS_OPENCODE_SESSION_ID \
+		-u OPENCODE_SESSION_ID \
 		-u OPENCODE_PID \
 		-u OPENCODE_RUN_ID \
 		-u OPENCODE_PROCESS_ROLE \
@@ -670,7 +671,7 @@ build_sandbox_passthrough_csv() {
 		case "$name" in
 		# Session-bound OpenCode env makes isolated canary/worker runs attach to
 		# the parent TUI session and fail with "Session not found" (GH#23065).
-		OPENCODE_SESSION_ID | OPENCODE_PID | OPENCODE_RUN_ID | OPENCODE_PROCESS_ROLE | OPENCODE | OPENCODE_SERVER_PASSWORD) ;;
+		AIDEVOPS_OPENCODE_SESSION_ID | OPENCODE_SESSION_ID | OPENCODE_PID | OPENCODE_RUN_ID | OPENCODE_PROCESS_ROLE | OPENCODE | OPENCODE_SERVER_PASSWORD) ;;
 		OPENAI_* | ANTHROPIC_* | GOOGLE_* | CLAUDE_*)
 			if [[ -n "$provider" ]] && ! _headless_provider_env_allowed "$provider" "$name"; then
 				continue

--- a/.agents/scripts/session-output-efficiency-helper.sh
+++ b/.agents/scripts/session-output-efficiency-helper.sh
@@ -24,9 +24,19 @@ Options:
   --max-findings N                Limit aggregate findings (default: 5)
 
 Without --input or --db, the helper resolves the runtime history path through
-the Vault-managed session-history read gate. Raw tool inputs and outputs are
-never emitted.
+the Vault-managed session-history read gate. Active OpenCode conversations are
+resolved from the runtime data store by exact ID. Raw tool inputs and outputs
+are never emitted.
 EOF
+	return 0
+}
+
+active_opencode_session() {
+	if [[ -n "${AIDEVOPS_OPENCODE_SESSION_ID:-}" ]]; then
+		printf '%s\n' "$AIDEVOPS_OPENCODE_SESSION_ID"
+	else
+		printf '%s\n' "${OPENCODE_SESSION_ID:-}"
+	fi
 	return 0
 }
 
@@ -36,7 +46,7 @@ resolve_runtime() {
 		printf '%s\n' "$requested"
 		return 0
 	fi
-	if [[ -n "${OPENCODE_SESSION_ID:-}" ]]; then
+	if [[ -n "${AIDEVOPS_OPENCODE_SESSION_ID:-}${OPENCODE_SESSION_ID:-}" ]]; then
 		printf '%s\n' "$OPENCODE_RUNTIME"
 		return 0
 	fi
@@ -52,11 +62,15 @@ resolve_session() {
 	local runtime="$1"
 	local requested="$2"
 	if [[ -n "$requested" ]]; then
+		if [[ "$runtime" == "$OPENCODE_RUNTIME" && -n "${AIDEVOPS_OPENCODE_SESSION_ID:-}" && -n "${AIDEVOPS_SESSION_ID:-}" && "$requested" == "$AIDEVOPS_SESSION_ID" ]]; then
+			active_opencode_session
+			return $?
+		fi
 		printf '%s\n' "$requested"
 		return 0
 	fi
 	case "$runtime" in
-	opencode) printf '%s\n' "${OPENCODE_SESSION_ID:-}" ;;
+	"$OPENCODE_RUNTIME") active_opencode_session ;;
 	claude-code) printf '%s\n' "${CLAUDE_SESSION_ID:-}" ;;
 	*) printf '\n' ;;
 	esac

--- a/.agents/scripts/session-review-helper.sh
+++ b/.agents/scripts/session-review-helper.sh
@@ -993,7 +993,7 @@ run_output_efficiency() {
 
 gather_output_efficiency() {
 	local session_filter="${1:-}"
-	if [[ -z "$session_filter" && -z "${OPENCODE_SESSION_ID:-}" && -z "${CLAUDE_SESSION_ID:-}" ]]; then
+	if [[ -z "$session_filter" && -z "${AIDEVOPS_OPENCODE_SESSION_ID:-}" && -z "${OPENCODE_SESSION_ID:-}" && -z "${CLAUDE_SESSION_ID:-}" ]]; then
 		return 0
 	fi
 	local -a args=()

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1100,7 +1100,7 @@ if [[ "${1:-}" == "--version" ]]; then
 	printf '1.14.31\n'
 	exit 0
 fi
-if [[ -n "${OPENCODE_SESSION_ID:-}${OPENCODE_PID:-}${OPENCODE_RUN_ID:-}${OPENCODE_PROCESS_ROLE:-}${OPENCODE:-}${OPENCODE_SERVER_PASSWORD:-}" ]]; then
+if [[ -n "${AIDEVOPS_OPENCODE_SESSION_ID:-}${OPENCODE_SESSION_ID:-}${OPENCODE_PID:-}${OPENCODE_RUN_ID:-}${OPENCODE_PROCESS_ROLE:-}${OPENCODE:-}${OPENCODE_SERVER_PASSWORD:-}" ]]; then
 	printf 'leaked session env\n' >"$AIDEVOPS_CANARY_ENV_FILE"
 	exit 42
 fi
@@ -1121,6 +1121,7 @@ EOF
 		HOME="${canary_root}/home" \
 		OPENCODE_BIN="${fake_bin_dir}/opencode" \
 		OPENCODE_DB="${canary_root}/opencode.db" \
+		AIDEVOPS_OPENCODE_SESSION_ID="ses_parent" \
 		OPENCODE_SESSION_ID="ses_parent" \
 		OPENCODE_PID="12345" \
 		OPENCODE_RUN_ID="run_parent" \
@@ -1163,6 +1164,7 @@ test_opencode_session_env_wrapper_strips_session_vars_only() {
 	local output
 	# shellcheck disable=SC2016 # Inner bash expands these after env stripping.
 	output=$(
+		AIDEVOPS_OPENCODE_SESSION_ID="ses_parent" \
 		OPENCODE_SESSION_ID="ses_parent" \
 		OPENCODE_PID="12345" \
 		OPENCODE_RUN_ID="run_parent" \
@@ -1172,14 +1174,14 @@ test_opencode_session_env_wrapper_strips_session_vars_only() {
 		OPENCODE_BIN="opencode" \
 		OPENCODE_DB="/tmp/opencode.db" \
 		run_without_opencode_session_env bash -c '
-			printf "%s|%s|%s|%s|%s|%s|%s|%s" \
-				"${OPENCODE_SESSION_ID:-}" "${OPENCODE_PID:-}" "${OPENCODE_RUN_ID:-}" \
+			printf "%s|%s|%s|%s|%s|%s|%s|%s|%s" \
+				"${AIDEVOPS_OPENCODE_SESSION_ID:-}" "${OPENCODE_SESSION_ID:-}" "${OPENCODE_PID:-}" "${OPENCODE_RUN_ID:-}" \
 				"${OPENCODE_PROCESS_ROLE:-}" "${OPENCODE:-}" "${OPENCODE_SERVER_PASSWORD:-}" \
 				"${OPENCODE_BIN:-}" "${OPENCODE_DB:-}"
 		'
 	)
 
-	if [[ "$output" == "||||||opencode|/tmp/opencode.db" ]]; then
+	if [[ "$output" == "|||||||opencode|/tmp/opencode.db" ]]; then
 		print_result "OpenCode session env wrapper strips only session-bound vars" 0
 		return 0
 	fi
@@ -1221,6 +1223,7 @@ test_sandbox_passthrough_scopes_provider_env() {
 		GOOGLE_API_KEY='google-test' \
 		OPENCODE_BIN='opencode' \
 		OPENCODE_DB='/tmp/opencode.db' \
+		AIDEVOPS_OPENCODE_SESSION_ID='ses_parent' \
 		OPENCODE_SESSION_ID='ses_parent' \
 		OPENCODE_PID='12345' \
 		OPENCODE_RUN_ID='run_parent' \
@@ -1235,6 +1238,7 @@ test_sandbox_passthrough_scopes_provider_env() {
 		[[ "$csv" != *"GOOGLE_API_KEY"* ]] &&
 		[[ "$csv" == *"OPENCODE_BIN"* ]] &&
 		[[ "$csv" == *"OPENCODE_DB"* ]] &&
+		[[ "$csv" != *"AIDEVOPS_OPENCODE_SESSION_ID"* ]] &&
 		[[ "$csv" != *"OPENCODE_SESSION_ID"* ]] &&
 		[[ "$csv" != *"OPENCODE_PID"* ]] &&
 		[[ "$csv" != *"OPENCODE_RUN_ID"* ]] &&

--- a/.agents/scripts/tests/test-session-output-efficiency.sh
+++ b/.agents/scripts/tests/test-session-output-efficiency.sh
@@ -141,6 +141,15 @@ for index in range(2):
         "INSERT INTO part (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
         (f"active-part-{index}", "active-session", index, json.dumps(part)),
     )
+unrelated_part = {
+    "type": "tool",
+    "tool": "read",
+    "state": {"status": "completed", "input": {}, "output": "UNRELATED-RECENT-SESSION"},
+}
+connection.execute(
+    "INSERT INTO part (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+    ("unrelated-part", "unrelated-recent-session", 1, json.dumps(unrelated_part)),
+)
 connection.commit()
 connection.close()
 PY
@@ -174,6 +183,36 @@ if python3 -c 'import json,sys; report=json.load(sys.stdin); assert report["sess
 else
 	fail "active OpenCode store resolves the exact current session"
 fi
+assert_omits "active aggregate report omits raw output" "SECRET-MARKER" "$active_output"
+assert_omits "active analysis does not substitute an unrelated recent session" "UNRELATED-RECENT-SESSION" "$active_output"
+
+mapped_output=$(
+	XDG_DATA_HOME="$active_data_home" \
+		AIDEVOPS_SESSION_ID="framework-session" \
+		OPENCODE_SESSION_ID="stale-opencode-session" \
+		AIDEVOPS_OPENCODE_SESSION_ID="active-session" \
+		"$HELPER" --runtime opencode --session framework-session --json
+)
+if python3 -c 'import json,sys; report=json.load(sys.stdin); assert report["session"] == "active-session"; assert report["stats"]["completed_tool_results"] == 2' <<<"$mapped_output"; then
+	pass "explicit framework-to-OpenCode identity mapping is honoured"
+else
+	fail "explicit framework-to-OpenCode identity mapping is honoured"
+fi
+
+set +e
+unmapped_output=$(
+	AIDEVOPS_SESSION_ID="framework-session" \
+		AIDEVOPS_OPENCODE_SESSION_ID='' \
+		OPENCODE_SESSION_ID="active-session" \
+		"$HELPER" --runtime opencode --db "$active_opencode_db" --session framework-session --json 2>&1
+)
+unmapped_rc=$?
+mismatched_output=$(OPENCODE_SESSION_ID='' AIDEVOPS_OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime opencode --db "$active_opencode_db" --session missing-active-session --json 2>&1)
+mismatched_rc=$?
+set -e
+[[ "$unmapped_rc" -eq 2 ]] && pass "framework identity requires an explicit OpenCode mapping" || fail "framework identity requires an explicit OpenCode mapping" "got ${unmapped_rc}"
+[[ "$mismatched_rc" -eq 2 ]] && pass "mismatched active identifier remains unavailable" || fail "mismatched active identifier remains unavailable" "got ${mismatched_rc}"
+assert_omits "mismatched identity does not expose unrelated recent sessions" "UNRELATED-RECENT-SESSION" "${unmapped_output}${mismatched_output}"
 
 set +e
 missing_session_output=$(OPENCODE_SESSION_ID='' CLAUDE_SESSION_ID='' "$HELPER" --runtime opencode --db "$opencode_db" --session absent-session 2>&1)

--- a/.agents/workflows/session-analysis.md
+++ b/.agents/workflows/session-analysis.md
@@ -53,13 +53,17 @@ dependencies; do not silently expand into a whole-repository audit.
 ## 2. Gather Minimum Sufficient Evidence
 
 Use the conversation and existing tool results first. Run only relevant,
-available diagnostics. Obtain the current runtime ID with
-`printenv OPENCODE_SESSION_ID || printenv CLAUDE_SESSION_ID || true`, then
-substitute the returned literal for `<session-id>` only when it is non-empty;
-this remains successful when neither variable is set and avoids expansion that
-command-policy parsing may reject. If the command returns no literal, mark
-session-specific diagnostics unavailable and skip every command requiring
-`<session-id>`.
+available diagnostics. For OpenCode, the authoritative conversation identity is
+`AIDEVOPS_OPENCODE_SESSION_ID`, stamped from each `shell.env` hook input; the
+legacy-compatible fallback is `OPENCODE_SESSION_ID`. `AIDEVOPS_SESSION_ID` may be
+a different framework identity, and the output-efficiency helper maps it only
+when the same shell explicitly provides `AIDEVOPS_OPENCODE_SESSION_ID`. Obtain
+the current runtime ID with `printenv AIDEVOPS_OPENCODE_SESSION_ID || printenv
+OPENCODE_SESSION_ID || printenv CLAUDE_SESSION_ID || true`, then substitute the
+returned literal for `<session-id>` only when it is non-empty. This remains
+successful when no variable is set and avoids expansion that command-policy
+parsing may reject. If the command returns no literal, mark session-specific
+diagnostics unavailable and skip every command requiring `<session-id>`.
 
 | Evidence | Command or source | Run when |
 |---|---|---|
@@ -77,6 +81,12 @@ session has no record, mark the metric unavailable; never fall back to another
 recent session or a broad daily report. A missing data source is not a reason to
 add telemetry. Avoid broad logs, generated reports, remote lookups, or repeated
 reads unless a specific finding cannot otherwise be proved.
+
+For an active OpenCode conversation, output-efficiency analysis passes the
+Vault-managed history read gate, then reads the exact session from OpenCode's
+runtime XDG data store when that store contains the requested ID. Missing,
+mismatched, or unavailable session rows fail closed and never select a title-,
+timestamp-, or recency-based substitute.
 
 Treat output-efficiency fingerprints as aggregate leads. Correlate a repeated
 snapshot or oversized result with the chronological tool calls before proposing


### PR DESCRIPTION
## Summary

Publish and refresh the authoritative OpenCode conversation ID at shell hook boundaries, map framework IDs only through explicit environment evidence, strip the identity from isolated workers, and document fail-closed exact-session analysis.

## Files Changed

.agents/plugins/opencode-aidevops/shell-env.mjs, .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/session-output-efficiency-helper.sh, .agents/scripts/session-review-helper.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-session-output-efficiency.sh, .agents/workflows/session-analysis.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 26 output-efficiency assertions; 12 shell-env plugin tests; ShellCheck for touched shell files; Python compilation for output-efficiency modules.

Resolves #27574


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 3m and 98,672 tokens on this as a headless worker.