### PR TITLE
GH#28164: fix: recover pulse merge progress signals

### DIFF
--- a/.agents/scripts/pulse-merge-pass.sh
+++ b/.agents/scripts/pulse-merge-pass.sh
@@ -420,14 +420,17 @@ merge_ready_prs_all_repos() {
 		_pmp_clear_merge_pr_cursor "$PULSE_MERGE_PR_CURSOR_FILE"
 	fi
 
-	# t3193: record the zero-progress signal AFTER all repos have been processed.
-	# Checkpoint-resumed passes intentionally skip this aggregate signal because
-	# they only cover the tail of the repo list; the next fresh full pass records
-	# the all-repo zero-progress state without partial-pass distortion.
+	# t3193: positive deterministic progress is conclusive even when a pass pauses
+	# or resumes from a checkpoint, so reset the streak immediately after a merge
+	# or conflict close. A no-progress aggregate is meaningful only after a fresh
+	# full pass; partial tails skip it to avoid distorting the all-repo signal.
 	# Resolves at runtime via bash lazy lookup (pulse-merge-stuck.sh).
-	if [[ "$_mr_completed_all" -eq 1 && "$_mr_resumed_from_checkpoint" -eq 0 ]] \
-		&& declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
-		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" "$total_closed" || true
+	if declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
+		if [[ "$total_merged" -gt 0 || "$total_closed" -gt 0 ]]; then
+			pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" "$total_closed" || true
+		elif [[ "$_mr_completed_all" -eq 1 && "$_mr_resumed_from_checkpoint" -eq 0 ]]; then
+			pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" "$total_closed" || true
+		fi
 	fi
 
 	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, closed_conflicting=${total_closed}, failed=${total_failed}, eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -461,14 +461,26 @@ _pmrc_snapshot_review_gate_fresh() {
 	local checks_json="$3"
 	local activity_json="$4"
 	local live_gate_evidence="${5:-}"
-	local gate_at="" activity_at="" gate_epoch="" activity_epoch=""
+	local gate_at="" activity_at="" evidence_at="" gate_epoch="" activity_epoch="" evidence_epoch=""
 
 	gate_at=$(jq -r --arg completed "$PMRC_CHECK_COMPLETED" --arg success "$PMRC_CHECK_SUCCESS" '[.[]? | select((.name == "review-bot-gate" or .name == "gate / review-bot-gate") and .status == $completed and .conclusion == $success) | .observed_at | select(. != "")] | max // ""' <<<"$checks_json") || return 1
 	activity_at=$(jq -r '.latest_at // ""' <<<"$activity_json") || return 1
+	if [[ -n "$activity_at" ]]; then
+		activity_epoch=$(_pmrc_iso_to_epoch "$activity_at") || return 1
+	fi
+	if [[ -n "$live_gate_evidence" ]]; then
+		evidence_at=$(jq -r '.observed_at // ""' <<<"$live_gate_evidence") || return 1
+		if [[ -n "$evidence_at" ]]; then
+			evidence_epoch=$(_pmrc_iso_to_epoch "$evidence_at") || return 1
+		fi
+	fi
 	if [[ -z "$gate_at" ]]; then
 		#aidevops:trust-boundary — the live helper ran for this exact PR/head, and
 		# the caller immediately revalidates that head before reaching this check.
-		if [[ -n "$live_gate_evidence" ]]; then
+		# Its caller-observed timestamp must also cover the latest bot activity so
+		# activity racing after the live helper remains fail-closed.
+		if [[ "$evidence_epoch" =~ ^[0-9]+$ ]] \
+			&& { [[ -z "$activity_epoch" ]] || [[ "$evidence_epoch" -ge "$activity_epoch" ]]; }; then
 			echo "[pulse-merge] pre-merge snapshot: accepted live review-bot gate bound to the current head for PR #${pr_number} in ${repo_slug}; no status context is installed (GH#27483)" >>"$LOGFILE"
 			return 0
 		fi
@@ -477,8 +489,14 @@ _pmrc_snapshot_review_gate_fresh() {
 	fi
 	[[ -z "$activity_at" ]] && return 0
 	gate_epoch=$(_pmrc_iso_to_epoch "$gate_at") || return 1
-	activity_epoch=$(_pmrc_iso_to_epoch "$activity_at") || return 1
 	if [[ "$activity_epoch" -gt "$gate_epoch" ]]; then
+		#aidevops:trust-boundary — permitted live evidence is bound to the exact
+		# current head. Accept it only when it was observed after the latest bot
+		# activity; otherwise retain the stale-status fail-closed decision.
+		if [[ "$evidence_epoch" =~ ^[0-9]+$ && "$evidence_epoch" -ge "$activity_epoch" ]]; then
+			echo "[pulse-merge] pre-merge snapshot: accepted current-head live review evidence observed after the stale status context for PR #${pr_number} in ${repo_slug} (status_gate=${gate_at}, latest_review_activity=${activity_at}, live_evidence=${evidence_at})" >>"$LOGFILE"
+			return 0
+		fi
 		echo "[pulse-merge] pre-merge snapshot: review-bot gate is stale for PR #${pr_number} in ${repo_slug} (gate=${gate_at}, latest_review_activity=${activity_at}) (GH#27137)" >>"$LOGFILE"
 		return 1
 	fi

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -431,10 +431,12 @@ _check_pr_merge_gates() {
 	# ── Review bot gate (GH#17490) ──
 	# --admin bypasses branch protection; enforce in code (see review-bot-gate-helper.sh).
 	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
+	local rbg_observed_at=""
 	if [[ -f "$rbg_helper" ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author"; then
-			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" --arg author "$pr_author" \
-				'{schema:$schema,repo:$repo,pr:$pr,head_sha:$head,status:"SKIP_TRUSTED_DEPENDABOT",author:{login:$author,association:"BOT",class:"trusted-bot"},permitted:true,reason:"trusted_dependabot_policy",state:"pass",merge_gate:"clear",exit_code:0}')
+			rbg_observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" --arg author "$pr_author" --arg observed_at "$rbg_observed_at" \
+				'{schema:$schema,repo:$repo,pr:$pr,head_sha:$head,status:"SKIP_TRUSTED_DEPENDABOT",author:{login:$author,association:"BOT",class:"trusted-bot"},permitted:true,reason:"trusted_dependabot_policy",state:"pass",merge_gate:"clear",exit_code:0,observed_at:$observed_at}')
 			echo "[pulse-wrapper] Review bot gate: SKIP for trusted Dependabot dependency update PR #${pr_number} in ${repo_slug} (GH#24473)" >>"$LOGFILE"
 			return 0
 		fi
@@ -449,7 +451,8 @@ _check_pr_merge_gates() {
 			and .repo == $repo and (.pr | tostring) == $pr and .head_sha == $head
 			and .permitted == true and .state == "pass" and .merge_gate == "clear"
 		' <<<"$rbg_result" >/dev/null 2>&1; then
-			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS . <<<"$rbg_result")
+			rbg_observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS --arg observed_at "$rbg_observed_at" '.observed_at = $observed_at' <<<"$rbg_result") || return 1
 			echo "[pulse-wrapper] Review bot gate: ${rbg_status} for PR #${pr_number} in ${repo_slug} (typed current-head evidence)" >>"$LOGFILE"
 		else
 			echo "[pulse-wrapper] Review bot gate: ${rbg_status:-${PULSE_UNKNOWN_STATE}} for PR #${pr_number} in ${repo_slug} — missing or unpermitted current-head evidence; skipping merge" >>"$LOGFILE"
@@ -476,7 +479,7 @@ _pulse_merge_refresh_review_gate_evidence() {
 	local expected_head_sha="$3"
 	local current_evidence="${_PULSE_REVIEW_GATE_EVIDENCE:-}"
 	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
-	local refreshed_evidence="" evidence_status="" dependabot_author=""
+	local refreshed_evidence="" evidence_status="" dependabot_author="" evidence_observed_at=""
 
 	if jq -e --arg schema "$PULSE_REVIEW_EVIDENCE_SCHEMA" --arg repo "$repo_slug" --arg pr "$pr_number" --arg head "$expected_head_sha" '
 		.schema == $schema
@@ -485,6 +488,8 @@ _pulse_merge_refresh_review_gate_evidence() {
 	' <<<"$current_evidence" >/dev/null 2>&1; then
 		dependabot_author=$(jq -r '.author.login // ""' <<<"$current_evidence" 2>/dev/null) || dependabot_author=""
 		if [[ -n "$dependabot_author" ]] && _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$dependabot_author"; then
+			evidence_observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+			_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS --arg observed_at "$evidence_observed_at" '.observed_at = $observed_at' <<<"$current_evidence") || return 1
 			return 0
 		fi
 		_PULSE_REVIEW_GATE_EVIDENCE=""
@@ -501,7 +506,8 @@ _pulse_merge_refresh_review_gate_evidence() {
 		echo "[pulse-merge] final trust gate: current-head review evidence is ${evidence_status:-${PULSE_UNKNOWN_STATE}} or unpermitted for PR #${pr_number} in ${repo_slug} — merge blocked" >>"$LOGFILE"
 		return 1
 	fi
-	_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS . <<<"$refreshed_evidence") || {
+	evidence_observed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	_PULSE_REVIEW_GATE_EVIDENCE=$(jq -cS --arg observed_at "$evidence_observed_at" '.observed_at = $observed_at' <<<"$refreshed_evidence") || {
 		_PULSE_REVIEW_GATE_EVIDENCE=""
 		return 1
 	}

--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -522,13 +522,14 @@ test_case_k_final_gate_refreshes_current_review_evidence() {
 		'## Summary\n\nResolves #920' 'VERIFIED' 'VERIFIED' 'trusted-contributor'
 	_PULSE_REVIEW_GATE_EVIDENCE='{"schema":"aidevops.review-gate-evidence/v1","repo":"owner/repo","pr":"920","head_sha":"old-head","status":"PASS","author":{"login":"trusted-contributor","association":"MEMBER","class":"trusted"},"permitted":true,"reason":"stale","state":"pass","merge_gate":"clear","exit_code":0}'
 	_PULSE_PREFLIGHT_CALLS=0
-	local result=0
+	local result=0 evidence_observed_at=""
 	_pulse_merge_final_trust_gate "920" "owner/repo" "head-current" || result=$?
-	if [[ "$result" -eq 0 && "$_PULSE_PREFLIGHT_CALLS" -eq 1 ]]; then
+	evidence_observed_at=$(jq -r '.observed_at // ""' <<<"${_PULSE_REVIEW_GATE_EVIDENCE:-}" 2>/dev/null) || evidence_observed_at=""
+	if [[ "$result" -eq 0 && "$_PULSE_PREFLIGHT_CALLS" -eq 1 && -n "$evidence_observed_at" ]]; then
 		print_result "Case K: final gate refreshes exact-head review evidence" 0
 		return 0
 	fi
-	print_result "Case K: current review evidence reaches preflight" 1 "rc=${result}; preflight_calls=${_PULSE_PREFLIGHT_CALLS}"
+	print_result "Case K: current timestamped review evidence reaches preflight" 1 "rc=${result}; preflight_calls=${_PULSE_PREFLIGHT_CALLS}; observed_at=${evidence_observed_at:-missing}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
+++ b/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
@@ -76,6 +76,7 @@ source "$PROCESS_FILE"
 PROCESSED_REPOS=""
 ZERO_PROGRESS_CALLS=""
 STOP_AFTER_REPO=""
+MERGE_ON_REPO=""
 
 repo_allows_pulse_write_actions() {
 	local repo_slug="$1"
@@ -90,8 +91,12 @@ _merge_ready_prs_for_repo() {
 	local failed_var="$4"
 	local pr_count_var="${5:-}"
 
+	local merged_count=0
+	[[ "$repo_slug" == "$MERGE_ON_REPO" ]] && merged_count=1
 	PROCESSED_REPOS="${PROCESSED_REPOS}${repo_slug} "
-	eval "${merged_var}=0; ${closed_var}=0; ${failed_var}=0"
+	printf -v "$merged_var" '%s' "$merged_count"
+	printf -v "$closed_var" '%s' '0'
+	printf -v "$failed_var" '%s' '0'
 	if [[ -n "$pr_count_var" ]]; then
 		printf -v "$pr_count_var" '%s' '0'
 	fi
@@ -156,6 +161,15 @@ if [[ ! -f "$PULSE_MERGE_CHECKPOINT_FILE" ]]; then
 else
 	fail "checkpoint without newline clears after resume" "checkpoint still exists"
 fi
+
+rm -f "$PULSE_MERGE_CHECKPOINT_FILE"
+STOP_AFTER_REPO="org/two"
+MERGE_ON_REPO="org/two"
+PROCESSED_REPOS=""
+ZERO_PROGRESS_CALLS=""
+merge_ready_prs_all_repos
+assert_equals "interrupted pass records conclusive merge progress" "2:1:0 " "$ZERO_PROGRESS_CALLS"
+rm -f "$STOP_FLAG"
 
 if [[ "$TESTS_FAILED" -eq 0 ]]; then
 	printf '\n%sAll %s tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -215,8 +215,9 @@ set_live_evidence() {
 	local head_sha="${2:-sha-reviewed}"
 	local author_class="${3:-trusted}"
 	local permitted="${4:-true}"
-	_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg status "$status" --arg head "$head_sha" --arg class "$author_class" --argjson permitted "$permitted" '
-		{schema:"aidevops.review-gate-evidence/v1",repo:"owner/repo",pr:"7",head_sha:$head,status:$status,author:{login:"reviewer",association:(if $class == "trusted" then "MEMBER" else "CONTRIBUTOR" end),class:$class},permitted:$permitted,reason:"test",state:(if $permitted then "pass" else "waiting" end),merge_gate:(if $permitted then "clear" else "blocked" end),exit_code:0}
+	local observed_at="${5:-2026-01-01T00:10:00Z}"
+	_PULSE_REVIEW_GATE_EVIDENCE=$(jq -nc --arg status "$status" --arg head "$head_sha" --arg class "$author_class" --arg observed_at "$observed_at" --argjson permitted "$permitted" '
+		{schema:"aidevops.review-gate-evidence/v1",repo:"owner/repo",pr:"7",head_sha:$head,status:$status,author:{login:"reviewer",association:(if $class == "trusted" then "MEMBER" else "CONTRIBUTOR" end),class:$class},permitted:$permitted,reason:"test",state:(if $permitted then "pass" else "waiting" end),merge_gate:(if $permitted then "clear" else "blocked" end),exit_code:0,observed_at:$observed_at}
 	')
 	return 0
 }
@@ -254,6 +255,57 @@ assert_infrastructure_rerun_unset_logfile_safe() {
 	fi
 	printf 'FAIL unset LOGFILE was not handled safely (rc=%s, output=%s)\n' "$rc" "$output"
 	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_review_and_head_snapshot_cases() {
+	assert_gate "same-name check-run and status retain independent source failures" same_name_source_conflict 1
+	set_live_evidence PASS
+	assert_gate "configured non-required provider failure passes with typed current-head evidence" configured_fail 0
+	set_live_evidence PASS_ADVISORY
+	assert_gate "configured provider failure passes with trusted advisory-default evidence" configured_fail 0
+	set_live_evidence PASS_ADVISORY sha-reviewed external false
+	assert_gate "configured provider failure blocks external advisory evidence" configured_fail 1
+	set_live_evidence PASS_RATE_LIMITED sha-reviewed external false
+	assert_gate "configured provider failure blocks external rate-limit evidence" configured_fail 1
+	_PULSE_REVIEW_GATE_EVIDENCE=""
+	assert_gate "stable maintainer-gate success supersedes stale alias failures" maintainer_alias_fail 0
+	assert_gate "stable maintainer-gate failure remains one logical blocker" maintainer_stable_fail 1
+	if [[ "$(grep -c "maintainer-gate family is terminal-failure" "$LOGFILE" || true)" -eq 1 ]]; then
+		printf 'PASS maintainer-gate aliases emit one audited blocker\n'
+	else
+		printf 'FAIL maintainer-gate aliases did not emit exactly one blocker\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
+	assert_gate "legacy maintainer aliases fail closed without stable context" maintainer_legacy_fail 1
+	assert_gate "infrastructure-failed maintainer gate requests rerun and stays blocked" maintainer_infra_fail 1
+	if [[ "$RERUN_CALLS" -eq 2 ]] && grep -q "maintainer-gate family has a proven infrastructure failure" "$LOGFILE"; then
+		printf 'PASS infrastructure-failed maintainer gate requests audited rerun\n'
+	else
+		printf 'FAIL infrastructure-failed maintainer gate rerun was not requested\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
+	assert_gate "unresolved late inline finding blocks merge" unresolved 1
+	assert_human_review_thread_rules
+	assert_gate "late review activity invalidates stale gate success" stale_gate 1
+	set_live_evidence PASS sha-reviewed trusted true 2026-01-01T00:00:50Z
+	assert_gate "newer typed live evidence supersedes a stale status context" stale_gate 0
+	set_live_evidence PASS sha-reviewed trusted true 2026-01-01T00:00:35Z
+	assert_gate "typed live evidence predating late activity fails closed" stale_gate 1
+	_PULSE_REVIEW_GATE_EVIDENCE=""
+	assert_gate "missing status gate fails closed without live evidence" no_status_gate 1
+	set_live_evidence PASS_ADVISORY
+	_PULSE_REVIEW_GATE_EVIDENCE=$(jq -c 'del(.observed_at)' <<<"$_PULSE_REVIEW_GATE_EVIDENCE")
+	assert_gate "live evidence without an observation timestamp fails closed" no_status_gate 1
+	set_live_evidence PASS_ADVISORY
+	assert_gate "trusted advisory evidence permits repositories without a status context" no_status_gate 0
+	set_live_evidence PASS sha-other
+	assert_gate "live gate evidence for another head fails closed" no_status_gate 1
+	_PULSE_REVIEW_GATE_EVIDENCE=""
+	assert_gate "new commit invalidates reviewed head" new_head 1
+	assert_gate "bounded quiet period blocks recent check completion" recent 1
 	return 0
 }
 
@@ -314,46 +366,7 @@ main() {
 		TESTS_FAILED=$((TESTS_FAILED + 1))
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
-	assert_gate "same-name check-run and status retain independent source failures" same_name_source_conflict 1
-	set_live_evidence PASS
-	assert_gate "configured non-required provider failure passes with typed current-head evidence" configured_fail 0
-	set_live_evidence PASS_ADVISORY
-	assert_gate "configured provider failure passes with trusted advisory-default evidence" configured_fail 0
-	set_live_evidence PASS_ADVISORY sha-reviewed external false
-	assert_gate "configured provider failure blocks external advisory evidence" configured_fail 1
-	set_live_evidence PASS_RATE_LIMITED sha-reviewed external false
-	assert_gate "configured provider failure blocks external rate-limit evidence" configured_fail 1
-	_PULSE_REVIEW_GATE_EVIDENCE=""
-	assert_gate "stable maintainer-gate success supersedes stale alias failures" maintainer_alias_fail 0
-	assert_gate "stable maintainer-gate failure remains one logical blocker" maintainer_stable_fail 1
-	if [[ "$(grep -c "maintainer-gate family is terminal-failure" "$LOGFILE" || true)" -eq 1 ]]; then
-		printf 'PASS maintainer-gate aliases emit one audited blocker\n'
-	else
-		printf 'FAIL maintainer-gate aliases did not emit exactly one blocker\n'
-		TESTS_FAILED=$((TESTS_FAILED + 1))
-	fi
-	TESTS_RUN=$((TESTS_RUN + 1))
-	assert_gate "legacy maintainer aliases fail closed without stable context" maintainer_legacy_fail 1
-	assert_gate "infrastructure-failed maintainer gate requests rerun and stays blocked" maintainer_infra_fail 1
-	if [[ "$RERUN_CALLS" -eq 2 ]] && grep -q "maintainer-gate family has a proven infrastructure failure" "$LOGFILE"; then
-		printf 'PASS infrastructure-failed maintainer gate requests audited rerun\n'
-	else
-		printf 'FAIL infrastructure-failed maintainer gate rerun was not requested\n'
-		TESTS_FAILED=$((TESTS_FAILED + 1))
-	fi
-	TESTS_RUN=$((TESTS_RUN + 1))
-	assert_gate "unresolved late inline finding blocks merge" unresolved 1
-	assert_human_review_thread_rules
-	assert_gate "late review activity invalidates stale gate success" stale_gate 1
-	_PULSE_REVIEW_GATE_EVIDENCE=""
-	assert_gate "missing status gate fails closed without live evidence" no_status_gate 1
-	set_live_evidence PASS_ADVISORY
-	assert_gate "trusted advisory evidence permits repositories without a status context" no_status_gate 0
-	set_live_evidence PASS sha-other
-	assert_gate "live gate evidence for another head fails closed" no_status_gate 1
-	_PULSE_REVIEW_GATE_EVIDENCE=""
-	assert_gate "new commit invalidates reviewed head" new_head 1
-	assert_gate "bounded quiet period blocks recent check completion" recent 1
+	assert_review_and_head_snapshot_cases
 	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?


### PR DESCRIPTION
## Summary

Timestamp typed current-head review evidence so a live PASS can safely supersede stale status contexts only when it covers the latest bot activity. Reset the zero-progress streak immediately when a checkpointed or partial merge pass makes deterministic progress.

## Files Changed

.agents/scripts/pulse-merge-pass.sh, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh, .agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Passed local linters, ShellCheck, 46 preflight snapshot tests, 11 checkpoint-resume tests, 17 final trust-gate tests, 59 stuck-detector tests, and 62 review-gate completion tests.

Resolves #28164


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.149 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 19m and 983,347 tokens on this with the user in an interactive session.