### PR TITLE
GH#28102: fix systemd ExecStart command quoting

### DIFF
--- a/.agents/scripts/routine-helper.sh
+++ b/.agents/scripts/routine-helper.sh
@@ -9,6 +9,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=setup/modules/schedulers-linux.sh
+source "${SCRIPT_DIR}/setup/modules/schedulers-linux.sh"
 
 readonly DEFAULT_AGENT="Build+"
 readonly DEFAULT_TITLE="Scheduled routine"
@@ -435,7 +437,7 @@ After=network.target
 [Service]
 Type=oneshot
 KillMode=process
-ExecStart=/bin/bash -lc $(printf '%q' "$command")
+ExecStart=/bin/bash -lc $(_systemd_escape "$command")
 Environment=HOME=${HOME}
 Environment=PATH=${PATH}
 StandardOutput=append:${log_file}

--- a/.agents/scripts/tests/test-routine-systemd-calendar.sh
+++ b/.agents/scripts/tests/test-routine-systemd-calendar.sh
@@ -99,6 +99,32 @@ test_step_minutes_supported() {
 	return 0
 }
 
+test_execstart_uses_systemd_quoting() {
+	local tmp_home=""
+	local service_file=""
+	local exec_start=""
+	local expected=""
+	tmp_home=$(mktemp -d)
+	service_file="${tmp_home}/.config/systemd/user/sh.aidevops.routine-test.service"
+
+	HOME="$tmp_home" "$ROUTINE_HELPER" install-systemd \
+		--name test \
+		--schedule '0 9 * * *' \
+		--dir "$tmp_home" \
+		--prompt 'test prompt' >/dev/null 2>&1
+	exec_start=$(grep '^ExecStart=' "$service_file")
+	expected="ExecStart=/bin/bash -lc \"opencode run --dir '${tmp_home}' --agent 'Build+' --title 'Scheduled routine' 'test prompt'\""
+
+	if [[ "$exec_start" == "$expected" ]]; then
+		print_result "ExecStart keeps the shell command as one systemd argument" 0
+	else
+		print_result "ExecStart keeps the shell command as one systemd argument" 1 \
+			"Expected: $expected; got: $exec_start"
+	fi
+	rm -rf "$tmp_home"
+	return 0
+}
+
 test_daily_expression_supported() {
 	local output=""
 	output=$("${REPO_SCRIPTS_DIR}/routine-schedule-helper.sh" systemd-calendar 'daily(@03:30)')
@@ -145,6 +171,7 @@ main() {
 	test_wildcard_weekday_omits_prefix
 	test_numeric_weekday_keeps_prefix
 	test_step_minutes_supported
+	test_execstart_uses_systemd_quoting
 	test_daily_expression_supported
 	test_pulse_step_minutes_supported
 	test_empty_schedule_fails_cleanly


### PR DESCRIPTION
## Summary

Use the shared systemd escaping helper for routine service ExecStart values instead of shell printf %q, preserving the full bash -lc command as one correctly quoted systemd argument.

## Files Changed

.agents/scripts/routine-helper.sh, .agents/scripts/tests/test-routine-systemd-calendar.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Local linters, ShellCheck, and shfmt passed; routine systemd calendar suite passed 7/7 including the generated ExecStart regression assertion; systemd-analyze test was unavailable on macOS and skipped.

Resolves #28102


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 22m and 719,389 tokens on this with the user in an interactive session.