### PR TITLE
GH#27874: Include complete review thread command signatures

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -957,9 +957,11 @@ Thread preview: ${safe_preview}
    PR, do not mark a draft PR ready, and do not bypass review-bot-gate.
 3. Do not use blanket auto-resolution scripts. For active review threads, respond
    in the same GitHub review thread with
-   '${scanner_path} reply'; resolve with
-   '${scanner_path} resolve' only after
+   '${scanner_path} reply ${repo_slug} <thread_id> <body_file>'; resolve with
+   '${scanner_path} resolve ${repo_slug} <thread_id>' only after
    you have verified the finding is addressed or no longer applies.
+   Write each reply to a local temporary file and pass that path as <body_file>.
+   Select <thread_id> from the unresolved thread IDs listed above.
    Review-thread read/reply/resolve operations are GraphQL-only in this helper;
    use the scanner commands above or 'gh api graphql'. The resolveReviewThread
    mutation has no REST endpoint, so do not try 'gh api repos/...' for resolve.
@@ -989,7 +991,7 @@ Verification context:
 - Preserve existing PR scope and provenance labels.
 - Keep comments concise and cite files/commands as evidence.
 - Completion requires each verified-addressed thread to be resolved with
-  resolveReviewThread via '${scanner_path} resolve'.
+  resolveReviewThread via '${scanner_path} resolve ${repo_slug} <thread_id>'.
 PROMPT_EOF
 	printf '%s\n' "$prompt_file"
 	return 0

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -267,14 +267,16 @@ test_dispatch_launches_worker_and_writes_state() {
 	return 0
 }
 
-test_dispatch_prompt_uses_framework_script_path() {
+test_dispatch_prompt_includes_full_thread_command_signatures() {
 	setup_test_env
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
 	wait_for_headless_log || true
-	if grep -q "${SCANNER} reply" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null && grep -q "${SCANNER} resolve" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
-		print_result "dispatch prompt uses framework scanner path" 0
+	if grep -Fq "${SCANNER} reply owner/repo <thread_id> <body_file>" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		grep -Fq "${SCANNER} resolve owner/repo <thread_id>" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		grep -Fq 'Write each reply to a local temporary file and pass that path as <body_file>' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
+		print_result "dispatch prompt includes full reply and resolve signatures" 0
 	else
-		print_result "dispatch prompt uses framework scanner path" 1 "prompt=$(tr '\n' ' ' <"$HEADLESS_PROMPT_CAPTURE" 2>/dev/null || printf '')"
+		print_result "dispatch prompt includes full reply and resolve signatures" 1 "prompt=$(tr '\n' ' ' <"$HEADLESS_PROMPT_CAPTURE" 2>/dev/null || printf '')"
 	fi
 	teardown_test_env
 	return 0
@@ -740,7 +742,7 @@ main() {
 	test_scan_pr_excludes_human_threads_by_default
 	test_scan_pr_can_include_human_threads_with_opt_in
 	test_dispatch_launches_worker_and_writes_state
-	test_dispatch_prompt_uses_framework_script_path
+	test_dispatch_prompt_includes_full_thread_command_signatures
 	test_dispatch_prompt_mentions_graphql_only_thread_operations
 	test_dispatch_prompt_requires_machine_readable_completion_state
 	test_dispatch_prompt_marks_dynamic_metadata_untrusted


### PR DESCRIPTION
## Summary

Render the full repo, thread ID, and body-file arguments for worker reply and resolve commands.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 30 focused scanner tests pass; ShellCheck clean.

Resolves #27874


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.127 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 36m and 278,884 tokens on this with the user in an interactive session.