### PR TITLE
GH#27778: wip: preserve host PATH in deployment coherence test

### DIFF
--- a/tests/test-cli-deployment-coherence.sh
+++ b/tests/test-cli-deployment-coherence.sh
@@ -37,7 +37,7 @@ exit 42
 EOF
 printf '#!/usr/bin/env bash\nexit 1\n' >"$TEST_HOME/bin/curl"
 chmod +x "$TEST_HOME/bin/curl"
-result=$(cd "$TEST_HOME" && HOME="$TEST_HOME" PATH="$TEST_HOME/bin:/usr/bin:/bin" bash "$REPO_DIR/bin/aidevops" --version)
+result=$(cd "$TEST_HOME" && HOME="$TEST_HOME" PATH="$TEST_HOME/bin:$PATH" bash "$REPO_DIR/bin/aidevops" --version)
 [[ "$result" == "aidevops 9.8.7" ]] || {
 	printf 'FAIL: real deployed CLI selected %s\n' "$result" >&2
 	exit 1


### PR DESCRIPTION
## Summary

Preserve the host toolchain PATH while keeping the mocked curl first in the deployment coherence test. The setup HOME concern is already superseded by setup.sh's explicit unset/empty HOME rejection and its regression coverage from #27253.

## Files Changed

tests/test-cli-deployment-coherence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Initial: git diff --check. Follow-up targeted shell test and ShellCheck run on the draft PR head.

Resolves #27778


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.120 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 3m and 55,927 tokens on this as a headless worker.