### PR TITLE
GH#27869: Recognize lowercase closed issue state

### DIFF
--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -266,7 +266,10 @@ _isc_issue_is_closed() {
 	local slug="$2"
 	local _state
 	_state=$(gh issue view "$issue" --repo "$slug" --json state --jq .state 2>/dev/null) || return 1
-	[[ "$_state" == "CLOSED" ]]
+	if [[ "$_state" == "CLOSED" || "$_state" == "closed" ]]; then
+		return 0
+	fi
+	return 1
 }
 
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -901,6 +901,24 @@ else
 		"(rc=$release_closed_rc, log=${release_closed_log:0:300})"
 fi
 
+# REST fallback reads return the GitHub issue state in lowercase. Preserve the
+# same closed-issue invariant when that path supplies `closed` (GH#27869).
+_isc_cmd_claim 70004 testowner/testrepo --worktree /tmp/wt-fake >/dev/null 2>&1
+: >"$STUB_LOG"
+export STUB_ISSUE_HAS_IN_REVIEW=1
+export STUB_ISSUE_STATE=closed
+_isc_cmd_release 70004 testowner/testrepo >/dev/null 2>&1
+release_rest_closed_rc=$?
+release_rest_closed_log=$(cat "$STUB_LOG")
+export STUB_ISSUE_STATE=
+
+if [[ $release_rest_closed_rc -eq 0 ]] && printf '%s' "$release_rest_closed_log" | grep -q "add-label status:done" && ! printf '%s' "$release_rest_closed_log" | grep -q "add-label status:available"; then
+	print_result "GH#27869: release on lowercase closed issue → status:done, not status:available" 0
+else
+	print_result "GH#27869: release on lowercase closed issue → status:done, not status:available" 1 \
+		"(rc=$release_rest_closed_rc, log=${release_rest_closed_log:0:300})"
+fi
+
 # Reset stub state
 export STUB_ISSUE_HAS_IN_REVIEW=0
 


### PR DESCRIPTION
## Summary

Accept lowercase REST fallback issue state as closed and cover the release transition with a focused regression test.

## Files Changed

.agents/scripts/interactive-session-helper.sh, .agents/scripts/tests/test-interactive-session-claim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-interactive-session-claim.sh; shellcheck .agents/scripts/interactive-session-helper.sh .agents/scripts/tests/test-interactive-session-claim.sh; .agents/scripts/linters-local.sh

Resolves #27869


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.125 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 2h 25m and 2,349,917 tokens on this with the user in an interactive session.