### PR TITLE
GH#27983: record portable audit lock owner PID

### DIFF
--- a/.agents/scripts/audit-log-helper.sh
+++ b/.agents/scripts/audit-log-helper.sh
@@ -360,7 +360,15 @@ _audit_acquire_lock() {
 		sleep 0.1
 	done
 
-	local owner_pid="${BASHPID:-$$}"
+	local owner_pid="${BASHPID:-}"
+	if [[ -z "$owner_pid" ]]; then
+		# Bash 3.2 has no BASHPID. The child shell reports this lock-holding
+		# shell as its parent, unlike $$ which remains the top-level shell PID.
+		owner_pid="$(sh -c 'printf "%s" "$PPID"')" || {
+			_audit_remove_lock_dir "$lock_dir" || true
+			return 1
+		}
+	fi
 	local created_at=""
 	created_at="$(date '+%s')" || {
 		_audit_remove_lock_dir "$lock_dir" || true

--- a/.agents/scripts/tests/test-audit-log-concurrency.sh
+++ b/.agents/scripts/tests/test-audit-log-concurrency.sh
@@ -129,6 +129,9 @@ SIGNAL_READY="${TEST_ROOT}/signal.ready"
 (
 	# Keep shared-constants from replacing this Bash 3.2 fixture process.
 	export AIDEVOPS_BASH_REEXECED=1
+	# Bash 3.2 does not define BASHPID; force that compatibility path even
+	# when this regression test runs under a newer Bash.
+	unset BASHPID
 	# shellcheck disable=SC1090
 	source "$HELPER"
 	_audit_acquire_lock "$SIGNAL_LOCK_DIR"
@@ -147,6 +150,12 @@ for attempt in $(seq 1 50); do
 	sleep 0.1
 done
 if [[ -f "$SIGNAL_READY" && -d "$SIGNAL_LOCK_DIR" ]]; then
+	IFS=' ' read -r signal_owner_pid _ <"${SIGNAL_LOCK_DIR}/owner"
+	if [[ "$signal_owner_pid" == "$signal_pid" ]]; then
+		pass "Bash 3.2 fallback records the lock-holding subshell PID"
+	else
+		fail "Bash 3.2 fallback recorded PID ${signal_owner_pid}, expected ${signal_pid}"
+	fi
 	kill -TERM "$signal_pid"
 	signal_rc=0
 	wait "$signal_pid" || signal_rc=$?


### PR DESCRIPTION
## Summary

- Record the actual lock-holding PID when Bash 3.2 lacks `BASHPID`.
- Add regression coverage that forces the Bash 3.2 fallback path.

## Testing

- `shellcheck .agents/scripts/audit-log-helper.sh .agents/scripts/tests/test-audit-log-concurrency.sh`
- `bash .agents/scripts/tests/test-audit-log-concurrency.sh` (16 passed)

## Runtime Testing

Runtime-verified through the concurrency, stale-lock recovery, signal cleanup, and rotation regression suite.

Resolves #27983

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit log lock ownership detection across Bash versions.
  * Added safer cleanup when the lock owner cannot be identified, preventing stale or invalid locks.

* **Tests**
  * Expanded concurrency coverage to validate lock ownership and Bash 3.2 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->