### PR TITLE
GH#27812: preserve UTF-8 vault test input

### DIFF
--- a/.agents/scripts/tests/test-vault-helper.sh
+++ b/.agents/scripts/tests/test-vault-helper.sh
@@ -67,7 +67,7 @@ import subprocess
 import sys
 import time
 
-inputs = os.fdopen(3, "rb").read().decode("unicode_escape").splitlines()
+inputs = os.fdopen(3, "rb").read().decode("unicode_escape").encode("latin-1").decode("utf-8").splitlines()
 cmd = sys.argv[1:]
 master, slave = pty.openpty()
 proc = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=slave)
@@ -107,6 +107,13 @@ PY
 	fi
 	return 1
 }
+
+unicode_input="välut-input"
+set +e
+run_with_tty "${unicode_input}\n" python3 -c 'import sys; print("Input: ", end="", file=sys.stderr, flush=True); raise SystemExit(sys.stdin.readline().rstrip("\n") != sys.argv[1])' "$unicode_input" >/dev/null 2>"$TEST_ROOT/unicode.err"
+unicode_rc=$?
+set -e
+assert_eq "tty input preserves multi-byte UTF-8" "0" "$unicode_rc"
 
 export AIDEVOPS_VAULT_DIR="$TEST_ROOT/vault"
 export AIDEVOPS_VAULT_RUNTIME_DIR="$TEST_ROOT/run"


### PR DESCRIPTION
## Summary

- preserve multi-byte UTF-8 while expanding escaped line separators in the Vault TTY test harness
- add a focused pseudo-terminal regression assertion for Unicode input

## Files

- `.agents/scripts/tests/test-vault-helper.sh`: repair byte decoding and cover UTF-8 input preservation

## Verification

- `shellcheck .agents/scripts/tests/test-vault-helper.sh`
- focused `tty input preserves multi-byte UTF-8` assertion passes
- full Vault test reaches the new assertion but cannot complete locally because the Vault crypto runtime is unavailable

Resolves #27812

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18
