### PR TITLE
t18122: Add cryptographically scoped worker permission grants

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -100,12 +100,13 @@ function parsePermissionGrantPayload(payload) {
 }
 
 function verifyPermissionGrantSignature(grant, publicKey, tempBase) {
-  mkdirSync(tempBase, { recursive: true });
-  const verifyDir = mkdtempSync(join(tempBase, "permission-grant-"));
-  const signaturePath = join(verifyDir, "signature");
-  const signersPath = join(verifyDir, "allowed-signers");
+  let verifyDir = "";
   let verified = false;
   try {
+    mkdirSync(tempBase, { recursive: true });
+    verifyDir = mkdtempSync(join(tempBase, "permission-grant-"));
+    const signaturePath = join(verifyDir, "signature");
+    const signersPath = join(verifyDir, "allowed-signers");
     writeFileSync(signaturePath, grant.signature, { mode: 0o600 });
     const key = readFileSync(publicKey, "utf8").trim();
     writeFileSync(signersPath, `approval@aidevops.sh namespaces="aidevops-approve" ${key}\n`, { mode: 0o600 });
@@ -117,7 +118,13 @@ function verifyPermissionGrantSignature(grant, publicKey, tempBase) {
   } catch {
     verified = false;
   } finally {
-    rmSync(verifyDir, { recursive: true, force: true });
+    if (verifyDir) {
+      try {
+        rmSync(verifyDir, { recursive: true, force: true });
+      } catch {
+        // Verification already completed; temporary cleanup remains best effort.
+      }
+    }
   }
   return verified;
 }

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -83,22 +83,28 @@ export function registerManagedDirectoryPermissions(config) {
   return count;
 }
 
-function verifyPermissionGrant(grantPath, options = {}) {
-  if (!grantPath || !existsSync(grantPath)) return null;
-  const publicKey = options.publicKey || join(homedir(), ".aidevops", "approval-keys", "approval.pub");
-  if (!existsSync(publicKey)) return null;
-  let grant;
+function readPermissionGrantFile(grantPath) {
   try {
-    grant = JSON.parse(readFileSync(grantPath, "utf8"));
+    return JSON.parse(readFileSync(grantPath, "utf8"));
   } catch {
     return null;
   }
-  if (typeof grant?.payload !== "string" || typeof grant?.signature !== "string") return null;
-  const tempBase = options.tempBase || process.env.AIDEVOPS_TEMP_DIR || join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+}
+
+function parsePermissionGrantPayload(payload) {
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return null;
+  }
+}
+
+function verifyPermissionGrantSignature(grant, publicKey, tempBase) {
   mkdirSync(tempBase, { recursive: true });
   const verifyDir = mkdtempSync(join(tempBase, "permission-grant-"));
   const signaturePath = join(verifyDir, "signature");
   const signersPath = join(verifyDir, "allowed-signers");
+  let verified = false;
   try {
     writeFileSync(signaturePath, grant.signature, { mode: 0o600 });
     const key = readFileSync(publicKey, "utf8").trim();
@@ -107,80 +113,145 @@ function verifyPermissionGrant(grantPath, options = {}) {
       "-Y", "verify", "-f", signersPath, "-I", "approval@aidevops.sh",
       "-n", "aidevops-approve", "-s", signaturePath,
     ], { input: grant.payload, stdio: ["pipe", "ignore", "ignore"] });
+    verified = true;
   } catch {
+    verified = false;
+  } finally {
     rmSync(verifyDir, { recursive: true, force: true });
-    return null;
   }
-  rmSync(verifyDir, { recursive: true, force: true });
-  try {
-    return JSON.parse(grant.payload);
-  } catch {
-    return null;
-  }
+  return verified;
 }
 
