### PR TITLE
GH#28111: classify Ruby-only changes as complexity-applicable

### DIFF
--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -55,6 +55,8 @@ SCRIPT_NAME=$(basename "$0")
 TMP_DIR=""
 BASE_WORKTREE=""
 HEAD_WORKTREE=""
+COMPLEXITY_APPLICABLE_EXTENSIONS="sh py rb md"
+COMPLEXITY_APPLICABLE_EXTENSION_REGEX="\\.(${COMPLEXITY_APPLICABLE_EXTENSIONS// /|})$"
 
 cleanup() {
 	if [ -n "$BASE_WORKTREE" ] && [ -d "$BASE_WORKTREE" ]; then
@@ -200,6 +202,19 @@ _filter_to_abs_paths() {
 	done <<<"$_filter"
 
 	[ -n "$_output" ] && printf '%s\n' "$_output"
+	return 0
+}
+
+applicable_extensions_markdown() {
+	local _extension
+	local _output=""
+	for _extension in $COMPLEXITY_APPLICABLE_EXTENSIONS; do
+		if [ -n "$_output" ]; then
+			_output="${_output}/"
+		fi
+		_output="${_output}\`.${_extension}\`"
+	done
+	printf '%s' "$_output"
 	return 0
 }
 
@@ -967,11 +982,11 @@ _check_dry_run() {
 # Scan base+head via worktrees, compute diff, optionally write report.
 # Exits 0 (no regression), 1 (regression), or 2 (error).
 #
-# Diff-scoped optimisation (t2827): computes the list of .sh/.py/.md files that
-# changed between base and head and passes it to scan_dir so each worktree
+# Diff-scoped optimisation (t2827): computes applicable source and Markdown
+# files changed between base and head and passes them to scan_dir so each worktree
 # scan covers only those files instead of the full repo. This reduces
 # wall-clock time from ~98s to <10s for a 2-file diff (949 .sh files → 2).
-# If no .sh/.py/.md files changed, exits 0 immediately without creating worktrees.
+# If no applicable files changed, exits 0 immediately without creating worktrees.
 # The `scan` subcommand (CI full-repo path) is unaffected.
 # ---------------------------------------------------------------------------
 _check_regression() {
@@ -988,23 +1003,23 @@ _check_regression() {
 		_changed_source=$({
 			git diff --name-only "$_base_sha" -- 2>/dev/null || true
 			git ls-files --others --exclude-standard 2>/dev/null || true
-		} | grep -E '\.(sh|py|md)$' | sort -u || true)
+		} | grep -E "$COMPLEXITY_APPLICABLE_EXTENSION_REGEX" | sort -u || true)
 	else
-		_changed_source=$(git diff --name-only "$_base_sha" "$_head_sha" 2>/dev/null \
-			| grep -E '\.(sh|py|md)$' || true)
+		_changed_source=$(git diff --name-only "$_base_sha" "$_head_sha" 2>/dev/null |
+			grep -E "$COMPLEXITY_APPLICABLE_EXTENSION_REGEX" || true)
 	fi
 	if [ -z "$_changed_source" ]; then
 		log "[$_metric] no applicable changes between ${_base_sha:0:7}..${_head_sha:0:7} — skipping"
 		# Write a clean "no applicable changes" report so any previously-posted
-		# stale report (from a prior run with .sh/.py/.md changes that were later
+		# stale report (from a prior run with applicable changes that were later
 		# reverted back to doc-only) is replaced via the CI upsert path.
 		if [ -n "$_output_md" ]; then
-			local _title_str
+			local _title_str _extensions_markdown
 			_title_str=$(metric_title "$_metric")
+			_extensions_markdown=$(applicable_extensions_markdown)
 			{
 				printf '## %s Regression Gate\n\n' "$_title_str"
-				# shellcheck disable=SC2016
-				printf '✅ **No applicable changes** — no `.sh`/`.py`/`.md` files changed in this PR.\n\n'
+				printf '✅ **No applicable changes** — no %s files changed in this PR.\n\n' "$_extensions_markdown"
 				printf '<!-- complexity-regression-gate:%s -->\n' "$_metric"
 			} >"$_output_md"
 			log "[$_metric] wrote no-changes report to $_output_md"

--- a/.agents/scripts/tests/test-complexity-regression-helper.sh
+++ b/.agents/scripts/tests/test-complexity-regression-helper.sh
@@ -598,8 +598,8 @@ test_diff_scoped_timing() {
 # ---------------------------------------------------------------------------
 # Test 15: diff-scoped skip — non-source diff exits 0 (t2827)
 #
-# When the diff between base and head contains no .sh, .py, or .md files, the
-# check subcommand should exit 0 immediately and report the applicable types.
+# When the diff contains no applicable source or Markdown files, the check
+# subcommand should exit 0 immediately and report the applicable types.
 # ---------------------------------------------------------------------------
 test_diff_scoped_skip_no_sh_changes() {
 	setup
@@ -618,7 +618,7 @@ test_diff_scoped_skip_no_sh_changes() {
 	local _base_sha
 	_base_sha=$(git -C "$_repo" rev-parse HEAD)
 
-	# Head commit: only a non-source file changed (no .sh/.py/.md)
+	# Head commit: only a non-source file changed
 	printf 'hello\n' >"$_repo/fixture.txt"
 	git -C "$_repo" add fixture.txt
 	git -C "$_repo" commit -q -m "head: fixture only"
@@ -630,11 +630,42 @@ test_diff_scoped_skip_no_sh_changes() {
 
 	# Literal Markdown backticks are intentional.
 	# shellcheck disable=SC2016
-	if [ "$_rc" -eq 0 ] && grep -Fq 'no `.sh`/`.py`/`.md` files changed' "$_report"; then
+	if [ "$_rc" -eq 0 ] && grep -Fq 'no `.sh`/`.py`/`.rb`/`.md` files changed' "$_report"; then
 		print_result "diff-scoped skip: non-source diff reports all applicable types" 0
 	else
 		print_result "diff-scoped skip: non-source diff reports all applicable types" 1 \
-			"expected exit 0 and .sh/.py/.md report text, got exit $_rc"
+			"expected exit 0 and complete applicable-extension report text, got exit $_rc"
+	fi
+	teardown
+	return 0
+}
+
+test_diff_scoped_ruby_change_is_applicable() {
+	setup
+	local _repo="$TEST_ROOT/repo"
+	local _base_sha=""
+	local _rc=0
+	local _report="$_repo/report.md"
+	mkdir -p "$_repo"
+	git -C "$_repo" init -q
+	printf 'base\n' >"$_repo/README.md"
+	git -C "$_repo" add README.md
+	git -C "$_repo" -c user.email=test@test.local -c user.name=Test \
+		-c commit.gpgsign=false commit -q -m "base"
+	_base_sha=$(git -C "$_repo" rev-parse HEAD)
+	printf 'puts "hello"\n' >"$_repo/app.rb"
+	git -C "$_repo" add app.rb
+	git -C "$_repo" -c user.email=test@test.local -c user.name=Test \
+		-c commit.gpgsign=false commit -q -m "head: Ruby source"
+
+	(cd "$_repo" && "$HELPER" check --base "$_base_sha" --metric function-complexity \
+		--output-md "$_report") >/dev/null 2>&1 || _rc=$?
+	if [ "$_rc" -eq 0 ] && grep -Fq 'No regression' "$_report" &&
+		! grep -Fq 'No applicable changes' "$_report"; then
+		print_result "diff-scoped classifier: Ruby-only change is applicable" 0
+	else
+		print_result "diff-scoped classifier: Ruby-only change is applicable" 1 \
+			"expected Ruby source to run the regression comparison, got exit $_rc"
 	fi
 	teardown
 	return 0
@@ -691,6 +722,7 @@ test_bash32_clean_to_new
 test_bash32_stable
 test_diff_scoped_timing
 test_diff_scoped_skip_no_sh_changes
+test_diff_scoped_ruby_change_is_applicable
 test_working_tree_101_line_function_blocks
 
 printf '\n'


### PR DESCRIPTION
## Summary

Add Ruby to the centralized set of complexity-applicable extensions so Ruby-only pushes run the regression comparison instead of being reported as documentation-only.

## Files Changed

.agents/scripts/complexity-regression-helper.sh, .agents/scripts/tests/test-complexity-regression-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Local linters passed; ShellCheck and shfmt passed; complexity regression helper suite passed all 17 tests, including Ruby-only and docs-only fixtures.

Resolves #28111


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 17m and 683,373 tokens on this with the user in an interactive session.