### PR TITLE
GH#27894: guard missing greeting version

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs
@@ -14,6 +14,11 @@ assert.match(instruction, /Call the appropriate tools immediately, before visibl
 assert.match(instruction, /Do not claim that tool access is unavailable without first attempting/);
 assert.doesNotMatch(instruction, /before tool calls, status updates/);
 
+for (const missingVersion of [null, undefined]) {
+  const missingVersionInstruction = buildSessionStartGreetingInstruction("/missing", () => missingVersion);
+  assert.match(missingVersionInstruction, /We're running aidevops vX\./);
+}
+
 const paths = {
   version: "/agents/VERSION",
 };

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -205,7 +205,7 @@ export function buildSessionStartGreetingInstruction(agentsDir, readIfExists, op
     : [];
   const cacheLine = cacheLines[0] || "";
   const cacheMatch = cacheLine.match(/^aidevops v(\S+) running in (.+?) v(\S+)(?:\s|$)/);
-  const deployedVersion = readIfExists(join(agentsDir, "VERSION")).trim().split("\n")[0];
+  const deployedVersion = (readIfExists(join(agentsDir, "VERSION")) ?? "").trim().split("\n")[0];
   const version = deployedVersion || cacheMatch?.[1] || "X";
   const cacheMatchesDeployedVersion = !deployedVersion || cacheMatch?.[1] === deployedVersion;
   const runtime = cacheMatch?.[2] || "OpenCode";


### PR DESCRIPTION
## Summary

Normalize nullish VERSION reads before trimming so session-start greeting construction falls back safely, with regression coverage for null and undefined reads.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-session-start-task-execution.mjs, .agents/plugins/opencode-aidevops/ttsr.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test targeted greeting suites; node --check changed modules; git diff --check

Resolves #27894


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 9m and 78,105 tokens on this as a headless worker.