### PR TITLE
t18147: security: stop completed child compaction resumes

### DIFF
--- a/.agents/plugins/opencode-aidevops/compaction-lifecycle.mjs
+++ b/.agents/plugins/opencode-aidevops/compaction-lifecycle.mjs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { createHash } from "node:crypto";
+
+const MAX_SESSION_STATES = 64;
+const TERMINAL_FINISH_REASONS = new Set(["stop", "end_turn", "completed"]);
+const CONTINUABLE_FINISH_REASONS = new Set([
+  "length",
+  "max_tokens",
+  "tool-calls",
+  "tool_calls",
+]);
+
+function unwrapResponse(response) {
+  return response?.data ?? response;
+}
+
+function capMap(map) {
+  while (map.size > MAX_SESSION_STATES) map.delete(map.keys().next().value);
+}
+
+function sessionHash(sessionID) {
+  return createHash("sha256").update(String(sessionID || "unknown-session")).digest("hex").slice(0, 12);
+}
+
+function lifecycleFromMessages(messages) {
+  const message = [...(Array.isArray(messages) ? messages : [])]
+    .reverse()
+    .map((entry) => entry?.info ?? entry)
+    .find((info) => info?.role === "assistant" && info?.summary !== true && info?.mode !== "compaction");
+
+  if (!message) return { finish: "", reason: "child_finish_missing" };
+  const finish = String(message.finish || "").toLowerCase();
+  if (TERMINAL_FINISH_REASONS.has(finish)) return { finish, reason: "child_terminal" };
+  if (CONTINUABLE_FINISH_REASONS.has(finish)) return { finish, reason: "child_incomplete" };
+  return { finish, reason: finish ? "child_finish_unknown" : "child_finish_missing" };
+}
+
+/**
+ * Guard OpenCode's experimental.compaction.autocontinue hook.
+ *
+ * OpenCode 1.18.3 supplies { sessionID, agent, model, provider, message,
+ * overflow } and a mutable { enabled } output. Its installed plugin type
+ * package currently omits this runtime hook, so focused tests pin the observed
+ * contract. The guard only narrows `enabled`; it never changes the message,
+ * model, provider, tools, or permission state.
+ */
+export function createCompactionAutoContinueGuard(client, options = {}) {
+  const qualityLog = options.qualityLog;
+  const sessions = new Map();
+  const finishes = new Map();
+
+  function rememberSession(session) {
+    if (!session?.id) return;
+    sessions.set(session.id, {
+      known: true,
+      child: Boolean(session.parentID),
+    });
+    capMap(sessions);
+  }
+
+  function rememberMessage(message) {
+    if (message?.role !== "assistant" || message?.summary === true || message?.mode === "compaction") return;
+    if (!message.sessionID) return;
+    finishes.set(message.sessionID, {
+      finish: String(message.finish || "").toLowerCase(),
+    });
+    capMap(finishes);
+  }
+
+  function handleEvent(input) {
+    const event = input?.event ?? input;
+    if (["session.created", "session.updated"].includes(event?.type)) {
+      rememberSession(event.properties?.info);
+    } else if (event?.type === "session.deleted") {
+      const sessionID = event.properties?.info?.id;
+      sessions.delete(sessionID);
+      finishes.delete(sessionID);
+    } else if (event?.type === "message.updated") {
+      rememberMessage(event.properties?.info);
+    }
+  }
+
+  async function inspect(sessionID) {
+    let session = null;
+    try {
+      session = unwrapResponse(await client?.session?.get?.({ path: { id: sessionID } })) || null;
+      rememberSession(session);
+    } catch {
+      session = null;
+    }
+
+    const knownSession = session?.id ? sessions.get(session.id) : sessions.get(sessionID);
+    if (knownSession?.known && !knownSession.child) {
+      return { enabled: true, reason: "primary_session" };
+    }
+    if (!knownSession?.child) {
+      return { enabled: false, reason: "session_lifecycle_unknown" };
+    }
+
+    let lifecycle = null;
+    try {
+      const response = await client?.session?.messages?.({ path: { id: sessionID } });
+      lifecycle = lifecycleFromMessages(unwrapResponse(response));
+    } catch {
+      lifecycle = lifecycleFromMessages([]);
+    }
+
+    if (lifecycle.reason === "child_finish_missing") {
+      const cached = finishes.get(sessionID);
+      lifecycle = lifecycleFromMessages(cached ? [{ role: "assistant", finish: cached.finish }] : []);
+    }
+    return {
+      enabled: lifecycle.reason === "child_incomplete",
+      reason: lifecycle.reason,
+      finish: lifecycle.finish,
+    };
+  }
+
+  async function autoContinue(input, output) {
+    const sessionID = String(input?.sessionID || "");
+    const decision = sessionID
+      ? await inspect(sessionID)
+      : { enabled: false, reason: "session_id_missing" };
+
+    if (!decision.enabled) {
+      output.enabled = false;
+      qualityLog?.(
+        "WARN",
+        `[compaction-autocontinue] blocked session sha256:${sessionHash(sessionID)} reason=${decision.reason}`,
+      );
+    }
+    return decision;
+  }
+
+  return { autoContinue, handleEvent };
+}
+
+export { CONTINUABLE_FINISH_REASONS, TERMINAL_FINISH_REASONS, lifecycleFromMessages };

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -33,6 +33,7 @@ import { createConfigHook } from "./config-hook.mjs";
 import { createQualityHooks } from "./quality-hooks.mjs";
 import { createShellEnvHook } from "./shell-env.mjs";
 import { compactingHook } from "./compaction.mjs";
