### PR TITLE
GH#27849: bound relationship sync aggregate duration

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -184,12 +184,20 @@ _push_finalize_task_creation() {
 		return 1
 	fi
 	[[ -n "$tier_label" ]] && _apply_tier_label_replace "$repo" "$_PUSH_CREATED_NUM" "$tier_label"
-	sync_relationships_for_task "$task_id" "$todo_file" "$repo"
+	local relationships_pending=false
+	if ! sync_relationships_for_task "$task_id" "$todo_file" "$repo"; then
+		relationships_pending=true
+		print_warning "Created #${_PUSH_CREATED_NUM}; durable mapping preserved, but relationship sync is pending"
+	fi
 	if [[ ",${labels}," == *",parent-task,"* ]] &&
 		! _parent_body_has_phase_markers "$body"; then
 		_post_parent_task_no_markers_warning "$repo" "$_PUSH_CREATED_NUM" || true
 	fi
-	echo "CREATED"
+	if [[ "$relationships_pending" == "true" ]]; then
+		echo "CREATED RELATIONSHIPS_PENDING"
+	else
+		echo "CREATED"
+	fi
 	return 0
 }
 
@@ -372,8 +380,12 @@ _enrich_process_task() {
 	if _enrich_update_issue "$repo" "$num" "$task_id" "$title" "$body" "$current_title" "$current_body"; then
 		print_success "Enriched #$num ($task_id)"
 		# Sync relationships (blocked-by, sub-issues) after enrichment (t1889)
-		sync_relationships_for_task "$task_id" "$todo_file" "$repo"
-		echo "ENRICHED"
+		if sync_relationships_for_task "$task_id" "$todo_file" "$repo"; then
+			echo "ENRICHED"
+		else
+			print_warning "Enriched #$num; issue update preserved, but relationship sync is pending"
+			echo "ENRICHED RELATIONSHIPS_PENDING"
+		fi
 	fi
 	return 0
 }

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -436,9 +436,11 @@ main() {
 	done
 	command="${positional_args[0]:-help}"
 	case "$command" in
-	push) cmd_push "${positional_args[1]:-}" ;; enrich) cmd_enrich "${positional_args[1]:-}" ;;
+	push) run_relationship_scoped_command cmd_push "${positional_args[1]:-}" ;;
+	enrich) run_relationship_scoped_command cmd_enrich "${positional_args[1]:-}" ;;
 	pull) cmd_pull ;; close) cmd_close "${positional_args[1]:-}" ;; reopen) cmd_reopen ;;
