### PR TITLE
GH#27756: fix: reuse review thread responses

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -321,11 +321,13 @@ fetch_review_threads_json() {
 #   0  — success (stdout is markdown; empty string = no unresolved findings)
 #   2  — fetch error (propagated from fetch_review_threads_json or jq failure)
 fetch_inline_comments_md() {
-	local repo="$1" pr="$2"
-	local json rc=0
-	json=$(fetch_review_threads_json "$repo" "$pr") || rc=$?
-	if [[ $rc -ne 0 ]]; then
-		return 2
+	local repo="$1" pr="$2" threads_json="${3:-}"
+	local json="$threads_json" rc=0
+	if [[ $# -lt 3 ]]; then
+		json=$(fetch_review_threads_json "$repo" "$pr") || rc=$?
+		if [[ $rc -ne 0 ]]; then
+			return 2
+		fi
 	fi
 	local out
 	out=$(printf '%s' "$json" | jq -r \
@@ -393,16 +395,18 @@ fetch_inline_comments_md() {
 #   0  — success (stdout is markdown; empty string = no bot summaries)
 #   2  — fetch error (gh call failed or jq failure)
 fetch_review_summaries_md() {
-	local repo="$1" pr="$2"
-	local resp threads resolved_review_ids rc=0 threads_rc=0
+	local repo="$1" pr="$2" threads_json="${3:-}"
+	local resp threads="$threads_json" resolved_review_ids rc=0 threads_rc=0
 	resp=$(gh api "repos/${repo}/pulls/${pr}/reviews" --paginate) || rc=$?
 	if [[ $rc -ne 0 ]]; then
 		log "fetch_review_summaries_md: gh api failed for ${repo}#${pr} (rc=${rc})"
 		return 2
 	fi
-	threads=$(fetch_review_threads_json "$repo" "$pr") || threads_rc=$?
-	if [[ $threads_rc -ne 0 ]]; then
-		return 2
+	if [[ $# -lt 3 ]]; then
+		threads=$(fetch_review_threads_json "$repo" "$pr") || threads_rc=$?
+		if [[ $threads_rc -ne 0 ]]; then
+			return 2
+		fi
 	fi
 	resolved_review_ids=$(printf '%s' "$threads" | jq -c \
 		--arg bots "$BOT_RE" '
@@ -473,11 +477,13 @@ fetch_review_summaries_md() {
 #   0  — success (stdout is markdown; empty string = no file refs)
 #   2  — fetch error (propagated from fetch_review_threads_json or jq failure)
 fetch_file_refs_md() {
-	local repo="$1" pr="$2"
-	local json rc=0
-	json=$(fetch_review_threads_json "$repo" "$pr") || rc=$?
-	if [[ $rc -ne 0 ]]; then
-		return 2
+	local repo="$1" pr="$2" threads_json="${3:-}"
+	local json="$threads_json" rc=0
+	if [[ $# -lt 3 ]]; then
+		json=$(fetch_review_threads_json "$repo" "$pr") || rc=$?
+		if [[ $rc -ne 0 ]]; then
+			return 2
+		fi
 	fi
 	local out
 	out=$(printf '%s' "$json" | jq -r --arg bots "$BOT_RE" '
@@ -655,11 +661,16 @@ MD
 # Arguments: repo, pr
 build_pr_followup_body() {
 	local repo="$1" pr="$2"
-	local inline review file_refs refs_section
-	local inline_rc=0 review_rc=0 refs_rc=0
-	inline=$(fetch_inline_comments_md "$repo" "$pr") || inline_rc=$?
-	review=$(fetch_review_summaries_md "$repo" "$pr") || review_rc=$?
-	file_refs=$(fetch_file_refs_md "$repo" "$pr") || refs_rc=$?
+	local threads inline review file_refs refs_section
+	local threads_rc=0 inline_rc=0 review_rc=0 refs_rc=0
+	threads=$(fetch_review_threads_json "$repo" "$pr") || threads_rc=$?
+	if [[ $threads_rc -ne 0 ]]; then
+		log "build_pr_followup_body: fetch error for ${repo}#${pr} (threads=${threads_rc})"
+		return 2
+	fi
+	inline=$(fetch_inline_comments_md "$repo" "$pr" "$threads") || inline_rc=$?
+	review=$(fetch_review_summaries_md "$repo" "$pr" "$threads") || review_rc=$?
+	file_refs=$(fetch_file_refs_md "$repo" "$pr" "$threads") || refs_rc=$?
 
 	# Any fetch error → refuse to produce a body. Callers get rc=2 and
 	# must log + skip (not close). This prevents closing valid issues on

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -103,7 +103,8 @@ FIX_GRAPHQL="${TMP_DIR}/fix-graphql.json"
 FIX_REVIEWS="${TMP_DIR}/fix-reviews.json"
 FIX_COMMENTS="${TMP_DIR}/fix-comments.json"
 FIX_ISSUE_LIST="${TMP_DIR}/fix-issue-list.json"
-export FIX_GRAPHQL FIX_REVIEWS FIX_COMMENTS FIX_ISSUE_LIST
+FIX_GRAPHQL_CALLS="${TMP_DIR}/graphql-calls"
+export FIX_GRAPHQL FIX_REVIEWS FIX_COMMENTS FIX_ISSUE_LIST FIX_GRAPHQL_CALLS
 
 # Mock gh binary. It dispatches based on its first two positional args.
 # - `api graphql` → cat $FIX_GRAPHQL
@@ -124,6 +125,7 @@ case "$cmd" in
 api)
 	case "$sub" in
 	graphql)
+		printf 'call\n' >>"$FIX_GRAPHQL_CALLS"
 		if [[ -n "${FIX_GRAPHQL:-}" && -f "$FIX_GRAPHQL" ]]; then
 			cat "$FIX_GRAPHQL"
 		else
@@ -366,11 +368,14 @@ write_graphql_fixture "$FIX_GRAPHQL" \
 	true false "coderabbitai" "src/done.js" 10 "MARKER_ALPHA_DONE" "@@ -1,3 +1,3 @@" \
 	false false "coderabbitai" "src/live.js" 20 "MARKER_BRAVO_LIVE" "@@ -5,3 +5,3 @@\n context line 1\n context line 2\n+new line"
 write_reviews_fixture "$FIX_REVIEWS"
+: >"$FIX_GRAPHQL_CALLS"
 out=$(build_pr_followup_body "stub/repo" "42")
 assert_contains "unresolved comment body is rendered" "MARKER_BRAVO_LIVE" "$out"
 assert_not_contains "resolved comment body is NOT rendered" "MARKER_ALPHA_DONE" "$out"
 assert_contains "unresolved file:line appears in file refs" "src/live.js:20" "$out"
 assert_not_contains "resolved file:line does NOT appear in file refs" "src/done.js:10" "$out"
+graphql_calls=$(wc -l <"$FIX_GRAPHQL_CALLS" | tr -d ' ')
+assert_equals "follow-up body reuses one GraphQL thread response" "1" "$graphql_calls"
 
 echo ""
 echo "Test: build_pr_followup_body — diffHunk tail rendered as \`\`\`diff fence"


### PR DESCRIPTION
## Summary

Fetch review threads once per follow-up body and reuse the response across inline comments, summaries, and file references.

## Files Changed

.agents/scripts/post-merge-review-scanner.sh, .agents/scripts/tests/test-post-merge-review-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/post-merge-review-scanner.sh .agents/scripts/tests/test-post-merge-review-scanner.sh; bash .agents/scripts/tests/test-post-merge-review-scanner.sh (74 passed)

Resolves #27756


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.120 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 6m and 99,688 tokens on this as a headless worker.