### PR TITLE
t18126: Preserve empty snapshots and canonicalise cache semantics

### DIFF
--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -113,6 +113,9 @@ _JSON_NULL="null"
 _JSON_EMPTY_OBJ="{}"
 _JSON_EMPTY_ARR="[]"
 _STATE_OPEN="open"
+_CACHE_STATE_MALFORMED="malformed"
+_CACHE_SNAPSHOT_STATE="missing"
+_CACHE_SNAPSHOT_PATH=""
 
 # --- Feature flag gate ---
 _check_enabled() {
@@ -736,6 +739,72 @@ _cmd_refresh() {
 	return 0
 }
 
+# Resolve a cache snapshot to one canonical state without printing payload data.
+# Sets _CACHE_SNAPSHOT_STATE and _CACHE_SNAPSHOT_PATH for Bash 3.2 callers.
+_resolve_cache_snapshot() {
+	local kind="$1"
+	local slug="$2"
+	local cache_file=""
+	local cache_ts=""
+	local cache_epoch=0
+	local now_epoch=0
+	local age=0
+
+	_CACHE_SNAPSHOT_STATE="missing"
+	_CACHE_SNAPSHOT_PATH=""
+	if ! _check_enabled; then
+		_CACHE_SNAPSHOT_STATE="disabled"
+		return 1
+	fi
+
+	cache_file=$(_cache_file_path "$kind" "$slug")
+	_CACHE_SNAPSHOT_PATH="$cache_file"
+	[[ -f "$cache_file" ]] || return 1
+
+	cache_ts=$(jq -er '
+		select((.timestamp | type) == "string" and (.timestamp | length) > 0) |
+		select((.items | type) == "array") |
+		.timestamp
+	' "$cache_file" 2>/dev/null) || {
+		_CACHE_SNAPSHOT_STATE="$_CACHE_STATE_MALFORMED"
+		return 1
+	}
+
+	if [[ "$(uname)" == "Darwin" ]]; then
+		cache_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$cache_ts" "+%s" 2>/dev/null) || cache_epoch=0
+	else
+		cache_epoch=$(date -u -d "$cache_ts" +%s 2>/dev/null) || cache_epoch=0
+	fi
+	now_epoch=$(date -u +%s) || now_epoch=0
+	if [[ "$cache_epoch" -le 0 || "$now_epoch" -le 0 ]]; then
+		_CACHE_SNAPSHOT_STATE="$_CACHE_STATE_MALFORMED"
+		return 1
+	fi
+
+	age=$((now_epoch - cache_epoch))
+	if [[ "$age" -lt 0 ]]; then
+		_CACHE_SNAPSHOT_STATE="$_CACHE_STATE_MALFORMED"
+		return 1
+	fi
+	if [[ "$age" -ge "$PULSE_PREFETCH_FULL_SWEEP_INTERVAL" ]]; then
+		_CACHE_SNAPSHOT_STATE="stale"
+		return 1
+	fi
+
+	_CACHE_SNAPSHOT_STATE="hit"
+	return 0
+}
+
+_emit_cache_state() {
+	local state="$1"
+	local kind="$2"
+	local slug="$3"
+	local cardinality="${4:-unknown}"
+	printf 'cache_state=%s kind=%s slug=%s cardinality=%s\n' \
+		"$state" "$kind" "$slug" "$cardinality" >&2
+	return 0
+}
+
 # =============================================================================
 # Subcommand: cache-path
 # =============================================================================
@@ -764,36 +833,16 @@ _cmd_cache_path() {
 		return 1
 	fi
 
-	_check_enabled || return 1
-
-	local cache_file
-	cache_file=$(_cache_file_path "$kind" "$slug")
-
-	if [[ ! -f "$cache_file" ]]; then
+	case "$kind" in
+	"$_KIND_ISSUES" | "$_KIND_PRS") ;;
+	*)
+		echo "Usage: pulse-batch-prefetch-helper.sh cache-path --kind issues|prs --slug owner/repo" >&2
 		return 1
-	fi
+		;;
+	esac
 
