### PR TITLE
GH#27853: Make pulse dispatch outcome-driven and backlog-aware

### DIFF
--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -187,7 +187,7 @@ _render_text_report() {
 		"- Auto-dispatch queue: " + (.summary.auto_dispatch_available_unassigned | tostring) + " available / " + (.summary.auto_dispatch_open | tostring) + " open across " + (.queue.repos | tostring) + " pulse repos",
 		"- Queue scan state: " + (.summary.auto_dispatch_scan_state // "scanned"),
 		"- Current window launches: " + (.summary.worker_launches_in_window | tostring) + "; terminal worker events: " + (.summary.worker_terminal_events_in_window | tostring),
-		"- Recent worker metric events: " + (.summary.recent_worker_events | tostring) + "; " + .inputs.historical_window + " success rate: " + (.summary.historical_success_rate | percent_text),
+		"- Recent worker metric events: " + (.summary.recent_worker_events | tostring) + "; " + .inputs.historical_window + " runtime handoff rate: " + (.summary.historical_runtime_handoff_rate | percent_text) + "; delivered success rate: " + (.summary.historical_delivery_success_rate | percent_text),
 		"- GraphQL/API: " + (.summary.graphql_budget_status // "unknown"),
 		"- Runner health: " + (.summary.runner_health // "unknown"),
 		"",

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -27,7 +27,9 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
 ($recent_summary.metrics.total // 0 | number_or_zero) as $recent_total |
 ($summary.metrics.total // 0 | number_or_zero) as $hist_total |
 ($summary.metrics.terminal_session_total // $summary.metrics.total // 0 | number_or_zero) as $hist_terminal_total |
-($summary.metrics.succeeded // 0 | number_or_zero) as $hist_success |
+($summary.metrics.runtime_handoffs // $summary.metrics.succeeded // 0 | number_or_zero) as $hist_handoffs |
+($summary.delivery_stages // {}) as $hist_delivery |
+(if ($hist_delivery.delivered_successes // null) == null then null else ($hist_delivery.delivered_successes | number_or_zero) end) as $hist_delivered |
 ($summary.metrics.failure_families // []) as $failure_families |
 ($recent_summary.metrics.failure_families // []) as $recent_failure_families |
 ($api.graphql_circuit_breaker_trips // 0 | number_or_zero) as $graphql_trips |
@@ -47,8 +49,12 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     worker_launch_validation_failures_in_window: $launch_validation_failed,
     recent_worker_events: $recent_total,
     historical_worker_events: $hist_total,
-    historical_worker_successes: $hist_success,
-    historical_success_rate: (if $hist_terminal_total > 0 then (($hist_success / $hist_terminal_total) * 100 | floor) else null end),
+    historical_worker_runtime_handoffs: $hist_handoffs,
+    historical_runtime_handoff_rate: (if $hist_terminal_total > 0 then (($hist_handoffs / $hist_terminal_total) * 100 | floor) else null end),
+    historical_worker_delivered_successes: $hist_delivered,
+    historical_delivery_success_rate: (if $hist_terminal_total > 0 and $hist_delivered != null then (($hist_delivered / $hist_terminal_total) * 100 | floor) else null end),
+    historical_worker_successes: $hist_delivered,
+    historical_success_rate: (if $hist_terminal_total > 0 and $hist_delivered != null then (($hist_delivered / $hist_terminal_total) * 100 | floor) else null end),
     auto_dispatch_open: ($queue.aggregate.auto_dispatch_open // 0),
     auto_dispatch_available_unassigned: $available_issues,
     auto_dispatch_available_old: $old_available,
@@ -75,12 +81,14 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     historical: {
       window: ($summary.window // {}),
       metrics: (($summary.metrics // {}) | del(.recent_examples, .failure_groups, .failure_families)),
-      pulse_stats: ($summary.pulse_stats // {})
+      pulse_stats: ($summary.pulse_stats // {}),
+      delivery_stages: ($summary.delivery_stages // {check_state: "unavailable"})
     },
     recent: {
       window: ($recent_summary.window // {}),
       metrics: (($recent_summary.metrics // {}) | del(.recent_examples, .failure_groups, .failure_families)),
-      pulse_stats: ($recent_summary.pulse_stats // {})
+      pulse_stats: ($recent_summary.pulse_stats // {}),
+      delivery_stages: ($recent_summary.delivery_stages // {check_state: "unavailable"})
     },
     providers: ($providers.provider_diagnostics // {})
   },
@@ -186,13 +194,23 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
         true
       )
     else empty end,
-    if ($hist_terminal_total >= 10 and (($hist_success * 100) / $hist_terminal_total) < 70) then
+    if ($hist_terminal_total >= 10 and (($hist_handoffs * 100) / $hist_terminal_total) < 70) then
       finding(
-        "worker-success-rate-regression";
+        "worker-runtime-handoff-rate-regression";
         "medium";
-        "Historical worker success rate is below the productivity target";
-        [("success_rate_percent=" + (((($hist_success * 100) / $hist_terminal_total) | floor) | tostring)), ("terminal_session_outcomes=" + ($hist_terminal_total | tostring)), ("worker_events=" + ($hist_total | tostring))];
+        "Historical worker runtime handoff rate is below the productivity target";
+        [("runtime_handoff_rate_percent=" + (((($hist_handoffs * 100) / $hist_terminal_total) | floor) | tostring)), ("terminal_session_outcomes=" + ($hist_terminal_total | tostring)), ("worker_events=" + ($hist_total | tostring))];
         "Cluster failure families with worker-activity-helper summary --json, then file targeted fixes for the dominant cause instead of increasing concurrency.";
+        false
+      )
+    else empty end,
+    if ($hist_terminal_total >= 10 and $hist_delivered != null and (($hist_delivered * 100) / $hist_terminal_total) < 70) then
+      finding(
+        "worker-delivery-rate-regression";
+        "medium";
+        "Historical worker delivered-success rate is below the productivity target";
+        [("delivered_success_rate_percent=" + (((($hist_delivered * 100) / $hist_terminal_total) | floor) | tostring)), ("delivered_successes=" + ($hist_delivered | tostring)), ("terminal_session_outcomes=" + ($hist_terminal_total | tostring))];
+        "Compare runtime handoffs, opened PRs, merged PRs, and solved issues with worker-activity-helper summary --pr-check before changing dispatch capacity.";
         false
       )
     else empty end

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -29,7 +29,7 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
 ($summary.metrics.terminal_session_total // $summary.metrics.total // 0 | number_or_zero) as $hist_terminal_total |
 ($summary.metrics.runtime_handoffs // $summary.metrics.succeeded // 0 | number_or_zero) as $hist_handoffs |
 ($summary.delivery_stages // {}) as $hist_delivery |
-(if ($hist_delivery.delivered_successes // null) == null then null else ($hist_delivery.delivered_successes | number_or_zero) end) as $hist_delivered |
+(if $hist_delivery.delivered_successes == null then null else ($hist_delivery.delivered_successes | number_or_zero) end) as $hist_delivered |
 ($summary.metrics.failure_families // []) as $failure_families |
 ($recent_summary.metrics.failure_families // []) as $recent_failure_families |
 ($api.graphql_circuit_breaker_trips // 0 | number_or_zero) as $graphql_trips |

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -269,6 +269,22 @@ _dedup_layer6_assignee_and_stale() {
 			printf '%s\n' "$assigned_output"
 			return 0
 		fi
+		# GH#27853: exhausted stale-recovery paths are terminal outcomes. Route
+		# them through the same idempotent consolidation dispatcher used by
+		# substantive-thread triage, then block this cycle so a stale candidate
+		# snapshot cannot launch a competing worker after NMR was applied.
+		if [[ "$assigned_output" == *STALE_ESCALATED* || "$assigned_output" == *STALE_PR_ESCALATED* ]]; then
+			local _stale_breaker_source="stale-recovery-threshold"
+			[[ "$assigned_output" == *STALE_PR_ESCALATED* ]] && _stale_breaker_source="stale-pr-checkpoint"
+			if declare -F _route_terminal_breaker_to_consolidation >/dev/null 2>&1; then
+				_route_terminal_breaker_to_consolidation "$issue_number" "$repo_slug" \
+					"$_stale_breaker_source" "$assigned_output" || true
+			else
+				echo "[pulse-wrapper] Dedup: terminal stale breaker for #${issue_number} in ${repo_slug} could not route to consolidation because bridge is unavailable" >>"$LOGFILE"
+			fi
+			echo "[pulse-wrapper] Dedup: terminal stale breaker blocked redispatch for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
+			return 0
+		fi
 		# t1927: Stale recovery must record fast-fail. When _is_stale_assignment()
 		# recovers a stale assignment (silent worker timeout), the dedup helper
 		# outputs STALE_RECOVERED on stdout. Without recording this as a failure,

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -93,6 +93,8 @@ fi
 : "${PULSE_LLM_STALL_THRESHOLD:=3600}"
 : "${PULSE_RATE_LIMIT_FLAG:=${HOME}/.aidevops/logs/pulse-graphql-rate-limited.flag}"
 : "${PULSE_RUNNABLE_ISSUE_LIMIT:=1000}"
+: "${PULSE_DISPATCH_AGE_BONUS_PER_DAY:=25}"
+: "${PULSE_DISPATCH_AGE_BONUS_CAP:=900}"
 : "${AIDEVOPS_PULSE_ASYNC_POST_DISPATCH_HOUSEKEEPING:=1}"
 
 # t2690: Source rate-limit circuit breaker (proactive dispatch pause on GraphQL exhaustion).
@@ -276,11 +278,18 @@ check_worker_launch() {
 # Build ranked deterministic dispatch candidates across all pulse repos.
 # Arguments:
 #   $1 - max issues to fetch per repo (optional)
-# Returns: JSON array sorted by score desc, updatedAt asc
+# Returns: JSON array sorted by score desc, createdAt asc, updatedAt asc
 #######################################
 build_ranked_dispatch_candidates_json() {
 	local per_repo_limit="${1:-$PULSE_RUNNABLE_ISSUE_LIMIT}"
 	[[ "$per_repo_limit" =~ ^[0-9]+$ ]] || per_repo_limit="$PULSE_RUNNABLE_ISSUE_LIMIT"
+	local age_bonus_per_day="${PULSE_DISPATCH_AGE_BONUS_PER_DAY:-25}"
+	local age_bonus_cap="${PULSE_DISPATCH_AGE_BONUS_CAP:-900}"
+	local current_epoch
+	[[ "$age_bonus_per_day" =~ ^[0-9]+$ ]] || age_bonus_per_day=25
+	[[ "$age_bonus_cap" =~ ^[0-9]+$ ]] || age_bonus_cap=900
+	current_epoch=$(date +%s)
+	[[ "$current_epoch" =~ ^[0-9]+$ ]] || current_epoch=0
 
 	if [[ ! -f "$REPOS_JSON" ]]; then
 		printf '[]\n'
@@ -309,37 +318,45 @@ build_ranked_dispatch_candidates_json() {
 			continue
 		fi
 
-		printf '%s' "$repo_candidates_json" | jq -c --arg slug "$repo_slug" --arg path "$repo_path" --arg priority "$repo_priority" --arg debt_label "${QUALITY_DEBT_LABEL:-quality-debt}" '
+		printf '%s' "$repo_candidates_json" | jq -c --arg slug "$repo_slug" --arg path "$repo_path" --arg priority "$repo_priority" --arg debt_label "${QUALITY_DEBT_LABEL:-quality-debt}" --argjson age_bonus_per_day "$age_bonus_per_day" --argjson age_bonus_cap "$age_bonus_cap" --argjson current_epoch "$current_epoch" '
 			.[] |
+			(try ((.createdAt // "") | fromdateiso8601) catch $current_epoch) as $created_epoch |
+			((($current_epoch - $created_epoch) / 86400) | floor | if . < 0 then 0 else . end) as $age_days |
+			($age_days * $age_bonus_per_day) as $uncapped_age_bonus |
+			(if $uncapped_age_bonus > $age_bonus_cap then $age_bonus_cap else $uncapped_age_bonus end) as $age_bonus |
+			((.labels // []) | map(.name? // .)) as $labels |
+			(
+				(if $priority == "tooling" then 2000 elif $priority == "product" then 1000 else 0 end) +
+				# Mission m-20260504-1e325d feature 3.4: when capacity is
+				# constrained, rank worker-ready/low-complexity issues above
+				# broad raw backlog so pulse fills slots with solvable work first.
+				(if (($labels | index("tier:simple")) != null or ($labels | index("low-complexity")) != null) then 2500
+				 elif ($labels | index("tier:standard")) != null then 1200
+				 else 0 end) +
+				(if (($labels | index("worker-ready")) != null or ($labels | index("status:available")) != null) then 1000 else 0 end) +
+				(if (($labels | index("good first issue")) != null or ($labels | index("quick-win")) != null) then 800 else 0 end) +
+				(if ($labels | index("auto-dispatch")) != null then 300 else 0 end) -
+				(if ($labels | index("tier:thinking")) != null then 1200 else 0 end) -
+				(if (($labels | index("research")) != null or ($labels | index("needs-design")) != null) then 800 else 0 end) +
+				(if (($labels | index($debt_label)) != null and ($labels | index("security")) != null) then 500 else 0 end) +
+				(if ($labels | index("priority:critical")) != null then 10000
+				 elif ($labels | index("priority:high")) != null then 9000
+				 elif ($labels | index("priority:medium")) != null then 8000
+				 elif ($labels | index("bug")) != null then 7000
+				 elif ($labels | index("enhancement")) != null then 6000
+				 elif ($labels | index($debt_label)) != null then 5000
+				 elif (($labels | index("file-size-debt")) != null or ($labels | index("function-complexity-debt")) != null) then 4000
+				 elif ($labels | index("priority:low")) != null then 3500
+				 else 3000 end)
+			) as $base_score |
 			. + {
 				repo_slug: $slug,
 				repo_path: $path,
 				repo_priority: $priority,
-				score: (
-					((.labels // []) | map(.name? // .)) as $labels |
-					(if $priority == "tooling" then 2000 elif $priority == "product" then 1000 else 0 end) +
-					# Mission m-20260504-1e325d feature 3.4: when capacity is
-					# constrained, rank worker-ready/low-complexity issues above
-					# broad raw backlog so pulse fills slots with solvable work first.
-					(if (($labels | index("tier:simple")) != null or ($labels | index("low-complexity")) != null) then 2500
-					 elif ($labels | index("tier:standard")) != null then 1200
-					 else 0 end) +
-					(if (($labels | index("worker-ready")) != null or ($labels | index("status:available")) != null) then 1000 else 0 end) +
-					(if (($labels | index("good first issue")) != null or ($labels | index("quick-win")) != null) then 800 else 0 end) +
-					(if ($labels | index("auto-dispatch")) != null then 300 else 0 end) -
-					(if ($labels | index("tier:thinking")) != null then 1200 else 0 end) -
-					(if (($labels | index("research")) != null or ($labels | index("needs-design")) != null) then 800 else 0 end) +
-					(if (($labels | index($debt_label)) != null and ($labels | index("security")) != null) then 500 else 0 end) +
-					(if ($labels | index("priority:critical")) != null then 10000
-					 elif ($labels | index("priority:high")) != null then 9000
-					 elif ($labels | index("priority:medium")) != null then 8000
-					 elif ($labels | index("bug")) != null then 7000
-					 elif ($labels | index("enhancement")) != null then 6000
-					 elif ($labels | index($debt_label)) != null then 5000
-					 elif (($labels | index("file-size-debt")) != null or ($labels | index("function-complexity-debt")) != null) then 4000
-					 elif ($labels | index("priority:low")) != null then 3500
-					 else 3000 end)
-				)
+				base_score: $base_score,
+				age_days: $age_days,
+				age_bonus: $age_bonus,
+				score: ($base_score + $age_bonus)
 			}
 		' >>"$tmp_candidates" 2>/dev/null || true
 	done < <(jq -r '
@@ -370,7 +387,13 @@ build_ranked_dispatch_candidates_json() {
 		return 0
 	fi
 
-	jq -cs 'sort_by([-.score, (.updatedAt // "")])' "$tmp_candidates" 2>/dev/null || printf '[]\n'
+	jq -cs 'sort_by([
+		-.score,
+		(if (.createdAt // "") == "" then "9999-12-31T23:59:59Z" else .createdAt end),
+		(if (.updatedAt // "") == "" then "9999-12-31T23:59:59Z" else .updatedAt end),
+		(.repo_slug // ""),
+		(.number // 0)
+	])' "$tmp_candidates" 2>/dev/null || printf '[]\n'
 	rm -f "$tmp_candidates"
 	return 0
 }

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -275,6 +275,67 @@ check_worker_launch() {
 }
 
 #######################################
+# Score one repository's dispatch candidates and append JSONL records to the
+# shared candidate file. Extracted so the cross-repository orchestrator stays
+# below the function-complexity threshold.
+# Arguments: candidates JSON, slug, path, priority, bonus/day, bonus cap,
+#            current epoch, destination JSONL file
+#######################################
+_append_ranked_repo_candidates() {
+	local repo_candidates_json="$1"
+	local repo_slug="$2"
+	local repo_path="$3"
+	local repo_priority="$4"
+	local age_bonus_per_day="$5"
+	local age_bonus_cap="$6"
+	local current_epoch="$7"
+	local tmp_candidates="$8"
+
+	printf '%s' "$repo_candidates_json" | jq -c --arg slug "$repo_slug" --arg path "$repo_path" --arg priority "$repo_priority" --arg debt_label "${QUALITY_DEBT_LABEL:-quality-debt}" --argjson age_bonus_per_day "$age_bonus_per_day" --argjson age_bonus_cap "$age_bonus_cap" --argjson current_epoch "$current_epoch" '
+		.[] |
+		(try ((.createdAt // "") | fromdateiso8601) catch $current_epoch) as $created_epoch |
+		((($current_epoch - $created_epoch) / 86400) | floor | if . < 0 then 0 else . end) as $age_days |
+		($age_days * $age_bonus_per_day) as $uncapped_age_bonus |
+		(if $uncapped_age_bonus > $age_bonus_cap then $age_bonus_cap else $uncapped_age_bonus end) as $age_bonus |
+		((.labels // []) | map(.name? // .)) as $labels |
+		(
+			(if $priority == "tooling" then 2000 elif $priority == "product" then 1000 else 0 end) +
+			# Mission m-20260504-1e325d feature 3.4: when capacity is
+			# constrained, rank worker-ready/low-complexity issues above
+			# broad raw backlog so pulse fills slots with solvable work first.
+			(if (($labels | index("tier:simple")) != null or ($labels | index("low-complexity")) != null) then 2500
+			 elif ($labels | index("tier:standard")) != null then 1200
+			 else 0 end) +
+			(if (($labels | index("worker-ready")) != null or ($labels | index("status:available")) != null) then 1000 else 0 end) +
+			(if (($labels | index("good first issue")) != null or ($labels | index("quick-win")) != null) then 800 else 0 end) +
+			(if ($labels | index("auto-dispatch")) != null then 300 else 0 end) -
+			(if ($labels | index("tier:thinking")) != null then 1200 else 0 end) -
+			(if (($labels | index("research")) != null or ($labels | index("needs-design")) != null) then 800 else 0 end) +
+			(if (($labels | index($debt_label)) != null and ($labels | index("security")) != null) then 500 else 0 end) +
+			(if ($labels | index("priority:critical")) != null then 10000
+			 elif ($labels | index("priority:high")) != null then 9000
+			 elif ($labels | index("priority:medium")) != null then 8000
+			 elif ($labels | index("bug")) != null then 7000
+			 elif ($labels | index("enhancement")) != null then 6000
+			 elif ($labels | index($debt_label)) != null then 5000
+			 elif (($labels | index("file-size-debt")) != null or ($labels | index("function-complexity-debt")) != null) then 4000
+			 elif ($labels | index("priority:low")) != null then 3500
+			 else 3000 end)
+		) as $base_score |
+		. + {
+			repo_slug: $slug,
+			repo_path: $path,
+			repo_priority: $priority,
+			base_score: $base_score,
+			age_days: $age_days,
+			age_bonus: $age_bonus,
+			score: ($base_score + $age_bonus)
+		}
+	' >>"$tmp_candidates" 2>/dev/null || true
+	return 0
+}
+
+#######################################
 # Build ranked deterministic dispatch candidates across all pulse repos.
 # Arguments:
 #   $1 - max issues to fetch per repo (optional)
@@ -318,47 +379,8 @@ build_ranked_dispatch_candidates_json() {
 			continue
 		fi
 
-		printf '%s' "$repo_candidates_json" | jq -c --arg slug "$repo_slug" --arg path "$repo_path" --arg priority "$repo_priority" --arg debt_label "${QUALITY_DEBT_LABEL:-quality-debt}" --argjson age_bonus_per_day "$age_bonus_per_day" --argjson age_bonus_cap "$age_bonus_cap" --argjson current_epoch "$current_epoch" '
-			.[] |
-			(try ((.createdAt // "") | fromdateiso8601) catch $current_epoch) as $created_epoch |
-			((($current_epoch - $created_epoch) / 86400) | floor | if . < 0 then 0 else . end) as $age_days |
-			($age_days * $age_bonus_per_day) as $uncapped_age_bonus |
-			(if $uncapped_age_bonus > $age_bonus_cap then $age_bonus_cap else $uncapped_age_bonus end) as $age_bonus |
-			((.labels // []) | map(.name? // .)) as $labels |
-			(
-				(if $priority == "tooling" then 2000 elif $priority == "product" then 1000 else 0 end) +
-				# Mission m-20260504-1e325d feature 3.4: when capacity is
-				# constrained, rank worker-ready/low-complexity issues above
-				# broad raw backlog so pulse fills slots with solvable work first.
-				(if (($labels | index("tier:simple")) != null or ($labels | index("low-complexity")) != null) then 2500
-				 elif ($labels | index("tier:standard")) != null then 1200
-				 else 0 end) +
-				(if (($labels | index("worker-ready")) != null or ($labels | index("status:available")) != null) then 1000 else 0 end) +
-				(if (($labels | index("good first issue")) != null or ($labels | index("quick-win")) != null) then 800 else 0 end) +
-				(if ($labels | index("auto-dispatch")) != null then 300 else 0 end) -
-				(if ($labels | index("tier:thinking")) != null then 1200 else 0 end) -
-				(if (($labels | index("research")) != null or ($labels | index("needs-design")) != null) then 800 else 0 end) +
-				(if (($labels | index($debt_label)) != null and ($labels | index("security")) != null) then 500 else 0 end) +
-				(if ($labels | index("priority:critical")) != null then 10000
-				 elif ($labels | index("priority:high")) != null then 9000
-				 elif ($labels | index("priority:medium")) != null then 8000
-				 elif ($labels | index("bug")) != null then 7000
-				 elif ($labels | index("enhancement")) != null then 6000
-				 elif ($labels | index($debt_label)) != null then 5000
-				 elif (($labels | index("file-size-debt")) != null or ($labels | index("function-complexity-debt")) != null) then 4000
-				 elif ($labels | index("priority:low")) != null then 3500
-				 else 3000 end)
-			) as $base_score |
-			. + {
-				repo_slug: $slug,
-				repo_path: $path,
-				repo_priority: $priority,
-				base_score: $base_score,
-				age_days: $age_days,
-				age_bonus: $age_bonus,
-				score: ($base_score + $age_bonus)
-			}
-		' >>"$tmp_candidates" 2>/dev/null || true
+		_append_ranked_repo_candidates "$repo_candidates_json" "$repo_slug" "$repo_path" \
+			"$repo_priority" "$age_bonus_per_day" "$age_bonus_cap" "$current_epoch" "$tmp_candidates"
 	done < <(jq -r '
 		def pulse_hour_start:
 			if (.pulse_hours | type) == "array" then .pulse_hours[0]

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1351,6 +1351,10 @@ _run_preflight_stages() {
 	# so one slow scanner cannot starve downstream scanners.
 	local _pflt_timeout="${PREFLIGHT_GROUP_TIMEOUT:-${PRE_RUN_STAGE_TIMEOUT:-600}}"
 
+	# GH#27853: start the existing lock-safe merge routine before any new
+	# dispatch. It runs asynchronously while cleanup/capacity stages proceed;
+	# dispatch never waits for merge, CI, review, or GitHub latency.
+	_preflight_start_merge_first || true
 	run_stage_with_timeout "preflight_cleanup_and_ledger" "$_pflt_timeout" \
 		_preflight_cleanup_and_ledger || true
 	run_stage_with_timeout "preflight_capacity_and_labels" "$_pflt_timeout" \

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -10,9 +10,9 @@
 # (which remains in the orchestrator because its 108-line body would
 # re-register as a new function-complexity violation if moved).
 #
-# Each helper groups one phase of preflight work: cleanup/reap, capacity/labels,
-# early dispatch, ownership reconcile, prefetch+scope. Behavior is byte-for-byte
-# identical to the pre-split monolithic structure -- no logic changes.
+# Each helper groups one phase of preflight work: asynchronous merge-first,
+# cleanup/reap, capacity/labels, early dispatch, ownership reconcile, and
+# prefetch+scope.
 #
 # Usage: source "${SCRIPT_DIR}/pulse-dispatch-preflight-lib.sh"
 #
@@ -36,10 +36,39 @@ _PULSE_DISPATCH_PREFLIGHT_LIB_LOADED=1
 # Helpers for _run_preflight_stages (GH#18656)
 # -----------------------------------------------------------------------------
 # The helpers below group related preflight work so _run_preflight_stages
-# stays under 100 lines and each group (cleanup/reap, capacity/labels, early
-# dispatch, daily scans, ownership reconcile, prefetch+scope) can be read
-# independently. Behavior is byte-for-byte equivalent to the pre-split
-# monolithic function — see git log for the refactor commit.
+# stays under 100 lines and each group (merge-first, cleanup/reap,
+# capacity/labels, early dispatch, daily scans, ownership reconcile, and
+# prefetch/scope) can be read independently.
+
+#######################################
+# Give the existing standalone merge routine a non-blocking head start before
+# cleanup, capacity calculation, and early dispatch. The routine owns its own
+# cross-process lock and timeout, so concurrent launchd/pulse kicks collapse to
+# one runner without making dispatch wait for CI, review, or GitHub latency.
+#######################################
+_preflight_start_merge_first() {
+	if [[ "${AIDEVOPS_PULSE_ASYNC_MERGE_FIRST:-1}" != "1" ]]; then
+		echo "[pulse-wrapper] merge-first kick disabled by AIDEVOPS_PULSE_ASYNC_MERGE_FIRST" >>"$LOGFILE"
+		return 0
+	fi
+
+	local merge_routine="${PULSE_MERGE_ROUTINE_HELPER:-${SCRIPT_DIR}/pulse-merge-routine.sh}"
+	if [[ ! -x "$merge_routine" ]]; then
+		echo "[pulse-wrapper] merge-first kick skipped: routine unavailable at ${merge_routine}" >>"$LOGFILE"
+		return 0
+	fi
+
+	local kick_log="${PULSE_MERGE_FIRST_KICK_LOG:-${HOME}/.aidevops/logs/pulse-merge-routine-kick.log}"
+	mkdir -p "$(dirname "$kick_log")" 2>/dev/null || true
+	nohup "$merge_routine" run </dev/null >>"$kick_log" 2>&1 &
+	local kick_pid=$!
+	disown "$kick_pid" 2>/dev/null || true
+	echo "[pulse-wrapper] merge-first kick started asynchronously (pid=${kick_pid})" >>"$LOGFILE"
+	if declare -F pulse_stats_increment >/dev/null 2>&1; then
+		pulse_stats_increment "pulse_merge_first_kick_started" 2>/dev/null || true
+	fi
+	return 0
+}
 
 #######################################
 # Cleanup + zombie reap + ledger maintenance. Runs before worker counting

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -22,6 +22,9 @@
 #   - _ff_query_pool_retry_seconds
 #   - _ff_with_lock
 #   - _ff_save
+#   - _ff_mark_terminal_consolidation_routed
+#   - _ff_route_terminal_consolidation
+#   - _ff_terminal_threshold_crossed
 #   - _ff_parse_entry
 #   - _ff_compute_rate_limit_strategy
 #   - _ff_compute_failure_strategy
@@ -224,6 +227,81 @@ _ff_save() {
 		echo "[pulse-wrapper] _ff_save: failed to write fast-fail state" >>"$LOGFILE"
 	fi
 	return 0
+}
+
+#######################################
+# Persist that the terminal fast-fail outcome has already passed through the
+# idempotent consolidation dispatcher. This avoids repeated GitHub reads and
+# label writes on every pulse cycle while the issue remains hard-stopped.
+# Arguments: issue number, repo slug, breaker source
+#######################################
+_ff_mark_terminal_consolidation_routed() {
+	_ff_with_lock _ff_mark_terminal_consolidation_routed_locked "$@" || return 1
+	return 0
+}
+
+_ff_mark_terminal_consolidation_routed_locked() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local breaker_source="$3"
+	local key state now updated_state
+
+	key=$(_ff_key "$issue_number" "$repo_slug")
+	state=$(_ff_load)
+	now=$(date +%s)
+	updated_state=$(printf '%s' "$state" | jq \
+		--arg k "$key" \
+		--arg source "$breaker_source" \
+		--argjson ts "$now" \
+		'if .[$k] then .[$k].terminal_consolidation_routed = true | .[$k].terminal_consolidation_source = $source | .[$k].terminal_consolidation_ts = $ts else . end' \
+		2>/dev/null) || return 1
+	_ff_save "$updated_state"
+	return 0
+}
+
+#######################################
+# Hand a terminal fast-fail outcome to the shared consolidation bridge after
+# releasing the fast-fail state lock. Missing bridge functions are fail-open:
+# fast_fail_is_skipped retries the handoff on the next main pulse cycle.
+# Arguments: issue number, repo slug, breaker source, optional detail
+#######################################
+_ff_route_terminal_consolidation() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local breaker_source="$3"
+	local breaker_detail="${4:-}"
+
+	if ! declare -F _route_terminal_breaker_to_consolidation >/dev/null 2>&1; then
+		echo "[pulse-wrapper] fast-fail consolidation deferred for #${issue_number} in ${repo_slug}: bridge unavailable" >>"$LOGFILE"
+		return 1
+	fi
+	if ! _route_terminal_breaker_to_consolidation \
+		"$issue_number" "$repo_slug" "$breaker_source" "$breaker_detail"; then
+		return 1
+	fi
+	_ff_mark_terminal_consolidation_routed "$issue_number" "$repo_slug" "$breaker_source" || true
+	return 0
+}
+
+#######################################
+# Check whether a non-rate-limit failure has just crossed the hard-stop
+# threshold. Kept separate so _fast_fail_record_locked stays below the
+# function-size complexity gate.
+# Arguments: existing count, new count, rate-limit boolean
+#######################################
+_ff_terminal_threshold_crossed() {
+	local existing_count="$1"
+	local new_count="$2"
+	local is_rate_limit="$3"
+	local terminal_threshold="${FAST_FAIL_SKIP_THRESHOLD:-5}"
+
+	[[ "$terminal_threshold" =~ ^[0-9]+$ ]] || terminal_threshold=5
+	if [[ "$is_rate_limit" == "false" \
+		&& "$existing_count" -lt "$terminal_threshold" \
+		&& "$new_count" -ge "$terminal_threshold" ]]; then
+		return 0
+	fi
+	return 1
 }
 
 #######################################
@@ -471,7 +549,16 @@ _ff_release_retry_reset_if_newer_locked() {
 #   $5 - crash_type (optional: "overwhelmed" | "no_work" | "partial" | "")
 #######################################
 fast_fail_record() {
-	_ff_with_lock _fast_fail_record_locked "$@" || return 0
+	local issue_number="$1"
+	local repo_slug="$2"
+	local reason="${3:-launch_failure}"
+	local record_rc=0
+
+	_ff_with_lock _fast_fail_record_locked "$@" || record_rc=$?
+	if [[ "$record_rc" -eq 2 ]]; then
+		_ff_route_terminal_consolidation "$issue_number" "$repo_slug" \
+			"fast-fail-hard-stop" "reason=${reason}" || true
+	fi
 	return 0
 }
 
@@ -564,6 +651,13 @@ _fast_fail_record_locked() {
 		escalate_issue_tier "$issue_number" "$repo_slug" "$new_count" "$reason" "$crash_type" || true
 	fi
 
+	# Return an internal sentinel when a non-rate-limit failure first crosses
+	# the hard-stop threshold. The public wrapper releases the state lock before
+	# invoking GitHub-backed consolidation machinery.
+	if _ff_terminal_threshold_crossed "$existing_count" "$new_count" "$is_rate_limit"; then
+		return 2
+	fi
+
 	return 0
 }
 
@@ -623,7 +717,15 @@ _fast_fail_reset_locked() {
 # Arguments: $1 issue_number, $2 repo_slug
 #######################################
 fast_fail_age_out() {
-	_ff_with_lock _fast_fail_age_out_locked "$@" || return 0
+	local issue_number="$1"
+	local repo_slug="$2"
+	local age_out_rc=0
+
+	_ff_with_lock _fast_fail_age_out_locked "$@" || age_out_rc=$?
+	if [[ "$age_out_rc" -eq 2 ]]; then
+		_ff_route_terminal_consolidation "$issue_number" "$repo_slug" \
+			"fast-fail-age-out-ceiling" "maximum automatic resets exhausted" || true
+	fi
 	return 0
 }
 
@@ -681,7 +783,10 @@ _fast_fail_age_out_locked() {
 	if [[ "$new_reset_count" -gt "$max_resets" ]]; then
 		echo "[pulse-wrapper] fast_fail_age_out: #${issue_number} (${repo_slug}) exceeded ${max_resets} auto-resets without success — applying needs-maintainer-review" >>"$LOGFILE"
 		gh issue edit "$issue_number" --repo "$repo_slug" --add-label "needs-maintainer-review" >>"$LOGFILE" 2>&1 || true
-		return 0
+		case "$existing_reason" in
+		rate_limit* | backoff) return 0 ;;
+		*) return 2 ;;
+		esac
 	fi
 
 	# Reset counter: count=0, retry_after=0, record reset metadata for audit.
@@ -726,7 +831,7 @@ fast_fail_is_skipped() {
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
 	[[ -n "$repo_slug" ]] || return 1
 
-	local key now state existing_ts existing_count existing_retry_after
+	local key now state existing_ts existing_count existing_retry_after existing_reason consolidation_routed
 	key=$(_ff_key "$issue_number" "$repo_slug")
 	now=$(date +%s)
 	state=$(_ff_load)
@@ -740,6 +845,8 @@ fast_fail_is_skipped() {
 	existing_ts=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].ts // 0' 2>/dev/null) || existing_ts=0
 	existing_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].count // 0' 2>/dev/null) || existing_count=0
 	existing_retry_after=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].retry_after // 0' 2>/dev/null) || existing_retry_after=0
+	existing_reason=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].reason // ""' 2>/dev/null) || existing_reason=""
+	consolidation_routed=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].terminal_consolidation_routed // false' 2>/dev/null) || consolidation_routed=false
 	[[ "$existing_ts" =~ ^[0-9]+$ ]] || existing_ts=0
 	[[ "$existing_count" =~ ^[0-9]+$ ]] || existing_count=0
 	[[ "$existing_retry_after" =~ ^[0-9]+$ ]] || existing_retry_after=0
@@ -756,6 +863,15 @@ fast_fail_is_skipped() {
 	# Hard stop: too many non-rate-limit failures
 	if [[ "$existing_count" -ge "$FAST_FAIL_SKIP_THRESHOLD" ]]; then
 		echo "[pulse-wrapper] fast_fail_is_skipped: #${issue_number} (${repo_slug}) HARD STOP count=${existing_count}>=${FAST_FAIL_SKIP_THRESHOLD}" >>"$LOGFILE"
+		case "$existing_reason" in
+		rate_limit* | backoff) ;;
+		*)
+			if [[ "$consolidation_routed" != "true" ]]; then
+				_ff_route_terminal_consolidation "$issue_number" "$repo_slug" \
+					"fast-fail-hard-stop" "reason=${existing_reason:-unknown} count=${existing_count}" || true
+			fi
+			;;
+		esac
 		return 0 # Skipped
 	fi
 

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -245,7 +245,10 @@ _ff_mark_terminal_consolidation_routed_locked() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local breaker_source="$3"
-	local key state now updated_state
+	local key
+	local state
+	local now
+	local updated_state
 
 	key=$(_ff_key "$issue_number" "$repo_slug")
 	state=$(_ff_load)
@@ -832,7 +835,14 @@ fast_fail_is_skipped() {
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
 	[[ -n "$repo_slug" ]] || return 1
 
-	local key now state existing_ts existing_count existing_retry_after existing_reason consolidation_routed
+	local key
+	local now
+	local state
+	local existing_ts
+	local existing_count
+	local existing_retry_after
+	local existing_reason
+	local consolidation_routed
 	key=$(_ff_key "$issue_number" "$repo_slug")
 	now=$(date +%s)
 	state=$(_ff_load)

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -53,6 +53,7 @@
 # Include guard — prevent double-sourcing.
 [[ -n "${_PULSE_FAST_FAIL_LOADED:-}" ]] && return 0
 _PULSE_FAST_FAIL_LOADED=1
+_FF_BOOL_FALSE="false"
 
 #######################################
 # Return the fast-fail state key for an issue.
@@ -296,7 +297,7 @@ _ff_terminal_threshold_crossed() {
 	local terminal_threshold="${FAST_FAIL_SKIP_THRESHOLD:-5}"
 
 	[[ "$terminal_threshold" =~ ^[0-9]+$ ]] || terminal_threshold=5
-	if [[ "$is_rate_limit" == "false" \
+	if [[ "$is_rate_limit" == "$_FF_BOOL_FALSE" \
 		&& "$existing_count" -lt "$terminal_threshold" \
 		&& "$new_count" -ge "$terminal_threshold" ]]; then
 		return 0
@@ -633,7 +634,7 @@ _fast_fail_record_locked() {
 	# Flag for enrichment on first non-rate-limit failure: a thinking-tier worker
 	# will analyze the issue and add implementation guidance before re-dispatch.
 	# Only set once — cleared after enrichment runs.
-	if [[ "$is_rate_limit" == "false" && "$new_count" -eq 1 ]]; then
+	if [[ "$is_rate_limit" == "$_FF_BOOL_FALSE" && "$new_count" -eq 1 ]]; then
 		updated_state=$(printf '%s' "$updated_state" | jq \
 			--arg k "$key" \
 			'.[$k].enrichment_needed = true' 2>/dev/null) || true
@@ -647,7 +648,7 @@ _fast_fail_record_locked() {
 	# the problem, it's provider capacity. Escalating would waste a higher tier.
 	# Pass crash_type to escalate_issue_tier for crash-type-aware thresholds:
 	# "overwhelmed" escalates immediately, others use default threshold.
-	if [[ "$is_rate_limit" == "false" && "$new_count" -gt "$existing_count" ]]; then
+	if [[ "$is_rate_limit" == "$_FF_BOOL_FALSE" && "$new_count" -gt "$existing_count" ]]; then
 		escalate_issue_tier "$issue_number" "$repo_slug" "$new_count" "$reason" "$crash_type" || true
 	fi
 

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -231,7 +231,7 @@ repo_allows_pulse_write_actions() {
 # Arguments:
 #   $1 - repo slug (owner/repo)
 #   $2 - max issues to fetch (optional, default 100)
-# Returns: JSON array of issue objects (number, title, url, updatedAt, labels, assignees)
+# Returns: JSON array of issue objects (number, title, url, createdAt, updatedAt, labels, assignees)
 #######################################
 list_dispatchable_issue_candidates_json() {
 	local repo_slug="$1"
@@ -246,7 +246,7 @@ list_dispatchable_issue_candidates_json() {
 	local issue_json issue_dispatch_err gh_exit_code
 	issue_dispatch_err=$(mktemp)
 	gh_exit_code=0
-	issue_json=$(gh_issue_list --repo "$repo_slug" --state open --json number,title,url,assignees,labels,updatedAt --limit "$limit" 2>"$issue_dispatch_err") || gh_exit_code=$?
+	issue_json=$(gh_issue_list --repo "$repo_slug" --state open --json number,title,url,assignees,labels,createdAt,updatedAt --limit "$limit" 2>"$issue_dispatch_err") || gh_exit_code=$?
 	if [[ "$gh_exit_code" -ne 0 ]] || [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
 		local _issue_dispatch_err_msg
 		_issue_dispatch_err_msg=$(<"$issue_dispatch_err") || _issue_dispatch_err_msg="unknown error"
@@ -271,7 +271,7 @@ list_dispatchable_issue_candidates_json() {
 	if printf '%s' "$issue_json" | jq -e 'any(.[]; any(.labels[]?; .name == "status:blocked"))' >/dev/null 2>&1 &&
 		declare -F normalize_repo_dependency_readiness_if_due >/dev/null 2>&1; then
 		normalize_repo_dependency_readiness_if_due "$repo_slug" >/dev/null 2>&1 || true
-		issue_json=$(gh_issue_list --repo "$repo_slug" --state open --json number,title,url,assignees,labels,updatedAt --limit "$limit" 2>/dev/null) || issue_json='[]'
+		issue_json=$(gh_issue_list --repo "$repo_slug" --state open --json number,title,url,assignees,labels,createdAt,updatedAt --limit "$limit" 2>/dev/null) || issue_json='[]'
 		candidates_json=$(_filter_dispatchable_issue_candidates_json "$issue_json")
 	fi
 
@@ -318,6 +318,7 @@ _filter_dispatchable_issue_candidates_json() {
 				number,
 				title,
 				url,
+				createdAt,
 				updatedAt,
 				labels: $labels,
 				assignees: $assignees

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -14,6 +14,7 @@
 #
 # This orchestrator retains:
 #   - Module-level defaults
+#   - _route_terminal_breaker_to_consolidation
 #   - _issue_needs_consolidation (>100 lines — identity key preserved)
 #   - _dispatch_issue_consolidation (>100 lines — identity key preserved)
 #   - Source calls to the three sub-libraries
@@ -75,6 +76,33 @@ source "${SCRIPT_DIR}/pulse-triage-evaluation.sh"
 # shellcheck source=./pulse-triage-dispatch.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/pulse-triage-dispatch.sh"
+
+# Route exhausted retry breakers through the existing idempotent consolidation
+# workflow. This bridge deliberately adds no labels, comments, or child issues
+# itself: _dispatch_issue_consolidation owns resolution checks, child dedup,
+# cross-runner locking, request creation, and parent notification.
+# Args: issue number, repo slug, breaker source, optional diagnostic detail.
+_route_terminal_breaker_to_consolidation() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local breaker_source="$3"
+	local breaker_detail="${4:-}"
+
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+	[[ -n "$repo_slug" && -n "$breaker_source" ]] || return 1
+	if ! declare -F _dispatch_issue_consolidation >/dev/null 2>&1; then
+		echo "[pulse-wrapper] Terminal breaker consolidation deferred for #${issue_number} in ${repo_slug}: dispatcher unavailable" >>"$LOGFILE"
+		return 1
+	fi
+
+	echo "[pulse-wrapper] Routing terminal breaker to consolidation: #${issue_number} in ${repo_slug} source=${breaker_source} detail=${breaker_detail:-none}" >>"$LOGFILE"
+	if ! _dispatch_issue_consolidation "$issue_number" "$repo_slug" ""; then
+		echo "[pulse-wrapper] Terminal breaker consolidation failed for #${issue_number} in ${repo_slug} source=${breaker_source}" >>"$LOGFILE"
+		return 1
+	fi
+	echo "[pulse-wrapper] Terminal breaker consolidation created or reused for #${issue_number} in ${repo_slug} source=${breaker_source}" >>"$LOGFILE"
+	return 0
+}
 
 # --- Functions retained in orchestrator (>100 lines, identity key preserved) ---
 

--- a/.agents/scripts/pulse-wrapper-config.sh
+++ b/.agents/scripts/pulse-wrapper-config.sh
@@ -173,6 +173,8 @@ NO_WORK_WINDOW_MAX="${AIDEVOPS_NO_WORK_WINDOW_MAX:-${NO_WORK_WINDOW_MAX:-10}}"  
 PULSE_PREFETCH_FULL_SWEEP_INTERVAL="${PULSE_PREFETCH_FULL_SWEEP_INTERVAL:-14400}"                          # Full sweep interval in seconds (default 4h) (GH#15286, GH#18979: reduced from 24h to prevent stale-cache drift on active repos)
 PULSE_RUNNABLE_PR_LIMIT="${PULSE_RUNNABLE_PR_LIMIT:-200}"                                                  # Open PR sample size for runnable-candidate counting
 PULSE_RUNNABLE_ISSUE_LIMIT="${PULSE_RUNNABLE_ISSUE_LIMIT:-1000}"                                           # Open issue sample size for runnable-candidate counting
+PULSE_DISPATCH_AGE_BONUS_PER_DAY="${PULSE_DISPATCH_AGE_BONUS_PER_DAY:-25}"                                 # Fairness boost per full day an eligible issue has waited
+PULSE_DISPATCH_AGE_BONUS_CAP="${PULSE_DISPATCH_AGE_BONUS_CAP:-900}"                                        # Keep age below the 1000-point major priority step
 PULSE_QUEUED_SCAN_LIMIT="${PULSE_QUEUED_SCAN_LIMIT:-1000}"                                                 # Queued/in-progress scan window per repo
 UNDERFILL_RECYCLE_DEFICIT_MIN_PCT="${UNDERFILL_RECYCLE_DEFICIT_MIN_PCT:-25}"                               # Run worker recycler when underfill reaches this threshold
 UNDERFILL_RECYCLE_THROTTLE_SECS="${UNDERFILL_RECYCLE_THROTTLE_SECS:-300}"                                  # Min seconds between recycler runs when candidates are scarce (t1885)
@@ -287,6 +289,8 @@ PULSE_PREFETCH_PR_LIMIT=$(_validate_int PULSE_PREFETCH_PR_LIMIT "$PULSE_PREFETCH
 PULSE_PREFETCH_ISSUE_LIMIT=$(_validate_int PULSE_PREFETCH_ISSUE_LIMIT "$PULSE_PREFETCH_ISSUE_LIMIT" 200 1)
 PULSE_RUNNABLE_PR_LIMIT=$(_validate_int PULSE_RUNNABLE_PR_LIMIT "$PULSE_RUNNABLE_PR_LIMIT" 200 1)
 PULSE_RUNNABLE_ISSUE_LIMIT=$(_validate_int PULSE_RUNNABLE_ISSUE_LIMIT "$PULSE_RUNNABLE_ISSUE_LIMIT" 1000 1)
+PULSE_DISPATCH_AGE_BONUS_PER_DAY=$(_validate_int PULSE_DISPATCH_AGE_BONUS_PER_DAY "$PULSE_DISPATCH_AGE_BONUS_PER_DAY" 25 0)
+PULSE_DISPATCH_AGE_BONUS_CAP=$(_validate_int PULSE_DISPATCH_AGE_BONUS_CAP "$PULSE_DISPATCH_AGE_BONUS_CAP" 900 0)
 PULSE_QUEUED_SCAN_LIMIT=$(_validate_int PULSE_QUEUED_SCAN_LIMIT "$PULSE_QUEUED_SCAN_LIMIT" 1000 1)
 UNDERFILL_RECYCLE_DEFICIT_MIN_PCT=$(_validate_int UNDERFILL_RECYCLE_DEFICIT_MIN_PCT "$UNDERFILL_RECYCLE_DEFICIT_MIN_PCT" 25 1)
 if [[ "$UNDERFILL_RECYCLE_DEFICIT_MIN_PCT" -gt 100 ]]; then

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -841,6 +841,38 @@ test_single_bot_comment_does_not_trigger_consolidation() {
 	return 0
 }
 
+# GH#27853: terminal retry breakers must delegate to the existing dispatcher
+# rather than creating labels, comments, or child issues through a parallel
+# path. Existing child/lock tests above provide the idempotency coverage.
+test_terminal_breaker_bridge_delegates_to_dispatcher() {
+	setup_gh_stub
+	GH_ISSUE_VIEW_TITLE="test: terminal breaker parent"
+	GH_ISSUE_VIEW_BODY="Original terminal breaker parent body."
+	GH_ISSUE_VIEW_LABELS="bug,tier:standard,needs-maintainer-review"
+	GH_API_COMMENTS_JSON="[]"
+	GH_ISSUE_LIST_CHILD_JSON="[]"
+	GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	GH_PR_LIST_RESOLVING_JSON="[]"
+	GH_ISSUE_CREATE_URL="https://github.com/owner/repo/issues/9002"
+	export GH_ISSUE_VIEW_TITLE GH_ISSUE_VIEW_BODY GH_ISSUE_VIEW_LABELS
+	export GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON
+	export GH_PR_LIST_RESOLVING_JSON GH_ISSUE_CREATE_URL
+
+	local rc=0
+	_route_terminal_breaker_to_consolidation \
+		123 "owner/repo" "fast-fail-hard-stop" "reason=runtime" || rc=$?
+
+	if [[ "$rc" -eq 0 ]] && grep -q 'issue create' "$GH_LOG" 2>/dev/null; then
+		print_result "GH#27853: terminal breaker bridge delegates to idempotent dispatcher" 0
+	else
+		print_result "GH#27853: terminal breaker bridge delegates to idempotent dispatcher" 1 \
+			"rc=${rc}; expected gh issue create through _dispatch_issue_consolidation"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
 # t2161 A2 regression: _dispatch_issue_consolidation must short-circuit
 # when an in-flight PR resolves the parent — even when no consolidation
 # child exists yet. Covers the path where _backfill_stale_consolidation_labels
@@ -893,6 +925,7 @@ main() {
 
 	# t2152 regression (GH#19415): single bot comment must not trigger
 	test_single_bot_comment_does_not_trigger_consolidation
+	test_terminal_breaker_bridge_delegates_to_dispatcher
 
 	# t2161 regression suite
 	test_resolving_pr_helper_detects_closing_keyword

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
@@ -68,6 +68,14 @@ if [[ "$cmd" == "is-assigned" ]]; then
 		printf '%s\n' 'STALE_BLOCKED_BY_DEPENDENCY: issue #2905 in exampleorg/examplerepo - unassigned runner but kept status:blocked due to unresolved blocked-by (no_work)'
 		exit 1
 		;;
+	terminal)
+		printf '%s\n' 'STALE_ESCALATED: issue #2905 in exampleorg/examplerepo — unassigned runner, applied needs-maintainer-review'
+		exit 1
+		;;
+	terminal_pr)
+		printf '%s\n' 'STALE_PR_ESCALATED: issue #2905 in exampleorg/examplerepo — PR #456 preserved, applied needs-maintainer-review'
+		exit 1
+		;;
 	*)
 		printf '%s\n' 'ASSIGNED: issue #2905 in exampleorg/examplerepo is assigned to runner'
 		exit 0
@@ -90,12 +98,26 @@ source "${SCRIPTS_DIR}/pulse-dispatch-dedup-layers.sh"
 FAST_FAIL_CALLS=0
 LAST_FAST_FAIL=""
 CLASSIFY_LOG="${TMP_DIR}/classify.log"
+CONSOLIDATION_CALLS=0
+LAST_CONSOLIDATION=""
 
 reset_observations() {
 	FAST_FAIL_CALLS=0
 	LAST_FAST_FAIL=""
+	CONSOLIDATION_CALLS=0
+	LAST_CONSOLIDATION=""
 	: >"$LOGFILE"
 	: >"$CLASSIFY_LOG"
+	return 0
+}
+
+_route_terminal_breaker_to_consolidation() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local breaker_source="$3"
+	local breaker_detail="${4:-}"
+	CONSOLIDATION_CALLS=$((CONSOLIDATION_CALLS + 1))
+	LAST_CONSOLIDATION="${issue_number}|${repo_slug}|${breaker_source}|${breaker_detail}"
 	return 0
 }
 
@@ -219,10 +241,50 @@ test_stale_recovery_blocked_by_dependency_blocks_redispatch() {
 	return 0
 }
 
+test_terminal_stale_recovery_routes_consolidation_and_blocks() {
+	export TEST_STALE_MODE="terminal"
+	reset_observations
+	local rc=0
+	_dedup_layer6_assignee_and_stale "2905" "exampleorg/examplerepo" "runner" || rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		fail "terminal stale recovery blocks redispatch" "expected rc=0, got rc=${rc}"
+		return 0
+	fi
+	if [[ "$CONSOLIDATION_CALLS" -ne 1 || "$LAST_CONSOLIDATION" != 2905\|exampleorg/examplerepo\|stale-recovery-threshold\|STALE_ESCALATED:* ]]; then
+		fail "terminal stale recovery routes consolidation once" \
+			"calls=${CONSOLIDATION_CALLS} payload=${LAST_CONSOLIDATION}"
+		return 0
+	fi
+	pass "terminal stale recovery routes consolidation once and blocks redispatch"
+	return 0
+}
+
+test_terminal_pr_checkpoint_routes_existing_consolidation_guard() {
+	export TEST_STALE_MODE="terminal_pr"
+	reset_observations
+	local rc=0
+	_dedup_layer6_assignee_and_stale "2905" "exampleorg/examplerepo" "runner" || rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		fail "terminal PR checkpoint blocks redispatch" "expected rc=0, got rc=${rc}"
+		return 0
+	fi
+	if [[ "$CONSOLIDATION_CALLS" -ne 1 || "$LAST_CONSOLIDATION" != 2905\|exampleorg/examplerepo\|stale-pr-checkpoint\|STALE_PR_ESCALATED:* ]]; then
+		fail "terminal PR checkpoint routes existing consolidation guard" \
+			"calls=${CONSOLIDATION_CALLS} payload=${LAST_CONSOLIDATION}"
+		return 0
+	fi
+	pass "terminal PR checkpoint routes consolidation guard and blocks redispatch"
+	return 0
+}
+
 test_stale_recovery_without_claim_skips_fast_fail
 test_prelaunch_canary_stale_recovery_skips_fast_fail
 test_stale_recovery_with_dispatch_claim_records_fast_fail
 test_stale_recovery_blocked_by_dependency_blocks_redispatch
+test_terminal_stale_recovery_routes_consolidation_and_blocks
+test_terminal_pr_checkpoint_routes_existing_consolidation_guard
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1

--- a/.agents/scripts/tests/test-fast-fail-age-out.sh
+++ b/.agents/scripts/tests/test-fast-fail-age-out.sh
@@ -14,15 +14,20 @@
 #   CI flakes). Manual recovery required touching the counter file — operators
 #   rarely do this, leaving issues permanently stuck.
 #
-# Tests (8):
+# Assertions (13):
 #   1. HARD STOP + age > 24h → counter reset to 0
 #   2. HARD STOP + age < 24h → NOT reset (quiet-period guard)
 #   3. count < HARD STOP (below threshold) → NOT affected
 #   4. After reset, fast_fail_is_skipped returns 1 (safe to dispatch)
 #   5. reset_count increments on each age-out
-#   6. After FAST_FAIL_AGE_OUT_MAX_RESETS resets, NMR label applied (not reset again)
-#   7. Issue comment posted once per age-out event
-#   8. Infra/no_work hard stops use FAST_FAIL_INFRA_AGE_OUT_SECONDS
+#   6. After FAST_FAIL_AGE_OUT_MAX_RESETS, the counter is not reset
+#   7. After FAST_FAIL_AGE_OUT_MAX_RESETS, NMR is applied
+#   8. Exhausted age-out retries route to consolidation
+#   9. Issue comment posted once per age-out event
+#  10. Infra/no_work hard stops use FAST_FAIL_INFRA_AGE_OUT_SECONDS
+#  11. Non-rate-limit threshold crossing routes consolidation exactly once
+#  12. Hard-stop checks reuse the persisted consolidation handoff marker
+#  13. Rate-limit hard stops do not consolidate issue scope
 #
 # Stub strategy:
 #   - Set FAST_FAIL_STATE_FILE to a tmpdir path so tests are hermetic.
@@ -115,6 +120,18 @@ escalate_issue_tier() {
 	return 0
 }
 export -f escalate_issue_tier
+
+CONSOLIDATION_CALLS=0
+LAST_CONSOLIDATION=""
+_route_terminal_breaker_to_consolidation() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local breaker_source="$3"
+	local breaker_detail="${4:-}"
+	CONSOLIDATION_CALLS=$((CONSOLIDATION_CALLS + 1))
+	LAST_CONSOLIDATION="${issue_number}|${repo_slug}|${breaker_source}|${breaker_detail}"
+	return 0
+}
 
 # Source fast-fail module (include guard prevents double-source)
 # shellcheck source=../pulse-fast-fail.sh
@@ -228,6 +245,8 @@ fi
 : >"$GH_CALLS"
 # reset_count=3 means this would be the 4th reset (> max=3), so NMR fires.
 _write_ff_entry "105" "6" "20" "3"
+CONSOLIDATION_CALLS=0
+LAST_CONSOLIDATION=""
 
 fast_fail_age_out "105" "test/repo" 2>/dev/null || true
 
@@ -247,6 +266,13 @@ if printf '%s' "$gh_calls_content" | grep -q "needs-maintainer-review"; then
 else
 	fail "after MAX_RESETS exceeded → needs-maintainer-review label applied" \
 		"expected 'needs-maintainer-review' in gh calls: ${gh_calls_content}"
+fi
+
+if [[ "$CONSOLIDATION_CALLS" -eq 1 && "$LAST_CONSOLIDATION" == "105|test/repo|fast-fail-age-out-ceiling|maximum automatic resets exhausted" ]]; then
+	pass "after MAX_RESETS exceeded → terminal outcome routes to consolidation"
+else
+	fail "after MAX_RESETS exceeded → terminal outcome routes to consolidation" \
+		"calls=${CONSOLIDATION_CALLS} payload=${LAST_CONSOLIDATION}"
 fi
 
 # =============================================================================
@@ -280,6 +306,54 @@ if [[ "$result_count" == "0" ]]; then
 else
 	fail "infra/no_work HARD STOP uses shorter age-out threshold" \
 		"expected count=0, got count=${result_count}"
+fi
+
+# =============================================================================
+# Assertions 11-13 — terminal fast-fail consolidation routing and dedup
+# =============================================================================
+export FAST_FAIL_SKIP_THRESHOLD=2
+export FAST_FAIL_AGE_OUT_MIN_COUNT=2
+CONSOLIDATION_CALLS=0
+LAST_CONSOLIDATION=""
+printf '{}\n' >"$FAST_FAIL_STATE_FILE"
+
+fast_fail_record "108" "test/repo" "runtime" 2>/dev/null || true
+fast_fail_record "108" "test/repo" "runtime" 2>/dev/null || true
+
+route_marker=$(jq -r '."test/repo/108".terminal_consolidation_routed // false' "$FAST_FAIL_STATE_FILE" 2>/dev/null) || route_marker=false
+if [[ "$CONSOLIDATION_CALLS" -eq 1 && "$LAST_CONSOLIDATION" == "108|test/repo|fast-fail-hard-stop|reason=runtime" && "$route_marker" == "true" ]]; then
+	pass "non-rate-limit threshold crossing routes consolidation exactly once"
+else
+	fail "non-rate-limit threshold crossing routes consolidation exactly once" \
+		"calls=${CONSOLIDATION_CALLS} payload=${LAST_CONSOLIDATION} marker=${route_marker}"
+fi
+
+skip_rc=0
+fast_fail_is_skipped "108" "test/repo" 2>/dev/null || skip_rc=$?
+if [[ "$skip_rc" -eq 0 && "$CONSOLIDATION_CALLS" -eq 1 ]]; then
+	pass "hard-stop check reuses persisted consolidation handoff marker"
+else
+	fail "hard-stop check reuses persisted consolidation handoff marker" \
+		"skip_rc=${skip_rc} calls=${CONSOLIDATION_CALLS}"
+fi
+
+CONSOLIDATION_CALLS=0
+LAST_CONSOLIDATION=""
+printf '{}\n' >"$FAST_FAIL_STATE_FILE"
+_ff_query_pool_retry_seconds() {
+	local provider="$1"
+	: "$provider"
+	printf '%s' '-1'
+	return 0
+}
+fast_fail_record "109" "test/repo" "rate_limit" 2>/dev/null || true
+fast_fail_record "109" "test/repo" "rate_limit" 2>/dev/null || true
+fast_fail_is_skipped "109" "test/repo" 2>/dev/null || true
+if [[ "$CONSOLIDATION_CALLS" -eq 0 ]]; then
+	pass "rate-limit hard stop does not consolidate issue scope"
+else
+	fail "rate-limit hard stop does not consolidate issue scope" \
+		"calls=${CONSOLIDATION_CALLS} payload=${LAST_CONSOLIDATION}"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -128,11 +128,11 @@ while [[ $# -gt 0 ]]; do
 done
 if [[ "$since" == "1h" ]]; then
   cat <<'JSON'
-{"window":{"since":"1h"},"metrics":{"total":0,"succeeded":0,"result_counts":{},"diagnostic_focus":{},"timing_ms":{"samples":0,"avg":0,"max":0},"recent_examples":[{"repo_slug":"private/repo-one"}],"failure_groups":[],"failure_families":[]},"pulse_stats":{}}
+{"window":{"since":"1h"},"metrics":{"total":0,"runtime_handoffs":0,"succeeded":null,"result_counts":{},"diagnostic_focus":{},"timing_ms":{"samples":0,"avg":0,"max":0},"recent_examples":[{"repo_slug":"private/repo-one"}],"failure_groups":[],"failure_families":[]},"pulse_stats":{},"delivery_stages":{"pr_opened":null,"pr_merged":null,"issue_solved":null,"delivered_successes":null,"check_state":"skipped"}}
 JSON
 else
   cat <<'JSON'
-{"window":{"since":"24h"},"metrics":{"total":20,"terminal_session_total":10,"succeeded":9,"result_counts":{"success":9,"blocked":1},"diagnostic_focus":{},"timing_ms":{"samples":10,"avg":1000,"max":2000},"recent_examples":[{"repo_slug":"private/repo-one"}],"failure_groups":[],"failure_families":[]},"pulse_stats":{}}
+{"window":{"since":"24h"},"metrics":{"total":20,"terminal_session_total":10,"runtime_handoffs":9,"succeeded":null,"result_counts":{"success":9,"blocked":1},"diagnostic_focus":{},"timing_ms":{"samples":10,"avg":1000,"max":2000},"recent_examples":[{"repo_slug":"private/repo-one"}],"failure_groups":[],"failure_families":[]},"pulse_stats":{},"delivery_stages":{"pr_opened":null,"pr_merged":null,"issue_solved":null,"delivered_successes":null,"check_state":"skipped"}}
 JSON
 fi
 SH
@@ -240,8 +240,10 @@ JSON_PRIVATE_COUNT=$(printf '%s' "$JSON_OUT" | grep -c "private/repo-one" 2>/dev
 assert_eq "json output removes raw worker examples" "0" "$JSON_PRIVATE_COUNT"
 ACTIVE_SOURCE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.active_workers_source')
 assert_eq "json uses process scan when available" "process_scan" "$ACTIVE_SOURCE"
+HANDOFF_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_runtime_handoff_rate')
+assert_eq "json runtime handoff rate uses terminal session denominator" "90" "$HANDOFF_RATE"
 SUCCESS_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_success_rate')
-assert_eq "json success rate uses terminal session denominator" "90" "$SUCCESS_RATE"
+assert_eq "json delivered success rate is unknown without GitHub delivery check" "null" "$SUCCESS_RATE"
 
 cat >"${TEST_ROOT}/current-state-active.sh" <<'SH'
 #!/usr/bin/env bash

--- a/.agents/scripts/tests/test-pulse-merge-first-nonblocking.sh
+++ b/.agents/scripts/tests/test-pulse-merge-first-nonblocking.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#27853: merge-first must start before dispatch
+# without making pulse preflight wait for the merge routine.
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PREFLIGHT_LIB="${TEST_SCRIPT_DIR}/../pulse-dispatch-preflight-lib.sh"
+DISPATCH_ENGINE="${TEST_SCRIPT_DIR}/../pulse-dispatch-engine.sh"
+TEST_DIR=""
+
+cleanup() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message"
+	exit 1
+}
+
+main() {
+	TEST_DIR=$(mktemp -d)
+	trap cleanup EXIT
+	local stub_dir="${TEST_DIR}/scripts"
+	local marker="${TEST_DIR}/merge-first.marker"
+	local merge_first_line early_dispatch_line
+	mkdir -p "$stub_dir" "${TEST_DIR}/home/.aidevops/logs"
+
+	merge_first_line=$(grep -n '^[[:space:]]*_preflight_start_merge_first' "$DISPATCH_ENGINE" | cut -d: -f1)
+	early_dispatch_line=$(grep -n '^[[:space:]]*_preflight_early_dispatch' "$DISPATCH_ENGINE" | cut -d: -f1)
+	[[ -n "$merge_first_line" ]] || fail "dispatch engine does not call merge-first"
+	[[ -n "$early_dispatch_line" ]] || fail "dispatch engine does not call early dispatch"
+	if [[ "$merge_first_line" -ge "$early_dispatch_line" ]]; then
+		fail "dispatch engine starts merge-first after early dispatch"
+	fi
+
+	cat >"${stub_dir}/pulse-merge-routine.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'started:%s\n' "$*" >"${PULSE_MERGE_FIRST_TEST_MARKER}"
+sleep 5
+printf 'finished:%s\n' "$*" >>"${PULSE_MERGE_FIRST_TEST_MARKER}"
+exit 0
+STUB
+	chmod +x "${stub_dir}/pulse-merge-routine.sh"
+
+	local start elapsed
+	start=$(date +%s)
+	(
+		export HOME="${TEST_DIR}/home"
+		export PULSE_MERGE_FIRST_TEST_MARKER="$marker"
+		SCRIPT_DIR="$stub_dir"
+		LOGFILE="${TEST_DIR}/pulse.log"
+		# shellcheck source=../pulse-dispatch-preflight-lib.sh
+		source "$PREFLIGHT_LIB"
+		_preflight_start_merge_first
+	)
+	elapsed=$(($(date +%s) - start))
+
+	if [[ "$elapsed" -ge 3 ]]; then
+		fail "merge-first kick blocked preflight for ${elapsed}s"
+	fi
+
+	local attempt
+	for attempt in 1 2 3 4 5; do
+		[[ -f "$marker" ]] && break
+		sleep 0.2
+	done
+	[[ -f "$marker" ]] || fail "standalone merge routine was not launched"
+	if [[ "$(<"$marker")" != started:run* ]]; then
+		fail "merge routine did not receive the run subcommand"
+	fi
+
+	rm -f "$marker"
+	(
+		export HOME="${TEST_DIR}/home"
+		export PULSE_MERGE_FIRST_TEST_MARKER="$marker"
+		SCRIPT_DIR="$stub_dir"
+		LOGFILE="${TEST_DIR}/pulse-disabled.log"
+		AIDEVOPS_PULSE_ASYNC_MERGE_FIRST=0
+		# shellcheck source=../pulse-dispatch-preflight-lib.sh
+		source "$PREFLIGHT_LIB"
+		_preflight_start_merge_first
+	)
+	sleep 0.2
+	[[ ! -f "$marker" ]] || fail "disabled merge-first kick still launched the routine"
+
+	printf 'PASS: merge-first starts asynchronously before dispatch and honours rollback flag\n'
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-merge-first-nonblocking.sh
+++ b/.agents/scripts/tests/test-pulse-merge-first-nonblocking.sh
@@ -32,8 +32,8 @@ main() {
 	local merge_first_line early_dispatch_line
 	mkdir -p "$stub_dir" "${TEST_DIR}/home/.aidevops/logs"
 
-	merge_first_line=$(grep -n '^[[:space:]]*_preflight_start_merge_first' "$DISPATCH_ENGINE" | cut -d: -f1)
-	early_dispatch_line=$(grep -n '^[[:space:]]*_preflight_early_dispatch' "$DISPATCH_ENGINE" | cut -d: -f1)
+	merge_first_line=$(grep -n '^[[:space:]]*_preflight_start_merge_first' "$DISPATCH_ENGINE" | cut -d: -f1 || printf '')
+	early_dispatch_line=$(grep -n '^[[:space:]]*_preflight_early_dispatch' "$DISPATCH_ENGINE" | cut -d: -f1 || printf '')
 	[[ -n "$merge_first_line" ]] || fail "dispatch engine does not call merge-first"
 	[[ -n "$early_dispatch_line" ]] || fail "dispatch engine does not call early dispatch"
 	if [[ "$merge_first_line" -ge "$early_dispatch_line" ]]; then

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -1010,6 +1010,60 @@ JSON
 	return 0
 }
 
+test_build_ranked_dispatch_candidates_json_applies_capped_age_bonus() {
+	local original_repos_json="$REPOS_JSON"
+	local original_age_bonus_per_day="$PULSE_DISPATCH_AGE_BONUS_PER_DAY"
+	local original_age_bonus_cap="$PULSE_DISPATCH_AGE_BONUS_CAP"
+	cat >"${REPOS_JSON}" <<'JSON'
+{
+  "initialized_repos": [
+    {
+      "slug": "marcusquinn/aidevops",
+      "path": "/tmp/aidevops",
+      "pulse": true,
+      "priority": "tooling",
+      "maintainer": "marcusquinn"
+    }
+  ]
+}
+JSON
+
+	gh_issue_list() {
+		if [[ "${1:-}" == "--repo" && "${2:-}" == "marcusquinn/aidevops" ]]; then
+			printf '%s\n' '[
+			  {"number":9303,"title":"old later update","url":"#9303","createdAt":"2020-01-01T00:00:00Z","updatedAt":"2026-03-31T00:02:00Z","assignees":[],"labels":[{"name":"bug"}]},
+			  {"number":9304,"title":"future issue","url":"#9304","createdAt":"2099-01-01T00:00:00Z","updatedAt":"2026-03-31T00:00:00Z","assignees":[],"labels":[{"name":"bug"}]},
+			  {"number":9305,"title":"old earlier update","url":"#9305","createdAt":"2020-01-01T00:00:00Z","updatedAt":"2026-03-31T00:01:00Z","assignees":[],"labels":[{"name":"bug"}]},
+			  {"number":9306,"title":"slightly newer capped issue","url":"#9306","createdAt":"2021-01-01T00:00:00Z","updatedAt":"2026-03-31T00:00:00Z","assignees":[],"labels":[{"name":"bug"}]}
+			]'
+			return 0
+		fi
+		return 1
+	}
+	export -f gh_issue_list
+	PULSE_DISPATCH_AGE_BONUS_PER_DAY=10
+	PULSE_DISPATCH_AGE_BONUS_CAP=100
+
+	local ranked_json ordered_numbers age_bonuses
+	ranked_json=$(build_ranked_dispatch_candidates_json 20)
+	ordered_numbers=$(printf '%s' "$ranked_json" | jq -r '.[].number' 2>/dev/null || true)
+	age_bonuses=$(printf '%s' "$ranked_json" | jq -r '[.[] | {key: (.number | tostring), value: .age_bonus}] | from_entries | [."9303", ."9304", ."9305", ."9306"] | join(",")' 2>/dev/null || true)
+
+	unset -f gh_issue_list
+	REPOS_JSON="$original_repos_json"
+	PULSE_DISPATCH_AGE_BONUS_PER_DAY="$original_age_bonus_per_day"
+	PULSE_DISPATCH_AGE_BONUS_CAP="$original_age_bonus_cap"
+
+	if [[ "$ordered_numbers" == $'9305\n9303\n9306\n9304' && "$age_bonuses" == "100,0,100,100" ]]; then
+		print_result "build_ranked_dispatch_candidates_json caps age bonus and uses creation/update tie-breaks" 0
+		return 0
+	fi
+
+	print_result "build_ranked_dispatch_candidates_json caps age bonus and uses creation/update tie-breaks" 1 \
+		"Unexpected order/bonuses: order=${ordered_numbers//$'\n'/,} bonuses=${age_bonuses}"
+	return 0
+}
+
 test_dispatch_max_dispatches_up_to_capacity() {
 	local dispatch_log="${TEST_ROOT}/deterministic-dispatch.log"
 	: >"$dispatch_log"
@@ -1413,6 +1467,7 @@ main() {
 	test_build_ranked_dispatch_candidates_json_respects_priority_labels
 	test_build_ranked_dispatch_candidates_json_prioritizes_security_quality_debt
 	test_build_ranked_dispatch_candidates_json_excludes_pull_requests
+	test_build_ranked_dispatch_candidates_json_applies_capped_age_bonus
 	test_build_ranked_dispatch_candidates_json_respects_schedule_gate
 	test_build_ranked_dispatch_candidates_json_accepts_array_pulse_hours
 	test_dispatch_max_dispatches_up_to_capacity

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -247,7 +247,9 @@ assert_eq "2c: raw event total remains backward compatible" "18" "$(printf '%s' 
 assert_eq "2c2: terminal session outcomes = 13" "13" "$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
 assert_eq "2c2b: event_total aliases raw total" "18" "$(printf '%s' "$JSON" | jq -r '.metrics.event_total')"
 assert_eq "2c3: continuation events = 4" "4" "$(printf '%s' "$JSON" | jq -r '.metrics.continuation_events')"
-assert_eq "2d: succeeded = 5" "5" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
+assert_eq "2d: runtime handoffs = 5" "5" "$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
+assert_eq "2d2: delivered success is unknown when GitHub check is skipped" "null" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
 assert_eq "2e: watchdog_killed = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
 assert_eq "2f: watchdog_continued = 2 (incl. nonzero-exit heartbeat)" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
@@ -307,6 +309,8 @@ assert_eq "2m: pr count is null when skipped" "null" \
 	"$(printf '%s' "$JSON" | jq -r '.worker_solved_issues.count')"
 assert_eq "2n: pr check_state = skipped" "skipped" \
 	"$(printf '%s' "$JSON" | jq -r '.worker_solved_issues.check_state')"
+assert_eq "2n2: delivery stages are explicitly skipped" "skipped" \
+	"$(printf '%s' "$JSON" | jq -r '.delivery_stages.check_state')"
 assert_eq "2o: blocker events obey the 24h window" "3" \
 	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.event_total')"
 assert_eq "2p: unresolved old blocker remains active until cleared" "2" \
@@ -327,7 +331,7 @@ JSON=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 1h --no-pr-check --json 2>&
 # continuation-only and therefore excluded from the outcome denominator.
 assert_eq "3a: 1h raw total = 4" "4" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
 assert_eq "3a2: 1h terminal total = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
-assert_eq "3b: 1h succeeded = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
+assert_eq "3b: 1h runtime handoffs = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
 assert_eq "3c: 1h watchdog_continued = 1" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
 assert_eq "3d: 1h watchdog_killed = 0" "0" \
@@ -367,7 +371,7 @@ OUT=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 24h --no-pr-check 2>&1)
 assert_contains "5a: human output names canonical jsonl source" \
 	"headless-runtime-metrics.jsonl" "$OUT"
 assert_contains "5b: human output names pulse-stats" "pulse-stats.json" "$OUT"
-assert_contains "5c: human output shows succeeded count" "Succeeded:                   5" "$OUT"
+assert_contains "5c: human output shows runtime handoff count" "Runtime handoffs:            5" "$OUT"
 assert_contains "5d: human output shows watchdog continued is heartbeat" \
 	"heartbeat" "$OUT"
 assert_contains "5d2: human output shows service interruption resumes" \
@@ -397,6 +401,8 @@ assert_eq "6c: openai capacity_slots uses redacted multiplier" "48" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.account_pool[] | select(.provider == "openai") | .capacity_slots')"
 assert_eq "6c2: provider diagnostics retain raw duplicate/attempt evidence" "7" \
 	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.provider_model_usage[] | select(.provider == "openai" and .model == "openai/gpt-5.5") | .other_failure')"
+assert_eq "6c2b: provider diagnostics name runtime handoffs without calling them success" "0" \
+	"$(printf '%s' "$JSON" | jq -r '.provider_diagnostics.provider_model_usage[] | select(.provider == "openai" and .model == "openai/gpt-5.5") | .runtime_handoffs')"
 
 JSONC_DEFAULTS="$FIXTURE_DIR/aidevops.defaults.jsonc"
 JSONC_USER="$FIXTURE_DIR/config.jsonc"
@@ -418,12 +424,13 @@ assert_eq "6c4: config multiplier overrides defaults" "14" \
 
 OUT=$(env "${RUN_ENV[@]}" "$HELPER" providers --since 24h 2>&1)
 assert_contains "6d: human provider output shows capacity slots" "capacity_slots=48" "$OUT"
+assert_contains "6e: human provider output names runtime handoffs" "runtime_handoffs=" "$OUT"
 
 # ---------------------------------------------------------------------------
-# Section 7: solved:worker attribution query excludes origin-only PR counts.
+# Section 7: runtime handoff and GitHub delivery stages remain distinct.
 # ---------------------------------------------------------------------------
 echo
-echo "--- Section 7: solved-by attribution query ---"
+echo "--- Section 7: delivery-stage attribution queries ---"
 
 GH_STUB_DIR="$FIXTURE_DIR/bin"
 mkdir -p "$GH_STUB_DIR"
@@ -431,6 +438,14 @@ GH_CALL_LOG="$FIXTURE_DIR/gh-calls.log"
 cat >"$GH_STUB_DIR/gh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"${GH_CALL_LOG}"
+if [[ "$1" == "pr" && "$2" == "list" && " $* " == *" --state merged "* ]]; then
+	printf '[{"number":201},{"number":202}]\n'
+	exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+	printf '[{"number":201},{"number":202},{"number":203}]\n'
+	exit 0
+fi
 if [[ "$1" == "issue" && "$2" == "list" ]]; then
 	printf '[{"number":101},{"number":102}]\n'
 	exit 0
@@ -443,18 +458,31 @@ JSON=$(env "${RUN_ENV[@]}" "GH_CALL_LOG=$GH_CALL_LOG" "PATH=$GH_STUB_DIR:$PATH" 
 	"$HELPER" summary --since 24h --repo marcusquinn/aidevops --pr-check --json 2>&1)
 RC=$?
 assert_rc "7a: solved attribution query exits 0" 0 "$RC"
-assert_eq "7b: solved worker issue count = 2" "2" \
-	"$(printf '%s' "$JSON" | jq -r '.worker_solved_issues.count')"
-assert_contains "7c: gh query uses solved:worker label" "label:solved:worker" \
+assert_eq "7b: worker PR opened count = 3" "3" \
+	"$(printf '%s' "$JSON" | jq -r '.delivery_stages.pr_opened')"
+assert_eq "7c: worker PR merged count = 2" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.delivery_stages.pr_merged')"
+assert_eq "7d: solved worker issue count = 2" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.delivery_stages.issue_solved')"
+assert_eq "7e: delivered success uses solved closed issues" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.delivery_stages.delivered_successes')"
+assert_eq "7f: metrics succeeded means delivered success" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
+assert_eq "7g: runtime handoffs remain distinct from delivery" "5" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
+assert_contains "7h: issue query uses solved:worker label" "label:solved:worker" \
 	"$(<"$GH_CALL_LOG")"
-if grep -q "label:origin:worker" "$GH_CALL_LOG" 2>/dev/null; then
-	TESTS_RUN=$((TESTS_RUN + 1))
-	TESTS_FAILED=$((TESTS_FAILED + 1))
-	echo "${TEST_RED}FAIL${TEST_NC}: 7d: query must not use origin:worker"
-else
-	TESTS_RUN=$((TESTS_RUN + 1))
-	echo "${TEST_GREEN}PASS${TEST_NC}: 7d: query does not use origin:worker"
-fi
+assert_contains "7i: PR queries use origin:worker attribution" "label:origin:worker" \
+	"$(<"$GH_CALL_LOG")"
+assert_eq "7j: delivery check performs three stage queries" "3" \
+	"$(wc -l <"$GH_CALL_LOG" | tr -d ' ')"
+
+JSON=$(env "${RUN_ENV[@]}" "GH_CALL_LOG=$GH_CALL_LOG" "PATH=$GH_STUB_DIR:$PATH" \
+	"$HELPER" summary --since 24h --repo marcusquinn/aidevops --pr-check --json 2>&1)
+assert_eq "7k: combined delivery-stage cache prevents repeated GitHub queries" "3" \
+	"$(wc -l <"$GH_CALL_LOG" | tr -d ' ')"
+assert_eq "7l: cached delivery stages preserve delivered success" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.delivery_stages.delivered_successes')"
 
 # ---------------------------------------------------------------------------
 # Summary.

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -50,6 +50,9 @@ WAH_PR_CACHE_TTL="${WAH_PR_CACHE_TTL:-60}" # seconds
 WAH_SERVICE_INTERRUPTION_RESULT="service_interruption_continue"
 WAH_RESULT_WATCHDOG_STALL_KILLED="watchdog_stall_killed"
 WAH_RESULT_LOCAL_KILL="local_kill"
+WAH_RESULT_RATE_LIMIT="rate_limit"
+WAH_DELIVERY_FAILED="failed"
+WAH_JSON_NULL="null"
 WAH_FAILURE_FAMILY_FILTER="${SCRIPT_DIR}/worker-activity-failure-families.jq"
 
 # Shared jq definitions keep terminal-session semantics identical in the scalar
@@ -146,9 +149,10 @@ _wah_aggregate_metrics() {
 	#          heartbeats even when their exit_code
 	#          is nonzero)
 	# Fail-open to zeros if jq fails (stale/corrupt jsonl).
-	local result service_result watchdog_killed_result
+	local result service_result watchdog_killed_result rate_limit_result
 	service_result="$WAH_SERVICE_INTERRUPTION_RESULT"
 	watchdog_killed_result="$WAH_RESULT_WATCHDOG_STALL_KILLED"
+	rate_limit_result="$WAH_RESULT_RATE_LIMIT"
 	local jq_program
 	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
 	jq_program=$WAH_SESSION_OUTCOME_JQ'
@@ -160,17 +164,17 @@ _wah_aggregate_metrics() {
 			wk:     ([$w[] | select(.result == $watchdog_killed_result)] | length),
 			wc:     ([$events[] | select(.result == "watchdog_stall_continue")] | length),
 			sic:    ([$events[] | select(.result == $service_result)] | length),
-			rl:     ([$w[] | select(.result == "rate_limit")] | length),
+			rl:     ([$w[] | select(.result == $rate_limit_result)] | length),
 			of:     ([$w[] | select(
 				(.result != "success" or .exit_code != 0)
 				and .result != $watchdog_killed_result
 				and .result != "watchdog_stall_continue"
 				and .result != $service_result
-				and .result != "rate_limit"
+				and .result != $rate_limit_result
 			)] | length)
 		} | "\(.total) \(.terminal) \(.succ) \(.wk) \(.wc) \(.sic) \(.rl) \(.of)"
 	'
-	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" "$jq_program" <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0 0"
+	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" --arg rate_limit_result "$rate_limit_result" "$jq_program" <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0 0"
 
 	[[ -n "$result" ]] || result="0 0 0 0 0 0 0 0"
 	printf '%s\n' "$result"
@@ -340,7 +344,7 @@ _wah_provider_usage_json() {
 	((account_multiplier < 1)) && account_multiplier=1
 
 	if [[ -f "$pool" ]]; then
-		jq -rn --slurpfile pool "$pool" --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson account_multiplier "$account_multiplier" --arg status_empty '' --arg status_auth_error 'auth-error' --arg status_rate_limited 'rate-limited' --arg status_active 'active' --arg status_idle 'idle' '
+		jq -rn --slurpfile pool "$pool" --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson account_multiplier "$account_multiplier" --arg rate_limit_result "$WAH_RESULT_RATE_LIMIT" --arg status_empty '' --arg status_auth_error 'auth-error' --arg status_rate_limited 'rate-limited' --arg status_active 'active' --arg status_idle 'idle' '
 			def account_status: .status // $status_empty;
 			def available_account:
 				(account_status) as $status
@@ -360,8 +364,8 @@ _wah_provider_usage_json() {
 						model: (.[0].model // "unknown"),
 						count: length,
 						runtime_handoffs: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length),
-						rate_limited: (map(select(.result == "rate_limit" or .provider_error_type == "rate_limit" or .provider_status == "429")) | length),
-						other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and .result != "rate_limit" and .provider_error_type != "rate_limit" and .provider_status != "429")) | length),
+						rate_limited: (map(select(.result == $rate_limit_result or .provider_error_type == $rate_limit_result or .provider_status == "429")) | length),
+						other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and .result != $rate_limit_result and .provider_error_type != $rate_limit_result and .provider_status != "429")) | length),
 						latest_ts: (map(.ts // 0) | max)
 					})
 					| sort_by(.count, .latest_ts) | reverse | .[0:12]
@@ -388,10 +392,10 @@ _wah_provider_usage_json() {
 				)
 			}' <"$input_file" 2>/dev/null || printf '{"provider_model_usage":[],"recent_events":[],"account_pool":[]}'
 	else
-		jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" '
+		jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg rate_limit_result "$WAH_RESULT_RATE_LIMIT" '
 			[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
 			| {
-				provider_model_usage: ($w | group_by([.provider // "unknown", .model // "unknown"]) | map({provider: (.[0].provider // "unknown"), model: (.[0].model // "unknown"), count: length, runtime_handoffs: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length), rate_limited: (map(select(.result == "rate_limit" or .provider_error_type == "rate_limit" or .provider_status == "429")) | length), other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and .result != "rate_limit" and .provider_error_type != "rate_limit" and .provider_status != "429")) | length), latest_ts: (map(.ts // 0) | max)}) | sort_by(.count, .latest_ts) | reverse | .[0:12]),
+				provider_model_usage: ($w | group_by([.provider // "unknown", .model // "unknown"]) | map({provider: (.[0].provider // "unknown"), model: (.[0].model // "unknown"), count: length, runtime_handoffs: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length), rate_limited: (map(select(.result == $rate_limit_result or .provider_error_type == $rate_limit_result or .provider_status == "429")) | length), other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and .result != $rate_limit_result and .provider_error_type != $rate_limit_result and .provider_status != "429")) | length), latest_ts: (map(.ts // 0) | max)}) | sort_by(.count, .latest_ts) | reverse | .[0:12]),
 				recent_events: ($w | sort_by(.ts // 0) | reverse | .[0:10] | map({ts, provider, model, result, exit_code, issue_number, session_key})),
 				account_pool: []
 			}' <"$input_file" 2>/dev/null || printf '{"provider_model_usage":[],"recent_events":[],"account_pool":[]}'
@@ -492,10 +496,10 @@ _wah_delivery_stages_json() {
 		fi
 	fi
 
-	local pr_opened="null" pr_merged="null" issue_solved="null" check_state="ok"
-	pr_opened=$(_wah_gh_list_count "pr" "all" "created:>=${since_iso} label:origin:worker" "$repo_slug") || check_state="failed"
-	pr_merged=$(_wah_gh_list_count "pr" "merged" "merged:>=${since_iso} label:origin:worker" "$repo_slug") || check_state="failed"
-	issue_solved=$(_wah_gh_list_count "issue" "closed" "closed:>=${since_iso} label:solved:worker" "$repo_slug") || check_state="failed"
+	local pr_opened="$WAH_JSON_NULL" pr_merged="$WAH_JSON_NULL" issue_solved="$WAH_JSON_NULL" check_state="ok"
+	pr_opened=$(_wah_gh_list_count "pr" "all" "created:>=${since_iso} label:origin:worker" "$repo_slug") || check_state="$WAH_DELIVERY_FAILED"
+	pr_merged=$(_wah_gh_list_count "pr" "merged" "merged:>=${since_iso} label:origin:worker" "$repo_slug") || check_state="$WAH_DELIVERY_FAILED"
+	issue_solved=$(_wah_gh_list_count "issue" "closed" "closed:>=${since_iso} label:solved:worker" "$repo_slug") || check_state="$WAH_DELIVERY_FAILED"
 
 	local delivery_json
 	delivery_json=$(jq -n \
@@ -546,7 +550,7 @@ _wah_emit_human() {
 		handoff_rate_pct=$(awk -v s="$succ" -v t="$terminal" 'BEGIN{printf "%.0f%%", (s/t)*100}')
 	fi
 	local delivery_state pr_opened pr_merged issue_solved delivered_successes
-	delivery_state=$(printf '%s' "$delivery_json" | jq -r '.check_state // "failed"' 2>/dev/null || printf 'failed')
+	delivery_state=$(printf '%s' "$delivery_json" | jq -r --arg failed "$WAH_DELIVERY_FAILED" '.check_state // $failed' 2>/dev/null || printf '%s' "$WAH_DELIVERY_FAILED")
 	pr_opened=$(printf '%s' "$delivery_json" | jq -r '.pr_opened // "?"' 2>/dev/null || printf '?')
 	pr_merged=$(printf '%s' "$delivery_json" | jq -r '.pr_merged // "?"' 2>/dev/null || printf '?')
 	issue_solved=$(printf '%s' "$delivery_json" | jq -r '.issue_solved // "?"' 2>/dev/null || printf '?')
@@ -595,7 +599,7 @@ _wah_emit_human() {
 	printf '  Delivered successes:         %s\n' "$delivered_successes"
 	printf '  Check state:                 %s' "$delivery_state"
 	[[ "$delivery_state" == "skipped" ]] && printf '  (use --pr-check)'
-	[[ "$delivery_state" == "failed" ]] && printf '  (one or more gh queries failed)'
+	[[ "$delivery_state" == "$WAH_DELIVERY_FAILED" ]] && printf '  (one or more gh queries failed)'
 	printf '\n'
 	printf '%s\n' "$divider"
 	return 0

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -12,9 +12,10 @@
 #   2. ~/.aidevops/logs/pulse-stats.json
 #      Pulse-level dispatch counters (each value is an array of unix-second
 #      timestamps; query with `jq '.counters[<name>] // []'`).
-#   3. Optional `gh issue list label:solved:worker --state closed`
-#      External truth: did headless workers actually solve tasks? Disabled by
-#      default because gh issue search uses the GraphQL search path.
+#   3. Optional GitHub delivery-stage queries for worker PRs and solved issues.
+#      External truth: did a runtime handoff become an opened PR, merged PR,
+#      and closed solved task? Disabled by default because GitHub search uses
+#      the GraphQL search path.
 #
 # Replaces the misdiagnosis-prone habit of reading worker-NNN.log mtimes,
 # which was the exact mistake that triggered this task. mtime tells you when
@@ -134,7 +135,7 @@ _wah_aggregate_metrics() {
 	now_epoch="${2:-$(date +%s)}"
 
 	# Bucket semantics (must match the original awk fallthrough chain):
-	#   succ — result=="success" AND exit_code==0
+#   succ — result=="success" AND exit_code==0 (runtime handoff, not delivery)
 	#   wk   — result=="watchdog_stall_killed"   (terminal)
 	#   wc   — result=="watchdog_stall_continue" (heartbeat, NOT terminal)
 	#   sic  — result=="service_interruption_continue" (heartbeat, NOT terminal)
@@ -358,7 +359,7 @@ _wah_provider_usage_json() {
 						provider: (.[0].provider // "unknown"),
 						model: (.[0].model // "unknown"),
 						count: length,
-						success: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length),
+						runtime_handoffs: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length),
 						rate_limited: (map(select(.result == "rate_limit" or .provider_error_type == "rate_limit" or .provider_status == "429")) | length),
 						other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and .result != "rate_limit" and .provider_error_type != "rate_limit" and .provider_status != "429")) | length),
 						latest_ts: (map(.ts // 0) | max)
@@ -390,7 +391,7 @@ _wah_provider_usage_json() {
 		jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" '
 			[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $w
 			| {
-				provider_model_usage: ($w | group_by([.provider // "unknown", .model // "unknown"]) | map({provider: (.[0].provider // "unknown"), model: (.[0].model // "unknown"), count: length, success: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length), rate_limited: (map(select(.result == "rate_limit" or .provider_error_type == "rate_limit" or .provider_status == "429")) | length), other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and .result != "rate_limit" and .provider_error_type != "rate_limit" and .provider_status != "429")) | length), latest_ts: (map(.ts // 0) | max)}) | sort_by(.count, .latest_ts) | reverse | .[0:12]),
+				provider_model_usage: ($w | group_by([.provider // "unknown", .model // "unknown"]) | map({provider: (.[0].provider // "unknown"), model: (.[0].model // "unknown"), count: length, runtime_handoffs: (map(select(.result == "success" and (.exit_code // 1) == 0)) | length), rate_limited: (map(select(.result == "rate_limit" or .provider_error_type == "rate_limit" or .provider_status == "429")) | length), other_failure: (map(select((.result != "success" or (.exit_code // 1) != 0) and .result != "rate_limit" and .provider_error_type != "rate_limit" and .provider_status != "429")) | length), latest_ts: (map(.ts // 0) | max)}) | sort_by(.count, .latest_ts) | reverse | .[0:12]),
 				recent_events: ($w | sort_by(.ts // 0) | reverse | .[0:10] | map({ts, provider, model, result, exit_code, issue_number, session_key})),
 				account_pool: []
 			}' <"$input_file" 2>/dev/null || printf '{"provider_model_usage":[],"recent_events":[],"account_pool":[]}'
@@ -422,50 +423,104 @@ _wah_count_stats_counter() {
 }
 
 #######################################
-# Get issue count for `solved:worker` issues closed since `since_iso`.
-# Caches result for $WAH_PR_CACHE_TTL seconds to avoid hammering gh.
+# Count one bounded GitHub list query.
+#
+# $1 — resource (`pr` or `issue`)
+# $2 — state (`all`, `merged`, or `closed`)
+# $3 — GitHub search expression
+# $4 — repo_slug (optional; empty = current repo)
+# stdout — integer count, or `null` on query/parse failure.
+#######################################
+_wah_gh_list_count() {
+	local resource="$1"
+	local state="$2"
+	local search_query="$3"
+	local repo_slug="${4:-}"
+	local -a gh_args=("$resource" list --search "$search_query" --state "$state" --limit 1000 --json number)
+	[[ -n "$repo_slug" ]] && gh_args+=(--repo "$repo_slug")
+
+	local payload count
+	if ! payload=$(gh "${gh_args[@]}" 2>/dev/null); then
+		printf 'null\n'
+		return 1
+	fi
+	count=$(printf '%s' "$payload" | jq -r 'if type == "array" then length else empty end' 2>/dev/null) || count=""
+	if [[ ! "$count" =~ ^[0-9]+$ ]]; then
+		printf 'null\n'
+		return 1
+	fi
+	printf '%s\n' "$count"
+	return 0
+}
+
+#######################################
+# Get worker delivery-stage counts since `since_iso`.
+# Caches the combined result for $WAH_PR_CACHE_TTL seconds so one summary run
+# does not turn into repeated GitHub search traffic.
+#
+# `delivered_successes` uses closed `solved:worker` issues as the authoritative
+# task-delivery signal. That label is applied by merge completion paths only
+# after a worker-owned PR has been merged and its linked issue is closed.
 #
 # $1 — since_iso (YYYY-MM-DDTHH:MM:SSZ)
 # $2 — repo_slug (optional; empty = current repo)
-# stdout — integer issue count, or "?" on gh failure.
+# $3 — stable window label for the cache key (optional; defaults to since_iso)
+# stdout — JSON object with nullable stage counts and check_state.
 #######################################
-_wah_solved_worker_count() {
-	local since_iso="$1" repo_slug="${2:-}"
+_wah_delivery_stages_json() {
+	local since_iso="$1"
+	local repo_slug="${2:-}"
+	local cache_window="${3:-$since_iso}"
 	local cache="$WAH_PR_CACHE_FILE"
-	local cache_key="solved-worker|${repo_slug:-current}|${since_iso}"
+	local cache_key="delivery-stages|${repo_slug:-current}|${cache_window}"
 
 	# Check cache freshness (portable mtime via shared-constants).
 	if [[ -f "$cache" ]]; then
-		local mtime now age cached_key cached_count
+		local mtime now age cached_key cached_delivery
 		mtime=$(_file_mtime_epoch "$cache" 2>/dev/null) || mtime=0
 		now=$(date +%s)
 		age=$((now - mtime))
 		if [[ $age -lt $WAH_PR_CACHE_TTL ]]; then
 			cached_key=$(jq -r '.key // ""' "$cache" 2>/dev/null) || cached_key=""
 			if [[ "$cached_key" == "$cache_key" ]]; then
-				cached_count=$(jq -r '.count // "?"' "$cache" 2>/dev/null) || cached_count="?"
-				printf '%s\n' "$cached_count"
-				return 0
+				cached_delivery=$(jq -c '.delivery // empty' "$cache" 2>/dev/null) || cached_delivery=""
+				if [[ -n "$cached_delivery" ]]; then
+					printf '%s\n' "$cached_delivery"
+					return 0
+				fi
 			fi
 		fi
 	fi
 
-	# Cache miss — query gh (5s timeout via gh's own client). solved:worker is
-	# the completion-attribution signal; origin:worker alone only says who
-	# created the PR and can over-credit interactive fixes.
-	local count gh_args=(issue list --search "closed:>=${since_iso} label:solved:worker" --state closed --limit 1000 --json number)
-	[[ -n "$repo_slug" ]] && gh_args+=(--repo "$repo_slug")
-	count=$(gh "${gh_args[@]}" 2>/dev/null | jq 'length' 2>/dev/null) || count="?"
+	local pr_opened="null" pr_merged="null" issue_solved="null" check_state="ok"
+	pr_opened=$(_wah_gh_list_count "pr" "all" "created:>=${since_iso} label:origin:worker" "$repo_slug") || check_state="failed"
+	pr_merged=$(_wah_gh_list_count "pr" "merged" "merged:>=${since_iso} label:origin:worker" "$repo_slug") || check_state="failed"
+	issue_solved=$(_wah_gh_list_count "issue" "closed" "closed:>=${since_iso} label:solved:worker" "$repo_slug") || check_state="failed"
+
+	local delivery_json
+	delivery_json=$(jq -n \
+		--argjson pr_opened "$pr_opened" \
+		--argjson pr_merged "$pr_merged" \
+		--argjson issue_solved "$issue_solved" \
+		--arg check_state "$check_state" \
+		'{
+			pr_opened: $pr_opened,
+			pr_merged: $pr_merged,
+			issue_solved: $issue_solved,
+			delivered_successes: (if $check_state == "ok" then $issue_solved else null end),
+			check_state: $check_state,
+			success_basis: "closed issue labelled solved:worker after merged worker PR"
+		}')
 
 	# Best-effort cache write.
 	mkdir -p "$(dirname "$cache")" 2>/dev/null || true
-	if [[ "$count" != "?" ]]; then
+	if [[ "$check_state" == "ok" ]]; then
 		local cache_ts
 		cache_ts=$(date +%s)
-		jq -n --arg key "$cache_key" --argjson count "$count" --argjson ts "$cache_ts" \
-			'{key: $key, count: $count, ts: $ts}' >"$cache" 2>/dev/null || true
+		jq -n --arg key "$cache_key" --argjson delivery "$delivery_json" --argjson ts "$cache_ts" \
+			'{key: $key, delivery: $delivery, ts: $ts}' >"$cache" 2>/dev/null || true
 	fi
-	printf '%s\n' "$count"
+	printf '%s\n' "$delivery_json"
 	return 0
 }
 
@@ -477,19 +532,25 @@ _wah_emit_human() {
 	local since_label="$1" cutoff_iso="$2"
 	local total="$3" terminal_total="$4" succ="$5" wk="$6" wc="$7" sic="$8" rl="$9" of="${10}"
 	local cb="${11}" gqlow="${12}" db_skip="${13}" nwbreaker="${14}"
-	local solved_count="${15}" pr_check_state="${16}" repo_label="${17}"
-	local details_json="${18}"
-	local blocker_json="${19}"
+	local delivery_json="${15}" repo_label="${16}"
+	local details_json="${17}"
+	local blocker_json="${18}"
 
 	local divider="==========================================================="
 
-	# Compute success rate (terminal events only — exclude watchdog_continue
-	# which is a heartbeat sample, not a terminal outcome).
+	# Runtime handoff rate excludes continuation heartbeats. It is intentionally
+	# not called success: external delivery requires a merged PR and closed issue.
 	local terminal=$((succ + wk + rl + of))
-	local rate_pct="n/a"
+	local handoff_rate_pct="n/a"
 	if [[ $terminal -gt 0 ]]; then
-		rate_pct=$(awk -v s="$succ" -v t="$terminal" 'BEGIN{printf "%.0f%%", (s/t)*100}')
+		handoff_rate_pct=$(awk -v s="$succ" -v t="$terminal" 'BEGIN{printf "%.0f%%", (s/t)*100}')
 	fi
+	local delivery_state pr_opened pr_merged issue_solved delivered_successes
+	delivery_state=$(printf '%s' "$delivery_json" | jq -r '.check_state // "failed"' 2>/dev/null || printf 'failed')
+	pr_opened=$(printf '%s' "$delivery_json" | jq -r '.pr_opened // "?"' 2>/dev/null || printf '?')
+	pr_merged=$(printf '%s' "$delivery_json" | jq -r '.pr_merged // "?"' 2>/dev/null || printf '?')
+	issue_solved=$(printf '%s' "$delivery_json" | jq -r '.issue_solved // "?"' 2>/dev/null || printf '?')
+	delivered_successes=$(printf '%s' "$delivery_json" | jq -r '.delivered_successes // "?"' 2>/dev/null || printf '?')
 
 	printf '%s\n' "$divider"
 	printf 'Worker activity since %s (cutoff: %s)\n' "$since_label" "$cutoff_iso"
@@ -499,7 +560,7 @@ _wah_emit_human() {
 	printf 'headless-runtime-metrics.jsonl (canonical worker outcomes):\n'
 	printf '  Raw attempt/events:          %d\n' "$total"
 	printf '  Terminal session outcomes:   %d\n' "$terminal_total"
-	printf '  Succeeded:                   %d  (%s of terminal)\n' "$succ" "$rate_pct"
+	printf '  Runtime handoffs:            %d  (%s of terminal)\n' "$succ" "$handoff_rate_pct"
 	printf '  Watchdog stall-killed:       %d\n' "$wk"
 	printf '  Watchdog stall-continued:    %d  (heartbeat, not terminal)\n' "$wc"
 	printf '  Service interruption resumed:%d  (heartbeat, not terminal)\n' "$sic"
@@ -527,10 +588,14 @@ _wah_emit_human() {
 	printf '  dispatch_backoff_skipped:                %d\n' "$db_skip"
 	printf '  pulse_dispatch_no_work_breaker_tripped:  %d\n' "$nwbreaker"
 	printf '\n'
-	printf 'solved:worker issues closed in window:\n'
-	printf '  %s' "$solved_count"
-	[[ "$pr_check_state" == "skipped" ]] && printf '  (skipped; use --pr-check)'
-	[[ "$pr_check_state" == "failed" ]] && printf '  (gh query failed)'
+	printf 'GitHub delivery stages (external truth):\n'
+	printf '  PRs opened:                  %s\n' "$pr_opened"
+	printf '  PRs merged:                  %s\n' "$pr_merged"
+	printf '  Issues solved and closed:    %s\n' "$issue_solved"
+	printf '  Delivered successes:         %s\n' "$delivered_successes"
+	printf '  Check state:                 %s' "$delivery_state"
+	[[ "$delivery_state" == "skipped" ]] && printf '  (use --pr-check)'
+	[[ "$delivery_state" == "failed" ]] && printf '  (one or more gh queries failed)'
 	printf '\n'
 	printf '%s\n' "$divider"
 	return 0
@@ -552,7 +617,7 @@ _wah_emit_providers_human() {
 	printf '%s' "$usage_json" | jq -r '
 		(.provider_model_usage // []) as $rows
 		| if ($rows | length) == 0 then "  (no worker metric events in window)"
-		else $rows[] | "  \(.provider)/\(.model): count=\(.count) success=\(.success) rate_limited=\(.rate_limited) other_failure=\(.other_failure) latest_ts=\(.latest_ts)"
+		else $rows[] | "  \(.provider)/\(.model): count=\(.count) runtime_handoffs=\(.runtime_handoffs) rate_limited=\(.rate_limited) other_failure=\(.other_failure) latest_ts=\(.latest_ts)"
 		end' 2>/dev/null || printf '  (provider/model usage unavailable)\n'
 	printf '\n'
 	printf 'OAuth account pool aggregate (redacted; no emails/tokens):\n'
@@ -579,13 +644,9 @@ _wah_emit_json() {
 	local since_label="$1" cutoff_iso="$2" cutoff_epoch="$3"
 	local total="$4" terminal_total="$5" succ="$6" wk="$7" wc="$8" sic="$9" rl="${10}" of="${11}"
 	local cb="${12}" gqlow="${13}" db_skip="${14}" nwbreaker="${15}"
-	local solved_count="${16}" pr_check_state="${17}" repo_label="${18}"
-	local details_json="${19}"
-	local blocker_json="${20}"
-
-	# solved_count may be "?" on gh failure — coerce to null in JSON.
-	local solved_json="$solved_count"
-	[[ "$solved_count" == "?" ]] && solved_json="null"
+	local delivery_json="${16}" repo_label="${17}"
+	local details_json="${18}"
+	local blocker_json="${19}"
 
 	jq -n \
 		--arg since "$since_label" \
@@ -603,10 +664,9 @@ _wah_emit_json() {
 		--argjson gqlow "$gqlow" \
 		--argjson db_skip "$db_skip" \
 		--argjson nwbreaker "$nwbreaker" \
-		--argjson solved_count "$solved_json" \
+		--argjson delivery "$delivery_json" \
 		--argjson details "$details_json" \
 		--argjson blockers "$blocker_json" \
-		--arg pr_check_state "$pr_check_state" \
 		--arg repo "$repo_label" \
 		'{
 			window: { since: $since, cutoff_iso: $cutoff_iso, cutoff_epoch: $cutoff_epoch },
@@ -616,7 +676,9 @@ _wah_emit_json() {
 				terminal_session_total: $terminal_total,
 				event_total: ($details.event_total // $total),
 				continuation_events: ($details.continuation_events // 0),
-				succeeded: $succ,
+				runtime_handoffs: $succ,
+				succeeded: ($delivery.delivered_successes // null),
+				success_basis: $delivery.success_basis,
 				watchdog_killed: $wk,
 				watchdog_continued: $wc,
 				service_interrupted: $sic,
@@ -637,8 +699,9 @@ _wah_emit_json() {
 				pulse_dispatch_no_work_breaker_tripped: $nwbreaker
 			},
 			progress_blockers: $blockers,
-			worker_solved_issues: { count: $solved_count, check_state: $pr_check_state },
-			worker_prs: { count: $solved_count, check_state: $pr_check_state, deprecated: true }
+			delivery_stages: $delivery,
+			worker_solved_issues: { count: $delivery.issue_solved, check_state: $delivery.check_state, deprecated: true },
+			worker_prs: { count: $delivery.pr_opened, merged_count: $delivery.pr_merged, check_state: $delivery.check_state, deprecated: true }
 		}'
 	return 0
 }
@@ -710,26 +773,24 @@ cmd_summary() {
 	db_skip=$(_wah_count_stats_counter "dispatch_backoff_skipped" "$cutoff_epoch")
 	nwbreaker=$(_wah_count_stats_counter "pulse_dispatch_no_work_breaker_tripped" "$cutoff_epoch")
 
-	# Solved issue count (optional, network-dependent).
-	local pr_count="?" pr_check_state="ok"
+	# Delivery-stage counts (optional, network-dependent).
+	local delivery_json
 	if [[ $do_pr_check -eq 1 ]]; then
-		pr_count=$(_wah_solved_worker_count "$cutoff_iso" "$repo_label")
-		[[ "$pr_count" == "?" ]] && pr_check_state="failed"
+		delivery_json=$(_wah_delivery_stages_json "$cutoff_iso" "$repo_label" "$since_label")
 	else
-		pr_count="?"
-		pr_check_state="skipped"
+		delivery_json='{"pr_opened":null,"pr_merged":null,"issue_solved":null,"delivered_successes":null,"check_state":"skipped","success_basis":"closed issue labelled solved:worker after merged worker PR"}'
 	fi
 
 	if [[ $emit_json -eq 1 ]]; then
 		_wah_emit_json "$since_label" "$cutoff_iso" "$cutoff_epoch" \
 			"$total" "$terminal_total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
-			"$pr_count" "$pr_check_state" "$repo_label" "$details_json" "$blocker_json"
+			"$delivery_json" "$repo_label" "$details_json" "$blocker_json"
 	else
 		_wah_emit_human "$since_label" "$cutoff_iso" \
 			"$total" "$terminal_total" "$succ" "$wk" "$wc" "$sic" "$rl" "$of" \
 			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
-			"$pr_count" "$pr_check_state" "$repo_label" "$details_json" "$blocker_json"
+			"$delivery_json" "$repo_label" "$details_json" "$blocker_json"
 	fi
 	return 0
 }
@@ -803,15 +864,16 @@ Usage:
 Options:
   --since 1h|6h|24h|48h|7d   Lookback window (default: 24h)
   --json                     Emit machine-readable JSON
-  --pr-check                 Run the gh solved-issue query (GraphQL search path)
-  --no-pr-check              Explicitly keep the gh solved-issue query skipped (default)
-  --repo OWNER/REPO          Constrain solved-issue query to a single repo
+  --pr-check                 Query opened/merged worker PRs and solved issues
+                             (three GitHub search calls; disabled by default)
+  --no-pr-check              Explicitly keep delivery-stage queries skipped (default)
+  --repo OWNER/REPO          Constrain delivery-stage queries to a single repo
 
 Sources read (in canonical-precedence order):
   1. ~/.aidevops/logs/headless-runtime-metrics.jsonl  (worker outcomes)
   2. ~/.aidevops/logs/pulse-stats.json                (dispatch counters)
   3. ~/.aidevops/logs/worker-progress-blockers.jsonl  (bounded progress holds)
-  4. gh issue list label:solved:worker                (optional external truth)
+  4. gh pr/issue list worker delivery stages          (optional external truth)
 
 Examples:
   # Last 24 hours, human-readable.
@@ -826,7 +888,7 @@ Examples:
   # Last 7 days, single repo, no network call.
   worker-activity-helper.sh summary --since 7d --repo marcusquinn/aidevops --no-pr-check
 
-  # Include solved:worker issue search when GraphQL budget is healthy.
+  # Include PR-opened, PR-merged, and solved-issue stages when API budget is healthy.
   worker-activity-helper.sh summary --since 24h --pr-check
 
 NOT a substitute for:


### PR DESCRIPTION
## Summary

Adds capped age-aware candidate ranking with deterministic tie-breaks; distinguishes runtime handoffs from opened, merged, and solved delivery stages; starts the existing merge routine asynchronously before dispatch; and routes exhausted fast-fail and stale-recovery breakers through the existing idempotent consolidation dispatcher.

## Files Changed

.agents/scripts/pulse-check-helper.sh, .agents/scripts/pulse-check-report.jq, .agents/scripts/pulse-dispatch-dedup-layers.sh, .agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-dispatch-preflight-lib.sh, .agents/scripts/pulse-fast-fail.sh, .agents/scripts/pulse-repo-meta.sh, .agents/scripts/pulse-triage.sh, .agents/scripts/pulse-wrapper-config.sh, .agents/scripts/tests/test-consolidation-dispatch.sh, .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh, .agents/scripts/tests/test-fast-fail-age-out.sh, .agents/scripts/tests/test-pulse-check-helper.sh, .agents/scripts/tests/test-pulse-merge-first-nonblocking.sh, .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh, .agents/scripts/tests/test-worker-activity-helper.sh, .agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh; test-worker-activity-helper.sh; test-pulse-check-helper.sh; test-pulse-merge-first-nonblocking.sh; test-fast-fail-age-out.sh; test-dispatch-dedup-stale-no-worker.sh; test-consolidation-dispatch.sh; complexity regression checks for Bash 3.2, function complexity, nesting, and file size.

Resolves #27853


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.124 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 1h 5m and 1,302,946 tokens on this with the user in an interactive session.