### PR TITLE
GH#28065: Enforce worktree-only canonical mirrors

### DIFF
--- a/.agents/hooks/git_safety_guard.py
+++ b/.agents/hooks/git_safety_guard.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Claude Code adapter for shared command policy and write safety.
+"""Claude Code adapter for shared command and direct-write safety.
 
-Shell-command decisions are delegated to command-policy-helper.py. This hook
-also enforces the canonical-workspace Edit/Write rule (t1712/t1990):
-  - Edit/Write on the default branch: only allowlisted paths permitted
-    (README.md, TODO.md, todo/**) without a linked worktree.
-  - Edit/Write on any non-default branch in the canonical workspace: always
-    denied unless inside a linked worktree. Default branch is auto-detected
-    from origin/HEAD (with fallbacks to init.defaultBranch then "main") so
-    repos using develop/trunk/etc. are covered equally.
+Shell-command decisions are delegated to command-policy-helper.py. Direct file
+mutations are delegated to canonical-write-policy-helper.py so every canonical
+checkout is read-only regardless of branch name or target path.
 
-This hook runs before Bash/Edit/Write tool calls execute.
-It is registered under BOTH the 'Bash' AND 'Edit|Write' PreToolUse matchers so that
-the Edit/Write protection branch is reachable (see GH#21814).
+This hook runs before Bash/Edit/Write tool calls execute. It is registered under
+both the Bash and direct-file-tool PreToolUse matchers.
 
 Installed by: aidevops setup (setup.sh) or install-hooks-helper.sh
 Location: ~/.aidevops/hooks/git_safety_guard.py
@@ -43,16 +37,7 @@ if not GIT_BINARY:
         else (shutil.which("git") or "git")
     )
 
-# =============================================================================
-# Main-branch file allowlist (t1712)
-# =============================================================================
-# Paths writable on main/master without a linked worktree.
-# Checked as exact match or prefix match (normalised, no leading ./).
-MAIN_BRANCH_ALLOWLIST = [
-    "README.md",
-    "TODO.md",
-    "todo/",  # prefix: todo/** subtree
-]
+DIRECT_FILE_TOOL_NAMES = {"edit", "write", "apply_patch", "applypatch"}
 WORKER_ENV_KEYS = (
     "FULL_LOOP_HEADLESS",
     "AIDEVOPS_HEADLESS",
@@ -74,185 +59,81 @@ def _is_worker_context() -> bool:
     )
 
 
-def _get_current_branch(cwd: str) -> str:
-    """Return the current git branch name, or empty string on failure."""
-    try:
-        result = subprocess.run(
-            [GIT_BINARY, "branch", "--show-current"],
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            timeout=5,
-        )
-        return result.stdout.strip()
-    except Exception:
-        return ""
+def _normalise_tool_name(tool_name: str) -> str:
+    """Return the leaf tool name for built-in and namespaced variants."""
+    normalised = tool_name.replace("::", ".").replace("/", ".")
+    return normalised.rsplit(".", 1)[-1].replace("-", "_").lower()
 
 
-def _is_linked_worktree(cwd: str) -> bool:
-    """Return True if cwd is inside a linked worktree (not the main worktree)."""
-    try:
-        git_dir = subprocess.run(
-            [GIT_BINARY, "rev-parse", "--git-dir"],
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            timeout=5,
-        ).stdout.strip()
-        git_common_dir = subprocess.run(
-            [GIT_BINARY, "rev-parse", "--git-common-dir"],
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            timeout=5,
-        ).stdout.strip()
-        # In a linked worktree, git-dir != git-common-dir
-        return git_dir != git_common_dir and git_dir != ".git"
-    except Exception:
-        return False
+def _is_direct_file_tool(tool_name: str) -> bool:
+    """Return whether a tool can mutate a file without a Bash command."""
+    return _normalise_tool_name(tool_name) in DIRECT_FILE_TOOL_NAMES
 
 
-def _get_repo_root(cwd: str) -> str:
-    """Return the absolute path of the git repository root, or empty string on failure."""
-    try:
-        result = subprocess.run(
-            [GIT_BINARY, "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            timeout=5,
-        )
-        return result.stdout.strip()
-    except Exception:
-        return ""
+def _canonical_write_policy_helper() -> str:
+    """Resolve the shared canonical-write policy helper."""
+    candidates = [
+        os.environ.get("AIDEVOPS_CANONICAL_WRITE_POLICY_HELPER", ""),
+        str(
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "canonical-write-policy-helper.py"
+        ),
+        str(
+            Path.home()
+            / ".aidevops"
+            / "agents"
+            / "scripts"
+            / "canonical-write-policy-helper.py"
+        ),
+    ]
+    return next((path for path in candidates if path and os.path.isfile(path)), "")
 
 
-def _is_main_allowlisted(file_path: str, repo_root: str) -> bool:
-    """Return True if file_path is in the main-branch write allowlist.
-
-    file_path may be absolute or repo-relative.
-    repo_root must be an absolute path (from git rev-parse --show-toplevel).
-    Rejects path traversal: any path that escapes repo_root is denied.
-    """
-    # Validation: invalid inputs
-    if not repo_root:
-        return False
-
-    # Resolve to absolute path
-    if os.path.isabs(file_path):
-        abs_path = os.path.normpath(file_path)
-    else:
-        abs_path = os.path.normpath(os.path.join(repo_root, file_path))
-
-    # Reject traversal: path must be inside repo_root
-    norm_root = os.path.normpath(repo_root)
-    try:
-        common = os.path.commonpath([abs_path, norm_root])
-        is_valid = common == norm_root
-    except ValueError:
-        # Different drives (Windows) or other error
-        is_valid = False
-    
-    if not is_valid:
-        return False
-
-    # Compute repo-relative path and validate no traversal
-    rel_path = os.path.relpath(abs_path, norm_root)
-    if rel_path.startswith(".."):
-        return False  # Contains traversal
-
-    # Check against allowlist
-    for allowed in MAIN_BRANCH_ALLOWLIST:
-        if allowed.endswith("/"):
-            # Prefix match (subtree): rel_path == "todo" or starts with "todo/"
-            prefix = allowed.rstrip("/")
-            if rel_path == prefix or rel_path.startswith(allowed):
-                break
-        elif rel_path == allowed:
-            # Exact match
-            break
-    else:
-        return False
-    
-    return True
-
-
-def _get_default_branch(repo_root: str) -> str:
-    """Return the default branch name for the repo at repo_root.
-
-    Detection order (first success wins):
-    1. git symbolic-ref --short refs/remotes/origin/HEAD  (strips "origin/" prefix)
-    2. git config --get init.defaultBranch
-    3. literal "main"
-
-    Each step is fail-soft — exceptions and non-zero exits fall through to the next.
-    Result is NOT cached between invocations (the hook runs once per tool call).
-    """
-    # 1. Try origin/HEAD
-    try:
-        result = subprocess.run(
-            [GIT_BINARY, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-            capture_output=True,
-            text=True,
-            cwd=repo_root,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            ref = result.stdout.strip()
-            # Strip "origin/" prefix that git symbolic-ref adds
-            if ref.startswith("origin/"):
-                ref = ref[len("origin/"):]
-            if ref:
-                return ref
-    except Exception:
-        pass
-
-    # 2. Try git config init.defaultBranch
-    try:
-        result = subprocess.run(
-            [GIT_BINARY, "config", "--get", "init.defaultBranch"],
-            capture_output=True,
-            text=True,
-            cwd=repo_root,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            branch = result.stdout.strip()
-            if branch:
-                return branch
-    except Exception:
-        pass
-
-    # 3. Hard fallback
-    return "main"
-
-
-def _build_canonical_off_default_deny(
-    file_path: str, branch: str, default_branch: str
-) -> dict:
-    """Return a deny dict for writes to the canonical workspace on a non-default branch.
-
-    This enforces the t1990 rule: ALL work goes through a linked worktree.
-    The canonical repo directory must stay on the default branch.
-    """
+def _direct_write_deny(reason: str) -> dict:
+    """Build the Claude Code deny payload for a direct file mutation."""
     return {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
             "permissionDecisionReason": (
-                f"BLOCKED by git_safety_guard.py (aidevops t1990)\n\n"
-                f"Reason: Canonical workspace is on '{branch}' "
-                f"(default branch is '{default_branch}').\n\n"
-                f"Per t1990, ALL work goes through a linked worktree. "
-                f"The canonical repo directory must stay on '{default_branch}'.\n\n"
-                f"Options:\n"
-                f"  (a) Use a linked worktree for this work:\n"
-                f"        wt switch -c feature/your-task-name\n\n"
-                f"  (b) Restore canonical state through the audited recovery helper "
-                f"when appropriate."
+                "BLOCKED by canonical write policy\n\n"
+                f"Reason: {reason}\n\n"
+                "ACTION_REQUIRED=create_or_use_linked_worktree"
             ),
         }
     }
+
+
+def _check_canonical_write(file_path: str) -> "dict | None":
+    """Delegate a direct file mutation to the shared structural policy."""
+    helper = _canonical_write_policy_helper()
+    if not helper:
+        return _direct_write_deny("required canonical-write policy is unavailable")
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                helper,
+                "check-write",
+                "--cwd",
+                os.getcwd(),
+                "--path",
+                file_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        payload = json.loads(result.stdout)
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        return _direct_write_deny(f"canonical-write policy failed closed: {exc}")
+    if result.returncode == 0 and payload.get("decision") == "allow":
+        return None
+    return _direct_write_deny(
+        payload.get("reason", "canonical-write policy returned an invalid response")
+    )
 
 
 def _check_command_policy(command: str) -> "dict | None":
@@ -315,63 +196,8 @@ def _check_command_policy(command: str) -> "dict | None":
     }
 
 
-def _check_main_branch_allowlist(file_path: str) -> "dict | None":
-    """Check if an Edit/Write to file_path is allowed on the current branch.
-
-    Enforces two related rules:
-      t1712 — On the default branch: only allowlisted paths may be written
-               without a linked worktree (README.md, TODO.md, todo/**).
-      t1990 — Off the default branch in the canonical workspace: all writes
-               are denied unless inside a linked worktree.
-
-    Returns a deny dict if the write should be blocked, None if allowed.
-    """
-    # Always use cwd for git commands — avoids failures for new (not-yet-created) files
-    cwd = os.getcwd()
-
-    # Resolve repo root from cwd (reliable even for new files)
-    repo_root = _get_repo_root(cwd) if file_path else ""
-    branch = _get_current_branch(repo_root) if repo_root else ""
-    if not file_path or not repo_root or not branch:
-        return None  # Invalid path, not in git, or cannot determine branch — allow
-
-    # Linked worktrees are the only writable branch context.
-    if _is_linked_worktree(repo_root):
-        return None
-
-    # Detect default branch dynamically (replaces hardcoded "main"/"master" check)
-    default_branch = _get_default_branch(repo_root)
-
-    if branch == default_branch:
-        # On the default branch: allowlist governs
-        if _is_main_allowlisted(file_path, repo_root):
-            return None  # Allowlisted path — allow
-
-        # Deny: non-allowlisted path on default branch in canonical workspace
-        return {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": (
-                    f"BLOCKED by git_safety_guard.py (aidevops t1712)\n\n"
-                    f"Reason: '{file_path}' is not in the default-branch write allowlist.\n\n"
-                    f"Allowlisted paths (writable on '{default_branch}' without a worktree): "
-                    f"README.md, TODO.md, todo/**\n\n"
-                    f"All other edits must be made in a linked worktree:\n"
-                    f"  wt switch -c feature/your-task-name\n\n"
-                    f"This enforces the canonical-repo-on-{default_branch} policy (t1712)."
-                ),
-            }
-        }
-    else:
-        # Off the default branch in the canonical workspace: always deny
-        # (workers operate in their own linked worktrees; an off-default canonical
-        # means a prior session left the canonical in a dirty state)
-        return _build_canonical_off_default_deny(file_path, branch, default_branch)
-
-
 def main():
-    """Delegate Bash policy and enforce the Edit/Write worktree allowlist."""
+    """Delegate Bash policy and enforce direct-file worktree isolation."""
     try:
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError:
@@ -380,12 +206,13 @@ def main():
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input") or {}
 
-    # ==========================================================================
-    # Edit / Write tool: enforce main-branch file allowlist (t1712)
-    # ==========================================================================
-    if tool_name in ("Edit", "Write"):
-        file_path = tool_input.get("filePath", "")
-        deny = _check_main_branch_allowlist(file_path)
+    if _is_direct_file_tool(tool_name):
+        file_path = (
+            tool_input.get("filePath", "")
+            or tool_input.get("file_path", "")
+            or tool_input.get("path", "")
+        )
+        deny = _check_canonical_write(file_path)
         if deny:
             print(json.dumps(deny))
         sys.exit(0)

--- a/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs
@@ -42,6 +42,58 @@ function isWorkerContext(env = process.env) {
     .some((key) => ["1", "true", "yes"].includes((env[key] || "").toLowerCase()));
 }
 
+function normaliseToolName(tool) {
+  if (typeof tool !== "string") return "";
+  return tool
+    .replaceAll("::", ".")
+    .replaceAll("/", ".")
+    .split(".")
+    .at(-1)
+    .replaceAll("-", "_")
+    .toLowerCase();
+}
+
+export function isDirectFileMutationTool(tool) {
+  return ["write", "edit", "apply_patch", "applypatch"].includes(normaliseToolName(tool));
+}
+
+export function checkCanonicalWriteSafetyGate(
+  filePath,
+  scriptsDir,
+  cwd = process.cwd(),
+) {
+  const helper = join(scriptsDir, "canonical-write-policy-helper.py");
+  if (!existsSync(helper)) {
+    throw new Error("BLOCKED: required canonical-write policy helper is missing");
+  }
+  let raw = "";
+  try {
+    raw = execFileSync(
+      "python3",
+      [helper, "check-write", "--cwd", cwd, "--path", filePath || ""],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 10000,
+      },
+    );
+  } catch (error) {
+    const detail = error?.stderr?.toString().trim() || error?.message || "policy check failed";
+    throw new Error(`BLOCKED: canonical-write policy failed closed: ${detail}`);
+  }
+  let result;
+  try {
+    result = JSON.parse(raw);
+  } catch {
+    throw new Error("BLOCKED: canonical-write policy returned malformed output");
+  }
+  if (result.decision !== "allow") {
+    throw new Error(
+      `BLOCKED by canonical write policy: ${result.reason || "invalid policy response"}. ACTION_REQUIRED=create_or_use_linked_worktree`,
+    );
+  }
+}
+
 export function checkCommandSafetyGate(command, scriptsDir, cwd = process.cwd(), options = {}) {
   if (typeof command !== "string" || !command) return;
   const helper = join(scriptsDir, "command-policy-helper.py");

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -13,7 +13,11 @@ import { recordToolStart, consumeToolDuration } from "./timing-tracing.mjs";
 import { qualityLog, runFileQualityGate } from "./quality-logging.mjs";
 import { enrichActiveSpan, detectTaskId, detectSessionOrigin } from "./otel-enrichment.mjs";
 import { checkSecretReadGate, isReadTool } from "./quality-hooks-secret-read.mjs";
-import { checkCanonicalGitSafetyGate } from "./quality-hooks-git-safety.mjs";
+import {
+  checkCanonicalGitSafetyGate,
+  checkCanonicalWriteSafetyGate,
+  isDirectFileMutationTool,
+} from "./quality-hooks-git-safety.mjs";
 
 // Re-export for consumers that import from this module
 export { scanForSecrets } from "./quality-logging.mjs";
@@ -113,7 +117,7 @@ function scrubToolOutput(output) {
  * @returns {boolean}
  */
 function isWriteOrEditTool(tool) {
-  return tool === "Write" || tool === "Edit" || tool === "write" || tool === "edit";
+  return isDirectFileMutationTool(tool);
 }
 
 /**
@@ -243,6 +247,12 @@ function recordChildSubagent(taskId, scriptsDir, log) {
  */
 function handleToolBefore(ctx, log, input, output) {
   ctx.continuationGuard?.beforeTool(input, output);
+
+  if (isDirectFileMutationTool(input.tool)) {
+    const writeCwd = output.args?.workdir || output.args?.cwd || process.cwd();
+    const filePath = output.args?.filePath || output.args?.file_path || output.args?.path || "";
+    checkCanonicalWriteSafetyGate(filePath, ctx.scriptsDir, writeCwd);
+  }
 
   if (isBashTool(input.tool)) {
     const bashCwd = output.args?.workdir || output.args?.cwd || process.cwd();

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -18,7 +18,9 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
   checkCanonicalGitSafetyGate,
+  checkCanonicalWriteSafetyGate,
   checkCommandSafetyGate,
+  isDirectFileMutationTool,
 } from "../quality-hooks-git-safety.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -40,6 +42,41 @@ function setupRepo() {
   execFileSync(realGit, ["worktree", "add", "-q", "-b", "feature/test", linked], { cwd: repo });
   return { root, repo, linked };
 }
+
+test("classifies built-in and namespaced direct file mutation tools", () => {
+  for (const tool of ["Write", "edit", "write", "functions.apply_patch", "namespace/Edit", "tools::apply-patch"]) {
+    assert.equal(isDirectFileMutationTool(tool), true, tool);
+  }
+  for (const tool of ["Bash", "read", "functions.read", "glob"]) {
+    assert.equal(isDirectFileMutationTool(tool), false, tool);
+  }
+});
+
+test("blocks every canonical direct write and preserves linked-worktree writes", () => {
+  const { root, repo, linked } = setupRepo();
+  try {
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(join(repo, "README.md"), scriptsDir, repo),
+      /canonical write policy.*read-only session mirrors/,
+    );
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate("", scriptsDir, repo),
+      /canonical write policy/,
+    );
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(join(repo, "new-file.md"), scriptsDir, linked),
+      /canonical write policy/,
+    );
+    assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate(join(linked, "README.md"), scriptsDir, linked),
+    );
+    assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate("new-file.md", scriptsDir, linked),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("blocks canonical branch mutation before execution", () => {
   const { root, repo } = setupRepo();

--- a/.agents/scripts/canonical-write-policy-helper.py
+++ b/.agents/scripts/canonical-write-policy-helper.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Runtime-neutral canonical-versus-linked worktree policy.
+
+The helper is intentionally process-based so shell, Claude Code, and OpenCode
+all consume the same structural classification. Branch names never decide
+whether a checkout is canonical: an absolute Git directory equal to the
+absolute common directory is canonical, while a different Git directory is a
+linked worktree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+POLICY_VERSION = "canonical-write-policy-v1"
+BRANCH_CONFIG_KEYS = (
+    "canonical_branch",
+    "integration_branch",
+    "dispatch_base_branch",
+    "pr_base_branch",
+    "pr_target_branch",
+    "base_branch",
+    "default_branch",
+)
+
+
+@dataclass
+class Classification:
+    """One repository-location classification."""
+
+    classification: str
+    inside_git: bool
+    repo_root: str = ""
+    git_dir: str = ""
+    common_dir: str = ""
+    branch: str = ""
+    reason: str = ""
+
+
+def _real_git() -> str:
+    explicit = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "") or os.environ.get(
+        "AIDEVOPS_REAL_GIT", ""
+    )
+    if explicit:
+        return explicit
+    if os.path.isfile("/usr/bin/git"):
+        return "/usr/bin/git"
+    return shutil.which("git") or "git"
+
+
+def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            [_real_git(), *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(f"Git repository probe failed: {exc}") from exc
+
+
+def _existing_probe_path(raw_path: str) -> Path:
+    path = Path(raw_path).expanduser().resolve(strict=False)
+    if path.is_file() or path.is_symlink():
+        path = path.parent
+    while not path.exists() and path != path.parent:
+        path = path.parent
+    return path
+
+
+def classify_location(raw_path: str) -> Classification:
+    """Classify a path as canonical, linked, outside Git, or unknown."""
+    probe_path = _existing_probe_path(raw_path)
+    try:
+        inside_result = _run_git(probe_path, "rev-parse", "--is-inside-work-tree")
+    except RuntimeError as exc:
+        return Classification("unknown", False, reason=str(exc))
+    if inside_result.returncode != 0 or inside_result.stdout.strip() != "true":
+        return Classification(
+            "outside", False, reason="path is outside a Git worktree"
+        )
+
+    try:
+        probes = {
+            "repo_root": _run_git(
+                probe_path, "rev-parse", "--path-format=absolute", "--show-toplevel"
+            ),
+            "git_dir": _run_git(
+                probe_path, "rev-parse", "--path-format=absolute", "--git-dir"
+            ),
+            "common_dir": _run_git(
+                probe_path,
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ),
+            "branch": _run_git(probe_path, "branch", "--show-current"),
+        }
+    except RuntimeError as exc:
+        return Classification("unknown", True, reason=str(exc))
+
+    required = ("repo_root", "git_dir", "common_dir")
+    if any(probes[name].returncode != 0 or not probes[name].stdout.strip() for name in required):
+        return Classification(
+            "unknown",
+            True,
+            reason="required Git worktree identity could not be resolved",
+        )
+
+    values = {name: result.stdout.strip() for name, result in probes.items()}
+    git_dir = os.path.realpath(values["git_dir"])
+    common_dir = os.path.realpath(values["common_dir"])
+    classification = "canonical" if git_dir == common_dir else "linked"
+    return Classification(
+        classification,
+        True,
+        repo_root=os.path.realpath(values["repo_root"]),
+        git_dir=git_dir,
+        common_dir=common_dir,
+        branch=values["branch"],
+        reason=(
+            "Git directory equals common directory"
+            if classification == "canonical"
+            else "Git directory is isolated beneath the common directory"
+        ),
+    )
+
+
+def _target_probe(cwd: str, file_path: str) -> str:
+    if not file_path:
+        return cwd
+    target = Path(file_path).expanduser()
+    if not target.is_absolute():
+        target = Path(cwd) / target
+    return str(target.resolve(strict=False))
+
+
+def check_write(cwd: str, file_path: str) -> dict[str, Any]:
+    """Return one fail-closed direct-file-write decision."""
+    context = classify_location(cwd)
+    target = classify_location(_target_probe(cwd, file_path))
+    classifications = (context, target)
+    unknown = next(
+        (item for item in classifications if item.classification == "unknown"), None
+    )
+    canonical = next(
+        (item for item in classifications if item.classification == "canonical"), None
+    )
+
+    if unknown is not None:
+        decision = "deny"
+        reason = f"worktree classification failed closed: {unknown.reason}"
+    elif canonical is not None:
+        decision = "deny"
+        reason = "canonical checkouts are read-only session mirrors"
+    else:
+        decision = "allow"
+        reason = "write target and process context are outside canonical worktrees"
+
+    return {
+        "policy": POLICY_VERSION,
+        "decision": decision,
+        "reason": reason,
+        "action": (
+            "create_or_use_linked_worktree" if decision == "deny" else "none"
+        ),
+        "context": asdict(context),
+        "target": asdict(target),
+    }
+
+
+def _normalise_branch(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    branch = value.strip()
+    for prefix in ("refs/heads/", "refs/remotes/origin/", "origin/"):
+        if branch.startswith(prefix):
+            branch = branch[len(prefix) :]
+            break
+    return branch
+
+
+def _branch_from_mapping(mapping: Any) -> str:
+    if not isinstance(mapping, dict):
+        return ""
+    for key in BRANCH_CONFIG_KEYS:
+        branch = _normalise_branch(mapping.get(key))
+        if branch:
+            return branch
+    return ""
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"configured branch metadata is unreadable: {path}: {exc}") from exc
+
+
+def _origin_slug(repo_root: str) -> str:
+    result = _run_git(Path(repo_root), "remote", "get-url", "origin")
+    if result.returncode != 0:
+        return ""
+    remote = result.stdout.strip()
+    match = re.search(r"github\.com[/:]([^/\s]+/[^/\s]+?)(?:\.git)?$", remote)
+    return match.group(1) if match else ""
+
+
+def _project_branch(repo_root: str) -> tuple[str, str]:
+    config_path = Path(repo_root) / ".aidevops.json"
+    if not config_path.is_file():
+        return "", ""
+    branch = _branch_from_mapping(_load_json(config_path))
+    return (branch, "project-config") if branch else ("", "")
+
+
+def _registered_branch(repo_root: str) -> tuple[str, str]:
+    configured_path = os.environ.get("AIDEVOPS_REPOS_CONFIG", "")
+    config_path = (
+        Path(configured_path).expanduser()
+        if configured_path
+        else Path.home() / ".config" / "aidevops" / "repos.json"
+    )
+    if not config_path.is_file():
+        return "", ""
+    payload = _load_json(config_path)
+    entries = payload.get("initialized_repos", []) if isinstance(payload, dict) else []
+    slug = _origin_slug(repo_root)
+    canonical_root = os.path.realpath(repo_root)
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_slug = entry.get("slug", "")
+        entry_path = entry.get("path", "") or entry.get("repo_path", "")
+        path_matches = bool(entry_path) and os.path.realpath(
+            os.path.expanduser(str(entry_path))
+        ) == canonical_root
+        if (slug and entry_slug == slug) or path_matches:
+            branch = _branch_from_mapping(entry)
+            if branch:
+                return branch, "registered-repo-config"
+    return "", ""
+
+
+def _origin_default_branch(repo_root: str) -> tuple[str, str]:
+    result = _run_git(
+        Path(repo_root),
+        "symbolic-ref",
+        "--quiet",
+        "--short",
+        "refs/remotes/origin/HEAD",
+    )
+    if result.returncode != 0:
+        return "", ""
+    branch = _normalise_branch(result.stdout)
+    return (branch, "origin-head") if branch else ("", "")
+
+
+def _valid_branch(repo_root: str, branch: str) -> bool:
+    result = _run_git(Path(repo_root), "check-ref-format", "--branch", branch)
+    return result.returncode == 0
+
+
+def resolve_canonical_branch(cwd: str) -> dict[str, str]:
+    classification = classify_location(cwd)
+    if classification.classification not in {"canonical", "linked"}:
+        raise RuntimeError(
+            f"canonical branch requires a classified Git worktree: {classification.reason}"
+        )
+    repo_root = classification.repo_root
+    for resolver in (_project_branch, _registered_branch, _origin_default_branch):
+        branch, source = resolver(repo_root)
+        if branch:
+            if not _valid_branch(repo_root, branch):
+                raise RuntimeError(f"configured canonical branch is invalid: {branch}")
+            return {
+                "policy": POLICY_VERSION,
+                "branch": branch,
+                "source": source,
+                "repo_root": repo_root,
+            }
+    raise RuntimeError("origin default or configured canonical branch cannot be resolved")
+
+
+def _emit(payload: dict[str, Any], field: str) -> None:
+    if field:
+        value = payload.get(field, "")
+        if isinstance(value, (dict, list)):
+            print(json.dumps(value, sort_keys=True))
+        else:
+            print(value)
+        return
+    print(json.dumps(payload, sort_keys=True))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    classify_parser = subparsers.add_parser("classify")
+    classify_parser.add_argument("--cwd", default=os.getcwd())
+    classify_parser.add_argument("--field", default="")
+
+    write_parser = subparsers.add_parser("check-write")
+    write_parser.add_argument("--cwd", default=os.getcwd())
+    write_parser.add_argument("--path", default="")
+    write_parser.add_argument("--field", default="")
+
+    branch_parser = subparsers.add_parser("resolve-branch")
+    branch_parser.add_argument("--cwd", default=os.getcwd())
+    branch_parser.add_argument("--field", default="")
+
+    args = parser.parse_args()
+    if args.command == "classify":
+        result = classify_location(args.cwd)
+        payload = {"policy": POLICY_VERSION, **asdict(result)}
+        _emit(payload, args.field)
+        return 2 if result.classification == "unknown" else 0
+    if args.command == "check-write":
+        _emit(check_write(args.cwd, args.path), args.field)
+        return 0
+    try:
+        payload = resolve_canonical_branch(args.cwd)
+    except RuntimeError as exc:
+        print(f"BLOCKED: {exc}", file=sys.stderr)
+        return 2
+    _emit(payload, args.field)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/dirty-worktree-backup-helper.sh
+++ b/.agents/scripts/dirty-worktree-backup-helper.sh
@@ -14,18 +14,37 @@ fi
 
 BACKUP_ROOT="${AIDEVOPS_DIRTY_BACKUP_ROOT:-${HOME}/.aidevops/.agent-workspace/tmp/dirty-main-backups}"
 DEFAULT_RETENTION_DAYS="${AIDEVOPS_DIRTY_BACKUP_RETENTION_DAYS:-30}"
+REAL_GIT="${AIDEVOPS_REAL_GIT_BIN:-/usr/bin/git}"
+
+CAPTURE_HEAD=""
+CAPTURE_BRANCH=""
+CAPTURE_INDEX_TREE=""
+CAPTURE_WORKTREE_TREE=""
+CAPTURE_STATUS_HASH=""
+CAPTURE_FINGERPRINT=""
 
 usage() {
 	cat <<'USAGE'
 Usage: dirty-worktree-backup-helper.sh <command> [options]
 
 Commands:
-  backup [--repo PATH] [--reason TEXT] [--pr N] [--issue N] [--session KEY] [--task ID]
-      Preserve dirty tracked diffs and untracked files without mutating the repo.
+  backup [--repo PATH] [--reason TEXT] [--pr N] [--issue N] [--session KEY]
+         [--task ID] [--operation-id ID] [--machine]
+      Preserve tracked, staged, and untracked state without changing the worktree.
+  verify --repo PATH --backup ID
+      Verify hashes, Git objects, and the stable backup ref.
+  matches --repo PATH --backup ID
+      Verify that the current worktree still byte-matches a backup.
+  clean --repo PATH --backup ID --confirm CLEAN_VERIFIED_DIRTY_WORKTREE_BACKUP
+      Remove only state that still exactly matches the verified backup.
+  restore --repo PATH --backup ID --confirm RESTORE_DIRTY_WORKTREE_BACKUP
+      Restore the original HEAD, index, worktree, and untracked state.
+  acknowledge --backup ID --confirm ACKNOWLEDGE_DIRTY_WORKTREE_BACKUP
+      Mark an open backup eligible for retention pruning.
   list
       List recorded dirty-worktree backups.
   prune [--dry-run] [--force] [--retention-days N]
-      Remove backups whose linked PR is closed/merged, or stale backups older than N days.
+      Remove only acknowledged/restored backups that are terminal or stale.
 
 Environment:
   AIDEVOPS_DIRTY_BACKUP_ROOT            Override backup directory.
@@ -50,6 +69,22 @@ safe_slug() {
 	return 0
 }
 
+hash_file() {
+	local file_path="$1"
+	python3 - "$file_path" <<'PY'
+import hashlib
+import pathlib
+import sys
+
+digest = hashlib.sha256()
+with pathlib.Path(sys.argv[1]).open("rb") as handle:
+    for block in iter(lambda: handle.read(1024 * 1024), b""):
+        digest.update(block)
+print(digest.hexdigest())
+PY
+	return $?
+}
+
 manifest_write() {
 	local manifest_path="$1"
 	local key="$2"
@@ -65,10 +100,25 @@ manifest_value() {
 	return 0
 }
 
+manifest_set() {
+	local manifest_path="$1"
+	local key="$2"
+	local value="$3"
+	local temp_path="${manifest_path}.tmp.$$"
+	awk -F '\t' -v wanted="$key" -v replacement="$value" '
+		BEGIN { found = 0 }
+		$1 == wanted { print wanted "\t" replacement; found = 1; next }
+		{ print }
+		END { if (!found) print wanted "\t" replacement }
+	' "$manifest_path" >"$temp_path" || return 1
+	mv "$temp_path" "$manifest_path" || return 1
+	return 0
+}
+
 repo_slug_from_remote() {
 	local repo_path="$1"
 	local remote_url=""
-	remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null || true)
+	remote_url=$($REAL_GIT -C "$repo_path" remote get-url origin 2>/dev/null || true)
 	remote_url=${remote_url%.git}
 	case "$remote_url" in
 	https://github.com/*/*)
@@ -86,28 +136,205 @@ repo_slug_from_remote() {
 repo_dirty() {
 	local repo_path="$1"
 	local status_output=""
-	status_output=$(git -C "$repo_path" status --porcelain=v1 2>/dev/null || true)
+	status_output=$($REAL_GIT -C "$repo_path" status --porcelain=v1 2>/dev/null || true)
 	[[ -n "$status_output" ]]
 	return $?
+}
+
+resolve_repo_path() {
+	local repo_path="$1"
+	[[ -n "$repo_path" && -d "$repo_path" ]] || return 1
+	(cd "$repo_path" && pwd -P) || return 1
+	return 0
+}
+
+resolve_backup_dir() {
+	local backup_id="$1"
+	[[ -n "$backup_id" ]] || return 1
+	if [[ "$backup_id" == */* ]]; then
+		return 1
+	fi
+	local backup_dir="${BACKUP_ROOT}/${backup_id}"
+	[[ -d "$backup_dir" && -f "$backup_dir/manifest.tsv" ]] || return 1
+	printf '%s\n' "$backup_dir"
+	return 0
 }
 
 copy_untracked_files() {
 	local repo_path="$1"
 	local backup_dir="$2"
-	local list_path="$backup_dir/untracked-files.txt"
 	local nul_path="$backup_dir/untracked-files.nul"
 	local rel_path=""
 	local target_path=""
 
-	: >"$list_path"
-	git -C "$repo_path" ls-files --others --exclude-standard -z >"$nul_path"
+	: >"$backup_dir/untracked-files.txt"
 	while IFS= read -r -d '' rel_path; do
 		[[ -n "$rel_path" ]] || continue
-		printf '%s\n' "$rel_path" >>"$list_path"
+		printf '%s\n' "$rel_path" >>"$backup_dir/untracked-files.txt"
 		target_path="$backup_dir/untracked/$rel_path"
 		mkdir -p "$(dirname "$target_path")"
-		cp -p "$repo_path/$rel_path" "$target_path"
+		cp -Pp "$repo_path/$rel_path" "$target_path"
 	done <"$nul_path"
+	return 0
+}
+
+capture_state() {
+	local repo_path="$1"
+	local capture_dir="$2"
+	local index_path=""
+	local temp_index="$capture_dir/worktree.index"
+	local fingerprint_input="$capture_dir/fingerprint-input"
+
+	mkdir -p "$capture_dir/untracked"
+	CAPTURE_HEAD=$($REAL_GIT -C "$repo_path" rev-parse --verify 'HEAD^{commit}') || return 1
+	CAPTURE_BRANCH=$($REAL_GIT -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+	[[ -n "$CAPTURE_BRANCH" ]] || CAPTURE_BRANCH="detached"
+	CAPTURE_INDEX_TREE=$($REAL_GIT -C "$repo_path" write-tree) || return 1
+	index_path=$($REAL_GIT -C "$repo_path" rev-parse --git-path index) || return 1
+	[[ "$index_path" == /* ]] || index_path="$repo_path/$index_path"
+	cp -p "$index_path" "$temp_index" || return 1
+	GIT_INDEX_FILE="$temp_index" $REAL_GIT -C "$repo_path" add -A -- . || return 1
+	CAPTURE_WORKTREE_TREE=$(GIT_INDEX_FILE="$temp_index" $REAL_GIT -C "$repo_path" write-tree) || return 1
+	rm -f "$temp_index"
+
+	$REAL_GIT -C "$repo_path" status --short --branch >"$capture_dir/git-status.txt"
+	$REAL_GIT -C "$repo_path" status --porcelain=v1 -z >"$capture_dir/git-status.nul"
+	$REAL_GIT -C "$repo_path" diff --binary >"$capture_dir/tracked.patch"
+	$REAL_GIT -C "$repo_path" diff --cached --binary >"$capture_dir/staged.patch"
+	$REAL_GIT -C "$repo_path" ls-files --others --exclude-standard -z >"$capture_dir/untracked-files.nul"
+	copy_untracked_files "$repo_path" "$capture_dir" || return 1
+	CAPTURE_STATUS_HASH=$(hash_file "$capture_dir/git-status.nul") || return 1
+	printf '%s\n%s\n%s\n%s\n' "$CAPTURE_HEAD" "$CAPTURE_INDEX_TREE" \
+		"$CAPTURE_WORKTREE_TREE" "$CAPTURE_STATUS_HASH" >"$fingerprint_input"
+	CAPTURE_FINGERPRINT=$(hash_file "$fingerprint_input") || return 1
+	rm -f "$fingerprint_input"
+	return 0
+}
+
+create_snapshot_commits() {
+	local repo_path="$1"
+	local backup_ref="$2"
+	local index_commit=""
+	local worktree_commit=""
+	local zero_sha="0000000000000000000000000000000000000000"
+	local identity_name="aidevops recovery"
+	local identity_email="recovery@localhost"
+
+	index_commit=$(printf 'aidevops dirty backup index\n' | \
+		GIT_AUTHOR_NAME="$identity_name" GIT_AUTHOR_EMAIL="$identity_email" \
+		GIT_COMMITTER_NAME="$identity_name" GIT_COMMITTER_EMAIL="$identity_email" \
+		$REAL_GIT -C "$repo_path" commit-tree "$CAPTURE_INDEX_TREE" -p "$CAPTURE_HEAD") || return 1
+	worktree_commit=$(printf 'aidevops dirty backup worktree\n' | \
+		GIT_AUTHOR_NAME="$identity_name" GIT_AUTHOR_EMAIL="$identity_email" \
+		GIT_COMMITTER_NAME="$identity_name" GIT_COMMITTER_EMAIL="$identity_email" \
+		$REAL_GIT -C "$repo_path" commit-tree "$CAPTURE_WORKTREE_TREE" -p "$index_commit") || return 1
+	$REAL_GIT -C "$repo_path" update-ref "$backup_ref" "$worktree_commit" "$zero_sha" || return 1
+	printf '%s\t%s\n' "$index_commit" "$worktree_commit"
+	return 0
+}
+
+write_backup_manifest() {
+	local manifest_path="$1"
+	local repo_path="$2"
+	local reason="$3"
+	local pr_number="$4"
+	local issue_number="$5"
+	local session_key="$6"
+	local task_id="$7"
+	local backup_id="$8"
+	local backup_ref="$9"
+	local index_commit="${10}"
+	local worktree_commit="${11}"
+	local repo_slug=""
+	repo_slug=$(repo_slug_from_remote "$repo_path" || true)
+
+	: >"$manifest_path"
+	manifest_write "$manifest_path" schema dirty-worktree-backup-v2
+	manifest_write "$manifest_path" created_at "$(iso_utc)"
+	manifest_write "$manifest_path" state open
+	manifest_write "$manifest_path" backup_id "$backup_id"
+	manifest_write "$manifest_path" repo_path "$repo_path"
+	manifest_write "$manifest_path" repo_slug "$repo_slug"
+	manifest_write "$manifest_path" branch "$CAPTURE_BRANCH"
+	manifest_write "$manifest_path" head "$CAPTURE_HEAD"
+	manifest_write "$manifest_path" index_tree "$CAPTURE_INDEX_TREE"
+	manifest_write "$manifest_path" worktree_tree "$CAPTURE_WORKTREE_TREE"
+	manifest_write "$manifest_path" index_commit "$index_commit"
+	manifest_write "$manifest_path" worktree_commit "$worktree_commit"
+	manifest_write "$manifest_path" backup_ref "$backup_ref"
+	manifest_write "$manifest_path" status_sha256 "$CAPTURE_STATUS_HASH"
+	manifest_write "$manifest_path" fingerprint "$CAPTURE_FINGERPRINT"
+	manifest_write "$manifest_path" tracked_patch_sha256 "$(hash_file "$(dirname "$manifest_path")/tracked.patch")"
+	manifest_write "$manifest_path" staged_patch_sha256 "$(hash_file "$(dirname "$manifest_path")/staged.patch")"
+	manifest_write "$manifest_path" untracked_list_sha256 "$(hash_file "$(dirname "$manifest_path")/untracked-files.nul")"
+	manifest_write "$manifest_path" session "$session_key"
+	manifest_write "$manifest_path" task "$task_id"
+	manifest_write "$manifest_path" pr "$pr_number"
+	manifest_write "$manifest_path" issue "$issue_number"
+	manifest_write "$manifest_path" reason "$reason"
+	manifest_write "$manifest_path" restore_confirm RESTORE_DIRTY_WORKTREE_BACKUP
+	return 0
+}
+
+verify_backup_dir() {
+	local repo_path="$1"
+	local backup_dir="$2"
+	local manifest_path="$backup_dir/manifest.tsv"
+	local backup_ref=""
+	local index_commit=""
+	local worktree_commit=""
+	local index_tree=""
+	local worktree_tree=""
+	local actual=""
+
+	[[ "$(manifest_value "$manifest_path" schema)" == "dirty-worktree-backup-v2" ]] || return 1
+	backup_ref=$(manifest_value "$manifest_path" backup_ref)
+	index_commit=$(manifest_value "$manifest_path" index_commit)
+	worktree_commit=$(manifest_value "$manifest_path" worktree_commit)
+	index_tree=$(manifest_value "$manifest_path" index_tree)
+	worktree_tree=$(manifest_value "$manifest_path" worktree_tree)
+	actual=$($REAL_GIT -C "$repo_path" rev-parse --verify "${backup_ref}^{commit}" 2>/dev/null || true)
+	[[ "$actual" == "$worktree_commit" ]] || return 1
+	[[ "$($REAL_GIT -C "$repo_path" rev-parse "${worktree_commit}^{tree}")" == "$worktree_tree" ]] || return 1
+	[[ "$($REAL_GIT -C "$repo_path" rev-parse "${worktree_commit}^1")" == "$index_commit" ]] || return 1
+	[[ "$($REAL_GIT -C "$repo_path" rev-parse "${index_commit}^{tree}")" == "$index_tree" ]] || return 1
+	[[ "$(hash_file "$backup_dir/git-status.nul")" == "$(manifest_value "$manifest_path" status_sha256)" ]] || return 1
+	[[ "$(hash_file "$backup_dir/tracked.patch")" == "$(manifest_value "$manifest_path" tracked_patch_sha256)" ]] || return 1
+	[[ "$(hash_file "$backup_dir/staged.patch")" == "$(manifest_value "$manifest_path" staged_patch_sha256)" ]] || return 1
+	[[ "$(hash_file "$backup_dir/untracked-files.nul")" == "$(manifest_value "$manifest_path" untracked_list_sha256)" ]] || return 1
+	return 0
+}
+
+current_state_matches_backup() {
+	local repo_path="$1"
+	local backup_dir="$2"
+	local manifest_path="$backup_dir/manifest.tsv"
+	local capture_dir=""
+	local expected_fingerprint=""
+	expected_fingerprint=$(manifest_value "$manifest_path" fingerprint)
+	capture_dir=$(mktemp -d "${BACKUP_ROOT}/.verify.XXXXXXXX") || return 1
+	if ! capture_state "$repo_path" "$capture_dir"; then
+		rm -rf "$capture_dir"
+		return 1
+	fi
+	rm -rf "$capture_dir"
+	[[ "$CAPTURE_FINGERPRINT" == "$expected_fingerprint" ]]
+	return $?
+}
+
+parse_repo_backup_args() {
+	PARSED_REPO_PATH=""
+	PARSED_BACKUP_ID=""
+	PARSED_CONFIRMATION=""
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--repo) PARSED_REPO_PATH="${2:-}"; shift 2 ;;
+		--backup) PARSED_BACKUP_ID="${2:-}"; shift 2 ;;
+		--confirm) PARSED_CONFIRMATION="${2:-}"; shift 2 ;;
+		*) return 1 ;;
+		esac
+	done
 	return 0
 }
 
@@ -118,119 +345,218 @@ cmd_backup() {
 	local issue_number=""
 	local session_key="${AIDEVOPS_SESSION_KEY:-${WORKER_SESSION_KEY:-}}"
 	local task_id="${AIDEVOPS_TASK_ID:-${WORKER_TASK_NUMBER:-}}"
-	local arg=""
-
+	local operation_id=""
+	local machine=false
 	while [[ $# -gt 0 ]]; do
-		arg="$1"
+		local arg="$1"
 		case "$arg" in
-		--repo)
-			repo_path="${2:-}"
-			shift 2
-			;;
-		--reason)
-			reason="${2:-}"
-			shift 2
-			;;
-		--pr)
-			pr_number="${2:-}"
-			shift 2
-			;;
-		--issue)
-			issue_number="${2:-}"
-			shift 2
-			;;
-		--session)
-			session_key="${2:-}"
-			shift 2
-			;;
-		--task)
-			task_id="${2:-}"
-			shift 2
-			;;
-		--help | -h)
-			usage
-			return 0
-			;;
-		*)
-			print_error "Unknown backup option: $arg"
-			return 1
-			;;
+		--repo) repo_path="${2:-}"; shift 2 ;;
+		--reason) reason="${2:-}"; shift 2 ;;
+		--pr) pr_number="${2:-}"; shift 2 ;;
+		--issue) issue_number="${2:-}"; shift 2 ;;
+		--session) session_key="${2:-}"; shift 2 ;;
+		--task) task_id="${2:-}"; shift 2 ;;
+		--operation-id) operation_id="${2:-}"; shift 2 ;;
+		--machine) machine=true; shift ;;
+		--help | -h) usage; return 0 ;;
+		*) print_error "Unknown backup option: $arg"; return 1 ;;
 		esac
 	done
-
-	if [[ -z "$repo_path" ]] || { [[ ! -d "$repo_path/.git" ]] && [[ ! -f "$repo_path/.git" ]]; }; then
-		print_error "Not a git worktree: $repo_path"
-		return 1
-	fi
-
-	if ! repo_dirty "$repo_path"; then
+	repo_path=$(resolve_repo_path "$repo_path") || return 1
+	repo_dirty "$repo_path" || {
 		print_info "No dirty worktree changes to back up: $repo_path"
 		return 0
-	fi
+	}
 
-	mkdir -p "$BACKUP_ROOT"
-
-	local branch_name=""
+	(umask 0077 && mkdir -p "$BACKUP_ROOT") || return 1
+	local capture_dir=""
+	capture_dir=$(mktemp -d "${BACKUP_ROOT}/.capture.XXXXXXXX") || return 1
+	trap 'rm -rf "${capture_dir:-}"' RETURN
+	capture_state "$repo_path" "$capture_dir" || return 1
 	local repo_name=""
+	repo_name=$(basename "$repo_path")
+	local id_component="${operation_id:-$(timestamp_utc)-$$}"
 	local backup_id=""
+	backup_id="$(safe_slug "$repo_name")-$(safe_slug "$CAPTURE_BRANCH")-$(safe_slug "$id_component")-${CAPTURE_FINGERPRINT:0:16}"
+	local backup_dir="${BACKUP_ROOT}/${backup_id}"
+	if [[ -d "$backup_dir" ]]; then
+		verify_backup_dir "$repo_path" "$backup_dir" || return 1
+		current_state_matches_backup "$repo_path" "$backup_dir" || return 1
+		rm -rf "$capture_dir"
+		capture_dir=""
+		[[ "$machine" == true ]] && printf '%s|%s\n' "$backup_id" "$backup_dir" || printf '%s\n' "$backup_dir"
+		return 0
+	fi
+	local backup_ref="refs/aidevops/dirty-worktree-backups/${backup_id}"
+	$REAL_GIT check-ref-format "$backup_ref" >/dev/null 2>&1 || return 1
+	local commit_pair=""
+	commit_pair=$(create_snapshot_commits "$repo_path" "$backup_ref") || return 1
+	local index_commit="${commit_pair%%$'\t'*}"
+	local worktree_commit="${commit_pair#*$'\t'}"
+	write_backup_manifest "$capture_dir/manifest.tsv" "$repo_path" "$reason" "$pr_number" \
+		"$issue_number" "$session_key" "$task_id" "$backup_id" "$backup_ref" \
+		"$index_commit" "$worktree_commit" || return 1
+	chmod 700 "$capture_dir"
+	chmod 600 "$capture_dir/manifest.tsv"
+	mv "$capture_dir" "$backup_dir" || return 1
+	capture_dir=""
+	verify_backup_dir "$repo_path" "$backup_dir" || return 1
+	print_success "Backed up dirty worktree state: $backup_id"
+	printf 'RESTORE_COMMAND=%q restore --repo %q --backup %q --confirm RESTORE_DIRTY_WORKTREE_BACKUP\n' "$0" "$repo_path" "$backup_id"
+	[[ "$machine" == true ]] && printf '%s|%s\n' "$backup_id" "$backup_dir" || printf '%s\n' "$backup_dir"
+	return 0
+}
+
+cmd_verify() {
+	parse_repo_backup_args "$@" || return 1
+	local repo_path=""
+	repo_path=$(resolve_repo_path "$PARSED_REPO_PATH") || return 1
 	local backup_dir=""
-	local manifest_path=""
-	local repo_head=""
-	local repo_slug=""
+	backup_dir=$(resolve_backup_dir "$PARSED_BACKUP_ID") || return 1
+	verify_backup_dir "$repo_path" "$backup_dir" || return 1
+	printf 'VERIFIED_BACKUP_ID=%s\n' "$PARSED_BACKUP_ID"
+	return 0
+}
 
-	branch_name=$(git -C "$repo_path" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'detached')
-	repo_name=$(basename "$(git -C "$repo_path" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$repo_path")")
-	repo_head=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null || true)
-	repo_slug=$(repo_slug_from_remote "$repo_path" || true)
-	backup_id="$(safe_slug "$repo_name")-$(safe_slug "$branch_name")-$(timestamp_utc)-$$"
-	backup_dir="$BACKUP_ROOT/$backup_id"
-	manifest_path="$backup_dir/manifest.tsv"
+cmd_matches() {
+	parse_repo_backup_args "$@" || return 1
+	local repo_path=""
+	repo_path=$(resolve_repo_path "$PARSED_REPO_PATH") || return 1
+	local backup_dir=""
+	backup_dir=$(resolve_backup_dir "$PARSED_BACKUP_ID") || return 1
+	verify_backup_dir "$repo_path" "$backup_dir" || return 1
+	current_state_matches_backup "$repo_path" "$backup_dir" || return 1
+	printf 'BACKUP_MATCH=true\n'
+	return 0
+}
 
-	mkdir -p "$backup_dir/untracked"
-	: >"$manifest_path"
-	manifest_write "$manifest_path" "schema" "dirty-worktree-backup-v1"
-	manifest_write "$manifest_path" "created_at" "$(iso_utc)"
-	manifest_write "$manifest_path" "state" "open"
-	manifest_write "$manifest_path" "repo_path" "$repo_path"
-	manifest_write "$manifest_path" "repo_slug" "$repo_slug"
-	manifest_write "$manifest_path" "branch" "$branch_name"
-	manifest_write "$manifest_path" "head" "$repo_head"
-	manifest_write "$manifest_path" "session" "$session_key"
-	manifest_write "$manifest_path" "task" "$task_id"
-	manifest_write "$manifest_path" "pr" "$pr_number"
-	manifest_write "$manifest_path" "issue" "$issue_number"
-	manifest_write "$manifest_path" "reason" "$reason"
+remove_preserved_untracked() {
+	local repo_path="$1"
+	local nul_path="$2"
+	python3 - "$repo_path" "$nul_path" <<'PY'
+import os
+import pathlib
+import sys
 
-	git -C "$repo_path" status --short --branch >"$backup_dir/git-status.txt"
-	git -C "$repo_path" diff --binary >"$backup_dir/tracked.patch"
-	git -C "$repo_path" diff --cached --binary >"$backup_dir/staged.patch"
-	copy_untracked_files "$repo_path" "$backup_dir"
+root = pathlib.Path(sys.argv[1]).resolve()
+paths = pathlib.Path(sys.argv[2]).read_bytes().split(b"\0")
+for raw in paths:
+    if not raw:
+        continue
+    relative = pathlib.Path(os.fsdecode(raw))
+    target = (root / relative).resolve(strict=False)
+    if os.path.commonpath((str(root), str(target))) != str(root):
+        raise SystemExit("untracked path escaped repository")
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    elif target.exists():
+        raise SystemExit(f"refusing unexpected untracked directory: {relative}")
+    parent = target.parent
+    while parent != root:
+        try:
+            parent.rmdir()
+        except OSError:
+            break
+        parent = parent.parent
+PY
+	return $?
+}
 
-	print_success "Backed up dirty worktree state: $backup_dir"
-	printf '%s\n' "$backup_dir"
+cmd_clean() {
+	parse_repo_backup_args "$@" || return 1
+	[[ "$PARSED_CONFIRMATION" == "CLEAN_VERIFIED_DIRTY_WORKTREE_BACKUP" ]] || return 1
+	local repo_path=""
+	repo_path=$(resolve_repo_path "$PARSED_REPO_PATH") || return 1
+	local backup_dir=""
+	backup_dir=$(resolve_backup_dir "$PARSED_BACKUP_ID") || return 1
+	verify_backup_dir "$repo_path" "$backup_dir" || return 1
+	current_state_matches_backup "$repo_path" "$backup_dir" || return 1
+	local original_head=""
+	original_head=$(manifest_value "$backup_dir/manifest.tsv" head)
+	$REAL_GIT -C "$repo_path" read-tree --reset -u "$original_head" || return 1
+	remove_preserved_untracked "$repo_path" "$backup_dir/untracked-files.nul" || return 1
+	[[ -z "$($REAL_GIT -C "$repo_path" status --porcelain=v1)" ]] || return 1
+	manifest_set "$backup_dir/manifest.tsv" cleaned_at "$(iso_utc)" || return 1
+	printf 'CLEANED_BACKUP_ID=%s\n' "$PARSED_BACKUP_ID"
+	return 0
+}
+
+rollback_restore() {
+	local repo_path="$1"
+	local branch_ref="$2"
+	local original_head="$3"
+	local rollback_head="$4"
+	local untracked_nul="$5"
+	$REAL_GIT -C "$repo_path" update-ref "$branch_ref" "$rollback_head" "$original_head" || return 1
+	$REAL_GIT -C "$repo_path" read-tree --reset -u "$rollback_head" || return 1
+	remove_preserved_untracked "$repo_path" "$untracked_nul" || return 1
+	return 0
+}
+
+cmd_restore() {
+	parse_repo_backup_args "$@" || return 1
+	[[ "$PARSED_CONFIRMATION" == "RESTORE_DIRTY_WORKTREE_BACKUP" ]] || return 1
+	local repo_path=""
+	repo_path=$(resolve_repo_path "$PARSED_REPO_PATH") || return 1
+	local backup_dir=""
+	backup_dir=$(resolve_backup_dir "$PARSED_BACKUP_ID") || return 1
+	verify_backup_dir "$repo_path" "$backup_dir" || return 1
+	[[ -z "$($REAL_GIT -C "$repo_path" status --porcelain=v1)" ]] || return 1
+	local branch=""
+	branch=$($REAL_GIT -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+	[[ "$branch" == "$(manifest_value "$backup_dir/manifest.tsv" branch)" ]] || return 1
+	local rollback_head=""
+	local original_head=""
+	local index_tree=""
+	local worktree_tree=""
+	rollback_head=$($REAL_GIT -C "$repo_path" rev-parse --verify 'HEAD^{commit}') || return 1
+	original_head=$(manifest_value "$backup_dir/manifest.tsv" head)
+	index_tree=$(manifest_value "$backup_dir/manifest.tsv" index_tree)
+	worktree_tree=$(manifest_value "$backup_dir/manifest.tsv" worktree_tree)
+	local branch_ref="refs/heads/${branch}"
+	$REAL_GIT -C "$repo_path" update-ref "$branch_ref" "$original_head" "$rollback_head" || return 1
+	if ! $REAL_GIT -C "$repo_path" read-tree --reset -u "$worktree_tree" ||
+		! $REAL_GIT -C "$repo_path" read-tree "$index_tree"; then
+		rollback_restore "$repo_path" "$branch_ref" "$original_head" "$rollback_head" \
+			"$backup_dir/untracked-files.nul" || return 1
+		return 1
+	fi
+	current_state_matches_backup "$repo_path" "$backup_dir" || return 1
+	manifest_set "$backup_dir/manifest.tsv" state restored || return 1
+	manifest_set "$backup_dir/manifest.tsv" restored_at "$(iso_utc)" || return 1
+	printf 'RESTORED_BACKUP_ID=%s\n' "$PARSED_BACKUP_ID"
+	return 0
+}
+
+cmd_acknowledge() {
+	parse_repo_backup_args "$@" || return 1
+	[[ -z "$PARSED_REPO_PATH" ]] || return 1
+	[[ "$PARSED_CONFIRMATION" == "ACKNOWLEDGE_DIRTY_WORKTREE_BACKUP" ]] || return 1
+	local backup_dir=""
+	backup_dir=$(resolve_backup_dir "$PARSED_BACKUP_ID") || return 1
+	manifest_set "$backup_dir/manifest.tsv" state acknowledged || return 1
+	manifest_set "$backup_dir/manifest.tsv" acknowledged_at "$(iso_utc)" || return 1
+	printf 'ACKNOWLEDGED_BACKUP_ID=%s\n' "$PARSED_BACKUP_ID"
 	return 0
 }
 
 cmd_list() {
 	local backup_dir=""
 	local manifest_path=""
-
-	if [[ ! -d "$BACKUP_ROOT" ]]; then
+	[[ -d "$BACKUP_ROOT" ]] || {
 		print_info "No dirty-worktree backups found."
 		return 0
-	fi
-
+	}
 	for backup_dir in "$BACKUP_ROOT"/*; do
 		[[ -d "$backup_dir" ]] || continue
 		manifest_path="$backup_dir/manifest.tsv"
-		if [[ -f "$manifest_path" ]]; then
-			printf '%s\tstate=%s\tpr=%s\ttask=%s\treason=%s\n' \
-				"$backup_dir" \
-				"$(manifest_value "$manifest_path" state)" \
-				"$(manifest_value "$manifest_path" pr)" \
-				"$(manifest_value "$manifest_path" task)" \
-				"$(manifest_value "$manifest_path" reason)"
-		fi
+		[[ -f "$manifest_path" ]] || continue
+		printf '%s\tstate=%s\tpr=%s\ttask=%s\treason=%s\n' \
+			"$(manifest_value "$manifest_path" backup_id)" \
+			"$(manifest_value "$manifest_path" state)" \
+			"$(manifest_value "$manifest_path" pr)" \
+			"$(manifest_value "$manifest_path" task)" \
+			"$(manifest_value "$manifest_path" reason)"
 	done
 	return 0
 }
@@ -239,16 +565,13 @@ backup_age_days() {
 	local backup_dir="$1"
 	local now_epoch=""
 	local backup_epoch=""
-
 	now_epoch=$(date +%s)
 	if command -v portable_stat_mtime >/dev/null 2>&1; then
 		backup_epoch=$(portable_stat_mtime "$backup_dir" 2>/dev/null || printf '%s' "$now_epoch")
 	else
 		backup_epoch="$now_epoch"
 	fi
-	if ! [[ "$backup_epoch" =~ ^[0-9]+$ ]]; then
-		backup_epoch="$now_epoch"
-	fi
+	[[ "$backup_epoch" =~ ^[0-9]+$ ]] || backup_epoch="$now_epoch"
 	printf '%s\n' $(((now_epoch - backup_epoch) / 86400))
 	return 0
 }
@@ -257,14 +580,11 @@ pr_is_terminal() {
 	local repo_slug="$1"
 	local pr_number="$2"
 	local pr_state=""
-
 	[[ -n "$repo_slug" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
 	command -v gh >/dev/null 2>&1 || return 1
 	pr_state=$(gh pr view "$pr_number" --repo "$repo_slug" --json state --jq '.state // ""' 2>/dev/null || true)
 	case "$pr_state" in
-	CLOSED | MERGED)
-		return 0
-		;;
+	CLOSED | MERGED) return 0 ;;
 	esac
 	return 1
 }
@@ -273,78 +593,61 @@ remove_backup_dir() {
 	local backup_dir="$1"
 	local force="$2"
 	local reason="$3"
-
-	if [[ "$force" != "true" ]]; then
-		print_info "[dry-run] Would remove backup ($reason): $backup_dir"
+	local manifest_path="$backup_dir/manifest.tsv"
+	if [[ "$force" != true ]]; then
+		print_info "[dry-run] Would remove backup ($reason): $(basename "$backup_dir")"
 		return 0
 	fi
+	local repo_path=""
+	local backup_ref=""
+	local worktree_commit=""
+	repo_path=$(manifest_value "$manifest_path" repo_path)
+	backup_ref=$(manifest_value "$manifest_path" backup_ref)
+	worktree_commit=$(manifest_value "$manifest_path" worktree_commit)
+	if [[ -n "$backup_ref" && -d "$repo_path" ]]; then
+		$REAL_GIT -C "$repo_path" update-ref -d "$backup_ref" "$worktree_commit" || return 1
+	fi
 	rm -rf "$backup_dir"
-	print_info "Removed backup ($reason): $backup_dir"
+	print_info "Removed backup ($reason): $(basename "$backup_dir")"
 	return 0
 }
 
 cmd_prune() {
-	local force="false"
+	local force=false
 	local retention_days="$DEFAULT_RETENTION_DAYS"
-	local arg=""
-
 	while [[ $# -gt 0 ]]; do
-		arg="$1"
+		local arg="$1"
 		case "$arg" in
-		--force)
-			force="true"
-			shift
-			;;
-		--dry-run)
-			force="false"
-			shift
-			;;
-		--retention-days)
-			retention_days="${2:-}"
-			shift 2
-			;;
-		--help | -h)
-			usage
-			return 0
-			;;
-		*)
-			print_error "Unknown prune option: $arg"
-			return 1
-			;;
+		--force) force=true; shift ;;
+		--dry-run) force=false; shift ;;
+		--retention-days) retention_days="${2:-}"; shift 2 ;;
+		*) return 1 ;;
 		esac
 	done
-
-	if ! [[ "$retention_days" =~ ^[0-9]+$ ]]; then
-		print_error "Retention days must be numeric: $retention_days"
-		return 1
-	fi
-
-	if [[ ! -d "$BACKUP_ROOT" ]]; then
-		return 0
-	fi
-
+	[[ "$retention_days" =~ ^[0-9]+$ ]] || return 1
+	[[ -d "$BACKUP_ROOT" ]] || return 0
 	local backup_dir=""
-	local manifest_path=""
-	local repo_slug=""
-	local pr_number=""
-	local age_days=""
-
 	for backup_dir in "$BACKUP_ROOT"/*; do
-		[[ -d "$backup_dir" ]] || continue
-		manifest_path="$backup_dir/manifest.tsv"
-		[[ -f "$manifest_path" ]] || continue
+		[[ -d "$backup_dir" && -f "$backup_dir/manifest.tsv" ]] || continue
 		[[ -f "$backup_dir/.keep" ]] && continue
-
-		repo_slug=$(manifest_value "$manifest_path" repo_slug)
-		pr_number=$(manifest_value "$manifest_path" pr)
+		local state=""
+		state=$(manifest_value "$backup_dir/manifest.tsv" state)
+		case "$state" in
+		acknowledged | restored) ;;
+		*) continue ;;
+		esac
+		local repo_slug=""
+		local pr_number=""
+		repo_slug=$(manifest_value "$backup_dir/manifest.tsv" repo_slug)
+		pr_number=$(manifest_value "$backup_dir/manifest.tsv" pr)
 		if pr_is_terminal "$repo_slug" "$pr_number"; then
-			remove_backup_dir "$backup_dir" "$force" "linked PR terminal"
+			remove_backup_dir "$backup_dir" "$force" "linked PR terminal" || return 1
 			continue
 		fi
-
+		local age_days=""
 		age_days=$(backup_age_days "$backup_dir")
 		if [[ "$age_days" -ge "$retention_days" ]]; then
-			remove_backup_dir "$backup_dir" "$force" "age ${age_days}d >= ${retention_days}d"
+			remove_backup_dir "$backup_dir" "$force" "age ${age_days}d >= ${retention_days}d" || return 1
 		fi
 	done
 	return 0
@@ -352,32 +655,18 @@ cmd_prune() {
 
 main() {
 	local command_name="${1:-help}"
-	if [[ $# -gt 0 ]]; then
-		shift
-	fi
-
+	[[ $# -eq 0 ]] || shift
 	case "$command_name" in
-	backup)
-		cmd_backup "$@"
-		return $?
-		;;
-	list)
-		cmd_list "$@"
-		return $?
-		;;
-	prune)
-		cmd_prune "$@"
-		return $?
-		;;
-	help | --help | -h)
-		usage
-		return 0
-		;;
-	*)
-		print_error "Unknown command: $command_name"
-		usage
-		return 1
-		;;
+	backup) cmd_backup "$@"; return $? ;;
+	verify) cmd_verify "$@"; return $? ;;
+	matches) cmd_matches "$@"; return $? ;;
+	clean) cmd_clean "$@"; return $? ;;
+	restore) cmd_restore "$@"; return $? ;;
+	acknowledge) cmd_acknowledge "$@"; return $? ;;
+	list) cmd_list "$@"; return $? ;;
+	prune) cmd_prune "$@"; return $? ;;
+	help | --help | -h) usage; return 0 ;;
+	*) print_error "Unknown command: $command_name"; usage; return 1 ;;
 	esac
 }
 

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -623,59 +623,47 @@ if ! git rev-parse --is-inside-work-tree &>/dev/null; then
 	exit 0
 fi
 
-# Resolve structural worktree identity before interpreting detached HEAD.
-precheck_git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
-precheck_git_dir=$(git rev-parse --path-format=absolute --git-dir 2>/dev/null || true)
+# Resolve structural worktree identity before branch handling or ownership.
+canonical_policy_helper="${SCRIPT_DIR}/canonical-write-policy-helper.py"
+if [[ ! -f "$canonical_policy_helper" ]]; then
+	echo -e "${RED}BLOCKED${NC}: canonical-write policy helper is unavailable"
+	echo "ACTION_REQUIRED=repair_canonical_write_policy"
+	exit 1
+fi
+worktree_classification=""
+if ! worktree_classification=$(python3 "$canonical_policy_helper" classify --cwd "$PWD" --field classification 2>/dev/null); then
+	echo -e "${RED}BLOCKED${NC}: Git worktree identity could not be classified safely"
+	echo "ACTION_REQUIRED=repair_canonical_write_policy"
+	exit 1
+fi
+
+if [[ "$worktree_classification" == "canonical" ]]; then
+	current_branch=$(git branch --show-current 2>/dev/null || true)
+	[[ -n "$current_branch" ]] || current_branch="detached"
+	[[ "$LOOP_MODE" == "true" ]] && _handle_loop_mode_on_protected "$current_branch"
+	echo -e "${RED}BLOCKED${NC}: canonical checkouts are read-only session mirrors"
+	echo "CANONICAL_WORKTREE=true"
+	echo "ACTION_REQUIRED=create_or_use_linked_worktree"
+	echo "HINT: create a safe linked worktree; use canonical-recovery-helper.sh only for audited mirror synchronization"
+	if [[ ! -t 0 ]] || [[ "${FULL_LOOP_HEADLESS:-false}" == "true" ]]; then
+		exit 2
+	fi
+	exit 1
+fi
+if [[ "$worktree_classification" != "linked" ]]; then
+	echo -e "${RED}BLOCKED${NC}: expected a linked Git worktree, got '$worktree_classification'"
+	echo "ACTION_REQUIRED=create_or_use_linked_worktree"
+	exit 1
+fi
 
 # Detached HEAD is valid only inside a linked worktree (for isolated releases).
 current_branch=$(git branch --show-current 2>/dev/null || echo "")
 if [[ -z "$current_branch" ]]; then
-	if [[ -n "$precheck_git_dir" && -n "$precheck_git_common_dir" && "$precheck_git_dir" != "$precheck_git_common_dir" ]]; then
-		current_branch="detached-release-worktree"
-	else
-		echo -e "${RED}BLOCKED${NC}: canonical detached HEAD is not a writable session context"
-		echo "ACTION_REQUIRED=create_or_use_linked_worktree"
-		exit 1
-	fi
-fi
-
-# --- Protected branch (main/master) ---
-if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
-	# Loop mode: auto-decide based on file path (preferred) or task description
-	[[ "$LOOP_MODE" == "true" ]] && _handle_loop_mode_on_protected "$current_branch"
-
-	# Detect headless mode (GH#4400): workers dispatched without --loop-mode
-	# get the interactive prompt and loop forever trying to edit. Detect
-	# headless by checking if stdin is not a terminal (no TTY = headless).
-	# In headless mode, output a concise machine-readable error and exit 2
-	# (worktree needed) instead of the verbose interactive prompt.
-	if [[ ! -t 0 ]] || [[ "${FULL_LOOP_HEADLESS:-false}" == "true" ]]; then
-		echo -e "${RED}BLOCKED${NC}: Canonical repo directory is on protected '$current_branch'; move code edits into a linked worktree."
-		echo "HEADLESS_BLOCKED=true"
-		echo "ACTION_REQUIRED=create_worktree"
-		echo "HINT: Use --loop-mode --file 'path' or --loop-mode --task 'description' to auto-create a worktree,"
-		echo "or dispatch with --dir pointing to an existing worktree, not the main repo."
-		exit 2
-	fi
-
-	# Interactive mode: show warning and exit
-	_show_protected_branch_warning "$current_branch"
-fi
-
-# --- Feature branch (not main/master) ---
-
-# Determine if this is the main worktree (canonical repo directory) or a linked worktree
-git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
-git_dir=$(git rev-parse --git-dir 2>/dev/null)
-
-is_main_worktree=false
-if [[ "$git_dir" == "$git_common_dir" ]] || [[ "$git_dir" == ".git" ]]; then
-	is_main_worktree=true
+	current_branch="detached-release-worktree"
 fi
 
 # Keep the OpenCode session title authoritative while OpenCode is active.
 # Outside OpenCode, retain the repo/branch shell-title fallback.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
@@ -706,11 +694,6 @@ if declare -f claim_worktree_ownership >/dev/null 2>&1; then
 		fi
 		_handle_ownership_conflict "$worktree_path" "$owner_pid" "$owner_session" "$owner_created"
 	fi
-fi
-
-# Canonical repo directory on a feature branch — warn and offer options
-if [[ "$is_main_worktree" == "true" ]]; then
-	_handle_main_repo_off_main "$current_branch"
 fi
 
 # --- Linked worktree (correct working context) ---

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -313,7 +313,11 @@ _verify_deployed_core_plugin_freshness() {
 	local source_file
 	local target_file
 	local -a core_plugin_files=(
+		"hooks/git_safety_guard.py"
 		"plugins/opencode-aidevops/model-limits.mjs"
+		"plugins/opencode-aidevops/quality-hooks-git-safety.mjs"
+		"plugins/opencode-aidevops/quality-hooks.mjs"
+		"scripts/canonical-write-policy-helper.py"
 	)
 
 	for rel_path in "${core_plugin_files[@]}"; do

--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -67,6 +67,7 @@ WORKTREE_REGISTRY_DIR="${WORKTREE_REGISTRY_DIR:-${_WORKTREE_REGISTRY_HOME}/.aide
 WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DB:-${WORKTREE_REGISTRY_DIR}/worktree-registry.db}"
 WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES="${WORKTREE_OWNER_DEAD_COOLDOWN_MINUTES:-60}"
 WORKTREE_OWNER_STALE_LIVE_MAX_HOURS="${WORKTREE_OWNER_STALE_LIVE_MAX_HOURS:-168}"
+_WORKTREE_REGISTRY_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
 
 # Get the command name (basename) for a given PID.
 # Returns empty string if the PID does not exist or info is unavailable.
@@ -283,6 +284,46 @@ _wt_registry_lookup_path() {
 	return 0
 }
 
+# Classify an existing path through the runtime-neutral canonical policy.
+# Synthetic/nonexistent fixture paths classify as outside Git and remain valid.
+_wt_worktree_classification() {
+	local wt_path="$1"
+	local policy_helper="${_WORKTREE_REGISTRY_SCRIPT_DIR}/canonical-write-policy-helper.py"
+	[[ -f "$policy_helper" ]] || return 1
+	python3 "$policy_helper" classify --cwd "$wt_path" --field classification 2>/dev/null
+	return $?
+}
+
+_wt_path_is_canonical() {
+	local wt_path="$1"
+	local classification=""
+	classification=$(_wt_worktree_classification "$wt_path") || return 1
+	[[ "$classification" == "canonical" ]]
+	return $?
+}
+
+_wt_delete_owner_row() {
+	local wt_path="$1"
+	[[ -f "$WORKTREE_REGISTRY_DB" ]] || return 0
+	sqlite3 "$WORKTREE_REGISTRY_DB" \
+		"DELETE FROM worktree_owners WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';" \
+		2>/dev/null || return 1
+	return 0
+}
+
+# Remove historical canonical rows without signalling or inspecting owner PIDs.
+_wt_purge_canonical_owner_rows() {
+	local stored_path=""
+	[[ -f "$WORKTREE_REGISTRY_DB" ]] || return 0
+	while IFS= read -r stored_path; do
+		[[ -n "$stored_path" ]] || continue
+		if _wt_path_is_canonical "$stored_path"; then
+			_wt_delete_owner_row "$stored_path" || return 1
+		fi
+	done < <(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT worktree_path FROM worktree_owners;" 2>/dev/null || true)
+	return 0
+}
+
 # Initialize the registry database
 _init_registry_db() {
 	mkdir -p "$WORKTREE_REGISTRY_DIR" 2>/dev/null || true
@@ -321,8 +362,19 @@ _init_registry_db() {
 		sqlite3 "$WORKTREE_REGISTRY_DB" "
             ALTER TABLE worktree_owners
             ADD COLUMN owner_comm TEXT DEFAULT '';
-        " 2>/dev/null || true
+		" 2>/dev/null || true
 	fi
+	_wt_purge_canonical_owner_rows || return 1
+	return 0
+}
+
+# Public recovery hook: delete only a structurally canonical ownership row.
+remove_canonical_worktree_owner() {
+	local wt_path="$1"
+	_init_registry_db || return 1
+	wt_path=$(_wt_registry_lookup_path "$wt_path")
+	_wt_path_is_canonical "$wt_path" || return 1
+	_wt_delete_owner_row "$wt_path" || return 1
 	return 0
 }
 
@@ -368,8 +420,12 @@ register_worktree() {
 	local owner_comm
 	owner_comm=$(_get_proc_comm "$owner_pid")
 
-	_init_registry_db
+	_init_registry_db || return 1
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
+	if _wt_path_is_canonical "$wt_path"; then
+		_wt_delete_owner_row "$wt_path" || return 1
+		return 1
+	fi
 
 	{
 		_wt_sqlite_set_owner_pid_param "$owner_pid"
@@ -543,8 +599,12 @@ claim_worktree_ownership() {
 	local trusted_opencode_session=0
 	_wt_is_trusted_opencode_session "$session_id" && trusted_opencode_session=1
 
-	_init_registry_db
+	_init_registry_db || return 1
 	wt_path=$(_wt_registry_lookup_path "$wt_path")
+	if _wt_path_is_canonical "$wt_path"; then
+		_wt_delete_owner_row "$wt_path" || return 1
+		return 1
+	fi
 
 	local final_owner_info=""
 	final_owner_info=$(_wt_claim_owner_record "$wt_path" "$branch" "$owner_pid" "$session_id" \

--- a/.agents/scripts/tests/test-git-safety-guard.sh
+++ b/.agents/scripts/tests/test-git-safety-guard.sh
@@ -4,8 +4,8 @@
 #
 # test-git-safety-guard.sh
 # Tests for git_safety_guard.py covering GH#21814 changes:
-#   - Dynamic default-branch detection (replaces hardcoded "main"/"master")
-#   - Off-default-branch canonical-workspace protection (t1990)
+#   - Structural canonical-versus-linked worktree detection
+#   - Canonical protection independent of branch names
 #   - environment variables cannot bypass canonical protection
 #   - shared command-policy destructive checks (regression)
 #
@@ -177,10 +177,10 @@ test_default_branch_detection_from_origin_head() {
 	local output=""
 	output=$(run_hook "$TEST_ROOT" "$json") || true
 
-	if hook_is_deny "$output" "t1712" && hook_is_deny "$output" "develop"; then
-		print_result "default-branch detection from origin/HEAD (develop denied with t1712)" 0
+	if hook_is_deny "$output" "canonical write policy" && hook_is_deny "$output" "read-only session mirrors"; then
+		print_result "origin-default develop canonical checkout is read-only" 0
 	else
-		print_result "default-branch detection from origin/HEAD (develop denied with t1712)" 1 "output=${output}"
+		print_result "origin-default develop canonical checkout is read-only" 1 "output=${output}"
 	fi
 
 	# Cleanup: back to main
@@ -202,10 +202,10 @@ test_off_default_branch_canonical_denied() {
 	local output=""
 	output=$(run_hook "$TEST_ROOT" "$json") || true
 
-	if hook_is_deny "$output" "t1990" && hook_is_deny "$output" "feature/test-off-default"; then
-		print_result "off-default-branch in canonical workspace is denied (t1990)" 0
+	if hook_is_deny "$output" "canonical write policy"; then
+		print_result "off-default-branch in canonical workspace is denied structurally" 0
 	else
-		print_result "off-default-branch in canonical workspace is denied (t1990)" 1 "output=${output}"
+		print_result "off-default-branch in canonical workspace is denied structurally" 1 "output=${output}"
 	fi
 
 	git -C "$TEST_ROOT" checkout main >/dev/null 2>&1 || true
@@ -220,17 +220,16 @@ test_off_default_branch_in_linked_worktree_allowed() {
 	local worktree_path="${TEST_ROOT}/linked-wt"
 	git -C "$TEST_ROOT" worktree add "$worktree_path" -b feature/linked-test >/dev/null 2>&1
 
-	local json
-	json=$(printf '{"tool_name":"Edit","tool_input":{"filePath":"%s/src/foo.ts"}}' "$worktree_path")
-
+	local tool_name=""
+	local json=""
 	local output=""
-	output=$(run_hook "$worktree_path" "$json") || true
-
-	if [[ -z "$output" ]]; then
-		print_result "off-default-branch edit in linked worktree is allowed (no output)" 0
-	else
-		print_result "off-default-branch edit in linked worktree is allowed (no output)" 1 "output=${output}"
-	fi
+	local rc=0
+	for tool_name in Edit Write functions.apply_patch apply_patch; do
+		json=$(printf '{"tool_name":"%s","tool_input":{"filePath":"%s/src/foo.ts"}}' "$tool_name" "$worktree_path")
+		output=$(run_hook "$worktree_path" "$json") || true
+		[[ -z "$output" ]] || rc=1
+	done
+	print_result "all direct file mutation tools are allowed in linked worktrees" "$rc" "output=${output}"
 
 	git -C "$TEST_ROOT" worktree remove "$worktree_path" 2>/dev/null || rm -rf "$worktree_path"
 	git -C "$TEST_ROOT" branch -D feature/linked-test 2>/dev/null || true
@@ -238,9 +237,9 @@ test_off_default_branch_in_linked_worktree_allowed() {
 }
 
 # =============================================================================
-# Test 4: Default-branch allowlist preserved (README.md, TODO.md, todo/*)
+# Test 4: Planning files have no canonical write exception
 # =============================================================================
-test_default_branch_allowlisted_paths_allowed() {
+test_default_branch_planning_paths_denied() {
 	# Repo is on main (default branch)
 	local passed=0
 
@@ -251,20 +250,20 @@ test_default_branch_allowlisted_paths_allowed() {
 		local output=""
 		output=$(run_hook "$TEST_ROOT" "$json") || true
 
-		if [[ -n "$output" ]]; then
-			print_result "allowlisted path '${allowed_path}' allowed on default branch" 1 "output=${output}"
+		if ! hook_is_deny "$output" "canonical write policy"; then
+			print_result "planning path '${allowed_path}' denied on canonical default branch" 1 "output=${output}"
 			passed=1
 		fi
 	done
 
 	if [[ "$passed" -eq 0 ]]; then
-		print_result "allowlisted paths (README.md, TODO.md, todo/*) allowed on default branch" 0
+		print_result "planning paths (README.md, TODO.md, todo/*) require linked worktrees" 0
 	fi
 	return 0
 }
 
 # =============================================================================
-# Test 5: Default-branch non-allowlisted path → denied with t1712 reason
+# Test 5: Direct code and namespaced patch tools are denied canonically
 # =============================================================================
 test_default_branch_non_allowlisted_denied() {
 	local json
@@ -273,10 +272,22 @@ test_default_branch_non_allowlisted_denied() {
 	local output=""
 	output=$(run_hook "$TEST_ROOT" "$json") || true
 
-	if hook_is_deny "$output" "t1712"; then
-		print_result "non-allowlisted path denied on default branch (t1712)" 0
+	if hook_is_deny "$output" "canonical write policy"; then
+		print_result "code path denied in canonical default checkout" 0
 	else
-		print_result "non-allowlisted path denied on default branch (t1712)" 1 "output=${output}"
+		print_result "code path denied in canonical default checkout" 1 "output=${output}"
+	fi
+	return 0
+}
+
+test_namespaced_apply_patch_denied_canonically() {
+	local json='{"tool_name":"functions.apply_patch","tool_input":{"patchText":"test"}}'
+	local output=""
+	output=$(run_hook "$TEST_ROOT" "$json") || true
+	if hook_is_deny "$output" "canonical write policy"; then
+		print_result "namespaced functions.apply_patch is denied in canonical checkout" 0
+	else
+		print_result "namespaced functions.apply_patch is denied in canonical checkout" 1 "output=${output}"
 	fi
 	return 0
 }
@@ -416,7 +427,7 @@ test_linked_worktree_branch_switch_allowed() {
 }
 
 # =============================================================================
-# Test 9: Repo without origin/HEAD → fallback to init.defaultBranch then "main"
+# Test 9: Structural protection does not depend on origin/HEAD
 # =============================================================================
 test_no_origin_head_falls_back_to_main() {
 	# Fresh temp repo with no remotes — falls back to "main"
@@ -436,7 +447,7 @@ test_no_origin_head_falls_back_to_main() {
 	git -C "$fresh_root" add .
 	git -C "$fresh_root" commit -m "test: seed" >/dev/null 2>&1
 
-	# On main (default), edit a non-allowlisted file — should get t1712 deny (not crash)
+	# On main without a remote, direct writes are still denied structurally.
 	local json
 	json=$(printf '{"tool_name":"Edit","tool_input":{"filePath":"%s/src/app.ts"}}' "$fresh_root")
 
@@ -444,10 +455,10 @@ test_no_origin_head_falls_back_to_main() {
 	local exit_code=0
 	output=$(run_hook "$fresh_root" "$json") || exit_code=$?
 
-	if [[ "$exit_code" -eq 0 ]] && hook_is_deny "$output" "t1712"; then
-		print_result "no origin/HEAD: falls back cleanly, enforces t1712 on main" 0
+	if [[ "$exit_code" -eq 0 ]] && hook_is_deny "$output" "canonical write policy"; then
+		print_result "no origin/HEAD: canonical checkout remains read-only" 0
 	else
-		print_result "no origin/HEAD: falls back cleanly, enforces t1712 on main" 1 "exit=${exit_code} output=${output}"
+		print_result "no origin/HEAD: canonical checkout remains read-only" 1 "exit=${exit_code} output=${output}"
 	fi
 
 	rm -rf "$fresh_root"
@@ -477,15 +488,15 @@ test_canonical_guard_skip_env_var() {
 
 	local passed=0
 
-	if ! hook_is_deny "$output_default" "t1990"; then
+	if ! hook_is_deny "$output_default" "canonical write policy"; then
 		print_result "canonical guard: off-default-branch denied without env override" 1 "output=${output_default}"
 		passed=1
 	fi
-	if ! hook_is_deny "$output_headless" "t1990"; then
+	if ! hook_is_deny "$output_headless" "canonical write policy"; then
 		print_result "canonical guard: FULL_LOOP_HEADLESS=1 alone does NOT bypass deny" 1 "output=${output_headless}"
 		passed=1
 	fi
-	if ! hook_is_deny "$output_skip" "t1990"; then
+	if ! hook_is_deny "$output_skip" "canonical write policy"; then
 		print_result "canonical guard: former skip variable does not bypass deny" 1 "output=${output_skip}"
 		passed=1
 	fi
@@ -539,8 +550,9 @@ main() {
 	test_default_branch_detection_from_origin_head
 	test_off_default_branch_canonical_denied
 	test_off_default_branch_in_linked_worktree_allowed
-	test_default_branch_allowlisted_paths_allowed
+	test_default_branch_planning_paths_denied
 	test_default_branch_non_allowlisted_denied
+	test_namespaced_apply_patch_denied_canonically
 	test_bash_destructive_commands_blocked
 	test_canonical_branch_switch_always_blocked
 	test_linked_worktree_branch_switch_allowed

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -47,6 +47,8 @@ setup_test_repo() {
 	}
 	"$GIT_BIN" -C "$TEST_ROOT" config user.name "Aidevops Test"
 	"$GIT_BIN" -C "$TEST_ROOT" config user.email "test@example.com"
+	"$GIT_BIN" -C "$TEST_ROOT" config core.hooksPath /dev/null
+	"$GIT_BIN" -C "$TEST_ROOT" config commit.gpgsign false
 	printf 'test\n' >"${TEST_ROOT}/README.md"
 	"$GIT_BIN" -C "$TEST_ROOT" add README.md
 	"$GIT_BIN" -C "$TEST_ROOT" commit -m "test: seed repo" >/dev/null 2>&1
@@ -93,7 +95,7 @@ test_blocks_headless_edits_on_main_with_worktree_guidance() {
 	local exit_code=0
 	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" 2>&1) || exit_code=$?
 
-	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"Canonical repo directory is on protected 'main'; move code edits into a linked worktree."* ]] && [[ "$output" == *"HEADLESS_BLOCKED=true"* ]] && [[ "$output" == *"ACTION_REQUIRED=create_worktree"* ]]; then
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"canonical checkouts are read-only session mirrors"* ]] && [[ "$output" == *"CANONICAL_WORKTREE=true"* ]] && [[ "$output" == *"ACTION_REQUIRED=create_or_use_linked_worktree"* ]]; then
 		print_result "blocks headless edits on main with worktree guidance" 0
 		return 0
 	fi
@@ -164,7 +166,7 @@ test_worker_env_does_not_bypass_canonical_guard() {
 	output=$(WORKER_WORKTREE_PATH="$TEST_ROOT" WORKER_WORKTREE_BRANCH="forged/worker" \
 		FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" 2>&1) || exit_code=$?
 
-	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"HEADLESS_BLOCKED=true"* ]]; then
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"CANONICAL_WORKTREE=true"* ]] && [[ "$output" == *"ACTION_REQUIRED=create_or_use_linked_worktree"* ]]; then
 		print_result "worker environment cannot bypass canonical worktree guard" 0
 		return 0
 	fi
@@ -174,18 +176,23 @@ test_worker_env_does_not_bypass_canonical_guard() {
 }
 
 test_warns_when_canonical_repo_is_off_main() {
-	"$GIT_BIN" -C "$TEST_ROOT" switch -c bugfix/off-main >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" switch -c develop >/dev/null 2>&1
+	"$GIT_BIN" -C "$TEST_ROOT" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
 
 	local output=""
 	local exit_code=0
 	output=$(run_helper "$TEST_ROOT" 2>&1) || exit_code=$?
+	local canonical_rows=0
+	if [[ -f "$TEST_REGISTRY_DB" ]]; then
+		canonical_rows=$(sqlite3 "$TEST_REGISTRY_DB" "SELECT COUNT(*) FROM worktree_owners WHERE worktree_path = '$TEST_ROOT';")
+	fi
 
-	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"CANONICAL_STATE_INVALID=true"* ]] && [[ "$output" == *"ACTION_REQUIRED=create_or_use_linked_worktree"* ]]; then
-		print_result "blocks when canonical repo directory is off main" 0
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"CANONICAL_WORKTREE=true"* ]] && [[ "$output" == *"ACTION_REQUIRED=create_or_use_linked_worktree"* ]] && [[ "$canonical_rows" -eq 0 ]]; then
+		print_result "blocks canonical origin-default develop before ownership claim" 0
 		return 0
 	fi
 
-	print_result "blocks when canonical repo directory is off main" 1 "exit=${exit_code} output=${output}"
+	print_result "blocks canonical origin-default develop before ownership claim" 1 "exit=${exit_code} rows=${canonical_rows} output=${output}"
 	return 0
 }
 
@@ -278,7 +285,7 @@ test_interactive_allowlisted_path_still_requires_worktree() {
 	local exit_code=0
 	output=$(run_helper "$TEST_ROOT" --file "README.md" 2>&1) || exit_code=$?
 
-	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"ACTION_REQUIRED=create_worktree"* ]]; then
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"ACTION_REQUIRED=create_or_use_linked_worktree"* ]]; then
 		print_result "interactive allowlisted path still requires a linked worktree" 0
 		return 0
 	fi
@@ -349,6 +356,8 @@ test_auto_creates_git_path_worktree_from_ansi_helper_output() {
 	}
 	"$GIT_BIN" -C "$repo_path" config user.name "Aidevops Test"
 	"$GIT_BIN" -C "$repo_path" config user.email "test@example.com"
+	"$GIT_BIN" -C "$repo_path" config core.hooksPath /dev/null
+	"$GIT_BIN" -C "$repo_path" config commit.gpgsign false
 	printf 'test\n' >"${repo_path}/README.md"
 	"$GIT_BIN" -C "$repo_path" add README.md
 	"$GIT_BIN" -C "$repo_path" commit -m "test: seed ansi repo" >/dev/null 2>&1

--- a/.agents/scripts/tests/test-worktree-registry-session-claim.sh
+++ b/.agents/scripts/tests/test-worktree-registry-session-claim.sh
@@ -156,6 +156,44 @@ test_untrusted_session_cannot_roll_owner_pid() {
 	return 0
 }
 
+test_canonical_paths_are_purged_without_signalling_live_owner() {
+	reset_registry
+	local canonical_path="${TEST_ROOT}/canonical"
+	local linked_path="${TEST_ROOT}/linked"
+	mkdir -p "$canonical_path"
+	/usr/bin/git -C "$canonical_path" init -q -b develop
+	/usr/bin/git -C "$canonical_path" config user.name Test
+	/usr/bin/git -C "$canonical_path" config user.email test@example.invalid
+	/usr/bin/git -C "$canonical_path" config commit.gpgsign false
+	printf 'seed\n' >"${canonical_path}/README.md"
+	/usr/bin/git -C "$canonical_path" add README.md
+	/usr/bin/git -C "$canonical_path" commit -q -m seed
+	/usr/bin/git -C "$canonical_path" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+	/usr/bin/git -C "$canonical_path" worktree add -q -b feature/linked "$linked_path"
+
+	_init_registry_db
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+		INSERT OR REPLACE INTO worktree_owners
+			(worktree_path, branch, owner_pid, owner_session)
+		VALUES ('$canonical_path', 'develop', $OWNER_PID, 'ses_invalid_canonical');
+	"
+
+	local rc=0
+	if claim_worktree_ownership "$canonical_path" develop --owner-pid "$CLAIM_PID" --session ses_claim; then
+		rc=1
+	fi
+	local canonical_rows=""
+	canonical_rows=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT COUNT(*) FROM worktree_owners WHERE worktree_path = '$canonical_path';")
+	[[ "$canonical_rows" == "0" ]] || rc=1
+	kill -0 "$OWNER_PID" >/dev/null 2>&1 || rc=1
+
+	export OPENCODE_SESSION_ID="ses_linked_owner"
+	claim_worktree_ownership "$linked_path" feature/linked --owner-pid "$CLAIM_PID" --session "$OPENCODE_SESSION_ID" || rc=1
+	[[ "$(owner_info "$linked_path")" == "${CLAIM_PID}|${OPENCODE_SESSION_ID}|"* ]] || rc=1
+	print_result "canonical rows are purged without signalling live PIDs while linked ownership works" "$rc"
+	return 0
+}
+
 main() {
 	start_live_pids
 	test_same_opencode_session_rolls_owner_pid
@@ -163,6 +201,7 @@ main() {
 	test_different_session_stays_blocked
 	test_empty_session_cannot_roll_owner_pid
 	test_untrusted_session_cannot_roll_owner_pid
+	test_canonical_paths_are_purged_without_signalling_live_owner
 	printf 'Results: %s/%s passed, %s failed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]] && return 0
 	return 1

--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -1,88 +1,153 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Regression tests for git_safety_guard.py branch-switch protection."""
+"""Regression tests for the shared canonical direct-write policy."""
 
 import importlib.util
+import json
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
-HOOK_PATH = Path(__file__).parent.parent / ".agents" / "hooks" / "git_safety_guard.py"
+
+ROOT = Path(__file__).parent.parent
+HOOK_PATH = ROOT / ".agents" / "hooks" / "git_safety_guard.py"
+POLICY_PATH = ROOT / ".agents" / "scripts" / "canonical-write-policy-helper.py"
+REAL_GIT = "/usr/bin/git"
 
 spec = importlib.util.spec_from_file_location("git_safety_guard", HOOK_PATH)
 git_safety_guard = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(git_safety_guard)
 
 
-class TestCanonicalBranchSwitchDash(unittest.TestCase):
-    """Protect canonical checkouts from ``git switch -`` bypasses."""
+class CanonicalWritePolicyTests(unittest.TestCase):
+    """Exercise canonical and linked contexts through the Claude adapter."""
 
-    def _patch_canonical_repo(self, previous_branch: str) -> mock.MagicMock:
-        """Patch repository helpers and return the authorization mock."""
-        patchers = [
-            mock.patch.object(git_safety_guard.os, "getcwd", return_value="/repo"),
-            mock.patch.object(git_safety_guard, "_get_repo_root", return_value="/repo"),
-            mock.patch.object(git_safety_guard, "_is_linked_worktree", return_value=False),
-            mock.patch.object(
-                git_safety_guard,
-                "_resolve_previous_branch",
-                return_value=previous_branch,
-            ),
-            mock.patch.object(git_safety_guard, "_get_default_branch", return_value="main"),
-            mock.patch.object(git_safety_guard, "_branch_target_is_current_turn_authorized"),
-        ]
-        started = [patcher.start() for patcher in patchers]
-        for patcher in patchers:
-            self.addCleanup(patcher.stop)
-        return started[-1]
-
-    def test_git_switch_dash_denies_previous_feature_branch(self):
-        branch_authorized = self._patch_canonical_repo("feature/work")
-
-        deny = git_safety_guard._check_canonical_branch_switch_command(
-            "git switch -", "restore the canonical repo"
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        self.repo = self.root / "repo"
+        self.linked = self.root / "linked"
+        self.repo.mkdir()
+        self._git(self.repo, "init", "-q", "-b", "develop")
+        self._git(self.repo, "config", "user.name", "Test")
+        self._git(self.repo, "config", "user.email", "test@example.invalid")
+        self._git(self.repo, "config", "commit.gpgsign", "false")
+        (self.repo / "README.md").write_text("seed\n", encoding="utf-8")
+        self._git(self.repo, "add", "README.md")
+        self._git(self.repo, "commit", "-q", "-m", "seed")
+        self._git(
+            self.repo,
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "feature/test",
+            str(self.linked),
         )
 
-        self.assertIsNotNone(deny)
-        reason = deny["hookSpecificOutput"]["permissionDecisionReason"]
-        self.assertIn("feature/work", reason)
-        branch_authorized.assert_not_called()
+    @staticmethod
+    def _git(cwd: Path, *args: str) -> str:
+        return subprocess.run(
+            [REAL_GIT, *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
 
-    def test_git_checkout_dash_denies_previous_feature_branch(self):
-        branch_authorized = self._patch_canonical_repo("feature/work")
+    def _check(self, cwd: Path, target: Path | str = ""):
+        with mock.patch.object(git_safety_guard.os, "getcwd", return_value=str(cwd)):
+            return git_safety_guard._check_canonical_write(str(target))
 
-        deny = git_safety_guard._check_canonical_branch_switch_command(
-            "git checkout -", "restore the canonical repo"
+    def test_planning_files_are_denied_in_canonical_develop_checkout(self):
+        for relative_path in ("README.md", "TODO.md", "todo/task.md"):
+            with self.subTest(relative_path=relative_path):
+                denial = self._check(self.repo, self.repo / relative_path)
+                self.assertIsNotNone(denial)
+                reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
+                self.assertIn("read-only session mirrors", reason)
+                self.assertIn("create_or_use_linked_worktree", reason)
+
+    def test_linked_worktree_write_is_allowed(self):
+        self.assertIsNone(self._check(self.linked, self.linked / "new-file.md"))
+
+    def test_linked_context_cannot_target_canonical_checkout(self):
+        denial = self._check(self.linked, self.repo / "README.md")
+        self.assertIsNotNone(denial)
+
+    def test_missing_policy_helper_fails_closed(self):
+        with mock.patch.object(
+            git_safety_guard, "_canonical_write_policy_helper", return_value=""
+        ):
+            denial = self._check(self.linked, self.linked / "README.md")
+        self.assertIn(
+            "policy is unavailable",
+            denial["hookSpecificOutput"]["permissionDecisionReason"],
         )
 
-        self.assertIsNotNone(deny)
-        reason = deny["hookSpecificOutput"]["permissionDecisionReason"]
-        self.assertIn("feature/work", reason)
-        branch_authorized.assert_not_called()
+    def test_namespaced_direct_file_tools_are_classified(self):
+        for tool_name in (
+            "Edit",
+            "write",
+            "functions.apply_patch",
+            "namespace/Edit",
+            "tools::apply-patch",
+        ):
+            with self.subTest(tool_name=tool_name):
+                self.assertTrue(git_safety_guard._is_direct_file_tool(tool_name))
+        self.assertFalse(git_safety_guard._is_direct_file_tool("functions.read"))
 
-    def test_git_switch_dash_without_previous_branch_is_ignored(self):
-        branch_authorized = self._patch_canonical_repo("")
-
-        deny = git_safety_guard._check_canonical_branch_switch_command(
-            "git switch -", "restore the canonical repo"
+    def test_runtime_neutral_classifier_reports_structure(self):
+        canonical = subprocess.run(
+            [
+                "python3",
+                str(POLICY_PATH),
+                "classify",
+                "--cwd",
+                str(self.repo),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
         )
-
-        self.assertIsNone(deny)
-        branch_authorized.assert_not_called()
-
-    def test_git_switch_dash_resolves_default_branch_before_authorization(self):
-        branch_authorized = self._patch_canonical_repo("main")
-        branch_authorized.return_value = True
-
-        deny = git_safety_guard._check_canonical_branch_switch_command(
-            "git switch -", "restore the canonical repo to main"
+        linked = subprocess.run(
+            [
+                "python3",
+                str(POLICY_PATH),
+                "classify",
+                "--cwd",
+                str(self.linked),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
         )
+        self.assertEqual(json.loads(canonical.stdout)["classification"], "canonical")
+        self.assertEqual(json.loads(linked.stdout)["classification"], "linked")
 
-        self.assertIsNone(deny)
-        branch_authorized.assert_called_once_with(
-            "main", "restore the canonical repo to main"
+    def test_explicit_project_integration_branch_is_resolved(self):
+        (self.repo / ".aidevops.json").write_text(
+            json.dumps({"pr_base_branch": "develop"}), encoding="utf-8"
         )
+        result = subprocess.run(
+            [
+                "python3",
+                str(POLICY_PATH),
+                "resolve-branch",
+                "--cwd",
+                str(self.repo),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["branch"], "develop")
+        self.assertEqual(payload["source"], "project-config")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Added shared structural canonical-write classification, direct-tool gates, and ownership-registry defence; lossless synchronization remains in progress.

## Files Changed

.agents/hooks/git_safety_guard.py, .agents/plugins/opencode-aidevops/quality-hooks-git-safety.mjs, .agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs, .agents/scripts/canonical-write-policy-helper.py, .agents/scripts/pre-edit-check.sh, .agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/shared-worktree-registry.sh, .agents/scripts/tests/test-git-safety-guard.sh, .agents/scripts/tests/test-pre-edit-check.sh, .agents/scripts/tests/test-worktree-registry-session-claim.sh, tests/test-git-safety-guard.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused pre-edit, registry, Claude, OpenCode, Python, syntax, ShellCheck, and TypeScript checks pass.

Resolves #28065


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 50m and 338,423 tokens on this as a headless worker.