### PR TITLE
t18118: Bind external approvals to immutable evidence

### DIFF
--- a/.agents/reference/auto-merge.md
+++ b/.agents/reference/auto-merge.md
@@ -55,13 +55,13 @@ Merge typically happens within one pulse cycle (4-10 minutes) after all checks g
 
 ### Interactive Admin Merge Authority
 
-Interactive sessions operate with the repo admin/owner account. When the trust source is maintainer-controlled — `OWNER`/`MEMBER` PR author, maintainer-authored linked issue, trusted issue author, or valid cryptographic maintainer approval — the admin account may merge with `gh pr merge <N> --repo <slug> --admin --squash --delete-branch` after verifying:
+Interactive sessions operate with the repo admin/owner account. When the trust source is maintainer-controlled — `OWNER`/`MEMBER` PR author, maintainer-authored linked issue, trusted issue author, or valid cryptographic maintainer approval — the admin account may merge through the guarded full-loop helper after verifying:
 
 1. Non-gate CI is green or skipped.
 2. No human `CHANGES_REQUESTED` review exists.
 3. The blocking condition is review-required branch protection, stale GitHub merge state, or a self-blocking framework gate.
 
-This is bypassing stale/redundant automation state, not bypassing maintainer policy. Keep the merge gated when the issue/PR originates from a non-maintainer and there is no valid cryptographic approval.
+This is bypassing stale/redundant automation state, not bypassing maintainer policy. Keep the merge gated when the issue/PR originates from a non-maintainer and there is no valid cryptographic approval. For external/fork PRs, issue approval is development authority only: final merge requires a V2 PR approval bound to the exact current head and content snapshot.
 
 `full-loop-helper.sh merge --auto` applies the same rule for interactive sessions: if native auto-merge is already blocked only by review-required branch policy or GitHub self-approval rules, the helper verifies the PR is non-draft, has no `CHANGES_REQUESTED`, has no pending/failing checks, and has no linked issue still carrying `needs-maintainer-review`; then it falls through to `--admin` automatically. Headless workers do not take this fallback.
 
@@ -132,14 +132,26 @@ Symmetric extension of t3052 to the **deterministic merge cascade** — the `_ch
 
 **Background:** t3052 (PR #21767) allowed cryptographic maintainer approval on a linked issue to satisfy the `OWNER`/`MEMBER` author-association gate in the worker-briefed auto-merge path. t3063 extends the same signal to:
 
-1. **`_check_pr_merge_gates`** (`pulse-merge.sh:185-196`) — the gate that short-circuits the merge pass for all non-collaborator PRs. With t3063, a verified crypto signature on the PR or its linked issue (checked by `_has_maintainer_crypto_approval` in `pulse-merge-gates.sh`) allows the PR to proceed through the gate instead of being skipped.
-2. **`approve_collaborator_pr`** (`pulse-merge-gates.sh`) — the function that posts the approval review before merge. With t3063, it accepts the same crypto signal as a bypass for the GH#17671 author guard before refusing to approve.
+1. **`_check_pr_merge_gates`** — the gate that short-circuits the merge pass for non-collaborator PRs. It requires current V2 PR authority before allowing the author-association bypass.
+2. **`approve_collaborator_pr`** — the function that posts the approval review before merge. Its GH#17671 self-check accepts only current V2 PR authority for a non-collaborator author.
 
 **Trust chain:** `sudo aidevops approve` requires a root-owned SSH private key that workers cannot forge. The signal is stronger than GitHub author-association, which is a proxy for maintainer trust. The four-layer GH#17671 defence-in-depth is preserved — Case P (CONTRIBUTOR + no crypto = refuse) is pinned by `test-pulse-merge-approve-collaborator-guard.sh`.
 
-**Helper:** `_has_maintainer_crypto_approval "$pr_number" "$repo_slug"` in `pulse-merge-gates.sh`. Checks PR-level comments first, then linked-issue comments, for `<!-- aidevops-signed-approval -->`. Falls back to marker-presence check when `approval-helper.sh` is unavailable (full crypto verification provided by `_external_pr_linked_issue_crypto_approved` downstream).
+**Helper:** `_has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$head_sha"` in `pulse-merge-gates.sh`. It fails closed unless `approval-helper.sh` verifies a V2 PR payload whose canonical digest and head match current GitHub state. Marker-only and helper-absent fallbacks are prohibited.
 
 **Test coverage:** `.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh` cases N, O, P.
+
+### V2 immutable approval snapshots
+
+`sudo aidevops approve issue|pr N OWNER/REPO` signs `aidevops-approval/v2`, which contains a SHA-256 digest of a canonical read-only GitHub snapshot. The snapshot binds object IDs, title/body, non-bot human comments and reviews, linked-reference timeline events, and—for PRs—the head SHA/ref/repository and base ref/repository. Verification excludes the exact signed comment being checked and the trusted deterministic NMR lifecycle audit written after verification. Marker text in any other external human comment remains content-bound, so copied unsigned markers cannot hide drift. A repeated approval binds prior approval comments and leaves only the newest matching snapshot authoritative.
+
+- Issue V2 authority permits development of that exact issue snapshot. It never authorizes a future or changed external PR.
+- External/fork merge requires both the existing approved linked-issue chain and PR-specific V2 merge authority for the exact current head. The final trust gate re-fetches this immediately before every native, admin, direct, and retry merge call; it also checks live author permission so missing external labels cannot bypass the rule.
+- Body/comment/link/linked-reference/base/head drift returns `STALE_APPROVAL`; malformed payloads, API uncertainty, and missing keys fail closed.
+- V1 `APPROVE:<kind>:<repo>:<number>:<timestamp>` signatures return `LEGACY_APPROVAL`. They are preserved as audit history but do not authorize external dispatch/merge; run the approval command again after reviewing current state.
+- A live `needs-maintainer-review` label on the PR or linked issue always blocks. Marker presence does not override current NMR state.
+
+Configured review-provider failures use `review_gate.advisory_check_contexts`. An exact named non-required failure is advisory only after the final trust gate reruns the read-only review helper and obtains typed `aidevops.review-gate-evidence/v1` for the exact PR head, a permitted author-class outcome, and resolved review threads. Duplicate maintainer-gate aliases are one audited family and remain blocking; all other check-run and commit-status sources retain independent failure identity.
 
 ## NMR Automation Signatures (t2386, Split Semantics)
 

--- a/.agents/reference/incident-gh17671-supply-chain.md
+++ b/.agents/reference/incident-gh17671-supply-chain.md
@@ -5,7 +5,7 @@
 
 **Date:** April 2025 (open) → April 2025 (remediation) → April 2026 (defense-in-depth, this doc) → April 2026 (t3063 crypto-approval bypass, preserving defence).
 **Severity:** Critical — would have shipped attacker-controlled GitHub Actions code into the default branch if the merge had completed.
-**Status:** Closed without merge. Live exploit gated by PR #17868 + #17877. Function-level regression guard added in t2933 (this doc). Crypto-approval bypass added in t3063 (see "t3063 Update" section).
+**Status:** Closed without merge. Live exploit gated by PR #17868 + #17877. Function-level regression guard added in t2933. The t3063 crypto bypass now requires immutable V2 PR authority for the exact current head.
 
 This is the canonical postmortem for the only known supply-chain attempt against this repo. Read it before touching `pulse-merge.sh`, `maintainer-gate.yml`, the review-bot gate, or anything else in the auto-merge cascade. The entire chain is the defense; removing any one layer reopens the hole.
 
@@ -80,24 +80,24 @@ PR #21733 (external contributor `superdav42`) demonstrated a gap: a maintainer c
 1. `_check_pr_merge_gates` in `pulse-merge.sh` — the upstream skip that skips non-collaborator PRs entirely.
 2. `approve_collaborator_pr` in `pulse-merge-gates.sh` — the function-level self-check.
 
-Both now call `_has_maintainer_crypto_approval "$pr_number" "$repo_slug"` before refusing. If the helper finds a `<!-- aidevops-signed-approval -->` marker (and cryptographically verifies it when `approval-helper.sh` is available), the PR is allowed to proceed. This is symmetric with t3052 (PR #21767), which extended the same signal to the worker-briefed auto-merge path.
+Both now call `_has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$head_sha"` before refusing. The helper must cryptographically verify an immutable V2 PR snapshot for the exact current head. A linked-issue approval remains development authority for the worker-briefed path but cannot authorize external merge; marker-only and legacy V1 signatures fail closed.
 
 **The four-layer defence is preserved:**
 
 - A non-collaborator PR with NO crypto approval is still blocked at every layer — Case P (CONTRIBUTOR + no crypto = refuse) is pinned in `test-pulse-merge-approve-collaborator-guard.sh`.
-- The crypto marker (`<!-- aidevops-signed-approval -->`) can only be posted by a user with repository write access, and the underlying payload is SSH-signed with a root-private key workers cannot access.
+- The V2 payload is SSH-signed with a root-private key workers cannot access and binds current PR content/head; marker presence alone has no authority.
 - The bypass is additive (OR condition), not substitutive — it opens a path for explicitly-approved contributor work without weakening the existing collaborator-only path.
 
 ## Test pinning
 
-`.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh` pins the function-level contract with seven cases:
+`.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh` pins the function-level contract, including these security cases:
 
 - **Case A:** collaborator author + collaborator runner + runner ≠ author → approval fires with the t2933-corrected body.
 - **Case B (regression of GH#17671):** non-collaborator author + collaborator runner → guard refuses approval, logs the GH#17671/t2933 audit attribution. **This case fails immediately if the function-level guard is removed**, regardless of the state of upstream gates.
 - **Case C:** self-authored PR (runner == author) → skipped; `--admin` merge handles it.
 - **Case D:** runner lacks write access → skipped (predates t2933, still required).
 - **Case N (t3063):** CONTRIBUTOR author + crypto-approval on PR → approved via t3063 bypass.
-- **Case O (t3063):** CONTRIBUTOR author + crypto-approval on linked issue → approved via t3063 bypass.
+- **Case O (V2 hardening):** CONTRIBUTOR author + linked-issue approval only → refused; development authority cannot substitute for exact-head PR merge authority.
 - **Case P (t3063 regression):** CONTRIBUTOR author + NO crypto-approval → still refused; GH#17671 guard preserved.
 
 The test is registered in `.github/workflows/code-quality.yml` so a regression cannot land without a CI failure.

--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -105,6 +105,7 @@ Global equivalent: `orchestration.interactive_pr_auto_merge` in `~/.config/aidev
 {
   "rate_limit_behavior": "pass",
   "min_edit_lag_seconds": 30,
+  "advisory_check_contexts": ["CodeRabbit"],
   "tools": {
     "coderabbitai": {
       "rate_limit_behavior": "wait",
@@ -118,11 +119,12 @@ Global equivalent: `orchestration.interactive_pr_auto_merge` in `~/.config/aidev
 |-------|---------|-------------|
 | `rate_limit_behavior` | `"pass"` | `"pass"` exits 0 on rate-limit; `"wait"` keeps polling |
 | `min_edit_lag_seconds` | 30 | Seconds a bot comment must be "settled" before it counts. Defeats CodeRabbit's two-phase placeholder (stub at ~14s, final edit at ~90-120s). |
+| `advisory_check_contexts` | `[]` | Exact non-required review-provider check names that may be advisory only when typed live evidence permits the outcome for the current PR head and review threads are resolved. Required, maintainer-gate, unknown, malformed-evidence, and external rate-limit failures always block. |
 | `tools` | — | Per-tool overrides keyed by bot login (`coderabbitai`, `gemini-code-assist`, `augment-code`, `augmentcode`, `copilot`) |
 
 Resolution order (per field independently): per-tool > per-repo > env var (`REVIEW_GATE_RATE_LIMIT_BEHAVIOR` / `REVIEW_BOT_MIN_EDIT_LAG_SECONDS`) > hard default.
 
-CLI: `aidevops review-gate --help` — configure `rate_limit_behavior` without hand-editing JSON.
+CLI: `aidevops review-gate --help` — configure rate-limit/completion policy and add or remove exact advisory check contexts without hand-editing JSON.
 
 ## Knowledge Plane
 

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -75,6 +75,9 @@ readonly APPROVAL_PUB="$APPROVAL_DIR/approval.pub"
 readonly APPROVAL_NAMESPACE="aidevops-approve"
 readonly APPROVAL_MARKER="<!-- aidevops-signed-approval -->"
 
+# shellcheck source=approval-snapshot-v2.sh
+source "${SCRIPT_DIR}/approval-snapshot-v2.sh"
+
 # Detect repo slug from current directory or repos.json
 _detect_slug() {
 	local slug=""
@@ -635,9 +638,6 @@ _post_issue_approval_updates() {
 		# window that exists for issues. Without locking, non-collaborators can
 		# add comments to an approved PR between approval and merge, potentially
 		# influencing automated review or merge decisions.
-		gh_pr_comment "$target_number" --repo "$slug" \
-			--body "This PR has been approved by a maintainer and is now locked for review." \
-			>/dev/null 2>&1 || true
 		local lock_err=""
 		lock_err=$(_approval_lock_pr "$target_number" "$slug" 2>&1 >/dev/null) || {
 			_print_error "Approval advisory lock failure: PR #$target_number conversation could not be locked after approval state updates"
@@ -781,7 +781,10 @@ _approve_target() {
 
 	local timestamp payload sig_file comment_body
 	timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-	payload="APPROVE:${target_type}:${slug}:${target_number}:${timestamp}"
+	payload=$(approval_snapshot_v2_payload "$target_type" "$target_number" "$slug" "$timestamp") || {
+		_print_error "Could not build the immutable approval snapshot; approval was not posted"
+		return 1
+	}
 	sig_file=$(mktemp)
 
 	if ! _sign_approval_payload "$payload" "$actual_key" "$sig_file"; then
@@ -802,6 +805,15 @@ _approve_target() {
 			_print_error "Failed to post approval comment on PR #$target_number"
 			return 1
 		fi
+	fi
+
+	# #aidevops:trust-boundary — content can drift between the snapshot read and
+	# comment write. Re-fetch and verify V2 before lifecycle writes or Pulse kick.
+	local posted_verification=""
+	posted_verification=$(cmd_verify "$target_type" "$target_number" "$slug" 2>/dev/null) || posted_verification="${posted_verification:-API_ERROR}"
+	if [[ "$posted_verification" != "VERIFIED" ]]; then
+		_print_error "Approval comment posted but current-state verification returned ${posted_verification}; lifecycle changes were not applied. Re-run approval after reviewing the latest state."
+		return 1
 	fi
 
 	if ! _post_issue_approval_updates "$target_type" "$target_number" "$slug"; then
@@ -857,17 +869,12 @@ _create_allowed_signers_file() {
 }
 
 _verify_comment_signature() {
-	local issue_number="$1"
-	local body="$2"
-	local pub_key="$3"
+	local body="$1"
+	local pub_key="$2"
 	local payload signature payload_file sig_file allowed_signers_file
 
 	payload=$(_extract_fenced_block "$body" 1)
 	if [[ -z "$payload" ]]; then
-		return 1
-	fi
-
-	if [[ ! "$payload" =~ ^APPROVE:(issue|pr):.*:[0-9]+: ]]; then
 		return 1
 	fi
 
@@ -887,14 +894,94 @@ _verify_comment_signature() {
 		-f "$allowed_signers_file" \
 		-I "approval@aidevops.sh" \
 		-n "$APPROVAL_NAMESPACE" \
-		-s "$sig_file" <"$payload_file" >/dev/null 2>&1 &&
-		[[ "$payload" == *":${issue_number}:"* ]]; then
+		-s "$sig_file" <"$payload_file" >/dev/null 2>&1; then
 		rm -f "$payload_file" "$sig_file" "$allowed_signers_file"
 		return 0
 	fi
 
 	rm -f "$payload_file" "$sig_file" "$allowed_signers_file"
 	return 1
+}
+
+_approval_classify_signed_comment() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+	local comment_id="$4"
+	local body="$5"
+	local pub_key="$6"
+	local expected_head_sha="${7:-}"
+	local payload="" snapshot_json="" current_digest="" signed_digest="" normalized_slug=""
+	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
+
+	payload=$(_extract_fenced_block "$body" 1)
+	if [[ -z "$payload" ]] || ! _verify_comment_signature "$body" "$pub_key"; then
+		printf 'MALFORMED_APPROVAL\n'
+		return 0
+	fi
+
+	if [[ "$payload" == APPROVE:* ]]; then
+		local legacy_payload_prefix=""
+		legacy_payload_prefix=$(printf 'APPROVE:%s:%s:%s:' "$target_type" "$slug" "$target_number" | tr '[:upper:]' '[:lower:]')
+		if [[ "$(printf '%s' "$payload" | tr '[:upper:]' '[:lower:]')" == "${legacy_payload_prefix}"* ]]; then
+			printf 'LEGACY_APPROVAL\n'
+		else
+			printf 'MALFORMED_APPROVAL\n'
+		fi
+		return 0
+	fi
+
+	if ! jq -e --arg type "$target_type" --arg repo "$normalized_slug" --arg number "$target_number" '
+		.schema == "aidevops-approval/v2"
+		and .target.kind == $type
+		and .target.repository == $repo
+		and (.target.number | tostring) == $number
+		and (.snapshot_sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+		and (.issued_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+		and (if $type == "pr" then (.authority == "merge" and (.pr | type == "object")) else (.authority == "development" and .pr == null) end)
+	' <<<"$payload" >/dev/null 2>&1; then
+		printf 'MALFORMED_APPROVAL\n'
+		return 0
+	fi
+
+	if [[ "$target_type" == "pr" && -n "$expected_head_sha" ]]; then
+		local payload_head=""
+		payload_head=$(jq -r '.pr.head_sha // ""' <<<"$payload") || payload_head=""
+		if [[ "$payload_head" != "$expected_head_sha" ]]; then
+			printf 'STALE_APPROVAL\n'
+			return 0
+		fi
+	fi
+
+	snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$comment_id") || {
+		printf 'API_ERROR\n'
+		return 0
+	}
+	current_digest=$(approval_snapshot_v2_digest "$snapshot_json") || {
+		printf 'API_ERROR\n'
+		return 0
+	}
+	signed_digest=$(jq -r '.snapshot_sha256' <<<"$payload") || signed_digest=""
+	if [[ "$current_digest" != "$signed_digest" ]]; then
+		printf 'STALE_APPROVAL\n'
+		return 0
+	fi
+
+	if [[ "$target_type" == "pr" ]]; then
+		if ! jq -e --argjson snapshot "$snapshot_json" '
+			.pr.head_sha == $snapshot.head.sha
+			and .pr.head_ref == $snapshot.head.ref
+			and .pr.head_repository == $snapshot.head.repository
+			and .pr.base_ref == $snapshot.base.ref
+			and .pr.base_repository == $snapshot.base.repository
+		' <<<"$payload" >/dev/null 2>&1; then
+			printf 'STALE_APPROVAL\n'
+			return 0
+		fi
+	fi
+
+	printf 'VERIFIED\n'
+	return 0
 }
 
 # ── Setup ────────────────────────────────────────────────────────────────────
@@ -990,26 +1077,65 @@ cmd_pr_approved() {
 
 # ── Verify Approval ──────────────────────────────────────────────────────────
 
-# Verify that an issue has a valid signed approval comment.
-# Returns 0 if valid approval found, 1 otherwise.
-# This is the function the pulse calls to check approvals.
+# Verify a V2 approval against the current immutable issue/PR snapshot.
+# Legacy syntax (`verify N slug`) remains an issue verification request, but V1
+# signatures return LEGACY_APPROVAL and never authorize an external merge.
 cmd_verify() {
-	local issue_number="${1:-}"
-	local slug="${2:-}"
+	local target_type="issue"
+	if [[ "${1:-}" == "issue" || "${1:-}" == "pr" ]]; then
+		target_type="$1"
+		shift
+	fi
+	local target_number="${1:-}"
+	local slug=""
+	shift 2>/dev/null || true
+	if [[ $# -gt 0 && "$1" != --* ]]; then
+		slug="$1"
+		shift
+	fi
+	local expected_head_sha=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--expect-head)
+			expected_head_sha="${2:-}"
+			shift 2
+			;;
+		*)
+			printf 'MALFORMED_APPROVAL\n'
+			return 5
+			;;
+		esac
+	done
+	if [[ -n "$expected_head_sha" && ! "$expected_head_sha" =~ ^[0-9A-Fa-f]{7,64}$ ]]; then
+		printf 'MALFORMED_APPROVAL\n'
+		return 5
+	fi
 
-	_require_number_arg "$issue_number" "Issue" "Usage: aidevops approve verify <number> [owner/repo]" || return 1
+	_require_number_arg "$target_number" "$target_type" "Usage: aidevops approve verify [issue|pr] <number> [owner/repo] [--expect-head SHA]" || return 5
 	slug=$(_resolve_slug_or_fail "$slug" "Could not detect repo slug") || return 1
 
-	# Fetch comments looking for approval marker
-	local comments_json
-	comments_json=$(gh api "repos/${slug}/issues/${issue_number}/comments" --paginate \
-		--jq "[.[] | select(.body | contains(\"$APPROVAL_MARKER\"))]" 2>/dev/null || echo "[]")
+	local comment_pages="" comments_json=""
+	comment_pages=$(gh api "repos/${slug}/issues/${target_number}/comments?per_page=100" --paginate --slurp 2>/dev/null) || {
+		printf 'API_ERROR\n'
+		return 6
+	}
+	comments_json=$(jq -c --arg marker "$APPROVAL_MARKER" '
+		(if type == "array" and all(.[]; type == "array") then [.[][]?] else [.[]?] end)
+		| [ .[] | select((.body // "") | contains($marker)) ]
+		| sort_by(.id)
+	' <<<"$comment_pages" 2>/dev/null) || {
+		printf 'API_ERROR\n'
+		return 6
+	}
 
 	local comment_count
-	comment_count=$(printf '%s' "$comments_json" | jq 'length' 2>/dev/null || echo "0")
+	comment_count=$(printf '%s' "$comments_json" | jq 'length' 2>/dev/null) || {
+		printf 'API_ERROR\n'
+		return 6
+	}
 
 	if [[ "$comment_count" -eq 0 ]]; then
-		echo "NO_APPROVAL"
+		printf 'NO_APPROVAL\n'
 		return 1
 	fi
 
@@ -1018,25 +1144,49 @@ cmd_verify() {
 	# worker cannot verify it" and avoids re-applying NMR over a signed approval.
 	local pub_key="${AIDEVOPS_APPROVAL_PUB:-$APPROVAL_PUB}"
 	if [[ ! -f "$pub_key" ]]; then
-		echo "NO_KEY"
-		return 1
+		printf 'NO_KEY\n'
+		return 2
 	fi
 
-	# Check each approval comment (most recent first)
+	local saw_api_error=0 saw_stale=0 saw_legacy=0 saw_malformed=0
 	local i=$((comment_count - 1))
 	while [[ "$i" -ge 0 ]]; do
-		local body
+		local body comment_id classification
 		body=$(printf '%s' "$comments_json" | jq -r ".[$i].body" 2>/dev/null || echo "")
+		comment_id=$(printf '%s' "$comments_json" | jq -r ".[$i].id // empty" 2>/dev/null || echo "")
 		i=$((i - 1))
-
-		if _verify_comment_signature "$issue_number" "$body" "$pub_key"; then
-			echo "VERIFIED"
-			return 0
+		if [[ ! "$comment_id" =~ ^[0-9]+$ ]]; then
+			saw_malformed=1
+			continue
 		fi
+		classification=$(_approval_classify_signed_comment "$target_type" "$target_number" "$slug" "$comment_id" "$body" "$pub_key" "$expected_head_sha")
+		case "$classification" in
+		VERIFIED)
+			printf 'VERIFIED\n'
+			return 0
+			;;
+		API_ERROR) saw_api_error=1 ;;
+		STALE_APPROVAL) saw_stale=1 ;;
+		LEGACY_APPROVAL) saw_legacy=1 ;;
+		*) saw_malformed=1 ;;
+		esac
 	done
 
-	echo "UNVERIFIED"
-	return 1
+	if [[ "$saw_api_error" -eq 1 ]]; then
+		printf 'API_ERROR\n'
+		return 6
+	fi
+	if [[ "$saw_stale" -eq 1 ]]; then
+		printf 'STALE_APPROVAL\n'
+		return 4
+	fi
+	if [[ "$saw_legacy" -eq 1 ]]; then
+		printf 'LEGACY_APPROVAL\n'
+		return 3
+	fi
+	[[ "$saw_malformed" -eq 1 ]] || saw_malformed=1
+	printf 'MALFORMED_APPROVAL\n'
+	return 5
 }
 
 # ── Status ───────────────────────────────────────────────────────────────────
@@ -1087,7 +1237,7 @@ cmd_help() {
 	echo "  pr <number> [slug]         Approve a PR"
 	echo ""
 	echo "Commands (no sudo needed):"
-	echo "  verify <number> [slug]     Verify approval signature on an issue"
+	echo "  verify [issue|pr] <number> [slug] [--expect-head SHA]"
 	echo "  status                     Show approval key setup status"
 	echo "  help                       Show this help"
 	echo ""
@@ -1095,6 +1245,7 @@ cmd_help() {
 	echo "  sudo aidevops approve setup"
 	echo "  sudo aidevops approve issue 17438 <owner/repo>"
 	echo "  aidevops approve verify 17438"
+	echo "  aidevops approve verify pr 17439 <owner/repo> --expect-head <sha>"
 	echo ""
 	echo "Security: The approval signing key is stored root-only. Workers run as your"
 	echo "user account and cannot access it, even with the same GitHub credentials."

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1077,6 +1077,44 @@ cmd_pr_approved() {
 
 # ── Verify Approval ──────────────────────────────────────────────────────────
 
+_approval_classify_marked_comments() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+	local comments_json="$4"
+	local pub_key="$5"
+	local expected_head_sha="${6:-}"
+	local comment_count="$7"
+	local saw_api_error=0 saw_stale=0 saw_legacy=0 saw_malformed=0
+	local i=$((comment_count - 1))
+
+	while [[ "$i" -ge 0 ]]; do
+		local body comment_id classification
+		body=$(printf '%s' "$comments_json" | jq -r ".[$i].body" 2>/dev/null || echo "")
+		comment_id=$(printf '%s' "$comments_json" | jq -r ".[$i].id // empty" 2>/dev/null || echo "")
+		i=$((i - 1))
+		if [[ ! "$comment_id" =~ ^[0-9]+$ ]]; then
+			saw_malformed=1
+			continue
+		fi
+		classification=$(_approval_classify_signed_comment "$target_type" "$target_number" "$slug" "$comment_id" "$body" "$pub_key" "$expected_head_sha")
+		case "$classification" in
+		VERIFIED) printf 'VERIFIED\n'; return 0 ;;
+		API_ERROR) saw_api_error=1 ;;
+		STALE_APPROVAL) saw_stale=1 ;;
+		LEGACY_APPROVAL) saw_legacy=1 ;;
+		*) saw_malformed=1 ;;
+		esac
+	done
+
+	[[ "$saw_api_error" -eq 0 ]] || { printf 'API_ERROR\n'; return 6; }
+	[[ "$saw_stale" -eq 0 ]] || { printf 'STALE_APPROVAL\n'; return 4; }
+	[[ "$saw_legacy" -eq 0 ]] || { printf 'LEGACY_APPROVAL\n'; return 3; }
+	[[ "$saw_malformed" -eq 1 ]] || saw_malformed=1
+	printf 'MALFORMED_APPROVAL\n'
+	return 5
+}
+
 # Verify a V2 approval against the current immutable issue/PR snapshot.
 # Legacy syntax (`verify N slug`) remains an issue verification request, but V1
 # signatures return LEGACY_APPROVAL and never authorize an external merge.
@@ -1148,45 +1186,8 @@ cmd_verify() {
 		return 2
 	fi
 
-	local saw_api_error=0 saw_stale=0 saw_legacy=0 saw_malformed=0
-	local i=$((comment_count - 1))
-	while [[ "$i" -ge 0 ]]; do
-		local body comment_id classification
-		body=$(printf '%s' "$comments_json" | jq -r ".[$i].body" 2>/dev/null || echo "")
-		comment_id=$(printf '%s' "$comments_json" | jq -r ".[$i].id // empty" 2>/dev/null || echo "")
-		i=$((i - 1))
-		if [[ ! "$comment_id" =~ ^[0-9]+$ ]]; then
-			saw_malformed=1
-			continue
-		fi
-		classification=$(_approval_classify_signed_comment "$target_type" "$target_number" "$slug" "$comment_id" "$body" "$pub_key" "$expected_head_sha")
-		case "$classification" in
-		VERIFIED)
-			printf 'VERIFIED\n'
-			return 0
-			;;
-		API_ERROR) saw_api_error=1 ;;
-		STALE_APPROVAL) saw_stale=1 ;;
-		LEGACY_APPROVAL) saw_legacy=1 ;;
-		*) saw_malformed=1 ;;
-		esac
-	done
-
-	if [[ "$saw_api_error" -eq 1 ]]; then
-		printf 'API_ERROR\n'
-		return 6
-	fi
-	if [[ "$saw_stale" -eq 1 ]]; then
-		printf 'STALE_APPROVAL\n'
-		return 4
-	fi
-	if [[ "$saw_legacy" -eq 1 ]]; then
-		printf 'LEGACY_APPROVAL\n'
-		return 3
-	fi
-	[[ "$saw_malformed" -eq 1 ]] || saw_malformed=1
-	printf 'MALFORMED_APPROVAL\n'
-	return 5
+	_approval_classify_marked_comments "$target_type" "$target_number" "$slug" "$comments_json" "$pub_key" "$expected_head_sha" "$comment_count"
+	return $?
 }
 
 # ── Status ───────────────────────────────────────────────────────────────────

