### PR TITLE
GH#27784: simplify worker blocker locking

### DIFF
--- a/.agents/scripts/worker-blocker-lock-recovery.mjs
+++ b/.agents/scripts/worker-blocker-lock-recovery.mjs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { randomUUID } from "node:crypto";
+import {
+  linkSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+export const LOCK_STALE_MS = 30_000;
+
+const LOCK_RETRY_MS = 4;
+const LOCK_RESTORE_RETRIES = 250;
+
+function sleepSync(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+export function recoveryMarkersActive(lockPath) {
+  const directory = dirname(lockPath);
+  const prefix = `${basename(lockPath)}.quarantine-`;
+  let active = false;
+  try {
+    for (const name of readdirSync(directory)) {
+      if (!name.startsWith(prefix)) continue;
+      const markerPath = join(directory, name);
+      try {
+        const markerStat = lstatSync(markerPath);
+        if (markerStat.isSymbolicLink() || Date.now() - markerStat.mtimeMs > LOCK_STALE_MS) {
+          unlinkSync(markerPath);
+        } else {
+          active = true;
+        }
+      } catch {
+        // Another contender completed recovery first.
+      }
+    }
+  } catch {
+    return false;
+  }
+  return active;
+}
+
+function readStaleLockSnapshot(lockPath) {
+  let snapshot = null;
+  try {
+    const stat = lstatSync(lockPath);
+    if (!stat.isSymbolicLink() && Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+      snapshot = { stat, token: readFileSync(lockPath, "utf8") };
+    }
+  } catch {
+    // A missing or concurrently moved lock cannot be reclaimed by this attempt.
+  }
+  return snapshot;
+}
+
+function isExactStaleLock(movedStat, movedToken, observed) {
+  const checks = [
+    !movedStat.isSymbolicLink(),
+    movedStat.dev === observed.stat.dev,
+    movedStat.ino === observed.stat.ino,
+    movedStat.mtimeMs === observed.stat.mtimeMs,
+    movedToken === observed.token,
+    Date.now() - movedStat.mtimeMs > LOCK_STALE_MS,
+  ];
+  return checks.every(Boolean);
+}
+
+function restoreQuarantinedLock(quarantinePath, lockPath) {
+  for (let attempt = 0; attempt < LOCK_RESTORE_RETRIES; attempt++) {
+    try {
+      linkSync(quarantinePath, lockPath);
+      unlinkSync(quarantinePath);
+      return;
+    } catch (error) {
+      if (error?.code !== "EEXIST") return;
+      sleepSync(LOCK_RETRY_MS);
+    }
+  }
+}
+
+export function quarantineStaleLock(lockPath) {
+  const observed = readStaleLockSnapshot(lockPath);
+  if (!observed) return false;
+
+  const quarantinePath = `${lockPath}.quarantine-${randomUUID()}`;
+  let reclaimed = false;
+  try {
+    renameSync(lockPath, quarantinePath);
+    const movedStat = lstatSync(quarantinePath);
+    const movedToken = readFileSync(quarantinePath, "utf8");
+    if (isExactStaleLock(movedStat, movedToken, observed)) {
+      unlinkSync(quarantinePath);
+      reclaimed = true;
+    } else if (movedStat.isSymbolicLink()) {
+      unlinkSync(quarantinePath);
+    } else {
+      restoreQuarantinedLock(quarantinePath, lockPath);
+    }
+  } catch {
+    // Another contender completed recovery first.
+  }
+  return reclaimed;
+}

--- a/.agents/scripts/worker-blocker-lock.mjs
+++ b/.agents/scripts/worker-blocker-lock.mjs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+
+import {
+  LOCK_STALE_MS,
+  quarantineStaleLock,
+  recoveryMarkersActive,
+} from "./worker-blocker-lock-recovery.mjs";
+
+const LOCK_RETRIES = 25;
+const LOCK_RETRY_MS = 4;
+
+const LOCK_ACQUIRED = "acquired";
+const LOCK_FAILED = "failed";
+const LOCK_RETRY = "retry";
+
+function sleepSync(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function tryCreateOwnedLock(lockPath, token) {
+  let descriptor;
+  try {
+    descriptor = openSync(lockPath, "wx", 0o600);
+    writeFileSync(descriptor, token);
+    return LOCK_ACQUIRED;
+  } catch (error) {
+    if (descriptor !== undefined) {
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // The incomplete lock remains stale and can be reclaimed.
+      }
+    }
+    return error?.code === "EEXIST" ? "exists" : LOCK_FAILED;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+export function releaseWorkerBlockerLock(lockPath, token) {
+  try {
+    if (readFileSync(lockPath, "utf8") !== token) return;
+    unlinkSync(lockPath);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+function removeStalePrimaryLock(lockPath) {
+  try {
+    const lockStat = lstatSync(lockPath);
+    if (lockStat.isSymbolicLink() || Date.now() - lockStat.mtimeMs <= LOCK_STALE_MS) return false;
+    unlinkSync(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function finishInitialAcquisition(lockPath, reclaimPath, token) {
+  let result = LOCK_ACQUIRED;
+  if (existsSync(reclaimPath) || recoveryMarkersActive(reclaimPath)) {
+    releaseWorkerBlockerLock(lockPath, token);
+    sleepSync(LOCK_RETRY_MS);
+    result = LOCK_RETRY;
+  }
+  return result;
+}
+
+function reclaimStaleLock(lockPath, reclaimPath, token) {
+  const reclaimToken = randomUUID();
+  let result = LOCK_RETRY;
+  if (tryCreateOwnedLock(reclaimPath, reclaimToken) === LOCK_ACQUIRED) {
+    if (recoveryMarkersActive(reclaimPath)) {
+      releaseWorkerBlockerLock(reclaimPath, reclaimToken);
+      sleepSync(LOCK_RETRY_MS);
+    } else {
+      try {
+        removeStalePrimaryLock(lockPath);
+        if (tryCreateOwnedLock(lockPath, token) === LOCK_ACQUIRED) result = LOCK_ACQUIRED;
+      } finally {
+        releaseWorkerBlockerLock(reclaimPath, reclaimToken);
+      }
+    }
+  } else {
+    sleepSync(LOCK_RETRY_MS);
+  }
+  return result;
+}
+
+function handleExistingLock(lockPath, reclaimPath, token) {
+  const lockStat = lstatSync(lockPath);
+  let result = LOCK_RETRY;
+  if (lockStat.isSymbolicLink()) {
+    result = LOCK_FAILED;
+  } else if (Date.now() - lockStat.mtimeMs <= LOCK_STALE_MS) {
+    sleepSync(LOCK_RETRY_MS);
+  } else {
+    result = reclaimStaleLock(lockPath, reclaimPath, token);
+  }
+  return result;
+}
+
+function tryAcquireLock(lockPath, reclaimPath, token) {
+  let result = LOCK_RETRY;
+  try {
+    if (recoveryMarkersActive(reclaimPath)) {
+      sleepSync(LOCK_RETRY_MS);
+    } else if (existsSync(reclaimPath)) {
+      quarantineStaleLock(reclaimPath);
+      sleepSync(LOCK_RETRY_MS);
+    } else {
+      const initialResult = tryCreateOwnedLock(lockPath, token);
+      if (initialResult === LOCK_ACQUIRED) {
+        result = finishInitialAcquisition(lockPath, reclaimPath, token);
+      } else if (initialResult === LOCK_FAILED) {
+        result = LOCK_FAILED;
+      } else {
+        result = handleExistingLock(lockPath, reclaimPath, token);
+      }
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") result = LOCK_FAILED;
+    else sleepSync(LOCK_RETRY_MS);
+  }
+  return result;
+}
+
+export function acquireWorkerBlockerLock(lockPath) {
+  const token = randomUUID();
+  const reclaimPath = `${lockPath}.reclaim`;
+  let acquiredToken = "";
+  for (let attempt = 0; attempt < LOCK_RETRIES; attempt++) {
+    const result = tryAcquireLock(lockPath, reclaimPath, token);
+    if (result === LOCK_ACQUIRED) {
+      acquiredToken = token;
+      break;
+    }
+    if (result === LOCK_FAILED) break;
+  }
+  return acquiredToken;
+}

--- a/.agents/scripts/worker-blocker-log.mjs
+++ b/.agents/scripts/worker-blocker-log.mjs
@@ -7,37 +7,30 @@ import {
   constants,
   existsSync,
   fchmodSync,
-  linkSync,
   lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
-  readdirSync,
   renameSync,
   statSync,
-  unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+
+import {
+  acquireWorkerBlockerLock as acquireLock,
+  releaseWorkerBlockerLock as releaseLock,
+} from "./worker-blocker-lock.mjs";
 
 export const WORKER_BLOCKER_SCHEMA = "aidevops-worker-blocker/v1";
 export const DEFAULT_WORKER_BLOCKER_LOG_MAX_BYTES = 5 * 1024 * 1024;
 
 const MIN_LOG_MAX_BYTES = 512;
-const LOCK_STALE_MS = 30_000;
-const LOCK_RETRIES = 25;
-const LOCK_RETRY_MS = 4;
-const LOCK_RESTORE_RETRIES = 250;
 const MAX_DETAIL_LENGTH = 500;
 const MAX_FIELD_LENGTH = 200;
 const CREDENTIAL_PATTERN = /(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
-
-function sleepSync(milliseconds) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
-}
 
 function cleanText(value, maxLength, options = {}) {
   if (value === null || value === undefined) return "";
@@ -99,173 +92,6 @@ export function normalizeWorkerBlockerEvent(input = {}, options = {}) {
     grantable,
     detail: cleanText(input.detail || "", MAX_DETAIL_LENGTH, options),
   };
-}
-
-function tryCreateOwnedLock(lockPath, token) {
-  let descriptor;
-  try {
-    descriptor = openSync(lockPath, "wx", 0o600);
-    writeFileSync(descriptor, token);
-    return "acquired";
-  } catch (error) {
-    if (descriptor !== undefined) {
-      try {
-        unlinkSync(lockPath);
-      } catch {
-        // The incomplete lock remains stale and can be reclaimed.
-      }
-    }
-    return error?.code === "EEXIST" ? "exists" : "failed";
-  } finally {
-    if (descriptor !== undefined) closeSync(descriptor);
-  }
-}
-
-function releaseLock(lockPath, token) {
-  try {
-    if (readFileSync(lockPath, "utf8") !== token) return;
-    unlinkSync(lockPath);
-  } catch (error) {
-    if (error?.code !== "ENOENT") throw error;
-  }
-}
-
-function removeStalePrimaryLock(lockPath) {
-  try {
-    const lockStat = lstatSync(lockPath);
-    if (lockStat.isSymbolicLink() || Date.now() - lockStat.mtimeMs <= LOCK_STALE_MS) return false;
-    unlinkSync(lockPath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function recoveryMarkersActive(lockPath) {
-  const directory = dirname(lockPath);
-  const prefix = `${basename(lockPath)}.quarantine-`;
-  let active = false;
-  try {
-    for (const name of readdirSync(directory)) {
-      if (!name.startsWith(prefix)) continue;
-      const markerPath = join(directory, name);
-      try {
-        const markerStat = lstatSync(markerPath);
-        if (markerStat.isSymbolicLink() || Date.now() - markerStat.mtimeMs > LOCK_STALE_MS) {
-          unlinkSync(markerPath);
-        } else {
-          active = true;
-        }
-      } catch {
-        // Another contender completed recovery first.
-      }
-    }
-  } catch {
-    return false;
-  }
-  return active;
-}
-
-function quarantineStaleLock(lockPath) {
-  let observedStat;
-  let observedToken;
-  try {
-    observedStat = lstatSync(lockPath);
-    if (observedStat.isSymbolicLink() || Date.now() - observedStat.mtimeMs <= LOCK_STALE_MS) return false;
-    observedToken = readFileSync(lockPath, "utf8");
-  } catch {
-    return false;
-  }
-
-  const quarantinePath = `${lockPath}.quarantine-${randomUUID()}`;
-  try {
-    renameSync(lockPath, quarantinePath);
-    const movedStat = lstatSync(quarantinePath);
-    const movedToken = readFileSync(quarantinePath, "utf8");
-    const exactStaleLock = !movedStat.isSymbolicLink()
-      && movedStat.dev === observedStat.dev
-      && movedStat.ino === observedStat.ino
-      && movedStat.mtimeMs === observedStat.mtimeMs
-      && movedToken === observedToken
-      && Date.now() - movedStat.mtimeMs > LOCK_STALE_MS;
-    if (exactStaleLock) {
-      unlinkSync(quarantinePath);
-      return true;
-    }
-    if (movedStat.isSymbolicLink()) {
-      unlinkSync(quarantinePath);
-      return false;
-    }
-    for (let attempt = 0; attempt < LOCK_RESTORE_RETRIES; attempt++) {
-      try {
-        linkSync(quarantinePath, lockPath);
-        unlinkSync(quarantinePath);
-        return false;
-      } catch (error) {
-        if (error?.code !== "EEXIST") return false;
-        sleepSync(LOCK_RETRY_MS);
-      }
-    }
-  } catch {
-    return false;
-  }
-  return false;
-}
-
-function acquireLock(lockPath) {
-  const token = randomUUID();
-  const reclaimPath = `${lockPath}.reclaim`;
-  for (let attempt = 0; attempt < LOCK_RETRIES; attempt++) {
-    try {
-      if (recoveryMarkersActive(reclaimPath)) {
-        sleepSync(LOCK_RETRY_MS);
-        continue;
-      }
-      if (existsSync(reclaimPath)) {
-        quarantineStaleLock(reclaimPath);
-        sleepSync(LOCK_RETRY_MS);
-        continue;
-      }
-      const lockResult = tryCreateOwnedLock(lockPath, token);
-      if (lockResult === "acquired") {
-        if (existsSync(reclaimPath) || recoveryMarkersActive(reclaimPath)) {
-          releaseLock(lockPath, token);
-          sleepSync(LOCK_RETRY_MS);
-          continue;
-        }
-        return token;
-      }
-      if (lockResult === "failed") return "";
-
-      const lockStat = lstatSync(lockPath);
-      if (lockStat.isSymbolicLink()) return "";
-      if (Date.now() - lockStat.mtimeMs <= LOCK_STALE_MS) {
-        sleepSync(LOCK_RETRY_MS);
-        continue;
-      }
-
-      const reclaimToken = randomUUID();
-      if (tryCreateOwnedLock(reclaimPath, reclaimToken) !== "acquired") {
-        sleepSync(LOCK_RETRY_MS);
-        continue;
-      }
-      if (recoveryMarkersActive(reclaimPath)) {
-        releaseLock(reclaimPath, reclaimToken);
-        sleepSync(LOCK_RETRY_MS);
-        continue;
-      }
-      try {
-        removeStalePrimaryLock(lockPath);
-        if (tryCreateOwnedLock(lockPath, token) === "acquired") return token;
-      } finally {
-        releaseLock(reclaimPath, reclaimToken);
-      }
-    } catch (error) {
-      if (error?.code !== "ENOENT") return "";
-      sleepSync(LOCK_RETRY_MS);
-    }
-  }
-  return "";
 }
 
 function newestCompleteLinesWithinBudget(content, budget) {


### PR DESCRIPTION
## Summary

- extract worker blocker lock acquisition and stale-lock recovery into focused private modules
- replace the high-complexity acquisition flow with small outcome-based helpers
- preserve the logger's public exports, JSONL behavior, permissions, and concurrency semantics

## Testing

- `qlty smells .agents/scripts/worker-blocker-log.mjs .agents/scripts/worker-blocker-lock.mjs .agents/scripts/worker-blocker-lock-recovery.mjs --no-snippets --quiet`
- `qlty check .agents/scripts/worker-blocker-log.mjs .agents/scripts/worker-blocker-lock.mjs .agents/scripts/worker-blocker-lock-recovery.mjs --no-progress`
- `node --check` on all three modules
- `node --test .agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs` (7 passed)

## Runtime Testing

Self-assessed as a low-risk structural refactor. The focused tests exercise stale-lock recovery, parallel recovery, concurrent appends, symlink rejection, bounded trimming, and fail-open behavior.

## Complexity Bump Justification

The base scanner reported five Qlty smells at `.agents/scripts/worker-blocker-log.mjs:1`, including total complexity 108. The head splits private lock mechanics into `.agents/scripts/worker-blocker-lock.mjs:1` and `.agents/scripts/worker-blocker-lock-recovery.mjs:1`; all three head files are individually below the Qlty file-complexity threshold and introduce no new smells.

Measurement: base=5 smells, head=0 smells, new=0 smells. The `ratchet-bump` label records the intentional file split while the measured complexity and smell count both decrease.

Resolves #27784

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 8m and 122,500 tokens on this as a headless worker.