### PR TITLE
GH#28074: simplify shell environment projection

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -83,6 +83,14 @@ const WORKER_LINEAGE_ENV_VARS = [
   "AIDEVOPS_ROOT_EVENT_ID",
 ];
 
+const OTEL_ENV_VARS = [
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_HEADERS",
+  "OTEL_EXPORTER_OTLP_PROTOCOL",
+  "OTEL_SERVICE_NAME",
+  "OTEL_RESOURCE_ATTRIBUTES",
+];
+
 /**
  * @param {string | undefined} value
  * @returns {boolean}
@@ -103,90 +111,95 @@ function shellSessionOrigin(env) {
   return headless ? "worker" : "interactive";
 }
 
+function prependScriptsPath(env, scriptsDir) {
+  if (!existsSync(scriptsDir)) return;
+  const currentPath = env.PATH || process.env.PATH || "";
+  const pathParts = currentPath.split(":").filter((part) => part && part !== scriptsDir);
+  env.PATH = [scriptsDir, ...pathParts].join(":");
+}
+
+function projectWorkerLineage(env) {
+  const sessionOrigin = shellSessionOrigin(env);
+  env.AIDEVOPS_SESSION_ORIGIN = sessionOrigin;
+  for (const key of WORKER_LINEAGE_ENV_VARS) {
+    if (sessionOrigin !== "worker") {
+      delete env[key];
+    } else if (!env[key] && process.env[key]) {
+      env[key] = process.env[key];
+    }
+  }
+}
+
+function resolveVersion({ activeAgentsDir, agentsDir, precomputedVersion }) {
+  if (precomputedVersion) return precomputedVersion;
+  const activeVersion = hasAgentsDir(activeAgentsDir)
+    ? readIfExists(join(activeAgentsDir, "VERSION"))
+    : "";
+  if (activeVersion || !hasAgentsDir(agentsDir)) return activeVersion;
+  return readIfExists(join(agentsDir, "VERSION")) ||
+    readIfExists(join(agentsDir, "..", "VERSION")) ||
+    readIfExists(join(agentsDir, "..", "version"));
+}
+
+function projectFrameworkEnvironment(env, config) {
+  env.AIDEVOPS_AGENTS_DIR = config.agentsDir;
+  if (hasAgentsDir(config.activeAgentsDir)) {
+    env.AIDEVOPS_ACTIVE_AGENTS_DIR = config.activeAgentsDir;
+  }
+  env.AIDEVOPS_WORKSPACE_DIR = config.workspaceDir;
+  projectWorkerLineage(env);
+
+  const version = resolveVersion(config);
+  if (version) env.AIDEVOPS_VERSION = version;
+}
+
+function projectSessionIdentity(input, env) {
+  const sessionId = getSessionId(input);
+  if (sessionId) {
+    env.OPENCODE_SESSION_ID = sessionId;
+    env.AIDEVOPS_OPENCODE_SESSION_ID = sessionId;
+  }
+
+  const modelId = getModelId(input);
+  if (modelId && !env.AIDEVOPS_SIG_MODEL) env.AIDEVOPS_SIG_MODEL = modelId;
+}
+
+function projectOtelEnvironment(env) {
+  for (const key of OTEL_ENV_VARS) {
+    const value = process.env[key];
+    if (value && !env[key]) env[key] = value;
+  }
+}
+
+function normalizeDependencies(deps) {
+  const {
+    activeAgentsDir = "",
+    agentsDir = "",
+    scriptsDir = "",
+    workspaceDir = "",
+    version,
+  } = deps || {};
+  return {
+    activeAgentsDir,
+    agentsDir,
+    scriptsDir,
+    workspaceDir,
+    precomputedVersion: typeof version === "string" ? version.trim() : "",
+  };
+}
+
+async function shellEnvHook(config, input, output) {
+  prependScriptsPath(output.env, config.scriptsDir);
+  projectFrameworkEnvironment(output.env, config);
+  projectSessionIdentity(input, output.env);
+  projectOtelEnvironment(output.env);
+}
+
 /**
  * Create the shell environment hook.
  * @param {object} deps - { activeAgentsDir?, agentsDir, scriptsDir, workspaceDir, version? }
  * @returns {Function} Shell env hook function
  */
 export function createShellEnvHook(deps) {
-  const { activeAgentsDir = "", agentsDir = "", scriptsDir = "", workspaceDir = "", version } = deps || {};
-  const precomputedVersion = typeof version === "string" ? version.trim() : "";
-
-  /**
-   * Inject aidevops environment variables into shell sessions.
-   * @param {object} input - { cwd, session/sessionID, model }
-   * @param {object} output - { env } (mutable)
-   */
-  return async function shellEnvHook(input, output) {
-    // Ensure aidevops scripts are on PATH
-    if (existsSync(scriptsDir)) {
-      const currentPath = output.env.PATH || process.env.PATH || "";
-      const pathParts = currentPath.split(":").filter((part) => part && part !== scriptsDir);
-      output.env.PATH = [scriptsDir, ...pathParts].join(":");
-    }
-
-    // Set aidevops workspace directory
-    output.env.AIDEVOPS_AGENTS_DIR = agentsDir;
-    if (hasAgentsDir(activeAgentsDir)) output.env.AIDEVOPS_ACTIVE_AGENTS_DIR = activeAgentsDir;
-    output.env.AIDEVOPS_WORKSPACE_DIR = workspaceDir;
-    const sessionOrigin = shellSessionOrigin(output.env);
-    output.env.AIDEVOPS_SESSION_ORIGIN = sessionOrigin;
-    for (const key of WORKER_LINEAGE_ENV_VARS) {
-      if (sessionOrigin === "worker") {
-        if (!output.env[key] && process.env[key]) output.env[key] = process.env[key];
-      } else {
-        delete output.env[key];
-      }
-    }
-
-    // Set aidevops version if available. Prefer the deployed framework version
-    // source; ~/.aidevops/version is a legacy/stale compatibility fallback.
-    const version = precomputedVersion ||
-      (hasAgentsDir(activeAgentsDir) ? readIfExists(join(activeAgentsDir, "VERSION")) : "") ||
-      (hasAgentsDir(agentsDir)
-        ? readIfExists(join(agentsDir, "VERSION")) ||
-          readIfExists(join(agentsDir, "..", "VERSION")) ||
-          readIfExists(join(agentsDir, "..", "version"))
-        : "");
-    if (version) {
-      output.env.AIDEVOPS_VERSION = version;
-    }
-
-    // Shell helpers need the exact current OpenCode conversation, not an ID
-    // inherited from a previous plugin instance or long-lived app process
-    // (GH#22003, GH#27574). AIDEVOPS_SESSION_ID may intentionally name a
-    // framework session, so publish the OpenCode side of that mapping explicitly.
-    // OpenCode hook input has changed shape across releases, so accept the known
-    // variants and keep this best-effort: absence should not block shell startup.
-    const sessionId = getSessionId(input);
-    if (sessionId) {
-      output.env.OPENCODE_SESSION_ID = sessionId;
-      output.env.AIDEVOPS_OPENCODE_SESSION_ID = sessionId;
-    }
-
-    const modelId = getModelId(input);
-    if (modelId && !output.env.AIDEVOPS_SIG_MODEL) {
-      output.env.AIDEVOPS_SIG_MODEL = modelId;
-    }
-
-    // OTEL env passthrough (t2177) — propagate OpenTelemetry config so
-    // subprocesses spawned by opencode (headless workers, helper scripts,
-    // nested shells) inherit the same trace endpoint. opencode itself reads
-    // these from its own process.env; we forward them to shell subprocesses
-    // which otherwise wouldn't see them across the Bun→Node→bash boundary.
-    // No-op when the user hasn't configured OTEL.
-    const OTEL_VARS = [
-      "OTEL_EXPORTER_OTLP_ENDPOINT",
-      "OTEL_EXPORTER_OTLP_HEADERS",
-      "OTEL_EXPORTER_OTLP_PROTOCOL",
-      "OTEL_SERVICE_NAME",
-      "OTEL_RESOURCE_ATTRIBUTES",
-    ];
-    for (const key of OTEL_VARS) {
-      const value = process.env[key];
-      if (value && !output.env[key]) {
-        output.env[key] = value;
-      }
-    }
-  };
+  return shellEnvHook.bind(null, normalizeDependencies(deps));
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -149,6 +149,37 @@ test("shell env preserves framework identity and publishes its OpenCode mapping"
   assert.equal(output.env.AIDEVOPS_OPENCODE_SESSION_ID, "opencode-session");
 });
 
