### PR TITLE
t18161: coordinate backup and failure evidence retention

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -62,8 +62,9 @@ Reference, lease, recovery, and audit checks remain hard vetoes.
 |---|---|---|---|---|
 | `~/.aidevops/runtime-bundles` | framework | active, leased, rollback, cache | Deployment protects current, previous, and live-leased bundles; unreferenced bundles converge under 30-day, 30-bundle, and 8 GiB soft limits | Keep the limits operator-configurable and preserve fail-closed reporting when references or sizing are unavailable |
 | `~/.aidevops/.agent-workspace/observability` | framework | audit, archive, cache | Runtime events are append-only evidence; plugin records runtime and tool-call data | Define the minimum audit envelope, payload/metadata limits, partition or archive semantics, and verified compaction rather than direct row deletion |
-| `~/.aidevops/agents-backups` | framework | rollback, archive | Count-based snapshot retention | Add byte/age reporting and preserve at least the newest verified rollback artifact |
-| `~/.aidevops/logs` and worker failure excerpts | framework | audit, archive, scratch | Individual excerpts are size-capped; policies vary by producer | Define producer ownership and combined age/count/byte retention while retaining terminal failure evidence |
+| `~/.aidevops/agents-backups` | framework | rollback, archive | Setup computes a dry-run plan under 10-snapshot, 180-day, and 4 GiB soft limits; the newest snapshot is always protected | Tune defaults from broader measurements without weakening rollback or attribution checks |
+| `~/.aidevops/logs/worker-failure-excerpts` | framework | recovery, archive | Excerpts are capped at 64 KiB; each session retains its newest evidence while older duplicates converge under 3-excerpt, 30-day, and 192 KiB soft limits | Add terminal issue/PR awareness before reclaiming the newest evidence for any session |
+| Pulse active logs and `~/.aidevops/logs/pulse-archive` | framework | active, archive | Pulse preserves active descriptors while gzip-rotating 50 MiB hot/wrapper logs and 1 MiB timing logs; cold archives converge under 1 GiB | Keep rotation producer-owned and never replace it with generic unlink-by-age cleanup |
 | OpenCode data under its application-data root | joint | active, recovery, archive, unknown | OpenCode owns session and DB formats; aidevops archive/maintenance helpers coordinate selected operations | Separate logical retention from WAL/fragmentation maintenance; report only classifications proven through OpenCode-aware queries |
 | npm and other package-manager caches | external | cache | Package manager owns lifecycle | Context-only reporting; no aidevops aggregate deletion |
 | OS temporary and Trash locations | external or joint | scratch, unknown | OS/runtime-specific | Reclaim only aidevops-attributable artifacts through an owner-aware migration; never broad-clean a directory |
@@ -81,6 +82,30 @@ integrity, and offline rollback dependencies into otherwise immutable bundles.
 The measured duplication is instead bounded by pruning unreferenced bundles.
 This preserves atomic activation and makes each retained rollback bundle
 self-verifying without making npm's global cache framework-owned.
+
+### Coordinated Backup and Log Policies
+
+Setup, headless-runtime failure evidence, and Pulse remain separate storage
+producers. Coordination means they publish compatible inventory records; it does
+not grant a generic helper authority to delete across `~/.aidevops`.
+
+- Setup accepts only timestamp-named snapshot directories that it created. It
+  measures all candidates, protects the newest rollback snapshot, computes an
+  oldest-first dry run, validates a producer-specific confirmation token, and
+  stages exact paths in `.retention-trash` before removal. A symlink, unexpected
+  name, sizing failure, or metadata failure preserves every snapshot.
+- Headless runtime applies the same plan/confirm/stage sequence only to older
+  excerpts for the same sanitized session key. The newest excerpt is unresolved
+  recovery evidence and remains protected regardless of age or size. Ambiguous
+  names and symlinks are unknown rather than cleanup candidates.
+- Pulse retains its descriptor-preserving gzip-and-truncate implementation.
+  Active files are never unlinked, so concurrent writers retain valid file
+  descriptors, and its existing combined cold-archive byte cap remains the only
+  cleanup authority for Pulse logs.
+
+An interrupted staged cleanup leaves either the original or an attributable
+producer-local trash copy. Inventory includes trash bytes as protected until a
+producer can complete or an operator can diagnose the interrupted action.
 
 ## Store Lifecycle Contract
 
@@ -146,8 +171,8 @@ filesystem age or size deletion loop.
    current, previous, and live-leased protections.
 3. Define observability audit retention, payload limits, and archival or
    partitioning semantics before compacting append-only evidence.
-4. Add coordinated policies for framework backups, logs, and worker failure
-   excerpts, including conservative leftover migration.
+4. Maintain coordinated policies for framework backups, Pulse logs, and worker
+   failure excerpts, including conservative attributable-only migration.
 5. Coordinate OpenCode-owned storage through runtime-aware reporting and
    maintenance; keep logical session deletion out of framework cleanup.
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -23,6 +23,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=./worker-lifecycle-common.sh
 source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
+# Worker failure excerpts own their capped write and duplicate-evidence
+# retention contract in a focused module.
+# shellcheck source=./worker-failure-evidence.sh
+source "${SCRIPT_DIR}/worker-failure-evidence.sh"
 
 # SSH agent integration for commit signing (t1882)
 # Source persisted agent.env so workers can sign commits without passphrase prompts.
@@ -768,42 +772,6 @@ _t3077_write_preflight_sentinel() {
 }
 
 #######################################
-# Preserve a small worker output excerpt for failure-metric forensics.
-#
-# Args:
-#   $1 - output file path
-#   $2 - session key
-# stdout: excerpt path, or empty on failure/no file
-# Returns: 0 always (observability must fail open)
-#######################################
-_metric_failure_excerpt_path() {
-	local output_file="$1"
-	local session_key="$2"
-	if [[ -z "$output_file" || ! -f "$output_file" ]]; then
-		return 0
-	fi
-	local excerpt_dir="${HOME}/.aidevops/logs/worker-failure-excerpts"
-	mkdir -p "$excerpt_dir" 2>/dev/null || return 0
-	local safe_key timestamp excerpt_path
-	safe_key=$(printf '%s' "$session_key" | tr -c 'A-Za-z0-9._-' '_')
-	timestamp=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || printf '%s' "unknown")
-	excerpt_path="${excerpt_dir}/${safe_key:-unknown}-${timestamp}-$$.log"
-	python3 - "$output_file" "$excerpt_path" <<'PY' >/dev/null 2>&1 || return 0
-import sys
-src, dst = sys.argv[1], sys.argv[2]
-try:
-    with open(src, "rb") as f:
-        data = f.read()[-65536:]
-    with open(dst, "wb") as f:
-        f.write(data)
-except OSError:
-    sys.exit(0)
-PY
-	[[ -s "$excerpt_path" ]] && printf '%s' "$excerpt_path"
-	return 0
-}
-
-#######################################
 # Derive structured, secret-free worker failure evidence fields.
 #
 # Args:
