### PR TITLE
t18125: Make REST pagination attempts explicit

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -385,8 +385,8 @@ _shim_run_single_transport() {
 _GHRP_LOADED=0
 for _cand in \
 	"$_SHIM_DIR/gh-rest-pagination-lib.sh" \
-	"$HOME/.aidevops/agents/scripts/gh-rest-pagination-lib.sh"; do
-	if [[ -f "$_cand" ]]; then
+	"${HOME:+${HOME}/.aidevops/agents/scripts/gh-rest-pagination-lib.sh}"; do
+	if [[ -n "$_cand" && -f "$_cand" ]]; then
 		# shellcheck source=/dev/null
 		source "$_cand" 2>/dev/null && _GHRP_LOADED=1
 		break

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -38,6 +38,7 @@
 # ------
 #   AIDEVOPS_GH_SHIM_DISABLE=1 gh …          # skip entire shim
 #   AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 gh …  # skip read-rewrite only (t3037)
+#   AIDEVOPS_GH_EXPLICIT_PAGINATION_DISABLE=1 # retain native opaque pagination
 #
 # Ops/audit comments
 # ------------------
@@ -346,6 +347,10 @@ _shim_transport_caller_label() {
 _shim_transport_page() {
 	local arg=""
 	local page=1
+	if [[ "${AIDEVOPS_GH_PAGE_NUMBER:-}" =~ ^[0-9]+$ && "${AIDEVOPS_GH_PAGE_NUMBER}" -gt 0 ]]; then
+		printf '%s' "$AIDEVOPS_GH_PAGE_NUMBER"
+		return 0
+	fi
 	for arg in "$@"; do
 		if [[ "$arg" == "--paginate" ]]; then
 			# Native gh owns the internal page loop, so one process is not proof of
@@ -361,7 +366,7 @@ _shim_transport_page() {
 	return 0
 }
 
-_shim_run_transport() {
+_shim_run_single_transport() {
 	local executable="$1"; shift
 	local path="$1"; shift
 	local caller="$1"; shift
@@ -374,6 +379,38 @@ _shim_run_transport() {
 	fi
 	AIDEVOPS_GH_ROUTE_DECISION="$decision" gh_run_transport_attempt \
 		"$path" "$caller" "$AIDEVOPS_GH_LOGICAL_ID" "$page" "$retry" -- "$executable" "$@"
+	return $?
+}
+
+_GHRP_LOADED=0
+for _cand in \
+	"$_SHIM_DIR/gh-rest-pagination-lib.sh" \
+	"$HOME/.aidevops/agents/scripts/gh-rest-pagination-lib.sh"; do
+	if [[ -f "$_cand" ]]; then
+		# shellcheck source=/dev/null
+		source "$_cand" 2>/dev/null && _GHRP_LOADED=1
+		break
+	fi
+done
+unset _cand
+
+_shim_run_transport() {
+	local executable="$1"; shift
+	local path="$1"; shift
+	local caller="$1"; shift
+	local retry="$1"; shift
+	local rc=0
+	local -a transport_args=("$@")
+	if [[ "$_GHRP_LOADED" -eq 1 ]] && _ghrp_prepare "$path" "${transport_args[@]}"; then
+		_ghrp_run "$executable" "$path" "$caller" "$retry" "${transport_args[@]}"
+		rc=$?
+		if [[ "$rc" -eq 125 && "${_GHRP_FALLBACK_SAFE:-0}" -eq 1 ]]; then
+			_shim_run_single_transport "$executable" "$path" "$caller" "$retry" "${transport_args[@]}"
+			return $?
+		fi
+		return "$rc"
+	fi
+	_shim_run_single_transport "$executable" "$path" "$caller" "$retry" "${transport_args[@]}"
 	return $?
 }
 

--- a/.agents/scripts/gh-rest-pagination-lib.sh
+++ b/.agents/scripts/gh-rest-pagination-lib.sh
@@ -1,0 +1,521 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Explicit REST page loop for the aidevops gh PATH shim. This library is
+# sourced by `.agents/scripts/gh`; it never records endpoint values or response
+# bodies and keeps temporary response data in a private, short-lived directory.
+# Set AIDEVOPS_GH_EXPLICIT_PAGINATION_DISABLE=1 to retain native pagination;
+# AIDEVOPS_GH_REST_MAX_PAGES bounds explicit loops from 1 to 1000 (default 100).
+
+_GHRP_ARGS=()
+_GHRP_BASE_ARGS=()
+_GHRP_ENDPOINT_INDEX=-1
+_GHRP_BASE_ENDPOINT_INDEX=-1
+_GHRP_ENDPOINT=""
+_GHRP_INCLUDE_REQUESTED=0
+_GHRP_SLURP_REQUESTED=0
+_GHRP_SILENT_REQUESTED=0
+_GHRP_HOSTNAME="${GH_HOST:-github.com}"
+_GHRP_FALLBACK_SAFE=0
+_GHRP_PAGE_ARGS=()
+_GHRP_PAGE_FILES=()
+_GHRP_VISITED_ENDPOINTS=()
+_GHRP_NEXT_ENDPOINT=""
+_GHRP_EXPECT_OPTION="option"
+_GHRP_INVALID_NEXT_SENTINEL="__GHRP_INVALID_NEXT__"
+
+_ghrp_is_value_flag() {
+	local arg="$1"
+	case "$arg" in
+	-F | --field | -H | --header | --hostname | --input | -q | --jq | -X | --method | -p | --preview | -f | --raw-field | -t | --template | --cache) return 0 ;;
+	esac
+	return 1
+}
+
+_ghrp_find_endpoint_index() {
+	local index=0
+	local arg=""
+	local expect_value=0
+	_GHRP_ENDPOINT_INDEX=-1
+	_GHRP_ENDPOINT=""
+	while [[ "$index" -lt "${#_GHRP_ARGS[@]}" ]]; do
+		arg="${_GHRP_ARGS[$index]}"
+		if [[ "$expect_value" -eq 1 ]]; then
+			expect_value=0
+			index=$((index + 1))
+			continue
+		fi
+		if _ghrp_is_value_flag "$arg"; then
+			expect_value=1
+			index=$((index + 1))
+			continue
+		fi
+		case "$arg" in
+		api | --paginate | --slurp | --include | -i | --silent) ;;
+		--*=* | -F* | -H* | -q* | -X* | -p* | -f* | -t*) ;;
+		-*) ;;
+		*)
+			_GHRP_ENDPOINT_INDEX="$index"
+			_GHRP_ENDPOINT="$arg"
+			return 0
+			;;
+		esac
+		index=$((index + 1))
+	done
+	return 1
+}
+
+_ghrp_prepare() {
+	local path="$1"
+	shift
+	local index=0
+	local arg=""
+	local paginate_requested=0
+	local jq_requested=0
+	local template_requested=0
+	local fields_requested=0
+	local unsupported=0
+	local method="GET"
+	local method_explicit=0
+	local expect_value=""
+
+	_GHRP_ARGS=("$@")
+	_GHRP_BASE_ARGS=()
+	_GHRP_INCLUDE_REQUESTED=0
+	_GHRP_SLURP_REQUESTED=0
+	_GHRP_SILENT_REQUESTED=0
+	_GHRP_HOSTNAME="${GH_HOST:-github.com}"
+	_GHRP_BASE_ENDPOINT_INDEX=-1
+	[[ "$path" == "rest" ]] || return 1
+	[[ "${AIDEVOPS_GH_EXPLICIT_PAGINATION_DISABLE:-0}" != "1" ]] || return 1
+
+	while [[ "$index" -lt "${#_GHRP_ARGS[@]}" ]]; do
+		arg="${_GHRP_ARGS[$index]}"
+		if [[ -n "$expect_value" ]]; then
+			if [[ "$expect_value" == "method" ]]; then
+				method="$arg"
+				method_explicit=1
+			elif [[ "$expect_value" == "hostname" ]]; then
+				_GHRP_HOSTNAME="$arg"
+			fi
+			expect_value=""
+			index=$((index + 1))
+			continue
+		fi
+		case "$arg" in
+		--paginate) paginate_requested=1 ;;
+		--slurp) _GHRP_SLURP_REQUESTED=1 ;;
+		--include | -i) _GHRP_INCLUDE_REQUESTED=1 ;;
+		--jq | -q)
+			jq_requested=1
+			expect_value="$_GHRP_EXPECT_OPTION"
+			;;
+		--jq=* | -q*) jq_requested=1 ;;
+		--template | -t)
+			template_requested=1
+			expect_value="$_GHRP_EXPECT_OPTION"
+			;;
+		--template=* | -t*) template_requested=1 ;;
+		--method | -X) expect_value="method" ;;
+		--method=*)
+			method="${arg#--method=}"
+			method_explicit=1
+			;;
+		-X*)
+			method="${arg#-X}"
+			method_explicit=1
+			;;
+		-F | --field | -f | --raw-field)
+			fields_requested=1
+			expect_value="$_GHRP_EXPECT_OPTION"
+			;;
+		-F* | --field=* | -f* | --raw-field=*) fields_requested=1 ;;
+		--hostname) expect_value="hostname" ;;
+		--hostname=*) _GHRP_HOSTNAME="${arg#--hostname=}" ;;
+		-H | --header | -p | --preview) expect_value="$_GHRP_EXPECT_OPTION" ;;
+		-H* | --header=* | -p* | --preview=* | api) ;;
+		--silent) _GHRP_SILENT_REQUESTED=1 ;;
+		--input | --cache)
+			unsupported=1
+			expect_value="$_GHRP_EXPECT_OPTION"
+			;;
+		--input=* | --cache=* | --verbose) unsupported=1 ;;
+		-*) unsupported=1 ;;
+		esac
+		index=$((index + 1))
+	done
+
+	[[ -z "$expect_value" ]] || return 1
+	[[ "$paginate_requested" -eq 1 ]] || return 1
+	[[ "$unsupported" -eq 0 ]] || return 1
+	[[ "$method" == "GET" ]] || return 1
+	if [[ "$fields_requested" -eq 1 && "$method_explicit" -ne 1 ]]; then
+		# Native gh changes its default method to POST when fields are present.
+		# Only an explicit GET proves these fields belong in the query string.
+		return 1
+	fi
+	if [[ "$_GHRP_SLURP_REQUESTED" -eq 1 ]]; then
+		[[ "$jq_requested" -eq 0 && "$template_requested" -eq 0 && "$_GHRP_INCLUDE_REQUESTED" -eq 0 && "$_GHRP_SILENT_REQUESTED" -eq 0 ]] || return 1
+		command -v jq >/dev/null 2>&1 || return 1
+	fi
+	[[ "$_GHRP_SILENT_REQUESTED" -eq 0 ]] || return 1
+	_ghrp_find_endpoint_index || return 1
+	[[ "$_GHRP_ENDPOINT" != "graphql" && "$_GHRP_ENDPOINT" != graphql/* ]] || return 1
+	return 0
+}
+
+_ghrp_build_base_args() {
+	local index=0
+	local arg=""
+	local expect_value=0
+	_GHRP_BASE_ARGS=()
+	_GHRP_BASE_ENDPOINT_INDEX=-1
+	while [[ "$index" -lt "${#_GHRP_ARGS[@]}" ]]; do
+		arg="${_GHRP_ARGS[$index]}"
+		if [[ "$index" -eq "$_GHRP_ENDPOINT_INDEX" ]]; then
+			_GHRP_BASE_ENDPOINT_INDEX="${#_GHRP_BASE_ARGS[@]}"
+			_GHRP_BASE_ARGS+=("$arg")
+			expect_value=0
+			index=$((index + 1))
+			continue
+		fi
+		if [[ "$expect_value" -eq 1 ]]; then
+			_GHRP_BASE_ARGS+=("$arg")
+			expect_value=0
+			index=$((index + 1))
+			continue
+		fi
+		if _ghrp_is_value_flag "$arg"; then
+			_GHRP_BASE_ARGS+=("$arg")
+			expect_value=1
+			index=$((index + 1))
+			continue
+		fi
+		if [[ "$arg" == "--paginate" || "$arg" == "--slurp" ]]; then
+			index=$((index + 1))
+			continue
+		fi
+		_GHRP_BASE_ARGS+=("$arg")
+		index=$((index + 1))
+	done
+	if [[ "$_GHRP_INCLUDE_REQUESTED" -eq 0 ]]; then
+		_GHRP_BASE_ARGS+=(--include)
+	fi
+	[[ "$_GHRP_BASE_ENDPOINT_INDEX" -ge 0 ]] || return 1
+	return 0
+}
+
+_ghrp_strip_replayed_fields() {
+	local index=0
+	local arg=""
+	local value_mode=""
+	local -a args=("$@")
+	_GHRP_PAGE_ARGS=()
+	while [[ "$index" -lt "${#args[@]}" ]]; do
+		arg="${args[$index]}"
+		if [[ "$value_mode" == "keep" ]]; then
+			_GHRP_PAGE_ARGS+=("$arg")
+			value_mode=""
+			index=$((index + 1))
+			continue
+		fi
+		if [[ "$value_mode" == "drop" ]]; then
+			value_mode=""
+			index=$((index + 1))
+			continue
+		fi
+		case "$arg" in
+		-F | --field | -f | --raw-field)
+			value_mode="drop"
+			;;
+		-F* | --field=* | -f* | --raw-field=*) ;;
+		*)
+			_GHRP_PAGE_ARGS+=("$arg")
+			if _ghrp_is_value_flag "$arg"; then
+				value_mode="keep"
+			fi
+			;;
+		esac
+		index=$((index + 1))
+	done
+	return 0
+}
+
+_ghrp_split_included_response() {
+	local response_file="$1"
+	local header_file="$2"
+	local body_file="$3"
+	local body_offset=""
+	body_offset=$(LC_ALL=C awk '
+		BEGIN { bytes = 0; found = 0 }
+		{
+			bytes += length($0) + 1
+			line = $0
+			sub(/\r$/, "", line)
+			if (line == "") {
+				found = 1
+				print bytes
+				exit
+			}
+		}
+		END { if (!found) exit 1 }
+	' "$response_file") || return 1
+	[[ "$body_offset" =~ ^[0-9]+$ && "$body_offset" -gt 0 ]] || return 1
+	command dd if="$response_file" of="$header_file" bs=1 count="$body_offset" 2>/dev/null || return 1
+	command dd if="$response_file" of="$body_file" bs="$body_offset" skip=1 2>/dev/null || return 1
+	return 0
+}
+
+_ghrp_next_endpoint() {
+	local header_file="$1"
+	local target=""
+	local authority=""
+	target=$(LC_ALL=C awk -v invalid="$_GHRP_INVALID_NEXT_SENTINEL" '
+		function emit_next(segment, lower, start_at, remainder, end_at) {
+			lower = tolower(segment)
+			if (lower !~ /rel[[:space:]]*=[[:space:]]*"?next"?/) return 0
+			start_at = index(segment, "<")
+			if (start_at == 0) {
+				print invalid
+				return 1
+			}
+			remainder = substr(segment, start_at + 1)
+			end_at = index(remainder, ">")
+			if (end_at == 0) {
+				print invalid
+				return 1
+			}
+			print substr(remainder, 1, end_at - 1)
+			return 1
+		}
+		{
+			line = tolower($0)
+			if (line !~ /^link:/) next
+			payload = substr($0, index($0, ":") + 1)
+			segment = ""
+			in_angle = 0
+			in_quote = 0
+			for (char_index = 1; char_index <= length(payload); char_index++) {
+				char = substr(payload, char_index, 1)
+				if (char == "<" && !in_quote) in_angle = 1
+				if (char == ">" && in_angle) in_angle = 0
+				if (char == "\"" && !in_angle) in_quote = !in_quote
+				if (char == "," && !in_angle && !in_quote) {
+					if (emit_next(segment)) exit
+					segment = ""
+					continue
+				}
+				segment = segment char
+			}
+			if (emit_next(segment)) exit
+		}
+	' "$header_file")
+	[[ -n "$target" ]] || return 1
+	[[ "$target" != "$_GHRP_INVALID_NEXT_SENTINEL" ]] || return 2
+	case "$target" in
+	https://* | http://*)
+		target="${target#*://}"
+		[[ "$target" == */* ]] || return 2
+		authority="${target%%/*}"
+		target="${target#*/}"
+		case "$_GHRP_HOSTNAME" in
+		github.com)
+			[[ "$authority" == "github.com" || "$authority" == "api.github.com" ]] || return 2
+			;;
+		*)
+			[[ "$authority" == "$_GHRP_HOSTNAME" || "$authority" == "api.${_GHRP_HOSTNAME}" ]] || return 2
+			;;
+		esac
+		;;
+	/*) target="${target#/}" ;;
+	esac
+	case "$target" in
+	api/v3/*) target="${target#api/v3/}" ;;
+	esac
+	[[ -n "$target" && "$target" != -* ]] || return 2
+	case "$target" in
+	*$'\n'* | *$'\r'*) return 2 ;;
+	esac
+	printf '%s' "$target"
+	return 0
+}
+
+_ghrp_max_pages() {
+	local value="${AIDEVOPS_GH_REST_MAX_PAGES:-100}"
+	if [[ ! "$value" =~ ^[0-9]+$ || "$value" -lt 1 ]]; then
+		value=100
+	fi
+	if [[ "$value" -gt 1000 ]]; then
+		value=1000
+	fi
+	printf '%s' "$value"
+	return 0
+}
+
+_ghrp_cleanup_temp() {
+	local temp_root="$1"
+	if [[ -n "$temp_root" && -d "$temp_root" ]]; then
+		rm -rf -- "$temp_root"
+	fi
+	return 0
+}
+
+_ghrp_restore_trap() {
+	local signal="$1"
+	local saved_trap="$2"
+	trap - "$signal"
+	if [[ -n "$saved_trap" ]]; then
+		# shellcheck disable=SC2294 # trap -p emits shell-escaped restorable code.
+		eval "$saved_trap"
+	fi
+	return 0
+}
+
+_ghrp_release_temp() {
+	local temp_root="$1"
+	local exit_trap="$2"
+	local hup_trap="$3"
+	local int_trap="$4"
+	local term_trap="$5"
+	_ghrp_cleanup_temp "$temp_root"
+	_ghrp_restore_trap EXIT "$exit_trap"
+	_ghrp_restore_trap HUP "$hup_trap"
+	_ghrp_restore_trap INT "$int_trap"
+	_ghrp_restore_trap TERM "$term_trap"
+	return 0
+}
+
+_ghrp_emit_page_output() {
+	local response_file="$1"
+	local body_file="$2"
+	if [[ "$_GHRP_SLURP_REQUESTED" -eq 1 ]]; then
+		_GHRP_PAGE_FILES+=("$body_file")
+	elif [[ "$_GHRP_INCLUDE_REQUESTED" -eq 1 ]]; then
+		command cat "$response_file" || return 1
+	else
+		command cat "$body_file" || return 1
+	fi
+	return 0
+}
+
+_ghrp_resolve_next_page() {
+	local header_file="$1"
+	local rc=0
+	local visited_endpoint=""
+	_GHRP_NEXT_ENDPOINT=""
+	_GHRP_NEXT_ENDPOINT=$(_ghrp_next_endpoint "$header_file" 2>/dev/null) || rc=$?
+	[[ "$rc" -ne 1 ]] || return 1
+	if [[ "$rc" -ne 0 ]]; then
+		printf 'gh pagination: rejected an invalid next-page link\n' >&2
+		return 2
+	fi
+	for visited_endpoint in "${_GHRP_VISITED_ENDPOINTS[@]}"; do
+		if [[ "$_GHRP_NEXT_ENDPOINT" == "$visited_endpoint" ]]; then
+			printf 'gh pagination: repeated next-page link detected\n' >&2
+			return 2
+		fi
+	done
+	_GHRP_VISITED_ENDPOINTS+=("$_GHRP_NEXT_ENDPOINT")
+	return 0
+}
+
+_ghrp_run() {
+	local executable="$1"
+	shift
+	local path="$1"
+	shift
+	local caller="$1"
+	shift
+	local retry="$1"
+	shift
+	local temp_base="${AIDEVOPS_TEMP_DIR:-${HOME:-}/.aidevops/.agent-workspace/tmp}"
+	local temp_root=""
+	local page_count=0
+	local max_pages=100
+	local page_endpoint="$_GHRP_ENDPOINT"
+	local response_file=""
+	local header_file=""
+	local body_file=""
+	local rc=0
+	local prior_exit_trap=""
+	local prior_hup_trap=""
+	local prior_int_trap=""
+	local prior_term_trap=""
+	local -a page_args=()
+
+	_GHRP_FALLBACK_SAFE=1
+	_GHRP_PAGE_FILES=()
+	_GHRP_VISITED_ENDPOINTS=("$page_endpoint")
+	_ghrp_build_base_args || return 125
+	max_pages=$(_ghrp_max_pages)
+	[[ -n "$temp_base" ]] || return 125
+	mkdir -p "$temp_base" 2>/dev/null || return 125
+	temp_root=$(mktemp -d "${temp_base}/gh-rest-pages.XXXXXX") || return 125
+	prior_exit_trap=$(trap -p EXIT)
+	prior_hup_trap=$(trap -p HUP)
+	prior_int_trap=$(trap -p INT)
+	prior_term_trap=$(trap -p TERM)
+	trap '_ghrp_cleanup_temp "$temp_root"' EXIT
+	trap 'exit 129' HUP
+	trap 'exit 130' INT
+	trap 'exit 143' TERM
+
+	while :; do
+		if [[ "$page_count" -ge "$max_pages" ]]; then
+			printf 'gh pagination: page budget exhausted after %s pages\n' "$page_count" >&2
+			_ghrp_release_temp "$temp_root" "$prior_exit_trap" "$prior_hup_trap" "$prior_int_trap" "$prior_term_trap"
+			return 1
+		fi
+		page_count=$((page_count + 1))
+		page_args=("${_GHRP_BASE_ARGS[@]}")
+		page_args[$_GHRP_BASE_ENDPOINT_INDEX]="$page_endpoint"
+		if [[ "$page_count" -gt 1 ]]; then
+			_ghrp_strip_replayed_fields "${page_args[@]}"
+			page_args=("${_GHRP_PAGE_ARGS[@]}")
+		fi
+		response_file="${temp_root}/response-${page_count}.txt"
+		header_file="${temp_root}/headers-${page_count}.txt"
+		body_file="${temp_root}/body-${page_count}.json"
+
+		_GHRP_FALLBACK_SAFE=0
+		AIDEVOPS_GH_PAGE_NUMBER="$page_count" \
+			AIDEVOPS_GH_ROUTE_DECISION="${AIDEVOPS_GH_ROUTE_DECISION:-explicit-rest-pagination}" \
+			_shim_run_single_transport "$executable" "$path" "$caller" "$retry" "${page_args[@]}" >"$response_file"
+		rc=$?
+		if [[ "$rc" -ne 0 ]]; then
+			_ghrp_release_temp "$temp_root" "$prior_exit_trap" "$prior_hup_trap" "$prior_int_trap" "$prior_term_trap"
+			return "$rc"
+		fi
+		if ! _ghrp_split_included_response "$response_file" "$header_file" "$body_file"; then
+			printf 'gh pagination: could not parse included response headers\n' >&2
+			_ghrp_release_temp "$temp_root" "$prior_exit_trap" "$prior_hup_trap" "$prior_int_trap" "$prior_term_trap"
+			return 1
+		fi
+
+		if ! _ghrp_emit_page_output "$response_file" "$body_file"; then
+			_ghrp_release_temp "$temp_root" "$prior_exit_trap" "$prior_hup_trap" "$prior_int_trap" "$prior_term_trap"
+			return 1
+		fi
+
+		rc=0
+		_ghrp_resolve_next_page "$header_file" || rc=$?
+		if [[ "$rc" -eq 1 ]]; then
+			break
+		fi
+		if [[ "$rc" -ne 0 ]]; then
+			_ghrp_release_temp "$temp_root" "$prior_exit_trap" "$prior_hup_trap" "$prior_int_trap" "$prior_term_trap"
+			return 1
+		fi
+		page_endpoint="$_GHRP_NEXT_ENDPOINT"
+	done
+
+	if [[ "$_GHRP_SLURP_REQUESTED" -eq 1 ]]; then
+		jq -s '.' "${_GHRP_PAGE_FILES[@]}" || {
+			_ghrp_release_temp "$temp_root" "$prior_exit_trap" "$prior_hup_trap" "$prior_int_trap" "$prior_term_trap"
+			return 1
+		}
+	fi
+	_ghrp_release_temp "$temp_root" "$prior_exit_trap" "$prior_hup_trap" "$prior_int_trap" "$prior_term_trap"
+	return 0
+}

--- a/.agents/scripts/gh-rest-pagination-lib.sh
+++ b/.agents/scripts/gh-rest-pagination-lib.sh
@@ -262,7 +262,7 @@ _ghrp_split_included_response() {
 		END { if (!found) exit 1 }
 	' "$response_file") || return 1
 	[[ "$body_offset" =~ ^[0-9]+$ && "$body_offset" -gt 0 ]] || return 1
-	command dd if="$response_file" of="$header_file" bs=1 count="$body_offset" 2>/dev/null || return 1
+	command dd if="$response_file" of="$header_file" bs="$body_offset" count=1 2>/dev/null || return 1
 	command dd if="$response_file" of="$body_file" bs="$body_offset" skip=1 2>/dev/null || return 1
 	return 0
 }
@@ -272,9 +272,7 @@ _ghrp_next_endpoint() {
 	local target=""
 	local authority=""
 	target=$(LC_ALL=C awk -v invalid="$_GHRP_INVALID_NEXT_SENTINEL" '
-		function emit_next(segment, lower, start_at, remainder, end_at) {
-			lower = tolower(segment)
-			if (lower !~ /rel[[:space:]]*=[[:space:]]*"?next"?/) return 0
+		function emit_next(segment, start_at, remainder, end_at, params) {
 			start_at = index(segment, "<")
 			if (start_at == 0) {
 				print invalid
@@ -286,6 +284,9 @@ _ghrp_next_endpoint() {
 				print invalid
 				return 1
 			}
+			params = tolower(substr(remainder, end_at + 1))
+			if (params !~ /(^|[;[:space:]])rel[[:space:]]*=[[:space:]]*"next"([;[:space:]]|$)/ &&
+				params !~ /(^|[;[:space:]])rel[[:space:]]*=[[:space:]]*next([;[:space:]]|$)/) return 0
 			print substr(remainder, 1, end_at - 1)
 			return 1
 		}

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -434,6 +434,8 @@ if [[ "${NATIVE_PAGINATED_RESPONSE:-0}" == "1" ]]; then
 			printf 'Link: <https://ghe.example/api/v3/repos/fixture/items?per_page=100&page=2>; rel="next"\r\n'
 		elif [[ "${NATIVE_COMMA_LINK:-0}" == "1" ]]; then
 			printf 'Link: <https://api.github.com/repos/fixture/items?labels=bug,help-wanted&page=2>; rel="next"\r\n'
+		elif [[ "${NATIVE_QUERY_REL_ONLY:-0}" == "1" ]]; then
+			printf 'Link: <https://api.github.com/repos/fixture/items?per_page=100&page=2&rel=next>; rel="prev"\r\n'
 		else
 			printf 'Link: <repos/fixture/items?per_page=100&page=2>; rel="next"\r\n'
 		fi
@@ -552,6 +554,16 @@ comma_link_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_RES
 	'/repos/private-owner/private-repo/issues?per_page=100' --jq '.[].page')
 assert_eq "comma-bearing Link pagination preserves output" $'1\n2' "$comma_link_output"
 assert_eq "comma-bearing next endpoint remains intact" "1" "$(grep -c '^repos/fixture/items?labels=bug,help-wanted&page=2$' "$NATIVE_ATTEMPT_LOG")"
+
+# A URL query parameter named rel must not override the Link relation declared
+# after the closing angle bracket.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+query_rel_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 NATIVE_QUERY_REL_ONLY=1 \
+	"$SHIM_FIXTURE/gh" api --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' --jq '.[].page')
+assert_eq "URL query rel does not impersonate the Link relation" "1" "$query_rel_output"
+assert_eq "non-next Link relation stops after the first page" "1" "$(grep -c '^api$' "$NATIVE_ATTEMPT_LOG")"
 
 # Raw bodies remain byte-for-byte intact, including a missing final newline.
 raw_actual="$TMPDIR/raw-pagination.actual"

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -402,10 +402,53 @@ NATIVE_FIXTURE="$TMPDIR/native-fixture"
 mkdir -p "$SHIM_FIXTURE" "$NATIVE_FIXTURE"
 cp "${PARENT_DIR}/gh" "$SHIM_FIXTURE/gh"
 cp "${PARENT_DIR}/gh-api-instrument.sh" "$SHIM_FIXTURE/gh-api-instrument.sh"
+cp "${PARENT_DIR}/gh-rest-pagination-lib.sh" "$SHIM_FIXTURE/gh-rest-pagination-lib.sh"
 chmod +x "$SHIM_FIXTURE/gh"
 cat >"$NATIVE_FIXTURE/gh" <<'EOF_NATIVE_GH'
 #!/usr/bin/env bash
 printf '%s\n' "$@" >>"$NATIVE_ATTEMPT_LOG"
+page=1
+jq_requested=0
+expect_jq=0
+for arg in "$@"; do
+	if [[ "$expect_jq" -eq 1 ]]; then
+		expect_jq=0
+		continue
+	fi
+	case "$arg" in
+	--jq | -q)
+		jq_requested=1
+		expect_jq=1
+		;;
+	*)
+		if [[ "$arg" =~ (^|[?\&])page=([0-9]+)($|\&) ]]; then
+			page="${BASH_REMATCH[2]}"
+		fi
+		;;
+	esac
+done
+if [[ "${NATIVE_PAGINATED_RESPONSE:-0}" == "1" ]]; then
+	printf 'HTTP/2.0 200 OK\r\n'
+	if [[ "$page" -eq 1 ]]; then
+		if [[ "${NATIVE_ENTERPRISE_LINK:-0}" == "1" ]]; then
+			printf 'Link: <https://ghe.example/api/v3/repos/fixture/items?per_page=100&page=2>; rel="next"\r\n'
+		elif [[ "${NATIVE_COMMA_LINK:-0}" == "1" ]]; then
+			printf 'Link: <https://api.github.com/repos/fixture/items?labels=bug,help-wanted&page=2>; rel="next"\r\n'
+		else
+			printf 'Link: <repos/fixture/items?per_page=100&page=2>; rel="next"\r\n'
+		fi
+	elif [[ "$page" -eq 2 && "${NATIVE_CYCLIC_LINK:-0}" == "1" ]]; then
+		printf 'Link: <repos/fixture/items?per_page=100&page=2>; rel="next"\r\n'
+	fi
+	printf '\r\n'
+	if [[ "$jq_requested" -eq 1 ]]; then
+		printf '%s\n' "$page"
+	elif [[ "${NATIVE_NO_FINAL_NEWLINE:-0}" == "1" ]]; then
+		printf '[{"page":%s}]' "$page"
+	else
+		printf '[{"page":%s}]\n' "$page"
+	fi
+fi
 exit "${NATIVE_ATTEMPT_STATUS:-0}"
 EOF_NATIVE_GH
 chmod +x "$NATIVE_FIXTURE/gh"
@@ -426,18 +469,166 @@ else
 	PASS=$((PASS + 1))
 fi
 
-# Native gh owns --paginate's hidden request loop. Keep that process visible as
-# opaque instead of falsely claiming it represents one HTTP page, and preserve
-# only framework-owned caller labels for migration prioritisation.
+# REST pagination is expanded into one observable native command per page while
+# preserving one logical operation and framework-owned caller attribution.
 rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
 PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 \
 	AIDEVOPS_GH_CALLER=gh-api-instrument.sh \
 	"$SHIM_FIXTURE/gh" api '/repos/private-owner/private-repo/issues?per_page=100' --paginate >/dev/null
 "${PARENT_DIR}/gh-api-instrument.sh" report "$AIDEVOPS_GH_API_REPORT" >/dev/null 2>&1
-assert_eq "native pagination remains explicitly opaque" "0" "$(awk -F'\t' '$9 == "attempt" { print $12 }' "$AIDEVOPS_GH_API_LOG")"
-assert_eq "opaque pagination uses a framework-owned caller" "gh-api-instrument.sh" "$(awk -F'\t' '$9 == "attempt" { print $2 }' "$AIDEVOPS_GH_API_LOG")"
-assert_eq "opaque pagination is counted separately" "1" "$(jq -r '._meta.opaque_paginated_attempts' "$AIDEVOPS_GH_API_REPORT")"
-assert_eq "opaque pagination prevents exactness claims" "false" "$(jq -r '._meta.attempts_exact' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "explicit pagination invokes native gh once per page" "2" "$(grep -c '^api$' "$NATIVE_ATTEMPT_LOG")"
+assert_eq "explicit pagination records page sequence" "1 2" "$(awk -F'\t' '$9 == "attempt" { printf "%s%s", separator, $12; separator=" " } END { print "" }' "$AIDEVOPS_GH_API_LOG")"
+assert_eq "explicit pagination uses a framework-owned caller" "2" "$(awk -F'\t' '$9 == "attempt" && $2 == "gh-api-instrument.sh" { count++ } END { print count + 0 }' "$AIDEVOPS_GH_API_LOG")"
+assert_eq "explicit pagination has no opaque attempts" "0" "$(jq -r '._meta.opaque_paginated_attempts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "explicit pagination supports exactness claims" "true" "$(jq -r '._meta.attempts_exact' "$AIDEVOPS_GH_API_REPORT")"
+if grep -q -- '--paginate' "$NATIVE_ATTEMPT_LOG"; then
+	echo "  FAIL: native gh retained hidden pagination"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: native gh receives only explicit pages"
+	PASS=$((PASS + 1))
+fi
+
+# The rollback switch preserves native pagination and its honest opaque marker.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_GH_EXPLICIT_PAGINATION_DISABLE=1 \
+	"$SHIM_FIXTURE/gh" api '/repos/private-owner/private-repo/issues?per_page=100' --paginate >/dev/null
+"${PARENT_DIR}/gh-api-instrument.sh" report "$AIDEVOPS_GH_API_REPORT" >/dev/null 2>&1
+assert_eq "pagination rollback retains native flag" "1" "$(grep -c -- '^--paginate$' "$NATIVE_ATTEMPT_LOG")"
+assert_eq "pagination rollback remains honestly opaque" "1" "$(jq -r '._meta.opaque_paginated_attempts' "$AIDEVOPS_GH_API_REPORT")"
+
+# Streaming jq remains page-local, matching native gh pagination semantics.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+jq_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 \
+	"$SHIM_FIXTURE/gh" api --paginate '/repos/private-owner/private-repo/issues?per_page=100' --jq '.[].page')
+assert_eq "explicit pagination preserves per-page jq output" $'1\n2' "$jq_output"
+
+# Option values that resemble pagination flags remain values rather than being
+# consumed as shim controls.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+option_value_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 \
+	"$SHIM_FIXTURE/gh" api -H '--slurp' --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' --jq '.[].page')
+assert_eq "pagination-like option values preserve output" $'1\n2' "$option_value_output"
+assert_eq "pagination-like option values reach every page" "2" "$(grep -c -- '^--slurp$' "$NATIVE_ATTEMPT_LOG")"
+
+# Explicit GET fields are query parameters, so their page loop remains
+# observable. Fields without an explicit method retain native POST semantics.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+get_field_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 \
+	"$SHIM_FIXTURE/gh" api --method GET --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' -f since=2026-07-01T00:00:00Z --jq '.[].page')
+assert_eq "explicit pagination supports explicit GET query fields" $'1\n2' "$get_field_output"
+assert_eq "explicit GET query fields invoke one native command per page" "2" "$(grep -c '^api$' "$NATIVE_ATTEMPT_LOG")"
+assert_eq "explicit GET query fields remove native pagination" "0" "$(grep -c -- '^--paginate$' "$NATIVE_ATTEMPT_LOG" || true)"
+assert_eq "next-page links do not replay explicit GET fields" "1" "$(grep -c '^since=2026-07-01T00:00:00Z$' "$NATIVE_ATTEMPT_LOG")"
+
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	"$SHIM_FIXTURE/gh" api '/repos/private-owner/private-repo/issues?per_page=100' --paginate -f state=open >/dev/null
+assert_eq "implicit field method retains native pagination semantics" "1" "$(grep -c -- '^--paginate$' "$NATIVE_ATTEMPT_LOG")"
+
+# Enterprise Link URLs are host-checked and normalized back to gh endpoint
+# paths without replaying the /api/v3 prefix.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+enterprise_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 NATIVE_ENTERPRISE_LINK=1 \
+	"$SHIM_FIXTURE/gh" api --hostname ghe.example --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' --jq '.[].page')
+assert_eq "enterprise Link pagination preserves output" $'1\n2' "$enterprise_output"
+assert_eq "enterprise Link pagination strips API prefix" "1" "$(grep -c '^repos/fixture/items?per_page=100&page=2$' "$NATIVE_ATTEMPT_LOG")"
+assert_eq "enterprise Link pagination avoids duplicated API prefix" "0" "$(grep -c '^api/v3/' "$NATIVE_ATTEMPT_LOG" || true)"
+
+# Commas inside a Link target are data, not page-link separators.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+comma_link_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 NATIVE_COMMA_LINK=1 \
+	"$SHIM_FIXTURE/gh" api --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' --jq '.[].page')
+assert_eq "comma-bearing Link pagination preserves output" $'1\n2' "$comma_link_output"
+assert_eq "comma-bearing next endpoint remains intact" "1" "$(grep -c '^repos/fixture/items?labels=bug,help-wanted&page=2$' "$NATIVE_ATTEMPT_LOG")"
+
+# Raw bodies remain byte-for-byte intact, including a missing final newline.
+raw_actual="$TMPDIR/raw-pagination.actual"
+raw_expected="$TMPDIR/raw-pagination.expected"
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG" "$raw_actual" "$raw_expected"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 NATIVE_NO_FINAL_NEWLINE=1 \
+	"$SHIM_FIXTURE/gh" api --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' >"$raw_actual"
+printf '[{"page":1}][{"page":2}]' >"$raw_expected"
+if cmp -s "$raw_expected" "$raw_actual"; then
+	echo "  PASS: explicit pagination preserves raw response bytes"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: explicit pagination changed raw response bytes"
+	FAIL=$((FAIL + 1))
+fi
+
+# Repeated next links stop before a duplicate request and remove private temp
+# responses on the error path.
+cycle_temp="$TMPDIR/cycle-temp"
+mkdir -p "$cycle_temp"
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+if PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_TEMP_DIR="$cycle_temp" NATIVE_PAGINATED_RESPONSE=1 NATIVE_CYCLIC_LINK=1 \
+	"$SHIM_FIXTURE/gh" api --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' >/dev/null 2>/dev/null; then
+	echo "  FAIL: cyclic next link unexpectedly succeeded"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: cyclic next link fails closed"
+	PASS=$((PASS + 1))
+fi
+assert_eq "cyclic next link stops before duplicate request" "2" "$(grep -c '^api$' "$NATIVE_ATTEMPT_LOG")"
+shopt -s nullglob
+cycle_leftovers=("$cycle_temp"/gh-rest-pages.*)
+shopt -u nullglob
+assert_eq "pagination error removes private temp responses" "0" "${#cycle_leftovers[@]}"
+
+# Pre-transport temp setup failures fall back to native pagination; once the
+# first page starts, page-budget failures remain explicit errors.
+blocked_temp="$TMPDIR/not-a-directory"
+printf 'blocked' >"$blocked_temp"
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_TEMP_DIR="$blocked_temp" \
+	"$SHIM_FIXTURE/gh" api --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' >/dev/null
+assert_eq "temp setup failure falls back to native pagination" "1" "$(grep -c -- '^--paginate$' "$NATIVE_ATTEMPT_LOG")"
+
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+if PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_GH_REST_MAX_PAGES=1 NATIVE_PAGINATED_RESPONSE=1 \
+	"$SHIM_FIXTURE/gh" api --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' >/dev/null 2>/dev/null; then
+	echo "  FAIL: page-budget exhaustion unexpectedly succeeded"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: page-budget exhaustion fails closed"
+	PASS=$((PASS + 1))
+fi
+assert_eq "page budget prevents an excess request" "1" "$(grep -c '^api$' "$NATIVE_ATTEMPT_LOG")"
+
+# Silent output remains on native pagination because explicit header parsing
+# requires response bytes that --silent intentionally suppresses.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	"$SHIM_FIXTURE/gh" api --paginate --silent \
+	'/repos/private-owner/private-repo/issues?per_page=100'
+assert_eq "silent pagination retains native semantics" "1" "$(grep -c -- '^--paginate$' "$NATIVE_ATTEMPT_LOG")"
+
+# Slurp buffers raw page objects into the same outer-array contract as gh.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+slurp_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 \
+	"$SHIM_FIXTURE/gh" api --paginate '/repos/private-owner/private-repo/issues?per_page=100' --slurp | jq -c '.')
+assert_eq "explicit pagination preserves slurp output" '[[{"page":1}],[{"page":2}]]' "$slurp_output"
 
 # Parent attribution tolerates shell interpreter flags without scanning
 # arbitrary non-interpreter command arguments for coincidental basenames.
@@ -448,9 +639,10 @@ EOF_PARENT_CALLER
 chmod +x "$SHIM_FIXTURE/parent-caller.sh"
 rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
 PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_PAGINATED_RESPONSE=1 \
 	GH_SHIM_FIXTURE="$SHIM_FIXTURE/gh" \
 	bash -euo pipefail "$SHIM_FIXTURE/parent-caller.sh"
-assert_eq "interpreter flags preserve framework caller attribution" "parent-caller.sh" "$(awk -F'\t' '$9 == "attempt" { print $2 }' "$AIDEVOPS_GH_API_LOG")"
+assert_eq "interpreter flags preserve framework caller attribution" "2" "$(awk -F'\t' '$9 == "attempt" && $2 == "parent-caller.sh" { count++ } END { print count + 0 }' "$AIDEVOPS_GH_API_LOG")"
 
 # --- Summary ----------------------------------------------------------
 echo ""

--- a/.agents/scripts/tests/test-worker-permission-helper.sh
+++ b/.agents/scripts/tests/test-worker-permission-helper.sh
@@ -12,6 +12,7 @@ test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT
 capture_file="${test_root}/capture.json"
 export AIDEVOPS_WORKER_BLOCKER_LOG_FILE="${test_root}/blockers.jsonl"
+gh_call_log="${test_root}/gh-calls.log"
 
 cat >"$capture_file" <<'JSON'
 {
@@ -56,6 +57,7 @@ fi
 repo_dir="${test_root}/repo"
 git init -q "$repo_dir"
 gh() {
+	printf '%s\n' "$*" >>"$gh_call_log"
 	printf '0\n'
 	return 0
 }
@@ -73,6 +75,18 @@ gh_issue_edit_safe() {
 	cd "$test_root"
 	cmd_request --file "$capture_file" --issue 123 --repo owner/repo --session issue-123 --work-dir "$repo_dir"
 )
+if grep -q -- '--slurp' "$gh_call_log"; then
+	printf 'permission comment lookup combined unsupported --slurp with --jq\n' >&2
+	exit 1
+fi
+if ! grep -q -- '--paginate' "$gh_call_log"; then
+	printf 'permission comment lookup did not request all pages\n' >&2
+	exit 1
+fi
+if ! grep -Fq -- '[.[] | select' "$gh_call_log"; then
+	printf 'permission comment lookup did not use page-local jq input\n' >&2
+	exit 1
+fi
 git_dir=$(git -C "$repo_dir" rev-parse --absolute-git-dir)
 if [[ ! -f "${git_dir}/aidevops-permission-pending" ]]; then
 	printf 'permission pending marker was not written to the target repository git directory\n' >&2

--- a/.agents/scripts/worker-permission-helper.sh
+++ b/.agents/scripts/worker-permission-helper.sh
@@ -168,8 +168,8 @@ permission_request_already_posted() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local request_id="$3"
-	gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" --paginate --slurp \
-		--jq "[.[][]? | select((.body // \"\") | contains(\"${PERMISSION_REQUEST_MARKER}\") and contains(\"${request_id}\"))] | length" \
+	gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" --paginate \
+		--jq "[.[] | select((.body // \"\") | contains(\"${PERMISSION_REQUEST_MARKER}\") and contains(\"${request_id}\"))] | length" \
 		2>/dev/null | awk '$1 > 0 { found=1 } END { exit(found ? 0 : 1) }'
 	return $?
 }


### PR DESCRIPTION
## Summary

Expand supported REST gh api --paginate calls into Link-driven native requests, preserve output, privacy, rollback, and GitHub Enterprise behavior, and remove the invalid slurp-plus-jq permission lookup.

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-rest-pagination-lib.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-worker-permission-helper.sh, .agents/scripts/worker-permission-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-gh-api-instrument.sh (94/94); test-worker-permission-helper.sh; test-gh-shim.sh (45/45); test-gh-shim-native-resolution.sh (7/7); pagination regressions (5/5 and 3/3); linters-local.sh --changed; live explicit-GET canary (6 pages, attempts_exact=true, zero opaque attempts).

For #27769


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 17h 12m and 4,735,168 tokens on this with the user in an interactive session.