### PR TITLE
t18159: feat: bound unreferenced runtime bundle storage

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -60,7 +60,7 @@ Reference, lease, recovery, and audit checks remain hard vetoes.
 
 | Store | Owner | Primary classes | Existing authority | Required next contract |
 |---|---|---|---|---|
-| `~/.aidevops/runtime-bundles` | framework | active, leased, rollback, cache | Deployment helper protects current, previous, and live-leased bundles; unleased bundles use an age threshold | Add byte/count visibility and bounded unreferenced convergence without weakening lease protection; assess immutable dependency reuse separately |
+| `~/.aidevops/runtime-bundles` | framework | active, leased, rollback, cache | Deployment protects current, previous, and live-leased bundles; unreferenced bundles converge under 30-day, 30-bundle, and 8 GiB soft limits | Keep the limits operator-configurable and preserve fail-closed reporting when references or sizing are unavailable |
 | `~/.aidevops/.agent-workspace/observability` | framework | audit, archive, cache | Runtime events are append-only evidence; plugin records runtime and tool-call data | Define the minimum audit envelope, payload/metadata limits, partition or archive semantics, and verified compaction rather than direct row deletion |
 | `~/.aidevops/agents-backups` | framework | rollback, archive | Count-based snapshot retention | Add byte/age reporting and preserve at least the newest verified rollback artifact |
 | `~/.aidevops/logs` and worker failure excerpts | framework | audit, archive, scratch | Individual excerpts are size-capped; policies vary by producer | Define producer ownership and combined age/count/byte retention while retaining terminal failure evidence |
@@ -70,6 +70,17 @@ Reference, lease, recovery, and audit checks remain hard vetoes.
 
 The inventory is intentionally conservative. A child implementation may split a
 row when one path contains artifacts with different owners or safety classes.
+
+### Runtime Bundle Dependency Decision
+
+Runtime activation continues to verify the OpenCode host's existing dependency
+tree first and installs declared dependencies inside a staged bundle only when
+that verification fails. A new lock-keyed shared dependency store is deferred:
+it would introduce shared mutable ownership, concurrent-install locking, cache
+integrity, and offline rollback dependencies into otherwise immutable bundles.
+The measured duplication is instead bounded by pruning unreferenced bundles.
+This preserves atomic activation and makes each retained rollback bundle
+self-verifying without making npm's global cache framework-owned.
 
 ## Store Lifecycle Contract
 

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -738,53 +738,107 @@ _runtime_bundle_switch_link() {
 	return 0
 }
 
