### PR TITLE
GH#27633: prevent review gate quota rerun escalations

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -214,8 +214,19 @@ _stale_recovery_find_open_pr() {
 				. == "no-auto-dispatch" or . == "needs-maintainer-review"
 			);
 			def worker_owned: names | any(. == "origin:worker" or . == "origin:worker-takeover");
+			def successful_review_status:
+				[.statusCheckRollup[]? |
+					select((.__typename // "") == "StatusContext" and
+						((.context // "") | ascii_downcase) == "review-bot-gate") |
+					(.state // "" | ascii_upcase)] | any(. == "SUCCESS");
 			def terminal_failure:
-				[.statusCheckRollup[]? | (.conclusion // .status // .state // empty) | ascii_upcase] |
+				successful_review_status as $review_pass |
+				[.statusCheckRollup[]? |
+					select((
+						$review_pass and (.__typename // "") == "CheckRun" and
+						((.name // "") | ascii_downcase | contains("review-bot-gate"))
+					) | not) |
+					(.conclusion // .status // .state // empty) | ascii_upcase] |
 				any(. == "FAILURE" or . == "ERROR" or . == "CANCELLED" or
 					. == "TIMED_OUT" or . == "ACTION_REQUIRED" or . == "STALE");
 			def kind:

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -5,6 +5,7 @@
 #
 # Usage:
 #   review-bot-gate-helper.sh check         <PR_NUMBER> [REPO]
+#   review-bot-gate-helper.sh event-check
 #   review-bot-gate-helper.sh wait          <PR_NUMBER> [REPO] [MAX_WAIT_SECONDS]
 #   review-bot-gate-helper.sh list          <PR_NUMBER> [REPO]
 #   review-bot-gate-helper.sh request-retry <PR_NUMBER> [REPO]
@@ -13,6 +14,7 @@
 #
 # Commands:
 #   check          — Check once, return PASS/PASS_RATE_LIMITED/WAITING/SKIP
+#   event-check    — Accept trusted bot review evidence from the Actions event
 #   wait           — Poll until a bot posts or timeout (default 600s)
 #   list           — List all bot comments found on the PR
 #   request-retry  — If bots were rate-limited and no real review exists,
@@ -148,10 +150,11 @@ REVIEW_BOT_MIN_EDIT_LAG_SECONDS="${REVIEW_BOT_MIN_EDIT_LAG_SECONDS:-30}"
 # --- Functions ---
 
 usage() {
-	echo "Usage: $(basename "$0") {check|wait|list|request-retry|status-json|batch-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
+	echo "Usage: $(basename "$0") {check|event-check|wait|list|request-retry|status-json|batch-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
 	echo ""
 	echo "Commands:"
 	echo "  check          Check once for bot reviews (returns PASS/PASS_RATE_LIMITED/WAITING/SKIP)"
+	echo "  event-check    Check trusted bot review evidence from REVIEW_GATE_EVENT_* variables"
 	echo "  wait           Poll until bot reviews appear or timeout"
 	echo "  list           List all bot comments found"
 	echo "  request-retry  Request review retry if bots were rate-limited (idempotent)"
@@ -440,6 +443,59 @@ is_non_review_comment() {
 			return 0
 		fi
 	done
+	return 1
+}
+
+is_known_review_bot() {
+	local actor="$1"
+	local known_bot=""
+	actor=$(printf '%s' "$actor" | tr '[:upper:]' '[:lower:]')
+	actor="${actor%\[bot\]}"
+
+	for known_bot in "${KNOWN_BOTS[@]}"; do
+		[[ "$actor" == "$known_bot" ]] && return 0
+	done
+	return 1
+}
+
+do_event_check() {
+	local event_name="${REVIEW_GATE_EVENT_NAME:-}"
+	local event_action="${REVIEW_GATE_EVENT_ACTION:-}"
+	local event_actor="${REVIEW_GATE_EVENT_ACTOR:-}"
+	local event_body="${REVIEW_GATE_EVENT_BODY:-}"
+	local review_state="${REVIEW_GATE_REVIEW_STATE:-}"
+	local evidence_head="${REVIEW_GATE_EVIDENCE_HEAD_SHA:-}"
+	local expected_head="${REVIEW_GATE_EXPECTED_HEAD_SHA:-}"
+
+	if ! is_known_review_bot "$event_actor"; then
+		printf 'NOT_APPLICABLE\n'
+		return 1
+	fi
+	if [[ -z "$evidence_head" || -z "$expected_head" || "$evidence_head" != "$expected_head" ]]; then
+		printf 'NOT_APPLICABLE\n'
+		return 1
+	fi
+
+	case "$event_name:$event_action" in
+	pull_request_review_comment:created | pull_request_review_comment:edited)
+		if [[ -n "$event_body" ]] && ! is_non_review_comment "$event_body"; then
+			printf 'PASS\n'
+			return 0
+		fi
+		;;
+	pull_request_review:submitted | pull_request_review:edited)
+		if [[ "$review_state" == "approved" || "$review_state" == "changes_requested" ]]; then
+			printf 'PASS\n'
+			return 0
+		fi
+		if [[ -n "$event_body" ]] && ! is_non_review_comment "$event_body"; then
+			printf 'PASS\n'
+			return 0
+		fi
+		;;
+	esac
+
+	printf 'NOT_APPLICABLE\n'
 	return 1
 }
 
@@ -1395,6 +1451,11 @@ main() {
 	local pr_number="${2:-}"
 	local repo="${3:-}"
 	local max_wait="${4:-}"
+
+	if [[ "$command" == "event-check" ]]; then
+		do_event_check
+		return $?
+	fi
 
 	# batch-retry only needs repo, not pr_number
 	if [[ "$command" == "batch-retry" ]]; then

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -178,6 +178,72 @@ Recommended changes: add a null check before line 42."
 	return 0
 }
 
+test_event_check_accepts_trusted_inline_bot_review() {
+	local output=""
+	if output=$(REVIEW_GATE_EVENT_NAME=pull_request_review_comment \
+		REVIEW_GATE_EVENT_ACTION=created \
+		REVIEW_GATE_EVENT_ACTOR='gemini-code-assist[bot]' \
+		REVIEW_GATE_EVENT_BODY='Thank you. The finding is resolved.' \
+		REVIEW_GATE_EVIDENCE_HEAD_SHA='head-123' \
+		REVIEW_GATE_EXPECTED_HEAD_SHA='head-123' \
+		do_event_check); then
+		[[ "$output" == "PASS" ]] && print_result "event-check accepts trusted inline bot evidence" 0 && return 0
+	fi
+	print_result "event-check accepts trusted inline bot evidence" 1 "output=${output}"
+	return 0
+}
+
+test_event_check_rejects_human_inline_reply() {
+	local output="" status=0
+	output=$(REVIEW_GATE_EVENT_NAME=pull_request_review_comment \
+		REVIEW_GATE_EVENT_ACTION=created \
+		REVIEW_GATE_EVENT_ACTOR='maintainer' \
+		REVIEW_GATE_EVENT_BODY='Addressed in the latest commit.' \
+		REVIEW_GATE_EVIDENCE_HEAD_SHA='head-123' \
+		REVIEW_GATE_EXPECTED_HEAD_SHA='head-123' \
+		do_event_check) || status=$?
+	if [[ "$status" -eq 1 && "$output" == "NOT_APPLICABLE" ]]; then
+		print_result "event-check rejects human inline replies" 0
+	else
+		print_result "event-check rejects human inline replies" 1 "status=${status} output=${output}"
+	fi
+	return 0
+}
+
+test_event_check_rejects_bot_failure_notice() {
+	local output="" status=0
+	output=$(REVIEW_GATE_EVENT_NAME=pull_request_review_comment \
+		REVIEW_GATE_EVENT_ACTION=created \
+		REVIEW_GATE_EVENT_ACTOR='coderabbitai' \
+		REVIEW_GATE_EVENT_BODY='Review failed due to an internal error.' \
+		REVIEW_GATE_EVIDENCE_HEAD_SHA='head-123' \
+		REVIEW_GATE_EXPECTED_HEAD_SHA='head-123' \
+		do_event_check) || status=$?
+	if [[ "$status" -eq 1 && "$output" == "NOT_APPLICABLE" ]]; then
+		print_result "event-check rejects bot failure notices" 0
+	else
+		print_result "event-check rejects bot failure notices" 1 "status=${status} output=${output}"
+	fi
+	return 0
+}
+
+test_event_check_rejects_stale_head_evidence() {
+	local output="" status=0
+	output=$(REVIEW_GATE_EVENT_NAME=pull_request_review_comment \
+		REVIEW_GATE_EVENT_ACTION=created \
+		REVIEW_GATE_EVENT_ACTOR='gemini-code-assist[bot]' \
+		REVIEW_GATE_EVENT_BODY='A substantive inline finding.' \
+		REVIEW_GATE_EVIDENCE_HEAD_SHA='old-head' \
+		REVIEW_GATE_EXPECTED_HEAD_SHA='current-head' \
+		do_event_check) || status=$?
+	if [[ "$status" -eq 1 && "$output" == "NOT_APPLICABLE" ]]; then
+		print_result "event-check rejects stale-head bot evidence" 0
+	else
+		print_result "event-check rejects stale-head bot evidence" 1 "status=${status} output=${output}"
+	fi
+	return 0
+}
+
 # t2799: is_rate_limit_only_comment matches the narrow 6-entry rate-limit set
 # only — NOT the broader non-review patterns ("Review failed", "Review
 # skipped", etc.). Used by grace-period logic where the semantic distinction
@@ -995,6 +1061,10 @@ main() {
 	test_is_non_review_comment_matches_review_skipped
 	test_is_non_review_comment_matches_closed_during_review
 	test_is_non_review_comment_rejects_real_review
+	test_event_check_accepts_trusted_inline_bot_review
+	test_event_check_rejects_human_inline_reply
+	test_event_check_rejects_bot_failure_notice
+	test_event_check_rejects_stale_head_evidence
 	test_is_rate_limit_only_matches_rate_limit
 	test_is_rate_limit_only_rejects_review_failed
 	test_is_rate_limit_only_rejects_review_skipped

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -244,6 +244,16 @@ test_event_check_rejects_stale_head_evidence() {
 	return 0
 }
 
+test_self_caller_uses_pr_head_helper_ref() {
+	local caller="${SCRIPT_DIR}/../../../.github/workflows/review-bot-gate.yml"
+	if grep -Fq "aidevops_ref: \${{ github.event.pull_request.head.sha || 'main' }}" "$caller"; then
+		print_result "self-caller validates the PR-head helper revision" 0
+	else
+		print_result "self-caller validates the PR-head helper revision" 1 "caller=${caller}"
+	fi
+	return 0
+}
+
 # t2799: is_rate_limit_only_comment matches the narrow 6-entry rate-limit set
 # only — NOT the broader non-review patterns ("Review failed", "Review
 # skipped", etc.). Used by grace-period logic where the semantic distinction
@@ -1065,6 +1075,7 @@ main() {
 	test_event_check_rejects_human_inline_reply
 	test_event_check_rejects_bot_failure_notice
 	test_event_check_rejects_stale_head_evidence
+	test_self_caller_uses_pr_head_helper_ref
 	test_is_rate_limit_only_matches_rate_limit
 	test_is_rate_limit_only_rejects_review_failed
 	test_is_rate_limit_only_rejects_review_skipped

--- a/.agents/scripts/tests/test-stale-recovery-escalation.sh
+++ b/.agents/scripts/tests/test-stale-recovery-escalation.sh
@@ -109,6 +109,7 @@ if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
 	case "${open_pr_kind}" in
 	ready) printf '%s\n' '[{"number":${open_pr_number},"isDraft":false,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' ;;
 	ready_failed) printf '%s\n' '[{"number":${open_pr_number},"isDraft":false,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"FAILURE"}]}]' ;;
+	ready_review_infra) printf '%s\n' '[{"number":${open_pr_number},"isDraft":false,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"__typename":"CheckRun","name":"gate / review-bot-gate","status":"COMPLETED","conclusion":"FAILURE"},{"__typename":"StatusContext","context":"review-bot-gate","state":"SUCCESS"}]}]' ;;
 	draft_checkpoint) printf '%s\n' '[{"number":${open_pr_number},"isDraft":true,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' ;;
 	protected_draft) printf '%s\n' '[{"number":${open_pr_number},"isDraft":true,"labels":[{"name":"origin:interactive"}],"statusCheckRollup":[]}]' ;;
 	*) printf '%s\n' '[]' ;;
@@ -317,6 +318,16 @@ if echo "$output" | grep -q "STALE_READY_FAILED_ESCALATED"; then
 	print_result "Ready PR with terminal failed checks escalates explicitly" 0
 else
 	print_result "Ready PR with terminal failed checks escalates explicitly" 1 "(got: '$output')"
+fi
+
+# A later review-event workflow can exhaust its API quota after the exact-head
+# commit status already passed. That infrastructure-only rerun is not a failed
+# implementation checkpoint and must not trigger maintainer escalation.
+run_recover 0 "80|ready_review_infra" 1
+if echo "$output" | grep -q "STALE_PROGRESS_PRESERVED" && ! grep -q "needs-maintainer-review" "$GH_CALLS_FILE"; then
+	print_result "Successful review status suppresses terminal infra rerun escalation" 0
+else
+	print_result "Successful review status suppresses terminal infra rerun escalation" 1 "(got: '$output')"
 fi
 
 export PATH="$OLD_PATH"

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -43,22 +43,31 @@ jobs:
   review-bot-gate:
     runs-on: ${{ inputs.runner }}
     # Only run on PRs (issue_comment fires for PR comments too).
-    # GH#27137: review submissions and inline review comments must re-evaluate
-    # the gate. Skipping bot-authored review events left a stale successful
-    # status after substantive findings arrived.
+    # GH#27137: bot review submissions and inline comments must re-evaluate the
+    # gate. Human replies cannot change AI-review evidence and must not replace
+    # a successful exact-head check with an API-quota failure.
     if: >
       (
         github.event_name == 'pull_request' ||
-        github.event_name == 'pull_request_review' ||
-        github.event_name == 'pull_request_review_comment' ||
         (
-          github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request &&
+          (
+            github.event_name == 'pull_request_review' ||
+            (
+              github.event_name == 'pull_request_review_comment' &&
+              github.event.comment.in_reply_to_id == null
+            ) ||
+            (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+          ) &&
           (
             github.actor == 'coderabbitai' ||
+            github.actor == 'coderabbitai[bot]' ||
+            github.actor == 'gemini-code-assist' ||
             github.actor == 'gemini-code-assist[bot]' ||
+            github.actor == 'augment-code' ||
             github.actor == 'augment-code[bot]' ||
+            github.actor == 'augmentcode' ||
             github.actor == 'augmentcode[bot]' ||
+            github.actor == 'copilot' ||
             github.actor == 'copilot[bot]' ||
             github.actor == 'github-actions[bot]'
           )
@@ -91,6 +100,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPO: ${{ github.repository }}
+          REVIEW_GATE_EVENT_NAME: ${{ github.event_name }}
+          REVIEW_GATE_EVENT_ACTION: ${{ github.event.action }}
+          REVIEW_GATE_EVENT_ACTOR: ${{ github.actor }}
+          REVIEW_GATE_EVENT_BODY: ${{ github.event.review.body || github.event.comment.body || '' }}
+          REVIEW_GATE_REVIEW_STATE: ${{ github.event.review.state || '' }}
+          REVIEW_GATE_EVIDENCE_HEAD_SHA: ${{ github.event.review.commit_id || github.event.comment.commit_id || '' }}
+          REVIEW_GATE_EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
           echo "Checking PR #${PR_NUMBER} for AI review bot activity..."
 
@@ -120,7 +136,13 @@ jobs:
           RESULT=""
           HELPER_EXIT=0
           HELPER_STDERR=$(mktemp)
-          RESULT=$(bash "${HELPER}" check "${PR_NUMBER}" "${REPO}" 2>"${HELPER_STDERR}") || HELPER_EXIT=$?
+          EVENT_RESULT=""
+          if EVENT_RESULT=$(bash "${HELPER}" event-check 2>"${HELPER_STDERR}"); then
+            RESULT="${EVENT_RESULT}"
+            echo "Accepted trusted review evidence from ${REVIEW_GATE_EVENT_NAME}:${REVIEW_GATE_EVENT_ACTION}."
+          else
+            RESULT=$(bash "${HELPER}" check "${PR_NUMBER}" "${REPO}" 2>"${HELPER_STDERR}") || HELPER_EXIT=$?
+          fi
           cat "${HELPER_STDERR}" >&2
 
           # API exhaustion is an infrastructure condition, not evidence that a

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -60,4 +60,9 @@ jobs:
         )
       )
     uses: ./.github/workflows/review-bot-gate-reusable.yml
+    # Self-modifying gate PRs must exercise their own helper revision. Without
+    # this, the reusable workflow fetches main and cannot validate a new helper
+    # command until after the PR that needs that command has merged.
+    with:
+      aidevops_ref: ${{ github.event.pull_request.head.sha || 'main' }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Use exact-head bot event evidence without extra API reads, ignore human and reply-only review events, and preserve successful review status during stale recovery

## Files Changed

.agents/scripts/dispatch-dedup-stale.sh, .agents/scripts/review-bot-gate-helper.sh, .agents/scripts/tests/test-review-bot-gate-completion-signal.sh, .agents/scripts/tests/test-stale-recovery-escalation.sh, .github/workflows/review-bot-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck; actionlint; 47 review-gate tests; 17 stale-recovery tests; linked-issue and reusable-workflow tests; linters-local.sh

Resolves #27633


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.117 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 16m and 233,795 tokens on this with the user in an interactive session.