### PR TITLE
GH#28119: Propagate worktree issue identity into ownership registry

### DIFF
--- a/.agents/scripts/tests/test-worktree-fresh-base.sh
+++ b/.agents/scripts/tests/test-worktree-fresh-base.sh
@@ -81,4 +81,23 @@ PINNED_PATH="${WORKTREES}/canonical-test-pinned-base"
 }
 printf 'PASS immutable explicit base permits audited offline recovery\n'
 
+REGISTRY_DB="${HOME}/.aidevops/.agent-workspace/worktree-registry.db"
+PINNED_OWNER=$(sqlite3 -separator '|' "$REGISTRY_DB" \
+	"SELECT branch, task_id FROM worktree_owners WHERE branch = 'test/pinned-base';")
+[[ "$PINNED_OWNER" == "test/pinned-base|" ]] || {
+	printf 'FAIL worktree without --issue registered unexpected owner row %s\n' "${PINNED_OWNER:-<missing>}"
+	exit 1
+}
+printf 'PASS worktree without --issue retains an empty registry task ID\n'
+
+(cd "$CANONICAL" && AIDEVOPS_SKIP_AUTO_CLAIM=1 "$HELPER" add test/issue-task \
+	--issue 123 --base "$PINNED_SHA" >/dev/null)
+ISSUE_OWNER=$(sqlite3 -separator '|' "$REGISTRY_DB" \
+	"SELECT branch, task_id FROM worktree_owners WHERE branch = 'test/issue-task';")
+[[ "$ISSUE_OWNER" == "test/issue-task|123" ]] || {
+	printf 'FAIL explicit --issue registered unexpected owner row %s\n' "${ISSUE_OWNER:-<missing>}"
+	exit 1
+}
+printf 'PASS explicit --issue propagates into the registry task ID\n'
+
 exit 0

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -898,8 +898,9 @@ cmd_add() {
 	# Create worktree (existing branch → simple checkout; new branch → base-ref dance).
 	_cmd_add_create_worktree "$branch" "$path" "$explicit_base" || return 1
 
-	# Register ownership (t189)
-	register_worktree "$path" "$branch"
+	# Register ownership (t189). Preserve the explicit issue identity so a
+	# same-task headless continuation can safely reclaim this worktree.
+	register_worktree "$path" "$branch" --task "$explicit_issue"
 
 	# Restore gitignored dependencies (node_modules) from canonical repo.
 	local _repo_root=""


### PR DESCRIPTION
## Summary

- Pass `worktree-helper.sh add --issue NNN` through to the ownership registry's existing `--task` field.
- Preserve the current empty task ID when callers omit `--issue`.
- Add integration coverage using an isolated repository, worktree base, HOME, and registry database.

## Why

The helper already retained the explicit issue for interactive GitHub claiming but dropped it during `register_worktree`. Headless same-task ownership transfer checks the registry task before reclaiming a clean live-owned worktree, so the empty field could block scheduled continuation despite the original `--issue` argument.

## Files

- `.agents/scripts/worktree-helper-add.sh`: propagate `explicit_issue` through `register_worktree --task`.
- `.agents/scripts/tests/test-worktree-fresh-base.sh`: verify both explicit and omitted issue identity in the isolated registry.

## Verification

- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin bash .agents/scripts/tests/test-worktree-fresh-base.sh` — passed.
- ShellCheck and Bash syntax checks — passed.
- `.agents/scripts/linters-local.sh --changed` — all required local checks passed.

Resolves #28119

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.147 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 13h 36m and 3,042,976 tokens on this with the user in an interactive session.