### PR TITLE
GH#27727: Couple reusable workflow helper provenance

### DIFF
--- a/.agents/reference/reusable-workflows.md
+++ b/.agents/reference/reusable-workflows.md
@@ -83,7 +83,11 @@ By default, downstream callers delegate to `marcusquinn/aidevops`. Organizations
 }
 ```
 
-Per-repo values override the global default. The default remains `marcusquinn/aidevops@main`. `check-workflows` treats only the explicitly configured repo/ref as trusted; it does not accept arbitrary repositories that happen to use the same reusable workflow filename.
+Per-repo values override the global default. The default remains `marcusquinn/aidevops@main`. `check-workflows` treats only the explicitly configured repo/ref as trusted; it does not accept arbitrary repositories that happen to use the same reusable workflow filename. Helper-bearing callers pass the same ref through `aidevops_ref`; configured mirrors also pass `aidevops_repository`, so reusable YAML and executed helper code share one provenance tuple.
+
+Update and register a configured mirror's reusable workflow files before syncing its callers. `sync-workflows` fails closed when the registered mirror does not declare the provenance input and optional read-token secret. Older mirrored reusable files reject those undeclared values at startup. Canonical `marcusquinn/aidevops` callers remain backward-compatible with older pins because they pass only the long-supported `aidevops_ref` input.
+
+Private mirrors require a caller-repository secret named `AIDEVOPS_READ_TOKEN` with read access to the mirror. Sync injects that secret only for configured mirror callers; public mirrors fall back to the caller's `GITHUB_TOKEN` when the secret is unset. Store the token as a GitHub Actions secret, never in `repos.json` or workflow YAML.
 
 Pinned refs are allowed for caller classification, but they do not suppress reusable-content update visibility. If the configured reusable repo is also registered in `repos.json` and has local `*-reusable.yml` copies, `check-workflows` compares those files against the aidevops baseline and reports `DRIFTED/REUSABLE` when an update should be reviewed.
 
@@ -94,14 +98,14 @@ Pinned refs are allowed for caller classification, but they do not suppress reus
 3. GitHub fetches the reusable workflow from `marcusquinn/aidevops` at the specified ref.
 4. Each job in the reusable workflow runs with `github.event_name` reflecting the caller's event (so the `if: github.event_name == 'push'` guards work correctly across repos).
 5. First step in each job: `actions/checkout` of the caller's repo (so the sync helpers see the caller's `TODO.md`, `todo/`, etc.).
-6. Second step: `actions/checkout` of `marcusquinn/aidevops` into `__aidevops/` (so `bash __aidevops/.agents/scripts/...` finds the framework scripts).
+6. Second step: `actions/checkout` of the caller's coupled `aidevops_repository` / `aidevops_ref` provenance into `__aidevops/` (so `bash __aidevops/.agents/scripts/...` finds the framework scripts).
 7. Subsequent steps run the sync helpers against the caller's repo files.
 
 This pattern also works when aidevops calls its own reusable workflow (same-repo use), at the cost of a ~2s secondary checkout. The uniformity (one code path for all callers) is worth it.
 
 ## Pinning strategies
 
-The caller declares which version of aidevops to fetch via the `@ref` suffix on `uses:`:
+The caller declares which version of aidevops to fetch via the `@ref` suffix on `uses:` and repeats that value in `with.aidevops_ref`. `check-workflows` treats a missing or mismatched helper ref as drift, and `sync-workflows` repairs both values together.
 
 | Pin | Behaviour | When to use |
 |---|---|---|
@@ -119,6 +123,8 @@ jobs:
     #                                                                   change this
     secrets:
       SYNC_PAT: ${{ secrets.SYNC_PAT }}
+    with:
+      aidevops_ref: v3.9.0
 ```
 
 Keep pinned callers in sync with aidevops releases via:
@@ -207,7 +213,7 @@ The caller YAML becomes `with: runner: "[self-hosted, linux, x64]"` and GitHub A
 
   **Symptom of the cross-account bug**: `gh secret list` shows `SYNC_PAT` set and recent, but the workflow's `Check SYNC_PAT visibility` step logs `SYNC_PAT_PRESENT:` (empty). Fix: `aidevops sync-workflows --apply`.
 
