### PR TITLE
GH#27685: fence task projection publication

### DIFF
--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -12,6 +12,16 @@ PLANNING_PUBLISH_RESULT=""
 PLANNING_PUBLICATION_ID=""
 PLANNING_PUBLISHED_COMMIT=""
 
+_planning_git() {
+	local git_bin="${AIDEVOPS_PLANNING_GIT_BIN:-git}"
+	if [[ "$git_bin" == */* && ! -x "$git_bin" ]]; then
+		_planning_publish_log error "Planning Git binary is not executable: $git_bin"
+		return 1
+	fi
+	command "$git_bin" "$@"
+	return $?
+}
+
 _planning_publish_log() {
 	local level="$1"
 	local message="$2"
@@ -37,9 +47,9 @@ _planning_publish_path_allowed() {
 _planning_publish_changed_paths() {
 	local repo_path="$1"
 	{
-		git -C "$repo_path" diff --name-only HEAD -- TODO.md todo/ 2>/dev/null || true
-		git -C "$repo_path" diff --name-only --cached -- TODO.md todo/ 2>/dev/null || true
-		git -C "$repo_path" ls-files --others --exclude-standard -- TODO.md todo/ 2>/dev/null || true
+		_planning_git -C "$repo_path" diff --name-only HEAD -- TODO.md todo/ 2>/dev/null || true
+		_planning_git -C "$repo_path" diff --name-only --cached -- TODO.md todo/ 2>/dev/null || true
+		_planning_git -C "$repo_path" ls-files --others --exclude-standard -- TODO.md todo/ 2>/dev/null || true
 	} | LC_ALL=C sort -u | grep -v '^$' || true
 	return 0
 }
@@ -62,7 +72,7 @@ _planning_publish_snapshot() {
 		fi
 		if [[ -f "${repo_path}/${path}" ]]; then
 			local blob_sha=""
-			blob_sha=$(git -C "$repo_path" hash-object -w -- "${repo_path}/${path}") || return 1
+			blob_sha=$(_planning_git -C "$repo_path" hash-object -w -- "${repo_path}/${path}") || return 1
 			printf 'file\t%s\t%s\n' "$blob_sha" "$path" >>"$snapshot_file" || return 1
 		else
 			printf 'delete\t-\t%s\n' "$path" >>"$snapshot_file" || return 1
@@ -78,13 +88,13 @@ _planning_publish_build_index() {
 	local index_file="$4"
 	local operation="" blob_sha="" path=""
 	rm -f "$index_file" || return 1
-	GIT_INDEX_FILE="$index_file" git -C "$repo_path" read-tree "$parent_sha" || return 1
+	GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" read-tree "$parent_sha" || return 1
 	while IFS=$'\t' read -r operation blob_sha path; do
 		[[ -n "$path" ]] || continue
 		if [[ "$operation" == "file" ]]; then
-			GIT_INDEX_FILE="$index_file" git -C "$repo_path" update-index --add --cacheinfo "100644,${blob_sha},${path}" || return 1
+			GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" update-index --add --cacheinfo "100644,${blob_sha},${path}" || return 1
 		else
-			GIT_INDEX_FILE="$index_file" git -C "$repo_path" update-index --force-remove -- "$path" || return 1
+			GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" update-index --force-remove -- "$path" || return 1
 		fi
 	done <"$snapshot_file"
 	return 0
@@ -99,12 +109,12 @@ _planning_publish_verify_index() {
 	while IFS= read -r changed_path; do
 		[[ -n "$changed_path" ]] || continue
 		_planning_publish_path_allowed "$changed_path" || return 1
-	done < <(GIT_INDEX_FILE="$index_file" git -C "$repo_path" diff --cached --name-only "$parent_sha")
+	done < <(GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" diff --cached --name-only "$parent_sha")
 	while IFS=$'\t' read -r operation expected_sha path; do
 		if [[ "$operation" == "file" ]]; then
-			staged_sha=$(GIT_INDEX_FILE="$index_file" git -C "$repo_path" rev-parse ":${path}" 2>/dev/null) || return 1
+			staged_sha=$(GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" rev-parse ":${path}" 2>/dev/null) || return 1
 			[[ "$staged_sha" == "$expected_sha" ]] || return 1
-		elif GIT_INDEX_FILE="$index_file" git -C "$repo_path" rev-parse ":${path}" >/dev/null 2>&1; then
+		elif GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" rev-parse ":${path}" >/dev/null 2>&1; then
 			return 1
 		fi
 	done <"$snapshot_file"
@@ -149,7 +159,7 @@ _planning_publish_parent_conflicts() {
 	local snapshot_file="$4"
 	local operation="" blob_sha="" path=""
 	while IFS=$'\t' read -r operation blob_sha path; do
-		if ! git -C "$repo_path" diff --quiet "$old_parent" "$new_parent" -- "$path"; then
+		if ! _planning_git -C "$repo_path" diff --quiet "$old_parent" "$new_parent" -- "$path"; then
 			return 0
 		fi
 	done <"$snapshot_file"
@@ -163,14 +173,14 @@ _planning_publish_push() {
 	local parent_sha="$4"
 	local candidate_sha="$5"
 	if [[ -n "${AIDEVOPS_PLANNING_FENCE_REF:-}" && -n "${AIDEVOPS_PLANNING_FENCE_SHA:-}" ]]; then
-		git -C "$repo_path" push -q --atomic \
+		_planning_git -C "$repo_path" push -q --atomic \
 			--force-with-lease="refs/heads/${branch_name}:${parent_sha}" \
 			--force-with-lease="${AIDEVOPS_PLANNING_FENCE_REF}:${AIDEVOPS_PLANNING_FENCE_SHA}" \
 			"$remote_name" "${candidate_sha}:refs/heads/${branch_name}" \
 			"${AIDEVOPS_PLANNING_FENCE_SHA}:${AIDEVOPS_PLANNING_FENCE_REF}"
 		return $?
 	fi
-	git -C "$repo_path" push -q --force-with-lease="refs/heads/${branch_name}:${parent_sha}" "$remote_name" "${candidate_sha}:refs/heads/${branch_name}"
+	_planning_git -C "$repo_path" push -q --force-with-lease="refs/heads/${branch_name}:${parent_sha}" "$remote_name" "${candidate_sha}:refs/heads/${branch_name}"
 	return $?
 }
 
@@ -183,7 +193,7 @@ planning_publish() {
 	local temp_dir="" snapshot_file="" index_file="" parent_sha="" tree_sha="" candidate_sha=""
 	local publication_id="" attempt=0 push_rc=0 latest_sha=""
 
-	[[ -n "$branch_name" ]] || branch_name=$(git -C "$repo_path" symbolic-ref --short HEAD 2>/dev/null) || return 1
+	[[ -n "$branch_name" ]] || branch_name=$(_planning_git -C "$repo_path" symbolic-ref --short HEAD 2>/dev/null) || return 1
 	[[ -n "$paths" ]] || paths=$(_planning_publish_changed_paths "$repo_path")
 	if [[ -z "$paths" ]]; then
 		PLANNING_PUBLISH_RESULT="noop"
@@ -196,7 +206,7 @@ planning_publish() {
 		rm -rf "$temp_dir"
 		return 1
 	}
-	publication_id=$(git -C "$repo_path" hash-object "$snapshot_file") || {
+	publication_id=$(_planning_git -C "$repo_path" hash-object "$snapshot_file") || {
 		rm -rf "$temp_dir"
 		return 1
 	}
@@ -204,11 +214,11 @@ planning_publish() {
 
 	while [[ $attempt -lt $PLANNING_PUBLISH_MAX_RETRIES ]]; do
 		attempt=$((attempt + 1))
-		git -C "$repo_path" fetch -q "$remote_name" "$branch_name" || {
+		_planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" || {
 			rm -rf "$temp_dir"
 			return 1
 		}
-		latest_sha=$(git -C "$repo_path" rev-parse FETCH_HEAD) || {
+		latest_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || {
 			rm -rf "$temp_dir"
 			return 1
 		}
@@ -226,17 +236,17 @@ planning_publish() {
 			rm -rf "$temp_dir"
 			return 1
 		}
-		tree_sha=$(GIT_INDEX_FILE="$index_file" git -C "$repo_path" write-tree) || {
+		tree_sha=$(GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" write-tree) || {
 			rm -rf "$temp_dir"
 			return 1
 		}
-		if [[ "$tree_sha" == "$(git -C "$repo_path" rev-parse "${parent_sha}^{tree}")" ]]; then
+		if [[ "$tree_sha" == "$(_planning_git -C "$repo_path" rev-parse "${parent_sha}^{tree}")" ]]; then
 			PLANNING_PUBLISH_RESULT="noop"
 			PLANNING_PUBLISHED_COMMIT="$parent_sha"
 			rm -rf "$temp_dir"
 			return 0
 		fi
-		candidate_sha=$(printf '%s\n\nPlanning-Publication-ID: %s\n' "$commit_msg" "$publication_id" | git -C "$repo_path" commit-tree "$tree_sha" -p "$parent_sha") || {
+		candidate_sha=$(printf '%s\n\nPlanning-Publication-ID: %s\n' "$commit_msg" "$publication_id" | _planning_git -C "$repo_path" commit-tree "$tree_sha" -p "$parent_sha") || {
 			rm -rf "$temp_dir"
 			return 1
 		}

--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -159,7 +159,7 @@ if (
 	export HOME="${FIXTURE_HOME}"
 	export PATH="${FIXTURE_SHIM_DIR}:/usr/bin:/bin"
 	FIXTURE_GIT=$(command -v git) &&
-	[[ "${FIXTURE_GIT}" != "${FIXTURE_SHIM_DIR}/git" ]] &&
+		[[ "${FIXTURE_GIT}" != "${FIXTURE_SHIM_DIR}/git" ]] &&
 		git config --global --add safe.directory "${FIXTURE_REPO}" &&
 		git init -q "${FIXTURE_REPO}" &&
 		git -C "${FIXTURE_REPO}" remote add origin "${FIXTURE_ROOT}/upstream.git" &&
@@ -222,14 +222,30 @@ else
 fi
 
 # ============================================================
-# Test 6: Update TODO.md proof-log step still references __aidevops/
-#         (sanity check — if this changes, the test premise needs updating)
+# Test 6: task-backed proof publication uses the path-allowlisted planning
+# publisher rather than direct canonical index/commit mutation.
 # ============================================================
-if printf '%s\n' "${JOB_BODY}" | grep -qE 'bash[[:space:]]+__aidevops/\.agents/scripts/issue-sync-git-push-helper\.sh'; then
-	check 1 "Update TODO.md proof-log invokes __aidevops/.agents/scripts/issue-sync-git-push-helper.sh" ""
+PROOF_BODY=$(printf '%s\n' "${JOB_BODY}" | awk '
+	/name:[[:space:]]+Update TODO\.md proof-log/ { capture=1 }
+	capture && /name:[[:space:]]+Sync PLANS\.md status from TODO\.md completions/ { exit }
+	capture { print }
+')
+PLANS_BODY=$(printf '%s\n' "${JOB_BODY}" | awk '
+	/name:[[:space:]]+Sync PLANS\.md status from TODO\.md completions/ { capture=1 }
+	capture && /name:[[:space:]]+Park canonical Git guard before action cleanup/ { exit }
+	capture { print }
+')
+# shellcheck disable=SC2016 # Assert the literal workflow variable reference.
+if printf '%s\n' "${JOB_BODY}" | grep -qE 'AIDEVOPS_PLANNING_GIT_BIN=.*RUNNER_GIT' &&
+	printf '%s\n' "${PROOF_BODY}" | grep -qE 'source[[:space:]]+"?\$SCRIPT_DIR/planning-publisher\.sh"?' &&
+	printf '%s\n' "${PROOF_BODY}" | grep -qE 'planning_publish[[:space:]]' &&
+	! printf '%s\n' "${PROOF_BODY}" | grep -qE '^[[:space:]]+git[[:space:]]+(config|add|commit|pull|push)' &&
+	printf '%s\n' "${PLANS_BODY}" | grep -qE 'planning_publish[[:space:]]' &&
+	! printf '%s\n' "${PLANS_BODY}" | grep -qE '^[[:space:]]+git[[:space:]]+(config|add|commit|pull|push)'; then
+	check 1 "task proof and plan status use capability-scoped planning publication" ""
 else
-	check 0 "Update TODO.md proof-log invokes __aidevops/.agents/scripts/issue-sync-git-push-helper.sh" \
-		"reference path changed — update this test to track the new invocation pattern"
+	check 0 "task proof and plan status use capability-scoped planning publication" \
+		"both projections must use the captured runner Git capability through planning-publisher.sh"
 fi
 
 # ============================================================

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -46,6 +46,7 @@ state_digest() {
 		git -C "$repo" ls-files -s
 		git -C "$repo" diff --binary
 		git -C "$repo" diff --cached --binary
+		git -C "$repo" status --porcelain=v1 --untracked-files=all
 	} | git hash-object --stdin
 	return 0
 }
@@ -222,12 +223,68 @@ HOOK
 	return 0
 }
 
+test_explicit_git_capability_preserves_guarded_checkout() {
+	local name="explicit Git capability publishes planning paths while canonical guard remains active"
+	local root="" repo="" shim_dir="" before="" after="" guard_rc=0 count=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	shim_dir="${root}/shim"
+	mkdir -p "$shim_dir" || {
+		fail "$name" shim
+		return 0
+	}
+	cp "${SCRIPT_DIR_TEST}/../git" \
+		"${SCRIPT_DIR_TEST}/../canonical-git-command-guard.py" \
+		"${SCRIPT_DIR_TEST}/../canonical_git_policy.py" \
+		"${SCRIPT_DIR_TEST}/../canonical_shell_parser.py" \
+		"$shim_dir/" || {
+		fail "$name" guard-copy
+		return 0
+	}
+	printf '%s\n' '- [x] t006 proof ref:GH#6 pr:#60 completed:2026-07-14' >>"${repo}/TODO.md"
+	printf '%s\n' '**Status:** Completed' '**TODO:** t006' '**PR:** #60' >"${repo}/todo/PLANS.md"
+	before=$(state_digest "$repo")
+	(
+		export PATH="${shim_dir}:/usr/bin:/bin"
+		export GIT_AUTHOR_NAME="GitHub Actions"
+		export GIT_AUTHOR_EMAIL="actions@github.com"
+		export GIT_COMMITTER_NAME="GitHub Actions"
+		export GIT_COMMITTER_EMAIL="actions@github.com"
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_GIT_BIN=/usr/bin/git \
+			AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+			planning_publish "$repo" "plan: guarded task projection" origin main $'TODO.md\ntodo/PLANS.md'
+	) || {
+		fail "$name" publish
+		rm -rf "$root"
+		return 0
+	}
+	after=$(state_digest "$repo")
+	PATH="${shim_dir}:/usr/bin:/bin" git -C "$repo" config user.name blocked-test >/dev/null 2>&1 || guard_rc=$?
+	count=$(git --git-dir="${root}/remote.git" show main:TODO.md | grep -c 'pr:#60 completed:2026-07-14' || true)
+	if [[ "$before" == "$after" && "$guard_rc" -eq 42 && "$count" -eq 1 ]] &&
+		git --git-dir="${root}/remote.git" show main:todo/PLANS.md | grep -q 'Status:\*\* Completed'; then
+		pass "$name"
+	else
+		fail "$name" "state or guard invariant failed (guard_rc=$guard_rc count=$count)"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
 main() {
 	test_state_allowlist_and_idempotence
 	test_validation_failure_pushes_nothing
 	test_contention_replay_and_conflict
 	test_crash_replay_is_single_publication
 	test_same_path_contention_is_retryable
+	test_explicit_git_capability_preserves_guarded_checkout
 	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 	[[ $FAIL -eq 0 ]] || return 1
 	return 0

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -723,6 +723,13 @@ jobs:
           # workspace deletion boundary, but park the canonical Git guard under
           # a non-command name. The trusted actions/checkout steps must select
           # the runner Git binary for their init/config/remote/submodule work.
+          RUNNER_GIT=$(command -v git)
+          if [[ ! -x "$RUNNER_GIT" ]]; then
+            echo "::error::Runner Git binary is unavailable before guard activation"
+            exit 1
+          fi
+          echo "AIDEVOPS_PLANNING_GIT_BIN=${RUNNER_GIT}" >> "$GITHUB_ENV"
+
           SHIM_DIR="${RUNNER_TEMP}/aidevops-issue-sync-shims"
           rm -rf "${SHIM_DIR}"
           mkdir -p "${SHIM_DIR}"
@@ -1172,10 +1179,11 @@ jobs:
           # evaluates to 'true' or 'false' at workflow-compile time and is
           # safe to log.
           SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
+          GIT_AUTHOR_NAME: GitHub Actions
+          GIT_AUTHOR_EMAIL: actions@github.com
+          GIT_COMMITTER_NAME: GitHub Actions
+          GIT_COMMITTER_EMAIL: actions@github.com
         run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-
           # t2391 / GH#19825: Skip TODO.md proof-log for range-syntax titled PRs.
           # Titles like `t2259..t2264: plan …` or `t2259, t2260: plan …` signal
           # multi-task planning PRs. The auto-complete regex only captures the
@@ -1249,17 +1257,19 @@ jobs:
             exit 0
           fi
 
-          # Commit and push
-          git add TODO.md
-          git commit -m "chore: mark $UPDATED_TASK_IDS complete ($PROOF) [skip ci]"
-
           # t2029: track success explicitly so a silent branch-protection
           # rejection becomes a loud failure. Without this, GH006 rejections
           # are hidden inside the retry loop and the workflow reports overall
           # success even though TODO.md was never pushed — which is exactly
           # how this workflow broke silently for ~3 weeks before t2029.
           PUSH_SUCCEEDED=false
-          if bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh push-todo main 3; then
+          SCRIPT_DIR="$GITHUB_WORKSPACE/__aidevops/.agents/scripts"
+          # shellcheck source=/dev/null
+          source "$SCRIPT_DIR/planning-publisher.sh"
+          if planning_publish \
+            "$GITHUB_WORKSPACE" \
+            "chore: mark $UPDATED_TASK_IDS complete ($PROOF) [skip ci]" \
+            origin main TODO.md; then
             PUSH_SUCCEEDED=true
           fi
 
@@ -1326,6 +1336,10 @@ jobs:
         env:
           TASK_IDS: ${{ steps.resolve-tasks.outputs.task_ids }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GIT_AUTHOR_NAME: GitHub Actions
+          GIT_AUTHOR_EMAIL: actions@github.com
+          GIT_COMMITTER_NAME: GitHub Actions
+          GIT_COMMITTER_EMAIL: actions@github.com
         run: |
           # When a task is marked complete in TODO.md, check if it belongs to
           # a plan in PLANS.md and update that plan's status if all its tasks
@@ -1438,20 +1452,15 @@ jobs:
           done
 
           if [[ "$PLANS_CHANGED" == "true" ]]; then
-            git add todo/PLANS.md
-            if git diff --cached --quiet todo/PLANS.md 2>/dev/null; then
-              echo "No PLANS.md changes to commit"
-            else
-              git commit -m "chore: sync PLANS.md status for $TASK_IDS (PR #${PR_NUMBER}) [skip ci]"
-              for i in 1 2 3; do
-                echo "Push attempt $i..."
-                git pull --rebase origin main || true
-                if git push; then
-                  echo "PLANS.md sync pushed on attempt $i"
-                  break
-                fi
-                sleep $((i * 3))
-              done
+            SCRIPT_DIR="$GITHUB_WORKSPACE/__aidevops/.agents/scripts"
+            # shellcheck source=/dev/null
+            source "$SCRIPT_DIR/planning-publisher.sh"
+            if ! planning_publish \
+              "$GITHUB_WORKSPACE" \
+              "chore: sync PLANS.md status for $TASK_IDS (PR #${PR_NUMBER}) [skip ci]" \
+              origin main todo/PLANS.md; then
+              echo "::error::Failed to publish PLANS.md status with a fenced planning update"
+              exit 1
             fi
           fi
 


### PR DESCRIPTION
## Summary

Publish task-backed TODO proof logs and PLANS status through the path-allowlisted, lease-fenced planning publisher while the canonical Git guard remains active.

## Files Changed

.agents/scripts/planning-publisher.sh, .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh, .agents/scripts/tests/test-planning-publisher.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** planning publisher 6/6; issue-sync lifecycle 12/12; canonical guard 50/50; issue-sync completion/resolver/push tests; ShellCheck, shfmt, actionlint, and changed-file local linters passed.

Resolves #27685


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.117 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 25m and 196,401 tokens on this with the user in an interactive session.