+import { createCompactionAutoContinueGuard } from "./compaction-lifecycle.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
 import { createGreetingHandler } from "./greeting.mjs";
 import { applyImageSizeGuard } from "./quality-hooks-image.mjs";
@@ -255,6 +256,7 @@ export async function AidevopsPlugin({ directory, client }) {
   const subagentEffortHooks = createSubagentEffortHooks(client, { tierReasoning });
   const shouldInjectGreeting = createSessionStartGreetingGate(client, isHeadless);
   const permissionBroker = createPermissionBroker({ client, isHeadless });
+  const compactionContinuation = createCompactionAutoContinueGuard(client, { qualityLog });
 
   // TTSR hooks
   const {
@@ -392,6 +394,7 @@ export async function AidevopsPlugin({ directory, client }) {
       // Fire both in parallel — neither depends on the other's result.
       await Promise.all([
         handleEvent(input),
+        Promise.resolve(compactionContinuation.handleEvent(input)),
         permissionBroker.handleEvent(input).catch((err) => debugEventError("permission broker", err)),
         sessionTitleStatusHandler(input).catch((err) => debugEventError("title status handler", err)),
         sessionTitleSuffixHandler(input).catch((err) => debugEventError("title suffix handler", err)),
@@ -424,5 +427,6 @@ export async function AidevopsPlugin({ directory, client }) {
         output,
         directory,
       ),
+    "experimental.compaction.autocontinue": compactionContinuation.autoContinue,
   };
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-compaction-autocontinue.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-compaction-autocontinue.mjs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { createCompactionAutoContinueGuard } from "../compaction-lifecycle.mjs";
+
+function clientFor(session, messages, options = {}) {
+  return {
+    session: {
+      get: async () => {
+        if (options.getError) throw new Error("session lookup unavailable");
+        return { data: session };
+      },
+      messages: async () => {
+        if (options.messagesError) throw new Error("message lookup unavailable");
+        return { data: messages };
+      },
+    },
+  };
+}
+
+function assistant(sessionID, finish, overrides = {}) {
+  return {
+    info: {
+      id: `message-${finish || "missing"}`,
+      sessionID,
+      role: "assistant",
+      finish,
+      ...overrides,
+    },
+    parts: [],
+  };
+}
+
+test("terminal child completion disables synthetic compaction continuation", async () => {
+  const sessionID = "child-terminal";
+  const logs = [];
+  const guard = createCompactionAutoContinueGuard(
+    clientFor(
+      { id: sessionID, parentID: "parent-session" },
+      [assistant(sessionID, "tool-calls"), assistant(sessionID, "stop")],
+    ),
+    { qualityLog: (level, message) => logs.push({ level, message }) },
+  );
+  const input = Object.freeze({
+    sessionID,
+    agent: "research-only",
+    model: Object.freeze({ providerID: "openai", modelID: "gpt-5.6-sol" }),
+    provider: Object.freeze({ source: "config" }),
+    message: Object.freeze({ tools: Object.freeze({ read: true, bash: false }) }),
+    overflow: false,
+  });
+  const before = JSON.stringify(input);
+  const output = { enabled: true };
+
+  assert.deepEqual(await guard.autoContinue(input, output), {
+    enabled: false,
+    reason: "child_terminal",
+    finish: "stop",
+  });
+  assert.equal(output.enabled, false);
+  assert.equal(JSON.stringify(input), before, "capability-bearing hook input must remain byte-equivalent");
+  assert.equal(logs.length, 1);
+  assert.match(logs[0].message, /reason=child_terminal/);
+  assert.doesNotMatch(logs[0].message, /child-terminal|parent-session/);
+});
+
+test("incomplete child and eligible primary preserve existing continuation state", async () => {
+  const childID = "child-incomplete";
+  const childGuard = createCompactionAutoContinueGuard(
+    clientFor({ id: childID, parentID: "parent" }, [assistant(childID, "tool-calls")]),
+  );
+  const childOutput = { enabled: true, marker: "unchanged" };
+  assert.equal((await childGuard.autoContinue({ sessionID: childID }, childOutput)).enabled, true);
+  assert.deepEqual(childOutput, { enabled: true, marker: "unchanged" });
+
+  const primaryID = "primary-incomplete";
+  const primaryGuard = createCompactionAutoContinueGuard(
+    clientFor({ id: primaryID }, [assistant(primaryID, "stop")]),
+  );
+  const primaryOutput = { enabled: true };
+  assert.deepEqual(await primaryGuard.autoContinue({ sessionID: primaryID }, primaryOutput), {
+    enabled: true,
+    reason: "primary_session",
+  });
+  assert.equal(primaryOutput.enabled, true);
+
+  const preDisabled = { enabled: false };
+  await primaryGuard.autoContinue({ sessionID: primaryID }, preDisabled);
+  assert.equal(preDisabled.enabled, false, "the guard must never widen another lifecycle denial");
+});
+
+test("missing or contradictory child lifecycle fails closed with event fallback", async () => {
+  const childID = "child-event-fallback";
+  const guard = createCompactionAutoContinueGuard(
+    clientFor(null, [], { getError: true, messagesError: true }),
+  );
+  guard.handleEvent({ event: {
+    type: "session.created",
+    properties: { info: { id: childID, parentID: "parent" } },
+  } });
+  guard.handleEvent({ event: {
+    type: "message.updated",
+    properties: { info: { sessionID: childID, role: "assistant", finish: "stop" } },
+  } });
+
+  const eventBackedOutput = { enabled: true };
+  assert.deepEqual(await guard.autoContinue({ sessionID: childID }, eventBackedOutput), {
+    enabled: false,
+    reason: "child_terminal",
+    finish: "stop",
+  });
+  assert.equal(eventBackedOutput.enabled, false);
+
+  const malformedID = "child-malformed";
+  const malformed = createCompactionAutoContinueGuard(
+    clientFor({ id: malformedID, parentID: "parent" }, [
+      assistant(malformedID, "stop", { summary: true, mode: "compaction" }),
+      assistant(malformedID, "mystery"),
+    ]),
+  );
+  const malformedOutput = { enabled: true };
+  assert.deepEqual(await malformed.autoContinue({ sessionID: malformedID }, malformedOutput), {
+    enabled: false,
+    reason: "child_finish_unknown",
+    finish: "mystery",
+  });
+  assert.equal(malformedOutput.enabled, false);
+
+  const unknownOutput = { enabled: true };
+  const unknown = createCompactionAutoContinueGuard(clientFor(null, [], { getError: true }));
+  assert.equal((await unknown.autoContinue({ sessionID: "unknown" }, unknownOutput)).reason, "session_lifecycle_unknown");
+  assert.equal(unknownOutput.enabled, false);
+});


### PR DESCRIPTION
## Summary

Implementation for issue #27992.

## Files Changed

.agents/plugins/opencode-aidevops/compaction-lifecycle.mjs, .agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/tests/test-compaction-autocontinue.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #27992


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.136 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 2h 37m and 1,694,637 tokens on this with the user in an interactive session.