### PR TITLE
t18135: fix: bypass gh shim during privacy probes

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -1140,8 +1140,10 @@ _shim_privacy_scan() {
 		target_url="https://github.com/${target_url}"
 	fi
 
-	# Public-target check — fail-open on private (rc=1) or unknown (rc=2).
-	privacy_is_target_public "$target_url"
+	# Public-target check — bind the already-resolved native binary so helper
+	# probes cannot re-enter this PATH shim while its recursion guard is active.
+	# This covers both the auth status probe and the subsequent repo API query.
+	PRIVACY_GH_BIN="$REAL_GH" privacy_is_target_public "$target_url"
 	local _pub_rc=$?
 	if [[ $_pub_rc -ne 0 ]]; then
 		return 0

--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -80,6 +80,7 @@ privacy_log() {
 privacy_is_target_public() {
 	local url="$1"
 	local slug=""
+	local gh_bin="${PRIVACY_GH_BIN:-gh}"
 
 	# Extract owner/repo from either SSH or HTTPS form, strip optional .git
 	if [[ "$url" =~ github\.com[:/]([^/]+/[^/]+) ]]; then
@@ -113,11 +114,11 @@ privacy_is_target_public() {
 	fi
 
 	# Cold probe via gh
-	if ! command -v gh >/dev/null 2>&1; then
+	if ! command -v "$gh_bin" >/dev/null 2>&1; then
 		privacy_log WARN "gh CLI not installed — fail-open, allowing push to $slug"
 		return 2
 	fi
-	if ! gh auth status >/dev/null 2>&1; then
+	if ! "$gh_bin" auth status >/dev/null 2>&1; then
 		privacy_log WARN "gh not authenticated — fail-open, allowing push to $slug"
 		return 2
 	fi
@@ -126,7 +127,7 @@ privacy_is_target_public() {
 	# treats `false` as null-ish, so `.private // "unknown"` returns "unknown"
 	# for every public repo. `tostring` returns "true", "false", or "null".
 	local is_private
-	is_private=$(gh api "repos/${slug}" --jq '.private | tostring' 2>/dev/null) || {
+	is_private=$("$gh_bin" api "repos/${slug}" --jq '.private | tostring' 2>/dev/null) || {
 		privacy_log WARN "gh api repos/${slug} failed — fail-open"
 		return 2
 	}

--- a/.agents/scripts/test-privacy-guard-shim.sh
+++ b/.agents/scripts/test-privacy-guard-shim.sh
@@ -277,7 +277,7 @@ rm -f "$PRIV_HOME/.aidevops/cache/repo-privacy.json" \
 	"$RECORD_FILE" "$AUTH_RECORD_FILE" "$API_RECORD_FILE"
 out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Clean cold-cache content" 2>&1)
 rc=$?
-if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" && -f "$AUTH_RECORD_FILE" && -f "$API_RECORD_FILE" ]] && \
+if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" && -f "$AUTH_RECORD_FILE" && -f "$API_RECORD_FILE" ]] &&
 	[[ "$out" != *"gh not authenticated"* ]]; then
 	pass "cold privacy probes use native gh without shim recursion"
 else

--- a/.agents/scripts/test-privacy-guard-shim.sh
+++ b/.agents/scripts/test-privacy-guard-shim.sh
@@ -207,9 +207,20 @@ chmod +x "$PATH_DIR/gh-signature-helper.sh"
 REAL_GH_DIR="${TMP}/real-gh-dir"
 mkdir -p "$REAL_GH_DIR"
 RECORD_FILE="${TMP}/gh-invocation.log"
+AUTH_RECORD_FILE="${TMP}/gh-auth-invocation.log"
+API_RECORD_FILE="${TMP}/gh-api-invocation.log"
 cat >"$REAL_GH_DIR/gh" <<STUB
 #!/usr/bin/env bash
-echo "REAL_GH_INVOKED" > '$RECORD_FILE'
+if [[ "\${1:-}" == "auth" && "\${2:-}" == "status" ]]; then
+	printf '%s\n' "REAL_GH_AUTH_INVOKED" > '$AUTH_RECORD_FILE'
+	exit 0
+fi
+if [[ "\${1:-}" == "api" && "\${2:-}" == repos/* ]]; then
+	printf '%s\n' "REAL_GH_API_INVOKED" > '$API_RECORD_FILE'
+	printf '%s\n' false
+	exit 0
+fi
+printf '%s\n' "REAL_GH_INVOKED" > '$RECORD_FILE'
 printf '%s\n' "\$@" >> '$RECORD_FILE'
 exit 0
 STUB
@@ -251,6 +262,8 @@ run_shim() {
 	HOME="$PRIV_HOME" \
 		PRIVACY_REPOS_CONFIG="$PRIV_HOME/.config/aidevops/repos.json" \
 		PRIVACY_CACHE_FILE="$PRIV_HOME/.aidevops/cache/repo-privacy.json" \
+		HEADLESS='' FULL_LOOP_HEADLESS='' AIDEVOPS_HEADLESS='' OPENCODE_HEADLESS='' \
+		GITHUB_ACTIONS='' AIDEVOPS_SESSION_ORIGIN='' \
 		PATH="$_path_dir:$REAL_GH_DIR:$PATH" \
 		"$_path_dir/gh" "$@" || _rc=$?
 	if [[ "$_rc" -ne 0 ]]; then
@@ -258,6 +271,26 @@ run_shim() {
 	fi
 	return 0
 }
+
+# -- Test 2.0: cold privacy probes bypass the active shim and use native gh
+rm -f "$PRIV_HOME/.aidevops/cache/repo-privacy.json" \
+	"$RECORD_FILE" "$AUTH_RECORD_FILE" "$API_RECORD_FILE"
+out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Clean cold-cache content" 2>&1)
+rc=$?
+if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" && -f "$AUTH_RECORD_FILE" && -f "$API_RECORD_FILE" ]] && \
+	[[ "$out" != *"gh not authenticated"* ]]; then
+	pass "cold privacy probes use native gh without shim recursion"
+else
+	fail "expected native auth/API/final invocations without auth warning. rc=$rc out='$out'"
+fi
+
+# Restore the warm cache used by the remaining integration cases.
+cat >"$PRIV_HOME/.aidevops/cache/repo-privacy.json" <<EOF
+{
+  "marcusquinn/aidevops": { "private": false, "checked_at": $(date +%s) },
+  "acme/longprivate":    { "private": true,  "checked_at": $(date +%s) }
+}
+EOF
 
 # -- Test 2.1: public target + private slug body → BLOCKED
 rm -f "$RECORD_FILE"


### PR DESCRIPTION
## Summary

Bind privacy guard auth and repository probes to the shim's resolved native gh binary, preventing recursion-guard false authentication warnings. Add a cold-cache integration regression covering native auth/API probes and make the harness independent of inherited headless markers.

## Files Changed

.agents/scripts/gh, .agents/scripts/privacy-guard-helper.sh, .agents/scripts/test-privacy-guard-shim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/test-privacy-guard-shim.sh (27 passed); bash .agents/scripts/tests/test-gh-shim.sh (45 passed); shellcheck .agents/scripts/gh .agents/scripts/privacy-guard-helper.sh .agents/scripts/test-privacy-guard-shim.sh

Resolves #27804


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 4m and 69,288 tokens on this as a headless worker.