### PR TITLE
GH#27983: record portable audit lock owner PID

### DIFF
--- a/.agents/scripts/audit-log-helper.sh
+++ b/.agents/scripts/audit-log-helper.sh
@@ -360,7 +360,21 @@ _audit_acquire_lock() {
 		sleep 0.1
 	done
 
-	local owner_pid="${BASHPID:-$$}"
+	local owner_pid="${BASHPID:-}"
+	if [[ -z "$owner_pid" ]]; then
+		# Bash 3.2 has no BASHPID. Run the fallback as the command-substitution
+		# process itself so the child shell sees this lock holder as its PPID;
+		# without exec it can report an intermediate command-substitution PID.
+		owner_pid="$(exec sh -c 'printf "%s" "$PPID"')" || {
+			_audit_remove_lock_dir "$lock_dir" || true
+			return 1
+		}
+	fi
+	if [[ ! "$owner_pid" =~ ^[0-9]+$ ]]; then
+		_audit_remove_lock_dir "$lock_dir" || true
+		_audit_error "Could not determine audit log lock owner PID"
+		return 1
+	fi
 	local created_at=""
 	created_at="$(date '+%s')" || {
 		_audit_remove_lock_dir "$lock_dir" || true

--- a/.agents/scripts/tests/test-audit-log-concurrency.sh
+++ b/.agents/scripts/tests/test-audit-log-concurrency.sh
@@ -129,6 +129,8 @@ SIGNAL_READY="${TEST_ROOT}/signal.ready"
 (
 	# Keep shared-constants from replacing this Bash 3.2 fixture process.
 	export AIDEVOPS_BASH_REEXECED=1
+	# Force the Bash 3.2 fallback under newer Bash versions.
+	unset BASHPID
 	# shellcheck disable=SC1090
 	source "$HELPER"
 	_audit_acquire_lock "$SIGNAL_LOCK_DIR"
@@ -147,6 +149,12 @@ for attempt in $(seq 1 50); do
 	sleep 0.1
 done
 if [[ -f "$SIGNAL_READY" && -d "$SIGNAL_LOCK_DIR" ]]; then
+	IFS=' ' read -r signal_owner_pid _ <"${SIGNAL_LOCK_DIR}/owner"
+	if [[ "$signal_owner_pid" == "$signal_pid" ]]; then
+		pass "Bash 3.2 fallback records the lock-holding subshell PID"
+	else
+		fail "Bash 3.2 fallback recorded PID ${signal_owner_pid}, expected ${signal_pid}"
+	fi
 	kill -TERM "$signal_pid"
 	signal_rc=0
 	wait "$signal_pid" || signal_rc=$?


### PR DESCRIPTION
## Summary

Replace the unsafe Bash 3.2 lock-owner fallback with an exec-based PPID probe and verify the recorded PID matches the real lock-holding subshell.

## Files Changed

.agents/scripts/audit-log-helper.sh, .agents/scripts/tests/test-audit-log-concurrency.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean; audit concurrency suite passed all 16 checks

Resolves #27983


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 49m and 348,245 tokens on this with the user in an interactive session.