### PR TITLE
t18125: feat: measure exact GitHub transport attempts

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -189,7 +189,39 @@ done
 if [[ $_INST_LOADED -eq 0 ]]; then
 	gh_record_call() { return 0; }
 fi
+if ! type gh_new_logical_id >/dev/null 2>&1; then
+	gh_new_logical_id() {
+		printf 'shim-%s-%s\n' "${BASHPID:-$$}" "${RANDOM:-0}"
+		return 0
+	}
+fi
+if ! type gh_attempt_count_for_logical >/dev/null 2>&1; then
+	gh_attempt_count_for_logical() {
+		local ignored_logical_id="$1"
+		: "$ignored_logical_id"
+		printf '0\n'
+		return 0
+	}
+fi
+if ! type gh_run_transport_attempt >/dev/null 2>&1; then
+	gh_run_transport_attempt() {
+		local ignored_path="$1"; shift
+		local ignored_caller="$1"; shift
+		local ignored_logical_id="$1"; shift
+		local ignored_page="$1"; shift
+		local ignored_retry="$1"; shift
+		: "$ignored_path" "$ignored_caller" "$ignored_logical_id" "$ignored_page" "$ignored_retry"
+		[[ "${1:-}" == "--" ]] && shift
+		"$@"
+		return $?
+	}
+fi
 unset _cand _INST_LOADED
+
+# One ID follows the complete wrapper invocation, including REST translation,
+# each explicit page, and any GraphQL fallback retry.
+AIDEVOPS_GH_LOGICAL_ID="${AIDEVOPS_GH_LOGICAL_ID:-$(gh_new_logical_id)}"
+export AIDEVOPS_GH_LOGICAL_ID
 
 # _shim_classify_endpoint <sub1> [<sub2>]
 # Classify a gh invocation for instrumentation. Returns one of:
@@ -246,6 +278,40 @@ _shim_caller_label() {
 	*) printf 'gh_%s%s' "${sub1:-unknown}" "${sub2:+_${sub2}}" ;;
 	esac
 	return 0
+}
+
+_shim_transport_page() {
+	local arg=""
+	local page=1
+	for arg in "$@"; do
+		if [[ "$arg" == "--paginate" ]]; then
+			# Native gh owns the internal page loop, so one process is not proof of
+			# one request. Mark this attempt as opaque rather than overclaiming.
+			printf '0'
+			return 0
+		fi
+		if [[ "$arg" =~ (^|[?\&])page=([0-9]+)($|\&) ]]; then
+			page="${BASH_REMATCH[2]}"
+		fi
+	done
+	printf '%s' "$page"
+	return 0
+}
+
+_shim_run_transport() {
+	local executable="$1"; shift
+	local path="$1"; shift
+	local caller="$1"; shift
+	local retry="$1"; shift
+	local page=1
+	local decision="${AIDEVOPS_GH_ROUTE_DECISION:-}"
+	page=$(_shim_transport_page "$@")
+	if [[ "$page" == "0" ]]; then
+		decision="native-pagination-opaque"
+	fi
+	AIDEVOPS_GH_ROUTE_DECISION="$decision" gh_run_transport_attempt \
+		"$path" "$caller" "$AIDEVOPS_GH_LOGICAL_ID" "$page" "$retry" -- "$executable" "$@"
+	return $?
 }
 
 # -----------------------------------------------------------------------------
