### PR TITLE
GH#27946: harden pulse infrastructure rerun defaults

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -205,8 +205,10 @@ _pmrc_rerun_infrastructure_check() {
 	local check_name="$3"
 	local check_url="$4"
 	local run_id="" cooldown_seconds="${PULSE_MERGE_INFRA_RERUN_COOLDOWN_SECONDS:-900}"
-	local state_dir="${PULSE_MERGE_INFRA_RERUN_STATE_DIR:-${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/pulse-infra-check-reruns}"
+	local state_root="${AIDEVOPS_TEMP_DIR:-${HOME:+$HOME/.aidevops/.agent-workspace/tmp}}"
+	local state_dir="${PULSE_MERGE_INFRA_RERUN_STATE_DIR:-${state_root:+$state_root/pulse-infra-check-reruns}}"
 	local state_file="" now_epoch="${PULSE_MERGE_NOW_EPOCH:-$(date +%s)}" last_attempt="0"
+	local log_target="${LOGFILE:-/dev/stderr}"
 
 	[[ -n "$repo_slug" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
 	[[ "$check_url" == "https://github.com/${repo_slug}/actions/runs/"*"/job/"* ]] || return 1
@@ -215,10 +217,11 @@ _pmrc_rerun_infrastructure_check() {
 	[[ "$run_id" =~ ^[0-9]+$ ]] || return 1
 	[[ "$cooldown_seconds" =~ ^[0-9]+$ ]] || cooldown_seconds=900
 	[[ "$now_epoch" =~ ^[0-9]+$ ]] || return 1
+	[[ -n "$state_dir" ]] || return 1
 
 	if declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 &&
 		! repo_allows_pulse_write_actions "$repo_slug"; then
-		echo "[pulse-merge] infrastructure rerun deferred for PR #${pr_number} check '${check_name}' in ${repo_slug} — repository writes are disabled" >>"$LOGFILE"
+		echo "[pulse-merge] infrastructure rerun deferred for PR #${pr_number} check '${check_name}' in ${repo_slug} — repository writes are disabled" >>"$log_target"
 		return 1
 	fi
 
@@ -229,7 +232,7 @@ _pmrc_rerun_infrastructure_check() {
 	fi
 	[[ "$last_attempt" =~ ^[0-9]+$ ]] || last_attempt=0
 	if [[ $((now_epoch - last_attempt)) -lt "$cooldown_seconds" ]]; then
-		echo "[pulse-merge] infrastructure rerun cooldown active for PR #${pr_number} check '${check_name}' in ${repo_slug} (run=${run_id}, cooldown=${cooldown_seconds}s) — merge remains blocked" >>"$LOGFILE"
+		echo "[pulse-merge] infrastructure rerun cooldown active for PR #${pr_number} check '${check_name}' in ${repo_slug} (run=${run_id}, cooldown=${cooldown_seconds}s) — merge remains blocked" >>"$log_target"
 		return 0
 	fi
 
@@ -237,10 +240,10 @@ _pmrc_rerun_infrastructure_check() {
 	#aidevops:trust-boundary — the run ID comes from the current-head check-run
 	# URL returned by GitHub, and the repository already passed pulse write policy.
 	if gh run rerun "$run_id" --repo "$repo_slug" --failed >/dev/null 2>&1; then
-		echo "[pulse-merge] requested infrastructure rerun for PR #${pr_number} check '${check_name}' in ${repo_slug} (run=${run_id}) — merge remains blocked pending fresh success (GH#27825)" >>"$LOGFILE"
+		echo "[pulse-merge] requested infrastructure rerun for PR #${pr_number} check '${check_name}' in ${repo_slug} (run=${run_id}) — merge remains blocked pending fresh success (GH#27825)" >>"$log_target"
 		return 0
 	fi
-	echo "[pulse-merge] infrastructure rerun request failed for PR #${pr_number} check '${check_name}' in ${repo_slug} (run=${run_id}); cooldown recorded — merge remains blocked (GH#27825)" >>"$LOGFILE"
+	echo "[pulse-merge] infrastructure rerun request failed for PR #${pr_number} check '${check_name}' in ${repo_slug} (run=${run_id}); cooldown recorded — merge remains blocked (GH#27825)" >>"$log_target"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -169,7 +169,45 @@ set_live_evidence() {
 	return 0
 }
 
+assert_infrastructure_rerun_unset_defaults_safe() {
+	local output="" rc=0
+	output=$(
+		unset LOGFILE HOME AIDEVOPS_TEMP_DIR PULSE_MERGE_INFRA_RERUN_STATE_DIR
+		_pmrc_rerun_infrastructure_check owner/repo 7 required-a \
+			"https://github.com/owner/repo/actions/runs/707/job/808"
+	) 2>&1 || rc=$?
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 1 && -z "$output" ]]; then
+		printf 'PASS unset HOME fails closed without resolving a root-level state directory\n'
+		return 0
+	fi
+	printf 'FAIL unset HOME was not handled safely (rc=%s, output=%s)\n' "$rc" "$output"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_infrastructure_rerun_unset_logfile_safe() {
+	local output="" rc=0 stderr_file="${TEST_ROOT}/unset-log-stderr"
+	(
+		unset LOGFILE HOME AIDEVOPS_TEMP_DIR
+		PULSE_MERGE_INFRA_RERUN_STATE_DIR="${TEST_ROOT}/unset-log-reruns"
+		_pmrc_rerun_infrastructure_check owner/repo 7 required-a \
+			"https://github.com/owner/repo/actions/runs/909/job/1001"
+	) 2>"$stderr_file" || rc=$?
+	output=$(<"$stderr_file")
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 && "$output" == *"requested infrastructure rerun"* ]]; then
+		printf 'PASS unset LOGFILE falls back to stderr under set -u\n'
+		return 0
+	fi
+	printf 'FAIL unset LOGFILE was not handled safely (rc=%s, output=%s)\n' "$rc" "$output"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
 main() {
+	assert_infrastructure_rerun_unset_defaults_safe
+	assert_infrastructure_rerun_unset_logfile_safe
 	assert_gate "terminal checks with explicit baseline advisory pass" happy_advisory 0
 	if grep -q "IGNORED non-required baseline advisory failure 'Qlty Smell Threshold'" "$LOGFILE"; then
 		printf 'PASS ignored advisory failure is audited\n'


### PR DESCRIPTION
## Summary

- safely resolve infrastructure rerun logging when `LOGFILE` is unset under `set -u`
- fail closed instead of deriving a root-level state directory when `HOME` and explicit temp roots are unavailable
- cover unset `HOME` and `LOGFILE` behavior in the preflight snapshot regression suite

## Testing

- `bash -n .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh`
- `shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh`
- `bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh` (33/33 passed)

## Runtime Testing

- runtime-verified through direct execution of infrastructure rerun paths with unset environment variables

Resolves #27946

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 5m and 76,070 tokens on this as a headless worker.