@@ -1358,10 +1326,9 @@ _execute_run_attempt() {
 	# session state to the output file so the worker log captures it.
 	# OpenCode exits silently on API errors; this is our only visibility.
 	# Extract session ID BEFORE the append block to avoid SC2094 (read+write same file).
-	local _diag_session_id="" _diag_incomplete_msgs="0" _metric_session_id="" _metric_output_file=""
+	local _diag_session_id="" _diag_incomplete_msgs="0" _metric_session_id="" _metric_output_file="" _metric_excerpt_candidate=""
 	if [[ -f "$output_file" ]]; then
 		_metric_session_id=$(extract_session_id_from_output "$output_file" 2>/dev/null || true)
-		_metric_output_file=$(_metric_failure_excerpt_path "$output_file" "$session_key")
 	fi
 	if [[ "${exit_code:-}" == "0" && -n "$_metric_session_id" ]]; then
 		_diag_session_id="$_metric_session_id"
@@ -1390,6 +1357,7 @@ _execute_run_attempt() {
 	} >>"$output_file" 2>/dev/null || true
 
 	print_info "[lifecycle] calling_handle_run_result session=$session_key exit_code=$exit_code output_size=$(wc -c <"$output_file" 2>/dev/null || echo 0)"
+	_metric_excerpt_candidate=$(_metric_failure_excerpt_candidate_path "$output_file" "$session_key")
 	local handle_exit=0
 	if _handle_run_result "$exit_code" "$output_file" "$role" "$provider" "$session_key" "$selected_model"; then
 		handle_exit=0
@@ -1417,9 +1385,8 @@ _execute_run_attempt() {
 		rm -f "$resource_stop_file" "$resource_result_file" 2>/dev/null || true
 	fi
 	local _metric_result_label="${_run_result_label:-fail""ed}"
-	if [[ "$_metric_result_label" == "success" ]]; then
-		_metric_output_file=""
-	fi
+	_metric_output_file=$(_metric_failure_excerpt_for_result "$_metric_result_label" "$_metric_excerpt_candidate" "$session_key")
+	[[ -z "$_metric_excerpt_candidate" ]] || rm -f "$_metric_excerpt_candidate"
 	local _launch_failure_cause="" _next_action=""
 	local _evidence_fields
 	_evidence_fields=$(_derive_worker_failure_evidence \

--- a/.agents/scripts/setup/_backup.sh
+++ b/.agents/scripts/setup/_backup.sh
@@ -2,33 +2,206 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 set -euo pipefail
-# Backup and rotation functions for setup.sh
+# Producer-owned backup and retention functions for setup.sh.
 
-# Create a backup with rotation (keeps last N backups)
+BACKUP_KEEP_COUNT="${BACKUP_KEEP_COUNT:-10}"
+BACKUP_MAX_AGE_DAYS="${AIDEVOPS_BACKUP_MAX_AGE_DAYS:-180}"
+BACKUP_MAX_BYTES="${AIDEVOPS_BACKUP_MAX_BYTES:-4294967296}"
+readonly BACKUP_RETENTION_CONFIRMATION="DELETE-STALE-AIDEVOPS-BACKUPS"
+
+if ! declare -F _file_mtime_epoch >/dev/null 2>&1; then
+	_backup_module_dir="${BASH_SOURCE[0]%/*}"
+	# shellcheck source=../portable-stat.sh
+	source "${_backup_module_dir}/../portable-stat.sh"
+	unset _backup_module_dir
+fi
+
+_backup_policy_value() {
+	local value="$1"
+	local fallback="$2"
+	case "$value" in
+	'' | *[!0-9]*) printf '%s' "$fallback" ;;
+	*) printf '%s' "$value" ;;
+	esac
+	return 0
+}
+
+_backup_snapshot_size_bytes() {
+	local snapshot_path="$1"
+	local kib=""
+	local ignored=""
+	IFS=$'\t ' read -r kib ignored < <(du -sk "$snapshot_path" 2>/dev/null) || return 1
+	case "$kib" in
+	'' | *[!0-9]*) return 1 ;;
+	esac
+	printf '%s' "$((kib * 1024))"
+	return 0
+}
+
+# Print a tab-delimited, oldest-first dry-run plan: path, bytes, reasons.
+# Unknown, symlinked, or unmeasurable snapshots fail closed and produce no plan.
+_backup_retention_plan() {
+	local backup_base="$1"
+	local keep_count=""
+	local max_age_days=""
+	local max_bytes=""
+	local now_epoch=""
+	local age_cutoff=""
+	local snapshot_path=""
+	local snapshot_size=""
+	local snapshot_mtime=""
+	local snapshot_count=0
+	local total_bytes=0
+	local remaining_count=0
+	local remaining_bytes=0
+	local reason=""
+	local newest_snapshot=""
+	local snapshot_name=""
+	local -a snapshots=()
+	local -a sizes=()
+	local -a mtimes=()
+
+	[[ -d "$backup_base" && ! -L "$backup_base" ]] || return 0
+	keep_count=$(_backup_policy_value "$BACKUP_KEEP_COUNT" 10)
+	max_age_days=$(_backup_policy_value "$BACKUP_MAX_AGE_DAYS" 180)
+	max_bytes=$(_backup_policy_value "$BACKUP_MAX_BYTES" 4294967296)
+	now_epoch=$(date +%s)
+	age_cutoff=$((now_epoch - (max_age_days * 86400)))
+	for snapshot_path in "$backup_base"/*; do
+		[[ -e "$snapshot_path" || -L "$snapshot_path" ]] || continue
+		snapshot_name="${snapshot_path##*/}"
+		[[ "$snapshot_name" == ".retention-trash" ]] && continue
+		[[ "$snapshot_name" =~ ^20[0-9]{6}_[0-9]{6}$ ]] || return 2
+		[[ -d "$snapshot_path" && ! -L "$snapshot_path" ]] || return 2
+	done
+
+	while IFS= read -r snapshot_path; do
+		[[ -n "$snapshot_path" ]] || continue
+		if [[ "$snapshot_path" == "$backup_base/20*" && ! -e "$snapshot_path" ]]; then
+			continue
+		fi
+		[[ -d "$snapshot_path" && ! -L "$snapshot_path" ]] || return 2
+		snapshot_size=$(_backup_snapshot_size_bytes "$snapshot_path") || return 2
+		snapshot_mtime=$(_file_mtime_epoch "$snapshot_path" 2>/dev/null) || return 2
+		case "$snapshot_mtime" in
+		'' | *[!0-9]* | 0) return 2 ;;
+		esac
+		snapshots+=("$snapshot_path")
+		sizes+=("$snapshot_size")
+		mtimes+=("$snapshot_mtime")
+		total_bytes=$((total_bytes + snapshot_size))
+	done < <(printf '%s\n' "$backup_base"/20* 2>/dev/null | LC_ALL=C sort)
+
+	snapshot_count=${#snapshots[@]}
+	[[ "$snapshot_count" -gt 1 ]] || return 0
+	remaining_count="$snapshot_count"
+	remaining_bytes="$total_bytes"
+	newest_snapshot="${snapshots[$((snapshot_count - 1))]}"
+
+	local index=0
+	while [[ "$index" -lt "$snapshot_count" ]]; do
+		snapshot_path="${snapshots[$index]}"
+		snapshot_size="${sizes[$index]}"
+		snapshot_mtime="${mtimes[$index]}"
+		reason=""
+		if [[ "$snapshot_path" != "$newest_snapshot" ]]; then
+			[[ "$remaining_count" -gt "$keep_count" ]] && reason="count"
+			if [[ "$remaining_bytes" -gt "$max_bytes" ]]; then
+				reason="${reason:+${reason},}bytes"
+			fi
+			if [[ "$snapshot_mtime" -lt "$age_cutoff" ]]; then
+				reason="${reason:+${reason},}age"
+			fi
+		fi
+		if [[ -n "$reason" ]]; then
+			printf '%s\t%s\t%s\n' "$snapshot_path" "$snapshot_size" "$reason"
+			remaining_count=$((remaining_count - 1))
+			remaining_bytes=$((remaining_bytes - snapshot_size))
+		fi
+		index=$((index + 1))
+	done
+	return 0
+}
+
+# Apply a previously generated plan after validating every attributable path.
+# Candidates are staged in producer-local trash before exact-path removal.
+_backup_retention_apply() {
+	local backup_base="$1"
+	local plan_file="$2"
+	local confirmation="$3"
+	local candidate_path=""
+	local candidate_bytes=""
+	local candidate_reason=""
+	local candidate_name=""
+	local trash_dir="${backup_base}/.retention-trash"
+	local staged_path=""
+	local current_plan=""
+	local current_size=""
+	local index=0
+	local -a staged_paths=()
+
+	[[ "$confirmation" == "$BACKUP_RETENTION_CONFIRMATION" ]] || return 1
+	[[ -d "$backup_base" && ! -L "$backup_base" && -f "$plan_file" ]] || return 1
+	current_plan=$(_backup_retention_plan "$backup_base") || return 1
+	current_plan=$'\n'"${current_plan}"$'\n'
+	mkdir -p "$trash_dir" || return 1
+
+	while IFS=$'\t' read -r candidate_path candidate_bytes candidate_reason; do
+		[[ -n "$candidate_path" ]] || continue
+		candidate_name="${candidate_path##*/}"
+		[[ "${candidate_path%/*}" == "$backup_base" ]] || return 1
+		[[ "$candidate_name" =~ ^20[0-9]{6}_[0-9]{6}$ ]] || return 1
+		[[ -d "$candidate_path" && ! -L "$candidate_path" ]] || return 1
+		case "$candidate_bytes" in
+		'' | *[!0-9]*) return 1 ;;
+		esac
+		[[ -n "$candidate_reason" ]] || return 1
+		[[ "$current_plan" == *$'\n'"${candidate_path}"$'\t'"${candidate_bytes}"$'\t'"${candidate_reason}"$'\n'* ]] || return 1
+		current_size=$(_backup_snapshot_size_bytes "$candidate_path") || return 1
+		[[ "$current_size" == "$candidate_bytes" ]] || return 1
+		staged_path="${trash_dir}/${candidate_name}-$$-${index}"
+		mv "$candidate_path" "$staged_path" || return 1
+		staged_paths+=("$staged_path")
+		index=$((index + 1))
+	done <"$plan_file"
+
+	if [[ "${AIDEVOPS_RETENTION_TEST_INTERRUPT_AFTER_STAGE:-0}" == "1" ]]; then
+		return 1
+	fi
+	for staged_path in "${staged_paths[@]}"; do
+		rm -rf "$staged_path" || return 1
+	done
+	rmdir "$trash_dir" 2>/dev/null || true
+	return 0
+}
+
+# Create a backup, compute the non-destructive plan, then apply that exact plan.
 # Usage: create_backup_with_rotation <source_path> <backup_name>
