### PR TITLE
t18150: Use compact emoji indicators in OpenCode terminal tab titles

### DIFF
--- a/.agents/plugins/opencode-aidevops/terminal-title.mjs
+++ b/.agents/plugins/opencode-aidevops/terminal-title.mjs
@@ -4,15 +4,15 @@
 import { closeSync, openSync, writeSync } from "node:fs";
 
 const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/g;
-const STATUS_PREFIX_RE = /^\[(?:RUN|WAIT)\]\s+/;
+const STATUS_PREFIX_RE = /^(?:\[(?:RUN|WAIT)\]|🟡|🟢)\s+/u;
 
 export function sanitizeTerminalTitle(title) {
   return String(title || "").replace(CONTROL_CHAR_RE, " ").trim();
 }
 
 export function terminalTitleStatusLabel(status) {
-  if (status === "busy" || status === "retry") return "RUN";
-  if (status === "idle") return "WAIT";
+  if (status === "busy" || status === "retry") return "🟡";
+  if (status === "idle") return "🟢";
   return "";
 }
 
@@ -20,7 +20,7 @@ export function withTerminalTitleStatus(title, status) {
   const baseTitle = sanitizeTerminalTitle(title).replace(STATUS_PREFIX_RE, "").trim();
   const label = terminalTitleStatusLabel(status);
   if (!baseTitle || !label) return baseTitle;
-  return `[${label}] ${baseTitle}`;
+  return `${label} ${baseTitle}`;
 }
 
 export function terminalTitleSequence(title) {

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -14,10 +14,11 @@ function event(type, properties = {}) {
   return { event: { type, properties } };
 }
 
-test("terminal titles map OpenCode status to idempotent RUN and WAIT prefixes", () => {
-  assert.equal(withTerminalTitleStatus("Issue #123: improve tabs", "busy"), "[RUN] Issue #123: improve tabs");
-  assert.equal(withTerminalTitleStatus("[WAIT] Issue #123: improve tabs", "retry"), "[RUN] Issue #123: improve tabs");
-  assert.equal(withTerminalTitleStatus("[RUN] Issue #123: improve tabs", "idle"), "[WAIT] Issue #123: improve tabs");
+test("terminal titles map OpenCode status to compact idempotent emoji prefixes", () => {
+  assert.equal(withTerminalTitleStatus("Issue #123: improve tabs", "busy"), "🟡 Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("🟢 Issue #123: improve tabs", "retry"), "🟡 Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("🟡 Issue #123: improve tabs", "idle"), "🟢 Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("[RUN] Issue #123: improve tabs", "idle"), "🟢 Issue #123: improve tabs");
   assert.equal(withTerminalTitleStatus("Issue #123: improve tabs", "unknown"), "Issue #123: improve tabs");
 });
 
@@ -39,9 +40,9 @@ test("terminal title controller preserves status across later session title upda
 
   assert.deepEqual(writes, [
     "Issue #123: initial title",
-    "[RUN] Issue #123: initial title",
-    "[RUN] Issue #123: renamed title",
-    "[WAIT] Issue #123: renamed title",
+    "🟡 Issue #123: initial title",
+    "🟡 Issue #123: renamed title",
+    "🟢 Issue #123: renamed title",
     "Issue #123: renamed title",
   ]);
 });

--- a/.agents/tools/terminal/terminal-title.md
+++ b/.agents/tools/terminal/terminal-title.md
@@ -24,7 +24,7 @@ tools:
 - **Script**: `~/.aidevops/agents/scripts/terminal-title-helper.sh`
 - **Auto-sync**: Runs via `pre-edit-check.sh` on task refs in linked worktrees
 - **Session sync**: For issue/PR work, OpenCode session titles should begin with `Issue #123:` or `PR #456:` plus a succinct description; branch auto-sync is only the fallback when no issue/PR context exists. Force branch sync via `session-rename_sync_branch`.
-- **Session status**: Interactive OpenCode root sessions prefix the terminal-only title with `[RUN]` for `busy`/`retry` and `[WAIT]` for `idle`. Stored OpenCode session titles remain unchanged.
+- **Session status**: Interactive OpenCode root sessions prefix the terminal-only title with 🟡 for `busy`/`retry` and 🟢 for `idle`. Stored OpenCode session titles remain unchanged.
 
 **Commands**:
 
@@ -50,7 +50,7 @@ terminal-title-helper.sh detect            # Check terminal compatibility
 |----------|---------|-------------|
 | `TERMINAL_TITLE_FORMAT` | `repo/branch` | Title format |
 | `TERMINAL_TITLE_ENABLED` | `true` | Set `false` to disable |
-| `AIDEVOPS_TAB_STATUS_ENABLED` | `true` | Set `false` to retain dynamic titles without OpenCode `[RUN]`/`[WAIT]` prefixes |
+| `AIDEVOPS_TAB_STATUS_ENABLED` | `true` | Set `false` to retain dynamic titles without OpenCode status glyphs |
 
 <!-- AI-CONTEXT-END -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- replace OpenCode terminal tab status text with compact running and waiting emoji indicators (#28005)
+
 ## [3.32.135] - 2026-07-16
 
 ### Changed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,7 +163,7 @@ AI DevOps is a developer-operations framework and OpenCode plugin. Its interface
 Design goals:
 
 - Keep operational state obvious: running, stopped, error, authenticated, last update, and command actions should scan quickly.
-- Use concise, text-first terminal status prefixes: `[RUN]` for active OpenCode turns and `[WAIT]` when the root session is awaiting input. Keep these terminal-only so issue/PR prefixes remain first in stored session titles and search results.
+- Use compact terminal-only status glyphs: 🟡 for active OpenCode turns and 🟢 when the root session is awaiting input. Retain the descriptive title and opt-out so colour is never the only essential status affordance; keep glyphs out of stored session titles so issue/PR prefixes remain first in search results.
 - Preserve developer trust with native system typography, code-friendly contrast, visible borders, and restrained motion.
 - Use compact density for dashboards and sidebars, but keep controls at least 44px high when touch use is plausible.
 - Prefer semantic tokens over one-off values so generated reports, OpenCode UI surfaces, and dashboard screens stay consistent.

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ See `.agents/tools/git/opencode-github-security.md` for the full security docume
 - **[OpenCode Zen](https://opencode.ai/)** - Free tier of OpenCode with included models. Start working with AI straight away at no cost -- no API keys or subscriptions required.
 - **OpenAI GPT-5.5 / GPT-5.4 mini** - Recommended model pair for aidevops today. Use GPT-5.5 for complex reasoning and high-impact agent tiers; use GPT-5.4 mini for triage, routine implementation, and cost-efficient parallel workers.
 - **[Claude](https://claude.ai/)** (Anthropic) - Fully supported alternative provider. Claude models remain useful for fallback, cross-provider verification, and users with Claude Pro/Max OAuth access.
-- **[Tabby](https://tabby.sh/)** - Recommended terminal. Colour-coded Profiles per project/repo, **auto-syncs tab titles with git/session context and marks OpenCode turns as `[RUN]` or `[WAIT]`.**
+- **[Tabby](https://tabby.sh/)** - Recommended terminal. Colour-coded Profiles per project/repo, **auto-syncs tab titles with git/session context and marks OpenCode turns as 🟡 or 🟢.**
 - **[Zed](https://zed.dev/)** - Recommended editor. High-performance with AI integration (use with the OpenCode Agent Extension).
 
 ### Troubleshooting Auth
@@ -620,7 +620,7 @@ The agent contains the full recovery flow and symptom table. Free models work fi
 
 ### Terminal Tab Title Sync
 
-Your terminal tab/window title automatically shows `repo/branch` context when working in git repositories. Interactive OpenCode tabs add `[RUN]` while the root session is busy or retrying and `[WAIT]` when it has finished and is awaiting input. This helps identify both the work context and session state across multiple terminal sessions.
+Your terminal tab/window title automatically shows `repo/branch` context when working in git repositories. Interactive OpenCode tabs add 🟡 while the root session is busy or retrying and 🟢 when it has finished and is awaiting input. This helps identify both the work context and session state across multiple terminal sessions.
 
 **Supported terminals:** [Tabby](https://tabby.sh/), [cmux](https://cmux.dev/), [iTerm2](https://iterm2.com/), [Kitty](https://sw.kovidgoyal.net/kitty/), [Alacritty](https://alacritty.org/), [WezTerm](https://wezfurlong.org/wezterm/), [Hyper](https://hyper.is/), and most xterm-compatible terminals.
 


### PR DESCRIPTION
## Summary

Replace terminal-only [RUN]/[WAIT] text with compact 🟡 running and 🟢 waiting indicators while preserving descriptive and stored OpenCode titles.

## Files Changed

.agents/plugins/opencode-aidevops/terminal-title.mjs, .agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs, .agents/tools/terminal/terminal-title.md, CHANGELOG.md, DESIGN.md, README.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 20 targeted title tests; 410 OpenCode plugin tests; Biome; markdownlint; changed-file repository lint; PTY transition plain → 🟡 → 🟢 → plain.

Resolves #28005


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.135 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 9m and 719,494 tokens on this with the user in an interactive session.