### PR TITLE
GH#28162: fix: make qlty scan counts deterministic

### DIFF
--- a/.agents/scripts/qlty-regression-helper.sh
+++ b/.agents/scripts/qlty-regression-helper.sh
@@ -28,8 +28,8 @@
 #   2 — invocation or environment error
 #
 # Design notes:
-# - Uses `git worktree add` to scan the base ref in an isolated tree so
-#   the primary worktree is not disturbed. Head is scanned in-place.
+# - Uses standalone shared clones for isolated refs. Unlike linked worktrees,
+#   these retain a .git directory, matching the authoritative CI checkout.
 # - Total-count diff (not SARIF fingerprint diff) because qlty's
 #   fingerprints are not stable across line shifts.
 
@@ -39,6 +39,10 @@ SCRIPT_NAME=$(basename "$0")
 TMP_DIR=""
 BASE_WORKTREE=""
 HEAD_WORKTREE=""
+QLTY_BIN=""
+QLTY_VERSION=""
+UNKNOWN_VALUE="unknown"
+DIRECT_SCAN_MODE="direct-checkout"
 
 cleanup() {
 	if [ -n "$BASE_WORKTREE" ] && [ -d "$BASE_WORKTREE" ]; then
@@ -97,14 +101,16 @@ find_qlty() {
 run_qlty_sarif() {
 	local _dir="$1"
 	local _out="$2"
-	local _qlty_bin
-	_qlty_bin=$(find_qlty) || {
-		die "qlty CLI not found (install: https://qlty.sh/install)"
-	}
+	local _mode="${3:-isolated-clone}"
+	local _cache_key=""
+	local _cache_dir=""
+	_cache_key=$(basename "$_out" .sarif)
+	_cache_dir="$TMP_DIR/cache-${_cache_key}"
+	mkdir -p "$_cache_dir"
 	# --all: scan all files; --sarif: JSON output;
 	# --no-snippets: compact; --quiet: suppress progress.
 	# qlty exits non-zero when smells exist — SARIF still written to stdout.
-	(cd "$_dir" && "$_qlty_bin" smells --all --sarif --no-snippets --quiet) \
+	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
 		>"$_out" 2>/dev/null || true
 	if [ ! -s "$_out" ]; then
 		log "ERROR: qlty produced no output for $_dir"
@@ -115,6 +121,65 @@ run_qlty_sarif() {
 		return 1
 	fi
 	return 0
+}
+
+create_scan_clone() {
+	local _destination="$1"
+	local _sha="$2"
+	local _repo_root="$3"
+	git clone --quiet --shared --no-checkout "$_repo_root" "$_destination" || return 1
+	git -C "$_destination" checkout --detach --quiet "$_sha" || return 1
+	return 0
+}
+
+normalized_identities() {
+	local _sarif="$1"
+	jq -r '.runs[0].results[] |
+		[(.ruleId // $unknown),
+		 ([.locations[]?.physicalLocation?.artifactLocation?.uri? | select(. != null)] | sort | join("|"))]
+		| @tsv' --arg unknown "$UNKNOWN_VALUE" "$_sarif" | LC_ALL=C sort
+	return 0
+}
+
+emit_scan_metadata() {
+	local _label="$1"
+	local _dir="$2"
+	local _sarif="$3"
+	local _mode="$4"
+	local _commit=""
+	local _tree=""
+	local _count=""
+	local _rule=""
+	_commit=$(git -C "$_dir" rev-parse HEAD)
+	_tree=$(git -C "$_dir" rev-parse 'HEAD^{tree}')
+	_count=$(count_smells "$_sarif")
+	log "$_label metadata: version=$QLTY_VERSION commit=$_commit tree=$_tree mode=$_mode root=repository-root config=.qlty/qlty.toml total=$_count"
+	log "$_label per-rule counts:"
+	while IFS= read -r _rule; do
+		log "  $_rule"
+	done < <(list_rules "$_sarif")
+	return 0
+}
+
+verify_same_tree_results() {
+	local _base_tree="$1"
+	local _head_tree="$2"
+	local _base_sarif="$3"
+	local _head_sarif="$4"
+	local _base_ids="$TMP_DIR/base.identities"
+	local _head_ids="$TMP_DIR/head.identities"
+	if [ "$_base_tree" != "$_head_tree" ]; then
+		return 0
+	fi
+	normalized_identities "$_base_sarif" >"$_base_ids"
+	normalized_identities "$_head_sarif" >"$_head_ids"
+	if cmp -s "$_base_ids" "$_head_ids"; then
+		log "identical trees produced identical normalized SARIF identities"
+		return 0
+	fi
+	log "ERROR: identical tree $_head_tree produced different normalized SARIF identities"
+	diff -u "$_base_ids" "$_head_ids" >&2 || true
+	return 1
 }
 
 # count_smells <sarif-file>
@@ -138,8 +203,8 @@ list_rules() {
 # list_files <sarif-file> — prints "<count>\t<file>" sorted desc.
 list_files() {
 	local _sarif="$1"
-	jq -r '.runs[0].results
-		| map(.locations[0].physicalLocation.artifactLocation.uri // "unknown")
+	jq -r --arg unknown "$UNKNOWN_VALUE" '.runs[0].results
+		| map(.locations[0].physicalLocation.artifactLocation.uri // $unknown)
 		| group_by(.)
 		| map({file: .[0], count: length})
 		| sort_by(-.count)
@@ -172,9 +237,9 @@ delta_rules() {
 delta_files() {
 	local _base="$1"
 	local _head="$2"
-	jq -rn --slurpfile b "$_base" --slurpfile h "$_head" '
+	jq -rn --arg unknown "$UNKNOWN_VALUE" --slurpfile b "$_base" --slurpfile h "$_head" '
 		def counts(s): s[0].runs[0].results
-			| map(.locations[0].physicalLocation.artifactLocation.uri // "unknown")
+			| map(.locations[0].physicalLocation.artifactLocation.uri // $unknown)
 			| group_by(.)
 			| map({key: .[0], value: length})
 			| from_entries;
@@ -307,9 +372,12 @@ done
 
 if [ "$DRY_RUN" -eq 1 ]; then
 	TMP_DIR=$(mktemp -d)
+	QLTY_BIN=$(find_qlty) || die "qlty CLI not found"
+	QLTY_VERSION=$("$QLTY_BIN" --version 2>/dev/null) || QLTY_VERSION="$UNKNOWN_VALUE"
 	_head_sarif="$TMP_DIR/head.sarif"
 	log "dry-run: scanning current tree"
-	run_qlty_sarif "." "$_head_sarif"
+	run_qlty_sarif "." "$_head_sarif" "$DIRECT_SCAN_MODE"
+	emit_scan_metadata "head" "." "$_head_sarif" "$DIRECT_SCAN_MODE"
 	_count=$(count_smells "$_head_sarif")
 	printf 'Total smells: %s\n' "$_count"
 	if [ -n "$SARIF_HEAD" ]; then
@@ -331,16 +399,24 @@ fi
 
 BASE_SHA=$(git rev-parse "$BASE")
 HEAD_SHA=$(git rev-parse "$HEAD")
+BASE_TREE=$(git rev-parse "$BASE^{tree}")
+HEAD_TREE=$(git rev-parse "$HEAD^{tree}")
+REPO_ROOT=$(git rev-parse --show-toplevel)
+QLTY_BIN=$(find_qlty) || die "qlty CLI not found"
+QLTY_VERSION=$("$QLTY_BIN" --version 2>/dev/null) || QLTY_VERSION="$UNKNOWN_VALUE"
+if [ -n "${QLTY_CLI_VERSION:-}" ] && [[ "$QLTY_VERSION" != *" ${QLTY_CLI_VERSION}"* ]]; then
+	die "Qlty CLI version mismatch: expected ${QLTY_CLI_VERSION}, resolved $QLTY_VERSION"
+fi
 
 TMP_DIR=$(mktemp -d)
 _base_sarif="$TMP_DIR/base.sarif"
 _head_sarif="$TMP_DIR/head.sarif"
 
-# Scan base in an isolated worktree so we do not disturb the primary tree.
+# Scan base in a standalone clone so qlty observes a normal .git directory.
 BASE_WORKTREE="$TMP_DIR/base-worktree"
-log "creating base worktree at $BASE_SHA"
-if ! git worktree add --detach --force "$BASE_WORKTREE" "$BASE_SHA" >/dev/null 2>&1; then
-	die "failed to create base worktree for $BASE_SHA"
+log "creating base scan clone at $BASE_SHA"
+if ! create_scan_clone "$BASE_WORKTREE" "$BASE_SHA" "$REPO_ROOT"; then
+	die "failed to create base scan clone for $BASE_SHA"
 fi
 
 log "scanning base ($BASE_SHA)"
@@ -350,21 +426,38 @@ if ! run_qlty_sarif "$BASE_WORKTREE" "$_base_sarif"; then
 	BASE_SCAN_FAILED=1
 else
 	BASE_SCAN_FAILED=0
+	emit_scan_metadata "base" "$BASE_WORKTREE" "$_base_sarif" "isolated-clone"
 fi
 
-# Scan head in its own isolated worktree so the result is always the
-# ref at HEAD_SHA, not whatever happens to be in the working tree.
-HEAD_WORKTREE="$TMP_DIR/head-worktree"
-log "creating head worktree at $HEAD_SHA"
-if ! git worktree add --detach --force "$HEAD_WORKTREE" "$HEAD_SHA" >/dev/null 2>&1; then
-	die "failed to create head worktree for $HEAD_SHA"
+# Prefer the authoritative direct checkout when it has the requested tree.
+# GitHub's synthetic merge commit and PR head can have different commits but
+# the same tree; scanning the direct checkout preserves absolute-gate parity.
+CURRENT_TREE=$(git rev-parse 'HEAD^{tree}')
+WORKTREE_STATUS=$(git status --porcelain --untracked-files=normal)
+if [ "$CURRENT_TREE" = "$HEAD_TREE" ] && [ -z "$WORKTREE_STATUS" ]; then
+	HEAD_SCAN_DIR="$REPO_ROOT"
+	HEAD_SCAN_MODE="$DIRECT_SCAN_MODE"
+else
+	HEAD_WORKTREE="$TMP_DIR/head-worktree"
+	HEAD_SCAN_DIR="$HEAD_WORKTREE"
+	HEAD_SCAN_MODE="isolated-clone"
+	log "creating head scan clone at $HEAD_SHA"
+	if ! create_scan_clone "$HEAD_WORKTREE" "$HEAD_SHA" "$REPO_ROOT"; then
+		die "failed to create head scan clone for $HEAD_SHA"
+	fi
 fi
 
 log "scanning head ($HEAD_SHA)"
-run_qlty_sarif "$HEAD_WORKTREE" "$_head_sarif"
+run_qlty_sarif "$HEAD_SCAN_DIR" "$_head_sarif" "$HEAD_SCAN_MODE"
+emit_scan_metadata "head" "$HEAD_SCAN_DIR" "$_head_sarif" "$HEAD_SCAN_MODE"
 
 if [ "$BASE_SCAN_FAILED" -eq 1 ]; then
 	cp "$_head_sarif" "$_base_sarif"
+fi
+
+IDENTITY_MISMATCH=0
+if [ "$BASE_SCAN_FAILED" -eq 0 ] && ! verify_same_tree_results "$BASE_TREE" "$HEAD_TREE" "$_base_sarif" "$_head_sarif"; then
+	IDENTITY_MISMATCH=1
 fi
 
 BASE_COUNT=$(count_smells "$_base_sarif")
@@ -385,6 +478,11 @@ if [ -n "$OUTPUT_MD" ]; then
 		"$_base_sarif" "$_head_sarif" \
 		"$BASE_SHA" "$HEAD_SHA" "$OUTPUT_MD"
 	log "report written to $OUTPUT_MD"
+fi
+
+if [ "$IDENTITY_MISMATCH" -eq 1 ]; then
+	log "REGRESSION: normalized SARIF differs for identical trees"
+	exit 1
 fi
 
 if [ "$DELTA" -gt 0 ] && [ "$ALLOW_INCREASE" -eq 0 ]; then

--- a/.agents/scripts/qlty-regression-helper.sh
+++ b/.agents/scripts/qlty-regression-helper.sh
@@ -448,7 +448,9 @@ else
 fi
 
 log "scanning head ($HEAD_SHA)"
-run_qlty_sarif "$HEAD_SCAN_DIR" "$_head_sarif" "$HEAD_SCAN_MODE"
+if ! run_qlty_sarif "$HEAD_SCAN_DIR" "$_head_sarif" "$HEAD_SCAN_MODE"; then
+	die "failed to scan head ($HEAD_SHA)"
+fi
 emit_scan_metadata "head" "$HEAD_SCAN_DIR" "$_head_sarif" "$HEAD_SCAN_MODE"
 
 if [ "$BASE_SCAN_FAILED" -eq 1 ]; then

--- a/.agents/scripts/qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/qlty-smell-threshold-helper.sh
@@ -7,6 +7,7 @@
 set -u
 
 SCRIPT_NAME=$(basename "$0")
+UNKNOWN_VALUE="unknown"
 
 log() {
 	local _msg="$1"
@@ -26,15 +27,59 @@ find_qlty() {
 	return 1
 }
 
+qlty_version() {
+	local _qlty_bin="$1"
+	local _version=""
+	_version=$("$_qlty_bin" --version 2>/dev/null) || _version="$UNKNOWN_VALUE"
+	printf '%s\n' "$_version"
+	return 0
+}
+
+verify_qlty_version() {
+	local _version="$1"
+	local _expected="${QLTY_CLI_VERSION:-}"
+	if [ -n "$_expected" ] && [[ "$_version" != *" $_expected"* ]]; then
+		printf '::error::Qlty CLI version mismatch: expected %s, resolved %s\n' "$_expected" "$_version"
+		return 1
+	fi
+	return 0
+}
+
+emit_valid_scan_metadata() {
+	local _qlty_version="$1"
+	local _sarif="$2"
+	local _commit="$UNKNOWN_VALUE"
+	local _tree="$UNKNOWN_VALUE"
+	local _config="none"
+	local _mode="${QLTY_SCAN_MODE:-direct-checkout}"
+	local _count="0"
+	_commit=$(git rev-parse HEAD 2>/dev/null) || _commit="$UNKNOWN_VALUE"
+	_tree=$(git rev-parse 'HEAD^{tree}' 2>/dev/null) || _tree="$UNKNOWN_VALUE"
+	if [ -f .qlty/qlty.toml ]; then
+		_config=".qlty/qlty.toml"
+	fi
+	_count=$(printf '%s\n' "$_sarif" | jq '.runs[0].results | length')
+	printf 'Qlty version: %s\n' "$_qlty_version"
+	printf 'Scan commit: %s\n' "$_commit"
+	printf 'Scan tree: %s\n' "$_tree"
+	printf 'Scan mode: %s\n' "$_mode"
+	printf 'Scan root: repository-root\n'
+	printf 'Qlty config: %s\n' "$_config"
+	printf 'Normalized result count: %s\n' "$_count"
+	printf 'Normalized per-rule counts:\n'
+	printf '%s\n' "$_sarif" | jq -r '[.runs[0].results[]?.ruleId? | select(. != null)] | group_by(.) | map({rule: .[0], count: length}) | sort_by(.rule) | .[] | "  \(.count)\t\(.rule)"'
+	return 0
+}
+
 is_non_negative_integer() {
 	local _value="$1"
 	case "$_value" in
-		'' | *[!0-9]*)
-			return 1
-			;;
-		*)
-			return 0
-			;;
+	'' | *[!0-9]*)
+		return 1
+		;;
+	*)
+		return 0
+		;;
 	esac
 	return 1
 }
@@ -127,6 +172,7 @@ run_threshold_check() {
 	local _count=""
 	local _headroom=""
 	local _qlty_rc="0"
+	local _qlty_version=""
 
 	_threshold=$(read_threshold "$_conf")
 	if [ "$_threshold" -eq 0 ]; then
@@ -138,6 +184,8 @@ run_threshold_check() {
 		printf '::error::qlty CLI not found\n'
 		return 1
 	}
+	_qlty_version=$(qlty_version "$_qlty_bin")
+	verify_qlty_version "$_qlty_version" || return 1
 
 	printf 'Counting total qlty smells across all files...\n'
 	_diag_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-threshold.XXXXXX") || return 1
@@ -160,6 +208,7 @@ run_threshold_check() {
 		printf '::error::Failed to parse smell count from SARIF output\n'
 		return 1
 	fi
+	emit_valid_scan_metadata "$_qlty_version" "$_sarif"
 
 	printf '\n'
 	printf 'Total qlty smells: %s\n' "$_count"

--- a/.agents/scripts/tests/test-qlty-regression-helper.sh
+++ b/.agents/scripts/tests/test-qlty-regression-helper.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for deterministic direct/isolated Qlty scans (GH#28162).
+
+set -u
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_rc() {
+	local _label="$1"
+	local _expected="$2"
+	local _actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [ "$_expected" = "$_actual" ]; then
+		printf 'PASS: %s\n' "$_label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf 'FAIL: %s (expected %s, got %s)\n' "$_label" "$_expected" "$_actual"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local _label="$1"
+	local _needle="$2"
+	local _haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$_haystack" == *"$_needle"* ]]; then
+		printf 'PASS: %s\n' "$_label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf 'FAIL: %s (missing %s)\n' "$_label" "$_needle"
+	fi
+	return 0
+}
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+HELPER="$SCRIPT_DIR/qlty-regression-helper.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/qlty-regression-test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+REPO="$TMP_ROOT/repo"
+BIN_DIR="$TMP_ROOT/bin"
+mkdir -p "$REPO" "$BIN_DIR"
+
+cat >"$BIN_DIR/qlty" <<'STUB'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = "--version" ]; then
+	printf 'qlty 0.635.0 linux-x64\n'
+	exit 0
+fi
+if [ "${QLTY_STUB_MODE:-parity}" = "base-fail" ] && [ "$(basename "$PWD")" = "base-worktree" ]; then
+	printf 'simulated base failure\n' >&2
+	exit 2
+fi
+if [ "${QLTY_STUB_MODE:-parity}" = "mismatch" ] && [ "$(basename "$PWD")" = "repo" ]; then
+	printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.sh"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"b.sh"}}}]}]}]}'
+	exit 0
+fi
+printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.sh"}}}]}]}]}'
+exit 0
+STUB
+chmod +x "$BIN_DIR/qlty"
+ln -s /usr/bin/git "$BIN_DIR/git"
+
+/usr/bin/git -C "$REPO" init --quiet
+/usr/bin/git -C "$REPO" config user.name "Qlty Test"
+/usr/bin/git -C "$REPO" config user.email "qlty-test@example.invalid"
+printf 'sample\n' >"$REPO/a.sh"
+/usr/bin/git -C "$REPO" add a.sh
+/usr/bin/git -C "$REPO" commit --quiet -m "fixture"
+
+PATH="$BIN_DIR:$PATH"
+export PATH
+
+QLTY_STUB_MODE=parity
+export QLTY_STUB_MODE
+parity_output=$(cd "$REPO" && "$HELPER" --base HEAD --head HEAD 2>&1)
+parity_rc=$?
+assert_rc "same tree passes with direct and standalone-clone scans" "0" "$parity_rc"
+assert_contains "base metadata identifies isolated clone" "mode=isolated-clone" "$parity_output"
+assert_contains "head metadata identifies direct checkout" "mode=direct-checkout" "$parity_output"
+assert_contains "same-tree identity parity is explicit" "identical normalized SARIF identities" "$parity_output"
+assert_contains "resolved Qlty version is logged" "version=qlty 0.635.0 linux-x64" "$parity_output"
+assert_contains "per-rule counts are logged" $'1\tqlty:similar-code' "$parity_output"
+
+QLTY_STUB_MODE=mismatch
+export QLTY_STUB_MODE
+mismatch_output=$(cd "$REPO" && "$HELPER" --base HEAD --head HEAD 2>&1)
+mismatch_rc=$?
+assert_rc "same-tree normalized mismatch blocks" "1" "$mismatch_rc"
+assert_contains "mismatch includes tree evidence" "produced different normalized SARIF identities" "$mismatch_output"
+assert_contains "mismatch includes normalized URI difference" $'+qlty:similar-code\tb.sh' "$mismatch_output"
+
+QLTY_STUB_MODE=base-fail
+export QLTY_STUB_MODE
+fallback_output=$(cd "$REPO" && "$HELPER" --base HEAD --head HEAD 2>&1)
+fallback_rc=$?
+assert_rc "base scan failure retains diagnostic fallback" "0" "$fallback_rc"
+assert_contains "base failure fallback is logged" "base scan failed; treating base count as equal to head" "$fallback_output"
+
+if [ "$TESTS_FAILED" -eq 0 ]; then
+	printf 'All %s tests passed\n' "$TESTS_RUN"
+	exit 0
+fi
+printf '%s of %s tests failed\n' "$TESTS_FAILED" "$TESTS_RUN"
+exit 1

--- a/.agents/scripts/tests/test-qlty-regression-helper.sh
+++ b/.agents/scripts/tests/test-qlty-regression-helper.sh
@@ -37,6 +37,18 @@ assert_contains() {
 	return 0
 }
 
+resolve_git() {
+	local _candidate=""
+	while IFS= read -r _candidate; do
+		case "$_candidate" in
+		*/.aidevops/*/agents/scripts/git | */.aidevops/bin/git | */.agents/scripts/git) continue ;;
+		esac
+		printf '%s\n' "$_candidate"
+		return 0
+	done < <(type -a -p git 2>/dev/null || true)
+	return 1
+}
+
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 HELPER="$SCRIPT_DIR/qlty-regression-helper.sh"
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/qlty-regression-test.XXXXXX")
@@ -60,18 +72,31 @@ if [ "${QLTY_STUB_MODE:-parity}" = "mismatch" ] && [ "$(basename "$PWD")" = "rep
 	printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.sh"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"b.sh"}}}]}]}]}'
 	exit 0
 fi
+if [ "${QLTY_STUB_MODE:-parity}" = "head-fail" ] && [ "$(basename "$PWD")" = "repo" ]; then
+	printf 'simulated head failure\n' >&2
+	exit 2
+fi
 printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.sh"}}}]}]}]}'
 exit 0
 STUB
 chmod +x "$BIN_DIR/qlty"
-ln -s /usr/bin/git "$BIN_DIR/git"
+GIT_PATH=$(resolve_git || true)
+if [ -z "$GIT_PATH" ]; then
+	printf 'git not found\n' >&2
+	exit 1
+fi
+ln -s "$GIT_PATH" "$BIN_DIR/git"
 
-/usr/bin/git -C "$REPO" init --quiet
-/usr/bin/git -C "$REPO" config user.name "Qlty Test"
-/usr/bin/git -C "$REPO" config user.email "qlty-test@example.invalid"
-printf 'sample\n' >"$REPO/a.sh"
-/usr/bin/git -C "$REPO" add a.sh
-/usr/bin/git -C "$REPO" commit --quiet -m "fixture"
+(
+	cd "$REPO" || exit 1
+	"$GIT_PATH" init --quiet
+	"$GIT_PATH" config user.name "Qlty Test"
+	"$GIT_PATH" config user.email "qlty-test@example.invalid"
+	"$GIT_PATH" config commit.gpgsign false
+	printf 'sample\n' >a.sh
+	"$GIT_PATH" add a.sh
+	"$GIT_PATH" commit --quiet -m "fixture"
+) || exit 1
 
 PATH="$BIN_DIR:$PATH"
 export PATH
@@ -94,6 +119,13 @@ mismatch_rc=$?
 assert_rc "same-tree normalized mismatch blocks" "1" "$mismatch_rc"
 assert_contains "mismatch includes tree evidence" "produced different normalized SARIF identities" "$mismatch_output"
 assert_contains "mismatch includes normalized URI difference" $'+qlty:similar-code\tb.sh' "$mismatch_output"
+
+QLTY_STUB_MODE=head-fail
+export QLTY_STUB_MODE
+head_failure_output=$(cd "$REPO" && "$HELPER" --base HEAD --head HEAD 2>&1)
+head_failure_rc=$?
+assert_rc "head scan failure stops before SARIF parsing" "2" "$head_failure_rc"
+assert_contains "head scan failure identifies the failed ref" "failed to scan head" "$head_failure_output"
 
 QLTY_STUB_MODE=base-fail
 export QLTY_STUB_MODE

--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -169,6 +169,11 @@ pass_output=$("$HELPER" "$CONF" 2>&1)
 pass_rc=$?
 assert_rc "valid SARIF below threshold passes" "0" "$pass_rc"
 assert_contains "valid SARIF reports headroom" "Within threshold" "$pass_output"
+assert_contains "valid SARIF reports qlty version" "Qlty version: qlty test-stub" "$pass_output"
+assert_contains "valid SARIF reports scan mode" "Scan mode: direct-checkout" "$pass_output"
+assert_contains "valid SARIF reports logical root" "Scan root: repository-root" "$pass_output"
+assert_contains "valid SARIF reports normalized count" "Normalized result count: 1" "$pass_output"
+assert_contains "valid SARIF reports per-rule counts" $'  1\tfile-complexity' "$pass_output"
 
 write_stub_qlty fail "$BIN_DIR"
 fail_output=$("$HELPER" "$CONF" 2>&1)

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -844,6 +844,8 @@ jobs:
   qlty-smell-threshold:
     name: Qlty Smell Threshold
     runs-on: ubuntu-latest
+    env:
+      QLTY_CLI_VERSION: "0.635.0"
 
     steps:
     - name: Checkout code

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -99,6 +99,8 @@ jobs:
   qlty-diff:
     name: Qlty Smell Regression
     runs-on: ubuntu-latest
+    env:
+      QLTY_CLI_VERSION: "0.635.0"
     needs: detect-scope
     if: needs.detect-scope.outputs.should_scan == 'true'
     steps:


### PR DESCRIPTION
## Summary

Use standalone scan clones with normal .git directories, prefer the authoritative clean direct checkout for identical head trees, isolate scan caches, compare normalized SARIF identities for same-tree scans, and log/pin Qlty scan metadata.

## Files Changed

.agents/scripts/qlty-regression-helper.sh, .agents/scripts/qlty-smell-threshold-helper.sh, .agents/scripts/tests/test-qlty-regression-helper.sh, .agents/scripts/tests/test-qlty-smell-threshold-helper.sh, .github/workflows/code-quality.yml, .github/workflows/qlty-regression.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; bash .agents/scripts/tests/test-qlty-regression-helper.sh; shellcheck on both helpers and tests; .agents/scripts/linters-local.sh --changed

Resolves #28162


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 11m and 128,784 tokens on this as a headless worker.