-# Example: create_backup_with_rotation "$target_dir" "agents"
-# Creates: ~/.aidevops/agents-backups/20251221_123456/
 create_backup_with_rotation() {
 	local source_path="$1"
 	local backup_name="$2"
-	local backup_base="$HOME/.aidevops/${backup_name}-backups"
-	local backup_dir
-	local backup_target
+	local backup_base=""
+	local backup_dir=""
+	local backup_target=""
+	local rsync_status=0
+	local retention_tmp_dir=""
+	local plan_file=""
+	local candidate_count=0
+
+	[[ "$backup_name" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
+	backup_base="$HOME/.aidevops/${backup_name}-backups"
 	backup_dir="$backup_base/$(date +%Y%m%d_%H%M%S)"
 	backup_target="$backup_dir/$(basename "$source_path")"
-
 	mkdir -p "$backup_dir"
 
 	if [[ -d "$source_path" ]]; then
 		mkdir -p "$backup_target"
 		if command -v rsync >/dev/null 2>&1; then
-			local rsync_status=0
 			if rsync -a "$source_path/" "$backup_target/"; then
 				rsync_status=0
 			else
 				rsync_status=$?
 			fi
-
 			if [[ "$rsync_status" -eq 24 ]]; then
 				print_warning "Backup completed with missing source entries skipped: $source_path"
 			elif [[ "$rsync_status" -ne 0 ]]; then
@@ -46,17 +219,23 @@ create_backup_with_rotation() {
 	fi
 
 	print_info "Backed up to $backup_dir"
-
-	local backup_count
-	backup_count=$(find "$backup_base" -maxdepth 1 -type d -name "20*" 2>/dev/null | wc -l | tr -d ' ')
-
-	if [[ $backup_count -gt $BACKUP_KEEP_COUNT ]]; then
-		local to_delete=$((backup_count - BACKUP_KEEP_COUNT))
-		print_info "Rotating backups: removing $to_delete old backup(s), keeping last $BACKUP_KEEP_COUNT"
-		find "$backup_base" -maxdepth 1 -type d -name "20*" 2>/dev/null | sort | head -n "$to_delete" | while read -r old_backup; do
-			rm -rf "$old_backup"
-		done
+	retention_tmp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	mkdir -p "$retention_tmp_dir"
+	plan_file=$(mktemp "${retention_tmp_dir}/backup-retention.XXXXXX") || return 1
+	if ! _backup_retention_plan "$backup_base" >"$plan_file"; then
+		rm -f "$plan_file"
+		print_warning "Backup retention classification unavailable; preserving every snapshot"
+		return 0
 	fi
-
+	candidate_count=$(wc -l <"$plan_file" | tr -d ' ')
+	if [[ "$candidate_count" -gt 0 ]]; then
+		print_info "Backup retention dry run selected ${candidate_count} attributable old snapshot(s)"
+		if ! _backup_retention_apply "$backup_base" "$plan_file" "$BACKUP_RETENTION_CONFIRMATION"; then
+			rm -f "$plan_file"
+			print_warning "Backup retention stopped safely; inspect ${backup_base}/.retention-trash"
+			return 1
+		fi
+	fi
+	rm -f "$plan_file"
 	return 0
 }

--- a/.agents/scripts/setup/_runtime_helpers.sh
+++ b/.agents/scripts/setup/_runtime_helpers.sh
@@ -388,59 +388,7 @@ confirm_step() {
 	done
 }
 
-# Backup rotation settings
-BACKUP_KEEP_COUNT=10
-
-# Create a backup with rotation (keeps last N backups)
-# Usage: create_backup_with_rotation <source_path> <backup_name>
-# Example: create_backup_with_rotation "$target_dir" "agents"
-# Creates: ~/.aidevops/agents-backups/20251221_123456/
-create_backup_with_rotation() {
-	local source_path="$1"
-	local backup_name="$2"
-	local backup_base="$HOME/.aidevops/${backup_name}-backups"
-	local backup_dir
-	backup_dir="$backup_base/$(date +%Y%m%d_%H%M%S)"
-
-	# Create backup directory
-	mkdir -p "$backup_dir"
-
-	# Copy source to backup (tolerant of broken symlinks / missing entries)
-	if [[ -d "$source_path" ]]; then
-		if command -v rsync >/dev/null 2>&1 && rsync --help 2>&1 | grep -q -- '--ignore-missing-args'; then
-			# rsync >= 3.1.0: --ignore-missing-args skips missing/broken entries gracefully
-			if ! rsync -a --ignore-missing-args "$source_path/" "$backup_dir/$(basename "$source_path")/" 2>/dev/null; then
-				print_warning "Backup had partial failures (broken symlinks?), continuing"
-			fi
-		else
-			# Fallback: cp -R may fail on broken symlinks under set -e,
-			# so run in a subshell that tolerates errors
-			if ! (cp -R "$source_path" "$backup_dir/" 2>/dev/null); then
-				print_warning "Backup had partial failures (broken symlinks?), continuing"
-			fi
-		fi
-	elif [[ -f "$source_path" ]]; then
-		cp "$source_path" "$backup_dir/"
-	else
-		print_warning "Source path does not exist: $source_path"
-		return 1
-	fi
-
-	print_info "Backed up to $backup_dir"
-
-	# Rotate old backups (keep last N)
-	local backup_count
-	backup_count=$(find "$backup_base" -maxdepth 1 -type d -name "20*" 2>/dev/null | wc -l | tr -d ' ')
-
-	if [[ $backup_count -gt $BACKUP_KEEP_COUNT ]]; then
-		local to_delete=$((backup_count - BACKUP_KEEP_COUNT))
-		print_info "Rotating backups: removing $to_delete old backup(s), keeping last $BACKUP_KEEP_COUNT"
-
-		# Delete oldest backups (sorted by name = sorted by date)
-		find "$backup_base" -maxdepth 1 -type d -name "20*" 2>/dev/null | sort | head -n "$to_delete" | while read -r old_backup; do
-			rm -rf "$old_backup"
-		done
-	fi
-
-	return 0
-}
+# Backup creation and retention are owned by the focused setup module so tests
+# and the setup entrypoint execute one implementation.
+# shellcheck source=./_backup.sh
+source "${BASH_SOURCE[0]%/*}/_backup.sh"

--- a/.agents/scripts/setup/modules/post-setup.sh
+++ b/.agents/scripts/setup/modules/post-setup.sh
@@ -122,7 +122,7 @@ print_final_instructions() {
 	echo ""
 	echo "Deployed to:"
 	echo "  ~/.aidevops/agents/     - Agent files (main agents, subagents, scripts)"
-	echo "  ~/.aidevops/*-backups/  - Backups with rotation (keeps last $BACKUP_KEEP_COUNT)"
+	echo "  ~/.aidevops/*-backups/  - Rollback backups (count/age/byte retention; newest protected)"
 	echo ""
 	echo "Next steps:"
 	echo "1. Review config templates in configs/ (keep as placeholders — never store real credentials there)"

--- a/.agents/scripts/storage-inventory-helper.sh
+++ b/.agents/scripts/storage-inventory-helper.sh
@@ -9,10 +9,21 @@ if [[ -f "$SCRIPT_DIR/shared-constants.sh" ]]; then
 	# shellcheck source=shared-constants.sh
 	source "$SCRIPT_DIR/shared-constants.sh"
 fi
+# Read-only policy classifiers are sourced from each producer. Their apply
+# functions are never called by this inventory helper.
+# shellcheck source=setup/_backup.sh
+source "$SCRIPT_DIR/setup/_backup.sh"
+# shellcheck source=worker-failure-evidence.sh
+source "$SCRIPT_DIR/worker-failure-evidence.sh"
 
 STORAGE_SCHEMA_VERSION=1
 STORAGE_SIZE_TIMEOUT_TENTHS="${AIDEVOPS_STORAGE_SIZE_TIMEOUT_TENTHS:-20}"
 STORAGE_DU_COMMAND="${AIDEVOPS_STORAGE_DU_COMMAND:-du}"
+STORAGE_JSON_NULL=null
+STORAGE_OWNER_FRAMEWORK=framework
+STORAGE_SAFETY_MIXED=mixed
+STORAGE_DISPOSITION_PROTECTED=protected
+STORAGE_PRODUCER_PULSE=pulse-wrapper
 
 _storage_usage() {
 	cat <<'USAGE'
@@ -101,7 +112,7 @@ _storage_emit_record() {
 
 	measured=$(_storage_measure_path "$actual_path")
 	IFS='|' read -r total_bytes confidence error <<<"$measured"
-	if [[ "$total_bytes" != "null" ]]; then
+	if [[ "$total_bytes" != "$STORAGE_JSON_NULL" ]]; then
 		case "$disposition" in
 		protected)
 			protected_bytes="$total_bytes"
@@ -252,22 +263,148 @@ _storage_emit_runtime_bundle_record() {
 	fi
 
 	jq -cn \
+		--arg owner "$STORAGE_OWNER_FRAMEWORK" \
+		--arg safety_class "$STORAGE_SAFETY_MIXED" \
 		--arg error "$error" \
 		--arg confidence "$confidence" \
 		--argjson total_bytes "$total_bytes" \
 		--argjson protected_bytes "$protected_bytes" \
 		--argjson reclaimable_bytes "$reclaimable_bytes" \
 		--argjson unknown_bytes "$unknown_bytes" \
-		'{store_id:"runtime-bundles",producer:"agent-deploy",path:"~/.aidevops/runtime-bundles",owner:"framework",safety_class:"mixed",policy:"30-day age, 30-bundle count, and 8 GiB soft limits; references and live leases veto deletion",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:$reclaimable_bytes,unknown_bytes:$unknown_bytes,protection_reasons:["current bundle, previous rollback bundle, live leases, and lease metadata"],sizing_confidence:$confidence,next_action:"Use setup activation for policy-owned pruning; do not delete protected bundles manually",error:(if $error == "" or $error == "missing" then null else $error end)}'
+		'{store_id:"runtime-bundles",producer:"agent-deploy",path:"~/.aidevops/runtime-bundles",owner:$owner,safety_class:$safety_class,policy:"30-day age, 30-bundle count, and 8 GiB soft limits; references and live leases veto deletion",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:$reclaimable_bytes,unknown_bytes:$unknown_bytes,protection_reasons:["current bundle, previous rollback bundle, live leases, and lease metadata"],sizing_confidence:$confidence,next_action:"Use setup activation for policy-owned pruning; do not delete protected bundles manually",error:(if $error == "" or $error == "missing" then null else $error end)}'
+	return 0
+}
+
+_storage_plan_reclaimable_bytes() {
+	local plan="$1"
+	local candidate_path=""
+	local candidate_bytes=""
+	local candidate_reason=""
+	local reclaimable_bytes=0
+	while IFS=$'\t' read -r candidate_path candidate_bytes candidate_reason; do
+		[[ -n "$candidate_path" ]] || continue
+		case "$candidate_bytes" in
+		'' | *[!0-9]*) return 1 ;;
+		esac
+		[[ -n "$candidate_reason" ]] || return 1
+		reclaimable_bytes=$((reclaimable_bytes + candidate_bytes))
+	done <<<"$plan"
+	printf '%s' "$reclaimable_bytes"
+	return 0
+}
+
+_storage_worker_excerpt_plan() {
+	local excerpt_dir="$1"
+	local excerpt_path=""
+	local excerpt_name=""
+	local safe_key=""
+	local known_keys=$'\n'
+	local plan=""
+	[[ -d "$excerpt_dir" && ! -L "$excerpt_dir" ]] || return 0
+	for excerpt_path in "$excerpt_dir"/*; do
+		[[ -e "$excerpt_path" || -L "$excerpt_path" ]] || continue
+		excerpt_name="${excerpt_path##*/}"
+		[[ "$excerpt_name" == ".retention-trash" && -d "$excerpt_path" && ! -L "$excerpt_path" ]] && continue
+		[[ -f "$excerpt_path" && ! -L "$excerpt_path" ]] || return 2
+		if [[ "$excerpt_name" =~ ^(.+)-[0-9]{8}T[0-9]{6}Z-[0-9]+\.log$ ]]; then
+			safe_key="${BASH_REMATCH[1]}"
+		else
+			return 2
+		fi
+		[[ "$safe_key" =~ ^[A-Za-z0-9._-]+$ ]] || return 2
+		[[ "$known_keys" == *$'\n'"${safe_key}"$'\n'* ]] || known_keys+="${safe_key}"$'\n'
+	done
+	while IFS= read -r safe_key; do
+		[[ -n "$safe_key" ]] || continue
+		plan=$(_worker_excerpt_retention_plan "$excerpt_dir" "$safe_key") || return 2
+		[[ -n "$plan" ]] && printf '%s\n' "$plan"
+	done <<<"$known_keys"
+	return 0
+}
+
+_storage_emit_retention_record() {
+	local store_id="$1"
+	local producer="$2"
+	local display_path="$3"
+	local actual_path="$4"
+	local safety_class="$5"
+	local policy="$6"
+	local protection_reason="$7"
+	local next_action="$8"
+	local classifier="$9"
+	local measured=""
+	local total_bytes="$STORAGE_JSON_NULL"
+	local confidence="unavailable"
+	local error=""
+	local plan=""
+	local reclaimable_bytes=0
+	local protected_bytes="$STORAGE_JSON_NULL"
+	local unknown_bytes="$STORAGE_JSON_NULL"
+
+	measured=$(_storage_measure_path "$actual_path")
+	IFS='|' read -r total_bytes confidence error <<<"$measured"
+	if [[ "$total_bytes" != "$STORAGE_JSON_NULL" ]]; then
+		if [[ "$total_bytes" == "0" ]]; then
+			protected_bytes=0
+			unknown_bytes=0
+		elif ! plan=$($classifier "$actual_path"); then
+			protected_bytes=0
+			reclaimable_bytes=0
+			unknown_bytes="$total_bytes"
+			error="classification-unavailable"
+			confidence="unavailable"
+		elif ! reclaimable_bytes=$(_storage_plan_reclaimable_bytes "$plan"); then
+			protected_bytes=0
+			reclaimable_bytes=0
+			unknown_bytes="$total_bytes"
+			error="invalid-retention-plan"
+			confidence="unavailable"
+		elif [[ "$reclaimable_bytes" -gt "$total_bytes" ]]; then
+			protected_bytes=0
+			reclaimable_bytes=0
+			unknown_bytes="$total_bytes"
+			error="candidate-bytes-exceed-total"
+			confidence="unavailable"
+		else
+			protected_bytes=$((total_bytes - reclaimable_bytes))
+			unknown_bytes=0
+		fi
+	fi
+
+	jq -cn \
+		--arg store_id "$store_id" \
+		--arg producer "$producer" \
+		--arg path "$display_path" \
+		--arg safety_class "$safety_class" \
+		--arg policy "$policy" \
+		--arg protection_reason "$protection_reason" \
+		--arg confidence "$confidence" \
+		--arg next_action "$next_action" \
+		--arg owner "$STORAGE_OWNER_FRAMEWORK" \
+		--arg error "$error" \
+		--argjson total_bytes "$total_bytes" \
+		--argjson protected_bytes "$protected_bytes" \
+		--argjson reclaimable_bytes "$reclaimable_bytes" \
+		--argjson unknown_bytes "$unknown_bytes" \
+		'{store_id:$store_id,producer:$producer,path:$path,owner:$owner,safety_class:$safety_class,policy:$policy,total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:$reclaimable_bytes,unknown_bytes:$unknown_bytes,protection_reasons:[$protection_reason],sizing_confidence:$confidence,next_action:$next_action,error:(if $error == "" or $error == "missing" then null else $error end)}'
 	return 0
 }
 
 _storage_inventory_records() {
 	local home_label="~"
+	local framework_owner="$STORAGE_OWNER_FRAMEWORK"
+	local active_class="active"
+	local active_writer_reason="active concurrent writer"
+	local protected_disposition="$STORAGE_DISPOSITION_PROTECTED"
+	local pulse_producer="$STORAGE_PRODUCER_PULSE"
 	_storage_emit_runtime_bundle_record
-	_storage_emit_record "observability" "opencode-aidevops" "${home_label}/.aidevops/.agent-workspace/observability" "${HOME}/.aidevops/.agent-workspace/observability" "framework" "audit" "append-only audit evidence; compaction contract pending" "protected" "audit evidence" "Use observability-helper.sh for bounded queries"
-	_storage_emit_record "agent-backups" "setup-backup" "${home_label}/.aidevops/agents-backups" "${HOME}/.aidevops/agents-backups" "framework" "rollback" "count-based snapshots; byte policy pending" "protected" "rollback safety" "Review backup inventory before any cleanup"
-	_storage_emit_record "framework-logs" "multiple-framework-producers" "${home_label}/.aidevops/logs" "${HOME}/.aidevops/logs" "framework" "audit" "producer-specific policies pending" "protected" "audit and unresolved failure evidence" "Use producer-specific diagnostics"
+	_storage_emit_record "observability" "opencode-aidevops" "${home_label}/.aidevops/.agent-workspace/observability" "${HOME}/.aidevops/.agent-workspace/observability" "$framework_owner" "audit" "append-only audit evidence; compaction contract pending" "$protected_disposition" "audit evidence" "Use observability-helper.sh for bounded queries"
+	_storage_emit_retention_record "agent-backups" "setup-backup" "${home_label}/.aidevops/agents-backups" "${HOME}/.aidevops/agents-backups" "$STORAGE_SAFETY_MIXED" "10 snapshots, 180 days, and 4 GiB soft limits" "newest verified rollback and retention trash" "Setup computes a dry run before confirmed producer-owned rotation" "_backup_retention_plan"
+	_storage_emit_retention_record "worker-failure-excerpts" "headless-runtime" "${home_label}/.aidevops/logs/worker-failure-excerpts" "${HOME}/.aidevops/logs/worker-failure-excerpts" "$STORAGE_SAFETY_MIXED" "64 KiB per excerpt; 3 excerpts, 30 days, and 192 KiB per session soft limits" "newest unresolved recovery evidence per session" "Headless runtime computes a dry run after each preserved failure" "_storage_worker_excerpt_plan"
+	_storage_emit_record "pulse-hot-log" "$pulse_producer" "${home_label}/.aidevops/logs/pulse.log" "${HOME}/.aidevops/logs/pulse.log" "$framework_owner" "$active_class" "50 MiB active-file cap with gzip archive rotation" "$protected_disposition" "$active_writer_reason" "Use pulse-owned rotate_pulse_log; never unlink the active file"
+	_storage_emit_record "pulse-wrapper-log" "$pulse_producer" "${home_label}/.aidevops/logs/pulse-wrapper.log" "${HOME}/.aidevops/logs/pulse-wrapper.log" "$framework_owner" "$active_class" "50 MiB active-file cap with gzip archive rotation" "$protected_disposition" "$active_writer_reason" "Use pulse-owned rotate_pulse_log; never unlink the active file"
+	_storage_emit_record "pulse-stage-timings" "$pulse_producer" "${home_label}/.aidevops/logs/pulse-stage-timings.log" "${HOME}/.aidevops/logs/pulse-stage-timings.log" "$framework_owner" "$active_class" "1 MiB active-file cap with gzip archive rotation" "$protected_disposition" "$active_writer_reason" "Use pulse-owned rotate_pulse_log; never unlink the active file"
+	_storage_emit_record "pulse-log-archive" "$pulse_producer" "${home_label}/.aidevops/logs/pulse-archive" "${HOME}/.aidevops/logs/pulse-archive" "$framework_owner" "archive" "1 GiB combined cold archive cap; oldest archives first" "$protected_disposition" "archive already converged by producer" "Use pulse-owned rotate_pulse_log for archive pruning"
 	_storage_emit_record "opencode-data" "opencode" "OpenCode application data" "${AIDEVOPS_OPENCODE_DATA_DIR:-${HOME}/.local/share/opencode}" "joint" "unknown" "runtime-aware maintenance only" "unknown" "OpenCode ownership and active-session state require runtime-aware queries" "Use aidevops opencode-db report"
 	_storage_emit_record "npm-cache" "npm" "npm cache" "${AIDEVOPS_NPM_CACHE_DIR:-${HOME}/.npm}" "external" "cache" "package-manager owned; no aidevops cleanup authority" "protected" "external owner" "Use npm-owned diagnostics and cleanup explicitly"
 	return 0

--- a/.agents/scripts/tests/test-setup-backup.sh
+++ b/.agents/scripts/tests/test-setup-backup.sh
@@ -111,9 +111,131 @@ test_directory_backup_tolerates_rsync_vanished_entries() {
 	return 0
 }
 
+make_snapshot_fixture() {
+	local backup_root="$1"
+	local snapshot_name="$2"
+	mkdir -p "${backup_root}/${snapshot_name}"
+	printf '%s\n' "$snapshot_name" >"${backup_root}/${snapshot_name}/data"
+	return 0
+}
+
+test_retention_plan_combines_limits_and_preserves_newest() {
+	local test_home=""
+	local backup_root=""
+	local plan=""
+	test_home="$(mktemp -d)"
+	backup_root="${test_home}/.aidevops/agents-backups"
+	make_snapshot_fixture "$backup_root" "20260101_000001"
+	make_snapshot_fixture "$backup_root" "20260102_000001"
+	make_snapshot_fixture "$backup_root" "20260103_000001"
+	make_snapshot_fixture "$backup_root" "20260104_000001"
+
+	BACKUP_KEEP_COUNT=2
+	BACKUP_MAX_AGE_DAYS=99999
+	BACKUP_MAX_BYTES=4294967296
+	plan=$(_backup_retention_plan "$backup_root")
+	if [[ "$(printf '%s\n' "$plan" | wc -l | tr -d ' ')" == "2" ]] &&
+		[[ "$plan" == *"20260101_000001"* ]] &&
+		[[ "$plan" == *"20260102_000001"* ]] &&
+		[[ "$plan" != *"20260104_000001"* ]]; then
+		print_result "retention plan applies count limit and protects newest" 0
+	else
+		print_result "retention plan applies count limit and protects newest" 1 "$plan"
+	fi
+
+	BACKUP_KEEP_COUNT=10
+	BACKUP_MAX_BYTES=1
+	plan=$(_backup_retention_plan "$backup_root")
+	if [[ "$plan" == *"bytes"* ]] && [[ "$plan" != *"20260104_000001"* ]]; then
+		print_result "retention plan applies byte limit and protects newest" 0
+	else
+		print_result "retention plan applies byte limit and protects newest" 1 "$plan"
+	fi
+
+	rm -rf "$test_home"
+	return 0
+}
+
+test_retention_fails_closed_and_stages_before_delete() {
+	local test_home=""
+	local backup_root=""
+	local plan_file=""
+	local forged_plan=""
+	local newest_size=""
+	local staged_match=""
+	test_home="$(mktemp -d)"
+	backup_root="${test_home}/.aidevops/agents-backups"
+	make_snapshot_fixture "$backup_root" "20260101_000001"
+	make_snapshot_fixture "$backup_root" "20260102_000001"
+	BACKUP_KEEP_COUNT=1
+	BACKUP_MAX_AGE_DAYS=99999
+	BACKUP_MAX_BYTES=4294967296
+	plan_file="${test_home}/plan.tsv"
+	_backup_retention_plan "$backup_root" >"$plan_file"
+
+	if _backup_retention_apply "$backup_root" "$plan_file" "wrong-token"; then
+		print_result "retention apply rejects missing confirmation" 1 "unexpected success"
+	elif [[ -d "${backup_root}/20260101_000001" ]]; then
+		print_result "retention apply rejects missing confirmation" 0
+	else
+		print_result "retention apply rejects missing confirmation" 1 "candidate changed"
+	fi
+	forged_plan="${test_home}/forged-plan.tsv"
+	newest_size=$(_backup_snapshot_size_bytes "${backup_root}/20260102_000001")
+	printf '%s\t%s\t%s\n' "${backup_root}/20260102_000001" "$newest_size" "count" >"$forged_plan"
+	if _backup_retention_apply "$backup_root" "$forged_plan" "$BACKUP_RETENTION_CONFIRMATION"; then
+		print_result "apply-time classification protects newest backup" 1 "forged plan succeeded"
+	elif [[ -d "${backup_root}/20260102_000001" ]]; then
+		print_result "apply-time classification protects newest backup" 0
+	else
+		print_result "apply-time classification protects newest backup" 1 "newest backup changed"
+	fi
+
+	if AIDEVOPS_RETENTION_TEST_INTERRUPT_AFTER_STAGE=1 \
+		_backup_retention_apply "$backup_root" "$plan_file" "$BACKUP_RETENTION_CONFIRMATION"; then
+		print_result "interrupted retention leaves recoverable trash" 1 "unexpected success"
+	else
+		for staged_match in "${backup_root}/.retention-trash"/20260101_000001-*; do
+			if [[ -d "$staged_match" && -d "${backup_root}/20260102_000001" ]]; then
+				print_result "interrupted retention leaves recoverable trash" 0
+				rm -rf "$test_home"
+				return 0
+			fi
+		done
+		print_result "interrupted retention leaves recoverable trash" 1 "staged candidate missing"
+	fi
+
+	rm -rf "$test_home"
+	return 0
+}
+
+test_retention_unknown_snapshot_fails_closed() {
+	local test_home=""
+	local backup_root=""
+	local plan=""
+	test_home="$(mktemp -d)"
+	backup_root="${test_home}/.aidevops/agents-backups"
+	make_snapshot_fixture "$backup_root" "20260101_000001"
+	make_snapshot_fixture "$backup_root" "20260102_000001"
+	ln -s "${backup_root}/20260101_000001" "${backup_root}/20260103_000001"
+	BACKUP_KEEP_COUNT=1
+	if plan=$(_backup_retention_plan "$backup_root"); then
+		print_result "unknown backup entry fails closed" 1 "classification unexpectedly succeeded: $plan"
+	elif [[ -z "$plan" ]]; then
+		print_result "unknown backup entry fails closed" 0
+	else
+		print_result "unknown backup entry fails closed" 1 "$plan"
+	fi
+	rm -rf "$test_home"
+	return 0
+}
+
 main() {
 	test_directory_backup_uses_basename_target
 	test_directory_backup_tolerates_rsync_vanished_entries
+	test_retention_plan_combines_limits_and_preserves_newest
+	test_retention_fails_closed_and_stages_before_delete
+	test_retention_unknown_snapshot_fails_closed
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/tests/test-storage-inventory-helper.sh
+++ b/.agents/scripts/tests/test-storage-inventory-helper.sh
@@ -26,14 +26,19 @@ make_fixture() {
 	mkdir -p \
 		"$HOME/.aidevops/runtime-bundles/bundle-a" \
 		"$HOME/.aidevops/.agent-workspace/observability" \
-		"$HOME/.aidevops/agents-backups/backup-a" \
-		"$HOME/.aidevops/logs" \
+		"$HOME/.aidevops/agents-backups/20260101_000001" \
+		"$HOME/.aidevops/agents-backups/20260102_000001" \
+		"$HOME/.aidevops/logs/worker-failure-excerpts" \
+		"$HOME/.aidevops/logs/pulse-archive" \
 		"$HOME/.local/share/opencode" \
 		"$HOME/.npm"
 	printf 'bundle-data\n' >"$HOME/.aidevops/runtime-bundles/bundle-a/data"
 	printf 'audit-data\n' >"$HOME/.aidevops/.agent-workspace/observability/events"
-	printf 'backup-data\n' >"$HOME/.aidevops/agents-backups/backup-a/data"
+	printf 'backup-data-a\n' >"$HOME/.aidevops/agents-backups/20260101_000001/data"
+	printf 'backup-data-b\n' >"$HOME/.aidevops/agents-backups/20260102_000001/data"
 	printf 'log-data\n' >"$HOME/.aidevops/logs/pulse.log"
+	printf 'failure-a\n' >"$HOME/.aidevops/logs/worker-failure-excerpts/issue-1-20260101T000001Z-1.log"
+	printf 'failure-b\n' >"$HOME/.aidevops/logs/worker-failure-excerpts/issue-1-20260101T000002Z-2.log"
 	printf 'runtime-data\n' >"$HOME/.local/share/opencode/opencode.db"
 	printf 'cache-data\n' >"$HOME/.npm/cache"
 	return 0
@@ -43,8 +48,11 @@ fixture_checksum() {
 	cksum \
 		"$HOME/.aidevops/runtime-bundles/bundle-a/data" \
 		"$HOME/.aidevops/.agent-workspace/observability/events" \
-		"$HOME/.aidevops/agents-backups/backup-a/data" \
+		"$HOME/.aidevops/agents-backups/20260101_000001/data" \
+		"$HOME/.aidevops/agents-backups/20260102_000001/data" \
 		"$HOME/.aidevops/logs/pulse.log" \
+		"$HOME/.aidevops/logs/worker-failure-excerpts/issue-1-20260101T000001Z-1.log" \
+		"$HOME/.aidevops/logs/worker-failure-excerpts/issue-1-20260101T000002Z-2.log" \
 		"$HOME/.local/share/opencode/opencode.db" \
 		"$HOME/.npm/cache"
 	return 0
@@ -58,11 +66,17 @@ after_checksum=$(fixture_checksum)
 
 [[ "$(printf '%s' "$report" | jq -r '.schema_version')" == "1" ]] || fail "schema version missing"
 [[ "$(printf '%s' "$report" | jq -r '.read_only')" == "true" ]] || fail "read-only marker missing"
-[[ "$(printf '%s' "$report" | jq '.stores | length')" == "6" ]] || fail "expected six explicit stores"
+[[ "$(printf '%s' "$report" | jq '.stores | length')" == "10" ]] || fail "expected ten explicit producer stores"
 [[ "$(printf '%s' "$report" | jq '[.stores[].reclaimable_bytes] | add')" == "0" ]] || fail "foundation report suggested reclaimable bytes"
+[[ "$(printf '%s' "$report" | jq '[.stores[] | select(.total_bytes != null) | (.total_bytes == (.protected_bytes + .reclaimable_bytes + .unknown_bytes))] | all')" == "true" ]] || fail "storage categories did not reconcile with totals"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .unknown_bytes > 0')" == "true" ]] || fail "runtime bundles were not fail-closed unknown"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "observability") | .protected_bytes > 0')" == "true" ]] || fail "audit evidence was not protected"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "npm-cache") | .owner')" == "external" ]] || fail "npm ownership was claimed by aidevops"
+
+report=$(BACKUP_KEEP_COUNT=1 AIDEVOPS_WORKER_EXCERPT_KEEP_COUNT=1 bash "$HELPER" json)
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "agent-backups") | .reclaimable_bytes > 0')" == "true" ]] || fail "backup dry-run candidates were not reported"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "worker-failure-excerpts") | .reclaimable_bytes > 0')" == "true" ]] || fail "worker excerpt dry-run candidates were not reported"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "worker-failure-excerpts") | .protected_bytes > 0')" == "true" ]] || fail "newest worker recovery evidence was not protected"
 
 human=$(bash "$HELPER" status)
 [[ "$human" == *"Storage Inventory (read-only)"* ]] || fail "human report heading missing"

