### PR TITLE
GH#27902: finalize WIP history before PR creation

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -308,6 +308,16 @@ _ensure_no_in_progress_integration() {
 
 # --- Input Validation ---
 
+# Return 0 when a commit subject is an intermediate WIP message.
+# Args: $1=commit subject
+_is_wip_commit_message() {
+	local message="$1"
+	if [[ "$message" =~ ^wip[[:space:]:\(] ]]; then
+		return 0
+	fi
+	return 1
+}
+
 # Validate commit-and-pr inputs: required fields and branch safety.
 # Sets caller-scoped $repo and $branch on success.
 # Returns 1 on validation failure.
@@ -316,6 +326,11 @@ _validate_commit_and_pr_inputs() {
 
 	if [[ -z "$issue_number" || -z "$commit_message" ]]; then
 		print_error "Usage: full-loop-helper.sh commit-and-pr|create-pr --issue <N> --message <msg>"
+		return 1
+	fi
+	if _is_wip_commit_message "$commit_message"; then
+		print_error "Refusing WIP final commit message: ${commit_message}"
+		print_error "Use a conventional final subject such as 'fix: describe the completed change'."
 		return 1
 	fi
 
@@ -378,6 +393,81 @@ _stage_and_commit() {
 	return 0
 }
 
+# Replace branch history with one final commit when any branch commit is WIP.
+# The caller-supplied final message is authoritative. On commit-hook failure,
+# restore the original branch tip and preserve any hook-produced working changes.
+# Args: $1=final commit message
+_finalize_wip_history() {
+	local commit_message="$1"
+	if _is_wip_commit_message "$commit_message"; then
+		print_error "Cannot finalize WIP history with another WIP message: ${commit_message}"
+		return 1
+	fi
+
+	local base_branch="" branch_range="" branch_subjects=""
+	local base_ref=""
+	base_branch=$(_resolve_remote_default_branch origin) || return 1
+	printf -v base_ref 'origin/%s' "$base_branch"
+	printf -v branch_range '%s..HEAD' "$base_ref"
+	if ! branch_subjects=$(git log --format=%s "$branch_range" 2>/dev/null); then
+		print_error "Cannot inspect branch commit subjects relative to ${base_ref}."
+		return 1
+	fi
+
+	local subject="" has_wip=0
+	while IFS= read -r subject; do
+		if _is_wip_commit_message "$subject"; then
+			has_wip=1
+			break
+		fi
+	done <<<"$branch_subjects"
+	if [[ "$has_wip" == "0" ]]; then
+		return 0
+	fi
+
+	local worktree_status=""
+	if ! worktree_status=$(git status --porcelain 2>/dev/null); then
+		print_error "Cannot verify a clean worktree before WIP history finalization."
+		return 1
+	fi
+	if [[ -n "$worktree_status" ]]; then
+		print_error "Refusing to rewrite WIP history with uncommitted changes present."
+		return 1
+	fi
+
+	local original_head=""
+	original_head=$(git rev-parse HEAD 2>/dev/null) || {
+		print_error "Cannot record the original branch tip before WIP finalization."
+		return 1
+	}
+	print_info "Finalizing WIP history into one commit relative to ${base_ref}..."
+	if ! git reset --soft "$base_ref"; then
+		print_error "Failed to prepare WIP history for finalization."
+		return 1
+	fi
+	if git diff --cached --quiet 2>/dev/null; then
+		print_error "WIP branch has no net changes relative to ${base_ref}."
+		git reset --mixed "$original_head" >/dev/null 2>&1 || true
+		return 1
+	fi
+	if ! git commit -m "$commit_message"; then
+		print_error "Final WIP squash commit failed; restoring original branch tip."
+		if ! git reset --mixed "$original_head" >/dev/null 2>&1; then
+			print_error "Failed to restore original branch tip ${original_head}; recover it manually."
+		fi
+		return 1
+	fi
+	local final_subject=""
+	final_subject=$(git log -1 --format=%s 2>/dev/null || echo "")
+	if _is_wip_commit_message "$final_subject"; then
+		print_error "Final commit hook produced another WIP subject; restoring original branch tip."
+		git reset --mixed "$original_head" >/dev/null 2>&1 || true
+		return 1
+	fi
+	print_info "WIP history finalized as: ${final_subject}"
+	return 0
+}
+
 # --- Project Validators (t2842) ---
 # Closes the worker-CI-failure gap where workers ship code that fails
 # project CI checks (Format/Lint/Typecheck) because no pre-push
@@ -399,12 +489,6 @@ _validators_should_run() {
 	fi
 	if [[ "${AIDEVOPS_SKIP_PROJECT_VALIDATORS:-0}" == "1" ]]; then
 		print_info "[validators] AIDEVOPS_SKIP_PROJECT_VALIDATORS=1, skipping"
-		return 1
-	fi
-	local last_msg
-	last_msg=$(git log -1 --format=%s 2>/dev/null || echo "")
-	if [[ "$last_msg" =~ ^wip[[:space:]:\(] ]]; then
-		print_info "[validators] wip commit (\"${last_msg}\"), skipping"
 		return 1
 	fi
 	local non_docs_count

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -82,6 +82,10 @@ cmd_commit_and_pr() {
 	_validate_commit_and_pr_inputs "$issue_number" "$commit_message" || return 1
 
 	_stage_and_commit "$commit_message" || return 1
+	# GH#27902: WIP commits are durable checkpoints, not publishable history.
+	# If any exist on the branch, replace the branch range with one final commit
+	# before validators inspect HEAD and before rebase/push can publish it.
+	_finalize_wip_history "$commit_message" || return 1
 	# t2842: project-aware validators (auto-fix format/lint, fail-closed typecheck).
 	# Inserted between commit and push so amends apply to the same commit
 	# the worker just made, and so failures abort BEFORE we push broken code.

--- a/.agents/scripts/tests/test-full-loop-wip-finalization.sh
+++ b/.agents/scripts/tests/test-full-loop-wip-finalization.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#27902: commit-and-pr must replace temporary WIP
+# history with one conventional final commit before validation and publication.
+
+set -uo pipefail
+
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+print_info() {
+	local message="$1"
+	printf 'INFO %s\n' "$message"
+	return 0
+}
+
+print_warning() {
+	local message="$1"
+	printf 'WARN %s\n' "$message" >&2
+	return 0
+}
+
+print_error() {
+	local message="$1"
+	printf 'ERROR %s\n' "$message" >&2
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../full-loop-helper-commit.sh
+source "${SCRIPT_DIR}/full-loop-helper-commit.sh"
+
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+make_repo() {
+	local repo_dir="$1"
+	mkdir -p "$repo_dir"
+	(
+		cd "$repo_dir" || exit 1
+		git init -q
+		git config user.name 'Test User'
+		git config user.email 'test@example.invalid'
+		git config commit.gpgsign false
+		printf 'base\n' >tracked.txt
+		git add tracked.txt
+		git commit -qm 'chore: initial fixture'
+		git branch -M develop
+		git update-ref refs/remotes/origin/develop HEAD
+		git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+	) || return 1
+	return 0
+}
+
+commit_change() {
+	local repo_dir="$1"
+	local content="$2"
+	local subject="$3"
+	(
+		cd "$repo_dir" || exit 1
+		printf '%s\n' "$content" >>tracked.txt
+		git add tracked.txt
+		git commit -qm "$subject"
+	) || return 1
+	return 0
+}
+
+test_single_wip_is_finalized() {
+	local repo_dir="${TEST_ROOT}/single-wip"
+	make_repo "$repo_dir" || return 1
+	commit_change "$repo_dir" 'single' 'wip: preserve single change' || return 1
+	local original_head=""
+	original_head=$(git -C "$repo_dir" rev-parse HEAD)
+	(
+		cd "$repo_dir" || exit 1
+		_finalize_wip_history 'fix: finalize single change'
+	) >/dev/null 2>&1
+	local rc=$?
+	local subject="" count="" final_head="" content=""
+	subject=$(git -C "$repo_dir" log -1 --format=%s)
+	count=$(git -C "$repo_dir" rev-list --count origin/develop..HEAD)
+	final_head=$(git -C "$repo_dir" rev-parse HEAD)
+	content=$(git -C "$repo_dir" show HEAD:tracked.txt)
+	if [[ "$rc" -eq 0 && "$subject" == 'fix: finalize single change' && "$count" == '1' &&
+		"$final_head" != "$original_head" && "$content" == $'base\nsingle' ]]; then
+		print_result 'single WIP becomes one final commit' 0
+	else
+		print_result 'single WIP becomes one final commit' 1 "rc=${rc}, subject=${subject}, count=${count}"
+	fi
+	return 0
+}
+
+test_buried_wip_squashes_branch_range() {
+	local repo_dir="${TEST_ROOT}/buried-wip"
+	make_repo "$repo_dir" || return 1
+	commit_change "$repo_dir" 'first' 'fix: first logical change' || return 1
+	commit_change "$repo_dir" 'checkpoint' 'wip: preserve checkpoint' || return 1
+	commit_change "$repo_dir" 'last' 'test: add coverage' || return 1
+	(
+		cd "$repo_dir" || exit 1
+		_finalize_wip_history 'fix: publish complete branch'
+	) >/dev/null 2>&1
+	local rc=$?
+	local subjects="" count="" content=""
+	subjects=$(git -C "$repo_dir" log --format=%s origin/develop..HEAD)
+	count=$(git -C "$repo_dir" rev-list --count origin/develop..HEAD)
+	content=$(git -C "$repo_dir" show HEAD:tracked.txt)
+	if [[ "$rc" -eq 0 && "$subjects" == 'fix: publish complete branch' && "$count" == '1' &&
+		"$content" == $'base\nfirst\ncheckpoint\nlast' ]]; then
+		print_result 'buried WIP squashes the complete branch range' 0
+	else
+		print_result 'buried WIP squashes the complete branch range' 1 "rc=${rc}, subjects=${subjects}, count=${count}"
+	fi
+	return 0
+}
+
+test_no_wip_preserves_history() {
+	local repo_dir="${TEST_ROOT}/no-wip"
+	make_repo "$repo_dir" || return 1
+	commit_change "$repo_dir" 'first' 'fix: first change' || return 1
+	commit_change "$repo_dir" 'second' 'test: second change' || return 1
+	local original_head=""
+	original_head=$(git -C "$repo_dir" rev-parse HEAD)
+	(
+		cd "$repo_dir" || exit 1
+		_finalize_wip_history 'fix: unused replacement subject'
+	) >/dev/null 2>&1
+	local rc=$?
+	local final_head="" count=""
+	final_head=$(git -C "$repo_dir" rev-parse HEAD)
+	count=$(git -C "$repo_dir" rev-list --count origin/develop..HEAD)
+	if [[ "$rc" -eq 0 && "$final_head" == "$original_head" && "$count" == '2' ]]; then
+		print_result 'branch without WIP preserves commit history' 0
+	else
+		print_result 'branch without WIP preserves commit history' 1 "rc=${rc}, count=${count}"
+	fi
+	return 0
+}
+
+test_commit_hook_failure_restores_tip() {
+	local repo_dir="${TEST_ROOT}/hook-failure"
+	make_repo "$repo_dir" || return 1
+	commit_change "$repo_dir" 'checkpoint' 'wip: preserve before failing hook' || return 1
+	local original_head=""
+	original_head=$(git -C "$repo_dir" rev-parse HEAD)
+	printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"${repo_dir}/.git/hooks/commit-msg"
+	chmod +x "${repo_dir}/.git/hooks/commit-msg"
+	(
+		cd "$repo_dir" || exit 1
+		_finalize_wip_history 'fix: hook should reject this'
+	) >/dev/null 2>&1
+	local rc=$?
+	local final_head="" status=""
+	final_head=$(git -C "$repo_dir" rev-parse HEAD)
+	status=$(git -C "$repo_dir" status --porcelain)
+	if [[ "$rc" -ne 0 && "$final_head" == "$original_head" && -z "$status" ]]; then
+		print_result 'commit-hook failure restores original WIP tip' 0
+	else
+		print_result 'commit-hook failure restores original WIP tip' 1 "rc=${rc}, status=${status}"
+	fi
+	return 0
+}
+
+test_wip_final_message_is_rejected() {
+	local repo_dir="${TEST_ROOT}/wip-message"
+	make_repo "$repo_dir" || return 1
+	commit_change "$repo_dir" 'checkpoint' 'wip: preserve checkpoint' || return 1
+	local original_head=""
+	original_head=$(git -C "$repo_dir" rev-parse HEAD)
+	(
+		cd "$repo_dir" || exit 1
+		_finalize_wip_history 'wip: still temporary'
+	) >/dev/null 2>&1
+	local rc=$?
+	local final_head=""
+	final_head=$(git -C "$repo_dir" rev-parse HEAD)
+	if [[ "$rc" -ne 0 && "$final_head" == "$original_head" ]]; then
+		print_result 'WIP final message is rejected without rewriting history' 0
+	else
+		print_result 'WIP final message is rejected without rewriting history' 1 "rc=${rc}"
+	fi
+	return 0
+}
+
+test_orchestrator_finalizes_before_validation() {
+	local orchestrator="${SCRIPT_DIR}/full-loop-helper.sh"
+	local stage_line="" finalize_line="" validators_line=""
+	# Literal caller variable names are the integration contract under test.
+	# shellcheck disable=SC2016
+	stage_line=$(grep -n '_stage_and_commit "\$commit_message"' "$orchestrator" | cut -d: -f1)
+	# shellcheck disable=SC2016
+	finalize_line=$(grep -n '_finalize_wip_history "\$commit_message"' "$orchestrator" | cut -d: -f1)
+	# shellcheck disable=SC2016
+	validators_line=$(grep -n '_run_project_validators "\$skip_hooks"' "$orchestrator" | cut -d: -f1)
+	if [[ "$stage_line" =~ ^[0-9]+$ && "$finalize_line" =~ ^[0-9]+$ && "$validators_line" =~ ^[0-9]+$ &&
+		"$stage_line" -lt "$finalize_line" && "$finalize_line" -lt "$validators_line" ]]; then
+		print_result 'commit-and-pr finalizes WIP before project validation' 0
+	else
+		print_result 'commit-and-pr finalizes WIP before project validation' 1 \
+			"stage=${stage_line}, finalize=${finalize_line}, validators=${validators_line}"
+	fi
+	return 0
+}
+
+test_single_wip_is_finalized
+test_buried_wip_squashes_branch_range
+test_no_wip_preserves_history
+test_commit_hook_failure_restores_tip
+test_wip_final_message_is_rejected
+test_orchestrator_finalizes_before_validation
+
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_RUN" -ne 6 ]]; then
+	printf '%sFAIL%s expected 6 tests to execute\n' "$TEST_RED" "$TEST_RESET"
+	exit 1
+fi
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Detect WIP commits anywhere in a commit-and-pr branch, transactionally replace the branch range with one conventional final commit, and keep validators fail-closed.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/tests/test-full-loop-wip-finalization.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 6 focused history-finalization tests pass; ShellCheck and Bash syntax clean; changed-file local linter suite passes.

Resolves #27902


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 21m and 237,449 tokens on this with the user in an interactive session.