### PR TITLE
GH#27789: harden dispatch and recovery workflows

### DIFF
--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -91,7 +91,7 @@ _has_open_pr_check_healthy_sibling() {
 	local pr_json match_pr draft_pr
 	pr_json=$(gh pr list --repo "$repo_slug" --state open \
 		--search "#${issue_number}" --limit 20 \
-		--json number,title,body,isDraft,reviewDecision,mergeStateStatus,mergeable 2>/dev/null) || pr_json="[]"
+		--json number,title,body,isDraft,reviewDecision,mergeStateStatus,mergeable,changedFiles,files 2>/dev/null) || pr_json="[]"
 
 	local issue_ref_pattern healthy_state_pattern blocked_state_pattern
 	issue_ref_pattern="([^[:alnum:]_]|^)((close[sd]?|fix(e[sd])?|resolve[sd]?|for|refs?):?[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}|GH#${issue_number}|#${issue_number})([^[:alnum:]_]|$)"
@@ -115,7 +115,12 @@ _has_open_pr_check_healthy_sibling() {
 		--arg issue_pattern "$issue_ref_pattern" \
 		--arg healthy_pattern "$healthy_state_pattern" \
 		--arg blocked_pattern "$blocked_state_pattern" \
-		'[
+		'def complete_planning_only_scope:
+			(.changedFiles // 0) as $changed |
+			([.files[]?.path] | length) as $returned |
+			($changed > 0) and ($returned == $changed) and
+			([.files[]?.path] | all(.[]; test("^(TODO\\.md$|todo/)")));
+		[
 			.[] | select(
 				(.isDraft // false | not) and
 				((.reviewDecision // "") != "CHANGES_REQUESTED") and
@@ -125,7 +130,8 @@ _has_open_pr_check_healthy_sibling() {
 					((.mergeStateStatus // "") | test($healthy_pattern)) or
 					((.mergeable // "") == "MERGEABLE")
 				) and
-				(((.title // "") | test($issue_pattern; "i")) or ((.body // "") | test($issue_pattern; "i")))
+				(((.title // "") | test($issue_pattern; "i")) or ((.body // "") | test($issue_pattern; "i"))) and
+				(complete_planning_only_scope | not)
 			)
 		] | .[0].number // empty' 2>/dev/null) || match_pr=""
 

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -405,10 +405,23 @@ _finalize_wip_history() {
 	fi
 
 	local base_branch="" branch_range="" branch_subjects=""
-	local base_ref=""
+	local base_ref="" base_oid=""
 	base_branch=$(_resolve_remote_default_branch origin) || return 1
 	printf -v base_ref 'origin/%s' "$base_branch"
-	printf -v branch_range '%s..HEAD' "$base_ref"
+	if ! git fetch origin "$base_branch" --quiet 2>/dev/null; then
+		print_error "Cannot refresh ${base_ref} before WIP history finalization."
+		return 1
+	fi
+	base_oid=$(git rev-parse "$base_ref" 2>/dev/null) || {
+		print_error "Cannot snapshot ${base_ref} before WIP history finalization."
+		return 1
+	}
+	if ! git merge-base --is-ancestor "$base_oid" HEAD 2>/dev/null; then
+		print_error "Refusing WIP finalization: current ${base_ref} is not an ancestor of HEAD."
+		print_error "Rebase onto ${base_ref}, resolve any conflicts, then retry commit-and-pr."
+		return 1
+	fi
+	printf -v branch_range '%s..HEAD' "$base_oid"
 	if ! branch_subjects=$(git log --format=%s "$branch_range" 2>/dev/null); then
 		print_error "Cannot inspect branch commit subjects relative to ${base_ref}."
 		return 1
@@ -440,8 +453,8 @@ _finalize_wip_history() {
 		print_error "Cannot record the original branch tip before WIP finalization."
 		return 1
 	}
-	print_info "Finalizing WIP history into one commit relative to ${base_ref}..."
-	if ! git reset --soft "$base_ref"; then
+	print_info "Finalizing WIP history into one commit relative to ${base_ref} at ${base_oid}..."
+	if ! git reset --soft "$base_oid"; then
 		print_error "Failed to prepare WIP history for finalization."
 		return 1
 	fi

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -1452,6 +1452,21 @@ _shim_normalize_interactive_tracking_issue_create() {
 
 _shim_normalize_interactive_tracking_issue_create
 
+_shim_normalize_pr_create_origin() {
+	[[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "pr:create" ]] || return 0
+	# Respect an explicit immutable origin. Raw gh callers otherwise receive the
+	# same session provenance as gh_create_pr so worker drafts are recoverable.
+	_shim_issue_create_has_label_prefix "origin:" && return 0
+	local origin_label="origin:interactive"
+	if _shim_is_headless_automation; then
+		origin_label="origin:worker"
+	fi
+	_modified_args+=(--label "$origin_label")
+	return 0
+}
+
+_shim_normalize_pr_create_origin
+
 _shim_pr_create_get_title() {
 	local idx=0
 	local arg=""

--- a/.agents/scripts/planning-commit-helper.sh
+++ b/.agents/scripts/planning-commit-helper.sh
@@ -321,7 +321,7 @@ complete_task() {
 # Parse arguments for next_task_id.
 # Prints assignments to stdout for eval.
 _next_task_id_parse_args() {
-	local _title="" _labels="" _description="" _offline_flag="" _dry_run_flag=""
+	local _title="" _labels="" _description="" _parent_issue="" _offline_flag="" _dry_run_flag=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -335,6 +335,14 @@ _next_task_id_parse_args() {
 			;;
 		--description)
 			_description="$2"
+			shift 2
+			;;
+		--parent-issue)
+			_parent_issue="${2:-}"
+			if [[ ! "$_parent_issue" =~ ^[1-9][0-9]*$ ]]; then
+				log_error "next_task_id: --parent-issue requires a positive issue number"
+				return 1
+			fi
 			shift 2
 			;;
 		--offline)
@@ -355,13 +363,14 @@ _next_task_id_parse_args() {
 	printf 'title=%q\n' "$_title"
 	printf 'labels=%q\n' "$_labels"
 	printf 'description=%q\n' "$_description"
+	printf 'parent_issue=%q\n' "$_parent_issue"
 	printf 'offline_flag=%q\n' "$_offline_flag"
 	printf 'dry_run_flag=%q\n' "$_dry_run_flag"
 	return 0
 }
 
 # Invoke claim-task-id.sh and capture its output + exit code.
-# Usage: _next_task_id_run_claim <claim_script> <repo_path> <title> <labels> <description> <offline_flag> <dry_run_flag>
+# Usage: _next_task_id_run_claim <claim_script> <repo_path> <title> <labels> <description> <parent_issue> <offline_flag> <dry_run_flag>
 # Prints: claim_output on stdout; sets global claim_rc via caller convention (prints "claim_rc=N")
 _next_task_id_run_claim() {
 	local claim_script="$1"
@@ -369,12 +378,14 @@ _next_task_id_run_claim() {
 	local title="$3"
 	local labels="$4"
 	local description="$5"
-	local offline_flag="$6"
-	local dry_run_flag="$7"
+	local parent_issue="$6"
+	local offline_flag="$7"
+	local dry_run_flag="$8"
 
 	local -a claim_args=(--title "$title" --repo-path "$repo_path")
 	[[ -n "$labels" ]] && claim_args+=(--labels "$labels")
 	[[ -n "$description" ]] && claim_args+=(--description "$description")
+	[[ -n "$parent_issue" ]] && claim_args+=(--parent-issue "$parent_issue")
 	[[ -n "$offline_flag" ]] && claim_args+=("$offline_flag")
 	[[ -n "$dry_run_flag" ]] && claim_args+=("$dry_run_flag")
 
@@ -451,6 +462,7 @@ _next_task_id_parse_output() {
 # Usage:
 #   next_task_id --title "Task description"
 #   next_task_id --title "Task description" --labels "bug,priority"
+#   next_task_id --title "Child task" --parent-issue 123
 #   next_task_id --title "Task description" --offline
 #   next_task_id --title "Task description" --dry-run
 #
@@ -465,7 +477,7 @@ _next_task_id_parse_output() {
 #   2 - Success with offline fallback
 #   1 - Error
 next_task_id() {
-	local title="" labels="" description="" offline_flag="" dry_run_flag=""
+	local title="" labels="" description="" parent_issue="" offline_flag="" dry_run_flag=""
 
 	# Parse arguments
 	local parsed_args
@@ -474,7 +486,7 @@ next_task_id() {
 
 	if [[ -z "$title" ]]; then
 		log_error "next_task_id: --title is required"
-		echo "Usage: next_task_id --title \"Task description\" [--labels \"l1,l2\"] [--offline] [--dry-run]"
+		echo "Usage: next_task_id --title \"Task description\" [--labels \"l1,l2\"] [--parent-issue N] [--offline] [--dry-run]"
 		return 1
 	fi
 
@@ -494,7 +506,7 @@ next_task_id() {
 	local claim_meta
 	claim_meta=$(_next_task_id_run_claim \
 		"$claim_script" "$repo_path" "$title" "$labels" "$description" \
-		"$offline_flag" "$dry_run_flag") || {
+		"$parent_issue" "$offline_flag" "$dry_run_flag") || {
 		claim_rc=$?
 		return "$claim_rc"
 	}

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -1517,12 +1517,13 @@ _cleanup_single_worktree() {
 	repo_name_age=$(basename "$rp_age")
 	local orphan_issue_num=""
 	orphan_issue_num=$(_pc_issue_from_branch "$wt_branch_age" 2>/dev/null || true)
-	if _pc_handle_terminal_worktree_archive "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
-		return 0
-	fi
-
+	# Live ownership is an unconditional destructive-operation guard. Terminal
+	# state must not bypass it and archive/stash/remove a still-owned worktree.
 	if _worktree_owner_alive "$wt_path_age" "$wt_branch_age"; then
 		return 1
+	fi
+	if _pc_handle_terminal_worktree_archive "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
+		return 0
 	fi
 
 	local audit_context

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -37,6 +37,11 @@
 [[ -n "${_PULSE_DISPATCH_ENGINE_LOADED:-}" ]] && return 0
 _PULSE_DISPATCH_ENGINE_LOADED=1
 
+# Resolve this module's dependencies relative to itself, not a caller-owned
+# SCRIPT_DIR. Test harnesses and other sourced callers legitimately use that
+# generic variable for their own directory (GH#27888).
+_PULSE_DISPATCH_ENGINE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # t2863: Module-level variable defaults (set -u guards).
 # These vars are normally set by pulse-wrapper.sh bootstrap and pulse-wrapper-config.sh.
 # Guard them here so dispatch engine functions survive standalone sourcing (test
@@ -99,16 +104,16 @@ fi
 
 # t2690: Source rate-limit circuit breaker (proactive dispatch pause on GraphQL exhaustion).
 # shellcheck source=pulse-rate-limit-circuit-breaker.sh
-if [[ -f "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/pulse-rate-limit-circuit-breaker.sh" ]]; then
+if [[ -f "${_PULSE_DISPATCH_ENGINE_SCRIPT_DIR}/pulse-rate-limit-circuit-breaker.sh" ]]; then
 	# shellcheck disable=SC1091
-	source "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/pulse-rate-limit-circuit-breaker.sh"
+	source "${_PULSE_DISPATCH_ENGINE_SCRIPT_DIR}/pulse-rate-limit-circuit-breaker.sh"
 fi
 
 # t2781: Source per-issue rate_limit backoff helper (graduated cooldown by failure count).
 # shellcheck source=dispatch-backoff-helper.sh
-if [[ -f "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/dispatch-backoff-helper.sh" ]]; then
+if [[ -f "${_PULSE_DISPATCH_ENGINE_SCRIPT_DIR}/dispatch-backoff-helper.sh" ]]; then
 	# shellcheck disable=SC1091
-	source "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/dispatch-backoff-helper.sh"
+	source "${_PULSE_DISPATCH_ENGINE_SCRIPT_DIR}/dispatch-backoff-helper.sh"
 fi
 
 # GH#21738: Source extracted helper sub-libraries (orchestrator + sub-library
@@ -120,14 +125,14 @@ fi
 # re-register them as new function-complexity violations under their new
 # (file, fname) identity keys).
 # shellcheck source=./pulse-dispatch-lib.sh
-# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
-source "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/pulse-dispatch-lib.sh"
+# shellcheck disable=SC1091  # sub-library resolved from this module's path
+source "${_PULSE_DISPATCH_ENGINE_SCRIPT_DIR}/pulse-dispatch-lib.sh"
 # shellcheck source=./pulse-dispatch-current-state-guardrails.sh
-# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
-source "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/pulse-dispatch-current-state-guardrails.sh"
+# shellcheck disable=SC1091  # sub-library resolved from this module's path
+source "${_PULSE_DISPATCH_ENGINE_SCRIPT_DIR}/pulse-dispatch-current-state-guardrails.sh"
 # shellcheck source=./pulse-dispatch-preflight-lib.sh
-# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
-source "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/pulse-dispatch-preflight-lib.sh"
+# shellcheck disable=SC1091  # sub-library resolved from this module's path
+source "${_PULSE_DISPATCH_ENGINE_SCRIPT_DIR}/pulse-dispatch-preflight-lib.sh"
 
 
 # t1959: Module-level variable to communicate launch failure reason to callers.

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -334,27 +334,16 @@ gh_create_issue() {
 		_rest_args+=("${_origin_label_args[@]}")
 	fi
 
-	# t2028/t2406: auto-assign interactive issues unless auto-dispatch is present.
-	local issue_output rc
+	# t2028/t2406/GH#27929: choose an eligible auto-assignee before creation,
+	# but keep durable creation independent from the best-effort assignment.
+	local issue_output rc auto_assignee="" target_repo=""
+	target_repo=$(_gh_extract_repo_from_args "$@" 2>/dev/null || true)
 	if ! _gh_wrapper_args_have_assignee "$@"; then
 		if _gh_wrapper_args_have_label "auto-dispatch" "$@"; then
 			# t2157/t2406: auto-dispatch means worker-owned; skip self-assignment.
 			print_info "[INFO] auto-dispatch label present — skipping self-assignment per t2157"
 		else
-			local auto_assignee
-			auto_assignee=$(_gh_wrapper_auto_assignee)
-			if [[ -n "$auto_assignee" ]]; then
-				issue_output=$("${_issue_cmd[@]}" --assignee "$auto_assignee") # aidevops-allow: raw-gh-wrapper
-				rc=$?
-				if [[ $rc -ne 0 ]] && _rest_should_fallback; then
-					print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-					issue_output=$(_rest_issue_create "${_rest_args[@]}" --assignee "$auto_assignee")
-					rc=$?
-				fi
-				echo "$issue_output"
-				[[ $rc -eq 0 ]] && _gh_auto_link_sub_issue "$issue_output" "$@"
-				return $rc
-			fi
+			auto_assignee=$(_gh_wrapper_auto_assignee "$target_repo")
 		fi
 	fi
 
@@ -366,7 +355,17 @@ gh_create_issue() {
 		rc=$?
 	fi
 	echo "$issue_output"
-	[[ $rc -eq 0 ]] && _gh_auto_link_sub_issue "$issue_output" "$@"
+	if [[ $rc -eq 0 ]]; then
+		if [[ -n "$auto_assignee" ]]; then
+			local issue_number="${issue_output##*/}"
+			issue_number="${issue_number%%[[:space:]]*}"
+			if [[ "$issue_number" =~ ^[0-9]+$ ]] &&
+				! gh issue edit "$issue_number" --repo "$target_repo" --add-assignee "$auto_assignee" >/dev/null 2>&1; then # aidevops-allow: raw-gh-wrapper
+				print_warning "Issue #${issue_number} was created, but automatic assignment to ${auto_assignee} failed; continuing with the durable issue."
+			fi
+		fi
+		_gh_auto_link_sub_issue "$issue_output" "$@"
+	fi
 	return $rc
 }
 

--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -311,7 +311,7 @@ _gh_wrapper_args_have_origin_label() {
 	return 1
 }
 
-# t2028: Internal — determine the auto-assignee for a newly-created issue.
+# t2028/GH#27929: determine the auto-assignee for a newly-created issue.
 # Returns empty string when the session is worker-origin, when the user
 # lookup fails, or when there is otherwise nothing to assign. Callers must
 # treat empty as "skip assignment". Non-fatal: all failure modes echo empty.
@@ -320,6 +320,7 @@ _gh_wrapper_args_have_origin_label() {
 # the direct gh_create_issue path reaches assignee-gate parity with the
 # claim-task-id.sh path.
 _gh_wrapper_auto_assignee() {
+	local repo_slug="$1"
 	local origin
 	origin=$(detect_session_origin)
 	if [[ "$origin" != "interactive" ]]; then
@@ -329,16 +330,28 @@ _gh_wrapper_auto_assignee() {
 	# to github.actor when the commit author is human. Prefer that explicit
 	# signal over `gh api user`, which would return github-actions[bot]
 	# inside a workflow run.
+	local current_user=""
 	if [[ -n "${AIDEVOPS_SESSION_USER:-}" ]]; then
-		printf '%s' "$AIDEVOPS_SESSION_USER"
-		return 0
+		current_user="$AIDEVOPS_SESSION_USER"
+	else
+		current_user=$(gh api user --jq '.login' 2>/dev/null || true)
 	fi
-	local current_user
-	current_user=$(gh api user --jq '.login' 2>/dev/null || true)
 	if [[ -z "$current_user" ]] || [[ "$current_user" == "null" ]]; then
 		return 0
 	fi
-	printf '%s' "$current_user"
+
+	# #aidevops:trust-boundary — assignment is valid only for a confirmed
+	# collaborator. Public issue creation may succeed for contributors, while
+	# assigning that contributor fails with ReplaceActorsForAssignable.
+	local permission=""
+	if [[ -z "$repo_slug" ]] || ! declare -F _gh_collaborator_permission_lookup >/dev/null; then
+		return 0
+	fi
+	_gh_collaborator_permission_lookup "$repo_slug" "$current_user" permission >/dev/null 2>&1 || return 0
+	case "$permission" in
+	admin | maintain | write | triage) printf '%s' "$current_user" ;;
+	*) return 0 ;;
+	esac
 	return 0
 }
 

--- a/.agents/scripts/stash-audit-helper.sh
+++ b/.agents/scripts/stash-audit-helper.sh
@@ -153,9 +153,11 @@ get_stash_age() {
 stash_changes_in_head() {
 	local stash_ref="$1"
 
-	# Get files changed in the stash
+	# Include the third-parent tree created by `git stash push -u`. The default
+	# inventory omits untracked-only files and can misclassify unique data as an
+	# empty, safe-to-drop stash (GH#27794).
 	local stash_files
-	stash_files=$(git stash show --name-only "$stash_ref" 2>/dev/null || echo "")
+	stash_files=$(git stash show --name-only --include-untracked "$stash_ref" 2>/dev/null || echo "")
 
 	if [[ -z "$stash_files" ]]; then
 		# Empty stash, safe to drop
@@ -166,15 +168,18 @@ stash_changes_in_head() {
 	while IFS= read -r file; do
 		[[ -z "$file" ]] && continue
 
-		# Get file content from stash and HEAD
-		local stash_content
-		local head_content
+		# Compare blob identities so binary content is safe. Untracked files live
+		# only under stash^3; tracked files remain in the stash commit tree.
+		local stash_blob=""
+		local head_blob=""
+		stash_blob=$(git rev-parse "${stash_ref}:${file}" 2>/dev/null || true)
+		if [[ -z "$stash_blob" ]]; then
+			stash_blob=$(git rev-parse "${stash_ref}^3:${file}" 2>/dev/null || true)
+		fi
+		head_blob=$(git rev-parse "HEAD:${file}" 2>/dev/null || true)
 
-		stash_content=$(git show "$stash_ref:$file" 2>/dev/null || echo "__STASH_FILE_NOT_FOUND__")
-		head_content=$(git show "HEAD:$file" 2>/dev/null || echo "__HEAD_FILE_NOT_FOUND__")
-
-		# If content differs, stash has unique changes
-		if [[ "$stash_content" != "$head_content" ]]; then
+		# Missing or different HEAD content means the stash contains unique data.
+		if [[ -z "$stash_blob" || "$stash_blob" != "$head_blob" ]]; then
 			return 1
 		fi
 	done <<<"$stash_files"

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -371,6 +371,34 @@ test_has_open_pr_blocks_approved_mergeable_sibling() {
 	return 0
 }
 
+test_has_open_pr_allows_healthy_planning_only_sibling() {
+	set_gh_fixtures 'marcusquinn/aidevops|open|#23257|[{"number":23299,"title":"Publish planning brief","body":"For #23257. Planning only.","isDraft":false,"reviewDecision":"APPROVED","mergeStateStatus":"CLEAN","changedFiles":2,"files":[{"path":"TODO.md"},{"path":"todo/tasks/t23257-brief.md"}]}]'
+
+	if "$HELPER_SCRIPT" has-open-pr 23257 marcusquinn/aidevops 't3507: implement planned work'; then
+		print_result "has-open-pr allows dispatch past healthy planning-only sibling" 1 \
+			"Expected complete TODO.md/todo/** file scope to remain non-owning"
+		return 0
+	fi
+
+	print_result "has-open-pr allows dispatch past healthy planning-only sibling" 0
+	return 0
+}
+
+test_has_open_pr_blocks_mixed_or_incomplete_sibling_scope() {
+	set_gh_fixtures 'marcusquinn/aidevops|open|#23258|[{"number":23300,"title":"Mixed implementation","body":"For #23258.","isDraft":false,"reviewDecision":"APPROVED","mergeStateStatus":"CLEAN","changedFiles":2,"files":[{"path":"TODO.md"},{"path":".agents/scripts/fix.sh"}]},{"number":23301,"title":"Incomplete metadata","body":"For #23258.","isDraft":false,"reviewDecision":"APPROVED","mergeStateStatus":"CLEAN","changedFiles":2,"files":[{"path":"TODO.md"}]}]'
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" has-open-pr 23258 marcusquinn/aidevops 't3508: preserve implementation ownership'); then
+		if [[ "$output" == *"open PR #23300 is approved or mergeable"* ]]; then
+			print_result "has-open-pr blocks mixed implementation and incomplete scope" 0
+			return 0
+		fi
+	fi
+
+	print_result "has-open-pr blocks mixed implementation and incomplete scope" 1 "Unexpected output: ${output}"
+	return 0
+}
+
 test_has_open_pr_blocks_approved_sibling_without_merge_state() {
 	# Approved siblings can briefly have UNKNOWN merge state while GitHub computes
 	# mergeability. They should still suppress redispatch unless explicitly
@@ -609,6 +637,8 @@ main() {
 	test_has_open_pr_ignores_open_body_planning_for_reference
 	test_has_open_pr_requires_open_close_keyword_for_our_issue
 	test_has_open_pr_blocks_approved_mergeable_sibling
+	test_has_open_pr_allows_healthy_planning_only_sibling
+	test_has_open_pr_blocks_mixed_or_incomplete_sibling_scope
 	test_has_open_pr_blocks_approved_sibling_without_merge_state
 	test_has_open_pr_blocks_mergeable_sibling_without_approval
 	test_has_open_pr_blocks_refs_colon_healthy_sibling

--- a/.agents/scripts/tests/test-full-loop-wip-finalization.sh
+++ b/.agents/scripts/tests/test-full-loop-wip-finalization.sh
@@ -71,8 +71,10 @@ make_repo() {
 		git add tracked.txt
 		git commit -qm 'chore: initial fixture'
 		git branch -M develop
+		git remote add origin .
 		git update-ref refs/remotes/origin/develop HEAD
 		git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+		git switch -qc feature/test
 	) || return 1
 	return 0
 }
@@ -207,6 +209,36 @@ test_wip_final_message_is_rejected() {
 	return 0
 }
 
+test_base_drift_fails_closed_without_reverting_upstream() {
+	local repo_dir="${TEST_ROOT}/base-drift"
+	make_repo "$repo_dir" || return 1
+	commit_change "$repo_dir" 'checkpoint' 'wip: preserve checkpoint' || return 1
+	local original_head=""
+	original_head=$(git -C "$repo_dir" rev-parse HEAD)
+
+	(
+		cd "$repo_dir" || exit 1
+		git switch -q --detach origin/develop
+		printf 'upstream\n' >upstream.txt
+		git add upstream.txt
+		git commit -qm 'fix: concurrent upstream change'
+		git branch -f develop HEAD
+		git switch -q --detach "$original_head"
+		_finalize_wip_history 'fix: preserve concurrent upstream change'
+	) >/dev/null 2>&1
+	local rc=$?
+	local final_head=""
+	final_head=$(git -C "$repo_dir" rev-parse HEAD)
+	if [[ "$rc" -ne 0 && "$final_head" == "$original_head" ]] &&
+		git -C "$repo_dir" show origin/develop:upstream.txt >/dev/null 2>&1; then
+		print_result 'concurrent base drift aborts without staging upstream reversions' 0
+	else
+		print_result 'concurrent base drift aborts without staging upstream reversions' 1 \
+			"rc=${rc}, final_head=${final_head}, original_head=${original_head}"
+	fi
+	return 0
+}
+
 test_orchestrator_finalizes_before_validation() {
 	local orchestrator="${SCRIPT_DIR}/full-loop-helper.sh"
 	local stage_line="" finalize_line="" validators_line=""
@@ -232,11 +264,12 @@ test_buried_wip_squashes_branch_range
 test_no_wip_preserves_history
 test_commit_hook_failure_restores_tip
 test_wip_final_message_is_rejected
+test_base_drift_fails_closed_without_reverting_upstream
 test_orchestrator_finalizes_before_validation
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
-if [[ "$TESTS_RUN" -ne 6 ]]; then
-	printf '%sFAIL%s expected 6 tests to execute\n' "$TEST_RED" "$TEST_RESET"
+if [[ "$TESTS_RUN" -ne 7 ]]; then
+	printf '%sFAIL%s expected 7 tests to execute\n' "$TEST_RED" "$TEST_RESET"
 	exit 1
 fi
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1

--- a/.agents/scripts/tests/test-gh-create-issue-auto-dispatch-skip.sh
+++ b/.agents/scripts/tests/test-gh-create-issue-auto-dispatch-skip.sh
@@ -95,6 +95,14 @@ export AIDEVOPS_SESSION_USER=testuser
 # shellcheck source=../shared-constants.sh
 source "${SCRIPTS_DIR}/shared-constants.sh" >/dev/null 2>&1 || true
 
+_gh_collaborator_permission_lookup() {
+	local _repo_slug="$1"
+	local _username="$2"
+	local out_var="$3"
+	printf -v "$out_var" '%s' "write"
+	return 0
+}
+
 # =============================================================================
 # Post-source stubs.
 #
@@ -115,6 +123,9 @@ gh() {
 	if [[ "$1" == "issue" && "$2" == "create" ]]; then
 		printf 'https://github.com/owner/repo/issues/9991\n'
 		return 0
+	fi
+	if [[ "$1" == "issue" && "$2" == "edit" && "${GH_EDIT_FAIL:-0}" == "1" ]]; then
+		return 1
 	fi
 	return 0
 }
@@ -147,7 +158,7 @@ else
 fi
 
 # =============================================================================
-# Test 2 — auto-dispatch absent → --assignee IS passed (regression guard)
+# Test 2 — auto-dispatch absent → post-create assignment is attempted
 # =============================================================================
 : >"$GH_CALLS"
 gh_create_issue \
@@ -157,11 +168,12 @@ gh_create_issue \
 	--label "bug,tier:standard" >/dev/null 2>&1 || true
 
 # Check whole file: --assignee may appear on a continuation line due to sig footer newlines
-if grep -q -- "--assignee" "$GH_CALLS" 2>/dev/null; then
-	pass "no auto-dispatch → --assignee IS passed"
+if grep -q -- "issue edit 9991 --repo owner/repo --add-assignee testuser" "$GH_CALLS" 2>/dev/null &&
+	! grep -q -- "issue create.*--assignee" "$GH_CALLS" 2>/dev/null; then
+	pass "no auto-dispatch → durable create then best-effort assignment"
 else
-	fail "no auto-dispatch → --assignee IS passed" \
-		"expected --assignee in gh call for interactive non-auto-dispatch issue"
+	fail "no auto-dispatch → durable create then best-effort assignment" \
+		"expected issue edit --add-assignee after an unassigned create"
 fi
 
 # =============================================================================
@@ -216,6 +228,50 @@ if grep -q -- "--assignee explicit-user" "$GH_CALLS" 2>/dev/null; then
 else
 	fail "explicit --assignee with auto-dispatch → caller assignee forwarded" \
 		"expected --assignee explicit-user in gh call"
+fi
+
+# =============================================================================
+# Test 6 — failed best-effort assignment preserves durable creation success
+# =============================================================================
+: >"$GH_CALLS"
+issue_output=""
+issue_rc=0
+issue_output=$(GH_EDIT_FAIL=1 gh_create_issue \
+	--repo "owner/repo" \
+	--title "t9996: durable issue" \
+	--body "test body" \
+	--label "bug") || issue_rc=$?
+
+if [[ "$issue_rc" -eq 0 && "$issue_output" == *"/issues/9991"* ]] &&
+	grep -q -- "issue edit 9991 --repo owner/repo --add-assignee testuser" "$GH_CALLS" 2>/dev/null; then
+	pass "assignment failure preserves created issue URL and success status"
+else
+	fail "assignment failure preserves created issue URL and success status" \
+		"rc=${issue_rc}, output=${issue_output}"
+fi
+
+# =============================================================================
+# Test 7 — confirmed non-collaborator creates without assignment mutation
+# =============================================================================
+_gh_collaborator_permission_lookup() {
+	local _repo_slug="$1"
+	local _username="$2"
+	local out_var="$3"
+	printf -v "$out_var" '%s' "none"
+	return 0
+}
+: >"$GH_CALLS"
+gh_create_issue \
+	--repo "owner/repo" \
+	--title "t9997: contributor issue" \
+	--body "test body" \
+	--label "bug" >/dev/null 2>&1 || true
+
+if ! grep -q -- "issue edit .*--add-assignee" "$GH_CALLS" 2>/dev/null; then
+	pass "non-collaborator creates durable issue without assignment"
+else
+	fail "non-collaborator creates durable issue without assignment" \
+		"unexpected assignment call: $(<"$GH_CALLS")"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -288,6 +288,31 @@ if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
 else
 	_fail "gh pr create injection" "argv: $argv"
 fi
+if [[ "$argv" == *$'--label\norigin:interactive'* ]]; then
+	_pass "interactive raw pr create gets one origin label"
+else
+	_fail "interactive raw pr create origin normalization" "argv: $argv"
+fi
+
+_reset_log
+AIDEVOPS_HEADLESS=1 AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE=owner/repo \
+	"$SHIM_RUN" pr create --repo owner/repo --title "worker" --body "For #25901" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *$'--label\norigin:worker'* ]] && [[ "$argv" != *"origin:interactive"* ]]; then
+	_pass "headless raw pr create gets worker origin label"
+else
+	_fail "headless raw pr create origin normalization" "argv: $argv"
+fi
+
+_reset_log
+"$SHIM_RUN" pr create --repo owner/repo --title "explicit" --label "origin:worker" --body "For #25901" 2>/dev/null
+argv=$(_read_argv)
+origin_count=$(printf '%s\n' "$argv" | grep -c '^origin:' || true)
+if [[ "$origin_count" -eq 1 ]] && [[ "$argv" == *"origin:worker"* ]]; then
+	_pass "explicit raw pr origin remains immutable and singular"
+else
+	_fail "explicit raw pr origin normalization" "count=${origin_count} argv: $argv"
+fi
 
 echo ""
 echo "Test 6a: issue-first repos block PR creation without linked issue"

--- a/.agents/scripts/tests/test-planning-commit-helper-next-id.sh
+++ b/.agents/scripts/tests/test-planning-commit-helper-next-id.sh
@@ -20,11 +20,23 @@ output=$("$PLANNING_HELPER" next-id \
 	--title "Run Phase 3 kickoff adjustment for post-t394 roadmap" \
 	--labels "bug,auto-dispatch" \
 	--description "Multi word description value" \
+	--parent-issue 123 \
 	--dry-run 2>&1)
 rc=$?
 
 if [[ $rc -ne 0 ]]; then
 	printf 'FAIL: expected next-id dry-run to succeed, rc=%s\n%s\n' "$rc" "$output" >&2
+	exit 1
+fi
+
+trace=$(bash -x "$PLANNING_HELPER" next-id --title "Child task" --parent-issue 123 --dry-run 2>&1)
+if [[ "$trace" != *"--parent-issue 123"* ]]; then
+	printf 'FAIL: expected --parent-issue to reach claim-task-id.sh\n%s\n' "$trace" >&2
+	exit 1
+fi
+
+if "$PLANNING_HELPER" next-id --title "Invalid child" --parent-issue 0 --dry-run >/dev/null 2>&1; then
+	printf 'FAIL: expected non-positive --parent-issue to fail before allocation\n' >&2
 	exit 1
 fi
 

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -15,6 +15,13 @@ TEST_ROOT=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PULSE_CLEANUP="${SCRIPT_DIR}/../pulse-cleanup.sh"
 
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
+export -f git
+
 print_result() {
 	local name="$1"
 	local rc="$2"
@@ -271,7 +278,7 @@ test_closed_issue_dirty_worktree_stashes_and_preserves_branch() {
 	return 0
 }
 
-test_terminal_worktree_bypasses_stale_owner_signal() {
+test_terminal_worktree_respects_live_owner_signal() {
 	local repo_dir="${TEST_ROOT}/repo-terminal-owner"
 	local wt_path="${TEST_ROOT}/worker-wt-terminal-owner"
 	local branch_name="feature/auto-20260507-190808-gh23083"
@@ -298,11 +305,10 @@ test_terminal_worktree_bypasses_stale_owner_signal() {
 	local cleanup_rc=$?
 
 	local rc=0
-	[[ "$cleanup_rc" -eq 0 ]] || rc=1
-	[[ ! -d "$wt_path" ]] || rc=1
-	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
-	grep -q 'recovery_path=branch-preserved-closed-issue' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
-	print_result "terminal worktree bypasses stale owner signal" "$rc" \
+	[[ "$cleanup_rc" -ne 0 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q "worktree-skipped: ${wt_path} — owned-skip" "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "terminal worktree respects live owner signal" "$rc" \
 		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
 	return 0
 }
@@ -677,7 +683,7 @@ test_closed_issue_local_commit_no_pr_removes_before_age_threshold
 test_closed_pr_reference_local_commit_no_pr_removes_before_age_threshold
 test_merged_branch_pr_removes_before_age_threshold
 test_closed_issue_dirty_worktree_stashes_and_preserves_branch
-test_terminal_worktree_bypasses_stale_owner_signal
+test_terminal_worktree_respects_live_owner_signal
 test_fix_numeric_closed_issue_worktree_archives
 test_stale_local_commit_no_pr_removes_worktree_preserves_branch
 test_stale_detached_review_cruft_removes_without_branch

--- a/.agents/scripts/tests/test-pulse-consolidation-phase2.sh
+++ b/.agents/scripts/tests/test-pulse-consolidation-phase2.sh
@@ -30,8 +30,8 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${TEST_SCRIPT_DIR}/../../.." && pwd)" || exit 1
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -121,14 +121,19 @@ setup_test_env() {
 	# Prevent loading the rate-limit circuit breaker (it has its own deps).
 	export _PULSE_RATE_LIMIT_CB_LOADED=1
 
-	# Clear the engine load guard so the module re-evaluates on source.
-	unset _PULSE_DISPATCH_ENGINE_LOADED
+	# Source once per harness process. Re-sourcing dependency modules that own
+	# readonly arrays is invalid; their functions use the per-test HOME/LOGFILE.
 
 	# shellcheck disable=SC1091
 	source "${REPO_ROOT}/.agents/scripts/pulse-dispatch-engine.sh" || {
 		printf 'ERROR: failed to source pulse-dispatch-engine.sh\n' >&2
 		return 1
 	}
+	if ! declare -F _dispatch_begin_benign_blocks_cycle >/dev/null ||
+		[[ ! -f "${_PULSE_DISPATCH_ENGINE_SCRIPT_DIR}/pulse-dispatch-lib.sh" ]]; then
+		printf 'ERROR: dispatch engine dependencies did not load from %s\n' "$_PULSE_DISPATCH_ENGINE_SCRIPT_DIR" >&2
+		return 1
+	fi
 
 	# Re-declare stubs AFTER source to override the module's definitions.
 	dispatch_max() {
@@ -140,6 +145,7 @@ setup_test_env() {
 	count_active_workers() { printf '%s\n' "${_STUB_ACTIVE_WORKERS:-0}"; return 0; }
 	get_max_workers_target() { printf '%s\n' "${_STUB_MAX_WORKERS:-3}"; return 0; }
 	_adaptive_launch_settle_wait() { return 0; }
+	_dispatch_min_worker_floor_refill() { return 0; }
 
 	_STUB_ACTIVE_WORKERS=0
 	_STUB_MAX_WORKERS=3
@@ -154,7 +160,6 @@ teardown_test_env() {
 	TEST_ROOT=""
 	LOGFILE=""
 	_DISPATCH_COUNT_FILE=""
-	unset _PULSE_DISPATCH_ENGINE_LOADED _PULSE_RATE_LIMIT_CB_LOADED
 	unset _STUB_ACTIVE_WORKERS _STUB_MAX_WORKERS
 	return 0
 }
@@ -198,7 +203,7 @@ test_phase2_fires_when_sentinel_and_slots_available() {
 	fi
 
 	# Phase 2 log line must appear.
-	if ! grep -q "fill floor Phase 2.*re-enumerating" "$LOGFILE" 2>/dev/null; then
+	if ! grep -q "Dispatch_max Phase 2.*re-enumerating" "$LOGFILE" 2>/dev/null; then
 		failures=$((failures + 1))
 		failmsg="${failmsg} | Phase 2 log line not found"
 	fi
@@ -236,7 +241,7 @@ test_phase2_skipped_when_no_sentinel() {
 	fi
 
 	# No Phase 2 log line.
-	if grep -q "fill floor Phase 2" "$LOGFILE" 2>/dev/null; then
+	if grep -q "Dispatch_max Phase 2" "$LOGFILE" 2>/dev/null; then
 		failures=$((failures + 1))
 		failmsg="${failmsg} | unexpected Phase 2 log line found"
 	fi

--- a/.agents/scripts/tests/test-stash-audit.sh
+++ b/.agents/scripts/tests/test-stash-audit.sh
@@ -17,6 +17,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 STASH_HELPER="${SCRIPT_DIR}/../stash-audit-helper.sh"
 
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
+export -f git
+
+# Source the helper so the test-local /usr/bin/git wrapper also applies to
+# helper calls under runtimes that install a canonical-repo git guard.
+# shellcheck source=../stash-audit-helper.sh
+source "$STASH_HELPER"
+
 # Colors
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -127,7 +139,7 @@ test_safe_to_drop() {
 
 	# Audit should classify as safe-to-drop
 	local output
-	output=$("$STASH_HELPER" audit --repo "$test_repo" 2>&1)
+	output=$(cmd_audit "$test_repo" 2>&1)
 
 	local result=1
 	if echo "$output" | grep -q "safe-to-drop"; then
@@ -163,7 +175,7 @@ test_needs_review() {
 
 	# Audit should classify as needs-review
 	local output
-	output=$("$STASH_HELPER" audit --repo "$test_repo" 2>&1)
+	output=$(cmd_audit "$test_repo" 2>&1)
 
 	local result=1
 	if echo "$output" | grep -q "needs-review"; then
@@ -172,6 +184,32 @@ test_needs_review() {
 
 	cleanup_test_repo "$test_repo"
 
+	return $result
+}
+
+#######################################
+# Test: unique untracked-only stash is preserved
+# Returns: 0 on success, 1 on failure
+#######################################
+test_untracked_only_stash_is_preserved() {
+	local test_repo
+	test_repo=$(setup_test_repo)
+	cd "$test_repo" || return 1
+
+	printf '%s\n' "unique untracked content" >untracked-only.txt
+	git stash push -q -u -m "Untracked-only stash"
+
+	local audit_output=""
+	audit_output=$(cmd_audit "$test_repo" 2>&1)
+	cmd_auto_clean "$test_repo" >/dev/null 2>&1
+
+	local result=1
+	if [[ "$audit_output" == *"needs-review"* ]] &&
+		git -C "$test_repo" stash list | grep -q "Untracked-only stash"; then
+		result=0
+	fi
+
+	cleanup_test_repo "$test_repo"
 	return $result
 }
 
@@ -194,7 +232,7 @@ test_list() {
 
 	# List should show the stash
 	local output
-	output=$("$STASH_HELPER" list --repo "$test_repo" 2>&1)
+	output=$(cmd_list "$test_repo" 2>&1)
 
 	local result=1
 	if echo "$output" | grep -q "Test stash"; then
@@ -229,7 +267,7 @@ test_auto_clean() {
 	git commit -q -m "Apply change"
 
 	# Auto-clean should drop the stash
-	"$STASH_HELPER" auto-clean --repo "$test_repo" >/dev/null 2>&1
+	cmd_auto_clean "$test_repo" >/dev/null 2>&1
 
 	# Verify stash was dropped
 	local stash_count
@@ -260,7 +298,7 @@ test_no_stashes() {
 
 	# Audit with no stashes should succeed
 	local output
-	output=$("$STASH_HELPER" audit --repo "$test_repo" 2>&1)
+	output=$(cmd_audit "$test_repo" 2>&1)
 
 	local result=1
 	if echo "$output" | grep -q "No stashes found"; then
@@ -281,7 +319,7 @@ test_no_stashes() {
 #######################################
 test_help() {
 	local output
-	output=$("$STASH_HELPER" help 2>&1)
+	output=$(show_help 2>&1)
 
 	local result=1
 	if echo "$output" | grep -q "Usage:"; then
@@ -300,7 +338,7 @@ test_help() {
 #######################################
 test_invalid_repo() {
 	local output
-	output=$("$STASH_HELPER" audit --repo /nonexistent/path 2>&1 || true)
+	output=$(cmd_audit /nonexistent/path 2>&1 || true)
 
 	local result=1
 	if echo "$output" | grep -q "does not exist"; then
@@ -333,6 +371,9 @@ main() {
 
 	test_needs_review
 	print_result "needs-review classification" $?
+
+	test_untracked_only_stash_is_preserved
+	print_result "untracked-only stash remains needs-review and survives auto-clean" $?
 
 	test_list
 	print_result "list command" $?

--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -21,10 +21,13 @@ Always assign to a variable first — never interpolate directly (shell injectio
 
 ```bash
 TASK_TITLE="<sanitized title from user input>"
+# For a child task, resolve the parent's durable `ref:GH#NNN` first. Fail
+# closed if the parent has no numeric GitHub ref; do not file an orphan child.
+PARENT_ISSUE_ARGS=() # or: PARENT_ISSUE_ARGS=(--parent-issue "$PARENT_ISSUE")
 # Via planning-commit-helper.sh wrapper (preferred)
-output=$(~/.aidevops/agents/scripts/planning-commit-helper.sh next-id --title "$TASK_TITLE")
+output=$(~/.aidevops/agents/scripts/planning-commit-helper.sh next-id --title "$TASK_TITLE" "${PARENT_ISSUE_ARGS[@]}")
 # Or directly
-output=$(~/.aidevops/agents/scripts/claim-task-id.sh --title "$TASK_TITLE" --repo-path "$(git rev-parse --show-toplevel)")
+output=$(~/.aidevops/agents/scripts/claim-task-id.sh --title "$TASK_TITLE" --repo-path "$(git rev-parse --show-toplevel)" "${PARENT_ISSUE_ARGS[@]}")
 ```
 
 ```bash
@@ -99,6 +102,9 @@ Fill in the `### Complexity Impact` subsection in the brief (see `templates/brie
 **Session ID:** `$OPENCODE_SESSION_ID` / `$CLAUDE_SESSION_ID`, or `{app}:unknown-{ISO-date}` if unavailable.
 
 **Subtasks:** MUST reference parent: `**Parent task:** {parent_id} — see [todo/tasks/{parent_id}-brief.md]`. Inherit context; add only subtask-specific details.
+Resolve the parent task's durable `ref:GH#NNN` before Step 1 and pass its numeric
+issue number through `--parent-issue N`. If the ref is absent, offline, or
+ambiguous, stop with actionable diagnostics rather than allocating an orphan.
 
 ### Step 3.2: Decide Whether to Seed a Draft PR
 


### PR DESCRIPTION
## Summary

Harden dispatch ownership, stash auditing, child-task allocation, PR origin labeling, cleanup ownership, issue assignment, pulse module loading, and WIP finalization across the consolidated batch.

## Files Changed

- Dispatch and GitHub wrapper hardening under `.agents/scripts/`
- Focused regression coverage under `.agents/scripts/tests/`
- Child-task workflow guidance in `.agents/workflows/new-task.md`

## Runtime Testing

- **Risk level:** Medium (dispatch, issue creation, cleanup, and history-rewrite safeguards)
- **Verification:** All focused regression suites passed (127 assertions/tests total).
- **Quality:** ShellCheck passed on every changed shell file, `git diff --check` passed, and `.agents/scripts/linters-local.sh` completed successfully.

## Decisions

- Treat a healthy sibling PR as planning-only only when complete changed-file evidence is limited to `TODO.md` and `todo/**`.
- Fail closed when ownership, stash content, parent linkage, or current base ancestry cannot be proven safe.
- Keep durable issue creation successful when a permission-checked, best-effort assignment fails afterward.

Resolves #27789
Resolves #27794
Resolves #27796
Resolves #27888
Resolves #27925
Resolves #27928
Resolves #27929
Resolves #27930

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.128 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 32m and 631,519 tokens on this with the user in an interactive session.
