### PR TITLE
GH#28060: fix: harden worker launch evidence

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -606,6 +606,18 @@ _dsi_ps_worker_lines() {
 }
 
 #######################################
+# Check whether a PID is currently signalable by this runner.
+# Tests override this function with deterministic process fixtures.
+# Args: $1 - PID
+# Returns: 0 live, 1 dead/inaccessible
+#######################################
+_dsi_pid_is_live() {
+	local pid="$1"
+	kill -0 "$pid" 2>/dev/null
+	return $?
+}
+
+#######################################
 # Check if a command line belongs to a worker for an issue number.
 # Args: $1 - issue number, $2 - command line
 # Returns: 0 match, 1 no match
@@ -720,6 +732,51 @@ _dsi_print_dispatch_details() {
 	_dsi_info "  Existing worktree:${worktree_path}"
 	_dsi_info "  Existing session: ${session_key}"
 	return 0
+}
+
+#######################################
+# Verify that a ledger record still names the same live worker process.
+# A lease can intentionally outlive its local PID for cross-runner dedup, so
+# launch-worker status must independently validate PID liveness plus the
+# session, worktree, issue, and repository encoded in the process command.
+# Args: $1 - issue number, $2 - repo slug, $3 - ledger TSV record
+# Returns: 0 verified live worker, 1 stale/dead/reused PID evidence
+#######################################
+_dsi_ledger_record_has_live_identity() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local record="$3"
+	local source="" pid="" log_path="" worktree_path="" session_key=""
+	IFS=$'\t' read -r source pid log_path worktree_path session_key <<<"$record"
+
+	[[ "$source" == "ledger" && "$pid" =~ ^[0-9]+$ ]] || return 1
+	[[ -n "$session_key" && "$session_key" != "$_DSI_UNKNOWN_VALUE" ]] || return 1
+	[[ -n "$worktree_path" && "$worktree_path" != "$_DSI_UNKNOWN_VALUE" ]] || return 1
+	_dsi_pid_is_live "$pid" || return 1
+
+	local line="" process_pid="" stat="" cmd=""
+	local process_session="" process_worktree="" process_repo=""
+	while IFS= read -r line; do
+		[[ -n "$line" ]] || continue
+		process_pid="${line%%[[:space:]]*}"
+		[[ "$process_pid" == "$pid" ]] || continue
+		line="${line#*[[:space:]]}"
+		stat="${line%%[[:space:]]*}"
+		cmd="${line#*[[:space:]]}"
+		[[ "$stat" != *Z* && "$stat" != *T* ]] || return 1
+		[[ "$cmd" == *"headless-runtime-helper.sh"* ]] || return 1
+
+		process_session=$(printf '%s' "$cmd" | sed -n 's/.*--session-key[[:space:]]\([^[:space:]]*\).*/\1/p')
+		[[ "$process_session" == "$session_key" ]] || return 1
+		process_worktree=$(_dsi_extract_worktree_from_cmd "$cmd")
+		[[ "$process_worktree" == "$worktree_path" ]] || return 1
+		_dsi_cmd_matches_issue "$issue_number" "$cmd" || return 1
+		process_repo=$(_dsi_repo_slug_for_worktree "$process_worktree")
+		[[ "$process_repo" == "$repo_slug" ]] || return 1
+		return 0
+	done < <(_dsi_ps_worker_lines)
+
+	return 1
 }
 
 #######################################
