### PR TITLE
GH#27834: preserve unassignment for already-available release

### DIFF
--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -437,6 +437,24 @@ _isc_cmd_unlock() {
 	return 0
 }
 
+_isc_unassign_released_issue() {
+	local issue="$1"
+	local slug="$2"
+	local user="$3"
+	local unassign_err=""
+	local unassign_rc=0
+
+	unassign_err=$(gh issue edit "$issue" --repo "$slug" \
+		--remove-assignee "$user" 2>&1 >/dev/null)
+	unassign_rc=$?
+	if [[ $unassign_rc -eq 0 ]]; then
+		_isc_info "release: #$issue already outside status:in-review — unassigned $user"
+		return 0
+	fi
+	_isc_warn "release: gh failed to unassign $user from #$issue (rc=$unassign_rc): $unassign_err"
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Subcommand: release
 # -----------------------------------------------------------------------------
@@ -499,14 +517,6 @@ _isc_cmd_release() {
 		return 0
 	fi
 
-	# Build extra_flags array before the label probe because --unassign remains
-	# actionable when another lifecycle path already moved the issue to
-	# status:available. Bash 3.2 empty-array guard — see reference/bash-compat.md.
-	local -a extra_flags=()
-	if [[ $unassign -eq 1 && -n "$user" ]]; then
-		extra_flags+=(--remove-assignee "$user")
-	fi
-
 	# Idempotency: skip only label work if not in-review. `_isc_has_in_review`
 	# has three return states (0 = present, 1 = absent, 2 = lookup failed),
 	# so we need the actual rc — but a bare call under `set -e` propagates
@@ -516,25 +526,22 @@ _isc_cmd_release() {
 	local has_rc=0
 	_isc_has_in_review "$issue" "$slug" || has_rc=$?
 	if [[ $has_rc -eq 1 ]]; then
-		if [[ $unassign -eq 0 || -z "$user" ]]; then
+		if [[ $unassign -eq 0 ]]; then
 			_isc_info "release: #$issue not in status:in-review — no-op"
 			return 0
 		fi
-
-		local _unassign_err
-		_unassign_err=$(gh issue edit "$issue" --repo "$slug" \
-			${extra_flags[@]+"${extra_flags[@]}"} 2>&1 >/dev/null)
-		local _unassign_rc=$?
-		if [[ $_unassign_rc -eq 0 ]]; then
-			_isc_info "release: #$issue already outside status:in-review — unassigned $user"
-			return 0
-		fi
-		_isc_warn "release: gh failed to unassign $user from #$issue (rc=$_unassign_rc): $_unassign_err"
+		_isc_unassign_released_issue "$issue" "$slug" "$user"
 		return 0
 	fi
 	if [[ $has_rc -eq 2 ]]; then
 		_isc_warn "release: could not read labels for #$issue — skipping label transition"
 		return 0
+	fi
+
+	# Bash 3.2 empty-array guard — see reference/bash-compat.md.
+	local -a extra_flags=()
+	if [[ $unassign -eq 1 && -n "$user" ]]; then
+		extra_flags+=(--remove-assignee "$user")
 	fi
 
 	# GH#21805: apply status:done for closed issues instead of

--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -448,7 +448,7 @@ _isc_cmd_unlock() {
 #   [--unassign] = also remove self from assignees
 #
 # Behaviour:
-#   - Idempotent: no-op when the label is not set.
+#   - Idempotent: when the label is not set, only a requested unassignment runs.
 #   - Offline gh: warn and exit 0. The stamp is still deleted so local state
 #     matches the caller's intent.
 #
@@ -499,7 +499,15 @@ _isc_cmd_release() {
 		return 0
 	fi
 
-	# Idempotency: skip label work if not in-review. `_isc_has_in_review`
+	# Build extra_flags array before the label probe because --unassign remains
+	# actionable when another lifecycle path already moved the issue to
+	# status:available. Bash 3.2 empty-array guard — see reference/bash-compat.md.
+	local -a extra_flags=()
+	if [[ $unassign -eq 1 && -n "$user" ]]; then
+		extra_flags+=(--remove-assignee "$user")
+	fi
+
+	# Idempotency: skip only label work if not in-review. `_isc_has_in_review`
 	# has three return states (0 = present, 1 = absent, 2 = lookup failed),
 	# so we need the actual rc — but a bare call under `set -e` propagates
 	# non-zero returns before `rc=$?` can capture them. Use `|| rc=$?` which
@@ -508,21 +516,25 @@ _isc_cmd_release() {
 	local has_rc=0
 	_isc_has_in_review "$issue" "$slug" || has_rc=$?
 	if [[ $has_rc -eq 1 ]]; then
-		_isc_info "release: #$issue not in status:in-review — no-op"
+		if [[ $unassign -eq 0 || -z "$user" ]]; then
+			_isc_info "release: #$issue not in status:in-review — no-op"
+			return 0
+		fi
+
+		local _unassign_err
+		_unassign_err=$(gh issue edit "$issue" --repo "$slug" \
+			${extra_flags[@]+"${extra_flags[@]}"} 2>&1 >/dev/null)
+		local _unassign_rc=$?
+		if [[ $_unassign_rc -eq 0 ]]; then
+			_isc_info "release: #$issue already outside status:in-review — unassigned $user"
+			return 0
+		fi
+		_isc_warn "release: gh failed to unassign $user from #$issue (rc=$_unassign_rc): $_unassign_err"
 		return 0
 	fi
 	if [[ $has_rc -eq 2 ]]; then
 		_isc_warn "release: could not read labels for #$issue — skipping label transition"
 		return 0
-	fi
-
-	# Build extra_flags array. Bash 3.2 empty-array guard — see
-	# reference/bash-compat.md. Fourth latent bug found alongside GH#18786.
-	local -a extra_flags=()
-	if [[ $unassign -eq 1 ]]; then
-		if [[ -n "$user" ]]; then
-			extra_flags+=(--remove-assignee "$user")
-		fi
 	fi
 
 	# GH#21805: apply status:done for closed issues instead of

--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -445,8 +445,7 @@ _isc_unassign_released_issue() {
 	local unassign_rc=0
 
 	unassign_err=$(gh issue edit "$issue" --repo "$slug" \
-		--remove-assignee "$user" 2>&1 >/dev/null)
-	unassign_rc=$?
+		--remove-assignee "$user" 2>&1 >/dev/null) || unassign_rc=$?
 	if [[ $unassign_rc -eq 0 ]]; then
 		_isc_info "release: #$issue already outside status:in-review — unassigned $user"
 		return 0

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -155,7 +155,11 @@ issue)
 		exit 0
 		;;
 	edit)
-		# Log the edit flags (already captured in STUB_LOG above). Success.
+		# Log the edit flags (already captured in STUB_LOG above).
+		if [[ "${STUB_GH_EDIT_FAILS:-0}" == "1" ]]; then
+			printf 'simulated issue edit failure\n' >&2
+			exit 1
+		fi
 		exit 0
 		;;
 	list)
@@ -932,6 +936,21 @@ if [[ $release_available_repeat_rc -eq 0 ]] &&
 else
 	print_result "GH#27834: already-available release --unassign is idempotent" 1 \
 		"(rc=$release_available_repeat_rc, log=${release_available_repeat_log:0:300})"
+fi
+
+# A failed unassignment is captured under `set -e` so the documented warning-
+# only release contract is preserved instead of aborting the caller.
+release_unassign_fail_out=$(
+	set -e
+	STUB_GH_EDIT_FAILS=1 _isc_unassign_released_issue 70003 testuser/testrepo testuser 2>&1
+)
+release_unassign_fail_rc=$?
+if [[ $release_unassign_fail_rc -eq 0 ]] &&
+	printf '%s' "$release_unassign_fail_out" | grep -q "(rc=1): simulated issue edit failure"; then
+	print_result "GH#27834: failed standalone unassignment remains warning-only under set -e" 0
+else
+	print_result "GH#27834: failed standalone unassignment remains warning-only under set -e" 1 \
+		"(rc=$release_unassign_fail_rc, out=${release_unassign_fail_out:0:300})"
 fi
 
 # Without --unassign, already-available remains a complete no-op.

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -23,6 +23,10 @@
 
 set -uo pipefail
 
+# This suite asserts the helper's primary `gh issue edit` command shapes.
+# Isolate it from pulse/runtime routing overrides inherited by worker shells.
+unset AIDEVOPS_GH_FORCE_REST_READS AIDEVOPS_GH_REST_FIRST_READS _GH_SHOULD_FALLBACK_OVERRIDE
+
 TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 HELPER_PATH="${TEST_SCRIPTS_DIR}/interactive-session-helper.sh"
 
@@ -84,6 +88,13 @@ auth)
 	exit 0
 	;;
 	api)
+		# Keep status transitions on their primary `gh issue edit` path. An empty
+		# rate-limit response now triggers REST fallback, which this focused stub
+		# does not model and would make label assertions environment-dependent.
+		if [[ "$2" == "rate_limit" ]]; then
+			printf '5000\n'
+			exit 0
+		fi
 		# gh api user --jq '.login'
 		if [[ "$2" == "user" ]]; then
 			printf 'testuser\n'
@@ -183,6 +194,12 @@ fi
 source "$HELPER_PATH" >/dev/null 2>&1
 # Helper sets `set -euo pipefail` — drop -e for negative assertions
 set +e
+
+# Persisted runtime cooldowns must not suppress the stubbed write calls this
+# isolated command-shape suite asserts.
+_gh_secondary_cooldown_preflight() {
+	return 0
+}
 
 # Sanity check — did sourcing expose the functions we need?
 if ! declare -f _isc_cmd_claim >/dev/null; then
@@ -884,10 +901,72 @@ fi
 export STUB_ISSUE_HAS_IN_REVIEW=0
 
 # =============================================================================
-# Test 25 — issue-start marker fails closed without explicit takeover
+# Test 25 — GH#27834: release --unassign remains actionable after another
+# lifecycle path has already moved the issue to status:available.
+# =============================================================================
+export STUB_ISSUE_HAS_IN_REVIEW=0
+export STUB_GH_VIEW_FAILS=0
+: >"$STUB_LOG"
+_isc_cmd_release 70003 testuser/testrepo --unassign >/dev/null 2>&1
+release_available_rc=$?
+release_available_log=$(cat "$STUB_LOG")
+
+if [[ $release_available_rc -eq 0 ]] &&
+	printf '%s' "$release_available_log" | grep -q "issue edit 70003 --repo testuser/testrepo --remove-assignee testuser" &&
+	! printf '%s' "$release_available_log" | grep -q "remove-label status:in-review" &&
+	! printf '%s' "$release_available_log" | grep -q "add-label status:available"; then
+	print_result "GH#27834: already-available release --unassign removes self-assignment only" 0
+else
+	print_result "GH#27834: already-available release --unassign removes self-assignment only" 1 \
+		"(rc=$release_available_rc, log=${release_available_log:0:300})"
+fi
+
+# A repeated call is harmless and still requests the idempotent removal.
+: >"$STUB_LOG"
+_isc_cmd_release 70003 testuser/testrepo --unassign >/dev/null 2>&1
+release_available_repeat_rc=$?
+release_available_repeat_log=$(cat "$STUB_LOG")
+if [[ $release_available_repeat_rc -eq 0 ]] &&
+	printf '%s' "$release_available_repeat_log" | grep -q -- "--remove-assignee testuser"; then
+	print_result "GH#27834: already-available release --unassign is idempotent" 0
+else
+	print_result "GH#27834: already-available release --unassign is idempotent" 1 \
+		"(rc=$release_available_repeat_rc, log=${release_available_repeat_log:0:300})"
+fi
+
+# Without --unassign, already-available remains a complete no-op.
+: >"$STUB_LOG"
+_isc_cmd_release 70004 testuser/testrepo >/dev/null 2>&1
+release_available_noop_rc=$?
+release_available_noop_log=$(cat "$STUB_LOG")
+if [[ $release_available_noop_rc -eq 0 ]] &&
+	! printf '%s' "$release_available_noop_log" | grep -q "issue edit 70004"; then
+	print_result "GH#27834: already-available release without --unassign stays unchanged" 0
+else
+	print_result "GH#27834: already-available release without --unassign stays unchanged" 1 \
+		"(rc=$release_available_noop_rc, log=${release_available_noop_log:0:300})"
+fi
+
+# A failed three-state label lookup preserves the warning/fail-open path and
+# does not guess whether a standalone unassignment is safe.
+: >"$STUB_LOG"
+release_lookup_out=$(STUB_GH_VIEW_FAILS=1 _isc_cmd_release 70005 testuser/testrepo --unassign 2>&1)
+release_lookup_rc=$?
+release_lookup_log=$(cat "$STUB_LOG")
+if [[ $release_lookup_rc -eq 0 ]] &&
+	printf '%s' "$release_lookup_out" | grep -q "could not read labels" &&
+	! printf '%s' "$release_lookup_log" | grep -q "issue edit 70005"; then
+	print_result "GH#27834: release label lookup failure remains warning-only" 0
+else
+	print_result "GH#27834: release label lookup failure remains warning-only" 1 \
+		"(rc=$release_lookup_rc, log=${release_lookup_log:0:300}, out=${release_lookup_out:0:200})"
+fi
+
+# =============================================================================
+# Test 26 — issue-start marker fails closed without explicit takeover
 # =============================================================================
 marker_out=$(AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION=1 \
-	_isc_cmd_claim 70003 testowner/testrepo --worktree /tmp/wt-fake 2>&1)
+	_isc_cmd_claim 70006 testowner/testrepo --worktree /tmp/wt-fake 2>&1)
 marker_rc=$?
 
 if [[ $marker_rc -eq 2 ]] && printf '%s' "$marker_out" | grep -q 'requires --implementing'; then


### PR DESCRIPTION
## Summary

- preserve `release --unassign` when an issue is already outside `status:in-review`
- skip label transitions on the already-available path
- cover repeated calls, no-flag no-ops, and label lookup failures

## Testing

- `bash .agents/scripts/tests/test-interactive-session-claim.sh`
- `shellcheck .agents/scripts/interactive-session-helper-commands.sh .agents/scripts/tests/test-interactive-session-claim.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

- runtime-verified through the stubbed helper command suite

Resolves #27834

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.1 with gpt-5.6-sol spent 9m and 110,632 tokens on this as a headless worker. Overall, 40m since this issue was created.
