### PR TITLE
t18149: security: require authorization for GitHub account mutations

### DIFF
--- a/.agents/configs/command-policy.json
+++ b/.agents/configs/command-policy.json
@@ -21,6 +21,16 @@
       "kind": "worker_network",
       "helper": "network-tier-helper.sh",
       "decision": "forbid"
+    },
+    {
+      "id": "github.account-mutation",
+      "kind": "trusted_account_mutation",
+      "authorization_env": "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION",
+      "command_paths": [
+        ["repo", "create"],
+        ["repo", "fork"]
+      ],
+      "decision": "forbid"
     }
   ],
   "rules": [

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -182,6 +182,59 @@ test("blocks generic destructive commands through shared policy", () => {
   );
 });
 
+test("blocks account mutations unless inherited authorization matches exactly", () => {
+  const cwd = process.cwd();
+  const helper = join(scriptsDir, "command-policy-helper.py");
+  const command = "gh repo fork owner/source --clone=false";
+  const previousAuthorization = process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION;
+  const authorization = execFileSync(
+    "python3",
+    [helper, "authorization-digest", "--cwd", cwd, "--command", command],
+    { encoding: "utf8" },
+  ).trim();
+  try {
+    delete process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION;
+    assert.throws(
+      () => checkCommandSafetyGate(command, scriptsDir, cwd),
+      /github\.account-mutation/,
+    );
+    assert.throws(
+      () => checkCommandSafetyGate(
+        "bash -lc 'gh repo fork owner/source --clone=false'",
+        scriptsDir,
+        cwd,
+      ),
+      /github\.account-mutation/,
+    );
+    assert.doesNotThrow(() => checkCommandSafetyGate("gh repo view owner/source", scriptsDir, cwd));
+
+    process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION = authorization;
+    assert.doesNotThrow(() => checkCommandSafetyGate(command, scriptsDir, cwd));
+    assert.throws(
+      () => checkCommandSafetyGate(
+        "sudo -n gh repo fork owner/source --clone=false",
+        scriptsDir,
+        cwd,
+      ),
+      /github\.account-mutation/,
+    );
+    assert.throws(
+      () => checkCommandSafetyGate("gh repo fork owner/different --clone=false", scriptsDir, cwd),
+      /github\.account-mutation/,
+    );
+    assert.throws(
+      () => checkCommandSafetyGate("gh repo create owner/new-repo --public", scriptsDir, cwd),
+      /github\.account-mutation/,
+    );
+  } finally {
+    if (previousAuthorization === undefined) {
+      delete process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION;
+    } else {
+      process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION = previousAuthorization;
+    }
+  }
+});
+
 test("rejects ambiguous shell syntax before execution", () => {
   assert.throws(
     () => checkCommandSafetyGate("printf one\nprintf two", scriptsDir, process.cwd()),

--- a/.agents/reference/gh-command-discipline.md
+++ b/.agents/reference/gh-command-discipline.md
@@ -14,6 +14,27 @@ When to load:
 
 For prompt-economy reasons these rules live here rather than in always-on AGENTS.md context. The pointer in AGENTS.md keeps `t2685`, `t2893`, `8a-8e`, and `#20978` searchable while moving the full walkthrough out of startup context.
 
+## Account-level mutation authorization
+
+Generic Bash permission does not authorize GitHub account or repository resource
+creation. The shared command policy denies protected commands such as `gh repo
+fork` and `gh repo create` before execution unless the runtime process inherits an
+authorization digest for that exact parsed argv and working directory.
+
+Generate the digest without executing the command:
+
+```bash
+python3 ~/.aidevops/agents/scripts/command-policy-helper.py \
+  authorization-digest --cwd "$PWD" --command 'gh repo fork <owner>/<repo> --clone=false'
+```
+
+The trusted operator or dispatcher may then set the returned value as
+`AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION` when launching the runtime. Never add
+that assignment to the Bash command being authorized: command-local attempts are
+rejected as a parse error. Any argv, quoting result, command chain, or working
+directory change requires a new authorization. Read-only `gh` commands and the
+normal issue/PR implementation workflow retain their existing behavior.
+
 ## Signature footer hallucination (t2685)
 
 (Observed: model composes inline, gets runtime/version wrong.)

--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -21,8 +21,11 @@ from command_policy_config import (
 )
 from command_policy_evaluation import (
     _evaluate_static,
+    _account_mutation_guard,
+    account_mutation_authorization,
     evaluate_invocations,
 )
+from command_policy_matchers import _matches_gh_command_path
 from command_policy_dispatch import (
     CommandParseError,
     _validate_argv,
@@ -105,7 +108,19 @@ def _parse_invocations(args: argparse.Namespace) -> list[list[str]]:
     return []
 
 
-def _policy_action(args: argparse.Namespace, invocations: list[list[str]]) -> int:
+def _authorization_source(args: argparse.Namespace) -> dict[str, Any] | None:
+    if args.command:
+        return {"kind": "command", "value": args.command}
+    if args.argv_json:
+        return {"kind": "argv", "value": _validate_argv(json.loads(args.argv_json))}
+    return None
+
+
+def _policy_action(
+    args: argparse.Namespace,
+    invocations: list[list[str]],
+    authorization_source: dict[str, Any] | None,
+) -> int:
     policy_path = Path(args.policy) if args.policy else _default_policy_path()
     try:
         policy = _load_policy(policy_path)
@@ -114,6 +129,26 @@ def _policy_action(args: argparse.Namespace, invocations: list[list[str]]) -> in
         return _report_policy_error(args.action, exc)
     if args.action == "validate":
         print(f"Command policy valid: {policy_path}")
+        return 0
+    if args.action == "authorization-digest":
+        guard = _account_mutation_guard(policy)
+        if len(invocations) != 1 or not _matches_gh_command_path(
+            invocations[0], guard["command_paths"]
+        ):
+            print(
+                json.dumps(
+                    _parse_error(
+                        "authorization digest requires one protected account mutation"
+                    ),
+                    sort_keys=True,
+                )
+            )
+            return FORBID_EXIT
+        print(
+            account_mutation_authorization(
+                invocations[0], args.cwd, authorization_source
+            )
+        )
         return 0
     if not invocations:
         print(json.dumps(_parse_error("command or argv input is required"), sort_keys=True))
@@ -126,6 +161,8 @@ def _policy_action(args: argparse.Namespace, invocations: list[list[str]]) -> in
         args.worker or _worker_from_environment(),
         args.worker_id,
         args.network_helper,
+        args.account_mutation_authorization,
+        authorization_source,
     )
     print(json.dumps(result, sort_keys=True))
     return 0 if result["decision"] == "allow" else FORBID_EXIT
@@ -136,12 +173,13 @@ def main() -> int:
 
     try:
         invocations = _parse_invocations(args)
+        authorization_source = _authorization_source(args)
     except (json.JSONDecodeError, CommandParseError) as exc:
         print(json.dumps(_parse_error(str(exc)), sort_keys=True))
         return FORBID_EXIT
     if args.action == "network-destinations":
         return _network_action(invocations, args.cwd)
-    return _policy_action(args, invocations)
+    return _policy_action(args, invocations, authorization_source)
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -131,25 +131,45 @@ def _policy_action(
         print(f"Command policy valid: {policy_path}")
         return 0
     if args.action == "authorization-digest":
-        guard = _account_mutation_guard(policy)
-        if len(invocations) != 1 or not _matches_gh_command_path(
-            invocations[0], guard["command_paths"]
-        ):
-            print(
-                json.dumps(
-                    _parse_error(
-                        "authorization digest requires one protected account mutation"
-                    ),
-                    sort_keys=True,
-                )
-            )
-            return FORBID_EXIT
+        return _authorization_action(
+            args, invocations, policy, authorization_source
+        )
+    return _check_action(args, invocations, policy, authorization_source)
+
+
+def _authorization_action(
+    args: argparse.Namespace,
+    invocations: list[list[str]],
+    policy: dict[str, Any],
+    authorization_source: dict[str, Any] | None,
+) -> int:
+    guard = _account_mutation_guard(policy)
+    if len(invocations) != 1 or not _matches_gh_command_path(
+        invocations[0], guard["command_paths"]
+    ):
         print(
-            account_mutation_authorization(
-                invocations[0], args.cwd, authorization_source
+            json.dumps(
+                _parse_error(
+                    "authorization digest requires one protected account mutation"
+                ),
+                sort_keys=True,
             )
         )
-        return 0
+        return FORBID_EXIT
+    print(
+        account_mutation_authorization(
+            invocations[0], args.cwd, authorization_source
+        )
+    )
+    return 0
+
+
+def _check_action(
+    args: argparse.Namespace,
+    invocations: list[list[str]],
+    policy: dict[str, Any],
+    authorization_source: dict[str, Any] | None,
+) -> int:
     if not invocations:
         print(json.dumps(_parse_error("command or argv input is required"), sort_keys=True))
         return FORBID_EXIT

--- a/.agents/scripts/command_policy_config.py
+++ b/.agents/scripts/command_policy_config.py
@@ -88,6 +88,7 @@ def _validate_policy_guards(guards: Any) -> None:
         raise PolicyError("command policy requires exactly one canonical Git guard")
     if not _has_required_guard(guards, "worker_network", "network-tier-helper.sh"):
         raise PolicyError("command policy requires exactly one worker network guard")
+    _validate_account_mutation_guard(guards)
 
 
 def _has_required_guard(guards: Any, kind: str, helper: str) -> bool:
@@ -101,6 +102,39 @@ def _has_required_guard(guards: Any, kind: str, helper: str) -> bool:
         and matches[0].get("helper") == helper
         and matches[0].get("decision") == "forbid"
     )
+
+
+def _validate_account_mutation_guard(guards: Any) -> None:
+    matches = [
+        guard
+        for guard in guards or []
+        if isinstance(guard, dict)
+        and guard.get("kind") == "trusted_account_mutation"
+    ]
+    if len(matches) != 1:
+        raise PolicyError(
+            "command policy requires exactly one trusted account-mutation guard"
+        )
+    guard = matches[0]
+    command_paths = guard.get("command_paths")
+    valid_paths = (
+        isinstance(command_paths, list)
+        and bool(command_paths)
+        and all(
+            isinstance(path, list)
+            and len(path) == 2
+            and all(isinstance(part, str) and part for part in path)
+            for path in command_paths
+        )
+    )
+    if (
+        guard.get("decision") != "forbid"
+        or guard.get("authorization_env")
+        != "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION"
+        or not valid_paths
+        or ["repo", "fork"] not in command_paths
+    ):
+        raise PolicyError("trusted account-mutation guard is malformed")
 
 
 def _validate_policy_rules(rules: Any) -> None:

--- a/.agents/scripts/command_policy_evaluation.py
+++ b/.agents/scripts/command_policy_evaluation.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import secrets
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -14,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from command_policy_config import _decision
-from command_policy_matchers import _matches
+from command_policy_matchers import _matches, _matches_gh_command_path
 
 DECISION_RANK = {"allow": 0, "forbid": 1}
 
@@ -25,6 +27,8 @@ class _EvaluationOptions:
     worker: bool = False
     worker_id: str = "unknown"
     network_helper: str = ""
+    account_mutation_authorization: str = ""
+    account_mutation_source: dict[str, Any] | None = None
 
 
 def _evaluate_static(
@@ -180,6 +184,70 @@ def _evaluate_worker_network(
     )
 
 
+def _account_mutation_guard(policy: dict[str, Any]) -> dict[str, Any]:
+    return next(
+        guard
+        for guard in policy["dynamic_guards"]
+        if guard["kind"] == "trusted_account_mutation"
+    )
+
+
+def account_mutation_authorization(
+    argv: list[str], cwd: str, source: dict[str, Any] | None = None
+) -> str:
+    payload = {
+        "argv": argv,
+        "cwd": os.path.realpath(cwd),
+        "schema": "aidevops-command-authorization/v1",
+        "source": source or {"kind": "invocations", "value": [argv]},
+    }
+    canonical = json.dumps(
+        payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def _evaluate_account_mutation(
+    invocations: list[list[str]],
+    cwd: str,
+    policy: dict[str, Any],
+    authorization: str,
+    source: dict[str, Any] | None,
+) -> dict[str, Any]:
+    guard = _account_mutation_guard(policy)
+    mutations = [
+        argv
+        for argv in invocations
+        if _matches_gh_command_path(argv, guard["command_paths"])
+    ]
+    if not mutations:
+        return _decision(
+            "allow",
+            "github.no-account-mutation",
+            "No protected GitHub account mutation detected",
+        )
+    if len(invocations) != 1 or len(mutations) != 1:
+        return _decision(
+            "forbid",
+            guard["id"],
+            "Protected GitHub account mutations must be authorized as one exact command",
+        )
+    expected = account_mutation_authorization(mutations[0], cwd, source)
+    # #aidevops:trust-boundary — only an authorization inherited by the policy
+    # process can cross this gate; command-local attempts are rejected while parsing.
+    if authorization and secrets.compare_digest(authorization, expected):
+        return _decision(
+            "allow",
+            "github.account-mutation-authorized",
+            "Exact GitHub account mutation matches trusted authorization",
+        )
+    return _decision(
+        "forbid",
+        guard["id"],
+        "GitHub account mutation requires exact trusted authorization",
+    )
+
+
 def evaluate_invocations(
     invocations: list[list[str]],
     cwd: str,
@@ -195,6 +263,13 @@ def evaluate_invocations(
             invocations,
             cwd,
             _canonical_guard_path(policy, options.guard_path, script_dir),
+        ),
+        _evaluate_account_mutation(
+            invocations,
+            cwd,
+            policy,
+            options.account_mutation_authorization,
+            options.account_mutation_source,
         ),
     ]
     if options.worker:
@@ -212,10 +287,17 @@ def evaluate_invocations(
 def _evaluation_options(
     legacy_options: tuple[Any, ...], named_options: dict[str, Any]
 ) -> _EvaluationOptions:
-    names = ("guard_path", "worker", "worker_id", "network_helper")
+    names = (
+        "guard_path",
+        "worker",
+        "worker_id",
+        "network_helper",
+        "account_mutation_authorization",
+        "account_mutation_source",
+    )
     if len(legacy_options) > len(names):
         raise TypeError(
-            f"evaluate_invocations() takes from 3 to 7 positional arguments "
+            f"evaluate_invocations() takes from 3 to 9 positional arguments "
             f"but {len(legacy_options) + 3} were given"
         )
     values: dict[str, Any] = dict(zip(names, legacy_options))

--- a/.agents/scripts/command_policy_matchers.py
+++ b/.agents/scripts/command_policy_matchers.py
@@ -22,11 +22,18 @@ __all__ = [
     "_is_root_or_home_operand",
     "_is_temp_operand",
     "_matches",
+    "_matches_gh_command_path",
     "_matches_git",
     "_matches_rm",
     "_rm_operands",
     "_short_flags",
 ]
+
+
+def _matches_gh_command_path(argv: list[str], command_paths: list[list[str]]) -> bool:
+    if len(argv) < 3 or os.path.basename(argv[0]) != "gh":
+        return False
+    return argv[1:3] in command_paths
 
 
 def _rm_operands(args: list[str]) -> list[str]:

--- a/.agents/scripts/command_policy_runtime.py
+++ b/.agents/scripts/command_policy_runtime.py
@@ -34,7 +34,13 @@ def _worker_from_environment() -> bool:
 def _argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "action", choices=("check-command", "validate", "network-destinations")
+        "action",
+        choices=(
+            "authorization-digest",
+            "check-command",
+            "validate",
+            "network-destinations",
+        ),
     )
     source = parser.add_mutually_exclusive_group()
     source.add_argument("--command", default="")
@@ -46,6 +52,12 @@ def _argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--worker", action="store_true")
     parser.add_argument(
         "--worker-id", default=os.environ.get("AIDEVOPS_WORKER_ID", "unknown")
+    )
+    # #aidevops:trust-boundary — this value comes from the policy process'
+    # inherited environment, never from an assignment inside the checked command.
+    parser.add_argument(
+        "--account-mutation-authorization",
+        default=os.environ.get("AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION", ""),
     )
     return parser
 

--- a/.agents/scripts/command_policy_wrapper_options.py
+++ b/.agents/scripts/command_policy_wrapper_options.py
@@ -116,10 +116,12 @@ def _unwrap_time(argv: list[str]) -> list[str]:
 def _is_safety_sensitive_assignment(name: str) -> bool:
     upper = name.upper()
     return upper.endswith("_PROXY") or upper.startswith("GIT_CONFIG_") or upper in {
+        "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION",
         "ALL_PROXY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR",
         "GIT_CONFIG_PARAMETERS", "GIT_DIR", "GIT_EXEC_PATH", "GIT_OBJECT_DIRECTORY",
         "GIT_PROXY_COMMAND", "GIT_SSH", "GIT_SSH_COMMAND", "GIT_WORK_TREE",
-        "CURL_HOME", "WGETRC", "BASH_ENV", "ENV", "ZDOTDIR",
+        "CURL_HOME", "WGETRC", "BASH_ENV", "ENV", "ZDOTDIR", "GH_CONFIG_DIR",
+        "GH_ENTERPRISE_TOKEN", "GH_HOST", "GH_REPO", "GH_TOKEN", "GITHUB_TOKEN",
     }
 
 

--- a/.agents/scripts/tests/test-command-policy-helper.sh
+++ b/.agents/scripts/tests/test-command-policy-helper.sh
@@ -146,6 +146,91 @@ PY
 	return 0
 }
 
+test_account_mutation_authorization() {
+	local command_text="gh repo fork owner/source --clone=false"
+	local authorization=""
+	local output=""
+	local status=0
+
+	assert_decision "blocks direct repository fork" "$command_text" forbid github.account-mutation 20 "/work"
+	assert_decision "blocks quoted repository fork" "gh repo fork 'owner/source' --clone=false" forbid github.account-mutation 20 "/work"
+	assert_decision "blocks wrapped repository fork" "sudo -n env -i command gh repo fork owner/source --clone=false" forbid github.account-mutation 20 "/work"
+	assert_decision "blocks shell-launched repository fork" "bash -lc 'gh repo fork owner/source --clone=false'" forbid github.account-mutation 20 "/work"
+	assert_argv_decision "blocks path-qualified repository fork" forbid github.account-mutation 20 "/work" /usr/local/bin/gh repo fork owner/source --clone=false
+	assert_decision "blocks equivalent repository creation" "gh repo create owner/new-repo --public" forbid github.account-mutation 20 "/work"
+	assert_decision "allows read-only repository view" "gh repo view owner/source" allow command.default-allow 0 "/work"
+	assert_decision "allows read-only issue view" "gh issue view 123" allow command.default-allow 0 "/work"
+	assert_decision "allows read-only pull request view" "gh pr view 456" allow command.default-allow 0 "/work"
+	assert_decision "fails closed on malformed repository fork" "gh repo fork 'owner/source" forbid command.parse-error 20 "/work"
+	assert_decision "rejects inline authorization injection" "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION=sha256:fake gh repo fork owner/source" forbid command.parse-error 20 "/work"
+	assert_decision "rejects wrapped authorization injection" "env AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION=sha256:fake gh repo fork owner/source" forbid command.parse-error 20 "/work"
+	assert_decision "rejects GitHub target environment override" "GH_REPO=other/target gh repo fork owner/source" forbid command.parse-error 20 "/work"
+
+	authorization="$(python3 "$HELPER" authorization-digest --cwd /work --command "$command_text")" || status=$?
+	if [[ "$status" -eq 0 && "$authorization" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+		pass "generates a content-bound account-mutation authorization"
+	else
+		fail "generates a content-bound account-mutation authorization" "status=${status} authorization=${authorization}"
+	fi
+
+	status=0
+	output="$(AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION="$authorization" python3 "$HELPER" check-command --cwd /work --command "$command_text")" || status=$?
+	if [[ "$status" -eq 0 && "$output" == *'"decision": "allow"'* ]]; then
+		pass "exact inherited authorization permits the approved fork"
+	else
+		fail "exact inherited authorization permits the approved fork" "status=${status} output=${output}"
+	fi
+
+	status=0
+	output="$(AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION="$authorization" python3 "$HELPER" check-command --cwd /work --command "sudo -n gh repo fork owner/source --clone=false")" || status=$?
+	if [[ "$status" -eq 20 && "$output" == *github.account-mutation* ]]; then
+		pass "direct authorization does not permit a privileged wrapper"
+	else
+		fail "direct authorization does not permit a privileged wrapper" "status=${status} output=${output}"
+	fi
+
+	status=0
+	output="$(AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION="$authorization" python3 "$HELPER" check-command --cwd /work --command "gh repo fork 'owner/source' --clone=false")" || status=$?
+	if [[ "$status" -eq 20 && "$output" == *github.account-mutation* ]]; then
+		pass "authorization remains bound to exact command quoting"
+	else
+		fail "authorization remains bound to exact command quoting" "status=${status} output=${output}"
+	fi
+
+	status=0
+	output="$(AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION="$authorization" python3 "$HELPER" check-command --cwd /work --command "gh repo fork owner/different --clone=false")" || status=$?
+	if [[ "$status" -eq 20 && "$output" == *github.account-mutation* ]]; then
+		pass "authorization does not permit a different fork target"
+	else
+		fail "authorization does not permit a different fork target" "status=${status} output=${output}"
+	fi
+
+	status=0
+	output="$(AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION="$authorization" python3 "$HELPER" check-command --cwd /different --command "$command_text")" || status=$?
+	if [[ "$status" -eq 20 && "$output" == *github.account-mutation* ]]; then
+		pass "authorization remains bound to the approved working directory"
+	else
+		fail "authorization remains bound to the approved working directory" "status=${status} output=${output}"
+	fi
+
+	status=0
+	output="$(AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION="$authorization" python3 "$HELPER" check-command --cwd /work --command "gh repo create owner/new-repo --public")" || status=$?
+	if [[ "$status" -eq 20 && "$output" == *github.account-mutation* ]]; then
+		pass "fork authorization does not grant another account write"
+	else
+		fail "fork authorization does not grant another account write" "status=${status} output=${output}"
+	fi
+
+	status=0
+	output="$(AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION="$authorization" python3 "$HELPER" check-command --cwd /work --command "$command_text && printf done")" || status=$?
+	if [[ "$status" -eq 20 && "$output" == *github.account-mutation* ]]; then
+		pass "authorization cannot widen a compound command"
+	else
+		fail "authorization cannot widen a compound command" "status=${status} output=${output}"
+	fi
+	return 0
+}
+
 test_static_decisions() {
 	assert_decision "allows unmatched command" "printf safe" allow command.default-allow 0
 	assert_decision "forbids recursive forced removal" "rm -rf ./build-output" forbid filesystem.rm-recursive-force 20 "/work"
@@ -344,6 +429,7 @@ PY
 test_policy_fail_closed() {
 	local output=""
 	local status=0
+	local missing_account_guard="${TEST_ROOT}/missing-account-guard.json"
 	output="$(python3 "$HELPER" check-command --policy "${TEST_ROOT}/missing.json" --command "printf safe")" || status=$?
 	if [[ "$status" -eq 21 && "$output" == *'"decision": "forbid"'* && "$output" == *'"rule_id": "policy.invalid"'* ]]; then
 		pass "missing required policy fails closed"
@@ -359,6 +445,29 @@ test_policy_fail_closed() {
 		pass "malformed required policy fails closed"
 	else
 		fail "malformed required policy fails closed" "status=${status} output=${output}"
+	fi
+
+	python3 - "$POLICY" "$missing_account_guard" <<'PY'
+import json
+import sys
+
+source, target = sys.argv[1:]
+with open(source, encoding="utf-8") as handle:
+    policy = json.load(handle)
+policy["dynamic_guards"] = [
+    guard
+    for guard in policy["dynamic_guards"]
+    if guard.get("kind") != "trusted_account_mutation"
+]
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump(policy, handle)
+PY
+	status=0
+	output="$(python3 "$HELPER" check-command --policy "$missing_account_guard" --command "printf safe")" || status=$?
+	if [[ "$status" -eq 21 && "$output" == *policy.invalid* && "$output" == *account-mutation* ]]; then
+		pass "missing account-mutation guard fails closed"
+	else
+		fail "missing account-mutation guard fails closed" "status=${status} output=${output}"
 	fi
 
 	status=0
@@ -385,6 +494,7 @@ main() {
 	test_validation
 	test_evaluate_invocations_compatibility
 	test_static_decisions
+	test_account_mutation_authorization
 	test_canonical_delegation
 	test_worker_network_policy
 	test_policy_fail_closed


### PR DESCRIPTION
## Summary

Default-deny protected GitHub repository creation commands unless an inherited authorization digest matches the exact command source, parsed argv, and working directory. Reject command-local authorization and GitHub target overrides, preserve read-only gh and ordinary Git behavior, and document the trusted operator flow.

## Files Changed

.agents/configs/command-policy.json, .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs, .agents/reference/gh-command-discipline.md, .agents/scripts/command-policy-helper.py, .agents/scripts/command_policy_config.py, .agents/scripts/command_policy_evaluation.py, .agents/scripts/command_policy_matchers.py, .agents/scripts/command_policy_runtime.py, .agents/scripts/command_policy_wrapper_options.py, .agents/scripts/tests/test-command-policy-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-command-policy-helper.sh (67 passed); node --test .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs (10 passed); npm test in .agents/plugins/opencode-aidevops (416 passed); bash .agents/scripts/linters-local.sh (passed)

Resolves #27994


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.136 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 3h 10m and 2,037,479 tokens on this with the user in an interactive session.