### PR TITLE
GH#28001: Isolate pulse merge safety test fixtures

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -321,10 +321,10 @@ test_case_n_empty_pr_metadata_is_logged() {
 
 test_case_o_malformed_pr_metadata_is_logged() {
 	: >"$LOGFILE"
+	set_fixture '[{"name":"bug"}]' 'false' '## Summary\n\nResolves #942' 'VERIFIED'
 	printf '%s' '{not-json' >"${TEST_ROOT}/labels.json"
 	local result=0
 	_pulse_merge_admin_safety_check "942" "owner/repo" "head-current" || result=$?
-	set_fixture '[{"name":"bug"}]' 'false' '## Summary\n\nResolves #942' 'VERIFIED'
 	if [[ "$result" -eq 1 ]] && grep -qF "gh pr view returned malformed metadata for PR #942 in owner/repo — failing closed" "$LOGFILE"; then
 		print_result "Case O: malformed PR metadata is logged" 0
 		return 0
@@ -335,10 +335,10 @@ test_case_o_malformed_pr_metadata_is_logged() {
 
 test_case_p_missing_pr_identity_is_logged() {
 	: >"$LOGFILE"
+	set_fixture '[{"name":"bug"}]' 'false' '## Summary\n\nResolves #943' 'VERIFIED'
 	printf '%s' '{"author":null,"labels":[],"isCrossRepository":false,"headRefOid":""}' >"${TEST_ROOT}/labels.json"
 	local result=0
 	_pulse_merge_admin_safety_check "943" "owner/repo" "head-current" || result=$?
-	set_fixture '[{"name":"bug"}]' 'false' '## Summary\n\nResolves #943' 'VERIFIED'
 	if [[ "$result" -eq 1 ]] && grep -qF "missing head SHA or author for PR #943 in owner/repo — failing closed" "$LOGFILE"; then
 		print_result "Case P: missing PR identity is logged" 0
 		return 0
@@ -355,6 +355,7 @@ test_case_q_linked_issue_extraction_failure_is_logged() {
 	}
 	local result=0
 	_pulse_merge_admin_safety_check "944" "owner/repo" "head-current" || result=$?
+	define_helpers_under_test >/dev/null
 	if [[ "$result" -eq 1 ]] && grep -qF "linked issue extraction failed for PR #944 in owner/repo — failing closed" "$LOGFILE"; then
 		print_result "Case Q: linked issue extraction failure is logged" 0
 		return 0


### PR DESCRIPTION
## Summary

- Initialize malformed and missing-identity fixtures before exercising the pulse merge safety check.
- Restore helper definitions after overriding linked-issue extraction in Case Q.

## Testing

- `shellcheck .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh`
- `bash .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh` (17 passed)

## Runtime Testing

- Self-assessed: test-only isolation correction with the complete targeted suite passing.

Resolves #28001

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 68,592 tokens on this as a headless worker.