-- **Referencing `@main` is a trust boundary.** You're trusting whoever controls aidevops's `main` branch. For higher-trust deployments, pin to a version tag (`@v3.9.0`) and update explicitly.
+- **Referencing `@main` is a trust boundary.** You're trusting whoever controls aidevops's `main` branch. For higher-trust deployments, pin both `jobs.<id>.uses` and `with.aidevops_ref` to the same version tag or SHA; `aidevops sync-workflows` keeps them coupled.
 - **`pull_request_target` vs `pull_request`.** The reusable workflow's job guards accept either event type. The caller picks based on its security model:
   - **Private repo with trusted contributors**: `pull_request` is simpler and has fewer footguns.
   - **Public repo accepting external PRs**: `pull_request_target` is required if the workflow needs write permissions or secrets (but bring standard `pull_request_target` hygiene — don't check out the PR's head code if you trust it to run with elevated privileges).

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -264,11 +264,50 @@ _render_template_for_target() {
 	_reusable_escaped=$(_escape_ere "$_reusable_file")
 	_repo_repl=$(_escape_sed_replacement "$_repo")
 	_ref_repl=$(_escape_sed_replacement "$_ref")
-	sed -E \
+	local _rendered
+	_rendered=$(sed -E \
 		-e "s|(uses:[[:space:]]*)${_default_repo_escaped}(/\.github/workflows/${_reusable_escaped})@[^[:space:]]+|\1${_repo_repl}\2@${_ref_repl}|" \
 		-e "s|${_default_repo_escaped}(/\.github/workflows/${_reusable_escaped})|${_repo_repl}\1|g" \
-		"$_template"
+		-e "s|^(      aidevops_ref:).*$|\1 ${_ref_repl}|" \
+		"$_template")
+	if [[ "$_repo" != "$_DEFAULT_WORKFLOW_REUSABLE_REPO" ]] && \
+		printf '%s\n' "$_rendered" | grep -qE '^      aidevops_ref:'; then
+		_rendered=$(printf '%s\n' "$_rendered" | sed -E \
+			"s|^(      aidevops_ref:.*)$|      aidevops_repository: ${_repo_repl}\n\1|"
+		)
+		_rendered=$(_inject_mirror_read_secret "$_rendered")
+	fi
+	printf '%s\n' "$_rendered"
 	return 0
+}
+
+_inject_mirror_read_secret() {
+	local _content="$1"
+	if printf '%s\n' "$_content" | grep -qE '^    secrets: inherit$'; then
+		printf '%s\n' "$_content" | sed -E \
+			's|^    secrets: inherit$|    secrets:\
+      AIDEVOPS_READ_TOKEN: ${{ secrets.AIDEVOPS_READ_TOKEN }}|'
+	else
+		printf '%s\n' "$_content" | sed -E \
+			's|^    secrets:$|    secrets:\
+      AIDEVOPS_READ_TOKEN: ${{ secrets.AIDEVOPS_READ_TOKEN }}|'
+	fi
+	return 0
+}
+
+_caller_helper_provenance_matches() {
+	local _wf="$1"
+	local _target_repo="$2"
+	local _target_escaped="$3"
+	local _uses_ref _helper_ref _helper_repo
+	_uses_ref=$(sed -nE "s|^[[:space:]]*uses:[[:space:]]*${_target_escaped}@([^[:space:]]+).*$|\1|p" "$_wf" | head -n 1)
+	_helper_ref=$(sed -nE 's|^      aidevops_ref:[[:space:]]*([^[:space:]]+).*$|\1|p' "$_wf" | head -n 1)
+	_helper_repo=$(sed -nE 's|^      aidevops_repository:[[:space:]]*([^[:space:]]+).*$|\1|p' "$_wf" | head -n 1)
+	[[ -z "$_helper_repo" ]] && _helper_repo="$_DEFAULT_WORKFLOW_REUSABLE_REPO"
+	if [[ -n "$_uses_ref" && "$_helper_ref" == "$_uses_ref" && "$_helper_repo" == "$_target_repo" ]]; then
+		return 0
+	fi
+	return 1
 }
 
 # ─── Classification ─────────────────────────────────────────────────────────
