### PR TITLE
GH#28128: fix: normalize OpenCode temporary roots

### DIFF
--- a/.agents/scripts/setup/_services.sh
+++ b/.agents/scripts/setup/_services.sh
@@ -171,6 +171,12 @@ _setup_opencode_binary_is_ephemeral() {
 	local bin="$1"
 	local temp_root="${TMPDIR:-}"
 
+	while [[ "$temp_root" == */ && "$temp_root" != "/" ]]; do
+		temp_root="${temp_root%/}"
+	done
+	if [[ "$temp_root" == "/" && "$bin" == /* ]]; then
+		return 0
+	fi
 	if [[ -n "$temp_root" && "$bin" == "$temp_root"/* ]]; then
 		return 0
 	fi

--- a/.agents/scripts/setup/modules/tool-install.sh
+++ b/.agents/scripts/setup/modules/tool-install.sh
@@ -2167,6 +2167,12 @@ _setup_opencode_binary_is_ephemeral() {
 	local bin="$1"
 	local temp_root="${TMPDIR:-}"
 
+	while [[ "$temp_root" == */ && "$temp_root" != "/" ]]; do
+		temp_root="${temp_root%/}"
+	done
+	if [[ "$temp_root" == "/" && "$bin" == /* ]]; then
+		return 0
+	fi
 	if [[ -n "$temp_root" && "$bin" == "$temp_root"/* ]]; then
 		return 0
 	fi

--- a/tests/test-opencode-stable-shim.sh
+++ b/tests/test-opencode-stable-shim.sh
@@ -38,6 +38,8 @@ TMPDIR="${TEST_DIR}/runtime-temp"
 export TMPDIR
 
 assert_ephemeral "${TMPDIR}/nvm/bin/opencode"
+TMPDIR="${TMPDIR}/" assert_ephemeral "${TEST_DIR}/runtime-temp/nvm/bin/opencode"
+TMPDIR="/" assert_ephemeral "/opt/example/bin/opencode"
 assert_ephemeral "/tmp/nvm/bin/opencode"
 assert_ephemeral "/private/tmp/nvm/bin/opencode"
 assert_ephemeral "/var/folders/aa/bb/T/tmp.example/.nvm/bin/opencode"


### PR DESCRIPTION
## Summary

Normalize trailing separators from `TMPDIR` before classifying OpenCode binaries, while preserving fail-safe handling when the configured temporary root is `/`.

## Files Changed

`.agents/scripts/setup/_services.sh`, `.agents/scripts/setup/modules/tool-install.sh`, `tests/test-opencode-stable-shim.sh`

## Runtime Testing

- **Risk level:** Medium (setup-time executable path trust classification)
- **Verification:** Focused regression passes under modern Bash and macOS Bash 3.2; active tool-install smoke suite passes 38/38; ShellCheck, changed-file linters, whitespace, portability, complexity, and Bash 3.2 gates pass.
- **Baseline note:** The orphan `_services.sh` smoke suite's existing macOS temporary-sandbox assertion fails identically at merge base `d6dc4dce4`; the focused regression and active tool-install suite pass.

Resolves #28128

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 36m and 800,172 tokens on this with the user in an interactive session. Overall, 3h 46m since this issue was created.
