### PR TITLE
GH#27683: secure DSPy disk cache

### DIFF
--- a/.agents/scripts/dspy-cache-security.sh
+++ b/.agents/scripts/dspy-cache-security.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Secure DSPy's diskcache-backed cache against writes by other local users.
+# CVE-2025-69872 can execute a pickled cache value when an attacker can replace
+# cache content before DSPy reads it.
+
+aidevops_secure_dspy_cache() {
+	local cache_root="${AIDEVOPS_CACHE_DIR:-$HOME/.aidevops/cache}"
+	local cache_dir="${DSPY_CACHEDIR:-${cache_root}/dspy}"
+	local previous_umask
+
+	if [[ "$cache_dir" != /* ]]; then
+		printf '[ERROR] DSPY_CACHEDIR must be an absolute path: %s\n' "$cache_dir" >&2
+		return 1
+	fi
+	if [[ -L "$cache_dir" ]]; then
+		printf '[ERROR] Refusing symlinked DSPy cache directory: %s\n' "$cache_dir" >&2
+		return 1
+	fi
+
+	previous_umask=$(umask)
+	umask 077
+	if ! mkdir -p -- "$cache_dir"; then
+		umask "$previous_umask"
+		printf '[ERROR] Unable to create DSPy cache directory: %s\n' "$cache_dir" >&2
+		return 1
+	fi
+	umask "$previous_umask"
+
+	if [[ -L "$cache_dir" || ! -d "$cache_dir" || ! -O "$cache_dir" ]]; then
+		printf '[ERROR] DSPy cache must be an owner-controlled directory: %s\n' "$cache_dir" >&2
+		return 1
+	fi
+	if ! chmod 700 "$cache_dir"; then
+		printf '[ERROR] Unable to restrict DSPy cache permissions: %s\n' "$cache_dir" >&2
+		return 1
+	fi
+
+	export DSPY_CACHEDIR="$cache_dir"
+	return 0
+}
+
+aidevops_persist_dspy_cache_env() {
+	local activate_file="$1"
+	local marker="# aidevops:dspy-cache-security"
+
+	if [[ ! -f "$activate_file" ]]; then
+		printf '[ERROR] DSPy virtualenv activation script not found: %s\n' "$activate_file" >&2
+		return 1
+	fi
+	if grep -Fq "$marker" "$activate_file"; then
+		return 0
+	fi
+
+	if ! cat >>"$activate_file" <<'EOF'; then
+
+# aidevops:dspy-cache-security
+# Keep DSPy's pickle-backed cache in the owner-only directory prepared by setup.
+export DSPY_CACHEDIR="${AIDEVOPS_CACHE_DIR:-$HOME/.aidevops/cache}/dspy"
+EOF
+		printf '[ERROR] Unable to persist the secure DSPy cache environment\n' >&2
+		return 1
+	fi
+	return 0
+}

--- a/.agents/scripts/dspy-helper.sh
+++ b/.agents/scripts/dspy-helper.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 # Load shared constants and functions
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/shared-constants.sh"
+# shellcheck source=dspy-cache-security.sh
+source "$SCRIPT_DIR/dspy-cache-security.sh"
 
 # Use shared print functions with fallback for compatibility
 # Configuration
@@ -55,7 +57,12 @@ activate_env() {
         print_error "Failed to activate Python virtual environment"
         exit 1
     fi
+	if ! aidevops_secure_dspy_cache; then
+		print_error "DSPy cache security validation failed"
+		exit 1
+	fi
     print_success "Python virtual environment activated"
+	print_info "DSPy cache restricted to: $DSPY_CACHEDIR"
     return 0
 }
 

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -1784,6 +1784,19 @@ setup_python_env() {
 		print_info "Python virtual environment already exists"
 	fi
 
+	if ! declare -F aidevops_secure_dspy_cache >/dev/null 2>&1; then
+		print_warning "DSPy cache security helper unavailable - DSPy setup skipped"
+		return 0
+	fi
+	if ! aidevops_secure_dspy_cache; then
+		print_warning "DSPy cache could not be restricted to an owner-only directory - DSPy setup skipped"
+		return 0
+	fi
+	if ! aidevops_persist_dspy_cache_env "python-env/dspy-env/bin/activate"; then
+		print_warning "DSPy cache environment could not be persisted - DSPy setup skipped"
+		return 0
+	fi
+
 	# Install DSPy dependencies
 	print_info "Installing DSPy dependencies..."
 	# shellcheck source=/dev/null
@@ -1801,6 +1814,7 @@ setup_python_env() {
 		print_info "Check requirements.txt or run manually:"
 		print_info "  source python-env/dspy-env/bin/activate && pip install -r requirements.txt"
 	fi
+	return 0
 }
 
 setup_nodejs_env() {

--- a/.agents/scripts/tests/test-dspy-cache-security.sh
+++ b/.agents/scripts/tests/test-dspy-cache-security.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../dspy-cache-security.sh
+source "$SCRIPT_DIR/../dspy-cache-security.sh"
+
+TEST_TMP_ROOT="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEST_TMP_ROOT"
+TEST_ROOT="$(mktemp -d "$TEST_TMP_ROOT/dspy-cache-security.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+test_secure_default_cache() {
+	local mode
+	HOME="$TEST_ROOT/home"
+	mkdir -p "$HOME"
+	unset AIDEVOPS_CACHE_DIR DSPY_CACHEDIR
+
+	aidevops_secure_dspy_cache
+	[[ "$DSPY_CACHEDIR" == "$HOME/.aidevops/cache/dspy" ]] || fail "unexpected default cache path"
+	[[ -O "$DSPY_CACHEDIR" && ! -L "$DSPY_CACHEDIR" ]] || fail "cache is not owner-controlled"
+	mode=$(python3 -c 'import os, stat, sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode)))' "$DSPY_CACHEDIR")
+	[[ "$mode" == "0o700" ]] || fail "cache mode is $mode, expected 0o700"
+	return 0
+}
+
+test_rejects_relative_cache() {
+	DSPY_CACHEDIR="relative/cache"
+	if aidevops_secure_dspy_cache 2>/dev/null; then
+		fail "relative cache path was accepted"
+	fi
+	return 0
+}
+
+test_rejects_symlink_cache() {
+	local target="$TEST_ROOT/target"
+	local link="$TEST_ROOT/cache-link"
+	mkdir -p "$target"
+	ln -s "$target" "$link"
+	DSPY_CACHEDIR="$link"
+	if aidevops_secure_dspy_cache 2>/dev/null; then
+		fail "symlinked cache path was accepted"
+	fi
+	return 0
+}
+
+test_persists_activation_once() {
+	local activate_file="$TEST_ROOT/activate"
+	local marker_count
+	printf '# virtualenv activation\n' >"$activate_file"
+
+	aidevops_persist_dspy_cache_env "$activate_file"
+	aidevops_persist_dspy_cache_env "$activate_file"
+	marker_count=$(grep -Fc '# aidevops:dspy-cache-security' "$activate_file")
+	[[ "$marker_count" == "1" ]] || fail "activation marker was not idempotent"
+	return 0
+}
+
+test_secure_default_cache
+test_rejects_relative_cache
+test_rejects_symlink_cache
+test_persists_activation_once
+printf 'PASS: DSPy cache security tests\n'

--- a/setup.sh
+++ b/setup.sh
@@ -140,6 +140,17 @@ if [[ -f "$_SHARED_CONSTANTS" ]]; then
 fi
 unset _SHARED_CONSTANTS
 
+# Secure the optional DSPy disk cache before setup installs or imports DSPy.
+_DSPY_CACHE_SECURITY="${BASH_SOURCE[0]%/*}/.agents/scripts/dspy-cache-security.sh"
+if [[ ! -f "$_DSPY_CACHE_SECURITY" ]]; then
+	_DSPY_CACHE_SECURITY="$HOME/.aidevops/agents/scripts/dspy-cache-security.sh"
+fi
+if [[ -f "$_DSPY_CACHE_SECURITY" ]]; then
+	# shellcheck disable=SC1090  # Dynamic path resolved at runtime
+	source "$_DSPY_CACHE_SECURITY"
+fi
+unset _DSPY_CACHE_SECURITY
+
 # Escape a string for safe embedding in XML (plist heredocs).
 # Prevents XML injection if paths contain &, <, >, ", or ' characters.
 _xml_escape() {


### PR DESCRIPTION
## Summary

Contain CVE-2025-69872 by enforcing an owner-controlled mode-0700 DSPy cache, rejecting unsafe paths, and persisting the protected cache location in the managed virtual environment.

## Files Changed

.agents/scripts/dspy-cache-security.sh, .agents/scripts/dspy-helper.sh, .agents/scripts/setup/modules/tool-install.sh, .agents/scripts/tests/test-dspy-cache-security.sh, setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused cache-security tests pass; ShellCheck and Bash syntax checks pass; .agents/scripts/linters-local.sh reports ALL LOCAL CHECKS PASSED.

Resolves #27683


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 15m and 143,926 tokens on this with the user in an interactive session.