### PR TITLE
GH#27714: block invalid OpenCode plugin bundle activation

### DIFF
--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -375,14 +375,43 @@ _verify_deployed_core_plugin_freshness() {
 	return 0
 }
 
+# _verify_opencode_plugin_deps plugin_dir
+# Imports both runtime dependencies with a JavaScript runtime before a bundle is
+# eligible for activation. Prefer Bun because OpenCode embeds Bun; use Node when
+# the standalone Bun CLI is unavailable.
+_verify_opencode_plugin_deps() {
+	local plugin_dir="$1"
+	local js_runtime=""
+
+	if command -v bun >/dev/null 2>&1; then
+		js_runtime="bun"
+	elif command -v node >/dev/null 2>&1; then
+		js_runtime="node"
+	else
+		printf 'Neither bun nor node is available for plugin dependency verification\n' >&2
+		return 1
+	fi
+
+	if (
+		cd "$plugin_dir" || exit 1
+		"$js_runtime" -e 'Promise.all([import("@bufbuild/protobuf"), import("@opencode-ai/plugin")]).then(([, plugin]) => { if (!plugin.tool || !plugin.tool.schema) throw new Error("@opencode-ai/plugin does not export tool.schema"); }).catch((error) => { console.error(error.message); process.exit(1); })'
+	); then
+		return 0
+	fi
+	return 1
+}
+
 # _install_opencode_plugin_deps target_dir
-# Installs node_modules for the opencode-aidevops plugin.
+# Installs and verifies node_modules for the opencode-aidevops plugin.
 # GH#17829: @bufbuild/protobuf was missing; GH#17891: only symlink on first run.
 # Uses --omit=peer to skip the 630MB opencode-ai peer dep (the host app).
