### PR TITLE
t18125: Recover exact telemetry recording after stale locks

### DIFF
--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -106,6 +106,7 @@ GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"
 GH_API_LOG_MAX_BYTES="${AIDEVOPS_GH_API_LOG_MAX_BYTES:-16777216}"
 GH_API_RETENTION_SECONDS="${AIDEVOPS_GH_API_RETENTION_SECONDS:-172800}"
 GH_API_ERROR_KEY="error"
+_GH_API_EMPTY_LOCK_GRACE_TRIES=100
 
 _gh_now_seconds() {
 	local now=""
@@ -195,22 +196,42 @@ _gh_resolve_caller() {
 	return 0
 }
 
+_gh_log_lock_reclaim() {
+	local lock_dir="$1"
+	local tries="$2"
+	local pid_path="${lock_dir}/pid"
+	local owner=""
+	[[ -d "$lock_dir" && ! -L "$lock_dir" ]] || return 1
+	if [[ -f "$pid_path" && ! -L "$pid_path" ]]; then
+		if ! IFS= read -r owner 2>/dev/null <"$pid_path"; then
+			owner=""
+		fi
+		if [[ "$owner" =~ ^[0-9]+$ ]]; then
+			kill -0 "$owner" 2>/dev/null && return 1
+			rm -f "$pid_path" 2>/dev/null || return 1
+			rmdir "$lock_dir" 2>/dev/null || return 1
+			return 0
+		fi
+	fi
+	# mkdir and PID publication are separate operations. Give a live owner one
+	# second to publish, then reclaim a missing/malformed PID left by a process
+	# killed inside that gap. rmdir still fails closed if unexpected files exist.
+	[[ "$tries" -ge "${_GH_API_EMPTY_LOCK_GRACE_TRIES:-100}" ]] || return 1
+	[[ ! -L "$pid_path" ]] || return 1
+	rm -f "$pid_path" 2>/dev/null || return 1
+	rmdir "$lock_dir" 2>/dev/null || return 1
+	return 0
+}
+
 _gh_log_lock_acquire() {
 	local lock_dir="${GH_API_LOG}.lock"
 	local tries=0
-	local owner=""
 	local owner_pid="${BASHPID:-$$}"
 	command -v mkdir >/dev/null 2>&1 || return 1
 	while ! mkdir "$lock_dir" 2>/dev/null; do
-		if [[ -f "$lock_dir/pid" && ! -L "$lock_dir" ]]; then
-			if ! IFS= read -r owner 2>/dev/null <"$lock_dir/pid"; then
-				owner=""
-			fi
-			if [[ "$owner" =~ ^[0-9]+$ ]] && ! kill -0 "$owner" 2>/dev/null; then
-				rm -f "$lock_dir/pid" 2>/dev/null || true
-				rmdir "$lock_dir" 2>/dev/null || true
-				continue
-			fi
+		if _gh_log_lock_reclaim "$lock_dir" "$tries"; then
+			tries=0
+			continue
 		fi
 		tries=$((tries + 1))
 		[[ $tries -ge 200 ]] && return 1

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -33,13 +33,16 @@ set -euo pipefail
 
 # Use pure-bash parameter expansion instead of dirname (external binary) to avoid
 # "dirname: command not found" in headless/MCP environments where PATH is restricted.
-# Defensive PATH export ensures downstream tools (gh, git, jq, sed, awk) are findable.
-export PATH="/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+# Preserve caller-provided shims before adding fallback system tool locations.
+export PATH="${PATH:+${PATH}:}/usr/local/bin:/usr/bin:/bin"
 
 _script_path="${BASH_SOURCE[0]%/*}"
 [[ "$_script_path" == "${BASH_SOURCE[0]}" ]] && _script_path="."
 SCRIPT_DIR="$(cd "$_script_path" && pwd)" || exit
 unset _script_path
+# Keep the framework gh shim ahead of native gh so issue-sync transport attempts
+# retain policy enforcement and exact telemetry when called from Pulse or directly.
+export PATH="${SCRIPT_DIR}:${PATH}"
 source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=issue-sync-lib.sh
 source "${SCRIPT_DIR}/issue-sync-lib.sh"

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -252,6 +252,58 @@ assert_eq "missing lock tools fail open" "1" "$lock_status"
 lock_stderr_bytes=$(wc -c <"$TMPDIR/no-lock-tools.stderr" | tr -d ' ')
 assert_eq "missing lock tools stay silent" "0" "$lock_stderr_bytes"
 
+# --- Test 10b: abandoned empty locks recover instead of wedging telemetry --
+export AIDEVOPS_GH_API_LOG="$TMPDIR/stale-lock-calls.log"
+export AIDEVOPS_GH_API_REPORT="$TMPDIR/stale-lock-report.json"
+unset _GH_API_INSTRUMENT_LOADED
+# shellcheck source=../gh-api-instrument.sh
+source "${PARENT_DIR}/gh-api-instrument.sh"
+gh_clear_log
+mkdir "${GH_API_LOG}.lock"
+_GH_API_EMPTY_LOCK_GRACE_TRIES=0
+gh_record_call rest stale-empty-lock-test
+assert_eq "stale empty lock permits the next record" "1" "$(wc -l <"$GH_API_LOG" | tr -d ' ')"
+if [[ -d "${GH_API_LOG}.lock" ]]; then
+	echo "  FAIL: stale empty telemetry lock survived recovery"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: stale empty telemetry lock was removed"
+	PASS=$((PASS + 1))
+fi
+
+mkdir "${GH_API_LOG}.lock"
+printf '%s\n' 'not-a-pid' >"${GH_API_LOG}.lock/pid"
+gh_record_call rest stale-malformed-lock-test
+assert_eq "stale malformed lock permits the next record" "2" "$(wc -l <"$GH_API_LOG" | tr -d ' ')"
+
+mkdir "${GH_API_LOG}.lock"
+printf '%s\n' '999999999' >"${GH_API_LOG}.lock/pid"
+_GH_API_EMPTY_LOCK_GRACE_TRIES=100
+dead_lock_status=0
+_gh_log_lock_reclaim "${GH_API_LOG}.lock" 0 || dead_lock_status=$?
+assert_eq "dead PID lock is reclaimed without the empty-lock grace" "0" "$dead_lock_status"
+
+mkdir "${GH_API_LOG}.lock"
+printf '%s\n' "${BASHPID:-$$}" >"${GH_API_LOG}.lock/pid"
+live_lock_status=0
+_gh_log_lock_reclaim "${GH_API_LOG}.lock" 100 || live_lock_status=$?
+assert_eq "live PID lock is not reclaimed" "1" "$live_lock_status"
+rm -f "${GH_API_LOG}.lock/pid"
+rmdir "${GH_API_LOG}.lock"
+
+# --- Test 10c: issue sync keeps the framework gh shim first on PATH -------
+issue_sync_scripts_dir="$(cd "$PARENT_DIR" && pwd)"
+issue_sync_probe="$TMPDIR/issue-sync-path-probe.sh"
+cat >"$issue_sync_probe" <<'EOF_ISSUE_SYNC_PROBE'
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=../issue-sync-helper.sh
+source "$ISSUE_SYNC_HELPER" >/dev/null
+printf '%s\n' "${PATH%%:*}"
+EOF_ISSUE_SYNC_PROBE
+issue_sync_path_head=$(ISSUE_SYNC_HELPER="${PARENT_DIR}/issue-sync-helper.sh" PATH="$FAKE_BIN:$saved_path" "$BASH" "$issue_sync_probe")
+assert_eq "issue sync preserves framework gh shim precedence" "$issue_sync_scripts_dir" "$issue_sync_path_head"
+
 # Restore per-test overrides for summary diagnostics if future tests append.
 export AIDEVOPS_GH_API_LOG="$TMPDIR/gh-api-calls.log"
 export AIDEVOPS_GH_API_REPORT="$TMPDIR/report.json"


### PR DESCRIPTION
## Summary

Recover abandoned telemetry lock directories and keep issue-sync GitHub calls behind the framework shim.

## Files Changed

.agents/scripts/gh-api-instrument.sh, .agents/scripts/issue-sync-helper.sh, .agents/scripts/tests/test-gh-api-instrument.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused telemetry suite: 102 passed; issue-sync source-impact suites passed; ShellCheck and .agents/scripts/linters-local.sh passed.

For #27769


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.132 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 1d 13h and 7,715,414 tokens on this with the user in an interactive session.