### PR TITLE
t18160: Bound observability growth while preserving append-only audit evidence

### DIFF
--- a/.agents/plugins/opencode-aidevops/observability-retention.mjs
+++ b/.agents/plugins/opencode-aidevops/observability-retention.mjs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/** Bounded ingestion primitives for high-volume OpenCode observability data. */
+
+export const TOOL_METADATA_MAX_BYTES = 1024;
+
+const PART_STREAM_TYPES = new Set(["message.part.delta", "message.part.updated"]);
+const TERMINAL_STATUSES = new Set([
+  "blocked", "cancelled", "completed", "denied", "error", "failed", "rejected",
+  "success", "succeeded", "timed_out", "timeout",
+]);
+const SAFE_STATUSES = new Set([
+  ...TERMINAL_STATUSES,
+  "pending", "running", "started",
+]);
+
+function jsonByteLength(value) {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    return 0;
+  }
+}
+
+function safeInteger(value) {
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+function firstDefined(object, keys) {
+  for (const key of keys) {
+    if (object?.[key] !== undefined) return object[key];
+  }
+  return undefined;
+}
+
+function normalizedStatus(value) {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  if (!normalized) return undefined;
+  return SAFE_STATUSES.has(normalized) ? normalized : "other";
+}
+
+/**
+ * Replace raw host-tool metadata with a small outcome envelope. Raw values,
+ * paths, output fragments, and unknown keys never cross the storage boundary.
+ */
+export function summarizeToolMetadata(metadata) {
+  if (metadata === null || metadata === undefined) return null;
+  const source = metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? metadata
+    : {};
+  const summary = {
+    schema_version: 1,
+    original_bytes: jsonByteLength(metadata),
+    omitted_keys: Object.keys(source).length,
+  };
+  const status = normalizedStatus(firstDefined(source, ["status", "state", "outcome"]));
+  const exitCode = safeInteger(firstDefined(source, ["exitCode", "exit_code"]));
+  const outputBytes = safeInteger(firstDefined(source, ["outputBytes", "output_bytes", "bytes"]));
+  const outputLines = safeInteger(firstDefined(source, ["outputLines", "output_lines", "lineCount"]));
+  const truncated = firstDefined(source, ["truncated", "isTruncated"]);
+  const timedOut = firstDefined(source, ["timedOut", "timed_out", "timeout"]);
+
+  if (status !== undefined) summary.status = status;
+  if (exitCode !== undefined) summary.exit_code = exitCode;
+  if (outputBytes !== undefined && outputBytes >= 0) summary.output_bytes = outputBytes;
+  if (outputLines !== undefined && outputLines >= 0) summary.output_lines = outputLines;
+  if (typeof truncated === "boolean") summary.truncated = truncated;
+  if (typeof timedOut === "boolean") summary.timed_out = timedOut;
+  if (source.error !== undefined) summary.has_error = Boolean(source.error);
+
+  const retainedSourceKeys = [
+    "status", "state", "outcome", "exitCode", "exit_code", "outputBytes",
+    "output_bytes", "bytes", "outputLines", "output_lines", "lineCount",
+    "truncated", "isTruncated", "timedOut", "timed_out", "timeout", "error",
+  ].filter((key) => Object.hasOwn(source, key)).length;
+  summary.omitted_keys = Math.max(0, summary.omitted_keys - retainedSourceKeys);
+
+  if (jsonByteLength(summary) > TOOL_METADATA_MAX_BYTES) {
+    return Object.freeze({
+      schema_version: 1,
+      original_bytes: summary.original_bytes,
+      truncated: true,
+    });
+  }
+  return Object.freeze(summary);
+}
+
+function partStreamKey(event) {
+  const properties = event?.properties || {};
+  const part = properties.part || {};
+  const info = properties.info || {};
+  const sessionId = part.sessionID || part.sessionId || info.sessionID ||
+    properties.sessionID || properties.sessionId || "unknown-session";
+  const messageId = part.messageID || part.messageId || info.messageID ||
+    info.messageId || properties.messageID || properties.messageId || "unknown-message";
+  return `${sessionId}:${messageId}`;
+}
+
+function partHasProtectedSignal(event) {
+  const properties = event?.properties || {};
+  const part = properties.part || {};
+  const state = part.state || {};
+  if (properties.error || part.error || state.error) return true;
+  const statuses = [properties.status, part.status, state.status, part.finish, state.finish]
+    .map(normalizedStatus)
+    .filter(Boolean);
+  return statuses.some((status) => TERMINAL_STATUSES.has(status));
+}
+
+/** Track suppressed stream amplification without retaining raw stream content. */
+export class PartStreamSummaryTracker {
+  constructor({ maxEntries = 1000 } = {}) {
+    this.maxEntries = maxEntries;
+    this.summaries = new Map();
+  }
+
+  observe(event) {
+    if (!PART_STREAM_TYPES.has(event?.type) || partHasProtectedSignal(event)) return false;
+    const key = partStreamKey(event);
+    const existing = this.summaries.get(key) || { bytes: 0, events: 0 };
+    existing.bytes += jsonByteLength(event);
+    existing.events += 1;
+    this.summaries.set(key, existing);
+    if (this.summaries.size > this.maxEntries) {
+      const oldest = this.summaries.keys().next().value;
+      this.summaries.delete(oldest);
+    }
+    return true;
+  }
+
+  consume(message) {
+    const synthetic = {
+      properties: {
+        info: {
+          messageID: message?.id,
+          sessionID: message?.sessionID,
+        },
+      },
+    };
+    const key = partStreamKey(synthetic);
+    const summary = this.summaries.get(key);
+    if (!summary) return Object.freeze({ suppressed_part_bytes: 0, suppressed_part_events: 0 });
+    this.summaries.delete(key);
+    return Object.freeze({
+      suppressed_part_bytes: summary.bytes,
+      suppressed_part_events: summary.events,
+    });
+  }
+}

--- a/.agents/plugins/opencode-aidevops/observability-retention.mjs
+++ b/.agents/plugins/opencode-aidevops/observability-retention.mjs
@@ -41,6 +41,10 @@ function normalizedStatus(value) {
   return SAFE_STATUSES.has(normalized) ? normalized : "other";
 }
 
+function firstTruthy(values, fallback) {
+  return values.find(Boolean) || fallback;
+}
+
 /**
  * Replace raw host-tool metadata with a small outcome envelope. Raw values,
  * paths, output fragments, and unknown keys never cross the storage boundary.
@@ -91,10 +95,13 @@ function partStreamKey(event) {
   const properties = event?.properties || {};
   const part = properties.part || {};
   const info = properties.info || {};
-  const sessionId = part.sessionID || part.sessionId || info.sessionID ||
-    properties.sessionID || properties.sessionId || "unknown-session";
-  const messageId = part.messageID || part.messageId || info.messageID ||
-    info.messageId || properties.messageID || properties.messageId || "unknown-message";
+  const sessionId = firstTruthy([
+    part.sessionID, part.sessionId, info.sessionID, properties.sessionID, properties.sessionId,
+  ], "unknown-session");
+  const messageId = firstTruthy([
+    part.messageID, part.messageId, info.messageID, info.messageId,
+    properties.messageID, properties.messageId,
+  ], "unknown-message");
   return `${sessionId}:${messageId}`;
 }
 

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -684,14 +684,20 @@ function projectRuntimeEvent(envelope) {
   enrichActiveSpan(runtimeEventOtelAttributes(envelope)).catch(() => {});
 }
 
+function firstTruthy(values, fallback = null) {
+  return values.find(Boolean) || fallback;
+}
+
 function recordOpenCodeRuntimeEvent(event, eventType = event.type, additionalPayload = {}) {
   const properties = event.properties || {};
   const info = properties.info || {};
   const part = properties.part || {};
-  const sessionId = info.sessionID || part.sessionID || part.sessionId ||
-    properties.sessionID || properties.sessionId || null;
-  const subjectId = info.id || part.id || part.messageID || part.messageId ||
-    properties.id || sessionId || "runtime:opencode";
+  const sessionId = firstTruthy([
+    info.sessionID, part.sessionID, part.sessionId, properties.sessionID, properties.sessionId,
+  ]);
+  const subjectId = firstTruthy([
+    info.id, part.id, part.messageID, part.messageId, properties.id, sessionId,
+  ], "runtime:opencode");
   const envelope = appendRuntimeEvent({
     eventType,
     subjectId,
@@ -701,8 +707,9 @@ function recordOpenCodeRuntimeEvent(event, eventType = event.type, additionalPay
     rootEventId: properties.rootEventID,
     parentEventId: properties.parentEventID,
     payload: {
-      error_type: info.error?.name || properties.error?.name || part.error?.name ||
-        part.state?.error?.name || null,
+      error_type: firstTruthy([
+        info.error?.name, properties.error?.name, part.error?.name, part.state?.error?.name,
+      ]),
       finish_reason: info.finish || part.finish || part.state?.status || null,
       model_id: info.modelID || null,
       provider_id: info.providerID || null,

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -36,6 +36,10 @@ import {
   enrichActiveSpan,
   runtimeEventOtelAttributes,
 } from "./otel-enrichment.mjs";
+import {
+  PartStreamSummaryTracker,
+  summarizeToolMetadata,
+} from "./observability-retention.mjs";
 import { toolOutcomeFailed } from "./session-continuation-guard.mjs";
 
 const HOME = homedir();
@@ -223,8 +227,11 @@ function _isSchemaInitialized() {
       ["-readonly", "-separator", "|", DB_PATH,
        "SELECT " +
       "(SELECT COUNT(*) FROM sqlite_master WHERE type='table' " +
-       "AND name IN ('llm_requests','tool_calls','session_summaries')) AS tbls, " +
-       "(SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='intent') AS intent_col;"],
+       "AND name IN ('llm_requests','tool_calls','session_summaries','runtime_events','runtime_event_archives')) AS tbls, " +
+       "(SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='intent') AS intent_col, " +
+       "(SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' " +
+       "AND name IN ('runtime_events_reject_update','runtime_events_reject_delete'," +
+       "'runtime_event_archives_reject_update','runtime_event_archives_reject_delete')) AS guards;"],
       {
         encoding: "utf-8",
         timeout: 2000,
@@ -232,8 +239,8 @@ function _isSchemaInitialized() {
       },
     ).trim();
     if (!result) return false;
-    const [tbls, intentCol] = result.split("|");
-    return tbls === "3" && intentCol === "1";
+    const [tbls, intentCol, guards] = result.split("|");
+    return tbls === "5" && intentCol === "1" && guards === "4";
   } catch {
     return false;
   }
@@ -620,6 +627,7 @@ const sessionToolCounts = new Map();
  * @type {Set<string>}
  */
 const recordedMessages = new Set();
+const partStreamSummaries = new PartStreamSummaryTracker();
 
 /**
  * Whether the database was successfully initialised.
@@ -663,6 +671,11 @@ export function handleEvent(input) {
     return;
   }
 
+  // Text/reasoning part streams can emit hundreds of redundant updates for a
+  // single response. Keep terminal/error parts, but summarize ordinary deltas
+  // into the eventual message.completed envelope.
+  if (partStreamSummaries.observe(event)) return;
+
   recordOpenCodeRuntimeEvent(event);
 }
 
@@ -671,11 +684,14 @@ function projectRuntimeEvent(envelope) {
   enrichActiveSpan(runtimeEventOtelAttributes(envelope)).catch(() => {});
 }
 
-function recordOpenCodeRuntimeEvent(event, eventType = event.type) {
+function recordOpenCodeRuntimeEvent(event, eventType = event.type, additionalPayload = {}) {
   const properties = event.properties || {};
   const info = properties.info || {};
-  const sessionId = info.sessionID || properties.sessionID || properties.sessionId || null;
-  const subjectId = info.id || properties.id || sessionId || "runtime:opencode";
+  const part = properties.part || {};
+  const sessionId = info.sessionID || part.sessionID || part.sessionId ||
+    properties.sessionID || properties.sessionId || null;
+  const subjectId = info.id || part.id || part.messageID || part.messageId ||
+    properties.id || sessionId || "runtime:opencode";
   const envelope = appendRuntimeEvent({
     eventType,
     subjectId,
@@ -685,12 +701,14 @@ function recordOpenCodeRuntimeEvent(event, eventType = event.type) {
     rootEventId: properties.rootEventID,
     parentEventId: properties.parentEventID,
     payload: {
-      error_type: info.error?.name || properties.error?.name || null,
-      finish_reason: info.finish || null,
+      error_type: info.error?.name || properties.error?.name || part.error?.name ||
+        part.state?.error?.name || null,
+      finish_reason: info.finish || part.finish || part.state?.status || null,
       model_id: info.modelID || null,
       provider_id: info.providerID || null,
       role: info.role || null,
       source: "opencode",
+      ...additionalPayload,
     },
   });
   projectRuntimeEvent(envelope);
@@ -716,7 +734,7 @@ function handleMessageUpdated(event) {
   if (recordedMessages.has(msg.id)) return;
   recordedMessages.add(msg.id);
 
-  recordOpenCodeRuntimeEvent(event, "message.completed");
+  recordOpenCodeRuntimeEvent(event, "message.completed", partStreamSummaries.consume(msg));
 
   // Prevent unbounded memory growth — prune old entries periodically
   if (recordedMessages.size > 10000) {
@@ -842,7 +860,7 @@ ON CONFLICT(session_id) DO UPDATE SET
  * @param {string | null | undefined} args.intent
  * @param {0 | 1} args.isSuccess
  * @param {number | null | undefined} args.durationMs - Elapsed ms, or null/undefined to store SQL NULL
- * @param {object | null | undefined} args.metadata - Raw metadata object; JSON-stringified before escape
+ * @param {object | null | undefined} args.metadata - Raw metadata object; summarized before persistence
  * @returns {string} INSERT statement ready for sqliteExec
  */
 export function buildToolCallInsertSql({ sessionID, callID, toolName, intent, isSuccess, durationMs, metadata }) {
@@ -851,9 +869,8 @@ export function buildToolCallInsertSql({ sessionID, callID, toolName, intent, is
     : "NULL";
   // sqlEscape(null) returns the literal string "NULL" — we exploit that
   // so the metadata column renders as SQL NULL when metadata is absent.
-  const metadataValue = (metadata !== null && metadata !== undefined)
-    ? JSON.stringify(metadata)
-    : null;
+  const metadataSummary = summarizeToolMetadata(metadata);
+  const metadataValue = metadataSummary === null ? null : JSON.stringify(metadataSummary);
 
   return `INSERT INTO tool_calls (
     session_id, call_id, tool_name, intent, success, duration_ms, metadata

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-retention.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-retention.mjs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  PartStreamSummaryTracker,
+  TOOL_METADATA_MAX_BYTES,
+  summarizeToolMetadata,
+} from "../observability-retention.mjs";
+
+describe("tool metadata retention", () => {
+  test("keeps outcome evidence while omitting raw metadata", () => {
+    const summary = summarizeToolMetadata({
+      bytes: 4096,
+      error: "sensitive-value",
+      exitCode: 7,
+      filePath: "/private/project/file.txt",
+      raw: "x".repeat(100_000),
+      status: "failed",
+    });
+    const encoded = JSON.stringify(summary);
+
+    assert.ok(Buffer.byteLength(encoded, "utf8") <= TOOL_METADATA_MAX_BYTES);
+    assert.equal(summary.status, "failed");
+    assert.equal(summary.exit_code, 7);
+    assert.equal(summary.output_bytes, 4096);
+    assert.equal(summary.has_error, true);
+    assert.equal(summary.omitted_keys, 2);
+    assert.doesNotMatch(encoded, /sensitive-value|private|project|raw/);
+  });
+});
+
+describe("part-stream retention", () => {
+  test("converges repeated ordinary parts to one bounded summary", () => {
+    const tracker = new PartStreamSummaryTracker();
+    for (let index = 0; index < 10_000; index++) {
+      assert.equal(tracker.observe({
+        type: index % 2 === 0 ? "message.part.delta" : "message.part.updated",
+        properties: {
+          part: { messageID: "message:1", sessionID: "session:1", text: "x".repeat(1000) },
+        },
+      }), true);
+    }
+
+    const summary = tracker.consume({ id: "message:1", sessionID: "session:1" });
+    assert.equal(summary.suppressed_part_events, 10_000);
+    assert.ok(summary.suppressed_part_bytes > 10_000_000);
+    assert.deepEqual(tracker.consume({ id: "message:1", sessionID: "session:1" }), {
+      suppressed_part_bytes: 0,
+      suppressed_part_events: 0,
+    });
+  });
+
+  test("never suppresses terminal or error part evidence", () => {
+    const tracker = new PartStreamSummaryTracker();
+    assert.equal(tracker.observe({
+      type: "message.part.updated",
+      properties: { part: { state: { status: "completed" } } },
+    }), false);
+    assert.equal(tracker.observe({
+      type: "message.part.delta",
+      properties: { part: { error: { name: "Failure" } } },
+    }), false);
+  });
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
@@ -11,7 +11,7 @@
 // global state — we can exhaustively verify:
 //   * duration_ms renders as a plain integer when supplied
 //   * duration_ms renders as the SQL NULL keyword (unquoted) when absent
-//   * metadata renders as a JSON-stringified, SQL-escaped literal
+//   * metadata renders as a bounded outcome summary, never raw host payloads
 //   * metadata renders as SQL NULL when absent
 //   * column-count / value-count schema alignment
 //
@@ -219,7 +219,7 @@ describe("buildToolCallInsertSql — duration_ms rendering", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildToolCallInsertSql — metadata rendering", () => {
-  test("object metadata renders as JSON-stringified, SQL-escaped literal", () => {
+  test("object metadata renders as a bounded outcome summary", () => {
     const sql = buildToolCallInsertSql({
       sessionID: "s1",
       callID: "c1",
@@ -227,7 +227,7 @@ describe("buildToolCallInsertSql — metadata rendering", () => {
       intent: null,
       isSuccess: 1,
       durationMs: 5,
-      metadata: { filePath: "/tmp/hello.txt", bytes: 42 },
+      metadata: { filePath: "/tmp/hello.txt", bytes: 42, exitCode: 0, status: "completed" },
     });
     const vals = extractValues(sql);
     // Column index 6 = metadata
@@ -235,7 +235,12 @@ describe("buildToolCallInsertSql — metadata rendering", () => {
     // Unescape the SQL string and parse the JSON.
     const inner = vals[6].slice(1, -1).replace(/''/g, "'");
     const parsed = JSON.parse(inner);
-    assert.deepEqual(parsed, { filePath: "/tmp/hello.txt", bytes: 42 });
+    assert.equal(parsed.status, "completed");
+    assert.equal(parsed.exit_code, 0);
+    assert.equal(parsed.output_bytes, 42);
+    assert.equal(parsed.omitted_keys, 1);
+    assert.equal(parsed.filePath, undefined);
+    assert.doesNotMatch(inner, /hello\.txt|\/tmp/);
   });
 
   test("metadata=null renders as SQL NULL keyword", () => {
@@ -266,7 +271,7 @@ describe("buildToolCallInsertSql — metadata rendering", () => {
     assert.equal(vals[6], "NULL");
   });
 
-  test("metadata containing single quotes is safely escaped", () => {
+  test("unknown metadata strings are omitted instead of escaped into storage", () => {
     const sql = buildToolCallInsertSql({
       sessionID: "s1",
       callID: "c1",
@@ -280,7 +285,9 @@ describe("buildToolCallInsertSql — metadata rendering", () => {
     const vals = extractValues(sql);
     const inner = vals[6].slice(1, -1).replace(/''/g, "'");
     const parsed = JSON.parse(inner);
-    assert.equal(parsed.note, "o'reilly");
+    assert.equal(parsed.omitted_keys, 1);
+    assert.equal(parsed.note, undefined);
+    assert.doesNotMatch(inner, /reilly/);
   });
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-runtime-event-retention.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-runtime-event-retention.mjs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  appendRuntimeEventSync,
+  appendStateSnapshot,
+  initialiseRuntimeEventStore,
+} from "../../../scripts/runtime-events.mjs";
+import {
+  archiveRuntimeEvents,
+  isProtectedRuntimeEvent,
+  runtimeEventRetentionInventory,
+  verifyRuntimeEventArchive,
+} from "../../../scripts/runtime-events-retention.mjs";
+
+const OLD_TIME = "2025-01-01T00:00:00.000Z";
+const CUTOFF = "2026-01-01T00:00:00.000Z";
+
+function sqliteAvailable() {
+  try {
+    execFileSync("sqlite3", ["-version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function scalar(dbPath, sql) {
+  return execFileSync("sqlite3", [dbPath, sql], { encoding: "utf8" }).trim();
+}
+
+function appendFixture(index, eventType = "message.part.delta", payload = { source: "fixture" }) {
+  const event = appendRuntimeEventSync({
+    eventId: `fixture:${eventType}:${index}`,
+    eventType,
+    occurredAt: OLD_TIME,
+    payload,
+    subjectId: `fixture:${index}`,
+  });
+  assert.ok(event, `fixture event ${index} should append`);
+}
+
+describe("runtime-event protection policy", () => {
+  test("protects lifecycle, terminal, failure, security, and recovery evidence", () => {
+    for (const eventType of [
+      "worker.started", "worker.completed", "session.created", "tool.completed",
+      "permission.denied", "security.alert", "release.failed",
+    ]) {
+      assert.equal(isProtectedRuntimeEvent({ event_type: eventType, payload_json: "{}" }), true);
+    }
+    assert.equal(isProtectedRuntimeEvent({
+      event_type: "provider.updated",
+      payload_json: '{"success":false}',
+    }), true);
+    assert.equal(isProtectedRuntimeEvent({
+      event_type: "message.part.delta",
+      payload_json: '{"source":"opencode"}',
+    }), false);
+    assert.equal(isProtectedRuntimeEvent({
+      event_type: "state.snapshot",
+      payload_json: '{"state":{}}',
+      state_version: 1,
+    }), true);
+  });
+});
+
+test("archive is dry-run first, interruption-safe, resumable, and append-only", {
+  skip: !sqliteAvailable() && "sqlite3 is unavailable",
+}, () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "aidevops-runtime-retention-"));
+  const dbPath = join(tempDir, "observability.db");
+  const archiveDir = join(tempDir, "archives");
+  try {
+    assert.equal(initialiseRuntimeEventStore(dbPath), true);
+    for (let index = 0; index < 100; index++) appendFixture(index);
+    appendFixture(100, "worker.completed", { result: "success", source: "fixture" });
+    appendFixture(101, "tool.completed", { error_type: "Failure", success: false });
+    assert.ok(appendStateSnapshot({
+      eventId: "fixture:state:1",
+      occurredAt: OLD_TIME,
+      state: { status: "running" },
+      subjectId: "fixture:state",
+    }));
+
+    const sourceRows = Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;"));
+    const dryRun = archiveRuntimeEvents({ archiveDir, cutoff: CUTOFF, dbPath, maxRows: 1000 });
+    assert.equal(dryRun.status, "dry_run");
+    assert.equal(dryRun.candidate_rows, 102);
+    assert.equal(dryRun.protected_rows, 2);
+    assert.equal(dryRun.compacted_rows, 100);
+    assert.equal(existsSync(archiveDir), false);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;")), sourceRows);
+
+    assert.throws(() => archiveRuntimeEvents({
+      apply: true,
+      archiveDir,
+      cutoff: CUTOFF,
+      dbPath,
+      maxRows: 1000,
+      simulateInterruption: "after_archive",
+    }), /simulated interruption/);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;")), sourceRows);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_event_archives;")), 0);
+
+    const archiveName = readdirSync(archiveDir).find((name) => name.endsWith(".jsonl"));
+    assert.ok(archiveName);
+    const archivePath = join(archiveDir, archiveName);
+    const verifiedBeforeResume = verifyRuntimeEventArchive(archivePath);
+    assert.equal(verifiedBeforeResume.ok, true);
+
+    const applied = archiveRuntimeEvents({
+      apply: true,
+      archiveDir,
+      cutoff: CUTOFF,
+      dbPath,
+      maxRows: 1000,
+    });
+    assert.equal(applied.status, "archived");
+    assert.equal(applied.partition_id, dryRun.partition_id);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;")), 1);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_event_archives;")), 1);
+    assert.equal(scalar(dbPath, "SELECT event_type FROM runtime_events;"), "state.snapshot");
+
+    const archived = readFileSync(archivePath, "utf8");
+    assert.match(archived, /worker\.completed/);
+    assert.match(archived, /tool\.completed/);
+    assert.match(archived, /"event_type":"message\.part\.delta"/);
+    assert.match(archived, /"count":100/);
+    assert.throws(() => execFileSync("sqlite3", [
+      dbPath,
+      "DELETE FROM runtime_event_archives;",
+    ], { stdio: "pipe" }));
+    assert.throws(() => execFileSync("sqlite3", [
+      dbPath,
+      "DELETE FROM runtime_events;",
+    ], { stdio: "pipe" }));
+
+    const inventory = runtimeEventRetentionInventory({ archiveDir, cutoff: CUTOFF, dbPath });
+    assert.ok(inventory.active_bytes > 0);
+    assert.ok(inventory.archive_bytes > 0);
+    assert.ok(inventory.protected_bytes > 0);
+    assert.equal(inventory.candidate_bytes, 0);
+    assert.equal(inventory.reclaimable_bytes, 0);
+    assert.doesNotMatch(JSON.stringify(inventory), /payload_json|fixture:|observability\.db/);
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("corrupt interrupted archives fail closed with source rows intact", {
+  skip: !sqliteAvailable() && "sqlite3 is unavailable",
+}, () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "aidevops-runtime-retention-corrupt-"));
+  const dbPath = join(tempDir, "observability.db");
+  const archiveDir = join(tempDir, "archives");
+  try {
+    assert.equal(initialiseRuntimeEventStore(dbPath), true);
+    appendFixture(200, "worker.completed", { result: "success" });
+    assert.throws(() => archiveRuntimeEvents({
+      apply: true,
+      archiveDir,
+      cutoff: CUTOFF,
+      dbPath,
+      simulateInterruption: "after_archive",
+    }), /simulated interruption/);
+    const archiveName = readdirSync(archiveDir).find((name) => name.endsWith(".jsonl"));
+    const archivePath = join(archiveDir, archiveName);
+    chmodSync(archivePath, 0o600);
+    writeFileSync(archivePath, `${readFileSync(archivePath, "utf8")}corrupt\n`);
+    assert.throws(() => archiveRuntimeEvents({
+      apply: true,
+      archiveDir,
+      cutoff: CUTOFF,
+      dbPath,
+    }), /archive partition verification failed/);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;")), 1);
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_event_archives;")), 0);
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("synthetic high-volume cycles converge in the active partition", {
+  skip: !sqliteAvailable() && "sqlite3 is unavailable",
+}, () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "aidevops-runtime-retention-growth-"));
+  const dbPath = join(tempDir, "observability.db");
+  const archiveDir = join(tempDir, "archives");
+  try {
+    assert.equal(initialiseRuntimeEventStore(dbPath), true);
+    for (let cycle = 0; cycle < 3; cycle++) {
+      for (let index = 0; index < 500; index++) {
+        appendFixture((cycle * 1000) + index, "message.part.delta");
+      }
+      appendFixture((cycle * 1000) + 999, "message.completed", { finish_reason: "stop" });
+      const applied = archiveRuntimeEvents({
+        apply: true,
+        archiveDir,
+        cutoff: CUTOFF,
+        dbPath,
+        maxRows: 1000,
+      });
+      assert.equal(applied.candidate_rows, 501);
+      assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_events;")), 0);
+    }
+    assert.equal(Number(scalar(dbPath, "SELECT COUNT(*) FROM runtime_event_archives;")), 3);
+    assert.equal(runtimeEventRetentionInventory({ archiveDir, cutoff: CUTOFF, dbPath }).candidate_bytes, 0);
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs
@@ -464,6 +464,21 @@ test("OpenCode observability emits runtime evidence without changing legacy tabl
       type: "session.created",
       properties: { info: { id: "session:1", sessionID: "session:1" } },
     } });
+    for (let index = 0; index < 100; index++) {
+      observability.handleEvent({ event: {
+        type: "message.part.delta",
+        properties: { part: {
+          id: "part:1", messageID: "message:1", sessionID: "session:1", text: "stream fragment",
+        } },
+      } });
+    }
+    observability.handleEvent({ event: {
+      type: "message.part.updated",
+      properties: { part: {
+        error: { name: "PartFailure" }, id: "part:error", messageID: "message:1",
+        sessionID: "session:1", state: { status: "failed" },
+      } },
+    } });
     observability.handleEvent({ event: {
       type: "message.updated",
       properties: { info: {
@@ -504,9 +519,16 @@ test("OpenCode observability emits runtime evidence without changing legacy tabl
         (SELECT COUNT(*) FROM runtime_events),
         (SELECT group_concat(event_type, ',') FROM (
           SELECT event_type FROM runtime_events ORDER BY id
-        ));
+        )),
+        (SELECT json_extract(payload_json, '$.suppressed_part_events')
+          FROM runtime_events WHERE event_type = 'message.completed'),
+        (SELECT json_extract(payload_json, '$.error_type')
+          FROM runtime_events WHERE event_type = 'message.part.updated');
     `], { encoding: "utf8" }).trim();
-    assert.equal(counts, "1|1|4|session.created,message.completed,tool.completed,subagent.cancellation.receipt");
+    assert.equal(
+      counts,
+      "1|1|5|session.created,message.part.updated,message.completed,tool.completed,subagent.cancellation.receipt|100|PartFailure",
+    );
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }

--- a/.agents/reference/observability.md
+++ b/.agents/reference/observability.md
@@ -49,6 +49,19 @@ credential-shaped values, absolute/file paths, configured private roots, and
 repository-like identifiers are redacted before persistence. CamelCase and
 snake_case path/repository keys receive the same treatment.
 
+The plugin additionally bounds two host-runtime amplification surfaces before
+they reach SQLite:
+
+- ordinary `message.part.delta` and `message.part.updated` streams are counted
+  and measured in memory, then represented by `suppressed_part_events` and
+  `suppressed_part_bytes` on the terminal `message.completed` event. Part
+  errors and terminal statuses bypass suppression and remain individual rows;
+- raw host-tool metadata is never persisted. `tool_calls.metadata` contains a
+  versioned outcome summary capped at 1 KiB (status, exit code, timeout,
+  truncation, and aggregate byte/line counts). Unknown keys, paths, output
+  fragments, and error text are omitted. The dedicated `success` and
+  `duration_ms` columns remain the primary tool outcome evidence.
+
 Use `appendRuntimeEvent()` for ordinary evidence. Evidence writes fail open:
 validation, queue, lock, or disk failures never change the runtime action's
 result. Use `appendStateSnapshot()` and `appendStateDelta()` for bounded state
@@ -69,9 +82,41 @@ with argv (`execFileSync`/`spawn`), never shell-interpolated database paths.
 `runtime-events.mjs` is the sole runtime-event schema and migration authority;
 the OpenCode plugin consumes it.
 
-Retention is not currently enforced for `runtime_events`: history can grow.
-Storage pressure is reduced by no-op state suppression and bounded payloads,
-but those controls do not constitute bounded history or an age/count policy.
+Runtime-event maintenance uses an explicit archive boundary rather than
+ordinary row deletion. The minimum retained envelope includes state-recovery
+rows and lifecycle, terminal, error, permission, security, audit, release,
+deploy, and subagent evidence. The default 30-day active window is a soft
+candidate threshold; state snapshots/deltas stay active because current-state
+reconstruction depends on them.
+
+`observability-helper.sh retention` is a dry run by default. `--apply` writes a
+bounded JSONL partition plus an immutable sidecar manifest under
+`runtime-events-archive/`, verifies SHA-256, bytes, source/event counts, and the
+protected/compacted split, and only then removes the verified source range in
+one `BEGIN IMMEDIATE` transaction. Protected rows are archived verbatim;
+unprotected rows become per-event-type count/byte/time summaries. The
+transaction rechecks the exact source range, temporarily suspends only the
+delete guard, restores it, and appends an immutable `runtime_event_archives`
+manifest row. A failed/corrupt archive leaves source rows intact. Interruption
+after file verification is resumable and reuses the verified partition.
+Archive deletion is not automatic.
+
+```bash
+# Physical and classified bytes; never prints raw payloads
+observability-helper.sh storage --json
+
+# Explain one bounded candidate partition without writing
+observability-helper.sh retention --dry-run
+
+# Explicit maintenance after reviewing the dry run
+observability-helper.sh retention --apply --max-rows 5000
+```
+
+The shared storage inventory reports active, archive, protected, reclaimable,
+candidate, and unknown bytes. Unattributed files and unavailable verification
+remain unknown; a verified archive or pinned state row is required before any
+byte is classified as protected, and source bytes are never called reclaimable
+before the archive transaction commits.
 
 Full-loop keeps authoritative resumable state in `.agents/loop-state/full-loop.local.state` and appends local transition evidence to `full-loop-events.jsonl`. Schema v2 records the run ID, state revision, phase status/start/end/attempt, terminal evidence, next safe action, observed executor status/PID/heartbeat, manual resumes, reused subagent units, and duplicate work avoided. Status must validate executor liveness instead of trusting a stale PID. These records drive lifecycle recovery; runtime events and plugin cost/tool data remain fail-open reporting evidence. Aggregate phase wall time, active compute, CI wait/repair, release/cleanup time, calls by tier, retries/outcomes, reuse, false-positive gates, and manual resumes when producing performance reports.
 

--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -61,7 +61,7 @@ Reference, lease, recovery, and audit checks remain hard vetoes.
 | Store | Owner | Primary classes | Existing authority | Required next contract |
 |---|---|---|---|---|
 | `~/.aidevops/runtime-bundles` | framework | active, leased, rollback, cache | Deployment protects current, previous, and live-leased bundles; unreferenced bundles converge under 30-day, 30-bundle, and 8 GiB soft limits | Keep the limits operator-configurable and preserve fail-closed reporting when references or sizing are unavailable |
-| `~/.aidevops/.agent-workspace/observability` | framework | audit, archive, cache | Runtime events are append-only evidence; plugin records runtime and tool-call data | Define the minimum audit envelope, payload/metadata limits, partition or archive semantics, and verified compaction rather than direct row deletion |
+| `~/.aidevops/.agent-workspace/observability` | framework | audit, archive, cache | Part streams and tool metadata are bounded at ingestion; runtime events use a 30-day active candidate window, verified immutable archive partitions, compacted low-value summaries, pinned recovery state, and append-only manifests | Measure defaults across routine/high-activity installations before changing the active window or adding any archive deletion policy |
 | `~/.aidevops/agents-backups` | framework | rollback, archive | Count-based snapshot retention | Add byte/age reporting and preserve at least the newest verified rollback artifact |
 | `~/.aidevops/logs` and worker failure excerpts | framework | audit, archive, scratch | Individual excerpts are size-capped; policies vary by producer | Define producer ownership and combined age/count/byte retention while retaining terminal failure evidence |
 | OpenCode data under its application-data root | joint | active, recovery, archive, unknown | OpenCode owns session and DB formats; aidevops archive/maintenance helpers coordinate selected operations | Separate logical retention from WAL/fragmentation maintenance; report only classifications proven through OpenCode-aware queries |
@@ -145,7 +145,10 @@ filesystem age or size deletion loop.
 2. Bound runtime bundles and evaluate lock-keyed dependency reuse while retaining
    current, previous, and live-leased protections.
 3. Define observability audit retention, payload limits, and archival or
-   partitioning semantics before compacting append-only evidence.
+   partitioning semantics before compacting append-only evidence. The initial
+   contract is implemented by `runtime-events-retention.mjs`; future changes
+   must preserve its dry-run, integrity, interruption, and protected-envelope
+   tests.
 4. Add coordinated policies for framework backups, logs, and worker failure
    excerpts, including conservative leftover migration.
 5. Coordinate OpenCode-owned storage through runtime-aware reporting and

--- a/.agents/scripts/observability-helper.sh
+++ b/.agents/scripts/observability-helper.sh
@@ -6,13 +6,13 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 set -euo pipefail
-init_log_file
 
 readonly OBS_DIR="${HOME}/.aidevops/.agent-workspace/observability"
 readonly OBS_METRICS="${OBS_DIR}/metrics.jsonl" OBS_OFFSETS="${OBS_DIR}/parse-offsets.json"
 readonly CLAUDE_LOG_DIR="${HOME}/.claude/projects"
 readonly RATE_LIMITS_CONFIG_USER="${HOME}/.config/aidevops/rate-limits.json"
 readonly RATE_LIMITS_CONFIG_TEMPLATE="${SCRIPT_DIR}/../configs/rate-limits.json.txt"
+readonly RUNTIME_EVENTS_RETENTION="${SCRIPT_DIR}/runtime-events-retention.mjs"
 readonly DEFAULT_WARN_PCT=80 DEFAULT_WINDOW_MINUTES=1
 
 init_storage() {
@@ -650,11 +650,30 @@ cmd_runtime_events() {
 	return 0
 }
 
+cmd_storage() {
+	command -v node &>/dev/null || {
+		print_error "node required"
+		return 1
+	}
+	node "$RUNTIME_EVENTS_RETENTION" inventory --db "${OBS_DIR}/llm-requests.db" "$@"
+	return $?
+}
+
+cmd_retention() {
+	command -v node &>/dev/null || {
+		print_error "node required"
+		return 1
+	}
+	node "$RUNTIME_EVENTS_RETENTION" archive --db "${OBS_DIR}/llm-requests.db" "$@"
+	return $?
+}
+
 cmd_help() {
 	cat <<EOF
 Observability Helper — LLM request and runtime-event evidence
 Usage: observability-helper.sh [command] [options]
-Commands: ingest | record (--model X) | rate-limits | cache-health | runtime-events [limit] | help
+Commands: ingest | record (--model X) | rate-limits | cache-health | runtime-events [limit]
+          storage [--json] | retention [--dry-run|--apply] [--before ISO] [--max-rows N] | help
 
 Record options:
   --model MODEL          Model name (required)
@@ -678,12 +697,20 @@ EOF
 main() {
 	local command="${1:-help}"
 	shift || true
-	init_storage || return 1
+	case "$command" in
+	storage | retention) ;;
+	*)
+		init_log_file
+		init_storage || return 1
+		;;
+	esac
 	case "$command" in
 	ingest | parse | import) cmd_ingest "$@" ;; record | r) cmd_record "$@" ;;
 	rate-limits | rate_limits | ratelimits | rl) cmd_rate_limits "$@" ;;
 	cache-health | cache_health | ch) cmd_cache_health "$@" ;;
 	runtime-events | runtime_events | events) cmd_runtime_events "$@" ;;
