### PR TITLE
GH#27693: protect managed workers from generic process guard

### DIFF
--- a/.agents/scripts/process-guard-helper.sh
+++ b/.agents/scripts/process-guard-helper.sh
@@ -22,7 +22,7 @@
 #
 # Configuration (environment variables):
 #   CHILD_RSS_LIMIT_KB     - Max RSS per child process (default: 2097152 = 2GB)
-#   CHILD_RUNTIME_LIMIT    - Max runtime in seconds (default: 600 = 10min)
+#   CHILD_RUNTIME_LIMIT    - Max unmanaged runtime in seconds (default: 7200 = 2h)
 #   SHELLCHECK_RSS_LIMIT_KB - ShellCheck-specific RSS limit (default: 1048576 = 1GB)
 #   SHELLCHECK_RUNTIME_LIMIT - ShellCheck-specific runtime (default: 300 = 5min)
 #   STALE_PLAYWRIGHT_LIST_AGE_LIMIT - Max aidevops Playwright --list age (default: 900 = 15min)
@@ -62,15 +62,18 @@ _validate_int() {
 
 # Configuration defaults
 CHILD_RSS_LIMIT_KB="${CHILD_RSS_LIMIT_KB:-2097152}"
-CHILD_RUNTIME_LIMIT="${CHILD_RUNTIME_LIMIT:-600}"
+CHILD_RUNTIME_LIMIT="${CHILD_RUNTIME_LIMIT:-7200}"
 SHELLCHECK_RSS_LIMIT_KB="${SHELLCHECK_RSS_LIMIT_KB:-1048576}"
 SHELLCHECK_RUNTIME_LIMIT="${SHELLCHECK_RUNTIME_LIMIT:-300}"
 STALE_PLAYWRIGHT_LIST_AGE_LIMIT="${STALE_PLAYWRIGHT_LIST_AGE_LIMIT:-900}"
 SESSION_COUNT_WARN="${SESSION_COUNT_WARN:-5}"
+readonly PROCESS_RUNTIME_OK="OK"
+readonly PROCESS_RUNTIME_MANAGED="MANAGED"
+readonly PROCESS_RUNTIME_OVER="OVER"
 
 # Validate all numeric config to prevent command injection via arithmetic expansion
 CHILD_RSS_LIMIT_KB=$(_validate_int CHILD_RSS_LIMIT_KB "$CHILD_RSS_LIMIT_KB" 2097152 1)
-CHILD_RUNTIME_LIMIT=$(_validate_int CHILD_RUNTIME_LIMIT "$CHILD_RUNTIME_LIMIT" 600 1)
+CHILD_RUNTIME_LIMIT=$(_validate_int CHILD_RUNTIME_LIMIT "$CHILD_RUNTIME_LIMIT" 7200 1)
 SHELLCHECK_RSS_LIMIT_KB=$(_validate_int SHELLCHECK_RSS_LIMIT_KB "$SHELLCHECK_RSS_LIMIT_KB" 1048576 1)
 SHELLCHECK_RUNTIME_LIMIT=$(_validate_int SHELLCHECK_RUNTIME_LIMIT "$SHELLCHECK_RUNTIME_LIMIT" 300 1)
 STALE_PLAYWRIGHT_LIST_AGE_LIMIT=$(_validate_int STALE_PLAYWRIGHT_LIST_AGE_LIMIT "$STALE_PLAYWRIGHT_LIST_AGE_LIMIT" 900 60)
@@ -114,6 +117,68 @@ _get_process_cwd() {
 		cwd_path=$(readlink "/proc/${pid}/cwd" 2>/dev/null || true)
 	fi
 	printf '%s' "$cwd_path"
+	return 0
+}
+
+#######################################
+# Return whether a process belongs to a systemd-managed aidevops worker.
+# All descendants of a transient worker service share its cgroup, so this
+# verifies lifecycle ownership without relying on mutable command strings.
+# Arguments:
+#   $1 - PID
+# Returns: 0 for managed worker lineage, 1 otherwise
+#######################################
+_is_managed_worker_process() {
+	local pid="$1"
+	local proc_root="${AIDEVOPS_PROCESS_GUARD_PROC_ROOT:-/proc}"
+	local cgroup_file="${proc_root%/}/${pid}/cgroup"
+	local cgroup_line=""
+	local cgroup_path=""
+	local worker_unit_regex='/aidevops-worker(-monitor|-observer)?-[0-9]+-[0-9]+-[0-9]+\.service(/|$)'
+
+	[[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ -r "$cgroup_file" ]] || return 1
+
+	while IFS= read -r cgroup_line || [[ -n "$cgroup_line" ]]; do
+		# cgroup v1: hierarchy:controllers:path; cgroup v2: 0::path.
+		cgroup_path="${cgroup_line#*:*:}"
+		if [[ "$cgroup_path" =~ $worker_unit_regex ]]; then
+			return 0
+		fi
+	done <"$cgroup_file"
+
+	return 1
+}
+
+#######################################
+# Classify a process against the generic runtime limit.
+# Managed worker services delegate runtime decisions to their lifecycle-aware
+# watchdog/sandbox controls. RSS limits remain independently enforced.
+# Arguments:
+#   $1 - PID
+#   $2 - process age in seconds
+#   $3 - generic runtime limit in seconds
+# Output: OK, MANAGED, or OVER
+#######################################
+_classify_runtime_limit() {
+	local pid="$1"
+	local age_seconds="$2"
+	local runtime_limit="$3"
+
+	if [[ ! "$age_seconds" =~ ^[0-9]+$ || ! "$runtime_limit" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$PROCESS_RUNTIME_OK"
+		return 0
+	fi
+	if [[ "$age_seconds" -le "$runtime_limit" ]]; then
+		printf '%s' "$PROCESS_RUNTIME_OK"
+		return 0
+	fi
+	if _is_managed_worker_process "$pid"; then
+		printf '%s' "$PROCESS_RUNTIME_MANAGED"
+		return 0
+	fi
+
+	printf '%s' "$PROCESS_RUNTIME_OVER"
 	return 0
 }
 
@@ -279,6 +344,7 @@ cmd_scan() {
 
 		local age_seconds
 		age_seconds=$(_get_process_age "$pid")
+		local runtime_status
 		local cwd_path
 		cwd_path=$(_get_process_cwd "$pid")
 
@@ -288,6 +354,7 @@ cmd_scan() {
 			rss_limit="$SHELLCHECK_RSS_LIMIT_KB"
 			runtime_limit="$SHELLCHECK_RUNTIME_LIMIT"
 		fi
+		runtime_status=$(_classify_runtime_limit "$pid" "$age_seconds" "$runtime_limit")
 
 		local status="OK"
 		local detail=""
@@ -299,10 +366,13 @@ cmd_scan() {
 			status="OVER_RSS"
 			detail="RSS ${rss_mb}MB > $((rss_limit / 1024))MB"
 			violations=$((violations + 1))
-		elif [[ "$age_seconds" -gt "$runtime_limit" ]]; then
+		elif [[ "$runtime_status" == "$PROCESS_RUNTIME_OVER" ]]; then
 			status="OVER_TIME"
 			detail="runtime ${age_seconds}s > ${runtime_limit}s"
 			violations=$((violations + 1))
+		elif [[ "$runtime_status" == "$PROCESS_RUNTIME_MANAGED" ]]; then
+			status="MANAGED"
+			detail="runtime delegated to worker lifecycle controls"
 		elif [[ "$cmd_base" == "shellcheck" ]]; then
 			[[ "$ppid" =~ ^[0-9]+$ ]] || ppid=0
 			if [[ "$ppid" -eq 1 ]] && [[ "$age_seconds" -gt 120 ]]; then
@@ -369,6 +439,7 @@ cmd_kill_runaways() {
 
 		local age_seconds
 		age_seconds=$(_get_process_age "$pid")
+		local runtime_status
 		local cwd_path
 		cwd_path=$(_get_process_cwd "$pid")
 
@@ -378,13 +449,20 @@ cmd_kill_runaways() {
 			rss_limit="$SHELLCHECK_RSS_LIMIT_KB"
 			runtime_limit="$SHELLCHECK_RUNTIME_LIMIT"
 		fi
+		runtime_status=$(_classify_runtime_limit "$pid" "$age_seconds" "$runtime_limit")
 
 		local violation=""
 		if [[ "$rss" -gt "$rss_limit" ]]; then
 			local rss_mb=$((rss / 1024))
 			violation="RSS ${rss_mb}MB > $((rss_limit / 1024))MB"
-		elif [[ "$age_seconds" -gt "$runtime_limit" ]]; then
+		elif [[ "$runtime_status" == "$PROCESS_RUNTIME_OVER" ]]; then
 			violation="runtime ${age_seconds}s > ${runtime_limit}s"
+		fi
+
+		# Managed worker trees have dedicated activity, sandbox, service, and
+		# lease controls. Do not apply any generic age-based cleanup to them.
+		if [[ -z "$violation" && "$runtime_status" == "$PROCESS_RUNTIME_MANAGED" ]]; then
+			continue
 		fi
 
 		# Orphan shellcheck reaper: if parent is PID 1 (reparented because the
@@ -487,6 +565,7 @@ cmd_status() {
 		cmd_base="${cmd_base##*/}"
 		local age_seconds
 		age_seconds=$(_get_process_age "$pid")
+		local runtime_status
 		local cwd_path
 		cwd_path=$(_get_process_cwd "$pid")
 		local rss_limit="$CHILD_RSS_LIMIT_KB"
@@ -495,8 +574,11 @@ cmd_status() {
 			rss_limit="$SHELLCHECK_RSS_LIMIT_KB"
 			runtime_limit="$SHELLCHECK_RUNTIME_LIMIT"
 		fi
-		if [[ "$rss" -gt "$rss_limit" ]] || [[ "$age_seconds" -gt "$runtime_limit" ]]; then
+		runtime_status=$(_classify_runtime_limit "$pid" "$age_seconds" "$runtime_limit")
+		if [[ "$rss" -gt "$rss_limit" ]] || [[ "$runtime_status" == "$PROCESS_RUNTIME_OVER" ]]; then
 			violations=$((violations + 1))
+		elif [[ "$runtime_status" == "$PROCESS_RUNTIME_MANAGED" ]]; then
+			continue
 		elif [[ "$cmd_base" == "shellcheck" ]]; then
 			[[ "$ppid" =~ ^[0-9]+$ ]] || ppid=0
 			if [[ "$ppid" -eq 1 ]] && [[ "$age_seconds" -gt 120 ]]; then
@@ -598,7 +680,10 @@ main() {
 	case "$command" in
 	scan) cmd_scan ;;
 	kill-runaways) cmd_kill_runaways ;;
-	match-playwright-list) shift; cmd_match_playwright_list "$@" ;;
+	match-playwright-list)
+		shift
+		cmd_match_playwright_list "$@"
+		;;
 	sessions) cmd_sessions ;;
 	status) cmd_status ;;
 	help | --help | -h) cmd_help ;;
@@ -610,4 +695,6 @@ main() {
 	esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-process-guard-managed-workers.sh
+++ b/.agents/scripts/tests/test-process-guard-managed-workers.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+HELPER="${REPO_ROOT}/.agents/scripts/process-guard-helper.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/process-guard-managed.XXXXXX")"
+export HOME="${TEST_ROOT}/home"
+export AIDEVOPS_PROCESS_GUARD_PROC_ROOT="${TEST_ROOT}/proc"
+mkdir -p "$HOME" "$AIDEVOPS_PROCESS_GUARD_PROC_ROOT"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+# shellcheck source=../process-guard-helper.sh
+source "$HELPER"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+MOCK_PROCESS_LINE=""
+MOCK_PROCESS_AGE=0
+MOCK_KILL_LOG="${TEST_ROOT}/kill.log"
+
+_list_ai_processes() {
+	printf '%s\n' "$MOCK_PROCESS_LINE"
+	return 0
+}
+
+_get_process_age() {
+	local pid="$1"
+	: "$pid"
+	printf '%s' "$MOCK_PROCESS_AGE"
+	return 0
+}
+
+_get_process_cwd() {
+	local pid="$1"
+	: "$pid"
+	printf '%s' "${TEST_ROOT}/worktree"
+	return 0
+}
+
+kill() {
+	printf '%s\n' "$*" >>"$MOCK_KILL_LOG"
+	return 0
+}
+
+sleep() {
+	local seconds="$1"
+	: "$seconds"
+	return 0
+}
+
+assert_eq() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$actual" == "$expected" ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+	printf 'FAIL %s\n     expected=%s actual=%s\n' "$test_name" "$expected" "$actual"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+write_cgroup() {
+	local pid="$1"
+	local cgroup_path="$2"
+	mkdir -p "${AIDEVOPS_PROCESS_GUARD_PROC_ROOT}/${pid}"
+	printf '0::%s\n' "$cgroup_path" >"${AIDEVOPS_PROCESS_GUARD_PROC_ROOT}/${pid}/cgroup"
+	return 0
+}
+
+test_managed_worker_runtime_is_delegated() {
+	write_cgroup 4101 '/user.slice/user-1000.slice/user@1000.service/app.slice/aidevops-worker-27693-4001-17.service'
+	local actual
+	actual=$(_classify_runtime_limit 4101 2064 600)
+	assert_eq "managed worker older than generic limit is delegated" "MANAGED" "$actual"
+	return 0
+}
+
+test_managed_worker_descendant_is_delegated() {
+	write_cgroup 4102 '/user.slice/user-1000.slice/user@1000.service/app.slice/aidevops-worker-27693-4001-17.service/runtime.scope'
+	local actual
+	actual=$(_classify_runtime_limit 4102 966 600)
+	assert_eq "managed worker descendant inherits service protection" "MANAGED" "$actual"
+	return 0
+}
+
+test_managed_observer_runtime_is_delegated() {
+	write_cgroup 4103 '/user.slice/user-1000.slice/user@1000.service/app.slice/aidevops-worker-observer-27693-4001-18.service'
+	local actual
+	actual=$(_classify_runtime_limit 4103 1200 600)
+	assert_eq "managed worker observer is delegated" "MANAGED" "$actual"
+	return 0
+}
+
+test_unmanaged_lookalike_remains_over_limit() {
+	write_cgroup 4201 '/user.slice/user-1000.slice/session-2.scope'
+	local actual
+	actual=$(_classify_runtime_limit 4201 966 600)
+	assert_eq "unmanaged process remains eligible" "OVER" "$actual"
+	return 0
+}
+
+test_command_string_is_not_lineage_evidence() {
+	write_cgroup 4202 '/user.slice/user-1000.slice/aidevops-worker-not-a-real-unit.scope'
+	local actual
+	actual=$(_classify_runtime_limit 4202 966 600)
+	assert_eq "worker-like cgroup text without valid service identity is rejected" "OVER" "$actual"
+	return 0
+}
+
+test_unavailable_cgroup_keeps_existing_behavior() {
+	local actual
+	actual=$(_classify_runtime_limit 4301 966 600)
+	assert_eq "missing cgroup evidence fails closed to generic guard" "OVER" "$actual"
+	return 0
+}
+
+test_fresh_managed_worker_is_not_misreported() {
+	write_cgroup 4401 '/user.slice/user-1000.slice/user@1000.service/app.slice/aidevops-worker-27693-4001-19.service'
+	local actual
+	actual=$(_classify_runtime_limit 4401 300 600)
+	assert_eq "fresh worker remains under limit" "OK" "$actual"
+	return 0
+}
+
+test_kill_runaways_skips_managed_worker() {
+	write_cgroup 4501 '/user.slice/user-1000.slice/user@1000.service/app.slice/aidevops-worker-27693-4001-20.service'
+	MOCK_PROCESS_LINE='4501 1 ? 1024 16:06 bash /usr/bin/bash worker-wrapper opencode run'
+	MOCK_PROCESS_AGE=966
+	CHILD_RUNTIME_LIMIT=600
+	: >"$MOCK_KILL_LOG"
+	local output
+	output=$(cmd_kill_runaways)
+	assert_eq "kill path skips old managed worker" "No runaway processes found" "$output"
+	assert_eq "managed worker receives no signal" "" "$(<"$MOCK_KILL_LOG")"
+	return 0
+}
+
+test_kill_runaways_keeps_unmanaged_cleanup() {
+	write_cgroup 4502 '/user.slice/user-1000.slice/session-2.scope'
+	MOCK_PROCESS_LINE='4502 1 ? 1024 16:06 bash /usr/bin/bash stale-wrapper opencode run'
+	MOCK_PROCESS_AGE=966
+	CHILD_RUNTIME_LIMIT=600
+	: >"$MOCK_KILL_LOG"
+	local output
+	output=$(cmd_kill_runaways)
+	if [[ "$output" == *"Killing PID 4502"* && "$(<"$MOCK_KILL_LOG")" == *"4502"* ]]; then
+		assert_eq "unmanaged orphan remains kill-eligible" "eligible" "eligible"
+	else
+		assert_eq "unmanaged orphan remains kill-eligible" "kill signal for 4502" "$output / $(<"$MOCK_KILL_LOG")"
+	fi
+	return 0
+}
+
+test_status_matches_kill_exemption() {
+	write_cgroup 4503 '/user.slice/user-1000.slice/user@1000.service/app.slice/aidevops-worker-27693-4001-21.service'
+	MOCK_PROCESS_LINE='4503 1 ? 1024 16:06 bash /usr/bin/bash worker-wrapper opencode run'
+	MOCK_PROCESS_AGE=966
+	CHILD_RUNTIME_LIMIT=600
+	local output
+	output=$(cmd_status)
+	if [[ "$output" == *'"violations":0'* ]]; then
+		assert_eq "status excludes managed runtime from violations" "0" "0"
+	else
+		assert_eq "status excludes managed runtime from violations" '"violations":0' "$output"
+	fi
+	return 0
+}
+
+main() {
+	test_managed_worker_runtime_is_delegated
+	test_managed_worker_descendant_is_delegated
+	test_managed_observer_runtime_is_delegated
+	test_unmanaged_lookalike_remains_over_limit
+	test_command_string_is_not_lineage_evidence
+	test_unavailable_cgroup_keeps_existing_behavior
+	test_fresh_managed_worker_is_not_misreported
+	test_kill_runaways_skips_managed_worker
+	test_kill_runaways_keeps_unmanaged_cleanup
+	test_status_matches_kill_exemption
+
+	printf '\n%s/%s tests passed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Use verified systemd cgroup lineage to delegate managed-worker runtime decisions while retaining RSS enforcement and unmanaged orphan cleanup; align the standalone default with the documented 7200-second scheduler limit.

## Files Changed

.agents/scripts/process-guard-helper.sh, .agents/scripts/tests/test-process-guard-managed-workers.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** runtime-verified fixture: 11 managed/unmanaged kill-path and status tests; existing 7 Playwright guard tests; ShellCheck; shfmt; linters-local.sh

Resolves #27693


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 19m and 213,624 tokens on this with the user in an interactive session.