### PR TITLE
GH#27761: Restore default-pass review gate behavior during API exhaustion

### DIFF
--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -117,12 +117,14 @@ Global equivalent: `orchestration.interactive_pr_auto_merge` in `~/.config/aidev
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `rate_limit_behavior` | `"pass"` | `"pass"` exits 0 on rate-limit; `"wait"` keeps polling |
+| `rate_limit_behavior` | `"pass"` | `"pass"` exits 0 for bot rate limits and trusted internal API exhaustion, delegating late feedback to the post-merge scanner; `"wait"` blocks when evidence cannot be evaluated. External/unknown authors always block. |
 | `min_edit_lag_seconds` | 30 | Seconds a bot comment must be "settled" before it counts. Defeats CodeRabbit's two-phase placeholder (stub at ~14s, final edit at ~90-120s). |
 | `advisory_check_contexts` | `[]` | Exact non-required review-provider check names that may be advisory only when typed live evidence permits the outcome for the current PR head and review threads are resolved. Required, maintainer-gate, unknown, malformed-evidence, and external rate-limit failures always block. |
 | `tools` | — | Per-tool overrides keyed by bot login (`coderabbitai`, `gemini-code-assist`, `augment-code`, `augmentcode`, `copilot`) |
 
 Resolution order (per field independently): per-tool > per-repo > env var (`REVIEW_GATE_RATE_LIMIT_BEHAVIOR` / `REVIEW_BOT_MIN_EDIT_LAG_SECONDS`) > hard default.
+
+The reusable workflow exposes matching `rate_limit_behavior` and `completion_behavior` inputs for CI callers. Their defaults are `pass` and `fast`; set either `rate_limit_behavior: wait` or `completion_behavior: strict` to keep GitHub API exhaustion fail-closed. Per-tool `wait`/`strict` overrides also fail closed when the unavailable API prevents identifying which provider supplied evidence.
 
 CLI: `aidevops review-gate --help` — configure rate-limit/completion policy and add or remove exact advisory check contexts without hand-editing JSON.
 

--- a/.agents/reference/review-bot-gate.md
+++ b/.agents/reference/review-bot-gate.md
@@ -35,7 +35,7 @@ Workers MUST use `full-loop-helper.sh merge` — direct `gh pr merge` bypasses t
 - If the PR has `skip-review-gate` label, bypass the gate (for docs-only PRs or repos without bots).
 - In headless mode: if still WAITING after timeout, proceed but log a warning. The CI required check is the hard gate.
 - ALWAYS read bot reviews before merging. Address critical/security findings; note non-critical suggestions for follow-up.
-- PASS_RATE_LIMITED means bots are rate-limited and `rate_limit_behavior=pass` (default). Safe to merge — bot reviews will arrive later and can be addressed in follow-up PRs. Use `request-retry` to trigger a re-review once rate limits clear. External-contributor PRs are exempt: rate-limit grace is always disabled for them.
+- PASS_RATE_LIMITED means either bots are rate-limited or the GitHub API is unavailable while immutable event evidence identifies a trusted internal PR and `rate_limit_behavior=pass` (default) with non-strict completion. Safe to merge — late feedback is handled by the post-merge review scanner. API-exhausted runs do not retry immediately. External/unknown authors and explicit `wait` or `strict` policies always fail closed.
 - When many PRs are rate-limited simultaneously, use `request-retry` on the highest-priority PRs first. Stagger retries to avoid re-triggering rate limits.
 
 ## Additive suggestion decision tree

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -6,6 +6,7 @@
 # Usage:
 #   review-bot-gate-helper.sh check         <PR_NUMBER> [REPO]
 #   review-bot-gate-helper.sh event-check
+#   review-bot-gate-helper.sh classify-infra-rate-limit <AUTHOR_ASSOCIATION> [REPO]
 #   review-bot-gate-helper.sh wait          <PR_NUMBER> [REPO] [MAX_WAIT_SECONDS]
 #   review-bot-gate-helper.sh list          <PR_NUMBER> [REPO]
 #   review-bot-gate-helper.sh request-retry <PR_NUMBER> [REPO]
@@ -15,6 +16,7 @@
 # Commands:
 #   check          — Check once, return PASS/PASS_RATE_LIMITED/WAITING/SKIP
 #   event-check    — Accept trusted bot review evidence from the Actions event
+#   classify-infra-rate-limit — Classify API exhaustion from immutable event trust
 #   wait           — Poll until a bot posts or timeout (default 600s)
 #   list           — List all bot comments found on the PR
 #   request-retry  — If bots were rate-limited and no real review exists,
@@ -150,16 +152,51 @@ REVIEW_BOT_MIN_EDIT_LAG_SECONDS="${REVIEW_BOT_MIN_EDIT_LAG_SECONDS:-30}"
 # --- Functions ---
 
 usage() {
-	echo "Usage: $(basename "$0") {check|event-check|wait|list|request-retry|status-json|batch-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
+	echo "Usage: $(basename "$0") {check|event-check|classify-infra-rate-limit|wait|list|request-retry|status-json|batch-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
 	echo ""
 	echo "Commands:"
 	echo "  check          Check once for bot reviews (returns PASS/PASS_RATE_LIMITED/WAITING/SKIP)"
 	echo "  event-check    Check trusted bot review evidence from REVIEW_GATE_EVENT_* variables"
+	echo "  classify-infra-rate-limit  Resolve trusted/default-pass API exhaustion without another API call"
 	echo "  wait           Poll until bot reviews appear or timeout"
 	echo "  list           List all bot comments found"
 	echo "  request-retry  Request review retry if bots were rate-limited (idempotent)"
 	echo "  status-json    Print machine-readable gate status"
 	echo "  batch-retry    Process all open PRs with 0 reviews, request retries (GH#3932)"
+	return 0
+}
+
+classify_infra_rate_limit() {
+	local author_association="$1"
+	local repo_slug="$2"
+	local rate_limit_behavior completion_behavior repos_json strict_tool_override="false"
+
+	#aidevops:trust-boundary
+	case "$author_association" in
+	OWNER | MEMBER | COLLABORATOR) ;;
+	*)
+		printf '%s\n' "INFRA_RATE_LIMITED"
+		return 0
+		;;
+	esac
+
+	rate_limit_behavior=$(_get_rate_limit_behavior "$repo_slug" "")
+	completion_behavior=$(_get_completion_behavior "$repo_slug" "")
+	repos_json="${HOME}/.config/aidevops/repos.json"
+	if [[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1; then
+		strict_tool_override=$(jq -r --arg slug "$repo_slug" '
+			[first(.initialized_repos[]? | select(.slug == $slug)).review_gate.tools[]?
+			| select(.rate_limit_behavior == "wait" or .completion_behavior == "strict")]
+			| if length > 0 then "true" else "false" end
+		' "$repos_json" 2>/dev/null) || strict_tool_override="true"
+	fi
+
+	if [[ "$rate_limit_behavior" == "pass" && "$completion_behavior" == "fast" && "$strict_tool_override" != "true" ]]; then
+		printf '%s\n' "PASS_RATE_LIMITED"
+		return 0
+	fi
+
+	printf '%s\n' "INFRA_RATE_LIMITED"
 	return 0
 }
 
@@ -1454,6 +1491,17 @@ main() {
 
 	if [[ "$command" == "event-check" ]]; then
 		do_event_check
+		return $?
+	fi
+
+	if [[ "$command" == "classify-infra-rate-limit" ]]; then
+		local author_association="${2:-}"
+		local infra_repo="${3:-}"
+		if [[ -z "$author_association" || -z "$infra_repo" ]]; then
+			echo "ERROR: classify-infra-rate-limit requires AUTHOR_ASSOCIATION and REPO." >&2
+			return 2
+		fi
+		classify_infra_rate_limit "$author_association" "$infra_repo"
 		return $?
 	fi
 

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -76,6 +76,7 @@ KNOWN_BOTS=(
 	"copilot"
 )
 REVIEW_GATE_STATUS_PASS="$(printf 'P%s' 'ASS')"
+RBG_PASS_RATE_LIMITED="PASS_RATE_LIMITED"
 RBG_FALSE="false"
 
 # Rate-limit / quota notice patterns — entries that indicate the bot tried to
@@ -169,7 +170,7 @@ usage() {
 classify_infra_rate_limit() {
 	local author_association="$1"
 	local repo_slug="$2"
-	local rate_limit_behavior completion_behavior repos_json strict_tool_override="false"
+	local rate_limit_behavior completion_behavior repos_json strict_tool_override="$RBG_FALSE"
 
 	#aidevops:trust-boundary
 	case "$author_association" in
@@ -192,7 +193,7 @@ classify_infra_rate_limit() {
 	fi
 
 	if [[ "$rate_limit_behavior" == "pass" && "$completion_behavior" == "fast" && "$strict_tool_override" != "true" ]]; then
-		printf '%s\n' "PASS_RATE_LIMITED"
+		printf '%s\n' "$RBG_PASS_RATE_LIMITED"
 		return 0
 	fi
 
@@ -954,14 +955,14 @@ _collect_review_gate_bot_states() {
 					return "$notice_rc"
 				fi
 				case "$notice_category" in
-					rate-limit)
-						REVIEW_GATE_RATE_LIMITED_BOTS="${REVIEW_GATE_RATE_LIMITED_BOTS}${bot} "
-						echo "rate-limit notice (not a real review): ${bot}" >&2
-						;;
-					non-rate-limit | none | *)
-						REVIEW_GATE_NON_REVIEW_BOTS="${REVIEW_GATE_NON_REVIEW_BOTS}${bot} "
-						echo "non-review state (not rate-limited, not a real review): ${bot}" >&2
-						;;
+				rate-limit)
+					REVIEW_GATE_RATE_LIMITED_BOTS="${REVIEW_GATE_RATE_LIMITED_BOTS}${bot} "
+					echo "rate-limit notice (not a real review): ${bot}" >&2
+					;;
+				non-rate-limit | none | *)
+					REVIEW_GATE_NON_REVIEW_BOTS="${REVIEW_GATE_NON_REVIEW_BOTS}${bot} "
+					echo "non-review state (not rate-limited, not a real review): ${bot}" >&2
+					;;
 				esac
 			fi
 		fi
@@ -1012,7 +1013,7 @@ _emit_review_gate_check_result() {
 		# Configure per-tool or per-repo via repos.json review_gate, or globally
 		# via REVIEW_GATE_RATE_LIMIT_BEHAVIOR env var.
 		if _should_pass_rate_limited "$repo" "$REVIEW_GATE_RATE_LIMITED_BOTS"; then
-			echo "PASS_RATE_LIMITED"
+			echo "$RBG_PASS_RATE_LIMITED"
 			echo "Bots are rate-limited (tried but capacity-constrained): ${REVIEW_GATE_RATE_LIMITED_BOTS}" >&2
 			echo "Passing gate — configured to pass on rate limit (review_gate.rate_limit_behavior=pass)." >&2
 			return 0
@@ -1086,7 +1087,7 @@ do_wait() {
 		local result
 		result=$(do_check "$pr_number" "$repo") || true
 
-		if [[ "$result" == "$REVIEW_GATE_STATUS_PASS" || "$result" == "PASS_RATE_LIMITED" || "$result" == "SKIP" ]]; then
+		if [[ "$result" == "$REVIEW_GATE_STATUS_PASS" || "$result" == "$RBG_PASS_RATE_LIMITED" || "$result" == "SKIP" ]]; then
 			echo "$result"
 			return 0
 		fi

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -673,7 +673,7 @@ test_any_bot_success_status_reuses_provided_contexts() {
 
 	local contexts
 	contexts=$'abc123def456\nCodeRabbit'
-	if any_bot_has_success_status 123 'testorg/strictrepo' "$contexts" 2>/dev/null && \
+	if any_bot_has_success_status 123 'testorg/strictrepo' "$contexts" 2>/dev/null &&
 		[[ "$TEST_STATUS_FETCHES" -eq 0 ]]; then
 		print_result "status fallback reuses provided success contexts" 0
 	else
@@ -692,7 +692,7 @@ test_any_bot_success_status_reuses_prepared_contexts() {
 
 	local contexts
 	contexts=$'abc123def456\ncoderabbit'
-	if any_bot_has_success_status 123 'testorg/strictrepo' "$contexts" true 2>/dev/null && \
+	if any_bot_has_success_status 123 'testorg/strictrepo' "$contexts" true 2>/dev/null &&
 		[[ "$prepare_calls" -eq 0 ]]; then
 		print_result "status fallback reuses prepared success contexts" 0
 	else
@@ -958,10 +958,16 @@ test_notice_category_propagates_api_failure() {
 
 test_do_check_passes_true_rate_limit_only() {
 	check_for_skip_label() { return 1; }
-	get_all_bot_commenters() { printf '%s\n' 'coderabbitai'; return 0; }
+	get_all_bot_commenters() {
+		printf '%s\n' 'coderabbitai'
+		return 0
+	}
 	_get_success_status_contexts() { return 1; }
 	bot_has_real_review() { return 1; }
-	bot_get_notice_category() { echo "rate-limit"; return 0; }
+	bot_get_notice_category() {
+		echo "rate-limit"
+		return 0
+	}
 	any_bot_has_success_status() { return 1; }
 
 	local output status
@@ -982,10 +988,16 @@ test_do_check_passes_true_rate_limit_only() {
 
 test_do_check_blocks_non_rate_limit_non_review_states() {
 	check_for_skip_label() { return 1; }
-	get_all_bot_commenters() { printf '%s\n' 'coderabbitai'; return 0; }
+	get_all_bot_commenters() {
+		printf '%s\n' 'coderabbitai'
+		return 0
+	}
 	_get_success_status_contexts() { return 1; }
 	bot_has_real_review() { return 1; }
-	bot_get_notice_category() { echo "non-rate-limit"; return 0; }
+	bot_get_notice_category() {
+		echo "non-rate-limit"
+		return 0
+	}
 	any_bot_has_success_status() { return 1; }
 
 	local output status
@@ -1006,10 +1018,19 @@ test_do_check_blocks_non_rate_limit_non_review_states() {
 
 test_do_check_accepts_non_review_with_success_status() {
 	check_for_skip_label() { return 1; }
-	get_all_bot_commenters() { printf '%s\n' 'coderabbitai'; return 0; }
-	_get_success_status_contexts() { printf '%s\n' 'abc123def456' 'CodeRabbit'; return 0; }
+	get_all_bot_commenters() {
+		printf '%s\n' 'coderabbitai'
+		return 0
+	}
+	_get_success_status_contexts() {
+		printf '%s\n' 'abc123def456' 'CodeRabbit'
+		return 0
+	}
 	bot_has_real_review() { return 1; }
-	bot_get_notice_category() { echo "non-rate-limit"; return 0; }
+	bot_get_notice_category() {
+		echo "non-rate-limit"
+		return 0
+	}
 	any_bot_has_success_status() { return 0; }
 
 	local output status
@@ -1030,9 +1051,15 @@ test_do_check_accepts_non_review_with_success_status() {
 
 test_do_check_fetches_success_status_contexts_once() {
 	check_for_skip_label() { return 1; }
-	get_all_bot_commenters() { printf '%s\n' 'coderabbitai gemini-code-assist'; return 0; }
+	get_all_bot_commenters() {
+		printf '%s\n' 'coderabbitai gemini-code-assist'
+		return 0
+	}
 	bot_has_real_review() { return 1; }
-	bot_get_notice_category() { echo "non-rate-limit"; return 0; }
+	bot_get_notice_category() {
+		echo "non-rate-limit"
+		return 0
+	}
 	_get_success_status_contexts() {
 		local pr_number="$1"
 		local repo="$2"
@@ -1065,7 +1092,10 @@ test_do_check_fetches_success_status_contexts_once() {
 }
 
 test_status_json_denies_external_rate_limit_grace() {
-	do_check() { printf 'PASS_RATE_LIMITED\n'; return 0; }
+	do_check() {
+		printf 'PASS_RATE_LIMITED\n'
+		return 0
+	}
 	gh() {
 		printf '%s\n' '{"head":{"sha":"head-123"},"user":{"login":"external"},"author_association":"CONTRIBUTOR"}'
 		return 0
@@ -1081,7 +1111,10 @@ test_status_json_denies_external_rate_limit_grace() {
 }
 
 test_status_json_allows_trusted_skip() {
-	do_check() { printf 'SKIP\n'; return 0; }
+	do_check() {
+		printf 'SKIP\n'
+		return 0
+	}
 	gh() {
 		printf '%s\n' '{"head":{"sha":"head-123"},"user":{"login":"maintainer"},"author_association":"MEMBER"}'
 		return 0
@@ -1097,7 +1130,10 @@ test_status_json_allows_trusted_skip() {
 }
 
 test_status_json_fails_closed_without_pr_metadata() {
-	do_check() { printf 'PASS\n'; return 0; }
+	do_check() {
+		printf 'PASS\n'
+		return 0
+	}
 	gh() { return 1; }
 	local output=""
 	output=$(do_status_json 123 'testorg/otherrepo')

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -82,6 +82,24 @@ setup_test_env() {
       }
     },
     {
+      "path": "/tmp/waitrepo",
+      "slug": "testorg/waitrepo",
+      "pulse": true,
+      "review_gate": {
+        "rate_limit_behavior": "wait"
+      }
+    },
+    {
+      "path": "/tmp/toolstrictrepo",
+      "slug": "testorg/toolstrictrepo",
+      "pulse": true,
+      "review_gate": {
+        "tools": {
+          "coderabbitai": { "completion_behavior": "strict" }
+        }
+      }
+    },
+    {
       "path": "/tmp/otherrepo",
       "slug": "testorg/otherrepo",
       "pulse": true
@@ -250,6 +268,42 @@ test_self_caller_uses_pr_head_helper_ref() {
 		print_result "self-caller validates the PR-head helper revision" 0
 	else
 		print_result "self-caller validates the PR-head helper revision" 1 "caller=${caller}"
+	fi
+	return 0
+}
+
+test_infra_rate_limit_passes_trusted_default_policy() {
+	local output
+	output=$(classify_infra_rate_limit "MEMBER" "testorg/otherrepo")
+	if [[ "$output" == "PASS_RATE_LIMITED" ]]; then
+		print_result "API exhaustion passes for trusted default policy" 0
+	else
+		print_result "API exhaustion passes for trusted default policy" 1 "output=${output}"
+	fi
+	return 0
+}
+
+test_infra_rate_limit_blocks_external_author() {
+	local output
+	output=$(classify_infra_rate_limit "CONTRIBUTOR" "testorg/otherrepo")
+	if [[ "$output" == "INFRA_RATE_LIMITED" ]]; then
+		print_result "API exhaustion fails closed for external authors" 0
+	else
+		print_result "API exhaustion fails closed for external authors" 1 "output=${output}"
+	fi
+	return 0
+}
+
+test_infra_rate_limit_blocks_explicit_wait_or_strict_policy() {
+	local wait_output strict_output tool_strict_output
+	wait_output=$(classify_infra_rate_limit "OWNER" "testorg/waitrepo")
+	strict_output=$(classify_infra_rate_limit "OWNER" "testorg/strictrepo")
+	tool_strict_output=$(classify_infra_rate_limit "OWNER" "testorg/toolstrictrepo")
+	if [[ "$wait_output" == "INFRA_RATE_LIMITED" && "$strict_output" == "INFRA_RATE_LIMITED" && "$tool_strict_output" == "INFRA_RATE_LIMITED" ]]; then
+		print_result "API exhaustion honors explicit wait and strict policies" 0
+	else
+		print_result "API exhaustion honors explicit wait and strict policies" 1 \
+			"wait=${wait_output} strict=${strict_output} tool_strict=${tool_strict_output}"
 	fi
 	return 0
 }
@@ -1076,6 +1130,9 @@ main() {
 	test_event_check_rejects_bot_failure_notice
 	test_event_check_rejects_stale_head_evidence
 	test_self_caller_uses_pr_head_helper_ref
+	test_infra_rate_limit_passes_trusted_default_policy
+	test_infra_rate_limit_blocks_external_author
+	test_infra_rate_limit_blocks_explicit_wait_or_strict_policy
 	test_is_rate_limit_only_matches_rate_limit
 	test_is_rate_limit_only_rejects_review_failed
 	test_is_rate_limit_only_rejects_review_skipped

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -43,6 +43,16 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
+      rate_limit_behavior:
+        description: 'API/bot rate-limit policy: pass (default) or wait'
+        required: false
+        default: 'pass'
+        type: string
+      completion_behavior:
+        description: 'Review completion policy: fast (default) or strict'
+        required: false
+        default: 'fast'
+        type: string
     secrets:
       AIDEVOPS_READ_TOKEN:
         required: false
@@ -117,21 +127,28 @@ jobs:
           REVIEW_GATE_REVIEW_STATE: ${{ github.event.review.state || '' }}
           REVIEW_GATE_EVIDENCE_HEAD_SHA: ${{ github.event.review.commit_id || github.event.comment.commit_id || '' }}
           REVIEW_GATE_EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          REVIEW_GATE_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association || github.event.issue.author_association || '' }}
+          REVIEW_GATE_RATE_LIMIT_BEHAVIOR: ${{ inputs.rate_limit_behavior }}
+          REVIEW_GATE_COMPLETION_BEHAVIOR: ${{ inputs.completion_behavior }}
         run: |
           echo "Checking PR #${PR_NUMBER} for AI review bot activity..."
 
-          # Check if this is an external contributor PR.
+          # Check if this is an external contributor PR using immutable event
+          # evidence, so API exhaustion cannot accidentally grant trust.
           # GH#17671: external-contributor PRs require real bot reviews;
           # rate-limit grace is disabled — they cannot merge on rate-limit-only.
-          IS_EXTERNAL_PR=false
-          PR_LABELS=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
-            --json labels --jq '.labels[].name' 2>/dev/null || true)
-          if echo "${PR_LABELS}" | grep -q 'external-contributor'; then
+          #aidevops:trust-boundary
+          case "${REVIEW_GATE_AUTHOR_ASSOCIATION}" in
+          OWNER|MEMBER|COLLABORATOR)
+            IS_EXTERNAL_PR=false
+            ;;
+          *)
             IS_EXTERNAL_PR=true
             echo "External contributor PR detected — rate-limit grace DISABLED"
             # Override to 'wait': prevents the default PASS_RATE_LIMITED shortcut.
             export REVIEW_GATE_RATE_LIMIT_BEHAVIOR=wait
-          fi
+            ;;
+          esac
           echo "is_external_pr=${IS_EXTERNAL_PR}" >> "${GITHUB_OUTPUT}"
 
           # Invoke the framework helper (runtime-fetched via __aidevops/).
@@ -155,12 +172,21 @@ jobs:
           fi
           cat "${HELPER_STDERR}" >&2
 
+          INFRA_DEFERRED=false
           # API exhaustion is an infrastructure condition, not evidence that a
-          # bot failed to review. Preserve fail-closed behavior while reporting
-          # the truthful reason and avoiding more API calls in this run.
+          # bot failed to review. Trusted default-pass PRs defer late feedback to
+          # the post-merge scanner; external or explicit wait/strict policies
+          # remain fail-closed. The classifier uses event/config evidence only.
           if grep -qiE 'API rate limit exceeded|x-ratelimit-remaining[^0-9]*0' "${HELPER_STDERR}"; then
-            RESULT="INFRA_RATE_LIMITED"
-            HELPER_EXIT=2
+            RESULT=$(bash "${HELPER}" classify-infra-rate-limit \
+              "${REVIEW_GATE_AUTHOR_ASSOCIATION}" "${REPO}")
+            if [[ "${RESULT}" == "PASS_RATE_LIMITED" ]]; then
+              HELPER_EXIT=0
+              INFRA_DEFERRED=true
+              echo "GitHub API quota exhausted; trusted default-pass policy delegates late feedback to the post-merge review scanner."
+            else
+              HELPER_EXIT=2
+            fi
           fi
           rm -f "${HELPER_STDERR}"
 
@@ -182,6 +208,7 @@ jobs:
             echo "gate_passed=false" >> "${GITHUB_OUTPUT}"
           fi
           echo "result=${RESULT}" >> "${GITHUB_OUTPUT}"
+          echo "infra_deferred=${INFRA_DEFERRED}" >> "${GITHUB_OUTPUT}"
 
       - name: Check for skip label
         id: skip
@@ -212,6 +239,7 @@ jobs:
         if: steps.check.outputs.gate_passed != 'true' && steps.skip.outputs.skip != 'true'
         env:
           RESULT: ${{ steps.check.outputs.result }}
+          INFRA_DEFERRED: ${{ steps.check.outputs.infra_deferred }}
         run: |
           if [[ "${RESULT}" == "INFRA_RATE_LIMITED" ]]; then
             echo "::error::Review state could not be evaluated because GitHub API quota is exhausted."
@@ -265,7 +293,11 @@ jobs:
 
           if [[ "${GATE_PASSED}" == "true" ]] || [[ "${SKIP_GATE}" == "true" ]]; then
             STATE=success
-            DESC="Review bot gate passed (${RESULT:-SKIP})"
+            if [[ "${INFRA_DEFERRED}" == "true" ]]; then
+              DESC="Review API unavailable — late feedback deferred post-merge"
+            else
+              DESC="Review bot gate passed (${RESULT:-SKIP})"
+            fi
           elif [[ "${RESULT}" == "INFRA_RATE_LIMITED" ]]; then
             STATE=failure
             DESC="Review bot gate infrastructure wait — GitHub API quota exhausted"
@@ -307,11 +339,18 @@ jobs:
           GATE_PASSED: ${{ steps.check.outputs.gate_passed }}
           RESULT: ${{ steps.check.outputs.result }}
           SKIP_GATE: ${{ steps.skip.outputs.skip }}
+          INFRA_DEFERRED: ${{ steps.check.outputs.infra_deferred }}
         run: |
           {
             echo "## Review Bot Gate"
             echo ""
-            if [[ "${GATE_PASSED}" == "true" && "${RESULT}" == "PASS_RATE_LIMITED" ]]; then
+            if [[ "${GATE_PASSED}" == "true" && "${INFRA_DEFERRED}" == "true" ]]; then
+              echo "**Status**: PASSED (GitHub API unavailable; deferred review)"
+              echo ""
+              echo "The PR author is trusted and rate_limit_behavior=pass with"
+              echo "non-strict completion. No API retry was attempted; late bot"
+              echo "feedback is delegated to the post-merge review scanner."
+            elif [[ "${GATE_PASSED}" == "true" && "${RESULT}" == "PASS_RATE_LIMITED" ]]; then
               echo "**Status**: PASSED (rate-limit grace)"
               echo ""
               echo "Bots are rate-limited (tried but capacity-constrained). Passing"


### PR DESCRIPTION
## Summary

Use immutable event trust and explicit review policy to pass GitHub API exhaustion only for trusted default-pass PRs; preserve external and strict fail-closed behavior and document post-merge review recovery.

## Files Changed

.agents/reference/repos-json-fields.md, .agents/reference/review-bot-gate.md, .agents/scripts/review-bot-gate-helper.sh, .agents/scripts/tests/test-review-bot-gate-completion-signal.sh, .github/workflows/review-bot-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused review-gate tests, config-path tests, ShellCheck, and git diff checks pass.

Resolves #27761


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.120 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 7m and 108,297 tokens on this as a headless worker.