-	# Check freshness — stale cache (past TTL) returns exit 1
-	local cache_ts
-	cache_ts=$(jq -r '.timestamp // ""' "$cache_file" 2>/dev/null) || cache_ts=""
-	if [[ -z "$cache_ts" || "$cache_ts" == "$_JSON_NULL" ]]; then
-		return 1
-	fi
-
-	local cache_epoch=0 now_epoch=0
-	if [[ "$(uname)" == "Darwin" ]]; then
-		cache_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$cache_ts" "+%s" 2>/dev/null) || cache_epoch=0
-	else
-		cache_epoch=$(date -u -d "$cache_ts" +%s 2>/dev/null) || cache_epoch=0
-	fi
-	now_epoch=$(date -u +%s)
-	local age=$((now_epoch - cache_epoch))
-
-	if [[ "$age" -ge "$PULSE_PREFETCH_FULL_SWEEP_INTERVAL" ]]; then
-		return 1  # Cache too old
-	fi
-
-	echo "$cache_file"
+	_resolve_cache_snapshot "$kind" "$slug" || return 1
+	printf '%s\n' "$_CACHE_SNAPSHOT_PATH"
 	return 0
 }
 
@@ -829,19 +878,39 @@ _cmd_read_cache() {
 		return 1
 	fi
 
-	local cache_file
-	cache_file=$(_cmd_cache_path --kind "$kind" --slug "$slug") || return 1
+	case "$kind" in
+	"$_KIND_ISSUES" | "$_KIND_PRS") ;;
+	*)
+		echo "Usage: pulse-batch-prefetch-helper.sh read-cache --kind issues|prs --slug owner/repo" >&2
+		return 1
+		;;
+	esac
 
-	if [[ "$kind" == "$_KIND_ISSUES" ]]; then
-		jq -c --arg state_open "$_STATE_OPEN" '[.items[]? | select(has("state") and ((.state | ascii_downcase) == $state_open))]' "$cache_file" 2>/dev/null || {
-			return 1
-		}
-		return 0
+	if ! _resolve_cache_snapshot "$kind" "$slug"; then
+		_emit_cache_state "$_CACHE_SNAPSHOT_STATE" "$kind" "$slug"
+		return 1
 	fi
 
-	jq -c '.items // []' "$cache_file" 2>/dev/null || {
-		return 1
-	}
+	local items=""
+
+	if [[ "$kind" == "$_KIND_ISSUES" ]]; then
+		items=$(jq -ce --arg state_open "$_STATE_OPEN" '[.items[] | select(has("state") and ((.state | ascii_downcase) == $state_open))]' "$_CACHE_SNAPSHOT_PATH" 2>/dev/null) || {
+			_CACHE_SNAPSHOT_STATE="$_CACHE_STATE_MALFORMED"
+			_emit_cache_state "$_CACHE_SNAPSHOT_STATE" "$kind" "$slug"
+			return 1
+		}
+	else
+		items=$(jq -ce '.items' "$_CACHE_SNAPSHOT_PATH" 2>/dev/null) || {
+			_CACHE_SNAPSHOT_STATE="$_CACHE_STATE_MALFORMED"
+			_emit_cache_state "$_CACHE_SNAPSHOT_STATE" "$kind" "$slug"
+			return 1
+		}
+	fi
+
+	local cardinality="nonempty"
+	[[ "$items" == "$_JSON_EMPTY_ARR" ]] && cardinality="empty"
+	_emit_cache_state "$_CACHE_SNAPSHOT_STATE" "$kind" "$slug" "$cardinality"
+	printf '%s\n' "$items"
 	return 0
 }
 

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -179,6 +179,35 @@ _prefetch_prs_format_output() {
 	return 0
 }
 
