### PR TITLE
GH#27775: harden dependency normalization environment handling

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -817,7 +817,7 @@ normalize_repo_dependency_readiness() {
 	graph_json=$(jq -cn --arg slug "$slug" --argjson data "$repo_data" \
 		'{repos:{($slug):$data}}' 2>/dev/null) || return 1
 
-	local previous_cache_file="${DEP_GRAPH_CACHE_FILE}"
+	local previous_cache_file="${DEP_GRAPH_CACHE_FILE:-}"
 	local scoped_cache_file=""
 	scoped_cache_file=$(mktemp 2>/dev/null || true)
 	[[ -n "$scoped_cache_file" ]] || return 1
@@ -835,10 +835,11 @@ normalize_repo_dependency_readiness() {
 normalize_repo_dependency_readiness_if_due() {
 	local slug="$1"
 	local ttl_secs="${PULSE_DEP_NORMALIZE_TTL_SECS:-60}"
-	local marker_dir="${HOME}/.aidevops/cache/dependency-normalization"
+	local marker_dir="${HOME:+$HOME/.aidevops/cache/dependency-normalization}"
 	local marker_file=""
 	local marker_age=0
 	[[ -n "$slug" ]] || return 1
+	[[ -n "$marker_dir" ]] || return 1
 	[[ "$ttl_secs" =~ ^[0-9]+$ ]] || ttl_secs=60
 	marker_file="${marker_dir}/${slug//\//_}"
 

--- a/.agents/scripts/tests/test-dependency-readiness-normalization.sh
+++ b/.agents/scripts/tests/test-dependency-readiness-normalization.sh
@@ -139,11 +139,20 @@ assert_true "post-read removes blocked after concurrent queue transition" \
 log_verbose() {
 	return 0
 }
+_gh_with_timeout() {
+	local mode="$1"
+	shift
+	[[ "$mode" == "read" || "$mode" == "write" ]] || return 1
+	if "$@"; then
+		return 0
+	fi
+	return 1
+}
 gh() {
 	printf 'GraphQL: Validation failed: already been taken\n'
 	return 1
 }
-export -f gh log_verbose
+export -f gh log_verbose _gh_with_timeout
 # shellcheck disable=SC1090
 source "${SCRIPTS_DIR}/issue-sync-lib-parse.sh"
 # shellcheck disable=SC1090
@@ -189,6 +198,32 @@ export -f gh_issue_list
 built_graph=$(_dep_graph_build_repo_data "owner/repo")
 assert_eq "repo graph build prunes circular dependency" '[]' \
 	"$(printf '%s' "$built_graph" | jq -c '.blocked_by["10"].issue_nums')"
+
+if (
+	unset DEP_GRAPH_CACHE_FILE
+	_dep_graph_build_repo_data() {
+		printf '%s\n' '{"open_issues":[],"task_to_issue":{},"blocked_by":{},"defer_flags":{}}'
+		return 0
+	}
+	refresh_blocked_status_from_graph() {
+		return 0
+	}
+	normalize_repo_dependency_readiness "owner/repo"
+); then
+	assert_eq "repo normalization tolerates unset cache path" "safe" "safe"
+else
+	assert_eq "repo normalization tolerates unset cache path" "safe" "failed"
+fi
+
+home_result=$(
+	unset HOME
+	if normalize_repo_dependency_readiness_if_due "owner/repo"; then
+		printf '0'
+	else
+		printf '%s' "$?"
+	fi
+)
+assert_eq "repo normalization fails safely without HOME" "1" "$home_result"
 
 # The shared candidate selector must recover an all-blocked roadmap even when
 # called directly by a workers sweep without the full pulse preflight.


### PR DESCRIPTION
## Summary

Guard dependency normalization against unset cache and HOME variables, fail safely without a marker directory, and add strict-mode regression coverage.

## Files Changed

.agents/scripts/pulse-dep-graph.sh, .agents/scripts/tests/test-dependency-readiness-normalization.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dep-graph.sh .agents/scripts/tests/test-dependency-readiness-normalization.sh; bash .agents/scripts/tests/test-dependency-readiness-normalization.sh (23 passed)

Resolves #27775


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.120 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 4m and 78,333 tokens on this as a headless worker.