### PR TITLE
GH#27911: treat skipped optional checks as neutral

### DIFF
--- a/.agents/scripts/gh-checks-wait-helper.sh
+++ b/.agents/scripts/gh-checks-wait-helper.sh
@@ -14,7 +14,7 @@ _GCW_DEFAULT_TIMEOUT="${AIDEVOPS_GH_CHECKS_TIMEOUT_SECONDS:-1800}"
 _GCW_DEFAULT_INITIAL_INTERVAL="${AIDEVOPS_GH_CHECKS_INITIAL_INTERVAL_SECONDS:-15}"
 _GCW_DEFAULT_MAX_INTERVAL="${AIDEVOPS_GH_CHECKS_MAX_INTERVAL_SECONDS:-120}"
 _GCW_DEFAULT_HEARTBEAT_INTERVAL="${AIDEVOPS_GH_CHECKS_HEARTBEAT_SECONDS:-120}"
-readonly _GCW_BUCKET_PASS="pass" _GCW_BUCKET_PENDING="pending"
+readonly _GCW_BUCKET_PASS="pass" _GCW_BUCKET_PENDING="pending" _GCW_BUCKET_SKIPPING="skipping"
 
 usage() {
 	cat <<'EOF'
@@ -161,12 +161,13 @@ classify_state() {
 		printf 'success\n'
 		return 0
 	fi
-	if printf '%s' "$checks" | jq -e --arg pass "$_GCW_BUCKET_PASS" --arg pending "$_GCW_BUCKET_PENDING" \
-		'any(.[]; .bucket == "fail" or .bucket == "cancel" or .bucket == "skipping" or (.bucket != $pass and .bucket != $pending))' >/dev/null; then
+	if printf '%s' "$checks" | jq -e --arg pass "$_GCW_BUCKET_PASS" --arg pending "$_GCW_BUCKET_PENDING" --arg skipping "$_GCW_BUCKET_SKIPPING" \
+		'any(.[]; .bucket != $pass and .bucket != $pending and .bucket != $skipping)' >/dev/null; then
 		printf 'failure\n'
 		return 0
 	fi
-	if printf '%s' "$checks" | jq -e --arg pass "$_GCW_BUCKET_PASS" 'all(.[]; .bucket == $pass)' >/dev/null; then
+	if printf '%s' "$checks" | jq -e --arg pass "$_GCW_BUCKET_PASS" --arg skipping "$_GCW_BUCKET_SKIPPING" \
+		'all(.[]; .bucket == $pass or .bucket == $skipping)' >/dev/null; then
 		printf 'success\n'
 		return 0
 	fi
@@ -177,8 +178,8 @@ classify_state() {
 emit_failure_details() {
 	local checks="$1"
 	printf 'FAIL: required checks reached a terminal failure\n'
-	printf '%s' "$checks" | jq -r --arg pass "$_GCW_BUCKET_PASS" --arg pending "$_GCW_BUCKET_PENDING" \
-		'.[] | select(.bucket != $pass and .bucket != $pending) | "  \(.name): \(.bucket)\(if .link == "" then "" else " " + .link end)"'
+	printf '%s' "$checks" | jq -r --arg pass "$_GCW_BUCKET_PASS" --arg pending "$_GCW_BUCKET_PENDING" --arg skipping "$_GCW_BUCKET_SKIPPING" \
+		'.[] | select(.bucket != $pass and .bucket != $pending and .bucket != $skipping) | "  \(.name): \(.bucket)\(if .link == "" then "" else " " + .link end)"'
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-checks-wait-helper.sh
+++ b/.agents/scripts/tests/test-gh-checks-wait-helper.sh
@@ -75,6 +75,16 @@ write_fixture "$empty_dir" 1 '[]'
 empty_output=$(run_fixture_wait "$empty_dir")
 assert_contains "no required checks is terminal success" "PASS: required checks completed" "$empty_output"
 
+mixed_skipping_dir="${TMPDIR_TEST}/mixed-skipping"
+write_fixture "$mixed_skipping_dir" 1 '[{"name":"Required","workflow":"CI","state":"SUCCESS","bucket":"pass","link":""},{"name":"Optional","workflow":"CI","state":"SKIPPED","bucket":"skipping","link":""}]'
+mixed_skipping_output=$(run_fixture_wait "$mixed_skipping_dir")
+assert_contains "pass plus skipping is terminal success" "PASS: required checks completed" "$mixed_skipping_output"
+
+skipping_only_dir="${TMPDIR_TEST}/skipping-only"
+write_fixture "$skipping_only_dir" 1 '[{"name":"Optional","workflow":"CI","state":"SKIPPED","bucket":"skipping","link":""}]'
+skipping_only_output=$(run_fixture_wait "$skipping_only_dir")
+assert_contains "skipping-only checks are terminal success" "PASS: required checks completed" "$skipping_only_output"
+
 set +e
 head_unavailable_output=$(AIDEVOPS_GH_CHECKS_TEST_HEAD_OVERRIDE='' run_fixture_wait "$empty_dir" 2>&1)
 head_unavailable_rc=$?
@@ -92,6 +102,18 @@ set -e
 assert_contains "terminal failure names failed check" "ShellCheck: fail" "$failure_output"
 failure_link_count=$(printf '%s\n' "$failure_output" | grep -c 'https://example.invalid/failure' || true)
 [[ "$failure_link_count" -eq 1 ]] && pass "failure link is emitted once" || fail "failure link is emitted once" "count ${failure_link_count}"
+
+other_failure_dir="${TMPDIR_TEST}/other-failures"
+write_fixture "$other_failure_dir" 1 '[{"name":"Cancelled","workflow":"CI","state":"CANCELLED","bucket":"cancel","link":""},{"name":"Unexpected","workflow":"CI","state":"UNKNOWN","bucket":"mystery","link":""},{"name":"Optional","workflow":"CI","state":"SKIPPED","bucket":"skipping","link":""}]'
+set +e
+other_failure_output=$(run_fixture_wait "$other_failure_dir" 2>&1)
+other_failure_rc=$?
+set -e
+[[ "$other_failure_rc" -eq 1 ]] && pass "cancel and unknown buckets return one" || fail "cancel and unknown buckets return one" "got ${other_failure_rc}"
+assert_contains "cancelled check is reported" "Cancelled: cancel" "$other_failure_output"
+assert_contains "unknown bucket is reported" "Unexpected: mystery" "$other_failure_output"
+skipping_detail_count=$(printf '%s\n' "$other_failure_output" | grep -c '^  Optional: skipping$' || true)
+[[ "$skipping_detail_count" -eq 1 ]] && pass "skipped check is omitted from failure details" || fail "skipped check is omitted from failure details" "count ${skipping_detail_count}"
 
 recovery_dir="${TMPDIR_TEST}/recovery"
 write_fixture "$recovery_dir" 1 'not-json'


### PR DESCRIPTION
## Summary

Treat GitHub's skipping bucket as a neutral terminal state and keep it out of failure details.

## Files Changed

.agents/scripts/gh-checks-wait-helper.sh, .agents/scripts/tests/test-gh-checks-wait-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 22 focused helper tests pass; ShellCheck clean; live PR #27899 completes with pass=45 skipping=22.

Resolves #27911


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 19m and 212,795 tokens on this with the user in an interactive session.