+_runtime_bundle_size_bytes() {
+	local bundle_dir="$1"
+	local size_kib=""
+	size_kib=$(LC_ALL=C du -sk "$bundle_dir" 2>/dev/null | cut -f1) || return 1
+	case "$size_kib" in
+	'' | *[!0-9]*) return 1 ;;
+	esac
+	printf '%s' "$((size_kib * 1024))"
+	return 0
+}
+
+_runtime_bundle_has_live_lease() {
+	local lease_dir="$1"
+	local lease_file=""
+	local lease_pid=""
+	local has_live_lease=false
+	[[ -d "$lease_dir" ]] || return 1
+	for lease_file in "$lease_dir"/*; do
+		[[ -f "$lease_file" ]] || continue
+		lease_pid="${lease_file##*/}"
+		case "$lease_pid" in
+		'' | *[!0-9]*) rm -f "$lease_file" ;;
+		*)
+			if kill -0 "$lease_pid" 2>/dev/null; then
+				has_live_lease=true
+			else
+				rm -f "$lease_file"
+			fi
+			;;
+		esac
+	done
+	rmdir "$lease_dir" 2>/dev/null || true
+	[[ "$has_live_lease" == "true" ]]
+}
+
+_runtime_bundle_numeric_limit() {
+	local value="$1"
+	local fallback="$2"
+	case "$value" in
+	'' | *[!0-9]*) printf '%s' "$fallback" ;;
+	*) printf '%s' "$value" ;;
+	esac
+	return 0
+}
+
 _runtime_bundle_prune() {
 	local bundles_dir="$1"
 	local active_root="$2"
 	local previous_root="$3"
 	local candidate_dir=""
+	local candidate_agents_root=""
 	local bundle_id=""
-	local lease_dir=""
-	local lease_file=""
-	local lease_pid=""
-	local has_live_lease=false
-	local retention_seconds="${AIDEVOPS_RUNTIME_BUNDLE_RETENTION_SECONDS:-2592000}"
+	local retention_seconds=""
+	local max_count=""
+	local max_bytes=""
 	local now=""
 	local modified=""
+	local bundle_bytes=""
+	local candidate_rows=""
+	local total_count=0
+	local total_bytes=0
+	local bytes_known=1
+	local should_remove=0
 
-	case "$retention_seconds" in
-	'' | *[!0-9]*) retention_seconds=2592000 ;;
-	esac
+	retention_seconds=$(_runtime_bundle_numeric_limit "${AIDEVOPS_RUNTIME_BUNDLE_RETENTION_SECONDS:-2592000}" 2592000)
+	max_count=$(_runtime_bundle_numeric_limit "${AIDEVOPS_RUNTIME_BUNDLE_MAX_COUNT:-30}" 30)
+	max_bytes=$(_runtime_bundle_numeric_limit "${AIDEVOPS_RUNTIME_BUNDLE_MAX_BYTES:-8589934592}" 8589934592)
 	now=$(date +%s) || return 1
 
 	for candidate_dir in "$bundles_dir"/*; do
 		[[ -d "$candidate_dir/agents" ]] || continue
-		[[ "$candidate_dir/agents" == "$active_root" || "$candidate_dir/agents" == "$previous_root" ]] && continue
-		bundle_id="${candidate_dir##*/}"
-		lease_dir="$bundles_dir/.leases/$bundle_id"
-		has_live_lease=false
-		if [[ -d "$lease_dir" ]]; then
-			for lease_file in "$lease_dir"/*; do
-				[[ -f "$lease_file" ]] || continue
-				lease_pid="${lease_file##*/}"
-				case "$lease_pid" in
-				'' | *[!0-9]*) rm -f "$lease_file" ;;
-				*)
-					if kill -0 "$lease_pid" 2>/dev/null; then
-						has_live_lease=true
-					else
-						rm -f "$lease_file"
-					fi
-					;;
-				esac
-			done
-			rmdir "$lease_dir" 2>/dev/null || true
+		candidate_agents_root=$(cd "$candidate_dir/agents" 2>/dev/null && pwd -P) || continue
+		total_count=$((total_count + 1))
+		if bundle_bytes=$(_runtime_bundle_size_bytes "$candidate_dir"); then
+			total_bytes=$((total_bytes + bundle_bytes))
+		else
+			bundle_bytes=0
+			bytes_known=0
 		fi
-		[[ "$has_live_lease" == "true" ]] && continue
+		[[ "$candidate_agents_root" == "$active_root" || "$candidate_agents_root" == "$previous_root" ]] && continue
+		bundle_id="${candidate_dir##*/}"
+		if _runtime_bundle_has_live_lease "$bundles_dir/.leases/$bundle_id"; then
+			continue
+		fi
 		modified=$(_file_mtime_epoch "$candidate_dir")
-		[[ $((now - modified)) -lt "$retention_seconds" ]] && continue
-		rm -rf "$candidate_dir"
+		candidate_rows+="${modified}"$'\t'"${bundle_bytes}"$'\t'"${candidate_dir}"$'\n'
 	done
+
+	while IFS=$'\t' read -r modified bundle_bytes candidate_dir; do
+		[[ -n "$candidate_dir" ]] || continue
+		should_remove=0
+		if [[ $((now - modified)) -ge "$retention_seconds" ]] || [[ "$total_count" -gt "$max_count" ]]; then
+			should_remove=1
+		elif [[ "$bytes_known" -eq 1 && "$total_bytes" -gt "$max_bytes" ]]; then
+			should_remove=1
+		fi
+		[[ "$should_remove" -eq 1 ]] || continue
+		rm -rf "$candidate_dir" || return 1
+		total_count=$((total_count - 1))
+		total_bytes=$((total_bytes - bundle_bytes))
+	done < <(printf '%s' "$candidate_rows" | LC_ALL=C sort -n -k1,1)
 	rmdir "$bundles_dir/.leases" 2>/dev/null || true
 	return 0
 }

--- a/.agents/scripts/storage-inventory-helper.sh
+++ b/.agents/scripts/storage-inventory-helper.sh
@@ -139,9 +139,132 @@ _storage_emit_record() {
 	return 0
 }
 
