### PR TITLE
GH#27740: scope release postflight evidence

### DIFF
--- a/.agents/scripts/github-release-helper.sh
+++ b/.agents/scripts/github-release-helper.sh
@@ -16,6 +16,7 @@
 #   --generate-notes     Auto-generate notes from commits (default when no notes given)
 #   --draft              Create as draft (create only; draft command always sets this)
 #   --prerelease         Mark as pre-release
+#   --reconcile-existing Update metadata when publication already exists
 #   --title <text>       Override release title (default: <version>)
 #   --repo <slug>        Target repo (default: current repo from gh)
 #   --tag <tag>          Override tag name (default: v<version> or <version> if already prefixed)
@@ -162,6 +163,7 @@ _create_flag_notes_file=""
 _create_flag_generate_notes=false
 _create_flag_draft=false
 _create_flag_prerelease=false
+_create_flag_reconcile_existing=false
 _create_already_exists=false
 # Resolved values (set by _resolve_create_inputs)
 _create_repo=""
@@ -225,6 +227,10 @@ _parse_create_args() {
 			_create_flag_prerelease=true
 			shift
 			;;
+		--reconcile-existing)
+			_create_flag_reconcile_existing=true
+			shift
+			;;
 		-*)
 			print_error "Unknown option: $1"
 			return 1
@@ -270,10 +276,44 @@ _resolve_create_inputs() {
 	return 0
 }
 
