### PR TITLE
GH#27910: allow prescribed aidevops temp body files

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs
@@ -8,7 +8,7 @@
 import { existsSync, readFileSync, appendFileSync, realpathSync, statSync } from "fs";
 import { execFileSync } from "child_process";
 import { dirname, isAbsolute, resolve, sep } from "path";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 
 import { FAIL_REASON } from "./quality-hooks-signature-failures.mjs";
 
@@ -76,11 +76,18 @@ function sameGitRepository(pathA, pathB) {
   return Boolean(commonA && commonB && commonA === commonB);
 }
 
+function aidevopsTempDir() {
+  return (
+    process.env.AIDEVOPS_TEMP_DIR ||
+    resolve(homedir(), ".aidevops", ".agent-workspace", "tmp")
+  );
+}
+
 function resolveAllowedBodyFilePath(filePath, commandWorkdir = process.cwd()) {
   const realCommandWorkdir = safeRealpath(commandWorkdir) || process.cwd();
   const candidatePath = isAbsolute(filePath) ? filePath : resolve(realCommandWorkdir, filePath);
   const realFilePath = realpathSync(candidatePath);
-  const allowedRoots = [realCommandWorkdir, process.cwd(), tmpdir()]
+  const allowedRoots = [realCommandWorkdir, process.cwd(), tmpdir(), aidevopsTempDir()]
     .filter((root) => existsSync(root))
     .map((root) => realpathSync(root));
   if (allowedRoots.some((root) => isPathWithin(realFilePath, root))) {

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -354,6 +354,48 @@ describe("tryRepairSignature", () => {
     assert.ok(readFileSync(bodyFile, "utf-8").includes(SIG_MARKER));
   });
 
+  test("allows --body-file under configured AIDEVOPS_TEMP_DIR", () => {
+    const dir = setupStubHelper();
+    const customRoot = mkdtempSync(join(homedir(), ".t27910-custom-temp-"));
+    const bodyFile = join(customRoot, "body.md");
+    const priorTempDir = process.env.AIDEVOPS_TEMP_DIR;
+    try {
+      process.env.AIDEVOPS_TEMP_DIR = customRoot;
+      writeFileSync(bodyFile, "configured temp content\n");
+      const { log } = makeLogger();
+      const cmd = `gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
+      const out = tryRepairSignature(cmd, dir, log);
+      assert.equal(out.status, "ok");
+      assert.ok(readFileSync(bodyFile, "utf-8").includes(SIG_MARKER));
+    } finally {
+      if (priorTempDir === undefined) delete process.env.AIDEVOPS_TEMP_DIR;
+      else process.env.AIDEVOPS_TEMP_DIR = priorTempDir;
+      rmSync(customRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("allows --body-file under the default aidevops temp root", () => {
+    const dir = setupStubHelper();
+    const defaultRoot = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+    mkdirSync(defaultRoot, { recursive: true });
+    const fixtureRoot = mkdtempSync(join(defaultRoot, "t27910-default-temp-"));
+    const bodyFile = join(fixtureRoot, "body.md");
+    const priorTempDir = process.env.AIDEVOPS_TEMP_DIR;
+    try {
+      delete process.env.AIDEVOPS_TEMP_DIR;
+      writeFileSync(bodyFile, "default temp content\n");
+      const { log } = makeLogger();
+      const cmd = `gh issue comment 1 --repo o/r --body-file ${bodyFile}`;
+      const out = tryRepairSignature(cmd, dir, log);
+      assert.equal(out.status, "ok");
+      assert.ok(readFileSync(bodyFile, "utf-8").includes(SIG_MARKER));
+    } finally {
+      if (priorTempDir === undefined) delete process.env.AIDEVOPS_TEMP_DIR;
+      else process.env.AIDEVOPS_TEMP_DIR = priorTempDir;
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   test("uses cheap no-session helper path when repairing body-file", () => {
     const dir = mkdtempSync(join(tmpdir(), "t24374-fast-helper-"));
     const helper = join(dir, "gh-signature-helper.sh");


### PR DESCRIPTION
## Summary

Allow signature-gate body files under configured AIDEVOPS_TEMP_DIR or its documented default while retaining realpath containment.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature-body-file.mjs, .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 72 signature-footer tests pass; Biome clean; direct host-/tmp simulation accepts the documented aidevops temp path.

Resolves #27910


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 33m and 269,420 tokens on this with the user in an interactive session.