### PR TITLE
t18142: validate MCP health service identity

### DIFF
--- a/.agents/scripts/mcp-inspector-helper.sh
+++ b/.agents/scripts/mcp-inspector-helper.sh
@@ -56,6 +56,31 @@ gateway_curl() {
     return $?
 }
 
+# Fetch a service health response, authenticating the API gateway when needed.
+fetch_health_response() {
+    local service="$1"
+    local url="$2"
+
+    if [[ "$service" == "api-gateway" ]]; then
+        gateway_curl "$url"
+        return $?
+    fi
+
+    curl --fail --silent --show-error "$url"
+    return $?
+}
+
+# Accept only the expected aidevops service's explicit healthy response.
+health_response_matches_service() {
+    local response="$1"
+    local expected_service="$2"
+
+    printf '%s' "$response" | jq -e --arg expected_service "$expected_service" \
+        'type == "object" and .status == "healthy" and .service == $expected_service' \
+        >/dev/null 2>&1
+    return $?
+}
+
 # Launch MCP Inspector Web UI
 launch_ui() {
     local server="${1:-}"
@@ -176,17 +201,18 @@ health_check() {
     for port in 3100 3101; do
         total=$((total + 1))
         local name="localhost:$port"
+        local expected_service="mcp-dashboard"
         local response
         if [[ "$port" == "3100" ]]; then
-            response=$(gateway_curl "http://localhost:$port/health" 2>/dev/null) || response=""
-        else
-            response=$(curl --fail --silent --show-error "http://localhost:$port/health" 2>/dev/null) || response=""
+            expected_service="api-gateway"
         fi
-        if [[ -n "$response" ]]; then
-            local status
-            status=$(echo "$response" | jq -r '.status // "ok"' 2>/dev/null || echo "healthy")
-            print_success "$name - $status"
+        response=$(fetch_health_response "$expected_service" "http://localhost:$port/health" 2>/dev/null) || response=""
+        if health_response_matches_service "$response" "$expected_service"; then
+            print_success "$name - healthy"
             healthy=$((healthy + 1))
+        elif [[ -n "$response" ]]; then
+            print_error "$name - unexpected service health response"
+            failed=$((failed + 1))
         else
             print_error "$name - not running"
             failed=$((failed + 1))
@@ -204,18 +230,15 @@ health_check() {
         
         if [[ "$server_type" == "streamable-http" || "$server_type" == "sse" ]]; then
             local url
-            local reachable=0
+            local response
             url=$(jq -r ".mcpServers[\"$srv\"].url" "$CONFIG_FILE")
-            if [[ "$srv" == "api-gateway" ]]; then
-                if gateway_curl "$url/health" > /dev/null 2>&1; then
-                    reachable=1
-                fi
-            elif curl --fail --silent --show-error "$url/health" > /dev/null 2>&1; then
-                reachable=1
-            fi
-            if [[ "$reachable" -eq 1 ]]; then
+            response=$(fetch_health_response "$srv" "$url/health" 2>/dev/null) || response=""
+            if health_response_matches_service "$response" "$srv"; then
                 print_success "$srv ($server_type) - healthy"
                 healthy=$((healthy + 1))
+            elif [[ -n "$response" ]]; then
+                print_error "$srv ($server_type) - unexpected service health response"
+                failed=$((failed + 1))
             else
                 print_warning "$srv ($server_type) - not reachable"
                 failed=$((failed + 1))

--- a/.agents/scripts/tests/test-mcp-inspector-health-identity.sh
+++ b/.agents/scripts/tests/test-mcp-inspector-health-identity.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#27967: MCP health checks must reject unrelated
+# HTTP responses and accept only explicit aidevops service identities.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../mcp-inspector-helper.sh"
+SANDBOX=""
+OUTPUT=""
+TEST_TOKEN="test-only-mcp-health-token-0123456789"
+
+cleanup() {
+	[[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX" 2>/dev/null || true
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+assert_contains() {
+	local description="$1"
+	local expected="$2"
+
+	if [[ "$OUTPUT" != *"$expected"* ]]; then
+		fail "$description (missing: $expected)"
+		return 1
+	fi
+	pass "$description"
+	return 0
+}
+
+assert_not_contains() {
+	local description="$1"
+	local unexpected="$2"
+
+	if [[ "$OUTPUT" == *"$unexpected"* ]]; then
+		fail "$description (unexpected: $unexpected)"
+		return 1
+	fi
+	pass "$description"
+	return 0
+}
+
+run_health_fixture() {
+	local fixture="$1"
+
+	OUTPUT=$(PATH="${SANDBOX}/bin:${PATH}" \
+		MCP_HEALTH_FIXTURE="$fixture" \
+		FAKE_CURL_ARGS_LOG="${SANDBOX}/curl-args.log" \
+		API_GATEWAY_TOKEN="$TEST_TOKEN" \
+		bash "$HELPER" health 2>&1)
+	return 0
+}
+
+SANDBOX=$(mktemp -d -t aidevops-mcp-health-XXXXXX)
+mkdir -p "${SANDBOX}/bin"
+
+cat >"${SANDBOX}/bin/npx" <<'EOF_NPX'
+#!/usr/bin/env bash
+exit 0
+EOF_NPX
+
+cat >"${SANDBOX}/bin/curl" <<'EOF_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=""
+for argument in "$@"; do
+	if [[ "$argument" == http://* || "$argument" == https://* ]]; then
+		url="$argument"
+	fi
+done
+printf '%s\n' "$*" >>"$FAKE_CURL_ARGS_LOG"
+
+case "${MCP_HEALTH_FIXTURE}:${url}" in
+valid:*:3100/health)
+	printf '%s\n' '{"status":"healthy","service":"api-gateway"}'
+	;;
+valid:*:3101/health)
+	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
+	;;
+unrelated:*:3100/health)
+	printf '%s\n' '<html>redirect</html>'
+	;;
+unrelated:*:3101/health)
+	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
+	;;
+wrong-service:*:3100/health)
+	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
+	;;
+wrong-service:*:3101/health)
+	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
+	;;
+unhealthy:*:3100/health)
+	printf '%s\n' '{"status":"unhealthy","service":"api-gateway"}'
+	;;
+unhealthy:*:3101/health)
+	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
+	;;
+*)
+	exit 22
+	;;
+esac
+exit 0
+EOF_CURL
+
+chmod +x "${SANDBOX}/bin/npx" "${SANDBOX}/bin/curl"
+
+run_health_fixture valid
+assert_contains "valid gateway identity is healthy" "localhost:3100 - healthy"
+assert_contains "valid dashboard identity is healthy" "localhost:3101 - healthy"
+assert_contains "configured gateway identity is healthy" "api-gateway (streamable-http) - healthy"
+assert_contains "configured dashboard identity is healthy" "mcp-dashboard (streamable-http) - healthy"
+
+run_health_fixture unrelated
+assert_contains "non-JSON gateway response is rejected locally" "localhost:3100 - unexpected service health response"
+assert_contains "non-JSON gateway response is rejected from config" "api-gateway (streamable-http) - unexpected service health response"
+assert_not_contains "non-JSON gateway response is not reported healthy" "localhost:3100 - healthy"
+
+run_health_fixture wrong-service
+assert_contains "wrong service identity is rejected" "localhost:3100 - unexpected service health response"
+
+run_health_fixture unhealthy
+assert_contains "unhealthy status is rejected" "localhost:3100 - unexpected service health response"
+
+if grep -Fq "$TEST_TOKEN" "${SANDBOX}/curl-args.log"; then
+	fail "gateway token leaked into curl argv"
+	exit 1
+fi
+pass "gateway token stays out of curl argv"
+
+printf 'All MCP inspector health identity tests passed.\n'
+exit 0

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -338,6 +338,12 @@ jobs:
         echo ""
         echo "All shell scripts passed ShellCheck"
 