--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# approval-snapshot-v2.sh — deterministic content/head snapshots for approvals.
+
+[[ -n "${_APPROVAL_SNAPSHOT_V2_LOADED:-}" ]] && return 0
+_APPROVAL_SNAPSHOT_V2_LOADED=1
+
+_approval_snapshot_v2_fetch_pages() {
+	local endpoint="$1"
+	local pages=""
+
+	pages=$(gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
+	printf '%s' "$pages" | jq -e 'type == "array" and all(.[]; type == "array")' >/dev/null 2>&1 || return 1
+	printf '%s\n' "$pages"
+	return 0
+}
+
+_approval_snapshot_v2_comments_json() {
+	local pages_json="$1"
+	local excluded_comment_id="${2:-}"
+	local source_name="${3:-conversation}"
+
+	# #aidevops:trust-boundary — exclude the exact approval comment whose
+	# signature is being verified plus the strict trusted-association lifecycle
+	# audit written after verification. Marker text is attacker-controlled:
+	# excluding arbitrary marker comments would let an external contributor hide
+	# later drift by copying the marker into an unsigned comment.
+	jq -cS --arg excluded "$excluded_comment_id" --arg source "$source_name" '
+		[.[][]?
+		| select((.id | tostring) != $excluded)
+		| select((.user.type // "") != "Bot")
+		| select((
+			((.author_association // "") == "OWNER" or (.author_association // "") == "MEMBER" or (.author_association // "") == "COLLABORATOR")
+			and ((.body // "") | startswith("<!-- aidevops-signed-approval -->\n<!-- stale-recovery-tick:0 (reset: auto-approved by maintainer — "))
+			and ((.body // "") | contains(") -->\nAuto-approved: "))
+			and ((.body // "") | contains(". Stale recovery tick reset."))
+		) | not)
+		| {
+			source: $source,
+			id: .id,
+			node_id: (.node_id // ""),
+			author: {
+				id: (.user.id // null),
+				node_id: (.user.node_id // ""),
+				login: (.user.login // ""),
+				type: (.user.type // "")
+			},
+			author_association: (.author_association // ""),
+			created_at: (.created_at // ""),
+			updated_at: (.updated_at // .created_at // ""),
+			body: (.body // ""),
+			path: (.path // null),
+			line: (.line // null),
+			side: (.side // null),
+			commit_id: (.commit_id // null),
+			original_commit_id: (.original_commit_id // null)
+		}
+		] | sort_by(.source, .id)
+	' <<<"$pages_json"
+	return $?
+}
+
+_approval_snapshot_v2_linked_references_json() {
+	local pages_json="$1"
+
+	# GitHub timeline cross-reference events are the authoritative read-only
+	# projection of issue/PR links. Keep external text and URLs as opaque bytes;
+	# this helper never follows or executes them.
+	jq -cS '
+		[.[][]?
+		| select((.event // "") == "cross-referenced" or (.event // "") == "connected" or (.event // "") == "disconnected" or (.event // "") == "referenced")
+		| {
+			event: (.event // ""),
+			id: (.id // null),
+			node_id: (.node_id // ""),
+			created_at: (.created_at // ""),
+			updated_at: (.updated_at // .created_at // ""),
+			actor: {
+				id: (.actor.id // null),
+				node_id: (.actor.node_id // ""),
+				login: (.actor.login // ""),
+				type: (.actor.type // "")
+			},
+			commit_id: (.commit_id // ""),
+			commit_url: (.commit_url // ""),
+			source: (if (.source.issue // null) == null then null else {
+				kind: (if (.source.issue.pull_request // null) == null then "issue" else "pr" end),
+				repository: ((.source.issue.repository.full_name // "") | ascii_downcase),
+				number: (.source.issue.number // null),
+				id: (.source.issue.id // null),
+				node_id: (.source.issue.node_id // ""),
+				title: (.source.issue.title // ""),
+				body: (.source.issue.body // ""),
+				state: (.source.issue.state // ""),
+				updated_at: (.source.issue.updated_at // ""),
+				author: {
+					id: (.source.issue.user.id // null),
+					node_id: (.source.issue.user.node_id // ""),
+					login: (.source.issue.user.login // ""),
+					type: (.source.issue.user.type // "")
+				}
+			} end)
+		}
+		] | sort_by(.created_at, .event, .id)
+	' <<<"$pages_json"
+	return $?
+}
+
+_approval_snapshot_v2_reviews_json() {
+	local pages_json="$1"
+
+	jq -cS '
+		[.[][]?
+		| select((.user.type // "") != "Bot")
+		| {
+			id: .id,
+			node_id: (.node_id // ""),
+			author: {
+				id: (.user.id // null),
+				node_id: (.user.node_id // ""),
+				login: (.user.login // ""),
+				type: (.user.type // "")
+			},
+			author_association: (.author_association // ""),
+			state: (.state // ""),
+			commit_id: (.commit_id // ""),
+			submitted_at: (.submitted_at // ""),
+			body: (.body // "")
+		}
+		] | sort_by(.id)
+	' <<<"$pages_json"
+	return $?
+}
+
+approval_snapshot_v2_build() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+	local excluded_comment_id="${4:-}"
+	local issue_json="" comments_pages="" comments_json="" timeline_pages="" linked_references_json="" normalized_slug=""
+
+	[[ "$target_type" == "issue" || "$target_type" == "pr" ]] || return 1
+	[[ "$target_number" =~ ^[0-9]+$ && "$slug" == */* ]] || return 1
+	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
+
+	issue_json=$(gh api "repos/${slug}/issues/${target_number}" 2>/dev/null) || return 1
+	printf '%s' "$issue_json" | jq -e 'type == "object" and (.id != null) and (.node_id != null)' >/dev/null 2>&1 || return 1
+	if [[ "$target_type" == "pr" ]]; then
+		printf '%s' "$issue_json" | jq -e 'has("pull_request")' >/dev/null 2>&1 || return 1
+	else
+		printf '%s' "$issue_json" | jq -e 'has("pull_request") | not' >/dev/null 2>&1 || return 1
+	fi
+
+	comments_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/comments?per_page=100") || return 1
+	comments_json=$(_approval_snapshot_v2_comments_json "$comments_pages" "$excluded_comment_id" "conversation") || return 1
+	timeline_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/timeline?per_page=100") || return 1
+	linked_references_json=$(_approval_snapshot_v2_linked_references_json "$timeline_pages") || return 1
+
+	if [[ "$target_type" == "issue" ]]; then
+		jq -cS -n --arg repo "$normalized_slug" --argjson number "$target_number" \
+			--argjson issue "$issue_json" --argjson comments "$comments_json" \
+			--argjson linked_references "$linked_references_json" '
+			{
+				schema: "aidevops-approval-snapshot/v2",
+				target: {kind: "issue", repository: $repo, number: $number, id: $issue.id, node_id: $issue.node_id},
+				author: {
+					id: ($issue.user.id // null), node_id: ($issue.user.node_id // ""),
+					login: ($issue.user.login // ""), type: ($issue.user.type // ""),
+					association: ($issue.author_association // "")
+				},
+				created_at: ($issue.created_at // ""),
+				title: ($issue.title // ""),
+				body: ($issue.body // ""),
+				comments: $comments,
+				linked_references: $linked_references
+			}
+		'
+		return $?
+	fi
+
+	local pr_json="" review_comment_pages="" review_comments_json="" review_pages="" reviews_json=""
+	pr_json=$(gh api "repos/${slug}/pulls/${target_number}" 2>/dev/null) || return 1
+	printf '%s' "$pr_json" | jq -e 'type == "object" and (.id != null) and (.node_id != null) and ((.head.sha // "") != "") and ((.base.ref // "") != "")' >/dev/null 2>&1 || return 1
+	review_comment_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/pulls/${target_number}/comments?per_page=100") || return 1
+	review_comments_json=$(_approval_snapshot_v2_comments_json "$review_comment_pages" "" "review") || return 1
+	review_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/pulls/${target_number}/reviews?per_page=100") || return 1
+	reviews_json=$(_approval_snapshot_v2_reviews_json "$review_pages") || return 1
+
+	jq -cS -n --arg repo "$normalized_slug" --argjson number "$target_number" \
+		--argjson issue "$issue_json" --argjson pr "$pr_json" \
+		--argjson comments "$comments_json" --argjson review_comments "$review_comments_json" \
+		--argjson reviews "$reviews_json" --argjson linked_references "$linked_references_json" '
+		{
+			schema: "aidevops-approval-snapshot/v2",
+			target: {kind: "pr", repository: $repo, number: $number, id: $pr.id, node_id: $pr.node_id, issue_id: $issue.id},
+			author: {
+				id: ($pr.user.id // null), node_id: ($pr.user.node_id // ""),
+				login: ($pr.user.login // ""), type: ($pr.user.type // ""),
+				association: ($pr.author_association // "")
+			},
+			created_at: ($pr.created_at // ""),
+			title: ($pr.title // ""),
+			body: ($pr.body // ""),
+			head: {
+				sha: $pr.head.sha, ref: ($pr.head.ref // ""),
+				repository_id: ($pr.head.repo.id // null), repository: (($pr.head.repo.full_name // "") | ascii_downcase)
+			},
+			base: {
+				ref: $pr.base.ref,
+				repository_id: ($pr.base.repo.id // null), repository: (($pr.base.repo.full_name // $repo) | ascii_downcase)
+			},
+			comments: $comments,
+			review_comments: $review_comments,
+			reviews: $reviews,
+			linked_references: $linked_references
+		}
+	'
+	return $?
+}
+
+approval_snapshot_v2_digest() {
+	local snapshot_json="$1"
+	local digest=""
+
+	if command -v sha256sum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$snapshot_json" | sha256sum | awk '{print $1}') || return 1
+	elif command -v shasum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$snapshot_json" | shasum -a 256 | awk '{print $1}') || return 1
+	else
+		return 1
+	fi
+	[[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+	printf '%s\n' "$digest"
+	return 0
+}
+
+approval_snapshot_v2_payload() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+	local issued_at="$4"
+	local excluded_comment_id="${5:-}"
+	local snapshot_json="" digest="" normalized_slug=""
+
+	snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$excluded_comment_id") || return 1
+	digest=$(approval_snapshot_v2_digest "$snapshot_json") || return 1
+	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
+	jq -cS -n --arg type "$target_type" --arg repo "$normalized_slug" --argjson number "$target_number" \
+		--arg issued "$issued_at" --arg digest "$digest" --argjson snapshot "$snapshot_json" '
+		{
+			schema: "aidevops-approval/v2",
+			authority: (if $type == "pr" then "merge" else "development" end),
+			issued_at: $issued,
+			target: {kind: $type, repository: $repo, number: $number},
+			snapshot_sha256: $digest,
+			pr: (if $type == "pr" then {
+				head_sha: $snapshot.head.sha,
+				head_ref: $snapshot.head.ref,
+				head_repository: $snapshot.head.repository,
+				base_ref: $snapshot.base.ref,
+				base_repository: $snapshot.base.repository
+			} else null end)
+		}
+	'
+	return $?
+}

--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -5,6 +5,7 @@
 
 [[ -n "${_APPROVAL_SNAPSHOT_V2_LOADED:-}" ]] && return 0
 _APPROVAL_SNAPSHOT_V2_LOADED=1
+APPROVAL_TARGET_ISSUE="issue"
 
 _approval_snapshot_v2_fetch_pages() {
 	local endpoint="$1"
@@ -20,21 +21,22 @@ _approval_snapshot_v2_comments_json() {
 	local pages_json="$1"
 	local excluded_comment_id="${2:-}"
 	local source_name="${3:-conversation}"
+	local empty_string=""
 
 	# #aidevops:trust-boundary — exclude the exact approval comment whose
 	# signature is being verified plus the strict trusted-association lifecycle
 	# audit written after verification. Marker text is attacker-controlled:
 	# excluding arbitrary marker comments would let an external contributor hide
 	# later drift by copying the marker into an unsigned comment.
-	jq -cS --arg excluded "$excluded_comment_id" --arg source "$source_name" '
+	jq -cS --arg excluded "$excluded_comment_id" --arg source "$source_name" --arg empty "$empty_string" '
 		[.[][]?
 		| select((.id | tostring) != $excluded)
-		| select((.user.type // "") != "Bot")
+		| select((.user.type // $empty) != "Bot")
 		| select((
-			((.author_association // "") == "OWNER" or (.author_association // "") == "MEMBER" or (.author_association // "") == "COLLABORATOR")
-			and ((.body // "") | startswith("<!-- aidevops-signed-approval -->\n<!-- stale-recovery-tick:0 (reset: auto-approved by maintainer — "))
-			and ((.body // "") | contains(") -->\nAuto-approved: "))
-			and ((.body // "") | contains(". Stale recovery tick reset."))
+			((.author_association // $empty) == "OWNER" or (.author_association // $empty) == "MEMBER" or (.author_association // $empty) == "COLLABORATOR")
+			and ((.body // $empty) | startswith("<!-- aidevops-signed-approval -->\n<!-- stale-recovery-tick:0 (reset: auto-approved by maintainer — "))
+			and ((.body // $empty) | contains(") -->\nAuto-approved: "))
+			and ((.body // $empty) | contains(". Stale recovery tick reset."))
 		) | not)
 		| {
 			source: $source,
@@ -42,14 +44,14 @@ _approval_snapshot_v2_comments_json() {
 			node_id: (.node_id // ""),
 			author: {
 				id: (.user.id // null),
-				node_id: (.user.node_id // ""),
-				login: (.user.login // ""),
-				type: (.user.type // "")
+				node_id: (.user.node_id // $empty),
+				login: (.user.login // $empty),
+				type: (.user.type // $empty)
 			},
-			author_association: (.author_association // ""),
-			created_at: (.created_at // ""),
-			updated_at: (.updated_at // .created_at // ""),
-			body: (.body // ""),
+			author_association: (.author_association // $empty),
+			created_at: (.created_at // $empty),
+			updated_at: (.updated_at // .created_at // $empty),
+			body: (.body // $empty),
 			path: (.path // null),
 			line: (.line // null),
 			side: (.side // null),
@@ -63,42 +65,43 @@ _approval_snapshot_v2_comments_json() {
 
 _approval_snapshot_v2_linked_references_json() {
 	local pages_json="$1"
+	local empty_string=""
 
 	# GitHub timeline cross-reference events are the authoritative read-only
 	# projection of issue/PR links. Keep external text and URLs as opaque bytes;
 	# this helper never follows or executes them.
-	jq -cS '
+	jq -cS --arg empty "$empty_string" '
 		[.[][]?
-		| select((.event // "") == "cross-referenced" or (.event // "") == "connected" or (.event // "") == "disconnected" or (.event // "") == "referenced")
+		| select((.event // $empty) == "cross-referenced" or (.event // $empty) == "connected" or (.event // $empty) == "disconnected" or (.event // $empty) == "referenced")
 		| {
-			event: (.event // ""),
+			event: (.event // $empty),
 			id: (.id // null),
-			node_id: (.node_id // ""),
-			created_at: (.created_at // ""),
-			updated_at: (.updated_at // .created_at // ""),
+			node_id: (.node_id // $empty),
+			created_at: (.created_at // $empty),
+			updated_at: (.updated_at // .created_at // $empty),
 			actor: {
 				id: (.actor.id // null),
-				node_id: (.actor.node_id // ""),
-				login: (.actor.login // ""),
-				type: (.actor.type // "")
+				node_id: (.actor.node_id // $empty),
+				login: (.actor.login // $empty),
+				type: (.actor.type // $empty)
 			},
-			commit_id: (.commit_id // ""),
-			commit_url: (.commit_url // ""),
+			commit_id: (.commit_id // $empty),
+			commit_url: (.commit_url // $empty),
 			source: (if (.source.issue // null) == null then null else {
 				kind: (if (.source.issue.pull_request // null) == null then "issue" else "pr" end),
-				repository: ((.source.issue.repository.full_name // "") | ascii_downcase),
+				repository: ((.source.issue.repository.full_name // $empty) | ascii_downcase),
 				number: (.source.issue.number // null),
 				id: (.source.issue.id // null),
-				node_id: (.source.issue.node_id // ""),
-				title: (.source.issue.title // ""),
-				body: (.source.issue.body // ""),
-				state: (.source.issue.state // ""),
-				updated_at: (.source.issue.updated_at // ""),
+				node_id: (.source.issue.node_id // $empty),
+				title: (.source.issue.title // $empty),
+				body: (.source.issue.body // $empty),
+				state: (.source.issue.state // $empty),
+				updated_at: (.source.issue.updated_at // $empty),
 				author: {
 					id: (.source.issue.user.id // null),
-					node_id: (.source.issue.user.node_id // ""),
-					login: (.source.issue.user.login // ""),
-					type: (.source.issue.user.type // "")
+					node_id: (.source.issue.user.node_id // $empty),
+					login: (.source.issue.user.login // $empty),
+					type: (.source.issue.user.type // $empty)
 				}
 			} end)
 		}
@@ -109,24 +112,25 @@ _approval_snapshot_v2_linked_references_json() {
 
 _approval_snapshot_v2_reviews_json() {
 	local pages_json="$1"
+	local empty_string=""
 
-	jq -cS '
+	jq -cS --arg empty "$empty_string" '
 		[.[][]?
-		| select((.user.type // "") != "Bot")
+		| select((.user.type // $empty) != "Bot")
 		| {
 			id: .id,
 			node_id: (.node_id // ""),
 			author: {
 				id: (.user.id // null),
-				node_id: (.user.node_id // ""),
-				login: (.user.login // ""),
-				type: (.user.type // "")
+				node_id: (.user.node_id // $empty),
+				login: (.user.login // $empty),
+				type: (.user.type // $empty)
 			},
-			author_association: (.author_association // ""),
-			state: (.state // ""),
-			commit_id: (.commit_id // ""),
-			submitted_at: (.submitted_at // ""),
-			body: (.body // "")
+			author_association: (.author_association // $empty),
+			state: (.state // $empty),
+			commit_id: (.commit_id // $empty),
+			submitted_at: (.submitted_at // $empty),
+			body: (.body // $empty)
 		}
 		] | sort_by(.id)
 	' <<<"$pages_json"
@@ -139,8 +143,9 @@ approval_snapshot_v2_build() {
 	local slug="$3"
 	local excluded_comment_id="${4:-}"
 	local issue_json="" comments_pages="" comments_json="" timeline_pages="" linked_references_json="" normalized_slug=""
+	local empty_string=""
 
-	[[ "$target_type" == "issue" || "$target_type" == "pr" ]] || return 1
+	[[ "$target_type" == "$APPROVAL_TARGET_ISSUE" || "$target_type" == "pr" ]] || return 1
 	[[ "$target_number" =~ ^[0-9]+$ && "$slug" == */* ]] || return 1
 	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
 
@@ -157,21 +162,21 @@ approval_snapshot_v2_build() {
 	timeline_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/timeline?per_page=100") || return 1
 	linked_references_json=$(_approval_snapshot_v2_linked_references_json "$timeline_pages") || return 1
 
-	if [[ "$target_type" == "issue" ]]; then
-		jq -cS -n --arg repo "$normalized_slug" --argjson number "$target_number" \
+	if [[ "$target_type" == "$APPROVAL_TARGET_ISSUE" ]]; then
+		jq -cS -n --arg repo "$normalized_slug" --arg empty "$empty_string" --arg issue_kind "$APPROVAL_TARGET_ISSUE" --argjson number "$target_number" \
 			--argjson issue "$issue_json" --argjson comments "$comments_json" \
 			--argjson linked_references "$linked_references_json" '
 			{
 				schema: "aidevops-approval-snapshot/v2",
-				target: {kind: "issue", repository: $repo, number: $number, id: $issue.id, node_id: $issue.node_id},
+				target: {kind: $issue_kind, repository: $repo, number: $number, id: $issue.id, node_id: $issue.node_id},
 				author: {
-					id: ($issue.user.id // null), node_id: ($issue.user.node_id // ""),
-					login: ($issue.user.login // ""), type: ($issue.user.type // ""),
-					association: ($issue.author_association // "")
+					id: ($issue.user.id // null), node_id: ($issue.user.node_id // $empty),
+					login: ($issue.user.login // $empty), type: ($issue.user.type // $empty),
+					association: ($issue.author_association // $empty)
 				},
-				created_at: ($issue.created_at // ""),
-				title: ($issue.title // ""),
-				body: ($issue.body // ""),
+				created_at: ($issue.created_at // $empty),
+				title: ($issue.title // $empty),
+				body: ($issue.body // $empty),
 				comments: $comments,
 				linked_references: $linked_references
 			}
@@ -181,13 +186,13 @@ approval_snapshot_v2_build() {
 
 	local pr_json="" review_comment_pages="" review_comments_json="" review_pages="" reviews_json=""
 	pr_json=$(gh api "repos/${slug}/pulls/${target_number}" 2>/dev/null) || return 1
-	printf '%s' "$pr_json" | jq -e 'type == "object" and (.id != null) and (.node_id != null) and ((.head.sha // "") != "") and ((.base.ref // "") != "")' >/dev/null 2>&1 || return 1
+	printf '%s' "$pr_json" | jq -e --arg empty "$empty_string" 'type == "object" and (.id != null) and (.node_id != null) and ((.head.sha // $empty) != $empty) and ((.base.ref // $empty) != $empty)' >/dev/null 2>&1 || return 1
 	review_comment_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/pulls/${target_number}/comments?per_page=100") || return 1
 	review_comments_json=$(_approval_snapshot_v2_comments_json "$review_comment_pages" "" "review") || return 1
 	review_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/pulls/${target_number}/reviews?per_page=100") || return 1
 	reviews_json=$(_approval_snapshot_v2_reviews_json "$review_pages") || return 1
 
-	jq -cS -n --arg repo "$normalized_slug" --argjson number "$target_number" \
+	jq -cS -n --arg repo "$normalized_slug" --arg empty "$empty_string" --argjson number "$target_number" \
 		--argjson issue "$issue_json" --argjson pr "$pr_json" \
 		--argjson comments "$comments_json" --argjson review_comments "$review_comments_json" \
 		--argjson reviews "$reviews_json" --argjson linked_references "$linked_references_json" '
@@ -195,16 +200,16 @@ approval_snapshot_v2_build() {
 			schema: "aidevops-approval-snapshot/v2",
 			target: {kind: "pr", repository: $repo, number: $number, id: $pr.id, node_id: $pr.node_id, issue_id: $issue.id},
 			author: {
-				id: ($pr.user.id // null), node_id: ($pr.user.node_id // ""),
-				login: ($pr.user.login // ""), type: ($pr.user.type // ""),
-				association: ($pr.author_association // "")
+				id: ($pr.user.id // null), node_id: ($pr.user.node_id // $empty),
+				login: ($pr.user.login // $empty), type: ($pr.user.type // $empty),
+				association: ($pr.author_association // $empty)
 			},
-			created_at: ($pr.created_at // ""),
-			title: ($pr.title // ""),
-			body: ($pr.body // ""),
+			created_at: ($pr.created_at // $empty),
+			title: ($pr.title // $empty),
+			body: ($pr.body // $empty),
 			head: {
-				sha: $pr.head.sha, ref: ($pr.head.ref // ""),
-				repository_id: ($pr.head.repo.id // null), repository: (($pr.head.repo.full_name // "") | ascii_downcase)
+				sha: $pr.head.sha, ref: ($pr.head.ref // $empty),
+				repository_id: ($pr.head.repo.id // null), repository: (($pr.head.repo.full_name // $empty) | ascii_downcase)
 			},
 			base: {
 				ref: $pr.base.ref,

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -159,7 +159,7 @@ _invoke_opencode() {
 		print_info "[lifecycle] db_isolated dir=$isolated_data_dir pid=$$"
 		_sync_worker_db_migration_metadata "$isolated_data_dir"
 		if [[ -n "${_invoke_persisted_session:-}" ]]; then
-			_seed_worker_db_session_context "$isolated_data_dir" "$_invoke_persisted_session"
+			_seed_worker_db_session_context "$isolated_data_dir" "$_invoke_persisted_session" "${_invoke_work_dir:-}"
 			print_info "[lifecycle] db_seeded session=$_invoke_persisted_session pid=$$"
 		fi
 
@@ -1090,6 +1090,10 @@ _execute_run_attempt() {
 	# GH#23958: expose the persisted OpenCode session to _invoke_opencode so
 	# isolated worker DBs can be seeded before --session <id> --continue runs.
 	_invoke_persisted_session="$persisted_session"
+	# GH#27560: persisted sessions retain their original worktree directory.
+	# Expose the current worker directory so isolated DB seeding can rebind the
+	# continuation without mutating the shared interactive session record.
+	_invoke_work_dir="$work_dir"
 
 	# t3077: expose session_key to the verbose lifecycle emitter via the
 	# convention WORKER_SESSION_KEY (read by _emit_verbose_checkpoint).

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1248,12 +1248,15 @@ _merge_worker_db() {
 # Called before `opencode run --session <id> --continue` so retries launched
 # with a fresh XDG_DATA_HOME can resolve the persisted conversation locally.
 # Copies only the selected session and its messages (plus its project row for
-# schema/FK compatibility). Non-fatal: failures fall back to normal runtime
-# stale-session handling.
+# schema/FK compatibility). When a retry moved to a replacement worktree, the
+# isolated copy is rebound to that current directory; the shared session stays
+# unchanged. Non-fatal: failures fall back to normal runtime stale-session
+# handling.
 #######################################
 _seed_worker_db_session_context() {
 	local isolated_dir="$1"
 	local session_id="$2"
+	local current_work_dir="${3:-}"
 	local worker_db="${isolated_dir}/opencode/opencode.db"
 	local shared_db="${HOME}/.local/share/opencode/opencode.db"
 
@@ -1272,9 +1275,13 @@ _seed_worker_db_session_context() {
 
 	_sync_worker_db_migration_ledgers "$worker_db" "$shared_db"
 
-	local shared_db_sql session_id_sql
+	local shared_db_sql session_id_sql current_work_dir_sql=""
 	shared_db_sql=$(sql_escape "$shared_db")
 	session_id_sql=$(sql_escape "$session_id")
+	if [[ -n "$current_work_dir" && -d "$current_work_dir" ]]; then
+		current_work_dir=$(cd "$current_work_dir" 2>/dev/null && pwd -P) || current_work_dir=""
+		current_work_dir_sql=$(sql_escape "$current_work_dir")
+	fi
 	sqlite3 "$worker_db" <<-SQL >/dev/null 2>&1 || true
 		.bail on
 		.timeout 5000
@@ -1284,6 +1291,7 @@ _seed_worker_db_session_context() {
 			WHERE id IN (SELECT project_id FROM shared.session WHERE id = '${session_id_sql}');
 		INSERT OR IGNORE INTO session SELECT * FROM shared.session WHERE id = '${session_id_sql}';
 		INSERT OR IGNORE INTO message SELECT * FROM shared.message WHERE session_id = '${session_id_sql}';
+		$(if [[ -n "$current_work_dir_sql" ]]; then printf "UPDATE main.session SET directory = '%s' WHERE id = '%s';" "$current_work_dir_sql" "$session_id_sql"; fi)
 		DELETE FROM main.message WHERE session_id != '${session_id_sql}';
 		DELETE FROM main.session WHERE id != '${session_id_sql}';
 		DELETE FROM main.project WHERE id NOT IN (SELECT project_id FROM main.session);

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -381,6 +381,33 @@ _external_pr_linked_issue_crypto_approved() {
 }
 
 #######################################
+# Verify PR-specific V2 merge authority against the current head.
+#
+# #aidevops:trust-boundary — issue approval authorizes development only. An
+# external/fork merge requires a signed PR snapshot; helper absence, legacy
+# signatures, stale content/head state, and API errors all fail closed.
+#
+# Args: $1=PR number, $2=repo slug, $3=expected head SHA (optional)
+# Returns: 0=current PR snapshot verified, 1=not authorized
+#######################################
+_external_pr_current_head_crypto_approved() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="${3:-}"
+	local approval_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/approval-helper.sh"
+	local result=""
+
+	[[ -f "$approval_helper" ]] || return 1
+	if [[ -n "$expected_head_sha" ]]; then
+		result=$(bash "$approval_helper" verify pr "$pr_number" "$repo_slug" --expect-head "$expected_head_sha" 2>/dev/null) || result=""
+	else
+		result=$(bash "$approval_helper" verify pr "$pr_number" "$repo_slug" 2>/dev/null) || result=""
+	fi
+	[[ "$result" == "VERIFIED" ]]
+	return $?
+}
+
+#######################################
 # Check whether a PR or its linked issue has a maintainer crypto-approval
 # signature (t3063 — symmetric extension of t3052 to the deterministic merge
 # cascade and the approve_collaborator_pr gate).
@@ -389,11 +416,8 @@ _external_pr_linked_issue_crypto_approved() {
 # trust signal as author-association because it requires a root-owned SSH
 # private key that workers cannot forge.
 #
-# Checks PR-level comments first, then linked-issue comments. Uses
-# approval-helper.sh for cryptographic verification when available; falls back
-# to marker presence when the helper is absent (the marker can only be posted
-# by someone with write access, and full verification is provided by the
-# existing downstream gate in _external_pr_linked_issue_crypto_approved).
+# Requires PR-level V2 merge authority. Linked-issue approval remains valid for
+# worker development authority, but it cannot authorize a future or changed PR.
 #
 # #aidevops:trust-boundary — this function gates security-relevant approval
 # decisions. Changes here require preserving the four-layer defence-in-depth
@@ -407,59 +431,10 @@ _external_pr_linked_issue_crypto_approved() {
 _has_maintainer_crypto_approval() {
 	local pr_number="$1"
 	local repo_slug="$2"
-	local approval_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/approval-helper.sh"
+	local expected_head_sha="${3:-}"
 
-	# Marker string embedded in every signed approval comment by approval-helper.sh.
-	# Source of truth: approval-helper.sh line ~65 APPROVAL_MARKER constant.
-	local _approval_marker="aidevops-signed-approval"
-	# Use a named local for the approval-helper success status to keep the
-	# literal string count below the repeated-string-literal ratchet threshold.
-	local _approved_status="VERIFIED"
-
-	# Check PR-level comments for a crypto-approval signature.
-	local pr_marker_count
-	pr_marker_count=$(gh api "repos/${repo_slug}/issues/${pr_number}/comments" \
-		--jq "[.[].body | strings | select(contains(\"${_approval_marker}\"))] | length" \
-		2>/dev/null || true)
-	[[ "$pr_marker_count" =~ ^[0-9]+$ ]] || pr_marker_count=0
-	if [[ "$pr_marker_count" -gt 0 ]]; then
-		if [[ -f "$approval_helper" ]]; then
-			local _pr_verify
-			_pr_verify=$(bash "$approval_helper" verify "$pr_number" "$repo_slug" 2>/dev/null) || _pr_verify=""
-			if [[ "$_pr_verify" == "$_approved_status" ]]; then
-				return 0
-			fi
-		else
-			# Trust the marker when the helper is absent — full cryptographic
-			# verification is provided by _external_pr_linked_issue_crypto_approved
-			# in the downstream gate chain.
-			return 0
-		fi
-	fi
-
-	# Check linked-issue comments for a crypto-approval signature.
-	local linked
-	linked=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || linked=""
-	[[ -z "$linked" ]] && return 1
-
-	local issue_marker_count
-	issue_marker_count=$(gh api "repos/${repo_slug}/issues/${linked}/comments" \
-		--jq "[.[].body | strings | select(contains(\"${_approval_marker}\"))] | length" \
-		2>/dev/null || true)
-	[[ "$issue_marker_count" =~ ^[0-9]+$ ]] || issue_marker_count=0
-	if [[ "$issue_marker_count" -gt 0 ]]; then
-		if [[ -f "$approval_helper" ]]; then
-			local _issue_verify
-			_issue_verify=$(bash "$approval_helper" verify "$linked" "$repo_slug" 2>/dev/null) || _issue_verify=""
-			if [[ "$_issue_verify" == "$_approved_status" ]]; then
-				return 0
-			fi
-		else
-			return 0
-		fi
-	fi
-
-	return 1
+	_external_pr_current_head_crypto_approved "$pr_number" "$repo_slug" "$expected_head_sha"
+	return $?
 }
 
 #######################################
@@ -487,46 +462,77 @@ _has_maintainer_crypto_approval() {
 #   * any future code path that reaches the merge invocation without
 #     traversing the existing gate chain.
 #
-# Two complementary triggers treat a PR as "external" for this gate:
+# Three complementary triggers treat a PR as "external" for this gate:
 #
 #   1. `external-contributor` label present, OR
 #   2. `isCrossRepository=true` (the PR head is on a fork) — even if the
-#      label is absent. An unlabeled fork PR is a HIGHER-severity signal
-#      than a labeled one, because the labeling system itself failed.
+#      label is absent, OR
+#   3. the live collaborator-permission lookup says the PR author lacks write.
 #
-# When external: require linked issue + cryptographic approval (the same
-# evidence the upstream gate requires). When not external: pass — the
-# existing collaborator gates apply.
+# An unlabeled fork/non-collaborator PR is a HIGHER-severity signal than a
+# labeled one, because the labeling system itself failed.
+#
+# When external: require a current approved linked-issue snapshot plus
+# PR-specific V2 authority for the exact head/content snapshot. When not
+# external: pass — the existing collaborator gates apply.
 #
 # Args:
 #   $1 - PR number
 #   $2 - repo slug (owner/repo)
 #
 # Returns:
-#   0 - safe to invoke `--admin` merge (not external, OR external with
-#       linked issue + crypto approval)
+#   0 - safe to invoke a merge path (not external, OR external with current
+#       linked-issue development authority and PR-specific merge authority)
 #   1 - REFUSE: external/fork PR without crypto approval
 #######################################
 _pulse_merge_admin_safety_check() {
 	local pr_number="$1"
 	local repo_slug="$2"
+	local expected_head_sha="${3:-}"
 
 	# t2863: initialise multi-var locals at declaration time so set -u
 	# is safe even on a partial-failure path through the assignments.
-	local pr_meta_json="" labels_str="" is_fork="false"
+	local pr_meta_json="" labels_str="" is_fork="false" current_head_sha="" pr_author=""
 	pr_meta_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json labels,isCrossRepository 2>/dev/null) || pr_meta_json=""
+		--json author,labels,isCrossRepository,headRefOid 2>/dev/null) || pr_meta_json=""
+	[[ -n "$pr_meta_json" ]] || return 1
 	labels_str=$(printf '%s' "$pr_meta_json" \
 		| jq -r '[.labels[].name] | join(",")' 2>/dev/null) || labels_str=""
 	is_fork=$(printf '%s' "$pr_meta_json" \
 		| jq -r '.isCrossRepository // false' 2>/dev/null) || is_fork="false"
+	current_head_sha=$(printf '%s' "$pr_meta_json" \
+		| jq -r '.headRefOid // ""' 2>/dev/null) || current_head_sha=""
+	pr_author=$(printf '%s' "$pr_meta_json" \
+		| jq -r '.author.login // ""' 2>/dev/null) || pr_author=""
+	[[ -n "$current_head_sha" && -n "$pr_author" ]] || return 1
+	if [[ -n "$expected_head_sha" && "$current_head_sha" != "$expected_head_sha" ]]; then
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — head changed before final authority check" >>"$LOGFILE"
+		return 1
+	fi
 
-	local treat_as_external=0
+	# #aidevops:trust-boundary — a live NMR label is an explicit hold. Signed
+	# marker presence never overrides it at the final merge call.
+	if [[ ",${labels_str}," == *",needs-maintainer-review,"* ]]; then
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — PR carries needs-maintainer-review" >>"$LOGFILE"
+		return 1
+	fi
+
+	local treat_as_external=0 author_collab_rc=0
+	# #aidevops:trust-boundary — labels and fork metadata are not authority.
+	# Re-check the author's live permission at the final merge boundary.
+	_is_collaborator_author "$pr_author" "$repo_slug" || author_collab_rc=$?
+	if [[ "$author_collab_rc" -eq 2 ]]; then
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — final collaborator permission lookup failed for ${pr_author}" >>"$LOGFILE"
+		return 1
+	fi
 	if [[ ",${labels_str}," == *",external-contributor,"* ]]; then
 		treat_as_external=1
 	elif [[ "$is_fork" == "true" ]]; then
 		treat_as_external=1
 		echo "[pulse-merge] DEFENSE-IN-DEPTH: PR #${pr_number} in ${repo_slug} — fork PR missing external-contributor label (label-system race or failure), treating as external (t2934)" >>"$LOGFILE"
+	elif [[ "$author_collab_rc" -ne 0 ]]; then
+		treat_as_external=1
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: PR #${pr_number} in ${repo_slug} — non-collaborator PR missing external-contributor label, treating as external (GH#17671)" >>"$LOGFILE"
 	fi
 
 	if [[ "$treat_as_external" -eq 0 ]]; then
@@ -538,10 +544,20 @@ _pulse_merge_admin_safety_check() {
 		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING --admin merge of PR #${pr_number} in ${repo_slug} — external/fork PR has no linked issue (t2934)" >>"$LOGFILE"
 		return 1
 	fi
+	local linked="" linked_labels=""
+	linked=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || linked=""
+	[[ -n "$linked" ]] || return 1
+	linked_labels=$(gh api "repos/${repo_slug}/issues/${linked}" --jq '[.labels[].name] | join(",")' 2>/dev/null) || linked_labels="__API_ERROR__"
+	if [[ "$linked_labels" == "__API_ERROR__" || ",${linked_labels}," == *",needs-maintainer-review,"* ]]; then
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — linked issue #${linked} is unavailable or carries needs-maintainer-review" >>"$LOGFILE"
+		return 1
+	fi
 	if ! _external_pr_linked_issue_crypto_approved "$pr_number" "$repo_slug"; then
-		local linked
-		linked=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || linked="unknown"
 		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING --admin merge of PR #${pr_number} in ${repo_slug} — external/fork PR linked issue #${linked} lacks crypto approval (t2934)" >>"$LOGFILE"
+		return 1
+	fi
+	if ! _external_pr_current_head_crypto_approved "$pr_number" "$repo_slug" "$current_head_sha"; then
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — external/fork PR lacks V2 authority for current head ${current_head_sha:0:12}" >>"$LOGFILE"
 		return 1
 	fi
 	return 0
@@ -753,7 +769,7 @@ approve_collaborator_pr() {
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
 			approval_body="Auto-approved by pulse runner @${current_user:-unknown} — trusted Dependabot dependency update verified: GitHub bot identity, same-repo branch, dependabot-authored commits, dependency-file-only diff, maintainer allowlist, no security-scan failures, and pre-merge gates passed."
 			echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number author (@$pr_author) is trusted Dependabot with allowlisted dependency update — proceeding (GH#24473)" >>"$LOGFILE"
-		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
+		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$pr_head_sha"; then
 			echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number author (@$pr_author) is not a collaborator on $repo_slug, but maintainer crypto-approval found — proceeding (t3063)" >>"$LOGFILE"
 			# fall through to the approval block below
 		else

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -535,21 +535,27 @@ _pulse_merge_admin_safety_check() {
 		echo "[pulse-merge] DEFENSE-IN-DEPTH: PR #${pr_number} in ${repo_slug} — non-collaborator PR missing external-contributor label, treating as external (GH#17671)" >>"$LOGFILE"
 	fi
 
-	if [[ "$treat_as_external" -eq 0 ]]; then
-		return 0
+	# A linked issue's live NMR state is a final-call hold for every PR, not only
+	# external PRs. Fail closed if a linked issue was found but cannot be read.
+	local linked="" linked_labels=""
+	linked=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || return 1
+	if [[ -n "$linked" ]]; then
+		linked_labels=$(gh api "repos/${repo_slug}/issues/${linked}" --jq '[.labels[].name] | join(",")' 2>/dev/null) || linked_labels="__API_ERROR__"
+		if [[ "$linked_labels" == "__API_ERROR__" || ",${linked_labels}," == *",needs-maintainer-review,"* ]]; then
+			echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — linked issue #${linked} is unavailable or carries needs-maintainer-review" >>"$LOGFILE"
+			return 1
+		fi
 	fi
 
-	# External / fork PR — require linked issue + crypto approval.
-	if ! _external_pr_has_linked_issue "$pr_number" "$repo_slug"; then
-		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING --admin merge of PR #${pr_number} in ${repo_slug} — external/fork PR has no linked issue (t2934)" >>"$LOGFILE"
-		return 1
+	if [[ "$treat_as_external" -eq 0 ]]; then
+		_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE=0
+		return 0
 	fi
-	local linked="" linked_labels=""
-	linked=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || linked=""
-	[[ -n "$linked" ]] || return 1
-	linked_labels=$(gh api "repos/${repo_slug}/issues/${linked}" --jq '[.labels[].name] | join(",")' 2>/dev/null) || linked_labels="__API_ERROR__"
-	if [[ "$linked_labels" == "__API_ERROR__" || ",${linked_labels}," == *",needs-maintainer-review,"* ]]; then
-		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — linked issue #${linked} is unavailable or carries needs-maintainer-review" >>"$LOGFILE"
+	_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE=1
+
+	# External / fork PR — require linked issue + crypto approval.
+	if [[ -z "$linked" ]]; then
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING --admin merge of PR #${pr_number} in ${repo_slug} — external/fork PR has no linked issue (t2934)" >>"$LOGFILE"
 		return 1
 	fi
 	if ! _external_pr_linked_issue_crypto_approved "$pr_number" "$repo_slug"; then

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1724,6 +1724,27 @@ _auto_merge_stuck_seconds() {
 	return 0
 }
 
+# Disarm an already-deferred merge whose mutable approval state now requires a
+# synchronous final gate. Draft conversion is the independent server-side hold
+# when GitHub rejects disable-auto.
+_stop_external_native_auto_merge() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local disable_output=""
+	local draft_hold_output=""
+
+	if disable_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --disable-auto 2>&1); then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disabled deferred native auto-merge because external approval state must be revalidated at the actual merge call" >>"$LOGFILE"
+		return 2
+	fi
+	if draft_hold_output=$(gh pr ready "$pr_number" --repo "$repo_slug" --undo 2>&1); then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disable-auto failed, so PR was returned to draft to stop deferred merge pending fresh approval: ${disable_output}" >>"$LOGFILE"
+		return 2
+	fi
+	echo "[pulse-merge] SECURITY HOLD FAILED for PR #${pr_number} in ${repo_slug}: could not disable external auto-merge or return PR to draft; manual intervention required. disable=${disable_output}; draft=${draft_hold_output}" >>"$LOGFILE"
+	return 3
+}
+
 #######################################
 # Conditionally hand a PR off to GitHub native auto-merge (t3070).
 #
@@ -1756,7 +1777,6 @@ _auto_merge_stuck_seconds() {
 # fallback (returns 1 path) — this trade-off is acceptable for owned-org
 # repos where allow_auto_merge=true is bulk-enabled and CI is fast.
 #
-# Args: $1=pr_number, $2=repo_slug
 # Args: $1=pr_number, $2=repo_slug, $3=require synchronous final gate (0|1)
 # Returns: 0=native-auto requested/deferred, 1=fall through,
 #          2=defer without native auto-merge so mutable approval state is
@@ -1780,21 +1800,8 @@ _set_native_auto_merge_or_skip() {
 
 	if [[ -n "$_existing_auto" ]]; then
 		if [[ "$require_synchronous_final_gate" == "1" ]]; then
-			local _disable_bound_auto_output=""
-			if _disable_bound_auto_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --disable-auto 2>&1); then
-				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disabled deferred native auto-merge because external approval state must be revalidated at the actual merge call" >>"$LOGFILE"
-				return 2
-			fi
-			# If GitHub refuses disable-auto, converting the PR back to draft is a
-			# second independent server-side merge stop. Never continue to another
-			# merge path while an external auto-merge may remain armed.
-			local _draft_hold_output=""
-			if _draft_hold_output=$(gh pr ready "$pr_number" --repo "$repo_slug" --undo 2>&1); then
-				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disable-auto failed, so PR was returned to draft to stop deferred merge pending fresh approval: ${_disable_bound_auto_output}" >>"$LOGFILE"
-				return 2
-			fi
-			echo "[pulse-merge] SECURITY HOLD FAILED for PR #${pr_number} in ${repo_slug}: could not disable external auto-merge or return PR to draft; manual intervention required. disable=${_disable_bound_auto_output}; draft=${_draft_hold_output}" >>"$LOGFILE"
-			return 3
+			_stop_external_native_auto_merge "$pr_number" "$repo_slug"
+			return $?
 		fi
 		# Auto-merge already requested — check for the GitHub auto_merge wedge
 		# before unconditionally deferring (t3192).

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1757,11 +1757,15 @@ _auto_merge_stuck_seconds() {
 # repos where allow_auto_merge=true is bulk-enabled and CI is fast.
 #
 # Args: $1=pr_number, $2=repo_slug
-# Returns: 0=native-auto requested/deferred, 1=fall through
+# Args: $1=pr_number, $2=repo_slug, $3=require synchronous final gate (0|1)
+# Returns: 0=native-auto requested/deferred, 1=fall through,
+#          2=defer without native auto-merge so mutable approval state is
+#            revalidated on a later synchronous merge cycle
 #######################################
 _set_native_auto_merge_or_skip() {
 	local pr_number="$1"
 	local repo_slug="$2"
+	local require_synchronous_final_gate="${3:-0}"
 
 	# Fetch auto_merge metadata + merge state in one call so the stuck-state
 	# check (t3192) does not require an extra round trip.
@@ -1775,6 +1779,23 @@ _set_native_auto_merge_or_skip() {
 	fi
 
 	if [[ -n "$_existing_auto" ]]; then
+		if [[ "$require_synchronous_final_gate" == "1" ]]; then
+			local _disable_bound_auto_output=""
+			if _disable_bound_auto_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --disable-auto 2>&1); then
+				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disabled deferred native auto-merge because external approval state must be revalidated at the actual merge call" >>"$LOGFILE"
+				return 2
+			fi
+			# If GitHub refuses disable-auto, converting the PR back to draft is a
+			# second independent server-side merge stop. Never continue to another
+			# merge path while an external auto-merge may remain armed.
+			local _draft_hold_output=""
+			if _draft_hold_output=$(gh pr ready "$pr_number" --repo "$repo_slug" --undo 2>&1); then
+				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disable-auto failed, so PR was returned to draft to stop deferred merge pending fresh approval: ${_disable_bound_auto_output}" >>"$LOGFILE"
+				return 2
+			fi
+			echo "[pulse-merge] SECURITY HOLD FAILED for PR #${pr_number} in ${repo_slug}: could not disable external auto-merge or return PR to draft; manual intervention required. disable=${_disable_bound_auto_output}; draft=${_draft_hold_output}" >>"$LOGFILE"
+			return 3
+		fi
 		# Auto-merge already requested — check for the GitHub auto_merge wedge
 		# before unconditionally deferring (t3192).
 		local _stuck_seconds=""
@@ -1833,6 +1854,10 @@ _set_native_auto_merge_or_skip() {
 	if [[ "$pending_count" -eq 0 ]]; then
 		# No pending required checks — immediate --admin merge is faster.
 		return 1
+	fi
+	if [[ "$require_synchronous_final_gate" == "1" ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: CI pending; external approval state requires synchronous final revalidation, so native auto-merge remains disabled" >>"$LOGFILE"
+		return 2
 	fi
 
 	# CI in flight — ask GitHub to merge on green.

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -44,6 +44,7 @@ _pmrc_snapshot_checks_json() {
 		"failure" as $failure | "error" as $error |
 		[
 			$pages[]?.check_runs[]? | {
+				source: "check_run",
 				name: (.name // ""),
 				status: ((.status // "") | ascii_downcase),
 				conclusion: ((.conclusion // "") | ascii_downcase),
@@ -52,6 +53,7 @@ _pmrc_snapshot_checks_json() {
 			}
 		] + [
 			$statuses.statuses[]? | ((.state // "") | ascii_downcase) as $state | {
+				source: "commit_status",
 				name: (.context // ""),
 				status: (if $state == $pending then $in_progress else $completed end),
 				conclusion: (if $state == $success then $success elif ($state == $failure or $state == $error) then $failure else "" end),
@@ -60,9 +62,35 @@ _pmrc_snapshot_checks_json() {
 			}
 		]
 		| map(select(.name != ""))
-		| sort_by(.name, .observed_at)
-		| group_by(.name)
+		| sort_by(.source, .name, .observed_at)
+		| group_by([.source, .name])
 		| map(last)
+		| map(. + {
+			family: (if (.name == "maintainer-gate" or .name == "Maintainer Review & Assignee Gate" or .name == "gate / Maintainer Review & Assignee Gate") then "maintainer-gate" else .name end),
+			family_key: (if (.name == "maintainer-gate" or .name == "Maintainer Review & Assignee Gate" or .name == "gate / Maintainer Review & Assignee Gate") then "maintainer-gate" else (.source + "\u0000" + .name) end)
+		})
+		| sort_by(.family_key, .name, .source)
+		| group_by(.family_key)
+		| map(
+			. as $members
+			| if .[0].family == "maintainer-gate" then {
+				name: "maintainer-gate",
+				family: "maintainer-gate",
+				source: "logical_family",
+				status: (if any($members[]; .status != $completed) then $in_progress else $completed end),
+				conclusion: (
+					if any($members[]; (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "startup_failure")) then $failure
+					elif all($members[]; (.conclusion == $success or .conclusion == "neutral" or .conclusion == "skipped")) then $success
+					else "" end
+				),
+				observed_at: ([$members[]?.observed_at | select(. != "")] | max // ""),
+				members: [$members[] | {name, source, status, conclusion, observed_at}]
+			} else
+				($members | sort_by(.observed_at) | last) as $latest
+				| ($latest | del(.family_key)) + {members: [$members[] | {name, source, status, conclusion, observed_at}]}
+			end
+		)
+		| sort_by(.name)
 	' 2>/dev/null) || return 1
 	printf '%s\n' "$checks_json"
 	return 0
@@ -145,21 +173,83 @@ _pmrc_is_explicit_advisory_failure() {
 	return $?
 }
 
+_pmrc_configured_advisory_contexts_json() {
+	local repo_slug="$1"
+	local repos_json="${AIDEVOPS_REPOS_JSON:-$HOME/.config/aidevops/repos.json}"
+	local contexts="[]"
+
+	if [[ ! -f "$repos_json" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+	contexts=$(jq -c --arg slug "$repo_slug" '
+		(first(.initialized_repos[]? | select((.slug | ascii_downcase) == ($slug | ascii_downcase)))
+		| .review_gate.advisory_check_contexts // []) as $contexts
+		| if ($contexts | type) == "array" and all($contexts[]; type == "string" and length > 0)
+			then ($contexts | unique)
+			else error("invalid review_gate.advisory_check_contexts") end
+	' "$repos_json" 2>/dev/null) || return 1
+	printf '%s\n' "$contexts"
+	return 0
+}
+
+_pmrc_review_evidence_permits_advisory() {
+	local evidence_json="$1"
+	local repo_slug="$2"
+	local pr_number="$3"
+	local head_sha="$4"
+
+	jq -e --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$head_sha" '
+		.schema == "aidevops.review-gate-evidence/v1"
+		and .repo == $repo and (.pr | tostring) == $pr and .head_sha == $head
+		and .permitted == true and .state == "pass" and .merge_gate == "clear"
+		and (
+			.status == "PASS"
+			or (.status == "SKIP" and .author.class == "trusted")
+			or (.status == "PASS_RATE_LIMITED" and .author.class == "trusted")
+			or (.status == "SKIP_TRUSTED_DEPENDABOT" and .author.class == "trusted-bot")
+		)
+	' <<<"$evidence_json" >/dev/null 2>&1
+	return $?
+}
+
+_pmrc_is_configured_advisory_failure() {
+	local check_name="$1"
+	local configured_contexts_json="$2"
+	local evidence_json="$3"
+	local repo_slug="$4"
+	local pr_number="$5"
+	local head_sha="$6"
+
+	jq -e --arg name "$check_name" 'index($name) != null' <<<"$configured_contexts_json" >/dev/null 2>&1 || return 1
+	_pmrc_review_evidence_permits_advisory "$evidence_json" "$repo_slug" "$pr_number" "$head_sha"
+	return $?
+}
+
 _pmrc_snapshot_checks_acceptable() {
 	local repo_slug="$1"
 	local pr_number="$2"
 	local checks_json="$3"
 	local required_contexts="$4"
-	local required_json="" rows="" name="" status="" conclusion="" required="" link=""
+	local evidence_json="${5:-}"
+	local head_sha="${6:-}"
+	local required_json="" configured_contexts_json="" rows="" name="" family="" status="" conclusion="" required="" members="" link=""
 	local blocking_names=""
 	local blockers=0 pending=0 advisory=0
 	_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON="[]"
 
 	required_json=$(printf '%s' "$required_contexts" | jq -Rsc '[split("\n")[] | select(length > 0)]') || return 1
-	rows=$(jq -r --argjson required "$required_json" '.[] | .name as $name | [
-		$name, .status, .conclusion, (($required | index($name)) != null), (.link // "")
+	configured_contexts_json=$(_pmrc_configured_advisory_contexts_json "$repo_slug") || return 1
+	rows=$(jq -r --argjson required "$required_json" '.[] | . as $check | ($check.members // [$check]) as $members | [
+		$check.name,
+		($check.family // $check.name),
+		$check.status,
+		$check.conclusion,
+		((($required | index($check.name)) != null) or any($members[]; .name as $member_name | ($required | index($member_name)) != null)),
+		($members | map("\(.name)@\(.source)") | join(",")),
+		($check.link // "")
 	] | @tsv' <<<"$checks_json" 2>/dev/null) || return 1
-	while IFS=$'\t' read -r name status conclusion required link; do
+	while IFS=$'\t' read -r name family status conclusion required members link; do
 		[[ -n "$name" ]] || continue
 		if [[ "$status" != "$PMRC_CHECK_COMPLETED" || -z "$conclusion" ]]; then
 			pending=$((pending + 1))
@@ -168,7 +258,10 @@ _pmrc_snapshot_checks_acceptable() {
 		case "$conclusion" in
 		success | neutral | skipped) continue ;;
 		esac
-		if [[ "$required" == "true" ]]; then
+		if [[ "$family" == "maintainer-gate" ]]; then
+			echo "[pulse-merge] pre-merge snapshot: maintainer-gate family is terminal-${conclusion} for PR #${pr_number} in ${repo_slug}; aliases=${members}, required=${required} — merge blocked" >>"$LOGFILE"
+			blockers=$((blockers + 1))
+		elif [[ "$required" == "true" ]]; then
 			echo "[pulse-merge] pre-merge snapshot: required check '${name}' is terminal-${conclusion} for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
 			blocking_names="${blocking_names}${name}"$'\n'
 			blockers=$((blockers + 1))
@@ -178,6 +271,9 @@ _pmrc_snapshot_checks_acceptable() {
 			advisory=$((advisory + 1))
 		elif _pmrc_is_explicit_advisory_failure "$name" "$checks_json"; then
 			echo "[pulse-merge] pre-merge snapshot: IGNORED non-required baseline advisory failure '${name}' because its regression companion passed for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
+			advisory=$((advisory + 1))
+		elif _pmrc_is_configured_advisory_failure "$name" "$configured_contexts_json" "$evidence_json" "$repo_slug" "$pr_number" "$head_sha"; then
+			echo "[pulse-merge] pre-merge snapshot: IGNORED configured non-required review-provider failure '${name}' with typed current-head review evidence for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
 			advisory=$((advisory + 1))
 		else
 			echo "[pulse-merge] pre-merge snapshot: unclassified non-required check '${name}' is terminal-${conclusion} for PR #${pr_number} in ${repo_slug} — merge blocked (GH#27137)" >>"$LOGFILE"
@@ -257,7 +353,6 @@ _pulse_merge_preflight_snapshot_gate() {
 	local repo_slug="$1"
 	local pr_number="$2"
 	local expected_head_sha="$3"
-	local expected_gate_evidence="${repo_slug}#${pr_number}@${expected_head_sha}"
 	local live_gate_evidence="${_PULSE_REVIEW_GATE_EVIDENCE:-}"
 	local pr_json="" current_head_sha="" required_contexts="" checks_json="" activity_json=""
 	_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON="[]"
@@ -271,10 +366,10 @@ _pulse_merge_preflight_snapshot_gate() {
 	required_contexts=$(_required_contexts_for_default_branch "$repo_slug") || return 1
 	checks_json=$(_pmrc_snapshot_checks_json "$repo_slug" "$current_head_sha") || return 1
 	activity_json=$(_pmrc_snapshot_bot_activity_json "$repo_slug" "$pr_number") || return 1
-	[[ "$live_gate_evidence" == "$expected_gate_evidence" ]] || live_gate_evidence=""
+	_pmrc_review_evidence_permits_advisory "$live_gate_evidence" "$repo_slug" "$pr_number" "$current_head_sha" || live_gate_evidence=""
 	_pmrc_snapshot_review_gate_fresh "$repo_slug" "$pr_number" "$checks_json" "$activity_json" "$live_gate_evidence" || return 1
 	_pmrc_snapshot_review_threads_clear "$repo_slug" "$pr_number" || return 1
-	_pmrc_snapshot_checks_acceptable "$repo_slug" "$pr_number" "$checks_json" "$required_contexts" || return 1
+	_pmrc_snapshot_checks_acceptable "$repo_slug" "$pr_number" "$checks_json" "$required_contexts" "$live_gate_evidence" "$current_head_sha" || return 1
 	_pmrc_snapshot_quiet_period_passes "$repo_slug" "$pr_number" "$checks_json" "$activity_json" || return 1
 	echo "[pulse-merge] pre-merge snapshot: current head ${current_head_sha:0:12}, fresh review gate, resolved bot threads, terminal checks, and quiet period verified for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
 	return 0

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -7,6 +7,10 @@
 _PULSE_MERGE_REQUIRED_CHECKS_LOADED=1
 PMRC_CHECK_COMPLETED="completed"
 PMRC_CHECK_SUCCESS="success"
+PMRC_CHECK_FAILURE="failure"
+PMRC_MAINTAINER_GATE="maintainer-gate"
+PMRC_MAINTAINER_GATE_DISPLAY="Maintainer Review & Assignee Gate"
+PMRC_MAINTAINER_GATE_WORKFLOW="gate / Maintainer Review & Assignee Gate"
 : "${_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON:=[]}"
 
 _pmrc_gh_read() {
@@ -39,9 +43,10 @@ _pmrc_snapshot_checks_json() {
 		--paginate --slurp 2>/dev/null) || return 1
 	statuses_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/status" 2>/dev/null) || return 1
 	checks_json=$(jq -n --argjson pages "$runs_pages" --argjson statuses "$statuses_json" \
-		--arg completed "$PMRC_CHECK_COMPLETED" --arg success "$PMRC_CHECK_SUCCESS" '
+		--arg completed "$PMRC_CHECK_COMPLETED" --arg success "$PMRC_CHECK_SUCCESS" --arg failure "$PMRC_CHECK_FAILURE" \
+		--arg maintainer "$PMRC_MAINTAINER_GATE" --arg maintainer_display "$PMRC_MAINTAINER_GATE_DISPLAY" --arg maintainer_workflow "$PMRC_MAINTAINER_GATE_WORKFLOW" '
 		"pending" as $pending | "in_progress" as $in_progress |
-		"failure" as $failure | "error" as $error |
+		"error" as $error |
 		[
 			$pages[]?.check_runs[]? | {
 				source: "check_run",
@@ -66,20 +71,20 @@ _pmrc_snapshot_checks_json() {
 		| group_by([.source, .name])
 		| map(last)
 		| map(. + {
-			family: (if (.name == "maintainer-gate" or .name == "Maintainer Review & Assignee Gate" or .name == "gate / Maintainer Review & Assignee Gate") then "maintainer-gate" else .name end),
-			family_key: (if (.name == "maintainer-gate" or .name == "Maintainer Review & Assignee Gate" or .name == "gate / Maintainer Review & Assignee Gate") then "maintainer-gate" else (.source + "\u0000" + .name) end)
+			family: (if (.name == $maintainer or .name == $maintainer_display or .name == $maintainer_workflow) then $maintainer else .name end),
+			family_key: (if (.name == $maintainer or .name == $maintainer_display or .name == $maintainer_workflow) then $maintainer else (.source + "\u0000" + .name) end)
 		})
 		| sort_by(.family_key, .name, .source)
 		| group_by(.family_key)
 		| map(
 			. as $members
-			| if .[0].family == "maintainer-gate" then {
-				name: "maintainer-gate",
-				family: "maintainer-gate",
+			| if .[0].family == $maintainer then {
+				name: $maintainer,
+				family: $maintainer,
 				source: "logical_family",
 				status: (if any($members[]; .status != $completed) then $in_progress else $completed end),
 				conclusion: (
-					if any($members[]; (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "startup_failure")) then $failure
+					if any($members[]; (.conclusion == $failure or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "startup_failure")) then $failure
 					elif all($members[]; (.conclusion == $success or .conclusion == "neutral" or .conclusion == "skipped")) then $success
 					else "" end
 				),
@@ -251,7 +256,7 @@ _pmrc_snapshot_checks_acceptable() {
 	] | @tsv' <<<"$checks_json" 2>/dev/null) || return 1
 	while IFS=$'\t' read -r name family status conclusion required members link; do
 		[[ -n "$name" ]] || continue
-		if [[ "$family" == "maintainer-gate" && "$conclusion" == "failure" ]]; then
+		if [[ "$family" == "$PMRC_MAINTAINER_GATE" && "$conclusion" == "$PMRC_CHECK_FAILURE" ]]; then
 			echo "[pulse-merge] pre-merge snapshot: maintainer-gate family is terminal-failure for PR #${pr_number} in ${repo_slug}; aliases=${members}, required=${required}, active_alias_present=$([[ "$status" != "$PMRC_CHECK_COMPLETED" ]] && printf true || printf false) — merge blocked" >>"$LOGFILE"
 			blockers=$((blockers + 1))
 			continue
@@ -263,7 +268,7 @@ _pmrc_snapshot_checks_acceptable() {
 		case "$conclusion" in
 		success | neutral | skipped) continue ;;
 		esac
-		if [[ "$family" == "maintainer-gate" ]]; then
+		if [[ "$family" == "$PMRC_MAINTAINER_GATE" ]]; then
 			echo "[pulse-merge] pre-merge snapshot: maintainer-gate family is terminal-${conclusion} for PR #${pr_number} in ${repo_slug}; aliases=${members}, required=${required} — merge blocked" >>"$LOGFILE"
 			blockers=$((blockers + 1))
 		elif [[ "$required" == "true" ]]; then
@@ -419,10 +424,8 @@ _check_required_pr_checks_passing_fallback() {
 
 	if [[ "$nonpassing_count" -gt 0 ]]; then
 		local stale_gate_pending_count="" _sg_exit=0
-		stale_gate_pending_count=$(printf '%s' "$checks_json" | jq '
+		stale_gate_pending_count=$(printf '%s' "$checks_json" | jq --arg stable "$PMRC_MAINTAINER_GATE" --arg legacy "$PMRC_MAINTAINER_GATE_DISPLAY" '
 			"pass" as $pass | "PENDING" as $pending |
-			"maintainer-gate" as $stable |
-			"Maintainer Review & Assignee Gate" as $legacy |
 			[.[]?
 			| (.name // "") as $name
 			| select((.bucket // "") != $pass)
@@ -447,9 +450,7 @@ _check_required_pr_checks_passing_fallback() {
 				local status_json="" pending_gate_status_count="" _ps_exit=0
 				status_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${pr_sha}/status" 2>/dev/null) || status_json=""
 				if [[ -n "$status_json" && "$status_json" != null ]]; then
-					pending_gate_status_count=$(jq '
-						"maintainer-gate" as $stable |
-						"Maintainer Review & Assignee Gate" as $legacy |
+					pending_gate_status_count=$(jq --arg stable "$PMRC_MAINTAINER_GATE" --arg legacy "$PMRC_MAINTAINER_GATE_DISPLAY" '
 						[.statuses[]?
 						| (.context // "") as $name
 						| select(($name == $stable or $name == $legacy)

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -251,6 +251,11 @@ _pmrc_snapshot_checks_acceptable() {
 	] | @tsv' <<<"$checks_json" 2>/dev/null) || return 1
 	while IFS=$'\t' read -r name family status conclusion required members link; do
 		[[ -n "$name" ]] || continue
+		if [[ "$family" == "maintainer-gate" && "$conclusion" == "failure" ]]; then
+			echo "[pulse-merge] pre-merge snapshot: maintainer-gate family is terminal-failure for PR #${pr_number} in ${repo_slug}; aliases=${members}, required=${required}, active_alias_present=$([[ "$status" != "$PMRC_CHECK_COMPLETED" ]] && printf true || printf false) — merge blocked" >>"$LOGFILE"
+			blockers=$((blockers + 1))
+			continue
+		fi
 		if [[ "$status" != "$PMRC_CHECK_COMPLETED" || -z "$conclusion" ]]; then
 			pending=$((pending + 1))
 			continue

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1457,10 +1457,16 @@ _process_single_ready_pr() {
 	# pulse poll cycle (~120s). Falls through to --admin immediate merge
 	# when CI is already green, repo opts out, or the API call fails.
 	local _native_auto_rc=0
-	_set_native_auto_merge_or_skip "$pr_number" "$repo_slug" || _native_auto_rc=$?
+	_set_native_auto_merge_or_skip "$pr_number" "$repo_slug" "${_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE:-0}" || _native_auto_rc=$?
 	case "$_native_auto_rc" in
 		0)
 			return 4
+			;;
+		2)
+			return 1
+			;;
+		3)
+			return 1
 			;;
 	esac
 	if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
@@ -1513,11 +1519,16 @@ ${_missing_check_update_output}"
 	fi
 	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then
 		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; retrying with native auto-merge without --admin (GH#24438): ${merge_output}" >>"$LOGFILE"
-		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
-			return 1
+		if [[ "${_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE:-0}" == "1" ]]; then
+			_auto_merge_output="native auto-merge skipped: mutable external approval state requires synchronous final revalidation"
+			_auto_merge_exit=1
+		else
+			if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+				return 1
+			fi
+			_auto_merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
+			_auto_merge_exit=$?
 		fi
-		_auto_merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
-		_auto_merge_exit=$?
 		if [[ $_auto_merge_exit -eq 0 ]]; then
 			echo "[pulse-wrapper] Deterministic merge: enabled native auto-merge for PR #${pr_number} in ${repo_slug} after ruleset blocked admin bypass (GH#24438)" >>"$LOGFILE"
 			return 0

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -337,7 +337,7 @@ _check_pr_merge_gates() {
 	if [[ "$_author_collab_rc" -ne 0 ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted Dependabot with allowlisted dependency update, proceeding (GH#24473)" >>"$LOGFILE"
-		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
+		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$expected_head_sha"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator but has maintainer crypto-approval, proceeding (t3063)" >>"$LOGFILE"
 		else
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE"
@@ -353,13 +353,8 @@ _check_pr_merge_gates() {
 		fi
 	fi
 
-	# Maintainer-gate: skip if linked issue has needs-maintainer-review
-	# UNLESS the issue also has the approval marker comment
-	# (<!-- aidevops-signed-approval -->), which means the auto-approve
-	# already ran and the NMR label is transient — the CI workflow
-	# re-adds it within seconds of removal, creating a race with the
-	# merge pass. The approval marker is the source of truth; NMR label
-	# is the transient symptom of the CI workflow fighting the pulse.
+	# Maintainer-gate: a live NMR label is an explicit hold. Approval marker
+	# presence is not authority and never overrides the current label state.
 	if [[ -n "$linked_issue" ]]; then
 		local _li_api
 		_li_api=$(_pm_issue_api "$repo_slug" "$linked_issue")
@@ -367,17 +362,8 @@ _check_pr_merge_gates() {
 		issue_labels=$(gh api "${_li_api}" \
 			--jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
 		if [[ "$issue_labels" == *"needs-maintainer-review"* ]]; then
-			# Check if approval marker exists — if so, NMR is transient
-			local _has_approval_marker
-			_has_approval_marker=$(gh api "${_li_api}/comments" \
-				--jq '[.[].body | select(contains("aidevops-signed-approval"))] | length' \
-				2>/dev/null) || _has_approval_marker=0
-			if [[ "$_has_approval_marker" -gt 0 ]]; then
-				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} has NMR but also approval marker — proceeding (NMR is transient)" >>"$LOGFILE"
-			else
-				echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} has needs-maintainer-review (no approval marker)" >>"$LOGFILE"
-				return 1
-			fi
+			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} has needs-maintainer-review" >>"$LOGFILE"
+			return 1
 		fi
 	fi
 
@@ -395,6 +381,10 @@ _check_pr_merge_gates() {
 			local ext_linked_for_log
 			ext_linked_for_log=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || ext_linked_for_log="unknown"
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — external-contributor PR linked issue #${ext_linked_for_log} lacks crypto approval (t1958)" >>"$LOGFILE"
+			return 1
+		fi
+		if ! _external_pr_current_head_crypto_approved "$pr_number" "$repo_slug" "$expected_head_sha"; then
+			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — external-contributor PR lacks V2 crypto approval for current head" >>"$LOGFILE"
 			return 1
 		fi
 	fi
@@ -436,25 +426,98 @@ _check_pr_merge_gates() {
 	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
 	if [[ -f "$rbg_helper" ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
-			_PULSE_REVIEW_GATE_EVIDENCE="${repo_slug}#${pr_number}@${expected_head_sha}"
+			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" --arg author "$pr_author" \
+				'{schema:"aidevops.review-gate-evidence/v1",repo:$repo,pr:$pr,head_sha:$head,status:"SKIP_TRUSTED_DEPENDABOT",author:{login:$author,association:"BOT",class:"trusted-bot"},permitted:true,reason:"trusted_dependabot_policy",state:"pass",merge_gate:"clear",exit_code:0}')
 			echo "[pulse-wrapper] Review bot gate: SKIP for trusted Dependabot dependency update PR #${pr_number} in ${repo_slug} (GH#24473)" >>"$LOGFILE"
 			return 0
 		fi
 		local rbg_result="" rbg_status=""
-		rbg_result=$(bash "$rbg_helper" check "$pr_number" "$repo_slug" 2>/dev/null) || rbg_result=""
-		rbg_status=$(printf '%s' "$rbg_result" | grep -oE '^(PASS|SKIP|WAITING|PASS_RATE_LIMITED)' | head -1)
-		case "$rbg_status" in
-		PASS | SKIP | PASS_RATE_LIMITED)
-			_PULSE_REVIEW_GATE_EVIDENCE="${repo_slug}#${pr_number}@${expected_head_sha}"
-			echo "[pulse-wrapper] Review bot gate: ${rbg_status} for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
-			;;
-		*)
-			echo "[pulse-wrapper] Review bot gate: ${rbg_status:-UNKNOWN} for PR #${pr_number} in ${repo_slug} — skipping merge" >>"$LOGFILE"
+		rbg_result=$(bash "$rbg_helper" status-json "$pr_number" "$repo_slug" 2>/dev/null) || rbg_result=""
+		rbg_status=$(jq -r '.status // "UNKNOWN"' <<<"$rbg_result" 2>/dev/null) || rbg_status="UNKNOWN"
+		# #aidevops:trust-boundary — persist only typed, permitted evidence for
+		# this exact repository, PR, and head. External SKIP/rate-limit outcomes
+		# and malformed helper output fail closed.
+		if jq -e --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" '
+			.schema == "aidevops.review-gate-evidence/v1"
+			and .repo == $repo and (.pr | tostring) == $pr and .head_sha == $head
+			and .permitted == true and .state == "pass" and .merge_gate == "clear"
+		' <<<"$rbg_result" >/dev/null 2>&1; then
+			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS . <<<"$rbg_result")
+			echo "[pulse-wrapper] Review bot gate: ${rbg_status} for PR #${pr_number} in ${repo_slug} (typed current-head evidence)" >>"$LOGFILE"
+		else
+			echo "[pulse-wrapper] Review bot gate: ${rbg_status:-UNKNOWN} for PR #${pr_number} in ${repo_slug} — missing or unpermitted current-head evidence; skipping merge" >>"$LOGFILE"
 			return 1
-			;;
-		esac
+		fi
 	fi
 
+	return 0
+}
+
+#######################################
+# Refresh typed review evidence at the final merge boundary.
+#
+# #aidevops:trust-boundary — evidence captured by the upstream gate can become
+# stale while Pulse posts reviews, updates branches, or attempts another merge
+# path. Re-run the read-only helper for the exact current head before each merge
+# call. Trusted Dependabot uses its dedicated live policy verifier instead.
+# Args: $1=PR number, $2=repo slug, $3=expected head SHA
+# Returns: 0=current evidence refreshed (or status-only fallback), 1=blocked
+#######################################
+_pulse_merge_refresh_review_gate_evidence() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+	local current_evidence="${_PULSE_REVIEW_GATE_EVIDENCE:-}"
+	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
+	local refreshed_evidence="" evidence_status="" dependabot_author=""
+
+	if jq -e --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" '
+		.schema == "aidevops.review-gate-evidence/v1"
+		and .repo == $repo and (.pr | tostring) == $pr and .head_sha == $head
+		and .status == "SKIP_TRUSTED_DEPENDABOT" and .permitted == true
+	' <<<"$current_evidence" >/dev/null 2>&1; then
+		dependabot_author=$(jq -r '.author.login // ""' <<<"$current_evidence" 2>/dev/null) || dependabot_author=""
+		if [[ -n "$dependabot_author" ]] && _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$dependabot_author"; then
+			return 0
+		fi
+		_PULSE_REVIEW_GATE_EVIDENCE=""
+		return 1
+	fi
+
+	_PULSE_REVIEW_GATE_EVIDENCE=""
+	if [[ ! -f "$rbg_helper" ]]; then
+		return 0
+	fi
+	refreshed_evidence=$(bash "$rbg_helper" status-json "$pr_number" "$repo_slug" 2>/dev/null) || refreshed_evidence=""
+	if ! _pmrc_review_evidence_permits_advisory "$refreshed_evidence" "$repo_slug" "$pr_number" "$expected_head_sha"; then
+		evidence_status=$(jq -r '.status // "UNKNOWN"' <<<"$refreshed_evidence" 2>/dev/null) || evidence_status="UNKNOWN"
+		echo "[pulse-merge] final trust gate: current-head review evidence is ${evidence_status:-UNKNOWN} or unpermitted for PR #${pr_number} in ${repo_slug} — merge blocked" >>"$LOGFILE"
+		return 1
+	fi
+	_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS . <<<"$refreshed_evidence") || {
+		_PULSE_REVIEW_GATE_EVIDENCE=""
+		return 1
+	}
+	return 0
+}
+
+#######################################
+# Revalidate all final merge authority and current-head evidence.
+#
+# #aidevops:trust-boundary — invoke this immediately before every native,
+# admin, or direct merge call. Preparatory writes and failed merge attempts can
+# race with external content/head changes; cached gate state is not authority.
+# Args: $1=PR number, $2=repo slug, $3=expected head SHA
+# Returns: 0=final snapshot authorized, 1=blocked
+#######################################
+_pulse_merge_final_trust_gate() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+
+	_pulse_merge_admin_safety_check "$pr_number" "$repo_slug" "$expected_head_sha" || return 1
+	_pulse_merge_refresh_review_gate_evidence "$pr_number" "$repo_slug" "$expected_head_sha" || return 1
+	_pulse_merge_preflight_snapshot_gate "$repo_slug" "$pr_number" "$expected_head_sha" || return 1
 	return 0
 }
 
@@ -1377,14 +1440,9 @@ _process_single_ready_pr() {
 	# or new code paths cannot re-open the threat addressed by PR #17868
 	# (the 2026-04-07 incident: #17671, #17685, #3846 merged via Check 0
 	# bypass). Returns 1 (skipped) — same semantics as a gate failure above.
-	if ! _pulse_merge_admin_safety_check "$pr_number" "$repo_slug"; then
-		return 1
-	fi
-
-	# #aidevops:trust-boundary — bind the final merge decision to the exact
-	# reviewed head and a fresh, terminal, quiet snapshot. This must run after
-	# all preparatory writes and immediately before native/admin merge paths.
-	if ! _pulse_merge_preflight_snapshot_gate "$repo_slug" "$pr_number" "$pr_head_ref_oid"; then
+	# #aidevops:trust-boundary — the combined final gate revalidates external
+	# authority, typed review evidence, and the terminal current-head snapshot.
+	if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
 		if [[ "${_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON:-[]}" != "[]" ]]; then
 			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" \
 				"$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" \
@@ -1405,6 +1463,9 @@ _process_single_ready_pr() {
 			return 4
 			;;
 	esac
+	if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+		return 1
+	fi
 
 	# Merge. Prefer the historical admin path for owned repos, but fall back to
 	# protection-respecting merge paths when repository rulesets reject admin
@@ -1419,6 +1480,9 @@ _process_single_ready_pr() {
 	_merge_exit=$?
 	if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
 		local _merge_original_output="$merge_output"
+		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+			return 1
+		fi
 		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin --match-head-commit "$pr_head_ref_oid" 2>&1)
 		_merge_exit=$?
 		if [[ $_merge_exit -ne 0 ]]; then
@@ -1449,6 +1513,9 @@ ${_missing_check_update_output}"
 	fi
 	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then
 		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; retrying with native auto-merge without --admin (GH#24438): ${merge_output}" >>"$LOGFILE"
+		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+			return 1
+		fi
 		_auto_merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
 		_auto_merge_exit=$?
 		if [[ $_auto_merge_exit -eq 0 ]]; then
@@ -1460,10 +1527,16 @@ ${_missing_check_update_output}"
 [native auto-merge fallback]
 ${_auto_merge_output}"
 		echo "[pulse-wrapper] Deterministic merge: native auto-merge fallback failed for PR #${pr_number} in ${repo_slug}; retrying direct merge without --admin (GH#23087): ${_auto_merge_output}" >>"$LOGFILE"
+		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+			return 1
+		fi
 		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
 		_merge_exit=$?
 		if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse direct merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
 			local _direct_merge_original_output="$merge_output"
+			if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+				return 1
+			fi
 			merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
 			_merge_exit=$?
 			if [[ $_merge_exit -ne 0 ]]; then

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -69,6 +69,8 @@
 # Include guard — prevent double-sourcing.
 [[ -n "${_PULSE_MERGE_LOADED:-}" ]] && return 0
 _PULSE_MERGE_LOADED=1
+PULSE_REVIEW_EVIDENCE_SCHEMA="aidevops.review-gate-evidence/v1"
+PULSE_UNKNOWN_STATE="UNKNOWN"
 
 # t2863: Module-level variable defaults (set -u guards).
 # When this module is sourced standalone (e.g. pulse-merge-routine.sh, test
@@ -426,26 +428,26 @@ _check_pr_merge_gates() {
 	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
 	if [[ -f "$rbg_helper" ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
-			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" --arg author "$pr_author" \
-				'{schema:"aidevops.review-gate-evidence/v1",repo:$repo,pr:$pr,head_sha:$head,status:"SKIP_TRUSTED_DEPENDABOT",author:{login:$author,association:"BOT",class:"trusted-bot"},permitted:true,reason:"trusted_dependabot_policy",state:"pass",merge_gate:"clear",exit_code:0}')
+			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" --arg author "$pr_author" \
+				'{schema:$schema,repo:$repo,pr:$pr,head_sha:$head,status:"SKIP_TRUSTED_DEPENDABOT",author:{login:$author,association:"BOT",class:"trusted-bot"},permitted:true,reason:"trusted_dependabot_policy",state:"pass",merge_gate:"clear",exit_code:0}')
 			echo "[pulse-wrapper] Review bot gate: SKIP for trusted Dependabot dependency update PR #${pr_number} in ${repo_slug} (GH#24473)" >>"$LOGFILE"
 			return 0
 		fi
 		local rbg_result="" rbg_status=""
 		rbg_result=$(bash "$rbg_helper" status-json "$pr_number" "$repo_slug" 2>/dev/null) || rbg_result=""
-		rbg_status=$(jq -r '.status // "UNKNOWN"' <<<"$rbg_result" 2>/dev/null) || rbg_status="UNKNOWN"
+		rbg_status=$(jq -r --arg unknown "$PULSE_UNKNOWN_STATE" '.status // $unknown' <<<"$rbg_result" 2>/dev/null) || rbg_status="$PULSE_UNKNOWN_STATE"
 		# #aidevops:trust-boundary — persist only typed, permitted evidence for
 		# this exact repository, PR, and head. External SKIP/rate-limit outcomes
 		# and malformed helper output fail closed.
-		if jq -e --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" '
-			.schema == "aidevops.review-gate-evidence/v1"
+		if jq -e --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" '
+			.schema == $schema
 			and .repo == $repo and (.pr | tostring) == $pr and .head_sha == $head
 			and .permitted == true and .state == "pass" and .merge_gate == "clear"
 		' <<<"$rbg_result" >/dev/null 2>&1; then
 			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS . <<<"$rbg_result")
 			echo "[pulse-wrapper] Review bot gate: ${rbg_status} for PR #${pr_number} in ${repo_slug} (typed current-head evidence)" >>"$LOGFILE"
 		else
-			echo "[pulse-wrapper] Review bot gate: ${rbg_status:-UNKNOWN} for PR #${pr_number} in ${repo_slug} — missing or unpermitted current-head evidence; skipping merge" >>"$LOGFILE"
+			echo "[pulse-wrapper] Review bot gate: ${rbg_status:-${PULSE_UNKNOWN_STATE}} for PR #${pr_number} in ${repo_slug} — missing or unpermitted current-head evidence; skipping merge" >>"$LOGFILE"
 			return 1
 		fi
 	fi
@@ -471,8 +473,8 @@ _pulse_merge_refresh_review_gate_evidence() {
 	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
 	local refreshed_evidence="" evidence_status="" dependabot_author=""
 
-	if jq -e --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" '
-		.schema == "aidevops.review-gate-evidence/v1"
+	if jq -e --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" '
+		.schema == $schema
 		and .repo == $repo and (.pr | tostring) == $pr and .head_sha == $head
 		and .status == "SKIP_TRUSTED_DEPENDABOT" and .permitted == true
 	' <<<"$current_evidence" >/dev/null 2>&1; then
@@ -490,8 +492,8 @@ _pulse_merge_refresh_review_gate_evidence() {
 	fi
 	refreshed_evidence=$(bash "$rbg_helper" status-json "$pr_number" "$repo_slug" 2>/dev/null) || refreshed_evidence=""
 	if ! _pmrc_review_evidence_permits_advisory "$refreshed_evidence" "$repo_slug" "$pr_number" "$expected_head_sha"; then
-		evidence_status=$(jq -r '.status // "UNKNOWN"' <<<"$refreshed_evidence" 2>/dev/null) || evidence_status="UNKNOWN"
-		echo "[pulse-merge] final trust gate: current-head review evidence is ${evidence_status:-UNKNOWN} or unpermitted for PR #${pr_number} in ${repo_slug} — merge blocked" >>"$LOGFILE"
+		evidence_status=$(jq -r --arg unknown "$PULSE_UNKNOWN_STATE" '.status // $unknown' <<<"$refreshed_evidence" 2>/dev/null) || evidence_status="$PULSE_UNKNOWN_STATE"
+		echo "[pulse-merge] final trust gate: current-head review evidence is ${evidence_status:-${PULSE_UNKNOWN_STATE}} or unpermitted for PR #${pr_number} in ${repo_slug} — merge blocked" >>"$LOGFILE"
 		return 1
 	fi
 	_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS . <<<"$refreshed_evidence") || {
@@ -1179,8 +1181,8 @@ _process_single_ready_pr() {
 	# check and blocking ALL merges across every repo (observed downstream).
 	local _RS=$'\x1e'
 	IFS="$_RS" read -r pr_number pr_mergeable pr_review pr_author pr_title pr_updated_at pr_head_ref_oid pr_head_ref_name pr_base_ref_name pr_labels pr_is_draft < <(
-		printf '%s' "$pr_obj" | jq -r \
-			'"\(.number // "")\u001e\(.mergeable // "UNKNOWN")\u001e\(if ((has("reviewDecision") | not) or .reviewDecision == null or (.reviewDecision | tostring | length) == 0) then "UNKNOWN" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")\u001e\(.headRefName // "")\u001e\(.baseRefName // "")\u001e\([(.labels // [])[].name] | join(","))\u001e\(.isDraft // false | tostring)"'
+		printf '%s' "$pr_obj" | jq -r --arg unknown "$PULSE_UNKNOWN_STATE" \
+			'"\(.number // "")\u001e\(.mergeable // $unknown)\u001e\(if ((has("reviewDecision") | not) or .reviewDecision == null or (.reviewDecision | tostring | length) == 0) then $unknown else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")\u001e\(.headRefName // "")\u001e\(.baseRefName // "")\u001e\([(.labels // [])[].name] | join(","))\u001e\(.isDraft // false | tostring)"'
 	)
 	_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
 	_pmp_normalize_review_decision_into pr_review "$pr_review"
@@ -1248,7 +1250,7 @@ _process_single_ready_pr() {
 			# has a UNKNOWN-retry loop so we reuse it.
 			local _refetched_mergeable
 			_refetched_mergeable=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-				--json mergeable --jq '.mergeable // "UNKNOWN"' 2>/dev/null) || _refetched_mergeable="UNKNOWN"
+				--json mergeable --jq ".mergeable // \"${PULSE_UNKNOWN_STATE}\"" 2>/dev/null) || _refetched_mergeable="$PULSE_UNKNOWN_STATE"
 			pr_mergeable="$_refetched_mergeable"
 			_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — update-branch succeeded, refetched mergeable=${pr_mergeable} (t2116)" >>"$LOGFILE"

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -72,6 +72,7 @@ KNOWN_BOTS=(
 	"copilot"
 )
 REVIEW_GATE_STATUS_PASS="$(printf 'P%s' 'ASS')"
+RBG_FALSE="false"
 
 # Rate-limit / quota notice patterns — entries that indicate the bot tried to
 # review but was capacity-constrained. Used by grace-period logic
@@ -595,7 +596,7 @@ bot_has_real_review() {
 	local success_status_contexts="${4-}"
 	local success_status_contexts_prepared="${5:-false}"
 	local expected_head_sha="${REVIEW_GATE_EXPECTED_HEAD_SHA:-}"
-	local has_success_status_contexts="false"
+	local has_success_status_contexts="$RBG_FALSE"
 	[[ $# -ge 4 ]] && has_success_status_contexts="true"
 
 	local min_lag
@@ -770,7 +771,7 @@ bot_has_success_status() {
 
 	if [[ $# -lt 4 ]]; then
 		status_contexts=$(_get_success_status_contexts "$pr_number" "$repo") || return 1
-		contexts_are_prepared="false"
+		contexts_are_prepared="$RBG_FALSE"
 	fi
 	[[ -z "$status_contexts" ]] && return 1
 	_status_contexts_match_bot "$bot_login" "$status_contexts" "$contexts_are_prepared" && return 0
@@ -785,7 +786,7 @@ any_bot_has_success_status() {
 
 	if [[ $# -lt 3 ]]; then
 		status_contexts=$(_get_success_status_contexts "$pr_number" "$repo") || return 1
-		contexts_are_prepared="false"
+		contexts_are_prepared="$RBG_FALSE"
 	fi
 	[[ -z "$status_contexts" ]] && return 1
 
@@ -1017,14 +1018,16 @@ do_status_json() {
 	local merge_gate="${blocked_prefix}ked"
 	local status_pass
 	local pr_json_before="" pr_json="" head_sha_before="" head_sha="" author_login="" author_association="" author_class="external"
-	local head_stable="false"
-	local permitted="false" reason="outcome_not_permitted"
+	local head_stable="$RBG_FALSE"
+	local permitted="$RBG_FALSE" reason="outcome_not_permitted"
 	status_pass=$(printf 'P%s' 'ASS')
 
-	pr_json_before=$(gh api "repos/${repo}/pulls/${pr_number}" 2>/dev/null) || pr_json_before=""
+	local pr_api=""
+	pr_api=$(printf 'repos/%s/pulls/%s' "$repo" "$pr_number")
+	pr_json_before=$(gh api "$pr_api" 2>/dev/null) || pr_json_before=""
 	head_sha_before=$(jq -r '.head.sha // ""' <<<"$pr_json_before" 2>/dev/null) || head_sha_before=""
 	output=$(REVIEW_GATE_EXPECTED_HEAD_SHA="$head_sha_before" do_check "$pr_number" "$repo" 2>/dev/null) || rc=$?
-	pr_json=$(gh api "repos/${repo}/pulls/${pr_number}" 2>/dev/null) || pr_json=""
+	pr_json=$(gh api "$pr_api" 2>/dev/null) || pr_json=""
 	if [[ -n "$pr_json" ]]; then
 		head_sha=$(jq -r '.head.sha // ""' <<<"$pr_json" 2>/dev/null) || head_sha=""
 		author_login=$(jq -r '.user.login // ""' <<<"$pr_json" 2>/dev/null) || author_login=""

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -1009,15 +1009,58 @@ do_status_json() {
 	local blocked_prefix="bloc"
 	local merge_gate="${blocked_prefix}ked"
 	local status_pass
+	local pr_json_before="" pr_json="" head_sha_before="" head_sha="" author_login="" author_association="" author_class="external"
+	local head_stable="false"
+	local permitted="false" reason="outcome_not_permitted"
 	status_pass=$(printf 'P%s' 'ASS')
 
+	pr_json_before=$(gh api "repos/${repo}/pulls/${pr_number}" 2>/dev/null) || pr_json_before=""
+	head_sha_before=$(jq -r '.head.sha // ""' <<<"$pr_json_before" 2>/dev/null) || head_sha_before=""
 	output=$(do_check "$pr_number" "$repo" 2>/dev/null) || rc=$?
+	pr_json=$(gh api "repos/${repo}/pulls/${pr_number}" 2>/dev/null) || pr_json=""
+	if [[ -n "$pr_json" ]]; then
+		head_sha=$(jq -r '.head.sha // ""' <<<"$pr_json" 2>/dev/null) || head_sha=""
+		author_login=$(jq -r '.user.login // ""' <<<"$pr_json" 2>/dev/null) || author_login=""
+		author_association=$(jq -r '.author_association // ""' <<<"$pr_json" 2>/dev/null) || author_association=""
+	fi
+	if [[ -n "$head_sha_before" && "$head_sha_before" == "$head_sha" ]]; then
+		head_stable="true"
+	fi
+	case "$author_association" in
+	OWNER | MEMBER | COLLABORATOR) author_class="trusted" ;;
+	esac
+
+	# #aidevops:trust-boundary — SKIP and rate-limit grace are trusted-author
+	# policy outcomes. External contributors require a real PASS; malformed or
+	# metadata-less evidence can never authorize an advisory merge decision.
 	case "$output" in
-	"$status_pass" | P[A]SS_RATE_LIMITED | SKIP)
+	"$status_pass")
+		[[ "$head_stable" == "true" && -n "$author_login" ]] && permitted="true" reason="live_review_pass"
+		;;
+	SKIP)
+		if [[ "$author_class" == "trusted" && "$head_stable" == "true" ]]; then
+			permitted="true"
+			reason="trusted_skip"
+		else
+			reason="external_skip_denied"
+		fi
+		;;
+	P[A]SS_RATE_LIMITED)
+		if [[ "$author_class" == "trusted" && "$head_stable" == "true" ]]; then
+			permitted="true"
+			reason="trusted_rate_limit_grace"
+		else
+			reason="external_rate_limit_grace_denied"
+		fi
+		;;
+	esac
+
+	case "$output:$permitted" in
+	"$status_pass:true" | P[A]SS_RATE_LIMITED:true | SKIP:true)
 		state="pass"
 		merge_gate="clear"
 		;;
-	WAITING)
+	WAITING:*)
 		state="waiting"
 		merge_gate="${blocked_prefix}ked"
 		;;
@@ -1032,10 +1075,16 @@ do_status_json() {
 		--arg pr "$pr_number" \
 		--arg repo "$repo" \
 		--arg status "${output:-ERROR}" \
+		--arg head_sha "$head_sha" \
+		--arg author_login "$author_login" \
+		--arg author_association "$author_association" \
+		--arg author_class "$author_class" \
+		--argjson permitted "$permitted" \
+		--arg reason "$reason" \
 		--arg state "$state" \
 		--arg merge_gate "$merge_gate" \
 		--argjson exit_code "$rc" \
-		'{pr:$pr,repo:$repo,status:$status,state:$state,merge_gate:$merge_gate,exit_code:$exit_code}'
+		'{schema:"aidevops.review-gate-evidence/v1",pr:$pr,repo:$repo,head_sha:$head_sha,status:$status,author:{login:$author_login,association:$author_association,class:$author_class},permitted:$permitted,reason:$reason,state:$state,merge_gate:$merge_gate,exit_code:$exit_code}'
 	return 0
 }
 
@@ -1319,6 +1368,10 @@ do_batch_retry() {
 			echo "  PR #${pr_num}: ${result:-error} (skipped)" >&2
 			;;
 		esac
+	if [[ "$head_stable" != "true" ]]; then
+		permitted="false"
+		reason="head_changed_or_metadata_unavailable"
+	fi
 	done <<<"$pr_numbers"
 
 	echo "REQUESTED_${requested}"

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -594,6 +594,7 @@ bot_has_real_review() {
 	local bot_login="$3"
 	local success_status_contexts="${4-}"
 	local success_status_contexts_prepared="${5:-false}"
+	local expected_head_sha="${REVIEW_GATE_EXPECTED_HEAD_SHA:-}"
 	local has_success_status_contexts="false"
 	[[ $# -ge 4 ]] && has_success_status_contexts="true"
 
@@ -605,7 +606,13 @@ bot_has_real_review() {
 	# and emits a TSV record of created_at \t updated_at \t base64(body).
 	# Reviews lack updated_at on some endpoints; default to created_at via //.
 	local jq_filter
-	jq_filter=".[] | select(.user.login | ascii_downcase | test(\"${bot_login}\")) | [(.created_at // .submitted_at // \"\"), (.updated_at // .submitted_at // .created_at // \"\"), (.body // \"\" | @base64)] | @tsv"
+	jq_filter=".[] | select(.user.login | ascii_downcase | test(\"${bot_login}\"))"
+	if [[ -n "$expected_head_sha" ]]; then
+		# Typed merge evidence must identify the reviewed commit. Conversation
+		# comments have no commit_id and therefore cannot prove current-head review.
+		jq_filter="${jq_filter} | select((.commit_id // .original_commit_id // \"\") == \"${expected_head_sha}\")"
+	fi
+	jq_filter="${jq_filter} | [(.created_at // .submitted_at // \"\"), (.updated_at // .submitted_at // .created_at // \"\"), (.body // \"\" | @base64)] | @tsv"
 
 	local api_endpoints=(
 		"repos/${repo}/pulls/${pr_number}/reviews"
@@ -1016,7 +1023,7 @@ do_status_json() {
 
 	pr_json_before=$(gh api "repos/${repo}/pulls/${pr_number}" 2>/dev/null) || pr_json_before=""
 	head_sha_before=$(jq -r '.head.sha // ""' <<<"$pr_json_before" 2>/dev/null) || head_sha_before=""
-	output=$(do_check "$pr_number" "$repo" 2>/dev/null) || rc=$?
+	output=$(REVIEW_GATE_EXPECTED_HEAD_SHA="$head_sha_before" do_check "$pr_number" "$repo" 2>/dev/null) || rc=$?
 	pr_json=$(gh api "repos/${repo}/pulls/${pr_number}" 2>/dev/null) || pr_json=""
 	if [[ -n "$pr_json" ]]; then
 		head_sha=$(jq -r '.head.sha // ""' <<<"$pr_json" 2>/dev/null) || head_sha=""
@@ -1368,10 +1375,6 @@ do_batch_retry() {
 			echo "  PR #${pr_num}: ${result:-error} (skipped)" >&2
 			;;
 		esac
-	if [[ "$head_stable" != "true" ]]; then
-		permitted="false"
-		reason="head_changed_or_metadata_unavailable"
-	fi
 	done <<<"$pr_numbers"
 
 	echo "REQUESTED_${requested}"

--- a/.agents/scripts/review-gate-config-helper.sh
+++ b/.agents/scripts/review-gate-config-helper.sh
@@ -13,6 +13,7 @@
 #   aidevops review-gate <slug> --tool <bot> pass|wait|unset  Per-tool override
 #   aidevops review-gate <slug> --completion fast|strict|unset  Completion policy
 #   aidevops review-gate <slug> --tool <bot> --completion fast|strict|unset
+#   aidevops review-gate <slug> --advisory-context <check> add|remove
 #   aidevops review-gate --help                       Show this help
 #
 # Schema written to ~/.config/aidevops/repos.json under the matching
@@ -42,6 +43,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 readonly RATE_LIMIT_BEHAVIOR_FIELD="rate_limit_behavior"
 readonly COMPLETION_BEHAVIOR_FIELD="completion_behavior"
+readonly ADVISORY_CONTEXTS_FIELD="advisory_check_contexts"
 
 # Known bot logins for --tool validation. New bots warn but are not rejected
 # (forward-compat: new bots should work without a helper update).
@@ -112,6 +114,15 @@ _validate_completion_behavior() {
 		return 1
 		;;
 	esac
+}
+
+_validate_advisory_context() {
+	local value="$1"
+	if [[ -z "$value" || ${#value} -gt 200 || "$value" == *$'\n'* || "$value" == *$'\r'* || "$value" == *$'\t'* ]]; then
+		_print_error "Invalid advisory check context. Use one non-empty check name of at most 200 characters."
+		return 1
+	fi
+	return 0
 }
 
 # Warn if a bot login is not in the known list (but don't reject it —
@@ -277,7 +288,7 @@ cmd_list() {
 	while IFS= read -r slug; do
 		[[ -z "$slug" ]] && continue
 
-		local rate_limit_val completion_val repo_values
+		local rate_limit_val completion_val advisory_contexts repo_values
 		repo_values=$(jq -r --arg slug "$slug" --arg rate_field "$RATE_LIMIT_BEHAVIOR_FIELD" --arg completion_field "$COMPLETION_BEHAVIOR_FIELD" \
 			'first(.initialized_repos[]? | select(.slug == $slug)) // {} | [(.review_gate[$rate_field] // ""), (.review_gate[$completion_field] // "")] | @tsv' \
 			"$REPOS_JSON" 2>/dev/null) || repo_values=$'\t'
@@ -302,6 +313,10 @@ cmd_list() {
 		else
 			printf "    completion per-repo: %-6s  effective: %s\n" "(unset)" "$completion_effective"
 		fi
+		advisory_contexts=$(jq -r --arg slug "$slug" --arg field "$ADVISORY_CONTEXTS_FIELD" \
+			'first(.initialized_repos[]? | select(.slug == $slug)) | .review_gate[$field] // [] | join(", ")' \
+			"$REPOS_JSON" 2>/dev/null) || advisory_contexts=""
+		printf "    advisory check contexts: %s\n" "${advisory_contexts:-(none; unknown failures block)}"
 
 		# List per-tool overrides if present
 		local tools_json
@@ -328,6 +343,48 @@ cmd_list() {
 		echo ""
 	done <<<"$slugs"
 
+	return 0
+}
+
+cmd_advisory_context() {
+	local slug="$1"
+	local context_name="$2"
+	local action="$3"
+
+	_require_jq || return 1
+	_require_repos_json || return 1
+	_validate_advisory_context "$context_name" || return 1
+	case "$action" in
+	add | remove) ;;
+	*)
+		_print_error "Invalid advisory-context action '${action}'. Must be: add or remove"
+		return 1
+		;;
+	esac
+
+	local resolved_slug=""
+	resolved_slug=$(_resolve_slug "$slug")
+	if [[ -z "$resolved_slug" ]]; then
+		_print_error "No registered repo found matching '${slug}'"
+		return 1
+	fi
+
+	local current_json="" new_json=""
+	current_json=$(<"$REPOS_JSON")
+	if [[ "$action" == "add" ]]; then
+		new_json=$(printf '%s' "$current_json" | jq --arg slug "$resolved_slug" --arg field "$ADVISORY_CONTEXTS_FIELD" --arg context "$context_name" '
+			(.initialized_repos[] | select(.slug == $slug) | .review_gate[$field]) |= ((. // []) + [$context] | unique)
+		' 2>/dev/null) || { _jq_mutation_failed; return 1; }
+	else
+		new_json=$(printf '%s' "$current_json" | jq --arg slug "$resolved_slug" --arg field "$ADVISORY_CONTEXTS_FIELD" --arg context "$context_name" '
+			(.initialized_repos[] | select(.slug == $slug) | .review_gate[$field]) |= ((. // []) | map(select(. != $context)))
+			| (.initialized_repos[] | select(.slug == $slug) | .review_gate) |= if (.[$field] // []) == [] then del(.[$field]) else . end
+		' 2>/dev/null) || { _jq_mutation_failed; return 1; }
+	fi
+
+	_safe_write_repos_json "$new_json" || return 1
+	_print_ok "${action} advisory check context '${context_name}' for ${resolved_slug}"
+	_print_info "Configured advisory contexts are exact names; required, maintainer-gate, unknown, and evidence-less failures still block."
 	return 0
 }
 
@@ -450,6 +507,7 @@ cmd_help() {
 	echo "  <slug> --tool <bot> pass|wait|unset    Set per-tool override"
 	echo "  <slug> --completion fast|strict|unset  Set completion default"
 	echo "  <slug> --tool <bot> --completion fast|strict|unset"
+	echo "  <slug> --advisory-context <check> add|remove"
 	echo "  help                                   Show this help"
 	echo ""
 	echo "Arguments:"
@@ -467,6 +525,7 @@ cmd_help() {
 	echo "  aidevops review-gate marcusquinn/myrepo --tool coderabbitai unset"
 	echo "  aidevops review-gate marcusquinn/myrepo --completion strict"
 	echo "  aidevops review-gate marcusquinn/myrepo --tool coderabbitai --completion strict"
+	echo "  aidevops review-gate marcusquinn/myrepo --advisory-context 'CodeRabbit' add"
 	echo ""
 	echo "Resolution order (per-tool wins):"
 	echo "  rate-limit: per-tool > per-repo > REVIEW_GATE_RATE_LIMIT_BEHAVIOR env > pass"
@@ -519,6 +578,18 @@ main() {
 				return 1
 			fi
 			cmd_set "$slug" "" "$value" "$COMPLETION_BEHAVIOR_FIELD"
+			return $?
+		fi
+
+		# slug --advisory-context <exact-check-name> add|remove
+		if [[ "$subcommand" == "--advisory-context" ]]; then
+			local context_name="${2:-}"
+			local context_action="${3:-}"
+			if [[ -z "$context_name" || -z "$context_action" ]]; then
+				_print_error "Usage: aidevops review-gate <slug> --advisory-context <exact-check-name> add|remove"
+				return 1
+			fi
+			cmd_advisory_context "$slug" "$context_name" "$context_action"
 			return $?
 		fi
 

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for immutable V2 approval snapshots (GH#27560).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+APPROVAL_HELPER="${SCRIPT_DIR}/../approval-helper.sh"
+# shellcheck source=../approval-snapshot-v2.sh
+source "${SCRIPT_DIR}/../approval-snapshot-v2.sh"
+
+TEST_ROOT="$(mktemp -d -t approval-content-binding.XXXXXX)"
+FIXTURES="${TEST_ROOT}/fixtures"
+TEST_HOME="${TEST_ROOT}/home"
+TESTS_RUN=0
+TESTS_FAILED=0
+PR_HEAD="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+print_result() {
+	local description="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$description"
+		return 0
+	fi
+	printf 'FAIL %s%s\n' "$description" "${detail:+ — $detail}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+install_gh_stub() {
+	mkdir -p "${TEST_ROOT}/bin" "$FIXTURES" "$TEST_HOME"
+	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "api" ]] || exit 1
+endpoint="${2:-}"
+if [[ -n "${GH_FAIL_ENDPOINT:-}" && "$endpoint" == *"${GH_FAIL_ENDPOINT}"* ]]; then
+	exit 1
+fi
+case "$endpoint" in
+repos/owner/repo/issues/41) cat "${FIXTURES}/issue-41.json" ;;
+repos/owner/repo/issues/41/comments*) cat "${FIXTURES}/comments-41.json" ;;
+repos/owner/repo/issues/41/timeline*) cat "${FIXTURES}/timeline-41.json" ;;
+repos/owner/repo/issues/42) cat "${FIXTURES}/issue-42.json" ;;
+repos/owner/repo/issues/42/comments*) cat "${FIXTURES}/comments-42.json" ;;
+repos/owner/repo/issues/42/timeline*) cat "${FIXTURES}/timeline-42.json" ;;
+repos/owner/repo/pulls/42) cat "${FIXTURES}/pr-42.json" ;;
+repos/owner/repo/pulls/42/comments*) cat "${FIXTURES}/review-comments-42.json" ;;
+repos/owner/repo/pulls/42/reviews*) cat "${FIXTURES}/reviews-42.json" ;;
+*) printf 'Unhandled endpoint: %s\n' "$endpoint" >&2; exit 1 ;;
+esac
+exit 0
+EOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+write_baseline_fixtures() {
+	cat >"${FIXTURES}/issue-41.json" <<'EOF'
+{"id":4100,"node_id":"I_41","number":41,"user":{"id":101,"node_id":"U_101","login":"external-author","type":"User"},"author_association":"CONTRIBUTOR","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","title":"Reviewed issue","body":"Issue body with https://example.invalid/opaque"}
+EOF
+	cat >"${FIXTURES}/issue-42.json" <<'EOF'
+{"id":4200,"node_id":"I_42","number":42,"user":{"id":102,"node_id":"U_102","login":"external-author","type":"User"},"author_association":"CONTRIBUTOR","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","title":"Reviewed PR","body":"PR body with opaque external link","pull_request":{"url":"opaque"}}
+EOF
+	cat >"${FIXTURES}/pr-42.json" <<EOF
+{"id":4201,"node_id":"PR_42","number":42,"user":{"id":102,"node_id":"U_102","login":"external-author","type":"User"},"author_association":"CONTRIBUTOR","created_at":"2026-01-01T00:00:00Z","title":"Reviewed PR","body":"PR body with opaque external link","head":{"sha":"${PR_HEAD}","ref":"feature/external","repo":{"id":5001,"full_name":"external/fork"}},"base":{"ref":"main","repo":{"id":5000,"full_name":"owner/repo"}}}
+EOF
+	cat >"${FIXTURES}/comments-41.json" <<'EOF'
+[[{"id":411,"node_id":"IC_411","user":{"id":103,"node_id":"U_103","login":"reviewer","type":"User"},"author_association":"MEMBER","created_at":"2026-01-01T00:01:00Z","updated_at":"2026-01-01T00:01:00Z","body":"Reviewed issue comment"}]]
+EOF
+	cat >"${FIXTURES}/comments-42.json" <<'EOF'
+[[{"id":421,"node_id":"IC_421","user":{"id":103,"node_id":"U_103","login":"reviewer","type":"User"},"author_association":"MEMBER","created_at":"2026-01-01T00:01:00Z","updated_at":"2026-01-01T00:01:00Z","body":"Reviewed PR comment"}]]
+EOF
+	cat >"${FIXTURES}/timeline-41.json" <<'EOF'
+[[{"id":419,"node_id":"EV_419","event":"cross-referenced","created_at":"2026-01-01T00:02:00Z","actor":{"id":103,"node_id":"U_103","login":"reviewer","type":"User"},"source":{"issue":{"id":9001,"node_id":"I_9001","number":9,"title":"Linked scope","body":"Linked body","state":"open","updated_at":"2026-01-01T00:02:00Z","repository":{"full_name":"owner/repo"},"user":{"id":104,"node_id":"U_104","login":"link-author","type":"User"}}}}]]
+EOF
+	cp "${FIXTURES}/timeline-41.json" "${FIXTURES}/timeline-42.json"
+	cat >"${FIXTURES}/review-comments-42.json" <<'EOF'
+[[{"id":422,"node_id":"RC_422","user":{"id":103,"node_id":"U_103","login":"reviewer","type":"User"},"author_association":"MEMBER","created_at":"2026-01-01T00:03:00Z","updated_at":"2026-01-01T00:03:00Z","body":"Inline review","path":"file.sh","line":7,"side":"RIGHT","commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","original_commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]]
+EOF
+	cat >"${FIXTURES}/reviews-42.json" <<'EOF'
+[[{"id":423,"node_id":"RV_423","user":{"id":103,"node_id":"U_103","login":"reviewer","type":"User"},"author_association":"MEMBER","state":"APPROVED","commit_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","submitted_at":"2026-01-01T00:04:00Z","body":"Reviewed"}]]
+EOF
+	return 0
+}
+
+sign_payload() {
+	local payload="$1"
+	local signature_file="$2"
+	printf '%s' "$payload" | ssh-keygen -Y sign -f "${TEST_ROOT}/approval.key" -n aidevops-approve -q - >"$signature_file" 2>/dev/null
+	return $?
+}
+
+append_signed_comment() {
+	local kind="$1"
+	local number="$2"
+	local issued_at="$3"
+	local comment_id="${4:-$((number * 100 + 99))}"
+	local comments_file="${FIXTURES}/comments-${number}.json"
+	local payload="" signature_file="" signature="" body="" updated=""
+	payload=$(PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload "$kind" "$number" owner/repo "$issued_at") || return 1
+	signature_file="${TEST_ROOT}/signature-${number}.txt"
+	sign_payload "$payload" "$signature_file" || return 1
+	signature=$(<"$signature_file")
+	body="<!-- aidevops-signed-approval -->
+\`\`\`
+${payload}
+\`\`\`
+\`\`\`
+${signature}
+\`\`\`"
+	updated=$(jq -c --arg body "$body" --argjson id "$comment_id" '
+		.[0] += [{id:$id,node_id:("APPROVAL_" + ($id|tostring)),user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:05:00Z",updated_at:"2026-01-01T00:05:00Z",body:$body}]
+	' "$comments_file") || return 1
+	printf '%s\n' "$updated" >"$comments_file"
+	printf '%s\n' "$payload" >"${TEST_ROOT}/payload-${number}.json"
+	return 0
+}
+
+replace_with_legacy_comment() {
+	local number="$1"
+	local payload="APPROVE:issue:owner/repo:${number}:2026-01-01T00:05:00Z"
+	local signature_file="${TEST_ROOT}/legacy-signature.txt" signature="" body=""
+	sign_payload "$payload" "$signature_file" || return 1
+	signature=$(<"$signature_file")
+	body="<!-- aidevops-signed-approval -->
+\`\`\`
+${payload}
+\`\`\`
+\`\`\`
+${signature}
+\`\`\`"
+	jq -nc --arg body "$body" '[[{id:4199,user:{type:"User"},body:$body}]]' >"${FIXTURES}/comments-${number}.json"
+	return 0
+}
+
+run_verify() {
+	local kind="$1"
+	local number="$2"
+	local expected_head="${3:-}"
+	if [[ -n "$expected_head" ]]; then
+		HOME="$TEST_HOME" PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" \
+			AIDEVOPS_APPROVAL_PUB="${TEST_ROOT}/approval.pub" \
+			"$APPROVAL_HELPER" verify "$kind" "$number" owner/repo --expect-head "$expected_head" 2>/dev/null
+		return $?
+	fi
+	HOME="$TEST_HOME" PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" \
+		AIDEVOPS_APPROVAL_PUB="${TEST_ROOT}/approval.pub" \
+		"$APPROVAL_HELPER" verify "$kind" "$number" owner/repo 2>/dev/null
+	return $?
+}
+
+assert_verify() {
+	local description="$1"
+	local kind="$2"
+	local number="$3"
+	local expected_output="$4"
+	local expected_rc="$5"
+	local expected_head="${6:-}"
+	local output="" rc=0
+	output=$(run_verify "$kind" "$number" "$expected_head") || rc=$?
+	if [[ "$output" == "$expected_output" && "$rc" -eq "$expected_rc" ]]; then
+		print_result "$description" 0
+		return 0
+	fi
+	print_result "$description" 1 "expected=${expected_output}/${expected_rc}, actual=${output}/${rc}"
+	return 0
+}
+
+reset_and_sign() {
+	local kind="$1"
+	local number="$2"
+	write_baseline_fixtures
+	append_signed_comment "$kind" "$number" "2026-01-01T00:05:00Z"
+	return $?
+}
+
+main() {
+	install_gh_stub
+	write_baseline_fixtures
+	ssh-keygen -t ed25519 -N '' -f "${TEST_ROOT}/approval.key" -q
+	cp "${TEST_ROOT}/approval.key.pub" "${TEST_ROOT}/approval.pub"
+
+	reset_and_sign issue 41
+	assert_verify "unchanged issue V2 snapshot verifies" issue 41 VERIFIED 0
+	jq '.body = "changed issue body"' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp"
+	mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
+	assert_verify "issue body drift is stale" issue 41 STALE_APPROVAL 4
+
+	reset_and_sign pr 42
+	assert_verify "unchanged PR V2 snapshot verifies exact head" pr 42 VERIFIED 0 "$PR_HEAD"
+	local original_digest="" repeated_payload="" repeated_digest=""
+	original_digest=$(jq -r '.snapshot_sha256' "${TEST_ROOT}/payload-42.json")
+	repeated_payload=$(PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload pr 42 owner/repo "2026-01-01T00:06:00Z")
+	repeated_digest=$(jq -r '.snapshot_sha256' <<<"$repeated_payload")
+	if [[ "$original_digest" != "$repeated_digest" ]]; then
+		print_result "existing human approval comments remain content-bound" 0
+	else
+		print_result "existing human approval comments remain content-bound" 1
+	fi
+	append_signed_comment pr 42 "2026-01-01T00:06:00Z" 4300
+	assert_verify "repeat approval verifies against the newest exact snapshot" pr 42 VERIFIED 0 "$PR_HEAD"
+
+	reset_and_sign pr 42
+	local audit_marker="<!-- aidevops-signed-approval -->
+<!-- stale-recovery-tick:0 (reset: auto-approved by maintainer — cryptographic approval verified) -->
+Auto-approved: cryptographic approval verified. Stale recovery tick reset."
+	local audit_comments=""
+	audit_comments=$(jq -c --arg body "$audit_marker" '.[0] += [{id:4301,node_id:"IC_4301",user:{id:1,node_id:"U_1",login:"maintainer",type:"User"},author_association:"OWNER",created_at:"2026-01-01T00:06:00Z",updated_at:"2026-01-01T00:06:00Z",body:$body}]' "${FIXTURES}/comments-42.json")
+	printf '%s\n' "$audit_comments" >"${FIXTURES}/comments-42.json"
+	assert_verify "trusted deterministic lifecycle audit comment is excluded" pr 42 VERIFIED 0 "$PR_HEAD"
+
+	reset_and_sign pr 42
+	local marker_drift="<!-- aidevops-signed-approval --> unsigned external drift"
+	local marker_comments=""
+	marker_comments=$(jq -c --arg body "$marker_drift" '.[0] += [{id:4302,node_id:"IC_4302",user:{id:105,node_id:"U_105",login:"external-author",type:"User"},author_association:"CONTRIBUTOR",created_at:"2026-01-01T00:06:00Z",updated_at:"2026-01-01T00:06:00Z",body:$body}]' "${FIXTURES}/comments-42.json")
+	printf '%s\n' "$marker_comments" >"${FIXTURES}/comments-42.json"
+	assert_verify "unsigned marker-bearing comment drift is not excluded" pr 42 STALE_APPROVAL 4 "$PR_HEAD"
+
+	jq '.body = "changed PR body"' "${FIXTURES}/pr-42.json" >"${FIXTURES}/pr.tmp" && mv "${FIXTURES}/pr.tmp" "${FIXTURES}/pr-42.json"
+	assert_verify "PR body drift is stale" pr 42 STALE_APPROVAL 4 "$PR_HEAD"
+
+	reset_and_sign pr 42
+	jq '.[0][0].body = "edited external comment" | .[0][0].updated_at = "2026-01-01T00:07:00Z"' "${FIXTURES}/comments-42.json" >"${FIXTURES}/comments.tmp" && mv "${FIXTURES}/comments.tmp" "${FIXTURES}/comments-42.json"
+	assert_verify "conversation comment drift is stale" pr 42 STALE_APPROVAL 4 "$PR_HEAD"
+
+	reset_and_sign pr 42
+	jq '.[0][0].body = "edited inline review"' "${FIXTURES}/review-comments-42.json" >"${FIXTURES}/review.tmp" && mv "${FIXTURES}/review.tmp" "${FIXTURES}/review-comments-42.json"
+	assert_verify "inline review drift is stale" pr 42 STALE_APPROVAL 4 "$PR_HEAD"
+
+	reset_and_sign pr 42
+	jq '.[0][0].source.issue.title = "changed linked scope"' "${FIXTURES}/timeline-42.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-42.json"
+	assert_verify "linked-reference drift is stale" pr 42 STALE_APPROVAL 4 "$PR_HEAD"
+
+	reset_and_sign pr 42
+	jq '.base.ref = "release"' "${FIXTURES}/pr-42.json" >"${FIXTURES}/pr.tmp" && mv "${FIXTURES}/pr.tmp" "${FIXTURES}/pr-42.json"
+	assert_verify "base-target drift is stale" pr 42 STALE_APPROVAL 4 "$PR_HEAD"
+
+	reset_and_sign pr 42
+	local changed_head="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	jq --arg head "$changed_head" '.head.sha = $head' "${FIXTURES}/pr-42.json" >"${FIXTURES}/pr.tmp" && mv "${FIXTURES}/pr.tmp" "${FIXTURES}/pr-42.json"
+	assert_verify "head drift is stale" pr 42 STALE_APPROVAL 4 "$PR_HEAD"
+
+	write_baseline_fixtures
+	replace_with_legacy_comment 41
+	assert_verify "V1 signature is legacy and cannot become V2 authority" issue 41 LEGACY_APPROVAL 3
+
+	reset_and_sign issue 41
+	jq '.[0][-1].body |= sub("aidevops-approval/v2"; "aidevops-approval/v3")' "${FIXTURES}/comments-41.json" >"${FIXTURES}/comments.tmp" && mv "${FIXTURES}/comments.tmp" "${FIXTURES}/comments-41.json"
+	assert_verify "tampered signed payload is malformed" issue 41 MALFORMED_APPROVAL 5
+
+	reset_and_sign issue 41
+	local output="" rc=0
+	output=$(GH_FAIL_ENDPOINT="timeline" run_verify issue 41) || rc=$?
+	if [[ "$output" == "API_ERROR" && "$rc" -eq 6 ]]; then
+		print_result "snapshot API uncertainty fails closed" 0
+	else
+		print_result "snapshot API uncertainty fails closed" 1 "output=${output}, rc=${rc}"
+	fi
+
+	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1322,6 +1322,41 @@ SQL
 	return 0
 }
 
+test_seed_worker_db_session_context_rebinds_replacement_worktree() {
+	local shared_dir="${HOME}/.local/share/opencode"
+	local isolated_dir="${TEST_ROOT}/isolated-opencode-rebound"
+	local replacement_dir="${TEST_ROOT}/replacement-worktree"
+	local shared_db="${shared_dir}/opencode.db"
+	local worker_db="${isolated_dir}/opencode/opencode.db"
+	local stale_dir="${TEST_ROOT}/removed-worktree"
+	mkdir -p "$shared_dir" "${isolated_dir}/opencode" "$replacement_dir"
+	rm -f "$shared_db" "$worker_db"
+
+	sqlite3 "$shared_db" <<SQL
+CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT);
+CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL);
+INSERT INTO project VALUES ('project-keep', 'Keep Project');
+INSERT INTO session VALUES ('session-keep', 'project-keep', '${stale_dir}', 'Keep');
+INSERT INTO message VALUES ('message-keep', 'session-keep', 'one');
+SQL
+
+	_seed_worker_db_session_context "$isolated_dir" "session-keep" "$replacement_dir"
+
+	local worker_directory="" shared_directory="" expected_replacement=""
+	expected_replacement=$(cd "$replacement_dir" && pwd -P)
+	worker_directory=$(sqlite3 "$worker_db" "SELECT directory FROM session WHERE id = 'session-keep';")
+	shared_directory=$(sqlite3 "$shared_db" "SELECT directory FROM session WHERE id = 'session-keep';")
+	if [[ "$worker_directory" == "$expected_replacement" && "$shared_directory" == "$stale_dir" ]]; then
+		print_result "seed worker DB rebinds stale session to replacement worktree only in isolation" 0
+		return 0
+	fi
+
+	print_result "seed worker DB rebinds stale session to replacement worktree only in isolation" 1 \
+		"worker_directory=$worker_directory shared_directory=$shared_directory"
+	return 0
+}
+
 test_seed_worker_db_session_context_copies_migration_metadata() {
 	local shared_dir="${HOME}/.local/share/opencode"
 	local isolated_dir="${TEST_ROOT}/isolated-opencode-metadata"
@@ -3037,6 +3072,7 @@ main() {
 	test_sandbox_passthrough_scopes_provider_env
 	test_copy_scoped_opencode_auth_keeps_selected_provider_only
 	test_seed_worker_db_session_context_copies_only_selected_session
+	test_seed_worker_db_session_context_rebinds_replacement_worktree
 	test_seed_worker_db_session_context_copies_migration_metadata
 	test_seed_worker_db_session_context_uses_backup_for_fresh_db
 	test_seed_worker_db_session_context_vacuums_pruned_backup

--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -266,6 +266,22 @@ test_case_a_collaborator_pr_returns_0() {
 	return 0
 }
 
+test_case_l_collaborator_linked_issue_nmr_blocks_final_gate() {
+	: >"$LOGFILE"
+	set_fixture '[{"name":"bug"}]' 'false' \
+		'## Summary\n\nResolves #930' 'VERIFIED' 'VERIFIED' 'trusted-contributor'
+	printf '%s' 'needs-maintainer-review' >"${TEST_ROOT}/linked-labels.txt"
+
+	local result=0
+	_pulse_merge_admin_safety_check "930" "owner/repo" "head-current" || result=$?
+	if [[ "$result" -eq 1 ]] && grep -qF "linked issue #930 is unavailable or carries needs-maintainer-review" "$LOGFILE"; then
+		print_result "Case L: collaborator linked-issue NMR blocks at final gate" 0
+		return 0
+	fi
+	print_result "Case L: collaborator linked-issue NMR blocks at final gate" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
 # =============================================================================
 # Case B: external-contributor labeled, no closing keyword in body.
 # Expected: returns 1 (refused — no linked issue).
@@ -526,6 +542,7 @@ main() {
 	test_case_i_unlabeled_non_collaborator_is_external
 	test_case_j_final_gate_rejects_stale_cached_review_evidence
 	test_case_k_final_gate_refreshes_current_review_evidence
+	test_case_l_collaborator_linked_issue_nmr_blocks_final_gate
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -18,9 +18,12 @@
 #   A — collaborator PR (no external-contributor label, not a fork)        → return 0
 #   B — external-contributor label, no closing keyword in PR body          → return 1
 #   C — external-contributor label, linked issue, no crypto approval       → return 1
-#   D — external-contributor label, linked issue, crypto approval present  → return 0
+#   D — external-contributor label, linked issue + current PR V2 approval → return 0
 #   E — unlabeled fork PR (isCrossRepository=true), no crypto approval     → return 1
 #   F — unlabeled fork PR (isCrossRepository=true), crypto approval        → return 0
+#   I — unlabeled non-collaborator, no current PR authority                 → return 1
+#   J — cached positive review evidence, live outcome no longer permitted  → return 1
+#   K — stale cached evidence, refreshed exact-head positive evidence      → return 0
 
 set -euo pipefail
 
@@ -31,6 +34,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # GH#21595, t3030.
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
 GATES_SCRIPT="${SCRIPT_DIR}/../pulse-merge-gates.sh"
+# shellcheck source=../pulse-merge-required-checks.sh
+source "${SCRIPT_DIR}/../pulse-merge-required-checks.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -65,18 +70,32 @@ set_fixture() {
 	local labels_json="$1"
 	local is_cross_repo="$2"
 	local body="$3"
-	local approval_result="$4"
+	local issue_approval_result="$4"
+	local pr_approval_result="${5:-$issue_approval_result}"
+	local pr_author="${6:-}"
+	if [[ -z "$pr_author" ]]; then
+		if [[ "$labels_json" == *"external-contributor"* || "$is_cross_repo" == "true" ]]; then
+			pr_author="external-contributor"
+		else
+			pr_author="trusted-contributor"
+		fi
+	fi
 
 	cat >"${TEST_ROOT}/labels.json" <<EOF
-{"labels": ${labels_json}, "isCrossRepository": ${is_cross_repo}}
+{"author":{"login":"${pr_author}"},"labels": ${labels_json}, "isCrossRepository": ${is_cross_repo}, "headRefOid": "head-current"}
 EOF
 
 	# PR title / body fixtures used by _extract_linked_issue.
 	printf 'test-pr-title' >"${TEST_ROOT}/title.txt"
 	printf '%s' "$body" >"${TEST_ROOT}/body.txt"
 
-	# approval-helper.sh stub output.
-	printf '%s' "$approval_result" >"${TEST_ROOT}/approval-result.txt"
+	# approval-helper.sh stub outputs distinguish development from merge authority.
+	printf '%s' "$issue_approval_result" >"${TEST_ROOT}/issue-approval-result.txt"
+	printf '%s' "$pr_approval_result" >"${TEST_ROOT}/pr-approval-result.txt"
+	printf '%s' '' >"${TEST_ROOT}/linked-labels.txt"
+	cat >"${TEST_ROOT}/review-evidence.json" <<EOF
+{"schema":"aidevops.review-gate-evidence/v1","repo":"owner/repo","pr":"${body##*#}","head_sha":"head-current","status":"PASS","author":{"login":"${pr_author}","association":"MEMBER","class":"trusted"},"permitted":true,"reason":"test","state":"pass","merge_gate":"clear","exit_code":0}
+EOF
 	return 0
 }
 
@@ -97,9 +116,15 @@ setup_test_env() {
 #!/usr/bin/env bash
 printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
 
-# gh pr view N --repo R --json labels,isCrossRepository
-if [[ "$*" == *"--json labels,isCrossRepository"* ]]; then
+# gh pr view N --repo R --json author,labels,isCrossRepository,headRefOid
+if [[ "$*" == *"--json author,labels,isCrossRepository,headRefOid"* ]]; then
 	cat "${TEST_ROOT}/labels.json"
+	exit 0
+fi
+
+# Linked issue label snapshot used by the final NMR gate.
+if [[ "${1:-}" == "api" && "$*" == *"repos/owner/repo/issues/"* && "$*" == *"--jq"* ]]; then
+	cat "${TEST_ROOT}/linked-labels.txt"
 	exit 0
 fi
 
@@ -119,13 +144,24 @@ exit 0
 GHEOF
 	chmod +x "${TEST_ROOT}/bin/gh"
 
-	# Mock approval-helper.sh — emits VERIFIED or NOT_VERIFIED based on fixture.
+# Mock approval-helper.sh — PR V2 authority is distinct from issue authority.
 	export AGENTS_DIR="${TEST_ROOT}/agents"
 	cat >"${TEST_ROOT}/agents/scripts/approval-helper.sh" <<'AHEOF'
 #!/usr/bin/env bash
-cat "${TEST_ROOT}/approval-result.txt"
+if [[ "$*" == *"verify pr"* ]]; then
+	cat "${TEST_ROOT}/pr-approval-result.txt"
+else
+	cat "${TEST_ROOT}/issue-approval-result.txt"
+fi
 AHEOF
 	chmod +x "${TEST_ROOT}/agents/scripts/approval-helper.sh"
+	cat >"${TEST_ROOT}/agents/scripts/review-bot-gate-helper.sh" <<'RBEOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "status-json" ]] || exit 1
+cat "${TEST_ROOT}/review-evidence.json"
+exit 0
+RBEOF
+	chmod +x "${TEST_ROOT}/agents/scripts/review-bot-gate-helper.sh"
 	return 0
 }
 
@@ -144,15 +180,24 @@ teardown_test_env() {
 #   - _pulse_merge_admin_safety_check            → pulse-merge-gates.sh ($GATES_SCRIPT)
 # All four are pure functions — no module-level state.
 define_helpers_under_test() {
-	local merge_src gates_src
+	local merge_src gates_src final_src
+	gh_pr_view() {
+		gh pr view "$@"
+		return $?
+	}
 	merge_src=$(awk '
 		/^_extract_linked_issue\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 	gates_src=$(awk '
 		/^_external_pr_has_linked_issue\(\) \{/,/^}$/ { print }
 		/^_external_pr_linked_issue_crypto_approved\(\) \{/,/^}$/ { print }
+		/^_external_pr_current_head_crypto_approved\(\) \{/,/^}$/ { print }
 		/^_pulse_merge_admin_safety_check\(\) \{/,/^}$/ { print }
 	' "$GATES_SCRIPT")
+	final_src=$(awk '
+		/^_pulse_merge_refresh_review_gate_evidence\(\) \{/,/^}$/ { print }
+		/^_pulse_merge_final_trust_gate\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
 	if [[ -z "$merge_src" ]]; then
 		printf 'ERROR: could not extract _extract_linked_issue from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
@@ -161,10 +206,35 @@ define_helpers_under_test() {
 		printf 'ERROR: could not extract gates helpers from %s\n' "$GATES_SCRIPT" >&2
 		return 1
 	fi
+	if [[ -z "$final_src" ]]; then
+		printf 'ERROR: could not extract final trust helpers from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	_is_collaborator_author() {
+		local author="$1"
+		local repo_slug="$2"
+		[[ -n "$repo_slug" ]] || return 2
+		[[ "$author" == "external-contributor" ]] && return 1
+		return 0
+	}
+	_is_trusted_dependabot_update_pr() {
+		return 1
+	}
 	# shellcheck disable=SC1090
 	eval "$merge_src"
 	# shellcheck disable=SC1090
 	eval "$gates_src"
+	# shellcheck disable=SC1090
+	eval "$final_src"
+	_PULSE_PREFLIGHT_CALLS=0
+	_pulse_merge_preflight_snapshot_gate() {
+		local repo_slug="$1"
+		local pr_number="$2"
+		local expected_head_sha="$3"
+		_PULSE_PREFLIGHT_CALLS=$((_PULSE_PREFLIGHT_CALLS + 1))
+		_pmrc_review_evidence_permits_advisory "${_PULSE_REVIEW_GATE_EVIDENCE:-}" "$repo_slug" "$pr_number" "$expected_head_sha"
+		return $?
+	}
 	return 0
 }
 
@@ -285,6 +355,87 @@ test_case_d_external_with_approval_returns_0() {
 	return 0
 }
 
+test_case_g_issue_approval_without_pr_v2_is_blocked() {
+	: >"$LOGFILE"
+	set_fixture '[{"name":"external-contributor"}]' 'false' \
+		'## Summary\n\nResolves #700' 'VERIFIED' 'LEGACY_APPROVAL'
+
+	local result=0
+	_pulse_merge_admin_safety_check "700" "owner/repo" "head-current" || result=$?
+	if [[ "$result" -eq 1 ]] && grep -qF "lacks V2 authority" "$LOGFILE"; then
+		print_result "Case G: issue approval alone cannot authorize external PR merge" 0
+		return 0
+	fi
+	print_result "Case G: issue approval alone is blocked" 1 \
+		"Expected current-head V2 refusal. rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_h_live_nmr_blocks_even_with_v2_approval() {
+	: >"$LOGFILE"
+	set_fixture '[{"name":"external-contributor"},{"name":"needs-maintainer-review"}]' 'false' \
+		'## Summary\n\nResolves #800' 'VERIFIED' 'VERIFIED'
+
+	local result=0
+	_pulse_merge_admin_safety_check "800" "owner/repo" "head-current" || result=$?
+	if [[ "$result" -eq 1 ]] && grep -qF "PR carries needs-maintainer-review" "$LOGFILE"; then
+		print_result "Case H: live PR NMR blocks current V2 authority" 0
+		return 0
+	fi
+	print_result "Case H: live PR NMR is blocked" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_i_unlabeled_non_collaborator_is_external() {
+	: >"$LOGFILE"
+	set_fixture '[{"name":"bug"}]' 'false' \
+		'## Summary\n\nResolves #900' 'VERIFIED' 'NO_APPROVAL' 'external-contributor'
+
+	local result=0
+	_pulse_merge_admin_safety_check "900" "owner/repo" "head-current" || result=$?
+	if [[ "$result" -eq 1 ]] && grep -qF "non-collaborator PR missing external-contributor label" "$LOGFILE"; then
+		print_result "Case I: unlabeled non-collaborator is treated as external" 0
+		return 0
+	fi
+	print_result "Case I: unlabeled non-collaborator is blocked" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_j_final_gate_rejects_stale_cached_review_evidence() {
+	: >"$LOGFILE"
+	set_fixture '[{"name":"bug"}]' 'false' \
+		'## Summary\n\nResolves #910' 'VERIFIED' 'VERIFIED' 'trusted-contributor'
+	cat >"${TEST_ROOT}/review-evidence.json" <<'EOF'
+{"schema":"aidevops.review-gate-evidence/v1","repo":"owner/repo","pr":"910","head_sha":"head-current","status":"WAITING","author":{"login":"trusted-contributor","association":"MEMBER","class":"trusted"},"permitted":false,"reason":"waiting","state":"waiting","merge_gate":"blocked","exit_code":1}
+EOF
+	_PULSE_REVIEW_GATE_EVIDENCE='{"schema":"aidevops.review-gate-evidence/v1","repo":"owner/repo","pr":"910","head_sha":"head-current","status":"PASS","author":{"login":"trusted-contributor","association":"MEMBER","class":"trusted"},"permitted":true,"reason":"stale","state":"pass","merge_gate":"clear","exit_code":0}'
+	_PULSE_PREFLIGHT_CALLS=0
+	local result=0
+	_pulse_merge_final_trust_gate "910" "owner/repo" "head-current" || result=$?
+	if [[ "$result" -eq 1 && "$_PULSE_PREFLIGHT_CALLS" -eq 0 ]]; then
+		print_result "Case J: final gate rejects stale cached review evidence" 0
+		return 0
+	fi
+	print_result "Case J: stale cached review evidence is rejected" 1 "rc=${result}; preflight_calls=${_PULSE_PREFLIGHT_CALLS}"
+	return 0
+}
+
+test_case_k_final_gate_refreshes_current_review_evidence() {
+	: >"$LOGFILE"
+	set_fixture '[{"name":"bug"}]' 'false' \
+		'## Summary\n\nResolves #920' 'VERIFIED' 'VERIFIED' 'trusted-contributor'
+	_PULSE_REVIEW_GATE_EVIDENCE='{"schema":"aidevops.review-gate-evidence/v1","repo":"owner/repo","pr":"920","head_sha":"old-head","status":"PASS","author":{"login":"trusted-contributor","association":"MEMBER","class":"trusted"},"permitted":true,"reason":"stale","state":"pass","merge_gate":"clear","exit_code":0}'
+	_PULSE_PREFLIGHT_CALLS=0
+	local result=0
+	_pulse_merge_final_trust_gate "920" "owner/repo" "head-current" || result=$?
+	if [[ "$result" -eq 0 && "$_PULSE_PREFLIGHT_CALLS" -eq 1 ]]; then
+		print_result "Case K: final gate refreshes exact-head review evidence" 0
+		return 0
+	fi
+	print_result "Case K: current review evidence reaches preflight" 1 "rc=${result}; preflight_calls=${_PULSE_PREFLIGHT_CALLS}"
+	return 0
+}
+
 # =============================================================================
 # Case E: unlabeled fork PR (isCrossRepository=true, no external label),
 # no crypto approval. Tests the label-system-failure detection path.
@@ -370,6 +521,11 @@ main() {
 	test_case_d_external_with_approval_returns_0
 	test_case_e_unlabeled_fork_no_approval_returns_1
 	test_case_f_unlabeled_fork_with_approval_returns_0
+	test_case_g_issue_approval_without_pr_v2_is_blocked
+	test_case_h_live_nmr_blocks_even_with_v2_approval
+	test_case_i_unlabeled_non_collaborator_is_external
+	test_case_j_final_gate_rejects_stale_cached_review_evidence
+	test_case_k_final_gate_refreshes_current_review_evidence
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
@@ -89,6 +89,8 @@ EOF
 	echo "0" >"${TEST_ROOT}/crypto-comment-count.txt"
 	# Default: linked issue number returned by the _extract_linked_issue stub.
 	echo "999" >"${TEST_ROOT}/linked-issue.txt"
+	# Default: no current-head V2 PR approval.
+	echo "NO_APPROVAL" >"${TEST_ROOT}/crypto-approval-result.txt"
 	return 0
 }
 
@@ -101,12 +103,16 @@ setup_test_env() {
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
-	# Point AGENTS_DIR to a mock directory without approval-helper.sh so
-	# _has_maintainer_crypto_approval falls back to the marker-presence
-	# path (trusting the count returned by the mock gh endpoint) rather
-	# than invoking the real SSH-key-based approval-helper.sh.
+	# Point AGENTS_DIR to a mock directory whose approval-helper fixture emits
+	# explicit V2 verification states. Marker presence alone has no authority.
 	export AGENTS_DIR="${TEST_ROOT}/mock-agents"
 	mkdir -p "${AGENTS_DIR}/scripts"
+	cat >"${AGENTS_DIR}/scripts/approval-helper.sh" <<'AHEOF'
+#!/usr/bin/env bash
+cat "${TEST_ROOT}/crypto-approval-result.txt"
+return 0 2>/dev/null || exit 0
+AHEOF
+	chmod +x "${AGENTS_DIR}/scripts/approval-helper.sh"
 
 	# Mock gh: logs every call and answers the five endpoints that
 	# `approve_collaborator_pr`, `_is_collaborator_author`, and
@@ -157,8 +163,8 @@ if [[ "${1:-}" == "api" && "$*" == *"/pulls/"*"/reviews"* ]]; then
 	exit 0
 fi
 
-# `gh api repos/SLUG/issues/N/comments --jq ...` — crypto-approval marker count
-# Used by _has_maintainer_crypto_approval. Returns the fixture-controlled count.
+# Legacy marker-count endpoint fixture. It remains to prove Case O cannot make
+# linked-issue marker presence substitute for current PR-specific V2 authority.
 if [[ "${1:-}" == "api" && "$*" == *"/issues/"*"/comments"* && "$*" == *"--jq"* ]]; then
 	cat "${TEST_ROOT}/crypto-comment-count.txt" 2>/dev/null || printf '0\n'
 	exit 0
@@ -195,6 +201,7 @@ define_helpers_under_test() {
 	local approve_src
 	local runner_src
 	local crypto_src
+	local current_head_crypto_src
 	local trusted_approval_src
 	approve_src=$(awk '
 		/^approve_collaborator_pr\(\) \{/,/^}$/ { print }
@@ -205,6 +212,9 @@ define_helpers_under_test() {
 	# _has_maintainer_crypto_approval was added in t3063
 	crypto_src=$(awk '
 		/^_has_maintainer_crypto_approval\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	current_head_crypto_src=$(awk '
+		/^_external_pr_current_head_crypto_approved\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 	trusted_approval_src=$(awk '
 		/^_trusted_existing_approver\(\) \{/,/^}$/ { print }
@@ -220,6 +230,10 @@ define_helpers_under_test() {
 	fi
 	if [[ -z "$crypto_src" ]]; then
 		printf 'ERROR: could not extract _has_maintainer_crypto_approval from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	if [[ -z "$current_head_crypto_src" ]]; then
+		printf 'ERROR: could not extract _external_pr_current_head_crypto_approved from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
 	fi
 	if [[ -z "$trusted_approval_src" ]]; then
@@ -242,6 +256,8 @@ define_helpers_under_test() {
 	source "$AUTHOR_CHECKS_SCRIPT"
 	# shellcheck disable=SC1090
 	eval "$runner_src"
+	# shellcheck disable=SC1090
+	eval "$current_head_crypto_src"
 	# shellcheck disable=SC1090
 	eval "$crypto_src"
 	# shellcheck disable=SC1090
@@ -534,9 +550,8 @@ test_case_h_failed_reviews_request_skips_jq() {
 
 test_case_n_contributor_with_crypto_on_pr() {
 	reset_mock_state
-	# PR author is NOT a collaborator; crypto marker is present on the PR.
-	# The comments endpoint (used for both PR and linked-issue) returns count=1.
-	echo "1" >"${TEST_ROOT}/crypto-comment-count.txt"
+	# PR author is NOT a collaborator; exact-current-head V2 authority verifies.
+	echo "VERIFIED" >"${TEST_ROOT}/crypto-approval-result.txt"
 
 	local result=0
 	approve_collaborator_pr "910" "owner/repo" "external-contributor" || result=$?
@@ -563,18 +578,13 @@ test_case_n_contributor_with_crypto_on_pr() {
 }
 
 # =============================================================================
-# Case O (t3063): CONTRIBUTOR author + crypto-approval on linked issue → approves.
-# Same bypass applies when the crypto signature is on the linked issue rather
-# than on the PR itself. PR comments return 0 but linked-issue comments return 1.
+# Case O (V2 hardening): CONTRIBUTOR author + linked-issue approval only → blocks.
+# Development authority cannot authorize a future or changed external PR head.
 # =============================================================================
 
 test_case_o_contributor_with_crypto_on_linked_issue() {
 	reset_mock_state
-	# The mock comments endpoint returns the same count for both PR and
-	# linked-issue paths (fixture is shared). Setting it to 1 simulates
-	# "crypto found on linked issue" — _has_maintainer_crypto_approval
-	# would find it on the first (PR-level) check in this simplified mock,
-	# which still correctly exercises the bypass path through approve_collaborator_pr.
+	# A linked issue exists, but the PR-specific verifier returns no authority.
 	echo "1" >"${TEST_ROOT}/crypto-comment-count.txt"
 
 	local result=0
@@ -587,17 +597,17 @@ test_case_o_contributor_with_crypto_on_linked_issue() {
 	fi
 	local approve_count
 	approve_count=$(count_approve_calls)
-	if [[ "${approve_count:-0}" -lt 1 ]]; then
-		print_result "Case O: CONTRIBUTOR + crypto on linked issue — approve API called" 1 \
-			"Expected at least one 'gh pr review' call. Log: $(cat "$GH_LOG")"
+	if [[ "${approve_count:-0}" -gt 0 ]]; then
+		print_result "Case O: linked-issue approval alone — NO approve API call" 1 \
+			"Expected zero 'gh pr review' calls. Log: $(cat "$GH_LOG")"
 		return 0
 	fi
-	if ! grep -qF "t3063" "$LOGFILE"; then
-		print_result "Case O: CONTRIBUTOR + crypto on linked issue — t3063 bypass logged" 1 \
-			"Expected 't3063' in log. Log: $(cat "$LOGFILE")"
+	if ! grep -qF "GH#17671 defense-in-depth" "$LOGFILE"; then
+		print_result "Case O: linked-issue approval alone — refusal audited" 1 \
+			"Expected GH#17671 refusal in log. Log: $(cat "$LOGFILE")"
 		return 0
 	fi
-	print_result "Case O: CONTRIBUTOR + crypto-approval on linked issue — approved via t3063 bypass" 0
+	print_result "Case O: linked-issue approval alone cannot authorize external PR" 0
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -159,7 +159,7 @@ teardown_test_env() {
 # into the test shell. _set_native_auto_merge_or_skip calls
 # _auto_merge_stuck_seconds (t3192), so we extract that too.
 define_helpers_under_test() {
-	local src_stuck src_repo_allow src_extract_state src_existing_green_behind src_green_behind src_set_native
+	local src_stuck src_repo_allow src_extract_state src_existing_green_behind src_green_behind src_stop_external src_set_native
 	src_stuck=$(awk '
 		/^_auto_merge_stuck_seconds\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
@@ -178,7 +178,10 @@ define_helpers_under_test() {
 	src_set_native=$(awk '
 		/^_set_native_auto_merge_or_skip\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
-	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_extract_state" || -z "$src_existing_green_behind" || -z "$src_green_behind" || -z "$src_set_native" ]]; then
+	src_stop_external=$(awk '
+		/^_stop_external_native_auto_merge\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$PROCESS_SCRIPT")
+	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_extract_state" || -z "$src_existing_green_behind" || -z "$src_green_behind" || -z "$src_stop_external" || -z "$src_set_native" ]]; then
 		printf 'ERROR: could not extract helpers from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
@@ -192,6 +195,8 @@ define_helpers_under_test() {
 	eval "$src_existing_green_behind"
 	# shellcheck disable=SC1090
 	eval "$src_green_behind"
+	# shellcheck disable=SC1090
+	eval "$src_stop_external"
 	# shellcheck disable=SC1090
 	eval "$src_set_native"
 	gh_pr_view() {

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -125,6 +125,12 @@ fi
 
 # `gh pr merge <N> --repo <slug> --disable-auto`
 if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--disable-auto"* ]]; then
+	[[ "${FAIL_DISABLE_AUTO:-0}" == "1" ]] && exit 1
+	exit 0
+fi
+
+if [[ "$1" == "pr" && "$2" == "ready" && "$*" == *"--undo"* ]]; then
+	[[ "${FAIL_DRAFT_HOLD:-0}" == "1" ]] && exit 1
 	exit 0
 fi
 
@@ -563,6 +569,59 @@ test_native_auto_defer_not_counted_as_completed_merge() {
 	return 0
 }
 
+test_external_pending_ci_never_sets_deferred_auto_merge() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	local result=0
+	_set_native_auto_merge_or_skip "900" "owner/repo" "1" || result=$?
+	if [[ "$result" -eq 2 ]] && ! grep -qE 'gh pr merge 900 .*--auto' "$GH_LOG"; then
+		print_result "External approval state with pending CI defers without native auto-merge" 0
+	else
+		print_result "External approval state with pending CI defers without native auto-merge" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_external_existing_auto_merge_is_disabled() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	printf '%s' '{"autoMergeRequest":{"enabledAt":"2026-07-14T12:00:00Z"},"mergeStateStatus":"BLOCKED","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+		>"${TEST_ROOT}/auto_merge_request.txt"
+
+	local result=0
+	_set_native_auto_merge_or_skip "901" "owner/repo" "1" || result=$?
+	if [[ "$result" -eq 2 ]] && grep -qE 'gh pr merge 901 --repo owner/repo --disable-auto' "$GH_LOG"; then
+		print_result "External approval state disables previously deferred auto-merge" 0
+	else
+		print_result "External approval state disables previously deferred auto-merge" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_external_auto_merge_disable_failure_applies_draft_hold() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	printf '%s' '{"autoMergeRequest":{"enabledAt":"2026-07-14T12:00:00Z"},"mergeStateStatus":"BLOCKED","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+		>"${TEST_ROOT}/auto_merge_request.txt"
+	export FAIL_DISABLE_AUTO=1
+	local result=0
+	_set_native_auto_merge_or_skip "902" "owner/repo" "1" || result=$?
+	unset FAIL_DISABLE_AUTO
+	if [[ "$result" -eq 2 ]] && grep -qE 'gh pr ready 902 --repo owner/repo --undo' "$GH_LOG"; then
+		print_result "External auto-merge disable failure applies a server-side draft hold" 0
+	else
+		print_result "External auto-merge disable failure applies a server-side draft hold" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG")"
+	fi
+	teardown_test_env
+	return 0
+}
+
 main() {
 	test_case_a_pending_ci_sets_auto_merge
 	test_case_b_ci_green_falls_through
@@ -573,6 +632,9 @@ main() {
 	test_case_f_green_behind_updates_branch
 	test_case_g_green_behind_without_auto_merge_updates_branch
 	test_native_auto_defer_not_counted_as_completed_merge
+	test_external_pending_ci_never_sets_deferred_auto_merge
+	test_external_existing_auto_merge_is_disabled
+	test_external_auto_merge_disable_failure_applies_draft_hold
 
 	printf '\n=================================\n'
 	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -10,6 +10,11 @@ source "${SCRIPT_DIR}/../pulse-merge-required-checks.sh"
 
 TEST_ROOT="$(mktemp -d -t pulse-preflight-snapshot.XXXXXX)"
 LOGFILE="${TEST_ROOT}/pulse.log"
+AIDEVOPS_REPOS_JSON="${TEST_ROOT}/repos.json"
+export AIDEVOPS_REPOS_JSON
+cat >"$AIDEVOPS_REPOS_JSON" <<'EOF'
+{"initialized_repos":[{"slug":"owner/repo","review_gate":{"advisory_check_contexts":["CodeFactor"]}}]}
+EOF
 PULSE_MERGE_QUIET_PERIOD_SECONDS=30
 PULSE_MERGE_NOW_EPOCH="$(_pmrc_iso_to_epoch '2026-01-01T00:10:00Z')"
 SNAPSHOT_MODE="happy_advisory"
@@ -26,6 +31,7 @@ _required_contexts_for_default_branch() {
 	local repo_slug="$1"
 	[[ -n "$repo_slug" ]] || return 1
 	printf 'required-a\n'
+	[[ "$SNAPSHOT_MODE" == "maintainer_alias_fail" ]] && printf 'Maintainer Review & Assignee Gate\n'
 	return 0
 }
 
@@ -72,6 +78,12 @@ gh() {
 			extra_check=',{"name":"CodeFactor","status":"completed","conclusion":"failure","details_url":"https://github.com/owner/repo/runs/99","completed_at":"2026-01-01T00:01:00Z"}'
 		elif [[ "$SNAPSHOT_MODE" == "infra_fail" ]]; then
 			extra_check=',{"name":"sync / Record ordered forge event","status":"completed","conclusion":"failure","details_url":"https://github.com/owner/repo/actions/runs/101/job/202","completed_at":"2026-01-01T00:01:00Z"}'
+		elif [[ "$SNAPSHOT_MODE" == "configured_fail" ]]; then
+			extra_check=',{"name":"CodeFactor","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:00Z"}'
+		elif [[ "$SNAPSHOT_MODE" == "maintainer_alias_fail" ]]; then
+			extra_check=',{"name":"maintainer-gate","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:00Z"},{"name":"Maintainer Review & Assignee Gate","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:01Z"},{"name":"gate / Maintainer Review & Assignee Gate","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:02Z"}'
+		elif [[ "$SNAPSHOT_MODE" == "same_name_source_conflict" ]]; then
+			extra_check=',{"name":"ProviderMirror","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:02Z"}'
 		fi
 		printf '[{"check_runs":[{"name":"required-a","status":"completed","conclusion":"%s","completed_at":"2026-01-01T00:01:00Z"},{"name":"Framework Validation","status":"%s","conclusion":%s,"completed_at":"%s"},{"name":"Qlty Smell Regression","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:00Z"},{"name":"Qlty Smell Threshold","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:00Z"}%s]}]\n' \
 			"$required_conclusion" "$broad_status" "$([[ "$broad_conclusion" == "null" ]] && printf 'null' || printf '"%s"' "$broad_conclusion")" "$broad_completed_at" "$extra_check"
@@ -81,6 +93,8 @@ gh() {
 		[[ "$SNAPSHOT_MODE" == "stale_gate" ]] && gate_at="2026-01-01T00:00:20Z"
 		if [[ "$SNAPSHOT_MODE" == "no_status_gate" ]]; then
 			printf '%s\n' '{"statuses":[]}'
+		elif [[ "$SNAPSHOT_MODE" == "same_name_source_conflict" ]]; then
+			printf '{"statuses":[{"context":"review-bot-gate","state":"success","updated_at":"%s"},{"context":"ProviderMirror","state":"failure","updated_at":"2026-01-01T00:01:03Z"}]}\n' "$gate_at"
 		else
 			printf '{"statuses":[{"context":"review-bot-gate","state":"success","updated_at":"%s"}]}\n' "$gate_at"
 		fi
@@ -124,6 +138,17 @@ assert_gate() {
 	return 0
 }
 
+set_live_evidence() {
+	local status="$1"
+	local head_sha="${2:-sha-reviewed}"
+	local author_class="${3:-trusted}"
+	local permitted="${4:-true}"
+	_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg status "$status" --arg head "$head_sha" --arg class "$author_class" --argjson permitted "$permitted" '
+		{schema:"aidevops.review-gate-evidence/v1",repo:"owner/repo",pr:"7",head_sha:$head,status:$status,author:{login:"reviewer",association:(if $class == "trusted" then "MEMBER" else "CONTRIBUTOR" end),class:$class},permitted:$permitted,reason:"test",state:(if $permitted then "pass" else "waiting" end),merge_gate:(if $permitted then "clear" else "blocked" end),exit_code:0}
+	')
+	return 0
+}
+
 main() {
 	assert_gate "terminal checks with explicit baseline advisory pass" happy_advisory 0
 	if grep -q "IGNORED non-required baseline advisory failure 'Qlty Smell Threshold'" "$LOGFILE"; then
@@ -160,13 +185,27 @@ main() {
 		TESTS_FAILED=$((TESTS_FAILED + 1))
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
+	assert_gate "same-name check-run and status retain independent source failures" same_name_source_conflict 1
+	set_live_evidence PASS
+	assert_gate "configured non-required provider failure passes with typed current-head evidence" configured_fail 0
+	set_live_evidence PASS_RATE_LIMITED sha-reviewed external false
+	assert_gate "configured provider failure blocks external rate-limit evidence" configured_fail 1
+	_PULSE_REVIEW_GATE_EVIDENCE=""
+	assert_gate "duplicate maintainer-gate aliases remain one logical blocker" maintainer_alias_fail 1
+	if [[ "$(grep -c "maintainer-gate family is terminal-failure" "$LOGFILE" || true)" -eq 1 ]]; then
+		printf 'PASS maintainer-gate aliases emit one audited blocker\n'
+	else
+		printf 'FAIL maintainer-gate aliases did not emit exactly one blocker\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
 	assert_gate "unresolved late inline finding blocks merge" unresolved 1
 	assert_gate "late review activity invalidates stale gate success" stale_gate 1
 	_PULSE_REVIEW_GATE_EVIDENCE=""
 	assert_gate "missing status gate fails closed without live evidence" no_status_gate 1
-	_PULSE_REVIEW_GATE_EVIDENCE="owner/repo#7@sha-reviewed"
+	set_live_evidence PASS
 	assert_gate "live gate evidence permits repositories without a status context" no_status_gate 0
-	_PULSE_REVIEW_GATE_EVIDENCE="owner/repo#7@sha-other"
+	set_live_evidence PASS sha-other
 	assert_gate "live gate evidence for another head fails closed" no_status_gate 1
 	_PULSE_REVIEW_GATE_EVIDENCE=""
 	assert_gate "new commit invalidates reviewed head" new_head 1

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -181,6 +181,7 @@ _check_ruleset_required_reviews_passing() { return 0; }
 _extract_merge_summary() { printf 'summary'; return 0; }
 _retarget_stacked_children() { return 0; }
 _pulse_merge_admin_safety_check() { return 0; }
+_pulse_merge_final_trust_gate() { _PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE=0; return 0; }
 _set_native_auto_merge_or_skip() { return 1; }
 _attempt_existing_auto_merge_behind_update_branch() { return 1; }
 _attempt_green_behind_update_branch() { return "${GREEN_BEHIND_UPDATE_RC:-1}"; }
@@ -214,7 +215,7 @@ test_ruleset_violation_enables_auto_merge_without_admin() {
 	setup_test_env
 	define_function_under_test || { teardown_test_env; return 0; }
 
-	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test"}'
+	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test","headRefOid":"head-current"}'
 	local result=0
 	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
 
@@ -228,7 +229,7 @@ test_ruleset_violation_enables_auto_merge_without_admin() {
 		teardown_test_env
 		return 0
 	fi
-	if ! grep -qE 'gh pr merge 77 --repo owner/repo --auto --squash$' "$GH_LOG"; then
+	if ! grep -qE 'gh pr merge 77 --repo owner/repo --auto --squash --match-head-commit head-current$' "$GH_LOG"; then
 		print_result "ruleset violation fallback enables native auto-merge" 1 "gh log: $(cat "$GH_LOG")"
 		teardown_test_env
 		return 0

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -172,6 +172,7 @@ _pmp_review_decision_is_unknown() {
 	return $?
 }
 
+PULSE_UNKNOWN_STATE="UNKNOWN"
 _resolve_pr_mergeable_status() { return 0; }
 _extract_linked_issue() { printf '123'; return 0; }
 _check_pr_merge_gates() { return 0; }

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -654,6 +654,59 @@ test_classify_bot_state_accepts_submitted_at_only_review() {
 	return 0
 }
 
+install_head_bound_review_gh_stub() {
+	local review_commit="$1"
+	local review_time="$2"
+	local gh_stub="${TEST_ROOT}/bin/gh"
+	cat >"$gh_stub" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+endpoint="\${2:-}"
+jq_filter=""
+shift 2
+while [[ "\$#" -gt 0 ]]; do
+	if [[ "\${1:-}" == "--jq" ]]; then jq_filter="\${2:-}"; shift 2; else shift; fi
+done
+case "\$endpoint" in
+	repos/testorg/otherrepo/pulls/123/reviews)
+		jq -r "\$jq_filter" <<'JSON'
+[{"user":{"login":"reviewbot"},"commit_id":"${review_commit}","submitted_at":"${review_time}","body":"Looks good on this revision."}]
+JSON
+		;;
+	*) jq -r "\$jq_filter" <<'JSON'
+[]
+JSON
+		;;
+esac
+EOF
+	chmod +x "$gh_stub"
+	return 0
+}
+
+test_current_head_evidence_rejects_historical_review() {
+	install_head_bound_review_gh_stub "old-head" "2026-07-14T12:00:00Z"
+	export REVIEW_GATE_EXPECTED_HEAD_SHA="new-head"
+	if bot_has_real_review 123 'testorg/otherrepo' 'reviewbot' 2>/dev/null; then
+		print_result "current-head evidence rejects a review bound to an older head" 1
+	else
+		print_result "current-head evidence rejects a review bound to an older head" 0
+	fi
+	unset REVIEW_GATE_EXPECTED_HEAD_SHA
+	return 0
+}
+
+test_current_head_evidence_accepts_exact_head_review() {
+	install_head_bound_review_gh_stub "new-head" "2026-07-14T14:00:00Z"
+	export REVIEW_GATE_EXPECTED_HEAD_SHA="new-head"
+	if bot_has_real_review 123 'testorg/otherrepo' 'reviewbot' 2>/dev/null; then
+		print_result "current-head evidence accepts a review bound to the exact head" 0
+	else
+		print_result "current-head evidence accepts a review bound to the exact head" 1
+	fi
+	unset REVIEW_GATE_EXPECTED_HEAD_SHA
+	return 0
+}
+
 # ---------- Unit tests: notice category classification (GH#22855) ----------
 
 install_notice_category_gh_stub() {
@@ -983,6 +1036,8 @@ main() {
 	echo "=== Reviews endpoint submitted_at fallback (GH#26473) ==="
 	test_bot_has_real_review_accepts_submitted_at_only_review
 	test_classify_bot_state_accepts_submitted_at_only_review
+	test_current_head_evidence_rejects_historical_review
+	test_current_head_evidence_accepts_exact_head_review
 
 	echo ""
 	echo "=== Notice category classification (GH#22855) ==="

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -881,6 +881,51 @@ test_do_check_fetches_success_status_contexts_once() {
 	return 0
 }
 
+test_status_json_denies_external_rate_limit_grace() {
+	do_check() { printf 'PASS_RATE_LIMITED\n'; return 0; }
+	gh() {
+		printf '%s\n' '{"head":{"sha":"head-123"},"user":{"login":"external"},"author_association":"CONTRIBUTOR"}'
+		return 0
+	}
+	local output=""
+	output=$(do_status_json 123 'testorg/otherrepo')
+	if jq -e '.schema == "aidevops.review-gate-evidence/v1" and .status == "PASS_RATE_LIMITED" and .author.class == "external" and .permitted == false and .merge_gate == "blocked"' <<<"$output" >/dev/null; then
+		print_result "status-json denies external rate-limit grace" 0
+	else
+		print_result "status-json denies external rate-limit grace" 1 "output=${output}"
+	fi
+	return 0
+}
+
+test_status_json_allows_trusted_skip() {
+	do_check() { printf 'SKIP\n'; return 0; }
+	gh() {
+		printf '%s\n' '{"head":{"sha":"head-123"},"user":{"login":"maintainer"},"author_association":"MEMBER"}'
+		return 0
+	}
+	local output=""
+	output=$(do_status_json 123 'testorg/otherrepo')
+	if jq -e '.status == "SKIP" and .head_sha == "head-123" and .author.class == "trusted" and .permitted == true and .merge_gate == "clear"' <<<"$output" >/dev/null; then
+		print_result "status-json permits trusted current-head skip" 0
+	else
+		print_result "status-json permits trusted current-head skip" 1 "output=${output}"
+	fi
+	return 0
+}
+
+test_status_json_fails_closed_without_pr_metadata() {
+	do_check() { printf 'PASS\n'; return 0; }
+	gh() { return 1; }
+	local output=""
+	output=$(do_status_json 123 'testorg/otherrepo')
+	if jq -e '.status == "PASS" and .head_sha == "" and .permitted == false and .merge_gate == "blocked"' <<<"$output" >/dev/null; then
+		print_result "status-json fails closed on missing PR metadata" 0
+	else
+		print_result "status-json fails closed on missing PR metadata" 1 "output=${output}"
+	fi
+	return 0
+}
+
 # ---------- Run ----------
 
 main() {
@@ -951,6 +996,12 @@ main() {
 	test_do_check_blocks_non_rate_limit_non_review_states
 	test_do_check_accepts_non_review_with_success_status
 	test_do_check_fetches_success_status_contexts_once
+
+	echo ""
+	echo "=== Typed current-head evidence ==="
+	test_status_json_denies_external_rate_limit_grace
+	test_status_json_allows_trusted_skip
+	test_status_json_fails_closed_without_pr_metadata
 
 	echo ""
 	echo "Tests run: ${TESTS_RUN}, failed: ${TESTS_FAILED}"


### PR DESCRIPTION
## Summary

Bind external approval and advisory review authority to deterministic issue/PR snapshots and exact head commits. Rebind isolated OpenCode worker sessions to replacement worktrees so retried workers do not retain deleted directories. Harden final merge gates against stale review evidence, linked-issue NMR changes, maintainer alias failures, and externally armed native auto-merge.

## Files Changed

.agents/reference/auto-merge.md, .agents/reference/incident-gh17671-supply-chain.md, .agents/reference/repos-json-fields.md, .agents/scripts/approval-helper.sh, .agents/scripts/approval-snapshot-v2.sh, .agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/pulse-merge-gates.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/review-bot-gate-helper.sh, .agents/scripts/review-gate-config-helper.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh, .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh, .agents/scripts/tests/test-pulse-merge-native-auto.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh, .agents/scripts/tests/test-review-bot-gate-completion-signal.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused approval, pulse-merge, review-bot, and headless-runtime shell suites; bash -n; ShellCheck; git diff --check; .agents/scripts/linters-local.sh --changed; full .agents/scripts/linters-local.sh.

Resolves #27560


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 42m and 767,583 tokens on this with the user in an interactive session.