### PR TITLE
GH#28176: fix: harden autoagent metric fallbacks

### DIFF
--- a/.agents/scripts/autoagent-metric-helper.sh
+++ b/.agents/scripts/autoagent-metric-helper.sh
@@ -306,8 +306,8 @@ cmd_lint() {
 	local sh_files=""
 	local md_files=""
 	if [[ -n "$candidate_files" ]]; then
-		sh_files=$(grep -E '^\.agents/scripts/.*\.sh$' <<<"$candidate_files") || sh_files=""
-		md_files=$(grep -E '^\.agents/.*\.md$' <<<"$candidate_files") || md_files=""
+		sh_files=$(grep -E '^\.agents/scripts/.*\.sh$' <<<"$candidate_files" || true)
+		md_files=$(grep -E '^\.agents/.*\.md$' <<<"$candidate_files" || true)
 	else
 		sh_files=$(git ls-files '.agents/scripts/*.sh' 2>/dev/null | head -20) || sh_files=""
 		md_files=$(git ls-files '.agents/**/*.md' 2>/dev/null | head -20) || md_files=""
@@ -387,10 +387,12 @@ _token_ratio_from_json() {
 		return 0
 	fi
 
-	local current_chars
-	current_chars=$(jq -r '.avg_response_chars // 0' 2>/dev/null <<<"$suite_json") || current_chars="0"
+	local current_chars=""
+	if [[ -n "$suite_json" ]]; then
+		current_chars=$(jq -r '.avg_response_chars // ""' <<<"$suite_json") || current_chars=""
+	fi
 
-	if [[ -z "$current_chars" || "$current_chars" == "0" || "$current_chars" == "null" ]]; then
+	if [[ -z "$current_chars" || "$current_chars" == "0" ]]; then
 		log_warn "Could not measure current avg_response_chars — returning neutral"
 		printf '%s\n' "1.0"
 		return 0

--- a/.agents/scripts/tests/test-autoagent-metric-helper.sh
+++ b/.agents/scripts/tests/test-autoagent-metric-helper.sh
@@ -250,6 +250,13 @@ else
 	fail "candidate lint selection is incorrect"
 	TESTS_RUN=$((TESTS_RUN + 1))
 fi
+
+printf '%s\n' '.agents/docs/new.md' >"$GIT_CHANGED_FILE"
+: >"$GIT_UNTRACKED_FILE"
+: >"$LINT_LOG_FILE"
+run_metric lint
+assert_success "lint tolerates a candidate set without shell files"
+assert_equals "1" "$(wc -l <"$LINT_LOG_FILE" | tr -d ' ')" "markdown-only candidates run one linter"
 : >"$GIT_CHANGED_FILE"
 : >"$GIT_UNTRACKED_FILE"
 : >"$LINT_LOG_FILE"
@@ -258,6 +265,14 @@ reset_count
 run_metric tokens --suite "$SUITE_FILE" --baseline-file "$BASELINE_FILE"
 assert_equals "1.0000" "$(<"$STDOUT_FILE")" "standalone tokens uses suite result"
 assert_count "1" "standalone tokens invokes suite once"
+
+reset_count
+MOCK_SUITE_JSON='{"pass_rate":1.0}'
+run_metric tokens --suite "$SUITE_FILE" --baseline-file "$BASELINE_FILE"
+assert_success "missing response-character metric degrades gracefully"
+assert_equals "1.0" "$(<"$STDOUT_FILE")" "missing response-character metric returns neutral token ratio"
+
+MOCK_SUITE_JSON='{"pass_rate":0.5,"avg_response_chars":100}'
 
 reset_count
 run_metric tokens --suite "$SUITE_FILE" --baseline-file "$TEST_ROOT/missing-baseline.json"


### PR DESCRIPTION
## Summary

Handle empty lint candidate subsets inside command substitutions and simplify response-character parsing while retaining jq diagnostics. Add regressions for markdown-only lint candidates and missing response-character metrics.

## Files Changed

.agents/scripts/autoagent-metric-helper.sh, .agents/scripts/tests/test-autoagent-metric-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/autoagent-metric-helper.sh .agents/scripts/tests/test-autoagent-metric-helper.sh; bash -n .agents/scripts/autoagent-metric-helper.sh; bash -n .agents/scripts/tests/test-autoagent-metric-helper.sh; bash .agents/scripts/tests/test-autoagent-metric-helper.sh

Resolves #28176


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 17m and 62,725 tokens on this as a headless worker.