### PR TITLE
GH#27644: Expose GraphQL page failure diagnostics

### DIFF
--- a/.agents/scripts/github-graphql-page-helper.sh
+++ b/.agents/scripts/github-graphql-page-helper.sh
@@ -180,6 +180,17 @@ while [[ "$ITEM_COUNT" -lt "$TOTAL" ]]; do
 
 	if [[ "$PAGE_FETCHED" != "true" ]]; then
 		fail "GraphQL API failed after $((MAX_RETRIES + 1)) bounded attempts"
+		if [[ -s "$ERROR_FILE" ]]; then
+			fail "GraphQL API stderr from the final attempt:"
+			while IFS= read -r ERROR_LINE || [[ -n "$ERROR_LINE" ]]; do
+				printf '%s\n' "$ERROR_LINE" >&2
+			done <"$ERROR_FILE"
+		fi
+		if [[ -s "$RESPONSE_FILE" ]] \
+			&& jq -e 'type == "object" and (.errors | type == "array") and ((.errors | length) > 0)' "$RESPONSE_FILE" >/dev/null; then
+			fail "GraphQL errors from the final attempt:"
+			jq -c '.errors' "$RESPONSE_FILE" >&2
+		fi
 		emit_result false "api_error" "$LAST_HAS_NEXT" "$LAST_CURSOR"
 		exit 1
 	fi

--- a/.agents/scripts/github-graphql-page-helper.sh
+++ b/.agents/scripts/github-graphql-page-helper.sh
@@ -182,9 +182,7 @@ while [[ "$ITEM_COUNT" -lt "$TOTAL" ]]; do
 		fail "GraphQL API failed after $((MAX_RETRIES + 1)) bounded attempts"
 		if [[ -s "$ERROR_FILE" ]]; then
 			fail "GraphQL API stderr from the final attempt:"
-			while IFS= read -r ERROR_LINE || [[ -n "$ERROR_LINE" ]]; do
-				printf '%s\n' "$ERROR_LINE" >&2
-			done <"$ERROR_FILE"
+			cat "$ERROR_FILE" >&2
 		fi
 		if [[ -s "$RESPONSE_FILE" ]] \
 			&& jq -e 'type == "object" and (.errors | type == "array") and ((.errors | length) > 0)' "$RESPONSE_FILE" >/dev/null; then

--- a/.agents/scripts/tests/test-gh-graphql-page-bounds.sh
+++ b/.agents/scripts/tests/test-gh-graphql-page-bounds.sh
@@ -61,6 +61,7 @@ page_size=$(jq -r '.variables.pageSize' "$input_file")
 cursor=$(jq -r '.variables.cursor // ""' "$input_file")
 printf 'page_size=%s cursor=%s\n' "$page_size" "$cursor" >>"$GH_CALL_LOG"
 if [[ "${MOCK_API_FAIL:-0}" == "1" ]]; then
+	printf 'mock transport failure\n' >&2
 	printf '{"errors":[{"message":"mock failure"}]}\n'
 	exit 1
 fi
@@ -168,10 +169,12 @@ attempts=$(grep -c '^api graphql --input ' "$GH_CALL_LOG" || true)
 if [[ "$rc" -ne 0 ]] \
 	&& [[ "$attempts" -eq 3 ]] \
 	&& [[ $(jq -r '.pageInfo.complete' <<<"$result") == "false" ]] \
-	&& [[ $(jq -r '.pageInfo.reason' <<<"$result") == "api_error" ]]; then
-	pass "API retries are bounded and incomplete"
+	&& [[ $(jq -r '.pageInfo.reason' <<<"$result") == "api_error" ]] \
+	&& grep -q '^mock transport failure$' "$TMP_ROOT/err" \
+	&& grep -q '^\[{"message":"mock failure"}\]$' "$TMP_ROOT/err"; then
+	pass "API retries expose final failure diagnostics"
 else
-	fail "API retries are bounded and incomplete" "expected 3 attempts and incomplete api_error result"
+	fail "API retries expose final failure diagnostics" "expected 3 attempts, incomplete api_error result, and final stderr/error details"
 fi
 
 printf '\nRan %s tests, %s failed.\n' "$((PASS + FAIL))" "$FAIL"


### PR DESCRIPTION
## Summary

- emit final GraphQL transport stderr after bounded retries fail
- emit structured GraphQL errors without suppressing jq parser diagnostics
- cover both diagnostics in the existing bounded-pagination regression test

## Testing

- `shellcheck .agents/scripts/github-graphql-page-helper.sh .agents/scripts/tests/test-gh-graphql-page-bounds.sh`
- `bash .agents/scripts/tests/test-gh-graphql-page-bounds.sh`

Resolves #27644

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.18
