### PR TITLE
GH#27658: repair maintainer approval pagination gate

### DIFF
--- a/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
@@ -66,12 +66,12 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 	esac
 fi
 
-if [[ "${1:-}" == "api" && "${2:-}" == */comments ]]; then
+if [[ "${1:-}" == "api" && "$*" == *"/comments"* ]]; then
 	case "${GH_SCENARIO:-}" in
 		issue-api-failure|pr-approval-failure) exit 1 ;;
 		issue-invalid|pr-invalid) printf '{"message":"rate limited"}\n'; exit 0 ;;
-		issue-signed|pr-signed) printf '1\n'; exit 0 ;;
-		issue-unsigned|pr-unsigned) printf '0\n'; exit 0 ;;
+		issue-signed|pr-signed) printf '[[{"body":"<!-- aidevops-signed-approval -->"}]]\n'; exit 0 ;;
+		issue-unsigned|pr-unsigned) printf '[[]]\n'; exit 0 ;;
 	esac
 fi
 
@@ -194,11 +194,30 @@ test_pr_approval_paths() {
 	return 0
 }
 
+test_slurp_and_jq_are_separate() {
+	if python3 - "$WORKFLOW_FILE" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text()
+combined = re.findall(r"gh api[^\n]*\\\n(?:[^\n]*\\\n)*?[^\n]*--slurp[^\n]*\\\n[^\n]*--jq", text)
+raise SystemExit(1 if combined else 0)
+PY
+	then
+		print_result "maintainer gate separates gh --slurp from jq" 0
+	else
+		print_result "maintainer gate separates gh --slurp from jq" 1 "unsupported gh flag combination remains"
+	fi
+	return 0
+}
+
 main() {
 	setup_test_env
 	trap teardown_test_env EXIT
 	test_issue_approval_paths
 	test_pr_approval_paths
+	test_slurp_and_jq_are_separate
 	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
 		return 1

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -233,13 +233,18 @@ jobs:
             # evidence that a signed approval is absent. Fail the check rather
             # than silently converting infrastructure uncertainty into a trust
             # verdict.
+            APPROVAL_COMMENTS=""
             SIGNED_APPROVAL=""
-            if ! SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-              --paginate --slurp \
-              --jq '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
-              2>/dev/null); then
+            if ! APPROVAL_COMMENTS=$(gh api --paginate --slurp \
+              "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null); then
               echo "::error::Unable to verify signed approvals for PR #$PR_NUMBER"
               post_maintainer_gate_status_with_retry failure "Unable to verify signed maintainer approval"
+              exit 1
+            fi
+            if ! SIGNED_APPROVAL=$(printf '%s' "$APPROVAL_COMMENTS" | jq -r \
+              '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' 2>/dev/null); then
+              echo "::error::Unable to parse signed approvals for PR #$PR_NUMBER"
+              post_maintainer_gate_status_with_retry failure "Unable to parse signed maintainer approval"
               exit 1
             fi
             if [[ ! "$SIGNED_APPROVAL" =~ ^[0-9]+$ ]]; then
@@ -594,12 +599,16 @@ jobs:
           # infrastructure uncertainty, not proof that approval is absent.
           # Never create/recreate an irreversible ever-NMR authority record from
           # a failed lookup.
+          APPROVAL_COMMENTS=""
           SIGNED_APPROVAL=""
-          if ! SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
-            --paginate --slurp \
-            --jq '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
-            2>/dev/null); then
+          if ! APPROVAL_COMMENTS=$(gh api --paginate --slurp \
+            "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" 2>/dev/null); then
             echo "::error::Unable to verify signed approvals for issue #$ISSUE_NUMBER — leaving labels unchanged"
+            exit 1
+          fi
+          if ! SIGNED_APPROVAL=$(printf '%s' "$APPROVAL_COMMENTS" | jq -r \
+            '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' 2>/dev/null); then
+            echo "::error::Unable to parse signed approvals for issue #$ISSUE_NUMBER — leaving labels unchanged"
             exit 1
           fi
           if [[ ! "$SIGNED_APPROVAL" =~ ^[0-9]+$ ]]; then
@@ -618,11 +627,16 @@ jobs:
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs-maintainer-review"
 
           # Post a comment explaining why
+          NOTICE_COMMENTS=""
           EXISTING=""
-          if ! EXISTING=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
-            --paginate --slurp \
-            --jq "[.[][] | select(.body | test(\"label-protection-notice\"))] | length" 2>/dev/null); then
+          if ! NOTICE_COMMENTS=$(gh api --paginate --slurp \
+            "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" 2>/dev/null); then
             echo "::warning::Unable to check for an existing label-protection notice — skipping comment"
+            exit 0
+          fi
+          if ! EXISTING=$(printf '%s' "$NOTICE_COMMENTS" | jq -r \
+            '[.[][] | select(.body | test("label-protection-notice"))] | length' 2>/dev/null); then
+            echo "::warning::Unable to parse existing label-protection notices — skipping comment"
             exit 0
           fi
           [[ "$EXISTING" =~ ^[0-9]+$ ]] || exit 0
@@ -947,12 +961,16 @@ jobs:
 
           # Check for a cryptographic signed approval comment on the PR.
           # PRs use the same issues API endpoint for comments.
+          APPROVAL_COMMENTS=""
           SIGNED_APPROVAL=""
-          if ! SIGNED_APPROVAL=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --paginate --slurp \
-            --jq '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' \
-            2>/dev/null); then
+          if ! APPROVAL_COMMENTS=$(gh api --paginate --slurp \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null); then
             echo "::error::Unable to verify signed approvals for PR #$PR_NUMBER — leaving labels unchanged"
+            exit 1
+          fi
+          if ! SIGNED_APPROVAL=$(printf '%s' "$APPROVAL_COMMENTS" | jq -r \
+            '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' 2>/dev/null); then
+            echo "::error::Unable to parse signed approvals for PR #$PR_NUMBER — leaving labels unchanged"
             exit 1
           fi
           if [[ ! "$SIGNED_APPROVAL" =~ ^[0-9]+$ ]]; then
@@ -971,11 +989,16 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "needs-maintainer-review"
 
           # Post a comment explaining why (only once)
+          NOTICE_COMMENTS=""
           EXISTING=""
-          if ! EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --paginate --slurp \
-            --jq "[.[][] | select(.body | test(\"pr-label-protection-notice\"))] | length" 2>/dev/null); then
+          if ! NOTICE_COMMENTS=$(gh api --paginate --slurp \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null); then
             echo "::warning::Unable to check for an existing PR label-protection notice — skipping comment"
+            exit 0
+          fi
+          if ! EXISTING=$(printf '%s' "$NOTICE_COMMENTS" | jq -r \
+            '[.[][] | select(.body | test("pr-label-protection-notice"))] | length' 2>/dev/null); then
+            echo "::warning::Unable to parse existing PR label-protection notices — skipping comment"
             exit 0
           fi
           [[ "$EXISTING" =~ ^[0-9]+$ ]] || exit 0


### PR DESCRIPTION
## Summary

Separate paginated comment retrieval from local jq parsing so the maintainer gate can verify signed approvals without an unsupported gh flag combination.

## Files Changed

.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh, .github/workflows/maintainer-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Maintainer gate approval/API regression suites pass; full local quality suite passes.

Resolves #27658


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 1h 53m and 676,299 tokens on this with the user in an interactive session.