### PR TITLE
t18143: Honor configurable ports in MCP inspector checks

### DIFF
--- a/.agents/scripts/mcp-inspector-helper.sh
+++ b/.agents/scripts/mcp-inspector-helper.sh
@@ -24,9 +24,25 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 readonly SCRIPT_DIR
 readonly CONFIG_FILE="${SCRIPT_DIR}/../../.opencode/server/mcp-test-config.json"
+readonly API_GATEWAY_PORT_DEFAULT=3100
+readonly MCP_DASHBOARD_PORT_DEFAULT=3101
+readonly API_GATEWAY_SERVICE="api-gateway"
+readonly MCP_DASHBOARD_SERVICE="mcp-dashboard"
 
 print_header() { 
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    return 0
+}
+
+# Validate a local TCP port before interpolating it into a URL.
+validate_local_port() {
+    local variable_name="$1"
+    local port="$2"
+
+    if [[ ! "$port" =~ ^[0-9]{1,5}$ ]] || ((10#$port < 1 || 10#$port > 65535)); then
+        print_error "${variable_name} must be an integer between 1 and 65535"
+        return 1
+    fi
     return 0
 }
 
@@ -61,7 +77,7 @@ fetch_health_response() {
     local service="$1"
     local url="$2"
 
-    if [[ "$service" == "api-gateway" ]]; then
+    if [[ "$service" == "$API_GATEWAY_SERVICE" ]]; then
         gateway_curl "$url"
         return $?
     fi
@@ -186,6 +202,14 @@ list_resources() {
 
 # Health check all servers
 health_check() {
+    local gateway_port="${API_GATEWAY_PORT:-$API_GATEWAY_PORT_DEFAULT}"
+    local dashboard_port="${MCP_DASHBOARD_PORT:-$MCP_DASHBOARD_PORT_DEFAULT}"
+
+    validate_local_port "API_GATEWAY_PORT" "$gateway_port" || return 1
+    validate_local_port "MCP_DASHBOARD_PORT" "$dashboard_port" || return 1
+    gateway_port=$((10#$gateway_port))
+    dashboard_port=$((10#$dashboard_port))
+
     print_header
     echo -e "${CYAN}🏥 MCP Server Health Check${NC}"
     print_header
@@ -197,15 +221,17 @@ health_check() {
     # Check local Elysia servers first
     echo -e "\n${BLUE}Local Elysia Servers:${NC}"
     
-    local port
-    for port in 3100 3101; do
+    local service
+    for service in "$API_GATEWAY_SERVICE" "$MCP_DASHBOARD_SERVICE"; do
         total=$((total + 1))
-        local name="localhost:$port"
-        local expected_service="mcp-dashboard"
-        local response
-        if [[ "$port" == "3100" ]]; then
-            expected_service="api-gateway"
+        local port="$dashboard_port"
+        local expected_service="$MCP_DASHBOARD_SERVICE"
+        if [[ "$service" == "$API_GATEWAY_SERVICE" ]]; then
+            port="$gateway_port"
+            expected_service="$API_GATEWAY_SERVICE"
         fi
+        local name="localhost:$port"
+        local response
         response=$(fetch_health_response "$expected_service" "http://localhost:$port/health" 2>/dev/null) || response=""
         if health_response_matches_service "$response" "$expected_service"; then
             print_success "$name - healthy"
@@ -232,6 +258,18 @@ health_check() {
             local url
             local response
             url=$(jq -r ".mcpServers[\"$srv\"].url" "$CONFIG_FILE")
+            case "$srv" in
+                "$API_GATEWAY_SERVICE")
+                    if [[ -n "${API_GATEWAY_PORT:-}" ]]; then
+                        url="http://localhost:${gateway_port}"
+                    fi
+                    ;;
+                "$MCP_DASHBOARD_SERVICE")
+                    if [[ -n "${MCP_DASHBOARD_PORT:-}" ]]; then
+                        url="http://localhost:${dashboard_port}"
+                    fi
+                    ;;
+            esac
             response=$(fetch_health_response "$srv" "$url/health" 2>/dev/null) || response=""
             if health_response_matches_service "$response" "$srv"; then
                 print_success "$srv ($server_type) - healthy"
@@ -274,11 +312,16 @@ show_config() {
 
 # Test API Gateway endpoints
 test_api_gateway() {
+    local gateway_port="${API_GATEWAY_PORT:-$API_GATEWAY_PORT_DEFAULT}"
+
+    validate_local_port "API_GATEWAY_PORT" "$gateway_port" || return 1
+    gateway_port=$((10#$gateway_port))
+
     print_header
     echo -e "${CYAN}🧪 API Gateway Test Suite${NC}"
     print_header
     
-    local base_url="http://localhost:3100"
+    local base_url="http://localhost:${gateway_port}"
     local passed=0
     local failed=0
 
@@ -429,6 +472,12 @@ Starting Local Servers:
   
   # Start MCP Dashboard (port 3101)
   bun run .opencode/server/mcp-dashboard.ts
+
+  # Use alternate ports when defaults are occupied
+  API_GATEWAY_PORT=3102 bun run .opencode/server/api-gateway.ts
+  API_GATEWAY_PORT=3102 ./mcp-inspector-helper.sh health
+  API_GATEWAY_PORT=3102 ./mcp-inspector-helper.sh test-gateway
+  MCP_DASHBOARD_PORT=3103 bun run .opencode/server/mcp-dashboard.ts
   
   # Or use npm scripts
   bun run dev        # API Gateway

--- a/.agents/scripts/tests/test-mcp-inspector-health-identity.sh
+++ b/.agents/scripts/tests/test-mcp-inspector-health-identity.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression coverage for GH#27967: MCP health checks must reject unrelated
-# HTTP responses and accept only explicit aidevops service identities.
+# Regression coverage for GH#27967 and GH#27972: MCP health checks must reject
+# unrelated responses, validate service identities, and honor configured ports.
 
 set -euo pipefail
 
@@ -57,11 +57,16 @@ assert_not_contains() {
 
 run_health_fixture() {
 	local fixture="$1"
+	local gateway_port="${2:-}"
+	local dashboard_port="${3:-}"
 
+	: >"${SANDBOX}/curl-args.log"
 	OUTPUT=$(PATH="${SANDBOX}/bin:${PATH}" \
 		MCP_HEALTH_FIXTURE="$fixture" \
 		FAKE_CURL_ARGS_LOG="${SANDBOX}/curl-args.log" \
 		API_GATEWAY_TOKEN="$TEST_TOKEN" \
+		API_GATEWAY_PORT="$gateway_port" \
+		MCP_DASHBOARD_PORT="$dashboard_port" \
 		bash "$HELPER" health 2>&1)
 	return 0
 }
@@ -79,6 +84,8 @@ cat >"${SANDBOX}/bin/curl" <<'EOF_CURL'
 set -euo pipefail
 
 url=""
+gateway_port="${API_GATEWAY_PORT:-3100}"
+dashboard_port="${MCP_DASHBOARD_PORT:-3101}"
 for argument in "$@"; do
 	if [[ "$argument" == http://* || "$argument" == https://* ]]; then
 		url="$argument"
@@ -87,29 +94,35 @@ done
 printf '%s\n' "$*" >>"$FAKE_CURL_ARGS_LOG"
 
 case "${MCP_HEALTH_FIXTURE}:${url}" in
-valid:*:3100/health)
+"valid:http://localhost:${gateway_port}/health")
 	printf '%s\n' '{"status":"healthy","service":"api-gateway"}'
 	;;
-valid:*:3101/health)
+"valid:http://localhost:${dashboard_port}/health")
 	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
 	;;
-unrelated:*:3100/health)
+"unrelated:http://localhost:${gateway_port}/health")
 	printf '%s\n' '<html>redirect</html>'
 	;;
-unrelated:*:3101/health)
+"unrelated:http://localhost:${dashboard_port}/health")
 	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
 	;;
-wrong-service:*:3100/health)
+"wrong-service:http://localhost:${gateway_port}/health")
 	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
 	;;
-wrong-service:*:3101/health)
+"wrong-service:http://localhost:${dashboard_port}/health")
 	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
 	;;
-unhealthy:*:3100/health)
+"unhealthy:http://localhost:${gateway_port}/health")
 	printf '%s\n' '{"status":"unhealthy","service":"api-gateway"}'
 	;;
-unhealthy:*:3101/health)
+"unhealthy:http://localhost:${dashboard_port}/health")
 	printf '%s\n' '{"status":"healthy","service":"mcp-dashboard"}'
