### PR TITLE
t18125: Make GitHub pagination baseline exactness truthful

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -280,6 +280,54 @@ _shim_caller_label() {
 	return 0
 }
 
+# Resolve only framework-owned script basenames. Never persist an arbitrary
+# parent command or private script name in telemetry that may later be attached
+# to a public issue.
+_shim_framework_caller_label() {
+	local candidate="${1:-}"
+	candidate="${candidate##*/}"
+	[[ "$candidate" =~ ^[A-Za-z0-9_.+-]+$ ]] || return 1
+	[[ -f "${_SHIM_DIR}/${candidate}" ]] || return 1
+	printf '%s' "$candidate"
+	return 0
+}
+
+_shim_parent_framework_caller() {
+	local parent_command=""
+	local parent_executable=""
+	local parent_script=""
+	local ignored_args=""
+	local caller=""
+	parent_command=$(ps -p "$PPID" -o command= 2>/dev/null) || parent_command=""
+	[[ -n "$parent_command" ]] || return 1
+	read -r parent_executable parent_script ignored_args <<<"$parent_command"
+	if caller=$(_shim_framework_caller_label "$parent_script"); then
+		printf '%s' "$caller"
+		return 0
+	fi
+	if caller=$(_shim_framework_caller_label "$parent_executable"); then
+		printf '%s' "$caller"
+		return 0
+	fi
+	return 1
+}
+
+_shim_transport_caller_label() {
+	local sub1="${1:-}"
+	local sub2="${2:-}"
+	local caller=""
+	if caller=$(_shim_framework_caller_label "${AIDEVOPS_GH_CALLER:-}"); then
+		printf '%s' "$caller"
+		return 0
+	fi
+	if caller=$(_shim_parent_framework_caller); then
+		printf '%s' "$caller"
+		return 0
+	fi
+	_shim_caller_label "$sub1" "$sub2"
+	return 0
+}
+
 _shim_transport_page() {
 	local arg=""
 	local page=1
@@ -1545,8 +1593,9 @@ if [[ "${1:-}" == "api" ]]; then
 	fi
 	# GH#21857: instrument gh api calls — rest or graphql depending on path.
 	_transport_path=$(_shim_classify_endpoint "${1:-}" "${2:-}")
-	gh_record_call "$_transport_path" gh-shim 2>/dev/null || true
-	_shim_run_transport "$REAL_GH" "$_transport_path" gh-shim 0 "${_modified_args[@]}"
+	_transport_caller=$(_shim_transport_caller_label "${1:-}" "${2:-}")
+	gh_record_call "$_transport_path" "$_transport_caller" 2>/dev/null || true
+	_shim_run_transport "$REAL_GH" "$_transport_path" "$_transport_caller" 0 "${_modified_args[@]}"
 	exit $?
 fi
 

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -286,6 +286,7 @@ _shim_caller_label() {
 _shim_framework_caller_label() {
 	local candidate="${1:-}"
 	candidate="${candidate##*/}"
+	[[ -n "${_SHIM_DIR:-}" ]] || return 1
 	[[ "$candidate" =~ ^[A-Za-z0-9_.+-]+$ ]] || return 1
 	[[ -f "${_SHIM_DIR}/${candidate}" ]] || return 1
 	printf '%s' "$candidate"
@@ -294,21 +295,35 @@ _shim_framework_caller_label() {
 
 _shim_parent_framework_caller() {
 	local parent_command=""
-	local parent_executable=""
-	local parent_script=""
-	local ignored_args=""
+	local word=""
+	local executable_name=""
 	local caller=""
+	local -a parent_words=()
 	parent_command=$(ps -p "$PPID" -o command= 2>/dev/null) || parent_command=""
 	[[ -n "$parent_command" ]] || return 1
-	read -r parent_executable parent_script ignored_args <<<"$parent_command"
-	if caller=$(_shim_framework_caller_label "$parent_script"); then
+	read -r -a parent_words <<<"$parent_command"
+	[[ ${#parent_words[@]} -gt 0 ]] || return 1
+	if caller=$(_shim_framework_caller_label "${parent_words[0]}"); then
 		printf '%s' "$caller"
 		return 0
 	fi
-	if caller=$(_shim_framework_caller_label "$parent_executable"); then
-		printf '%s' "$caller"
-		return 0
-	fi
+	executable_name="${parent_words[0]##*/}"
+	case "$executable_name" in
+	env | bash | dash | ksh | sh | zsh) ;;
+	*) return 1 ;;
+	esac
+	for word in "${parent_words[@]:1}"; do
+		case "$word" in
+		-* | *=*) continue ;;
+		esac
+		case "${word##*/}" in
+		env | bash | dash | ksh | sh | zsh) continue ;;
+		esac
+		if caller=$(_shim_framework_caller_label "$word"); then
+			printf '%s' "$caller"
+			return 0
+		fi
+	done
 	return 1
 }
 

--- a/.agents/scripts/gh-api-aggregate.awk
+++ b/.agents/scripts/gh-api-aggregate.awk
@@ -17,6 +17,7 @@ BEGIN {
 	cache_events = 0
 	legacy_events = 0
 	attempted_requests = 0
+	opaque_paginated_attempts = 0
 }
 
 function metric_add(group, value, metric, amount,    key) {
@@ -70,6 +71,7 @@ function emit_group(title, group,    pair, parts, values, n, i, value) {
 		printf "      \"cache_events\": %d,\n", metric_get(group, value, "cache_events")
 		printf "      \"legacy_events\": %d,\n", metric_get(group, value, "legacy_events")
 		printf "      \"attempted_requests\": %d,\n", metric_get(group, value, "attempted_requests")
+		printf "      \"opaque_paginated_attempts\": %d,\n", metric_get(group, value, "opaque_paginated_attempts")
 		printf "      \"retries\": %d,\n", metric_get(group, value, "retries")
 		printf "      \"pages\": %d,\n", metric_get(group, value, "pages")
 		printf "      \"additional_pages\": %d,\n", metric_get(group, value, "additional_pages")
@@ -123,10 +125,14 @@ $1 !~ /^[0-9]+$/ || NF < 3 {
 	decision = (NF >= 6 && $6 != "") ? $6 : "unspecified"
 	budget = (NF >= 7) ? $7 : ""
 	version = (NF >= 8) ? $8 : ""
+	attempt_unidentified = 0
+	attempt_duplicate = 0
+	attempt_page_unknown = 0
 
 	if (version == "v2" && NF < 17) {
 		malformed_records++
 		malformed_v2_records++
+		if (ts >= cutoff) window_malformed_v2_records++
 		next
 	}
 
@@ -159,14 +165,18 @@ $1 !~ /^[0-9]+$/ || NF < 3 {
 
 	if (kind == "attempt") {
 		if (attempt_id == "" || attempt_id == "unknown") {
-			unidentified_attempts++
+			retained_unidentified_attempts++
+			attempt_unidentified = 1
 		} else if (attempt_id in seen_attempt_id) {
-			duplicate_attempt_ids++
-			next
+			retained_duplicate_attempt_ids++
+			attempt_duplicate = 1
 		} else {
 			seen_attempt_id[attempt_id] = 1
 		}
-		if (page !~ /^[0-9]+$/ || page + 0 < 1) unknown_page_attempts++
+		if (page !~ /^[0-9]+$/ || page + 0 < 1) {
+			retained_unknown_page_attempts++
+			attempt_page_unknown = 1
+		}
 		if (first_retained_attempt_ts == 0 || ts < first_retained_attempt_ts) first_retained_attempt_ts = ts
 		if (ts > last_retained_attempt_ts) last_retained_attempt_ts = ts
 	}
@@ -200,10 +210,20 @@ $1 !~ /^[0-9]+$/ || NF < 3 {
 		}
 		next
 	}
+	if (attempt_unidentified) unidentified_attempts++
+	if (attempt_duplicate) {
+		duplicate_attempt_ids++
+		next
+	}
+	if (attempt_page_unknown) unknown_page_attempts++
 
 	attempted_requests++
 	metric_add_dimensions(caller, path, auth, pool, decision, "attempted_requests", 1)
 	metric_add("outcome", outcome, "attempted_requests", 1)
+	if (decision == "native-pagination-opaque") {
+		opaque_paginated_attempts++
+		metric_add_dimensions(caller, path, auth, pool, decision, "opaque_paginated_attempts", 1)
+	}
 	if (retry ~ /^[0-9]+$/ && retry + 0 > 0) {
 		retries++
 		metric_add_dimensions(caller, path, auth, pool, decision, "retries", 1)
@@ -243,7 +263,7 @@ END {
 	if (first_retained_attempt_ts > 0 && last_retained_attempt_ts >= first_retained_attempt_ts) {
 		effective_window_seconds = last_retained_attempt_ts - first_retained_attempt_ts
 	}
-	attempts_exact = (duplicate_attempt_ids == 0 && unidentified_attempts == 0 && unknown_page_attempts == 0 && malformed_v2_records == 0) ? "true" : "false"
+	attempts_exact = (duplicate_attempt_ids == 0 && unidentified_attempts == 0 && unknown_page_attempts == 0 && window_malformed_v2_records == 0) ? "true" : "false"
 
 	print "{"
 	print "  \"_meta\": {"
@@ -265,6 +285,7 @@ END {
 	printf "    \"cache_events\": %d,\n", cache_events
 	printf "    \"legacy_events\": %d,\n", legacy_events
 	printf "    \"attempted_requests\": %d,\n", attempted_requests
+	printf "    \"opaque_paginated_attempts\": %d,\n", opaque_paginated_attempts + 0
 	printf "    \"retries\": %d,\n", retries + 0
 	printf "    \"pages\": %d,\n", pages + 0
 	printf "    \"additional_pages\": %d,\n", additional_pages + 0
@@ -276,6 +297,10 @@ END {
 	printf "    \"duplicate_attempt_ids\": %d,\n", duplicate_attempt_ids + 0
 	printf "    \"unidentified_attempts\": %d,\n", unidentified_attempts + 0
 	printf "    \"unknown_page_attempts\": %d,\n", unknown_page_attempts + 0
+	printf "    \"retained_duplicate_attempt_ids\": %d,\n", retained_duplicate_attempt_ids + 0
+	printf "    \"retained_unidentified_attempts\": %d,\n", retained_unidentified_attempts + 0
+	printf "    \"retained_unknown_page_attempts\": %d,\n", retained_unknown_page_attempts + 0
+	printf "    \"window_malformed_v2_records\": %d,\n", window_malformed_v2_records + 0
 	printf "    \"legacy_retained_records\": %d,\n", retained_legacy_records + 0
 	printf "    \"malformed_records\": %d,\n", malformed_records + 0
 	printf "    \"attempts_exact\": %s\n", attempts_exact

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -200,6 +200,7 @@ _gh_log_lock_acquire() {
 	local tries=0
 	local owner=""
 	local owner_pid="${BASHPID:-$$}"
+	command -v mkdir >/dev/null 2>&1 || return 1
 	while ! mkdir "$lock_dir" 2>/dev/null; do
 		if [[ -f "$lock_dir/pid" && ! -L "$lock_dir" ]]; then
 			if ! IFS= read -r owner 2>/dev/null <"$lock_dir/pid"; then
@@ -213,6 +214,7 @@ _gh_log_lock_acquire() {
 		fi
 		tries=$((tries + 1))
 		[[ $tries -ge 200 ]] && return 1
+		command -v sleep >/dev/null 2>&1 || return 1
 		sleep 0.01
 	done
 	if ! printf '%s\n' "$owner_pid" >"$lock_dir/pid" 2>/dev/null; then

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -238,11 +238,25 @@ symlink_status="$?"
 set -e
 assert_eq "HOME-less temp fallback rejects symlink" "0" "$symlink_status"
 
+# --- Test 10: missing lock tools fail open without stderr noise --------
+saved_path="$PATH"
+mkdir -p "$TMPDIR/no-lock-tools"
+set +e
+# shellcheck disable=SC2123 # Intentional empty-tool fixture for fail-open coverage.
+PATH="$TMPDIR/no-lock-tools"
+_gh_log_lock_acquire 2>"$TMPDIR/no-lock-tools.stderr"
+lock_status=$?
+PATH="$saved_path"
+set -e
+assert_eq "missing lock tools fail open" "1" "$lock_status"
+lock_stderr_bytes=$(wc -c <"$TMPDIR/no-lock-tools.stderr" | tr -d ' ')
+assert_eq "missing lock tools stay silent" "0" "$lock_stderr_bytes"
+
 # Restore per-test overrides for summary diagnostics if future tests append.
 export AIDEVOPS_GH_API_LOG="$TMPDIR/gh-api-calls.log"
 export AIDEVOPS_GH_API_REPORT="$TMPDIR/report.json"
 
-# --- Test 10: exact replay separates events, attempts, pages, and retries --
+# --- Test 11: exact replay separates events, attempts, pages, and retries --
 unset _GH_API_INSTRUMENT_LOADED
 # shellcheck source=../gh-api-instrument.sh
 source "${PARENT_DIR}/gh-api-instrument.sh"
@@ -308,6 +322,18 @@ assert_eq "requested window retained separately" "3600" "$(jq -r '._meta.request
 assert_eq "first retained attempt timestamp" "$first_ts" "$(jq -r '._meta.first_retained_ts' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "last retained attempt timestamp" "$last_ts" "$(jq -r '._meta.last_retained_ts' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "effective window uses observed range" "20" "$(jq -r '._meta.effective_window_seconds' "$AIDEVOPS_GH_API_REPORT")"
+
+# --- Test 12b: retained opaque history does not poison a fresh window -------
+gh_clear_log
+outside_ts=$((now - 120))
+inside_ts=$((now - 10))
+printf '%s\topaque-caller\trest\tgh-pat\trest-core\tnative-pagination-opaque\t\tv2\tattempt\tlogical-old\tattempt-old\t0\t0\tsuccess\t200\t10\t\n' "$outside_ts" >>"$AIDEVOPS_GH_API_LOG"
+printf '%s\texact-caller\trest\tgh-pat\trest-core\trest-selected\t\tv2\tattempt\tlogical-new\tattempt-new\t1\t0\tsuccess\t200\t10\t\n' "$inside_ts" >>"$AIDEVOPS_GH_API_LOG"
+gh_aggregate_calls "$AIDEVOPS_GH_API_REPORT" 60
+assert_eq "fresh window excludes retained unknown pages" "0" "$(jq -r '._meta.unknown_page_attempts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "retained unknown page remains auditable" "1" "$(jq -r '._meta.retained_unknown_page_attempts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "fresh exact window ignores old opaque call" "0" "$(jq -r '._meta.opaque_paginated_attempts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "fresh window exactness is true" "true" "$(jq -r '._meta.attempts_exact' "$AIDEVOPS_GH_API_REPORT")"
 
 # --- Test 13: time/line/byte retention is atomic and bounded -------------
 export AIDEVOPS_GH_API_LOG_MAX_LINES=3
@@ -399,6 +425,19 @@ else
 	echo "  PASS: shim telemetry keeps path/query arguments private"
 	PASS=$((PASS + 1))
 fi
+
+# Native gh owns --paginate's hidden request loop. Keep that process visible as
+# opaque instead of falsely claiming it represents one HTTP page, and preserve
+# only framework-owned caller labels for migration prioritisation.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_GH_CALLER=gh-api-instrument.sh \
+	"$SHIM_FIXTURE/gh" api '/repos/private-owner/private-repo/issues?per_page=100' --paginate >/dev/null
+"${PARENT_DIR}/gh-api-instrument.sh" report "$AIDEVOPS_GH_API_REPORT" >/dev/null 2>&1
+assert_eq "native pagination remains explicitly opaque" "0" "$(awk -F'\t' '$9 == "attempt" { print $12 }' "$AIDEVOPS_GH_API_LOG")"
+assert_eq "opaque pagination uses a framework-owned caller" "gh-api-instrument.sh" "$(awk -F'\t' '$9 == "attempt" { print $2 }' "$AIDEVOPS_GH_API_LOG")"
+assert_eq "opaque pagination is counted separately" "1" "$(jq -r '._meta.opaque_paginated_attempts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "opaque pagination prevents exactness claims" "false" "$(jq -r '._meta.attempts_exact' "$AIDEVOPS_GH_API_REPORT")"
 
 # --- Summary ----------------------------------------------------------
 echo ""

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -439,6 +439,19 @@ assert_eq "opaque pagination uses a framework-owned caller" "gh-api-instrument.s
 assert_eq "opaque pagination is counted separately" "1" "$(jq -r '._meta.opaque_paginated_attempts' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "opaque pagination prevents exactness claims" "false" "$(jq -r '._meta.attempts_exact' "$AIDEVOPS_GH_API_REPORT")"
 
+# Parent attribution tolerates shell interpreter flags without scanning
+# arbitrary non-interpreter command arguments for coincidental basenames.
+cat >"$SHIM_FIXTURE/parent-caller.sh" <<'EOF_PARENT_CALLER'
+#!/usr/bin/env bash
+"$GH_SHIM_FIXTURE" api '/repos/private-owner/private-repo/issues?per_page=100' --paginate >/dev/null
+EOF_PARENT_CALLER
+chmod +x "$SHIM_FIXTURE/parent-caller.sh"
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	GH_SHIM_FIXTURE="$SHIM_FIXTURE/gh" \
+	bash -euo pipefail "$SHIM_FIXTURE/parent-caller.sh"
+assert_eq "interpreter flags preserve framework caller attribution" "parent-caller.sh" "$(awk -F'\t' '$9 == "attempt" { print $2 }' "$AIDEVOPS_GH_API_LOG")"
+
 # --- Summary ----------------------------------------------------------
 echo ""
 echo "===================================================="


### PR DESCRIPTION
## Summary

Scope exactness integrity counters to the requested report window, expose native gh pagination as explicitly opaque, attribute opaque calls only to verified framework-owned script basenames, and keep telemetry lock failures silent under minimal PATH environments.

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-api-aggregate.awk, .agents/scripts/gh-api-instrument.sh, .agents/scripts/tests/test-gh-api-instrument.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 68/68 gh-api instrumentation fixtures; 45/45 gh shim tests; 7/7 native-resolution tests with telemetry disabled for the deployed-version fixture; ShellCheck; git diff --check; linters-local.sh --changed; all required PR checks passed.

For #27769


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 14h 39m and 2,873,213 tokens on this with the user in an interactive session.
