### PR TITLE
GH#27788: address CLI deployment review feedback

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
@@ -34,7 +34,7 @@ _update_fresh_install() {
 		return 1
 	}
 	trap 'rm -rf "${tmp_checkout:-}"' RETURN
-	if ! git clone --depth 1 --branch main "https://github.com/marcusquinn/aidevops.git" "$tmp_checkout" >/dev/null 2>&1; then
+	if ! git clone --depth 1 "${REPO_URL:-https://github.com/marcusquinn/aidevops.git}" "$tmp_checkout" >/dev/null 2>&1; then
 		print_error "Failed to create clean update checkout"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-aidevops-cli-convergence.sh
+++ b/.agents/scripts/tests/test-aidevops-cli-convergence.sh
@@ -27,6 +27,16 @@ fail() {
 	return 0
 }
 
+file_mtime() {
+	local file_path="$1"
+	if [[ "$(uname)" == "Darwin" ]]; then
+		stat -f '%m' "$file_path" || return 1
+	else
+		stat -c '%Y' "$file_path" || return 1
+	fi
+	return 0
+}
+
 make_fixture() {
 	local fixture="$1"
 	mkdir -p "$fixture/home/.aidevops/agents" "$fixture/global" "$fixture/home/.local/bin" "$fixture/bin"
@@ -174,11 +184,11 @@ test_already_current() {
 	cp "$fixture/launcher" "$fixture/global/aidevops"
 	chmod +x "$fixture/global/aidevops"
 	local before
-	before=$(stat -f '%m' "$fixture/global/aidevops" 2>/dev/null || stat -c '%Y' "$fixture/global/aidevops")
+	before=$(file_mtime "$fixture/global/aidevops")
 	sleep 1
 	if run_converge "$fixture" env >/dev/null 2>&1; then
 		local after
-		after=$(stat -f '%m' "$fixture/global/aidevops" 2>/dev/null || stat -c '%Y' "$fixture/global/aidevops")
+		after=$(file_mtime "$fixture/global/aidevops")
 		[[ "$before" == "$after" ]] && pass "already-current launcher is a no-op" || fail "already-current launcher is a no-op" "mtime changed"
 	else
 		fail "already-current launcher is a no-op" "convergence failed"

--- a/bin/aidevops
+++ b/bin/aidevops
@@ -4,6 +4,7 @@
 #
 # Priority order (highest to lowest):
 #   1. ~/.aidevops/agents/aidevops.sh — coherent setup-deployed CLI and modules
+#      (skip with AIDEVOPS_PREFER_LOCAL=1 for checkout development)
 #   2. ~/Git/aidevops/aidevops.sh     — bootstrap/development checkout
 #   3. Auto-clone the git repo         — first-run bootstrap
 #   4. npm-bundled aidevops.sh         — snapshot at publish time
@@ -39,7 +40,7 @@ DEPLOYED_CLI="$REAL_HOME/.aidevops/agents/aidevops.sh"
 
 # 1. Prefer the setup-deployed copy. It is released atomically with its modules,
 # so a stale or dirty canonical checkout cannot split the CLI version from them.
-if [[ -f "$DEPLOYED_CLI" ]]; then
+if [[ -z "${AIDEVOPS_PREFER_LOCAL:-}" && -f "$DEPLOYED_CLI" ]]; then
 	DEPLOYED_ROOT="$(cd "$(dirname "$DEPLOYED_CLI")" && pwd -P)"
 	export AIDEVOPS_AGENTS_DIR="$DEPLOYED_ROOT"
 	exec bash "$DEPLOYED_ROOT/aidevops.sh" "$@"

--- a/tests/test-cli-deployment-coherence.sh
+++ b/tests/test-cli-deployment-coherence.sh
@@ -10,7 +10,8 @@ grep -q 'DEPLOYED_CLI="$REAL_HOME/.aidevops/agents/aidevops.sh"' "$REPO_DIR/bin/
 # shellcheck disable=SC2016
 grep -q '"$convergence_helper" converge "$cli_source" "$orchestrator_source" "$deployed_cli" "$deployed_version"' \
 	"$REPO_DIR/.agents/scripts/setup/modules/config.sh"
-grep -q 'git clone --depth 1 --branch main' \
+# shellcheck disable=SC2016
+grep -q 'git clone --depth 1 "${REPO_URL:-https://github.com/marcusquinn/aidevops.git}"' \
 	"$REPO_DIR/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
 
 mkdir -p "$TEST_HOME/.aidevops/agents/scripts" \
@@ -21,6 +22,11 @@ printf '#!/usr/bin/env bash\nprintf "canonical\\n"\n' >"$TEST_HOME/Git/aidevops/
 result=$(HOME="$TEST_HOME" bash "$REPO_DIR/bin/aidevops" version-check)
 [[ "$result" == "deployed:version-check" ]] || {
 	printf 'FAIL: launcher selected %s\n' "$result" >&2
+	exit 1
+}
+result=$(HOME="$TEST_HOME" AIDEVOPS_PREFER_LOCAL=1 bash "$REPO_DIR/bin/aidevops" version-check)
+[[ "$result" == "canonical" ]] || {
+	printf 'FAIL: local-development override selected %s\n' "$result" >&2
 	exit 1
 }
 


### PR DESCRIPTION
## Summary

Preserve local checkout development opt-in, use configurable default-branch-aware update clones, and make CLI convergence mtime checks portable.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-update-lib.sh, .agents/scripts/tests/test-aidevops-cli-convergence.sh, bin/aidevops, tests/test-cli-deployment-coherence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck clean; CLI deployment coherence and CLI convergence tests pass.

Resolves #27788


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 5m and 102,321 tokens on this as a headless worker.