### PR TITLE
feat: allow per-project canonical Git guard opt-out

### DIFF
--- a/.agents/configs/aidevops-config.schema.json
+++ b/.agents/configs/aidevops-config.schema.json
@@ -256,6 +256,11 @@
           "default": true,
           "description": "Install git pre-commit and pre-push safety hooks."
         },
+        "canonical_git_guard": {
+          "type": "boolean",
+          "default": true,
+          "description": "Keep the canonical-worktree Git mutation guard enabled. Set false only in an untracked local .aidevops.json project config; tracked config is ignored for this safety opt-out."
+        },
         "verification_enabled": {
           "type": "boolean",
           "default": true,

--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -13,6 +14,7 @@ from pathlib import Path
 from typing import Callable
 
 BLOCK_EXIT = 42
+PROJECT_CONFIG_NAME = ".aidevops.json"
 READ_ONLY = {
     "status",
     "diff",
@@ -97,6 +99,37 @@ def _is_canonical(real_git_path: str, cwd: str, git_prefix: list[str]) -> bool:
         and common_dir
         and os.path.realpath(git_dir) == os.path.realpath(common_dir)
     )
+
+
+def _project_disables_canonical_guard(real_git_path: str, cwd: str) -> bool:
+    """Return whether an untracked local project config opts out of the guard."""
+    repo_root = _git_output(real_git_path, cwd, "rev-parse", "--show-toplevel")
+    if not repo_root:
+        return False
+
+    config_path = Path(repo_root) / PROJECT_CONFIG_NAME
+    if not config_path.is_file():
+        return False
+
+    # A tracked file could arrive from an untrusted clone. Only a local config
+    # may opt out of this safety control.
+    if _git_output(
+        real_git_path,
+        repo_root,
+        "ls-files",
+        "--error-unmatch",
+        "--",
+        PROJECT_CONFIG_NAME,
+    ):
+        return False
+
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    safety = config.get("safety") if isinstance(config, dict) else None
+    return isinstance(safety, dict) and safety.get("canonical_git_guard") is False
 
 
 def _split_invocation(
@@ -269,6 +302,8 @@ def classify_git_argv(
     else:
         if not is_canonical:
             result = True, "linked worktree or non-repository target"
+        elif _project_disables_canonical_guard(real_git_path, effective_cwd):
+            result = True, "canonical Git guard disabled by untracked local project configuration"
         elif _is_allowed_canonical(subcommand, args):
             result = True, "read-only canonical operation or linked-worktree creation"
         else:

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -126,6 +126,12 @@ assert_allowed "allows canonical symbolic-ref query" "$REPO" "git symbolic-ref r
 assert_allowed "allows canonical short symbolic-ref query" "$REPO" "git symbolic-ref --short refs/remotes/origin/HEAD"
 assert_allowed "allows reordered canonical symbolic-ref query flags" "$REPO" "git symbolic-ref refs/remotes/origin/HEAD --quiet --short"
 assert_allowed "allows canonical non-recursive symbolic-ref query" "$REPO" "git symbolic-ref --no-recurse refs/remotes/origin/HEAD"
+printf '{"safety":{"canonical_git_guard":false}}\n' >"${REPO}/.aidevops.json"
+assert_allowed "allows canonical mutation when untracked project config disables guard" "$REPO" "git add README.md"
+git -C "$REPO" add .aidevops.json
+assert_blocked "ignores tracked project config attempting to disable guard" "git add README.md"
+git -C "$REPO" reset -- .aidevops.json
+rm -f "${REPO}/.aidevops.json"
 assert_allowed "allows canonical worktree creation" "$REPO" "git worktree add '$LINKED' -b feature/example"
 git -C "$REPO" worktree add -q -b feature/example "$LINKED"
 assert_allowed "allows normal Git mutation in linked worktree" "$LINKED" "git switch -c feature/linked-child"

--- a/.agents/scripts/tests/test-command-policy-helper.sh
+++ b/.agents/scripts/tests/test-command-policy-helper.sh
@@ -255,6 +255,13 @@ test_canonical_delegation() {
 	git -C "$repo" add README.md
 	git -C "$repo" commit -q -m seed
 	assert_decision "forbids canonical branch mutation through canonical guard" "git branch -m main renamed" forbid git.canonical-worktree 20 "$repo"
+	printf '{"safety":{"canonical_git_guard":false}}\n' >"${repo}/.aidevops.json"
+	assert_decision "allows canonical mutation from untracked project guard opt-out" "git add README.md" allow command.default-allow 0 "$repo"
+	git -C "$repo" add .aidevops.json
+	assert_decision "rejects tracked project guard opt-out" "git add README.md" forbid git.canonical-worktree 20 "$repo"
+	git -C "$repo" reset -- .aidevops.json
+	rm -f "${repo}/.aidevops.json"
+
 	git -C "$repo" worktree add -q -b feature/test "$linked"
 	assert_decision "allows linked-worktree branch creation" "git switch -c feature/child" allow command.default-allow 0 "$linked"
 	assert_decision "forbids generic Git destructive operation in linked worktree" "git reset --hard HEAD" forbid git.reset-destructive 20 "$linked"

--- a/README.md
+++ b/README.md
@@ -340,6 +340,22 @@ This creates:
 
 **Available features:** `planning`, `git-workflow`, `code-quality`, `time-tracking`, `beads`
 
+### Per-project canonical Git guard
+
+The canonical-worktree Git guard is enabled by default. To opt out for one
+local project, add this to that project's **untracked** `.aidevops.json`:
+
+```json
+{
+  "safety": {
+    "canonical_git_guard": false
+  }
+}
+```
+
+Tracked configuration is deliberately ignored for this opt-out, so a cloned
+repository cannot disable the local safety control.
+
 ### Per-repo platform setup
 
 After `aidevops init` registers a new repo, run `/setup-git` in your AI assistant


### PR DESCRIPTION
## Summary

- add `safety.canonical_git_guard` as a per-project `.aidevops.json` option
- honor `false` only for an untracked local config, preventing cloned repositories from disabling the guard
- cover the guard shim and shared command-policy path, and document the configuration

## Verification

- `python3 -m py_compile .agents/scripts/canonical_git_policy.py`
- `.agents/scripts/tests/test-canonical-git-command-guard.sh`
- `.agents/scripts/tests/test-command-policy-helper.sh`
- `.agents/scripts/linters-local.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.147 plugin for [OpenCode](https://opencode.ai) v1.18.3
