### PR TITLE
GH#28081: Explain worktree removal guard refusals

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -213,7 +213,9 @@ _worktree_has_process_cwd() {
 #   $4  cwd_snapshot — optional newline-separated live-process cwd snapshot
 #
 # Refuses registered canonical repos, the caller's current working directory,
-# and worktrees that still have any live process cwd inside them.
+# and worktrees that still have any live process cwd inside them. On refusal,
+# WORKTREE_REMOVAL_GUARD_REASON contains the short audit reason for callers that
+# opt into a user-facing diagnostic. The guard itself remains silent.
 # Returns 0 when callers may continue, 1 when removal must be skipped.
 # =============================================================================
 worktree_removal_guard() {
@@ -222,15 +224,18 @@ worktree_removal_guard() {
 	local reason="$3"
 	local cwd_snapshot="${4:-}"
 	local cwd_snapshot_provided=0
+	WORKTREE_REMOVAL_GUARD_REASON=""
 	[[ "$#" -ge 4 ]] && cwd_snapshot_provided=1
 
 	if [[ -z "$wt_path" ]]; then
+		WORKTREE_REMOVAL_GUARD_REASON="empty-path"
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "empty-path" "skipped"
 		return 1
 	fi
 
 	if command -v is_registered_canonical >/dev/null 2>&1; then
 		if is_registered_canonical "$wt_path"; then
+			WORKTREE_REMOVAL_GUARD_REASON="canonical-skip"
 			log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "canonical-skip" "skipped"
 			return 1
 		fi
@@ -246,6 +251,7 @@ worktree_removal_guard() {
 	if [[ -n "$current_dir" ]]; then
 		case "$current_dir" in
 		"$wt_path" | "$wt_path"/* | "$wt_path_real" | "$wt_path_real"/*)
+			WORKTREE_REMOVAL_GUARD_REASON="current-worktree"
 			log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "current-worktree" "skipped"
 			return 1
 			;;
@@ -255,6 +261,7 @@ worktree_removal_guard() {
 	if { [[ "$cwd_snapshot_provided" -eq 1 ]] && \
 		_worktree_cwd_snapshot_contains_path "$wt_path" "$wt_path_real" "$cwd_snapshot"; } || \
 		{ [[ "$cwd_snapshot_provided" -eq 0 ]] && _worktree_has_process_cwd "$wt_path" "$wt_path_real"; }; then
+		WORKTREE_REMOVAL_GUARD_REASON="active-cwd"
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "active-cwd" "skipped"
 		return 1
 	fi

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -258,8 +258,8 @@ worktree_removal_guard() {
 		esac
 	fi
 
-	if { [[ "$cwd_snapshot_provided" -eq 1 ]] && \
-		_worktree_cwd_snapshot_contains_path "$wt_path" "$wt_path_real" "$cwd_snapshot"; } || \
+	if { [[ "$cwd_snapshot_provided" -eq 1 ]] &&
+		_worktree_cwd_snapshot_contains_path "$wt_path" "$wt_path_real" "$cwd_snapshot"; } ||
 		{ [[ "$cwd_snapshot_provided" -eq 0 ]] && _worktree_has_process_cwd "$wt_path" "$wt_path_real"; }; then
 		WORKTREE_REMOVAL_GUARD_REASON="active-cwd"
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "active-cwd" "skipped"

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -31,6 +31,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AUDIT_HELPER="${SCRIPT_DIR}/../audit-worktree-removal-helper.sh"
+COMMANDS_HELPER="${SCRIPT_DIR}/../worktree-helper-cmds.sh"
 
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -345,7 +346,13 @@ test_permanent_helper_removes_and_logs() {
 	source "$AUDIT_HELPER"
 
 	local rc=0
-	remove_worktree_path_permanently "$wt_path" "test.sh" "age-eligible" || rc=$?
+	(
+		capture_worktree_process_cwds() {
+			printf '/\n'
+			return 0
+		}
+		remove_worktree_path_permanently "$wt_path" "test.sh" "age-eligible"
+	) || rc=$?
 	[[ ! -e "$wt_path" ]] || rc=1
 	assert_file_contains "$log_file" "worktree-removed.*age-eligible.*mode=permanent" || rc=1
 	print_result "permanent_helper_removes_and_logs" "$rc" \
@@ -485,6 +492,73 @@ test_proc_snapshot_rejects_partial_visibility() {
 }
 
 # =============================================================================
+# Test 15: guard refusals expose a machine-readable reason without changing the
+# exactly-once audit contract.
+# =============================================================================
+test_guard_reason_is_machine_readable() {
+	local log_file="${TEST_DIR}/t15-cleanup.log"
+	local wt_path="${TEST_DIR}/reason-wt"
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	mkdir -p "$wt_path"
+
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../audit-worktree-removal-helper.sh
+	source "$AUDIT_HELPER"
+	if worktree_removal_guard "$wt_path" "test.sh" "manual" "$wt_path"; then
+		rc=1
+	fi
+	[[ "${WORKTREE_REMOVAL_GUARD_REASON:-}" == "active-cwd" ]] || rc=1
+	assert_line_count "$log_file" 1 || rc=1
+	print_result "guard_reason_is_machine_readable" "$rc" \
+		"Expected active-cwd reason and exactly one audit row"
+	return 0
+}
+
+# =============================================================================
+# Test 16: manual removal renders safe actionable diagnostics for each shared
+# guard reason. The guard remains the sole audit writer.
+# =============================================================================
+test_manual_guard_refusal_diagnostics() {
+	local output_file="${TEST_DIR}/t16-output.log"
+	local log_file="${TEST_DIR}/t16-cleanup.log"
+	local rc=0
+	local reason=""
+	local guard_reason_to_test=""
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	unset _WORKTREE_CMDS_LIB_LOADED 2>/dev/null || true
+	RED=""
+	NC=""
+	# shellcheck source=../worktree-helper-cmds.sh
+	source "$COMMANDS_HELPER"
+	worktree_removal_guard() {
+		local path_to_remove="$1"
+		local caller="$2"
+		local removal_mode="$3"
+		WORKTREE_REMOVAL_GUARD_REASON="$guard_reason_to_test"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$path_to_remove" \
+			"$guard_reason_to_test" "skipped"
+		: "$removal_mode"
+		return 1
+	}
+	for reason in active-cwd current-worktree canonical-skip; do
+		guard_reason_to_test="$reason"
+		if _remove_validate_path "/safe/example-worktree" 2>>"$output_file"; then
+			rc=1
+		fi
+	done
+	assert_file_contains "$output_file" "Reason: active-cwd.*live process" || rc=1
+	assert_file_contains "$output_file" "Reason: current-worktree.*inside the target" || rc=1
+	assert_file_contains "$output_file" "Reason: canonical-skip.*canonical checkout" || rc=1
+	assert_file_contains "$output_file" "cannot bypass this protection" || rc=1
+	assert_line_count "$log_file" 3 || rc=1
+	print_result "manual_guard_refusal_diagnostics" "$rc" \
+		"Expected safe diagnostics and exactly one audit row per refusal"
+	return 0
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -506,6 +580,8 @@ test_process_cwd_guard_refuses_empty_paths
 test_process_cwd_snapshot_failure_is_fail_closed
 test_snapshot_backend_requires_visible_target
 test_proc_snapshot_rejects_partial_visibility
+test_guard_reason_is_machine_readable
+test_manual_guard_refusal_diagnostics
 
 echo ""
 echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed."

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -193,11 +193,17 @@ test_should_skip_cleanup_owned_skip_logs() {
 	(
 		RED='' NC=''
 		is_worktree_owned_by_others() { return 0; }
-		check_worktree_owner()         { echo "99999|session-stub"; return 0; }
-		worktree_is_in_grace_period()  { return 1; }
-		get_validated_grace_hours()    { echo "4"; return 0; }
-		worktree_has_changes()         { return 1; }
-		branch_has_zero_commits_ahead(){ return 1; }
+		check_worktree_owner() {
+			echo "99999|session-stub"
+			return 0
+		}
+		worktree_is_in_grace_period() { return 1; }
+		get_validated_grace_hours() {
+			echo "4"
+			return 0
+		}
+		worktree_has_changes() { return 1; }
+		branch_has_zero_commits_ahead() { return 1; }
 
 		export AIDEVOPS_CLEANUP_LOG="$log_file"
 		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
@@ -248,7 +254,7 @@ test_idempotent_sourcing() {
 	# shellcheck source=../audit-worktree-removal-helper.sh
 	source "$AUDIT_HELPER"
 	# shellcheck source=../audit-worktree-removal-helper.sh
-	source "$AUDIT_HELPER"  # second source — guard makes this a no-op
+	source "$AUDIT_HELPER" # second source — guard makes this a no-op
 
 	log_worktree_removal_event "$_WTAR_REMOVED" "test.sh" "/wt" "manual" "trash"
 

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -101,6 +101,35 @@ cmd_list() {
 
 # --- cmd_remove helpers ---
 
+# Explain a shared removal-guard refusal to an explicit/manual caller without
+# exposing process details. Background cleanup callers do not call this helper.
+# Args: $1=path_to_remove, $2=machine-readable guard reason
+_remove_show_guard_error() {
+	local path_to_remove="$1"
+	local guard_reason="$2"
+
+	printf '%b\n' "${RED}Error: Worktree removal refused: ${path_to_remove}${NC}" >&2
+	case "$guard_reason" in
+	active-cwd)
+		printf '%s\n' "Reason: active-cwd — a live process has its current directory inside the target." >&2
+		printf '%s\n' "Recovery: close processes or terminal windows using the target, then retry. --force cannot bypass this protection." >&2
+		;;
+	current-worktree)
+		printf '%s\n' "Reason: current-worktree — this command is running from inside the target." >&2
+		printf '%s\n' "Recovery: change directory outside the target, then retry. --force cannot bypass this protection." >&2
+		;;
+	canonical-skip)
+		printf '%s\n' "Reason: canonical-skip — the target is a registered canonical checkout." >&2
+		printf '%s\n' "Recovery: preserve the canonical checkout and remove only an eligible linked worktree. --force cannot bypass this protection." >&2
+		;;
+	*)
+		printf '%s\n' "Reason: ${guard_reason:-guard-refused} — the shared safety guard did not authorize removal." >&2
+		printf '%s\n' "Recovery: inspect the cleanup audit log, resolve the safety condition, then retry." >&2
+		;;
+	esac
+	return 0
+}
+
 # Validate that a resolved worktree path is safe to remove.
 # Checks: shared non-overridable removal guard, then ownership.
 # Args: $1=path_to_remove
@@ -112,7 +141,10 @@ _remove_validate_path() {
 	# The shared guard blocks canonical repos, this shell's cwd, and every live
 	# process whose cwd is inside the target. --force may override ownership or
 	# dirty-state policy, but it must never override a live process cwd.
-	worktree_removal_guard "$path_to_remove" "$guard_caller" "$_WT_REMOVE_MODE_MANUAL" || return 1
+	if ! worktree_removal_guard "$path_to_remove" "$guard_caller" "$_WT_REMOVE_MODE_MANUAL"; then
+		_remove_show_guard_error "$path_to_remove" "${WORKTREE_REMOVAL_GUARD_REASON:-}"
+		return 1
+	fi
 
 	# Don't allow removing main worktree
 	# NOTE: avoid piping git worktree list through head — with set -o pipefail
@@ -170,7 +202,10 @@ _remove_cleanup_and_execute() {
 	# Close the validation/removal race as tightly as possible. A process may
 	# enter the worktree after cmd_remove validates it; recheck immediately
 	# before the directory is moved or deregistered.
-	worktree_removal_guard "$path_to_remove" "${SCRIPT_NAME:-worktree-helper.sh}" "$_WT_REMOVE_MODE_MANUAL" || return 1
+	if ! worktree_removal_guard "$path_to_remove" "${SCRIPT_NAME:-worktree-helper.sh}" "$_WT_REMOVE_MODE_MANUAL"; then
+		_remove_show_guard_error "$path_to_remove" "${WORKTREE_REMOVAL_GUARD_REASON:-}"
+		return 1
+	fi
 
 	echo -e "${BLUE}Removing worktree: $path_to_remove${NC}"
 	# Move the worktree directory to trash BEFORE git deregisters it.


### PR DESCRIPTION
## Summary

- Expose machine-readable worktree removal guard reasons without changing fail-closed behavior.
- Print safe, actionable diagnostics for explicit manual removal refusals.
- Cover active-cwd, current-worktree, canonical, and exactly-once audit behavior.

## Testing

- `bash .agents/scripts/tests/test-worktree-removal-audit.sh` (16/16 pass)
- `shellcheck .agents/scripts/audit-worktree-removal-helper.sh .agents/scripts/worktree-helper-cmds.sh .agents/scripts/tests/test-worktree-removal-audit.sh`

## Runtime Testing

- Self-assessed: shell diagnostics and tests only; destructive protections remain fail-closed.

Resolves #28081

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 6m and 106,788 tokens on this as a headless worker. Overall, 20m since this issue was created.
