### PR TITLE
GH#27825: Retry infrastructure-failed required checks

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -102,10 +102,10 @@ _pmrc_snapshot_checks_json() {
 						else "" end
 					),
 					observed_at: ([$effective[]?.observed_at | select(. != "")] | max // ""),
-					members: [$members[] | {name, source, status, conclusion, observed_at}]
+					members: [$members[] | {name, source, status, conclusion, link, observed_at}]
 				} else
 				($members | sort_by(.observed_at) | last) as $latest
-				| ($latest | del(.family_key)) + {members: [$members[] | {name, source, status, conclusion, observed_at}]}
+				| ($latest | del(.family_key)) + {members: [$members[] | {name, source, status, conclusion, link, observed_at}]}
 			end
 		)
 		| sort_by(.name)
@@ -191,6 +191,59 @@ _pmrc_is_explicit_advisory_failure() {
 	return $?
 }
 
+#######################################
+# Request a bounded rerun for a GitHub Actions job whose failed log proves an
+# infrastructure failure. The merge remains blocked until a later snapshot
+# observes a successful replacement run.
+#
+# Args: $1=repo_slug, $2=pr_number, $3=check_name, $4=check_url
+# Returns: 0=rerun requested or within cooldown, 1=invalid/unavailable
+#######################################
+_pmrc_rerun_infrastructure_check() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local check_name="$3"
+	local check_url="$4"
+	local run_id="" cooldown_seconds="${PULSE_MERGE_INFRA_RERUN_COOLDOWN_SECONDS:-900}"
+	local state_dir="${PULSE_MERGE_INFRA_RERUN_STATE_DIR:-${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/pulse-infra-check-reruns}"
+	local state_file="" now_epoch="${PULSE_MERGE_NOW_EPOCH:-$(date +%s)}" last_attempt="0"
+
+	[[ -n "$repo_slug" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	[[ "$check_url" == "https://github.com/${repo_slug}/actions/runs/"*"/job/"* ]] || return 1
+	run_id="${check_url#*/actions/runs/}"
+	run_id="${run_id%%/*}"
+	[[ "$run_id" =~ ^[0-9]+$ ]] || return 1
+	[[ "$cooldown_seconds" =~ ^[0-9]+$ ]] || cooldown_seconds=900
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || return 1
+
+	if declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+		&& ! repo_allows_pulse_write_actions "$repo_slug"; then
+		echo "[pulse-merge] infrastructure rerun deferred for PR #${pr_number} check '${check_name}' in ${repo_slug} — repository writes are disabled" >>"$LOGFILE"
+		return 1
+	fi
+
+	mkdir -p "$state_dir" 2>/dev/null || return 1
+	state_file="${state_dir}/${repo_slug//\//-}-${run_id}.last-attempt"
+	if [[ -f "$state_file" ]]; then
+		IFS= read -r last_attempt <"$state_file" || last_attempt="0"
+	fi
+	[[ "$last_attempt" =~ ^[0-9]+$ ]] || last_attempt=0
+	if [[ $((now_epoch - last_attempt)) -lt "$cooldown_seconds" ]]; then
+		echo "[pulse-merge] infrastructure rerun cooldown active for PR #${pr_number} check '${check_name}' in ${repo_slug} (run=${run_id}, cooldown=${cooldown_seconds}s) — merge remains blocked" >>"$LOGFILE"
+		return 0
+	fi
+
+	printf '%s\n' "$now_epoch" >"$state_file" || return 1
+	#aidevops:trust-boundary — the run ID comes from the current-head check-run
+	# URL returned by GitHub, and the repository already passed pulse write policy.
+	if gh run rerun "$run_id" --repo "$repo_slug" --failed >/dev/null 2>&1; then
+		echo "[pulse-merge] requested infrastructure rerun for PR #${pr_number} check '${check_name}' in ${repo_slug} (run=${run_id}) — merge remains blocked pending fresh success (GH#27825)" >>"$LOGFILE"
+		return 0
+	fi
+	echo "[pulse-merge] infrastructure rerun request failed for PR #${pr_number} check '${check_name}' in ${repo_slug} (run=${run_id}); cooldown recorded — merge remains blocked (GH#27825)" >>"$LOGFILE"
+	return 0
+}
+
 _pmrc_configured_advisory_contexts_json() {
 	local repo_slug="$1"
 	local repos_json="${AIDEVOPS_REPOS_JSON:-$HOME/.config/aidevops/repos.json}"
@@ -265,11 +318,18 @@ _pmrc_snapshot_checks_acceptable() {
 		$check.conclusion,
 		((($required | index($check.name)) != null) or any($members[]; .name as $member_name | ($required | index($member_name)) != null)),
 		($members | map("\(.name)@\(.source)") | join(",")),
-		($check.link // "")
+		($check.link // ([$members[] | select(.conclusion == "failure" and (.link // "") != "") | .link] | last) // "")
 	] | @tsv' <<<"$checks_json" 2>/dev/null) || return 1
 	while IFS=$'\t' read -r name family status conclusion required members link; do
 		[[ -n "$name" ]] || continue
 		if [[ "$family" == "$PMRC_MAINTAINER_GATE" && "$conclusion" == "$PMRC_CHECK_FAILURE" ]]; then
+			if declare -F _ci_check_url_has_infra_failure_log >/dev/null 2>&1 \
+				&& _ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
+				_pmrc_rerun_infrastructure_check "$repo_slug" "$pr_number" "$name" "$link" || true
+				echo "[pulse-merge] pre-merge snapshot: maintainer-gate family has a proven infrastructure failure for PR #${pr_number} in ${repo_slug} — code repair suppressed; merge blocked pending rerun" >>"$LOGFILE"
+				blockers=$((blockers + 1))
+				continue
+			fi
 			echo "[pulse-merge] pre-merge snapshot: maintainer-gate family is terminal-failure for PR #${pr_number} in ${repo_slug}; aliases=${members}, required=${required}, active_alias_present=$([[ "$status" != "$PMRC_CHECK_COMPLETED" ]] && printf true || printf false) — merge blocked" >>"$LOGFILE"
 			blockers=$((blockers + 1))
 			continue
@@ -283,6 +343,12 @@ _pmrc_snapshot_checks_acceptable() {
 		esac
 		if [[ "$family" == "$PMRC_MAINTAINER_GATE" ]]; then
 			echo "[pulse-merge] pre-merge snapshot: maintainer-gate family is terminal-${conclusion} for PR #${pr_number} in ${repo_slug}; aliases=${members}, required=${required} — merge blocked" >>"$LOGFILE"
+			blockers=$((blockers + 1))
+		elif [[ "$required" == "true" ]] \
+			&& declare -F _ci_check_url_has_infra_failure_log >/dev/null 2>&1 \
+			&& _ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
+			_pmrc_rerun_infrastructure_check "$repo_slug" "$pr_number" "$name" "$link" || true
+			echo "[pulse-merge] pre-merge snapshot: required check '${name}' has a proven infrastructure failure for PR #${pr_number} in ${repo_slug} — code repair suppressed; merge blocked pending rerun" >>"$LOGFILE"
 			blockers=$((blockers + 1))
 		elif [[ "$required" == "true" ]]; then
 			echo "[pulse-merge] pre-merge snapshot: required check '${name}' is terminal-${conclusion} for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -27,8 +27,8 @@ _pmrc_iso_to_epoch() {
 	local iso="$1"
 	local epoch=""
 	[[ -n "$iso" ]] || return 1
-	epoch=$(date -u -d "$iso" +%s 2>/dev/null \
-		|| TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) || epoch=""
+	epoch=$(date -u -d "$iso" +%s 2>/dev/null ||
+		TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) || epoch=""
 	[[ "$epoch" =~ ^[0-9]+$ ]] || return 1
 	printf '%s\n' "$epoch"
 	return 0
@@ -216,8 +216,8 @@ _pmrc_rerun_infrastructure_check() {
 	[[ "$cooldown_seconds" =~ ^[0-9]+$ ]] || cooldown_seconds=900
 	[[ "$now_epoch" =~ ^[0-9]+$ ]] || return 1
 
-	if declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
-		&& ! repo_allows_pulse_write_actions "$repo_slug"; then
+	if declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 &&
+		! repo_allows_pulse_write_actions "$repo_slug"; then
 		echo "[pulse-merge] infrastructure rerun deferred for PR #${pr_number} check '${check_name}' in ${repo_slug} — repository writes are disabled" >>"$LOGFILE"
 		return 1
 	fi
@@ -311,20 +311,20 @@ _pmrc_snapshot_checks_acceptable() {
 
 	required_json=$(printf '%s' "$required_contexts" | jq -Rsc '[split("\n")[] | select(length > 0)]') || return 1
 	configured_contexts_json=$(_pmrc_configured_advisory_contexts_json "$repo_slug") || return 1
-	rows=$(jq -r --argjson required "$required_json" '.[] | . as $check | ($check.members // [$check]) as $members | [
+	rows=$(jq -r --argjson required "$required_json" --arg failure "$PMRC_CHECK_FAILURE" '.[] | . as $check | ($check.members // [$check]) as $members | [
 		$check.name,
 		($check.family // $check.name),
 		$check.status,
 		$check.conclusion,
 		((($required | index($check.name)) != null) or any($members[]; .name as $member_name | ($required | index($member_name)) != null)),
 		($members | map("\(.name)@\(.source)") | join(",")),
-		($check.link // ([$members[] | select(.conclusion == "failure" and (.link // "") != "") | .link] | last) // "")
+		($check.link // ([$members[] | select(.conclusion == $failure and (.link // "") != "") | .link] | last) // "")
 	] | @tsv' <<<"$checks_json" 2>/dev/null) || return 1
 	while IFS=$'\t' read -r name family status conclusion required members link; do
 		[[ -n "$name" ]] || continue
 		if [[ "$family" == "$PMRC_MAINTAINER_GATE" && "$conclusion" == "$PMRC_CHECK_FAILURE" ]]; then
-			if declare -F _ci_check_url_has_infra_failure_log >/dev/null 2>&1 \
-				&& _ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
+			if declare -F _ci_check_url_has_infra_failure_log >/dev/null 2>&1 &&
+				_ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
 				_pmrc_rerun_infrastructure_check "$repo_slug" "$pr_number" "$name" "$link" || true
 				echo "[pulse-merge] pre-merge snapshot: maintainer-gate family has a proven infrastructure failure for PR #${pr_number} in ${repo_slug} — code repair suppressed; merge blocked pending rerun" >>"$LOGFILE"
 				blockers=$((blockers + 1))
@@ -344,9 +344,9 @@ _pmrc_snapshot_checks_acceptable() {
 		if [[ "$family" == "$PMRC_MAINTAINER_GATE" ]]; then
 			echo "[pulse-merge] pre-merge snapshot: maintainer-gate family is terminal-${conclusion} for PR #${pr_number} in ${repo_slug}; aliases=${members}, required=${required} — merge blocked" >>"$LOGFILE"
 			blockers=$((blockers + 1))
-		elif [[ "$required" == "true" ]] \
-			&& declare -F _ci_check_url_has_infra_failure_log >/dev/null 2>&1 \
-			&& _ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
+		elif [[ "$required" == "true" ]] &&
+			declare -F _ci_check_url_has_infra_failure_log >/dev/null 2>&1 &&
+			_ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
 			_pmrc_rerun_infrastructure_check "$repo_slug" "$pr_number" "$name" "$link" || true
 			echo "[pulse-merge] pre-merge snapshot: required check '${name}' has a proven infrastructure failure for PR #${pr_number} in ${repo_slug} — code repair suppressed; merge blocked pending rerun" >>"$LOGFILE"
 			blockers=$((blockers + 1))
@@ -354,8 +354,8 @@ _pmrc_snapshot_checks_acceptable() {
 			echo "[pulse-merge] pre-merge snapshot: required check '${name}' is terminal-${conclusion} for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
 			blocking_names="${blocking_names}${name}"$'\n'
 			blockers=$((blockers + 1))
-		elif declare -F _ci_check_url_has_infra_failure_log >/dev/null 2>&1 \
-			&& _ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
+		elif declare -F _ci_check_url_has_infra_failure_log >/dev/null 2>&1 &&
+			_ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
 			echo "[pulse-merge] pre-merge snapshot: IGNORED non-required infrastructure failure '${name}' for PR #${pr_number} in ${repo_slug} after failed-log classification (GH#27600)" >>"$LOGFILE"
 			advisory=$((advisory + 1))
 		elif _pmrc_is_explicit_advisory_failure "$name" "$checks_json"; then
@@ -494,8 +494,8 @@ _check_required_pr_checks_passing_fallback() {
 	fi
 
 	local nonpassing_count="" _pc_exit=0
-	nonpassing_count=$(printf '%s' "$checks_json" \
-		| jq '[.[]? | select((.bucket // "") != "pass")] | length' 2>/dev/null)
+	nonpassing_count=$(printf '%s' "$checks_json" |
+		jq '[.[]? | select((.bucket // "") != "pass")] | length' 2>/dev/null)
 	_pc_exit=$?
 	if [[ $_pc_exit -ne 0 || -z "$nonpassing_count" ]]; then
 		return 2
@@ -558,8 +558,8 @@ _check_required_pr_checks_passing_fallback() {
 							or $conclusion == $skipped)
 					] | length' <<<"$rollup_json" 2>/dev/null)
 					_gp_exit=$?
-					if [[ $_gp_exit -eq 0 && "$gate_pass_count" =~ ^[0-9]+$ \
-						&& "$gate_pass_count" -gt 0 ]]; then
+					if [[ $_gp_exit -eq 0 && "$gate_pass_count" =~ ^[0-9]+$ &&
+						"$gate_pass_count" -gt 0 ]]; then
 						return 0
 					fi
 				fi
@@ -729,8 +729,8 @@ _check_required_checks_has_terminal_failure() {
 	fi
 
 	local req_json
-	req_json=$(printf '%s' "$required_contexts" \
-		| jq -Rsc '[split("\n")[] | select(length > 0)]' 2>/dev/null) || req_json="[]"
+	req_json=$(printf '%s' "$required_contexts" |
+		jq -Rsc '[split("\n")[] | select(length > 0)]' 2>/dev/null) || req_json="[]"
 
 	local failing_count="" _fc_exit=0
 	failing_count=$(jq -n \
@@ -798,8 +798,8 @@ _check_required_checks_have_pending_or_in_progress() {
 	fi
 
 	local req_json
-	req_json=$(printf '%s' "$required_contexts" \
-		| jq -Rsc '[split("\n")[] | select(length > 0)]' 2>/dev/null) || req_json="[]"
+	req_json=$(printf '%s' "$required_contexts" |
+		jq -Rsc '[split("\n")[] | select(length > 0)]' 2>/dev/null) || req_json="[]"
 
 	local pending_count="" _pc_exit=0
 	pending_count=$(jq -n \

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -41,9 +41,9 @@ _ci_check_url_has_infra_failure_log() {
 	local repo_slug="$1"
 	local check_url="$2"
 	[[ -n "$repo_slug" ]] || return 1
-	[[ "$SNAPSHOT_MODE" == "infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/101/job/202" \
-		|| "$SNAPSHOT_MODE" == "required_infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/303/job/404" \
-		|| "$SNAPSHOT_MODE" == "maintainer_infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/505/job/606" ]]
+	[[ "$SNAPSHOT_MODE" == "infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/101/job/202" ||
+		"$SNAPSHOT_MODE" == "required_infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/303/job/404" ||
+		"$SNAPSHOT_MODE" == "maintainer_infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/505/job/606" ]]
 	return $?
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -17,7 +17,9 @@ cat >"$AIDEVOPS_REPOS_JSON" <<'EOF'
 EOF
 PULSE_MERGE_QUIET_PERIOD_SECONDS=30
 PULSE_MERGE_NOW_EPOCH="$(_pmrc_iso_to_epoch '2026-01-01T00:10:00Z')"
+PULSE_MERGE_INFRA_RERUN_STATE_DIR="${TEST_ROOT}/infra-reruns"
 SNAPSHOT_MODE="happy_advisory"
+RERUN_CALLS=0
 TESTS_RUN=0
 TESTS_FAILED=0
 
@@ -31,7 +33,7 @@ _required_contexts_for_default_branch() {
 	local repo_slug="$1"
 	[[ -n "$repo_slug" ]] || return 1
 	printf 'required-a\n'
-	[[ "$SNAPSHOT_MODE" == "maintainer_alias_fail" ]] && printf 'Maintainer Review & Assignee Gate\n'
+	[[ "$SNAPSHOT_MODE" == "maintainer_alias_fail" || "$SNAPSHOT_MODE" == "maintainer_infra_fail" ]] && printf 'Maintainer Review & Assignee Gate\n'
 	return 0
 }
 
@@ -39,13 +41,19 @@ _ci_check_url_has_infra_failure_log() {
 	local repo_slug="$1"
 	local check_url="$2"
 	[[ -n "$repo_slug" ]] || return 1
-	[[ "$SNAPSHOT_MODE" == "infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/101/job/202" ]]
+	[[ "$SNAPSHOT_MODE" == "infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/101/job/202" \
+		|| "$SNAPSHOT_MODE" == "required_infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/303/job/404" \
+		|| "$SNAPSHOT_MODE" == "maintainer_infra_fail" && "$check_url" == "https://github.com/owner/repo/actions/runs/505/job/606" ]]
 	return $?
 }
 
 gh() {
 	local command="$1"
 	local endpoint="${2:-}"
+	if [[ "$command" == "run" && "$endpoint" == "rerun" ]]; then
+		RERUN_CALLS=$((RERUN_CALLS + 1))
+		return 0
+	fi
 	[[ "$command" == "api" ]] || return 1
 
 	if [[ "$endpoint" == "graphql" ]]; then
@@ -66,9 +74,13 @@ gh() {
 		fi
 		;;
 	*check-runs*)
-		local required_conclusion="success" broad_status="completed" broad_conclusion="success"
+		local required_conclusion="success" required_url="" broad_status="completed" broad_conclusion="success"
 		local broad_completed_at="2026-01-01T00:01:00Z" extra_check=""
 		[[ "$SNAPSHOT_MODE" == "required_fail" ]] && required_conclusion="failure"
+		if [[ "$SNAPSHOT_MODE" == "required_infra_fail" ]]; then
+			required_conclusion="failure"
+			required_url=',"details_url":"https://github.com/owner/repo/actions/runs/303/job/404"'
+		fi
 		if [[ "$SNAPSHOT_MODE" == "pending" ]]; then
 			broad_status="in_progress"
 			broad_conclusion="null"
@@ -82,6 +94,8 @@ gh() {
 			extra_check=',{"name":"CodeFactor","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:00Z"}'
 		elif [[ "$SNAPSHOT_MODE" == "maintainer_alias_fail" ]]; then
 			extra_check=',{"name":"maintainer-gate","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:00Z"},{"name":"Maintainer Review & Assignee Gate","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:01Z"},{"name":"gate / Maintainer Review & Assignee Gate","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:02Z"}'
+		elif [[ "$SNAPSHOT_MODE" == "maintainer_infra_fail" ]]; then
+			extra_check=',{"name":"gate / Maintainer Review & Assignee Gate","status":"completed","conclusion":"failure","details_url":"https://github.com/owner/repo/actions/runs/505/job/606","completed_at":"2026-01-01T00:01:02Z"}'
 		elif [[ "$SNAPSHOT_MODE" == "maintainer_stable_fail" ]]; then
 			extra_check=',{"name":"maintainer-gate","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:02Z"},{"name":"gate / Maintainer Review & Assignee Gate","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:01Z"}'
 		elif [[ "$SNAPSHOT_MODE" == "maintainer_legacy_fail" ]]; then
@@ -91,8 +105,8 @@ gh() {
 		elif [[ "$SNAPSHOT_MODE" == "same_name_source_conflict" ]]; then
 			extra_check=',{"name":"ProviderMirror","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:02Z"}'
 		fi
-		printf '[{"check_runs":[{"name":"required-a","status":"completed","conclusion":"%s","completed_at":"2026-01-01T00:01:00Z"},{"name":"Framework Validation","status":"%s","conclusion":%s,"completed_at":"%s"},{"name":"Qlty Smell Regression","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:00Z"},{"name":"Qlty Smell Threshold","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:00Z"}%s]}]\n' \
-			"$required_conclusion" "$broad_status" "$([[ "$broad_conclusion" == "null" ]] && printf 'null' || printf '"%s"' "$broad_conclusion")" "$broad_completed_at" "$extra_check"
+		printf '[{"check_runs":[{"name":"required-a","status":"completed","conclusion":"%s"%s,"completed_at":"2026-01-01T00:01:00Z"},{"name":"Framework Validation","status":"%s","conclusion":%s,"completed_at":"%s"},{"name":"Qlty Smell Regression","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:00Z"},{"name":"Qlty Smell Threshold","status":"completed","conclusion":"failure","completed_at":"2026-01-01T00:01:00Z"}%s]}]\n' \
+			"$required_conclusion" "$required_url" "$broad_status" "$([[ "$broad_conclusion" == "null" ]] && printf 'null' || printf '"%s"' "$broad_conclusion")" "$broad_completed_at" "$extra_check"
 		;;
 	*commits/sha-reviewed/status*)
 		local gate_at="2026-01-01T00:01:10Z"
@@ -167,6 +181,22 @@ main() {
 	assert_gate "skipped rerun preserves successful baseline companion" skipped_companion_rerun 0
 	assert_gate "active broad check blocks merge" pending 1
 	assert_gate "terminal failed required check blocks merge" required_fail 1
+	assert_gate "infrastructure-failed required check requests rerun and stays blocked" required_infra_fail 1
+	if [[ "$RERUN_CALLS" -eq 1 ]] && grep -q "requested infrastructure rerun.*run=303" "$LOGFILE"; then
+		printf 'PASS infrastructure-failed required check requests one audited rerun\n'
+	else
+		printf 'FAIL infrastructure-failed required check rerun was not requested once\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
+	assert_gate "infrastructure rerun cooldown keeps merge blocked without duplicate write" required_infra_fail 1
+	if [[ "$RERUN_CALLS" -eq 1 ]] && grep -q "infrastructure rerun cooldown active.*run=303" "$LOGFILE"; then
+		printf 'PASS infrastructure rerun cooldown suppresses duplicate write\n'
+	else
+		printf 'FAIL infrastructure rerun cooldown did not suppress duplicate write\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
 	assert_gate "unclassified non-required failure blocks merge" unclassified_fail 1
 	if jq -e 'length == 1 and .[0].name == "CodeFactor" and .[0].bucket == "fail" and .[0].conclusion == "failure" and .[0].link == "https://github.com/owner/repo/runs/99"' \
 		<<<"$_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON" >/dev/null; then
@@ -208,6 +238,14 @@ main() {
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
 	assert_gate "legacy maintainer aliases fail closed without stable context" maintainer_legacy_fail 1
+	assert_gate "infrastructure-failed maintainer gate requests rerun and stays blocked" maintainer_infra_fail 1
+	if [[ "$RERUN_CALLS" -eq 2 ]] && grep -q "maintainer-gate family has a proven infrastructure failure" "$LOGFILE"; then
+		printf 'PASS infrastructure-failed maintainer gate requests audited rerun\n'
+	else
+		printf 'FAIL infrastructure-failed maintainer gate rerun was not requested\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
 	assert_gate "unresolved late inline finding blocks merge" unresolved 1
 	assert_gate "late review activity invalidates stale gate success" stale_gate 1
 	_PULSE_REVIEW_GATE_EVIDENCE=""


### PR DESCRIPTION
## Summary

Retry GitHub Actions required checks after failed logs prove a transient infrastructure failure, with a durable cooldown and fail-closed merge behavior.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 31 preflight snapshot tests and 34 phantom-pending tests pass; ShellCheck, shfmt, git diff --check, and linters-local.sh pass.

Resolves #27825


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.122 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 15m and 446,588 tokens on this with the user in an interactive session.