### PR TITLE
GH#27769: Exclude native preflight failures from transport counts

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -410,6 +410,10 @@ _shim_run_transport() {
 		fi
 		return "$rc"
 	fi
+	if [[ "${_GHRP_PREFLIGHT_ONLY:-0}" -eq 1 ]]; then
+		"$executable" "${transport_args[@]}"
+		return $?
+	fi
 	_shim_run_single_transport "$executable" "$path" "$caller" "$retry" "${transport_args[@]}"
 	return $?
 }

--- a/.agents/scripts/gh-rest-pagination-lib.sh
+++ b/.agents/scripts/gh-rest-pagination-lib.sh
@@ -18,6 +18,7 @@ _GHRP_SLURP_REQUESTED=0
 _GHRP_SILENT_REQUESTED=0
 _GHRP_HOSTNAME="${GH_HOST:-github.com}"
 _GHRP_FALLBACK_SAFE=0
+_GHRP_PREFLIGHT_ONLY=0
 _GHRP_PAGE_ARGS=()
 _GHRP_PAGE_FILES=()
 _GHRP_VISITED_ENDPOINTS=()
@@ -66,6 +67,39 @@ _ghrp_find_endpoint_index() {
 	return 1
 }
 
+_ghrp_validate_prepare() {
+	local paginate_requested="$1"
+	local unsupported="$2"
+	local method="$3"
+	local fields_requested="$4"
+	local method_explicit="$5"
+	local jq_requested="$6"
+	local template_requested="$7"
+
+	[[ "$paginate_requested" -eq 1 ]] || return 1
+	[[ "$unsupported" -eq 0 ]] || return 1
+	[[ "$method" == "GET" ]] || return 1
+	if [[ "$fields_requested" -eq 1 && "$method_explicit" -ne 1 ]]; then
+		# Native gh changes its default method to POST when fields are present.
+		# Only an explicit GET proves these fields belong in the query string.
+		return 1
+	fi
+	if [[ "$_GHRP_SLURP_REQUESTED" -eq 1 && ("$jq_requested" -eq 1 || "$template_requested" -eq 1) ]]; then
+		# Native gh rejects --slurp with --jq/--template before transport. Let the
+		# native CLI preserve its exact diagnostic without recording a request.
+		_GHRP_PREFLIGHT_ONLY=1
+		return 1
+	fi
+	if [[ "$_GHRP_SLURP_REQUESTED" -eq 1 ]]; then
+		[[ "$_GHRP_INCLUDE_REQUESTED" -eq 0 && "$_GHRP_SILENT_REQUESTED" -eq 0 ]] || return 1
+		command -v jq >/dev/null 2>&1 || return 1
+	fi
+	[[ "$_GHRP_SILENT_REQUESTED" -eq 0 ]] || return 1
+	_ghrp_find_endpoint_index || return 1
+	[[ "$_GHRP_ENDPOINT" != "graphql" && "$_GHRP_ENDPOINT" != graphql/* ]] || return 1
+	return 0
+}
+
 _ghrp_prepare() {
 	local path="$1"
 	shift
@@ -87,6 +121,7 @@ _ghrp_prepare() {
 	_GHRP_SILENT_REQUESTED=0
 	_GHRP_HOSTNAME="${GH_HOST:-github.com}"
 	_GHRP_BASE_ENDPOINT_INDEX=-1
+	_GHRP_PREFLIGHT_ONLY=0
 	[[ "$path" == "rest" ]] || return 1
 	[[ "${AIDEVOPS_GH_EXPLICIT_PAGINATION_DISABLE:-0}" != "1" ]] || return 1
 
@@ -147,21 +182,8 @@ _ghrp_prepare() {
 	done
 
 	[[ -z "$expect_value" ]] || return 1
-	[[ "$paginate_requested" -eq 1 ]] || return 1
-	[[ "$unsupported" -eq 0 ]] || return 1
-	[[ "$method" == "GET" ]] || return 1
-	if [[ "$fields_requested" -eq 1 && "$method_explicit" -ne 1 ]]; then
-		# Native gh changes its default method to POST when fields are present.
-		# Only an explicit GET proves these fields belong in the query string.
-		return 1
-	fi
-	if [[ "$_GHRP_SLURP_REQUESTED" -eq 1 ]]; then
-		[[ "$jq_requested" -eq 0 && "$template_requested" -eq 0 && "$_GHRP_INCLUDE_REQUESTED" -eq 0 && "$_GHRP_SILENT_REQUESTED" -eq 0 ]] || return 1
-		command -v jq >/dev/null 2>&1 || return 1
-	fi
-	[[ "$_GHRP_SILENT_REQUESTED" -eq 0 ]] || return 1
-	_ghrp_find_endpoint_index || return 1
-	[[ "$_GHRP_ENDPOINT" != "graphql" && "$_GHRP_ENDPOINT" != graphql/* ]] || return 1
+	_ghrp_validate_prepare "$paginate_requested" "$unsupported" "$method" \
+		"$fields_requested" "$method_explicit" "$jq_requested" "$template_requested" || return 1
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -474,9 +474,16 @@ printf '%s\n' "$@" >>"$NATIVE_ATTEMPT_LOG"
 page=1
 jq_requested=0
 expect_jq=0
+slurp_requested=0
+template_requested=0
+expect_template=0
 for arg in "$@"; do
 	if [[ "$expect_jq" -eq 1 ]]; then
 		expect_jq=0
+		continue
+	fi
+	if [[ "$expect_template" -eq 1 ]]; then
+		expect_template=0
 		continue
 	fi
 	case "$arg" in
@@ -484,6 +491,13 @@ for arg in "$@"; do
 		jq_requested=1
 		expect_jq=1
 		;;
+	--jq=* | -q*) jq_requested=1 ;;
+	--slurp) slurp_requested=1 ;;
+	--template | -t)
+		template_requested=1
+		expect_template=1
+		;;
+	--template=* | -t*) template_requested=1 ;;
 	*)
 		if [[ "$arg" =~ (^|[?\&])page=([0-9]+)($|\&) ]]; then
 			page="${BASH_REMATCH[2]}"
@@ -491,6 +505,11 @@ for arg in "$@"; do
 		;;
 	esac
 done
+if [[ "${NATIVE_REJECT_SLURP_FILTERS:-0}" == "1" && "$slurp_requested" -eq 1 \
+	&& ("$jq_requested" -eq 1 || "$template_requested" -eq 1) ]]; then
+	printf 'the --slurp option is not supported with --jq or --template\n' >&2
+	exit "${NATIVE_PREFLIGHT_STATUS:-1}"
+fi
 if [[ "${NATIVE_PAGINATED_RESPONSE:-0}" == "1" ]]; then
 	printf 'HTTP/2.0 200 OK\r\n'
 	if [[ "$page" -eq 1 ]]; then
@@ -564,6 +583,38 @@ PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
 "${PARENT_DIR}/gh-api-instrument.sh" report "$AIDEVOPS_GH_API_REPORT" >/dev/null 2>&1
 assert_eq "pagination rollback retains native flag" "1" "$(grep -c -- '^--paginate$' "$NATIVE_ATTEMPT_LOG")"
 assert_eq "pagination rollback remains honestly opaque" "1" "$(jq -r '._meta.opaque_paginated_attempts' "$AIDEVOPS_GH_API_REPORT")"
+
+# Native gh rejects --slurp combined with --jq or --template before issuing an
+# HTTP request. Preserve that CLI validation result without misclassifying the
+# native process invocation as an opaque transport attempt.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+preflight_jq_rc=0
+preflight_jq_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_REJECT_SLURP_FILTERS=1 \
+	"$SHIM_FIXTURE/gh" api --method GET --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' -f state=open \
+	--slurp --jq '.' 2>&1) || preflight_jq_rc=$?
+preflight_template_rc=0
+preflight_template_output=$(PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	NATIVE_REJECT_SLURP_FILTERS=1 \
+	"$SHIM_FIXTURE/gh" api --paginate \
+	'/repos/private-owner/private-repo/issues?per_page=100' --slurp --template '{{.}}' 2>&1) || preflight_template_rc=$?
+"${PARENT_DIR}/gh-api-instrument.sh" report "$AIDEVOPS_GH_API_REPORT" >/dev/null 2>&1
+assert_eq "slurp/jq native preflight exit is preserved" "1" "$preflight_jq_rc"
+assert_eq "slurp/template native preflight exit is preserved" "1" "$preflight_template_rc"
+assert_eq "native CLI still validates both invalid invocations" "2" "$(grep -c '^api$' "$NATIVE_ATTEMPT_LOG")"
+assert_eq "invalid pagination combinations retain logical events" "2" "$(awk -F'\t' '$9 == "logical" { count++ } END { print count + 0 }' "$AIDEVOPS_GH_API_LOG")"
+assert_eq "invalid pagination combinations record zero transport attempts" "0" "$(jq -r '._meta.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "invalid pagination combinations create no opaque attempts" "0" "$(jq -r '._meta.opaque_paginated_attempts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "invalid pagination combinations preserve exactness" "true" "$(jq -r '._meta.attempts_exact' "$AIDEVOPS_GH_API_REPORT")"
+if [[ "$preflight_jq_output" == *"not supported with --jq or --template"* &&
+	"$preflight_template_output" == *"not supported with --jq or --template"* ]]; then
+	echo "  PASS: native preflight diagnostics are preserved"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: native preflight diagnostics changed"
+	FAIL=$((FAIL + 1))
+fi
 
 # Streaming jq remains page-local, matching native gh pagination semantics.
 rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"


### PR DESCRIPTION
## Summary

- Preserve native `gh api` validation for incompatible `--slurp` plus `--jq`/`--template` combinations.
- Keep the logical routing event while recording zero HTTP transport attempts for these preflight-only failures.
- Cover the observed explicit-GET/query-field invocation and the template variant with exactness regressions.

## Context

Generation 7 surfaced one opaque native pagination event. Aggregate-safe investigation traced it to native `gh` rejecting incompatible formatting flags before network transport, while the shim had counted the native process as an opaque request. This repair separates CLI validation from transport accounting; a fresh observation window is still required before accepting #27769.

## Files

- `.agents/scripts/gh`: bypass transport instrumentation for a classified native preflight-only invocation.
- `.agents/scripts/gh-rest-pagination-lib.sh`: classify the incompatible native pagination flags without changing the native diagnostic or exit status.
- `.agents/scripts/tests/test-gh-api-instrument.sh`: assert logical-event retention, zero attempts, zero opacity, and exact aggregate state.

## Verification

- `bash .agents/scripts/tests/test-gh-api-instrument.sh` — 113 passed, 0 failed.
- `.agents/scripts/linters-local.sh --changed` — all local checks passed.
- Native dependency verified with GitHub CLI 2.96.0; its local validation diagnostic was reproduced without issuing a request.

For #27769

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.147 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 12h 49m and 2,796,680 tokens on this with the user in an interactive session.