### PR TITLE
GH#28038: feat(localdev): add owner-safe saved-profile server reuse

### DIFF
--- a/.agents/scripts/localdev-helper-serve.sh
+++ b/.agents/scripts/localdev-helper-serve.sh
@@ -278,11 +278,7 @@ _serve_remove_stale_launch_lock() {
 		return 1
 	fi
 	# Do not reclaim a just-created directory before its owner writes the PID.
-	if [[ "$(uname -s)" == "Darwin" ]]; then
-		modified_at="$(stat -f '%m' "$lock_dir" 2>/dev/null)" || return 1
-	else
-		modified_at="$(stat -c '%Y' "$lock_dir" 2>/dev/null)" || return 1
-	fi
+	modified_at="$(_file_mtime_epoch "$lock_dir")" || return 1
 	now="$(date +%s)"
 	[[ "$modified_at" =~ ^[0-9]+$ ]] || return 1
 	age=$((now - modified_at))

--- a/.agents/scripts/localdev-helper-serve.sh
+++ b/.agents/scripts/localdev-helper-serve.sh
@@ -1,0 +1,445 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Idempotent, owner-safe development server launcher for saved profiles.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ -n "${_LOCALDEV_SERVE_LIB_LOADED:-}" ]] && return 0
+_LOCALDEV_SERVE_LIB_LOADED=1
+
+SERVE_CHILD_PID=""
+SERVE_EXISTING=0
+SERVE_LAUNCH_LOCK=""
+SERVE_LOCK_HELD=0
+
+_serve_usage() {
+	print_error "Usage: localdev-helper.sh serve --port <port> [options] -- <command...>"
+	print_info "Options: --name, --root, --lock, --health-url, --startup-timeout, --no-host"
+	return 1
+}
+
+_serve_parse_value() {
+	local flag="$1"
+	local value="${2:-}"
+	if [[ -z "$value" ]]; then
+		print_error "$flag requires a value"
+		return 1
+	fi
+	printf '%s\n' "$value"
+	return 0
+}
+
+_serve_parse_args() {
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--name)
+			name="$(_serve_parse_value "$arg" "${2:-}")" || return 1
+			shift 2
+			;;
+		--port)
+			port="$(_serve_parse_value "$arg" "${2:-}")" || return 1
+			shift 2
+			;;
+		--root)
+			root="$(_serve_parse_value "$arg" "${2:-}")" || return 1
+			shift 2
+			;;
+		--lock)
+			stale_lock="$(_serve_parse_value "$arg" "${2:-}")" || return 1
+			shift 2
+			;;
+		--health-url)
+			health_url="$(_serve_parse_value "$arg" "${2:-}")" || return 1
+			shift 2
+			;;
+		--startup-timeout)
+			startup_timeout="$(_serve_parse_value "$arg" "${2:-}")" || return 1
+			shift 2
+			;;
+		--no-host)
+			set_host=0
+			shift
+			;;
+		--)
+			shift
+			cmd_args+=("$@")
+			break
+			;;
+		-*)
+			print_error "Unknown serve option: $arg"
+			return 1
+			;;
+		*)
+			cmd_args+=("$@")
+			break
+			;;
+		esac
+	done
+	return 0
+}
+
+_serve_validate_args() {
+	local port="$1"
+	local startup_timeout="$2"
+	local command_count="$3"
+	local health_url="$4"
+	if [[ ! "$port" =~ ^[0-9]+$ ]] || [[ "$port" -lt 1 ]] || [[ "$port" -gt 65535 ]]; then
+		print_error "Invalid or missing --port: ${port:-<empty>}"
+		return 1
+	fi
+	if [[ ! "$startup_timeout" =~ ^[0-9]+$ ]] || [[ "$startup_timeout" -lt 1 ]] || [[ "$startup_timeout" -gt 900 ]]; then
+		print_error "Invalid --startup-timeout: $startup_timeout (expected 1-900)"
+		return 1
+	fi
+	if [[ "$command_count" -eq 0 ]]; then
+		_serve_usage
+		return 1
+	fi
+	if ! command -v lsof >/dev/null 2>&1; then
+		print_error "lsof is required for owner-safe port inspection"
+		return 1
+	fi
+	if [[ -n "$health_url" ]] && ! command -v curl >/dev/null 2>&1; then
+		print_error "curl is required when --health-url is supplied"
+		return 1
+	fi
+	if [[ -n "$health_url" ]]; then
+		case "$health_url" in
+		"http://127.0.0.1:${port}" | "http://127.0.0.1:${port}/"* | \
+			"http://localhost:${port}" | "http://localhost:${port}/"* | \
+			"http://[::1]:${port}" | "http://[::1]:${port}/"*) ;;
+		*)
+			print_error "--health-url must use this port on localhost: $port"
+			return 1
+			;;
+		esac
+	fi
+	return 0
+}
+
+_serve_canonical_root() {
+	local root="$1"
+	if [[ ! -d "$root" ]]; then
+		print_error "Project root does not exist: $root"
+		return 1
+	fi
+	local canonical_root=""
+	canonical_root="$(cd "$root" && pwd -P)" || return 1
+	if [[ "$canonical_root" == "/" ]]; then
+		print_error "Project root cannot be the filesystem root"
+		return 1
+	fi
+	printf '%s\n' "$canonical_root"
+	return 0
+}
+
+_serve_listener_pids() {
+	local port="$1"
+	local output=""
+	local status=0
+	output="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null)" || status=$?
+	if [[ "$status" -ne 0 && "$status" -ne 1 ]]; then
+		print_error "Unable to inspect port $port (lsof exit $status)"
+		return 1
+	fi
+	[[ -n "$output" ]] && printf '%s\n' "$output"
+	return 0
+}
+
+_serve_process_cwd() {
+	local pid="$1"
+	local process_cwd=""
+	process_cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/{sub(/^n/, ""); print; exit}')"
+	if [[ -n "$process_cwd" ]]; then
+		(cd "$process_cwd" 2>/dev/null && pwd -P) || true
+	fi
+	return 0
+}
+
+_serve_validate_owners() {
+	local listener_pids="$1"
+	local root="$2"
+	local pid=""
+	local owner_cwd=""
+	while IFS= read -r pid; do
+		[[ -z "$pid" ]] && continue
+		owner_cwd="$(_serve_process_cwd "$pid")"
+		case "$owner_cwd" in
+		"$root" | "$root"/*) ;;
+		*)
+			print_error "Port owner PID $pid is outside project root: ${owner_cwd:-unknown}"
+			return 1
+			;;
+		esac
+	done <<<"$listener_pids"
+	return 0
+}
+
+_serve_health_ready() {
+	local health_url="$1"
+	[[ -z "$health_url" ]] && return 0
+	curl --fail --silent --output /dev/null --noproxy '*' --connect-timeout 2 --max-time 5 "$health_url"
+	return $?
+}
+
+_serve_check_existing() {
+	local port="$1"
+	local root="$2"
+	local health_url="$3"
+	local allow_unhealthy="${4:-0}"
+	local announce="${5:-1}"
+	local listener_pids=""
+	SERVE_EXISTING=0
+	listener_pids="$(_serve_listener_pids "$port")" || return 1
+	[[ -z "$listener_pids" ]] && return 0
+	_serve_validate_owners "$listener_pids" "$root" || return 1
+	if ! _serve_health_ready "$health_url"; then
+		[[ "$allow_unhealthy" -eq 1 ]] && return 0
+		print_error "Owned listener on port $port is unhealthy; stop it explicitly before restarting"
+		return 1
+	fi
+	SERVE_EXISTING=1
+	[[ "$announce" -eq 1 ]] && print_success "Reusing $name on port $port"
+	return 0
+}
+
+_serve_resolve_stale_lock() {
+	local root="$1"
+	local stale_lock="$2"
+	local candidate=""
+	local parent=""
+	local relative=""
+	local ancestor=""
+	local next_ancestor=""
+	local canonical_ancestor=""
+	[[ -z "$stale_lock" ]] && return 0
+	case "$stale_lock" in
+	/*)
+		case "$stale_lock" in
+		"$root"/*)
+			candidate="$stale_lock"
+			relative="${stale_lock#"$root"/}"
+			;;
+		*)
+			print_error "Refusing stale-lock path outside project root: $stale_lock"
+			return 1
+			;;
+		esac
+		;;
+	*)
+		candidate="$root/$stale_lock"
+		relative="$stale_lock"
+		;;
+	esac
+	case "/$relative/" in
+	*/../*)
+		print_error "Refusing stale-lock path outside project root: $stale_lock"
+		return 1
+		;;
+	esac
+	parent="$(dirname "$candidate")"
+	ancestor="$parent"
+	while [[ ! -d "$ancestor" ]]; do
+		next_ancestor="$(dirname "$ancestor")"
+		[[ "$next_ancestor" == "$ancestor" ]] && return 1
+		ancestor="$next_ancestor"
+	done
+	canonical_ancestor="$(cd "$ancestor" && pwd -P)" || return 1
+	case "$canonical_ancestor" in
+	"$root" | "$root"/*) ;;
+	*)
+		print_error "Refusing stale-lock path outside project root: $candidate"
+		return 1
+		;;
+	esac
+	[[ ! -e "$candidate" && ! -L "$candidate" ]] && return 0
+	printf '%s/%s\n' "$canonical_ancestor" "$(basename "$candidate")"
+	return 0
+}
+
+_serve_cleanup_launch_lock() {
+	if [[ "$SERVE_LOCK_HELD" -eq 1 && -n "$SERVE_LAUNCH_LOCK" ]]; then
+		rm -f -- "$SERVE_LAUNCH_LOCK/pid"
+		rmdir "$SERVE_LAUNCH_LOCK" 2>/dev/null || true
+		SERVE_LOCK_HELD=0
+	fi
+	return 0
+}
+
+_serve_remove_stale_launch_lock() {
+	local lock_dir="$1"
+	local holder_pid=""
+	local modified_at=""
+	local now=""
+	local age=0
+	[[ -f "$lock_dir/pid" ]] && IFS= read -r holder_pid <"$lock_dir/pid" || true
+	if [[ "$holder_pid" =~ ^[0-9]+$ ]] && kill -0 "$holder_pid" 2>/dev/null; then
+		return 1
+	fi
+	# Do not reclaim a just-created directory before its owner writes the PID.
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		modified_at="$(stat -f '%m' "$lock_dir" 2>/dev/null)" || return 1
+	else
+		modified_at="$(stat -c '%Y' "$lock_dir" 2>/dev/null)" || return 1
+	fi
+	now="$(date +%s)"
+	[[ "$modified_at" =~ ^[0-9]+$ ]] || return 1
+	age=$((now - modified_at))
+	[[ "$age" -ge 5 ]] || return 1
+	rm -f -- "$lock_dir/pid"
+	rmdir "$lock_dir" 2>/dev/null || return 1
+	return 0
+}
+
+_serve_acquire_launch_lock() {
+	local port="$1"
+	local startup_timeout="$2"
+	local lock_root="${LOCALDEV_DIR:-$HOME/.local-dev-proxy}/run-locks"
+	local attempts=$((startup_timeout * 4))
+	local attempt=0
+	if ! mkdir -p "$lock_root"; then
+		print_error "Unable to create launch-lock directory: $lock_root"
+		return 1
+	fi
+	SERVE_LAUNCH_LOCK="$lock_root/port-${port}.lock"
+	while [[ "$attempt" -lt "$attempts" ]]; do
+		if mkdir "$SERVE_LAUNCH_LOCK" 2>/dev/null; then
+			if ! printf '%s\n' "$$" >"$SERVE_LAUNCH_LOCK/pid"; then
+				rmdir "$SERVE_LAUNCH_LOCK" 2>/dev/null || true
+				print_error "Unable to record launch-lock owner for port $port"
+				return 1
+			fi
+			SERVE_LOCK_HELD=1
+			return 0
+		fi
+		if [[ -L "$SERVE_LAUNCH_LOCK" || (-e "$SERVE_LAUNCH_LOCK" && ! -d "$SERVE_LAUNCH_LOCK") ]]; then
+			print_error "Refusing invalid launch-lock path: $SERVE_LAUNCH_LOCK"
+			return 1
+		fi
+		_serve_remove_stale_launch_lock "$SERVE_LAUNCH_LOCK" || true
+		sleep 0.25
+		attempt=$((attempt + 1))
+	done
+	print_error "Timed out waiting for launch lock on port $port"
+	return 1
+}
+
+_serve_forward_signal() {
+	local signal="$1"
+	if [[ "$SERVE_CHILD_PID" =~ ^[0-9]+$ ]] && kill -0 "$SERVE_CHILD_PID" 2>/dev/null; then
+		kill -s "$signal" "$SERVE_CHILD_PID" 2>/dev/null || true
+	fi
+	return 0
+}
+
+_serve_wait_for_readiness() {
+	local port="$1"
+	local root="$2"
+	local health_url="$3"
+	local startup_timeout="$4"
+	local attempt=0
+	local check_status=0
+	local child_status=0
+	while [[ "$attempt" -lt "$startup_timeout" ]]; do
+		check_status=0
+		_serve_check_existing "$port" "$root" "$health_url" 1 0 || check_status=$?
+		if [[ "$check_status" -ne 0 ]]; then
+			return "$check_status"
+		fi
+		if [[ "$SERVE_EXISTING" -eq 1 ]]; then
+			return 0
+		fi
+		if ! kill -0 "$SERVE_CHILD_PID" 2>/dev/null; then
+			wait "$SERVE_CHILD_PID" || child_status=$?
+			print_error "Server command exited before port $port became ready (status $child_status)"
+			[[ "$child_status" -eq 0 ]] && return 1
+			return "$child_status"
+		fi
+		sleep 1
+		attempt=$((attempt + 1))
+	done
+	print_error "Server did not become ready on port $port within ${startup_timeout}s"
+	return 1
+}
+
+_serve_stop_failed_child() {
+	if [[ "$SERVE_CHILD_PID" =~ ^[0-9]+$ ]] && kill -0 "$SERVE_CHILD_PID" 2>/dev/null; then
+		kill -TERM "$SERVE_CHILD_PID" 2>/dev/null || true
+		sleep 1
+		kill -0 "$SERVE_CHILD_PID" 2>/dev/null && kill -KILL "$SERVE_CHILD_PID" 2>/dev/null || true
+		wait "$SERVE_CHILD_PID" 2>/dev/null || true
+	fi
+	return 0
+}
+
+_serve_launch() {
+	local port="$1"
+	local root="$2"
+	local health_url="$3"
+	local startup_timeout="$4"
+	local set_host="$5"
+	local child_status=0
+	shift 5
+	export PORT="$port"
+	[[ "$set_host" -eq 1 ]] && export HOST="0.0.0.0"
+	"$@" &
+	SERVE_CHILD_PID=$!
+	trap '_serve_forward_signal INT' INT
+	trap '_serve_forward_signal TERM' TERM
+	trap '_serve_forward_signal HUP' HUP
+	if ! _serve_wait_for_readiness "$port" "$root" "$health_url" "$startup_timeout"; then
+		_serve_stop_failed_child
+		return 1
+	fi
+	_serve_cleanup_launch_lock
+	print_success "$name is ready on port $port"
+	wait "$SERVE_CHILD_PID" || child_status=$?
+	return "$child_status"
+}
+
+cmd_serve() {
+	local name
+	local port=""
+	local root
+	local stale_lock=""
+	local health_url=""
+	local startup_timeout=120
+	local set_host=1
+	local cmd_args=()
+	name="$(basename "$(pwd -P)")"
+	root="$(pwd -P)"
+	_serve_parse_args "$@" || return 1
+	_serve_validate_args "$port" "$startup_timeout" "${#cmd_args[@]}" "$health_url" || return 1
+	root="$(_serve_canonical_root "$root")" || return 1
+	_serve_check_existing "$port" "$root" "$health_url" || return 1
+	[[ "$SERVE_EXISTING" -eq 1 ]] && return 0
+	_serve_acquire_launch_lock "$port" "$startup_timeout" || return 1
+	trap '_serve_cleanup_launch_lock' EXIT
+	if ! _serve_check_existing "$port" "$root" "$health_url"; then
+		_serve_cleanup_launch_lock
+		trap - EXIT
+		return 1
+	fi
+	if [[ "$SERVE_EXISTING" -eq 1 ]]; then
+		_serve_cleanup_launch_lock
+		trap - EXIT
+		return 0
+	fi
+	local resolved_lock=""
+	if ! resolved_lock="$(_serve_resolve_stale_lock "$root" "$stale_lock")"; then
+		_serve_cleanup_launch_lock
+		trap - EXIT
+		return 1
+	fi
+	if [[ -n "$resolved_lock" ]]; then
+		print_warning "Removing stale lock after confirming port $port is unused: $resolved_lock"
+		rm -f -- "$resolved_lock"
+	fi
+	print_info "Starting $name on port $port: ${cmd_args[*]}"
+	local launch_status=0
+	_serve_launch "$port" "$root" "$health_url" "$startup_timeout" "$set_host" "${cmd_args[@]}" || launch_status=$?
+	_serve_cleanup_launch_lock
+	trap - EXIT INT TERM HUP
+	return "$launch_status"
+}

--- a/.agents/scripts/localdev-helper.sh
+++ b/.agents/scripts/localdev-helper.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # take precedence; localdev entries use a different marker (# localdev:).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
+source "$SCRIPT_DIR/shared-constants.sh" || true
 
 # Error message constants (fallback if shared-constants.sh unavailable)
 if [[ -z "${ERROR_UNKNOWN_COMMAND:-}" ]]; then
@@ -71,6 +71,10 @@ source "${SCRIPT_DIR}/localdev-helper-branch.sh"
 # shellcheck source=./localdev-helper-run.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/localdev-helper-run.sh"
+
+# shellcheck source=./localdev-helper-serve.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/localdev-helper-serve.sh"
 
 # shellcheck source=./localdev-helper-db.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
@@ -289,6 +293,7 @@ cmd_help() {
 	echo ""
 	echo "Commands:"
 	echo "  run <command...>   Zero-config: auto-register + inject PORT + exec command"
+	echo "  serve [opts] -- <command...>  Reuse or safely launch a saved-profile server"
 	echo "  init               One-time setup: dnsmasq, resolver, Traefik conf.d migration"
 	echo "  add <name> [port]  Register app: cert + Traefik route + port registry"
 	echo "  rm <name>          Remove app: reverses all add operations (incl. branches)"
@@ -306,6 +311,13 @@ cmd_help() {
 	echo "  3. Detect worktree/branch and create branch subdomain if needed"
 	echo "  4. Set PORT and HOST=0.0.0.0 environment variables"
 	echo "  5. Exec the command (signals pass through directly)"
+	echo ""
+	echo "Serve performs (opt-in for saved profiles):"
+	echo "  1. Reuse a healthy listener only when every owner runs under --root"
+	echo "  2. Reject foreign or unhealthy listeners without killing them"
+	echo "  3. Serialize launches by port and remove --lock only while the port is unused"
+	echo "  Usage: serve --port <port> [--root <dir>] [--lock <path>]"
+	echo "         [--health-url <local-url>] [--startup-timeout <seconds>] -- <command...>"
 	echo ""
 	echo "Add performs:"
 	echo "  1. Collision detection (LocalWP, registry, port)"
@@ -356,6 +368,10 @@ main() {
 	run)
 		shift
 		cmd_run "$@"
+		;;
+	serve)
+		shift
+		cmd_serve "$@"
 		;;
 	add)
 		shift

--- a/.agents/scripts/tests/test-localdev-helper-serve.sh
+++ b/.agents/scripts/tests/test-localdev-helper-serve.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Integration coverage for owner-safe, serialized local development launches.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$REPO_ROOT/.agents/scripts/localdev-helper.sh"
+SERVE_LIB="$REPO_ROOT/.agents/scripts/localdev-helper-serve.sh"
+TEST_TMP_BASE="${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}"
+mkdir -p "$TEST_TMP_BASE"
+TEST_ROOT="$(mktemp -d "$TEST_TMP_BASE/localdev-helper-serve.XXXXXX")"
+ORIGINAL_HOME="$HOME"
+export HOME="$TEST_ROOT/home"
+PROJECT_A="$TEST_ROOT/project-a"
+PROJECT_B="$TEST_ROOT/project-b"
+PASS=0
+FAIL=0
+ACTIVE_PIDS=()
+
+record_pass() {
+	local description="$1"
+	printf 'PASS: %s\n' "$description"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+record_fail() {
+	local description="$1"
+	printf 'FAIL: %s\n' "$description" >&2
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_true() {
+	local description="$1"
+	shift
+	if "$@"; then
+		record_pass "$description"
+	else
+		record_fail "$description"
+	fi
+	return 0
+}
+
+assert_status() {
+	local description="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" -eq "$actual" ]]; then
+		record_pass "$description"
+	else
+		record_fail "$description (expected $expected, got $actual)"
+	fi
+	return 0
+}
+
+line_count_is() {
+	local file="$1"
+	local expected="$2"
+	local actual=0
+	[[ -f "$file" ]] && actual="$(wc -l <"$file" | tr -d ' ')"
+	[[ "$actual" -eq "$expected" ]]
+	return $?
+}
+
+file_contains() {
+	local file="$1"
+	local text="$2"
+	local line=""
+	grep -Fq -- "$text" "$file" && return 0
+	printf '  expected output containing: %s\n' "$text" >&2
+	while IFS= read -r line; do
+		printf '  actual output: %s\n' "$line" >&2
+	done <"$file"
+	return 1
+}
+
+pick_port() {
+	python3 - <<'PY'
+import socket
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+	return 0
+}
+
+wait_for_health() {
+	local port="$1"
+	local attempts="${2:-50}"
+	local attempt=0
+	while [[ "$attempt" -lt "$attempts" ]]; do
+		if curl --fail --silent --output /dev/null --noproxy '*' "http://127.0.0.1:${port}/"; then
+			return 0
+		fi
+		sleep 0.2
+		attempt=$((attempt + 1))
+	done
+	return 1
+}
+
+wait_for_port_free() {
+	local port="$1"
+	local attempt=0
+	while [[ "$attempt" -lt 50 ]]; do
+		if ! lsof -nP -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 0.2
+		attempt=$((attempt + 1))
+	done
+	return 1
+}
+
+wait_for_path_absent() {
+	local path="$1"
+	local attempt=0
+	while [[ "$attempt" -lt 50 ]]; do
+		[[ ! -e "$path" ]] && return 0
+		sleep 0.1
+		attempt=$((attempt + 1))
+	done
+	return 1
+}
+
+register_pid() {
+	local pid="$1"
+	ACTIVE_PIDS+=("$pid")
+	return 0
+}
+
+terminate_pid() {
+	local pid="$1"
+	local attempt=0
+	if kill -0 "$pid" 2>/dev/null; then
+		kill -TERM "$pid" 2>/dev/null || true
+		while kill -0 "$pid" 2>/dev/null && [[ "$attempt" -lt 20 ]]; do
+			sleep 0.1
+			attempt=$((attempt + 1))
+		done
+		kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
+	fi
+	wait "$pid" 2>/dev/null || true
+	return 0
+}
+
+cleanup() {
+	local pid=""
+	for pid in "${ACTIVE_PIDS[@]}"; do
+		terminate_pid "$pid"
+	done
+	export HOME="$ORIGINAL_HOME"
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+
+start_helper() {
+	local project="$1"
+	local port="$2"
+	local launch_log="$3"
+	local output_file="$4"
+	local startup_delay="${5:-0}"
+	local stale_lock="${6:-.next/dev/lock}"
+	(
+		cd "$project" || exit 1
+		exec /bin/bash "$HELPER" serve --name integration-test --port "$port" --root "$project" \
+			--lock "$stale_lock" --health-url "http://127.0.0.1:${port}/" \
+			--startup-timeout 15 -- env LAUNCH_LOG="$launch_log" STARTUP_DELAY="$startup_delay" \
+			python3 server.py
+	) >"$output_file" 2>&1 &
+	STARTED_PID=$!
+	register_pid "$STARTED_PID"
+	return 0
+}
+
+run_helper_once() {
+	local project="$1"
+	local port="$2"
+	local launch_log="$3"
+	local output_file="$4"
+	local stale_lock="${5:-.next/dev/lock}"
+	local status=0
+	(
+		cd "$project" || exit 1
+		/bin/bash "$HELPER" serve --name integration-test --port "$port" --root "$project" \
+			--lock "$stale_lock" --health-url "http://127.0.0.1:${port}/" \
+			--startup-timeout 5 -- env LAUNCH_LOG="$launch_log" python3 server.py
+	) >"$output_file" 2>&1 || status=$?
+	return "$status"
+}
+
+for required_command in python3 curl lsof; do
+	if ! command -v "$required_command" >/dev/null 2>&1; then
+		printf 'FAIL: required test command unavailable: %s\n' "$required_command" >&2
+		exit 1
+	fi
+done
+
+trap cleanup EXIT
+mkdir -p "$HOME/.local-dev-proxy/run-locks" "$PROJECT_A/.next/dev" "$PROJECT_B/.next/dev" "$TEST_ROOT/empty-bin"
+
+missing_lsof_output="$TEST_ROOT/missing-lsof.out"
+missing_lsof_status=0
+(
+	print_error() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	print_info() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	# shellcheck source=/dev/null
+	source "$SERVE_LIB"
+	PATH="$TEST_ROOT/empty-bin" _serve_validate_args 32000 5 1 ""
+) >"$missing_lsof_output" 2>&1 || missing_lsof_status=$?
+assert_status "missing lsof fails closed" 1 "$missing_lsof_status"
+assert_true "missing lsof diagnostic is explicit" file_contains "$missing_lsof_output" "lsof is required"
+
+missing_curl_output="$TEST_ROOT/missing-curl.out"
+missing_curl_status=0
+(
+	print_error() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	print_info() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	lsof() { return 0; }
+	# shellcheck source=/dev/null
+	source "$SERVE_LIB"
+	PATH="$TEST_ROOT/empty-bin" _serve_validate_args 32000 5 1 "http://127.0.0.1:32000/"
+) >"$missing_curl_output" 2>&1 || missing_curl_status=$?
+assert_status "missing curl fails closed when health is required" 1 "$missing_curl_status"
+assert_true "missing curl diagnostic is explicit" file_contains "$missing_curl_output" "curl is required"
+
+unknown_owner_output="$TEST_ROOT/unknown-owner.out"
+unknown_owner_status=0
+(
+	print_error() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	print_info() {
+		printf '%s\n' "$*"
+		return 0
+	}
+	# shellcheck source=/dev/null
+	source "$SERVE_LIB"
+	_serve_process_cwd() { return 0; }
+	_serve_validate_owners 12345 "$PROJECT_A"
+) >"$unknown_owner_output" 2>&1 || unknown_owner_status=$?
+assert_status "uninspectable listener owner fails closed" 1 "$unknown_owner_status"
+assert_true "uninspectable owner diagnostic is explicit" file_contains "$unknown_owner_output" "unknown"
+
+for project in "$PROJECT_A" "$PROJECT_B"; do
+	cat >"$project/server.py" <<'PY'
+import http.server
+import os
+import time
+
+port = int(os.environ["PORT"])
+with open(os.environ["LAUNCH_LOG"], "a", encoding="utf-8") as log:
+    log.write(f"pid={os.getpid()} port={port} host={os.environ.get('HOST', '')}\n")
+    log.flush()
+time.sleep(float(os.environ.get("STARTUP_DELAY", "0")))
+status = int(os.environ.get("HEALTH_STATUS", "200"))
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(status)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, format, *args):
+        return
+
+http.server.ThreadingHTTPServer(("127.0.0.1", port), Handler).serve_forever()
+PY
+done
+
+port="$(pick_port)"
+launch_log="$TEST_ROOT/launch.log"
+leader_output="$TEST_ROOT/leader.out"
+reuse_output="$TEST_ROOT/reuse.out"
+foreign_output="$TEST_ROOT/foreign.out"
+touch "$PROJECT_A/.next/dev/lock" "$PROJECT_B/.next/dev/lock" "$launch_log"
+
+# A dead, old launch lock must not permanently block the next owner.
+mkdir "$HOME/.local-dev-proxy/run-locks/port-${port}.lock"
+printf '%s\n' '999999' >"$HOME/.local-dev-proxy/run-locks/port-${port}.lock/pid"
+touch -t 202001010000 "$HOME/.local-dev-proxy/run-locks/port-${port}.lock"
+
+start_helper "$PROJECT_A" "$port" "$launch_log" "$leader_output"
+leader_pid="$STARTED_PID"
+assert_true "first launch becomes healthy" wait_for_health "$port"
+assert_true "project-contained stale lock is removed" test ! -e "$PROJECT_A/.next/dev/lock"
+assert_true "server launches once" line_count_is "$launch_log" 1
+assert_true "PORT and HOST reach the command" file_contains "$launch_log" "port=$port host=0.0.0.0"
+assert_true "stale per-port launch lock is reclaimed" wait_for_path_absent "$HOME/.local-dev-proxy/run-locks/port-${port}.lock"
+
+run_helper_once "$PROJECT_A" "$port" "$launch_log" "$reuse_output"
+reuse_status=$?
+assert_status "healthy same-project listener is reused" 0 "$reuse_status"
+assert_true "reuse does not launch a duplicate" line_count_is "$launch_log" 1
+assert_true "reuse is reported" file_contains "$reuse_output" "Reusing integration-test on port $port"
+
+run_helper_once "$PROJECT_B" "$port" "$launch_log" "$foreign_output"
+foreign_status=$?
+assert_status "foreign project listener fails closed" 1 "$foreign_status"
+assert_true "foreign collision leaves its stale lock untouched" test -e "$PROJECT_B/.next/dev/lock"
+assert_true "foreign collision does not stop the owner" kill -0 "$leader_pid"
+assert_true "foreign collision is explained" file_contains "$foreign_output" "outside project root"
+
+terminate_pid "$leader_pid"
+assert_true "leader termination releases the port" wait_for_port_free "$port"
+
+# An owned but unhealthy listener must remain running and block replacement.
+unhealthy_log="$TEST_ROOT/unhealthy.log"
+(
+	cd "$PROJECT_A" || exit 1
+	exec env PORT="$port" LAUNCH_LOG="$unhealthy_log" HEALTH_STATUS=503 python3 server.py
+) >"$TEST_ROOT/unhealthy-server.out" 2>&1 &
+unhealthy_pid=$!
+register_pid "$unhealthy_pid"
+sleep 0.5
+unhealthy_output="$TEST_ROOT/unhealthy-helper.out"
+run_helper_once "$PROJECT_A" "$port" "$launch_log" "$unhealthy_output"
+unhealthy_status=$?
+assert_status "owned unhealthy listener is not replaced" 1 "$unhealthy_status"
+assert_true "owned unhealthy listener is not killed" kill -0 "$unhealthy_pid"
+assert_true "unhealthy collision is explained" file_contains "$unhealthy_output" "is unhealthy"
+terminate_pid "$unhealthy_pid"
+assert_true "unhealthy listener cleanup releases the port" wait_for_port_free "$port"
+
+# A requested stale-lock path outside the project must fail without launching.
+outside_lock="$TEST_ROOT/outside.lock"
+outside_output="$TEST_ROOT/outside.out"
+touch "$outside_lock"
+run_helper_once "$PROJECT_A" "$port" "$launch_log" "$outside_output" "$outside_lock"
+outside_status=$?
+assert_status "outside stale-lock path is rejected" 1 "$outside_status"
+assert_true "outside stale-lock file is preserved" test -e "$outside_lock"
+assert_true "outside stale-lock rejection does not launch" line_count_is "$launch_log" 1
+
+missing_outside_lock="$TEST_ROOT/not-created/outside.lock"
+run_helper_once "$PROJECT_A" "$port" "$launch_log" "$outside_output" "$missing_outside_lock"
+missing_outside_status=$?
+assert_status "absent outside stale-lock path is rejected" 1 "$missing_outside_status"
+
+run_helper_once "$PROJECT_A" "$port" "$launch_log" "$outside_output" "../outside-absent.lock"
+traversal_status=$?
+assert_status "relative stale-lock traversal is rejected" 1 "$traversal_status"
+
+mkdir "$TEST_ROOT/outside-dir"
+ln -s "$TEST_ROOT/outside-dir" "$PROJECT_A/escape"
+run_helper_once "$PROJECT_A" "$port" "$launch_log" "$outside_output" "escape/absent.lock"
+symlink_escape_status=$?
+assert_status "stale-lock parent symlink escape is rejected" 1 "$symlink_escape_status"
+assert_true "all invalid stale-lock paths avoid launching" line_count_is "$launch_log" 1
+
+launch_lock_target="$TEST_ROOT/launch-lock-target"
+launch_lock_path="$HOME/.local-dev-proxy/run-locks/port-${port}.lock"
+mkdir "$launch_lock_target"
+printf '%s\n' 'preserve-me' >"$launch_lock_target/pid"
+ln -s "$launch_lock_target" "$launch_lock_path"
+run_helper_once "$PROJECT_A" "$port" "$launch_log" "$outside_output"
+launch_lock_symlink_status=$?
+assert_status "symlinked per-port launch lock is rejected" 1 "$launch_lock_symlink_status"
+assert_true "symlinked launch-lock target is preserved" file_contains "$launch_lock_target/pid" "preserve-me"
+assert_true "invalid launch lock does not launch" line_count_is "$launch_log" 1
+rm -f "$launch_lock_path"
+
+# Parallel cold starts must serialize and produce exactly one server process.
+parallel_port="$(pick_port)"
+parallel_log="$TEST_ROOT/parallel.log"
+parallel_one="$TEST_ROOT/parallel-one.out"
+parallel_two="$TEST_ROOT/parallel-two.out"
+touch "$parallel_log" "$PROJECT_A/.next/dev/lock"
+start_helper "$PROJECT_A" "$parallel_port" "$parallel_log" "$parallel_one" 2
+parallel_pid_one="$STARTED_PID"
+start_helper "$PROJECT_A" "$parallel_port" "$parallel_log" "$parallel_two" 2
+parallel_pid_two="$STARTED_PID"
+assert_true "parallel launch becomes healthy" wait_for_health "$parallel_port" 75
+sleep 1
+assert_true "parallel launch starts one command" line_count_is "$parallel_log" 1
+
+alive_one=0
+alive_two=0
+kill -0 "$parallel_pid_one" 2>/dev/null && alive_one=1
+kill -0 "$parallel_pid_two" 2>/dev/null && alive_two=1
+if [[ $((alive_one + alive_two)) -eq 1 ]]; then
+	record_pass "parallel follower exits after reusing the leader"
+else
+	record_fail "parallel follower exits after reusing the leader (alive: $alive_one/$alive_two)"
+fi
+
+if [[ "$alive_one" -eq 1 ]]; then
+	parallel_leader="$parallel_pid_one"
+	parallel_follower="$parallel_pid_two"
+else
+	parallel_leader="$parallel_pid_two"
+	parallel_follower="$parallel_pid_one"
+fi
+follower_status=0
+wait "$parallel_follower" || follower_status=$?
+assert_status "parallel follower returns success" 0 "$follower_status"
+terminate_pid "$parallel_leader"
+assert_true "parallel leader termination releases the port" wait_for_port_free "$parallel_port"
+
+printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/services/hosting/local-hosting.md
+++ b/.agents/services/hosting/local-hosting.md
@@ -20,7 +20,7 @@ tools:
 
 ## Quick Reference
 
-- **Primary CLI**: `localdev-helper.sh [run|init|add|rm|branch|db|list|status|help]`
+- **Primary CLI**: `localdev-helper.sh [run|serve|init|add|rm|branch|db|list|status|help]`
 - **Legacy CLI**: `localhost-helper.sh [check-port|find-port|list-ports|kill-port|generate-cert|setup-dns|setup-proxy|create-app|start-mcp]`
 - **Port registry**: `~/.local-dev-proxy/ports.json` (range: 3100-3999)
 - **Certs**: `~/.local-ssl-certs/` | **Routes**: `~/.local-dev-proxy/conf.d/`
@@ -32,6 +32,8 @@ localdev-helper.sh init          # One-time: dnsmasq, resolver, Traefik conf.d (
 cd ~/Git/myapp
 localdev-helper.sh run npm run dev
 # → Auto-registers myapp (cert, route, /etc/hosts, port 3100) → https://myapp.local
+localdev-helper.sh serve --port 3100 --health-url http://127.0.0.1:3100/ -- npm run dev
+# → Reuses a healthy myapp listener or safely starts exactly one
 localdev-helper.sh add myapp    # Manual: cert + route + /etc/hosts + port
 ```
 
@@ -88,6 +90,22 @@ localdev-helper.sh run [--name <name>] [--port <port>] [--no-host] <command...>
 # Name inference: --name → package.json name → git repo basename → dir basename
 # In worktree → auto-creates branch subdomain (e.g. https://bugfix-fix.myapp.local)
 ```
+
+**serve** — Opt-in saved-profile wrapper: reuses a healthy project-owned listener or serializes a new launch. It never terminates a pre-existing process.
+
+```bash
+localdev-helper.sh serve --port 3100 \
+  --root "$PWD" \
+  --lock apps/web/.next/dev/lock \
+  --health-url http://127.0.0.1:3100/ \
+  -- pnpm dev:web
+```
+
+- Every listener PID must have a working directory equal to or below `--root`; foreign or uninspectable owners fail closed.
+- `--health-url` is optional, must use the selected port on localhost, and requires a successful HTTP response.
+- Concurrent invocations serialize on the port. Followers reuse the first healthy launch rather than starting duplicates.
+- `--lock` is optional and must resolve inside `--root`. It is removed only after the port is confirmed unused and the launch lock is held.
+- An owned but unhealthy listener is not restarted implicitly. Stop it explicitly, diagnose it, then retry.
 
 **add / rm**
 
@@ -152,8 +170,7 @@ localhost-helper.sh start-mcp | stop-mcp | test-mcp | mcp-query "<sql>"
 | **Laravel** | `php artisan serve --port=3100` |
 | **Bun** | `PORT=3100 bun run dev` |
 
-**Next.js stale lock (16+):** `rm -f .next/dev/lock && PORT=3100 npm run dev`
-Or: `"dev": "rm -f .next/dev/lock && next dev --port ${PORT:-3000}"`
+**Next.js stale lock (16+):** use `serve --lock .next/dev/lock`; never remove the lock before confirming that the configured port is unused.
 
 **Turborepo quirks:**
 
@@ -161,7 +178,7 @@ Or: `"dev": "rm -f .next/dev/lock && next dev --port ${PORT:-3000}"`
 2. `allowedDevOrigins: ["myapp.local"]` required in `next.config.ts` (Next.js 15+)
 3. `with-env` loads `.env.local` from monorepo root — place `URL`/`DATABASE_URL` there
 4. Skip `localdev db start` if project has own `docker-compose.yml` on port 5432
-5. Stale lock: `rm -f apps/web/.next/dev/lock && pnpm dev:web`
+5. Stale lock: `localdev-helper.sh serve --port 3100 --lock apps/web/.next/dev/lock -- pnpm dev:web`
 
 **Docker Compose projects:** Map to localdev port (`"3100:3000"`) and join `local-dev` network.
 


### PR DESCRIPTION
## Summary

Add an opt-in localdev serve command that reuses only healthy project-owned listeners, serializes cold starts by port, constrains stale-lock cleanup beneath the project root, and never terminates pre-existing listeners. Preserve the existing run contract and document the safe saved-profile pattern.

## Files Changed

.agents/scripts/localdev-helper-serve.sh, .agents/scripts/localdev-helper.sh, .agents/scripts/tests/test-localdev-helper-serve.sh, .agents/services/hosting/local-hosting.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** /bin/bash .agents/scripts/tests/test-localdev-helper-serve.sh (38 checks); .agents/scripts/linters-local.sh --changed; Bash 3.2 help/dispatch verification

Resolves #28038


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.139 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 28d 23h and 1,631,092 tokens on this with the user in an interactive session.