### PR TITLE
t18148: security: reap cancelled subagents before returning

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -44,10 +44,15 @@ import { installPluginConsoleRouter } from "./plugin-console.mjs";
 import { createSubagentEffortHooks, loadTierReasoningPolicies } from "./subagent-effort.mjs";
 import { createSessionContinuationGuard } from "./session-continuation-guard.mjs";
 import { createPermissionBroker } from "./permission-broker.mjs";
+import { createSubagentCancellationReceipt } from "./subagent-cancellation-receipt.mjs";
 
 // Existing modules
 import { createTools } from "./tools.mjs";
-import { initObservability, handleEvent } from "./observability.mjs";
+import {
+  initObservability,
+  handleEvent,
+  recordSubagentCancellationReceipt,
+} from "./observability.mjs";
 import { createSessionStartGreetingGate, createTtsrHooks } from "./ttsr.mjs";
 import { createPoolAuthHook, createPoolTool, initPoolAuth, getAccounts } from "./oauth-pool.mjs";
 import { createProviderAuthHook } from "./provider-auth.mjs";
@@ -257,6 +262,10 @@ export async function AidevopsPlugin({ directory, client }) {
   const shouldInjectGreeting = createSessionStartGreetingGate(client, isHeadless);
   const permissionBroker = createPermissionBroker({ client, isHeadless });
   const compactionContinuation = createCompactionAutoContinueGuard(client, { qualityLog });
+  const cancellationReceipt = createSubagentCancellationReceipt(client, {
+    qualityLog,
+    recordReceipt: recordSubagentCancellationReceipt,
+  });
 
   // TTSR hooks
   const {
@@ -376,9 +385,13 @@ export async function AidevopsPlugin({ directory, client }) {
     // Quality hooks
     "tool.execute.before": async (input, output) => {
       permissionBroker.recordToolCall(input, output);
+      cancellationReceipt.beforeTool(input, output);
       return toolExecuteBefore(input, output);
     },
-    "tool.execute.after": toolExecuteAfter,
+    "tool.execute.after": async (input, output) => {
+      await cancellationReceipt.afterTool(input, output);
+      return toolExecuteAfter(input, output);
+    },
 
     // Shell environment
     "shell.env": shellEnvHook,
@@ -395,6 +408,7 @@ export async function AidevopsPlugin({ directory, client }) {
       await Promise.all([
         handleEvent(input),
         Promise.resolve(compactionContinuation.handleEvent(input)),
+        Promise.resolve(cancellationReceipt.handleEvent(input)),
         permissionBroker.handleEvent(input).catch((err) => debugEventError("permission broker", err)),
         sessionTitleStatusHandler(input).catch((err) => debugEventError("title status handler", err)),
         sessionTitleSuffixHandler(input).catch((err) => debugEventError("title suffix handler", err)),

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -935,6 +935,31 @@ export function recordToolCall(input, output, intent, durationMs) {
   projectRuntimeEvent(runtimeEnvelope);
 }
 
+/** Persist a bounded cancellation receipt without making termination depend on telemetry. */
+export function recordSubagentCancellationReceipt(receipt, context = {}) {
+  const envelope = appendRuntimeEvent({
+    eventType: "subagent.cancellation.receipt",
+    subjectId: context.childSessionID || receipt?.child || "unknown-child",
+    sessionId: context.parentSessionID || null,
+    correlationId: context.parentSessionID || context.childSessionID || "subagent-cancellation",
+    payload: {
+      classification: "subagent_cancellation",
+      observation: JSON.stringify({
+        complete: Boolean(receipt?.complete),
+        ledger: receipt?.ledger || [],
+        reaped: Boolean(receipt?.reaped),
+        termination: receipt?.termination || "unconfirmed",
+        truncated: Boolean(receipt?.truncated),
+      }),
+      reason: (receipt?.incomplete_reasons || []).join(",") || "confirmed",
+      status: receipt?.termination || "unconfirmed",
+      success: Boolean(receipt?.complete),
+    },
+  });
+  if (envelope) projectRuntimeEvent(envelope);
+  return envelope;
+}
+
 /**
  * Get the database path for external tools (e.g., observability-helper.sh).
  * @returns {string}

--- a/.agents/plugins/opencode-aidevops/subagent-cancellation-ledger.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-cancellation-ledger.mjs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { createHash } from "node:crypto";
+import { toolOutcomeFailed } from "./session-continuation-guard.mjs";
+import { classifySideEffect, safeToolName } from "./subagent-side-effect-classifier.mjs";
+import { eventSessionID } from "./subagent-lifecycle-tracker.mjs";
+
+const MAX_SESSION_STATES = 64;
+
+function capMap(map, maximum = MAX_SESSION_STATES) {
+  while (map.size > maximum) map.delete(map.keys().next().value);
+}
+
+export function shortSessionHash(value) {
+  return createHash("sha256").update(String(value || "unknown")).digest("hex").slice(0, 12);
+}
+
+export class SubagentCancellationLedger {
+  constructor(maxEntries, qualityLog, lifecycle) {
+    this.maxEntries = maxEntries;
+    this.qualityLog = qualityLog;
+    this.lifecycle = lifecycle;
+    this.activity = new Map();
+    this.sequence = 0;
+    this.trackingFailed = false;
+  }
+
+  safeLog(level, message) {
+    try {
+      this.qualityLog?.(level, message);
+    } catch {
+      this.trackingFailed = true;
+    }
+  }
+
+  sessionActivity(sessionID) {
+    if (!this.activity.has(sessionID)) {
+      if (this.activity.size >= MAX_SESSION_STATES) this.trackingFailed = true;
+      this.activity.set(sessionID, { events: [], inflight: new Map(), keys: new Set(), truncated: false });
+      capMap(this.activity);
+    }
+    return this.activity.get(sessionID);
+  }
+
+  addLedgerEvent(sessionID, callID, effect, status) {
+    if (!sessionID || !effect) return;
+    const state = this.sessionActivity(sessionID);
+    const call = `sha256:${shortSessionHash(callID)}`;
+    const key = `${call}:${effect.kind}:${effect.operation}:${status}`;
+    if (state.keys.has(key)) return;
+    state.keys.add(key);
+    if (state.events.length >= this.maxEntries) {
+      state.truncated = true;
+    } else {
+      state.events.push({ call, kind: effect.kind, operation: effect.operation, status, tool: effect.tool });
+    }
+  }
+
+  beforeTool(input, output) {
+    const tool = safeToolName(input?.tool);
+    const callID = String(input?.callID || `event-${++this.sequence}`);
+    const sessionID = String(input?.sessionID || "");
+    if (tool === "task" || tool === "mcp_task") {
+      this.lifecycle.beforeTask(callID, sessionID);
+    } else {
+      const effect = classifySideEffect(tool, output?.args || input?.args || {});
+      if (effect && sessionID) {
+        const state = this.sessionActivity(sessionID);
+        state.inflight.set(callID, effect);
+        this.addLedgerEvent(sessionID, callID, effect, "attempted");
+      }
+    }
+  }
+
+  afterSideEffect(input, output) {
+    const sessionID = String(input?.sessionID || "");
+    const callID = String(input?.callID || "");
+    const state = this.activity.get(sessionID);
+    const effect = state?.inflight.get(callID);
+    if (effect) {
+      state.inflight.delete(callID);
+      this.addLedgerEvent(sessionID, callID, effect, toolOutcomeFailed(output) ? "failed" : "completed");
+    }
+  }
+
+  observeRuntimeToolPart(part) {
+    const sessionID = String(part?.sessionID || "");
+    const callID = String(part?.callID || "");
+    const status = String(part?.state?.status || "").toLowerCase();
+    if (!sessionID || !callID || part?.type !== "tool") return;
+    if (["pending", "running"].includes(status)) {
+      this.beforeTool({ tool: part.tool, sessionID, callID }, { args: part.state?.input || {} });
+    } else if (["completed", "error", "failed", "aborted", "cancelled", "canceled"].includes(status)) {
+      this.afterSideEffect({ tool: part.tool, sessionID, callID }, { status, error: part.state?.error });
+    }
+  }
+
+  routeEvent(event) {
+    const sessionID = eventSessionID(event);
+    this.lifecycle.handleEvent(event);
+    if (["message.part.updated", "message.part.delta"].includes(event.type)) {
+      this.observeRuntimeToolPart(event.properties?.part);
+    } else if (event.type === "file.edited") {
+      this.addLedgerEvent(sessionID, event?.id || `file-event-${++this.sequence}`, {
+        kind: "file", operation: "write", tool: "runtime-event",
+      }, "completed");
+    }
+  }
+
+  handleEvent(input) {
+    try {
+      this.routeEvent(input?.event || input || {});
+    } catch (error) {
+      this.trackingFailed = true;
+      this.safeLog("WARN", `[subagent-cancellation] lifecycle event tracking failed: ${error?.name || "Error"}`);
+    }
+  }
+
+  ledgerFor(childID) {
+    const state = this.activity.get(childID) || { events: [], inflight: new Map(), truncated: false };
+    const ledger = [...state.events];
+    for (const [callID, effect] of state.inflight) {
+      if (ledger.length >= this.maxEntries) break;
+      ledger.push({
+        call: `sha256:${shortSessionHash(callID)}`,
+        kind: effect.kind,
+        operation: effect.operation,
+        status: "unknown",
+        tool: effect.tool,
+      });
+    }
+    return {
+      ledger,
+      truncated: state.truncated || state.events.length + state.inflight.size > this.maxEntries,
+      unknown: state.inflight.size > 0,
+    };
+  }
+}

--- a/.agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs
@@ -134,7 +134,7 @@ class SubagentCancellationReceipt {
   appendReceipt(output, receipt) {
     const bounded = boundedReceipt(receipt);
     output.output = `${String(output.output || "").trim()}\n\n[AIDevOps cancellation receipt]\n${bounded.json}`.trim();
-    output.metadata = { ...(output.metadata || {}), aidevopsCancellationReceipt: bounded.receipt };
+    output.metadata = { ...output.metadata, aidevopsCancellationReceipt: bounded.receipt };
     this.ledger.safeLog(
       bounded.receipt.complete ? "INFO" : "WARN",
       `[subagent-cancellation] child ${bounded.receipt.child} termination=${bounded.receipt.termination} receipt=${bounded.receipt.complete ? "complete" : "incomplete"}`,

--- a/.agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { SubagentCancellationLedger, shortSessionHash } from "./subagent-cancellation-ledger.mjs";
+import { SubagentLifecycleTracker } from "./subagent-lifecycle-tracker.mjs";
+import { classifySideEffect, safeToolName } from "./subagent-side-effect-classifier.mjs";
+
+export { classifySideEffect };
+export const MAX_CANCELLATION_LEDGER_ENTRIES = 24;
+export const MAX_CANCELLATION_RECEIPT_BYTES = 8 * 1024;
+
+function taskWasCancelled(output) {
+  const status = String(output?.metadata?.status || output?.status || "").toLowerCase();
+  return ["aborted", "cancelled", "canceled"].includes(status)
+    || /\b(?:abort(?:ed)?|cancel(?:led|ed)?)\b/i.test(`${output?.title || ""} ${output?.output || ""}`);
+}
+
+function responseError(response) {
+  return response?.error || response?.data?.error || null;
+}
+
+function boundedReceipt(receipt) {
+  const bounded = { ...receipt, ledger: [...receipt.ledger] };
+  let json = JSON.stringify(bounded);
+  while (Buffer.byteLength(json, "utf8") > MAX_CANCELLATION_RECEIPT_BYTES && bounded.ledger.length > 0) {
+    bounded.ledger.pop();
+    bounded.truncated = true;
+    bounded.complete = false;
+    if (!bounded.incomplete_reasons.includes("receipt_size_limit")) {
+      bounded.incomplete_reasons.push("receipt_size_limit");
+    }
+    json = JSON.stringify(bounded);
+  }
+  return { receipt: bounded, json };
+}
+
+class SubagentCancellationReceipt {
+  constructor(client, options) {
+    this.client = client;
+    this.maxWaitMs = options.maxWaitMs ?? 3000;
+    this.pollMs = options.pollMs ?? 25;
+    this.sleep = options.sleep || ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+    this.recordReceipt = options.recordReceipt;
+    this.lifecycle = new SubagentLifecycleTracker();
+    this.ledger = new SubagentCancellationLedger(
+      options.maxEntries || MAX_CANCELLATION_LEDGER_ENTRIES,
+      options.qualityLog,
+      this.lifecycle,
+    );
+  }
+
+  async terminateAndConfirm(childID) {
+    const result = { abortRequested: false, evidence: "", reason: "child_identity_missing" };
+    if (childID && typeof this.client?.session?.abort === "function") {
+      result.reason = "abort_api_failed";
+      try {
+        const response = await this.client.session.abort({ path: { id: childID } });
+        if (!responseError(response)) {
+          result.abortRequested = true;
+          result.reason = "termination_unconfirmed";
+          const deadline = Date.now() + this.maxWaitMs;
+          result.evidence = this.lifecycle.terminalEvidence(childID);
+          while (!result.evidence && Date.now() < deadline) {
+            await this.sleep(this.pollMs);
+            result.evidence = this.lifecycle.terminalEvidence(childID);
+          }
+          if (result.evidence) result.reason = "";
+        }
+      } catch {
+        result.reason = "abort_api_failed";
+      }
+    } else if (childID) {
+      result.reason = "abort_api_unavailable";
+      result.evidence = this.lifecycle.terminalEvidence(childID);
+    }
+    return result;
+  }
+
+  incompleteReasons(termination, observedSession, ledgerState) {
+    const reasons = [];
+    if (!termination.abortRequested) reasons.push(termination.reason || "abort_not_requested");
+    if (!termination.evidence) reasons.push("termination_unconfirmed");
+    if (!observedSession) reasons.push("lifecycle_events_missing");
+    if (ledgerState.unknown) reasons.push("side_effect_outcome_unknown");
+    if (ledgerState.truncated) reasons.push("ledger_truncated");
+    if (this.ledger.trackingFailed || this.lifecycle.trackingFailed) reasons.push("event_tracking_failed");
+    return [...new Set(reasons)];
+  }
+
+  buildReceipt(identity, termination) {
+    const observedSession = this.lifecycle.observedSession(identity.childID);
+    const ledgerState = this.ledger.ledgerFor(identity.childID);
+    if ((!identity.childID || !observedSession) && ledgerState.ledger.length === 0) {
+      ledgerState.ledger.push({
+        call: `sha256:${shortSessionHash(identity.callID)}`,
+        kind: "subagent",
+        operation: "activity",
+        status: "unknown",
+        tool: "task",
+      });
+    }
+    const incompleteReasons = this.incompleteReasons(termination, observedSession, ledgerState);
+    return {
+      version: 1,
+      child: `sha256:${shortSessionHash(identity.childID)}`,
+      complete: incompleteReasons.length === 0,
+      incomplete_reasons: incompleteReasons,
+      ledger: ledgerState.ledger.slice(0, MAX_CANCELLATION_LEDGER_ENTRIES),
+      reaped: Boolean(termination.abortRequested && termination.evidence),
+      telemetry: "pending",
+      termination: termination.evidence ? "confirmed" : "unconfirmed",
+      termination_evidence: termination.evidence || "none",
+      truncated: ledgerState.truncated,
+    };
+  }
+
+  persistReceipt(receipt, input, childID) {
+    let recorded = false;
+    try {
+      recorded = Boolean(this.recordReceipt?.(receipt, {
+        childSessionID: childID,
+        parentSessionID: String(input?.sessionID || ""),
+      }));
+    } catch {
+      recorded = false;
+    }
+    receipt.telemetry = recorded ? "recorded" : "unavailable";
+    if (!recorded) {
+      receipt.complete = false;
+      receipt.incomplete_reasons.push("telemetry_unavailable");
+    }
+  }
+
+  appendReceipt(output, receipt) {
+    const bounded = boundedReceipt(receipt);
+    output.output = `${String(output.output || "").trim()}\n\n[AIDevOps cancellation receipt]\n${bounded.json}`.trim();
+    output.metadata = { ...(output.metadata || {}), aidevopsCancellationReceipt: bounded.receipt };
+    this.ledger.safeLog(
+      bounded.receipt.complete ? "INFO" : "WARN",
+      `[subagent-cancellation] child ${bounded.receipt.child} termination=${bounded.receipt.termination} receipt=${bounded.receipt.complete ? "complete" : "incomplete"}`,
+    );
+    return bounded.receipt;
+  }
+
+  async cancelledTaskReceipt(input, output) {
+    const identity = this.lifecycle.takeChildIdentity(input, output);
+    const termination = await this.terminateAndConfirm(identity.childID);
+    const receipt = this.buildReceipt(identity, termination);
+    this.persistReceipt(receipt, input, identity.childID);
+    return this.appendReceipt(output, receipt);
+  }
+
+  async afterTool(input, output) {
+    const tool = safeToolName(input?.tool);
+    let receipt = null;
+    if (tool === "task" || tool === "mcp_task") {
+      if (taskWasCancelled(output)) receipt = await this.cancelledTaskReceipt(input, output);
+      else this.lifecycle.takeChildIdentity(input, output);
+    } else {
+      this.ledger.afterSideEffect(input, output);
+    }
+    return receipt;
+  }
+}
+
+/** Delay a cancelled Task result until child termination is confirmed. */
+export function createSubagentCancellationReceipt(client, options = {}) {
+  const handler = new SubagentCancellationReceipt(client, options);
+  return {
+    afterTool: handler.afterTool.bind(handler),
+    beforeTool: handler.ledger.beforeTool.bind(handler.ledger),
+    handleEvent: handler.ledger.handleEvent.bind(handler.ledger),
+  };
+}

--- a/.agents/plugins/opencode-aidevops/subagent-lifecycle-tracker.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-lifecycle-tracker.mjs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const MAX_SESSION_STATES = 64;
+const TERMINAL_SESSION_STATES = new Set([
+  "aborted", "cancelled", "canceled", "completed", "deleted", "end_turn", "error", "idle", "stop",
+]);
+
+function capMap(map, maximum = MAX_SESSION_STATES) {
+  while (map.size > maximum) map.delete(map.keys().next().value);
+}
+
+export function eventSessionID(event) {
+  const candidates = [
+    event?.properties?.sessionID,
+    event?.properties?.sessionId,
+    event?.properties?.info?.id,
+    event?.properties?.part?.sessionID,
+  ];
+  return String(candidates.find(Boolean) || "");
+}
+
+export class SubagentLifecycleTracker {
+  constructor() {
+    this.sessions = new Map();
+    this.taskCalls = new Map();
+    this.sequence = 0;
+    this.trackingFailed = false;
+  }
+
+  beforeTask(callID, parentID) {
+    this.taskCalls.set(callID, { parentID, startSequence: ++this.sequence });
+    capMap(this.taskCalls, MAX_SESSION_STATES * 2);
+  }
+
+  rememberSession(info) {
+    if (!info?.id) return;
+    const previous = this.sessions.get(info.id) || {};
+    this.sessions.set(info.id, {
+      ...previous,
+      observed: true,
+      parentID: info.parentID || previous.parentID || "",
+      sequence: previous.sequence || ++this.sequence,
+    });
+    capMap(this.sessions);
+  }
+
+  rememberStatus(sessionID, status) {
+    if (!sessionID) return;
+    const previous = this.sessions.get(sessionID) || { observed: false, parentID: "", sequence: ++this.sequence };
+    this.sessions.set(sessionID, { ...previous, status: String(status || "").toLowerCase() });
+    capMap(this.sessions);
+  }
+
+  routeEvent(event) {
+    const sessionID = eventSessionID(event);
+    if (["session.created", "session.updated"].includes(event.type)) {
+      this.rememberSession(event.properties?.info);
+    } else if (event.type === "session.status") {
+      this.rememberStatus(sessionID, event.properties?.status?.type);
+    } else if (event.type === "session.idle") {
+      this.rememberStatus(sessionID, "idle");
+    } else if (event.type === "session.error") {
+      this.rememberStatus(sessionID, "error");
+    } else if (event.type === "session.deleted") {
+      this.rememberStatus(sessionID, "deleted");
+    } else if (event.type === "message.updated") {
+      const message = event.properties?.info;
+      if (message?.role === "assistant" && message?.finish) this.rememberStatus(message.sessionID, message.finish);
+    }
+  }
+
+  handleEvent(event) {
+    try {
+      this.routeEvent(event);
+    } catch {
+      this.trackingFailed = true;
+    }
+  }
+
+  takeChildIdentity(input, output) {
+    const callID = String(input?.callID || "");
+    const taskCall = this.taskCalls.get(callID);
+    this.taskCalls.delete(callID);
+    const metadata = output?.metadata || {};
+    const explicit = String(metadata.sessionId || metadata.sessionID || metadata.session_id || "");
+    const parentID = String(input?.sessionID || taskCall?.parentID || "");
+    let identity = { childID: "", reason: "child_identity_missing" };
+    if (explicit) {
+      const known = this.sessions.get(explicit);
+      identity = known?.parentID && known.parentID !== parentID
+        ? { childID: "", reason: "child_parent_mismatch" }
+        : { childID: explicit, reason: "metadata" };
+    } else {
+      const candidates = [...this.sessions.entries()]
+        .filter(([, state]) => state.parentID === parentID && state.sequence >= (taskCall?.startSequence || 0))
+        .sort((left, right) => right[1].sequence - left[1].sequence);
+      if (candidates.length > 0) identity = { childID: candidates[0][0], reason: "lifecycle" };
+    }
+    return { ...identity, callID };
+  }
+
+  terminalEvidence(childID) {
+    const status = this.sessions.get(childID)?.status || "";
+    return TERMINAL_SESSION_STATES.has(status) ? status : "";
+  }
+
+  observedSession(childID) {
+    return Boolean(this.sessions.get(childID)?.observed);
+  }
+}

--- a/.agents/plugins/opencode-aidevops/subagent-side-effect-classifier.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-side-effect-classifier.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const COMMAND_RULES = [
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?gh\s+repo\s+fork\b/, "github", "fork"],
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?gh\s+repo\s+(?:create|delete|archive|rename|edit)\b/, "github", "repository"],
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?gh\s+issue\s+(?:create|edit|close|reopen|comment|delete|transfer|pin|unpin|lock|unlock)\b/, "github", "issue"],
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?gh\s+pr\s+(?:create|edit|close|reopen|merge|comment|review|ready)\b/, "github", "pull_request"],
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?git\s+worktree\s+(?:add|move|remove|prune|repair)\b/, "git", "worktree"],
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?git\s+push\b/, "git", "push"],
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?git\s+commit\b/, "git", "commit"],
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?git\s+remote\s+(?:add|remove|rename|set-url|set-head|prune|update)\b/, "git", "remote"],
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?git\s+(?:branch|tag|update-ref|symbolic-ref)\b/, "git", "ref"],
+  [/(?:^|[;&|]\s*)(?:[\w./-]+\/)?git\s+(?:add|rm|mv|merge|rebase|reset|revert|cherry-pick|stash|clean)\b/, "git", "state"],
+  [/\bgh\s+api\b[^\n]*(?:--method|-x)\s+(?:post|put|patch|delete)\b/, "external", "write"],
+  [/\bcurl\b[^\n]*(?:-x|--request)\s+(?:post|put|patch|delete)\b/, "external", "write"],
+  [/(?:^|[;&|]\s*)(?:rm|mv|cp|touch|mkdir|install|tee)\b/, "file", "write"],
+];
+
+const FILE_TOOLS = new Set(["write", "edit", "apply_patch", "write_file", "functions.apply_patch"]);
+const READ_ONLY_TOOLS = new Set(["read", "grep", "glob", "todowrite", "webfetch"]);
+const SHELL_TOOLS = new Set(["bash", "shell", "functions.bash"]);
+
+export function safeToolName(value) {
+  const name = String(value || "unknown").toLowerCase();
+  return /^[a-z0-9_.:-]+$/.test(name) ? name.slice(0, 48) : "redacted-tool";
+}
+
+function commandText(args) {
+  let command = "";
+  if (typeof args?.command === "string") command = args.command;
+  else if (Array.isArray(args?.argv)) command = args.argv.join(" ");
+  return command;
+}
+
+function commandClassification(command) {
+  const text = String(command || "").toLowerCase();
+  const rule = COMMAND_RULES.find(([pattern]) => pattern.test(text));
+  return rule ? { kind: rule[1], operation: rule[2] } : null;
+}
+
+/** Classify only observed mutation-shaped calls without retaining their arguments. */
+export function classifySideEffect(toolName, args = {}) {
+  const tool = safeToolName(toolName);
+  let effect = null;
+  if (FILE_TOOLS.has(tool)) {
+    effect = { kind: "file", operation: "write", tool };
+  } else if (READ_ONLY_TOOLS.has(tool)) {
+    effect = null;
+  } else if (SHELL_TOOLS.has(tool)) {
+    const classification = commandClassification(commandText(args));
+    effect = classification ? { ...classification, tool } : null;
+  } else if (/fork/.test(tool)) {
+    effect = { kind: "github", operation: "fork", tool };
+  } else if (/issue/.test(tool) && /create|edit|close|comment|write|update|delete/.test(tool)) {
+    effect = { kind: "github", operation: "issue", tool };
+  } else if (/(?:pull.?request|\bpr\b)/.test(tool) && /create|edit|close|merge|comment|review|write|update/.test(tool)) {
+    effect = { kind: "github", operation: "pull_request", tool };
+  } else if (/create|write|edit|update|delete|remove|send|post|publish|deploy|merge|push/.test(tool)) {
+    effect = { kind: "external", operation: "write", tool };
+  }
+  return effect;
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs
@@ -479,6 +479,14 @@ test("OpenCode observability emits runtime evidence without changing legacy tabl
       "reading a fixture",
       5,
     );
+    if (!observability.recordSubagentCancellationReceipt({
+      complete: true,
+      incomplete_reasons: [],
+      ledger: [{ kind: "git", operation: "push", status: "completed", tool: "bash" }],
+      reaped: true,
+      termination: "confirmed",
+      truncated: false,
+    }, { childSessionID: "session:child", parentSessionID: "session:1" })) process.exit(3);
     await new Promise((resolve) => setTimeout(resolve, 500));
     process.exit(0);
   `;
@@ -498,7 +506,7 @@ test("OpenCode observability emits runtime evidence without changing legacy tabl
           SELECT event_type FROM runtime_events ORDER BY id
         ));
     `], { encoding: "utf8" }).trim();
