### PR TITLE
GH#27726: prevent stale workflow sync and no-diff PRs

### DIFF
--- a/.agents/reference/reusable-workflows.md
+++ b/.agents/reference/reusable-workflows.md
@@ -132,6 +132,17 @@ These are the canonical drift tools for managed downstream repos. Use
 `check-workflows` when auditing, and `sync-workflows --apply` when you are ready
 to update caller YAMLs to the current framework template/pin.
 
+`check-workflows` is a read-only audit of each registered local checkout. JSON
+rows include an `evidence` object with the local branch, known upstream,
+ahead/behind counts, and freshness state. Human output warns when a checkout is
+behind or diverged, so local drift is not mistaken for current remote evidence.
+The command does not fetch implicitly.
+
+Apply mode validates a clean default-branch checkout, fast-forwards it, and
+reclassifies that refreshed snapshot before rendering or writing. If refresh
+makes the workflow current, or rendering produces no diff, the operation exits
+successfully without pushing a sync branch or opening a PR.
+
 See also [`auto-dispatch.md`](auto-dispatch.md) for the `SYNC_PAT` requirement (unchanged under the reusable pattern — still per-repo secret).
 
 ## Runner override (GH#21877)

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -453,6 +453,63 @@ _iterate_repos() {
 	return 0
 }
 
+# _repo_freshness <repo-path>
+# Emits: source\tbranch\tupstream\tahead\tbehind\tstate
+# Uses only existing refs: check-workflows remains a read-only, no-network audit.
+_repo_freshness() {
+	local _path="$1"
+	if ! git -C "$_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		printf 'local\tunknown\tunknown\tunknown\tunknown\tunknown\n'
+		return 0
+	fi
+
+	local _branch
+	_branch=$(git -C "$_path" symbolic-ref --short HEAD 2>/dev/null || printf 'DETACHED')
+	local _upstream
+	_upstream=$(git -C "$_path" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
+	if [[ -z "$_upstream" ]]; then
+		printf 'local\t%s\tunknown\tunknown\tunknown\tuntracked\n' "$_branch"
+		return 0
+	fi
+
+	local _ahead _behind
+	if ! read -r _ahead _behind < <(git -C "$_path" rev-list --left-right --count "HEAD...${_upstream}" 2>/dev/null); then
+		printf 'local\t%s\t%s\tunknown\tunknown\tunknown\n' "$_branch" "$_upstream"
+		return 0
+	fi
+
+	local _state="current"
+	if ((_ahead > 0 && _behind > 0)); then
+		_state="diverged"
+	elif ((_behind > 0)); then
+		_state="behind"
+	elif ((_ahead > 0)); then
+		_state="ahead"
+	fi
+	printf 'local\t%s\t%s\t%s\t%s\t%s\n' \
+		"$_branch" "$_upstream" "$_ahead" "$_behind" "$_state"
+	return 0
+}
+
+# _freshness_note <branch> <upstream> <ahead> <behind> <state>
+_freshness_note() {
+	local _branch="$1"
+	local _upstream="$2"
+	local _ahead="$3"
+	local _behind="$4"
+	local _state="$5"
+	case "$_state" in
+	behind)
+		printf 'local evidence; %s is %s commit(s) behind %s' "$_branch" "$_behind" "$_upstream"
+		;;
+	diverged)
+		printf 'local evidence; %s is %s ahead and %s behind %s' \
+			"$_branch" "$_ahead" "$_behind" "$_upstream"
+		;;
+	esac
+	return 0
+}
+
 # ─── Output formats ─────────────────────────────────────────────────────────
 
 # _render_row_human <slug> <path> <classification> <note> [<workflow>]
