### PR TITLE
GH#27947: preserve objective input indices

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1383,7 +1383,7 @@ reconcile_issues_single_pass() {
 			fi
 			# GH#27803: issue and PR caches can exceed Linux MAX_ARG_STRLEN.
 			# Stream both JSON documents to jq instead of passing either via argv.
-			objective_input=$(printf '%s\n%s\n' "$issues_json" "$objective_prs" | jq -sc \
+			objective_input=$(printf '%s\n%s\n' "${issues_json:-[]}" "${objective_prs:-[]}" | jq -sc \
 				--arg merged "$oimp_lookup" '{issues: .[0], prs: .[1], merged_lookup: $merged}') || objective_input=""
 			if [[ -n "$objective_input" ]]; then
 				printf '%s' "$objective_input" | "$objective_helper" reconcile --repo "$slug" \

--- a/.agents/scripts/tests/test-jq-large-json-argv-regression.sh
+++ b/.agents/scripts/tests/test-jq-large-json-argv-regression.sh
@@ -174,6 +174,18 @@ test_objective_reconciliation_accepts_large_lists() {
 	return 0
 }
 
+test_objective_reconciliation_defaults_empty_lists() {
+	local issues_json="" objective_prs='[{"number":7}]' output
+	output=$(printf '%s\n%s\n' "${issues_json:-[]}" "${objective_prs:-[]}" | jq -sc \
+		'{issues: .[0], prs: .[1]}')
+	if printf '%s' "$output" | jq -e '.issues == [] and .prs == [{"number":7}]' >/dev/null; then
+		print_result "objective reconciliation preserves indices for empty lists" 0
+	else
+		print_result "objective reconciliation preserves indices for empty lists" 1
+	fi
+	return 0
+}
+
 test_known_large_argjson_patterns_absent() {
 	local failed=0
 	if grep -nE -- '--argjson (prs|issues) "\$\{PREFETCH_UPDATED_(PRS|ISSUES)' "$SCRIPTS_DIR/pulse-prefetch-fetch.sh" >/dev/null 2>&1; then
@@ -202,6 +214,7 @@ main() {
 	test_prefetch_cache_set_accepts_large_entry
 	test_quality_feedback_summary_accepts_large_details
 	test_objective_reconciliation_accepts_large_lists
+	test_objective_reconciliation_defaults_empty_lists
 	test_known_large_argjson_patterns_absent
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Default empty issue and PR payloads to valid JSON arrays before jq slurping so document indices cannot shift

## Files Changed

.agents/scripts/pulse-issue-reconcile.sh, .agents/scripts/tests/test-jq-large-json-argv-regression.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-jq-large-json-argv-regression.sh; shellcheck .agents/scripts/pulse-issue-reconcile.sh .agents/scripts/tests/test-jq-large-json-argv-regression.sh

Resolves #27947


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 42,339 tokens on this as a headless worker.