### PR TITLE
t18125: Bound Pulse idle available-work queries

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -13,7 +13,7 @@
 # Dependencies:
 #   - pulse-wrapper-config.sh globals (LOGFILE, WRAPPER_LOGFILE, SCOPE_FILE,
 #     REPOS_JSON, _PULSE_HEALTH_* counters, _file_mtime_epoch)
-#   - gh, jq, tr, date, mkdir, touch, rm
+#   - timeout_sec (shared-constants.sh), gh, jq, tr, date, mkdir, touch, rm
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -51,14 +51,35 @@ _pulse_scope_repos_for_available_work_gate() {
 
 _pulse_available_auto_dispatch_work_exists() {
 	[[ "${AIDEVOPS_SKIP_PULSE_IDLE_AVAILABLE_WORK_CHECK:-0}" == "1" ]] && return 1
-	local _slug=""
+	local _timeout_secs="${AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK_TIMEOUT:-30}"
+	[[ "$_timeout_secs" =~ ^[1-9][0-9]*$ ]] || _timeout_secs=30
+	if ! declare -F timeout_sec >/dev/null 2>&1; then
+		printf '[pulse-wrapper] Idle available-work check has no timeout helper; proceeding without idle backoff (GH#27769)\n' \
+			>>"${WRAPPER_LOGFILE:-/dev/null}"
+		return 124
+	fi
+
+	local _deadline=$((SECONDS + _timeout_secs))
+	local _slug="" _count="" _query_rc=0 _remaining=0
 	while IFS= read -r _slug; do
 		[[ -n "$_slug" ]] || continue
-		local _count=""
-		_count=$(gh api -X GET search/issues \
+		_remaining=$((_deadline - SECONDS))
+		if [[ "$_remaining" -lt 1 ]]; then
+			printf '[pulse-wrapper] Idle available-work check timed out after %ss; proceeding without idle backoff (GH#27769)\n' \
+				"$_timeout_secs" >>"${WRAPPER_LOGFILE:-/dev/null}"
+			return 124
+		fi
+		_count=""
+		_query_rc=0
+		_count=$(timeout_sec "$_remaining" gh api -X GET search/issues \
 			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:needs-maintainer-review -label:needs-maintainer-permissions no:assignee" \
 			-f per_page=1 \
-			--jq '.total_count // 0' 2>/dev/null) || _count=""
+			--jq '.total_count // 0' 2>/dev/null) || _query_rc=$?
+		if [[ "$_query_rc" -eq 124 ]]; then
+			printf '[pulse-wrapper] Idle available-work check timed out after %ss; proceeding without idle backoff (GH#27769)\n' \
+				"$_timeout_secs" >>"${WRAPPER_LOGFILE:-/dev/null}"
+			return 124
+		fi
 		[[ "$_count" =~ ^[0-9]+$ ]] || _count=0
 		if [[ "$_count" -gt 0 ]]; then
 			echo "[pulse-wrapper] Idle backoff bypass: eligible auto-dispatch work is visible in ${_slug} (GH#22631)" >>"$WRAPPER_LOGFILE"
@@ -72,8 +93,13 @@ _pulse_check_idle_backoff_gate() {
 	local _ib_helper="${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
 	[[ -x "$_ib_helper" ]] || return 0
 	local _ib_available_work=0
+	local _ib_available_work_rc=0
 	if _pulse_available_auto_dispatch_work_exists; then
 		_ib_available_work=1
+	else
+		_ib_available_work_rc=$?
+		# Unknown work state must not suppress the watchdog-protected cycle.
+		[[ "$_ib_available_work_rc" -eq 124 ]] && return 0
 	fi
 	local _ib_ts_file="${HOME}/.aidevops/logs/pulse-wrapper-last-run.ts"
 	local _ib_last=0

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -32,12 +32,39 @@ mkdir -p "$SCRIPT_DIR"
 : >"$WRAPPER_LOGFILE"
 
 GH_QUERY_FILE="${TMP}/query.txt"
+TIMEOUT_CALL_FILE="${TMP}/timeout.txt"
 export GH_QUERY_FILE
+export TIMEOUT_CALL_FILE
+export TIMEOUT_MODE="pass"
 gh() {
 	printf '%s\n' "$*" >"$GH_QUERY_FILE"
 	printf '0\n'
 	return 0
 }
+
+timeout_sec() {
+	local timeout_seconds="$1"
+	shift
+	printf '%s\n' "$timeout_seconds" >"$TIMEOUT_CALL_FILE"
+	if [[ "$TIMEOUT_MODE" == "timeout" ]]; then
+		return 124
+	fi
+	"$@"
+	return $?
+}
+
+cat >"${SCRIPT_DIR}/pulse-idle-backoff-helper.sh" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+should-skip) exit 0 ;;
+state)
+	printf '{"consecutive_idle":2,"current_effective_interval_s":120}\n'
+	exit 0
+	;;
+*) exit 1 ;;
+esac
+EOF
+chmod +x "${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
 
 SOURCE_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/pulse-wrapper-cycle-gates.sh"
 # shellcheck disable=SC1090
@@ -52,7 +79,37 @@ fi
 if grep -q -- '-label:needs-maintainer-review' "$GH_QUERY_FILE"; then
 	pass "idle-work query excludes NMR-held issues"
 else
-	fail "idle-work query excludes NMR-held issues" "query=$(cat "$GH_QUERY_FILE")"
+	fail "idle-work query excludes NMR-held issues" "query=$(<"$GH_QUERY_FILE")"
+fi
+
+if [[ "$(<"$TIMEOUT_CALL_FILE")" == "30" ]]; then
+	pass "idle-work query uses bounded default timeout"
+else
+	fail "idle-work query uses bounded default timeout" "timeout=$(<"$TIMEOUT_CALL_FILE")"
+fi
+
+export TIMEOUT_MODE="timeout"
+if _pulse_available_auto_dispatch_work_exists; then
+	fail "idle-work query surfaces timeout status"
+else
+	query_rc=$?
+	if [[ "$query_rc" -eq 124 ]]; then
+		pass "idle-work query surfaces timeout status"
+	else
+		fail "idle-work query surfaces timeout status" "rc=${query_rc}"
+	fi
+fi
+
+if _pulse_check_idle_backoff_gate; then
+	pass "idle-work timeout bypasses idle backoff"
+else
+	fail "idle-work timeout bypasses idle backoff"
+fi
+
+if grep -q 'timed out after 30s' "$WRAPPER_LOGFILE"; then
+	pass "idle-work timeout is logged"
+else
+	fail "idle-work timeout is logged"
 fi
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
@@ -22,6 +22,8 @@
 #   2. The dry-run output line confirms the expected short-circuit fired
 #   3. Static check: include guard exists in pulse-stats-helper.sh
 #   4. Static check: dry-run short-circuit exists in pulse-wrapper.sh
+#   5. Static check: supervisor circuit-breaker refresh remains wired
+#   6. Static check: idle backoff's available-work bypass remains wired
 #
 # What is NOT exercised:
 #   - GitHub API calls (no network)
@@ -34,6 +36,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 WRAPPER_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper.sh"
+CYCLE_GATES_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper-cycle-gates.sh"
 STATS_HELPER="${SCRIPT_DIR}/../pulse-stats-helper.sh"
 DEFAULTS_SOURCE="${SCRIPT_DIR}/../../configs/aidevops.defaults.jsonc"
 
@@ -196,13 +199,14 @@ test_supervisor_circuit_breaker_refresh_present() {
 
 # Test 6: Static check — idle backoff observes eligible auto-dispatch work.
 test_idle_backoff_available_work_bypass_present() {
-	if grep -q '_pulse_available_auto_dispatch_work_exists' "$WRAPPER_SCRIPT" && \
-		grep -q 'AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK' "$WRAPPER_SCRIPT"; then
-		print_result "idle backoff available-work bypass present in pulse-wrapper.sh" 0
+	if grep -q 'pulse-wrapper-cycle-gates.sh' "$WRAPPER_SCRIPT" &&
+		grep -q '_pulse_available_auto_dispatch_work_exists' "$CYCLE_GATES_SCRIPT" &&
+		grep -q 'AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK' "$CYCLE_GATES_SCRIPT"; then
+		print_result "idle backoff available-work bypass present in pulse cycle gates" 0
 		return 0
 	fi
-	print_result "idle backoff available-work bypass present in pulse-wrapper.sh" 1 \
-		"Expected available-work check and env bridge in $WRAPPER_SCRIPT"
+	print_result "idle backoff available-work bypass present in pulse cycle gates" 1 \
+		"Expected wrapper source plus available-work check and env bridge in $CYCLE_GATES_SCRIPT"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Bound the pre-watchdog idle available-work search to a 30-second total budget, surface timeouts explicitly, and bypass idle backoff when the work state is unknown; refreshed moved-module regression coverage.

## Files Changed

.agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh, .agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck; pulse cycle-gate, idle-backoff, dry-run bootstrap, canary, and characterization tests; changed-file and full local linter suites.

For #27769


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 1h 10m and 1,566,714 tokens on this with the user in an interactive session.