### PR TITLE
t18138: fix: reconcile worker attempt outcomes before retry routing

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -362,7 +362,7 @@ cmd_register() {
 	local dispatch_tier=""
 	local dispatch_model=""
 	local worktree_path=""
-	local lease_token=""
+	local lease_token="" attempt_id=""
 	local runner_device=""
 	local lease_ttl="$PRELAUNCH_TTL"
 
@@ -400,6 +400,7 @@ cmd_register() {
 			lease_token="${2:-}"
 			shift 2
 			;;
+		--attempt-id) attempt_id="${2:-}"; shift 2 ;;
 		--device-id)
 			runner_device="${2:-}"
 			shift 2
@@ -432,7 +433,7 @@ cmd_register() {
 	[[ "$lease_ttl" =~ ^[0-9]+$ ]] || lease_ttl="$PRELAUNCH_TTL"
 	local lease_expires_at=""
 	lease_expires_at=$(_lease_expiry "$lease_ttl")
-	local attempt_id="${lease_token:-${session_key}:${now}:${dispatch_pid}}"
+	[[ -n "$attempt_id" ]] || attempt_id=$(aidevops_generate_execution_id "attempt")
 
 	jq -cn \
 		--arg sk "$session_key" \
@@ -740,6 +741,7 @@ cmd_check_issue() {
 cmd_complete() {
 	local session_key=""
 	local lease_token=""
+	local attempt_id=""
 	local reason=""
 
 	while [[ $# -gt 0 ]]; do
@@ -750,6 +752,10 @@ cmd_complete() {
 			;;
 		--lease-token)
 			lease_token="${2:-}"
+			shift 2
+			;;
+		--attempt-id)
+			attempt_id="${2:-}"
 			shift 2
 			;;
 		--reason)
@@ -772,7 +778,7 @@ cmd_complete() {
 		_lease_append_transition "$session_key" "$lease_token" "terminal" "$LEDGER_STATUS_COMPLETED" "0" "$reason"
 		return $?
 	else
-		_update_status "$session_key" "$LEDGER_STATUS_COMPLETED"
+		_update_status "$session_key" "$LEDGER_STATUS_COMPLETED" "" "$attempt_id"
 	fi
 	return 0
 }
@@ -818,6 +824,7 @@ cmd_terminal_reason() {
 cmd_fail() {
 	local session_key=""
 	local lease_token=""
+	local attempt_id=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -827,6 +834,10 @@ cmd_fail() {
 			;;
 		--lease-token)
 			lease_token="${2:-}"
+			shift 2
+			;;
+		--attempt-id)
+			attempt_id="${2:-}"
 			shift 2
 			;;
 		*)
@@ -841,7 +852,7 @@ cmd_fail() {
 		return 1
 	fi
 
-	_update_status "$session_key" "$LEDGER_STATUS_FAILED" "$lease_token"
+	_update_status "$session_key" "$LEDGER_STATUS_FAILED" "$lease_token" "$attempt_id"
 	return 0
 }
 
@@ -874,6 +885,24 @@ _find_pending_telemetry_attempt() {
 	jq -sc -f "$TIER_TELEMETRY_FILTER" --arg operation find \
 		--arg aid "$attempt_id" --arg sk "$session_key" \
 		--arg inum "$issue_number" --arg slug "$repo_slug" "$telemetry_file" 2>/dev/null
+	return 0
+}
+
+_resolve_attempt_id_from_lease() {
+	local lease_token="$1"
+	local session_key="$2"
+	local issue_number="$3"
+	local repo_slug="$4"
+
+	[[ -n "$lease_token" && -s "$LEDGER_FILE" ]] || return 0
+	jq -rs --arg token "$lease_token" --arg sk "$session_key" \
+		--arg inum "$issue_number" --arg slug "$repo_slug" \
+		'[.[] | select(
+			(.lease_token // "") == $token and
+			($sk == "" or (.session_key // "") == $sk) and
+			($inum == "" or (.issue_number // "") == $inum) and
+			($slug == "" or (.repo_slug // "") == $slug)
+		)] | last | .attempt_id // empty' "$LEDGER_FILE" 2>/dev/null
 	return 0
 }
 
@@ -963,7 +992,10 @@ cmd_record_outcome() {
 		return 0
 	fi
 
-	[[ -n "$attempt_id" ]] || attempt_id="$lease_token"
+	if [[ -z "$attempt_id" && -n "$lease_token" ]]; then
+		attempt_id=$(_resolve_attempt_id_from_lease "$lease_token" "$session_key" \
+			"$issue_number" "$repo_slug" || true)
+	fi
 	local pending=""
 	pending=$(_find_pending_telemetry_attempt "$telemetry_file" "$attempt_id" \
 		"$session_key" "$issue_number" "$repo_slug" || true)
@@ -1062,6 +1094,7 @@ _update_status() {
 	local session_key="$1"
 	local new_status="$2"
 	local lease_token="${3:-}"
+	local attempt_id="${4:-}"
 	if [[ -n "$lease_token" ]]; then
 		_lease_append_transition "$session_key" "$lease_token" "terminal" "$new_status" "0"
 		return $?
@@ -1086,8 +1119,8 @@ _update_status() {
 	# Only transition entries that are still "in-flight" — terminal statuses
 	# ("completed", "failed") are immutable. A late fail from dead-PID cleanup
 	# must not overwrite a genuinely completed dispatch.
-	jq -c --arg sk "$session_key" --arg st "$new_status" --arg ts "$now" --arg active "$LEDGER_STATUS_ACTIVE" \
-		'if .session_key == $sk and .status == $active
+	jq -c --arg sk "$session_key" --arg aid "$attempt_id" --arg st "$new_status" --arg ts "$now" --arg active "$LEDGER_STATUS_ACTIVE" \
+		'if .session_key == $sk and .status == $active and ($aid == "" or (.attempt_id // "") == $aid)
 			then .status = $st | .updated_at = $ts
 			else .
 		end' \

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -1155,6 +1155,11 @@ _report_failure_to_fast_fail() {
 	if [[ "$session_key" != issue-* ]]; then
 		return 0
 	fi
+	if declare -F _objective_disposition_suppresses >/dev/null 2>&1 && \
+		_objective_disposition_suppresses suppress_fast_fail "$issue_number" "$repo_slug" "${AIDEVOPS_ATTEMPT_ID:-}"; then
+		print_info "[fast-fail] suppressed reconciled non-failure #${issue_number} (${repo_slug})"
+		return 0
+	fi
 
 	# Launch/preflight aborts happen before a worker reaches the brief. They are
 	# useful launch diagnostics, but they must not accrue as per-issue fast-fail

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -463,6 +463,11 @@ _handle_run_result() {
 				print_warning "$selected_model worker exited with activity but no completion signal (premature exit — will attempt continuation)"
 				return 77
 			fi
+			if output_has_post_pr_handoff_signal "$output_file"; then
+				_run_result_label="post_pr_handoff"
+				rm -f "$output_file"
+				return 0
+			fi
 			if output_has_missing_context_blocked_signal "$output_file"; then
 				_run_result_label="brief_recovery"
 				_run_failure_reason="missing_implementation_context"
@@ -1024,6 +1029,7 @@ _execute_run_attempt() {
 	local agent_name="$8"
 	shift 8
 	local -a extra_args=("$@")
+	_begin_worker_runtime_run
 
 	_recover_deleted_cwd_before_launch "$work_dir" "execute_run_attempt" || return 1
 
@@ -1246,6 +1252,7 @@ _execute_run_attempt() {
 			return 1
 		}
 		exit_code=0
+		_begin_worker_runtime_run
 		_invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}"
 		if ! read -r exit_code <"$exit_code_file" 2>/dev/null; then
 			exit_code=1
@@ -1286,6 +1293,7 @@ _execute_run_attempt() {
 				cmd+=("$arg")
 			done < <(_build_run_cmd "$selected_model" "$work_dir" "$prompt_arg" "$title" \
 				"$variant_override" "$agent_name" "$persisted_session" "${extra_args[@]+"${extra_args[@]}"}")
+			_begin_worker_runtime_run
 			_invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}"
 			exit_code=$(cat "$exit_code_file" 2>/dev/null) || exit_code=1
 			_normalized_exit_info=$(_normalize_worker_exit_code_and_kill_reason "$exit_code_file" "$exit_code")
@@ -1516,6 +1524,7 @@ cmd_run() {
 
 	if [[ "$role" == "worker" ]]; then
 		_ensure_worker_lineage "$session_key"
+		_ensure_worker_attempt_identity
 		# GH#23520: publish canonical worker-origin markers before canary,
 		# sandbox passthrough, and downstream GitHub/signature helpers run.
 		# The sandbox allowlist already forwards AIDEVOPS_*; legacy generic
@@ -1658,7 +1667,7 @@ cmd_run() {
 			clear_startup_no_model_feedback "$selected_model"
 			# GH#20721: Pass work_dir so _cmd_run_finish can detect no-op exits.
 			_cmd_run_finish "$session_key" "complete" "$work_dir"
-			return 0
+			return $?
 		fi
 
 		# GH#21578 / t3021: Rate-limit fast-exit (exit 80).

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -461,6 +461,7 @@ append_runtime_metric() {
 		LAUNCH_FAILURE_CAUSE="$launch_failure_cause" KILL_REASON="$kill_reason" NEXT_ACTION="$next_action" \
 		WORKER_ID="${AIDEVOPS_WORKER_ID:-}" PARENT_WORKER_ID="${AIDEVOPS_PARENT_WORKER_ID:-}" \
 		ROOT_WORKER_ID="${AIDEVOPS_ROOT_WORKER_ID:-}" CORRELATION_ID="${AIDEVOPS_CORRELATION_ID:-}" \
+		ATTEMPT_ID="${AIDEVOPS_ATTEMPT_ID:-}" RUN_ID="${AIDEVOPS_RUN_ID:-}" \
 		METRICS_PATH="$METRICS_FILE" python3 - <<'PY' >/dev/null 2>&1 || true
 import json
 import os
@@ -496,6 +497,8 @@ optional_fields = {
     "parent_worker_id": os.environ.get("PARENT_WORKER_ID", ""),
     "root_worker_id": os.environ.get("ROOT_WORKER_ID", ""),
     "correlation_id": os.environ.get("CORRELATION_ID", ""),
+    "attempt_id": os.environ.get("ATTEMPT_ID", ""),
+    "run_id": os.environ.get("RUN_ID", ""),
 }
 for key, value in optional_fields.items():
     if value:
@@ -781,7 +784,7 @@ Mandatory behavior:
 5. Never emit user-directed language ("If you want...", "Let me know...", "Should I...").
 6. Reading the issue and reading docs are SETUP -- not completion. You MUST continue through implementation, commit, push, and PR creation after setup.
 7. A draft PR is only a durable checkpoint, never completion. Continue until the implementation and required local verification are complete, every intended commit is pushed, the PR is non-draft, the PR head matches local HEAD, and the required MERGE_SUMMARY exists.
-8. Attempt the merge path once. If it merges, finish the required closing comments. If the exact-head non-draft PR has no terminal check failure and only asynchronous CI, review-bot, human approval, or native auto-merge remains, report a post-PR handoff and exit normally. Pulse/webhook automation owns subsequent monitoring. Do not sleep, wait, or poll for those gates, and never bypass, disable, or weaken branch protection, approval, review-bot, CI, or security gates.
+8. Attempt the merge path once. If it merges, finish the required closing comments. If the exact-head non-draft PR has no terminal check failure and only asynchronous CI, review-bot, human approval, or native auto-merge remains, emit POST_PR_HANDOFF on its own line and exit normally. Pulse/webhook automation owns subsequent monitoring. Do not sleep, wait, or poll for those gates, and never bypass, disable, or weaken branch protection, approval, review-bot, CI, or security gates.
 9. Model escalation before BLOCKED (GH#14964): BLOCKED is only valid after exhausting all autonomous solution paths. Before exiting BLOCKED, retry at the thinking tier and let runtime routing choose the available model and reasoning level. Review-policy metadata, nominal GitHub states, and lower-tier model limits are NOT valid blockers on their own. Genuine blockers require evidence: a failing check that cannot be repaired, missing permission, unresolved conflict, or explicit policy gate.
 
 Activity watchdog constraint -- CRITICAL:
@@ -822,7 +825,7 @@ Before ending your session, verify ALL of these:
   - Check remote state once. Terminal failures are worker-actionable and must not
     be reported as a successful handoff; pending CI/review alone is handed off.
   - If any readiness check fails, you are NOT done -- continue working.
-  - Valid exit states are FULL_LOOP_COMPLETE, a verified post-PR handoff, or
+  - Valid exit states are FULL_LOOP_COMPLETE, POST_PR_HANDOFF, or
     BLOCKED with evidence. Runtime classification independently validates PR state.
 EOF
 	return 0
@@ -1550,6 +1553,7 @@ _register_dispatch_ledger() {
 	[[ -n "$ledger_work_dir" ]] && ledger_args+=(--worktree "$ledger_work_dir")
 	[[ -n "${AIDEVOPS_DISPATCH_TIER:-}" ]] && ledger_args+=(--tier "$AIDEVOPS_DISPATCH_TIER")
 	[[ -n "${AIDEVOPS_DISPATCH_MODEL:-}" ]] && ledger_args+=(--model "$AIDEVOPS_DISPATCH_MODEL")
+	[[ -n "${AIDEVOPS_ATTEMPT_ID:-}" ]] && ledger_args+=(--attempt-id "$AIDEVOPS_ATTEMPT_ID")
 
 	"$DISPATCH_LEDGER_HELPER" "${ledger_args[@]}" 2>/dev/null || true
 	return 0
@@ -1565,6 +1569,7 @@ _update_dispatch_ledger() {
 
 	local -a ledger_args=("$ledger_status" --session-key "$ledger_session_key")
 	[[ -n "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" ]] && ledger_args+=(--lease-token "$AIDEVOPS_DISPATCH_LEASE_TOKEN")
+	[[ -n "${AIDEVOPS_ATTEMPT_ID:-}" ]] && ledger_args+=(--attempt-id "$AIDEVOPS_ATTEMPT_ID")
 	"$DISPATCH_LEDGER_HELPER" "${ledger_args[@]}" 2>/dev/null || true
 	return 0
 }

--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -617,7 +617,7 @@ _build_claude_cmd() {
 }
 
 # output_has_completion_signal: check if a worker run produced a meaningful
-# completion signal (FULL_LOOP_COMPLETE, BLOCKED, or PR creation).
+# completion signal (FULL_LOOP_COMPLETE, exact POST_PR_HANDOFF, BLOCKED, or PR creation).
 # Workers that produce tool calls but exit without these signals stopped
 # prematurely -- typically after investigation/setup but before implementation.
 #
@@ -684,8 +684,13 @@ for line in raw.splitlines():
 
 model_text = "\n".join(model_text_parts)
 
+def has_post_pr_handoff(text):
+    return any(line.strip() == "POST_PR_HANDOFF" for line in text.splitlines())
+
 # If we extracted model text, use it exclusively
 if model_text.strip():
+    if has_post_pr_handoff(model_text):
+        sys.exit(0)
     for marker in ("FULL_LOOP_COMPLETE", blocked_marker, "TASK_COMPLETE"):
         if marker in model_text:
             sys.exit(0)
@@ -702,6 +707,8 @@ if model_text.strip():
     sys.exit(1)
 
 # Fallback for non-JSON output (claude CLI, plain text)
+if has_post_pr_handoff(raw):
+    sys.exit(0)
 for marker in ("FULL_LOOP_COMPLETE", blocked_marker, "TASK_COMPLETE"):
     if marker in raw:
         sys.exit(0)
@@ -713,6 +720,38 @@ if "git push" in raw and ("-> " in raw or "branch " in raw):
     sys.exit(0)
 
 sys.exit(1)
+PY
+	return $?
+}
+
+output_has_post_pr_handoff_signal() {
+	local file_path="$1"
+	[[ -f "$file_path" ]] || return 1
+	python3 - "$file_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_text(errors='ignore')
+model_text_parts = []
+for line in raw.splitlines():
+    line = line.strip()
+    if not line.startswith('{'):
+        continue
+    try:
+        obj = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        continue
+    if obj.get('type', '') != 'text':
+        continue
+    part = obj.get('part', {})
+    text = obj.get('text') or part.get('text') or ''
+    if text:
+        model_text_parts.append(text)
+
+model_text = '\n'.join(model_text_parts)
+candidate = model_text if model_text.strip() else raw
+sys.exit(0 if any(line.strip() == 'POST_PR_HANDOFF' for line in candidate.splitlines()) else 1)
 PY
 	return $?
 }

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -29,6 +29,7 @@ _HRW_STATUS_FAIL="fail"
 _HRW_STATUS_FAILED="failed"
 _HRW_STATUS_ESCALATED="escalated"
 _HRW_STATUS_UNKNOWN="unknown"
+_HRW_STATUS_PERMISSION_REQUIRED="permission_required"
 _HRW_GIT_HEAD="HEAD"
 _HRW_CRASH_NO_WORK="no_work"
 _HRW_CRASH_OVERWHELMED="overwhelmed"
@@ -39,6 +40,7 @@ _HRW_TELEMETRY_DEFERRED="deferred"
 _HRW_REASON_DRAFT_CHECKPOINT="worker_draft_checkpoint"
 _HRW_REASON_DRAFT_ESCALATION_FAILED="worker_draft_checkpoint_escalation_failed"
 _HRW_REASON_CLOSED_UNMERGED="worker_closed_unmerged_pr"
+_HRW_REASON_UNVERIFIED_HANDOFF="worker_post_pr_handoff_unverified"
 _HRW_EVENT_FAILED="worker.failed"
 _HRW_NMR_LABEL="needs-maintainer-review"
 _HRW_PERMISSION_PERSISTENCE_FAILED="permission_request_persistence_failed"
@@ -1420,7 +1422,7 @@ _hrw_finish_permission_required_run() {
 	local session_key="$1"
 	local work_dir="$2"
 	local helper="${SCRIPT_DIR}/worker-permission-helper.sh"
-	local permission_status="permission_required"
+	local permission_status="$_HRW_STATUS_PERMISSION_REQUIRED"
 	if [[ ! -x "$helper" || -z "${_run_permission_request_file:-}" ]]; then
 		_hrw_record_permission_blocker_failure "$session_key" "permission_capture_or_helper_unavailable"
 		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_PERMISSION_PERSISTENCE_FAILED"
@@ -1455,10 +1457,55 @@ _hrw_record_terminal_outcome() {
 	"$ledger_helper" record-outcome \
 		--session-key "$session_key" \
 		--lease-token "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" \
+		--attempt-id "${AIDEVOPS_ATTEMPT_ID:-}" \
 		--issue "${WORKER_ISSUE_NUMBER:-}" \
 		--repo "${DISPATCH_REPO_SLUG:-${WORKER_REPO_SLUG:-}}" \
 		--outcome "$outcome" \
 		--reason "$reason" 2>/dev/null || true
+	return 0
+}
+
+_hrw_record_reconciled_outcome() {
+	local session_key="$1"
+	local raw_result="$2"
+	local outcome="$3"
+	local status="$4"
+	local classification="$5"
+	local helper="${OBJECTIVE_RECONCILIATION_HELPER:-${SCRIPT_DIR}/objective-reconciliation-helper.sh}"
+	local issue_number="${WORKER_ISSUE_NUMBER:-}"
+	local repo_slug="${DISPATCH_REPO_SLUG:-${WORKER_REPO_SLUG:-}}"
+	local next_action="narrow_redispatch"
+	local write_attempt=1
+	local max_write_attempts="${AIDEVOPS_OBJECTIVE_OUTCOME_WRITE_ATTEMPTS:-3}"
+	[[ "$max_write_attempts" =~ ^[1-5]$ ]] || max_write_attempts=3
+
+	if [[ -z "$issue_number" && "$session_key" =~ ([0-9]+)$ ]]; then
+		issue_number="${BASH_REMATCH[1]}"
+	fi
+	case "$outcome" in
+	success) next_action="monitor_pr" ;;
+	deferred)
+		if [[ "$status" == "$_HRW_STATUS_PERMISSION_REQUIRED" ]]; then
+			next_action="await_maintainer_permission"
+		else
+			next_action="retry_infrastructure"
+		fi
+		;;
+	escalated) next_action="decision_ready_human_packet" ;;
+	esac
+	[[ -x "$helper" && "$issue_number" =~ ^[1-9][0-9]*$ && -n "$repo_slug" && -n "${AIDEVOPS_ATTEMPT_ID:-}" ]] || return 0
+	while [[ "$write_attempt" -le "$max_write_attempts" ]]; do
+		if "$helper" record-outcome --repo "$repo_slug" --issue "$issue_number" \
+			--attempt-id "$AIDEVOPS_ATTEMPT_ID" --run-id "${AIDEVOPS_RUN_ID:-}" \
+			--attempt-started-at "${AIDEVOPS_ATTEMPT_STARTED_AT:-}" \
+			--raw-result "$raw_result" --outcome "$outcome" --status "$status" \
+			--classification "$classification" --next-action "$next_action" >/dev/null 2>&1; then
+			return 0
+		fi
+		write_attempt=$((write_attempt + 1))
+		[[ "$write_attempt" -le "$max_write_attempts" ]] && sleep 0.1
+	done
+	print_warning "[lifecycle] reconciled outcome persistence failed after ${max_write_attempts} attempts session=${session_key} attempt=${AIDEVOPS_ATTEMPT_ID}"
 	return 0
 }
 
@@ -1476,7 +1523,18 @@ _hrw_finish_success_run() {
 	local session_key="$1"
 	local work_dir="$2"
 	local release_needed=1
+	local finish_status=0
 	local permission_pending_file=""
+	if [[ "${_run_result_label:-}" == "post_pr_handoff" ]] &&
+		(! declare -F _worker_post_pr_handoff_confirmed >/dev/null 2>&1 ||
+			! _worker_post_pr_handoff_confirmed "$session_key" "$work_dir"); then
+		print_warning "[lifecycle] ${_HRW_REASON_UNVERIFIED_HANDOFF} session=${session_key} — exact-head non-draft PR handoff could not be verified; routing as failure"
+		_release_dispatch_claim "$session_key" "$_HRW_REASON_UNVERIFIED_HANDOFF"
+		_report_failure_to_fast_fail "$session_key" "$_HRW_REASON_UNVERIFIED_HANDOFF" "$_HRW_CRASH_OVERWHELMED"
+		release_needed=0
+		finish_status=1
+		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_REASON_UNVERIFIED_HANDOFF"
+	fi
 
 	# GH#20721 + GH#20819: Classify worker output quality.
 	# _worker_produced_output distinguishes exact-head completion from drafts,
@@ -1491,7 +1549,7 @@ _hrw_finish_success_run() {
 	# Fail-open semantics are preserved: when signals cannot be evaluated (no git
 	# repo, no gh, no remote) the classification is "pr_exists", so false-negatives
 	# (legit work misclassified) are impossible.
-	if [[ -n "$work_dir" ]]; then
+	if [[ "$release_needed" -eq 1 && -n "$work_dir" ]]; then
 		local output_class="pr_exists"
 		output_class=$(_worker_produced_output "$session_key" "$work_dir")
 		case "$output_class" in
@@ -1551,7 +1609,7 @@ _hrw_finish_success_run() {
 		rm -f "${AIDEVOPS_PERMISSION_GRANT_FILE:-}" "$permission_pending_file" 2>/dev/null || true
 	fi
 
-	return 0
+	return "$finish_status"
 }
 
 _hrw_finish_cleanup() {
@@ -1580,6 +1638,7 @@ _cmd_run_finish() {
 	# boundary. Reusing it avoids a second GitHub query that could fail after the
 	# first query already proved the issue and matching PR are terminal.
 	local external_terminal_confirmed="${4:-0}"
+	local finish_status=0
 	_HRW_FINAL_RUNTIME_EVENT="worker.completed"
 	_HRW_FINAL_RUNTIME_STATUS="${_run_result_label:-$ledger_status}"
 	_HRW_FINAL_RUNTIME_CLASSIFICATION="${_run_failure_reason:-}"
@@ -1608,27 +1667,34 @@ _cmd_run_finish() {
 		_HRW_FINAL_RUNTIME_STATUS="rate_limit_fast"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="rate_limit"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
-	elif [[ "$ledger_status" == "permission_required" ]]; then
+	elif [[ "$ledger_status" == "$_HRW_STATUS_PERMISSION_REQUIRED" ]]; then
 		if ! _hrw_finish_permission_required_run "$session_key" "$work_dir"; then
 			_hrw_record_terminal_outcome "$session_key" "$_HRW_TERMINAL_OUTCOME" \
 				"$_HRW_FINAL_RUNTIME_CLASSIFICATION"
 			_emit_worker_runtime_event "$_HRW_FINAL_RUNTIME_EVENT" \
 				"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
-			_update_dispatch_ledger "$session_key" "fail"
+			_hrw_record_reconciled_outcome "$session_key" "${_run_result_label:-$ledger_status}" \
+				"$_HRW_TERMINAL_OUTCOME" "$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
+			_update_dispatch_ledger "$session_key" "$_HRW_STATUS_FAIL"
 			_release_session_lock "$session_key"
 			trap - EXIT
 			return 1
 		fi
 	else
-		_hrw_finish_success_run "$session_key" "$work_dir"
+		if ! _hrw_finish_success_run "$session_key" "$work_dir"; then
+			finish_status=1
+			ledger_status="$_HRW_STATUS_FAIL"
+		fi
 	fi
 	_hrw_record_terminal_outcome "$session_key" "$_HRW_TERMINAL_OUTCOME" \
 		"$_HRW_FINAL_RUNTIME_CLASSIFICATION"
 	_emit_worker_runtime_event "$_HRW_FINAL_RUNTIME_EVENT" \
 		"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
+	_hrw_record_reconciled_outcome "$session_key" "${_run_result_label:-$ledger_status}" \
+		"$_HRW_TERMINAL_OUTCOME" "$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
 
 	_hrw_finish_cleanup "$session_key" "$ledger_status" "$work_dir"
-	return 0
+	return "$finish_status"
 }
 
 _hrw_permission_pending_path() {

--- a/.agents/scripts/objective-reconciliation-helper.sh
+++ b/.agents/scripts/objective-reconciliation-helper.sh
@@ -6,8 +6,30 @@
 
 set -uo pipefail
 
+OBJECTIVE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=portable-stat.sh
+source "${OBJECTIVE_SCRIPT_DIR}/portable-stat.sh"
+
 OBJECTIVE_DEFAULT_TTL_SECS="${AIDEVOPS_OBJECTIVE_ASSUMPTION_TTL_SECS:-3600}"
 OBJECTIVE_DEFAULT_MAX_REPAIRS="${AIDEVOPS_OBJECTIVE_MAX_REPAIRS:-25}"
+OBJECTIVE_RECORD_ATTEMPT_OUTCOME="attempt_outcome"
+OBJECTIVE_EVENT_COMPLETED="worker.completed"
+OBJECTIVE_EVENT_FAILED="worker.failed"
+OBJECTIVE_EVENT_DEFERRED="worker.deferred"
+OBJECTIVE_OUTCOME_SUCCESS="success"
+OBJECTIVE_OUTCOME_FAILED="failed"
+OBJECTIVE_OUTCOME_DEFERRED="deferred"
+OBJECTIVE_OUTCOME_UNKNOWN="unknown"
+OBJECTIVE_OUTCOME_TERMINAL="terminal"
+OBJECTIVE_SOURCE_NONE="none"
+OBJECTIVE_SOURCE_LIFECYCLE="lifecycle_event"
+OBJECTIVE_SOURCE_STATE="objective_state"
+OBJECTIVE_STATE_COMPLETED="completed"
+OBJECTIVE_STATE_CANCELLED="cancelled"
+OBJECTIVE_STATE_IMPOSSIBLE="impossible"
+OBJECTIVE_STATE_REVIEW="under review"
+OBJECTIVE_JSON_TYPE_OBJECT="object"
+OBJECTIVE_EMPTY_STATE='{"objectives":[]}'
 
 _objective_usage() {
 	cat <<'EOF'
@@ -16,6 +38,12 @@ Usage:
   objective-reconciliation-helper.sh reconcile --repo OWNER/REPO [--input FILE]
       [--state-file FILE] [--now EPOCH] [--ttl SECONDS] [--max-repairs COUNT]
   objective-reconciliation-helper.sh summary [--state-file FILE]
+  objective-reconciliation-helper.sh record-outcome --repo OWNER/REPO --issue NUM
+      --attempt-id ID [--run-id ID] --raw-result RESULT --outcome OUTCOME
+      [--status STATUS] [--classification CLASS] [--next-action ACTION]
+      [--attempt-started-at EPOCH] [--timestamp EPOCH]
+  objective-reconciliation-helper.sh disposition --repo OWNER/REPO --issue NUM
+      [--attempt-id ID] [--state-file FILE]
 
 Input is either an issue array or an object containing `issues`, `prs`, and an
 optional pipe-delimited `merged_lookup`. Reconciliation is API-free: its
@@ -53,6 +81,201 @@ _objective_read_input() {
 	return $?
 }
 
+_objective_lock_age() {
+	local lock_dir="$1"
+	local now_epoch=""
+	local mtime_epoch=""
+
+	now_epoch=$(_objective_now)
+	mtime_epoch=$(_file_mtime_epoch "$lock_dir")
+	[[ "$now_epoch" =~ ^[0-9]+$ && "$mtime_epoch" =~ ^[0-9]+$ && "$now_epoch" -ge "$mtime_epoch" ]] || {
+		printf '0\n'
+		return 0
+	}
+	printf '%s\n' "$((now_epoch - mtime_epoch))"
+	return 0
+}
+
+_objective_acquire_append_lock() {
+	local lock_dir="$1"
+	local attempts=0
+	local owner_pid=""
+	local lock_age="0"
+	local orphan_age="${AIDEVOPS_OBJECTIVE_LOCK_ORPHAN_AGE_SECS:-30}"
+	[[ "$orphan_age" =~ ^[0-9]+$ && "$orphan_age" -ge 5 ]] || orphan_age=30
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		attempts=$((attempts + 1))
+		owner_pid=$(tr -d '[:space:]' "${lock_dir}/owner.pid" 2>/dev/null || true)
+		if [[ "$owner_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+			rm -f "${lock_dir}/owner.pid" 2>/dev/null || true
+			rmdir "$lock_dir" 2>/dev/null || true
+			continue
+		fi
+		if [[ -z "$owner_pid" && "$attempts" -ge 20 ]]; then
+			lock_age=$(_objective_lock_age "$lock_dir")
+			if [[ "$lock_age" -ge "$orphan_age" ]]; then
+				rmdir "$lock_dir" 2>/dev/null || true
+				continue
+			fi
+		fi
+		[[ "$attempts" -lt 100 ]] || return 1
+		sleep 0.05
+	done
+	printf '%s\n' "$$" >"${lock_dir}/owner.pid" 2>/dev/null || true
+	return 0
+}
+
+_objective_release_append_lock() {
+	local lock_dir="$1"
+	rm -f "${lock_dir}/owner.pid" 2>/dev/null || true
+	rmdir "$lock_dir" 2>/dev/null || true
+	return 0
+}
+
+_objective_record_outcome() {
+	local repo="$1"
+	local issue_number="$2"
+	local attempt_id="$3"
+	local run_id="$4"
+	local raw_result="$5"
+	local outcome="$6"
+	local status="$7"
+	local classification="$8"
+	local next_action="$9"
+	local evidence_timestamp="${10}"
+	local attempt_started_at="${11}"
+	local evidence_file="${AIDEVOPS_OBJECTIVE_EVIDENCE_FILE:-${HOME}/.aidevops/state/objective-evidence.jsonl}"
+	local evidence_dir=""
+	local lock_dir="${evidence_file}.lockdir"
+	local event_type="$OBJECTIVE_EVENT_FAILED"
+	local execution_path_state="recovery"
+
+	[[ -n "$repo" && "$issue_number" =~ ^[1-9][0-9]*$ && -n "$attempt_id" ]] || {
+		printf 'ERROR: record-outcome requires --repo, --issue, and --attempt-id\n' >&2
+		return 2
+	}
+	case "$outcome" in
+	success) event_type="$OBJECTIVE_EVENT_COMPLETED"; execution_path_state="$OBJECTIVE_OUTCOME_TERMINAL" ;;
+	failed) event_type="$OBJECTIVE_EVENT_FAILED"; execution_path_state="recovery" ;;
+	deferred) event_type="$OBJECTIVE_EVENT_DEFERRED"; execution_path_state="$OBJECTIVE_OUTCOME_DEFERRED" ;;
+	escalated) event_type="$OBJECTIVE_EVENT_FAILED"; execution_path_state="escalated" ;;
+	*) printf 'ERROR: unsupported reconciled outcome: %s\n' "$outcome" >&2; return 2 ;;
+	esac
+	[[ "$evidence_timestamp" =~ ^[0-9]+$ ]] || evidence_timestamp=$(_objective_now)
+	[[ "$attempt_started_at" =~ ^[0-9]+$ ]] || attempt_started_at="$evidence_timestamp"
+	evidence_dir=$(dirname "$evidence_file")
+	mkdir -p "$evidence_dir" 2>/dev/null || return 1
+	touch "$evidence_file" 2>/dev/null || return 1
+	_objective_acquire_append_lock "$lock_dir" || return 1
+	if jq -Rse --arg repo "$repo" --argjson issue "$issue_number" --arg aid "$attempt_id" \
+		--arg record_type "$OBJECTIVE_RECORD_ATTEMPT_OUTCOME" \
+		'split("\n") | any(.[]; (try fromjson catch {}) as $row |
+			$row.record_type == $record_type and $row.repo == $repo and
+			(($row.issue_number // 0) | tonumber? // 0) == $issue and ($row.attempt_id // "") == $aid)' \
+		"$evidence_file" >/dev/null 2>&1; then
+		_objective_release_append_lock "$lock_dir"
+		return 0
+	fi
+	jq -cn --argjson schema_version 2 --arg record_type "$OBJECTIVE_RECORD_ATTEMPT_OUTCOME" \
+		--arg event_type "$event_type" --arg repo "$repo" --argjson issue_number "$issue_number" \
+		--arg attempt_id "$attempt_id" --arg run_id "$run_id" --arg raw_result "$raw_result" \
+		--arg effective_outcome "$outcome" --arg status "$status" --arg classification "$classification" \
+		--arg next_action "$next_action" --arg execution_path_state "$execution_path_state" \
+		--arg worker_id "${AIDEVOPS_WORKER_ID:-}" --argjson evidence_timestamp "$evidence_timestamp" \
+		--arg attempt_started_at "$attempt_started_at" \
+		'{schema_version:$schema_version,record_type:$record_type,event_type:$event_type,
+		repo:$repo,issue_number:$issue_number,attempt_id:$attempt_id,run_id:$run_id,
+		attempt_started_at:$attempt_started_at,
+		raw_result:$raw_result,effective_outcome:$effective_outcome,status:$status,
+		classification:$classification,next_action:$next_action,
+		execution_path_state:$execution_path_state,worker_id:$worker_id,
+		evidence_timestamp:$evidence_timestamp,terminal:true,process_active:false,
+		subsequent_action_at:$evidence_timestamp}' >>"$evidence_file" 2>/dev/null || {
+		_objective_release_append_lock "$lock_dir"
+		return 1
+	}
+	_objective_release_append_lock "$lock_dir"
+	return 0
+}
+
+_objective_disposition() {
+	local repo="$1"
+	local issue_number="$2"
+	local attempt_id="$3"
+	local state_file="$4"
+	local evidence_file="${AIDEVOPS_OBJECTIVE_EVIDENCE_FILE:-${HOME}/.aidevops/state/objective-evidence.jsonl}"
+	local evidence_limit="${AIDEVOPS_OBJECTIVE_EVIDENCE_LIMIT:-2000}"
+	local evidence_json='[]'
+	local state_json="$OBJECTIVE_EMPTY_STATE"
+
+	[[ -n "$repo" && "$issue_number" =~ ^[1-9][0-9]*$ ]] || {
+		printf 'ERROR: disposition requires --repo and --issue\n' >&2
+		return 2
+	}
+	[[ "$evidence_limit" =~ ^[1-9][0-9]*$ ]] || evidence_limit=2000
+	if [[ -s "$evidence_file" ]]; then
+		evidence_json=$(tail -n "$evidence_limit" "$evidence_file" 2>/dev/null | jq -sc \
+			--arg object_type "$OBJECTIVE_JSON_TYPE_OBJECT" '[.[] | select(type == $object_type)]') || evidence_json='[]'
+	fi
+	if [[ -s "$state_file" ]]; then
+		state_json=$(jq -c '.' "$state_file" 2>/dev/null) || state_json="$OBJECTIVE_EMPTY_STATE"
+	fi
+	jq -nc --arg repo "$repo" --argjson issue "$issue_number" --arg aid "$attempt_id" \
+		--argjson evidence "$evidence_json" --argjson state "$state_json" \
+		--arg record_type "$OBJECTIVE_RECORD_ATTEMPT_OUTCOME" \
+		--arg event_completed "$OBJECTIVE_EVENT_COMPLETED" --arg event_failed "$OBJECTIVE_EVENT_FAILED" --arg event_deferred "$OBJECTIVE_EVENT_DEFERRED" \
+		--arg outcome_success "$OBJECTIVE_OUTCOME_SUCCESS" --arg outcome_failed "$OBJECTIVE_OUTCOME_FAILED" --arg outcome_deferred "$OBJECTIVE_OUTCOME_DEFERRED" \
+		--arg outcome_unknown "$OBJECTIVE_OUTCOME_UNKNOWN" --arg outcome_terminal "$OBJECTIVE_OUTCOME_TERMINAL" \
+		--arg source_lifecycle "$OBJECTIVE_SOURCE_LIFECYCLE" --arg source_state "$OBJECTIVE_SOURCE_STATE" --arg source_none "$OBJECTIVE_SOURCE_NONE" \
+		--arg state_completed "$OBJECTIVE_STATE_COMPLETED" --arg state_cancelled "$OBJECTIVE_STATE_CANCELLED" \
+		--arg state_impossible "$OBJECTIVE_STATE_IMPOSSIBLE" --arg state_review "$OBJECTIVE_STATE_REVIEW" '
+		def timestamp: ((.evidence_timestamp // .timestamp // .ts // 0) | tonumber? // 0);
+		def epoch_key:
+			((.attempt_started_at // timestamp) | tostring) as $raw |
+			if ($raw | test("^[0-9]+$")) then
+				if ($raw | length) >= 19 then $raw[0:19]
+				else ($raw + "0000000000000000000")[0:19] end
+			else "0000000000000000000" end;
+		def terminal_event: .event_type == $event_completed or .event_type == $event_failed or .event_type == $event_deferred;
+		def output($source; $record; $effective):
+			($effective == $outcome_success or $effective == "handoff" or $effective == $outcome_terminal or $effective == "escalated") as $stop_retry |
+			($effective != $outcome_unknown and $effective != $outcome_failed) as $nonfailure |
+			{
+				schema_version:2, source:$source, repo:$repo, issue_number:$issue,
+				attempt_id:($record.attempt_id // $aid), run_id:($record.run_id // ""),
+				attempt_started_at:($record.attempt_started_at // null),
+				effective_outcome:$effective, raw_result:($record.raw_result // ""),
+				status:($record.status // ""), classification:($record.classification // ""),
+				next_action:($record.next_action // ""), evidence_timestamp:($record | timestamp),
+				terminal:($effective != $outcome_unknown), suppress_fast_fail:$nonfailure,
+				suppress_retry:$stop_retry, suppress_enrichment:$nonfailure,
+				suppress_failure_mining:$nonfailure
+			};
+		[$evidence[] | select(.repo == $repo and ((.issue_number // 0) | tonumber? // 0) == $issue)] as $rows |
+		[$rows[] | select(.record_type == $record_type)] as $outcomes |
+		(if $aid == "" then $outcomes else [$outcomes[] | select((.attempt_id // "") == $aid)] end |
+			sort_by([epoch_key, timestamp]) | last // null) as $exact |
+		([$rows[] | select((.record_type // "") != $record_type and terminal_event) |
+			select($aid == "" or (.attempt_id // "") == $aid or
+				((.attempt_id // "") == "" and ($outcomes | length) == 0))] |
+			sort_by([epoch_key, timestamp]) | last // null) as $lifecycle |
+		([$state.objectives[]? | select(.repo == $repo and ((.number // .issue_number // 0) | tonumber? // 0) == $issue)] |
+			last // null) as $objective |
+		if $exact != null then output($record_type; $exact; ($exact.effective_outcome // $outcome_unknown))
+		elif $lifecycle != null then
+			if $lifecycle.event_type == $event_completed then output($source_lifecycle; $lifecycle; $outcome_success)
+			elif $lifecycle.event_type == $event_deferred then output($source_lifecycle; $lifecycle; $outcome_deferred)
+			else output($source_lifecycle; $lifecycle; $outcome_failed) end
+		elif $objective != null then
+			if $objective.objective_state == $state_completed then output($source_state; $objective; $outcome_success)
+			elif $objective.objective_state == $state_review then output($source_state; $objective; "handoff")
+			elif $objective.objective_state == $state_cancelled or $objective.objective_state == $state_impossible then output($source_state; $objective; $outcome_terminal)
+			elif $objective.objective_state == "authority-blocked" or $objective.objective_state == "dependency-blocked" then output($source_state; $objective; $outcome_deferred)
+			else output($source_none; {}; $outcome_unknown) end
+		else output($source_none; {}; $outcome_unknown) end'
+	return $?
+}
+
 _objective_attach_durable_evidence() {
 	local input_json="$1"
 	local repo="$2"
@@ -64,17 +287,34 @@ _objective_attach_durable_evidence() {
 		return 0
 	fi
 	local evidence_json="[]"
-	evidence_json=$(tail -n "$evidence_limit" "$evidence_file" 2>/dev/null | jq -sc '[.[] | select(type == "object")]') || evidence_json="[]"
-	jq -nc --arg repo "$repo" --argjson input "$input_json" --argjson evidence "$evidence_json" '
+	evidence_json=$(tail -n "$evidence_limit" "$evidence_file" 2>/dev/null | jq -sc \
+		--arg object_type "$OBJECTIVE_JSON_TYPE_OBJECT" '[.[] | select(type == $object_type)]') || evidence_json="[]"
+	jq -nc --arg repo "$repo" --argjson input "$input_json" --argjson evidence "$evidence_json" \
+		--arg event_completed "$OBJECTIVE_EVENT_COMPLETED" --arg event_failed "$OBJECTIVE_EVENT_FAILED" \
+		--arg event_deferred "$OBJECTIVE_EVENT_DEFERRED" '
+		def evidence_epoch: (.evidence_timestamp // .timestamp // .ts // 0) | tonumber? // 0;
+		def epoch_key:
+			((.attempt_started_at // evidence_epoch) | tostring) as $raw |
+			if ($raw | test("^[0-9]+$")) then
+				if ($raw | length) >= 19 then $raw[0:19]
+				else ($raw + "0000000000000000000")[0:19] end
+			else "0000000000000000000" end;
 		(if ($input | type) == "array" then {issues:$input, prs:[], merged_lookup:""} else $input end) |
 		.issues = [(.issues // [])[] | . as $issue |
-			([$evidence[] | select(.repo == ($issue.repo // $repo) and (.issue_number | tonumber) == (($issue.number // 0) | tonumber))] | sort_by(.evidence_timestamp) | last // {}) as $event |
+			([$evidence[] | select(.repo == ($issue.repo // $repo) and
+				((.issue_number // 0) | tonumber? // 0) == (($issue.number // 0) | tonumber? // 0))] |
+				sort_by([epoch_key, evidence_epoch]) | last // {}) as $event |
 			if ($event | length) == 0 then $issue else
 				$issue + {
 					evidence_timestamp: $event.evidence_timestamp,
-					lease_active: true,
-					process_active: ($event.event_type != "worker.completed" and $event.event_type != "worker.failed"),
+					lease_active: (($event.terminal // false) != true and $event.event_type != $event_completed and $event.event_type != $event_failed and $event.event_type != $event_deferred),
+					process_active: (($event.terminal // false) != true and $event.event_type != $event_completed and $event.event_type != $event_failed and $event.event_type != $event_deferred),
 					execution_path_state: $event.execution_path_state,
+					attempt_id: ($event.attempt_id // ""),
+					run_id: ($event.run_id // ""),
+					raw_result: ($event.raw_result // ""),
+					terminal_outcome: ($event.effective_outcome // ""),
+					reconciled_next_action: ($event.next_action // ""),
 					branch_exists: ($event.branch_preserved // false),
 					worktree_exists: ($event.worktree_preserved // false),
 					commits_preserved: ($event.commits_preserved // false),
@@ -90,11 +330,11 @@ _objective_attach_durable_evidence() {
 
 _objective_derive_json() {
 	local input_json="$1" repo="$2" now_epoch="$3" ttl_secs="$4"
-	printf '%s' "$input_json" | jq -c --arg repo "$repo" --argjson now "$now_epoch" --argjson ttl "$ttl_secs" '
-		def labels: [(.labels // [])[] | if type == "object" then .name else . end] | map(select(type == "string"));
+	printf '%s' "$input_json" | jq -c --arg repo "$repo" --argjson now "$now_epoch" --argjson ttl "$ttl_secs" \
+		--arg state_completed "$OBJECTIVE_STATE_COMPLETED" --arg state_cancelled "$OBJECTIVE_STATE_CANCELLED" --arg state_impossible "$OBJECTIVE_STATE_IMPOSSIBLE" --arg state_review "$OBJECTIVE_STATE_REVIEW" --arg action_none "$OBJECTIVE_SOURCE_NONE" --arg outcome_failed "$OBJECTIVE_OUTCOME_FAILED" --arg object_type "$OBJECTIVE_JSON_TYPE_OBJECT" '
+		def labels: [(.labels // [])[] | if type == $object_type then .name else . end] | map(select(type == "string"));
 		def has_label($name): labels | index($name) != null;
 		def has_status($name): has_label("status:" + $name);
-		def state_completed: "completed"; def state_cancelled: "cancelled"; def state_impossible: "impossible"; def action_none: "none";
 		def action_resume: "resume_session"; def action_recover_branch: "recover_branch"; def action_repair_pr: "repair_pr"; def action_redispatch: "narrow_redispatch";
 		def evidence_epoch:
 			(.evidence_timestamp // .evidence_at // .updatedAt // .updated_at // $now) as $value |
@@ -109,21 +349,17 @@ _objective_derive_json() {
 				((.headRefName // .head_ref_name // "") | test($number_pattern)))) // {};
 		def ladder($attempt; $authority):
 			if $attempt <= 0 then "retry_infrastructure"
-			elif $attempt == 1 then action_resume
-			elif $attempt == 2 then action_recover_branch
-			elif $attempt == 3 then action_repair_pr
-			elif $attempt == 4 then action_redispatch
+			elif $attempt <= 4 then [action_resume, action_recover_branch, action_repair_pr, action_redispatch][$attempt - 1]
 			elif $attempt == 5 then "model_escalation"
 			elif $attempt == 6 then "diagnostic_worker"
 			elif $authority then "decision_ready_human_packet"
 			else "diagnostic_worker" end;
 		def owner_for($action):
-			if $action == "monitor_worker" or $action == action_resume then "worker-supervisor"
-			elif $action == "monitor_pr" or $action == action_repair_pr then "pr-repair"
+			if $action == "monitor_worker" or $action == action_resume then "worker-supervisor" elif $action == "monitor_pr" or $action == action_repair_pr then "pr-repair"
 			elif $action == "reverify_dependency" then "dependency-monitor"
 			elif $action == "decision_ready_human_packet" then "maintainer-gate"
 			elif $action == "close_issue" then "issue-reconciler"
-			elif $action == action_none then action_none
+			elif $action == $action_none then $action_none
 			else "pulse-dispatch" end;
 		(.issues // (if type == "array" then . else [] end)) as $issues | (.prs // []) as $prs | (.merged_lookup // "") as $merged_lookup |
 		[$issues[] |
@@ -144,26 +380,26 @@ _objective_derive_json() {
 			(($issue.recovery_attempt // 0) | tonumber) as $attempt |
 			(($issue.recovery_comment_at // 0) | tonumber) as $recovery_comment |
 			(($issue.subsequent_action_at // 0) | tonumber) as $subsequent_action |
-			(if ($issue.state // "open" | ascii_downcase) == "closed" or $merged or has_status("done") then state_completed
-			 elif ($issue.cancelled // false) == true or has_label("status:cancelled") then state_cancelled
-			 elif ($issue.impossible // false) == true or has_label("status:impossible") then state_impossible
+			(if ($issue.state // "open" | ascii_downcase) == "closed" or $merged or has_status("done") then $state_completed
+			 elif ($issue.cancelled // false) == true or has_label("status:cancelled") then $state_cancelled
+			 elif ($issue.impossible // false) == true or has_label("status:impossible") then $state_impossible
 			 elif $authority then "authority-blocked"
 			 elif $dependency_blocked and ($dependency_resolved | not) then "dependency-blocked"
-			 elif $has_pr_assumption then "under review"
+			 elif $has_pr_assumption then $state_review
 			 elif $lease and $process then "actively owned"
 			 else "actionable" end) as $objective_state |
 			(if $merged and (($issue.state // "open" | ascii_downcase) != "closed") then "close_issue"
-			 elif [state_completed, state_cancelled, state_impossible] | index($objective_state) then action_none
+			 elif [$state_completed, $state_cancelled, $state_impossible] | index($objective_state) then $action_none
 			 elif $authority then ladder($attempt; true)
 			 elif $dependency_blocked and ($dependency_resolved | not) then "reverify_dependency"
 			 elif $dependency_resolved then action_redispatch
 			 elif $recovery_comment > 0 and $subsequent_action <= $recovery_comment then ladder($attempt; false)
 			 elif $has_pr_assumption and (($pr_evidence | length) == 0) then action_recover_branch
-			 elif ($checks == "fail" or $checks == "failed" or $checks == "failure") and (($issue.repair_active // false) | not) then action_repair_pr
+			 elif ($checks == "fail" or $checks == $outcome_failed or $checks == "failure") and (($issue.repair_active // false) | not) then action_repair_pr
 			 elif $lease and ($process | not) and (($issue.worktree_exists // false) == true) then action_resume
 			 elif $lease and ($process | not) and (($issue.branch_exists // false) == true) then action_recover_branch
 			 elif $lease and ($process | not) then action_redispatch
-			 elif $objective_state == "under review" then "monitor_pr"
+			 elif $objective_state == $state_review then "monitor_pr"
 			 elif $objective_state == "actively owned" then "monitor_worker"
 			 else "dispatch_objective" end) as $next_action |
 			($evidence + $ttl) as $expiry |
@@ -174,16 +410,20 @@ _objective_derive_json() {
 				execution_path_state: ($issue.execution_path_state // (if $process then "running" elif $lease then "leased" elif $has_pr_assumption then "review" else "idle" end)),
 				evidence_timestamp: $evidence,
 				assumption_expires_at: $expiry,
-				assumption_expired: (([state_completed, state_cancelled, state_impossible] | index($objective_state) | not) and $expiry <= $now),
+				assumption_expired: (([$state_completed, $state_cancelled, $state_impossible] | index($objective_state) | not) and $expiry <= $now),
 				next_action: $next_action,
-				trigger_at: (if $next_action == "none" then null else $expiry end),
+				trigger_at: (if $next_action == $action_none then null else $expiry end),
 				responsible_component: owner_for($next_action),
 				recovery_attempt: $attempt,
+				attempt_id: ($issue.attempt_id // ""),
+				run_id: ($issue.run_id // ""),
+				raw_result: ($issue.raw_result // ""),
+				effective_outcome: ($issue.terminal_outcome // ""),
 				preservation: {commits: ($issue.commits_preserved // false), logs: ($issue.logs_preserved // false),
 					verification: ($issue.verification_preserved // false)}
 			} |
-			.unattended = (([state_completed, state_cancelled, state_impossible] | index($objective_state) | not) and
-				((.next_action == "" or .next_action == action_none or .trigger_at == null or .responsible_component == "") or .assumption_expired))
+			.unattended = (([$state_completed, $state_cancelled, $state_impossible] | index($objective_state) | not) and
+				((.next_action == "" or .next_action == $action_none or .trigger_at == null or .responsible_component == "") or .assumption_expired))
 		]'
 	return $?
 }
@@ -195,12 +435,12 @@ _objective_merge_state() {
 	local now_epoch="$4"
 	local max_repairs="$5"
 	local state_dir=""
-	local previous='{"objectives":[]}'
+	local previous="$OBJECTIVE_EMPTY_STATE"
 	local tmp_file=""
 	state_dir=$(dirname "$state_file")
 	mkdir -p "$state_dir" 2>/dev/null || return 1
 	if [[ -s "$state_file" ]]; then
-		previous=$(jq -c '.' "$state_file" 2>/dev/null) || previous='{"objectives":[]}'
+		previous=$(jq -c '.' "$state_file" 2>/dev/null) || previous="$OBJECTIVE_EMPTY_STATE"
 	fi
 	tmp_file=$(mktemp "${state_file}.tmp.XXXXXX") || return 1
 	jq -n \
@@ -209,7 +449,7 @@ _objective_merge_state() {
 		--argjson max "$max_repairs" \
 		--argjson previous "$previous" \
 		--argjson current "$derived_json" '
-		def plan: {objective_state, execution_path_state, evidence_timestamp, assumption_expires_at, next_action, trigger_at, responsible_component, preservation};
+		def plan: {objective_state, execution_path_state, evidence_timestamp, assumption_expires_at, next_action, trigger_at, responsible_component, attempt_id, run_id, raw_result, effective_outcome, preservation};
 		($previous.objectives // []) as $old |
 		[$current[] | . as $item | select(([$old[] | select(.repo == $item.repo and .number == $item.number) | plan] | first // null) != ($item | plan))] as $changed |
 		{
@@ -232,16 +472,14 @@ _objective_summary() {
 		printf '{"total":0,"nonterminal":0,"objectives_without_next_action":0,"expired_assumptions":0,"oldest_unverified_assumption":null}\n'
 		return 0
 	fi
-	jq -c '
-		def state_completed: "completed";
-		def state_cancelled: "cancelled";
-		def state_impossible: "impossible";
+	jq -c --arg state_completed "$OBJECTIVE_STATE_COMPLETED" --arg state_cancelled "$OBJECTIVE_STATE_CANCELLED" \
+		--arg state_impossible "$OBJECTIVE_STATE_IMPOSSIBLE" --arg action_none "$OBJECTIVE_SOURCE_NONE" '
 		(.objectives // []) as $items |
-		[$items[] | .objective_state as $state | select(([state_completed, state_cancelled, state_impossible] | index($state)) == null)] as $open |
+		[$items[] | .objective_state as $state | select(([$state_completed, $state_cancelled, $state_impossible] | index($state)) == null)] as $open |
 		{
 			total: ($items | length),
 			nonterminal: ($open | length),
-			objectives_without_next_action: ([$open[] | select((.next_action // "") == "" or .next_action == "none" or .trigger_at == null)] | length),
+			objectives_without_next_action: ([$open[] | select((.next_action // "") == "" or .next_action == $action_none or .trigger_at == null)] | length),
 			expired_assumptions: ([$open[] | select(.assumption_expired == true)] | length),
 			oldest_unverified_assumption: ([$open[] | select(.assumption_expired == true)] | sort_by(.evidence_timestamp) | first // null)
 		}' "$state_file"
@@ -257,6 +495,16 @@ main() {
 	local now_epoch=""
 	local ttl_secs="$OBJECTIVE_DEFAULT_TTL_SECS"
 	local max_repairs="$OBJECTIVE_DEFAULT_MAX_REPAIRS"
+	local issue_number=""
+	local attempt_id=""
+	local run_id=""
+	local raw_result=""
+	local outcome=""
+	local status=""
+	local classification=""
+	local next_action=""
+	local outcome_timestamp=""
+	local attempt_started_at=""
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		shift
@@ -267,6 +515,16 @@ main() {
 		--now) [[ $# -gt 0 ]] || return 2; now_epoch="$1"; shift ;;
 		--ttl) [[ $# -gt 0 ]] || return 2; ttl_secs="$1"; shift ;;
 		--max-repairs) [[ $# -gt 0 ]] || return 2; max_repairs="$1"; shift ;;
+		--issue) [[ $# -gt 0 ]] || return 2; issue_number="$1"; shift ;;
+		--attempt-id) [[ $# -gt 0 ]] || return 2; attempt_id="$1"; shift ;;
+		--run-id) [[ $# -gt 0 ]] || return 2; run_id="$1"; shift ;;
+		--raw-result) [[ $# -gt 0 ]] || return 2; raw_result="$1"; shift ;;
+		--outcome) [[ $# -gt 0 ]] || return 2; outcome="$1"; shift ;;
+		--status) [[ $# -gt 0 ]] || return 2; status="$1"; shift ;;
+		--classification) [[ $# -gt 0 ]] || return 2; classification="$1"; shift ;;
+		--next-action) [[ $# -gt 0 ]] || return 2; next_action="$1"; shift ;;
+		--timestamp) [[ $# -gt 0 ]] || return 2; outcome_timestamp="$1"; shift ;;
+		--attempt-started-at) [[ $# -gt 0 ]] || return 2; attempt_started_at="$1"; shift ;;
 		--help|-h) _objective_usage; return 0 ;;
 		*) printf 'ERROR: unknown option: %s\n' "$arg" >&2; return 2 ;;
 		esac
@@ -278,6 +536,17 @@ main() {
 	case "$command_name" in
 	help) _objective_usage; return 0 ;;
 	summary) _objective_summary "$state_file"; return $? ;;
+	record-outcome)
+		[[ -n "$outcome_timestamp" ]] || outcome_timestamp="$now_epoch"
+		[[ -n "$attempt_started_at" ]] || attempt_started_at="$outcome_timestamp"
+		_objective_record_outcome "$repo" "$issue_number" "$attempt_id" "$run_id" \
+			"$raw_result" "$outcome" "$status" "$classification" "$next_action" "$outcome_timestamp" "$attempt_started_at"
+		return $?
+		;;
+	disposition)
+		_objective_disposition "$repo" "$issue_number" "$attempt_id" "$state_file"
+		return $?
+		;;
 	derive|reconcile)
 		local input_json="" derived_json=""
 		input_json=$(_objective_read_input "$input_file") || return $?

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -572,6 +572,62 @@ EOF
 	return 0
 }
 
+_dlw_validated_context_token() {
+	local value="$1"
+	if [[ "$value" =~ ^[A-Za-z0-9._:/-]{1,128}$ ]]; then
+		printf '%s' "$value"
+	else
+		printf 'unknown'
+	fi
+	return 0
+}
+
+_dlw_prior_attempt_context() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local helper="${OBJECTIVE_RECONCILIATION_HELPER:-${BASH_SOURCE[0]%/*}/objective-reconciliation-helper.sh}"
+	local disposition=""
+	local fields=""
+	local empty_field="__AIDEVOPS_EMPTY_FIELD__"
+	local source="" prior_attempt_id="" effective_outcome="" raw_result=""
+	local status="" classification="" next_action=""
+	local context=""
+	local max_chars="${AIDEVOPS_RETRY_CONTEXT_MAX_CHARS:-1024}"
+
+	[[ -x "$helper" ]] || return 0
+	disposition=$("$helper" disposition --repo "$repo_slug" --issue "$issue_number" 2>/dev/null) || return 0
+	fields=$(printf '%s' "$disposition" | jq -r --arg empty "$empty_field" \
+		'[.source // "", .attempt_id // "", .effective_outcome // "", .raw_result // "", .status // "", .classification // "", .next_action // ""]
+		| map(if . == "" then $empty else . end) | @tsv' 2>/dev/null) || return 0
+	IFS=$'\t' read -r source prior_attempt_id effective_outcome raw_result status classification next_action <<<"$fields"
+	[[ "$source" == "$empty_field" ]] && source=""
+	[[ "$prior_attempt_id" == "$empty_field" ]] && prior_attempt_id=""
+	[[ "$effective_outcome" == "$empty_field" ]] && effective_outcome=""
+	[[ "$raw_result" == "$empty_field" ]] && raw_result=""
+	[[ "$status" == "$empty_field" ]] && status=""
+	[[ "$classification" == "$empty_field" ]] && classification=""
+	[[ "$next_action" == "$empty_field" ]] && next_action=""
+	case "$effective_outcome" in
+	failed | deferred | escalated) ;;
+	*) return 0 ;;
+	esac
+	source=$(_dlw_validated_context_token "$source")
+	prior_attempt_id=$(_dlw_validated_context_token "$prior_attempt_id")
+	effective_outcome=$(_dlw_validated_context_token "$effective_outcome")
+	raw_result=$(_dlw_validated_context_token "$raw_result")
+	status=$(_dlw_validated_context_token "$status")
+	classification=$(_dlw_validated_context_token "$classification")
+	next_action=$(_dlw_validated_context_token "$next_action")
+	printf -v context '\nValidated prior-attempt state (machine-generated; prior model prose and issue comments are excluded):\n- source: %s\n- attempt_id: %s\n- effective_outcome: %s\n- raw_result: %s\n- status: %s\n- classification: %s\n- next_action: %s\nContinue from validated repository and PR state; do not repeat completed setup.' \
+		"$source" "$prior_attempt_id" "$effective_outcome" "$raw_result" "$status" "$classification" "$next_action"
+	[[ "$max_chars" =~ ^[0-9]+$ && "$max_chars" -ge 256 && "$max_chars" -le 4096 ]] || max_chars=1024
+	if [[ "${#context}" -gt "$max_chars" ]]; then
+		context="${context:0:max_chars}"
+	fi
+	printf '%s\n' "$context"
+	return 0
+}
+
 _dlw_prepare_prompt_for_launch() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -584,6 +640,9 @@ _dlw_prepare_prompt_for_launch() {
 	local metrics_zero_count=""
 	local chars=""
 	local precomputed_zero_count=""
+	local prior_attempt_context=""
+
+	prior_attempt_context=$(_dlw_prior_attempt_context "$issue_number" "$repo_slug" || true)
 
 	comment_metrics="$precomputed_comment_metrics"
 	[[ -n "$comment_metrics" ]] || comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
@@ -600,6 +659,7 @@ _dlw_prepare_prompt_for_launch() {
 			return 0
 		fi
 		_dlw_clean_room_prompt "$issue_number" "$repo_slug" "$issue_title" "$issue_body"
+		printf '%s' "$prior_attempt_context"
 		_dlw_first_pass_completion_contract
 		return 0
 	fi
@@ -618,11 +678,13 @@ _dlw_prepare_prompt_for_launch() {
 		fi
 		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: using URL-only bootstrap prompt after ${zero_count} zero-output launches" >>"$LOGFILE"
 		_dlw_zero_output_fallback_prompt "$issue_number" "$repo_slug" "$issue_title" "$snapshot_ready"
+		printf '%s' "$prior_attempt_context"
 		_dlw_first_pass_completion_contract
 		return 0
 	fi
 
 	printf '%s' "$original_prompt"
+	printf '%s' "$prior_attempt_context"
 	_dlw_first_pass_completion_contract
 	return 0
 }
@@ -1697,14 +1759,10 @@ _dlw_nohup_launch() {
 	local repo_path="$8"
 	local dispatch_model_tier="$9"
 	local selected_model="${10}"
-	local worker_worktree_path="${11}"
-	local worker_worktree_branch="${12}"
-	local parent_worker_id=""
-	local root_worker_id=""
-	local correlation_id=""
-	local worker_id=""
-	local dispatch_event_id=""
-	local root_event_id=""
+	local worker_worktree_path="${11}" worker_worktree_branch="${12}" attempt_id="${13:-}" attempt_started_at="${14:-}"
+	[[ -n "$attempt_id" ]] || attempt_id=$(aidevops_generate_execution_id "attempt")
+	[[ "$attempt_started_at" =~ ^[0-9]+$ ]] || attempt_started_at=$(_worker_attempt_start_marker)
+	local parent_worker_id="" root_worker_id="" correlation_id="" worker_id="" dispatch_event_id="" root_event_id=""
 	_dlw_prepare_worker_lineage "$session_key"
 
 	_dlw_validate_worktree_for_launch "$issue_number" "$worker_worktree_path" || return 1
@@ -1733,6 +1791,8 @@ _dlw_nohup_launch() {
 		AIDEVOPS_PARENT_WORKER_ID="$parent_worker_id"
 		AIDEVOPS_ROOT_WORKER_ID="$root_worker_id"
 		AIDEVOPS_CORRELATION_ID="$correlation_id"
+		AIDEVOPS_ATTEMPT_ID="$attempt_id"
+		AIDEVOPS_ATTEMPT_STARTED_AT="$attempt_started_at"
 		AIDEVOPS_ROOT_EVENT_ID="$root_event_id"
 		AIDEVOPS_PARENT_EVENT_ID="$dispatch_event_id"
 		AIDEVOPS_CAUSATION_ID="$dispatch_event_id"
@@ -1828,6 +1888,7 @@ _dlw_post_launch_hooks() {
 	local dispatch_tier="$6"
 	local selected_model="$7"
 	local worker_worktree_path="${8:-}"
+	local attempt_id="${9:-}"
 
 	# Record in dispatch ledger (with tier telemetry)
 	local ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
@@ -1836,6 +1897,7 @@ _dlw_post_launch_hooks() {
 			--issue "$issue_number" --repo "$repo_slug" \
 			--pid "$worker_pid" --tier "$dispatch_tier" \
 			--model "$selected_model" --lease-token "${_claim_lease_token:-}" \
+			--attempt-id "$attempt_id" \
 			--device-id "${_claim_lease_device:-}" --worktree "$worker_worktree_path" 2>/dev/null || true
 	fi
 
@@ -2330,21 +2392,21 @@ _dispatch_launch_worker() {
 		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worktree_precreation_failed" 2 || return $?
 	fi
 	_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
-	local worker_worktree_path="$_DLW_WORKTREE_PATH"
-	local worker_worktree_branch="$_DLW_WORKTREE_BRANCH"
-	local worker_worktree_reused="${_DLW_WORKTREE_REUSED:-0}"
+	local worker_worktree_path="$_DLW_WORKTREE_PATH" worker_worktree_branch="$_DLW_WORKTREE_BRANCH" worker_worktree_reused="${_DLW_WORKTREE_REUSED:-0}"
 	if _dlw_check_worker_branch_orphan_loop "$issue_number" "$repo_slug" "$worker_worktree_branch" "$worker_worktree_reused" "${repo_path}/TODO.md" "$worker_worktree_path"; then
 		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worker_branch_orphan_hold" 2 || return $?
 	fi
 
 	_ds_t0=$(_ds_now_ns)
-	local worker_pid
+	local worker_pid attempt_id="" attempt_started_at=""
+	attempt_id=$(aidevops_generate_execution_id "attempt")
+	attempt_started_at=$(_worker_attempt_start_marker)
 	local launch_prompt=""
 	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt" "$zero_output_comment_metrics")
 	if ! worker_pid=$(_dlw_nohup_launch "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
 		"$session_key" "$worker_log" "$launch_prompt" "$repo_path" \
 		"$dispatch_model_tier" "$selected_model" \
-		"$worker_worktree_path" "$worker_worktree_branch"); then
+		"$worker_worktree_path" "$worker_worktree_branch" "$attempt_id" "$attempt_started_at"); then
 		_ds_record "$issue_number" "$repo_slug" "worker_spawn" "$_ds_t0"
 		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "worker_launch_failed" 2 || return $?
 		return 1
@@ -2353,7 +2415,7 @@ _dispatch_launch_worker() {
 
 	_ds_t0=$(_ds_now_ns)
 	_dlw_post_launch_hooks "$issue_number" "$repo_slug" "$self_login" \
-		"$worker_pid" "$session_key" "$dispatch_tier" "$selected_model" "$worker_worktree_path"
+		"$worker_pid" "$session_key" "$dispatch_tier" "$selected_model" "$worker_worktree_path" "$attempt_id"
 	_ds_record "$issue_number" "$repo_slug" "post_launch_hooks" "$_ds_t0"
 
 	echo "[dispatch_with_dedup] Dispatched worker PID ${worker_pid} for #${issue_number} in ${repo_slug}" >>"$LOGFILE"

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -551,12 +551,23 @@ _ff_release_retry_reset_if_newer_locked() {
 #                no_worker_process, cli_usage_output, local_error, etc.)
 #   $4 - provider (optional, for rate-limit pool queries; default: anthropic)
 #   $5 - crash_type (optional: "overwhelmed" | "no_work" | "partial" | "")
+#   $6 - attempt_id (optional exact objective correlation; resolved from ledger when omitted)
 #######################################
 fast_fail_record() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local reason="${3:-launch_failure}"
+	local attempt_id="${6:-}"
 	local record_rc=0
+
+	if declare -F _worker_attempt_id_for_issue >/dev/null 2>&1; then
+		attempt_id=$(_worker_attempt_id_for_issue "$issue_number" "$repo_slug" "$attempt_id") || attempt_id=""
+	fi
+	if [[ -n "$attempt_id" ]] && declare -F _objective_disposition_suppresses >/dev/null 2>&1 && \
+		_objective_disposition_suppresses suppress_fast_fail "$issue_number" "$repo_slug" "$attempt_id"; then
+		echo "[pulse-wrapper] fast_fail_record: #${issue_number} (${repo_slug}) suppressed by reconciled objective outcome" >>"$LOGFILE"
+		return 0
+	fi
 
 	_ff_with_lock _fast_fail_record_locked "$@" || record_rc=$?
 	if [[ "$record_rc" -eq 2 ]]; then

--- a/.agents/scripts/pulse-quality-debt.sh
+++ b/.agents/scripts/pulse-quality-debt.sh
@@ -21,6 +21,9 @@
 
 [[ -n "${_PULSE_QUALITY_DEBT_LOADED:-}" ]] && return 0
 _PULSE_QUALITY_DEBT_LOADED=1
+_PQD_PRIOR_SOURCE_NONE="none"
+_PQD_PRIOR_OUTCOME_UNKNOWN="unknown"
+_PQD_DEFAULT_PRIOR_ATTEMPT='{"source":"none","effective_outcome":"unknown"}'
 
 #######################################
 # Create a pre-isolated worktree for a quality-debt worker
@@ -45,7 +48,7 @@ create_quality_debt_worktree() {
 	local issue_number="$2"
 	local issue_title="$3"
 
-	local qd_branch_slug qd_branch qd_wt_path
+	local qd_branch_slug="" qd_branch="" qd_wt_path=""
 	qd_branch_slug=$(printf '%s' "$issue_title" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-30)
 	qd_branch="bugfix/qd-${issue_number}-${qd_branch_slug}"
 
@@ -55,7 +58,7 @@ create_quality_debt_worktree() {
 		grep "^worktree " | cut -d' ' -f2- 2>/dev/null || true)
 
 	if [[ -z "$qd_wt_path" ]]; then
-		local repo_name parent_dir qd_wt_slug
+		local repo_name="" parent_dir="" qd_wt_slug=""
 		repo_name=$(basename "$repo_path")
 		parent_dir=$(dirname "$repo_path")
 		qd_wt_slug=$(printf '%s' "$qd_branch" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
@@ -100,7 +103,7 @@ close_stale_quality_debt_prs() {
 
 	local i
 	for i in $(seq 0 $((pr_count - 1))); do
-		local pr_num pr_updated_at pr_epoch
+		local pr_num="" pr_updated_at="" pr_epoch=""
 		pr_num=$(printf '%s' "$pr_json" | jq -r ".[$i].number" 2>/dev/null) || continue
 		pr_updated_at=$(printf '%s' "$pr_json" | jq -r ".[$i].updatedAt" 2>/dev/null) || continue
 		# GH#17699: TZ=UTC required — macOS date interprets input as local time
@@ -176,13 +179,49 @@ _enrichment_resolve_repo_path() {
 }
 
 #######################################
-# Fetch issue body, title, and relevant failure-context comments
+# Check whether reconciled objective state makes enrichment unnecessary.
+# Returns 0 when enrichment should be skipped, 1 when it remains actionable.
+_enrichment_should_skip_for_objective() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	if declare -F _objective_disposition_suppresses >/dev/null 2>&1 && \
+		_objective_disposition_suppresses suppress_enrichment "$issue_number" "$repo_slug"; then
+		return 0
+	fi
+	return 1
+}
+
+_enrichment_parse_fast_fail_key() {
+	local ff_key="$1"
+	local issue_number=""
+	local repo_slug=""
+
+	case "$ff_key" in
+	*:* )
+		# Legacy format retained for existing state files.
+		issue_number="${ff_key%%:*}"
+		repo_slug="${ff_key#*:}"
+		;;
+	*/* )
+		# Canonical _ff_key format: owner/repo/issue_number.
+		issue_number="${ff_key##*/}"
+		repo_slug="${ff_key%/*}"
+		;;
+	*) return 1 ;;
+	esac
+	[[ "$issue_number" =~ ^[1-9][0-9]*$ && "$repo_slug" == */* ]] || return 1
+	printf '%s\t%s' "$issue_number" "$repo_slug"
+	return 0
+}
+
+#######################################
+# Fetch issue body, title, and validated prior-attempt state.
 #
 # Arguments:
 #   $1 - issue number
 #   $2 - repo slug (owner/repo)
 #
-# Outputs: JSON object {title, body, comments} (stdout)
+# Outputs: JSON object {title, body, prior_attempt} (stdout)
 # Exit codes:
 #   0 - data fetched (partial data is acceptable; fields may be empty strings)
 #######################################
@@ -190,22 +229,32 @@ _enrichment_fetch_issue_data() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
-	local issue_json issue_body issue_title issue_comments
+	local issue_json="" issue_body="" issue_title="" prior_attempt=""
 	issue_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
 		--json title,body 2>/dev/null) || issue_json="{}"
 	issue_title=$(printf '%s' "$issue_json" | jq -r '.title // ""')
 	issue_body=$(printf '%s' "$issue_json" | jq -r '.body // ""')
 
-	# Get kill/dispatch comments for failure context
-	issue_comments=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--jq '[.[] | select(.body | test("CLAIM|kill|premature|BLOCKED|worker_failed|Dispatching")) | {author: .user.login, body: .body, created: .created_at}] | last(3) // []' \
-		2>/dev/null) || issue_comments="[]"
+	prior_attempt="$_PQD_DEFAULT_PRIOR_ATTEMPT"
+	if declare -F _objective_disposition_json >/dev/null 2>&1; then
+		prior_attempt=$(_objective_disposition_json "$issue_number" "$repo_slug" 2>/dev/null) || prior_attempt="$_PQD_DEFAULT_PRIOR_ATTEMPT"
+	fi
 
 	jq -n \
 		--arg title "$issue_title" \
 		--arg body "$issue_body" \
-		--argjson comments "$issue_comments" \
-		'{title: $title, body: $body, comments: $comments}'
+		--arg source_none "$_PQD_PRIOR_SOURCE_NONE" \
+		--arg outcome_unknown "$_PQD_PRIOR_OUTCOME_UNKNOWN" \
+		--argjson prior_attempt "$prior_attempt" \
+		'{title: $title, body: $body, prior_attempt: {
+			source: ($prior_attempt.source // $source_none),
+			attempt_id: ($prior_attempt.attempt_id // ""),
+			effective_outcome: ($prior_attempt.effective_outcome // $outcome_unknown),
+			raw_result: ($prior_attempt.raw_result // ""),
+			status: ($prior_attempt.status // ""),
+			classification: ($prior_attempt.classification // ""),
+			next_action: ($prior_attempt.next_action // "")
+		}}'
 	return 0
 }
 
@@ -216,7 +265,7 @@ _enrichment_fetch_issue_data() {
 #   $1 - issue number
 #   $2 - issue title
 #   $3 - issue body
-#   $4 - issue comments (JSON array string)
+#   $4 - validated prior-attempt state (JSON object string)
 #   $5 - repo slug (owner/repo)
 #
 # Outputs: path to the temporary prompt file (stdout)
@@ -228,7 +277,7 @@ _enrichment_build_prompt() {
 	local issue_number="$1"
 	local issue_title="$2"
 	local issue_body="$3"
-	local issue_comments="$4"
+	local prior_attempt="$4"
 	local repo_slug="$5"
 
 	local prompt_file
@@ -244,8 +293,8 @@ ${issue_title}
 ## Current Issue Body
 ${issue_body}
 
-## Recent Comments (failure context)
-${issue_comments}
+## Validated Prior-Attempt State
+${prior_attempt}
 
 ## Instructions
 
@@ -271,8 +320,9 @@ ${issue_comments}
 
 **Verification:** command to verify completion
 
-5. Keep analysis focused — spend at most 5 minutes. If the task is genuinely ambiguous, say so in the guidance rather than guessing.
-6. Do NOT implement the solution. Only analyze and document guidance.
+5. Do not read or reuse prior model prose, issue comments, dispatch comments, or watchdog comments as retry context. The validated state above is the only prior-attempt context.
+6. Keep analysis focused — spend at most 5 minutes. If the task is genuinely ambiguous, say so in the guidance rather than guessing.
+7. Do NOT implement the solution. Only analyze and document guidance.
 ENRICHMENT_PROMPT_EOF
 
 	printf '%s\n' "$prompt_file"
@@ -368,13 +418,6 @@ dispatch_enrichment_workers() {
 		return 0
 	}
 
-	# Resolve thinking-tier model (opus preferred, sonnet fallback)
-	local resolved_model
-	resolved_model=$(_enrichment_resolve_model) || {
-		printf '%d\n' "$available"
-		return 0
-	}
-
 	# Extract keys with enrichment_needed=true
 	local enrichment_keys
 	enrichment_keys=$(printf '%s' "$state" | jq -r 'to_entries[] | select(.value.enrichment_needed == true) | .key' 2>/dev/null) || enrichment_keys=""
@@ -386,6 +429,7 @@ dispatch_enrichment_workers() {
 
 	local repos_json="${REPOS_JSON:-$HOME/.config/aidevops/repos.json}"
 	local enriched_total=0
+	local resolved_model=""
 
 	while IFS= read -r ff_key; do
 		[[ -n "$ff_key" ]] || continue
@@ -393,12 +437,18 @@ dispatch_enrichment_workers() {
 		[[ "$available" -gt 0 ]] || break
 		[[ -f "$STOP_FLAG" ]] && break
 
-		# Parse key format: "issue_number:repo_slug"
-		local issue_number repo_slug
-		issue_number="${ff_key%%:*}"
-		repo_slug="${ff_key#*:}"
-		[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
-		[[ -n "$repo_slug" ]] || continue
+		# Parse canonical owner/repo/issue keys plus the legacy issue:owner/repo form.
+		local parsed_key="" issue_number="" repo_slug=""
+		parsed_key=$(_enrichment_parse_fast_fail_key "$ff_key") || continue
+		IFS=$'\t' read -r issue_number repo_slug <<<"$parsed_key"
+		if _enrichment_should_skip_for_objective "$issue_number" "$repo_slug"; then
+			echo "[pulse-wrapper] Enrichment: skipping #${issue_number} in ${repo_slug}; reconciled outcome is non-failure" >>"$LOGFILE"
+			_ff_with_lock _ff_mark_enrichment_done "$issue_number" "$repo_slug" || true
+			continue
+		fi
+		if [[ -z "$resolved_model" ]]; then
+			resolved_model=$(_enrichment_resolve_model) || break
+		fi
 
 		# Resolve repo path
 		local repo_path
@@ -406,17 +456,19 @@ dispatch_enrichment_workers() {
 
 		echo "[pulse-wrapper] Enrichment: analyzing #${issue_number} in ${repo_slug} after worker failure" >>"$LOGFILE"
 
-		# Fetch issue data (body, title, failure-context comments) as JSON
-		local issue_data issue_title issue_body issue_comments
+		# Fetch issue data and bounded machine-generated prior-attempt state.
+		local issue_data="" issue_title="" issue_body="" prior_attempt=""
 		issue_data=$(_enrichment_fetch_issue_data "$issue_number" "$repo_slug")
 		issue_title=$(printf '%s' "$issue_data" | jq -r '.title // ""')
 		issue_body=$(printf '%s' "$issue_data" | jq -r '.body // ""')
-		issue_comments=$(printf '%s' "$issue_data" | jq -r '.comments // []')
+		prior_attempt=$(printf '%s' "$issue_data" | jq -c \
+			--arg source_none "$_PQD_PRIOR_SOURCE_NONE" --arg outcome_unknown "$_PQD_PRIOR_OUTCOME_UNKNOWN" \
+			'.prior_attempt // {source:$source_none,effective_outcome:$outcome_unknown}')
 
 		# Build enrichment prompt file
 		local prompt_file
 		prompt_file=$(_enrichment_build_prompt \
-			"$issue_number" "$issue_title" "$issue_body" "$issue_comments" "$repo_slug") || continue
+			"$issue_number" "$issue_title" "$issue_body" "$prior_attempt" "$repo_slug") || continue
 
 		# Run enrichment worker; prompt_file is deleted inside helper
 		if _enrichment_run_worker \

--- a/.agents/scripts/runtime-events-cli.mjs
+++ b/.agents/scripts/runtime-events-cli.mjs
@@ -30,7 +30,9 @@ function emitPayload(args) {
   const payloadText = optionValue(args, "--payload");
   const payload = payloadText ? JSON.parse(payloadText) : {};
   const additions = {
+    attempt_id: process.env.AIDEVOPS_ATTEMPT_ID || "",
     classification: optionValue(args, "--classification"),
+    run_id: process.env.AIDEVOPS_RUN_ID || "",
     source: optionValue(args, "--source"),
     status: optionValue(args, "--status"),
   };

--- a/.agents/scripts/runtime-events-payload.mjs
+++ b/.agents/scripts/runtime-events-payload.mjs
@@ -23,9 +23,9 @@ const FILE_URL_PATTERN = /\bfile:\/\/\/[^\s"',)}\]]+/gi;
 const ABSOLUTE_PATH_PATTERN = /(^|[\s("'=])(?:\/[^\s"',)}\]]+|[A-Za-z]:[\\/][^\s"',)}\]]+)/gm;
 const REPOSITORY_LIKE_PATTERN = /\b[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\b/g;
 const ORDINARY_PAYLOAD_KEYS = new Set([
-  "call_id", "classification", "duration_ms", "error_type", "exit_code",
+  "attempt_id", "call_id", "classification", "duration_ms", "error_type", "exit_code",
   "finish_reason", "model_id", "observation", "provider_id", "reason", "result",
-  "role", "source", "status", "success", "tool_name",
+  "role", "run_id", "source", "status", "success", "tool_name",
 ]);
 const NOT_SCALAR = Symbol("not-scalar");
 

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -101,6 +101,24 @@ if [[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]]; then
 	unset AIDEVOPS_BASH_REEXECED
 fi
 
+# Generate a non-authority execution identifier for telemetry correlation.
+# Lease/claim tokens are fencing credentials and must never double as public IDs.
+aidevops_generate_execution_id() {
+	local prefix="$1"
+	local identifier=""
+	[[ -n "$prefix" ]] || prefix="execution"
+	if command -v uuidgen >/dev/null 2>&1; then
+		identifier=$(uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]') || identifier=""
+	elif command -v python3 >/dev/null 2>&1; then
+		identifier=$(python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null) || identifier=""
+	fi
+	if [[ -z "$identifier" ]]; then
+		identifier="$(date +%s 2>/dev/null || printf '0')-$$-${RANDOM:-0}"
+	fi
+	printf '%s:%s' "$prefix" "$identifier"
+	return 0
+}
+
 # Ensure standalone pulse-adjacent runners have the elapsed-time baseline that
 # pulse-wrapper.sh normally exports. Helpers that create GitHub comments/issues
 # use PULSE_START_EPOCH for signature footers; launchd/cron runners that source

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -103,6 +103,45 @@ test_register_creates_entry() {
 	return 0
 }
 
+test_register_separates_attempt_identity_from_lease() {
+	setup_test_env
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
+		--repo "owner/repo" --pid $$ --lease-token "private-lease-token" \
+		--attempt-id "attempt-public-id"
+
+	local result=0 attempt_id="" lease_token=""
+	attempt_id=$(jq -r '.attempt_id' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl")
+	lease_token=$(jq -r '.lease_token' "${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl")
+	[[ "$attempt_id" == "attempt-public-id" ]] || result=1
+	[[ "$lease_token" == "private-lease-token" && "$attempt_id" != "$lease_token" ]] || result=1
+	print_result "register keeps public attempt identity separate from the dispatch lease" "$result" \
+		"attempt=${attempt_id}, lease=${lease_token}"
+	teardown_test_env
+	return 0
+}
+
+test_terminal_updates_target_exact_attempt() {
+	setup_test_env
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
+		--repo "owner/repo" --pid $$ --attempt-id "attempt-a"
+	run_helper "$LEDGER_HELPER" fail --session-key "issue-42" --attempt-id "attempt-a"
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
+		--repo "owner/repo" --pid $$ --attempt-id "attempt-b"
+	# A late completion from attempt A must not close active attempt B.
+	run_helper "$LEDGER_HELPER" complete --session-key "issue-42" --attempt-id "attempt-a"
+
+	local result=0 first_status="" second_status=""
+	first_status=$(jq -rs 'map(select(.attempt_id == "attempt-a")) | last | .status' \
+		"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl")
+	second_status=$(jq -rs 'map(select(.attempt_id == "attempt-b")) | last | .status' \
+		"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl")
+	[[ "$first_status" == "failed" && "$second_status" == "in-flight" ]] || result=1
+	print_result "terminal updates target one dispatch attempt instead of every session generation" "$result" \
+		"attempt-a=${first_status}, attempt-b=${second_status}"
+	teardown_test_env
+	return 0
+}
+
 test_record_recovery_is_idempotent() {
 	setup_test_env
 	run_helper "$LEDGER_HELPER" register --session-key "issue-27138" --issue 27138 --repo "owner/repo" --pid $$ --worktree "/private/worker/path"
@@ -142,21 +181,24 @@ test_record_recovery_rejects_missing_option_values() {
 test_tier_telemetry_correlates_terminal_outcomes() {
 	setup_test_env
 	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
-		--repo "owner/repo" --pid $$ --tier simple --model model-a --lease-token attempt-42
+		--repo "owner/repo" --pid $$ --tier simple --model model-a \
+		--attempt-id attempt-42 --lease-token private-lease-42
 	run_helper "$LEDGER_HELPER" register --session-key "issue-43" --issue 43 \
-		--repo "owner/repo" --pid $$ --tier standard --model model-b --lease-token attempt-43
+		--repo "owner/repo" --pid $$ --tier standard --model model-b \
+		--attempt-id attempt-43 --lease-token private-lease-43
 	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
-		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome success
+		--lease-token private-lease-42 --issue 42 --repo "owner/repo" --outcome success
 	# Aggregate the streamed records so a later unrelated row cannot hide an
 	# existing terminal outcome for this attempt.
 	run_helper "$LEDGER_HELPER" register --session-key "issue-44" --issue 44 \
-		--repo "owner/repo" --pid $$ --tier standard --model model-c --lease-token attempt-44
+		--repo "owner/repo" --pid $$ --tier standard --model model-c \
+		--attempt-id attempt-44 --lease-token private-lease-44
 	# Repeated cleanup and a conflicting late event must not create or replace the
 	# first terminal result for this attempt.
 	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
-		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome success
+		--lease-token private-lease-42 --issue 42 --repo "owner/repo" --outcome success
 	run_helper "$LEDGER_HELPER" record-outcome --session-key "issue-42" \
-		--lease-token attempt-42 --issue 42 --repo "owner/repo" --outcome failed
+		--lease-token private-lease-42 --issue 42 --repo "owner/repo" --outcome failed
 	# Raw duplicate and unmatched rows model pre-v2 data or manual corruption.
 	# The report must normalize the known attempt and keep unmatched data separate.
 	printf '%s\n' '{"schema":2,"attempt_id":"attempt-42","issue":"42","repo":"owner/repo","tier":"simple","outcome":"success","completed_at":"2026-01-01T00:00:00Z"}' >>"${AIDEVOPS_DISPATCH_LEDGER_DIR}/tier-telemetry.jsonl"
@@ -884,6 +926,8 @@ main() {
 	fi
 
 	test_register_creates_entry
+	test_register_separates_attempt_identity_from_lease
+	test_terminal_updates_target_exact_attempt
 	test_record_recovery_is_idempotent
 	test_record_recovery_rejects_missing_option_values
 	test_tier_telemetry_correlates_terminal_outcomes

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -91,7 +91,8 @@ test_appends_escalation_contract() {
 		[[ "$output" == *'Load only referenced workflow/reference docs'* ]] &&
 		[[ "$output" == *'Stop reading once target files, reference pattern, constraints, and verification are clear.'* ]] &&
 		[[ "$output" == *'Never ask for user confirmation, approval, or next steps. No user will respond.'* ]] &&
-		[[ "$output" == *'Valid exit states are FULL_LOOP_COMPLETE, a verified post-PR handoff'* ]]; then
+		[[ "$output" == *'emit POST_PR_HANDOFF on its own line'* ]] &&
+		[[ "$output" == *'Valid exit states are FULL_LOOP_COMPLETE, POST_PR_HANDOFF'* ]]; then
 		print_result "appends escalation-before-blocked contract to full-loop prompts" 0
 		return 0
 	fi
@@ -872,6 +873,37 @@ test_blocked_completion_records_blocked_label() {
 		"rc=$rc label=${_run_result_label:-<unset>} reason=${_run_failure_reason:-<unset>} source=${_run_classification_source:-<unset>}"
 	return 0
 }
+
+test_post_pr_handoff_completion_signal_is_exact() {
+	local exact_file="${TEST_ROOT}/post-pr-handoff-exact.jsonl"
+	local prose_file="${TEST_ROOT}/post-pr-handoff-prose.jsonl"
+	printf '%s\n' '{"type":"text","text":"POST_PR_HANDOFF"}' >"$exact_file"
+	printf '%s\n' '{"type":"text","text":"I will mention POST_PR_HANDOFF after more work."}' >"$prose_file"
+
+	local result=0
+	output_has_post_pr_handoff_signal "$exact_file" || result=1
+	output_has_completion_signal "$exact_file" || result=1
+	if output_has_post_pr_handoff_signal "$prose_file" || output_has_completion_signal "$prose_file"; then
+		result=1
+	fi
+	print_result "POST_PR_HANDOFF is accepted only as an exact model-text line" "$result"
+	return 0
+}
+
+test_post_pr_handoff_records_distinct_result_label() {
+	local output_file="${TEST_ROOT}/post-pr-handoff-result.jsonl"
+	printf '%s\n' '{"type":"text","sessionID":"ses_handoff","text":"POST_PR_HANDOFF"}' >"$output_file"
+	local rc=0
+	_handle_run_result 0 "$output_file" "worker" "openai" "issue-456" "openai/gpt-5.5" || rc=$?
+	if [[ "$rc" -eq 0 && "${_run_result_label:-}" == "post_pr_handoff" ]]; then
+		print_result "POST_PR_HANDOFF remains distinct from raw process success" 0
+		return 0
+	fi
+	print_result "POST_PR_HANDOFF remains distinct from raw process success" 1 \
+		"rc=${rc} label=${_run_result_label:-<unset>}"
+	return 0
+}
+
 test_missing_context_blocked_requests_brief_recovery() {
 	local output_file="${TEST_ROOT}/missing-context-blocked-output.jsonl"
 	printf '%s\n' '{"type":"text","sessionID":"ses_blocked","text":"BLOCKED: missing implementation context"}' >"$output_file"
@@ -2401,6 +2433,176 @@ test_cmd_run_finish_emits_complete_for_real_output() {
 	return 0
 }
 
+test_cmd_run_finish_appends_reconciled_attempt_outcome() {
+	local work_dir="${TEST_ROOT}/repo-finish-reconciled"
+	local capture_file="${TEST_ROOT}/reconciled-outcome.capture"
+	_setup_test_git_repo "$work_dir" 1
+
+	(
+		_run_result_label="premature_exit"
+		_run_failure_reason="model_stopped_before_completion"
+		_release_dispatch_claim() { return 0; }
+		_report_failure_to_fast_fail() { return 0; }
+		_update_dispatch_ledger() { return 0; }
+		_release_session_lock() { return 0; }
+		_hrw_record_terminal_outcome() { return 0; }
+		_emit_worker_runtime_event() { return 0; }
+		_hrw_record_reconciled_outcome() {
+			local session_key="$1"
+			local raw_result="$2"
+			local outcome="$3"
+			local status="$4"
+			local classification="$5"
+			printf '%s|%s|%s|%s|%s\n' "$session_key" "$raw_result" "$outcome" "$status" "$classification" >"$capture_file"
+			return 0
+		}
+		_cmd_run_finish "issue-99999" "complete" "$work_dir"
+	)
+
+	local captured=""
+	[[ -s "$capture_file" ]] && captured=$(<"$capture_file")
+	if [[ "$captured" == "issue-99999|premature_exit|success|premature_exit|model_stopped_before_completion" ]]; then
+		print_result "_cmd_run_finish appends the reconciled attempt outcome after final classification" 0
+	else
+		print_result "_cmd_run_finish appends the reconciled attempt outcome after final classification" 1 \
+			"captured=${captured:-<empty>}"
+	fi
+	return 0
+}
+
+test_cmd_run_finish_rejects_unverified_post_pr_handoff() {
+	local work_dir="${TEST_ROOT}/repo-finish-unverified-handoff"
+	local capture_file="${TEST_ROOT}/unverified-handoff.capture"
+	local release_file="${TEST_ROOT}/unverified-handoff.release"
+	local ledger_file="${TEST_ROOT}/unverified-handoff.ledger"
+	local result_file="${TEST_ROOT}/unverified-handoff.result"
+	_setup_test_git_repo "$work_dir" 1
+
+	(
+		_run_result_label="post_pr_handoff"
+		_run_failure_reason=""
+		_release_dispatch_claim() { printf '%s' "$2" >"$release_file"; return 0; }
+		_report_failure_to_fast_fail() { return 0; }
+		_update_dispatch_ledger() { printf '%s' "$2" >"$ledger_file"; return 0; }
+		_release_session_lock() { return 0; }
+		_hrw_record_terminal_outcome() { return 0; }
+		_emit_worker_runtime_event() { return 0; }
+		_worker_post_pr_handoff_confirmed() { return 1; }
+		_hrw_record_reconciled_outcome() {
+			local session_key="$1"
+			local raw_result="$2"
+			local outcome="$3"
+			local status="$4"
+			local classification="$5"
+			printf '%s|%s|%s|%s|%s\n' "$session_key" "$raw_result" "$outcome" "$status" "$classification" >"$capture_file"
+			return 0
+		}
+		set +e
+		_cmd_run_finish "issue-99999" "complete" "$work_dir"
+		printf '%s' "$?" >"$result_file"
+		set -e
+	)
+
+	local captured="" release_reason="" ledger_status="" finish_result=""
+	[[ -s "$capture_file" ]] && captured=$(<"$capture_file")
+	[[ -s "$release_file" ]] && release_reason=$(<"$release_file")
+	[[ -s "$ledger_file" ]] && ledger_status=$(<"$ledger_file")
+	[[ -s "$result_file" ]] && finish_result=$(<"$result_file")
+	if [[ "$captured" == "issue-99999|post_pr_handoff|failed|failed|worker_post_pr_handoff_unverified" ]] &&
+		[[ "$release_reason" == "worker_post_pr_handoff_unverified" && "$ledger_status" == "fail" && "$finish_result" == "1" ]]; then
+		print_result "unverified POST_PR_HANDOFF cannot suppress failure routing" 0
+	else
+		print_result "unverified POST_PR_HANDOFF cannot suppress failure routing" 1 \
+			"captured=${captured:-<empty>} release=${release_reason:-<empty>} ledger=${ledger_status:-<empty>} result=${finish_result:-<empty>}"
+	fi
+	return 0
+}
+
+test_begin_worker_runtime_run_refreshes_run_id() {
+	local first_run_id="" second_run_id=""
+	AIDEVOPS_RUN_ID="run:stale"
+	_begin_worker_runtime_run
+	first_run_id="$AIDEVOPS_RUN_ID"
+	_begin_worker_runtime_run
+	second_run_id="$AIDEVOPS_RUN_ID"
+
+	if [[ "$first_run_id" == run:* && "$second_run_id" == run:* ]] &&
+		[[ "$first_run_id" != "run:stale" && "$second_run_id" != "$first_run_id" ]]; then
+		print_result "each runtime process invocation receives a fresh run ID" 0
+	else
+		print_result "each runtime process invocation receives a fresh run ID" 1 \
+			"first=${first_run_id:-<empty>} second=${second_run_id:-<empty>}"
+	fi
+	return 0
+}
+
+test_internal_opencode_retries_refresh_run_id() {
+	local refresh_count=""
+	refresh_count=$(python3 - "$HELPER_SCRIPT" <<'PY'
+import pathlib
+import re
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text()
+start = source.index("_execute_run_attempt() {")
+end = source.index("\n#######################################\n# _discover_actual_worktree_dir", start)
+body = source[start:end]
+print(len(re.findall(r"_begin_worker_runtime_run\s*\n\s*_invoke_opencode", body)))
+PY
+	)
+
+	if [[ "$refresh_count" == "2" ]]; then
+		print_result "internal OpenCode retries refresh run identity before invocation" 0
+	else
+		print_result "internal OpenCode retries refresh run identity before invocation" 1 \
+			"Expected two guarded internal retries, got ${refresh_count:-<empty>}"
+	fi
+	return 0
+}
+
+test_reconciled_outcome_persistence_retries() {
+	local fake_helper="${TEST_ROOT}/fake-objective-helper.sh"
+	local count_file="${TEST_ROOT}/fake-objective-helper.count"
+	local args_file="${TEST_ROOT}/fake-objective-helper.args"
+	cat >"$fake_helper" <<'SH'
+#!/usr/bin/env bash
+set -u
+count=0
+[[ -f "$AIDEVOPS_FAKE_OBJECTIVE_COUNT_FILE" ]] && read -r count <"$AIDEVOPS_FAKE_OBJECTIVE_COUNT_FILE"
+count=$((count + 1))
+printf '%s\n' "$count" >"$AIDEVOPS_FAKE_OBJECTIVE_COUNT_FILE"
+printf '%s\n' "$*" >"$AIDEVOPS_FAKE_OBJECTIVE_ARGS_FILE"
+[[ "$count" -ge 3 ]]
+SH
+	chmod +x "$fake_helper"
+
+	(
+		export OBJECTIVE_RECONCILIATION_HELPER="$fake_helper"
+		export AIDEVOPS_FAKE_OBJECTIVE_COUNT_FILE="$count_file"
+		export AIDEVOPS_FAKE_OBJECTIVE_ARGS_FILE="$args_file"
+		export AIDEVOPS_OBJECTIVE_OUTCOME_WRITE_ATTEMPTS=3
+		export AIDEVOPS_ATTEMPT_ID="attempt:retry-test"
+		export AIDEVOPS_ATTEMPT_STARTED_AT=700
+		export AIDEVOPS_RUN_ID="run:retry-test"
+		export WORKER_ISSUE_NUMBER=99999
+		export DISPATCH_REPO_SLUG="owner/repo"
+		_hrw_record_reconciled_outcome "issue-99999" "premature_exit" \
+			"success" "recovered" "worker_complete"
+	)
+
+	local call_count="" captured_args=""
+	[[ -f "$count_file" ]] && read -r call_count <"$count_file"
+	[[ -f "$args_file" ]] && read -r captured_args <"$args_file"
+	if [[ "$call_count" == "3" && "$captured_args" == *"--attempt-id attempt:retry-test"* ]] &&
+		[[ "$captured_args" == *"--run-id run:retry-test"* ]]; then
+		print_result "reconciled outcome persistence retries bounded transient failures" 0
+	else
+		print_result "reconciled outcome persistence retries bounded transient failures" 1 \
+			"calls=${call_count:-<empty>} args=${captured_args:-<empty>}"
+	fi
+	return 0
+}
+
 test_cmd_run_finish_emits_complete_when_no_workdir() {
 	# When work_dir is absent (fail paths), behaviour is unchanged: worker_complete
 	local released_reason="" fast_fail_called=0
@@ -3319,6 +3521,8 @@ main() {
 	test_provider_sessions_scope_issue_keys_by_repo_slug
 	test_provider_sessions_keep_pulse_unscoped
 	test_blocked_completion_records_blocked_label
+	test_post_pr_handoff_completion_signal_is_exact
+	test_post_pr_handoff_records_distinct_result_label
 	test_missing_context_blocked_requests_brief_recovery
 	test_headless_activity_timeout_default_matches_watchdog
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
@@ -3354,6 +3558,11 @@ main() {
 	test_release_dispatch_claim_ignores_non_issue_session_key_digits
 	test_cmd_run_finish_emits_noop_for_zero_output
 	test_cmd_run_finish_emits_complete_for_real_output
+	test_cmd_run_finish_appends_reconciled_attempt_outcome
+	test_cmd_run_finish_rejects_unverified_post_pr_handoff
+	test_begin_worker_runtime_run_refreshes_run_id
+	test_internal_opencode_retries_refresh_run_id
+	test_reconciled_outcome_persistence_retries
 	test_cmd_run_finish_emits_complete_when_no_workdir
 	test_attempt_orphan_recovery_pr_calls_gh_create
 	test_ensure_orphan_recovery_rejects_empty_branch

--- a/.agents/scripts/tests/test-objective-reconciliation.sh
+++ b/.agents/scripts/tests/test-objective-reconciliation.sh
@@ -99,4 +99,94 @@ AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$evidence_file" AIDEVOPS_OBJECTIVE_EVIDENCE_LI
 	"$HELPER" derive --repo owner/repo --input "$fixture" --now 10000 --ttl 3600 >"$derived"
 jq -e '.[] | select(.number == 1 and .execution_path_state == "idle" and .preservation.commits == false)' "$derived" >/dev/null || fail "durable evidence read must honour the bounded tail"
 
+outcome_file="$TMP_DIR/outcomes.jsonl"
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$outcome_file" \
+	"$HELPER" record-outcome --repo owner/repo --issue 41 \
+	--attempt-id attempt-a --run-id run-a --raw-result premature_exit \
+	--outcome success --status recovered --classification worker_complete \
+	--next-action monitor_pr --timestamp 10100
+printf '%s\n' '{"issue_number":"bad"}' >>"$outcome_file"
+# First terminal outcome wins for an attempt, even if delayed raw cleanup tries
+# to append a conflicting failure later.
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$outcome_file" \
+	"$HELPER" record-outcome --repo owner/repo --issue 41 \
+	--attempt-id attempt-a --run-id run-late --raw-result watchdog_stall_killed \
+	--outcome failed --status failed --classification stale_cleanup \
+	--next-action narrow_redispatch --timestamp 10200
+jq -se '[.[] | select(.record_type == "attempt_outcome" and .attempt_id == "attempt-a")] | length == 1' \
+	"$outcome_file" >/dev/null || fail "one reconciled terminal outcome per attempt"
+
+disposition="$TMP_DIR/disposition.json"
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$outcome_file" \
+	"$HELPER" disposition --repo owner/repo --issue 41 --attempt-id attempt-a \
+	--state-file "$state_file" >"$disposition"
+jq -e '.source == "attempt_outcome" and .effective_outcome == "success" and
+	.raw_result == "premature_exit" and .suppress_retry == true and
+	.suppress_enrichment == true and .suppress_failure_mining == true' \
+	"$disposition" >/dev/null || fail "successful reconciled disposition suppresses false failure routing"
+
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$outcome_file" \
+	"$HELPER" record-outcome --repo owner/repo --issue 41 \
+	--attempt-id attempt-b --run-id run-b --raw-result premature_exit \
+	--outcome failed --status failed --classification worker_failed \
+	--next-action narrow_redispatch --timestamp 10300
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$outcome_file" \
+	"$HELPER" disposition --repo owner/repo --issue 41 --attempt-id attempt-b \
+	--state-file "$state_file" >"$disposition"
+jq -e '.effective_outcome == "failed" and .suppress_retry == false and
+	.suppress_enrichment == false and .suppress_failure_mining == false' \
+	"$disposition" >/dev/null || fail "failed reconciled disposition remains actionable"
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$outcome_file" \
+	"$HELPER" disposition --repo owner/repo --issue 41 --attempt-id attempt-c \
+	--state-file "$state_file" >"$disposition"
+jq -e '.source == "none" and .effective_outcome == "unknown" and .suppress_retry == false' \
+	"$disposition" >/dev/null || fail "another attempt outcome must not contaminate a new attempt"
+
+# Issue-level consumers must prefer the newest logical attempt, not a delayed
+# cleanup record with a later evidence timestamp from an older attempt.
+chronology_file="$TMP_DIR/chronology.jsonl"
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$chronology_file" \
+	"$HELPER" record-outcome --repo owner/repo --issue 42 \
+	--attempt-id attempt-new --run-id run-new --attempt-started-at 2000000000000000001 \
+	--raw-result premature_exit --outcome failed --status failed \
+	--classification worker_failed --next-action narrow_redispatch --timestamp 300
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$chronology_file" \
+	"$HELPER" record-outcome --repo owner/repo --issue 42 \
+	--attempt-id attempt-old --run-id run-old --attempt-started-at 2000000000000000000 \
+	--raw-result recovered --outcome success --status recovered \
+	--classification stale_cleanup --next-action monitor_pr --timestamp 400
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$chronology_file" \
+	"$HELPER" disposition --repo owner/repo --issue 42 \
+	--state-file "$state_file" >"$disposition"
+jq -e '.attempt_id == "attempt-new" and .effective_outcome == "failed" and
+	.suppress_retry == false' "$disposition" >/dev/null ||
+	fail "issue-level disposition must sort by logical attempt chronology"
+
+# Concurrent terminal writers for one attempt must produce one valid record.
+concurrent_file="$TMP_DIR/concurrent.jsonl"
+concurrent_pids=()
+for concurrent_index in 1 2 3 4 5 6 7 8; do
+	AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$concurrent_file" \
+		"$HELPER" record-outcome --repo owner/repo --issue 43 \
+		--attempt-id attempt-concurrent --run-id "run-${concurrent_index}" \
+		--attempt-started-at 500 --raw-result premature_exit --outcome success \
+		--status recovered --classification worker_complete \
+		--next-action monitor_pr --timestamp "$((500 + concurrent_index))" &
+	concurrent_pids+=("$!")
+done
+for concurrent_pid in "${concurrent_pids[@]}"; do
+	wait "$concurrent_pid" || fail "concurrent outcome writer failed"
+done
+jq -se 'length == 1 and .[0].attempt_id == "attempt-concurrent"' \
+	"$concurrent_file" >/dev/null || fail "concurrent writes must remain valid and idempotent"
+
+legacy_state="$TMP_DIR/legacy-state.json"
+printf '%s\n' '{"objectives":[{"repo":"owner/repo","number":77,"objective_state":"completed","next_action":"none"}]}' >"$legacy_state"
+AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="$TMP_DIR/missing-legacy-evidence.jsonl" \
+	"$HELPER" disposition --repo owner/repo --issue 77 --attempt-id attempt-new \
+	--state-file "$legacy_state" >"$disposition"
+jq -e '.source == "objective_state" and .effective_outcome == "success" and
+	.suppress_retry == true and .suppress_failure_mining == true' \
+	"$disposition" >/dev/null || fail "legacy objective state remains readable"
+
 printf 'PASS objective-reconciliation\n'

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
@@ -52,6 +52,19 @@ esac
 EOF
 chmod +x "${FAKE_BIN}/gh" || fail "failed to make fake gh executable"
 
+OBJECTIVE_HELPER="${FAKE_BIN}/objective-reconciliation-helper.sh"
+cat >"$OBJECTIVE_HELPER" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${RETRY_DISPOSITION:-failed}" == "success" ]]; then
+	printf '%s\n' '{"source":"attempt_outcome","attempt_id":"attempt-success","effective_outcome":"success","raw_result":"post_pr_handoff","status":"recovered","classification":"worker_complete","next_action":"monitor_pr"}'
+elif [[ "${RETRY_DISPOSITION:-failed}" == "sparse" ]]; then
+	printf '%s\n' '{"source":"attempt_outcome","attempt_id":"attempt-sparse","effective_outcome":"failed","raw_result":"","status":"","classification":"","next_action":"narrow_redispatch"}'
+else
+	printf '%s\n' '{"source":"attempt_outcome","attempt_id":"attempt-prior","effective_outcome":"failed","raw_result":"premature_exit","status":"failed","classification":"unsafe prior model prose","next_action":"narrow_redispatch"}'
+fi
+EOF
+chmod +x "$OBJECTIVE_HELPER" || fail "failed to make objective helper executable"
+
 PATH="${FAKE_BIN}:${PATH}"
 export GH_CALLS_FILE
 
@@ -89,7 +102,33 @@ if [[ "$(<"${TEST_TMP}/blocked-prompt")" == *"original composed prompt"* ]]; the
 	fail "clean-room blocker leaked the original composed prompt"
 fi
 
+retry_context=$(OBJECTIVE_RECONCILIATION_HELPER="$OBJECTIVE_HELPER" \
+	AIDEVOPS_RETRY_CONTEXT_MAX_CHARS=512 _dlw_prior_attempt_context 123 owner/repo)
+if [[ "$retry_context" != *"Validated prior-attempt state"* || "$retry_context" != *"attempt-prior"* ]]; then
+	fail "failed prior attempt did not produce deterministic retry context"
+fi
+if [[ "$retry_context" == *"unsafe prior model prose"* || "$retry_context" != *"classification: unknown"* ]]; then
+	fail "retry context admitted non-machine prior prose"
+fi
+if [[ "${#retry_context}" -gt 512 ]]; then
+	fail "retry context exceeded configured bound: ${#retry_context}"
+fi
+success_context=$(OBJECTIVE_RECONCILIATION_HELPER="$OBJECTIVE_HELPER" RETRY_DISPOSITION=success \
+	_dlw_prior_attempt_context 123 owner/repo)
+if [[ -n "$success_context" ]]; then
+	fail "successful prior outcome produced unnecessary retry context"
+fi
+sparse_context=$(OBJECTIVE_RECONCILIATION_HELPER="$OBJECTIVE_HELPER" RETRY_DISPOSITION=sparse \
+	_dlw_prior_attempt_context 123 owner/repo)
+if [[ "$sparse_context" != *"attempt_id: attempt-sparse"* || \
+	"$sparse_context" != *"raw_result: unknown"* || \
+	"$sparse_context" != *"status: unknown"* || \
+	"$sparse_context" != *"next_action: narrow_redispatch"* ]]; then
+	fail "sparse retry disposition shifted empty machine fields: ${sparse_context}"
+fi
+
 printf 'PASS: dispatch prompt reuses comment metrics for zero-output fallback\n'
 printf 'PASS: zero-output evidence detection uses one shared pattern\n'
 printf 'PASS: invalid clean-room snapshots cannot authorize implementation\n'
+printf 'PASS: retry context is bounded, deterministic, and excludes prior prose\n'
 exit 0

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -80,6 +80,7 @@ STATS="$FIXTURE_DIR/pulse-stats.json"
 PR_CACHE="$FIXTURE_DIR/pr-cache.json"
 OAUTH_POOL="$FIXTURE_DIR/oauth-pool.json"
 BLOCKERS="$FIXTURE_DIR/worker-progress-blockers.jsonl"
+OBJECTIVE_EVIDENCE="$FIXTURE_DIR/objective-evidence.jsonl"
 
 cleanup() {
 	rm -rf "$FIXTURE_DIR"
@@ -190,6 +191,7 @@ RUN_ENV=(
 	"WAH_PR_CACHE_FILE=$PR_CACHE"
 	"WAH_OAUTH_POOL_FILE=$OAUTH_POOL"
 	"WAH_BLOCKER_LOG_FILE=$BLOCKERS"
+	"WAH_OBJECTIVE_EVIDENCE_FILE=$OBJECTIVE_EVIDENCE"
 	"PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER=24"
 )
 
@@ -483,6 +485,57 @@ assert_eq "7k: combined delivery-stage cache prevents repeated GitHub queries" "
 	"$(wc -l <"$GH_CALL_LOG" | tr -d ' ')"
 assert_eq "7l: cached delivery stages preserve delivered success" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.delivery_stages.delivered_successes')"
+
+# ---------------------------------------------------------------------------
+# Section 8: reconciled outcomes override routing summaries, not raw evidence.
+# ---------------------------------------------------------------------------
+echo
+echo "--- Section 8: objective outcome reconciliation ---"
+
+RECON_METRICS="$FIXTURE_DIR/reconciled-metrics.jsonl"
+cat >"$RECON_METRICS" <<EOF
+{"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-601","issue_number":601,"repo_slug":"owner/repo","attempt_id":"attempt-success","run_id":"run-a","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-602","issue_number":602,"repo_slug":"owner/repo","attempt_id":"attempt-failed","run_id":"run-b","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-603","issue_number":603,"repo_slug":"owner/repo","attempt_id":"attempt-unknown","run_id":"run-c","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-604","issue_number":604,"repo_slug":"owner/repo","attempt_id":"attempt-latest-failed","run_id":"run-d","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":$T_5MIN_AGO,"role":"worker","session_key":"issue-605","issue_number":605,"repo_slug":"owner/repo","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":$((T_5MIN_AGO - 20)),"role":"worker","session_key":"issue-606","issue_number":606,"repo_slug":"","attempt_id":"attempt-unscoped","run_id":"run-e","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":$((T_5MIN_AGO - 20)),"role":"worker","session_key":"issue-607","issue_number":607,"repo_slug":"owner/repo","attempt_id":"","run_id":"run-f","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+EOF
+cat >"$OBJECTIVE_EVIDENCE" <<EOF
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":601,"attempt_id":"attempt-success","run_id":"run-a","effective_outcome":"success","evidence_timestamp":$T_5MIN_AGO}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":602,"attempt_id":"attempt-failed","run_id":"run-b","effective_outcome":"failed","evidence_timestamp":$T_5MIN_AGO}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":603,"attempt_id":"attempt-unknown","run_id":"run-c","effective_outcome":"unknown","evidence_timestamp":$T_5MIN_AGO}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":604,"attempt_id":"attempt-latest-failed","run_id":"run-d","effective_outcome":"success","evidence_timestamp":$((T_5MIN_AGO - 10))}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":604,"attempt_id":"attempt-latest-failed","run_id":"run-d","effective_outcome":"failed","evidence_timestamp":$T_5MIN_AGO}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":606,"attempt_id":"attempt-unscoped","run_id":"run-e","effective_outcome":"success","evidence_timestamp":$((T_5MIN_AGO - 20))}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":607,"attempt_id":"","run_id":"run-f","effective_outcome":"success","evidence_timestamp":$((T_5MIN_AGO - 20))}
+EOF
+
+JSON=$(env "${RUN_ENV[@]}" "WAH_METRICS_FILE=$RECON_METRICS" \
+	"$HELPER" summary --since 1h --no-pr-check --json 2>&1)
+assert_eq "8a: raw events remain queryable" "7" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.event_result_counts.premature_exit')"
+assert_eq "8b: reconciled success becomes an effective runtime handoff" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
+assert_eq "8c: validated failures and raw fallbacks remain in failure totals" "5" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.other_failure')"
+assert_eq "8d: successful attempt is absent from failure groups" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 601)] | length')"
+assert_eq "8e: failed attempt remains in failure groups" "1" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 602)] | length')"
+assert_eq "8f: effective examples retain the raw parser result" "premature_exit" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.recent_examples[] | select(.issue_number == 601) | .raw_result')"
+assert_eq "8g: unknown reconciled outcomes fall back to raw failure" "1" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 603)] | length')"
+assert_eq "8h: latest terminal evidence wins for duplicate attempt records" "1" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 604)] | length')"
+assert_eq "8i: legacy rows without attempt identity remain readable" "1" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 605)] | length')"
+assert_eq "8j: empty repo slug remains an unscoped attempt match" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 606)] | length')"
+assert_eq "8k: empty attempt identities never reconcile with each other" "1" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.issue_number == 607)] | length')"
 
 # ---------------------------------------------------------------------------
 # Summary.

--- a/.agents/scripts/tests/test-worker-diagnostic-evidence.sh
+++ b/.agents/scripts/tests/test-worker-diagnostic-evidence.sh
@@ -56,6 +56,8 @@ test_runtime_metric_accepts_structured_evidence() {
 	export AIDEVOPS_PARENT_WORKER_ID="worker:parent"
 	export AIDEVOPS_ROOT_WORKER_ID="worker:root"
 	export AIDEVOPS_CORRELATION_ID="correlation:root"
+	export AIDEVOPS_ATTEMPT_ID="attempt:test"
+	export AIDEVOPS_RUN_ID="run:test"
 	# shellcheck source=../headless-runtime-lib.sh
 	source "${AGENTS_SCRIPTS}/headless-runtime-lib.sh"
 
@@ -66,7 +68,7 @@ test_runtime_metric_accepts_structured_evidence() {
 		"" "" "" "worker_exit_diagnostics" "hard_kill_sentinel" \
 		"stall_hard_killed" "hard_kill_stall" "redispatch_worker"
 
-	if jq -e 'select(.session_key == "issue-123" and .launch_failure_cause == "stall_hard_killed" and .kill_reason == "hard_kill_stall" and .next_action == "redispatch_worker" and .worker_id == "worker:child" and .parent_worker_id == "worker:parent" and .root_worker_id == "worker:root" and .correlation_id == "correlation:root")' \
+	if jq -e 'select(.session_key == "issue-123" and .launch_failure_cause == "stall_hard_killed" and .kill_reason == "hard_kill_stall" and .next_action == "redispatch_worker" and .worker_id == "worker:child" and .parent_worker_id == "worker:parent" and .root_worker_id == "worker:root" and .correlation_id == "correlation:root" and .attempt_id == "attempt:test" and .run_id == "run:test")' \
 		"$metrics_file" >/dev/null 2>&1; then
 		print_result "append_runtime_metric records structured evidence and lineage projection" 0
 	else

--- a/.agents/scripts/tests/test-worker-failure-feedback-reconciliation.sh
+++ b/.agents/scripts/tests/test-worker-failure-feedback-reconciliation.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../worker-failure-feedback-helper.sh"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+METRICS_FILE="${TEST_ROOT}/metrics.jsonl"
+EVIDENCE_FILE="${TEST_ROOT}/objective-evidence.jsonl"
+NOW="$(date +%s)"
+
+cat >"$METRICS_FILE" <<JSONL
+{"ts":${NOW},"role":"worker","session_key":"issue-601","issue_number":601,"repo_slug":"owner/repo","attempt_id":"attempt-success","run_id":"run-a","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":${NOW},"role":"worker","session_key":"issue-602","issue_number":602,"repo_slug":"owner/repo","attempt_id":"attempt-failed","run_id":"run-b","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":${NOW},"role":"worker","session_key":"issue-603","issue_number":603,"repo_slug":"owner/repo","attempt_id":"attempt-unknown","run_id":"run-c","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":${NOW},"role":"worker","session_key":"issue-604","issue_number":604,"repo_slug":"owner/repo","attempt_id":"attempt-latest-failed","run_id":"run-d","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+{"ts":${NOW},"role":"worker","session_key":"issue-605","issue_number":605,"repo_slug":"owner/repo","result":"premature_exit","failure_reason":"premature_exit","exit_code":77}
+JSONL
+
+cat >"$EVIDENCE_FILE" <<JSONL
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":601,"attempt_id":"attempt-success","run_id":"run-a","effective_outcome":"success","evidence_timestamp":${NOW}}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":602,"attempt_id":"attempt-failed","run_id":"run-b","effective_outcome":"failed","evidence_timestamp":${NOW}}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":603,"attempt_id":"attempt-unknown","run_id":"run-c","effective_outcome":"unknown","evidence_timestamp":${NOW}}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":604,"attempt_id":"attempt-latest-failed","run_id":"run-d","effective_outcome":"success","evidence_timestamp":$((NOW - 10))}
+{"record_type":"attempt_outcome","repo":"owner/repo","issue_number":604,"attempt_id":"attempt-latest-failed","run_id":"run-d","effective_outcome":"failed","evidence_timestamp":${NOW}}
+JSONL
+
+REPORT=$("$HELPER" report --since-hours 1 --threshold 1 \
+	--metrics-file "$METRICS_FILE" --evidence-file "$EVIDENCE_FILE")
+if [[ "$(printf '%s' "$REPORT" | jq -r 'length')" != "4" ]]; then
+	printf 'FAIL: expected four effective failure groups: %s\n' "$REPORT" >&2
+	exit 1
+fi
+if ! printf '%s' "$REPORT" | jq -e '.[] | select(.issue_number == 602 and .examples[0].attempt_id == "attempt-failed")' >/dev/null; then
+	printf 'FAIL: miner did not retain the reconciled failure: %s\n' "$REPORT" >&2
+	exit 1
+fi
+if ! printf '%s' "$REPORT" | jq -e '[.[].issue_number] | sort == [602,603,604,605]' >/dev/null; then
+	printf 'FAIL: unknown, latest-failed, or legacy evidence did not fall back to raw failure: %s\n' "$REPORT" >&2
+	exit 1
+fi
+
+printf 'PASS worker failure mining excludes only validated reconciled non-failures\n'

--- a/.agents/scripts/tests/test-worker-outcome-routing.sh
+++ b/.agents/scripts/tests/test-worker-outcome-routing.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="${TEST_ROOT}/home"
+export LOGFILE="${TEST_ROOT}/pulse.log"
+export FAST_FAIL_STATE_FILE="${HOME}/.aidevops/.agent-workspace/supervisor/fast-fail-counter.json"
+export FAST_FAIL_SKIP_THRESHOLD=5
+export FAST_FAIL_EXPIRY_SECS=604800
+export FAST_FAIL_INITIAL_BACKOFF_SECS=600
+export FAST_FAIL_MAX_BACKOFF_SECS=604800
+export AIDEVOPS_OBJECTIVE_EVIDENCE_FILE="${TEST_ROOT}/objective-evidence.jsonl"
+export AIDEVOPS_DISPATCH_LEDGER_DIR="${TEST_ROOT}/ledger"
+mkdir -p "${FAST_FAIL_STATE_FILE%/*}"
+mkdir -p "$AIDEVOPS_DISPATCH_LEDGER_DIR"
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+}
+
+log_msg() {
+	local message="$1"
+	printf '%s\n' "$message" >>"$LOGFILE"
+	return 0
+}
+
+escalate_issue_tier() {
+	return 0
+}
+
+# shellcheck source=../shared-constants.sh
+source "${SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=../worker-lifecycle-common.sh
+source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+# shellcheck source=../pulse-fast-fail.sh
+source "${SCRIPTS_DIR}/pulse-fast-fail.sh"
+# shellcheck source=../worker-watchdog-ff.sh
+source "${SCRIPTS_DIR}/worker-watchdog-ff.sh"
+# shellcheck source=../pulse-quality-debt.sh
+source "${SCRIPTS_DIR}/pulse-quality-debt.sh"
+
+OBJECTIVE_HELPER="${SCRIPTS_DIR}/objective-reconciliation-helper.sh"
+"$OBJECTIVE_HELPER" record-outcome --repo owner/repo --issue 501 \
+	--attempt-id attempt-success --run-id run-success --raw-result premature_exit \
+	--outcome success --status recovered --classification worker_complete --next-action monitor_pr
+"$OBJECTIVE_HELPER" record-outcome --repo owner/repo --issue 502 \
+	--attempt-id attempt-failed --run-id run-failed --raw-result premature_exit \
+	--outcome failed --status failed --classification worker_failed --next-action narrow_redispatch
+"$OBJECTIVE_HELPER" record-outcome --repo owner/repo --issue 503 \
+	--attempt-id attempt-old-success --run-id run-old --raw-result premature_exit \
+	--outcome success --status recovered --classification worker_complete --next-action monitor_pr
+"$OBJECTIVE_HELPER" record-outcome --repo owner/repo --issue 504 \
+	--attempt-id attempt-ledger-success --run-id run-ledger --raw-result premature_exit \
+	--outcome success --status recovered --classification worker_complete --next-action monitor_pr
+
+cat >"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" <<'JSONL'
+{"session_key":"issue-503","attempt_id":"attempt-current-without-outcome","issue_number":"503","repo_slug":"owner/repo","status":"failed"}
+{"session_key":"issue-504","attempt_id":"attempt-ledger-success","issue_number":"504","repo_slug":"owner/repo","status":"completed"}
+JSONL
+
+fast_fail_record 501 owner/repo premature_exit openai overwhelmed attempt-success
+if [[ -s "$FAST_FAIL_STATE_FILE" ]] && jq -e '."owner/repo/501" != null' "$FAST_FAIL_STATE_FILE" >/dev/null 2>&1; then
+	fail "pulse fast-fail recorded a reconciled success"
+fi
+
+fast_fail_record 502 owner/repo premature_exit openai overwhelmed attempt-failed
+if ! jq -e '."owner/repo/502".count == 1' "$FAST_FAIL_STATE_FILE" >/dev/null 2>&1; then
+	fail "pulse fast-fail suppressed a reconciled failure"
+fi
+
+fast_fail_record 503 owner/repo premature_exit openai overwhelmed
+if ! jq -e '."owner/repo/503".count == 1' "$FAST_FAIL_STATE_FILE" >/dev/null 2>&1; then
+	fail "pulse fast-fail let an older successful attempt suppress the current unresolved attempt"
+fi
+
+fast_fail_record 504 owner/repo premature_exit openai overwhelmed
+if jq -e '."owner/repo/504" != null' "$FAST_FAIL_STATE_FILE" >/dev/null 2>&1; then
+	fail "pulse fast-fail did not resolve the current successful attempt from the dispatch ledger"
+fi
+
+_watchdog_record_failure_and_escalate 501 owner/repo stall openai overwhelmed attempt-success
+if jq -e '."owner/repo/501" != null' "$FAST_FAIL_STATE_FILE" >/dev/null 2>&1; then
+	fail "watchdog fast-fail recorded a reconciled success"
+fi
+
+_watchdog_record_failure_and_escalate 504 owner/repo stall openai overwhelmed
+if jq -e '."owner/repo/504" != null' "$FAST_FAIL_STATE_FILE" >/dev/null 2>&1; then
+	fail "watchdog fast-fail did not correlate the current ledger attempt"
+fi
+
+if ! _enrichment_should_skip_for_objective 501 owner/repo; then
+	fail "quality-debt enrichment did not suppress reconciled success"
+fi
+if _enrichment_should_skip_for_objective 502 owner/repo; then
+	fail "quality-debt enrichment suppressed reconciled failure"
+fi
+
+if [[ "$(_enrichment_parse_fast_fail_key owner/repo/501)" != $'501\towner/repo' ]]; then
+	fail "quality-debt enrichment could not parse the canonical fast-fail key"
+fi
+if [[ "$(_enrichment_parse_fast_fail_key 501:owner/repo)" != $'501\towner/repo' ]]; then
+	fail "quality-debt enrichment lost legacy fast-fail key compatibility"
+fi
+
+ENRICHMENT_MAX_PER_CYCLE=5
+STOP_FLAG="${TEST_ROOT}/stop"
+ENRICHMENT_MODEL_CALLS="${TEST_ROOT}/enrichment-model-calls"
+ENRICHMENT_RUN_CALLS="${TEST_ROOT}/enrichment-run-calls"
+ENRICHMENT_MARK_CALLS="${TEST_ROOT}/enrichment-mark-calls"
+_ff_load() {
+	printf '%s\n' '{"owner/repo/501":{"enrichment_needed":true},"owner/repo/502":{"enrichment_needed":true}}'
+	return 0
+}
+_ff_with_lock() {
+	printf '%s\n' "$*" >>"$ENRICHMENT_MARK_CALLS"
+	return 0
+}
+_enrichment_resolve_model() {
+	printf 'resolve\n' >>"$ENRICHMENT_MODEL_CALLS"
+	printf 'test/model\n'
+	return 0
+}
+_enrichment_resolve_repo_path() {
+	printf '%s\n' "$TEST_ROOT"
+	return 0
+}
+_enrichment_fetch_issue_data() {
+	printf '%s\n' '{"title":"test","body":"brief","prior_attempt":{"effective_outcome":"failed"}}'
+	return 0
+}
+_enrichment_build_prompt() {
+	printf '/dev/null\n'
+	return 0
+}
+_enrichment_run_worker() {
+	printf '%s\n' "$2" >>"$ENRICHMENT_RUN_CALLS"
+	return 0
+}
+remaining_slots=$(dispatch_enrichment_workers 2)
+if [[ "$remaining_slots" != "1" ]]; then
+	fail "quality-debt enrichment consumed a slot for a reconciled success: ${remaining_slots}"
+fi
+if [[ "$(wc -l <"$ENRICHMENT_MODEL_CALLS" | tr -d ' ')" != "1" ]]; then
+	fail "quality-debt enrichment did not resolve its model lazily after suppression"
+fi
+if [[ "$(<"$ENRICHMENT_RUN_CALLS")" != "502" ]]; then
+	fail "quality-debt enrichment routed the wrong effective outcome"
+fi
+if [[ "$(wc -l <"$ENRICHMENT_MARK_CALLS" | tr -d ' ')" != "2" ]]; then
+	fail "quality-debt enrichment did not finalize both suppressed and processed entries"
+fi
+
+printf 'PASS worker outcome routing consults reconciled dispositions\n'

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -46,6 +46,7 @@ WAH_PULSE_STATS_FILE="${WAH_PULSE_STATS_FILE:-${HOME}/.aidevops/logs/pulse-stats
 WAH_PR_CACHE_FILE="${WAH_PR_CACHE_FILE:-${HOME}/.aidevops/cache/worker-activity-prs.json}"
 WAH_OAUTH_POOL_FILE="${WAH_OAUTH_POOL_FILE:-${HOME}/.aidevops/oauth-pool.json}"
 WAH_BLOCKER_LOG_FILE="${WAH_BLOCKER_LOG_FILE:-${HOME}/.aidevops/logs/worker-progress-blockers.jsonl}"
+WAH_OBJECTIVE_EVIDENCE_FILE="${WAH_OBJECTIVE_EVIDENCE_FILE:-${HOME}/.aidevops/state/objective-evidence.jsonl}"
 WAH_PR_CACHE_TTL="${WAH_PR_CACHE_TTL:-60}" # seconds
 WAH_SERVICE_INTERRUPTION_RESULT="service_interruption_continue"
 WAH_RESULT_WATCHDOG_STALL_KILLED="watchdog_stall_killed"
@@ -61,8 +62,29 @@ WAH_FAILURE_FAMILY_FILTER="${SCRIPT_DIR}/worker-activity-failure-families.jq"
 WAH_SESSION_OUTCOME_JQ='
 	def _wah_nonterminal:
 		((.result // "") | endswith("_continue")) or (.result == "brief_recovery");
+	def _wah_known_effective_outcome:
+		. == "success" or . == $outcome_failed or . == "deferred" or . == "escalated";
+	def _wah_nonempty_string:
+		type == "string" and length > 0;
+	def _wah_reconcile_outcome:
+		. as $row
+		| ([$objective_outcomes[] | select(
+			(.attempt_id | _wah_nonempty_string) and .attempt_id == ($row.attempt_id // null) and
+			((($row.repo_slug // null) | _wah_nonempty_string | not) or (.repo // null) == $row.repo_slug) and
+			(($row.issue_number // null) == null or ((.issue_number // 0) | tostring) == (($row.issue_number // "") | tostring))
+		)] | sort_by(.evidence_timestamp // 0) | last // null) as $outcome
+		| ($outcome.effective_outcome // "") as $effective
+		| if $outcome == null or (($effective | _wah_known_effective_outcome) | not) then . else
+			. + {raw_result:(.result // "unknown"), effective_outcome:$effective, outcome_source:"attempt_outcome"}
+			| if .effective_outcome == "success" then .result = "success" | .exit_code = 0 else . end
+		end;
+	def _wah_effective_failure:
+		(.effective_outcome // "") as $effective
+		| if ($effective | _wah_known_effective_outcome) then $effective == $outcome_failed
+		else ((.result // "") != "success" or (.exit_code // 1) != 0) end;
 	def _wah_session_outcomes:
-		. as $all
+		map(_wah_reconcile_outcome) as $all
+		| $all
 		| to_entries
 		| map(. as $entry | select(
 			(($entry.value.repo_slug // "") | length) > 0
@@ -114,6 +136,18 @@ _wah_parse_since() {
 	return 0
 }
 
+_wah_objective_outcomes_json() {
+	local evidence_limit="${AIDEVOPS_OBJECTIVE_EVIDENCE_LIMIT:-2000}"
+	[[ "$evidence_limit" =~ ^[1-9][0-9]*$ ]] || evidence_limit=2000
+	if [[ ! -s "$WAH_OBJECTIVE_EVIDENCE_FILE" ]]; then
+		printf '[]'
+		return 0
+	fi
+	tail -n "$evidence_limit" "$WAH_OBJECTIVE_EVIDENCE_FILE" 2>/dev/null | \
+		jq -sc '[.[] | select(.record_type == "attempt_outcome")]' 2>/dev/null || printf '[]'
+	return 0
+}
+
 #######################################
 # Aggregate worker outcomes from headless-runtime-metrics.jsonl.
 # Single jq streaming pass: filter by ts cutoff, bucket by result + exit_code.
@@ -149,10 +183,11 @@ _wah_aggregate_metrics() {
 	#          heartbeats even when their exit_code
 	#          is nonzero)
 	# Fail-open to zeros if jq fails (stale/corrupt jsonl).
-	local result service_result watchdog_killed_result rate_limit_result
+	local result service_result watchdog_killed_result rate_limit_result objective_outcomes
 	service_result="$WAH_SERVICE_INTERRUPTION_RESULT"
 	watchdog_killed_result="$WAH_RESULT_WATCHDOG_STALL_KILLED"
 	rate_limit_result="$WAH_RESULT_RATE_LIMIT"
+	objective_outcomes=$(_wah_objective_outcomes_json)
 	local jq_program
 	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
 	jq_program=$WAH_SESSION_OUTCOME_JQ'
@@ -161,12 +196,12 @@ _wah_aggregate_metrics() {
 			total:  ($events | length),
 			terminal: ($w | length),
 			succ:   ([$w[] | select(.result == "success" and .exit_code == 0)] | length),
-			wk:     ([$w[] | select(.result == $watchdog_killed_result)] | length),
+			wk:     ([$w[] | select(.result == $watchdog_killed_result and _wah_effective_failure)] | length),
 			wc:     ([$events[] | select(.result == "watchdog_stall_continue")] | length),
 			sic:    ([$events[] | select(.result == $service_result)] | length),
-			rl:     ([$w[] | select(.result == $rate_limit_result)] | length),
+			rl:     ([$w[] | select(.result == $rate_limit_result and _wah_effective_failure)] | length),
 			of:     ([$w[] | select(
-				(.result != "success" or .exit_code != 0)
+				_wah_effective_failure
 				and .result != $watchdog_killed_result
 				and .result != "watchdog_stall_continue"
 				and .result != $service_result
@@ -174,7 +209,7 @@ _wah_aggregate_metrics() {
 			)] | length)
 		} | "\(.total) \(.terminal) \(.succ) \(.wk) \(.wc) \(.sic) \(.rl) \(.of)"
 	'
-	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" --arg rate_limit_result "$rate_limit_result" "$jq_program" <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0 0"
+	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson objective_outcomes "$objective_outcomes" --arg outcome_failed "$WAH_DELIVERY_FAILED" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" --arg rate_limit_result "$rate_limit_result" "$jq_program" <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0 0"
 
 	[[ -n "$result" ]] || result="0 0 0 0 0 0 0 0"
 	printf '%s\n' "$result"
@@ -199,13 +234,14 @@ _wah_metric_details_json() {
 	fi
 	now_epoch="${2:-$(date +%s)}"
 
-	local jq_program
+	local jq_program objective_outcomes
+	objective_outcomes=$(_wah_objective_outcomes_json)
 	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
 	jq_program=$WAH_SESSION_OUTCOME_JQ$WAH_FAILURE_FAMILY_JQ'
 		[inputs | select((.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
 		| ($events | _wah_session_outcomes) as $w
 		| ($w | map(.duration_ms // 0)) as $durations
-		| ($w | map(select((.result // "") != "success" or (.exit_code // 1) != 0))) as $failures
+		| ($w | map(select(_wah_effective_failure))) as $failures
 		| {
 			event_total: ($events | length),
 			continuation_events: ($events | map(select(_wah_nonterminal)) | length),
@@ -241,6 +277,11 @@ _wah_metric_details_json() {
 				launch_failure_cause,
 				kill_reason,
 				next_action,
+				attempt_id,
+				run_id,
+				raw_result,
+				effective_outcome,
+				outcome_source,
 				duration_ms,
 				work_dir,
 				output_file,
@@ -272,7 +313,7 @@ _wah_metric_details_json() {
 				| sort_by(.count) | reverse | .[0:10]),
 			failure_families: ($failures | _wah_failure_family_summary)
 		}'
-	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" "$jq_program" <"$metrics" 2>/dev/null || \
+	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson objective_outcomes "$objective_outcomes" --arg outcome_failed "$WAH_DELIVERY_FAILED" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" "$jq_program" <"$metrics" 2>/dev/null || \
 		printf '{"result_counts":{},"diagnostic_focus":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[],"failure_groups":[],"failure_families":[]}'
 	return 0
 }

--- a/.agents/scripts/worker-failure-feedback-helper.sh
+++ b/.agents/scripts/worker-failure-feedback-helper.sh
@@ -13,14 +13,15 @@ DEFAULT_SINCE_HOURS=24
 DEFAULT_THRESHOLD=3
 DEFAULT_LIMIT=5
 DEFAULT_METRICS_FILE="${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl"
+DEFAULT_EVIDENCE_FILE="${HOME}/.aidevops/state/objective-evidence.jsonl"
 
 print_usage() {
 	cat <<'EOF'
 worker-failure-feedback-helper.sh - Mine non-success worker metrics into feedback tasks
 
 Usage:
-  worker-failure-feedback-helper.sh report [--since-hours N] [--threshold N] [--metrics-file PATH]
-  worker-failure-feedback-helper.sh create-issues [--since-hours N] [--threshold N] [--limit N] [--dry-run]
+  worker-failure-feedback-helper.sh report [--since-hours N] [--threshold N] [--metrics-file PATH] [--evidence-file PATH]
+  worker-failure-feedback-helper.sh create-issues [--since-hours N] [--threshold N] [--limit N] [--evidence-file PATH] [--dry-run]
 
 The miner groups recent non-success headless-runtime-metrics.jsonl rows by
 result, failure_reason, session_key, issue_number, and repo_slug. Repeated
@@ -50,6 +51,7 @@ parse_common_args() {
 	THRESHOLD="$DEFAULT_THRESHOLD"
 	LIMIT="$DEFAULT_LIMIT"
 	METRICS_FILE="$DEFAULT_METRICS_FILE"
+	EVIDENCE_FILE="$DEFAULT_EVIDENCE_FILE"
 	DRY_RUN=0
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
@@ -58,6 +60,7 @@ parse_common_args() {
 		--threshold) THRESHOLD="${2:-}"; require_positive_integer "$arg" "$THRESHOLD" || return 2; shift 2 ;;
 		--limit) LIMIT="${2:-}"; require_positive_integer "$arg" "$LIMIT" || return 2; shift 2 ;;
 		--metrics-file) METRICS_FILE="${2:-}"; [[ -n "$METRICS_FILE" ]] || return 2; shift 2 ;;
+		--evidence-file) EVIDENCE_FILE="${2:-}"; [[ -n "$EVIDENCE_FILE" ]] || return 2; shift 2 ;;
 		--dry-run) DRY_RUN=1; shift ;;
 		-h | --help) print_usage; return 64 ;;
 		*) die "unknown flag: $arg"; return 2 ;;
@@ -70,15 +73,36 @@ mine_failure_groups_json() {
 	local since_hours="$1"
 	local threshold="$2"
 	local metrics_file="$3"
+	local evidence_file="${4:-$DEFAULT_EVIDENCE_FILE}"
 	if [[ ! -f "$metrics_file" ]]; then
 		printf '[]\n'
 		return 0
 	fi
 	local cutoff_epoch
 	cutoff_epoch=$(( $(date +%s) - (since_hours * 3600) ))
-	jq -s --argjson cutoff "$cutoff_epoch" --argjson threshold "$threshold" '
+	local dispositions='[]'
+	local evidence_limit="${AIDEVOPS_OBJECTIVE_EVIDENCE_LIMIT:-2000}"
+	[[ "$evidence_limit" =~ ^[1-9][0-9]*$ ]] || evidence_limit=2000
+	if [[ -s "$evidence_file" ]]; then
+		dispositions=$(tail -n "$evidence_limit" "$evidence_file" 2>/dev/null | \
+			jq -sc '[.[] | select(.record_type == "attempt_outcome")]') || dispositions='[]'
+	fi
+	jq -s --argjson cutoff "$cutoff_epoch" --argjson threshold "$threshold" --argjson dispositions "$dispositions" '
+	def evidence_timestamp: (.evidence_timestamp // .timestamp // .ts // 0) | tonumber? // 0;
+    def reconciled_nonfailure:
+      . as $row |
+	  ([$dispositions[] | select(
+		(($row.attempt_id // "") != "") and
+		(.attempt_id // "") == ($row.attempt_id // "") and
+		(($row.repo_slug // "") == "" or (.repo // "") == ($row.repo_slug // "")) and
+		(($row.issue_number // null) == null or ((.issue_number // 0) | tostring) == (($row.issue_number // "") | tostring))
+	  )] | sort_by(evidence_timestamp) | last // null) as $outcome |
+	  if $outcome == null then false
+	  else ["success", "deferred", "escalated"] | index($outcome.effective_outcome // "") != null
+	  end;
     map(select((.ts // 0) >= $cutoff))
     | map(select((.result // "") != "success" or (.exit_code // 1) != 0))
+    | map(select(reconciled_nonfailure | not))
     | group_by([.result // "unknown", .failure_reason // "", .session_key // "", (.issue_number // "" | tostring), .repo_slug // ""])
     | map({
         result: (.[0].result // "unknown"),
@@ -89,7 +113,7 @@ mine_failure_groups_json() {
         count: length,
         first_ts: (map(.ts // 0) | min),
         last_ts: (map(.ts // 0) | max),
-        examples: (sort_by(.ts // 0) | reverse | .[0:5] | map({ts, model, provider, exit_code, duration_ms, session_id, work_dir, output_file}))
+        examples: (sort_by(.ts // 0) | reverse | .[0:5] | map({ts, model, provider, exit_code, duration_ms, session_id, attempt_id, run_id, work_dir, output_file}))
       })
     | map(select(.count >= $threshold))
     | sort_by(.count) | reverse
@@ -102,7 +126,7 @@ cmd_report() {
 	local parse_rc=$?
 	[[ "$parse_rc" -eq 64 ]] && return 0
 	[[ "$parse_rc" -eq 0 ]] || return "$parse_rc"
-	mine_failure_groups_json "$SINCE_HOURS" "$THRESHOLD" "$METRICS_FILE"
+	mine_failure_groups_json "$SINCE_HOURS" "$THRESHOLD" "$METRICS_FILE" "$EVIDENCE_FILE"
 	return 0
 }
 
@@ -131,7 +155,7 @@ cmd_create_issues() {
 	[[ "$parse_rc" -eq 64 ]] && return 0
 	[[ "$parse_rc" -eq 0 ]] || return "$parse_rc"
 	local groups_json
-	groups_json=$(mine_failure_groups_json "$SINCE_HOURS" "$THRESHOLD" "$METRICS_FILE")
+	groups_json=$(mine_failure_groups_json "$SINCE_HOURS" "$THRESHOLD" "$METRICS_FILE" "$EVIDENCE_FILE")
 	local created=0
 	while IFS= read -r group; do
 		[[ -n "$group" ]] || continue

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -19,6 +19,7 @@
 #   _sanitize_log_field()     Strip control characters from log fields
 #   _sanitize_markdown()      Strip @ mentions and backticks from markdown
 #   _validate_int()           Validate and sanitize integer config values
+#   _worker_attempt_id_for_issue() Resolve the latest public attempt identity
 #   _count_issue_comments_containing_marker() Pagination-safe comment marker count
 #   _count_worker_commits()   Count commits in a worktree since elapsed seconds ago
 #   _count_worker_messages()  Count session DB messages for a worker
@@ -64,6 +65,84 @@ _ensure_worker_lineage() {
 	return 0
 }
 
+_ensure_worker_attempt_identity() {
+	if [[ -z "${AIDEVOPS_ATTEMPT_ID:-}" ]]; then
+		AIDEVOPS_ATTEMPT_ID=$(aidevops_generate_execution_id "attempt")
+	fi
+	if [[ ! "${AIDEVOPS_ATTEMPT_STARTED_AT:-}" =~ ^[0-9]+$ ]]; then
+		AIDEVOPS_ATTEMPT_STARTED_AT=$(_worker_attempt_start_marker)
+	fi
+	export AIDEVOPS_ATTEMPT_ID AIDEVOPS_ATTEMPT_STARTED_AT
+	return 0
+}
+
+# Return a high-resolution epoch marker so attempts dispatched within the same
+# second retain deterministic chronology. Python is already a framework runtime
+# dependency; the seconds fallback preserves a comparable 19-digit shape.
+_worker_attempt_start_marker() {
+	local marker=""
+	marker=$(python3 -c 'import time; print(time.time_ns())' 2>/dev/null || true)
+	if [[ ! "$marker" =~ ^[0-9]{19}$ ]]; then
+		marker="$(date +%s 2>/dev/null || printf '0')000000000"
+	fi
+	printf '%s' "$marker"
+	return 0
+}
+
+_begin_worker_runtime_run() {
+	AIDEVOPS_RUN_ID=$(aidevops_generate_execution_id "run")
+	export AIDEVOPS_RUN_ID
+	return 0
+}
+
+_worker_attempt_id_for_issue() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local attempt_id="${3:-${AIDEVOPS_ATTEMPT_ID:-}}"
+	local ledger_dir="${AIDEVOPS_DISPATCH_LEDGER_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local ledger_file="${ledger_dir}/dispatch-ledger.jsonl"
+
+	[[ "$issue_number" =~ ^[1-9][0-9]*$ && -n "$repo_slug" ]] || return 1
+	if [[ -z "$attempt_id" && -s "$ledger_file" ]]; then
+		attempt_id=$(jq -sr --arg issue "$issue_number" --arg repo "$repo_slug" '
+			[.[] | select((.issue_number // "") == $issue and (.repo_slug // "") == $repo and (.attempt_id // "") != "")]
+			| last | .attempt_id // empty
+		' "$ledger_file" 2>/dev/null) || attempt_id=""
+	fi
+	[[ "$attempt_id" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$ ]] || return 1
+	printf '%s' "$attempt_id"
+	return 0
+}
+
+_objective_disposition_json() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local attempt_id="${3:-}"
+	local helper="${BASH_SOURCE[0]%/*}/objective-reconciliation-helper.sh"
+	local -a disposition_args=(disposition --repo "$repo_slug" --issue "$issue_number")
+
+	[[ -x "$helper" && "$issue_number" =~ ^[1-9][0-9]*$ && -n "$repo_slug" ]] || return 1
+	[[ -n "$attempt_id" ]] && disposition_args+=(--attempt-id "$attempt_id")
+	"$helper" "${disposition_args[@]}" 2>/dev/null
+	return $?
+}
+
+_objective_disposition_suppresses() {
+	local suppression_field="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	local attempt_id="${4:-}"
+	local disposition=""
+
+	case "$suppression_field" in
+	suppress_fast_fail | suppress_retry | suppress_enrichment | suppress_failure_mining) ;;
+	*) return 1 ;;
+	esac
+	disposition=$(_objective_disposition_json "$issue_number" "$repo_slug" "$attempt_id") || return 1
+	printf '%s' "$disposition" | jq -e --arg field "$suppression_field" '.[$field] == true' >/dev/null 2>&1
+	return $?
+}
+
 _emit_objective_recovery_evidence() {
 	local event_type="$1"
 	local status="$2"
@@ -81,11 +160,13 @@ _emit_objective_recovery_evidence() {
 	local next_action="monitor_worker"
 	local execution_path_state="running"
 	local recovery_attempt="${AIDEVOPS_RECOVERY_ATTEMPT:-0}"
+	local attempt_started_at="${AIDEVOPS_ATTEMPT_STARTED_AT:-0}"
 	local repair_pr_number="${AIDEVOPS_PR_REPAIR_NUMBER:-}"
 	local repair_head_sha="${AIDEVOPS_PR_REPAIR_HEAD_SHA:-}"
 	local repair_head_ref="${AIDEVOPS_PR_REPAIR_HEAD_REF:-}"
 	local repair_fingerprint="${AIDEVOPS_PR_REPAIR_FINGERPRINT:-}"
 	[[ "$recovery_attempt" =~ ^[0-9]+$ ]] || recovery_attempt=0
+	[[ "$attempt_started_at" =~ ^[0-9]+$ ]] || attempt_started_at=0
 	evidence_dir=$(dirname "$evidence_file")
 	mkdir -p "$evidence_dir" 2>/dev/null || return 0
 	evidence_timestamp=$(date +%s 2>/dev/null) || evidence_timestamp=0
@@ -106,6 +187,9 @@ _emit_objective_recovery_evidence() {
 		--argjson issue_number "$issue_number" \
 		--argjson evidence_timestamp "$evidence_timestamp" \
 		--arg worker_id "${AIDEVOPS_WORKER_ID:-}" \
+		--arg attempt_id "${AIDEVOPS_ATTEMPT_ID:-}" \
+		--arg run_id "${AIDEVOPS_RUN_ID:-}" \
+		--argjson attempt_started_at "$attempt_started_at" \
 		--arg branch "$branch_name" \
 		--arg worktree "$worktree_name" \
 		--arg commit "$commit_sha" \
@@ -120,6 +204,7 @@ _emit_objective_recovery_evidence() {
 		--argjson verification_preserved "$([[ -n "${AIDEVOPS_VERIFICATION_EVIDENCE:-}" ]] && printf true || printf false)" \
 		'{event_type:$event_type,status:$status,classification:$classification,repo:$repo,
 		issue_number:$issue_number,evidence_timestamp:$evidence_timestamp,worker_id:$worker_id,
+		attempt_id:$attempt_id,run_id:$run_id,attempt_started_at:$attempt_started_at,
 		branch:$branch,worktree:$worktree,commit:$commit,next_action:$next_action,
 		execution_path_state:$execution_path_state,recovery_attempt:$recovery_attempt,
 		branch_preserved:($branch != ""),worktree_preserved:($worktree != ""),

--- a/.agents/scripts/worker-watchdog-ff.sh
+++ b/.agents/scripts/worker-watchdog-ff.sh
@@ -239,6 +239,7 @@ _ff_write_state_entry() {
 #   $3 - kill reason (idle, stall, thrash, runtime, backoff, etc.)
 #   $4 - provider (anthropic, openai, cursor, google; default: anthropic)
 #   $5 - crash_type (no_work|overwhelmed|""; for tier escalation)
+#   $6 - attempt_id (optional exact objective correlation)
 #######################################
 _watchdog_record_failure_and_escalate() {
 	local issue_number="$1"
@@ -246,9 +247,18 @@ _watchdog_record_failure_and_escalate() {
 	local reason="$3"
 	local provider="${4:-anthropic}"
 	local crash_type="${5:-}"
+	local attempt_id="${6:-}"
 
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 0
 	[[ -n "$repo_slug" ]] || return 0
+	if declare -F _worker_attempt_id_for_issue >/dev/null 2>&1; then
+		attempt_id=$(_worker_attempt_id_for_issue "$issue_number" "$repo_slug" "$attempt_id") || attempt_id=""
+	fi
+	if [[ -n "$attempt_id" ]] && declare -F _objective_disposition_suppresses >/dev/null 2>&1 && \
+		_objective_disposition_suppresses suppress_fast_fail "$issue_number" "$repo_slug" "$attempt_id"; then
+		log_msg "Fast-fail suppressed for #${issue_number} (${repo_slug}) by reconciled objective outcome"
+		return 0
+	fi
 
 	local state_file="${HOME}/.aidevops/.agent-workspace/supervisor/fast-fail-counter.json"
 	local state_dir

--- a/TODO.md
+++ b/TODO.md
@@ -1172,6 +1172,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18137 Update model tier reasoning defaults and migrate custom routing configs #feat ref:GH#27863 pr:#27865 completed:2026-07-15
 
+- [ ] t18138 fix(worker): reconcile attempt outcomes before retry and failure routing #bug #observability #pulse ref:GH#27907
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Correlate dispatch attempts and runtime runs, persist reconciled objective outcomes safely, and route retries, failures, activity, and handoffs from verified objective state while retaining raw runtime evidence.

## Files Changed

.agents/scripts/dispatch-ledger-helper.sh, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/headless-runtime-model.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/objective-reconciliation-helper.sh, .agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/pulse-fast-fail.sh, .agents/scripts/pulse-quality-debt.sh, .agents/scripts/runtime-events-cli.mjs, .agents/scripts/runtime-events-payload.mjs, .agents/scripts/shared-constants.sh, .agents/scripts/tests/test-dispatch-ledger-helper.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-issue-sync-linkage-guidance.sh, .agents/scripts/tests/test-objective-reconciliation.sh, .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh, .agents/scripts/tests/test-worker-activity-helper.sh, .agents/scripts/tests/test-worker-diagnostic-evidence.sh, .agents/scripts/tests/test-worker-failure-feedback-reconciliation.sh, .agents/scripts/tests/test-worker-outcome-routing.sh, .agents/scripts/worker-activity-helper.sh, .agents/scripts/worker-failure-feedback-helper.sh, .agents/scripts/worker-lifecycle-common.sh, .agents/scripts/worker-watchdog-ff.sh, .github/workflows/issue-sync-reusable.yml, TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Repository linters and complexity gates pass; focused dispatch-ledger, headless-runtime, objective-reconciliation, activity, failure-feedback, watchdog, and fast-fail regression suites pass.

Resolves #27907


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 2h 47m and 2,570,925 tokens on this with the user in an interactive session.