### PR TITLE
GH#28011: support older Git in workflow sync

### DIFF
--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -150,10 +150,15 @@ _info() {
 
 _is_linked_worktree() {
 	local _path="$1"
-	local _git_dir _common_dir
-	_git_dir=$(git -C "$_path" rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 1
-	_common_dir=$(git -C "$_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
-	[[ "$_git_dir" != "$_common_dir" ]]
+	local _git_dir _common_dir _path_abs
+	_git_dir=$(git -C "$_path" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+	_common_dir=$(git -C "$_path" rev-parse --git-common-dir 2>/dev/null) || return 1
+	if [[ "$_common_dir" != /* ]]; then
+		_path_abs=$(cd "$_path" && pwd -P) || return 1
+		_common_dir="${_path_abs}/${_common_dir}"
+	fi
+	[[ "$_git_dir" != "$_common_dir" ]] || return 1
+	return 0
 }
 
 _remote_default_ref() {
@@ -211,7 +216,8 @@ _prepare_apply_worktree() {
 		return 0
 	fi
 
-	local _base_dir="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"
+	local _base_dir="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME:+$HOME/Git/_worktrees}}"
+	[[ -n "$_base_dir" ]] || return 1
 	local _safe_name
 	_safe_name=$(printf '%s-%s' "$_slug" "$_branch" | sed 's|[^A-Za-z0-9._-]|-|g')
 	local _worktree_path="${_base_dir}/${_safe_name}"

--- a/.agents/scripts/tests/test-sync-workflows-helper.sh
+++ b/.agents/scripts/tests/test-sync-workflows-helper.sh
@@ -576,6 +576,18 @@ rm -rf "$TMPDIR_16"
 TMPDIR_17="$(mktemp -d)"
 _setup_fake_home "$TMPDIR_17"
 _setup_mock_gh "$TMPDIR_17"
+REAL_GIT_17=$(command -v git)
+cat >"$TMPDIR_17/bin/git" <<'EOF'
+#!/usr/bin/env bash
+for _arg in "$@"; do
+	if [[ "$_arg" == --path-format=* ]]; then
+		printf 'unsupported git option: %s\n' "$_arg" >&2
+		exit 129
+	fi
+done
+exec "${REAL_GIT:?}" "$@"
+EOF
+chmod +x "$TMPDIR_17/bin/git"
 BARE_17="$TMPDIR_17/bare.git"
 REPO_17="$TMPDIR_17/repos/canonical"
 LINKED_17="$TMPDIR_17/worktrees/caller-owned"
@@ -600,7 +612,8 @@ _write_repos_json "$TMPDIR_17" \
 	"{\"initialized_repos\":[{\"path\":\"$REPO_17\",\"slug\":\"owner/repo-caller-owned\"}]}"
 SYNC_BRANCH_17="chore/test-caller-owned"
 OUT_17=$(cd "$LINKED_17" && \
-	HOME="$TMPDIR_17" PATH="$TMPDIR_17/bin:$PATH" GH_CALL_LOG="$TMPDIR_17/gh-calls.log" \
+	HOME="$TMPDIR_17" PATH="$TMPDIR_17/bin:$PATH" REAL_GIT="$REAL_GIT_17" \
+	GH_CALL_LOG="$TMPDIR_17/gh-calls.log" \
 	AIDEVOPS_WORKTREE_BASE_DIR="$TMPDIR_17/framework-worktrees" \
 	bash "$HELPER" --apply --repo owner/repo-caller-owned --workflow issue-sync \
 		--branch "$SYNC_BRANCH_17" 2>&1)
@@ -622,6 +635,17 @@ else
 fi
 _assert_exit "GH#27980 linked-worktree apply exits 0" 0 "$EXIT_17"
 rm -rf "$TMPDIR_17"
+
+# ─── Test 18: GH#28011 — HOME fallback is nounset-safe and never root-based ─
+# shellcheck disable=SC2016 # These are intentional literal source-code assertions.
+if grep -qF '${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME:+$HOME/Git/_worktrees}}' "$HELPER" &&
+	grep -qF '[[ -n "$_base_dir" ]] || return 1' "$HELPER"; then
+	printf '%sPASS%s GH#28011 unset HOME cannot select a root-level worktree base\n' "$GREEN" "$NC"
+	((_PASS++))
+else
+	printf '%sFAIL%s GH#28011 HOME fallback is not nounset-safe\n' "$RED" "$NC"
+	((_FAIL++))
+fi
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 printf '\n'


### PR DESCRIPTION
## Summary

- Replace Git 2.31-only `--path-format` usage in `.agents/scripts/sync-workflows-helper.sh` with portable absolute git-dir/common-dir resolution.
- Fail safely when neither `AIDEVOPS_WORKTREE_BASE_DIR` nor `HOME` provides a worktree base.
- Extend `.agents/scripts/tests/test-sync-workflows-helper.sh` with an older-Git option rejection shim and HOME fallback ratchet.

Resolves #28011

## Verification

- `shellcheck .agents/scripts/sync-workflows-helper.sh .agents/scripts/tests/test-sync-workflows-helper.sh`
- `bash -n .agents/scripts/sync-workflows-helper.sh .agents/scripts/tests/test-sync-workflows-helper.sh`
- Focused integration suite delegated to CI because the local command-policy guard blocks its temporary canonical-repository fixture mutations.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 7m and 83,715 tokens on this as a headless worker.