### PR TITLE
GH#27838: Continue setup after CLI install failure

### DIFF
--- a/.agents/scripts/tests/test-setup-stage-timing-observability.sh
+++ b/.agents/scripts/tests/test-setup-stage-timing-observability.sh
@@ -75,8 +75,68 @@ test_time_step_logs_running_before_command() {
 	return 0
 }
 
+test_noninteractive_cli_failure_continues_config_reconciliation() {
+	local snippet=""
+	snippet=$(perl -0ne 'print $1 if /(_setup_run_non_interactive\(\) \{.*?^\})/ms' "$SETUP_SH")
+	if [[ -z "$snippet" ]]; then
+		print_result "non-interactive setup extraction succeeds" 1 "setup function block not found"
+		return 0
+	fi
+
+	local tmp_home=""
+	tmp_home=$(mktemp -d 2>/dev/null || mktemp -d -t setup-cli-continuation)
+	local trace_file="${tmp_home}/stages.log"
+	local output_file="${tmp_home}/output.log"
+	local status=0
+
+	(
+		set -e
+		eval "$snippet"
+		SETUP_STAGE_OPENCODE="opencode"
+		SETUP_STAGE_AGENTS="agents"
+		SETUP_STAGE_OPENCODE_PLUGINS="opencode_plugins"
+		SETUP_STAGE_HOTFIX_CONFIG="hotfix_config"
+		SETUP_STAGE_HOOKS="hooks"
+		_setup_init_stage_timing_log() { return 0; }
+		_setup_register_child_pid() { return 0; }
+		is_feature_enabled() { return 1; }
+		print_info() { return 0; }
+		print_warning() {
+			printf 'warning=%s\n' "$*"
+			return 0
+		}
+		_time_step() {
+			local stage_name="$1"
+			printf '%s\n' "$stage_name" >>"$trace_file"
+			if [[ "$stage_name" == "install_aidevops_cli" ]]; then
+				return 23
+			fi
+			return 0
+		}
+		_setup_run_non_interactive
+	) >"$output_file" 2>&1
+	status=$?
+
+	local output=""
+	output=$(<"$output_file")
+	if [[ "$status" -eq 0 ]] &&
+		grep -qx "install_aidevops_cli" "$trace_file" &&
+		grep -qx "update_opencode_config" "$trace_file" &&
+		[[ "$output" == *"continuing configuration reconciliation"* ]]; then
+		print_result "non-interactive setup continues config reconciliation after CLI failure" 0
+		rm -rf "$tmp_home"
+		return 0
+	fi
+
+	print_result "non-interactive setup continues config reconciliation after CLI failure" 1 \
+		"status=${status}, output=${output}"
+	rm -rf "$tmp_home"
+	return 0
+}
+
 main() {
 	test_time_step_logs_running_before_command
+	test_noninteractive_cli_failure_continues_config_reconciliation
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -1494,7 +1494,7 @@ _setup_run_non_interactive() {
 	_time_step "$SETUP_STAGE_HOTFIX_CONFIG" _deploy_hotfix_config
 	_time_step "setup_opencode_desktop_launcher" setup_opencode_desktop_launcher
 	_time_step "sync_agent_sources" sync_agent_sources
-	_time_step "install_aidevops_cli" install_aidevops_cli
+	_time_step "install_aidevops_cli" install_aidevops_cli || print_warning "aidevops CLI installation encountered issues; continuing configuration reconciliation"
 	_time_step "setup_shellcheck_wrapper" setup_shellcheck_wrapper
 	if is_feature_enabled safety_hooks 2>/dev/null; then
 		_time_step "$SETUP_STAGE_HOOKS" setup_safety_hooks


### PR DESCRIPTION
## Summary

- make CLI launcher convergence warn-only in the non-interactive full setup flow
- preserve the failed `install_aidevops_cli` exit code in stage timing diagnostics
- prove setup still reaches `update_opencode_config` after the simulated CLI failure

Interactive and scoped CLI installation behavior remains unchanged.

## Files

- `setup.sh`
- `.agents/scripts/tests/test-setup-stage-timing-observability.sh`

## Verification

- `bash -n setup.sh .agents/scripts/tests/test-setup-stage-timing-observability.sh`
- `shellcheck setup.sh .agents/scripts/tests/test-setup-stage-timing-observability.sh`
- `bash .agents/scripts/tests/test-setup-stage-timing-observability.sh` — 2 passed, 0 failed
- related CLI-install, non-interactive guard, and setup completion sentinel tests passed
- repository pre-commit and pre-push quality gates passed

Fixes #27838

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.123 plugin for [OpenCode](https://opencode.ai) v1.18.1
