### PR TITLE
GH#27755: test: include local bin in repo sync PATH

### DIFF
--- a/.agents/scripts/tests/test-repo-sync-helper-gh-auth.sh
+++ b/.agents/scripts/tests/test-repo-sync-helper-gh-auth.sh
@@ -92,7 +92,7 @@ run_canonical_guard_case() {
 	local rc=0
 	env \
 		HOME="${tmp_dir}/home" \
-		PATH="${tmp_dir}/bin:/usr/bin:/bin:/opt/homebrew/bin" \
+		PATH="${tmp_dir}/bin:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
 		FAKE_GH_LOG="${tmp_dir}/gh.log" \
 		"$HELPER" check >"${tmp_dir}/stdout.log" 2>"${tmp_dir}/stderr.log" || rc=$?
 	local after


### PR DESCRIPTION
## Summary

Include /usr/local/bin in the canonical repo-sync test PATH so python3 and other dependencies remain discoverable on common macOS and Linux installations.

## Files Changed

.agents/scripts/tests/test-repo-sync-helper-gh-auth.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-repo-sync-helper-gh-auth.sh; bash .agents/scripts/tests/test-repo-sync-helper-gh-auth.sh

Resolves #27755


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 45,452 tokens on this as a headless worker.