--- a/.agents/scripts/tests/test-worker-failure-evidence-retention.sh
+++ b/.agents/scripts/tests/test-worker-failure-evidence-retention.sh
@@ -28,6 +28,14 @@ source "${SCRIPTS_DIR}/shared-constants.sh"
 # shellcheck source=../worker-failure-evidence.sh
 source "${SCRIPTS_DIR}/worker-failure-evidence.sh"
 
+test_standalone_source_loads_portable_stat() {
+	WORKER_MODULE_PATH="${SCRIPTS_DIR}/worker-failure-evidence.sh" \
+		bash -c 'source "$WORKER_MODULE_PATH" && declare -F _file_mtime_epoch >/dev/null' \
+		|| fail "standalone source did not load portable stat dependency"
+	printf 'PASS: standalone source loads portable stat dependency\n'
+	return 0
+}
+
 make_excerpt() {
 	local excerpt_dir="$1"
 	local excerpt_name="$2"
@@ -150,6 +158,7 @@ test_failure_result_survives_source_cleanup() {
 }
 
 main() {
+	test_standalone_source_loads_portable_stat
 	test_plan_preserves_newest_recovery_evidence
 	test_apply_requires_confirmation_and_stages_first
 	test_writer_caps_excerpt_and_fails_closed_on_unknown

--- a/.agents/scripts/tests/test-worker-failure-evidence-retention.sh
+++ b/.agents/scripts/tests/test-worker-failure-evidence-retention.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d -t aidevops-worker-excerpts.XXXXXX)"
+HOME="${TEST_ROOT}/home"
+AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp"
+export HOME AIDEVOPS_TEMP_DIR
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+}
+
+# shellcheck source=../shared-constants.sh
+source "${SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=../worker-failure-evidence.sh
+source "${SCRIPTS_DIR}/worker-failure-evidence.sh"
+
+make_excerpt() {
+	local excerpt_dir="$1"
+	local excerpt_name="$2"
+	mkdir -p "$excerpt_dir"
+	printf '%s\n' "$excerpt_name" >"${excerpt_dir}/${excerpt_name}"
+	return 0
+}
+
+test_plan_preserves_newest_recovery_evidence() {
+	local excerpt_dir="${TEST_ROOT}/plan"
+	local plan=""
+	make_excerpt "$excerpt_dir" "issue-1-20260101T000001Z-1.log"
+	make_excerpt "$excerpt_dir" "issue-1-20260101T000002Z-2.log"
+	make_excerpt "$excerpt_dir" "issue-1-20260101T000003Z-3.log"
+	make_excerpt "$excerpt_dir" "issue-1-20260101T000004Z-4.log"
+	WORKER_EXCERPT_KEEP_COUNT=2
+	WORKER_EXCERPT_MAX_AGE_DAYS=99999
+	WORKER_EXCERPT_MAX_BYTES=999999
+	plan=$(_worker_excerpt_retention_plan "$excerpt_dir" "issue-1")
+	[[ "$plan" == *"000001Z-1.log"* ]] || fail "oldest duplicate was not selected"
+	[[ "$plan" == *"000002Z-2.log"* ]] || fail "second duplicate was not selected"
+	[[ "$plan" != *"000004Z-4.log"* ]] || fail "newest recovery evidence was selected"
+	printf 'PASS: worker excerpt plan preserves newest recovery evidence\n'
+	return 0
+}
+
+test_apply_requires_confirmation_and_stages_first() {
+	local excerpt_dir="${TEST_ROOT}/apply"
+	local plan_file="${TEST_ROOT}/apply-plan.tsv"
+	local forged_plan="${TEST_ROOT}/forged-plan.tsv"
+	local newest_size=""
+	local staged_path=""
+	make_excerpt "$excerpt_dir" "issue-2-20260101T000001Z-1.log"
+	make_excerpt "$excerpt_dir" "issue-2-20260101T000002Z-2.log"
+	WORKER_EXCERPT_KEEP_COUNT=1
+	_worker_excerpt_retention_plan "$excerpt_dir" "issue-2" >"$plan_file"
+	if _worker_excerpt_retention_apply "$excerpt_dir" "issue-2" "$plan_file" "wrong-token"; then
+		fail "apply accepted an invalid confirmation"
+	fi
+	[[ -f "${excerpt_dir}/issue-2-20260101T000001Z-1.log" ]] || fail "invalid confirmation changed evidence"
+	newest_size=$(_worker_excerpt_size_bytes "${excerpt_dir}/issue-2-20260101T000002Z-2.log")
+	printf '%s\t%s\t%s\n' "${excerpt_dir}/issue-2-20260101T000002Z-2.log" "$newest_size" "count" >"$forged_plan"
+	if _worker_excerpt_retention_apply "$excerpt_dir" "issue-2" "$forged_plan" "$WORKER_EXCERPT_RETENTION_CONFIRMATION"; then
+		fail "apply-time classifier accepted newest recovery evidence"
+	fi
+	[[ -f "${excerpt_dir}/issue-2-20260101T000002Z-2.log" ]] || fail "newest evidence changed after forged plan"
+	if AIDEVOPS_RETENTION_TEST_INTERRUPT_AFTER_STAGE=1 \
+		_worker_excerpt_retention_apply "$excerpt_dir" "issue-2" "$plan_file" "$WORKER_EXCERPT_RETENTION_CONFIRMATION"; then
+		fail "interrupted apply unexpectedly succeeded"
+	fi
+	for staged_path in "${excerpt_dir}/.retention-trash"/issue-2-20260101T000001Z-1.log-*; do
+		[[ -f "$staged_path" ]] || continue
+		[[ -f "${excerpt_dir}/issue-2-20260101T000002Z-2.log" ]] || fail "newest evidence did not survive"
+		printf 'PASS: worker excerpt apply stages candidates before deletion\n'
+		return 0
+	done
+	fail "interrupted apply did not leave recoverable trash"
+}
+
+test_writer_caps_excerpt_and_fails_closed_on_unknown() {
+	local source_file="${TEST_ROOT}/large-output.log"
+	local excerpt_path=""
+	local excerpt_size=""
+	local excerpt_dir="${HOME}/.aidevops/logs/worker-failure-excerpts"
+	local plan=""
+	mkdir -p "$AIDEVOPS_TEMP_DIR"
+	dd if=/dev/zero of="$source_file" bs=1024 count=100 2>/dev/null
+	excerpt_path=$(_metric_failure_excerpt_path "$source_file" "issue-3")
+	[[ -f "$excerpt_path" ]] || fail "writer did not preserve failure excerpt"
+	excerpt_size=$(_file_size_bytes "$excerpt_path")
+	[[ "$excerpt_size" == "65536" ]] || fail "excerpt cap was ${excerpt_size}, expected 65536"
+	ln -s "$excerpt_path" "${excerpt_dir}/issue-3-99999999T999999Z-9.log"
+	WORKER_EXCERPT_KEEP_COUNT=1
+	if plan=$(_worker_excerpt_retention_plan "$excerpt_dir" "issue-3"); then
+		fail "symlinked unknown evidence classification unexpectedly succeeded: $plan"
+	fi
+	[[ -z "$plan" ]] || fail "unknown evidence emitted reclaimable candidates"
+	rm "${excerpt_dir}/issue-3-99999999T999999Z-9.log"
+	printf 'ambiguous\n' >"${excerpt_dir}/issue-3-malformed.log"
+	if plan=$(_worker_excerpt_retention_plan "$excerpt_dir" "issue-3"); then
+		fail "malformed regular evidence classification unexpectedly succeeded: $plan"
+	fi
+	printf 'PASS: worker excerpt writer caps output and unknown entries fail closed\n'
+	return 0
+}
+
+test_success_result_never_creates_failure_evidence() {
+	local success_home="${TEST_ROOT}/success-home"
+	local source_file="${TEST_ROOT}/successful-output.log"
+	local candidate_path=""
+	local result=""
+	printf 'successful worker output\n' >"$source_file"
+	candidate_path=$(HOME="$success_home" AIDEVOPS_TEMP_DIR="${success_home}/tmp" _metric_failure_excerpt_candidate_path "$source_file" "issue-4")
+	rm "$source_file"
+	result=$(HOME="$success_home" _metric_failure_excerpt_for_result "success" "$candidate_path" "issue-4")
+	[[ -z "$result" ]] || fail "success returned a failure excerpt path"
+	[[ ! -e "${success_home}/.aidevops/logs/worker-failure-excerpts" ]] || fail "success persisted failure evidence"
+	result=$(HOME="$success_home" _metric_failure_excerpt_for_result "post_pr_handoff" "$candidate_path" "issue-4")
+	[[ -z "$result" ]] || fail "post-PR handoff returned a failure excerpt path"
+	[[ ! -e "${success_home}/.aidevops/logs/worker-failure-excerpts" ]] || fail "post-PR handoff persisted failure evidence"
+	rm -f "$candidate_path"
+	printf 'PASS: successful attempts do not displace failure evidence\n'
+	return 0
+}
+
+test_failure_result_survives_source_cleanup() {
+	local failure_home="${TEST_ROOT}/failure-home"
+	local source_file="${TEST_ROOT}/failed-output.log"
+	local candidate_path=""
+	local excerpt_path=""
+	printf 'failed worker output\n' >"$source_file"
+	candidate_path=$(HOME="$failure_home" AIDEVOPS_TEMP_DIR="${failure_home}/tmp" _metric_failure_excerpt_candidate_path "$source_file" "issue-5")
+	[[ -f "$candidate_path" ]] || fail "failure candidate was not captured before classification"
+	rm "$source_file"
+	excerpt_path=$(HOME="$failure_home" AIDEVOPS_TEMP_DIR="${failure_home}/tmp" _metric_failure_excerpt_for_result "premature_exit" "$candidate_path" "issue-5")
+	[[ -f "$excerpt_path" ]] || fail "failure evidence was lost after source cleanup"
+	rm -f "$candidate_path"
+	printf 'PASS: failure evidence survives result-handler source cleanup\n'
+	return 0
+}
+
+main() {
+	test_plan_preserves_newest_recovery_evidence
+	test_apply_requires_confirmation_and_stages_first
+	test_writer_caps_excerpt_and_fails_closed_on_unknown
+	test_success_result_never_creates_failure_evidence
+	test_failure_result_survives_source_cleanup
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/worker-failure-evidence.sh
+++ b/.agents/scripts/worker-failure-evidence.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Producer-owned write and retention policy for worker failure excerpts.
+
+[[ -n "${_WORKER_FAILURE_EVIDENCE_LOADED:-}" ]] && return 0
+_WORKER_FAILURE_EVIDENCE_LOADED=1
+
+WORKER_EXCERPT_KEEP_COUNT="${AIDEVOPS_WORKER_EXCERPT_KEEP_COUNT:-3}"
+WORKER_EXCERPT_MAX_AGE_DAYS="${AIDEVOPS_WORKER_EXCERPT_MAX_AGE_DAYS:-30}"
+WORKER_EXCERPT_MAX_BYTES="${AIDEVOPS_WORKER_EXCERPT_MAX_BYTES:-196608}"
+readonly WORKER_EXCERPT_RETENTION_CONFIRMATION="DELETE-STALE-WORKER-EXCERPTS"
+
+_worker_excerpt_policy_value() {
+	local value="$1"
+	local fallback="$2"
+	case "$value" in
+	'' | *[!0-9]*) printf '%s' "$fallback" ;;
+	*) printf '%s' "$value" ;;
+	esac
+	return 0
+}
+
+_worker_excerpt_size_bytes() {
+	local excerpt_path="$1"
+	local excerpt_kib=""
+	local ignored=""
+	IFS=$'\t ' read -r excerpt_kib ignored < <(du -sk "$excerpt_path" 2>/dev/null) || return 1
+	case "$excerpt_kib" in
+	'' | *[!0-9]*) return 1 ;;
+	esac
+	printf '%s' "$((excerpt_kib * 1024))"
+	return 0
+}
+
+# Print a tab-delimited dry-run plan for older duplicate evidence from one
+# session. The newest excerpt is an unresolved-recovery hard veto at any size.
+_worker_excerpt_retention_plan() {
+	local excerpt_dir="$1"
+	local safe_key="$2"
+	local keep_count=""
+	local max_age_days=""
+	local max_bytes=""
+	local age_cutoff=""
+	local excerpt_path=""
+	local excerpt_size=""
+	local excerpt_mtime=""
+	local excerpt_name=""
+	local excerpt_suffix=""
+	local excerpt_count=0
+	local total_bytes=0
+	local remaining_count=0
+	local remaining_bytes=0
+	local newest_excerpt=""
+	local reason=""
+	local index=0
+	local -a excerpts=()
+	local -a sizes=()
+	local -a mtimes=()
+
+	[[ -d "$excerpt_dir" && ! -L "$excerpt_dir" ]] || return 0
+	[[ "$safe_key" =~ ^[A-Za-z0-9._-]+$ ]] || return 2
+	keep_count=$(_worker_excerpt_policy_value "$WORKER_EXCERPT_KEEP_COUNT" 3)
+	max_age_days=$(_worker_excerpt_policy_value "$WORKER_EXCERPT_MAX_AGE_DAYS" 30)
+	max_bytes=$(_worker_excerpt_policy_value "$WORKER_EXCERPT_MAX_BYTES" 196608)
+	age_cutoff=$(($(date +%s) - (max_age_days * 86400)))
+
+	while IFS= read -r excerpt_path; do
+		[[ -n "$excerpt_path" ]] || continue
+		if [[ "$excerpt_path" == "$excerpt_dir/${safe_key}-*.log" && ! -e "$excerpt_path" ]]; then
+			continue
+		fi
+		[[ -f "$excerpt_path" && ! -L "$excerpt_path" ]] || return 2
+		excerpt_name="${excerpt_path##*/}"
+		excerpt_suffix="${excerpt_name#"${safe_key}-"}"
+		[[ "$excerpt_suffix" =~ ^[0-9]{8}T[0-9]{6}Z-[0-9]+\.log$ ]] || return 2
+		excerpt_size=$(_worker_excerpt_size_bytes "$excerpt_path") || return 2
+		excerpt_mtime=$(_file_mtime_epoch "$excerpt_path" 2>/dev/null) || return 2
+		case "$excerpt_mtime" in
+		'' | *[!0-9]* | 0) return 2 ;;
+		esac
+		excerpts+=("$excerpt_path")
+		sizes+=("$excerpt_size")
+		mtimes+=("$excerpt_mtime")
+		total_bytes=$((total_bytes + excerpt_size))
+	done < <(printf '%s\n' "$excerpt_dir/${safe_key}-"*.log 2>/dev/null | LC_ALL=C sort)
+
+	excerpt_count=${#excerpts[@]}
+	[[ "$excerpt_count" -gt 1 ]] || return 0
+	remaining_count="$excerpt_count"
+	remaining_bytes="$total_bytes"
+	newest_excerpt="${excerpts[$((excerpt_count - 1))]}"
+	while [[ "$index" -lt "$excerpt_count" ]]; do
+		excerpt_path="${excerpts[$index]}"
+		excerpt_size="${sizes[$index]}"
+		excerpt_mtime="${mtimes[$index]}"
+		reason=""
+		if [[ "$excerpt_path" != "$newest_excerpt" ]]; then
+			[[ "$remaining_count" -gt "$keep_count" ]] && reason="count"
+			if [[ "$remaining_bytes" -gt "$max_bytes" ]]; then
+				reason="${reason:+${reason},}bytes"
+			fi
+			if [[ "$excerpt_mtime" -lt "$age_cutoff" ]]; then
+				reason="${reason:+${reason},}age"
+			fi
+		fi
+		if [[ -n "$reason" ]]; then
+			printf '%s\t%s\t%s\n' "$excerpt_path" "$excerpt_size" "$reason"
+			remaining_count=$((remaining_count - 1))
+			remaining_bytes=$((remaining_bytes - excerpt_size))
+		fi
+		index=$((index + 1))
+	done
+	return 0
+}
+
+_worker_excerpt_retention_apply() {
+	local excerpt_dir="$1"
+	local safe_key="$2"
+	local plan_file="$3"
+	local confirmation="$4"
+	local candidate_path=""
+	local candidate_bytes=""
+	local candidate_reason=""
+	local candidate_name=""
+	local trash_dir="${excerpt_dir}/.retention-trash"
+	local staged_path=""
+	local current_plan=""
+	local current_size=""
+	local index=0
+	local -a staged_paths=()
+
+	[[ "$confirmation" == "$WORKER_EXCERPT_RETENTION_CONFIRMATION" ]] || return 1
+	[[ -d "$excerpt_dir" && ! -L "$excerpt_dir" && -f "$plan_file" ]] || return 1
+	[[ "$safe_key" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
+	current_plan=$(_worker_excerpt_retention_plan "$excerpt_dir" "$safe_key") || return 1
+	current_plan=$'\n'"${current_plan}"$'\n'
+	mkdir -p "$trash_dir" || return 1
+	while IFS=$'\t' read -r candidate_path candidate_bytes candidate_reason; do
+		[[ -n "$candidate_path" ]] || continue
+		candidate_name="${candidate_path##*/}"
+		[[ "${candidate_path%/*}" == "$excerpt_dir" ]] || return 1
+		[[ "$candidate_name" == "${safe_key}-"*.log ]] || return 1
+		[[ -f "$candidate_path" && ! -L "$candidate_path" ]] || return 1
+		case "$candidate_bytes" in
+		'' | *[!0-9]*) return 1 ;;
+		esac
+		[[ -n "$candidate_reason" ]] || return 1
+		[[ "$current_plan" == *$'\n'"${candidate_path}"$'\t'"${candidate_bytes}"$'\t'"${candidate_reason}"$'\n'* ]] || return 1
+		current_size=$(_worker_excerpt_size_bytes "$candidate_path") || return 1
+		[[ "$current_size" == "$candidate_bytes" ]] || return 1
+		staged_path="${trash_dir}/${candidate_name}-$$-${index}"
+		mv "$candidate_path" "$staged_path" || return 1
+		staged_paths+=("$staged_path")
+		index=$((index + 1))
+	done <"$plan_file"
+	if [[ "${AIDEVOPS_RETENTION_TEST_INTERRUPT_AFTER_STAGE:-0}" == "1" ]]; then
+		return 1
+	fi
+	for staged_path in "${staged_paths[@]}"; do
+		rm -f "$staged_path" || return 1
+	done
+	rmdir "$trash_dir" 2>/dev/null || true
+	return 0
+}
+
+# Preserve a capped output excerpt, then converge older duplicate evidence for
+# the same session. Observability and retention failures remain non-fatal.
+_metric_failure_excerpt_candidate_path() {
+	local output_file="$1"
+	local session_key="$2"
+	local retention_tmp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local safe_key=""
+	local candidate_path=""
+	[[ -n "$output_file" && -f "$output_file" ]] || return 0
+	safe_key=$(printf '%s' "$session_key" | tr -c 'A-Za-z0-9._-' '_')
+	mkdir -p "$retention_tmp_dir" 2>/dev/null || return 0
+	candidate_path=$(mktemp "${retention_tmp_dir}/worker-failure-${safe_key:-unknown}.XXXXXX" 2>/dev/null || true)
+	[[ -n "$candidate_path" ]] || return 0
+	if ! python3 - "$output_file" "$candidate_path" <<'PY' >/dev/null 2>&1
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+try:
+    with open(src, "rb") as f:
+        data = f.read()[-65536:]
+    with open(dst, "wb") as f:
+        f.write(data)
+except OSError:
+    sys.exit(1)
+PY
+	then
+		rm -f "$candidate_path"
+		return 0
+	fi
+	if [[ -s "$candidate_path" ]]; then
+		printf '%s' "$candidate_path"
+	else
+		rm -f "$candidate_path"
+	fi
+	return 0
+}
+
+_metric_failure_excerpt_path() {
+	local output_file="$1"
+	local session_key="$2"
+	local excerpt_dir="${HOME}/.aidevops/logs/worker-failure-excerpts"
+	local safe_key=""
+	local timestamp=""
+	local excerpt_path=""
+	local retention_tmp_dir=""
+	local plan_file=""
+
+	[[ -n "$output_file" && -f "$output_file" ]] || return 0
+	mkdir -p "$excerpt_dir" 2>/dev/null || return 0
+	safe_key=$(printf '%s' "$session_key" | tr -c 'A-Za-z0-9._-' '_')
+	timestamp=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || printf '%s' "unknown")
+	excerpt_path="${excerpt_dir}/${safe_key:-unknown}-${timestamp}-$$.log"
+	python3 - "$output_file" "$excerpt_path" <<'PY' >/dev/null 2>&1 || return 0
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+try:
+    with open(src, "rb") as f:
+        data = f.read()[-65536:]
+    with open(dst, "wb") as f:
+        f.write(data)
+except OSError:
+    sys.exit(0)
+PY
+	if [[ -s "$excerpt_path" ]]; then
+		retention_tmp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+		if mkdir -p "$retention_tmp_dir" 2>/dev/null; then
+			plan_file=$(mktemp "${retention_tmp_dir}/worker-excerpt-retention.XXXXXX" 2>/dev/null || true)
+			if [[ -n "$plan_file" ]]; then
+				if _worker_excerpt_retention_plan "$excerpt_dir" "${safe_key:-unknown}" >"$plan_file"; then
+					_worker_excerpt_retention_apply "$excerpt_dir" "${safe_key:-unknown}" "$plan_file" "$WORKER_EXCERPT_RETENTION_CONFIRMATION" 2>/dev/null || true
+				fi
+				rm -f "$plan_file"
+			fi
+		fi
+		printf '%s' "$excerpt_path"
+	fi
+	return 0
+}
+
+# Gate excerpt creation on the final reconciled attempt result so successful
+# continuations cannot displace the failure evidence they recovered from.
+_metric_failure_excerpt_for_result() {
+	local result_label="$1"
+	local output_file="$2"
+	local session_key="$3"
+	case "$result_label" in
+	success | post_pr_handoff) return 0 ;;
+	esac
+	_metric_failure_excerpt_path "$output_file" "$session_key"
+	return 0
+}

