### PR TITLE
GH#28028: Show retrying OpenCode tabs in red

### DIFF
--- a/.agents/plugins/opencode-aidevops/terminal-title.mjs
+++ b/.agents/plugins/opencode-aidevops/terminal-title.mjs
@@ -4,14 +4,15 @@
 import { closeSync, openSync, writeSync } from "node:fs";
 
 const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/g;
-const STATUS_PREFIX_RE = /^(?:\[(?:RUN|WAIT)\]|⚪|🟡|🟢)\s+/u;
+const STATUS_PREFIX_RE = /^(?:\[(?:RUN|WAIT)\]|⚪|🔴|🟡|🟢)\s+/u;
 
 export function sanitizeTerminalTitle(title) {
   return String(title || "").replace(CONTROL_CHAR_RE, " ").trim();
 }
 
 export function terminalTitleStatusLabel(status) {
-  if (status === "busy" || status === "retry") return "⚪";
+  if (status === "busy") return "⚪";
+  if (status === "retry") return "🔴";
   if (status === "permission") return "🟡";
   if (status === "idle") return "🟢";
   return "";

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -16,7 +16,8 @@ function event(type, properties = {}) {
 
 test("terminal titles map OpenCode status to compact idempotent emoji prefixes", () => {
   assert.equal(withTerminalTitleStatus("Issue #123: improve tabs", "busy"), "⚪ Issue #123: improve tabs");
-  assert.equal(withTerminalTitleStatus("🟢 Issue #123: improve tabs", "retry"), "⚪ Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("🟢 Issue #123: improve tabs", "retry"), "🔴 Issue #123: improve tabs");
+  assert.equal(withTerminalTitleStatus("🔴 Issue #123: improve tabs", "busy"), "⚪ Issue #123: improve tabs");
   assert.equal(withTerminalTitleStatus("⚪ Issue #123: improve tabs", "permission"), "🟡 Issue #123: improve tabs");
   assert.equal(withTerminalTitleStatus("🟡 Issue #123: improve tabs", "idle"), "🟢 Issue #123: improve tabs");
   assert.equal(withTerminalTitleStatus("[RUN] Issue #123: improve tabs", "idle"), "🟢 Issue #123: improve tabs");
@@ -45,6 +46,7 @@ test("terminal title controller preserves status across later session title upda
     "Issue #123: initial title",
     "⚪ Issue #123: initial title",
     "⚪ Issue #123: renamed title",
+    "🔴 Issue #123: renamed title",
     "🟡 Issue #123: renamed title",
     "⚪ Issue #123: renamed title",
     "🟢 Issue #123: renamed title",

--- a/.agents/tools/terminal/terminal-title.md
+++ b/.agents/tools/terminal/terminal-title.md
@@ -24,7 +24,7 @@ tools:
 - **Script**: `~/.aidevops/agents/scripts/terminal-title-helper.sh`
 - **Auto-sync**: Runs via `pre-edit-check.sh` on task refs in linked worktrees
 - **Session sync**: For issue/PR work, OpenCode session titles should begin with `Issue #123:` or `PR #456:` plus a succinct description; branch auto-sync is only the fallback when no issue/PR context exists. Force branch sync via `session-rename_sync_branch`.
-- **Session status**: Interactive OpenCode root sessions prefix the terminal-only title with ⚪ for `busy`/`retry`, 🟡 while awaiting permission, and 🟢 for `idle`. Stored OpenCode session titles remain unchanged.
+- **Session status**: Interactive OpenCode root sessions prefix the terminal-only title with ⚪ for `busy`, 🔴 for `retry`, 🟡 while awaiting permission, and 🟢 for `idle`. Stored OpenCode session titles remain unchanged.
 
 **Commands**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- show red OpenCode tab status while retrying errors
+
 ## [3.32.137] - 2026-07-16
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,7 +163,7 @@ AI DevOps is a developer-operations framework and OpenCode plugin. Its interface
 Design goals:
 
 - Keep operational state obvious: running, stopped, error, authenticated, last update, and command actions should scan quickly.
-- Use compact terminal-only status glyphs: ⚪ for active OpenCode turns, 🟡 when a permission decision is required, and 🟢 when the root session is awaiting input. Retain the descriptive title and opt-out so colour is never the only essential status affordance; keep glyphs out of stored session titles so issue/PR prefixes remain first in search results.
+- Use compact terminal-only status glyphs: ⚪ for active OpenCode turns, 🔴 while retrying after errors, 🟡 when a permission decision is required, and 🟢 when the root session is awaiting input. Retain the descriptive title and opt-out so colour is never the only essential status affordance; keep glyphs out of stored session titles so issue/PR prefixes remain first in search results.
 - Preserve developer trust with native system typography, code-friendly contrast, visible borders, and restrained motion.
 - Use compact density for dashboards and sidebars, but keep controls at least 44px high when touch use is plausible.
 - Prefer semantic tokens over one-off values so generated reports, OpenCode UI surfaces, and dashboard screens stay consistent.

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ See `.agents/tools/git/opencode-github-security.md` for the full security docume
 - **[OpenCode Zen](https://opencode.ai/)** - Free tier of OpenCode with included models. Start working with AI straight away at no cost -- no API keys or subscriptions required.
 - **OpenAI GPT-5.5 / GPT-5.4 mini** - Recommended model pair for aidevops today. Use GPT-5.5 for complex reasoning and high-impact agent tiers; use GPT-5.4 mini for triage, routine implementation, and cost-efficient parallel workers.
 - **[Claude](https://claude.ai/)** (Anthropic) - Fully supported alternative provider. Claude models remain useful for fallback, cross-provider verification, and users with Claude Pro/Max OAuth access.
-- **[Tabby](https://tabby.sh/)** - Recommended terminal. Colour-coded Profiles per project/repo, **auto-syncs tab titles with git/session context and marks OpenCode turns as 🟡 or 🟢.**
+- **[Tabby](https://tabby.sh/)** - Recommended terminal. Colour-coded Profiles per project/repo, **auto-syncs tab titles with git/session context and marks OpenCode turns as ⚪, 🔴, 🟡, or 🟢.**
 - **[Zed](https://zed.dev/)** - Recommended editor. High-performance with AI integration (use with the OpenCode Agent Extension).
 
 ### Troubleshooting Auth
@@ -620,7 +620,7 @@ The agent contains the full recovery flow and symptom table. Free models work fi
 
 ### Terminal Tab Title Sync
 
-Your terminal tab/window title automatically shows `repo/branch` context when working in git repositories. Interactive OpenCode tabs add ⚪ while the root session is busy or retrying, 🟡 while it is awaiting permission, and 🟢 when it has finished and is awaiting input. This helps identify both the work context and session state across multiple terminal sessions.
+Your terminal tab/window title automatically shows `repo/branch` context when working in git repositories. Interactive OpenCode tabs add ⚪ while the root session is busy, 🔴 while it is retrying after an error, 🟡 while it is awaiting permission, and 🟢 when it has finished and is awaiting input. This helps identify both the work context and session state across multiple terminal sessions.
 
 **Supported terminals:** [Tabby](https://tabby.sh/), [cmux](https://cmux.dev/), [iTerm2](https://iterm2.com/), [Kitty](https://sw.kovidgoyal.net/kitty/), [Alacritty](https://alacritty.org/), [WezTerm](https://wezfurlong.org/wezterm/), [Hyper](https://hyper.is/), and most xterm-compatible terminals.
 


### PR DESCRIPTION
## Summary

Map OpenCode retry status to a red terminal-title glyph, preserve idempotent prefix replacement, and document the four-state status scheme.

## Files Changed

.agents/plugins/opencode-aidevops/terminal-title.mjs, .agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs, .agents/tools/terminal/terminal-title.md, CHANGELOG.md, DESIGN.md, README.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted status tests (5/5); full OpenCode plugin suite; Biome; Markdown lint; repository linters; PTY transition base → ⚪ → 🔴 → ⚪ → 🟢.

Resolves #28028


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.137 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 23m and 393,212 tokens on this with the user in an interactive session.