### PR TITLE
GH#28010: harden workflow checkout path resolution

### DIFF
--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -481,6 +481,8 @@ _classify_workflow() {
 
 _expand_home_path() {
 	local _path="$1"
+	# Preserve ~/ when HOME is unavailable; stripping the tilde would turn the
+	# configured repository into an unrelated root-relative path.
 	if [[ "${_path#\~/}" != "$_path" && -n "${HOME:-}" ]]; then
 		_path="${HOME}${_path#\~}"
 	fi

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -270,10 +270,11 @@ _render_template_for_target() {
 		-e "s|${_default_repo_escaped}(/\.github/workflows/${_reusable_escaped})|${_repo_repl}\1|g" \
 		-e "s|^(      aidevops_ref:).*$|\1 ${_ref_repl}|" \
 		"$_template")
-	if [[ "$_repo" != "$_DEFAULT_WORKFLOW_REUSABLE_REPO" ]] && \
+	if [[ "$_repo" != "$_DEFAULT_WORKFLOW_REUSABLE_REPO" ]] &&
 		printf '%s\n' "$_rendered" | grep -qE '^      aidevops_ref:'; then
-		_rendered=$(printf '%s\n' "$_rendered" | sed -E \
-			"s|^(      aidevops_ref:.*)$|      aidevops_repository: ${_repo_repl}\n\1|"
+		_rendered=$(
+			printf '%s\n' "$_rendered" | sed -E \
+				"s|^(      aidevops_ref:.*)$|      aidevops_repository: ${_repo_repl}\n\1|"
 		)
 		_rendered=$(_inject_mirror_read_secret "$_rendered")
 	fi
@@ -435,7 +436,7 @@ _classify_workflow() {
 		# Helper-bearing callers must bind runtime helper provenance to the same
 		# repository/ref tuple as the reusable YAML. Missing or mismatched values
 		# are drift so sync-workflows can repair legacy callers safely.
-		if grep -qE '^      aidevops_ref:' "$_canon" && \
+		if grep -qE '^      aidevops_ref:' "$_canon" &&
 			! _caller_helper_provenance_matches "$_wf" "$_target_repo" "$_target_escaped"; then
 			printf 'DRIFTED/CALLER\n'
 			return 0
@@ -897,7 +898,7 @@ _resolve_row_checkout() {
 	local _filter_slug="$4"
 	local _source="local"
 	_path=$(_expand_home_path "$_path")
-	if [[ -n "${_CALLER_WORKTREE_ROOT:-}" && "$_slug" == "$_filter_slug" && \
+	if [[ -n "${_CALLER_WORKTREE_ROOT:-}" && "$_slug" == "$_filter_slug" &&
 		"$_local_only_flag" != "true" ]]; then
 		_path="$_CALLER_WORKTREE_ROOT"
 		_source="caller-worktree"

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -478,6 +478,26 @@ _classify_workflow() {
 
 # ─── Repo iteration ─────────────────────────────────────────────────────────
 
+_expand_home_path() {
+	local _path="$1"
+	if [[ "${_path#\~/}" != "$_path" && -n "${HOME:-}" ]]; then
+		_path="${HOME}${_path#\~}"
+	fi
+	printf '%s\n' "$_path"
+	return 0
+}
+
+_absolute_git_common_dir() {
+	local _repo="$1"
+	local _common_dir
+	_common_dir=$(git -C "$_repo" rev-parse --git-common-dir 2>/dev/null) || return 1
+	if [[ "$_common_dir" != /* ]]; then
+		_common_dir=$(cd "$_repo/$_common_dir" 2>/dev/null && pwd -P) || return 1
+	fi
+	printf '%s\n' "$_common_dir"
+	return 0
+}
+
 # _resolve_caller_worktree_root <slug>
 # Prefer an explicitly supplied or current caller-owned linked worktree when it
 # belongs to the registered repository. The common-dir comparison binds the
@@ -495,12 +515,12 @@ _resolve_caller_worktree_root() {
 		'.initialized_repos[]? | select(.slug == $s) | .path // empty' \
 		"$REPOS_JSON" 2>/dev/null | head -n 1)
 	[[ -n "$_registered" ]] || return 1
-	_registered="${_registered/#\~/$HOME}"
+	_registered=$(_expand_home_path "$_registered")
 
 	local _candidate_git_dir _candidate_common_dir _registered_common_dir
-	_candidate_git_dir=$(git -C "$_candidate" rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 1
-	_candidate_common_dir=$(git -C "$_candidate" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
-	_registered_common_dir=$(git -C "$_registered" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	_candidate_git_dir=$(git -C "$_candidate" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+	_candidate_common_dir=$(_absolute_git_common_dir "$_candidate") || return 1
+	_registered_common_dir=$(_absolute_git_common_dir "$_registered") || return 1
 	[[ "$_candidate_git_dir" != "$_candidate_common_dir" ]] || return 1
 	[[ "$_candidate_common_dir" == "$_registered_common_dir" ]] || return 1
 
@@ -876,7 +896,7 @@ _resolve_row_checkout() {
 	local _slug="$3"
 	local _filter_slug="$4"
 	local _source="local"
-	_path="${_path/#\~/$HOME}"
+	_path=$(_expand_home_path "$_path")
 	if [[ -n "${_CALLER_WORKTREE_ROOT:-}" && "$_slug" == "$_filter_slug" && \
 		"$_local_only_flag" != "true" ]]; then
 		_path="$_CALLER_WORKTREE_ROOT"

--- a/.agents/scripts/tests/test-check-workflows-helper.sh
+++ b/.agents/scripts/tests/test-check-workflows-helper.sh
@@ -22,6 +22,7 @@
 #  18. Unset HOME exits cleanly instead of raising an unbound-variable error
 #  19. Stale local checkout reports local evidence and upstream divergence
 #  20. Repository-scoped checks prefer a matching caller-owned linked worktree
+#      without relying on Git 2.31's --path-format option
 #
 # Strategy: Each scenario writes a temporary repos.json + temporary repo trees
 # under a per-test TMPDIR, points HOME at it, and invokes the helper. No
@@ -527,6 +528,7 @@ rm -rf "$TMPDIR_19"
 # must classify that worktree rather than the registered canonical checkout.
 TMPDIR_20="$(mktemp -d)"
 _setup_fake_home "$TMPDIR_20"
+REAL_GIT_20=$(command -v git)
 BARE_20="$TMPDIR_20/remote.git"
 REPO_20="$TMPDIR_20/repos/canonical"
 LINKED_20="$TMPDIR_20/worktrees/caller-owned"
@@ -550,14 +552,23 @@ git -C "$LINKED_20" commit -q -m "linked worktree drift"
 printf 'unrelated canonical dirt\n' >"$REPO_20/unrelated.txt"
 _write_repos_json "$TMPDIR_20" \
 	"$(jq -n --arg path "$REPO_20" '{initialized_repos: [{slug: "x/caller-owned", path: $path, local_only: false}]}')"
-json_row=$(cd "$LINKED_20" && HOME="$TMPDIR_20" bash "$HELPER" \
+mkdir -p "$TMPDIR_20/bin"
+cat >"$TMPDIR_20/bin/git" <<EOF
+#!/usr/bin/env bash
+for arg in "\$@"; do
+	[[ "\$arg" == --path-format=* ]] && exit 129
+done
+exec "$REAL_GIT_20" "\$@"
+EOF
+chmod +x "$TMPDIR_20/bin/git"
+json_row=$(cd "$LINKED_20" && HOME="$TMPDIR_20" PATH="$TMPDIR_20/bin:$PATH" bash "$HELPER" \
 	--json --repo x/caller-owned --workflow issue-sync 2>/dev/null || true)
 LINKED_ROOT_20=$(git -C "$LINKED_20" rev-parse --show-toplevel)
 if [[ "$(printf '%s\n' "$json_row" | jq -r '.classification')" == "DRIFTED/CALLER" ]] &&
 	[[ "$(printf '%s\n' "$json_row" | jq -r '.path')" == "$LINKED_ROOT_20" ]] &&
 	[[ "$(printf '%s\n' "$json_row" | jq -r '.evidence.source')" == "caller-worktree" ]] &&
 	[[ -f "$REPO_20/unrelated.txt" ]]; then
-	_pass "repository-scoped check → caller-owned linked-worktree evidence"
+	_pass "repository-scoped check → Git 2.25-compatible linked-worktree evidence"
 else
 	_fail "repository-scoped check → caller-owned linked-worktree evidence" "json: $json_row"
 fi


### PR DESCRIPTION
## Summary

- handle registered `~` paths safely when `HOME` is unset
- resolve Git common directories without Git 2.31-only `--path-format`
- cover linked-worktree detection with a Git 2.25 compatibility guard

## Runtime Testing

- **Risk level:** Low (shell helper compatibility fix)
- **Verification:** 22 check-workflows fixture tests passed; ShellCheck, shfmt, secretlint, portability, complexity, and changed-file local lint gates passed

## Decisions

Unexpandable tilde paths remain unchanged when `HOME` is absent instead of becoming root-relative. Relative common-directory output is canonicalized with `pwd -P`.

Resolves #28010

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 7m and 114,056 tokens on this as a headless worker.
