### PR TITLE
t18146: security: enforce no-write research subagents

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -52,6 +52,7 @@ subagents:
   - build-agent
   - agent-review
   # Built-in
+  - research-only
   - general
   - explore
 ---
@@ -68,6 +69,8 @@ subagents:
 ## Core Responsibility
 
 Build+: keep going until fully resolved. Make announced tool calls. Solve autonomously. Greenfield = ambitious. Existing codebase = surgical.
+
+Research-only delegation uses `research-only`, never `general` or `explore`.
 
 ## Intent Detection
 

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -572,6 +572,71 @@ function registerAgents(config, agentsDir) {
   return injected;
 }
 
+const RESEARCH_ONLY_AGENT_NAME = "research-only";
+const RESEARCH_ONLY_FALLBACK_PROMPT = `# Research-only subagent
+
+Gather evidence from the assigned repository and read-only web sources. Return
+findings, citations, uncertainty, and recommendations. Never modify local or
+external state, invoke another agent, access credentials, or perform Git,
+account, network-write, or worktree operations.`;
+
+function researchOnlyPrompt(agentsDir) {
+  const source = readIfExists(join(agentsDir, "tools", "ai-assistants", "research-only.md"));
+  if (!source) return RESEARCH_ONLY_FALLBACK_PROMPT;
+  return source.replace(/^---\n[\s\S]*?\n---\n?/, "").trim();
+}
+
+/**
+ * Register a fail-closed research profile after all broad/global permission
+ * transforms so managed-directory grants and MCP defaults cannot widen it.
+ * @param {object} config - OpenCode Config object (mutable)
+ * @param {string} agentsDir
+ * @returns {number} Number of enforced profiles
+ */
+export function registerResearchOnlyAgent(config, agentsDir) {
+  if (!config.agent) config.agent = {};
+  config.agent[RESEARCH_ONLY_AGENT_NAME] = {
+    description: "Non-mutating repository and web research with a fail-closed capability envelope",
+    mode: "subagent",
+    prompt: researchOnlyPrompt(agentsDir),
+    tools: {
+      "*": false,
+      read: true,
+      grep: true,
+      glob: true,
+      webfetch: true,
+      websearch: true,
+      write: false,
+      edit: false,
+      apply_patch: false,
+      bash: false,
+      task: false,
+      todowrite: false,
+      skill: false,
+    },
+    permission: {
+      "*": "deny",
+      read: {
+        "*": "allow",
+        "*.env": "deny",
+        "*.env.*": "deny",
+        "*.env.example": "allow",
+      },
+      grep: "allow",
+      glob: "allow",
+      webfetch: "allow",
+      websearch: "allow",
+      write: "deny",
+      edit: "deny",
+      apply_patch: "deny",
+      bash: "deny",
+      task: "deny",
+      external_directory: "deny",
+    },
+  };
+  return 1;
+}
+
 /**
  * Ensure at least one agent is enabled (prevents OpenCode crash).
  * @param {object} config - OpenCode Config object (mutable)
@@ -689,13 +754,14 @@ export function createConfigHook(deps) {
   return async function configHook(config) {
     if (!config.agent) config.agent = {};
 
-    const agents = registerAgents(config, agentsDir);
+    let agents = registerAgents(config, agentsDir);
     ensureAgentGuard(config, workspaceDir);
 
     const mcps = registerMcpServers(config);
     const agentTools = applyAgentMcpTools(config);
     const directories = registerManagedDirectoryPermissions(config);
     const permissionGrants = registerApprovedWorkerPermissions(config, { repositoryDir });
+    agents += registerResearchOnlyAgent(config, agentsDir);
     const poolCleaned = registerPoolProvider(config);
     const anthropic = registerAnthropicModels(config);
     const openai = registerGpt56ContextLimits(config);

--- a/.agents/plugins/opencode-aidevops/tests/test-research-only-profile.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-research-only-profile.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerResearchOnlyAgent } from "../config-hook.mjs";
+
+test("research-only profile overrides permissive config and fails closed", () => {
+  const agentsDir = mkdtempSync(join(tmpdir(), "aidevops-research-only-"));
+  const sourceDir = join(agentsDir, "tools", "ai-assistants");
+  mkdirSync(sourceDir, { recursive: true });
+  writeFileSync(join(sourceDir, "research-only.md"), "---\nmode: subagent\n---\n\nCanonical research prompt.\n");
+
+  try {
+    const config = {
+      tools: { "playwriter_*": true },
+      agent: {
+        "research-only": {
+          tools: { bash: true, task: true },
+          permission: "allow",
+        },
+      },
+    };
+
+    assert.equal(registerResearchOnlyAgent(config, agentsDir), 1);
+    const profile = config.agent["research-only"];
+
+    assert.equal(profile.mode, "subagent");
+    assert.equal(profile.prompt, "Canonical research prompt.");
+    assert.deepEqual(profile.tools, {
+      "*": false,
+      read: true,
+      grep: true,
+      glob: true,
+      webfetch: true,
+      websearch: true,
+      write: false,
+      edit: false,
+      apply_patch: false,
+      bash: false,
+      task: false,
+      todowrite: false,
+      skill: false,
+    });
+    assert.equal(profile.permission["*"], "deny");
+    assert.equal(profile.permission.bash, "deny");
+    assert.equal(profile.permission.task, "deny");
+    assert.equal(profile.permission.edit, "deny");
+    assert.equal(profile.permission.write, "deny");
+    assert.equal(profile.permission.apply_patch, "deny");
+    assert.equal(profile.permission.external_directory, "deny");
+    assert.equal(profile.permission.read["*"], "allow");
+    assert.equal(profile.permission.read["*.env"], "deny");
+    assert.equal(profile.permission.webfetch, "allow");
+    assert.equal(config.tools["playwriter_*"], true);
+  } finally {
+    rmSync(agentsDir, { recursive: true, force: true });
+  }
+});

--- a/.agents/research.md
+++ b/.agents/research.md
@@ -3,19 +3,7 @@ name: research
 description: Research and analysis - data gathering, competitive analysis, market research
 mode: subagent
 subagents:
-  # Context/docs
-  - context7
-  # Web research
-  - crawl4ai
-  - serper
-  - outscraper
-  # Summarization
-  - summarize
-  # Domain-specific corpus research
-  - legal-research
-  # Built-in
-  - general
-  - explore
+  - research-only
 ---
 
 <!-- SPDX-License-Identifier: MIT -->
@@ -35,7 +23,8 @@ Stay in analyst mode. Answer with findings, evidence, and recommendations; do no
 
 - **Purpose**: research and analysis
 - **Mode**: gather evidence, not implement changes
-- **Primary tools**: Context7 for official docs, Crawl4AI/browser tools for web content, webfetch for supplied URLs
+- **Delegation**: dispatch research work only to `research-only`; never use mutation-capable `general` or `explore` agents for a research-only request
+- **Primary tools**: repository read/search plus webfetch for supplied URLs
 - **Common tasks**: technical documentation, competitor analysis, market research, best-practice discovery, tool evaluation
 - **Output**: structured findings, not code changes
 
@@ -73,3 +62,12 @@ Stay in analyst mode. Answer with findings, evidence, and recommendations; do no
 - Next steps
 
 Research informs implementation; it does not perform it.
+
+## Capability envelope
+
+The `research-only` OpenCode profile is the canonical non-mutating research
+boundary. It permits repository reads, grep/glob search, and read-only web
+retrieval. It denies edits, writes, patches, Bash, nested tasks, external
+directories, credential/account tools, and all unlisted tools. Permission
+prompts must fail closed rather than widening this profile after resume or
+compaction.

--- a/.agents/scripts/lib/agent_config.py
+++ b/.agents/scripts/lib/agent_config.py
@@ -114,7 +114,8 @@ AGENT_TOOLS = {
         "write": True, "edit": True, "read": True, "webfetch": True
     },
     "Research": {
-        "read": True, "webfetch": True, "bash": True,
+        "read": True, "glob": True, "grep": True,
+        "webfetch": True, "task": True,
         "openapi-search_*": True
     },
     "Automate": {

--- a/.agents/scripts/tests/test-agent-discovery-smoke.sh
+++ b/.agents/scripts/tests/test-agent-discovery-smoke.sh
@@ -254,8 +254,12 @@ assert build["permission"]["grep"] == "allow"
 assert build["permission"]["task"] == {"*": "deny", "research": "allow"}
 
 research = get_agent_config("Research", "research.md")
-assert "grep" not in research["tools"]
-assert "grep" not in research["permission"]
+assert research["tools"]["grep"] is True
+assert research["tools"]["task"] is True
+assert "bash" not in research["tools"]
+assert "write" not in research["tools"]
+assert "edit" not in research["tools"]
+assert research["permission"]["grep"] == "allow"
 
 print("OK")
 PYEOF

--- a/.agents/scripts/tests/test-opencode-subagent-runtime-guards.sh
+++ b/.agents/scripts/tests/test-opencode-subagent-runtime-guards.sh
@@ -33,6 +33,38 @@ tools:
 # Bounded review
 EOF_AGENT
 
+cat >"$AGENTS_DIR/tools/code-review/research-only.md" <<'EOF_AGENT'
+---
+description: Research-only agent
+mode: subagent
+tools:
+  "*": false
+  read: true
+  grep: true
+  glob: true
+  webfetch: true
+  write: false
+  edit: false
+  apply_patch: false
+  bash: false
+  task: false
+permission:
+  "*": deny
+  read: allow
+  grep: allow
+  glob: allow
+  webfetch: allow
+  write: deny
+  edit: deny
+  apply_patch: deny
+  bash: deny
+  task: deny
+  external_directory: deny
+---
+
+# Research-only
+EOF_AGENT
+
 cat >"$AGENTS_DIR/tools/code-review/sandboxed-review.md" <<'EOF_AGENT'
 ---
 description: Sandboxed review agent
@@ -76,6 +108,21 @@ if grep -q '^model: thinking$' "$sandboxed_generated"; then
 	printf '%s\n' 'FAIL: workload tier leaked into OpenCode model field' >&2
 	exit 1
 fi
+
+if ! _write_subagent_stub "$AGENTS_DIR/tools/code-review/research-only.md" >/dev/null; then
+	printf '%s\n' 'FAIL: could not generate research-only OpenCode subagent' >&2
+	exit 1
+fi
+
+research_generated="$agent_dir/research-only.md"
+grep -q '^  "\*": false$' "$research_generated"
+grep -q '^  read: true$' "$research_generated"
+grep -q '^  write: false$' "$research_generated"
+grep -q '^  edit: false$' "$research_generated"
+grep -q '^  apply_patch: false$' "$research_generated"
+grep -q '^  bash: false$' "$research_generated"
+grep -q '^  task: false$' "$research_generated"
+grep -q '^  external_directory: deny$' "$research_generated"
 
 printf '%s\n' 'PASS: generated OpenCode subagents preserve guards without treating workload tiers as model IDs'
 exit 0

--- a/.agents/tools/ai-assistants/research-only.md
+++ b/.agents/tools/ai-assistants/research-only.md
@@ -1,0 +1,46 @@
+---
+name: research-only
+description: Non-mutating repository and web research with a fail-closed capability envelope
+mode: subagent
+tools:
+  "*": false
+  read: true
+  grep: true
+  glob: true
+  webfetch: true
+  websearch: true
+  write: false
+  edit: false
+  apply_patch: false
+  bash: false
+  task: false
+  todowrite: false
+  skill: false
+permission:
+  "*": deny
+  read:
+    "*": allow
+    "*.env": deny
+    "*.env.*": deny
+    "*.env.example": allow
+  grep: allow
+  glob: allow
+  webfetch: allow
+  websearch: allow
+  write: deny
+  edit: deny
+  apply_patch: deny
+  bash: deny
+  task: deny
+  external_directory: deny
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Research-only subagent
+
+Gather evidence from the assigned repository and read-only web sources. Return
+findings, citations, uncertainty, and recommendations. Do not modify local or
+external state, request a permission escalation, invoke another agent, access
+credentials, or perform Git, account, network-write, or worktree operations.


### PR DESCRIPTION
## Summary

Implementation for issue #27991.

## Files Changed

.agents/build-plus.md, .agents/plugins/opencode-aidevops/config-hook.mjs, .agents/plugins/opencode-aidevops/tests/test-research-only-profile.mjs, .agents/research.md, .agents/scripts/lib/agent_config.py, .agents/scripts/tests/test-agent-discovery-smoke.sh, .agents/scripts/tests/test-opencode-subagent-runtime-guards.sh, .agents/tools/ai-assistants/research-only.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #27991


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.135 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 2h 11m and 1,599,607 tokens on this with the user in an interactive session.