### PR TITLE
GH#27882: keep consolidation tasks dispatchable

### DIFF
--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -30,7 +30,12 @@ _ddpr_issue_body_from_meta() {
 }
 
 #######################################
-# Extract related issue refs from consolidation/supersession lines.
+# Extract the related issue ref from the canonical consolidated-spec marker.
+#
+# Operational consolidation-task bodies inline instructions, parent threads,
+# and historical references that may contain words such as "superseded" or
+# "consolidated". Only a marker at the start of a line establishes the
+# current issue's supersession relationship.
 #
 # Args: $1 = issue body
 # Outputs: one issue number per line
@@ -38,18 +43,32 @@ _ddpr_issue_body_from_meta() {
 #######################################
 _ddpr_superseded_issue_refs() {
 	local issue_body="$1"
-	local line="" lower_line="" refs=""
+	local line="" ref=""
 	while IFS= read -r line; do
-		lower_line=$(printf '%s' "$line" | tr '[:upper:]' '[:lower:]')
-		case "$lower_line" in
-		*supersedes* | *superseded* | *consolidated*)
-			refs=$(printf '%s\n' "$line" | grep -oE '#[0-9]+' | tr -d '#' || true)
-			[[ -n "$refs" ]] && printf '%s\n' "$refs"
-			;;
-		*) ;;
-		esac
+		if ! printf '%s\n' "$line" | grep -qE '^_Supersedes #[0-9]+ (—|-) this issue is the consolidated spec\._$'; then
+			continue
+		fi
+		ref=$(printf '%s\n' "$line" | grep -oE '^_Supersedes #[0-9]+' | grep -oE '[0-9]+' || true)
+		[[ -n "$ref" ]] && printf '%s\n' "$ref"
 	done <<<"$issue_body"
 	return 0
+}
+
+#######################################
+# Check whether dispatch metadata identifies an operational consolidation task.
+#
+# Args: none
+# Returns: 0 for consolidation-task metadata, 1 otherwise
+#######################################
+_ddpr_is_consolidation_task() {
+	[[ -n "${ISSUE_META_JSON:-}" ]] || return 1
+	if printf '%s' "$ISSUE_META_JSON" | jq -e '
+		[.labels[]? | if type == "object" then (.name // "") else . end]
+		| any(. == "consolidation-task")
+	' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
 }
 
 #######################################
@@ -343,6 +362,9 @@ _has_open_pr_check_superseded_issue_pr() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local issue_body=""
+	# Operational children describe how to create a consolidated spec and inline
+	# arbitrary historical text; they are not consolidated specs themselves.
+	_ddpr_is_consolidation_task && return 1
 	issue_body=$(_ddpr_issue_body_from_meta)
 	[[ -n "$issue_body" ]] || return 1
 

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -559,6 +559,40 @@ test_has_open_pr_ignores_planning_only_superseded_reference() {
 	return 0
 }
 
+test_has_open_pr_ignores_consolidation_task_historical_reference() {
+	set_gh_fixtures 'marcusquinn/aidevops|merged|#18670|[{"number":18676,"title":"Fix origin labels","body":"For #18670. Implements the earlier fix."}]'
+	# shellcheck disable=SC2016 # Literal backticks are part of the issue-body fixture.
+	export ISSUE_META_JSON='{"labels":[{"name":"consolidation-task"}],"body":"## What to do\n\nStart the merged body with: `_Supersedes #27799 — this issue is the consolidated spec._`\n\n**Note (GH#18670):** consolidated issues require origin:worker."}'
+
+	if "$HELPER_SCRIPT" has-open-pr 27848 marcusquinn/aidevops 'consolidation-task: merge thread on #27799 into single spec'; then
+		unset ISSUE_META_JSON
+		print_result "has-open-pr ignores historical references in consolidation tasks" 1 \
+			"Expected operational consolidation-task metadata to bypass consolidated-spec PR dedup"
+		return 0
+	fi
+
+	unset ISSUE_META_JSON
+	print_result "has-open-pr ignores historical references in consolidation tasks" 0
+	return 0
+}
+
+test_has_open_pr_requires_canonical_supersedes_marker() {
+	set_gh_fixtures 'marcusquinn/aidevops|merged|#27799|[{"number":27824,"title":"For #27799: implement wrapper fix","body":"For #27799. Implements the fix."}]'
+	# shellcheck disable=SC2016 # Literal backticks are part of the issue-body fixture.
+	export ISSUE_META_JSON='{"body":"## What to do\n\nStart the merged body with: `_Supersedes #27799 — this issue is the consolidated spec._`"}'
+
+	if "$HELPER_SCRIPT" has-open-pr 27868 marcusquinn/aidevops 'consolidation-task: merge thread on #27802 into single spec'; then
+		unset ISSUE_META_JSON
+		print_result "has-open-pr requires canonical supersedes marker position" 1 \
+			"Expected an instructional inline marker to remain dispatchable"
+		return 0
+	fi
+
+	unset ISSUE_META_JSON
+	print_result "has-open-pr requires canonical supersedes marker position" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -584,6 +618,8 @@ main() {
 	test_has_open_pr_ignores_adjacent_issue_number_sibling_reference
 	test_has_open_pr_blocks_superseded_consolidated_issue
 	test_has_open_pr_ignores_planning_only_superseded_reference
+	test_has_open_pr_ignores_consolidation_task_historical_reference
+	test_has_open_pr_requires_canonical_supersedes_marker
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Restrict superseded-parent PR dedup to canonical consolidated-spec markers and bypass that check for operational consolidation-task children.

## Files Changed

.agents/scripts/dispatch-dedup-pr.sh, .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 23 focused has-open-pr tests pass; 25 consolidation-dispatch tests pass; ShellCheck clean; linters-local.sh passes.

Resolves #27882


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.126 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 9m and 234,765 tokens on this with the user in an interactive session.