### PR TITLE
GH#27615: fix issue-sync caller permission ceiling

### DIFF
--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -467,6 +467,12 @@ with open(sys.argv[1]) as reusable_file:
     reusable = yaml.safe_load(reusable_file)
 with open(sys.argv[2]) as caller_file:
     caller = yaml.safe_load(caller_file)
+if not isinstance(reusable, dict):
+    print("FAIL: reusable workflow root must be a mapping")
+    sys.exit(1)
+if not isinstance(caller, dict):
+    print("FAIL: caller workflow root must be a mapping")
+    sys.exit(1)
 
 levels = {"none": 0, "read": 1, "write": 2}
 required = {}

--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -448,21 +448,58 @@ if [[ -f "$REUSABLE_WF" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Tests 18-19: GH#20967 — every caller template must declare permissions:
+# Tests 18-19: GH#20967/GH#27615 — caller permission ceilings
 # Repos with default_workflow_permissions: read cause startup_failure unless
-# the caller sets a permissions ceiling. Both templates must declare permissions.
+# callers grant every permission requested by their reusable workflow jobs.
 # ---------------------------------------------------------------------------
 
-# Test 18: issue-sync-caller.yml declares a permissions: block
-if [[ -f "$DOWNSTREAM_TEMPLATE" ]]; then
-	if grep -qE "^permissions:" "$DOWNSTREAM_TEMPLATE" 2>/dev/null; then
-		_pass "issue-sync-caller.yml declares top-level permissions: block (GH#20967)"
-	else
-		_fail "issue-sync-caller.yml declares top-level permissions: block (GH#20967)" \
-			"missing 'permissions:' in $DOWNSTREAM_TEMPLATE — repos with default_workflow_permissions: read will get startup_failure"
-	fi
+# Test 18: issue-sync caller ceiling equals the union of reusable job permissions
+if [[ ! -f "$DOWNSTREAM_TEMPLATE" || ! -f "$REUSABLE_WF" ]]; then
+	_skip "issue-sync caller permissions equal reusable job union" "workflow or template file missing"
+elif ! command -v python3 >/dev/null 2>&1 || ! python3 -c "import yaml" 2>/dev/null; then
+	_skip "issue-sync caller permissions equal reusable job union" "python3 or pyyaml unavailable"
 else
-	_skip "issue-sync-caller.yml permissions check" "template file missing"
+	permission_result="$(python3 - "$REUSABLE_WF" "$DOWNSTREAM_TEMPLATE" <<'PYEOF' 2>&1
+import sys
+import yaml
+
+with open(sys.argv[1]) as reusable_file:
+    reusable = yaml.safe_load(reusable_file)
+with open(sys.argv[2]) as caller_file:
+    caller = yaml.safe_load(caller_file)
+
+levels = {"none": 0, "read": 1, "write": 2}
+required = {}
+for job_name, job in (reusable.get("jobs", {}) or {}).items():
+    if not isinstance(job, dict):
+        continue
+    permissions = job.get("permissions", {}) or {}
+    if not isinstance(permissions, dict):
+        print(f"FAIL: job {job_name} permissions must be an explicit mapping")
+        sys.exit(1)
+    for permission, level in permissions.items():
+        if level not in levels:
+            print(f"FAIL: unsupported permission level {permission}={level}")
+            sys.exit(1)
+        if levels[level] > levels.get(required.get(permission, "none"), 0):
+            required[permission] = level
+
+granted = caller.get("permissions", {}) or {}
+if not isinstance(granted, dict):
+    print("FAIL: caller permissions must be an explicit mapping")
+    sys.exit(1)
+if granted != required:
+    print(f"FAIL: caller={granted}; required_union={required}")
+    sys.exit(1)
+print("OK")
+PYEOF
+)"
+	if [[ "$permission_result" == "OK" ]]; then
+		_pass "issue-sync caller permissions equal reusable job union (GH#27615)"
+	else
+		_fail "issue-sync caller permissions equal reusable job union (GH#27615)" \
+			"$permission_result"
+	fi
 fi
 
 # Test 19: review-bot-gate-caller.yml declares a permissions: block

--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -475,20 +475,42 @@ if not isinstance(caller, dict):
     sys.exit(1)
 
 levels = {"none": 0, "read": 1, "write": 2}
-required = {}
-for job_name, job in (reusable.get("jobs", {}) or {}).items():
-    if not isinstance(job, dict):
-        continue
-    permissions = job.get("permissions", {}) or {}
-    if not isinstance(permissions, dict):
-        print(f"FAIL: job {job_name} permissions must be an explicit mapping")
+
+def permission_union(workflow):
+    top_permissions = workflow.get("permissions", {}) or {}
+    if not isinstance(top_permissions, dict):
+        print("FAIL: reusable top-level permissions must be an explicit mapping")
         sys.exit(1)
-    for permission, level in permissions.items():
-        if level not in levels:
-            print(f"FAIL: unsupported permission level {permission}={level}")
+    required = {}
+    for job_name, job in (workflow.get("jobs", {}) or {}).items():
+        if not isinstance(job, dict):
+            continue
+        permissions = job.get("permissions") if "permissions" in job else top_permissions
+        permissions = permissions or {}
+        if not isinstance(permissions, dict):
+            print(f"FAIL: job {job_name} permissions must be an explicit mapping")
             sys.exit(1)
-        if levels[level] > levels.get(required.get(permission, "none"), 0):
-            required[permission] = level
+        for permission, level in permissions.items():
+            if level not in levels:
+                print(f"FAIL: unsupported permission level {permission}={level}")
+                sys.exit(1)
+            # An omitted caller key already means none, so only granted access
+            # contributes to the required ceiling.
+            if levels[level] > levels.get(required.get(permission, "none"), 0):
+                required[permission] = level
+    return required
+
+fixtures = [
+    ({"permissions": {"actions": "read"}, "jobs": {"inherited": {}}}, {"actions": "read"}),
+    ({"jobs": {"disabled": {"permissions": {"actions": "none"}}}}, {}),
+]
+for fixture, expected in fixtures:
+    actual = permission_union(fixture)
+    if actual != expected:
+        print(f"FAIL: permission-union fixture={actual}; expected={expected}")
+        sys.exit(1)
+
+required = permission_union(reusable)
 
 granted = caller.get("permissions", {}) or {}
 if not isinstance(granted, dict):

--- a/.agents/templates/workflows/issue-sync-caller.yml
+++ b/.agents/templates/workflows/issue-sync-caller.yml
@@ -22,6 +22,7 @@ name: Issue Sync - Bi-directional TODO.md ↔ GitHub Issues
 # Reusable workflow job-level permissions cannot exceed the caller's ceiling.
 # This block sets the union of all job-level permissions used by issue-sync-reusable.yml.
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write


### PR DESCRIPTION
## Summary

Grant the canonical issue-sync caller actions: read and replace the block-presence regression check with an exact reusable-job permission-union assertion.

## Files Changed

.agents/scripts/tests/test-reusable-workflow-caller.sh, .agents/templates/workflows/issue-sync-caller.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused reusable-workflow caller test (24/24), ShellCheck, actionlint, changed-file lint, and full local lint passed; pre-fix test reproduced the missing actions permission. Runtime classified low-risk workflow configuration and self-assessed because the reporter downstream repository is unavailable.

Resolves #27615


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 58m and 159,036 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the issue synchronization workflow to include the required read access for actions.
  * Added validation to ensure workflow permissions match the required access level, helping prevent configuration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->