### PR TITLE
GH#27913: publish planning files to absent remote branches

### DIFF
--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -166,21 +166,74 @@ _planning_publish_parent_conflicts() {
 	return 1
 }
 
+_planning_publish_remote_default_branch() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local remote_head=""
+	local default_branch=""
+	remote_head=$(_planning_git -C "$repo_path" ls-remote --symref "$remote_name" HEAD 2>/dev/null) || return 1
+	default_branch=$(printf '%s\n' "$remote_head" | sed -n 's@^ref: refs/heads/\([^[:space:]]*\)[[:space:]]*HEAD$@\1@p')
+	if [[ -z "$default_branch" || "$default_branch" == *$'\n'* ]]; then
+		_planning_publish_log error "Cannot determine one remote default branch for first planning publication"
+		return 1
+	fi
+	printf '%s\n' "$default_branch"
+	return 0
+}
+
+_planning_publish_resolve_parent() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local target_check_rc=0
+	local default_branch=""
+	local parent_sha=""
+
+	if _planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" 2>/dev/null; then
+		parent_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+		printf '%s|%s\n' "$parent_sha" "$parent_sha"
+		return 0
+	fi
+
+	if _planning_git -C "$repo_path" ls-remote --exit-code --heads "$remote_name" "refs/heads/${branch_name}" >/dev/null 2>&1; then
+		# The branch appeared after the failed fetch. Refetch it and use the
+		# normal update lease rather than misclassifying it as absent.
+		_planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" || return 1
+		parent_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+		printf '%s|%s\n' "$parent_sha" "$parent_sha"
+		return 0
+	else
+		target_check_rc=$?
+	fi
+	if [[ "$target_check_rc" -ne 2 ]]; then
+		_planning_publish_log error "Unable to verify whether remote branch ${branch_name} exists"
+		return 1
+	fi
+
+	default_branch=$(_planning_publish_remote_default_branch "$repo_path" "$remote_name") || return 1
+	_planning_git -C "$repo_path" fetch -q "$remote_name" "$default_branch" || return 1
+	parent_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+	# An empty expected value is Git's creation-safe lease: the push succeeds
+	# only while the target ref remains absent.
+	printf '%s|\n' "$parent_sha"
+	return 0
+}
+
 _planning_publish_push() {
 	local repo_path="$1"
 	local remote_name="$2"
 	local branch_name="$3"
-	local parent_sha="$4"
+	local expected_sha="$4"
 	local candidate_sha="$5"
 	if [[ -n "${AIDEVOPS_PLANNING_FENCE_REF:-}" && -n "${AIDEVOPS_PLANNING_FENCE_SHA:-}" ]]; then
 		_planning_git -C "$repo_path" push -q --atomic \
-			--force-with-lease="refs/heads/${branch_name}:${parent_sha}" \
+			--force-with-lease="refs/heads/${branch_name}:${expected_sha}" \
 			--force-with-lease="${AIDEVOPS_PLANNING_FENCE_REF}:${AIDEVOPS_PLANNING_FENCE_SHA}" \
 			"$remote_name" "${candidate_sha}:refs/heads/${branch_name}" \
 			"${AIDEVOPS_PLANNING_FENCE_SHA}:${AIDEVOPS_PLANNING_FENCE_REF}"
 		return $?
 	fi
-	_planning_git -C "$repo_path" push -q --force-with-lease="refs/heads/${branch_name}:${parent_sha}" "$remote_name" "${candidate_sha}:refs/heads/${branch_name}"
+	_planning_git -C "$repo_path" push -q --force-with-lease="refs/heads/${branch_name}:${expected_sha}" "$remote_name" "${candidate_sha}:refs/heads/${branch_name}"
 	return $?
 }
 
