### PR TITLE
GH#28047: log subagent cancellation failures

### DIFF
--- a/.agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs
@@ -66,7 +66,11 @@ class SubagentCancellationReceipt {
           }
           if (result.evidence) result.reason = "";
         }
-      } catch {
+      } catch (error) {
+        this.ledger.safeLog(
+          "WARN",
+          `[subagent-cancellation] session abort failed: ${error?.message || error?.name || "Error"}`,
+        );
         result.reason = "abort_api_failed";
       }
     } else if (childID) {
@@ -121,7 +125,11 @@ class SubagentCancellationReceipt {
         childSessionID: childID,
         parentSessionID: String(input?.sessionID || ""),
       }));
-    } catch {
+    } catch (error) {
+      this.ledger.safeLog(
+        "WARN",
+        `[subagent-cancellation] receipt persistence failed: ${error?.message || error?.name || "Error"}`,
+      );
       recorded = false;
     }
     receipt.telemetry = recorded ? "recorded" : "unavailable";

--- a/.agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs
@@ -180,6 +180,44 @@ test("missing lifecycle events and telemetry produce an explicit incomplete unkn
   assert.equal(receipt.ledger[0].status, "unknown");
 });
 
+test("abort and receipt persistence failures are logged for diagnostics", async () => {
+  const logs = [];
+  const lifecycle = createSubagentCancellationReceipt({
+    session: {
+      abort: async () => {
+        throw new Error("abort unavailable");
+      },
+    },
+  }, {
+    maxWaitMs: 0,
+    qualityLog: (level, message) => logs.push([level, message]),
+    recordReceipt: () => {
+      throw new Error("telemetry unavailable");
+    },
+  });
+  lifecycle.beforeTool(
+    { tool: "task", sessionID: "parent-failure", callID: "task-failure" },
+    { args: {} },
+  );
+  const output = {
+    output: "Task aborted",
+    metadata: { sessionId: "child-failure", status: "aborted" },
+  };
+
+  const receipt = await lifecycle.afterTool(
+    { tool: "task", sessionID: "parent-failure", callID: "task-failure" },
+    output,
+  );
+
+  assert.equal(receipt.complete, false);
+  assert.ok(receipt.incomplete_reasons.includes("abort_api_failed"));
+  assert.ok(receipt.incomplete_reasons.includes("telemetry_unavailable"));
+  assert.deepEqual(logs.slice(0, 2), [
+    ["WARN", "[subagent-cancellation] session abort failed: abort unavailable"],
+    ["WARN", "[subagent-cancellation] receipt persistence failed: telemetry unavailable"],
+  ]);
+});
+
 test("the parent-facing receipt remains entry- and byte-bounded", async () => {
   let lifecycle;
   const client = {


### PR DESCRIPTION
## Summary

- Log exceptions from failed child-session abort requests through the existing cancellation quality logger.
- Log exceptions from failed cancellation-receipt persistence through the same safe logger.
- Cover both diagnostic paths with a focused regression test.

## Testing

- `node --check .agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs`
- `node --check .agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs`
- `node --test .agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs` (17 passed)
- `git diff --check origin/main...HEAD`
- Full typecheck unavailable locally because Bun and installed TypeScript dependencies are absent; remote CI remains authoritative.

Resolves #28047

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18
