### PR TITLE
GH#27944: preserve API gateway curl failures

### DIFF
--- a/.agents/scripts/mcp-inspector-helper.sh
+++ b/.agents/scripts/mcp-inspector-helper.sh
@@ -53,7 +53,7 @@ gateway_curl() {
     curl --fail --silent --show-error \
         --config <(printf 'header = "Authorization: Bearer %s"\n' "$API_GATEWAY_TOKEN") \
         "${curl_args[@]}" "$url"
-    return 0
+    return $?
 }
 
 # Launch MCP Inspector Web UI


### PR DESCRIPTION
## Summary

- Preserve curl's failure status in the authenticated API gateway wrapper.
- Prevent gateway health checks and endpoint tests from treating transport or HTTP errors as successful requests.

## Testing

- `shellcheck .agents/scripts/mcp-inspector-helper.sh`
- `API_GATEWAY_TOKEN=<32-character-placeholder> bash .agents/scripts/mcp-inspector-helper.sh test-gateway` with no local gateway: reported `0 passed / 5 failed`

## Runtime Testing

`runtime-verified`: exercised every authenticated gateway call site against an unavailable endpoint and confirmed each followed its failure path.

Resolves #27944

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18
