### PR TITLE
GH#27881: bind release success to runtime convergence

### DIFF
--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -745,6 +745,26 @@ _runtime_bundle_switch_link() {
 	return 0
 }
 
+_runtime_bundle_version_is_older() {
+	local candidate="$1"
+	local active="$2"
+	local candidate_major="" candidate_minor="" candidate_patch=""
+	local active_major="" active_minor="" active_patch=""
+
+	IFS=. read -r candidate_major candidate_minor candidate_patch <<<"$candidate"
+	IFS=. read -r active_major active_minor active_patch <<<"$active"
+	case "${candidate_major}.${candidate_minor}.${candidate_patch}.${active_major}.${active_minor}.${active_patch}" in
+	*[!0-9.]*) return 1 ;;
+	esac
+
+	if [[ "$candidate_major" -lt "$active_major" ]] ||
+		[[ "$candidate_major" -eq "$active_major" && "$candidate_minor" -lt "$active_minor" ]] ||
+		[[ "$candidate_major" -eq "$active_major" && "$candidate_minor" -eq "$active_minor" && "$candidate_patch" -lt "$active_patch" ]]; then
+		return 0
+	fi
+	return 1
+}
+
 _runtime_bundle_prune() {
 	local bundles_dir="$1"
 	local active_root="$2"
@@ -805,11 +825,19 @@ _runtime_bundle_activate() {
 	local previous_link="$parent_dir/previous-runtime-bundle"
 	local previous_root=""
 	local legacy_dir=""
+	local candidate_version=""
+	local active_version=""
 	agents_root=$(_runtime_bundle_resolve_root "$bundle_dir/agents") || return 1
 	bundles_dir=$(cd "${bundle_dir%/*}" && pwd -P) || return 1
+	[[ -r "$agents_root/VERSION" ]] && IFS= read -r candidate_version <"$agents_root/VERSION"
 
 	if previous_root=$(_runtime_bundle_resolve_root "$target_dir" 2>/dev/null); then
 		_AIDEVOPS_PREVIOUS_BUNDLE_ROOT="$previous_root"
+		[[ -r "$previous_root/VERSION" ]] && IFS= read -r active_version <"$previous_root/VERSION"
+		if _runtime_bundle_version_is_older "$candidate_version" "$active_version"; then
+			print_error "Refusing to replace active aidevops v${active_version} runtime bundle with older v${candidate_version}"
+			return 1
+		fi
 	fi
 	if [[ -d "$target_dir" && ! -L "$target_dir" ]]; then
 		legacy_dir="${bundle_dir%/*}/legacy-$(date +%s)-$$"

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -753,16 +753,18 @@ _runtime_bundle_version_is_older() {
 
 	IFS=. read -r candidate_major candidate_minor candidate_patch <<<"$candidate"
 	IFS=. read -r active_major active_minor active_patch <<<"$active"
-	case "${candidate_major}.${candidate_minor}.${candidate_patch}.${active_major}.${active_minor}.${active_patch}" in
-	*[!0-9.]*) return 1 ;;
-	esac
-
 	if [[ "$candidate_major" -lt "$active_major" ]] ||
 		[[ "$candidate_major" -eq "$active_major" && "$candidate_minor" -lt "$active_minor" ]] ||
 		[[ "$candidate_major" -eq "$active_major" && "$candidate_minor" -eq "$active_minor" && "$candidate_patch" -lt "$active_patch" ]]; then
 		return 0
 	fi
 	return 1
+}
+
+_runtime_bundle_version_is_valid() {
+	local version="$1"
+	[[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || return 1
+	return 0
 }
 
 _runtime_bundle_prune() {
@@ -834,6 +836,11 @@ _runtime_bundle_activate() {
 	if previous_root=$(_runtime_bundle_resolve_root "$target_dir" 2>/dev/null); then
 		_AIDEVOPS_PREVIOUS_BUNDLE_ROOT="$previous_root"
 		[[ -r "$previous_root/VERSION" ]] && IFS= read -r active_version <"$previous_root/VERSION"
+		if ! _runtime_bundle_version_is_valid "$candidate_version" ||
+			! _runtime_bundle_version_is_valid "$active_version"; then
+			print_error "Refusing runtime bundle activation with malformed version: active=${active_version:-missing}, candidate=${candidate_version:-missing}"
+			return 1
+		fi
 		if _runtime_bundle_version_is_older "$candidate_version" "$active_version"; then
 			print_error "Refusing to replace active aidevops v${active_version} runtime bundle with older v${candidate_version}"
 			return 1

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -50,6 +50,10 @@ fi
 [[ -n "${AIDEVOPS_EXPECTED_DEPLOY_VERSION:-}" ]] || exit 0
 deployed_version="${AIDEVOPS_EXPECTED_DEPLOY_VERSION:?}"
 [[ "${MOCK_DEPLOY_STATE:-current}" == "stale" ]] && deployed_version="9.8.6"
+if [[ "${MOCK_DEPLOY_STATE:-current}" == "stale-once" && ! -f "${MOCK_DEPLOY_ATTEMPT_FILE:?}" ]]; then
+	printf 'stale deployment observed\n' >"$MOCK_DEPLOY_ATTEMPT_FILE"
+	deployed_version="9.8.6"
+fi
 bundle_dir="$HOME/.aidevops/runtime-bundles/${deployed_version}-fixture"
 mkdir -p "$bundle_dir/agents" "$HOME/bin"
 printf '%s\n' "$deployed_version" >"$bundle_dir/agents/VERSION"
@@ -100,6 +104,7 @@ invoke_release_sync() {
 		SYNC_ENV_LOG_PATH="$TEST_DIR/sync-env.log" \
 		MOCK_DEPLOY_EXIT_CODE="${MOCK_DEPLOY_EXIT_CODE:-0}" \
 		MOCK_DEPLOY_STATE="${MOCK_DEPLOY_STATE:-current}" \
+		MOCK_DEPLOY_ATTEMPT_FILE="$TEST_DIR/deploy-attempt" \
 		bash -c 'source "$1" && run_post_release_agent_sync' _ "$VERSION_HELPER"
 	return $?
 }
@@ -224,6 +229,23 @@ test_release_sync_rejects_stale_final_bundle() {
 	return 0
 }
 
+test_release_sync_recovers_after_competing_stale_setup() {
+	local repo_path
+	local deploy_count=""
+	: >"$TEST_DIR/sync.log"
+	rm -f "$TEST_DIR/deploy-attempt"
+	repo_path=$(create_fake_repo "release-recovery" "https://github.com/marcusquinn/aidevops.git")
+	if MOCK_DEPLOY_STATE=stale-once invoke_release_sync "$repo_path" >/dev/null 2>&1; then
+		deploy_count=$(grep -c -- "--repo $repo_path --full --quiet" "$TEST_DIR/sync.log")
+		if [[ "$deploy_count" -eq 2 && "$(tr -d '[:space:]' <"$TEST_DIR/home/.aidevops/agents/VERSION")" == "9.8.7" ]]; then
+			print_result "release sync recovers after a competing stale setup" 0
+			return 0
+		fi
+	fi
+	print_result "release sync recovers after a competing stale setup" 1 "Expected one retry ending at v9.8.7"
+	return 0
+}
+
 main() {
 	echo "Running agent auto-sync regression tests"
 	setup
@@ -236,6 +258,7 @@ main() {
 	test_release_sync_propagates_deploy_failure
 	test_release_sync_unsets_session_pins
 	test_release_sync_rejects_stale_final_bundle
+	test_release_sync_recovers_after_competing_stale_setup
 
 	teardown
 	trap - EXIT

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -42,8 +42,25 @@ cat >"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" <<'EOF'
 set -euo pipefail
 printf 'AIDEVOPS_AGENTS_DIR=%s\n' "${AIDEVOPS_AGENTS_DIR-unset}" >>"${SYNC_ENV_LOG_PATH:?SYNC_ENV_LOG_PATH must be set}"
 printf 'AGENTS_DIR=%s\n' "${AGENTS_DIR-unset}" >>"$SYNC_ENV_LOG_PATH"
+printf 'EXPECTED=%s\n' "${AIDEVOPS_EXPECTED_DEPLOY_VERSION-unset}" >>"$SYNC_ENV_LOG_PATH"
 printf '%s\n' "$*" >>"${SYNC_LOG_PATH:?SYNC_LOG_PATH must be set}"
-exit "${MOCK_DEPLOY_EXIT_CODE:-0}"
+if [[ "${MOCK_DEPLOY_EXIT_CODE:-0}" -ne 0 ]]; then
+	exit "$MOCK_DEPLOY_EXIT_CODE"
+fi
+[[ -n "${AIDEVOPS_EXPECTED_DEPLOY_VERSION:-}" ]] || exit 0
+deployed_version="${AIDEVOPS_EXPECTED_DEPLOY_VERSION:?}"
+[[ "${MOCK_DEPLOY_STATE:-current}" == "stale" ]] && deployed_version="9.8.6"
+bundle_dir="$HOME/.aidevops/runtime-bundles/${deployed_version}-fixture"
+mkdir -p "$bundle_dir/agents" "$HOME/bin"
+printf '%s\n' "$deployed_version" >"$bundle_dir/agents/VERSION"
+printf 'status=validated\nframework_version=%s\n' "$deployed_version" >"$bundle_dir/manifest"
+ln -sfn "$bundle_dir/agents" "$HOME/.aidevops/agents"
+cat >"$HOME/bin/aidevops" <<CLI
+#!/usr/bin/env bash
+printf 'aidevops %s\\n' '$deployed_version'
+CLI
+chmod +x "$HOME/bin/aidevops"
+exit 0
 EOF
 	chmod +x "$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh"
 	: >"$TEST_DIR/sync.log"
@@ -72,12 +89,17 @@ invoke_github_sync() {
 invoke_release_sync() {
 	local repo_root="$1"
 	local deployment_scope="${2:-incremental}"
-	AIDEVOPS_SYNC_REPO_ROOT="$repo_root" \
+	HOME="$TEST_DIR/home" \
+		PATH="$TEST_DIR/home/bin:/usr/bin:/bin" \
+		AIDEVOPS_RELEASE_DEPLOY_STABLE_S=0 \
+		AIDEVOPS_RELEASE_DEPLOY_SETTLE_TIMEOUT_S=2 \
+		AIDEVOPS_SYNC_REPO_ROOT="$repo_root" \
 		AIDEVOPS_RELEASE_DEPLOY_SCOPE="$deployment_scope" \
 		AIDEVOPS_SYNC_DEPLOY_SCRIPT="$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" \
 		SYNC_LOG_PATH="$TEST_DIR/sync.log" \
 		SYNC_ENV_LOG_PATH="$TEST_DIR/sync-env.log" \
 		MOCK_DEPLOY_EXIT_CODE="${MOCK_DEPLOY_EXIT_CODE:-0}" \
+		MOCK_DEPLOY_STATE="${MOCK_DEPLOY_STATE:-current}" \
 		bash -c 'source "$1" && run_post_release_agent_sync' _ "$VERSION_HELPER"
 	return $?
 }
@@ -91,6 +113,7 @@ create_fake_repo() {
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git init -q "$repo_path"
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" remote add origin "$remote_url"
 	printf '#!/usr/bin/env bash\nexit 0\n' >"$repo_path/setup.sh"
+	printf '9.8.7\n' >"$repo_path/VERSION"
 	printf '%s\n' "$repo_path"
 	return 0
 }
@@ -125,8 +148,8 @@ test_release_sync_triggers_for_aidevops_remote() {
 	repo_path=$(create_fake_repo "release-aidevops" "https://github.com/marcusquinn/aidevops.git")
 	invoke_release_sync "$repo_path"
 
-	if grep -q -- "--repo $repo_path --quiet" "$TEST_DIR/sync.log" && ! grep -q -- "--full" "$TEST_DIR/sync.log"; then
-		print_result "release sync defaults to incremental for aidevops remote" 0
+	if grep -q -- "--repo $repo_path --full --quiet" "$TEST_DIR/sync.log"; then
+		print_result "release sync uses atomic full deployment for release convergence" 0
 	else
 		print_result "release sync triggers for aidevops remote" 1 "Release sync command was not recorded"
 	fi
@@ -138,7 +161,7 @@ test_release_sync_explicit_full() {
 	local repo_path
 	repo_path=$(create_fake_repo "release-full" "https://github.com/marcusquinn/aidevops.git")
 	invoke_release_sync "$repo_path" full
-	if grep -q -- "--repo $repo_path --quiet --full" "$TEST_DIR/sync.log"; then
+	if grep -q -- "--repo $repo_path --full --quiet" "$TEST_DIR/sync.log"; then
 		print_result "release sync supports explicit full deployment" 0
 	else
 		print_result "release sync supports explicit full deployment" 1 "Full sync command was not recorded"
@@ -181,10 +204,22 @@ test_release_sync_unsets_session_pins() {
 		invoke_release_sync "$repo_path"
 
 	if grep -q '^AIDEVOPS_AGENTS_DIR=unset$' "$TEST_DIR/sync-env.log" && \
-		grep -q '^AGENTS_DIR=unset$' "$TEST_DIR/sync-env.log"; then
+		grep -q '^AGENTS_DIR=unset$' "$TEST_DIR/sync-env.log" && \
+		grep -q '^EXPECTED=9.8.7$' "$TEST_DIR/sync-env.log"; then
 		print_result "release sync isolates inherited runtime pins" 0
 	else
 		print_result "release sync isolates inherited runtime pins" 1 "Deployment child inherited a session pin"
+	fi
+	return 0
+}
+
+test_release_sync_rejects_stale_final_bundle() {
+	local repo_path
+	repo_path=$(create_fake_repo "release-stale" "https://github.com/marcusquinn/aidevops.git")
+	if MOCK_DEPLOY_STATE=stale invoke_release_sync "$repo_path" >/dev/null 2>&1; then
+		print_result "release sync rejects stale final runtime bundle" 1 "Stale convergence was reported as success"
+	else
+		print_result "release sync rejects stale final runtime bundle" 0
 	fi
 	return 0
 }
@@ -200,6 +235,7 @@ main() {
 	test_release_sync_skips_other_remotes
 	test_release_sync_propagates_deploy_failure
 	test_release_sync_unsets_session_pins
+	test_release_sync_rejects_stale_final_bundle
 
 	teardown
 	trap - EXIT

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -326,6 +326,23 @@ test_dependency_install_failure_preserves_active_bundle() {
 	return 0
 }
 
+test_older_candidate_cannot_replace_active_bundle() {
+	local target_dir="$HOME/.aidevops/agents"
+	local active_before=""
+	local active_after=""
+	active_before=$(_runtime_bundle_resolve_root "$target_dir")
+	write_fake_revision "7.9.0" "stale-setup"
+	rm -rf "$FAKE_REPO/.agents/plugins"
+	stage_revision "$target_dir"
+	if _runtime_bundle_activate "$target_dir" "$_AIDEVOPS_STAGED_BUNDLE_DIR" >/dev/null 2>&1; then
+		fail "older setup candidate unexpectedly replaced the active bundle"
+	fi
+	active_after=$(_runtime_bundle_resolve_root "$target_dir")
+	assert_eq "$active_before" "$active_after" "older setup candidate cannot replace a newer active bundle"
+	assert_eq "8.0.0" "$(tr -d '[:space:]' <"$target_dir/VERSION")" "newer active version survives stale setup activation"
+	return 0
+}
+
 main() {
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
@@ -349,6 +366,7 @@ main() {
 	test_plugin_dependency_smoke_check
 	install_mock_plugin_dependency_hooks
 	test_dependency_install_recovery_activates_candidate
+	test_older_candidate_cannot_replace_active_bundle
 	test_dependency_install_failure_preserves_active_bundle
 
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -343,6 +343,25 @@ test_older_candidate_cannot_replace_active_bundle() {
 	return 0
 }
 
+test_malformed_candidate_version_cannot_replace_active_bundle() {
+	local target_dir="$HOME/.aidevops/agents"
+	local active_before=""
+	local active_after=""
+	local malformed_version=""
+	active_before=$(_runtime_bundle_resolve_root "$target_dir")
+	for malformed_version in 08.0.0 1.2.3.4; do
+		write_fake_revision "$malformed_version" "malformed-version"
+		stage_revision "$target_dir"
+		if _runtime_bundle_activate "$target_dir" "$_AIDEVOPS_STAGED_BUNDLE_DIR" >/dev/null 2>&1; then
+			fail "malformed version $malformed_version unexpectedly replaced the active bundle"
+		fi
+		active_after=$(_runtime_bundle_resolve_root "$target_dir")
+		assert_eq "$active_before" "$active_after" "malformed version $malformed_version preserves the active bundle"
+	done
+	assert_eq "8.0.0" "$(tr -d '[:space:]' <"$target_dir/VERSION")" "valid active version survives malformed setup candidates"
+	return 0
+}
+
 main() {
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
@@ -367,6 +386,7 @@ main() {
 	install_mock_plugin_dependency_hooks
 	test_dependency_install_recovery_activates_candidate
 	test_older_candidate_cannot_replace_active_bundle
+	test_malformed_candidate_version_cannot_replace_active_bundle
 	test_dependency_install_failure_preserves_active_bundle
 
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-setup-cli-convergence-mutex.sh
+++ b/.agents/scripts/tests/test-setup-cli-convergence-mutex.sh
@@ -23,8 +23,8 @@ main() {
 	local deploy_line=""
 	local converge_line=""
 	local exit_trap_line=""
-	# shellcheck disable=SC2016 # Match the literal release-library command.
-	local full_deploy_pattern='bash "$deploy_script" --repo "$sync_repo_root" --full --quiet'
+	# shellcheck disable=SC2016 # Match the literal release-library argument contract.
+	local full_deploy_pattern='local -a deploy_args=(--repo "$sync_repo_root" --full --quiet)'
 
 	acquire_line=$(line_for '_setup_acquire_noninteractive_setup_lock "$@"' "$SETUP_SCRIPT")
 	dispatch_line=$(line_for '^[[:space:]]*_setup_run_non_interactive$' "$SETUP_SCRIPT" | while IFS= read -r line_number; do

--- a/.agents/scripts/tests/test-setup-stage-timing-observability.sh
+++ b/.agents/scripts/tests/test-setup-stage-timing-observability.sh
@@ -114,6 +114,7 @@ test_noninteractive_cli_failure_continues_config_reconciliation() {
 			return 0
 		}
 		_setup_run_non_interactive
+		printf 'critical_failure=%s\n' "${_SETUP_DEPLOYMENT_CRITICAL_FAILURE:-0}"
 	) >"$output_file" 2>&1
 	status=$?
 
@@ -122,7 +123,9 @@ test_noninteractive_cli_failure_continues_config_reconciliation() {
 	if [[ "$status" -eq 0 ]] &&
 		grep -qx "install_aidevops_cli" "$trace_file" &&
 		grep -qx "update_opencode_config" "$trace_file" &&
-		[[ "$output" == *"continuing configuration reconciliation"* ]]; then
+		[[ "$output" == *"continuing configuration reconciliation"* ]] &&
+		[[ "$output" == *"critical_failure=1"* ]] &&
+		grep -q 'Setup configuration reconciliation finished, but CLI convergence failed' "$SETUP_SH"; then
 		print_result "non-interactive setup continues config reconciliation after CLI failure" 0
 		rm -rf "$tmp_home"
 		return 0

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -355,7 +355,68 @@ validate_release_deployment_readiness() {
 	return 0
 }
 
+verify_release_deployment_convergence() {
+	local expected_version="$1"
+	local target_dir="$HOME/.aidevops/agents"
+	local active_root=""
+	local deployed_version=""
+	local active_version=""
+	local manifest_version=""
+	local cli_version=""
+
+	[[ -n "$expected_version" ]] || return 1
+	if [[ ! -L "$target_dir" ]]; then
+		print_error "Release deployment convergence failed: active agents target is not a runtime-bundle symlink"
+		return 1
+	fi
+	active_root=$(cd "$target_dir" 2>/dev/null && pwd -P) || active_root=""
+	case "$active_root" in
+	"$HOME/.aidevops/runtime-bundles/"*/agents) ;;
+	*)
+		print_error "Release deployment convergence failed: active agents target does not resolve inside runtime-bundles"
+		return 1
+		;;
+	esac
+	[[ -r "$target_dir/VERSION" ]] && IFS= read -r deployed_version <"$target_dir/VERSION"
+	[[ -r "$active_root/VERSION" ]] && IFS= read -r active_version <"$active_root/VERSION"
+	if [[ -r "${active_root%/agents}/manifest" ]]; then
+		manifest_version=$(awk -F= '$1=="framework_version" { print $2; exit }' "${active_root%/agents}/manifest")
+	fi
+	cli_version=$(aidevops --version 2>/dev/null | awk 'NR==1 && $1=="aidevops" { print $2; exit }') || cli_version=""
+
+	if [[ "$deployed_version" != "$expected_version" || "$active_version" != "$expected_version" ||
+		"$manifest_version" != "$expected_version" || "$cli_version" != "$expected_version" ]]; then
+		print_error "Release deployment convergence failed: expected v${expected_version}, CLI=${cli_version:-missing}, agents=${deployed_version:-missing}, active-bundle=${active_version:-missing}, manifest=${manifest_version:-missing}"
+		return 1
+	fi
+	return 0
+}
+
+wait_for_release_deployment_settle() {
+	local lock_dir="${AIDEVOPS_SETUP_LOCK_DIR:-$HOME/.aidevops/locks/setup-noninteractive.lock.d}"
+	local timeout_s="${AIDEVOPS_RELEASE_DEPLOY_SETTLE_TIMEOUT_S:-900}"
+	local stable_s="${AIDEVOPS_RELEASE_DEPLOY_STABLE_S:-3}"
+	local waited=0
+	local stable=0
+
+	[[ "$timeout_s" =~ ^[0-9]+$ ]] || timeout_s=900
+	[[ "$stable_s" =~ ^[0-9]+$ ]] || stable_s=3
+	while [[ "$waited" -lt "$timeout_s" ]]; do
+		if [[ -d "$lock_dir" ]]; then
+			stable=0
+		else
+			stable=$((stable + 1))
+			[[ "$stable" -gt "$stable_s" ]] && return 0
+		fi
+		sleep 1
+		waited=$((waited + 1))
+	done
+	print_error "Timed out waiting for competing setup processes to settle after release deployment"
+	return 1
+}
+
 run_post_release_agent_sync() {
+	local expected_version="${1:-}"
 	local sync_repo_root="${AIDEVOPS_SYNC_REPO_ROOT:-$REPO_ROOT}"
 	local remote_url
 	remote_url=$(git -C "$sync_repo_root" remote get-url origin 2>/dev/null || echo "")
@@ -366,10 +427,9 @@ run_post_release_agent_sync() {
 
 	local deploy_script="${AIDEVOPS_SYNC_DEPLOY_SCRIPT:-$sync_repo_root/.agents/scripts/deploy-agents-on-merge.sh}"
 	local deployment_scope="${AIDEVOPS_RELEASE_DEPLOY_SCOPE:-incremental}"
-	local -a deploy_args=(--repo "$sync_repo_root" --quiet)
+	local -a deploy_args=(--repo "$sync_repo_root" --full --quiet)
 	case "$deployment_scope" in
-	incremental) ;;
-	full) deploy_args+=(--full) ;;
+	incremental | full) ;;
 	*)
 		print_error "Invalid release deployment scope: $deployment_scope (expected incremental or full)"
 		return 1
@@ -380,20 +440,34 @@ run_post_release_agent_sync() {
 		return 1
 	fi
 	validate_release_deployment_readiness || return 1
+	if [[ -z "$expected_version" && -r "$sync_repo_root/VERSION" ]]; then
+		IFS= read -r expected_version <"$sync_repo_root/VERSION"
+	fi
+	if [[ -z "$expected_version" ]]; then
+		print_error "Post-release deployment gate cannot resolve the requested release version"
+		return 1
+	fi
 
 	print_info "Running post-release aidevops agent sync..."
 	local sync_output=""
 	local sync_exit=0
-	sync_output=$(env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR \
-		AIDEVOPS_DEPLOY_TARGET="$HOME/.aidevops/agents" \
-		bash "$deploy_script" "${deploy_args[@]}" 2>&1) || sync_exit=$?
+	local attempt=1
+	while [[ "$attempt" -le 2 ]]; do
+		sync_exit=0
+		sync_output=$(env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR \
+			AIDEVOPS_DEPLOY_TARGET="$HOME/.aidevops/agents" \
+			AIDEVOPS_EXPECTED_DEPLOY_VERSION="$expected_version" \
+			bash "$deploy_script" "${deploy_args[@]}" 2>&1) || sync_exit=$?
+		if [[ "$sync_exit" -eq 0 ]] && wait_for_release_deployment_settle &&
+			verify_release_deployment_convergence "$expected_version"; then
+			print_success "Post-release aidevops deployment and CLI convergence completed for v${expected_version}"
+			return 0
+		fi
+		print_warning "Release deployment convergence attempt ${attempt} did not remain at v${expected_version}; retrying after competing setup activity"
+		attempt=$((attempt + 1))
+	done
 
-	if [[ "$sync_exit" -eq 0 ]]; then
-		print_success "Post-release aidevops deployment and CLI convergence completed"
-		return 0
-	fi
-
-	print_error "Post-release aidevops deployment or CLI convergence failed: $sync_output"
+	print_error "Post-release aidevops deployment or CLI convergence failed for v${expected_version}: $sync_output"
 	return 1
 }
 
@@ -409,7 +483,7 @@ run_post_publication_gates() {
 	if [[ "$hotfix_flag" -eq 1 ]]; then
 		_create_hotfix_tag "$version" || hotfix_exit=$?
 	fi
-	run_post_release_agent_sync || deployment_exit=$?
+	run_post_release_agent_sync "$version" || deployment_exit=$?
 
 	if [[ "$hotfix_exit" -ne 0 || "$deployment_exit" -ne 0 ]]; then
 		print_error "PARTIAL RELEASE SUCCESS: GitHub release v$version remains published; post-publication gates failed"

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -427,6 +427,8 @@ run_post_release_agent_sync() {
 
 	local deploy_script="${AIDEVOPS_SYNC_DEPLOY_SCRIPT:-$sync_repo_root/.agents/scripts/deploy-agents-on-merge.sh}"
 	local deployment_scope="${AIDEVOPS_RELEASE_DEPLOY_SCOPE:-incremental}"
+	# Every version publication requires atomic bundle and CLI convergence, so
+	# both accepted scopes intentionally use a serialized full deployment.
 	local -a deploy_args=(--repo "$sync_repo_root" --full --quiet)
 	case "$deployment_scope" in
 	incremental | full) ;;
@@ -462,6 +464,9 @@ run_post_release_agent_sync() {
 			verify_release_deployment_convergence "$expected_version"; then
 			print_success "Post-release aidevops deployment and CLI convergence completed for v${expected_version}"
 			return 0
+		fi
+		if [[ "$sync_exit" -ne 0 ]]; then
+			wait_for_release_deployment_settle || true
 		fi
 		print_warning "Release deployment convergence attempt ${attempt} did not remain at v${expected_version}; retrying after competing setup activity"
 		attempt=$((attempt + 1))

--- a/setup.sh
+++ b/setup.sh
@@ -1452,6 +1452,7 @@ _setup_run_scoped_stage() {
 
 _setup_run_non_interactive() {
 	print_info "Non-interactive mode: deploying agents and running safe migrations only"
+	_SETUP_DEPLOYMENT_CRITICAL_FAILURE=0
 
 	_setup_init_stage_timing_log
 
@@ -1495,7 +1496,10 @@ _setup_run_non_interactive() {
 	_time_step "$SETUP_STAGE_HOTFIX_CONFIG" _deploy_hotfix_config
 	_time_step "setup_opencode_desktop_launcher" setup_opencode_desktop_launcher
 	_time_step "sync_agent_sources" sync_agent_sources
-	_time_step "install_aidevops_cli" install_aidevops_cli || print_warning "aidevops CLI installation encountered issues; continuing configuration reconciliation"
+	if ! _time_step "install_aidevops_cli" install_aidevops_cli; then
+		print_warning "aidevops CLI installation encountered issues; continuing configuration reconciliation"
+		_SETUP_DEPLOYMENT_CRITICAL_FAILURE=1
+	fi
 	_time_step "setup_shellcheck_wrapper" setup_shellcheck_wrapper
 	if is_feature_enabled safety_hooks 2>/dev/null; then
 		_time_step "$SETUP_STAGE_HOOKS" setup_safety_hooks
@@ -1953,6 +1957,10 @@ main() {
 	_setup_restart_pulse_if_running
 
 	if [[ "$NON_INTERACTIVE" == "true" ]]; then
+		if [[ "${_SETUP_DEPLOYMENT_CRITICAL_FAILURE:-0}" -ne 0 ]]; then
+			print_error "Setup configuration reconciliation finished, but CLI convergence failed"
+			return 1
+		fi
 		_setup_print_noninteractive_success
 	fi
 


### PR DESCRIPTION
## Summary

Require release deployments to converge the CLI, agents VERSION, and active runtime-bundle manifest to the requested version; preserve configuration reconciliation while failing setup on CLI convergence errors; reject stale bundle downgrades.

## Files Changed

.agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/tests/test-agent-auto-sync.sh, .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh, .agents/scripts/tests/test-setup-cli-convergence-mutex.sh, .agents/scripts/tests/test-setup-stage-timing-observability.sh, .agents/scripts/version-manager-release.sh, setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused release/setup tests and ShellCheck pass; package typecheck could not run locally because dependencies are not installed, so remote CI remains authoritative.

Resolves #27881


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 9m and 159,104 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented older runtime bundles from replacing newer active versions.
  - Improved release deployment reliability by verifying version consistency across deployed components.
  - Added automatic retry and settlement checks when competing deployments are detected.
  - Non-interactive setup now reports CLI installation failures clearly and exits with an error instead of showing a false success.

- **Tests**
  - Expanded coverage for stale bundle rejection, deployment recovery, and setup failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->