-    assert.equal(counts, "1|1|3|session.created,message.completed,tool.completed");
+    assert.equal(counts, "1|1|4|session.created,message.completed,tool.completed,subagent.cancellation.receipt");
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }

--- a/.agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  MAX_CANCELLATION_LEDGER_ENTRIES,
+  MAX_CANCELLATION_RECEIPT_BYTES,
+  classifySideEffect,
+  createSubagentCancellationReceipt,
+} from "../subagent-cancellation-receipt.mjs";
+
+function event(type, properties) {
+  return { event: { type, properties } };
+}
+
+function receiptFrom(output) {
+  const marker = "[AIDevOps cancellation receipt]\n";
+  return JSON.parse(output.output.slice(output.output.indexOf(marker) + marker.length));
+}
+
+describe("side-effect classification", () => {
+  const fixtures = [
+    ["Write", { filePath: "/private/file" }, "file", "write"],
+    ["functions.apply_patch", { patchText: "secret" }, "file", "write"],
+    ["bash", { command: "git worktree add /private/worktree branch" }, "git", "worktree"],
+    ["bash", { command: "git update-ref refs/heads/private deadbeef" }, "git", "ref"],
+    ["bash", { command: "git remote set-url origin private-url" }, "git", "remote"],
+    ["bash", { command: "git commit -m private" }, "git", "commit"],
+    ["bash", { command: "git push origin private" }, "git", "push"],
+    ["bash", { command: "gh repo fork owner/private" }, "github", "fork"],
+    ["bash", { command: "gh issue create --title private" }, "github", "issue"],
+    ["bash", { command: "gh pr create --title private" }, "github", "pull_request"],
+    ["bash", { command: "gh repo create private" }, "github", "repository"],
+    ["bash", { command: "curl --request POST https://private.invalid" }, "external", "write"],
+  ];
+
+  for (const [tool, args, kind, operation] of fixtures) {
+    test(`${kind}.${operation} from ${tool}`, () => {
+      assert.deepEqual(classifySideEffect(tool, args), {
+        kind,
+        operation,
+        tool: tool.toLowerCase(),
+      });
+    });
+  }
+
+  test("read-only and todo tools are not reported as side effects", () => {
+    assert.equal(classifySideEffect("Read", { filePath: "/private/file" }), null);
+    assert.equal(classifySideEffect("TodoWrite", { todos: [] }), null);
+    assert.equal(classifySideEffect("bash", { command: "git status --short" }), null);
+    assert.equal(classifySideEffect("bash", { command: "gh issue view 1" }), null);
+  });
+});
+
+test("cancelled tasks wait for child termination and return a status-classified redacted ledger", async () => {
+  let lifecycle;
+  let abortCalled = false;
+  const client = {
+    session: {
+      abort: async ({ path }) => {
+        assert.equal(path.id, "child-1");
+        abortCalled = true;
+        queueMicrotask(() => lifecycle.handleEvent(event("session.status", {
+          sessionID: "child-1",
+          status: { type: "idle" },
+        })));
+        return { data: true };
+      },
+    },
+  };
+  lifecycle = createSubagentCancellationReceipt(client, {
+    maxWaitMs: 100,
+    pollMs: 1,
+    recordReceipt: () => ({ recorded: true }),
+  });
+
+  lifecycle.beforeTool(
+    { tool: "task", sessionID: "parent-1", callID: "task-call" },
+    { args: { prompt: "private task" } },
+  );
+  lifecycle.handleEvent(event("session.created", {
+    info: { id: "child-1", parentID: "parent-1" },
+  }));
+
+  lifecycle.beforeTool(
+    { tool: "write", sessionID: "child-1", callID: "file-call" },
+    { args: { filePath: "/Users/private/repository/file.txt", content: "ghp_privatevalue" } },
+  );
+  await lifecycle.afterTool(
+    { tool: "write", sessionID: "child-1", callID: "file-call" },
+    { output: "written" },
+  );
+  lifecycle.beforeTool(
+    { tool: "bash", sessionID: "child-1", callID: "commit-call" },
+    { args: { command: "git commit -m private" } },
+  );
+  await lifecycle.afterTool(
+    { tool: "bash", sessionID: "child-1", callID: "commit-call" },
+    { status: "failed", output: "failed" },
+  );
+  lifecycle.beforeTool(
+    { tool: "bash", sessionID: "child-1", callID: "push-call" },
+    { args: { command: "git push https://user:secret@example.invalid/private/repo" } },
+  );
+  lifecycle.beforeTool(
+    { tool: "bash", sessionID: "child-1", callID: "fork-call" },
+    { args: { command: "gh repo fork owner/private --clone=false" } },
+  );
+  await lifecycle.afterTool(
+    { tool: "bash", sessionID: "child-1", callID: "fork-call" },
+    { output: "forked" },
+  );
+
+  const output = {
+    title: "Task aborted",
+    output: "The task was aborted",
+    metadata: { sessionId: "child-1", status: "aborted" },
+  };
+  const receipt = await lifecycle.afterTool(
+    { tool: "task", sessionID: "parent-1", callID: "task-call" },
+    output,
+  );
+
+  assert.equal(abortCalled, true);
+  assert.equal(receipt.termination, "confirmed");
+  assert.equal(receipt.reaped, true);
+  assert.equal(receipt.telemetry, "recorded");
+  assert.equal(receipt.complete, false);
+  assert.ok(receipt.incomplete_reasons.includes("side_effect_outcome_unknown"));
+  assert.deepEqual(new Set(receipt.ledger.map((entry) => entry.status)), new Set([
+    "attempted", "completed", "failed", "unknown",
+  ]));
+  assert.deepEqual(new Set(receipt.ledger.map((entry) => `${entry.kind}.${entry.operation}`)), new Set([
+    "file.write", "git.commit", "git.push", "github.fork",
+  ]));
+  assert.doesNotMatch(
+    JSON.stringify(receipt),
+    /Users|private|repository|ghp_|user:secret|owner\//i,
+  );
+  assert.deepEqual(output.metadata.aidevopsCancellationReceipt, receipt);
+});
+
+test("missing lifecycle events and telemetry produce an explicit incomplete unknown receipt", async () => {
+  let abortCalls = 0;
+  const lifecycle = createSubagentCancellationReceipt({
+    session: {
+      abort: async () => {
+        abortCalls += 1;
+        return { data: true };
+      },
+    },
+  }, {
+    maxWaitMs: 0,
+    recordReceipt: () => null,
+  });
+  lifecycle.beforeTool(
+    { tool: "task", sessionID: "parent-missing", callID: "task-missing" },
+    { args: {} },
+  );
+  const output = {
+    output: "Operation cancelled",
+    metadata: { sessionId: "child-missing", status: "cancelled" },
+  };
+
+  const receipt = await lifecycle.afterTool(
+    { tool: "task", sessionID: "parent-missing", callID: "task-missing" },
+    output,
+  );
+
+  assert.equal(abortCalls, 1);
+  assert.equal(receipt.termination, "unconfirmed");
+  assert.equal(receipt.reaped, false);
+  assert.equal(receipt.complete, false);
+  assert.ok(receipt.incomplete_reasons.includes("termination_unconfirmed"));
+  assert.ok(receipt.incomplete_reasons.includes("lifecycle_events_missing"));
+  assert.ok(receipt.incomplete_reasons.includes("telemetry_unavailable"));
+  assert.equal(receipt.ledger.length, 1);
+  assert.equal(receipt.ledger[0].status, "unknown");
+});
+
+test("the parent-facing receipt remains entry- and byte-bounded", async () => {
+  let lifecycle;
+  const client = {
+    session: {
+      abort: async () => {
+        lifecycle.handleEvent(event("session.status", {
+          sessionID: "child-bounded",
+          status: { type: "idle" },
+        }));
+        return { data: true };
+      },
+    },
+  };
+  lifecycle = createSubagentCancellationReceipt(client, {
+    maxWaitMs: 0,
+    recordReceipt: () => true,
+  });
+  lifecycle.beforeTool(
+    { tool: "task", sessionID: "parent-bounded", callID: "task-bounded" },
+    { args: {} },
+  );
+  lifecycle.handleEvent(event("session.created", {
+    info: { id: "child-bounded", parentID: "parent-bounded" },
+  }));
+  for (let index = 0; index < MAX_CANCELLATION_LEDGER_ENTRIES + 8; index += 1) {
+    const callID = `write-${index}`;
+    lifecycle.beforeTool(
+      { tool: "write", sessionID: "child-bounded", callID },
+      { args: { filePath: `/private/${index}` } },
+    );
+    await lifecycle.afterTool(
+      { tool: "write", sessionID: "child-bounded", callID },
+      { output: "written" },
+    );
+  }
+  const output = {
+    output: "Task aborted",
+    metadata: { sessionId: "child-bounded", status: "aborted" },
+  };
+  const receipt = await lifecycle.afterTool(
+    { tool: "task", sessionID: "parent-bounded", callID: "task-bounded" },
+    output,
+  );
+
+  assert.equal(receipt.ledger.length, MAX_CANCELLATION_LEDGER_ENTRIES);
+  assert.equal(receipt.truncated, true);
+  assert.equal(receipt.complete, false);
+  assert.ok(Buffer.byteLength(JSON.stringify(receipt), "utf8") <= MAX_CANCELLATION_RECEIPT_BYTES);
+  assert.deepEqual(receiptFrom(output), receipt);
+});


### PR DESCRIPTION
## Summary

Implementation for issue #27993.

## Files Changed

.agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/observability.mjs, .agents/plugins/opencode-aidevops/subagent-cancellation-ledger.mjs, .agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs, .agents/plugins/opencode-aidevops/subagent-lifecycle-tracker.mjs, .agents/plugins/opencode-aidevops/subagent-side-effect-classifier.mjs, .agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs, .agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #27993


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.137 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 4h 7m and 2,497,118 tokens on this with the user in an interactive session.