### PR TITLE
GH#28022: Show yellow OpenCode tab status while awaiting permission

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-status.mjs
@@ -25,6 +25,12 @@ export function createSessionTitleStatusHandler({
   setTerminalTitleStatus = defaultSetTerminalTitleStatus,
 } = {}) {
   let activeRootSessionID = "";
+  const pendingPermissionIDs = new Set();
+
+  const resetState = () => {
+    pendingPermissionIDs.clear();
+    resetTerminalTitleState();
+  };
 
   return async function sessionTitleStatusHandler(input) {
     if (isHeadless() || !isEnabled()) return;
@@ -35,16 +41,27 @@ export function createSessionTitleStatusHandler({
 
     if (event.type === "session.created" && isRootSessionInfo(info) && sessionID) {
       activeRootSessionID = sessionID;
-      resetTerminalTitleState();
+      resetState();
     } else if (event.type === "session.updated" && !activeRootSessionID && isRootSessionInfo(info) && sessionID) {
       activeRootSessionID = sessionID;
-      resetTerminalTitleState();
+      resetState();
     } else if (event.type === "session.deleted" && sessionID === activeRootSessionID) {
       activeRootSessionID = "";
-      resetTerminalTitleState();
+      resetState();
     } else if (event.type === "session.status" && sessionID === activeRootSessionID) {
       const status = event.properties?.status?.type;
-      if (status === "busy" || status === "retry" || status === "idle") setTerminalTitleStatus(status);
+      if (pendingPermissionIDs.size === 0 && (status === "busy" || status === "retry" || status === "idle")) {
+        setTerminalTitleStatus(status);
+      }
+    } else if (event.type === "permission.asked" && sessionID === activeRootSessionID) {
+      const requestID = event.properties?.id;
+      if (requestID) {
+        pendingPermissionIDs.add(requestID);
+        setTerminalTitleStatus("permission");
+      }
+    } else if (event.type === "permission.replied" && sessionID === activeRootSessionID) {
+      const wasPending = pendingPermissionIDs.delete(event.properties?.requestID);
+      if (wasPending && pendingPermissionIDs.size === 0) setTerminalTitleStatus("busy");
     }
   };
 }

--- a/.agents/plugins/opencode-aidevops/terminal-title.mjs
+++ b/.agents/plugins/opencode-aidevops/terminal-title.mjs
@@ -4,14 +4,15 @@
 import { closeSync, openSync, writeSync } from "node:fs";
 
 const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/g;
-const STATUS_PREFIX_RE = /^(?:\[(?:RUN|WAIT)\]|🟡|🟢)\s+/u;
+const STATUS_PREFIX_RE = /^(?:\[(?:RUN|WAIT)\]|⚪|🟡|🟢)\s+/u;
 
 export function sanitizeTerminalTitle(title) {
   return String(title || "").replace(CONTROL_CHAR_RE, " ").trim();
 }
 
 export function terminalTitleStatusLabel(status) {
-  if (status === "busy" || status === "retry") return "🟡";
+  if (status === "busy" || status === "retry") return "⚪";
+  if (status === "permission") return "🟡";
   if (status === "idle") return "🟢";
   return "";
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -15,8 +15,9 @@ function event(type, properties = {}) {
 }
 
 test("terminal titles map OpenCode status to compact idempotent emoji prefixes", () => {
-  assert.equal(withTerminalTitleStatus("Issue #123: improve tabs", "busy"), "🟡 Issue #123: improve tabs");
-  assert.equal(withTerminalTitleStatus("🟢 Issue #123: improve tabs", "retry"), "🟡 Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("Issue #123: improve tabs", "busy"), "⚪ Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("🟢 Issue #123: improve tabs", "retry"), "⚪ Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("⚪ Issue #123: improve tabs", "permission"), "🟡 Issue #123: improve tabs");
   assert.equal(withTerminalTitleStatus("🟡 Issue #123: improve tabs", "idle"), "🟢 Issue #123: improve tabs");
   assert.equal(withTerminalTitleStatus("[RUN] Issue #123: improve tabs", "idle"), "🟢 Issue #123: improve tabs");
   assert.equal(withTerminalTitleStatus("Issue #123: improve tabs", "unknown"), "Issue #123: improve tabs");
@@ -33,6 +34,8 @@ test("terminal title controller preserves status across later session title upda
   controller.setStatus("busy");
   controller.emit("Issue #123: renamed title");
   controller.setStatus("retry");
+  controller.setStatus("permission");
+  controller.setStatus("busy");
   controller.setStatus("idle");
   controller.setStatus("");
   controller.reset();
@@ -40,8 +43,10 @@ test("terminal title controller preserves status across later session title upda
 
   assert.deepEqual(writes, [
     "Issue #123: initial title",
-    "🟡 Issue #123: initial title",
+    "⚪ Issue #123: initial title",
+    "⚪ Issue #123: renamed title",
     "🟡 Issue #123: renamed title",
+    "⚪ Issue #123: renamed title",
     "🟢 Issue #123: renamed title",
     "Issue #123: renamed title",
   ]);
@@ -67,7 +72,12 @@ test("session status handler follows only the active interactive root session", 
   await handler(event("session.created", { info: { id: "root-1", title: "Root" } }));
   await handler(event("session.created", { info: { id: "child-1", parentID: "root-1", title: "Child" } }));
   await handler(event("session.status", { sessionID: "child-1", status: { type: "busy" } }));
+  await handler(event("permission.replied", { requestID: "unknown", sessionID: "root-1", reply: "once" }));
   await handler(event("session.status", { sessionID: "root-1", status: { type: "busy" } }));
+  await handler(event("permission.asked", { id: "permission-child", sessionID: "child-1" }));
+  await handler(event("permission.asked", { id: "permission-root", sessionID: "root-1" }));
+  await handler(event("session.status", { sessionID: "root-1", status: { type: "idle" } }));
+  await handler(event("permission.replied", { requestID: "permission-root", sessionID: "root-1", reply: "once" }));
   await handler(event("session.status", { sessionID: "root-1", status: { type: "retry" } }));
   await handler(event("session.status", { sessionID: "root-1", status: { type: "idle" } }));
   await handler(event("session.created", { info: { id: "root-2", title: "New root" } }));
@@ -75,7 +85,7 @@ test("session status handler follows only the active interactive root session", 
   await handler(event("session.status", { sessionID: "root-2", status: { type: "idle" } }));
 
   assert.equal(resets, 2);
-  assert.deepEqual(statuses, ["busy", "retry", "idle", "idle"]);
+  assert.deepEqual(statuses, ["busy", "permission", "busy", "retry", "idle", "idle"]);
 });
 
 test("session status handler supports hot-loaded root sessions and ignores headless sessions", async () => {

--- a/.agents/tools/terminal/terminal-title.md
+++ b/.agents/tools/terminal/terminal-title.md
@@ -24,7 +24,7 @@ tools:
 - **Script**: `~/.aidevops/agents/scripts/terminal-title-helper.sh`
 - **Auto-sync**: Runs via `pre-edit-check.sh` on task refs in linked worktrees
 - **Session sync**: For issue/PR work, OpenCode session titles should begin with `Issue #123:` or `PR #456:` plus a succinct description; branch auto-sync is only the fallback when no issue/PR context exists. Force branch sync via `session-rename_sync_branch`.
-- **Session status**: Interactive OpenCode root sessions prefix the terminal-only title with 🟡 for `busy`/`retry` and 🟢 for `idle`. Stored OpenCode session titles remain unchanged.
+- **Session status**: Interactive OpenCode root sessions prefix the terminal-only title with ⚪ for `busy`/`retry`, 🟡 while awaiting permission, and 🟢 for `idle`. Stored OpenCode session titles remain unchanged.
 
 **Commands**:
 
@@ -58,7 +58,7 @@ terminal-title-helper.sh detect            # Check terminal compatibility
 
 Uses OSC escape sequences (`printf '\033]0;%s\007' "title"`). **Full support**: Tabby, iTerm2, Windows Terminal, Kitty, Alacritty, WezTerm, Hyper, GNOME Terminal, Konsole, VS Code Terminal, xterm. **Partial**: Apple Terminal (basic), tmux/screen (requires config).
 
-The OpenCode plugin consumes `session.status` events only for the active interactive root session. Subagent and headless-worker events are ignored, and status remains applied when OpenCode later renames the session.
+The OpenCode plugin consumes `session.status`, `permission.asked`, and `permission.replied` events only for the active interactive root session. Subagent and headless-worker events are ignored, and status remains applied when OpenCode later renames the session.
 
 ## Shell Integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- use grey for running OpenCode tabs and yellow for permission waits
+
 ## [3.32.136] - 2026-07-16
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,7 +163,7 @@ AI DevOps is a developer-operations framework and OpenCode plugin. Its interface
 Design goals:
 
 - Keep operational state obvious: running, stopped, error, authenticated, last update, and command actions should scan quickly.
-- Use compact terminal-only status glyphs: 🟡 for active OpenCode turns and 🟢 when the root session is awaiting input. Retain the descriptive title and opt-out so colour is never the only essential status affordance; keep glyphs out of stored session titles so issue/PR prefixes remain first in search results.
+- Use compact terminal-only status glyphs: ⚪ for active OpenCode turns, 🟡 when a permission decision is required, and 🟢 when the root session is awaiting input. Retain the descriptive title and opt-out so colour is never the only essential status affordance; keep glyphs out of stored session titles so issue/PR prefixes remain first in search results.
 - Preserve developer trust with native system typography, code-friendly contrast, visible borders, and restrained motion.
 - Use compact density for dashboards and sidebars, but keep controls at least 44px high when touch use is plausible.
 - Prefer semantic tokens over one-off values so generated reports, OpenCode UI surfaces, and dashboard screens stay consistent.

--- a/README.md
+++ b/README.md
@@ -620,11 +620,11 @@ The agent contains the full recovery flow and symptom table. Free models work fi
 
 ### Terminal Tab Title Sync
 
-Your terminal tab/window title automatically shows `repo/branch` context when working in git repositories. Interactive OpenCode tabs add 🟡 while the root session is busy or retrying and 🟢 when it has finished and is awaiting input. This helps identify both the work context and session state across multiple terminal sessions.
+Your terminal tab/window title automatically shows `repo/branch` context when working in git repositories. Interactive OpenCode tabs add ⚪ while the root session is busy or retrying, 🟡 while it is awaiting permission, and 🟢 when it has finished and is awaiting input. This helps identify both the work context and session state across multiple terminal sessions.
 
 **Supported terminals:** [Tabby](https://tabby.sh/), [cmux](https://cmux.dev/), [iTerm2](https://iterm2.com/), [Kitty](https://sw.kovidgoyal.net/kitty/), [Alacritty](https://alacritty.org/), [WezTerm](https://wezfurlong.org/wezterm/), [Hyper](https://hyper.is/), and most xterm-compatible terminals.
 
-**How it works:** The `pre-edit-check.sh` script's primary role is enforcing git workflow protection (blocking edits on main/master branches). As a secondary, non-blocking action, it updates the terminal title via escape sequences. The OpenCode plugin listens for root-session `busy`, `retry`, and `idle` events and updates the same title without changing the stored OpenCode session name. No configuration is needed when dynamic terminal titles are enabled.
+**How it works:** The `pre-edit-check.sh` script's primary role is enforcing git workflow protection (blocking edits on main/master branches). As a secondary, non-blocking action, it updates the terminal title via escape sequences. The OpenCode plugin listens for root-session status and permission events and updates the same title without changing the stored OpenCode session name. No configuration is needed when dynamic terminal titles are enabled.
 
 **Example format:** `{repo}/{branch-type}/{description}`
 


### PR DESCRIPTION
## Summary

Map running/retrying to a grey circle, consume OpenCode permission asked/replied events for a persistent yellow permission-wait state, and retain green idle status with root/headless filtering.

## Files Changed

.agents/plugins/opencode-aidevops/session-title-status.mjs, .agents/plugins/opencode-aidevops/terminal-title.mjs, .agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs, .agents/tools/terminal/terminal-title.md, CHANGELOG.md, DESIGN.md, README.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 415 OpenCode plugin tests pass; targeted Node tests, Biome, Markdown lint, local repository lint, and a PTY OSC transition through grey-yellow-grey-green pass.

Resolves #28022


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.136 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 31m and 179,178 tokens on this with the user in an interactive session.