### PR TITLE
GH#27892: fix: harden model routing migration diagnostics

### DIFF
--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -455,8 +455,8 @@ cleanup_worktree_entries_in_repos_json() {
 		git_dir=$(cd "$git_dir" 2>/dev/null && pwd -P) || git_dir=""
 		common_dir=$(cd "$common_dir" 2>/dev/null && pwd -P) || common_dir=""
 		if [[ -n "$git_dir" && -n "$common_dir" && "$git_dir" != "$common_dir" ]]; then
-			if [[ -n "$current_worktree" && -n "$resolved_path" && "$resolved_path" == "$current_worktree" ]] \
-				|| [[ -n "$resolved_path" && "$current_physical_dir" == "$resolved_path"/* ]]; then
+			if [[ -n "$current_worktree" && -n "$resolved_path" && "$resolved_path" == "$current_worktree" ]] ||
+				[[ -n "$resolved_path" && "$current_physical_dir" == "$resolved_path"/* ]]; then
 				skipped_current_paths+=("$path")
 				continue
 			fi
@@ -1598,7 +1598,7 @@ migrate_custom_model_routing_reasoning_defaults() {
 		date -u +%Y-%m-%dT%H:%M:%SZ >"$marker_file"
 		return 0
 	fi
-	if [[ -L "$custom_table" || ! -f "$custom_table" || ( ! -O "$custom_table" && "$effective_uid" -ne 0 ) ]]; then
+	if [[ -L "$custom_table" || ! -f "$custom_table" || (! -O "$custom_table" && "$effective_uid" -ne 0) ]]; then
 		print_warning "Skipping unsafe custom model routing table; t18137 migration will retry"
 		return 0
 	fi

--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -1578,13 +1578,19 @@ migrate_orphaned_supervisor() {
 # defaults through agent deployment, so this migration must not create a custom
 # table that would freeze future framework routing updates.
 migrate_custom_model_routing_reasoning_defaults() {
-	local marker_dir="$HOME/.aidevops/cache/migrations"
-	local marker_file="$marker_dir/t18137-model-routing-reasoning-defaults"
-	local custom_table="$HOME/.aidevops/agents/custom/configs/model-routing-table.json"
-	local backup_dir="$HOME/.aidevops/config-backups/migrations"
-	local backup_file="$backup_dir/t18137-model-routing-table.json"
+	local marker_dir="${HOME:+$HOME/.aidevops/cache/migrations}"
+	local marker_file="${marker_dir:+$marker_dir/t18137-model-routing-reasoning-defaults}"
+	local custom_table="${HOME:+$HOME/.aidevops/agents/custom/configs/model-routing-table.json}"
+	local backup_dir="${HOME:+$HOME/.aidevops/config-backups/migrations}"
+	local backup_file="${backup_dir:+$backup_dir/t18137-model-routing-table.json}"
 	local temp_file=""
 	local jq_object_type="object"
+	local effective_uid="${EUID:-$(id -u)}"
+
+	if [[ -z "$custom_table" ]]; then
+		print_warning "HOME unavailable; t18137 custom model routing migration will retry"
+		return 0
+	fi
 
 	[[ -f "$marker_file" ]] && return 0
 	if [[ ! -e "$custom_table" ]]; then
@@ -1592,7 +1598,7 @@ migrate_custom_model_routing_reasoning_defaults() {
 		date -u +%Y-%m-%dT%H:%M:%SZ >"$marker_file"
 		return 0
 	fi
-	if [[ -L "$custom_table" || ! -f "$custom_table" || ! -O "$custom_table" ]]; then
+	if [[ -L "$custom_table" || ! -f "$custom_table" || ( ! -O "$custom_table" && "$effective_uid" -ne 0 ) ]]; then
 		print_warning "Skipping unsafe custom model routing table; t18137 migration will retry"
 		return 0
 	fi
@@ -1614,9 +1620,15 @@ migrate_custom_model_routing_reasoning_defaults() {
 
 	mkdir -p "$marker_dir" "$backup_dir"
 	if [[ ! -f "$backup_file" ]]; then
-		cp -p "$custom_table" "$backup_file" || return 0
+		cp -p "$custom_table" "$backup_file" || {
+			print_warning "Failed to create backup of custom model routing table at $backup_file; t18137 migration will retry"
+			return 0
+		}
 	fi
-	temp_file=$(mktemp "${custom_table}.t18137.XXXXXX") || return 0
+	temp_file=$(mktemp "${custom_table}.t18137.XXXXXX") || {
+		print_warning "Failed to create temporary file for migration of $custom_table; t18137 migration will retry"
+		return 0
+	}
 	if ! jq '
 		.tiers = (.tiers // {}) |
 		.tiers.simple = (.tiers.simple // {}) |
@@ -1626,11 +1638,13 @@ migrate_custom_model_routing_reasoning_defaults() {
 		.tiers.thinking.reasoning = (.tiers.thinking.reasoning // {}) |
 		.tiers.thinking.reasoning.openai = "max"
 	' "$custom_table" >"$temp_file"; then
+		print_warning "Failed to update custom model routing table structure in $custom_table; t18137 migration will retry"
 		rm -f "$temp_file"
 		return 0
 	fi
 	chmod 600 "$temp_file"
 	if ! mv "$temp_file" "$custom_table"; then
+		print_warning "Failed to replace custom model routing table at $custom_table; t18137 migration will retry"
 		rm -f "$temp_file"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-model-routing-reasoning-migration.sh
+++ b/.agents/scripts/tests/test-model-routing-reasoning-migration.sh
@@ -9,12 +9,15 @@ MIGRATIONS_MODULE="${SCRIPT_DIR}/../setup/modules/migrations.sh"
 SETUP_SCRIPT="${SCRIPT_DIR}/../../../setup.sh"
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
+WARNING_LOG="$TEST_ROOT/warnings.log"
 
 print_info() {
 	return 0
 }
 
 print_warning() {
+	local message="$1"
+	printf '%s\n' "$message" >>"$WARNING_LOG"
 	return 0
 }
 
@@ -36,7 +39,32 @@ assert_eq() {
 	return 0
 }
 
+assert_file_contains() {
+	local expected="$1"
+	local file="$2"
+	local message="$3"
+	if ! grep -Fq "$expected" "$file"; then
+		printf 'FAIL: %s (missing=%s)\n' "$message" "$expected" >&2
+		failures=$((failures + 1))
+		return 1
+	fi
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
 assert_eq "2" "$(grep -c 'migrate_custom_model_routing_reasoning_defaults' "$SETUP_SCRIPT")" "setup runs the migration in interactive and non-interactive paths" || true
+
+unset HOME
+migrate_custom_model_routing_reasoning_defaults
+assert_file_contains "HOME unavailable; t18137 custom model routing migration will retry" "$WARNING_LOG" "unset HOME defers migration without an unbound-variable failure" || true
+HOME=""
+migrate_custom_model_routing_reasoning_defaults
+assert_eq "2" "$(grep -c 'HOME unavailable; t18137 custom model routing migration will retry' "$WARNING_LOG")" "empty HOME also defers migration without resolving a root-level path" || true
+
+assert_file_contains "Failed to create backup of custom model routing table at \$backup_file" "$MIGRATIONS_MODULE" "backup failure reports its destination path" || true
+assert_file_contains "Failed to create temporary file for migration of \$custom_table" "$MIGRATIONS_MODULE" "temporary-file failure reports the custom table path" || true
+assert_file_contains "Failed to update custom model routing table structure in \$custom_table" "$MIGRATIONS_MODULE" "jq update failure reports the custom table path" || true
+assert_file_contains "Failed to replace custom model routing table at \$custom_table" "$MIGRATIONS_MODULE" "replacement failure reports the custom table path" || true
 
 HOME="$TEST_ROOT/no-custom"
 mkdir -p "$HOME"


### PR DESCRIPTION
## Summary

Guard the t18137 custom routing migration when HOME is unavailable, permit root-owned setup execution to process regular-user files, and emit path-specific warnings for recoverable file-operation failures. Extend migration regression coverage for HOME handling and diagnostics.

## Files Changed

.agents/scripts/setup/modules/migrations.sh, .agents/scripts/tests/test-model-routing-reasoning-migration.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-model-routing-reasoning-migration.sh; shellcheck .agents/scripts/setup/modules/migrations.sh .agents/scripts/tests/test-model-routing-reasoning-migration.sh; shfmt -d .agents/scripts/setup/modules/migrations.sh .agents/scripts/tests/test-model-routing-reasoning-migration.sh; .agents/scripts/linters-local.sh

Resolves #27892


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 31m and 70,689 tokens on this as a headless worker.