### PR TITLE
GH#28175: fix stale worker DB replay locks

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1515,6 +1515,91 @@ _verify_worker_db_merge() {
 }
 
 #######################################
+# Read the owner PID from a worker DB replay lock.
+# Args: $1 = replay lock directory.
+#######################################
+_read_worker_db_replay_lock_pid() {
+	local replay_lock="$1"
+	local locking_pid=""
+	if [[ -f "${replay_lock}/pid" ]]; then
+		IFS= read -r locking_pid 2>/dev/null <"${replay_lock}/pid" || locking_pid=""
+	fi
+	printf '%s' "$locking_pid"
+	return 0
+}
+
+#######################################
+# Acquire a PID-owned replay lock, reclaiming dead or incomplete stale locks.
+# Args: $1 = replay lock directory.
+# Returns: 0 when acquired, 1 when another owner is live or acquisition fails.
+#######################################
+_acquire_worker_db_replay_lock() {
+	local replay_lock="$1"
+	local locking_pid=""
+	local wait_attempt=0
+	local acquire_attempt=0
+
+	while [[ "$acquire_attempt" -lt 2 ]]; do
+		acquire_attempt=$((acquire_attempt + 1))
+		locking_pid=""
+		wait_attempt=0
+		if mkdir "$replay_lock" 2>/dev/null; then
+			if printf '%s\n' "$$" >"${replay_lock}/pid" 2>/dev/null; then
+				return 0
+			fi
+			rm -rf "$replay_lock"
+			return 1
+		fi
+
+		# The owner writes its PID immediately after mkdir. Give that write up to one
+		# second to become visible before treating a PID-less directory as stale.
+		while [[ "$wait_attempt" -lt 10 ]]; do
+			locking_pid=$(_read_worker_db_replay_lock_pid "$replay_lock")
+			[[ -n "$locking_pid" ]] && break
+			wait_attempt=$((wait_attempt + 1))
+			sleep 0.1
+		done
+		if [[ "$locking_pid" =~ ^[0-9]+$ ]] && kill -0 "$locking_pid" 2>/dev/null; then
+			return 1
+		fi
+
+		# Serialize stale cleanup inside the existing directory. If the owner
+		# released it between the liveness check and this mkdir, retry acquisition.
+		if ! mkdir "${replay_lock}/.reclaim" 2>/dev/null; then
+			[[ ! -d "$replay_lock" ]] && continue
+			return 1
+		fi
+		locking_pid=$(_read_worker_db_replay_lock_pid "$replay_lock")
+		if [[ "$locking_pid" =~ ^[0-9]+$ ]] && kill -0 "$locking_pid" 2>/dev/null; then
+			rm -rf "${replay_lock}/.reclaim"
+			return 1
+		fi
+		rm -rf "$replay_lock" || return 1
+		mkdir "$replay_lock" 2>/dev/null || return 1
+		if ! printf '%s\n' "$$" >"${replay_lock}/pid" 2>/dev/null; then
+			rm -rf "$replay_lock"
+			return 1
+		fi
+		return 0
+	done
+	return 1
+}
+
+#######################################
+# Release a worker DB replay lock only when this process still owns it.
+# Args: $1 = replay lock directory.
+#######################################
+_release_worker_db_replay_lock() {
+	local replay_lock="$1"
+	local locking_pid=""
+	locking_pid=$(_read_worker_db_replay_lock_pid "$replay_lock")
+	if [[ "$locking_pid" == "$$" ]]; then
+		rm -rf "$replay_lock"
+	fi
+	return 0
+}
+
+#######################################
 # Replay retained worker DBs. Artifacts are deleted only after graph verification.
 # Returns 0 when every attempted artifact merged or no artifacts exist.
 #######################################
