### PR TITLE
GH#27989: Show OpenCode run and wait state in Tabby tab titles

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -37,6 +37,7 @@ import { INTENT_FIELD } from "./intent-tracing.mjs";
 import { createGreetingHandler } from "./greeting.mjs";
 import { applyImageSizeGuard } from "./quality-hooks-image.mjs";
 import { createSessionTitleFallbackHandler } from "./session-title-fallback.mjs";
+import { createSessionTitleStatusHandler } from "./session-title-status.mjs";
 import { createSessionTitleSuffixHandler } from "./session-title-suffix.mjs";
 import { installPluginConsoleRouter } from "./plugin-console.mjs";
 import { createSubagentEffortHooks, loadTierReasoningPolicies } from "./subagent-effort.mjs";
@@ -341,6 +342,7 @@ export async function AidevopsPlugin({ directory, client }) {
     agentsDir: AGENTS_DIR,
     client,
   });
+  const sessionTitleStatusHandler = createSessionTitleStatusHandler({ isHeadless });
   const sessionTitleFallbackHandler = createSessionTitleFallbackHandler({
     agentsDir: ACTIVE_AGENTS_DIR,
     client,
@@ -391,6 +393,7 @@ export async function AidevopsPlugin({ directory, client }) {
       await Promise.all([
         handleEvent(input),
         permissionBroker.handleEvent(input).catch((err) => debugEventError("permission broker", err)),
+        sessionTitleStatusHandler(input).catch((err) => debugEventError("title status handler", err)),
         sessionTitleSuffixHandler(input).catch((err) => debugEventError("title suffix handler", err)),
         sessionTitleFallbackHandler(input).catch((err) => debugEventError("title fallback handler", err)),
         greetingHandler(input).catch((err) => debugEventError("greeting handler", err)),

--- a/.agents/plugins/opencode-aidevops/session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-status.mjs
@@ -36,24 +36,15 @@ export function createSessionTitleStatusHandler({
     if (event.type === "session.created" && isRootSessionInfo(info) && sessionID) {
       activeRootSessionID = sessionID;
       resetTerminalTitleState();
-      return;
-    }
-
-    if (event.type === "session.updated" && !activeRootSessionID && isRootSessionInfo(info) && sessionID) {
+    } else if (event.type === "session.updated" && !activeRootSessionID && isRootSessionInfo(info) && sessionID) {
       activeRootSessionID = sessionID;
       resetTerminalTitleState();
-      return;
-    }
-
-    if (event.type === "session.deleted" && sessionID === activeRootSessionID) {
+    } else if (event.type === "session.deleted" && sessionID === activeRootSessionID) {
       activeRootSessionID = "";
       resetTerminalTitleState();
-      return;
+    } else if (event.type === "session.status" && sessionID === activeRootSessionID) {
+      const status = event.properties?.status?.type;
+      if (status === "busy" || status === "retry" || status === "idle") setTerminalTitleStatus(status);
     }
-
-    if (event.type !== "session.status" || sessionID !== activeRootSessionID) return;
-    const status = event.properties?.status?.type;
-    if (status !== "busy" && status !== "retry" && status !== "idle") return;
-    setTerminalTitleStatus(status);
   };
 }

--- a/.agents/plugins/opencode-aidevops/session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-status.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {
+  resetTerminalTitleState as defaultResetTerminalTitleState,
+  setTerminalTitleStatus as defaultSetTerminalTitleStatus,
+} from "./terminal-title.mjs";
+
+function getEvent(input) {
+  return input?.event || input || {};
+}
+
+function sessionIDFrom(event) {
+  return event.properties?.sessionID || event.properties?.info?.id || "";
+}
+
+function isRootSessionInfo(info) {
+  return Boolean(info) && !info.parentID;
+}
+
+export function createSessionTitleStatusHandler({
+  isHeadless = () => false,
+  isEnabled = () => process.env.AIDEVOPS_TAB_STATUS_ENABLED !== "false",
+  resetTerminalTitleState = defaultResetTerminalTitleState,
+  setTerminalTitleStatus = defaultSetTerminalTitleStatus,
+} = {}) {
+  let activeRootSessionID = "";
+
+  return async function sessionTitleStatusHandler(input) {
+    if (isHeadless() || !isEnabled()) return;
+
+    const event = getEvent(input);
+    const info = event.properties?.info;
+    const sessionID = sessionIDFrom(event);
+
+    if (event.type === "session.created" && isRootSessionInfo(info) && sessionID) {
+      activeRootSessionID = sessionID;
+      resetTerminalTitleState();
+      return;
+    }
+
+    if (event.type === "session.updated" && !activeRootSessionID && isRootSessionInfo(info) && sessionID) {
+      activeRootSessionID = sessionID;
+      resetTerminalTitleState();
+      return;
+    }
+
+    if (event.type === "session.deleted" && sessionID === activeRootSessionID) {
+      activeRootSessionID = "";
+      resetTerminalTitleState();
+      return;
+    }
+
+    if (event.type !== "session.status" || sessionID !== activeRootSessionID) return;
+    const status = event.properties?.status?.type;
+    if (status !== "busy" && status !== "retry" && status !== "idle") return;
+    setTerminalTitleStatus(status);
+  };
+}

--- a/.agents/plugins/opencode-aidevops/terminal-title.mjs
+++ b/.agents/plugins/opencode-aidevops/terminal-title.mjs
@@ -41,7 +41,13 @@ function writeTerminalTitle(title) {
     // Terminal title synchronization is best-effort and must not affect sessions.
     return false;
   } finally {
-    if (ttyFd !== undefined) closeSync(ttyFd);
+    if (ttyFd !== undefined) {
+      try {
+        closeSync(ttyFd);
+      } catch {
+        // Terminal title synchronization is best-effort and must not affect sessions.
+      }
+    }
   }
 }
 
@@ -65,7 +71,7 @@ export function createTerminalTitleController({
     },
     setStatus(nextStatus) {
       const nextLabel = terminalTitleStatusLabel(nextStatus);
-      if (!nextLabel || nextLabel === terminalTitleStatusLabel(status)) return false;
+      if (nextLabel === terminalTitleStatusLabel(status)) return false;
       status = nextStatus;
       return render();
     },

--- a/.agents/plugins/opencode-aidevops/terminal-title.mjs
+++ b/.agents/plugins/opencode-aidevops/terminal-title.mjs
@@ -4,22 +4,88 @@
 import { closeSync, openSync, writeSync } from "node:fs";
 
 const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/g;
+const STATUS_PREFIX_RE = /^\[(?:RUN|WAIT)\]\s+/;
+
+export function sanitizeTerminalTitle(title) {
+  return String(title || "").replace(CONTROL_CHAR_RE, " ").trim();
+}
+
+export function terminalTitleStatusLabel(status) {
+  if (status === "busy" || status === "retry") return "RUN";
+  if (status === "idle") return "WAIT";
+  return "";
+}
+
+export function withTerminalTitleStatus(title, status) {
+  const baseTitle = sanitizeTerminalTitle(title).replace(STATUS_PREFIX_RE, "").trim();
+  const label = terminalTitleStatusLabel(status);
+  if (!baseTitle || !label) return baseTitle;
+  return `[${label}] ${baseTitle}`;
+}
 
 export function terminalTitleSequence(title) {
-  const sanitizedTitle = String(title || "").replace(CONTROL_CHAR_RE, " ").trim();
+  const sanitizedTitle = sanitizeTerminalTitle(title);
+  if (!sanitizedTitle) return "";
   return `\u001B]0;${sanitizedTitle}\u0007`;
 }
 
-export function emitTerminalTitle(title) {
-  if (process.env.TERMINAL_TITLE_ENABLED === "false" || process.env.AIDEVOPS_TABBY_ENABLED === "false") return;
-
+function writeTerminalTitle(title) {
+  const sequence = terminalTitleSequence(title);
+  if (!sequence) return false;
   let ttyFd;
   try {
     ttyFd = openSync("/dev/tty", "w");
-    writeSync(ttyFd, terminalTitleSequence(title));
+    writeSync(ttyFd, sequence);
+    return true;
   } catch {
     // Terminal title synchronization is best-effort and must not affect sessions.
+    return false;
   } finally {
     if (ttyFd !== undefined) closeSync(ttyFd);
   }
+}
+
+export function createTerminalTitleController({
+  writeTitle = writeTerminalTitle,
+  isEnabled = () =>
+    process.env.TERMINAL_TITLE_ENABLED !== "false" && process.env.AIDEVOPS_TABBY_ENABLED !== "false",
+} = {}) {
+  let baseTitle = "";
+  let status = "";
+
+  const render = () => {
+    if (!baseTitle || !isEnabled()) return false;
+    return writeTitle(withTerminalTitleStatus(baseTitle, status)) !== false;
+  };
+
+  return {
+    emit(title) {
+      baseTitle = sanitizeTerminalTitle(title).replace(STATUS_PREFIX_RE, "").trim();
+      return render();
+    },
+    setStatus(nextStatus) {
+      const nextLabel = terminalTitleStatusLabel(nextStatus);
+      if (!nextLabel || nextLabel === terminalTitleStatusLabel(status)) return false;
+      status = nextStatus;
+      return render();
+    },
+    reset() {
+      baseTitle = "";
+      status = "";
+    },
+  };
+}
+
+const terminalTitleController = createTerminalTitleController();
+
+export function emitTerminalTitle(title) {
+  return terminalTitleController.emit(title);
+}
+
+export function setTerminalTitleStatus(status) {
+  return terminalTitleController.setStatus(status);
+}
+
+export function resetTerminalTitleState() {
+  terminalTitleController.reset();
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -33,6 +33,7 @@ test("terminal title controller preserves status across later session title upda
   controller.emit("Issue #123: renamed title");
   controller.setStatus("retry");
   controller.setStatus("idle");
+  controller.setStatus("");
   controller.reset();
   controller.setStatus("busy");
 
@@ -41,6 +42,7 @@ test("terminal title controller preserves status across later session title upda
     "[RUN] Issue #123: initial title",
     "[RUN] Issue #123: renamed title",
     "[WAIT] Issue #123: renamed title",
+    "Issue #123: renamed title",
   ]);
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createSessionTitleStatusHandler } from "../session-title-status.mjs";
+import {
+  createTerminalTitleController,
+  terminalTitleSequence,
+  withTerminalTitleStatus,
+} from "../terminal-title.mjs";
+
+function event(type, properties = {}) {
+  return { event: { type, properties } };
+}
+
+test("terminal titles map OpenCode status to idempotent RUN and WAIT prefixes", () => {
+  assert.equal(withTerminalTitleStatus("Issue #123: improve tabs", "busy"), "[RUN] Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("[WAIT] Issue #123: improve tabs", "retry"), "[RUN] Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("[RUN] Issue #123: improve tabs", "idle"), "[WAIT] Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("Issue #123: improve tabs", "unknown"), "Issue #123: improve tabs");
+});
+
+test("terminal title controller preserves status across later session title updates", () => {
+  const writes = [];
+  const controller = createTerminalTitleController({
+    isEnabled: () => true,
+    writeTitle: (title) => writes.push(title),
+  });
+
+  controller.emit("Issue #123: initial title");
+  controller.setStatus("busy");
+  controller.emit("Issue #123: renamed title");
+  controller.setStatus("retry");
+  controller.setStatus("idle");
+  controller.reset();
+  controller.setStatus("busy");
+
+  assert.deepEqual(writes, [
+    "Issue #123: initial title",
+    "[RUN] Issue #123: initial title",
+    "[RUN] Issue #123: renamed title",
+    "[WAIT] Issue #123: renamed title",
+  ]);
+});
+
+test("terminal title sequences reject empty and control-only titles", () => {
+  assert.equal(terminalTitleSequence("\n\t"), "");
+  assert.equal(terminalTitleSequence("Task\u0007 title"), "\u001B]0;Task  title\u0007");
+});
+
+test("session status handler follows only the active interactive root session", async () => {
+  const statuses = [];
+  let resets = 0;
+  const handler = createSessionTitleStatusHandler({
+    isHeadless: () => false,
+    isEnabled: () => true,
+    resetTerminalTitleState: () => {
+      resets += 1;
+    },
+    setTerminalTitleStatus: (status) => statuses.push(status),
+  });
+
+  await handler(event("session.created", { info: { id: "root-1", title: "Root" } }));
+  await handler(event("session.created", { info: { id: "child-1", parentID: "root-1", title: "Child" } }));
+  await handler(event("session.status", { sessionID: "child-1", status: { type: "busy" } }));
+  await handler(event("session.status", { sessionID: "root-1", status: { type: "busy" } }));
+  await handler(event("session.status", { sessionID: "root-1", status: { type: "retry" } }));
+  await handler(event("session.status", { sessionID: "root-1", status: { type: "idle" } }));
+  await handler(event("session.created", { info: { id: "root-2", title: "New root" } }));
+  await handler(event("session.status", { sessionID: "root-1", status: { type: "busy" } }));
+  await handler(event("session.status", { sessionID: "root-2", status: { type: "idle" } }));
+
+  assert.equal(resets, 2);
+  assert.deepEqual(statuses, ["busy", "retry", "idle", "idle"]);
+});
+
+test("session status handler supports hot-loaded root sessions and ignores headless sessions", async () => {
+  const statuses = [];
+  let resets = 0;
+  const interactiveHandler = createSessionTitleStatusHandler({
+    isHeadless: () => false,
+    resetTerminalTitleState: () => {
+      resets += 1;
+    },
+    setTerminalTitleStatus: (status) => statuses.push(status),
+  });
+  await interactiveHandler(event("session.updated", { info: { id: "restored-root", title: "Restored" } }));
+  await interactiveHandler(event("session.status", { sessionID: "restored-root", status: { type: "busy" } }));
+
+  const headlessHandler = createSessionTitleStatusHandler({
+    isHeadless: () => true,
+    resetTerminalTitleState: () => {
+      resets += 1;
+    },
+    setTerminalTitleStatus: (status) => statuses.push(status),
+  });
+  await headlessHandler(event("session.created", { info: { id: "headless-root" } }));
+  await headlessHandler(event("session.status", { sessionID: "headless-root", status: { type: "idle" } }));
+
+  assert.equal(resets, 1);
+  assert.deepEqual(statuses, ["busy"]);
+});

--- a/.agents/tools/terminal/terminal-title.md
+++ b/.agents/tools/terminal/terminal-title.md
@@ -24,6 +24,7 @@ tools:
 - **Script**: `~/.aidevops/agents/scripts/terminal-title-helper.sh`
 - **Auto-sync**: Runs via `pre-edit-check.sh` on task refs in linked worktrees
 - **Session sync**: For issue/PR work, OpenCode session titles should begin with `Issue #123:` or `PR #456:` plus a succinct description; branch auto-sync is only the fallback when no issue/PR context exists. Force branch sync via `session-rename_sync_branch`.
+- **Session status**: Interactive OpenCode root sessions prefix the terminal-only title with `[RUN]` for `busy`/`retry` and `[WAIT]` for `idle`. Stored OpenCode session titles remain unchanged.
 
 **Commands**:
 
@@ -49,12 +50,15 @@ terminal-title-helper.sh detect            # Check terminal compatibility
 |----------|---------|-------------|
 | `TERMINAL_TITLE_FORMAT` | `repo/branch` | Title format |
 | `TERMINAL_TITLE_ENABLED` | `true` | Set `false` to disable |
+| `AIDEVOPS_TAB_STATUS_ENABLED` | `true` | Set `false` to retain dynamic titles without OpenCode `[RUN]`/`[WAIT]` prefixes |
 
 <!-- AI-CONTEXT-END -->
 
 ## How It Works
 
 Uses OSC escape sequences (`printf '\033]0;%s\007' "title"`). **Full support**: Tabby, iTerm2, Windows Terminal, Kitty, Alacritty, WezTerm, Hyper, GNOME Terminal, Konsole, VS Code Terminal, xterm. **Partial**: Apple Terminal (basic), tmux/screen (requires config).
+
+The OpenCode plugin consumes `session.status` events only for the active interactive root session. Subagent and headless-worker events are ignored, and status remains applied when OpenCode later renames the session.
 
 ## Shell Integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- show `[RUN]` and `[WAIT]` state in terminal titles for interactive OpenCode sessions
+
 ## [3.32.134] - 2026-07-16
 
 ### Fixed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,6 +163,7 @@ AI DevOps is a developer-operations framework and OpenCode plugin. Its interface
 Design goals:
 
 - Keep operational state obvious: running, stopped, error, authenticated, last update, and command actions should scan quickly.
+- Use concise, text-first terminal status prefixes: `[RUN]` for active OpenCode turns and `[WAIT]` when the root session is awaiting input. Keep these terminal-only so issue/PR prefixes remain first in stored session titles and search results.
 - Preserve developer trust with native system typography, code-friendly contrast, visible borders, and restrained motion.
 - Use compact density for dashboards and sidebars, but keep controls at least 44px high when touch use is plausible.
 - Prefer semantic tokens over one-off values so generated reports, OpenCode UI surfaces, and dashboard screens stay consistent.

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ See `.agents/tools/git/opencode-github-security.md` for the full security docume
 - **[OpenCode Zen](https://opencode.ai/)** - Free tier of OpenCode with included models. Start working with AI straight away at no cost -- no API keys or subscriptions required.
 - **OpenAI GPT-5.5 / GPT-5.4 mini** - Recommended model pair for aidevops today. Use GPT-5.5 for complex reasoning and high-impact agent tiers; use GPT-5.4 mini for triage, routine implementation, and cost-efficient parallel workers.
 - **[Claude](https://claude.ai/)** (Anthropic) - Fully supported alternative provider. Claude models remain useful for fallback, cross-provider verification, and users with Claude Pro/Max OAuth access.
-- **[Tabby](https://tabby.sh/)** - Recommended terminal. Colour-coded Profiles per project/repo, **auto-syncs tab title with git repo/branch.**
+- **[Tabby](https://tabby.sh/)** - Recommended terminal. Colour-coded Profiles per project/repo, **auto-syncs tab titles with git/session context and marks OpenCode turns as `[RUN]` or `[WAIT]`.**
 - **[Zed](https://zed.dev/)** - Recommended editor. High-performance with AI integration (use with the OpenCode Agent Extension).
 
 ### Troubleshooting Auth
@@ -620,11 +620,11 @@ The agent contains the full recovery flow and symptom table. Free models work fi
 
 ### Terminal Tab Title Sync
 
-Your terminal tab/window title automatically shows `repo/branch` context when working in git repositories. This helps identify which codebase and branch you're working on across multiple terminal sessions.
+Your terminal tab/window title automatically shows `repo/branch` context when working in git repositories. Interactive OpenCode tabs add `[RUN]` while the root session is busy or retrying and `[WAIT]` when it has finished and is awaiting input. This helps identify both the work context and session state across multiple terminal sessions.
 
 **Supported terminals:** [Tabby](https://tabby.sh/), [cmux](https://cmux.dev/), [iTerm2](https://iterm2.com/), [Kitty](https://sw.kovidgoyal.net/kitty/), [Alacritty](https://alacritty.org/), [WezTerm](https://wezfurlong.org/wezterm/), [Hyper](https://hyper.is/), and most xterm-compatible terminals.
 
-**How it works:** The `pre-edit-check.sh` script's primary role is enforcing git workflow protection (blocking edits on main/master branches). As a secondary, non-blocking action, it updates the terminal title via escape sequences. No configuration needed - it's automatic.
+**How it works:** The `pre-edit-check.sh` script's primary role is enforcing git workflow protection (blocking edits on main/master branches). As a secondary, non-blocking action, it updates the terminal title via escape sequences. The OpenCode plugin listens for root-session `busy`, `retry`, and `idle` events and updates the same title without changing the stored OpenCode session name. No configuration is needed when dynamic terminal titles are enabled.
 
 **Example format:** `{repo}/{branch-type}/{description}`
 


### PR DESCRIPTION
## Summary

Add terminal-only `[RUN]` and `[WAIT]` indicators driven by interactive root-session status while preserving stored OpenCode titles and ignoring subagent/headless events.

## Files changed

- `.agents/plugins/opencode-aidevops/index.mjs`
- `.agents/plugins/opencode-aidevops/session-title-status.mjs`
- `.agents/plugins/opencode-aidevops/terminal-title.mjs`
- `.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs`
- `.agents/tools/terminal/terminal-title.md`
- `CHANGELOG.md`
- `DESIGN.md`
- `README.md`

## Runtime testing

- **Risk level:** High — event-driven root-session state transitions.
- **Runtime evidence:** A pseudo-terminal exercised the real `/dev/tty` OSC writer and status handler, producing the exact sequence `Runtime status test` → `[RUN] Runtime status test` → `[WAIT] Runtime status test`.
- **Regression evidence:** 410/410 OpenCode plugin tests passed, including root/subagent isolation, headless exclusion, retry handling, status persistence across title renames, and control-character sanitisation.
- **Quality evidence:** Biome, markdownlint, changed-file repository gates, full repository linters, and commit-time TypeScript validation passed. Broad full-linter warnings were pre-existing/advisory and introduced no changed-file regression.

## Key decisions

- Use text prefixes rather than colour-only state so the indicator remains accessible and portable across OSC-compatible terminals.
- Keep status decoration terminal-only so stored OpenCode issue/PR titles and search ordering remain unchanged.
- Centralise status in the OSC title controller so native and fallback session renames cannot erase the current state.
- Allow `AIDEVOPS_TAB_STATUS_ENABLED=false` to retain dynamic titles without state prefixes.

Resolves #27989
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.134 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 24m and 389,105 tokens on this with the user in an interactive session.