### PR TITLE
GH#28075: harden localdev proxy generation

### DIFF
--- a/.agents/scripts/localdev-helper-init.sh
+++ b/.agents/scripts/localdev-helper-init.sh
@@ -63,6 +63,23 @@ cmd_init() {
 	return 0
 }
 
+# Run mkcert without a runtime-isolated XDG data root. OpenCode intentionally
+# redirects XDG_DATA_HOME per session; inheriting it would create a different CA
+# for every project. A caller-provided CAROOT remains the explicit override.
+run_stable_mkcert() {
+	local explicit_caroot="${CAROOT:-}"
+	(
+		unset XDG_DATA_HOME
+		if [[ -n "$explicit_caroot" ]]; then
+			export CAROOT="$explicit_caroot"
+		else
+			unset CAROOT
+		fi
+		command mkcert "$@"
+	) && return 0
+	return 1
+}
+
 # Install mkcert if not present. Supports macOS (brew) and Linux (apt, dnf,
 # pacman, apk). On Linux, the apt package name is "mkcert" (available in
 # Ubuntu 20.04+ and Debian 11+). libnss3-tools is required on Debian/Ubuntu
@@ -73,37 +90,35 @@ cmd_init() {
 # to create and trust the local CA root.
 # Returns: 0 if mkcert is available after this function, 1 if installation failed.
 ensure_mkcert() {
-	if command -v mkcert >/dev/null 2>&1; then
-		return 0
-	fi
-
-	print_info "mkcert not found — attempting to install..."
-
 	local installed=false
-
-	if command -v brew >/dev/null 2>&1; then
-		if brew install mkcert 2>/dev/null; then
-			installed=true
-		fi
-	elif command -v apt-get >/dev/null 2>&1; then
-		if sudo apt-get update -qq && sudo apt-get install -y -qq mkcert libnss3-tools 2>/dev/null; then
-			installed=true
-		fi
-	elif command -v apt >/dev/null 2>&1; then
-		if sudo apt update -qq && sudo apt install -y -qq mkcert libnss3-tools 2>/dev/null; then
-			installed=true
-		fi
-	elif command -v dnf >/dev/null 2>&1; then
-		if sudo dnf install -y mkcert 2>/dev/null; then
-			installed=true
-		fi
-	elif command -v pacman >/dev/null 2>&1; then
-		if sudo pacman -S --noconfirm mkcert 2>/dev/null; then
-			installed=true
-		fi
-	elif command -v apk >/dev/null 2>&1; then
-		if sudo apk add mkcert 2>/dev/null; then
-			installed=true
+	if command -v mkcert >/dev/null 2>&1; then
+		installed=true
+	else
+		print_info "mkcert not found — attempting to install..."
+		if command -v brew >/dev/null 2>&1; then
+			if brew install mkcert 2>/dev/null; then
+				installed=true
+			fi
+		elif command -v apt-get >/dev/null 2>&1; then
+			if sudo apt-get update -qq && sudo apt-get install -y -qq mkcert libnss3-tools 2>/dev/null; then
+				installed=true
+			fi
+		elif command -v apt >/dev/null 2>&1; then
+			if sudo apt update -qq && sudo apt install -y -qq mkcert libnss3-tools 2>/dev/null; then
+				installed=true
+			fi
+		elif command -v dnf >/dev/null 2>&1; then
+			if sudo dnf install -y mkcert 2>/dev/null; then
+				installed=true
+			fi
+		elif command -v pacman >/dev/null 2>&1; then
+			if sudo pacman -S --noconfirm mkcert 2>/dev/null; then
+				installed=true
+			fi
+		elif command -v apk >/dev/null 2>&1; then
+			if sudo apk add mkcert 2>/dev/null; then
+				installed=true
+			fi
 		fi
 	fi
 
@@ -147,16 +162,16 @@ ensure_mkcert() {
 		return 1
 	fi
 
-	print_success "mkcert installed"
+	print_success "mkcert available"
 
 	# Install the local CA into the system trust store (one-time setup).
 	# This makes mkcert-generated certs trusted by browsers and curl.
 	print_info "Installing mkcert local CA root (may require sudo)..."
-	if mkcert -install 2>/dev/null; then
+	if run_stable_mkcert -install 2>/dev/null; then
 		print_success "mkcert CA root installed and trusted"
 	else
 		print_warning "mkcert -install failed — certs will generate but browsers may not trust them"
-		echo "  Run manually: mkcert -install"
+		echo "  Re-run localdev-helper.sh init in an interactive terminal to authorize trust installation"
 	fi
 
 	return 0
@@ -168,8 +183,8 @@ check_init_prerequisites() {
 
 	command -v docker >/dev/null 2>&1 || missing+=("docker")
 
-	# Try to auto-install mkcert if missing (GH#6415)
-	if ! command -v mkcert >/dev/null 2>&1 && ! ensure_mkcert; then
+	# Install if missing and reconcile trust against the stable CA root (GH#6415).
+	if ! ensure_mkcert; then
 		missing+=("mkcert")
 	fi
 
@@ -400,8 +415,6 @@ entryPoints:
     address: ":443"
 
 providers:
-  docker:
-    exposedByDefault: false
   file:
     directory: /etc/traefik/conf.d
     watch: true
@@ -447,7 +460,6 @@ services:
       - "443:443"
       - "8080:8080"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./traefik.yml:/etc/traefik/traefik.yml:ro
       - ./conf.d:/etc/traefik/conf.d:ro
       - ~/.local-ssl-certs:/certs:ro

--- a/.agents/scripts/localdev-helper-ports.sh
+++ b/.agents/scripts/localdev-helper-ports.sh
@@ -356,7 +356,7 @@ generate_cert() {
 
 	# mkcert generates files named after the first domain arg
 	# Output: {domain}+1.pem and {domain}+1-key.pem (wildcard is second arg)
-	(cd "$CERTS_DIR" && mkcert "$domain" "$wildcard")
+	(cd "$CERTS_DIR" && run_stable_mkcert "$domain" "$wildcard")
 
 	# Verify cert was created
 	local cert_file="$CERTS_DIR/${domain}+1.pem"

--- a/.agents/scripts/localdev-helper-routes.sh
+++ b/.agents/scripts/localdev-helper-routes.sh
@@ -47,7 +47,7 @@ create_traefik_route() {
 http:
   routers:
     ${name}:
-      rule: "Host(\`${domain}\`) || Host(\`*.${domain}\`)"
+      rule: "Host(\`${domain}\`)"
       entryPoints:
         - websecure
       service: ${name}

--- a/.agents/scripts/tests/test-localdev-helper-config.sh
+++ b/.agents/scripts/tests/test-localdev-helper-config.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for generated localdev proxy and certificate configuration.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+INIT_LIB="$REPO_ROOT/.agents/scripts/localdev-helper-init.sh"
+PORTS_LIB="$REPO_ROOT/.agents/scripts/localdev-helper-ports.sh"
+ROUTES_LIB="$REPO_ROOT/.agents/scripts/localdev-helper-routes.sh"
+TEST_TMP_BASE="${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}"
+mkdir -p "$TEST_TMP_BASE"
+TEST_ROOT="$(mktemp -d "$TEST_TMP_BASE/localdev-helper-config.XXXXXX")"
+PASS=0
+FAIL=0
+
+record_pass() {
+	local description="$1"
+	printf 'PASS: %s\n' "$description"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+record_fail() {
+	local description="$1"
+	printf 'FAIL: %s\n' "$description" >&2
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_file_contains() {
+	local description="$1"
+	local file="$2"
+	local text="$3"
+	if grep -Fq -- "$text" "$file"; then
+		record_pass "$description"
+	else
+		record_fail "$description"
+	fi
+	return 0
+}
+
+assert_file_excludes() {
+	local description="$1"
+	local file="$2"
+	local text="$3"
+	if grep -Fq -- "$text" "$file"; then
+		record_fail "$description"
+	else
+		record_pass "$description"
+	fi
+	return 0
+}
+
+assert_file_exists() {
+	local description="$1"
+	local file="$2"
+	if [[ -f "$file" ]]; then
+		record_pass "$description"
+	else
+		record_fail "$description"
+	fi
+	return 0
+}
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+
+print_error() {
+	printf 'ERROR: %s\n' "$*" >&2
+	return 0
+}
+
+print_info() {
+	printf 'INFO: %s\n' "$*"
+	return 0
+}
+
+print_success() {
+	printf 'SUCCESS: %s\n' "$*"
+	return 0
+}
+
+print_warning() {
+	printf 'WARNING: %s\n' "$*" >&2
+	return 0
+}
+
+detect_brew_prefix() {
+	return 0
+}
+
+trap cleanup EXIT
+export LOCALDEV_DIR="$TEST_ROOT/localdev"
+export CONFD_DIR="$LOCALDEV_DIR/conf.d"
+export CERTS_DIR="$TEST_ROOT/certs"
+export TRAEFIK_STATIC="$LOCALDEV_DIR/traefik.yml"
+export DOCKER_COMPOSE="$LOCALDEV_DIR/docker-compose.yml"
+export BACKUP_DIR="$LOCALDEV_DIR/backup"
+mkdir -p "$CONFD_DIR" "$CERTS_DIR" "$BACKUP_DIR" "$TEST_ROOT/bin"
+
+# shellcheck source=/dev/null
+source "$INIT_LIB"
+# shellcheck source=/dev/null
+source "$PORTS_LIB"
+# shellcheck source=/dev/null
+source "$ROUTES_LIB"
+
+create_traefik_route sample 3210 >/dev/null
+route_file="$CONFD_DIR/sample.yml"
+assert_file_contains "base route uses an exact host" "$route_file" "rule: \"Host(\`sample.local\`)\""
+assert_file_excludes "base route omits invalid wildcard Host matcher" "$route_file" '*.sample.local'
+
+write_traefik_static
+assert_file_contains "static config enables the file provider" "$TRAEFIK_STATIC" '  file:'
+assert_file_excludes "static config omits the Docker provider" "$TRAEFIK_STATIC" '  docker:'
+assert_file_excludes "static config omits exposedByDefault" "$TRAEFIK_STATIC" 'exposedByDefault'
+
+write_docker_compose
+assert_file_contains "Compose mounts file-provider routes" "$DOCKER_COMPOSE" './conf.d:/etc/traefik/conf.d:ro'
+assert_file_excludes "Compose does not mount the Docker socket" "$DOCKER_COMPOSE" '/var/run/docker.sock'
+
+mkcert_log="$TEST_ROOT/mkcert.log"
+cat >"$TEST_ROOT/bin/mkcert" <<'MKCERT'
+#!/usr/bin/env bash
+printf '%s|%s|%s\n' "${XDG_DATA_HOME:-}" "${CAROOT:-}" "$*" >>"$MKCERT_LOG"
+case "${1:-}" in
+-*) ;;
+*)
+	touch "${1}+1.pem" "${1}+1-key.pem"
+	;;
+esac
+exit 0
+MKCERT
+chmod +x "$TEST_ROOT/bin/mkcert"
+export MKCERT_LOG="$mkcert_log"
+export PATH="$TEST_ROOT/bin:$PATH"
+hash -r
+
+export XDG_DATA_HOME="$TEST_ROOT/session-data"
+unset CAROOT
+run_stable_mkcert -CAROOT
+assert_file_contains "mkcert ignores session-scoped XDG data" "$mkcert_log" '||-CAROOT'
+
+export CAROOT="$TEST_ROOT/explicit-ca"
+run_stable_mkcert -CAROOT
+assert_file_contains "mkcert preserves an explicit CAROOT" "$mkcert_log" "|$CAROOT|-CAROOT"
+
+unset CAROOT
+ensure_mkcert >/dev/null
+assert_file_contains "init reconciles trust when mkcert already exists" "$mkcert_log" '||-install'
+
+generate_cert sample >/dev/null
+assert_file_exists "stable mkcert creates the certificate" "$CERTS_DIR/sample.local+1.pem"
+assert_file_exists "stable mkcert creates the private key" "$CERTS_DIR/sample.local+1-key.pem"
+assert_file_contains "certificate generation ignores session XDG data" "$mkcert_log" '||sample.local *.sample.local'
+
+printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Generate valid exact-host Traefik routes, remove the unused Docker provider and socket from new local proxy templates, and run mkcert outside session-scoped XDG isolation while preserving explicit CAROOT.

## Files Changed

.agents/scripts/localdev-helper-init.sh, .agents/scripts/localdev-helper-ports.sh, .agents/scripts/localdev-helper-routes.sh, .agents/scripts/tests/test-localdev-helper-config.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused config regression test: 13/13 under bash and macOS /bin/bash; owner-safe serve regression test: 38/38; ShellCheck: zero findings; linters-local changed-file gates: pass; git diff --check: pass.

Resolves #28075


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 29d 4h and 4,342,678 tokens on this with the user in an interactive session.