### PR TITLE
GH#27977: fix: isolate pulse TODO reconciliation (#27977)

### DIFF
--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -33,6 +33,13 @@ _planning_publish_log() {
 	return 0
 }
 
+_planning_publish_log_retryable_conflict() {
+	local publication_id="$1"
+	_planning_publish_log warning \
+		"AIDEVOPS_PLANNING_PUBLISH_STATUS=retryable_conflict publication_id=${publication_id}"
+	return 0
+}
+
 _planning_publish_path_allowed() {
 	local path="$1"
 	case "$path" in
@@ -244,7 +251,7 @@ planning_publish() {
 	local branch_name="${4:-}"
 	local paths="${5:-}"
 	local temp_dir="" snapshot_file="" index_file="" parent_sha="" tree_sha="" candidate_sha=""
-	local publication_id="" attempt=0 push_rc=0 latest_sha="" expected_sha="" parent_resolution=""
+	local publication_id="" attempt=0 push_rc=0 latest_sha="" expected_sha="" parent_resolution="" base_sha="${AIDEVOPS_PLANNING_BASE_SHA:-}"
 
 	[[ -n "$branch_name" ]] || branch_name=$(_planning_git -C "$repo_path" symbolic-ref --short HEAD 2>/dev/null) || return 1
 	[[ -n "$paths" ]] || paths=$(_planning_publish_changed_paths "$repo_path")
@@ -273,8 +280,14 @@ planning_publish() {
 		}
 		latest_sha="${parent_resolution%%|*}"
 		expected_sha="${parent_resolution#*|}"
+		if [[ -z "$parent_sha" && -n "$base_sha" && "$base_sha" != "$latest_sha" ]] && \
+			_planning_publish_parent_conflicts "$repo_path" "$base_sha" "$latest_sha" "$snapshot_file"; then
+			_planning_publish_log_retryable_conflict "$publication_id"
+			rm -rf "$temp_dir"
+			return 2
+		fi
 		if [[ -n "$parent_sha" ]] && _planning_publish_parent_conflicts "$repo_path" "$parent_sha" "$latest_sha" "$snapshot_file"; then
-			_planning_publish_log warning "AIDEVOPS_PLANNING_PUBLISH_STATUS=retryable_conflict publication_id=${publication_id}"
+			_planning_publish_log_retryable_conflict "$publication_id"
 			rm -rf "$temp_dir"
 			return 2
 		fi
@@ -328,7 +341,7 @@ planning_publish() {
 			return 0
 		fi
 	done
-	_planning_publish_log warning "AIDEVOPS_PLANNING_PUBLISH_STATUS=retryable_conflict publication_id=${publication_id}"
+	_planning_publish_log_retryable_conflict "$publication_id"
 	rm -rf "$temp_dir"
 	return 2
 }

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -479,33 +479,117 @@ _pulse_reconcile_stale_blocked_if_due() {
 }
 
 #######################################
+# _pulse_create_todo_sync_workspace
+#
+# Clone the current remote default branch into an isolated automation
+# workspace. The registered human checkout is used only to resolve origin.
+#######################################
+_pulse_create_todo_sync_workspace() {
+	local repo_path="$1"
+	local remote_url=""
+	local temp_base="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local workspace=""
+	remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null) || return 1
+	[[ -n "$remote_url" ]] || return 1
+	mkdir -p "$temp_base" || return 1
+	workspace=$(mktemp -d "${temp_base}/pulse-todo-sync.XXXXXX") || return 1
+	if ! git clone --quiet --no-tags "$remote_url" "${workspace}/repo" >/dev/null 2>&1; then
+		rm -rf "$workspace"
+		return 1
+	fi
+	printf '%s\n' "${workspace}/repo"
+	return 0
+}
+
+_pulse_run_issue_sync_stage() {
+	local script_dir="$1"
+	local stage="$2"
+	local repo_slug="$3"
+	local workspace="$4"
+	/bin/bash "${script_dir}/issue-sync-helper.sh" "$stage" \
+		--repo "$repo_slug" --project-root "$workspace" 2>&1
+	return $?
+}
+
+#######################################
 # sync_todo_refs_for_repo
 #
 # Pull issue→TODO refs, close completed entries, and reopen entries whose
-# linked issue reopened. If TODO.md changed, commit and push. All steps
-# are best-effort (errors swallowed) so a single repo failure can't abort
-# the cycle's other repos.
+# linked issue reopened. Reconciliation runs from a fresh remote clone and
+# publishes allowlisted planning paths through the fenced publisher. Failures
+# are logged and returned so the caller can continue other repositories while
+# preserving retryable evidence.
 #######################################
 sync_todo_refs_for_repo() {
 	local repo_slug="$1"
 	local repo_path="$2"
 	local script_dir="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"
+	local workspace="" workspace_root="" base_sha="" branch_name="" changed_paths=""
+	local stage="" sync_failed=0 publication_rc=0
 
-	printf '[pulse-wrapper] Syncing TODO refs: repo=%s root=validated\n' "$repo_slug" >>"$WRAPPER_LOGFILE"
-	/bin/bash "${script_dir}/issue-sync-helper.sh" pull --repo "$repo_slug" --project-root "$repo_path" 2>&1 || true
-	/bin/bash "${script_dir}/issue-sync-helper.sh" close --repo "$repo_slug" --project-root "$repo_path" 2>&1 || true
-	/bin/bash "${script_dir}/issue-sync-helper.sh" reopen --repo "$repo_slug" --project-root "$repo_path" 2>&1 || true
+	workspace=$(_pulse_create_todo_sync_workspace "$repo_path") || {
+		printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=workspace repo=%s\n' \
+			"$repo_slug" >>"$WRAPPER_LOGFILE"
+		return 1
+	}
+	workspace_root="${workspace%/repo}"
+	base_sha=$(git -C "$workspace" rev-parse HEAD 2>/dev/null) || {
+		rm -rf "$workspace_root"
+		return 1
+	}
+	branch_name=$(git -C "$workspace" symbolic-ref --short HEAD 2>/dev/null) || {
+		rm -rf "$workspace_root"
+		return 1
+	}
+
+	printf '[pulse-wrapper] Syncing TODO refs: repo=%s root=automation base=%s\n' \
+		"$repo_slug" "${base_sha:0:12}" >>"$WRAPPER_LOGFILE"
+	for stage in pull close reopen; do
+		if ! _pulse_run_issue_sync_stage "$script_dir" "$stage" "$repo_slug" "$workspace"; then
+			printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=%s repo=%s\n' \
+				"$stage" "$repo_slug" >>"$WRAPPER_LOGFILE"
+			sync_failed=1
+		fi
+	done
 	# Materialize TODO dependency edges before the graph and dispatch stages.
 	# Failures remain retryable and the relationship helper moves affected
 	# available issues to blocked rather than exposing an unverified ordering.
-	local relationships_rc=0
-	/bin/bash "${script_dir}/issue-sync-helper.sh" relationships --repo "$repo_slug" --project-root "$repo_path" 2>&1 || relationships_rc=$?
-	git -C "$repo_path" diff --quiet TODO.md 2>/dev/null || {
-		git -C "$repo_path" add TODO.md &&
-			git -C "$repo_path" commit -m "chore: sync GitHub issue refs to TODO.md [skip ci]" &&
-			git -C "$repo_path" push
-	} 2>/dev/null || true
-	return "$relationships_rc"
+	if ! _pulse_run_issue_sync_stage "$script_dir" relationships "$repo_slug" "$workspace"; then
+		printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=relationships repo=%s\n' \
+			"$repo_slug" >>"$WRAPPER_LOGFILE"
+		sync_failed=1
+	fi
+	if [[ "$sync_failed" -ne 0 ]]; then
+		rm -rf "$workspace_root"
+		return 1
+	fi
+
+	if ! declare -F planning_publish >/dev/null 2>&1; then
+		[[ -f "${script_dir}/planning-publisher.sh" ]] || {
+			rm -rf "$workspace_root"
+			return 1
+		}
+		# shellcheck source=planning-publisher.sh
+		source "${script_dir}/planning-publisher.sh"
+	fi
+	changed_paths=$(_planning_publish_changed_paths "$workspace")
+	PLANNING_PUBLISH_RESULT=""
+	PLANNING_PUBLICATION_ID=""
+	PLANNING_PUBLISHED_COMMIT=""
+	TMPDIR="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}" \
+		AIDEVOPS_PLANNING_BASE_SHA="$base_sha" \
+		planning_publish "$workspace" "chore: sync GitHub issue refs to TODO.md [skip ci]" \
+			origin "$branch_name" "$changed_paths" || publication_rc=$?
+	case "$publication_rc" in
+	0) printf '[pulse-wrapper] TODO ref sync status=%s repo=%s commit=%s\n' \
+		"${PLANNING_PUBLISH_RESULT:-noop}" "$repo_slug" "${PLANNING_PUBLISHED_COMMIT:0:12}" >>"$WRAPPER_LOGFILE" ;;
+	2) printf '[pulse-wrapper] TODO ref sync status=retryable_conflict repo=%s base=%s\n' \
+		"$repo_slug" "${base_sha:0:12}" >>"$WRAPPER_LOGFILE" ;;
+	*) printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=publication repo=%s rc=%s\n' \
+		"$repo_slug" "$publication_rc" >>"$WRAPPER_LOGFILE" ;;
+	esac
+	rm -rf "$workspace_root"
+	return "$publication_rc"
 }
 
 #######################################
