### PR TITLE
GH#28109: remove deprecated gh_grep MCP from plugin tool registry

### DIFF
--- a/.agents/plugins/opencode-aidevops/agent-mcp-tools.mjs
+++ b/.agents/plugins/opencode-aidevops/agent-mcp-tools.mjs
@@ -25,7 +25,6 @@ const AGENT_MCP_TOOLS = {
   // Context / search
   context7: ["context7_*"],
   "openapi-search": ["openapi-search_*"],
-  "github-search": ["gh_grep_*"],
   // Cloud / API
   "cloudflare-mcp": ["cloudflare-api_*"],
   // SEO / analytics

--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -348,6 +348,8 @@ const DEPRECATED_MCPS = [
   { name: "auggie-mcp", toolPattern: "auggie-mcp_*" },
   // augment-context-engine relied on the Auggie MCP; local code search is preferred.
   { name: "augment-context-engine", toolPattern: "augment-context-engine_*" },
+  // gh_grep MCP (mcp.grep.app) removed — github-search subagent uses rg/bash instead
+  { name: "gh_grep", toolPattern: "gh_grep_*" },
 ];
 
 /**

--- a/.agents/plugins/opencode-aidevops/mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/mcp-registry.mjs
@@ -194,15 +194,6 @@ function getMcpRegistry() {
       globallyEnabled: false,
       description: "OpenAPI schema search across public APIs",
     },
-    {
-      name: "gh_grep",
-      type: "remote",
-      url: "https://mcp.grep.app",
-      eager: false,
-      toolPattern: "gh_grep_*",
-      globallyEnabled: false,
-      description: "GitHub code search via grep.app",
-    },
     // --- Local MCPs requiring installed binaries ---
     {
       name: "chrome-devtools",

--- a/.agents/scripts/lib/agent_config.py
+++ b/.agents/scripts/lib/agent_config.py
@@ -76,7 +76,6 @@ def managed_external_directories():
 # MCP On-Demand Loading Strategy:
 # The following MCPs are DISABLED globally to reduce context token usage:
 #   - playwriter_*: ~3K tokens - enable via @playwriter subagent
-#   - gh_grep_*: ~600 tokens - replaced by @github-search subagent (uses rg/bash)
 #   - google-analytics-mcp_*: ~800 tokens - enable via @google-analytics subagent
 #   - context7_*: ~800 tokens - enable via @context7 subagent (library docs lookup)
 #   - openapi-search_*: ~500 tokens - enabled for Build+, AI-DevOps, Research only

--- a/.agents/scripts/lib/mcp_config.py
+++ b/.agents/scripts/lib/mcp_config.py
@@ -61,6 +61,12 @@ def remove_deprecated_mcps(config):
         print("  Removed deprecated osgrep MCP")
     if 'osgrep_*' in config.get('tools', {}):
         del config['tools']['osgrep_*']
+    # gh_grep MCP removed — github-search subagent uses rg/bash instead
+    if 'gh_grep' in config.get('mcp', {}):
+        del config['mcp']['gh_grep']
+        print("  Removed deprecated gh_grep MCP")
+    if 'gh_grep_*' in config.get('tools', {}):
+        del config['tools']['gh_grep_*']
 
 
 def _register_playwriter(config, bun_path):

--- a/.agents/scripts/lib/mcp_config.py
+++ b/.agents/scripts/lib/mcp_config.py
@@ -23,14 +23,14 @@ EAGER_MCPS = set()
 # Lazy-loaded (enabled: False): Subagent-only, start on-demand
 LAZY_MCPS = {
     'MCP_DOCKER', 'ahrefs', 'amazon-order-history',
-    'chrome-devtools', 'claude-code-mcp', 'context7', 'dataforseo', 'gh_grep',
+    'chrome-devtools', 'claude-code-mcp', 'context7', 'dataforseo',
     'google-analytics-mcp', 'grep_app', 'gsc', 'ios-simulator', 'localwp',
     'macos-automator', 'openapi-search', 'outscraper', 'playwriter', 'quickfile',
     'sentry', 'shadcn', 'socket', 'websearch',
 }
 
 # Oh-My-OpenCode tool patterns to disable globally
-OMO_TOOL_PATTERNS = ['grep_app_*', 'websearch_*', 'gh_grep_*']
+OMO_TOOL_PATTERNS = ['grep_app_*', 'websearch_*']
 
 
 def apply_mcp_loading_policy(config):

--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -815,11 +815,13 @@ _remove_deprecated_mcp_entries() {
 		"hostinger-api"
 		"shadcn"
 		"repomix"
+		"gh_grep"
 	)
 
 	# Tool rules to remove (for MCPs that no longer exist)
 	local auggie_tool="auggie-mcp_*"
 	local augment_tool="augment-context-engine_*"
+	local gh_grep_tool="gh_grep_*"
 	local deprecated_tools=(
 		"$auggie_tool"
 		"$augment_tool"
@@ -830,6 +832,7 @@ _remove_deprecated_mcp_entries() {
 		"serper_*"
 		"shadcn_*"
 		"repomix_*"
+		"$gh_grep_tool"
 	)
 
 	for mcp in "${deprecated_mcps[@]}"; do

--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -998,7 +998,6 @@ cleanup_deprecated_mcps() {
 # Disable MCPs globally that should only be enabled on-demand via subagents
 # This reduces session startup context by disabling rarely-used MCPs
 # - playwriter: ~3K tokens - enable via @playwriter subagent
-# - gh_grep: ~600 tokens - replaced by @github-search subagent (uses rg/bash)
 # - google-analytics-mcp: ~800 tokens - enable via @google-analytics subagent
 # - context7: ~800 tokens - enable via @context7 subagent (for library docs lookup)
 disable_ondemand_mcps() {
@@ -1019,7 +1018,6 @@ disable_ondemand_mcps() {
 	local -a ondemand_mcps=(
 		"cloudflare-api"
 		"context7"
-		"gh_grep"
 		"google-analytics-mcp"
 		"grep_app"
 		"playwright"

--- a/.agents/tools/context/github-search.md
+++ b/.agents/tools/context/github-search.md
@@ -81,8 +81,8 @@ rg '"scripts"' package.json -A 10
 
 ## vs GitHub Search MCPs
 
-| Feature | github-search (this) | grep_app / gh_grep MCP |
-|---------|---------------------|------------------------|
+| Feature | github-search (this) | grep_app MCP |
+|---------|---------------------|--------------|
 | Token cost | 0 (no MCP) | ~600 tokens |
 | Speed | Fast (local rg) | Network dependent |
 | Scope | Local + gh CLI | GitHub API |

--- a/.agents/tools/context/mcp-discovery.md
+++ b/.agents/tools/context/mcp-discovery.md
@@ -62,7 +62,7 @@ npx mcporter generate-cli --command https://mcp.context7.com/mcp --compile
 
 | MCP | Subagent | Notes |
 |-----|----------|-------|
-| `grep_app` / `gh_grep` | `@github-search` | GitHub code search (no MCP used) |
+| `grep_app` | `@github-search` | GitHub code search (no MCP used) |
 
 **Primary search**: `rg`/`fd` (local, instant). Use `osgrep` for semantic code search.
 


### PR DESCRIPTION
## Summary

Remove gh_grep MCP - deprecated and replaced by @github-search subagent (uses rg/bash, zero token overhead).

## Changes

- agent-mcp-tools.mjs: Remove github-search -> gh_grep_* mapping
- mcp-registry.mjs: Remove gh_grep MCP entry (grep.app remote)
- mcp_config.py: Remove from LAZY_MCPS and OMO_TOOL_PATTERNS
- agent_config.py: Remove from token-saving comment
- migrations.sh: Remove from disable_ondemand_mcps array and comments
- mcp-discovery.md: Update table (grep_app only)
- github-search.md: Update comparison table

## Rationale

- gh_grep was already disabled globally (gh_grep_*: false in opencode.json)
- @github-search subagent provides the same capability with zero token cost
- Removes dead code from 7 files across plugin, scripts, and docs

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3
