### PR TITLE
GH#27742: prevent duplicate OpenCode startup toasts

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -106,9 +106,9 @@ const FALLBACK_WINDOW_MS = 30000;
  * it, including empty-output and failure paths.
  *
  * @param {{ scriptsDir: string, client: any, cacheFile: string, lockDir: string,
- *   execGreeting: Function, maintenanceNoticeFn: Function }} options
+ *   execGreeting: Function, maintenanceNoticeFn: Function, cachedFallback: object|null }} options
  */
-function runGreetingAsync({ scriptsDir, client, cacheFile, lockDir, lockToken, execGreeting, maintenanceNoticeFn }) {
+function runGreetingAsync({ scriptsDir, client, cacheFile, lockDir, lockToken, execGreeting, maintenanceNoticeFn, cachedFallback }) {
   const script = join(scriptsDir, "aidevops-update-check.sh");
   Promise.resolve()
     .then(() => execGreeting(`bash ${JSON.stringify(script)} --interactive`, {
@@ -118,8 +118,9 @@ function runGreetingAsync({ scriptsDir, client, cacheFile, lockDir, lockToken, e
       const output = stdout ? stdout.trim() : "";
       if (!output) {
         if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
-          console.error("[aidevops] greeting: update-check returned empty, skipping toasts");
+          console.error("[aidevops] greeting: update-check returned empty, using cached fallback");
         }
+        emitCachedGreeting(client, cachedFallback);
         return;
       }
 
@@ -147,6 +148,7 @@ function runGreetingAsync({ scriptsDir, client, cacheFile, lockDir, lockToken, e
       if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
         console.error(`[aidevops] greeting: update-check failed: ${err.message}`);
       }
+      emitCachedGreeting(client, cachedFallback);
     })
     .finally(() => {
       releaseRefreshLock(lockDir, lockToken);
@@ -274,11 +276,11 @@ function releaseRefreshLock(lockDir, lockToken) {
   }
 }
 
-function observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now }) {
+function observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now, minimumMtimeMs }) {
   const deadline = now() + lockStaleMs;
   const poll = () => {
     const cached = readGreetingCache(cacheFile);
-    if (cached) {
+    if (cached && cached.mtimeMs > minimumMtimeMs) {
       emitCachedGreeting(client, cached);
       return;
     }
@@ -289,7 +291,7 @@ function observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now }) 
       // The owner may publish the cache and remove its lock between our cache
       // read and lock stat. Re-check once so that handoff still emits it.
       const finalCached = readGreetingCache(cacheFile);
-      if (finalCached) {
+      if (finalCached && finalCached.mtimeMs > minimumMtimeMs) {
         emitCachedGreeting(client, finalCached);
         return;
       }
@@ -436,13 +438,19 @@ function refreshGreetingIfStale({ cached, now, refreshTtlMs, lockDir, lockStaleM
       lockToken,
       execGreeting,
       maintenanceNoticeFn,
+      cachedFallback: cached,
     });
     return;
   }
 
-  if (!cached) {
-    observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now });
-  }
+  observeSharedRefresh({
+    cacheFile,
+    lockDir,
+    lockStaleMs,
+    client,
+    now,
+    minimumMtimeMs: cached?.mtimeMs ?? Number.NEGATIVE_INFINITY,
+  });
   if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
     console.error("[aidevops] greeting: refresh already running in another process");
   }
@@ -505,10 +513,13 @@ export function createGreetingHandler({
       console.error(`[aidevops] greeting: triggered (mode=${mode}, type=${event.type})`);
     }
 
-    // Serve the last complete cache synchronously. This keeps the event hook
-    // independent of refresh latency even when this process becomes lock owner.
+    // Serve a fresh cache synchronously. A stale cache is retained only as a
+    // refresh-failure fallback; emitting it here and the refreshed value later
+    // would display two startup toasts for one session.
     const cached = readGreetingCache(cacheFile);
-    emitCachedGreeting(client, cached);
+    if (cached && now() - cached.mtimeMs <= refreshTtlMs) {
+      emitCachedGreeting(client, cached);
+    }
 
     refreshGreetingIfStale({
       cached,

--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
@@ -84,11 +84,11 @@ test("eight concurrent plugin handlers share one stale-cache refresh", async (t)
   await Promise.all(handlers.map((handler) => handler({ event: { type: "session.created" } })));
 
   assert.equal(spawnCount, 1);
-  assert.ok(f.clients.every((toasts) => toasts.length === 1));
-  assert.ok(f.clients.every((toasts) => toasts[0].message.includes(OLD_GREETING)));
+  assert.ok(f.clients.every((toasts) => toasts.length === 0));
 
   resolveRefresh({ stdout: NEW_GREETING });
-  await waitFor(() => cacheEquals(f, NEW_GREETING));
+  await waitFor(() => cacheEquals(f, NEW_GREETING) && f.clients.every((toasts) => toasts.length === 1));
+  assert.ok(f.clients.every((toasts) => toasts[0].message.includes(NEW_GREETING)));
 });
 
 test("fresh cache emits immediately without spawning a refresh", async (t) => {
@@ -292,6 +292,22 @@ test("failed refresh preserves the last valid cache and releases its lock", asyn
   await waitFor(() => !readdirSync(f.cacheDir).includes("session-greeting-refresh.lock"));
 
   assert.equal(readFileSync(f.cacheFile, "utf8").trim(), OLD_GREETING);
+  assert.equal(f.clients[0].length, 1);
+  assert.match(f.clients[0][0].message, /aidevops v1\.0\.0/);
+});
+
+test("empty refresh output falls back to one cached greeting", async (t) => {
+  const f = fixture();
+  t.after(() => f.cleanup());
+  writeFileSync(f.cacheFile, `${OLD_GREETING}\n`);
+  utimesSync(f.cacheFile, new Date(0), new Date(0));
+  const handler = createGreetingHandler(handlerOptions(f, f.client(), async () => ({ stdout: "" })));
+
+  await handler({ event: { type: "session.created" } });
+  await waitFor(() => !readdirSync(f.cacheDir).includes("session-greeting-refresh.lock"));
+
+  assert.equal(f.clients[0].length, 1);
+  assert.match(f.clients[0][0].message, /aidevops v1\.0\.0/);
 });
 
 test("successful refresh atomically replaces the cache without temp files", async (t) => {


### PR DESCRIPTION
## Summary

- emit a fresh cached greeting immediately, but do not emit stale cache before refresh
- retain stale cache as the sole fallback when refresh fails or returns empty output
- make concurrent refresh followers wait for cache content newer than the stale value
- add regression coverage proving each stale-cache handler receives exactly one refreshed toast

## Root cause

The cache single-flight lock deduplicated update-check subprocesses, not UI delivery. The handler emitted stale cached content synchronously and the refresh owner emitted the refreshed content again, producing two session-start toasts whenever the 15-minute cache TTL had expired.

## Testing

- `npm test` in `.agents/plugins/opencode-aidevops` — 397 passed
- `node --test .agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs` — 12 passed after rebase
- `.agents/scripts/linters-local.sh` — passed
- `node --check .agents/plugins/opencode-aidevops/greeting.mjs`
- `git diff --check`

## Runtime Testing

Self-assessed: exercising the real TUI requires loading the changed plugin in a new OpenCode process. The plugin-level suite executes the same `client.tui.showToast()` boundary with fresh, stale, failed, empty, concurrent, and cross-process cache paths.

## Decisions

Preserve immediate display only for cache entries inside the existing TTL. For stale entries, prefer one current toast after asynchronous refresh; if that refresh cannot produce output, display the stale cache once rather than dropping startup status.

Resolves #27742

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.119 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 5m and 113,598 tokens on this with the user in an interactive session.