+test("shell env derives the signature model without replacing an explicit value", async () => {
+  const hook = makeHook();
+  const derived = { env: { PATH: "/usr/bin:/bin" } };
+  await hook({ model: { providerID: "openai", modelID: "gpt-5.6-sol" } }, derived);
+  assert.equal(derived.env.AIDEVOPS_SIG_MODEL, "openai/gpt-5.6-sol");
+
+  const explicit = { env: { PATH: "/usr/bin:/bin", AIDEVOPS_SIG_MODEL: "configured/model" } };
+  await hook({ model: { providerID: "openai", modelID: "other-model" } }, explicit);
+  assert.equal(explicit.env.AIDEVOPS_SIG_MODEL, "configured/model");
+});
+
+test("shell env forwards OTEL values without replacing shell-specific values", async () => {
+  const keys = ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_SERVICE_NAME"];
+  const saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+  try {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "test-endpoint";
+    process.env.OTEL_SERVICE_NAME = "parent-service";
+    const output = { env: { PATH: "/usr/bin:/bin", OTEL_SERVICE_NAME: "shell-service" } };
+
+    await makeHook()({ sessionID: "otel-session" }, output);
+
+    assert.equal(output.env.OTEL_EXPORTER_OTLP_ENDPOINT, "test-endpoint");
+    assert.equal(output.env.OTEL_SERVICE_NAME, "shell-service");
+  } finally {
+    for (const key of keys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  }
+});
+
 test("headless shell preserves explicit worker lineage", async () => {
   const keys = [
     "AIDEVOPS_WORKER_ID",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- reduce OpenCode shell environment hook complexity (#28074)
+
 ## [3.32.144] - 2026-07-17
 
 ### Changed


### PR DESCRIPTION
## Summary

Split OpenCode shell environment projection into small behavior-specific helpers, removing the stable complexity debt that kept v3.32.144 postflight above the Qlty threshold while preserving the exported hook contract.

## Files Changed

.agents/plugins/opencode-aidevops/shell-env.mjs, .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs, CHANGELOG.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Qlty threshold helper reported 59 smells against threshold 61 on two consecutive committed-tree runs and no shell-env findings; targeted shell-env tests passed 14/14; full OpenCode plugin tests passed 439/439 with an isolated worktree registry; typecheck, changed-file linters, secret scan, Markdown lint, and diff checks passed.

Resolves #28074


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 43m and 1,300,165 tokens on this with the user in an interactive session.