### PR TITLE
t18132: fix: prevent cross-install upstream-watch duplicates

### DIFF
--- a/.agents/scripts/tests/test-upstream-watch-issue-gate.sh
+++ b/.agents/scripts/tests/test-upstream-watch-issue-gate.sh
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression coverage for GH#22495:
-# - non-maintainer upstream-watch contexts write local reports instead of public
-#   issues in marcusquinn/aidevops
-# - maintainer-authorized contexts can still create issues
-# - large scan batches coalesce into a single tracker issue
+# Regression coverage for GH#22495 and GH#27821: owner-only publication,
+# exact-value repository-history deduplication, and post-filter batching.
 
 set -euo pipefail
 
@@ -50,10 +47,12 @@ export YELLOW="" BLUE="" GREEN="" NC=""
 
 GH_CREATE_CALLS="${TMP}/gh_create_calls.log"
 GH_EDIT_CALLS="${TMP}/gh_edit_calls.log"
+GH_CLOSE_CALLS="${TMP}/gh_close_calls.log"
 GH_ISSUE_LIST_CALLS="${TMP}/gh_issue_list_calls.log"
 GH_WARNINGS="${TMP}/warnings.log"
 : >"$GH_CREATE_CALLS"
 : >"$GH_EDIT_CALLS"
+: >"$GH_CLOSE_CALLS"
 : >"$GH_ISSUE_LIST_CALLS"
 : >"$GH_WARNINGS"
 
