### PR TITLE
GH#27637: fix: make CLI convergence test PATH portable

### DIFF
--- a/.agents/scripts/tests/test-aidevops-cli-convergence.sh
+++ b/.agents/scripts/tests/test-aidevops-cli-convergence.sh
@@ -44,7 +44,7 @@ run_converge() {
 	local fixture="$1"
 	shift
 	HOME="$fixture/home" \
-		PATH="${AIDEVOPS_TEST_CLI_PATH:-$fixture/global:$fixture/home/.local/bin}:$fixture/bin:/usr/bin:/bin" \
+		PATH="${AIDEVOPS_TEST_CLI_PATH:-$fixture/global:$fixture/home/.local/bin}:$fixture/bin:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
 		AIDEVOPS_CLI_GLOBAL_TARGET="$fixture/global/aidevops" \
 		AIDEVOPS_CLI_USER_TARGET="$fixture/home/.local/bin/aidevops" \
 		AIDEVOPS_CLI_LOCK_DIR="$fixture/home/.aidevops/locks/cli.lock" \


### PR DESCRIPTION
## Summary

Extend the CLI convergence fixture PATH with common Homebrew installation directories. Verified the other review suggestions are already satisfied on the default branch by prior follow-up fixes.

## Files Changed

.agents/scripts/tests/test-aidevops-cli-convergence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-aidevops-cli-convergence.sh; bash .agents/scripts/tests/test-aidevops-cli-convergence.sh (14 passed)

Resolves #27637


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 3m and 53,868 tokens on this as a headless worker.