@@ -301,6 +340,8 @@ _normalize_wf_for_compare() {
 	#         where a `with:` followed by no children should survive normalisation.
 	sed -E "s|(${_target_escaped})@[^[:space:]]+|\1@REF|g" "$_file" |
 		sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|' |
+		sed -E 's|^      aidevops_ref: .+$|      aidevops_ref: REF|' |
+		sed -E '/^      aidevops_repository: /d' |
 		sed -E '/^      runner: /d' |
 		awk '
 			/^    with:$/ { pending = $0; next }
@@ -326,6 +367,8 @@ _normalize_wf_text_for_compare() {
 	printf '%s\n' "$_content" |
 		sed -E "s|(${_target_escaped})@[^[:space:]]+|\1@REF|g" |
 		sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|' |
+		sed -E 's|^      aidevops_ref: .+$|      aidevops_ref: REF|' |
+		sed -E '/^      aidevops_repository: /d' |
 		sed -E '/^      runner: /d' |
 		awk '
 			/^    with:$/ { pending = $0; next }
@@ -389,6 +432,14 @@ _classify_workflow() {
 	local _downstream_pattern
 	_downstream_pattern="uses:[[:space:]]*${_target_escaped}@"
 	if grep -qE "$_downstream_pattern" "$_wf"; then
+		# Helper-bearing callers must bind runtime helper provenance to the same
+		# repository/ref tuple as the reusable YAML. Missing or mismatched values
+		# are drift so sync-workflows can repair legacy callers safely.
+		if grep -qE '^      aidevops_ref:' "$_canon" && \
+			! _caller_helper_provenance_matches "$_wf" "$_target_repo" "$_target_escaped"; then
+			printf 'DRIFTED/CALLER\n'
+			return 0
+		fi
 		# It's a caller. Compare against canonical, normalising the @ref so that
 		# `@main` vs `@v3.9.0` doesn't count as drift (intentional pinning is OK).
 		# Also normalise the push-trigger branch filter so a repo with

--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -237,11 +237,56 @@ _render_template_with_target() {
 	# Template ships with `marcusquinn/aidevops@main` by default; rewrite the
 	# executable `uses:` target and any managed comment/reference path so
 	# sync-generated org-owned callers are byte-comparable by check-workflows.
-	sed -E \
+	local _rendered
+	_rendered=$(sed -E \
 		-e 's|(uses:[[:space:]]*)marcusquinn/aidevops(/\.github/workflows/[^@[:space:]]+)@[^[:space:]]+|\1'"$_repo_escaped"'\2@'"$_ref_escaped"'|' \
 		-e 's|marcusquinn/aidevops(/\.github/workflows/[^[:space:]]+)|'"$_repo_escaped"'\1|g' \
-		"$_template"
+		-e 's|^(      aidevops_ref:).*$|\1 '"$_ref_escaped"'|' \
+		"$_template")
+	# Existing pinned reusable versions already accept aidevops_ref. The new
+	# repository input is emitted only for configured mirrors, which must update
+	# their reusable workflow before callers are resynced.
+	if [[ "$_repo" != "$_DEFAULT_WORKFLOW_REUSABLE_REPO" ]] && \
+		printf '%s\n' "$_rendered" | grep -qE '^      aidevops_ref:'; then
+		_rendered=$(printf '%s\n' "$_rendered" | sed -E \
+			's|^(      aidevops_ref:.*)$|      aidevops_repository: '"$_repo_escaped"'\n\1|'
+		)
+		_rendered=$(_inject_mirror_read_secret "$_rendered")
+	fi
+	printf '%s\n' "$_rendered"
 	return 0
+}
+
+_inject_mirror_read_secret() {
+	local _content="$1"
+	if printf '%s\n' "$_content" | grep -qE '^    secrets: inherit$'; then
+		printf '%s\n' "$_content" | sed -E \
+			's|^    secrets: inherit$|    secrets:\
+      AIDEVOPS_READ_TOKEN: ${{ secrets.AIDEVOPS_READ_TOKEN }}|'
+	else
+		printf '%s\n' "$_content" | sed -E \
+			's|^    secrets:$|    secrets:\
+      AIDEVOPS_READ_TOKEN: ${{ secrets.AIDEVOPS_READ_TOKEN }}|'
+	fi
+	return 0
+}
+
+_mirror_supports_helper_provenance() {
+	local _repo="$1"
+	local _workflow_name="$2"
+	local _ref="$3"
+	local _path _reusable_path _reusable_content
+	_path=$(jq -r --arg s "$_repo" \
+		'.initialized_repos[]? | select(.slug == $s) | .path // empty' \
+		"$REPOS_JSON" 2>/dev/null | head -n 1)
+	_reusable_path=".github/workflows/${_workflow_name}-reusable.yml"
+	[[ -n "$_path" && -d "$_path/.git" ]] || return 1
+	_reusable_content=$(git -C "$_path" show "${_ref#@}:${_reusable_path}" 2>/dev/null) || return 1
+	if grep -qE '^      aidevops_repository:' <<<"$_reusable_content" && \
+		grep -qE '^      AIDEVOPS_READ_TOKEN:' <<<"$_reusable_content"; then
+		return 0
+	fi
+	return 1
 }
 
 # Rewrite `branches: [main]` → `branches: [<default_branch>]` in caller YAML content.
@@ -855,10 +900,21 @@ _process_rows() {
 			_target_ref=$(_workflow_reusable_ref_for_slug "$_slug")
 		fi
 
-		local _result
+		local _result _effective_ref _target_ref_arg
+		_target_ref_arg="@${_target_ref}"
+		_effective_ref=$(_resolve_effective_ref \
+			"$_status" "$_path/$_workflow_relpath" "$_target_ref_arg" "$_OPT_FORCE_REF")
+		if [[ "$_target_repo" != "$_DEFAULT_WORKFLOW_REUSABLE_REPO" ]] && \
+			grep -qE '^      aidevops_ref:' "$_template" && \
+			! _mirror_supports_helper_provenance "$_target_repo" "$_workflow_name" "$_effective_ref"; then
+			_result="${_slug}"$'\t'"${_status}"$'\t'"${_STATUS_FAILED}"$'\t'"configured mirror must be registered and updated at ${_effective_ref} before caller sync"
+			_any_failed=1
+			_print_result_row "$_OPT_JSON" "$_target_ref_arg" "$_OPT_BRANCH_NAME" "$_result"
+			continue
+		fi
 		if _result=$(_sync_one_repo \
 			"$_slug" "$_path" "$_status" "$_template" \
-			"$_target_repo" "@${_target_ref}" "$_OPT_FORCE_REF" "$_OPT_BRANCH_NAME" "$_OPT_APPLY" \
+			"$_target_repo" "$_target_ref_arg" "$_OPT_FORCE_REF" "$_OPT_BRANCH_NAME" "$_OPT_APPLY" \
 			"$_workflow_relpath"); then
 			:
 		else
@@ -870,7 +926,7 @@ _process_rows() {
 		"$_STATUS_PLANNED") ((_COUNT_PLANNED++)) ;;
 		"$_STATUS_SKIPPED") ((_COUNT_SKIPPED++)) ;;
 		esac
-		_print_result_row "$_OPT_JSON" "@${_target_ref}" "$_OPT_BRANCH_NAME" "$_result"
+		_print_result_row "$_OPT_JSON" "$_target_ref_arg" "$_OPT_BRANCH_NAME" "$_result"
 	done <<<"$_tsv"
 	return "$_any_failed"
 }

--- a/.agents/scripts/tests/test-check-workflows-classifier.sh
+++ b/.agents/scripts/tests/test-check-workflows-classifier.sh
@@ -11,11 +11,8 @@
 # Introduced in PR #20809 (GH#20794). Fixed in GH#21477.
 #
 # Scenarios covered:
-#   1–3.  Byte-identical caller for each of the three managed workflow types
-#         (issue-sync, review-bot-gate, maintainer-gate) → CURRENT/CALLER
-#   4–6.  Version-pinned (@v3.9.0) variant of each → CURRENT/CALLER (normalised @ref)
-#   7–9.  Non-default-branch variant (branches: [develop]) for each → CURRENT/CALLER
-#  10–12. Actually-drifted caller for each → DRIFTED/CALLER (true positive preserved)
+# Covers byte-identical, coherently pinned, non-default-branch, and genuinely
+# drifted callers for every managed workflow tuple.
 #
 # Strategy: each scenario copies the canonical caller template byte-for-byte
 # (or with a single normalisation-allowed variant) into a temporary repo tree,
@@ -38,6 +35,7 @@ readonly -a _WORKFLOWS=(
 	"issue-sync.yml:issue-sync-reusable.yml:issue-sync-caller.yml"
 	"review-bot-gate.yml:review-bot-gate-reusable.yml:review-bot-gate-caller.yml"
 	"maintainer-gate.yml:maintainer-gate-reusable.yml:maintainer-gate-caller.yml"
+	"loc-badge.yml:loc-badge-reusable.yml:loc-badge-caller.yml"
 )
 
 readonly _T_GREEN='\033[0;32m'
@@ -137,7 +135,8 @@ for _wf_tuple in "${_WORKFLOWS[@]}"; do
 	_TD="$(mktemp -d)"
 	_setup_fake_home "$_TD"
 	mkdir -p "$_TD/repos/repo-b/.github/workflows"
-	sed "s|${_reusable_file}@main|${_reusable_file}@v3.9.0|g" \
+	sed -e "s|${_reusable_file}@main|${_reusable_file}@v3.9.0|g" \
+		-e 's|aidevops_ref: main|aidevops_ref: v3.9.0|g' \
 		"$_src_template" > "$_TD/repos/repo-b/.github/workflows/${_workflow_file}"
 	_write_repos_json "$_TD" \
 		"$(jq -n --arg p "$_TD/repos/repo-b" \

--- a/.agents/scripts/tests/test-check-workflows-helper.sh
+++ b/.agents/scripts/tests/test-check-workflows-helper.sh
@@ -166,7 +166,8 @@ rm -rf "$TMPDIR_3"
 TMPDIR_4="$(mktemp -d)"
 _setup_fake_home "$TMPDIR_4"
 _make_repo_with_workflow "$TMPDIR_4/repos/downstream-pinned"
-sed 's|issue-sync-reusable\.yml@main|issue-sync-reusable.yml@v3.9.0|g' \
+sed -e 's|issue-sync-reusable\.yml@main|issue-sync-reusable.yml@v3.9.0|g' \
+	-e 's|aidevops_ref: main|aidevops_ref: v3.9.0|g' \
 	"$CANONICAL_TEMPLATE" >"$TMPDIR_4/repos/downstream-pinned/.github/workflows/issue-sync.yml"
 _write_repos_json "$TMPDIR_4" \
 	"$(jq -n --arg path "$TMPDIR_4/repos/downstream-pinned" '{initialized_repos: [{slug: "x/pinned", path: $path, local_only: false}]}')"
@@ -177,6 +178,39 @@ else
 	_fail "pinned @v3.9.0 caller → CURRENT/CALLER (normalised @ref)" "got: $result"
 fi
 rm -rf "$TMPDIR_4"
+
+# Test 4b: A pinned reusable YAML with a mutable helper ref is drift.
+TMPDIR_4B="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_4B"
+_make_repo_with_workflow "$TMPDIR_4B/repos/downstream-split-pin"
+sed 's|issue-sync-reusable\.yml@main|issue-sync-reusable.yml@v3.9.0|g' \
+	"$CANONICAL_TEMPLATE" >"$TMPDIR_4B/repos/downstream-split-pin/.github/workflows/issue-sync.yml"
+_write_repos_json "$TMPDIR_4B" \
+	"$(jq -n --arg path "$TMPDIR_4B/repos/downstream-split-pin" '{initialized_repos: [{slug: "x/split-pin", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_4B")
+if [[ "$result" == "DRIFTED/CALLER" ]]; then
+	_pass "pinned reusable with helper on main → DRIFTED/CALLER"
+else
+	_fail "pinned reusable with helper on main → DRIFTED/CALLER" "got: $result"
+fi
+rm -rf "$TMPDIR_4B"
+
+# Test 4c: Valid punctuation in a coherently coupled ref remains current.
+TMPDIR_4C="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_4C"
+_make_repo_with_workflow "$TMPDIR_4C/repos/downstream-punctuation-ref"
+sed -e 's|issue-sync-reusable\.yml@main|issue-sync-reusable.yml@release#candidate|g' \
+	-e 's|aidevops_ref: main|aidevops_ref: release#candidate|g' \
+	"$CANONICAL_TEMPLATE" >"$TMPDIR_4C/repos/downstream-punctuation-ref/.github/workflows/issue-sync.yml"
+_write_repos_json "$TMPDIR_4C" \
+	"$(jq -n --arg path "$TMPDIR_4C/repos/downstream-punctuation-ref" '{initialized_repos: [{slug: "x/punctuation-ref", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_4C")
+if [[ "$result" == "CURRENT/CALLER" ]]; then
+	_pass "coupled release#candidate ref → CURRENT/CALLER"
+else
+	_fail "coupled release#candidate ref → CURRENT/CALLER" "got: $result"
+fi
+rm -rf "$TMPDIR_4C"
 
 # Test 5: Caller with extra triggers → DRIFTED/CALLER
 TMPDIR_5="$(mktemp -d)"
