### PR TITLE
GH#27981: avoid SIGPIPE in worktree branch lookup

### DIFF
--- a/.agents/scripts/tests/test-worktree-helper-branch-lookup-sigpipe.sh
+++ b/.agents/scripts/tests/test-worktree-helper-branch-lookup-sigpipe.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+: "${RED:=}"
+: "${NC:=}"
+
+# shellcheck source=../worktree-helper-add.sh
+source "${SCRIPT_DIR}/worktree-helper-add.sh"
+
+fail() {
+	local message="$1"
+	printf 'FAIL %s\n' "$message"
+	return 1
+}
+
+emit_porcelain_fixture() {
+	local i
+	printf 'worktree /tmp/aidevops path with spaces\n'
+	printf 'HEAD 1111111111111111111111111111111111111111\n'
+	printf 'branch refs/heads/feature/exact\n\n'
+	printf 'worktree /tmp/aidevops-prefix\n'
+	printf 'HEAD 2222222222222222222222222222222222222222\n'
+	printf 'branch refs/heads/feature/exact-extra\n\n'
+	for ((i = 0; i < 20000; i++)); do
+		printf 'worktree /tmp/aidevops-%s\n' "$i"
+		printf 'HEAD 3333333333333333333333333333333333333333\n'
+		printf 'branch refs/heads/feature/filler-%s\n\n' "$i"
+	done
+	return 0
+}
+
+git() {
+	local command_name="${1:-}"
+	local subcommand="${2:-}"
+	local format="${3:-}"
+	if [[ "$command_name" == "worktree" && "$subcommand" == "list" && "$format" == "--porcelain" ]]; then
+		emit_porcelain_fixture || return 1
+		return 0
+	fi
+	command git "$@" || return 1
+	return 0
+}
+
+# Prove the fixture reproduces the original pipefail false negative: grep exits
+# after the first match, the still-writing producer receives SIGPIPE, and the
+# pipeline reports failure even though the branch exists.
+if git worktree list --porcelain | grep -q 'branch refs/heads/feature/exact$'; then
+	fail "legacy early-closing lookup unexpectedly survived the SIGPIPE fixture"
+fi
+
+resolved_path=$(get_worktree_path_for_branch "feature/exact") || fail "exact branch lookup failed"
+[[ "$resolved_path" == "/tmp/aidevops path with spaces" ]] || fail "path with spaces was not preserved"
+
+worktree_exists_for_branch "feature/exact" || fail "existing branch was reported missing"
+
+if get_worktree_path_for_branch "feature/exact-extra-more" >/dev/null; then
+	fail "branch lookup accepted a non-exact prefix match"
+fi
+
+if worktree_exists_for_branch "feature/missing"; then
+	fail "missing branch was reported present"
+fi
+
+resolved_path=$(_remove_resolve_path "feature/exact") || fail "remove target did not resolve"
+[[ "$resolved_path" == "/tmp/aidevops path with spaces" ]] || fail "remove target resolved the wrong path"
+
+missing_error=""
+if missing_error=$(_remove_resolve_path "feature/missing" 2>&1); then
+	fail "missing remove target did not fail closed"
+fi
+[[ "$missing_error" == *"No worktree found"* ]] || fail "missing remove target omitted its error"
+
+printf 'PASS worktree branch lookup is SIGPIPE-safe\n'

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -142,13 +142,30 @@ branch_exists() {
 # Check if worktree exists for branch
 worktree_exists_for_branch() {
 	local branch="$1"
-	git worktree list --porcelain | grep -q "branch refs/heads/$branch$"
+	get_worktree_path_for_branch "$branch" >/dev/null || return 1
+	return 0
 }
 
 # Get worktree path for branch
 get_worktree_path_for_branch() {
 	local branch="$1"
-	git worktree list --porcelain | grep -B2 "branch refs/heads/$branch$" | grep "^worktree " | cut -d' ' -f2-
+	local porcelain line worktree_path=""
+	porcelain=$(git worktree list --porcelain) || return 1
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		case "$line" in
+		"worktree "*) worktree_path="${line#worktree }" ;;
+		"branch refs/heads/"*)
+			if [[ "$line" == "branch refs/heads/$branch" && -n "$worktree_path" ]]; then
+				printf '%s\n' "$worktree_path"
+				return 0
+			fi
+			;;
+		"") worktree_path="" ;;
+		esac
+	done <<<"$porcelain"
+
+	return 1
 }
 
 # --- Remove Helpers ---
@@ -157,14 +174,15 @@ get_worktree_path_for_branch() {
 # Prints the resolved path on success. Returns 1 with an error message on failure.
 _remove_resolve_path() {
 	local target="$1"
+	local resolved_path
 
 	if [[ -d "$target" ]]; then
 		echo "$target"
 		return 0
 	fi
 
-	if worktree_exists_for_branch "$target"; then
-		get_worktree_path_for_branch "$target"
+	if resolved_path=$(get_worktree_path_for_branch "$target"); then
+		printf '%s\n' "$resolved_path"
 		return 0
 	fi
 
@@ -850,9 +868,8 @@ cmd_add() {
 	fi
 
 	# Check if worktree already exists for this branch
-	if worktree_exists_for_branch "$branch"; then
-		local existing_path
-		existing_path=$(get_worktree_path_for_branch "$branch")
+	local existing_path
+	if existing_path=$(get_worktree_path_for_branch "$branch"); then
 		echo -e "${YELLOW}Worktree already exists for branch '$branch'${NC}"
 		echo -e "Path: ${BOLD}$existing_path${NC}"
 		echo ""


### PR DESCRIPTION
## Summary

- capture the complete `git worktree list --porcelain` snapshot before parsing
- match branch records exactly while preserving worktree paths containing spaces
- cover the former SIGPIPE false negative, exact matching, removal resolution, and fail-closed missing branches

## Testing

- `bash .agents/scripts/tests/test-worktree-helper-branch-lookup-sigpipe.sh`
- `bash -n .agents/scripts/worktree-helper-add.sh .agents/scripts/tests/test-worktree-helper-branch-lookup-sigpipe.sh`
- `shellcheck .agents/scripts/worktree-helper-add.sh .agents/scripts/tests/test-worktree-helper-branch-lookup-sigpipe.sh`
- `shfmt -d .agents/scripts/tests/test-worktree-helper-branch-lookup-sigpipe.sh`

## Runtime Testing

Runtime-verified with a deterministic porcelain producer that reproduces exit 141 under the legacy early-closing pipeline.

Resolves #27981

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 6m and 77,380 tokens on this as a headless worker.
