### PR TITLE
GH#27871: Skip closed issue claim lifecycle

### DIFF
--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -67,6 +67,8 @@ _isc_resolve_manageable_user() {
 # -----------------------------------------------------------------------------
 # Subcommand: claim
 # -----------------------------------------------------------------------------
+# GH#27871: terminal issues skip before claim idempotency, which can refresh a
+# stamp. Lookup failures return 1 and preserve the existing fail-open contract.
 _isc_claim_closed_issue_guard() {
 	local issue="$1"
 	local slug="$2"
@@ -178,8 +180,6 @@ _isc_cmd_claim() {
 		return 0
 	fi
 
-	# GH#27871: check before idempotency because that path refreshes a stamp.
-	# Lookup failures preserve the existing fail-open contract.
 	_isc_claim_closed_issue_guard "$issue" "$slug" && return 0
 
 	# Idempotency: if already in-review, refresh stamp and exit. The `if`

--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -170,6 +170,14 @@ _isc_cmd_claim() {
 		return 0
 	fi
 
+	# GH#27871: terminal issues must remain terminal. Check before the
+	# idempotent in-review branch because that path still refreshes a local
+	# claim stamp. Lookup failures preserve the existing fail-open contract.
+	if _isc_issue_is_closed "$issue" "$slug"; then
+		_isc_info "claim: #$issue is closed — skipping interactive claim lifecycle"
+		return 0
+	fi
+
 	# Idempotency: if already in-review, refresh stamp and exit. The `if`
 	# conditional consumes any non-zero return so set -e doesn't propagate
 	# rc=2 (lookup failed) up the call stack — see _isc_has_in_review header

--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -67,6 +67,14 @@ _isc_resolve_manageable_user() {
 # -----------------------------------------------------------------------------
 # Subcommand: claim
 # -----------------------------------------------------------------------------
+_isc_claim_closed_issue_guard() {
+	local issue="$1"
+	local slug="$2"
+	_isc_issue_is_closed "$issue" "$slug" || return 1
+	_isc_info "claim: #$issue is closed — skipping interactive claim lifecycle"
+	return 0
+}
+
 # Apply status:in-review, self-assign, and write a stamp in repos where the
 # authenticated account has maintainer-equivalent issue-management access.
 #
@@ -170,13 +178,9 @@ _isc_cmd_claim() {
 		return 0
 	fi
 
-	# GH#27871: terminal issues must remain terminal. Check before the
-	# idempotent in-review branch because that path still refreshes a local
-	# claim stamp. Lookup failures preserve the existing fail-open contract.
-	if _isc_issue_is_closed "$issue" "$slug"; then
-		_isc_info "claim: #$issue is closed — skipping interactive claim lifecycle"
-		return 0
-	fi
+	# GH#27871: check before idempotency because that path refreshes a stamp.
+	# Lookup failures preserve the existing fail-open contract.
+	_isc_claim_closed_issue_guard "$issue" "$slug" && return 0
 
 	# Idempotency: if already in-review, refresh stamp and exit. The `if`
 	# conditional consumes any non-zero return so set -e doesn't propagate

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -1025,10 +1025,10 @@ for closed_state in CLOSED closed; do
 	closed_rc=$?
 	closed_log=$(cat "$STUB_LOG")
 
-	if [[ $closed_rc -eq 0 && ! -f "$closed_stamp" ]] &&
-		printf '%s' "$closed_out" | grep -q 'is closed' &&
-		! printf '%s' "$closed_log" | grep -q 'issue edit 70007' &&
-		! printf '%s' "$closed_log" | grep -q 'issue comment 70007'; then
+	if [[ $closed_rc -eq 0 && ! -f "$closed_stamp" &&
+		"$closed_out" == *"is closed"* &&
+		"$closed_log" != *"issue edit 70007"* &&
+		"$closed_log" != *"issue comment 70007"* ]]; then
 		print_result "GH#27871: claim on ${closed_state} issue skips lifecycle writes" 0
 	else
 		print_result "GH#27871: claim on ${closed_state} issue skips lifecycle writes" 1 \

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -1014,6 +1014,29 @@ else
 fi
 
 # =============================================================================
+# Test 27 — GH#27871: closed issues skip every interactive claim write
+# =============================================================================
+for closed_state in CLOSED closed; do
+	closed_stamp=$(_isc_stamp_path 70007 closed/test)
+	rm -f "$closed_stamp" >/dev/null 2>&1 || true
+	: >"$STUB_LOG"
+	closed_out=$(STUB_ISSUE_STATE="$closed_state" STUB_ISSUE_HAS_IN_REVIEW=1 \
+		_isc_cmd_claim 70007 closed/test --worktree /tmp/closed-wt --implementing 2>&1)
+	closed_rc=$?
+	closed_log=$(cat "$STUB_LOG")
+
+	if [[ $closed_rc -eq 0 && ! -f "$closed_stamp" ]] &&
+		printf '%s' "$closed_out" | grep -q 'is closed' &&
+		! printf '%s' "$closed_log" | grep -q 'issue edit 70007' &&
+		! printf '%s' "$closed_log" | grep -q 'issue comment 70007'; then
+		print_result "GH#27871: claim on ${closed_state} issue skips lifecycle writes" 0
+	else
+		print_result "GH#27871: claim on ${closed_state} issue skips lifecycle writes" 1 \
+			"(rc=$closed_rc, stamp=$([[ -f "$closed_stamp" ]] && echo yes || echo no), log=${closed_log:0:300}, out=${closed_out:0:200})"
+	fi
+done
+
+# =============================================================================
 # Summary
 # =============================================================================
 printf '\n'


### PR DESCRIPTION
## Summary

Guard interactive claims before any stamp, label, assignment, or comment write when the target issue is closed.

## Files Changed

.agents/scripts/interactive-session-helper-commands.sh, .agents/scripts/tests/test-interactive-session-claim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 40 interactive-session claim tests pass; 7 worktree auto-claim tests pass; ShellCheck clean; complexity regression check has no new violations.

Resolves #27871


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.127 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 33m and 262,775 tokens on this with the user in an interactive session.