@@ -347,6 +381,10 @@ _make_repo_with_workflow "$TMPDIR_13/repos/org-current"
 sed \
 	-e 's|marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@main|ORG/.github/.github/workflows/issue-sync-reusable.yml@1234567890abcdef1234567890abcdef12345678|g' \
 	-e 's|marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml|ORG/.github/.github/workflows/issue-sync-reusable.yml|g' \
+	-e 's|^      aidevops_ref: main|      aidevops_repository: ORG/.github\
+      aidevops_ref: 1234567890abcdef1234567890abcdef12345678|' \
+	-e 's|^    secrets:$|    secrets:\
+      AIDEVOPS_READ_TOKEN: ${{ secrets.AIDEVOPS_READ_TOKEN }}|' \
 	"$CANONICAL_TEMPLATE" >"$TMPDIR_13/repos/org-current/.github/workflows/issue-sync.yml"
 _write_repos_json "$TMPDIR_13" \
 	"$(jq -n --arg path "$TMPDIR_13/repos/org-current" '{workflow_reusable_repo: "ORG/.github", workflow_reusable_ref: "1234567890abcdef1234567890abcdef12345678", initialized_repos: [{slug: "x/org-current", path: $path, local_only: false}]}')"

--- a/.agents/scripts/tests/test-loc-badge-reusable-install.sh
+++ b/.agents/scripts/tests/test-loc-badge-reusable-install.sh
@@ -61,6 +61,9 @@ main() {
 	_assert_contains "uses repo metrics helper" "repo-metrics-helper.sh generate"
 	_assert_contains "writes JSON metrics" "docs/metrics"
 	_assert_contains "uses freshness skip" "skip_if_fresh_hours"
+	_assert_contains "declares helper repository input" "aidevops_repository:"
+	_assert_contains "declares private mirror read token" "AIDEVOPS_READ_TOKEN:"
+	_assert_contains "checks out configured helper repository" "repository: \${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}"
 	_assert_contains "keeps runtime bounded" "timeout-minutes: 5"
 	_assert_contains "detects untracked generated metrics" "git status --porcelain"
 	_assert_not_regex "does not apt-install tokei" 'apt(-get)? install.*tokei'

--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -251,13 +251,13 @@ for jname, jdef in jobs.items():
             path = (with_.get('path') or '').strip()
             co_steps.append((i, repo, path))
     # Jobs that do any work with framework scripts must have at least one
-    # framework checkout (repository: marcusquinn/aidevops, path: __aidevops)
+    # framework checkout (configured aidevops repository, path: __aidevops)
     job_yaml = yaml.safe_dump(jdef)
     needs_framework = '__aidevops/.agents/scripts/' in job_yaml
     if not needs_framework:
         continue
     has_framework_checkout = any(
-        (r == 'marcusquinn/aidevops' and p == '__aidevops')
+        (('aidevops_repository' in r or r == 'marcusquinn/aidevops') and p == '__aidevops')
         for (_, r, p) in co_steps
     )
     if not has_framework_checkout:
@@ -319,13 +319,14 @@ if 'workflow_call' not in on:
     print(f"FAIL: `on:` missing `workflow_call`. Keys: {list(on.keys())}"); sys.exit(1)
 wc = on['workflow_call'] or {}
 inputs = wc.get('inputs', {}) or {}
-if 'aidevops_ref' not in inputs:
-    print(f"FAIL: workflow_call.inputs missing `aidevops_ref`. Keys: {list(inputs.keys())}"); sys.exit(1)
+for required_input in ('aidevops_repository', 'aidevops_ref'):
+    if required_input not in inputs:
+        print(f"FAIL: workflow_call.inputs missing `{required_input}`. Keys: {list(inputs.keys())}"); sys.exit(1)
 print("OK")
 PYEOF
 )"
 		if [[ "$parse_result" == "OK" ]]; then
