### PR TITLE
GH#27945: derive dashboard WebSocket URL from page

### DIFF
--- a/.opencode/server/mcp-dashboard.ts
+++ b/.opencode/server/mcp-dashboard.ts
@@ -467,7 +467,8 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
     }
 
     function connectWebSocket() {
-      ws = new WebSocket('ws://localhost:${CONFIG.port}/ws');
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      ws = new WebSocket(protocol + '//' + window.location.host + '/ws');
       ws.onmessage = (e) => {
         const data = JSON.parse(e.data);
         if (data.type === 'update') {

--- a/.opencode/server/security.test.ts
+++ b/.opencode/server/security.test.ts
@@ -204,6 +204,11 @@ describe('local server runtime security', () => {
     await waitForServer(`${baseUrl}/health`)
     await expectLoopbackOnly(port, '/health')
 
+    const dashboardHtml = await fetch(baseUrl).then(response => response.text())
+    expect(dashboardHtml).toContain("window.location.protocol === 'https:' ? 'wss:' : 'ws:'")
+    expect(dashboardHtml).toContain("window.location.host + '/ws'")
+    expect(dashboardHtml).not.toContain('ws://localhost:')
+
     expect((await fetch(`${baseUrl}/api/servers`)).status).toBe(401)
     expect((await fetch(`${baseUrl}/api/servers/memory/start`, { method: 'POST' })).status).toBe(401)
     expect((await fetch(`${baseUrl}/api/servers/memory/stop`, { method: 'POST' })).status).toBe(401)


### PR DESCRIPTION
## Summary

- derive the dashboard WebSocket scheme from the current page protocol
- use the current page host and port for remote deployments
- cover the served client script with a runtime regression test

## Testing

- `bun run server:check` (TypeScript typecheck; 9 tests, 43 assertions)

## Runtime Testing

- `runtime-verified`: launched the MCP dashboard in the Bun integration suite and fetched its served HTML

Resolves #27945

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 5m and 124,916 tokens on this as a headless worker.
