### PR TITLE
GH#27835: Ignore stale OpenCode greeting cache

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -82,7 +82,7 @@ const LOCK_OWNER_BASENAME = "owner";
 // Comprehensive checks run at most once per 15-minute window. The subprocess
 // times out after 15 seconds, so a lock older than 30 seconds is safe to reap
 // after an abrupt plugin-process exit.
-const REFRESH_TTL_MS = 15 * 60 * 1000;
+export const REFRESH_TTL_MS = 15 * 60 * 1000;
 const LOCK_STALE_MS = 30 * 1000;
 const WARNING_LINE_PREFIXES = ["Pulse stalled", "[OPENCODE MAINTENANCE]", "[WARNING]", "[WARN]"];
 
@@ -203,7 +203,7 @@ function cacheGreeting(cacheFile, output) {
   }
 }
 
-function readGreetingCache(cacheFile) {
+export function readGreetingCache(cacheFile) {
   let fd;
   try {
     fd = openSync(cacheFile, "r");

--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -217,6 +217,15 @@ export function readGreetingCache(cacheFile) {
   }
 }
 
+export function greetingCacheHasCurrentProvenance(cached, initializedAtMs) {
+  return Boolean(cached && cached.mtimeMs >= initializedAtMs);
+}
+
+export function isGreetingCacheUsable(cached, nowMs, refreshTtlMs, initializedAtMs) {
+  return greetingCacheHasCurrentProvenance(cached, initializedAtMs) &&
+    nowMs - cached.mtimeMs <= refreshTtlMs;
+}
+
 function greetingToast(output) {
   return buildToast(classifyLines(output));
 }
@@ -431,8 +440,10 @@ async function emitToast(client, body) {
 // The caller MUST NOT await runGreetingAsync — doing so would restore the
 // blocking behaviour this change is meant to fix.
 
-function refreshGreetingIfStale({ cached, now, refreshTtlMs, lockDir, lockStaleMs, scriptsDir, client, cacheFile, execGreeting, maintenanceNoticeFn }) {
-  if (cached && now() - cached.mtimeMs <= refreshTtlMs) return;
+function refreshGreetingIfStale({ cached, now, refreshTtlMs, initializedAtMs, lockDir, lockStaleMs, scriptsDir, client, cacheFile, execGreeting, maintenanceNoticeFn }) {
+  if (isGreetingCacheUsable(cached, now(), refreshTtlMs, initializedAtMs)) return;
+
+  const cachedFallback = greetingCacheHasCurrentProvenance(cached, initializedAtMs) ? cached : null;
 
   const lockToken = acquireRefreshLock(lockDir, lockStaleMs, now());
   if (lockToken) {
@@ -444,7 +455,7 @@ function refreshGreetingIfStale({ cached, now, refreshTtlMs, lockDir, lockStaleM
       lockToken,
       execGreeting,
       maintenanceNoticeFn,
-      cachedFallback: cached,
+      cachedFallback,
     });
     return;
   }
@@ -455,7 +466,7 @@ function refreshGreetingIfStale({ cached, now, refreshTtlMs, lockDir, lockStaleM
     lockStaleMs,
     client,
     now,
-    minimumMtimeMs: cached?.mtimeMs ?? Number.NEGATIVE_INFINITY,
+    minimumMtimeMs: Math.max(cached?.mtimeMs ?? Number.NEGATIVE_INFINITY, initializedAtMs),
   });
   if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
     console.error("[aidevops] greeting: refresh already running in another process");
@@ -487,10 +498,10 @@ export function createGreetingHandler({
   execGreeting = execAsync,
   maintenanceNoticeFn = getOpenCodeMaintenanceNotice,
   now = Date.now,
+  initializedAtMs = now(),
   isHeadless = () => false,
 }) {
   let fired = false;
-  const initTime = now();
   const cacheFile = join(cacheDir, CACHE_BASENAME);
   const lockDir = join(cacheDir, LOCK_BASENAME);
 
@@ -508,7 +519,7 @@ export function createGreetingHandler({
     const isPrimary = event.type === "session.created";
     const isFallback =
       event.type === "session.updated" &&
-      now() - initTime < FALLBACK_WINDOW_MS;
+      now() - initializedAtMs < FALLBACK_WINDOW_MS;
 
     if (!isPrimary && !isFallback) return;
 
@@ -523,7 +534,7 @@ export function createGreetingHandler({
     // refresh-failure fallback; emitting it here and the refreshed value later
     // would display two startup toasts for one session.
     const cached = readGreetingCache(cacheFile);
-    if (cached && now() - cached.mtimeMs <= refreshTtlMs) {
+    if (isGreetingCacheUsable(cached, now(), refreshTtlMs, initializedAtMs)) {
       emitCachedGreeting(client, cached);
     }
 
@@ -531,6 +542,7 @@ export function createGreetingHandler({
       cached,
       now,
       refreshTtlMs,
+      initializedAtMs,
       lockDir,
       lockStaleMs,
       scriptsDir,

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -169,6 +169,8 @@ installPluginConsoleRouter({
  * @type {import('@opencode-ai/plugin').Plugin}
  */
 export async function AidevopsPlugin({ directory, client }) {
+  const initializedAtMs = Date.now();
+
   // Initialise LLM observability
   initObservability();
 
@@ -267,6 +269,7 @@ export async function AidevopsPlugin({ directory, client }) {
     intentField: INTENT_FIELD,
     isHeadless,
     shouldInjectGreeting,
+    initializedAtMs,
   });
 
   // Lazy-start dispatch table for local proxies. Keys are OpenCode
@@ -331,6 +334,7 @@ export async function AidevopsPlugin({ directory, client }) {
     scriptsDir: SCRIPTS_DIR,
     client,
     isHeadless,
+    initializedAtMs,
   });
   const sessionTitleSuffixHandler = createSessionTitleSuffixHandler({
     activeAgentsDir: ACTIVE_AGENTS_DIR,

--- a/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs
@@ -56,6 +56,7 @@ function handlerOptions(f, client, execGreeting) {
     cacheDir: f.cacheDir,
     refreshTtlMs: 1000,
     lockStaleMs: 2000,
+    initializedAtMs: 0,
     execGreeting,
     maintenanceNoticeFn: async () => "",
   };
@@ -107,6 +108,30 @@ test("fresh cache emits immediately without spawning a refresh", async (t) => {
 
   assert.equal(spawnCount, 0);
   assert.equal(f.clients[0].length, 1);
+});
+
+test("fresh pre-init cache is withheld until a current-process refresh", async (t) => {
+  const f = fixture();
+  t.after(() => f.cleanup());
+  writeFileSync(f.cacheFile, `${OLD_GREETING}\n`);
+  utimesSync(f.cacheFile, new Date(1_000), new Date(1_000));
+  let spawnCount = 0;
+  const handler = createGreetingHandler({
+    ...handlerOptions(f, f.client(), async () => {
+      spawnCount += 1;
+      return { stdout: NEW_GREETING };
+    }),
+    now: () => 2_000,
+    initializedAtMs: 1_500,
+    refreshTtlMs: 1_500,
+  });
+
+  await handler({ event: { type: "session.created" } });
+  await waitFor(() => cacheEquals(f, NEW_GREETING) && f.clients[0].length === 1);
+
+  assert.equal(spawnCount, 1);
+  assert.match(f.clients[0][0].message, /aidevops v1\.0\.1/);
+  assert.doesNotMatch(f.clients[0][0].message, /aidevops v1\.0\.0/);
 });
 
 test("shared Claude cache cannot leak into OpenCode and refresh receives runtime identity", async (t) => {
@@ -222,7 +247,7 @@ test("cold-cache follower emits a cache published while its owner lock disappear
   let nowCalls = 0;
   const now = () => {
     nowCalls += 1;
-    if (nowCalls === 5) {
+    if (nowCalls === 6) {
       writeFileSync(f.cacheFile, `${NEW_GREETING}\n`);
       rmSync(lockDir, { recursive: true, force: true });
     }
@@ -239,7 +264,7 @@ test("cold-cache follower emits a cache published while its owner lock disappear
   await handler({ event: { type: "session.created" } });
   await waitFor(() => f.clients[0].length === 1);
 
-  assert.equal(nowCalls, 5);
+  assert.equal(nowCalls, 6);
   assert.equal(f.clients[0][0].message.includes(NEW_GREETING), true);
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
@@ -14,4 +14,40 @@ assert.match(instruction, /Call the appropriate tools immediately, before visibl
 assert.match(instruction, /Do not claim that tool access is unavailable without first attempting/);
 assert.doesNotMatch(instruction, /before tool calls, status updates/);
 
+const paths = {
+  version: "/agents/VERSION",
+};
+const readVersion = (path) => path === paths.version ? "3.32.122\n" : "";
+const staleCache = {
+  output: "aidevops v3.32.118 running in OpenCode v1.17.20 | local",
+  mtimeMs: 1_000,
+};
+const freshCache = {
+  output: "aidevops v3.32.122 running in OpenCode v1.18.1 | local",
+  mtimeMs: 9_500,
+};
+
+const staleInstruction = buildSessionStartGreetingInstruction("/agents", readVersion, {
+  now: () => 10_000,
+  refreshTtlMs: 1_000,
+  readGreetingCache: () => staleCache,
+});
+assert.match(staleInstruction, /We're running aidevops v3\.32\.122\./);
+assert.doesNotMatch(staleInstruction, /3\.32\.118|1\.17\.20/);
+
+const freshInstruction = buildSessionStartGreetingInstruction("/agents", readVersion, {
+  now: () => 10_000,
+  refreshTtlMs: 1_000,
+  readGreetingCache: () => freshCache,
+});
+assert.match(freshInstruction, /We're running aidevops v3\.32\.122 in OpenCode v1\.18\.1\./);
+
+const mismatchedInstruction = buildSessionStartGreetingInstruction("/agents", readVersion, {
+  now: () => 10_000,
+  refreshTtlMs: 1_000,
+  readGreetingCache: () => ({ ...staleCache, mtimeMs: 9_500 }),
+});
+assert.match(mismatchedInstruction, /We're running aidevops v3\.32\.122\./);
+assert.doesNotMatch(mismatchedInstruction, /3\.32\.118|1\.17\.20/);
+
 console.log("session-start task execution instruction tests passed");

--- a/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
@@ -38,6 +38,7 @@ assert.doesNotMatch(staleInstruction, /3\.32\.118|1\.17\.20/);
 const freshInstruction = buildSessionStartGreetingInstruction("/agents", readVersion, {
   now: () => 10_000,
   refreshTtlMs: 1_000,
+  initializedAtMs: 9_000,
   readGreetingCache: () => freshCache,
 });
 assert.match(freshInstruction, /We're running aidevops v3\.32\.122 in OpenCode v1\.18\.1\./);
@@ -49,5 +50,17 @@ const mismatchedInstruction = buildSessionStartGreetingInstruction("/agents", re
 });
 assert.match(mismatchedInstruction, /We're running aidevops v3\.32\.122\./);
 assert.doesNotMatch(mismatchedInstruction, /3\.32\.118|1\.17\.20/);
+
+const runtimeUpgradeInstruction = buildSessionStartGreetingInstruction("/agents", readVersion, {
+  now: () => 10_000,
+  refreshTtlMs: 1_000,
+  initializedAtMs: 9_750,
+  readGreetingCache: () => ({
+    output: "aidevops v3.32.122 running in OpenCode v1.17.20 | local",
+    mtimeMs: 9_500,
+  }),
+});
+assert.match(runtimeUpgradeInstruction, /We're running aidevops v3\.32\.122\./);
+assert.doesNotMatch(runtimeUpgradeInstruction, /1\.17\.20/);
 
 console.log("session-start task execution instruction tests passed");

--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -28,6 +28,7 @@ function createHooks(options = {}) {
     readGreetingCache: options.readGreetingCache,
     now: options.now,
     refreshTtlMs: options.refreshTtlMs,
+    initializedAtMs: options.initializedAtMs,
   });
   return { hooks, logs };
 }
@@ -60,6 +61,7 @@ describe("token cost advisory threshold", () => {
       }),
       now: () => 10_000,
       refreshTtlMs: 1_000,
+      initializedAtMs: 9_000,
     });
     const output = { system: ["base system prompt"] };
 

--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -25,6 +25,9 @@ function createHooks(options = {}) {
     intentField: "agent__intent",
     isHeadless: options.isHeadless || (() => false),
     shouldInjectGreeting: options.shouldInjectGreeting,
+    readGreetingCache: options.readGreetingCache,
+    now: options.now,
+    refreshTtlMs: options.refreshTtlMs,
   });
   return { hooks, logs };
 }
@@ -50,9 +53,13 @@ function advisoryMessages(output) {
 describe("token cost advisory threshold", () => {
   test("prepends session greeting order to system prompt", async () => {
     const { hooks } = createHooks({
-      readIfExists: (path) => path.endsWith("session-greeting-opencode.txt")
-        ? "aidevops v3.14.23 running in OpenCode v1.14.33 | aidevops/main"
-        : "",
+      readIfExists: (path) => path.endsWith("VERSION") ? "3.14.23\n" : "",
+      readGreetingCache: () => ({
+        output: "aidevops v3.14.23 running in OpenCode v1.14.33 | aidevops/main",
+        mtimeMs: 9_500,
+      }),
+      now: () => 10_000,
+      refreshTtlMs: 1_000,
     });
     const output = { system: ["base system prompt"] };
 

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -8,6 +8,7 @@ import {
   collectDedupedViolations,
   recordFiredViolations,
 } from "./ttsr-rules.mjs";
+import { readGreetingCache, REFRESH_TTL_MS } from "./greeting.mjs";
 
 // ---------------------------------------------------------------------------
 // Token Cost Advisory
@@ -190,14 +191,23 @@ function buildCorrectionMessage(violations, sessionID) {
 // Hook implementations (module-level, accept state + deps as parameters)
 // ---------------------------------------------------------------------------
 
-export function buildSessionStartGreetingInstruction(agentsDir, readIfExists) {
+export function buildSessionStartGreetingInstruction(agentsDir, readIfExists, options = {}) {
+  const now = options.now ?? Date.now;
+  const readCache = options.readGreetingCache ?? readGreetingCache;
+  const refreshTtlMs = options.refreshTtlMs ?? REFRESH_TTL_MS;
   const cachePath = join(agentsDir, "..", "cache", "session-greeting-opencode.txt");
-  const cacheLines = readIfExists(cachePath).split("\n").map((line) => line.trim()).filter(Boolean);
+  const cached = readCache(cachePath);
+  const cacheIsFresh = cached && now() - cached.mtimeMs <= refreshTtlMs;
+  const cacheLines = cacheIsFresh
+    ? cached.output.split("\n").map((line) => line.trim()).filter(Boolean)
+    : [];
   const cacheLine = cacheLines[0] || "";
   const cacheMatch = cacheLine.match(/^aidevops v(\S+) running in (.+?) v(\S+)(?:\s|$)/);
-  const version = cacheMatch?.[1] || readIfExists(join(agentsDir, "VERSION")).trim().split("\n")[0] || "X";
+  const deployedVersion = readIfExists(join(agentsDir, "VERSION")).trim().split("\n")[0];
+  const version = deployedVersion || cacheMatch?.[1] || "X";
+  const cacheMatchesDeployedVersion = !deployedVersion || cacheMatch?.[1] === deployedVersion;
   const runtime = cacheMatch?.[2] || "OpenCode";
-  const runtimeVersion = cacheMatch?.[3];
+  const runtimeVersion = cacheMatchesDeployedVersion ? cacheMatch?.[3] : undefined;
   const versionLine = runtimeVersion
     ? `We're running aidevops v${version} in ${runtime} v${runtimeVersion}.`
     : `We're running aidevops v${version}.`;
@@ -260,7 +270,7 @@ export function createSessionStartGreetingGate(client, isHeadless = () => false)
  * and quality rules.
  */
 async function ttsrSystemTransform(input, output, context) {
-  const { state, intentField, shouldInjectGreeting, agentsDir, readIfExists } = context;
+  const { state, intentField, shouldInjectGreeting, agentsDir, readIfExists, greetingOptions } = context;
   if (input.model?.providerID === "anthropic") {
     const prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
     output.system.unshift(prefix);
@@ -268,7 +278,7 @@ async function ttsrSystemTransform(input, output, context) {
   }
 
   if (await shouldInjectGreeting(input)) {
-    output.system.unshift(buildSessionStartGreetingInstruction(agentsDir, readIfExists));
+    output.system.unshift(buildSessionStartGreetingInstruction(agentsDir, readIfExists, greetingOptions));
   }
 
   const rules = loadTtsrRules(state);
@@ -378,6 +388,9 @@ async function ttsrTextComplete(input, output, state, execDeps, qualityLog) {
  * @param {(level: string, message: string) => void} deps.qualityLog
  * @param {(cmd: string, timeout?: number) => string} deps.run
  * @param {string} deps.intentField
+ * @param {(path: string) => { output: string, mtimeMs: number } | null} [deps.readGreetingCache]
+ * @param {() => number} [deps.now]
+ * @param {number} [deps.refreshTtlMs]
  * @returns {{ loadTtsrRules: Function, systemTransformHook: Function, messagesTransformHook: Function, textCompleteHook: Function }}
  */
 export function createTtsrHooks(deps) {
@@ -387,7 +400,12 @@ export function createTtsrHooks(deps) {
   const ttsrRulesPath = join(agentsDir, "configs", "ttsr-rules.json");
   const state = createTtsrState(ttsrRulesPath, readIfExists);
   const execDeps = { scriptsDir, run };
-  const systemTransformContext = { state, intentField, shouldInjectGreeting, agentsDir, readIfExists };
+  const greetingOptions = {
+    readGreetingCache: deps.readGreetingCache,
+    now: deps.now,
+    refreshTtlMs: deps.refreshTtlMs,
+  };
+  const systemTransformContext = { state, intentField, shouldInjectGreeting, agentsDir, readIfExists, greetingOptions };
 
   return {
     loadTtsrRules: () => loadTtsrRules(state),

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -8,7 +8,9 @@ import {
   collectDedupedViolations,
   recordFiredViolations,
 } from "./ttsr-rules.mjs";
-import { readGreetingCache, REFRESH_TTL_MS } from "./greeting.mjs";
+// Prompt injection and the startup toast intentionally share cache provenance
+// and freshness policy so they cannot present contradictory version pairs.
+import { isGreetingCacheUsable, readGreetingCache, REFRESH_TTL_MS } from "./greeting.mjs";
 
 // ---------------------------------------------------------------------------
 // Token Cost Advisory
@@ -195,10 +197,10 @@ export function buildSessionStartGreetingInstruction(agentsDir, readIfExists, op
   const now = options.now ?? Date.now;
   const readCache = options.readGreetingCache ?? readGreetingCache;
   const refreshTtlMs = options.refreshTtlMs ?? REFRESH_TTL_MS;
+  const initializedAtMs = options.initializedAtMs ?? Number.NEGATIVE_INFINITY;
   const cachePath = join(agentsDir, "..", "cache", "session-greeting-opencode.txt");
   const cached = readCache(cachePath);
-  const cacheIsFresh = cached && now() - cached.mtimeMs <= refreshTtlMs;
-  const cacheLines = cacheIsFresh
+  const cacheLines = isGreetingCacheUsable(cached, now(), refreshTtlMs, initializedAtMs)
     ? cached.output.split("\n").map((line) => line.trim()).filter(Boolean)
     : [];
   const cacheLine = cacheLines[0] || "";
@@ -391,6 +393,7 @@ async function ttsrTextComplete(input, output, state, execDeps, qualityLog) {
  * @param {(path: string) => { output: string, mtimeMs: number } | null} [deps.readGreetingCache]
  * @param {() => number} [deps.now]
  * @param {number} [deps.refreshTtlMs]
+ * @param {number} [deps.initializedAtMs]
  * @returns {{ loadTtsrRules: Function, systemTransformHook: Function, messagesTransformHook: Function, textCompleteHook: Function }}
  */
 export function createTtsrHooks(deps) {
@@ -404,6 +407,7 @@ export function createTtsrHooks(deps) {
     readGreetingCache: deps.readGreetingCache,
     now: deps.now,
     refreshTtlMs: deps.refreshTtlMs,
+    initializedAtMs: deps.initializedAtMs,
   };
   const systemTransformContext = { state, intentField, shouldInjectGreeting, agentsDir, readIfExists, greetingOptions };
 


### PR DESCRIPTION
## Summary

- apply one shared freshness/provenance policy to the OpenCode startup toast and prompt injection
- accept cached runtime details only when the cache was written after the current plugin initialized
- prefer the deployed aidevops version and omit unproven runtime details while the existing single-flight refresh runs
- cover stale age, aidevops mismatch, runtime-only upgrade, and fresh pre-initialization cache cases

## Files

- `.agents/plugins/opencode-aidevops/greeting.mjs`
- `.agents/plugins/opencode-aidevops/index.mjs`
- `.agents/plugins/opencode-aidevops/ttsr.mjs`
- `.agents/plugins/opencode-aidevops/tests/test-greeting-single-flight.mjs`
- `.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs`
- `.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs`

## Verification

- Node syntax checks passed for all modified modules and tests
- focused greeting/provenance tests — 32 passed, 0 failed
- full OpenCode plugin suite — 400 passed, 0 failed
- repository pre-commit and pre-push gates passed

Fixes #27835
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.123 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 38m and 620,709 tokens on this with the user in an interactive session.