### PR TITLE
GH#28130: block merges on required human review threads

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -8,6 +8,7 @@ _PULSE_MERGE_REQUIRED_CHECKS_LOADED=1
 PMRC_CHECK_COMPLETED="completed"
 PMRC_CHECK_SUCCESS="success"
 PMRC_CHECK_FAILURE="failure"
+PMRC_BOOL_TRUE="true"
 PMRC_MAINTAINER_GATE="maintainer-gate"
 PMRC_MAINTAINER_GATE_DISPLAY="Maintainer Review & Assignee Gate"
 PMRC_MAINTAINER_GATE_WORKFLOW="gate / Maintainer Review & Assignee Gate"
@@ -140,10 +141,53 @@ _pmrc_snapshot_bot_activity_json() {
 	return 0
 }
 
+#######################################
+# Resolve whether active rulesets applying to a PR base branch require every
+# review thread to be resolved. GitHub exposes the effective rules for a branch,
+# so this does not rely on user-defined ruleset names or duplicate ref matching.
+#
+# Args: $1=repo_slug, $2=base_branch
+# Stdout: true or false
+# Returns: 0=requirement resolved, 1=API/parse error
+#######################################
+_pmrc_review_thread_resolution_required() {
+	local repo_slug="$1"
+	local base_branch="$2"
+	local encoded_branch="" rules_json="" required=""
+	local log_target="${LOGFILE:-/dev/stderr}"
+
+	[[ -n "$repo_slug" && -n "$base_branch" ]] || return 1
+	encoded_branch=$(jq -nr --arg branch "$base_branch" '$branch | @uri') || return 1
+	[[ -n "$encoded_branch" ]] || return 1
+	rules_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/rules/branches/${encoded_branch}" 2>/dev/null) || {
+		echo "[pulse-merge] pre-merge snapshot: effective rules fetch failed for ${repo_slug} branch ${base_branch} — failing closed (GH#28130)" >>"$log_target"
+		return 1
+	}
+	required=$(printf '%s' "$rules_json" | jq -r '
+		if type != "array" then error("effective rules response must be an array")
+		else [
+			.[]?
+			| select(.type == "pull_request")
+			| (.parameters?.required_review_thread_resolution? // false)
+		] | any
+		end
+	' 2>>"$log_target") || {
+		echo "[pulse-merge] pre-merge snapshot: effective rules parse failed for ${repo_slug} branch ${base_branch} — failing closed (GH#28130)" >>"$log_target"
+		return 1
+	}
+	case "$required" in
+	true | false) printf '%s\n' "$required" ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
 _pmrc_snapshot_review_threads_clear() {
 	local repo_slug="$1"
 	local pr_number="$2"
-	local owner="${repo_slug%%/*}" name="${repo_slug##*/}" response="" count="" has_next=""
+	local base_branch="$3"
+	local owner="${repo_slug%%/*}" name="${repo_slug##*/}" response="" counts="" has_next=""
+	local total_count="" bot_count="" resolution_required=""
 	local bot_re="coderabbitai|gemini-code-assist|augment-code|augmentcode|copilot"
 
 	# shellcheck disable=SC2016
@@ -164,14 +208,27 @@ _pmrc_snapshot_review_threads_clear() {
 	fi
 	has_next=$(printf '%s' "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false') || return 1
 	[[ "$has_next" == "false" ]] || return 1
-	count=$(printf '%s' "$response" | jq -r --arg bots "$bot_re" '[
-		.data.repository.pullRequest.reviewThreads.nodes[]?
-		| select((.isResolved // false) == false)
-		| select((.comments.nodes[0].author.login // "") | test($bots; "i"))
-	] | length') || return 1
-	[[ "$count" =~ ^[0-9]+$ ]] || return 1
-	if [[ "$count" -gt 0 ]]; then
-		echo "[pulse-merge] pre-merge snapshot: PR #${pr_number} in ${repo_slug} has ${count} unresolved review-bot thread(s) — merge blocked until resolved or classified (GH#27137)" >>"$LOGFILE"
+	counts=$(printf '%s' "$response" | jq -c --arg bots "$bot_re" '
+		[.data.repository.pullRequest.reviewThreads.nodes[]?
+		| select((.isResolved // false) == false)] as $unresolved
+		| {
+			total: ($unresolved | length),
+			bots: ([$unresolved[]
+				| select((.comments.nodes[0].author.login // "") | test($bots; "i"))
+			] | length)
+		}
+	') || return 1
+	total_count=$(jq -r '.total' <<<"$counts") || return 1
+	bot_count=$(jq -r '.bots' <<<"$counts") || return 1
+	[[ "$total_count" =~ ^[0-9]+$ && "$bot_count" =~ ^[0-9]+$ ]] || return 1
+	if [[ "$bot_count" -gt 0 ]]; then
+		echo "[pulse-merge] pre-merge snapshot: PR #${pr_number} in ${repo_slug} has ${bot_count} unresolved review-bot thread(s) — merge blocked until resolved or classified (GH#27137)" >>"$LOGFILE"
+		return 1
+	fi
+	[[ "$total_count" -gt 0 ]] || return 0
+	resolution_required=$(_pmrc_review_thread_resolution_required "$repo_slug" "$base_branch") || return 1
+	if [[ "$resolution_required" == "$PMRC_BOOL_TRUE" ]]; then
+		echo "[pulse-merge] pre-merge snapshot: PR #${pr_number} in ${repo_slug} has ${total_count} unresolved review thread(s), and branch ${base_branch} requires thread resolution — merge blocked (GH#28130)" >>"$LOGFILE"
 		return 1
 	fi
 	return 0
@@ -349,13 +406,13 @@ _pmrc_snapshot_checks_acceptable() {
 		if [[ "$family" == "$PMRC_MAINTAINER_GATE" ]]; then
 			echo "[pulse-merge] pre-merge snapshot: maintainer-gate family is terminal-${conclusion} for PR #${pr_number} in ${repo_slug}; aliases=${members}, required=${required} — merge blocked" >>"$LOGFILE"
 			blockers=$((blockers + 1))
-		elif [[ "$required" == "true" ]] &&
+		elif [[ "$required" == "$PMRC_BOOL_TRUE" ]] &&
 			declare -F _ci_check_url_has_infra_failure_log >/dev/null 2>&1 &&
 			_ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
 			_pmrc_rerun_infrastructure_check "$repo_slug" "$pr_number" "$name" "$link" || true
 			echo "[pulse-merge] pre-merge snapshot: required check '${name}' has a proven infrastructure failure for PR #${pr_number} in ${repo_slug} — code repair suppressed; merge blocked pending rerun" >>"$LOGFILE"
 			blockers=$((blockers + 1))
-		elif [[ "$required" == "true" ]]; then
+		elif [[ "$required" == "$PMRC_BOOL_TRUE" ]]; then
 			echo "[pulse-merge] pre-merge snapshot: required check '${name}' is terminal-${conclusion} for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
 			blocking_names="${blocking_names}${name}"$'\n'
 			blockers=$((blockers + 1))
@@ -448,11 +505,12 @@ _pulse_merge_preflight_snapshot_gate() {
 	local pr_number="$2"
 	local expected_head_sha="$3"
 	local live_gate_evidence="${_PULSE_REVIEW_GATE_EVIDENCE:-}"
-	local pr_json="" current_head_sha="" required_contexts="" checks_json="" activity_json=""
+	local pr_json="" current_head_sha="" base_branch="" required_contexts="" checks_json="" activity_json=""
 	_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON="[]"
 
 	pr_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || return 1
 	current_head_sha=$(jq -r '.head.sha // ""' <<<"$pr_json" 2>/dev/null) || return 1
+	base_branch=$(jq -r '.base.ref // ""' <<<"$pr_json" 2>/dev/null) || return 1
 	if [[ -z "$current_head_sha" || "$current_head_sha" != "$expected_head_sha" ]]; then
 		echo "[pulse-merge] pre-merge snapshot: head changed for PR #${pr_number} in ${repo_slug} (expected=${expected_head_sha:-unknown}, current=${current_head_sha:-unknown}) — prior gate state revoked (GH#27137)" >>"$LOGFILE"
 		return 1
@@ -462,10 +520,10 @@ _pulse_merge_preflight_snapshot_gate() {
 	activity_json=$(_pmrc_snapshot_bot_activity_json "$repo_slug" "$pr_number") || return 1
 	_pmrc_review_evidence_permits_advisory "$live_gate_evidence" "$repo_slug" "$pr_number" "$current_head_sha" || live_gate_evidence=""
 	_pmrc_snapshot_review_gate_fresh "$repo_slug" "$pr_number" "$checks_json" "$activity_json" "$live_gate_evidence" || return 1
-	_pmrc_snapshot_review_threads_clear "$repo_slug" "$pr_number" || return 1
+	_pmrc_snapshot_review_threads_clear "$repo_slug" "$pr_number" "$base_branch" || return 1
 	_pmrc_snapshot_checks_acceptable "$repo_slug" "$pr_number" "$checks_json" "$required_contexts" "$live_gate_evidence" "$current_head_sha" || return 1
 	_pmrc_snapshot_quiet_period_passes "$repo_slug" "$pr_number" "$checks_json" "$activity_json" || return 1
-	echo "[pulse-merge] pre-merge snapshot: current head ${current_head_sha:0:12}, fresh review gate, resolved bot threads, terminal checks, and quiet period verified for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
+	echo "[pulse-merge] pre-merge snapshot: current head ${current_head_sha:0:12}, fresh review gate, merge-policy-compatible review threads, terminal checks, and quiet period verified for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -47,6 +47,33 @@ _ci_check_url_has_infra_failure_log() {
 	return $?
 }
 
+stub_review_threads() {
+	if [[ "$SNAPSHOT_MODE" == "unresolved" ]]; then
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"}}]}}]}}}}}'
+	elif [[ "$SNAPSHOT_MODE" == human_* ]]; then
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"human-reviewer"}}]}}]}}}}}'
+	else
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}'
+	fi
+	return 0
+}
+
+stub_effective_rules() {
+	local endpoint="$1"
+	if [[ "$SNAPSHOT_MODE" == "human_rules_error" ]]; then
+		return 1
+	elif [[ "$SNAPSHOT_MODE" == "human_rules_malformed" ]]; then
+		printf '%s\n' '{"unexpected":"object"}'
+	elif [[ "$SNAPSHOT_MODE" == "human_required_slash" && "$endpoint" != "repos/owner/repo/rules/branches/release%2F1.x" ]]; then
+		return 1
+	elif [[ "$SNAPSHOT_MODE" == "human_required" || "$SNAPSHOT_MODE" == "human_required_slash" ]]; then
+		printf '%s\n' '[{"type":"pull_request","ruleset_source":"arbitrary-policy-name","parameters":{"required_review_thread_resolution":true}}]'
+	else
+		printf '%s\n' '[{"type":"pull_request","parameters":{"required_review_thread_resolution":false}}]'
+	fi
+	return 0
+}
+
 gh() {
 	local command="$1"
 	local endpoint="${2:-}"
@@ -57,21 +84,23 @@ gh() {
 	[[ "$command" == "api" ]] || return 1
 
 	if [[ "$endpoint" == "graphql" ]]; then
-		if [[ "$SNAPSHOT_MODE" == "unresolved" ]]; then
-			printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"}}]}}]}}}}}'
-		else
-			printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}'
-		fi
-		return 0
+		stub_review_threads
+		return $?
 	fi
 
 	case "$endpoint" in
 	repos/owner/repo/pulls/7)
 		if [[ "$SNAPSHOT_MODE" == "new_head" ]]; then
-			printf '%s\n' '{"head":{"sha":"sha-new"}}'
+			printf '%s\n' '{"head":{"sha":"sha-new"},"base":{"ref":"main"}}'
+		elif [[ "$SNAPSHOT_MODE" == "human_required_slash" ]]; then
+			printf '%s\n' '{"head":{"sha":"sha-reviewed"},"base":{"ref":"release/1.x"}}'
 		else
-			printf '%s\n' '{"head":{"sha":"sha-reviewed"}}'
+			printf '%s\n' '{"head":{"sha":"sha-reviewed"},"base":{"ref":"main"}}'
 		fi
+		;;
+	repos/owner/repo/rules/branches/*)
+		stub_effective_rules "$endpoint"
+		return $?
 		;;
 	*check-runs*)
 		local required_conclusion="success" required_url="" broad_status="completed" broad_conclusion="success"
@@ -155,6 +184,22 @@ assert_gate() {
 	fi
 	printf 'FAIL %s (expected rc=%s, actual rc=%s)\n' "$description" "$expected_rc" "$rc"
 	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_human_review_thread_rules() {
+	assert_gate "unresolved human thread blocks when effective rules require resolution" human_required 1
+	if grep -q "requires thread resolution" "$LOGFILE"; then
+		printf 'PASS required human thread blocker is audited\n'
+	else
+		printf 'FAIL required human thread blocker is audited\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
+	assert_gate "unresolved human thread passes when effective rules do not require resolution" human_not_required 0
+	assert_gate "required human thread supports slash-containing base branches" human_required_slash 1
+	assert_gate "effective-rules API failure with unresolved human thread fails closed" human_rules_error 1
+	assert_gate "malformed effective-rules response with unresolved human thread fails closed" human_rules_malformed 1
 	return 0
 }
 
@@ -289,6 +334,7 @@ main() {
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
 	assert_gate "unresolved late inline finding blocks merge" unresolved 1
+	assert_human_review_thread_rules
 	assert_gate "late review activity invalidates stale gate success" stale_gate 1
 	_PULSE_REVIEW_GATE_EVIDENCE=""
 	assert_gate "missing status gate fails closed without live evidence" no_status_gate 1

--- a/.agents/tests/test-pulse-merge-required-checks.sh
+++ b/.agents/tests/test-pulse-merge-required-checks.sh
@@ -84,8 +84,12 @@ test_snapshot_review_threads_fail_closed_on_missing_pr_data() {
 		"jq -e '.data.repository.pullRequest != null' >/dev/null"
 	_assert_not_contains_literal "review thread pagination does not hide jq diagnostics" \
 		"jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null"
-	_assert_contains_literal "review thread count preserves jq diagnostics" \
-		"] | length') || return 1"
+	_assert_contains_literal "review thread counts preserve jq diagnostics" \
+		"counts=\$(printf '%s' \"\$response\" | jq -c --arg bots \"\$bot_re\" '"
+	_assert_contains_literal "effective rules inspect the exact thread-resolution parameter" \
+		".parameters?.required_review_thread_resolution? // false"
+	_assert_not_contains_literal "thread-resolution policy does not rely on ruleset names" \
+		"thread.*resolut"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Inspect effective branch rules when human-authored review threads remain, and stop deterministic merge before GitHub rejects required unresolved conversations.

## Files Changed

`.agents/scripts/pulse-merge-required-checks.sh`, `.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh`, `.agents/tests/test-pulse-merge-required-checks.sh`

## Runtime Testing

- **Risk level:** High (deterministic merge state machine and GitHub API policy gate)
- **Verification:** Runtime-verified GitHub effective-rules schema; 41 preflight snapshot cases, 15 static required-check assertions, ShellCheck, and changed-file local linters pass.

Resolves #28130

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 9m and 447,126 tokens on this with the user in an interactive session. Overall, 3h 6m since this issue was created.