-			_pass "review-bot-gate reusable workflow declares workflow_call with aidevops_ref input"
+			_pass "review-bot-gate reusable workflow declares coupled repository/ref inputs"
 		else
 			_fail "review-bot-gate reusable workflow declares workflow_call with aidevops_ref input" "$parse_result"
 		fi
@@ -398,6 +399,13 @@ if [[ -f "$RBG_REUSABLE_WF" ]]; then
 	else
 		_fail "review-bot-gate reusable workflow uses inputs.aidevops_ref" \
 			"expected 'ref: \${{ inputs.aidevops_ref ... }}' — SHA pin not eliminated"
+	fi
+
+	if grep -qF "repository: \${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}" "$RBG_REUSABLE_WF"; then
+		_pass "review-bot-gate reusable workflow uses inputs.aidevops_repository"
+	else
+		_fail "review-bot-gate reusable workflow uses inputs.aidevops_repository" \
+			"expected helper checkout repository to use the provenance input"
 	fi
 
 	# Helper path must not reference .aidevops-helper/ in functional (non-comment) lines.

--- a/.agents/scripts/tests/test-sync-workflows-helper.sh
+++ b/.agents/scripts/tests/test-sync-workflows-helper.sh
@@ -14,6 +14,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 HELPER="$SCRIPT_DIR/../sync-workflows-helper.sh"
 CHECK_HELPER="$SCRIPT_DIR/../check-workflows-helper.sh"
 
@@ -328,6 +329,18 @@ rm -rf "$TMPDIR_12"
 # ─── Test 13: GH#24520 — apply renders configured reusable repo/ref ─────────
 TMPDIR_13="$(mktemp -d)"
 _setup_fake_home "$TMPDIR_13"
