### PR TITLE
GH#27803: prevent objective reconciliation jq E2BIG

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1381,8 +1381,10 @@ reconcile_issues_single_pass() {
 			if [[ -r "$objective_cache_file" ]]; then
 				objective_prs=$(jq -c --arg slug "$slug" '.[$slug].prs // []' "$objective_cache_file" 2>/dev/null) || objective_prs="[]"
 			fi
-			objective_input=$(jq -nc --argjson issues "$issues_json" --argjson prs "$objective_prs" \
-				--arg merged "$oimp_lookup" '{issues:$issues, prs:$prs, merged_lookup:$merged}') || objective_input=""
+			# GH#27803: issue and PR caches can exceed Linux MAX_ARG_STRLEN.
+			# Stream both JSON documents to jq instead of passing either via argv.
+			objective_input=$(printf '%s\n%s\n' "$issues_json" "$objective_prs" | jq -sc \
+				--arg merged "$oimp_lookup" '{issues: .[0], prs: .[1], merged_lookup: $merged}') || objective_input=""
 			if [[ -n "$objective_input" ]]; then
 				printf '%s' "$objective_input" | "$objective_helper" reconcile --repo "$slug" \
 					--max-repairs "${AIDEVOPS_OBJECTIVE_MAX_REPAIRS:-25}" >/dev/null 2>&1 || true

--- a/.agents/scripts/tests/test-jq-large-json-argv-regression.sh
+++ b/.agents/scripts/tests/test-jq-large-json-argv-regression.sh
@@ -103,8 +103,8 @@ test_prefetch_fingerprint_accepts_large_lists() {
 
 test_prefetch_cache_entry_accepts_large_lists() {
 	setup_env
-	# shellcheck source=../pulse-prefetch-fetch.sh
-	source "$SCRIPTS_DIR/pulse-prefetch-fetch.sh"
+	# shellcheck source=../pulse-prefetch-repo.sh
+	source "$SCRIPTS_DIR/pulse-prefetch-repo.sh"
 	local entry pr_count issue_count
 	entry=$(_prefetch_build_cache_entry \
 		"2026-06-26T00:00:00Z" \
@@ -159,6 +159,21 @@ test_quality_feedback_summary_accepts_large_details() {
 	return 0
 }
 
+test_objective_reconciliation_accepts_large_lists() {
+	local output issue_count pr_count
+	output=$(printf '%s\n%s\n' "$LARGE_ISSUES_JSON" "$LARGE_PRS_JSON" | jq -sc \
+		--arg merged '{"42":true}' \
+		'{issues: .[0], prs: .[1], merged_lookup: $merged}')
+	issue_count=$(printf '%s' "$output" | jq '.issues | length')
+	pr_count=$(printf '%s' "$output" | jq '.prs | length')
+	if [[ "$issue_count" == "600" && "$pr_count" == "600" ]]; then
+		print_result "objective reconciliation avoids large jq argv" 0
+	else
+		print_result "objective reconciliation avoids large jq argv" 1
+	fi
+	return 0
+}
+
 test_known_large_argjson_patterns_absent() {
 	local failed=0
 	if grep -nE -- '--argjson (prs|issues) "\$\{PREFETCH_UPDATED_(PRS|ISSUES)' "$SCRIPTS_DIR/pulse-prefetch-fetch.sh" >/dev/null 2>&1; then
@@ -172,6 +187,10 @@ test_known_large_argjson_patterns_absent() {
 	if grep -nE -- '--argjson details "\$details_json"' "$SCRIPTS_DIR/quality-feedback-helper.sh" >/dev/null 2>&1; then
 		failed=1
 	fi
+	# shellcheck disable=SC2016 # Literal regex: match shell variable names in source.
+	if grep -nE -- '--argjson (issues|prs) "\$(issues_json|objective_prs)"' "$SCRIPTS_DIR/pulse-issue-reconcile.sh" >/dev/null 2>&1; then
+		failed=1
+	fi
 	print_result "known-large jq --argjson variables stay out of argv" "$failed"
 	return 0
 }
@@ -182,6 +201,7 @@ main() {
 	test_prefetch_cache_entry_accepts_large_lists
 	test_prefetch_cache_set_accepts_large_entry
 	test_quality_feedback_summary_accepts_large_details
+	test_objective_reconciliation_accepts_large_lists
 	test_known_large_argjson_patterns_absent
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Streams issue and PR cache documents through jq stdin so objective reconciliation is not constrained by Linux per-argument limits; adds a 600-record regression case and repairs its moved helper source.

## Files Changed

.agents/scripts/pulse-issue-reconcile.sh, .agents/scripts/tests/test-jq-large-json-argv-regression.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n and shellcheck on changed scripts; test-jq-large-json-argv-regression.sh (6 passed); test-pulse-issue-reconcile.sh (25 passed)

Resolves #27803


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 3m and 60,697 tokens on this as a headless worker.