### PR TITLE
GH#27925: fix: protect WIP finalization from base drift

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -393,6 +393,32 @@ _stage_and_commit() {
 	return 0
 }
 
+# Integrate the immutable base selected for WIP finalization before resetting.
+# A mutable remote-tracking ref may advance after staging; rebasing first keeps
+# those upstream changes in the branch tree instead of staging their reversal.
+# Args: $1=base OID $2=display base ref
+_integrate_wip_finalization_base() {
+	local base_oid="$1"
+	local base_ref="$2"
+	if git merge-base --is-ancestor "$base_oid" HEAD 2>/dev/null; then
+		return 0
+	fi
+
+	print_info "${base_ref} advanced before WIP finalization; integrating ${base_oid} first..."
+	_check_and_handle_shallow_clone || return 1
+	if ! git rebase "$base_oid" 2>/dev/null; then
+		git rebase --abort 2>/dev/null || true
+		print_error "Base drift could not be integrated safely before WIP finalization."
+		print_error "Resolve the rebase onto ${base_ref}, then rerun commit-and-pr."
+		return 1
+	fi
+	if ! git merge-base --is-ancestor "$base_oid" HEAD 2>/dev/null; then
+		print_error "Refusing WIP finalization: integrated tip does not contain ${base_oid}."
+		return 1
+	fi
+	return 0
+}
+
 # Replace branch history with one final commit when any branch commit is WIP.
 # The caller-supplied final message is authoritative. On commit-hook failure,
 # restore the original branch tip and preserve any hook-produced working changes.
@@ -405,10 +431,14 @@ _finalize_wip_history() {
 	fi
 
 	local base_branch="" branch_range="" branch_subjects=""
-	local base_ref=""
+	local base_ref="" base_oid=""
 	base_branch=$(_resolve_remote_default_branch origin) || return 1
 	printf -v base_ref 'origin/%s' "$base_branch"
-	printf -v branch_range '%s..HEAD' "$base_ref"
+	base_oid=$(git rev-parse --verify "${base_ref}^{commit}" 2>/dev/null) || {
+		print_error "Cannot snapshot ${base_ref} before WIP finalization."
+		return 1
+	}
+	printf -v branch_range '%s..HEAD' "$base_oid"
 	if ! branch_subjects=$(git log --format=%s "$branch_range" 2>/dev/null); then
 		print_error "Cannot inspect branch commit subjects relative to ${base_ref}."
 		return 1
@@ -440,8 +470,9 @@ _finalize_wip_history() {
 		print_error "Cannot record the original branch tip before WIP finalization."
 		return 1
 	}
-	print_info "Finalizing WIP history into one commit relative to ${base_ref}..."
-	if ! git reset --soft "$base_ref"; then
+	_integrate_wip_finalization_base "$base_oid" "$base_ref" || return 1
+	print_info "Finalizing WIP history into one commit relative to ${base_ref} (${base_oid})..."
+	if ! git reset --soft "$base_oid"; then
 		print_error "Failed to prepare WIP history for finalization."
 		return 1
 	fi

--- a/.agents/scripts/tests/test-full-loop-wip-finalization.sh
+++ b/.agents/scripts/tests/test-full-loop-wip-finalization.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression coverage for GH#27902: commit-and-pr must replace temporary WIP
-# history with one conventional final commit before validation and publication.
+# Regression coverage for GH#27902 and GH#27925: commit-and-pr must replace
+# temporary WIP history without reverting concurrent default-branch updates.
 
 set -uo pipefail
 
@@ -68,11 +68,29 @@ make_repo() {
 		git config user.email 'test@example.invalid'
 		git config commit.gpgsign false
 		printf 'base\n' >tracked.txt
-		git add tracked.txt
+		printf 'upstream base\n' >upstream-edit.txt
+		git add tracked.txt upstream-edit.txt
 		git commit -qm 'chore: initial fixture'
 		git branch -M develop
 		git update-ref refs/remotes/origin/develop HEAD
 		git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+	) || return 1
+	return 0
+}
+
+advance_remote_base() {
+	local repo_dir="$1"
+	(
+		cd "$repo_dir" || exit 1
+		git switch -qc simulated-upstream origin/develop
+		printf 'upstream changed\n' >>upstream-edit.txt
+		printf 'new upstream file\n' >upstream-new.txt
+		git add upstream-edit.txt upstream-new.txt
+		git commit -qm 'fix: concurrent upstream update'
+		local upstream_oid=""
+		upstream_oid=$(git rev-parse HEAD)
+		git switch -q develop
+		git update-ref refs/remotes/origin/develop "$upstream_oid"
 	) || return 1
 	return 0
 }
@@ -207,6 +225,31 @@ test_wip_final_message_is_rejected() {
 	return 0
 }
 
+test_concurrent_base_advance_is_integrated() {
+	local repo_dir="${TEST_ROOT}/concurrent-base"
+	make_repo "$repo_dir" || return 1
+	commit_change "$repo_dir" 'feature' 'wip: preserve feature before base drift' || return 1
+	advance_remote_base "$repo_dir" || return 1
+	(
+		cd "$repo_dir" || exit 1
+		_finalize_wip_history 'fix: preserve concurrent base update'
+	) >/dev/null 2>&1
+	local rc=$?
+	local count="" feature_content="" upstream_edit="" upstream_new=""
+	count=$(git -C "$repo_dir" rev-list --count origin/develop..HEAD)
+	feature_content=$(git -C "$repo_dir" show HEAD:tracked.txt)
+	upstream_edit=$(git -C "$repo_dir" show HEAD:upstream-edit.txt)
+	upstream_new=$(git -C "$repo_dir" show HEAD:upstream-new.txt)
+	if [[ "$rc" -eq 0 && "$count" == '1' && "$feature_content" == $'base\nfeature' &&
+		"$upstream_edit" == $'upstream base\nupstream changed' && "$upstream_new" == 'new upstream file' ]]; then
+		print_result 'concurrent base advance is integrated before WIP finalization' 0
+	else
+		print_result 'concurrent base advance is integrated before WIP finalization' 1 \
+			"rc=${rc}, count=${count}, feature=${feature_content}, upstream=${upstream_edit}"
+	fi
+	return 0
+}
+
 test_orchestrator_finalizes_before_validation() {
 	local orchestrator="${SCRIPT_DIR}/full-loop-helper.sh"
 	local stage_line="" finalize_line="" validators_line=""
@@ -232,11 +275,12 @@ test_buried_wip_squashes_branch_range
 test_no_wip_preserves_history
 test_commit_hook_failure_restores_tip
 test_wip_final_message_is_rejected
+test_concurrent_base_advance_is_integrated
 test_orchestrator_finalizes_before_validation
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
-if [[ "$TESTS_RUN" -ne 6 ]]; then
-	printf '%sFAIL%s expected 6 tests to execute\n' "$TEST_RED" "$TEST_RESET"
+if [[ "$TESTS_RUN" -ne 7 ]]; then
+	printf '%sFAIL%s expected 7 tests to execute\n' "$TEST_RED" "$TEST_RESET"
 	exit 1
 fi
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Snapshot the default-branch OID, integrate concurrent base drift before soft-reset finalization, and preserve upstream files and edits.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/tests/test-full-loop-wip-finalization.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-full-loop-wip-finalization.sh; .agents/scripts/linters-local.sh

Resolves #27925


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 10m and 65,080 tokens on this as a headless worker.