@@ -1524,7 +1609,7 @@ _replay_preserved_worker_dbs() {
 	local replay_lock="${recovery_root}/.replay.lock"
 	local recovery_db recovery_dir replay_dir replay_failed=0
 	[[ -d "$recovery_root" && -f "$shared_db" ]] || return 0
-	mkdir "$replay_lock" 2>/dev/null || return 0
+	_acquire_worker_db_replay_lock "$replay_lock" || return 0
 	for recovery_db in "$recovery_root"/*/opencode.db; do
 		[[ -f "$recovery_db" ]] || continue
 		recovery_dir="${recovery_db%/opencode.db}"
@@ -1544,7 +1629,7 @@ _replay_preserved_worker_dbs() {
 		fi
 		rm -rf "$replay_dir"
 	done
-	rm -rf "$replay_lock"
+	_release_worker_db_replay_lock "$replay_lock"
 	[[ "$replay_failed" -eq 0 ]]
 }
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1857,6 +1857,59 @@ test_replay_preserved_worker_db_verifies_before_deletion() {
 	return 0
 }
 
+test_worker_db_replay_lock_recovers_stale_owner_and_waits_for_pid() {
+	local recovery_root="${TEST_ROOT}/replay-lock-recovery"
+	local replay_lock="${recovery_root}/.replay.lock"
+	local stale_status=0 live_status=0 race_status=0
+	local acquired_pid="" observed_pid="" race_pid=""
+	local lock_holder_pid="" pid_writer_pid=""
+
+	mkdir -p "$replay_lock"
+	printf '%s\n' '99999999' >"${replay_lock}/pid"
+	_acquire_worker_db_replay_lock "$replay_lock" || stale_status=$?
+	acquired_pid=$(_read_worker_db_replay_lock_pid "$replay_lock")
+	_release_worker_db_replay_lock "$replay_lock"
+
+	mkdir -p "$replay_lock"
+	command sleep 5 &
+	lock_holder_pid=$!
+	(
+		command sleep 0.2
+		printf '%s\n' "$lock_holder_pid" >"${replay_lock}/pid"
+	) &
+	pid_writer_pid=$!
+	_acquire_worker_db_replay_lock "$replay_lock" || live_status=$?
+	wait "$pid_writer_pid" 2>/dev/null || true
+	observed_pid=$(_read_worker_db_replay_lock_pid "$replay_lock")
+	kill "$lock_holder_pid" 2>/dev/null || true
+	wait "$lock_holder_pid" 2>/dev/null || true
+	rm -rf "$replay_lock"
+
+	mkdir -p "$replay_lock"
+	printf '%s\n' '99999999' >"${replay_lock}/pid"
+	mkdir() {
+		local mkdir_target="$1"
+		if [[ "$mkdir_target" == "${replay_lock}/.reclaim" ]]; then
+			command rm -rf "$replay_lock"
+			return 1
+		fi
+		command mkdir "$@"
+		return $?
+	}
+	_acquire_worker_db_replay_lock "$replay_lock" || race_status=$?
+	unset -f mkdir
+	race_pid=$(_read_worker_db_replay_lock_pid "$replay_lock")
+	_release_worker_db_replay_lock "$replay_lock"
+
+	if [[ "$stale_status" -eq 0 && "$acquired_pid" == "$$" && "$live_status" -eq 1 && "$observed_pid" == "$lock_holder_pid" && "$race_status" -eq 0 && "$race_pid" == "$$" ]]; then
+		print_result "worker DB replay lock reclaims stale owners, waits for PIDs, and retries owner release races" 0
+		return 0
+	fi
+	print_result "worker DB replay lock reclaims stale owners, waits for PIDs, and retries owner release races" 1 \
+		"stale_status=$stale_status acquired=$acquired_pid live_status=$live_status observed=$observed_pid holder=$lock_holder_pid race_status=$race_status race_pid=$race_pid"
+	return 0
+}
+
 test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table() {
 	local shared_dir="${HOME}/.local/share/opencode"
 	local isolated_dir="${TEST_ROOT}/isolated-opencode-prewarm"
@@ -3650,6 +3703,7 @@ run_worker_db_persistence_tests() {
 	test_merge_worker_db_rejects_missing_required_destination_column
 	test_merge_worker_db_failure_preserves_recovery_db_without_auth
 	test_replay_preserved_worker_db_verifies_before_deletion
+	test_worker_db_replay_lock_recovers_stale_owner_and_waits_for_pid
 	test_sync_worker_db_migration_metadata_repairs_prewarmed_project_table
 	test_sync_worker_db_migration_metadata_replaces_stale_ledgers
 	test_copy_worker_db_migration_ledger_preserves_rows_when_attach_fails


### PR DESCRIPTION
## Summary

Record replay lock owner PIDs, wait for in-flight PID publication, and safely reclaim dead locks

## Files Changed

.agents/scripts/headless-runtime-lib.sh, .agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash syntax and ShellCheck clean; headless runtime replay-lock regression passed

Resolves #28175


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 32m and 139,479 tokens on this as a headless worker.