@@ -495,6 +552,12 @@ _render_row_json() {
 	local _class="$3"
 	local _note="${4:-}"
 	local _workflow="${5:-}"
+	local _evidence_source="${6:-local}"
+	local _branch="${7:-unknown}"
+	local _upstream="${8:-unknown}"
+	local _ahead="${9:-unknown}"
+	local _behind="${10:-unknown}"
+	local _freshness="${11:-unknown}"
 
 	jq -cn \
 		--arg slug "$_slug" \
@@ -502,7 +565,16 @@ _render_row_json() {
 		--arg class "$_class" \
 		--arg note "$_note" \
 		--arg workflow "$_workflow" \
-		'{slug: $slug, path: $path, workflow: $workflow, classification: $class, note: $note}'
+		--arg evidence_source "$_evidence_source" \
+		--arg branch "$_branch" \
+		--arg upstream "$_upstream" \
+		--arg ahead "$_ahead" \
+		--arg behind "$_behind" \
+		--arg freshness "$_freshness" \
+		'{slug: $slug, path: $path, workflow: $workflow, classification: $class, note: $note,
+		  evidence: {source: $evidence_source, branch: $branch, upstream: $upstream,
+		    ahead: (($ahead | tonumber?) // null), behind: (($behind | tonumber?) // null),
+		    freshness: $freshness}}'
 	return 0
 }
 
@@ -675,6 +747,44 @@ _resolve_wf_canonical() {
 	return 0
 }
 
+# _classify_row_with_freshness <slug> <path> <local-only> <canonical>
+#   <reusable-file> <workflow-file> <canon-norm>
+# Emits form-feed-delimited classification, note, and evidence fields.
+_classify_row_with_freshness() {
+	local _slug="$1"
+	local _path="$2"
+	local _local_only_flag="$3"
+	local _canonical="$4"
+	local _reusable_file="$5"
+	local _workflow_file="$6"
+	local _canon_norm="${7:-}"
+	local _class _note
+	IFS=$'\t' read -r _class _note < <(_classify_row \
+		"$_slug" "$_path" "$_local_only_flag" "$_canonical" \
+		"$_reusable_file" "$_workflow_file" "$_canon_norm")
+	local _source _branch _upstream _ahead _behind _freshness
+	IFS=$'\t' read -r _source _branch _upstream _ahead _behind _freshness \
+		< <(_repo_freshness "$_path")
+	local _freshness_note_text
+	_freshness_note_text=$(_freshness_note "$_branch" "$_upstream" "$_ahead" "$_behind" "$_freshness")
+	if [[ -n "$_freshness_note_text" ]]; then
+		[[ -n "$_note" ]] && _note="${_note}; "
+		_note="${_note}${_freshness_note_text}"
+	fi
+	printf '%s\034%s\034%s\034%s\034%s\034%s\034%s\034%s\n' \
+		"$_class" "$_note" "$_source" "$_branch" "$_upstream" "$_ahead" "$_behind" "$_freshness"
+	return 0
+}
+
+_render_rows_header() {
+	local _mode="$1"
+	if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
+		printf '\n  %-50s %-16s %s\n' "REPO [WORKFLOW]" "STATUS" "NOTE"
+		printf '  %s\n' "$(printf '%.0s─' {1..88})"
+	fi
+	return 0
+}
+
 # Process all rows: for each known workflow, classify each repo, render output,
 # tally. Returns exit status (1 if any drifted/needs-migration, 0 otherwise).
 # _process_rows <mode> <verbose> <filter_slug> <filter_workflow>
@@ -687,10 +797,7 @@ _process_rows() {
 	local _any_failure=0
 	local _total=0 _current=0 _drifted=0 _needs_mig=0 _legacy=0 _no_wf=0 _local_only=0 _no_template=0
 
-	if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
-		printf '\n  %-50s %-16s %s\n' "REPO [WORKFLOW]" "STATUS" "NOTE"
-		printf '  %s\n' "$(printf '%.0s─' {1..88})"
-	fi
+	_render_rows_header "$_mode"
 
 	local _rows
 	_rows=$(_iterate_repos) || exit $?
@@ -724,10 +831,10 @@ _process_rows() {
 			_total=$((_total + 1))
 			_path="${_path/#\~/$HOME}"
 
-			local _class _note
-			IFS=$'\t' read -r _class _note < <(_classify_row \
-				"$_slug" "$_path" "$_local_only_flag" "$_canonical" \
-				"$_reusable_file" "$_workflow_file" "$_canon_norm")
+			local _class _note _evidence_source _branch _upstream _ahead _behind _freshness
+			IFS=$'\034' read -r _class _note _evidence_source _branch _upstream _ahead _behind _freshness \
+				< <(_classify_row_with_freshness "$_slug" "$_path" "$_local_only_flag" \
+					"$_canonical" "$_reusable_file" "$_workflow_file" "$_canon_norm")
 
 			local _base_class="${_class% + LEGACY_ARTIFACTS}"
 			if [[ "$_class" == *" + LEGACY_ARTIFACTS" ]]; then
@@ -751,7 +858,8 @@ _process_rows() {
 			esac
 
 			if [[ "$_mode" == "$_MODE_JSON" ]]; then
-				_render_row_json "$_label" "$_path" "$_class" "$_note" "$_workflow_name"
+				_render_row_json "$_label" "$_path" "$_class" "$_note" "$_workflow_name" \
+					"$_evidence_source" "$_branch" "$_upstream" "$_ahead" "$_behind" "$_freshness"
 			else
 				_render_row_human "$_label" "$_path" "$_class" "$_note" "$_workflow_name"
 				if ((_verbose == 1)) && [[ "$_base_class" == "DRIFTED/CALLER" ]] && [[ -n "$_canonical" ]]; then

--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -413,6 +413,21 @@ _list_actionable_repos() {
 	return 0
 }
 
+# _classify_after_refresh <slug> <workflow>
+# Reuses check-workflows as the single classifier after apply refreshes a repo.
+_classify_after_refresh() {
+	local _slug="$1"
+	local _workflow="$2"
+	local _json
+	_json=$("$CHECK_HELPER" --json --repo "$_slug" --workflow "$_workflow" 2>/dev/null || true)
+	if [[ -z "$_json" ]]; then
+		return 1
+	fi
+	printf '%s\n' "$_json" | jq -r --arg slug "$_slug" \
+		'select(.slug == $slug) | .classification' 2>/dev/null | head -n 1
+	return 0
+}
+
 # ─── Message Formatters ─────────────────────────────────────────────────────
 # Bash 3.2-safe multi-line body builders (no heredoc inside $()).
 
@@ -528,7 +543,24 @@ _sync_preflight() {
 	return 0
 }
 
+# _sync_refresh_checkout <slug> <path> <status> <default_branch>
+# Apply must classify and mutate the same refreshed snapshot. Fail closed when
+# refresh is unavailable rather than continuing with stale local evidence.
+_sync_refresh_checkout() {
+	local _slug="$1"
+	local _path="$2"
+	local _status="$3"
+	local _default_branch="$4"
+	if ! git -C "$_path" pull --ff-only origin "$_default_branch" >/dev/null 2>&1; then
+		printf '%s\t%s\t%s\tpull --ff-only failed; refusing stale classification\n' \
+			"$_slug" "$_status" "$_STATUS_FAILED"
+		return 1
+	fi
+	return 0
+}
+
 # _sync_write_commit_push <slug> <path> <status> <branch> <default_branch> <effective_ref> <content> [workflow_relpath]
+# Returns 2 for an explicit successful no-op; the caller must not open a PR.
 _sync_write_commit_push() {
 	local _slug="$1"
 	local _path="$2"
@@ -540,8 +572,12 @@ _sync_write_commit_push() {
 	local _workflow_relpath="${8:-.github/workflows/issue-sync.yml}"
 	local _workflow="$_path/$_workflow_relpath"
 
-	if ! git -C "$_path" pull --ff-only origin "$_default_branch" >/dev/null 2>&1; then
-		_warn "$_slug: pull --ff-only failed, attempting without"
+	# Avoid even creating a local sync branch when rendering is byte-identical to
+	# the refreshed default branch.
+	if [[ -f "$_workflow" ]] && diff -q <(printf '%s\n' "$_target_content") "$_workflow" >/dev/null 2>&1; then
+		printf '%s\t%s\t%s\trendered workflow already current after refresh\n' \
+			"$_slug" "$_status" "$_STATUS_SKIPPED"
+		return 2
 	fi
 	if ! git -C "$_path" checkout -q -B "$_branch_name" "$_default_branch"; then
 		printf '%s\t%s\t%s\tbranch create/reset failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
@@ -553,13 +589,17 @@ _sync_write_commit_push() {
 	local _commit_subject="chore: resync framework workflow ($_status → CURRENT/CALLER)"
 	local _commit_body
 	_commit_body=$(_format_commit_body "$_status" "$_effective_ref" "$_workflow_relpath")
-	if ! git -C "$_path" diff --cached --quiet; then
-		if ! git -C "$_path" commit -q -m "$_commit_subject" -m "$_commit_body"; then
-			printf '%s\t%s\t%s\tgit commit failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
-			# Return to default branch on failure so subsequent runs are clean.
-			git -C "$_path" checkout -q "$_default_branch" || true
-			return 1
-		fi
+	if git -C "$_path" diff --cached --quiet; then
+		git -C "$_path" checkout -q "$_default_branch" || true
+		printf '%s\t%s\t%s\tno staged diff after render; push and PR skipped\n' \
+			"$_slug" "$_status" "$_STATUS_SKIPPED"
+		return 2
+	fi
+	if ! git -C "$_path" commit -q -m "$_commit_subject" -m "$_commit_body"; then
+		printf '%s\t%s\t%s\tgit commit failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
+		# Return to default branch on failure so subsequent runs are clean.
+		git -C "$_path" checkout -q "$_default_branch" || true
+		return 1
 	fi
 	if ! git -C "$_path" push -u origin "$_branch_name" >/dev/null 2>&1; then
 		printf '%s\t%s\t%s\tgit push failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
@@ -601,6 +641,23 @@ _sync_open_pr() {
 	return 0
 }
 
+# _render_sync_target <template> <target-repo> <effective-ref> <slug>
+_render_sync_target() {
+	local _template="$1"
+	local _target_repo="$2"
+	local _effective_ref="$3"
+	local _slug="$4"
+	local _content
+	_content=$(_render_template_with_target "$_template" "$_target_repo" "$_effective_ref") || return 1
+	local _runner_override
+	_runner_override=$(_read_runner_field "$_slug")
+	if [[ -n "$_runner_override" ]]; then
+		_content=$(_inject_runner_in_content "$_content" "$_runner_override")
+	fi
+	printf '%s\n' "$_content"
+	return 0
+}
+
 # _sync_one_repo <slug> <path> <status> <template_path> <target_repo> <target_ref> <force_ref> <branch_name> <apply> <workflow_relpath>
 # Emits a single-line summary; returns 0 on success, 1 on failure.
 # workflow_relpath — path relative to repo root e.g. .github/workflows/review-bot-gate.yml
@@ -617,23 +674,9 @@ _sync_one_repo() {
 	local _workflow_relpath="${10:-.github/workflows/issue-sync.yml}"
 
 	local _workflow="$_path/$_workflow_relpath"
-	local _effective_ref
-	_effective_ref=$(_resolve_effective_ref "$_status" "$_workflow" "$_target_ref" "$_force_ref")
-
-	local _target_content
-	if ! _target_content=$(_render_template_with_target "$_template" "$_target_repo" "$_effective_ref"); then
-		printf '%s\t%s\t%s\ttemplate render failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
-		return 1
-	fi
-
-	# Inject runner override when repos.json carries a "runner" field for this slug.
-	local _runner_override=""
-	_runner_override=$(_read_runner_field "$_slug")
-	if [[ -n "$_runner_override" ]]; then
-		_target_content=$(_inject_runner_in_content "$_target_content" "$_runner_override")
-	fi
-
 	if [[ "$_apply" -eq 0 ]]; then
+		local _effective_ref
+		_effective_ref=$(_resolve_effective_ref "$_status" "$_workflow" "$_target_ref" "$_force_ref")
 		_sync_dryrun_emit "$_slug" "$_status" "$_effective_ref"
 		return 0
 	fi
@@ -648,15 +691,69 @@ _sync_one_repo() {
 		return 1
 	fi
 	local _default_branch="$_PREFLIGHT_DEFAULT_BRANCH"
+	local _refresh_output
+	if ! _refresh_output=$(_sync_refresh_checkout "$_slug" "$_path" "$_status" "$_default_branch"); then
+		printf '%s\n' "$_refresh_output"
+		return 1
+	fi
+
+	local _workflow_name
+	_workflow_name=$(basename "$_workflow_relpath" .yml)
+	local _refreshed_status
+	if ! _refreshed_status=$(_classify_after_refresh "$_slug" "$_workflow_name"); then
+		printf '%s\t%s\t%s\tpost-refresh classification failed\n' \
+			"$_slug" "$_status" "$_STATUS_FAILED"
+		return 1
+	fi
+	if [[ -z "$_refreshed_status" ]]; then
+		printf '%s\t%s\t%s\tpost-refresh classification returned no row\n' \
+			"$_slug" "$_status" "$_STATUS_FAILED"
+		return 1
+	fi
+
+	case "$_refreshed_status" in
+	"$_CLASS_DRIFTED" | "$_CLASS_NEEDS_MIGRATION")
+		_status="$_refreshed_status"
+		;;
+	"$_CLASS_CURRENT_CALLER")
+		if ! _needs_runner_sync "$_slug" "$_workflow"; then
+			printf '%s\t%s\t%s\trefreshed checkout is CURRENT/CALLER; no changes\n' \
+				"$_slug" "$_status" "$_STATUS_SKIPPED"
+			return 0
+		fi
+		_status="$_refreshed_status"
+		;;
+	*)
+		printf '%s\t%s\t%s\tpost-refresh classification is %s; no workflow write attempted\n' \
+			"$_slug" "$_status" "$_STATUS_SKIPPED" "$_refreshed_status"
+		return 0
+		;;
+	esac
+
+	local _effective_ref
+	_effective_ref=$(_resolve_effective_ref "$_status" "$_workflow" "$_target_ref" "$_force_ref")
+	local _target_content
+	if ! _target_content=$(_render_sync_target "$_template" "$_target_repo" "$_effective_ref" "$_slug"); then
+		printf '%s\t%s\t%s\ttemplate render failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
+		return 1
+	fi
 
 	# Rewrite branch filter to match downstream default branch (e.g. develop → develop).
 	if [[ "$_default_branch" != "$_BRANCH_DEFAULT_NAME" ]]; then
 		_target_content=$(_rewrite_content_branch_filter "$_target_content" "$_default_branch")
 	fi
 
-	if ! _sync_write_commit_push \
+	local _write_output _write_rc
+	_write_output=$(_sync_write_commit_push \
 		"$_slug" "$_path" "$_status" "$_branch_name" \
-		"$_default_branch" "$_effective_ref" "$_target_content" "$_workflow_relpath"; then
+		"$_default_branch" "$_effective_ref" "$_target_content" "$_workflow_relpath")
+	_write_rc=$?
+	if [[ "$_write_rc" -eq 2 ]]; then
+		printf '%s\n' "$_write_output"
+		return 0
+	fi
+	if [[ "$_write_rc" -ne 0 ]]; then
+		printf '%s\n' "$_write_output"
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-check-workflows-helper.sh
+++ b/.agents/scripts/tests/test-check-workflows-helper.sh
@@ -20,6 +20,7 @@
 #  16. Current caller plus obsolete framework scripts → legacy-artifact warning
 #  17. Legacy-artifact manifest without a trailing newline processes its final row
 #  18. Unset HOME exits cleanly instead of raising an unbound-variable error
+#  19. Stale local checkout reports local evidence and upstream divergence
 #
 # Strategy: Each scenario writes a temporary repos.json + temporary repo trees
 # under a per-test TMPDIR, points HOME at it, and invokes the helper. No
@@ -439,6 +440,49 @@ if [[ "$unset_home_output" == *"repos.json not found"* ]] &&
 else
 	_fail "unset HOME → clean missing-config error" "got: $unset_home_output"
 fi
+
+# Test 19: A stale registered checkout must disclose that its classification is
+# local evidence and that the branch is behind its known upstream ref.
+TMPDIR_19="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_19"
+BARE_19="$TMPDIR_19/remote.git"
+REPO_19="$TMPDIR_19/repos/stale-local"
+git init --bare -q "$BARE_19"
+mkdir -p "$REPO_19/.github/workflows"
+git -C "$REPO_19" init -q
+git -C "$REPO_19" config user.email test@example.com
+git -C "$REPO_19" config user.name Test
+git -C "$REPO_19" config commit.gpgsign false
+git -C "$REPO_19" checkout -q -b main
+{
+	cat "$CANONICAL_TEMPLATE"
+	printf '\n# stale local drift\n'
+} >"$REPO_19/.github/workflows/issue-sync.yml"
+git -C "$REPO_19" add -A
+git -C "$REPO_19" commit -q -m "stale workflow"
+STALE_SHA_19=$(git -C "$REPO_19" rev-parse HEAD)
+git -C "$REPO_19" remote add origin "$BARE_19"
+git -C "$REPO_19" push -q -u origin main
+git --git-dir="$BARE_19" symbolic-ref HEAD refs/heads/main
+cp "$CANONICAL_TEMPLATE" "$REPO_19/.github/workflows/issue-sync.yml"
+git -C "$REPO_19" add -A
+git -C "$REPO_19" commit -q -m "canonical remote workflow"
+git -C "$REPO_19" push -q origin main
+git -C "$REPO_19" reset -q --hard "$STALE_SHA_19"
+_write_repos_json "$TMPDIR_19" \
+	"$(jq -n --arg path "$REPO_19" '{initialized_repos: [{slug: "x/stale-local", path: $path, local_only: false}]}')"
+json_row=$(HOME="$TMPDIR_19" bash "$HELPER" --json --repo x/stale-local --workflow issue-sync 2>/dev/null || true)
+human_row=$(HOME="$TMPDIR_19" bash "$HELPER" --repo x/stale-local --workflow issue-sync 2>/dev/null || true)
+if [[ "$(printf '%s\n' "$json_row" | jq -r '.classification')" == "DRIFTED/CALLER" ]] &&
+	[[ "$(printf '%s\n' "$json_row" | jq -r '.evidence.source')" == "local" ]] &&
+	[[ "$(printf '%s\n' "$json_row" | jq -r '.evidence.behind')" == "1" ]] &&
+	[[ "$human_row" == *"local evidence; main is 1 commit(s) behind origin/main"* ]]; then
+	_pass "stale checkout → local evidence with upstream-behind warning"
+else
+	_fail "stale checkout → local evidence with upstream-behind warning" \
+		"json: $json_row; human: $human_row"
+fi
+rm -rf "$TMPDIR_19"
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 

--- a/.agents/scripts/tests/test-sync-workflows-helper.sh
+++ b/.agents/scripts/tests/test-sync-workflows-helper.sh
@@ -88,6 +88,22 @@ _init_fake_repo() {
 	return 0
 }
 
+_setup_mock_gh() {
+	local _tmpdir="$1"
+	mkdir -p "$_tmpdir/bin"
+	cat >"$_tmpdir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${GH_CALL_LOG:?}"
+if [[ "${1:-} ${2:-}" == "pr create" ]]; then
+	printf 'mock-pr\n'
+fi
+exit 0
+EOF
+	chmod +x "$_tmpdir/bin/gh"
+	: >"$_tmpdir/gh-calls.log"
+	return 0
+}
+
 CANONICAL_CALLER_CONTENT=$(cat "$SCRIPT_DIR/../../templates/workflows/issue-sync-caller.yml")
 
 # ─── Test 1: no work when all current ───────────────────────────────────────
@@ -364,6 +380,96 @@ else
 	((_FAIL++))
 fi
 rm -rf "$TMPDIR_13"
+
+# ─── Test 14: GH#27726 — stale local, canonical remote → successful no-op ──
+TMPDIR_14="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_14"
+_setup_mock_gh "$TMPDIR_14"
+BARE_14="$TMPDIR_14/bare.git"
+REPO_14="$TMPDIR_14/repo-stale-current"
+git init --bare -q "$BARE_14"
+mkdir -p "$REPO_14/.github/workflows"
+git -C "$REPO_14" init -q
+git -C "$REPO_14" config user.email test@example.com
+git -C "$REPO_14" config user.name Test
+git -C "$REPO_14" config commit.gpgsign false
+git -C "$REPO_14" checkout -q -b main
+printf '%s\n# stale local drift\n' "$CANONICAL_CALLER_CONTENT" >"$REPO_14/.github/workflows/issue-sync.yml"
+git -C "$REPO_14" add -A
+git -C "$REPO_14" commit -q -m "stale workflow"
+STALE_SHA_14=$(git -C "$REPO_14" rev-parse HEAD)
+git -C "$REPO_14" remote add origin "$BARE_14"
+git -C "$REPO_14" push -q -u origin main
+git --git-dir="$BARE_14" symbolic-ref HEAD refs/heads/main
+printf '%s\n' "$CANONICAL_CALLER_CONTENT" >"$REPO_14/.github/workflows/issue-sync.yml"
+git -C "$REPO_14" add -A
+git -C "$REPO_14" commit -q -m "canonical remote workflow"
+git -C "$REPO_14" push -q origin main
+git -C "$REPO_14" reset -q --hard "$STALE_SHA_14"
+git -C "$REPO_14" remote set-head origin main
+_write_repos_json "$TMPDIR_14" \
+	"{\"initialized_repos\":[{\"path\":\"$REPO_14\",\"slug\":\"owner/repo-stale-current\"}]}"
+OUT_14=$(HOME="$TMPDIR_14" PATH="$TMPDIR_14/bin:$PATH" GH_CALL_LOG="$TMPDIR_14/gh-calls.log" \
+	bash "$HELPER" --apply --branch chore/test-stale-current 2>&1)
+EXIT_14=$?
+if [[ "$OUT_14" == *"refreshed checkout is CURRENT/CALLER; no changes"* ]] &&
+	[[ ! -s "$TMPDIR_14/gh-calls.log" ]] &&
+	! git --git-dir="$BARE_14" show-ref --verify --quiet refs/heads/chore/test-stale-current; then
+	printf '%sPASS%s GH#27726 stale local + canonical remote → no push or PR\n' "$GREEN" "$NC"
+	((_PASS++))
+else
+	printf '%sFAIL%s GH#27726 stale local + canonical remote → no push or PR\n' "$RED" "$NC"
+	printf '       output: %s\n' "$OUT_14"
+	((_FAIL++))
+fi
+_assert_exit "GH#27726 refreshed-current no-op exits 0" 0 "$EXIT_14"
+rm -rf "$TMPDIR_14"
+
+# ─── Test 15: GH#27726 — stale local, drifted remote → apply refreshed state ─
+TMPDIR_15="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_15"
+_setup_mock_gh "$TMPDIR_15"
+BARE_15="$TMPDIR_15/bare.git"
+REPO_15="$TMPDIR_15/repo-stale-drifted"
+git init --bare -q "$BARE_15"
+mkdir -p "$REPO_15/.github/workflows"
+git -C "$REPO_15" init -q
+git -C "$REPO_15" config user.email test@example.com
+git -C "$REPO_15" config user.name Test
+git -C "$REPO_15" config commit.gpgsign false
+git -C "$REPO_15" checkout -q -b main
+printf '%s\n# old local drift\n' "$CANONICAL_CALLER_CONTENT" >"$REPO_15/.github/workflows/issue-sync.yml"
+git -C "$REPO_15" add -A
+git -C "$REPO_15" commit -q -m "old drift"
+STALE_SHA_15=$(git -C "$REPO_15" rev-parse HEAD)
+git -C "$REPO_15" remote add origin "$BARE_15"
+git -C "$REPO_15" push -q -u origin main
+git --git-dir="$BARE_15" symbolic-ref HEAD refs/heads/main
+printf '%s\n# newer remote drift\n' "$CANONICAL_CALLER_CONTENT" >"$REPO_15/.github/workflows/issue-sync.yml"
+git -C "$REPO_15" add -A
+git -C "$REPO_15" commit -q -m "newer remote drift"
+git -C "$REPO_15" push -q origin main
+git -C "$REPO_15" reset -q --hard "$STALE_SHA_15"
+git -C "$REPO_15" remote set-head origin main
+_write_repos_json "$TMPDIR_15" \
+	"{\"initialized_repos\":[{\"path\":\"$REPO_15\",\"slug\":\"owner/repo-stale-drifted\"}]}"
+OUT_15=$(HOME="$TMPDIR_15" PATH="$TMPDIR_15/bin:$PATH" GH_CALL_LOG="$TMPDIR_15/gh-calls.log" \
+	bash "$HELPER" --apply --branch chore/test-stale-drifted 2>&1)
+EXIT_15=$?
+APPLIED_15=$(git --git-dir="$BARE_15" show \
+	"refs/heads/chore/test-stale-drifted:.github/workflows/issue-sync.yml" 2>/dev/null || true)
+if [[ "$OUT_15" == *"APPLIED"* ]] &&
+	grep -qF "pr create" "$TMPDIR_15/gh-calls.log" &&
+	[[ "$APPLIED_15" == "$CANONICAL_CALLER_CONTENT" ]]; then
+	printf '%sPASS%s GH#27726 stale local + drifted remote → refreshed drift applied\n' "$GREEN" "$NC"
+	((_PASS++))
+else
+	printf '%sFAIL%s GH#27726 stale local + drifted remote → refreshed drift applied\n' "$RED" "$NC"
+	printf '       output: %s\n' "$OUT_15"
+	((_FAIL++))
+fi
+_assert_exit "GH#27726 refreshed-drift apply exits 0" 0 "$EXIT_15"
+rm -rf "$TMPDIR_15"
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 printf '\n'


### PR DESCRIPTION
## Summary

Expose local workflow-audit freshness, reclassify apply operations after fast-forwarding the default branch, and stop no-diff paths before push or PR creation.

## Files Changed

.agents/reference/reusable-workflows.md, .agents/scripts/check-workflows-helper.sh, .agents/scripts/sync-workflows-helper.sh, .agents/scripts/tests/test-check-workflows-helper.sh, .agents/scripts/tests/test-sync-workflows-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck passed; check-workflows tests 19/19; sync-workflows tests 35/35; local linter suite passed.

Resolves #27726


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.119 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 26m and 645,438 tokens on this with the user in an interactive session.