### PR TITLE
GH#28029: recover durable PR origin labels

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -1123,6 +1123,64 @@ _compose_pr_title() {
 
 # --- PR Creation ---
 
+# Verify that a PR has exactly one origin label and that it is the expected
+# immutable session origin. REST readback is deliberate: a successful mutation
+# exit code is not proof that GitHub reached the required postcondition.
+# Arguments: PR number, repository slug, expected origin name (without prefix).
+# Returns: 0=verified, 1=read failure, 2=missing/wrong/dual origin labels.
+_verify_pr_origin_label() {
+	local pr_number="$1"
+	local repo="$2"
+	local origin_name="$3"
+	local origin_labels=""
+	origin_labels=$(gh api "repos/${repo}/issues/${pr_number}" \
+		--jq '[.labels[].name | select(startswith("origin:"))]' 2>/dev/null) || return 1
+	if printf '%s' "$origin_labels" |
+		jq -e --arg expected "origin:${origin_name}" \
+			'length == 1 and .[0] == $expected' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 2
+}
+
+# Reconcile and verify the immutable origin postcondition while retaining a
+# bounded, non-secret failure classification for operators. The caller keeps
+# authority over origin_name; gh_create_pr remains the sole creation injector.
+# Arguments: PR number, repository slug, expected origin name (without prefix).
+_reconcile_pr_origin_label() {
+	local pr_number="$1"
+	local repo="$2"
+	local origin_name="$3"
+	local origin_error=""
+	origin_error=$(mktemp -t aidevops-pr-origin-error.XXXXXX) || return 1
+	if ! set_origin_label "$pr_number" "$repo" "$origin_name" --pr 2>"$origin_error"; then
+		local failure_kind="GitHub label write failed"
+		if grep -qiE 'permission|forbidden|Resource not accessible|HTTP 403' "$origin_error" 2>/dev/null; then
+			failure_kind="credential lacks PR label permission"
+		elif grep -qiE 'rate limit|rateLimitExceeded|HTTP 429' "$origin_error" 2>/dev/null; then
+			failure_kind="GitHub API rate limited the label write"
+		fi
+		rm -f "$origin_error"
+		print_error "Could not apply origin:${origin_name} to PR #${pr_number}: ${failure_kind}; retry commit-and-pr after GitHub writes recover"
+		return 1
+	fi
+	rm -f "$origin_error"
+
+	local verify_rc=0
+	_verify_pr_origin_label "$pr_number" "$repo" "$origin_name" || verify_rc=$?
+	case "$verify_rc" in
+	0) return 0 ;;
+	1)
+		print_error "Could not read back origin labels on PR #${pr_number}; retry commit-and-pr after GitHub reads recover"
+		return 1
+		;;
+	*)
+		print_error "PR #${pr_number} did not reach the exact origin:${origin_name} postcondition; retry commit-and-pr to reconcile missing, wrong, or dual origin labels"
+		return 1
+		;;
+	esac
+}
+
 # Create the PR and print the PR number to stdout.
 # Arguments: repo, pr_title, pr_body, origin_label; extra_labels passed as remaining args.
 # Returns 1 on failure.
