### PR TITLE
GH#27631: strengthen pulse merge checkpoint regression coverage

### DIFF
--- a/.agents/tests/test-pulse-merge-pass-strict-mode.sh
+++ b/.agents/tests/test-pulse-merge-pass-strict-mode.sh
@@ -52,7 +52,11 @@ total_closed=0
 total_failed=0
 total_eligible=0
 completed_all=1
-_pmp_process_merge_repo_for_pass "owner/repo" "${tmp_dir}/process-checkpoint" "${tmp_dir}/process.log" \
+process_checkpoint="${tmp_dir}/process-checkpoint"
+_pmp_process_merge_repo_for_pass "owner/repo" "$process_checkpoint" "${tmp_dir}/process.log" \
 	"${tmp_dir}/stop" total_merged total_closed total_failed total_eligible completed_all
+[[ -f "$process_checkpoint" ]]
+IFS= read -r process_checkpoint_repo <"$process_checkpoint"
+[[ "$process_checkpoint_repo" == "owner/repo" ]]
 
 printf 'pulse merge-pass strict-mode regression checks passed\n'

--- a/.agents/tests/test-pulse-merge-pass-strict-mode.sh
+++ b/.agents/tests/test-pulse-merge-pass-strict-mode.sh
@@ -56,7 +56,7 @@ process_checkpoint="${tmp_dir}/process-checkpoint"
 _pmp_process_merge_repo_for_pass "owner/repo" "$process_checkpoint" "${tmp_dir}/process.log" \
 	"${tmp_dir}/stop" total_merged total_closed total_failed total_eligible completed_all
 [[ -f "$process_checkpoint" ]]
-IFS= read -r process_checkpoint_repo <"$process_checkpoint"
+process_checkpoint_repo=$(<"$process_checkpoint")
 [[ "$process_checkpoint_repo" == "owner/repo" ]]
 
 printf 'pulse merge-pass strict-mode regression checks passed\n'


### PR DESCRIPTION
## Summary

Assert the strict-mode merge-pass regression test writes the expected repository checkpoint

## Files Changed

.agents/tests/test-pulse-merge-pass-strict-mode.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/tests/test-pulse-merge-pass-strict-mode.sh; bash .agents/tests/test-pulse-merge-pass-strict-mode.sh

Resolves #27631


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 5m and 68,701 tokens on this as a headless worker.