### PR TITLE
GH#27909: target pre-edit checks to linked worktrees

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createTools } from "../tools.mjs";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const scriptsDir = resolve(testDir, "../../../scripts");
+
+function git(cwd, args) {
+  return execFileSync("/usr/bin/git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+test("pre-edit tool validates the explicitly targeted Git worktree", async () => {
+  const root = mkdtempSync(join(tmpdir(), "t27909-pre-edit-tool-"));
+  const repo = join(root, "repo");
+  const linked = join(root, "linked");
+  const nonGit = join(root, "not-git");
+  const injectionMarker = join(root, "injected");
+
+  try {
+    mkdirSync(repo);
+    mkdirSync(nonGit);
+    git(repo, ["init", "--initial-branch=main"]);
+    git(repo, ["config", "user.email", "test@example.invalid"]);
+    git(repo, ["config", "user.name", "Test"]);
+    git(repo, ["config", "commit.gpgsign", "false"]);
+    writeFileSync(join(repo, "README.md"), "fixture\n");
+    git(repo, ["add", "README.md"]);
+    git(repo, ["commit", "--no-gpg-sign", "-m", "init"]);
+    git(repo, ["worktree", "add", "-b", "bugfix/fixture", linked]);
+
+    const preEditTool = createTools(scriptsDir, () => "").aidevops_pre_edit_check;
+    const canonicalResult = await preEditTool.execute({ workdir: repo });
+    assert.match(canonicalResult, /Pre-edit check exit [12]:/);
+    assert.match(canonicalResult, /create a worktree/i);
+
+    const linkedResult = await preEditTool.execute({
+      workdir: linked,
+      task: `fix fixture '; touch ${injectionMarker}`,
+    });
+    assert.match(linkedResult, /Pre-edit check PASSED \(exit 0\)/);
+    assert.equal(existsSync(injectionMarker), false, "task text must remain one argv value");
+
+    const invalidResult = await preEditTool.execute({ workdir: nonGit, task: "fix fixture" });
+    assert.match(invalidResult, /target workdir must resolve to an existing Git worktree/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs
@@ -30,6 +30,7 @@ describe("aidevops plugin tool schemas", () => {
 
     assert.ok(tools.aidevops.args.command?._zod, "aidevops.command must be Zod");
     assert.ok(tools.aidevops_pre_edit_check.args.task?._zod, "pre-edit task must be Zod");
+    assert.ok(tools.aidevops_pre_edit_check.args.workdir?._zod, "pre-edit workdir must be Zod");
     assert.ok(pool.args.action?._zod, "pool action must be Zod");
     assert.ok(pool.args.provider?._zod, "pool provider must be Zod");
   });

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -1,5 +1,5 @@
-import { execSync } from "child_process";
-import { existsSync } from "fs";
+import { execFileSync, execSync } from "child_process";
+import { existsSync, realpathSync, statSync } from "fs";
 import { join } from "path";
 
 let tool;
@@ -179,9 +179,10 @@ function createPreEditCheckTool(scriptsDir) {
 
   return tool({
     description:
-      'Run the pre-edit git safety check before modifying files. Returns exit code and guidance. Args: task (optional string for loop mode)',
+      'Run the pre-edit git safety check before modifying files. Returns exit code and guidance. Args: task (optional string for loop mode), workdir (optional target Git worktree)',
     args: {
       task: z.string().optional().describe('Optional task description for loop-mode worktree guidance'),
+      workdir: z.string().optional().describe('Optional target Git worktree to validate'),
     },
     async execute(args) {
       args = args && typeof args === "object" ? args : {};
@@ -189,11 +190,29 @@ function createPreEditCheckTool(scriptsDir) {
       if (!existsSync(script)) {
         return "pre-edit-check.sh not found — cannot verify git safety";
       }
-      const taskFlag = args.task
-        ? ` --loop-mode --task ${shellEscape(args.task)}`
-        : "";
+      const requestedWorkdir = args.workdir || process.cwd();
+      let targetWorkdir = "";
       try {
-        const result = execSync(`bash "${script}"${taskFlag}`, {
+        targetWorkdir = realpathSync(requestedWorkdir);
+        if (!statSync(targetWorkdir).isDirectory()) targetWorkdir = "";
+        const insideWorktree = targetWorkdir
+          ? execFileSync("git", ["-C", targetWorkdir, "rev-parse", "--is-inside-work-tree"], {
+              encoding: "utf-8",
+              timeout: 5000,
+              stdio: ["ignore", "pipe", "ignore"],
+            }).trim()
+          : "";
+        if (insideWorktree !== "true") targetWorkdir = "";
+      } catch {
+        targetWorkdir = "";
+      }
+      if (!targetWorkdir) {
+        return `Pre-edit check exit 1: target workdir must resolve to an existing Git worktree\n${requestedWorkdir}`;
+      }
+      const taskArgs = args.task ? ["--loop-mode", "--task", args.task] : [];
+      try {
+        const result = execFileSync("bash", [script, ...taskArgs], {
+          cwd: targetWorkdir,
           encoding: "utf-8",
           timeout: 10000,
           stdio: ["pipe", "pipe", "pipe"],


### PR DESCRIPTION
## Summary

Add a validated workdir argument to the OpenCode pre-edit tool and execute the fixed safety script in that Git worktree.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs, .agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs, .agents/plugins/opencode-aidevops/tools.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 7 focused plugin tests pass; typecheck passes; regression covers canonical failure, linked-worktree success, invalid paths, and task argv safety.

Resolves #27909


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 49m and 324,126 tokens on this with the user in an interactive session.