### PR TITLE
GH#27811: bound greeting lock handoff polling

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -278,6 +278,7 @@ function releaseRefreshLock(lockDir, lockToken) {
 
 function observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now, minimumMtimeMs }) {
   const deadline = now() + lockStaleMs;
+  let missingLockRetries = 0;
   const poll = () => {
     const cached = readGreetingCache(cacheFile);
     if (cached && cached.mtimeMs > minimumMtimeMs) {
@@ -287,6 +288,7 @@ function observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now, mi
 
     try {
       if (now() >= deadline || now() - statSync(lockDir).mtimeMs > lockStaleMs) return;
+      missingLockRetries = 0;
     } catch {
       // The owner may publish the cache and remove its lock between our cache
       // read and lock stat. Re-check once so that handoff still emits it.
@@ -296,8 +298,11 @@ function observeSharedRefresh({ cacheFile, lockDir, lockStaleMs, client, now, mi
         return;
       }
       // A stale-lock contender may have renamed the old lock but not created
-      // its replacement yet. Keep polling within the original safety bound.
+      // its replacement yet. Allow a short handoff window without polling for
+      // the full stale-lock lifetime when an owner exits without publishing.
       if (now() >= deadline) return;
+      if (missingLockRetries >= 4) return;
+      missingLockRetries += 1;
     }
 
     const timer = setTimeout(poll, 25);

--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
@@ -249,6 +249,33 @@ test("cold-cache follower survives a transient lock gap before publication", asy
   assert.equal(f.clients[0][0].message.includes(NEW_GREETING), true);
 });
 
+test("cold-cache follower stops polling after an owner exits without publishing", async (t) => {
+  const f = fixture();
+  t.after(() => f.cleanup());
+  const lockDir = join(f.cacheDir, "session-greeting-refresh.lock");
+  mkdirSync(lockDir);
+  let nowCalls = 0;
+  const now = () => {
+    nowCalls += 1;
+    return 1000;
+  };
+  const handler = createGreetingHandler({
+    ...handlerOptions(f, f.client(), async () => {
+      throw new Error("follower must not start a refresh");
+    }),
+    now,
+  });
+
+  await handler({ event: { type: "session.created" } });
+  rmSync(lockDir, { recursive: true, force: true });
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  const settledNowCalls = nowCalls;
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  assert.equal(f.clients[0].length, 0);
+  assert.equal(nowCalls, settledNowCalls);
+});
+
 test("an expired owner cannot release a replacement owner's lock", async (t) => {
   const f = fixture();
   t.after(() => f.cleanup());


### PR DESCRIPTION
## Summary - Limit cold-cache follower polling to four retries after an owner lock disappears; reset the retry budget when the lock reappears so transient stale-lock rename handoffs remain supported; add regression coverage for owner failure without cache publication. ## Testing - node --test tests/test-greeting-single-flight.mjs; npm test (398 tests). Resolves #27811
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18
