### PR TITLE
GH#28140: Fix OpenCode Tabby status lifecycle across idle and permission waits

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-status.mjs
@@ -20,16 +20,22 @@ function isRootSessionInfo(info) {
 
 const ROOT_SESSION_STATUSES = new Set(["busy", "retry", "idle"]);
 
-function handleSessionCreated({ info, sessionID, state, resetState }) {
-  if (!isRootSessionInfo(info)) return;
+function activateRootSession({ sessionID, state, resetState, setTerminalTitleStatus }) {
   state.activeRootSessionID = sessionID;
   resetState();
+  setTerminalTitleStatus("idle");
 }
 
-function handleSessionUpdated({ info, sessionID, state, resetState }) {
+function handleSessionCreated(context) {
+  const { info } = context;
+  if (!isRootSessionInfo(info)) return;
+  activateRootSession(context);
+}
+
+function handleSessionUpdated(context) {
+  const { info, state } = context;
   if (state.activeRootSessionID || !isRootSessionInfo(info)) return;
-  state.activeRootSessionID = sessionID;
-  resetState();
+  activateRootSession(context);
 }
 
 function handleSessionDeleted({ sessionID, state, resetState }) {
@@ -56,6 +62,11 @@ function handleSessionStatus({ event, sessionID, state, setTerminalTitleStatus }
   setTerminalTitleStatus(status);
 }
 
+function handleSessionIdle({ sessionID, state, setTerminalTitleStatus }) {
+  if (sessionID !== state.activeRootSessionID || state.pendingPermissionIDs.size > 0) return;
+  setTerminalTitleStatus("idle");
+}
+
 function handlePermissionAsked({ event, sessionID, state, setTerminalTitleStatus }) {
   if (sessionID !== state.activeRootSessionID) return;
   const requestID = event.properties?.id;
@@ -66,7 +77,8 @@ function handlePermissionAsked({ event, sessionID, state, setTerminalTitleStatus
 
 function handlePermissionReplied({ event, sessionID, state, setTerminalTitleStatus }) {
   if (sessionID !== state.activeRootSessionID) return;
-  const wasPending = state.pendingPermissionIDs.delete(event.properties?.requestID);
+  const requestID = event.properties?.requestID || event.properties?.permissionID;
+  const wasPending = state.pendingPermissionIDs.delete(requestID);
   if (!wasPending || state.pendingPermissionIDs.size > 0) return;
   setTerminalTitleStatus("busy");
 }
@@ -77,7 +89,9 @@ const EVENT_HANDLERS = new Map([
   ["session.deleted", handleSessionDeleted],
   ["message.updated", handleMessageUpdated],
   ["session.status", handleSessionStatus],
+  ["session.idle", handleSessionIdle],
   ["permission.asked", handlePermissionAsked],
+  ["permission.updated", handlePermissionAsked],
   ["permission.replied", handlePermissionReplied],
 ]);
 

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -87,7 +87,7 @@ test("session status handler follows only the active interactive root session", 
   await handler(event("session.status", { sessionID: "root-2", status: { type: "idle" } }));
 
   assert.equal(resets, 2);
-  assert.deepEqual(statuses, ["busy", "permission", "busy", "retry", "idle", "idle"]);
+  assert.deepEqual(statuses, ["idle", "busy", "permission", "busy", "retry", "idle", "idle", "idle"]);
 });
 
 test("first root user message marks the session busy before native status", async () => {
@@ -119,7 +119,93 @@ test("first root user message marks the session busy before native status", asyn
     info: { id: "message-user-2", sessionID: "root-1", role: "user" },
   }));
 
-  assert.deepEqual(statuses, ["busy", "permission"]);
+  assert.deepEqual(statuses, ["idle", "busy", "permission"]);
+});
+
+test("legacy idle and permission events retain lifecycle status compatibility", async () => {
+  const statuses = [];
+  const handler = createSessionTitleStatusHandler({
+    isHeadless: () => false,
+    isEnabled: () => true,
+    setTerminalTitleStatus: (status) => statuses.push(status),
+  });
+
+  await handler(event("session.created", { info: { id: "root-legacy", title: "Legacy" } }));
+  await handler(event("session.idle", { sessionID: "root-legacy" }));
+  await handler(event("permission.updated", { id: "permission-legacy", sessionID: "root-legacy" }));
+  await handler(event("session.idle", { sessionID: "root-legacy" }));
+  await handler(event("permission.replied", {
+    permissionID: "permission-legacy",
+    response: "once",
+    sessionID: "root-legacy",
+  }));
+  await handler(event("session.idle", { sessionID: "root-legacy" }));
+
+  assert.deepEqual(statuses, ["idle", "idle", "permission", "busy", "idle"]);
+});
+
+test("permission status persists until current and legacy requests both reply", async () => {
+  const statuses = [];
+  const handler = createSessionTitleStatusHandler({
+    isHeadless: () => false,
+    isEnabled: () => true,
+    setTerminalTitleStatus: (status) => statuses.push(status),
+  });
+
+  await handler(event("session.created", { info: { id: "root-pending", title: "Pending" } }));
+  await handler(event("permission.asked", { id: "permission-current", sessionID: "root-pending" }));
+  await handler(event("permission.updated", { id: "permission-legacy", sessionID: "root-pending" }));
+  await handler(event("permission.replied", {
+    requestID: "permission-current",
+    reply: "once",
+    sessionID: "root-pending",
+  }));
+  await handler(event("session.status", { sessionID: "root-pending", status: { type: "idle" } }));
+  await handler(event("permission.replied", {
+    permissionID: "permission-legacy",
+    response: "once",
+    sessionID: "root-pending",
+  }));
+  await handler(event("session.idle", { sessionID: "root-pending" }));
+
+  assert.deepEqual(statuses, ["idle", "permission", "permission", "busy", "idle"]);
+});
+
+test("event lifecycle renders idle, busy, permission, and waiting titles end to end", async () => {
+  const writes = [];
+  const controller = createTerminalTitleController({
+    isEnabled: () => true,
+    writeTitle: (title) => writes.push(title),
+  });
+  const handler = createSessionTitleStatusHandler({
+    isHeadless: () => false,
+    isEnabled: () => true,
+    resetTerminalTitleState: () => controller.reset(),
+    setTerminalTitleStatus: (status) => controller.setStatus(status),
+  });
+
+  await handler(event("session.created", { info: { id: "root-e2e", title: "Lifecycle" } }));
+  controller.emit("Issue #123: lifecycle status");
+  await handler(event("message.updated", {
+    sessionID: "root-e2e",
+    info: { id: "message-user", sessionID: "root-e2e", role: "user" },
+  }));
+  await handler(event("permission.asked", { id: "permission-current", sessionID: "root-e2e" }));
+  await handler(event("session.status", { sessionID: "root-e2e", status: { type: "idle" } }));
+  await handler(event("permission.replied", {
+    requestID: "permission-current",
+    reply: "once",
+    sessionID: "root-e2e",
+  }));
+  await handler(event("session.status", { sessionID: "root-e2e", status: { type: "idle" } }));
+
+  assert.deepEqual(writes, [
+    "🟢 Issue #123: lifecycle status",
+    "⚪ Issue #123: lifecycle status",
+    "🟡 Issue #123: lifecycle status",
+    "⚪ Issue #123: lifecycle status",
+    "🟢 Issue #123: lifecycle status",
+  ]);
 });
 
 test("session status handler supports hot-loaded root sessions and ignores headless sessions", async () => {
@@ -150,5 +236,5 @@ test("session status handler supports hot-loaded root sessions and ignores headl
   await headlessHandler(event("session.status", { sessionID: "headless-root", status: { type: "idle" } }));
 
   assert.equal(resets, 1);
-  assert.deepEqual(statuses, ["busy"]);
+  assert.deepEqual(statuses, ["idle", "busy"]);
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- initialize OpenCode tab status for idle and legacy permission events (#28140)
+
 ## [3.32.147] - 2026-07-17
 
 ### Fixed


### PR DESCRIPTION
## Summary

Initialize interactive root tabs as idle and normalize current plus legacy idle and permission lifecycle events so Tabby titles reliably move through green, white, yellow, and red states.

## Files Changed

- `.agents/plugins/opencode-aidevops/session-title-status.mjs`
- `.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs`
- `CHANGELOG.md`

## Runtime Testing

- **Risk level:** High (event-driven lifecycle state machine)
- **Verification:** Runtime-verified with the event-to-terminal-title controller harness; focused lifecycle tests 9/9; complete OpenCode plugin suite 444/444; `.agents/scripts/linters-local.sh --changed` passed.

## Decisions

- Preserve immutable live runtime bundles; already-running OpenCode processes reload the status handler only after restart.
- Accept both current and legacy OpenCode lifecycle event schemas.
- Keep permission status authoritative until every pending request replies.

Resolves #28140

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 19m and 389,386 tokens on this with the user in an interactive session.