+MIRROR_13="$TMPDIR_13/org-dotgithub"
+mkdir -p "$MIRROR_13/.github/workflows"
+git -C "$MIRROR_13" init -q 2>/dev/null
+git -C "$MIRROR_13" config user.email test@example.com
+git -C "$MIRROR_13" config user.name Test
+git -C "$MIRROR_13" config commit.gpgsign false
+git -C "$MIRROR_13" symbolic-ref HEAD refs/heads/main 2>/dev/null
+cp "$REPO_ROOT/.github/workflows/issue-sync-reusable.yml" \
+	"$MIRROR_13/.github/workflows/issue-sync-reusable.yml"
+git -C "$MIRROR_13" add -A >/dev/null
+git -C "$MIRROR_13" commit -q -m "current mirror contract"
+MIRROR_REF_13=$(git -C "$MIRROR_13" rev-parse HEAD)
 BARE_13="$TMPDIR_13/bare.git"
 git init --bare -q "$BARE_13" 2>/dev/null
 REPO_13="$TMPDIR_13/repo-org-target"
@@ -344,18 +357,24 @@ git -C "$REPO_13" remote add origin "$BARE_13" 2>/dev/null
 git -C "$REPO_13" push -q origin main 2>/dev/null
 git -C "$REPO_13" fetch -q origin 2>/dev/null
 git -C "$REPO_13" remote set-head origin main 2>/dev/null
-_write_repos_json "$TMPDIR_13" "{\"workflow_reusable_repo\":\"ORG/.github\",\"workflow_reusable_ref\":\"1234567890abcdef1234567890abcdef12345678\",\"initialized_repos\":[{\"path\":\"$REPO_13\",\"slug\":\"owner/repo-org-target\",\"runner\":\"ubuntu-latest-arm64\"}]}"
+_write_repos_json "$TMPDIR_13" "{\"workflow_reusable_repo\":\"ORG/.github\",\"workflow_reusable_ref\":\"$MIRROR_REF_13\",\"initialized_repos\":[{\"path\":\"$REPO_13\",\"slug\":\"owner/repo-org-target\",\"runner\":\"ubuntu-latest-arm64\"},{\"path\":\"$MIRROR_13\",\"slug\":\"ORG/.github\"}]}"
 SYNC_BRANCH_13="chore/workflow-sync-$(date +%Y%m%d)"
 HOME="$TMPDIR_13" bash "$HELPER" --apply 2>/dev/null || true
 WF_USES_13=$(git -C "$REPO_13" show "${SYNC_BRANCH_13}:.github/workflows/issue-sync.yml" 2>/dev/null \
 	| grep -E "^[[:space:]]+uses:" | head -n 1 || true)
 WF_RUNNER_13=$(git -C "$REPO_13" show "${SYNC_BRANCH_13}:.github/workflows/issue-sync.yml" 2>/dev/null \
 	| grep -E "^[[:space:]]+runner:" | head -n 1 || true)
+WF_HELPER_REPO_13=$(git -C "$REPO_13" show "${SYNC_BRANCH_13}:.github/workflows/issue-sync.yml" 2>/dev/null \
+	| grep -E "^[[:space:]]+aidevops_repository:" | head -n 1 || true)
+WF_HELPER_REF_13=$(git -C "$REPO_13" show "${SYNC_BRANCH_13}:.github/workflows/issue-sync.yml" 2>/dev/null \
+	| grep -E "^[[:space:]]+aidevops_ref:" | head -n 1 || true)
+WF_HELPER_SECRET_13=$(git -C "$REPO_13" show "${SYNC_BRANCH_13}:.github/workflows/issue-sync.yml" 2>/dev/null \
+	| grep -E "^[[:space:]]+AIDEVOPS_READ_TOKEN:" | head -n 1 || true)
 git -C "$REPO_13" checkout -q "$SYNC_BRANCH_13" 2>/dev/null || true
 CHECK_CLASS_13=$(HOME="$TMPDIR_13" bash "$CHECK_HELPER" --json --repo "owner/repo-org-target" --workflow issue-sync 2>/dev/null \
 	| jq -r 'select(.slug == "owner/repo-org-target") | .classification' \
 	| head -n 1)
-if [[ "$WF_USES_13" == *"ORG/.github/.github/workflows/issue-sync-reusable.yml@1234567890abcdef1234567890abcdef12345678"* ]]; then
+if [[ "$WF_USES_13" == *"ORG/.github/.github/workflows/issue-sync-reusable.yml@${MIRROR_REF_13}"* ]]; then
 	printf '%sPASS%s GH#24520 apply writes configured org reusable target\n' "$GREEN" "$NC"
 	((_PASS++))
 else
@@ -369,6 +388,16 @@ if [[ "$WF_RUNNER_13" == *"ubuntu-latest-arm64"* ]]; then
 else
 	printf '%sFAIL%s GH#24520 runner injection survives configured org target\n' "$RED" "$NC"
 	printf '       got: %s\n' "$WF_RUNNER_13"
+	((_FAIL++))
+fi
+if [[ "$WF_HELPER_REPO_13" == *"ORG/.github"* && \
+	"$WF_HELPER_REF_13" == *"${MIRROR_REF_13}"* && \
+	"$WF_HELPER_SECRET_13" == *'secrets.AIDEVOPS_READ_TOKEN'* ]]; then
+	printf '%sPASS%s GH#27727 helper provenance matches configured reusable target\n' "$GREEN" "$NC"
+	((_PASS++))
+else
+	printf '%sFAIL%s GH#27727 helper provenance matches configured reusable target\n' "$RED" "$NC"
+	printf '       repo: %s ref: %s\n' "$WF_HELPER_REPO_13" "$WF_HELPER_REF_13"
 	((_FAIL++))
 fi
 if [[ "$CHECK_CLASS_13" == "CURRENT/CALLER" ]]; then
@@ -470,6 +499,29 @@ else
 fi
 _assert_exit "GH#27726 refreshed-drift apply exits 0" 0 "$EXIT_15"
 rm -rf "$TMPDIR_15"
