### PR TITLE
GH#27635: fix: propagate critical postflight failures

### DIFF
--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -114,6 +114,7 @@ check_cicd_status() {
 	print_section "CI/CD Pipeline Status"
 
 	if ! check_gh_cli; then
+		((++FAILED))
 		return 1
 	fi
 
@@ -121,6 +122,7 @@ check_cicd_status() {
 	repo=$(get_repo_info)
 	if [[ -z "$repo" ]]; then
 		print_error "Could not determine repository"
+		((++FAILED))
 		return 1
 	fi
 
@@ -136,6 +138,7 @@ check_cicd_status() {
 
 	if [[ -z "$latest_run" || "$latest_run" == "[]" ]]; then
 		print_error "No workflow runs found for release evidence"
+		((++FAILED))
 		return 1
 	fi
 
@@ -178,17 +181,21 @@ check_cicd_status() {
 	# Check final status
 	if [[ "$status" != "completed" ]]; then
 		print_error "Workflow did not complete within timeout"
+		((++FAILED))
 		return 1
 	fi
 
 	if [[ "$conclusion" == "success" ]]; then
 		print_success "CI/CD pipeline: $name"
+		((++PASSED))
 	elif [[ "$conclusion" == "failure" ]]; then
 		print_error "CI/CD pipeline failed: $name"
 		print_info "View logs: gh run view $run_id --repo $repo --log-failed"
+		((++FAILED))
 		return 1
 	else
 		print_warning "CI/CD pipeline conclusion: $conclusion"
+		((++WARNINGS))
 	fi
 
 	# Check all recent workflows
@@ -318,15 +325,18 @@ check_snyk() {
 
 	if [[ $snyk_exit -eq 0 ]]; then
 		print_success "Snyk: No high/critical vulnerabilities"
+		((++PASSED))
 	elif [[ $snyk_exit -eq 1 ]]; then
 		local vuln_count
 		vuln_count=$(echo "$snyk_output" | jq -r '.vulnerabilities | length // 0')
 		print_error "Snyk: $vuln_count vulnerabilities found"
+		((++FAILED))
 
 		# Show top vulnerabilities
 		echo "$snyk_output" | jq -r '.vulnerabilities[:5][] | "  - [\(.severity)] \(.title) in \(.packageName)"' 2>/dev/null || true
 	else
 		print_warning "Snyk scan completed with warnings"
+		((++WARNINGS))
 	fi
 
 	return 0
@@ -341,8 +351,10 @@ check_secrets() {
 
 		if secretlint "**/*" --format compact 2>/dev/null; then
 			print_success "Secretlint: No secrets detected"
+			((++PASSED))
 		else
 			print_error "Secretlint: Potential secrets found"
+			((++FAILED))
 			return 1
 		fi
 	elif [[ -f "$REPO_ROOT/node_modules/.bin/secretlint" ]]; then
@@ -350,8 +362,10 @@ check_secrets() {
 
 		if "$REPO_ROOT/node_modules/.bin/secretlint" "**/*" --format compact 2>/dev/null; then
 			print_success "Secretlint: No secrets detected"
+			((++PASSED))
 		else
 			print_error "Secretlint: Potential secrets found"
+			((++FAILED))
 			return 1
 		fi
 	else

--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -57,6 +57,27 @@ print_section() {
 	return 0
 }
 
+count_success() {
+	local message="$1"
+	print_success "$message"
+	((++PASSED))
+	return 0
+}
+
+count_failure() {
+	local message="$1"
+	print_error "$message"
+	((++FAILED))
+	return 0
+}
+
+count_warning() {
+	local message="$1"
+	print_warning "$message"
+	((++WARNINGS))
+	return 0
+}
+
 # Check if gh CLI is available and authenticated
 check_gh_cli() {
 	if ! command -v gh &>/dev/null; then
@@ -121,8 +142,7 @@ check_cicd_status() {
 	local repo
 	repo=$(get_repo_info)
 	if [[ -z "$repo" ]]; then
-		print_error "Could not determine repository"
-		((++FAILED))
+		count_failure "Could not determine repository"
 		return 1
 	fi
 
@@ -137,8 +157,7 @@ check_cicd_status() {
 	fi
 
 	if [[ -z "$latest_run" || "$latest_run" == "[]" ]]; then
-		print_error "No workflow runs found for release evidence"
-		((++FAILED))
+		count_failure "No workflow runs found for release evidence"
 		return 1
 	fi
 
@@ -180,22 +199,18 @@ check_cicd_status() {
 
 	# Check final status
 	if [[ "$status" != "completed" ]]; then
-		print_error "Workflow did not complete within timeout"
-		((++FAILED))
+		count_failure "Workflow did not complete within timeout"
 		return 1
 	fi
 
 	if [[ "$conclusion" == "success" ]]; then
-		print_success "CI/CD pipeline: $name"
-		((++PASSED))
+		count_success "CI/CD pipeline: $name"
 	elif [[ "$conclusion" == "failure" ]]; then
-		print_error "CI/CD pipeline failed: $name"
+		count_failure "CI/CD pipeline failed: $name"
 		print_info "View logs: gh run view $run_id --repo $repo --log-failed"
-		((++FAILED))
 		return 1
 	else
-		print_warning "CI/CD pipeline conclusion: $conclusion"
-		((++WARNINGS))
+		count_warning "CI/CD pipeline conclusion: $conclusion"
 	fi
 
 	# Check all recent workflows
@@ -235,20 +250,16 @@ check_sonarcloud() {
 	qg_status=$(echo "$qg_response" | jq -r '.projectStatus.status // "UNKNOWN"')
 
 	if [[ "$qg_status" == "OK" ]]; then
-		print_success "SonarCloud quality gate: PASSED"
-		((++PASSED))
+		count_success "SonarCloud quality gate: PASSED"
 	elif [[ "$qg_status" == "ERROR" ]]; then
-		print_error "SonarCloud quality gate: FAILED"
-		((++FAILED))
+		count_failure "SonarCloud quality gate: FAILED"
 
 		# Get failing conditions
 		echo "$qg_response" | jq -r '.projectStatus.conditions[] | select(.status == "ERROR") | "  - \(.metricKey): \(.actualValue) (threshold: \(.errorThreshold))"'
 	elif [[ "$qg_status" == "WARN" ]]; then
-		print_warning "SonarCloud quality gate: WARNING"
-		((++WARNINGS))
+		count_warning "SonarCloud quality gate: WARNING"
 	else
-		print_warning "SonarCloud quality gate status: $qg_status"
-		((++WARNINGS))
+		count_warning "SonarCloud quality gate status: $qg_status"
 	fi
 
 	# Get current metrics
@@ -324,19 +335,16 @@ check_snyk() {
 	snyk_output=$(snyk test --severity-threshold=high --json 2>/dev/null) || snyk_exit=$?
 
 	if [[ $snyk_exit -eq 0 ]]; then
-		print_success "Snyk: No high/critical vulnerabilities"
-		((++PASSED))
+		count_success "Snyk: No high/critical vulnerabilities"
 	elif [[ $snyk_exit -eq 1 ]]; then
 		local vuln_count
 		vuln_count=$(echo "$snyk_output" | jq -r '.vulnerabilities | length // 0')
-		print_error "Snyk: $vuln_count vulnerabilities found"
-		((++FAILED))
+		count_failure "Snyk: $vuln_count vulnerabilities found"
 
 		# Show top vulnerabilities
 		echo "$snyk_output" | jq -r '.vulnerabilities[:5][] | "  - [\(.severity)] \(.title) in \(.packageName)"' 2>/dev/null || true
 	else
-		print_warning "Snyk scan completed with warnings"
-		((++WARNINGS))
+		count_warning "Snyk scan completed with warnings"
 	fi
 
 	return 0
@@ -350,22 +358,18 @@ check_secrets() {
 		print_info "Running Secretlint scan..."
 
 		if secretlint "**/*" --format compact 2>/dev/null; then
-			print_success "Secretlint: No secrets detected"
-			((++PASSED))
+			count_success "Secretlint: No secrets detected"
 		else
-			print_error "Secretlint: Potential secrets found"
-			((++FAILED))
+			count_failure "Secretlint: Potential secrets found"
 			return 1
 		fi
 	elif [[ -f "$REPO_ROOT/node_modules/.bin/secretlint" ]]; then
 		print_info "Running Secretlint (local)..."
 
 		if "$REPO_ROOT/node_modules/.bin/secretlint" "**/*" --format compact 2>/dev/null; then
-			print_success "Secretlint: No secrets detected"
-			((++PASSED))
+			count_success "Secretlint: No secrets detected"
 		else
-			print_error "Secretlint: Potential secrets found"
-			((++FAILED))
+			count_failure "Secretlint: Potential secrets found"
 			return 1
 		fi
 	else

--- a/.agents/scripts/tests/test-postflight-sonarcloud-gate.sh
+++ b/.agents/scripts/tests/test-postflight-sonarcloud-gate.sh
@@ -20,9 +20,9 @@ if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
 fi
 if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
 	if [[ "$*" == *"--limit=1"* || "$*" == *"--limit 1"* ]]; then
-		printf '%s\n' '[{"databaseId":1,"status":"completed","conclusion":"success","name":"Stub CI"}]'
+		printf '[{"databaseId":1,"status":"completed","conclusion":"%s","name":"Stub CI"}]\n' "${CI_STUB_CONCLUSION:-success}"
 	else
-		printf '%s\n' '[{"name":"Stub CI","status":"completed","conclusion":"success"}]'
+		printf '[{"name":"Stub CI","status":"completed","conclusion":"%s"}]\n' "${CI_STUB_CONCLUSION:-success}"
 	fi
 	exit 0
 fi
@@ -50,18 +50,43 @@ case "$url" in
 esac
 EOF
 
-chmod +x "${STUB_DIR}/gh" "${STUB_DIR}/curl"
+cat >"${STUB_DIR}/snyk" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "check" ]]; then
+	exit 0
+fi
+if [[ "${1:-}" == "test" ]]; then
+	if [[ "${SNYK_STUB_RESULT:-clean}" == "vulnerable" ]]; then
+		printf '%s\n' '{"vulnerabilities":[{"severity":"high","title":"Stub vulnerability","packageName":"stub-package"}]}'
+		exit 1
+	fi
+	printf '%s\n' '{"vulnerabilities":[]}'
+	exit 0
+fi
+exit 1
+EOF
+
+cat >"${STUB_DIR}/secretlint" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${SECRETLINT_STUB_RESULT:-clean}" == "detected" ]]; then
+	exit 1
+fi
+exit 0
+EOF
+
+chmod +x "${STUB_DIR}/gh" "${STUB_DIR}/curl" "${STUB_DIR}/snyk" "${STUB_DIR}/secretlint"
 
 run_case() {
-	local status="$1"
-	local expected_exit="$2"
-	local expected_text="$3"
-	local forbidden_text="$4"
+	local mode="$1"
+	local status="$2"
+	local expected_exit="$3"
+	local expected_text="$4"
+	local forbidden_text="$5"
 	local output
 	local plain_output
 	local actual_exit=0
 
-	output=$(PATH="${STUB_DIR}:$PATH" SONAR_STUB_STATUS="$status" bash "$POSTFLIGHT_SCRIPT" --quick 2>&1) || actual_exit=$?
+	output=$(PATH="${STUB_DIR}:$PATH" SONAR_STUB_STATUS="$status" bash "$POSTFLIGHT_SCRIPT" "$mode" 2>&1) || actual_exit=$?
 	plain_output=$(printf '%s' "$output" | sed $'s/\033\[[0-9;]*m//g')
 
 	if [[ "$actual_exit" -ne "$expected_exit" ]]; then
@@ -79,10 +104,14 @@ run_case() {
 	return 0
 }
 
-run_case "ERROR" 1 "Failed:   1" "POSTFLIGHT VERIFICATION PASSED"
-run_case "OK" 0 "POSTFLIGHT VERIFICATION PASSED" "POSTFLIGHT VERIFICATION FAILED"
-run_case "WARN" 0 "POSTFLIGHT VERIFICATION PASSED WITH WARNINGS" "POSTFLIGHT VERIFICATION FAILED"
-run_case "UNKNOWN" 0 "SonarCloud quality gate status: UNKNOWN" "POSTFLIGHT VERIFICATION FAILED"
-run_case "UNAVAILABLE" 0 "SKIPPED Could not reach SonarCloud API" "POSTFLIGHT VERIFICATION FAILED"
+run_case "--quick" "ERROR" 1 "Failed:   1" "POSTFLIGHT VERIFICATION PASSED"
+run_case "--quick" "OK" 0 "POSTFLIGHT VERIFICATION PASSED" "POSTFLIGHT VERIFICATION FAILED"
+run_case "--quick" "WARN" 0 "POSTFLIGHT VERIFICATION PASSED WITH WARNINGS" "POSTFLIGHT VERIFICATION FAILED"
+run_case "--quick" "UNKNOWN" 0 "SonarCloud quality gate status: UNKNOWN" "POSTFLIGHT VERIFICATION FAILED"
+run_case "--quick" "UNAVAILABLE" 0 "SKIPPED Could not reach SonarCloud API" "POSTFLIGHT VERIFICATION FAILED"
 
-printf 'PASS: postflight propagates SonarCloud quality-gate results\n'
+CI_STUB_CONCLUSION="failure" run_case "--ci-only" "OK" 1 "CI/CD pipeline failed: Stub CI" "POSTFLIGHT VERIFICATION PASSED"
+SNYK_STUB_RESULT="vulnerable" run_case "--security-only" "OK" 1 "Snyk: 1 vulnerabilities found" "POSTFLIGHT VERIFICATION PASSED"
+SECRETLINT_STUB_RESULT="detected" run_case "--security-only" "OK" 1 "Secretlint: Potential secrets found" "POSTFLIGHT VERIFICATION PASSED"
+
+printf 'PASS: postflight propagates critical check results\n'


### PR DESCRIPTION
## Summary

Count CI, Snyk, and Secretlint outcomes in the postflight summary so critical failures cannot be masked by main's tolerant check orchestration; extend the focused regression test with failing stubs. The safe-expansion review suggestions are not applied because STUB_DIR is initialized before trap registration and run_case has five required arguments at every call site; retaining local var="$1" preserves strict missing-argument detection and repository shell style.

## Files Changed

.agents/scripts/postflight-check.sh, .agents/scripts/tests/test-postflight-sonarcloud-gate.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-postflight-sonarcloud-gate.sh; shellcheck .agents/scripts/postflight-check.sh .agents/scripts/tests/test-postflight-sonarcloud-gate.sh; git diff origin/main...HEAD --check

Resolves #27635


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 5m and 40,125 tokens on this as a headless worker.