### PR TITLE
GH#27636: reduce issue mapping jq processes

### DIFF
--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -228,20 +228,19 @@ resolve_task_gh_number() {
 	local repo="${3:-}"
 	[[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 1
 	local repository_id="" mapping="" coordinator="${SCRIPT_DIR}/task-coordinator.mjs"
-	repository_id=$(_gh_with_timeout read gh api "repos/${repo}" --jq '.node_id' 2>/dev/null || true)
-	[[ -n "$repository_id" && "$repository_id" != "null" ]] || return 1
+	repository_id=$(_gh_with_timeout read gh api "repos/${repo}" --jq '.node_id // ""' 2>/dev/null || true)
+	[[ -n "$repository_id" ]] || return 1
 	if [[ -f "$coordinator" ]]; then
 		mapping=$(node "$coordinator" resolve-issue --task-id "$task_id" --forge github \
 			--repository-id "$repository_id" 2>/dev/null || true)
 		if [[ -n "$mapping" ]]; then
 			local mapped_slug="" mapped_role="" mapped_issue_id="" mapped_number="" mapped_project="" mapped_cursor="" mapped_metadata=""
-			mapped_slug=$(printf '%s' "$mapping" | jq -r '.repositorySlug')
-			mapped_role=$(printf '%s' "$mapping" | jq -r '.role')
-			mapped_issue_id=$(printf '%s' "$mapping" | jq -r '.issueId')
-			mapped_number=$(printf '%s' "$mapping" | jq -r '.displayNumber')
-			mapped_project=$(printf '%s' "$mapping" | jq -r '.projectId // empty')
-			mapped_cursor=$(printf '%s' "$mapping" | jq -r '.stateCursor // empty')
-			mapped_metadata=$(printf '%s' "$mapping" | jq -c '.syncMetadata')
+			if ! IFS=$'\034' read -r mapped_slug mapped_role mapped_issue_id mapped_number mapped_project mapped_cursor mapped_metadata < <(
+				printf '%s' "$mapping" | jq -r \
+					'[.repositorySlug // "", .role // "", .issueId // "", (.displayNumber // "" | tostring), .projectId // "", .stateCursor // "", (.syncMetadata | tojson)] | join("\u001c")'
+			); then
+				return 1
+			fi
 			if [[ "$mapped_slug" != "$repo" ]]; then
 				local refresh_args=()
 				[[ -n "$mapped_project" ]] && refresh_args+=(--project-id "$mapped_project")

--- a/.agents/scripts/tests/test-issue-mapping-isolation.sh
+++ b/.agents/scripts/tests/test-issue-mapping-isolation.sh
@@ -81,6 +81,16 @@ fi
 [[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t101 --repository-id R_one | jq -r '.issueId')" == "I_one_42" ]]
 [[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t102 --repository-id R_two | jq -r '.issueId')" == "I_two_42" ]]
 require_task_issue_mapping t1873.1 "$TODO_FILE" owner/dotted 73
+
+# Existing coordinator mappings are decoded in one jq process even when
+# optional project and cursor fields are empty.
+: >"$JQ_CALL_LOG"
+[[ "$(resolve_task_gh_number t102 "$TODO_FILE" owner/two)" == "42" ]]
+if [[ "$(wc -l <"$JQ_CALL_LOG" | tr -d ' ')" != "1" ]]; then
+	printf 'FAIL coordinator mapping did not parse fields with one jq process\n' >&2
+	exit 1
+fi
+
 if require_task_issue_mapping t1873.1 "$TODO_FILE" owner/dotted 74; then
 	printf 'FAIL mismatched display number passed the issue write gate\n' >&2
 	exit 1


### PR DESCRIPTION
## Summary

Parse coordinator issue mappings with one jq process and normalize missing repository IDs to empty output

## Files Changed

.agents/scripts/issue-sync-lib-ref.sh, .agents/scripts/tests/test-issue-mapping-isolation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck target scripts; Bash 3.2 issue-mapping isolation test

Resolves #27636


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 4m and 63,637 tokens on this as a headless worker.