+_storage_bundle_root_from_link() {
+	local link_path="$1"
+	local bundles_dir="$2"
+	local agents_root=""
+	local bundle_root=""
+	local canonical_bundles=""
+	[[ -L "$link_path" ]] || return 1
+	agents_root=$(cd "$link_path" 2>/dev/null && pwd -P) || return 1
+	bundle_root="${agents_root%/agents}"
+	canonical_bundles=$(cd "$bundles_dir" 2>/dev/null && pwd -P) || return 1
+	[[ "$agents_root" == "$bundle_root/agents" && "$bundle_root" == "$canonical_bundles/"* ]] || return 1
+	printf '%s' "$bundle_root"
+	return 0
+}
+
+_storage_bundle_lease_is_live() {
+	local lease_dir="$1"
+	local lease_file=""
+	local lease_pid=""
+	[[ -d "$lease_dir" ]] || return 1
+	for lease_file in "$lease_dir"/*; do
+		[[ -f "$lease_file" ]] || continue
+		lease_pid="${lease_file##*/}"
+		case "$lease_pid" in
+		'' | *[!0-9]*) continue ;;
+		esac
+		kill -0 "$lease_pid" 2>/dev/null && return 0
+	done
+	return 1
+}
+
+_storage_emit_runtime_bundle_record() {
+	local bundles_dir="${HOME}/.aidevops/runtime-bundles"
+	local measured=""
+	local total_bytes="null"
+	local confidence="unavailable"
+	local error=""
+	local protected_bytes=0
+	local reclaimable_bytes=0
+	local unknown_bytes="null"
+	local active_bundle=""
+	local previous_bundle=""
+	local protected_list=$'\n'
+	local lease_dir=""
+	local leased_bundle=""
+	local bundle_root=""
+	local bundle_measure=""
+	local bundle_bytes=""
+	local bundle_confidence=""
+	local bundle_error=""
+
+	measured=$(_storage_measure_path "$bundles_dir")
+	IFS='|' read -r total_bytes confidence error <<<"$measured"
+	if [[ "$total_bytes" == "0" ]]; then
+		unknown_bytes=0
+	elif [[ "$total_bytes" != "null" ]]; then
+		if ! active_bundle=$(_storage_bundle_root_from_link "${HOME}/.aidevops/agents" "$bundles_dir"); then
+			error="active-reference-unavailable"
+			unknown_bytes="$total_bytes"
+		else
+			protected_list+="${active_bundle}"$'\n'
+			if [[ -L "${HOME}/.aidevops/previous-runtime-bundle" ]]; then
+				if previous_bundle=$(_storage_bundle_root_from_link "${HOME}/.aidevops/previous-runtime-bundle" "$bundles_dir"); then
+					[[ "$protected_list" == *$'\n'"${previous_bundle}"$'\n'* ]] || protected_list+="${previous_bundle}"$'\n'
+				else
+					error="previous-reference-unavailable"
+				fi
+			fi
+			for lease_dir in "$bundles_dir/.leases"/*; do
+				[[ -d "$lease_dir" ]] || continue
+				_storage_bundle_lease_is_live "$lease_dir" || continue
+				leased_bundle="$bundles_dir/${lease_dir##*/}"
+				[[ -d "$leased_bundle/agents" ]] || {
+					error="live-lease-target-unavailable"
+					continue
+				}
+				[[ "$protected_list" == *$'\n'"${leased_bundle}"$'\n'* ]] || protected_list+="${leased_bundle}"$'\n'
+			done
+			if [[ -z "$error" ]]; then
+				while IFS= read -r bundle_root; do
+					[[ -n "$bundle_root" ]] || continue
+					bundle_measure=$(_storage_measure_path "$bundle_root")
+					IFS='|' read -r bundle_bytes bundle_confidence bundle_error <<<"$bundle_measure"
+					if [[ "$bundle_bytes" == "null" ]]; then
+						error="protected-size-unavailable"
+						break
+					fi
+					protected_bytes=$((protected_bytes + bundle_bytes))
+				done <<<"$protected_list"
+			fi
+			if [[ -z "$error" ]]; then
+				bundle_measure=$(_storage_measure_path "$bundles_dir/.leases")
+				IFS='|' read -r bundle_bytes bundle_confidence bundle_error <<<"$bundle_measure"
+				if [[ "$bundle_bytes" == "null" ]]; then
+					error="lease-metadata-size-unavailable"
+				else
+					protected_bytes=$((protected_bytes + bundle_bytes))
+				fi
+			fi
+			if [[ -z "$error" ]]; then
+				[[ "$protected_bytes" -le "$total_bytes" ]] || protected_bytes="$total_bytes"
+				reclaimable_bytes=$((total_bytes - protected_bytes))
+				unknown_bytes=0
+			else
+				protected_bytes=0
+				reclaimable_bytes=0
+				unknown_bytes="$total_bytes"
+				confidence="unavailable"
+			fi
+		fi
+	fi
+
+	jq -cn \
+		--arg error "$error" \
+		--arg confidence "$confidence" \
+		--argjson total_bytes "$total_bytes" \
+		--argjson protected_bytes "$protected_bytes" \
+		--argjson reclaimable_bytes "$reclaimable_bytes" \
+		--argjson unknown_bytes "$unknown_bytes" \
+		'{store_id:"runtime-bundles",producer:"agent-deploy",path:"~/.aidevops/runtime-bundles",owner:"framework",safety_class:"mixed",policy:"30-day age, 30-bundle count, and 8 GiB soft limits; references and live leases veto deletion",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:$reclaimable_bytes,unknown_bytes:$unknown_bytes,protection_reasons:["current bundle, previous rollback bundle, live leases, and lease metadata"],sizing_confidence:$confidence,next_action:"Use setup activation for policy-owned pruning; do not delete protected bundles manually",error:(if $error == "" or $error == "missing" then null else $error end)}'
+	return 0
+}
+
 _storage_inventory_records() {
 	local home_label="~"
-	_storage_emit_record "runtime-bundles" "agent-deploy" "${home_label}/.aidevops/runtime-bundles" "${HOME}/.aidevops/runtime-bundles" "framework" "unknown" "30-day unleased age policy; detailed bounds pending" "unknown" "bundle references require store-specific classification" "Review runtime-bundle status; do not delete manually"
+	_storage_emit_runtime_bundle_record
 	_storage_emit_record "observability" "opencode-aidevops" "${home_label}/.aidevops/.agent-workspace/observability" "${HOME}/.aidevops/.agent-workspace/observability" "framework" "audit" "append-only audit evidence; compaction contract pending" "protected" "audit evidence" "Use observability-helper.sh for bounded queries"
 	_storage_emit_record "agent-backups" "setup-backup" "${home_label}/.aidevops/agents-backups" "${HOME}/.aidevops/agents-backups" "framework" "rollback" "count-based snapshots; byte policy pending" "protected" "rollback safety" "Review backup inventory before any cleanup"
 	_storage_emit_record "framework-logs" "multiple-framework-producers" "${home_label}/.aidevops/logs" "${HOME}/.aidevops/logs" "framework" "audit" "producer-specific policies pending" "protected" "audit and unresolved failure evidence" "Use producer-specific diagnostics"

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -223,6 +223,67 @@ test_stale_lease_and_old_bundle_are_pruned() {
 	return 0
 }
 
+test_count_and_byte_pressure_preserve_protected_bundles() {
+	local target_dir="$HOME/.aidevops/agents"
+	local bundles_dir="$HOME/.aidevops/runtime-bundles"
+	local previous_bundle="$bundles_dir/pressure-previous"
+	local active_root=""
+	local previous_root=""
+	local live_bundle="$bundles_dir/pressure-live"
+	local before_checksum=""
+	local after_checksum=""
+	active_root=$(_runtime_bundle_resolve_root "$target_dir")
+	mkdir -p "$previous_bundle/agents/scripts"
+	printf '#!/usr/bin/env bash\n' >"$previous_bundle/agents/scripts/helper.sh"
+	previous_root=$(cd "$previous_bundle/agents" && pwd -P)
+	rm -f "$HOME/.aidevops/previous-runtime-bundle"
+	ln -s "$previous_root" "$HOME/.aidevops/previous-runtime-bundle"
+	mkdir -p "$live_bundle/agents" "$bundles_dir/.leases/pressure-live"
+	printf 'live\n' >"$live_bundle/agents/marker"
+	printf '%s\n' "$live_bundle/agents" >"$bundles_dir/.leases/pressure-live/$$"
+	mkdir -p "$bundles_dir/pressure-count-a/agents" "$bundles_dir/pressure-count-b/agents"
+	printf 'candidate-a\n' >"$bundles_dir/pressure-count-a/agents/marker"
+	printf 'candidate-b\n' >"$bundles_dir/pressure-count-b/agents/marker"
+	before_checksum=$(cksum "$active_root/scripts/helper.sh" "$previous_root/scripts/helper.sh" "$live_bundle/agents/marker")
+
+	AIDEVOPS_RUNTIME_BUNDLE_RETENTION_SECONDS=999999999 \
+		AIDEVOPS_RUNTIME_BUNDLE_MAX_COUNT=3 \
+		AIDEVOPS_RUNTIME_BUNDLE_MAX_BYTES=999999999999 \
+		_runtime_bundle_prune "$bundles_dir" "$active_root" "$previous_root"
+	[[ ! -d "$bundles_dir/pressure-count-a" && ! -d "$bundles_dir/pressure-count-b" ]] || fail "count pressure did not converge unprotected bundles"
+	[[ -d "$active_root" && -d "$previous_root" && -d "$live_bundle" ]] || fail "count pressure removed a protected bundle"
+
+	mkdir -p "$bundles_dir/pressure-bytes/agents"
+	printf 'byte-pressure-candidate\n' >"$bundles_dir/pressure-bytes/agents/marker"
+	AIDEVOPS_RUNTIME_BUNDLE_RETENTION_SECONDS=999999999 \
+		AIDEVOPS_RUNTIME_BUNDLE_MAX_COUNT=999 \
+		AIDEVOPS_RUNTIME_BUNDLE_MAX_BYTES=1 \
+		_runtime_bundle_prune "$bundles_dir" "$active_root" "$previous_root"
+	[[ ! -d "$bundles_dir/pressure-bytes" ]] || fail "byte pressure did not prune the unprotected candidate"
+	after_checksum=$(cksum "$active_root/scripts/helper.sh" "$previous_root/scripts/helper.sh" "$live_bundle/agents/marker")
+	assert_eq "$before_checksum" "$after_checksum" "count and byte pressure preserve protected bundle byte identity"
+	return 0
+}
+
+test_runtime_bundle_inventory_explains_protection() {
+	local bundles_dir="$HOME/.aidevops/runtime-bundles"
+	local report_candidate="$bundles_dir/report-candidate"
+	local report=""
+	local before_checksum=""
+	local after_checksum=""
+	mkdir -p "$report_candidate/agents"
+	printf 'reclaimable-candidate\n' >"$report_candidate/agents/marker"
+	before_checksum=$(cksum "$report_candidate/agents/marker")
+	report=$(bash "$REPO_ROOT/.agents/scripts/storage-inventory-helper.sh" json)
+	after_checksum=$(cksum "$report_candidate/agents/marker")
+	assert_eq "$before_checksum" "$after_checksum" "runtime bundle inventory is read-only"
+	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protected_bytes > 0')" == "true" ]] || fail "runtime inventory omitted protected bytes"
+	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .reclaimable_bytes > 0')" == "true" ]] || fail "runtime inventory omitted unreferenced reclaimable bytes"
+	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .unknown_bytes')" == "0" ]] || fail "runtime inventory left classified bundles unknown"
+	pass "runtime inventory explains protected and reclaimable bundle bytes"
+	return 0
+}
+
 test_macos_and_linux_link_paths() {
 	local os_name=""
 	local os_root=""
@@ -392,6 +453,8 @@ main() {
 	test_setup_rebinds_stale_process_pin_to_active_bundle
 	test_live_bundle_lease_survives_three_updates
 	test_stale_lease_and_old_bundle_are_pruned
+	test_count_and_byte_pressure_preserve_protected_bundles
+	test_runtime_bundle_inventory_explains_protection
 	test_macos_and_linux_link_paths
 	test_plugin_dependency_smoke_check
 	install_mock_plugin_dependency_hooks


### PR DESCRIPTION
## Summary

Implementation for issue #28150.

## Files Changed

.agents/reference/storage-lifecycle.md, .agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/storage-inventory-helper.sh, .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #28150


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 4h 44m and 2,317,962 tokens on this with the user in an interactive session.