### PR TITLE
GH#27731: harden maintainer gate flag regression check

### DIFF
--- a/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
@@ -195,19 +195,13 @@ test_pr_approval_paths() {
 }
 
 test_slurp_and_jq_are_separate() {
-	if python3 - "$WORKFLOW_FILE" <<'PY'
-import re
-import sys
-from pathlib import Path
-
-text = Path(sys.argv[1]).read_text()
-combined = re.findall(r"gh api[^\n]*\\\n(?:[^\n]*\\\n)*?[^\n]*--slurp[^\n]*\\\n[^\n]*--jq", text)
-raise SystemExit(1 if combined else 0)
-PY
-	then
-		print_result "maintainer gate separates gh --slurp from jq" 0
-	else
+	if sed -e :a -e '/\\$/N; s/\\\n[[:space:]]*/ /; ta' "$WORKFLOW_FILE" |
+		grep 'gh[[:space:]][[:space:]]*api' |
+		grep -F -- '--slurp' |
+		grep -Fq -- '--jq'; then
 		print_result "maintainer gate separates gh --slurp from jq" 1 "unsupported gh flag combination remains"
+	else
+		print_result "maintainer gate separates gh --slurp from jq" 0
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
@@ -194,11 +194,31 @@ test_pr_approval_paths() {
 	return 0
 }
 
-test_slurp_and_jq_are_separate() {
-	if sed -e :a -e '/\\$/N; s/\\\n[[:space:]]*/ /; ta' "$WORKFLOW_FILE" |
+has_combined_slurp_and_jq() {
+	local workflow_file="$1"
+	if sed -e :a -e '/\\$/N; s/\\\n[[:space:]]*/ /; ta' "$workflow_file" |
 		grep 'gh[[:space:]][[:space:]]*api' |
 		grep -F -- '--slurp' |
 		grep -Fq -- '--jq'; then
+		return 0
+	fi
+	return 1
+}
+
+test_slurp_and_jq_are_separate() {
+	local combined_fixture="${TEST_ROOT}/combined-flags.sh"
+	cat >"$combined_fixture" <<'EOF'
+gh api --jq '.[]' \
+  --paginate \
+  --slurp repos/example/project/issues/1/comments
+EOF
+	if has_combined_slurp_and_jq "$combined_fixture"; then
+		print_result "slurp/jq detector handles reordered multiline flags" 0
+	else
+		print_result "slurp/jq detector handles reordered multiline flags" 1 "forbidden fixture was not detected"
+	fi
+
+	if has_combined_slurp_and_jq "$WORKFLOW_FILE"; then
 		print_result "maintainer gate separates gh --slurp from jq" 1 "unsupported gh flag combination remains"
 	else
 		print_result "maintainer gate separates gh --slurp from jq" 0


### PR DESCRIPTION
## Summary

Replace the order-sensitive Python regex with a logical-command shell detector and add a reordered multiline fixture proving forbidden flag combinations are caught.

## Files Changed

- `.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh`

## Runtime Testing

- `shellcheck .agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh`
- `.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh`
- `.agents/scripts/linters-local.sh`

Resolves #27731

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18
