### PR TITLE
t18136: Stabilize LaunchAgent runtime paths

### DIFF
--- a/.agents/scripts/setup/modules/schedulers.sh
+++ b/.agents/scripts/setup/modules/schedulers.sh
@@ -37,14 +37,22 @@ CRON_EVERY_MINUTE="* * * * *"
 if ! declare -F aidevops_launchd_sanitized_path >/dev/null 2>&1; then
 	aidevops_launchd_sanitized_path() {
 		local input_path="${1:-${PATH:-}}"
-		local default_path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+		local stable_path=""
+		if [[ -n "${HOME:-}" ]]; then
+			stable_path="${HOME}/.local/bin:${HOME}/.aidevops/agents/scripts:${HOME}/.aidevops/bin"
+		fi
+		local default_path="${stable_path:+${stable_path}:}/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 		local result=""
 		local seen=""
 		local dir=""
 		local old_ifs="$IFS"
 		IFS=':'
 		for dir in $default_path:$input_path; do
-			[[ -n "$dir" && -d "$dir" ]] || continue
+			[[ -n "$dir" ]] || continue
+			case "$dir" in
+			*/.aidevops/runtime-bundles/*) continue ;;
+			esac
+			[[ -d "$dir" ]] || continue
 			case ":$seen:" in
 			*":${dir}:"*) continue ;;
 			esac

--- a/.agents/scripts/setup/modules/schedulers.sh
+++ b/.agents/scripts/setup/modules/schedulers.sh
@@ -45,8 +45,7 @@ if ! declare -F aidevops_launchd_sanitized_path >/dev/null 2>&1; then
 		local result=""
 		local seen=""
 		local dir=""
-		local old_ifs="$IFS"
-		IFS=':'
+		local IFS=':'
 		for dir in $default_path:$input_path; do
 			[[ -n "$dir" ]] || continue
 			case "$dir" in
@@ -59,7 +58,6 @@ if ! declare -F aidevops_launchd_sanitized_path >/dev/null 2>&1; then
 			seen="${seen:+${seen}:}${dir}"
 			result="${result:+${result}:}${dir}"
 		done
-		IFS="$old_ifs"
 		printf '%s' "$result"
 		return 0
 	}

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -370,16 +370,14 @@ aidevops_launchd_sanitized_path() {
 	local _aidevops_launchd_path_result=""
 	local _aidevops_launchd_path_seen=""
 	local dir=""
-	local old_ifs="$IFS"
+	local IFS=':'
 
-	IFS=':'
 	for dir in $default_path; do
 		_aidevops_append_launchd_path_dir "$dir"
 	done
 	for dir in $input_path; do
 		_aidevops_append_launchd_path_dir "$dir"
 	done
-	IFS="$old_ifs"
 
 	printf '%s' "$_aidevops_launchd_path_result"
 	return 0

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -341,12 +341,16 @@ readonly TEMP_PREFIX="tmp_"
 # Build a PATH value safe to embed in macOS LaunchAgent EnvironmentVariables.
 # launchd jobs inherit no useful interactive shell setup, but serialising the
 # caller's raw PATH bakes stale manager-specific entries into long-lived plists.
-# Keep known system/tool roots first, then preserve only inherited entries that
-# actually exist on this host.
+# Keep stable user and known system/tool roots first, then preserve inherited
+# entries that exist on this host. Never persist immutable runtime-bundle paths:
+# long-lived sessions intentionally retain old bundles after stable activation.
 
 _aidevops_append_launchd_path_dir() {
 	local dir="$1"
 	[[ -n "$dir" ]] || return 0
+	case "$dir" in
+	*/.aidevops/runtime-bundles/*) return 0 ;;
+	esac
 	[[ -d "$dir" ]] || return 0
 	case ":${_aidevops_launchd_path_seen:-}:" in
 	*":${dir}:"*) return 0 ;;
@@ -358,7 +362,11 @@ _aidevops_append_launchd_path_dir() {
 
 aidevops_launchd_sanitized_path() {
 	local input_path="${1:-${PATH:-}}"
-	local default_path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+	local stable_path=""
+	if [[ -n "${HOME:-}" ]]; then
+		stable_path="${HOME}/.local/bin:${HOME}/.aidevops/agents/scripts:${HOME}/.aidevops/bin"
+	fi
+	local default_path="${stable_path:+${stable_path}:}/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 	local _aidevops_launchd_path_result=""
 	local _aidevops_launchd_path_seen=""
 	local dir=""

--- a/.agents/scripts/tests/test-launchd-sanitized-path.sh
+++ b/.agents/scripts/tests/test-launchd-sanitized-path.sh
@@ -70,30 +70,40 @@ assert_not_contains() {
 	return 0
 }
 
-test_sanitized_path_filters_missing_entries() {
+test_sanitized_path_filters_unsafe_entries() {
+	local test_home="$TEST_DIR/home"
+	local stable_local_bin="$test_home/.local/bin"
+	local stable_scripts="$test_home/.aidevops/agents/scripts"
+	local stable_bin="$test_home/.aidevops/bin"
+	local stale_bundle="$test_home/.aidevops/runtime-bundles/old/agents/scripts"
 	local existing_dir="$TEST_DIR/existing-bin"
 	local missing_dir="$TEST_DIR/missing-bin"
-	mkdir -p "$existing_dir"
+	mkdir -p "$stable_local_bin" "$stable_scripts" "$stable_bin" \
+		"$stale_bundle" "$existing_dir"
 
 	local polluted_path result
-	polluted_path="${missing_dir}:${existing_dir}:/usr/bin:${existing_dir}:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin"
-	result=$(aidevops_launchd_sanitized_path "$polluted_path")
+	polluted_path="${stale_bundle}:${missing_dir}:${existing_dir}:/usr/bin:${stable_scripts}:${existing_dir}:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin"
+	result=$(HOME="$test_home" aidevops_launchd_sanitized_path "$polluted_path")
 
-	local ok=0
+	local ok=0 stable_scripts_count=0
+	[[ "$result" == "${stable_local_bin}:${stable_scripts}:${stable_bin}:"* ]] || ok=1
 	[[ "$result" == *"$existing_dir"* ]] || ok=1
 	[[ "$result" == *"/usr/bin"* ]] || ok=1
-	assert_not_contains "test_sanitized_path_filters_missing_entries" "$result" "$missing_dir" || ok=1
+	stable_scripts_count=$(printf '%s' "$result" | tr ':' '\n' | grep -Fxc "$stable_scripts" || true)
+	[[ "$stable_scripts_count" -eq 1 ]] || ok=1
+	assert_not_contains "test_sanitized_path_filters_unsafe_entries" "$result" "$stale_bundle" || ok=1
+	assert_not_contains "test_sanitized_path_filters_unsafe_entries" "$result" "$missing_dir" || ok=1
 	if [[ ! -d /opt/pkg/env/active/bin ]]; then
-		assert_not_contains "test_sanitized_path_filters_missing_entries" "$result" "/opt/pkg/env/active/bin" || ok=1
+		assert_not_contains "test_sanitized_path_filters_unsafe_entries" "$result" "/opt/pkg/env/active/bin" || ok=1
 	fi
 	if [[ ! -d /opt/pmk/env/global/bin ]]; then
-		assert_not_contains "test_sanitized_path_filters_missing_entries" "$result" "/opt/pmk/env/global/bin" || ok=1
+		assert_not_contains "test_sanitized_path_filters_unsafe_entries" "$result" "/opt/pmk/env/global/bin" || ok=1
 	fi
 
 	if [[ "$ok" -eq 0 ]]; then
-		pass "test_sanitized_path_filters_missing_entries"
+		pass "test_sanitized_path_filters_unsafe_entries"
 	else
-		fail "test_sanitized_path_filters_missing_entries" "sanitized PATH was: $result"
+		fail "test_sanitized_path_filters_unsafe_entries" "sanitized PATH was: $result"
 	fi
 	return 0
 }
@@ -132,7 +142,7 @@ test_auto_update_plist_filters_polluted_env_path() {
 
 main() {
 	setup
-	test_sanitized_path_filters_missing_entries
+	test_sanitized_path_filters_unsafe_entries
 	test_auto_update_plist_filters_polluted_env_path
 
 	printf 'Ran %d tests, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-launchd-sanitized-path.sh
+++ b/.agents/scripts/tests/test-launchd-sanitized-path.sh
@@ -108,6 +108,29 @@ test_sanitized_path_filters_unsafe_entries() {
 	return 0
 }
 
+test_sanitized_path_preserves_unset_ifs() {
+	local test_home="$TEST_DIR/unset-ifs-home"
+	mkdir -p "$test_home/.aidevops/agents/scripts"
+
+	local ifs_state=""
+	ifs_state=$(
+		unset IFS
+		HOME="$test_home" aidevops_launchd_sanitized_path "/usr/bin:/bin" >/dev/null
+		if [[ -z "${IFS+x}" ]]; then
+			printf 'unset'
+		else
+			printf 'set'
+		fi
+	)
+
+	if [[ "$ifs_state" == "unset" ]]; then
+		pass "test_sanitized_path_preserves_unset_ifs"
+	else
+		fail "test_sanitized_path_preserves_unset_ifs" "IFS became set after sanitization"
+	fi
+	return 0
+}
+
 test_auto_update_plist_filters_polluted_env_path() {
 	local existing_dir="$TEST_DIR/existing-tool-bin"
 	local missing_dir="$TEST_DIR/missing-tool-bin"
@@ -143,6 +166,7 @@ test_auto_update_plist_filters_polluted_env_path() {
 main() {
 	setup
 	test_sanitized_path_filters_unsafe_entries
+	test_sanitized_path_preserves_unset_ifs
 	test_auto_update_plist_filters_polluted_env_path
 
 	printf 'Ran %d tests, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-defense-restart.sh
+++ b/.agents/scripts/tests/test-pulse-defense-restart.sh
@@ -65,7 +65,9 @@ setup() {
 # _build_plist_env_overrides_xml.
 _render_pulse_plist() {
 	local out_file="$1"
-	bash -c '
+	local render_home="${2:-$HOME}"
+	local render_path="${3:-$PATH}"
+	HOME="$render_home" PATH="$render_path" bash -c '
 		set -uo pipefail
 		export PULSE_STALE_THRESHOLD_SECONDS=1800
 		_xml_escape() {
@@ -91,6 +93,7 @@ _render_pulse_plist() {
 		_build_plist_env_overrides_xml() { return 0; }
 		_generate_pulse_plist_content "com.test.pulse" "/path/to/pulse.sh" "/opt/homebrew/bin/opencode"
 	' >"$out_file"
+	return 0
 }
 
 _render_watchdog_plist() {
@@ -111,6 +114,7 @@ _render_watchdog_plist() {
 		source "'"$SCHEDULERS_SH"'" 2>/dev/null || true
 		_generate_pulse_watchdog_plist_content "sh.aidevops.pulse-watchdog" "/path/to/tick.sh" "/opt/homebrew/bin/bash"
 	' >"$out_file"
+	return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -140,6 +144,26 @@ test_pulse_plist_throttle_interval() {
 	fi
 	print_result "test_pulse_plist_throttle_interval" "$rc" \
 		"ThrottleInterval prevents rapid-restart loops (t2939 layer 1)"
+	return 0
+}
+
+test_pulse_plist_filters_runtime_bundle_path() {
+	local render_home="$TEST_DIR/pulse-path-home"
+	local stable_scripts="$render_home/.aidevops/agents/scripts"
+	local stale_bundle="$render_home/.aidevops/runtime-bundles/old/agents/scripts"
+	local plist="$TEST_DIR/pulse-path.plist"
+	mkdir -p "$render_home/.local/bin" "$stable_scripts" \
+		"$render_home/.aidevops/bin" "$stale_bundle"
+
+	_render_pulse_plist "$plist" "$render_home" "${stale_bundle}:/usr/bin:/bin"
+
+	local rc=0
+	grep -Fq "$stable_scripts" "$plist" || rc=1
+	if grep -Fq "/.aidevops/runtime-bundles/" "$plist"; then
+		rc=1
+	fi
+	print_result "test_pulse_plist_filters_runtime_bundle_path" "$rc" \
+		"Pulse plist must replace inherited immutable bundle paths with the stable agents path"
 	return 0
 }
 
@@ -386,6 +410,7 @@ main() {
 	# we only skip the plutil-lint validation).
 	test_pulse_plist_keepalive_dict
 	test_pulse_plist_throttle_interval
+	test_pulse_plist_filters_runtime_bundle_path
 	test_watchdog_plist_label
 	test_watchdog_plist_start_interval
 	test_watchdog_plist_valid_xml

--- a/TODO.md
+++ b/TODO.md
@@ -4608,4 +4608,4 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [ ] t18132 Prevent cross-install upstream-watch duplicate issues #auto-dispatch #bug #framework #reliability ref:GH#27821
 
-- [ ] t18136 Prevent LaunchAgents from pinning stale runtime-bundle PATH entries #bug #framework #pulse #reliability ref:GH#27851
+- [ ] t18136 Prevent LaunchAgents from pinning stale runtime-bundle PATH entries #bug #framework #pulse #reliability #interactive #no-auto-dispatch ~1.5h tier:standard -> [todo/tasks/t18136-brief.md] ref:GH#27851

--- a/todo/tasks/t18136-brief.md
+++ b/todo/tasks/t18136-brief.md
@@ -1,0 +1,163 @@
+<!-- aidevops:brief-schema=v2 -->
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18136: Prevent LaunchAgents from pinning stale runtime-bundle PATH entries
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `t18125 launchd runtime bundle path sanitization` → 0 hits — no relevant indexed lesson
+- [x] Discovery pass: 3 recent target-file commits / 0 related merged PRs / 0 related open PRs; issue-title and body searches found no exact duplicate
+- [x] File refs verified: 8 source/test refs checked, all present at `3428e0535`
+- [x] Tier: `tier:standard` — four coordinated shell/test surfaces and setup/deployment recovery disqualify `tier:simple`, while the implementation pattern is established
+- [x] Seeded draft PR decision recorded: skipped — implement the reproduced fix directly with focused regression tests
+
+## Origin
+
+- **Created:** 2026-07-15
+- **Session:** OpenCode interactive t18125 deployment verification
+- **Created by:** AI DevOps (ai-interactive) under maintainer-authorised full-loop execution
+- **Parent task:** None; leaf reliability defect discovered while completing t18125
+- **Blocked by:** None
+- **Conversation context:** Deploying the merged exact-telemetry patch activated framework `3.32.123`, but setup generated the Pulse LaunchAgent with an inherited `3.32.112` runtime-bundle scripts directory at the front of `PATH`. The directory still existed, so the current sanitiser retained it and the daemon continued resolving stale helpers until the plist was corrected and reloaded manually.
+
+## What
+
+Make launchd PATH generation reject immutable aidevops runtime-bundle entries even when those directories still exist, while adding the stable user-level aidevops tool roots before system defaults. Mirror the contract in the scheduler module's standalone fallback, cover both the shared helper and generated Pulse plist, then regenerate the live scheduler through setup.
+
+## Why
+
+`aidevops_launchd_sanitized_path` currently filters only missing directories. A long-lived interactive session intentionally retains a valid immutable bundle, so any setup run from that session serialises the old physical path into new LaunchAgent plists. Restarting Pulse then selects stale scripts despite successful atomic activation, undermining deployment convergence and invalidating telemetry canaries that assume the merged recorder is live.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** The desired stable-path contract is clear, but production and standalone fallback implementations plus two shell harnesses must remain aligned across mixed-version and deployment states.
+
+## PR Conventions
+
+Leaf task: title the implementation PR `t18136: ...` and use the standard closing keyword for this issue.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** The issue is being implemented immediately in its dedicated linked worktree; a separate unverified seed would add no value.
+- **Status:** `not-created`
+- **Freshness evidence:** Source, fallback, Pulse plist generator, focused tests, current `PATH`, deployed plist, and current `origin/main` were checked in this session.
+- **Verification run:** Live reproduction and manual stable-path recovery verified; source regression tests are unrun at brief creation.
+- **Stale-assumption warning:** Re-check the shared sanitiser and scheduler fallback if either changes before implementation.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/shared-constants.sh:339-378` — reject managed runtime-bundle entries and prepend existing stable user-level aidevops roots.
+- `EDIT: .agents/scripts/setup/modules/schedulers.sh:34-58` — keep the direct-test/standalone fallback behavior identical.
+- `EDIT: .agents/scripts/tests/test-launchd-sanitized-path.sh:73-99` — prove an existing stale bundle is excluded and stable roots are retained.
+- `EDIT: .agents/scripts/tests/test-pulse-defense-restart.sh:63-114,116-170` — prove the generated Pulse plist cannot serialise an inherited runtime-bundle path.
+
+### Complete Write Surface
+
+- **Callers/readers:** `aidevops_launchd_sanitized_path` is consumed by auto-update, repository sync/health, routine, memory-pressure, watchdog, DB-maintenance, and setup scheduler plist generators; all should receive the same exclusion contract.
+- **Writers/mutation paths:** `.agents/scripts/setup/modules/schedulers-pulse.sh:_generate_pulse_plist_content` and sibling generators serialise the helper result into LaunchAgent `EnvironmentVariables.PATH`; setup's `_launchd_install_if_changed` atomically replaces changed plists.
+- **Tests/fixtures:** `.agents/scripts/tests/test-launchd-sanitized-path.sh` owns shared helper behavior; `.agents/scripts/tests/test-pulse-defense-restart.sh` owns Pulse/watchdog plist generation.
+- **Schemas/config:** No persistent schema changes. PATH ordering gains stable `$HOME/.local/bin`, `$HOME/.aidevops/agents/scripts`, and `$HOME/.aidevops/bin` when those directories exist.
+- **Generated/deployed mirrors:** Repository scripts deploy through `setup.sh`; the live `~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist` must be regenerated and reloaded after merge.
+- **Migrations/backfills:** `setup.sh` regenerates existing plists when content changes; no historical data migration is required.
+- **Cleanup/rollback paths:** `git revert` plus `setup.sh` restores prior generation. Do not delete runtime bundles: active interactive sessions may legitimately lease them.
+
+### Implementation Steps
+
+1. Extend shared path hygiene so managed immutable bundle entries are rejected before existence/dedup checks, while existing stable user roots are considered before system defaults:
+
+```bash
+case "$dir" in
+*/.aidevops/runtime-bundles/*) return 0 ;;
+esac
+
+local default_path="${HOME:-}/.local/bin:${HOME:-}/.aidevops/agents/scripts:${HOME:-}/.aidevops/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+```
+
+2. Apply the same ordering and runtime-bundle exclusion to the fallback function in `schedulers.sh`; direct tests source this module without the shared helper.
+3. Expand `test_sanitized_path_filters_missing_entries` with a physically existing `.../.aidevops/runtime-bundles/old/agents/scripts` entry plus stable roots. Assert stable roots are present once and the old bundle is absent.
+4. Add a Pulse plist fixture whose subshell `HOME` contains stable directories and whose inherited `PATH` begins with an existing old runtime bundle. Assert the rendered XML contains the stable scripts path and excludes `/runtime-bundles/`.
+5. Run setup after merge and verify both plist text and `launchctl print gui/<uid>/com.aidevops.aidevops-supervisor-pulse` show stable roots with no runtime-bundle component.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** Do not prune or mutate runtime bundles; only omit their paths from newly generated plist content. Existing atomic plist replacement remains unchanged.
+- **Migration/rollback:** Setup detects changed content and reloads launchd. If reload fails, `_launchd_install_if_changed` must preserve its existing recovery behavior.
+- **Mixed-version/backward compatibility:** Interactive processes remain pinned to their startup bundle as designed. Newly launched daemons use the stable symlink so atomic activation updates future child resolution.
+- **Idempotency/retry:** Repeated sanitisation/setup runs produce the same ordered deduplicated PATH. All unrelated existing inherited directories remain preserved.
+- **Partial failure/recovery:** If user-level stable roots do not exist, the helper still emits existing system/tool roots. A setup failure must not delete runtime bundles or the prior valid plist.
+
+### Complexity Impact
+
+- **Target functions:** `_aidevops_append_launchd_path_dir`, `aidevops_launchd_sanitized_path`, and the scheduler fallback.
+- **Current line count:** Each target function is below 30 lines.
+- **Estimated growth:** Under 30 production lines plus focused fixtures.
+- **Projected post-change:** Functions remain below complexity thresholds with one high-precision path guard.
+- **Action required:** Keep the shared and fallback contracts textually aligned; do not add Pulse-only path rewriting.
+
+### Verification Before Dispatch
+
+```bash
+bash .agents/scripts/tests/test-launchd-sanitized-path.sh
+bash .agents/scripts/tests/test-pulse-defense-restart.sh
+shellcheck .agents/scripts/shared-constants.sh .agents/scripts/setup/modules/schedulers.sh .agents/scripts/tests/test-launchd-sanitized-path.sh .agents/scripts/tests/test-pulse-defense-restart.sh
+.agents/scripts/linters-local.sh --changed
+```
+
+- **Surface mapping:** The first suite proves global sanitisation and auto-update plist behavior; the second proves actual Pulse/watchdog generation; ShellCheck protects Bash 3.2/explicit-return rules; changed lint covers repository gates.
+- **Broad verification trigger:** Run setup and inspect live launchd state because the defect occurred only after deployment from a pinned session.
+
+### Recoverability Checkpoint
+
+- [ ] Focused tests pass before broad setup/deployment checks.
+- [ ] Create WIP commit `wip: stabilize launchd runtime paths` after focused tests.
+- [ ] Run changed lint, PR CI, merge, setup, and live LaunchAgent verification from the exact merged SHA.
+
+### Files Scope
+
+- `.agents/scripts/shared-constants.sh`
+- `.agents/scripts/setup/modules/schedulers.sh`
+- `.agents/scripts/tests/test-launchd-sanitized-path.sh`
+- `.agents/scripts/tests/test-pulse-defense-restart.sh`
+
+## Acceptance Criteria
+
+- [ ] An existing inherited `~/.aidevops/runtime-bundles/*/agents/scripts` directory is absent from sanitised PATH output and generated Pulse plist XML.
+- [ ] Existing stable user roots are ordered before system defaults, deduplicated, and missing roots remain omitted.
+- [ ] Non-aidevops existing inherited directories remain preserved and missing directories remain filtered.
+- [ ] Focused tests, ShellCheck, changed-file lint, and required PR checks pass.
+- [ ] Post-merge setup reloads Pulse with stable `~/.aidevops/agents/scripts` and no runtime-bundle entry in live launchd state.
+
+## Context & Decisions
+
+- Filter managed immutable bundle paths globally rather than special-casing Pulse; every long-lived LaunchAgent has the same stale-pin risk.
+- Preserve runtime bundles themselves because live interactive sessions lease and require them.
+- Replace stale physical paths with stable user-level roots, not merely deletion, so daemon child commands remain resolvable.
+
+## Relevant Files
+
+- `.agents/scripts/shared-constants.sh:339-378` — canonical launchd PATH hygiene.
+- `.agents/scripts/setup/modules/schedulers.sh:34-58` — fallback used by direct scheduler tests.
+- `.agents/scripts/setup/modules/schedulers-pulse.sh:734-748,887-897` — Pulse and watchdog PATH serialisation.
+- `.agents/scripts/tests/test-launchd-sanitized-path.sh:73-130` — shared helper and auto-update coverage.
+- `.agents/scripts/tests/test-pulse-defense-restart.sh:63-114` — Pulse/watchdog renderer fixtures.
+
+## Dependencies
+
+- **Blocked by:** None.
+- **Blocks:** Starting the trustworthy t18125 telemetry observation window.
+- **External:** macOS launchd is required only for post-merge deployment verification; focused fixtures are hermetic.
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Implementation | 30m | Shared/fallback path contract |
+| Focused tests | 30m | Helper and Pulse plist fixtures |
+| Review/deploy | 30m | CI, merge, setup, live launchd check |
+| **Total** | **1.5h** | |


### PR DESCRIPTION
## Summary

Replace inherited immutable runtime-bundle entries with stable user-level aidevops paths in launchd PATH generation, including the standalone scheduler fallback. Add shared-helper and generated-Pulse-plist regressions.

## Files Changed

.agents/scripts/setup/modules/schedulers.sh, .agents/scripts/shared-constants.sh, .agents/scripts/tests/test-launchd-sanitized-path.sh, .agents/scripts/tests/test-pulse-defense-restart.sh, TODO.md, todo/tasks/t18136-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused suites 2/2 and 15/15; scheduler interval 3/3; launchd install 13/13; non-interactive Pulse setup 3/3; ShellCheck and changed-file lint passed.

Resolves #27851


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.124 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 15h 41m and 3,792,605 tokens on this with the user in an interactive session.