+	storage | storage-inventory) cmd_storage "$@" ;;
+	retention | archive) cmd_retention "$@" ;;
 	help | --help | -h) cmd_help ;; *)
 		print_error "Unknown: $command"
 		cmd_help

--- a/.agents/scripts/runtime-events-payload.mjs
+++ b/.agents/scripts/runtime-events-payload.mjs
@@ -25,7 +25,8 @@ const REPOSITORY_LIKE_PATTERN = /\b[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\b/g;
 const ORDINARY_PAYLOAD_KEYS = new Set([
   "attempt_id", "call_id", "classification", "duration_ms", "error_type", "exit_code",
   "finish_reason", "model_id", "observation", "provider_id", "reason", "result",
-  "role", "run_id", "source", "status", "success", "tool_name",
+  "role", "run_id", "source", "status", "success", "suppressed_part_bytes",
+  "suppressed_part_events", "tool_name",
 ]);
 const NOT_SCALAR = Symbol("not-scalar");
 

--- a/.agents/scripts/runtime-events-retention-cli.mjs
+++ b/.agents/scripts/runtime-events-retention-cli.mjs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const VALUE_OPTION_KEYS = new Map([
+  ["--active-days", "activeDays"],
+  ["--archive-dir", "archiveDir"],
+  ["--before", "cutoff"],
+  ["--db", "dbPath"],
+  ["--max-rows", "maxRows"],
+]);
+
+function parseCli(argv) {
+  const options = {};
+  const command = argv[0] || "inventory";
+  for (let index = 1; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument === "--apply" || argument === "--dry-run") {
+      options.apply = argument === "--apply";
+      continue;
+    }
+    if (argument === "--json") continue;
+    const optionKey = VALUE_OPTION_KEYS.get(argument);
+    if (!optionKey) throw new TypeError(`unknown retention argument: ${argument}`);
+    const value = argv[++index];
+    if (!value) throw new TypeError(`${argument} requires a value`);
+    options[optionKey] = value;
+  }
+  return { command, options };
+}
+
+export function runRetentionCommand(argv, actions) {
+  try {
+    const { command, options } = parseCli(argv);
+    const action = actions[command];
+    if (typeof action !== "function") throw new TypeError("command must be inventory or archive");
+    process.stdout.write(`${JSON.stringify(action(options))}\n`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    process.stderr.write(`runtime-event retention failed: ${message}\n`);
+    return 1;
+  }
+}

--- a/.agents/scripts/runtime-events-retention-inventory.mjs
+++ b/.agents/scripts/runtime-events-retention-inventory.mjs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { existsSync, lstatSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+function fileSize(filePath) {
+  try {
+    const entry = lstatSync(filePath);
+    return entry.isFile() && !entry.isSymbolicLink() ? entry.size : null;
+  } catch {
+    return null;
+  }
+}
+
+function activeStoreBytes(dbPath) {
+  return [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]
+    .map(fileSize)
+    .filter((value) => value !== null)
+    .reduce((total, value) => total + value, 0);
+}
+
+function archiveDirectoryBytes(archiveDir) {
+  if (!existsSync(archiveDir)) return { error: null, files: new Map(), total: 0 };
+  const files = new Map();
+  let total = 0;
+  try {
+    if (lstatSync(archiveDir).isSymbolicLink()) {
+      return { error: "archive-root-is-symlink", files, total };
+    }
+    for (const entry of readdirSync(archiveDir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      const bytes = fileSize(join(archiveDir, entry.name));
+      if (bytes === null) continue;
+      files.set(entry.name, bytes);
+      total += bytes;
+    }
+  } catch {
+    return { error: "archive-inventory-unavailable", files, total };
+  }
+  return { error: null, files, total };
+}
+
+function verifiedArchiveInventory(manifests, archiveStorage, archiveDir, verifyArchive) {
+  let error = null;
+  let verifiedArchiveBytes = 0;
+  for (const manifest of manifests) {
+    const archiveBytes = archiveStorage.files.get(manifest.archive_file);
+    const sidecarBytes = archiveStorage.files.get(`${manifest.archive_file}.manifest.json`);
+    const verification = verifyArchive(join(archiveDir, manifest.archive_file));
+    const matchesManifest = archiveBytes === Number(manifest.archive_bytes) &&
+      sidecarBytes !== undefined && verification.ok &&
+      verification.manifest?.archive_sha256 === manifest.archive_sha256;
+    if (matchesManifest) verifiedArchiveBytes += archiveBytes + sidecarBytes;
+    else error = "archive-verification-failed";
+  }
+  return { error, verifiedArchiveBytes };
+}
+
+function runtimeDbInventory(dbPath, cutoffAt, archiveDir, archiveStorage, dependencies) {
+  const { sqlEscape, sqliteRows, verifyArchive } = dependencies;
+  const empty = { candidateBytes: 0, error: null, protectedActiveBytes: 0, verifiedArchiveBytes: 0 };
+  if (!existsSync(dbPath)) return empty;
+  try {
+    const tables = sqliteRows(dbPath, `
+      SELECT name FROM sqlite_master WHERE type = 'table'
+      AND name IN ('runtime_events', 'runtime_event_archives');
+    `, { readonly: true });
+    if (!tables.some((row) => row.name === "runtime_events")) throw new Error("schema-unavailable");
+    const aggregates = sqliteRows(dbPath, `
+      SELECT
+        COALESCE(SUM(CASE WHEN occurred_at < ${sqlEscape(cutoffAt)} AND state_version IS NULL
+          THEN payload_bytes ELSE 0 END), 0) AS candidate_bytes,
+        COALESCE(SUM(CASE WHEN state_version IS NOT NULL THEN payload_bytes ELSE 0 END), 0)
+          AS protected_active_bytes
+      FROM runtime_events;
+    `, { readonly: true })[0] || {};
+    const hasArchiveTable = tables.some((row) => row.name === "runtime_event_archives");
+    const manifests = hasArchiveTable
+      ? sqliteRows(
+        dbPath,
+        "SELECT archive_file, archive_bytes, archive_sha256 FROM runtime_event_archives;",
+        { readonly: true },
+      )
+      : [];
+    const archiveInventory = verifiedArchiveInventory(
+      manifests,
+      archiveStorage,
+      archiveDir,
+      verifyArchive,
+    );
+    return {
+      candidateBytes: Number(aggregates.candidate_bytes || 0),
+      error: archiveInventory.error,
+      protectedActiveBytes: Number(aggregates.protected_active_bytes || 0),
+      verifiedArchiveBytes: archiveInventory.verifiedArchiveBytes,
+    };
+  } catch {
+    return { ...empty, error: "inventory-unavailable" };
+  }
+}
+
+/** Build a conservative physical/logical inventory without exposing payloads or private paths. */
+export function buildRuntimeEventRetentionInventory(options, dependencies) {
+  const {
+    activeDaysDefault,
+    canonicalizeDbPath,
+    normalizedArchiveDir,
+    normalizedCutoff,
+    resolveDbPath,
+    sqlEscape,
+    sqliteRows,
+    verifyArchive,
+  } = dependencies;
+  const dbPath = canonicalizeDbPath(options.dbPath || resolveDbPath());
+  const archiveDir = normalizedArchiveDir(options.archiveDir, dbPath);
+  const cutoffAt = normalizedCutoff(options.cutoff, options);
+  const activeBytes = existsSync(dbPath) ? activeStoreBytes(dbPath) : 0;
+  const archiveStorage = archiveDirectoryBytes(archiveDir);
+  const dbInventory = runtimeDbInventory(dbPath, cutoffAt, archiveDir, archiveStorage, {
+    sqlEscape,
+    sqliteRows,
+    verifyArchive,
+  });
+  const error = archiveStorage.error || dbInventory.error;
+  const totalBytes = activeBytes + archiveStorage.total;
+  const protectedBytes = Math.min(
+    totalBytes,
+    dbInventory.verifiedArchiveBytes + dbInventory.protectedActiveBytes,
+  );
+  return Object.freeze({
+    active_bytes: activeBytes,
+    archive_bytes: archiveStorage.total,
+    candidate_bytes: dbInventory.candidateBytes,
+    error,
+    next_action: "observability-helper.sh retention --dry-run",
+    policy: `${options.activeDays || activeDaysDefault}-day active window; verified archives; state recovery evidence pinned active`,
+    protected_bytes: protectedBytes,
+    reclaimable_bytes: 0,
+    sizing_confidence: error ? "unavailable" : "estimated",
+    total_bytes: totalBytes,
+    unknown_bytes: Math.max(0, totalBytes - protectedBytes),
+  });
+}

--- a/.agents/scripts/runtime-events-retention-verification.mjs
+++ b/.agents/scripts/runtime-events-retention-verification.mjs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { lstatSync, readFileSync } from "node:fs";
+import { basename } from "node:path";
+
+/** Verify a partition and sidecar without trusting filenames or row claims. */
+export function verifyArchiveArtifacts({ archivePath, digest, manifestPath, schemaVersion }) {
+  const errors = [];
+  let manifest = null;
+  let contents = "";
+  try {
+    if (lstatSync(archivePath).isSymbolicLink() || lstatSync(manifestPath).isSymbolicLink()) {
+      throw new Error("archive artifacts must not be symbolic links");
+    }
+    contents = readFileSync(archivePath, "utf8");
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const lines = contents.trimEnd().split("\n").map((line) => JSON.parse(line));
+    const header = lines[0];
+    const eventCount = lines.slice(1).filter((record) => record.record_type === "event").length;
+    const compactedCount = lines.slice(1)
+      .filter((record) => record.record_type === "summary")
+      .reduce((total, record) => total + Number(record.count || 0), 0);
+    if (header.record_type !== "manifest" || header.schema_version !== schemaVersion) {
+      errors.push("invalid archive header");
+    }
+    if (manifest.archive_sha256 !== digest(contents)) errors.push("archive digest mismatch");
+    if (manifest.archive_file !== basename(archivePath)) errors.push("archive filename mismatch");
+    if (manifest.archive_bytes !== Buffer.byteLength(contents, "utf8")) {
+      errors.push("archive byte count mismatch");
+    }
+    if (manifest.archive_record_count !== lines.length - 1) errors.push("archive record count mismatch");
+    if (manifest.protected_row_count !== eventCount) errors.push("protected event count mismatch");
+    if (manifest.compacted_row_count !== compactedCount) errors.push("compacted event count mismatch");
+    if (manifest.source_row_count !== eventCount + compactedCount) errors.push("source event count mismatch");
+    if (manifest.partition_id !== header.partition_id || manifest.source_sha256 !== header.source_sha256) {
+      errors.push("archive manifest/header mismatch");
+    }
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : "archive verification failed");
+  }
+  return Object.freeze({ errors, manifest, ok: errors.length === 0 });
+}

--- a/.agents/scripts/runtime-events-retention.mjs
+++ b/.agents/scripts/runtime-events-retention.mjs
@@ -1,0 +1,538 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/** Verified partition/archive maintenance for append-only runtime evidence. */
+
+import { execFileSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  initialiseRuntimeEventStore,
+  resolveRuntimeEventsDbPath,
+} from "./runtime-events-store.mjs";
+import { canonicalizeSqliteDbPath, sqlEscape } from "./sqlite-process.mjs";
+
+export const RUNTIME_EVENT_ARCHIVE_SCHEMA_VERSION = 1;
+export const RUNTIME_EVENT_ACTIVE_DAYS_DEFAULT = 30;
+export const RUNTIME_EVENT_ARCHIVE_MAX_ROWS_DEFAULT = 5000;
+
+const ERROR_STATUS = new Set([
+  "blocked", "cancelled", "denied", "error", "failed", "rejected", "timed_out", "timeout",
+]);
+const PROTECTED_EVENT_TYPE = /^(audit|deploy|full-loop|permission|release|security|session|subagent|worker)\.|(^|\.)(blocked|cancelled|completed|denied|error|failed|rejected|started|stopped|terminated|timeout)(\.|$)/;
+const EVENT_COLUMNS = [
+  "id", "envelope_version", "occurred_at", "event_id", "event_type", "correlation_id",
+  "causation_id", "subject_id", "session_id", "worker_id", "parent_worker_id",
+  "root_worker_id", "root_event_id", "parent_event_id", "state_version", "payload_json",
+  "payload_bytes", "redaction_count",
+];
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalValue(value) {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalValue(value[key])]));
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  return JSON.stringify(canonicalValue(value));
+}
+
+function normalizedArchiveDir(value, dbPath) {
+  const candidate = value || join(dirname(dbPath), "runtime-events-archive");
+  if (typeof candidate !== "string" || !isAbsolute(candidate) || candidate.includes("\0")) {
+    throw new TypeError("runtime-event archive directory must be an absolute filesystem path");
+  }
+  return resolve(candidate);
+}
+
+function normalizedCutoff(value, { now = new Date(), activeDays = RUNTIME_EVENT_ACTIVE_DAYS_DEFAULT } = {}) {
+  let cutoff;
+  if (value) {
+    cutoff = new Date(value);
+  } else {
+    const days = Number.parseInt(String(activeDays), 10);
+    if (!Number.isSafeInteger(days) || days < 1 || days > 3650) {
+      throw new TypeError("active days must be an integer from 1 to 3650");
+    }
+    cutoff = new Date(now.getTime() - (days * 24 * 60 * 60 * 1000));
+  }
+  if (Number.isNaN(cutoff.getTime()) || cutoff.getTime() >= now.getTime()) {
+    throw new TypeError("archive cutoff must be a valid time in the past");
+  }
+  return cutoff.toISOString();
+}
+
+function normalizedMaxRows(value) {
+  const parsed = Number.parseInt(String(value || RUNTIME_EVENT_ARCHIVE_MAX_ROWS_DEFAULT), 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 100000) {
+    throw new TypeError("archive max rows must be an integer from 1 to 100000");
+  }
+  return parsed;
+}
+
+function sqlite(dbPath, sql, { json = false, readonly = false } = {}) {
+  const args = ["-cmd", ".timeout 15000"];
+  if (json) args.push("-json");
+  if (readonly) args.push("-readonly");
+  args.push(dbPath);
+  return execFileSync("sqlite3", args, {
+    encoding: "utf8",
+    input: sql,
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: 30000,
+  }).trim();
+}
+
+function sqliteRows(dbPath, sql, options = {}) {
+  const output = sqlite(dbPath, sql, { ...options, json: true });
+  if (!output) return [];
+  const parsed = JSON.parse(output);
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+function parsedPayload(row) {
+  try {
+    const payload = JSON.parse(row.payload_json || "{}");
+    return payload && typeof payload === "object" ? payload : {};
+  } catch {
+    return {};
+  }
+}
+
+/** True when a row belongs to the minimum terminal/error/lifecycle/security/audit envelope. */
+export function isProtectedRuntimeEvent(row) {
+  if (row?.state_version !== null && row?.state_version !== undefined) return true;
+  const eventType = String(row?.event_type || "").toLowerCase();
+  if (PROTECTED_EVENT_TYPE.test(eventType)) return true;
+  const payload = parsedPayload(row);
+  if (payload.success === false || payload.error_type ||
+      (payload.exit_code !== undefined && Number(payload.exit_code) !== 0)) {
+    return true;
+  }
+  return ERROR_STATUS.has(String(payload.status || "").toLowerCase());
+}
+
+function normalizedEventRow(row) {
+  return Object.fromEntries(EVENT_COLUMNS.map((column) => [column, row[column] ?? null]));
+}
+
+function sourceDigest(rows) {
+  return sha256(rows.map((row) => canonicalJson(normalizedEventRow(row))).join("\n"));
+}
+
+function logicalRowBytes(row) {
+  return Buffer.byteLength(canonicalJson(normalizedEventRow(row)), "utf8");
+}
+
+function compactedSummaries(rows) {
+  const groups = new Map();
+  for (const row of rows) {
+    const eventType = String(row.event_type || "unknown");
+    const group = groups.get(eventType) || {
+      count: 0,
+      event_type: eventType,
+      first_occurred_at: row.occurred_at,
+      last_occurred_at: row.occurred_at,
+      payload_bytes: 0,
+      record_type: "summary",
+      redaction_count: 0,
+    };
+    group.count += 1;
+    group.first_occurred_at = group.first_occurred_at < row.occurred_at
+      ? group.first_occurred_at
+      : row.occurred_at;
+    group.last_occurred_at = group.last_occurred_at > row.occurred_at
+      ? group.last_occurred_at
+      : row.occurred_at;
+    group.payload_bytes += Number(row.payload_bytes || 0);
+    group.redaction_count += Number(row.redaction_count || 0);
+    groups.set(eventType, group);
+  }
+  return [...groups.values()].sort((left, right) => left.event_type.localeCompare(right.event_type));
+}
+
+function buildPartition(rows, cutoffAt, createdAt = new Date().toISOString()) {
+  const protectedRows = rows.filter(isProtectedRuntimeEvent);
+  const compactedRows = rows.filter((row) => !isProtectedRuntimeEvent(row));
+  const digest = sourceDigest(rows);
+  const firstId = Number(rows[0].id);
+  const lastId = Number(rows.at(-1).id);
+  const partitionId = `runtime-events-${firstId}-${lastId}-${digest.slice(0, 12)}`;
+  const eventRecords = protectedRows.map((row) => ({
+    event: normalizedEventRow(row),
+    record_type: "event",
+  }));
+  const summaryRecords = compactedSummaries(compactedRows);
+  const header = {
+    archive_record_count: eventRecords.length + summaryRecords.length,
+    compacted_row_count: compactedRows.length,
+    created_at: createdAt,
+    cutoff_at: cutoffAt,
+    partition_id: partitionId,
+    protected_row_count: protectedRows.length,
+    record_type: "manifest",
+    schema_version: RUNTIME_EVENT_ARCHIVE_SCHEMA_VERSION,
+    source_first_id: firstId,
+    source_last_id: lastId,
+    source_logical_bytes: rows.reduce((total, row) => total + logicalRowBytes(row), 0),
+    source_payload_bytes: rows.reduce((total, row) => total + Number(row.payload_bytes || 0), 0),
+    source_row_count: rows.length,
+    source_sha256: digest,
+  };
+  const contents = [header, ...eventRecords, ...summaryRecords]
+    .map((record) => canonicalJson(record))
+    .join("\n") + "\n";
+  return { contents, header };
+}
+
+function atomicWrite(filePath, contents) {
+  const tempPath = `${filePath}.tmp-${process.pid}-${randomUUID()}`;
+  let descriptor;
+  try {
+    descriptor = openSync(tempPath, "wx", 0o600);
+    writeFileSync(descriptor, contents, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(tempPath, filePath);
+    chmodSync(filePath, 0o444);
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+    if (existsSync(tempPath)) unlinkSync(tempPath);
+  }
+}
+
+function manifestForContents(header, archiveFile, contents) {
+  return {
+    ...header,
+    archive_bytes: Buffer.byteLength(contents, "utf8"),
+    archive_file: archiveFile,
+    archive_sha256: sha256(contents),
+  };
+}
+
+/** Verify a partition and its sidecar without trusting filenames or row claims. */
+export function verifyRuntimeEventArchive(archivePath, manifestPath = `${archivePath}.manifest.json`) {
+  const errors = [];
+  let manifest = null;
+  let contents = "";
+  try {
+    if (lstatSync(archivePath).isSymbolicLink() || lstatSync(manifestPath).isSymbolicLink()) {
+      throw new Error("archive artifacts must not be symbolic links");
+    }
+    contents = readFileSync(archivePath, "utf8");
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const lines = contents.trimEnd().split("\n").map((line) => JSON.parse(line));
+    const header = lines[0];
+    const eventCount = lines.slice(1).filter((record) => record.record_type === "event").length;
+    const compactedCount = lines.slice(1)
+      .filter((record) => record.record_type === "summary")
+      .reduce((total, record) => total + Number(record.count || 0), 0);
+    if (header.record_type !== "manifest" || header.schema_version !== RUNTIME_EVENT_ARCHIVE_SCHEMA_VERSION) {
+      errors.push("invalid archive header");
+    }
+    if (manifest.archive_sha256 !== sha256(contents)) errors.push("archive digest mismatch");
+    if (manifest.archive_file !== basename(archivePath)) errors.push("archive filename mismatch");
+    if (manifest.archive_bytes !== Buffer.byteLength(contents, "utf8")) errors.push("archive byte count mismatch");
+    if (manifest.archive_record_count !== lines.length - 1) errors.push("archive record count mismatch");
+    if (manifest.protected_row_count !== eventCount) errors.push("protected event count mismatch");
+    if (manifest.compacted_row_count !== compactedCount) errors.push("compacted event count mismatch");
+    if (manifest.source_row_count !== eventCount + compactedCount) errors.push("source event count mismatch");
+    if (manifest.partition_id !== header.partition_id || manifest.source_sha256 !== header.source_sha256) {
+      errors.push("archive manifest/header mismatch");
+    }
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : "archive verification failed");
+  }
+  return Object.freeze({ errors, manifest, ok: errors.length === 0 });
+}
+
+function persistPartition(archiveDir, partition) {
+  mkdirSync(archiveDir, { mode: 0o700, recursive: true });
+  if (lstatSync(archiveDir).isSymbolicLink()) throw new Error("archive directory must not be a symbolic link");
+  const archiveFile = `${partition.header.partition_id}.jsonl`;
+  const archivePath = join(archiveDir, archiveFile);
+  const manifestPath = `${archivePath}.manifest.json`;
+  const expectedManifest = manifestForContents(partition.header, archiveFile, partition.contents);
+
+  if (!existsSync(archivePath)) atomicWrite(archivePath, partition.contents);
+  if (!existsSync(manifestPath)) atomicWrite(manifestPath, `${canonicalJson(expectedManifest)}\n`);
+
+  const verified = verifyRuntimeEventArchive(archivePath, manifestPath);
+  if (!verified.ok || verified.manifest?.source_sha256 !== partition.header.source_sha256) {
+    throw new Error(`archive partition verification failed: ${verified.errors.join("; ")}`);
+  }
+  return { archivePath, manifest: verified.manifest, manifestPath };
+}
+
+function candidateRows(dbPath, cutoffAt, maxRows, { readonly = false } = {}) {
+  return sqliteRows(dbPath, `
+    SELECT ${EVENT_COLUMNS.join(", ")}
+    FROM runtime_events
+    WHERE occurred_at < ${sqlEscape(cutoffAt)} AND state_version IS NULL
+    ORDER BY id ASC LIMIT ${maxRows};
+  `, { readonly });
+}
+
+function archiveManifestInsertSql(manifest) {
+  return `INSERT INTO runtime_event_archives (
+    partition_id, schema_version, created_at, cutoff_at, source_first_id,
+    source_last_id, source_row_count, protected_row_count, compacted_row_count,
+    archive_record_count, source_payload_bytes, archive_bytes, source_sha256,
+    archive_sha256, archive_file
+  ) VALUES (
+    ${sqlEscape(manifest.partition_id)}, ${manifest.schema_version},
+    ${sqlEscape(manifest.created_at)}, ${sqlEscape(manifest.cutoff_at)},
+    ${manifest.source_first_id}, ${manifest.source_last_id}, ${manifest.source_row_count},
+    ${manifest.protected_row_count}, ${manifest.compacted_row_count},
+    ${manifest.archive_record_count}, ${manifest.source_payload_bytes},
+    ${manifest.archive_bytes}, ${sqlEscape(manifest.source_sha256)},
+    ${sqlEscape(manifest.archive_sha256)}, ${sqlEscape(manifest.archive_file)}
+  );`;
+}
+
+function pruneVerifiedSource(dbPath, manifest) {
+  const predicate = `id <= ${manifest.source_last_id} AND occurred_at < ${sqlEscape(manifest.cutoff_at)} AND state_version IS NULL`;
+  sqlite(dbPath, `.bail on
+BEGIN IMMEDIATE;
+CREATE TEMP TABLE runtime_retention_assert(ok INTEGER NOT NULL CHECK(ok = 1));
+INSERT INTO runtime_retention_assert VALUES ((
+  SELECT CASE WHEN COUNT(*) = ${manifest.source_row_count}
+    AND COALESCE(MIN(id), 0) = ${manifest.source_first_id}
+    AND COALESCE(MAX(id), 0) = ${manifest.source_last_id}
+    AND COALESCE(SUM(payload_bytes), 0) = ${manifest.source_payload_bytes}
+  THEN 1 ELSE 0 END FROM runtime_events WHERE ${predicate}
+));
+DROP TRIGGER runtime_events_reject_delete;
+DELETE FROM runtime_events WHERE ${predicate};
+INSERT INTO runtime_retention_assert VALUES (CASE WHEN changes() = ${manifest.source_row_count} THEN 1 ELSE 0 END);
+CREATE TRIGGER runtime_events_reject_delete
+BEFORE DELETE ON runtime_events
+BEGIN
+  SELECT RAISE(ABORT, 'runtime_events is append-only');
+END;
+${archiveManifestInsertSql(manifest)}
+COMMIT;
+`);
+  const remaining = Number(sqlite(dbPath, `SELECT COUNT(*) FROM runtime_events WHERE ${predicate};`) || 0);
+  const manifestRows = Number(sqlite(dbPath, `
+    SELECT COUNT(*) FROM runtime_event_archives
+    WHERE partition_id = ${sqlEscape(manifest.partition_id)}
+      AND archive_sha256 = ${sqlEscape(manifest.archive_sha256)};
+  `) || 0);
+  if (remaining !== 0 || manifestRows !== 1) throw new Error("archive commit verification failed");
+}
+
+/** Plan or apply one bounded archive partition. Apply is always explicit. */
+export function archiveRuntimeEvents(options = {}) {
+  const dbPath = canonicalizeSqliteDbPath(options.dbPath || resolveRuntimeEventsDbPath());
+  const archiveDir = normalizedArchiveDir(options.archiveDir, dbPath);
+  const cutoffAt = normalizedCutoff(options.cutoff, options);
+  const maxRows = normalizedMaxRows(options.maxRows);
+  if (!existsSync(dbPath)) {
+    return Object.freeze({ applied: false, candidate_bytes: 0, candidate_rows: 0, status: "database_missing" });
+  }
+  if (options.apply && !initialiseRuntimeEventStore(dbPath)) {
+    throw new Error("runtime-event store is unavailable");
+  }
+  const rows = candidateRows(dbPath, cutoffAt, maxRows, { readonly: !options.apply });
+  if (rows.length === 0) {
+    return Object.freeze({ applied: false, candidate_bytes: 0, candidate_rows: 0, status: "no_candidates" });
+  }
+  const partition = buildPartition(rows, cutoffAt, options.createdAt);
+  const result = {
+    applied: false,
+    candidate_bytes: partition.header.source_logical_bytes,
+    candidate_rows: partition.header.source_row_count,
+    compacted_rows: partition.header.compacted_row_count,
+    partition_id: partition.header.partition_id,
+    protected_rows: partition.header.protected_row_count,
+    status: options.apply ? "prepared" : "dry_run",
+  };
+  if (!options.apply) return Object.freeze(result);
+
+  const persisted = persistPartition(archiveDir, partition);
+  if (options.simulateInterruption === "after_archive") {
+    throw new Error("simulated interruption after verified archive");
+  }
+  pruneVerifiedSource(dbPath, persisted.manifest);
+  return Object.freeze({
+    ...result,
+    applied: true,
+    archive_bytes: persisted.manifest.archive_bytes,
+    archive_file: persisted.manifest.archive_file,
+    status: "archived",
+  });
+}
+
+function fileSize(filePath) {
+  try {
+    const entry = lstatSync(filePath);
+    return entry.isFile() && !entry.isSymbolicLink() ? entry.size : null;
+  } catch {
+    return null;
+  }
+}
+
+function activeStoreBytes(dbPath) {
+  return [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]
+    .map(fileSize)
+    .filter((value) => value !== null)
+    .reduce((total, value) => total + value, 0);
+}
+
+function archiveDirectoryBytes(archiveDir) {
+  if (!existsSync(archiveDir)) return { error: null, files: new Map(), total: 0 };
+  const files = new Map();
+  let total = 0;
+  try {
+    if (lstatSync(archiveDir).isSymbolicLink()) {
+      return { error: "archive-root-is-symlink", files, total };
+    }
+    for (const entry of readdirSync(archiveDir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      const bytes = fileSize(join(archiveDir, entry.name));
+      if (bytes === null) continue;
+      files.set(entry.name, bytes);
+      total += bytes;
+    }
+  } catch {
+    return { error: "archive-inventory-unavailable", files, total };
+  }
+  return { error: null, files, total };
+}
+
+/** Conservative physical/logical inventory with no raw payload or private path output. */
+export function runtimeEventRetentionInventory(options = {}) {
+  const dbPath = canonicalizeSqliteDbPath(options.dbPath || resolveRuntimeEventsDbPath());
+  const archiveDir = normalizedArchiveDir(options.archiveDir, dbPath);
+  const cutoffAt = normalizedCutoff(options.cutoff, options);
+  const activeBytes = existsSync(dbPath) ? activeStoreBytes(dbPath) : 0;
+  const archiveStorage = archiveDirectoryBytes(archiveDir);
+  let candidateBytes = 0;
+  let protectedActiveBytes = 0;
+  let verifiedArchiveBytes = 0;
+  let error = archiveStorage.error;
+
+  if (existsSync(dbPath)) {
+    try {
+      const tables = sqliteRows(dbPath, `
+        SELECT name FROM sqlite_master WHERE type = 'table'
+        AND name IN ('runtime_events', 'runtime_event_archives');
+      `, { readonly: true });
+      if (!tables.some((row) => row.name === "runtime_events")) throw new Error("schema-unavailable");
+      const aggregates = sqliteRows(dbPath, `
+        SELECT
+          COALESCE(SUM(CASE WHEN occurred_at < ${sqlEscape(cutoffAt)} AND state_version IS NULL
+            THEN payload_bytes ELSE 0 END), 0) AS candidate_bytes,
+          COALESCE(SUM(CASE WHEN state_version IS NOT NULL THEN payload_bytes ELSE 0 END), 0)
+            AS protected_active_bytes
+        FROM runtime_events;
+      `, { readonly: true })[0] || {};
+      candidateBytes = Number(aggregates.candidate_bytes || 0);
+      protectedActiveBytes = Number(aggregates.protected_active_bytes || 0);
+      const manifests = tables.some((row) => row.name === "runtime_event_archives")
+        ? sqliteRows(
+          dbPath,
+          "SELECT archive_file, archive_bytes, archive_sha256 FROM runtime_event_archives;",
+          { readonly: true },
+        )
+        : [];
+      for (const manifest of manifests) {
+        const archiveBytes = archiveStorage.files.get(manifest.archive_file);
+        const sidecarBytes = archiveStorage.files.get(`${manifest.archive_file}.manifest.json`);
+        const verification = verifyRuntimeEventArchive(join(archiveDir, manifest.archive_file));
+        if (archiveBytes === Number(manifest.archive_bytes) && sidecarBytes !== undefined &&
+            verification.ok && verification.manifest?.archive_sha256 === manifest.archive_sha256) {
+          verifiedArchiveBytes += archiveBytes + sidecarBytes;
+        } else {
+          error = "archive-verification-failed";
+        }
+      }
+    } catch {
+      error ||= "inventory-unavailable";
+    }
+  }
+
+  const totalBytes = activeBytes + archiveStorage.total;
+  const protectedBytes = Math.min(totalBytes, verifiedArchiveBytes + protectedActiveBytes);
+  return Object.freeze({
+    active_bytes: activeBytes,
+    archive_bytes: archiveStorage.total,
+    candidate_bytes: candidateBytes,
+    error,
+    next_action: "observability-helper.sh retention --dry-run",
+    policy: `${options.activeDays || RUNTIME_EVENT_ACTIVE_DAYS_DEFAULT}-day active window; verified archives; state recovery evidence pinned active`,
+    protected_bytes: protectedBytes,
+    reclaimable_bytes: 0,
+    sizing_confidence: error ? "unavailable" : "estimated",
+    total_bytes: totalBytes,
+    unknown_bytes: Math.max(0, totalBytes - protectedBytes),
+  });
+}
+
+function parseCli(argv) {
+  const options = {};
+  let command = argv[0] || "inventory";
+  for (let index = 1; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--apply") options.apply = true;
+    else if (arg === "--dry-run") options.apply = false;
+    else if (["--active-days", "--archive-dir", "--before", "--db", "--max-rows"].includes(arg)) {
+      const value = argv[++index];
+      if (!value) throw new TypeError(`${arg} requires a value`);
+      if (arg === "--active-days") options.activeDays = value;
+      if (arg === "--archive-dir") options.archiveDir = value;
+      if (arg === "--before") options.cutoff = value;
+      if (arg === "--db") options.dbPath = value;
+      if (arg === "--max-rows") options.maxRows = value;
+    } else if (arg === "--json") {
+      // JSON is the only output format; accepted for shell command symmetry.
+    } else {
+      throw new TypeError(`unknown retention argument: ${arg}`);
+    }
+  }
+  return { command, options };
+}
+
+export function runRetentionCli(argv = process.argv.slice(2)) {
+  try {
+    const { command, options } = parseCli(argv);
+    const result = command === "inventory"
+      ? runtimeEventRetentionInventory(options)
+      : command === "archive"
+        ? archiveRuntimeEvents(options)
+        : null;
+    if (!result) throw new TypeError("command must be inventory or archive");
+    process.stdout.write(`${canonicalJson(result)}\n`);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`runtime-event retention failed: ${error instanceof Error ? error.message : "unknown error"}\n`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  process.exitCode = runRetentionCli();
+}

--- a/.agents/scripts/runtime-events-retention.mjs
+++ b/.agents/scripts/runtime-events-retention.mjs
@@ -25,6 +25,7 @@ import {
   initialiseRuntimeEventStore,
   resolveRuntimeEventsDbPath,
 } from "./runtime-events-store.mjs";
+import { runRetentionCommand } from "./runtime-events-retention-cli.mjs";
 import { canonicalizeSqliteDbPath, sqlEscape } from "./sqlite-process.mjs";
 
 export const RUNTIME_EVENT_ARCHIVE_SCHEMA_VERSION = 1;
@@ -423,6 +424,59 @@ function archiveDirectoryBytes(archiveDir) {
   return { error: null, files, total };
 }
 
+function verifiedArchiveInventory(manifests, archiveStorage, archiveDir) {
+  let error = null;
+  let verifiedArchiveBytes = 0;
+  for (const manifest of manifests) {
+    const archiveBytes = archiveStorage.files.get(manifest.archive_file);
+    const sidecarBytes = archiveStorage.files.get(`${manifest.archive_file}.manifest.json`);
+    const verification = verifyRuntimeEventArchive(join(archiveDir, manifest.archive_file));
+    const matchesManifest = archiveBytes === Number(manifest.archive_bytes) &&
+      sidecarBytes !== undefined && verification.ok &&
+      verification.manifest?.archive_sha256 === manifest.archive_sha256;
+    if (matchesManifest) verifiedArchiveBytes += archiveBytes + sidecarBytes;
+    else error = "archive-verification-failed";
+  }
+  return { error, verifiedArchiveBytes };
+}
+
+function runtimeDbInventory(dbPath, cutoffAt, archiveDir, archiveStorage) {
+  const empty = { candidateBytes: 0, error: null, protectedActiveBytes: 0, verifiedArchiveBytes: 0 };
+  if (!existsSync(dbPath)) return empty;
+  try {
+    const tables = sqliteRows(dbPath, `
+      SELECT name FROM sqlite_master WHERE type = 'table'
+      AND name IN ('runtime_events', 'runtime_event_archives');
+    `, { readonly: true });
+    if (!tables.some((row) => row.name === "runtime_events")) throw new Error("schema-unavailable");
+    const aggregates = sqliteRows(dbPath, `
+      SELECT
+        COALESCE(SUM(CASE WHEN occurred_at < ${sqlEscape(cutoffAt)} AND state_version IS NULL
+          THEN payload_bytes ELSE 0 END), 0) AS candidate_bytes,
+        COALESCE(SUM(CASE WHEN state_version IS NOT NULL THEN payload_bytes ELSE 0 END), 0)
+          AS protected_active_bytes
+      FROM runtime_events;
+    `, { readonly: true })[0] || {};
+    const hasArchiveTable = tables.some((row) => row.name === "runtime_event_archives");
+    const manifests = hasArchiveTable
+      ? sqliteRows(
+        dbPath,
+        "SELECT archive_file, archive_bytes, archive_sha256 FROM runtime_event_archives;",
+        { readonly: true },
+      )
+      : [];
+    const archiveInventory = verifiedArchiveInventory(manifests, archiveStorage, archiveDir);
+    return {
+      candidateBytes: Number(aggregates.candidate_bytes || 0),
+      error: archiveInventory.error,
+      protectedActiveBytes: Number(aggregates.protected_active_bytes || 0),
+      verifiedArchiveBytes: archiveInventory.verifiedArchiveBytes,
+    };
+  } catch {
+    return { ...empty, error: "inventory-unavailable" };
+  }
+}
+
 /** Conservative physical/logical inventory with no raw payload or private path output. */
 export function runtimeEventRetentionInventory(options = {}) {
   const dbPath = canonicalizeSqliteDbPath(options.dbPath || resolveRuntimeEventsDbPath());
@@ -430,57 +484,18 @@ export function runtimeEventRetentionInventory(options = {}) {
   const cutoffAt = normalizedCutoff(options.cutoff, options);
   const activeBytes = existsSync(dbPath) ? activeStoreBytes(dbPath) : 0;
   const archiveStorage = archiveDirectoryBytes(archiveDir);
-  let candidateBytes = 0;
-  let protectedActiveBytes = 0;
-  let verifiedArchiveBytes = 0;
-  let error = archiveStorage.error;
-
-  if (existsSync(dbPath)) {
-    try {
-      const tables = sqliteRows(dbPath, `
-        SELECT name FROM sqlite_master WHERE type = 'table'
-        AND name IN ('runtime_events', 'runtime_event_archives');
-      `, { readonly: true });
-      if (!tables.some((row) => row.name === "runtime_events")) throw new Error("schema-unavailable");
-      const aggregates = sqliteRows(dbPath, `
-        SELECT
-          COALESCE(SUM(CASE WHEN occurred_at < ${sqlEscape(cutoffAt)} AND state_version IS NULL
-            THEN payload_bytes ELSE 0 END), 0) AS candidate_bytes,
-          COALESCE(SUM(CASE WHEN state_version IS NOT NULL THEN payload_bytes ELSE 0 END), 0)
-            AS protected_active_bytes
-        FROM runtime_events;
-      `, { readonly: true })[0] || {};
-      candidateBytes = Number(aggregates.candidate_bytes || 0);
-      protectedActiveBytes = Number(aggregates.protected_active_bytes || 0);
-      const manifests = tables.some((row) => row.name === "runtime_event_archives")
-        ? sqliteRows(
-          dbPath,
-          "SELECT archive_file, archive_bytes, archive_sha256 FROM runtime_event_archives;",
-          { readonly: true },
-        )
-        : [];
-      for (const manifest of manifests) {
-        const archiveBytes = archiveStorage.files.get(manifest.archive_file);
-        const sidecarBytes = archiveStorage.files.get(`${manifest.archive_file}.manifest.json`);
-        const verification = verifyRuntimeEventArchive(join(archiveDir, manifest.archive_file));
-        if (archiveBytes === Number(manifest.archive_bytes) && sidecarBytes !== undefined &&
-            verification.ok && verification.manifest?.archive_sha256 === manifest.archive_sha256) {
-          verifiedArchiveBytes += archiveBytes + sidecarBytes;
-        } else {
-          error = "archive-verification-failed";
-        }
-      }
-    } catch {
-      error ||= "inventory-unavailable";
-    }
-  }
+  const dbInventory = runtimeDbInventory(dbPath, cutoffAt, archiveDir, archiveStorage);
+  const error = archiveStorage.error || dbInventory.error;
 
   const totalBytes = activeBytes + archiveStorage.total;
-  const protectedBytes = Math.min(totalBytes, verifiedArchiveBytes + protectedActiveBytes);
+  const protectedBytes = Math.min(
+    totalBytes,
+    dbInventory.verifiedArchiveBytes + dbInventory.protectedActiveBytes,
+  );
   return Object.freeze({
     active_bytes: activeBytes,
     archive_bytes: archiveStorage.total,
-    candidate_bytes: candidateBytes,
+    candidate_bytes: dbInventory.candidateBytes,
     error,
     next_action: "observability-helper.sh retention --dry-run",
     policy: `${options.activeDays || RUNTIME_EVENT_ACTIVE_DAYS_DEFAULT}-day active window; verified archives; state recovery evidence pinned active`,
@@ -492,45 +507,11 @@ export function runtimeEventRetentionInventory(options = {}) {
   });
 }
 
-function parseCli(argv) {
-  const options = {};
-  let command = argv[0] || "inventory";
-  for (let index = 1; index < argv.length; index++) {
-    const arg = argv[index];
-    if (arg === "--apply") options.apply = true;
-    else if (arg === "--dry-run") options.apply = false;
-    else if (["--active-days", "--archive-dir", "--before", "--db", "--max-rows"].includes(arg)) {
-      const value = argv[++index];
-      if (!value) throw new TypeError(`${arg} requires a value`);
-      if (arg === "--active-days") options.activeDays = value;
-      if (arg === "--archive-dir") options.archiveDir = value;
-      if (arg === "--before") options.cutoff = value;
-      if (arg === "--db") options.dbPath = value;
-      if (arg === "--max-rows") options.maxRows = value;
-    } else if (arg === "--json") {
-      // JSON is the only output format; accepted for shell command symmetry.
-    } else {
-      throw new TypeError(`unknown retention argument: ${arg}`);
-    }
-  }
-  return { command, options };
-}
-
 export function runRetentionCli(argv = process.argv.slice(2)) {
-  try {
-    const { command, options } = parseCli(argv);
-    const result = command === "inventory"
-      ? runtimeEventRetentionInventory(options)
-      : command === "archive"
-        ? archiveRuntimeEvents(options)
-        : null;
-    if (!result) throw new TypeError("command must be inventory or archive");
-    process.stdout.write(`${canonicalJson(result)}\n`);
-    return 0;
-  } catch (error) {
-    process.stderr.write(`runtime-event retention failed: ${error instanceof Error ? error.message : "unknown error"}\n`);
-    return 1;
-  }
+  return runRetentionCommand(argv, {
+    archive: archiveRuntimeEvents,
+    inventory: runtimeEventRetentionInventory,
+  });
 }
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {

--- a/.agents/scripts/runtime-events-retention.mjs
+++ b/.agents/scripts/runtime-events-retention.mjs
@@ -14,7 +14,6 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
-  readdirSync,
   renameSync,
   unlinkSync,
   writeFileSync,
@@ -26,6 +25,7 @@ import {
   resolveRuntimeEventsDbPath,
 } from "./runtime-events-store.mjs";
 import { runRetentionCommand } from "./runtime-events-retention-cli.mjs";
+import { buildRuntimeEventRetentionInventory } from "./runtime-events-retention-inventory.mjs";
 import { canonicalizeSqliteDbPath, sqlEscape } from "./sqlite-process.mjs";
 
 export const RUNTIME_EVENT_ARCHIVE_SCHEMA_VERSION = 1;
@@ -387,123 +387,17 @@ export function archiveRuntimeEvents(options = {}) {
   });
 }
 
-function fileSize(filePath) {
-  try {
-    const entry = lstatSync(filePath);
-    return entry.isFile() && !entry.isSymbolicLink() ? entry.size : null;
-  } catch {
-    return null;
-  }
-}
-
-function activeStoreBytes(dbPath) {
-  return [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]
-    .map(fileSize)
-    .filter((value) => value !== null)
-    .reduce((total, value) => total + value, 0);
-}
-
-function archiveDirectoryBytes(archiveDir) {
-  if (!existsSync(archiveDir)) return { error: null, files: new Map(), total: 0 };
-  const files = new Map();
-  let total = 0;
-  try {
-    if (lstatSync(archiveDir).isSymbolicLink()) {
-      return { error: "archive-root-is-symlink", files, total };
-    }
-    for (const entry of readdirSync(archiveDir, { withFileTypes: true })) {
-      if (!entry.isFile()) continue;
-      const bytes = fileSize(join(archiveDir, entry.name));
-      if (bytes === null) continue;
-      files.set(entry.name, bytes);
-      total += bytes;
-    }
-  } catch {
-    return { error: "archive-inventory-unavailable", files, total };
-  }
-  return { error: null, files, total };
-}
-
-function verifiedArchiveInventory(manifests, archiveStorage, archiveDir) {
-  let error = null;
-  let verifiedArchiveBytes = 0;
-  for (const manifest of manifests) {
-    const archiveBytes = archiveStorage.files.get(manifest.archive_file);
-    const sidecarBytes = archiveStorage.files.get(`${manifest.archive_file}.manifest.json`);
-    const verification = verifyRuntimeEventArchive(join(archiveDir, manifest.archive_file));
-    const matchesManifest = archiveBytes === Number(manifest.archive_bytes) &&
-      sidecarBytes !== undefined && verification.ok &&
-      verification.manifest?.archive_sha256 === manifest.archive_sha256;
-    if (matchesManifest) verifiedArchiveBytes += archiveBytes + sidecarBytes;
-    else error = "archive-verification-failed";
-  }
-  return { error, verifiedArchiveBytes };
-}
-
-function runtimeDbInventory(dbPath, cutoffAt, archiveDir, archiveStorage) {
-  const empty = { candidateBytes: 0, error: null, protectedActiveBytes: 0, verifiedArchiveBytes: 0 };
-  if (!existsSync(dbPath)) return empty;
-  try {
-    const tables = sqliteRows(dbPath, `
-      SELECT name FROM sqlite_master WHERE type = 'table'
-      AND name IN ('runtime_events', 'runtime_event_archives');
-    `, { readonly: true });
-    if (!tables.some((row) => row.name === "runtime_events")) throw new Error("schema-unavailable");
-    const aggregates = sqliteRows(dbPath, `
-      SELECT
-        COALESCE(SUM(CASE WHEN occurred_at < ${sqlEscape(cutoffAt)} AND state_version IS NULL
-          THEN payload_bytes ELSE 0 END), 0) AS candidate_bytes,
-        COALESCE(SUM(CASE WHEN state_version IS NOT NULL THEN payload_bytes ELSE 0 END), 0)
-          AS protected_active_bytes
-      FROM runtime_events;
-    `, { readonly: true })[0] || {};
-    const hasArchiveTable = tables.some((row) => row.name === "runtime_event_archives");
-    const manifests = hasArchiveTable
-      ? sqliteRows(
-        dbPath,
-        "SELECT archive_file, archive_bytes, archive_sha256 FROM runtime_event_archives;",
-        { readonly: true },
-      )
-      : [];
-    const archiveInventory = verifiedArchiveInventory(manifests, archiveStorage, archiveDir);
-    return {
-      candidateBytes: Number(aggregates.candidate_bytes || 0),
-      error: archiveInventory.error,
-      protectedActiveBytes: Number(aggregates.protected_active_bytes || 0),
-      verifiedArchiveBytes: archiveInventory.verifiedArchiveBytes,
-    };
-  } catch {
-    return { ...empty, error: "inventory-unavailable" };
-  }
-}
-
 /** Conservative physical/logical inventory with no raw payload or private path output. */
 export function runtimeEventRetentionInventory(options = {}) {
-  const dbPath = canonicalizeSqliteDbPath(options.dbPath || resolveRuntimeEventsDbPath());
-  const archiveDir = normalizedArchiveDir(options.archiveDir, dbPath);
-  const cutoffAt = normalizedCutoff(options.cutoff, options);
-  const activeBytes = existsSync(dbPath) ? activeStoreBytes(dbPath) : 0;
-  const archiveStorage = archiveDirectoryBytes(archiveDir);
-  const dbInventory = runtimeDbInventory(dbPath, cutoffAt, archiveDir, archiveStorage);
-  const error = archiveStorage.error || dbInventory.error;
-
-  const totalBytes = activeBytes + archiveStorage.total;
-  const protectedBytes = Math.min(
-    totalBytes,
-    dbInventory.verifiedArchiveBytes + dbInventory.protectedActiveBytes,
-  );
-  return Object.freeze({
-    active_bytes: activeBytes,
-    archive_bytes: archiveStorage.total,
-    candidate_bytes: dbInventory.candidateBytes,
-    error,
-    next_action: "observability-helper.sh retention --dry-run",
-    policy: `${options.activeDays || RUNTIME_EVENT_ACTIVE_DAYS_DEFAULT}-day active window; verified archives; state recovery evidence pinned active`,
-    protected_bytes: protectedBytes,
-    reclaimable_bytes: 0,
-    sizing_confidence: error ? "unavailable" : "estimated",
-    total_bytes: totalBytes,
-    unknown_bytes: Math.max(0, totalBytes - protectedBytes),
+  return buildRuntimeEventRetentionInventory(options, {
+    activeDaysDefault: RUNTIME_EVENT_ACTIVE_DAYS_DEFAULT,
+    canonicalizeDbPath: canonicalizeSqliteDbPath,
+    normalizedArchiveDir,
+    normalizedCutoff,
+    resolveDbPath: resolveRuntimeEventsDbPath,
+    sqlEscape,
+    sqliteRows,
+    verifyArchive: verifyRuntimeEventArchive,
   });
 }
 

--- a/.agents/scripts/runtime-events-retention.mjs
+++ b/.agents/scripts/runtime-events-retention.mjs
@@ -13,12 +13,11 @@ import {
   lstatSync,
   mkdirSync,
   openSync,
-  readFileSync,
   renameSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   initialiseRuntimeEventStore,
@@ -26,6 +25,7 @@ import {
 } from "./runtime-events-store.mjs";
 import { runRetentionCommand } from "./runtime-events-retention-cli.mjs";
 import { buildRuntimeEventRetentionInventory } from "./runtime-events-retention-inventory.mjs";
+import { verifyArchiveArtifacts } from "./runtime-events-retention-verification.mjs";
 import { canonicalizeSqliteDbPath, sqlEscape } from "./sqlite-process.mjs";
 
 export const RUNTIME_EVENT_ARCHIVE_SCHEMA_VERSION = 1;
@@ -235,38 +235,12 @@ function manifestForContents(header, archiveFile, contents) {
 
 /** Verify a partition and its sidecar without trusting filenames or row claims. */
 export function verifyRuntimeEventArchive(archivePath, manifestPath = `${archivePath}.manifest.json`) {
-  const errors = [];
-  let manifest = null;
-  let contents = "";
-  try {
-    if (lstatSync(archivePath).isSymbolicLink() || lstatSync(manifestPath).isSymbolicLink()) {
-      throw new Error("archive artifacts must not be symbolic links");
-    }
-    contents = readFileSync(archivePath, "utf8");
-    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-    const lines = contents.trimEnd().split("\n").map((line) => JSON.parse(line));
-    const header = lines[0];
-    const eventCount = lines.slice(1).filter((record) => record.record_type === "event").length;
-    const compactedCount = lines.slice(1)
-      .filter((record) => record.record_type === "summary")
-      .reduce((total, record) => total + Number(record.count || 0), 0);
-    if (header.record_type !== "manifest" || header.schema_version !== RUNTIME_EVENT_ARCHIVE_SCHEMA_VERSION) {
-      errors.push("invalid archive header");
-    }
-    if (manifest.archive_sha256 !== sha256(contents)) errors.push("archive digest mismatch");
-    if (manifest.archive_file !== basename(archivePath)) errors.push("archive filename mismatch");
-    if (manifest.archive_bytes !== Buffer.byteLength(contents, "utf8")) errors.push("archive byte count mismatch");
-    if (manifest.archive_record_count !== lines.length - 1) errors.push("archive record count mismatch");
-    if (manifest.protected_row_count !== eventCount) errors.push("protected event count mismatch");
-    if (manifest.compacted_row_count !== compactedCount) errors.push("compacted event count mismatch");
-    if (manifest.source_row_count !== eventCount + compactedCount) errors.push("source event count mismatch");
-    if (manifest.partition_id !== header.partition_id || manifest.source_sha256 !== header.source_sha256) {
-      errors.push("archive manifest/header mismatch");
-    }
-  } catch (error) {
-    errors.push(error instanceof Error ? error.message : "archive verification failed");
-  }
-  return Object.freeze({ errors, manifest, ok: errors.length === 0 });
+  return verifyArchiveArtifacts({
+    archivePath,
+    digest: sha256,
+    manifestPath,
+    schemaVersion: RUNTIME_EVENT_ARCHIVE_SCHEMA_VERSION,
+  });
 }
 
 function persistPartition(archiveDir, partition) {

--- a/.agents/scripts/runtime-events-store.mjs
+++ b/.agents/scripts/runtime-events-store.mjs
@@ -71,6 +71,38 @@ BEFORE DELETE ON runtime_events
 BEGIN
   SELECT RAISE(ABORT, 'runtime_events is append-only');
 END;
+
+CREATE TABLE IF NOT EXISTS runtime_event_archives (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  partition_id TEXT NOT NULL UNIQUE,
+  schema_version INTEGER NOT NULL CHECK(schema_version = 1),
+  created_at TEXT NOT NULL,
+  cutoff_at TEXT NOT NULL,
+  source_first_id INTEGER NOT NULL,
+  source_last_id INTEGER NOT NULL,
+  source_row_count INTEGER NOT NULL CHECK(source_row_count > 0),
+  protected_row_count INTEGER NOT NULL CHECK(protected_row_count >= 0),
+  compacted_row_count INTEGER NOT NULL CHECK(compacted_row_count >= 0),
+  archive_record_count INTEGER NOT NULL CHECK(archive_record_count > 0),
+  source_payload_bytes INTEGER NOT NULL CHECK(source_payload_bytes >= 0),
+  archive_bytes INTEGER NOT NULL CHECK(archive_bytes > 0),
+  source_sha256 TEXT NOT NULL CHECK(length(source_sha256) = 64),
+  archive_sha256 TEXT NOT NULL CHECK(length(archive_sha256) = 64),
+  archive_file TEXT NOT NULL CHECK(instr(archive_file, '/') = 0),
+  CHECK(source_row_count = protected_row_count + compacted_row_count)
+);
+
+CREATE TRIGGER IF NOT EXISTS runtime_event_archives_reject_update
+BEFORE UPDATE ON runtime_event_archives
+BEGIN
+  SELECT RAISE(ABORT, 'runtime_event_archives is append-only');
+END;
+
+CREATE TRIGGER IF NOT EXISTS runtime_event_archives_reject_delete
+BEFORE DELETE ON runtime_event_archives
+BEGIN
+  SELECT RAISE(ABORT, 'runtime_event_archives is append-only');
+END;
 `;
 
 function queryJsonRows(sql, { executeSync = sqliteExecSync } = {}) {
@@ -93,12 +125,16 @@ function runtimeEventSchemaReady() {
     SELECT type, name FROM sqlite_master
     WHERE name IN (
       'runtime_events_reject_update', 'runtime_events_reject_delete',
-      'idx_runtime_events_subject_state_version', 'idx_runtime_events_worker_lineage'
+      'runtime_event_archives_reject_update', 'runtime_event_archives_reject_delete',
+      'runtime_event_archives', 'idx_runtime_events_subject_state_version',
+      'idx_runtime_events_worker_lineage'
     );
   `);
   const names = new Set(objects.map((row) => row.name));
   return [
     "runtime_events_reject_update", "runtime_events_reject_delete",
+    "runtime_event_archives_reject_update", "runtime_event_archives_reject_delete",
+    "runtime_event_archives",
     "idx_runtime_events_subject_state_version", "idx_runtime_events_worker_lineage",
   ].every((name) => names.has(name));
 }
@@ -196,7 +232,9 @@ function runtimeStoreIsValid(result) {
   return [
     result.quickCheck === "ok",
     result.missingColumns.length === 0,
+    result.archiveManifestReady,
     result.triggerCount === 2,
+    result.archiveTriggerCount === 2,
     result.invalidPayloadRows === 0,
     result.invalidStateSubjects.length === 0,
   ].every(Boolean);
@@ -213,6 +251,14 @@ export function verifyRuntimeEventStore() {
   const triggerCount = Number(sqliteExecSync(`
     SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger'
     AND name IN ('runtime_events_reject_update', 'runtime_events_reject_delete');
+  `, 15000) || 0);
+  const archiveManifestReady = Number(sqliteExecSync(`
+    SELECT COUNT(*) FROM sqlite_master
+    WHERE type = 'table' AND name = 'runtime_event_archives';
+  `, 15000) || 0) === 1;
+  const archiveTriggerCount = Number(sqliteExecSync(`
+    SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger'
+    AND name IN ('runtime_event_archives_reject_update', 'runtime_event_archives_reject_delete');
   `, 15000) || 0);
   const invalidPayloadRows = Number(sqliteExecSync(`
     SELECT COUNT(*) FROM runtime_events
@@ -232,6 +278,8 @@ export function verifyRuntimeEventStore() {
     }
   }
   const result = {
+    archiveManifestReady,
+    archiveTriggerCount,
     invalidPayloadRows,
     invalidStateSubjects,
     missingColumns,

--- a/.agents/scripts/runtime-events.mjs
+++ b/.agents/scripts/runtime-events.mjs
@@ -35,6 +35,12 @@ import {
   sqliteExecSync,
   sqlEscape,
 } from "./sqlite-process.mjs";
+import {
+  archiveRuntimeEvents,
+  isProtectedRuntimeEvent,
+  runtimeEventRetentionInventory,
+  verifyRuntimeEventArchive,
+} from "./runtime-events-retention.mjs";
 
 export const RUNTIME_EVENT_ENVELOPE_VERSION = 1;
 export {
@@ -49,6 +55,10 @@ export {
   reconstructRuntimeState,
   resolveRuntimeEventsDbPath,
   verifyRuntimeEventStore,
+  archiveRuntimeEvents,
+  isProtectedRuntimeEvent,
+  runtimeEventRetentionInventory,
+  verifyRuntimeEventArchive,
 };
 
 function normaliseOccurredAt(value) {

--- a/.agents/scripts/storage-inventory-helper.sh
+++ b/.agents/scripts/storage-inventory-helper.sh
@@ -13,6 +13,8 @@ fi
 STORAGE_SCHEMA_VERSION=1
 STORAGE_SIZE_TIMEOUT_TENTHS="${AIDEVOPS_STORAGE_SIZE_TIMEOUT_TENTHS:-20}"
 STORAGE_DU_COMMAND="${AIDEVOPS_STORAGE_DU_COMMAND:-du}"
+STORAGE_JSON_NULL="null"
+STORAGE_OWNER_FRAMEWORK="framework"
 
 _storage_usage() {
 	cat <<'USAGE'
@@ -92,16 +94,16 @@ _storage_emit_record() {
 	local protection_reason="$9"
 	local next_action="${10}"
 	local measured=""
-	local total_bytes="null"
+	local total_bytes="$STORAGE_JSON_NULL"
 	local confidence="unavailable"
 	local error=""
-	local protected_bytes="null"
+	local protected_bytes="$STORAGE_JSON_NULL"
 	local reclaimable_bytes=0
-	local unknown_bytes="null"
+	local unknown_bytes="$STORAGE_JSON_NULL"
 
 	measured=$(_storage_measure_path "$actual_path")
 	IFS='|' read -r total_bytes confidence error <<<"$measured"
-	if [[ "$total_bytes" != "null" ]]; then
+	if [[ "$total_bytes" != "$STORAGE_JSON_NULL" ]]; then
 		case "$disposition" in
 		protected)
 			protected_bytes="$total_bytes"
@@ -262,12 +264,58 @@ _storage_emit_runtime_bundle_record() {
 	return 0
 }
 
+_storage_observability_record() {
+	local home_label="~"
+	local display_path="${home_label}/.aidevops/.agent-workspace/observability"
+	local actual_path="${HOME}/.aidevops/.agent-workspace/observability"
+	local report=""
+	local measured=""
+	local total_bytes="$STORAGE_JSON_NULL"
+	local confidence="unavailable"
+	local sizing_error=""
+
+	report=$(bash "$SCRIPT_DIR/observability-helper.sh" storage --json 2>/dev/null || true)
+	if [[ -z "$report" ]] || ! printf '%s\n' "$report" | jq -e '
+		def is_number: type == "number";
+		type == "object" and (.active_bytes | is_number) and
+		(.archive_bytes | is_number) and (.protected_bytes | is_number) and
+		(.reclaimable_bytes | is_number) and (.unknown_bytes | is_number)
+	' >/dev/null 2>&1; then
+		_storage_emit_record "observability" "opencode-aidevops" "$display_path" "$actual_path" \
+			"$STORAGE_OWNER_FRAMEWORK" "unknown" "retention inventory unavailable" "unknown" \
+			"classification unavailable" "Use observability-helper.sh storage --json" |
+			jq -c '.error = "retention-inventory-unavailable"'
+		return 0
+	fi
+
+	measured=$(_storage_measure_path "$actual_path")
+	IFS='|' read -r total_bytes confidence sizing_error <<<"$measured"
+	jq -cn \
+		--arg path "$display_path" \
+		--arg owner "$STORAGE_OWNER_FRAMEWORK" \
+		--arg confidence "$confidence" \
+		--arg sizing_error "$sizing_error" \
+		--argjson total_bytes "$total_bytes" \
+		--argjson retention "$report" '
+		($retention.protected_bytes | if $total_bytes == null then null elif . > $total_bytes then $total_bytes else . end) as $protected |
+		(if $total_bytes == null then null else ($total_bytes - ($protected // 0)) end) as $unknown |
+		{store_id:"observability",producer:"opencode-aidevops",path:$path,owner:$owner,safety_class:"audit",
+		 policy:$retention.policy,total_bytes:$total_bytes,active_bytes:$retention.active_bytes,
+		 archive_bytes:$retention.archive_bytes,candidate_bytes:$retention.candidate_bytes,
+		 protected_bytes:$protected,reclaimable_bytes:0,unknown_bytes:$unknown,
+		 protection_reasons:["verified archives and pinned state-recovery evidence"],
+		 sizing_confidence:(if $sizing_error == "" and $retention.error == null then "estimated" else "unavailable" end),
+		 next_action:$retention.next_action,
+		 error:(if $sizing_error != "" then $sizing_error else $retention.error end)}'
+	return 0
+}
+
 _storage_inventory_records() {
 	local home_label="~"
 	_storage_emit_runtime_bundle_record
-	_storage_emit_record "observability" "opencode-aidevops" "${home_label}/.aidevops/.agent-workspace/observability" "${HOME}/.aidevops/.agent-workspace/observability" "framework" "audit" "append-only audit evidence; compaction contract pending" "protected" "audit evidence" "Use observability-helper.sh for bounded queries"
-	_storage_emit_record "agent-backups" "setup-backup" "${home_label}/.aidevops/agents-backups" "${HOME}/.aidevops/agents-backups" "framework" "rollback" "count-based snapshots; byte policy pending" "protected" "rollback safety" "Review backup inventory before any cleanup"
-	_storage_emit_record "framework-logs" "multiple-framework-producers" "${home_label}/.aidevops/logs" "${HOME}/.aidevops/logs" "framework" "audit" "producer-specific policies pending" "protected" "audit and unresolved failure evidence" "Use producer-specific diagnostics"
+	_storage_observability_record
+	_storage_emit_record "agent-backups" "setup-backup" "${home_label}/.aidevops/agents-backups" "${HOME}/.aidevops/agents-backups" "$STORAGE_OWNER_FRAMEWORK" "rollback" "count-based snapshots; byte policy pending" "protected" "rollback safety" "Review backup inventory before any cleanup"
+	_storage_emit_record "framework-logs" "multiple-framework-producers" "${home_label}/.aidevops/logs" "${HOME}/.aidevops/logs" "$STORAGE_OWNER_FRAMEWORK" "audit" "producer-specific policies pending" "protected" "audit and unresolved failure evidence" "Use producer-specific diagnostics"
 	_storage_emit_record "opencode-data" "opencode" "OpenCode application data" "${AIDEVOPS_OPENCODE_DATA_DIR:-${HOME}/.local/share/opencode}" "joint" "unknown" "runtime-aware maintenance only" "unknown" "OpenCode ownership and active-session state require runtime-aware queries" "Use aidevops opencode-db report"
 	_storage_emit_record "npm-cache" "npm" "npm cache" "${AIDEVOPS_NPM_CACHE_DIR:-${HOME}/.npm}" "external" "cache" "package-manager owned; no aidevops cleanup authority" "protected" "external owner" "Use npm-owned diagnostics and cleanup explicitly"
 	return 0
@@ -287,7 +335,7 @@ _storage_inventory_json() {
 
 _storage_format_bytes() {
 	local bytes="$1"
-	if [[ "$bytes" == "null" ]]; then
+	if [[ "$bytes" == "$STORAGE_JSON_NULL" ]]; then
 		printf 'unavailable'
 	elif [[ "$bytes" -ge 1073741824 ]]; then
 		printf '%s.%s GiB' "$((bytes / 1073741824))" "$(((bytes % 1073741824) * 10 / 1073741824))"

--- a/.agents/scripts/tests/test-observability-concurrent-init.sh
+++ b/.agents/scripts/tests/test-observability-concurrent-init.sh
@@ -154,8 +154,8 @@ fi
 # This is the primary regression — pre-fix, ALL workers logged this error.
 # =============================================================================
 
-lock_errors=$(grep -c "database is locked" "${LOG_DIR}"/worker-*.log 2>/dev/null \
-	| awk -F: '{sum += $2} END {print sum+0}')
+lock_errors=$(grep -c "database is locked" "${LOG_DIR}"/worker-*.log 2>/dev/null |
+	awk -F: '{sum += $2} END {print sum+0}')
 if [[ "$lock_errors" -eq 0 ]]; then
 	pass "zero 'database is locked' errors across $WORKER_COUNT workers"
 else
@@ -176,17 +176,17 @@ else
 fi
 
 # =============================================================================
-# Assertion 4: all four tables exist with expected columns and triggers.
+# Assertion 4: all five tables exist with expected columns and triggers.
 # =============================================================================
 
 table_count=$(sqlite3 "$DB_PATH" \
-	"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('llm_requests','tool_calls','session_summaries','runtime_events');" \
+	"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('llm_requests','tool_calls','session_summaries','runtime_events','runtime_event_archives');" \
 	2>/dev/null || echo "0")
-if [[ "$table_count" == "4" ]]; then
-	pass "all 4 tables created, including runtime_events"
+if [[ "$table_count" == "5" ]]; then
+	pass "all 5 tables created, including runtime-event archive manifests"
 else
-	fail "all 4 observability tables created" \
-		"found $table_count of 4"
+	fail "all 5 observability tables created" \
+		"found $table_count of 5"
 fi
 
 intent_col_count=$(sqlite3 "$DB_PATH" \
@@ -207,6 +207,16 @@ if [[ "$runtime_guard_count" == "2" ]]; then
 else
 	fail "runtime_events append-only triggers present" \
 		"trigger count: $runtime_guard_count (expected 2)"
+fi
+
+archive_guard_count=$(sqlite3 "$DB_PATH" \
+	"SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' AND name IN ('runtime_event_archives_reject_update','runtime_event_archives_reject_delete');" \
+	2>/dev/null || echo "0")
+if [[ "$archive_guard_count" == "2" ]]; then
+	pass "runtime-event archive manifests are append-only"
+else
+	fail "runtime-event archive manifest guards present" \
+		"trigger count: $archive_guard_count (expected 2)"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-runtime-events-cli.sh
+++ b/.agents/scripts/tests/test-runtime-events-cli.sh
@@ -47,7 +47,9 @@ source "$WORKER_LIFECYCLE"
 source "$WORKER_LAUNCH"
 CAPTURED_LAUNCH_ARGS="${TEST_ROOT}/launch-args"
 HEADLESS_RUNTIME_HELPER="${TEST_ROOT}/headless-runtime-helper.sh"
+LOGFILE="${TEST_ROOT}/pulse.log"
 self_login="runner"
+mkdir -p "${TEST_ROOT}/worktree"
 _dlw_prewarm_opencode_db() {
 	local worker_log="$1"
 	[[ -n "$worker_log" ]] || return 1
@@ -77,7 +79,7 @@ _dlw_exec_detached() {
 launch_pid=$(_dlw_nohup_launch \
 	"27030" "owner/repo" "dispatch" "lineage" "issue-27030" \
 	"${TEST_ROOT}/worker.log" "prompt" "${TEST_ROOT}/repo" "sonnet" "" \
-	"${TEST_ROOT}/worktree" "feature/gh-27030")
+	"${TEST_ROOT}/worktree" "feature/gh-27030" "attempt-test" "12345")
 [[ "$launch_pid" == "43210" ]]
 grep -Eq '^AIDEVOPS_WORKER_ID=worker:issue-27030:' "$CAPTURED_LAUNCH_ARGS"
 grep -q '^AIDEVOPS_PARENT_WORKER_ID=worker:child$' "$CAPTURED_LAUNCH_ARGS"
@@ -97,7 +99,7 @@ AIDEVOPS_WORKER_ID="$child_worker_id" \
 	AIDEVOPS_PARENT_EVENT_ID="$dispatch_event_id" \
 	AIDEVOPS_CAUSATION_ID="$dispatch_event_id" \
 	node "$RUNTIME_EVENTS" emit worker.started --status running \
-		--source worker_self_reported >/dev/null
+	--source worker_self_reported >/dev/null
 
 causal_rows=$(node "$RUNTIME_EVENTS" query --worker "$child_worker_id" --limit 10)
 [[ "$(printf '%s' "$causal_rows" | jq -r 'map(select(.event_type == "worker.dispatched"))[0].event_id')" == "$dispatch_event_id" ]]
@@ -114,8 +116,10 @@ import sys
 failure = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 handler = failure[failure.index("_exit_trap_handler()") : failure.index("_recover_dirty_worker_pr()")]
 assert "worker.exited" not in handler
-assert handler.index("_push_wip_commits_on_exit") < handler.index("_emit_worker_runtime_event")
-assert handler.index('reason="worker_complete"') < handler.index("_emit_worker_runtime_event")
+assert "_hrff_finalize_exit_trap" in handler
+finalizer = failure[failure.index("_hrff_finalize_exit_trap()") : failure.index("_exit_trap_handler()")]
+assert finalizer.index("_push_wip_commits_on_exit") < finalizer.index("_emit_worker_runtime_event")
+assert finalizer.index('reason="worker_complete"') < finalizer.index("_emit_worker_runtime_event")
 
 worker = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
 finish = worker[worker.index("_cmd_run_finish()") : worker.index("_cmd_run_prepare()")]

--- a/.agents/scripts/tests/test-storage-inventory-helper.sh
+++ b/.agents/scripts/tests/test-storage-inventory-helper.sh
@@ -61,7 +61,9 @@ after_checksum=$(fixture_checksum)
 [[ "$(printf '%s' "$report" | jq '.stores | length')" == "6" ]] || fail "expected six explicit stores"
 [[ "$(printf '%s' "$report" | jq '[.stores[].reclaimable_bytes] | add')" == "0" ]] || fail "foundation report suggested reclaimable bytes"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .unknown_bytes > 0')" == "true" ]] || fail "runtime bundles were not fail-closed unknown"
-[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "observability") | .protected_bytes > 0')" == "true" ]] || fail "audit evidence was not protected"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "observability") | .total_bytes > 0')" == "true" ]] || fail "observability bytes were not measured"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "observability") | .unknown_bytes > 0')" == "true" ]] || fail "unattributed observability bytes did not fail closed"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "observability") | has("active_bytes") and has("archive_bytes") and has("candidate_bytes")')" == "true" ]] || fail "observability lifecycle byte classes missing"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "npm-cache") | .owner')" == "external" ]] || fail "npm ownership was claimed by aidevops"
 
 human=$(bash "$HELPER" status)


### PR DESCRIPTION
## Summary

- Bound OpenCode part-stream amplification to per-message count/byte summaries with least-recently-used eviction.
- Replace raw tool metadata persistence with a 1 KiB outcome envelope while preserving terminal and error evidence.
- Add dry-run-first, interruption-safe runtime-event archive partitions, protected recovery envelopes, and ownership-aware storage reporting.

## Runtime Testing

- **Risk level:** Critical (append-only audit evidence archival and compaction)
- **Verification:** 46 Node tests passed across observability, tool-call, archive interruption, corruption, convergence, privacy, reconstruction, concurrency, and SQLite append-only fixtures; runtime-events CLI and storage inventory fixtures passed; `.agents/scripts/linters-local.sh` passed.

## Decisions

- Raw part streams and tool metadata are bounded at ingestion without suppressing terminal/error evidence.
- Runtime-event retention is dry-run first and fails closed on corrupt or incomplete archives.
- Verified archives and pinned state-recovery evidence remain protected; no archive deletion policy is introduced.

Resolves #28151

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 6h 10m and 936,439 tokens on this with the user in an interactive session. Overall, 2h 31m since this issue was created.