@@ -61,23 +60,31 @@ _log_warn() { printf '%s\n' "$*" >>"$GH_WARNINGS"; return 0; }
 _log_info() { return 0; }
 
 gh() {
-	if [[ "$1" == "auth" && "${2:-}" == "status" ]]; then
+	local command_name="${1:-}"
+	local subcommand="${2:-}"
+	if [[ "$command_name" == "auth" && "$subcommand" == "status" ]]; then
 		return 0
 	fi
-	if [[ "$1" == "api" && "${2:-}" == "user" ]]; then
-		printf 'test-login\n'
+	if [[ "$command_name" == "api" && "$subcommand" == "user" ]]; then
+		printf '%s\n' "${GH_LOGIN:-test-login}"
 		return 0
 	fi
-	if [[ "$1" == "api" && "${2:-}" == "-i" && "${3:-}" == */collaborators/*/permission ]]; then
+	if [[ "$command_name" == "api" && "$subcommand" == "-i" && "${3:-}" == */collaborators/*/permission ]]; then
 		printf 'HTTP/2.0 200 OK\n\n{"permission":"%s"}\n' "${GH_PERMISSION:-read}"
 		return 0
 	fi
-	if [[ "$1" == "api" && ( "${2:-}" == repos/*/collaborators/*/permission || "${2:-}" == /repos/*/collaborators/*/permission ) ]]; then
+	if [[ "$command_name" == "api" && ( "$subcommand" == repos/*/collaborators/*/permission || "$subcommand" == /repos/*/collaborators/*/permission ) ]]; then
 		printf '%s\n' "${GH_PERMISSION:-read}"
 		return 0
 	fi
-	if [[ "$1" == "issue" && "${2:-}" == "list" ]]; then
+	if [[ "$command_name" == "issue" && "$subcommand" == "list" ]]; then
 		printf '%s\n' "$*" >>"$GH_ISSUE_LIST_CALLS"
+		if [[ " $* " == *" --state all "* ]]; then
+			[[ "${GH_HISTORY_FAIL:-0}" == "1" ]] && return 1
+			printf '%s\n' "${GH_HISTORY_JSON:-[]}"
+		else
+			printf '%s\n' "${GH_OPEN_NUMBER:-}"
+		fi
 		return 0
 	fi
 	return 0
@@ -94,32 +101,82 @@ gh_issue_edit_safe() {
 	return 0
 }
 
-export -f _log_warn _log_info gh gh_create_issue gh_issue_edit_safe
+gh_issue_close_safe() {
+	printf '%s\n' "$*" >>"$GH_CLOSE_CALLS"
+	return 0
+}
+
+export -f _log_warn _log_info gh gh_create_issue gh_issue_edit_safe gh_issue_close_safe
 
 # shellcheck source=../upstream-watch-helper-issues.sh
 source "${SCRIPTS_DIR}/upstream-watch-helper-issues.sh"
 
 entry_json='{"slug":"owner/repo","relevance":"test relevance","affects":[".agents/example.md"]}'
 
-# Test 1: non-maintainer individual update writes local report and creates no issue.
-export GH_PERMISSION="read"
+# Test 1: a write-capable non-owner still writes locally by default.
+export GH_LOGIN="collaborator"
+export GH_PERMISSION="write"
+export GH_HISTORY_JSON='[]'
+export GH_HISTORY_FAIL=0
 : >"$GH_CREATE_CALLS"
 _file_upstream_update_issue "owner/repo" "release" "v1" "v2" "$entry_json" >/dev/null
 create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
 report_count=$(find "${HOME}/.aidevops/reports/upstream-watch" -type f | wc -l | tr -d '[:space:]')
 [[ "$create_count" == "0" && "$report_count" == "1" ]] && ok=1 || ok=0
-check "$ok" "non-maintainer writes local report instead of public issue" "create_count=${create_count} report_count=${report_count}"
+check "$ok" "write collaborator writes local report instead of public issue" "create_count=${create_count} report_count=${report_count}"
 
-# Test 2: maintainer-authorized individual update can create a public issue.
-export GH_PERMISSION="write"
+# Test 2: repository owner can create a genuinely new issue.
+export GH_LOGIN="marcusquinn"
 : >"$GH_CREATE_CALLS"
 _file_upstream_update_issue "owner/repo" "release" "v2" "v3" "$entry_json" >/dev/null
 create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
 [[ "$create_count" == "1" ]] && ok=1 || ok=0
-check "$ok" "authorized context creates upstream-watch issue" "create_count=${create_count}"
+check "$ok" "repository owner creates upstream-watch issue" "create_count=${create_count}"
 
-# Test 3: five queued updates coalesce into one batch issue.
-export GH_PERMISSION="write"
+# Test 3: explicit designated-publisher override authorizes a non-owner.
+export GH_LOGIN="designated-publisher"
+export AIDEVOPS_UPSTREAM_WATCH_ALLOW_PUBLIC_ISSUES=1
+: >"$GH_CREATE_CALLS"
+_file_upstream_update_issue "owner/repo" "release" "v3" "v4" "$entry_json" >/dev/null
+unset AIDEVOPS_UPSTREAM_WATCH_ALLOW_PUBLIC_ISSUES
+create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
+[[ "$create_count" == "1" ]] && ok=1 || ok=0
+check "$ok" "designated publisher override creates upstream-watch issue" "create_count=${create_count}"
+
+# Test 4: exact legacy title in open/closed history suppresses recreation.
+export GH_LOGIN="marcusquinn"
+export GH_HISTORY_JSON='[{"number":42,"title":"upstream: owner/repo release -> v5 (review adoption)","body":"legacy issue"}]'
+: >"$GH_CREATE_CALLS"
+_file_upstream_update_issue "owner/repo" "release" "v4" "v5" "$entry_json" >/dev/null
+create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
+[[ "$create_count" == "0" ]] && ok=1 || ok=0
+check "$ok" "exact legacy history title suppresses recreation" "create_count=${create_count}"
+
+# Test 5: a different full value sharing the same displayed prefix still publishes.
+handled_value="123456789012-old"
+changed_value="123456789012-new"
+handled_key=$(_upstream_watch_update_key "owner/repo" "commit" "$handled_value")
+export GH_HISTORY_JSON="[{\"number\":43,\"title\":\"old tracker\",\"body\":\"<!-- upstream-watch:update-key=${handled_key} -->\"}]"
+: >"$GH_CREATE_CALLS"
+_file_upstream_update_issue "owner/repo" "commit" "previous" "$changed_value" "$entry_json" >/dev/null
+create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
+[[ "$create_count" == "1" ]] && ok=1 || ok=0
+check "$ok" "changed full value with same title prefix still publishes" "create_count=${create_count}"
+
+# Test 6: history API failure fails closed into a local report.
+export GH_HISTORY_FAIL=1
+export GH_HISTORY_JSON='[]'
+: >"$GH_CREATE_CALLS"
+before_reports=$(find "${HOME}/.aidevops/reports/upstream-watch" -type f | wc -l | tr -d '[:space:]')
+_file_upstream_update_issue "owner/repo" "release" "v5" "v6" "$entry_json" >/dev/null
+after_reports=$(find "${HOME}/.aidevops/reports/upstream-watch" -type f | wc -l | tr -d '[:space:]')
+create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
+[[ "$create_count" == "0" && "$after_reports" -gt "$before_reports" ]] && ok=1 || ok=0
+check "$ok" "history lookup failure writes local report" "create_count=${create_count} reports=${before_reports}->${after_reports}"
+export GH_HISTORY_FAIL=0
+
+# Test 7: five genuinely new queued updates coalesce into one batch issue.
+export GH_HISTORY_JSON='[]'
 : >"$GH_CREATE_CALLS"
 queue_file="${TMP}/queue.ndjson"
 : >"$queue_file"
@@ -135,36 +192,63 @@ if [[ "$create_count" == "1" ]] && grep -q 'upstream: batch review adoption' "$G
 else
 	ok=0
 fi
-check "$ok" "five queued updates coalesce into one batch issue" "create_count=${create_count}"
+check "$ok" "five new queued updates coalesce into one batch issue" "create_count=${create_count}"
 
-# Test 4: unauthorized batch writes another local report and creates no issue.
-export GH_PERMISSION="read"
+# Test 8: handled values are removed before threshold calculation.
+export GH_HISTORY_JSON='[
+ {"number":51,"title":"upstream: owner/filtered-1 commit -> new1 (review adoption)","body":""},
+ {"number":52,"title":"upstream: owner/filtered-2 commit -> new2 (review adoption)","body":""}
+]'
 : >"$GH_CREATE_CALLS"
-before_reports=$(find "${HOME}/.aidevops/reports/upstream-watch" -type f | wc -l | tr -d '[:space:]')
-queue_file_unauth="${TMP}/queue-unauth.ndjson"
-: >"$queue_file_unauth"
-_UPSTREAM_WATCH_ISSUE_QUEUE_FILE="$queue_file_unauth"
+queue_filtered="${TMP}/queue-filtered.ndjson"
+: >"$queue_filtered"
+_UPSTREAM_WATCH_ISSUE_QUEUE_FILE="$queue_filtered"
 for index in 1 2 3 4 5; do
-	_queue_upstream_update_issue "owner/unauth-${index}" "commit" "old${index}" "new${index}" "$entry_json"
+	_queue_upstream_update_issue "owner/filtered-${index}" "commit" "old${index}" "new${index}" "$entry_json"
 done
 unset _UPSTREAM_WATCH_ISSUE_QUEUE_FILE
-_flush_upstream_update_issue_queue "$queue_file_unauth" >/dev/null
+_flush_upstream_update_issue_queue "$queue_filtered" >/dev/null
 create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
-after_reports=$(find "${HOME}/.aidevops/reports/upstream-watch" -type f | wc -l | tr -d '[:space:]')
-if [[ "$create_count" == "0" && "$after_reports" -gt "$before_reports" ]]; then
-	ok=1
-else
-	ok=0
-fi
-check "$ok" "unauthorized batch writes local report without public issue" "create_count=${create_count} reports=${before_reports}->${after_reports}"
+if [[ "$create_count" == "3" ]] && ! grep -q 'upstream: batch review adoption' "$GH_CREATE_CALLS"; then ok=1; else ok=0; fi
+check "$ok" "batch threshold applies after handled-value filtering" "create_count=${create_count}"
 
-# Test 5: issue discovery uses gh's supported --limit flag, not unsupported --paginate.
+# Test 9: an entirely handled queue creates nothing.
+export GH_HISTORY_JSON='[
+ {"number":61,"title":"upstream: owner/done-1 release -> v2 (review adoption)","body":""},
+ {"number":62,"title":"upstream: owner/done-2 release -> v2 (review adoption)","body":""}
+]'
+: >"$GH_CREATE_CALLS"
+queue_done="${TMP}/queue-done.ndjson"
+: >"$queue_done"
+_UPSTREAM_WATCH_ISSUE_QUEUE_FILE="$queue_done"
+_queue_upstream_update_issue "owner/done-1" "release" "v1" "v2" "$entry_json"
+_queue_upstream_update_issue "owner/done-2" "release" "v1" "v2" "$entry_json"
+unset _UPSTREAM_WATCH_ISSUE_QUEUE_FILE
+_flush_upstream_update_issue_queue "$queue_done" >/dev/null
+create_count=$(grep -c '^--repo ' "$GH_CREATE_CALLS" 2>/dev/null || true)
+[[ "$create_count" == "0" && ! -s "$queue_done" ]] && ok=1 || ok=0
+check "$ok" "entirely handled queue creates nothing" "create_count=${create_count}"
+
+# Test 10: concurrent exact-key creation closes the higher-number duplicate.
+race_key=$(_upstream_watch_update_key "owner/race" "release" "v9")
+export GH_HISTORY_JSON="[
+ {\"number\":70,\"title\":\"canonical\",\"body\":\"<!-- upstream-watch:update-key=${race_key} -->\"},
+ {\"number\":71,\"title\":\"duplicate\",\"body\":\"<!-- upstream-watch:update-key=${race_key} -->\"}
+]"
+: >"$GH_CLOSE_CALLS"
+_reconcile_upstream_update_issue "marcusquinn/aidevops" "owner/race" "release" "v9" "71"
+close_count=$(grep -c '^71 --repo marcusquinn/aidevops --reason completed' "$GH_CLOSE_CALLS" 2>/dev/null || true)
+[[ "$close_count" == "1" ]] && ok=1 || ok=0
+check "$ok" "concurrent duplicate reconciliation closes newer tracker" "close_count=${close_count}"
+
+# Test 11: issue discovery uses supported --state all/--limit, not --paginate.
 if grep -q -- '--paginate' "$GH_ISSUE_LIST_CALLS"; then
 	ok=0
 else
 	ok=1
 fi
-check "$ok" "upstream-watch issue list avoids unsupported gh --paginate flag" "calls=$(wc -l <"$GH_ISSUE_LIST_CALLS" | tr -d '[:space:]')"
+if ! grep -q -- '--state all' "$GH_ISSUE_LIST_CALLS"; then ok=0; fi
+check "$ok" "upstream-watch history uses --state all without --paginate" "calls=$(wc -l <"$GH_ISSUE_LIST_CALLS" | tr -d '[:space:]')"
 
 if [[ "$FAIL" -gt 0 ]]; then
 	printf '%s test(s) failed, %s passed\n' "$FAIL" "$PASS" >&2

--- a/.agents/scripts/upstream-watch-helper-issues.sh
+++ b/.agents/scripts/upstream-watch-helper-issues.sh
@@ -31,21 +31,6 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
-if ! declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
-	if [[ -f "${SCRIPT_DIR}/github-app-auth-helper.sh" ]]; then
-		# shellcheck source=./github-app-auth-helper.sh
-		source "${SCRIPT_DIR}/github-app-auth-helper.sh"
-	fi
-	if [[ -f "${SCRIPT_DIR}/shared-gh-wrappers-rest-fallback.sh" ]]; then
-		# shellcheck source=./shared-gh-wrappers-rest-fallback.sh
-		source "${SCRIPT_DIR}/shared-gh-wrappers-rest-fallback.sh"
-	fi
-	if [[ -f "${SCRIPT_DIR}/shared-gh-collaborator-permission.sh" ]]; then
-		# shellcheck source=./shared-gh-collaborator-permission.sh
-		source "${SCRIPT_DIR}/shared-gh-collaborator-permission.sh"
-	fi
-fi
-
 # =============================================================================
 # GitHub issue filing (t2810)
 # =============================================================================
@@ -86,23 +71,152 @@ _upstream_watch_issue_creation_authorized() {
 		return 1
 	fi
 
-	local permission=""
 	# #aidevops:trust-boundary — public upstream-watch issue creation requires
-	# confirmed write+ access; API lookup failures skip without claiming none.
-	if ! _gh_collaborator_permission_lookup "$aidevops_slug" "$login" permission; then
-		_log_warn "Skipping public upstream-watch issue creation in ${aidevops_slug}: permission check failed for gh user ${login} (HTTP ${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unknown})"
+	# repository-owner identity; collaborators need the explicit override above.
+	local repo_owner="${aidevops_slug%%/*}" repo_name="${aidevops_slug#*/}"
+	local login_normalized="" owner_normalized=""
+	if [[ -z "$repo_owner" || -z "$repo_name" || "$repo_owner" == "$aidevops_slug" || "$repo_name" == */* ]]; then
+		_log_warn "Skipping public upstream-watch issue creation: invalid repository slug '${aidevops_slug}'"
 		return 1
 	fi
+	login_normalized=$(printf '%s' "$login" | tr '[:upper:]' '[:lower:]')
+	owner_normalized=$(printf '%s' "$repo_owner" | tr '[:upper:]' '[:lower:]')
+	if [[ -n "$repo_owner" && "$repo_owner" != "$aidevops_slug" && "$login_normalized" == "$owner_normalized" ]]; then
+		return 0
+	fi
 
-	case "$permission" in
-		admin | maintain | write)
-			return 0
-			;;
-		*)
-			_log_warn "Skipping public upstream-watch issue creation in ${aidevops_slug}: gh user ${login} has permission '${permission:-none}', not maintainer/collaborator write access"
-			return 1
-			;;
-	esac
+	_log_warn "Skipping public upstream-watch issue creation in ${aidevops_slug}: gh user ${login} is not repository owner ${repo_owner:-unknown}"
+	return 1
+}
+
+#######################################
+# Build the normalized title used by current and legacy issue deduplication.
+# Arguments: slug/name, kind, full new value
+# Outputs: normalized issue title
+#######################################
+_upstream_watch_update_title() {
+	local slug_or_name="$1"
+	local kind="$2"
+	local new_value="$3"
+	printf 'upstream: %s %s -> %s (review adoption)' "$slug_or_name" "$kind" "${new_value:0:12}"
+	return 0
+}
+
+#######################################
+# Compute a deterministic identity from the full, untruncated update value.
+# Arguments: slug/name, kind, full new value
+# Outputs: SHA-256 identity
+#######################################
+_upstream_watch_update_key() {
+	local slug_or_name="$1"
+	local kind="$2"
+	local new_value="$3"
+	local payload=""
+	payload=$(jq -nc --arg slug "$slug_or_name" --arg kind "$kind" --arg value "$new_value" \
+		'{slug:$slug,kind:$kind,value:$value}') || return 1
+	if command -v shasum >/dev/null 2>&1; then
+		printf '%s' "$payload" | shasum -a 256 | cut -d' ' -f1
+		return 0
+	fi
+	if command -v sha256sum >/dev/null 2>&1; then
+		printf '%s' "$payload" | sha256sum | cut -d' ' -f1
+		return 0
+	fi
+	_log_warn "Unable to compute upstream-watch update key: no SHA-256 tool available"
+	return 1
+}
+
+#######################################
+# Check open and closed repository history for an exact handled update.
+# Arguments: repo slug, upstream slug/name, kind, full new value
+# Returns: 0 handled, 1 not handled, 2 lookup/key failure
+#######################################
+_upstream_watch_update_handled() {
+	local aidevops_slug="$1"
+	local slug_or_name="$2"
+	local kind="$3"
+	local new_value="$4"
+	local update_key=""
+	local title=""
+	local issues_json=""
+	update_key=$(_upstream_watch_update_key "$slug_or_name" "$kind" "$new_value") || return 2
+	title=$(_upstream_watch_update_title "$slug_or_name" "$kind" "$new_value")
+	if ! issues_json=$(gh issue list --repo "$aidevops_slug" --state all \
+		--label "$UPSTREAM_WATCH_LABEL" --limit 1000 --json number,title,body); then
+		_log_warn "Unable to query upstream-watch issue history in ${aidevops_slug}; refusing public creation"
+		return 2
+	fi
+	if ! jq -e 'type == "array"' <<<"$issues_json" >/dev/null 2>&1; then
+		_log_warn "Invalid upstream-watch issue history response from ${aidevops_slug}; refusing public creation"
+		return 2
+	fi
+	if jq -e --arg marker "<!-- upstream-watch:update-key=${update_key} -->" --arg title "$title" \
+		'any(.[]; ((.body // "") | contains($marker)) or .title == $title)' \
+		<<<"$issues_json" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Close a just-created issue when a concurrent publisher won the same key race.
+# Arguments: repo, slug/name, kind, full new value, created issue number
+# Returns: 0 reconciled/no duplicate, 1 when reconciliation lookup fails
+#######################################
+_reconcile_upstream_update_issue() {
+	local aidevops_slug="$1"
+	local slug_or_name="$2"
+	local kind="$3"
+	local new_value="$4"
+	local created_number="$5"
+	local update_key=""
+	local title=""
+	local issues_json=""
+	local canonical_number=""
+	update_key=$(_upstream_watch_update_key "$slug_or_name" "$kind" "$new_value") || return 1
+	title=$(_upstream_watch_update_title "$slug_or_name" "$kind" "$new_value")
+	if ! issues_json=$(gh issue list --repo "$aidevops_slug" --state all \
+		--label "$UPSTREAM_WATCH_LABEL" --limit 1000 --json number,title,body); then
+		_log_warn "Unable to reconcile concurrent upstream-watch creation for #${created_number}"
+		return 1
+	fi
+	canonical_number=$(jq -r --arg marker "<!-- upstream-watch:update-key=${update_key} -->" --arg title "$title" \
+		'[.[] | select(((.body // "") | contains($marker)) or .title == $title) | .number] | min // empty' \
+		<<<"$issues_json" 2>/dev/null) || return 1
+	if [[ -n "$canonical_number" && "$canonical_number" != "$created_number" ]]; then
+		_log_warn "Closing duplicate upstream-watch issue #${created_number}; canonical tracker is #${canonical_number}"
+		gh_issue_close_safe "$created_number" --repo "$aidevops_slug" --reason completed >/dev/null 2>&1 || return 1
+	fi
+	return 0
+}
+
+#######################################
+# Remove exact handled values from a queued scan before batch thresholding.
+# Arguments: queue path, destination repo slug
+# Returns: 0 filtered, 1 when history is unknown
+#######################################
+_filter_handled_upstream_updates() {
+	local queue_file="$1"
+	local aidevops_slug="$2"
+	local filtered_file=""
+	filtered_file=$(mktemp "${queue_file}.filtered.XXXXXX") || return 1
+	while IFS= read -r update_json; do
+		[[ -n "$update_json" ]] || continue
+		local slug_or_name="" kind="" new_value="" handled_status=0
+		slug_or_name=$(printf '%s' "$update_json" | jq -r '.slug_or_name') || handled_status=2
+		kind=$(printf '%s' "$update_json" | jq -r '.kind') || handled_status=2
+		new_value=$(printf '%s' "$update_json" | jq -r '.new_value') || handled_status=2
+		if [[ "$handled_status" -ne 2 ]]; then
+			_upstream_watch_update_handled "$aidevops_slug" "$slug_or_name" "$kind" "$new_value" || handled_status=$?
+		fi
+		case "$handled_status" in
+			0) ;;
+			1) printf '%s\n' "$update_json" >>"$filtered_file" ;;
+			*) rm -f "$filtered_file"; return 1 ;;
+		esac
+	done <"$queue_file"
+	mv "$filtered_file" "$queue_file"
+	return 0
 }
 
 #######################################
@@ -184,11 +298,33 @@ _compose_upstream_batch_issue_body() {
 		printf "| \`%s\` | %s | \`%s\` | \`%s\` | %s |\n" \
 			"$slug_or_name" "$kind" "${old_value:-none}" "${new_value:0:12}" "$relevance"
 	done <"$queue_file"
+	while IFS= read -r update_json; do
+		[[ -n "$update_json" ]] || continue
+		local marker_slug="" marker_kind="" marker_value="" marker_key=""
+		marker_slug=$(printf '%s' "$update_json" | jq -r '.slug_or_name')
+		marker_kind=$(printf '%s' "$update_json" | jq -r '.kind')
+		marker_value=$(printf '%s' "$update_json" | jq -r '.new_value')
+		marker_key=$(_upstream_watch_update_key "$marker_slug" "$marker_kind" "$marker_value") || return 1
+		printf '<!-- upstream-watch:update-key=%s -->\n' "$marker_key"
+	done <"$queue_file"
 	printf '\n## Action\n\n'
 	printf '1. Review each upstream source above.\n'
 	printf '2. Decide which changes warrant adoption.\n'
 	printf "3. Acknowledge reviewed sources with \`upstream-watch-helper.sh ack <upstream>\`.\n\n"
 	printf '<!-- aidevops:generator=upstream-watch batch=true -->\n'
+	return 0
+}
+
+#######################################
+# Write a queue as a local batch report without retrying public publication.
+# Arguments: queue path
+# Outputs: local report path
+#######################################
+_write_upstream_batch_local_report() {
+	local queue_file="$1"
+	local title="upstream: batch review adoption" body=""
+	body=$(_compose_upstream_batch_issue_body "$queue_file") || return 1
+	_write_upstream_watch_local_report "$title" "$body"
 	return 0
 }
 
@@ -207,7 +343,7 @@ _file_upstream_batch_update_issue() {
 	if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null; then
 		_log_warn "gh unavailable -- writing local upstream-watch batch report"
 		local offline_report
-		offline_report=$(_write_upstream_watch_local_report "$title" "$body")
+		offline_report=$(_write_upstream_batch_local_report "$queue_file")
 		echo -e "  ${YELLOW}Local upstream-watch report: ${offline_report}${NC}"
 		return 0
 	fi
@@ -216,18 +352,23 @@ _file_upstream_batch_update_issue() {
 	aidevops_slug=$(_get_aidevops_slug)
 	if ! _upstream_watch_issue_creation_authorized "$aidevops_slug"; then
 		local report_file
-		report_file=$(_write_upstream_watch_local_report "$title" "$body")
+		report_file=$(_write_upstream_batch_local_report "$queue_file")
 		_log_info "Wrote local upstream-watch batch report: ${report_file}"
 		echo -e "  ${YELLOW}Skipped public issue creation; local report: ${report_file}${NC}"
 		return 0
 	fi
 
 	local existing_number=""
-	existing_number=$(gh issue list --repo "$aidevops_slug" --state open \
+	if ! existing_number=$(gh issue list --repo "$aidevops_slug" --state open \
 		--label "$UPSTREAM_WATCH_LABEL" \
 		--search 'in:title "upstream: batch"' \
 		--limit 1000 \
-		--json number --jq '.[0].number // empty') || existing_number=""
+		--json number --jq '.[0].number // empty'); then
+		local lookup_report=""
+		lookup_report=$(_write_upstream_batch_local_report "$queue_file")
+		_log_warn "Batch issue lookup failed; local report: ${lookup_report}"
+		return 0
+	fi
 
 	local sig_footer=""
 	if [[ -x "${SCRIPT_DIR}/gh-signature-helper.sh" ]]; then
@@ -275,6 +416,20 @@ _flush_upstream_update_issue_queue() {
 		return 0
 	fi
 
+	local aidevops_slug=""
+	aidevops_slug=$(_get_aidevops_slug)
+	if command -v gh &>/dev/null && gh auth status &>/dev/null && \
+		_upstream_watch_issue_creation_authorized "$aidevops_slug"; then
+		if ! _filter_handled_upstream_updates "$queue_file" "$aidevops_slug"; then
+			_log_warn "Upstream-watch history is unknown -- writing a local batch report"
+			local unknown_report=""
+			unknown_report=$(_write_upstream_batch_local_report "$queue_file")
+			_log_info "Wrote local upstream-watch batch report: ${unknown_report}"
+			return 0
+		fi
+	fi
+	[[ -s "$queue_file" ]] || return 0
+
 	local threshold="${UPSTREAM_WATCH_BATCH_THRESHOLD:-5}"
 	local queue_count
 	queue_count=$(wc -l <"$queue_file" | tr -d '[:space:]')
@@ -309,6 +464,7 @@ _flush_upstream_update_issue_queue() {
 #   $5 - relevance     (may be empty)
 #   $6 - affects       (newline-separated list, may be empty)
 #   $7 - compare_url   (may be empty)
+#   $8 - deterministic full-value update key
 # Outputs: issue body text via stdout
 #######################################
 _compose_upstream_issue_body() {
@@ -319,6 +475,7 @@ _compose_upstream_issue_body() {
 	local relevance="$5"
 	local affects="$6"
 	local compare_url="$7"
+	local update_key="$8"
 
 	# Build affects section using real newlines to avoid printf %b backslash expansion
 	# on user/config-provided data (e.g. Windows paths with \t would be misinterpreted).
@@ -364,7 +521,39 @@ ${affects_section}
 
 <!-- aidevops:generator=upstream-watch upstream_slug=${slug_or_name} -->
 <!-- upstream-watch:slug=${slug_or_name} -->
+<!-- upstream-watch:update-key=${update_key} -->
 ISSUEEOF
+	return 0
+}
+
+#######################################
+# Compose an individual issue body from its config entry.
+# Arguments: slug/name, kind, old value, full new value, entry JSON, update key
+# Outputs: issue body text
+#######################################
+_compose_upstream_issue_from_entry() {
+	local slug_or_name="$1"
+	local kind="$2"
+	local old_value="$3"
+	local new_value="$4"
+	local entry_json="$5"
+	local update_key="$6"
+	local relevance="" affects="" upstream_url="" entry_slug="" compare_url=""
+	if [[ -n "$entry_json" ]]; then
+		relevance=$(printf '%s' "$entry_json" | jq -r '.relevance // ""' 2>/dev/null) || relevance=""
+		affects=$(printf '%s' "$entry_json" | jq -r '.affects // [] | .[]' 2>/dev/null) || affects=""
+		entry_slug=$(printf '%s' "$entry_json" | jq -r '.slug // ""' 2>/dev/null) || entry_slug=""
+		if [[ -n "$entry_slug" ]]; then
+			upstream_url="https://github.com/${entry_slug}"
+		else
+			upstream_url=$(printf '%s' "$entry_json" | jq -r '.url // ""' 2>/dev/null) || upstream_url=""
+		fi
+	fi
+	if [[ -n "$old_value" && -n "$upstream_url" && "$upstream_url" == *"github.com"* ]]; then
+		compare_url="${upstream_url}/compare/${old_value}...${new_value:0:12}"
+	fi
+	_compose_upstream_issue_body "$slug_or_name" "$kind" "${old_value:-none}" \
+		"${new_value:0:12}" "$relevance" "$affects" "$compare_url" "$update_key"
 	return 0
 }
 
@@ -399,47 +588,43 @@ _file_upstream_update_issue() {
 	aidevops_slug=$(_get_aidevops_slug)
 
 	local new_value_short="${new_value:0:12}"
-	local title="upstream: ${slug_or_name} ${kind} -> ${new_value_short} (review adoption)"
+	local update_key=""
+	local title=""
+	update_key=$(_upstream_watch_update_key "$slug_or_name" "$kind" "$new_value") || return 1
+	title=$(_upstream_watch_update_title "$slug_or_name" "$kind" "$new_value")
 
-	# --- Dedup: check for existing open issue ---
-	# Quote the search term to handle slugs/names with special characters or spaces.
-	# Use a high limit because `gh issue list` does not support `--paginate`.
-	local existing_number=""
-	existing_number=$(gh issue list --repo "$aidevops_slug" --state open \
-		--label "$UPSTREAM_WATCH_LABEL" \
-		--search "in:title \"upstream: ${slug_or_name}\"" \
-		--limit 1000 \
-		--json number --jq '.[0].number // empty') || existing_number=""
-
-	# Extract relevance, affects, and upstream URL from config entry
-	local relevance="" affects="" upstream_url=""
-	if [[ -n "$entry_json" ]]; then
-		relevance=$(printf '%s' "$entry_json" | jq -r '.relevance // ""' 2>/dev/null) || relevance=""
-		affects=$(printf '%s' "$entry_json" | jq -r '.affects // [] | .[]' 2>/dev/null) || affects=""
-		local entry_slug=""
-		entry_slug=$(printf '%s' "$entry_json" | jq -r '.slug // ""' 2>/dev/null) || entry_slug=""
-		if [[ -n "$entry_slug" ]]; then
-			upstream_url="https://github.com/${entry_slug}"
-		else
-			upstream_url=$(printf '%s' "$entry_json" | jq -r '.url // ""' 2>/dev/null) || upstream_url=""
-		fi
-	fi
-
-	# Build compare URL for GitHub repos
-	local compare_url=""
-	if [[ -n "$old_value" && -n "$upstream_url" && "$upstream_url" == *"github.com"* ]]; then
-		compare_url="${upstream_url}/compare/${old_value}...${new_value_short}"
-	fi
-
-	# Compose body via helper and append signature footer
 	local body
-	body=$(_compose_upstream_issue_body "$slug_or_name" "$kind" "${old_value:-none}" \
-		"$new_value_short" "$relevance" "$affects" "$compare_url")
+	body=$(_compose_upstream_issue_from_entry "$slug_or_name" "$kind" "$old_value" \
+		"$new_value" "$entry_json" "$update_key")
 	if ! _upstream_watch_issue_creation_authorized "$aidevops_slug"; then
 		local report_file
 		report_file=$(_write_upstream_watch_local_report "$title" "$body")
 		_log_info "Wrote local upstream-watch report for ${slug_or_name}: ${report_file}"
 		echo -e "  ${YELLOW}Skipped public issue creation; local report: ${report_file}${NC}"
+		return 0
+	fi
+
+	local handled_status=0
+	_upstream_watch_update_handled "$aidevops_slug" "$slug_or_name" "$kind" "$new_value" || handled_status=$?
+	if [[ "$handled_status" -eq 0 ]]; then
+		_log_info "Exact upstream value already handled for ${slug_or_name}; skipping issue creation"
+		return 0
+	fi
+	if [[ "$handled_status" -ne 1 ]]; then
+		local history_report=""
+		history_report=$(_write_upstream_watch_local_report "$title" "$body")
+		_log_warn "Upstream-watch history lookup failed; local report: ${history_report}"
+		return 0
+	fi
+
+	# Preserve the existing behavior of advancing one open tracker per upstream.
+	local existing_number=""
+	if ! existing_number=$(gh issue list --repo "$aidevops_slug" --state open \
+		--label "$UPSTREAM_WATCH_LABEL" --search "in:title \"upstream: ${slug_or_name}\"" \
+		--limit 1000 --json number --jq '.[0].number // empty'); then
+		local search_report=""
+		search_report=$(_write_upstream_watch_local_report "$title" "$body")
+		_log_warn "Open upstream-watch lookup failed; local report: ${search_report}"
 		return 0
 	fi
 
@@ -475,6 +660,10 @@ ${sig_footer}"
 			return 0
 		}
 		if [[ -n "$issue_url" ]]; then
+			local created_number="${issue_url##*/}"
+			if [[ "$created_number" =~ ^[0-9]+$ ]]; then
+				_reconcile_upstream_update_issue "$aidevops_slug" "$slug_or_name" "$kind" "$new_value" "$created_number" || true
+			fi
 			_log_info "Filed issue: ${issue_url}"
 			echo -e "  ${BLUE}Filed issue: ${issue_url}${NC}"
 		fi


### PR DESCRIPTION
## Summary

Restrict upstream-watch publication to repository owners or explicit designated publishers; add full-value issue markers, open/closed history deduplication, fail-closed local reports, post-filter batching, and concurrent-create reconciliation.

## Files Changed

.agents/scripts/tests/test-upstream-watch-issue-gate.sh, .agents/scripts/upstream-watch-helper-issues.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-upstream-watch-issue-gate.sh; shellcheck .agents/scripts/upstream-watch-helper-issues.sh .agents/scripts/tests/test-upstream-watch-issue-gate.sh; bash -n .agents/scripts/upstream-watch-helper-issues.sh .agents/scripts/tests/test-upstream-watch-issue-gate.sh; .agents/scripts/linters-local.sh --changed

Resolves #27821


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 10m and 124,019 tokens on this as a headless worker.