### PR TITLE
GH#27935: preserve tracked project config during updates

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
@@ -26,6 +26,15 @@ fi
 
 _AIDEVOPS_UPDATE_TRUE=true
 
+# Tracked project config is repository-owned policy. Framework updates may read
+# it to refresh local registration metadata, but must not create working-tree
+# changes that block the repository's normal git workflow.
+_update_project_config_is_tracked() {
+	local repo="$1"
+	git -C "$repo" ls-files --error-unmatch -- .aidevops.json >/dev/null 2>&1
+	return $?
+}
+
 _update_fresh_install() {
 	print_warning "Repository not found at the active CLI tree, updating from a clean temporary checkout..."
 	local tmp_checkout
@@ -60,7 +69,7 @@ _update_sync_projects() {
 		print_success "All registered projects are up to date"
 		return 0
 	fi
-	local synced=0 skipped=0 failed=0
+	local synced=0 skipped=0 failed=0 preserved=0
 	for repo in "${repos_needing_upgrade[@]}"; do
 		[[ ! -f "$repo/.aidevops.json" ]] && {
 			skipped=$((skipped + 1))
@@ -68,21 +77,29 @@ _update_sync_projects() {
 		}
 		local did_sync=false
 		if command -v jq &>/dev/null; then
-			local temp_file="${repo}/.aidevops.json.tmp"
-			if jq --arg version "$current_ver" '.version = $version' "$repo/.aidevops.json" >"$temp_file" 2>/dev/null && [[ -s "$temp_file" ]]; then
-				mv "$temp_file" "$repo/.aidevops.json"
-				local features
-				features=$(jq -r '[.features | to_entries[] | select(.value == true) | .key] | join(",")' "$repo/.aidevops.json" 2>/dev/null || echo "")
-				register_repo "$repo" "$current_ver" "$features"
-				did_sync=true
-			else rm -f "$temp_file"; fi
+			local features
+			features=$(jq -r '[.features | to_entries[] | select(.value == true) | .key] | join(",")' "$repo/.aidevops.json" 2>/dev/null || echo "")
+			if _update_project_config_is_tracked "$repo"; then
+				if register_repo "$repo" "$current_ver" "$features"; then
+					did_sync=true
+					preserved=$((preserved + 1))
+				fi
+			else
+				local temp_file="${repo}/.aidevops.json.tmp"
+				if jq --arg version "$current_ver" '.version = $version' "$repo/.aidevops.json" >"$temp_file" 2>/dev/null && [[ -s "$temp_file" ]]; then
+					mv "$temp_file" "$repo/.aidevops.json"
+					register_repo "$repo" "$current_ver" "$features"
+					did_sync=true
+				else rm -f "$temp_file"; fi
+			fi
 		fi
-		if [[ "$did_sync" != "$_AIDEVOPS_UPDATE_TRUE" ]]; then
+		if [[ "$did_sync" != "$_AIDEVOPS_UPDATE_TRUE" ]] && ! _update_project_config_is_tracked "$repo"; then
 			sed -i '' "s/\"version\": *\"[^\"]*\"/\"version\": \"$current_ver\"/" "$repo/.aidevops.json" 2>/dev/null && did_sync=true
 		fi
 		[[ "$did_sync" == "$_AIDEVOPS_UPDATE_TRUE" ]] && synced=$((synced + 1)) || failed=$((failed + 1))
 	done
 	[[ $synced -gt 0 ]] && print_success "Synced $synced project(s) to v$current_ver"
+	[[ $preserved -gt 0 ]] && print_info "Preserved $preserved tracked project config(s); updated registration metadata only"
 	[[ $skipped -gt 0 ]] && print_info "Skipped $skipped uninitialized project(s) (run 'aidevops init' in each to enable)"
 	[[ $failed -gt 0 ]] && print_warning "$failed project(s) failed to sync (jq missing or write error)"
 	return 0
@@ -131,7 +148,7 @@ _update_sync_agent_source_repos() {
 		fi
 		if seed_agent_source_repo_templates "$repo"; then
 			synced=$((synced + 1))
-			if [[ -f "$repo/.aidevops.json" ]] && command -v jq &>/dev/null; then
+			if [[ -f "$repo/.aidevops.json" ]] && command -v jq &>/dev/null && ! _update_project_config_is_tracked "$repo"; then
 				local temp_file="${repo}/.aidevops.json.tmp"
 				jq --arg version "$current_ver" '.version = $version | .agent_source = true' "$repo/.aidevops.json" >"$temp_file" 2>/dev/null && mv "$temp_file" "$repo/.aidevops.json" || rm -f "$temp_file"
 			fi

--- a/.agents/scripts/tests/test-update-project-config-safety.sh
+++ b/.agents/scripts/tests/test-update-project-config-safety.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+passed=0
+failed=0
+
+pass() {
+	local name="$1"
+	printf 'PASS: %s\n' "$name"
+	passed=$((passed + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="$2"
+	printf 'FAIL: %s — %s\n' "$name" "$detail" >&2
+	failed=$((failed + 1))
+	return 0
+}
+
+assert_equal() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected=${expected} actual=${actual}"
+	fi
+	return 0
+}
+
+make_repo() {
+	local repo="$1"
+	local tracked="$2"
+	mkdir -p "$repo"
+	/usr/bin/git -C "$repo" init -q -b main
+	/usr/bin/git -C "$repo" config user.email test@example.invalid
+	/usr/bin/git -C "$repo" config user.name Test
+	/usr/bin/git -C "$repo" config commit.gpgsign false
+	printf '%s\n' '{"version":"0.0.1","features":{"planning":true}}' >"$repo/.aidevops.json"
+	if [[ "$tracked" == "true" ]]; then
+		/usr/bin/git -C "$repo" add .aidevops.json
+	else
+		printf '%s\n' '.aidevops.json' >"$repo/.gitignore"
+		/usr/bin/git -C "$repo" add .gitignore
+	fi
+	/usr/bin/git -C "$repo" commit -qm fixture
+	return 0
+}
+
+export HOME="${TEST_ROOT}/home"
+INSTALL_DIR="$REPO_ROOT"
+AGENTS_DIR="$REPO_ROOT/.agents"
+CONFIG_DIR="${HOME}/.config/aidevops"
+REPOS_FILE="${CONFIG_DIR}/repos.json"
+mkdir -p "$CONFIG_DIR"
+
+print_header() { return 0; }
+print_info() { return 0; }
+print_warning() { return 0; }
+print_success() { return 0; }
+get_version() {
+	printf '9.9.9\n'
+	return 0
+}
+
+# shellcheck source=../aidevops-cli/aidevops-repos-lib.sh
+source "$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh"
+# shellcheck source=../aidevops-cli/aidevops-update-lib.sh
+source "$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
+
+_repo_registration_maintainer() {
+	printf '\n'
+	return 0
+}
+seed_agent_source_repo_templates() { return 0; }
+
+tracked_repo="${TEST_ROOT}/tracked"
+local_repo="${TEST_ROOT}/local"
+make_repo "$tracked_repo" true
+make_repo "$local_repo" false
+tracked_repo="$(cd "$tracked_repo" && pwd -P)"
+local_repo="$(cd "$local_repo" && pwd -P)"
+
+jq -n --arg tracked "$tracked_repo" --arg local "$local_repo" '{
+	initialized_repos: [
+		{path: $tracked, version: "0.0.1", features: ["planning"], agent_source: true},
+		{path: $local, version: "0.0.1", features: ["planning"]}
+	],
+	git_parent_dirs: []
+}' >"$REPOS_FILE"
+
+get_agent_source_repos() {
+	printf '%s\n' "$tracked_repo"
+	return 0
+}
+
+tracked_before=$(cksum <"$tracked_repo/.aidevops.json")
+_update_sync_projects false 9.9.9
+tracked_after=$(cksum <"$tracked_repo/.aidevops.json")
+
+assert_equal "tracked config remains byte-identical" "$tracked_before" "$tracked_after"
+assert_equal "tracked repository remains clean" "" "$(/usr/bin/git -C "$tracked_repo" status --porcelain)"
+assert_equal "tracked config does not gain agent-source metadata" "false" "$(jq -r 'has("agent_source")' "$tracked_repo/.aidevops.json")"
+assert_equal "tracked registration advances" "9.9.9" "$(jq -r --arg path "$tracked_repo" '.initialized_repos[] | select(.path == $path) | .version' "$REPOS_FILE")"
+assert_equal "tracked registration preserves features" "planning" "$(jq -r --arg path "$tracked_repo" '.initialized_repos[] | select(.path == $path) | .features | join(",")' "$REPOS_FILE")"
+assert_equal "local config version advances" "9.9.9" "$(jq -r '.version' "$local_repo/.aidevops.json")"
+assert_equal "local registration advances" "9.9.9" "$(jq -r --arg path "$local_repo" '.initialized_repos[] | select(.path == $path) | .version' "$REPOS_FILE")"
+assert_equal "local repository remains clean" "" "$(/usr/bin/git -C "$local_repo" status --porcelain)"
+
+printf '\nRan %d tests, %d failed.\n' "$((passed + failed))" "$failed"
+[[ "$failed" -eq 0 ]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- preserve tracked project configuration during framework updates (#27935)
+
 ## [3.32.129] - 2026-07-16
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Treat tracked `.aidevops.json` files as repository-owned policy during framework updates.
- Refresh central registration metadata without rewriting tracked project configuration.
- Preserve existing updates for ignored/local configuration and cover agent-source synchronization.

## Verification

- `.agents/scripts/linters-local.sh`
- `bash .agents/scripts/tests/test-update-project-config-safety.sh`
- `bash .agents/scripts/tests/test-agent-source-init-update.sh`

Resolves #27935

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.129 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 3h 59m and 1,053,462 tokens on this with the user in an interactive session.