### PR TITLE
GH#27663: Avoid pulse snapshot argv overflow

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -38,8 +38,12 @@ _pmrc_snapshot_checks_json() {
 	runs_pages=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/check-runs?per_page=100" \
 		--paginate --slurp 2>/dev/null) || return 1
 	statuses_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/status" 2>/dev/null) || return 1
-	checks_json=$(jq -n --argjson pages "$runs_pages" --argjson statuses "$statuses_json" \
+	# Feed API payloads over stdin instead of argv. Check-run responses include
+	# annotation and app metadata, so a healthy repository can exceed Linux's
+	# 128 KiB per-argument ceiling before jq gets a chance to project the fields.
+	checks_json=$(printf '%s\n%s\n' "$runs_pages" "$statuses_json" | jq -s \
 		--arg completed "$PMRC_CHECK_COMPLETED" --arg success "$PMRC_CHECK_SUCCESS" '
+		.[0] as $pages | .[1] as $statuses |
 		"pending" as $pending | "in_progress" as $in_progress |
 		"failure" as $failure | "error" as $error |
 		[

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -61,7 +61,7 @@ gh() {
 		;;
 	*check-runs*)
 		local required_conclusion="success" broad_status="completed" broad_conclusion="success"
-		local broad_completed_at="2026-01-01T00:01:00Z" extra_check=""
+		local broad_completed_at="2026-01-01T00:01:00Z" extra_check="" payload_padding=""
 		[[ "$SNAPSHOT_MODE" == "required_fail" ]] && required_conclusion="failure"
 		if [[ "$SNAPSHOT_MODE" == "pending" ]]; then
 			broad_status="in_progress"
@@ -73,8 +73,11 @@ gh() {
 		elif [[ "$SNAPSHOT_MODE" == "infra_fail" ]]; then
 			extra_check=',{"name":"sync / Record ordered forge event","status":"completed","conclusion":"failure","details_url":"https://github.com/owner/repo/actions/runs/101/job/202","completed_at":"2026-01-01T00:01:00Z"}'
 		fi
-		printf '[{"check_runs":[{"name":"required-a","status":"completed","conclusion":"%s","completed_at":"2026-01-01T00:01:00Z"},{"name":"Framework Validation","status":"%s","conclusion":%s,"completed_at":"%s"},{"name":"Qlty Smell Regression","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:00Z"},{"name":"Qlty Smell Threshold","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:00Z"}%s]}]\n' \
-			"$required_conclusion" "$broad_status" "$([[ "$broad_conclusion" == "null" ]] && printf 'null' || printf '"%s"' "$broad_conclusion")" "$broad_completed_at" "$extra_check"
+		if [[ "$SNAPSHOT_MODE" == "large_payload" ]]; then
+			payload_padding=$(dd if=/dev/zero bs=1024 count=140 2>/dev/null | tr '\0' x)
+		fi
+		printf '[{"check_runs":[{"name":"required-a","status":"completed","conclusion":"%s","completed_at":"2026-01-01T00:01:00Z","output":{"text":"%s"}},{"name":"Framework Validation","status":"%s","conclusion":%s,"completed_at":"%s"},{"name":"Qlty Smell Regression","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:00Z"},{"name":"Qlty Smell Threshold","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:00Z"}%s]}]\n' \
+			"$required_conclusion" "$payload_padding" "$broad_status" "$([[ "$broad_conclusion" == "null" ]] && printf 'null' || printf '"%s"' "$broad_conclusion")" "$broad_completed_at" "$extra_check"
 		;;
 	*commits/sha-reviewed/status*)
 		local gate_at="2026-01-01T00:01:10Z"
@@ -126,6 +129,7 @@ assert_gate() {
 
 main() {
 	assert_gate "terminal checks with explicit baseline advisory pass" happy_advisory 0
+	assert_gate "large check-run payload is projected without argv overflow" large_payload 0
 	if grep -q "IGNORED non-required baseline advisory failure 'Qlty Smell Threshold'" "$LOGFILE"; then
 		printf 'PASS ignored advisory failure is audited\n'
 	else


### PR DESCRIPTION
## Summary

Stream check-run and commit-status JSON to jq over stdin so healthy payloads larger than Linux's per-argument ceiling cannot silently fail the pre-merge snapshot.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh; shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh; pre-commit quality validation

Resolves #27663


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 23m and 418,300 tokens on this as a headless worker.