+
+# ─── Test 16: GH#27727 — stale/unregistered mirror fails closed ─────────────
+TMPDIR_16="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_16"
+mkdir -p "$TMPDIR_16/repo-stale-mirror/.github/workflows"
+printf '%s\n' "$LEGACY_CONTENT" >"$TMPDIR_16/repo-stale-mirror/.github/workflows/issue-sync.yml"
+mkdir -p "$TMPDIR_16/org-dotgithub/.github/workflows"
+git -C "$TMPDIR_16/org-dotgithub" init -q 2>/dev/null
+git -C "$TMPDIR_16/org-dotgithub" config user.email test@example.com
+git -C "$TMPDIR_16/org-dotgithub" config user.name Test
+git -C "$TMPDIR_16/org-dotgithub" config commit.gpgsign false
+git -C "$TMPDIR_16/org-dotgithub" symbolic-ref HEAD refs/heads/main 2>/dev/null
+printf '%s\n' 'name: stale reusable without provenance inputs' > \
+	"$TMPDIR_16/org-dotgithub/.github/workflows/issue-sync-reusable.yml"
+git -C "$TMPDIR_16/org-dotgithub" add -A >/dev/null
+git -C "$TMPDIR_16/org-dotgithub" commit -q -m "stale mirror contract"
+_write_repos_json "$TMPDIR_16" "{\"workflow_reusable_repo\":\"ORG/.github\",\"initialized_repos\":[{\"path\":\"$TMPDIR_16/repo-stale-mirror\",\"slug\":\"owner/repo-stale-mirror\"},{\"path\":\"$TMPDIR_16/org-dotgithub\",\"slug\":\"ORG/.github\"}]}"
+OUT_16=$(HOME="$TMPDIR_16" bash "$HELPER" --repo owner/repo-stale-mirror --workflow issue-sync 2>&1)
+EXIT_16=$?
+_assert_contains "GH#27727 stale mirror reports compatibility blocker" "$OUT_16" \
+	"configured mirror must be registered and updated at @main before caller sync"
+_assert_exit "GH#27727 stale mirror exits non-zero" 1 "$EXIT_16"
+rm -rf "$TMPDIR_16"
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 printf '\n'

--- a/.agents/templates/workflows/issue-sync-caller.yml
+++ b/.agents/templates/workflows/issue-sync-caller.yml
@@ -78,6 +78,8 @@ jobs:
     secrets:
       SYNC_PAT: ${{ secrets.SYNC_PAT }}
     with:
+      # Keep this equal to the ref on `uses:` so helper code is pinned with the reusable YAML.
+      aidevops_ref: main
       command: ${{ inputs.command || '' }}
       subject_id: ${{ inputs.subject_id || '' }}
       cursor: ${{ inputs.cursor || '' }}

--- a/.agents/templates/workflows/loc-badge-caller.yml
+++ b/.agents/templates/workflows/loc-badge-caller.yml
@@ -27,14 +27,16 @@ on:
 jobs:
   metrics:
     uses: marcusquinn/aidevops/.github/workflows/loc-badge-reusable.yml@main
+    with:
+      # Keep this equal to the ref on `uses:` so helper code is pinned with the reusable YAML.
+      aidevops_ref: main
+      # Optional input overrides — uncomment and edit as needed:
+      # top_n: 8
+      # skip_if_fresh_hours: 24
+      # extra_excludes: |
+      #   fixtures/
+      #   test-data/
     # GH#20976: `secrets: inherit` only works within the same GitHub account/org.
     # Cross-account consumers must pass secrets explicitly.
     secrets:
       SYNC_PAT: ${{ secrets.SYNC_PAT }}
-    # Optional input overrides — uncomment and edit as needed:
-    # with:
-    #   top_n: 8
-    #   skip_if_fresh_hours: 24
-    #   extra_excludes: |
-    #     fixtures/
-    #     test-data/

--- a/.agents/templates/workflows/review-bot-gate-caller.yml
+++ b/.agents/templates/workflows/review-bot-gate-caller.yml
@@ -59,4 +59,7 @@ concurrency:
 jobs:
   gate:
     uses: marcusquinn/aidevops/.github/workflows/review-bot-gate-reusable.yml@main
+    with:
+      # Keep this equal to the ref on `uses:` so helper code is pinned with the reusable YAML.
+      aidevops_ref: main
     secrets: inherit

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -12,6 +12,11 @@ name: Issue Sync (reusable) - Bi-directional TODO.md ↔ GitHub Issues
 on:
   workflow_call:
     inputs:
+      aidevops_repository:
+        description: 'Repository to fetch framework scripts from (defaults to the canonical aidevops repository)'
+        required: false
+        type: string
+        default: 'marcusquinn/aidevops'
       command:
         description: 'Sync command (pass-through from workflow_dispatch inputs)'
         required: false
@@ -43,6 +48,9 @@ on:
         type: string
         default: ''
     secrets:
+      AIDEVOPS_READ_TOKEN:
+        required: false
+        description: 'Optional token with read access to a private configured helper repository'
       SYNC_PAT:
         required: false
         description: 'Fine-grained PAT with Contents:read/write, bypasses branch protection on TODO.md push'
@@ -71,10 +79,11 @@ jobs:
       - name: Checkout coordinator scripts
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: marcusquinn/aidevops
+          repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
+          token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Restore durable coordinator state
         env:
