### PR TITLE
GH#27982: harden empty telemetry lock recovery

### DIFF
--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -57,6 +57,8 @@
 #                                   the newest bounded records (default 50000)
 #   AIDEVOPS_GH_API_LOG_MAX_BYTES — maximum retained log bytes (default 16 MiB)
 #   AIDEVOPS_GH_API_RETENTION_SECONDS — maximum record age (default 172800)
+#   AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES — 10ms waits before reclaiming an
+#                                   empty lock directory (default 100)
 #   AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1 — make all calls no-ops
 #
 # Part of aidevops framework: https://aidevops.sh
@@ -106,7 +108,8 @@ GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"
 GH_API_LOG_MAX_BYTES="${AIDEVOPS_GH_API_LOG_MAX_BYTES:-16777216}"
 GH_API_RETENTION_SECONDS="${AIDEVOPS_GH_API_RETENTION_SECONDS:-172800}"
 GH_API_ERROR_KEY="error"
-_GH_API_EMPTY_LOCK_GRACE_TRIES=100
+_GH_API_EMPTY_LOCK_GRACE_TRIES="${AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES:-100}"
+[[ "$_GH_API_EMPTY_LOCK_GRACE_TRIES" =~ ^[0-9]+$ ]] || _GH_API_EMPTY_LOCK_GRACE_TRIES=100
 
 _gh_now_seconds() {
 	local now=""
@@ -206,16 +209,19 @@ _gh_log_lock_reclaim() {
 		if ! IFS= read -r owner 2>/dev/null <"$pid_path"; then
 			owner=""
 		fi
-		if [[ "$owner" =~ ^[0-9]+$ ]]; then
-			kill -0 "$owner" 2>/dev/null && return 1
+		if [[ -n "$owner" ]]; then
+			if [[ "$owner" =~ ^[0-9]+$ ]] && kill -0 "$owner" 2>/dev/null; then
+				return 1
+			fi
 			rm -f "$pid_path" 2>/dev/null || return 1
 			rmdir "$lock_dir" 2>/dev/null || return 1
 			return 0
 		fi
 	fi
 	# mkdir and PID publication are separate operations. Give a live owner one
-	# second to publish, then reclaim a missing/malformed PID left by a process
-	# killed inside that gap. rmdir still fails closed if unexpected files exist.
+	# second to publish an empty PID, then reclaim it if its owner was killed
+	# inside that gap. Malformed and dead PIDs are reclaimed immediately.
+	# rmdir still fails closed if unexpected files exist.
 	[[ "$tries" -ge "${_GH_API_EMPTY_LOCK_GRACE_TRIES:-100}" ]] || return 1
 	[[ ! -L "$pid_path" ]] || return 1
 	rm -f "$pid_path" 2>/dev/null || return 1

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -211,7 +211,7 @@ PATH="$FAKE_BIN:$PATH" HOME='' TMPDIR="$FALLBACK_TMP" USER="ghapitest" bash -c '
 	# shellcheck source=../gh-api-instrument.sh
 	source "$1"
 	gh_record_call rest fallback-test
-	mode=$(stat -f %Lp "$TMPDIR/aidevops-$USER" 2>/dev/null || stat -c %a "$TMPDIR/aidevops-$USER")
+	mode=$(stat -c '%a' "$TMPDIR/aidevops-$USER" 2>/dev/null || stat -f '%Lp' "$TMPDIR/aidevops-$USER")
 	[[ "$mode" == "700" ]]
 	[[ -f "$TMPDIR/aidevops-$USER/.aidevops/logs/gh-api-calls.log" ]]
 ' _ "${PARENT_DIR}/gh-api-instrument.sh"

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -255,12 +255,19 @@ assert_eq "missing lock tools stay silent" "0" "$lock_stderr_bytes"
 # --- Test 10b: abandoned empty locks recover instead of wedging telemetry --
 export AIDEVOPS_GH_API_LOG="$TMPDIR/stale-lock-calls.log"
 export AIDEVOPS_GH_API_REPORT="$TMPDIR/stale-lock-report.json"
+export AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES=0
 unset _GH_API_INSTRUMENT_LOADED
 # shellcheck source=../gh-api-instrument.sh
 source "${PARENT_DIR}/gh-api-instrument.sh"
+assert_eq "empty lock grace accepts an environment override" "0" "$_GH_API_EMPTY_LOCK_GRACE_TRIES"
+invalid_grace=$(AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES=invalid bash -c '
+	# shellcheck source=/dev/null
+	source "$1"
+	printf "%s\n" "$_GH_API_EMPTY_LOCK_GRACE_TRIES"
+' _ "${PARENT_DIR}/gh-api-instrument.sh")
+assert_eq "invalid empty lock grace uses the default" "100" "$invalid_grace"
 gh_clear_log
 mkdir "${GH_API_LOG}.lock"
-_GH_API_EMPTY_LOCK_GRACE_TRIES=0
 gh_record_call rest stale-empty-lock-test
 assert_eq "stale empty lock permits the next record" "1" "$(wc -l <"$GH_API_LOG" | tr -d ' ')"
 if [[ -d "${GH_API_LOG}.lock" ]]; then
@@ -273,6 +280,10 @@ fi
 
 mkdir "${GH_API_LOG}.lock"
 printf '%s\n' 'not-a-pid' >"${GH_API_LOG}.lock/pid"
+_GH_API_EMPTY_LOCK_GRACE_TRIES=100
+malformed_lock_status=0
+_gh_log_lock_reclaim "${GH_API_LOG}.lock" 0 || malformed_lock_status=$?
+assert_eq "malformed PID lock is reclaimed without the empty-lock grace" "0" "$malformed_lock_status"
 gh_record_call rest stale-malformed-lock-test
 assert_eq "stale malformed lock permits the next record" "2" "$(wc -l <"$GH_API_LOG" | tr -d ' ')"
 
@@ -307,6 +318,7 @@ assert_eq "issue sync preserves framework gh shim precedence" "$issue_sync_scrip
 # Restore per-test overrides for summary diagnostics if future tests append.
 export AIDEVOPS_GH_API_LOG="$TMPDIR/gh-api-calls.log"
 export AIDEVOPS_GH_API_REPORT="$TMPDIR/report.json"
+unset AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES
 
 # --- Test 11: exact replay separates events, attempts, pages, and retries --
 unset _GH_API_INSTRUMENT_LOADED


### PR DESCRIPTION
## Summary

- Validate the configurable empty telemetry lock grace before arithmetic comparisons.
- Reclaim malformed PID locks immediately while preserving grace for unpublished PIDs.
- Add regression coverage for environment overrides, invalid values, and immediate malformed-PID recovery.
- Make the existing fallback permission assertion portable across GNU and BSD `stat`.

## Testing

- `shellcheck .agents/scripts/gh-api-instrument.sh .agents/scripts/tests/test-gh-api-instrument.sh`
- `bash -n .agents/scripts/gh-api-instrument.sh .agents/scripts/tests/test-gh-api-instrument.sh`
- `bash .agents/scripts/tests/test-gh-api-instrument.sh` (105 passed)

Resolves #27982

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 62,736 tokens on this as a headless worker.
