### PR TITLE
GH#27980: isolate workflow sync mutations from canonical checkouts

### DIFF
--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -478,6 +478,36 @@ _classify_workflow() {
 
 # ─── Repo iteration ─────────────────────────────────────────────────────────
 
+# _resolve_caller_worktree_root <slug>
+# Prefer an explicitly supplied or current caller-owned linked worktree when it
+# belongs to the registered repository. The common-dir comparison binds the
+# candidate to repos.json without relying on remote URL string parsing.
+_resolve_caller_worktree_root() {
+	local _slug="$1"
+	local _candidate="${AIDEVOPS_WORKFLOW_REPO_ROOT:-}"
+	if [[ -z "$_candidate" ]]; then
+		_candidate=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null) || return 1
+	fi
+	_candidate=$(git -C "$_candidate" rev-parse --show-toplevel 2>/dev/null) || return 1
+
+	local _registered
+	_registered=$(jq -r --arg s "$_slug" \
+		'.initialized_repos[]? | select(.slug == $s) | .path // empty' \
+		"$REPOS_JSON" 2>/dev/null | head -n 1)
+	[[ -n "$_registered" ]] || return 1
+	_registered="${_registered/#\~/$HOME}"
+
+	local _candidate_git_dir _candidate_common_dir _registered_common_dir
+	_candidate_git_dir=$(git -C "$_candidate" rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 1
+	_candidate_common_dir=$(git -C "$_candidate" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	_registered_common_dir=$(git -C "$_registered" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	[[ "$_candidate_git_dir" != "$_candidate_common_dir" ]] || return 1
+	[[ "$_candidate_common_dir" == "$_registered_common_dir" ]] || return 1
+
+	printf '%s\n' "$_candidate"
+	return 0
+}
+
 # _iterate_repos — emit one "slug|path|local_only" line per registered repo
 _iterate_repos() {
 	if [[ ! -f "$REPOS_JSON" ]]; then
@@ -504,13 +534,14 @@ _iterate_repos() {
 	return 0
 }
 
-# _repo_freshness <repo-path>
+# _repo_freshness <repo-path> [evidence-source]
 # Emits: source\tbranch\tupstream\tahead\tbehind\tstate
 # Uses only existing refs: check-workflows remains a read-only, no-network audit.
 _repo_freshness() {
 	local _path="$1"
+	local _source="${2:-local}"
 	if ! git -C "$_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-		printf 'local\tunknown\tunknown\tunknown\tunknown\tunknown\n'
+		printf '%s\tunknown\tunknown\tunknown\tunknown\tunknown\n' "$_source"
 		return 0
 	fi
 
@@ -519,13 +550,13 @@ _repo_freshness() {
 	local _upstream
 	_upstream=$(git -C "$_path" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
 	if [[ -z "$_upstream" ]]; then
-		printf 'local\t%s\tunknown\tunknown\tunknown\tuntracked\n' "$_branch"
+		printf '%s\t%s\tunknown\tunknown\tunknown\tuntracked\n' "$_source" "$_branch"
 		return 0
 	fi
 
 	local _ahead _behind
 	if ! read -r _ahead _behind < <(git -C "$_path" rev-list --left-right --count "HEAD...${_upstream}" 2>/dev/null); then
-		printf 'local\t%s\t%s\tunknown\tunknown\tunknown\n' "$_branch" "$_upstream"
+		printf '%s\t%s\t%s\tunknown\tunknown\tunknown\n' "$_source" "$_branch" "$_upstream"
 		return 0
 	fi
 
@@ -537,25 +568,26 @@ _repo_freshness() {
 	elif ((_ahead > 0)); then
 		_state="ahead"
 	fi
-	printf 'local\t%s\t%s\t%s\t%s\t%s\n' \
-		"$_branch" "$_upstream" "$_ahead" "$_behind" "$_state"
+	printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$_source" "$_branch" "$_upstream" "$_ahead" "$_behind" "$_state"
 	return 0
 }
 
-# _freshness_note <branch> <upstream> <ahead> <behind> <state>
+# _freshness_note <branch> <upstream> <ahead> <behind> <state> [evidence-source]
 _freshness_note() {
 	local _branch="$1"
 	local _upstream="$2"
 	local _ahead="$3"
 	local _behind="$4"
 	local _state="$5"
+	local _source="${6:-local}"
 	case "$_state" in
 	behind)
-		printf 'local evidence; %s is %s commit(s) behind %s' "$_branch" "$_behind" "$_upstream"
+		printf '%s evidence; %s is %s commit(s) behind %s' "$_source" "$_branch" "$_behind" "$_upstream"
 		;;
 	diverged)
-		printf 'local evidence; %s is %s ahead and %s behind %s' \
-			"$_branch" "$_ahead" "$_behind" "$_upstream"
+		printf '%s evidence; %s is %s ahead and %s behind %s' \
+			"$_source" "$_branch" "$_ahead" "$_behind" "$_upstream"
 		;;
 	esac
 	return 0
@@ -799,7 +831,7 @@ _resolve_wf_canonical() {
 }
 
 # _classify_row_with_freshness <slug> <path> <local-only> <canonical>
-#   <reusable-file> <workflow-file> <canon-norm>
+#   <reusable-file> <workflow-file> <canon-norm> [evidence-source]
 # Emits form-feed-delimited classification, note, and evidence fields.
 _classify_row_with_freshness() {
 	local _slug="$1"
@@ -809,15 +841,17 @@ _classify_row_with_freshness() {
 	local _reusable_file="$5"
 	local _workflow_file="$6"
 	local _canon_norm="${7:-}"
+	local _evidence_source="${8:-local}"
 	local _class _note
 	IFS=$'\t' read -r _class _note < <(_classify_row \
 		"$_slug" "$_path" "$_local_only_flag" "$_canonical" \
 		"$_reusable_file" "$_workflow_file" "$_canon_norm")
 	local _source _branch _upstream _ahead _behind _freshness
 	IFS=$'\t' read -r _source _branch _upstream _ahead _behind _freshness \
-		< <(_repo_freshness "$_path")
+		< <(_repo_freshness "$_path" "$_evidence_source")
 	local _freshness_note_text
-	_freshness_note_text=$(_freshness_note "$_branch" "$_upstream" "$_ahead" "$_behind" "$_freshness")
+	_freshness_note_text=$(_freshness_note \
+		"$_branch" "$_upstream" "$_ahead" "$_behind" "$_freshness" "$_source")
 	if [[ -n "$_freshness_note_text" ]]; then
 		[[ -n "$_note" ]] && _note="${_note}; "
 		_note="${_note}${_freshness_note_text}"
@@ -833,6 +867,22 @@ _render_rows_header() {
 		printf '\n  %-50s %-16s %s\n' "REPO [WORKFLOW]" "STATUS" "NOTE"
 		printf '  %s\n' "$(printf '%.0s─' {1..88})"
 	fi
+	return 0
+}
+
+_resolve_row_checkout() {
+	local _path="$1"
+	local _local_only_flag="$2"
+	local _slug="$3"
+	local _filter_slug="$4"
+	local _source="local"
+	_path="${_path/#\~/$HOME}"
+	if [[ -n "${_CALLER_WORKTREE_ROOT:-}" && "$_slug" == "$_filter_slug" && \
+		"$_local_only_flag" != "true" ]]; then
+		_path="$_CALLER_WORKTREE_ROOT"
+		_source="caller-worktree"
+	fi
+	printf '%s\034%s\n' "$_path" "$_source"
 	return 0
 }
 
@@ -880,12 +930,14 @@ _process_rows() {
 			[[ -n "$_filter_slug" && "$_slug" != "$_filter_slug" ]] && continue
 
 			_total=$((_total + 1))
-			_path="${_path/#\~/$HOME}"
+			local _row_evidence_source
+			IFS=$'\034' read -r _path _row_evidence_source < <(_resolve_row_checkout "$_path" "$_local_only_flag" "$_slug" "$_filter_slug")
 
 			local _class _note _evidence_source _branch _upstream _ahead _behind _freshness
 			IFS=$'\034' read -r _class _note _evidence_source _branch _upstream _ahead _behind _freshness \
 				< <(_classify_row_with_freshness "$_slug" "$_path" "$_local_only_flag" \
-					"$_canonical" "$_reusable_file" "$_workflow_file" "$_canon_norm")
+					"$_canonical" "$_reusable_file" "$_workflow_file" "$_canon_norm" \
+					"$_row_evidence_source")
 
 			local _base_class="${_class% + LEGACY_ARTIFACTS}"
 			if [[ "$_class" == *" + LEGACY_ARTIFACTS" ]]; then
@@ -951,6 +1003,10 @@ main() {
 
 	local _mode _verbose _filter_slug _filter_workflow
 	IFS=$'\t' read -r _mode _verbose _filter_slug _filter_workflow < <(_parse_args "$@")
+	_CALLER_WORKTREE_ROOT=""
+	if [[ -n "$_filter_slug" ]]; then
+		_CALLER_WORKTREE_ROOT=$(_resolve_caller_worktree_root "$_filter_slug") || _CALLER_WORKTREE_ROOT=""
+	fi
 
 	if _process_rows "$_mode" "$_verbose" "$_filter_slug" "$_filter_workflow"; then
 		exit 0

--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -25,8 +25,9 @@
 #   - Preserve intentional @ref pinning: if the repo's current caller pins a
 #     specific ref and the new template's ref would change it, keep the repo's
 #     choice unless --force-ref is set.
-#   - Skip repos with uncommitted changes. Skip repos that aren't on their
-#     default branch. Report both as warnings.
+#   - Never mutate registered canonical checkouts. Reuse a matching caller-owned
+#     linked worktree or create a fresh framework-owned linked worktree.
+#   - Skip linked worktrees with uncommitted changes.
 #
 # Exit codes:
 #   0  all targeted repos processed successfully (or no work needed)
@@ -144,6 +145,86 @@ _warn() {
 _info() {
 	local _msg="$1"
 	printf '[%s] %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	return 0
+}
+
+_is_linked_worktree() {
+	local _path="$1"
+	local _git_dir _common_dir
+	_git_dir=$(git -C "$_path" rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 1
+	_common_dir=$(git -C "$_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	[[ "$_git_dir" != "$_common_dir" ]]
+}
+
+_remote_default_ref() {
+	local _default_branch="$1"
+	printf 'origin/%s\n' "$_default_branch"
+	return 0
+}
+
+_worktree_for_branch() {
+	local _repo_path="$1"
+	local _branch="$2"
+	local _line _candidate=""
+	while IFS= read -r _line; do
+		case "$_line" in
+		worktree\ *) _candidate="${_line#worktree }" ;;
+		"branch refs/heads/${_branch}")
+			printf '%s\n' "$_candidate"
+			return 0
+			;;
+		esac
+	done < <(git -C "$_repo_path" worktree list --porcelain 2>/dev/null)
+	return 1
+}
+
+# _prepare_apply_worktree <slug> <classified-path> <branch>
+# Emits the safe linked worktree path used for mutation.
+_prepare_apply_worktree() {
+	local _slug="$1"
+	local _classified_path="$2"
+	local _branch="$3"
+	if _is_linked_worktree "$_classified_path"; then
+		if command -v is_worktree_owned_by_others >/dev/null 2>&1 && \
+			is_worktree_owned_by_others "$_classified_path"; then
+			return 1
+		fi
+		printf '%s\n' "$_classified_path"
+		return 0
+	fi
+	git -C "$_classified_path" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+
+	local _default_branch
+	_default_branch=$(git -C "$_classified_path" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+	[[ -z "$_default_branch" ]] && _default_branch="$_BRANCH_DEFAULT_NAME"
+	git -C "$_classified_path" fetch -q origin "$_default_branch" >/dev/null 2>&1 || return 1
+
+	local _existing
+	_existing=$(_worktree_for_branch "$_classified_path" "$_branch") || _existing=""
+	if [[ -n "$_existing" ]]; then
+		_is_linked_worktree "$_existing" || return 1
+		if command -v is_worktree_owned_by_others >/dev/null 2>&1 && \
+			is_worktree_owned_by_others "$_existing"; then
+			return 1
+		fi
+		printf '%s\n' "$_existing"
+		return 0
+	fi
+
+	local _base_dir="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"
+	local _safe_name
+	_safe_name=$(printf '%s-%s' "$_slug" "$_branch" | sed 's|[^A-Za-z0-9._-]|-|g')
+	local _worktree_path="${_base_dir}/${_safe_name}"
+	local _default_ref
+	_default_ref=$(_remote_default_ref "$_default_branch")
+	mkdir -p "$_base_dir" || return 1
+	[[ ! -e "$_worktree_path" ]] || return 1
+	git -C "$_classified_path" worktree add -q -B "$_branch" \
+		"$_worktree_path" "$_default_ref" >/dev/null 2>&1 || return 1
+	if command -v register_worktree >/dev/null 2>&1; then
+		register_worktree "$_worktree_path" "$_branch" --task workflow-sync || true
+	fi
+	printf '%s\n' "$_worktree_path"
 	return 0
 }
 
@@ -280,7 +361,8 @@ _mirror_supports_helper_provenance() {
 		'.initialized_repos[]? | select(.slug == $s) | .path // empty' \
 		"$REPOS_JSON" 2>/dev/null | head -n 1)
 	_reusable_path=".github/workflows/${_workflow_name}-reusable.yml"
-	[[ -n "$_path" && -d "$_path/.git" ]] || return 1
+	[[ -n "$_path" ]] || return 1
+	git -C "$_path" rev-parse --git-dir >/dev/null 2>&1 || return 1
 	_reusable_content=$(git -C "$_path" show "${_ref#@}:${_reusable_path}" 2>/dev/null) || return 1
 	if grep -qE '^      aidevops_repository:' <<<"$_reusable_content" && \
 		grep -qE '^      AIDEVOPS_READ_TOKEN:' <<<"$_reusable_content"; then
@@ -458,13 +540,15 @@ _list_actionable_repos() {
 	return 0
 }
 
-# _classify_after_refresh <slug> <workflow>
+# _classify_after_refresh <slug> <workflow> <worktree-path>
 # Reuses check-workflows as the single classifier after apply refreshes a repo.
 _classify_after_refresh() {
 	local _slug="$1"
 	local _workflow="$2"
+	local _path="$3"
 	local _json
-	_json=$("$CHECK_HELPER" --json --repo "$_slug" --workflow "$_workflow" 2>/dev/null || true)
+	_json=$(AIDEVOPS_WORKFLOW_REPO_ROOT="$_path" \
+		"$CHECK_HELPER" --json --repo "$_slug" --workflow "$_workflow" 2>/dev/null || true)
 	if [[ -z "$_json" ]]; then
 		return 1
 	fi
@@ -559,7 +643,7 @@ _sync_dryrun_emit() {
 }
 
 # _sync_preflight <slug> <path> <status> <default_branch_out>
-# Validates repo precondition and clean-tree/branch state.
+# Validates linked-worktree identity and clean state.
 # Returns 0 proceed; 1 fail; 2 skip. Sets _PREFLIGHT_DEFAULT_BRANCH on proceed.
 _sync_preflight() {
 	local _slug="$1"
@@ -570,29 +654,27 @@ _sync_preflight() {
 		printf '%s\t%s\t%s\trepo directory missing: %s\n' "$_slug" "$_status" "$_STATUS_FAILED" "$_path"
 		return 1
 	fi
-	if [[ ! -d "$_path/.git" ]]; then
+	if ! git -C "$_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 		printf '%s\t%s\t%s\tnot a git repo: %s\n' "$_slug" "$_status" "$_STATUS_FAILED" "$_path"
+		return 1
+	fi
+	if ! _is_linked_worktree "$_path"; then
+		printf '%s\t%s\t%s\trefusing canonical checkout mutation: %s\n' \
+			"$_slug" "$_status" "$_STATUS_FAILED" "$_path"
 		return 1
 	fi
 	local _default_branch
 	_default_branch=$(git -C "$_path" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
 	[[ -z "$_default_branch" ]] && _default_branch="$_BRANCH_DEFAULT_NAME"
-	if ! git -C "$_path" diff-index --quiet HEAD -- 2>/dev/null; then
+	if [[ -n "$(git -C "$_path" status --porcelain 2>/dev/null)" ]]; then
 		printf '%s\t%s\t%s\tworking tree not clean; skipping\n' "$_slug" "$_status" "$_STATUS_SKIPPED"
-		return 2
-	fi
-	local _current_branch
-	_current_branch=$(git -C "$_path" symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
-	if [[ "$_current_branch" != "$_default_branch" ]]; then
-		printf '%s\t%s\t%s\ton %s, expected %s; skipping\n' \
-			"$_slug" "$_status" "$_STATUS_SKIPPED" "$_current_branch" "$_default_branch"
 		return 2
 	fi
 	_PREFLIGHT_DEFAULT_BRANCH="$_default_branch"
 	return 0
 }
 
-# _sync_refresh_checkout <slug> <path> <status> <default_branch>
+# _sync_refresh_checkout <slug> <path> <status> <default_branch> <sync-branch>
 # Apply must classify and mutate the same refreshed snapshot. Fail closed when
 # refresh is unavailable rather than continuing with stale local evidence.
 _sync_refresh_checkout() {
@@ -600,8 +682,19 @@ _sync_refresh_checkout() {
 	local _path="$2"
 	local _status="$3"
 	local _default_branch="$4"
-	if ! git -C "$_path" pull --ff-only origin "$_default_branch" >/dev/null 2>&1; then
-		printf '%s\t%s\t%s\tpull --ff-only failed; refusing stale classification\n' \
+	local _branch_name="$5"
+	if ! git -C "$_path" fetch -q origin "$_default_branch" >/dev/null 2>&1; then
+		printf '%s\t%s\t%s\tfetch failed; refusing stale classification\n' \
+			"$_slug" "$_status" "$_STATUS_FAILED"
+		return 1
+	fi
+	local _current_branch
+	local _default_ref
+	_current_branch=$(git -C "$_path" symbolic-ref --short HEAD 2>/dev/null || printf 'DETACHED')
+	_default_ref=$(_remote_default_ref "$_default_branch")
+	if [[ "$_current_branch" != "$_branch_name" ]] && \
+		! git -C "$_path" checkout -q -B "$_branch_name" "$_default_ref"; then
+		printf '%s\t%s\t%s\tfailed to prepare sync branch\n' \
 			"$_slug" "$_status" "$_STATUS_FAILED"
 		return 1
 	fi
@@ -628,7 +721,12 @@ _sync_write_commit_push() {
 			"$_slug" "$_status" "$_STATUS_SKIPPED"
 		return 2
 	fi
-	if ! git -C "$_path" checkout -q -B "$_branch_name" "$_default_branch"; then
+	local _current_branch
+	local _default_ref
+	_current_branch=$(git -C "$_path" symbolic-ref --short HEAD 2>/dev/null || printf 'DETACHED')
+	_default_ref=$(_remote_default_ref "$_default_branch")
+	if [[ "$_current_branch" != "$_branch_name" ]] && \
+		! git -C "$_path" checkout -q -B "$_branch_name" "$_default_ref"; then
 		printf '%s\t%s\t%s\tbranch create/reset failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
 		return 1
 	fi
@@ -741,7 +839,7 @@ _sync_one_repo() {
 	fi
 	local _default_branch="$_PREFLIGHT_DEFAULT_BRANCH"
 	local _refresh_output
-	if ! _refresh_output=$(_sync_refresh_checkout "$_slug" "$_path" "$_status" "$_default_branch"); then
+	if ! _refresh_output=$(_sync_refresh_checkout "$_slug" "$_path" "$_status" "$_default_branch" "$_branch_name"); then
 		printf '%s\n' "$_refresh_output"
 		return 1
 	fi
@@ -749,7 +847,7 @@ _sync_one_repo() {
 	local _workflow_name
 	_workflow_name=$(basename "$_workflow_relpath" .yml)
 	local _refreshed_status
-	if ! _refreshed_status=$(_classify_after_refresh "$_slug" "$_workflow_name"); then
+	if ! _refreshed_status=$(_classify_after_refresh "$_slug" "$_workflow_name" "$_path"); then
 		printf '%s\t%s\t%s\tpost-refresh classification failed\n' \
 			"$_slug" "$_status" "$_STATUS_FAILED"
 		return 1
@@ -884,6 +982,17 @@ _process_rows() {
 		# Never touch aidevops itself (defence in depth; Phase 1 also emits
 		# CURRENT/SELF-CALLER).
 		[[ "$_slug" == "marcusquinn/aidevops" ]] && continue
+		if [[ "$_OPT_APPLY" -eq 1 ]]; then
+			local _safe_path
+			if ! _safe_path=$(_prepare_apply_worktree "$_slug" "$_path" "$_OPT_BRANCH_NAME"); then
+				local _prepare_result="${_slug}"$'\t'"${_status}"$'\t'"${_STATUS_FAILED}"$'\t'"safe linked worktree preparation failed"
+				_any_failed=1
+				_print_result_row "$_OPT_JSON" "${_OPT_TARGET_REF:-@${_DEFAULT_WORKFLOW_REUSABLE_REF}}" \
+					"$_OPT_BRANCH_NAME" "$_prepare_result"
+				continue
+			fi
+			_path="$_safe_path"
+		fi
 
 		# Resolve the template for this workflow.
 		# _workflow_name is the short name (e.g. "issue-sync" or "review-bot-gate").

--- a/.agents/scripts/tests/test-check-workflows-helper.sh
+++ b/.agents/scripts/tests/test-check-workflows-helper.sh
@@ -21,6 +21,7 @@
 #  17. Legacy-artifact manifest without a trailing newline processes its final row
 #  18. Unset HOME exits cleanly instead of raising an unbound-variable error
 #  19. Stale local checkout reports local evidence and upstream divergence
+#  20. Repository-scoped checks prefer a matching caller-owned linked worktree
 #
 # Strategy: Each scenario writes a temporary repos.json + temporary repo trees
 # under a per-test TMPDIR, points HOME at it, and invokes the helper. No
@@ -521,6 +522,46 @@ else
 		"json: $json_row; human: $human_row"
 fi
 rm -rf "$TMPDIR_19"
+
+# Test 20: A repository-scoped check launched from a matching linked worktree
+# must classify that worktree rather than the registered canonical checkout.
+TMPDIR_20="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_20"
+BARE_20="$TMPDIR_20/remote.git"
+REPO_20="$TMPDIR_20/repos/canonical"
+LINKED_20="$TMPDIR_20/worktrees/caller-owned"
+git init --bare -q "$BARE_20"
+mkdir -p "$REPO_20/.github/workflows" "$(dirname "$LINKED_20")"
+git -C "$REPO_20" init -q
+git -C "$REPO_20" config user.email test@example.com
+git -C "$REPO_20" config user.name Test
+git -C "$REPO_20" config commit.gpgsign false
+git -C "$REPO_20" checkout -q -b main
+cp "$CANONICAL_TEMPLATE" "$REPO_20/.github/workflows/issue-sync.yml"
+git -C "$REPO_20" add -A
+git -C "$REPO_20" commit -q -m "canonical workflow"
+git -C "$REPO_20" remote add origin "$BARE_20"
+git -C "$REPO_20" push -q -u origin main
+git --git-dir="$BARE_20" symbolic-ref HEAD refs/heads/main
+git -C "$REPO_20" worktree add -q -b caller-owned "$LINKED_20" main
+printf '\n# caller-owned worktree drift\n' >>"$LINKED_20/.github/workflows/issue-sync.yml"
+git -C "$LINKED_20" add -A
+git -C "$LINKED_20" commit -q -m "linked worktree drift"
+printf 'unrelated canonical dirt\n' >"$REPO_20/unrelated.txt"
+_write_repos_json "$TMPDIR_20" \
+	"$(jq -n --arg path "$REPO_20" '{initialized_repos: [{slug: "x/caller-owned", path: $path, local_only: false}]}')"
+json_row=$(cd "$LINKED_20" && HOME="$TMPDIR_20" bash "$HELPER" \
+	--json --repo x/caller-owned --workflow issue-sync 2>/dev/null || true)
+LINKED_ROOT_20=$(git -C "$LINKED_20" rev-parse --show-toplevel)
+if [[ "$(printf '%s\n' "$json_row" | jq -r '.classification')" == "DRIFTED/CALLER" ]] &&
+	[[ "$(printf '%s\n' "$json_row" | jq -r '.path')" == "$LINKED_ROOT_20" ]] &&
+	[[ "$(printf '%s\n' "$json_row" | jq -r '.evidence.source')" == "caller-worktree" ]] &&
+	[[ -f "$REPO_20/unrelated.txt" ]]; then
+	_pass "repository-scoped check → caller-owned linked-worktree evidence"
+else
+	_fail "repository-scoped check → caller-owned linked-worktree evidence" "json: $json_row"
+fi
+rm -rf "$TMPDIR_20"
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 

--- a/.agents/scripts/tests/test-sync-workflows-helper.sh
+++ b/.agents/scripts/tests/test-sync-workflows-helper.sh
@@ -416,8 +416,11 @@ WF_HELPER_REF_13=$(git -C "$REPO_13" show "${SYNC_BRANCH_13}:.github/workflows/i
 	| grep -E "^[[:space:]]+aidevops_ref:" | head -n 1 || true)
 WF_HELPER_SECRET_13=$(git -C "$REPO_13" show "${SYNC_BRANCH_13}:.github/workflows/issue-sync.yml" 2>/dev/null \
 	| grep -E "^[[:space:]]+AIDEVOPS_READ_TOKEN:" | head -n 1 || true)
-git -C "$REPO_13" checkout -q "$SYNC_BRANCH_13" 2>/dev/null || true
-CHECK_CLASS_13=$(HOME="$TMPDIR_13" bash "$CHECK_HELPER" --json --repo "owner/repo-org-target" --workflow issue-sync 2>/dev/null \
+SYNC_WORKTREE_13=$(git -C "$REPO_13" worktree list --porcelain | awk \
+	-v branch="refs/heads/${SYNC_BRANCH_13}" \
+	'/^worktree / { path = substr($0, 10) } /^branch / { if (substr($0, 8) == branch) { print path; exit } }')
+CHECK_CLASS_13=$(HOME="$TMPDIR_13" AIDEVOPS_WORKFLOW_REPO_ROOT="$SYNC_WORKTREE_13" \
+	bash "$CHECK_HELPER" --json --repo "owner/repo-org-target" --workflow issue-sync 2>/dev/null \
 	| jq -r 'select(.slug == "owner/repo-org-target") | .classification' \
 	| head -n 1)
 if [[ "$WF_USES_13" == *"ORG/.github/.github/workflows/issue-sync-reusable.yml@${MIRROR_REF_13}"* ]]; then
@@ -568,6 +571,57 @@ _assert_contains "GH#27727 stale mirror reports compatibility blocker" "$OUT_16"
 	"configured mirror must be registered and updated at @main before caller sync"
 _assert_exit "GH#27727 stale mirror exits non-zero" 1 "$EXIT_16"
 rm -rf "$TMPDIR_16"
+
+# ─── Test 17: GH#27980 — caller-owned linked worktree protects canonical ────
+TMPDIR_17="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_17"
+_setup_mock_gh "$TMPDIR_17"
+BARE_17="$TMPDIR_17/bare.git"
+REPO_17="$TMPDIR_17/repos/canonical"
+LINKED_17="$TMPDIR_17/worktrees/caller-owned"
+git init --bare -q "$BARE_17"
+mkdir -p "$REPO_17/.github/workflows" "$(dirname "$LINKED_17")"
+git -C "$REPO_17" init -q
+git -C "$REPO_17" config user.email test@example.com
+git -C "$REPO_17" config user.name Test
+git -C "$REPO_17" config commit.gpgsign false
+git -C "$REPO_17" checkout -q -b main
+printf '%s\n' "$LEGACY_CONTENT" >"$REPO_17/.github/workflows/issue-sync.yml"
+git -C "$REPO_17" add -A
+git -C "$REPO_17" commit -q -m "legacy workflow"
+git -C "$REPO_17" remote add origin "$BARE_17"
+git -C "$REPO_17" push -q -u origin main
+git --git-dir="$BARE_17" symbolic-ref HEAD refs/heads/main
+git -C "$REPO_17" remote set-head origin main
+git -C "$REPO_17" worktree add -q -b caller-owned "$LINKED_17" main
+printf 'preserve canonical dirt\n' >"$REPO_17/unrelated.txt"
+CANONICAL_STATUS_17=$(git -C "$REPO_17" status --porcelain)
+_write_repos_json "$TMPDIR_17" \
+	"{\"initialized_repos\":[{\"path\":\"$REPO_17\",\"slug\":\"owner/repo-caller-owned\"}]}"
+SYNC_BRANCH_17="chore/test-caller-owned"
+OUT_17=$(cd "$LINKED_17" && \
+	HOME="$TMPDIR_17" PATH="$TMPDIR_17/bin:$PATH" GH_CALL_LOG="$TMPDIR_17/gh-calls.log" \
+	AIDEVOPS_WORKTREE_BASE_DIR="$TMPDIR_17/framework-worktrees" \
+	bash "$HELPER" --apply --repo owner/repo-caller-owned --workflow issue-sync \
+		--branch "$SYNC_BRANCH_17" 2>&1)
+EXIT_17=$?
+APPLIED_17=$(git --git-dir="$BARE_17" show \
+	"refs/heads/${SYNC_BRANCH_17}:.github/workflows/issue-sync.yml" 2>/dev/null || true)
+CANONICAL_STATUS_AFTER_17=$(git -C "$REPO_17" status --porcelain)
+if [[ "$OUT_17" == *"APPLIED"* ]] &&
+	[[ "$APPLIED_17" == "$CANONICAL_CALLER_CONTENT" ]] &&
+	[[ "$(git -C "$REPO_17" symbolic-ref --short HEAD)" == "main" ]] &&
+	[[ "$CANONICAL_STATUS_AFTER_17" == "$CANONICAL_STATUS_17" ]] &&
+	[[ -f "$REPO_17/unrelated.txt" ]]; then
+	printf '%sPASS%s GH#27980 linked-worktree apply preserves dirty canonical checkout\n' "$GREEN" "$NC"
+	((_PASS++))
+else
+	printf '%sFAIL%s GH#27980 linked-worktree apply preserves dirty canonical checkout\n' "$RED" "$NC"
+	printf '       output: %s\n' "$OUT_17"
+	((_FAIL++))
+fi
+_assert_exit "GH#27980 linked-worktree apply exits 0" 0 "$EXIT_17"
+rm -rf "$TMPDIR_17"
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 printf '\n'


### PR DESCRIPTION
## Summary

Prefer matching caller-owned linked worktrees for repository-scoped checks, create framework-owned linked worktrees for apply operations, and reject canonical checkout mutation.

## Files Changed

.agents/scripts/check-workflows-helper.sh, .agents/scripts/sync-workflows-helper.sh, .agents/scripts/tests/test-check-workflows-helper.sh, .agents/scripts/tests/test-sync-workflows-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 22 check-workflows tests and 47 sync-workflows tests passed; ShellCheck clean; local quality suite passed.

Resolves #27980


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.129 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 36m and 800,704 tokens on this with the user in an interactive session.