### PR TITLE
GH#28090: optimize superseded issue extraction

### DIFF
--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -44,12 +44,12 @@ _ddpr_issue_body_from_meta() {
 _ddpr_superseded_issue_refs() {
 	local issue_body="$1"
 	local line="" ref=""
+	local marker_regex='^_Supersedes #([0-9]+) (—|-) this issue is the consolidated spec\._$'
 	while IFS= read -r line; do
-		if ! printf '%s\n' "$line" | grep -qE '^_Supersedes #[0-9]+ (—|-) this issue is the consolidated spec\._$'; then
-			continue
+		if [[ "$line" =~ $marker_regex ]]; then
+			ref="${BASH_REMATCH[1]}"
+			printf '%s\n' "$ref"
 		fi
-		ref=$(printf '%s\n' "$line" | grep -oE '^_Supersedes #[0-9]+' | grep -oE '[0-9]+' || true)
-		[[ -n "$ref" ]] && printf '%s\n' "$ref"
 	done <<<"$issue_body"
 	return 0
 }


### PR DESCRIPTION
## Summary

- Replace per-line grep subprocesses with Bash regular-expression matching.
- Capture the superseded issue number directly through `BASH_REMATCH`.

## Files changed

- `.agents/scripts/dispatch-dedup-pr.sh`

## Testing

- `shellcheck .agents/scripts/dispatch-dedup-pr.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh` (28 passed)

Resolves #28090

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.116 plugin for [OpenCode](https://opencode.ai) v1.17.18
