### PR TITLE
GH#28048: docs: clarify empty JSON parameter defaults

### DIFF
--- a/todo/tasks/t18134-brief.md
+++ b/todo/tasks/t18134-brief.md
@@ -67,6 +67,11 @@ Leaf task: title the implementation PR `t18134: ...` and use `Resolves #27803`.
 
 1. Use a two-document stdin stream that consumes both arrays explicitly. Do not pass either array through `--argjson`; the temp-file plus `--slurpfile` pattern at `.agents/scripts/pulse-prefetch-infra.sh:261-284` remains fallback reference only if a verified platform incompatibility blocks streaming.
 
+   Bash's `${parameter:-word}` form substitutes `word` when `parameter` is
+   either unset or set to an empty string. The `[]` defaults below therefore
+   preserve both document positions in either case; the focused regression
+   test covers the empty-string path explicitly.
+
 ```bash
 # Safe selected shape: two JSON documents enter jq through stdin.
 objective_input=$(printf '%s\n%s\n' "${issues_json:-[]}" "${objective_prs:-[]}" |

--- a/todo/tasks/t18134-brief.md
+++ b/todo/tasks/t18134-brief.md
@@ -134,6 +134,7 @@ shellcheck .agents/scripts/pulse-issue-reconcile.sh .agents/scripts/tests/test-j
 - The issue's proposed `jq -n '{issues:.}'` form is explicitly rejected because `.` is `null` under `-n` without `input`.
 - Both potentially large arrays move off argv, not only the array that first triggered E2BIG.
 - Extend the existing deterministic regression suite rather than creating another one-off test.
+- Retain `${parameter:-[]}` because Bash applies the default to both unset and empty values; `test_objective_reconciliation_defaults_empty_lists` verifies the latter case.
 
 ## Relevant Files
 


### PR DESCRIPTION
## Summary

Document that Bash colon-hyphen parameter expansion defaults both unset and empty objective cache variables, matching the existing implementation and focused regression test.

## Files Changed

todo/tasks/t18134-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-jq-large-json-argv-regression.sh; .agents/scripts/linters-local.sh --changed

For #28048


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 2m and 93,617 tokens on this as a headless worker.
