### PR TITLE
GH#27884: fix: preserve plist overrides across runtime bundles

### DIFF
--- a/.agents/configs/plist-env-overrides.json.txt
+++ b/.agents/configs/plist-env-overrides.json.txt
@@ -1,5 +1,5 @@
 {
-  "_doc": "Copy this file to plist-env-overrides.json (gitignored) to activate. Keys are launchd plist labels. Values are objects mapping env var names to string values. Keys prefixed with _ are ignored by the loader.",
+  "_doc": "Copy this template to ~/.config/aidevops/plist-env-overrides.json to activate. Keys are launchd plist labels. Values are objects mapping env var names to string values. Keys prefixed with _ are ignored by the loader.",
   "com.aidevops.aidevops-supervisor-pulse": {
     "_doc": "Examples — rename (remove leading _) to activate. All values must be strings.",
     "_SCANNER_NUDGE_AGE_HOURS": "0",

--- a/.agents/reference/plist-env-overrides.md
+++ b/.agents/reference/plist-env-overrides.md
@@ -10,19 +10,20 @@ losing them on every `aidevops update` or `setup.sh` run.
 `~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist`
 are silently wiped.
 
-The override file survives framework updates because it lives outside the
-deployed agent scripts tree and is gitignored.
+The override file survives framework updates because it lives in the stable
+user config root, outside replaceable runtime bundles.
 
 ## Setup
 
 ```bash
 # 1. Copy the committed template to the working file
+mkdir -p ~/.config/aidevops
 cp ~/.aidevops/agents/configs/plist-env-overrides.json.txt \
-   ~/.aidevops/agents/configs/plist-env-overrides.json
+   ~/.config/aidevops/plist-env-overrides.json
 
 # 2. Edit the working file — add the env vars you want
 #    Keys prefixed with _ are ignored (template examples)
-nano ~/.aidevops/agents/configs/plist-env-overrides.json
+nano ~/.config/aidevops/plist-env-overrides.json
 
 # 3. Run setup.sh to regenerate the plist with your overrides
 ~/.aidevops/agents/../setup.sh --non-interactive
@@ -102,11 +103,19 @@ override file for aidevops-specific tuning variables only.
 | File present, malformed JSON | `WARN` logged; plist generated without overrides. |
 | `jq` not installed | `WARN` logged; plist generated without overrides. |
 
+## Legacy File Migration
+
+During runtime-bundle deployment, setup copies an existing legacy working file
+from `~/.aidevops/agents/configs/plist-env-overrides.json` to the stable config
+root once. An existing stable file is never overwritten. Until that migration
+runs, the scheduler still reads the legacy file when no stable file exists.
+The stable file always takes precedence when both are present. Migration and
+setup diagnostics never print override values; injection logs key names only.
+
 ## Template Location
 
 The committed template (with example keys, all `_`-prefixed) lives at:
 `.agents/configs/plist-env-overrides.json.txt`
 
-The working file (gitignored) lives at:
-`.agents/configs/plist-env-overrides.json`
-(deployed to `~/.aidevops/agents/configs/plist-env-overrides.json`)
+The user-owned working file lives at:
+`~/.config/aidevops/plist-env-overrides.json`

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -587,6 +587,32 @@ _runtime_bundle_copy_preserved_dirs() {
 	return 0
 }
 
+# Move the user-owned plist override out of the replaceable runtime bundle.
+# The no-clobber hard link makes concurrent setup runs converge without
+# overwriting an existing stable config. No file contents are logged.
+_runtime_bundle_migrate_plist_env_overrides() {
+	local current_root="$1"
+	local legacy_file="$current_root/configs/plist-env-overrides.json"
+	local config_dir="$HOME/.config/aidevops"
+	local stable_file="$config_dir/plist-env-overrides.json"
+	local migration_tmp=""
+
+	[[ -f "$stable_file" || ! -f "$legacy_file" ]] && return 0
+	mkdir -p "$config_dir" || return 1
+	migration_tmp=$(mktemp "$config_dir/.plist-env-overrides.json.XXXXXX") || return 1
+	if ! cp "$legacy_file" "$migration_tmp" || ! chmod 600 "$migration_tmp"; then
+		rm -f "$migration_tmp"
+		return 1
+	fi
+	if ! ln "$migration_tmp" "$stable_file" 2>/dev/null && [[ ! -f "$stable_file" ]]; then
+		rm -f "$migration_tmp"
+		return 1
+	fi
+	rm -f "$migration_tmp"
+	print_info "  Migrated plist environment overrides to ~/.config/aidevops/plist-env-overrides.json"
+	return 0
+}
+
 _runtime_bundle_write_manifest() {
 	local bundle_dir="$1"
 	local repo_dir="$2"
@@ -668,12 +694,18 @@ _runtime_bundle_stage() {
 	bundle_id="${version//[^A-Za-z0-9._-]/_}-${git_sha}-$(date +%s)-$$"
 	bundle_dir=$(mktemp -d "$bundles_dir/.staging.${bundle_id}.XXXXXX") || return 1
 	mkdir -p "$bundle_dir/agents" || return 1
+	if current_root=$(_runtime_bundle_resolve_root "$target_dir" 2>/dev/null); then
+		_runtime_bundle_migrate_plist_env_overrides "$current_root" || {
+			rm -rf "$bundle_dir"
+			return 1
+		}
+	fi
 
 	if ! _deploy_agents_copy "$source_dir" "$bundle_dir/agents" "$@"; then
 		rm -rf "$bundle_dir"
 		return 1
 	fi
-	if current_root=$(_runtime_bundle_resolve_root "$target_dir" 2>/dev/null); then
+	if [[ -n "$current_root" ]]; then
 		_runtime_bundle_copy_preserved_dirs "$current_root" "$bundle_dir/agents" "$@" || {
 			rm -rf "$bundle_dir"
 			return 1

--- a/.agents/scripts/setup/modules/schedulers-pulse.sh
+++ b/.agents/scripts/setup/modules/schedulers-pulse.sh
@@ -642,16 +642,32 @@ _build_pulse_headless_env_xml() {
 # (used as comments in the JSON template).
 #
 # Args: $1=plist_label (e.g. "com.aidevops.aidevops-supervisor-pulse")
-#       $2=override_file (absolute path; default ~/.agents/configs/plist-env-overrides.json)
+#       $2=override_file (absolute path; default ~/.config/aidevops/plist-env-overrides.json)
 #       $3=indent (string to prepend each line; default "\t\t")
 #
 # Returns 0 on success (including empty result when label not found).
 # Prints WARN to stderr and returns 0 when file is present but malformed.
 # Emits nothing when file is absent.
+_plist_env_overrides_file() {
+	local stable_file="$HOME/.config/aidevops/plist-env-overrides.json"
+	local legacy_file="$HOME/.aidevops/agents/configs/plist-env-overrides.json"
+
+	if [[ -f "$stable_file" ]]; then
+		printf '%s' "$stable_file"
+	elif [[ -f "$legacy_file" ]]; then
+		# Compatibility fallback for installs that have not run bundle migration yet.
+		printf '%s' "$legacy_file"
+	else
+		printf '%s' "$stable_file"
+	fi
+	return 0
+}
+
 _build_plist_env_overrides_xml() {
 	local _label="$1"
-	local _override_file="${2:-$HOME/.aidevops/agents/configs/plist-env-overrides.json}"
+	local _override_file="${2:-}"
 	local _indent="${3:-		}"
+	[[ -n "$_override_file" ]] || _override_file=$(_plist_env_overrides_file)
 
 	# Missing file is the normal case (user has not created the override file yet)
 	[[ -f "$_override_file" ]] || return 0
@@ -698,7 +714,8 @@ _build_plist_env_overrides_xml() {
 # Args: $1=plist_label, $2=override_file (optional)
 _log_plist_env_overrides() {
 	local _label="$1"
-	local _override_file="${2:-$HOME/.aidevops/agents/configs/plist-env-overrides.json}"
+	local _override_file="${2:-}"
+	[[ -n "$_override_file" ]] || _override_file=$(_plist_env_overrides_file)
 
 	[[ -f "$_override_file" ]] || return 0
 	command -v jq >/dev/null 2>&1 || return 0
@@ -761,7 +778,8 @@ _generate_pulse_plist_content() {
 	_pulse_interval_sec=$(_read_pulse_interval_seconds)
 
 	# Inject user-owned plist env overrides (GH#20563 / t2759).
-	# Reads ~/.aidevops/agents/configs/plist-env-overrides.json when present.
+	# Reads ~/.config/aidevops/plist-env-overrides.json when present.
+	# A legacy bundle-local file remains readable until setup migrates it.
 	# Missing file or label not found → emits nothing (no-op, safe default).
 	local _env_overrides_xml
 	_env_overrides_xml=$(_build_plist_env_overrides_xml "$pulse_label")

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -26,6 +26,10 @@ source "$REPO_ROOT/.agents/scripts/setup/modules/plugins.sh"
 source "$REPO_ROOT/.agents/scripts/setup/modules/agent-deploy.sh"
 # shellcheck source=../setup/modules/agent-runtime.sh
 source "$REPO_ROOT/.agents/scripts/setup/modules/agent-runtime.sh"
+# shellcheck source=../setup/modules/schedulers-pulse.sh
+source "$REPO_ROOT/.agents/scripts/setup/modules/schedulers-pulse.sh"
+
+_xml_escape() { local value="$1"; printf '%s' "$value"; return 0; }
 
 cleanup() {
 	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
@@ -326,6 +330,34 @@ test_dependency_install_failure_preserves_active_bundle() {
 	return 0
 }
 
+test_plist_override_survives_two_bundle_activations() {
+	local target_dir="$HOME/.aidevops/agents"
+	local label="com.aidevops.aidevops-supervisor-pulse"
+	local legacy_file="$target_dir/configs/plist-env-overrides.json"
+	local stable_file="$HOME/.config/aidevops/plist-env-overrides.json"
+	local active_root=""
+	local output=""
+	local version=""
+	mkdir -p "${legacy_file%/*}"
+	printf '{"%s":{"TEST_OVERRIDE":"survives-two-activations"}}\n' "$label" >"$legacy_file"
+
+	for version in 10.0.0 11.0.0; do
+		write_fake_revision "$version" "plist-override-$version"
+		write_fake_plugin_manifest
+		MOCK_PLUGIN_VERIFY_MODE="available"
+		stage_revision "$target_dir"
+		_runtime_bundle_activate "$target_dir" "$_AIDEVOPS_STAGED_BUNDLE_DIR"
+		active_root=$(_runtime_bundle_resolve_root "$target_dir")
+		[[ ! -f "$active_root/configs/plist-env-overrides.json" ]] || fail "active $version bundle contains user-owned plist overrides"
+		output=$(_build_plist_env_overrides_xml "$label")
+		[[ "$output" == *"TEST_OVERRIDE"* && "$output" == *"survives-two-activations"* ]] || fail "override missing after $version activation"
+		pass "stable plist override applies after $version activation"
+	done
+	[[ -f "$stable_file" ]] || fail "legacy plist override was not migrated to stable config"
+	pass "legacy plist override migrates outside runtime bundles"
+	return 0
+}
+
 main() {
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
@@ -350,6 +382,7 @@ main() {
 	install_mock_plugin_dependency_hooks
 	test_dependency_install_recovery_activates_candidate
 	test_dependency_install_failure_preserves_active_bundle
+	test_plist_override_survives_two_bundle_activations
 
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"
 	return 0

--- a/.agents/scripts/tests/test-plist-env-overrides.sh
+++ b/.agents/scripts/tests/test-plist-env-overrides.sh
@@ -173,6 +173,48 @@ test_malformed_json_logs_warn_and_emits_nothing() {
 	return 0
 }
 
+test_default_path_prefers_stable_config_with_legacy_fallback() {
+	local original_home="$HOME"
+	local label="com.aidevops.aidevops-supervisor-pulse"
+	local legacy_file="$TEST_DIR/home/.aidevops/agents/configs/plist-env-overrides.json"
+	local stable_file="$TEST_DIR/home/.config/aidevops/plist-env-overrides.json"
+	local output=""
+	local ok=0
+	HOME="$TEST_DIR/home"
+	mkdir -p "${legacy_file%/*}" "${stable_file%/*}"
+	printf '{"%s":{"LEGACY_KEY":"legacy-value"}}\n' "$label" >"$legacy_file"
+
+	output=$(_build_plist_env_overrides_xml "$label")
+	[[ "$output" == *"LEGACY_KEY"* && "$output" == *"legacy-value"* ]] || ok=1
+	printf '{"%s":{"STABLE_KEY":"stable-value"}}\n' "$label" >"$stable_file"
+	output=$(_build_plist_env_overrides_xml "$label")
+	[[ "$output" == *"STABLE_KEY"* && "$output" == *"stable-value"* ]] || ok=1
+	[[ "$output" != *"LEGACY_KEY"* && "$output" != *"legacy-value"* ]] || ok=1
+
+	HOME="$original_home"
+	print_result "default_path: stable config wins with legacy fallback" "$ok" "output was: $output"
+	return 0
+}
+
+test_logging_contains_keys_not_values() {
+	local override_file="$TEST_DIR/logging-plist-env-overrides.json"
+	local output=""
+	local ok=0
+	cat >"$override_file" <<'EOF'
+{
+  "com.aidevops.aidevops-supervisor-pulse": {
+    "VISIBLE_KEY_NAME": "value-must-not-be-logged"
+  }
+}
+EOF
+	print_info() { printf '%s\n' "$*"; return 0; }
+	output=$(_log_plist_env_overrides "com.aidevops.aidevops-supervisor-pulse" "$override_file")
+	[[ "$output" == *"VISIBLE_KEY_NAME"* ]] || ok=1
+	[[ "$output" != *"value-must-not-be-logged"* ]] || ok=1
+	print_result "logging: reports override keys without values" "$ok" "output was: $output"
+	return 0
+}
+
 test_xml_structure_valid() {
 	# Check that the output is parseable XML when embedded in a minimal plist.
 	# Only runs if xmllint is available.
@@ -229,6 +271,8 @@ main() {
 	test_underscore_keys_skipped
 	test_no_label_match_emits_nothing
 	test_malformed_json_logs_warn_and_emits_nothing
+	test_default_path_prefers_stable_config_with_legacy_fallback
+	test_logging_contains_keys_not_values
 	test_xml_structure_valid
 
 	echo ""


### PR DESCRIPTION
## Summary

Preserve user-owned plist overrides outside runtime bundles with safe legacy migration and regression coverage.

## Files Changed

.agents/configs/plist-env-overrides.json.txt, .agents/reference/plist-env-overrides.md, .agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/setup/modules/schedulers-pulse.sh, .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh, .agents/scripts/tests/test-plist-env-overrides.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Scoped ShellCheck and both plist override regression tests pass.

Resolves #27884


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 16m and 99,149 tokens on this as a headless worker.