### PR TITLE
GH#27942: harden local OpenCode server access

### DIFF
--- a/.agents/scripts/mcp-inspector-helper.sh
+++ b/.agents/scripts/mcp-inspector-helper.sh
@@ -39,6 +39,23 @@ check_inspector() {
     return 0
 }
 
+# Call the authenticated API gateway without exposing its bearer token in argv.
+gateway_curl() {
+    local url="$1"
+    shift || true
+    local -a curl_args=("$@")
+
+    if [[ ! "${API_GATEWAY_TOKEN:-}" =~ ^[A-Za-z0-9._~-]{32,}$ ]]; then
+        print_error "API_GATEWAY_TOKEN must be at least 32 URL-safe characters"
+        return 1
+    fi
+
+    curl --fail --silent --show-error \
+        --config <(printf 'header = "Authorization: Bearer %s"\n' "$API_GATEWAY_TOKEN") \
+        "${curl_args[@]}" "$url"
+    return 0
+}
+
 # Launch MCP Inspector Web UI
 launch_ui() {
     local server="${1:-}"
@@ -160,7 +177,12 @@ health_check() {
         total=$((total + 1))
         local name="localhost:$port"
         local response
-        if response=$(curl -s "http://localhost:$port/health" 2>/dev/null); then
+        if [[ "$port" == "3100" ]]; then
+            response=$(gateway_curl "http://localhost:$port/health" 2>/dev/null) || response=""
+        else
+            response=$(curl --fail --silent --show-error "http://localhost:$port/health" 2>/dev/null) || response=""
+        fi
+        if [[ -n "$response" ]]; then
             local status
             status=$(echo "$response" | jq -r '.status // "ok"' 2>/dev/null || echo "healthy")
             print_success "$name - $status"
@@ -182,8 +204,16 @@ health_check() {
         
         if [[ "$server_type" == "streamable-http" || "$server_type" == "sse" ]]; then
             local url
+            local reachable=0
             url=$(jq -r ".mcpServers[\"$srv\"].url" "$CONFIG_FILE")
-            if curl -s "$url/health" > /dev/null 2>&1; then
+            if [[ "$srv" == "api-gateway" ]]; then
+                if gateway_curl "$url/health" > /dev/null 2>&1; then
+                    reachable=1
+                fi
+            elif curl --fail --silent --show-error "$url/health" > /dev/null 2>&1; then
+                reachable=1
+            fi
+            if [[ "$reachable" -eq 1 ]]; then
                 print_success "$srv ($server_type) - healthy"
                 healthy=$((healthy + 1))
             else
@@ -228,6 +258,11 @@ test_api_gateway() {
     local base_url="http://localhost:3100"
     local passed=0
     local failed=0
+
+    if [[ -z "${API_GATEWAY_TOKEN:-}" ]]; then
+        print_error "Set API_GATEWAY_TOKEN to the same value used to start the gateway"
+        return 1
+    fi
     
     # Test health endpoint
     echo -e "\n${BLUE}Testing endpoints:${NC}"
@@ -235,7 +270,7 @@ test_api_gateway() {
     local response
     
     # Health check
-    if response=$(curl -s "$base_url/health" 2>/dev/null); then
+    if response=$(gateway_curl "$base_url/health" 2>/dev/null); then
         print_success "GET /health"
         echo "  Response: $response"
         passed=$((passed + 1))
@@ -245,7 +280,7 @@ test_api_gateway() {
     fi
     
     # Quality summary
-    if response=$(curl -s "$base_url/api/quality/summary" 2>/dev/null); then
+    if response=$(gateway_curl "$base_url/api/quality/summary" 2>/dev/null); then
         print_success "GET /api/quality/summary"
         local issues
         local gate
@@ -260,7 +295,7 @@ test_api_gateway() {
     fi
     
     # SonarCloud status
-    if curl -s "$base_url/api/sonarcloud/status" > /dev/null 2>&1; then
+    if gateway_curl "$base_url/api/sonarcloud/status" > /dev/null 2>&1; then
         print_success "GET /api/sonarcloud/status"
         passed=$((passed + 1))
     else
@@ -269,7 +304,7 @@ test_api_gateway() {
     fi
     
     # Cache stats
-    if response=$(curl -s "$base_url/api/cache/stats" 2>/dev/null); then
+    if response=$(gateway_curl "$base_url/api/cache/stats" 2>/dev/null); then
         print_success "GET /api/cache/stats"
         local size
         size=$(echo "$response" | jq -r '.size // 0' 2>/dev/null || echo "0")
@@ -281,7 +316,7 @@ test_api_gateway() {
     fi
     
     # Crawl4AI health
-    if response=$(curl -s "$base_url/api/crawl4ai/health" 2>/dev/null); then
+    if response=$(gateway_curl "$base_url/api/crawl4ai/health" 2>/dev/null); then
         local status
         status=$(echo "$response" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
         if [[ "$status" == "healthy" ]]; then
@@ -362,6 +397,10 @@ Configuration:
     - github           (stdio) - GitHub API
 
 Starting Local Servers:
+  # Generate tokens in a trusted shell; never commit them
+  export API_GATEWAY_TOKEN="$(openssl rand -hex 32)"
+  export DASHBOARD_TOKEN="$(openssl rand -hex 32)"
+
   # Start API Gateway (port 3100)
   bun run .opencode/server/api-gateway.ts
   

--- a/.opencode/MCP-TESTING-GUIDE.md
+++ b/.opencode/MCP-TESTING-GUIDE.md
@@ -9,12 +9,33 @@ This guide covers testing MCP servers and the Elysia API Gateway using the MCP I
 
 ### 1. Start Local Servers
 
+Generate local bearer tokens in trusted shells. Do not commit the values:
+
 ```bash
 # Terminal 1: Start API Gateway (port 3100)
+export API_GATEWAY_TOKEN="$(openssl rand -hex 32)"
 bun run dev
 
-# Terminal 2: Start MCP Dashboard (port 3101)  
+# Terminal 2: Start MCP Dashboard (port 3101)
+export DASHBOARD_TOKEN="$(openssl rand -hex 32)"
 bun run dashboard
+```
+
+Both servers bind to `127.0.0.1` by default and refuse to start without their token.
+Keep `API_GATEWAY_TOKEN` available in shells that run gateway checks. Enter
+`DASHBOARD_TOKEN` in the dashboard when prompted; it is retained only in session storage.
+
+For direct gateway requests, define this Bash helper so the token is passed through an
+anonymous configuration stream instead of appearing in process arguments:
+
+```bash
+gateway_curl() {
+  local url="$1"
+  shift
+  curl --fail --silent --show-error \
+    --config <(printf 'header = "Authorization: Bearer %s"\n' "$API_GATEWAY_TOKEN") \
+    "$@" "$url"
+}
 ```
 
 ### 2. Run Health Check
@@ -98,16 +119,9 @@ npx @modelcontextprotocol/inspector --config .opencode/server/mcp-test-config.js
 
 ### HTTP/SSE Servers
 
-```bash
-# Connect to HTTP server
-npx @modelcontextprotocol/inspector --cli http://localhost:3100 --transport http --method tools/list
-
-# With custom headers
-npx @modelcontextprotocol/inspector --cli http://localhost:3100 \
-  --transport http \
-  --method tools/list \
-  --header "Authorization: Bearer token"
-```
+Do not pass bearer tokens through the Inspector's `--header` option: command-line
+arguments can be visible to other local processes. Use a protected Inspector
+configuration mechanism or the `gateway_curl` helper for gateway HTTP endpoints.
 
 ## API Gateway Endpoints
 
@@ -115,45 +129,44 @@ npx @modelcontextprotocol/inspector --cli http://localhost:3100 \
 
 ```bash
 # Health check
-curl http://localhost:3100/health
+gateway_curl http://localhost:3100/health
 
 # Cache statistics
-curl http://localhost:3100/api/cache/stats
+gateway_curl http://localhost:3100/api/cache/stats
 
 # Clear cache
-curl -X DELETE http://localhost:3100/api/cache
+gateway_curl http://localhost:3100/api/cache -X DELETE
 ```
 
 ### SonarCloud Integration
 
 ```bash
 # Get issues
-curl http://localhost:3100/api/sonarcloud/issues
+gateway_curl http://localhost:3100/api/sonarcloud/issues
 
 # Get quality gate status
-curl http://localhost:3100/api/sonarcloud/status
+gateway_curl http://localhost:3100/api/sonarcloud/status
 
 # Get metrics
-curl http://localhost:3100/api/sonarcloud/metrics
+gateway_curl http://localhost:3100/api/sonarcloud/metrics
 ```
 
 ### Quality Summary
 
 ```bash
 # Unified quality summary (cached)
-curl http://localhost:3100/api/quality/summary
+gateway_curl http://localhost:3100/api/quality/summary
 ```
 
 ### Crawl4AI Proxy
 
 ```bash
 # Check Crawl4AI health
-curl http://localhost:3100/api/crawl4ai/health
+gateway_curl http://localhost:3100/api/crawl4ai/health
 
 # Crawl a URL (requires Crawl4AI running)
-curl -X POST http://localhost:3100/api/crawl4ai/crawl \
-  -H "Content-Type: application/json" \
-  -d '{"urls": ["https://example.com"]}'
+gateway_curl http://localhost:3100/api/crawl4ai/crawl \
+  -X POST -H "Content-Type: application/json" -d '{"urls": ["https://example.com"]}'
 ```
 
 ## MCP Dashboard
@@ -161,7 +174,7 @@ curl -X POST http://localhost:3100/api/crawl4ai/crawl \
 Access at `http://localhost:3101` for:
 
 - Real-time server status monitoring
-- Start/stop MCP servers
+- Authenticated status and start/stop controls
 - WebSocket-based live updates
 - Server health checks
 
@@ -173,6 +186,19 @@ ws.onmessage = (e) => console.log(JSON.parse(e.data))
 ```
 
 ## Configuration
+
+### Local Server Security
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `API_GATEWAY_TOKEN` | Yes | None | Bearer token required by every gateway endpoint |
+| `DASHBOARD_TOKEN` | Yes | None | Bearer token required by dashboard status and control endpoints |
+| `API_GATEWAY_HOST` | No | `127.0.0.1` | Gateway listen host |
+| `MCP_DASHBOARD_HOST` | No | `127.0.0.1` | Dashboard listen host |
+| `CORS_ORIGINS` | No | None | Comma-separated explicit HTTP(S) origins; wildcard values are rejected |
+
+Setting either host to `0.0.0.0` is an explicit network-exposure opt-in. Authentication
+remains mandatory; use TLS plus additional firewall and network controls.
 
 ### Config File Location
 
@@ -225,7 +251,7 @@ ws.onmessage = (e) => console.log(JSON.parse(e.data))
 3. Test direct connection:
 
    ```bash
-   curl -v http://localhost:3100/health
+   gateway_curl http://localhost:3100/health --verbose
    ```
 
 ### Inspector Connection Failed
@@ -259,16 +285,9 @@ ws.onmessage = (e) => console.log(JSON.parse(e.data))
 
 ### Benchmark API Gateway
 
-```bash
-# Install hey (HTTP load generator)
-brew install hey
-
-# Benchmark health endpoint
-hey -n 1000 -c 10 http://localhost:3100/health
-
-# Benchmark quality summary (with caching)
-hey -n 100 -c 5 http://localhost:3100/api/quality/summary
-```
+Avoid benchmark clients that accept authorization headers only through command-line
+arguments, because they expose the token through process inspection. Use an isolated,
+disposable gateway token and a client that accepts headers through protected standard input.
 
 ### Expected Performance
 
@@ -284,7 +303,9 @@ The API Gateway integrates with OpenCode tools:
 
 ```typescript
 // In .opencode/tool/quality-check.ts
-const response = await fetch('http://localhost:3100/api/quality/summary')
+const response = await fetch('http://localhost:3100/api/quality/summary', {
+  headers: { Authorization: `Bearer ${process.env.API_GATEWAY_TOKEN}` },
+})
 const data = await response.json()
 ```
 

--- a/.opencode/server/api-gateway.ts
+++ b/.opencode/server/api-gateway.ts
@@ -14,12 +14,15 @@
  * 
  * Environment Variables:
  *   API_GATEWAY_PORT - Port to listen on (default: 3100)
- *   CORS_ORIGINS - Comma-separated allowed origins (default: *)
+ *   API_GATEWAY_HOST - Host to listen on (default: 127.0.0.1)
+ *   API_GATEWAY_TOKEN - Required bearer token for every endpoint
+ *   CORS_ORIGINS - Comma-separated trusted HTTP(S) origins (default: none)
  *   RATE_LIMIT_MAX - Max requests per window (default: 100)
  *   RATE_LIMIT_WINDOW - Window in ms (default: 60000)
  */
 
 import { Elysia, t } from 'elysia'
+import { getListenHost, hasValidBearerToken, parseAllowedOrigins, requireServerToken } from './security'
 
 // Types
 interface CacheEntry<T> {
@@ -59,6 +62,8 @@ interface RateLimitEntry {
 // Configuration
 const CONFIG = {
   port: Number(process.env.API_GATEWAY_PORT) || 3100,
+  host: getListenHost(process.env.API_GATEWAY_HOST),
+  authToken: requireServerToken('API_GATEWAY_TOKEN', process.env.API_GATEWAY_TOKEN),
   sonarcloud: {
     baseUrl: 'https://sonarcloud.io/api',
     projectKey: process.env.SONAR_PROJECT_KEY || 'marcusquinn_aidevops',
@@ -77,7 +82,7 @@ const CONFIG = {
     window: Number(process.env.RATE_LIMIT_WINDOW) || 60000,
   },
   cors: {
-    origins: (process.env.CORS_ORIGINS || '*').split(','),
+    origins: parseAllowedOrigins(process.env.CORS_ORIGINS),
   },
 }
 
@@ -371,17 +376,32 @@ function handleCacheStats() {
 // Middleware
 // ============================================
 
-function applyCorsHeaders(request: Request, set: { headers: Record<string, string> }): Response | undefined {
+function applyCorsHeaders(request: Request, set: { headers: Record<string, string | number> }): Response | undefined {
   const origin = request.headers.get('origin')
-  if (CONFIG.cors.origins.includes('*') || (origin && CONFIG.cors.origins.includes(origin))) {
-    set.headers['Access-Control-Allow-Origin'] = origin || '*'
-    set.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, OPTIONS'
+  if (origin && CONFIG.cors.origins.includes(origin)) {
+    set.headers['Access-Control-Allow-Origin'] = origin
+    set.headers['Access-Control-Allow-Methods'] = 'GET, POST, DELETE, OPTIONS'
     set.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+    set.headers['Vary'] = 'Origin'
   }
   if (request.method === 'OPTIONS') {
     return new Response(null, { status: 204 })
   }
   return undefined
+}
+
+function applyAuthentication(
+  request: Request,
+  set: { headers: Record<string, string | number>; status: number }
+): { error: string; message: string } | undefined {
+  if (hasValidBearerToken(request.headers.get('authorization'), CONFIG.authToken)) return undefined
+
+  set.status = 401
+  set.headers['WWW-Authenticate'] = 'Bearer realm="aidevops-api-gateway"'
+  return {
+    error: 'Unauthorized',
+    message: 'Set the Authorization header to Bearer <API_GATEWAY_TOKEN>',
+  }
 }
 
 function applyRateLimit(
@@ -412,6 +432,7 @@ function applyRateLimit(
 // Create the Elysia app
 const app = new Elysia()
   .onBeforeHandle(({ request, set }) => applyCorsHeaders(request, set))
+  .onBeforeHandle(({ request, set }) => applyAuthentication(request, set as Parameters<typeof applyAuthentication>[1]))
   .onBeforeHandle(({ request, set }) => applyRateLimit(request, set as Parameters<typeof applyRateLimit>[1]))
 
   .get('/health', () => handleHealth())
@@ -450,7 +471,7 @@ const app = new Elysia()
           })),
         }),
       })
-      .post('/extract', ({ body }) => handleCrawl4aiExtract(body), {
+      .post('/extract', ({ body }) => handleCrawl4aiExtract(body as { urls: string[]; schema: Record<string, string> }), {
         body: t.Object({
           urls: t.Array(t.String()),
           schema: t.Record(t.String(), t.String()),
@@ -475,18 +496,20 @@ const app = new Elysia()
 
   // Error handling
   .onError(({ code, error }) => {
-    console.error(`[API Gateway Error] ${code}:`, error.message)
-    return { error: true, code, message: error.message }
+    const message = error instanceof Error ? error.message : 'Request failed'
+    console.error(`[API Gateway Error] ${code}:`, message)
+    return { error: true, code, message }
   })
 
-  .listen(CONFIG.port)
+  .listen({ port: CONFIG.port, hostname: CONFIG.host })
 
-console.log(`🦊 API Gateway running at http://localhost:${CONFIG.port}`)
+console.log(`🦊 API Gateway running at http://${CONFIG.host}:${CONFIG.port}`)
 console.log(`
 Configuration:
+  Authentication: required
   Cache: ${CONFIG.cache.maxSize} max entries, ${CONFIG.cache.qualityTtl/1000}s TTL
   Rate Limit: ${CONFIG.rateLimit.max} requests per ${CONFIG.rateLimit.window/1000}s
-  CORS: ${CONFIG.cors.origins.join(', ')}
+  CORS: ${CONFIG.cors.origins.join(', ') || 'same-origin only'}
 
 Available endpoints:
   GET  /health                    - Gateway health check

--- a/.opencode/server/index.ts
+++ b/.opencode/server/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { Elysia } from 'elysia'
+import { getListenHost } from './security'
 
 // Read version from VERSION file
 async function getVersion(): Promise<string> {
@@ -29,6 +30,7 @@ async function getVersion(): Promise<string> {
 }
 
 const PORT = Number(process.env.PORT) || 3100
+const HOST = getListenHost(process.env.OPENCODE_SERVER_HOST)
 const VERSION = await getVersion()
 
 const app = new Elysia()
@@ -49,13 +51,13 @@ const app = new Elysia()
     uptime: process.uptime(),
   }))
 
-  .listen(PORT)
+  .listen({ port: PORT, hostname: HOST })
 
 console.log(`
 🚀 AI DevOps Framework Server v${VERSION}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Main server:     http://localhost:${PORT}
+Main server:     http://${HOST}:${PORT}
 
 To start individual services:
   bun run .opencode/server/api-gateway.ts    # API Gateway (port 3100)

--- a/.opencode/server/mcp-dashboard.ts
+++ b/.opencode/server/mcp-dashboard.ts
@@ -8,11 +8,13 @@
  * Usage: bun run .opencode/server/mcp-dashboard.ts
  * 
  * Environment Variables:
- *   DASHBOARD_TOKEN - Bearer token for authenticated endpoints (required for start/stop)
+ *   DASHBOARD_TOKEN - Required bearer token for server status and control endpoints
  *   MCP_DASHBOARD_PORT - Port to listen on (default: 3101)
+ *   MCP_DASHBOARD_HOST - Host to listen on (default: 127.0.0.1)
  */
 
 import { Elysia, t } from 'elysia'
+import { getListenHost, hasValidBearerToken, requireServerToken } from './security'
 
 // Types
 interface McpServer {
@@ -27,8 +29,8 @@ interface McpServer {
 // Configuration
 const CONFIG = {
   port: Number(process.env.MCP_DASHBOARD_PORT) || 3101,
-  authToken: process.env.DASHBOARD_TOKEN || '',
-  requireAuth: !!process.env.DASHBOARD_TOKEN,
+  host: getListenHost(process.env.MCP_DASHBOARD_HOST),
+  authToken: requireServerToken('DASHBOARD_TOKEN', process.env.DASHBOARD_TOKEN),
 }
 
 // MCP Server definitions
@@ -42,16 +44,21 @@ const MCP_SERVERS: Array<{ name: string; command: string; port?: number; healthC
   { name: 'memory', command: 'npx @anthropic/mcp-server-memory', port: 3012 },
 ]
 
-// Authentication helper
-function validateAuth(authHeader: string | null): boolean {
-  if (!CONFIG.requireAuth) {
-    return true
+function applyAuthentication(
+  request: Request,
+  set: { headers: Record<string, string | number>; status: number }
+): { error: string; message: string } | undefined {
+  const pathname = new URL(request.url).pathname
+  const protectedRoute = pathname === '/api/servers' || pathname.startsWith('/api/servers/')
+  if (!protectedRoute) return undefined
+  if (hasValidBearerToken(request.headers.get('authorization'), CONFIG.authToken)) return undefined
+
+  set.status = 401
+  set.headers['WWW-Authenticate'] = 'Bearer realm="aidevops-mcp-dashboard"'
+  return {
+    error: 'Unauthorized',
+    message: 'Set the Authorization header to Bearer <DASHBOARD_TOKEN>',
   }
-  if (!authHeader) {
-    return false
-  }
-  const token = authHeader.replace('Bearer ', '')
-  return token === CONFIG.authToken
 }
 
 // Check if a server is running
@@ -95,9 +102,12 @@ async function checkServerHealth(server: typeof MCP_SERVERS[0]): Promise<McpServ
 
 // Server state
 const serverState = new Map<string, McpServer>()
+const managedProcesses = new Map<string, Bun.Subprocess>()
 
 // Create the dashboard app
 const app = new Elysia()
+  .onBeforeHandle(({ request, set }) => applyAuthentication(request, set as Parameters<typeof applyAuthentication>[1]))
+
   // Serve dashboard HTML
   .get('/', () => {
     return new Response(DASHBOARD_HTML, {
@@ -105,7 +115,7 @@ const app = new Elysia()
     })
   })
 
-  // Get all server statuses (public)
+  // Get all server statuses (authenticated)
   .get('/api/servers', async () => {
     // Refresh all server statuses
     const checks = await Promise.all(
@@ -122,7 +132,7 @@ const app = new Elysia()
     }
   })
 
-  // Get single server status (public)
+  // Get single server status (authenticated)
   .get('/api/servers/:name', async ({ params }) => {
     const serverDef = MCP_SERVERS.find(s => s.name === params.name)
     if (!serverDef) {
@@ -135,31 +145,32 @@ const app = new Elysia()
   })
 
   // Start a server (authenticated)
-  .post('/api/servers/:name/start', async ({ params, headers, set }) => {
-    // Check authentication
-    const authHeader = headers.authorization || null
-    if (!validateAuth(authHeader)) {
-      set.status = 401
-      return { 
-        error: 'Unauthorized', 
-        message: CONFIG.requireAuth 
-          ? 'Set Authorization: Bearer <DASHBOARD_TOKEN> header' 
-          : 'Authentication not configured'
-      }
-    }
-
+  .post('/api/servers/:name/start', async ({ params, set }) => {
     const serverDef = MCP_SERVERS.find(s => s.name === params.name)
     if (!serverDef) {
       set.status = 404
       return { error: 'Server not found' }
     }
 
+    const existingProcess = managedProcesses.get(params.name)
+    if (existingProcess?.exitCode === null) {
+      set.status = 409
+      return { error: 'Server was already started by this dashboard instance' }
+    }
+    managedProcesses.delete(params.name)
+
     try {
       // Start the server in background using safe spawn with array args
       const [cmd, ...args] = serverDef.command.split(' ')
-      Bun.spawn([cmd, ...args], {
+      const process = Bun.spawn([cmd, ...args], {
         stdout: 'ignore',
         stderr: 'ignore',
+      })
+      managedProcesses.set(params.name, process)
+      void process.exited.then(() => {
+        if (managedProcesses.get(params.name)?.pid === process.pid) {
+          managedProcesses.delete(params.name)
+        }
       })
 
       return { 
@@ -176,37 +187,26 @@ const app = new Elysia()
   })
 
   // Stop a server (authenticated)
-  .post('/api/servers/:name/stop', async ({ params, headers, set }) => {
-    // Check authentication
-    const authHeader = headers.authorization || null
-    if (!validateAuth(authHeader)) {
-      set.status = 401
-      return { 
-        error: 'Unauthorized',
-        message: CONFIG.requireAuth 
-          ? 'Set Authorization: Bearer <DASHBOARD_TOKEN> header' 
-          : 'Authentication not configured'
-      }
-    }
-
+  .post('/api/servers/:name/stop', async ({ params, set }) => {
     const serverDef = MCP_SERVERS.find(s => s.name === params.name)
     if (!serverDef) {
       set.status = 404
       return { error: 'Server not found' }
     }
 
-    try {
-      // Use safe spawn with array args - escape the server name for pkill pattern
-      const safeName = params.name.replace(/[^a-zA-Z0-9-_]/g, '')
-      const proc = Bun.spawn(['pkill', '-f', safeName], {
-        stdout: 'pipe',
-        stderr: 'pipe',
-      })
-      await proc.exited
-      return { success: true, message: `Stopped ${params.name}` }
-    } catch {
-      return { success: true, message: `${params.name} was not running` }
+    const process = managedProcesses.get(params.name)
+    if (!process || process.exitCode !== null) {
+      managedProcesses.delete(params.name)
+      set.status = 409
+      return { error: 'Only processes started by this dashboard instance can be stopped' }
     }
+
+    process.kill()
+    await process.exited
+    if (managedProcesses.get(params.name)?.pid === process.pid) {
+      managedProcesses.delete(params.name)
+    }
+    return { success: true, message: `Stopped ${params.name}` }
   })
 
   // WebSocket for real-time updates
@@ -217,7 +217,7 @@ const app = new Elysia()
       ws.send(JSON.stringify({
         type: 'connected',
         servers: MCP_SERVERS.map(s => s.name),
-        authRequired: CONFIG.requireAuth,
+        authRequired: true,
       }))
     },
     message(ws, message) {
@@ -241,25 +241,21 @@ const app = new Elysia()
   .get('/health', () => ({
     status: 'healthy',
     service: 'mcp-dashboard',
-    authRequired: CONFIG.requireAuth,
+    authRequired: true,
     timestamp: Date.now(),
   }))
 
   // Auth status (public - shows if auth is required, not the token)
   .get('/api/auth/status', () => ({
-    required: CONFIG.requireAuth,
-    configured: !!CONFIG.authToken,
+    required: true,
+    configured: true,
   }))
 
-  .listen(CONFIG.port)
+  .listen({ port: CONFIG.port, hostname: CONFIG.host })
 
-console.log(`🎛️  MCP Dashboard running at http://localhost:${CONFIG.port}`)
-console.log(`   WebSocket available at ws://localhost:${CONFIG.port}/ws`)
-if (CONFIG.requireAuth) {
-  console.log(`   🔐 Authentication ENABLED for control endpoints`)
-} else {
-  console.log(`   ⚠️  Authentication DISABLED - set DASHBOARD_TOKEN to enable`)
-}
+console.log(`🎛️  MCP Dashboard running at http://${CONFIG.host}:${CONFIG.port}`)
+console.log(`   WebSocket available at ws://${CONFIG.host}:${CONFIG.port}/ws`)
+console.log(`   🔐 Authentication ENABLED for server status and control endpoints`)
 
 // Dashboard HTML with auth support
 const DASHBOARD_HTML = `<!DOCTYPE html>
@@ -326,7 +322,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   <h1>🎛️ MCP Server Dashboard</h1>
   
   <div class="auth-bar">
-    <input type="password" id="authToken" placeholder="Enter DASHBOARD_TOKEN for control access" onkeydown="if(event.key==='Enter')setToken()">
+    <input type="password" id="authToken" placeholder="Enter DASHBOARD_TOKEN for server access" onkeydown="if(event.key==='Enter')setToken()">
     <button onclick="setToken()">Set Token</button>
     <button id="clearTokenBtn" onclick="clearToken()" style="display:none;background:#da3633;border-color:#da3633;">Clear Token</button>
     <span class="auth-status" id="authStatus">Not authenticated</span>
@@ -340,7 +336,11 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   <script>
     let ws;
     let authToken = sessionStorage.getItem('dashboardToken') || '';
-    let authRequired = false;
+    let authRequired = true;
+
+    function authHeaders() {
+      return authToken ? { 'Authorization': 'Bearer ' + authToken } : {};
+    }
     
     function setToken() {
       const input = document.getElementById('authToken');
@@ -375,7 +375,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
     
     async function fetchServers() {
       try {
-        const res = await fetch('/api/servers');
+        const res = await fetch('/api/servers', { headers: authHeaders() });
         const data = await res.json();
         renderServers(data.servers);
         document.getElementById('lastUpdate').textContent = 
@@ -423,7 +423,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       try {
         const res = await fetch('/api/servers/' + name + '/start', { 
           method: 'POST',
-          headers: authToken ? { 'Authorization': 'Bearer ' + authToken } : {}
+          headers: authHeaders()
         });
         const data = await res.json();
         if (data.error) {
@@ -441,7 +441,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       try {
         const res = await fetch('/api/servers/' + name + '/stop', { 
           method: 'POST',
-          headers: authToken ? { 'Authorization': 'Bearer ' + authToken } : {}
+          headers: authHeaders()
         });
         const data = await res.json();
         if (data.error) {
@@ -456,7 +456,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
     }
 
     async function checkServer(name) {
-      const res = await fetch('/api/servers/' + name);
+      const res = await fetch('/api/servers/' + name, { headers: authHeaders() });
       const data = await res.json();
       alert(name + ': ' + data.status);
       fetchServers();

--- a/.opencode/server/security.test.ts
+++ b/.opencode/server/security.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { networkInterfaces } from 'node:os'
+import {
+  DEFAULT_LISTEN_HOST,
+  getListenHost,
+  hasValidBearerToken,
+  parseAllowedOrigins,
+  requireServerToken,
+} from './security'
+
+const REPOSITORY_ROOT = new URL('../../', import.meta.url).pathname
+const TEST_TOKEN = 'test-only-local-server-token-0123456789'
+const childProcesses: Array<ReturnType<typeof spawnServer>> = []
+
+function createChildEnvironment(overrides: Record<string, string | undefined>): Record<string, string> {
+  const environment: Record<string, string> = {}
+  for (const [name, value] of Object.entries(process.env)) {
+    if (value !== undefined) environment[name] = value
+  }
+  for (const [name, value] of Object.entries(overrides)) {
+    if (value === undefined) delete environment[name]
+    else environment[name] = value
+  }
+  return environment
+}
+
+function spawnServer(script: string, environment: Record<string, string | undefined>) {
+  return Bun.spawn([process.execPath, 'run', script], {
+    cwd: REPOSITORY_ROOT,
+    env: createChildEnvironment(environment),
+    stdout: 'ignore',
+    stderr: 'pipe',
+  })
+}
+
+async function allocateLoopbackPort(): Promise<number> {
+  const reservation = Bun.serve({
+    hostname: DEFAULT_LISTEN_HOST,
+    port: 0,
+    fetch: () => new Response('reserved'),
+  })
+  const port = reservation.port
+  await reservation.stop(true)
+  return port
+}
+
+async function waitForServer(url: string, headers: HeadersInit = {}): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt++) {
+    try {
+      await fetch(url, { headers, signal: AbortSignal.timeout(250) })
+      return
+    } catch {
+      await Bun.sleep(50)
+    }
+  }
+  throw new Error(`Timed out waiting for ${url}`)
+}
+
+function getNonLoopbackIpv4Address(): string | undefined {
+  for (const addresses of Object.values(networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      if (!address.internal && address.family === 'IPv4') return address.address
+    }
+  }
+  return undefined
+}
+
+async function expectLoopbackOnly(port: number, path: string, headers: HeadersInit = {}): Promise<void> {
+  const address = getNonLoopbackIpv4Address()
+  if (!address) return
+
+  let reachable = false
+  try {
+    await fetch(`http://${address}:${port}${path}`, {
+      headers,
+      signal: AbortSignal.timeout(500),
+    })
+    reachable = true
+  } catch {
+    reachable = false
+  }
+  expect(reachable).toBe(false)
+}
+
+async function expectStartupFailure(
+  script: string,
+  environment: Record<string, string | undefined>,
+  expectedMessage: string,
+): Promise<void> {
+  const process = spawnServer(script, environment)
+  const exitCode = await Promise.race([
+    process.exited,
+    Bun.sleep(3000).then(() => null),
+  ])
+  if (exitCode === null) {
+    process.kill()
+    throw new Error(`${script} did not fail closed when its token was missing`)
+  }
+  const errorOutput = await new Response(process.stderr).text()
+  expect(exitCode).not.toBe(0)
+  expect(errorOutput).toContain(expectedMessage)
+}
+
+afterEach(async () => {
+  const processes = childProcesses.splice(0)
+  for (const process of processes) {
+    if (process.exitCode === null) process.kill()
+  }
+  await Promise.allSettled(processes.map(process => process.exited))
+})
+
+describe('local server security helpers', () => {
+  test('defaults to the IPv4 loopback interface', () => {
+    expect(getListenHost(undefined)).toBe(DEFAULT_LISTEN_HOST)
+    expect(getListenHost('')).toBe(DEFAULT_LISTEN_HOST)
+    expect(getListenHost(' 127.0.0.1 ')).toBe(DEFAULT_LISTEN_HOST)
+    expect(getListenHost('0.0.0.0')).toBe('0.0.0.0')
+  })
+
+  test('requires a non-empty token', () => {
+    expect(() => requireServerToken('SERVER_TOKEN', undefined)).toThrow('SERVER_TOKEN')
+    expect(() => requireServerToken('SERVER_TOKEN', '   ')).toThrow('SERVER_TOKEN')
+    expect(() => requireServerToken('SERVER_TOKEN', 'too-short')).toThrow('at least 32')
+    expect(() => requireServerToken('SERVER_TOKEN', `${TEST_TOKEN}!`)).toThrow('URL-safe')
+    expect(requireServerToken('SERVER_TOKEN', ` ${TEST_TOKEN} `)).toBe(TEST_TOKEN)
+  })
+
+  test('accepts only an exact bearer token', () => {
+    expect(hasValidBearerToken(`Bearer ${TEST_TOKEN}`, TEST_TOKEN)).toBe(true)
+    expect(hasValidBearerToken(`bearer ${TEST_TOKEN}`, TEST_TOKEN)).toBe(true)
+    expect(hasValidBearerToken(TEST_TOKEN, TEST_TOKEN)).toBe(false)
+    expect(hasValidBearerToken(`Bearer wrong-${TEST_TOKEN}`, TEST_TOKEN)).toBe(false)
+    expect(hasValidBearerToken(`prefix Bearer ${TEST_TOKEN}`, TEST_TOKEN)).toBe(false)
+    expect(hasValidBearerToken(null, TEST_TOKEN)).toBe(false)
+  })
+
+  test('allows only explicit HTTP origins', () => {
+    expect(parseAllowedOrigins(undefined)).toEqual([])
+    expect(parseAllowedOrigins('https://example.com, http://localhost:5173,https://example.com')).toEqual([
+      'https://example.com',
+      'http://localhost:5173',
+    ])
+    expect(() => parseAllowedOrigins('*')).toThrow('wildcard')
+    expect(() => parseAllowedOrigins('https://example.com/path')).toThrow('without paths')
+    expect(() => parseAllowedOrigins('not-an-origin')).toThrow('invalid origin')
+  })
+})
+
+describe('local server runtime security', () => {
+  test('API gateway fails closed without a token', async () => {
+    await expectStartupFailure(
+      '.opencode/server/api-gateway.ts',
+      { API_GATEWAY_TOKEN: '', API_GATEWAY_PORT: String(await allocateLoopbackPort()) },
+      'API_GATEWAY_TOKEN',
+    )
+  })
+
+  test('API gateway authenticates every route and does not reflect untrusted origins', async () => {
+    const port = await allocateLoopbackPort()
+    const process = spawnServer('.opencode/server/api-gateway.ts', {
+      API_GATEWAY_HOST: '',
+      API_GATEWAY_PORT: String(port),
+      API_GATEWAY_TOKEN: TEST_TOKEN,
+      CORS_ORIGINS: 'https://example.com',
+    })
+    childProcesses.push(process)
+    const healthUrl = `http://${DEFAULT_LISTEN_HOST}:${port}/health`
+    await waitForServer(healthUrl, { Authorization: `Bearer ${TEST_TOKEN}` })
+    await expectLoopbackOnly(port, '/health', { Authorization: `Bearer ${TEST_TOKEN}` })
+
+    expect((await fetch(healthUrl)).status).toBe(401)
+    expect((await fetch(healthUrl, { headers: { Authorization: 'Bearer wrong-token' } })).status).toBe(401)
+
+    const allowedOriginResponse = await fetch(healthUrl, {
+      headers: { Authorization: `Bearer ${TEST_TOKEN}`, Origin: 'https://example.com' },
+    })
+    expect(allowedOriginResponse.status).toBe(200)
+    expect(allowedOriginResponse.headers.get('access-control-allow-origin')).toBe('https://example.com')
+
+    const untrustedOriginResponse = await fetch(healthUrl, {
+      headers: { Authorization: `Bearer ${TEST_TOKEN}`, Origin: 'http://localhost:9999' },
+    })
+    expect(untrustedOriginResponse.status).toBe(200)
+    expect(untrustedOriginResponse.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  test('MCP dashboard fails closed without a token', async () => {
+    await expectStartupFailure(
+      '.opencode/server/mcp-dashboard.ts',
+      { DASHBOARD_TOKEN: '', MCP_DASHBOARD_PORT: String(await allocateLoopbackPort()) },
+      'DASHBOARD_TOKEN',
+    )
+  })
+
+  test('MCP dashboard requires authentication before server inspection or control', async () => {
+    const port = await allocateLoopbackPort()
+    const process = spawnServer('.opencode/server/mcp-dashboard.ts', {
+      DASHBOARD_TOKEN: TEST_TOKEN,
+      MCP_DASHBOARD_HOST: '',
+      MCP_DASHBOARD_PORT: String(port),
+    })
+    childProcesses.push(process)
+    const baseUrl = `http://${DEFAULT_LISTEN_HOST}:${port}`
+    await waitForServer(`${baseUrl}/health`)
+    await expectLoopbackOnly(port, '/health')
+
+    expect((await fetch(`${baseUrl}/api/servers`)).status).toBe(401)
+    expect((await fetch(`${baseUrl}/api/servers/memory/start`, { method: 'POST' })).status).toBe(401)
+    expect((await fetch(`${baseUrl}/api/servers/memory/stop`, { method: 'POST' })).status).toBe(401)
+
+    const authorizedResponse = await fetch(`${baseUrl}/api/servers/not-configured/start`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TEST_TOKEN}` },
+    })
+    expect(authorizedResponse.status).toBe(404)
+
+    const unmanagedStopResponse = await fetch(`${baseUrl}/api/servers/memory/stop`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TEST_TOKEN}` },
+    })
+    expect(unmanagedStopResponse.status).toBe(409)
+
+    const authStatus = await fetch(`${baseUrl}/api/auth/status`).then(response => response.json())
+    expect(authStatus).toEqual({ required: true, configured: true })
+
+    const dashboardSource = await Bun.file(`${REPOSITORY_ROOT}.opencode/server/mcp-dashboard.ts`).text()
+    expect(dashboardSource).not.toContain("Bun.spawn(['pkill'")
+  })
+
+  test('main server binds only to loopback by default', async () => {
+    const port = await allocateLoopbackPort()
+    const process = spawnServer('.opencode/server/index.ts', {
+      OPENCODE_SERVER_HOST: '',
+      PORT: String(port),
+    })
+    childProcesses.push(process)
+    await waitForServer(`http://${DEFAULT_LISTEN_HOST}:${port}/health`)
+    await expectLoopbackOnly(port, '/health')
+  })
+})

--- a/.opencode/server/security.ts
+++ b/.opencode/server/security.ts
@@ -1,0 +1,46 @@
+export const DEFAULT_LISTEN_HOST = '127.0.0.1'
+
+export function getListenHost(configuredHost: string | undefined): string {
+  return configuredHost?.trim() || DEFAULT_LISTEN_HOST
+}
+
+export function requireServerToken(environmentName: string, configuredToken: string | undefined): string {
+  const token = configuredToken?.trim()
+  if (!token) {
+    throw new Error(`${environmentName} must be set to a non-empty bearer token before this server can start`)
+  }
+  if (!/^[A-Za-z0-9._~-]{32,}$/.test(token)) {
+    throw new Error(`${environmentName} must contain at least 32 letters, digits, or URL-safe token characters`)
+  }
+  return token
+}
+
+export function hasValidBearerToken(authorization: string | null, expectedToken: string): boolean {
+  if (!authorization) return false
+
+  const match = authorization.match(/^Bearer ([^\s]+)$/i)
+  return match?.[1] === expectedToken
+}
+
+export function parseAllowedOrigins(configuredOrigins: string | undefined): string[] {
+  if (!configuredOrigins?.trim()) return []
+
+  const origins = [...new Set(configuredOrigins.split(',').map(origin => origin.trim()).filter(Boolean))]
+  if (origins.includes('*')) {
+    throw new Error('CORS_ORIGINS cannot contain a wildcard; configure explicit trusted origins')
+  }
+
+  for (const origin of origins) {
+    let parsed: URL
+    try {
+      parsed = new URL(origin)
+    } catch {
+      throw new Error(`CORS_ORIGINS contains an invalid origin: ${origin}`)
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol) || parsed.origin !== origin) {
+      throw new Error(`CORS_ORIGINS entries must be HTTP(S) origins without paths: ${origin}`)
+    }
+  }
+
+  return origins
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "scripts": {
     "dev": "bun run .opencode/server/api-gateway.ts",
     "dashboard": "bun run .opencode/server/mcp-dashboard.ts",
+    "server:test": "bun test ./.opencode/server/security.test.ts",
+    "server:typecheck": "tsc --noEmit --skipLibCheck --target ES2022 --module ESNext --moduleResolution Bundler --types bun .opencode/server/api-gateway.ts .opencode/server/mcp-dashboard.ts .opencode/server/index.ts .opencode/server/security.ts .opencode/server/security.test.ts",
+    "server:check": "bun run server:typecheck && bun run server:test",
     "quality": "bun run .opencode/tool/parallel-quality.ts",
     "dspy:init": "dspyground init",
     "dspy:dev": "dspyground dev",


### PR DESCRIPTION
## Summary

- Restrict the bundled OpenCode servers to loopback by default.
- Require strong bearer-token authentication and explicit CORS configuration.
- Track and stop only subprocesses launched by the current dashboard instance.
- Add runtime security regression coverage and authenticated local-workflow documentation.

Resolves #27942

## Verification

- `bun run server:check`: 9 tests passed; targeted TypeScript check passed.
- `bun test`: 96 tests passed, 0 failed.
- `shellcheck .agents/scripts/mcp-inspector-helper.sh`: passed with zero findings.
- `.agents/scripts/linters-local.sh`: all changed-file gates passed.
- Independent security re-review found no remaining blocking or high-severity findings.

This is a coordinated security hardening change. Detailed disclosure remains private until the patched release is available.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 44m and 600,483 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added required bearer-token authentication for API Gateway and MCP Dashboard access.
  * Added configurable listen hosts, defaulting to local-only access.
  * Added allowlisted CORS origin support.
  * Improved dashboard server start/stop controls and status handling.

* **Documentation**
  * Updated local setup, authentication, troubleshooting, and API usage guidance.

* **Tests**
  * Added security coverage for authentication, CORS, host binding, and server controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->