@@ -202,10 +211,11 @@ jobs:
       - name: Checkout aidevops framework scripts
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: marcusquinn/aidevops
+          repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
+          token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         if: steps.check-author.outputs.skip != 'true'
@@ -340,10 +350,11 @@ jobs:
       - name: Checkout aidevops framework scripts
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: marcusquinn/aidevops
+          repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
+          token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         if: steps.check-issue.outputs.sync == 'true'
@@ -409,10 +420,11 @@ jobs:
       - name: Checkout aidevops framework scripts
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: marcusquinn/aidevops
+          repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
+          token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       # t3204: prepend the framework scripts dir to PATH so subsequent gh
       # commands hit the `gh` PATH shim, which auto-injects the signature
@@ -622,10 +634,11 @@ jobs:
       - name: Checkout aidevops framework scripts
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: marcusquinn/aidevops
+          repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
+          token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -713,10 +726,11 @@ jobs:
       - name: Checkout aidevops framework scripts (early — for gh shim)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: marcusquinn/aidevops
+          repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
+          token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup gh shim (auto-inject signature footer on writes)
         run: |
@@ -807,10 +821,11 @@ jobs:
         if: steps.extract.outputs.linked_issues != ''
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: marcusquinn/aidevops
+          repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
+          token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Enable canonical Git guard after trusted checkouts
         run: |

--- a/.github/workflows/loc-badge-reusable.yml
+++ b/.github/workflows/loc-badge-reusable.yml
@@ -18,6 +18,11 @@ name: Repository Metrics (reusable) — generate local README data and badges
 on:
   workflow_call:
     inputs:
+      aidevops_repository:
+        description: 'Repository to fetch the metrics helper from (defaults to the canonical aidevops repository)'
+        required: false
+        type: string
+        default: 'marcusquinn/aidevops'
       aidevops_ref:
         description: 'aidevops ref to fetch the metrics helper from (main, vX.Y.Z, or sha)'
         required: false
@@ -64,6 +69,9 @@ on:
         default: 'ubuntu-latest'
         type: string
     secrets:
+      AIDEVOPS_READ_TOKEN:
+        required: false
+        description: 'Optional token with read access to a private configured helper repository'
       SYNC_PAT:
         required: false
         description: 'Fine-grained PAT with Contents:read/write, bypasses branch protection on default-branch push'
@@ -116,10 +124,11 @@ jobs:
         if: steps.check-author.outputs.skip != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: marcusquinn/aidevops
+          repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
+          token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Build extra-excludes args
         id: excludes

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -6,7 +6,7 @@ name: Review Bot Gate (reusable)
 #
 # The caller declares the triggers (pull_request / pull_request_review / issue_comment)
 # and the concurrency group. All gate logic lives here; the framework helper
-# is fetched at runtime from marcusquinn/aidevops via inputs.aidevops_ref.
+# is fetched at runtime via the coupled aidevops_repository/aidevops_ref inputs.
 #
 # GH#20727: migrated from vendored full-copy (SHA-pinned checkout) to
 # reusable-workflow pattern. Helper is now fetched from marcusquinn/aidevops
@@ -28,6 +28,11 @@ name: Review Bot Gate (reusable)
 on:
   workflow_call:
     inputs:
+      aidevops_repository:
+        description: 'Repository to fetch framework scripts from (defaults to the canonical aidevops repository)'
+        required: false
+        type: string
+        default: 'marcusquinn/aidevops'
       aidevops_ref:
         description: 'aidevops ref to fetch framework scripts from (main, or a version tag like v3.9.0)'
         required: false
@@ -38,6 +43,10 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
+    secrets:
+      AIDEVOPS_READ_TOKEN:
+        required: false
+        description: 'Optional token with read access to a private configured helper repository'
 
 jobs:
   review-bot-gate:
@@ -85,14 +94,15 @@ jobs:
         # GH#20727: replaces the SHA-pinned checkout (path: .aidevops-helper) that
         # silently drifted after helper changes (e.g. the Option A' settlement fix
         # in PR #20572 never propagated to downstream repos pinned to 73b664a).
-        # The ref is controlled by the caller via inputs.aidevops_ref (default: main).
+        # Repository and ref are controlled by the caller provenance inputs.
         # Pin to @v3.x.y for stability; see .agents/reference/reusable-workflows.md.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: marcusquinn/aidevops
+          repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           ref: ${{ inputs.aidevops_ref || 'main' }}
           path: __aidevops
           fetch-depth: 1
+          token: ${{ secrets.AIDEVOPS_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Check for AI review bot activity
         id: check


### PR DESCRIPTION
## Summary

Couple reusable-workflow caller pins to the repository and ref used for runtime helper checkouts; validate and render that provenance for configured mirrors.

## Files Changed

.agents/reference/reusable-workflows.md, .agents/scripts/check-workflows-helper.sh, .agents/scripts/sync-workflows-helper.sh, .agents/scripts/tests/test-check-workflows-classifier.sh, .agents/scripts/tests/test-check-workflows-helper.sh, .agents/scripts/tests/test-loc-badge-reusable-install.sh, .agents/scripts/tests/test-reusable-workflow-caller.sh, .agents/scripts/tests/test-sync-workflows-helper.sh, .agents/templates/workflows/issue-sync-caller.yml, .agents/templates/workflows/loc-badge-caller.yml, .agents/templates/workflows/review-bot-gate-caller.yml, .github/workflows/issue-sync-reusable.yml, .github/workflows/loc-badge-reusable.yml, .github/workflows/review-bot-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck and actionlint passed; focused workflow checker/sync/caller tests passed; workflow cascade and lint-helper tests passed; linters-local.sh passed required gates.

Resolves #27727


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.119 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 48m and 1,129,304 tokens on this with the user in an interactive session.