### PR TITLE
GH#28059: Prevent agent-only deployment from terminating custom Pulse schedulers

### DIFF
--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -166,19 +166,26 @@ _pulse_runtime_bundle_id() {
 	return 0
 }
 
-_pulse_launchd_supervisor_disabled() {
+_pulse_launchd_supervisor_enabled() {
 	local os_name="${AIDEVOPS_PULSE_OS_NAME:-}"
 	local pulse_label="${AIDEVOPS_PULSE_LAUNCHD_LABEL:-com.aidevops.aidevops-supervisor-pulse}"
 	local disabled_state=""
 	local disabled_line=""
+	local trimmed_line=""
 	[[ -n "$os_name" ]] || os_name=$(uname -s 2>/dev/null || printf 'unknown')
 	[[ "$os_name" == "$_PULSE_OS_DARWIN" ]] || return 1
 	command -v launchctl >/dev/null 2>&1 || return 1
 	disabled_state=$(launchctl print-disabled "gui/$(id -u)" 2>/dev/null) || return 1
 	while IFS= read -r disabled_line; do
-		if [[ "$disabled_line" == *"$pulse_label"* && "$disabled_line" == *"=> true"* ]]; then
+		trimmed_line="${disabled_line#"${disabled_line%%[![:space:]]*}"}"
+		case "$trimmed_line" in
+		\"${pulse_label}\"\ =\>\ false*)
 			return 0
-		fi
+			;;
+		\"${pulse_label}\"\ =\>\ true*)
+			return 1
+			;;
+		esac
 	done <<<"$disabled_state"
 	return 1
 }
@@ -196,9 +203,11 @@ _pulse_launchd_supervisor_present() {
 _pulse_managed_supervisor_kind() {
 	local os_name="${AIDEVOPS_PULSE_OS_NAME:-}"
 	local cron_state=""
+	local cron_line=""
+	local trimmed_line=""
 	[[ -n "$os_name" ]] || os_name=$(uname -s 2>/dev/null || printf 'unknown')
 	if [[ "$os_name" == "$_PULSE_OS_DARWIN" ]]; then
-		_pulse_launchd_supervisor_disabled && return 1
+		_pulse_launchd_supervisor_enabled || return 1
 		_pulse_launchd_supervisor_present || return 1
 		printf '%s\n' "launchd"
 		return 0
@@ -211,66 +220,175 @@ _pulse_managed_supervisor_kind() {
 	fi
 	if command -v crontab >/dev/null 2>&1; then
 		cron_state=$(crontab -l 2>/dev/null) || cron_state=""
-		if [[ "$cron_state" == *"aidevops: supervisor-pulse"* ]]; then
-			printf '%s\n' "cron"
-			return 0
-		fi
+		while IFS= read -r cron_line; do
+			trimmed_line="${cron_line#"${cron_line%%[![:space:]]*}"}"
+			case "$trimmed_line" in
+			"" | \#*) continue ;;
+			esac
+			if [[ "$trimmed_line" =~ [[:space:]]#[[:space:]]aidevops:[[:space:]]supervisor-pulse[[:space:]]*$ ]]; then
+				printf '%s\n' "cron"
+				return 0
+			fi
+		done <<<"$cron_state"
 	fi
 	return 1
 }
 
-_pulse_command_uses_script() {
-	local command_line="$1"
+_pulse_pid_invokes_script() {
+	local candidate_pid="$1"
 	local script_path="$2"
+	local command_line=""
+	local command_arg=""
+	local command_name=""
+	local arg_index=0
+	local options_done=false
+	[[ "$candidate_pid" =~ ^[0-9]+$ && -n "$script_path" ]] || return 1
+
+	if [[ -r "/proc/${candidate_pid}/cmdline" ]]; then
+		while IFS= read -r -d '' command_arg; do
+			if [[ "$arg_index" -eq 0 ]]; then
+				[[ "$command_arg" == "$script_path" ]] && return 0
+				command_name="${command_arg##*/}"
+				case "$command_name" in
+				bash | dash | ksh | sh | zsh) ;;
+				*) return 1 ;;
+				esac
+				arg_index=1
+				continue
+			fi
+			if [[ "$options_done" == "false" ]]; then
+				case "$command_arg" in
+				--)
+					options_done=true
+					continue
+					;;
+				-*c*) return 1 ;;
+				-*) continue ;;
+				esac
+			fi
+			[[ "$command_arg" == "$script_path" ]] && return 0
+			return 1
+		done <"/proc/${candidate_pid}/cmdline"
+		return 1
+	fi
+
+	command_line=$(ps -p "$candidate_pid" -o command= 2>/dev/null) || command_line=""
 	case "$command_line" in
-	"$script_path" | "$script_path "* | *" $script_path" | *" $script_path "*) return 0 ;;
+	"$script_path" | "$script_path "*) return 0 ;;
 	esac
+	for command_name in bash dash ksh sh zsh; do
+		case "$command_line" in
+		"${command_name} ${script_path}" | "${command_name} ${script_path} "* | */"${command_name} ${script_path}" | */"${command_name} ${script_path} "*)
+			return 0
+			;;
+		esac
+	done
 	return 1
 }
 