@@ -1199,10 +1257,7 @@ _create_pr() {
 		return 1
 		;;
 	esac
-	if ! set_origin_label "$pr_number" "$repo" "$origin_name" --pr >/dev/null 2>&1; then
-		print_error "Could not verify origin:${origin_name} on PR #${pr_number}; retry commit-and-pr after GitHub writes recover"
-		return 1
-	fi
+	_reconcile_pr_origin_label "$pr_number" "$repo" "$origin_name" || return 1
 
 	print_success "PR #${pr_number} created: ${pr_url}"
 	printf '%s\n' "$pr_number"

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -742,18 +742,6 @@ fi
 #   set_origin_label 19638 owner/repo worker \
 #       --add-assignee "$worker_login"
 #######################################
-_set_origin_label_should_rest_fallback() {
-	local err_file="$1"
-	if [[ -f "$err_file" ]] && grep -qiE 'GraphQL: API rate limit( already)? exceeded|rateLimitExceeded' "$err_file" 2>/dev/null; then
-		return 0
-	fi
-	if command -v _rest_should_fallback >/dev/null 2>&1 && _rest_should_fallback; then
-		return 0
-	fi
-	return 1
-}
-
-#######################################
 # Apply origin label mutual exclusion via REST labels endpoints.
 # Args: $1=issue/pr num, $2=repo slug, $3=new origin, $4..=extra edit flags
 #######################################
@@ -853,8 +841,12 @@ set_origin_label() {
 	else
 		_gh_rc=$?
 	fi
-	if _set_origin_label_should_rest_fallback "$_err_file" && \
-		_set_origin_label_rest "$issue_num" "$repo_slug" "$new_origin" "${extra_flags[@]}"; then
+	# GH#28029: a GraphQL edit can create or expose the PR successfully but fail
+	# while applying labels. Always attempt the equivalent REST label mutation
+	# before returning failure; this is idempotent and preserves the origin mutex.
+	# The previous rate-limit-only fallback left durable PRs without provenance
+	# after non-rate-limit GraphQL failures.
+	if _set_origin_label_rest "$issue_num" "$repo_slug" "$new_origin" "${extra_flags[@]}"; then
 		rm -f "$_err_file"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
+++ b/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
@@ -111,6 +111,13 @@ _SOURCING_FOR_TEST=1
 # shellcheck disable=SC2312
 eval "$(sed -n '/^_create_pr() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
 
+# Extract origin reconciliation helpers used by _create_pr
+# shellcheck disable=SC2312
+eval "$(sed -n '/^_verify_pr_origin_label() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
+
+# shellcheck disable=SC2312
+eval "$(sed -n '/^_reconcile_pr_origin_label() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
+
 # Extract _post_merge_summary
 # shellcheck disable=SC2312
 eval "$(sed -n '/^_post_merge_summary() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper-commit.sh")"
@@ -252,6 +259,9 @@ export -f gh_pr_comment
 
 # Control variable: set to 1 to simulate post-create origin reconciliation failure.
 SET_ORIGIN_LABEL_FAIL=0
+# Control variables for the required readback postcondition.
+ORIGIN_READBACK_FAIL=0
+ORIGIN_READBACK_LABELS='["origin:worker"]'
 
 set_origin_label() {
 	local issue_num="${1:-}"
@@ -261,11 +271,28 @@ set_origin_label() {
 	printf 'set_origin_label num=%s repo=%s origin=%s flags=%s\n' \
 		"$issue_num" "$repo_slug" "$new_origin" "$*" >>"$STUB_LOG"
 	if [[ "$SET_ORIGIN_LABEL_FAIL" -eq 1 ]]; then
+		printf 'GraphQL: Resource not accessible by integration\n' >&2
 		return 1
 	fi
 	return 0
 }
 export -f set_origin_label
+
+_verify_pr_origin_label() {
+	local pr_number="${1:-}"
+	local repo_slug="${2:-}"
+	local expected_origin="${3:-}"
+	printf '_verify_pr_origin_label num=%s repo=%s origin=%s labels=%s\n' \
+		"$pr_number" "$repo_slug" "$expected_origin" "$ORIGIN_READBACK_LABELS" >>"$STUB_LOG"
+	[[ "$ORIGIN_READBACK_FAIL" -eq 0 ]] || return 1
+	if printf '%s' "$ORIGIN_READBACK_LABELS" |
+		jq -e --arg expected "origin:${expected_origin}" \
+			'length == 1 and .[0] == $expected' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 2
+}
+export -f _verify_pr_origin_label
 
 # =============================================================================
 # Test 1: _create_pr partial-success recovery
@@ -390,14 +417,45 @@ else
 		"expected non-zero exit; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
 fi
 
-if grep -q "Could not verify origin:worker on PR #889" "$STUB_LOG" 2>/dev/null; then
-	pass "origin reconciliation failure: error message emitted"
+if grep -q "credential lacks PR label permission" "$STUB_LOG" 2>/dev/null; then
+	pass "origin reconciliation failure: classified diagnostic emitted"
 else
-	fail "origin reconciliation failure: error message emitted" \
-		"expected verification failure in log; got: $(cat "$STUB_LOG" 2>/dev/null)"
+	fail "origin reconciliation failure: classified diagnostic emitted" \
+		"expected permission classification in log; got: $(cat "$STUB_LOG" 2>/dev/null)"
 fi
 
 SET_ORIGIN_LABEL_FAIL=0
+
+# =============================================================================
+# Test 3a.1: mutation success is not enough when readback lacks exact origin.
+# Expected: _create_pr fails closed for missing, wrong, or dual origin labels.
+# =============================================================================
+for readback_labels in '[]' '["origin:interactive"]' '["origin:worker","origin:interactive"]'; do
+	: >"$STUB_LOG"
+	ORIGIN_READBACK_LABELS="$readback_labels"
+	readback_rc=0
+	_create_pr "owner/repo" "t2767: test" "body text" "origin:worker" >/dev/null 2>&1 || readback_rc=$?
+	if [[ "$readback_rc" -ne 0 ]] && grep -q "did not reach the exact origin:worker postcondition" "$STUB_LOG" 2>/dev/null; then
+		pass "origin readback rejects non-exact postcondition: ${readback_labels}"
+	else
+		fail "origin readback rejects non-exact postcondition: ${readback_labels}" \
+			"rc=${readback_rc}; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+	fi
+done
+ORIGIN_READBACK_LABELS='["origin:worker"]'
+
+# Readback API failure must remain distinct from a label mismatch.
+: >"$STUB_LOG"
+ORIGIN_READBACK_FAIL=1
+readback_api_rc=0
+_create_pr "owner/repo" "t2767: test" "body text" "origin:worker" >/dev/null 2>&1 || readback_api_rc=$?
+if [[ "$readback_api_rc" -ne 0 ]] && grep -q "Could not read back origin labels" "$STUB_LOG" 2>/dev/null; then
+	pass "origin readback API failure: classified diagnostic emitted"
+else
+	fail "origin readback API failure: classified diagnostic emitted" \
+		"rc=${readback_api_rc}; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+ORIGIN_READBACK_FAIL=0
 
 # =============================================================================
 # Test 3b: _create_pr REST fallback logs do not pollute machine stdout

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -15,7 +15,7 @@
 # divergent values — full-loop-helper.sh's hand-rolled headless-env check
 # disagreed with detect_session_origin() in shared-gh-wrappers-session.sh).
 #
-# Three layers tested:
+# Four layers tested:
 #
 #   A. _gh_wrapper_args_have_origin_label — argv inspection helper used by
 #      the wrapper's defence-in-depth guard (Fix 3).
@@ -25,6 +25,8 @@
 #      longer passes its own --label "$origin_label" (Fix 2), and the upstream
 #      origin_label computation now uses canonical session_origin_label() so
 #      env-var divergence with detect_session_origin() is impossible (Fix 1).
+#   D. set_origin_label — any failed GraphQL edit attempts the equivalent REST
+#      mutex mutation before returning failure (GH#28029).
 
 set -uo pipefail
 
@@ -591,6 +593,32 @@ if [[ -f "$LOOP_HELPER" ]]; then
 		print_result "C3: full-loop-helper.sh has no legacy HEADLESS=1 hand-rolled check" 1 \
 			"legacy hand-rolled check still present"
 	fi
+fi
+
+# ---------------------------------------------------------------------------
+# Layer D: set_origin_label REST recovery after any GraphQL edit failure
+# ---------------------------------------------------------------------------
+
+ensure_origin_labels_exist() { return 0; }
+_rest_should_fallback() { return 1; }
+_gh_with_timeout() {
+	local operation="$1"
+	shift
+	printf '%s %s\n' "$operation" "$*" >>"$GH_RECORD_FILE"
+	if [[ "$*" == "gh pr edit "* ]]; then
+		printf 'GraphQL: Something went wrong while executing your query\n' >&2
+		return 1
+	fi
+	return 0
+}
+
+reset_recorder
+if set_origin_label 28029 owner/repo worker --pr >/dev/null 2>&1 &&
+	grep -q 'gh api -X POST /repos/owner/repo/issues/28029/labels' "$GH_RECORD_FILE"; then
+	print_result "D1: set_origin_label uses REST after non-rate-limit GraphQL failure" 0
+else
+	print_result "D1: set_origin_label uses REST after non-rate-limit GraphQL failure" 1 \
+		"calls: $(tr '\n' ' ' <"$GH_RECORD_FILE")"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Added REST fallback and exact readback verification for PR origin-label reconciliation after partial creation failures

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/shared-gh-wrappers.sh, .agents/scripts/tests/test-commit-and-pr-partial-success.sh, .agents/scripts/tests/test-origin-label-mutex-create.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck clean; 31 partial-success tests, 29 origin-mutex tests, and 9 fix-worker routing tests passed; changed-file linters passed

Resolves #28029


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.138 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 23m and 252,381 tokens on this with the user in an interactive session.