### PR TITLE
GH#27936: prevent tracked local config from dirtying checkouts

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -964,6 +964,26 @@ _init_run_workflow() {
 	return 0
 }
 
+_init_prepare_project_config() {
+	local config_file="$1"
+	local aidevops_version="$2"
+	if _project_config_is_tracked "$project_root"; then
+		config_migration_deferred=true
+		if ! _project_config_migrate_linked_worktree "$project_root"; then
+			_project_config_write_migration_plan "$project_root" || print_warning "Could not write tracked config repair plan"
+		fi
+		print_info "Preserved tracked .aidevops.json byte-for-byte during migration"
+		return 0
+	fi
+	_init_write_project_config "$config_file" "$aidevops_version" "$init_scope" "$has_interface" "$is_agent_source" \
+		"$enable_planning" "$enable_git_workflow" "$enable_code_quality" "$enable_time_tracking" \
+		"$enable_database" "$enable_beads" "$enable_sops" "$enable_security" || {
+		print_error "Failed to write .aidevops.json"
+		return 1
+	}
+	return 0
+}
+
 _init_config_and_agents() {
 
 	# Create .aidevops.json config
@@ -973,20 +993,7 @@ _init_config_and_agents() {
 
 	print_info "Creating or refreshing .aidevops.json..."
 	local config_migration_deferred=false
-	if _project_config_is_tracked "$project_root"; then
-		config_migration_deferred=true
-		if ! _project_config_migrate_linked_worktree "$project_root"; then
-			_project_config_write_migration_plan "$project_root" || print_warning "Could not write tracked config repair plan"
-		fi
-		print_info "Preserved tracked .aidevops.json byte-for-byte during migration"
-	else
-		_init_write_project_config "$config_file" "$aidevops_version" "$init_scope" "$has_interface" "$is_agent_source" \
-			"$enable_planning" "$enable_git_workflow" "$enable_code_quality" "$enable_time_tracking" \
-			"$enable_database" "$enable_beads" "$enable_sops" "$enable_security" || {
-			print_error "Failed to write .aidevops.json"
-			return 1
-		}
-	fi
+	_init_prepare_project_config "$config_file" "$aidevops_version" || return 1
 	# Note: plugins array is always present but empty by default.
 	# Users add plugins via: aidevops plugin add <repo-url> [--namespace <name>]
 	# Schema per plugin entry:

--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -31,6 +31,12 @@
 [[ -n "${_AIDEVOPS_INIT_LIB_LOADED:-}" ]] && return 0
 _AIDEVOPS_INIT_LIB_LOADED=1
 
+_init_lib_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_init_lib_dir" == "${BASH_SOURCE[0]}" ]] && _init_lib_dir="."
+# shellcheck source=aidevops-project-config-lib.sh
+source "${_init_lib_dir}/aidevops-project-config-lib.sh"
+unset _init_lib_dir
+
 _AGENT_SOURCE_TEMPLATE_VERSION="1"
 
 _init_load_repo_verify_lib() {
@@ -966,12 +972,21 @@ _init_config_and_agents() {
 	aidevops_version=$(get_version)
 
 	print_info "Creating or refreshing .aidevops.json..."
-	_init_write_project_config "$config_file" "$aidevops_version" "$init_scope" "$has_interface" "$is_agent_source" \
-		"$enable_planning" "$enable_git_workflow" "$enable_code_quality" "$enable_time_tracking" \
-		"$enable_database" "$enable_beads" "$enable_sops" "$enable_security" || {
-		print_error "Failed to write .aidevops.json"
-		return 1
-	}
+	local config_migration_deferred=false
+	if _project_config_is_tracked "$project_root"; then
+		config_migration_deferred=true
+		if ! _project_config_migrate_linked_worktree "$project_root"; then
+			_project_config_write_migration_plan "$project_root" || print_warning "Could not write tracked config repair plan"
+		fi
+		print_info "Preserved tracked .aidevops.json byte-for-byte during migration"
+	else
+		_init_write_project_config "$config_file" "$aidevops_version" "$init_scope" "$has_interface" "$is_agent_source" \
+			"$enable_planning" "$enable_git_workflow" "$enable_code_quality" "$enable_time_tracking" \
+			"$enable_database" "$enable_beads" "$enable_sops" "$enable_security" || {
+			print_error "Failed to write .aidevops.json"
+			return 1
+		}
+	fi
 	# Note: plugins array is always present but empty by default.
 	# Users add plugins via: aidevops plugin add <repo-url> [--namespace <name>]
 	# Schema per plugin entry:
@@ -983,7 +998,11 @@ _init_config_and_agents() {
 	#   "enabled": true
 	# }
 	# Plugins deploy to ~/.aidevops/agents/<namespace>/ (namespaced, no collisions)
-	print_success "Created .aidevops.json"
+	if [[ "$config_migration_deferred" == "true" ]]; then
+		print_success "Preserved .aidevops.json pending index migration"
+	else
+		print_success "Created .aidevops.json"
+	fi
 	_init_configure_repo_verify "$project_root"
 
 	# Derive repo name for scaffolding
@@ -1417,14 +1436,9 @@ GITATTRSEOF
 		fi
 
 		# Add .aidevops.json to gitignore (local config, not committed).
-		# If .aidevops.json is already tracked by git (committed by older framework
-		# versions), untrack it first — adding a tracked file to .gitignore is a
-		# no-op and the file keeps showing in git diff on every re-init (#2570 bug 3).
+		# Tracked legacy configs are migrated earlier only in linked worktrees.
+		# Canonical checkouts receive a worker-ready repair plan and remain untouched.
 		if ! grep -q "^\.aidevops\.json$" "$gitignore" 2>/dev/null; then
-			if git -C "$project_root" ls-files --error-unmatch .aidevops.json &>/dev/null; then
-				git -C "$project_root" rm --cached .aidevops.json &>/dev/null || true
-				print_info "Untracked .aidevops.json from git (was committed by older version)"
-			fi
 			# Ensure trailing newline before appending
 			ensure_trailing_newline "$gitignore"
 			echo ".aidevops.json" >>"$gitignore"
@@ -1540,7 +1554,7 @@ _init_optional_scaffolding() {
 _init_security_and_registration() {
 
 	# Run security posture assessment if enabled (t1412.11)
-	if [[ "$enable_security" == "true" ]]; then
+	if [[ "$enable_security" == "true" && "${config_migration_deferred:-false}" != "true" ]]; then
 		local security_posture_script="$AGENTS_DIR/scripts/security-posture-helper.sh"
 		if [[ -f "$security_posture_script" ]]; then
 			print_info "Running security posture assessment..."
@@ -1552,6 +1566,8 @@ _init_security_and_registration() {
 		else
 			print_info "Security posture check skipped (security-posture-helper.sh not available)"
 		fi
+	elif [[ "$enable_security" == "true" ]]; then
+		print_info "Security posture storage deferred until .aidevops.json migration is committed"
 	fi
 
 	# Build features string for registration

--- a/.agents/scripts/aidevops-cli/aidevops-project-config-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-project-config-lib.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+[[ -n "${_AIDEVOPS_PROJECT_CONFIG_LIB_LOADED:-}" ]] && return 0
+_AIDEVOPS_PROJECT_CONFIG_LIB_LOADED=1
+
+_project_config_is_tracked() {
+	local repo="$1"
+	git -C "$repo" ls-files --error-unmatch -- .aidevops.json >/dev/null 2>&1
+	return $?
+}
+
+_project_config_is_linked_worktree() {
+	local repo="$1"
+	local git_dir common_dir
+	git_dir=$(git -C "$repo" rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 1
+	common_dir=$(git -C "$repo" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	[[ "$git_dir" != "$common_dir" ]]
+	return $?
+}
+
+_project_config_write_migration_plan() {
+	local repo="$1"
+	local plan_dir plan_file repo_key temp_file
+	plan_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/work}"
+	repo_key=$(printf '%s' "$repo" | cksum | cut -d' ' -f1)
+	plan_file="${plan_dir}/project-config-migration-${repo_key}.json"
+	mkdir -p "$plan_dir" || return 1
+	temp_file=$(mktemp "${plan_file}.XXXXXX") || return 1
+	if ! jq -n --arg repo "$repo" '{
+		repo:$repo,
+		files:[".aidevops.json",".gitignore"],
+		worker_brief:"In an isolated linked worktree, ensure .aidevops.json is ignored, run git rm --cached -- .aidevops.json, verify the working-tree file is byte-identical, commit the index-only migration, and open a PR. Never delete the local file."
+	}' >"$temp_file"; then
+		rm -f "$temp_file"
+		return 1
+	fi
+	chmod 600 "$temp_file"
+	mv "$temp_file" "$plan_file"
+	print_warning "Tracked .aidevops.json requires a linked-worktree PR; repair plan: $plan_file"
+	return 0
+}
+
+_project_config_migrate_linked_worktree() {
+	local repo="$1"
+	_project_config_is_tracked "$repo" || return 0
+	_project_config_is_linked_worktree "$repo" || return 1
+	git -C "$repo" rm --cached -- .aidevops.json >/dev/null || return 1
+	print_info "Staged .aidevops.json index migration in the linked worktree; local file preserved"
+	return 0
+}

--- a/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
@@ -17,6 +17,12 @@
 [[ -n "${_AIDEVOPS_UPDATE_LIB_LOADED:-}" ]] && return 0
 _AIDEVOPS_UPDATE_LIB_LOADED=1
 
+_update_lib_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_update_lib_dir" == "${BASH_SOURCE[0]}" ]] && _update_lib_dir="."
+# shellcheck source=aidevops-project-config-lib.sh
+source "${_update_lib_dir}/aidevops-project-config-lib.sh"
+unset _update_lib_dir
+
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	_lib_path="${BASH_SOURCE[0]%/*}"
 	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
@@ -29,12 +35,6 @@ _AIDEVOPS_UPDATE_TRUE=true
 # Tracked project config is repository-owned policy. Framework updates may read
 # it to refresh local registration metadata, but must not create working-tree
 # changes that block the repository's normal git workflow.
-_update_project_config_is_tracked() {
-	local repo="$1"
-	git -C "$repo" ls-files --error-unmatch -- .aidevops.json >/dev/null 2>&1
-	return $?
-}
-
 _update_fresh_install() {
 	print_warning "Repository not found at the active CLI tree, updating from a clean temporary checkout..."
 	local tmp_checkout
@@ -79,7 +79,8 @@ _update_sync_projects() {
 		if command -v jq &>/dev/null; then
 			local features
 			features=$(jq -r '[.features | to_entries[] | select(.value == true) | .key] | join(",")' "$repo/.aidevops.json" 2>/dev/null || echo "")
-			if _update_project_config_is_tracked "$repo"; then
+			if _project_config_is_tracked "$repo"; then
+				_project_config_write_migration_plan "$repo" || print_warning "Could not write tracked config repair plan"
 				if register_repo "$repo" "$current_ver" "$features"; then
 					did_sync=true
 					preserved=$((preserved + 1))
@@ -93,7 +94,7 @@ _update_sync_projects() {
 				else rm -f "$temp_file"; fi
 			fi
 		fi
-		if [[ "$did_sync" != "$_AIDEVOPS_UPDATE_TRUE" ]] && ! _update_project_config_is_tracked "$repo"; then
+		if [[ "$did_sync" != "$_AIDEVOPS_UPDATE_TRUE" ]] && ! _project_config_is_tracked "$repo"; then
 			sed -i '' "s/\"version\": *\"[^\"]*\"/\"version\": \"$current_ver\"/" "$repo/.aidevops.json" 2>/dev/null && did_sync=true
 		fi
 		[[ "$did_sync" == "$_AIDEVOPS_UPDATE_TRUE" ]] && synced=$((synced + 1)) || failed=$((failed + 1))
@@ -148,7 +149,7 @@ _update_sync_agent_source_repos() {
 		fi
 		if seed_agent_source_repo_templates "$repo"; then
 			synced=$((synced + 1))
-			if [[ -f "$repo/.aidevops.json" ]] && command -v jq &>/dev/null && ! _update_project_config_is_tracked "$repo"; then
+			if [[ -f "$repo/.aidevops.json" ]] && command -v jq &>/dev/null && ! _project_config_is_tracked "$repo"; then
 				local temp_file="${repo}/.aidevops.json.tmp"
 				jq --arg version "$current_ver" '.version = $version | .agent_source = true' "$repo/.aidevops.json" >"$temp_file" 2>/dev/null && mv "$temp_file" "$repo/.aidevops.json" || rm -f "$temp_file"
 			fi

--- a/.agents/scripts/tests/test-update-project-config-safety.sh
+++ b/.agents/scripts/tests/test-update-project-config-safety.sh
@@ -49,7 +49,9 @@ make_repo() {
 	/usr/bin/git -C "$repo" config commit.gpgsign false
 	printf '%s\n' '{"version":"0.0.1","features":{"planning":true}}' >"$repo/.aidevops.json"
 	if [[ "$tracked" == "true" ]]; then
-		/usr/bin/git -C "$repo" add .aidevops.json
+		printf '%s\n' '.aidevops.json' >"$repo/.gitignore"
+		/usr/bin/git -C "$repo" add -f .aidevops.json
+		/usr/bin/git -C "$repo" add .gitignore
 	else
 		printf '%s\n' '.aidevops.json' >"$repo/.gitignore"
 		/usr/bin/git -C "$repo" add .gitignore
@@ -87,10 +89,12 @@ seed_agent_source_repo_templates() { return 0; }
 
 tracked_repo="${TEST_ROOT}/tracked"
 local_repo="${TEST_ROOT}/local"
+linked_repo="${TEST_ROOT}/tracked-linked"
 make_repo "$tracked_repo" true
 make_repo "$local_repo" false
 tracked_repo="$(cd "$tracked_repo" && pwd -P)"
 local_repo="$(cd "$local_repo" && pwd -P)"
+/usr/bin/git -C "$tracked_repo" worktree add -q -b config-migration "$linked_repo"
 
 jq -n --arg tracked "$tracked_repo" --arg local "$local_repo" '{
 	initialized_repos: [
@@ -108,15 +112,26 @@ get_agent_source_repos() {
 tracked_before=$(cksum <"$tracked_repo/.aidevops.json")
 _update_sync_projects false 9.9.9
 tracked_after=$(cksum <"$tracked_repo/.aidevops.json")
+plans=("${HOME}/.aidevops/.agent-workspace/work"/project-config-migration-*.json)
+plan_count=${#plans[@]}
 
 assert_equal "tracked config remains byte-identical" "$tracked_before" "$tracked_after"
 assert_equal "tracked repository remains clean" "" "$(/usr/bin/git -C "$tracked_repo" status --porcelain)"
+assert_equal "tracked-and-ignored config emits one migration plan" "1" "$plan_count"
 assert_equal "tracked config does not gain agent-source metadata" "false" "$(jq -r 'has("agent_source")' "$tracked_repo/.aidevops.json")"
 assert_equal "tracked registration advances" "9.9.9" "$(jq -r --arg path "$tracked_repo" '.initialized_repos[] | select(.path == $path) | .version' "$REPOS_FILE")"
 assert_equal "tracked registration preserves features" "planning" "$(jq -r --arg path "$tracked_repo" '.initialized_repos[] | select(.path == $path) | .features | join(",")' "$REPOS_FILE")"
 assert_equal "local config version advances" "9.9.9" "$(jq -r '.version' "$local_repo/.aidevops.json")"
 assert_equal "local registration advances" "9.9.9" "$(jq -r --arg path "$local_repo" '.initialized_repos[] | select(.path == $path) | .version' "$REPOS_FILE")"
 assert_equal "local repository remains clean" "" "$(/usr/bin/git -C "$local_repo" status --porcelain)"
+
+linked_before=$(cksum <"$linked_repo/.aidevops.json")
+_project_config_migrate_linked_worktree "$linked_repo"
+linked_after=$(cksum <"$linked_repo/.aidevops.json")
+assert_equal "linked-worktree migration preserves config bytes" "$linked_before" "$linked_after"
+assert_equal "linked-worktree migration removes config from index" "" "$(/usr/bin/git -C "$linked_repo" ls-files -- .aidevops.json)"
+assert_equal "linked-worktree migration stages only the config deletion" "D  .aidevops.json" "$(/usr/bin/git -C "$linked_repo" status --porcelain)"
+assert_equal "linked-worktree migration leaves canonical checkout clean" "" "$(/usr/bin/git -C "$tracked_repo" status --porcelain)"
 
 printf '\nRan %d tests, %d failed.\n' "$((passed + failed))" "$failed"
 [[ "$failed" -eq 0 ]]


### PR DESCRIPTION
## Summary

- Detect tracked-and-ignored `.aidevops.json` independently from the ignore rule.
- Preserve tracked configs during init and update; stage index removal only in linked worktrees.
- Emit an idempotent, permission-protected worker repair plan for canonical repositories.

## Testing

- `bash .agents/scripts/tests/test-update-project-config-safety.sh` (13/13)
- `bash .agents/scripts/tests/test-agent-source-init-update.sh` (10/10)
- `bash .agents/scripts/tests/test-aidevops-cli-convergence.sh` (14/14)
- ShellCheck on modified CLI libraries and focused test
- Complexity regression check: no new violations

## Runtime Testing

- self-assessed (shell migration and regression-test change)

Resolves #27936

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 7m and 124,341 tokens on this as a headless worker. Overall, 46m since this issue was created.