-_pulse_command_is_managed() {
-	local command_line="$1"
+_pulse_pid_invokes_managed_script() {
+	local candidate_pid="$1"
 	local active_link_script="${_PULSE_ACTIVE_AGENTS_LINK}/scripts/pulse-wrapper.sh"
 	local bundles_dir=""
-	_pulse_command_uses_script "$command_line" "$active_link_script" && return 0
-	_pulse_command_uses_script "$command_line" "$_PULSE_SCRIPT" && return 0
+	local bundle_script=""
+	_pulse_pid_invokes_script "$candidate_pid" "$active_link_script" && return 0
+	_pulse_pid_invokes_script "$candidate_pid" "$_PULSE_SCRIPT" && return 0
 	case "$_PULSE_AGENTS_DIR" in
 	*/runtime-bundles/*/agents) bundles_dir="${_PULSE_AGENTS_DIR%/*/*}" ;;
 	esac
-	if [[ -n "$bundles_dir" &&
-		"$command_line" == *"${bundles_dir}/"*"/agents/scripts/pulse-wrapper.sh"* ]]; then
-		return 0
-	fi
+	[[ -n "$bundles_dir" ]] || return 1
+	for bundle_script in "$bundles_dir"/*/agents/scripts/pulse-wrapper.sh; do
+		[[ -f "$bundle_script" ]] || continue
+		_pulse_pid_invokes_script "$candidate_pid" "$bundle_script" && return 0
+	done
 	return 1
 }
 
-_pulse_managed_pids() {
+_pulse_pid_is_managed() {
+	local candidate_pid="$1"
+	local parent_pid=""
+	_pulse_pid_invokes_managed_script "$candidate_pid" || return 1
+	parent_pid=$(ps -p "$candidate_pid" -o ppid= 2>/dev/null | tr -d '[:space:]') || parent_pid=""
+	if [[ "$parent_pid" =~ ^[0-9]+$ ]] && _pulse_pid_invokes_managed_script "$parent_pid"; then
+		return 1
+	fi
+	return 0
+}
+
+_pulse_process_start_token() {
+	local candidate_pid="$1"
+	local stat_content=""
+	local stat_after_comm=""
+	local start_token=""
+	[[ "$candidate_pid" =~ ^[0-9]+$ ]] || return 1
+	if [[ -r "/proc/${candidate_pid}/stat" ]]; then
+		stat_content=$(<"/proc/${candidate_pid}/stat") || stat_content=""
+		[[ -n "$stat_content" ]] || return 1
+		stat_after_comm="${stat_content##*) }"
+		start_token=$(printf '%s\n' "$stat_after_comm" | awk '{print $20}') || start_token=""
+	else
+		start_token=$(LC_ALL=C ps -p "$candidate_pid" -o lstart= 2>/dev/null | tr -s ' ') || start_token=""
+		start_token="${start_token#"${start_token%%[![:space:]]*}"}"
+		start_token="${start_token%"${start_token##*[![:space:]]}"}"
+	fi
+	[[ -n "$start_token" ]] || return 1
+	printf '%s\n' "$start_token"
+	return 0
+}
+
+_pulse_pid_identity_is_managed() {
+	local candidate_pid="$1"
+	local expected_start="$2"
+	local current_start=""
+	[[ "$candidate_pid" =~ ^[0-9]+$ && -n "$expected_start" ]] || return 1
+	kill -0 "$candidate_pid" 2>/dev/null || return 1
+	current_start=$(_pulse_process_start_token "$candidate_pid") || return 1
+	[[ "$current_start" == "$expected_start" ]] || return 1
+	_pulse_pid_is_managed "$candidate_pid" || return 1
+	return 0
+}
+
+_pulse_managed_identities() {
 	local candidate_pids=""
 	local candidate_pid=""
-	local command_line=""
+	local start_token=""
 	candidate_pids=$(_pulse_pids_raw)
 	[[ -n "$candidate_pids" ]] || return 0
 	while IFS= read -r candidate_pid; do
 		[[ "$candidate_pid" =~ ^[0-9]+$ ]] || continue
-		command_line=$(ps -p "$candidate_pid" -o command= 2>/dev/null) || command_line=""
-		if _pulse_command_is_managed "$command_line"; then
-			printf '%s\n' "$candidate_pid"
+		_pulse_pid_is_managed "$candidate_pid" || continue
+		start_token=$(_pulse_process_start_token "$candidate_pid") || start_token=""
+		if [[ -z "$start_token" ]]; then
+			_pl_warn "Skipping managed Pulse PID ${candidate_pid}: stable process identity unavailable"
+			continue
 		fi
+		printf '%s\t%s\n' "$candidate_pid" "$start_token"
 	done <<<"$candidate_pids"
+	return 0
+}
+
+_pulse_managed_pids() {
+	local managed_identities=""
+	local managed_pid=""
+	local start_token=""
+	managed_identities=$(_pulse_managed_identities)
+	[[ -n "$managed_identities" ]] || return 0
+	while IFS=$'\t' read -r managed_pid start_token; do
+		[[ -n "$managed_pid" && -n "$start_token" ]] || continue
+		printf '%s\n' "$managed_pid"
+	done <<<"$managed_identities"
 	return 0
 }
 
 _pulse_active_runtime_pids() {
 	local managed_pids=""
 	local managed_pid=""
-	local command_line=""
 	local active_link_script="${_PULSE_ACTIVE_AGENTS_LINK}/scripts/pulse-wrapper.sh"
 	managed_pids=$(_pulse_managed_pids)
 	[[ -n "$managed_pids" ]] || return 0
 	while IFS= read -r managed_pid; do
-		command_line=$(ps -p "$managed_pid" -o command= 2>/dev/null) || command_line=""
-		if _pulse_command_uses_script "$command_line" "$_PULSE_SCRIPT" ||
-			_pulse_command_uses_script "$command_line" "$active_link_script"; then
+		if _pulse_pid_invokes_script "$managed_pid" "$_PULSE_SCRIPT" ||
+			_pulse_pid_invokes_script "$managed_pid" "$active_link_script"; then
 			printf '%s\n' "$managed_pid"
 		fi
 	done <<<"$managed_pids"
@@ -287,38 +405,47 @@ _pulse_pid_is_live() {
 }
 
 _stop_managed() {
-	local managed_pids=""
+	local managed_identities=""
 	local managed_pid=""
+	local start_token=""
 	local survivors=""
 	local residual=""
 	local display_pids=""
-	managed_pids=$(_pulse_managed_pids)
-	[[ -n "$managed_pids" ]] || return 0
-	display_pids=$(printf '%s\n' "$managed_pids" | tr '\n' ' ')
+	managed_identities=$(_pulse_managed_identities)
+	[[ -n "$managed_identities" ]] || return 0
+	while IFS=$'\t' read -r managed_pid start_token; do
+		[[ -n "$managed_pid" && -n "$start_token" ]] || continue
+		display_pids+="${managed_pid} "
+	done <<<"$managed_identities"
 	_pl_info "Stopping managed Pulse instance(s): ${display_pids}"
-	while IFS= read -r managed_pid; do
+	while IFS=$'\t' read -r managed_pid start_token; do
+		_pulse_pid_identity_is_managed "$managed_pid" "$start_token" || continue
 		kill -TERM "$managed_pid" 2>/dev/null || true
-	done <<<"$managed_pids"
+	done <<<"$managed_identities"
 	sleep "$_PULSE_SIGTERM_WAIT"
-	while IFS= read -r managed_pid; do
-		if _pulse_pid_is_live "$managed_pid"; then
-			survivors+="${managed_pid}"$'\n'
+	while IFS=$'\t' read -r managed_pid start_token; do
+		if _pulse_pid_identity_is_managed "$managed_pid" "$start_token"; then
+			survivors+="${managed_pid}"$'\t'"${start_token}"$'\n'
 		fi
-	done <<<"$managed_pids"
+	done <<<"$managed_identities"
 	if [[ -n "$survivors" ]]; then
-		display_pids=$(printf '%s' "$survivors" | tr '\n' ' ')
+		display_pids=""
+		while IFS=$'\t' read -r managed_pid start_token; do
+			[[ -n "$managed_pid" && -n "$start_token" ]] || continue
+			display_pids+="${managed_pid} "
+		done <<<"$survivors"
 		_pl_warn "SIGTERM timeout, escalating managed Pulse to SIGKILL: ${display_pids}"
-		while IFS= read -r managed_pid; do
-			[[ -n "$managed_pid" ]] || continue
+		while IFS=$'\t' read -r managed_pid start_token; do
+			_pulse_pid_identity_is_managed "$managed_pid" "$start_token" || continue
 			kill -KILL "$managed_pid" 2>/dev/null || true
 		done <<<"$survivors"
 		sleep 1
 	fi
-	while IFS= read -r managed_pid; do
-		if _pulse_pid_is_live "$managed_pid"; then
+	while IFS=$'\t' read -r managed_pid start_token; do
+		if _pulse_pid_identity_is_managed "$managed_pid" "$start_token"; then
 			residual+="${managed_pid}"$'\n'
 		fi
-	done <<<"$managed_pids"
+	done <<<"$managed_identities"
 	if [[ -n "$residual" ]]; then
 		display_pids=$(printf '%s' "$residual" | tr '\n' ' ')
 		_pl_err "Failed to stop managed Pulse PIDs: ${display_pids}"

--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -54,6 +54,7 @@ _PULSE_AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}"
 _PULSE_SCRIPT="${_PULSE_AGENTS_DIR}/scripts/pulse-wrapper.sh"
 _PULSE_LOG="${HOME}/.aidevops/logs/pulse-wrapper.log"
 _PULSE_ACTIVE_AGENTS_LINK="${AIDEVOPS_ACTIVE_AGENTS_LINK:-${HOME}/.aidevops/agents}"
+_PULSE_OS_DARWIN="Darwin"
 
 # Process-match pattern for pgrep. The production default matches any
 # pulse-wrapper.sh script regardless of path. Tests may override this to
@@ -171,7 +172,7 @@ _pulse_launchd_supervisor_disabled() {
 	local disabled_state=""
 	local disabled_line=""
 	[[ -n "$os_name" ]] || os_name=$(uname -s 2>/dev/null || printf 'unknown')
-	[[ "$os_name" == "Darwin" ]] || return 1
+	[[ "$os_name" == "$_PULSE_OS_DARWIN" ]] || return 1
 	command -v launchctl >/dev/null 2>&1 || return 1
 	disabled_state=$(launchctl print-disabled "gui/$(id -u)" 2>/dev/null) || return 1
 	while IFS= read -r disabled_line; do
@@ -185,39 +186,189 @@ _pulse_launchd_supervisor_disabled() {
 _pulse_launchd_supervisor_present() {
 	local os_name="${AIDEVOPS_PULSE_OS_NAME:-}"
 	local pulse_label="${AIDEVOPS_PULSE_LAUNCHD_LABEL:-com.aidevops.aidevops-supervisor-pulse}"
-	local pulse_plist="${HOME}/Library/LaunchAgents/${pulse_label}.plist"
 	[[ -n "$os_name" ]] || os_name=$(uname -s 2>/dev/null || printf 'unknown')
-	[[ "$os_name" == "Darwin" ]] || return 1
+	[[ "$os_name" == "$_PULSE_OS_DARWIN" ]] || return 1
 	command -v launchctl >/dev/null 2>&1 || return 1
-	[[ -f "$pulse_plist" ]] && return 0
 	launchctl print "gui/$(id -u)/${pulse_label}" >/dev/null 2>&1 || return 1
 	return 0
 }
 
+_pulse_managed_supervisor_kind() {
+	local os_name="${AIDEVOPS_PULSE_OS_NAME:-}"
+	local cron_state=""
+	[[ -n "$os_name" ]] || os_name=$(uname -s 2>/dev/null || printf 'unknown')
+	if [[ "$os_name" == "$_PULSE_OS_DARWIN" ]]; then
+		_pulse_launchd_supervisor_disabled && return 1
+		_pulse_launchd_supervisor_present || return 1
+		printf '%s\n' "launchd"
+		return 0
+	fi
+	if [[ -f "${HOME}/.config/systemd/user/aidevops-supervisor-pulse.timer" ]] &&
+		command -v systemctl >/dev/null 2>&1 &&
+		systemctl --user is-enabled aidevops-supervisor-pulse.timer >/dev/null 2>&1; then
+		printf '%s\n' "systemd"
+		return 0
+	fi
+	if command -v crontab >/dev/null 2>&1; then
+		cron_state=$(crontab -l 2>/dev/null) || cron_state=""
+		if [[ "$cron_state" == *"aidevops: supervisor-pulse"* ]]; then
+			printf '%s\n' "cron"
+			return 0
+		fi
+	fi
+	return 1
+}
+
+_pulse_command_uses_script() {
+	local command_line="$1"
+	local script_path="$2"
+	case "$command_line" in
+	"$script_path" | "$script_path "* | *" $script_path" | *" $script_path "*) return 0 ;;
+	esac
+	return 1
+}
+
+_pulse_command_is_managed() {
+	local command_line="$1"
+	local active_link_script="${_PULSE_ACTIVE_AGENTS_LINK}/scripts/pulse-wrapper.sh"
+	local bundles_dir=""
+	_pulse_command_uses_script "$command_line" "$active_link_script" && return 0
+	_pulse_command_uses_script "$command_line" "$_PULSE_SCRIPT" && return 0
+	case "$_PULSE_AGENTS_DIR" in
+	*/runtime-bundles/*/agents) bundles_dir="${_PULSE_AGENTS_DIR%/*/*}" ;;
+	esac
+	if [[ -n "$bundles_dir" &&
+		"$command_line" == *"${bundles_dir}/"*"/agents/scripts/pulse-wrapper.sh"* ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_pulse_managed_pids() {
+	local candidate_pids=""
+	local candidate_pid=""
+	local command_line=""
+	candidate_pids=$(_pulse_pids_raw)
+	[[ -n "$candidate_pids" ]] || return 0
+	while IFS= read -r candidate_pid; do
+		[[ "$candidate_pid" =~ ^[0-9]+$ ]] || continue
+		command_line=$(ps -p "$candidate_pid" -o command= 2>/dev/null) || command_line=""
+		if _pulse_command_is_managed "$command_line"; then
+			printf '%s\n' "$candidate_pid"
+		fi
+	done <<<"$candidate_pids"
+	return 0
+}
+
+_pulse_active_runtime_pids() {
+	local managed_pids=""
+	local managed_pid=""
+	local command_line=""
+	local active_link_script="${_PULSE_ACTIVE_AGENTS_LINK}/scripts/pulse-wrapper.sh"
+	managed_pids=$(_pulse_managed_pids)
+	[[ -n "$managed_pids" ]] || return 0
+	while IFS= read -r managed_pid; do
+		command_line=$(ps -p "$managed_pid" -o command= 2>/dev/null) || command_line=""
+		if _pulse_command_uses_script "$command_line" "$_PULSE_SCRIPT" ||
+			_pulse_command_uses_script "$command_line" "$active_link_script"; then
+			printf '%s\n' "$managed_pid"
+		fi
+	done <<<"$managed_pids"
+	return 0
+}
+
+_pulse_pid_is_live() {
+	local pulse_pid="$1"
+	local process_state=""
+	kill -0 "$pulse_pid" 2>/dev/null || return 1
+	process_state=$(ps -p "$pulse_pid" -o stat= 2>/dev/null | tr -d ' ') || return 1
+	[[ -n "$process_state" && "$process_state" != Z* ]] || return 1
+	return 0
+}
+
+_stop_managed() {
+	local managed_pids=""
+	local managed_pid=""
+	local survivors=""
+	local residual=""
+	local display_pids=""
+	managed_pids=$(_pulse_managed_pids)
+	[[ -n "$managed_pids" ]] || return 0
+	display_pids=$(printf '%s\n' "$managed_pids" | tr '\n' ' ')
+	_pl_info "Stopping managed Pulse instance(s): ${display_pids}"
+	while IFS= read -r managed_pid; do
+		kill -TERM "$managed_pid" 2>/dev/null || true
+	done <<<"$managed_pids"
+	sleep "$_PULSE_SIGTERM_WAIT"
+	while IFS= read -r managed_pid; do
+		if _pulse_pid_is_live "$managed_pid"; then
+			survivors+="${managed_pid}"$'\n'
+		fi
+	done <<<"$managed_pids"
+	if [[ -n "$survivors" ]]; then
+		display_pids=$(printf '%s' "$survivors" | tr '\n' ' ')
+		_pl_warn "SIGTERM timeout, escalating managed Pulse to SIGKILL: ${display_pids}"
+		while IFS= read -r managed_pid; do
+			[[ -n "$managed_pid" ]] || continue
+			kill -KILL "$managed_pid" 2>/dev/null || true
+		done <<<"$survivors"
+		sleep 1
+	fi
+	while IFS= read -r managed_pid; do
+		if _pulse_pid_is_live "$managed_pid"; then
+			residual+="${managed_pid}"$'\n'
+		fi
+	done <<<"$managed_pids"
+	if [[ -n "$residual" ]]; then
+		display_pids=$(printf '%s' "$residual" | tr '\n' ' ')
+		_pl_err "Failed to stop managed Pulse PIDs: ${display_pids}"
+		return 1
+	fi
+	return 0
+}
+
 _pulse_start_managed() {
+	local supervisor_kind="$1"
 	local pulse_label="${AIDEVOPS_PULSE_LAUNCHD_LABEL:-com.aidevops.aidevops-supervisor-pulse}"
 	local launchd_target=""
-	local launchd_wait_count=0
-	launchd_target="gui/$(id -u)/${pulse_label}"
-	if _pulse_launchd_supervisor_present; then
+	local managed_wait_count=0
+	case "$supervisor_kind" in
+	launchd)
+		launchd_target="gui/$(id -u)/${pulse_label}"
 		_pl_info "Requesting Pulse restart from launchd supervisor ${pulse_label}"
 		if ! launchctl kickstart -k "$launchd_target" >/dev/null 2>&1; then
 			_pl_err "launchd could not restart Pulse; refusing an unmanaged fallback"
 			return 1
 		fi
-		while [[ "$launchd_wait_count" -lt 5 ]]; do
-			if _is_running; then
-				_pl_ok "Pulse restarted by launchd"
-				return 0
-			fi
-			sleep 1
-			launchd_wait_count=$((launchd_wait_count + 1))
-		done
-		_pl_err "launchd accepted the Pulse restart but no managed process appeared"
+		;;
+	systemd)
+		_pl_info "Requesting Pulse restart from systemd supervisor aidevops-supervisor-pulse"
+		if ! systemctl --user restart aidevops-supervisor-pulse.service >/dev/null 2>&1; then
+			_pl_err "systemd could not restart Pulse; refusing an unmanaged fallback"
+			return 1
+		fi
+		;;
+	cron)
+		_pl_info "Starting Pulse from the canonical managed cron runtime"
+		mkdir -p "${_PULSE_LOG%/*}"
+		AIDEVOPS_PULSE_SOURCE=lifecycle-helper nohup "$_PULSE_SCRIPT" >>"$_PULSE_LOG" 2>&1 &
+		disown 2>/dev/null || true
+		;;
+	*)
+		_pl_err "Unknown managed Pulse supervisor kind: ${supervisor_kind}"
 		return 1
