### PR TITLE
GH#28104: fix: avoid large approval JSON in argv

### DIFF
--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -7,6 +7,29 @@
 _APPROVAL_SNAPSHOT_V2_LOADED=1
 APPROVAL_TARGET_ISSUE="issue"
 
+_approval_snapshot_v2_create_temp_dir() {
+	local root="${AIDEVOPS_TEMP_DIR:-${HOME:?}/.aidevops/.agent-workspace/tmp}"
+	local temp_dir=""
+	(umask 077 && mkdir -p "$root") || return 1
+	chmod 700 "$root" 2>/dev/null || return 1
+	temp_dir=$(mktemp -d "$root/approval-snapshot-v2.XXXXXX") || return 1
+	chmod 700 "$temp_dir" 2>/dev/null || {
+		rm -rf "$temp_dir"
+		return 1
+	}
+	printf '%s\n' "$temp_dir"
+	return 0
+}
+
+_approval_snapshot_v2_write_json_file() {
+	local path="$1"
+	local json="$2"
+	(umask 077 && printf '%s' "$json" >"$path") || return 1
+	chmod 600 "$path" 2>/dev/null || return 1
+	jq -e . "$path" >/dev/null 2>&1 || return 1
+	return 0
+}
+
 _approval_snapshot_v2_fetch_pages() {
 	local endpoint="$1"
 	local pages=""
@@ -137,13 +160,14 @@ _approval_snapshot_v2_reviews_json() {
 	return $?
 }
 
-approval_snapshot_v2_build() {
+approval_snapshot_v2_build() (
 	local target_type="$1"
 	local target_number="$2"
 	local slug="$3"
 	local excluded_comment_id="${4:-}"
 	local issue_json="" comments_pages="" comments_json="" timeline_pages="" linked_references_json="" normalized_slug=""
 	local empty_string=""
+	local temp_dir=""
 
 	[[ "$target_type" == "$APPROVAL_TARGET_ISSUE" || "$target_type" == "pr" ]] || return 1
 	[[ "$target_number" =~ ^[0-9]+$ && "$slug" == */* ]] || return 1
@@ -161,11 +185,17 @@ approval_snapshot_v2_build() {
 	comments_json=$(_approval_snapshot_v2_comments_json "$comments_pages" "$excluded_comment_id" "conversation") || return 1
 	timeline_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/timeline?per_page=100") || return 1
 	linked_references_json=$(_approval_snapshot_v2_linked_references_json "$timeline_pages") || return 1
+	temp_dir=$(_approval_snapshot_v2_create_temp_dir) || return 1
+	trap 'rm -rf "$temp_dir"' EXIT
+	_approval_snapshot_v2_write_json_file "$temp_dir/issue.json" "$issue_json" || return 1
+	_approval_snapshot_v2_write_json_file "$temp_dir/comments.json" "$comments_json" || return 1
+	_approval_snapshot_v2_write_json_file "$temp_dir/linked-references.json" "$linked_references_json" || return 1
 
 	if [[ "$target_type" == "$APPROVAL_TARGET_ISSUE" ]]; then
 		jq -cS -n --arg repo "$normalized_slug" --arg empty "$empty_string" --arg issue_kind "$APPROVAL_TARGET_ISSUE" --argjson number "$target_number" \
-			--argjson issue "$issue_json" --argjson comments "$comments_json" \
-			--argjson linked_references "$linked_references_json" '
+			--slurpfile issue_input "$temp_dir/issue.json" --slurpfile comments_input "$temp_dir/comments.json" \
+			--slurpfile linked_references_input "$temp_dir/linked-references.json" '
+			($issue_input[0]) as $issue |
 			{
 				schema: "aidevops-approval-snapshot/v2",
 				target: {kind: $issue_kind, repository: $repo, number: $number, id: $issue.id, node_id: $issue.node_id},
@@ -177,8 +207,8 @@ approval_snapshot_v2_build() {
 				created_at: ($issue.created_at // $empty),
 				title: ($issue.title // $empty),
 				body: ($issue.body // $empty),
-				comments: $comments,
-				linked_references: $linked_references
+				comments: $comments_input[0],
+				linked_references: $linked_references_input[0]
 			}
 		'
 		return $?
@@ -191,11 +221,15 @@ approval_snapshot_v2_build() {
 	review_comments_json=$(_approval_snapshot_v2_comments_json "$review_comment_pages" "" "review") || return 1
 	review_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/pulls/${target_number}/reviews?per_page=100") || return 1
 	reviews_json=$(_approval_snapshot_v2_reviews_json "$review_pages") || return 1
+	_approval_snapshot_v2_write_json_file "$temp_dir/pr.json" "$pr_json" || return 1
+	_approval_snapshot_v2_write_json_file "$temp_dir/review-comments.json" "$review_comments_json" || return 1
+	_approval_snapshot_v2_write_json_file "$temp_dir/reviews.json" "$reviews_json" || return 1
 
 	jq -cS -n --arg repo "$normalized_slug" --arg empty "$empty_string" --argjson number "$target_number" \
-		--argjson issue "$issue_json" --argjson pr "$pr_json" \
-		--argjson comments "$comments_json" --argjson review_comments "$review_comments_json" \
-		--argjson reviews "$reviews_json" --argjson linked_references "$linked_references_json" '
+		--slurpfile issue_input "$temp_dir/issue.json" --slurpfile pr_input "$temp_dir/pr.json" \
+		--slurpfile comments_input "$temp_dir/comments.json" --slurpfile review_comments_input "$temp_dir/review-comments.json" \
+		--slurpfile reviews_input "$temp_dir/reviews.json" --slurpfile linked_references_input "$temp_dir/linked-references.json" '
+		($issue_input[0]) as $issue | ($pr_input[0]) as $pr |
 		{
 			schema: "aidevops-approval-snapshot/v2",
 			target: {kind: "pr", repository: $repo, number: $number, id: $pr.id, node_id: $pr.node_id, issue_id: $issue.id},
@@ -215,14 +249,14 @@ approval_snapshot_v2_build() {
 				ref: $pr.base.ref,
 				repository_id: ($pr.base.repo.id // null), repository: (($pr.base.repo.full_name // $repo) | ascii_downcase)
 			},
-			comments: $comments,
-			review_comments: $review_comments,
-			reviews: $reviews,
-			linked_references: $linked_references
+			comments: $comments_input[0],
+			review_comments: $review_comments_input[0],
+			reviews: $reviews_input[0],
+			linked_references: $linked_references_input[0]
 		}
 	'
 	return $?
-}
+)
 
 approval_snapshot_v2_digest() {
 	local snapshot_json="$1"
@@ -240,19 +274,24 @@ approval_snapshot_v2_digest() {
 	return 0
 }
 
-approval_snapshot_v2_payload() {
+approval_snapshot_v2_payload() (
 	local target_type="$1"
 	local target_number="$2"
 	local slug="$3"
 	local issued_at="$4"
 	local excluded_comment_id="${5:-}"
 	local snapshot_json="" digest="" normalized_slug=""
+	local temp_dir=""
 
 	snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$excluded_comment_id") || return 1
 	digest=$(approval_snapshot_v2_digest "$snapshot_json") || return 1
 	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
+	temp_dir=$(_approval_snapshot_v2_create_temp_dir) || return 1
+	trap 'rm -rf "$temp_dir"' EXIT
+	_approval_snapshot_v2_write_json_file "$temp_dir/snapshot.json" "$snapshot_json" || return 1
 	jq -cS -n --arg type "$target_type" --arg repo "$normalized_slug" --argjson number "$target_number" \
-		--arg issued "$issued_at" --arg digest "$digest" --argjson snapshot "$snapshot_json" '
+		--arg issued "$issued_at" --arg digest "$digest" --slurpfile snapshot_input "$temp_dir/snapshot.json" '
+		($snapshot_input[0]) as $snapshot |
 		{
 			schema: "aidevops-approval/v2",
 			authority: (if $type == "pr" then "merge" else "development" end),
@@ -269,4 +308,4 @@ approval_snapshot_v2_payload() {
 		}
 	'
 	return $?
-}
+)

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -209,20 +209,28 @@ test_snapshot_temp_permissions() {
 	return 0
 }
 
+write_large_fixture_body() {
+	local path="$1"
+	local fill_character="$2"
+	python3 - "$path" "$fill_character" <<'PY'
+import json
+import sys
+
+path, fill_character = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+payload[0][0]["body"] = fill_character * 2200000
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+	return $?
+}
+
 test_large_snapshots_avoid_argv_limits() {
 	local AIDEVOPS_TEMP_DIR="${TEST_ROOT}/managed-temp-large"
 	local payload="" issue_digest="" pr_head=""
 	write_baseline_fixtures
-	python3 - "$FIXTURES/comments-41.json" <<'PY'
-import json
-import sys
-path = sys.argv[1]
-with open(path, encoding="utf-8") as handle:
-    payload = json.load(handle)
-payload[0][0]["body"] = "i" * 2200000
-with open(path, "w", encoding="utf-8") as handle:
-    json.dump(payload, handle)
-PY
+	write_large_fixture_body "$FIXTURES/comments-41.json" i
 	payload=$(AIDEVOPS_TEMP_DIR="$AIDEVOPS_TEMP_DIR" PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload issue 41 owner/repo "2026-01-01T00:05:00Z") || true
 	issue_digest=$(printf '%s' "$payload" | jq -r 'select(.target.kind == "issue") | .snapshot_sha256' 2>/dev/null || true)
 	if [[ "$issue_digest" =~ ^[0-9a-f]{64}$ ]] && directory_is_empty "$AIDEVOPS_TEMP_DIR"; then
@@ -232,16 +240,7 @@ PY
 	fi
 
 	write_baseline_fixtures
-	python3 - "$FIXTURES/review-comments-42.json" <<'PY'
-import json
-import sys
-path = sys.argv[1]
-with open(path, encoding="utf-8") as handle:
-    payload = json.load(handle)
-payload[0][0]["body"] = "p" * 2200000
-with open(path, "w", encoding="utf-8") as handle:
-    json.dump(payload, handle)
-PY
+	write_large_fixture_body "$FIXTURES/review-comments-42.json" p
 	payload=$(AIDEVOPS_TEMP_DIR="$AIDEVOPS_TEMP_DIR" PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload pr 42 owner/repo "2026-01-01T00:05:00Z") || true
 	pr_head=$(printf '%s' "$payload" | jq -r '.pr.head_sha' 2>/dev/null || true)
 	if [[ "$pr_head" == "$PR_HEAD" ]] && directory_is_empty "$AIDEVOPS_TEMP_DIR"; then

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -185,9 +185,88 @@ reset_and_sign() {
 	return $?
 }
 
+file_mode() {
+	local path="$1"
+	stat -f '%Lp' "$path" 2>/dev/null || stat -c '%a' "$path" 2>/dev/null
+	return $?
+}
+
+test_snapshot_temp_permissions() {
+	local AIDEVOPS_TEMP_DIR="${TEST_ROOT}/managed-temp-permissions"
+	local temp_dir="" json_file=""
+	temp_dir=$(_approval_snapshot_v2_create_temp_dir) || {
+		print_result "snapshot staging uses a private managed temp directory" 1
+		return 0
+	}
+	json_file="$temp_dir/input.json"
+	_approval_snapshot_v2_write_json_file "$json_file" '{"ok":true}' || true
+	if [[ "$(file_mode "$AIDEVOPS_TEMP_DIR")" == "700" && "$(file_mode "$temp_dir")" == "700" && "$(file_mode "$json_file")" == "600" ]]; then
+		print_result "snapshot staging uses mode-700 directories and mode-600 files" 0
+	else
+		print_result "snapshot staging uses mode-700 directories and mode-600 files" 1
+	fi
+	rm -rf "$temp_dir"
+	return 0
+}
+
+test_large_snapshots_avoid_argv_limits() {
+	local AIDEVOPS_TEMP_DIR="${TEST_ROOT}/managed-temp-large"
+	local payload="" issue_digest="" pr_head=""
+	write_baseline_fixtures
+	python3 - "$FIXTURES/comments-41.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+payload[0][0]["body"] = "i" * 2200000
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+	payload=$(AIDEVOPS_TEMP_DIR="$AIDEVOPS_TEMP_DIR" PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload issue 41 owner/repo "2026-01-01T00:05:00Z") || true
+	issue_digest=$(printf '%s' "$payload" | jq -r 'select(.target.kind == "issue") | .snapshot_sha256' 2>/dev/null || true)
+	if [[ "$issue_digest" =~ ^[0-9a-f]{64}$ ]] && directory_is_empty "$AIDEVOPS_TEMP_DIR"; then
+		print_result "oversized issue approval avoids argv and cleans staging files" 0
+	else
+		print_result "oversized issue approval avoids argv and cleans staging files" 1
+	fi
+
+	write_baseline_fixtures
+	python3 - "$FIXTURES/review-comments-42.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+payload[0][0]["body"] = "p" * 2200000
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+	payload=$(AIDEVOPS_TEMP_DIR="$AIDEVOPS_TEMP_DIR" PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload pr 42 owner/repo "2026-01-01T00:05:00Z") || true
+	pr_head=$(printf '%s' "$payload" | jq -r '.pr.head_sha' 2>/dev/null || true)
+	if [[ "$pr_head" == "$PR_HEAD" ]] && directory_is_empty "$AIDEVOPS_TEMP_DIR"; then
+		print_result "oversized PR approval avoids argv and cleans staging files" 0
+	else
+		print_result "oversized PR approval avoids argv and cleans staging files" 1
+	fi
+	return 0
+}
+
+directory_is_empty() {
+	local directory="$1"
+	local candidate=""
+	[[ -d "$directory" ]] || return 1
+	for candidate in "$directory"/* "$directory"/.[!.]* "$directory"/..?*; do
+		[[ -e "$candidate" || -L "$candidate" ]] && return 1
+	done
+	return 0
+}
+
 main() {
 	install_gh_stub
 	write_baseline_fixtures
+	test_snapshot_temp_permissions
+	test_large_snapshots_avoid_argv_limits
 	ssh-keygen -t ed25519 -N '' -f "${TEST_ROOT}/approval.key" -q
 	cp "${TEST_ROOT}/approval.key.pub" "${TEST_ROOT}/approval.pub"
 


### PR DESCRIPTION
## Summary

Implementation for issue #28104.

## Files Changed

.agents/scripts/approval-snapshot-v2.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #28104


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 2h 9m and 1,348,842 tokens on this with the user in an interactive session.