### PR TITLE
GH#27702: resolve DSPy helper from install directory

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -141,7 +141,7 @@ fi
 unset _SHARED_CONSTANTS
 
 # Secure the optional DSPy disk cache before setup installs or imports DSPy.
-_DSPY_CACHE_SECURITY="${BASH_SOURCE[0]%/*}/.agents/scripts/dspy-cache-security.sh"
+_DSPY_CACHE_SECURITY="${INSTALL_DIR}/.agents/scripts/dspy-cache-security.sh"
 if [[ ! -f "$_DSPY_CACHE_SECURITY" ]]; then
 	_DSPY_CACHE_SECURITY="$HOME/.aidevops/agents/scripts/dspy-cache-security.sh"
 fi


### PR DESCRIPTION
## Summary

- resolve the DSPy cache security helper from the normalized absolute `INSTALL_DIR`
- preserve the deployed-helper fallback when the repository helper is unavailable
- ensure `bash setup.sh` loads the security helper instead of constructing `setup.sh/.agents/...`

Resolves #27702

## Testing

- `bash -n setup.sh`
- `shellcheck setup.sh`
- `.agents/scripts/tests/test-dspy-cache-security.sh`

## Runtime Testing

- self-assessed: low-risk one-line path resolution correction covered by syntax, static analysis, and the existing DSPy cache security test

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 90,184 tokens on this as a headless worker.