@@ -191,7 +244,7 @@ planning_publish() {
 	local branch_name="${4:-}"
 	local paths="${5:-}"
 	local temp_dir="" snapshot_file="" index_file="" parent_sha="" tree_sha="" candidate_sha=""
-	local publication_id="" attempt=0 push_rc=0 latest_sha=""
+	local publication_id="" attempt=0 push_rc=0 latest_sha="" expected_sha="" parent_resolution=""
 
 	[[ -n "$branch_name" ]] || branch_name=$(_planning_git -C "$repo_path" symbolic-ref --short HEAD 2>/dev/null) || return 1
 	[[ -n "$paths" ]] || paths=$(_planning_publish_changed_paths "$repo_path")
@@ -214,14 +267,12 @@ planning_publish() {
 
 	while [[ $attempt -lt $PLANNING_PUBLISH_MAX_RETRIES ]]; do
 		attempt=$((attempt + 1))
-		_planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" || {
+		parent_resolution=$(_planning_publish_resolve_parent "$repo_path" "$remote_name" "$branch_name") || {
 			rm -rf "$temp_dir"
 			return 1
 		}
-		latest_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || {
-			rm -rf "$temp_dir"
-			return 1
-		}
+		latest_sha="${parent_resolution%%|*}"
+		expected_sha="${parent_resolution#*|}"
 		if [[ -n "$parent_sha" ]] && _planning_publish_parent_conflicts "$repo_path" "$parent_sha" "$latest_sha" "$snapshot_file"; then
 			_planning_publish_log warning "AIDEVOPS_PLANNING_PUBLISH_STATUS=retryable_conflict publication_id=${publication_id}"
 			rm -rf "$temp_dir"
@@ -268,7 +319,7 @@ planning_publish() {
 			}
 		fi
 		push_rc=0
-		_planning_publish_push "$repo_path" "$remote_name" "$branch_name" "$parent_sha" "$candidate_sha" || push_rc=$?
+		_planning_publish_push "$repo_path" "$remote_name" "$branch_name" "$expected_sha" "$candidate_sha" || push_rc=$?
 		if [[ $push_rc -eq 0 ]]; then
 			PLANNING_PUBLISH_RESULT="published"
 			PLANNING_PUBLISHED_COMMIT="$candidate_sha"

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -55,11 +55,12 @@ state_digest() {
 run_publish() {
 	local repo="$1"
 	local validator="${2:-/usr/bin/true}"
+	local branch="${3:-main}"
 	(
 		SCRIPT_DIR="$(dirname "$PUBLISHER")"
 		# shellcheck source=../planning-publisher.sh
 		source "$PUBLISHER"
-		AIDEVOPS_PLANNING_VALIDATOR="$validator" planning_publish "$repo" "plan: test publication" origin main
+		AIDEVOPS_PLANNING_VALIDATOR="$validator" planning_publish "$repo" "plan: test publication" origin "$branch"
 	)
 	return $?
 }
@@ -241,6 +242,106 @@ HOOK
 	return 0
 }
 
+test_absent_remote_branch_uses_safe_parent() {
+	local name="creates an absent remote branch from a safe parent without local state leakage"
+	local root="" repo="" branch="plan/new-branch" before="" after="" remote_sha="" replay_sha="" count=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	git -C "$repo" switch -c "$branch" >/dev/null 2>&1 || {
+		fail "$name" branch
+		return 0
+	}
+	printf 'unrelated local commit\n' >>"${repo}/README.md"
+	git -C "$repo" add README.md
+	GIT_AUTHOR_NAME=Local GIT_AUTHOR_EMAIL=local@example.invalid GIT_COMMITTER_NAME=Local GIT_COMMITTER_EMAIL=local@example.invalid \
+		git -C "$repo" -c commit.gpgsign=false commit -qm local-only || {
+		fail "$name" local-commit
+		return 0
+	}
+	printf '%s\n' '- [ ] t007 first publication ref:GH#7' >>"${repo}/TODO.md"
+	before=$(state_digest "$repo")
+	run_publish "$repo" /usr/bin/true "$branch" || {
+		fail "$name" publish
+		return 0
+	}
+	after=$(state_digest "$repo")
+	remote_sha=$(git --git-dir="${root}/remote.git" rev-parse "$branch")
+	run_publish "$repo" /usr/bin/true "$branch" || {
+		fail "$name" replay
+		return 0
+	}
+	replay_sha=$(git --git-dir="${root}/remote.git" rev-parse "$branch")
+	count=$(git --git-dir="${root}/remote.git" log --format=%B "$branch" | grep -c 'Planning-Publication-ID:' || true)
+	if [[ "$before" == "$after" && "$remote_sha" == "$replay_sha" && "$count" -eq 1 ]] &&
+		[[ "$(git --git-dir="${root}/remote.git" rev-parse "${branch}^")" == "$(git --git-dir="${root}/remote.git" rev-parse main)" ]] &&
+		git --git-dir="${root}/remote.git" show "${branch}:TODO.md" | grep -q t007 &&
+		[[ "$(git --git-dir="${root}/remote.git" show "${branch}:README.md")" == "base" ]]; then
+		pass "$name"
+	else
+		fail "$name" invariant
+	fi
+	rm -rf "$root"
+	return 0
+}
+
+test_absent_remote_branch_creation_contention() {
+	local name="replays safely when a competitor creates the absent remote branch"
+	local root="" repo="" branch="plan/raced-branch" hook="" before="" after="" rival_sha="" remote_sha="" rc=0
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	git -C "$repo" switch -c "$branch" >/dev/null 2>&1 || {
+		fail "$name" branch
+		return 0
+	}
+	printf '%s\n' '- [ ] t008 creation race ref:GH#8' >>"${repo}/TODO.md"
+	hook="${root}/create-rival.sh"
+	cat >"$hook" <<'HOOK'
+#!/usr/bin/env bash
+repo="$1"; remote="$2"; branch="$3"; attempt="$6"
+[[ "$attempt" == "1" ]] || exit 0
+tmp=$(mktemp -d)
+git clone -q "$(git -C "$repo" remote get-url "$remote")" "$tmp/work"
+git -C "$tmp/work" switch -c "$branch" >/dev/null 2>&1
+printf 'rival branch creator\n' >>"$tmp/work/README.md"
+git -C "$tmp/work" add README.md
+GIT_AUTHOR_NAME=Rival GIT_AUTHOR_EMAIL=rival@example.invalid GIT_COMMITTER_NAME=Rival GIT_COMMITTER_EMAIL=rival@example.invalid git -C "$tmp/work" -c commit.gpgsign=false commit -qm rival
+git -C "$tmp/work" push -q origin "$branch"
+git -C "$tmp/work" rev-parse HEAD >"$(dirname "$repo")/rival-sha"
+rm -rf "$tmp"
+exit 0
+HOOK
+	chmod +x "$hook"
+	before=$(state_digest "$repo")
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK="$hook" \
+			planning_publish "$repo" "plan: creation contention" origin "$branch"
+	) || rc=$?
+	after=$(state_digest "$repo")
+	rival_sha=$(<"${root}/rival-sha")
+	remote_sha=$(git --git-dir="${root}/remote.git" rev-parse "$branch")
+	if [[ "$rc" -eq 0 && "$before" == "$after" ]] &&
+		git --git-dir="${root}/remote.git" merge-base --is-ancestor "$rival_sha" "$remote_sha" &&
+		git --git-dir="${root}/remote.git" show "${branch}:README.md" | grep -q 'rival branch creator' &&
+		git --git-dir="${root}/remote.git" show "${branch}:TODO.md" | grep -q t008; then
+		pass "$name"
+	else
+		fail "$name" "contention rc=$rc"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
 test_explicit_git_capability_preserves_guarded_checkout() {
 	local name="explicit Git capability publishes planning paths while canonical guard remains active"
 	local root="" repo="" shim_dir="" before="" after="" guard_rc=0 count="" real_git="" real_true=""
@@ -309,6 +410,8 @@ main() {
 	test_contention_replay_and_conflict
 	test_crash_replay_is_single_publication
 	test_same_path_contention_is_retryable
+	test_absent_remote_branch_uses_safe_parent
+	test_absent_remote_branch_creation_contention
 	test_explicit_git_capability_preserves_guarded_checkout
 	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 	[[ $FAIL -eq 0 ]] || return 1


### PR DESCRIPTION
## Summary

Create absent planning branches from the fetched remote default branch with an empty creation lease, then replay bounded contention through the existing update path

## Files Changed

.agents/scripts/planning-publisher.sh, .agents/scripts/tests/test-planning-publisher.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 28 planning tests, ShellCheck, shfmt, git diff check, and linters-local.sh passed

Resolves #27913


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 1h 21m and 617,559 tokens on this with the user in an interactive session.