@@ -1531,7 +1588,8 @@ cmd_status() {
 	fi
 
 	local record=""
-	if record=$(_dsi_find_ledger_dispatch "$issue_number" "$repo_slug"); then
+	if record=$(_dsi_find_ledger_dispatch "$issue_number" "$repo_slug") &&
+		_dsi_ledger_record_has_live_identity "$issue_number" "$repo_slug" "$record"; then
 		_dsi_ok "Active dispatch for #${issue_number} (${repo_slug}):"
 		_dsi_print_dispatch_details "$record"
 		return 0

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -50,6 +50,7 @@ unset _HRFF_SCRIPT_DIR
 # Recognised by dispatch-dedup-helper.sh: any CLAIM_RELEASED is treated as
 # authoritative regardless of reason value.
 readonly _HRFF_FALLBACK_EXIT="process_exit"
+readonly _HRFF_PRELAUNCH_NOT_INVOKED="worker_runtime_not_invoked"
 
 # Per-issue transient rate-limit release circuit breaker (t3570 / GH#23102).
 # These defaults intentionally keep the first transient failures visible while
@@ -858,22 +859,59 @@ _worker_archive_dirty_worktree_patch() {
 }
 
 #######################################
-# EXIT trap handler — classify worker termination and post CLAIM_RELEASED.
-# Replaces the inline 'process_exit' reason in the EXIT trap with a
-# classified reason from classify_worker_exit. Falls back to process_exit
-# if classification fails, preserving backward compatibility.
-#
-# Args:
-#   $1 = session_key (baked in at trap-set time via SC2064-disabled trap)
-#
-# Globals consumed:
-#   _WORKER_START_EPOCH_MS   — ms epoch set by _cmd_run_prepare
-#   _WORKER_ISOLATED_DB_PATH — isolated DB path set by _invoke_opencode
-#   _WORKER_WORKTREE_PATH    — worktree path set by _cmd_run_prepare (t2923)
-#   _WORKER_EXIT_CODE_FILE   — exit_code_file path set by _invoke_opencode
-#                              (t3050); .wait_status sentinel persisted
-#                              alongside it preserves the worker subshell
-#                              wait_status across the EXIT trap boundary.
+# Finalize an EXIT-trap classification: preserve work, emit terminal evidence,
+# release the claim/lock, and force a non-zero process exit when preparation
+# ended cleanly before runtime invocation.
+# Args: $1=session, $2=reason, $3=exit status, $4=session count, $5=force nonzero
+#######################################
+_hrff_finalize_exit_trap() {
+	local session_key="$1"
+	local reason="$2"
+	local exit_status="$3"
+	local session_count="$4"
+	local force_nonzero_exit="$5"
+
+	print_info "[exit-trap] session=$session_key exit=$exit_status reason=$reason session_count=$session_count"
+	_push_wip_commits_on_exit
+	if [[ "${_WORKER_DIRTY_WORK_PRESERVED:-0}" == "1" ]]; then
+		if _recover_dirty_worker_pr "$session_key"; then
+			reason="worker_complete"
+		else
+			reason="worker_dirty_work_preserved"
+		fi
+	fi
+	if declare -F _emit_worker_runtime_event >/dev/null 2>&1; then
+		if [[ "$reason" == "worker_complete" ]]; then
+			_emit_worker_runtime_event "worker.completed" "recovered" "$reason"
+		else
+			_emit_worker_runtime_event "worker.failed" "failed" "$reason"
+		fi
+	fi
+	if declare -F _hrw_record_terminal_outcome >/dev/null 2>&1; then
+		local terminal_outcome="failed"
+		local complete_reason="${_HRW_REASON_WORKER_COMPLETE:-worker_complete}"
+		[[ "$reason" == "$complete_reason" ]] && terminal_outcome="success"
+		_hrw_record_terminal_outcome "$session_key" "$terminal_outcome" "$reason"
+	fi
+	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
+		_cleanup_headless_runtime_temp_paths
+	fi
+	_release_dispatch_claim "$session_key" "$reason" "$exit_status" "$session_count"
+	_release_session_lock "$session_key"
+	_update_dispatch_ledger "$session_key" "fail"
+	if [[ "$force_nonzero_exit" -eq 1 ]]; then
+		trap - EXIT
+		exit "$exit_status"
+	fi
+	return 0
+}
+
+#######################################
+# Classify worker termination and post CLAIM_RELEASED. Falls back to
+# process_exit when runtime/session evidence cannot identify the cause.
+# Args: $1=session_key (baked into the EXIT trap at registration time)
+# Globals: _WORKER_START_EPOCH_MS, _WORKER_ISOLATED_DB_PATH,
+# _WORKER_WORKTREE_PATH, _WORKER_EXIT_CODE_FILE, _WORKER_RUNTIME_LAUNCH_STARTED
 #######################################
 _exit_trap_handler() {
 	local session_key="$1"
@@ -905,11 +943,19 @@ _exit_trap_handler() {
 	local reason="$_HRFF_FALLBACK_EXIT"
 	local session_count=0
 	local ledger_terminal_reason=""
+	local force_nonzero_exit=0
 	if [[ -x "${DISPATCH_LEDGER_HELPER:-}" && -n "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" ]]; then
 		ledger_terminal_reason=$("$DISPATCH_LEDGER_HELPER" terminal-reason --session-key "$session_key" \
 			--lease-token "$AIDEVOPS_DISPATCH_LEASE_TOKEN" 2>/dev/null) || ledger_terminal_reason=""
 	fi
-	if [[ -n "$ledger_terminal_reason" ]]; then
+	if [[ "${_WORKER_RUNTIME_LAUNCH_STARTED:-0}" != "1" ]]; then
+		reason="${_WORKER_PRELAUNCH_FAILURE_REASON:-$_HRFF_PRELAUNCH_NOT_INVOKED}"
+		print_warning "[exit-trap] runtime invocation never started after worker preparation; reason=${reason}"
+		if [[ ! "$exit_status" =~ ^[1-9][0-9]*$ ]]; then
+			exit_status=1
+			force_nonzero_exit=1
+		fi
+	elif [[ -n "$ledger_terminal_reason" ]]; then
 		reason="$ledger_terminal_reason"
 		print_info "[exit-trap] using dispatch ledger terminal reason: $reason"
 	elif [[ -n "${_WORKER_PRELAUNCH_FAILURE_REASON:-}" ]]; then
@@ -942,37 +988,10 @@ _exit_trap_handler() {
 		fi
 	fi
 
-	print_info "[exit-trap] session=$session_key exit=$exit_status reason=$reason session_count=$session_count"
 	# t2923/GH#22965: Preserve WIP before releasing the claim so re-dispatch can
 	# continue from the pushed branch instead of starting over. Dirty preserved
 	# work is reported distinctly to avoid zero-output brief-rewrite holds.
-	_push_wip_commits_on_exit
-	if [[ "${_WORKER_DIRTY_WORK_PRESERVED:-0}" == "1" ]]; then
-		if _recover_dirty_worker_pr "$session_key"; then
-			reason="worker_complete"
-		else
-			reason="worker_dirty_work_preserved"
-		fi
-	fi
-	if declare -F _emit_worker_runtime_event >/dev/null 2>&1; then
-		if [[ "$reason" == "worker_complete" ]]; then
-			_emit_worker_runtime_event "worker.completed" "recovered" "$reason"
-		else
-			_emit_worker_runtime_event "worker.failed" "failed" "$reason"
-		fi
-	fi
-	if declare -F _hrw_record_terminal_outcome >/dev/null 2>&1; then
-		local terminal_outcome="failed"
-		local complete_reason="${_HRW_REASON_WORKER_COMPLETE:-worker_complete}"
-		[[ "$reason" == "$complete_reason" ]] && terminal_outcome="success"
-		_hrw_record_terminal_outcome "$session_key" "$terminal_outcome" "$reason"
-	fi
-	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
-		_cleanup_headless_runtime_temp_paths
-	fi
-	_release_dispatch_claim "$session_key" "$reason" "$exit_status" "$session_count"
-	_release_session_lock "$session_key"
-	_update_dispatch_ledger "$session_key" "fail"
+	_hrff_finalize_exit_trap "$session_key" "$reason" "$exit_status" "$session_count" "$force_nonzero_exit"
 	return 0
 }
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1172,13 +1172,6 @@ _execute_run_attempt() {
 		return 11
 	fi
 
-	# t3077 — emit canonical worker_started lifecycle marker.
-	# Replaces the legacy print_info worker_start emit; the legacy line
-	# format is preserved as a fallback when verbose mode is disabled so
-	# existing log parsers continue to work.
-	_emit_verbose_checkpoint worker_started \
-		"model=${selected_model} runtime=${runtime} fix_the_fixer=${_T3077_FIX_THE_FIXER:-0}"
-	print_info "[lifecycle] worker_start session=$session_key model=$selected_model runtime=$runtime pid=$$"
 	if [[ -x "$RESOURCE_METRICS_HELPER" ]]; then
 		"$RESOURCE_METRICS_HELPER" sample \
 			--pid "$$" \
@@ -1201,6 +1194,13 @@ _execute_run_attempt() {
 		print_info "[lifecycle] verbose_watcher_started pid=${_t3077_watcher_pid} worker=$$ log=${output_file}"
 	fi
 
+	# Publish readiness only at the runtime invocation boundary. The EXIT trap
+	# uses the pre_runtime_launch marker to distinguish preparation failures
+	# from legitimate post-launch zero-output exits.
+	_hrw_mark_runtime_launch_started "$session_key" "$runtime"
+	_emit_verbose_checkpoint worker_started \
+		"model=${selected_model} runtime=${runtime} fix_the_fixer=${_T3077_FIX_THE_FIXER:-0}"
+	print_info "[lifecycle] worker_start session=$session_key model=$selected_model runtime=$runtime pid=$$"
 	case "$runtime" in
 	claude) _invoke_claude "$output_file" "$exit_code_file" "$work_dir" "${cmd[@]}" ;;
 	*) _invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}" ;;

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1705,9 +1705,19 @@ _hrw_permission_pending_path() {
 	return 0
 }
 
+_hrw_mark_runtime_launch_started() {
+	local session_key="$1"
+	local runtime="$2"
+	_WORKER_RUNTIME_LAUNCH_STARTED=1
+	print_info "[lifecycle] pre_runtime_launch session=${session_key} runtime=${runtime} pid=$$"
+	return 0
+}
+
 _cmd_run_prepare() {
 	local session_key="$1"
 	local work_dir="$2"
+	_WORKER_RUNTIME_LAUNCH_STARTED=0
+	unset _WORKER_PRELAUNCH_FAILURE_REASON 2>/dev/null || true
 
 	# t2983 Fix C: Worker-role guard — WORKER_WORKTREE_PATH must be set.
 	# After GH#21353 (Fix A), the dispatcher never launches a worker when
@@ -1780,11 +1790,17 @@ _cmd_run_prepare() {
 	# the 10-15 minute gap between dispatch and PR creation.
 	_register_dispatch_ledger "$session_key" "$work_dir"
 	if [[ -n "${AIDEVOPS_DISPATCH_LEASE_TOKEN:-}" && -n "${WORKER_ISSUE_NUMBER:-}" && -n "${DISPATCH_REPO_SLUG:-}" ]]; then
-		"${SCRIPT_DIR}/dispatch-ledger-helper.sh" ready --session-key "$session_key" \
-			--lease-token "$AIDEVOPS_DISPATCH_LEASE_TOKEN" 2>/dev/null || return 1
-		"${SCRIPT_DIR}/dispatch-claim-helper.sh" transition ready "$WORKER_ISSUE_NUMBER" \
+		if ! "${SCRIPT_DIR}/dispatch-ledger-helper.sh" ready --session-key "$session_key" \
+			--lease-token "$AIDEVOPS_DISPATCH_LEASE_TOKEN" 2>/dev/null; then
+			_WORKER_PRELAUNCH_FAILURE_REASON="worker_ledger_ready_failed"
+			return 1
+		fi
+		if ! "${SCRIPT_DIR}/dispatch-claim-helper.sh" transition ready "$WORKER_ISSUE_NUMBER" \
 			"$DISPATCH_REPO_SLUG" "$AIDEVOPS_DISPATCH_LEASE_TOKEN" "$session_key" \
-			"${AIDEVOPS_DISPATCH_READY_LEASE_TTL:-7200}" 2>/dev/null || return 1
+			"${AIDEVOPS_DISPATCH_READY_LEASE_TTL:-7200}" 2>/dev/null; then
+			_WORKER_PRELAUNCH_FAILURE_REASON="worker_claim_ready_transition_failed"
+			return 1
+		fi
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -44,6 +44,7 @@ MOCK_GH_REST_LOGIN_MODE="success"
 MOCK_GH_GRAPHQL_LOGIN_MODE="success"
 MOCK_GH_CALL_LOG=""
 MOCK_PS_LINES=""
+MOCK_LIVE_PIDS=""
 MOCK_LEDGER_RECORD=""
 MOCK_GIT_WORKTREE_LIST="0"
 MOCK_REPO_PATH=""
@@ -227,6 +228,16 @@ gh() {
 _dsi_ps_worker_lines() {
 	printf '%s\n' "$MOCK_PS_LINES"
 	return 0
+}
+
+# shellcheck disable=SC2317
+_dsi_pid_is_live() {
+	local pid="$1"
+	local live_pid=""
+	for live_pid in $MOCK_LIVE_PIDS; do
+		[[ "$pid" == "$live_pid" ]] && return 0
+	done
+	return 1
 }
 
 # shellcheck disable=SC2317
@@ -1269,6 +1280,48 @@ test_status_reports_live_process_without_ledger() {
 	return 0
 }
 
+test_status_rejects_dead_or_reused_ledger_pid() {
+	MOCK_LEDGER_RECORD=$'ledger\t888\t/tmp/manual.log\t/tmp/aidevops-existing\tmanual-cli-12345-1'
+	MOCK_LIVE_PIDS=""
+	MOCK_PS_LINES=""
+
+	local out="" rc=0
+	out=$(cmd_status 12345 owner/repo 2>&1) || rc=$?
+	local dead_rejected=1
+	[[ "$rc" -eq 0 && "$out" == *"No active dispatch"* && "$out" != *"Active dispatch"* ]] && dead_rejected=0
+	print_result "status rejects a dead ledger PID despite active lease evidence" "$dead_rejected" "rc=$rc output=$out"
+
+	MOCK_LIVE_PIDS="888"
+	MOCK_PS_LINES='888 S bash /tmp/unrelated-process --session-key unrelated --dir /tmp/aidevops-existing'
+	rc=0
+	out=$(cmd_status 12345 owner/repo 2>&1) || rc=$?
+	local reused_rejected=1
+	[[ "$rc" -eq 0 && "$out" == *"No active dispatch"* && "$out" != *"Active dispatch"* ]] && reused_rejected=0
+	print_result "status rejects a reused PID with mismatched worker identity" "$reused_rejected" "rc=$rc output=$out"
+
+	MOCK_LEDGER_RECORD=""
+	MOCK_LIVE_PIDS=""
+	MOCK_PS_LINES=""
+	return 0
+}
+
+test_status_accepts_live_identity_matched_ledger_pid() {
+	MOCK_LEDGER_RECORD=$'ledger\t888\t/tmp/manual.log\t/tmp/aidevops-existing\tmanual-cli-12345-1'
+	MOCK_LIVE_PIDS="888"
+	MOCK_PS_LINES='888 S bash /Users/test/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key manual-cli-12345-1 --dir /tmp/aidevops-existing --title Issue #12345'
+
+	local out="" rc=0
+	out=$(cmd_status 12345 owner/repo 2>&1) || rc=$?
+	local active=1
+	[[ "$rc" -eq 0 && "$out" == *"Active dispatch"* && "$out" == *"Existing session: manual-cli-12345-1"* ]] && active=0
+	print_result "status accepts a live identity-matched ledger PID" "$active" "rc=$rc output=$out"
+
+	MOCK_LEDGER_RECORD=""
+	MOCK_LIVE_PIDS=""
+	MOCK_PS_LINES=""
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Runner
 # -----------------------------------------------------------------------------
@@ -1327,6 +1380,8 @@ _run_tests() {
 	test_guard_blocks_ledger_duplicate
 	test_guard_blocks_live_worktree_duplicate
 	test_status_reports_live_process_without_ledger
+	test_status_rejects_dead_or_reused_ledger_pid
+	test_status_accepts_live_identity_matched_ledger_pid
 
 	echo
 	echo "======================================"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -653,6 +653,62 @@ test_worker_worktree_claim_classifies_unreclaimed_live_owner() {
 	return 0
 }
 
+test_runtime_launch_marker_precedes_invocation() {
+	local marker_file="${TEST_ROOT}/runtime-launch-marker.log"
+	_WORKER_RUNTIME_LAUNCH_STARTED=0
+	_hrw_mark_runtime_launch_started "issue-28060" "opencode" >"$marker_file" 2>&1
+	local output=""
+	output=$(<"$marker_file")
+
+	local marker_line="" invoke_line=""
+	# shellcheck disable=SC2016 # Match the literal caller variables in source.
+	marker_line=$(grep -n '_hrw_mark_runtime_launch_started "$session_key" "$runtime"' "$HELPER_SCRIPT" | cut -d: -f1)
+	invoke_line=$(grep -n 'claude) _invoke_claude' "$HELPER_SCRIPT" | cut -d: -f1)
+	if [[ "$_WORKER_RUNTIME_LAUNCH_STARTED" -eq 1 && "$output" == *"pre_runtime_launch session=issue-28060 runtime=opencode"* &&
+		"$marker_line" =~ ^[0-9]+$ && "$invoke_line" =~ ^[0-9]+$ && "$marker_line" -lt "$invoke_line" ]]; then
+		print_result "runtime launch marker is emitted immediately before invocation" 0
+	else
+		print_result "runtime launch marker is emitted immediately before invocation" 1 \
+			"started=$_WORKER_RUNTIME_LAUNCH_STARTED marker_line=$marker_line invoke_line=$invoke_line output=$output"
+	fi
+	_WORKER_RUNTIME_LAUNCH_STARTED=0
+	return 0
+}
+
+test_clean_prelaunch_exit_is_precise_nonzero_failure() {
+	local output="" status=0
+	set +e
+	output=$(
+		(
+			print_info() { printf '%s\n' "$*"; return 0; }
+			print_warning() { printf '%s\n' "$*"; return 0; }
+			_push_wip_commits_on_exit() { return 0; }
+			_emit_worker_runtime_event() { return 0; }
+			_hrw_record_terminal_outcome() { return 0; }
+			_cleanup_headless_runtime_temp_paths() { return 0; }
+			_release_dispatch_claim() { return 0; }
+			_release_session_lock() { return 0; }
+			_update_dispatch_ledger() { return 0; }
+			_WORKER_RUNTIME_LAUNCH_STARTED=0
+			_WORKER_START_EPOCH_MS=0
+			AIDEVOPS_DISPATCH_LEASE_TOKEN=""
+			trap "_exit_trap_handler 'issue-28060'" EXIT
+			exit 0
+		)
+	) || status=$?
+	set -e
+
+	if [[ "$status" -eq 1 && "$output" == *"reason=worker_runtime_not_invoked"* &&
+		"$output" != *"worker_noop_zero_output"* ]] &&
+		_worker_failure_reason_is_launch_preflight "worker_runtime_not_invoked"; then
+		print_result "clean exit before runtime invocation is a precise non-zero prelaunch failure" 0
+		return 0
+	fi
+	print_result "clean exit before runtime invocation is a precise non-zero prelaunch failure" 1 \
+		"status=$status output=$output"
+	return 0
+}
+
 test_deleted_cwd_recovery_uses_worker_worktree() {
 	local worktree_dir="${TEST_ROOT}/deleted-cwd-worktree"
 	local stale_dir="${TEST_ROOT}/deleted-cwd-stale"
@@ -3513,6 +3569,8 @@ main() {
 	test_worker_worktree_claim_reclaims_dispatch_precreate_owner
 	test_worker_worktree_clean_without_upstream_blocks_local_commits
 	test_worker_worktree_claim_classifies_unreclaimed_live_owner
+	test_runtime_launch_marker_precedes_invocation
+	test_clean_prelaunch_exit_is_precise_nonzero_failure
 	test_deleted_cwd_recovery_uses_worker_worktree
 	test_cmd_run_aborts_issue_worker_before_canary_when_env_missing
 	test_cmd_run_preserves_worker_origin_overrides_before_canary

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -1253,6 +1253,9 @@ _worker_failure_reason_is_launch_preflight() {
 	case "$reason" in
 	worker_launch_rc_2 | \
 	worker_worktree_live_owner | \
+	worker_runtime_not_invoked | \
+	worker_ledger_ready_failed | \
+	worker_claim_ready_transition_failed | \
 	dispatch_aborted:worker_launch_rc_2 | \
 	canary_preflight | \
 	*"canary preflight failed"* | \


### PR DESCRIPTION
## Summary

Reject stale or identity-mismatched manual dispatch PIDs, publish readiness only at the runtime invocation boundary, and classify clean pre-runtime exits as precise non-zero launch failures.

## Files Changed

.agents/scripts/dispatch-single-issue-helper.sh, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/tests/test-dispatch-single-issue-helper.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/worker-lifecycle-common.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck on seven changed shell files; test-dispatch-single-issue-helper.sh (71/71); test-headless-runtime-helper.sh (136/136); test-worker-exit-classifier.sh (16/16); test-worker-lifecycle-exit-emit.sh (4/4); test-headless-runtime-failure-classification.sh (57/57); complexity regression check (0 new).

Resolves #28060


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 21m and 416,003 tokens on this as a headless worker.