### PR TITLE
GH#28084: Explain greeting lock retry limit

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -79,6 +79,8 @@ const CACHE_DIR = join(homedir(), ".aidevops", "cache");
 const CACHE_BASENAME = "session-greeting-opencode.txt";
 const LOCK_BASENAME = "session-greeting-refresh.lock";
 const LOCK_OWNER_BASENAME = "owner";
+// Number of times to poll for a replacement lock or refreshed cache after the
+// prior lock disappears.
 const MAX_MISSING_LOCK_RETRIES = 4;
 // Comprehensive checks run at most once per 15-minute window. The subprocess
 // times out after 15 seconds, so a lock older than 30 seconds is safe to reap


### PR DESCRIPTION
## Summary

Documented why the bounded missing-lock retry constant exists and what handoff state it observes.

## Files Changed

.agents/plugins/opencode-aidevops/greeting.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check greeting.mjs; npm test in .agents/plugins/opencode-aidevops (441 tests passed); git diff --check

Resolves #28084


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 3m and 78,164 tokens on this as a headless worker.