### PR TITLE
t18162: Report and maintain OpenCode storage through ownership-aware contracts

### DIFF
--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -180,6 +180,35 @@ When both modes are provided, the archive uses the conservative intersection:
 recently updated sessions are preserved if they are within either the last-update
 age window or the most-recently-updated session budget.
 
+Archive mutation is also fail-closed. Before selecting or moving rows, the helper
+requires positive evidence that no process holds the active DB, the WAL remains
+stable across two observations, and the complete session-linked schema matches
+the supported archive contract. Missing holder tooling, a changing WAL,
+unavailable schema, new columns, or unknown session-linked tables leave the
+active database untouched. The async runner records these as protected or
+unsupported skips and does not advance its successful-run marker.
+
+After committed archive batches, SQLite compaction is independent of logical
+retention. VACUUM runs only when free pages exist and a second idle-holder plus
+stable-WAL check succeeds. A truncating checkpoint runs before and after VACUUM,
+then both active and archive databases are checked for queryability. An
+interrupted batch rolls back atomically; previously committed batches remain in
+the verified archive.
+
+## Unified storage report
+
+`aidevops status` reports OpenCode storage as separate ownership-aware records:
+
+- active database and logical-session bytes (`joint`, active or unknown);
+- active WAL/shared-memory bytes (`joint`, protected);
+- the aidevops-coordinated archive (`joint`, archive or unknown);
+- legacy formats, tool output, and unclassified future formats (`unknown`).
+
+The report never reads session content, never marks an OpenCode component
+reclaimable, and never infers logical-session retention from age or file size.
+Unavailable schemas and unknown future formats remain visible and untouched with
+an upstream/manual next action.
+
 ## Disruptive maintenance window
 
 `opencode-db-maintenance-helper.sh maintenance-window` is for explicit off-hours

