### PR TITLE
GH#27828: isolate OpenCode greeting cache

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -15,7 +15,7 @@
 //     fires on the first session.updated event within 30s of plugin init.
 //
 // Caching: raw update-check output is written to
-//   ~/.aidevops/cache/session-greeting.txt
+//   ~/.aidevops/cache/session-greeting-opencode.txt
 // so non-Bash agents can read it without re-running the script (t2724 phase 2
 // template change points agents at this file).
 //
@@ -76,7 +76,7 @@ import { homedir } from "os";
 const execAsync = promisify(exec);
 
 const CACHE_DIR = join(homedir(), ".aidevops", "cache");
-const CACHE_BASENAME = "session-greeting.txt";
+const CACHE_BASENAME = "session-greeting-opencode.txt";
 const LOCK_BASENAME = "session-greeting-refresh.lock";
 const LOCK_OWNER_BASENAME = "owner";
 // Comprehensive checks run at most once per 15-minute window. The subprocess
@@ -113,6 +113,7 @@ function runGreetingAsync({ scriptsDir, client, cacheFile, lockDir, lockToken, e
   Promise.resolve()
     .then(() => execGreeting(`bash ${JSON.stringify(script)} --interactive`, {
       timeout: 15000,
+      env: { ...process.env, OPENCODE: "1" },
     }))
     .then(async ({ stdout }) => {
       const output = stdout ? stdout.trim() : "";
@@ -182,7 +183,7 @@ async function getOpenCodeMaintenanceNotice(scriptsDir) {
 }
 
 /**
- * Write raw update-check output to ~/.aidevops/cache/session-greeting.txt
+ * Write raw update-check output to ~/.aidevops/cache/session-greeting-opencode.txt
  * so non-Bash agents can consult it without re-running the script.
  * Failures are non-fatal — the toast path continues regardless.
  *

--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
@@ -14,11 +14,13 @@ const NEW_GREETING = "aidevops v1.0.1 running in OpenCode v1.0.1";
 
 function fixture() {
   const cacheDir = mkdtempSync(join(tmpdir(), "aidevops-greeting-test-"));
-  const cacheFile = join(cacheDir, "session-greeting.txt");
+  const cacheFile = join(cacheDir, "session-greeting-opencode.txt");
+  const sharedCacheFile = join(cacheDir, "session-greeting.txt");
   const clients = [];
   return {
     cacheDir,
     cacheFile,
+    sharedCacheFile,
     clients,
     client() {
       const toasts = [];
@@ -105,6 +107,26 @@ test("fresh cache emits immediately without spawning a refresh", async (t) => {
 
   assert.equal(spawnCount, 0);
   assert.equal(f.clients[0].length, 1);
+});
+
+test("shared Claude cache cannot leak into OpenCode and refresh receives runtime identity", async (t) => {
+  const f = fixture();
+  t.after(() => f.cleanup());
+  const claudeGreeting = "aidevops v1.0.0 running in Claude Code v2.1.209";
+  writeFileSync(f.sharedCacheFile, `${claudeGreeting}\n`);
+  let execOptions;
+  const handler = createGreetingHandler(handlerOptions(f, f.client(), async (_command, options) => {
+    execOptions = options;
+    return { stdout: NEW_GREETING };
+  }));
+
+  await handler({ event: { type: "session.created" } });
+  await waitFor(() => cacheEquals(f, NEW_GREETING) && f.clients[0].length === 1);
+
+  assert.equal(execOptions.env.OPENCODE, "1");
+  assert.equal(readFileSync(f.sharedCacheFile, "utf8").trim(), claudeGreeting);
+  assert.match(f.clients[0][0].message, /running in OpenCode/);
+  assert.doesNotMatch(f.clients[0][0].message, /Claude Code/);
 });
 
 test("headless sessions never emit or refresh a greeting", async (t) => {
@@ -343,8 +365,8 @@ test("successful refresh atomically replaces the cache without temp files", asyn
   const handler = createGreetingHandler(handlerOptions(f, f.client(), async () => ({ stdout: NEW_GREETING })));
 
   await handler({ event: { type: "session.created" } });
-  await waitFor(() => readdirSync(f.cacheDir).includes("session-greeting.txt"));
+  await waitFor(() => readdirSync(f.cacheDir).includes("session-greeting-opencode.txt"));
 
   assert.equal(readFileSync(f.cacheFile, "utf8").trim(), NEW_GREETING);
-  assert.deepEqual(readdirSync(f.cacheDir), ["session-greeting.txt"]);
+  assert.deepEqual(readdirSync(f.cacheDir), ["session-greeting-opencode.txt"]);
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -50,7 +50,7 @@ function advisoryMessages(output) {
 describe("token cost advisory threshold", () => {
   test("prepends session greeting order to system prompt", async () => {
     const { hooks } = createHooks({
-      readIfExists: (path) => path.endsWith("session-greeting.txt")
+      readIfExists: (path) => path.endsWith("session-greeting-opencode.txt")
         ? "aidevops v3.14.23 running in OpenCode v1.14.33 | aidevops/main"
         : "",
     });
@@ -91,7 +91,7 @@ describe("token cost advisory threshold", () => {
 
   test("keeps startup advisory messages out of chat instructions", async () => {
     const { hooks } = createHooks({
-      readIfExists: (path) => path.endsWith("session-greeting.txt")
+      readIfExists: (path) => path.endsWith("session-greeting-opencode.txt")
         ? [
             "aidevops v3.14.23 running in OpenCode v1.14.33 | aidevops/main",
             "Security: all protections active",
@@ -113,7 +113,7 @@ describe("token cost advisory threshold", () => {
 
   test("avoids duplicate greeting after salutation-only launch input", async () => {
     const { hooks } = createHooks({
-      readIfExists: (path) => path.endsWith("session-greeting.txt")
+      readIfExists: (path) => path.endsWith("session-greeting-opencode.txt")
         ? [
             "aidevops v3.14.23 running in OpenCode v1.14.33 | aidevops/main",
             "Security: all protections active",

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -191,7 +191,7 @@ function buildCorrectionMessage(violations, sessionID) {
 // ---------------------------------------------------------------------------
 
 export function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
-  const cachePath = join(agentsDir, "..", "cache", "session-greeting.txt");
+  const cachePath = join(agentsDir, "..", "cache", "session-greeting-opencode.txt");
   const cacheLines = readIfExists(cachePath).split("\n").map((line) => line.trim()).filter(Boolean);
   const cacheLine = cacheLines[0] || "";
   const cacheMatch = cacheLine.match(/^aidevops v(\S+) running in (.+?) v(\S+)(?:\s|$)/);

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -46,11 +46,11 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 
 ## aidevops Framework Status
 
-The opencode-aidevops plugin renders session-start framework status (version, environment, security advisories, pulse health, contribution count) as TUI toasts at session creation via `client.tui.showToast()`. Raw output is cached at `~/.aidevops/cache/session-greeting.txt`.
+The opencode-aidevops plugin renders session-start framework status (version, environment, security advisories, pulse health, contribution count) as TUI toasts at session creation via `client.tui.showToast()`. Raw output is cached at `~/.aidevops/cache/session-greeting-opencode.txt`.
 
 Do not re-run `aidevops-update-check.sh` or repeat toast content as a greeting — the user has already seen it. Respond directly to the user's message.
 
-**Fallback for agents without a Bash tool** (the plugin only fires toasts when the host runtime exposes the TUI — subagents may not see them): read `~/.aidevops/cache/session-greeting.txt` if it exists; otherwise read `~/.aidevops/agents/VERSION` for `{version}` and greet with `"Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"`.
+**Fallback for agents without a Bash tool** (the plugin only fires toasts when the host runtime exposes the TUI — subagents may not see them): read `~/.aidevops/cache/session-greeting-opencode.txt` if it exists; otherwise read `~/.aidevops/agents/VERSION` for `{version}` and greet with `"Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"`.
 
 **Update available prompt**: the raw cached output may begin with `UPDATE_AVAILABLE|<current>|<latest>|<runtime>`. When present, inform the user: "Update available (current → latest). Run `aidevops update` in a terminal session, or type `!aidevops update` below and hit Enter." If the cached output also contains `AUTO_UPDATE_ENABLED`, replace the manual instruction with: "Auto-update is enabled and will apply this within ~10 minutes."
 

--- a/.agents/scripts/generate-runtime-config-agents.sh
+++ b/.agents/scripts/generate-runtime-config-agents.sh
@@ -81,7 +81,7 @@ _generate_greeting_agents_md() {
 	case "$runtime_id" in
 	opencode)
 		# shellcheck disable=SC2088
-		cache_path="~/.aidevops/cache/session-greeting.txt"
+		cache_path="~/.aidevops/cache/session-greeting-opencode.txt"
 		plugin_name="opencode-aidevops plugin"
 		# shellcheck disable=SC2088
 		global_config_path="~/.config/opencode/opencode.json"

--- a/.agents/scripts/tests/test-greeting-precedence.sh
+++ b/.agents/scripts/tests/test-greeting-precedence.sh
@@ -40,6 +40,10 @@ TEMPLATE_FILE="${REPO_ROOT}/templates/opencode-config-agents.md"
 
 grep -q 'authoritative plugin-injected greeting block' "$GENERATED_FILE"
 grep -q 'plugin injection is unavailable' "$GENERATED_FILE"
+grep -q 'session-greeting-opencode.txt' "$GENERATED_FILE"
+if grep -q 'session-greeting.txt' "$GENERATED_FILE"; then
+	exit 1
+fi
 # shellcheck disable=SC2016
 grep -q 'if the cache file is missing, read `~/.aidevops/agents/VERSION`' "$GENERATED_FILE"
 grep -q 'Never emit both the injected greeting and the fallback greeting' "$GENERATED_FILE"
@@ -57,6 +61,10 @@ fi
 
 grep -q 'authoritative plugin-injected greeting block' "$TEMPLATE_FILE"
 grep -q 'plugin injection is unavailable' "$TEMPLATE_FILE"
+grep -q 'session-greeting-opencode.txt' "$TEMPLATE_FILE"
+if grep -q 'session-greeting.txt' "$TEMPLATE_FILE"; then
+	exit 1
+fi
 # shellcheck disable=SC2016
 grep -q 'if the cache file is missing, read `~/.aidevops/agents/VERSION`' "$TEMPLATE_FILE"
 grep -q 'Never emit both the injected greeting and the fallback greeting' "$TEMPLATE_FILE"

--- a/.agents/scripts/tests/test-greeting-precedence.sh
+++ b/.agents/scripts/tests/test-greeting-precedence.sh
@@ -40,8 +40,8 @@ TEMPLATE_FILE="${REPO_ROOT}/templates/opencode-config-agents.md"
 
 grep -q 'authoritative plugin-injected greeting block' "$GENERATED_FILE"
 grep -q 'plugin injection is unavailable' "$GENERATED_FILE"
-grep -q 'session-greeting-opencode.txt' "$GENERATED_FILE"
-if grep -q 'session-greeting.txt' "$GENERATED_FILE"; then
+grep -Fq 'session-greeting-opencode.txt' "$GENERATED_FILE"
+if grep -Fq 'session-greeting.txt' "$GENERATED_FILE"; then
 	exit 1
 fi
 # shellcheck disable=SC2016
@@ -61,8 +61,8 @@ fi
 
 grep -q 'authoritative plugin-injected greeting block' "$TEMPLATE_FILE"
 grep -q 'plugin injection is unavailable' "$TEMPLATE_FILE"
-grep -q 'session-greeting-opencode.txt' "$TEMPLATE_FILE"
-if grep -q 'session-greeting.txt' "$TEMPLATE_FILE"; then
+grep -Fq 'session-greeting-opencode.txt' "$TEMPLATE_FILE"
+if grep -Fq 'session-greeting.txt' "$TEMPLATE_FILE"; then
 	exit 1
 fi
 # shellcheck disable=SC2016

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -7,14 +7,14 @@
 
 The opencode-aidevops plugin renders session-start framework status (versions,
 security posture, advisories, update hints) as a TUI toast before the first
-turn. Raw output is cached at `~/.aidevops/cache/session-greeting.txt`. The
+turn. Raw output is cached at `~/.aidevops/cache/session-greeting-opencode.txt`. The
 user has already seen it — do NOT re-run `aidevops-update-check.sh` and do
 NOT repeat toast content in the chat.
 
 **On interactive conversation start** (skip only when the runtime is actually headless; a slash-command name such as `/full-loop` does not make an interactive session headless):
 
 1. If an earlier system instruction declares itself the authoritative plugin-injected greeting block and supplies exact version values, follow it. Its first-visible-text requirement does not prevent task tool calls from running first. Do not read the cache or VERSION first.
-2. Otherwise, the plugin injection is unavailable. Read line 1 of `~/.aidevops/cache/session-greeting.txt`. Format: `aidevops v{X} running in OpenCode v{Y} | ...`. Extract `{X}` and `{Y}`, then make the first visible text in your first assistant response exactly this template — no extra prose or status dump:
+2. Otherwise, the plugin injection is unavailable. Read line 1 of `~/.aidevops/cache/session-greeting-opencode.txt`. Format: `aidevops v{X} running in OpenCode v{Y} | ...`. Extract `{X}` and `{Y}`, then make the first visible text in your first assistant response exactly this template — no extra prose or status dump:
 
    ```text
    Hi!


### PR DESCRIPTION
## Summary

Use an OpenCode-scoped startup greeting cache and explicitly identify refresh subprocesses as OpenCode so Claude Code cache state cannot leak into OpenCode toasts or prompt injection.

## Files Changed

.agents/plugins/opencode-aidevops/greeting.mjs, .agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs, .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs, .agents/plugins/opencode-aidevops/ttsr.mjs, .agents/scripts/generate-opencode-agents.sh, .agents/scripts/generate-runtime-config-agents.sh, .agents/scripts/tests/test-greeting-precedence.sh, templates/opencode-config-agents.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** OpenCode plugin test suite: 399 passed; focused greeting tests: 30 passed; greeting generator regression passed; local linters passed.

Resolves #27828


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.122 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 15h 18m and 840,996 tokens on this with the user in an interactive session.