### PR TITLE
GH#27696: persist direct release publication receipts

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -267,6 +267,20 @@ _full_loop_release_receipt_path() {
 	return 0
 }
 
+_full_loop_write_release_receipt() {
+	local repo="$1"
+	local pr_number="$2"
+	local status="$3"
+	[[ -n "$repo" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	[[ "$status" == "not-requested" || "$status" == "$_FULL_LOOP_RELEASE_PUBLISHED" || "$status" == "$_FULL_LOOP_PHASE_FAILED" ]] || return 1
+	local receipt_path=""
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
+	mkdir -p "${receipt_path%/*}" || return 1
+	printf '%s\n' "$status" >"${receipt_path}.tmp.$$" || return 1
+	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
+	return 0
+}
+
 _full_loop_persist_release_status() {
 	local status="$1"
 	local repo=""
@@ -276,12 +290,8 @@ _full_loop_persist_release_status() {
 	fi
 	[[ "${PR_NUMBER:-}" =~ ^[0-9]+$ ]] || return 0
 	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1
-	local receipt_path=""
-	receipt_path=$(_full_loop_release_receipt_path "$repo" "$PR_NUMBER") || return 1
-	mkdir -p "${receipt_path%/*}" || return 1
-	printf '%s\n' "$status" >"${receipt_path}.tmp.$$" || return 1
-	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
-	return 0
+	_full_loop_write_release_receipt "$repo" "$PR_NUMBER" "$status"
+	return $?
 }
 
 _full_loop_invoke_authorized_release() {

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 REPO_ROOT="$(git rev-parse --show-toplevel)" || exit 1
 _FULL_LOOP_RELEASE_PATH=""
+source "${SCRIPT_DIR}/full-loop-helper-state.sh"
 
 cleanup_release_worktree() {
 	local release_path="${_FULL_LOOP_RELEASE_PATH:-}"
@@ -35,14 +36,19 @@ main() {
 	local version_manager="${AIDEVOPS_FULL_LOOP_VERSION_MANAGER:-$release_path/.agents/scripts/version-manager.sh}"
 	[[ "$version_manager" = /* ]] || version_manager="$PWD/$version_manager"
 	[[ -f "$version_manager" ]] || return 1
-	(
+	if ! (
 		trap - EXIT
 		cd "$release_path" || exit 1
 		AIDEVOPS_RELEASE_INTENT_TRUSTED=1 \
 			AIDEVOPS_TRUSTED_ISSUE_PRIORITY="${AIDEVOPS_TRUSTED_ISSUE_PRIORITY:-}" \
 			AIDEVOPS_RELEASE_DEPLOY_SCOPE="$deployment_scope" \
 			bash "$version_manager" release "$release_type" --source-pr "$source_pr"
-	)
+	); then
+		return 1
+	fi
+	local repo=""
+	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1
+	_full_loop_write_release_receipt "$repo" "$source_pr" "$_FULL_LOOP_RELEASE_PUBLISHED"
 	return $?
 }
 

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -36,7 +36,7 @@ printf 'cwd=%s\n' "$PWD" >>"$VM_CALL_LOG"
 printf 'intent=%s\n' "${AIDEVOPS_RELEASE_INTENT_TRUSTED:-}" >>"$VM_CALL_LOG"
 printf 'priority=%s\n' "${AIDEVOPS_TRUSTED_ISSUE_PRIORITY:-}" >>"$VM_CALL_LOG"
 printf 'deploy=%s\n' "${AIDEVOPS_RELEASE_DEPLOY_SCOPE:-}" >>"$VM_CALL_LOG"
-exit 0
+exit "${VM_EXIT:-0}"
 STUB
 chmod +x "$ROOT/version-manager.sh"
 
@@ -48,6 +48,8 @@ chmod +x "$ROOT/version-manager.sh"
 		FAKE_REPO_ROOT="$ROOT/repo" \
 		AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" \
 		AIDEVOPS_FULL_LOOP_VERSION_MANAGER="../../version-manager.sh" \
+		AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts" \
+		AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
 		AIDEVOPS_TRUSTED_ISSUE_PRIORITY=critical \
 		bash "$SCRIPT_DIR/full-loop-release-helper.sh" minor 42 full
 )
@@ -59,10 +61,33 @@ grep -Eq "^cwd=${ROOT}/worktrees/aidevops-release-42-[0-9]+$" "$ROOT/vm.log"
 grep -qx 'intent=1' "$ROOT/vm.log"
 grep -qx 'priority=critical' "$ROOT/vm.log"
 grep -qx 'deploy=full' "$ROOT/vm.log"
+grep -qx 'published' "$ROOT/receipts/marcusquinn_aidevops-42.status"
 if compgen -G "$ROOT/worktrees/aidevops-release-42-*" >/dev/null; then
 	printf 'FAIL detached release worktree was not removed\n'
 	exit 1
 fi
-printf 'PASS detached release runner propagates explicit release and deployment scope\n'
+printf 'PASS detached release runner persists publication receipt after successful gates\n'
+
+if (
+	cd "$ROOT/repo/linked-branch"
+	PATH="$ROOT/bin:/usr/bin:/bin" \
+		GIT_CALL_LOG="$ROOT/git.log" \
+		VM_CALL_LOG="$ROOT/vm.log" \
+		VM_EXIT=1 \
+		FAKE_REPO_ROOT="$ROOT/repo" \
+		AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" \
+		AIDEVOPS_FULL_LOOP_VERSION_MANAGER="../../version-manager.sh" \
+		AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts" \
+		AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
+		bash "$SCRIPT_DIR/full-loop-release-helper.sh" patch 43 incremental
+); then
+	printf 'FAIL partial release returned success\n'
+	exit 1
+fi
+if [[ -e "$ROOT/receipts/marcusquinn_aidevops-43.status" ]]; then
+	printf 'FAIL partial release persisted a success receipt\n'
+	exit 1
+fi
+printf 'PASS failed release never persists publication receipt\n'
 
 exit 0


### PR DESCRIPTION
## Summary

- centralize repository/PR-scoped release receipt writes in `full-loop-helper-state.sh`
- persist `release:published` only after the direct release runner completes publication, deployment convergence, and postflight successfully
- cover successful and partial direct-release outcomes in the focused release-helper test

## Testing

- `bash .agents/scripts/tests/test-full-loop-release-helper.sh`
- `bash .agents/scripts/tests/test-full-loop-completion-evidence.sh`
- `shellcheck .agents/scripts/full-loop-release-helper.sh .agents/scripts/full-loop-helper-state.sh .agents/scripts/tests/test-full-loop-release-helper.sh`

Resolves #27696

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.118 plugin for [OpenCode](https://opencode.ai) v1.17.20