+# GH#27714: installation or import failure must block bundle activation.
 _install_opencode_plugin_deps() {
 	local target_dir="$1"
 	local oc_node_modules="$HOME/.config/opencode/node_modules"
 	local plugin_dir="$target_dir/plugins/opencode-aidevops"
+	local install_log=""
+	local verify_output=""
 
 	if [[ ! -d "$plugin_dir" ]]; then
 		return 0
@@ -395,14 +424,32 @@ _install_opencode_plugin_deps() {
 		fi
 	fi
 
-	# Verify critical dependency is available; npm install if not
-	if [[ ! -d "$plugin_dir/node_modules/@bufbuild/protobuf" ]]; then
-		if command -v npm &>/dev/null; then
-			# Remove symlink if present so npm creates a local node_modules
-			[[ -L "$plugin_dir/node_modules" ]] && rm "$plugin_dir/node_modules"
-			npm install --omit=dev --omit=peer --prefix "$plugin_dir" >/dev/null 2>&1 ||
-				print_warning "Failed to install plugin dependencies (non-blocking)"
-		fi
+	if verify_output=$(_verify_opencode_plugin_deps "$plugin_dir" 2>&1); then
+		return 0
+	fi
+
+	if ! command -v npm >/dev/null 2>&1; then
+		print_error "Plugin dependencies are unavailable and npm is not installed: ${verify_output:-import failed}"
+		return 1
+	fi
+
+	# Remove the shared symlink so npm installs the declared versions locally.
+	[[ -L "$plugin_dir/node_modules" ]] && rm "$plugin_dir/node_modules"
+	install_log=$(mktemp "${TMPDIR:-/tmp}/aidevops-plugin-install.XXXXXX") || {
+		print_error "Failed to create the plugin dependency install log"
+		return 1
+	}
+	if ! npm install --omit=dev --omit=peer --prefix "$plugin_dir" >"$install_log" 2>&1; then
+		print_error "Failed to install OpenCode plugin dependencies; runtime bundle activation blocked"
+		tail -n 12 "$install_log" >&2
+		rm -f "$install_log"
+		return 1
+	fi
+	rm -f "$install_log"
+
+	if ! verify_output=$(_verify_opencode_plugin_deps "$plugin_dir" 2>&1); then
+		print_error "OpenCode plugin dependency verification failed after install: ${verify_output:-import failed}"
+		return 1
 	fi
 	return 0
 }
@@ -881,7 +928,7 @@ _deploy_agents_post_copy() {
 	local plugins_file="$4"
 
 	_set_script_permissions_and_report "$target_dir"
-	_install_opencode_plugin_deps "$target_dir"
+	_install_opencode_plugin_deps "$target_dir" || return 1
 	_deploy_version_file "$target_dir" "$repo_dir"
 	_deploy_security_advisories_files "$source_dir"
 	_inject_plan_reminder "$target_dir"

--- a/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
+++ b/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
@@ -303,6 +303,9 @@ test_no_change_corrupt_live_scripts_reserved_namespace_recovers() {
 
 	mkdir -p "$repo/.agents/scripts" "$target" "$(dirname "$plugins_file")" "${TEST_DIR}/.aidevops"
 	printf 'canonical script\n' >"$repo/.agents/scripts/hello.sh"
+	printf '#!/usr/bin/env bash\nexec git "$@"\n' >"$repo/.agents/scripts/git"
+	printf '#!/usr/bin/env bash\n' >"$repo/aidevops.sh"
+	chmod +x "$repo/.agents/scripts/git"
 	printf '%s\n' "$sha" >"${TEST_DIR}/.aidevops/.deployed-sha"
 	printf '{"plugins":[{"name":"bad","namespace":"scripts","repo":"unused"}]}\n' >"$plugins_file"
 

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -66,6 +66,7 @@ assert_file_contains() {
 write_fake_revision() {
 	local version="$1"
 	local marker="$2"
+	rm -rf "$FAKE_REPO/.agents/plugins"
 	mkdir -p "$FAKE_REPO/.agents/scripts"
 	printf '%s\n' "$version" >"$FAKE_REPO/VERSION"
 	printf '#!/usr/bin/env bash\nprintf %s\\n "%s"\n' '%s' "$version" >"$FAKE_REPO/aidevops.sh"
@@ -73,6 +74,22 @@ write_fake_revision() {
 	printf '#!/usr/bin/env bash\nexec git "$@"\n' >"$FAKE_REPO/.agents/scripts/git"
 	printf '# test agents\n' >"$FAKE_REPO/.agents/AGENTS.md"
 	chmod +x "$FAKE_REPO/aidevops.sh" "$FAKE_REPO/.agents/scripts/helper.sh" "$FAKE_REPO/.agents/scripts/git"
+	return 0
+}
+
+write_fake_plugin_manifest() {
+	mkdir -p "$FAKE_REPO/.agents/plugins/opencode-aidevops"
+	printf '{"name":"opencode-aidevops","type":"module"}\n' >"$FAKE_REPO/.agents/plugins/opencode-aidevops/package.json"
+	return 0
+}
+
+write_fake_plugin_dependencies() {
+	local plugin_dir="$FAKE_REPO/.agents/plugins/opencode-aidevops"
+	mkdir -p "$plugin_dir/node_modules/@bufbuild/protobuf" "$plugin_dir/node_modules/@opencode-ai/plugin"
+	printf '{"name":"@bufbuild/protobuf","type":"module","exports":"./index.mjs"}\n' >"$plugin_dir/node_modules/@bufbuild/protobuf/package.json"
+	printf 'export const fixture = true;\n' >"$plugin_dir/node_modules/@bufbuild/protobuf/index.mjs"
+	printf '{"name":"@opencode-ai/plugin","type":"module","exports":"./index.mjs"}\n' >"$plugin_dir/node_modules/@opencode-ai/plugin/package.json"
+	printf 'export const tool = Object.assign((definition) => definition, { schema: {} });\n' >"$plugin_dir/node_modules/@opencode-ai/plugin/index.mjs"
 	return 0
 }
 
@@ -225,6 +242,90 @@ test_macos_and_linux_link_paths() {
 	return 0
 }
 
+test_plugin_dependency_smoke_check() {
+	local plugin_dir=""
+	write_fake_revision "7.1.0" "dependency-smoke-check"
+	write_fake_plugin_manifest
+	write_fake_plugin_dependencies
+	plugin_dir="$FAKE_REPO/.agents/plugins/opencode-aidevops"
+
+	_verify_opencode_plugin_deps "$plugin_dir" || fail "complete plugin dependencies pass the import smoke check"
+	pass "complete plugin dependencies pass the import smoke check"
+	rm -rf "$plugin_dir/node_modules/@opencode-ai/plugin"
+	if _verify_opencode_plugin_deps "$plugin_dir" >/dev/null 2>&1; then
+		fail "missing @opencode-ai/plugin unexpectedly passed the import smoke check"
+	fi
+	pass "missing @opencode-ai/plugin fails the import smoke check"
+	return 0
+}
+
+install_mock_plugin_dependency_hooks() {
+	_verify_opencode_plugin_deps() {
+		local plugin_dir="$1"
+		: "$plugin_dir"
+		case "$MOCK_PLUGIN_VERIFY_MODE" in
+		available)
+			return 0
+			;;
+		recover)
+			[[ -f "$TEST_ROOT/npm-install-complete" ]] && return 0
+			return 1
+			;;
+		failure)
+			return 1
+			;;
+		esac
+		return 1
+	}
+
+	npm() {
+		printf '%s\n' "$MOCK_PLUGIN_VERIFY_MODE" >"$TEST_ROOT/npm-called"
+		if [[ "$MOCK_PLUGIN_VERIFY_MODE" == "recover" ]]; then
+			printf 'installed\n' >"$TEST_ROOT/npm-install-complete"
+			return 0
+		fi
+		printf 'mock npm install failure\n' >&2
+		return 1
+	}
+	return 0
+}
+
+test_dependency_install_recovery_activates_candidate() {
+	local target_dir="$HOME/.aidevops/agents"
+	write_fake_revision "8.0.0" "dependency-recovery"
+	write_fake_plugin_manifest
+	MOCK_PLUGIN_VERIFY_MODE="recover"
+	rm -f "$TEST_ROOT/npm-called" "$TEST_ROOT/npm-install-complete"
+
+	stage_revision "$target_dir"
+	[[ -f "$TEST_ROOT/npm-called" ]] || fail "missing dependencies invoke npm install"
+	pass "missing dependencies invoke npm install"
+	_runtime_bundle_activate "$target_dir" "$_AIDEVOPS_STAGED_BUNDLE_DIR"
+	assert_eq "8.0.0" "$(tr -d '[:space:]' <"$target_dir/VERSION")" "dependency-complete candidate activates after install"
+	return 0
+}
+
+test_dependency_install_failure_preserves_active_bundle() {
+	local target_dir="$HOME/.aidevops/agents"
+	local active_before=""
+	local active_after=""
+	active_before=$(_runtime_bundle_resolve_root "$target_dir")
+	write_fake_revision "9.0.0" "dependency-failure"
+	write_fake_plugin_manifest
+	MOCK_PLUGIN_VERIFY_MODE="failure"
+	rm -f "$TEST_ROOT/npm-called" "$TEST_ROOT/npm-install-complete"
+
+	if stage_revision "$target_dir"; then
+		fail "plugin dependency install failure unexpectedly staged a bundle"
+	fi
+	[[ -f "$TEST_ROOT/npm-called" ]] || fail "failed dependency recovery invokes npm install"
+	pass "failed dependency recovery invokes npm install"
+	active_after=$(_runtime_bundle_resolve_root "$target_dir")
+	assert_eq "$active_before" "$active_after" "plugin dependency install failure preserves active bundle"
+	assert_eq "8.0.0" "$(tr -d '[:space:]' <"$target_dir/VERSION")" "failed candidate never becomes active"
+	return 0
+}
+
 main() {
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
@@ -245,6 +346,10 @@ main() {
 	test_live_bundle_lease_survives_three_updates
 	test_stale_lease_and_old_bundle_are_pruned
 	test_macos_and_linux_link_paths
+	test_plugin_dependency_smoke_check
+	install_mock_plugin_dependency_hooks
+	test_dependency_install_recovery_activates_candidate
+	test_dependency_install_failure_preserves_active_bundle
 
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"
 	return 0


### PR DESCRIPTION
## Summary

Fail runtime-bundle staging when core OpenCode plugin dependencies cannot be installed or imported, preserving the prior active bundle and exposing bounded npm diagnostics.

## Files Changed

.agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/tests/test-agent-deploy-staging-invariant.sh, .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Local linters passed; atomic runtime-bundle test passed 25 checks; staging invariant test passed 13 checks; OpenCode plugin suite passed 389 tests.

Resolves #27714


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 22m and 241,516 tokens on this with the user in an interactive session.