### PR TITLE
GH#27701: fix: filter exact-head verification praise

### DIFF
--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -229,14 +229,8 @@ _apply_positive_filter() {
 			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
 			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
 
-		# Maintainer exact-head reviews commonly list verified fixes and passing
-		# suites. Historic terms such as "unsupported" and "failures" describe
-		# the fixed behaviour, not fresh findings. Keep reviews with contrast or
-		# unresolved-work language so real concerns are never hidden.
-		(($body | test("\\breviewed exact head\\b"; "i")) and
-		 ($body | test("\\b(corrects?|keeps?|preserves?|verif(y|ies|ied)|pass(es|ed)?)\\b"; "i")) and
-		 ($body | test("\\b(tests?|checks?|suites?)\\b"; "i")) and
-		 (($body | test("\\b(but|however|although|yet|except|still|remaining|unresolved)\\b"; "i")) | not)) as $exact_head_verification |
+		# Exact-head fix/pass evidence is praise unless contrast or unresolved-work language remains.
+		(($body | test("\\breviewed exact head\\b"; "i")) and ($body | test("\\b(corrects?|keeps?|preserves?|verif(y|ies|ied)|pass(es|ed)?)\\b"; "i")) and ($body | test("\\b(tests?|checks?|suites?)\\b"; "i")) and (($body | test("\\b(but|however|although|yet|except|still|remaining|unresolved)\\b"; "i")) | not)) as $exact_head_verification |
 
 		# Review summaries often describe the bug the PR already fixed, e.g.
 		# "corrects a broken URL". Do not treat those historic defect words as

--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -229,6 +229,15 @@ _apply_positive_filter() {
 			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
 			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
 
+		# Maintainer exact-head reviews commonly list verified fixes and passing
+		# suites. Historic terms such as "unsupported" and "failures" describe
+		# the fixed behaviour, not fresh findings. Keep reviews with contrast or
+		# unresolved-work language so real concerns are never hidden.
+		(($body | test("\\breviewed exact head\\b"; "i")) and
+		 ($body | test("\\b(corrects?|keeps?|preserves?|verif(y|ies|ied)|pass(es|ed)?)\\b"; "i")) and
+		 ($body | test("\\b(tests?|checks?|suites?)\\b"; "i")) and
+		 (($body | test("\\b(but|however|although|yet|except|still|remaining|unresolved)\\b"; "i")) | not)) as $exact_head_verification |
+
 		# Review summaries often describe the bug the PR already fixed, e.g.
 		# "corrects a broken URL". Do not treat those historic defect words as
 		# new quality-debt findings when the same body is otherwise praise-only.
@@ -256,7 +265,7 @@ _apply_positive_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $strong_actionable |
 
-		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not))) as $actionable |
+		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not)) and ($strong_actionable or ($exact_head_verification | not))) as $actionable |
 
 		($body | test(
 			"\\bmerging\\.?$|\\bmerge (this|the) pr\\b|" +
@@ -265,7 +274,7 @@ _apply_positive_filter() {
 			"\\breview.bot.gate (pass|ok)\\b|" +
 			"\\bpulse supervisor\\b"; "i")) as $merge_status_only |
 
-		select($include_positive or (((($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $merge_status_only) and ($actionable | not))) | not)) |
+		select($include_positive or (((($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $exact_head_verification or $merge_status_only) and ($actionable | not))) | not)) |
 
 		. + {_actionable: $actionable}]
 	' || echo "[]"

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -76,6 +76,11 @@ _test_approval_filter() {
 			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
 			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
 
+		(($body | test("\\breviewed exact head\\b"; "i")) and
+		 ($body | test("\\b(corrects?|keeps?|preserves?|verif(y|ies|ied)|pass(es|ed)?)\\b"; "i")) and
+		 ($body | test("\\b(tests?|checks?|suites?)\\b"; "i")) and
+		 (($body | test("\\b(but|however|although|yet|except|still|remaining|unresolved)\\b"; "i")) | not)) as $exact_head_verification |
+
 		($body | test(
 			"\\b(corrects?|fix(es|ed)?|replaces?|addresses?)\\b[^.\\n]*(\\bbroken\\b|\\bincorrect\\b|\\bwrong\\b|\\bbug\\b|\\berror\\b|\\bissue\\b)|" +
 			"\\b(change|fix) is correct\\b|\\bcorrect and improves?\\b"; "i")) as $historic_fix_praise |
@@ -100,7 +105,7 @@ _test_approval_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $strong_actionable |
 
-		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not))) as $actionable |
+		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not)) and ($strong_actionable or ($exact_head_verification | not))) as $actionable |
 
 		# GH#5668: merge/CI-status comments are not actionable review feedback
 		($body | test(
@@ -112,7 +117,7 @@ _test_approval_filter() {
 
 		# skip = approval-only/no-recommendation/no-suggestions/no-actionable sentiment
 		# or summary praise with no actionable critique, or merge/CI-status comment
-		if (($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $merge_status_only) and ($actionable | not)) then "skip"
+		if (($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $exact_head_verification or $merge_status_only) and ($actionable | not)) then "skip"
 		else "keep"
 		end
 	')
@@ -523,6 +528,39 @@ test_skips_pr26938_resolved_timeout_thread() {
 		print_result "skip PR #26938 resolved timeout thread" 0
 	else
 		print_result "skip PR #26938 resolved timeout thread" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
+test_skips_pr27659_exact_head_verification_review() {
+	local result
+	# Exact source review from PR #27659: failure-related words describe the
+	# verified fix and must not become a new quality-debt finding.
+	# shellcheck disable=SC1112,SC2016  # exact review contains Unicode punctuation and Markdown code spans
+	result=$(_test_approval_filter 'Reviewed exact head `492b3aace`.
+
+- Corrects the maintainer gate’s unsupported `gh api --slurp --jq` combination.
+- Keeps API and JSON parse failures fail-closed.
+- Maintainer gate regression suites and the full local quality suite pass.' "APPROVED")
+	if [[ "$result" == "skip" ]]; then
+		print_result "skip PR #27659 exact-head verification review" 0
+	else
+		print_result "skip PR #27659 exact-head verification review" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
+test_keeps_exact_head_verification_with_remaining_concern() {
+	local result
+	# shellcheck disable=SC2016  # literal review body includes a Markdown code span
+	result=$(_test_approval_filter 'Reviewed exact head `abcdef123`.
+
+- The regression suites pass.
+- However, this still needs error handling for malformed API output.' "APPROVED")
+	if [[ "$result" == "keep" ]]; then
+		print_result "keep exact-head verification with remaining concern" 0
+	else
+		print_result "keep exact-head verification with remaining concern" 1 "expected keep, got ${result}"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -76,10 +76,7 @@ _test_approval_filter() {
 			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
 			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
 
-		(($body | test("\\breviewed exact head\\b"; "i")) and
-		 ($body | test("\\b(corrects?|keeps?|preserves?|verif(y|ies|ied)|pass(es|ed)?)\\b"; "i")) and
-		 ($body | test("\\b(tests?|checks?|suites?)\\b"; "i")) and
-		 (($body | test("\\b(but|however|although|yet|except|still|remaining|unresolved)\\b"; "i")) | not)) as $exact_head_verification |
+		(($body | test("\\breviewed exact head\\b"; "i")) and ($body | test("\\b(corrects?|keeps?|preserves?|verif(y|ies|ied)|pass(es|ed)?)\\b"; "i")) and ($body | test("\\b(tests?|checks?|suites?)\\b"; "i")) and (($body | test("\\b(but|however|although|yet|except|still|remaining|unresolved)\\b"; "i")) | not)) as $exact_head_verification |
 
 		($body | test(
 			"\\b(corrects?|fix(es|ed)?|replaces?|addresses?)\\b[^.\\n]*(\\bbroken\\b|\\bincorrect\\b|\\bwrong\\b|\\bbug\\b|\\berror\\b|\\bissue\\b)|" +

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -201,6 +201,8 @@ source "${SCRIPT_DIR}/test-quality-feedback-main-verification-scan.sh"
 # --- Main ---
 
 run_positive_review_filter_regressions() {
+	test_skips_pr27659_exact_head_verification_review
+	test_keeps_exact_head_verification_with_remaining_concern
 	test_scan_single_pr_filters_issue4814_pr2166_exact_body
 	test_scan_single_pr_positive_body_with_inline_comments_not_summary_only
 	test_scan_single_pr_filters_positive_inline_acknowledgement_reply
@@ -270,8 +272,6 @@ main() {
 	test_skips_pr26877_regression_test_verification_ack
 	test_skips_pr26892_nongreedy_quantifier_ack
 	test_skips_pr26938_resolved_timeout_thread
-	test_skips_pr27659_exact_head_verification_review
-	test_keeps_exact_head_verification_with_remaining_concern
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -270,6 +270,8 @@ main() {
 	test_skips_pr26877_regression_test_verification_ack
 	test_skips_pr26892_nongreedy_quantifier_ack
 	test_skips_pr26938_resolved_timeout_thread
+	test_skips_pr27659_exact_head_verification_review
+	test_keeps_exact_head_verification_with_remaining_concern
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary

Filter positive exact-head maintainer verification reviews while retaining reviews with contrast or unresolved-work language; add exact-source and actionable-counterexample regression coverage.

## Files Changed

.agents/scripts/quality-feedback-findings-lib.sh, .agents/scripts/tests/test-quality-feedback-main-verification-approval.sh, .agents/scripts/tests/test-quality-feedback-main-verification.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 83/83 quality-feedback verification tests; changed-file bash -n and ShellCheck; function-complexity regression gate passes.

Resolves #27701


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.118 plugin for [OpenCode](https://opencode.ai) v1.17.20 with gpt-5.6-sol spent 25m and 134,705 tokens on this as a headless worker.