### PR TITLE
GH#27703: cover portable approval decoding and stabilize Qlty

### DIFF
--- a/.agents/scripts/tests/test-approval-helper-portable-base64.sh
+++ b/.agents/scripts/tests/test-approval-helper-portable-base64.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for portable approval comment decoding (GH#27703).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../approval-helper.sh
+source "${SCRIPT_DIR}/approval-helper.sh"
+
+TEST_ROOT="$(mktemp -d -t approval-portable-base64.XXXXXX)"
+FLAG_LOG="${TEST_ROOT}/base64-flag"
+TEST_UNAME="Linux"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+uname() {
+	printf '%s\n' "$TEST_UNAME"
+	return 0
+}
+
+base64() {
+	local decode_flag="$1"
+	printf '%s\n' "$decode_flag" >"$FLAG_LOG"
+	if command base64 -d; then
+		return 0
+	fi
+	return 1
+}
+
+_approval_classify_signed_comment() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+	local comment_id="$4"
+	local body="$5"
+	local pub_key="$6"
+	local expected_head_sha="${7:-}"
+	: "$target_type" "$target_number" "$slug" "$comment_id" "$pub_key" "$expected_head_sha"
+	[[ "$body" == $'portable\tapproval\nbody' ]] || return 1
+	printf 'VERIFIED\n'
+	return 0
+}
+
+run_decode_case() {
+	local os_name="$1"
+	local expected_flag="$2"
+	local comments_json result actual_flag
+	TEST_UNAME="$os_name"
+	comments_json=$(jq -cn --arg body $'portable\tapproval\nbody' '[{id: 42, body: $body}]')
+	result=$(_approval_classify_marked_comments issue 123 owner/repo "$comments_json" unused-key "" 1)
+	actual_flag=$(<"$FLAG_LOG")
+	if [[ "$result" == "VERIFIED" && "$actual_flag" == "$expected_flag" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+run_decode_case Linux -d
+run_decode_case Darwin -D
+
+printf 'approval helper portable base64 tests passed\n'

--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -113,6 +113,7 @@ STUB
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HELPER="$SCRIPT_DIR/qlty-smell-threshold-helper.sh"
+WORKFLOW="$SCRIPT_DIR/../../.github/workflows/code-quality.yml"
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/qlty-threshold-test.XXXXXX")
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -124,6 +125,13 @@ export PATH
 
 echo "${TEST_BLUE}=== GH#26017: qlty smell threshold helper tests ===${TEST_NC}"
 echo ""
+
+qlty_threshold_job=$(awk '
+	/^  qlty-smell-threshold:/ { in_job = 1 }
+	in_job { print }
+	/^  sonarcloud:/ { exit }
+' "$WORKFLOW")
+assert_contains "absolute threshold checkout preserves git history" "fetch-depth: 0" "$qlty_threshold_job"
 
 write_stub_qlty empty "$BIN_DIR"
 empty_output=$("$HELPER" "$CONF" 2>&1)

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -842,6 +842,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        # Match qlty-regression.yml so git-aware similar-code results are stable.
+        fetch-depth: 0
 
     - name: Install Qlty CLI
       uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0


### PR DESCRIPTION
## Summary

- Add regression coverage for approval comment base64 decoding on GNU/Linux and macOS.
- Verify the existing decoder selects `-d` on GNU/Linux and `-D` on Darwin while preserving tabs and newlines.
- Align the absolute Qlty threshold checkout with the full-history PR regression scan, preventing git-aware similar-code count drift without changing the threshold.

## Verification

- `.agents/scripts/tests/test-approval-helper-portable-base64.sh`
- `shellcheck .agents/scripts/tests/test-approval-helper-portable-base64.sh .agents/scripts/approval-helper.sh`
- `.agents/scripts/tests/test-qlty-smell-threshold-helper.sh`
- `.agents/scripts/linters-local.sh`

Resolves #27703
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 23m and 304,181 tokens on this as a headless worker.