### PR TITLE
GH#28086: refactor: map terminal title statuses

### DIFF
--- a/.agents/plugins/opencode-aidevops/terminal-title.mjs
+++ b/.agents/plugins/opencode-aidevops/terminal-title.mjs
@@ -5,17 +5,19 @@ import { closeSync, openSync, writeSync } from "node:fs";
 
 const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/g;
 const STATUS_PREFIX_RE = /^(?:\[(?:RUN|WAIT)\]|⚪|🔴|🟡|🟢)\s+/u;
+const STATUS_LABELS = new Map([
+  ["busy", "⚪"],
+  ["retry", "🔴"],
+  ["permission", "🟡"],
+  ["idle", "🟢"],
+]);
 
 export function sanitizeTerminalTitle(title) {
   return String(title || "").replace(CONTROL_CHAR_RE, " ").trim();
 }
 
 export function terminalTitleStatusLabel(status) {
-  if (status === "busy") return "⚪";
-  if (status === "retry") return "🔴";
-  if (status === "permission") return "🟡";
-  if (status === "idle") return "🟢";
-  return "";
+  return STATUS_LABELS.get(status) || "";
 }
 
 export function withTerminalTitleStatus(title, status) {


### PR DESCRIPTION
## Summary

Replace the terminal-title status conditional chain with a module-level Map while preserving existing labels and fallback behavior.

## Files Changed

.agents/plugins/opencode-aidevops/terminal-title.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test .agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs; node --check .agents/plugins/opencode-aidevops/terminal-title.mjs; git diff --check

Resolves #28086


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 2m and 45,488 tokens on this as a headless worker.