### PR TITLE
t18144: Serialize audit hash-chain writes on macOS without flock

### DIFF
--- a/.agents/scripts/audit-log-helper.sh
+++ b/.agents/scripts/audit-log-helper.sh
@@ -39,6 +39,8 @@
 #   AUDIT_LOG_DIR    Override log directory (default: ~/.aidevops/.agent-workspace/observability)
 #   AUDIT_LOG_FILE   Override log file path (default: $AUDIT_LOG_DIR/audit.jsonl)
 #   AUDIT_QUIET      Suppress informational stderr output when "true"
+#   AUDIT_LOCK_TIMEOUT_SECONDS     Lock wait before failing closed (default: 10)
+#   AUDIT_LOCK_ORPHAN_AGE_SECONDS  Ownerless-lock reclaim age (default: 60)
 
 set -euo pipefail
 
@@ -58,6 +60,13 @@ readonly AUDIT_GENESIS_HASH="000000000000000000000000000000000000000000000000000
 readonly AUDIT_MAX_MESSAGE_LEN=4096
 readonly AUDIT_MAX_DETAIL_LEN=8192
 readonly AUDIT_DEFAULT_ROTATE_MB=50
+readonly AUDIT_DEFAULT_LOCK_TIMEOUT_SECONDS=10
+readonly AUDIT_DEFAULT_LOCK_ORPHAN_AGE_SECONDS=60
+
+# Mutable state for the process-local lock owner and the most recent append.
+_AUDIT_HELD_LOCK_DIR=""
+_AUDIT_HELD_LOCK_OWNER=""
+_AUDIT_LAST_SEQ=""
 
 # Valid event types (prefix-based hierarchy)
 readonly -a AUDIT_EVENT_TYPES=(
@@ -101,12 +110,20 @@ _audit_ensure_log() {
 	log_dir="$(dirname "$log_file")"
 
 	if [[ ! -d "$log_dir" ]]; then
-		mkdir -p "$log_dir" || true
+		if ! mkdir -p "$log_dir"; then
+			_audit_error "Could not create audit log directory: $log_dir"
+			return 1
+		fi
 		chmod 700 "$log_dir" || _audit_warn "Could not set log directory permissions to 700: $log_dir"
 	fi
 
 	if [[ ! -f "$log_file" ]]; then
-		: >"$log_file"
+		# Append-open creates the file without truncating an entry another process
+		# may have written after this process checked for its existence.
+		if ! (umask 077 && : >>"$log_file"); then
+			_audit_error "Could not create audit log file: $log_file"
+			return 1
+		fi
 		chmod 600 "$log_file" || _audit_warn "Could not set log file permissions to 600: $log_file"
 	fi
 
@@ -132,10 +149,10 @@ _audit_sha256() {
 }
 
 # Get the hash of the last entry in the audit log.
+# Arguments: $1 — audit log file path
 # Output: hash on stdout (genesis hash if log is empty)
 _audit_last_hash() {
-	local log_file
-	log_file="$(_audit_log_path)"
+	local log_file="$1"
 
 	if [[ ! -f "$log_file" ]] || [[ ! -s "$log_file" ]]; then
 		echo "$AUDIT_GENESIS_HASH"
@@ -238,6 +255,205 @@ _audit_error() {
 	return 0
 }
 
+# Read a path's modification time as epoch seconds on macOS or Linux.
+# Arguments: $1 — path
+# Output: epoch seconds on stdout
+_audit_path_mtime_epoch() {
+	local path="$1"
+	local mtime=""
+
+	mtime="$(stat -f '%m' "$path" 2>/dev/null || true)"
+	if [[ "$mtime" =~ ^[0-9]+$ ]]; then
+		echo "$mtime"
+		return 0
+	fi
+
+	mtime="$(stat -c '%Y' "$path" 2>/dev/null || true)"
+	if [[ "$mtime" =~ ^[0-9]+$ ]]; then
+		echo "$mtime"
+		return 0
+	fi
+
+	return 1
+}
+
+# Remove only the files owned by the audit lock protocol, then the directory.
+# Arguments: $1 — lock directory
+_audit_remove_lock_dir() {
+	local lock_dir="$1"
+
+	rm -f "${lock_dir}/owner" || return 1
+	rmdir "${lock_dir}/.reclaim" 2>/dev/null || true
+	if ! rmdir "$lock_dir" 2>/dev/null; then
+		_audit_error "Could not remove audit log lock directory: $lock_dir"
+		return 1
+	fi
+
+	return 0
+}
+
+# Reclaim a dead-owner lock, or an old ownerless lock. A .reclaim directory
+# atomically elects one reclaimer while the parent lock still blocks writers.
+# Arguments: $1 — lock directory, $2 — ownerless-lock minimum age in seconds
+# Returns: 0 only when the stale lock was removed
+_audit_reclaim_stale_lock() {
+	local lock_dir="$1"
+	local orphan_age="$2"
+
+	if [[ ! -d "$lock_dir" ]]; then
+		return 1
+	fi
+
+	local owner_record=""
+	local owner_pid=""
+	local stale_reason=""
+	if [[ -f "${lock_dir}/owner" ]]; then
+		IFS= read -r owner_record <"${lock_dir}/owner" || owner_record=""
+		owner_pid="${owner_record%% *}"
+		if [[ "$owner_pid" =~ ^[0-9]+$ ]]; then
+			if kill -0 "$owner_pid" 2>/dev/null; then
+				return 1
+			fi
+			stale_reason="dead owner PID ${owner_pid}"
+		fi
+	fi
+
+	if [[ -z "$stale_reason" ]]; then
+		local lock_mtime=""
+		lock_mtime="$(_audit_path_mtime_epoch "$lock_dir")" || return 1
+		local now=""
+		now="$(date '+%s')" || return 1
+		local lock_age=$((now - lock_mtime))
+		if [[ $lock_age -lt 0 ]]; then
+			lock_age=0
+		fi
+		if [[ $lock_age -lt $orphan_age ]]; then
+			return 1
+		fi
+		stale_reason="missing or invalid owner metadata for ${lock_age}s"
+	fi
+
+	if ! mkdir "${lock_dir}/.reclaim" 2>/dev/null; then
+		return 1
+	fi
+
+	_audit_warn "Reclaiming stale audit log lock (${stale_reason})"
+	if ! _audit_remove_lock_dir "$lock_dir"; then
+		return 1
+	fi
+
+	return 0
+}
+
+# Acquire a portable process lock using atomic mkdir.
+# Arguments: $1 — lock directory
+_audit_acquire_lock() {
+	local lock_dir="$1"
+	local timeout="${AUDIT_LOCK_TIMEOUT_SECONDS:-${AUDIT_DEFAULT_LOCK_TIMEOUT_SECONDS}}"
+	local orphan_age="${AUDIT_LOCK_ORPHAN_AGE_SECONDS:-${AUDIT_DEFAULT_LOCK_ORPHAN_AGE_SECONDS}}"
+
+	if [[ ! "$timeout" =~ ^[0-9]+$ ]]; then
+		_audit_error "Invalid AUDIT_LOCK_TIMEOUT_SECONDS: $timeout (must be a non-negative integer)"
+		return 1
+	fi
+	if [[ ! "$orphan_age" =~ ^[0-9]+$ ]]; then
+		_audit_error "Invalid AUDIT_LOCK_ORPHAN_AGE_SECONDS: $orphan_age (must be a non-negative integer)"
+		return 1
+	fi
+
+	local started_at=""
+	started_at="$(date '+%s')" || return 1
+	while ! (umask 077 && mkdir "$lock_dir") 2>/dev/null; do
+		if _audit_reclaim_stale_lock "$lock_dir" "$orphan_age"; then
+			continue
+		fi
+
+		local now=""
+		now="$(date '+%s')" || return 1
+		if [[ $((now - started_at)) -ge $timeout ]]; then
+			_audit_error "Could not acquire audit log lock after ${timeout}s"
+			return 1
+		fi
+		sleep 0.1
+	done
+
+	local owner_pid="${BASHPID:-$$}"
+	local created_at=""
+	created_at="$(date '+%s')" || {
+		_audit_remove_lock_dir "$lock_dir" || true
+		return 1
+	}
+	local owner_token="${owner_pid}-${created_at}-${RANDOM}"
+	local owner_record="${owner_pid} ${owner_token}"
+	if ! printf '%s\n' "$owner_record" >"${lock_dir}/owner"; then
+		_audit_remove_lock_dir "$lock_dir" || true
+		_audit_error "Could not write audit log lock owner metadata"
+		return 1
+	fi
+	chmod 600 "${lock_dir}/owner" || _audit_warn "Could not set audit lock owner permissions to 600"
+
+	_AUDIT_HELD_LOCK_DIR="$lock_dir"
+	_AUDIT_HELD_LOCK_OWNER="$owner_record"
+	return 0
+}
+
+# Release the lock only when its owner metadata still matches this process.
+_audit_release_current_lock() {
+	local lock_dir="$_AUDIT_HELD_LOCK_DIR"
+	local expected_owner="$_AUDIT_HELD_LOCK_OWNER"
+
+	if [[ -z "$lock_dir" ]]; then
+		return 0
+	fi
+	if [[ ! -d "$lock_dir" ]]; then
+		_AUDIT_HELD_LOCK_DIR=""
+		_AUDIT_HELD_LOCK_OWNER=""
+		return 0
+	fi
+
+	local actual_owner=""
+	if [[ -f "${lock_dir}/owner" ]]; then
+		IFS= read -r actual_owner <"${lock_dir}/owner" || actual_owner=""
+	fi
+	if [[ "$actual_owner" != "$expected_owner" ]]; then
+		_audit_error "Refusing to release audit log lock owned by another process"
+		_AUDIT_HELD_LOCK_DIR=""
+		_AUDIT_HELD_LOCK_OWNER=""
+		return 1
+	fi
+
+	if ! _audit_remove_lock_dir "$lock_dir"; then
+		_AUDIT_HELD_LOCK_DIR=""
+		_AUDIT_HELD_LOCK_OWNER=""
+		return 1
+	fi
+	_AUDIT_HELD_LOCK_DIR=""
+	_AUDIT_HELD_LOCK_OWNER=""
+	return 0
+}
+
+# Ensure normal exit and termination signals release a held lock.
+_audit_arm_lock_cleanup() {
+	trap '_audit_release_current_lock || true' EXIT
+	trap 'exit 129' HUP
+	trap 'exit 130' INT
+	trap 'exit 143' TERM
+	return 0
+}
+
+# Release a held lock and disarm its process traps.
+_audit_finish_lock() {
+	local release_failed="false"
+	if ! _audit_release_current_lock; then
+		release_failed="true"
+	fi
+	trap - EXIT HUP INT TERM
+	if [[ "$release_failed" == "true" ]]; then
+		return 1
+	fi
+	return 0
+}
+
 # =============================================================================
 # Commands
 # =============================================================================
@@ -319,28 +535,18 @@ _audit_build_entry_no_hash() {
 	return 0
 }
 
-# Append a single audit entry to the log under an flock-serialised lock.
+# Append one entry while the caller holds this log's lock.
 # Handles: seq allocation, prev_hash lookup, entry construction, hash, append.
 # Arguments: $1=log_file $2=event_type $3=message $4=detail_json $5=ts $6=actor $7=host
-# Returns: 0 on success, 1 on lock failure
-_audit_locked_append() {
+_audit_append_entry() {
 	local log_file="$1" event_type="$2" message="$3" detail_json="$4"
 	local ts="$5" actor="$6" host="$7"
 
-	local lock_file="${log_file}.lock"
-	# Serialize the read-modify-write path with flock to prevent concurrent
-	# writers from duplicating sequence numbers or breaking the hash chain.
-	# Uses fd 200 for the lock file; released automatically when fd is closed.
-	if command -v flock &>/dev/null; then
-		exec 200>"$lock_file"
-		if ! flock -w 10 200; then
-			_audit_error "Could not acquire audit log lock after 10s"
-			exec 200>&-
-			return 1
-		fi
+	if [[ "$_AUDIT_HELD_LOCK_DIR" != "${log_file}.lock.d" ]]; then
+		_audit_error "Refusing to append without the matching audit log lock"
+		return 1
 	fi
-	# Note: if flock is unavailable (e.g., macOS without util-linux), we proceed
-	# without locking — single-writer scenarios are still safe.
+	_AUDIT_LAST_SEQ=""
 
 	local seq
 	if [[ -s "$log_file" ]]; then
@@ -351,31 +557,47 @@ _audit_locked_append() {
 	fi
 
 	local prev_hash
-	prev_hash="$(_audit_last_hash)"
+	prev_hash="$(_audit_last_hash "$log_file")" || return 1
 
 	local entry_no_hash
 	entry_no_hash="$(_audit_build_entry_no_hash \
-		"$seq" "$ts" "$event_type" "$message" "$detail_json" "$actor" "$host" "$prev_hash")"
+		"$seq" "$ts" "$event_type" "$message" "$detail_json" "$actor" "$host" "$prev_hash")" || return 1
 
 	local entry_hash
-	entry_hash="$(_audit_sha256 "$entry_no_hash")"
+	entry_hash="$(_audit_sha256 "$entry_no_hash")" || return 1
 
 	local entry
 	if command -v jq &>/dev/null; then
-		entry=$(echo "$entry_no_hash" | jq -c --arg hash "$entry_hash" '. + {hash: $hash}')
+		entry="$(echo "$entry_no_hash" | jq -c --arg hash "$entry_hash" '. + {hash: $hash}')" || return 1
 	else
 		# Reconstruct with hash appended (fallback — jq strongly preferred)
 		# Strip trailing } and append hash field
 		entry="${entry_no_hash%\}},\"hash\":\"${entry_hash}\"}"
 	fi
 
-	echo "$entry" >>"$log_file"
-
-	if command -v flock &>/dev/null; then
-		exec 200>&-
+	if ! printf '%s\n' "$entry" >>"$log_file"; then
+		_audit_error "Could not append to audit log: $log_file"
+		return 1
 	fi
 
-	echo "$seq"
+	_AUDIT_LAST_SEQ="$seq"
+	return 0
+}
+
+# Serialize the full sequence/hash/append transaction with an atomic mkdir lock.
+# Arguments: $1=log_file $2=event_type $3=message $4=detail_json $5=ts $6=actor $7=host
+_audit_locked_append() {
+	local log_file="$1" event_type="$2" message="$3" detail_json="$4"
+	local ts="$5" actor="$6" host="$7"
+	local lock_dir="${log_file}.lock.d"
+
+	_audit_acquire_lock "$lock_dir" || return 1
+	_audit_arm_lock_cleanup
+	if ! _audit_append_entry "$log_file" "$event_type" "$message" "$detail_json" "$ts" "$actor" "$host"; then
+		_audit_finish_lock || true
+		return 1
+	fi
+	_audit_finish_lock || return 1
 	return 0
 }
 
@@ -433,7 +655,7 @@ cmd_log() {
 	local detail_json
 	detail_json="$(_audit_parse_details "$@")" || return 1
 
-	_audit_ensure_log
+	_audit_ensure_log || return 1
 
 	local log_file
 	log_file="$(_audit_log_path)"
@@ -443,9 +665,9 @@ cmd_log() {
 	actor="${AIDEVOPS_SESSION_ID:-${USER:-unknown}}"
 	host="$(hostname -s 2>/dev/null || echo "unknown")"
 
-	local seq
-	seq="$(_audit_locked_append \
-		"$log_file" "$event_type" "$message" "$detail_json" "$ts" "$actor" "$host")" || return 1
+	_audit_locked_append \
+		"$log_file" "$event_type" "$message" "$detail_json" "$ts" "$actor" "$host" || return 1
+	local seq="$_AUDIT_LAST_SEQ"
 
 	_audit_info "Logged ${event_type} (seq=${seq})"
 
@@ -675,6 +897,94 @@ cmd_status() {
 	return 0
 }
 
+# Rotate a qualifying log while excluding appenders with the same lock.
+# Arguments: $1=log_file $2=max_size_bytes $3=max_size_mb
+_audit_rotate_locked() {
+	local log_file="$1"
+	local max_size_bytes="$2"
+	local max_size_mb="$3"
+	local size_bytes=""
+	local lock_dir="${log_file}.lock.d"
+
+	_audit_acquire_lock "$lock_dir" || return 1
+	_audit_arm_lock_cleanup
+	if [[ ! -f "$log_file" ]]; then
+		_audit_finish_lock || true
+		_audit_info "No audit log to rotate"
+		return 0
+	fi
+	size_bytes="$(wc -c <"$log_file" | tr -d ' ')"
+	if [[ $size_bytes -lt $max_size_bytes ]]; then
+		_audit_finish_lock || return 1
+		local size_mb=$((size_bytes / 1048576))
+		_audit_info "Log size (${size_mb}MB) below threshold (${max_size_mb}MB) — no rotation needed"
+		return 0
+	fi
+
+	# Verify the exact segment being rotated while writers are excluded.
+	if ! cmd_verify --quiet 2>/dev/null; then
+		_audit_warn "Chain verification failed before rotation — rotating anyway but chain is already broken"
+	fi
+
+	# Rotate: rename with timestamp
+	local rotate_ts
+	rotate_ts="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || date '+%Y%m%dT%H%M%SZ')"
+	local rotated_prefix="${log_file%.jsonl}.${rotate_ts}"
+	local rotated_file="${rotated_prefix}.jsonl"
+	local collision=0
+	while [[ -e "$rotated_file" ]]; do
+		collision=$((collision + 1))
+		rotated_file="${rotated_prefix}.${BASHPID:-$$}.${collision}.jsonl"
+	done
+
+	# Capture the last entry's hash before moving — this creates a cryptographic
+	# link from the new log segment back to the rotated one. Without this, an
+	# attacker could swap or delete rotated segments undetectably.
+	local prev_segment_hash
+	if ! prev_segment_hash="$(_audit_last_hash "$log_file")"; then
+		_audit_finish_lock || true
+		return 1
+	fi
+	local rotated_entries
+	rotated_entries="$(wc -l <"$log_file" | tr -d ' ')"
+
+	if ! mv "$log_file" "$rotated_file"; then
+		_audit_finish_lock || true
+		_audit_error "Could not rotate audit log"
+		return 1
+	fi
+	chmod 400 "$rotated_file" || _audit_warn "Could not set rotated log permissions to 400: $rotated_file"
+	if ! (umask 077 && : >>"$log_file"); then
+		_audit_finish_lock || true
+		_audit_error "Could not create new audit log segment"
+		return 1
+	fi
+	chmod 600 "$log_file" || _audit_warn "Could not set log file permissions to 600: $log_file"
+
+	local detail_json
+	detail_json="$(_audit_parse_details \
+		--detail "rotated_file=${rotated_file}" \
+		--detail "entries=${rotated_entries}" \
+		--detail "size_bytes=${size_bytes}" \
+		--detail "prev_segment_hash=${prev_segment_hash}")" || {
+		_audit_finish_lock || true
+		return 1
+	}
+	local ts actor host
+	ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')"
+	actor="${AIDEVOPS_SESSION_ID:-${USER:-unknown}}"
+	host="$(hostname -s 2>/dev/null || echo "unknown")"
+	if ! _audit_append_entry "$log_file" "system.rotate" "Audit log rotated" "$detail_json" "$ts" "$actor" "$host"; then
+		_audit_finish_lock || true
+		return 1
+	fi
+	local rotation_seq="$_AUDIT_LAST_SEQ"
+	_audit_finish_lock || return 1
+	_audit_info "Rotated to ${rotated_file}; logged system.rotate (seq=${rotation_seq})"
+
+	return 0
+}
+
 # Rotate the audit log when it exceeds a size threshold.
 # The rotated file is renamed with a timestamp suffix.
 # A rotation event is logged in the new log file.
@@ -707,7 +1017,6 @@ cmd_rotate() {
 
 	local log_file
 	log_file="$(_audit_log_path)"
-
 	if [[ ! -f "$log_file" ]]; then
 		_audit_info "No audit log to rotate"
 		return 0
@@ -716,43 +1025,13 @@ cmd_rotate() {
 	local size_bytes
 	size_bytes="$(wc -c <"$log_file" | tr -d ' ')"
 	local max_size_bytes=$((max_size_mb * 1048576))
-
 	if [[ $size_bytes -lt $max_size_bytes ]]; then
 		local size_mb=$((size_bytes / 1048576))
 		_audit_info "Log size (${size_mb}MB) below threshold (${max_size_mb}MB) — no rotation needed"
 		return 0
 	fi
 
-	# Verify chain before rotation
-	if ! cmd_verify --quiet 2>/dev/null; then
-		_audit_warn "Chain verification failed before rotation — rotating anyway but chain is already broken"
-	fi
-
-	# Rotate: rename with timestamp
-	local rotate_ts
-	rotate_ts="$(date -u '+%Y%m%dT%H%M%SZ' 2>/dev/null || date '+%Y%m%dT%H%M%SZ')"
-	local rotated_file="${log_file%.jsonl}.${rotate_ts}.jsonl"
-
-	# Capture the last entry's hash before moving — this creates a cryptographic
-	# link from the new log segment back to the rotated one. Without this, an
-	# attacker could swap or delete rotated segments undetectably.
-	local prev_segment_hash
-	prev_segment_hash="$(_audit_last_hash)"
-
-	mv "$log_file" "$rotated_file"
-	chmod 400 "$rotated_file" || _audit_warn "Could not set rotated log permissions to 400: $rotated_file"
-
-	_audit_info "Rotated to ${rotated_file}"
-
-	# Log rotation event in the new (empty) log file with cryptographic handoff
-	local rotated_entries
-	rotated_entries="$(wc -l <"$rotated_file" | tr -d ' ')"
-	cmd_log "system.rotate" "Audit log rotated" \
-		--detail "rotated_file=${rotated_file}" \
-		--detail "entries=${rotated_entries}" \
-		--detail "size_bytes=${size_bytes}" \
-		--detail "prev_segment_hash=${prev_segment_hash}"
-
+	_audit_rotate_locked "$log_file" "$max_size_bytes" "$max_size_mb" || return 1
 	return 0
 }
 
@@ -813,6 +1092,8 @@ Environment:
   AUDIT_LOG_DIR    Override log directory
   AUDIT_LOG_FILE   Override log file path
   AUDIT_QUIET      Suppress informational output ("true")
+  AUDIT_LOCK_TIMEOUT_SECONDS      Lock wait before failing closed (default: 10)
+  AUDIT_LOCK_ORPHAN_AGE_SECONDS   Ownerless-lock reclaim age (default: 60)
 HELP
 	return 0
 }
@@ -853,6 +1134,9 @@ main() {
 		return 1
 		;;
 	esac
+	return 0
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/audit-log-helper.sh
+++ b/.agents/scripts/audit-log-helper.sh
@@ -255,28 +255,6 @@ _audit_error() {
 	return 0
 }
 
-# Read a path's modification time as epoch seconds on macOS or Linux.
-# Arguments: $1 — path
-# Output: epoch seconds on stdout
-_audit_path_mtime_epoch() {
-	local path="$1"
-	local mtime=""
-
-	mtime="$(stat -f '%m' "$path" 2>/dev/null || true)"
-	if [[ "$mtime" =~ ^[0-9]+$ ]]; then
-		echo "$mtime"
-		return 0
-	fi
-
-	mtime="$(stat -c '%Y' "$path" 2>/dev/null || true)"
-	if [[ "$mtime" =~ ^[0-9]+$ ]]; then
-		echo "$mtime"
-		return 0
-	fi
-
-	return 1
-}
-
 # Remove only the files owned by the audit lock protocol, then the directory.
 # Arguments: $1 — lock directory
 _audit_remove_lock_dir() {
@@ -320,7 +298,12 @@ _audit_reclaim_stale_lock() {
 
 	if [[ -z "$stale_reason" ]]; then
 		local lock_mtime=""
-		lock_mtime="$(_audit_path_mtime_epoch "$lock_dir")" || return 1
+		lock_mtime="$(_file_mtime_epoch "$lock_dir")" || return 1
+		# The shared helper returns 0 when a path vanishes between the directory
+		# check and stat. Treat that race as non-stale and retry acquisition.
+		if [[ ! "$lock_mtime" =~ ^[0-9]+$ || "$lock_mtime" -eq 0 ]]; then
+			return 1
+		fi
 		local now=""
 		now="$(date '+%s')" || return 1
 		local lock_age=$((now - lock_mtime))

--- a/.agents/scripts/tests/test-audit-log-concurrency.sh
+++ b/.agents/scripts/tests/test-audit-log-concurrency.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#27973: concurrent audit writers must preserve
+# unique sequence numbers and an intact hash chain without relying on flock.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../audit-log-helper.sh"
+TEST_ROOT=""
+PASS=0
+FAIL=0
+
+cleanup() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT" 2>/dev/null || true
+	return 0
+}
+trap cleanup EXIT
+
+pass() {
+	local message="$1"
+	printf 'PASS: %s\n' "$message"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_chain() {
+	local description="$1"
+	local log_file="$2"
+	if AUDIT_LOG_FILE="$log_file" AUDIT_QUIET=true "$HELPER" verify --quiet; then
+		pass "$description"
+	else
+		fail "$description"
+	fi
+	return 0
+}
+
+run_parallel_writers() {
+	local log_file="$1"
+	local count="$2"
+	local prefix="$3"
+	local index
+	local -a pids=()
+
+	for index in $(seq 1 "$count"); do
+		AUDIT_LOG_FILE="$log_file" AUDIT_QUIET=true AUDIT_LOCK_TIMEOUT_SECONDS=30 \
+			"$HELPER" log operation.verify "${prefix}-${index}" &
+		pids+=("$!")
+	done
+	local pid
+	for pid in "${pids[@]}"; do
+		if ! wait "$pid"; then
+			fail "parallel writer process $pid failed unexpectedly"
+		fi
+	done
+	return 0
+}
+
+TEST_ROOT="$(mktemp -d -t aidevops-audit-lock-XXXXXX)"
+LOG_FILE="${TEST_ROOT}/audit.jsonl"
+
+run_parallel_writers "$LOG_FILE" 40 "concurrent"
+line_count="$(wc -l <"$LOG_FILE" | tr -d ' ')"
+if [[ "$line_count" == "40" ]]; then
+	pass "all concurrent writers appended exactly once"
+else
+	fail "expected 40 concurrent entries, found $line_count"
+fi
+
+if jq -e 'length == 40 and ([.[].seq] | unique | length == 40) and ([.[].seq] | sort == [range(1; 41)])' \
+	--slurp "$LOG_FILE" >/dev/null; then
+	pass "concurrent sequence numbers are unique and monotonic"
+else
+	fail "concurrent sequence numbers are duplicated or non-monotonic"
+fi
+assert_chain "concurrent hash chain is intact" "$LOG_FILE"
+
+LOCK_DIR="${LOG_FILE}.lock.d"
+mkdir "$LOCK_DIR"
+printf '%s held-by-test\n' "$$" >"${LOCK_DIR}/owner"
+before_timeout_count="$(wc -l <"$LOG_FILE" | tr -d ' ')"
+timeout_rc=0
+timeout_output=$(AUDIT_LOG_FILE="$LOG_FILE" AUDIT_QUIET=true AUDIT_LOCK_TIMEOUT_SECONDS=1 \
+	"$HELPER" log operation.verify "must-not-append" 2>&1) || timeout_rc=$?
+after_timeout_count="$(wc -l <"$LOG_FILE" | tr -d ' ')"
+rm -rf "$LOCK_DIR"
+if [[ "$timeout_rc" -ne 0 && "$before_timeout_count" == "$after_timeout_count" ]]; then
+	pass "lock timeout fails closed without appending"
+else
+	fail "lock timeout appended or returned success"
+fi
+if [[ "$timeout_output" == *"Could not acquire audit log lock after 1s"* ]]; then
+	pass "lock timeout reports a bounded failure"
+else
+	fail "lock timeout did not report the expected error"
+fi
+
+mkdir "$LOCK_DIR"
+printf '999999 stale-owner\n' >"${LOCK_DIR}/owner"
+AUDIT_LOG_FILE="$LOG_FILE" AUDIT_QUIET=true "$HELPER" log operation.verify "after-stale-lock"
+if [[ ! -d "$LOCK_DIR" ]]; then
+	pass "dead-owner lock is reclaimed and released"
+else
+	fail "dead-owner lock remained after append"
+fi
+assert_chain "hash chain remains intact after stale-lock reclaim" "$LOG_FILE"
+
+mkdir "$LOCK_DIR"
+AUDIT_LOG_FILE="$LOG_FILE" AUDIT_QUIET=true AUDIT_LOCK_ORPHAN_AGE_SECONDS=0 \
+	"$HELPER" log operation.verify "after-ownerless-lock"
+if [[ ! -d "$LOCK_DIR" ]]; then
+	pass "old ownerless lock is reclaimed and released"
+else
+	fail "ownerless lock remained after append"
+fi
+assert_chain "hash chain remains intact after ownerless-lock reclaim" "$LOG_FILE"
+
+SIGNAL_LOCK_DIR="${TEST_ROOT}/signal.jsonl.lock.d"
+SIGNAL_READY="${TEST_ROOT}/signal.ready"
+(
+	# Keep shared-constants from replacing this Bash 3.2 fixture process.
+	export AIDEVOPS_BASH_REEXECED=1
+	# shellcheck disable=SC1090
+	source "$HELPER"
+	_audit_acquire_lock "$SIGNAL_LOCK_DIR"
+	_audit_arm_lock_cleanup
+	: >"$SIGNAL_READY"
+	sleep 30
+) &
+signal_pid=$!
+for attempt in $(seq 1 50); do
+	[[ -f "$SIGNAL_READY" ]] && break
+	if ! kill -0 "$signal_pid" 2>/dev/null; then
+		break
+	fi
+	sleep 0.1
+done
+if [[ -f "$SIGNAL_READY" && -d "$SIGNAL_LOCK_DIR" ]]; then
+	kill -TERM "$signal_pid"
+	signal_rc=0
+	wait "$signal_pid" || signal_rc=$?
+	if [[ "$signal_rc" -eq 143 && ! -d "$SIGNAL_LOCK_DIR" ]]; then
+		pass "termination signal releases the owned lock"
+	else
+		fail "termination signal left the owned lock or returned an unexpected status"
+	fi
+else
+	fail "signal cleanup fixture did not acquire its lock"
+	kill -TERM "$signal_pid" 2>/dev/null || true
+	wait "$signal_pid" 2>/dev/null || true
+fi
+
+ROTATE_LOG="${TEST_ROOT}/rotate.jsonl"
+for index in $(seq 1 5); do
+	AUDIT_LOG_FILE="$ROTATE_LOG" AUDIT_QUIET=true "$HELPER" log operation.verify "before-rotate-${index}"
+done
+run_parallel_writers "$ROTATE_LOG" 20 "during-rotate" &
+writer_group_pid=$!
+AUDIT_LOG_FILE="$ROTATE_LOG" AUDIT_QUIET=true "$HELPER" rotate --max-size 0
+wait "$writer_group_pid"
+
+rotated_file=""
+for candidate in "${ROTATE_LOG%.jsonl}".*.jsonl; do
+	if [[ -f "$candidate" ]]; then
+		rotated_file="$candidate"
+		break
+	fi
+done
+if [[ -n "$rotated_file" ]]; then
+	pass "rotation produced an immutable segment"
+	assert_chain "rotated segment hash chain is intact" "$rotated_file"
+	assert_chain "new segment hash chain is intact" "$ROTATE_LOG"
+	rotated_last_hash="$(jq -r -s '.[-1].hash // empty' "$rotated_file")"
+	handoff_hash="$(jq -r -s 'map(select(.type == "system.rotate"))[0].detail.prev_segment_hash // empty' "$ROTATE_LOG")"
+	if [[ -n "$rotated_last_hash" && "$handoff_hash" == "$rotated_last_hash" ]]; then
+		pass "rotation event links to the prior segment hash"
+	else
+		fail "rotation event does not link to the prior segment hash"
+	fi
+	combined_count=$(($(wc -l <"$rotated_file") + $(wc -l <"$ROTATE_LOG")))
+	if [[ "$combined_count" -eq 26 ]]; then
+		pass "rotation preserves every writer plus the handoff event"
+	else
+		fail "rotation expected 26 total entries, found $combined_count"
+	fi
+else
+	fail "rotation did not produce a rotated segment"
+fi
+
+if [[ "$FAIL" -gt 0 ]]; then
+	printf '%s audit concurrency test(s) failed; %s passed\n' "$FAIL" "$PASS" >&2
+	exit 1
+fi
+printf 'All %s audit concurrency tests passed.\n' "$PASS"
+exit 0

--- a/.agents/scripts/tests/test-audit-log-concurrency.sh
+++ b/.agents/scripts/tests/test-audit-log-concurrency.sh
@@ -134,7 +134,9 @@ SIGNAL_READY="${TEST_ROOT}/signal.ready"
 	_audit_acquire_lock "$SIGNAL_LOCK_DIR"
 	_audit_arm_lock_cleanup
 	: >"$SIGNAL_READY"
-	sleep 30
+	while true; do
+		sleep 0.1
+	done
 ) &
 signal_pid=$!
 for attempt in $(seq 1 50); do

--- a/.agents/tools/security/tamper-evident-audit.md
+++ b/.agents/tools/security/tamper-evident-audit.md
@@ -48,6 +48,8 @@ Append-only JSONL file. Each entry contains:
 
 Modifying or deleting any entry breaks the `prev_hash` link in the next entry. `audit-log-helper.sh verify` walks the chain and reports breaks.
 
+Every sequence/hash/append transaction is serialized with an atomic `mkdir` lock. This works without `flock` on macOS and Linux. Lock acquisition is bounded and fails closed rather than writing without serialization; dead-owner locks are reclaimed safely.
+
 ## Event Types
 
 | Type | When to log |
@@ -109,6 +111,8 @@ audit-log-helper.sh log operation.verify "Force push verified by cross-provider 
 
 Run `audit-log-helper.sh verify` before log rotation, during security audits, or when investigating suspicious activity. Exit: 0 = intact, 1 = broken (tampered/corrupted).
 
+If verification reports a historical break, preserve the affected file as forensic evidence. Do not rewrite or truncate it. After investigation and explicit operator approval, rotate/archive the broken segment and begin a new chain; the rotation event records the prior segment hash.
+
 ## Log Rotation
 
 Threshold: 50 MB (default). Rotated files get a timestamp suffix and `0400` permissions. A rotation event is logged in the new file to maintain chain continuity.
@@ -122,7 +126,7 @@ audit-log-helper.sh rotate --max-size 50
 - **Tamper-evident, not tamper-proof.** Write access to the log allows modification; the hash chain makes this detectable. Future: remote syslog forwarding.
 - **Single-machine scope.** Local-only; compromised host can destroy logs. Remote forwarding addresses this.
 - **No encryption.** Plaintext JSON. Never log credential values -- only key names and access metadata.
-- **Sequential writes.** Concurrent writers may race. In practice, aidevops serializes operations (one pulse at a time).
+- **Bounded local serialization.** Concurrent local writers are serialized. A writer exits non-zero when it cannot acquire the lock within `AUDIT_LOCK_TIMEOUT_SECONDS` (default 10) rather than risking a forked chain.
 
 ## File Permissions
 


### PR DESCRIPTION
## Summary

Serialize the complete sequence, previous-hash, hash, append, and rotation transactions with a portable atomic-mkdir lock; add deterministic coverage for concurrency, fail-closed timeout, stale-lock recovery, signal cleanup, and rotation handoff.

## Files Changed

.agents/scripts/audit-log-helper.sh, .agents/scripts/tests/test-audit-log-concurrency.sh, .agents/tools/security/tamper-evident-audit.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** /bin/bash .agents/scripts/tests/test-audit-log-concurrency.sh (15 assertions); ShellCheck; bash -n; .agents/scripts/linters-local.sh

Resolves #27973


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.132 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 12h 4m and 2,242,797 tokens on this with the user in an interactive session.