### PR TITLE
GH#28070: simplify session status event dispatch

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-status.mjs
@@ -18,17 +18,82 @@ function isRootSessionInfo(info) {
   return Boolean(info) && !info.parentID;
 }
 
+const ROOT_SESSION_STATUSES = new Set(["busy", "retry", "idle"]);
+
+function handleSessionCreated({ info, sessionID, state, resetState }) {
+  if (!isRootSessionInfo(info)) return;
+  state.activeRootSessionID = sessionID;
+  resetState();
+}
+
+function handleSessionUpdated({ info, sessionID, state, resetState }) {
+  if (state.activeRootSessionID || !isRootSessionInfo(info)) return;
+  state.activeRootSessionID = sessionID;
+  resetState();
+}
+
+function handleSessionDeleted({ sessionID, state, resetState }) {
+  if (sessionID !== state.activeRootSessionID) return;
+  state.activeRootSessionID = "";
+  resetState();
+}
+
+function handleMessageUpdated({ info, sessionID, state, setTerminalTitleStatus }) {
+  if (
+    sessionID !== state.activeRootSessionID ||
+    info?.role !== "user" ||
+    state.pendingPermissionIDs.size > 0
+  ) {
+    return;
+  }
+  setTerminalTitleStatus("busy");
+}
+
+function handleSessionStatus({ event, sessionID, state, setTerminalTitleStatus }) {
+  if (sessionID !== state.activeRootSessionID || state.pendingPermissionIDs.size > 0) return;
+  const status = event.properties?.status?.type;
+  if (!ROOT_SESSION_STATUSES.has(status)) return;
+  setTerminalTitleStatus(status);
+}
+
+function handlePermissionAsked({ event, sessionID, state, setTerminalTitleStatus }) {
+  if (sessionID !== state.activeRootSessionID) return;
+  const requestID = event.properties?.id;
+  if (!requestID) return;
+  state.pendingPermissionIDs.add(requestID);
+  setTerminalTitleStatus("permission");
+}
+
+function handlePermissionReplied({ event, sessionID, state, setTerminalTitleStatus }) {
+  if (sessionID !== state.activeRootSessionID) return;
+  const wasPending = state.pendingPermissionIDs.delete(event.properties?.requestID);
+  if (!wasPending || state.pendingPermissionIDs.size > 0) return;
+  setTerminalTitleStatus("busy");
+}
+
+const EVENT_HANDLERS = new Map([
+  ["session.created", handleSessionCreated],
+  ["session.updated", handleSessionUpdated],
+  ["session.deleted", handleSessionDeleted],
+  ["message.updated", handleMessageUpdated],
+  ["session.status", handleSessionStatus],
+  ["permission.asked", handlePermissionAsked],
+  ["permission.replied", handlePermissionReplied],
+]);
+
 export function createSessionTitleStatusHandler({
   isHeadless = () => false,
   isEnabled = () => process.env.AIDEVOPS_TAB_STATUS_ENABLED !== "false",
   resetTerminalTitleState = defaultResetTerminalTitleState,
   setTerminalTitleStatus = defaultSetTerminalTitleStatus,
 } = {}) {
-  let activeRootSessionID = "";
-  const pendingPermissionIDs = new Set();
+  const state = {
+    activeRootSessionID: "",
+    pendingPermissionIDs: new Set(),
+  };
 
   const resetState = () => {
-    pendingPermissionIDs.clear();
+    state.pendingPermissionIDs.clear();
     resetTerminalTitleState();
   };
 
@@ -38,37 +103,8 @@ export function createSessionTitleStatusHandler({
     const event = getEvent(input);
     const info = event.properties?.info;
     const sessionID = sessionIDFrom(event);
+    if (!sessionID) return;
 
-    if (event.type === "session.created" && isRootSessionInfo(info) && sessionID) {
-      activeRootSessionID = sessionID;
-      resetState();
-    } else if (event.type === "session.updated" && !activeRootSessionID && isRootSessionInfo(info) && sessionID) {
-      activeRootSessionID = sessionID;
-      resetState();
-    } else if (event.type === "session.deleted" && sessionID === activeRootSessionID) {
-      activeRootSessionID = "";
-      resetState();
-    } else if (
-      event.type === "message.updated" &&
-      sessionID === activeRootSessionID &&
-      info?.role === "user" &&
-      pendingPermissionIDs.size === 0
-    ) {
-      setTerminalTitleStatus("busy");
-    } else if (event.type === "session.status" && sessionID === activeRootSessionID) {
-      const status = event.properties?.status?.type;
-      if (pendingPermissionIDs.size === 0 && (status === "busy" || status === "retry" || status === "idle")) {
-        setTerminalTitleStatus(status);
-      }
-    } else if (event.type === "permission.asked" && sessionID === activeRootSessionID) {
-      const requestID = event.properties?.id;
-      if (requestID) {
-        pendingPermissionIDs.add(requestID);
-        setTerminalTitleStatus("permission");
-      }
-    } else if (event.type === "permission.replied" && sessionID === activeRootSessionID) {
-      const wasPending = pendingPermissionIDs.delete(event.properties?.requestID);
-      if (wasPending && pendingPermissionIDs.size === 0) setTerminalTitleStatus("busy");
-    }
+    EVENT_HANDLERS.get(event.type)?.({ event, info, sessionID, state, resetState, setTerminalTitleStatus });
   };
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -98,6 +98,8 @@ test("first root user message marks the session busy before native status", asyn
     setTerminalTitleStatus: (status) => statuses.push(status),
   });
 
+  await handler(event("message.updated", { info: { role: "user" } }));
+  await handler(event("permission.asked", { id: "permission-without-session" }));
   await handler(event("session.created", { info: { id: "root-1", title: "Root" } }));
   await handler(event("message.updated", {
     sessionID: "child-1",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- simplify OpenCode session status event dispatch (#28070)
+
 ## [3.32.143] - 2026-07-17
 
 ### Added


### PR DESCRIPTION
## Summary

Split OpenCode session-title status event handling into small event-specific handlers so the Qlty function-complexity regression is removed without changing status precedence or title behavior.

## Files Changed

.agents/plugins/opencode-aidevops/session-title-status.mjs, .agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs, CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 437/437 OpenCode plugin tests passed with an isolated worktree registry; targeted status tests 6/6 passed; changed-file lint, Biome, Markdown lint, diff checks, local complexity metrics, and PTY title-transition verification passed.

Resolves #28070


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.143 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 5m and 899,203 tokens on this with the user in an interactive session.