### PR TITLE
GH#28114: reject temporary OpenCode shim targets

### DIFF
--- a/.agents/scripts/setup/_services.sh
+++ b/.agents/scripts/setup/_services.sh
@@ -167,6 +167,21 @@ _setup_opencode_node_path_for_binary() {
 	return 0
 }
 
+_setup_opencode_binary_is_ephemeral() {
+	local bin="$1"
+	local temp_root="${TMPDIR:-}"
+
+	if [[ -n "$temp_root" && "$bin" == "$temp_root"/* ]]; then
+		return 0
+	fi
+
+	case "$bin" in
+	/tmp/* | /private/tmp/* | /var/tmp/* | /var/folders/*/*/T/* | /private/var/folders/*/*/T/*) return 0 ;;
+	esac
+
+	return 1
+}
+
 _setup_clear_canary_negative_cache() {
 	local state_dir="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
 	rm -f "${state_dir}/canary-last-fail" "${state_dir}/canary-last-fail.reason" 2>/dev/null || true
@@ -211,6 +226,7 @@ EOF
 _setup_find_valid_opencode_binary() {
 	local preferred_bin="${1:-}"
 	local candidate=""
+	local candidate_path=""
 	local shim_path="${HOME}/.local/bin/opencode"
 
 	for candidate in \
@@ -223,8 +239,10 @@ _setup_find_valid_opencode_binary() {
 		opencode; do
 		[[ -n "$candidate" ]] || continue
 		[[ "$candidate" == "$shim_path" ]] && continue
-		if _setup_validate_opencode_binary "$candidate"; then
-			command -v "$candidate" 2>/dev/null || printf '%s\n' "$candidate"
+		candidate_path=$(command -v "$candidate" 2>/dev/null || printf '%s' "$candidate")
+		_setup_opencode_binary_is_ephemeral "$candidate_path" && continue
+		if _setup_validate_opencode_binary "$candidate_path"; then
+			printf '%s\n' "$candidate_path"
 			return 0
 		fi
 	done

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -2163,6 +2163,21 @@ _setup_opencode_node_path_for_binary() {
 	return 0
 }
 
+_setup_opencode_binary_is_ephemeral() {
+	local bin="$1"
+	local temp_root="${TMPDIR:-}"
+
+	if [[ -n "$temp_root" && "$bin" == "$temp_root"/* ]]; then
+		return 0
+	fi
+
+	case "$bin" in
+	/tmp/* | /private/tmp/* | /var/tmp/* | /var/folders/*/*/T/* | /private/var/folders/*/*/T/*) return 0 ;;
+	esac
+
+	return 1
+}
+
 _setup_clear_canary_negative_cache() {
 	local state_dir="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
 	rm -f "${state_dir}/canary-last-fail" "${state_dir}/canary-last-fail.reason" 2>/dev/null || true
@@ -2208,6 +2223,7 @@ EOF
 _setup_find_valid_opencode_binary() {
 	local preferred_bin="${1:-}"
 	local candidate=""
+	local candidate_path=""
 	local shim_path="${HOME}/.local/bin/opencode"
 
 	for candidate in \
@@ -2220,8 +2236,10 @@ _setup_find_valid_opencode_binary() {
 		opencode; do
 		[[ -n "$candidate" ]] || continue
 		[[ "$candidate" == "$shim_path" ]] && continue
-		if _setup_validate_opencode_binary "$candidate"; then
-			command -v "$candidate" 2>/dev/null || printf '%s\n' "$candidate"
+		candidate_path=$(command -v "$candidate" 2>/dev/null || printf '%s' "$candidate")
+		_setup_opencode_binary_is_ephemeral "$candidate_path" && continue
+		if _setup_validate_opencode_binary "$candidate_path"; then
+			printf '%s\n' "$candidate_path"
 			return 0
 		fi
 	done

--- a/tests/test-opencode-stable-shim.sh
+++ b/tests/test-opencode-stable-shim.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# shellcheck source=../.agents/scripts/setup/_services.sh
+source "${REPO_ROOT}/.agents/scripts/setup/_services.sh"
+
+assert_ephemeral() {
+	local path="$1"
+
+	if ! _setup_opencode_binary_is_ephemeral "$path"; then
+		printf 'FAIL: expected ephemeral path: %s\n' "$path" >&2
+		return 1
+	fi
+
+	return 0
+}
+
+assert_durable() {
+	local path="$1"
+
+	if _setup_opencode_binary_is_ephemeral "$path"; then
+		printf 'FAIL: expected durable path: %s\n' "$path" >&2
+		return 1
+	fi
+
+	return 0
+}
+
+TMPDIR="${TEST_DIR}/runtime-temp"
+export TMPDIR
+
+assert_ephemeral "${TMPDIR}/nvm/bin/opencode"
+assert_ephemeral "/tmp/nvm/bin/opencode"
+assert_ephemeral "/private/tmp/nvm/bin/opencode"
+assert_ephemeral "/var/folders/aa/bb/T/tmp.example/.nvm/bin/opencode"
+assert_ephemeral "/private/var/folders/aa/bb/T/tmp.example/.nvm/bin/opencode"
+assert_durable "/opt/homebrew/bin/opencode"
+assert_durable "${HOME}/.nvm/versions/node/v24/bin/opencode"
+
+mkdir -p "${TEST_DIR}/bin" "${TEST_DIR}/home"
+printf '#!/usr/bin/env bash\nexit 0\n' >"${TEST_DIR}/bin/opencode"
+chmod +x "${TEST_DIR}/bin/opencode"
+PATH="${TEST_DIR}/bin:/usr/bin:/bin"
+HOME="${TEST_DIR}/home"
+export PATH HOME
+
+VALIDATION_LOG="${TEST_DIR}/validation.log"
+_setup_validate_opencode_binary() {
+	local bin="$1"
+
+	printf '%s\n' "$bin" >>"$VALIDATION_LOG"
+	[[ "$bin" == "/opt/homebrew/bin/opencode" ]] || return 1
+	return 0
+}
+
+ephemeral_preferred="${TMPDIR}/tmp.install/.nvm/versions/node/v24/bin/opencode"
+resolved=$(_setup_find_valid_opencode_binary "$ephemeral_preferred")
+if [[ "$resolved" != "/opt/homebrew/bin/opencode" ]]; then
+	printf 'FAIL: expected durable fallback, got: %s\n' "$resolved" >&2
+	exit 1
+fi
+if grep -Fq "$ephemeral_preferred" "$VALIDATION_LOG"; then
+	printf 'FAIL: ephemeral preferred binary reached validation\n' >&2
+	exit 1
+fi
+
+_setup_validate_opencode_binary() {
+	local bin="$1"
+
+	[[ "$bin" == "${TEST_DIR}/bin/opencode" ]] || return 1
+	return 0
+}
+if _setup_find_valid_opencode_binary "$ephemeral_preferred" >/dev/null; then
+	printf 'FAIL: resolved an OpenCode binary from a temporary PATH entry\n' >&2
+	exit 1
+fi
+
+printf 'PASS: OpenCode setup rejects temporary binary paths\n'


### PR DESCRIPTION
## Summary

Resolve OpenCode candidates before validation and skip binaries located under operating-system temporary roots in both setup implementations; add focused regression coverage.

## Files Changed

.agents/scripts/setup/_services.sh, .agents/scripts/setup/modules/tool-install.sh, tests/test-opencode-stable-shim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Runtime-verified opencode 1.18.3; focused regression test, ShellCheck, git diff --check, and changed-file local linters pass.

Resolves #28114


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 31m and 278,659 tokens on this with the user in an interactive session.