### PR TITLE
GH#27742: restore startup status when updates are available

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -180,11 +180,11 @@ is_headless() {
 # -----------------------------------------------------------------------------
 # _build_version_str: resolve version string from current/remote versions.
 # Sets $1 (nameref not available in bash 3.2) — caller reads stdout.
-# Prints the version string, or "UPDATE_AVAILABLE|..." and returns 1 to signal
-# early exit.
+# Prints the version string, or "UPDATE_AVAILABLE|..." and returns 1 so the
+# caller can add update metadata without skipping the normal session status.
 # -----------------------------------------------------------------------------
 _build_version_str() {
-	local current="$1" remote="$2" app_name="$3" cache_dir="$4"
+	local current="$1" remote="$2" app_name="$3"
 	if [[ "$current" == "unknown" ]]; then
 		echo "aidevops not installed"
 		return 0
@@ -193,9 +193,6 @@ _build_version_str() {
 		return 0
 	elif [[ "$current" != "$remote" ]]; then
 		# Special format for update available - parsed by AGENTS.md
-		# Cache the update-available string so no-Bash agents can display it too
-		_write_cache "$cache_dir" "UPDATE_AVAILABLE|$current|$remote|$app_name" \
-			"" "" "" "" "" "" "" || true
 		echo "UPDATE_AVAILABLE|$current|$remote|$app_name"
 		return 1
 	else
@@ -1038,9 +1035,10 @@ main() {
 
 	local cache_dir="$HOME/.aidevops/cache"
 
-	# Build version string — returns 1 and prints UPDATE_AVAILABLE if update found
+	# Build version string. Update metadata is additive: continue through the
+	# normal status/advisory path so the toast and fallback cache remain useful.
 	local version_str
-	if ! version_str=$(_build_version_str "$current" "$remote" "$app_name" "$cache_dir"); then
+	if ! version_str=$(_build_version_str "$current" "$remote" "$app_name"); then
 		# Output the UPDATE_AVAILABLE line so the AI sees it via stdout
 		echo "$version_str"
 		# Append auto-update status so the AI can reassure the user
@@ -1050,7 +1048,7 @@ main() {
 		local gh_slurp_notice
 		gh_slurp_notice=$(_check_gh_slurp_prerequisite)
 		[[ -n "$gh_slurp_notice" ]] && echo "$gh_slurp_notice"
-		return 0
+		version_str="aidevops v$current"
 	fi
 
 	local app_str git_context_val output

--- a/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
+++ b/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
@@ -48,10 +48,12 @@ print_result() {
 
 setup_fake_tools() {
 	local gh_version_line="$1"
+	local remote_version="${2:-}"
 	TEST_ROOT=$(mktemp -d)
-	mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/home"
+	mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/home/.aidevops/agents"
 	HOME="${TEST_ROOT}/home"
 	PATH="${TEST_ROOT}/bin:${ORIGINAL_PATH}"
+	printf '1.0.0\n' >"${HOME}/.aidevops/agents/VERSION"
 
 	cat >"${TEST_ROOT}/bin/gh" <<EOF
 #!/usr/bin/env bash
@@ -60,8 +62,12 @@ exit 0
 EOF
 	chmod +x "${TEST_ROOT}/bin/gh"
 
-	cat >"${TEST_ROOT}/bin/curl" <<'EOF'
+	cat >"${TEST_ROOT}/bin/curl" <<EOF
 #!/usr/bin/env bash
+	if [[ -n "${remote_version}" ]]; then
+		printf '%s\n' '${remote_version}'
+		exit 0
+	fi
 exit 22
 EOF
 	chmod +x "${TEST_ROOT}/bin/curl"
@@ -89,6 +95,22 @@ test_supported_gh_has_no_warning() {
 		print_result "supported gh omits session-start prerequisite warning" 0
 	else
 		print_result "supported gh omits warning and writes complete cache" 1 "output='${output}', cache='${cache_file}'"
+	fi
+	return 0
+}
+
+test_update_available_preserves_full_session_status() {
+	setup_fake_tools "gh version 2.51.0 (2024-05-29)" "1.0.1"
+	local output=""
+	local cache_file="$HOME/.aidevops/cache/session-greeting.txt"
+	output=$(OPENCODE=1 bash "$UPDATE_CHECK" --interactive 2>/dev/null || true)
+	if [[ "$output" == *"UPDATE_AVAILABLE|1.0.0|1.0.1|OpenCode"* ]] &&
+		[[ "$output" == *"aidevops v1.0.0 running in OpenCode"* ]] &&
+		[[ -s "$cache_file" ]] &&
+		grep -qF "aidevops v1.0.0 running in OpenCode" "$cache_file"; then
+		print_result "update available preserves normal session status and cache" 0
+	else
+		print_result "update available preserves normal session status and cache" 1 "output='${output}', cache='${cache_file}'"
 	fi
 	return 0
 }
@@ -150,6 +172,7 @@ test_cache_write_propagates_move_failure() {
 
 test_old_gh_warns_in_update_check
 test_supported_gh_has_no_warning
+test_update_available_preserves_full_session_status
 test_cache_write_propagates_output_failure
 test_cache_write_propagates_move_failure
 


### PR DESCRIPTION
## Summary

- keep update metadata additive instead of returning early from session startup checks
- preserve the usual version, runtime, security, advisory, and contribution status when an update exists
- stop writing a transient sentinel-only greeting cache
- cover update-available stdout and cache behavior with a regression test

## Root cause

When the installed and remote aidevops versions differed, `aidevops-update-check.sh` wrote only `UPDATE_AVAILABLE` to the greeting cache and returned before `_run_session_advisories`. The OpenCode toast correctly filters that machine sentinel, leaving none of the usual startup status available to display.

## Testing

- `bash .agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh` — 5 passed
- OpenCode plugin suite — 398 passed
- `.agents/scripts/linters-local.sh` — passed
- ShellCheck — both changed shell files passed
- `git diff --check`

## Runtime Testing

Runtime-shaped fixture verified the actual update-check script with installed version `1.0.0`, remote version `1.0.1`, and OpenCode detection. Output retained the update sentinel and normal status; the persisted cache began with the normal status rather than machine-only metadata.

## Decision

Keep update metadata on stdout for machine consumers, but always continue through the ordinary greeting and advisory pipeline. This restores user-visible status without reintroducing duplicate toast delivery.

Resolves #27742

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 14h 28m and 442,005 tokens on this with the user in an interactive session. Overall, 14h 21m since this issue was created.
