### PR TITLE
GH#27952: accept canonical task brief paths

### DIFF
--- a/.agents/scripts/task-identity-lib.sh
+++ b/.agents/scripts/task-identity-lib.sh
@@ -192,9 +192,20 @@ task_identity_has_malformed_candidate() {
 	# Spell out the uppercase set: locale collation can make A-Z match lowercase
 	# letters, falsely classifying ordinary words such as "throughput" as IDs.
 	local candidate_ere='(^|[^[:alnum:].])([tT][0123456789][[:alnum:].-]*|t[ABCDEFGHIJKLMNOPQRSTUVWXYZ][[:alnum:].-]*|[tT][oO][[:alnum:]]{26}-[[:alnum:].-]+)($|[^[:alnum:].])'
+	local brief_path_ere="(^|[^[:alnum:]./])todo/tasks/(${TASK_IDENTITY_TOKEN_ERE})-brief\\.md($|[^[:alnum:].])"
 	local candidate=""
 	local remaining="$text"
 	local matched=""
+
+	# Canonical task-brief paths contain a valid ID followed by a filename suffix,
+	# not a malformed task identity. Remove only this repository path grammar;
+	# arbitrary <task-id>-suffix tokens must continue to fail closed below.
+	while [[ "$remaining" =~ $brief_path_ere ]]; do
+		matched="${BASH_REMATCH[0]}"
+		candidate="${BASH_REMATCH[2]}"
+		task_identity_validate "$candidate" || return 0
+		remaining="${remaining/"$matched"/ }"
+	done
 
 	while [[ "$remaining" =~ $candidate_ere ]]; do
 		matched="${BASH_REMATCH[0]}"

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -987,6 +987,50 @@ test_no_false_positive_multiple_subagent_names() {
 }
 
 # ---------------------------------------------------------------------------
+# Case 20: Allow — canonical task-brief paths do not make valid PR IDs malformed
+# ---------------------------------------------------------------------------
+test_check_pr_allows_canonical_task_brief_path() {
+	local name="case-20: check-pr allows a canonical task-brief path in the PR body"
+	local rc
+	_run_check_pr_with_pr_title \
+		"9999" \
+		"20000" \
+		"t18139: implement repository campaigns" \
+		$'Implementation: todo/tasks/t18139-brief.md\n\nResolves #42' \
+		"42" \
+		"t18139: implement repository campaigns"
+	rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (canonical task-brief path accepted), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 21: Reject — malformed IDs remain blocked inside task-like brief paths
+# ---------------------------------------------------------------------------
+test_check_pr_rejects_malformed_task_brief_path() {
+	local name="case-21: check-pr rejects a malformed task ID in a brief path"
+	local rc
+	_run_check_pr_with_pr_title \
+		"9999" \
+		"20000" \
+		"chore: document implementation" \
+		"Implementation: todo/tasks/t018139-brief.md" \
+		"" \
+		""
+	rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 1 (malformed task ID blocked), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
@@ -1011,6 +1055,8 @@ main() {
 	test_check_pr_cached_branch_subjects_read_final_range_claim
 	test_no_false_positive_subagent_name
 	test_no_false_positive_multiple_subagent_names
+	test_check_pr_allows_canonical_task_brief_path
+	test_check_pr_rejects_malformed_task_brief_path
 
 	printf '\n'
 	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"

--- a/.agents/scripts/tests/test-task-identity-lib.sh
+++ b/.agents/scripts/tests/test-task-identity-lib.sh
@@ -296,6 +296,19 @@ test_structured_helpers() {
 		return 1
 	fi
 	pass "malformed detector accepts a valid task-prefixed title"
+	if task_identity_has_malformed_candidate "See todo/tasks/t18139-brief.md for implementation context" ||
+		task_identity_has_malformed_candidate "See todo/tasks/${namespaced}-brief.md for implementation context"; then
+		fail "malformed detector rejected a canonical task-brief path"
+		return 1
+	fi
+	pass "malformed detector accepts canonical task-brief paths"
+	if ! task_identity_has_malformed_candidate "See todo/tasks/t018139-brief.md" ||
+		! task_identity_has_malformed_candidate "See notes/t18139-brief.md" ||
+		! task_identity_has_malformed_candidate "See todo/tasks/t18139-draft.md"; then
+		fail "malformed detector weakened non-canonical task-like path checks"
+		return 1
+	fi
+	pass "malformed detector rejects malformed and non-canonical task-like paths"
 	if task_identity_has_malformed_candidate "TODO.md and Testing evidence"; then
 		fail "malformed detector treated ordinary uppercase T-words as task IDs"
 		return 1


### PR DESCRIPTION
## Summary

Accept canonical todo task-brief file references while preserving malformed task identity detection

## Files Changed

.agents/scripts/task-identity-lib.sh, .agents/scripts/tests/test-task-id-collision-guard.sh, .agents/scripts/tests/test-task-identity-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Task identity suite passes 83 assertions and ShellCheck is clean; collision-guard integration regressions are included for CI

Resolves #27952


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 5m and 85,724 tokens on this as a headless worker.