-	fi
-	_start || return $?
-	return 0
+		;;
+	esac
+	while [[ "$managed_wait_count" -lt 5 ]]; do
+		if [[ -n "$(_pulse_active_runtime_pids)" ]]; then
+			_pl_ok "Pulse restarted by ${supervisor_kind}"
+			return 0
+		fi
+		sleep 1
+		managed_wait_count=$((managed_wait_count + 1))
+	done
+	_pl_err "${supervisor_kind} accepted the Pulse restart but no managed process appeared"
+	return 1
 }
 
 # _pulse_pids_raw: print ALL matching pulse PIDs including subshells of the
@@ -460,7 +611,7 @@ _reconcile_managed() {
 	local runtime_module="${_PULSE_AGENTS_DIR}/scripts/setup/modules/agent-runtime.sh"
 	local reconcile_rc=0
 	local bundle_id=""
-	local supervisor_disabled=false
+	local supervisor_kind=""
 
 	if [[ ! -r "$runtime_module" ]]; then
 		_pl_err "Runtime transition support is missing from the activated bundle"
@@ -474,19 +625,21 @@ _reconcile_managed() {
 	fi
 
 	if [[ "${AIDEVOPS_PULSE_MANAGED_ENABLED:-false}" != "true" ]]; then
-		supervisor_disabled=true
-	elif _pulse_launchd_supervisor_disabled; then
-		supervisor_disabled=true
+		_pl_info "Pulse reconciliation skipped because its canonical supervisor is disabled"
+		aidevops_runtime_transition_lock_release
+		return 0
+	fi
+	if ! supervisor_kind=$(_pulse_managed_supervisor_kind); then
+		_pl_info "Pulse reconciliation skipped because its canonical supervisor is absent or disabled"
+		aidevops_runtime_transition_lock_release
+		return 0
 	fi
 
 	if ! _pulse_refresh_active_runtime; then
 		_pl_err "Unable to resolve the active runtime bundle"
 		reconcile_rc=1
-	elif [[ "$supervisor_disabled" == "true" ]]; then
-		_stop_all || reconcile_rc=$?
-		[[ "$reconcile_rc" -eq 0 ]] && _pl_info "Pulse remains stopped because its supervisor is disabled"
 	else
-		_stop_all || reconcile_rc=$?
+		_stop_managed || reconcile_rc=$?
 		if [[ "$reconcile_rc" -eq 0 ]]; then
 			sleep "$_PULSE_RESTART_WAIT"
 			if ! _pulse_refresh_active_runtime; then
@@ -495,7 +648,7 @@ _reconcile_managed() {
 			else
 				bundle_id=$(_pulse_runtime_bundle_id)
 				_pl_info "Starting Pulse from activated runtime bundle ${bundle_id}"
-				_pulse_start_managed || reconcile_rc=$?
+				_pulse_start_managed "$supervisor_kind" || reconcile_rc=$?
 			fi
 		fi
 	fi

--- a/.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh
+++ b/.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 TEST_ROOT=""
 PULSE_PATTERN=""
+CUSTOM_PULSE_PID=""
+CUSTOM_SIGNAL_LOG=""
 TESTS_RUN=0
 
 print_info() { local message="$1"; printf '%s\n' "$message"; return 0; }
@@ -65,6 +67,33 @@ SH
 	return 0
 }
 
+write_enabled_launchctl_fixture() {
+	local fake_bin="$1"
+	mkdir -p "$fake_bin"
+	cat >"$fake_bin/launchctl" <<'SH'
+#!/usr/bin/env bash
+command_name="${1:-}"
+case "$command_name" in
+print-disabled)
+	printf '%s\n' '    "com.aidevops.aidevops-supervisor-pulse" => false'
+	exit 0
+	;;
+print)
+	exit 0
+	;;
+kickstart)
+	printf '%s\n' "$*" >>"${LAUNCHCTL_LOG:?}"
+	active_root=$(cd "${AIDEVOPS_ACTIVE_AGENTS_LINK:?}" && pwd -P)
+	nohup "$active_root/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
+	exit 0
+	;;
+esac
+exit 1
+SH
+	chmod +x "$fake_bin/launchctl"
+	return 0
+}
+
 assert_only_active_bundle_runs() {
 	local active_script="$1"
 	local stale_script="$2"
@@ -84,6 +113,7 @@ test_stale_install_dir_uses_active_bundle() {
 	local active_link="$3"
 	local output=""
 	local output_file="$TEST_ROOT/stale-restart.out"
+	local stale_pid=""
 
 	INSTALL_DIR="$TEST_ROOT/caller-worktree"
 	export INSTALL_DIR
@@ -94,8 +124,14 @@ printf 'caller-worktree\n' >>"${PULSE_START_LOG:?}"
 SH
 	chmod +x "$INSTALL_DIR/.agents/scripts/pulse-wrapper.sh"
 
+	nohup "$stale_root/agents/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
+	stale_pid=$!
+	sleep 0.2
 	_restart_pulse_if_running "$stale_root/agents" true "$active_link" >"$output_file"
 	output=$(<"$output_file")
+	if kill -0 "$stale_pid" 2>/dev/null; then
+		fail "stale managed Pulse PID survived reconciliation"
+	fi
 	[[ "$output" == *"bundle-b"* ]] || fail "restart diagnostics omit the selected active bundle"
 	[[ "$output" != *"$TEST_ROOT"* ]] || fail "restart diagnostics expose a private local path"
 	grep -qF "$active_root/agents/scripts/pulse-wrapper.sh" "$PULSE_START_LOG" || \
@@ -110,19 +146,25 @@ SH
 	return 0
 }
 
-test_disabled_supervisor_stays_stopped() {
+test_disabled_supervisor_is_safe_noop() {
 	local active_root="$1"
 	local active_link="$2"
 	local starts_before=""
 	local starts_after=""
+	local pulse_pid=""
+	pulse_pid=$(pgrep -f "$PULSE_PATTERN" | while IFS= read -r candidate_pid; do
+		if ps -p "$candidate_pid" -o command= | grep -qF "$active_root/agents/scripts/pulse-wrapper.sh"; then
+			printf '%s\n' "$candidate_pid"
+			break
+		fi
+	done)
 	starts_before=$(wc -l <"$PULSE_START_LOG" | tr -d ' ')
 	_restart_pulse_if_running "$active_root/agents" false "$active_link" >/dev/null
 	starts_after=$(wc -l <"$PULSE_START_LOG" | tr -d ' ')
 	[[ "$starts_after" == "$starts_before" ]] || fail "disabled reconciliation started a new Pulse"
-	if pgrep -f "$PULSE_PATTERN" >/dev/null 2>&1; then
-		fail "disabled supervisor reconciliation left Pulse running"
-	fi
-	pass "disabled supervisor remains stopped without a manual fallback"
+	[[ -n "$pulse_pid" ]] || fail "disabled reconciliation fixture had no active managed Pulse"
+	kill -0 "$pulse_pid" 2>/dev/null || fail "disabled reconciliation terminated the existing managed Pulse"
+	pass "disabled supervisor causes a signal-free reconciliation no-op"
 	return 0
 }
 
@@ -169,6 +211,7 @@ test_launchd_disabled_service_stays_stopped() {
 	local fake_bin="$TEST_ROOT/fake-bin"
 	local starts_before=""
 	local starts_after=""
+	local pulse_pid=""
 	mkdir -p "$fake_bin"
 	cat >"$fake_bin/launchctl" <<'SH'
 #!/usr/bin/env bash
@@ -180,6 +223,12 @@ fi
 exit 1
 SH
 	chmod +x "$fake_bin/launchctl"
+	pulse_pid=$(pgrep -f "$PULSE_PATTERN" | while IFS= read -r candidate_pid; do
+		if ps -p "$candidate_pid" -o command= | grep -qF "$active_root/agents/scripts/pulse-wrapper.sh"; then
+			printf '%s\n' "$candidate_pid"
+			break
+		fi
+	done)
 	starts_before=$(wc -l <"$PULSE_START_LOG" | tr -d ' ')
 	(
 		export PATH="$fake_bin:$PATH"
@@ -188,10 +237,57 @@ SH
 	)
 	starts_after=$(wc -l <"$PULSE_START_LOG" | tr -d ' ')
 	[[ "$starts_after" == "$starts_before" ]] || fail "disabled launchd reconciliation started a new Pulse"
-	if pgrep -f "$PULSE_PATTERN" >/dev/null 2>&1; then
-		fail "disabled launchd service reconciliation left Pulse running"
-	fi
-	pass "disabled launchd service remains authoritative without a manual fallback"
+	[[ -n "$pulse_pid" ]] || fail "disabled launchd fixture had no active managed Pulse"
+	kill -0 "$pulse_pid" 2>/dev/null || fail "disabled launchd reconciliation terminated the existing managed Pulse"
+	pass "disabled launchd service causes a signal-free reconciliation no-op"
+	return 0
+}
+
+test_missing_canonical_supervisor_preserves_custom_scheduler() {
+	local active_root="$1"
+	local active_link="$2"
+	local fake_bin="$TEST_ROOT/fake-bin"
+	local custom_script="$TEST_ROOT/custom/scripts/pulse-wrapper.sh"
+	local output=""
+	local starts_before=""
+	local starts_after=""
+	mkdir -p "${custom_script%/*}"
+	cat >"$fake_bin/launchctl" <<'SH'
+#!/usr/bin/env bash
+command_name="${1:-}"
+target="${2:-}"
+if [[ "$command_name" == "print-disabled" ]]; then
+	printf '%s\n' '    "com.example.observation-pulse" => false'
+	exit 0
+fi
+if [[ "$command_name" == "print" && "$target" == *"com.example.observation-pulse" ]]; then
+	exit 0
+fi
+exit 1
+SH
+	chmod +x "$fake_bin/launchctl"
+	cat >"$custom_script" <<'SH'
+#!/usr/bin/env bash
+trap 'printf "TERM\n" >>"${CUSTOM_SIGNAL_LOG:?}"; exit 0' TERM
+while :; do
+	sleep 1
+done
+SH
+	chmod +x "$custom_script"
+	CUSTOM_SIGNAL_LOG="$TEST_ROOT/custom-signals.log"
+	: >"$CUSTOM_SIGNAL_LOG"
+	export CUSTOM_SIGNAL_LOG
+	"$custom_script" &
+	CUSTOM_PULSE_PID=$!
+	sleep 0.2
+	starts_before=$(wc -l <"$PULSE_START_LOG" | tr -d ' ')
+	output=$(_restart_pulse_if_running "$active_root/agents" true "$active_link" 2>&1)
+	starts_after=$(wc -l <"$PULSE_START_LOG" | tr -d ' ')
+	[[ "$starts_after" == "$starts_before" ]] || fail "missing canonical supervisor started a managed Pulse"
+	kill -0 "$CUSTOM_PULSE_PID" 2>/dev/null || fail "missing canonical supervisor terminated custom scheduler PID"
+	[[ ! -s "$CUSTOM_SIGNAL_LOG" ]] || fail "missing canonical supervisor signalled custom scheduler"
+	[[ "$output" == *"canonical supervisor is absent or disabled"* ]] || fail "missing canonical supervisor did not report a no-op"
+	pass "agent deployment preserves custom scheduler when canonical supervisor is absent"
 	return 0
 }
 
@@ -201,27 +297,7 @@ test_launchd_enabled_service_owns_restart() {
 	local fake_bin="$TEST_ROOT/fake-bin"
 	local launchctl_log="$TEST_ROOT/launchctl.log"
 	local output_file="$TEST_ROOT/launchd-restart.out"
-	cat >"$fake_bin/launchctl" <<'SH'
-#!/usr/bin/env bash
-command_name="${1:-}"
-case "$command_name" in
-print-disabled)
-	printf '%s\n' '    "com.aidevops.aidevops-supervisor-pulse" => false'
-	exit 0
-	;;
-print)
-	exit 0
-	;;
-kickstart)
-	printf '%s\n' "$*" >>"${LAUNCHCTL_LOG:?}"
-	active_root=$(cd "${AIDEVOPS_ACTIVE_AGENTS_LINK:?}" && pwd -P)
-	nohup "$active_root/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
-	exit 0
-	;;
-esac
-exit 1
-SH
-	chmod +x "$fake_bin/launchctl"
+	write_enabled_launchctl_fixture "$fake_bin"
 	: >"$launchctl_log"
 	(
 		export PATH="$fake_bin:$PATH"
@@ -232,6 +308,8 @@ SH
 	grep -q '^kickstart -k gui/' "$launchctl_log" || fail "enabled launchd service did not receive the restart request"
 	grep -qF "$active_root/agents/scripts/pulse-wrapper.sh" "$PULSE_START_LOG" || \
 		fail "launchd fixture did not start Pulse from the active bundle"
+	kill -0 "$CUSTOM_PULSE_PID" 2>/dev/null || fail "enabled canonical restart terminated custom scheduler PID"
+	[[ ! -s "$CUSTOM_SIGNAL_LOG" ]] || fail "enabled canonical restart signalled custom scheduler"
 	assert_only_active_bundle_runs \
 		"$active_root/agents/scripts/pulse-wrapper.sh" \
 		"$TEST_ROOT/caller-worktree/.agents/scripts/pulse-wrapper.sh"
@@ -244,6 +322,7 @@ main() {
 	local active_root=""
 	local active_link=""
 	local escaped_root=""
+	local fake_bin=""
 
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
@@ -258,20 +337,27 @@ main() {
 	ln -s "$active_root/agents" "$active_link"
 
 	escaped_root=$(printf '%s' "$TEST_ROOT" | sed 's/[][\\.^$*+?{}|()]/\\&/g')
-	PULSE_PATTERN="${escaped_root}/runtime-bundles/.*/agents/scripts/pulse-wrapper\\.sh"
+	PULSE_PATTERN="${escaped_root}/.*/pulse-wrapper\\.sh"
 	PULSE_START_LOG="$TEST_ROOT/pulse-starts.log"
 	: >"$PULSE_START_LOG"
 	export PULSE_START_LOG
 	export AIDEVOPS_PULSE_PROCESS_PATTERN="$PULSE_PATTERN"
 	export AIDEVOPS_PULSE_RESTART_WAIT=0
 	export AIDEVOPS_PULSE_SIGTERM_WAIT=1
-	export AIDEVOPS_PULSE_OS_NAME=Linux
+	fake_bin="$TEST_ROOT/fake-bin"
+	LAUNCHCTL_LOG="$TEST_ROOT/launchctl.log"
+	: >"$LAUNCHCTL_LOG"
+	write_enabled_launchctl_fixture "$fake_bin"
+	PATH="$fake_bin:$PATH"
+	export PATH LAUNCHCTL_LOG
+	export AIDEVOPS_PULSE_OS_NAME=Darwin
 	export AIDEVOPS_RUNTIME_TRANSITION_LOCK_WAIT_SECONDS=10
 
 	test_stale_install_dir_uses_active_bundle "$stale_root" "$active_root" "$active_link"
-	test_disabled_supervisor_stays_stopped "$active_root" "$active_link"
+	test_disabled_supervisor_is_safe_noop "$active_root" "$active_link"
 	test_concurrent_transition_converges_on_active_bundle "$stale_root" "$active_root" "$active_link"
 	test_launchd_disabled_service_stays_stopped "$active_root" "$active_link"
+	test_missing_canonical_supervisor_preserves_custom_scheduler "$active_root" "$active_link"
 	test_launchd_enabled_service_owns_restart "$active_root" "$active_link"
 
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -68,7 +68,9 @@ _assert_eq() {
 
 _setup() {
 	TEST_ROOT=$(mktemp -d -t pulse-lifecycle-test.XXXXXX)
-	mkdir -p "${TEST_ROOT}/scripts" "${TEST_ROOT}/logs"
+	mkdir -p "${TEST_ROOT}/scripts/setup/modules" "${TEST_ROOT}/logs" "${TEST_ROOT}/custom"
+	cp "${SCRIPT_DIR}/../setup/modules/agent-runtime.sh" \
+		"${TEST_ROOT}/scripts/setup/modules/agent-runtime.sh"
 
 	# Create mock pulse-wrapper.sh that sleeps long enough to be caught by
 	# pgrep. sleep 300 keeps it alive for the life of the test suite.
@@ -90,7 +92,7 @@ SH
 	# . must be escaped. mktemp paths contain only [A-Za-z0-9./] so this
 	# is sufficient.
 	local _escaped_root="${TEST_ROOT//./\\.}"
-	export AIDEVOPS_PULSE_PROCESS_PATTERN="${_escaped_root}/scripts/pulse-wrapper\\.sh"
+	export AIDEVOPS_PULSE_PROCESS_PATTERN="${_escaped_root}/.*/pulse-wrapper\\.sh"
 
 	# Ensure env overrides don't leak between tests.
 	unset AIDEVOPS_SKIP_PULSE_RESTART 2>/dev/null || true
@@ -477,6 +479,66 @@ test_missing_pulse_script_exit_2() {
 	# Restore for subsequent tests.
 	mv "$_saved" "${TEST_ROOT}/scripts/pulse-wrapper.sh"
 	_assert_eq "start with missing pulse-wrapper.sh exits 2" "2" "$rc"
+	return 0
+}
+
+test_reconcile_managed_preserves_custom_scheduler_without_canonical_supervisor() {
+	local fake_bin="${TEST_ROOT}/fake-bin-missing-supervisor"
+	local custom_script="${TEST_ROOT}/custom/pulse-wrapper.sh"
+	local signal_log="${TEST_ROOT}/custom-signals.log"
+	local custom_pid=""
+	local output=""
+	mkdir -p "$fake_bin"
+	cat >"$fake_bin/launchctl" <<'SH'
+#!/usr/bin/env bash
+command_name="${1:-}"
+target="${2:-}"
+if [[ "$command_name" == "print-disabled" ]]; then
+	printf '%s\n' '    "com.example.observation-pulse" => false'
+	exit 0
+fi
+if [[ "$command_name" == "print" && "$target" == *"com.example.observation-pulse" ]]; then
+	exit 0
+fi
+exit 1
+SH
+	chmod +x "$fake_bin/launchctl"
+	cat >"$custom_script" <<'SH'
+#!/usr/bin/env bash
+trap 'printf "TERM\n" >>"${CUSTOM_SIGNAL_LOG:?}"; exit 0' TERM
+while :; do
+	sleep 1
+done
+SH
+	chmod +x "$custom_script"
+	: >"$signal_log"
+	CUSTOM_SIGNAL_LOG="$signal_log" "$custom_script" &
+	custom_pid=$!
+	MOCK_PIDS+=("$custom_pid")
+	sleep 0.2
+	output=$(PATH="$fake_bin:$PATH" \
+		AIDEVOPS_ACTIVE_AGENTS_LINK="$TEST_ROOT" \
+		AIDEVOPS_PULSE_MANAGED_ENABLED=true \
+		AIDEVOPS_PULSE_OS_NAME=Darwin \
+		AIDEVOPS_RUNTIME_TRANSITION_LOCK_DIR="${TEST_ROOT}/locks/reconcile.lock.d" \
+		"$HELPER" reconcile-managed 2>&1)
+	if kill -0 "$custom_pid" 2>/dev/null; then
+		_print_result "reconcile-managed preserves custom scheduler PID when canonical supervisor is absent" 1
+	else
+		_print_result "reconcile-managed terminated custom scheduler PID $custom_pid" 0
+	fi
+	if [[ ! -s "$signal_log" ]]; then
+		_print_result "reconcile-managed sends no signal to custom scheduler" 1
+	else
+		_print_result "reconcile-managed signalled custom scheduler (signals=$(<"$signal_log"))" 0
+	fi
+	if [[ "$output" == *"canonical supervisor is absent or disabled"* ]]; then
+		_print_result "reconcile-managed reports a clear missing-supervisor no-op" 1
+	else
+		_print_result "reconcile-managed missing-supervisor result was unclear (out=$output)" 0
+	fi
+	kill -KILL "$custom_pid" 2>/dev/null || true
+	wait "$custom_pid" 2>/dev/null || true
 	return 0
 }
 
@@ -901,6 +963,7 @@ main() {
 	test_skip_env_honoured_in_restart_if_running
 	test_skip_env_honoured_in_restart
 	test_missing_pulse_script_exit_2
+	test_reconcile_managed_preserves_custom_scheduler_without_canonical_supervisor
 	test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early
 	test_pipe_trap_restore_avoids_eval
 	test_pipe_trap_restore_ignored_sigpipe

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -542,6 +542,142 @@ SH
 	return 0
 }
 
+test_launchd_disabled_query_failure_fails_closed() {
+	local fake_bin="${TEST_ROOT}/fake-bin-disabled-query-failure"
+	local output=""
+	mkdir -p "$fake_bin"
+	cat >"$fake_bin/launchctl" <<'SH'
+#!/usr/bin/env bash
+command_name="${1:-}"
+if [[ "$command_name" == "print-disabled" ]]; then
+	exit 1
+fi
+if [[ "$command_name" == "print" ]]; then
+	exit 0
+fi
+exit 1
+SH
+	chmod +x "$fake_bin/launchctl"
+	output=$(PATH="$fake_bin:$PATH" \
+		AIDEVOPS_ACTIVE_AGENTS_LINK="$TEST_ROOT" \
+		AIDEVOPS_PULSE_MANAGED_ENABLED=true \
+		AIDEVOPS_PULSE_OS_NAME=Darwin \
+		AIDEVOPS_RUNTIME_TRANSITION_LOCK_DIR="${TEST_ROOT}/locks/disabled-query.lock.d" \
+		"$HELPER" reconcile-managed 2>&1)
+	if [[ "$output" == *"canonical supervisor is absent or disabled"* ]]; then
+		_print_result "reconcile-managed fails closed when launchd disabled-state query fails" 1
+	else
+		_print_result "launchd disabled-state query failure did not fail closed (out=$output)" 0
+	fi
+	return 0
+}
+
+test_cron_supervisor_requires_active_canonical_entry() {
+	local fake_bin="${TEST_ROOT}/fake-bin-cron-state"
+	local fake_home="${TEST_ROOT}/home-cron-state"
+	local output=""
+	local rc=0
+	mkdir -p "$fake_bin" "$fake_home"
+	cat >"$fake_bin/crontab" <<'SH'
+#!/usr/bin/env bash
+[[ "${1:-}" == "-l" ]] || exit 1
+printf '%s\n' "${CRON_FIXTURE:-}"
+SH
+	chmod +x "$fake_bin/crontab"
+	output=$(PATH="$fake_bin:$PATH" \
+		HOME="$fake_home" \
+		CRON_FIXTURE='# */2 * * * * /bin/bash pulse-wrapper.sh # aidevops: supervisor-pulse' \
+		AIDEVOPS_PULSE_OS_NAME=Linux \
+		bash -c 'source "$1"; _pulse_managed_supervisor_kind' _ "$HELPER" 2>&1) || rc=$?
+	_assert_eq "commented canonical cron entry is disabled" "1" "$rc"
+	_assert_eq "commented canonical cron entry emits no supervisor kind" "" "$output"
+
+	rc=0
+	output=$(PATH="$fake_bin:$PATH" \
+		HOME="$fake_home" \
+		CRON_FIXTURE='*/2 * * * * /bin/bash -lc pulse-wrapper.sh >> pulse.log 2>&1 # aidevops: supervisor-pulse' \
+		AIDEVOPS_PULSE_OS_NAME=Linux \
+		bash -c 'source "$1"; _pulse_managed_supervisor_kind' _ "$HELPER" 2>&1) || rc=$?
+	_assert_eq "active canonical cron entry is enabled" "0" "$rc"
+	_assert_eq "active canonical cron entry reports cron" "cron" "$output"
+	return 0
+}
+
+test_managed_stop_rejects_observer_argv() {
+	local managed_pid=""
+	local observer_pid=""
+	"${TEST_ROOT}/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
+	managed_pid=$!
+	bash -c 'while :; do sleep 1; done' pulse-observer "${TEST_ROOT}/scripts/pulse-wrapper.sh" &
+	observer_pid=$!
+	MOCK_PIDS+=("$managed_pid" "$observer_pid")
+	sleep 0.2
+	AIDEVOPS_AGENTS_DIR="$TEST_ROOT" \
+		AIDEVOPS_ACTIVE_AGENTS_LINK="$TEST_ROOT" \
+		AIDEVOPS_PULSE_SIGTERM_WAIT=0 \
+		bash -c 'source "$1"; _stop_managed' _ "$HELPER" >/dev/null 2>&1 || true
+	if kill -0 "$managed_pid" 2>/dev/null; then
+		_print_result "managed stop terminates the actual Pulse process" 0
+	else
+		_print_result "managed stop terminates the actual Pulse process" 1
+	fi
+	if kill -0 "$observer_pid" 2>/dev/null; then
+		_print_result "managed stop preserves an observer that only mentions pulse-wrapper.sh" 1
+	else
+		_print_result "managed stop killed an observer that only mentioned pulse-wrapper.sh" 0
+	fi
+	kill -KILL "$observer_pid" 2>/dev/null || true
+	wait "$observer_pid" 2>/dev/null || true
+	return 0
+}
+
+test_managed_stop_revalidates_identity_before_kill() {
+	local validation_count_file="${TEST_ROOT}/identity-validation-count"
+	local signal_log="${TEST_ROOT}/identity-signals.log"
+	local signal_state=""
+	printf '0\n' >"$validation_count_file"
+	: >"$signal_log"
+	bash -c '
+		source "$1"
+		validation_count_file="$2"
+		signal_log="$3"
+		_pulse_managed_identities() {
+			printf "4242\tstart-a\n"
+			return 0
+		}
+		_pulse_pid_identity_is_managed() {
+			local candidate_pid="$1"
+			local expected_start="$2"
+			local validation_count=""
+			: "$candidate_pid" "$expected_start"
+			validation_count=$(<"$validation_count_file")
+			validation_count=$((validation_count + 1))
+			printf "%s\n" "$validation_count" >"$validation_count_file"
+			[[ "$validation_count" -le 2 ]] || return 1
+			return 0
+		}
+		kill() {
+			local signal_name="$1"
+			local target_pid="$2"
+			printf "%s %s\n" "$signal_name" "$target_pid" >>"$signal_log"
+			return 0
+		}
+		sleep() {
+			local duration="$1"
+			: "$duration"
+			return 0
+		}
+		_stop_managed
+	' _ "$HELPER" "$validation_count_file" "$signal_log" >/dev/null 2>&1
+	signal_state=$(<"$signal_log")
+	if [[ "$signal_state" == *"-TERM 4242"* && "$signal_state" != *"-KILL 4242"* ]]; then
+		_print_result "managed stop revalidates stable identity before SIGKILL" 1
+	else
+		_print_result "managed stop signalled a changed identity (signals=$signal_state)" 0
+	fi
+	return 0
+}
+
 test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early() {
 	local rc=0 err=""
 	err=$(
@@ -964,6 +1100,10 @@ main() {
 	test_skip_env_honoured_in_restart
 	test_missing_pulse_script_exit_2
 	test_reconcile_managed_preserves_custom_scheduler_without_canonical_supervisor
+	test_launchd_disabled_query_failure_fails_closed
+	test_cron_supervisor_requires_active_canonical_entry
+	test_managed_stop_rejects_observer_argv
+	test_managed_stop_revalidates_identity_before_kill
 	test_pulse_pids_suppresses_broken_pipe_when_consumer_exits_early
 	test_pipe_trap_restore_avoids_eval
 	test_pipe_trap_restore_ignored_sigpipe


### PR DESCRIPTION
## Summary

- require the canonical Pulse supervisor to be present and enabled before deployment reconciliation can signal any process
- target only PIDs whose command paths prove ownership by the canonical active link or immutable runtime bundles
- preserve custom and observation Pulse schedulers when the canonical supervisor is missing, disabled, or restarted

## Implementation

- `.agents/scripts/pulse-lifecycle-helper.sh`: add supervisor validation, exact managed-PID discovery, exact TERM/KILL escalation, and supervisor-native launchd/systemd/cron restart paths; preserve broad `stop` semantics for explicit manual use
- `.agents/scripts/tests/test-pulse-lifecycle-helper.sh`: prove a custom path and custom launchd label receive no signal when the canonical supervisor is absent
- `.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh`: prove agent deployment is a safe no-op without the canonical supervisor and that enabled canonical restart preserves the custom scheduler while converging onto the active runtime bundle

## Testing

- `shellcheck .agents/scripts/pulse-lifecycle-helper.sh .agents/scripts/tests/test-pulse-lifecycle-helper.sh .agents/scripts/tests/test-agent-deploy-pulse-runtime.sh`
- `bash .agents/scripts/tests/test-pulse-lifecycle-helper.sh` (45 checks)
- `bash .agents/scripts/tests/test-agent-deploy-pulse-runtime.sh` (9 checks)

## Runtime Testing

Runtime-verified with real background mock Pulse processes, exact PID preservation checks, TERM signal logs, and fake launchd supervisor state transitions.

## Decisions

- Keep explicit manual `stop` behavior unchanged.
- Treat plist presence alone as insufficient ownership evidence; the canonical launchd label must be loaded.
- Preserve runtime-bundle activation as non-fatal when reconciliation safely skips.

Resolves #28059

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 16m and 203,836 tokens on this as a headless worker. Overall, 31m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pulse lifecycle reconciliation with supervisor-type awareness (launchd, systemd, cron), including safer managed start/stop behavior.
  * Avoided unnecessary restarts when the canonical supervisor is disabled or missing.
  * Ensured custom/independently managed Pulse processes remain running during safe no-op reconciliations.
  * Strengthened restart success verification by waiting for the expected managed runtime process.

* **Tests**
  * Expanded reconciliation and stop coverage for disabled/missing/enabled supervisor scenarios.
  * Added signal/no-op assertions to confirm custom schedulers aren’t terminated and that failure-closed behaviors are correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->