+	;;
+gateway-test:*)
+	if [[ "$url" != "http://localhost:${gateway_port}/"* ]]; then
+		exit 22
+	fi
+	printf '%s\n' '{}'
 	;;
 *)
 	exit 22
@@ -137,11 +150,58 @@ assert_contains "wrong service identity is rejected" "localhost:3100 - unexpecte
 run_health_fixture unhealthy
 assert_contains "unhealthy status is rejected" "localhost:3100 - unexpected service health response"
 
+run_health_fixture valid 3200 3201
+assert_contains "configured gateway port is used locally" "localhost:3200 - healthy"
+assert_contains "configured dashboard port is used locally" "localhost:3201 - healthy"
+assert_contains "configured gateway URL honors its port" "api-gateway (streamable-http) - healthy"
+assert_contains "configured dashboard URL honors its port" "mcp-dashboard (streamable-http) - healthy"
+if grep -Eq 'localhost:3100|localhost:3101' "${SANDBOX}/curl-args.log"; then
+	fail "configured health checks fell back to default ports"
+	exit 1
+fi
+pass "configured health checks avoid default ports"
+
+: >"${SANDBOX}/curl-args.log"
+OUTPUT=$(PATH="${SANDBOX}/bin:${PATH}" \
+	MCP_HEALTH_FIXTURE="gateway-test" \
+	FAKE_CURL_ARGS_LOG="${SANDBOX}/curl-args.log" \
+	API_GATEWAY_TOKEN="$TEST_TOKEN" \
+	API_GATEWAY_PORT=3200 \
+	bash "$HELPER" test-gateway 2>&1)
+assert_contains "gateway test runs on configured port" "GET /health"
+if grep -Fq 'localhost:3100' "${SANDBOX}/curl-args.log"; then
+	fail "gateway test fell back to default port"
+	exit 1
+fi
+if ! grep -Fq 'localhost:3200' "${SANDBOX}/curl-args.log"; then
+	fail "gateway test did not call configured port"
+	exit 1
+fi
+pass "gateway test uses configured port"
 if grep -Fq "$TEST_TOKEN" "${SANDBOX}/curl-args.log"; then
 	fail "gateway token leaked into curl argv"
 	exit 1
 fi
 pass "gateway token stays out of curl argv"
