### PR TITLE
GH#28094: Harden full-loop evidence validation

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -413,9 +413,15 @@ _merge_resolve_match_head() {
 	local repo="$2"
 	local pre_merge_head_sha=""
 	pre_merge_head_sha=$(_merge_fetch_head_sha_rest "$pr_number" "$repo" || true)
-	if [[ -n "${FULL_LOOP_VERIFIED_PR_HEAD_SHA:-}" && "$pre_merge_head_sha" != "$FULL_LOOP_VERIFIED_PR_HEAD_SHA" ]]; then
-		print_error "PR #${pr_number} head changed after remote verification; refusing merge"
-		return 1
+	if [[ -n "${FULL_LOOP_VERIFIED_PR_HEAD_SHA:-}" ]]; then
+		if [[ -z "$pre_merge_head_sha" ]]; then
+			print_error "Could not retrieve PR #${pr_number} head SHA for verification; refusing merge"
+			return 1
+		fi
+		if [[ "$pre_merge_head_sha" != "$FULL_LOOP_VERIFIED_PR_HEAD_SHA" ]]; then
+			print_error "PR #${pr_number} head changed after remote verification; refusing merge"
+			return 1
+		fi
 	fi
 	local match_head_sha="${FULL_LOOP_VERIFIED_PR_HEAD_SHA:-$pre_merge_head_sha}"
 	[[ -n "$match_head_sha" ]] || return 1
@@ -531,7 +537,7 @@ _merge_verify_completed_state() {
 		def present: ((. // "") | length > 0);
 		(.state == "MERGED")
 		and (.mergedAt | present)
-		and (.mergeCommit.oid | present)
+		and (.mergeCommit | type == "object" and (.oid | present))
 	' >/dev/null; then
 		return 1
 	fi

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -1093,7 +1093,7 @@ _full_loop_verify_merged_pr() {
 	printf '%s' "$pr_json" | jq -e '
 		(.state == "MERGED")
 		and ((.mergedAt // "") != "")
-		and ((.mergeCommit.oid // "") != "")
+		and (.mergeCommit | type == "object" and ((.oid // "") != ""))
 	' >/dev/null
 	return $?
 }
@@ -1166,7 +1166,7 @@ _full_loop_verify_aidevops_release_deploy() {
 	[[ -f "${HOME}/.aidevops/agents/VERSION" ]] && IFS= read -r deployed_version <"${HOME}/.aidevops/agents/VERSION"
 	[[ "$deployed_version" == "$version" ]] || return 1
 	local postflight="${SCRIPT_DIR}/postflight-check.sh"
-	[[ -x "$postflight" ]] || return 1
+	[[ -f "$postflight" ]] || return 1
 	bash "$postflight" --quick --sha "$release_sha" >/dev/null 2>&1 || return 1
 	return 0
 }

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -212,6 +212,10 @@ if [[ "\$_gh_cmd" == "api" ]]; then
 		exit 0
 	fi
 	if [[ "\$*" == *"repos/testorg/testrepo/pulls/42"* ]]; then
+		if [[ "$mode" == "head-fetch-failure" ]]; then
+			echo 'transient pull lookup failure' >&2
+			exit 1
+		fi
 		echo 'abc123headsha'
 		exit 0
 	fi
@@ -294,6 +298,7 @@ RUNNER_EOF
 	env PATH="${TEST_ROOT}/bin:${scripts_dir}:${PATH}" \
 		HOME="${TEST_ROOT}/home" \
 		FULL_LOOP_HEADLESS="${FULL_LOOP_HEADLESS:-}" \
+		FULL_LOOP_VERIFIED_PR_HEAD_SHA="${FULL_LOOP_VERIFIED_PR_HEAD_SHA:-}" \
 		AIDEVOPS_HEADLESS= \
 		Claude_HEADLESS= \
 		GITHUB_ACTIONS= \
@@ -733,6 +738,27 @@ RUNNER_EOF
 	return 0
 }
 
+# Test 12: A failed head lookup is reported as unavailable evidence, not drift.
+test_verified_head_lookup_failure_is_not_reported_as_drift() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+	create_gh_stub "head-fetch-failure"
+
+	local output=""
+	local rc=0
+	output=$(FULL_LOOP_VERIFIED_PR_HEAD_SHA="verified123" run_merge_execute \
+		"42" "testorg/testrepo" "--squash" "0" "0") || rc=$?
+	print_result "verified head lookup failure: merge remains blocked" "$((rc == 0 ? 1 : 0))"
+
+	local reports_retrieval_failure=0
+	[[ "$output" == *"Could not retrieve PR #42 head SHA for verification"* ]] && reports_retrieval_failure=1
+	print_result "verified head lookup failure: retrieval error is explicit" "$((1 - reports_retrieval_failure))"
+
+	local reports_false_drift=0
+	[[ "$output" == *"head changed after remote verification"* ]] && reports_false_drift=1
+	print_result "verified head lookup failure: no false drift diagnosis" "$reports_false_drift"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -754,6 +780,7 @@ main() {
 	test_auth_401_detection_avoids_numeric_false_positives
 	test_pr_ready_accepts_prefetched_json
 	test_pr_ready_blocks_nonpassing_rollup
+	test_verified_head_lookup_failure_is_not_reported_as_drift
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-version-manager-release-provenance.sh
+++ b/.agents/scripts/tests/test-version-manager-release-provenance.sh
@@ -62,7 +62,8 @@ printf 'PASS unreachable merge SHA is rejected\n'
 
 git -C "$REPO" switch -q -c safety/release-test
 printf 'canonical human work\n' >>"${REPO}/README.md"
-git -C "$REPO" commit -q -am 'local canonical divergence'
+git -C "$REPO" add README.md
+git -C "$REPO" commit -q -m 'local canonical divergence'
 printf 'uncommitted human work\n' >>"${REPO}/README.md"
 if verify_remote_sync main >/dev/null 2>&1 &&
 	PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin" verify_release_source_pr 42 main testorg/aidevops; then

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -153,7 +153,7 @@ verify_release_source_pr() {
 		and (.mergedAt | present)
 		and (.baseRefName == $branch)
 		and (.headRefOid | present)
-		and (.mergeCommit.oid | present)
+		and (.mergeCommit | type == "object" and (.oid | present))
 	' >/dev/null; then
 		print_error "Source PR #${source_pr} lacks verified MERGED provenance for ${branch}"
 		return 1


### PR DESCRIPTION
## Summary

- Distinguish unavailable PR-head evidence from confirmed head drift.
- Require merge commit objects before accepting merge/release provenance.
- Allow postflight scripts invoked through bash without executable mode.

## Testing

- `bash .agents/scripts/tests/test-full-loop-merge.sh`
- `bash .agents/scripts/tests/test-full-loop-completion-evidence.sh`
- `PATH=/usr/bin:/bin bash .agents/scripts/tests/test-version-manager-release-provenance.sh`
- `shellcheck .agents/scripts/full-loop-helper-merge.sh .agents/scripts/full-loop-helper-state.sh .agents/scripts/version-manager-git.sh .agents/scripts/tests/test-full-loop-merge.sh`

## Runtime Testing

- self-assessed: low-risk shell validation and diagnostics changes covered by targeted tests.

Resolves #28094

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 6m and 129,886 tokens on this as a headless worker.
