### PR TITLE
t18137: Update model tier reasoning defaults and migrate custom routing configs

### DIFF
--- a/.agents/configs/aidevops.defaults.jsonc
+++ b/.agents/configs/aidevops.defaults.jsonc
@@ -235,7 +235,7 @@
     "tiers": {
       "simple": {
         "models": ["openai/gpt-5.6-terra", "anthropic/claude-haiku-4-5"],
-        "reasoning": { "openai": "low" }
+        "reasoning": { "openai": "medium" }
       },
       "standard": {
         "models": ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-4-6"],
@@ -243,7 +243,7 @@
       },
       "thinking": {
         "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"],
-        "reasoning": { "openai": "xhigh" }
+        "reasoning": { "openai": "max" }
       }
     },
 

--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -7,7 +7,7 @@
   "tiers": {
     "simple": {
       "models": ["openai/gpt-5.6-terra", "anthropic/claude-haiku-4-5"],
-      "reasoning": { "openai": "low" }
+      "reasoning": { "openai": "medium" }
     },
     "standard": {
       "models": ["openai/gpt-5.6-sol", "zai-coding-plan/glm-5.2", "anthropic/claude-sonnet-4-6"],
@@ -15,7 +15,7 @@
     },
     "thinking": {
       "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"],
-      "reasoning": { "openai": "xhigh" }
+      "reasoning": { "openai": "max" }
     }
   },
 