+
+: >"${SANDBOX}/curl-args.log"
+invalid_rc=0
+OUTPUT=$(PATH="${SANDBOX}/bin:${PATH}" \
+	MCP_HEALTH_FIXTURE="valid" \
+	FAKE_CURL_ARGS_LOG="${SANDBOX}/curl-args.log" \
+	API_GATEWAY_TOKEN="$TEST_TOKEN" \
+	API_GATEWAY_PORT="not-a-port" \
+	bash "$HELPER" health 2>&1) || invalid_rc=$?
+if [[ "$invalid_rc" -eq 0 ]]; then
+	fail "invalid gateway port was accepted"
+	exit 1
+fi
+assert_contains "invalid gateway port reports validation error" "API_GATEWAY_PORT must be an integer between 1 and 65535"
+if [[ -s "${SANDBOX}/curl-args.log" ]]; then
+	fail "invalid gateway port reached curl"
+	exit 1
+fi
+pass "invalid gateway port fails before curl"
 
 printf 'All MCP inspector health identity tests passed.\n'
 exit 0


### PR DESCRIPTION
## Summary

Use API_GATEWAY_PORT and MCP_DASHBOARD_PORT consistently across local health probes, configured local-service probes, gateway tests, and help while preserving defaults and custom config URLs.

## Files Changed

.agents/scripts/mcp-inspector-helper.sh, .agents/scripts/tests/test-mcp-inspector-health-identity.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused regression test passed; ShellCheck and bash -n passed; changed-file local lint gates passed; runtime gateway on port 3102 was detected healthy without touching the existing port-3100 listener.

Resolves #27972


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.132 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 11h 18m and 1,826,314 tokens on this with the user in an interactive session.