### PR TITLE
GH#27686: normalize authenticated forge event ingestion

### DIFF
--- a/.agents/scripts/task-coordinator.mjs
+++ b/.agents/scripts/task-coordinator.mjs
@@ -121,6 +121,24 @@ function validId(value, label) {
   if (typeof value !== "string" || !SAFE_ID.test(value)) throw new TypeError(`${label} is not a canonical opaque identifier`);
   return value;
 }
+function canonicalRfc3339(value, label) {
+  const match = typeof value === "string" ? /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?(Z|([+-])(\d{2}):(\d{2}))$/.exec(value) : null;
+  if (!match) throw new TypeError(`${label} must be a valid RFC3339 timestamp`);
+  const [, year, month, day, hour, minute, second, , zone, sign, rawOffsetHours, rawOffsetMinutes] = match;
+  const offsetHours = zone === "Z" ? 0 : Number(rawOffsetHours);
+  const offsetMinutes = zone === "Z" ? 0 : Number(rawOffsetMinutes);
+  const epoch = Date.parse(value);
+  if (!Number.isFinite(epoch) || offsetHours > 23 || offsetMinutes > 59) {
+    throw new TypeError(`${label} must be a valid RFC3339 timestamp`);
+  }
+  const offsetDirection = sign === "-" ? -1 : 1;
+  const localEpoch = epoch + offsetDirection * (offsetHours * 60 + offsetMinutes) * 60_000;
+  const expectedLocal = `${year}-${month}-${day}T${hour}:${minute}:${second}`;
+  if (!new Date(localEpoch).toISOString().startsWith(expectedLocal)) {
+    throw new TypeError(`${label} must be a valid RFC3339 timestamp`);
+  }
+  return new Date(epoch).toISOString();
+}
 function originId() {
   let value = BigInt(`0x${randomBytes(16).toString("hex")}`);
   let encoded = "";
@@ -513,10 +531,7 @@ function issueMappingInput(input) {
   const displayNumber = Number(input.displayNumber);
   if (!Number.isSafeInteger(displayNumber) || displayNumber < 1) throw new TypeError("display_number must be a positive integer");
   const rawStateCursor = input.stateCursor || null;
-  if (rawStateCursor && (typeof rawStateCursor !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(rawStateCursor) || !Number.isFinite(Date.parse(rawStateCursor)))) {
-    throw new TypeError("state_cursor must be a canonical UTC RFC3339 timestamp");
-  }
-  const stateCursor = rawStateCursor ? new Date(rawStateCursor).toISOString() : null;
+  const stateCursor = rawStateCursor ? canonicalRfc3339(rawStateCursor, "state_cursor") : null;
   const syncMetadataText = jsonText(input.syncMetadata || {}, "sync_metadata");
   return { taskId, forge, repositoryId, repositorySlug, role, issueId, projectId, displayNumber, stateCursor, syncMetadataText };
 }
@@ -564,16 +579,13 @@ function forgeEventInput(input) {
   const subjectId = validId(input.subjectId, "subject_id");
   const deliveryId = validId(input.deliveryId, "delivery_id");
   const cursorTiebreaker = validId(input.cursorTiebreaker, "cursor_tiebreaker");
-  const cursor = input.cursor;
-  if (typeof cursor !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(cursor) || !Number.isFinite(Date.parse(cursor))) {
-    throw new TypeError("cursor must be a canonical UTC RFC3339 timestamp");
-  }
+  const cursor = canonicalRfc3339(input.cursor, "cursor");
   const repositoryPath = input.repositoryPath;
   if (repositoryPath && (typeof repositoryPath !== "string" || !repositoryPath.startsWith("/") || repositoryPath.includes("\0"))) throw new TypeError("repository_path must be absolute");
   const taskId = input.taskId || null;
   if (taskId && !TASK_ID.test(taskId)) throw new TypeError("task_id is not canonical");
   if (eventKind === "manual" && !taskId) throw new TypeError("manual events require an explicit trusted task mapping");
-  return { operationId, repositoryId, repositorySlug, eventKind, action, subjectId, deliveryId, cursorTiebreaker, repositoryPath, taskId, cursor: new Date(cursor).toISOString() };
+  return { operationId, repositoryId, repositorySlug, eventKind, action, subjectId, deliveryId, cursorTiebreaker, repositoryPath, taskId, cursor };
 }
 function transitionForEvent(eventKind, action) {
   if (eventKind === "push") return "repository.projection_changed";

--- a/.agents/scripts/tests/test-forge-event-workflow.sh
+++ b/.agents/scripts/tests/test-forge-event-workflow.sh
@@ -25,6 +25,8 @@ assert "forge-event-mapping-helper.sh" in normal
 assert "task-publication-worker-helper.sh" in normal
 assert "forge-coordinator-state-helper.sh" in normal
 assert "upload-artifact" in normal
+ingest = next(step for step in jobs["forge-event"]["steps"] if step.get("name") == "Ingest event and execute publication queue")
+assert ingest["env"]["GH_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
 PY
 
 for caller in "$SELF_CALLER" "$CALLER_TEMPLATE"; do

--- a/.agents/scripts/tests/test-task-coordinator.sh
+++ b/.agents/scripts/tests/test-task-coordinator.sh
@@ -134,7 +134,7 @@ v2_backup=$(ls "${TEST_ROOT}"/v2.db-backup-*-pre-migrate-v3.db)
 # one task to retain home, implementation, and upstream issue projections.
 mapping_task=$(node "$COORDINATOR" allocate --operation-id mapping-task --payload '{}' | jq -r '.tasks[0].taskId')
 node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_home --repository-slug owner/home \
-	--role home --issue-id I_home --project-id P_home --display-number 42 --state-cursor 2026-07-12T10:00:00Z \
+	--role home --issue-id I_home --project-id P_home --display-number 42 --state-cursor 2026-07-12T06:00:00-04:00 \
 	--sync-metadata '{"state":"OPEN","source":"backfill"}' >/dev/null
 node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_impl --repository-slug owner/implementation \
 	--role implementation --issue-id I_impl --display-number 42 --sync-metadata '{"state":"OPEN"}' >/dev/null
@@ -143,6 +143,7 @@ node "$COORDINATOR" bind-issue --task-id "$mapping_task" --repository-id R_upstr
 [[ "$(node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_home | jq -r '.issueId')" == "I_home" ]]
 [[ "$(node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_impl | jq -r '.issueId')" == "I_impl" ]]
 [[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(*) FROM issue_mappings WHERE task_id='${mapping_task}';")" == "3" ]]
+[[ "$(node "$COORDINATOR" resolve-issue --task-id "$mapping_task" --repository-id R_home | jq -r '.stateCursor')" == "2026-07-12T10:00:00.000Z" ]]
 
 # A renamed slug updates display metadata without changing repository identity;
 # conflicting issue identity or an unvalidated repository fails closed.
@@ -216,9 +217,29 @@ conflict_forge=$(node "$COORDINATOR" forge-event --operation-id delivery-conflic
 # Pushes use trusted repository semantics and never attempt SHA-to-issue mapping.
 push_forge=$(node "$COORDINATOR" forge-event --operation-id delivery-push --delivery-id delivery-push \
 	--cursor-tiebreaker run-30 --repository-id R_home --repository-slug renamed/home \
-	--event-kind push --action pushed --subject-id aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --cursor 2026-07-12T14:00:00Z)
+	--event-kind push --action pushed --subject-id aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --cursor 2026-07-12T10:00:00-04:00)
 [[ "$(printf '%s' "$push_forge" | jq -r '.mappingMode')" == "trusted-repository" ]]
 [[ "$(printf '%s' "$push_forge" | jq -r '.taskId')" == "null" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT cursor_timestamp FROM forge_event_cursors WHERE repository_id='R_home' AND subject_kind='push';")" == "2026-07-12T14:00:00.000Z" ]]
+[[ "$(node "$COORDINATOR" forge-event --operation-id delivery-push --delivery-id delivery-push --cursor-tiebreaker run-30 --repository-id R_home --repository-slug renamed/home --event-kind push --action pushed --subject-id aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --cursor 2026-07-12T14:00:00Z)" == "$push_forge" ]]
+
+# Manual events share the same canonical cursor boundary, while malformed dates
+# fail before an operation or cursor can be persisted.
+manual_forge=$(node "$COORDINATOR" forge-event --operation-id delivery-manual --delivery-id delivery-manual \
+	--cursor-tiebreaker run-31 --repository-id R_home --repository-slug renamed/home --task-id "$mapping_task" \
+	--event-kind manual --action requested --subject-id I_home --cursor 2026-07-12T15:00:00+01:00)
+[[ "$(printf '%s' "$manual_forge" | jq -r '.mappingMode')" == "explicit-task" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT cursor_timestamp FROM forge_event_cursors WHERE repository_id='R_home' AND subject_kind='manual';")" == "2026-07-12T14:00:00.000Z" ]]
+invalid_cursor_error="${TEST_ROOT}/invalid-cursor-error"
+if node "$COORDINATOR" forge-event --operation-id delivery-invalid --delivery-id delivery-invalid \
+	--cursor-tiebreaker run-32 --repository-id R_home --repository-slug renamed/home \
+	--event-kind push --action pushed --subject-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+	--cursor 2026-02-30T12:00:00Z >/dev/null 2>"$invalid_cursor_error"; then
+	printf 'FAIL invalid RFC3339 cursor was accepted\n' >&2
+	exit 1
+fi
+grep -q 'cursor must be a valid RFC3339 timestamp' "$invalid_cursor_error"
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(*) FROM operations WHERE operation_id='delivery-invalid';")" == "0" ]]
 
 # Repository identity isolates otherwise identical subjects and cursors.
 other_repo=$(node "$COORDINATOR" forge-event --operation-id delivery-other-repo --delivery-id delivery-other-repo \
@@ -228,7 +249,7 @@ other_repo=$(node "$COORDINATOR" forge-event --operation-id delivery-other-repo 
 
 # A fresh process observes the same durable cursor and outbox after restart.
 node "$COORDINATOR" status >/dev/null
-[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT transition_kind FROM forge_event_cursors WHERE repository_id='R_home' AND subject_id='I_home';")" == "task.completed" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT transition_kind FROM forge_event_cursors WHERE repository_id='R_home' AND subject_kind='issue' AND subject_id='I_home';")" == "task.completed" ]]
 
 # Concurrent conflicting first binds are serialized in SQLite: exactly one
 # identity wins and every competing identity fails without overwriting it.

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -86,6 +86,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch' || inputs.command == 'event'
         env:
           AIDEVOPS_TASK_COORDINATOR_DB: ${{ runner.temp }}/aidevops-coordinator/tasks.db
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action || '' }}
           EVENT_MERGED: ${{ github.event.pull_request.merged || false }}


### PR DESCRIPTION
## Summary

Authenticate forge-event ingestion and canonicalize valid RFC3339 offset cursors before idempotent coordinator processing.

## Files Changed

.agents/scripts/task-coordinator.mjs, .agents/scripts/tests/test-forge-event-workflow.sh, .agents/scripts/tests/test-task-coordinator.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** High (durable coordinator state machine and authenticated workflow ingestion)
- **Verification:** Runtime-verified with test-task-coordinator.sh; test-forge-event-workflow.sh, ShellCheck, node --check, and linters-local.sh all pass.

Resolves #27686


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.117 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 21m and 177,167 tokens on this with the user in an interactive session.
