### PR TITLE
GH#28097: fix: keep bundle detection cache outside repositories

### DIFF
--- a/.agents/scripts/bundle-helper.sh
+++ b/.agents/scripts/bundle-helper.sh
@@ -95,6 +95,7 @@ _resolve_bundles_dir() {
 
 REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 FALLBACK_BUNDLE="cli-tool"
+BUNDLE_CACHE_DIR="${AIDEVOPS_BUNDLE_CACHE_DIR:-${HOME}/.aidevops/cache/bundle}"
 
 # =============================================================================
 # Internal Utilities
@@ -149,60 +150,77 @@ _read_project_config_bundle() {
 	fi
 }
 
-# Read the cached detected bundle from .aidevops.json.
+_bundle_cache_file() {
+	local project_path="$1"
+	local path_digest=""
+	if command -v sha256sum >/dev/null 2>&1; then
+		path_digest=$(printf '%s' "$project_path" | sha256sum | awk '{print $1}') || return 1
+	elif command -v shasum >/dev/null 2>&1; then
+		path_digest=$(printf '%s' "$project_path" | shasum -a 256 | awk '{print $1}') || return 1
+	else
+		print_warning "Could not hash project path for bundle cache"
+		return 1
+	fi
+	printf '%s/%s.json' "$BUNDLE_CACHE_DIR" "$path_digest"
+	return 0
+}
+
+# Read an explicitly committed legacy detection, then the user-local cache.
 # Arguments:
 #   $1 - absolute project path
 # Output: cached bundle name(s) to stdout, empty if not cached
 _read_cached_detection() {
 	local project_path="$1"
 	local config_file="${project_path}/.aidevops.json"
+	local cached="" cache_file=""
 
 	if [[ -f "$config_file" ]]; then
-		jq -r '.detected_bundle // empty' "$config_file" 2>/dev/null || true
+		cached=$(jq -r '.detected_bundle // empty' "$config_file" 2>/dev/null) || cached=""
+		if [[ -n "$cached" ]]; then
+			printf '%s' "$cached"
+			return 0
+		fi
 	fi
+	cache_file=$(_bundle_cache_file "$project_path") || return 0
+	[[ -f "$cache_file" ]] || return 0
+	jq -r '.detected_bundle // empty' "$cache_file" 2>/dev/null || true
+	return 0
 }
 
-# Write detected bundle to .aidevops.json cache.
-# Creates the file if it doesn't exist; merges if it does.
+# Write detected bundle to a user-local cache outside the project checkout.
 # Arguments:
 #   $1 - absolute project path
 #   $2 - detected bundle name(s), comma-separated
 _write_cached_detection() {
 	local project_path="$1"
 	local detected="$2"
-	local config_file="${project_path}/.aidevops.json"
+	local cache_file=""
 	local timestamp
 	timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	cache_file=$(_bundle_cache_file "$project_path") || return 0
+	mkdir -p "$BUNDLE_CACHE_DIR" 2>/dev/null || {
+		print_warning "Could not create bundle cache directory ${BUNDLE_CACHE_DIR}"
+		return 0
+	}
+	chmod 700 "$BUNDLE_CACHE_DIR" 2>/dev/null || true
 
 	# Use atomic write (mktemp + mv) to prevent race conditions
 	local tmpfile
-	tmpfile=$(mktemp "${config_file}.XXXXXX") || {
-		print_warning "Could not create temp file for ${config_file}"
+	tmpfile=$(mktemp "${cache_file}.XXXXXX") || {
+		print_warning "Could not create temp file for ${cache_file}"
+		return 0
+	}
+	chmod 600 "$tmpfile" 2>/dev/null || true
+	jq -n --arg d "$detected" --arg t "$timestamp" \
+		'{detected_bundle: $d, detected_bundle_at: $t}' >"$tmpfile" 2>/dev/null || {
+		rm -f "$tmpfile"
+		print_warning "Could not create cache file ${cache_file}"
 		return 0
 	}
 
-	if [[ -f "$config_file" ]]; then
-		# Merge into existing file
-		jq --arg d "$detected" --arg t "$timestamp" \
-			'.detected_bundle = $d | .detected_bundle_at = $t' \
-			"$config_file" >"$tmpfile" 2>/dev/null || {
-			rm -f "$tmpfile"
-			print_warning "Could not update cache in ${config_file}"
-			return 0
-		}
-	else
-		# Create new file
-		jq -n --arg d "$detected" --arg t "$timestamp" \
-			'{detected_bundle: $d, detected_bundle_at: $t}' >"$tmpfile" 2>/dev/null || {
-			rm -f "$tmpfile"
-			print_warning "Could not create cache file ${config_file}"
-			return 0
-		}
-	fi
-
-	mv -f "$tmpfile" "$config_file" || {
+	mv -f "$tmpfile" "$cache_file" || {
 		rm -f "$tmpfile"
-		print_warning "Could not write cache file ${config_file}"
+		print_warning "Could not write cache file ${cache_file}"
 		return 0
 	}
 

--- a/.agents/scripts/tests/test-bundle-helper-readonly-cache.sh
+++ b/.agents/scripts/tests/test-bundle-helper-readonly-cache.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+export AIDEVOPS_BUNDLE_CACHE_DIR="${HOME}/.aidevops/cache/bundle"
+mkdir -p "$HOME"
+
+repo="${TEST_ROOT}/canonical-repo"
+mkdir -p "$repo"
+printf '{"plugins":[]}\n' >"${repo}/.aidevops.json"
+printf '{"name":"readonly-cache-test"}\n' >"${repo}/package.json"
+
+snapshot_repo() {
+	local target_repo="$1"
+	cksum <"${target_repo}/.aidevops.json"
+	cksum <"${target_repo}/package.json"
+	printf '%s\n' "${target_repo}"/* "${target_repo}"/.[!.]* | sort
+	return 0
+}
+
+before=$(snapshot_repo "$repo")
+"${SCRIPT_DIR}/bundle-helper.sh" detect --force "$repo" >/dev/null
+"${SCRIPT_DIR}/bundle-helper.sh" resolve --force "$repo" >/dev/null
+"${SCRIPT_DIR}/bundle-helper.sh" get model_defaults.implementation "$repo" >/dev/null
+"${SCRIPT_DIR}/bundle-helper.sh" show "$repo" >/dev/null
+after=$(snapshot_repo "$repo")
+
+if [[ "$before" != "$after" ]]; then
+	printf 'FAIL bundle helper changed canonical checkout bytes\n' >&2
+	exit 1
+fi
+
+cache_files=("${AIDEVOPS_BUNDLE_CACHE_DIR}"/*.json)
+if [[ ! -f "${cache_files[0]:-}" ]]; then
+	printf 'FAIL bundle helper did not write user-local cache\n' >&2
+	exit 1
+fi
+if [[ "$(stat -f '%Lp' "${cache_files[0]}" 2>/dev/null || stat -c '%a' "${cache_files[0]}")" != "600" ]]; then
+	printf 'FAIL bundle cache file is not mode 600\n' >&2
+	exit 1
+fi
+
+first_detection=$("${SCRIPT_DIR}/bundle-helper.sh" detect "$repo")
+second_detection=$("${SCRIPT_DIR}/bundle-helper.sh" detect "$repo")
+if [[ -z "$first_detection" || "$first_detection" != "$second_detection" ]]; then
+	printf 'FAIL bundle cache did not survive helper restart\n' >&2
+	exit 1
+fi
+
+printf 'PASS bundle helper caches outside canonical checkout and preserves byte identity\n'


### PR DESCRIPTION
## Summary

Implementation for issue #28097.

## Files Changed

.agents/scripts/bundle-helper.sh, .agents/scripts/tests/test-bundle-helper-readonly-cache.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #28097


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 3h 20m and 1,932,185 tokens on this with the user in an interactive session.