### PR TITLE
GH#27647: suppress resolved review recap summaries

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -278,6 +278,7 @@ fetch_review_threads_json() {
 								comments(first: 1) {
 									nodes {
 										author { login }
+										pullRequestReview { databaseId }
 										path
 										line
 										url
@@ -384,26 +385,52 @@ fetch_inline_comments_md() {
 #     is a LGTM. See webapp#2349 for the canonical false-positive.
 #   - Body must contain at least one ACT_RE keyword (cheap noise filter
 #     against "LGTM"/"Reviewed" acks).
+#   - Reviews whose associated inline bot threads are all resolved or outdated
+#     are omitted. Bot summaries commonly recap those same findings, so keeping
+#     the summary would recreate already-resolved feedback as a new issue.
 #
 # Exit codes:
 #   0  — success (stdout is markdown; empty string = no bot summaries)
 #   2  — fetch error (gh call failed or jq failure)
 fetch_review_summaries_md() {
 	local repo="$1" pr="$2"
-	local resp rc=0
+	local resp threads resolved_review_ids rc=0 threads_rc=0
 	resp=$(gh api "repos/${repo}/pulls/${pr}/reviews" --paginate) || rc=$?
 	if [[ $rc -ne 0 ]]; then
 		log "fetch_review_summaries_md: gh api failed for ${repo}#${pr} (rc=${rc})"
 		return 2
 	fi
+	threads=$(fetch_review_threads_json "$repo" "$pr") || threads_rc=$?
+	if [[ $threads_rc -ne 0 ]]; then
+		return 2
+	fi
+	resolved_review_ids=$(printf '%s' "$threads" | jq -c \
+		--arg bots "$BOT_RE" '
+			[.data.repository.pullRequest.reviewThreads.nodes[]?
+				| . as $thread
+				| .comments.nodes[0]?
+				| select(. != null)
+				| select(((.author.login // "")) | test($bots; "i"))
+				| select(.pullRequestReview.databaseId != null)
+				| {review_id: .pullRequestReview.databaseId, resolved: (($thread.isResolved // false) or ($thread.isOutdated // false))}
+			]
+			| group_by(.review_id)
+			| map(select(all(.[]; .resolved)) | .[0].review_id)
+		') || {
+		log "fetch_review_summaries_md: resolved review mapping failed on ${repo}#${pr}"
+		return 2
+	}
 	local out
 	out=$(printf '%s' "$resp" | jq -r \
 		--arg bots "$BOT_RE" \
 		--arg noop "$NOOP_RE" \
 		--arg acts "$ACT_RE" \
+		--argjson resolved_review_ids "$resolved_review_ids" \
 		--argjson cap "$SCANNER_MAX_COMMENTS" '
 			[.[]?
 				| select(((.user.login // "")) | test($bots; "i"))
+				| .id as $review_id
+				| select(($resolved_review_ids | index($review_id)) == null)
 				| select(((.body // "")) | length > 0)
 				# Drop CodeRabbit "Actionable comments posted: N" metadata
 				# summary reviews. These add no information beyond the

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -271,6 +271,7 @@ write_graphql_fixture() {
 				comments: {
 					nodes: [{
 						author: {login: $author},
+						pullRequestReview: {databaseId: 42},
 						path: $path,
 						line: $line,
 						url: "https://example/thread",
@@ -303,7 +304,7 @@ write_reviews_fixture() {
 			arr+=","
 		fi
 		arr+=$(jq -n --arg login "$login" --arg body "$body" \
-			'{user: {login: $login}, body: $body, html_url: "https://example/review"}')
+			'{id: 42, user: {login: $login}, body: $body, html_url: "https://example/review"}')
 	done
 	arr+="]"
 	printf '%s\n' "$arr" >"$out"
@@ -332,6 +333,19 @@ else
 	echo "    actual (first 200): ${out:0:200}"
 	FAIL=$((FAIL + 1))
 fi
+
+echo ""
+echo "Test: build_pr_followup_body — resolved inline findings suppress their recap summary"
+write_graphql_fixture "$FIX_GRAPHQL" \
+	true false "gemini-code-assist" "src/a.js" 10 "FIXED_INLINE_MARKER" "@@ -1,3 +1,3 @@"
+write_reviews_fixture "$FIX_REVIEWS" \
+	"gemini-code-assist" "## Code Review
+
+The PR should fix the FIXED_SUMMARY_MARKER issue."
+rc=0
+out=$(build_pr_followup_body "stub/repo" "42") || rc=$?
+assert_rc "resolved recap summary produces zero findings" "1" "$rc"
+assert_not_contains "resolved recap summary is omitted" "FIXED_SUMMARY_MARKER" "$out"
 
 echo ""
 echo "Test: build_pr_followup_body — all threads outdated → exit 1"


### PR DESCRIPTION
## Summary

Suppress top-level bot review summaries when every associated inline finding is already resolved or outdated, preventing scanner-created duplicate follow-up issues.

## Files Changed

.agents/scripts/post-merge-review-scanner.sh, .agents/scripts/tests/test-post-merge-review-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck, bash syntax, git diff check, and 73-case post-merge review scanner regression suite pass.

Resolves #27647


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 7m and 85,973 tokens on this as a headless worker.