### PR TITLE
GH#27740: scope release postflight to release-owned evidence

### DIFF
--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -156,6 +156,35 @@ get_scoped_workflow_runs() {
 	return 0
 }
 
+evaluate_scoped_workflow_runs() {
+	local scoped_runs="$1"
+	local unrelated_count release_runs pending_count failed_count
+
+	unrelated_count=$(echo "$scoped_runs" | jq '.unrelated_runs | length')
+	if [[ "$unrelated_count" -gt 0 ]]; then
+		count_warning "$unrelated_count unrelated exact-SHA issue/comment workflow run(s) excluded from release evidence"
+		echo "$scoped_runs" | jq -r '.unrelated_runs[] | "  - Unrelated: \(.workflowName // .name) (event: \(.event), conclusion: \(.conclusion // "pending"))"'
+	fi
+
+	release_runs=$(echo "$scoped_runs" | jq -c '.release_runs')
+	pending_count=$(echo "$release_runs" | jq '[.[] | select(.status != "completed")] | length')
+	if [[ "$pending_count" -gt 0 ]]; then
+		count_failure "$pending_count required release-owned workflow(s) remain non-terminal"
+		echo "$release_runs" | jq -r '.[] | select(.status != "completed") | "  - Required release check pending: \(.workflowName // .name): \(.status)"'
+		return 1
+	fi
+
+	failed_count=$(echo "$release_runs" | jq '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length')
+	if [[ "$failed_count" -gt 0 ]]; then
+		count_failure "$failed_count required release-owned workflow(s) failed"
+		echo "$release_runs" | jq -r '.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | "  - Required release check failed: \(.workflowName // .name): \(.conclusion)"'
+		return 1
+	fi
+
+	count_success "All exact-SHA release-owned workflows passed"
+	return 0
+}
+
 # Check GitHub Actions CI/CD status
 check_cicd_status() {
 	print_section "CI/CD Pipeline Status"
@@ -189,31 +218,8 @@ check_cicd_status() {
 	fi
 
 	if [[ -n "$POSTFLIGHT_COMMIT_SHA" ]]; then
-		local unrelated_count
-		unrelated_count=$(echo "$scoped_runs" | jq '.unrelated_runs | length')
-		if [[ "$unrelated_count" -gt 0 ]]; then
-			count_warning "$unrelated_count unrelated exact-SHA issue/comment workflow run(s) excluded from release evidence"
-			echo "$scoped_runs" | jq -r '.unrelated_runs[] | "  - Unrelated: \(.workflowName // .name) (event: \(.event), conclusion: \(.conclusion // "pending"))"'
-		fi
-
-		local release_runs pending_count failed_count
-		release_runs=$(echo "$scoped_runs" | jq -c '.release_runs')
-		pending_count=$(echo "$release_runs" | jq '[.[] | select(.status != "completed")] | length')
-		if [[ "$pending_count" -gt 0 ]]; then
-			count_failure "$pending_count required release-owned workflow(s) remain non-terminal"
-			echo "$release_runs" | jq -r '.[] | select(.status != "completed") | "  - Required release check pending: \(.workflowName // .name): \(.status)"'
-			return 1
-		fi
-
-		failed_count=$(echo "$release_runs" | jq '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length')
-		if [[ "$failed_count" -gt 0 ]]; then
-			count_failure "$failed_count required release-owned workflow(s) failed"
-			echo "$release_runs" | jq -r '.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | "  - Required release check failed: \(.workflowName // .name): \(.conclusion)"'
-			return 1
-		fi
-
-		count_success "All exact-SHA release-owned workflows passed"
-		return 0
+		evaluate_scoped_workflow_runs "$scoped_runs"
+		return $?
 	fi
 
 	local run_id status conclusion name

--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -130,6 +130,32 @@ get_repo_info() {
 	return 1
 }
 
+# Return exact-SHA workflow runs split into release-owned and unrelated events.
+get_scoped_workflow_runs() {
+	local repo="$1"
+	local commit_sha="$2"
+	local runs
+
+	runs=$(gh run list --repo "$repo" --commit "$commit_sha" --limit 100 \
+		--json databaseId,status,conclusion,name,event,headSha,updatedAt,workflowName 2>/dev/null || echo "")
+	if [[ -z "$runs" || "$runs" == "[]" ]]; then
+		echo ""
+		return 1
+	fi
+
+	echo "$runs" | jq -c --arg release_sha "$commit_sha" '
+		def run_name: (.workflowName // .name // "unknown");
+		def latest_by_workflow:
+			sort_by(run_name)
+			| group_by(run_name)
+			| map(max_by([(.updatedAt // ""), (.databaseId // 0)]));
+		{
+			release_runs: ([.[] | select(.headSha == $release_sha) | select(.event == "push" or .event == "release" or .event == "workflow_dispatch")] | latest_by_workflow),
+			unrelated_runs: [.[] | select(.headSha == $release_sha) | select((.event == "push" or .event == "release" or .event == "workflow_dispatch") | not)]
+		}'
+	return 0
+}
+
 # Check GitHub Actions CI/CD status
 check_cicd_status() {
 	print_section "CI/CD Pipeline Status"
@@ -148,10 +174,11 @@ check_cicd_status() {
 
 	print_info "Repository: $repo"
 
-	# Get the latest workflow run for the exact release commit when supplied.
-	local latest_run
+	# Get release-owned workflow runs for the exact release commit when supplied.
+	local scoped_runs latest_run
 	if [[ -n "$POSTFLIGHT_COMMIT_SHA" ]]; then
-		latest_run=$(gh run list --repo "$repo" --commit "$POSTFLIGHT_COMMIT_SHA" --limit=1 --json databaseId,status,conclusion,name 2>/dev/null || echo "")
+		scoped_runs=$(get_scoped_workflow_runs "$repo" "$POSTFLIGHT_COMMIT_SHA" || echo "")
+		latest_run=$(echo "$scoped_runs" | jq -c '.release_runs // []' 2>/dev/null || echo "")
 	else
 		latest_run=$(gh run list --repo "$repo" --limit=1 --json databaseId,status,conclusion,name 2>/dev/null || echo "")
 	fi
@@ -159,6 +186,34 @@ check_cicd_status() {
 	if [[ -z "$latest_run" || "$latest_run" == "[]" ]]; then
 		count_failure "No workflow runs found for release evidence"
 		return 1
+	fi
+
+	if [[ -n "$POSTFLIGHT_COMMIT_SHA" ]]; then
+		local unrelated_count
+		unrelated_count=$(echo "$scoped_runs" | jq '.unrelated_runs | length')
+		if [[ "$unrelated_count" -gt 0 ]]; then
+			count_warning "$unrelated_count unrelated exact-SHA issue/comment workflow run(s) excluded from release evidence"
+			echo "$scoped_runs" | jq -r '.unrelated_runs[] | "  - Unrelated: \(.workflowName // .name) (event: \(.event), conclusion: \(.conclusion // "pending"))"'
+		fi
+
+		local release_runs pending_count failed_count
+		release_runs=$(echo "$scoped_runs" | jq -c '.release_runs')
+		pending_count=$(echo "$release_runs" | jq '[.[] | select(.status != "completed")] | length')
+		if [[ "$pending_count" -gt 0 ]]; then
+			count_failure "$pending_count required release-owned workflow(s) remain non-terminal"
+			echo "$release_runs" | jq -r '.[] | select(.status != "completed") | "  - Required release check pending: \(.workflowName // .name): \(.status)"'
+			return 1
+		fi
+
+		failed_count=$(echo "$release_runs" | jq '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length')
+		if [[ "$failed_count" -gt 0 ]]; then
+			count_failure "$failed_count required release-owned workflow(s) failed"
+			echo "$release_runs" | jq -r '.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | "  - Required release check failed: \(.workflowName // .name): \(.conclusion)"'
+			return 1
+		fi
+
+		count_success "All exact-SHA release-owned workflows passed"
+		return 0
 	fi
 
 	local run_id status conclusion name
@@ -213,11 +268,11 @@ check_cicd_status() {
 		count_warning "CI/CD pipeline conclusion: $conclusion"
 	fi
 
-	# Check all recent workflows
-	print_info "Checking all recent workflows..."
+	# Check every effective release-owned workflow, not just whichever run is newest.
+	print_info "Checking all release-owned workflows..."
 	local all_runs
 	if [[ -n "$POSTFLIGHT_COMMIT_SHA" ]]; then
-		all_runs=$(gh run list --repo "$repo" --commit "$POSTFLIGHT_COMMIT_SHA" --limit=5 --json name,conclusion,status 2>/dev/null || echo "[]")
+		all_runs=$(echo "$scoped_runs" | jq -c '.release_runs')
 	else
 		all_runs=$(gh run list --repo "$repo" --limit=5 --json name,conclusion,status 2>/dev/null || echo "[]")
 	fi
@@ -226,8 +281,9 @@ check_cicd_status() {
 	failed_count=$(echo "$all_runs" | jq '[.[] | select(.conclusion == "failure")] | length')
 
 	if [[ "$failed_count" -gt 0 ]]; then
-		print_warning "$failed_count workflow(s) failed recently"
-		echo "$all_runs" | jq -r '.[] | select(.conclusion == "failure") | "  - \(.name): \(.conclusion)"'
+		count_failure "$failed_count required release-owned workflow(s) failed"
+		echo "$all_runs" | jq -r '.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | "  - Required release check failed: \(.workflowName // .name): \(.conclusion)"'
+		return 1
 	fi
 
 	return 0

--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -185,6 +185,21 @@ evaluate_scoped_workflow_runs() {
 	return 0
 }
 
+evaluate_recent_workflow_runs() {
+	local repo="$1"
+	local all_runs failed_count
+
+	print_info "Checking all recent workflows..."
+	all_runs=$(gh run list --repo "$repo" --limit=5 --json name,conclusion,status 2>/dev/null || echo "[]")
+	failed_count=$(echo "$all_runs" | jq '[.[] | select(.conclusion == "failure")] | length')
+	if [[ "$failed_count" -gt 0 ]]; then
+		count_failure "$failed_count workflow(s) failed recently"
+		echo "$all_runs" | jq -r '.[] | select(.conclusion == "failure") | "  - \(.name): \(.conclusion)"'
+		return 1
+	fi
+	return 0
+}
+
 # Check GitHub Actions CI/CD status
 check_cicd_status() {
 	print_section "CI/CD Pipeline Status"
@@ -274,25 +289,8 @@ check_cicd_status() {
 		count_warning "CI/CD pipeline conclusion: $conclusion"
 	fi
 
-	# Check every effective release-owned workflow, not just whichever run is newest.
-	print_info "Checking all release-owned workflows..."
-	local all_runs
-	if [[ -n "$POSTFLIGHT_COMMIT_SHA" ]]; then
-		all_runs=$(echo "$scoped_runs" | jq -c '.release_runs')
-	else
-		all_runs=$(gh run list --repo "$repo" --limit=5 --json name,conclusion,status 2>/dev/null || echo "[]")
-	fi
-
-	local failed_count
-	failed_count=$(echo "$all_runs" | jq '[.[] | select(.conclusion == "failure")] | length')
-
-	if [[ "$failed_count" -gt 0 ]]; then
-		count_failure "$failed_count required release-owned workflow(s) failed"
-		echo "$all_runs" | jq -r '.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | "  - Required release check failed: \(.workflowName // .name): \(.conclusion)"'
-		return 1
-	fi
-
-	return 0
+	evaluate_recent_workflow_runs "$repo"
+	return $?
 }
 
 # Check SonarCloud quality gate

--- a/.agents/scripts/tests/test-github-release-helper-idempotent.sh
+++ b/.agents/scripts/tests/test-github-release-helper-idempotent.sh
@@ -53,10 +53,22 @@ fi
 
 if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
 	if [[ "${FAKE_RELEASE_EXISTS:-0}" == "1" || -f "$marker_file" ]]; then
-		printf 'release %s exists\n' "${3:-}"
+		printf '%s\n' "${3:-}"
 		exit 0
 	fi
 	exit 1
+fi
+
+if [[ "${1:-}" == "release" && "${2:-}" == "edit" ]]; then
+	if [[ "${FAKE_EDIT_RATE_LIMIT:-0}" == "1" ]]; then
+		printf 'HTTP 403: API rate limit exceeded\n' >&2
+		exit 1
+	fi
+	if [[ "${FAKE_EDIT_FAILURE:-0}" == "1" ]]; then
+		printf 'HTTP 500: metadata update failed\n' >&2
+		exit 1
+	fi
+	exit 0
 fi
 
 if [[ "${1:-}" == "release" && "${2:-}" == "create" ]]; then
@@ -109,6 +121,32 @@ if grep -q 'release view v1.2.4 --repo marcusquinn/aidevops' "$FAKE_GH_LOG" 2>/d
 	print_result 'duplicate create race verifies release after create failure' 0
 else
 	print_result 'duplicate create race verifies release after create failure' 1 'missing expected gh calls'
+fi
+
+NOTES_FILE="${TEST_ROOT}/notes.md"
+printf 'release notes\n' >"$NOTES_FILE"
+PUBLISH_SCRIPT="${TEST_SCRIPTS_DIR}/../../.github/scripts/publish-github-release.sh"
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_RELEASE_EXISTS=1
+export FAKE_EDIT_RATE_LIMIT=1
+rc=0
+output=$("$PUBLISH_SCRIPT" v1.2.4 v1.2.4 "$NOTES_FILE" 2>&1) || rc=$?
+if [[ "$rc" -eq 0 && "$output" == *"publication receipt verified"* && "$output" == *"metadata reconciliation deferred after API rate limit"* ]]; then
+	print_result 'rate-limited metadata edit preserves verified publication' 0
+else
+	print_result 'rate-limited metadata edit preserves verified publication' 1 "rc=$rc output=$output"
+fi
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_EDIT_RATE_LIMIT=0
+export FAKE_EDIT_FAILURE=1
+rc=0
+output=$("$PUBLISH_SCRIPT" v1.2.4 v1.2.4 "$NOTES_FILE" 2>&1) || rc=$?
+if [[ "$rc" -eq 1 && "$output" == *"metadata reconciliation failed"* ]]; then
+	print_result 'non-rate-limit metadata failure remains blocking' 0
+else
+	print_result 'non-rate-limit metadata failure remains blocking' 1 "rc=$rc output=$output"
 fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-github-release-helper-idempotent.sh
+++ b/.agents/scripts/tests/test-github-release-helper-idempotent.sh
@@ -53,7 +53,11 @@ fi
 
 if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
 	if [[ "${FAKE_RELEASE_EXISTS:-0}" == "1" || -f "$marker_file" ]]; then
-		printf '%s\n' "${3:-}"
+		if [[ "$*" == *"--json tagName,isDraft"* ]]; then
+			printf '{"tagName":"%s","isDraft":false}\n' "${3:-}"
+		else
+			printf '%s\n' "${3:-}"
+		fi
 		exit 0
 	fi
 	exit 1

--- a/.agents/scripts/tests/test-postflight-release-owned-checks.sh
+++ b/.agents/scripts/tests/test-postflight-release-owned-checks.sh
@@ -60,3 +60,31 @@ grep -Fq -- '--slurpfile release_run_documents' "${REPO_ROOT}/.github/workflows/
 grep -Fq 'non-required advisory check(s) remain non-terminal' "${REPO_ROOT}/.github/workflows/postflight.yml"
 
 printf 'PASS: postflight keeps paginated exact-SHA classification and advisory warnings\n'
+
+STUB_DIR=$(mktemp -d)
+trap 'rm -rf "$STUB_DIR"' EXIT
+cat >"${STUB_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+	exit 0
+fi
+if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
+	printf '%s\n' "${POSTFLIGHT_RUNS_JSON:?}"
+	exit 0
+fi
+exit 1
+EOF
+chmod +x "${STUB_DIR}/gh"
+
+SUCCESS_RUNS='[{"databaseId":3001,"name":"Issue Sync","workflowName":"Issue Sync","event":"issues","headSha":"release-sha","status":"completed","conclusion":"failure","updatedAt":"2026-07-15T00:10:00Z"},{"databaseId":3002,"name":"Framework Validation","workflowName":"Framework Validation","event":"push","headSha":"release-sha","status":"completed","conclusion":"success","updatedAt":"2026-07-15T00:09:00Z"}]'
+SUCCESS_OUTPUT=$(PATH="${STUB_DIR}:$PATH" POSTFLIGHT_RUNS_JSON="$SUCCESS_RUNS" bash "${REPO_ROOT}/.agents/scripts/postflight-check.sh" --ci-only --sha release-sha 2>&1)
+grep -Fq 'Unrelated: Issue Sync (event: issues, conclusion: failure)' <<<"$SUCCESS_OUTPUT"
+grep -Fq 'POSTFLIGHT VERIFICATION PASSED WITH WARNINGS' <<<"$SUCCESS_OUTPUT"
+printf 'PASS: newer unrelated issues event is reported without replacing release evidence\n'
+
+FAILED_RUNS='[{"databaseId":3003,"name":"Qlty Code Quality","workflowName":"Qlty Code Quality","event":"push","headSha":"release-sha","status":"completed","conclusion":"failure","updatedAt":"2026-07-15T00:11:00Z"}]'
+FAILED_STATUS=0
+FAILED_OUTPUT=$(PATH="${STUB_DIR}:$PATH" POSTFLIGHT_RUNS_JSON="$FAILED_RUNS" bash "${REPO_ROOT}/.agents/scripts/postflight-check.sh" --ci-only --sha release-sha 2>&1) || FAILED_STATUS=$?
+[[ "$FAILED_STATUS" -eq 1 ]]
+grep -Fq 'Required release check failed: Qlty Code Quality: failure' <<<"$FAILED_OUTPUT"
+printf 'PASS: genuine failed Qlty release check remains explicitly blocking\n'

--- a/.agents/scripts/tests/test-postflight-sonarcloud-gate.sh
+++ b/.agents/scripts/tests/test-postflight-sonarcloud-gate.sh
@@ -25,7 +25,7 @@ if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
 	if [[ "$*" == *"--limit=1"* || "$*" == *"--limit 1"* ]]; then
 		printf '[{"databaseId":1,"status":"completed","conclusion":"%s","name":"Stub CI"}]\n' "${CI_STUB_CONCLUSION:-success}"
 	else
-		printf '[{"name":"Stub CI","status":"completed","conclusion":"%s"}]\n' "${CI_STUB_CONCLUSION:-success}"
+		printf '[{"databaseId":1,"name":"Stub CI","workflowName":"Stub CI","event":"push","headSha":"release-sha","updatedAt":"2026-07-15T00:00:00Z","status":"completed","conclusion":"%s"}]\n' "${CI_STUB_CONCLUSION:-success}"
 	fi
 	exit 0
 fi

--- a/.github/scripts/publish-github-release.sh
+++ b/.github/scripts/publish-github-release.sh
@@ -10,8 +10,9 @@ notes_file="${3:?release notes file is required}"
 
 verify_publication() {
 	local published_tag
-	published_tag=$(gh release view "$tag" --json tagName,isDraft \
-		--jq 'select(.tagName == "'"$tag"'" and .isDraft == false) | .tagName' 2>/dev/null || true)
+	published_tag=$(gh release view "$tag" --json tagName,isDraft 2>/dev/null \
+		| jq -r --arg expected_tag "$tag" 'select(.tagName == $expected_tag and .isDraft == false) | .tagName' \
+		|| true)
 	if [[ "$published_tag" == "$tag" ]]; then
 		return 0
 	fi

--- a/.github/scripts/publish-github-release.sh
+++ b/.github/scripts/publish-github-release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+tag="${1:?release tag is required}"
+title="${2:?release title is required}"
+notes_file="${3:?release notes file is required}"
+
+verify_publication() {
+	local published_tag
+	published_tag=$(gh release view "$tag" --json tagName,isDraft \
+		--jq 'select(.tagName == "'"$tag"'" and .isDraft == false) | .tagName' 2>/dev/null || true)
+	if [[ "$published_tag" == "$tag" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+reconcile_metadata() {
+	local error_file
+	error_file=$(mktemp)
+	if gh release edit "$tag" --title "$title" --notes-file "$notes_file" 2>"$error_file"; then
+		printf 'Release %s metadata reconciled\n' "$tag"
+		rm -f "$error_file"
+		return 0
+	fi
+
+	if grep -qiE 'HTTP 403|rate limit' "$error_file" && verify_publication; then
+		printf '::warning::Release %s is published; metadata reconciliation deferred after API rate limit\n' "$tag"
+		rm -f "$error_file"
+		return 0
+	fi
+
+	printf '::error::Release %s metadata reconciliation failed\n' "$tag" >&2
+	cat "$error_file" >&2
+	rm -f "$error_file"
+	return 1
+}
+
+main() {
+	if verify_publication; then
+		printf 'Release %s publication receipt verified; reconciling metadata\n' "$tag"
+		reconcile_metadata
+		return $?
+	fi
+
+	if gh release create "$tag" --title "$title" --notes-file "$notes_file"; then
+		if verify_publication; then
+			printf 'Release %s created and publication receipt verified\n' "$tag"
+			return 0
+		fi
+		printf '::error::Release %s creation returned success without a publication receipt\n' "$tag" >&2
+		return 1
+	fi
+
+	if verify_publication; then
+		printf 'Release %s appeared after create failed; reconciling metadata\n' "$tag"
+		reconcile_metadata
+		return $?
+	fi
+
+	printf '::error::Release %s is not published after create failed\n' "$tag" >&2
+	return 1
+}
+
+main "$@"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,32 +25,15 @@ jobs:
             EXTRA=$(git log --oneline "$PREV_TAG..v$VERSION" -- | grep -v 'chore: claim t' | head -10)
             BODY="$BODY"$'\n\n### Commits since CHANGELOG generation\n'"$EXTRA"
           fi
-          {
-            echo "body<<DELIM"
-            echo "$BODY"
-            echo "DELIM"
-          } >> "$GITHUB_OUTPUT"
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          printf '%s\n' "$BODY" > "$NOTES_FILE"
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            echo "Release $GITHUB_REF_NAME already exists; updating metadata"
-            gh release edit "$GITHUB_REF_NAME" \
-              --title "$GITHUB_REF_NAME" \
-              --notes "${{ steps.changelog.outputs.body }}"
-          else
-            if gh release create "$GITHUB_REF_NAME" \
-              --title "$GITHUB_REF_NAME" \
-              --notes "${{ steps.changelog.outputs.body }}"; then
-              echo "Release $GITHUB_REF_NAME created"
-            elif gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-              echo "Release $GITHUB_REF_NAME appeared after create failed; updating metadata"
-              gh release edit "$GITHUB_REF_NAME" \
-                --title "$GITHUB_REF_NAME" \
-                --notes "${{ steps.changelog.outputs.body }}"
-            else
-              exit 1
-            fi
-          fi
+          .github/scripts/publish-github-release.sh \
+            "$GITHUB_REF_NAME" \
+            "$GITHUB_REF_NAME" \
+            "${{ steps.changelog.outputs.notes_file }}"


### PR DESCRIPTION
## Summary

Filter exact-SHA postflight checks to release-owned workflow events and preserve verified release publication when metadata reconciliation is rate-limited.

## Files Changed

.agents/scripts/postflight-check.sh, .agents/scripts/tests/test-github-release-helper-idempotent.sh, .agents/scripts/tests/test-postflight-release-owned-checks.sh, .agents/scripts/tests/test-postflight-sonarcloud-gate.sh, .github/scripts/publish-github-release.sh, .github/workflows/release.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted postflight and release idempotency tests pass; ShellCheck passes. Broad secret scan remains in progress.

Resolves #27740


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.119 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 8m and 93,359 tokens on this as a headless worker.