-	reconcile) cmd_reconcile ;; relationships) cmd_relationships "${positional_args[1]:-}" ;;
+	reconcile) cmd_reconcile ;;
+	relationships) run_relationship_scoped_command cmd_relationships "${positional_args[1]:-}" ;;
 	backfill-sub-issues)
 		if [[ ${#positional_args[@]} -gt 1 ]]; then
 			cmd_backfill_sub_issues "${positional_args[@]:1}"

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -52,6 +52,60 @@ _NODE_ID_CACHE_FILE=""
 # Callers check via _node_id_was_rate_limited. Reset to empty at each call.
 _NODE_ID_RATE_LIMITED_FILE=""
 
+# Invocation-scoped native-edge set. A file is required because relationship
+# helpers are commonly called through command substitutions; file writes
+# survive those subshell boundaries while Bash variables do not.
+_RELATIONSHIP_EDGE_SEEN_FILE=""
+
+_init_relationship_sync_state() {
+	_init_node_id_cache
+	if [[ -z "$_RELATIONSHIP_EDGE_SEEN_FILE" ]]; then
+		_RELATIONSHIP_EDGE_SEEN_FILE=$(mktemp "${TMPDIR:-/tmp}/aidevops-relationship-edges.XXXXXX") || return 1
+	fi
+	: >"$_RELATIONSHIP_EDGE_SEEN_FILE"
+	return 0
+}
+
+_cleanup_relationship_sync_state() {
+	if [[ -n "$_RELATIONSHIP_EDGE_SEEN_FILE" ]]; then
+		rm -f "$_RELATIONSHIP_EDGE_SEEN_FILE"
+		_RELATIONSHIP_EDGE_SEEN_FILE=""
+	fi
+	return 0
+}
+
+_relationship_sync_deadline_epoch() {
+	# Keep automatic post-create work below common 120-second outer worker
+	# ceilings. Callers may override this documented aggregate budget.
+	local budget="${AIDEVOPS_RELATIONSHIP_SYNC_TIMEOUT:-90}"
+	local now_epoch=""
+	[[ "$budget" =~ ^[1-9][0-9]*$ ]] || budget=90
+	now_epoch=$(date +%s 2>/dev/null) || return 1
+	printf '%s\n' "$((now_epoch + budget))"
+	return 0
+}
+
+_relationship_deadline_expired() {
+	local deadline_epoch="${AIDEVOPS_GH_DEADLINE_EPOCH:-0}"
+	local now_epoch=""
+	[[ "$deadline_epoch" =~ ^[1-9][0-9]*$ ]] || return 1
+	now_epoch=$(date +%s 2>/dev/null) || return 0
+	[[ "$now_epoch" -ge "$deadline_epoch" ]]
+	return $?
+}
+
+_relationship_edge_should_attempt() {
+	local blocked_num="$1"
+	local blocker_num="$2"
+	local edge_key="${blocked_num}|${blocker_num}"
+	[[ -n "$_RELATIONSHIP_EDGE_SEEN_FILE" ]] || return 1
+	if grep -Fxq -- "$edge_key" "$_RELATIONSHIP_EDGE_SEEN_FILE" 2>/dev/null; then
+		return 1
+	fi
+	printf '%s\n' "$edge_key" >>"$_RELATIONSHIP_EDGE_SEEN_FILE"
+	return 0
+}
+
 _init_node_id_cache() {
 	if [[ -z "$_NODE_ID_CACHE_FILE" ]]; then
 		_NODE_ID_CACHE_FILE=$(mktemp "${TMPDIR:-/tmp}/aidevops-node-cache.XXXXXX")
@@ -379,6 +433,10 @@ _sync_declared_blocked_by_edges() {
 	local saved_ifs="$IFS"
 	IFS=','
 	for dep_task_id in $blocked_by; do
+			if _relationship_deadline_expired; then
+				retryable_errors=$((retryable_errors + 1))
+				break
+			fi
 			dep_task_id="${dep_task_id// /}"
 			[[ -z "$dep_task_id" ]] && continue
 			if [[ "$dep_task_id" == "$task_id" ]]; then
@@ -394,6 +452,10 @@ _sync_declared_blocked_by_edges() {
 			}
 			if [[ "$dep_gh_num" == "$this_gh_num" ]]; then
 				log_verbose "$task_id: ignoring blocked-by edge that resolves back to #$this_gh_num"
+				continue
+			fi
+			if ! _relationship_edge_should_attempt "$this_gh_num" "$dep_gh_num"; then
+				log_verbose "$task_id: skipping duplicate native edge #$this_gh_num blocked-by #$dep_gh_num"
 				continue
 			fi
 			local dep_node_id
@@ -433,6 +495,10 @@ _sync_declared_blocks_edges() {
 	local saved_ifs="$IFS"
 	IFS=','
 	for dep_task_id in $blocks; do
+			if _relationship_deadline_expired; then
+				retryable_errors=$((retryable_errors + 1))
+				break
+			fi
 			dep_task_id="${dep_task_id// /}"
 			[[ -z "$dep_task_id" ]] && continue
 			if [[ "$dep_task_id" == "$task_id" ]]; then
@@ -447,6 +513,10 @@ _sync_declared_blocks_edges() {
 				continue
 			}
 			[[ "$dep_gh_num" == "$this_gh_num" ]] && continue
+			if ! _relationship_edge_should_attempt "$dep_gh_num" "$this_gh_num"; then
+				log_verbose "$task_id: skipping duplicate native edge #$dep_gh_num blocked-by #$this_gh_num"
+				continue
+			fi
 			local dep_node_id
 			dep_node_id=$(_cached_node_id "$dep_gh_num" "$repo")
 			if [[ -z "$dep_node_id" ]]; then
@@ -597,13 +667,20 @@ _is_parent_tagged_task() {
 # Returns: "RELS:N" with count of relationships set
 _sync_subtask_hierarchy_for_task() {
 	local task_id="$1" todo_file="$2" repo="$3"
-	local rels_set=0
+	local rels_set=0 retryable_errors=0
+	local key="" value="" dep_task_id=""
 
 	# Method 1: Dot-notation (t1873.2 → parent t1873)
 	local dot_parent
 	dot_parent=$(detect_parent_task_id "$task_id")
 	if [[ -n "$dot_parent" ]]; then
-		_link_sub_issue_pair "$task_id" "$dot_parent" "$todo_file" "$repo" && rels_set=$((rels_set + 1))
+		if _relationship_deadline_expired; then
+			retryable_errors=$((retryable_errors + 1))
+		elif _link_sub_issue_pair "$task_id" "$dot_parent" "$todo_file" "$repo"; then
+			rels_set=$((rels_set + 1))
+		else
+			retryable_errors=$((retryable_errors + 1))
+		fi
 	fi
 
 	# Method 2: blocked-by a #parent-tagged task
@@ -621,20 +698,28 @@ _sync_subtask_hierarchy_for_task() {
 			local _saved_ifs="$IFS"
 			IFS=','
 			for dep_task_id in $blocked_by; do
+				if _relationship_deadline_expired; then
+					retryable_errors=$((retryable_errors + 1))
+					break
+				fi
 				dep_task_id="${dep_task_id// /}"
 				[[ -z "$dep_task_id" ]] && continue
 				# Skip if this is already the dot-notation parent (avoid duplicate)
 				[[ "$dep_task_id" == "$dot_parent" ]] && continue
 				# Only create sub-issue if the dependency is a parent-tagged task
 				if _is_parent_tagged_task "$dep_task_id" "$todo_file"; then
-					_link_sub_issue_pair "$task_id" "$dep_task_id" "$todo_file" "$repo" && rels_set=$((rels_set + 1))
+					if _link_sub_issue_pair "$task_id" "$dep_task_id" "$todo_file" "$repo"; then
+						rels_set=$((rels_set + 1))
+					else
+						retryable_errors=$((retryable_errors + 1))
+					fi
 				fi
 			done
 			IFS="$_saved_ifs"
 		fi
 	fi
 
-	echo "RELS:$rels_set"
+	echo "RELS:$rels_set RETRYABLE:$retryable_errors"
 	return 0
 }
 
@@ -646,8 +731,29 @@ _sync_subtask_hierarchy_for_task() {
 #   $3 - repo slug
 sync_relationships_for_task() {
 	local task_id="$1" todo_file="$2" repo="$3"
-	_sync_blocked_by_for_task "$task_id" "$todo_file" "$repo" >/dev/null 2>&1 || true
-	_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" >/dev/null 2>&1 || true
+	_init_relationship_sync_state || return 1
+	local AIDEVOPS_GH_DEADLINE_EPOCH=""
+	AIDEVOPS_GH_DEADLINE_EPOCH=$(_relationship_sync_deadline_epoch) || {
+		_cleanup_relationship_sync_state
+		return 1
+	}
+	local result="" retryable_total=0 count=""
+	result=$(_sync_blocked_by_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0 RETRYABLE:1")
+	count=$(echo "$result" | grep -oE 'RETRYABLE:[0-9]+' | head -1 | sed 's/RETRYABLE://' || echo "0")
+	retryable_total=$((retryable_total + count))
+	if ! _relationship_deadline_expired; then
+		result=$(_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0 RETRYABLE:1")
+		count=$(echo "$result" | grep -oE 'RETRYABLE:[0-9]+' | head -1 | sed 's/RETRYABLE://' || echo "0")
+		retryable_total=$((retryable_total + count))
+	else
+		retryable_total=$((retryable_total + 1))
+	fi
+	if [[ "$retryable_total" -gt 0 ]] || _relationship_deadline_expired; then
+		print_warning "$task_id: relationship sync pending; retry with: .agents/scripts/issue-sync-helper.sh relationships $task_id"
+		_cleanup_relationship_sync_state
+		return 1
+	fi
+	_cleanup_relationship_sync_state
 	return 0
 }
 
@@ -682,6 +788,12 @@ cmd_relationships() {
 		print_info "No tasks with relationships to sync"
 		return 0
 	}
+	_init_relationship_sync_state || return 1
+	local AIDEVOPS_GH_DEADLINE_EPOCH=""
+	AIDEVOPS_GH_DEADLINE_EPOCH=$(_relationship_sync_deadline_epoch) || {
+		_cleanup_relationship_sync_state
+		return 1
+	}
 
 	# Deduplicate (bash 3.2 compatible — no associative arrays)
 	local seen_list=""
@@ -697,8 +809,13 @@ cmd_relationships() {
 	local total="${#unique_tasks[@]}"
 	print_info "Syncing relationships for $total task(s) in $repo"
 
-	local blocked_set=0 sub_set=0 processed=0 retryable_total=0
+	local blocked_set=0 sub_set=0 processed=0 retryable_total=0 deadline_exhausted=false
 	for task_id in "${unique_tasks[@]}"; do
+		if _relationship_deadline_expired; then
+			deadline_exhausted=true
+			retryable_total=$((retryable_total + 1))
+			break
+		fi
 		processed=$((processed + 1))
 		# Progress indicator every 25 tasks
 		if [[ $((processed % 25)) -eq 0 || $processed -eq $total ]]; then
@@ -716,14 +833,22 @@ cmd_relationships() {
 		retryable_total=$((retryable_total + n))
 
 		# Sub-issue hierarchy
-		result=$(_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0")
-		n=$(echo "$result" | grep -oE 'RELS:[0-9]+' | head -1 | sed 's/RELS://' || echo "0")
-		sub_set=$((sub_set + n))
+		if _relationship_deadline_expired; then
+			deadline_exhausted=true
+			retryable_total=$((retryable_total + 1))
+		else
+			result=$(_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0 RETRYABLE:1")
+			n=$(echo "$result" | grep -oE 'RELS:[0-9]+' | head -1 | sed 's/RELS://' || echo "0")
+			sub_set=$((sub_set + n))
+			n=$(echo "$result" | grep -oE 'RETRYABLE:[0-9]+' | head -1 | sed 's/RETRYABLE://' || echo "0")
+			retryable_total=$((retryable_total + n))
+		fi
 	done
 	[[ $total -gt 25 ]] && printf "\n" >&2
 
-	printf "\n=== Relationships Sync ===\nBlocked-by: %d | Sub-issues: %d | Tasks processed: %d | Retryable: %d\n" \
-		"$blocked_set" "$sub_set" "${#unique_tasks[@]}" "$retryable_total"
+	printf "\n=== Relationships Sync ===\nBlocked-by: %d | Sub-issues: %d | Tasks processed: %d/%d | Retryable: %d | Deadline exhausted: %s\n" \
+		"$blocked_set" "$sub_set" "$processed" "${#unique_tasks[@]}" "$retryable_total" "$deadline_exhausted"
+	_cleanup_relationship_sync_state
 	[[ "$retryable_total" -eq 0 ]] || return 1
 	return 0
 }

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -99,8 +99,8 @@ _relationship_edge_should_attempt() {
 	local blocked_num="$1"
 	local blocker_num="$2"
 	local edge_key="${blocked_num}|${blocker_num}"
-	[[ -n "$_RELATIONSHIP_EDGE_SEEN_FILE" ]] || return 1
-	if grep -Fxq -- "$edge_key" "$_RELATIONSHIP_EDGE_SEEN_FILE" 2>/dev/null; then
+	[[ -f "${_RELATIONSHIP_EDGE_SEEN_FILE:-}" ]] || return 1
+	if grep -Fxq -- "$edge_key" "$_RELATIONSHIP_EDGE_SEEN_FILE"; then
 		return 1
 	fi
 	printf '%s\n' "$edge_key" >>"$_RELATIONSHIP_EDGE_SEEN_FILE"
@@ -732,7 +732,10 @@ _sync_subtask_hierarchy_for_task() {
 #   $3 - repo slug
 sync_relationships_for_task() {
 	local task_id="$1" todo_file="$2" repo="$3"
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
 	_init_relationship_sync_state || return 1
+	push_cleanup "rm -f '${_RELATIONSHIP_EDGE_SEEN_FILE}'"
 	local AIDEVOPS_GH_DEADLINE_EPOCH=""
 	AIDEVOPS_GH_DEADLINE_EPOCH=$(_relationship_sync_deadline_epoch) || {
 		_cleanup_relationship_sync_state
@@ -789,7 +792,10 @@ cmd_relationships() {
 		print_info "No tasks with relationships to sync"
 		return 0
 	}
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
 	_init_relationship_sync_state || return 1
+	push_cleanup "rm -f '${_RELATIONSHIP_EDGE_SEEN_FILE}'"
 	local AIDEVOPS_GH_DEADLINE_EPOCH=""
 	AIDEVOPS_GH_DEADLINE_EPOCH=$(_relationship_sync_deadline_epoch) || {
 		_cleanup_relationship_sync_state

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -56,6 +56,7 @@ _NODE_ID_RATE_LIMITED_FILE=""
 # helpers are commonly called through command substitutions; file writes
 # survive those subshell boundaries while Bash variables do not.
 _RELATIONSHIP_EDGE_SEEN_FILE=""
+_RELATIONSHIP_RETRY_RESULT="RELS:0 RETRYABLE:1"
 
 _init_relationship_sync_state() {
 	_init_node_id_cache
@@ -738,11 +739,11 @@ sync_relationships_for_task() {
 		return 1
 	}
 	local result="" retryable_total=0 count=""
-	result=$(_sync_blocked_by_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0 RETRYABLE:1")
+	result=$(_sync_blocked_by_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "$_RELATIONSHIP_RETRY_RESULT")
 	count=$(echo "$result" | grep -oE 'RETRYABLE:[0-9]+' | head -1 | sed 's/RETRYABLE://' || echo "0")
 	retryable_total=$((retryable_total + count))
 	if ! _relationship_deadline_expired; then
-		result=$(_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0 RETRYABLE:1")
+		result=$(_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "$_RELATIONSHIP_RETRY_RESULT")
 		count=$(echo "$result" | grep -oE 'RETRYABLE:[0-9]+' | head -1 | sed 's/RETRYABLE://' || echo "0")
 		retryable_total=$((retryable_total + count))
 	else
@@ -837,7 +838,7 @@ cmd_relationships() {
 			deadline_exhausted=true
 			retryable_total=$((retryable_total + 1))
 		else
-			result=$(_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0 RETRYABLE:1")
+			result=$(_sync_subtask_hierarchy_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "$_RELATIONSHIP_RETRY_RESULT")
 			n=$(echo "$result" | grep -oE 'RELS:[0-9]+' | head -1 | sed 's/RELS://' || echo "0")
 			sub_set=$((sub_set + n))
 			n=$(echo "$result" | grep -oE 'RETRYABLE:[0-9]+' | head -1 | sed 's/RETRYABLE://' || echo "0")
@@ -1028,8 +1029,9 @@ _detect_parent_from_gh_state() {
 # Echoes one of: "LINKED <child>:<parent>", "SKIPPED <child>", "DRY <child>:<parent>"
 _backfill_one_issue() {
 	local num="$1" repo="$2" prefetched_title="${3:-}" prefetched_body="${4:-}"
+	local backfill_skipped="SKIPPED"
 	[[ -z "$num" || -z "$repo" ]] && {
-		echo "SKIPPED $num"
+		echo "$backfill_skipped $num"
 		return 0
 	}
 
@@ -1046,14 +1048,14 @@ _backfill_one_issue() {
 		body=$(printf '%s' "$meta" | jq -r '.body // ""' 2>/dev/null)
 	fi
 	if [[ -z "$title" ]]; then
-		echo "SKIPPED $num"
+		echo "$backfill_skipped $num"
 		return 0
 	fi
 
 	local parent_num
 	parent_num=$(_detect_parent_from_gh_state "$title" "$body" "$repo")
 	if [[ -z "$parent_num" || "$parent_num" == "$num" ]]; then
-		echo "SKIPPED $num"
+		echo "$backfill_skipped $num"
 		return 0
 	fi
 
@@ -1073,7 +1075,7 @@ _backfill_one_issue() {
 		if [[ "$_rate_limited" == "1" ]]; then
 			echo "RATE_LIMITED $num"
 		else
-			echo "SKIPPED $num"
+			echo "$backfill_skipped $num"
 		fi
 		return 0
 	fi
@@ -1083,7 +1085,7 @@ _backfill_one_issue() {
 		echo "LINKED $num:$parent_num"
 		return 0
 	fi
-	echo "SKIPPED $num"
+	echo "$backfill_skipped $num"
 	return 0
 }
 

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -57,6 +57,8 @@ _NODE_ID_RATE_LIMITED_FILE=""
 # survive those subshell boundaries while Bash variables do not.
 _RELATIONSHIP_EDGE_SEEN_FILE=""
 _RELATIONSHIP_RETRY_RESULT="RELS:0 RETRYABLE:1"
+_RELATIONSHIP_SYNC_SCOPE_ACTIVE=0
+_RELATIONSHIP_SYNC_DEADLINE_EPOCH=
 
 _init_relationship_sync_state() {
 	_init_node_id_cache
@@ -73,6 +75,44 @@ _cleanup_relationship_sync_state() {
 		_RELATIONSHIP_EDGE_SEEN_FILE=""
 	fi
 	return 0
+}
+
+_begin_relationship_sync_scope() {
+	[[ "$_RELATIONSHIP_SYNC_SCOPE_ACTIVE" -eq 1 ]] && return 0
+	_init_relationship_sync_state || return 1
+	_RELATIONSHIP_SYNC_DEADLINE_EPOCH=
+	_RELATIONSHIP_SYNC_SCOPE_ACTIVE=1
+	return 0
+}
+
+_ensure_relationship_sync_deadline() {
+	if [[ ! "$_RELATIONSHIP_SYNC_DEADLINE_EPOCH" =~ ^[1-9][0-9]*$ ]]; then
+		_RELATIONSHIP_SYNC_DEADLINE_EPOCH=$(_relationship_sync_deadline_epoch) || return 1
+	fi
+	return 0
+}
+
+_end_relationship_sync_scope() {
+	_cleanup_relationship_sync_state
+	_RELATIONSHIP_SYNC_SCOPE_ACTIVE=0
+	_RELATIONSHIP_SYNC_DEADLINE_EPOCH=
+	return 0
+}
+
+_register_relationship_sync_cleanup() {
+	push_cleanup "rm -f '${_RELATIONSHIP_EDGE_SEEN_FILE}'"
+	return 0
+}
+
+run_relationship_scoped_command() {
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	_begin_relationship_sync_scope || return 1
+	_register_relationship_sync_cleanup
+	local rc=0
+	"$@" || rc=$?
+	_end_relationship_sync_scope
+	return "$rc"
 }
 
 _relationship_sync_deadline_epoch() {
@@ -732,15 +772,19 @@ _sync_subtask_hierarchy_for_task() {
 #   $3 - repo slug
 sync_relationships_for_task() {
 	local task_id="$1" todo_file="$2" repo="$3"
-	_save_cleanup_scope
-	trap '_run_cleanups' RETURN
-	_init_relationship_sync_state || return 1
-	push_cleanup "rm -f '${_RELATIONSHIP_EDGE_SEEN_FILE}'"
-	local AIDEVOPS_GH_DEADLINE_EPOCH=""
-	AIDEVOPS_GH_DEADLINE_EPOCH=$(_relationship_sync_deadline_epoch) || {
-		_cleanup_relationship_sync_state
+	local owns_scope=0
+	if [[ "$_RELATIONSHIP_SYNC_SCOPE_ACTIVE" -ne 1 ]]; then
+		_save_cleanup_scope
+		trap '_run_cleanups' RETURN
+		_begin_relationship_sync_scope || return 1
+		_register_relationship_sync_cleanup
+		owns_scope=1
+	fi
+	_ensure_relationship_sync_deadline || {
+		[[ "$owns_scope" -eq 0 ]] || _end_relationship_sync_scope
 		return 1
 	}
+	local AIDEVOPS_GH_DEADLINE_EPOCH="$_RELATIONSHIP_SYNC_DEADLINE_EPOCH"
 	local result="" retryable_total=0 count=""
 	result=$(_sync_blocked_by_for_task "$task_id" "$todo_file" "$repo" 2>/dev/null || echo "$_RELATIONSHIP_RETRY_RESULT")
 	count=$(echo "$result" | grep -oE 'RETRYABLE:[0-9]+' | head -1 | sed 's/RETRYABLE://' || echo "0")
@@ -754,10 +798,10 @@ sync_relationships_for_task() {
 	fi
 	if [[ "$retryable_total" -gt 0 ]] || _relationship_deadline_expired; then
 		print_warning "$task_id: relationship sync pending; retry with: .agents/scripts/issue-sync-helper.sh relationships $task_id"
-		_cleanup_relationship_sync_state
+		[[ "$owns_scope" -eq 0 ]] || _end_relationship_sync_scope
 		return 1
 	fi
-	_cleanup_relationship_sync_state
+	[[ "$owns_scope" -eq 0 ]] || _end_relationship_sync_scope
 	return 0
 }
 
@@ -792,15 +836,19 @@ cmd_relationships() {
 		print_info "No tasks with relationships to sync"
 		return 0
 	}
-	_save_cleanup_scope
-	trap '_run_cleanups' RETURN
-	_init_relationship_sync_state || return 1
-	push_cleanup "rm -f '${_RELATIONSHIP_EDGE_SEEN_FILE}'"
-	local AIDEVOPS_GH_DEADLINE_EPOCH=""
-	AIDEVOPS_GH_DEADLINE_EPOCH=$(_relationship_sync_deadline_epoch) || {
-		_cleanup_relationship_sync_state
+	local owns_scope=0
+	if [[ "$_RELATIONSHIP_SYNC_SCOPE_ACTIVE" -ne 1 ]]; then
+		_save_cleanup_scope
+		trap '_run_cleanups' RETURN
+		_begin_relationship_sync_scope || return 1
+		_register_relationship_sync_cleanup
+		owns_scope=1
+	fi
+	_ensure_relationship_sync_deadline || {
+		[[ "$owns_scope" -eq 0 ]] || _end_relationship_sync_scope
 		return 1
 	}
+	local AIDEVOPS_GH_DEADLINE_EPOCH="$_RELATIONSHIP_SYNC_DEADLINE_EPOCH"
 
 	# Deduplicate (bash 3.2 compatible — no associative arrays)
 	local seen_list=""
@@ -855,7 +903,7 @@ cmd_relationships() {
 
 	printf "\n=== Relationships Sync ===\nBlocked-by: %d | Sub-issues: %d | Tasks processed: %d/%d | Retryable: %d | Deadline exhausted: %s\n" \
 		"$blocked_set" "$sub_set" "$processed" "${#unique_tasks[@]}" "$retryable_total" "$deadline_exhausted"
-	_cleanup_relationship_sync_state
+	[[ "$owns_scope" -eq 0 ]] || _end_relationship_sync_scope
 	[[ "$retryable_total" -eq 0 ]] || return 1
 	return 0
 }

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -324,14 +324,16 @@ _gh_cooldown_context_from_args() {
 }
 
 # _gh_with_timeout — invoke a command (typically `gh ...`) with a wall-clock
-# cap classified by operation type. Falls through to direct invocation when
-# coreutils `timeout` is not on PATH (rare; macOS users have it via Homebrew
-# coreutils, Linux distros ship it by default).
+# cap classified by operation type. Uses timeout_sec when shared constants are
+# loaded, covering GNU timeout, macOS gtimeout, and the bare-macOS fallback.
 #
 # Usage:
 #   _gh_with_timeout read  gh issue list --repo owner/repo --state open
 #   _gh_with_timeout write gh issue edit 123 --repo owner/repo --add-label foo
 #   _gh_with_timeout read  gh api /repos/owner/repo/issues
+#
+# Set AIDEVOPS_GH_DEADLINE_EPOCH to an absolute Unix timestamp to cap each
+# invocation to the remaining aggregate operation budget.
 #
 # Exit codes:
 #   124 = timeout fired (per coreutils convention)
@@ -349,6 +351,14 @@ _gh_with_timeout() {
 	write) secs="${AIDEVOPS_GH_WRITE_TIMEOUT:-45}" ;;
 	*) secs=30 ;;
 	esac
+	local deadline_epoch="${AIDEVOPS_GH_DEADLINE_EPOCH:-}"
+	local now_epoch="" remaining_secs=""
+	if [[ "$deadline_epoch" =~ ^[0-9]+$ ]]; then
+		now_epoch=$(date +%s 2>/dev/null) || return 124
+		remaining_secs=$((deadline_epoch - now_epoch))
+		[[ "$remaining_secs" -gt 0 ]] || return 124
+		[[ "$remaining_secs" -ge "$secs" ]] || secs="$remaining_secs"
+	fi
 	local cmd="${1:-}"
 	local err_file=""
 	local out_file=""
@@ -386,12 +396,28 @@ $(cat "$err_file" 2>/dev/null || true)"
 			err_file=""
 		}
 	fi
-	if command -v timeout >/dev/null 2>&1; then
+	if command -v timeout_sec >/dev/null 2>&1; then
+		if [[ -n "$err_file" && -n "$out_file" ]]; then
+			timeout_sec "$secs" "$@" >"$out_file" 2>"$err_file"
+			rc=$?
+		else
+			timeout_sec "$secs" "$@"
+			rc=$?
+		fi
+	elif command -v timeout >/dev/null 2>&1; then
 		if [[ -n "$err_file" && -n "$out_file" ]]; then
 			timeout "$secs" "$@" >"$out_file" 2>"$err_file"
 			rc=$?
 		else
 			timeout "$secs" "$@"
+			rc=$?
+		fi
+	elif command -v gtimeout >/dev/null 2>&1; then
+		if [[ -n "$err_file" && -n "$out_file" ]]; then
+			gtimeout "$secs" "$@" >"$out_file" 2>"$err_file"
+			rc=$?
+		else
+			gtimeout "$secs" "$@"
 			rc=$?
 		fi
 	else

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -357,6 +357,31 @@ _gh_run_bounded_command() {
 	return $?
 }
 
+_gh_run_bounded_function() {
+	local secs="$1"
+	shift
+	local monitor_was_enabled=false
+	[[ $- == *m* ]] && monitor_was_enabled=true
+	set -m
+	"$@" &
+	local cmd_pid=$!
+	$monitor_was_enabled && set -m || set +m
+	local half_secs_remaining=$((secs * 2))
+	while kill -0 "$cmd_pid" 2>/dev/null; do
+		if ((half_secs_remaining <= 0)); then
+			kill -TERM -- "-${cmd_pid}" 2>/dev/null || true
+			sleep 0.2
+			kill -KILL -- "-${cmd_pid}" 2>/dev/null || true
+			wait "$cmd_pid" 2>/dev/null || true
+			return 124
+		fi
+		sleep 0.5
+		((half_secs_remaining--)) || true
+	done
+	wait "$cmd_pid" 2>/dev/null
+	return $?
+}
+
 _gh_with_timeout() {
 	local op_class="${1:-read}"
 	shift
@@ -395,7 +420,11 @@ _gh_with_timeout() {
 			rm -f "$err_file"
 			return $rc
 		}
-		"$@" >"$out_file" 2>"$err_file"
+		if [[ "$deadline_epoch" =~ ^[0-9]+$ ]]; then
+			_gh_run_bounded_function "$secs" "$@" >"$out_file" 2>"$err_file"
+		else
+			"$@" >"$out_file" 2>"$err_file"
+		fi
 		rc=$?
 		cat "$out_file" 2>/dev/null || true
 		cat "$err_file" >&2 2>/dev/null || true

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -338,6 +338,25 @@ _gh_cooldown_context_from_args() {
 # Exit codes:
 #   124 = timeout fired (per coreutils convention)
 #   *   = passthrough from the wrapped command
+_gh_run_bounded_command() {
+	local secs="$1"
+	shift
+	if command -v timeout_sec >/dev/null 2>&1; then
+		timeout_sec "$secs" "$@"
+		return $?
+	fi
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$secs" "$@"
+		return $?
+	fi
+	if command -v gtimeout >/dev/null 2>&1; then
+		gtimeout "$secs" "$@"
+		return $?
+	fi
+	"$@"
+	return $?
+}
+
 _gh_with_timeout() {
 	local op_class="${1:-read}"
 	shift
@@ -396,38 +415,12 @@ $(cat "$err_file" 2>/dev/null || true)"
 			err_file=""
 		}
 	fi
-	if command -v timeout_sec >/dev/null 2>&1; then
-		if [[ -n "$err_file" && -n "$out_file" ]]; then
-			timeout_sec "$secs" "$@" >"$out_file" 2>"$err_file"
-			rc=$?
-		else
-			timeout_sec "$secs" "$@"
-			rc=$?
-		fi
-	elif command -v timeout >/dev/null 2>&1; then
-		if [[ -n "$err_file" && -n "$out_file" ]]; then
-			timeout "$secs" "$@" >"$out_file" 2>"$err_file"
-			rc=$?
-		else
-			timeout "$secs" "$@"
-			rc=$?
-		fi
-	elif command -v gtimeout >/dev/null 2>&1; then
-		if [[ -n "$err_file" && -n "$out_file" ]]; then
-			gtimeout "$secs" "$@" >"$out_file" 2>"$err_file"
-			rc=$?
-		else
-			gtimeout "$secs" "$@"
-			rc=$?
-		fi
+	if [[ -n "$err_file" && -n "$out_file" ]]; then
+		_gh_run_bounded_command "$secs" "$@" >"$out_file" 2>"$err_file"
+		rc=$?
 	else
-		if [[ -n "$err_file" && -n "$out_file" ]]; then
-			"$@" >"$out_file" 2>"$err_file"
-			rc=$?
-		else
-			"$@"
-			rc=$?
-		fi
+		_gh_run_bounded_command "$secs" "$@"
+		rc=$?
 	fi
 	if [[ -n "$err_file" && -n "$out_file" ]]; then
 		cat "$out_file" 2>/dev/null || true

--- a/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
@@ -164,6 +164,7 @@ fi
 {
 	extract_function _gh_with_timeout "$WRAPPERS_FILE"
 	printf '\n'
+	printf '%s\n' '_gh_cooldown_context_from_args(){ return 0; }'
 	# shellcheck disable=SC2016 # Intentional: emit zsh function definitions literally.
 	printf '%s\n' 'fake_gh(){ echo "fake-gh-called:$*"; return 0; }'
 	# shellcheck disable=SC2016 # If function detection regresses, this captures the timeout route.

--- a/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
+++ b/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${TEST_DIR}/.."
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# shellcheck source=../issue-sync-helper.sh
+source "${SCRIPTS_DIR}/issue-sync-helper.sh"
+
+pass() {
+	local message="$1"
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+deadline_probe() {
+	printf 'called\n' >>"${TMP_DIR}/deadline-probe.log"
+	return 0
+}
+
+: >"${TMP_DIR}/deadline-probe.log"
+AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) - 1 ))
+deadline_rc=0
+_gh_with_timeout read deadline_probe || deadline_rc=$?
+[[ "$deadline_rc" -eq 124 ]] || fail "expired aggregate deadline did not return 124"
+[[ ! -s "${TMP_DIR}/deadline-probe.log" ]] || fail "expired aggregate deadline invoked the child command"
+pass "expired aggregate deadline stops before the next GitHub call"
+
+cat >"${TMP_DIR}/slow-command" <<'SLOW_EOF'
+#!/usr/bin/env bash
+sleep 5
+printf 'late\n'
+SLOW_EOF
+chmod +x "${TMP_DIR}/slow-command"
+AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) + 1 ))
+started_at=$(date +%s)
+slow_rc=0
+_gh_with_timeout write "${TMP_DIR}/slow-command" >/dev/null 2>&1 || slow_rc=$?
+elapsed=$(( $(date +%s) - started_at ))
+[[ "$slow_rc" -eq 124 ]] || fail "remaining aggregate budget did not cap a slow child"
+[[ "$elapsed" -le 3 ]] || fail "slow child exceeded aggregate deadline allowance (${elapsed}s)"
+pass "remaining aggregate budget caps an individual slow call"
+
+unset AIDEVOPS_GH_DEADLINE_EPOCH
+_init_relationship_sync_state || fail "relationship invocation state did not initialize"
+AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) + 30 ))
+DRY_RUN=true
+
+resolve_task_gh_number() {
+	local task_id="$1"
+	local todo_file="$2"
+	local repo="$3"
+	: "$todo_file" "$repo"
+	case "$task_id" in
+	t1) printf '101\n' ;;
+	t2) printf '102\n' ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+_cached_node_id() {
+	local issue_num="$1"
+	local repo="$2"
+	: "$repo"
+	printf 'NODE_%s\n' "$issue_num"
+	return 0
+}
+
+_dependency_cycle_should_skip_edge() {
+	local blocked_task="$1"
+	local blocker_task="$2"
+	local blocked_num="$3"
+	local blocker_num="$4"
+	local todo_file="$5"
+	: "$blocked_task" "$blocker_task" "$blocked_num" "$blocker_num" "$todo_file"
+	return 1
+}
+
+first_result=$(_sync_declared_blocked_by_edges t1 "${TMP_DIR}/TODO.md" example/repo 101 NODE_101 t2)
+reciprocal_result=$(_sync_declared_blocks_edges t2 "${TMP_DIR}/TODO.md" example/repo 102 NODE_102 t1)
+[[ "$first_result" == "1:0" ]] || fail "first normalized edge was not attempted once: $first_result"
+[[ "$reciprocal_result" == "0:0" ]] || fail "reciprocal declaration replayed normalized edge: $reciprocal_result"
+[[ "$(wc -l <"$_RELATIONSHIP_EDGE_SEEN_FILE" | tr -d '[:space:]')" -eq 1 ]] || fail "edge set did not retain exactly one normalized edge"
+pass "reciprocal declarations attempt one normalized native edge"
+
+AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) - 1 ))
+expired_result=$(_sync_declared_blocked_by_edges t1 "${TMP_DIR}/TODO.md" example/repo 101 NODE_101 t2,t3,t4)
+[[ "$expired_result" == "0:1" ]] || fail "expired edge loop did not stop with retryable state: $expired_result"
+pass "edge loop stops with retryable state after aggregate exhaustion"
+
+MAPPING_LOG="${TMP_DIR}/mapping.log"
+: >"$MAPPING_LOG"
+_PUSH_CREATED_NUM=123
+add_gh_ref_to_todo() {
+	local task_id="$1"
+	local issue_num="$2"
+	local todo_file="$3"
+	printf 'mapped:%s:%s:%s\n' "$task_id" "$issue_num" "$todo_file" >>"$MAPPING_LOG"
+	return 0
+}
+require_task_issue_mapping() {
+	local task_id="$1"
+	local todo_file="$2"
+	local repo="$3"
+	local issue_num="$4"
+	: "$task_id" "$todo_file" "$repo" "$issue_num"
+	return 0
+}
+sync_relationships_for_task() {
+	local task_id="$1"
+	local todo_file="$2"
+	local repo="$3"
+	: "$task_id" "$todo_file" "$repo"
+	return 1
+}
+finalize_output=$(_push_finalize_task_creation t1 example/repo "${TMP_DIR}/TODO.md" "title" "" "bug" "body" 2>"${TMP_DIR}/finalize.err")
+[[ "$finalize_output" == *"CREATED RELATIONSHIPS_PENDING"* ]] || fail "post-create pending result was not actionable"
+grep -q '^mapped:t1:123:' "$MAPPING_LOG" || fail "durable mapping was not preserved before pending relationship result"
+grep -q 'durable mapping preserved' "${TMP_DIR}/finalize.err" || fail "pending result omitted durable-mapping diagnostic"
+pass "post-create relationship timeout preserves mapping and reports pending recovery"
+
+printf 'PASS: issue-sync relationship aggregate deadline regressions\n'

--- a/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
+++ b/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
@@ -52,6 +52,21 @@ elapsed=$(( $(date +%s) - started_at ))
 [[ "$elapsed" -le 3 ]] || fail "slow child exceeded aggregate deadline allowance (${elapsed}s)"
 pass "remaining aggregate budget caps an individual slow call"
 
+slow_function_probe() {
+	sleep 5
+	printf 'late\n'
+	return 0
+}
+
+AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) + 1 ))
+started_at=$(date +%s)
+slow_rc=0
+_gh_with_timeout write slow_function_probe >/dev/null 2>&1 || slow_rc=$?
+elapsed=$(( $(date +%s) - started_at ))
+[[ "$slow_rc" -eq 124 ]] || fail "remaining aggregate budget did not cap a slow shell function"
+[[ "$elapsed" -le 3 ]] || fail "slow shell function exceeded aggregate deadline allowance (${elapsed}s)"
+pass "remaining aggregate budget caps a slow shell function"
+
 unset AIDEVOPS_GH_DEADLINE_EPOCH
 _init_relationship_sync_state || fail "relationship invocation state did not initialize"
 AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) + 30 ))
@@ -99,6 +114,30 @@ AIDEVOPS_GH_DEADLINE_EPOCH=$(( $(date +%s) - 1 ))
 expired_result=$(_sync_declared_blocked_by_edges t1 "${TMP_DIR}/TODO.md" example/repo 101 NODE_101 t2,t3,t4)
 [[ "$expired_result" == "0:1" ]] || fail "expired edge loop did not stop with retryable state: $expired_result"
 pass "edge loop stops with retryable state after aggregate exhaustion"
+
+_sync_blocked_by_for_task() {
+	printf 'RELS:0 RETRYABLE:0\n'
+	return 0
+}
+_sync_subtask_hierarchy_for_task() {
+	printf 'RELS:0 RETRYABLE:0\n'
+	return 0
+}
+_cleanup_relationship_sync_state
+_RELATIONSHIP_SYNC_SCOPE_ACTIVE=0
+_begin_relationship_sync_scope || fail "command relationship scope did not initialize"
+_ensure_relationship_sync_deadline || fail "command relationship deadline did not initialize"
+scope_file="$_RELATIONSHIP_EDGE_SEEN_FILE"
+scope_deadline="$_RELATIONSHIP_SYNC_DEADLINE_EPOCH"
+_relationship_edge_should_attempt 201 202 || fail "command scope did not retain its first edge"
+sync_relationships_for_task t1 "${TMP_DIR}/TODO.md" example/repo || fail "nested task relationship sync failed"
+[[ "$_RELATIONSHIP_EDGE_SEEN_FILE" == "$scope_file" ]] || fail "nested task sync replaced the command edge set"
+[[ "$_RELATIONSHIP_SYNC_DEADLINE_EPOCH" == "$scope_deadline" ]] || fail "nested task sync reset the command deadline"
+if _relationship_edge_should_attempt 201 202; then
+	fail "nested task sync cleared command-level edge deduplication"
+fi
+_end_relationship_sync_scope
+pass "nested task sync reuses command deadline and edge set"
 
 MAPPING_LOG="${TMP_DIR}/mapping.log"
 : >"$MAPPING_LOG"


### PR DESCRIPTION
## Summary

Bound relationship synchronization to one lazily started 90-second command budget, deduplicated reciprocal normalized edges across the command, bounded external and function-backed GitHub calls by remaining time, and preserved durable push/enrich results with actionable pending diagnostics.

## Files Changed

.agents/scripts/issue-sync-helper.sh, .agents/scripts/issue-sync-relationships.sh, .agents/scripts/shared-gh-wrappers.sh, .agents/scripts/tests/test-gh-wrapper-zsh-compat.sh, .agents/scripts/tests/test-issue-sync-relationship-deadline.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Runtime-verified command-scoped deadline and reciprocal-edge deduplication; slow external-command and shell-function timeout fixtures; durable-mapping, push-failure, dependency, stale-process, zsh compatibility, ShellCheck, and linters-local.sh checks.

Resolves #27849


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.124 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 40m and 254,151 tokens on this with the user in an interactive session.
