### PR TITLE
GH#27676: refactor: streamline approval review helpers

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1087,6 +1087,8 @@ _approval_classify_marked_comments() {
 	local comment_count="$7"
 	local saw_api_error=0 saw_stale=0 saw_legacy=0 saw_malformed=0
 	local comment_rows=""
+	local base64_decode_flag="-d"
+	[[ "$(uname -s)" == "Darwin" ]] && base64_decode_flag="-D"
 
 	if [[ -z "$comments_json" || "$comment_count" -le 0 ]]; then
 		printf 'MALFORMED_APPROVAL\n'
@@ -1103,7 +1105,7 @@ _approval_classify_marked_comments() {
 
 	while IFS=$'\t' read -r comment_id encoded_body; do
 		local body="" classification
-		body=$(printf '%s' "$encoded_body" | base64 -d) || {
+		body=$(printf '%s' "$encoded_body" | base64 "$base64_decode_flag") || {
 			saw_malformed=1
 			continue
 		}

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1086,13 +1086,27 @@ _approval_classify_marked_comments() {
 	local expected_head_sha="${6:-}"
 	local comment_count="$7"
 	local saw_api_error=0 saw_stale=0 saw_legacy=0 saw_malformed=0
-	local i=$((comment_count - 1))
+	local comment_rows=""
 
-	while [[ "$i" -ge 0 ]]; do
-		local body comment_id classification
-		body=$(printf '%s' "$comments_json" | jq -r ".[$i].body" 2>/dev/null || echo "")
-		comment_id=$(printf '%s' "$comments_json" | jq -r ".[$i].id // empty" 2>/dev/null || echo "")
-		i=$((i - 1))
+	if [[ -z "$comments_json" || "$comment_count" -le 0 ]]; then
+		printf 'MALFORMED_APPROVAL\n'
+		return 5
+	fi
+	comment_rows=$(jq -r '
+		reverse[]
+		| [((.id // "") | tostring), ((.body // "") | @base64)]
+		| @tsv
+	' <<<"$comments_json") || {
+		printf 'MALFORMED_APPROVAL\n'
+		return 5
+	}
+
+	while IFS=$'\t' read -r comment_id encoded_body; do
+		local body="" classification
+		body=$(printf '%s' "$encoded_body" | base64 -d) || {
+			saw_malformed=1
+			continue
+		}
 		if [[ ! "$comment_id" =~ ^[0-9]+$ ]]; then
 			saw_malformed=1
 			continue
@@ -1105,7 +1119,7 @@ _approval_classify_marked_comments() {
 		LEGACY_APPROVAL) saw_legacy=1 ;;
 		*) saw_malformed=1 ;;
 		esac
-	done
+	done <<<"$comment_rows"
 
 	[[ "$saw_api_error" -eq 0 ]] || { printf 'API_ERROR\n'; return 6; }
 	[[ "$saw_stale" -eq 0 ]] || { printf 'STALE_APPROVAL\n'; return 4; }

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -1045,7 +1045,10 @@ do_status_json() {
 	# metadata-less evidence can never authorize an advisory merge decision.
 	case "$output" in
 	"$status_pass")
-		[[ "$head_stable" == "true" && -n "$author_login" ]] && permitted="true" reason="live_review_pass"
+		if [[ "$head_stable" == "true" && -n "$author_login" ]]; then
+			permitted="true"
+			reason="live_review_pass"
+		fi
 		;;
 	SKIP)
 		if [[ "$author_class" == "trusted" && "$head_stable" == "true" ]]; then

--- a/.agents/scripts/review-gate-config-helper.sh
+++ b/.agents/scripts/review-gate-config-helper.sh
@@ -40,7 +40,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ -z "${BLUE+x}" ]]   && BLUE='\033[0;34m'
 [[ -z "${NC+x}" ]]     && NC='\033[0m'
 
-readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+readonly REPOS_JSON="${AIDEVOPS_REPOS_JSON:-${HOME:+$HOME/.config/aidevops/repos.json}}"
 readonly RATE_LIMIT_BEHAVIOR_FIELD="rate_limit_behavior"
 readonly COMPLETION_BEHAVIOR_FIELD="completion_behavior"
 readonly ADVISORY_CONTEXTS_FIELD="advisory_check_contexts"

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -193,6 +193,8 @@ main() {
 
 	reset_and_sign issue 41
 	assert_verify "unchanged issue V2 snapshot verifies" issue 41 VERIFIED 0
+	jq '.[0][-1].body = ("audit\tcontext\n" + .[0][-1].body)' "${FIXTURES}/comments-41.json" >"${FIXTURES}/comments.tmp" && mv "${FIXTURES}/comments.tmp" "${FIXTURES}/comments-41.json"
+	assert_verify "approval body preserves tabs and newlines" issue 41 VERIFIED 0
 	jq '.body = "changed issue body"' "${FIXTURES}/issue-41.json" >"${FIXTURES}/issue.tmp"
 	mv "${FIXTURES}/issue.tmp" "${FIXTURES}/issue-41.json"
 	assert_verify "issue body drift is stale" issue 41 STALE_APPROVAL 4
@@ -258,6 +260,10 @@ Auto-approved: cryptographic approval verified. Stale recovery tick reset."
 	reset_and_sign issue 41
 	jq '.[0][-1].body |= sub("aidevops-approval/v2"; "aidevops-approval/v3")' "${FIXTURES}/comments-41.json" >"${FIXTURES}/comments.tmp" && mv "${FIXTURES}/comments.tmp" "${FIXTURES}/comments-41.json"
 	assert_verify "tampered signed payload is malformed" issue 41 MALFORMED_APPROVAL 5
+
+	write_baseline_fixtures
+	jq -nc '[[{id:"invalid",body:"<!-- aidevops-signed-approval -->"}]]' >"${FIXTURES}/comments-41.json"
+	assert_verify "non-numeric approval comment ID is malformed" issue 41 MALFORMED_APPROVAL 5
 
 	reset_and_sign issue 41
 	local output="" rc=0

--- a/.agents/scripts/tests/test-review-gate-config-path.sh
+++ b/.agents/scripts/tests/test-review-gate-config-path.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for review-gate repos.json path resolution (GH#27676).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../review-gate-config-helper.sh"
+TEST_ROOT="$(mktemp -d -t review-gate-config-path.XXXXXX)"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+override_repos_json="${TEST_ROOT}/override-repos.json"
+printf '%s\n' '{"initialized_repos":[]}' >"$override_repos_json"
+
+output=$(env -u HOME AIDEVOPS_REPOS_JSON="$override_repos_json" "$HELPER" list)
+if [[ "$output" != *"No repos registered"* ]]; then
+	printf 'FAIL AIDEVOPS_REPOS_JSON override was not used with HOME unset\n' >&2
+	exit 1
+fi
+printf 'PASS AIDEVOPS_REPOS_JSON override works with HOME unset\n'
+
+stderr_file="${TEST_ROOT}/empty-home.stderr"
+if HOME="" env -u AIDEVOPS_REPOS_JSON "$HELPER" list >/dev/null 2>"$stderr_file"; then
+	printf 'FAIL empty HOME unexpectedly resolved a repos.json file\n' >&2
+	exit 1
+fi
+if grep -Fq 'repos.json not found: /.config/aidevops/repos.json' "$stderr_file"; then
+	printf 'FAIL empty HOME resolved to a root-level config path\n' >&2
+	exit 1
+fi
+printf 'PASS empty HOME does not resolve to a root-level config path\n'
+
+exit 0


### PR DESCRIPTION
## Summary

Parse marked approval comments with one jq pass while preserving multiline and tabbed bodies; honor AIDEVOPS_REPOS_JSON safely; clarify live review pass assignment.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/review-bot-gate-helper.sh, .agents/scripts/review-gate-config-helper.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh, .agents/scripts/tests/test-review-gate-config-path.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused approval content-binding and review-gate config path tests; bash -n and ShellCheck on changed shell files.

Resolves #27676


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 6m and 96,379 tokens on this as a headless worker.