@@ -524,7 +608,6 @@ sync_todo_refs_all_repos() {
 		[[ -n "$repo_slug" && -n "$repo_path" ]] || continue
 		repo_path="${repo_path/#\~/$HOME}"
 		[[ -d "$repo_path" ]] || continue
-		[[ -f "${repo_path}/TODO.md" ]] || continue
 		_pulse_refresh_repo "$repo_path" || true
 		sync_todo_refs_for_repo "$repo_slug" "$repo_path" || sync_failed=1
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | [.slug, .path] | join("|")' "$repos_json" 2>/dev/null || true)

--- a/.agents/scripts/tests/test-issue-sync-project-root.sh
+++ b/.agents/scripts/tests/test-issue-sync-project-root.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# Regression coverage for GH#27146: pulse issue sync must bind every mutation
-# and commit check to the repository root paired with the requested slug.
+# Regression coverage for GH#27146 and GH#27977: pulse issue sync must bind
+# mutations to the requested slug without changing human canonical checkouts.
 
 set -euo pipefail
 
@@ -45,11 +45,34 @@ fi
 [[ $(shasum "$repo_a/TODO.md") == "$before_a" ]] || fail "repo A changed after rejected roots"
 [[ $(shasum "$repo_b/TODO.md") == "$before_b" ]] || fail "repo B changed after rejected roots"
 
-# Exercise the real pulse function with a fixture helper. The helper records
-# the contract and mutates only the explicitly supplied root on pull.
+# Exercise the real pulse function with a fixture helper. Rebuild the fixtures
+# as clones of local remotes so Pulse can create fresh automation workspaces.
+rm -rf "$repo_a" "$repo_b"
+setup_sync_repo() {
+	local root="$1"
+	local remote="$2"
+	git init --bare --quiet --initial-branch=main "$remote" 2>/dev/null || git init --bare --quiet "$remote"
+	git clone --quiet "$remote" "$root"
+	git -C "$root" config user.email test@example.com
+	git -C "$root" config user.name Test
+	git -C "$root" config commit.gpgsign false
+	printf '%s\n' '- [ ] t1 fixture' >"${root}/TODO.md"
+	git -C "$root" add TODO.md
+	git -C "$root" commit --quiet -m seed
+	git -C "$root" push --quiet origin main
+	git --git-dir="$remote" symbolic-ref HEAD refs/heads/main
+	return 0
+}
+
+remote_a="${TMP}/remote-a.git"
+remote_b="${TMP}/remote-b.git"
+setup_sync_repo "$repo_a" "$remote_a"
+setup_sync_repo "$repo_b" "$remote_b"
+
 fixture_scripts="${TMP}/scripts"
 mkdir -p "$fixture_scripts"
 cp "$SCRIPTS_DIR/pulse-wrapper-cycle.sh" "$fixture_scripts/pulse-wrapper-cycle.sh"
+cp "$SCRIPTS_DIR/planning-publisher.sh" "$fixture_scripts/planning-publisher.sh"
 cat >"${fixture_scripts}/issue-sync-helper.sh" <<'FIXTURE'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -72,35 +95,67 @@ fi
 FIXTURE
 chmod +x "${fixture_scripts}/issue-sync-helper.sh"
 
-function_src=$(awk '/^sync_todo_refs_for_repo\(\) \{/,/^}$/ { print }' "$fixture_scripts/pulse-wrapper-cycle.sh")
-[[ -n "$function_src" ]] || fail "could not extract pulse sync function"
-eval "$function_src"
 export CALL_LOG="${TMP}/calls.log"
 export WRAPPER_LOGFILE="${TMP}/pulse.log"
 export SCRIPT_DIR="$fixture_scripts"
+export AIDEVOPS_TEMP_DIR="${TMP}/automation"
+export AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true
+export GIT_AUTHOR_NAME=Test
+export GIT_AUTHOR_EMAIL=test@example.com
+export GIT_COMMITTER_NAME=Test
+export GIT_COMMITTER_EMAIL=test@example.com
+# shellcheck source=/dev/null
+source "$fixture_scripts/pulse-wrapper-cycle.sh"
 
-# Commit mechanics are not under test here. Stub git after the real helper's
-# remote validation so pulse cannot attempt to push fixture repositories.
-git() {
+canonical_snapshot() {
+	local root="$1"
+	{
+		git -C "$root" rev-parse HEAD
+		cksum <"${root}/.git/index"
+		cksum <"${root}/TODO.md"
+		git -C "$root" status --porcelain=v1 --untracked-files=all
+	}
 	return 0
 }
 
-snapshot_b=$(shasum "$repo_b/TODO.md")
+printf '%s\n' 'human canonical dirt A' >>"$repo_a/TODO.md"
+printf '%s\n' 'human canonical dirt B' >>"$repo_b/TODO.md"
+snapshot_a=$(canonical_snapshot "$repo_a")
+snapshot_b=$(canonical_snapshot "$repo_b")
 sync_todo_refs_for_repo owner/repo-a "$repo_a"
-[[ $(shasum "$repo_b/TODO.md") == "$snapshot_b" ]] || fail "repo A invocation changed repo B"
-grep -q '^synced:owner/repo-a$' "$repo_a/TODO.md" || fail "repo A was not synced"
+[[ $(canonical_snapshot "$repo_a") == "$snapshot_a" ]] || fail "repo A canonical checkout changed"
+[[ $(canonical_snapshot "$repo_b") == "$snapshot_b" ]] || fail "repo A invocation changed repo B"
+git --git-dir="$remote_a" show main:TODO.md | grep -q '^synced:owner/repo-a$' || fail "repo A remote was not synced"
 
-snapshot_a=$(shasum "$repo_a/TODO.md")
 sync_todo_refs_for_repo owner/repo-b "$repo_b"
-[[ $(shasum "$repo_a/TODO.md") == "$snapshot_a" ]] || fail "repo B invocation changed repo A"
-grep -q '^synced:owner/repo-b$' "$repo_b/TODO.md" || fail "repo B was not synced"
+[[ $(canonical_snapshot "$repo_a") == "$snapshot_a" ]] || fail "repo B invocation changed repo A"
+[[ $(canonical_snapshot "$repo_b") == "$snapshot_b" ]] || fail "repo B canonical checkout changed"
+git --git-dir="$remote_b" show main:TODO.md | grep -q '^synced:owner/repo-b$' || fail "repo B remote was not synced"
 
-[[ $(wc -l <"$CALL_LOG" | tr -d ' ') -eq 6 ]] || fail "pulse did not make three bound calls per repository"
-grep -q "pull|owner/repo-a|${repo_a}" "$CALL_LOG" || fail "repo A root was not passed explicitly"
-grep -q "pull|owner/repo-b|${repo_b}" "$CALL_LOG" || fail "repo B root was not passed explicitly"
-grep -q 'repo=owner/repo-a root=validated' "$WRAPPER_LOGFILE" || fail "resolved slug/root status was not logged"
+[[ $(wc -l <"$CALL_LOG" | tr -d ' ') -eq 8 ]] || fail "pulse did not make four bound calls per repository"
+if grep -Fq "|${repo_a}" "$CALL_LOG" || grep -Fq "|${repo_b}" "$CALL_LOG"; then
+	fail "registered canonical root was passed to a mutating issue-sync command"
+fi
+grep -q 'repo=owner/repo-a root=automation' "$WRAPPER_LOGFILE" || fail "automation-root status was not logged"
 if grep -q "$TMP" "$WRAPPER_LOGFILE"; then
 	fail "pulse log disclosed a private project path"
 fi
 
-printf 'PASS: issue sync project-root contract\n'
+# Publication failure must be observable, retryable, and leave both remote and
+# canonical state unchanged.
+repo_c="${TMP}/repo-c"
+remote_c="${TMP}/remote-c.git"
+setup_sync_repo "$repo_c" "$remote_c"
+printf '%s\n' 'human canonical dirt C' >>"$repo_c/TODO.md"
+snapshot_c=$(canonical_snapshot "$repo_c")
+remote_c_before=$(git --git-dir="$remote_c" rev-parse main)
+publication_rc=0
+AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK=/usr/bin/false \
+	sync_todo_refs_for_repo owner/repo-c "$repo_c" || publication_rc=$?
+[[ "$publication_rc" -eq 1 ]] || fail "publication failure was swallowed"
+[[ $(canonical_snapshot "$repo_c") == "$snapshot_c" ]] || fail "failed publication changed canonical checkout"
+[[ $(git --git-dir="$remote_c" rev-parse main) == "$remote_c_before" ]] || fail "failed publication changed remote"
+grep -q 'status=retryable_failure stage=publication repo=owner/repo-c rc=1' "$WRAPPER_LOGFILE" || \
+	fail "publication failure evidence was not logged"
+
+printf 'PASS: issue sync automation-workspace contract\n'

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -242,6 +242,41 @@ HOOK
 	return 0
 }
 
+test_stale_base_same_path_is_retryable() {
+	local name="stale pinned base rejects an upstream planning overwrite"
+	local root="" repo="" rival="" base_sha="" rc=0 remote_todo=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	base_sha=$(git -C "$repo" rev-parse HEAD)
+	printf '%s\n' '- [ ] t009 local ref:GH#9' >>"${repo}/TODO.md"
+	rival="${root}/rival"
+	git clone -q "${root}/remote.git" "$rival"
+	printf '%s\n' '- [ ] t999 upstream ref:GH#999' >>"${rival}/TODO.md"
+	git -C "$rival" add TODO.md
+	GIT_AUTHOR_NAME=Rival GIT_AUTHOR_EMAIL=rival@example.invalid GIT_COMMITTER_NAME=Rival GIT_COMMITTER_EMAIL=rival@example.invalid \
+		git -C "$rival" -c commit.gpgsign=false commit -qm rival
+	git -C "$rival" push -q origin main
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_BASE_SHA="$base_sha" AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+			planning_publish "$repo" "plan: stale base" origin main
+	) || rc=$?
+	remote_todo=$(git --git-dir="${root}/remote.git" show main:TODO.md)
+	if [[ "$rc" -eq 2 && "$remote_todo" == *"t999"* && "$remote_todo" != *"t009"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "rc=$rc"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
 test_absent_remote_branch_uses_safe_parent() {
 	local name="creates an absent remote branch from a safe parent without local state leakage"
 	local root="" repo="" branch="plan/new-branch" before="" after="" remote_sha="" replay_sha="" count=""
@@ -410,6 +445,7 @@ main() {
 	test_contention_replay_and_conflict
 	test_crash_replay_is_single_publication
 	test_same_path_contention_is_retryable
+	test_stale_base_same_path_is_retryable
 	test_absent_remote_branch_uses_safe_parent
 	test_absent_remote_branch_creation_contention
 	test_explicit_git_capability_preserves_guarded_checkout


### PR DESCRIPTION
## Summary

Implementation for issue #27977.

## Files Changed

.agents/scripts/planning-publisher.sh, .agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/tests/test-issue-sync-project-root.sh, .agents/scripts/tests/test-planning-publisher.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #27977


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 56m and 1,018,802 tokens on this with the user in an interactive session.