+    - name: MCP Inspector Health Identity Regression (GH#27967)
+      run: |
+        echo "Running MCP inspector health identity regression test..."
+        bash .agents/scripts/tests/test-mcp-inspector-health-identity.sh
+        echo "MCP inspector health identity regression test passed"
+
     - name: Secret Safety Policy Check
       run: |
         echo "Running secret safety policy checks..."

--- a/.opencode/server/api-gateway.ts
+++ b/.opencode/server/api-gateway.ts
@@ -242,6 +242,7 @@ function getClientIP(request: Request): string {
 function handleHealth() {
   return {
     status: 'healthy',
+    service: 'api-gateway',
     uptime: Math.floor((Date.now() - startTime) / 1000),
     requests: requestCount,
     cache: { size: cache.size, maxSize: CONFIG.cache.maxSize },

--- a/.opencode/server/security.test.ts
+++ b/.opencode/server/security.test.ts
@@ -176,6 +176,10 @@ describe('local server runtime security', () => {
     })
     expect(allowedOriginResponse.status).toBe(200)
     expect(allowedOriginResponse.headers.get('access-control-allow-origin')).toBe('https://example.com')
+    expect(await allowedOriginResponse.json()).toMatchObject({
+      status: 'healthy',
+      service: 'api-gateway',
+    })
 
     const untrustedOriginResponse = await fetch(healthUrl, {
       headers: { Authorization: `Bearer ${TEST_TOKEN}`, Origin: 'http://localhost:9999' },
@@ -227,6 +231,9 @@ describe('local server runtime security', () => {
 
     const authStatus = await fetch(`${baseUrl}/api/auth/status`).then(response => response.json())
     expect(authStatus).toEqual({ required: true, configured: true })
+
+    const health = await fetch(`${baseUrl}/health`).then(response => response.json())
+    expect(health).toMatchObject({ status: 'healthy', service: 'mcp-dashboard' })
 
     const dashboardSource = await Bun.file(`${REPOSITORY_ROOT}.opencode/server/mcp-dashboard.ts`).text()
     expect(dashboardSource).not.toContain("Bun.spawn(['pkill'")


### PR DESCRIPTION
## Summary

Require MCP health probes to match explicit healthy service markers, add the gateway marker, and run the mocked identity regression in CI.

## Files Changed

.agents/scripts/mcp-inspector-helper.sh, .agents/scripts/tests/test-mcp-inspector-health-identity.sh, .github/workflows/code-quality.yml, .opencode/server/api-gateway.ts, .opencode/server/security.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun run server:check (9 passed, 45 assertions); bun test (96 passed, 640 assertions); Bash 3.2 regression test; ShellCheck; actionlint; linters-local.sh; live port-3100 unrelated-service rejection.

Resolves #27967


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.131 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 10h 24m and 1,380,159 tokens on this with the user in an interactive session.