### PR TITLE
GH#27729: fix: quote review bot suffix portably

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -450,7 +450,7 @@ is_known_review_bot() {
 	local actor="$1"
 	local known_bot=""
 	actor=$(printf '%s' "$actor" | tr '[:upper:]' '[:lower:]')
-	actor="${actor%\[bot\]}"
+	actor="${actor%"[bot]"}"
 
 	for known_bot in "${KNOWN_BOTS[@]}"; do
 		[[ "$actor" == "$known_bot" ]] && return 0


### PR DESCRIPTION
## Summary

Use a quoted literal suffix pattern when normalizing GitHub bot logins so review event checks remain portable to Bash 3.2.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh; shellcheck .agents/scripts/review-bot-gate-helper.sh

Resolves #27729


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 87,674 tokens on this as a headless worker.