### PR TITLE
GH#27906: restore pulse dispatch PR guard fixture

### DIFF
--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
@@ -17,6 +17,7 @@ readonly TEST_RESET='\033[0m'
 TESTS_RUN=0
 TESTS_FAILED=0
 MOCK_GH_TARGET_IS_PR="0"
+_PULSE_DISPATCH_FALSE="false"
 
 print_result() {
 	local test_name="$1"


### PR DESCRIPTION
## Summary

Define the production false-sentinel fixture required by the extracted PR guard helper so the standalone regression suite remains strict under set -u.

## Files Changed

.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh; shellcheck .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh; git diff --check

Resolves #27906


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 7m and 57,688 tokens on this as a headless worker.