### PR TITLE
GH#28116: Handle missing HOME in runtime status

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-status-lib.sh
@@ -153,8 +153,8 @@ _status_bundle_manifest_value() {
 }
 
 _status_active_bundle_version() {
-	local active_version="${HOME:-}/.aidevops/agents/VERSION"
-	if [[ -r "$active_version" ]]; then
+	local active_version="${HOME:+$HOME/.aidevops/agents/VERSION}"
+	if [[ -n "$active_version" && -r "$active_version" ]]; then
 		tr -d '[:space:]' <"$active_version"
 		return 0
 	fi
@@ -163,28 +163,35 @@ _status_active_bundle_version() {
 }
 
 _status_runtime_bundle_integrity() {
-	local active_link="${HOME:-}/.aidevops/agents"
+	local active_link="${HOME:+$HOME/.aidevops/agents}"
 	local active_root=""
+	local bundles_dir="${HOME:+$HOME/.aidevops/runtime-bundles}"
 	local bundles_root=""
 	local manifest_file=""
 	local active_version=""
 	local manifest_status=""
 	local manifest_version=""
 	local manifest_sha=""
+	local deployed_sha_file="${HOME:+$HOME/.aidevops/.deployed-sha}"
 	local deployed_sha=""
+
+	if [[ -z "$active_link" ]]; then
+		print_warning "Active runtime bundle mismatch: HOME is not set"
+		return 0
+	fi
 
 	if [[ ! -L "$active_link" ]]; then
 		print_warning "Active runtime bundle mismatch: agents path is not an activation symlink"
 		return 0
 	fi
 	active_root=$(cd "$active_link" 2>/dev/null && pwd -P) || active_root=""
-	bundles_root=$(cd "${HOME:-}/.aidevops/runtime-bundles" 2>/dev/null && pwd -P) || bundles_root=""
+	bundles_root=$(cd "$bundles_dir" 2>/dev/null && pwd -P) || bundles_root=""
 	manifest_file="$active_root/.bundle-manifest"
 	[[ -r "$active_root/VERSION" ]] && active_version=$(tr -d '[:space:]' <"$active_root/VERSION" 2>/dev/null) || active_version=""
 	[[ -r "$manifest_file" ]] && manifest_status=$(_status_bundle_manifest_value "$manifest_file" status) || manifest_status=""
 	[[ -r "$manifest_file" ]] && manifest_version=$(_status_bundle_manifest_value "$manifest_file" framework_version) || manifest_version=""
 	[[ -r "$manifest_file" ]] && manifest_sha=$(_status_bundle_manifest_value "$manifest_file" git_sha) || manifest_sha=""
-	[[ -r "${HOME:-}/.aidevops/.deployed-sha" ]] && deployed_sha=$(tr -d '[:space:]' <"${HOME}/.aidevops/.deployed-sha" 2>/dev/null) || deployed_sha=""
+	[[ -n "$deployed_sha_file" && -r "$deployed_sha_file" ]] && deployed_sha=$(tr -d '[:space:]' <"$deployed_sha_file" 2>/dev/null) || deployed_sha=""
 
 	if [[ -z "$bundles_root" || "$active_root" != "$bundles_root/"*/agents || "$manifest_status" != "validated" ||
 		-z "$active_version" || -z "$manifest_version" || -z "$manifest_sha" || -z "$deployed_sha" ||

--- a/.agents/scripts/tests/test-status-runtime-bundle-integrity.sh
+++ b/.agents/scripts/tests/test-status-runtime-bundle-integrity.sh
@@ -68,5 +68,27 @@ if [[ "$output" != *"Active runtime bundle mismatch"* || "$output" != *"manifest
 	exit 1
 fi
 
+unset HOME
+if [[ "$(_status_active_bundle_version)" != "stale-process-version" ]]; then
+	printf 'FAIL: unset HOME did not fall back to the process version\n' >&2
+	exit 1
+fi
+output=$(_status_runtime_bundle_integrity)
+if [[ "$output" != *"HOME is not set"* ]]; then
+	printf 'FAIL: unset HOME did not produce a safe integrity warning: %s\n' "$output" >&2
+	exit 1
+fi
+
+HOME=""
+if [[ "$(_status_active_bundle_version)" != "stale-process-version" ]]; then
+	printf 'FAIL: empty HOME did not fall back to the process version\n' >&2
+	exit 1
+fi
+output=$(_status_runtime_bundle_integrity)
+if [[ "$output" != *"HOME is not set"* ]]; then
+	printf 'FAIL: empty HOME did not produce a safe integrity warning: %s\n' "$output" >&2
+	exit 1
+fi
+
 printf '%s\n' 'PASS: status resolves the active bundle and exposes metadata mismatch'
 exit 0


### PR DESCRIPTION
## Summary

Guard runtime bundle status paths when HOME is unset or empty, preventing unbound-variable and accidental root-path resolution; add regression coverage for both cases.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-status-lib.sh, .agents/scripts/tests/test-status-runtime-bundle-integrity.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash and bash -u status bundle integrity regression tests; ShellCheck; changed-file local linter suite

Resolves #28116


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 3m and 48,972 tokens on this as a headless worker.