@@ -369,7 +435,7 @@ _shim_repo_role() {
 	# fail-closed to contributor.
 	if [[ -n "$repo_slug" && "$repo_slug" == */* && -n "${REAL_GH:-}" ]]; then
 		slug_owner="${repo_slug%%/*}"
-		current_user=$("$REAL_GH" api user --jq '.login' 2>/dev/null || true)
+		current_user=$(_shim_run_transport "$REAL_GH" rest gh_api_user 0 api user --jq '.login' 2>/dev/null || true)
 		if [[ -n "$current_user" && ( "$configured_maintainer" == "$current_user" || "$slug_owner" == "$current_user" ) ]]; then
 			printf 'maintainer\n'
 			return 0
@@ -446,21 +512,36 @@ api:*)
 	;;
 *)
 	_real_gh="$(_find_real_gh)" || {
-		echo "[aidevops] gh shim: real gh binary not found on PATH" >&2
+		printf '[aidevops] gh shim: real gh binary not found on PATH\n' >&2
 		exit 127
 	}
 	# GH#21857/t3448: instrument every passthrough gh call (pr merge, pr checks,
 	# run list, repo clone, etc.) that previously bypassed all recording.
-	gh_record_call "$(_shim_classify_endpoint "${1:-}" "${2:-}")" "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
-	exec "$_real_gh" "$@"
+	_transport_path=$(_shim_classify_endpoint "${1:-}" "${2:-}")
+	_transport_caller=$(_shim_caller_label "${1:-}" "${2:-}")
+	gh_record_call "$_transport_path" "$_transport_caller" 2>/dev/null || true
+	_shim_run_transport "$_real_gh" "$_transport_path" "$_transport_caller" 0 "$@"
+	exit $?
 	;;
 esac
 
 export _AIDEVOPS_GH_SHIM_ACTIVE=1
 
 REAL_GH="$(_find_real_gh)" || {
-	echo "[aidevops] gh shim: real gh binary not found; aborting" >&2
+	printf '[aidevops] gh shim: real gh binary not found; aborting\n' >&2
 	exit 127
+}
+
+# REST translators are sourced into this process and invoke `gh api` by name.
+# Keep those calls at the same logical ID while bypassing PATH recursion and
+# recording each native page/try at the actual execution boundary.
+gh() {
+	local path=""
+	local caller=""
+	path=$(_shim_classify_endpoint "${1:-}" "${2:-}")
+	caller=$(_shim_caller_label "${1:-}" "${2:-}")
+	_shim_run_transport "$REAL_GH" "$path" "$caller" "${AIDEVOPS_GH_RETRY_INDEX:-0}" "$@"
+	return $?
 }
 
 # -----------------------------------------------------------------------------
@@ -548,7 +629,11 @@ fi
 if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 	# Bypass — explicit override.
 	if [[ "${AIDEVOPS_GH_SHIM_NO_REST_REWRITE:-0}" == "1" ]]; then
-		exec "$REAL_GH" "$@"
+		_transport_path=$(_shim_classify_endpoint "${1:-}" "${2:-}")
+		_transport_caller=$(_shim_caller_label "${1:-}" "${2:-}")
+		gh_record_call "$_transport_path" "$_transport_caller" 2>/dev/null || true
+		_shim_run_transport "$REAL_GH" "$_transport_path" "$_transport_caller" 0 "$@"
+		exit $?
 	fi
 
 	# _shim_extract_repo_and_args: Parse --repo/-R from args and build the
@@ -685,8 +770,13 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# are already printed to stderr by the _rest_* functions.
 		# Conservative: always fall through to real gh.
 		# GH#21857/t3448: record the graphql call — the real gh will use GraphQL.
-		gh_record_call graphql "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
-		exec "$REAL_GH" "$@"
+		_transport_caller=$(_shim_caller_label "${1:-}" "${2:-}")
+		_transport_retry=$(gh_attempt_count_for_logical "$AIDEVOPS_GH_LOGICAL_ID")
+		[[ "$_transport_retry" =~ ^[0-9]+$ ]] || _transport_retry=0
+		gh_record_call graphql "$_transport_caller" "" "" rest-fallback-graphql 2>/dev/null || true
+		AIDEVOPS_GH_ROUTE_DECISION=rest-fallback-graphql \
+			_shim_run_transport "$REAL_GH" graphql "$_transport_caller" "$_transport_retry" "$@"
+		exit $?
 	fi
 fi
 
@@ -705,7 +795,11 @@ done
 
 if [[ -z "$SIG_HELPER" ]]; then
 	# No helper available — fail-open: exec real gh unchanged.
-	exec "$REAL_GH" "$@"
+	_transport_path=$(_shim_classify_endpoint "${1:-}" "${2:-}")
+	_transport_caller=$(_shim_caller_label "${1:-}" "${2:-}")
+	gh_record_call "$_transport_path" "$_transport_caller" 2>/dev/null || true
+	_shim_run_transport "$REAL_GH" "$_transport_path" "$_transport_caller" 0 "$@"
+	exit $?
 fi
 
 # -----------------------------------------------------------------------------
@@ -1450,8 +1544,10 @@ if [[ "${1:-}" == "api" ]]; then
 		fi
 	fi
 	# GH#21857: instrument gh api calls — rest or graphql depending on path.
-	gh_record_call "$(_shim_classify_endpoint "${1:-}" "${2:-}")" gh-shim 2>/dev/null || true
-	exec "$REAL_GH" "${_modified_args[@]}"
+	_transport_path=$(_shim_classify_endpoint "${1:-}" "${2:-}")
+	gh_record_call "$_transport_path" gh-shim 2>/dev/null || true
+	_shim_run_transport "$REAL_GH" "$_transport_path" gh-shim 0 "${_modified_args[@]}"
+	exit $?
 fi
 
 # -----------------------------------------------------------------------------
@@ -1511,8 +1607,8 @@ fi
 # --- --body-file case --------------------------------------------------------
 # t2861: write the augmented content to a fresh temp file rather than appending
 # to the user's source. The user's brief on disk stays byte-identical after the
-# gh call. The temp file is cleaned up by a background reaper (the shim ends
-# with exec, which replaces the process and clears traps).
+# gh call. The temp file is cleaned up by a background reaper because the native
+# transport may outlive setup-time shell traps.
 if [[ $_body_file_idx -ge 0 && -n "$_body_file_val" && -f "$_body_file_val" ]]; then
 	if ! grep -q "<!-- aidevops:sig -->" "$_body_file_val" 2>/dev/null; then
 		_file_content=$(<"$_body_file_val") || _file_content=""
@@ -1528,9 +1624,8 @@ if [[ $_body_file_idx -ge 0 && -n "$_body_file_val" && -f "$_body_file_val" ]]; 
 					else
 						_modified_args[_body_file_idx + 1]="$_tmp_body_file"
 					fi
-					# Background reaper: exec replaces this process so EXIT traps
-					# never fire. Fork a sleep-then-rm to clean up the temp file
-					# after gh has had time to read it (30s >> typical gh runtime).
+					# Fork a sleep-then-rm reaper so the temp survives long enough
+					# for native gh to read it (30s >> typical gh runtime).
 					( sleep 30 && rm -f "$_tmp_body_file" ) &
 					disown
 				else
@@ -1570,5 +1665,7 @@ fi
 
 # GH#21857: instrument write commands (issue comment/create/edit, pr create/
 # comment/edit) — these all use the GraphQL endpoint.
-gh_record_call graphql "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
-exec "$REAL_GH" "${_modified_args[@]}"
+_transport_caller=$(_shim_caller_label "${1:-}" "${2:-}")
+gh_record_call graphql "$_transport_caller" 2>/dev/null || true
+_shim_run_transport "$REAL_GH" graphql "$_transport_caller" 0 "${_modified_args[@]}"
+exit $?

--- a/.agents/scripts/gh-api-aggregate.awk
+++ b/.agents/scripts/gh-api-aggregate.awk
@@ -1,130 +1,299 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # =============================================================================
-# gh-api-aggregate.awk -- Aggregate gh API call records into JSON (t2902)
+# gh-api-aggregate.awk -- Aggregate logical gh events and transport attempts
 # =============================================================================
-# Reads tab-separated log lines `<unix_ts>\t<caller>\t<path>` (legacy) or
-# `<unix_ts>\t<caller>\t<path>\t<auth>\t<pool>\t<decision>\t<budget>` and writes a
-# JSON report keyed by caller. Designed for BSD awk (macOS default) — does
-# not use systime() or other gawk extensions; receives `now` from the caller.
+# Reads legacy three/seven-column records and versioned v2 records emitted by
+# gh-api-instrument.sh. Legacy rows remain logical observations; they are never
+# represented as proven network attempts. Designed for BSD awk (macOS default).
 #
-# Required -v variables:
-#   now    — current unix timestamp (passed from bash; BSD awk lacks systime)
-#   cutoff — entries older than this unix ts are ignored
-#   window — window seconds (echoed in _meta.window_seconds)
-#
-# Path enum:
-#   graphql | rest | search-graphql | search-rest | other
-#
-# Output: one JSON document on stdout.
-#
-# Used by: gh-api-instrument.sh (gh_aggregate_calls)
+# Required -v variables: now, cutoff, window
+# Output: one deterministic JSON document on stdout.
 # =============================================================================
 
-BEGIN { total = 0 }
+BEGIN {
+	total_calls = 0
+	logical_events = 0
+	cache_events = 0
+	legacy_events = 0
+	attempted_requests = 0
+}
 
-function emit_count_section(title, keys, counts,    n, i, j, tmp, key, swap) {
-	printf "  \"%s\": {\n", title
-	n = 0
-	for (key in keys) tmp[++n] = key
+function metric_add(group, value, metric, amount,    key) {
+	if (value == "") value = "unknown"
+	key = group SUBSEP value
+	group_keys[key] = 1
+	metrics[key SUBSEP metric] += amount
+}
+
+function metric_get(group, value, metric) {
+	return metrics[group SUBSEP value SUBSEP metric] + 0
+}
+
+function metric_add_dimensions(caller, path, auth, pool, decision, metric, amount) {
+	metric_add("caller", caller, metric, amount)
+	metric_add("path", path, metric, amount)
+	metric_add("auth", auth, metric, amount)
+	metric_add("pool", pool, metric, amount)
+	metric_add("decision", decision, metric, amount)
+}
+
+function sort_values(values, n,    i, j, swap) {
 	for (i = 2; i <= n; i++) {
-		for (j = i; j > 1 && tmp[j-1] > tmp[j]; j--) {
-			swap = tmp[j]; tmp[j] = tmp[j-1]; tmp[j-1] = swap
+		for (j = i; j > 1 && values[j - 1] > values[j]; j--) {
+			swap = values[j]
+			values[j] = values[j - 1]
+			values[j - 1] = swap
 		}
 	}
+}
+
+function emit_group(title, group,    pair, parts, values, n, i, value) {
+	printf "  \"%s\": {\n", title
+	n = 0
+	for (pair in group_keys) {
+		split(pair, parts, SUBSEP)
+		if (parts[1] == group) values[++n] = parts[2]
+	}
+	sort_values(values, n)
 	for (i = 1; i <= n; i++) {
-		key = tmp[i]
+		value = values[i]
 		if (i > 1) print ","
-		printf "    \"%s\": {\"total\": %d}", key, counts[key] + 0
+		printf "    \"%s\": {\n", value
+		printf "      \"graphql_calls\": %d,\n", metric_get(group, value, "graphql_calls")
+		printf "      \"rest_calls\": %d,\n", metric_get(group, value, "rest_calls")
+		printf "      \"search_graphql_calls\": %d,\n", metric_get(group, value, "search_graphql_calls")
+		printf "      \"search_rest_calls\": %d,\n", metric_get(group, value, "search_rest_calls")
+		printf "      \"other_calls\": %d,\n", metric_get(group, value, "other_calls")
+		printf "      \"total\": %d,\n", metric_get(group, value, "total")
+		printf "      \"logical_events\": %d,\n", metric_get(group, value, "logical_events")
+		printf "      \"cache_events\": %d,\n", metric_get(group, value, "cache_events")
+		printf "      \"legacy_events\": %d,\n", metric_get(group, value, "legacy_events")
+		printf "      \"attempted_requests\": %d,\n", metric_get(group, value, "attempted_requests")
+		printf "      \"retries\": %d,\n", metric_get(group, value, "retries")
+		printf "      \"pages\": %d,\n", metric_get(group, value, "pages")
+		printf "      \"additional_pages\": %d,\n", metric_get(group, value, "additional_pages")
+		printf "      \"successful_attempts\": %d,\n", metric_get(group, value, "successful_attempts")
+		printf "      \"failed_attempts\": %d,\n", metric_get(group, value, "failed_attempts")
+		printf "      \"elapsed_ms\": %d,\n", metric_get(group, value, "elapsed_ms")
+		printf "      \"known_quota_cost\": %d,\n", metric_get(group, value, "known_quota_cost")
+		printf "      \"unknown_quota_cost_attempts\": %d\n", metric_get(group, value, "unknown_quota_cost_attempts")
+		printf "    }"
 	}
 	if (n > 0) print ""
 	print "  }"
 }
 
-# Sanity: skip lines that do not parse as <int>\t<caller>\t<path>
-$1 ~ /^[0-9]+$/ && NF >= 3 && $1 >= cutoff {
-	caller = $2
-	path = $3
+function record_budget(pool, budget, ts) {
+	if (budget !~ /^[0-9]+$/) return
+	budget_keys[pool] = 1
+	if (!(pool in budget_min) || budget + 0 < budget_min[pool] + 0) budget_min[pool] = budget
+	if (!(pool in budget_last_ts) || ts >= budget_last_ts[pool]) {
+		budget_last_ts[pool] = ts
+		budget_last[pool] = budget
+	}
+}
+
+function emit_budgets(    pool, values, n, i) {
+	print "  \"budget_by_pool\": {"
+	n = 0
+	for (pool in budget_keys) values[++n] = pool
+	sort_values(values, n)
+	for (i = 1; i <= n; i++) {
+		pool = values[i]
+		if (i > 1) print ","
+		printf "    \"%s\": {\"min_remaining\": %d, \"last_remaining\": %d}", pool, budget_min[pool] + 0, budget_last[pool] + 0
+	}
+	if (n > 0) print ""
+	print "  }"
+}
+
+# Reject records without a numeric timestamp or the legacy prefix.
+$1 !~ /^[0-9]+$/ || NF < 3 {
+	malformed_records++
+	next
+}
+
+{
+	ts = $1 + 0
+	caller = ($2 != "") ? $2 : "unknown"
+	path = ($3 != "") ? $3 : "other"
 	auth = (NF >= 4 && $4 != "") ? $4 : "unknown"
 	pool = (NF >= 5 && $5 != "") ? $5 : path
 	decision = (NF >= 6 && $6 != "") ? $6 : "unspecified"
 	budget = (NF >= 7) ? $7 : ""
-	callers[caller] = 1
-	auth_keys[auth] = 1
-	pool_keys[pool] = 1
-	decision_keys[decision] = 1
-	if      (path == "graphql")        graphql[caller]++
-	else if (path == "rest")           rest[caller]++
-	else if (path == "search-graphql") sg[caller]++
-	else if (path == "search-rest")    sr[caller]++
-	else                                other[caller]++
-	auth_counts[auth]++
-	pool_counts[pool]++
-	decision_counts[decision]++
-	if (budget ~ /^[0-9]+$/) {
-		budget_keys[pool] = 1
-		budget_last[pool] = budget
-		if (!(pool in budget_min) || budget + 0 < budget_min[pool] + 0) budget_min[pool] = budget
+	version = (NF >= 8) ? $8 : ""
+
+	if (version == "v2" && NF < 17) {
+		malformed_records++
+		malformed_v2_records++
+		next
 	}
-	total++
+
+	if (version == "v2") {
+		kind = ($9 != "") ? $9 : "logical"
+		logical_id = $10
+		attempt_id = $11
+		page = $12
+		retry = $13
+		outcome = ($14 != "") ? $14 : "unknown"
+		http_status = $15
+		elapsed_ms = $16
+		quota_cost = $17
+	} else {
+		kind = "legacy"
+		logical_id = ""
+		attempt_id = ""
+		page = ""
+		retry = ""
+		outcome = "unknown"
+		http_status = ""
+		elapsed_ms = ""
+		quota_cost = ""
+		retained_legacy_records++
+	}
+
+	retained_records++
+	if (first_retained_record_ts == 0 || ts < first_retained_record_ts) first_retained_record_ts = ts
+	if (ts > last_retained_record_ts) last_retained_record_ts = ts
+
+	if (kind == "attempt") {
+		if (attempt_id == "" || attempt_id == "unknown") {
+			unidentified_attempts++
+		} else if (attempt_id in seen_attempt_id) {
+			duplicate_attempt_ids++
+			next
+		} else {
+			seen_attempt_id[attempt_id] = 1
+		}
+		if (page !~ /^[0-9]+$/ || page + 0 < 1) unknown_page_attempts++
+		if (first_retained_attempt_ts == 0 || ts < first_retained_attempt_ts) first_retained_attempt_ts = ts
+		if (ts > last_retained_attempt_ts) last_retained_attempt_ts = ts
+	}
+
+	if (ts < cutoff) next
+	window_records++
+	record_budget(pool, budget, ts)
+	if (logical_id != "" && logical_id != "unknown" && !(logical_id in seen_window_logical_id)) {
+		seen_window_logical_id[logical_id] = 1
+		logical_operations++
+	}
+
+	if (kind != "attempt") {
+		total_calls++
+		metric_add_dimensions(caller, path, auth, pool, decision, "total", 1)
+		if (path == "graphql") call_metric = "graphql_calls"
+		else if (path == "rest") call_metric = "rest_calls"
+		else if (path == "search-graphql") call_metric = "search_graphql_calls"
+		else if (path == "search-rest") call_metric = "search_rest_calls"
+		else call_metric = "other_calls"
+		metric_add_dimensions(caller, path, auth, pool, decision, call_metric, 1)
+		if (kind == "cache") {
+			cache_events++
+			metric_add_dimensions(caller, path, auth, pool, decision, "cache_events", 1)
+		} else if (kind == "legacy") {
+			legacy_events++
+			metric_add_dimensions(caller, path, auth, pool, decision, "legacy_events", 1)
+		} else {
+			logical_events++
+			metric_add_dimensions(caller, path, auth, pool, decision, "logical_events", 1)
+		}
+		next
+	}
+
+	attempted_requests++
+	metric_add_dimensions(caller, path, auth, pool, decision, "attempted_requests", 1)
+	metric_add("outcome", outcome, "attempted_requests", 1)
+	if (retry ~ /^[0-9]+$/ && retry + 0 > 0) {
+		retries++
+		metric_add_dimensions(caller, path, auth, pool, decision, "retries", 1)
+		metric_add("outcome", outcome, "retries", 1)
+	}
+	if (page ~ /^[0-9]+$/ && page + 0 > 0) {
+		pages++
+		metric_add_dimensions(caller, path, auth, pool, decision, "pages", 1)
+		if (page + 0 > 1) {
+			additional_pages++
+			metric_add_dimensions(caller, path, auth, pool, decision, "additional_pages", 1)
+		}
+	}
+	if (outcome == "success") {
+		successful_attempts++
+		metric_add_dimensions(caller, path, auth, pool, decision, "successful_attempts", 1)
+	} else {
+		failed_attempts++
+		metric_add_dimensions(caller, path, auth, pool, decision, "failed_attempts", 1)
+	}
+	if (elapsed_ms ~ /^[0-9]+$/) {
+		elapsed_ms_total += elapsed_ms
+		metric_add_dimensions(caller, path, auth, pool, decision, "elapsed_ms", elapsed_ms)
+	}
+	if (quota_cost ~ /^[0-9]+$/) {
+		known_quota_cost += quota_cost
+		metric_add_dimensions(caller, path, auth, pool, decision, "known_quota_cost", quota_cost)
+	} else {
+		unknown_quota_cost_attempts++
+		metric_add_dimensions(caller, path, auth, pool, decision, "unknown_quota_cost_attempts", 1)
+	}
+	if (http_status ~ /^[0-9]+$/) metric_add("http_status", http_status, "attempted_requests", 1)
 }
 
 END {
+	effective_window_seconds = 0
+	if (first_retained_attempt_ts > 0 && last_retained_attempt_ts >= first_retained_attempt_ts) {
+		effective_window_seconds = last_retained_attempt_ts - first_retained_attempt_ts
+	}
+	attempts_exact = (duplicate_attempt_ids == 0 && unidentified_attempts == 0 && unknown_page_attempts == 0 && malformed_v2_records == 0) ? "true" : "false"
+
 	print "{"
 	print "  \"_meta\": {"
+	print "    \"schema_version\": 2,"
 	printf "    \"generated_at_ts\": %d,\n", now
-	printf "    \"since_ts\":        %d,\n", cutoff
-	printf "    \"window_seconds\":  %d,\n", window
-	printf "    \"total_calls\":     %d\n",  total
+	printf "    \"since_ts\": %d,\n", cutoff
+	printf "    \"requested_window_seconds\": %d,\n", window
+	printf "    \"window_seconds\": %d,\n", window
+	printf "    \"first_retained_ts\": %d,\n", first_retained_attempt_ts + 0
+	printf "    \"last_retained_ts\": %d,\n", last_retained_attempt_ts + 0
+	printf "    \"effective_window_seconds\": %d,\n", effective_window_seconds
+	printf "    \"first_retained_record_ts\": %d,\n", first_retained_record_ts + 0
+	printf "    \"last_retained_record_ts\": %d,\n", last_retained_record_ts + 0
+	printf "    \"retained_records\": %d,\n", retained_records + 0
+	printf "    \"window_records\": %d,\n", window_records + 0
+	printf "    \"total_calls\": %d,\n", total_calls
+	printf "    \"logical_operations\": %d,\n", logical_operations + 0
+	printf "    \"logical_events\": %d,\n", logical_events
+	printf "    \"cache_events\": %d,\n", cache_events
+	printf "    \"legacy_events\": %d,\n", legacy_events
+	printf "    \"attempted_requests\": %d,\n", attempted_requests
+	printf "    \"retries\": %d,\n", retries + 0
+	printf "    \"pages\": %d,\n", pages + 0
+	printf "    \"additional_pages\": %d,\n", additional_pages + 0
+	printf "    \"successful_attempts\": %d,\n", successful_attempts + 0
+	printf "    \"failed_attempts\": %d,\n", failed_attempts + 0
+	printf "    \"elapsed_ms\": %d,\n", elapsed_ms_total + 0
+	printf "    \"known_quota_cost\": %d,\n", known_quota_cost + 0
+	printf "    \"unknown_quota_cost_attempts\": %d,\n", unknown_quota_cost_attempts + 0
+	printf "    \"duplicate_attempt_ids\": %d,\n", duplicate_attempt_ids + 0
+	printf "    \"unidentified_attempts\": %d,\n", unidentified_attempts + 0
+	printf "    \"unknown_page_attempts\": %d,\n", unknown_page_attempts + 0
+	printf "    \"legacy_retained_records\": %d,\n", retained_legacy_records + 0
+	printf "    \"malformed_records\": %d,\n", malformed_records + 0
+	printf "    \"attempts_exact\": %s\n", attempts_exact
 	print "  },"
-	print "  \"by_caller\": {"
-	# Sort caller keys for deterministic output.
-	n = 0
-	for (c in callers) keys[++n] = c
-	for (i = 2; i <= n; i++) {
-		for (j = i; j > 1 && keys[j-1] > keys[j]; j--) {
-			t = keys[j]; keys[j] = keys[j-1]; keys[j-1] = t
-		}
-	}
-	for (i = 1; i <= n; i++) {
-		c = keys[i]
-		g   = graphql[c] + 0
-		r   = rest[c]    + 0
-		s_g = sg[c]      + 0
-		s_r = sr[c]      + 0
-		o   = other[c]   + 0
-		if (i > 1) print ","
-		printf "    \"%s\": {\n", c
-		printf "      \"graphql_calls\":        %d,\n", g
-		printf "      \"rest_calls\":           %d,\n", r
-		printf "      \"search_graphql_calls\": %d,\n", s_g
-		printf "      \"search_rest_calls\":    %d,\n", s_r
-		printf "      \"other_calls\":          %d,\n", o
-		printf "      \"total\":                %d\n",  g + r + s_g + s_r + o
-		printf "    }"
-	}
-	if (n > 0) print ""
-	print "  },"
-	emit_count_section("by_auth_mode", auth_keys, auth_counts)
+	emit_group("by_caller", "caller")
 	print ","
-	emit_count_section("by_api_pool", pool_keys, pool_counts)
+	emit_group("by_path", "path")
 	print ","
-	emit_count_section("by_route_decision", decision_keys, decision_counts)
+	emit_group("by_auth_mode", "auth")
 	print ","
-	print "  \"budget_by_pool\": {"
-	nb = 0
-	for (b in budget_keys) bkeys[++nb] = b
-	for (i = 2; i <= nb; i++) {
-		for (j = i; j > 1 && bkeys[j-1] > bkeys[j]; j--) {
-			t = bkeys[j]; bkeys[j] = bkeys[j-1]; bkeys[j-1] = t
-		}
-	}
-	for (i = 1; i <= nb; i++) {
-		b = bkeys[i]
-		if (i > 1) print ","
-		printf "    \"%s\": {\"min_remaining\": %d, \"last_remaining\": %d}", b, budget_min[b] + 0, budget_last[b] + 0
-	}
-	if (nb > 0) print ""
-	print "  }"
+	emit_group("by_api_pool", "pool")
+	print ","
+	emit_group("by_route_decision", "decision")
+	print ","
+	emit_group("by_outcome", "outcome")
+	print ","
+	emit_group("attempts_by_http_status", "http_status")
+	print ","
+	emit_budgets()
 	print "}"
 }

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -4,9 +4,10 @@
 # =============================================================================
 # gh-api-instrument.sh -- Lightweight gh API call instrumentation (t2902)
 # =============================================================================
-# Records every routed gh CLI / gh api call partitioned by path (graphql, rest,
-# search-graphql, search-rest, other), auth mode, API pool, route decision, and
-# caller script. Aggregation produces
+# Records logical routing/cache events separately from native gh transport
+# attempts. Attempts include stable logical/attempt identities, retry/page
+# metadata, outcome, elapsed time, and known quota cost without recording argv,
+# request bodies, headers, tokens, or query values. Aggregation produces
 # a JSON report at ~/.aidevops/logs/gh-api-calls-by-stage.json so heavy
 # GraphQL consumers can be identified and routed through the separate REST
 # core pool (t2574, t2689) or the Search API bucket where applicable.
@@ -16,7 +17,7 @@
 #   covers writes (t2574) and reads (t2689). Something is still draining
 #   GraphQL between resets. Without per-call-site visibility, the heavy
 #   consumer is invisible. This file is a minimum-overhead recorder; it
-#   adds one append to a tab-separated log per gh call.
+#   adds one bounded append to a tab-separated log per event or attempt.
 #
 # Usage from a sourced shell script:
 #
@@ -42,8 +43,10 @@
 #   search-rest    — REST per-repo iteration replacing a search call
 #   other          — anything not covered above (counted but not partitioned)
 #
-# Log format (TSV, append-only):
+# Legacy log format (TSV, still readable):
 #   <unix_ts>\t<caller_basename>\t<path>\t<auth_mode>\t<api_pool>\t<route_decision>\t<budget_remaining>
+# Version 2 appends these privacy-safe fields after the legacy prefix:
+#   v2\t<event_kind>\t<logical_id>\t<attempt_id>\t<page>\t<retry>\t<outcome>\t<http_status>\t<elapsed_ms>\t<quota_cost>
 #
 # Override env vars:
 #   AIDEVOPS_GH_API_LOG          — path to the log file (default
@@ -51,7 +54,9 @@
 #   AIDEVOPS_GH_API_REPORT       — path to the JSON report (default
 #                                   ~/.aidevops/logs/gh-api-calls-by-stage.json)
 #   AIDEVOPS_GH_API_LOG_MAX_LINES — when set and exceeded, trim() retains
-#                                   the most-recent half (default 50000)
+#                                   the newest bounded records (default 50000)
+#   AIDEVOPS_GH_API_LOG_MAX_BYTES — maximum retained log bytes (default 16 MiB)
+#   AIDEVOPS_GH_API_RETENTION_SECONDS — maximum record age (default 172800)
 #   AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1 — make all calls no-ops
 #
 # Part of aidevops framework: https://aidevops.sh
@@ -98,9 +103,211 @@ esac
 GH_API_LOG="${AIDEVOPS_GH_API_LOG:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls.log}"
 GH_API_REPORT="${AIDEVOPS_GH_API_REPORT:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls-by-stage.json}"
 GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"
+GH_API_LOG_MAX_BYTES="${AIDEVOPS_GH_API_LOG_MAX_BYTES:-16777216}"
+GH_API_RETENTION_SECONDS="${AIDEVOPS_GH_API_RETENTION_SECONDS:-172800}"
 
-# --- gh_record_call <path> [caller] [auth] [pool] [decision] [budget] ------
-# Append a record to the log. Cheapest possible: one open+append.
+_gh_now_seconds() {
+	local now=""
+	printf -v now '%(%s)T' -1 2>/dev/null || now=$(date +%s 2>/dev/null) || return 1
+	printf '%s\n' "$now"
+	return 0
+}
+
+_gh_now_ms() {
+	local now=""
+	if command -v perl >/dev/null 2>&1; then
+		now=$(perl -MTime::HiRes=time -e 'printf "%.0f\n", time * 1000' 2>/dev/null || true)
+	elif command -v python3 >/dev/null 2>&1; then
+		now=$(python3 -c 'import time; print(round(time.time() * 1000))' 2>/dev/null || true)
+	fi
+	if [[ ! "$now" =~ ^[0-9]+$ ]]; then
+		now=$(_gh_now_seconds) || return 1
+		now=$((now * 1000))
+	fi
+	printf '%s\n' "$now"
+	return 0
+}
+
+_gh_safe_text() {
+	local value="$1"
+	local fallback="$2"
+	value="${value##*/}"
+	if [[ "$value" =~ ^[A-Za-z0-9_.:+-]+$ ]]; then
+		printf '%s' "$value"
+	else
+		printf '%s' "$fallback"
+	fi
+	return 0
+}
+
+_gh_safe_number() {
+	local value="$1"
+	[[ "$value" =~ ^[0-9]+$ ]] && printf '%s' "$value"
+	return 0
+}
+
+_gh_default_pool() {
+	local path="$1"
+	case "$path" in
+	graphql | search-graphql) printf 'graphql' ;;
+	rest) printf 'rest-core' ;;
+	search-rest) printf 'rest-search' ;;
+	*) printf 'other' ;;
+	esac
+	return 0
+}
+
+_gh_default_auth() {
+	local api_pool="$1"
+	case "$api_pool" in
+	rest-core | rest-search)
+		if command -v github_app_is_configured >/dev/null 2>&1 && github_app_is_configured; then
+			printf 'github-app'
+		else
+			printf 'gh-pat'
+		fi
+		;;
+	*) printf 'gh-pat' ;;
+	esac
+	return 0
+}
+
+_gh_resolve_caller() {
+	local caller="$1"
+	local i=1
+	local src=""
+	if [[ -z "$caller" ]]; then
+		while [[ $i -lt ${#BASH_SOURCE[@]} ]]; do
+			src="${BASH_SOURCE[$i]}"
+			if [[ -n "$src" && "${src##*/}" != "gh-api-instrument.sh" ]]; then
+				caller="${src##*/}"
+				break
+			fi
+			i=$((i + 1))
+		done
+		[[ -z "$caller" ]] && caller="${0##*/}"
+	fi
+	case "$caller" in
+	"" | -bash | bash) caller="unknown" ;;
+	esac
+	_gh_safe_text "$caller" unknown
+	return 0
+}
+
+_gh_log_lock_acquire() {
+	local lock_dir="${GH_API_LOG}.lock"
+	local tries=0
+	local owner=""
+	local owner_pid="${BASHPID:-$$}"
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		if [[ -f "$lock_dir/pid" && ! -L "$lock_dir" ]]; then
+			if ! IFS= read -r owner 2>/dev/null <"$lock_dir/pid"; then
+				owner=""
+			fi
+			if [[ "$owner" =~ ^[0-9]+$ ]] && ! kill -0 "$owner" 2>/dev/null; then
+				rm -f "$lock_dir/pid" 2>/dev/null || true
+				rmdir "$lock_dir" 2>/dev/null || true
+				continue
+			fi
+		fi
+		tries=$((tries + 1))
+		[[ $tries -ge 200 ]] && return 1
+		sleep 0.01
+	done
+	if ! printf '%s\n' "$owner_pid" >"$lock_dir/pid" 2>/dev/null; then
+		rmdir "$lock_dir" 2>/dev/null || true
+		return 1
+	fi
+	return 0
+}
+
+_gh_log_lock_release() {
+	local lock_dir="${GH_API_LOG}.lock"
+	rm -f "$lock_dir/pid" 2>/dev/null || true
+	rmdir "$lock_dir" 2>/dev/null || true
+	return 0
+}
+
+_gh_append_record() {
+	local record="$1"
+	[[ ${#record} -le 4000 ]] || return 0
+	[[ "$GH_API_LOG" == */* ]] && mkdir -p "${GH_API_LOG%/*}" 2>/dev/null || true
+	_gh_log_lock_acquire || return 0
+	printf '%s\n' "$record" >>"$GH_API_LOG" 2>/dev/null || true
+	_gh_log_lock_release
+	return 0
+}
+
+gh_new_logical_id() {
+	local ts=""
+	ts=$(_gh_now_seconds) || ts=0
+	printf 'l%s-%s-%s\n' "$ts" "${BASHPID:-$$}" "${RANDOM:-0}"
+	return 0
+}
+
+gh_new_attempt_id() {
+	local logical_id="$1"
+	_GH_API_ATTEMPT_SEQUENCE=$((${_GH_API_ATTEMPT_SEQUENCE:-0} + 1))
+	printf '%s-a%s-%s-%s\n' "$logical_id" "${BASHPID:-$$}" "$_GH_API_ATTEMPT_SEQUENCE" "${RANDOM:-0}"
+	return 0
+}
+
+gh_attempt_count_for_logical() {
+	local logical_id="$1"
+	[[ -f "$GH_API_LOG" ]] || {
+		printf '0\n'
+		return 0
+	}
+	awk -F'\t' -v logical_id="$logical_id" \
+		'$8 == "v2" && $9 == "attempt" && $10 == logical_id { count++ } END { print count + 0 }' \
+		"$GH_API_LOG" 2>/dev/null || printf '0\n'
+	return 0
+}
+
+_gh_append_v2() {
+	local event_kind="$1"; shift
+	local caller="$1"; shift
+	local path="$1"; shift
+	local auth_mode="$1"; shift
+	local api_pool="$1"; shift
+	local route_decision="$1"; shift
+	local budget_remaining="$1"; shift
+	local logical_id="$1"; shift
+	local attempt_id="$1"; shift
+	local page="$1"; shift
+	local retry="$1"; shift
+	local outcome="$1"; shift
+	local http_status="$1"; shift
+	local elapsed_ms="$1"; shift
+	local quota_cost="$1"
+	local ts=""
+	local record=""
+	ts=$(_gh_now_seconds) || return 0
+	caller=$(_gh_resolve_caller "$caller")
+	path=$(_gh_safe_text "$path" other)
+	auth_mode=$(_gh_safe_text "$auth_mode" unknown)
+	api_pool=$(_gh_safe_text "$api_pool" other)
+	route_decision=$(_gh_safe_text "$route_decision" unspecified)
+	event_kind=$(_gh_safe_text "$event_kind" logical)
+	logical_id=$(_gh_safe_text "$logical_id" unknown)
+	attempt_id=$(_gh_safe_text "$attempt_id" unknown)
+	outcome=$(_gh_safe_text "$outcome" unknown)
+	budget_remaining=$(_gh_safe_number "$budget_remaining")
+	page=$(_gh_safe_number "$page")
+	retry=$(_gh_safe_number "$retry")
+	http_status=$(_gh_safe_number "$http_status")
+	elapsed_ms=$(_gh_safe_number "$elapsed_ms")
+	quota_cost=$(_gh_safe_number "$quota_cost")
+	printf -v record '%s\t%s\t%s\t%s\t%s\t%s\t%s\tv2\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s' \
+		"$ts" "$caller" "$path" "$auth_mode" "$api_pool" "$route_decision" "$budget_remaining" \
+		"$event_kind" "$logical_id" "$attempt_id" "$page" "$retry" "$outcome" "$http_status" "$elapsed_ms" "$quota_cost"
+	_gh_append_record "$record"
+	return 0
+}
+
+# --- gh_record_call <path> [caller] [auth] [pool] [decision] [budget] [kind]
+# Append a logical routing or cache event. Existing six-argument callers remain
+# compatible; known cache decisions are classified automatically.
 # Failure is silent — instrumentation must never break the host script.
 #
 # Args:
@@ -121,58 +328,88 @@ gh_record_call() {
 	local api_pool="${4:-${AIDEVOPS_GH_API_POOL:-}}"
 	local route_decision="${5:-${AIDEVOPS_GH_ROUTE_DECISION:-}}"
 	local budget_remaining="${6:-${AIDEVOPS_GH_BUDGET_REMAINING:-${_GH_LAST_GRAPHQL_REMAINING:-}}}"
-	if [[ -z "$caller" ]]; then
-		# Default: name of the script that called us. Walk up until we find
-		# a frame outside this file (tests sometimes source us; we want the
-		# real caller, not gh-api-instrument.sh itself).
-		local i=1 src
-		while [[ $i -lt ${#BASH_SOURCE[@]} ]]; do
-			src="${BASH_SOURCE[$i]}"
-			if [[ -n "$src" && "${src##*/}" != "gh-api-instrument.sh" ]]; then
-				caller="${src##*/}"
-				break
-			fi
-			i=$((i + 1))
-		done
-		[[ -z "$caller" ]] && caller="${0##*/}"
-		[[ -z "$caller" || "$caller" == "-bash" || "$caller" == "bash" ]] && caller="unknown"
-	fi
+	local event_kind="${7:-logical}"
+	local logical_id="${AIDEVOPS_GH_LOGICAL_ID:-}"
+	caller=$(_gh_resolve_caller "$caller")
 	if [[ -z "$api_pool" ]]; then
-		case "$path" in
-		graphql | search-graphql) api_pool="graphql" ;;
-		rest) api_pool="rest-core" ;;
-		search-rest) api_pool="rest-search" ;;
-		*) api_pool="other" ;;
-		esac
+		api_pool=$(_gh_default_pool "$path")
 	fi
 	if [[ -z "$auth_mode" ]]; then
-		case "$api_pool" in
-		rest-core | rest-search)
-			if command -v github_app_is_configured >/dev/null 2>&1 && github_app_is_configured; then
-				auth_mode="github-app"
-			else
-				auth_mode="gh-pat"
-			fi
-			;;
-		*) auth_mode="gh-pat" ;;
-		esac
+		auth_mode=$(_gh_default_auth "$api_pool")
 	fi
 	[[ -z "$route_decision" ]] && route_decision="${api_pool}-selected"
-	[[ "$budget_remaining" =~ ^[0-9]+$ ]] || budget_remaining=""
-	local ts
-	# Use bash builtin printf for timestamp when available (bash 4.2+) to avoid
-	# forking a date subprocess on every call in this high-frequency path.
-	# Falls back to date(1) for bash < 4.2; fails safe by returning 0.
-	printf -v ts '%(%s)T' -1 || ts=$(date +%s) || return 0
-	# Only create the parent dir when the path contains a slash — avoids
-	# creating a directory named like the log file on relative paths (e.g.
-	# AIDEVOPS_GH_API_LOG="gh.log" would expand ${GH_API_LOG%/*} to "gh.log").
-	[[ "$GH_API_LOG" == */* ]] && mkdir -p "${GH_API_LOG%/*}" 2>/dev/null || true
-	# Tab-separated; printf is atomic for short lines on POSIX file systems.
-	printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-		"$ts" "$caller" "$path" "$auth_mode" "$api_pool" "$route_decision" "$budget_remaining" \
-		>>"$GH_API_LOG" 2>/dev/null || true
+	case "$route_decision" in
+	hit | miss | store | stale | invalid-json | bypass | bypass-disabled) event_kind="cache" ;;
+	esac
+	[[ -n "$logical_id" ]] || logical_id=$(gh_new_logical_id)
+	_gh_append_v2 "$event_kind" "$caller" "$path" "$auth_mode" "$api_pool" "$route_decision" \
+		"$budget_remaining" "$logical_id" "" "" "" "" "" "" ""
 	return 0
+}
+
+# --- gh_record_attempt ---------------------------------------------------
+# Record one completed native transport try/page. Arguments are metadata only;
+# command argv never enters the record.
+gh_record_attempt() {
+	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
+	local path="$1"; shift
+	local caller="$1"; shift
+	local logical_id="$1"; shift
+	local attempt_id="$1"; shift
+	local page="$1"; shift
+	local retry="$1"; shift
+	local outcome="$1"; shift
+	local http_status="$1"; shift
+	local elapsed_ms="$1"; shift
+	local quota_cost="$1"; shift
+	local auth_mode="$1"; shift
+	local api_pool="$1"; shift
+	local route_decision="$1"; shift
+	local budget_remaining="$1"
+	[[ -n "$logical_id" ]] || logical_id=$(gh_new_logical_id)
+	[[ -n "$attempt_id" ]] || attempt_id=$(gh_new_attempt_id "$logical_id")
+	[[ -n "$page" ]] || page=1
+	[[ -n "$retry" ]] || retry=0
+	[[ -n "$api_pool" ]] || api_pool=$(_gh_default_pool "$path")
+	[[ -n "$auth_mode" ]] || auth_mode="${AIDEVOPS_GH_AUTH_MODE:-$(_gh_default_auth "$api_pool")}"
+	[[ -n "$route_decision" ]] || route_decision="${AIDEVOPS_GH_ROUTE_DECISION:-${api_pool}-selected}"
+	_gh_append_v2 attempt "$caller" "$path" "$auth_mode" "$api_pool" "$route_decision" \
+		"$budget_remaining" "$logical_id" "$attempt_id" "$page" "$retry" "$outcome" \
+		"$http_status" "$elapsed_ms" "$quota_cost"
+	return 0
+}
+
+# --- gh_run_transport_attempt <path> <caller> <logical> <page> <retry> -- cmd
+# Execute one native transport command with unmodified stdio and status, then
+# append exactly one attempt record. Telemetry failures remain fail-open.
+gh_run_transport_attempt() {
+	local path="$1"; shift
+	local caller="$1"; shift
+	local logical_id="$1"; shift
+	local page="$1"; shift
+	local retry="$1"; shift
+	[[ "${1:-}" == "--" ]] && shift
+	local start_ms=""
+	local end_ms=""
+	local elapsed_ms=""
+	local rc=0
+	local outcome="success"
+	start_ms=$(_gh_now_ms) || start_ms=""
+	if "$@"; then
+		rc=0
+	else
+		rc=$?
+		outcome="error"
+	fi
+	end_ms=$(_gh_now_ms) || end_ms=""
+	if [[ "$start_ms" =~ ^[0-9]+$ && "$end_ms" =~ ^[0-9]+$ && "$end_ms" -ge "$start_ms" ]]; then
+		elapsed_ms=$((end_ms - start_ms))
+	fi
+	gh_record_attempt "$path" "$caller" "$logical_id" "" "$page" "$retry" "$outcome" \
+		"${AIDEVOPS_GH_HTTP_STATUS:-}" "$elapsed_ms" "${AIDEVOPS_GH_QUOTA_COST:-}" \
+		"${AIDEVOPS_GH_AUTH_MODE:-}" "${AIDEVOPS_GH_API_POOL:-}" "${AIDEVOPS_GH_ROUTE_DECISION:-}" \
+		"${AIDEVOPS_GH_BUDGET_REMAINING:-${_GH_LAST_GRAPHQL_REMAINING:-}}"
+	return "$rc"
 }
 
 # --- gh_aggregate_calls [out_path] [window_secs] -------------------------
@@ -215,7 +452,8 @@ gh_aggregate_calls() {
 	cutoff=$((now - window))
 	mkdir -p "${out%/*}" 2>/dev/null || true
 	if [[ ! -f "$GH_API_LOG" ]]; then
-		printf '{"_meta":{"error":"no-log","window_seconds":%d},"by_caller":{}}\n' \
+		printf '{"_meta":{"error":"no-log","schema_version":2,"requested_window_seconds":%d,"window_seconds":%d},"by_caller":{}}\n' \
+			"$window" \
 			"$window" >"$out" 2>/dev/null || true
 		return 1
 	fi
@@ -236,19 +474,48 @@ gh_aggregate_calls() {
 }
 
 # --- gh_trim_log ----------------------------------------------------------
-# Rotate the log if it exceeds GH_API_LOG_MAX_LINES, retaining the most
-# recent half. Cheap: one wc, one tail. Safe to call frequently.
+# Atomically retain only valid records within the configured age, line, and byte
+# bounds. Appenders share the same short-lived lock so replacement cannot lose
+# a concurrent record. The original remains untouched if filtering fails.
 gh_trim_log() {
 	[[ -f "$GH_API_LOG" ]] || return 0
-	local lines
-	lines=$(wc -l <"$GH_API_LOG" 2>/dev/null | tr -d ' ')
-	[[ "$lines" =~ ^[0-9]+$ ]] || return 0
-	if [[ "$lines" -gt "$GH_API_LOG_MAX_LINES" ]]; then
-		local keep=$((GH_API_LOG_MAX_LINES / 2))
-		local tmp
-		tmp=$(mktemp "${GH_API_LOG}.XXXXXX") || return 0
-		tail -n "$keep" "$GH_API_LOG" >"$tmp" 2>/dev/null && mv "$tmp" "$GH_API_LOG"
+	local now=""
+	local cutoff=0
+	local tmp=""
+	[[ "$GH_API_LOG_MAX_LINES" =~ ^[0-9]+$ && "$GH_API_LOG_MAX_LINES" -gt 0 ]] || GH_API_LOG_MAX_LINES=50000
+	[[ "$GH_API_LOG_MAX_BYTES" =~ ^[0-9]+$ && "$GH_API_LOG_MAX_BYTES" -gt 0 ]] || GH_API_LOG_MAX_BYTES=16777216
+	[[ "$GH_API_RETENTION_SECONDS" =~ ^[0-9]+$ && "$GH_API_RETENTION_SECONDS" -gt 0 ]] || GH_API_RETENTION_SECONDS=172800
+	now=$(_gh_now_seconds) || return 0
+	cutoff=$((now - GH_API_RETENTION_SECONDS))
+	_gh_log_lock_acquire || return 0
+	tmp=$(mktemp "${GH_API_LOG}.trim.XXXXXX") || {
+		_gh_log_lock_release
+		return 0
+	}
+	if LC_ALL=C awk -F'\t' -v cutoff="$cutoff" -v max_lines="$GH_API_LOG_MAX_LINES" -v max_bytes="$GH_API_LOG_MAX_BYTES" '
+		$1 ~ /^[0-9]+$/ && $1 >= cutoff {
+			last++
+			rows[last] = $0
+			row_bytes[last] = length($0) + 1
+			bytes += row_bytes[last]
+			while (first < last && ((last - first) > max_lines || bytes > max_bytes)) {
+				first++
+				bytes -= row_bytes[first]
+				delete rows[first]
+				delete row_bytes[first]
+			}
+		}
+		END {
+			for (i = first + 1; i <= last; i++) {
+				if (i in rows) print rows[i]
+			}
+		}
+	' "$GH_API_LOG" >"$tmp" 2>/dev/null && mv "$tmp" "$GH_API_LOG" 2>/dev/null; then
+		:
+	else
+		rm -f "$tmp" 2>/dev/null || true
 	fi
+	_gh_log_lock_release
 	return 0
 }
 
@@ -286,7 +553,7 @@ Subcommands:
   record <path> [caller] [auth] [pool] [decision] [budget]
                           Append one record to ${GH_API_LOG##*/}
   report [out] [window_s]  Aggregate to JSON (default ${GH_API_REPORT##*/}, 24h)
-  trim                     Rotate log if larger than \$AIDEVOPS_GH_API_LOG_MAX_LINES
+  trim                     Atomically apply age, line, and byte retention bounds
   clear                    Remove log + report
 
 Path values:

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -105,6 +105,7 @@ GH_API_REPORT="${AIDEVOPS_GH_API_REPORT:-${_GH_API_HOME}/.aidevops/logs/gh-api-c
 GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"
 GH_API_LOG_MAX_BYTES="${AIDEVOPS_GH_API_LOG_MAX_BYTES:-16777216}"
 GH_API_RETENTION_SECONDS="${AIDEVOPS_GH_API_RETENTION_SECONDS:-172800}"
+GH_API_ERROR_KEY="error"
 
 _gh_now_seconds() {
 	local now=""
@@ -265,20 +266,34 @@ gh_attempt_count_for_logical() {
 }
 
 _gh_append_v2() {
-	local event_kind="$1"; shift
-	local caller="$1"; shift
-	local path="$1"; shift
-	local auth_mode="$1"; shift
-	local api_pool="$1"; shift
-	local route_decision="$1"; shift
-	local budget_remaining="$1"; shift
-	local logical_id="$1"; shift
-	local attempt_id="$1"; shift
-	local page="$1"; shift
-	local retry="$1"; shift
-	local outcome="$1"; shift
-	local http_status="$1"; shift
-	local elapsed_ms="$1"; shift
+	local event_kind="$1"
+	shift
+	local caller="$1"
+	shift
+	local path="$1"
+	shift
+	local auth_mode="$1"
+	shift
+	local api_pool="$1"
+	shift
+	local route_decision="$1"
+	shift
+	local budget_remaining="$1"
+	shift
+	local logical_id="$1"
+	shift
+	local attempt_id="$1"
+	shift
+	local page="$1"
+	shift
+	local retry="$1"
+	shift
+	local outcome="$1"
+	shift
+	local http_status="$1"
+	shift
+	local elapsed_ms="$1"
+	shift
 	local quota_cost="$1"
 	local ts=""
 	local record=""
@@ -352,19 +367,32 @@ gh_record_call() {
 # command argv never enters the record.
 gh_record_attempt() {
 	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
-	local path="$1"; shift
-	local caller="$1"; shift
-	local logical_id="$1"; shift
-	local attempt_id="$1"; shift
-	local page="$1"; shift
-	local retry="$1"; shift
-	local outcome="$1"; shift
-	local http_status="$1"; shift
-	local elapsed_ms="$1"; shift
-	local quota_cost="$1"; shift
-	local auth_mode="$1"; shift
-	local api_pool="$1"; shift
-	local route_decision="$1"; shift
+	local path="$1"
+	shift
+	local caller="$1"
+	shift
+	local logical_id="$1"
+	shift
+	local attempt_id="$1"
+	shift
+	local page="$1"
+	shift
+	local retry="$1"
+	shift
+	local outcome="$1"
+	shift
+	local http_status="$1"
+	shift
+	local elapsed_ms="$1"
+	shift
+	local quota_cost="$1"
+	shift
+	local auth_mode="$1"
+	shift
+	local api_pool="$1"
+	shift
+	local route_decision="$1"
+	shift
 	local budget_remaining="$1"
 	[[ -n "$logical_id" ]] || logical_id=$(gh_new_logical_id)
 	[[ -n "$attempt_id" ]] || attempt_id=$(gh_new_attempt_id "$logical_id")
@@ -383,11 +411,16 @@ gh_record_attempt() {
 # Execute one native transport command with unmodified stdio and status, then
 # append exactly one attempt record. Telemetry failures remain fail-open.
 gh_run_transport_attempt() {
-	local path="$1"; shift
-	local caller="$1"; shift
-	local logical_id="$1"; shift
-	local page="$1"; shift
-	local retry="$1"; shift
+	local path="$1"
+	shift
+	local caller="$1"
+	shift
+	local logical_id="$1"
+	shift
+	local page="$1"
+	shift
+	local retry="$1"
+	shift
 	[[ "${1:-}" == "--" ]] && shift
 	local start_ms=""
 	local end_ms=""
@@ -399,7 +432,7 @@ gh_run_transport_attempt() {
 		rc=0
 	else
 		rc=$?
-		outcome="error"
+		outcome="$GH_API_ERROR_KEY"
 	fi
 	end_ms=$(_gh_now_ms) || end_ms=""
 	if [[ "$start_ms" =~ ^[0-9]+$ && "$end_ms" =~ ^[0-9]+$ && "$end_ms" -ge "$start_ms" ]]; then
@@ -452,7 +485,8 @@ gh_aggregate_calls() {
 	cutoff=$((now - window))
 	mkdir -p "${out%/*}" 2>/dev/null || true
 	if [[ ! -f "$GH_API_LOG" ]]; then
-		printf '{"_meta":{"error":"no-log","schema_version":2,"requested_window_seconds":%d,"window_seconds":%d},"by_caller":{}}\n' \
+		printf '{"_meta":{"%s":"no-log","schema_version":2,"requested_window_seconds":%d,"window_seconds":%d},"by_caller":{}}\n' \
+			"$GH_API_ERROR_KEY" \
 			"$window" \
 			"$window" >"$out" 2>/dev/null || true
 		return 1
@@ -464,8 +498,8 @@ gh_aggregate_calls() {
 	local awk_script
 	awk_script="$(dirname "${BASH_SOURCE[0]}")/gh-api-aggregate.awk"
 	if [[ ! -f "$awk_script" ]]; then
-		printf '{"_meta":{"error":"missing-awk-script","path":"%s"},"by_caller":{}}\n' \
-			"$awk_script" >"$out" 2>/dev/null || true
+		printf '{"_meta":{"%s":"missing-awk-script","path":"%s"},"by_caller":{}}\n' \
+			"$GH_API_ERROR_KEY" "$awk_script" >"$out" 2>/dev/null || true
 		return 1
 	fi
 	awk -F'\t' -v now="$now" -v cutoff="$cutoff" -v window="$window" \

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # =============================================================================
-# Smoke test for t2902 / GH#21043: gh-api-instrument.sh records gh API call
-# partitioning and aggregates to JSON correctly. Also verifies the wrapper
-# integration: sourcing shared-gh-wrappers.sh defines gh_record_call.
+# Regression test for t2902 / GH#21043 / GH#27769: logical gh events and real
+# transport attempts remain separately replayable, bounded, privacy-safe, and
+# backward-compatible with legacy records.
 # =============================================================================
 #
 # Background: t2902 added per-call-site instrumentation to identify the
@@ -128,8 +128,8 @@ unset _GH_API_INSTRUMENT_LOADED
 source "${PARENT_DIR}/gh-api-instrument.sh"
 gh_trim_log
 trimmed_count=$(wc -l <"$AIDEVOPS_GH_API_LOG" | tr -d ' ')
-# After trim, should retain max/2 = 2 lines.
-assert_eq "trim retained max/2 lines" "2" "$trimmed_count"
+# Bounded retention keeps at most the configured maximum.
+assert_eq "trim retained max lines" "4" "$trimmed_count"
 
 # --- Test 4: clear wipes both log and report --------------------------
 gh_clear_log
@@ -241,6 +241,164 @@ assert_eq "HOME-less temp fallback rejects symlink" "0" "$symlink_status"
 # Restore per-test overrides for summary diagnostics if future tests append.
 export AIDEVOPS_GH_API_LOG="$TMPDIR/gh-api-calls.log"
 export AIDEVOPS_GH_API_REPORT="$TMPDIR/report.json"
+
+# --- Test 10: exact replay separates events, attempts, pages, and retries --
+unset _GH_API_INSTRUMENT_LOADED
+# shellcheck source=../gh-api-instrument.sh
+source "${PARENT_DIR}/gh-api-instrument.sh"
+gh_clear_log
+
+AIDEVOPS_GH_LOGICAL_ID=logical-replay gh_record_call rest replay-caller github-app rest-core rest-selected 4998
+gh_record_attempt rest replay-caller logical-replay attempt-rest-1 1 0 success 200 120 1 github-app rest-core rest-selected 4998
+gh_record_attempt rest replay-caller logical-replay attempt-rest-2 2 0 success 200 80 1 github-app rest-core rest-selected 4997
+gh_record_attempt graphql replay-caller logical-replay attempt-graphql-1 1 1 error 403 40 1 gh-pat graphql rest-fallback-graphql 0
+AIDEVOPS_GH_LOGICAL_ID=logical-cache gh_record_call other replay-cache unknown other hit ""
+now=$(date +%s)
+printf '%s\tlegacy-caller\trest\tgh-pat\trest-core\tlegacy-route\t4996\n' "$now" >>"$AIDEVOPS_GH_API_LOG"
+# Duplicate IDs are rejected from replay totals and surfaced in metadata.
+gh_record_attempt rest replay-caller logical-replay attempt-rest-2 2 0 success 200 80 1 github-app rest-core rest-selected 4997
+printf 'malformed legacy row\n' >>"$AIDEVOPS_GH_API_LOG"
+gh_aggregate_calls
+
+assert_eq "schema version = 2" "2" "$(jq -r '._meta.schema_version' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "attempt replay excludes duplicate ID" "3" "$(jq -r '._meta.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "logical routing events remain separate" "1" "$(jq -r '._meta.logical_events' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "cache-only decision has zero attempts" "0" "$(jq -r '.by_caller["replay-cache"].attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "cache event counted separately" "1" "$(jq -r '._meta.cache_events' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "legacy row remains a logical observation" "1" "$(jq -r '._meta.legacy_events' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "one retry linked to logical operation" "1" "$(jq -r '._meta.retries' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "three explicit request pages" "3" "$(jq -r '._meta.pages' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "one additional page" "1" "$(jq -r '._meta.additional_pages' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "quota replay sum" "3" "$(jq -r '._meta.known_quota_cost' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "elapsed replay sum" "240" "$(jq -r '._meta.elapsed_ms' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "REST attempts grouped by path" "2" "$(jq -r '.by_path.rest.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "attempts grouped by auth pool" "2" "$(jq -r '.by_api_pool["rest-core"].attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "duplicate attempt ID surfaced" "1" "$(jq -r '._meta.duplicate_attempt_ids' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "duplicate makes exactness false" "false" "$(jq -r '._meta.attempts_exact' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "malformed row surfaced" "1" "$(jq -r '._meta.malformed_records' "$AIDEVOPS_GH_API_REPORT")"
+
+# --- Test 11: command arguments remain private and exit status is preserved --
+gh_clear_log
+gh_run_transport_attempt rest privacy-caller logical-private 1 0 -- true \
+	'https://example.invalid/private?token=do-not-log' 'Authorization: bearer do-not-log' '--body=private-payload'
+set +e
+gh_run_transport_attempt graphql privacy-caller logical-private 1 1 -- false
+transport_status=$?
+set -e
+assert_eq "transport failure status preserved" "1" "$transport_status"
+if grep -Eq 'do-not-log|private-payload|Authorization|example\.invalid' "$AIDEVOPS_GH_API_LOG"; then
+	echo "  FAIL: transport telemetry exposed command arguments"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: transport telemetry excludes command arguments"
+	PASS=$((PASS + 1))
+fi
+gh_aggregate_calls
+assert_eq "success and failure attempts recorded" "2" "$(jq -r '._meta.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "failed outcome recorded" "1" "$(jq -r '._meta.failed_attempts' "$AIDEVOPS_GH_API_REPORT")"
+
+# --- Test 12: effective window comes from retained attempt timestamps -----
+gh_clear_log
+first_ts=$((now - 30))
+last_ts=$((now - 10))
+printf '%s\twindow-caller\trest\tgh-pat\trest-core\trest-selected\t4999\tv2\tattempt\tlogical-window\tattempt-window-1\t1\t0\tsuccess\t200\t10\t1\n' "$first_ts" >>"$AIDEVOPS_GH_API_LOG"
+printf '%s\twindow-caller\trest\tgh-pat\trest-core\trest-selected\t4998\tv2\tattempt\tlogical-window\tattempt-window-2\t2\t0\tsuccess\t200\t20\t1\n' "$last_ts" >>"$AIDEVOPS_GH_API_LOG"
+gh_aggregate_calls "$AIDEVOPS_GH_API_REPORT" 3600
+assert_eq "requested window retained separately" "3600" "$(jq -r '._meta.requested_window_seconds' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "first retained attempt timestamp" "$first_ts" "$(jq -r '._meta.first_retained_ts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "last retained attempt timestamp" "$last_ts" "$(jq -r '._meta.last_retained_ts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "effective window uses observed range" "20" "$(jq -r '._meta.effective_window_seconds' "$AIDEVOPS_GH_API_REPORT")"
+
+# --- Test 13: time/line/byte retention is atomic and bounded -------------
+export AIDEVOPS_GH_API_LOG_MAX_LINES=3
+export AIDEVOPS_GH_API_LOG_MAX_BYTES=10000
+export AIDEVOPS_GH_API_RETENTION_SECONDS=100
+unset _GH_API_INSTRUMENT_LOADED
+# shellcheck source=../gh-api-instrument.sh
+source "${PARENT_DIR}/gh-api-instrument.sh"
+gh_clear_log
+printf '1\told-caller\trest\n' >>"$AIDEVOPS_GH_API_LOG"
+for fixture_index in 1 2 3 4; do
+	fixture_ts=$((now - 5 + fixture_index))
+	printf '%s\tretained-%s\trest\tgh-pat\trest-core\trest-selected\t\tv2\tlogical\tlogical-retained-%s\t\t\t\t\t\t\t\n' \
+		"$fixture_ts" "$fixture_index" "$fixture_index" >>"$AIDEVOPS_GH_API_LOG"
+done
+gh_trim_log
+assert_eq "retention applies maximum line count" "3" "$(wc -l <"$AIDEVOPS_GH_API_LOG" | tr -d ' ')"
+if grep -q 'old-caller' "$AIDEVOPS_GH_API_LOG"; then
+	echo "  FAIL: time retention kept expired record"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: time retention removed expired record"
+	PASS=$((PASS + 1))
+fi
+
+export AIDEVOPS_GH_API_LOG_MAX_LINES=100
+export AIDEVOPS_GH_API_LOG_MAX_BYTES=220
+unset _GH_API_INSTRUMENT_LOADED
+# shellcheck source=../gh-api-instrument.sh
+source "${PARENT_DIR}/gh-api-instrument.sh"
+gh_clear_log
+for fixture_index in 1 2 3 4 5; do
+	gh_record_call rest "byte-retention-${fixture_index}"
+done
+gh_trim_log
+retained_bytes=$(wc -c <"$AIDEVOPS_GH_API_LOG" | tr -d ' ')
+if [[ "$retained_bytes" -le 220 ]]; then
+	echo "  PASS: byte retention stayed within bound"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: byte retention exceeded bound ($retained_bytes > 220)"
+	FAIL=$((FAIL + 1))
+fi
+
+# --- Test 14: concurrent append keeps one complete record per writer ------
+export AIDEVOPS_GH_API_LOG_MAX_BYTES=10000
+unset _GH_API_INSTRUMENT_LOADED
+# shellcheck source=../gh-api-instrument.sh
+source "${PARENT_DIR}/gh-api-instrument.sh"
+gh_clear_log
+for fixture_index in 1 2 3 4 5 6 7 8 9 10 11 12; do
+	(
+		unset _GH_API_INSTRUMENT_LOADED
+		# shellcheck source=../gh-api-instrument.sh
+		source "${PARENT_DIR}/gh-api-instrument.sh"
+		gh_record_attempt rest concurrent-caller "logical-${fixture_index}" "attempt-${fixture_index}" 1 0 success 200 1 1 gh-pat rest-core rest-selected 4999
+	) &
+done
+wait
+assert_eq "concurrent append retained all complete records" "12" "$(wc -l <"$AIDEVOPS_GH_API_LOG" | tr -d ' ')"
+assert_eq "concurrent attempt IDs remain unique" "12" "$(cut -f11 "$AIDEVOPS_GH_API_LOG" | sort -u | wc -l | tr -d ' ')"
+
+# --- Test 15: the shim records exactly one native transport attempt -------
+SHIM_FIXTURE="$TMPDIR/shim-fixture"
+NATIVE_FIXTURE="$TMPDIR/native-fixture"
+mkdir -p "$SHIM_FIXTURE" "$NATIVE_FIXTURE"
+cp "${PARENT_DIR}/gh" "$SHIM_FIXTURE/gh"
+cp "${PARENT_DIR}/gh-api-instrument.sh" "$SHIM_FIXTURE/gh-api-instrument.sh"
+chmod +x "$SHIM_FIXTURE/gh"
+cat >"$NATIVE_FIXTURE/gh" <<'EOF_NATIVE_GH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >>"$NATIVE_ATTEMPT_LOG"
+exit "${NATIVE_ATTEMPT_STATUS:-0}"
+EOF_NATIVE_GH
+chmod +x "$NATIVE_FIXTURE/gh"
+export AIDEVOPS_GH_API_LOG="$TMPDIR/shim-attempts.log"
+export NATIVE_ATTEMPT_LOG="$TMPDIR/native-attempts.log"
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	"$SHIM_FIXTURE/gh" api '/repos/private-owner/private-repo/issues?page=2&token=private-value' >/dev/null
+assert_eq "shim invokes native gh exactly once" "1" "$(grep -c '^api$' "$NATIVE_ATTEMPT_LOG")"
+assert_eq "shim emits one logical event" "1" "$(awk -F'\t' '$9 == "logical" { count++ } END { print count + 0 }' "$AIDEVOPS_GH_API_LOG")"
+assert_eq "shim emits one transport attempt" "1" "$(awk -F'\t' '$9 == "attempt" { count++ } END { print count + 0 }' "$AIDEVOPS_GH_API_LOG")"
+assert_eq "shim records explicit page number" "2" "$(awk -F'\t' '$9 == "attempt" { print $12 }' "$AIDEVOPS_GH_API_LOG")"
+if grep -Eq 'private-owner|private-repo|private-value|token=' "$AIDEVOPS_GH_API_LOG"; then
+	echo "  FAIL: shim telemetry exposed path/query arguments"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: shim telemetry keeps path/query arguments private"
+	PASS=$((PASS + 1))
+fi
 
 # --- Summary ----------------------------------------------------------
 echo ""

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -280,13 +280,13 @@ assert_eq "malformed row surfaced" "1" "$(jq -r '._meta.malformed_records' "$AID
 # --- Test 11: command arguments remain private and exit status is preserved --
 gh_clear_log
 gh_run_transport_attempt rest privacy-caller logical-private 1 0 -- true \
-	'https://example.invalid/private?token=do-not-log' 'Authorization: bearer do-not-log' '--body=private-payload'
+	'endpoint-private?token=do-not-log' 'Authorization: bearer do-not-log' '--body=private-payload'
 set +e
 gh_run_transport_attempt graphql privacy-caller logical-private 1 1 -- false
 transport_status=$?
 set -e
 assert_eq "transport failure status preserved" "1" "$transport_status"
-if grep -Eq 'do-not-log|private-payload|Authorization|example\.invalid' "$AIDEVOPS_GH_API_LOG"; then
+if grep -Eq 'do-not-log|private-payload|Authorization|endpoint-private' "$AIDEVOPS_GH_API_LOG"; then
 	echo "  FAIL: transport telemetry exposed command arguments"
 	FAIL=$((FAIL + 1))
 else

--- a/.agents/scripts/tests/test-gh-shim-native-resolution.sh
+++ b/.agents/scripts/tests/test-gh-shim-native-resolution.sh
@@ -73,7 +73,10 @@ run_case() {
 	if NATIVE_GH_LOG="$TMP/native.log" PATH="$TMP/runtime-bundles/old/agents/scripts:$TMP/home/.aidevops/agents/scripts:$TMP/repo/.agents/scripts:$TMP/home/.aidevops/bin:$TMP/native-linux:/usr/bin:/bin" \
 		"$entry" "$command_one" ${command_two:+"$command_two"}; then
 		count=$(wc -l <"$TMP/native.log" | tr -d ' ')
-		if [[ $count -ge 1 ]] && [[ "$(sed -n '1p' "$TMP/native.log")" == "$expected_one" ]]; then
+		# Intercepted reads may make instrumented REST preflight attempts before
+		# forwarding the original command. Native resolution is correct when the
+		# requested command reaches the native binary at least once.
+		if [[ $count -ge 1 ]] && grep -Fxq -- "$expected_one" "$TMP/native.log"; then
 			pass "$name reaches native gh without selecting another shim"
 		else
 			fail "$name expected native invocation, log=$(tr '\n' ';' <"$TMP/native.log")"


### PR DESCRIPTION
## Summary

Separate logical/cache events from versioned native transport attempts, add privacy-safe retry/page/outcome/latency/quota replay, and enforce honest atomic time/line/byte retention. Legacy TSV rows remain readable but excluded from exact-attempt claims. The required 12-24 hour production baseline remains an asynchronous observation gate before t18126 is promoted.

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-api-aggregate.awk, .agents/scripts/gh-api-instrument.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-gh-shim-native-resolution.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-api-instrument.sh; bash .agents/scripts/tests/test-gh-shim.sh; bash .agents/scripts/tests/test-gh-shim-native-resolution.sh; shellcheck .agents/scripts/gh-api-instrument.sh .agents/scripts/gh .agents/scripts/tests/test-gh-api-instrument.sh .agents/scripts/tests/test-gh-shim-native-resolution.sh; .agents/scripts/linters-local.sh --changed

Resolves #27769


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.120 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 24m and 276,866 tokens on this as a headless worker.