### PR TITLE
GH#28012: default empty objective arrays safely in brief

### DIFF
--- a/todo/tasks/t18134-brief.md
+++ b/todo/tasks/t18134-brief.md
@@ -69,7 +69,7 @@ Leaf task: title the implementation PR `t18134: ...` and use `Resolves #27803`.
 
 ```bash
 # Safe selected shape: two JSON documents enter jq through stdin.
-objective_input=$(printf '%s\n%s\n' "$issues_json" "$objective_prs" |
+objective_input=$(printf '%s\n%s\n' "${issues_json:-[]}" "${objective_prs:-[]}" |
 	jq -sc --arg merged "$oimp_lookup" \
 	'{issues: .[0], prs: .[1], merged_lookup: $merged}') || objective_input=""
 ```


### PR DESCRIPTION
## Summary

Update the t18134 implementation brief so empty or unset issue and PR payloads default to valid JSON arrays before jq slurps them.

## Files Changed

todo/tasks/t18134-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 todo/tasks/t18134-brief.md; git diff --check; jq 1.7 empty-input behavior reproduced

Resolves #28012


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 49,628 tokens on this as a headless worker.