### PR TITLE
GH#27960: Log pulse merge safety failures

### DIFF
--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -493,9 +493,19 @@ _pulse_merge_admin_safety_check() {
 	# t2863: initialise multi-var locals at declaration time so set -u
 	# is safe even on a partial-failure path through the assignments.
 	local pr_meta_json="" labels_str="" is_fork="false" current_head_sha="" pr_author=""
-	pr_meta_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json author,labels,isCrossRepository,headRefOid 2>/dev/null) || pr_meta_json=""
-	[[ -n "$pr_meta_json" ]] || return 1
+	if ! pr_meta_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json author,labels,isCrossRepository,headRefOid 2>/dev/null); then
+		echo "[pulse-merge] _pulse_merge_admin_safety_check: gh pr view failed for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ -z "$pr_meta_json" ]]; then
+		echo "[pulse-merge] _pulse_merge_admin_safety_check: gh pr view returned empty metadata for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
+		return 1
+	fi
+	if ! printf '%s' "$pr_meta_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+		echo "[pulse-merge] _pulse_merge_admin_safety_check: gh pr view returned malformed metadata for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
+		return 1
+	fi
 	labels_str=$(printf '%s' "$pr_meta_json" \
 		| jq -r '[.labels[].name] | join(",")' 2>/dev/null) || labels_str=""
 	is_fork=$(printf '%s' "$pr_meta_json" \
@@ -504,7 +514,10 @@ _pulse_merge_admin_safety_check() {
 		| jq -r '.headRefOid // ""' 2>/dev/null) || current_head_sha=""
 	pr_author=$(printf '%s' "$pr_meta_json" \
 		| jq -r '.author.login // ""' 2>/dev/null) || pr_author=""
-	[[ -n "$current_head_sha" && -n "$pr_author" ]] || return 1
+	if [[ -z "$current_head_sha" || -z "$pr_author" ]]; then
+		echo "[pulse-merge] _pulse_merge_admin_safety_check: missing head SHA or author for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
+		return 1
+	fi
 	if [[ -n "$expected_head_sha" && "$current_head_sha" != "$expected_head_sha" ]]; then
 		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — head changed before final authority check" >>"$LOGFILE"
 		return 1
@@ -538,7 +551,10 @@ _pulse_merge_admin_safety_check() {
 	# A linked issue's live NMR state is a final-call hold for every PR, not only
 	# external PRs. Fail closed if a linked issue was found but cannot be read.
 	local linked="" linked_labels=""
-	linked=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || return 1
+	if ! linked=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null); then
+		echo "[pulse-merge] _pulse_merge_admin_safety_check: linked issue extraction failed for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
+		return 1
+	fi
 	if [[ -n "$linked" ]]; then
 		linked_labels=$(gh api "repos/${repo_slug}/issues/${linked}" --jq '[.labels[].name] | join(",")' 2>/dev/null) || linked_labels="__API_ERROR__"
 		if [[ "$linked_labels" == "__API_ERROR__" || ",${linked_labels}," == *",needs-maintainer-review,"* ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -24,6 +24,7 @@
 #   I — unlabeled non-collaborator, no current PR authority                 → return 1
 #   J — cached positive review evidence, live outcome no longer permitted  → return 1
 #   K — stale cached evidence, refreshed exact-head positive evidence      → return 0
+#   M-Q — metadata and linked-issue lookup failures are logged              → return 1
 
 set -euo pipefail
 
@@ -118,6 +119,12 @@ printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
 
 # gh pr view N --repo R --json author,labels,isCrossRepository,headRefOid
 if [[ "$*" == *"--json author,labels,isCrossRepository,headRefOid"* ]]; then
+	if [[ -f "${TEST_ROOT}/pr-meta-fail" ]]; then
+		exit 1
+	fi
+	if [[ -f "${TEST_ROOT}/pr-meta-empty" ]]; then
+		exit 0
+	fi
 	cat "${TEST_ROOT}/labels.json"
 	exit 0
 fi
@@ -226,6 +233,8 @@ define_helpers_under_test() {
 	eval "$gates_src"
 	# shellcheck disable=SC1090
 	eval "$final_src"
+	PULSE_REVIEW_EVIDENCE_SCHEMA="aidevops.review-gate-evidence/v1"
+	PULSE_UNKNOWN_STATE="UNKNOWN"
 	_PULSE_PREFLIGHT_CALLS=0
 	_pulse_merge_preflight_snapshot_gate() {
 		local repo_slug="$1"
@@ -279,6 +288,78 @@ test_case_l_collaborator_linked_issue_nmr_blocks_final_gate() {
 		return 0
 	fi
 	print_result "Case L: collaborator linked-issue NMR blocks at final gate" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_m_pr_metadata_command_failure_is_logged() {
+	: >"$LOGFILE"
+	touch "${TEST_ROOT}/pr-meta-fail"
+	local result=0
+	_pulse_merge_admin_safety_check "940" "owner/repo" "head-current" || result=$?
+	rm -f "${TEST_ROOT}/pr-meta-fail"
+	if [[ "$result" -eq 1 ]] && grep -qF "gh pr view failed for PR #940 in owner/repo — failing closed" "$LOGFILE"; then
+		print_result "Case M: PR metadata command failure is logged" 0
+		return 0
+	fi
+	print_result "Case M: PR metadata command failure is logged" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_n_empty_pr_metadata_is_logged() {
+	: >"$LOGFILE"
+	touch "${TEST_ROOT}/pr-meta-empty"
+	local result=0
+	_pulse_merge_admin_safety_check "941" "owner/repo" "head-current" || result=$?
+	rm -f "${TEST_ROOT}/pr-meta-empty"
+	if [[ "$result" -eq 1 ]] && grep -qF "gh pr view returned empty metadata for PR #941 in owner/repo — failing closed" "$LOGFILE"; then
+		print_result "Case N: empty PR metadata is logged" 0
+		return 0
+	fi
+	print_result "Case N: empty PR metadata is logged" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_o_malformed_pr_metadata_is_logged() {
+	: >"$LOGFILE"
+	printf '%s' '{not-json' >"${TEST_ROOT}/labels.json"
+	local result=0
+	_pulse_merge_admin_safety_check "942" "owner/repo" "head-current" || result=$?
+	set_fixture '[{"name":"bug"}]' 'false' '## Summary\n\nResolves #942' 'VERIFIED'
+	if [[ "$result" -eq 1 ]] && grep -qF "gh pr view returned malformed metadata for PR #942 in owner/repo — failing closed" "$LOGFILE"; then
+		print_result "Case O: malformed PR metadata is logged" 0
+		return 0
+	fi
+	print_result "Case O: malformed PR metadata is logged" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_p_missing_pr_identity_is_logged() {
+	: >"$LOGFILE"
+	printf '%s' '{"author":null,"labels":[],"isCrossRepository":false,"headRefOid":""}' >"${TEST_ROOT}/labels.json"
+	local result=0
+	_pulse_merge_admin_safety_check "943" "owner/repo" "head-current" || result=$?
+	set_fixture '[{"name":"bug"}]' 'false' '## Summary\n\nResolves #943' 'VERIFIED'
+	if [[ "$result" -eq 1 ]] && grep -qF "missing head SHA or author for PR #943 in owner/repo — failing closed" "$LOGFILE"; then
+		print_result "Case P: missing PR identity is logged" 0
+		return 0
+	fi
+	print_result "Case P: missing PR identity is logged" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_q_linked_issue_extraction_failure_is_logged() {
+	: >"$LOGFILE"
+	set_fixture '[{"name":"bug"}]' 'false' '## Summary\n\nResolves #944' 'VERIFIED'
+	_extract_linked_issue() {
+		return 1
+	}
+	local result=0
+	_pulse_merge_admin_safety_check "944" "owner/repo" "head-current" || result=$?
+	if [[ "$result" -eq 1 ]] && grep -qF "linked issue extraction failed for PR #944 in owner/repo — failing closed" "$LOGFILE"; then
+		print_result "Case Q: linked issue extraction failure is logged" 0
+		return 0
+	fi
+	print_result "Case Q: linked issue extraction failure is logged" 1 "rc=${result}; log=$(cat "$LOGFILE")"
 	return 0
 }
 
@@ -543,6 +624,11 @@ main() {
 	test_case_j_final_gate_rejects_stale_cached_review_evidence
 	test_case_k_final_gate_refreshes_current_review_evidence
 	test_case_l_collaborator_linked_issue_nmr_blocks_final_gate
+	test_case_m_pr_metadata_command_failure_is_logged
+	test_case_n_empty_pr_metadata_is_logged
+	test_case_o_malformed_pr_metadata_is_logged
+	test_case_p_missing_pr_identity_is_logged
+	test_case_q_linked_issue_extraction_failure_is_logged
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Log distinct command failure, empty output, malformed metadata, missing PR identity, and linked-issue extraction failures before the final admin safety gate fails closed.

## Files Changed

.agents/scripts/pulse-merge-gates.sh, .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh; shellcheck .agents/scripts/pulse-merge-gates.sh .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh; .agents/scripts/linters-local.sh --changed

Resolves #27960


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.132 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 1h 23m and 675,901 tokens on this with the user in an interactive session.