### PR TITLE
GH#27984: guard MCP health test sandbox path

### DIFF
--- a/.agents/scripts/tests/test-mcp-inspector-health-identity.sh
+++ b/.agents/scripts/tests/test-mcp-inspector-health-identity.sh
@@ -60,7 +60,7 @@ run_health_fixture() {
 	local gateway_port="${2:-}"
 	local dashboard_port="${3:-}"
 
-	: >"${SANDBOX}/curl-args.log"
+	: >"${SANDBOX:?SANDBOX must be initialized}/curl-args.log"
 	OUTPUT=$(PATH="${SANDBOX}/bin:${PATH}" \
 		MCP_HEALTH_FIXTURE="$fixture" \
 		FAKE_CURL_ARGS_LOG="${SANDBOX}/curl-args.log" \


### PR DESCRIPTION
## Summary

- require the MCP health-test sandbox path to be initialized before truncating its curl argument log
- prevent an empty sandbox value from targeting `/curl-args.log`

## Verification

- `bash .agents/scripts/tests/test-mcp-inspector-health-identity.sh`
- `shellcheck .agents/scripts/tests/test-mcp-inspector-health-identity.sh`
- pre-commit quality validation

Resolves #27984

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 4m and 96,068 tokens on this as a headless worker.