### PR TITLE
GH#28122: fix: preserve host process temp directories

### DIFF
--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -24,10 +24,65 @@ _legacy_temp_artifact_is_active() {
 	return $?
 }
 
+_legacy_opencode_native_is_attributable() {
+	local path="$1"
+	local symbols=""
+	command -v nm >/dev/null 2>&1 || return 1
+	symbols=$(nm -D -g "$path" 2>/dev/null) || return 1
+	grep -Eq '(^|[[:space:]])fff_create_instance2?$' <<<"$symbols" || return 1
+	grep -Eq '(^|[[:space:]])fff_destroy$' <<<"$symbols" || return 1
+	grep -Eq '(^|[[:space:]])fff_search$' <<<"$symbols" || return 1
+	return 0
+}
+
+_legacy_opencode_native_has_no_holder() {
+	local path="$1"
+	local lsof_status=0
+	command -v lsof >/dev/null 2>&1 || return 1
+	lsof "$path" >/dev/null 2>&1 || lsof_status=$?
+	[[ "$lsof_status" -eq 1 ]] || return 1
+	return 0
+}
+
+_cleanup_legacy_opencode_native_artifacts() {
+	local workspace_root="${AIDEVOPS_WORKSPACE_DIR:-${HOME:?}/.aidevops/.agent-workspace}"
+	local root="${AIDEVOPS_TEMP_DIR:-${workspace_root}/tmp}"
+	[[ -d "$root" ]] || return 0
+	root=$(cd "$root" && pwd -P) || return 0
+
+	local now=""
+	now=$(date +%s)
+	local max_age="${AIDEVOPS_TEMP_MAX_AGE_SECONDS:-604800}"
+	[[ "$max_age" =~ ^[0-9]+$ ]] || max_age=604800
+	local uid=""
+	uid=$(id -u)
+	local cleaned=0
+	local candidate=""
+	for candidate in "$root"/.*-00000000.so; do
+		[[ -f "$candidate" && ! -L "$candidate" ]] || continue
+		local owner=""
+		owner=$(stat -f '%u' "$candidate" 2>/dev/null) || owner=$(stat -c '%u' "$candidate" 2>/dev/null) || continue
+		[[ "$owner" == "$uid" ]] || continue
+		local mtime=""
+		mtime=$(_file_mtime_epoch "$candidate") || continue
+		((now - mtime > max_age)) || continue
+		_legacy_opencode_native_is_attributable "$candidate" || continue
+		_legacy_opencode_native_has_no_holder "$candidate" || continue
+		rm -f -- "$candidate" || continue
+		((++cleaned))
+	done
+
+	if ((cleaned > 0)); then
+		print_info "Cleaned $cleaned stale OpenCode FFF native temporary artifact(s)"
+	fi
+	return 0
+}
+
 # Remove only directly attributable aidevops artifacts from the macOS per-user
 # temporary root. Generic tmp.* entries are intentionally excluded because
 # their ownership cannot be proven after creation.
 cleanup_legacy_aidevops_temp_artifacts() {
+	_cleanup_legacy_opencode_native_artifacts
 	local root="${AIDEVOPS_LEGACY_TEMP_ROOT:-}"
 	if [[ -z "$root" ]]; then
 		[[ "$(uname -s 2>/dev/null || true)" == "$MIGRATION_PLATFORM_DARWIN" ]] || return 0

--- a/.agents/scripts/shared-temp-workspace.sh
+++ b/.agents/scripts/shared-temp-workspace.sh
@@ -3,7 +3,8 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 # Route framework-owned temporary files away from the host-wide temporary
-# directory. Call this only at managed session/runtime entry points.
+# directory without changing the process scratch lifecycle used by runtimes
+# and third-party libraries. Call this only at managed session entry points.
 aidevops_init_temp_workspace() {
 	local workspace_root="${AIDEVOPS_WORKSPACE_DIR:-${HOME:?}/.aidevops/.agent-workspace}"
 	local temp_root="${workspace_root}/tmp"
@@ -12,9 +13,6 @@ aidevops_init_temp_workspace() {
 	chmod 700 "$temp_root" 2>/dev/null || true
 	temp_root=$(cd "$temp_root" && pwd -P) || return 1
 
-	export TMPDIR="$temp_root"
-	export TMP="$temp_root"
-	export TEMP="$temp_root"
 	export AIDEVOPS_TEMP_DIR="$temp_root"
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -203,6 +203,31 @@ test_runtime_temp_files_use_managed_workspace() {
 	return 0
 }
 
+test_headless_temp_initialization_preserves_process_scratch() {
+	local TMPDIR="/host/tmpdir"
+	local TMP="/host/tmp"
+	local TEMP="/host/temp"
+	local AIDEVOPS_WORKSPACE_DIR="${HOME}/.aidevops/.agent-workspace"
+	local expected=""
+
+	aidevops_init_temp_workspace || {
+		print_result "headless initialization preserves process scratch" 1 "Could not initialize managed temp workspace"
+		return 0
+	}
+	expected=$(cd "$AIDEVOPS_WORKSPACE_DIR/tmp" && pwd -P)
+
+	if [[ "$TMPDIR" == "/host/tmpdir" && "$TMP" == "/host/tmp" && "$TEMP" == "/host/temp" ]] &&
+		[[ "$AIDEVOPS_TEMP_DIR" == "$expected" ]] &&
+		grep -q 'aidevops_init_temp_workspace' "$HELPER_SCRIPT"; then
+		print_result "headless initialization preserves process scratch" 0
+		return 0
+	fi
+
+	print_result "headless initialization preserves process scratch" 1 \
+		"TMPDIR=$TMPDIR TMP=$TMP TEMP=$TEMP AIDEVOPS_TEMP_DIR=${AIDEVOPS_TEMP_DIR:-<unset>}"
+	return 0
+}
+
 test_startup_no_activity_timeout_returns_watchdog_continue() {
 	local output_file="${TEST_ROOT}/startup-stall.log"
 	printf '%s\n' 'sqlite-migration:done' >"$output_file"
@@ -3554,6 +3579,7 @@ main() {
 	test_parse_initial_model_does_not_set_explicit_override
 	test_launch_helpers_tolerate_unset_state_under_nounset
 	test_runtime_temp_files_use_managed_workspace
+	test_headless_temp_initialization_preserves_process_scratch
 	test_startup_no_activity_timeout_returns_watchdog_continue
 	test_startup_no_activity_can_rotate_after_continuation_budget
 	test_sigkill_with_activity_attempts_continuation

--- a/.agents/scripts/tests/test-managed-temp-workspace.sh
+++ b/.agents/scripts/tests/test-managed-temp-workspace.sh
@@ -29,18 +29,23 @@ source "$SCRIPTS_DIR/shared-temp-workspace.sh"
 HOME="$TEST_ROOT/home"
 mkdir -p "$HOME"
 unset AIDEVOPS_WORKSPACE_DIR
-TMPDIR="/host/tmp"
-TMP="/host/tmp"
-TEMP="/host/tmp"
+export TMPDIR="/host/tmpdir"
+export TMP="/host/tmp"
+export TEMP="/host/temp"
 aidevops_init_temp_workspace
 expected=$(cd "$HOME/.aidevops/.agent-workspace/tmp" && pwd -P)
-assert "initializer overrides TMPDIR" test "$TMPDIR" = "$expected"
-assert "initializer aligns TMP" test "$TMP" = "$expected"
-assert "initializer aligns TEMP" test "$TEMP" = "$expected"
+assert "initializer preserves host TMPDIR" test "$TMPDIR" = "/host/tmpdir"
+assert "initializer preserves host TMP" test "$TMP" = "/host/tmp"
+assert "initializer preserves host TEMP" test "$TEMP" = "/host/temp"
 assert "initializer exports the canonical aidevops temp directory" test "$AIDEVOPS_TEMP_DIR" = "$expected"
 assert "managed temp directory exists" test -d "$expected"
 managed_temp_file=$(mktemp "$AIDEVOPS_TEMP_DIR/aidevops-test.XXXXXX")
 assert "canonical temp directory supports managed artifacts" test "${managed_temp_file#"$expected"/}" != "$managed_temp_file"
+unset TMPDIR TMP TEMP
+aidevops_init_temp_workspace
+assert "initializer leaves absent TMPDIR unset" test -z "${TMPDIR+x}"
+assert "initializer leaves absent TMP unset" test -z "${TMP+x}"
+assert "initializer leaves absent TEMP unset" test -z "${TEMP+x}"
 
 runtime_artifact_files=(
 	"$SCRIPTS_DIR/../AGENTS.md"
@@ -60,6 +65,17 @@ print_info() { return 0; }
 print_warning() { return 0; }
 FRAMEWORK_PROCESS_PATTERN='opencode|aidevops'
 _is_process_alive_and_matches() { return 1; }
+nm() {
+	local path="${*: -1}"
+	[[ "$path" != *not-fff* ]] || return 1
+	printf '00000000 T fff_create_instance2\n00000000 T fff_destroy\n00000000 T fff_search\n'
+	return 0
+}
+lsof() {
+	local path="$1"
+	[[ "$path" == *held* ]] && return 0
+	return 1
+}
 # shellcheck source=../portable-stat.sh
 source "$SCRIPTS_DIR/portable-stat.sh"
 # shellcheck source=../setup/modules/migrations.sh
@@ -72,10 +88,20 @@ old_generic="$legacy_root/tmp.not-owned"
 new_named="$legacy_root/aidevops-canary.new"
 mkdir -p "$old_named" "$old_generic" "$new_named"
 touch -t 202001010000 "$old_named" "$old_generic"
+stale_fff="$expected/.stale-00000000.so"
+held_fff="$expected/.held-00000000.so"
+not_fff="$expected/.not-fff-00000000.so"
+recent_fff="$expected/.recent-00000000.so"
+touch "$stale_fff" "$held_fff" "$not_fff" "$recent_fff"
+touch -t 202001010000 "$stale_fff" "$held_fff" "$not_fff"
 AIDEVOPS_LEGACY_TEMP_ROOT="$legacy_root" AIDEVOPS_TEMP_MAX_AGE_SECONDS=60 cleanup_legacy_aidevops_temp_artifacts
 assert "old named aidevops artifact is removed" test ! -e "$old_named"
 assert "generic tmp artifact is preserved" test -d "$old_generic"
 assert "recent named artifact is preserved" test -d "$new_named"
+assert "stale attributable FFF artifact without holders is removed" test ! -e "$stale_fff"
+assert "held FFF artifact is preserved" test -f "$held_fff"
+assert "non-attributable native artifact is preserved" test -f "$not_fff"
+assert "recent FFF artifact is preserved" test -f "$recent_fff"
 
 assert "setup invokes legacy cleanup in both modes" test "$(grep -c 'cleanup_legacy_aidevops_temp_artifacts' "$SCRIPTS_DIR/../../setup.sh")" -ge 2
 

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -40,6 +40,10 @@ if [[ -n "${FAKE_OPENCODE_LOG:-}" ]]; then
 fi
 printf 'XDG_DATA_HOME=%s\n' "${XDG_DATA_HOME:-}"
 printf 'AIDEVOPS_OPENCODE_ISOLATED_DB=%s\n' "${AIDEVOPS_OPENCODE_ISOLATED_DB:-}"
+printf 'AIDEVOPS_TEMP_DIR=%s\n' "${AIDEVOPS_TEMP_DIR:-}"
+printf 'TMPDIR=%s\n' "${TMPDIR:-}"
+printf 'TMP=%s\n' "${TMP:-}"
+printf 'TEMP=%s\n' "${TEMP:-}"
 printf 'PWD=%s\n' "$PWD"
 printf 'ARGS=%s\n' "$*"
 SH
@@ -84,8 +88,11 @@ printf 'ARGS=%s\n' "$*"
 SH
 chmod +x "${desktop_source}"
 
-output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" FAKE_OPENCODE_LOG="${fake_log}" \
+output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    AIDEVOPS_WORKSPACE_DIR="${home_dir}/.aidevops/.agent-workspace" FAKE_OPENCODE_LOG="${fake_log}" \
+    TMPDIR="/host/tmpdir" TMP="/host/tmp" TEMP="/host/temp" \
     "${HELPER}" --dir "${launch_dir}" -- --version 2>&1)
+expected_temp=$(cd "${home_dir}/.aidevops/.agent-workspace/tmp" && pwd -P)
 line_count=0
 prewarm_line=""
 project_auth_count=0
@@ -101,6 +108,10 @@ for auth_file in "${work_dir}"/opencode-interactive/project-repo-*/opencode/auth
 done
 if [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]] \
     && [[ "${output}" == *"XDG_DATA_HOME=${work_dir}/opencode-interactive/project-repo-"* ]] \
+    && [[ "${output}" == *"AIDEVOPS_TEMP_DIR=${expected_temp}"* ]] \
+    && [[ "${output}" == *"TMPDIR=/host/tmpdir"* ]] \
+    && [[ "${output}" == *"TMP=/host/tmp"* ]] \
+    && [[ "${output}" == *"TEMP=/host/temp"* ]] \
     && [[ "${output}" == *"PWD=${launch_dir}"* ]] \
     && [[ "${project_auth_count}" == "1" ]] \
     && [[ "${line_count}" == "2" ]] \


### PR DESCRIPTION
## Summary

Implementation for issue #28122.

## Files Changed

.agents/scripts/setup/modules/migrations.sh, .agents/scripts/shared-temp-workspace.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-managed-temp-workspace.sh, .agents/scripts/tests/test-opencode-launcher-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #28122


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 55m and 1,093,368 tokens on this with the user in an interactive session.