### PR TITLE
GH#27705: fix: filter outdated quality feedback comments

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -98,16 +98,10 @@ _build_inline_findings() {
 
 		select($sev_num >= $min_num) |
 
-		# GitHub keeps original_line/position on comments whose reviewed line was
-		# replaced by a later PR commit, but clears line. Those stale comments are
-		# evidence about an earlier revision, not unactioned debt in the merged PR.
-		# Preserve modern file-level comments and legacy payloads that predate the
-		# line field while requiring a current line for modern line comments.
-		select(
-			.subject_type == "file" or
-			.line != null or
-			((has("line") | not) and .position != null)
-		) |
+		# Replaced PR lines retain original_line/position but clear line; suppress
+		# that stale evidence while preserving file comments and legacy payloads.
+		select(.subject_type == "file" or .line != null or
+			((has("line") | not) and .position != null)) |
 
 		{
 			pr: ($pr | tonumber),

--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -98,8 +98,16 @@ _build_inline_findings() {
 
 		select($sev_num >= $min_num) |
 
-		# Skip resolved/outdated comments
-		select(.position != null or .line != null or .original_line != null) |
+		# GitHub keeps original_line/position on comments whose reviewed line was
+		# replaced by a later PR commit, but clears line. Those stale comments are
+		# evidence about an earlier revision, not unactioned debt in the merged PR.
+		# Preserve modern file-level comments and legacy payloads that predate the
+		# line field while requiring a current line for modern line comments.
+		select(
+			.subject_type == "file" or
+			.line != null or
+			((has("line") | not) and .position != null)
+		) |
 
 		{
 			pr: ($pr | tonumber),

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -974,6 +974,25 @@ test_scan_single_pr_filters_resolved_review_threads() {
 	return 0
 }
 
+test_build_inline_findings_filters_outdated_pr_revision_comment() {
+	local comments findings urls
+	comments='[
+		{"id":3579184014,"user":{"login":"gemini-code-assist[bot]"},"path":"aidevops.sh","subject_type":"line","line":null,"original_line":336,"position":1,"original_position":33,"body":"Since git fetch already ran, you should avoid a redundant pull.","html_url":"https://example.invalid/outdated","created_at":"2026-07-14T12:00:00Z"},
+		{"id":3579184015,"user":{"login":"gemini-code-assist[bot]"},"path":"aidevops.sh","subject_type":"line","line":347,"original_line":347,"position":2,"original_position":34,"body":"You should retain this current-line finding.","html_url":"https://example.invalid/current","created_at":"2026-07-14T12:01:00Z"},
+		{"id":3579184016,"user":{"login":"gemini-code-assist[bot]"},"path":"aidevops.sh","subject_type":"file","line":null,"position":null,"body":"You should retain this file-level finding.","html_url":"https://example.invalid/file","created_at":"2026-07-14T12:02:00Z"}
+	]'
+
+	findings=$(_build_inline_findings "$comments" "27662" "medium")
+	urls=$(printf '%s' "$findings" | jq -r '[.[].url] | sort | join(",")')
+	if [[ "$urls" == "https://example.invalid/current,https://example.invalid/file" ]]; then
+		print_result "outdated inline comments from replaced PR revisions are filtered" 0
+	else
+		print_result "outdated inline comments from replaced PR revisions are filtered" 1 \
+			"unexpected findings: ${findings}"
+	fi
+	return 0
+}
+
 test_scan_single_pr_filters_parent_of_resolution_reply() {
 	reset_mock_state
 

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -206,6 +206,7 @@ run_positive_review_filter_regressions() {
 	test_scan_single_pr_filters_positive_inline_acknowledgement_reply
 	test_scan_single_pr_filters_parent_of_resolution_reply
 	test_scan_single_pr_filters_resolved_review_threads
+	test_build_inline_findings_filters_outdated_pr_revision_comment
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Suppress inline review comments whose reviewed line was replaced before merge while preserving current-line, file-level, and legacy review payloads; add a regression fixture based on PR #27662.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh, .agents/scripts/tests/test-quality-feedback-main-verification-scan.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-quality-feedback-main-verification.sh (82/82 passed); .agents/scripts/linters-local.sh (all local checks passed); ShellCheck and bash -n passed.

Resolves #27705


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.118 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 20m and 165,905 tokens on this as a headless worker.