### PR TITLE
GH#27669: test: cover Linuxbrew in CLI convergence PATH

### DIFF
--- a/.agents/scripts/tests/test-aidevops-cli-convergence.sh
+++ b/.agents/scripts/tests/test-aidevops-cli-convergence.sh
@@ -42,9 +42,10 @@ EOF
 
 run_converge() {
 	local fixture="$1"
+	local user_linuxbrew_path="${HOME:+:$HOME/.linuxbrew/bin}"
 	shift
 	HOME="$fixture/home" \
-		PATH="${AIDEVOPS_TEST_CLI_PATH:-$fixture/global:$fixture/home/.local/bin}:$fixture/bin:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin" \
+		PATH="${AIDEVOPS_TEST_CLI_PATH:-$fixture/global:$fixture/home/.local/bin}:$fixture/bin:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin$user_linuxbrew_path" \
 		AIDEVOPS_CLI_GLOBAL_TARGET="$fixture/global/aidevops" \
 		AIDEVOPS_CLI_USER_TARGET="$fixture/home/.local/bin/aidevops" \
 		AIDEVOPS_CLI_LOCK_DIR="$fixture/home/.aidevops/locks/cli.lock" \

--- a/.agents/scripts/tests/test-aidevops-cli-convergence.sh
+++ b/.agents/scripts/tests/test-aidevops-cli-convergence.sh
@@ -44,7 +44,7 @@ run_converge() {
 	local fixture="$1"
 	shift
 	HOME="$fixture/home" \
-		PATH="${AIDEVOPS_TEST_CLI_PATH:-$fixture/global:$fixture/home/.local/bin}:$fixture/bin:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+		PATH="${AIDEVOPS_TEST_CLI_PATH:-$fixture/global:$fixture/home/.local/bin}:$fixture/bin:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin" \
 		AIDEVOPS_CLI_GLOBAL_TARGET="$fixture/global/aidevops" \
 		AIDEVOPS_CLI_USER_TARGET="$fixture/home/.local/bin/aidevops" \
 		AIDEVOPS_CLI_LOCK_DIR="$fixture/home/.aidevops/locks/cli.lock" \


### PR DESCRIPTION
## Summary

Append the default Linux Homebrew bin directory to the isolated CLI convergence test PATH so Linuxbrew installations retain access to standard tooling.

## Files Changed

.agents/scripts/tests/test-aidevops-cli-convergence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-aidevops-cli-convergence.sh (14 passed); shellcheck .agents/scripts/tests/test-aidevops-cli-convergence.sh; git diff --check

Resolves #27669


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 5m and 28,492 tokens on this as a headless worker.