### PR TITLE
GH#28073: Fix incremental deployment convergence

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -143,13 +143,66 @@ _status_capability_readiness() {
 	return 0
 }
 
+_status_bundle_manifest_value() {
+	local manifest_file="$1"
+	local key="$2"
+	local value=""
+	value=$(grep -m 1 "^${key}=" "$manifest_file" 2>/dev/null) || return 1
+	printf '%s' "${value#*=}"
+	return 0
+}
+
+_status_active_bundle_version() {
+	local active_version="${HOME:-}/.aidevops/agents/VERSION"
+	if [[ -r "$active_version" ]]; then
+		tr -d '[:space:]' <"$active_version"
+		return 0
+	fi
+	get_version
+	return 0
+}
+
+_status_runtime_bundle_integrity() {
+	local active_link="${HOME:-}/.aidevops/agents"
+	local active_root=""
+	local bundles_root=""
+	local manifest_file=""
+	local active_version=""
+	local manifest_status=""
+	local manifest_version=""
+	local manifest_sha=""
+	local deployed_sha=""
+
+	if [[ ! -L "$active_link" ]]; then
+		print_warning "Active runtime bundle mismatch: agents path is not an activation symlink"
+		return 0
+	fi
+	active_root=$(cd "$active_link" 2>/dev/null && pwd -P) || active_root=""
+	bundles_root=$(cd "${HOME:-}/.aidevops/runtime-bundles" 2>/dev/null && pwd -P) || bundles_root=""
+	manifest_file="$active_root/.bundle-manifest"
+	[[ -r "$active_root/VERSION" ]] && active_version=$(tr -d '[:space:]' <"$active_root/VERSION" 2>/dev/null) || active_version=""
+	[[ -r "$manifest_file" ]] && manifest_status=$(_status_bundle_manifest_value "$manifest_file" status) || manifest_status=""
+	[[ -r "$manifest_file" ]] && manifest_version=$(_status_bundle_manifest_value "$manifest_file" framework_version) || manifest_version=""
+	[[ -r "$manifest_file" ]] && manifest_sha=$(_status_bundle_manifest_value "$manifest_file" git_sha) || manifest_sha=""
+	[[ -r "${HOME:-}/.aidevops/.deployed-sha" ]] && deployed_sha=$(tr -d '[:space:]' <"${HOME}/.aidevops/.deployed-sha" 2>/dev/null) || deployed_sha=""
+
+	if [[ -z "$bundles_root" || "$active_root" != "$bundles_root/"*/agents || "$manifest_status" != "validated" ||
+		-z "$active_version" || -z "$manifest_version" || -z "$manifest_sha" || -z "$deployed_sha" ||
+		"$active_version" != "$manifest_version" || "$manifest_sha" != "$deployed_sha" ]]; then
+		print_warning "Active runtime bundle mismatch: target=${active_root:-missing}, status=${manifest_status:-missing}, VERSION=${active_version:-missing}, manifest version=${manifest_version:-missing}, manifest SHA=${manifest_sha:-missing}, deployed SHA=${deployed_sha:-missing}"
+		return 0
+	fi
+	print_success "Active runtime bundle metadata is coherent"
+	return 0
+}
+
 # Status command
 cmd_status() {
 	print_header "AI DevOps Framework Status"
 	echo "=========================="
 	echo ""
 	local current_version
-	current_version=$(get_version)
+	current_version=$(_status_active_bundle_version)
 	local remote_version
 	remote_version=$(get_remote_version)
 	print_header "Version"
@@ -158,6 +211,7 @@ cmd_status() {
 	if [[ "$current_version" != "$remote_version" && "$remote_version" != "unknown" ]]; then
 		print_warning "Update available! Run: aidevops update"
 	elif [[ "$current_version" == "$remote_version" ]]; then print_success "Up to date"; fi
+	_status_runtime_bundle_integrity
 	echo ""
 	print_header "Installation"
 	check_dir "$INSTALL_DIR" && print_success "Repository: $INSTALL_DIR" || print_error "Repository: Not found at $INSTALL_DIR"

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -1182,6 +1182,10 @@ deploy_aidevops_agents() {
 	fi
 	_runtime_bundle_activate "$target_dir" "$_AIDEVOPS_STAGED_BUNDLE_DIR" || return 1
 	_verify_agents_deploy_or_restore "$source_dir" "$target_dir" || return 1
+	pin_aidevops_active_runtime_bundle_root || {
+		print_error "Unable to bind setup to the activated runtime bundle"
+		return 1
+	}
 
 	print_success "Deployed agents to $target_dir"
 	_install_canonical_git_guard_shim "$target_dir" || return 1

--- a/.agents/scripts/setup/modules/agent-runtime.sh
+++ b/.agents/scripts/setup/modules/agent-runtime.sh
@@ -33,6 +33,19 @@ pin_aidevops_runtime_bundle_root() {
 	return 0
 }
 
+# Setup and deployment are global reconciliation operations, not long-lived
+# runtime processes. Always bind them to the current activation link instead of
+# an inherited process pin that may name an older immutable bundle.
+pin_aidevops_active_runtime_bundle_root() {
+	local active_link="${HOME:?HOME must be set}/.aidevops/agents"
+	local resolved_root=""
+	resolved_root=$(resolve_aidevops_runtime_bundle_root "$active_link") || return 1
+	AIDEVOPS_AGENTS_DIR="$resolved_root"
+	AGENTS_DIR="$resolved_root"
+	export AIDEVOPS_AGENTS_DIR AGENTS_DIR
+	return 0
+}
+
 # Serialize activation-link changes with Pulse restart/start operations. A
 # lifecycle process always re-resolves the active link after taking this lock,
 # so concurrent setup callers cannot leave Pulse running an older bundle.

--- a/.agents/scripts/setup/modules/config.sh
+++ b/.agents/scripts/setup/modules/config.sh
@@ -62,9 +62,16 @@ install_aidevops_cli() {
 	# which resolves to .agents/scripts/setup/modules/ when sourced from setup.sh.
 	local cli_source="${INSTALL_DIR:?INSTALL_DIR not set}/bin/aidevops"
 	local orchestrator_source="$INSTALL_DIR/aidevops.sh"
-	local deployed_cli="${AGENTS_DIR:?AGENTS_DIR not set}/aidevops.sh"
+	local deployed_root=""
+	if declare -F resolve_aidevops_runtime_bundle_root >/dev/null 2>&1; then
+		deployed_root=$(resolve_aidevops_runtime_bundle_root "$HOME/.aidevops/agents") || deployed_root=""
+	fi
+	if [[ -z "$deployed_root" ]]; then
+		deployed_root="${AGENTS_DIR:?AGENTS_DIR not set}"
+	fi
+	local deployed_cli="${deployed_root}/aidevops.sh"
 	local convergence_helper="${INSTALL_DIR}/.agents/scripts/aidevops-cli-converge-helper.sh"
-	local deployed_version="${AGENTS_DIR}/VERSION"
+	local deployed_version="${deployed_root}/VERSION"
 
 	if [[ ! -f "$cli_source" || ! -f "$orchestrator_source" || ! -x "$convergence_helper" ]]; then
 		print_warning "aidevops CLI sources not found under $INSTALL_DIR - skipping CLI installation"

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -177,6 +177,18 @@ test_process_pin_survives_activation() {
 	return 0
 }
 
+test_setup_rebinds_stale_process_pin_to_active_bundle() {
+	local target_dir="$HOME/.aidevops/agents"
+	local stale_root="$AIDEVOPS_AGENTS_DIR"
+	local active_root=""
+	active_root=$(_runtime_bundle_resolve_root "$target_dir")
+	[[ "$stale_root" != "$active_root" ]] || fail "fixture process pin is not stale"
+	pin_aidevops_active_runtime_bundle_root || fail "setup could not resolve active bundle"
+	assert_eq "$active_root" "$AIDEVOPS_AGENTS_DIR" "setup re-resolves a stale inherited AIDEVOPS_AGENTS_DIR"
+	assert_eq "$active_root" "$AGENTS_DIR" "setup re-resolves a stale inherited AGENTS_DIR"
+	return 0
+}
+
 test_live_bundle_lease_survives_three_updates() {
 	local target_dir="$HOME/.aidevops/agents"
 	local leased_root=""
@@ -377,6 +389,7 @@ main() {
 	test_interrupted_staging_preserves_active
 	test_failed_activation_rolls_back
 	test_process_pin_survives_activation
+	test_setup_rebinds_stale_process_pin_to_active_bundle
 	test_live_bundle_lease_survives_three_updates
 	test_stale_lease_and_old_bundle_are_pruned
 	test_macos_and_linux_link_paths

--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -107,7 +107,15 @@ test_setup_stage_contract() {
 	assert_contains "gui-desktop scope maps to native app installer" "$text" "gui-desktop | gui | app | \"\$SETUP_STAGE_GUI_DESKTOP\") printf '%s' \"\$SETUP_STAGE_GUI_DESKTOP\""
 	assert_contains "ai-session scope maps to incremental setup" "$text" "ai-session | ai | \"\$SETUP_STAGE_AI_SESSION\") printf '%s' \"\$SETUP_STAGE_AI_SESSION\""
 	assert_contains "ai-session scoped stage falls back to full setup" "$text" "AI-session incremental setup unavailable or failed; falling back to full setup"
+	# shellcheck disable=SC2016 # Match literal setup.sh expressions.
+	assert_contains "ai-session accepts linked worktree git files" "$text" 'git -C "$checkout_root" rev-parse --git-dir'
+	# shellcheck disable=SC2016 # Match literal setup.sh expressions.
+	assert_contains "ai-session resolves linked worktree common git dir" "$text" 'git -C "$checkout_root" rev-parse --git-common-dir'
 	assert_contains "ai-session verifies deployed sha" "$text" "_setup_ai_session_verify_deploy \"\$current_sha\""
+	# shellcheck disable=SC2016 # Match literal setup.sh expressions.
+	assert_contains "ai-session verifies active bundle manifest version" "$text" '_setup_bundle_manifest_value "$manifest_file" framework_version'
+	# shellcheck disable=SC2016 # Match literal setup.sh expressions.
+	assert_contains "ai-session verifies active bundle manifest sha" "$text" '_setup_bundle_manifest_value "$manifest_file" git_sha'
 	assert_contains "ai-session reconciles generated runtime config" "$text" "_time_step \"\$SETUP_STAGE_RUNTIME_CONFIG\" _setup_reconcile_runtime_config"
 	assert_contains "runtime reconciliation updates enabled primary runtimes" "$text" "update_runtime_configs || return \$?"
 	assert_contains "runtime reconciliation deploys commands to remaining runtimes" "$text" "deploy_commands_to_all_runtimes || return \$?"
@@ -124,6 +132,54 @@ test_setup_stage_contract() {
 	assert_occurrence_count "scoped, ai-session, and noninteractive setup register opencode plugin" "$text" \
 		"_time_step \"\$SETUP_STAGE_OPENCODE_PLUGINS\" setup_opencode_plugins" 3
 	assert_contains "unknown stages print actionable help" "$text" "Unknown setup stage/scope"
+	return 0
+}
+
+test_linked_worktree_checkout_contract() {
+	local tmp_dir=""
+	local source_repo=""
+	local linked_worktree=""
+	local helper_text=""
+	tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-linked-checkout-test.XXXXXX") || {
+		print_result "linked worktree fixture created" 1
+		return 0
+	}
+	source_repo="$tmp_dir/repo"
+	linked_worktree="$tmp_dir/linked"
+	/usr/bin/git init -q "$source_repo" &&
+		/usr/bin/git -C "$source_repo" config user.email "test@example.invalid" &&
+		/usr/bin/git -C "$source_repo" config user.name "Test" &&
+		/usr/bin/git -C "$source_repo" config commit.gpgsign false &&
+		printf 'fixture\n' >"$source_repo/file" &&
+		/usr/bin/git -C "$source_repo" add file &&
+		/usr/bin/git -C "$source_repo" commit -qm fixture &&
+		/usr/bin/git -C "$source_repo" worktree add -q -b linked-test "$linked_worktree" || {
+		print_result "linked worktree fixture created" 1
+		rm -rf "$tmp_dir"
+		return 0
+	}
+	helper_text=$(python3 - "$SETUP_SH" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+match = re.search(r"(?ms)^_setup_git_checkout_available\(\) \{.*?^\}", text)
+if not match:
+    raise SystemExit(1)
+print(match.group(0))
+PY
+	) || helper_text=""
+	if [[ -n "$helper_text" ]]; then
+		eval "$helper_text"
+	fi
+	if [[ -f "$linked_worktree/.git" ]] && declare -F _setup_git_checkout_available >/dev/null 2>&1 &&
+		_setup_git_checkout_available "$linked_worktree"; then
+		print_result "ai-session checkout detection accepts linked worktree .git files" 0
+	else
+		print_result "ai-session checkout detection accepts linked worktree .git files" 1
+	fi
+	rm -rf "$tmp_dir"
 	return 0
 }
 
@@ -234,6 +290,7 @@ PY
 
 main() {
 	test_setup_stage_contract
+	test_linked_worktree_checkout_contract
 	test_setup_version_substitution_keeps_syntax
 	test_cli_scope_contract
 	test_gui_desktop_package_contract

--- a/.agents/scripts/tests/test-status-runtime-bundle-integrity.sh
+++ b/.agents/scripts/tests/test-status-runtime-bundle-integrity.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUS_LIB="$SCRIPT_DIR/../aidevops-cli/aidevops-status-lib.sh"
+TEST_ROOT="$(mktemp -d -t aidevops-status-bundle.XXXXXX)"
+HOME="$TEST_ROOT/home"
+ACTIVE_BUNDLE="$HOME/.aidevops/runtime-bundles/fixture/agents"
+STALE_BUNDLE="$HOME/.aidevops/runtime-bundles/stale/agents"
+export HOME
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+print_success() {
+	local text="$1"
+	printf 'SUCCESS: %s\n' "$text"
+	return 0
+}
+
+print_warning() {
+	local text="$1"
+	printf 'WARNING: %s\n' "$text"
+	return 0
+}
+
+get_version() {
+	printf 'stale-process-version\n'
+	return 0
+}
+
+mkdir -p "$ACTIVE_BUNDLE" "$STALE_BUNDLE" "$HOME/.aidevops"
+ln -s "$ACTIVE_BUNDLE" "$HOME/.aidevops/agents"
+printf '3.32.145\n' >"$ACTIVE_BUNDLE/VERSION"
+printf '3.32.140\n' >"$STALE_BUNDLE/VERSION"
+printf '%s\n' \
+	'status=validated' \
+	'framework_version=3.32.145' \
+	'git_sha=0123456789abcdef' >"$ACTIVE_BUNDLE/.bundle-manifest"
+printf '0123456789abcdef\n' >"$HOME/.aidevops/.deployed-sha"
+AIDEVOPS_AGENTS_DIR="$STALE_BUNDLE"
+AGENTS_DIR="$STALE_BUNDLE"
+export AIDEVOPS_AGENTS_DIR AGENTS_DIR
+
+# shellcheck source=../aidevops-cli/aidevops-status-lib.sh
+source "$STATUS_LIB"
+
+if [[ "$(_status_active_bundle_version)" != "3.32.145" ]]; then
+	printf 'FAIL: status trusted a stale inherited bundle instead of the active symlink\n' >&2
+	exit 1
+fi
+output=$(_status_runtime_bundle_integrity)
+if [[ "$output" != *"Active runtime bundle metadata is coherent"* ]]; then
+	printf 'FAIL: coherent active bundle was not recognized: %s\n' "$output" >&2
+	exit 1
+fi
+
+printf '3.32.999\n' >"$ACTIVE_BUNDLE/VERSION"
+output=$(_status_runtime_bundle_integrity)
+if [[ "$output" != *"Active runtime bundle mismatch"* || "$output" != *"manifest version=3.32.145"* ]]; then
+	printf 'FAIL: mutated VERSION versus stale manifest was not exposed: %s\n' "$output" >&2
+	exit 1
+fi
+
+printf '%s\n' 'PASS: status resolves the active bundle and exposes metadata mismatch'
+exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -1313,33 +1313,84 @@ _setup_ai_session_build_plan() {
 }
 
 _setup_reconcile_runtime_config() {
+	pin_aidevops_active_runtime_bundle_root || {
+		print_warning "Runtime configuration reconciliation could not resolve the active agents bundle"
+		return 1
+	}
 	update_runtime_configs || return $?
 	deploy_commands_to_all_runtimes || return $?
 	return 0
 }
 
+_setup_git_checkout_available() {
+	local checkout_root="$1"
+	local git_dir=""
+	local git_common_dir=""
+
+	git_dir=$(git -C "$checkout_root" rev-parse --git-dir 2>/dev/null) || return 1
+	git_common_dir=$(git -C "$checkout_root" rev-parse --git-common-dir 2>/dev/null) || return 1
+	[[ -n "$git_dir" && -n "$git_common_dir" ]] || return 1
+	return 0
+}
+
+_setup_bundle_manifest_value() {
+	local manifest_file="$1"
+	local key="$2"
+	local value=""
+	value=$(grep -m 1 "^${key}=" "$manifest_file" 2>/dev/null) || return 1
+	printf '%s' "${value#*=}"
+	return 0
+}
+
 _setup_ai_session_verify_deploy() {
 	local expected_sha="$1"
+	local active_link="$HOME/.aidevops/agents"
+	local active_root=""
+	local manifest_file=""
+	local manifest_status=""
+	local manifest_version=""
+	local manifest_sha=""
 	local repo_version=""
 	local deployed_version=""
 	local deployed_sha=""
 
+	if [[ ! -L "$active_link" ]]; then
+		print_warning "AI-session incremental verification failed: active agents path is not an activation symlink"
+		return 1
+	fi
+	active_root=$(resolve_aidevops_runtime_bundle_root "$active_link") || {
+		print_warning "AI-session incremental verification failed: active agents symlink cannot be resolved"
+		return 1
+	}
+	manifest_file="$active_root/.bundle-manifest"
+	if [[ ! -r "$manifest_file" ]]; then
+		print_warning "AI-session incremental verification failed: active bundle manifest is missing"
+		return 1
+	fi
+	manifest_status=$(_setup_bundle_manifest_value "$manifest_file" status) || manifest_status=""
+	manifest_version=$(_setup_bundle_manifest_value "$manifest_file" framework_version) || manifest_version=""
+	manifest_sha=$(_setup_bundle_manifest_value "$manifest_file" git_sha) || manifest_sha=""
+
 	if [[ -f "$INSTALL_DIR/VERSION" ]]; then
 		repo_version=$(tr -d '[:space:]' <"$INSTALL_DIR/VERSION" 2>/dev/null) || repo_version=""
 	fi
-	if [[ -f "$HOME/.aidevops/agents/VERSION" ]]; then
-		deployed_version=$(tr -d '[:space:]' <"$HOME/.aidevops/agents/VERSION" 2>/dev/null) || deployed_version=""
+	if [[ -f "$active_root/VERSION" ]]; then
+		deployed_version=$(tr -d '[:space:]' <"$active_root/VERSION" 2>/dev/null) || deployed_version=""
 	fi
 	if [[ -f "$HOME/.aidevops/.deployed-sha" ]]; then
 		deployed_sha=$(tr -d '[:space:]' <"$HOME/.aidevops/.deployed-sha" 2>/dev/null) || deployed_sha=""
 	fi
 
-	if [[ -z "$repo_version" || "$repo_version" != "$deployed_version" ]]; then
-		print_warning "AI-session incremental verification failed: repo version=${repo_version:-unknown}, deployed=${deployed_version:-none}"
+	if [[ "$manifest_status" != "validated" ]]; then
+		print_warning "AI-session incremental verification failed: active bundle manifest status=${manifest_status:-missing}"
 		return 1
 	fi
-	if [[ -z "$deployed_sha" || "$deployed_sha" != "$expected_sha" ]]; then
-		print_warning "AI-session incremental verification failed: deployed SHA=${deployed_sha:-none}, expected=${expected_sha:0:12}"
+	if [[ -z "$repo_version" || "$repo_version" != "$deployed_version" || "$repo_version" != "$manifest_version" ]]; then
+		print_warning "AI-session incremental verification failed: repo version=${repo_version:-unknown}, active=${deployed_version:-none}, manifest=${manifest_version:-none}"
+		return 1
+	fi
+	if [[ -z "$deployed_sha" || "$deployed_sha" != "$expected_sha" || "$manifest_sha" != "$expected_sha" ]]; then
+		print_warning "AI-session incremental verification failed: stamp SHA=${deployed_sha:-none}, manifest SHA=${manifest_sha:-none}, expected=${expected_sha:0:12}"
 		return 1
 	fi
 
@@ -1354,7 +1405,7 @@ _setup_run_ai_session_incremental() {
 	local changed_files=""
 
 	print_info "AI-session setup mode: applying changed deploy stages only"
-	if [[ ! -d "$INSTALL_DIR/.git" || ! -f "$stamp_file" ]]; then
+	if ! _setup_git_checkout_available "$INSTALL_DIR" || [[ ! -f "$stamp_file" ]]; then
 		print_warning "AI-session incremental setup needs a git checkout and deployed SHA stamp"
 		return 1
 	fi
@@ -1413,6 +1464,7 @@ _setup_run_ai_session_incremental() {
 _setup_run_scoped_stage() {
 	local os="$1"
 	local stage
+	local current_sha=""
 	stage="$(_setup_canonical_stage "$SETUP_STAGE")" || return 1
 
 	if [[ "$stage" == "full" ]]; then
@@ -1453,6 +1505,9 @@ _setup_run_scoped_stage() {
 			print_warning "AI-session incremental setup unavailable or failed; falling back to full setup"
 			_setup_run_non_interactive || return $?
 			_setup_post_setup_steps "$os" || return $?
+			current_sha=$(git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null) || current_sha=""
+			[[ -n "$current_sha" ]] || return 1
+			_setup_ai_session_verify_deploy "$current_sha" || return $?
 		fi
 		;;
 	*)


### PR DESCRIPTION
## Summary

Make linked-worktree incremental setup resolve and verify one active runtime bundle, and expose bundle metadata drift in status

## Files Changed

.agents/scripts/aidevops-cli/aidevops-status-lib.sh, .agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/setup/modules/agent-runtime.sh, .agents/scripts/setup/modules/config.sh, .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh, .agents/scripts/tests/test-setup-scoped-dispatch.sh, .agents/scripts/tests/test-status-runtime-bundle-integrity.sh, setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused setup, atomic bundle, and status integrity tests pass; ShellCheck clean on modified scripts

Resolves #28073


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 24m and 147,203 tokens on this as a headless worker.