### PR TITLE
GH#27997: fix: use active Bash for issue sync

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -506,7 +506,7 @@ _pulse_run_issue_sync_stage() {
 	local stage="$2"
 	local repo_slug="$3"
 	local workspace="$4"
-	/bin/bash "${script_dir}/issue-sync-helper.sh" "$stage" \
+	"$BASH" "${script_dir}/issue-sync-helper.sh" "$stage" \
 		--repo "$repo_slug" --project-root "$workspace" 2>&1
 	return $?
 }


### PR DESCRIPTION
## Summary

- invoke the issue-sync helper with the active Bash executable instead of hardcoding `/bin/bash`
- preserve existing arguments, output capture, and exit-status behavior

## Testing

- `shellcheck .agents/scripts/pulse-wrapper-cycle.sh`
- `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bash .agents/scripts/tests/test-issue-sync-project-root.sh`

Resolves #27997

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18
