### PR TITLE
t18123: add bounded worker progress blocker logging

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -15,6 +15,7 @@ import { getCursorProxyPort, registerCursorProvider } from "./cursor-proxy.mjs";
 import { getGoogleProxyPort, registerGoogleProvider } from "./google-proxy.mjs";
 import { getClaudeProxyPort, registerClaudeProvider } from "./claude-proxy.mjs";
 import { checkOpenCodeVersionDriftAsync } from "./version-tracking.mjs";
+import { appendWorkerBlockerEvent } from "../../scripts/worker-blocker-log.mjs";
 import {
   CLAUDE_MODEL_LIMITS,
   GPT56_CONTEXT_DEFAULT,
@@ -152,14 +153,21 @@ function verifyPermissionGrantSignature(grant, publicKey, tempBase) {
 }
 
 function verifyPermissionGrant(grantPath, options = {}) {
-  if (!grantPath || !existsSync(grantPath)) return null;
+  if (!grantPath) return { grant: null, reason: "grant_path_unset" };
+  if (!existsSync(grantPath)) return { grant: null, reason: "grant_file_missing" };
   const publicKey = options.publicKey || join(homedir(), ".aidevops", "approval-keys", "approval.pub");
-  if (!existsSync(publicKey)) return null;
+  if (!existsSync(publicKey)) return { grant: null, reason: "approval_public_key_missing" };
   const grant = readPermissionGrantFile(grantPath);
-  if (typeof grant?.payload !== "string" || typeof grant?.signature !== "string") return null;
+  if (typeof grant?.payload !== "string" || typeof grant?.signature !== "string") {
+    return { grant: null, reason: "grant_envelope_invalid" };
+  }
   const tempBase = options.tempBase || process.env.AIDEVOPS_TEMP_DIR || join(homedir(), ".aidevops", ".agent-workspace", "tmp");
-  if (!verifyPermissionGrantSignature(grant, publicKey, tempBase)) return null;
-  return parsePermissionGrantPayload(grant.payload);
+  if (!verifyPermissionGrantSignature(grant, publicKey, tempBase)) {
+    return { grant: null, reason: "grant_signature_invalid" };
+  }
+  const payload = parsePermissionGrantPayload(grant.payload);
+  if (!payload) return { grant: null, reason: "grant_payload_invalid" };
+  return { grant: payload, reason: "verified" };
 }
 
 function ensurePermissionMap(target) {
@@ -207,13 +215,16 @@ function permissionGrantTargetMatches(grant) {
   return String(grant.target?.repository || "").toLowerCase() === repo;
 }
 
-function permissionGrantTimeValid(grant) {
+function permissionGrantTimeReason(grant) {
   const issued = Date.parse(grant.issued_at || "");
   const expires = Date.parse(grant.expires_at || "");
   const now = Date.now();
-  if (!Number.isFinite(issued) || !Number.isFinite(expires)) return false;
-  if (issued > now + 5 * 60 * 1000 || expires <= now) return false;
-  return expires > issued && expires - issued <= MAX_PERMISSION_GRANT_MS;
+  if (!Number.isFinite(issued) || !Number.isFinite(expires)) return "grant_time_invalid";
+  if (expires <= now) return "grant_expired";
+  if (issued > now + 5 * 60 * 1000) return "grant_issued_in_future";
+  if (expires <= issued) return "grant_time_invalid";
+  if (expires - issued > MAX_PERMISSION_GRANT_MS) return "grant_duration_excessive";
+  return "";
 }
 
 function permissionGrantRequestValid(grant) {
@@ -236,17 +247,18 @@ function permissionGrantBranchMatches(grantBranch, currentBranch) {
   return grantBranch === currentBranch;
 }
 
-function permissionGrantWorkerMatches(grant, options) {
+function permissionGrantWorkerMismatchReason(grant, options) {
   const pendingRequest = String(options.pendingRequest || process.env.AIDEVOPS_PERMISSION_REQUEST_ID || "");
-  if (!pendingRequest || grant.request_id !== pendingRequest) return false;
+  if (!pendingRequest || grant.request_id !== pendingRequest) return "grant_request_mismatch";
   const repositoryDir = String(options.repositoryDir || "");
-  if (!repositoryDir) return false;
+  if (!repositoryDir) return "grant_worktree_unavailable";
   const expectedWorktree = createHash("sha256").update(repositoryDir).digest("hex");
-  if (grant.worker?.worktree_sha256 !== expectedWorktree) return false;
+  if (grant.worker?.worktree_sha256 !== expectedWorktree) return "grant_worktree_mismatch";
   const currentSession = String(options.currentSession || process.env.WORKER_SESSION_KEY || "");
-  if (!currentSession || grant.worker?.session !== currentSession) return false;
+  if (!currentSession || grant.worker?.session !== currentSession) return "grant_session_mismatch";
   const currentBranch = currentWorkerBranch(options, repositoryDir);
-  return permissionGrantBranchMatches(grant.worker?.branch, currentBranch);
+  if (!permissionGrantBranchMatches(grant.worker?.branch, currentBranch)) return "grant_branch_mismatch";
+  return "";
 }
 
 function permissionGrantPatternSafe(pattern) {
@@ -270,25 +282,55 @@ function permissionGrantCapabilitiesSafe(grant) {
   return grant.capabilities.every(permissionGrantCapabilitySafe);
 }
 
-function permissionGrantUsable(grant, options) {
-  const checks = [
-    permissionGrantTargetMatches(grant),
-    permissionGrantTimeValid(grant),
-    permissionGrantRequestValid(grant),
-    permissionGrantWorkerMatches(grant, options),
-    permissionGrantCapabilitiesSafe(grant),
-  ];
-  return checks.every(Boolean);
+function permissionGrantRejectionReason(grant, options) {
+  if (!permissionGrantTargetMatches(grant)) return "grant_target_mismatch";
+  const timeReason = permissionGrantTimeReason(grant);
+  if (timeReason) return timeReason;
+  if (!permissionGrantRequestValid(grant)) return "grant_request_invalid";
+  const workerReason = permissionGrantWorkerMismatchReason(grant, options);
+  if (workerReason) return workerReason;
+  if (!permissionGrantCapabilitiesSafe(grant)) return "grant_capabilities_unsafe";
+  return "";
+}
+
+function recordPermissionGrantEvent(options, grant, event, status, reason, blocking) {
+  appendWorkerBlockerEvent({
+    event,
+    status,
+    reason,
+    blocking,
+    source: "opencode-config-hook",
+    request_id: options.pendingRequest || process.env.AIDEVOPS_PERMISSION_REQUEST_ID || grant?.request_id || "",
+    session_key: options.currentSession || process.env.WORKER_SESSION_KEY || grant?.worker?.session || "",
+    detail: blocking ? "Worker permission grant was unavailable or rejected" : "Scoped worker permission grant applied",
+  }, { logPath: options.blockerLogPath });
 }
 
 export function registerApprovedWorkerPermissions(config, options = {}) {
   const grantPath = options.grantPath || process.env.AIDEVOPS_PERMISSION_GRANT_FILE || "";
-  const grant = verifyPermissionGrant(grantPath, options);
-  if (!grant || !permissionGrantUsable(grant, options)) return 0;
+  const pendingRequest = String(options.pendingRequest || process.env.AIDEVOPS_PERMISSION_REQUEST_ID || "");
+  if (!pendingRequest) return 0;
+  const verification = verifyPermissionGrant(grantPath, options);
+  if (!verification.grant) {
+    const event = verification.reason === "grant_file_missing"
+      ? "permission_awaiting_approval"
+      : "permission_grant_rejected";
+    recordPermissionGrantEvent({ ...options, pendingRequest }, null, event, "blocked", verification.reason, true);
+    return 0;
+  }
+  const grant = verification.grant;
+  const rejectionReason = permissionGrantRejectionReason(grant, { ...options, pendingRequest });
+  if (rejectionReason) {
+    recordPermissionGrantEvent({ ...options, pendingRequest }, grant,
+      "permission_grant_rejected", "blocked", rejectionReason, true);
+    return 0;
+  }
   let count = addApprovedCapabilityRules(config, grant.capabilities);
   for (const agent of Object.values(config.agent || {})) {
     count += addApprovedCapabilityRules(agent, grant.capabilities);
   }
+  recordPermissionGrantEvent({ ...options, pendingRequest }, grant,
+    "permission_grant_applied", "resuming", "scoped_permission_granted", false);
   return count;
 }
 

--- a/.agents/plugins/opencode-aidevops/permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker.mjs
@@ -5,6 +5,7 @@ import { createHash } from "crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { dirname } from "path";
 import { homedir } from "os";
+import { appendWorkerBlockerEvent } from "../../scripts/worker-blocker-log.mjs";
 
 const REQUEST_SCHEMA = "aidevops-permission-capture/v1";
 const MAX_PATTERN_LENGTH = 500;
@@ -114,9 +115,28 @@ function recordPermissionToolCall(toolCalls, isHeadless, home, input, output) {
   while (toolCalls.size > 100) toolCalls.delete(toolCalls.keys().next().value);
 }
 
-function capturePermissionRequest(toolCalls, home, raw) {
+function recordPermissionBlocker(loggedEvents, home, blockerLogPath, request, event, reason, detail) {
+  const dedupeKey = `${event}:${request?.request_id || "unknown"}`;
+  if (loggedEvents.has(dedupeKey)) return;
+  loggedEvents.add(dedupeKey);
+  while (loggedEvents.size > 100) loggedEvents.delete(loggedEvents.values().next().value);
+  appendWorkerBlockerEvent({
+    event,
+    status: "blocked",
+    reason,
+    blocking: true,
+    source: "opencode-permission-broker",
+    request_id: request?.request_id || "",
+    permission: request?.permission || "",
+    tool: request?.tool || "",
+    risk_level: request?.risk?.level || "",
+    grantable: request?.risk?.grantable,
+    detail,
+  }, { home, logPath: blockerLogPath });
+}
+
+function capturePermissionRequest(toolCalls, loggedEvents, home, blockerLogPath, raw) {
   const requestFile = process.env.AIDEVOPS_PERMISSION_REQUEST_FILE || "";
-  if (!requestFile) return null;
   const callID = raw?.tool?.callID || raw?.callID || "";
   const toolContext = toolCalls.get(callID) || {};
   const options = { home, workDir: process.env.WORKER_WORKTREE_PATH || "" };
@@ -146,11 +166,26 @@ function capturePermissionRequest(toolCalls, home, raw) {
     requests: [],
   };
   request.request_id = stableRequestID({ ...request, issue: capture.issue, repo: capture.repo });
+  if (!requestFile) {
+    recordPermissionBlocker(loggedEvents, home, blockerLogPath, request,
+      "permission_capture_failed", "request_file_unset", "Headless permission request capture path was unavailable");
+    return request;
+  }
   const existingIndex = capture.requests.findIndex((item) => item.request_id === request.request_id);
   if (existingIndex >= 0) capture.requests[existingIndex] = request;
   else capture.requests.push(request);
   capture.requests = capture.requests.slice(-MAX_REQUESTS);
-  writeCaptureFile(requestFile, capture);
+  const written = writeCaptureFile(requestFile, capture);
+  if (!written) {
+    recordPermissionBlocker(loggedEvents, home, blockerLogPath, request,
+      "permission_capture_failed", "capture_file_write_failed", "Permission request could not be persisted");
+  } else if (request.risk.grantable) {
+    recordPermissionBlocker(loggedEvents, home, blockerLogPath, request,
+      "permission_request_captured", "permission_required", request.risk.reason);
+  } else {
+    recordPermissionBlocker(loggedEvents, home, blockerLogPath, request,
+      "permission_request_non_grantable", "permission_non_grantable", request.risk.reason);
+  }
   return request;
 }
 
@@ -166,25 +201,26 @@ async function rejectPermissionRequest(client, request) {
   }
 }
 
-async function handlePermissionEvent(client, isHeadless, toolCalls, home, input) {
+async function handlePermissionEvent(client, isHeadless, toolCalls, loggedEvents, home, blockerLogPath, input) {
   const event = input?.event;
   if (!isHeadless() || event?.type !== "permission.asked") return;
   const request = event.properties || {};
-  capturePermissionRequest(toolCalls, home, request);
+  capturePermissionRequest(toolCalls, loggedEvents, home, blockerLogPath, request);
   await rejectPermissionRequest(client, request);
 }
 
-function handlePermissionAsk(isHeadless, toolCalls, home, input, output) {
+function handlePermissionAsk(isHeadless, toolCalls, loggedEvents, home, blockerLogPath, input, output) {
   if (!isHeadless()) return;
-  capturePermissionRequest(toolCalls, home, input || {});
+  capturePermissionRequest(toolCalls, loggedEvents, home, blockerLogPath, input || {});
   output.status = "deny";
 }
 
-export function createPermissionBroker({ client, isHeadless, home = homedir() }) {
+export function createPermissionBroker({ client, isHeadless, home = homedir(), blockerLogPath = undefined }) {
   const toolCalls = new Map();
+  const loggedEvents = new Set();
   return {
     recordToolCall: (input, output) => recordPermissionToolCall(toolCalls, isHeadless, home, input, output),
-    handleEvent: (input) => handlePermissionEvent(client, isHeadless, toolCalls, home, input),
-    permissionAsk: (input, output) => handlePermissionAsk(isHeadless, toolCalls, home, input, output),
+    handleEvent: (input) => handlePermissionEvent(client, isHeadless, toolCalls, loggedEvents, home, blockerLogPath, input),
+    permissionAsk: (input, output) => handlePermissionAsk(isHeadless, toolCalls, loggedEvents, home, blockerLogPath, input, output),
   };
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
@@ -12,6 +12,7 @@ import { createPermissionBroker, sanitizePermissionText } from "../permission-br
 test("headless permission event is sanitized, persisted, and rejected", async () => {
   const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
   const requestFile = join(root, "request.json");
+  const blockerLog = join(root, "blockers.jsonl");
   const previous = process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
   process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
   process.env.WORKER_ISSUE_NUMBER = "123";
@@ -21,6 +22,7 @@ test("headless permission event is sanitized, persisted, and rejected", async ()
     client: { postSessionIdPermissionsPermissionId: async (value) => replies.push(value) },
     isHeadless: () => true,
     home: "/Users/example",
+    blockerLogPath: blockerLog,
   });
   broker.recordToolCall(
     { tool: "read", callID: "call-1" },
@@ -39,6 +41,10 @@ test("headless permission event is sanitized, persisted, and rejected", async ()
   assert.match(capture.requests[0].patterns[0], /^~\//);
   assert.doesNotMatch(capture.requests[0].intent, /secret-value/);
   assert.equal(replies[0].body.response, "reject");
+  const blocker = JSON.parse(readFileSync(blockerLog, "utf8").trim());
+  assert.equal(blocker.reason, "permission_required");
+  assert.equal(blocker.blocking, true);
+  assert.doesNotMatch(blocker.detail, /secret-value/);
   if (previous === undefined) delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
   else process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = previous;
   rmSync(root, { recursive: true, force: true });
@@ -48,7 +54,8 @@ test("sensitive locations are non-grantable", async () => {
   const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
   const requestFile = join(root, "request.json");
   process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
-  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example" });
+  const blockerLog = join(root, "blockers.jsonl");
+  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example", blockerLogPath: blockerLog });
   const output = { status: "ask" };
   await broker.permissionAsk({
     id: "permission-2",
@@ -58,6 +65,7 @@ test("sensitive locations are non-grantable", async () => {
   const capture = JSON.parse(readFileSync(requestFile, "utf8"));
   assert.equal(output.status, "deny");
   assert.equal(capture.requests[0].risk.grantable, false);
+  assert.equal(JSON.parse(readFileSync(blockerLog, "utf8").trim()).reason, "permission_non_grantable");
   rmSync(root, { recursive: true, force: true });
   delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
 });
@@ -66,7 +74,7 @@ test("requests without an exact pattern are non-grantable", async () => {
   const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
   const requestFile = join(root, "request.json");
   process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
-  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example" });
+  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example", blockerLogPath: join(root, "blockers.jsonl") });
   const output = { status: "ask" };
   await broker.permissionAsk({ id: "permission-3", type: "bash", patterns: [] }, output);
   const capture = JSON.parse(readFileSync(requestFile, "utf8"));
@@ -80,7 +88,7 @@ test("action-only permissions are non-grantable", async () => {
   const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
   const requestFile = join(root, "request.json");
   process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
-  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example" });
+  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example", blockerLogPath: join(root, "blockers.jsonl") });
   await broker.permissionAsk({ id: "permission-4", type: "webfetch", patterns: ["example.invalid"] }, { status: "ask" });
   const capture = JSON.parse(readFileSync(requestFile, "utf8"));
   assert.equal(capture.requests[0].risk.grantable, false);
@@ -94,10 +102,12 @@ test("capture write failure still denies the permission without crashing", async
   const blocker = join(root, "not-a-directory");
   writeFileSync(blocker, "block");
   process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = join(blocker, "request.json");
-  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example" });
+  const blockerLog = join(root, "blockers.jsonl");
+  const broker = createPermissionBroker({ client: {}, isHeadless: () => true, home: "/Users/example", blockerLogPath: blockerLog });
   const output = { status: "ask" };
   await broker.permissionAsk({ id: "permission-5", type: "bash", patterns: ["git status"] }, output);
   assert.equal(output.status, "deny");
+  assert.equal(JSON.parse(readFileSync(blockerLog, "utf8").trim()).reason, "capture_file_write_failed");
   rmSync(root, { recursive: true, force: true });
   delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  appendWorkerBlockerEvent,
+  normalizeWorkerBlockerEvent,
+  WORKER_BLOCKER_SCHEMA,
+} from "../../../scripts/worker-blocker-log.mjs";
+
+const LOGGER_PATH = fileURLToPath(new URL("../../../scripts/worker-blocker-log.mjs", import.meta.url));
+
+function appendInSubprocess(logPath, event) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [LOGGER_PATH, "append", "--log-file", logPath, "--event", event]);
+    let stderr = "";
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`blocker logger exited ${code}: ${stderr}`));
+    });
+  });
+}
+
+test("worker blocker event normalization redacts credentials and local paths", () => {
+  const event = normalizeWorkerBlockerEvent({
+    event: "permission_request_captured",
+    reason: "permission_required",
+    detail: "/Users/example/worktree token=secret-value credential=placeholder-value Authorization: Bearer bearer-value",
+    repo_slug: "Owner/Repo",
+    issue_number: "123",
+  }, { home: "/Users/example", workDir: "/Users/example/worktree", now: new Date("2026-07-14T12:00:00Z") });
+  assert.equal(event.schema, WORKER_BLOCKER_SCHEMA);
+  assert.equal(event.repo_slug, "owner/repo");
+  assert.equal(event.issue_number, 123);
+  assert.doesNotMatch(event.detail, /secret-value|placeholder-value|bearer-value|ghp_|\/Users\/example/);
+  assert.match(event.detail, /\$WORKTREE|~/);
+});
+
+test("append trims oldest complete records before the bounded log exceeds its cap", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-blockers-"));
+  const logPath = join(root, "worker-progress-blockers.jsonl");
+  const maxBytes = 1_200;
+  for (let index = 0; index < 20; index++) {
+    assert.equal(appendWorkerBlockerEvent({
+      event: `event-${index}`,
+      reason: "permission_required",
+      source: "test",
+      issue_number: 123,
+      repo_slug: "owner/repo",
+      session_key: "issue-123",
+      detail: "bounded append fixture",
+    }, { logPath, maxBytes }), true);
+  }
+  const content = readFileSync(logPath, "utf8");
+  const events = content.trim().split("\n").map((line) => JSON.parse(line));
+  assert.ok(statSync(logPath).size <= maxBytes);
+  assert.equal(statSync(logPath).mode & 0o777, 0o600);
+  assert.equal(events.at(-1).event, "event-19");
+  assert.equal(events.some((event) => event.event === "event-0"), false);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("append fails open when the parent path is not a directory", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-blocker-parent-"));
+  const parentFile = join(root, "not-a-directory");
+  writeFileSync(parentFile, "occupied");
+  assert.equal(appendWorkerBlockerEvent(
+    { event: "permission_blocked" },
+    { logPath: join(parentFile, "events.jsonl") },
+  ), false);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("append rejects symlinked logs", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-blocker-symlink-"));
+  const target = join(root, "target.txt");
+  const logPath = join(root, "events.jsonl");
+  writeFileSync(target, "unchanged");
+  symlinkSync(target, logPath);
+  assert.equal(appendWorkerBlockerEvent({ event: "permission_blocked" }, { logPath }), false);
+  assert.equal(readFileSync(target, "utf8"), "unchanged");
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("append reclaims a stale owned lock", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-blocker-stale-"));
+  const logPath = join(root, "events.jsonl");
+  const lockPath = `${logPath}.lock`;
+  writeFileSync(lockPath, "abandoned", { mode: 0o600 });
+  const staleTime = new Date(Date.now() - 60_000);
+  utimesSync(lockPath, staleTime, staleTime);
+  assert.equal(appendWorkerBlockerEvent({ event: "permission_blocked" }, { logPath }), true);
+  assert.equal(JSON.parse(readFileSync(logPath, "utf8")).event, "permission_blocked");
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("parallel appenders recover after a stale reclaim lock", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-blocker-reclaim-"));
+  const logPath = join(root, "events.jsonl");
+  const reclaimPath = `${logPath}.lock.reclaim`;
+  writeFileSync(reclaimPath, "abandoned", { mode: 0o600 });
+  const staleTime = new Date(Date.now() - 60_000);
+  utimesSync(reclaimPath, staleTime, staleTime);
+  const eventNames = Array.from({ length: 12 }, (_, index) => `recovered-${index}`);
+  await Promise.all(eventNames.map((event) => appendInSubprocess(logPath, event)));
+  const events = readFileSync(logPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+  assert.deepEqual(new Set(events.map((event) => event.event)), new Set(eventNames));
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("concurrent appenders preserve complete JSONL records", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-blocker-concurrent-"));
+  const logPath = join(root, "events.jsonl");
+  const eventNames = Array.from({ length: 12 }, (_, index) => `concurrent-${index}`);
+  await Promise.all(eventNames.map((event) => appendInSubprocess(logPath, event)));
+  const events = readFileSync(logPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+  assert.deepEqual(new Set(events.map((event) => event.event)), new Set(eventNames));
+  rmSync(root, { recursive: true, force: true });
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-worker-permission-grant.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-worker-permission-grant.mjs
@@ -11,6 +11,10 @@ import { tmpdir } from "os";
 
 import { registerApprovedWorkerPermissions } from "../config-hook.mjs";
 
+function blockerEvents(root) {
+  return readFileSync(join(root, "blockers.jsonl"), "utf8").trim().split("\n").map((line) => JSON.parse(line));
+}
+
 function signedGrant(root, options = {}) {
   const key = join(root, "approval.key");
   execFileSync("ssh-keygen", ["-t", "ed25519", "-N", "", "-q", "-f", key]);
@@ -56,10 +60,12 @@ test("verified unexpired grant adds exact rules globally and per agent", () => {
   assert.equal(registerApprovedWorkerPermissions(config, {
     grantPath: grant.grantPath, publicKey: grant.publicKey, tempBase: root, repositoryDir: root,
     currentSession: "issue-123", currentBranch: "feature/auto-gh123", pendingRequest: "perm-0123456789abcdef",
+    blockerLogPath: join(root, "blockers.jsonl"),
   }), 2);
   const pattern = "~/.cache/opencode/node_modules/@opencode-ai/sdk/**";
   assert.equal(config.permission.external_directory[pattern], "allow");
   assert.equal(config.agent.review.permission.external_directory[pattern], "allow");
+  assert.equal(blockerEvents(root).at(-1).blocking, false);
   for (const [key, value] of Object.entries({ WORKER_ISSUE_NUMBER: old.issue, WORKER_REPO_SLUG: old.repo })) {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
@@ -76,8 +82,10 @@ test("expired grant is ignored even with a valid signature", () => {
   assert.equal(registerApprovedWorkerPermissions(config, {
     grantPath: grant.grantPath, publicKey: grant.publicKey, tempBase: root, repositoryDir: root,
     currentSession: "issue-123", currentBranch: "feature/auto-gh123", pendingRequest: "perm-0123456789abcdef",
+    blockerLogPath: join(root, "blockers.jsonl"),
   }), 0);
   assert.equal(config.permission, undefined);
+  assert.equal(blockerEvents(root).at(-1).reason, "grant_expired");
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -95,8 +103,10 @@ test("grant cannot be replayed from a different worktree", () => {
     currentSession: "issue-123",
     currentBranch: "feature/auto-gh123",
     pendingRequest: "perm-0123456789abcdef",
+    blockerLogPath: join(root, "blockers.jsonl"),
   }), 0);
   assert.equal(config.permission, undefined);
+  assert.equal(blockerEvents(root).at(-1).reason, "grant_worktree_mismatch");
   const differentSessionConfig = { agent: {} };
   assert.equal(registerApprovedWorkerPermissions(differentSessionConfig, {
     grantPath: grant.grantPath,
@@ -106,8 +116,22 @@ test("grant cannot be replayed from a different worktree", () => {
     currentSession: "issue-999",
     currentBranch: "feature/auto-gh123",
     pendingRequest: "perm-0123456789abcdef",
+    blockerLogPath: join(root, "blockers.jsonl"),
   }), 0);
   assert.equal(differentSessionConfig.permission, undefined);
+  assert.equal(blockerEvents(root).at(-1).session_key, "issue-999");
+  const differentRequestConfig = { agent: {} };
+  assert.equal(registerApprovedWorkerPermissions(differentRequestConfig, {
+    grantPath: grant.grantPath,
+    publicKey: grant.publicKey,
+    tempBase: root,
+    repositoryDir: root,
+    currentSession: "issue-123",
+    currentBranch: "feature/auto-gh123",
+    pendingRequest: "perm-fedcba9876543210",
+    blockerLogPath: join(root, "blockers.jsonl"),
+  }), 0);
+  assert.equal(blockerEvents(root).at(-1).request_id, "perm-fedcba9876543210");
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -124,6 +148,7 @@ test("branch lookup failure cannot match a null grant branch", () => {
     repositoryDir: root,
     currentSession: "issue-123",
     pendingRequest: "perm-0123456789abcdef",
+    blockerLogPath: join(root, "blockers.jsonl"),
   }), 0);
   assert.equal(config.permission, undefined);
   rmSync(root, { recursive: true, force: true });
@@ -145,6 +170,7 @@ test("signature verification temp failure ignores the grant without crashing", (
     currentSession: "issue-123",
     currentBranch: "feature/auto-gh123",
     pendingRequest: "perm-0123456789abcdef",
+    blockerLogPath: join(root, "blockers.jsonl"),
   }), 0);
   assert.equal(config.permission, undefined);
   rmSync(root, { recursive: true, force: true });
@@ -168,6 +194,7 @@ for (const [name, options] of [
     assert.equal(registerApprovedWorkerPermissions(config, {
       grantPath: grant.grantPath, publicKey: grant.publicKey, tempBase: root, repositoryDir: root,
       currentSession: "issue-123", currentBranch: "feature/auto-gh123", pendingRequest: "perm-0123456789abcdef",
+      blockerLogPath: join(root, "blockers.jsonl"),
     }), 0);
     assert.equal(config.permission, undefined);
     rmSync(root, { recursive: true, force: true });

--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -30,6 +30,11 @@ Applied to GitHub issues. The pulse checks these before spawning a worker.
 
 Permission grants are limited to exact-pattern `bash` and `external_directory` requests, bound to the issue, request digest, worker session, branch, and worktree hash, and expire after four hours. Action-only permissions and credential-bearing or unbounded paths remain non-grantable.
 
+The permission broker, approval flow, and grant verifier append blocker-state
+transitions to `~/.aidevops/logs/worker-progress-blockers.jsonl`. Diagnose the
+label and its exact local reason with `pulse-diagnose-helper.sh issue <N> --repo
+<owner/repo>`; removing the label does not alter or bypass grant verification.
+
 ### Conditional Dispatch Blocks (require active claim state)
 
 These labels DO NOT block dispatch on their own. They become blockers only when combined with an active claim signal — see "Claim-State Blockers" below.

--- a/.agents/reference/observability.md
+++ b/.agents/reference/observability.md
@@ -75,6 +75,32 @@ but those controls do not constitute bounded history or an age/count policy.
 
 Full-loop keeps authoritative resumable state in `.agents/loop-state/full-loop.local.state` and appends local transition evidence to `full-loop-events.jsonl`. Schema v2 records the run ID, state revision, phase status/start/end/attempt, terminal evidence, next safe action, observed executor status/PID/heartbeat, manual resumes, reused subagent units, and duplicate work avoided. Status must validate executor liveness instead of trusting a stale PID. These records drive lifecycle recovery; runtime events and plugin cost/tool data remain fail-open reporting evidence. Aggregate phase wall time, active compute, CI wait/repair, release/cleanup time, calls by tier, retries/outcomes, reuse, false-positive gates, and manual resumes when producing performance reports.
 
+### Worker progress-blocker log
+
+Headless permission and approval stops append redacted lifecycle records to
+`~/.aidevops/logs/worker-progress-blockers.jsonl`. Records use schema
+`aidevops-worker-blocker/v1` and correlate `issue_number`, `repo_slug`,
+`session_key`, and `request_id` with the event, reason, source, risk class, and
+whether the condition is still blocking. Exact permission patterns, model
+intent, credentials, and raw tool metadata are not stored in this log.
+
+The default cap is 5 MiB. Each append acquires a short-lived local lock and,
+when the incoming record would exceed the cap, atomically keeps only the newest
+complete JSONL records that fit before appending. Override the path with
+`AIDEVOPS_WORKER_BLOCKER_LOG_FILE` or the cap with
+`AIDEVOPS_WORKER_BLOCKER_LOG_MAX_BYTES`. The writer is fail-open: logging or
+trimming failures never grant a permission or change the worker action.
+
+Writers cover permission capture/non-grantable scope, handoff persistence,
+awaiting maintainer approval, approval persistence, expired or replay-rejected
+grants, and successful grant application. Query through bounded diagnostics
+instead of recursively searching worker logs:
+
+```bash
+worker-activity-helper.sh summary --since 24h
+pulse-diagnose-helper.sh issue <N> --repo <owner/repo>
+```
+
 Inspect recent events without exposing any other store:
 
 ```bash
@@ -335,7 +361,8 @@ If aidevops attributes are missing in a mode where they should work:
   context, GraphQL-budget counters, and top recent examples so “is work
   happening now?” can be answered from current evidence.
 - `worker-activity-helper.sh summary --since 1h [--json]` — historical worker
-  outcome summary. JSON output includes `metrics.result_counts`,
+  outcome and progress-blocker summary. JSON output includes
+  `metrics.result_counts`, `progress_blockers.active_blockers`,
   `metrics.timing_ms`, and `metrics.recent_examples` with load context from
   `headless-runtime-metrics.jsonl`.
 - `session-miner` routine — post-hoc mining of successful/failed sessions

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -59,6 +59,30 @@ terminal marker. The first recovery emits one combined recovery/tick comment;
 the second applies `needs-maintainer-review`. An open PR is durable progress, so
 stale recovery preserves its ownership and emits no synthetic reset comment.
 
+## Progress-Blocker Evidence
+
+Before opening raw worker logs, inspect the bounded blocker lifecycle alongside
+canonical runtime outcomes:
+
+```bash
+worker-activity-helper.sh summary --since 24h
+pulse-diagnose-helper.sh issue <N> --repo <owner/repo>
+```
+
+Both commands read `~/.aidevops/logs/worker-progress-blockers.jsonl`.
+`worker-activity-helper.sh` reports events in the selected window plus current
+active blockers from the latest retained event per worker session.
+`pulse-diagnose-helper.sh issue` filters the same records by issue/repository and
+includes them in human output and JSON `progress_blockers`.
+
+Permission blocker reasons distinguish a normal `permission_required` or
+`needs_maintainer_permissions` pause from non-grantable sensitive scope,
+capture/comment/label/marker persistence failures, missing or invalid signed
+grants, expiry, target/request/worktree/session/branch replay mismatches, and a
+successful `scoped_permission_granted` resume. A non-blocking grant event clears
+the prior blocker for the same worker session even though the envelope request
+ID differs from the source OpenCode request ID.
+
 ## Manual Worker Launch
 
 Use `aidevops launch-worker` when an operator needs a controlled headless

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -82,6 +82,82 @@ readonly PERMISSION_SHA256_PATTERN='^[0-9a-f]{64}$'
 readonly PERMISSION_JSON_ARRAY_TYPE="array"
 readonly PERMISSION_JSON_STRING_TYPE="string"
 readonly _APPROVAL_AUTO_DISPATCH_LABEL="auto-dispatch"
+readonly _PERMISSION_BLOCKER_STATUS="blocked"
+readonly _PERMISSION_BLOCKER_TRUE="true"
+readonly _PERMISSION_APPROVAL_REJECTED_EVENT="permission_approval_rejected"
+readonly _PERMISSION_GRANT_PERSISTENCE_FAILED_EVENT="permission_grant_persistence_failed"
+
+_run_worker_blocker_logger() {
+	local logger="$1"
+	shift
+	local node_bin
+	node_bin=$(command -v node) || return 0
+	if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
+		command -v sudo >/dev/null 2>&1 || return 0
+		sudo -u "$SUDO_USER" -H -- "$node_bin" "$logger" "$@" >/dev/null 2>&1 || true
+		return 0
+	fi
+	"$node_bin" "$logger" "$@" >/dev/null 2>&1 || true
+	return 0
+}
+
+_record_permission_blocker_event() {
+	local event="$1"
+	local status="$2"
+	local reason="$3"
+	local blocking="$4"
+	local target_number="$5"
+	local slug="$6"
+	local request_id="$7"
+	local session_key="${8:-}"
+	local detail="${9:-}"
+	local logger="${SCRIPT_DIR}/worker-blocker-log.mjs"
+	local log_file="${AIDEVOPS_WORKER_BLOCKER_LOG_FILE:-${_APPROVAL_HOME}/.aidevops/logs/worker-progress-blockers.jsonl}"
+	[[ -f "$logger" ]] || return 0
+	_run_worker_blocker_logger "$logger" append \
+		--event "$event" \
+		--status "$status" \
+		--reason "$reason" \
+		--blocking "$blocking" \
+		--source "approval-helper" \
+		--issue-number "$target_number" \
+		--repo-slug "$slug" \
+		--request-id "$request_id" \
+		--session-key "$session_key" \
+		--detail "$detail" \
+		--log-file "$log_file"
+	return 0
+}
+
+_record_permission_approval_rejection() {
+	local reason="$1"
+	local target_number="$2"
+	local slug="$3"
+	local request_id="$4"
+	local session_key="$5"
+	local detail="$6"
+	_record_permission_blocker_event "$_PERMISSION_APPROVAL_REJECTED_EVENT" "$_PERMISSION_BLOCKER_STATUS" \
+		"$reason" "$_PERMISSION_BLOCKER_TRUE" "$target_number" "$slug" "$request_id" "$session_key" "$detail"
+	return 0
+}
+
+_record_permission_grant_failure() {
+	local reason="$1"
+	local target_number="$2"
+	local slug="$3"
+	local request_id="$4"
+	local session_key="$5"
+	local detail="$6"
+	_record_permission_blocker_event "$_PERMISSION_GRANT_PERSISTENCE_FAILED_EVENT" "$_PERMISSION_BLOCKER_STATUS" \
+		"$reason" "$_PERMISSION_BLOCKER_TRUE" "$target_number" "$slug" "$request_id" "$session_key" "$detail"
+	return 0
+}
+
+_permission_request_session() {
+	local request_json="$1"
+	jq -r '.worker.session // empty' <<<"$request_json"
+	return $?
+}
 
 # shellcheck source=approval-snapshot-v2.sh
 source "${SCRIPT_DIR}/approval-snapshot-v2.sh"
@@ -1072,6 +1148,14 @@ _permission_grant_path() {
 	return 0
 }
 
+_set_permission_grant_owner() {
+	local real_user="$1"
+	local grant_path="$2"
+	[[ "$(id -u)" -eq 0 ]] || return 0
+	chown "$real_user" "$grant_path" 2>/dev/null || return 1
+	return 0
+}
+
 _write_local_permission_grant() {
 	local payload="$1"
 	local sig_file="$2"
@@ -1079,13 +1163,25 @@ _write_local_permission_grant() {
 	local target_number="$4"
 	local grant_path grant_tmp real_user
 	grant_path=$(_permission_grant_path "$slug" "$target_number")
-	grant_tmp=$(mktemp)
+	grant_tmp=$(mktemp) || return 1
 	real_user=$(_approval_real_user)
-	jq -n --arg payload "$payload" --rawfile signature "$sig_file" \
-		'{payload: $payload, signature: $signature}' >"$grant_tmp"
-	mkdir -p "$(dirname "$grant_path")"
-	install -m 600 "$grant_tmp" "$grant_path"
-	chown "$real_user" "$grant_path" 2>/dev/null || true
+	if ! jq -n --arg payload "$payload" --rawfile signature "$sig_file" \
+		'{payload: $payload, signature: $signature}' >"$grant_tmp"; then
+		rm -f "$grant_tmp"
+		return 1
+	fi
+	if ! mkdir -p "$(dirname "$grant_path")"; then
+		rm -f "$grant_tmp"
+		return 1
+	fi
+	if ! install -m 600 "$grant_tmp" "$grant_path"; then
+		rm -f "$grant_tmp"
+		return 1
+	fi
+	if ! _set_permission_grant_owner "$real_user" "$grant_path"; then
+		rm -f "$grant_tmp" "$grant_path" || true
+		return 1
+	fi
 	rm -f "$grant_tmp"
 	return 0
 }
@@ -1133,6 +1229,63 @@ _kick_pulse_after_permission_approval() {
 	return 0
 }
 
+_persist_signed_permission_grant() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+	local request_id="$4"
+	local request_json="$5"
+	local payload="$6"
+	local sig_file="$7"
+	local expires_at="$8"
+	local worker_session="${9:-}"
+	local comment_body
+	comment_body=$(_build_permission_grant_comment "$payload" "$sig_file")
+
+	if [[ "$target_type" == "issue" ]]; then
+		if ! gh_issue_comment "$target_number" --repo "$slug" --body "$comment_body"; then
+			rm -f "$sig_file"
+			_record_permission_grant_failure "grant_comment_write_failed" "$target_number" "$slug" \
+				"$request_id" "$worker_session" "Signed grant comment could not be persisted"
+			return 1
+		fi
+	elif ! gh_pr_comment "$target_number" --repo "$slug" --body "$comment_body"; then
+		rm -f "$sig_file"
+		_record_permission_grant_failure "grant_comment_write_failed" "$target_number" "$slug" \
+			"$request_id" "$worker_session" "Signed grant comment could not be persisted"
+		return 1
+	fi
+
+	if ! _permission_request_is_latest "$request_json" "$target_number" "$slug"; then
+		rm -f "$sig_file"
+		_record_permission_approval_rejection "request_superseded_after_signing" "$target_number" "$slug" \
+			"$request_id" "$worker_session" "Permission request changed after the signed grant comment was posted"
+		_print_error "Permission grant was posted, but the request is no longer latest; dispatch remains blocked"
+		return 1
+	fi
+
+	if ! _write_local_permission_grant "$payload" "$sig_file" "$slug" "$target_number"; then
+		rm -f "$sig_file"
+		_record_permission_grant_failure "grant_file_write_failed" "$target_number" "$slug" \
+			"$request_id" "$worker_session" "Local signed grant file could not be persisted"
+		return 1
+	fi
+	rm -f "$sig_file"
+
+	if ! _apply_permission_approval_state "$target_type" "$target_number" "$slug" "$request_json"; then
+		_record_permission_grant_failure "approval_state_update_failed" "$target_number" "$slug" \
+			"$request_id" "$worker_session" "Permission grant exists but the blocking issue state could not be cleared"
+		return 1
+	fi
+
+	_record_permission_blocker_event "permission_grant_approved" "resuming" \
+		"scoped_permission_granted" "false" "$target_number" "$slug" "$request_id" \
+		"$worker_session" "Signed permission grant persisted and dispatch block cleared"
+	_kick_pulse_after_permission_approval
+	_print_ok "Scoped permissions ${request_id} approved for ${target_type} #${target_number} until ${expires_at}"
+	return 0
+}
+
 cmd_permissions() {
 	local target_type="${1:-}"
 	local target_number="${2:-}"
@@ -1160,21 +1313,27 @@ cmd_permissions() {
 	_require_gh_auth || return 1
 	slug=$(_resolve_slug_or_fail "$slug" "$usage") || return 1
 	_validate_approval_target_kind "$target_type" "$target_number" "$slug" || return 1
-	local request_json
+	local request_json worker_session
 	request_json=$(_fetch_permission_request_json "$target_number" "$slug" "$request_id") || {
 		_print_error "Could not find permission request ${request_id} on ${target_type} #${target_number}"
 		return 1
 	}
+	worker_session=$(_permission_request_session "$request_json")
 	_validate_permission_request_json "$request_json" "$target_type" "$target_number" "$slug" "$request_id" || {
+		_record_permission_approval_rejection "request_invalid_or_non_grantable" "$target_number" "$slug" "$request_id" "" \
+			"Permission request was malformed, changed, or contained non-grantable scope"
 		_print_error "Permission request is malformed, changed, or contains a non-grantable sensitive capability"
 		return 1
 	}
 	_confirm_permission_approval "$request_json" "$target_type" "$target_number" "$slug" || return 1
 	_permission_request_is_latest "$request_json" "$target_number" "$slug" || {
+		_record_permission_approval_rejection "request_superseded" "$target_number" "$slug" "$request_id" \
+			"$worker_session" \
+			"A newer permission request superseded the request under review"
 		_print_error "A newer permission request appeared while approval was pending; review and approve the latest request instead"
 		return 1
 	}
-	local issued_at expires_at payload sig_file comment_body
+	local issued_at expires_at payload sig_file
 	issued_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	expires_at=$(_permission_grant_expiry)
 	payload=$(jq -cS --arg schema "$PERMISSION_GRANT_SCHEMA" --arg issued "$issued_at" --arg expires "$expires_at" '
@@ -1189,26 +1348,21 @@ cmd_permissions() {
 			issued_at: $issued,
 			expires_at: $expires
 		}
-	' <<<"$request_json") || return 1
-	sig_file=$(mktemp)
-	_sign_approval_payload "$payload" "$actual_key" "$sig_file" || { rm -f "$sig_file"; return 1; }
-	comment_body=$(_build_permission_grant_comment "$payload" "$sig_file")
-	if [[ "$target_type" == "issue" ]]; then
-		gh_issue_comment "$target_number" --repo "$slug" --body "$comment_body" || { rm -f "$sig_file"; return 1; }
-	else
-		gh_pr_comment "$target_number" --repo "$slug" --body "$comment_body" || { rm -f "$sig_file"; return 1; }
-	fi
-	_permission_request_is_latest "$request_json" "$target_number" "$slug" || {
-		rm -f "$sig_file"
-		_print_error "Permission grant was posted, but the request is no longer latest; dispatch remains blocked"
+	' <<<"$request_json") || {
+		_record_permission_grant_failure "grant_payload_build_failed" "$target_number" "$slug" "$request_id" \
+			"$worker_session" "Signed grant payload could not be built"
 		return 1
 	}
-	_write_local_permission_grant "$payload" "$sig_file" "$slug" "$target_number" || { rm -f "$sig_file"; return 1; }
-	rm -f "$sig_file"
-	_apply_permission_approval_state "$target_type" "$target_number" "$slug" "$request_json" || return 1
-	_kick_pulse_after_permission_approval
-	_print_ok "Scoped permissions ${request_id} approved for ${target_type} #${target_number} until ${expires_at}"
-	return 0
+	sig_file=$(mktemp)
+	if ! _sign_approval_payload "$payload" "$actual_key" "$sig_file"; then
+		rm -f "$sig_file"
+		_record_permission_grant_failure "grant_signing_failed" "$target_number" "$slug" "$request_id" \
+			"$worker_session" "Signed grant payload could not be signed"
+		return 1
+	fi
+	_persist_signed_permission_grant "$target_type" "$target_number" "$slug" "$request_id" \
+		"$request_json" "$payload" "$sig_file" "$expires_at" "$worker_session"
+	return $?
 }
 
 _create_allowed_signers_file() {

--- a/.agents/scripts/commands/pulse-check.md
+++ b/.agents/scripts/commands/pulse-check.md
@@ -30,7 +30,14 @@ from canonical current-state evidence, not process snapshots or log mtimes.
    ~/.aidevops/agents/scripts/pulse-check-helper.sh json $ARGUMENTS
    ```
 
-3. If the user explicitly asks to file self-improvement work, or this is the
+3. If the report identifies a specific issue whose worker stopped progressing,
+   inspect its bounded blocker lifecycle before opening raw logs:
+
+   ```bash
+   ~/.aidevops/agents/scripts/pulse-diagnose-helper.sh issue <N> --repo <owner/repo>
+   ```
+
+4. If the user explicitly asks to file self-improvement work, or this is the
    scheduled daily routine, use deduplicated apply mode:
 
    ```bash

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -41,6 +41,7 @@ _HRW_REASON_DRAFT_ESCALATION_FAILED="worker_draft_checkpoint_escalation_failed"
 _HRW_REASON_CLOSED_UNMERGED="worker_closed_unmerged_pr"
 _HRW_EVENT_FAILED="worker.failed"
 _HRW_NMR_LABEL="needs-maintainer-review"
+_HRW_PERMISSION_PERSISTENCE_FAILED="permission_request_persistence_failed"
 _HRW_SPOTLIGHT_MARKER=".metadata_never_index"
 _HRW_RECOVERY_CLASSIFICATION=""
 
@@ -1398,13 +1399,31 @@ _hrw_finish_rate_limit_fast_run() {
 	return 0
 }
 
+_hrw_record_permission_blocker_failure() {
+	local session_key="$1"
+	local reason="$2"
+	local logger="${SCRIPT_DIR}/worker-blocker-log.mjs"
+	[[ -f "$logger" ]] || return 0
+	command -v node >/dev/null 2>&1 || return 0
+	node "$logger" append \
+		--event "$_HRW_PERMISSION_PERSISTENCE_FAILED" \
+		--status "blocked" \
+		--reason "$reason" \
+		--blocking "true" \
+		--source "headless-runtime-worker" \
+		--session-key "$session_key" \
+		--detail "Worker could not persist the maintainer permission handoff" >/dev/null 2>&1 || true
+	return 0
+}
+
 _hrw_finish_permission_required_run() {
 	local session_key="$1"
 	local work_dir="$2"
 	local helper="${SCRIPT_DIR}/worker-permission-helper.sh"
 	local permission_status="permission_required"
 	if [[ ! -x "$helper" || -z "${_run_permission_request_file:-}" ]]; then
-		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "permission_request_persistence_failed"
+		_hrw_record_permission_blocker_failure "$session_key" "permission_capture_or_helper_unavailable"
+		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_PERMISSION_PERSISTENCE_FAILED"
 		return 1
 	fi
 	if ! "$helper" request \
@@ -1413,7 +1432,8 @@ _hrw_finish_permission_required_run() {
 		--repo "${DISPATCH_REPO_SLUG:-${WORKER_REPO_SLUG:-}}" \
 		--session "$session_key" \
 		--work-dir "$work_dir"; then
-		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "permission_request_persistence_failed"
+		_hrw_record_permission_blocker_failure "$session_key" "permission_handoff_failed"
+		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_PERMISSION_PERSISTENCE_FAILED"
 		return 1
 	fi
 	_release_dispatch_claim "$session_key" "$permission_status"

--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -21,6 +21,7 @@
 #   PULSE_DIAGNOSE_METRICS_FILE — override headless-runtime-metrics.jsonl path
 #   PULSE_DIAGNOSE_STATS_FILE   — override pulse-stats.json path
 #   PULSE_DIAGNOSE_GH_API_LOG   — override gh-api-calls.log path
+#   PULSE_DIAGNOSE_BLOCKER_LOG  — override worker-progress-blockers.jsonl path
 #   PULSE_DIAGNOSE_SYSTEMD_TIMER_FILE — override systemd timer unit path
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
@@ -49,6 +50,7 @@ readonly DEFAULT_LOGDIR="${HOME}/.aidevops/logs"
 readonly DEFAULT_METRICS_FILE="${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl"
 readonly DEFAULT_STATS_FILE="${HOME}/.aidevops/logs/pulse-stats.json"
 readonly DEFAULT_GH_API_LOG="${HOME}/.aidevops/logs/gh-api-calls.log"
+readonly DEFAULT_BLOCKER_LOG="${HOME}/.aidevops/logs/worker-progress-blockers.jsonl"
 readonly DEFAULT_SYSTEMD_TIMER_FILE="${HOME}/.config/systemd/user/aidevops-supervisor-pulse.timer"
 readonly _UNKNOWN="unknown"
 
@@ -197,6 +199,15 @@ _resolve_gh_api_log() {
 		return 0
 	fi
 	echo "$DEFAULT_GH_API_LOG"
+	return 0
+}
+
+_resolve_blocker_log() {
+	if [[ -n "${PULSE_DIAGNOSE_BLOCKER_LOG:-}" ]]; then
+		printf '%s\n' "$PULSE_DIAGNOSE_BLOCKER_LOG"
+		return 0
+	fi
+	printf '%s\n' "$DEFAULT_BLOCKER_LOG"
 	return 0
 }
 
@@ -353,6 +364,36 @@ _issue_attempt_summary_json() {
 		--argjson active "$active" \
 		'. + {cooldown_secs: $cooldown, next_eligible_epoch: $next, backoff_active: $active}' \
 		2>/dev/null || printf '%s\n' "$summary"
+	return 0
+}
+
+# Summarise all retained progress-blocker events for one issue and repository.
+# Args: issue_number repo_slug blocker_log
+_issue_blocker_summary_json() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local blocker_log="$3"
+	if [[ ! -f "$blocker_log" ]] || ! command -v jq >/dev/null 2>&1; then
+		printf '{"event_total":0,"active_total":0,"event_counts":{},"reason_counts":{},"active_blockers":[],"recent_events":[]}'
+		return 0
+	fi
+	jq -Rsc --arg issue "$issue_number" --arg repo "$repo_slug" '
+		def identity:
+			if ((.session_key // "") | length) > 0 then .session_key else (.request_id // "unknown") end;
+		[split("\n")[] | fromjson?
+			| select(.schema == "aidevops-worker-blocker/v1")
+			| select(((.issue_number // "") | tostring) == $issue)
+			| select(((.repo_slug // "") | ascii_downcase) == ($repo | ascii_downcase))] as $events
+		| ($events | group_by(identity) | map(sort_by(.ts // 0) | last) | map(select(.blocking == true))) as $active
+		| {
+			event_total: ($events | length),
+			active_total: ($active | length),
+			event_counts: (reduce $events[] as $row ({}; .[$row.event // "unknown"] += 1)),
+			reason_counts: (reduce $events[] as $row ({}; .[$row.reason // "unknown"] += 1)),
+			active_blockers: ($active | sort_by(.ts // 0) | reverse | .[0:10]),
+			recent_events: ($events | sort_by(.ts // 0) | reverse | .[0:10])
+		}' "$blocker_log" 2>/dev/null || \
+		printf '{"event_total":0,"active_total":0,"event_counts":{},"reason_counts":{},"active_blockers":[],"recent_events":[]}'
 	return 0
 }
 
@@ -1484,12 +1525,46 @@ _render_issue_attempts_text() {
 	return 0
 }
 
+# Render bounded progress-blocker evidence for one issue.
+# Args: blocker_summary_json
+_render_issue_blockers_text() {
+	local blocker_summary_json="$1"
+	printf 'Worker progress blockers:\n'
+	if ! command -v jq >/dev/null 2>&1; then
+		printf '  (jq not available — cannot parse blocker records)\n\n'
+		return 0
+	fi
+	local event_total="0" active_total="0"
+	event_total=$(printf '%s' "$blocker_summary_json" | jq -r '.event_total // 0' 2>/dev/null || printf '0')
+	active_total=$(printf '%s' "$blocker_summary_json" | jq -r '.active_total // 0' 2>/dev/null || printf '0')
+	printf '  Retained events: %s\n' "$event_total"
+	printf '  Currently active: %s\n' "$active_total"
+	printf '  Reasons: %s\n' "$(printf '%s' "$blocker_summary_json" | jq -c '.reason_counts // {}' 2>/dev/null || printf '{}')"
+	local recent_lines=""
+	recent_lines=$(printf '%s' "$blocker_summary_json" | jq -r '
+		.recent_events[]?
+		| "  " + (.timestamp // ((.ts // 0) | tostring))
+		+ "  " + (.event // "unknown")
+		+ "  reason=" + (.reason // "unknown")
+		+ "  blocking=" + ((.blocking // false) | tostring)
+		+ "  source=" + (.source // "unknown")' 2>/dev/null || true)
+	if [[ -n "$recent_lines" ]]; then
+		printf '  Recent blocker lifecycle:\n%s\n' "$recent_lines"
+	else
+		printf '  (no blocker records found for this issue)\n'
+	fi
+	printf '\n'
+	return 0
+}
+
 # Render the human-readable issue correlation report.
-# Args: issue_number repo_slug issue_json comments_json pr_numbers logfile logdir verbose attempt_summary_json issue_log_lines
+# Args: issue_number repo_slug issue_json comments_json pr_numbers logfile logdir verbose attempt_summary_json issue_log_lines blocker_summary_json
 _render_issue_text() {
 	local issue_number="$1" repo_slug="$2" issue_json="$3" comments_json="$4"
 	local pr_numbers="$5" logfile="$6" logdir="$7" verbose="$8"
 	local attempt_summary_json="$9" issue_log_lines="${10:-}"
+	local blocker_summary_json="${11:-}"
+	[[ -n "$blocker_summary_json" ]] || blocker_summary_json='{}'
 
 	local title="" state="" created_at="" closed_at="" labels="" assignees=""
 	title=$(_jq_field "$issue_json" "$_IQ_TITLE" "")
@@ -1508,16 +1583,19 @@ _render_issue_text() {
 	printf '  Created: %s\n\n' "${created_at:-(unknown)}"
 
 	_render_issue_lifecycle_comments "$comments_json"
+	_render_issue_blockers_text "$blocker_summary_json"
 	_render_issue_attempts_text "$attempt_summary_json" "$issue_log_lines" "$verbose"
 	_render_issue_linked_prs "$repo_slug" "$pr_numbers" "$logfile" "$logdir" "$verbose"
 	return 0
 }
 
 # Render JSON issue correlation report.
-# Args: issue_number repo_slug issue_json comments_json pr_numbers logfile logdir attempt_summary_json issue_log_lines
+# Args: issue_number repo_slug issue_json comments_json pr_numbers logfile logdir attempt_summary_json issue_log_lines blocker_summary_json
 _render_issue_json() {
 	local issue_number="$1" repo_slug="$2" issue_json="$3" comments_json="$4"
 	local pr_numbers="$5" logfile="$6" logdir="$7" attempt_summary_json="$8" issue_log_lines="${9:-}"
+	local blocker_summary_json="${10:-}"
+	[[ -n "$blocker_summary_json" ]] || blocker_summary_json='{}'
 
 	local title="" state="" created_at=""
 	title=$(_jq_field "$issue_json" "$_IQ_TITLE" "")
@@ -1567,6 +1645,9 @@ _render_issue_json() {
 	else
 		printf '{}'
 	fi
+	printf ',\n'
+	printf '  "progress_blockers": '
+	printf '%s' "$blocker_summary_json" | jq -c '.' 2>/dev/null || printf '{}'
 	printf ',\n'
 
 	printf '  "linked_prs": [\n'
@@ -2085,23 +2166,26 @@ cmd_issue() {
 	local metrics_file=""
 	metrics_file=$(_resolve_metrics_file)
 
-	local issue_json="" comments_json="" pr_numbers="" attempt_summary_json="" issue_log_lines=""
+	local issue_json="" comments_json="" pr_numbers="" attempt_summary_json="" issue_log_lines="" blocker_summary_json=""
+	local blocker_log=""
+	blocker_log=$(_resolve_blocker_log)
 	issue_json=$(_fetch_issue_metadata "$_CMD_ISSUE_NUMBER" "$_CMD_ISSUE_REPO_SLUG")
 	comments_json=$(_fetch_issue_comments "$_CMD_ISSUE_NUMBER" "$_CMD_ISSUE_REPO_SLUG")
 	pr_numbers=$(_fetch_issue_linked_prs "$_CMD_ISSUE_NUMBER" "$_CMD_ISSUE_REPO_SLUG")
 	attempt_summary_json=$(_issue_attempt_summary_json "$_CMD_ISSUE_NUMBER" "$metrics_file" "$_CMD_ISSUE_REPO_SLUG")
 	issue_log_lines=$(_collect_issue_log_lines "$_CMD_ISSUE_NUMBER" "$logfile" "$logdir")
+	blocker_summary_json=$(_issue_blocker_summary_json "$_CMD_ISSUE_NUMBER" "$_CMD_ISSUE_REPO_SLUG" "$blocker_log")
 
 	if [[ "$_CMD_ISSUE_JSON_OUTPUT" -eq 1 ]]; then
 		_render_issue_json "$_CMD_ISSUE_NUMBER" "$_CMD_ISSUE_REPO_SLUG" \
 			"$issue_json" "$comments_json" "$pr_numbers" "$logfile" "$logdir" \
-			"$attempt_summary_json" "$issue_log_lines"
+			"$attempt_summary_json" "$issue_log_lines" "$blocker_summary_json"
 		return 0
 	fi
 
 	_render_issue_text "$_CMD_ISSUE_NUMBER" "$_CMD_ISSUE_REPO_SLUG" \
 		"$issue_json" "$comments_json" "$pr_numbers" "$logfile" "$logdir" \
-		"$_CMD_ISSUE_VERBOSE" "$attempt_summary_json" "$issue_log_lines"
+		"$_CMD_ISSUE_VERBOSE" "$attempt_summary_json" "$issue_log_lines" "$blocker_summary_json"
 	return 0
 }
 
@@ -2142,6 +2226,7 @@ ENVIRONMENT:
   PULSE_DIAGNOSE_WRAPPER_LOG    Override pulse-wrapper.log path
   PULSE_DIAGNOSE_STATS_FILE     Override pulse-stats.json path
   PULSE_DIAGNOSE_GH_API_LOG     Override gh-api-calls.log path
+  PULSE_DIAGNOSE_BLOCKER_LOG    Override worker-progress-blockers.jsonl path
   PULSE_DIAGNOSE_SYSTEMD_TIMER_FILE Override systemd timer unit path
 
 EXAMPLES:

--- a/.agents/scripts/tests/test-permission-approval-content-binding.sh
+++ b/.agents/scripts/tests/test-permission-approval-content-binding.sh
@@ -10,7 +10,9 @@ source "${SCRIPT_DIR}/approval-helper.sh"
 
 request_file=$(mktemp)
 edit_log=$(mktemp)
-trap 'rm -f "$request_file" "${request_file}.unsafe" "$edit_log"' EXIT
+failure_home=$(mktemp -d)
+failure_sig=$(mktemp)
+trap 'rm -f "$request_file" "${request_file}.unsafe" "$edit_log" "$failure_sig"; rm -rf "$failure_home"' EXIT
 
 jq -cnS '{
   schema: "aidevops-permission-request/v1",
@@ -99,5 +101,30 @@ edit_args=$(<"$edit_log")
 [[ "$edit_args" != *"--remove-label status:blocked"* ]]
 [[ "$edit_args" != *"--add-label status:available"* ]]
 [[ "$edit_args" != *"--add-label auto-dispatch"* ]]
+
+original_approval_home="$_APPROVAL_HOME"
+_APPROVAL_HOME="$failure_home"
+printf '%s\n' 'fixture-signature' >"$failure_sig"
+install() {
+	return 1
+}
+if _write_local_permission_grant '{}' "$failure_sig" owner/repo 123; then
+	printf 'grant persistence unexpectedly succeeded after install failure\n' >&2
+	exit 1
+fi
+unset -f install
+[[ ! -e "$failure_home/.aidevops/permission-grants/owner_repo/123.json" ]]
+
+if (
+	_set_permission_grant_owner() {
+		return 1
+	}
+	_write_local_permission_grant '{}' "$failure_sig" owner/repo 123
+); then
+	printf 'grant persistence unexpectedly succeeded after ownership failure\n' >&2
+	exit 1
+fi
+[[ ! -e "$failure_home/.aidevops/permission-grants/owner_repo/123.json" ]]
+_APPROVAL_HOME="$original_approval_home"
 
 printf 'permission approval content-binding tests passed\n'

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -85,6 +85,8 @@ FIXTURE_GH_API_LOG="${TMPDIR_TEST}/gh-api-calls.log"
 FIXTURE_TIMER="${TMPDIR_TEST}/aidevops-supervisor-pulse.timer"
 FIXTURE_GH_COOLDOWN="${TMPDIR_TEST}/gh-secondary-cooldown.json"
 FIXTURE_GH_COOLDOWN_EVENTS="${TMPDIR_TEST}/gh-cooldown-events.jsonl"
+FIXTURE_BLOCKERS="${TMPDIR_TEST}/worker-progress-blockers.jsonl"
+export PULSE_DIAGNOSE_BLOCKER_LOG="$FIXTURE_BLOCKERS"
 
 # Create fixture pulse.log with 3+ distinct rule outcomes:
 # 1. PR #20329: escalated by dirty-pr-sweep (notify), then admin-bypass merge
@@ -108,6 +110,13 @@ cat > "$FIXTURE_LOGFILE" <<'FIXTURE'
 2026-04-21T19:30:00Z [pulse-dirty-pr-sweep] sweep complete: rebased=1 closed=0 notified=2
 2026-04-21T20:00:00Z [pulse-wrapper] Deterministic merge pass complete: merged=3, closed_conflicting=0, failed=0
 FIXTURE
+
+cat >"$FIXTURE_BLOCKERS" <<'BLOCKERS'
+{"schema":"aidevops-worker-blocker/v1","ts":100,"timestamp":"2026-04-27T09:00:00Z","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"opencode-permission-broker","issue_number":21860,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21860","request_id":"perm-source"}
+{"schema":"aidevops-worker-blocker/v1","ts":110,"timestamp":"2026-04-27T09:01:00Z","event":"permission_grant_applied","status":"resuming","reason":"scoped_permission_granted","blocking":false,"source":"opencode-config-hook","issue_number":21860,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21860","request_id":"perm-envelope"}
+{"schema":"aidevops-worker-blocker/v1","ts":120,"timestamp":"2026-04-27T09:02:00Z","event":"permission_request_non_grantable","status":"blocked","reason":"permission_non_grantable","blocking":true,"source":"opencode-permission-broker","issue_number":21860,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21860-retry","request_id":"perm-sensitive"}
+malformed-row
+BLOCKERS
 
 cat > "$FIXTURE_TIMER" <<'TIMER'
 [Unit]
@@ -427,6 +436,9 @@ assert_contains "shows issue number" "Issue #21860" "$output"
 assert_contains "shows issue title" "worker re-dispatch" "$output"
 assert_contains "shows issue labels" "auto-dispatch" "$output"
 assert_contains "shows lifecycle comments section" "Lifecycle comments:" "$output"
+assert_contains "shows worker progress blockers section" "Worker progress blockers:" "$output"
+assert_contains "shows current blocker count" "Currently active: 1" "$output"
+assert_contains "shows non-grantable blocker reason" "permission_non_grantable" "$output"
 assert_contains "shows WORKER_BRANCH_ORPHAN comment" "WORKER_BRANCH_ORPHAN" "$output"
 assert_contains "shows repeated attempts section" "Repeated attempts / dispatch backoff:" "$output"
 assert_contains "shows metric attempt count" "Attempts in metrics: 3" "$output"
@@ -502,6 +514,10 @@ if command -v jq >/dev/null 2>&1; then
 		FAIL=$((FAIL + 1))
 		printf '  ✗ JSON repeated_attempts dispatch_log_events has ≥1 entry (got %s)\n' "$json_dispatch_events"
 	fi
+	json_blocker_events=$(echo "$output" | jq '.progress_blockers.event_total' 2>/dev/null || echo 0)
+	assert_eq "JSON progress_blockers event_total" "3" "$json_blocker_events"
+	json_active_blockers=$(echo "$output" | jq '.progress_blockers.active_total' 2>/dev/null || echo 0)
+	assert_eq "JSON progress_blockers active_total" "1" "$json_active_blockers"
 fi
 
 # --- Test 17: issue --verbose shows raw log lines ---

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -79,6 +79,7 @@ METRICS="$FIXTURE_DIR/headless-runtime-metrics.jsonl"
 STATS="$FIXTURE_DIR/pulse-stats.json"
 PR_CACHE="$FIXTURE_DIR/pr-cache.json"
 OAUTH_POOL="$FIXTURE_DIR/oauth-pool.json"
+BLOCKERS="$FIXTURE_DIR/worker-progress-blockers.jsonl"
 
 cleanup() {
 	rm -rf "$FIXTURE_DIR"
@@ -146,6 +147,15 @@ T_FUTURE_SENTINEL_MS=$((T_FUTURE_SENTINEL * 1000))
 	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-c","session_key":"issue-18","result":"provider_error","exit_code":2}\n' "$((T_2H_AGO + 1))"
 } >"$METRICS"
 
+{
+	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"recent","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"test","issue_number":20,"repo_slug":"marcusquinn/aidevops","session_key":"issue-20","request_id":"perm-source"}\n' "$T_2H_AGO"
+	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"recent","event":"permission_grant_applied","status":"resuming","reason":"scoped_permission_granted","blocking":false,"source":"test","issue_number":20,"repo_slug":"marcusquinn/aidevops","session_key":"issue-20","request_id":"perm-envelope"}\n' "$T_5MIN_AGO"
+	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"recent","event":"permission_request_non_grantable","status":"blocked","reason":"permission_non_grantable","blocking":true,"source":"test","issue_number":21,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21","request_id":"perm-sensitive"}\n' "$T_5MIN_AGO"
+	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"permission_awaiting_approval","status":"blocked","reason":"needs_maintainer_permissions","blocking":true,"source":"test","issue_number":22,"repo_slug":"marcusquinn/aidevops","session_key":"issue-22","request_id":"perm-old"}\n' "$T_25H_AGO"
+	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"future","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"test","issue_number":23,"repo_slug":"marcusquinn/aidevops","session_key":"issue-23","request_id":"perm-future"}\n' "$T_FUTURE_SENTINEL"
+	printf 'malformed-jsonl-row\n'
+} >"$BLOCKERS"
+
 cat >"$OAUTH_POOL" <<EOF
 {
   "openai": [
@@ -179,6 +189,7 @@ RUN_ENV=(
 	"WAH_PULSE_STATS_FILE=$STATS"
 	"WAH_PR_CACHE_FILE=$PR_CACHE"
 	"WAH_OAUTH_POOL_FILE=$OAUTH_POOL"
+	"WAH_BLOCKER_LOG_FILE=$BLOCKERS"
 	"PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER=24"
 )
 
@@ -296,6 +307,14 @@ assert_eq "2m: pr count is null when skipped" "null" \
 	"$(printf '%s' "$JSON" | jq -r '.worker_solved_issues.count')"
 assert_eq "2n: pr check_state = skipped" "skipped" \
 	"$(printf '%s' "$JSON" | jq -r '.worker_solved_issues.check_state')"
+assert_eq "2o: blocker events obey the 24h window" "3" \
+	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.event_total')"
+assert_eq "2p: unresolved old blocker remains active until cleared" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.active_total')"
+assert_eq "2q: grant event clears the earlier request for the same session" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.progress_blockers.active_blockers[] | select(.session_key == "issue-20")] | length')"
+assert_eq "2r: malformed blocker rows fail open" "1" \
+	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.reason_counts.permission_non_grantable')"
 
 # ---------------------------------------------------------------------------
 # Section 3: 1h window narrows correctly.
@@ -315,6 +334,8 @@ assert_eq "3d: 1h watchdog_killed = 0" "0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
 assert_eq "3e: 1h recent examples exclude future sentinel" "0" \
 	"$(printf '%s' "$JSON" | jq -r '[.metrics.recent_examples[] | select(.session_key == "issue-9")] | length')"
+assert_eq "3f: 1h blocker event total is bounded" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.event_total')"
 
 # ---------------------------------------------------------------------------
 # Section 4: missing files fail-open to zeros.
@@ -326,12 +347,15 @@ JSON=$(env \
 	"WAH_METRICS_FILE=/nonexistent/metrics.jsonl" \
 	"WAH_PULSE_STATS_FILE=/nonexistent/stats.json" \
 	"WAH_PR_CACHE_FILE=$PR_CACHE" \
+	"WAH_BLOCKER_LOG_FILE=/nonexistent/blockers.jsonl" \
 	"$HELPER" summary --since 24h --no-pr-check --json 2>&1)
 RC=$?
 assert_rc "4a: missing files exits 0 (fail-open)" 0 "$RC"
 assert_eq "4b: missing metrics → total=0" "0" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
 assert_eq "4c: missing stats → counter=0" "0" \
 	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.pulse_dispatch_circuit_broken')"
+assert_eq "4d: missing blocker log → active=0" "0" \
+	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.active_total')"
 
 # ---------------------------------------------------------------------------
 # Section 5: human-output legibility.
@@ -353,6 +377,8 @@ assert_contains "5f: human output shows timing summary" "Timing ms" "$OUT"
 assert_contains "5g: human output shows failure groups" "Failure groups" "$OUT"
 assert_contains "5h: human output shows diagnostic focus" "Diagnostic focus" "$OUT"
 assert_contains "5i: human output shows failure families" "Failure families" "$OUT"
+assert_contains "5j: human output shows bounded blocker evidence" "worker-progress-blockers.jsonl" "$OUT"
+assert_contains "5k: human output shows active blocker count" "Currently active:            2" "$OUT"
 
 # ---------------------------------------------------------------------------
 # Section 6: provider/account diagnostics expose redacted capacity slots.

--- a/.agents/scripts/tests/test-worker-permission-helper.sh
+++ b/.agents/scripts/tests/test-worker-permission-helper.sh
@@ -11,6 +11,7 @@ source "${SCRIPT_DIR}/worker-permission-helper.sh"
 test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT
 capture_file="${test_root}/capture.json"
+export AIDEVOPS_WORKER_BLOCKER_LOG_FILE="${test_root}/blockers.jsonl"
 
 cat >"$capture_file" <<'JSON'
 {
@@ -77,5 +78,7 @@ if [[ ! -f "${git_dir}/aidevops-permission-pending" ]]; then
 	printf 'permission pending marker was not written to the target repository git directory\n' >&2
 	exit 1
 fi
+jq -e 'select(.event == "permission_awaiting_approval" and .reason == "needs_maintainer_permissions" and .blocking == true)' \
+	"$AIDEVOPS_WORKER_BLOCKER_LOG_FILE" >/dev/null
 
 printf 'worker permission helper tests passed\n'

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -44,6 +44,7 @@ WAH_METRICS_FILE="${WAH_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-me
 WAH_PULSE_STATS_FILE="${WAH_PULSE_STATS_FILE:-${HOME}/.aidevops/logs/pulse-stats.json}"
 WAH_PR_CACHE_FILE="${WAH_PR_CACHE_FILE:-${HOME}/.aidevops/cache/worker-activity-prs.json}"
 WAH_OAUTH_POOL_FILE="${WAH_OAUTH_POOL_FILE:-${HOME}/.aidevops/oauth-pool.json}"
+WAH_BLOCKER_LOG_FILE="${WAH_BLOCKER_LOG_FILE:-${HOME}/.aidevops/logs/worker-progress-blockers.jsonl}"
 WAH_PR_CACHE_TTL="${WAH_PR_CACHE_TTL:-60}" # seconds
 WAH_SERVICE_INTERRUPTION_RESULT="service_interruption_continue"
 WAH_RESULT_WATCHDOG_STALL_KILLED="watchdog_stall_killed"
@@ -272,6 +273,45 @@ _wah_metric_details_json() {
 }
 
 #######################################
+# Summarise bounded worker progress-blocker events and current blocker state.
+# Event counts obey the requested window; current blockers use the latest
+# retained event for each repo/issue/session identity so older unresolved holds
+# remain visible until a later non-blocking event clears them.
+# Args: cutoff_epoch now_epoch optional_repo_slug
+#######################################
+_wah_blocker_details_json() {
+	local cutoff_epoch="$1"
+	local now_epoch="$2"
+	local repo_slug="${3:-}"
+	local blocker_log="$WAH_BLOCKER_LOG_FILE"
+	if [[ ! -f "$blocker_log" ]]; then
+		printf '{"event_total":0,"active_total":0,"event_counts":{},"reason_counts":{},"active_blockers":[],"recent_blockers":[]}'
+		return 0
+	fi
+	jq -Rsc --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg repo "$repo_slug" '
+		def scoped:
+			select(.schema == "aidevops-worker-blocker/v1")
+			| select(($repo == "") or (((.repo_slug // "") | ascii_downcase) == ($repo | ascii_downcase)))
+			| select((.ts // 0) <= $now);
+		def identity:
+			(.repo_slug // "") + "|" + ((.issue_number // "") | tostring) + "|"
+			+ (if ((.session_key // "") | length) > 0 then .session_key else (.request_id // "unknown") end);
+		[split("\n")[] | fromjson? | scoped] as $all
+		| [$all[] | select((.ts // 0) >= $cutoff)] as $window
+		| ($all | group_by(identity) | map(sort_by(.ts // 0) | last) | map(select(.blocking == true))) as $active
+		| {
+			event_total: ($window | length),
+			active_total: ($active | length),
+			event_counts: (reduce $window[] as $row ({}; .[$row.event // "unknown"] += 1)),
+			reason_counts: (reduce $window[] as $row ({}; .[$row.reason // "unknown"] += 1)),
+			active_blockers: ($active | sort_by(.ts // 0) | reverse | .[0:10] | map({ts, timestamp, issue_number, repo_slug, session_key, request_id, event, reason, status, source, permission, tool, risk_level, grantable, detail})),
+			recent_blockers: ($window | sort_by(.ts // 0) | reverse | .[0:10] | map({ts, timestamp, issue_number, repo_slug, session_key, request_id, event, reason, status, blocking, source}))
+		}' "$blocker_log" 2>/dev/null || \
+		printf '{"event_total":0,"active_total":0,"event_counts":{},"reason_counts":{},"active_blockers":[],"recent_blockers":[]}'
+	return 0
+}
+
+#######################################
 # Emit bounded provider/model/account-pool usage from canonical metrics.
 # This is the narrow diagnostic path for recent worker provider questions; it
 # intentionally avoids recursive searches over logs or OpenCode storage.
@@ -439,6 +479,7 @@ _wah_emit_human() {
 	local cb="${11}" gqlow="${12}" db_skip="${13}" nwbreaker="${14}"
 	local solved_count="${15}" pr_check_state="${16}" repo_label="${17}"
 	local details_json="${18}"
+	local blocker_json="${19}"
 
 	local divider="==========================================================="
 
@@ -473,6 +514,12 @@ _wah_emit_human() {
 	printf '  Provider/model usage:        worker-activity-helper.sh providers --since %s\n' "$since_label"
 	printf '  Failure groups:             %s\n' "$(printf '%s' "$details_json" | jq -c '.failure_groups // []' 2>/dev/null || printf '[]')"
 	printf '  Failure families:           %s\n' "$(printf '%s' "$details_json" | jq -c '.failure_families // []' 2>/dev/null || printf '[]')"
+	printf '\n'
+	printf 'worker-progress-blockers.jsonl (bounded progress holds):\n'
+	printf '  Events in window:            %s\n' "$(printf '%s' "$blocker_json" | jq -r '.event_total // 0' 2>/dev/null || printf '0')"
+	printf '  Currently active:            %s\n' "$(printf '%s' "$blocker_json" | jq -r '.active_total // 0' 2>/dev/null || printf '0')"
+	printf '  Reasons:                     %s\n' "$(printf '%s' "$blocker_json" | jq -c '.reason_counts // {}' 2>/dev/null || printf '{}')"
+	printf '  Active blockers:             %s\n' "$(printf '%s' "$blocker_json" | jq -c '.active_blockers // []' 2>/dev/null || printf '[]')"
 	printf '\n'
 	printf 'pulse-stats.json (dispatch-side counters):\n'
 	printf '  pulse_dispatch_circuit_broken:           %d\n' "$cb"
@@ -534,6 +581,7 @@ _wah_emit_json() {
 	local cb="${12}" gqlow="${13}" db_skip="${14}" nwbreaker="${15}"
 	local solved_count="${16}" pr_check_state="${17}" repo_label="${18}"
 	local details_json="${19}"
+	local blocker_json="${20}"
 
 	# solved_count may be "?" on gh failure — coerce to null in JSON.
 	local solved_json="$solved_count"
@@ -557,6 +605,7 @@ _wah_emit_json() {
 		--argjson nwbreaker "$nwbreaker" \
 		--argjson solved_count "$solved_json" \
 		--argjson details "$details_json" \
+		--argjson blockers "$blocker_json" \
 		--arg pr_check_state "$pr_check_state" \
 		--arg repo "$repo_label" \
 		'{
@@ -587,6 +636,7 @@ _wah_emit_json() {
 				dispatch_backoff_skipped: $db_skip,
 				pulse_dispatch_no_work_breaker_tripped: $nwbreaker
 			},
+			progress_blockers: $blockers,
 			worker_solved_issues: { count: $solved_count, check_state: $pr_check_state },
 			worker_prs: { count: $solved_count, check_state: $pr_check_state, deprecated: true }
 		}'
@@ -647,10 +697,11 @@ cmd_summary() {
 		cutoff_iso="(unknown)"
 
 	# Aggregate metrics (single jq+awk pass).
-	local agg total terminal_total succ wk wc sic rl of details_json
+	local agg total terminal_total succ wk wc sic rl of details_json blocker_json
 	agg=$(_wah_aggregate_metrics "$cutoff_epoch" "$now_epoch")
 	read -r total terminal_total succ wk wc sic rl of <<<"$agg"
 	details_json=$(_wah_metric_details_json "$cutoff_epoch" "$now_epoch")
+	blocker_json=$(_wah_blocker_details_json "$cutoff_epoch" "$now_epoch" "$repo_label")
 
 	# Pulse-stats counters.
 	local cb gqlow db_skip nwbreaker
@@ -673,12 +724,12 @@ cmd_summary() {
 		_wah_emit_json "$since_label" "$cutoff_iso" "$cutoff_epoch" \
 			"$total" "$terminal_total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
-			"$pr_count" "$pr_check_state" "$repo_label" "$details_json"
+			"$pr_count" "$pr_check_state" "$repo_label" "$details_json" "$blocker_json"
 	else
 		_wah_emit_human "$since_label" "$cutoff_iso" \
 			"$total" "$terminal_total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
-			"$pr_count" "$pr_check_state" "$repo_label" "$details_json"
+			"$pr_count" "$pr_check_state" "$repo_label" "$details_json" "$blocker_json"
 	fi
 	return 0
 }
@@ -759,7 +810,8 @@ Options:
 Sources read (in canonical-precedence order):
   1. ~/.aidevops/logs/headless-runtime-metrics.jsonl  (worker outcomes)
   2. ~/.aidevops/logs/pulse-stats.json                (dispatch counters)
-  3. gh issue list label:solved:worker                (optional external truth)
+  3. ~/.aidevops/logs/worker-progress-blockers.jsonl  (bounded progress holds)
+  4. gh issue list label:solved:worker                (optional external truth)
 
 Examples:
   # Last 24 hours, human-readable.

--- a/.agents/scripts/worker-blocker-log.mjs
+++ b/.agents/scripts/worker-blocker-log.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fchmodSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const WORKER_BLOCKER_SCHEMA = "aidevops-worker-blocker/v1";
+export const DEFAULT_WORKER_BLOCKER_LOG_MAX_BYTES = 5 * 1024 * 1024;
+
+const MIN_LOG_MAX_BYTES = 512;
+const LOCK_STALE_MS = 30_000;
+const LOCK_RETRIES = 25;
+const LOCK_RETRY_MS = 4;
+const LOCK_RESTORE_RETRIES = 250;
+const MAX_DETAIL_LENGTH = 500;
+const MAX_FIELD_LENGTH = 200;
+const CREDENTIAL_PATTERN = /(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+
+function sleepSync(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function cleanText(value, maxLength, options = {}) {
+  if (value === null || value === undefined) return "";
+  const home = options.home || homedir();
+  const workDir = options.workDir || process.env.WORKER_WORKTREE_PATH || "";
+  let text = String(value)
+    .replace(CREDENTIAL_PATTERN, "$1[redacted-credential]")
+    .replace(/(authorization\s*:\s*bearer\s+)[^\s,;]+/gi, "$1[REDACTED]")
+    .replace(/((?:api[_-]?key|token|secret|password|authorization|credential)\s*[:=]\s*)[^\s,;]+/gi, "$1[REDACTED]")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .trim();
+  if (home && text.includes(home)) text = text.split(home).join("~");
+  if (workDir && text.includes(workDir)) text = text.split(workDir).join("$WORKTREE");
+  return text.slice(0, maxLength);
+}
+
+function cleanIssueNumber(value) {
+  const text = String(value ?? "");
+  if (!/^[0-9]+$/.test(text)) return null;
+  const parsed = Number(text);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function resolveLogPath(options = {}) {
+  return options.logPath
+    || process.env.AIDEVOPS_WORKER_BLOCKER_LOG_FILE
+    || resolve(homedir(), ".aidevops", "logs", "worker-progress-blockers.jsonl");
+}
+
+function resolveMaxBytes(options = {}) {
+  const raw = options.maxBytes ?? process.env.AIDEVOPS_WORKER_BLOCKER_LOG_MAX_BYTES;
+  const parsed = Number(raw || DEFAULT_WORKER_BLOCKER_LOG_MAX_BYTES);
+  if (!Number.isSafeInteger(parsed) || parsed < MIN_LOG_MAX_BYTES) {
+    return DEFAULT_WORKER_BLOCKER_LOG_MAX_BYTES;
+  }
+  return parsed;
+}
+
+export function normalizeWorkerBlockerEvent(input = {}, options = {}) {
+  const now = options.now instanceof Date ? options.now : new Date();
+  const issueNumber = cleanIssueNumber(input.issue_number ?? process.env.WORKER_ISSUE_NUMBER);
+  const grantable = typeof input.grantable === "boolean" ? input.grantable : null;
+  return {
+    schema: WORKER_BLOCKER_SCHEMA,
+    ts: Math.floor(now.getTime() / 1000),
+    timestamp: now.toISOString(),
+    event: cleanText(input.event || "worker_progress_blocked", MAX_FIELD_LENGTH, options),
+    status: cleanText(input.status || "blocked", 50, options),
+    reason: cleanText(input.reason || "unknown", MAX_FIELD_LENGTH, options),
+    blocking: input.blocking !== false,
+    source: cleanText(input.source || "unknown", MAX_FIELD_LENGTH, options),
+    issue_number: issueNumber,
+    repo_slug: cleanText(input.repo_slug || process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "", MAX_FIELD_LENGTH, options).toLowerCase(),
+    session_key: cleanText(input.session_key || process.env.WORKER_SESSION_KEY || "", MAX_FIELD_LENGTH, options),
+    request_id: cleanText(input.request_id || process.env.AIDEVOPS_PERMISSION_REQUEST_ID || "", MAX_FIELD_LENGTH, options),
+    permission: cleanText(input.permission || "", 100, options),
+    tool: cleanText(input.tool || "", 100, options),
+    risk_level: cleanText(input.risk_level || "", 20, options),
+    grantable,
+    detail: cleanText(input.detail || "", MAX_DETAIL_LENGTH, options),
+  };
+}
+
+function tryCreateOwnedLock(lockPath, token) {
+  let descriptor;
+  try {
+    descriptor = openSync(lockPath, "wx", 0o600);
+    writeFileSync(descriptor, token);
+    return "acquired";
+  } catch (error) {
+    if (descriptor !== undefined) {
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // The incomplete lock remains stale and can be reclaimed.
+      }
+    }
+    return error?.code === "EEXIST" ? "exists" : "failed";
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function releaseLock(lockPath, token) {
+  try {
+    if (readFileSync(lockPath, "utf8") !== token) return;
+    unlinkSync(lockPath);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+function removeStalePrimaryLock(lockPath) {
+  try {
+    const lockStat = lstatSync(lockPath);
+    if (lockStat.isSymbolicLink() || Date.now() - lockStat.mtimeMs <= LOCK_STALE_MS) return false;
+    unlinkSync(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function recoveryMarkersActive(lockPath) {
+  const directory = dirname(lockPath);
+  const prefix = `${basename(lockPath)}.quarantine-`;
+  let active = false;
+  try {
+    for (const name of readdirSync(directory)) {
+      if (!name.startsWith(prefix)) continue;
+      const markerPath = join(directory, name);
+      try {
+        const markerStat = lstatSync(markerPath);
+        if (markerStat.isSymbolicLink() || Date.now() - markerStat.mtimeMs > LOCK_STALE_MS) {
+          unlinkSync(markerPath);
+        } else {
+          active = true;
+        }
+      } catch {
+        // Another contender completed recovery first.
+      }
+    }
+  } catch {
+    return false;
+  }
+  return active;
+}
+
+function quarantineStaleLock(lockPath) {
+  let observedStat;
+  let observedToken;
+  try {
+    observedStat = lstatSync(lockPath);
+    if (observedStat.isSymbolicLink() || Date.now() - observedStat.mtimeMs <= LOCK_STALE_MS) return false;
+    observedToken = readFileSync(lockPath, "utf8");
+  } catch {
+    return false;
+  }
+
+  const quarantinePath = `${lockPath}.quarantine-${randomUUID()}`;
+  try {
+    renameSync(lockPath, quarantinePath);
+    const movedStat = lstatSync(quarantinePath);
+    const movedToken = readFileSync(quarantinePath, "utf8");
+    const exactStaleLock = !movedStat.isSymbolicLink()
+      && movedStat.dev === observedStat.dev
+      && movedStat.ino === observedStat.ino
+      && movedStat.mtimeMs === observedStat.mtimeMs
+      && movedToken === observedToken
+      && Date.now() - movedStat.mtimeMs > LOCK_STALE_MS;
+    if (exactStaleLock) {
+      unlinkSync(quarantinePath);
+      return true;
+    }
+    if (movedStat.isSymbolicLink()) {
+      unlinkSync(quarantinePath);
+      return false;
+    }
+    for (let attempt = 0; attempt < LOCK_RESTORE_RETRIES; attempt++) {
+      try {
+        linkSync(quarantinePath, lockPath);
+        unlinkSync(quarantinePath);
+        return false;
+      } catch (error) {
+        if (error?.code !== "EEXIST") return false;
+        sleepSync(LOCK_RETRY_MS);
+      }
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function acquireLock(lockPath) {
+  const token = randomUUID();
+  const reclaimPath = `${lockPath}.reclaim`;
+  for (let attempt = 0; attempt < LOCK_RETRIES; attempt++) {
+    try {
+      if (recoveryMarkersActive(reclaimPath)) {
+        sleepSync(LOCK_RETRY_MS);
+        continue;
+      }
+      if (existsSync(reclaimPath)) {
+        quarantineStaleLock(reclaimPath);
+        sleepSync(LOCK_RETRY_MS);
+        continue;
+      }
+      const lockResult = tryCreateOwnedLock(lockPath, token);
+      if (lockResult === "acquired") {
+        if (existsSync(reclaimPath) || recoveryMarkersActive(reclaimPath)) {
+          releaseLock(lockPath, token);
+          sleepSync(LOCK_RETRY_MS);
+          continue;
+        }
+        return token;
+      }
+      if (lockResult === "failed") return "";
+
+      const lockStat = lstatSync(lockPath);
+      if (lockStat.isSymbolicLink()) return "";
+      if (Date.now() - lockStat.mtimeMs <= LOCK_STALE_MS) {
+        sleepSync(LOCK_RETRY_MS);
+        continue;
+      }
+
+      const reclaimToken = randomUUID();
+      if (tryCreateOwnedLock(reclaimPath, reclaimToken) !== "acquired") {
+        sleepSync(LOCK_RETRY_MS);
+        continue;
+      }
+      if (recoveryMarkersActive(reclaimPath)) {
+        releaseLock(reclaimPath, reclaimToken);
+        sleepSync(LOCK_RETRY_MS);
+        continue;
+      }
+      try {
+        removeStalePrimaryLock(lockPath);
+        if (tryCreateOwnedLock(lockPath, token) === "acquired") return token;
+      } finally {
+        releaseLock(reclaimPath, reclaimToken);
+      }
+    } catch (error) {
+      if (error?.code !== "ENOENT") return "";
+      sleepSync(LOCK_RETRY_MS);
+    }
+  }
+  return "";
+}
+
+function newestCompleteLinesWithinBudget(content, budget) {
+  if (budget <= 0) return "";
+  const lines = content.toString("utf8").split("\n").filter(Boolean);
+  const kept = [];
+  let bytes = 0;
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const line = `${lines[index]}\n`;
+    const lineBytes = Buffer.byteLength(line);
+    if (lineBytes > budget - bytes) break;
+    kept.push(line);
+    bytes += lineBytes;
+  }
+  return kept.reverse().join("");
+}
+
+function trimBeforeAppend(logPath, incomingBytes, maxBytes) {
+  if (!existsSync(logPath)) return;
+  if (lstatSync(logPath).isSymbolicLink()) throw new Error("Refusing symlinked blocker log");
+  const currentSize = statSync(logPath).size;
+  if (currentSize + incomingBytes <= maxBytes) return;
+  const retained = newestCompleteLinesWithinBudget(readFileSync(logPath), maxBytes - incomingBytes);
+  const temporary = `${logPath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(temporary, retained, { mode: 0o600 });
+  renameSync(temporary, logPath);
+}
+
+export function appendWorkerBlockerEvent(input, options = {}) {
+  let lockPath = "";
+  let lockToken = "";
+  try {
+    const logPath = resolveLogPath(options);
+    const maxBytes = resolveMaxBytes(options);
+    const line = `${JSON.stringify(normalizeWorkerBlockerEvent(input, options))}\n`;
+    const incomingBytes = Buffer.byteLength(line);
+    if (incomingBytes > maxBytes) return false;
+
+    mkdirSync(dirname(logPath), { recursive: true, mode: 0o700 });
+    if (existsSync(logPath) && lstatSync(logPath).isSymbolicLink()) return false;
+    lockPath = `${logPath}.lock`;
+    lockToken = acquireLock(lockPath);
+    if (!lockToken) return false;
+    trimBeforeAppend(logPath, incomingBytes, maxBytes);
+    const descriptor = openSync(logPath, constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW, 0o600);
+    try {
+      writeFileSync(descriptor, line);
+      fchmodSync(descriptor, 0o600);
+    } finally {
+      closeSync(descriptor);
+    }
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (lockToken) {
+      try {
+        releaseLock(lockPath, lockToken);
+      } catch {
+        // Logging remains best effort and must never stop worker execution.
+      }
+    }
+  }
+}
+
+function parseCliArguments(argv) {
+  const event = {};
+  const options = {};
+  for (let index = 0; index < argv.length; index++) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === "--blocking") {
+      event.blocking = value !== "false";
+      index++;
+    } else if (flag === "--log-file") {
+      options.logPath = value;
+      index++;
+    } else if (flag === "--max-bytes") {
+      options.maxBytes = Number(value);
+      index++;
+    } else if (flag?.startsWith("--")) {
+      const key = flag.slice(2).replaceAll("-", "_");
+      event[key] = value ?? "";
+      index++;
+    }
+  }
+  return { event, options };
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command !== "append") return 2;
+  const { event, options } = parseCliArguments(args);
+  return appendWorkerBlockerEvent(event, options) ? 0 : 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = main();
+}

--- a/.agents/scripts/worker-permission-helper.sh
+++ b/.agents/scripts/worker-permission-helper.sh
@@ -10,6 +10,36 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 readonly PERMISSION_REQUEST_MARKER="<!-- aidevops-permission-request -->"
 readonly PERMISSION_REQUEST_SCHEMA="aidevops-permission-request/v1"
+readonly PERMISSION_BLOCKER_STATUS="blocked"
+readonly PERMISSION_BLOCKER_TRUE="true"
+readonly PERMISSION_PERSISTENCE_FAILED_EVENT="permission_request_persistence_failed"
+
+permission_record_blocker() {
+	local event="$1"
+	local status="$2"
+	local reason="$3"
+	local blocking="$4"
+	local issue_number="$5"
+	local repo_slug="$6"
+	local session_key="$7"
+	local request_id="${8:-}"
+	local detail="${9:-}"
+	local logger="${SCRIPT_DIR}/worker-blocker-log.mjs"
+	[[ -f "$logger" ]] || return 0
+	command -v node >/dev/null 2>&1 || return 0
+	node "$logger" append \
+		--event "$event" \
+		--status "$status" \
+		--reason "$reason" \
+		--blocking "$blocking" \
+		--source "worker-permission-helper" \
+		--issue-number "$issue_number" \
+		--repo-slug "$repo_slug" \
+		--session-key "$session_key" \
+		--request-id "$request_id" \
+		--detail "$detail" >/dev/null 2>&1 || true
+	return 0
+}
 
 permission_sha256() {
 	local source_file="$1"
@@ -246,16 +276,44 @@ cmd_request() {
 		esac
 	done
 	[[ -f "$capture_file" && "$issue_number" =~ ^[0-9]+$ && "$repo_slug" == */* ]] || return 1
-	permission_validate_capture "$capture_file" "$issue_number" "$repo_slug" || return 1
-	request_id=$(permission_post_request "$capture_file" "$issue_number" "$repo_slug" "$session_key" "$work_dir") || return 1
-	permission_apply_block "$issue_number" "$repo_slug" || return 1
+	if ! permission_validate_capture "$capture_file" "$issue_number" "$repo_slug"; then
+		permission_record_blocker "$PERMISSION_PERSISTENCE_FAILED_EVENT" "$PERMISSION_BLOCKER_STATUS" \
+			"capture_validation_failed" "$PERMISSION_BLOCKER_TRUE" "$issue_number" "$repo_slug" "$session_key" "" \
+			"Captured permission request failed validation"
+		return 1
+	fi
+	if ! request_id=$(permission_post_request "$capture_file" "$issue_number" "$repo_slug" "$session_key" "$work_dir"); then
+		permission_record_blocker "$PERMISSION_PERSISTENCE_FAILED_EVENT" "$PERMISSION_BLOCKER_STATUS" \
+			"github_request_comment_failed" "$PERMISSION_BLOCKER_TRUE" "$issue_number" "$repo_slug" "$session_key" "" \
+			"Maintainer permission request comment could not be persisted"
+		return 1
+	fi
+	if ! permission_apply_block "$issue_number" "$repo_slug"; then
+		permission_record_blocker "$PERMISSION_PERSISTENCE_FAILED_EVENT" "$PERMISSION_BLOCKER_STATUS" \
+			"github_block_label_failed" "$PERMISSION_BLOCKER_TRUE" "$issue_number" "$repo_slug" "$session_key" "$request_id" \
+			"Maintainer permission blocker label could not be persisted"
+		return 1
+	fi
 	if [[ -n "$work_dir" && -d "$work_dir" ]]; then
 		local git_dir="" pending_file=""
-		git_dir=$(git -C "$work_dir" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+		if ! git_dir=$(git -C "$work_dir" rev-parse --absolute-git-dir 2>/dev/null); then
+			permission_record_blocker "$PERMISSION_PERSISTENCE_FAILED_EVENT" "$PERMISSION_BLOCKER_STATUS" \
+				"git_directory_lookup_failed" "$PERMISSION_BLOCKER_TRUE" "$issue_number" "$repo_slug" "$session_key" "$request_id" \
+				"Permission pending marker location could not be resolved"
+			return 1
+		fi
 		pending_file="${git_dir}/aidevops-permission-pending"
-		jq -cn --arg request "$request_id" --arg issue "$issue_number" \
-			'{request_id: $request, issue: ($issue | tonumber)}' >"$pending_file"
+		if ! jq -cn --arg request "$request_id" --arg issue "$issue_number" \
+			'{request_id: $request, issue: ($issue | tonumber)}' >"$pending_file"; then
+			permission_record_blocker "$PERMISSION_PERSISTENCE_FAILED_EVENT" "$PERMISSION_BLOCKER_STATUS" \
+				"pending_marker_write_failed" "$PERMISSION_BLOCKER_TRUE" "$issue_number" "$repo_slug" "$session_key" "$request_id" \
+				"Permission pending marker could not be persisted"
+			return 1
+		fi
 	fi
+	permission_record_blocker "permission_awaiting_approval" "$PERMISSION_BLOCKER_STATUS" \
+		"needs_maintainer_permissions" "$PERMISSION_BLOCKER_TRUE" "$issue_number" "$repo_slug" "$session_key" "$request_id" \
+		"Worker paused until the exact scoped permission request is approved"
 	return 0
 }
 

--- a/TODO.md
+++ b/TODO.md
@@ -1155,6 +1155,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18122 Add cryptographically scoped worker permission grants ref:GH#27688
 
+- [ ] t18123 Add bounded worker progress blocker logging ref:GH#27732
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Add a bounded, redacted worker progress-blocker JSONL log; record permission and approval lifecycle failures; expose active blockers in worker activity and pulse diagnostics; harden concurrent writes, stale-lock recovery, symlink handling, and root-invoked ownership.

## Files Changed

.agents/plugins/opencode-aidevops/config-hook.mjs, .agents/plugins/opencode-aidevops/permission-broker.mjs, .agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs, .agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs, .agents/plugins/opencode-aidevops/tests/test-worker-permission-grant.mjs, .agents/reference/dispatch-blockers.md, .agents/reference/observability.md, .agents/reference/worker-diagnostics.md, .agents/scripts/approval-helper.sh, .agents/scripts/commands/pulse-check.md, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/pulse-diagnose-helper.sh, .agents/scripts/tests/test-permission-approval-content-binding.sh, .agents/scripts/tests/test-pulse-diagnose-helper.sh, .agents/scripts/tests/test-worker-activity-helper.sh, .agents/scripts/tests/test-worker-permission-helper.sh, .agents/scripts/worker-activity-helper.sh, .agents/scripts/worker-blocker-log.mjs, .agents/scripts/worker-permission-helper.sh, TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Runtime-verified: OpenCode plugin suite 396/396; blocker concurrency/recovery tests; worker-activity 81/81; pulse-diagnose 94/94; approval and permission helper suites; local lint, ShellCheck, Secretlint, complexity ratchets, and git diff --check.

Resolves #27732


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 7h 49m and 1,520,028 tokens on this with the user in an interactive session.