### PR TITLE
GH#28013: avoid duplicate update prerequisite warnings

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -1045,9 +1045,6 @@ main() {
 		if _is_auto_update_active; then
 			echo "AUTO_UPDATE_ENABLED"
 		fi
-		local gh_slurp_notice
-		gh_slurp_notice=$(_check_gh_slurp_prerequisite)
-		[[ -n "$gh_slurp_notice" ]] && echo "$gh_slurp_notice"
 		version_str="aidevops v$current"
 	fi
 

--- a/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
+++ b/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
@@ -116,31 +116,20 @@ test_supported_gh_has_no_warning() {
 }
 
 test_update_available_preserves_full_session_status() {
-	setup_fake_tools "gh version 2.51.0 (2024-05-29)" "1.0.1"
-	local output=""
-	local cache_file="$HOME/.aidevops/cache/session-greeting.txt"
-	output=$(OPENCODE=1 bash "$UPDATE_CHECK" --interactive 2>/dev/null || true)
-	if [[ "$output" == *"UPDATE_AVAILABLE|1.0.0|1.0.1|OpenCode"* ]] &&
-		[[ "$output" == *"aidevops v1.0.0 running in OpenCode"* ]] &&
-		[[ -s "$cache_file" ]] &&
-		grep -qF "aidevops v1.0.0 running in OpenCode" "$cache_file"; then
-		print_result "update available preserves normal session status and cache" 0
-	else
-		print_result "update available preserves normal session status and cache" 1 "output='${output}', cache='${cache_file}'"
-	fi
-	return 0
-}
-
-test_update_available_warns_once_for_old_gh() {
 	setup_fake_tools "gh version 2.45.0 (2025-07-18 Ubuntu 2.45.0-1ubuntu0.3)" "1.0.1"
 	local output=""
+	local cache_file="$HOME/.aidevops/cache/session-greeting.txt"
 	local warning_count=0
 	output=$(OPENCODE=1 bash "$UPDATE_CHECK" --interactive 2>/dev/null || true)
 	warning_count=$(printf '%s\n' "$output" | grep -cF "[WARN] GitHub CLI prerequisite:" || true)
-	if [[ "$warning_count" -eq 1 ]]; then
-		print_result "update available emits the old gh warning once" 0
+	if [[ "$output" == *"UPDATE_AVAILABLE|1.0.0|1.0.1|OpenCode"* ]] &&
+		[[ "$output" == *"aidevops v1.0.0 running in OpenCode"* ]] &&
+		[[ "$warning_count" -eq 1 ]] &&
+		[[ -s "$cache_file" ]] &&
+		grep -qF "aidevops v1.0.0 running in OpenCode" "$cache_file"; then
+		print_result "update available preserves session status and warns once" 0
 	else
-		print_result "update available emits the old gh warning once" 1 "count=${warning_count}, output='${output}'"
+		print_result "update available preserves session status and warns once" 1 "count=${warning_count}, output='${output}', cache='${cache_file}'"
 	fi
 	return 0
 }
@@ -204,7 +193,6 @@ test_setup_fake_tools_removes_previous_root
 test_old_gh_warns_in_update_check
 test_supported_gh_has_no_warning
 test_update_available_preserves_full_session_status
-test_update_available_warns_once_for_old_gh
 test_cache_write_propagates_output_failure
 test_cache_write_propagates_move_failure
 

--- a/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
+++ b/.agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh
@@ -131,6 +131,20 @@ test_update_available_preserves_full_session_status() {
 	return 0
 }
 
+test_update_available_warns_once_for_old_gh() {
+	setup_fake_tools "gh version 2.45.0 (2025-07-18 Ubuntu 2.45.0-1ubuntu0.3)" "1.0.1"
+	local output=""
+	local warning_count=0
+	output=$(OPENCODE=1 bash "$UPDATE_CHECK" --interactive 2>/dev/null || true)
+	warning_count=$(printf '%s\n' "$output" | grep -cF "[WARN] GitHub CLI prerequisite:" || true)
+	if [[ "$warning_count" -eq 1 ]]; then
+		print_result "update available emits the old gh warning once" 0
+	else
+		print_result "update available emits the old gh warning once" 1 "count=${warning_count}, output='${output}'"
+	fi
+	return 0
+}
+
 test_cache_write_propagates_output_failure() {
 	local cache_dir=""
 	local status=0
@@ -190,6 +204,7 @@ test_setup_fake_tools_removes_previous_root
 test_old_gh_warns_in_update_check
 test_supported_gh_has_no_warning
 test_update_available_preserves_full_session_status
+test_update_available_warns_once_for_old_gh
 test_cache_write_propagates_output_failure
 test_cache_write_propagates_move_failure
 


### PR DESCRIPTION
## Summary

Removed the update-available path's duplicate gh prerequisite emission and added regression coverage proving old gh warnings appear exactly once; confirmed the temporary-root cleanup was already fixed on the default branch.

## Files Changed

.agents/scripts/aidevops-update-check.sh, .agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/aidevops-update-check.sh .agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh; bash .agents/scripts/tests/test-update-check-gh-slurp-prerequisite.sh (7 tests, 0 failed)

Resolves #28013


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 54,562 tokens on this as a headless worker.