### PR TITLE
GH#28056: preserve dispatch identity during REST outages

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -1276,6 +1276,32 @@ _dsi_write_recovery_checkpoint() {
 }
 
 #######################################
+# Resolve the authenticated GitHub login without accepting caller-supplied
+# identity. REST remains preferred; authenticated GraphQL viewer identity is
+# the bounded fallback when REST is unavailable. Both transports use the same
+# gh credential context, and malformed output fails closed.
+#######################################
+_dsi_resolve_runner_login() {
+	local runner_login=""
+
+	runner_login=$(gh api user --jq '.login // ""' 2>/dev/null || true)
+	if [[ "$runner_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+		printf '%s\n' "$runner_login"
+		return 0
+	fi
+
+	runner_login=$(gh api graphql \
+		-f 'query=query { viewer { login } }' \
+		--jq '.data.viewer.login // ""' 2>/dev/null || true)
+	if [[ "$runner_login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+		printf '%s\n' "$runner_login"
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
 # Subcommand: dispatch <issue> <slug> [--model M] [--dry-run]
 #######################################
 cmd_dispatch() {
@@ -1315,7 +1341,7 @@ cmd_dispatch() {
 	# Treat anything other than 0 or 1 as "fail closed" — refuse to dispatch
 	# when we can't be sure of the state. The pulse has its own retry layers.
 	local self_login
-	self_login=$(gh api user --jq .login 2>/dev/null || echo "")
+	self_login=$(_dsi_resolve_runner_login 2>/dev/null) || self_login=""
 	_dsi_run_dedup_check "$issue_number" "$repo_slug" "$self_login"
 	local dedup_result="$_DSI_DEDUP_RESULT"
 	local dedup_rc="$_DSI_DEDUP_RC"

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -40,6 +40,9 @@ MOCK_GH_LABELS_JSON="[]"
 MOCK_GH_FAIL="0"
 MOCK_GH_TARGET_IS_PR="0"
 MOCK_GH_PERMISSION_EVENTS_JSON='[[]]'
+MOCK_GH_REST_LOGIN_MODE="success"
+MOCK_GH_GRAPHQL_LOGIN_MODE="success"
+MOCK_GH_CALL_LOG=""
 MOCK_PS_LINES=""
 MOCK_LEDGER_RECORD=""
 MOCK_GIT_WORKTREE_LIST="0"
@@ -161,6 +164,9 @@ git() {
 gh() {
 	local gh_subcommand="${1:-}"
 	local gh_resource="${2:-}"
+	if [[ -n "$MOCK_GH_CALL_LOG" ]]; then
+		printf '%s\n' "$*" >>"$MOCK_GH_CALL_LOG"
+	fi
 	if [[ "$MOCK_GH_FAIL" == "1" ]]; then
 		return 1
 	fi
@@ -172,8 +178,31 @@ gh() {
 	fi
 
 	if [[ "$gh_subcommand" == "api" && "$gh_resource" == "user" ]]; then
-		printf '%s\n' 'runner-self'
-		return 0
+		case "$MOCK_GH_REST_LOGIN_MODE" in
+		success)
+			printf '%s\n' 'runner-self'
+			return 0
+			;;
+		invalid)
+			printf '%s\n' 'invalid login!'
+			return 0
+			;;
+		*) return 1 ;;
+		esac
+	fi
+
+	if [[ "$gh_subcommand" == "api" && "$gh_resource" == "graphql" ]]; then
+		case "$MOCK_GH_GRAPHQL_LOGIN_MODE" in
+		success)
+			printf '%s\n' 'fallback-runner'
+			return 0
+			;;
+		invalid)
+			printf '%s\n' 'fallback;injection'
+			return 0
+			;;
+		*) return 1 ;;
+		esac
 	fi
 	if [[ "$gh_subcommand" == "api" && "$gh_resource" == */events\?* ]]; then
 		printf '%s\n' "$MOCK_GH_PERMISSION_EVENTS_JSON"
@@ -704,6 +733,56 @@ test_cmd_dispatch_blocks_needs_maintainer_review_before_dedup() {
 	return 0
 }
 
+test_runner_login_transport_security() {
+	local test_dir=""
+	test_dir=$(mktemp -d)
+	MOCK_GH_CALL_LOG="${test_dir}/gh-calls"
+	MOCK_GH_REST_LOGIN_MODE="success"
+	MOCK_GH_GRAPHQL_LOGIN_MODE="fail"
+
+	local login="" rc=0 check=1
+	login=$(_dsi_resolve_runner_login) || rc=$?
+	if [[ "$rc" -eq 0 && "$login" == "runner-self" ]] &&
+		! grep -Fq 'api graphql' "$MOCK_GH_CALL_LOG"; then
+		check=0
+	fi
+	print_result "runner identity prefers authenticated REST" "$check" "rc=$rc login=$login"
+
+	: >"$MOCK_GH_CALL_LOG"
+	MOCK_GH_REST_LOGIN_MODE="fail"
+	MOCK_GH_GRAPHQL_LOGIN_MODE="success"
+	login=""
+	rc=0
+	login=$(_dsi_resolve_runner_login) || rc=$?
+	check=1
+	[[ "$rc" -eq 0 && "$login" == "fallback-runner" ]] && check=0
+	print_result "runner identity falls back to authenticated GraphQL" "$check" "rc=$rc login=$login"
+
+	MOCK_GH_REST_LOGIN_MODE="invalid"
+	MOCK_GH_GRAPHQL_LOGIN_MODE="invalid"
+	login=""
+	rc=0
+	login=$(_dsi_resolve_runner_login) || rc=$?
+	check=1
+	[[ "$rc" -eq 1 && -z "$login" ]] && check=0
+	print_result "runner identity rejects malformed transport output" "$check" "rc=$rc login=$login"
+
+	MOCK_GH_REST_LOGIN_MODE="fail"
+	MOCK_GH_GRAPHQL_LOGIN_MODE="fail"
+	login=""
+	rc=0
+	login=$(_dsi_resolve_runner_login) || rc=$?
+	check=1
+	[[ "$rc" -eq 1 && -z "$login" ]] && check=0
+	print_result "runner identity fails closed when both transports fail" "$check" "rc=$rc login=$login"
+
+	MOCK_GH_REST_LOGIN_MODE="success"
+	MOCK_GH_GRAPHQL_LOGIN_MODE="success"
+	MOCK_GH_CALL_LOG=""
+	rm -rf "$test_dir"
+	return 0
+}
+
 test_dedup_receives_prefetched_issue_metadata() {
 	local test_dir=""
 	test_dir=$(mktemp -d)
@@ -1224,6 +1303,7 @@ _run_tests() {
 	test_maintainer_permission_guard_blocks_manual_dispatch
 	test_permission_history_guard_requires_current_grant
 	test_cmd_dispatch_blocks_needs_maintainer_review_before_dedup
+	test_runner_login_transport_security
 	test_dedup_receives_prefetched_issue_metadata
 	test_transient_dedup_retries_are_bounded
 	test_persistent_uncertainty_does_not_retry_and_checkpoints_dryrun


### PR DESCRIPTION
## Summary

Prefer the authenticated REST user login, fall back to authenticated GraphQL viewer identity when REST is unavailable, validate GitHub login syntax, and fail closed if neither transport yields a valid identity.

## Files Changed

.agents/scripts/dispatch-single-issue-helper.sh, .agents/scripts/tests/test-dispatch-single-issue-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 68/68 dispatch-single tests; 58/58 consensus-claim tests; ShellCheck; bash -n; changed-file linters including Bash 3.2, portability, secret, complexity, and nesting gates; real #27984 dry-run.

Resolves #28056


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.140 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 3h 40m and 1,276,056 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authenticated account detection during issue dispatch.
  * Added a secure fallback when the primary identity lookup is unavailable or returns invalid data.
  * Prevented malformed identity responses from affecting duplicate checks and claim handling.

* **Tests**
  * Added coverage for successful, fallback, invalid, and failed identity lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->