-function addApprovedCapabilityRules(target, capabilities) {
+function verifyPermissionGrant(grantPath, options = {}) {
+  if (!grantPath || !existsSync(grantPath)) return null;
+  const publicKey = options.publicKey || join(homedir(), ".aidevops", "approval-keys", "approval.pub");
+  if (!existsSync(publicKey)) return null;
+  const grant = readPermissionGrantFile(grantPath);
+  if (typeof grant?.payload !== "string" || typeof grant?.signature !== "string") return null;
+  const tempBase = options.tempBase || process.env.AIDEVOPS_TEMP_DIR || join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+  if (!verifyPermissionGrantSignature(grant, publicKey, tempBase)) return null;
+  return parsePermissionGrantPayload(grant.payload);
+}
+
+function ensurePermissionMap(target) {
   if (typeof target.permission === "string") {
     const fallback = target.permission;
     target.permission = { "*": fallback, external_directory: { "*": fallback } };
   } else if (!target.permission) {
     target.permission = {};
   }
+}
+
+function addApprovedCapabilityRule(target, capability) {
+  const permission = capability.permission;
+  const patterns = Array.isArray(capability.patterns) ? capability.patterns : [];
+  if (!PATTERN_CAPABLE_PERMISSIONS.has(permission) || patterns.length === 0) return 0;
+  const existing = target.permission[permission];
+  if (existing === "allow") return 0;
+  const rules = typeof existing === "string" ? { "*": existing } : { ...existing };
+  let count = 0;
+  for (const pattern of patterns) {
+    if (typeof pattern !== "string" || pattern.length === 0 || pattern.length > 500) continue;
+    delete rules[pattern];
+    rules[pattern] = "allow";
+    count++;
+  }
+  target.permission[permission] = rules;
+  return count;
+}
+
+function addApprovedCapabilityRules(target, capabilities) {
+  ensurePermissionMap(target);
   let count = 0;
   for (const capability of capabilities) {
-    const permission = capability.permission;
-    const patterns = Array.isArray(capability.patterns) ? capability.patterns : [];
-    if (!PATTERN_CAPABLE_PERMISSIONS.has(permission) || patterns.length === 0) continue;
-    const existing = target.permission[permission];
-    if (existing === "allow") continue;
-    const rules = typeof existing === "string" ? { "*": existing } : { ...existing };
-    for (const pattern of patterns) {
-      if (typeof pattern !== "string" || pattern.length === 0 || pattern.length > 500) continue;
-      delete rules[pattern];
-      rules[pattern] = "allow";
-      count++;
-    }
-    target.permission[permission] = rules;
+    count += addApprovedCapabilityRule(target, capability);
   }
   return count;
+}
+
+function permissionGrantTargetMatches(grant) {
+  if (grant?.schema !== "aidevops-permission-grant/v1") return false;
+  if (grant.authority !== "worker-permissions") return false;
+  const issue = String(process.env.WORKER_ISSUE_NUMBER || "");
+  const repo = String(process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "").toLowerCase();
+  if (String(grant.target?.number || "") !== issue) return false;
+  return String(grant.target?.repository || "").toLowerCase() === repo;
+}
+
+function permissionGrantTimeValid(grant) {
+  const issued = Date.parse(grant.issued_at || "");
+  const expires = Date.parse(grant.expires_at || "");
+  const now = Date.now();
+  if (!Number.isFinite(issued) || !Number.isFinite(expires)) return false;
+  if (issued > now + 5 * 60 * 1000 || expires <= now) return false;
+  return expires > issued && expires - issued <= MAX_PERMISSION_GRANT_MS;
+}
+
+function permissionGrantRequestValid(grant) {
+  if (!/^perm-[0-9a-f]{16}$/.test(grant.request_id || "")) return false;
+  return /^[0-9a-f]{64}$/.test(grant.request_sha256 || "");
+}
+
+function currentWorkerBranch(options, repositoryDir) {
+  if (options.currentBranch !== undefined) return options.currentBranch;
+  try {
+    return execFileSync("git", ["-C", repositoryDir, "branch", "--show-current"], { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function permissionGrantWorkerMatches(grant, options) {
+  const pendingRequest = String(options.pendingRequest || process.env.AIDEVOPS_PERMISSION_REQUEST_ID || "");
+  if (!pendingRequest || grant.request_id !== pendingRequest) return false;
+  const repositoryDir = String(options.repositoryDir || "");
+  if (!repositoryDir) return false;
+  const expectedWorktree = createHash("sha256").update(repositoryDir).digest("hex");
+  if (grant.worker?.worktree_sha256 !== expectedWorktree) return false;
+  const currentSession = String(options.currentSession || process.env.WORKER_SESSION_KEY || "");
+  if (!currentSession || grant.worker?.session !== currentSession) return false;
+  const currentBranch = currentWorkerBranch(options, repositoryDir);
+  if (typeof currentBranch !== "string" || currentBranch.length === 0) return false;
+  if (typeof grant.worker?.branch !== "string" || grant.worker.branch.length === 0) return false;
+  return grant.worker.branch === currentBranch;
+}
+
+function permissionGrantPatternSafe(pattern) {
+  if (typeof pattern !== "string") return false;
+  if (pattern.length === 0 || pattern.length > 500) return false;
+  if (FORBIDDEN_GRANT_PATTERN.test(pattern)) return false;
+  return !UNBOUNDED_GRANT_PATTERN.test(pattern);
+}
+
+function permissionGrantCapabilitySafe(item) {
+  if (item?.risk?.grantable !== true) return false;
+  if (!PATTERN_CAPABLE_PERMISSIONS.has(item?.permission || "")) return false;
+  if (!Array.isArray(item.patterns)) return false;
+  if (item.patterns.length === 0 || item.patterns.length > 20) return false;
+  return item.patterns.every(permissionGrantPatternSafe);
+}
+
+function permissionGrantCapabilitiesSafe(grant) {
+  if (!Array.isArray(grant.capabilities)) return false;
+  if (grant.capabilities.length === 0 || grant.capabilities.length > 20) return false;
+  return grant.capabilities.every(permissionGrantCapabilitySafe);
+}
+
+function permissionGrantUsable(grant, options) {
+  const checks = [
+    permissionGrantTargetMatches(grant),
+    permissionGrantTimeValid(grant),
+    permissionGrantRequestValid(grant),
+    permissionGrantWorkerMatches(grant, options),
+    permissionGrantCapabilitiesSafe(grant),
+  ];
+  return checks.every(Boolean);
 }
 
 export function registerApprovedWorkerPermissions(config, options = {}) {
   const grantPath = options.grantPath || process.env.AIDEVOPS_PERMISSION_GRANT_FILE || "";
   const grant = verifyPermissionGrant(grantPath, options);
-  if (!grant || grant.schema !== "aidevops-permission-grant/v1" || grant.authority !== "worker-permissions") return 0;
-  const issue = String(process.env.WORKER_ISSUE_NUMBER || "");
-  const repo = String(process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "").toLowerCase();
-  if (String(grant.target?.number || "") !== issue || String(grant.target?.repository || "").toLowerCase() !== repo) return 0;
-  const issued = Date.parse(grant.issued_at || "");
-  const expires = Date.parse(grant.expires_at || "");
-  const now = Date.now();
-  if (!Number.isFinite(issued) || !Number.isFinite(expires) || issued > now + 5 * 60 * 1000 || expires <= now) return 0;
-  if (expires <= issued || expires - issued > MAX_PERMISSION_GRANT_MS) return 0;
-  if (!Array.isArray(grant.capabilities) || grant.capabilities.length === 0 || grant.capabilities.length > 20) return 0;
-  if (!/^perm-[0-9a-f]{16}$/.test(grant.request_id || "") || !/^[0-9a-f]{64}$/.test(grant.request_sha256 || "")) return 0;
-  const pendingRequest = String(options.pendingRequest || process.env.AIDEVOPS_PERMISSION_REQUEST_ID || "");
-  if (!pendingRequest || grant.request_id !== pendingRequest) return 0;
-  const repositoryDir = String(options.repositoryDir || "");
-  const expectedWorktree = createHash("sha256").update(repositoryDir).digest("hex");
-  if (!repositoryDir || grant.worker?.worktree_sha256 !== expectedWorktree) return 0;
-  const currentSession = String(options.currentSession || process.env.WORKER_SESSION_KEY || "");
-  if (!currentSession || grant.worker?.session !== currentSession) return 0;
-  let currentBranch = options.currentBranch;
-  if (currentBranch === undefined) {
-    try {
-      currentBranch = execFileSync("git", ["-C", repositoryDir, "branch", "--show-current"], { encoding: "utf8" }).trim();
-    } catch {
-      return 0;
-    }
-  }
-  if (grant.worker?.branch !== currentBranch) return 0;
-  if (grant.capabilities.some((item) => {
-    if (item?.risk?.grantable !== true || !PATTERN_CAPABLE_PERMISSIONS.has(item?.permission || "")) return true;
-    if (!Array.isArray(item.patterns) || item.patterns.length === 0 || item.patterns.length > 20) return true;
-    return item.patterns.some((pattern) => typeof pattern !== "string" || pattern.length === 0 || pattern.length > 500
-      || FORBIDDEN_GRANT_PATTERN.test(pattern) || UNBOUNDED_GRANT_PATTERN.test(pattern));
-  })) return 0;
+  if (!grant || !permissionGrantUsable(grant, options)) return 0;
   let count = addApprovedCapabilityRules(config, grant.capabilities);
   for (const agent of Object.values(config.agent || {})) {
     count += addApprovedCapabilityRules(agent, grant.capabilities);

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -3,9 +3,11 @@
 // Extracted from index.mjs (t1914).
 // ---------------------------------------------------------------------------
 
-import { existsSync, readFileSync, appendFileSync } from "fs";
+import { existsSync, readFileSync, appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
+import { execFileSync } from "child_process";
+import { createHash } from "crypto";
 import { loadAgentIndex, applyAgentMcpTools } from "./agent-loader.mjs";
 import { registerMcpServers } from "./mcp-registry.mjs";
 import { registerPoolProvider, getAccounts, ensureValidToken } from "./oauth-pool.mjs";
@@ -31,6 +33,11 @@ const MANAGED_EXTERNAL_DIRECTORIES = [
   "~/Git/_worktrees",
   "~/Git/_worktrees/**",
 ];
+
+const PATTERN_CAPABLE_PERMISSIONS = new Set(["bash", "external_directory"]);
+const FORBIDDEN_GRANT_PATTERN = /(?:approval-keys\/private|\/(?:\.ssh|\.gnupg|\.aws|\.azure|\.kube)(?:\/|$)|\/(?:\.config\/(?:gh|gcloud|glab-cli|hub)|\.docker)(?:\/|$)|\/(?:\.netrc|\.npmrc|\.pypirc|\.git-credentials)(?:$|\*)|auth\.json(?:$|\*)|credentials?(?:\.|\/|$)|(?:^|\/)\.env(?:\.|$|\/))/i;
+const UNBOUNDED_GRANT_PATTERN = /^(?:\*|\*\*|\/\*\*|~\/\*\*|\$WORKTREE\/\*\*)$/;
+const MAX_PERMISSION_GRANT_MS = 4 * 60 * 60 * 1000;
 
 /**
  * Allow OpenCode to use aidevops-managed state and linked worktrees without
@@ -72,6 +79,111 @@ export function registerManagedDirectoryPermissions(config) {
   let count = addManagedDirectoryRules(config);
   for (const agent of Object.values(config.agent || {})) {
     count += addManagedDirectoryRules(agent);
+  }
+  return count;
+}
+
+function verifyPermissionGrant(grantPath, options = {}) {
+  if (!grantPath || !existsSync(grantPath)) return null;
+  const publicKey = options.publicKey || join(homedir(), ".aidevops", "approval-keys", "approval.pub");
+  if (!existsSync(publicKey)) return null;
+  let grant;
+  try {
+    grant = JSON.parse(readFileSync(grantPath, "utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof grant?.payload !== "string" || typeof grant?.signature !== "string") return null;
+  const tempBase = options.tempBase || process.env.AIDEVOPS_TEMP_DIR || join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+  mkdirSync(tempBase, { recursive: true });
+  const verifyDir = mkdtempSync(join(tempBase, "permission-grant-"));
+  const signaturePath = join(verifyDir, "signature");
+  const signersPath = join(verifyDir, "allowed-signers");
+  try {
+    writeFileSync(signaturePath, grant.signature, { mode: 0o600 });
+    const key = readFileSync(publicKey, "utf8").trim();
+    writeFileSync(signersPath, `approval@aidevops.sh namespaces="aidevops-approve" ${key}\n`, { mode: 0o600 });
+    execFileSync("ssh-keygen", [
+      "-Y", "verify", "-f", signersPath, "-I", "approval@aidevops.sh",
+      "-n", "aidevops-approve", "-s", signaturePath,
+    ], { input: grant.payload, stdio: ["pipe", "ignore", "ignore"] });
+  } catch {
+    rmSync(verifyDir, { recursive: true, force: true });
+    return null;
+  }
+  rmSync(verifyDir, { recursive: true, force: true });
+  try {
+    return JSON.parse(grant.payload);
+  } catch {
+    return null;
+  }
+}
+
+function addApprovedCapabilityRules(target, capabilities) {
+  if (typeof target.permission === "string") {
+    const fallback = target.permission;
+    target.permission = { "*": fallback, external_directory: { "*": fallback } };
+  } else if (!target.permission) {
+    target.permission = {};
+  }
+  let count = 0;
+  for (const capability of capabilities) {
+    const permission = capability.permission;
+    const patterns = Array.isArray(capability.patterns) ? capability.patterns : [];
+    if (!PATTERN_CAPABLE_PERMISSIONS.has(permission) || patterns.length === 0) continue;
+    const existing = target.permission[permission];
+    if (existing === "allow") continue;
+    const rules = typeof existing === "string" ? { "*": existing } : { ...existing };
+    for (const pattern of patterns) {
+      if (typeof pattern !== "string" || pattern.length === 0 || pattern.length > 500) continue;
+      delete rules[pattern];
+      rules[pattern] = "allow";
+      count++;
+    }
+    target.permission[permission] = rules;
+  }
+  return count;
+}
+
+export function registerApprovedWorkerPermissions(config, options = {}) {
+  const grantPath = options.grantPath || process.env.AIDEVOPS_PERMISSION_GRANT_FILE || "";
+  const grant = verifyPermissionGrant(grantPath, options);
+  if (!grant || grant.schema !== "aidevops-permission-grant/v1" || grant.authority !== "worker-permissions") return 0;
+  const issue = String(process.env.WORKER_ISSUE_NUMBER || "");
+  const repo = String(process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "").toLowerCase();
+  if (String(grant.target?.number || "") !== issue || String(grant.target?.repository || "").toLowerCase() !== repo) return 0;
+  const issued = Date.parse(grant.issued_at || "");
+  const expires = Date.parse(grant.expires_at || "");
+  const now = Date.now();
+  if (!Number.isFinite(issued) || !Number.isFinite(expires) || issued > now + 5 * 60 * 1000 || expires <= now) return 0;
+  if (expires <= issued || expires - issued > MAX_PERMISSION_GRANT_MS) return 0;
+  if (!Array.isArray(grant.capabilities) || grant.capabilities.length === 0 || grant.capabilities.length > 20) return 0;
+  if (!/^perm-[0-9a-f]{16}$/.test(grant.request_id || "") || !/^[0-9a-f]{64}$/.test(grant.request_sha256 || "")) return 0;
+  const pendingRequest = String(options.pendingRequest || process.env.AIDEVOPS_PERMISSION_REQUEST_ID || "");
+  if (!pendingRequest || grant.request_id !== pendingRequest) return 0;
+  const repositoryDir = String(options.repositoryDir || "");
+  const expectedWorktree = createHash("sha256").update(repositoryDir).digest("hex");
+  if (!repositoryDir || grant.worker?.worktree_sha256 !== expectedWorktree) return 0;
+  const currentSession = String(options.currentSession || process.env.WORKER_SESSION_KEY || "");
+  if (!currentSession || grant.worker?.session !== currentSession) return 0;
+  let currentBranch = options.currentBranch;
+  if (currentBranch === undefined) {
+    try {
+      currentBranch = execFileSync("git", ["-C", repositoryDir, "branch", "--show-current"], { encoding: "utf8" }).trim();
+    } catch {
+      return 0;
+    }
+  }
+  if (grant.worker?.branch !== currentBranch) return 0;
+  if (grant.capabilities.some((item) => {
+    if (item?.risk?.grantable !== true || !PATTERN_CAPABLE_PERMISSIONS.has(item?.permission || "")) return true;
+    if (!Array.isArray(item.patterns) || item.patterns.length === 0 || item.patterns.length > 20) return true;
+    return item.patterns.some((pattern) => typeof pattern !== "string" || pattern.length === 0 || pattern.length > 500
+      || FORBIDDEN_GRANT_PATTERN.test(pattern) || UNBOUNDED_GRANT_PATTERN.test(pattern));
+  })) return 0;
+  let count = addApprovedCapabilityRules(config, grant.capabilities);
+  for (const agent of Object.values(config.agent || {})) {
+    count += addApprovedCapabilityRules(agent, grant.capabilities);
   }
   return count;
 }
@@ -365,6 +477,7 @@ function logConfigSummary(counts) {
     [counts.mcps, "MCPs"],
     [counts.agentTools, "agent tool perms"],
     [counts.directories, "managed directory perms"],
+    [counts.permissionGrants, "signed worker permission grants"],
     [counts.poolCleaned, `cleaned ${counts.poolCleaned} stale pool provider${counts.poolCleaned === 1 ? "" : "s"}`],
     [counts.anthropic, "anthropic models"],
     [counts.openai, "OpenAI context limits"],
@@ -393,11 +506,11 @@ function logVersionDriftAsync(pluginDir) {
 
 /**
  * Create the config hook function.
- * @param {object} deps - { agentsDir, workspaceDir, pluginDir }
+ * @param {object} deps - { agentsDir, workspaceDir, pluginDir, repositoryDir }
  * @returns {Function} Config hook
  */
 export function createConfigHook(deps) {
-  const { agentsDir, workspaceDir, pluginDir } = deps;
+  const { agentsDir, workspaceDir, pluginDir, repositoryDir } = deps;
 
   /**
    * Modify OpenCode config to register aidevops subagents, MCP servers,
@@ -413,6 +526,7 @@ export function createConfigHook(deps) {
     const mcps = registerMcpServers(config);
     const agentTools = applyAgentMcpTools(config);
     const directories = registerManagedDirectoryPermissions(config);
+    const permissionGrants = registerApprovedWorkerPermissions(config, { repositoryDir });
     const poolCleaned = registerPoolProvider(config);
     const anthropic = registerAnthropicModels(config);
     const openai = registerGpt56ContextLimits(config);
@@ -450,7 +564,7 @@ export function createConfigHook(deps) {
     const claude = registerClaudeCliModels(config);
 
     logConfigSummary(
-      { agents, mcps, agentTools, directories, poolCleaned, anthropic, openai, cursor, google, claude },
+      { agents, mcps, agentTools, directories, permissionGrants, poolCleaned, anthropic, openai, cursor, google, claude },
     );
     logVersionDriftAsync(pluginDir);
   };

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -201,6 +201,12 @@ function currentWorkerBranch(options, repositoryDir) {
   }
 }
 
+function permissionGrantBranchMatches(grantBranch, currentBranch) {
+  if (typeof currentBranch !== "string" || currentBranch.length === 0) return false;
+  if (typeof grantBranch !== "string" || grantBranch.length === 0) return false;
+  return grantBranch === currentBranch;
+}
+
 function permissionGrantWorkerMatches(grant, options) {
   const pendingRequest = String(options.pendingRequest || process.env.AIDEVOPS_PERMISSION_REQUEST_ID || "");
   if (!pendingRequest || grant.request_id !== pendingRequest) return false;
@@ -211,9 +217,7 @@ function permissionGrantWorkerMatches(grant, options) {
   const currentSession = String(options.currentSession || process.env.WORKER_SESSION_KEY || "");
   if (!currentSession || grant.worker?.session !== currentSession) return false;
   const currentBranch = currentWorkerBranch(options, repositoryDir);
-  if (typeof currentBranch !== "string" || currentBranch.length === 0) return false;
-  if (typeof grant.worker?.branch !== "string" || grant.worker.branch.length === 0) return false;
-  return grant.worker.branch === currentBranch;
+  return permissionGrantBranchMatches(grant.worker?.branch, currentBranch);
 }
 
 function permissionGrantPatternSafe(pattern) {

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -226,6 +226,7 @@ export async function AidevopsPlugin({ directory, client }) {
     agentsDir: AGENTS_DIR,
     workspaceDir: WORKSPACE_DIR,
     pluginDir: PLUGIN_DIR,
+    repositoryDir: directory,
   });
 
   const continuationGuard = createSessionContinuationGuard({

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -41,6 +41,7 @@ import { createSessionTitleSuffixHandler } from "./session-title-suffix.mjs";
 import { installPluginConsoleRouter } from "./plugin-console.mjs";
 import { createSubagentEffortHooks, loadTierReasoningPolicies } from "./subagent-effort.mjs";
 import { createSessionContinuationGuard } from "./session-continuation-guard.mjs";
+import { createPermissionBroker } from "./permission-broker.mjs";
 
 // Existing modules
 import { createTools } from "./tools.mjs";
@@ -249,6 +250,7 @@ export async function AidevopsPlugin({ directory, client }) {
   ]);
   const subagentEffortHooks = createSubagentEffortHooks(client, { tierReasoning });
   const shouldInjectGreeting = createSessionStartGreetingGate(client, isHeadless);
+  const permissionBroker = createPermissionBroker({ client, isHeadless });
 
   // TTSR hooks
   const {
@@ -363,7 +365,10 @@ export async function AidevopsPlugin({ directory, client }) {
     "chat.params": subagentEffortHooks.chatParams,
 
     // Quality hooks
-    "tool.execute.before": toolExecuteBefore,
+    "tool.execute.before": async (input, output) => {
+      permissionBroker.recordToolCall(input, output);
+      return toolExecuteBefore(input, output);
+    },
     "tool.execute.after": toolExecuteAfter,
 
     // Shell environment
@@ -380,11 +385,16 @@ export async function AidevopsPlugin({ directory, client }) {
       // Fire both in parallel — neither depends on the other's result.
       await Promise.all([
         handleEvent(input),
+        permissionBroker.handleEvent(input).catch((err) => debugEventError("permission broker", err)),
         sessionTitleSuffixHandler(input).catch((err) => debugEventError("title suffix handler", err)),
         sessionTitleFallbackHandler(input).catch((err) => debugEventError("title fallback handler", err)),
         greetingHandler(input).catch((err) => debugEventError("greeting handler", err)),
       ]);
     },
+
+    // Legacy OpenCode compatibility. Current runtimes publish
+    // `permission.asked` through the event hook instead.
+    "permission.ask": permissionBroker.permissionAsk,
 
     // OAuth multi-account pool + provider auth
     auth: (() => {

--- a/.agents/plugins/opencode-aidevops/permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker.mjs
@@ -34,25 +34,23 @@ export function sanitizePermissionText(value, options = {}) {
 
 function classifyRisk(permission, patterns, tool) {
   const combined = patterns.join("\n");
+  let risk;
   if (!PATTERN_CAPABLE_PERMISSIONS.has(permission)) {
-    return { level: "critical", grantable: false, reason: "permission cannot be represented as an exact OpenCode pattern rule" };
+    risk = { level: "critical", grantable: false, reason: "permission cannot be represented as an exact OpenCode pattern rule" };
+  } else if (patterns.length === 0) {
+    risk = { level: "critical", grantable: false, reason: "request omitted an exact permission pattern" };
+  } else if (patterns.some((pattern) => FORBIDDEN_PATTERN.test(pattern))) {
+    risk = { level: "critical", grantable: false, reason: "sensitive credential or signing-key location" };
+  } else if (["bash", "edit", "write"].includes(tool) || ["bash", "edit"].includes(permission)) {
+    risk = { level: "high", grantable: true, reason: "capability can modify or execute content" };
+  } else if (HIGH_RISK_PATTERN.test(combined)) {
+    risk = { level: "high", grantable: true, reason: "shared runtime or OpenCode configuration path" };
+  } else if (permission === "external_directory") {
+    risk = { level: "medium", grantable: true, reason: "access crosses the worker project boundary" };
+  } else {
+    risk = { level: "low", grantable: true, reason: "bounded non-destructive capability" };
   }
-  if (patterns.length === 0) {
-    return { level: "critical", grantable: false, reason: "request omitted an exact permission pattern" };
-  }
-  if (patterns.some((pattern) => FORBIDDEN_PATTERN.test(pattern))) {
-    return { level: "critical", grantable: false, reason: "sensitive credential or signing-key location" };
-  }
-  if (["bash", "edit", "write"].includes(tool) || ["bash", "edit"].includes(permission)) {
-    return { level: "high", grantable: true, reason: "capability can modify or execute content" };
-  }
-  if (HIGH_RISK_PATTERN.test(combined)) {
-    return { level: "high", grantable: true, reason: "shared runtime or OpenCode configuration path" };
-  }
-  if (permission === "external_directory") {
-    return { level: "medium", grantable: true, reason: "access crosses the worker project boundary" };
-  }
-  return { level: "low", grantable: true, reason: "bounded non-destructive capability" };
+  return risk;
 }
 
 function stableRequestID(request) {
@@ -92,87 +90,89 @@ function normalizePatterns(input, options) {
     .filter(Boolean))].slice(0, 20);
 }
 
+function recordPermissionToolCall(toolCalls, isHeadless, home, input, output) {
+  if (!isHeadless()) return;
+  const callID = input?.callID || input?.callId;
+  if (!callID) return;
+  const args = output?.args || input?.args || {};
+  toolCalls.set(callID, {
+    tool: sanitizePermissionText(input?.tool || input?.name || "unknown", { home, maxLength: 100 }),
+    intent: sanitizePermissionText(args?.agent__intent || "", { home, maxLength: MAX_INTENT_LENGTH }),
+  });
+  while (toolCalls.size > 100) toolCalls.delete(toolCalls.keys().next().value);
+}
+
+function capturePermissionRequest(toolCalls, home, raw) {
+  const requestFile = process.env.AIDEVOPS_PERMISSION_REQUEST_FILE || "";
+  if (!requestFile) return null;
+  const callID = raw?.tool?.callID || raw?.callID || "";
+  const toolContext = toolCalls.get(callID) || {};
+  const options = { home, workDir: process.env.WORKER_WORKTREE_PATH || "" };
+  const permission = sanitizePermissionText(raw?.permission || raw?.type || "unknown", { ...options, maxLength: 100 });
+  const patterns = normalizePatterns(raw?.patterns ?? raw?.pattern, options);
+  const tool = sanitizePermissionText(toolContext.tool || raw?.metadata?.tool || permission, { ...options, maxLength: 100 });
+  const request = {
+    request_id: "",
+    permission,
+    patterns,
+    tool,
+    intent: sanitizePermissionText(toolContext.intent || raw?.metadata?.description || raw?.title || "", { ...options, maxLength: MAX_INTENT_LENGTH }),
+    risk: classifyRisk(permission, patterns, tool),
+    opencode: {
+      request_id: sanitizePermissionText(raw?.id || "", { ...options, maxLength: 100 }),
+      session_id: sanitizePermissionText(raw?.sessionID || "", { ...options, maxLength: 100 }),
+      message_id: sanitizePermissionText(raw?.tool?.messageID || raw?.messageID || "", { ...options, maxLength: 100 }),
+      call_id: sanitizePermissionText(callID, { ...options, maxLength: 100 }),
+    },
+    captured_at: new Date().toISOString(),
+  };
+  const capture = readCaptureFile(requestFile) || {
+    schema: REQUEST_SCHEMA,
+    issue: sanitizePermissionText(process.env.WORKER_ISSUE_NUMBER || "", { ...options, maxLength: 30 }),
+    repo: sanitizePermissionText(process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "", { ...options, maxLength: 200 }),
+    worker_session: sanitizePermissionText(process.env.WORKER_SESSION_KEY || "", { ...options, maxLength: 200 }),
+    requests: [],
+  };
+  request.request_id = stableRequestID({ ...request, issue: capture.issue, repo: capture.repo });
+  const existingIndex = capture.requests.findIndex((item) => item.request_id === request.request_id);
+  if (existingIndex >= 0) capture.requests[existingIndex] = request;
+  else capture.requests.push(request);
+  capture.requests = capture.requests.slice(-MAX_REQUESTS);
+  writeCaptureFile(requestFile, capture);
+  return request;
+}
+
+async function rejectPermissionRequest(client, request) {
+  if (!request?.id || !request?.sessionID) return;
+  try {
+    await client.postSessionIdPermissionsPermissionId({
+      path: { id: request.sessionID, permissionID: request.id },
+      body: { response: "reject" },
+    });
+  } catch {
+    // `opencode run` may have already rejected the same request.
+  }
+}
+
+async function handlePermissionEvent(client, isHeadless, toolCalls, home, input) {
+  const event = input?.event;
+  if (!isHeadless() || event?.type !== "permission.asked") return;
+  const request = event.properties || {};
+  capturePermissionRequest(toolCalls, home, request);
+  await rejectPermissionRequest(client, request);
+}
+
+function handlePermissionAsk(isHeadless, toolCalls, home, input, output) {
+  if (!isHeadless()) return;
+  capturePermissionRequest(toolCalls, home, input || {});
+  output.status = "deny";
+}
+
 export function createPermissionBroker({ client, isHeadless, home = homedir() }) {
   const toolCalls = new Map();
-
-  function recordToolCall(input, output) {
-    if (!isHeadless()) return;
-    const callID = input?.callID || input?.callId;
-    if (!callID) return;
-    const args = output?.args || input?.args || {};
-    toolCalls.set(callID, {
-      tool: sanitizePermissionText(input?.tool || input?.name || "unknown", { home, maxLength: 100 }),
-      intent: sanitizePermissionText(args?.agent__intent || "", { home, maxLength: MAX_INTENT_LENGTH }),
-    });
-    while (toolCalls.size > 100) toolCalls.delete(toolCalls.keys().next().value);
-  }
-
-  function captureRequest(raw) {
-    const requestFile = process.env.AIDEVOPS_PERMISSION_REQUEST_FILE || "";
-    if (!requestFile) return null;
-    const callID = raw?.tool?.callID || raw?.callID || "";
-    const toolContext = toolCalls.get(callID) || {};
-    const options = { home, workDir: process.env.WORKER_WORKTREE_PATH || "" };
-    const permission = sanitizePermissionText(raw?.permission || raw?.type || "unknown", { ...options, maxLength: 100 });
-    const patterns = normalizePatterns(raw?.patterns ?? raw?.pattern, options);
-    const tool = sanitizePermissionText(toolContext.tool || raw?.metadata?.tool || permission, { ...options, maxLength: 100 });
-    const risk = classifyRisk(permission, patterns, tool);
-    const request = {
-      request_id: "",
-      permission,
-      patterns,
-      tool,
-      intent: sanitizePermissionText(toolContext.intent || raw?.metadata?.description || raw?.title || "", { ...options, maxLength: MAX_INTENT_LENGTH }),
-      risk,
-      opencode: {
-        request_id: sanitizePermissionText(raw?.id || "", { ...options, maxLength: 100 }),
-        session_id: sanitizePermissionText(raw?.sessionID || "", { ...options, maxLength: 100 }),
-        message_id: sanitizePermissionText(raw?.tool?.messageID || raw?.messageID || "", { ...options, maxLength: 100 }),
-        call_id: sanitizePermissionText(callID, { ...options, maxLength: 100 }),
-      },
-      captured_at: new Date().toISOString(),
-    };
-    const capture = readCaptureFile(requestFile) || {
-      schema: REQUEST_SCHEMA,
-      issue: sanitizePermissionText(process.env.WORKER_ISSUE_NUMBER || "", { ...options, maxLength: 30 }),
-      repo: sanitizePermissionText(process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "", { ...options, maxLength: 200 }),
-      worker_session: sanitizePermissionText(process.env.WORKER_SESSION_KEY || "", { ...options, maxLength: 200 }),
-      requests: [],
-    };
-    request.request_id = stableRequestID({ ...request, issue: capture.issue, repo: capture.repo });
-    const existingIndex = capture.requests.findIndex((item) => item.request_id === request.request_id);
-    if (existingIndex >= 0) capture.requests[existingIndex] = request;
-    else capture.requests.push(request);
-    capture.requests = capture.requests.slice(-MAX_REQUESTS);
-    writeCaptureFile(requestFile, capture);
-    return request;
-  }
-
-  async function replyReject(request) {
-    if (!request?.id || !request?.sessionID) return;
-    try {
-      await client.postSessionIdPermissionsPermissionId({
-        path: { id: request.sessionID, permissionID: request.id },
-        body: { response: "reject" },
-      });
-    } catch {
-      // `opencode run` may have already rejected the same request.
-    }
-  }
-
-  async function handleEvent(input) {
-    const event = input?.event;
-    if (!isHeadless() || event?.type !== "permission.asked") return;
-    const request = event.properties || {};
-    captureRequest(request);
-    await replyReject(request);
-  }
-
-  async function permissionAsk(input, output) {
-    if (!isHeadless()) return;
-    captureRequest(input || {});
-    output.status = "deny";
-  }
-
-  return { recordToolCall, handleEvent, permissionAsk };
+  return {
+    recordToolCall: (input, output) => recordPermissionToolCall(toolCalls, isHeadless, home, input, output),
+    handleEvent: (input) => handlePermissionEvent(client, isHeadless, toolCalls, home, input),
+    permissionAsk: (input, output) => handlePermissionAsk(isHeadless, toolCalls, home, input, output),
+  };
 }

--- a/.agents/plugins/opencode-aidevops/permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker.mjs
@@ -10,7 +10,8 @@ const REQUEST_SCHEMA = "aidevops-permission-capture/v1";
 const MAX_PATTERN_LENGTH = 500;
 const MAX_INTENT_LENGTH = 500;
 const MAX_REQUESTS = 20;
-const FORBIDDEN_PATTERN = /(?:approval-keys\/private|\/(?:\.ssh|\.gnupg)(?:\/|$)|auth\.json(?:$|\*)|credentials?(?:\.|\/|$)|(?:^|\/)\.env(?:\.|$|\/))/i;
+const PATTERN_CAPABLE_PERMISSIONS = new Set(["bash", "external_directory"]);
+const FORBIDDEN_PATTERN = /(?:approval-keys\/private|\/(?:\.ssh|\.gnupg|\.aws|\.azure|\.kube)(?:\/|$)|\/(?:\.config\/(?:gh|gcloud|glab-cli|hub)|\.docker)(?:\/|$)|\/(?:\.netrc|\.npmrc|\.pypirc|\.git-credentials)(?:$|\*)|auth\.json(?:$|\*)|credentials?(?:\.|\/|$)|(?:^|\/)\.env(?:\.|$|\/))/i;
 const HIGH_RISK_PATTERN = /(?:\.config\/opencode|node_modules\/@opencode-ai\/plugin|(?:^|\/)\.git(?:\/|$))/i;
 
 function redactSecrets(value) {
@@ -25,6 +26,7 @@ export function sanitizePermissionText(value, options = {}) {
   const workDir = options.workDir || process.env.WORKER_WORKTREE_PATH || "";
   let sanitized = value.replace(/[\u0000-\u001f\u007f]/g, " ").trim();
   sanitized = redactSecrets(sanitized);
+  sanitized = sanitized.replace(/~~~/g, "~ ~ ~");
   if (home && sanitized.includes(home)) sanitized = sanitized.split(home).join("~");
   if (workDir && sanitized.includes(workDir)) sanitized = sanitized.split(workDir).join("$WORKTREE");
   return sanitized.slice(0, options.maxLength || MAX_PATTERN_LENGTH);
@@ -32,6 +34,12 @@ export function sanitizePermissionText(value, options = {}) {
 
 function classifyRisk(permission, patterns, tool) {
   const combined = patterns.join("\n");
+  if (!PATTERN_CAPABLE_PERMISSIONS.has(permission)) {
+    return { level: "critical", grantable: false, reason: "permission cannot be represented as an exact OpenCode pattern rule" };
+  }
+  if (patterns.length === 0) {
+    return { level: "critical", grantable: false, reason: "request omitted an exact permission pattern" };
+  }
   if (patterns.some((pattern) => FORBIDDEN_PATTERN.test(pattern))) {
     return { level: "critical", grantable: false, reason: "sensitive credential or signing-key location" };
   }

--- a/.agents/plugins/opencode-aidevops/permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker.mjs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import { createHash } from "crypto";
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { dirname } from "path";
 import { homedir } from "os";
 
@@ -76,11 +76,23 @@ function readCaptureFile(path) {
 }
 
 function writeCaptureFile(path, capture) {
-  if (!path) return;
-  mkdirSync(dirname(path), { recursive: true });
-  const temporary = `${path}.${process.pid}.tmp`;
-  writeFileSync(temporary, `${JSON.stringify(capture, null, 2)}\n`, { mode: 0o600 });
-  renameSync(temporary, path);
+  let written = false;
+  if (path) {
+    const temporary = `${path}.${process.pid}.tmp`;
+    try {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(temporary, `${JSON.stringify(capture, null, 2)}\n`, { mode: 0o600 });
+      renameSync(temporary, path);
+      written = true;
+    } catch {
+      try {
+        rmSync(temporary, { force: true });
+      } catch {
+        // Capturing is best effort and must not crash the runtime.
+      }
+    }
+  }
+  return written;
 }
 
 function normalizePatterns(input, options) {

--- a/.agents/plugins/opencode-aidevops/permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker.mjs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { createHash } from "crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { dirname } from "path";
+import { homedir } from "os";
+
+const REQUEST_SCHEMA = "aidevops-permission-capture/v1";
+const MAX_PATTERN_LENGTH = 500;
+const MAX_INTENT_LENGTH = 500;
+const MAX_REQUESTS = 20;
+const FORBIDDEN_PATTERN = /(?:approval-keys\/private|\/(?:\.ssh|\.gnupg)(?:\/|$)|auth\.json(?:$|\*)|credentials?(?:\.|\/|$)|(?:^|\/)\.env(?:\.|$|\/))/i;
+const HIGH_RISK_PATTERN = /(?:\.config\/opencode|node_modules\/@opencode-ai\/plugin|(?:^|\/)\.git(?:\/|$))/i;
+
+function redactSecrets(value) {
+  return value
+    .replace(/((?:api[_-]?key|token|secret|password|authorization)\s*[:=]\s*)[^\s,;]+/gi, "$1[REDACTED]")
+    .replace(/\b(?:sk|ghp|github_pat|sntryu)_[A-Za-z0-9_-]{12,}\b/g, "[REDACTED]");
+}
+
+export function sanitizePermissionText(value, options = {}) {
+  if (typeof value !== "string") return "";
+  const home = options.home || homedir();
+  const workDir = options.workDir || process.env.WORKER_WORKTREE_PATH || "";
+  let sanitized = value.replace(/[\u0000-\u001f\u007f]/g, " ").trim();
+  sanitized = redactSecrets(sanitized);
+  if (home && sanitized.includes(home)) sanitized = sanitized.split(home).join("~");
+  if (workDir && sanitized.includes(workDir)) sanitized = sanitized.split(workDir).join("$WORKTREE");
+  return sanitized.slice(0, options.maxLength || MAX_PATTERN_LENGTH);
+}
+
+function classifyRisk(permission, patterns, tool) {
+  const combined = patterns.join("\n");
+  if (patterns.some((pattern) => FORBIDDEN_PATTERN.test(pattern))) {
+    return { level: "critical", grantable: false, reason: "sensitive credential or signing-key location" };
+  }
+  if (["bash", "edit", "write"].includes(tool) || ["bash", "edit"].includes(permission)) {
+    return { level: "high", grantable: true, reason: "capability can modify or execute content" };
+  }
+  if (HIGH_RISK_PATTERN.test(combined)) {
+    return { level: "high", grantable: true, reason: "shared runtime or OpenCode configuration path" };
+  }
+  if (permission === "external_directory") {
+    return { level: "medium", grantable: true, reason: "access crosses the worker project boundary" };
+  }
+  return { level: "low", grantable: true, reason: "bounded non-destructive capability" };
+}
+
+function stableRequestID(request) {
+  const canonical = JSON.stringify({
+    issue: request.issue,
+    repo: request.repo,
+    permission: request.permission,
+    patterns: [...request.patterns].sort(),
+    tool: request.tool,
+    intent: request.intent,
+  });
+  return `perm-${createHash("sha256").update(canonical).digest("hex").slice(0, 16)}`;
+}
+
+function readCaptureFile(path) {
+  if (!path || !existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return parsed?.schema === REQUEST_SCHEMA ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCaptureFile(path, capture) {
+  if (!path) return;
+  mkdirSync(dirname(path), { recursive: true });
+  const temporary = `${path}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(capture, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, path);
+}
+
+function normalizePatterns(input, options) {
+  const source = Array.isArray(input) ? input : input == null ? [] : [input];
+  return [...new Set(source
+    .map((value) => sanitizePermissionText(String(value), options))
+    .filter(Boolean))].slice(0, 20);
+}
+
+export function createPermissionBroker({ client, isHeadless, home = homedir() }) {
+  const toolCalls = new Map();
+
+  function recordToolCall(input, output) {
+    if (!isHeadless()) return;
+    const callID = input?.callID || input?.callId;
+    if (!callID) return;
+    const args = output?.args || input?.args || {};
+    toolCalls.set(callID, {
+      tool: sanitizePermissionText(input?.tool || input?.name || "unknown", { home, maxLength: 100 }),
+      intent: sanitizePermissionText(args?.agent__intent || "", { home, maxLength: MAX_INTENT_LENGTH }),
+    });
+    while (toolCalls.size > 100) toolCalls.delete(toolCalls.keys().next().value);
+  }
+
+  function captureRequest(raw) {
+    const requestFile = process.env.AIDEVOPS_PERMISSION_REQUEST_FILE || "";
+    if (!requestFile) return null;
+    const callID = raw?.tool?.callID || raw?.callID || "";
+    const toolContext = toolCalls.get(callID) || {};
+    const options = { home, workDir: process.env.WORKER_WORKTREE_PATH || "" };
+    const permission = sanitizePermissionText(raw?.permission || raw?.type || "unknown", { ...options, maxLength: 100 });
+    const patterns = normalizePatterns(raw?.patterns ?? raw?.pattern, options);
+    const tool = sanitizePermissionText(toolContext.tool || raw?.metadata?.tool || permission, { ...options, maxLength: 100 });
+    const risk = classifyRisk(permission, patterns, tool);
+    const request = {
+      request_id: "",
+      permission,
+      patterns,
+      tool,
+      intent: sanitizePermissionText(toolContext.intent || raw?.metadata?.description || raw?.title || "", { ...options, maxLength: MAX_INTENT_LENGTH }),
+      risk,
+      opencode: {
+        request_id: sanitizePermissionText(raw?.id || "", { ...options, maxLength: 100 }),
+        session_id: sanitizePermissionText(raw?.sessionID || "", { ...options, maxLength: 100 }),
+        message_id: sanitizePermissionText(raw?.tool?.messageID || raw?.messageID || "", { ...options, maxLength: 100 }),
+        call_id: sanitizePermissionText(callID, { ...options, maxLength: 100 }),
+      },
+      captured_at: new Date().toISOString(),
+    };
+    const capture = readCaptureFile(requestFile) || {
+      schema: REQUEST_SCHEMA,
+      issue: sanitizePermissionText(process.env.WORKER_ISSUE_NUMBER || "", { ...options, maxLength: 30 }),
+      repo: sanitizePermissionText(process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "", { ...options, maxLength: 200 }),
+      worker_session: sanitizePermissionText(process.env.WORKER_SESSION_KEY || "", { ...options, maxLength: 200 }),
+      requests: [],
+    };
+    request.request_id = stableRequestID({ ...request, issue: capture.issue, repo: capture.repo });
+    const existingIndex = capture.requests.findIndex((item) => item.request_id === request.request_id);
+    if (existingIndex >= 0) capture.requests[existingIndex] = request;
+    else capture.requests.push(request);
+    capture.requests = capture.requests.slice(-MAX_REQUESTS);
+    writeCaptureFile(requestFile, capture);
+    return request;
+  }
+
+  async function replyReject(request) {
+    if (!request?.id || !request?.sessionID) return;
+    try {
+      await client.postSessionIdPermissionsPermissionId({
+        path: { id: request.sessionID, permissionID: request.id },
+        body: { response: "reject" },
+      });
+    } catch {
+      // `opencode run` may have already rejected the same request.
+    }
+  }
+
+  async function handleEvent(input) {
+    const event = input?.event;
+    if (!isHeadless() || event?.type !== "permission.asked") return;
+    const request = event.properties || {};
+    captureRequest(request);
+    await replyReject(request);
+  }
+
+  async function permissionAsk(input, output) {
+    if (!isHeadless()) return;
+    captureRequest(input || {});
+    output.status = "deny";
+  }
+
+  return { recordToolCall, handleEvent, permissionAsk };
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { createPermissionBroker, sanitizePermissionText } from "../permission-broker.mjs";
+
+test("headless permission event is sanitized, persisted, and rejected", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
+  const requestFile = join(root, "request.json");
+  const previous = process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
+  process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
+  process.env.WORKER_ISSUE_NUMBER = "123";
+  process.env.WORKER_REPO_SLUG = "owner/repo";
+  const replies = [];
+  const broker = createPermissionBroker({
+    client: { postSessionIdPermissionsPermissionId: async (value) => replies.push(value) },
+    isHeadless: () => true,
+    home: "/Users/example",
+  });
+  broker.recordToolCall(
+    { tool: "read", callID: "call-1" },
+    { args: { agent__intent: "Reading SDK declarations token=secret-value" } },
+  );
+  await broker.handleEvent({ event: { type: "permission.asked", properties: {
+    id: "permission-1",
+    sessionID: "session-1",
+    permission: "external_directory",
+    patterns: ["/Users/example/.cache/opencode/node_modules/@opencode-ai/sdk/**"],
+    tool: { callID: "call-1", messageID: "message-1" },
+  } } });
+  const capture = JSON.parse(readFileSync(requestFile, "utf8"));
+  assert.equal(capture.issue, "123");
+  assert.equal(capture.requests[0].tool, "read");
+  assert.match(capture.requests[0].patterns[0], /^~\//);
+  assert.doesNotMatch(capture.requests[0].intent, /secret-value/);
+  assert.equal(replies[0].body.response, "reject");
+  if (previous === undefined) delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
+  else process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = previous;
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("sensitive locations are non-grantable", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
+  const requestFile = join(root, "request.json");
+  process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
+  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example" });
+  const output = { status: "ask" };
+  await broker.permissionAsk({
+    id: "permission-2",
+    type: "external_directory",
+    pattern: "/Users/example/.ssh/**",
+  }, output);
+  const capture = JSON.parse(readFileSync(requestFile, "utf8"));
+  assert.equal(output.status, "deny");
+  assert.equal(capture.requests[0].risk.grantable, false);
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
+});
+
+test("sanitizer normalizes home and redacts credential-like values", () => {
+  const value = sanitizePermissionText("/Users/example/file token=abc123", { home: "/Users/example" });
+  assert.equal(value, "~/file token=[REDACTED]");
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
@@ -62,6 +62,33 @@ test("sensitive locations are non-grantable", async () => {
   delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
 });
 
+test("requests without an exact pattern are non-grantable", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
+  const requestFile = join(root, "request.json");
+  process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
+  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example" });
+  const output = { status: "ask" };
+  await broker.permissionAsk({ id: "permission-3", type: "bash", patterns: [] }, output);
+  const capture = JSON.parse(readFileSync(requestFile, "utf8"));
+  assert.equal(capture.requests[0].risk.grantable, false);
+  assert.match(capture.requests[0].risk.reason, /exact permission pattern/);
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
+});
+
+test("action-only permissions are non-grantable", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
+  const requestFile = join(root, "request.json");
+  process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
+  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example" });
+  await broker.permissionAsk({ id: "permission-4", type: "webfetch", patterns: ["example.invalid"] }, { status: "ask" });
+  const capture = JSON.parse(readFileSync(requestFile, "utf8"));
+  assert.equal(capture.requests[0].risk.grantable, false);
+  assert.match(capture.requests[0].risk.reason, /exact OpenCode pattern rule/);
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
+});
+
 test("sanitizer normalizes home and redacts credential-like values", () => {
   const value = sanitizePermissionText("/Users/example/file token=abc123", { home: "/Users/example" });
   assert.equal(value, "~/file token=[REDACTED]");

--- a/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
@@ -3,7 +3,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -85,6 +85,19 @@ test("action-only permissions are non-grantable", async () => {
   const capture = JSON.parse(readFileSync(requestFile, "utf8"));
   assert.equal(capture.requests[0].risk.grantable, false);
   assert.match(capture.requests[0].risk.reason, /exact OpenCode pattern rule/);
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
+});
+
+test("capture write failure still denies the permission without crashing", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
+  const blocker = join(root, "not-a-directory");
+  writeFileSync(blocker, "block");
+  process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = join(blocker, "request.json");
+  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example" });
+  const output = { status: "ask" };
+  await broker.permissionAsk({ id: "permission-5", type: "bash", patterns: ["git status"] }, output);
+  assert.equal(output.status, "deny");
   rmSync(root, { recursive: true, force: true });
   delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-worker-permission-grant.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-worker-permission-grant.mjs
@@ -20,7 +20,11 @@ function signedGrant(root, options = {}) {
     target: { kind: "issue", repository: "owner/repo", number: 123 },
     request_id: "perm-0123456789abcdef",
     request_sha256: "a".repeat(64),
-    worker: { session: "issue-123", branch: "feature/auto-gh123", worktree_sha256: createHash("sha256").update(root).digest("hex") },
+    worker: {
+      session: "issue-123",
+      branch: options.branch === undefined ? "feature/auto-gh123" : options.branch,
+      worktree_sha256: createHash("sha256").update(root).digest("hex"),
+    },
     capabilities: [{
       permission: options.permission || "external_directory",
       patterns: [options.pattern || "~/.cache/opencode/node_modules/@opencode-ai/sdk/**"],
@@ -104,6 +108,24 @@ test("grant cannot be replayed from a different worktree", () => {
     pendingRequest: "perm-0123456789abcdef",
   }), 0);
   assert.equal(differentSessionConfig.permission, undefined);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("branch lookup failure cannot match a null grant branch", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-grant-"));
+  const grant = signedGrant(root, { branch: null });
+  process.env.WORKER_ISSUE_NUMBER = "123";
+  process.env.WORKER_REPO_SLUG = "owner/repo";
+  const config = { agent: {} };
+  assert.equal(registerApprovedWorkerPermissions(config, {
+    grantPath: grant.grantPath,
+    publicKey: grant.publicKey,
+    tempBase: root,
+    repositoryDir: root,
+    currentSession: "issue-123",
+    pendingRequest: "perm-0123456789abcdef",
+  }), 0);
+  assert.equal(config.permission, undefined);
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-worker-permission-grant.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-worker-permission-grant.mjs
@@ -129,6 +129,27 @@ test("branch lookup failure cannot match a null grant branch", () => {
   rmSync(root, { recursive: true, force: true });
 });
 
+test("signature verification temp failure ignores the grant without crashing", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-grant-"));
+  const grant = signedGrant(root);
+  const blocker = join(root, "not-a-directory");
+  writeFileSync(blocker, "block");
+  process.env.WORKER_ISSUE_NUMBER = "123";
+  process.env.WORKER_REPO_SLUG = "owner/repo";
+  const config = { agent: {} };
+  assert.equal(registerApprovedWorkerPermissions(config, {
+    grantPath: grant.grantPath,
+    publicKey: grant.publicKey,
+    tempBase: join(blocker, "verification"),
+    repositoryDir: root,
+    currentSession: "issue-123",
+    currentBranch: "feature/auto-gh123",
+    pendingRequest: "perm-0123456789abcdef",
+  }), 0);
+  assert.equal(config.permission, undefined);
+  rmSync(root, { recursive: true, force: true });
+});
+
 for (const [name, options] of [
   ["sensitive signed grant", { pattern: "~/.ssh/**" }],
   ["unbounded signed grant", { pattern: "**" }],

--- a/.agents/plugins/opencode-aidevops/tests/test-worker-permission-grant.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-worker-permission-grant.mjs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "child_process";
+import { createHash } from "crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { registerApprovedWorkerPermissions } from "../config-hook.mjs";
+
+function signedGrant(root, options = {}) {
+  const key = join(root, "approval.key");
+  execFileSync("ssh-keygen", ["-t", "ed25519", "-N", "", "-q", "-f", key]);
+  const payload = JSON.stringify({
+    schema: "aidevops-permission-grant/v1",
+    authority: "worker-permissions",
+    target: { kind: "issue", repository: "owner/repo", number: 123 },
+    request_id: "perm-0123456789abcdef",
+    request_sha256: "a".repeat(64),
+    worker: { session: "issue-123", branch: "feature/auto-gh123", worktree_sha256: createHash("sha256").update(root).digest("hex") },
+    capabilities: [{
+      permission: options.permission || "external_directory",
+      patterns: [options.pattern || "~/.cache/opencode/node_modules/@opencode-ai/sdk/**"],
+      tool: "read",
+      intent: "Inspect generated SDK declarations",
+      risk: { level: "medium", grantable: true, reason: "external directory" },
+    }],
+    issued_at: options.issuedAt || new Date().toISOString(),
+    expires_at: options.expiresAt || new Date(Date.now() + 60_000).toISOString(),
+  });
+  const signed = spawnSync("ssh-keygen", ["-Y", "sign", "-f", key, "-n", "aidevops-approve", "-q", "-"], {
+    input: payload,
+    encoding: "utf8",
+  });
+  assert.equal(signed.status, 0, signed.stderr);
+  const grantPath = join(root, "grant.json");
+  writeFileSync(grantPath, JSON.stringify({ payload, signature: signed.stdout }));
+  return { grantPath, publicKey: `${key}.pub` };
+}
+
+test("verified unexpired grant adds exact rules globally and per agent", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-grant-"));
+  const grant = signedGrant(root);
+  const old = { issue: process.env.WORKER_ISSUE_NUMBER, repo: process.env.WORKER_REPO_SLUG };
+  process.env.WORKER_ISSUE_NUMBER = "123";
+  process.env.WORKER_REPO_SLUG = "owner/repo";
+  process.env.WORKER_SESSION_KEY = "issue-123";
+  const config = { agent: { review: { permission: { read: "allow" } } } };
+  assert.equal(registerApprovedWorkerPermissions(config, {
+    grantPath: grant.grantPath, publicKey: grant.publicKey, tempBase: root, repositoryDir: root,
+    currentSession: "issue-123", currentBranch: "feature/auto-gh123", pendingRequest: "perm-0123456789abcdef",
+  }), 2);
+  const pattern = "~/.cache/opencode/node_modules/@opencode-ai/sdk/**";
+  assert.equal(config.permission.external_directory[pattern], "allow");
+  assert.equal(config.agent.review.permission.external_directory[pattern], "allow");
+  for (const [key, value] of Object.entries({ WORKER_ISSUE_NUMBER: old.issue, WORKER_REPO_SLUG: old.repo })) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("expired grant is ignored even with a valid signature", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-grant-"));
+  const grant = signedGrant(root, { expiresAt: new Date(Date.now() - 60_000).toISOString() });
+  process.env.WORKER_ISSUE_NUMBER = "123";
+  process.env.WORKER_REPO_SLUG = "owner/repo";
+  const config = { agent: {} };
+  assert.equal(registerApprovedWorkerPermissions(config, {
+    grantPath: grant.grantPath, publicKey: grant.publicKey, tempBase: root, repositoryDir: root,
+    currentSession: "issue-123", currentBranch: "feature/auto-gh123", pendingRequest: "perm-0123456789abcdef",
+  }), 0);
+  assert.equal(config.permission, undefined);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("grant cannot be replayed from a different worktree", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-grant-"));
+  const grant = signedGrant(root);
+  process.env.WORKER_ISSUE_NUMBER = "123";
+  process.env.WORKER_REPO_SLUG = "owner/repo";
+  const config = { agent: {} };
+  assert.equal(registerApprovedWorkerPermissions(config, {
+    grantPath: grant.grantPath,
+    publicKey: grant.publicKey,
+    tempBase: root,
+    repositoryDir: join(root, "different-worktree"),
+    currentSession: "issue-123",
+    currentBranch: "feature/auto-gh123",
+    pendingRequest: "perm-0123456789abcdef",
+  }), 0);
+  assert.equal(config.permission, undefined);
+  const differentSessionConfig = { agent: {} };
+  assert.equal(registerApprovedWorkerPermissions(differentSessionConfig, {
+    grantPath: grant.grantPath,
+    publicKey: grant.publicKey,
+    tempBase: root,
+    repositoryDir: root,
+    currentSession: "issue-999",
+    currentBranch: "feature/auto-gh123",
+    pendingRequest: "perm-0123456789abcdef",
+  }), 0);
+  assert.equal(differentSessionConfig.permission, undefined);
+  rmSync(root, { recursive: true, force: true });
+});
+
+for (const [name, options] of [
+  ["sensitive signed grant", { pattern: "~/.ssh/**" }],
+  ["unbounded signed grant", { pattern: "**" }],
+  ["action-only signed grant", { permission: "webfetch", pattern: "example.invalid" }],
+  ["grant longer than four hours", {
+    issuedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString(),
+  }],
+]) {
+  test(`${name} is ignored`, () => {
+    const root = mkdtempSync(join(tmpdir(), "aidevops-worker-grant-"));
+    const grant = signedGrant(root, options);
+    process.env.WORKER_ISSUE_NUMBER = "123";
+    process.env.WORKER_REPO_SLUG = "owner/repo";
+    const config = { agent: {} };
+    assert.equal(registerApprovedWorkerPermissions(config, {
+      grantPath: grant.grantPath, publicKey: grant.publicKey, tempBase: root, repositoryDir: root,
+      currentSession: "issue-123", currentBranch: "feature/auto-gh123", pendingRequest: "perm-0123456789abcdef",
+    }), 0);
+    assert.equal(config.permission, undefined);
+    rmSync(root, { recursive: true, force: true });
+  });
+}

--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -19,6 +19,7 @@ Applied to GitHub issues. The pulse checks these before spawning a worker.
 | `no-auto-dispatch` | `dispatch-dedup-helper.sh` `_is_assigned_check_no_auto_dispatch` (t2832), `issue-sync-lib.sh`, `interactive-session-helper.sh` lockdown | Canonical manual hold for issues. Blocks dispatch path (`NO_AUTO_DISPATCH_BLOCKED` signal), enrich path, and decomposer path. Applied by `interactive-session-helper.sh lockdown`. Pre-fix (before t2832) the label was honoured by enrichment/decomposition only — workers got dispatched anyway. |
 | `hold-for-review` | `dispatch-dedup-helper.sh` `_is_assigned_check_hold_for_review`, `issue-sync-lib.sh`; PR merge checks below | Manual review hold. On issues, same dispatch-block intent as `no-auto-dispatch` (`HOLD_FOR_REVIEW_BLOCKED` signal). On PRs, blocks auto-merge until a maintainer removes the label. |
 | `needs-maintainer-review` | `pulse-nmr-approval.sh` `auto_approve_maintainer_issues` | Requires maintainer cryptographic approval (`sudo aidevops approve issue <N>`) before dispatch. |
+| `needs-maintainer-permissions` | `worker-permission-helper.sh`, `dispatch-dedup-helper.sh`, `pulse-dispatch-core.sh`, candidate filters | Worker paused after requesting a capability outside its sandbox. Only the request-specific signed permission command clears this label; dispatch also verifies historical applications against the matching unexpired grant, so removing the label alone cannot bypass the hold. It is distinct from scope/trust approval. |
 | `needs-credentials` | `label-sync-helper.sh` SYSTEM_LABELS | Task requires credentials, API keys, or account access — cannot be completed by a headless worker autonomously. Add when the TODO entry has `#no-auto-dispatch` due to credential dependency. |
 | `persistent` | `pulse-issue-reconcile.sh` | Monitoring/tracking issue — must not be dispatched as a code task. |
 | `supervisor` | `pulse-issue-reconcile.sh` | Supervisor health dashboard — pulse-managed, not a dispatch target. |
@@ -26,6 +27,8 @@ Applied to GitHub issues. The pulse checks these before spawning a worker.
 | `quality-review` | `pulse-issue-reconcile.sh` | Daily quality review tracker — pulse-managed. |
 | `routine-tracking` | `pulse-issue-reconcile.sh` | Routine execution tracking — pulse skips these unconditionally. |
 | `status:blocked` | `dispatch-dedup-helper.sh` `_has_active_claim` | Blocked on incomplete dependent tasks (`blocked-by:` edges). |
+
+Permission grants are limited to exact-pattern `bash` and `external_directory` requests, bound to the issue, request digest, worker session, branch, and worktree hash, and expire after four hours. Action-only permissions and credential-bearing or unbounded paths remain non-grantable.
 
 ### Conditional Dispatch Blocks (require active claim state)
 

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -917,7 +917,10 @@ _trusted_permission_comments_json() {
 	local pages="$1"
 	jq -c --arg array_type "$PERMISSION_JSON_ARRAY_TYPE" '
 		(if type == $array_type and all(.[]; type == $array_type) then [.[][]?] else [.[]?] end)
-		| [ .[] | select((.author_association // "") | IN("OWNER", "MEMBER", "COLLABORATOR")) ]
+		| [ .[] | select(
+			(.author_association // "") as $association
+			| ["OWNER", "MEMBER", "COLLABORATOR"] | index($association) != null
+		) ]
 	' <<<"$pages"
 	return $?
 }
@@ -976,7 +979,7 @@ _validate_permission_request_json() {
 		and (.worker.worktree_sha256 | type == $string_type and test($sha_pattern))
 		and (.capabilities | type == $array_type and length > 0 and length <= 20)
 		and all(.capabilities[];
-			(.permission | IN("bash", "external_directory"))
+			(.permission as $permission | ["bash", "external_directory"] | index($permission) != null)
 			and (.patterns | type == $array_type and length > 0 and length <= 20)
 			and all(.patterns[]; type == $string_type and length <= 500)
 			and .risk.grantable == true

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -74,9 +74,24 @@ readonly APPROVAL_KEY="$APPROVAL_PRIVATE_DIR/approval.key"
 readonly APPROVAL_PUB="$APPROVAL_DIR/approval.pub"
 readonly APPROVAL_NAMESPACE="aidevops-approve"
 readonly APPROVAL_MARKER="<!-- aidevops-signed-approval -->"
+readonly PERMISSION_REQUEST_MARKER="<!-- aidevops-permission-request -->"
+readonly PERMISSION_GRANT_MARKER="<!-- aidevops-signed-permission-grant -->"
+readonly PERMISSION_REQUEST_SCHEMA="aidevops-permission-request/v1"
+readonly PERMISSION_GRANT_SCHEMA="aidevops-permission-grant/v1"
+readonly PERMISSION_SHA256_PATTERN='^[0-9a-f]{64}$'
+readonly PERMISSION_JSON_ARRAY_TYPE="array"
+readonly PERMISSION_JSON_STRING_TYPE="string"
+readonly _APPROVAL_AUTO_DISPATCH_LABEL="auto-dispatch"
 
 # shellcheck source=approval-snapshot-v2.sh
 source "${SCRIPT_DIR}/approval-snapshot-v2.sh"
+
+_permission_comments_endpoint() {
+	local slug="$1"
+	local target_number="$2"
+	printf 'repos/%s/issues/%s/comments?per_page=100' "$slug" "$target_number"
+	return 0
+}
 
 # Detect repo slug from current directory or repos.json
 _detect_slug() {
@@ -550,7 +565,7 @@ _approval_verify_issue_state() {
 		_print_error "Approval state verification failed: needs-maintainer-review is still present on #$target_number"
 		return 1
 	fi
-	if ! printf '%s' "$issue_json" | jq -e '(.labels // []) | any(.name == "auto-dispatch")' >/dev/null 2>&1; then
+	if ! printf '%s' "$issue_json" | jq -e --arg label "$_APPROVAL_AUTO_DISPATCH_LABEL" '(.labels // []) | any(.name == $label)' >/dev/null 2>&1; then
 		_print_error "Approval state verification failed: auto-dispatch is missing on #$target_number"
 		return 1
 	fi
@@ -581,7 +596,7 @@ _approval_apply_issue_lifecycle_updates() {
 
 	edit_err=$(gh_issue_edit_safe "$target_number" --repo "$slug" \
 		--remove-label "needs-maintainer-review" \
-		--add-label "auto-dispatch" \
+		--add-label "$_APPROVAL_AUTO_DISPATCH_LABEL" \
 		--add-assignee "$gh_user" 2>&1 >/dev/null) || {
 		_print_error "Failed to update approval labels/assignee on issue #$target_number"
 		[[ -n "$edit_err" ]] && _print_error "$edit_err"
@@ -859,6 +874,340 @@ _extract_fenced_block() {
 	return 0
 }
 
+_extract_tilde_fenced_block() {
+	local body="$1"
+	printf '%s\n' "$body" | awk '
+		/^~~~/ {
+			if (inside) { exit }
+			inside = 1
+			next
+		}
+		inside { print }
+	'
+	return 0
+}
+
+_permission_request_digest() {
+	local request_json="$1"
+	local canonical_file
+	canonical_file=$(mktemp)
+	jq -cS 'del(.request_id, .request_sha256)' <<<"$request_json" >"$canonical_file" || {
+		rm -f "$canonical_file"
+		return 1
+	}
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$canonical_file" | awk '{print $1}'
+	else
+		sha256sum "$canonical_file" | awk '{print $1}'
+	fi
+	rm -f "$canonical_file"
+	return 0
+}
+
+_permission_grant_expiry() {
+	if date -u -v+4H +%Y-%m-%dT%H:%M:%SZ >/dev/null 2>&1; then
+		date -u -v+4H +%Y-%m-%dT%H:%M:%SZ
+	else
+		date -u -d '+4 hours' +%Y-%m-%dT%H:%M:%SZ
+	fi
+	return 0
+}
+
+_trusted_permission_comments_json() {
+	local pages="$1"
+	jq -c --arg array_type "$PERMISSION_JSON_ARRAY_TYPE" '
+		(if type == $array_type and all(.[]; type == $array_type) then [.[][]?] else [.[]?] end)
+		| [ .[] | select((.author_association // "") | IN("OWNER", "MEMBER", "COLLABORATOR")) ]
+	' <<<"$pages"
+	return $?
+}
+
+_fetch_permission_request_json() {
+	local target_number="$1"
+	local slug="$2"
+	local request_id="$3"
+	local pages comments body endpoint
+	endpoint=$(_permission_comments_endpoint "$slug" "$target_number")
+	pages=$(gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
+	comments=$(_trusted_permission_comments_json "$pages") || return 1
+	body=$(jq -r --arg marker "$PERMISSION_REQUEST_MARKER" --arg request "$request_id" '
+		[.[] | select((.body // "") | contains($marker) and contains($request))]
+		| sort_by(.id) | last | .body // ""
+	' <<<"$comments") || return 1
+	[[ -n "$body" ]] || return 1
+	_extract_tilde_fenced_block "$body"
+	return 0
+}
+
+_fetch_latest_permission_request_json() {
+	local target_number="$1"
+	local slug="$2"
+	local pages comments body endpoint
+	endpoint=$(_permission_comments_endpoint "$slug" "$target_number")
+	pages=$(gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
+	comments=$(_trusted_permission_comments_json "$pages") || return 1
+	body=$(jq -r --arg marker "$PERMISSION_REQUEST_MARKER" '
+		[.[] | select((.body // "") | contains($marker))]
+		| sort_by(.id) | last | .body // ""
+	' <<<"$comments") || return 1
+	[[ -n "$body" ]] || return 1
+	_extract_tilde_fenced_block "$body"
+	return 0
+}
+
+_validate_permission_request_json() {
+	local request_json="$1"
+	local target_type="$2"
+	local target_number="$3"
+	local slug="$4"
+	local request_id="$5"
+	local normalized_slug digest expected_digest
+	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
+	jq -e --arg schema "$PERMISSION_REQUEST_SCHEMA" --arg type "$target_type" \
+		--arg number "$target_number" --arg repo "$normalized_slug" --arg request "$request_id" \
+		--arg sha_pattern "$PERMISSION_SHA256_PATTERN" --arg array_type "$PERMISSION_JSON_ARRAY_TYPE" \
+		--arg string_type "$PERMISSION_JSON_STRING_TYPE" '
+		.schema == $schema
+		and .target.kind == $type
+		and (.target.number | tostring) == $number
+		and .target.repository == $repo
+		and .request_id == $request
+		and (.request_sha256 | type == $string_type and test($sha_pattern))
+		and (.worker.worktree_sha256 | type == $string_type and test($sha_pattern))
+		and (.capabilities | type == $array_type and length > 0 and length <= 20)
+		and all(.capabilities[];
+			(.permission | IN("bash", "external_directory"))
+			and (.patterns | type == $array_type and length > 0 and length <= 20)
+			and all(.patterns[]; type == $string_type and length <= 500)
+			and .risk.grantable == true
+			and all(.patterns[]?;
+				(test("(?i)(approval-keys/private|/(\\.ssh|\\.gnupg|\\.aws|\\.azure|\\.kube)(/|$)|/(\\.config/(gh|gcloud|glab-cli|hub)|\\.docker)(/|$)|/(\\.netrc|\\.npmrc|\\.pypirc|\\.git-credentials)($|\\*)|auth\\.json($|\\*)|credentials?([./]|$)|(^|/)\\.env([./]|$))") | not)
+				and (test("^(\\*|\\*\\*|/\\*\\*|~/\\*\\*|\\$WORKTREE/\\*\\*)$") | not)
+			)
+		)
+	' <<<"$request_json" >/dev/null || return 1
+	digest=$(_permission_request_digest "$request_json") || return 1
+	expected_digest=$(jq -r '.request_sha256' <<<"$request_json")
+	[[ "$digest" == "$expected_digest" ]] || return 1
+	[[ "$request_id" == "perm-${digest:0:16}" ]] || return 1
+	return 0
+}
+
+_permission_request_is_latest() {
+	local request_json="$1"
+	local target_number="$2"
+	local slug="$3"
+	local latest_json latest_id latest_digest expected_id expected_digest
+	latest_json=$(_fetch_latest_permission_request_json "$target_number" "$slug") || return 1
+	latest_id=$(jq -r '.request_id // ""' \
+		<<<"$latest_json")
+	latest_digest=$(jq -r '.request_sha256 // ""' \
+		<<<"$latest_json")
+	expected_id=$(jq -r '.request_id // ""' \
+		<<<"$request_json")
+	expected_digest=$(jq -r '.request_sha256 // ""' \
+		<<<"$request_json")
+	[[ "$latest_id" == "$expected_id" && "$latest_digest" == "$expected_digest" ]]
+	return $?
+}
+
+_confirm_permission_approval() {
+	local request_json="$1"
+	local target_type="$2"
+	local target_number="$3"
+	local slug="$4"
+	echo ""
+	echo "Approving scoped worker permissions:"
+	echo "  Target:  ${target_type} #${target_number}"
+	echo "  Repo:    ${slug}"
+	echo "  Request: $(jq -r '.request_id' <<<"$request_json")"
+	echo "  Session: $(jq -r '.worker.session' <<<"$request_json")"
+	echo "  Branch:  $(jq -r '.worker.branch' <<<"$request_json")"
+	echo "  Worktree binding: $(jq -r '.worker.worktree_sha256[0:16]' <<<"$request_json")..."
+	echo "  Expires: 4 hours after signing"
+	echo ""
+	jq -r '.capabilities[] | "  - [" + (.risk.level | ascii_upcase) + "] " + .permission + " via " + .tool + ": " + (if (.patterns | length) == 0 then "(no pattern)" else (.patterns | join(", ")) end)' <<<"$request_json"
+	echo ""
+	printf "Type APPROVE to confirm these exact capabilities: "
+	local confirmation=""
+	read -r confirmation
+	[[ "$confirmation" == "APPROVE" ]] || {
+		_print_error "Permission approval cancelled"
+		return 1
+	}
+	return 0
+}
+
+_build_permission_grant_comment() {
+	local payload="$1"
+	local sig_file="$2"
+	local signature
+	signature=$(<"$sig_file")
+	cat <<EOF
+${PERMISSION_GRANT_MARKER}
+## Worker permission grant (cryptographically signed)
+
+\`\`\`
+${payload}
+\`\`\`
+
+\`\`\`
+${signature}
+\`\`\`
+
+This grant authorizes only the embedded capabilities, target, request digest, and expiry. It does not approve issue scope or merge/release.
+EOF
+	return 0
+}
+
+_permission_grant_path() {
+	local slug="$1"
+	local target_number="$2"
+	local safe_slug
+	safe_slug=$(printf '%s' "$slug" | tr '/:' '__')
+	printf '%s/.aidevops/permission-grants/%s/%s.json' "$_APPROVAL_HOME" "$safe_slug" "$target_number"
+	return 0
+}
+
+_write_local_permission_grant() {
+	local payload="$1"
+	local sig_file="$2"
+	local slug="$3"
+	local target_number="$4"
+	local grant_path grant_tmp real_user
+	grant_path=$(_permission_grant_path "$slug" "$target_number")
+	grant_tmp=$(mktemp)
+	real_user=$(_approval_real_user)
+	jq -n --arg payload "$payload" --rawfile signature "$sig_file" \
+		'{payload: $payload, signature: $signature}' >"$grant_tmp"
+	mkdir -p "$(dirname "$grant_path")"
+	install -m 600 "$grant_tmp" "$grant_path"
+	chown "$real_user" "$grant_path" 2>/dev/null || true
+	rm -f "$grant_tmp"
+	return 0
+}
+
+_apply_permission_approval_state() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+	local request_json="$4"
+	if [[ "$target_type" == "issue" ]]; then
+		local issue_json labels_csv resume_auto
+		issue_json=$(gh_issue_view "$target_number" --repo "$slug" --json labels 2>/dev/null) || return 1
+		labels_csv=$(jq -r '(.labels // []) | map(.name) | join(",")' <<<"$issue_json") || return 1
+		resume_auto=$(jq -r '.context.resume_auto_dispatch == true' <<<"$request_json") || return 1
+		local -a edit_args=(--remove-label "needs-maintainer-permissions")
+		if [[ ",${labels_csv}," != *",status:blocked,"* ]]; then
+			edit_args+=(--add-label "status:available")
+		fi
+		if [[ "$resume_auto" == "true" ]]; then
+			edit_args+=(--add-label "$_APPROVAL_AUTO_DISPATCH_LABEL")
+		fi
+		gh_issue_edit_safe "$target_number" --repo "$slug" "${edit_args[@]}" >/dev/null || return 1
+	else
+		gh pr edit "$target_number" --repo "$slug" --remove-label "needs-maintainer-permissions" >/dev/null || return 1
+	fi
+	return 0
+}
+
+_kick_pulse_after_permission_approval() {
+	local pulse_wrapper="${_APPROVAL_HOME}/.aidevops/agents/scripts/pulse-wrapper.sh"
+	local kick_log="${_APPROVAL_HOME}/.aidevops/logs/pulse-approve-kick.log"
+	[[ -x "$pulse_wrapper" ]] || return 0
+	mkdir -p "$(dirname "$kick_log")" 2>/dev/null || true
+	if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]] && command -v sudo >/dev/null 2>&1; then
+		(
+			nohup sudo -u "$SUDO_USER" -H -- "$pulse_wrapper" >>"$kick_log" 2>&1 </dev/null &
+			disown 2>/dev/null || true
+		) 2>/dev/null
+	else
+		(
+			nohup "$pulse_wrapper" >>"$kick_log" 2>&1 </dev/null &
+			disown 2>/dev/null || true
+		) 2>/dev/null
+	fi
+	return 0
+}
+
+cmd_permissions() {
+	local target_type="${1:-}"
+	local target_number="${2:-}"
+	shift 2 2>/dev/null || true
+	local slug="" request_id=""
+	if [[ $# -gt 0 && "$1" != --* ]]; then
+		slug="$1"
+		shift
+	fi
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--request) request_id="${2:-}"; shift 2 ;;
+		*) _print_error "Unknown permissions option: $arg"; return 1 ;;
+		esac
+	done
+	local usage="Usage: sudo aidevops approve permissions issue|pr <number> [owner/repo] --request perm-<id>"
+	[[ "$target_type" == "issue" || "$target_type" == "pr" ]] || { _print_error "$usage"; return 1; }
+	_require_number_arg "$target_number" "$target_type" "$usage" || return 1
+	[[ "$request_id" =~ ^perm-[0-9a-f]{16}$ ]] || { _print_error "$usage"; return 1; }
+	_require_interactive_root "$usage" || return 1
+	local actual_key
+	actual_key=$(_approval_private_key_path)
+	_require_approval_key "$actual_key" || return 1
+	_require_gh_auth || return 1
+	slug=$(_resolve_slug_or_fail "$slug" "$usage") || return 1
+	_validate_approval_target_kind "$target_type" "$target_number" "$slug" || return 1
+	local request_json
+	request_json=$(_fetch_permission_request_json "$target_number" "$slug" "$request_id") || {
+		_print_error "Could not find permission request ${request_id} on ${target_type} #${target_number}"
+		return 1
+	}
+	_validate_permission_request_json "$request_json" "$target_type" "$target_number" "$slug" "$request_id" || {
+		_print_error "Permission request is malformed, changed, or contains a non-grantable sensitive capability"
+		return 1
+	}
+	_confirm_permission_approval "$request_json" "$target_type" "$target_number" "$slug" || return 1
+	_permission_request_is_latest "$request_json" "$target_number" "$slug" || {
+		_print_error "A newer permission request appeared while approval was pending; review and approve the latest request instead"
+		return 1
+	}
+	local issued_at expires_at payload sig_file comment_body
+	issued_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	expires_at=$(_permission_grant_expiry)
+	payload=$(jq -cS --arg schema "$PERMISSION_GRANT_SCHEMA" --arg issued "$issued_at" --arg expires "$expires_at" '
+		{
+			schema: $schema,
+			authority: "worker-permissions",
+			target,
+			request_id,
+			request_sha256,
+			worker,
+			capabilities,
+			issued_at: $issued,
+			expires_at: $expires
+		}
+	' <<<"$request_json") || return 1
+	sig_file=$(mktemp)
+	_sign_approval_payload "$payload" "$actual_key" "$sig_file" || { rm -f "$sig_file"; return 1; }
+	comment_body=$(_build_permission_grant_comment "$payload" "$sig_file")
+	if [[ "$target_type" == "issue" ]]; then
+		gh_issue_comment "$target_number" --repo "$slug" --body "$comment_body" || { rm -f "$sig_file"; return 1; }
+	else
+		gh_pr_comment "$target_number" --repo "$slug" --body "$comment_body" || { rm -f "$sig_file"; return 1; }
+	fi
+	_permission_request_is_latest "$request_json" "$target_number" "$slug" || {
+		rm -f "$sig_file"
+		_print_error "Permission grant was posted, but the request is no longer latest; dispatch remains blocked"
+		return 1
+	}
+	_write_local_permission_grant "$payload" "$sig_file" "$slug" "$target_number" || { rm -f "$sig_file"; return 1; }
+	rm -f "$sig_file"
+	_apply_permission_approval_state "$target_type" "$target_number" "$slug" "$request_json" || return 1
+	_kick_pulse_after_permission_approval
+	_print_ok "Scoped permissions ${request_id} approved for ${target_type} #${target_number} until ${expires_at}"
+	return 0
+}
+
 _create_allowed_signers_file() {
 	local pub_key="$1"
 	local allowed_signers_file="$2"
@@ -931,13 +1280,14 @@ _approval_classify_signed_comment() {
 		return 0
 	fi
 
-	if ! jq -e --arg type "$target_type" --arg repo "$normalized_slug" --arg number "$target_number" '
+	if ! jq -e --arg type "$target_type" --arg repo "$normalized_slug" --arg number "$target_number" \
+		--arg sha_pattern "$PERMISSION_SHA256_PATTERN" --arg string_type "$PERMISSION_JSON_STRING_TYPE" '
 		.schema == "aidevops-approval/v2"
 		and .target.kind == $type
 		and .target.repository == $repo
 		and (.target.number | tostring) == $number
-		and (.snapshot_sha256 | type == "string" and test("^[0-9a-f]{64}$"))
-		and (.issued_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+		and (.snapshot_sha256 | type == $string_type and test($sha_pattern))
+		and (.issued_at | type == $string_type and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
 		and (if $type == "pr" then (.authority == "merge" and (.pr | type == "object")) else (.authority == "development" and .pr == null) end)
 	' <<<"$payload" >/dev/null 2>&1; then
 		printf 'MALFORMED_APPROVAL\n'
@@ -1131,6 +1481,84 @@ _approval_classify_marked_comments() {
 	return 5
 }
 
+_fetch_latest_permission_grant_body() {
+	local target_number="$1"
+	local slug="$2"
+	local request_id="$3"
+	local pages comments endpoint
+	endpoint=$(_permission_comments_endpoint "$slug" "$target_number")
+	pages=$(gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
+	comments=$(_trusted_permission_comments_json "$pages") || return 1
+	jq -r --arg marker "$PERMISSION_GRANT_MARKER" --arg request "$request_id" '
+		[.[] | select((.body // "") | contains($marker) and contains($request))]
+		| sort_by(.id) | last | .body // ""
+	' <<<"$comments"
+	return $?
+}
+
+_permission_grant_time_valid() {
+	local payload="$1"
+	python3 - "$payload" <<'PY'
+import datetime as dt
+import json
+import sys
+
+try:
+    payload = json.loads(sys.argv[1])
+    issued = dt.datetime.fromisoformat(payload["issued_at"].replace("Z", "+00:00"))
+    expires = dt.datetime.fromisoformat(payload["expires_at"].replace("Z", "+00:00"))
+    now = dt.datetime.now(dt.timezone.utc)
+except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+    raise SystemExit(1)
+valid = issued <= now + dt.timedelta(minutes=5) and expires > now and expires > issued
+valid = valid and expires - issued <= dt.timedelta(hours=4)
+raise SystemExit(0 if valid else 1)
+PY
+	return $?
+}
+
+_validate_permission_grant_payload() {
+	local payload="$1"
+	local request_json="$2"
+	jq -e --argjson request "$request_json" '
+		.schema == "aidevops-permission-grant/v1"
+		and .authority == "worker-permissions"
+		and .target == $request.target
+		and .request_id == $request.request_id
+		and .request_sha256 == $request.request_sha256
+		and .worker == $request.worker
+		and .capabilities == $request.capabilities
+	' <<<"$payload" >/dev/null || return 1
+	_permission_grant_time_valid "$payload"
+	return $?
+}
+
+cmd_verify_permissions() {
+	local target_type="${1:-}"
+	local target_number="${2:-}"
+	local slug="${3:-}"
+	local usage="Usage: aidevops approve verify-permissions issue|pr <number> [owner/repo]"
+	[[ "$target_type" == "issue" || "$target_type" == "pr" ]] || { printf 'MALFORMED_APPROVAL\n'; return 5; }
+	_require_number_arg "$target_number" "$target_type" "$usage" >/dev/null 2>&1 || { printf 'MALFORMED_APPROVAL\n'; return 5; }
+	slug=$(_resolve_slug_or_fail "$slug" "$usage") || { printf 'API_ERROR\n'; return 6; }
+	local request_json request_id grant_body payload
+	request_json=$(_fetch_latest_permission_request_json "$target_number" "$slug") || { printf 'NO_REQUEST\n'; return 1; }
+	request_id=$(jq -r '.request_id // ""' \
+		<<<"$request_json")
+	_validate_permission_request_json "$request_json" "$target_type" "$target_number" "$slug" "$request_id" || {
+		printf 'MALFORMED_REQUEST\n'
+		return 5
+	}
+	grant_body=$(_fetch_latest_permission_grant_body "$target_number" "$slug" "$request_id") || { printf 'API_ERROR\n'; return 6; }
+	[[ -n "$grant_body" ]] || { printf 'NO_APPROVAL\n'; return 1; }
+	[[ -f "$APPROVAL_PUB" ]] || { printf 'NO_KEY\n'; return 2; }
+	_verify_comment_signature "$grant_body" "$APPROVAL_PUB" || { printf 'MALFORMED_APPROVAL\n'; return 5; }
+	payload=$(_extract_fenced_block "$grant_body" 1)
+	_validate_permission_grant_payload "$payload" "$request_json" || { printf 'STALE_APPROVAL\n'; return 4; }
+	printf 'VERIFIED\n'
+	return 0
+}
+
 # Verify a V2 approval against the current immutable issue/PR snapshot.
 # Legacy syntax (`verify N slug`) remains an issue verification request, but V1
 # signatures return LEGACY_APPROVAL and never authorize an external merge.
@@ -1168,13 +1596,14 @@ cmd_verify() {
 	_require_number_arg "$target_number" "$target_type" "Usage: aidevops approve verify [issue|pr] <number> [owner/repo] [--expect-head SHA]" || return 5
 	slug=$(_resolve_slug_or_fail "$slug" "Could not detect repo slug") || return 1
 
-	local comment_pages="" comments_json=""
-	comment_pages=$(gh api "repos/${slug}/issues/${target_number}/comments?per_page=100" --paginate --slurp 2>/dev/null) || {
+	local comment_pages="" comments_json="" endpoint=""
+	endpoint=$(_permission_comments_endpoint "$slug" "$target_number")
+	comment_pages=$(gh api "$endpoint" --paginate --slurp 2>/dev/null) || {
 		printf 'API_ERROR\n'
 		return 6
 	}
-	comments_json=$(jq -c --arg marker "$APPROVAL_MARKER" '
-		(if type == "array" and all(.[]; type == "array") then [.[][]?] else [.[]?] end)
+	comments_json=$(jq -c --arg marker "$APPROVAL_MARKER" --arg array_type "$PERMISSION_JSON_ARRAY_TYPE" '
+		(if type == $array_type and all(.[]; type == $array_type) then [.[][]?] else [.[]?] end)
 		| [ .[] | select((.body // "") | contains($marker)) ]
 		| sort_by(.id)
 	' <<<"$comment_pages" 2>/dev/null) || {
@@ -1252,15 +1681,18 @@ cmd_help() {
 	echo "  setup                      Generate root-protected approval key pair"
 	echo "  issue <number> [slug]      Approve an issue"
 	echo "  pr <number> [slug]         Approve a PR"
+	echo "  permissions issue|pr <number> [slug] --request perm-<id>"
 	echo ""
 	echo "Commands (no sudo needed):"
 	echo "  verify [issue|pr] <number> [slug] [--expect-head SHA]"
+	echo "  verify-permissions issue|pr <number> [slug]"
 	echo "  status                     Show approval key setup status"
 	echo "  help                       Show this help"
 	echo ""
 	echo "Examples:"
 	echo "  sudo aidevops approve setup"
 	echo "  sudo aidevops approve issue 17438 <owner/repo>"
+	echo "  sudo aidevops approve permissions issue 17438 <owner/repo> --request perm-0123456789abcdef"
 	echo "  aidevops approve verify 17438"
 	echo "  aidevops approve verify pr 17439 <owner/repo> --expect-head <sha>"
 	echo ""
@@ -1279,6 +1711,8 @@ main() {
 	setup) cmd_setup "$@" ;;
 	issue | issue-approved) cmd_issue_approved "$@" ;;
 	pr | pr-approved) cmd_pr_approved "$@" ;;
+	permissions) cmd_permissions "$@" ;;
+	verify-permissions) cmd_verify_permissions "$@" ;;
 	verify) cmd_verify "$@" ;;
 	status) cmd_status "$@" ;;
 	help | --help | -h) cmd_help ;;
@@ -1290,4 +1724,6 @@ main() {
 	esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -942,6 +942,16 @@ _is_assigned_check_no_auto_dispatch() {
 		"no-auto-dispatch" "NO_AUTO_DISPATCH_BLOCKED" "no-auto-dispatch-check"
 }
 
+_is_assigned_check_maintainer_permissions() {
+	local meta_json="$1"
+	local issue_number="${2:-unknown}"
+	local repo_slug="${3:-unknown}"
+	#aidevops:trust-boundary -- only the request-specific signed grant flow may
+	# clear this unconditional worker-dispatch hold.
+	_is_assigned_check_label_block "$meta_json" "$issue_number" "$repo_slug" \
+		"needs-maintainer-permissions" "MAINTAINER_PERMISSIONS_BLOCKED" "maintainer-permissions-check"
+}
+
 #######################################
 # is_assigned helper: check the infrastructure unconditional block.
 #
@@ -1797,6 +1807,9 @@ _is_assigned_pre_assignee_guard_blocks() {
 	if _is_assigned_check_no_auto_dispatch "$issue_meta_json" "$issue_number" "$repo_slug"; then
 		return 0
 	fi
+	if _is_assigned_check_maintainer_permissions "$issue_meta_json" "$issue_number" "$repo_slug"; then
+		return 0
+	fi
 
 	# Advisory/review/cooldown/cost/hydration gates short-circuit before assignees.
 	if _is_assigned_check_infrastructure "$issue_meta_json" "$issue_number" "$repo_slug"; then
@@ -1987,21 +2000,28 @@ enumerate_blockers() {
 		_found=true
 	fi
 
-	# Check 3: infrastructure advisory/operator block.
+	# Check 3: request-specific signed worker permission hold.
+	_blocker_out=$(_is_assigned_check_maintainer_permissions "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
+	if [[ -n "$_blocker_out" ]]; then
+		printf '%s\n' "$_blocker_out"
+		_found=true
+	fi
+
+	# Check 4: infrastructure advisory/operator block.
 	_blocker_out=$(_is_assigned_check_infrastructure "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"
 		_found=true
 	fi
 
-	# Check 4: hold-for-review unconditional maintainer hold.
+	# Check 5: hold-for-review unconditional maintainer hold.
 	_blocker_out=$(_is_assigned_check_hold_for_review "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"
 		_found=true
 	fi
 
-	# Check 5: t3197 dispatch cooldown after no_worker_process launch failure.
+	# Check 6: t3197 dispatch cooldown after no_worker_process launch failure.
 	_blocker_out=$(_is_assigned_check_dispatch_cooldown "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -65,8 +65,10 @@ _DSI_WORKTREE_HELPER="${_DSI_SCRIPT_DIR}/worktree-helper.sh"
 _DSI_DEDUP_HELPER="${_DSI_SCRIPT_DIR}/dispatch-dedup-helper.sh"
 _DSI_VALIDATOR_HELPER="${_DSI_SCRIPT_DIR}/pre-dispatch-validator-helper.sh"
 _DSI_BACKOFF_HELPER="${_DSI_SCRIPT_DIR}/dispatch-backoff-helper.sh"
+_DSI_APPROVAL_HELPER="${_DSI_SCRIPT_DIR}/approval-helper.sh"
 _DSI_DISPATCH_BASE_BRANCH=""
 _DSI_STATE_RECOVERING="recovering"
+_DSI_UNKNOWN_VALUE="<unknown>"
 _DSI_CLAIM_WON=0
 _DSI_CLAIM_COMMENT_ID=""
 
@@ -174,7 +176,8 @@ _dsi_target_is_pull_request() {
 #######################################
 _dsi_guard_no_interactive_hold() {
 	local labels_csv="$1"
-	local labels_with_commas=",${labels_csv},"
+	local labels_with_commas=""
+	labels_with_commas=$(printf ',%s,' "$labels_csv")
 	if [[ "$labels_with_commas" == *",status:in-review,"* && "$labels_with_commas" != *",auto-dispatch,"* ]]; then
 		_dsi_err "Target carries an interactive review hold label; refusing worker dispatch (GH#22948)"
 		return 1
@@ -206,6 +209,47 @@ _dsi_guard_no_maintainer_review_required() {
 	fi
 
 	return 0
+}
+
+_dsi_guard_no_maintainer_permission_required() {
+	local labels_csv="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	local labels_with_commas=""
+	labels_with_commas=$(printf ',%s,' "$labels_csv")
+	if [[ "$labels_with_commas" == *",needs-maintainer-permissions,"* ]]; then
+		_dsi_err "Issue #${issue_number} in ${repo_slug} is waiting for a scoped maintainer permission grant; refusing manual worker dispatch"
+		_dsi_info "  Run the request-specific 'sudo aidevops approve permissions ... --request perm-...' command from the issue comment."
+		return 1
+	fi
+	return 0
+}
+
+_dsi_guard_permission_history_verified() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local events_json labeled_count verification
+	events_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/events?per_page=100" --paginate --slurp 2>/dev/null) || {
+		_dsi_err "Unable to inspect permission-request history for issue #${issue_number} in ${repo_slug}; refusing manual worker dispatch"
+		return 1
+	}
+	labeled_count=$(jq '[.[][]? | select(.event == "labeled" and .label.name == "needs-maintainer-permissions")] | length' <<<"$events_json" 2>/dev/null) || {
+		_dsi_err "Permission-request history for issue #${issue_number} in ${repo_slug} is malformed; refusing manual worker dispatch"
+		return 1
+	}
+	[[ "$labeled_count" -gt 0 ]] || return 0
+	[[ -x "$_DSI_APPROVAL_HELPER" ]] || {
+		_dsi_err "Permission verification helper is unavailable; refusing manual worker dispatch"
+		return 1
+	}
+	verification=$("$_DSI_APPROVAL_HELPER" verify-permissions issue "$issue_number" "$repo_slug" 2>/dev/null) || true
+	if [[ "$verification" == "VERIFIED" ]]; then
+		_dsi_err "Issue #${issue_number} in ${repo_slug} has a signed grant bound to its original worker session and worktree; a new manual worker cannot consume it"
+		_dsi_info "  Resume through the original pulse/worker path so the bound pending request can be loaded safely."
+		return 1
+	fi
+	_dsi_err "Issue #${issue_number} in ${repo_slug} has permission-request history without a current matching signed grant (${verification:-NO_APPROVAL}); refusing manual worker dispatch"
+	return 1
 }
 
 #######################################
@@ -595,7 +639,7 @@ _dsi_find_log_for_pid() {
 			return 0
 		fi
 	done
-	printf '%s\n' "<unknown>"
+	printf '%s\n' "$_DSI_UNKNOWN_VALUE"
 	return 0
 }
 
@@ -625,7 +669,7 @@ _dsi_find_live_dispatch() {
 		if [[ -n "$target_worktree" && "$worktree_path" == "$target_worktree" ]]; then
 			log_path=$(_dsi_find_log_for_pid "$issue_number" "$pid")
 			session_key=$(printf '%s' "$cmd" | sed -n 's/.*--session-key[[:space:]]\([^[:space:]]*\).*/\1/p' | head -1)
-			printf 'process\t%s\t%s\t%s\t%s\n' "$pid" "$log_path" "$worktree_path" "${session_key:-<unknown>}"
+			printf 'process\t%s\t%s\t%s\t%s\n' "$pid" "$log_path" "$worktree_path" "${session_key:-$_DSI_UNKNOWN_VALUE}"
 			return 0
 		fi
 
@@ -634,7 +678,7 @@ _dsi_find_live_dispatch() {
 		[[ "$worker_repo" == "$repo_slug" ]] || continue
 		log_path=$(_dsi_find_log_for_pid "$issue_number" "$pid")
 		session_key=$(printf '%s' "$cmd" | sed -n 's/.*--session-key[[:space:]]\([^[:space:]]*\).*/\1/p' | head -1)
-		printf 'process\t%s\t%s\t%s\t%s\n' "$pid" "$log_path" "${worktree_path:-<unknown>}" "${session_key:-<unknown>}"
+		printf 'process\t%s\t%s\t%s\t%s\n' "$pid" "$log_path" "${worktree_path:-$_DSI_UNKNOWN_VALUE}" "${session_key:-$_DSI_UNKNOWN_VALUE}"
 		return 0
 	done < <(_dsi_ps_worker_lines)
 
@@ -654,9 +698,9 @@ _dsi_find_ledger_dispatch() {
 	entry=$("$_DSI_LEDGER_HELPER" check-issue --issue "$issue_number" --repo "$repo_slug" 2>/dev/null) || entry=""
 	[[ -n "$entry" ]] || return 1
 	pid=$(printf '%s' "$entry" | jq -r '.pid // "?"')
-	session_key=$(printf '%s' "$entry" | jq -r '.session_key // "<unknown>"')
+	session_key=$(printf '%s' "$entry" | jq -r --arg unknown "$_DSI_UNKNOWN_VALUE" '.session_key // $unknown')
 	worktree_path=$(printf '%s' "$entry" | jq -r '.worktree_path // ""')
-	[[ -n "$worktree_path" && "$worktree_path" != "null" ]] || worktree_path="<unknown>"
+	[[ -n "$worktree_path" && "$worktree_path" != "null" ]] || worktree_path="$_DSI_UNKNOWN_VALUE"
 	log_path=$(_dsi_find_log_for_pid "$issue_number" "$pid")
 	printf 'ledger\t%s\t%s\t%s\t%s\n' "$pid" "$log_path" "$worktree_path" "$session_key"
 	return 0
@@ -1259,6 +1303,8 @@ cmd_dispatch() {
 	fi
 	_dsi_guard_no_interactive_hold "$_DSI_ISSUE_LABELS" || return 1
 	_dsi_guard_no_maintainer_review_required "$_DSI_ISSUE_LABELS" "$issue_number" "$repo_slug" || return 1
+	_dsi_guard_no_maintainer_permission_required "$_DSI_ISSUE_LABELS" "$issue_number" "$repo_slug" || return 1
+	_dsi_guard_permission_history_verified "$issue_number" "$repo_slug" || return 1
 	_dsi_check_parent_task "$_DSI_ISSUE_LABELS" || return 1
 
 	# Step 3: dedup check (informational under --dry-run, blocking otherwise).

--- a/.agents/scripts/gh-audit-log-helper.sh
+++ b/.agents/scripts/gh-audit-log-helper.sh
@@ -71,6 +71,7 @@ readonly GH_AUDIT_PROTECTED_LABELS=(
 	"origin:interactive"
 	"no-auto-dispatch"
 	"needs-maintainer-review"
+	"needs-maintainer-permissions"
 )
 
 # Valid operation names

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -393,6 +393,23 @@ _handle_run_result() {
 	_run_classification_source=""
 	_run_classification_pattern=""
 
+	# A headless OpenCode permission event is captured by the plugin and rejected
+	# immediately so no worker slot waits for an interactive answer. Preserve the
+	# session and route the attempt to the maintainer-permission lifecycle unless
+	# the worker subsequently proved the full objective completed without it.
+	if [[ "$role" == "worker" && -n "${_run_permission_request_file:-}" && \
+		-f "${_run_permission_request_file}" ]]; then
+		if [[ -n "$discovered_session" ]]; then
+			store_session_id "$provider" "$session_key" "$discovered_session" "$selected_model"
+		fi
+		_run_result_label="permission_required"
+		_run_failure_reason="$_run_result_label"
+		_run_classification_source="opencode_permission_event"
+		_run_classification_pattern="permission.asked"
+		print_warning "$selected_model requested a capability outside the worker permission boundary — pausing for maintainer approval"
+		return 84
+	fi
+
 	if [[ "${exit_code:-}" == "0" ]]; then
 		if [[ "$activity_detected" != "1" ]]; then
 			_run_result_label="no_activity"
@@ -1064,14 +1081,21 @@ _execute_run_attempt() {
 	# non-empty slug. The role+session_key guard here is no longer needed —
 	# _cmd_run_prepare sets the slug for all roles unconditionally.
 
-	local output_file exit_code_file exit_code
+	local output_file exit_code_file exit_code permission_request_file
 	local start_ms end_ms duration_ms
 	local resource_stop_file resource_result_file resource_sampler_pid
 	local _metric_kill_reason=""
 	start_ms=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || printf '%s' "0")
 	output_file=$(_create_headless_runtime_temp_file) || return 1
-	exit_code_file=$(_create_headless_runtime_temp_file) || {
+	permission_request_file=$(_create_headless_runtime_temp_file) || {
 		rm -f "$output_file"
+		return 1
+	}
+	rm -f "$permission_request_file" 2>/dev/null || true
+	export AIDEVOPS_PERMISSION_REQUEST_FILE="$permission_request_file"
+	_run_permission_request_file="$permission_request_file"
+	exit_code_file=$(_create_headless_runtime_temp_file) || {
+		rm -f "$output_file" "$permission_request_file"
 		return 1
 	}
 	resource_stop_file=$(_create_headless_runtime_temp_file) || {
@@ -1281,7 +1305,9 @@ _execute_run_attempt() {
 			_rl_metric_session_id=$(extract_session_id_from_output "$output_file" 2>/dev/null || true)
 			_rl_metric_output_file=$(_metric_failure_excerpt_path "$output_file" "$session_key")
 		fi
-		rm -f "$_rl_fast_sentinel" "$output_file" 2>/dev/null || true
+		rm -f "$_rl_fast_sentinel" "$output_file" "$permission_request_file" 2>/dev/null || true
+		_run_permission_request_file=""
+		unset AIDEVOPS_PERMISSION_REQUEST_FILE
 		# One literal here; _cmd_run_finish elif is a second. Keeping total at 2
 		# avoids the repeated-string-literal ratchet gate (threshold: >=3).
 		_run_result_label="rate_limit_fast"
@@ -1352,6 +1378,11 @@ _execute_run_attempt() {
 		handle_exit=0
 	else
 		handle_exit=$?
+	fi
+	if [[ "$handle_exit" -ne 84 ]]; then
+		rm -f "$permission_request_file" 2>/dev/null || true
+		_run_permission_request_file=""
+		unset AIDEVOPS_PERMISSION_REQUEST_FILE
 	fi
 	_run_metric_output_file="$_metric_output_file"
 	_run_metric_session_id="$_metric_session_id"
@@ -1640,6 +1671,11 @@ cmd_run() {
 			# repeated-string-literal ratchet gate (threshold: >=3 distinct occurrences).
 			_cmd_run_finish "$session_key" "$_run_result_label"
 			return 0
+		fi
+
+		if [[ "$attempt_exit" -eq 84 ]]; then
+			_cmd_run_finish "$session_key" "$_run_result_label" "$work_dir"
+			return $?
 		fi
 
 		# GH#23037: Handle transient service interruptions separately from

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1540,7 +1540,7 @@ _hrw_finish_success_run() {
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 	fi
 	if [[ "$_HRW_TERMINAL_OUTCOME" == "$_HRW_TELEMETRY_SUCCESS" ]]; then
-		permission_pending_file=$(git -C "$work_dir" rev-parse --git-path aidevops-permission-pending 2>/dev/null || true)
+		permission_pending_file=$(_hrw_permission_pending_path "$work_dir" || true)
 		rm -f "${AIDEVOPS_PERMISSION_GRANT_FILE:-}" "$permission_pending_file" 2>/dev/null || true
 	fi
 
@@ -1620,6 +1620,14 @@ _cmd_run_finish() {
 	return 0
 }
 
+_hrw_permission_pending_path() {
+	local work_dir="$1"
+	local git_dir=""
+	git_dir=$(git -C "$work_dir" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+	printf '%s/aidevops-permission-pending\n' "$git_dir"
+	return 0
+}
+
 _cmd_run_prepare() {
 	local session_key="$1"
 	local work_dir="$2"
@@ -1634,7 +1642,7 @@ _cmd_run_prepare() {
 		return 1
 	fi
 	local permission_pending_file=""
-	permission_pending_file=$(git -C "$work_dir" rev-parse --git-path aidevops-permission-pending 2>/dev/null || true)
+	permission_pending_file=$(_hrw_permission_pending_path "$work_dir" || true)
 	if [[ -f "$permission_pending_file" ]]; then
 		export AIDEVOPS_PERMISSION_REQUEST_ID
 		AIDEVOPS_PERMISSION_REQUEST_ID=$(jq -r '.request_id // ""' "$permission_pending_file" 2>/dev/null || true)

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1402,6 +1402,33 @@ _hrw_finish_rate_limit_fast_run() {
 	return 0
 }
 
+_hrw_finish_permission_required_run() {
+	local session_key="$1"
+	local work_dir="$2"
+	local helper="${SCRIPT_DIR}/worker-permission-helper.sh"
+	local permission_status="permission_required"
+	if [[ ! -x "$helper" || -z "${_run_permission_request_file:-}" ]]; then
+		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "permission_request_persistence_failed"
+		return 1
+	fi
+	if ! "$helper" request \
+		--file "$_run_permission_request_file" \
+		--issue "${WORKER_ISSUE_NUMBER:-}" \
+		--repo "${DISPATCH_REPO_SLUG:-${WORKER_REPO_SLUG:-}}" \
+		--session "$session_key" \
+		--work-dir "$work_dir"; then
+		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "permission_request_persistence_failed"
+		return 1
+	fi
+	_release_dispatch_claim "$session_key" "$permission_status"
+	_HRW_FINAL_RUNTIME_EVENT="worker.deferred"
+	_HRW_FINAL_RUNTIME_STATUS="$permission_status"
+	_HRW_FINAL_RUNTIME_CLASSIFICATION="awaiting_maintainer_permission"
+	_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
+	rm -f "$_run_permission_request_file" 2>/dev/null || true
+	return 0
+}
+
 _hrw_record_terminal_outcome() {
 	local session_key="$1"
 	local outcome="$2"
@@ -1433,6 +1460,7 @@ _hrw_finish_success_run() {
 	local session_key="$1"
 	local work_dir="$2"
 	local release_needed=1
+	local permission_pending_file=""
 
 	# GH#20721 + GH#20819: Classify worker output quality.
 	# _worker_produced_output distinguishes exact-head completion from drafts,
@@ -1511,6 +1539,10 @@ _hrw_finish_success_run() {
 		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 	fi
+	if [[ "$_HRW_TERMINAL_OUTCOME" == "$_HRW_TELEMETRY_SUCCESS" ]]; then
+		permission_pending_file=$(git -C "$work_dir" rev-parse --git-path aidevops-permission-pending 2>/dev/null || true)
+		rm -f "${AIDEVOPS_PERMISSION_GRANT_FILE:-}" "$permission_pending_file" 2>/dev/null || true
+	fi
 
 	return 0
 }
@@ -1565,6 +1597,17 @@ _cmd_run_finish() {
 		_HRW_FINAL_RUNTIME_STATUS="rate_limit_fast"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="rate_limit"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
+	elif [[ "$ledger_status" == "permission_required" ]]; then
+		if ! _hrw_finish_permission_required_run "$session_key" "$work_dir"; then
+			_hrw_record_terminal_outcome "$session_key" "$_HRW_TERMINAL_OUTCOME" \
+				"$_HRW_FINAL_RUNTIME_CLASSIFICATION"
+			_emit_worker_runtime_event "$_HRW_FINAL_RUNTIME_EVENT" \
+				"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
+			_update_dispatch_ledger "$session_key" "fail"
+			_release_session_lock "$session_key"
+			trap - EXIT
+			return 1
+		fi
 	else
 		_hrw_finish_success_run "$session_key" "$work_dir"
 	fi
@@ -1590,6 +1633,14 @@ _cmd_run_prepare() {
 		printf '[fatal] WORKER_WORKTREE_PATH unset — pre-creation skipped or failed silently; aborting per t2983 Fix C\n' >&2
 		return 1
 	fi
+	local permission_pending_file=""
+	permission_pending_file=$(git -C "$work_dir" rev-parse --git-path aidevops-permission-pending 2>/dev/null || true)
+	if [[ -f "$permission_pending_file" ]]; then
+		export AIDEVOPS_PERMISSION_REQUEST_ID
+		AIDEVOPS_PERMISSION_REQUEST_ID=$(jq -r '.request_id // ""' "$permission_pending_file" 2>/dev/null || true)
+	else
+		unset AIDEVOPS_PERMISSION_REQUEST_ID
+	fi
 
 	# GH#20542: Export DISPATCH_REPO_SLUG BEFORE arming the EXIT trap so
 	# _release_dispatch_claim always has a non-empty slug, even when the
@@ -1601,6 +1652,11 @@ _cmd_run_prepare() {
 		| sed -E 's|.*github\.com[:/]||; s|\.git$||' || true)
 	if [[ -n "$_prepare_repo_slug" ]]; then
 		export DISPATCH_REPO_SLUG="$_prepare_repo_slug"
+	fi
+	if [[ -n "${WORKER_ISSUE_NUMBER:-}" && -n "${DISPATCH_REPO_SLUG:-}" ]]; then
+		local permission_grant_slug=""
+		permission_grant_slug=$(printf '%s' "$DISPATCH_REPO_SLUG" | tr '/:' '__')
+		export AIDEVOPS_PERMISSION_GRANT_FILE="${HOME}/.aidevops/permission-grants/${permission_grant_slug}/${WORKER_ISSUE_NUMBER}.json"
 	fi
 
 	# GH#6538: Acquire a session-key lock to prevent duplicate workers.

--- a/.agents/scripts/issue-sync-helper-labels.sh
+++ b/.agents/scripts/issue-sync-helper-labels.sh
@@ -196,7 +196,7 @@ _is_protected_label() {
 	# signals set by explicit user/session action and must survive enrich.
 	# t2754: added hold-for-review and needs-credentials — canonical dispatch-blockers.
 	case "$lbl" in
-	persistent | needs-maintainer-review | not-planned | duplicate | wontfix | \
+	persistent | needs-maintainer-review | needs-maintainer-permissions | not-planned | duplicate | wontfix | \
 		already-fixed | "good first issue" | "help wanted" | \
 		parent-task | meta | auto-dispatch | no-auto-dispatch | no-takeover | \
 		hold-for-review | needs-credentials | \

--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -119,6 +119,7 @@ SYSTEM_LABELS=(
 	"security-adjacent|D73A4A|Security-adjacent issue requiring human attention"
 	"needs-review|D73A4A|Flagged for human review by AI supervisor"
 	"needs-maintainer-review|D73A4A|Requires maintainer approval before work begins"
+	"needs-maintainer-permissions|B60205|Block: background work paused for a scoped maintainer permission grant"
 	"security-review|D73A4A|Requires security review — suspicious AI request"
 	"parent-task|D4C5F9|Parent/meta task — children implement, not this issue"
 	"quality-debt|D93F0B|Unactioned review feedback from merged PRs"

--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -29,6 +29,7 @@ REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 BLOCKING_LABELS = frozenset({
     "parent-task",
     "needs-maintainer-review",
+    "needs-maintainer-permissions",
     "no-auto-dispatch",
     "hold-for-review",
     "blocked",

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1076,7 +1076,7 @@ _dispatch_waiting_for_maintainer_permission() {
 _dispatch_permission_history_requires_grant() {
 	local issue_number="$1"
 	local repo_slug="$2"
-	local events_json labeled_count verification
+	local events_json="" labeled_count="" verification=""
 	_DISPATCH_PERMISSION_VERIFY_RESULT=""
 	events_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/events?per_page=100" --paginate --slurp 2>/dev/null) || {
 		_DISPATCH_PERMISSION_VERIFY_RESULT="API_ERROR"

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -29,6 +29,8 @@
 #   - _is_task_committed_to_main
 #   - _dispatch_target_is_pull_request
 #   - _is_renovate_dependency_dashboard_issue
+#   - _dispatch_waiting_for_maintainer_permission
+#   - _dispatch_permission_history_requires_grant
 #   - _dispatch_has_interactive_hold
 #   - _dispatch_dedup_check_layers  (t1999: extracted from dispatch_with_dedup)
 #   - dispatch_with_dedup           (t1999: thin orchestrator, <80 lines)
@@ -1064,6 +1066,38 @@ _is_bot_generated_cleanup_issue() {
 		jq -e '.labels | map(.name) | (index("review-followup") != null or index("source:review-scanner") != null or index("source:review-feedback") != null)' >/dev/null 2>&1
 }
 
+_dispatch_waiting_for_maintainer_permission() {
+	local issue_meta_json="$1"
+	printf '%s' "$issue_meta_json" \
+		| jq -e '.labels | map(.name) | index("needs-maintainer-permissions") != null' >/dev/null 2>&1
+	return $?
+}
+
+_dispatch_permission_history_requires_grant() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local events_json labeled_count verification
+	_DISPATCH_PERMISSION_VERIFY_RESULT=""
+	events_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/events?per_page=100" --paginate --slurp 2>/dev/null) || {
+		_DISPATCH_PERMISSION_VERIFY_RESULT="API_ERROR"
+		return 0
+	}
+	labeled_count=$(jq '[.[][]? | select(.event == "labeled" and .label.name == "needs-maintainer-permissions")] | length' <<<"$events_json" 2>/dev/null) || {
+		_DISPATCH_PERMISSION_VERIFY_RESULT="API_ERROR"
+		return 0
+	}
+	[[ "$labeled_count" -gt 0 ]] || return 1
+	local approval_helper="${BASH_SOURCE[0]%/*}/approval-helper.sh"
+	[[ -x "$approval_helper" ]] || {
+		_DISPATCH_PERMISSION_VERIFY_RESULT="HELPER_MISSING"
+		return 0
+	}
+	verification=$($approval_helper verify-permissions issue "$issue_number" "$repo_slug" 2>/dev/null) || true
+	_DISPATCH_PERMISSION_VERIFY_RESULT="${verification:-NO_APPROVAL}"
+	[[ "$verification" == "VERIFIED" ]] && return 1
+	return 0
+}
+
 #######################################
 # GH#17574: Check if a task has already landed on main (via PR merge or direct commit).
 #
@@ -1666,6 +1700,19 @@ dispatch_with_dedup() {
 	if [[ "$issue_state" == "CLOSED" ]]; then
 		echo "[dispatch] Skipping #${issue_number}: state=CLOSED" >>"$LOGFILE"
 		pulse-batch-prefetch-helper.sh evict-issue "$repo_slug" "$issue_number" 2>/dev/null || true
+		return 1
+	fi
+
+	#aidevops:trust-boundary -- a worker permission request is dispatchable only
+	# after the request-specific signed grant flow removes its dedicated label.
+	if _dispatch_waiting_for_maintainer_permission "$issue_meta_json"; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: waiting for a scoped signed maintainer permission grant" >>"$LOGFILE"
+		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=needs_maintainer_permissions signal=needs-maintainer-permissions issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
+		return 1
+	fi
+	if _dispatch_permission_history_requires_grant "$issue_number" "$repo_slug"; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: permission-request history lacks a current matching signed grant (${_DISPATCH_PERMISSION_VERIFY_RESULT:-unknown})" >>"$LOGFILE"
+		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=permission_grant_unverified signal=${_DISPATCH_PERMISSION_VERIFY_RESULT:-unknown} issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
 		return 1
 	fi
 

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -56,7 +56,7 @@ _pulse_available_auto_dispatch_work_exists() {
 		[[ -n "$_slug" ]] || continue
 		local _count=""
 		_count=$(gh api -X GET search/issues \
-			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:needs-maintainer-review no:assignee" \
+			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:needs-maintainer-review -label:needs-maintainer-permissions no:assignee" \
 			-f per_page=1 \
 			--jq '.total_count // 0' 2>/dev/null) || _count=""
 		[[ "$_count" =~ ^[0-9]+$ ]] || _count=0

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -252,8 +252,10 @@ run_case "post-approval protection failure blocks final success" '
 	_validate_approval_target_kind() { return 0; }
 	_fetch_target_title() { printf "Mock issue"; return 0; }
 	_confirm_approval() { return 0; }
+	approval_snapshot_v2_payload() { printf "%s" "{\"schema\":\"aidevops-approval/v2\"}"; return 0; }
 	_sign_approval_payload() { local payload="$1"; local actual_key="$2"; local sig_file="$3"; : "$payload" "$actual_key"; printf "mock-signature" >"$sig_file"; return 0; }
 	gh_issue_comment() { return 0; }
+	cmd_verify() { printf "VERIFIED"; return 0; }
 	_post_issue_approval_updates() { return 1; }
 	_kick_pulse_after_approval() { printf "SHOULD_NOT_KICK"; return 0; }
 	_approve_target issue 123 marcusquinn/aidevops

--- a/.agents/scripts/tests/test-dispatch-dedup-maintainer-permission-block.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-maintainer-permission-block.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+metadata='{"state":"OPEN","labels":[{"name":"needs-maintainer-permissions"}],"assignees":[],"createdAt":"2026-07-14T00:00:00Z"}'
+output=""
+rc=0
+output=$(ISSUE_META_JSON="$metadata" "${SCRIPT_DIR}/dispatch-dedup-helper.sh" is-assigned 123 owner/repo runner 2>&1) || rc=$?
+
+if [[ "$rc" -ne 0 || "$output" != *"MAINTAINER_PERMISSIONS_BLOCKED"* ]]; then
+	printf 'dedup helper did not enforce the maintainer-permission block: rc=%s output=%s\n' "$rc" "$output" >&2
+	exit 1
+fi
+
+printf 'dispatch dedup maintainer-permission tests passed\n'

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -39,6 +39,7 @@ MOCK_GH_ISSUE_STATE="OPEN"
 MOCK_GH_LABELS_JSON="[]"
 MOCK_GH_FAIL="0"
 MOCK_GH_TARGET_IS_PR="0"
+MOCK_GH_PERMISSION_EVENTS_JSON='[[]]'
 MOCK_PS_LINES=""
 MOCK_LEDGER_RECORD=""
 MOCK_GIT_WORKTREE_LIST="0"
@@ -172,6 +173,10 @@ gh() {
 
 	if [[ "$gh_subcommand" == "api" && "$gh_resource" == "user" ]]; then
 		printf '%s\n' 'runner-self'
+		return 0
+	fi
+	if [[ "$gh_subcommand" == "api" && "$gh_resource" == */events\?* ]]; then
+		printf '%s\n' "$MOCK_GH_PERMISSION_EVENTS_JSON"
 		return 0
 	fi
 
@@ -635,6 +640,47 @@ test_maintainer_review_guard_blocks_manual_dispatch() {
 	local check=1
 	[[ "$rc" -eq 1 && "$out" == *"requires maintainer review"* && "$out" == *"sudo aidevops approve issue 24354 owner/repo"* ]] && check=0
 	print_result "maintainer-review guard blocks manual dispatch" "$check" "rc=$rc output=$out"
+	return 0
+}
+
+test_maintainer_permission_guard_blocks_manual_dispatch() {
+	local rc=0
+	local out=""
+	out=$(_dsi_guard_no_maintainer_permission_required "bug,needs-maintainer-permissions" 24354 owner/repo 2>&1) || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 1 && "$out" == *"scoped maintainer permission grant"* && "$out" == *"--request perm-"* ]] && check=0
+	print_result "maintainer-permission guard blocks manual dispatch" "$check" "rc=$rc output=$out"
+	return 0
+}
+
+test_permission_history_guard_requires_current_grant() {
+	local helper_dir helper original_helper out rc=0
+	helper_dir=$(mktemp -d)
+	helper="${helper_dir}/approval-helper.sh"
+	printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "${MOCK_PERMISSION_VERIFICATION:-NO_APPROVAL}"' >"$helper"
+	chmod +x "$helper"
+	original_helper="$_DSI_APPROVAL_HELPER"
+	_DSI_APPROVAL_HELPER="$helper"
+	MOCK_GH_PERMISSION_EVENTS_JSON='[[{"event":"labeled","label":{"name":"needs-maintainer-permissions"}}]]'
+	export MOCK_PERMISSION_VERIFICATION="STALE_APPROVAL"
+	out=$(_dsi_guard_permission_history_verified 24354 owner/repo 2>&1) || rc=$?
+
+	local check=1
+	[[ "$rc" -eq 1 && "$out" == *"without a current matching signed grant (STALE_APPROVAL)"* ]] && check=0
+	print_result "permission history guard blocks stale grant" "$check" "rc=$rc output=$out"
+
+	rc=0
+	export MOCK_PERMISSION_VERIFICATION="VERIFIED"
+	out=$(_dsi_guard_permission_history_verified 24354 owner/repo 2>&1) || rc=$?
+	check=1
+	[[ "$rc" -eq 1 && "$out" == *"bound to its original worker session and worktree"* ]] && check=0
+	print_result "permission history guard rejects new worker for bound grant" "$check" "rc=$rc output=$out"
+
+	_DSI_APPROVAL_HELPER="$original_helper"
+	MOCK_GH_PERMISSION_EVENTS_JSON='[[]]'
+	unset MOCK_PERMISSION_VERIFICATION
+	rm -rf "$helper_dir"
 	return 0
 }
 
@@ -1175,6 +1221,8 @@ _run_tests() {
 	test_interactive_hold_guard_allows_auto_dispatch_handoff
 	test_interactive_hold_guard_allows_auto_dispatch_review_handoff
 	test_maintainer_review_guard_blocks_manual_dispatch
+	test_maintainer_permission_guard_blocks_manual_dispatch
+	test_permission_history_guard_requires_current_grant
 	test_cmd_dispatch_blocks_needs_maintainer_review_before_dedup
 	test_dedup_receives_prefetched_issue_metadata
 	test_transient_dedup_retries_are_bounded

--- a/.agents/scripts/tests/test-parent-task-guard.sh
+++ b/.agents/scripts/tests/test-parent-task-guard.sh
@@ -88,7 +88,7 @@ else
 fi
 
 # Regression guards for the existing protected set (must not break)
-for existing in persistent needs-maintainer-review not-planned duplicate wontfix already-fixed; do
+for existing in persistent needs-maintainer-review needs-maintainer-permissions not-planned duplicate wontfix already-fixed; do
 	if _is_protected_label "$existing"; then
 		print_result "_is_protected_label still accepts $existing" 0
 	else
@@ -159,7 +159,7 @@ write_stub_gh() {
 	cat >"${STUB_DIR}/gh" <<STUB
 #!/usr/bin/env bash
 # Stub for test-parent-task-guard.sh
-if [[ "\$1" == "issue" && "\$2" == "view" ]]; then
+if [[ "\$1" == "issue" && "\$2" == "view" ]] || [[ "\$1" == "api" ]]; then
 	cat <<'JSON'
 ${payload}
 JSON

--- a/.agents/scripts/tests/test-permission-approval-content-binding.sh
+++ b/.agents/scripts/tests/test-permission-approval-content-binding.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../approval-helper.sh
+source "${SCRIPT_DIR}/approval-helper.sh"
+
+request_file=$(mktemp)
+edit_log=$(mktemp)
+trap 'rm -f "$request_file" "${request_file}.unsafe" "$edit_log"' EXIT
+
+jq -cnS '{
+  schema: "aidevops-permission-request/v1",
+  target: {kind: "issue", repository: "owner/repo", number: 123},
+  worker: {session: "issue-123", branch: "feature/auto-gh123", worktree_sha256: ("a" * 64)},
+  context: {stage: "worker tool execution", changed_files: [], alternatives: "none"},
+  capabilities: [{
+    permission: "external_directory",
+    patterns: ["~/.cache/opencode/node_modules/@opencode-ai/sdk/**"],
+    tool: "read",
+    intent: "Inspect generated SDK declarations",
+    risk: {level: "medium", grantable: true, reason: "external boundary"},
+    opencode: {request_id: "oc-1", session_id: "ses-1"}
+  }],
+  created_at: "2026-07-14T00:00:00Z"
+}' >"$request_file"
+
+digest=$(_permission_request_digest "$(<"$request_file")")
+request_id="perm-${digest:0:16}"
+jq -cS --arg id "$request_id" --arg digest "$digest" \
+  '. + {request_id: $id, request_sha256: $digest}' "$request_file" >"${request_file}.bound"
+mv "${request_file}.bound" "$request_file"
+request_json=$(<"$request_file")
+
+_validate_permission_request_json "$request_json" issue 123 owner/repo "$request_id"
+
+tampered=$(jq -cS '.capabilities[0].patterns = ["~/.config/opencode/**"]' "$request_file")
+if _validate_permission_request_json "$tampered" issue 123 owner/repo "$request_id"; then
+	printf 'tampered request unexpectedly retained a valid digest\n' >&2
+	exit 1
+fi
+
+substituted_base=$(jq -cS 'del(.request_id, .request_sha256) | .worker.session = "different-session"' "$request_file")
+substituted_digest=$(_permission_request_digest "$substituted_base")
+substituted=$(jq -cS --arg id "$request_id" --arg digest "$substituted_digest" \
+  '. + {request_id: $id, request_sha256: $digest}' <<<"$substituted_base")
+if _validate_permission_request_json "$substituted" issue 123 owner/repo "$request_id"; then
+	printf 'substituted request unexpectedly retained the original request ID\n' >&2
+	exit 1
+fi
+
+unsafe_base=$(jq -cS '
+  del(.request_id, .request_sha256)
+  | .capabilities[0].patterns = ["~/.ssh/**"]
+  | .capabilities[0].risk.grantable = true
+' "$request_file")
+unsafe_digest=$(_permission_request_digest "$unsafe_base")
+unsafe_id="perm-${unsafe_digest:0:16}"
+unsafe=$(jq -cS --arg id "$unsafe_id" --arg digest "$unsafe_digest" \
+  '. + {request_id: $id, request_sha256: $digest}' <<<"$unsafe_base")
+if _validate_permission_request_json "$unsafe" issue 123 owner/repo "$unsafe_id"; then
+	printf 'sensitive path unexpectedly passed approval validation\n' >&2
+	exit 1
+fi
+
+unbounded_base=$(jq -cS '
+  del(.request_id, .request_sha256)
+  | .capabilities[0].patterns = ["**"]
+' "$request_file")
+unbounded_digest=$(_permission_request_digest "$unbounded_base")
+unbounded_id="perm-${unbounded_digest:0:16}"
+unbounded=$(jq -cS --arg id "$unbounded_id" --arg digest "$unbounded_digest" \
+  '. + {request_id: $id, request_sha256: $digest}' <<<"$unbounded_base")
+if _validate_permission_request_json "$unbounded" issue 123 owner/repo "$unbounded_id"; then
+	printf 'unbounded path unexpectedly passed approval validation\n' >&2
+	exit 1
+fi
+
+gh_issue_view() {
+	local issue_number="$1"
+	: "$issue_number"
+	printf '%s\n' '{"labels":[{"name":"status:blocked"},{"name":"needs-maintainer-permissions"}]}'
+	return 0
+}
+
+gh_issue_edit_safe() {
+	local issue_number="$1"
+	shift
+	printf '%s %s\n' "$issue_number" "$*" >"$edit_log"
+	return 0
+}
+
+_apply_permission_approval_state issue 123 owner/repo "$request_json"
+edit_args=$(<"$edit_log")
+[[ "$edit_args" == *"--remove-label needs-maintainer-permissions"* ]]
+[[ "$edit_args" != *"--remove-label status:blocked"* ]]
+[[ "$edit_args" != *"--add-label status:available"* ]]
+[[ "$edit_args" != *"--add-label auto-dispatch"* ]]
+
+printf 'permission approval content-binding tests passed\n'

--- a/.agents/scripts/tests/test-permission-grant-verification.sh
+++ b/.agents/scripts/tests/test-permission-grant-verification.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+ORIGINAL_HOME="$HOME"
+TEST_ROOT=$(mktemp -d)
+export HOME="${TEST_ROOT}/home"
+mkdir -p "$HOME/.aidevops/approval-keys/private" "$TEST_ROOT/bin"
+trap 'rm -rf "$TEST_ROOT"; export HOME="$ORIGINAL_HOME"' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../approval-helper.sh
+source "${SCRIPT_DIR}/approval-helper.sh"
+
+ssh-keygen -t ed25519 -N '' -q -f "$APPROVAL_KEY"
+cp "${APPROVAL_KEY}.pub" "$APPROVAL_PUB"
+
+request_base=$(jq -cnS '{
+  schema: "aidevops-permission-request/v1",
+  target: {kind: "issue", repository: "owner/repo", number: 123},
+  worker: {session: "issue-123", branch: "feature/auto-gh123", worktree_sha256: ("a" * 64)},
+  context: {stage: "worker tool execution", changed_files: [], alternatives: "none", resume_auto_dispatch: true},
+  capabilities: [{
+    permission: "external_directory",
+    patterns: ["~/.cache/opencode/node_modules/@opencode-ai/sdk/**"],
+    tool: "read",
+    intent: "Inspect generated SDK declarations",
+    risk: {level: "medium", grantable: true, reason: "external boundary"},
+    opencode: {request_id: "oc-1", session_id: "ses-1"}
+  }],
+  created_at: "2026-07-14T00:00:00Z"
+}')
+request_digest=$(_permission_request_digest "$request_base")
+request_id="perm-${request_digest:0:16}"
+request_json=$(jq -cS --arg id "$request_id" --arg digest "$request_digest" \
+  '. + {request_id: $id, request_sha256: $digest}' <<<"$request_base")
+
+issued_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+expires_at=$(_permission_grant_expiry)
+payload=$(jq -cS --arg issued "$issued_at" --arg expires "$expires_at" '
+  {
+    schema: "aidevops-permission-grant/v1",
+    authority: "worker-permissions",
+    target,
+    request_id,
+    request_sha256,
+    worker,
+    capabilities,
+    issued_at: $issued,
+    expires_at: $expires
+  }
+' <<<"$request_json")
+signature_file=$(mktemp)
+_sign_approval_payload "$payload" "$APPROVAL_KEY" "$signature_file"
+grant_comment=$(_build_permission_grant_comment "$payload" "$signature_file")
+rm -f "$signature_file"
+request_comment=$(printf '%s\n~~~json\n%s\n~~~\n' "$PERMISSION_REQUEST_MARKER" "$request_json")
+fake_request_comment=$(printf '%s\n~~~json\n{}\n~~~\n' "$PERMISSION_REQUEST_MARKER")
+fake_grant_comment=$(printf '%s\nmalformed\n' "$PERMISSION_GRANT_MARKER")
+
+comments_file="${TEST_ROOT}/comments.json"
+events_file="${TEST_ROOT}/events.json"
+jq -cn --arg request "$request_comment" --arg grant "$grant_comment" \
+	--arg fake_request "$fake_request_comment" --arg fake_grant "$fake_grant_comment" \
+	'[[
+		{id: 1, author_association: "MEMBER", body: $request},
+		{id: 2, author_association: "OWNER", body: $grant},
+		{id: 3, author_association: "CONTRIBUTOR", body: $fake_request},
+		{id: 4, author_association: "NONE", body: $fake_grant}
+	]]' >"$comments_file"
+jq -cn '[[{event: "labeled", label: {name: "needs-maintainer-permissions"}}]]' >"$events_file"
+
+cat >"${TEST_ROOT}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+if [[ "$args" == *"/events?"* ]]; then
+  command cat "$PERMISSION_EVENTS_FILE"
+else
+  command cat "$PERMISSION_COMMENTS_FILE"
+fi
+STUB
+chmod +x "${TEST_ROOT}/bin/gh"
+export PATH="${TEST_ROOT}/bin:${PATH}"
+export PERMISSION_COMMENTS_FILE="$comments_file"
+export PERMISSION_EVENTS_FILE="$events_file"
+
+verification=$(cmd_verify_permissions issue 123 owner/repo)
+[[ "$verification" == "VERIFIED" ]] || {
+	printf 'valid permission grant did not verify: %s\n' "$verification" >&2
+	exit 1
+}
+
+# shellcheck source=../pulse-dispatch-core.sh
+source "${SCRIPT_DIR}/pulse-dispatch-core.sh"
+if _dispatch_permission_history_requires_grant 123 owner/repo; then
+	printf 'dispatch remained blocked despite a matching valid grant: %s\n' "${_DISPATCH_PERMISSION_VERIFY_RESULT:-}" >&2
+	exit 1
+fi
+[[ "$_DISPATCH_PERMISSION_VERIFY_RESULT" == "VERIFIED" ]]
+
+jq '.[0] = [.[0][0], .[0][2], .[0][3]]' "$comments_file" >"${comments_file}.pending"
+mv "${comments_file}.pending" "$comments_file"
+if ! _dispatch_permission_history_requires_grant 123 owner/repo; then
+	printf 'dispatch was allowed after the signed grant disappeared\n' >&2
+	exit 1
+fi
+[[ "$_DISPATCH_PERMISSION_VERIFY_RESULT" == "NO_APPROVAL" ]]
+
+printf 'permission grant verification tests passed\n'

--- a/.agents/scripts/tests/test-pulse-dispatch-permission-gate.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-permission-gate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../pulse-dispatch-core.sh
+source "${SCRIPT_DIR}/pulse-dispatch-core.sh"
+
+blocked='{"labels":[{"name":"status:available"},{"name":"needs-maintainer-permissions"}]}'
+allowed='{"labels":[{"name":"status:available"},{"name":"auto-dispatch"}]}'
+
+_dispatch_waiting_for_maintainer_permission "$blocked"
+if _dispatch_waiting_for_maintainer_permission "$allowed"; then
+	printf 'permission gate blocked metadata without the dedicated label\n' >&2
+	exit 1
+fi
+
+printf 'pulse dispatch permission-gate tests passed\n'

--- a/.agents/scripts/tests/test-worker-permission-helper.sh
+++ b/.agents/scripts/tests/test-worker-permission-helper.sh
@@ -52,4 +52,30 @@ if permission_validate_capture "${capture_file}.unsafe" 123 owner/repo; then
 	exit 1
 fi
 
+repo_dir="${test_root}/repo"
+git init -q "$repo_dir"
+gh() {
+	printf '0\n'
+	return 0
+}
+gh_issue_view() {
+	printf '{"labels":[]}\n'
+	return 0
+}
+gh_issue_comment() {
+	return 0
+}
+gh_issue_edit_safe() {
+	return 0
+}
+(
+	cd "$test_root"
+	cmd_request --file "$capture_file" --issue 123 --repo owner/repo --session issue-123 --work-dir "$repo_dir"
+)
+git_dir=$(git -C "$repo_dir" rev-parse --absolute-git-dir)
+if [[ ! -f "${git_dir}/aidevops-permission-pending" ]]; then
+	printf 'permission pending marker was not written to the target repository git directory\n' >&2
+	exit 1
+fi
+
 printf 'worker permission helper tests passed\n'

--- a/.agents/scripts/tests/test-worker-permission-helper.sh
+++ b/.agents/scripts/tests/test-worker-permission-helper.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../worker-permission-helper.sh
+source "${SCRIPT_DIR}/worker-permission-helper.sh"
+
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+capture_file="${test_root}/capture.json"
+
+cat >"$capture_file" <<'JSON'
+{
+  "schema": "aidevops-permission-capture/v1",
+  "issue": "123",
+  "repo": "owner/repo",
+  "worker_session": "issue-123",
+  "requests": [{
+    "request_id": "perm-source",
+    "permission": "external_directory",
+    "patterns": ["~/.cache/opencode/node_modules/@opencode-ai/sdk/**"],
+    "tool": "read",
+    "intent": "Inspect generated SDK declarations",
+    "risk": {"level": "medium", "grantable": true, "reason": "external boundary"},
+    "opencode": {"request_id": "oc-1", "session_id": "ses-1"}
+  }]
+}
+JSON
+
+permission_validate_capture "$capture_file" 123 owner/repo
+envelope=$(permission_build_envelope "$capture_file" 123 owner/repo issue-123 "$PWD" '{"auto_dispatch":true}')
+expected_worktree_digest=$(permission_sha256_text "$PWD")
+jq -e '
+  .schema == "aidevops-permission-request/v1"
+  and (.request_id | test("^perm-[0-9a-f]{16}$"))
+  and .target.repository == "owner/repo"
+  and .capabilities[0].tool == "read"
+' <<<"$envelope" >/dev/null
+jq -e --arg digest "$expected_worktree_digest" '.worker.worktree_sha256 == $digest' <<<"$envelope" >/dev/null
+jq -e '.context.resume_auto_dispatch == true' <<<"$envelope" >/dev/null
+if [[ "$envelope" == *"$PWD"* ]]; then
+	printf 'permission envelope exposed the local worktree path\n' >&2
+	exit 1
+fi
+
+jq '.requests[0].patterns = ["/Users/private/.ssh/id_ed25519"]' "$capture_file" >"${capture_file}.unsafe"
+if permission_validate_capture "${capture_file}.unsafe" 123 owner/repo; then
+	printf 'unsafe private path unexpectedly passed validation\n' >&2
+	exit 1
+fi
+
+printf 'worker permission helper tests passed\n'

--- a/.agents/scripts/worker-permission-helper.sh
+++ b/.agents/scripts/worker-permission-helper.sh
@@ -44,7 +44,7 @@ permission_validate_capture() {
 			(.permission | type == "string" and length > 0 and length <= 100)
 			and (.patterns | type == "array" and length <= 20)
 			and all(.patterns[]; type == "string" and length <= 500)
-			and (.risk.level | IN("low", "medium", "high", "critical"))
+			and (.risk.level as $level | ["low", "medium", "high", "critical"] | index($level) != null)
 			and (.risk.grantable | type == "boolean")
 		)
 		and all(.requests[];
@@ -63,11 +63,13 @@ permission_changed_files_json() {
 		printf '[]\n'
 		return 0
 	fi
-	git -C "$work_dir" status --short 2>/dev/null \
-		| cut -c4- \
-		| awk 'NF { print }' \
-		| head -20 \
-		| jq -Rsc 'split("\n") | map(select(length > 0))'
+	local status_output=""
+	if ! status_output=$(git -C "$work_dir" status --short 2>/dev/null); then
+		printf '[]\n'
+		return 0
+	fi
+	printf '%s\n' "$status_output" \
+		| jq -Rsc 'split("\n") | map(select(length >= 4) | .[3:]) | map(select(length > 0)) | .[:20]'
 	return 0
 }
 
@@ -248,8 +250,9 @@ cmd_request() {
 	request_id=$(permission_post_request "$capture_file" "$issue_number" "$repo_slug" "$session_key" "$work_dir") || return 1
 	permission_apply_block "$issue_number" "$repo_slug" || return 1
 	if [[ -n "$work_dir" && -d "$work_dir" ]]; then
-		local pending_file=""
-		pending_file=$(git -C "$work_dir" rev-parse --git-path aidevops-permission-pending 2>/dev/null) || return 1
+		local git_dir="" pending_file=""
+		git_dir=$(git -C "$work_dir" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+		pending_file="${git_dir}/aidevops-permission-pending"
 		jq -cn --arg request "$request_id" --arg issue "$issue_number" \
 			'{request_id: $request, issue: ($issue | tonumber)}' >"$pending_file"
 	fi

--- a/.agents/scripts/worker-permission-helper.sh
+++ b/.agents/scripts/worker-permission-helper.sh
@@ -180,8 +180,10 @@ ${PERMISSION_REQUEST_MARKER}
 
 Background work paused instead of waiting indefinitely for an unavailable interactive permission response.
 
-**Request:** ${request_id}  
-**Worker stage:** tool execution  
+**Request:** ${request_id}
+
+**Worker stage:** tool execution
+
 **Branch:** ${branch:-not available}
 
 ### Requested capabilities

--- a/.agents/scripts/worker-permission-helper.sh
+++ b/.agents/scripts/worker-permission-helper.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+readonly PERMISSION_REQUEST_MARKER="<!-- aidevops-permission-request -->"
+readonly PERMISSION_REQUEST_SCHEMA="aidevops-permission-request/v1"
+
+permission_sha256() {
+	local source_file="$1"
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$source_file" | awk '{print $1}'
+	else
+		sha256sum "$source_file" | awk '{print $1}'
+	fi
+	return 0
+}
+
+permission_sha256_text() {
+	local value="$1"
+	local source_file
+	source_file=$(mktemp)
+	printf '%s' "$value" >"$source_file"
+	permission_sha256 "$source_file"
+	rm -f "$source_file"
+	return 0
+}
+
+permission_validate_capture() {
+	local capture_file="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	jq -e --arg issue "$issue_number" --arg repo "$repo_slug" '
+		.schema == "aidevops-permission-capture/v1"
+		and .issue == $issue
+		and (.repo | ascii_downcase) == ($repo | ascii_downcase)
+		and (.requests | type == "array" and length > 0 and length <= 20)
+		and all(.requests[];
+			(.permission | type == "string" and length > 0 and length <= 100)
+			and (.patterns | type == "array" and length <= 20)
+			and all(.patterns[]; type == "string" and length <= 500)
+			and (.risk.level | IN("low", "medium", "high", "critical"))
+			and (.risk.grantable | type == "boolean")
+		)
+		and all(.requests[];
+			all((.patterns[]?), .intent;
+				(test("^/(Users|home)/[^/]+/") | not)
+				and (test("(?i)(api[_-]?key|token|secret|password|authorization)[[:space:]]*[:=][[:space:]]*(?!\\[REDACTED\\])[^[:space:],;]+") | not)
+			)
+		)
+	' "$capture_file" >/dev/null
+	return $?
+}
+
+permission_changed_files_json() {
+	local work_dir="$1"
+	if [[ -z "$work_dir" || ! -d "$work_dir" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+	git -C "$work_dir" status --short 2>/dev/null \
+		| cut -c4- \
+		| awk 'NF { print }' \
+		| head -20 \
+		| jq -Rsc 'split("\n") | map(select(length > 0))'
+	return 0
+}
+
+permission_issue_resume_json() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_json=""
+	issue_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" --json labels 2>/dev/null) || {
+		printf '{"auto_dispatch":false}\n'
+		return 0
+	}
+	jq -c '{auto_dispatch: ((.labels // []) | map(.name) | index("auto-dispatch") != null)}' <<<"$issue_json"
+	return 0
+}
+
+permission_build_envelope() {
+	local capture_file="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	local session_key="$4"
+	local work_dir="$5"
+	local resume_json="${6:-}"
+	[[ -n "$resume_json" ]] || resume_json='{"auto_dispatch":false}'
+	local changed_files branch worktree_digest created_at base_file digest request_id
+	changed_files=$(permission_changed_files_json "$work_dir")
+	branch=$(git -C "$work_dir" branch --show-current 2>/dev/null || true)
+	worktree_digest=$(permission_sha256_text "$work_dir")
+	created_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	base_file=$(mktemp)
+	jq -cS \
+		--arg schema "$PERMISSION_REQUEST_SCHEMA" \
+		--arg issue "$issue_number" \
+		--arg repo "$(printf '%s' "$repo_slug" | tr '[:upper:]' '[:lower:]')" \
+		--arg session "$session_key" \
+		--arg branch "$branch" \
+		--arg worktree_digest "$worktree_digest" \
+		--arg created "$created_at" \
+		--argjson changed "$changed_files" \
+		--argjson resume "$resume_json" '
+		{
+			schema: $schema,
+			target: {kind: "issue", repository: $repo, number: ($issue | tonumber)},
+			worker: {session: $session, branch: $branch, worktree_sha256: $worktree_digest},
+			context: {
+				stage: "worker tool execution",
+				changed_files: $changed,
+				alternatives: "The worker was unable to continue within its current permission boundary.",
+				resume_auto_dispatch: $resume.auto_dispatch
+			},
+			capabilities: [.requests[] | {
+				permission, patterns, tool, intent, risk,
+				opencode: {request_id: .opencode.request_id, session_id: .opencode.session_id}
+			}],
+			created_at: $created
+		}
+	' "$capture_file" >"$base_file"
+	digest=$(permission_sha256 "$base_file")
+	request_id="perm-${digest:0:16}"
+	jq -cS --arg id "$request_id" --arg digest "$digest" \
+		'. + {request_id: $id, request_sha256: $digest}' "$base_file"
+	rm -f "$base_file"
+	return 0
+}
+
+permission_request_already_posted() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local request_id="$3"
+	gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" --paginate --slurp \
+		--jq "[.[][]? | select((.body // \"\") | contains(\"${PERMISSION_REQUEST_MARKER}\") and contains(\"${request_id}\"))] | length" \
+		2>/dev/null | awk '$1 > 0 { found=1 } END { exit(found ? 0 : 1) }'
+	return $?
+}
+
+permission_render_capabilities() {
+	local envelope_file="$1"
+	jq -r '.capabilities[] |
+		def safe: gsub("<"; "&lt;") | gsub(">"; "&gt;");
+		"- **" + .permission + "** via `" + .tool + "` — "
+		+ (if (.patterns | length) == 0 then "(no pattern supplied)" else (.patterns | map(tojson | safe) | join(", ")) end)
+		+ "\n  - Reason: " + (if .intent == "" then "No additional model rationale was available." else (.intent | safe) end)
+		+ "\n  - Risk: **" + .risk.level + "** — " + (.risk.reason | safe)
+		+ (if .risk.grantable then "" else "\n  - **Not grantable:** sensitive scope requires an alternative approach." end)'
+	return 0
+}
+
+permission_post_request() {
+	local capture_file="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	local session_key="$4"
+	local work_dir="$5"
+	local envelope_file comment_file request_id capability_text changed_text branch resume_json
+	envelope_file=$(mktemp)
+	comment_file=$(mktemp)
+	resume_json=$(permission_issue_resume_json "$issue_number" "$repo_slug")
+	permission_build_envelope "$capture_file" "$issue_number" "$repo_slug" "$session_key" "$work_dir" "$resume_json" >"$envelope_file"
+	request_id=$(jq -r '.request_id' "$envelope_file")
+	if permission_request_already_posted "$issue_number" "$repo_slug" "$request_id"; then
+		rm -f "$envelope_file" "$comment_file"
+		printf '%s\n' "$request_id"
+		return 0
+	fi
+	capability_text=$(permission_render_capabilities "$envelope_file")
+	changed_text=$(jq -r 'if (.context.changed_files | length) == 0 then "- No uncommitted repository files detected." else (.context.changed_files[] | "- " + tojson) end' "$envelope_file")
+	branch=$(jq -r '(.worker.branch // "") | tojson' "$envelope_file")
+	cat >"$comment_file" <<EOF
+${PERMISSION_REQUEST_MARKER}
+## Maintainer permission required
+
+Background work paused instead of waiting indefinitely for an unavailable interactive permission response.
+
+**Request:** ${request_id}  
+**Worker stage:** tool execution  
+**Branch:** ${branch:-not available}
+
+### Requested capabilities
+
+${capability_text}
+
+### Preserved work context
+
+${changed_text}
+
+The worktree and OpenCode session are preserved for continuation. Paths are home/worktree-normalized, credential-like values are redacted, and raw tool metadata is intentionally omitted.
+
+### Approval
+
+Review the exact scope above, then run:
+
+    sudo aidevops approve permissions issue ${issue_number} ${repo_slug} --request ${request_id}
+
+This signs only the listed capabilities for this issue. It does not approve the issue scope, clear needs-maintainer-review, or authorize merge/release.
+
+~~~json
+$(jq . "$envelope_file")
+~~~
+EOF
+	if ! gh_issue_comment "$issue_number" --repo "$repo_slug" --body-file "$comment_file" >/dev/null; then
+		rm -f "$envelope_file" "$comment_file"
+		return 1
+	fi
+	rm -f "$envelope_file" "$comment_file"
+	printf '%s\n' "$request_id"
+	return 0
+}
+
+permission_apply_block() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	gh_issue_edit_safe "$issue_number" --repo "$repo_slug" \
+		--add-label "needs-maintainer-permissions" \
+		--remove-label "status:queued" \
+		--remove-label "status:claimed" \
+		--remove-label "status:in-progress" \
+		--remove-label "status:in-review" >/dev/null
+	return $?
+}
+
+cmd_request() {
+	local capture_file="" issue_number="" repo_slug="" session_key="" work_dir=""
+	local request_id=""
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--file) capture_file="${2:-}"; shift 2 ;;
+		--issue) issue_number="${2:-}"; shift 2 ;;
+		--repo) repo_slug="${2:-}"; shift 2 ;;
+		--session) session_key="${2:-}"; shift 2 ;;
+		--work-dir) work_dir="${2:-}"; shift 2 ;;
+		*) printf 'Unknown option: %s\n' "$arg" >&2; return 1 ;;
+		esac
+	done
+	[[ -f "$capture_file" && "$issue_number" =~ ^[0-9]+$ && "$repo_slug" == */* ]] || return 1
+	permission_validate_capture "$capture_file" "$issue_number" "$repo_slug" || return 1
+	request_id=$(permission_post_request "$capture_file" "$issue_number" "$repo_slug" "$session_key" "$work_dir") || return 1
+	permission_apply_block "$issue_number" "$repo_slug" || return 1
+	if [[ -n "$work_dir" && -d "$work_dir" ]]; then
+		local pending_file=""
+		pending_file=$(git -C "$work_dir" rev-parse --git-path aidevops-permission-pending 2>/dev/null) || return 1
+		jq -cn --arg request "$request_id" --arg issue "$issue_number" \
+			'{request_id: $request, issue: ($issue | tonumber)}' >"$pending_file"
+	fi
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	shift 2>/dev/null || true
+	case "$command" in
+	request) cmd_request "$@" ;;
+	*) printf 'Usage: worker-permission-helper.sh request --file FILE --issue N --repo OWNER/REPO --session KEY --work-dir PATH\n' >&2; return 1 ;;
+	esac
+	return $?
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/TODO.md
+++ b/TODO.md
@@ -1153,6 +1153,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18121 Route pending full-loop CI through delta-aware wait-checks #bug #framework #full-loop #efficiency #auto-dispatch ~30m tier:simple ref:GH#27585 logged:2026-07-14 -> [todo/tasks/t18121-brief.md]
 
+- [ ] t18122 Add cryptographically scoped worker permission grants ref:GH#27688
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Capture background worker permission requests, require exact cryptographically signed short-lived grants, and enforce the grant lifecycle across OpenCode, headless workers, approval, dispatch, queue, and audit paths.

## Files Changed

- `.agents/plugins/opencode-aidevops/permission-broker.mjs`: capture, sanitize, classify, persist, and reject headless permission requests.
- `.agents/plugins/opencode-aidevops/config-hook.mjs`: verify signed grants and inject exact OpenCode rules.
- `.agents/scripts/worker-permission-helper.sh`: persist request envelopes and Git-private pending markers.
- `.agents/scripts/approval-helper.sh`: validate, sign, publish, and verify scoped grants.
- Headless runtime, pulse, dedup, queue, label-sync, and audit helpers: enforce pause/resume lifecycle gates.
- Bash and Node tests: cover content binding, expiry, replay, sensitive and unbounded scopes, untrusted comments, and manual dispatch.

## Runtime Testing

- **Risk level:** Critical (cryptographic authorization, worker sessions, and privileged capability grants).
- **Verification:** Runtime-verified with the full local lint gate; 387 OpenCode plugin tests; 124 headless-runtime tests; 64 manual-dispatch tests; focused approval, permission-grant, pulse, and dedup regression suites; local Qlty regression delta 0.

## Key Decisions

- Bind every grant to repository target, request digest and ID, worker session, branch, worktree hash, and pending marker.
- Grant only exact `bash` and `external_directory` patterns; reject sensitive, unsupported, action-only, or unbounded scopes.
- Ignore permission request and grant comments from untrusted GitHub associations.
- Preserve historical cryptographic verification so mutable label removal cannot authorize dispatch.
- Block new manual workers from consuming grants bound to an original worker session and worktree.

Resolves #27688

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.117 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 2h 55m and 153,052 tokens on this with the user in an interactive session. Overall, 19m since this issue was created.
