### PR TITLE
GH#28033: fix(opencode): make dry-run observational and restore Desktop DB isolation

### DIFF
--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -248,6 +248,15 @@ under `~/.aidevops/.agent-workspace/work/opencode-desktop/` before execing
 rows out of `~/.local/share/opencode/opencode.db` while preserving the normal
 Electron app support directory for window state and preferences.
 
+Desktop and TUI shards intentionally do not reuse each other's
+`XDG_DATA_HOME`. Older launcher versions wrote an
+`opencode-launcher/last-data-dir` marker; current launchers ignore that marker
+because directing independent Desktop and TUI processes to one SQLite WAL
+reintroduces the write contention that isolation prevents. Cross-client history
+continuity requires one `opencode serve` process to own the shard while each UI
+attaches as a client. Until aidevops supports that server-backed flow, history
+remains isolated per Desktop or TUI shard.
+
 CLI entry points:
 
 ```bash

--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -155,43 +155,6 @@ build_desktop_data_dir() {
     return 0
 }
 
-launcher_state_dir() {
-    printf '%s/opencode-launcher' "${AIDEVOPS_WORK_DIR:-${HOME}/.aidevops/.agent-workspace/work}"
-    return 0
-}
-
-last_data_dir_file() {
-    local state_dir
-    state_dir=$(launcher_state_dir)
-    printf '%s/last-data-dir' "${state_dir}"
-    return 0
-}
-
-remember_data_dir() {
-    local data_dir="$1"
-    local state_dir marker tmp_marker
-
-    [[ -n "${data_dir}" ]] || return 0
-    state_dir=$(launcher_state_dir)
-    marker=$(last_data_dir_file)
-    tmp_marker="${marker}.$$"
-    mkdir -p "${state_dir}" 2>/dev/null || return 0
-    printf '%s\n' "${data_dir}" >"${tmp_marker}" 2>/dev/null || return 0
-    mv "${tmp_marker}" "${marker}" 2>/dev/null || return 0
-    return 0
-}
-
-read_last_data_dir() {
-    local marker data_dir
-
-    marker=$(last_data_dir_file)
-    [[ -r "${marker}" ]] || return 1
-    IFS= read -r data_dir <"${marker}" || return 1
-    [[ -n "${data_dir}" && -d "${data_dir}/opencode" ]] || return 1
-    printf '%s' "${data_dir}"
-    return 0
-}
-
 xml_escape() {
     local value="$1"
     value=${value//&/\&amp;}
@@ -504,9 +467,6 @@ cmd_desktop_launch() {
     fi
     [[ -d "${launch_dir}" ]] || { print_error "Directory not found: ${launch_dir}"; return 1; }
 
-    if [[ -z "${data_dir}" && ${from_app} -eq 1 && ${launch_dir_set} -eq 0 && -z "${session_id}" ]]; then
-        data_dir=$(read_last_data_dir || true)
-    fi
     if [[ -z "${data_dir}" ]]; then
         if ((launch_dir_set == 1)); then
             data_dir=$(build_desktop_data_dir "${session_id}" "${launch_dir}")
@@ -514,10 +474,6 @@ cmd_desktop_launch() {
             data_dir=$(build_desktop_data_dir "${session_id}" "")
         fi
     fi
-    mkdir -p "${data_dir}/opencode" || return 1
-    copy_auth_json "${data_dir}" || true
-    prewarm_opencode_data_dir "${data_dir}"
-    remember_data_dir "${data_dir}"
 
     if ((dry_run == 1)); then
         printf 'cd %q && TMPDIR=%q TMP=%q TEMP=%q XDG_DATA_HOME=%q AIDEVOPS_OPENCODE_ISOLATED_DB=1 %q' "${launch_dir}" "${TMPDIR}" "${TMP}" "${TEMP}" "${data_dir}" "${desktop_binary}"
@@ -525,6 +481,10 @@ cmd_desktop_launch() {
         printf '\n'
         return 0
     fi
+
+    mkdir -p "${data_dir}/opencode" || return 1
+    copy_auth_json "${data_dir}" || true
+    prewarm_opencode_data_dir "${data_dir}"
 
     cd "${launch_dir}" || return 1
     export XDG_DATA_HOME="${data_dir}"
@@ -632,12 +592,6 @@ main() {
 
     local data_dir
     data_dir=$(build_session_data_dir "${session_id}")
-    mkdir -p "${data_dir}/opencode" || return 1
-    # Keep stdout/stderr clean before exec: OpenCode's TUI is sensitive to any
-    # pre-launch terminal output and can leave visible redraw artifacts.
-    copy_auth_json "${data_dir}" || true
-    prewarm_opencode_data_dir "${data_dir}"
-    remember_data_dir "${data_dir}"
 
     if ((dry_run == 1)); then
         printf 'cd %q && TMPDIR=%q TMP=%q TEMP=%q XDG_DATA_HOME=%q AIDEVOPS_OPENCODE_ISOLATED_DB=1 opencode' "${launch_dir}" "${TMPDIR}" "${TMP}" "${TEMP}" "${data_dir}"
@@ -645,6 +599,12 @@ main() {
         printf '\n'
         return 0
     fi
+
+    mkdir -p "${data_dir}/opencode" || return 1
+    # Keep stdout/stderr clean before exec: OpenCode's TUI is sensitive to any
+    # pre-launch terminal output and can leave visible redraw artifacts.
+    copy_auth_json "${data_dir}" || true
+    prewarm_opencode_data_dir "${data_dir}"
 
     cd "${launch_dir}" || return 1
     export XDG_DATA_HOME="${data_dir}"

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -48,9 +48,10 @@ SH
 }
 
 directory_is_empty() {
-    local directory="$1"
+    local directory="${1:-}"
     local candidate=""
 
+    [[ -n "${directory}" && -d "${directory}" ]] || return 1
     for candidate in "${directory}"/* "${directory}"/.[!.]* "${directory}"/..?*; do
         if [[ -e "${candidate}" || -L "${candidate}" ]]; then
             return 1

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -47,21 +47,39 @@ SH
     return 0
 }
 
+directory_is_empty() {
+    local directory="$1"
+    local candidate=""
+
+    for candidate in "${directory}"/* "${directory}"/.[!.]* "${directory}"/..?*; do
+        if [[ -e "${candidate}" || -L "${candidate}" ]]; then
+            return 1
+        fi
+    done
+    return 0
+}
+
 tmp_root="$(mktemp -d)"
 trap 'rm -rf "${tmp_root}"' EXIT
 fake_bin="${tmp_root}/bin"
 work_dir="${tmp_root}/work"
+tui_dry_run_work_dir="${tmp_root}/tui-dry-run-work"
+desktop_dry_run_work_dir="${tmp_root}/desktop-dry-run-work"
 launch_dir="${tmp_root}/repo"
 home_dir="${tmp_root}/home"
 fake_log="${tmp_root}/fake-opencode.log"
-mkdir -p "${work_dir}" "${launch_dir}" "${home_dir}/.local/share/opencode"
+mkdir -p "${work_dir}" "${tui_dry_run_work_dir}" "${desktop_dry_run_work_dir}" \
+    "${launch_dir}" "${home_dir}/.local/share/opencode"
 make_fake_opencode "${fake_bin}"
 printf '{"anthropic":{}}\n' >"${home_dir}/.local/share/opencode/auth.json"
 desktop_source="${tmp_root}/OpenCode.app/Contents/MacOS/OpenCode"
 mkdir -p "$(dirname "${desktop_source}")"
 cat >"${desktop_source}" <<'SH'
 #!/usr/bin/env bash
-printf 'desktop source launched\n'
+printf 'XDG_DATA_HOME=%s\n' "${XDG_DATA_HOME:-}"
+printf 'AIDEVOPS_OPENCODE_ISOLATED_DB=%s\n' "${AIDEVOPS_OPENCODE_ISOLATED_DB:-}"
+printf 'PWD=%s\n' "$PWD"
+printf 'ARGS=%s\n' "$*"
 SH
 chmod +x "${desktop_source}"
 
@@ -86,6 +104,7 @@ if [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]] \
     && [[ "${project_auth_count}" == "1" ]] \
     && [[ "${line_count}" == "2" ]] \
     && [[ "${prewarm_line}" == *"|db path" ]] \
+    && [[ ! -e "${work_dir}/opencode-launcher/last-data-dir" ]] \
     && [[ "${output}" != *"sqlite-migration"* ]]; then
     _pass "isolated launcher sets per-session data dir and copies auth"
 else
@@ -101,13 +120,26 @@ else
     _fail "explicit session-id output unexpected: ${output}"
 fi
 
-output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" XDG_DATA_HOME="${work_dir}/opencode-interactive/test-session" \
-    "${HELPER}" --dir "${launch_dir}" --session-id test-session --dry-run 2>&1)
+output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    XDG_DATA_HOME="${work_dir}/opencode-interactive/test-session" \
+    "${HELPER}" --dir "${launch_dir}" --session-id test-session -- --version 2>&1)
 if [[ "${output}" == *"XDG_DATA_HOME=${work_dir}/opencode-interactive/test-session"* ]] \
     && [[ "${output}" != *"identical"* ]]; then
     _pass "launcher skips auth copy when source and target match"
 else
     _fail "same auth copy guard output unexpected: ${output}"
+fi
+
+tui_dry_run_log="${tmp_root}/tui-dry-run-opencode.log"
+output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${tui_dry_run_work_dir}" \
+    FAKE_OPENCODE_LOG="${tui_dry_run_log}" \
+    "${HELPER}" --dir "${launch_dir}" --session-id dry-run-only --dry-run 2>&1)
+if [[ "${output}" == *"XDG_DATA_HOME=${tui_dry_run_work_dir}/opencode-interactive/dry-run-only"* ]] \
+    && directory_is_empty "${tui_dry_run_work_dir}" \
+    && [[ ! -e "${tui_dry_run_log}" ]]; then
+    _pass "TUI dry-run prints the command without writing launcher state"
+else
+    _fail "TUI dry-run mutated state or output an unexpected command: ${output}"
 fi
 
 output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
@@ -135,23 +167,66 @@ else
     _fail "desktop app wrapper install unexpected: ${output}"
 fi
 
-output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
-    "${HELPER}" desktop launch --from-app --source-binary "${desktop_source}" --dry-run 2>&1)
-if [[ "${output}" == *"XDG_DATA_HOME=${work_dir}/opencode-interactive/test-session"* ]] \
-    && [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]]; then
-    _pass "desktop app launch resumes last isolated data dir"
-else
-    _fail "desktop app launch did not reuse last data dir: ${output}"
-fi
+mkdir -p "${work_dir}/opencode-launcher"
+obsolete_marker="${work_dir}/opencode-launcher/last-data-dir"
+obsolete_data_dir="${work_dir}/opencode-interactive/test-session"
+printf '%s\n' "${obsolete_data_dir}" >"${obsolete_marker}"
 
 output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" desktop launch --from-app --source-binary "${desktop_source}" --dry-run 2>&1)
+obsolete_marker_value=$(<"${obsolete_marker}")
+if [[ "${output}" == *"XDG_DATA_HOME=${work_dir}/opencode-desktop/desktop-default"* ]] \
+    && [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]] \
+    && [[ "${obsolete_marker_value}" == "${obsolete_data_dir}" ]] \
+    && [[ ! -d "${work_dir}/opencode-desktop/desktop-default" ]]; then
+    _pass "desktop app ignores the obsolete cross-mode data-dir marker"
+else
+    _fail "desktop app launch reused or mutated obsolete cross-mode state: ${output}"
+fi
+
+desktop_dry_run_log="${tmp_root}/desktop-dry-run-opencode.log"
+output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${desktop_dry_run_work_dir}" \
+    FAKE_OPENCODE_LOG="${desktop_dry_run_log}" \
     "${HELPER}" desktop launch --source-binary "${desktop_source}" --dir "${launch_dir}" --dry-run 2>&1)
+if [[ "${output}" == *"XDG_DATA_HOME=${desktop_dry_run_work_dir}/opencode-desktop/desktop-project-repo-"* ]] \
+    && [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]] \
+    && [[ "${output}" == *"${desktop_source}"* ]] \
+    && directory_is_empty "${desktop_dry_run_work_dir}" \
+    && [[ ! -e "${desktop_dry_run_log}" ]]; then
+    _pass "desktop dry-run prints an isolated command without writing state"
+else
+    _fail "desktop dry-run mutated state or output an unexpected command: ${output}"
+fi
+
+rm -f "${fake_log}"
+output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    FAKE_OPENCODE_LOG="${fake_log}" \
+    "${HELPER}" desktop launch --source-binary "${desktop_source}" --dir "${launch_dir}" -- --version 2>&1)
+line_count=0
+prewarm_line=""
+desktop_auth_count=0
+while IFS= read -r line; do
+    line_count=$((line_count + 1))
+    if [[ ${line_count} -eq 1 ]]; then
+        prewarm_line="${line}"
+    fi
+done <"${fake_log}"
+for auth_file in "${work_dir}"/opencode-desktop/desktop-project-repo-*/opencode/auth.json; do
+    [[ -f "${auth_file}" ]] || continue
+    desktop_auth_count=$((desktop_auth_count + 1))
+done
+obsolete_marker_value=$(<"${obsolete_marker}")
 if [[ "${output}" == *"XDG_DATA_HOME=${work_dir}/opencode-desktop/desktop-project-repo-"* ]] \
     && [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]] \
-    && [[ "${output}" == *"${desktop_source}"* ]]; then
-    _pass "desktop launch dry-run uses isolated per-project data dir"
+    && [[ "${output}" == *"PWD=${launch_dir}"* ]] \
+    && [[ "${output}" == *"ARGS=--version"* ]] \
+    && [[ "${desktop_auth_count}" == "1" ]] \
+    && [[ "${line_count}" == "1" ]] \
+    && [[ "${prewarm_line}" == *"|db path" ]] \
+    && [[ "${obsolete_marker_value}" == "${obsolete_data_dir}" ]]; then
+    _pass "desktop real launch prewarms its isolated shard without updating cross-mode state"
 else
-    _fail "desktop launch dry-run output unexpected: ${output}"
+    _fail "desktop real launch output or state unexpected: ${output}"
 fi
 
 if ((fail_count > 0)); then


### PR DESCRIPTION
## Summary

Made TUI and Desktop dry-run output-only, removed the global last-data-dir bridge, preserved isolated launch behavior, and documented server-backed continuity.

## Files Changed

.agents/reference/opencode-maintenance.md, .agents/scripts/opencode-launcher-helper.sh, .agents/scripts/tests/test-opencode-launcher-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 9 focused launcher tests passed; ShellCheck passed for both modified shell files; changed-file repository lint passed; disposable TUI and Desktop runtime probes left their work roots empty.

Resolves #28033


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.138 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 25d 20h and 1,888,610 tokens on this with the user in an interactive session.