### PR TITLE
fix: harden pulse worker completion lifecycle

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -3,8 +3,8 @@
 // Extracted from index.mjs (t1914).
 // ---------------------------------------------------------------------------
 
-import { existsSync, readFileSync, appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
-import { homedir } from "os";
+import { existsSync, readFileSync, appendFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { execFileSync } from "child_process";
 import { createHash } from "crypto";
@@ -23,6 +23,27 @@ import {
   GPT56_OUTPUT_DEFAULT,
 } from "./model-limits.mjs";
 
+const tempDirectories = new Set();
+function addTempDirectory(path) {
+  const normalized = path.replace(/\/+$/, "");
+  if (!normalized) return;
+  tempDirectories.add(normalized);
+  try {
+    tempDirectories.add(realpathSync(normalized));
+  } catch {
+    // The unresolved path remains a valid, least-privilege fallback.
+  }
+}
+addTempDirectory(tmpdir());
+if (process.platform === "darwin") {
+  try {
+    const darwinTemp = execFileSync("/usr/bin/getconf", ["DARWIN_USER_TEMP_DIR"], { encoding: "utf8" }).trim();
+    addTempDirectory(darwinTemp);
+  } catch {
+    // The configured tmpdir() remains available when getconf is unavailable.
+  }
+}
+
 const MANAGED_EXTERNAL_DIRECTORIES = [
   "~/.aidevops",
   "~/.aidevops/**",
@@ -32,6 +53,7 @@ const MANAGED_EXTERNAL_DIRECTORIES = [
   "~/.config/opencode/command/**",
   "~/Git/_worktrees",
   "~/Git/_worktrees/**",
+  ...[...tempDirectories].sort().flatMap((path) => [path, `${path}/**`]),
 ];
 
 const PATTERN_CAPABLE_PERMISSIONS = new Set(["bash", "external_directory"]);

--- a/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
@@ -3,9 +3,23 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 import { registerManagedDirectoryPermissions } from "../config-hook.mjs";
 
+const tempDirectories = new Set();
+function addTempDirectory(path) {
+  const normalized = path.replace(/\/+$/, "");
+  tempDirectories.add(normalized);
+  tempDirectories.add(realpathSync(normalized));
+}
+addTempDirectory(tmpdir());
+if (process.platform === "darwin") {
+  const darwinTemp = execFileSync("/usr/bin/getconf", ["DARWIN_USER_TEMP_DIR"], { encoding: "utf8" }).trim();
+  addTempDirectory(darwinTemp);
+}
 const managedRules = {
   "~/.aidevops": "allow",
   "~/.aidevops/**": "allow",
@@ -15,7 +29,12 @@ const managedRules = {
   "~/.config/opencode/command/**": "allow",
   "~/Git/_worktrees": "allow",
   "~/Git/_worktrees/**": "allow",
+  ...Object.fromEntries([...tempDirectories].sort().flatMap((path) => [
+    [path, "allow"],
+    [`${path}/**`, "allow"],
+  ])),
 };
+const managedRuleCount = Object.keys(managedRules).length;
 
 test("adds narrow managed-directory exceptions after a broad ask rule", () => {
   const config = {
@@ -27,7 +46,7 @@ test("adds narrow managed-directory exceptions after a broad ask rule", () => {
     },
   };
 
-  assert.equal(registerManagedDirectoryPermissions(config), 8);
+  assert.equal(registerManagedDirectoryPermissions(config), managedRuleCount);
   assert.deepEqual(config.permission.external_directory, {
     "*": "ask",
     "~/Documents/**": "deny",
@@ -38,7 +57,7 @@ test("adds narrow managed-directory exceptions after a broad ask rule", () => {
 test("converts a top-level default without allowing unrelated directories", () => {
   const config = { permission: "ask" };
 
-  assert.equal(registerManagedDirectoryPermissions(config), 8);
+  assert.equal(registerManagedDirectoryPermissions(config), managedRuleCount);
   assert.equal(config.permission["*"], "ask");
   assert.deepEqual(config.permission.external_directory, {
     "*": "ask",
@@ -56,9 +75,9 @@ test("leaves an existing global external-directory allow unchanged", () => {
 test("is idempotent and keeps managed rules last", () => {
   const config = { permission: { external_directory: { "*": "ask" } } };
 
-  assert.equal(registerManagedDirectoryPermissions(config), 8);
+  assert.equal(registerManagedDirectoryPermissions(config), managedRuleCount);
   assert.equal(registerManagedDirectoryPermissions(config), 0);
-  assert.deepEqual(Object.keys(config.permission.external_directory).slice(-8), Object.keys(managedRules));
+  assert.deepEqual(Object.keys(config.permission.external_directory).slice(-managedRuleCount), Object.keys(managedRules));
 });
 
 test("adds managed rules to per-agent permissions that override top-level defaults", () => {
@@ -70,7 +89,7 @@ test("adds managed rules to per-agent permissions that override top-level defaul
     },
   };
 
-  assert.equal(registerManagedDirectoryPermissions(config), 24);
+  assert.equal(registerManagedDirectoryPermissions(config), managedRuleCount * 3);
   assert.deepEqual(config.agent["Build+"].permission.external_directory, {
     "*": "ask",
     ...managedRules,

--- a/.agents/scripts/agent-discovery.py
+++ b/.agents/scripts/agent-discovery.py
@@ -11,6 +11,7 @@ from discovery_utils import atomic_json_write
 from agent_config import (
     discover_primary_agents, validate_subagent_refs,
     apply_disabled_agents, sort_key, display_to_filename,
+    managed_external_directories,
 )
 from mcp_config import (
     apply_mcp_loading_policy, remove_deprecated_mcps,
@@ -102,16 +103,7 @@ def _persist_managed_external_directories(config):
     if existing == 'allow':
         return
     rules = {'*': existing} if isinstance(existing, str) else dict(existing or {})
-    managed_paths = (
-        '~/.aidevops',
-        '~/.aidevops/**',
-        '~/.config/aidevops',
-        '~/.config/aidevops/**',
-        '~/.config/opencode/command',
-        '~/.config/opencode/command/**',
-        '~/Git/_worktrees',
-        '~/Git/_worktrees/**',
-    )
+    managed_paths = managed_external_directories()
     for path in managed_paths:
         rules.pop(path, None)
         rules[path] = 'allow'

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -267,21 +267,31 @@ _full_loop_release_receipt_path() {
 	return 0
 }
 
+_full_loop_write_release_receipt() {
+	local repo="$1"
+	local pr_number="$2"
+	local status="$3"
+	[[ -n "$repo" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	[[ "$status" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" || "$status" == "$_FULL_LOOP_RELEASE_PUBLISHED" || "$status" == "$_FULL_LOOP_PHASE_FAILED" ]] || return 1
+	local receipt_path=""
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
+	mkdir -p "${receipt_path%/*}" || return 1
+	printf '%s\n' "$status" >"${receipt_path}.tmp.$$" || return 1
+	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
+	return 0
+}
+
 _full_loop_persist_release_status() {
 	local status="$1"
 	local repo=""
-	[[ "$status" == "not-requested" || "$status" == "$_FULL_LOOP_RELEASE_PUBLISHED" || "$status" == "$_FULL_LOOP_PHASE_FAILED" ]] || return 1
+	[[ "$status" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" || "$status" == "$_FULL_LOOP_RELEASE_PUBLISHED" || "$status" == "$_FULL_LOOP_PHASE_FAILED" ]] || return 1
 	if [[ -f "$STATE_FILE" ]]; then
 		save_state "${CURRENT_PHASE:-${PHASE:-postflight}}" "$SAVED_PROMPT" "${PR_NUMBER:-}" "${STARTED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}"
 	fi
 	[[ "${PR_NUMBER:-}" =~ ^[0-9]+$ ]] || return 0
 	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1
-	local receipt_path=""
-	receipt_path=$(_full_loop_release_receipt_path "$repo" "$PR_NUMBER") || return 1
-	mkdir -p "${receipt_path%/*}" || return 1
-	printf '%s\n' "$status" >"${receipt_path}.tmp.$$" || return 1
-	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
-	return 0
+	_full_loop_write_release_receipt "$repo" "$PR_NUMBER" "$status"
+	return $?
 }
 
 _full_loop_invoke_authorized_release() {
@@ -574,7 +584,7 @@ _init_start_defaults() {
 	fi
 	RELEASE_TYPE="${RELEASE_TYPE:-${AIDEVOPS_RELEASE_TYPE:-patch}}"
 	DEPLOYMENT_SCOPE="${DEPLOYMENT_SCOPE:-${AIDEVOPS_RELEASE_DEPLOY_SCOPE:-incremental}}"
-	RELEASE_STATUS="${RELEASE_STATUS:-not-requested}"
+	RELEASE_STATUS="${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}"
 	DRY_RUN="${DRY_RUN:-false}"
 	_BACKGROUND=false
 	return 0

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 REPO_ROOT="$(git rev-parse --show-toplevel)" || exit 1
 _FULL_LOOP_RELEASE_PATH=""
+source "${SCRIPT_DIR}/full-loop-helper-state.sh"
 
 cleanup_release_worktree() {
 	local release_path="${_FULL_LOOP_RELEASE_PATH:-}"
@@ -35,14 +36,19 @@ main() {
 	local version_manager="${AIDEVOPS_FULL_LOOP_VERSION_MANAGER:-$release_path/.agents/scripts/version-manager.sh}"
 	[[ "$version_manager" = /* ]] || version_manager="$PWD/$version_manager"
 	[[ -f "$version_manager" ]] || return 1
-	(
+	if ! (
 		trap - EXIT
 		cd "$release_path" || exit 1
 		AIDEVOPS_RELEASE_INTENT_TRUSTED=1 \
 			AIDEVOPS_TRUSTED_ISSUE_PRIORITY="${AIDEVOPS_TRUSTED_ISSUE_PRIORITY:-}" \
 			AIDEVOPS_RELEASE_DEPLOY_SCOPE="$deployment_scope" \
 			bash "$version_manager" release "$release_type" --source-pr "$source_pr"
-	)
+	); then
+		return 1
+	fi
+	local repo=""
+	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1
+	_full_loop_write_release_receipt "$repo" "$source_pr" "$_FULL_LOOP_RELEASE_PUBLISHED"
 	return $?
 }
 

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -38,7 +38,6 @@ _HRW_TELEMETRY_FAILED="failed"
 _HRW_TELEMETRY_DEFERRED="deferred"
 _HRW_REASON_DRAFT_CHECKPOINT="worker_draft_checkpoint"
 _HRW_REASON_DRAFT_ESCALATION_FAILED="worker_draft_checkpoint_escalation_failed"
-_HRW_REASON_READY_FAILED="worker_ready_failed"
 _HRW_REASON_CLOSED_UNMERGED="worker_closed_unmerged_pr"
 _HRW_EVENT_FAILED="worker.failed"
 _HRW_NMR_LABEL="needs-maintainer-review"
@@ -484,7 +483,6 @@ _hrw_worker_base_commit_state() {
 #   "dirty_worktree"        — uncommitted/untracked edits exist after a crash
 #   "draft_checkpoint"      — exact-head worker draft (durable, incomplete)
 #   "protected_draft"       — interactive/held/NMR/non-worker draft
-#   "ready_failed"          — exact-head ready PR has terminal failed checks
 #   "closed_unmerged"       — exact-head PR closed without merge
 #   "unverified_open_pr"    — issue-search fallback cannot prove exact head
 #   "head_mismatch"         — local HEAD is not the open PR head
@@ -589,7 +587,7 @@ _worker_produced_output() {
 	pr_state="${pr_handoff%%|*}"
 	case "$pr_state" in
 		ready | merged) printf 'pr_exists'; return 0 ;;
-		draft_checkpoint | protected_draft | ready_failed | closed_unmerged | unverified_open_pr | head_mismatch | ready_missing_summary | merged_missing_summary)
+		draft_checkpoint | protected_draft | closed_unmerged | unverified_open_pr | head_mismatch | ready_missing_summary | merged_missing_summary)
 			printf '%s' "$pr_state"
 			return 0
 			;;
@@ -1001,10 +999,6 @@ _recover_worker_output_on_failure() {
 		fi
 		if [[ "$pr_state" == "draft_checkpoint" ]]; then
 			_escalate_worker_pr_checkpoint "$session_key" "$repo_slug" "$pr_state"
-			return 0
-		fi
-		if [[ "$pr_state" == "ready_failed" ]]; then
-			_escalate_worker_pr_checkpoint "$session_key" "$repo_slug" "$pr_state" "$_HRW_REASON_READY_FAILED"
 			return 0
 		fi
 		if [[ "$pr_state" == "protected_draft" || "$pr_state" == "unverified_open_pr" || \
@@ -1504,15 +1498,6 @@ _hrw_finish_success_run() {
 			_escalate_worker_pr_checkpoint "$session_key" "${DISPATCH_REPO_SLUG:-}" "$output_class"
 			release_needed=0
 			if [[ "$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_DRAFT_CHECKPOINT" ]]; then
-				_hrw_mark_failed_terminal_state "$_HRW_STATUS_ESCALATED" "$_HRW_RECOVERY_CLASSIFICATION"
-			else
-				_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_RECOVERY_CLASSIFICATION"
-			fi
-			;;
-		ready_failed)
-			_escalate_worker_pr_checkpoint "$session_key" "${DISPATCH_REPO_SLUG:-}" "$output_class" "$_HRW_REASON_READY_FAILED"
-			release_needed=0
-			if [[ "$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_READY_FAILED" ]]; then
 				_hrw_mark_failed_terminal_state "$_HRW_STATUS_ESCALATED" "$_HRW_RECOVERY_CLASSIFICATION"
 			else
 				_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_RECOVERY_CLASSIFICATION"

--- a/.agents/scripts/lib/agent_config.py
+++ b/.agents/scripts/lib/agent_config.py
@@ -10,11 +10,15 @@ duplication and reduce file complexity.
 
 import glob
 import os
-import subprocess
 import sys
 import tempfile
 
 from discovery_utils import parse_frontmatter
+
+
+# Darwin's unistd.h exposes this confstr key, but Python omits its symbolic
+# name from os.confstr_names. Passing the native key avoids spawning getconf.
+_CS_DARWIN_USER_TEMP_DIR = 65537
 
 
 # =============================================================================
@@ -56,14 +60,10 @@ def managed_external_directories():
     temp_dirs = {configured_temp, os.path.realpath(configured_temp)}
     if sys.platform == "darwin":
         try:
-            darwin_temp = subprocess.check_output(
-                ["/usr/bin/getconf", "DARWIN_USER_TEMP_DIR"],
-                text=True,
-                timeout=2,
-            ).strip().rstrip("/")
+            darwin_temp = os.confstr(_CS_DARWIN_USER_TEMP_DIR).rstrip("/")
             if darwin_temp:
                 temp_dirs.update((darwin_temp, os.path.realpath(darwin_temp)))
-        except (OSError, subprocess.SubprocessError):
+        except (OSError, ValueError):
             pass
     for temp_dir in sorted(temp_dirs):
         if temp_dir:

--- a/.agents/scripts/lib/agent_config.py
+++ b/.agents/scripts/lib/agent_config.py
@@ -10,7 +10,9 @@ duplication and reduce file complexity.
 
 import glob
 import os
+import subprocess
 import sys
+import tempfile
 
 from discovery_utils import parse_frontmatter
 
@@ -36,6 +38,37 @@ AGENT_ORDER = ["Build+", "Automate"]
 # plan-plus.md and aidevops.md are now subagents, not primary agents
 # browser-extension-dev.md and mobile-app-dev.md are specialist subagents under Build+
 SKIP_PRIMARY_AGENTS = {"plan-plus.md", "aidevops.md", "browser-extension-dev.md", "mobile-app-dev.md"}
+
+
+def managed_external_directories():
+    """Return stable framework paths plus this user's resolved OS temp path."""
+    paths = [
+        "~/.aidevops",
+        "~/.aidevops/**",
+        "~/.config/aidevops",
+        "~/.config/aidevops/**",
+        "~/.config/opencode/command",
+        "~/.config/opencode/command/**",
+        "~/Git/_worktrees",
+        "~/Git/_worktrees/**",
+    ]
+    configured_temp = tempfile.gettempdir().rstrip("/")
+    temp_dirs = {configured_temp, os.path.realpath(configured_temp)}
+    if sys.platform == "darwin":
+        try:
+            darwin_temp = subprocess.check_output(
+                ["/usr/bin/getconf", "DARWIN_USER_TEMP_DIR"],
+                text=True,
+                timeout=2,
+            ).strip().rstrip("/")
+            if darwin_temp:
+                temp_dirs.update((darwin_temp, os.path.realpath(darwin_temp)))
+        except (OSError, subprocess.SubprocessError):
+            pass
+    for temp_dir in sorted(temp_dirs):
+        if temp_dir:
+            paths.extend((temp_dir, f"{temp_dir.rstrip('/')}/**"))
+    return tuple(paths)
 
 # Special tool configurations per agent (by display name)
 # These are MCP tools that specific agents need access to
@@ -175,20 +208,16 @@ def get_agent_config(display_name, filename, subagents=None, model_tier=None):
     if effective_tier and effective_tier not in WORKLOAD_TIERS and "/" in effective_tier:
         config["model"] = effective_tier
 
-    # Grep is a read-only search tool. Explicitly allow it when enabled so
-    # OpenCode does not fall back to its interactive permission default.
+    # OpenCode applies the external-directory boundary to shell paths too.
+    # Permit only managed paths and this user's resolved OS temp directory so
+    # disposable test worktrees work without opening all of /tmp or /var/folders.
     config["permission"] = {
         "external_directory": {
-            "~/.aidevops": "allow",
-            "~/.aidevops/**": "allow",
-            "~/.config/aidevops": "allow",
-            "~/.config/aidevops/**": "allow",
-            "~/.config/opencode/command": "allow",
-            "~/.config/opencode/command/**": "allow",
-            "~/Git/_worktrees": "allow",
-            "~/Git/_worktrees/**": "allow",
+            path: "allow" for path in managed_external_directories()
         }
     }
+    # Grep is a read-only search tool. Explicitly allow it when enabled so
+    # OpenCode does not fall back to its interactive permission default.
     if tools.get("grep") is True:
         config["permission"]["grep"] = "allow"
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -14,7 +14,9 @@
 #   - _dlw_setup_worker_log
 #   - _dlw_resolve_tier_and_model
 #   - _dlw_precreate_worktree
+#   - _dlw_renew_prelaunch_lease
 #   - _dlw_prewarm_opencode_db
+#   - _dlw_prepare_opencode_db
 #   - _dlw_exec_detached
 #   - _dlw_exec_systemd_user_service
 #   - _dlw_spawn_early_exit_monitor
@@ -1011,6 +1013,52 @@ _dlw_prewarm_opencode_db() {
 }
 
 #######################################
+# Renew the dispatcher's prelaunch lease before the potentially slow OpenCode
+# database warm-up. The worker renews it again after process start; this renewal
+# closes the gap between worktree preparation and that worker-side transition.
+# Arguments: issue_number repo_slug session_key worker_log
+#######################################
+_dlw_renew_prelaunch_lease() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local session_key="$3"
+	local worker_log="$4"
+	local prewarm_timeout="${OPENCODE_PREWARM_TIMEOUT_SECONDS:-90}"
+	local lease_ttl="${AIDEVOPS_DISPATCH_PREWARM_LEASE_TTL:-}"
+
+	if [[ -z "${_claim_lease_token:-}" ]]; then
+		return 0
+	fi
+	[[ "$prewarm_timeout" =~ ^[0-9]+$ ]] || prewarm_timeout=90
+	[[ "$lease_ttl" =~ ^[0-9]+$ ]] || lease_ttl=$((prewarm_timeout + 60))
+
+	printf '[lifecycle] dispatcher_prelaunch_lease_renew_start session=%s pid=%s\n' \
+		"$session_key" "$$" >>"$worker_log"
+	if ! AIDEVOPS_DEVICE_ID="${_claim_lease_device:-${AIDEVOPS_DEVICE_ID:-}}" \
+		"${SCRIPT_DIR}/dispatch-claim-helper.sh" transition prelaunch "$issue_number" \
+		"$repo_slug" "$_claim_lease_token" "$session_key" "$lease_ttl" \
+		>/dev/null 2>&1; then
+		printf '[lifecycle] WARN dispatcher prelaunch lease renewal failed before OpenCode warm-up session=%s pid=%s\n' \
+			"$session_key" "$$" >>"$worker_log"
+		return 1
+	fi
+	printf '[lifecycle] dispatcher_prelaunch_lease_renew_done session=%s pid=%s\n' \
+		"$session_key" "$$" >>"$worker_log"
+	return 0
+}
+
+_dlw_prepare_opencode_db() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local session_key="$3"
+	local worker_log="$4"
+
+	_dlw_renew_prelaunch_lease "$issue_number" "$repo_slug" "$session_key" "$worker_log" || return 1
+	_dlw_prewarm_opencode_db "$worker_log"
+	return 0
+}
+
+#######################################
 # Return 0 when a Linux systemd user manager is available for transient
 # services. `setsid` detaches workers from the pulse process group, but it
 # does NOT move them out of the systemd service cgroup. On systemd pulse
@@ -1668,8 +1716,8 @@ _dlw_nohup_launch() {
 	local worker_title
 	worker_title=$(_dlw_build_worker_title "$issue_number" "$issue_title" "$dispatch_title")
 
-	# t2758: Pre-warm OpenCode DB before launch (extracted to helper)
-	_dlw_prewarm_opencode_db "$worker_log"
+	# Renew the lease before pre-warm; the child renews again before canary.
+	_dlw_prepare_opencode_db "$issue_number" "$repo_slug" "$session_key" "$worker_log" || return 1
 	local worker_prewarm_dir="$_DLW_PREWARM_DIR"
 
 	# Launch worker — headless-runtime-helper.sh handles model selection
@@ -2292,10 +2340,14 @@ _dispatch_launch_worker() {
 	local worker_pid
 	local launch_prompt=""
 	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt" "$zero_output_comment_metrics")
-	worker_pid=$(_dlw_nohup_launch "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
+	if ! worker_pid=$(_dlw_nohup_launch "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
 		"$session_key" "$worker_log" "$launch_prompt" "$repo_path" \
 		"$dispatch_model_tier" "$selected_model" \
-		"$worker_worktree_path" "$worker_worktree_branch")
+		"$worker_worktree_path" "$worker_worktree_branch"); then
+		_ds_record "$issue_number" "$repo_slug" "worker_spawn" "$_ds_t0"
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worker_launch_failed" 2 || return $?
+		return 1
+	fi
 	_ds_record "$issue_number" "$repo_slug" "worker_spawn" "$_ds_t0"
 
 	_ds_t0=$(_ds_now_ns)

--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -98,8 +98,10 @@ _build_inline_findings() {
 
 		select($sev_num >= $min_num) |
 
-		# Skip resolved/outdated comments
-		select(.position != null or .line != null or .original_line != null) |
+		# Replaced PR lines retain original_line/position but clear line; suppress
+		# that stale evidence while preserving file comments and legacy payloads.
+		select(.subject_type == "file" or .line != null or
+			((has("line") | not) and .position != null)) |
 
 		{
 			pr: ($pr | tonumber),
@@ -229,6 +231,9 @@ _apply_positive_filter() {
 			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
 			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
 
+		# Exact-head fix/pass evidence is praise unless contrast or unresolved-work language remains.
+		(($body | test("\\breviewed exact head\\b"; "i")) and ($body | test("\\b(corrects?|keeps?|preserves?|verif(y|ies|ied)|pass(es|ed)?)\\b"; "i")) and ($body | test("\\b(tests?|checks?|suites?)\\b"; "i")) and (($body | test("\\b(but|however|although|yet|except|still|remaining|unresolved)\\b"; "i")) | not)) as $exact_head_verification |
+
 		# Review summaries often describe the bug the PR already fixed, e.g.
 		# "corrects a broken URL". Do not treat those historic defect words as
 		# new quality-debt findings when the same body is otherwise praise-only.
@@ -256,7 +261,7 @@ _apply_positive_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $strong_actionable |
 
-		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not))) as $actionable |
+		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not)) and ($strong_actionable or ($exact_head_verification | not))) as $actionable |
 
 		($body | test(
 			"\\bmerging\\.?$|\\bmerge (this|the) pr\\b|" +
@@ -265,7 +270,7 @@ _apply_positive_filter() {
 			"\\breview.bot.gate (pass|ok)\\b|" +
 			"\\bpulse supervisor\\b"; "i")) as $merge_status_only |
 
-		select($include_positive or (((($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $merge_status_only) and ($actionable | not))) | not)) |
+		select($include_positive or (((($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $exact_head_verification or $merge_status_only) and ($actionable | not))) | not)) |
 
 		. + {_actionable: $actionable}]
 	' || echo "[]"

--- a/.agents/scripts/quality-feedback-issues-lib.sh
+++ b/.agents/scripts/quality-feedback-issues-lib.sh
@@ -573,14 +573,28 @@ _create_or_append_file_issue() {
 	# Cross-PR file dedup (t1411): check if there's an existing open
 	# quality-debt issue for the same FILE from a different PR. If so,
 	# append findings as a comment instead of creating a new issue.
+	local existing_file_issue_json=""
 	local existing_file_issue=""
+	local existing_file_issue_pr=""
 	if [[ "$file" != "general" ]]; then
-		existing_file_issue=$(echo "$existing_open_issues_json" | jq -r --arg f "$file" \
-			'[.[] | select((.title // "") | startswith("quality-debt: \($f) —"))] | .[0].number // empty' ||
-			echo "")
+		existing_file_issue_json=$(echo "$existing_open_issues_json" | jq -c --arg f "$file" \
+			'[.[] | select((.title // "") | startswith("quality-debt: \($f) —"))] | .[0] // {}' ||
+			echo '{}')
+		existing_file_issue=$(echo "$existing_file_issue_json" | jq -r '.number // empty')
+		existing_file_issue_pr=$(echo "$existing_file_issue_json" | jq -r \
+			'(.title // "") | try capture("— PR #(?<number>[0-9]+) review feedback").number catch ""')
 	fi
 
 	if [[ -n "$existing_file_issue" ]]; then
+		# PR numbers are monotonically increasing within a repository. Never append
+		# older review feedback to debt opened from a newer PR: the newer change may
+		# already supersede the older finding (GH#27703).
+		if [[ "$pr_num" =~ ^[0-9]+$ && "$existing_file_issue_pr" =~ ^[0-9]+$ && \
+			"$pr_num" -lt "$existing_file_issue_pr" ]]; then
+			echo "  Skipping superseded PR #${pr_num} feedback; #${existing_file_issue} already tracks newer PR #${existing_file_issue_pr} for ${file}" >&2
+			echo "0"
+			return 0
+		fi
 		_append_findings_to_issue "$repo_slug" "$existing_file_issue" "$pr_num" "$file" \
 			"$reviewers" "$file_finding_count" "$max_severity" "$finding_details"
 		echo "0"

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -170,7 +170,7 @@ _release_interactive_claim_on_merge() {
 #   $3 = repo_slug     (e.g. "owner/repo")
 #
 # Exact-head output states:
-#   ready | ready_failed | merged | closed_unmerged | draft_checkpoint |
+#   ready | merged | closed_unmerged | draft_checkpoint |
 #   protected_draft | head_mismatch | ready_missing_summary |
 #   merged_missing_summary
 # Issue-search matches are deliberately `unverified_open_pr`: search can return
@@ -190,11 +190,6 @@ _pr_handoff_state_from_json() {
 			. == "origin:interactive" or . == "hold-for-review" or
 			. == "no-auto-dispatch" or . == "needs-maintainer-review"
 		);
-		def terminal_failure:
-			[.statusCheckRollup[]? |
-				(.conclusion // .status // .state // empty) | ascii_upcase] |
-			any(. == "FAILURE" or . == "ERROR" or . == "CANCELLED" or
-				. == "TIMED_OUT" or . == "ACTION_REQUIRED" or . == "STALE");
 		def rank:
 			if .state == $open_state then 0
 			elif .state == $merged_state or ((.mergedAt // "") | length) > 0 then 1
@@ -208,7 +203,6 @@ _pr_handoff_state_from_json() {
 		elif .state != $open_state then "closed_unmerged|\(.number)"
 		elif (.isDraft // false) and worker_owned and (protected | not) then "draft_checkpoint|\(.number)"
 		elif (.isDraft // false) then "protected_draft|\(.number)"
-		elif terminal_failure then "ready_failed|\(.number)"
 		else "ready|\(.number)" end' 2>/dev/null || true
 	return 0
 }
@@ -250,7 +244,7 @@ _pr_handoff_state_for_branch_or_issue() {
 
 	if [[ -n "$branch_name" ]]; then
 		if pr_json=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state all \
-			--limit 10 --json number,state,isDraft,mergedAt,headRefOid,labels,statusCheckRollup 2>/dev/null); then
+			--limit 10 --json number,state,isDraft,mergedAt,headRefOid,labels 2>/dev/null); then
 			queried=1
 			pr_state=$(_pr_handoff_state_from_json "$pr_json" "$expected_head")
 			if [[ -n "$pr_state" ]]; then

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -244,7 +244,7 @@ _pr_handoff_state_for_branch_or_issue() {
 
 	if [[ -n "$branch_name" ]]; then
 		if pr_json=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state all \
-			--limit 10 --json number,state,isDraft,mergedAt,headRefOid,labels 2>/dev/null); then
+			--limit 10 --json number,state,isDraft,mergedAt,headRefOid,labels,statusCheckRollup 2>/dev/null); then
 			queried=1
 			pr_state=$(_pr_handoff_state_from_json "$pr_json" "$expected_head")
 			if [[ -n "$pr_state" ]]; then

--- a/.agents/scripts/tests/test-agent-discovery-smoke.sh
+++ b/.agents/scripts/tests/test-agent-discovery-smoke.sh
@@ -133,7 +133,6 @@ test_opencode_config_persists_managed_directory_permissions() {
 	if HOME="$fake_home" python3 - "$config_path" <<'PY'; then
 import json
 import os
-import subprocess
 import sys
 import tempfile
 
@@ -155,9 +154,9 @@ assert all(rules.get(path) == "allow" for path in expected)
 configured_temp = tempfile.gettempdir().rstrip("/")
 temp_dirs = {configured_temp, os.path.realpath(configured_temp)}
 if sys.platform == "darwin":
-    darwin_temp = subprocess.check_output(
-        ["/usr/bin/getconf", "DARWIN_USER_TEMP_DIR"], text=True
-    ).strip().rstrip("/")
+    # _CS_DARWIN_USER_TEMP_DIR from Darwin's unistd.h; Python does not expose
+    # this symbolic name in os.confstr_names.
+    darwin_temp = os.confstr(65537).rstrip("/")
     temp_dirs.update((darwin_temp, os.path.realpath(darwin_temp)))
 assert all(rules.get(path) == "allow" for path in temp_dirs)
 assert all(rules.get(f"{path.rstrip('/')}/**") == "allow" for path in temp_dirs)

--- a/.agents/scripts/tests/test-agent-discovery-smoke.sh
+++ b/.agents/scripts/tests/test-agent-discovery-smoke.sh
@@ -132,7 +132,10 @@ test_opencode_config_persists_managed_directory_permissions() {
 
 	if HOME="$fake_home" python3 - "$config_path" <<'PY'; then
 import json
+import os
+import subprocess
 import sys
+import tempfile
 
 with open(sys.argv[1], encoding="utf-8") as handle:
     config = json.load(handle)
@@ -149,6 +152,15 @@ expected = (
     "~/Git/_worktrees/**",
 )
 assert all(rules.get(path) == "allow" for path in expected)
+configured_temp = tempfile.gettempdir().rstrip("/")
+temp_dirs = {configured_temp, os.path.realpath(configured_temp)}
+if sys.platform == "darwin":
+    darwin_temp = subprocess.check_output(
+        ["/usr/bin/getconf", "DARWIN_USER_TEMP_DIR"], text=True
+    ).strip().rstrip("/")
+    temp_dirs.update((darwin_temp, os.path.realpath(darwin_temp)))
+assert all(rules.get(path) == "allow" for path in temp_dirs)
+assert all(rules.get(f"{path.rstrip('/')}/**") == "allow" for path in temp_dirs)
 assert "~/.config/opencode" not in rules
 PY
 		print_result "OpenCode config persists managed external directories" 0

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -36,7 +36,7 @@ printf 'cwd=%s\n' "$PWD" >>"$VM_CALL_LOG"
 printf 'intent=%s\n' "${AIDEVOPS_RELEASE_INTENT_TRUSTED:-}" >>"$VM_CALL_LOG"
 printf 'priority=%s\n' "${AIDEVOPS_TRUSTED_ISSUE_PRIORITY:-}" >>"$VM_CALL_LOG"
 printf 'deploy=%s\n' "${AIDEVOPS_RELEASE_DEPLOY_SCOPE:-}" >>"$VM_CALL_LOG"
-exit 0
+exit "${VM_EXIT:-0}"
 STUB
 chmod +x "$ROOT/version-manager.sh"
 
@@ -48,6 +48,8 @@ chmod +x "$ROOT/version-manager.sh"
 		FAKE_REPO_ROOT="$ROOT/repo" \
 		AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" \
 		AIDEVOPS_FULL_LOOP_VERSION_MANAGER="../../version-manager.sh" \
+		AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts" \
+		AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
 		AIDEVOPS_TRUSTED_ISSUE_PRIORITY=critical \
 		bash "$SCRIPT_DIR/full-loop-release-helper.sh" minor 42 full
 )
@@ -59,10 +61,33 @@ grep -Eq "^cwd=${ROOT}/worktrees/aidevops-release-42-[0-9]+$" "$ROOT/vm.log"
 grep -qx 'intent=1' "$ROOT/vm.log"
 grep -qx 'priority=critical' "$ROOT/vm.log"
 grep -qx 'deploy=full' "$ROOT/vm.log"
+grep -qx 'published' "$ROOT/receipts/marcusquinn_aidevops-42.status"
 if compgen -G "$ROOT/worktrees/aidevops-release-42-*" >/dev/null; then
 	printf 'FAIL detached release worktree was not removed\n'
 	exit 1
 fi
-printf 'PASS detached release runner propagates explicit release and deployment scope\n'
+printf 'PASS detached release runner persists publication receipt after successful gates\n'
+
+if (
+	cd "$ROOT/repo/linked-branch"
+	PATH="$ROOT/bin:/usr/bin:/bin" \
+		GIT_CALL_LOG="$ROOT/git.log" \
+		VM_CALL_LOG="$ROOT/vm.log" \
+		VM_EXIT=1 \
+		FAKE_REPO_ROOT="$ROOT/repo" \
+		AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" \
+		AIDEVOPS_FULL_LOOP_VERSION_MANAGER="../../version-manager.sh" \
+		AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts" \
+		AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
+		bash "$SCRIPT_DIR/full-loop-release-helper.sh" patch 43 incremental
+); then
+	printf 'FAIL partial release returned success\n'
+	exit 1
+fi
+if [[ -e "$ROOT/receipts/marcusquinn_aidevops-43.status" ]]; then
+	printf 'FAIL partial release persisted a success receipt\n'
+	exit 1
+fi
+printf 'PASS failed release never persists publication receipt\n'
 
 exit 0

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -2935,28 +2935,35 @@ test_protected_draft_is_not_mutated_or_completed() {
 }
 
 test_checkpoint_terminal_telemetry_is_failed_escalated() {
-	local fixture_class result expected_reason
-	for fixture_class in draft_checkpoint ready_failed; do
-		if [[ "$fixture_class" == "draft_checkpoint" ]]; then
-			expected_reason="worker_draft_checkpoint"
-		else
-			expected_reason="worker_ready_failed"
-		fi
-		result=$(
-			(
-				_worker_produced_output() { printf '%s' "$fixture_class"; return 0; }
-				_escalate_worker_pr_checkpoint() { _HRW_RECOVERY_CLASSIFICATION="$expected_reason"; return 0; }
-				_hrw_finish_success_run "issue-99999" "${TEST_ROOT}"
-				printf '%s|%s|%s|%s' "$_HRW_TERMINAL_OUTCOME" "$_HRW_FINAL_RUNTIME_EVENT" \
-					"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
-			)
+	local fixture_class="draft_checkpoint"
+	local expected_reason="worker_draft_checkpoint"
+	local result
+	result=$(
+		(
+			_worker_produced_output() { printf '%s' "$fixture_class"; return 0; }
+			_escalate_worker_pr_checkpoint() { _HRW_RECOVERY_CLASSIFICATION="$expected_reason"; return 0; }
+			_hrw_finish_success_run "issue-99999" "${TEST_ROOT}"
+			printf '%s|%s|%s|%s' "$_HRW_TERMINAL_OUTCOME" "$_HRW_FINAL_RUNTIME_EVENT" \
+				"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
 		)
-		if [[ "$result" == "failed|worker.failed|escalated|${expected_reason}" ]]; then
-			print_result "${fixture_class} records failed/escalated terminal telemetry" 0
-		else
-			print_result "${fixture_class} records failed/escalated terminal telemetry" 1 "$result"
-		fi
-	done
+	)
+	if [[ "$result" == "failed|worker.failed|escalated|${expected_reason}" ]]; then
+		print_result "${fixture_class} records failed/escalated terminal telemetry" 0
+	else
+		print_result "${fixture_class} records failed/escalated terminal telemetry" 1 "$result"
+	fi
+	return 0
+}
+
+test_failed_ci_ready_pr_is_durable_handoff() {
+	local pr_json result
+	pr_json='[{"number":457,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"abc123","labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"name":"tests","conclusion":"FAILURE"},{"name":"tests","conclusion":"SUCCESS"}]}]'
+	result=$(_pr_handoff_state_from_json "$pr_json" "abc123")
+	if [[ "$result" == "ready|457" ]]; then
+		print_result "failed or historical CI does not invalidate a ready PR handoff" 0
+	else
+		print_result "failed or historical CI does not invalidate a ready PR handoff" 1 "$result"
+	fi
 	return 0
 }
 
@@ -3100,6 +3107,7 @@ test_pr_checkpoint_lifecycle_cases() {
 	test_failed_worker_draft_retains_claim_when_block_not_visible
 	test_protected_draft_is_not_mutated_or_completed
 	test_checkpoint_terminal_telemetry_is_failed_escalated
+	test_failed_ci_ready_pr_is_durable_handoff
 	test_closed_unmerged_pr_is_failed_not_completed
 	test_failed_worker_ready_pr_remains_completed_handoff
 	return 0

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-approval.sh
@@ -76,6 +76,8 @@ _test_approval_filter() {
 			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
 			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
 
+		(($body | test("\\breviewed exact head\\b"; "i")) and ($body | test("\\b(corrects?|keeps?|preserves?|verif(y|ies|ied)|pass(es|ed)?)\\b"; "i")) and ($body | test("\\b(tests?|checks?|suites?)\\b"; "i")) and (($body | test("\\b(but|however|although|yet|except|still|remaining|unresolved)\\b"; "i")) | not)) as $exact_head_verification |
+
 		($body | test(
 			"\\b(corrects?|fix(es|ed)?|replaces?|addresses?)\\b[^.\\n]*(\\bbroken\\b|\\bincorrect\\b|\\bwrong\\b|\\bbug\\b|\\berror\\b|\\bissue\\b)|" +
 			"\\b(change|fix) is correct\\b|\\bcorrect and improves?\\b"; "i")) as $historic_fix_praise |
@@ -100,7 +102,7 @@ _test_approval_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $strong_actionable |
 
-		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not))) as $actionable |
+		(($actionable_raw or $strong_actionable) and ($no_actionable_recommendation | not) and ($no_actionable_suggestions | not) and ($strong_actionable or (($historic_fix_praise and $summary_praise_only) | not)) and ($strong_actionable or ($exact_head_verification | not))) as $actionable |
 
 		# GH#5668: merge/CI-status comments are not actionable review feedback
 		($body | test(
@@ -112,7 +114,7 @@ _test_approval_filter() {
 
 		# skip = approval-only/no-recommendation/no-suggestions/no-actionable sentiment
 		# or summary praise with no actionable critique, or merge/CI-status comment
-		if (($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $merge_status_only) and ($actionable | not)) then "skip"
+		if (($approval_only or $no_actionable_recommendation or $no_actionable_suggestions or $no_actionable_sentiment or $summary_praise_only or $exact_head_verification or $merge_status_only) and ($actionable | not)) then "skip"
 		else "keep"
 		end
 	')
@@ -523,6 +525,39 @@ test_skips_pr26938_resolved_timeout_thread() {
 		print_result "skip PR #26938 resolved timeout thread" 0
 	else
 		print_result "skip PR #26938 resolved timeout thread" 1 "expected 0 findings, got ${result}"
+	fi
+	return 0
+}
+
+test_skips_pr27659_exact_head_verification_review() {
+	local result
+	# Exact source review from PR #27659: failure-related words describe the
+	# verified fix and must not become a new quality-debt finding.
+	# shellcheck disable=SC1112,SC2016  # exact review contains Unicode punctuation and Markdown code spans
+	result=$(_test_approval_filter 'Reviewed exact head `492b3aace`.
+
+- Corrects the maintainer gate’s unsupported `gh api --slurp --jq` combination.
+- Keeps API and JSON parse failures fail-closed.
+- Maintainer gate regression suites and the full local quality suite pass.' "APPROVED")
+	if [[ "$result" == "skip" ]]; then
+		print_result "skip PR #27659 exact-head verification review" 0
+	else
+		print_result "skip PR #27659 exact-head verification review" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
+test_keeps_exact_head_verification_with_remaining_concern() {
+	local result
+	# shellcheck disable=SC2016  # literal review body includes a Markdown code span
+	result=$(_test_approval_filter 'Reviewed exact head `abcdef123`.
+
+- The regression suites pass.
+- However, this still needs error handling for malformed API output.' "APPROVED")
+	if [[ "$result" == "keep" ]]; then
+		print_result "keep exact-head verification with remaining concern" 0
+	else
+		print_result "keep exact-head verification with remaining concern" 1 "expected keep, got ${result}"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-scan.sh
@@ -974,6 +974,25 @@ test_scan_single_pr_filters_resolved_review_threads() {
 	return 0
 }
 
+test_build_inline_findings_filters_outdated_pr_revision_comment() {
+	local comments findings urls
+	comments='[
+		{"id":3579184014,"user":{"login":"gemini-code-assist[bot]"},"path":"aidevops.sh","subject_type":"line","line":null,"original_line":336,"position":1,"original_position":33,"body":"Since git fetch already ran, you should avoid a redundant pull.","html_url":"https://example.invalid/outdated","created_at":"2026-07-14T12:00:00Z"},
+		{"id":3579184015,"user":{"login":"gemini-code-assist[bot]"},"path":"aidevops.sh","subject_type":"line","line":347,"original_line":347,"position":2,"original_position":34,"body":"You should retain this current-line finding.","html_url":"https://example.invalid/current","created_at":"2026-07-14T12:01:00Z"},
+		{"id":3579184016,"user":{"login":"gemini-code-assist[bot]"},"path":"aidevops.sh","subject_type":"file","line":null,"position":null,"body":"You should retain this file-level finding.","html_url":"https://example.invalid/file","created_at":"2026-07-14T12:02:00Z"}
+	]'
+
+	findings=$(_build_inline_findings "$comments" "27662" "medium")
+	urls=$(printf '%s' "$findings" | jq -r '[.[].url] | sort | join(",")')
+	if [[ "$urls" == "https://example.invalid/current,https://example.invalid/file" ]]; then
+		print_result "outdated inline comments from replaced PR revisions are filtered" 0
+	else
+		print_result "outdated inline comments from replaced PR revisions are filtered" 1 \
+			"unexpected findings: ${findings}"
+	fi
+	return 0
+}
+
 test_scan_single_pr_filters_parent_of_resolution_reply() {
 	reset_mock_state
 

--- a/.agents/scripts/tests/test-quality-feedback-main-verification-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification-verification.sh
@@ -456,3 +456,22 @@ test_suggestion_fence_with_markdown_list_item_not_yet_applied() {
 	fi
 	return 0
 }
+
+test_cross_pr_dedup_rejects_older_superseded_feedback() {
+	local findings existing result
+	findings='[{"file":".agents/scripts/example.sh","line":42,"body_full":"Older actionable finding","reviewer":"gemini","reviewer_login":"gemini-code-assist[bot]","severity":"medium","url":"https://example.test/comment"}]'
+	existing='[{"number":9001,"state":"OPEN","title":"quality-debt: .agents/scripts/example.sh — PR #27680 review feedback (medium)"}]'
+	result=$(
+		(
+			_append_findings_to_issue() { printf 'unexpected-append'; return 0; }
+			_create_or_append_file_issue "owner/repo" "27675" ".agents/scripts/example.sh" \
+				"$findings" "$existing" "$existing" "false"
+		)
+	)
+	if [[ "$result" == "0" ]]; then
+		print_result "cross-PR dedup rejects older feedback superseded by newer PR" 0
+	else
+		print_result "cross-PR dedup rejects older feedback superseded by newer PR" 1 "$result"
+	fi
+	return 0
+}

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -201,11 +201,21 @@ source "${SCRIPT_DIR}/test-quality-feedback-main-verification-scan.sh"
 # --- Main ---
 
 run_positive_review_filter_regressions() {
+	test_skips_pr27659_exact_head_verification_review
+	test_keeps_exact_head_verification_with_remaining_concern
 	test_scan_single_pr_filters_issue4814_pr2166_exact_body
 	test_scan_single_pr_positive_body_with_inline_comments_not_summary_only
 	test_scan_single_pr_filters_positive_inline_acknowledgement_reply
 	test_scan_single_pr_filters_parent_of_resolution_reply
 	test_scan_single_pr_filters_resolved_review_threads
+	test_build_inline_findings_filters_outdated_pr_revision_comment
+	return 0
+}
+
+run_suggestion_fence_regressions() {
+	test_suggestion_fence_with_markdown_list_item_already_applied
+	test_suggestion_fence_with_markdown_list_item_not_yet_applied
+	test_cross_pr_dedup_rejects_older_superseded_feedback
 	return 0
 }
 
@@ -234,8 +244,7 @@ main() {
 
 	echo ""
 	echo "Running suggestion-fence false-positive regression tests (GH#4874)"
-	test_suggestion_fence_with_markdown_list_item_already_applied
-	test_suggestion_fence_with_markdown_list_item_not_yet_applied
+	run_suggestion_fence_regressions
 
 	echo ""
 	echo "Running approval/sentiment detection tests (GH#4604)"

--- a/.agents/scripts/tests/test-stale-recovery-escalation.sh
+++ b/.agents/scripts/tests/test-stale-recovery-escalation.sh
@@ -310,14 +310,14 @@ else
 fi
 
 # =============================================================================
-# Test 8 — Terminally failed ready PR escalates explicitly
+# Test 8 — Ready PR preserves durable progress for pulse CI repair
 # =============================================================================
 
-run_recover 0 "79|ready_failed" 1
-if echo "$output" | grep -q "STALE_READY_FAILED_ESCALATED"; then
-	print_result "Ready PR with terminal failed checks escalates explicitly" 0
+run_recover 0 "79|ready" 1
+if echo "$output" | grep -q "STALE_PROGRESS_PRESERVED" && ! grep -q "needs-maintainer-review" "$GH_CALLS_FILE"; then
+	print_result "Ready PR preserves durable progress without NMR escalation" 0
 else
-	print_result "Ready PR with terminal failed checks escalates explicitly" 1 "(got: '$output')"
+	print_result "Ready PR preserves durable progress without NMR escalation" 1 "(got: '$output')"
 fi
 
 # A later review-event workflow can exhaust its API quota after the exact-head

--- a/.agents/scripts/tests/test-worker-output-classification-head-vs-search.sh
+++ b/.agents/scripts/tests/test-worker-output-classification-head-vs-search.sh
@@ -426,22 +426,22 @@ test_case_active_pr_wins_over_historical_pr() {
 	return 0
 }
 
-test_case_real_checkrun_and_statuscontext_failures() {
+test_case_ci_failures_remain_ready_handoffs() {
 	local fixture expected got
 	for fixture in \
 		'[{"number":328,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"__typename":"CheckRun","name":"tests","status":"COMPLETED","conclusion":"FAILURE"}]}]' \
 		'[{"number":329,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"__typename":"StatusContext","context":"ci/test","state":"ERROR"}]}]'; do
 		case "$fixture" in
-			*328*) expected="ready_failed|328" ;;
-			*) expected="ready_failed|329" ;;
+			*328*) expected="ready|328" ;;
+			*) expected="ready|329" ;;
 		esac
 		export STUB_HEAD_JSON="$fixture"
 		export STUB_SEARCH_JSON='[]'
 		got=$(_pr_handoff_state_for_branch_or_issue "feature/failed-checks" "27517" "owner/repo")
 		if [[ "$got" == "$expected" ]]; then
-			print_result "real CheckRun/StatusContext failure shape classifies ${expected}" 0
+			print_result "real CheckRun/StatusContext failure remains durable ${expected}" 0
 		else
-			print_result "real CheckRun/StatusContext failure shape classifies ${expected}" 1 "got: '$got'"
+			print_result "real CheckRun/StatusContext failure remains durable ${expected}" 1 "got: '$got'"
 		fi
 	done
 	return 0
@@ -545,7 +545,7 @@ test_case_ready_requires_exact_head_and_merge_summary
 test_case_merged_requires_exact_head_and_merge_summary
 test_case_head_only_does_not_capture_unrelated_issue_draft
 test_case_active_pr_wins_over_historical_pr
-test_case_real_checkrun_and_statuscontext_failures
+test_case_ci_failures_remain_ready_handoffs
 test_case_protected_draft_labels_are_preserved
 test_case_e_orphan_recovery_skips_when_pr_exists
 test_case_f_orphan_recovery_proceeds_when_no_pr

--- a/.agents/scripts/tests/test-worker-output-classification.sh
+++ b/.agents/scripts/tests/test-worker-output-classification.sh
@@ -121,7 +121,7 @@ case "${1:-}" in
 			list)
 				case " $* " in
 					*".[].number"*) printf '%s\n' "${STUB_PR_NUMBERS:-}" ;;
-					*"number,state,isDraft,mergedAt,labels,statusCheckRollup"*) printf '%s\n' "${STUB_PR_JSON:-[]}" ;;
+					*"number,state,isDraft,mergedAt,headRefOid,labels,statusCheckRollup"*) printf '%s\n' "${STUB_PR_JSON:-[]}" ;;
 					*"--json number "*) printf '%s\n' "${STUB_SEARCH_JSON:-[]}" ;;
 					*) printf '%s\n' "${STUB_PR_COUNT:-0}" ;;
 				esac
@@ -131,8 +131,13 @@ case "${1:-}" in
 		;;
 	api)
 		# `_gh_wrapper_auto_sig` and friends call `gh api user --jq .login`.
-		# Emit a JSON object so callers that consume stdout don't break.
-		printf '{}\n'
+		# Emit a merge summary for the ready-PR fixture and a JSON object for
+		# source-time identity probes.
+		if [[ "$*" == *"/issues/77/comments"* ]]; then
+			printf '%s\n' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
+		else
+			printf '{}\n'
+		fi
 		;;
 	*) ;;
 esac
@@ -324,7 +329,10 @@ test_feature_branch_with_pr_returns_pr_exists() {
 		return 0
 	}
 	export STUB_PR_COUNT=1
-	export STUB_PR_JSON='[{"number":77,"state":"OPEN","isDraft":false,"mergedAt":null,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' STUB_SEARCH_JSON='[]'
+	local expected_head
+	expected_head=$(git -C "$WORK_DIR" rev-parse HEAD)
+	STUB_PR_JSON=$(printf '[{"number":77,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' "$expected_head")
+	export STUB_PR_JSON STUB_SEARCH_JSON='[]'
 	local got
 	got=$(_worker_produced_output "issue-1004" "$WORK_DIR")
 	if [[ "$got" == "pr_exists" ]]; then

--- a/.agents/scripts/tests/test-worker-warm-start-opencode.sh
+++ b/.agents/scripts/tests/test-worker-warm-start-opencode.sh
@@ -326,6 +326,19 @@ test_launch_script_has_prewarm() {
 		print_result "prewarm_env_var_in_launch_script" 0
 	fi
 
+	local renew_line prewarm_line
+	# shellcheck disable=SC2016 # Match literal runtime variables in helper source.
+	renew_line=$(grep -n '_dlw_renew_prelaunch_lease "\$issue_number"' "$launch_path" | tail -1 | cut -d: -f1)
+	# shellcheck disable=SC2016 # Match literal runtime variables in helper source.
+	prewarm_line=$(grep -n '_dlw_prewarm_opencode_db "\$worker_log"' "$launch_path" | tail -1 | cut -d: -f1)
+	if [[ -z "$renew_line" || -z "$prewarm_line" || "$renew_line" -ge "$prewarm_line" ]]; then
+		print_result "prelaunch_lease_renewed_before_prewarm" 1 \
+			"renew_line=${renew_line:-missing}, prewarm_line=${prewarm_line:-missing}"
+		rc=1
+	else
+		print_result "prelaunch_lease_renewed_before_prewarm" 0
+	fi
+
 	if [[ "$rc" -eq 0 ]]; then return 0; fi
 	return 1
 }


### PR DESCRIPTION
## Summary

- treat an exact-head, non-draft worker PR as a durable handoff even when its check rollup contains failed, cancelled, or historical runs, leaving CI repair and merge to pulse
- renew the dispatch prelaunch lease before OpenCode database warm-up and fail launch bookkeeping cleanly if the lease cannot be renewed
- permit only the current user's configured and native OS temporary directories through OpenCode's external-directory boundary, including resolved macOS paths
- suppress outdated review comments, exact-head verification praise, and older cross-PR feedback that a newer PR may already supersede
- persist direct release publication receipts so completion evidence survives the detached release runner

## Root cause and trade-offs

Worker completion was incorrectly coupled to aggregate check-rollup history. A valid PR could therefore apply `needs-maintainer-review` to its own issue and deadlock the normal pulse repair path. PR existence and exact-head/merge-summary evidence now define handoff durability; required-check health remains the merge pipeline's responsibility.

The OpenCode permission change is deliberately scoped to per-user temporary directories discovered at config generation/startup, rather than allowing all of `/tmp` or `/var/folders`.

## Verification

- `.agents/scripts/linters-local.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-worker-output-classification.sh`
- `bash .agents/scripts/tests/test-worker-output-classification-head-vs-search.sh`
- `bash .agents/scripts/tests/test-stale-recovery-escalation.sh`
- `bash .agents/scripts/tests/test-worker-warm-start-opencode.sh`
- `bash .agents/scripts/tests/test-agent-discovery-smoke.sh`
- `node --test .agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs`
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `bash .agents/scripts/tests/test-full-loop-release-helper.sh`

Supersedes the partial fixes in #27711 and #27712.

Resolves #27696
Resolves #27701
Resolves #27703
Resolves #27705
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 30m and 774,331 tokens on this with the user in an interactive session.