### PR TITLE
GH#27643: Harden recovery checkpoint handling

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-continuation-guard.mjs
+++ b/.agents/plugins/opencode-aidevops/session-continuation-guard.mjs
@@ -79,7 +79,7 @@ function defaultCheckpointAdapter(checkpointHelper, repository, qualityLog) {
   function run(args, capture = false) {
     if (!checkpointHelper) return "";
     try {
-      return execFileSync(checkpointHelper, args, {
+      return execFileSync("bash", [checkpointHelper, ...args], {
         cwd: repository,
         encoding: "utf8",
         stdio: capture ? ["ignore", "pipe", "ignore"] : "ignore",

--- a/.agents/plugins/opencode-aidevops/session-continuation-guard.mjs
+++ b/.agents/plugins/opencode-aidevops/session-continuation-guard.mjs
@@ -3,6 +3,7 @@
 
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
 
 const DEFAULT_FAILURE_THRESHOLD = 3;
 const DEFAULT_MAX_SCOPES = 32;
@@ -79,7 +80,8 @@ function defaultCheckpointAdapter(checkpointHelper, repository, qualityLog) {
   function run(args, capture = false) {
     if (!checkpointHelper) return "";
     try {
-      return execFileSync("bash", [checkpointHelper, ...args], {
+      const helperPath = resolve(repository, checkpointHelper);
+      return execFileSync("bash", [helperPath, ...args], {
         cwd: repository,
         encoding: "utf8",
         stdio: capture ? ["ignore", "pipe", "ignore"] : "ignore",

--- a/.agents/plugins/opencode-aidevops/tests/test-session-continuation-checkpoint-helper.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-continuation-checkpoint-helper.mjs
@@ -17,7 +17,7 @@ if [[ "$1" == "recovery-status" && "$2" == "--json" ]]; then
 fi
 `, { mode: 0o644 });
 
-  const guard = createSessionContinuationGuard({ repository: fixtureDir, checkpointHelper });
+  const guard = createSessionContinuationGuard({ repository: fixtureDir, checkpointHelper: "checkpoint-helper.sh" });
   const state = guard.getState({ sessionID: "non-executable-helper" });
 
   assert.equal(state.recovery?.status, "recovering");

--- a/.agents/plugins/opencode-aidevops/tests/test-session-continuation-checkpoint-helper.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-continuation-checkpoint-helper.mjs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSessionContinuationGuard } from "../session-continuation-guard.mjs";
+
+const fixtureDir = mkdtempSync(join(tmpdir(), "aidevops-continuation-"));
+
+try {
+  const checkpointHelper = join(fixtureDir, "checkpoint-helper.sh");
+  writeFileSync(checkpointHelper, `#!/usr/bin/env bash
+if [[ "$1" == "recovery-status" && "$2" == "--json" ]]; then
+  printf '%s\\n' '{"status":"recovering","unresolved":true,"remaining":"Verify checkpoint recovery"}'
+fi
+`, { mode: 0o644 });
+
+  const guard = createSessionContinuationGuard({ repository: fixtureDir, checkpointHelper });
+  const state = guard.getState({ sessionID: "non-executable-helper" });
+
+  assert.equal(state.recovery?.status, "recovering");
+  assert.equal(state.recovery?.remaining, "Verify checkpoint recovery");
+} finally {
+  rmSync(fixtureDir, { recursive: true, force: true });
+}
+
+console.log("session continuation checkpoint helper tests passed");

--- a/.agents/scripts/session-checkpoint-helper.sh
+++ b/.agents/scripts/session-checkpoint-helper.sh
@@ -491,8 +491,10 @@ _recovery_field() {
 	local label="$2"
 	awk -v label="$label" '
 		index($0, "- **" label ":**") == 1 {
-			sub("^- \\*\\*" label ":\\*\\*[ ]?", "")
-			print
+			value_start = length("- **" label ":**") + 1
+			value = substr($0, value_start)
+			if (substr(value, 1, 1) == " ") value = substr(value, 2)
+			print value
 			exit
 		}
 	' "$checkpoint_file"

--- a/.agents/scripts/session-checkpoint-helper.sh
+++ b/.agents/scripts/session-checkpoint-helper.sh
@@ -490,8 +490,8 @@ _recovery_field() {
 	local checkpoint_file="$1"
 	local label="$2"
 	awk -v label="$label" '
-		index($0, "- **" label ":** ") == 1 {
-			sub("^- \\*\\*" label ":\\*\\* ", "")
+		index($0, "- **" label ":**") == 1 {
+			sub("^- \\*\\*" label ":\\*\\*[ ]?", "")
 			print
 			exit
 		}

--- a/.agents/scripts/tests/test-session-checkpoint-repo-scope.sh
+++ b/.agents/scripts/tests/test-session-checkpoint-repo-scope.sh
@@ -100,4 +100,18 @@ assert_not_contains "repo three continuation" "$continuation_three" "LEGACY_UNRE
 assert_not_contains "repo three continuation" "$continuation_three" "TARGET_REPO_SCOPED_NOTE"
 assert_not_contains "repo three continuation" "$continuation_three" "SIBLING_REPO_SCOPED_NOTE"
 
+(cd "$repo_one" && "$HELPER" recovery-save --session "session-no-space" --owner "worker" --status "recovering" >/dev/null)
+checkpoint_files=("$HOME"/.aidevops/.agent-workspace/tmp/session-checkpoints/repo-*.md)
+checkpoint_file="${checkpoint_files[0]}"
+awk '{
+	if ($0 == "- **Session:** session-no-space") {
+		print "- **Session:**session-no-space"
+	} else {
+		print
+	}
+}' "$checkpoint_file" >"${checkpoint_file}.tmp"
+mv "${checkpoint_file}.tmp" "$checkpoint_file"
+recovery_status="$(cd "$repo_one" && "$HELPER" recovery-status --json)"
+assert_contains "recovery field without separator space" "$recovery_status" '"session":"session-no-space"'
+
 printf 'session-checkpoint repo scope test passed\n'


### PR DESCRIPTION
Resolves #27643

## Summary

- invoke the Bash checkpoint helper through `bash` so its executable bit is not required
- parse structured recovery fields whether or not a separator space follows the Markdown label
- cover non-executable helper invocation and no-space recovery fields with regression tests

## Testing

- `node --test tests/test-session-continuation-checkpoint-helper.mjs`
- `bash .agents/scripts/tests/test-session-checkpoint-repo-scope.sh`
- `shellcheck .agents/scripts/session-checkpoint-helper.sh .agents/scripts/tests/test-session-checkpoint-repo-scope.sh`

## Runtime Testing

Runtime-verified with temporary checkpoint helpers and repo-scoped checkpoint fixtures.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 5m and 65,512 tokens on this as a headless worker. Overall, 16m since this issue was created.
