### PR TITLE
GH#27622: fix: guard missing version directories

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-suffix.mjs
@@ -21,15 +21,17 @@ function readIfExists(filepath) {
 }
 
 export function readAidevopsVersion(activeAgentsDir, runtimeAgentsDir = activeAgentsDir) {
-  const activeVersion = readIfExists(join(activeAgentsDir, "VERSION"));
+  const activeVersion = activeAgentsDir ? readIfExists(join(activeAgentsDir, "VERSION")) : "";
   if (activeVersion) return activeVersion;
   if (process.env.AIDEVOPS_VERSION?.trim()) return process.env.AIDEVOPS_VERSION.trim();
 
-  const candidates = [
-    join(runtimeAgentsDir, "VERSION"),
-    join(runtimeAgentsDir, "..", "VERSION"),
-    join(runtimeAgentsDir, "..", "version"),
-  ];
+  const candidates = runtimeAgentsDir
+    ? [
+        join(runtimeAgentsDir, "VERSION"),
+        join(runtimeAgentsDir, "..", "VERSION"),
+        join(runtimeAgentsDir, "..", "version"),
+      ]
+    : [];
 
   for (const candidate of candidates) {
     const version = readIfExists(candidate);

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs
@@ -106,6 +106,20 @@ test("version reader prefers deployed agents VERSION", async () => {
   });
 });
 
+test("version reader handles missing agent directories", async () => {
+  const saved = process.env.AIDEVOPS_VERSION;
+  try {
+    process.env.AIDEVOPS_VERSION = " 3.20.104 ";
+    assert.equal(readAidevopsVersion(undefined), "3.20.104");
+
+    delete process.env.AIDEVOPS_VERSION;
+    assert.equal(readAidevopsVersion(null), "");
+  } finally {
+    if (saved === undefined) delete process.env.AIDEVOPS_VERSION;
+    else process.env.AIDEVOPS_VERSION = saved;
+  }
+});
+
 test("session.updated handler appends suffix through OpenCode session update API", async () => {
   await withoutEnvVersion(() =>
     withTempAgentsDir(async (agentsDir) => {


### PR DESCRIPTION
## Summary

Guard OpenCode version lookup when active or runtime agent directories are unavailable; retain the already-merged one-per-profile Tabby repair counter fix.

## Files Changed

.agents/plugins/opencode-aidevops/session-title-suffix.mjs, .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-session-title-suffix.mjs (15 passed)

Resolves #27622


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 44,112 tokens on this as a headless worker.