### PR TITLE
GH#27694: stop exit-78 retries for completed workers

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1777,6 +1777,15 @@ cmd_run() {
 		# Track cumulative stall events per session and apply hard-kill caps
 		# before retrying — unbounded stall-continue burns tokens indefinitely.
 		if [[ "$attempt_exit" -eq 78 ]]; then
+			# GH#27694: A worker can be killed after its PR merged and issue
+			# closed. Confirm that external terminal state before any continuation
+			# can seed another isolated database or launch another runtime. Unknown
+			# or failed GitHub reads return non-zero and preserve normal recovery.
+			if _worker_external_terminal_complete "$session_key" "$work_dir"; then
+				print_info "[lifecycle] exit-78 continuation skipped — external terminal state already complete"
+				_cmd_run_finish "$session_key" "fail" "$work_dir" "1"
+				return 0
+			fi
 			if [[ "${_run_failure_reason:-}" == "startup_no_model_activity" ]]; then
 				record_startup_no_model_feedback "$selected_model"
 			fi

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1337,9 +1337,11 @@ _hrw_run_finish_crash_type() {
 _hrw_finish_failed_run() {
 	local session_key="$1"
 	local work_dir="$2"
+	local external_terminal_confirmed="${3:-0}"
 	local failure_recovered=0
 
-	if _worker_external_terminal_complete "$session_key" "$work_dir"; then
+	if [[ "$external_terminal_confirmed" -eq 1 ]] || \
+		_worker_external_terminal_complete "$session_key" "$work_dir"; then
 		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
 		failure_recovered=1
 	elif _recover_worker_output_on_failure "$session_key" "$work_dir"; then
@@ -1569,6 +1571,10 @@ _cmd_run_finish() {
 	# _worker_produced_output() classifies tangible output to distinguish
 	# worker_complete, worker_branch_orphan, and worker_noop (GH#20721, GH#20819).
 	local work_dir="${3:-${_WORKER_WORKTREE_PATH:-}}"
+	# Optional $4 carries a terminal-state proof already confirmed at a retry
+	# boundary. Reusing it avoids a second GitHub query that could fail after the
+	# first query already proved the issue and matching PR are terminal.
+	local external_terminal_confirmed="${4:-0}"
 	_HRW_FINAL_RUNTIME_EVENT="worker.completed"
 	_HRW_FINAL_RUNTIME_STATUS="${_run_result_label:-$ledger_status}"
 	_HRW_FINAL_RUNTIME_CLASSIFICATION="${_run_failure_reason:-}"
@@ -1590,7 +1596,7 @@ _cmd_run_finish() {
 	# create a PR with Closes, the PR-based dedup signal still wins and the
 	# CLAIM_RELEASED comment is redundant operational metadata.
 	if [[ "$ledger_status" == "$_HRW_STATUS_FAIL" ]]; then
-		_hrw_finish_failed_run "$session_key" "$work_dir"
+		_hrw_finish_failed_run "$session_key" "$work_dir" "$external_terminal_confirmed"
 	elif [[ "$ledger_status" == "rate_limit_fast" ]]; then
 		_hrw_finish_rate_limit_fast_run "$session_key"
 		_HRW_FINAL_RUNTIME_EVENT="worker.deferred"

--- a/.agents/scripts/tests/test-watchdog-stall-cap.sh
+++ b/.agents/scripts/tests/test-watchdog-stall-cap.sh
@@ -153,6 +153,60 @@ test_defaults_applied_when_args_omitted() {
 # This test stubs all external dependencies so no real processes are launched.
 # ──────────────────────────────────────────────────────────────────────────────
 
+test_cmd_run_finishes_confirmed_terminal_worker_before_continuation() {
+	local execute_calls=0
+	local external_checks=0
+	local released_reason=""
+	local fast_fail_calls=0
+	local recorded_outcome=""
+	local runtime_status=""
+
+	_execute_run_attempt() {
+		execute_calls=$((execute_calls + 1))
+		_run_result_label="signal_killed_continue"
+		_run_failure_reason="signal_killed_continue"
+		_run_activity_detected="1"
+		return 78
+	}
+	_worker_external_terminal_complete() {
+		external_checks=$((external_checks + 1))
+		return 0
+	}
+	_release_dispatch_claim() { released_reason="$2"; return 0; }
+	_recover_worker_output_on_failure() { return 1; }
+	_report_failure_to_fast_fail() { fast_fail_calls=$((fast_fail_calls + 1)); return 0; }
+	_hrw_record_terminal_outcome() { recorded_outcome="$2"; return 0; }
+	_emit_worker_runtime_event() { runtime_status="$2"; return 0; }
+	_update_dispatch_ledger() { return 0; }
+	_release_session_lock() { return 0; }
+	_hrw_release_worker_worktree() { return 0; }
+	_cleanup_headless_runtime_temp_paths() { return 0; }
+	_cmd_run_prepare() { return 0; }
+	choose_model() { printf '%s' "anthropic/claude-sonnet-4-6"; return 0; }
+	_enforce_opencode_version_pin() { return 0; }
+	_run_canary_test() { return 0; }
+	append_worker_headless_contract() { printf '%s' "$1"; return 0; }
+	resolve_headless_variant() { printf '%s' "default"; return 0; }
+	extract_provider() { printf '%s' "anthropic"; return 0; }
+
+	export AIDEVOPS_HEADLESS_APPEND_CONTRACT=0
+	local cmd_exit=0
+	cmd_run --role worker --session-key "test-terminal-recovery" \
+		--dir "/tmp" --title "test" --prompt "test prompt" 2>/dev/null || cmd_exit=$?
+
+	local passed=1
+	local msg=""
+	if [[ "$cmd_exit" -eq 0 && "$execute_calls" -eq 1 && "$external_checks" -eq 1 && \
+		"$released_reason" == "worker_complete" && "$fast_fail_calls" -eq 0 && \
+		"$recorded_outcome" == "success" && "$runtime_status" == "recovered" ]]; then
+		passed=0
+	else
+		msg="exit=${cmd_exit} execute=${execute_calls} checks=${external_checks} release=${released_reason:-<empty>} fast_fail=${fast_fail_calls} outcome=${recorded_outcome:-<empty>} status=${runtime_status:-<empty>}"
+	fi
+	print_result "exit 78 finishes externally terminal worker before continuation" "$passed" "$msg"
+	return 0
+}
+
 test_cmd_run_kills_after_stall_cap() {
 	# Stub heavy functions so cmd_run doesn't spin up real processes.
 	local _metric_result=""
@@ -169,6 +223,7 @@ test_cmd_run_kills_after_stall_cap() {
 		_run_should_retry=0
 		return 78
 	}
+	_worker_external_terminal_complete() { return 1; }
 
 	append_runtime_metric() {
 		# Capture the result field (argument $5)
@@ -210,7 +265,7 @@ test_cmd_run_kills_after_stall_cap() {
 	local msg=""
 
 	# The stall cap should have fired and recorded watchdog_stall_killed.
-	if [[ "$_metric_result" == "watchdog_stall_killed" ]]; then
+	if [[ "$_metric_result" == "watchdog_stall_killed" && "$_execute_calls" -eq 4 ]]; then
 		passed=0
 	else
 		msg="metric_result='${_metric_result}' expected 'watchdog_stall_killed'; execute_calls=${_execute_calls}"
@@ -236,6 +291,7 @@ test_cmd_run_does_not_duplicate_exit_79_metric() {
 			watchdog_stall_killed 79 watchdog_stall_killed 1 100
 		return 79
 	}
+	_worker_external_terminal_complete() { return 1; }
 	_cmd_run_finish() { finish_status="${2:-}"; return 0; }
 
 	local cmd_exit=0
@@ -266,6 +322,7 @@ main() {
 	test_defaults_applied_when_args_omitted
 
 	# cmd_run integration test
+	test_cmd_run_finishes_confirmed_terminal_worker_before_continuation
 	test_cmd_run_kills_after_stall_cap
 	test_cmd_run_does_not_duplicate_exit_79_metric
 


### PR DESCRIPTION
## Summary

Check confirmed closed-issue plus matching merged-PR state before exit-78 continuation setup, then reuse recovered-success finalization without a second GitHub proof.

## Files Changed

.agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/tests/test-watchdog-stall-cap.sh

## Runtime Testing

- **Risk level:** High (worker retry state machine and external lifecycle checks)
- **Verification:** Runtime-verified through the `cmd_run` state-machine regression. Runtime state-machine regression: test-watchdog-stall-cap.sh (10/10); test-headless-runtime-helper.sh (124/124); bash -n; ShellCheck; linters-local.sh; git diff --check.

- **Additional evidence:** `test-headless-runtime-helper.sh` passed 124/124; the focused exit-78 suite proves externally complete workers execute once while inconclusive workers retain four-attempt stall-cap behavior.

## Key Decision

Forward the already-confirmed terminal proof into recovered-success finalization. This avoids a second GitHub query while preserving fail-open continuation on unknown or failed external-state reads.

Resolves #27694


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 17m and 168,775 tokens on this with the user in an interactive session.