+# Reconcile optional metadata without invalidating an already verified release.
+_reconcile_release_metadata() {
+	local gh_args=("$_create_tag" "--repo" "$_create_repo" "--title" "$_create_title")
+	local attempt=1 output=""
+	if [[ -n "$_create_flag_notes_file" ]]; then
+		gh_args+=("--notes-file" "$_create_flag_notes_file")
+	elif [[ -n "$_create_flag_notes" ]]; then
+		gh_args+=("--notes" "$_create_flag_notes")
+	fi
+
+	while [[ "$attempt" -le 3 ]]; do
+		if output=$(gh release edit "${gh_args[@]}" 2>&1); then
+			print_success "Release '$_create_tag' metadata reconciled"
+			return 0
+		fi
+		print_warning "Release metadata reconciliation attempt $attempt/3 failed: $output"
+		if [[ "$output" == *"rate limit"* || "$output" == *"HTTP 403"* ]]; then
+			break
+		fi
+		((attempt++))
+	done
+
+	if release_exists "$_create_repo" "$_create_tag"; then
+		print_warning "Release '$_create_tag' publication is verified; metadata reconciliation is deferred"
+		return 0
+	fi
+	print_error "Release '$_create_tag' could not be verified after metadata reconciliation failed"
+	return 1
+}
+
 # Build gh CLI arguments and execute the release creation.
 # Reads _create_* variables set by earlier phases.
 _execute_release_create() {
 	if [[ "$_create_already_exists" == true ]]; then
+		if [[ "$_create_flag_reconcile_existing" == true ]]; then
+			_reconcile_release_metadata
+			return $?
+		fi
 		return 0
 	fi
 
@@ -308,6 +348,10 @@ _execute_release_create() {
 	else
 		if release_exists "$_create_repo" "$_create_tag"; then
 			print_warning "Release '$_create_tag' now exists on $_create_repo — treating duplicate create as already complete"
+			if [[ "$_create_flag_reconcile_existing" == true ]]; then
+				_reconcile_release_metadata
+				return $?
+			fi
 			return 0
 		fi
 		print_error "Failed to create release '$_create_tag' on $_create_repo"
@@ -330,6 +374,7 @@ cmd_create() {
 	_create_flag_generate_notes=false
 	_create_flag_draft=false
 	_create_flag_prerelease=false
+	_create_flag_reconcile_existing=false
 	_create_already_exists=false
 
 	_parse_create_args "$@" || return 1
@@ -444,6 +489,7 @@ Options (create / draft):
   --generate-notes     Auto-generate notes from commits (default when no notes given)
   --draft              Create as draft (always set for 'draft' command)
   --prerelease         Mark as pre-release
+  --reconcile-existing Reconcile metadata without invalidating verified publication
 
 Options (list):
   --repo <slug>        Target repo

--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -130,7 +130,26 @@ get_repo_info() {
 	return 1
 }
 
-# Check GitHub Actions CI/CD status
+# Load check runs whose suites belong to release-triggered workflows on one SHA.
+load_release_owned_checks() {
+	local repo="$1"
+	local release_sha="$2"
+	local check_runs_response release_runs_response
+	check_runs_response=$(gh api --paginate --slurp \
+		"repos/${repo}/commits/${release_sha}/check-runs?per_page=100" 2>/dev/null |
+		jq -c -f "$REPO_ROOT/.github/scripts/flatten-check-run-pages.jq") || return 1
+	release_runs_response=$(gh api --paginate --slurp \
+		"repos/${repo}/actions/runs?head_sha=${release_sha}&per_page=100" 2>/dev/null) || return 1
+	jq -c \
+		--arg release_sha "$release_sha" \
+		--arg self_name "Verify Release Health" \
+		--slurpfile release_run_documents <(printf '%s\n' "$release_runs_response") \
+		-f "$REPO_ROOT/.github/scripts/release-owned-check-runs.jq" \
+		<<<"$check_runs_response"
+	return $?
+}
+
+# Check GitHub Actions CI/CD status using release-owned exact-SHA evidence.
 check_cicd_status() {
 	print_section "CI/CD Pipeline Status"
 
@@ -139,97 +158,66 @@ check_cicd_status() {
 		return 1
 	fi
 
-	local repo
+	local repo release_sha release_checks
 	repo=$(get_repo_info)
 	if [[ -z "$repo" ]]; then
 		count_failure "Could not determine repository"
 		return 1
 	fi
-
 	print_info "Repository: $repo"
+	release_sha="${POSTFLIGHT_COMMIT_SHA:-$(git -C "$ORIGINAL_PWD" rev-parse HEAD 2>/dev/null || true)}"
+	if [[ -z "$release_sha" ]]; then
+		count_failure "Could not determine exact release commit"
+		return 1
+	fi
+	print_info "Release commit: $release_sha"
+	release_checks=$(load_release_owned_checks "$repo" "$release_sha") || {
+		count_failure "Could not load release-owned workflow evidence"
+		return 1
+	}
 
-	# Get the latest workflow run for the exact release commit when supplied.
-	local latest_run
-	if [[ -n "$POSTFLIGHT_COMMIT_SHA" ]]; then
-		latest_run=$(gh run list --repo "$repo" --commit "$POSTFLIGHT_COMMIT_SHA" --limit=1 --json databaseId,status,conclusion,name 2>/dev/null || echo "")
-	else
-		latest_run=$(gh run list --repo "$repo" --limit=1 --json databaseId,status,conclusion,name 2>/dev/null || echo "")
+	local unrelated_count
+	unrelated_count=$(jq '.unrelated_workflow_runs | length' <<<"$release_checks")
+	if [[ "$unrelated_count" -gt 0 ]]; then
+		count_warning "$unrelated_count unrelated issue/comment workflow run(s) excluded from release evidence"
+		jq -r '.unrelated_workflow_runs[] | "  - \(.name) [event=\(.event), id=\(.id)]"' <<<"$release_checks"
 	fi
 
-	if [[ -z "$latest_run" || "$latest_run" == "[]" ]]; then
-		count_failure "No workflow runs found for release evidence"
+	local attempt=0 pending_count
+	pending_count=$(jq '[.check_runs[] | select(.status != "completed")] | length' <<<"$release_checks")
+	while [[ "$pending_count" -gt 0 && "$attempt" -lt "$MAX_ATTEMPTS" ]]; do
+		((++attempt))
+		print_info "Waiting for $pending_count release-owned check(s) (attempt $attempt/$MAX_ATTEMPTS)"
+		sleep "$POLL_INTERVAL"
+		release_checks=$(load_release_owned_checks "$repo" "$release_sha") || continue
+		pending_count=$(jq '[.check_runs[] | select(.status != "completed")] | length' <<<"$release_checks")
+	done
+
+	local required_count failed_count
+	required_count=$(jq '.check_runs | length' <<<"$release_checks")
+	if [[ "$required_count" -eq 0 ]]; then
+		count_failure "No release-owned check-run evidence exists for $release_sha"
+		return 1
+	fi
+	if [[ "$pending_count" -gt 0 ]]; then
+		count_failure "$pending_count release-owned check(s) remained non-terminal after timeout"
+		jq -r '.check_runs[] | select(.status != "completed") | "  - \(.name): \(.status)"' <<<"$release_checks"
 		return 1
 	fi
 
-	local run_id status conclusion name
-	run_id=$(echo "$latest_run" | jq -r '.[0].databaseId')
-	status=$(echo "$latest_run" | jq -r '.[0].status')
-	conclusion=$(echo "$latest_run" | jq -r '.[0].conclusion')
-	name=$(echo "$latest_run" | jq -r '.[0].name')
-
-	print_info "Latest run: $name (#$run_id)"
-	print_info "Status: $status, Conclusion: $conclusion"
-
-	# If still running, wait for completion
-	if [[ "$status" == "in_progress" || "$status" == "queued" ]]; then
-		print_info "Waiting for workflow to complete (timeout: ${TIMEOUT_CI}s)..."
-
-		local attempt=0
-		while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
-			sleep "$POLL_INTERVAL"
-			((++attempt))
-
-			local current_status
-			current_status=$(gh run view "$run_id" --repo "$repo" --json status,conclusion 2>/dev/null || echo "")
-
-			if [[ -z "$current_status" ]]; then
-				continue
-			fi
-
-			status=$(echo "$current_status" | jq -r '.status')
-			conclusion=$(echo "$current_status" | jq -r '.conclusion')
-
-			if [[ "$status" == "completed" ]]; then
-				break
-			fi
-
-			print_info "Still waiting... (attempt $attempt/$MAX_ATTEMPTS)"
-		done
-	fi
-
-	# Check final status
-	if [[ "$status" != "completed" ]]; then
-		count_failure "Workflow did not complete within timeout"
-		return 1
-	fi
-
-	if [[ "$conclusion" == "success" ]]; then
-		count_success "CI/CD pipeline: $name"
-	elif [[ "$conclusion" == "failure" ]]; then
-		count_failure "CI/CD pipeline failed: $name"
-		print_info "View logs: gh run view $run_id --repo $repo --log-failed"
-		return 1
-	else
-		count_warning "CI/CD pipeline conclusion: $conclusion"
-	fi
-
-	# Check all recent workflows
-	print_info "Checking all recent workflows..."
-	local all_runs
-	if [[ -n "$POSTFLIGHT_COMMIT_SHA" ]]; then
-		all_runs=$(gh run list --repo "$repo" --commit "$POSTFLIGHT_COMMIT_SHA" --limit=5 --json name,conclusion,status 2>/dev/null || echo "[]")
-	else
-		all_runs=$(gh run list --repo "$repo" --limit=5 --json name,conclusion,status 2>/dev/null || echo "[]")
-	fi
-
-	local failed_count
-	failed_count=$(echo "$all_runs" | jq '[.[] | select(.conclusion == "failure")] | length')
-
+	failed_count=$(jq '[.check_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length' <<<"$release_checks")
 	if [[ "$failed_count" -gt 0 ]]; then
-		print_warning "$failed_count workflow(s) failed recently"
-		echo "$all_runs" | jq -r '.[] | select(.conclusion == "failure") | "  - \(.name): \(.conclusion)"'
+		count_failure "$failed_count required release-owned check(s) failed"
+		jq -r '.check_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | "  - \(.name): \(.conclusion)"' <<<"$release_checks"
+		return 1
 	fi
 
+	count_success "$required_count required release-owned check(s) passed"
+	local advisory_pending
+	advisory_pending=$(jq '[.advisory_check_runs[] | select(.status != "completed")] | length' <<<"$release_checks")
+	if [[ "$advisory_pending" -gt 0 ]]; then
+		count_warning "$advisory_pending non-required advisory check(s) remain non-terminal"
+	fi
 	return 0
 }
 

--- a/.agents/scripts/tests/test-github-release-helper-idempotent.sh
+++ b/.agents/scripts/tests/test-github-release-helper-idempotent.sh
@@ -70,6 +70,14 @@ if [[ "${1:-}" == "release" && "${2:-}" == "create" ]]; then
 	exit 0
 fi
 
+if [[ "${1:-}" == "release" && "${2:-}" == "edit" ]]; then
+	if [[ "${FAKE_EDIT_RATE_LIMIT:-0}" == "1" ]]; then
+		printf 'HTTP 403: API rate limit exceeded for installation\n' >&2
+		exit 1
+	fi
+	exit 0
+fi
+
 exit 1
 EOF
 chmod +x "${TEST_ROOT}/bin/gh"
@@ -80,6 +88,7 @@ export FAKE_GH_RELEASE_MARKER="${TEST_ROOT}/release-created.marker"
 rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
 export FAKE_RELEASE_EXISTS=1
 export FAKE_CREATE_DUPLICATES=0
+export FAKE_EDIT_RATE_LIMIT=0
 rc=0
 output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' 2>&1) || rc=$?
 if [[ "$rc" -eq 0 && "$output" == *"already exists"* ]]; then
@@ -109,6 +118,25 @@ if grep -q 'release view v1.2.4 --repo marcusquinn/aidevops' "$FAKE_GH_LOG" 2>/d
 	print_result 'duplicate create race verifies release after create failure' 0
 else
 	print_result 'duplicate create race verifies release after create failure' 1 'missing expected gh calls'
+fi
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_RELEASE_EXISTS=1
+export FAKE_CREATE_DUPLICATES=0
+export FAKE_EDIT_RATE_LIMIT=1
+rc=0
+output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' --reconcile-existing 2>&1) || rc=$?
+if [[ "$rc" -eq 0 && "$output" == *"publication is verified"* && "$output" == *"metadata reconciliation is deferred"* ]]; then
+	print_result 'rate-limited metadata edit preserves verified publication' 0
+else
+	print_result 'rate-limited metadata edit preserves verified publication' 1 "rc=$rc output=$output"
+fi
+
+EDIT_COUNT=$(grep -c 'release edit' "$FAKE_GH_LOG" 2>/dev/null || true)
+if [[ "$EDIT_COUNT" -eq 1 ]]; then
+	print_result 'rate-limited metadata reconciliation stops without retry storm' 0
+else
+	print_result 'rate-limited metadata reconciliation stops without retry storm' 1 "edit_count=$EDIT_COUNT"
 fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-postflight-release-owned-checks.sh
+++ b/.agents/scripts/tests/test-postflight-release-owned-checks.sh
@@ -26,11 +26,14 @@ jq -e '
   (.advisory_check_runs | length) == 1 and
   .advisory_check_runs[0].name == "Socket Security: Project Report" and
   .advisory_check_runs[0].status == "in_progress" and
-  (all((.check_runs + .advisory_check_runs)[]; .name != "Verify Release Health"))
+  (all((.check_runs + .advisory_check_runs)[]; .name != "Verify Release Health")) and
+  (.unrelated_workflow_runs | length) == 2 and
+  [.unrelated_workflow_runs[].event] == ["issues", "issue_comment"]
 ' <<<"$SCOPED" >/dev/null
 
 printf 'PASS: superseded, self, and unrelated checks do not delay successful release checks\n'
 printf 'PASS: pending external checks are classified as non-required advisories\n'
+printf 'PASS: newer unrelated issue and comment runs are reported separately\n'
 
 PAGINATED_SCOPED=$(jq -c \
 	--arg release_sha "release-sha" \
@@ -48,15 +51,18 @@ jq -e '[.check_runs[] | select(.status != "completed")] | length == 1' <<<"$PEND
 
 printf 'PASS: pending release-quality checks remain pending\n'
 
-FAILED_INPUT=$(jq '(.check_runs[] | select(.id == 2001)) |= (.conclusion = "failure")' "$CHECK_FIXTURE")
+FAILED_INPUT=$(jq '(.check_runs[] | select(.id == 2001)) |= (.name = "Qlty Code Quality" | .conclusion = "failure")' "$CHECK_FIXTURE")
 FAILED=$(scope_checks <<<"$FAILED_INPUT")
-jq -e '[.check_runs[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required"))] | length == 1' <<<"$FAILED" >/dev/null
+jq -e '([.check_runs[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required"))] | length == 1) and any(.check_runs[]; .name == "Qlty Code Quality" and .conclusion == "failure")' <<<"$FAILED" >/dev/null
 
-printf 'PASS: terminal release-quality failures remain blocking\n'
+printf 'PASS: terminal release-quality failures such as Qlty remain named and blocking\n'
 
 grep -Fq "actions/runs?head_sha=\${COMMIT_SHA}&per_page=100" "${REPO_ROOT}/.github/workflows/postflight.yml"
 grep -Fq 'release-owned-check-runs.jq' "${REPO_ROOT}/.github/workflows/postflight.yml"
 grep -Fq -- '--slurpfile release_run_documents' "${REPO_ROOT}/.github/workflows/postflight.yml"
 grep -Fq 'non-required advisory check(s) remain non-terminal' "${REPO_ROOT}/.github/workflows/postflight.yml"
+grep -Fq 'load_release_owned_checks' "${REPO_ROOT}/.agents/scripts/postflight-check.sh"
+grep -Fq 'unrelated issue/comment workflow run(s) excluded' "${REPO_ROOT}/.agents/scripts/postflight-check.sh"
+grep -Fq -- '--reconcile-existing' "${REPO_ROOT}/.github/workflows/release.yml"
 
 printf 'PASS: postflight keeps paginated exact-SHA classification and advisory warnings\n'

--- a/.github/scripts/release-owned-check-runs.jq
+++ b/.github/scripts/release-owned-check-runs.jq
@@ -20,6 +20,18 @@ def latest_by_key:
  | map(select(. != null))
  | unique) as $release_suite_ids
 |
+($release_run_documents
+ | flatten
+ | map(.workflow_runs // [])
+ | add
+ | map(
+     select(.head_sha == $release_sha)
+     | select((.event == "push" or .event == "release" or .event == "workflow_dispatch") | not)
+     | {id, name, event, status, conclusion, check_suite_id}
+   )
+ | sort_by([(.created_at // .run_started_at // ""), (.id // 0)])
+) as $unrelated_workflow_runs
+|
 {
   check_runs: (
     [
@@ -37,5 +49,6 @@ def latest_by_key:
       | select((.app.slug // "") != "github-actions")
     ]
     | latest_by_key
-  )
+  ),
+  unrelated_workflow_runs: $unrelated_workflow_runs
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,22 +35,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            echo "Release $GITHUB_REF_NAME already exists; updating metadata"
-            gh release edit "$GITHUB_REF_NAME" \
-              --title "$GITHUB_REF_NAME" \
-              --notes "${{ steps.changelog.outputs.body }}"
-          else
-            if gh release create "$GITHUB_REF_NAME" \
-              --title "$GITHUB_REF_NAME" \
-              --notes "${{ steps.changelog.outputs.body }}"; then
-              echo "Release $GITHUB_REF_NAME created"
-            elif gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-              echo "Release $GITHUB_REF_NAME appeared after create failed; updating metadata"
-              gh release edit "$GITHUB_REF_NAME" \
-                --title "$GITHUB_REF_NAME" \
-                --notes "${{ steps.changelog.outputs.body }}"
-            else
-              exit 1
-            fi
-          fi
+          bash .agents/scripts/github-release-helper.sh create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --tag "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes "${{ steps.changelog.outputs.body }}" \
+            --reconcile-existing


### PR DESCRIPTION
## Summary

Filter postflight checks to release-owned exact-SHA suites, report unrelated issue/comment runs separately, and preserve verified publication when metadata reconciliation is rate-limited.

## Files Changed

.agents/scripts/github-release-helper.sh, .agents/scripts/postflight-check.sh, .agents/scripts/tests/test-github-release-helper-idempotent.sh, .agents/scripts/tests/test-postflight-release-owned-checks.sh, .github/scripts/release-owned-check-runs.jq, .github/workflows/release.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted postflight and release-helper regression tests pass; ShellCheck, shfmt, actionlint, secretlint, and changed-file linters pass. Full repository lint reports only pre-existing unrelated Markdown, complexity, nesting, and Qlty debt.

Resolves #27740


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.119 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 15m and 111,735 tokens on this with the user in an interactive session.