### PR TITLE
GH#27664: fix: harden postflight failure counters

### DIFF
--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -67,7 +67,7 @@ count_success() {
 count_failure() {
 	local message="$1"
 	print_error "$message"
-	((++FAILED))
+	FAILED=$((FAILED + 1))
 	return 0
 }
 
@@ -135,7 +135,7 @@ check_cicd_status() {
 	print_section "CI/CD Pipeline Status"
 
 	if ! check_gh_cli; then
-		((++FAILED))
+		FAILED=$((FAILED + 1))
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-postflight-sonarcloud-gate.sh
+++ b/.agents/scripts/tests/test-postflight-sonarcloud-gate.sh
@@ -16,6 +16,9 @@ trap cleanup EXIT
 cat >"${STUB_DIR}/gh" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+	if [[ "${GH_AUTH_STUB_RESULT:-authenticated}" == "failure" ]]; then
+		exit 1
+	fi
 	exit 0
 fi
 if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
@@ -111,6 +114,7 @@ run_case "--quick" "UNKNOWN" 0 "SonarCloud quality gate status: UNKNOWN" "POSTFL
 run_case "--quick" "UNAVAILABLE" 0 "SKIPPED Could not reach SonarCloud API" "POSTFLIGHT VERIFICATION FAILED"
 
 CI_STUB_CONCLUSION="failure" run_case "--ci-only" "OK" 1 "CI/CD pipeline failed: Stub CI" "POSTFLIGHT VERIFICATION PASSED"
+GH_AUTH_STUB_RESULT="failure" run_case "--ci-only" "OK" 1 "Failed:   1" "POSTFLIGHT VERIFICATION PASSED"
 SNYK_STUB_RESULT="vulnerable" run_case "--security-only" "OK" 1 "Snyk: 1 vulnerabilities found" "POSTFLIGHT VERIFICATION PASSED"
 SECRETLINT_STUB_RESULT="detected" run_case "--security-only" "OK" 1 "Secretlint: Potential secrets found" "POSTFLIGHT VERIFICATION PASSED"
 


### PR DESCRIPTION
## Summary

Replace postflight FAILED arithmetic commands with assignment-based increments and cover the unauthenticated gh path so set -e cannot terminate before the final failure summary.

## Files Changed

.agents/scripts/postflight-check.sh, .agents/scripts/tests/test-postflight-sonarcloud-gate.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/postflight-check.sh .agents/scripts/tests/test-postflight-sonarcloud-gate.sh; shellcheck .agents/scripts/postflight-check.sh .agents/scripts/tests/test-postflight-sonarcloud-gate.sh; bash .agents/scripts/tests/test-postflight-sonarcloud-gate.sh; bash .agents/scripts/tests/test-postflight-no-source-rescan.sh

Resolves #27664


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 13m and 62,457 tokens on this as a headless worker.