### PR TITLE
GH#27893: fix: guard migration test cleanup trap

### DIFF
--- a/.agents/scripts/tests/test-model-routing-reasoning-migration.sh
+++ b/.agents/scripts/tests/test-model-routing-reasoning-migration.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MIGRATIONS_MODULE="${SCRIPT_DIR}/../setup/modules/migrations.sh"
 SETUP_SCRIPT="${SCRIPT_DIR}/../../../setup.sh"
 TEST_ROOT=$(mktemp -d)
-trap 'rm -rf "$TEST_ROOT"' EXIT
+trap '[[ -z "${TEST_ROOT:-}" ]] || rm -rf "$TEST_ROOT"' EXIT
 
 print_info() {
 	return 0


### PR DESCRIPTION
## Summary

Guard the model-routing migration test cleanup trap against an unset or empty TEST_ROOT so EXIT cleanup cannot mask an earlier failure under set -u.

## Files Changed

.agents/scripts/tests/test-model-routing-reasoning-migration.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-model-routing-reasoning-migration.sh; shellcheck .agents/scripts/tests/test-model-routing-reasoning-migration.sh

Resolves #27893


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 10m and 48,164 tokens on this as a headless worker.