--- a/.agents/scripts/worker-failure-evidence.sh
+++ b/.agents/scripts/worker-failure-evidence.sh
@@ -6,6 +6,13 @@
 [[ -n "${_WORKER_FAILURE_EVIDENCE_LOADED:-}" ]] && return 0
 _WORKER_FAILURE_EVIDENCE_LOADED=1
 
+if ! declare -F _file_mtime_epoch >/dev/null 2>&1; then
+	_worker_failure_evidence_dir="${BASH_SOURCE[0]%/*}"
+	# shellcheck source=./portable-stat.sh
+	source "${_worker_failure_evidence_dir}/portable-stat.sh"
+	unset _worker_failure_evidence_dir
+fi
+
 WORKER_EXCERPT_KEEP_COUNT="${AIDEVOPS_WORKER_EXCERPT_KEEP_COUNT:-3}"
 WORKER_EXCERPT_MAX_AGE_DAYS="${AIDEVOPS_WORKER_EXCERPT_MAX_AGE_DAYS:-30}"
 WORKER_EXCERPT_MAX_BYTES="${AIDEVOPS_WORKER_EXCERPT_MAX_BYTES:-196608}"


### PR DESCRIPTION
## Summary

Add producer-owned count, age, and byte retention for setup backups and worker failure excerpts; preserve newest rollback/recovery evidence; register Pulse and retention policies in shared storage inventory.

## Files Changed

`.agents/reference/storage-lifecycle.md`, `.agents/scripts/headless-runtime-helper.sh`, `.agents/scripts/setup/_backup.sh`, `.agents/scripts/setup/_runtime_helpers.sh`, `.agents/scripts/setup/modules/post-setup.sh`, `.agents/scripts/storage-inventory-helper.sh`, and focused tests.

## Runtime Testing

- **Risk level:** Critical (producer-owned backup and recovery-evidence deletion)
- **Verification:** Runtime-verified with synthetic deletion, stale-plan, malformed-artifact, success/failure classification, and interrupted-staging fixtures; 140 headless-runtime tests; setup integration tests; ShellCheck; Bash 3.2 compatibility; and `.agents/scripts/linters-local.sh`.

## Decisions

- Preserve the newest backup and newest failure evidence per session as hard vetoes.
- Reclassify and remeasure exact candidates immediately before staged removal.
- Keep Pulse rotation producer-owned without adding a competing generic cleaner.
- Fail closed for symlinks, malformed names, unknown artifacts, and unavailable sizing or metadata.

Resolves #28152

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 5h 38m and 794,494 tokens on this with the user in an interactive session. Overall, 1h 58m since this issue was created.
