### PR TITLE
GH#28164: restore pulse merge throughput

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -43,10 +43,13 @@ _pmrc_snapshot_checks_json() {
 	runs_pages=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/check-runs?per_page=100" \
 		--paginate --slurp 2>/dev/null) || return 1
 	statuses_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/status" 2>/dev/null) || return 1
-	checks_json=$(jq -n --argjson pages "$runs_pages" --argjson statuses "$statuses_json" \
+	# Stream API documents over stdin instead of passing large check-run payloads
+	# through --argjson, which can exceed the OS per-argument limit (GH#28164).
+	checks_json=$(printf '%s\n%s\n' "$runs_pages" "$statuses_json" | jq -s \
 		--arg completed "$PMRC_CHECK_COMPLETED" --arg success "$PMRC_CHECK_SUCCESS" --arg failure "$PMRC_CHECK_FAILURE" \
 		--arg skipped "skipped" --arg maintainer "$PMRC_MAINTAINER_GATE" --arg maintainer_display "$PMRC_MAINTAINER_GATE_DISPLAY" \
 		--arg maintainer_workflow "$PMRC_MAINTAINER_GATE_WORKFLOW" '
+		.[0] as $pages | .[1] as $statuses |
 		"pending" as $pending | "in_progress" as $in_progress |
 		"error" as $error |
 		[

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -9,6 +9,7 @@ PMRC_CHECK_COMPLETED="completed"
 PMRC_CHECK_SUCCESS="success"
 PMRC_CHECK_FAILURE="failure"
 PMRC_BOOL_TRUE="true"
+PMRC_JSON_ARRAY="array"
 PMRC_MAINTAINER_GATE="maintainer-gate"
 PMRC_MAINTAINER_GATE_DISPLAY="Maintainer Review & Assignee Gate"
 PMRC_MAINTAINER_GATE_WORKFLOW="gate / Maintainer Review & Assignee Gate"
@@ -47,8 +48,12 @@ _pmrc_snapshot_checks_json() {
 	# through --argjson, which can exceed the OS per-argument limit (GH#28164).
 	checks_json=$(printf '%s\n%s\n' "$runs_pages" "$statuses_json" | jq -s \
 		--arg completed "$PMRC_CHECK_COMPLETED" --arg success "$PMRC_CHECK_SUCCESS" --arg failure "$PMRC_CHECK_FAILURE" \
+		--arg array_type "$PMRC_JSON_ARRAY" \
 		--arg skipped "skipped" --arg maintainer "$PMRC_MAINTAINER_GATE" --arg maintainer_display "$PMRC_MAINTAINER_GATE_DISPLAY" \
 		--arg maintainer_workflow "$PMRC_MAINTAINER_GATE_WORKFLOW" '
+		if length != 2 or (.[0] | type) != $array_type or (.[1] | type) != "object"
+		then error("invalid check-runs or commit-status response")
+		else . end |
 		.[0] as $pages | .[1] as $statuses |
 		"pending" as $pending | "in_progress" as $in_progress |
 		"error" as $error |
@@ -166,8 +171,8 @@ _pmrc_review_thread_resolution_required() {
 		echo "[pulse-merge] pre-merge snapshot: effective rules fetch failed for ${repo_slug} branch ${base_branch} — failing closed (GH#28130)" >>"$log_target"
 		return 1
 	}
-	required=$(printf '%s' "$rules_json" | jq -r '
-		if type != "array" then error("effective rules response must be an array")
+	required=$(printf '%s' "$rules_json" | jq -r --arg array_type "$PMRC_JSON_ARRAY" '
+		if type != $array_type then error("effective rules response must be an array")
 		else [
 			.[]?
 			| select(.type == "pull_request")
@@ -316,10 +321,10 @@ _pmrc_configured_advisory_contexts_json() {
 		printf '[]\n'
 		return 0
 	fi
-	contexts=$(jq -c --arg slug "$repo_slug" '
+	contexts=$(jq -c --arg slug "$repo_slug" --arg array_type "$PMRC_JSON_ARRAY" '
 		(first(.initialized_repos[]? | select((.slug | ascii_downcase) == ($slug | ascii_downcase)))
 		| .review_gate.advisory_check_contexts // []) as $contexts
-		| if ($contexts | type) == "array" and all($contexts[]; type == "string" and length > 0)
+		| if ($contexts | type) == $array_type and all($contexts[]; type == "string" and length > 0)
 			then ($contexts | unique)
 			else error("invalid review_gate.advisory_check_contexts") end
 	' "$repos_json" 2>/dev/null) || return 1

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -382,6 +382,51 @@ _gh_run_bounded_function() {
 	return $?
 }
 
+# Successful commands without `gh api --include` cannot carry HTTP cooldown
+# headers. Skip their response bodies so large JSON payloads do not enter the
+# secondary-rate-limit classifier (GH#28164).
+_gh_cooldown_should_inspect_response() {
+	local rc="$1"
+	shift
+	local arg=""
+	[[ "$rc" != "0" ]] && return 0
+	for arg in "$@"; do
+		case "$arg" in
+		-i | --include) return 0 ;;
+		esac
+	done
+	return 1
+}
+
+# Bound response evidence before passing it through shell classifiers. GitHub
+# rate-limit headers and error messages occur at the start of their streams.
+_gh_cooldown_response_excerpt() {
+	local out_file="$1"
+	local err_file="$2"
+	local max_bytes=65536
+	if [[ -f "$out_file" ]]; then
+		dd if="$out_file" "bs=${max_bytes}" count=1 2>/dev/null || true
+	fi
+	printf '\n'
+	if [[ -f "$err_file" ]]; then
+		dd if="$err_file" "bs=${max_bytes}" count=1 2>/dev/null || true
+	fi
+	return 0
+}
+
+_gh_record_cooldown_response_if_needed() {
+	local rc="$1"
+	local out_file="$2"
+	local err_file="$3"
+	shift 3
+	local response_text=""
+	command -v _gh_secondary_cooldown_record_if_needed >/dev/null 2>&1 || return 0
+	_gh_cooldown_should_inspect_response "$rc" "$@" || return 0
+	response_text=$(_gh_cooldown_response_excerpt "$out_file" "$err_file") || response_text=""
+	_gh_secondary_cooldown_record_if_needed "$rc" "$response_text" "$_GH_COOLDOWN_CONTEXT_METHOD" "$_GH_COOLDOWN_CONTEXT_ENDPOINT" "$_GH_COOLDOWN_CONTEXT_QUERY_SHAPE" "$_GH_COOLDOWN_CONTEXT_OPERATION" "$_GH_COOLDOWN_CONTEXT_WRAPPER" "$_GH_COOLDOWN_CONTEXT_STAGE"
+	return 0
+}
+
 _gh_with_timeout() {
 	local op_class="${1:-read}"
 	shift
@@ -406,7 +451,6 @@ _gh_with_timeout() {
 	local cmd="${1:-}"
 	local err_file=""
 	local out_file=""
-	local response_text=""
 	local rc=0
 	if [[ -n "$cmd" ]] && declare -f "$cmd" >/dev/null; then
 		err_file=$(mktemp -t aidevops-gh-secondary.XXXXXX) || {
@@ -428,11 +472,7 @@ _gh_with_timeout() {
 		rc=$?
 		cat "$out_file" 2>/dev/null || true
 		cat "$err_file" >&2 2>/dev/null || true
-		if command -v _gh_secondary_cooldown_record_if_needed >/dev/null 2>&1; then
-			response_text="$(cat "$out_file" 2>/dev/null || true)
-$(cat "$err_file" 2>/dev/null || true)"
-			_gh_secondary_cooldown_record_if_needed "$rc" "$response_text" "$_GH_COOLDOWN_CONTEXT_METHOD" "$_GH_COOLDOWN_CONTEXT_ENDPOINT" "$_GH_COOLDOWN_CONTEXT_QUERY_SHAPE" "$_GH_COOLDOWN_CONTEXT_OPERATION" "$_GH_COOLDOWN_CONTEXT_WRAPPER" "$_GH_COOLDOWN_CONTEXT_STAGE"
-		fi
+		_gh_record_cooldown_response_if_needed "$rc" "$out_file" "$err_file" "$@"
 		rm -f "$err_file" "$out_file"
 		return $rc
 	fi
@@ -454,11 +494,7 @@ $(cat "$err_file" 2>/dev/null || true)"
 	if [[ -n "$err_file" && -n "$out_file" ]]; then
 		cat "$out_file" 2>/dev/null || true
 		cat "$err_file" >&2 2>/dev/null || true
-		if command -v _gh_secondary_cooldown_record_if_needed >/dev/null 2>&1; then
-			response_text="$(cat "$out_file" 2>/dev/null || true)
-$(cat "$err_file" 2>/dev/null || true)"
-			_gh_secondary_cooldown_record_if_needed "$rc" "$response_text" "$_GH_COOLDOWN_CONTEXT_METHOD" "$_GH_COOLDOWN_CONTEXT_ENDPOINT" "$_GH_COOLDOWN_CONTEXT_QUERY_SHAPE" "$_GH_COOLDOWN_CONTEXT_OPERATION" "$_GH_COOLDOWN_CONTEXT_WRAPPER" "$_GH_COOLDOWN_CONTEXT_STAGE"
-		fi
+		_gh_record_cooldown_response_if_needed "$rc" "$out_file" "$err_file" "$@"
 		rm -f "$err_file" "$out_file"
 	fi
 	return $rc

--- a/.agents/scripts/tests/test-gh-secondary-cooldown.sh
+++ b/.agents/scripts/tests/test-gh-secondary-cooldown.sh
@@ -72,6 +72,16 @@ gh() {
 		printf 'HTTP/2 200\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 9999999999\r\nX-RateLimit-Resource: graphql\r\nX-GitHub-Request-Id: REQ-PRIMARY\r\n\r\n{"message":"GraphQL: API rate limit already exceeded"}\n'
 		return 1
 	fi
+	if [[ "${GH_PRIMARY_REMAINING_ZERO_SUCCESS:-0}" == "1" ]]; then
+		printf 'HTTP/2 200\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 9999999999\r\nX-RateLimit-Resource: graphql\r\nX-GitHub-Request-Id: REQ-PRIMARY-SUCCESS\r\n\r\n{"ok":true}\n'
+		return 0
+	fi
+	if [[ "${GH_LARGE_SUCCESS:-0}" == "1" ]]; then
+		printf '{"payload":"'
+		dd if=/dev/zero bs=1024 count=512 2>/dev/null | tr '\000' x
+		printf '"}\n'
+		return 0
+	fi
 	printf '{"ok":true}\n'
 	return 0
 }
@@ -85,7 +95,7 @@ reset_case() {
 	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE"
 	rm -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE"
 	rm -f "$AIDEVOPS_GH_READ_RAMP_STATE_FILE"
-	unset GH_SECONDARY_FAIL GH_REST_CORE_403_FAIL GH_CORE_RATE_LIMIT_RESET GH_SEARCH_RATE_LIMIT_RESET GH_HEADER_LIMIT_FAIL GH_GENERIC_403_FAIL GH_ABUSE_403_FAIL GH_PRIMARY_REMAINING_ZERO_FAIL AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_LINES AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_BYTES AIDEVOPS_GH_READ_RAMP_BUDGET AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_OVERRIDE AIDEVOPS_GH_AUTH_MODE AIDEVOPS_GH_AUTH_PRINCIPAL AIDEVOPS_GH_COOLDOWN_OPERATION AIDEVOPS_GH_COOLDOWN_WRAPPER AIDEVOPS_GH_COOLDOWN_STAGE AIDEVOPS_GH_API_POOL AIDEVOPS_GH_ROUTE_DECISION 2>/dev/null || true
+	unset GH_SECONDARY_FAIL GH_REST_CORE_403_FAIL GH_CORE_RATE_LIMIT_RESET GH_SEARCH_RATE_LIMIT_RESET GH_HEADER_LIMIT_FAIL GH_GENERIC_403_FAIL GH_ABUSE_403_FAIL GH_PRIMARY_REMAINING_ZERO_FAIL GH_PRIMARY_REMAINING_ZERO_SUCCESS GH_LARGE_SUCCESS AIDEVOPS_GH_SECONDARY_COOLDOWN_OVERRIDE AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_LINES AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_MAX_BYTES AIDEVOPS_GH_READ_RAMP_BUDGET AIDEVOPS_GH_READ_RAMP_BOOT_SECS AIDEVOPS_GH_READ_RAMP_RECOVERY_SECS AIDEVOPS_GH_READ_RAMP_OVERRIDE AIDEVOPS_GH_AUTH_MODE AIDEVOPS_GH_AUTH_PRINCIPAL AIDEVOPS_GH_COOLDOWN_OPERATION AIDEVOPS_GH_COOLDOWN_WRAPPER AIDEVOPS_GH_COOLDOWN_STAGE AIDEVOPS_GH_API_POOL AIDEVOPS_GH_ROUTE_DECISION 2>/dev/null || true
 	_GH_SECONDARY_COOLDOWN_LOGGED_ACTIVE=0
 	_GH_SECONDARY_COOLDOWN_LOGGED_RAMP=0
 	_gh_secondary_system_boot_ts() { return 1; }
@@ -243,6 +253,39 @@ test_remaining_zero_diagnostic_classifies_primary_quota() {
 		return 0
 	fi
 	printf 'FAIL remaining-zero diagnostic missing or malformed\n'
+	return 1
+}
+
+test_successful_include_preserves_remaining_zero_detection() {
+	reset_case
+	export GH_PRIMARY_REMAINING_ZERO_SUCCESS=1
+	_gh_with_timeout read gh api -i graphql >"${TMP_HOME}/primary-quota-success.out" 2>"$ERR_LOG"
+	local rc=$?
+	if [[ "$rc" -eq 0 ]] && [[ -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]] && \
+		jq -e '.reason == "github-api-rate-limit-remaining-zero" and .last_request_id == "REQ-PRIMARY-SUCCESS" and .diagnostic.http_status == "200"' "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" >/dev/null; then
+		printf 'PASS successful include response preserves remaining-zero detection\n'
+		return 0
+	fi
+	printf 'FAIL successful include response lost remaining-zero detection\n'
+	return 1
+}
+
+test_large_success_response_skips_cooldown_scan() {
+	reset_case
+	export GH_LARGE_SUCCESS=1
+	local output_file="${TMP_HOME}/large-success.out"
+	local rc=0
+	local output_bytes=0
+	set +e
+	_gh_run_bounded_function 5 _gh_with_timeout read gh api repos/owner/repo/check-runs >"$output_file" 2>"$ERR_LOG"
+	rc=$?
+	set -e
+	output_bytes=$(wc -c <"$output_file" | tr -d ' ')
+	if [[ "$rc" -eq 0 && "$output_bytes" -gt 500000 && ! -f "$AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE" ]]; then
+		printf 'PASS large successful response bypasses cooldown body scan\n'
+		return 0
+	fi
+	printf 'FAIL large successful response stalled or created cooldown: rc=%s bytes=%s\n' "$rc" "$output_bytes"
 	return 1
 }
 
@@ -443,6 +486,8 @@ test_rest_core_403_uses_rate_limit_reset_and_skips_next_call
 test_rest_search_403_uses_search_rate_limit_reset
 test_abuse_403_diagnostic_distinguishes_abuse_text
 test_remaining_zero_diagnostic_classifies_primary_quota
+test_successful_include_preserves_remaining_zero_detection
+test_large_success_response_skips_cooldown_scan
 test_active_cooldown_skips_without_gh_call
 test_override_allows_audited_call
 test_default_path_without_home_is_user_scoped

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -103,6 +103,12 @@ gh() {
 		return $?
 		;;
 	*check-runs*)
+		if [[ "$SNAPSHOT_MODE" == "large_payload" ]]; then
+			printf '[{"padding":"'
+			dd if=/dev/zero bs=1024 count=512 2>/dev/null | tr '\000' x
+			printf '","check_runs":[{"name":"required-a","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:00Z"}]}]\n'
+			return 0
+		fi
 		local required_conclusion="success" required_url="" broad_status="completed" broad_conclusion="success"
 		local broad_completed_at="2026-01-01T00:01:00Z" extra_check=""
 		[[ "$SNAPSHOT_MODE" == "required_fail" ]] && required_conclusion="failure"
@@ -253,6 +259,7 @@ assert_infrastructure_rerun_unset_logfile_safe() {
 main() {
 	assert_infrastructure_rerun_unset_defaults_safe
 	assert_infrastructure_rerun_unset_logfile_safe
+	assert_gate "large paginated check payload streams without argument overflow" large_payload 0
 	assert_gate "terminal checks with explicit baseline advisory pass" happy_advisory 0
 	if grep -q "IGNORED non-required baseline advisory failure 'Qlty Smell Threshold'" "$LOGFILE"; then
 		printf 'PASS ignored advisory failure is audited\n'

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -109,6 +109,7 @@ gh() {
 			printf '","check_runs":[{"name":"required-a","status":"completed","conclusion":"success","completed_at":"2026-01-01T00:01:00Z"}]}]\n'
 			return 0
 		fi
+		[[ "$SNAPSHOT_MODE" == "empty_check_runs" ]] && return 0
 		local required_conclusion="success" required_url="" broad_status="completed" broad_conclusion="success"
 		local broad_completed_at="2026-01-01T00:01:00Z" extra_check=""
 		[[ "$SNAPSHOT_MODE" == "required_fail" ]] && required_conclusion="failure"
@@ -260,6 +261,7 @@ main() {
 	assert_infrastructure_rerun_unset_defaults_safe
 	assert_infrastructure_rerun_unset_logfile_safe
 	assert_gate "large paginated check payload streams without argument overflow" large_payload 0
+	assert_gate "empty check-run response fails closed" empty_check_runs 1
 	assert_gate "terminal checks with explicit baseline advisory pass" happy_advisory 0
 	if grep -q "IGNORED non-required baseline advisory failure 'Qlty Smell Threshold'" "$LOGFILE"; then
 		printf 'PASS ignored advisory failure is audited\n'


### PR DESCRIPTION
## Summary

Prevent successful large GitHub API payloads from entering cooldown body classification, cap inspected failure/header evidence, and stream check-run JSON into jq without OS argument overflow.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/shared-gh-wrappers.sh, .agents/scripts/tests/test-gh-secondary-cooldown.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck clean; 19 cooldown tests pass; 42 preflight snapshot tests pass; live 451KB check-run snapshot completes in 2.47s instead of stalling.

Resolves #28164


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 27m and 552,470 tokens on this as a headless worker.