### PR TITLE
GH#27668: Resolve relative checkpoint helper paths before changing cwd

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-continuation-guard.mjs
+++ b/.agents/plugins/opencode-aidevops/session-continuation-guard.mjs
@@ -77,10 +77,11 @@ function capMap(map, maxEntries) {
 }
 
 function defaultCheckpointAdapter(checkpointHelper, repository, qualityLog) {
+  const helperPath = checkpointHelper ? resolve(checkpointHelper) : "";
+
   function run(args, capture = false) {
-    if (!checkpointHelper) return "";
+    if (!helperPath) return "";
     try {
-      const helperPath = resolve(repository, checkpointHelper);
       return execFileSync("bash", [helperPath, ...args], {
         cwd: repository,
         encoding: "utf8",

--- a/.agents/plugins/opencode-aidevops/tests/test-session-continuation-checkpoint-helper.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-continuation-checkpoint-helper.mjs
@@ -2,22 +2,27 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { createSessionContinuationGuard } from "../session-continuation-guard.mjs";
 
 const fixtureDir = mkdtempSync(join(tmpdir(), "aidevops-continuation-"));
 
 try {
+  const repository = join(fixtureDir, "repository");
   const checkpointHelper = join(fixtureDir, "checkpoint-helper.sh");
+  mkdirSync(repository);
   writeFileSync(checkpointHelper, `#!/usr/bin/env bash
 if [[ "$1" == "recovery-status" && "$2" == "--json" ]]; then
   printf '%s\\n' '{"status":"recovering","unresolved":true,"remaining":"Verify checkpoint recovery"}'
 fi
 `, { mode: 0o644 });
 
-  const guard = createSessionContinuationGuard({ repository: fixtureDir, checkpointHelper: "checkpoint-helper.sh" });
+  const guard = createSessionContinuationGuard({
+    repository,
+    checkpointHelper: relative(process.cwd(), checkpointHelper),
+  });
   const state = guard.getState({ sessionID: "non-executable-helper" });
 
   assert.equal(state.recovery?.status, "recovering");


### PR DESCRIPTION
## Summary

Resolve relative checkpoint helper paths against the plugin process cwd before executing them from the target repository, with regression coverage for a distinct repository directory.

## Files Changed

.agents/plugins/opencode-aidevops/session-continuation-guard.mjs, .agents/plugins/opencode-aidevops/tests/test-session-continuation-checkpoint-helper.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted checkpoint helper regression test passes; full plugin suite reached 372/373 with one unrelated command-policy timeout pending rerun.

Resolves #27668


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 7m and 74,390 tokens on this as a headless worker.