### PR TITLE
t18141: Fix Pulse campaign coordinator symlink entrypoint

### DIFF
--- a/.agents/scripts/pulse-campaign-coordinator.mjs
+++ b/.agents/scripts/pulse-campaign-coordinator.mjs
@@ -7,10 +7,12 @@ import {
   existsSync,
   lstatSync,
   readFileSync,
+  realpathSync,
   statSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   campaignCheckpointPath,
@@ -189,7 +191,16 @@ export function run(args = process.argv.slice(2)) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+function invokedAsScript(moduleUrl, argvPath) {
+  if (!argvPath) return false;
+  try {
+    return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url, process.argv[1])) {
   try {
     process.exitCode = run();
   } catch (error) {

--- a/.agents/scripts/tests/test-pulse-campaign-coordinator.mjs
+++ b/.agents/scripts/tests/test-pulse-campaign-coordinator.mjs
@@ -381,10 +381,13 @@ test("derives the same scope from paths in one Git common directory", () => {
   assert.match(rootScope.scopeKey, /^[0-9a-f]{16}$/);
 });
 
-test("CLI creates and renews exactly one checkpoint for one repository scope", () => {
+test("CLI creates and renews one checkpoint through a symlinked deployed entrypoint", () => {
   const directory = testTempRoot();
   try {
     const repositoryRoot = resolve(import.meta.dirname, "../../..");
+    const deployedAgents = join(directory, "deployed-agents");
+    symlinkSync(resolve(import.meta.dirname, "../.."), deployedAgents);
+    const deployedCoordinator = join(deployedAgents, "scripts", "pulse-campaign-coordinator.mjs");
     const checkpointRoot = join(directory, "checkpoints");
     const issuesFile = join(directory, "issues.json");
     const readyFile = join(directory, "ready.json");
@@ -404,7 +407,7 @@ test("CLI creates and renews exactly one checkpoint for one repository scope", (
     writeFileSync(peerFile, JSON.stringify({}));
 
     const baseArgs = [
-      COORDINATOR_PATH,
+      deployedCoordinator,
       "plan",
       "--repo", "example/repository",
       "--repo-path", repositoryRoot,

--- a/.agents/scripts/tests/test-pulse-campaign-coordinator.mjs
+++ b/.agents/scripts/tests/test-pulse-campaign-coordinator.mjs
@@ -386,7 +386,7 @@ test("CLI creates and renews one checkpoint through a symlinked deployed entrypo
   try {
     const repositoryRoot = resolve(import.meta.dirname, "../../..");
     const deployedAgents = join(directory, "deployed-agents");
-    symlinkSync(resolve(import.meta.dirname, "../.."), deployedAgents);
+    symlinkSync(resolve(import.meta.dirname, "../.."), deployedAgents, "dir");
     const deployedCoordinator = join(deployedAgents, "scripts", "pulse-campaign-coordinator.mjs");
     const checkpointRoot = join(directory, "checkpoints");
     const issuesFile = join(directory, "issues.json");


### PR DESCRIPTION
## Summary

Resolve the coordinator main-module guard against canonical filesystem paths so deployed directory symlinks execute the CLI, and cover checkpoint creation through a deployed-style symlink.

## Files Changed

.agents/scripts/pulse-campaign-coordinator.mjs, .agents/scripts/tests/test-pulse-campaign-coordinator.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check; node --test test-pulse-campaign-coordinator.mjs (21/21); test-pulse-campaign-shadow.sh; linters-local.sh --changed; Qlty changed-file check

Resolves #27966


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.131 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 10h 58m and 3,187,522 tokens on this with the user in an interactive session.