### PR TITLE
GH#27815: fix: parameterize worktree owner claims

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -398,25 +398,97 @@ _wt_is_trusted_opencode_session() {
 	return 0
 }
 
-_wt_existing_owner_claim_state() {
+_wt_claim_owner_record() {
 	local wt_path="$1"
-	local owner_pid="$2"
-	local existing_owner_info=""
-	existing_owner_info=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
-		SELECT owner_pid, COALESCE(owner_session, '') FROM worktree_owners
-		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
-	" 2>/dev/null || echo "")
-	local existing_owner_pid=""
-	local existing_owner_session=""
-	IFS='|' read -r existing_owner_pid existing_owner_session <<<"$existing_owner_info"
-	local existing_owner_pid_sql=0
-	[[ "$existing_owner_pid" =~ ^[0-9]+$ ]] && existing_owner_pid_sql="$existing_owner_pid"
-	local existing_owner_dead=0
-	if [[ -n "$existing_owner_pid" ]] && [[ "$existing_owner_pid" != "$owner_pid" ]] && \
-		! kill -0 "$existing_owner_pid" 2>/dev/null; then
-		existing_owner_dead=1
-	fi
-	printf '%s|%s|%s|%s' "$existing_owner_pid" "$existing_owner_session" "$existing_owner_pid_sql" "$existing_owner_dead"
+	local branch="$2"
+	local owner_pid="$3"
+	local session_id="$4"
+	local batch_id="$5"
+	local task_id="$6"
+	local owner_comm="$7"
+	local trusted_opencode_session="$8"
+
+	python3 - "$WORKTREE_REGISTRY_DB" "$wt_path" "$branch" "$owner_pid" "$session_id" \
+		"$batch_id" "$task_id" "$owner_comm" "$trusted_opencode_session" <<'PY' || return 1
+import os
+import sqlite3
+import sys
+
+(
+    db_path,
+    worktree_path,
+    branch,
+    owner_pid_text,
+    session_id,
+    batch_id,
+    task_id,
+    owner_comm,
+    trusted_session_text,
+) = sys.argv[1:]
+owner_pid = int(owner_pid_text)
+trusted_session = trusted_session_text == "1"
+
+connection = sqlite3.connect(db_path)
+try:
+    connection.execute("BEGIN IMMEDIATE")
+    existing_owner = connection.execute(
+        """SELECT owner_pid, COALESCE(owner_session, '')
+           FROM worktree_owners WHERE worktree_path = ?""",
+        (worktree_path,),
+    ).fetchone()
+    if (
+        existing_owner
+        and isinstance(existing_owner[0], int)
+        and existing_owner[0] != owner_pid
+    ):
+        try:
+            os.kill(existing_owner[0], 0)
+        except OSError:
+            connection.execute(
+                """DELETE FROM worktree_owners
+                   WHERE worktree_path = ? AND owner_pid = ?
+                     AND COALESCE(owner_session, '') = ?""",
+                (worktree_path, existing_owner[0], existing_owner[1]),
+            )
+
+    connection.execute(
+        """UPDATE worktree_owners
+           SET branch = ?, owner_pid = ?, owner_session = ?, owner_batch = ?,
+               task_id = ?, owner_comm = ?, owner_dead_seen_at = ''
+           WHERE worktree_path = ?
+             AND (owner_pid = ? OR (? AND owner_session = ?))""",
+        (
+            branch,
+            owner_pid,
+            session_id,
+            batch_id,
+            task_id,
+            owner_comm,
+            worktree_path,
+            owner_pid,
+            trusted_session,
+            session_id,
+        ),
+    )
+    connection.execute(
+        """INSERT OR IGNORE INTO worktree_owners
+           (worktree_path, branch, owner_pid, owner_session, owner_batch,
+            task_id, owner_comm, owner_dead_seen_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, '')""",
+        (worktree_path, branch, owner_pid, session_id, batch_id, task_id, owner_comm),
+    )
+    final_owner = connection.execute(
+        """SELECT owner_pid, COALESCE(owner_session, '')
+           FROM worktree_owners WHERE worktree_path = ?""",
+        (worktree_path,),
+    ).fetchone()
+    connection.commit()
+finally:
+    connection.close()
+
+if final_owner:
+    print(f"{final_owner[0]}|{final_owner[1]}")
+PY
 	return 0
 }
 
@@ -470,57 +542,9 @@ claim_worktree_ownership() {
 	_init_registry_db
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
 
-	local existing_owner_pid=""
-	local existing_owner_session=""
-	local existing_owner_pid_sql=0
-	local existing_owner_dead=0
-	local existing_owner_state=""
-	existing_owner_state=$(_wt_existing_owner_claim_state "$wt_path" "$owner_pid")
-	IFS='|' read -r existing_owner_pid existing_owner_session existing_owner_pid_sql existing_owner_dead <<<"$existing_owner_state"
-
 	local final_owner_info=""
-	final_owner_info=$({
-		_wt_sqlite_set_owner_pid_param "$owner_pid"
-		printf '%s\n' "
-		BEGIN IMMEDIATE;
-		DELETE FROM worktree_owners
-		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
-		  AND owner_pid = ${existing_owner_pid_sql}
-		  AND COALESCE(owner_session, '') = '$(_wt_sql_escape "$existing_owner_session")'
-		  AND ${existing_owner_dead} = 1;
-
-		UPDATE worktree_owners
-		SET branch = '$(_wt_sql_escape "$branch")',
-			owner_pid = :owner_pid,
-			owner_session = '$(_wt_sql_escape "$session_id")',
-			owner_batch = '$(_wt_sql_escape "$batch_id")',
-			task_id = '$(_wt_sql_escape "$task_id")',
-			owner_comm = '$(_wt_sql_escape "$owner_comm")',
-			owner_dead_seen_at = ''
-		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")'
-		  AND (
-			owner_pid = :owner_pid
-			OR (${trusted_opencode_session} = 1
-				AND owner_session = '$(_wt_sql_escape "$session_id")')
-		  );
-
-		INSERT OR IGNORE INTO worktree_owners
-			(worktree_path, branch, owner_pid, owner_session, owner_batch, task_id, owner_comm, owner_dead_seen_at)
-        VALUES
-            ('$(_wt_sql_escape "$wt_path")',
-             '$(_wt_sql_escape "$branch")',
-             :owner_pid,
-             '$(_wt_sql_escape "$session_id")',
-             '$(_wt_sql_escape "$batch_id")',
-             '$(_wt_sql_escape "$task_id")',
-			 '$(_wt_sql_escape "$owner_comm")',
-			 '');
-		COMMIT;
-		SELECT owner_pid || '|' || COALESCE(owner_session, '')
-		FROM worktree_owners
-		WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
-	"
-	} | sqlite3 "$WORKTREE_REGISTRY_DB" 2>/dev/null) || return 1
+	final_owner_info=$(_wt_claim_owner_record "$wt_path" "$branch" "$owner_pid" "$session_id" \
+		"$batch_id" "$task_id" "$owner_comm" "$trusted_opencode_session") || return 1
 
 	if [[ "${final_owner_info%%|*}" == "$owner_pid" ]]; then
 		return 0

--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -428,7 +428,7 @@ import sys
 owner_pid = int(owner_pid_text)
 trusted_session = trusted_session_text == "1"
 
-connection = sqlite3.connect(db_path)
+connection = sqlite3.connect(db_path, isolation_level=None)
 try:
     connection.execute("BEGIN IMMEDIATE")
     existing_owner = connection.execute(
@@ -482,7 +482,11 @@ try:
            FROM worktree_owners WHERE worktree_path = ?""",
         (worktree_path,),
     ).fetchone()
-    connection.commit()
+    connection.execute("COMMIT")
+except Exception:
+    if connection.in_transaction:
+        connection.execute("ROLLBACK")
+    raise
 finally:
     connection.close()
 

--- a/.agents/scripts/tests/test-worktree-registry-session-claim.sh
+++ b/.agents/scripts/tests/test-worktree-registry-session-claim.sh
@@ -89,7 +89,8 @@ test_parameterized_claim_preserves_metacharacters() {
 	local registry_path=""
 	registry_path=$(_wt_registry_lookup_path "$wt_path")
 	local stored_metadata=""
-	stored_metadata=$(python3 - "$WORKTREE_REGISTRY_DB" "$registry_path" <<'PY'
+	stored_metadata=$(
+		python3 - "$WORKTREE_REGISTRY_DB" "$registry_path" <<'PY'
 import sqlite3
 import sys
 

--- a/.agents/scripts/tests/test-worktree-registry-session-claim.sh
+++ b/.agents/scripts/tests/test-worktree-registry-session-claim.sh
@@ -75,6 +75,38 @@ test_same_opencode_session_rolls_owner_pid() {
 	return 0
 }
 
+test_parameterized_claim_preserves_metacharacters() {
+	reset_registry
+	local wt_path="${TEST_ROOT}/quote-'|worktree"
+	local session_id="ses_quote_'|session"
+	mkdir -p "$wt_path"
+	export OPENCODE_SESSION_ID="$session_id"
+	register_worktree "$wt_path" "feature/original" --owner-pid "$OWNER_PID" --session "$session_id"
+
+	local rc=0
+	claim_worktree_ownership "$wt_path" "feature/quote-'branch" --owner-pid "$CLAIM_PID" \
+		--session "$session_id" --batch "batch-'value" --task "task-'value" || rc=1
+	local registry_path=""
+	registry_path=$(_wt_registry_lookup_path "$wt_path")
+	local stored_metadata=""
+	stored_metadata=$(python3 - "$WORKTREE_REGISTRY_DB" "$registry_path" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    row = connection.execute(
+        """SELECT branch, owner_session, owner_batch, task_id
+           FROM worktree_owners WHERE worktree_path = ?""",
+        (sys.argv[2],),
+    ).fetchone()
+print("|".join(row) if row else "")
+PY
+	) || rc=1
+	[[ "$stored_metadata" == "feature/quote-'branch|${session_id}|batch-'value|task-'value" ]] || rc=1
+	print_result "parameterized claim preserves SQL metacharacters" "$rc"
+	return 0
+}
+
 test_different_session_stays_blocked() {
 	reset_registry
 	local wt_path="${TEST_ROOT}/different-session"
@@ -126,6 +158,7 @@ test_untrusted_session_cannot_roll_owner_pid() {
 main() {
 	start_live_pids
 	test_same_opencode_session_rolls_owner_pid
+	test_parameterized_claim_preserves_metacharacters
 	test_different_session_stays_blocked
 	test_empty_session_cannot_roll_owner_pid
 	test_untrusted_session_cannot_roll_owner_pid


### PR DESCRIPTION
## Summary

Move same-session owner rollover reads and writes into one Python sqlite3 transaction with parameterized queries, preserving live-owner protections and adding metacharacter regression coverage.

## Files Changed

.agents/scripts/shared-worktree-registry.sh, .agents/scripts/tests/test-worktree-registry-session-claim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-worktree-registry.sh .agents/scripts/tests/test-worktree-registry-session-claim.sh; bash .agents/scripts/tests/test-worktree-registry-session-claim.sh; bash .agents/scripts/tests/test-pre-edit-check.sh

Resolves #27815


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 4m and 88,216 tokens on this as a headless worker.