--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -1584,6 +1584,7 @@ migrate_custom_model_routing_reasoning_defaults() {
 	local backup_dir="$HOME/.aidevops/config-backups/migrations"
 	local backup_file="$backup_dir/t18137-model-routing-table.json"
 	local temp_file=""
+	local jq_object_type="object"
 
 	[[ -f "$marker_file" ]] && return 0
 	if [[ ! -e "$custom_table" ]]; then
@@ -1599,13 +1600,13 @@ migrate_custom_model_routing_reasoning_defaults() {
 		print_warning "jq unavailable; t18137 custom model routing migration will retry"
 		return 0
 	fi
-	if ! jq -e '
-		type == "object" and
-		((.tiers // {}) | type == "object") and
-		((.tiers.simple // {}) | type == "object") and
-		((.tiers.simple.reasoning // {}) | type == "object") and
-		((.tiers.thinking // {}) | type == "object") and
-		((.tiers.thinking.reasoning // {}) | type == "object")
+	if ! jq -e --arg object_type "$jq_object_type" '
+		type == $object_type and
+		((.tiers // {}) | type == $object_type) and
+		((.tiers.simple // {}) | type == $object_type) and
+		((.tiers.simple.reasoning // {}) | type == $object_type) and
+		((.tiers.thinking // {}) | type == $object_type) and
+		((.tiers.thinking.reasoning // {}) | type == $object_type)
 	' "$custom_table" >/dev/null 2>&1; then
 		print_warning "Invalid custom model routing structure; t18137 migration will retry"
 		return 0

--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -1573,6 +1573,71 @@ migrate_orphaned_supervisor() {
 	return 0
 }
 
+# Apply the t18137 reasoning defaults to an existing user-local routing table
+# exactly once. Installs without a custom table already receive the canonical
+# defaults through agent deployment, so this migration must not create a custom
+# table that would freeze future framework routing updates.
+migrate_custom_model_routing_reasoning_defaults() {
+	local marker_dir="$HOME/.aidevops/cache/migrations"
+	local marker_file="$marker_dir/t18137-model-routing-reasoning-defaults"
+	local custom_table="$HOME/.aidevops/agents/custom/configs/model-routing-table.json"
+	local backup_dir="$HOME/.aidevops/config-backups/migrations"
+	local backup_file="$backup_dir/t18137-model-routing-table.json"
+	local temp_file=""
+
+	[[ -f "$marker_file" ]] && return 0
+	if [[ ! -e "$custom_table" ]]; then
+		mkdir -p "$marker_dir"
+		date -u +%Y-%m-%dT%H:%M:%SZ >"$marker_file"
+		return 0
+	fi
+	if [[ -L "$custom_table" || ! -f "$custom_table" || ! -O "$custom_table" ]]; then
+		print_warning "Skipping unsafe custom model routing table; t18137 migration will retry"
+		return 0
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		print_warning "jq unavailable; t18137 custom model routing migration will retry"
+		return 0
+	fi
+	if ! jq -e '
+		type == "object" and
+		((.tiers // {}) | type == "object") and
+		((.tiers.simple // {}) | type == "object") and
+		((.tiers.simple.reasoning // {}) | type == "object") and
+		((.tiers.thinking // {}) | type == "object") and
+		((.tiers.thinking.reasoning // {}) | type == "object")
+	' "$custom_table" >/dev/null 2>&1; then
+		print_warning "Invalid custom model routing structure; t18137 migration will retry"
+		return 0
+	fi
+
+	mkdir -p "$marker_dir" "$backup_dir"
+	if [[ ! -f "$backup_file" ]]; then
+		cp -p "$custom_table" "$backup_file" || return 0
+	fi
+	temp_file=$(mktemp "${custom_table}.t18137.XXXXXX") || return 0
+	if ! jq '
+		.tiers = (.tiers // {}) |
+		.tiers.simple = (.tiers.simple // {}) |
+		.tiers.simple.reasoning = (.tiers.simple.reasoning // {}) |
+		.tiers.simple.reasoning.openai = "medium" |
+		.tiers.thinking = (.tiers.thinking // {}) |
+		.tiers.thinking.reasoning = (.tiers.thinking.reasoning // {}) |
+		.tiers.thinking.reasoning.openai = "max"
+	' "$custom_table" >"$temp_file"; then
+		rm -f "$temp_file"
+		return 0
+	fi
+	chmod 600 "$temp_file"
+	if ! mv "$temp_file" "$custom_table"; then
+		rm -f "$temp_file"
+		return 0
+	fi
+	date -u +%Y-%m-%dT%H:%M:%SZ >"$marker_file"
+	print_info "Updated custom model routing reasoning defaults (t18137)"
+	return 0
+}
+
 # Backfill GitHub issue relationships from TODO.md metadata (t1889)
 # One-time migration: reads blocked-by:/blocks: and subtask hierarchy from
 # TODO.md in each pulse-enabled repo, and sets the corresponding GitHub

--- a/.agents/scripts/tests/test-headless-runtime-variant.sh
+++ b/.agents/scripts/tests/test-headless-runtime-variant.sh
@@ -56,12 +56,16 @@ actual=$(resolve_headless_variant "pulse" "standard" "openai/gpt-5.5")
 assert_equals "high" "$actual" "pulse standard routing keeps configured variant" || true
 
 with_clean_variant_env
+actual=$(resolve_headless_variant "worker" "simple" "openai/gpt-5.6-terra")
+assert_equals "medium" "$actual" "GPT-5.6 Terra simple worker uses medium routed effort" || true
+
+with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol")
-assert_equals "xhigh" "$actual" "GPT-5.6 Sol thinking worker uses routed effort" || true
+assert_equals "max" "$actual" "GPT-5.6 Sol thinking worker uses max routed effort" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol-fast")
-assert_equals "xhigh" "$actual" "GPT-5.6 Sol Fast thinking worker uses provider mapping" || true
+assert_equals "max" "$actual" "GPT-5.6 Sol Fast thinking worker uses max provider mapping" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "standard" "openai/gpt-5.6-sol")
@@ -79,7 +83,7 @@ assert_equals "xhigh" "$actual" "explicit GPT-5.6 Sol xhigh opt-in remains avail
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "pulse" "thinking" "openai/gpt-5.6-sol")
-assert_equals "xhigh" "$actual" "pulse thinking tier uses the same runtime mapping" || true
+assert_equals "max" "$actual" "pulse thinking tier uses the same max runtime mapping" || true
 
 with_clean_variant_env
 

--- a/.agents/scripts/tests/test-model-routing-reasoning-migration.sh
+++ b/.agents/scripts/tests/test-model-routing-reasoning-migration.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATIONS_MODULE="${SCRIPT_DIR}/../setup/modules/migrations.sh"
+SETUP_SCRIPT="${SCRIPT_DIR}/../../../setup.sh"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+print_info() {
+	return 0
+}
+
+print_warning() {
+	return 0
+}
+
+# shellcheck source=/dev/null
+source "$MIGRATIONS_MODULE"
+
+failures=0
+
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	if [[ "$expected" != "$actual" ]]; then
+		printf 'FAIL: %s (expected=%s actual=%s)\n' "$message" "$expected" "$actual" >&2
+		failures=$((failures + 1))
+		return 1
+	fi
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+assert_eq "2" "$(grep -c 'migrate_custom_model_routing_reasoning_defaults' "$SETUP_SCRIPT")" "setup runs the migration in interactive and non-interactive paths" || true
+
+HOME="$TEST_ROOT/no-custom"
+mkdir -p "$HOME"
+migrate_custom_model_routing_reasoning_defaults
+assert_eq "yes" "$([[ -f "$HOME/.aidevops/cache/migrations/t18137-model-routing-reasoning-defaults" ]] && printf yes || printf no)" "install without custom table is marked complete" || true
+assert_eq "no" "$([[ -e "$HOME/.aidevops/agents/custom/configs/model-routing-table.json" ]] && printf yes || printf no)" "migration does not create a custom routing table" || true
+
+HOME="$TEST_ROOT/custom"
+custom_table="$HOME/.aidevops/agents/custom/configs/model-routing-table.json"
+mkdir -p "${custom_table%/*}"
+cat >"$custom_table" <<'JSON'
+{
+  "tiers": {
+    "simple": {"models": ["custom/simple"], "reasoning": {"openai": "low", "other": "keep"}},
+    "thinking": {"models": ["custom/thinking"], "reasoning": {"openai": "xhigh"}}
+  },
+  "user_setting": "preserve"
+}
+JSON
+migrate_custom_model_routing_reasoning_defaults
+assert_eq "medium" "$(jq -r '.tiers.simple.reasoning.openai' "$custom_table")" "simple custom reasoning migrates to medium" || true
+assert_eq "max" "$(jq -r '.tiers.thinking.reasoning.openai' "$custom_table")" "thinking custom reasoning migrates to max" || true
+assert_eq "custom/simple" "$(jq -r '.tiers.simple.models[0]' "$custom_table")" "custom model order is preserved" || true
+assert_eq "keep" "$(jq -r '.tiers.simple.reasoning.other' "$custom_table")" "unrelated reasoning settings are preserved" || true
+assert_eq "preserve" "$(jq -r '.user_setting' "$custom_table")" "unrelated custom configuration is preserved" || true
+assert_eq "low" "$(jq -r '.tiers.simple.reasoning.openai' "$HOME/.aidevops/config-backups/migrations/t18137-model-routing-table.json")" "pre-migration backup is retained" || true
+
+jq '.tiers.simple.reasoning.openai = "high"' "$custom_table" >"${custom_table}.tmp"
+mv "${custom_table}.tmp" "$custom_table"
+migrate_custom_model_routing_reasoning_defaults
+assert_eq "high" "$(jq -r '.tiers.simple.reasoning.openai' "$custom_table")" "marker prevents later user changes from being overwritten" || true
+
+HOME="$TEST_ROOT/invalid"
+custom_table="$HOME/.aidevops/agents/custom/configs/model-routing-table.json"
+mkdir -p "${custom_table%/*}"
+printf '{invalid\n' >"$custom_table"
+migrate_custom_model_routing_reasoning_defaults
+assert_eq "{invalid" "$(tr -d '\n' <"$custom_table")" "invalid custom table remains untouched" || true
+assert_eq "no" "$([[ -f "$HOME/.aidevops/cache/migrations/t18137-model-routing-reasoning-defaults" ]] && printf yes || printf no)" "invalid custom table remains eligible for retry" || true
+
+if [[ "$failures" -ne 0 ]]; then
+	printf '\n%d model routing migration test(s) failed\n' "$failures" >&2
+	exit 1
+fi
+
+printf '\nAll model routing reasoning migration tests passed\n'
+exit 0

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -81,7 +81,7 @@ is always denied because secrets must flow through secret tooling, not prompts.
 - **Workers**: Round-robin across canonical `simple`, `standard`, or `thinking` routes after allowlist filtering and auth checks.
 - **Local switch**: Set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto the default OpenAI fallbacks. If you want OpenAI primary but Anthropic fallback, reorder `custom/configs/model-routing-table.json` and omit the allowlist.
 - **Current default mapping**: The active routing table currently maps `simple` to OpenAI Terra then Anthropic Haiku, `standard` to OpenAI Sol then Z.AI GLM then Anthropic Sonnet, and `thinking` to OpenAI Sol then Anthropic Opus. Availability and provider policy decide the exact model at execution time.
-- **Reasoning mapping**: The same routing table currently maps OpenAI `simple`, `standard`, and `thinking` to `low`, `medium`, and `xhigh`. Other providers use their provider/runtime defaults unless configured explicitly.
+- **Reasoning mapping**: The same routing table currently maps OpenAI `simple`, `standard`, and `thinking` to `medium`, `medium`, and `max`. Other providers use their provider/runtime defaults unless configured explicitly.
 - **OpenAI tier rationale**: Terra costs $2.50/M input and $15/M output and is competitive with GPT-5.5, making it the conservative choice for prescriptive/simple work. Sol costs $5/M input and $30/M output and is OpenAI's recommended flagship coding model.
 - **OpenAI pro caveat**: `openai/gpt-5.6-sol-pro` passed a live OpenCode ChatGPT OAuth smoke test on 2026-07-10, but OpenAI publishes neither an API price nor comparative Sol Pro benchmarks. It remains excluded from automatic workers pending repository-specific completion-rate evidence. Historical `gpt-5.5-pro` and older `*-pro`/`o3-pro` IDs remain excluded.
 - **GPT-5.5 standard workers**: aidevops omits env-derived standard-tier variants so OpenCode sends no explicit thinking override. Explicit CLI `--variant` still wins.
@@ -119,14 +119,14 @@ Example reasoning effort override:
 
 ```bash
 export AIDEVOPS_HEADLESS_VARIANT_STANDARD="high"
-export AIDEVOPS_HEADLESS_VARIANT_THINKING="xhigh"
+export AIDEVOPS_HEADLESS_VARIANT_THINKING="max"
 ```
 
 Role-specific overrides still exist when needed:
 
 ```bash
 export AIDEVOPS_HEADLESS_PULSE_VARIANT="high"
-export AIDEVOPS_HEADLESS_WORKER_VARIANT="xhigh"
+export AIDEVOPS_HEADLESS_WORKER_VARIANT="max"
 ```
 
 ## CLI Tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Route OpenAI simple-tier work at medium reasoning and thinking-tier work at max reasoning, including a one-time migration for existing custom routing tables (#27863)
+
 ## [3.32.124] - 2026-07-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.123] - 2026-07-15
 
 ### Added
@@ -124,13 +123,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.114] - 2026-07-14
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.113] - 2026-07-14
 
@@ -154,7 +151,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.110] - 2026-07-14
 
@@ -207,7 +203,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.104] - 2026-07-13
 
 ### Fixed
@@ -219,7 +214,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.102] - 2026-07-13
 
@@ -257,7 +251,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.97] - 2026-07-13
 
 ### Changed
@@ -275,7 +268,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.94] - 2026-07-13
 
@@ -316,7 +308,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.89] - 2026-07-13
 
 ### Changed
@@ -342,7 +333,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.85] - 2026-07-13
 
@@ -372,13 +362,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.81] - 2026-07-13
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.80] - 2026-07-13
 
@@ -386,13 +374,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.79] - 2026-07-13
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.78] - 2026-07-12
 
@@ -422,13 +408,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.74] - 2026-07-12
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.73] - 2026-07-12
 
@@ -443,13 +427,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.71] - 2026-07-12
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.70] - 2026-07-12
 
@@ -457,13 +439,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [3.32.69] - 2026-07-12
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.68] - 2026-07-12
 
@@ -476,7 +456,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [3.32.66] - 2026-07-12
 

--- a/TODO.md
+++ b/TODO.md
@@ -1170,6 +1170,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18123 Add bounded worker progress blocker logging ref:GH#27732
 
+- [ ] t18137 Update model tier reasoning defaults and migrate custom routing configs #feat ref:GH#27863
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/setup.sh
+++ b/setup.sh
@@ -1473,6 +1473,7 @@ _setup_run_non_interactive() {
 	_time_step "migrate_pulse_repos_to_repos_json" migrate_pulse_repos_to_repos_json
 	_time_step "cleanup_deprecated_paths" cleanup_deprecated_paths
 	_time_step "migrate_orphaned_supervisor" migrate_orphaned_supervisor
+	_time_step "migrate_custom_model_routing_reasoning_defaults" migrate_custom_model_routing_reasoning_defaults
 	_time_step "backfill_issue_relationships" backfill_issue_relationships
 	_time_step "cleanup_deprecated_mcps" cleanup_deprecated_mcps
 	_time_step "cleanup_stale_bun_opencode" cleanup_stale_bun_opencode
@@ -1647,6 +1648,7 @@ _setup_run_interactive() {
 	confirm_step "Migrate pulse-repos.json into repos.json" && migrate_pulse_repos_to_repos_json
 	confirm_step "Cleanup deprecated agent paths" && cleanup_deprecated_paths
 	confirm_step "Migrate orphaned supervisor to pulse-wrapper" && migrate_orphaned_supervisor
+	migrate_custom_model_routing_reasoning_defaults
 	confirm_step "Backfill GitHub issue relationships (blocked-by, sub-issues)" && backfill_issue_relationships
 	confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
 	confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode


### PR DESCRIPTION
## Summary

Set OpenAI simple-tier reasoning to medium and thinking-tier reasoning to max; migrate existing custom routing tables once while preserving model order and unrelated settings.

## Files Changed

.agents/configs/aidevops.defaults.jsonc, .agents/configs/model-routing-table.json, .agents/scripts/setup/modules/migrations.sh, .agents/scripts/tests/test-headless-runtime-variant.sh, .agents/scripts/tests/test-model-routing-reasoning-migration.sh, .agents/tools/context/model-routing.md, CHANGELOG.md, TODO.md, setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted routing and migration tests pass; ShellCheck passes; .agents/scripts/linters-local.sh passes.

Resolves #27863


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 20m and 175,755 tokens on this with the user in an interactive session.