### PR TITLE
GH#27908: fix issue-link guidance matching

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-linkage-guidance.sh
+++ b/.agents/scripts/tests/test-issue-sync-linkage-guidance.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#27908 issue-link guidance matching.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/issue-sync-reusable.yml"
+PASS=0
+FAIL=0
+
+pass() {
+	local message="$1"
+	PASS=$((PASS + 1))
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: %s\n' "$message"
+	return 0
+}
+
+expect_reference() {
+	local body="$1"
+	local description="$2"
+	if printf '%s\n' "$body" | grep -qiE '(closes|fixes|resolves|for|ref)[[:space:]]+#[0-9]+'; then
+		pass "$description"
+	else
+		fail "$description"
+	fi
+	return 0
+}
+
+expect_no_reference() {
+	local body="$1"
+	local description="$2"
+	if printf '%s\n' "$body" | grep -qiE '(closes|fixes|resolves|for|ref)[[:space:]]+#[0-9]+'; then
+		fail "$description"
+	else
+		pass "$description"
+	fi
+	return 0
+}
+
+resolve_task_issue() {
+	local task_id="$1"
+	local issues_json="$2"
+	jq -r --arg prefix "${task_id}:" \
+		'[.[] | select(.title | startswith($prefix))] | if length == 1 then .[0].number else empty end' \
+		<<<"$issues_json"
+	return 0
+}
+
+expect_task_issue() {
+	local task_id="$1"
+	local issues_json="$2"
+	local expected="$3"
+	local description="$4"
+	local actual=""
+	actual=$(resolve_task_issue "$task_id" "$issues_json")
+	if [[ "$actual" == "$expected" ]]; then
+		pass "$description"
+	else
+		fail "$description (expected '${expected}', got '${actual}')"
+	fi
+	return 0
+}
+
+expect_workflow_pattern() {
+	local pattern="$1"
+	local description="$2"
+	if grep -Fq -- "$pattern" "$WORKFLOW_FILE"; then
+		pass "$description"
+	else
+		fail "$description"
+	fi
+	return 0
+}
+
+expect_reference 'For #27908' 'For reference satisfies linkage guidance'
+expect_reference 'ref #27908' 'Ref reference is case-insensitive'
+expect_reference 'Resolves #27908' 'closing keyword still satisfies linkage guidance'
+expect_no_reference 'Mentions issue 27908 without a supported reference' 'plain issue mention does not satisfy linkage guidance'
+
+ISSUES='[{"number":27908,"title":"t2879: exact task"},{"number":27909,"title":"t28790: similar task"}]'
+expect_task_issue 't2879' "$ISSUES" '27908' 'one exact task-title prefix resolves uniquely'
+expect_task_issue 't2999' "$ISSUES" '' 'no exact task-title prefix does not resolve'
+
+AMBIGUOUS='[{"number":27908,"title":"t2879: first"},{"number":27910,"title":"t2879: duplicate"}]'
+expect_task_issue 't2879' "$AMBIGUOUS" '' 'ambiguous exact task-title prefixes do not resolve'
+
+expect_workflow_pattern '(closes|fixes|resolves|for|ref)[[:space:]]+#[0-9]+' 'workflow recognizes closing and non-closing references'
+expect_workflow_pattern '--json number,title' 'workflow fetches titles for exact identity filtering'
+expect_workflow_pattern 'if length == 1 then .[0].number else empty end' 'workflow requires one exact task match'
+
+printf 'Summary: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -1602,9 +1602,9 @@ jobs:
             exit 0
           fi
 
-          # Check for GitHub closing keywords or ref:GH# pattern
-          if echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+'; then
-            echo "PR body contains issue closing keyword"
+          # Check for GitHub closing keywords, non-closing references, or ref:GH# pattern
+          if echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves|for|ref)[[:space:]]+#[0-9]+'; then
+            echo "PR body contains a recognized issue reference"
             exit 0
           fi
 
@@ -1620,7 +1620,12 @@ jobs:
             # GH#NNNN: prefix directly references the issue number
             ISSUE_NUM="$GH_REF"
           elif [[ -n "$TASK_ID" ]]; then
-            ISSUE_NUM=$(gh issue list --repo "$REPO" --state open --search "${TASK_ID}:" --json number --jq '.[0].number' 2>/dev/null || true)
+            # Search narrows the result set; the exact title prefix and unique-match
+            # filter prevent fuzzy or ambiguous search results from guiding the PR.
+            ISSUE_NUM=$(gh issue list --repo "$REPO" --state open \
+              --search "\"${TASK_ID}:\" in:title" --limit 100 --json number,title \
+              --jq "[.[] | select(.title | startswith(\"${TASK_ID}:\"))] | if length == 1 then .[0].number else empty end" \
+              2>/dev/null || true)
           else
             ISSUE_NUM=""
           fi


### PR DESCRIPTION
## Summary

Treat For/Ref body references as valid linkage and require one exact task-title match before posting guidance

## Files Changed

.agents/scripts/tests/test-issue-sync-linkage-guidance.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 10 linkage regression cases, 7 existing identity cases, ShellCheck, Actionlint, YAML parse, and linters-local.sh passed

Resolves #27908


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 1h 3m and 523,679 tokens on this with the user in an interactive session.