--- a/.agents/scripts/opencode-db-archive-async-helper.sh
+++ b/.agents/scripts/opencode-db-archive-async-helper.sh
@@ -144,6 +144,10 @@ main() {
 	if [[ "$rc" -eq 0 ]]; then
 		_update_last_run
 		echo "[opencode-db-archive-async] Completed successfully at $(date -u '+%Y-%m-%dT%H:%M:%SZ'). last-run updated." >>"$LOGFILE"
+	elif [[ "$rc" -eq 2 ]]; then
+		echo "[opencode-db-archive-async] Protected skip: active holder, changing WAL, or incomplete checkpoint evidence — last-run NOT updated" >>"$LOGFILE"
+	elif [[ "$rc" -eq 3 ]]; then
+		echo "[opencode-db-archive-async] Unsupported OpenCode schema — active data left untouched and last-run NOT updated" >>"$LOGFILE"
 	else
 		echo "[opencode-db-archive-async] archive exited with rc=${rc} — last-run NOT updated" >>"$LOGFILE"
 	fi

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -27,6 +27,13 @@ set -Eeuo pipefail
 _oda_dir="${BASH_SOURCE[0]%/*}"
 # shellcheck source=shared-constants.sh
 [[ -f "${_oda_dir}/shared-constants.sh" ]] && source "${_oda_dir}/shared-constants.sh"
+# shellcheck source=opencode-db-safety-lib.sh
+if [[ -f "${_oda_dir}/opencode-db-safety-lib.sh" ]]; then
+	source "${_oda_dir}/opencode-db-safety-lib.sh"
+else
+	printf 'opencode-db-archive: missing safety library\n' >&2
+	exit 1
+fi
 
 # --- Configuration -----------------------------------------------------------
 
@@ -43,7 +50,6 @@ readonly DEFAULT_RETENTION_DAYS=30
 readonly DEFAULT_BATCH_SIZE=500
 readonly DEFAULT_MAX_DURATION=60
 readonly EVENT_TABLE_NAME="event"
-readonly UNKNOWN_STATE="unknown"
 
 ARCHIVE_BATCH_SIZE="${OPENCODE_DB_ARCHIVE_BATCH_SIZE:-$DEFAULT_BATCH_SIZE}"
 ARCHIVE_BATCH_DELAY_SECONDS="${OPENCODE_DB_ARCHIVE_BATCH_DELAY_SECONDS:-0}"
@@ -175,129 +181,23 @@ file_size_bytes() {
 	return 0
 }
 
-# Return a stable signature for the active WAL without reading its contents.
-# Missing is a valid stable state; unknown metadata fails closed.
-_wal_signature() {
-	local wal_path="$1"
-	local wal_bytes=""
-	local wal_mtime=""
-
-	if [[ ! -e "$wal_path" && ! -L "$wal_path" ]]; then
-		printf '%s' "missing"
-		return 0
-	fi
-	if [[ ! -f "$wal_path" ]]; then
-		printf '%s' "$UNKNOWN_STATE"
-		return 0
-	fi
-
-	wal_bytes=$(file_size_bytes "$wal_path" 2>/dev/null || true)
-	wal_mtime=$(_file_mtime_epoch "$wal_path" 2>/dev/null || true)
-	if [[ ! "$wal_bytes" =~ ^[0-9]+$ || ! "$wal_mtime" =~ ^[0-9]+$ ]]; then
-		printf '%s' "$UNKNOWN_STATE"
-		return 0
-	fi
-	printf '%s:%s' "$wal_bytes" "$wal_mtime"
-	return 0
-}
-
-# Hard-veto mutation while the WAL changes between two observations.
 _wal_is_stable() {
 	local db="$1"
-	local wal_path="${db}-wal"
-	local before=""
-	local after=""
-
-	before=$(_wal_signature "$wal_path")
-	if [[ "$before" == "$UNKNOWN_STATE" ]]; then
-		return 1
-	fi
-	sleep "$WAL_STABILITY_DELAY_SECONDS"
-	after=$(_wal_signature "$wal_path")
-	if [[ "$after" == "$UNKNOWN_STATE" || "$before" != "$after" ]]; then
-		return 1
-	fi
-	return 0
-}
-
-# Emit a holder count, or "unknown" when holder evidence is unavailable.
-_db_holder_count() {
-	local db="$1"
-	local holder_pids=""
-	local holder_count="0"
-
-	if ! command -v "$DB_HOLDER_COMMAND" >/dev/null 2>&1; then
-		printf '%s' "$UNKNOWN_STATE"
-		return 0
-	fi
-	holder_pids=$("$DB_HOLDER_COMMAND" -t "$db" 2>/dev/null || true)
-	if [[ -n "$holder_pids" ]]; then
-		holder_count=$(printf '%s\n' "$holder_pids" | awk 'NF' | sort -u | wc -l | tr -d ' ')
-	fi
-	printf '%s' "${holder_count:-0}"
-	return 0
-}
-
-_sqlite_table_columns() {
-	local db="$1"
-	local table_name="$2"
-	sqlite3 "$db" "SELECT COALESCE(group_concat(name, ','), '') FROM (SELECT name FROM pragma_table_info('${table_name}') ORDER BY cid);" 2>/dev/null
+	local wal_state=""
+	wal_state=$(opencode_db_wal_state "$db" "$WAL_STABILITY_DELAY_SECONDS")
+	[[ "$wal_state" == "stable" ]]
 	return $?
 }
 
-# Support only a schema whose complete logical-session write surface is known.
-# Extra columns or session-linked tables are unknown OpenCode data and remain
-# in the active database untouched.
-_archive_table_schema_supported() {
+_db_holder_count() {
 	local db="$1"
-	local table_name="$2"
-	local actual=""
-	local expected=""
-	local compatible=""
-
-	actual=$(_sqlite_table_columns "$db" "$table_name") || return 1
-	case "$table_name" in
-	project)
-		expected="id,worktree,vcs,name,icon_url,icon_color,time_created,time_updated,time_initialized,sandboxes,commands"
-		compatible="${expected},icon_url_override"
-		;;
-	session)
-		expected="id,project_id,parent_id,slug,directory,title,version,share_url,summary_additions,summary_deletions,summary_files,summary_diffs,revert,permission,time_created,time_updated,time_compacting,time_archived,workspace_id"
-		compatible="${expected},path"
-		;;
-	message) expected="id,session_id,time_created,time_updated,data" ;;
-	part) expected="id,message_id,session_id,time_created,time_updated,data" ;;
-	todo) expected="session_id,content,status,priority,position,time_created,time_updated" ;;
-	session_share) expected="session_id,id,secret,url,time_created,time_updated" ;;
-	event) expected="id,aggregate_id,seq,type,data" ;;
-	*) return 1 ;;
-	esac
-
-	if [[ "$actual" == "$expected" || (-n "$compatible" && "$actual" == "$compatible") ]]; then
-		return 0
-	fi
-	return 1
+	opencode_db_holder_count "$db" "$DB_HOLDER_COMMAND"
+	return 0
 }
 
 _archive_validate_active_schema() {
-	local table_name=""
-	local unknown_session_tables=""
-
-	for table_name in project session message part todo session_share; do
-		if ! _archive_table_schema_supported "$ACTIVE_DB" "$table_name"; then
-			print_error "Unsupported or unavailable OpenCode ${table_name} schema; active data was left untouched."
-			return 1
-		fi
-	done
-	if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME" && ! _archive_table_schema_supported "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
-		print_error "Unsupported OpenCode event schema; active data was left untouched."
-		return 1
-	fi
-
-	unknown_session_tables=$(sqlite3 "$ACTIVE_DB" \
-		"SELECT DISTINCT m.name FROM sqlite_master m JOIN pragma_table_info(m.name) p WHERE m.type='table' AND p.name='session_id' AND m.name NOT IN ('message','part','todo','session_share') ORDER BY m.name;" 2>/dev/null || true)
-	if [[ -n "$unknown_session_tables" ]]; then
-		print_error "Unsupported session-linked OpenCode tables detected; active data was left untouched."
+	if ! opencode_archive_schema_supported "$ACTIVE_DB" optional; then
+		print_error "Unsupported or unavailable OpenCode session schema; active data was left untouched."
 		return 1
 	fi
 	return 0
@@ -307,7 +207,7 @@ _archive_mutation_preflight() {
 	local holder_count=""
 
 	holder_count=$(_db_holder_count "$ACTIVE_DB")
-	if [[ "$holder_count" == "$UNKNOWN_STATE" ]]; then
+	if [[ "$holder_count" == "$OPENCODE_DB_STATE_UNKNOWN" ]]; then
 		print_warning "Archive deferred — active DB holder state is unavailable."
 		return 2
 	fi
@@ -607,7 +507,7 @@ _check_wal_post_archive() {
 	[[ -f "$wal_path" ]] || return 0
 	local wal_bytes wal_mb
 	wal_bytes=$(file_size_bytes "$wal_path")
-	wal_mb=$(( wal_bytes / 1048576 ))
+	wal_mb=$((wal_bytes / 1048576))
 	local threshold="${WAL_LARGE_THRESHOLD_MB:-500}"
 	[[ "$wal_mb" -ge "$threshold" ]] || return 0
 	print_warning "WAL still large after archive: $(format_bytes "$wal_bytes") (${wal_path})"
@@ -616,7 +516,7 @@ _check_wal_post_archive() {
 	ckpt_out=$(sqlite3 "$db" "PRAGMA wal_checkpoint(PASSIVE);" 2>/dev/null || echo "0|0|0")
 	IFS='|' read -r blocked log_pages ckpt_pages <<<"$ckpt_out"
 	if [[ "${blocked:-0}" == "1" ]] && [[ "${log_pages:-0}" -gt "${ckpt_pages:-0}" ]]; then
-		local unckpt=$(( ${log_pages:-0} - ${ckpt_pages:-0} ))
+		local unckpt=$((${log_pages:-0} - ${ckpt_pages:-0}))
 		print_warning "WAL checkpoint busy: ${unckpt} frame(s) still held by active readers"
 		local n_holders=0
 		if command -v lsof >/dev/null 2>&1 && [[ -f "$db" ]]; then
@@ -666,7 +566,7 @@ _archive_compact_active_db() {
 	fi
 
 	holder_count=$(_db_holder_count "$ACTIVE_DB")
-	if [[ "$holder_count" == "$UNKNOWN_STATE" ]]; then
+	if [[ "$holder_count" == "$OPENCODE_DB_STATE_UNKNOWN" ]]; then
 		print_warning "VACUUM deferred — active DB holder state is unavailable."
 		return 2
 	fi
@@ -685,7 +585,7 @@ _archive_compact_active_db() {
 		return 2
 	fi
 	holder_count=$(_db_holder_count "$ACTIVE_DB")
-	if [[ "$holder_count" == "$UNKNOWN_STATE" || "$holder_count" -gt 0 ]]; then
+	if [[ "$holder_count" == "$OPENCODE_DB_STATE_UNKNOWN" || "$holder_count" -gt 0 ]]; then
 		print_warning "VACUUM deferred — active DB holder state changed after checkpoint."
 		return 2
 	fi
@@ -880,13 +780,10 @@ cmd_archive() {
 
 	# Create archive DB and schema
 	create_archive_schema "$ARCHIVE_DB"
-	local archive_table=""
-	for archive_table in project session message part todo session_share event; do
-		if ! _archive_table_schema_supported "$ARCHIVE_DB" "$archive_table"; then
-			print_error "Archive schema is unavailable or unsupported; active data was left untouched."
-			return 3
-		fi
-	done
+	if ! opencode_archive_schema_supported "$ARCHIVE_DB" required; then
+		print_error "Archive schema is unavailable or unsupported; active data was left untouched."
+		return 3
+	fi
 
 	local project_insert_columns project_select_columns
 	local session_insert_columns session_select_columns

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -43,6 +43,12 @@ readonly DEFAULT_RETENTION_DAYS=30
 readonly DEFAULT_BATCH_SIZE=500
 readonly DEFAULT_MAX_DURATION=60
 readonly EVENT_TABLE_NAME="event"
+readonly UNKNOWN_STATE="unknown"
+
+ARCHIVE_BATCH_SIZE="${OPENCODE_DB_ARCHIVE_BATCH_SIZE:-$DEFAULT_BATCH_SIZE}"
+ARCHIVE_BATCH_DELAY_SECONDS="${OPENCODE_DB_ARCHIVE_BATCH_DELAY_SECONDS:-0}"
+DB_HOLDER_COMMAND="${OPENCODE_DB_HOLDER_COMMAND:-lsof}"
+WAL_STABILITY_DELAY_SECONDS="${OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS:-1}"
 
 ACTIVE_DB="${OPENCODE_DB_PATH:-${OPENCODE_DB:-$DEFAULT_DB}}"
 _archive_default_dir="${ACTIVE_DB%/*}"
@@ -169,15 +175,180 @@ file_size_bytes() {
 	return 0
 }
 
+# Return a stable signature for the active WAL without reading its contents.
+# Missing is a valid stable state; unknown metadata fails closed.
+_wal_signature() {
+	local wal_path="$1"
+	local wal_bytes=""
+	local wal_mtime=""
+
+	if [[ ! -e "$wal_path" && ! -L "$wal_path" ]]; then
+		printf '%s' "missing"
+		return 0
+	fi
+	if [[ ! -f "$wal_path" ]]; then
+		printf '%s' "$UNKNOWN_STATE"
+		return 0
+	fi
+
+	wal_bytes=$(file_size_bytes "$wal_path" 2>/dev/null || true)
+	wal_mtime=$(_file_mtime_epoch "$wal_path" 2>/dev/null || true)
+	if [[ ! "$wal_bytes" =~ ^[0-9]+$ || ! "$wal_mtime" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$UNKNOWN_STATE"
+		return 0
+	fi
+	printf '%s:%s' "$wal_bytes" "$wal_mtime"
+	return 0
+}
+
+# Hard-veto mutation while the WAL changes between two observations.
+_wal_is_stable() {
+	local db="$1"
+	local wal_path="${db}-wal"
+	local before=""
+	local after=""
+
+	before=$(_wal_signature "$wal_path")
+	if [[ "$before" == "$UNKNOWN_STATE" ]]; then
+		return 1
+	fi
+	sleep "$WAL_STABILITY_DELAY_SECONDS"
+	after=$(_wal_signature "$wal_path")
+	if [[ "$after" == "$UNKNOWN_STATE" || "$before" != "$after" ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# Emit a holder count, or "unknown" when holder evidence is unavailable.
+_db_holder_count() {
+	local db="$1"
+	local holder_pids=""
+	local holder_count="0"
+
+	if ! command -v "$DB_HOLDER_COMMAND" >/dev/null 2>&1; then
+		printf '%s' "$UNKNOWN_STATE"
+		return 0
+	fi
+	holder_pids=$("$DB_HOLDER_COMMAND" -t "$db" 2>/dev/null || true)
+	if [[ -n "$holder_pids" ]]; then
+		holder_count=$(printf '%s\n' "$holder_pids" | awk 'NF' | sort -u | wc -l | tr -d ' ')
+	fi
+	printf '%s' "${holder_count:-0}"
+	return 0
+}
+
+_sqlite_table_columns() {
+	local db="$1"
+	local table_name="$2"
+	sqlite3 "$db" "SELECT COALESCE(group_concat(name, ','), '') FROM (SELECT name FROM pragma_table_info('${table_name}') ORDER BY cid);" 2>/dev/null
+	return $?
+}
+
+# Support only a schema whose complete logical-session write surface is known.
+# Extra columns or session-linked tables are unknown OpenCode data and remain
+# in the active database untouched.
+_archive_table_schema_supported() {
+	local db="$1"
+	local table_name="$2"
+	local actual=""
+	local expected=""
+	local compatible=""
+
+	actual=$(_sqlite_table_columns "$db" "$table_name") || return 1
+	case "$table_name" in
+	project)
+		expected="id,worktree,vcs,name,icon_url,icon_color,time_created,time_updated,time_initialized,sandboxes,commands"
+		compatible="${expected},icon_url_override"
+		;;
+	session)
+		expected="id,project_id,parent_id,slug,directory,title,version,share_url,summary_additions,summary_deletions,summary_files,summary_diffs,revert,permission,time_created,time_updated,time_compacting,time_archived,workspace_id"
+		compatible="${expected},path"
+		;;
+	message) expected="id,session_id,time_created,time_updated,data" ;;
+	part) expected="id,message_id,session_id,time_created,time_updated,data" ;;
+	todo) expected="session_id,content,status,priority,position,time_created,time_updated" ;;
+	session_share) expected="session_id,id,secret,url,time_created,time_updated" ;;
+	event) expected="id,aggregate_id,seq,type,data" ;;
+	*) return 1 ;;
+	esac
+
+	if [[ "$actual" == "$expected" || (-n "$compatible" && "$actual" == "$compatible") ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_archive_validate_active_schema() {
+	local table_name=""
+	local unknown_session_tables=""
+
+	for table_name in project session message part todo session_share; do
+		if ! _archive_table_schema_supported "$ACTIVE_DB" "$table_name"; then
+			print_error "Unsupported or unavailable OpenCode ${table_name} schema; active data was left untouched."
+			return 1
+		fi
+	done
+	if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME" && ! _archive_table_schema_supported "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+		print_error "Unsupported OpenCode event schema; active data was left untouched."
+		return 1
+	fi
+
+	unknown_session_tables=$(sqlite3 "$ACTIVE_DB" \
+		"SELECT DISTINCT m.name FROM sqlite_master m JOIN pragma_table_info(m.name) p WHERE m.type='table' AND p.name='session_id' AND m.name NOT IN ('message','part','todo','session_share') ORDER BY m.name;" 2>/dev/null || true)
+	if [[ -n "$unknown_session_tables" ]]; then
+		print_error "Unsupported session-linked OpenCode tables detected; active data was left untouched."
+		return 1
+	fi
+	return 0
+}
+
+_archive_mutation_preflight() {
+	local holder_count=""
+
+	holder_count=$(_db_holder_count "$ACTIVE_DB")
+	if [[ "$holder_count" == "$UNKNOWN_STATE" ]]; then
+		print_warning "Archive deferred — active DB holder state is unavailable."
+		return 2
+	fi
+	if [[ "$holder_count" -gt 0 ]]; then
+		print_warning "Archive deferred — ${holder_count} process(es) hold the active DB open."
+		return 2
+	fi
+	if ! _wal_is_stable "$ACTIVE_DB"; then
+		print_warning "Archive deferred — active WAL changed during the safety observation window."
+		return 2
+	fi
+	if ! _archive_validate_active_schema; then
+		return 3
+	fi
+	return 0
+}
+
 # Checkpoint the archive WAL — called on normal exit and via trap on early return.
 # Uses a global flag to prevent double-run when the fast-path calls it explicitly.
 _ARCHIVE_CHECKPOINT_DONE=0
+_ARCHIVE_CLEANUP_ENABLED=0
 _checkpoint_archive_db() {
 	local archive_db="$1"
 	if ((_ARCHIVE_CHECKPOINT_DONE)); then return 0; fi
 	_ARCHIVE_CHECKPOINT_DONE=1
 	sqlite3 "$archive_db" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true
 	return 0
+}
+
+_archive_cleanup() {
+	if ((_ARCHIVE_CLEANUP_ENABLED)) && [[ -f "$ARCHIVE_DB" ]]; then
+		_checkpoint_archive_db "$ARCHIVE_DB"
+	fi
+	return 0
+}
+
+_archive_interrupt() {
+	local exit_code="$1"
+	print_warning "Archive interrupted; committed batches remain queryable and the active transaction will roll back."
+	exit "$exit_code"
+	return 1
 }
 
 # --- Schema creation in archive DB -------------------------------------------
@@ -463,6 +634,80 @@ _check_wal_post_archive() {
 	return 0
 }
 
+_checkpoint_active_db_truncate() {
+	local checkpoint_output=""
+	local blocked=""
+	local log_pages=""
+	local checkpointed_pages=""
+
+	checkpoint_output=$(sqlite3 "$ACTIVE_DB" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null) || return 1
+	IFS='|' read -r blocked log_pages checkpointed_pages <<<"$checkpoint_output"
+	if [[ "${blocked:-1}" != "0" ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# Compact only with positive idle-holder, stable-WAL, and checkpoint evidence.
+# This reclaims SQLite free pages; it never selects logical sessions by size.
+_archive_compact_active_db() {
+	local freelist_count=""
+	local holder_count=""
+	local quick_check=""
+
+	freelist_count=$(sqlite3 "$ACTIVE_DB" "PRAGMA freelist_count;" 2>/dev/null || true)
+	if [[ ! "$freelist_count" =~ ^[0-9]+$ ]]; then
+		print_warning "VACUUM deferred — freelist state is unavailable."
+		return 2
+	fi
+	if [[ "$freelist_count" -eq 0 ]]; then
+		print_info "VACUUM not needed — active DB has no free pages."
+		return 0
+	fi
+
+	holder_count=$(_db_holder_count "$ACTIVE_DB")
+	if [[ "$holder_count" == "$UNKNOWN_STATE" ]]; then
+		print_warning "VACUUM deferred — active DB holder state is unavailable."
+		return 2
+	fi
+	if [[ "$holder_count" -gt 0 ]]; then
+		print_warning "VACUUM deferred — ${holder_count} process(es) hold the active DB open."
+		return 2
+	fi
+	if ! _wal_is_stable "$ACTIVE_DB"; then
+		print_warning "VACUUM deferred — active WAL changed during the safety observation window."
+		return 2
+	fi
+
+	print_info "Running pre-VACUUM wal_checkpoint(TRUNCATE)..."
+	if ! _checkpoint_active_db_truncate; then
+		print_warning "VACUUM deferred — pre-VACUUM checkpoint was busy or unavailable."
+		return 2
+	fi
+	holder_count=$(_db_holder_count "$ACTIVE_DB")
+	if [[ "$holder_count" == "$UNKNOWN_STATE" || "$holder_count" -gt 0 ]]; then
+		print_warning "VACUUM deferred — active DB holder state changed after checkpoint."
+		return 2
+	fi
+
+	print_info "Running VACUUM on active DB..."
+	if ! sqlite3 "$ACTIVE_DB" "VACUUM;" 2>/dev/null; then
+		print_warning "VACUUM deferred — exclusive access was lost. Will retry next cycle."
+		return 2
+	fi
+	print_info "Running post-VACUUM wal_checkpoint(TRUNCATE)..."
+	if ! _checkpoint_active_db_truncate; then
+		print_warning "Post-VACUUM checkpoint was busy or unavailable; maintenance remains incomplete."
+		return 2
+	fi
+	quick_check=$(sqlite3 "$ACTIVE_DB" "PRAGMA quick_check;" 2>/dev/null || true)
+	if [[ "$quick_check" != "ok" ]]; then
+		print_error "Active DB quick_check failed after VACUUM."
+		return 1
+	fi
+	return 0
+}
+
 _archive_candidate_filter() {
 	local retention_enabled="$1"
 	local cutoff_ms="$2"
@@ -535,6 +780,26 @@ cmd_archive() {
 	check_active_db || return 1
 	_validate_nonnegative_integer "$retention_days" "--retention-days" || return 1
 	_validate_nonnegative_integer "$keep_sessions" "--keep-sessions" || return 1
+	_validate_nonnegative_integer "$max_duration" "--max-duration-seconds" || return 1
+	_validate_nonnegative_integer "$ARCHIVE_BATCH_SIZE" "OPENCODE_DB_ARCHIVE_BATCH_SIZE" || return 1
+	if [[ "$ARCHIVE_BATCH_SIZE" -eq 0 ]]; then
+		print_error "OPENCODE_DB_ARCHIVE_BATCH_SIZE must be greater than zero."
+		return 1
+	fi
+	if [[ ! "$ARCHIVE_BATCH_DELAY_SECONDS" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+		print_error "OPENCODE_DB_ARCHIVE_BATCH_DELAY_SECONDS must be a non-negative number."
+		return 1
+	fi
+	if [[ ! "$WAL_STABILITY_DELAY_SECONDS" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+		print_error "OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS must be a non-negative number."
+		return 1
+	fi
+
+	local preflight_rc=0
+	_archive_mutation_preflight || preflight_rc=$?
+	if [[ "$preflight_rc" -ne 0 ]]; then
+		return "$preflight_rc"
+	fi
 
 	local cutoff_ms
 	cutoff_ms=$(($(date +%s) * 1000 - retention_days * 86400 * 1000))
@@ -580,7 +845,8 @@ cmd_archive() {
 
 	if ((total_eligible == 0)); then
 		print_success "No sessions match the archive retention target."
-		return 0
+		_archive_compact_active_db
+		return $?
 	fi
 
 	print_info "Found $total_eligible sessions eligible for archiving"
@@ -614,6 +880,13 @@ cmd_archive() {
 
 	# Create archive DB and schema
 	create_archive_schema "$ARCHIVE_DB"
+	local archive_table=""
+	for archive_table in project session message part todo session_share event; do
+		if ! _archive_table_schema_supported "$ARCHIVE_DB" "$archive_table"; then
+			print_error "Archive schema is unavailable or unsupported; active data was left untouched."
+			return 3
+		fi
+	done
 
 	local project_insert_columns project_select_columns
 	local session_insert_columns session_select_columns
@@ -629,12 +902,13 @@ cmd_archive() {
 	local size_before
 	size_before=$(file_size_bytes "$ACTIVE_DB")
 
-	# Cleanup scope: checkpoint the archive WAL on any exit path (normal or signal).
-	# _checkpoint_archive_db uses a global flag to prevent double-run; the trap
-	# ensures it runs on early return between batches, and the fast-path call below
-	# (before vacuum) runs it explicitly on normal completion.
+	# Cleanup scope: checkpoint the archive WAL on every process exit. SQLite rolls
+	# back an interrupted in-flight batch; already committed batches stay queryable.
 	_ARCHIVE_CHECKPOINT_DONE=0
-	trap '_checkpoint_archive_db "$ARCHIVE_DB"' RETURN
+	_ARCHIVE_CLEANUP_ENABLED=1
+	trap '_archive_cleanup' EXIT
+	trap '_archive_interrupt 130' INT
+	trap '_archive_interrupt 143' TERM
 
 	local start_time
 	start_time=$(date +%s)
@@ -652,7 +926,7 @@ cmd_archive() {
 		fi
 
 		batch_num=$((batch_num + 1))
-		local batch_limit="$DEFAULT_BATCH_SIZE"
+		local batch_limit="$ARCHIVE_BATCH_SIZE"
 		local remaining=$((total_eligible - archived_total))
 		if ((remaining < batch_limit)); then
 			batch_limit=$remaining
@@ -758,20 +1032,22 @@ BATCH_SQL
 		if ((freed < 0)); then freed=0; fi
 
 		print_info "Archived $archived_total/$total_eligible sessions [batch $batch_num] ($(format_bytes "$freed") freed)"
+		if [[ "$ARCHIVE_BATCH_DELAY_SECONDS" != "0" ]]; then
+			sleep "$ARCHIVE_BATCH_DELAY_SECONDS"
+		fi
 	done
 
 	# Fast-path explicit cleanup: checkpoint archive WAL before vacuum.
 	# Marks done so the RETURN trap does not double-run.
 	_checkpoint_archive_db "$ARCHIVE_DB"
 
-	# Reclaim space — VACUUM works regardless of auto_vacuum setting.
-	# PRAGMA incremental_vacuum is a no-op when auto_vacuum=0 (the SQLite default
-	# used by OpenCode), so VACUUM is required here. VACUUM needs exclusive access;
-	# if another connection holds the DB (interactive session), skip gracefully and
-	# retry on the next archive cycle.
-	print_info "Running VACUUM on active DB..."
-	if ! sqlite3 "$ACTIVE_DB" "VACUUM;" 2>/dev/null; then
-		print_warning "VACUUM skipped — database is in use by another process. Will retry next cycle."
+	local compact_rc=0
+	_archive_compact_active_db || compact_rc=$?
+	local archive_quick_check=""
+	archive_quick_check=$(sqlite3 "$ARCHIVE_DB" "PRAGMA quick_check;" 2>/dev/null || true)
+	if [[ "$archive_quick_check" != "ok" ]]; then
+		print_error "Archive DB quick_check failed after archive pass."
+		return 1
 	fi
 
 	local size_after
@@ -785,6 +1061,11 @@ BATCH_SQL
 	print_success "Archive DB: $(format_bytes "$(file_size_bytes "$ARCHIVE_DB")")"
 	# Surface large WAL that remains after archiving (active readers may be blocking truncation).
 	_check_wal_post_archive "$ACTIVE_DB"
+	_ARCHIVE_CLEANUP_ENABLED=0
+	trap - EXIT INT TERM
+	if [[ "$compact_rc" -ne 0 ]]; then
+		return "$compact_rc"
+	fi
 	return 0
 }
 
@@ -918,14 +1199,15 @@ HELP
 
 main() {
 	local command="${1:-help}"
+	local rc=0
 	shift || true
 
 	case "$command" in
 	archive)
-		cmd_archive "$@"
+		cmd_archive "$@" || rc=$?
 		;;
 	stats)
-		cmd_stats "$@"
+		cmd_stats "$@" || rc=$?
 		;;
 	help | --help | -h)
 		cmd_help
@@ -936,7 +1218,7 @@ main() {
 		return 1
 		;;
 	esac
-	return 0
+	return "$rc"
 }
 
 main "$@"

--- a/.agents/scripts/opencode-db-safety-lib.sh
+++ b/.agents/scripts/opencode-db-safety-lib.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Shared, read-only evidence probes for OpenCode SQLite maintenance and storage
+# reporting. Callers own policy decisions; this library never mutates a DB.
+
+OPENCODE_DB_STATE_UNKNOWN="${OPENCODE_DB_STATE_UNKNOWN:-unknown}"
+
+opencode_db_file_signature() {
+	local file_path="$1"
+	local file_bytes=""
+	local file_mtime=""
+
+	if [[ ! -e "$file_path" && ! -L "$file_path" ]]; then
+		printf '%s' "missing"
+		return 0
+	fi
+	if [[ ! -f "$file_path" ]] || ! declare -F _file_size_bytes >/dev/null 2>&1 || ! declare -F _file_mtime_epoch >/dev/null 2>&1; then
+		printf '%s' "$OPENCODE_DB_STATE_UNKNOWN"
+		return 0
+	fi
+
+	file_bytes=$(_file_size_bytes "$file_path" 2>/dev/null || true)
+	file_mtime=$(_file_mtime_epoch "$file_path" 2>/dev/null || true)
+	if [[ ! "$file_bytes" =~ ^[0-9]+$ || ! "$file_mtime" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$OPENCODE_DB_STATE_UNKNOWN"
+		return 0
+	fi
+	printf '%s:%s' "$file_bytes" "$file_mtime"
+	return 0
+}
+
+# Emit stable, changing, or unknown for a WAL observed twice. The optional
+# third argument supports isolated fixtures without changing the active DB path.
+opencode_db_wal_state() {
+	local db_path="$1"
+	local sample_delay="${2:-1}"
+	local wal_path="${3:-${db_path}-wal}"
+	local before=""
+	local after=""
+
+	if [[ ! "$sample_delay" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+		printf '%s' "$OPENCODE_DB_STATE_UNKNOWN"
+		return 0
+	fi
+	before=$(opencode_db_file_signature "$wal_path")
+	if [[ "$before" == "$OPENCODE_DB_STATE_UNKNOWN" ]]; then
+		printf '%s' "$OPENCODE_DB_STATE_UNKNOWN"
+		return 0
+	fi
+	sleep "$sample_delay"
+	after=$(opencode_db_file_signature "$wal_path")
+	if [[ "$after" == "$OPENCODE_DB_STATE_UNKNOWN" ]]; then
+		printf '%s' "$OPENCODE_DB_STATE_UNKNOWN"
+	elif [[ "$before" != "$after" ]]; then
+		printf '%s' "changing"
+	else
+		printf '%s' "stable"
+	fi
+	return 0
+}
+
+# Emit a holder count, or unknown when lsof-compatible evidence is unavailable.
+opencode_db_holder_count() {
+	local db_path="$1"
+	local holder_command="${2:-lsof}"
+	local holder_pids=""
+	local holder_count="0"
+
+	if ! command -v "$holder_command" >/dev/null 2>&1; then
+		printf '%s' "$OPENCODE_DB_STATE_UNKNOWN"
+		return 0
+	fi
+	holder_pids=$("$holder_command" -t "$db_path" 2>/dev/null || true)
+	if [[ -n "$holder_pids" ]]; then
+		holder_count=$(printf '%s\n' "$holder_pids" | awk 'NF' | sort -u | wc -l | tr -d ' ')
+	fi
+	printf '%s' "${holder_count:-0}"
+	return 0
+}
+
+# Emit readable, missing, or unknown without selecting session content.
+opencode_db_schema_state() {
+	local db_path="$1"
+	local table_count=""
+
+	if [[ ! -e "$db_path" && ! -L "$db_path" ]]; then
+		printf '%s' "missing"
+		return 0
+	fi
+	if [[ ! -f "$db_path" || ! -r "$db_path" ]] || ! command -v sqlite3 >/dev/null 2>&1; then
+		printf '%s' "$OPENCODE_DB_STATE_UNKNOWN"
+		return 0
+	fi
+	table_count=$(sqlite3 -readonly "$db_path" \
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('project','session','message','part');" 2>/dev/null || true)
+	if [[ "$table_count" == "4" ]]; then
+		printf '%s' "readable"
+	else
+		printf '%s' "$OPENCODE_DB_STATE_UNKNOWN"
+	fi
+	return 0
+}
+
+opencode_db_table_columns() {
+	local db_path="$1"
+	local table_name="$2"
+	sqlite3 "$db_path" "SELECT COALESCE(group_concat(name, ','), '') FROM (SELECT name FROM pragma_table_info('${table_name}') ORDER BY cid);" 2>/dev/null
+	return $?
+}
+
+opencode_archive_table_schema_supported() {
+	local db_path="$1"
+	local table_name="$2"
+	local actual=""
+	local expected=""
+	local compatible=""
+
+	actual=$(opencode_db_table_columns "$db_path" "$table_name") || return 1
+	case "$table_name" in
+	project)
+		expected="id,worktree,vcs,name,icon_url,icon_color,time_created,time_updated,time_initialized,sandboxes,commands"
+		compatible="${expected},icon_url_override"
+		;;
+	session)
+		expected="id,project_id,parent_id,slug,directory,title,version,share_url,summary_additions,summary_deletions,summary_files,summary_diffs,revert,permission,time_created,time_updated,time_compacting,time_archived,workspace_id"
+		compatible="${expected},path"
+		;;
+	message) expected="id,session_id,time_created,time_updated,data" ;;
+	part) expected="id,message_id,session_id,time_created,time_updated,data" ;;
+	todo) expected="session_id,content,status,priority,position,time_created,time_updated" ;;
+	session_share) expected="session_id,id,secret,url,time_created,time_updated" ;;
+	event) expected="id,aggregate_id,seq,type,data" ;;
+	*) return 1 ;;
+	esac
+
+	if [[ "$actual" == "$expected" || (-n "$compatible" && "$actual" == "$compatible") ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# Validate only the complete logical-session schema supported by the existing
+# archive contract. event_mode is optional for active DBs and required for the
+# aidevops-owned archive schema.
+opencode_archive_schema_supported() {
+	local db_path="$1"
+	local event_mode="${2:-optional}"
+	local table_name=""
+	local event_exists=""
+	local unknown_session_tables=""
+
+	for table_name in project session message part todo session_share; do
+		opencode_archive_table_schema_supported "$db_path" "$table_name" || return 1
+	done
+	event_exists=$(sqlite3 "$db_path" \
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='event';" 2>/dev/null || true)
+	if [[ "$event_exists" == "1" ]]; then
+		opencode_archive_table_schema_supported "$db_path" event || return 1
+	elif [[ "$event_mode" == "required" ]]; then
+		return 1
+	fi
+
+	unknown_session_tables=$(sqlite3 "$db_path" \
+		"SELECT DISTINCT m.name FROM sqlite_master m JOIN pragma_table_info(m.name) p WHERE m.type='table' AND p.name='session_id' AND m.name NOT IN ('message','part','todo','session_share') ORDER BY m.name;" 2>/dev/null) || return 1
+	[[ -z "$unknown_session_tables" ]] || return 1
+	return 0
+}

--- a/.agents/scripts/storage-inventory-helper.sh
+++ b/.agents/scripts/storage-inventory-helper.sh
@@ -9,10 +9,22 @@ if [[ -f "$SCRIPT_DIR/shared-constants.sh" ]]; then
 	# shellcheck source=shared-constants.sh
 	source "$SCRIPT_DIR/shared-constants.sh"
 fi
+OPENCODE_STORAGE_PROBES_AVAILABLE=0
+if [[ -f "$SCRIPT_DIR/opencode-db-safety-lib.sh" ]]; then
+	# shellcheck source=opencode-db-safety-lib.sh
+	source "$SCRIPT_DIR/opencode-db-safety-lib.sh"
+	OPENCODE_STORAGE_PROBES_AVAILABLE=1
+fi
 
-STORAGE_SCHEMA_VERSION=1
+STORAGE_SCHEMA_VERSION=2
 STORAGE_SIZE_TIMEOUT_TENTHS="${AIDEVOPS_STORAGE_SIZE_TIMEOUT_TENTHS:-20}"
 STORAGE_DU_COMMAND="${AIDEVOPS_STORAGE_DU_COMMAND:-du}"
+STORAGE_UNKNOWN="unknown"
+STORAGE_PROTECTED="protected"
+STORAGE_JOINT="joint"
+STORAGE_ACTIVE="active"
+STORAGE_ARCHIVE="archive"
+STORAGE_PRODUCER_OPENCODE="opencode"
 
 _storage_usage() {
 	cat <<'USAGE'
@@ -80,18 +92,17 @@ _storage_measure_path() {
 	return 0
 }
 
-_storage_emit_record() {
+_storage_emit_measured_record() {
 	local store_id="$1"
 	local producer="$2"
 	local display_path="$3"
-	local actual_path="$4"
-	local owner="$5"
-	local safety_class="$6"
-	local policy="$7"
-	local disposition="$8"
-	local protection_reason="$9"
-	local next_action="${10}"
-	local measured=""
+	local owner="$4"
+	local safety_class="$5"
+	local policy="$6"
+	local disposition="$7"
+	local protection_reason="$8"
+	local next_action="$9"
+	local measured="${10}"
 	local total_bytes="null"
 	local confidence="unavailable"
 	local error=""
@@ -99,7 +110,6 @@ _storage_emit_record() {
 	local reclaimable_bytes=0
 	local unknown_bytes="null"
 
-	measured=$(_storage_measure_path "$actual_path")
 	IFS='|' read -r total_bytes confidence error <<<"$measured"
 	if [[ "$total_bytes" != "null" ]]; then
 		case "$disposition" in
@@ -139,13 +149,182 @@ _storage_emit_record() {
 	return 0
 }
 
+_storage_emit_record() {
+	local store_id="$1"
+	local producer="$2"
+	local display_path="$3"
+	local actual_path="$4"
+	local owner="$5"
+	local safety_class="$6"
+	local policy="$7"
+	local disposition="$8"
+	local protection_reason="$9"
+	local next_action="${10}"
+	local measured=""
+
+	measured=$(_storage_measure_path "$actual_path")
+	_storage_emit_measured_record "$store_id" "$producer" "$display_path" "$owner" \
+		"$safety_class" "$policy" "$disposition" "$protection_reason" "$next_action" "$measured"
+	return 0
+}
+
+_storage_measure_group() {
+	local total_bytes=0
+	local path=""
+	local measured=""
+	local path_bytes=""
+	local confidence=""
+	local error=""
+	local saw_path=0
+
+	for path in "$@"; do
+		measured=$(_storage_measure_path "$path")
+		IFS='|' read -r path_bytes confidence error <<<"$measured"
+		if [[ "$path_bytes" == "null" ]]; then
+			printf 'null|unavailable|%s' "${error:-component-unavailable}"
+			return 0
+		fi
+		if [[ "$error" != "missing" ]]; then
+			saw_path=1
+		fi
+		total_bytes=$((total_bytes + path_bytes))
+	done
+	if [[ "$saw_path" -eq 0 ]]; then
+		printf '0|exact|missing'
+	else
+		printf '%s|exact|' "$total_bytes"
+	fi
+	return 0
+}
+
+_storage_opencode_residual_measurement() {
+	local root_path="$1"
+	shift
+	local root_measure=""
+	local root_bytes=""
+	local root_confidence=""
+	local root_error=""
+	local known_bytes=0
+	local component_path=""
+	local component_measure=""
+	local component_bytes=""
+	local component_confidence=""
+	local component_error=""
+
+	root_measure=$(_storage_measure_path "$root_path")
+	IFS='|' read -r root_bytes root_confidence root_error <<<"$root_measure"
+	if [[ "$root_bytes" == "null" ]]; then
+		printf 'null|unavailable|%s' "${root_error:-root-unavailable}"
+		return 0
+	fi
+	for component_path in "$@"; do
+		if [[ "$component_path" != "$root_path" && "$component_path" != "$root_path/"* ]]; then
+			continue
+		fi
+		component_measure=$(_storage_measure_path "$component_path")
+		IFS='|' read -r component_bytes component_confidence component_error <<<"$component_measure"
+		if [[ "$component_bytes" == "null" ]]; then
+			printf 'null|unavailable|known-component-unavailable'
+			return 0
+		fi
+		known_bytes=$((known_bytes + component_bytes))
+	done
+	root_bytes=$((root_bytes - known_bytes))
+	[[ "$root_bytes" -ge 0 ]] || root_bytes=0
+	printf '%s|estimated|' "$root_bytes"
+	return 0
+}
+
+_storage_opencode_records() {
+	local data_root="${AIDEVOPS_OPENCODE_DATA_DIR:-${HOME}/.local/share/opencode}"
+	local active_db="${AIDEVOPS_OPENCODE_DB_PATH:-${OPENCODE_DB_PATH:-${OPENCODE_DB:-${data_root}/opencode.db}}}"
+	local active_dir="${active_db%/*}"
+	local archive_db=""
+	local legacy_path="${data_root}/storage"
+	local tool_path="${data_root}/tool"
+	local active_measure=""
+	local wal_measure=""
+	local archive_measure=""
+	local legacy_measure=""
+	local tool_measure=""
+	local residual_measure=""
+	local active_schema="$STORAGE_UNKNOWN"
+	local archive_schema="$STORAGE_UNKNOWN"
+	local holder_count="$STORAGE_UNKNOWN"
+	local wal_state="$STORAGE_UNKNOWN"
+	local active_class="$STORAGE_ACTIVE"
+	local active_disposition="$STORAGE_PROTECTED"
+	local active_reason="OpenCode-owned logical sessions and live SQLite pages are never cleanup candidates"
+	local archive_class="$STORAGE_ARCHIVE"
+	local archive_disposition="$STORAGE_PROTECTED"
+	local archive_reason="archive retention and integrity require explicit OpenCode-aware verification"
+	local wal_reason="idle snapshot only; maintenance still requires holder and checkpoint evidence"
+
+	if [[ "$active_dir" == "$active_db" ]]; then
+		active_dir="."
+	fi
+	archive_db="${AIDEVOPS_OPENCODE_ARCHIVE_DB:-${OPENCODE_ARCHIVE_DB:-${active_dir}/opencode-archive.db}}"
+	active_measure=$(_storage_measure_group "$active_db")
+	wal_measure=$(_storage_measure_group "${active_db}-wal" "${active_db}-shm")
+	archive_measure=$(_storage_measure_group "$archive_db" "${archive_db}-wal" "${archive_db}-shm")
+	legacy_measure=$(_storage_measure_group "$legacy_path")
+	tool_measure=$(_storage_measure_group "$tool_path")
+	residual_measure=$(_storage_opencode_residual_measurement "$data_root" \
+		"$active_db" "${active_db}-wal" "${active_db}-shm" \
+		"$archive_db" "${archive_db}-wal" "${archive_db}-shm" "$legacy_path" "$tool_path")
+
+	if [[ "$OPENCODE_STORAGE_PROBES_AVAILABLE" -eq 1 ]]; then
+		active_schema=$(opencode_db_schema_state "$active_db")
+		archive_schema=$(opencode_db_schema_state "$archive_db")
+		holder_count=$(opencode_db_holder_count "$active_db" "${AIDEVOPS_STORAGE_LSOF_COMMAND:-lsof}")
+		wal_state=$(opencode_db_wal_state "$active_db" "${AIDEVOPS_STORAGE_WAL_SAMPLE_DELAY_SECONDS:-0.1}")
+	fi
+	if [[ "$active_schema" == "$STORAGE_UNKNOWN" ]]; then
+		active_class="$STORAGE_UNKNOWN"
+		active_disposition="$STORAGE_UNKNOWN"
+		active_reason="active database schema is unavailable; all bytes remain unknown and untouched"
+	fi
+	if [[ "$archive_schema" == "$STORAGE_UNKNOWN" ]]; then
+		archive_class="$STORAGE_UNKNOWN"
+		archive_disposition="$STORAGE_UNKNOWN"
+		archive_reason="archive schema is unavailable; all bytes remain unknown and untouched"
+	fi
+	if [[ "$holder_count" =~ ^[0-9]+$ && "$holder_count" -gt 0 ]]; then
+		wal_reason="active database holder detected; WAL and shared-memory bytes are protected"
+	elif [[ "$wal_state" == "changing" ]]; then
+		wal_reason="WAL changed during observation; active SQLite state is protected"
+	elif [[ "$holder_count" == "$STORAGE_UNKNOWN" || "$wal_state" == "$STORAGE_UNKNOWN" ]]; then
+		wal_reason="holder or WAL state is unavailable; active SQLite bytes are protected"
+	fi
+
+	_storage_emit_measured_record "opencode-active-db" "$STORAGE_PRODUCER_OPENCODE" "OpenCode active database" "$STORAGE_JOINT" \
+		"$active_class" "logical session retention is OpenCode-owned" "$active_disposition" "$active_reason" \
+		"Use aidevops opencode-db report; do not select sessions by age or size" "$active_measure"
+	_storage_emit_measured_record "opencode-active-wal" "$STORAGE_PRODUCER_OPENCODE" "OpenCode active WAL/SHM" "$STORAGE_JOINT" \
+		"$STORAGE_ACTIVE" "checkpoint and VACUUM only after idle-holder evidence" "$STORAGE_PROTECTED" "$wal_reason" \
+		"Close OpenCode holders, then use aidevops opencode-db maintain" "$wal_measure"
+	_storage_emit_measured_record "opencode-archive" "aidevops-opencode-archive" "OpenCode archive database" "$STORAGE_JOINT" \
+		"$archive_class" "archive data is retained; no generic deletion contract" "$archive_disposition" "$archive_reason" \
+		"Inspect with aidevops opencode-db sessions --include-archive" "$archive_measure"
+	_storage_emit_measured_record "opencode-legacy" "$STORAGE_PRODUCER_OPENCODE" "OpenCode legacy storage" "$STORAGE_UNKNOWN" \
+		"$STORAGE_UNKNOWN" "legacy format lifecycle is owned upstream" "$STORAGE_UNKNOWN" "legacy format ownership or migration state is unproved" \
+		"Use an upstream OpenCode migration/export path; leave data untouched" "$legacy_measure"
+	_storage_emit_measured_record "opencode-tool-output" "$STORAGE_PRODUCER_OPENCODE" "OpenCode tool output" "$STORAGE_UNKNOWN" \
+		"$STORAGE_UNKNOWN" "tool-output lifecycle is owned upstream" "$STORAGE_UNKNOWN" "tool output may be referenced by logical sessions" \
+		"Use OpenCode-owned controls; no aidevops cleanup is available" "$tool_measure"
+	_storage_emit_measured_record "opencode-unclassified" "$STORAGE_PRODUCER_OPENCODE" "Other OpenCode application data" "$STORAGE_UNKNOWN" \
+		"$STORAGE_UNKNOWN" "future and unclassified formats fail closed" "$STORAGE_UNKNOWN" "unclassified OpenCode bytes have no proved mutation contract" \
+		"Review with current OpenCode documentation and leave untouched" "$residual_measure"
+	return 0
+}
+
 _storage_inventory_records() {
 	local home_label="~"
 	_storage_emit_record "runtime-bundles" "agent-deploy" "${home_label}/.aidevops/runtime-bundles" "${HOME}/.aidevops/runtime-bundles" "framework" "unknown" "30-day unleased age policy; detailed bounds pending" "unknown" "bundle references require store-specific classification" "Review runtime-bundle status; do not delete manually"
 	_storage_emit_record "observability" "opencode-aidevops" "${home_label}/.aidevops/.agent-workspace/observability" "${HOME}/.aidevops/.agent-workspace/observability" "framework" "audit" "append-only audit evidence; compaction contract pending" "protected" "audit evidence" "Use observability-helper.sh for bounded queries"
 	_storage_emit_record "agent-backups" "setup-backup" "${home_label}/.aidevops/agents-backups" "${HOME}/.aidevops/agents-backups" "framework" "rollback" "count-based snapshots; byte policy pending" "protected" "rollback safety" "Review backup inventory before any cleanup"
 	_storage_emit_record "framework-logs" "multiple-framework-producers" "${home_label}/.aidevops/logs" "${HOME}/.aidevops/logs" "framework" "audit" "producer-specific policies pending" "protected" "audit and unresolved failure evidence" "Use producer-specific diagnostics"
-	_storage_emit_record "opencode-data" "opencode" "OpenCode application data" "${AIDEVOPS_OPENCODE_DATA_DIR:-${HOME}/.local/share/opencode}" "joint" "unknown" "runtime-aware maintenance only" "unknown" "OpenCode ownership and active-session state require runtime-aware queries" "Use aidevops opencode-db report"
+	_storage_opencode_records
 	_storage_emit_record "npm-cache" "npm" "npm cache" "${AIDEVOPS_NPM_CACHE_DIR:-${HOME}/.npm}" "external" "cache" "package-manager owned; no aidevops cleanup authority" "protected" "external owner" "Use npm-owned diagnostics and cleanup explicitly"
 	return 0
 }
@@ -189,17 +368,19 @@ _storage_status() {
 	local unknown=""
 	local confidence=""
 	local reason=""
+	local next_action=""
 	local error=""
 	report=$(_storage_inventory_json)
 	printf 'Storage Inventory (read-only)\n'
-	printf '%-20s %-10s %-10s %12s %12s %12s %12s %-11s\n' "Store" "Owner" "Class" "Total" "Protected" "Reclaimable" "Unknown" "Confidence"
-	printf '%s\n' "$report" | jq -r '.stores[] | [.store_id,.owner,.safety_class,(.total_bytes|tostring),(.protected_bytes|tostring),(.reclaimable_bytes|tostring),(.unknown_bytes|tostring),.sizing_confidence,.protection_reasons[0],(.error // "")] | @tsv' |
-		while IFS=$'\t' read -r store_id owner safety_class total protected reclaimable unknown confidence reason error; do
-			printf '%-20s %-10s %-10s %12s %12s %12s %12s %-11s\n' \
+	printf '%-24s %-10s %-10s %12s %12s %12s %12s %-11s\n' "Store" "Owner" "Class" "Total" "Protected" "Reclaimable" "Unknown" "Confidence"
+	printf '%s\n' "$report" | jq -r '.stores[] | [.store_id,.owner,.safety_class,(.total_bytes|tostring),(.protected_bytes|tostring),(.reclaimable_bytes|tostring),(.unknown_bytes|tostring),.sizing_confidence,.protection_reasons[0],.next_action,(.error // "")] | @tsv' |
+		while IFS=$'\t' read -r store_id owner safety_class total protected reclaimable unknown confidence reason next_action error; do
+			printf '%-24s %-10s %-10s %12s %12s %12s %12s %-11s\n' \
 				"$store_id" "$owner" "$safety_class" "$(_storage_format_bytes "$total")" "$(_storage_format_bytes "$protected")" "$(_storage_format_bytes "$reclaimable")" "$(_storage_format_bytes "$unknown")" "$confidence"
 			printf '  reason: %s' "$reason"
 			[[ -n "$error" ]] && printf ' (%s)' "$error"
 			printf '\n'
+			printf '  next: %s\n' "$next_action"
 		done
 	printf 'No cleanup was performed. Unknown or unavailable classifications are never reclaimable.\n'
 	return 0

--- a/.agents/scripts/tests/test-opencode-db-archive.sh
+++ b/.agents/scripts/tests/test-opencode-db-archive.sh
@@ -469,6 +469,131 @@ else
 	_fail "HOME/XDG unset default path mismatch with rc=$rc — output: $out"
 fi
 
+# Active database holders are a hard veto before candidate selection or writes.
+_reset_dbs
+_make_active_db_with_session_path
+mock_holder="${SANDBOX}/mock-holder"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "4242\n"' 'exit 0' >"$mock_holder"
+chmod +x "$mock_holder"
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
+	OPENCODE_DB_HOLDER_COMMAND="$mock_holder" OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=0 \
+	"$HELPER" archive --retention-days 0 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+active_sessions=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session;")
+if [[ "$rc" -eq 2 && "$active_sessions" == "1" && ! -e "$ARCHIVE_DB" && "$out" == *"hold the active DB open"* ]]; then
+	_pass "active DB holder veto leaves logical sessions untouched"
+else
+	_fail "active-holder veto mismatch: rc=${rc}, active=${active_sessions}, output=${out}"
+fi
+
+# A changing WAL is a hard veto even when holder inspection reports idle.
+_reset_dbs
+_make_active_db_with_session_path
+mock_idle_holder="${SANDBOX}/mock-idle-holder"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$mock_idle_holder"
+chmod +x "$mock_idle_holder"
+(
+	sleep 1
+	: >"${ACTIVE_DB}-wal"
+) &
+wal_writer_pid=$!
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
+	OPENCODE_DB_HOLDER_COMMAND="$mock_idle_holder" OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=3 \
+	"$HELPER" archive --retention-days 0 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+wait "$wal_writer_pid"
+rm -f "${ACTIVE_DB}-wal" "${ACTIVE_DB}-shm"
+active_sessions=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session;")
+if [[ "$rc" -eq 2 && "$active_sessions" == "1" && ! -e "$ARCHIVE_DB" && "$out" == *"active WAL changed"* ]]; then
+	_pass "changing WAL veto leaves logical sessions untouched"
+else
+	_fail "changing-WAL veto mismatch: rc=${rc}, active=${active_sessions}, output=${out}"
+fi
+
+# Unavailable and future schemas remain unknown and are never partially moved.
+_reset_dbs
+printf 'not-a-sqlite-database\n' >"$ACTIVE_DB"
+before_checksum=$(cksum "$ACTIVE_DB")
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
+	OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=0 "$HELPER" archive --retention-days 0 2>&1)
+rc=$?
+set -e
+after_checksum=$(cksum "$ACTIVE_DB")
+if [[ "$rc" -eq 3 && "$before_checksum" == "$after_checksum" && ! -e "$ARCHIVE_DB" && "$out" == *"schema"* ]]; then
+	_pass "unavailable schema fails closed without creating an archive"
+else
+	_fail "unavailable-schema fail-closed mismatch: rc=${rc}, output=${out}"
+fi
+
+_reset_dbs
+_make_active_db_with_session_path
+sqlite3 "$ACTIVE_DB" "ALTER TABLE session ADD COLUMN future_payload text; UPDATE session SET future_payload='preserve-me';"
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
+	OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=0 "$HELPER" archive --retention-days 0 2>&1)
+rc=$?
+set -e
+future_payload=$(sqlite3 "$ACTIVE_DB" "SELECT future_payload FROM session WHERE id='ses1';")
+if [[ "$rc" -eq 3 && "$future_payload" == "preserve-me" && ! -e "$ARCHIVE_DB" ]]; then
+	_pass "unknown future session schema remains active and untouched"
+else
+	_fail "future-schema fail-closed mismatch: rc=${rc}, payload=${future_payload}, output=${out}"
+fi
+
+# A signal between committed batches leaves both databases queryable and every
+# logical session present in exactly one database.
+_reset_dbs
+_make_active_db_with_sessions $'interrupt-a,1\ninterrupt-b,2'
+interrupt_output="${SANDBOX}/interrupt-output.log"
+OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
+	OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=0 OPENCODE_DB_ARCHIVE_BATCH_SIZE=1 \
+	OPENCODE_DB_ARCHIVE_BATCH_DELAY_SECONDS=10 \
+	"$HELPER" archive --retention-days 0 --max-duration-seconds 30 >"$interrupt_output" 2>&1 &
+archive_pid=$!
+archive_rows=0
+for _attempt in {1..100}; do
+	if [[ -f "$ARCHIVE_DB" ]]; then
+		archive_rows=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session;" 2>/dev/null || printf '0')
+		[[ "$archive_rows" -gt 0 ]] && break
+	fi
+	sleep 0.05
+done
+kill -TERM "$archive_pid" 2>/dev/null || true
+set +e
+wait "$archive_pid"
+rc=$?
+set -e
+active_quick_check=$(sqlite3 "$ACTIVE_DB" "PRAGMA quick_check;" 2>/dev/null || true)
+archive_quick_check=$(sqlite3 "$ARCHIVE_DB" "PRAGMA quick_check;" 2>/dev/null || true)
+preserved_sessions=$(sqlite3 "$ACTIVE_DB" "ATTACH DATABASE '$ARCHIVE_DB' AS archive; SELECT COUNT(*) FROM (SELECT id FROM main.session UNION SELECT id FROM archive.session);" 2>/dev/null || printf '0')
+if [[ "$rc" -eq 143 && "$active_quick_check" == "ok" && "$archive_quick_check" == "ok" && "$preserved_sessions" == "2" ]]; then
+	_pass "interrupted archive preserves queryable active and archive databases"
+else
+	_fail "interrupted archive mismatch: rc=${rc}, active=${active_quick_check}, archive=${archive_quick_check}, sessions=${preserved_sessions}"
+fi
+
+# VACUUM is bracketed by idle-only checkpoints and leaves both DBs verified.
+_reset_dbs
+_make_active_db_with_session_path
+sqlite3 "$ACTIVE_DB" "UPDATE message SET data=hex(randomblob(262144));"
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
+	OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=0 "$HELPER" archive --retention-days 0 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+active_quick_check=$(sqlite3 "$ACTIVE_DB" "PRAGMA quick_check;" 2>/dev/null || true)
+archive_quick_check=$(sqlite3 "$ARCHIVE_DB" "PRAGMA quick_check;" 2>/dev/null || true)
+if [[ "$rc" -eq 0 && "$out" == *"pre-VACUUM wal_checkpoint(TRUNCATE)"* && "$out" == *"post-VACUUM wal_checkpoint(TRUNCATE)"* && "$active_quick_check" == "ok" && "$archive_quick_check" == "ok" ]]; then
+	_pass "archive VACUUM uses idle checkpoints and verifies both databases"
+else
+	_fail "archive VACUUM coordination mismatch: rc=${rc}, active=${active_quick_check}, archive=${archive_quick_check}, output=${out}"
+fi
+
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then
 	exit 1

--- a/.agents/scripts/tests/test-opencode-storage-inventory.sh
+++ b/.agents/scripts/tests/test-opencode-storage-inventory.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/../storage-inventory-helper.sh"
+SAFETY_LIB="$SCRIPT_DIR/../opencode-db-safety-lib.sh"
+SHARED_CONSTANTS="$SCRIPT_DIR/../shared-constants.sh"
+TEST_ROOT="$(mktemp -d -t aidevops-opencode-storage.XXXXXX)"
+HOME="$TEST_ROOT/home"
+export HOME
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v sqlite3 >/dev/null 2>&1 || fail "sqlite3 is required"
+
+data_root="$HOME/.local/share/opencode"
+active_db="$data_root/opencode.db"
+archive_db="$data_root/opencode-archive.db"
+mkdir -p "$data_root/storage" "$data_root/tool" "$data_root/future-format-v2"
+
+sqlite3 "$active_db" <<'SQL'
+CREATE TABLE project (id text PRIMARY KEY);
+CREATE TABLE session (id text PRIMARY KEY, title text);
+CREATE TABLE message (id text PRIMARY KEY, session_id text);
+CREATE TABLE part (id text PRIMARY KEY, session_id text);
+INSERT INTO session VALUES ('ses-private', 'PRIVATE_SENTINEL_TITLE');
+SQL
+sqlite3 "$archive_db" <<'SQL'
+CREATE TABLE project (id text PRIMARY KEY);
+CREATE TABLE session (id text PRIMARY KEY, title text);
+CREATE TABLE message (id text PRIMARY KEY, session_id text);
+CREATE TABLE part (id text PRIMARY KEY, session_id text);
+INSERT INTO session VALUES ('ses-archived', 'ARCHIVE_PRIVATE_SENTINEL');
+SQL
+printf 'legacy-format\n' >"$data_root/storage/session.json"
+printf 'tool-output\n' >"$data_root/tool/output.bin"
+printf 'future-format\n' >"$data_root/future-format-v2/blob.bin"
+
+fixture_checksum() {
+	cksum "$active_db" "$archive_db" \
+		"$data_root/storage/session.json" \
+		"$data_root/tool/output.bin" \
+		"$data_root/future-format-v2/blob.bin"
+	return 0
+}
+
+idle_holder="$TEST_ROOT/idle-holder"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$idle_holder"
+chmod +x "$idle_holder"
+
+before_checksum=$(fixture_checksum)
+report=$(AIDEVOPS_OPENCODE_DATA_DIR="$data_root" \
+	AIDEVOPS_STORAGE_LSOF_COMMAND="$idle_holder" \
+	AIDEVOPS_STORAGE_WAL_SAMPLE_DELAY_SECONDS=0 \
+	bash "$HELPER" json)
+after_checksum=$(fixture_checksum)
+
+[[ "$before_checksum" == "$after_checksum" ]] || fail "inventory changed OpenCode fixture bytes"
+[[ "$report" != *"PRIVATE_SENTINEL_TITLE"* && "$report" != *"ARCHIVE_PRIVATE_SENTINEL"* ]] || fail "inventory exposed private session content"
+[[ "$(printf '%s' "$report" | jq -r '.schema_version')" == "2" ]] || fail "OpenCode inventory schema version missing"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-active-db") | [.owner,.safety_class,(.protected_bytes > 0),.unknown_bytes] | @tsv')" == $'joint\tactive\ttrue\t0' ]] || fail "active DB was not jointly owned and protected"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-active-wal") | [.owner,.safety_class,.reclaimable_bytes] | @tsv')" == $'joint\tactive\t0' ]] || fail "active WAL lifecycle was not protected"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-archive") | [.owner,.safety_class,(.protected_bytes > 0)] | @tsv')" == $'joint\tarchive\ttrue' ]] || fail "archive bytes were not jointly owned and protected"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-legacy") | [.owner,.safety_class,(.unknown_bytes > 0)] | @tsv')" == $'unknown\tunknown\ttrue' ]] || fail "legacy format was not fail-closed unknown"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-tool-output") | [.owner,.safety_class,(.unknown_bytes > 0)] | @tsv')" == $'unknown\tunknown\ttrue' ]] || fail "tool output was not fail-closed unknown"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-unclassified") | [.owner,.safety_class,(.unknown_bytes > 0)] | @tsv')" == $'unknown\tunknown\ttrue' ]] || fail "future format was not reported as unclassified"
+[[ "$(printf '%s' "$report" | jq '[.stores[] | select(.store_id | startswith("opencode-")) | .reclaimable_bytes] | add')" == "0" ]] || fail "OpenCode storage exposed generic cleanup candidates"
+
+active_holder="$TEST_ROOT/active-holder"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "999\n"' 'exit 0' >"$active_holder"
+chmod +x "$active_holder"
+holder_report=$(AIDEVOPS_OPENCODE_DATA_DIR="$data_root" \
+	AIDEVOPS_STORAGE_LSOF_COMMAND="$active_holder" \
+	AIDEVOPS_STORAGE_WAL_SAMPLE_DELAY_SECONDS=0 \
+	bash "$HELPER" json)
+[[ "$(printf '%s' "$holder_report" | jq -r '.stores[] | select(.store_id == "opencode-active-wal") | .protection_reasons[0]')" == *"holder detected"* ]] || fail "active holder was not surfaced as a hard protection reason"
+
+bad_root="$TEST_ROOT/bad-opencode"
+mkdir -p "$bad_root"
+printf 'unavailable-schema\n' >"$bad_root/opencode.db"
+bad_report=$(AIDEVOPS_OPENCODE_DATA_DIR="$bad_root" \
+	AIDEVOPS_STORAGE_LSOF_COMMAND="$idle_holder" \
+	AIDEVOPS_STORAGE_WAL_SAMPLE_DELAY_SECONDS=0 \
+	bash "$HELPER" json)
+[[ "$(printf '%s' "$bad_report" | jq -r '.stores[] | select(.store_id == "opencode-active-db") | [.safety_class,(.unknown_bytes > 0),.reclaimable_bytes] | @tsv')" == $'unknown\ttrue\t0' ]] || fail "unavailable active schema did not remain unknown"
+
+# Exercise the shared changing-WAL probe directly with an isolated fixture.
+# shellcheck source=../shared-constants.sh
+source "$SHARED_CONSTANTS"
+# shellcheck source=../opencode-db-safety-lib.sh
+source "$SAFETY_LIB"
+changing_wal="$TEST_ROOT/changing.wal"
+printf 'before\n' >"$changing_wal"
+(
+	sleep 1
+	printf 'after\n' >>"$changing_wal"
+) &
+writer_pid=$!
+wal_state=$(opencode_db_wal_state "$TEST_ROOT/unused.db" 2 "$changing_wal")
+wait "$writer_pid"
+[[ "$wal_state" == "changing" ]] || fail "changing WAL fixture was not detected"
+
+printf 'PASS: OpenCode storage is ownership-aware, content-private, and fail-closed\n'
+exit 0

--- a/.agents/scripts/tests/test-storage-inventory-helper.sh
+++ b/.agents/scripts/tests/test-storage-inventory-helper.sh
@@ -56,17 +56,21 @@ report=$(bash "$HELPER" json)
 after_checksum=$(fixture_checksum)
 [[ "$before_checksum" == "$after_checksum" ]] || fail "inventory changed fixture byte identity"
 
-[[ "$(printf '%s' "$report" | jq -r '.schema_version')" == "1" ]] || fail "schema version missing"
+[[ "$(printf '%s' "$report" | jq -r '.schema_version')" == "2" ]] || fail "schema version missing"
 [[ "$(printf '%s' "$report" | jq -r '.read_only')" == "true" ]] || fail "read-only marker missing"
-[[ "$(printf '%s' "$report" | jq '.stores | length')" == "6" ]] || fail "expected six explicit stores"
+[[ "$(printf '%s' "$report" | jq '.stores | length')" == "11" ]] || fail "expected split OpenCode storage records"
 [[ "$(printf '%s' "$report" | jq '[.stores[].reclaimable_bytes] | add')" == "0" ]] || fail "foundation report suggested reclaimable bytes"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .unknown_bytes > 0')" == "true" ]] || fail "runtime bundles were not fail-closed unknown"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "observability") | .protected_bytes > 0')" == "true" ]] || fail "audit evidence was not protected"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "npm-cache") | .owner')" == "external" ]] || fail "npm ownership was claimed by aidevops"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-active-db") | .owner')" == "joint" ]] || fail "OpenCode active DB ownership was not bounded"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-active-db") | .safety_class')" == "unknown" ]] || fail "unavailable OpenCode schema did not fail closed"
+[[ "$(printf '%s' "$report" | jq '[.stores[] | select(.store_id | startswith("opencode-")) | .reclaimable_bytes] | add')" == "0" ]] || fail "OpenCode report exposed cleanup candidates"
 
 human=$(bash "$HELPER" status)
 [[ "$human" == *"Storage Inventory (read-only)"* ]] || fail "human report heading missing"
 [[ "$human" == *"No cleanup was performed"* ]] || fail "human report omitted non-destructive guarantee"
+[[ "$human" == *"next: Use aidevops opencode-db report"* ]] || fail "human report omitted OpenCode guidance"
 
 mv "$HOME/.aidevops/runtime-bundles" "$HOME/.aidevops/runtime-bundles-real"
 ln -s "$HOME/.aidevops/runtime-bundles-real" "$HOME/.aidevops/runtime-bundles"


### PR DESCRIPTION
## Summary

- Report active OpenCode DB/WAL, archive, legacy, tool-output, and unclassified storage as separate ownership-aware records without exposing session content.
- Veto archive and VACUUM mutation when holder, WAL, or complete session-schema evidence is unavailable or unsafe.
- Preserve queryable active/archive databases across interrupted batches and bracket compaction with verified checkpoints.

## Implementation

- Added shared read-only OpenCode holder, WAL, and schema probes in `.agents/scripts/opencode-db-safety-lib.sh`.
- Reused those probes in archive mutation and storage reporting, with unknown formats failing closed and zero OpenCode bytes classified as generically reclaimable.
- Added focused ownership, privacy, active-holder, changing-WAL, unavailable-schema, interruption, and future-format fixtures.
- Documented the unified report and archive/compaction safety contract.

## Verification

- `bash .agents/scripts/tests/test-opencode-db-archive.sh` — 28 passed.
- `bash .agents/scripts/tests/test-opencode-db-maintenance.sh` — 28 passed.
- `bash .agents/scripts/tests/test-storage-inventory-helper.sh` — passed.
- `bash .agents/scripts/tests/test-opencode-storage-inventory.sh` — passed.
- `bash .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh` — 35 passed after integrating current `main`.
- Targeted `shellcheck` and `bash -n` checks passed.
- `.agents/scripts/linters-local.sh` passed; unavailable native Secretlint/Markdownlint remained explicitly advisory.

## Runtime Testing

- **Risk level:** Critical (database archival and compaction safety).
- **Status:** `runtime-verified` with isolated SQLite fixtures covering positive and fail-closed mutation paths.

## Key Decisions

- Logical session retention remains OpenCode-owned; file age and size never imply reclaimability.
- Active DB/WAL and archive bytes are jointly owned and protected; legacy, tool-output, and future formats remain unknown and untouched.
- Generic cleanup remains unavailable unless a separate upstream-backed mutation contract is established.

Resolves #28153


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 44m and 510,348 tokens on this as a headless worker.
