### PR TITLE
GH#27879: Gate ruleset auto-merge fallback

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1522,9 +1522,12 @@ ${merge_output}"
 ${_missing_check_update_output}"
 	fi
 	if [[ $_merge_exit -ne 0 && "$merge_output" == *"Repository rule violations found"* ]]; then
-		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; retrying with native auto-merge without --admin (GH#24438): ${merge_output}" >>"$LOGFILE"
+		echo "[pulse-wrapper] Deterministic merge: admin merge hit repository rulesets for PR #${pr_number} in ${repo_slug}; evaluating protection-respecting fallbacks (GH#24438): ${merge_output}" >>"$LOGFILE"
 		if [[ "${_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE:-0}" == "1" ]]; then
 			_auto_merge_output="native auto-merge skipped: mutable external approval state requires synchronous final revalidation"
+			_auto_merge_exit=1
+		elif ! _repo_allows_auto_merge "$repo_slug"; then
+			_auto_merge_output="native auto-merge skipped: repository does not allow auto-merge (GH#27879)"
 			_auto_merge_exit=1
 		else
 			if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
@@ -1541,7 +1544,7 @@ ${_missing_check_update_output}"
 
 [native auto-merge fallback]
 ${_auto_merge_output}"
-		echo "[pulse-wrapper] Deterministic merge: native auto-merge fallback failed for PR #${pr_number} in ${repo_slug}; retrying direct merge without --admin (GH#23087): ${_auto_merge_output}" >>"$LOGFILE"
+		echo "[pulse-wrapper] Deterministic merge: native auto-merge fallback unavailable or failed for PR #${pr_number} in ${repo_slug}; retrying direct merge without --admin (GH#23087): ${_auto_merge_output}" >>"$LOGFILE"
 		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
 			return 1
 		fi

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -184,6 +184,7 @@ _retarget_stacked_children() { return 0; }
 _pulse_merge_admin_safety_check() { return 0; }
 _pulse_merge_final_trust_gate() { _PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE=0; return 0; }
 _set_native_auto_merge_or_skip() { return 1; }
+_repo_allows_auto_merge() { return "${REPO_ALLOWS_AUTO_MERGE_RC:-0}"; }
 _attempt_existing_auto_merge_behind_update_branch() { return 1; }
 _attempt_green_behind_update_branch() { return "${GREEN_BEHIND_UPDATE_RC:-1}"; }
 _handle_post_merge_actions() { return 0; }
@@ -240,13 +241,40 @@ test_ruleset_violation_enables_auto_merge_without_admin() {
 		teardown_test_env
 		return 0
 	fi
-	if ! grep -qE 'retrying with native auto-merge without --admin.*GH#24438' "$LOGFILE"; then
+	if ! grep -qE 'evaluating protection-respecting fallbacks.*GH#24438' "$LOGFILE"; then
 		print_result "ruleset violation fallback writes audit log" 1 "pulse log: $(cat "$LOGFILE")"
 		teardown_test_env
 		return 0
 	fi
 	print_result "ruleset violation fallback enables native auto-merge and succeeds" 0
 	teardown_test_env
+	return 0
+}
+
+test_ruleset_violation_skips_native_auto_merge_when_disabled() {
+	REPO_ALLOWS_AUTO_MERGE_RC=1
+	setup_test_env
+	define_function_under_test || {
+		teardown_test_env
+		unset REPO_ALLOWS_AUTO_MERGE_RC
+		return 0
+	}
+
+	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test","headRefOid":"head-current"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -eq 3 ]] &&
+		! grep -qE 'gh pr merge 77 .*--auto' "$GH_LOG" &&
+		grep -qE 'gh pr merge 77 --repo owner/repo --squash --match-head-commit head-current$' "$GH_LOG" &&
+		grep -qF 'native auto-merge skipped: repository does not allow auto-merge' "$LOGFILE"; then
+		print_result "ruleset fallback skips native auto-merge when repository disables it" 0
+	else
+		print_result "ruleset fallback skips native auto-merge when repository disables it" 1 \
+			"result=${result}; gh log: $(tr '\n' ';' <"$GH_LOG"); pulse log: $(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	unset REPO_ALLOWS_AUTO_MERGE_RC
 	return 0
 }
 
@@ -478,6 +506,7 @@ test_ruleset_fallback_failure_preserves_admin_conversation_context() {
 
 main() {
 	test_ruleset_violation_enables_auto_merge_without_admin
+	test_ruleset_violation_skips_native_auto_merge_when_disabled
 	test_green_behind_update_defers_before_merge_attempts
 	test_draft_pr_without_origin_labels_skips_merge_write
 	test_expected_required_check_updates_branch_and_defers


### PR DESCRIPTION
## Summary

Skip the impossible native auto-merge mutation when repository settings disable auto-merge and continue to the direct fallback.

## Files Changed

.agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 8 ruleset fallback tests pass; ShellCheck clean.

Resolves #27879


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.127 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 43m and 331,131 tokens on this with the user in an interactive session.