+#######################################
+# Record a validated batch-cache hit without counting an HTTP attempt.
+# Arguments: $1=kind, $2=validated JSON-array payload
+#######################################
+_prefetch_record_batch_cache_hit() {
+	local kind="$1"
+	local payload="$2"
+	local decision="hit-nonempty"
+	[[ "$payload" == "[]" ]] && decision="hit-empty"
+	if command -v gh_record_call >/dev/null 2>&1; then
+		gh_record_call other "pulse_batch_prefetch_${kind}_cache" unknown other \
+			"$decision" "" cache 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
+# Log a canonical cache state that occurs after a cache miss.
+# Arguments: $1=state, $2=kind, $3=slug
+#######################################
+_prefetch_log_batch_cache_state() {
+	local state="$1"
+	local kind="$2"
+	local slug="$3"
+	printf '[pulse-wrapper] cache_state=%s kind=%s slug=%s cardinality=unknown\n' \
+		"$state" "$kind" "$slug" >>"$LOGFILE"
+	return 0
+}
+
 _prefetch_repo_prs() {
 	local slug="$1"
 	local cache_entry="${2:-}"
@@ -208,11 +237,11 @@ _prefetch_repo_prs() {
 	local _used_batch_cache=false
 	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
 		local _batch_prs
-		_batch_prs=$("$_batch_helper" read-cache --kind prs --slug "$slug" 2>/dev/null) || _batch_prs=""
-		if [[ -n "$_batch_prs" && "$_batch_prs" != "[]" && "$_batch_prs" != "null" ]]; then
+		if _batch_prs=$("$_batch_helper" read-cache --kind prs --slug "$slug" 2>>"$LOGFILE"); then
 			pr_json="$_batch_prs"
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_prs: using batch cache for ${slug}" >>"$LOGFILE"
+			_prefetch_record_batch_cache_hit prs "$_batch_prs"
 			_PULSE_HEALTH_BATCH_CACHE_HITS=$((_PULSE_HEALTH_BATCH_CACHE_HITS + 1))
 		fi
 	fi
@@ -242,6 +271,7 @@ _prefetch_repo_prs() {
 					_pulse_mark_rate_limited "_prefetch_repo_prs:${slug}"
 				fi
 				echo "[pulse-wrapper] _prefetch_repo_prs: gh_pr_list FAILED for ${slug}: ${err_msg}" >>"$LOGFILE"
+				_prefetch_log_batch_cache_state fetch-failed prs "$slug"
 				pr_json="[]"
 			fi
 		fi
@@ -342,11 +372,11 @@ _prefetch_repo_issues() {
 	local _used_batch_cache=false
 	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
 		local _batch_issues
-		_batch_issues=$("$_batch_helper" read-cache --kind issues --slug "$slug" 2>/dev/null) || _batch_issues=""
-		if [[ -n "$_batch_issues" && "$_batch_issues" != "[]" && "$_batch_issues" != "null" ]]; then
+		if _batch_issues=$("$_batch_helper" read-cache --kind issues --slug "$slug" 2>>"$LOGFILE"); then
 			issue_json="$_batch_issues"
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_issues: using batch cache for ${slug}" >>"$LOGFILE"
+			_prefetch_record_batch_cache_hit issues "$_batch_issues"
 			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
 		fi
 	fi
@@ -375,6 +405,7 @@ _prefetch_repo_issues() {
 					_pulse_mark_rate_limited "_prefetch_repo_issues:${slug}"
 				fi
 				echo "[pulse-wrapper] _prefetch_repo_issues: gh_issue_list FAILED for ${slug}: ${issue_err_msg}" >>"$LOGFILE"
+				_prefetch_log_batch_cache_state fetch-failed issues "$slug"
 				issue_json="[]"
 			fi
 		fi

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -242,7 +242,7 @@ _prefetch_repo_prs() {
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_prs: using batch cache for ${slug}" >>"$LOGFILE"
 			_prefetch_record_batch_cache_hit prs "$_batch_prs"
-			_PULSE_HEALTH_BATCH_CACHE_HITS=$((_PULSE_HEALTH_BATCH_CACHE_HITS + 1))
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -221,6 +221,259 @@ JSON
 	return 0
 }
 
+test_read_cache_accepts_fresh_empty_arrays() {
+	setup_env
+	local now=""
+	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	printf '{"timestamp":"%s","items":[]}\n' "$now" \
+		>"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json"
+	printf '{"timestamp":"%s","items":[]}\n' "$now" \
+		>"$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json"
+	local issues_output="" prs_output=""
+	local issues_meta="$TEST_ROOT/issues-meta.log"
+	local prs_meta="$TEST_ROOT/prs-meta.log"
+	local passed=0
+	if issues_output=$("$HELPER" read-cache --kind issues --slug owner/repo 2>"$issues_meta") \
+		&& prs_output=$("$HELPER" read-cache --kind prs --slug owner/repo 2>"$prs_meta") \
+		&& [[ "$issues_output" == "[]" && "$prs_output" == "[]" ]] \
+		&& grep -q 'cache_state=hit.*cardinality=empty' "$issues_meta" \
+		&& grep -q 'cache_state=hit.*cardinality=empty' "$prs_meta"; then
+		passed=0
+	else
+		passed=1
+	fi
+	print_result "read-cache accepts fresh empty issue and PR arrays" "$passed"
+	teardown_env
+	return 0
+}
+
+test_read_cache_rejects_non_hit_states() {
+	setup_env
+	local cache_file="$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json"
+	local state_meta="$TEST_ROOT/cache-state.log"
+	local now=""
+	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+	if "$HELPER" read-cache --kind prs --slug owner/repo 2>"$state_meta"; then
+		print_result "read-cache rejects missing snapshots" 1
+	elif grep -q 'cache_state=missing' "$state_meta"; then
+		print_result "read-cache rejects missing snapshots" 0
+	else
+		print_result "read-cache rejects missing snapshots" 1
+	fi
+
+	printf '{malformed\n' >"$cache_file"
+	if "$HELPER" read-cache --kind prs --slug owner/repo 2>"$state_meta"; then
+		print_result "read-cache rejects malformed JSON snapshots" 1
+	elif grep -q 'cache_state=malformed' "$state_meta"; then
+		print_result "read-cache rejects malformed JSON snapshots" 0
+	else
+		print_result "read-cache rejects malformed JSON snapshots" 1
+	fi
+
+	printf '{"timestamp":"%s","items":{}}\n' "$now" >"$cache_file"
+	if "$HELPER" read-cache --kind prs --slug owner/repo 2>"$state_meta"; then
+		print_result "read-cache rejects non-array snapshot items" 1
+	elif grep -q 'cache_state=malformed' "$state_meta"; then
+		print_result "read-cache rejects non-array snapshot items" 0
+	else
+		print_result "read-cache rejects non-array snapshot items" 1
+	fi
+
+	export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=1
+	printf '{"timestamp":"2026-01-01T00:00:00Z","items":[]}\n' >"$cache_file"
+	if "$HELPER" read-cache --kind prs --slug owner/repo 2>"$state_meta"; then
+		print_result "read-cache rejects stale snapshots" 1
+	elif grep -q 'cache_state=stale' "$state_meta"; then
+		print_result "read-cache rejects stale snapshots" 0
+	else
+		print_result "read-cache rejects stale snapshots" 1
+	fi
+
+	teardown_env
+	return 0
+}
+
+test_read_cache_recovers_after_atomic_replacement() {
+	setup_env
+	local cache_file="$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json"
+	local replacement_file="${cache_file}.new"
+	local state_meta="$TEST_ROOT/atomic-state.log"
+	local now=""
+	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	printf '{"timestamp":"%s","items":[' "$now" >"$cache_file"
+	local passed=0
+	if "$HELPER" read-cache --kind prs --slug owner/repo 2>"$state_meta"; then
+		passed=1
+	elif ! grep -q 'cache_state=malformed' "$state_meta"; then
+		passed=1
+	fi
+	printf '{"timestamp":"%s","items":[]}\n' "$now" >"$replacement_file"
+	mv "$replacement_file" "$cache_file"
+	local first_read="" second_read=""
+	if ! first_read=$("$HELPER" read-cache --kind prs --slug owner/repo 2>"$state_meta") \
+		|| ! second_read=$("$HELPER" read-cache --kind prs --slug owner/repo 2>>"$state_meta") \
+		|| [[ "$first_read" != "[]" || "$second_read" != "[]" ]] \
+		|| [[ "$(grep -c 'cache_state=hit.*cardinality=empty' "$state_meta")" != "2" ]]; then
+		passed=1
+	fi
+	print_result "read-cache rejects partial files and retries after atomic replacement" "$passed"
+	teardown_env
+	return 0
+}
+
+run_prefetch_consumer_case() (
+	local mode="$1"
+	setup_env
+	local scripts_dir=""
+	scripts_dir=$(cd "$SCRIPT_DIR/.." && pwd)
+	SCRIPT_DIR="$scripts_dir"
+	export SCRIPT_DIR LOGFILE PULSE_BATCH_PREFETCH_CACHE_DIR
+	export PULSE_BATCH_PREFETCH_ENABLED=1
+	export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=999999999
+	export PULSE_PREFETCH_PR_LIMIT=100
+	export PULSE_PREFETCH_ISSUE_LIMIT=100
+	local now=""
+	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	case "$mode" in
+	empty)
+		printf '{"timestamp":"%s","items":[]}\n' "$now" \
+			>"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json"
+		printf '{"timestamp":"%s","items":[]}\n' "$now" \
+			>"$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json"
+		;;
+	nonempty)
+		printf '{"timestamp":"%s","items":[{"number":7,"title":"Issue","state":"OPEN","labels":[],"updatedAt":"%s","assignees":[],"body":""}]}\n' \
+			"$now" "$now" >"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json"
+		printf '{"schema_version":2,"timestamp":"%s","items":[{"number":8,"title":"PR","reviewDecision":"","updatedAt":"%s","headRefName":"test","headRefOid":"abc","createdAt":"%s","author":{"login":"tester"}}]}\n' \
+			"$now" "$now" "$now" >"$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json"
+		;;
+	missing | fetch-failed)
+		;;
+	stale)
+		export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=1
+		printf '{"timestamp":"2026-01-01T00:00:00Z","items":[]}\n' \
+			>"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json"
+		printf '{"timestamp":"2026-01-01T00:00:00Z","items":[]}\n' \
+			>"$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json"
+		;;
+	malformed)
+		printf '{malformed\n' >"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json"
+		printf '{"timestamp":"%s","items":{}}\n' "$now" \
+			>"$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json"
+		;;
+	*) return 1 ;;
+	esac
+
+	local live_calls="$TEST_ROOT/live-calls.log"
+	local telemetry_calls="$TEST_ROOT/telemetry-calls.log"
+	gh_record_call() {
+		printf '%s\n' "$*" >>"$telemetry_calls"
+		return 0
+	}
+	gh_pr_list() {
+		printf 'prs\n' >>"$live_calls"
+		if [[ "$mode" == "fetch-failed" ]]; then
+			printf 'simulated transport failure\n' >&2
+			return 1
+		fi
+		printf '[]'
+		return 0
+	}
+	gh_issue_list() {
+		printf 'issues\n' >>"$live_calls"
+		if [[ "$mode" == "fetch-failed" ]]; then
+			printf 'simulated transport failure\n' >&2
+			return 1
+		fi
+		printf '[]'
+		return 0
+	}
+	_filter_non_task_issues() {
+		cat
+		return 0
+	}
+	_pulse_gh_err_is_rate_limit() {
+		return 1
+	}
+	_pulse_mark_rate_limited() {
+		return 0
+	}
+
+	unset _PULSE_PREFETCH_FETCH_LOADED
+	# shellcheck source=../pulse-prefetch-fetch.sh
+	source "$scripts_dir/pulse-prefetch-fetch.sh"
+	_prefetch_prs_enrich_checks() {
+		printf '[]'
+		return 0
+	}
+	_PULSE_HEALTH_BATCH_CACHE_HITS=0
+	_prefetch_repo_prs owner/repo '{}' full >"$TEST_ROOT/pr-output.txt"
+	_prefetch_repo_issues owner/repo '{}' full >"$TEST_ROOT/issue-output.txt"
+
+	if [[ "$mode" == "empty" || "$mode" == "nonempty" ]]; then
+		[[ ! -s "$live_calls" ]] || return 1
+		[[ "$_PULSE_HEALTH_BATCH_CACHE_HITS" == "2" ]] || return 1
+		local decision="hit-nonempty"
+		local cardinality="nonempty"
+		if [[ "$mode" == "empty" ]]; then
+			decision="hit-empty"
+			cardinality="empty"
+			[[ "$PREFETCH_UPDATED_PRS" == "[]" && "$PREFETCH_UPDATED_ISSUES" == "[]" ]] || return 1
+			grep -q 'Open PRs (0)' "$TEST_ROOT/pr-output.txt" || return 1
+			grep -q 'Open Issues (0)' "$TEST_ROOT/issue-output.txt" || return 1
+		else
+			jq -e 'length == 1' <<<"$PREFETCH_UPDATED_PRS" >/dev/null || return 1
+			jq -e 'length == 1' <<<"$PREFETCH_UPDATED_ISSUES" >/dev/null || return 1
+		fi
+		[[ "$(grep -Ec "^other pulse_batch_prefetch_(prs|issues)_cache unknown other ${decision}  cache$" "$telemetry_calls")" == "2" ]] || return 1
+		[[ "$(grep -c "cache_state=hit.*cardinality=${cardinality}" "$LOGFILE")" == "2" ]] || return 1
+		return 0
+	fi
+
+	[[ "$(grep -c -E '^(prs|issues)$' "$live_calls")" == "2" ]] || return 1
+	[[ ! -s "$telemetry_calls" ]] || return 1
+	[[ "$_PULSE_HEALTH_BATCH_CACHE_HITS" == "0" ]] || return 1
+	local expected_state="$mode"
+	[[ "$mode" == "fetch-failed" ]] && expected_state="missing"
+	grep -q "cache_state=${expected_state}" "$LOGFILE" || return 1
+	if [[ "$mode" == "fetch-failed" ]]; then
+		grep -q 'cache_state=fetch-failed kind=prs' "$LOGFILE" || return 1
+		grep -q 'cache_state=fetch-failed kind=issues' "$LOGFILE" || return 1
+	fi
+	return 0
+)
+
+test_prefetch_consumers_accept_fresh_empty_hits() {
+	if run_prefetch_consumer_case empty; then
+		print_result "PR and issue consumers accept fresh empty cache hits without live calls" 0
+	else
+		print_result "PR and issue consumers accept fresh empty cache hits without live calls" 1
+	fi
+	return 0
+}
+
+test_prefetch_consumers_accept_nonempty_legacy_and_versioned_hits() {
+	if run_prefetch_consumer_case nonempty; then
+		print_result "PR and issue consumers accept nonempty legacy and versioned cache hits" 0
+	else
+		print_result "PR and issue consumers accept nonempty legacy and versioned cache hits" 1
+	fi
+	return 0
+}
+
+test_prefetch_consumers_fallback_on_non_hit_states() {
+	local mode=""
+	for mode in missing stale malformed fetch-failed; do
+		if ! run_prefetch_consumer_case "$mode"; then
+			print_result "PR and issue consumers preserve fallback and failure classification" 1
+			return 0
+		fi
+	done
+	print_result "PR and issue consumers preserve fallback and failure classification" 0
+	return 0
+}
+
 test_conditional_failure_routes_to_rest_by_default() {
 	setup_env
 	seed_cache
@@ -289,6 +542,12 @@ test_conditional_failure_routes_to_rest_by_default
 test_search_opt_in_preserves_owner_search
 test_legacy_issue_cache_avoids_search_by_default
 test_read_cache_filters_closed_issues
+test_read_cache_accepts_fresh_empty_arrays
+test_read_cache_rejects_non_hit_states
+test_read_cache_recovers_after_atomic_replacement
+test_prefetch_consumers_accept_fresh_empty_hits
+test_prefetch_consumers_accept_nonempty_legacy_and_versioned_hits
+test_prefetch_consumers_fallback_on_non_hit_states
 test_prefetch_raw_gh_read_detector_rejects_missing_file
 test_prefetch_gh_reads_are_timeout_wrapped
 test_prefetch_raw_gh_read_detector_covers_shell_edges

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -407,7 +407,7 @@ run_prefetch_consumer_case() (
 		printf '[]'
 		return 0
 	}
-	_PULSE_HEALTH_BATCH_CACHE_HITS=0
+	unset _PULSE_HEALTH_BATCH_CACHE_HITS
 	_prefetch_repo_prs owner/repo '{}' full >"$TEST_ROOT/pr-output.txt"
 	_prefetch_repo_issues owner/repo '{}' full >"$TEST_ROOT/issue-output.txt"
 
@@ -433,7 +433,7 @@ run_prefetch_consumer_case() (
 
 	[[ "$(grep -c -E '^(prs|issues)$' "$live_calls")" == "2" ]] || return 1
 	[[ ! -s "$telemetry_calls" ]] || return 1
-	[[ "$_PULSE_HEALTH_BATCH_CACHE_HITS" == "0" ]] || return 1
+	[[ "${_PULSE_HEALTH_BATCH_CACHE_HITS:-0}" == "0" ]] || return 1
 	local expected_state="$mode"
 	[[ "$mode" == "fetch-failed" ]] && expected_state="missing"
 	grep -q "cache_state=${expected_state}" "$LOGFILE" || return 1


### PR DESCRIPTION
## Summary

Treat validated fresh empty snapshots as authoritative cache hits while preserving explicit non-hit fallback states. For #27768. Release: not requested.

## Files Changed

.agents/scripts/pulse-batch-prefetch-helper.sh, .agents/scripts/pulse-prefetch-fetch.sh, .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 18 batch-prefetch tests, 6 exact-output cache tests, 27 enrich tests, 113 instrumentation tests, ShellCheck, Bash syntax, and linters-local.sh --changed

Resolves #27770


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.112 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 1d 4h and 4,579,382 tokens on this with the user in an interactive session.