### PR TITLE
GH#27771: Reuse canonical snapshots and remove duplicate verification reads

### DIFF
--- a/.agents/configs/pulse-sweep-budget.json
+++ b/.agents/configs/pulse-sweep-budget.json
@@ -4,7 +4,6 @@
 		"token_budget": 3000,
 		"max_events_per_pass": 50,
 		"deferral_promotion_threshold": 3,
-		"verification_query_limit": 5,
 		"state_fingerprint_cache_hit_enabled": true
 	},
 	"per_repo": {}

--- a/.agents/scripts/pulse-batch-conditional-cache.py
+++ b/.agents/scripts/pulse-batch-conditional-cache.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Normalize conditional GitHub REST responses into pulse batch cache files."""
+"""Normalize conditional GitHub REST responses into canonical Pulse snapshots."""
 
 from __future__ import annotations
 
@@ -26,7 +26,10 @@ def _write_cache(cache_file: str, payload: dict[str, Any]) -> None:
     os.replace(tmp, cache_file)
 
 
-def _split_response(response_file: str) -> tuple[int, str, str]:
+_SNAPSHOT_SCHEMA = "aidevops-pulse-snapshot/v1"
+
+
+def _split_response(response_file: str) -> tuple[int, str, bool, str]:
     raw = open(response_file, "rb").read().decode("utf-8", "replace")
     normalized = raw.replace("\r\n", "\n")
     headers, body = normalized.split("\n\n", 1) if "\n\n" in normalized else (normalized, "")
@@ -34,7 +37,14 @@ def _split_response(response_file: str) -> tuple[int, str, str]:
     if not match:
         raise ValueError("missing HTTP status")
     etag_match = re.search(r"^etag:\s*(.+)$", headers, re.I | re.M)
-    return int(match.group(1)), etag_match.group(1).strip() if etag_match else "", body
+    link_match = re.search(r"^link:\s*(.+)$", headers, re.I | re.M)
+    has_next = bool(link_match and re.search(r'rel="next"', link_match.group(1), re.I))
+    return (
+        int(match.group(1)),
+        etag_match.group(1).strip() if etag_match else "",
+        has_next,
+        body,
+    )
 
 
 def _normalize_items(kind: str, body: str) -> list[dict[str, Any]]:
@@ -72,42 +82,105 @@ def _normalize_items(kind: str, body: str) -> list[dict[str, Any]]:
     return items
 
 
+def _snapshot_payload(
+    kind: str,
+    slug: str,
+    projection: str,
+    auth_scope: str,
+    generation: str,
+    source: str,
+    now: str,
+    etag: str,
+    status: int,
+    complete: bool,
+    items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema": _SNAPSHOT_SCHEMA,
+        "repository": slug,
+        "collection": kind,
+        "projection": projection,
+        "auth_scope": auth_scope,
+        "generation": generation,
+        "source": source,
+        "complete": complete,
+        "truncated": not complete,
+        "fetched_at": now,
+        "timestamp": now,
+        "last_success": now,
+        "etag": etag,
+        "validator": {"etag": etag} if etag else {},
+        "conditional_status": status,
+        "conditional_cache_hit": status == 304,
+        "items": items,
+    }
+
+
 def main(argv: list[str]) -> int:
     result = 0
-    if len(argv) != 5:
-        print("usage: pulse-batch-conditional-cache.py KIND SLUG RESPONSE_FILE CACHE_FILE", file=sys.stderr)
+    if len(argv) != 8:
+        print(
+            "usage: pulse-batch-conditional-cache.py KIND SLUG RESPONSE_FILE "
+            "CACHE_FILE GENERATION AUTH_SCOPE PROJECTION",
+            file=sys.stderr,
+        )
         result = 2
     else:
-        kind, _slug, response_file, cache_file = argv[1:5]
-        status, etag, body = _split_response(response_file)
+        kind, slug, response_file, cache_file, generation, auth_scope, projection = argv[1:8]
+        status, etag, has_next, body = _split_response(response_file)
         now = _now_iso()
         if status == 304:
-            result = _refresh_cached_response(kind, cache_file, etag, now)
+            result = _refresh_cached_response(
+                kind,
+                slug,
+                cache_file,
+                etag,
+                now,
+                generation,
+                auth_scope,
+                projection,
+            )
         elif status < 200 or status >= 300:
             result = 1
         else:
             _write_cache(
                 cache_file,
-                {
-                    "timestamp": now,
-                    "last_success": now,
-                    "etag": etag,
-                    "conditional_status": status,
-                    "conditional_cache_hit": False,
-                    "items": _normalize_items(kind, body),
-                },
+                _snapshot_payload(
+                    kind,
+                    slug,
+                    projection,
+                    auth_scope,
+                    generation,
+                    "conditional-rest",
+                    now,
+                    etag,
+                    status,
+                    not has_next,
+                    _normalize_items(kind, body),
+                ),
             )
             print(str(status))
     return result
 
 
-def _refresh_cached_response(kind: str, cache_file: str, etag: str, now: str) -> int:
+def _refresh_cached_response(
+    kind: str,
+    slug: str,
+    cache_file: str,
+    etag: str,
+    now: str,
+    generation: str,
+    auth_scope: str,
+    projection: str,
+) -> int:
     if not os.path.exists(cache_file):
         return 1
     with open(cache_file, encoding="utf-8") as handle:
         payload = json.load(handle)
+    items = payload.get("items")
+    if not isinstance(items, list) or any(not isinstance(item, dict) for item in items):
+        return 1
     if kind == "issues":
-        items = payload.get("items") or []
         if any("state" not in item for item in items):
             return 1
         payload["items"] = [
@@ -115,8 +188,26 @@ def _refresh_cached_response(kind: str, cache_file: str, etag: str, now: str) ->
             for item in items
             if str(item.get("state") or "open").lower() == "open"
         ]
+    compatible = (
+        payload.get("schema") == _SNAPSHOT_SCHEMA
+        and payload.get("repository") == slug
+        and payload.get("collection") == kind
+        and payload.get("projection") == projection
+        and payload.get("auth_scope") == auth_scope
+        and isinstance(payload.get("complete"), bool)
+    )
     payload.update(
         {
+            "schema": _SNAPSHOT_SCHEMA if compatible else payload.get("schema", "legacy"),
+            "repository": slug,
+            "collection": kind,
+            "projection": projection if compatible else payload.get("projection", "legacy"),
+            "auth_scope": auth_scope,
+            "generation": generation,
+            "source": "conditional-rest",
+            "complete": payload.get("complete", False) if compatible else False,
+            "truncated": not (payload.get("complete", False) if compatible else False),
+            "fetched_at": now,
             "timestamp": now,
             "last_success": now,
             "conditional_status": 304,
@@ -125,6 +216,7 @@ def _refresh_cached_response(kind: str, cache_file: str, etag: str, now: str) ->
     )
     if etag:
         payload["etag"] = etag
+        payload["validator"] = {"etag": etag}
     _write_cache(cache_file, payload)
     print("304")
     return 0

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -113,6 +113,9 @@ _KIND_PRS="prs"
 _JSON_NULL="null"
 _JSON_EMPTY_OBJ="{}"
 _JSON_EMPTY_ARR="[]"
+_JSON_TYPE_ARRAY=array
+_JSON_TYPE_BOOLEAN=boolean
+_JSON_TYPE_STRING=string
 _STATE_OPEN="open"
 _CACHE_STATE_MALFORMED="malformed"
 _CACHE_SNAPSHOT_STATE="missing"
@@ -911,7 +914,8 @@ _emit_cache_state() {
 # Subcommand: cache-path
 # =============================================================================
 _cmd_cache_path() {
-	local kind="" slug=""
+	local kind=""
+	local slug=""
 	local _args=("$@")
 	local _i=0
 	while [[ $_i -lt ${#_args[@]} ]]; do
@@ -956,7 +960,8 @@ _cmd_cache_path() {
 # Output: JSON array of items on stdout, exit 1 on miss/stale
 # =============================================================================
 _cmd_read_cache() {
-	local kind="" slug=""
+	local kind=""
+	local slug=""
 	local _args=("$@")
 	local _i=0
 	while [[ $_i -lt ${#_args[@]} ]]; do
@@ -1022,7 +1027,8 @@ _cmd_read_cache() {
 # but cannot authorize state-fingerprint hits through this stricter interface.
 # =============================================================================
 _cmd_read_snapshot() {
-	local kind="" slug=""
+	local kind=""
+	local slug=""
 	local _args=("$@")
 	local _i=0
 	while [[ $_i -lt ${#_args[@]} ]]; do
@@ -1057,25 +1063,27 @@ _cmd_read_snapshot() {
 	local envelope=""
 	envelope=$(jq -ce \
 		--arg schema "$_SNAPSHOT_SCHEMA" --arg slug "$slug" --arg kind "$kind" \
-		--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" '
+		--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" \
+		--arg type_array "$_JSON_TYPE_ARRAY" --arg type_boolean "$_JSON_TYPE_BOOLEAN" \
+		--arg type_string "$_JSON_TYPE_STRING" '
 		select(.schema == $schema and .repository == $slug and .collection == $kind) |
 		select(.projection == $projection and .auth_scope == $auth_scope) |
-		select((.generation | type) == "string" and (.generation | length) > 0) |
-		select((.source | type) == "string" and (.source | length) > 0) |
-		select((.fetched_at | type) == "string" and (.fetched_at | length) > 0) |
-		select((.complete | type) == "boolean" and (.items | type) == "array") |
+		select((.generation | type) == $type_string and (.generation | length) > 0) |
+		select((.source | type) == $type_string and (.source | length) > 0) |
+		select((.fetched_at | type) == $type_string and (.fetched_at | length) > 0) |
+		select((.complete | type) == $type_boolean and (.items | type) == $type_array) |
 		if $kind == "issues" then
 			select(all(.items[];
 				(.number | type) == "number" and has("title") and
-				(.state | type) == "string" and (.labels | type) == "array" and
-				has("updatedAt") and (.assignees | type) == "array")) |
+				(.state | type) == $type_string and (.labels | type) == $type_array and
+				has("updatedAt") and (.assignees | type) == $type_array)) |
 			.items = [.items[] | select((.state | ascii_downcase) == "open")]
 		else
 			select(all(.items[];
 				(.number | type) == "number" and has("title") and
-				(.labels | type) == "array" and has("updatedAt") and
-				(.assignees | type) == "array" and has("createdAt") and
-				has("author") and (.headRefOid | type) == "string" and
+				(.labels | type) == $type_array and has("updatedAt") and
+				(.assignees | type) == $type_array and has("createdAt") and
+				has("author") and (.headRefOid | type) == $type_string and
 				(.headRefOid | length) > 0 and has("headRefName")))
 		end
 	' "$_CACHE_SNAPSHOT_PATH" 2>/dev/null) || {

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -18,6 +18,7 @@
 # Usage:
 #   pulse-batch-prefetch-helper.sh refresh              # Fetch and cache
 #   pulse-batch-prefetch-helper.sh cache-path --kind issues --slug owner/repo
+#   pulse-batch-prefetch-helper.sh read-snapshot --kind issues --slug owner/repo
 #   pulse-batch-prefetch-helper.sh evict-issue owner/repo 123
 #   pulse-batch-prefetch-helper.sh clear                # Wipe cache
 #   pulse-batch-prefetch-helper.sh status               # Show cache ages
@@ -116,6 +117,11 @@ _STATE_OPEN="open"
 _CACHE_STATE_MALFORMED="malformed"
 _CACHE_SNAPSHOT_STATE="missing"
 _CACHE_SNAPSHOT_PATH=""
+_SNAPSHOT_SCHEMA="aidevops-pulse-snapshot/v1"
+_SNAPSHOT_ISSUES_PROJECTION="number,title,state,labels,updatedAt,assignees"
+_SNAPSHOT_PRS_PROJECTION="number,title,labels,updatedAt,assignees,createdAt,author,headRefOid,headRefName"
+_BATCH_SNAPSHOT_GENERATION="${PULSE_BATCH_SNAPSHOT_GENERATION:-}"
+_BATCH_SNAPSHOT_AUTH_SCOPE="${PULSE_BATCH_SNAPSHOT_AUTH_SCOPE:-${GH_HOST:-github.com}|${AIDEVOPS_GH_AUTH_MODE:-gh}|${AIDEVOPS_GH_AUTH_PRINCIPAL:-default}}"
 
 # --- Feature flag gate ---
 _check_enabled() {
@@ -123,6 +129,29 @@ _check_enabled() {
 		return 1
 	fi
 	return 0
+}
+
+_snapshot_projection() {
+	local kind="$1"
+	case "$kind" in
+	issues) printf '%s\n' "$_SNAPSHOT_ISSUES_PROJECTION" ;;
+	prs) printf '%s\n' "$_SNAPSHOT_PRS_PROJECTION" ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+_snapshot_collection_complete() {
+	local payload="$1"
+	local limit="${2:-100}"
+	[[ "$limit" =~ ^[0-9]+$ && "$limit" -gt 0 ]] || limit=100
+	[[ "$limit" -le 100 ]] || limit=100
+	local count=""
+	count=$(printf '%s' "$payload" | jq -er 'select(type == "array") | length' 2>/dev/null) || return 1
+	if [[ "$count" =~ ^[0-9]+$ && "$count" -lt "$limit" ]]; then
+		return 0
+	fi
+	return 1
 }
 
 # --- Logging ---
@@ -161,7 +190,7 @@ _prefetch_rest_issues_for_slug() {
 	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rest_issues || true
 	local rest_json
 	rest_json=$(_prefetch_gh_read gh api "/repos/${slug}/issues?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
-	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" || "$rest_json" == "$_JSON_EMPTY_ARR" ]]; then
+	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" ]]; then
 		_log "REST issues fallback: empty/null response for ${slug}"
 		return 1
 	fi
@@ -169,9 +198,28 @@ _prefetch_rest_issues_for_slug() {
 	cache_file=$(_cache_file_path "$_KIND_ISSUES" "$slug")
 	local ts
 	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-	echo "$rest_json" | jq --arg ts "$ts" --arg state_open "$_STATE_OPEN" '{
+	local complete=false
+	_snapshot_collection_complete "$rest_json" "$BATCH_SEARCH_LIMIT" && complete=true
+	local projection=""
+	projection=$(_snapshot_projection "$_KIND_ISSUES") || return 1
+	local tmp_file=""
+	tmp_file=$(mktemp "${BATCH_CACHE_DIR}/.issues-snapshot.XXXXXX") || return 1
+	echo "$rest_json" | jq --arg ts "$ts" --arg state_open "$_STATE_OPEN" \
+		--arg schema "$_SNAPSHOT_SCHEMA" --arg slug "$slug" --arg collection "$_KIND_ISSUES" \
+		--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" \
+		--arg generation "$_BATCH_SNAPSHOT_GENERATION" --argjson complete "$complete" '{
+		schema: $schema,
+		repository: $slug,
+		collection: $collection,
+		projection: $projection,
+		auth_scope: $auth_scope,
+		generation: $generation,
+		source: "rest-fallback",
+		complete: $complete,
+		truncated: ($complete | not),
+		fetched_at: $ts,
 		timestamp: $ts,
-		items: [.[] | {
+		items: [.[] | select(.pull_request == null) | {
 			number: .number,
 			title: .title,
 			state: (.state // $state_open),
@@ -179,7 +227,8 @@ _prefetch_rest_issues_for_slug() {
 			updatedAt: .updated_at,
 			assignees: (.assignees // [])
 		}]
-	}' >"$cache_file" 2>/dev/null || {
+	}' >"$tmp_file" 2>/dev/null && mv "$tmp_file" "$cache_file" || {
+		rm -f "$tmp_file"
 		_log "REST issues fallback: failed to write cache for ${slug}"
 		return 1
 	}
@@ -202,7 +251,7 @@ _prefetch_rest_prs_for_slug() {
 	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rest_prs || true
 	local rest_json
 	rest_json=$(_prefetch_gh_read gh api "/repos/${slug}/pulls?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
-	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" || "$rest_json" == "$_JSON_EMPTY_ARR" ]]; then
+	if [[ -z "$rest_json" || "$rest_json" == "$_JSON_NULL" ]]; then
 		_log "REST PRs fallback: empty/null response for ${slug}"
 		return 1
 	fi
@@ -210,7 +259,26 @@ _prefetch_rest_prs_for_slug() {
 	cache_file=$(_cache_file_path "$_KIND_PRS" "$slug")
 	local ts
 	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-	echo "$rest_json" | jq --arg ts "$ts" '{
+	local complete=false
+	_snapshot_collection_complete "$rest_json" "$BATCH_SEARCH_LIMIT" && complete=true
+	local projection=""
+	projection=$(_snapshot_projection "$_KIND_PRS") || return 1
+	local tmp_file=""
+	tmp_file=$(mktemp "${BATCH_CACHE_DIR}/.prs-snapshot.XXXXXX") || return 1
+	echo "$rest_json" | jq --arg ts "$ts" --arg schema "$_SNAPSHOT_SCHEMA" \
+		--arg slug "$slug" --arg collection "$_KIND_PRS" --arg projection "$projection" \
+		--arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" --arg generation "$_BATCH_SNAPSHOT_GENERATION" \
+		--argjson complete "$complete" '{
+		schema: $schema,
+		repository: $slug,
+		collection: $collection,
+		projection: $projection,
+		auth_scope: $auth_scope,
+		generation: $generation,
+		source: "rest-fallback",
+		complete: $complete,
+		truncated: ($complete | not),
+		fetched_at: $ts,
 		timestamp: $ts,
 		items: [.[] | {
 			number: .number,
@@ -219,9 +287,12 @@ _prefetch_rest_prs_for_slug() {
 			updatedAt: .updated_at,
 			assignees: (.assignees // []),
 			createdAt: (.created_at // null),
-			author: (if .user then {login: .user.login} else null end)
+			author: (if .user then {login: .user.login} else null end),
+			headRefOid: (.head.sha // null),
+			headRefName: (.head.ref // null)
 		}]
-	}' >"$cache_file" 2>/dev/null || {
+	}' >"$tmp_file" 2>/dev/null && mv "$tmp_file" "$cache_file" || {
+		rm -f "$tmp_file"
 		_log "REST PRs fallback: failed to write cache for ${slug}"
 		return 1
 	}
@@ -335,7 +406,9 @@ _normalize_search_to_prefetch_schema() {
 					updatedAt: .updatedAt,
 					assignees: (.assignees // []),
 					createdAt: (.createdAt // null),
-					author: (.author // null)
+					author: (.author // null),
+					headRefOid: (.headRefOid // null),
+					headRefName: (.headRefName // null)
 				}]
 			}) |
 			from_entries
@@ -373,7 +446,11 @@ _conditional_rest_update_cache_from_response() {
 	local cache_file="$4"
 	# Keep response parsing in Python so this shell library stays below the
 	# function-complexity gate while preserving atomic cache writes.
-	python3 "${SCRIPT_DIR}/pulse-batch-conditional-cache.py" "$kind" "$slug" "$response_file" "$cache_file"
+	local projection=""
+	projection=$(_snapshot_projection "$kind") || return 1
+	python3 "${SCRIPT_DIR}/pulse-batch-conditional-cache.py" \
+		"$kind" "$slug" "$response_file" "$cache_file" \
+		"$_BATCH_SNAPSHOT_GENERATION" "$_BATCH_SNAPSHOT_AUTH_SCOPE" "$projection"
 	return 0
 }
 
@@ -385,9 +462,15 @@ _conditional_rest_refresh_slug() {
 	cache_file=$(_cache_file_path "$kind" "$slug")
 	local endpoint
 	endpoint=$(_conditional_rest_endpoint "$kind" "$slug") || return 1
+	local projection=""
+	projection=$(_snapshot_projection "$kind") || return 1
 	local etag=""
 	if [[ -f "$cache_file" ]]; then
-		etag=$(jq -r '.etag // ""' "$cache_file" 2>/dev/null) || etag=""
+		etag=$(jq -r --arg schema "$_SNAPSHOT_SCHEMA" --arg kind "$kind" \
+			--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" '
+			select(.schema == $schema and .collection == $kind and .projection == $projection) |
+			select(.auth_scope == $auth_scope and .complete == true) | .etag // ""
+		' "$cache_file" 2>/dev/null) || etag=""
 		[[ "$etag" == "$_JSON_NULL" ]] && etag=""
 	fi
 	[[ -n "$etag" ]] || _OWNER_CONDITIONAL_MISSES=$((_OWNER_CONDITIONAL_MISSES + 1))
@@ -444,6 +527,8 @@ _write_per_slug_caches() {
 
 	local slugs
 	slugs=$(echo "$normalized_json" | jq -r 'keys[]' 2>/dev/null) || return 1
+	local projection=""
+	projection=$(_snapshot_projection "$kind") || return 1
 
 	local slug
 	while IFS= read -r slug; do
@@ -452,10 +537,26 @@ _write_per_slug_caches() {
 		cache_file=$(_cache_file_path "$kind" "$slug")
 		local ts
 		ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-		echo "$normalized_json" | jq --arg slug "$slug" --arg ts "$ts" '{
+		local tmp_file=""
+		tmp_file=$(mktemp "${BATCH_CACHE_DIR}/.search-snapshot.XXXXXX") || continue
+		echo "$normalized_json" | jq --arg slug "$slug" --arg ts "$ts" \
+			--arg schema "$_SNAPSHOT_SCHEMA" --arg collection "$kind" \
+			--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" \
+			--arg generation "$_BATCH_SNAPSHOT_GENERATION" '{
+			schema: $schema,
+			repository: $slug,
+			collection: $collection,
+			projection: $projection,
+			auth_scope: $auth_scope,
+			generation: $generation,
+			source: "owner-search",
+			complete: false,
+			truncated: true,
+			fetched_at: $ts,
 			timestamp: $ts,
 			items: .[$slug]
-		}' >"$cache_file" 2>/dev/null || {
+		}' >"$tmp_file" 2>/dev/null && mv "$tmp_file" "$cache_file" || {
+			rm -f "$tmp_file"
 			_log "WARNING: failed to write cache for ${kind}/${slug}"
 		}
 	done <<<"$slugs"
@@ -654,6 +755,7 @@ _cmd_refresh() {
 	}
 
 	mkdir -p "$BATCH_CACHE_DIR" 2>/dev/null || true
+	_BATCH_SNAPSHOT_GENERATION="$(date -u +%Y%m%dT%H%M%SZ)-$$"
 
 	local owner_groups
 	owner_groups=$(_group_repos_by_owner "$REPOS_JSON") || {
@@ -915,6 +1017,81 @@ _cmd_read_cache() {
 }
 
 # =============================================================================
+# Subcommand: read-snapshot
+# Read a versioned canonical envelope. Legacy caches remain valid for read-cache
+# but cannot authorize state-fingerprint hits through this stricter interface.
+# =============================================================================
+_cmd_read_snapshot() {
+	local kind="" slug=""
+	local _args=("$@")
+	local _i=0
+	while [[ $_i -lt ${#_args[@]} ]]; do
+		case "${_args[$_i]}" in
+		--kind)
+			kind="${_args[$_i+1]:-}"
+			_i=$((_i + 2))
+			;;
+		--slug)
+			slug="${_args[$_i+1]:-}"
+			_i=$((_i + 2))
+			;;
+		*) _i=$((_i + 1)) ;;
+		esac
+	done
+
+	local projection=""
+	projection=$(_snapshot_projection "$kind") || {
+		echo "Usage: pulse-batch-prefetch-helper.sh read-snapshot --kind issues|prs --slug owner/repo" >&2
+		return 1
+	}
+	[[ -n "$slug" ]] || {
+		echo "Usage: pulse-batch-prefetch-helper.sh read-snapshot --kind issues|prs --slug owner/repo" >&2
+		return 1
+	}
+
+	if ! _resolve_cache_snapshot "$kind" "$slug"; then
+		_emit_cache_state "$_CACHE_SNAPSHOT_STATE" "$kind" "$slug"
+		return 1
+	fi
+
+	local envelope=""
+	envelope=$(jq -ce \
+		--arg schema "$_SNAPSHOT_SCHEMA" --arg slug "$slug" --arg kind "$kind" \
+		--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" '
+		select(.schema == $schema and .repository == $slug and .collection == $kind) |
+		select(.projection == $projection and .auth_scope == $auth_scope) |
+		select((.generation | type) == "string" and (.generation | length) > 0) |
+		select((.source | type) == "string" and (.source | length) > 0) |
+		select((.fetched_at | type) == "string" and (.fetched_at | length) > 0) |
+		select((.complete | type) == "boolean" and (.items | type) == "array") |
+		if $kind == "issues" then
+			select(all(.items[];
+				(.number | type) == "number" and has("title") and
+				(.state | type) == "string" and (.labels | type) == "array" and
+				has("updatedAt") and (.assignees | type) == "array")) |
+			.items = [.items[] | select((.state | ascii_downcase) == "open")]
+		else
+			select(all(.items[];
+				(.number | type) == "number" and has("title") and
+				(.labels | type) == "array" and has("updatedAt") and
+				(.assignees | type) == "array" and has("createdAt") and
+				has("author") and (.headRefOid | type) == "string" and
+				(.headRefOid | length) > 0 and has("headRefName")))
+		end
+	' "$_CACHE_SNAPSHOT_PATH" 2>/dev/null) || {
+		_CACHE_SNAPSHOT_STATE="incompatible"
+		_emit_cache_state "$_CACHE_SNAPSHOT_STATE" "$kind" "$slug"
+		return 1
+	}
+
+	local cardinality="nonempty"
+	[[ "$(printf '%s' "$envelope" | jq -c '.items')" == "$_JSON_EMPTY_ARR" ]] && cardinality="empty"
+	_emit_cache_state "$_CACHE_SNAPSHOT_STATE" "$kind" "$slug" "$cardinality"
+	printf '%s\n' "$envelope"
+	return 0
+}
+
+# =============================================================================
 # Subcommand: evict-issue
 # Remove a single issue from the normalized owner/repo issues cache.
 # Arguments: owner/repo issue_number
@@ -937,8 +1114,14 @@ _cmd_evict_issue() {
 	fi
 
 	local tmp_file
-	tmp_file=$(mktemp)
-	if jq --argjson issue_number "$issue_number" '(.items // []) as $items | .items = [$items[] | select((.number // 0) != $issue_number)]' "$cache_file" >"$tmp_file" 2>/dev/null; then
+	tmp_file=$(mktemp "${BATCH_CACHE_DIR}/.evict-snapshot.XXXXXX") || return 1
+	if jq --argjson issue_number "$issue_number" '
+		(.items // []) as $items |
+		.items = [$items[] | select((.number // 0) != $issue_number)] |
+		.complete = false |
+		.truncated = true |
+		.source = "local-eviction"
+	' "$cache_file" >"$tmp_file" 2>/dev/null; then
 		mv "$tmp_file" "$cache_file"
 		_log "evicted issue #${issue_number} from issues cache for ${slug}"
 		return 0
@@ -1036,6 +1219,9 @@ main() {
 	read-cache)
 		_cmd_read_cache "$@"
 		;;
+	read-snapshot)
+		_cmd_read_snapshot "$@"
+		;;
 	evict-issue)
 		_cmd_evict_issue "$@"
 		;;
@@ -1052,6 +1238,7 @@ main() {
 		echo "  refresh                          Fetch all repos via org-level search and cache"
 		echo "  cache-path --kind K --slug S     Return cache path if fresh, exit 1 if stale"
 		echo "  read-cache --kind K --slug S     Read cached items as JSON array"
+		echo "  read-snapshot --kind K --slug S  Read a canonical snapshot envelope"
 		echo "  evict-issue owner/repo N         Remove one issue from the issues cache"
 		echo "  clear                            Wipe batch cache directory"
 		echo "  status                           Show cache file ages and counts"

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -168,13 +168,14 @@ _prefetch_prs_format_output() {
 			(.number | tostring) as $num |
 			($check_map[$num] // "unknown") as $cs |
 			"- PR #\(.number): \(.title) [checks: \($cs)] [review: \(
-				if .reviewDecision == null or .reviewDecision == "" then "NONE"
+				if has("reviewDecision") | not then "UNKNOWN"
+				elif .reviewDecision == null or .reviewDecision == "" then "NONE"
 				else .reviewDecision
 				end
-			)] [author: \(.author.login // "unknown")] [branch: \(.headRefName)] [updated: \(.updatedAt)]"
+			)] [author: \(.author.login // "unknown")] [branch: \(.headRefName // "unknown")] [updated: \(.updatedAt)]"
 		'
 	else
-		echo "$pr_json" | jq -r '.[] | "- PR #\(.number): \(.title) [checks: unknown] [review: \(if .reviewDecision == null or .reviewDecision == "" then "NONE" else .reviewDecision end)] [author: \(.author.login // "unknown")] [branch: \(.headRefName)] [updated: \(.updatedAt)]"'
+		echo "$pr_json" | jq -r '.[] | "- PR #\(.number): \(.title) [checks: unknown] [review: \(if has("reviewDecision") | not then "UNKNOWN" elif .reviewDecision == null or .reviewDecision == "" then "NONE" else .reviewDecision end)] [author: \(.author.login // "unknown")] [branch: \(.headRefName // "unknown")] [updated: \(.updatedAt)]"'
 	fi
 	return 0
 }
@@ -213,6 +214,9 @@ _prefetch_repo_prs() {
 	local cache_entry="${2:-}"
 	[[ -n "$cache_entry" ]] || cache_entry="{}"
 	local sweep_mode="${3:-full}"
+	local canonical_snapshot="${4:-}"
+	local canonical_snapshot_supplied=false
+	[[ "$#" -ge 4 ]] && canonical_snapshot_supplied=true
 
 	# PRs (createdAt included for daily PR cap — GH#3821)
 	# GH#15060: statusCheckRollup is the heaviest field in the GraphQL payload —
@@ -235,7 +239,16 @@ _prefetch_repo_prs() {
 	# Execution order: idle skip (L2, handled by caller) → batch cache (L3) → delta/full (L4/L5)
 	local _batch_helper="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
 	local _used_batch_cache=false
-	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
+	if [[ "$canonical_snapshot_supplied" == "true" ]]; then
+		local _canonical_prs=""
+		if _canonical_prs=$(printf '%s' "$canonical_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
+			pr_json="$_canonical_prs"
+			_used_batch_cache=true
+			echo "[pulse-wrapper] _prefetch_repo_prs: using cycle canonical snapshot for ${slug}" >>"$LOGFILE"
+			_prefetch_record_batch_cache_hit prs "$_canonical_prs"
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
+		fi
+	elif [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
 		local _batch_prs
 		if _batch_prs=$("$_batch_helper" read-cache --kind prs --slug "$slug" 2>>"$LOGFILE"); then
 			pr_json="$_batch_prs"
@@ -355,6 +368,9 @@ _prefetch_repo_issues() {
 	local cache_entry="${2:-}"
 	[[ -n "$cache_entry" ]] || cache_entry="{}"
 	local sweep_mode="${3:-full}"
+	local canonical_snapshot="${4:-}"
+	local canonical_snapshot_supplied=false
+	[[ "$#" -ge 4 ]] && canonical_snapshot_supplied=true
 
 	# Issues (include assignees for dispatch dedup)
 	# Filter out supervisor/contributor/persistent/quality-review issues —
@@ -370,7 +386,16 @@ _prefetch_repo_issues() {
 	# Execution order: idle skip (L2, handled by caller) → batch cache (L3) → delta/full (L4/L5)
 	local _batch_helper="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
 	local _used_batch_cache=false
-	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
+	if [[ "$canonical_snapshot_supplied" == "true" ]]; then
+		local _canonical_issues=""
+		if _canonical_issues=$(printf '%s' "$canonical_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
+			issue_json="$_canonical_issues"
+			_used_batch_cache=true
+			echo "[pulse-wrapper] _prefetch_repo_issues: using cycle canonical snapshot for ${slug}" >>"$LOGFILE"
+			_prefetch_record_batch_cache_hit issues "$_canonical_issues"
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
+		fi
+	elif [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
 		local _batch_issues
 		if _batch_issues=$("$_batch_helper" read-cache --kind issues --slug "$slug" 2>>"$LOGFILE"); then
 			issue_json="$_batch_issues"

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -46,6 +46,10 @@ fi
 # =============================================================================
 
 _PREFETCH_PR_SWEEP_FULL=full
+_PREFETCH_BOOL_TRUE=true
+_PREFETCH_JSON_NULL=null
+_PREFETCH_UNKNOWN=unknown
+_PREFETCH_UNKNOWN_ERROR="unknown error"
 
 #######################################
 # Attempt delta PR fetch and merge into cached list (GH#15286).
@@ -75,7 +79,7 @@ _prefetch_prs_try_delta() {
 		--search "updated:>=${last_prefetch}" \
 		--limit "$PULSE_PREFETCH_PR_LIMIT" 2>"$pr_err") || delta_json=""
 
-	if [[ -z "$delta_json" || "$delta_json" == "null" ]]; then
+	if [[ -z "$delta_json" || "$delta_json" == "$_PREFETCH_JSON_NULL" ]]; then
 		local _delta_err_msg
 		_delta_err_msg=$(cat "$pr_err" 2>/dev/null || echo "no timestamp or fetch error")
 		echo "[pulse-wrapper] _prefetch_repo_prs: delta fetch failed for ${slug} (falling back to full): ${_delta_err_msg}" >>"$LOGFILE"
@@ -93,7 +97,7 @@ _prefetch_prs_try_delta() {
 		$delta
 	' 2>/dev/null) || merged=""
 
-	if [[ -z "$merged" || "$merged" == "null" ]]; then
+	if [[ -z "$merged" || "$merged" == "$_PREFETCH_JSON_NULL" ]]; then
 		echo "[pulse-wrapper] _prefetch_repo_prs: delta merge failed for ${slug} (falling back to full)" >>"$LOGFILE"
 		PREFETCH_PR_SWEEP_MODE="$_PREFETCH_PR_SWEEP_FULL"
 		return 0
@@ -124,7 +128,7 @@ _prefetch_prs_enrich_checks() {
 	local slug="$1"
 	local pr_json="$2"
 
-	if [[ -z "$pr_json" || "$pr_json" == "[]" || "$pr_json" == "null" ]]; then
+	if [[ -z "$pr_json" || "$pr_json" == "[]" || "$pr_json" == "$_PREFETCH_JSON_NULL" ]]; then
 		printf '[]'
 		return 0
 	fi
@@ -132,7 +136,7 @@ _prefetch_prs_enrich_checks() {
 	local checks_json=""
 	checks_json=$(gh_pr_check_status_rest_batch "$slug" "$pr_json" 2>/dev/null) || checks_json=""
 
-	if [[ -z "$checks_json" || "$checks_json" == "null" ]]; then
+	if [[ -z "$checks_json" || "$checks_json" == "$_PREFETCH_JSON_NULL" ]]; then
 		echo "[pulse-wrapper] _prefetch_repo_prs: REST check-suites enrichment FAILED for ${slug} (non-fatal, PRs shown without check status)" >>"$LOGFILE"
 		checks_json="[]"
 	fi
@@ -162,20 +166,20 @@ _prefetch_prs_format_output() {
 		# GH#21799: checks_json now contains pre-computed status strings
 		# from REST check-suites (~15KB total vs ~245KB GraphQL rollup).
 		# Stdin keeps the path that handles large pr_json safely.
-		echo "$checks_json" | jq -r --argjson prs "$pr_json" '
+		echo "$checks_json" | jq -r --argjson prs "$pr_json" --arg unknown "$_PREFETCH_UNKNOWN" '
 			(. | map({(.number | tostring): .status}) | add // {}) as $check_map |
 			$prs[] |
 			(.number | tostring) as $num |
-			($check_map[$num] // "unknown") as $cs |
+			($check_map[$num] // $unknown) as $cs |
 			"- PR #\(.number): \(.title) [checks: \($cs)] [review: \(
 				if has("reviewDecision") | not then "UNKNOWN"
 				elif .reviewDecision == null or .reviewDecision == "" then "NONE"
 				else .reviewDecision
 				end
-			)] [author: \(.author.login // "unknown")] [branch: \(.headRefName // "unknown")] [updated: \(.updatedAt)]"
+			)] [author: \(.author.login // $unknown)] [branch: \(.headRefName // $unknown)] [updated: \(.updatedAt)]"
 		'
 	else
-		echo "$pr_json" | jq -r '.[] | "- PR #\(.number): \(.title) [checks: unknown] [review: \(if has("reviewDecision") | not then "UNKNOWN" elif .reviewDecision == null or .reviewDecision == "" then "NONE" else .reviewDecision end)] [author: \(.author.login // "unknown")] [branch: \(.headRefName // "unknown")] [updated: \(.updatedAt)]"'
+		echo "$pr_json" | jq -r --arg unknown "$_PREFETCH_UNKNOWN" '.[] | "- PR #\(.number): \(.title) [checks: \($unknown)] [review: \(if has("reviewDecision") | not then "UNKNOWN" elif .reviewDecision == null or .reviewDecision == "" then "NONE" else .reviewDecision end)] [author: \(.author.login // $unknown)] [branch: \(.headRefName // $unknown)] [updated: \(.updatedAt)]"'
 	fi
 	return 0
 }
@@ -239,7 +243,7 @@ _prefetch_repo_prs() {
 	# Execution order: idle skip (L2, handled by caller) → batch cache (L3) → delta/full (L4/L5)
 	local _batch_helper="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
 	local _used_batch_cache=false
-	if [[ "$canonical_snapshot_supplied" == "true" ]]; then
+	if [[ "$canonical_snapshot_supplied" == "$_PREFETCH_BOOL_TRUE" ]]; then
 		local _canonical_prs=""
 		if _canonical_prs=$(printf '%s' "$canonical_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
 			pr_json="$_canonical_prs"
@@ -276,9 +280,9 @@ _prefetch_repo_prs() {
 				--json number,title,reviewDecision,updatedAt,headRefName,headRefOid,createdAt,author \
 				--limit "$PULSE_PREFETCH_PR_LIMIT" 2>"$pr_err") || pr_json=""
 
-			if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
+			if [[ -z "$pr_json" || "$pr_json" == "$_PREFETCH_JSON_NULL" ]]; then
 				local err_msg
-				err_msg=$(cat "$pr_err" 2>/dev/null || echo "unknown error")
+				err_msg=$(cat "$pr_err" 2>/dev/null || echo "$_PREFETCH_UNKNOWN_ERROR")
 				# GH#18979 (t2097): classify rate-limit errors and flag the cycle
 				if _pulse_gh_err_is_rate_limit "$pr_err"; then
 					_pulse_mark_rate_limited "_prefetch_repo_prs:${slug}"
@@ -330,9 +334,9 @@ _prefetch_repo_daily_cap() {
 	daily_cap_err=$(mktemp)
 	daily_cap_json=$(gh_pr_list --repo "$slug" --state all \
 		--json createdAt --limit 200 2>"$daily_cap_err") || daily_cap_json="[]"
-	if [[ -z "$daily_cap_json" || "$daily_cap_json" == "null" ]]; then
+	if [[ -z "$daily_cap_json" || "$daily_cap_json" == "$_PREFETCH_JSON_NULL" ]]; then
 		local _daily_cap_err_msg
-		_daily_cap_err_msg=$(cat "$daily_cap_err" 2>/dev/null || echo "unknown error")
+		_daily_cap_err_msg=$(cat "$daily_cap_err" 2>/dev/null || echo "$_PREFETCH_UNKNOWN_ERROR")
 		# GH#18979 (t2097): detect rate-limit exhaustion
 		if _pulse_gh_err_is_rate_limit "$daily_cap_err"; then
 			_pulse_mark_rate_limited "_prefetch_repo_daily_cap:${slug}"
@@ -363,80 +367,12 @@ _prefetch_repo_daily_cap() {
 	return 0
 }
 
-_prefetch_repo_issues() {
-	local slug="$1"
-	local cache_entry="${2:-}"
-	[[ -n "$cache_entry" ]] || cache_entry="{}"
-	local sweep_mode="${3:-full}"
-	local canonical_snapshot="${4:-}"
-	local canonical_snapshot_supplied=false
-	[[ "$#" -ge 4 ]] && canonical_snapshot_supplied=true
-
-	# Issues (include assignees for dispatch dedup)
-	# Filter out supervisor/contributor/persistent/quality-review issues —
-	# these are managed by pulse-wrapper.sh and must not be touched by the
-	# pulse agent. Exposing them in pre-fetched state causes the LLM to
-	# close them as "stale", creating churn (wrapper recreates on next cycle).
-	# GH#15060: Log errors instead of silently swallowing them with 2>/dev/null.
-	# GH#15286: Delta mode — fetch only recently-updated issues, merge into cache.
-	local issue_json="" issue_err
-	issue_err=$(mktemp)
-
-	# GH#19963 L3: Check batch prefetch cache before per-repo API calls.
-	# Execution order: idle skip (L2, handled by caller) → batch cache (L3) → delta/full (L4/L5)
-	local _batch_helper="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
-	local _used_batch_cache=false
-	if [[ "$canonical_snapshot_supplied" == "true" ]]; then
-		local _canonical_issues=""
-		if _canonical_issues=$(printf '%s' "$canonical_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
-			issue_json="$_canonical_issues"
-			_used_batch_cache=true
-			echo "[pulse-wrapper] _prefetch_repo_issues: using cycle canonical snapshot for ${slug}" >>"$LOGFILE"
-			_prefetch_record_batch_cache_hit issues "$_canonical_issues"
-			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
-		fi
-	elif [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
-		local _batch_issues
-		if _batch_issues=$("$_batch_helper" read-cache --kind issues --slug "$slug" 2>>"$LOGFILE"); then
-			issue_json="$_batch_issues"
-			_used_batch_cache=true
-			echo "[pulse-wrapper] _prefetch_repo_issues: using batch cache for ${slug}" >>"$LOGFILE"
-			_prefetch_record_batch_cache_hit issues "$_batch_issues"
-			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
-		fi
-	fi
-
-	if [[ "$_used_batch_cache" == "false" ]]; then
-		# Delta fetch: try merging recent changes into cache (GH#15286)
-		PREFETCH_ISSUE_SWEEP_MODE="$sweep_mode"
-		PREFETCH_ISSUE_RESULT=""
-		if [[ "$sweep_mode" == "delta" ]]; then
-			_prefetch_issues_try_delta "$slug" "$cache_entry" "$issue_err"
-			sweep_mode="$PREFETCH_ISSUE_SWEEP_MODE"
-			issue_json="$PREFETCH_ISSUE_RESULT"
-		fi
-
-		# Full fetch: either requested directly or delta fell back
-		if [[ "$sweep_mode" == "full" ]]; then
-		issue_json=$(gh_issue_list --repo "$slug" --state open \
-			--json number,title,state,labels,updatedAt,assignees,body \
-			--limit "$PULSE_PREFETCH_ISSUE_LIMIT" 2>"$issue_err") || issue_json=""
-
-			if [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
-				local issue_err_msg
-				issue_err_msg=$(cat "$issue_err" 2>/dev/null || echo "unknown error")
-				# GH#18979 (t2097): detect rate-limit exhaustion
-				if _pulse_gh_err_is_rate_limit "$issue_err"; then
-					_pulse_mark_rate_limited "_prefetch_repo_issues:${slug}"
-				fi
-				echo "[pulse-wrapper] _prefetch_repo_issues: gh_issue_list FAILED for ${slug}: ${issue_err_msg}" >>"$LOGFILE"
-				_prefetch_log_batch_cache_state fetch-failed issues "$slug"
-				issue_json="[]"
-			fi
-		fi
-	fi
-	rm -f "$issue_err"
-	issue_json=$(echo "$issue_json" | _prefetch_open_issues_only)
+#######################################
+# Render normalized issues and export them for the cache-update path.
+# Arguments: $1=issue JSON array
+#######################################
+_prefetch_repo_issues_render() {
+	local issue_json="$1"
 
 	# Export updated issue list for cache update by caller (Bash 3.2: no namerefs)
 	PREFETCH_UPDATED_ISSUES="$issue_json"
@@ -473,6 +409,84 @@ _prefetch_repo_issues() {
 		echo "$sweep_tracked_json" | jq -r '.[] | "- Issue #\(.number): \(.title) [labels: \(if (.labels | length) == 0 then "none" else (.labels | map(.name) | join(", ")) end)] [assignees: \(if (.assignees | length) == 0 then "none" else (.assignees | map(.login) | join(", ")) end)]"'
 		echo ""
 	fi
+	return 0
+}
+
+_prefetch_repo_issues() {
+	local slug="$1"
+	local cache_entry="${2:-}"
+	[[ -n "$cache_entry" ]] || cache_entry="{}"
+	local sweep_mode="${3:-full}"
+	local canonical_snapshot="${4:-}"
+	local canonical_snapshot_supplied=false
+	[[ "$#" -ge 4 ]] && canonical_snapshot_supplied=true
+
+	# Issues (include assignees for dispatch dedup)
+	# Filter out supervisor/contributor/persistent/quality-review issues —
+	# these are managed by pulse-wrapper.sh and must not be touched by the
+	# pulse agent. Exposing them in pre-fetched state causes the LLM to
+	# close them as "stale", creating churn (wrapper recreates on next cycle).
+	# GH#15060: Log errors instead of silently swallowing them with 2>/dev/null.
+	# GH#15286: Delta mode — fetch only recently-updated issues, merge into cache.
+	local issue_json="" issue_err
+	issue_err=$(mktemp)
+
+	# GH#19963 L3: Check batch prefetch cache before per-repo API calls.
+	# Execution order: idle skip (L2, handled by caller) → batch cache (L3) → delta/full (L4/L5)
+	local _batch_helper="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
+	local _used_batch_cache=false
+	if [[ "$canonical_snapshot_supplied" == "$_PREFETCH_BOOL_TRUE" ]]; then
+		local _canonical_issues=""
+		if _canonical_issues=$(printf '%s' "$canonical_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
+			issue_json="$_canonical_issues"
+			_used_batch_cache=true
+			echo "[pulse-wrapper] _prefetch_repo_issues: using cycle canonical snapshot for ${slug}" >>"$LOGFILE"
+			_prefetch_record_batch_cache_hit issues "$_canonical_issues"
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
+		fi
+	elif [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
+		local _batch_issues
+		if _batch_issues=$("$_batch_helper" read-cache --kind issues --slug "$slug" 2>>"$LOGFILE"); then
+			issue_json="$_batch_issues"
+			_used_batch_cache=true
+			echo "[pulse-wrapper] _prefetch_repo_issues: using batch cache for ${slug}" >>"$LOGFILE"
+			_prefetch_record_batch_cache_hit issues "$_batch_issues"
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
+		fi
+	fi
+
+	if [[ "$_used_batch_cache" == "false" ]]; then
+		# Delta fetch: try merging recent changes into cache (GH#15286)
+		PREFETCH_ISSUE_SWEEP_MODE="$sweep_mode"
+		PREFETCH_ISSUE_RESULT=""
+		if [[ "$sweep_mode" == "delta" ]]; then
+			_prefetch_issues_try_delta "$slug" "$cache_entry" "$issue_err"
+			sweep_mode="$PREFETCH_ISSUE_SWEEP_MODE"
+			issue_json="$PREFETCH_ISSUE_RESULT"
+		fi
+
+		# Full fetch: either requested directly or delta fell back
+		if [[ "$sweep_mode" == "full" ]]; then
+			issue_json=$(gh_issue_list --repo "$slug" --state open \
+				--json number,title,state,labels,updatedAt,assignees,body \
+				--limit "$PULSE_PREFETCH_ISSUE_LIMIT" 2>"$issue_err") || issue_json=""
+
+			if [[ -z "$issue_json" || "$issue_json" == "$_PREFETCH_JSON_NULL" ]]; then
+				local issue_err_msg
+				issue_err_msg=$(cat "$issue_err" 2>/dev/null || echo "$_PREFETCH_UNKNOWN_ERROR")
+				# GH#18979 (t2097): detect rate-limit exhaustion
+				if _pulse_gh_err_is_rate_limit "$issue_err"; then
+					_pulse_mark_rate_limited "_prefetch_repo_issues:${slug}"
+				fi
+				echo "[pulse-wrapper] _prefetch_repo_issues: gh_issue_list FAILED for ${slug}: ${issue_err_msg}" >>"$LOGFILE"
+				_prefetch_log_batch_cache_state fetch-failed issues "$slug"
+				issue_json="[]"
+			fi
+		fi
+	fi
+	rm -f "$issue_err"
+	issue_json=$(echo "$issue_json" | _prefetch_open_issues_only)
+	_prefetch_repo_issues_render "$issue_json"
 	return 0
 }
 
@@ -525,7 +539,7 @@ _prefetch_issues_try_delta() {
 		--search "updated:>=${last_prefetch}" \
 		--limit "$PULSE_PREFETCH_ISSUE_LIMIT" 2>"$issue_err") || delta_json=""
 
-	if [[ -z "$delta_json" || "$delta_json" == "null" ]]; then
+	if [[ -z "$delta_json" || "$delta_json" == "$_PREFETCH_JSON_NULL" ]]; then
 		local _delta_issue_err
 		_delta_issue_err=$(cat "$issue_err" 2>/dev/null || echo "no timestamp or fetch error")
 		echo "[pulse-wrapper] _prefetch_repo_issues: delta fetch failed for ${slug} (falling back to full): ${_delta_issue_err}" >>"$LOGFILE"

--- a/.agents/scripts/pulse-prefetch-infra.sh
+++ b/.agents/scripts/pulse-prefetch-infra.sh
@@ -16,8 +16,7 @@
 #   - Environment vars: PULSE_RATE_LIMIT_FLAG, LOGFILE, PULSE_PREFETCH_CACHE_FILE,
 #     PULSE_PREFETCH_FULL_SWEEP_INTERVAL, PULSE_QUEUED_SCAN_LIMIT,
 #     PULSE_SWEEP_TOKEN_BUDGET, PULSE_SWEEP_MAX_EVENTS_PER_PASS,
-#     PULSE_SWEEP_DEFERRAL_PROMOTION_THRESHOLD, PULSE_SWEEP_VERIFICATION_QUERY_LIMIT,
-#     PULSE_SWEEP_CACHE_HIT_ENABLED
+#     PULSE_SWEEP_DEFERRAL_PROMOTION_THRESHOLD, PULSE_SWEEP_CACHE_HIT_ENABLED
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -170,8 +169,12 @@ _prefetch_cached_label_count_is_zero() {
 : "${PULSE_SWEEP_TOKEN_BUDGET:=3000}"
 : "${PULSE_SWEEP_MAX_EVENTS_PER_PASS:=50}"
 : "${PULSE_SWEEP_DEFERRAL_PROMOTION_THRESHOLD:=3}"
-: "${PULSE_SWEEP_VERIFICATION_QUERY_LIMIT:=5}"
 : "${PULSE_SWEEP_CACHE_HIT_ENABLED:=true}"
+
+_PREFETCH_SNAPSHOT_SCHEMA="aidevops-pulse-snapshot/v1"
+_PREFETCH_ISSUES_PROJECTION="number,title,state,labels,updatedAt,assignees"
+_PREFETCH_PRS_PROJECTION="number,title,labels,updatedAt,assignees,createdAt,author,headRefOid,headRefName"
+_PREFETCH_FINGERPRINT_SCHEMA="canonical-snapshot-v1"
 
 # Load the budget config once per process. Called lazily from the t2041
 # helpers. Reads `.agents/configs/pulse-sweep-budget.json` relative to
@@ -199,8 +202,6 @@ _load_pulse_sweep_budget_config() {
 	[[ "$_v" =~ ^[0-9]+$ ]] && PULSE_SWEEP_MAX_EVENTS_PER_PASS="$_v"
 	_v=$(jq -r '.default.deferral_promotion_threshold // empty' "$config_file" 2>/dev/null)
 	[[ "$_v" =~ ^[0-9]+$ ]] && PULSE_SWEEP_DEFERRAL_PROMOTION_THRESHOLD="$_v"
-	_v=$(jq -r '.default.verification_query_limit // empty' "$config_file" 2>/dev/null)
-	[[ "$_v" =~ ^[0-9]+$ ]] && PULSE_SWEEP_VERIFICATION_QUERY_LIMIT="$_v"
 	_v=$(jq -r '.default.state_fingerprint_cache_hit_enabled // empty' "$config_file" 2>/dev/null)
 	[[ "$_v" == "true" || "$_v" == "false" ]] && PULSE_SWEEP_CACHE_HIT_ENABLED="$_v"
 
@@ -208,58 +209,79 @@ _load_pulse_sweep_budget_config() {
 }
 
 #######################################
-# t2041 Layer 1: Compute a short deterministic fingerprint of a repo's
-# LLM-observable state.
+# Return 0 only when two canonical collection snapshots form one complete,
+# projection-compatible repository generation.
+# Arguments: $1=slug, $2=issue snapshot envelope, $3=PR snapshot envelope
+#######################################
+_canonical_snapshot_pair_complete() {
+	local slug="$1"
+	local issues_snapshot="$2"
+	local prs_snapshot="$3"
+	[[ -n "$slug" && -n "$issues_snapshot" && -n "$prs_snapshot" ]] || return 1
+
+	local issues_identity="" prs_identity=""
+	issues_identity=$(printf '%s' "$issues_snapshot" | jq -er \
+		--arg schema "$_PREFETCH_SNAPSHOT_SCHEMA" --arg slug "$slug" \
+		--arg projection "$_PREFETCH_ISSUES_PROJECTION" '
+		select(.schema == $schema and .repository == $slug and .collection == "issues") |
+		select(.projection == $projection and .complete == true and (.items | type) == "array") |
+		select(all(.items[];
+			(.number | type) == "number" and (.state | type) == "string" and
+			(.labels | type) == "array" and (.assignees | type) == "array" and has("updatedAt"))) |
+		select((.source | type) == "string" and (.fetched_at | type) == "string") |
+		[.generation, .auth_scope] | select(all(.[]; type == "string" and length > 0)) | @tsv
+	' 2>/dev/null) || return 1
+	prs_identity=$(printf '%s' "$prs_snapshot" | jq -er \
+		--arg schema "$_PREFETCH_SNAPSHOT_SCHEMA" --arg slug "$slug" \
+		--arg projection "$_PREFETCH_PRS_PROJECTION" '
+		select(.schema == $schema and .repository == $slug and .collection == "prs") |
+		select(.projection == $projection and .complete == true and (.items | type) == "array") |
+		select(all(.items[];
+			(.number | type) == "number" and (.labels | type) == "array" and
+			(.assignees | type) == "array" and has("updatedAt") and
+			(.headRefOid | type) == "string" and (.headRefOid | length) > 0)) |
+		select((.source | type) == "string" and (.fetched_at | type) == "string") |
+		[.generation, .auth_scope] | select(all(.[]; type == "string" and length > 0)) | @tsv
+	' 2>/dev/null) || return 1
+	if [[ "$issues_identity" == "$prs_identity" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Compute a short deterministic fingerprint from one canonical snapshot pair.
 #
 # The fingerprint is a SHA-256 of the canonicalized set of:
 #   - issues: (number, labels_sorted, assignees_sorted, updatedAt)
-#   - PRs:    (number, labels_sorted, assignees_sorted, reviewDecision,
-#              mergeable, updatedAt)
-# across all open issues and PRs. PR state must be in the fingerprint so
-# PR churn (review rotation, CI status change, labels) invalidates the
-# cache — if PRs were excluded, the cache would say "clean" even when
-# a PR was ready to merge (CodeRabbit review on PR #18546).
+#   - PRs:    (number, labels_sorted, assignees_sorted, updatedAt, headRefOid)
+# across all open issues and PRs. GraphQL-only projections remain on the exact
+# PR-list provider; this normalized fingerprint never fabricates those fields.
+# Final dispatch and merge authority remains live and fail-closed.
 #
 # Arguments:
 #   $1 - repo slug (owner/repo)
+#   $2 - canonical issue snapshot envelope
+#   $3 - canonical PR snapshot envelope
 # Outputs:
 #   16-char hex fingerprint on stdout, empty string on error
-# Returns: 0 always (fail-open)
+# Returns: 0 always (empty forces the full-analysis path)
 #######################################
 _compute_repo_state_fingerprint() {
 	local slug="$1"
+	local issues_snapshot="${2:-}"
+	local prs_snapshot="${3:-}"
 	[[ -n "$slug" ]] || {
 		echo ""
 		return 0
 	}
-
-	local limit="${PULSE_QUEUED_SCAN_LIMIT:-200}"
-
-	local issues_json prs_json
-	local issues_ok=false prs_ok=false
-	issues_json=$(gh_issue_list --repo "$slug" --state open \
-		--json number,labels,assignees,updatedAt \
-		--limit "$limit" 2>/dev/null) && issues_ok=true
-	prs_json=$(pulse_pr_list_get --repo "$slug" --state open \
-		--json number,labels,assignees,reviewDecision,mergeable,updatedAt \
-		--limit "$limit" 2>/dev/null) && prs_ok=true
-
-	# Fail-open: if BOTH fetches failed entirely (not just returned empty
-	# lists from successful fetches), return an empty fingerprint so the
-	# caller falls through to the existing Layer 2 delta prefetch. A
-	# single-side failure still produces a usable fingerprint because
-	# t2041's verification query is a second check — worst case we miss
-	# one churn cycle, never worse than today's behaviour.
-	if [[ "$issues_ok" != "true" && "$prs_ok" != "true" ]]; then
+	_canonical_snapshot_pair_complete "$slug" "$issues_snapshot" "$prs_snapshot" || {
 		echo ""
 		return 0
-	fi
-
-	[[ -n "$issues_json" && "$issues_json" != "null" ]] || issues_json="[]"
-	[[ -n "$prs_json" && "$prs_json" != "null" ]] || prs_json="[]"
+	}
 
 	# Canonicalize both lists. The PR/issue arrays can exceed Linux
-	# MAX_ARG_STRLEN, so pass them through temp files instead of jq --argjson.
+	# MAX_ARG_STRLEN, so pass their envelopes through files instead of jq argv.
 	local canon
 	local issues_file="" prs_file=""
 	issues_file=$(mktemp) || {
@@ -271,12 +293,12 @@ _compute_repo_state_fingerprint() {
 		echo ""
 		return 0
 	}
-	if ! printf '%s' "$issues_json" >"$issues_file"; then
+	if ! printf '%s' "$issues_snapshot" >"$issues_file"; then
 		rm -f "$issues_file" "$prs_file"
 		echo ""
 		return 0
 	fi
-	if ! printf '%s' "$prs_json" >"$prs_file"; then
+	if ! printf '%s' "$prs_snapshot" >"$prs_file"; then
 		rm -f "$issues_file" "$prs_file"
 		echo ""
 		return 0
@@ -284,8 +306,8 @@ _compute_repo_state_fingerprint() {
 	canon=$(jq -cSn \
 		--slurpfile issues "$issues_file" \
 		--slurpfile prs "$prs_file" '
-		($issues[0] // []) as $issues |
-		($prs[0] // []) as $prs |
+		($issues[0].items // []) as $issues |
+		($prs[0].items // []) as $prs |
 		{
 			issues: ($issues | sort_by(.number) | map({
 				n: .number,
@@ -297,9 +319,8 @@ _compute_repo_state_fingerprint() {
 				n: .number,
 				l: ([.labels[].name] | sort),
 				a: ([.assignees[].login] | sort),
-				r: .reviewDecision,
-				m: .mergeable,
-				u: .updatedAt
+				u: .updatedAt,
+				h: .headRefOid
 			}))
 		}
 	' 2>/dev/null) || canon=""
@@ -319,51 +340,6 @@ _compute_repo_state_fingerprint() {
 		hash=""
 	fi
 	echo "$hash"
-	return 0
-}
-
-#######################################
-# t2041 Layer 1: Run the cheap verification queries.
-#
-# Returns 0 (unchanged) only if BOTH `gh issue list --search "updated:>ISO"`
-# AND `gh pr list --search "updated:>ISO"` return empty results. Returns 1
-# if anything has changed since ISO or any query fails (fail-closed — force
-# fresh fetch on any doubt).
-#
-# The PR-side verification is critical: without it, cache-hit cycles
-# would continue serving stale PR state even when a PR was ready for
-# merge (CodeRabbit review on PR #18546).
-#
-# Arguments:
-#   $1 - repo slug
-#   $2 - last_pass_iso (from cache)
-#######################################
-_verify_repo_state_unchanged() {
-	local slug="$1"
-	local last_pass_iso="$2"
-	[[ -n "$slug" && -n "$last_pass_iso" && "$last_pass_iso" != "null" ]] || return 1
-	_load_pulse_sweep_budget_config
-	local verif_limit="${PULSE_SWEEP_VERIFICATION_QUERY_LIMIT:-5}"
-
-	# Issue-side verification
-	local changed_json count
-	changed_json=$(gh_issue_list --repo "$slug" --state open \
-		--search "updated:>${last_pass_iso}" \
-		--json number --limit "$verif_limit" 2>/dev/null) || return 1
-	[[ -n "$changed_json" && "$changed_json" != "null" ]] || return 1
-	count=$(printf '%s' "$changed_json" | jq 'length' 2>/dev/null) || count=""
-	[[ "$count" =~ ^[0-9]+$ ]] || return 1
-	[[ "$count" -eq 0 ]] || return 1
-
-	# PR-side verification — same bound, same fail-closed semantics
-	changed_json=$(gh_pr_list --repo "$slug" --state open \
-		--search "updated:>${last_pass_iso}" \
-		--json number --limit "$verif_limit" 2>/dev/null) || return 1
-	[[ -n "$changed_json" && "$changed_json" != "null" ]] || return 1
-	count=$(printf '%s' "$changed_json" | jq 'length' 2>/dev/null) || count=""
-	[[ "$count" =~ ^[0-9]+$ ]] || return 1
-	[[ "$count" -eq 0 ]] || return 1
-
 	return 0
 }
 
@@ -428,34 +404,35 @@ prefetch_hygiene_anomalies() {
 # Returns 0 (hit — LLM can skip deep analysis) if:
 #   1. Cache entry has a state_fingerprint field
 #   2. Current fingerprint equals cached fingerprint
-#   3. Verification query confirms no changes since last_prefetch
+#   3. Both snapshots are complete, compatible, and from one generation
 # Returns 1 (miss — run full analysis) otherwise.
 #
 # Arguments:
 #   $1 - repo slug
 #   $2 - cache entry JSON (from _prefetch_cache_get)
-#   $3 - output variable name: caller reads PREFETCH_CURRENT_FINGERPRINT
-#        after return (bash 3.2 — no namerefs)
+#   $3 - canonical issue snapshot envelope
+#   $4 - canonical PR snapshot envelope
 #######################################
 _prefetch_detect_cache_hit() {
 	local slug="$1"
 	local cache_entry="$2"
+	local issues_snapshot="${3:-}"
+	local prs_snapshot="${4:-}"
 
 	PREFETCH_CURRENT_FINGERPRINT=""
+	PREFETCH_CURRENT_SNAPSHOT_GENERATION=""
 
-	# Compute the current fingerprint unconditionally — we need it for
-	# the cache write at end-of-pass even on a miss.
-	PREFETCH_CURRENT_FINGERPRINT=$(_compute_repo_state_fingerprint "$slug")
+	PREFETCH_CURRENT_FINGERPRINT=$(_compute_repo_state_fingerprint \
+		"$slug" "$issues_snapshot" "$prs_snapshot")
 	[[ -n "$PREFETCH_CURRENT_FINGERPRINT" ]] || return 1
+	PREFETCH_CURRENT_SNAPSHOT_GENERATION=$(printf '%s' "$issues_snapshot" | jq -r '.generation // ""' 2>/dev/null) || PREFETCH_CURRENT_SNAPSHOT_GENERATION=""
 
-	local cached_fp
+	local cached_fp cached_schema
 	cached_fp=$(echo "$cache_entry" | jq -r '.state_fingerprint // ""' 2>/dev/null) || cached_fp=""
+	cached_schema=$(echo "$cache_entry" | jq -r '.state_fingerprint_schema // ""' 2>/dev/null) || cached_schema=""
+	[[ "$cached_schema" == "$_PREFETCH_FINGERPRINT_SCHEMA" ]] || return 1
 	[[ -n "$cached_fp" && "$cached_fp" != "null" ]] || return 1
 	[[ "$cached_fp" == "$PREFETCH_CURRENT_FINGERPRINT" ]] || return 1
-
-	local last_prefetch
-	last_prefetch=$(echo "$cache_entry" | jq -r '.last_prefetch // ""' 2>/dev/null) || last_prefetch=""
-	_verify_repo_state_unchanged "$slug" "$last_prefetch" || return 1
 
 	return 0
 }

--- a/.agents/scripts/pulse-prefetch-infra.sh
+++ b/.agents/scripts/pulse-prefetch-infra.sh
@@ -427,7 +427,7 @@ _prefetch_detect_cache_hit() {
 	[[ -n "$PREFETCH_CURRENT_FINGERPRINT" ]] || return 1
 	PREFETCH_CURRENT_SNAPSHOT_GENERATION=$(printf '%s' "$issues_snapshot" | jq -r '.generation // ""' 2>/dev/null) || PREFETCH_CURRENT_SNAPSHOT_GENERATION=""
 
-	local cached_fp cached_schema
+	local cached_fp="" cached_schema=""
 	cached_fp=$(echo "$cache_entry" | jq -r '.state_fingerprint // ""' 2>/dev/null) || cached_fp=""
 	cached_schema=$(echo "$cache_entry" | jq -r '.state_fingerprint_schema // ""' 2>/dev/null) || cached_schema=""
 	[[ "$cached_schema" == "$_PREFETCH_FINGERPRINT_SCHEMA" ]] || return 1

--- a/.agents/scripts/pulse-prefetch-repo.sh
+++ b/.agents/scripts/pulse-prefetch-repo.sh
@@ -352,7 +352,7 @@ _prefetch_single_repo_update_cache() {
 	local now_iso
 	now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	local fingerprint="${PREFETCH_CURRENT_FINGERPRINT:-}"
-	local new_entry last_full_sweep
+	local new_entry="" last_full_sweep=""
 	last_full_sweep=$(printf '%s\n' "$cache_entry" | jq -r '.last_full_sweep // ""') || last_full_sweep=""
 	if [[ "$sweep_mode" == "$_PREFETCH_ISSUE_SWEEP_FULL" && "$snapshot_complete" == "$_PREFETCH_BOOL_TRUE" ]]; then
 		last_full_sweep="$now_iso"

--- a/.agents/scripts/pulse-prefetch-repo.sh
+++ b/.agents/scripts/pulse-prefetch-repo.sh
@@ -29,10 +29,9 @@ _PREFETCH_NONE_LINE="- None"
 #######################################
 # GH#18984 (t2098): Emit cached-data replay for an idle repo on cache-hit.
 #
-# On cache-hit, replays cached PR/issue sections from the cache entry
-# instead of making 6 expensive gh API calls. The only live call is
-# _prefetch_prs_enrich_checks for repos with cached PRs > 0 (catches
-# reviewDecision changes that don't always update updatedAt).
+# On cache-hit, renders the current canonical PR/issue snapshots instead of
+# making duplicate list calls. Check enrichment remains observational and live;
+# normalized snapshots report GraphQL-only review fields as UNKNOWN.
 #
 # Writes markdown sections to stdout. Sets PREFETCH_UPDATED_PRS and
 # PREFETCH_UPDATED_ISSUES for the cache-update path in the caller.
@@ -40,10 +39,14 @@ _PREFETCH_NONE_LINE="- None"
 # Arguments:
 #   $1 - repo slug
 #   $2 - cache_entry JSON
+#   $3 - canonical PR snapshot envelope (optional for tier replay)
+#   $4 - canonical issue snapshot envelope (optional for tier replay)
 #######################################
 _prefetch_single_repo_idle_skip() {
 	local slug="$1"
 	local cache_entry="$2"
+	local prs_snapshot="${3:-}"
+	local issues_snapshot="${4:-}"
 
 	local _cached_last
 	_cached_last=$(echo "$cache_entry" | jq -r '.last_prefetch // "unknown"' 2>/dev/null) || _cached_last="unknown"
@@ -53,8 +56,16 @@ _prefetch_single_repo_idle_skip() {
 	echo ""
 
 	local _cached_prs="" _cached_issues="" _cached_pr_count=0 _cached_issue_count=0
-	_cached_prs=$(echo "$cache_entry" | jq -c '.prs // []' 2>/dev/null) || _cached_prs="[]"
-	_cached_issues=$(echo "$cache_entry" | jq -c '.issues // []' 2>/dev/null) || _cached_issues="[]"
+	if [[ -n "$prs_snapshot" ]] && _cached_prs=$(printf '%s' "$prs_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
+		:
+	else
+		_cached_prs=$(echo "$cache_entry" | jq -c '.prs // []' 2>/dev/null) || _cached_prs="[]"
+	fi
+	if [[ -n "$issues_snapshot" ]] && _cached_issues=$(printf '%s' "$issues_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
+		:
+	else
+		_cached_issues=$(echo "$cache_entry" | jq -c '.issues // []' 2>/dev/null) || _cached_issues="[]"
+	fi
 	_cached_pr_count=$(echo "$_cached_prs" | jq 'length' 2>/dev/null) || _cached_pr_count=0
 	[[ "$_cached_pr_count" =~ ^[0-9]+$ ]] || _cached_pr_count=0
 	_cached_issues=$(echo "$_cached_issues" | _prefetch_open_issues_only)
@@ -64,7 +75,7 @@ _prefetch_single_repo_idle_skip() {
 	# Replay cached PR section
 	echo "### Open PRs (${_cached_pr_count}) [cached]"
 	if [[ "$_cached_pr_count" -gt 0 ]]; then
-		echo "$_cached_prs" | jq -r '.[] | "- PR #\(.number): \(.title) [review: \(.reviewDecision // "NONE")] [updated: \(.updatedAt)]"'
+		echo "$_cached_prs" | jq -r '.[] | "- PR #\(.number): \(.title) [review: \(if has("reviewDecision") | not then "UNKNOWN" elif .reviewDecision == null or .reviewDecision == "" then "NONE" else .reviewDecision end)] [updated: \(.updatedAt)]"'
 	else
 		echo "$_PREFETCH_NONE_LINE"
 	fi
@@ -133,6 +144,8 @@ _prefetch_single_repo_idle_skip() {
 #   $3 - state fingerprint
 #   $4 - PR JSON array
 #   $5 - issue JSON array
+#   $6 - whether the canonical snapshot pair was complete
+#   $7 - canonical snapshot generation
 # Outputs: JSON cache entry object
 #######################################
 _prefetch_build_cache_entry() {
@@ -141,6 +154,9 @@ _prefetch_build_cache_entry() {
 	local fingerprint="$3"
 	local prs_json="$4"
 	local issues_json="$5"
+	local snapshot_complete="${6:-false}"
+	local snapshot_generation="${7:-}"
+	[[ "$snapshot_complete" == "true" ]] || snapshot_complete=false
 
 	[[ -n "$prs_json" && "$prs_json" != "$_PREFETCH_JSON_NULL" ]] || prs_json="[]"
 	[[ -n "$issues_json" && "$issues_json" != "$_PREFETCH_JSON_NULL" ]] || issues_json="[]"
@@ -166,9 +182,15 @@ _prefetch_build_cache_entry() {
 		--arg now "$now_iso" \
 		--arg lfs "$last_full_sweep" \
 		--arg fp "$fingerprint" \
+		--arg fp_schema "${_PREFETCH_FINGERPRINT_SCHEMA:-canonical-snapshot-v1}" \
+		--arg generation "$snapshot_generation" \
+		--argjson snapshot_complete "$snapshot_complete" \
 		--slurpfile prs "$prs_file" \
 		--slurpfile issues "$issues_file" \
-		'{last_prefetch: $now, last_full_sweep: $lfs, state_fingerprint: $fp, prs: ($prs[0] // []), issues: ($issues[0] // [])}') || jq_status=$?
+		'{last_prefetch: $now, last_full_sweep: $lfs, state_fingerprint: $fp,
+		  state_fingerprint_schema: $fp_schema, snapshot_generation: $generation,
+		  snapshot_complete: $snapshot_complete,
+		  prs: ($prs[0] // []), issues: ($issues[0] // [])}') || jq_status=$?
 	rm -f "$prs_file" "$issues_file"
 	[[ "$jq_status" -eq 0 ]] || return "$jq_status"
 	printf '%s\n' "$jq_output"
@@ -230,18 +252,48 @@ _prefetch_single_repo_sweep_mode() {
 }
 
 #######################################
+# Resolve each canonical collection exactly once for a repository cycle.
+# Sets PREFETCH_CANONICAL_* globals for Bash 3.2 callers.
+# Arguments: $1=slug
+#######################################
+_prefetch_single_repo_load_snapshots() {
+	local slug="$1"
+	local helper="${PULSE_BATCH_PREFETCH_HELPER:-${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh}"
+	PREFETCH_CANONICAL_ISSUES_SNAPSHOT="{}"
+	PREFETCH_CANONICAL_PRS_SNAPSHOT="{}"
+	PREFETCH_CANONICAL_SNAPSHOT_COMPLETE=false
+	PREFETCH_CANONICAL_SNAPSHOT_GENERATION=""
+
+	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" != "1" || ! -x "$helper" ]]; then
+		return 0
+	fi
+	PREFETCH_CANONICAL_ISSUES_SNAPSHOT=$("$helper" read-snapshot --kind issues --slug "$slug" 2>>"$LOGFILE") || PREFETCH_CANONICAL_ISSUES_SNAPSHOT="{}"
+	PREFETCH_CANONICAL_PRS_SNAPSHOT=$("$helper" read-snapshot --kind prs --slug "$slug" 2>>"$LOGFILE") || PREFETCH_CANONICAL_PRS_SNAPSHOT="{}"
+
+	if _canonical_snapshot_pair_complete \
+		"$slug" "$PREFETCH_CANONICAL_ISSUES_SNAPSHOT" "$PREFETCH_CANONICAL_PRS_SNAPSHOT"; then
+		PREFETCH_CANONICAL_SNAPSHOT_COMPLETE=true
+		PREFETCH_CANONICAL_SNAPSHOT_GENERATION=$(printf '%s' "$PREFETCH_CANONICAL_ISSUES_SNAPSHOT" | jq -r '.generation // ""' 2>/dev/null) || PREFETCH_CANONICAL_SNAPSHOT_GENERATION=""
+	fi
+	return 0
+}
+
+#######################################
 # Detect whether cached repo state can be replayed.
-# Arguments: $1=slug, $2=cache_entry, $3=sweep_mode
+# Arguments: $1=slug, $2=cache_entry, $3=sweep_mode,
+#            $4=issue snapshot, $5=PR snapshot
 # Sets: PREFETCH_CACHE_HIT, PREFETCH_SWEEP_MODE
 #######################################
 _prefetch_single_repo_cache_decision() {
 	local slug="$1"
 	local cache_entry="$2"
 	local sweep_mode="$3"
+	local issues_snapshot="${4:-}"
+	local prs_snapshot="${5:-}"
 	PREFETCH_SWEEP_MODE="$sweep_mode"
 
 	PREFETCH_CACHE_HIT="false"
-	if _prefetch_detect_cache_hit "$slug" "$cache_entry"; then
+	if _prefetch_detect_cache_hit "$slug" "$cache_entry" "$issues_snapshot" "$prs_snapshot"; then
 		PREFETCH_CACHE_HIT="true"
 		echo "[pulse-wrapper] _prefetch_single_repo: STATE CACHE HIT for ${slug} (fingerprint=${PREFETCH_CURRENT_FINGERPRINT})" >>"$LOGFILE"
 	fi
@@ -255,7 +307,8 @@ _prefetch_single_repo_cache_decision() {
 
 #######################################
 # Render one repo prefetch block to its output file.
-# Arguments: $1=slug, $2=path, $3=outfile, $4=cache_entry, $5=sweep_mode, $6=cache_hit
+# Arguments: $1=slug, $2=path, $3=outfile, $4=cache_entry, $5=sweep_mode,
+#            $6=cache_hit, $7=issue snapshot, $8=PR snapshot
 #######################################
 _prefetch_single_repo_write_output() {
 	local slug="$1"
@@ -264,16 +317,18 @@ _prefetch_single_repo_write_output() {
 	local cache_entry="$4"
 	local sweep_mode="$5"
 	local cache_hit="$6"
+	local issues_snapshot="${7:-}"
+	local prs_snapshot="${8:-}"
 
 	{
 		echo "## ${slug} (${path})"
 		echo ""
 		if [[ "$cache_hit" == "$_PREFETCH_BOOL_TRUE" ]]; then
-			_prefetch_single_repo_idle_skip "$slug" "$cache_entry"
+			_prefetch_single_repo_idle_skip "$slug" "$cache_entry" "$prs_snapshot" "$issues_snapshot"
 		else
-			_prefetch_repo_prs "$slug" "$cache_entry" "$sweep_mode"
+			_prefetch_repo_prs "$slug" "$cache_entry" "$sweep_mode" "$prs_snapshot"
 			_prefetch_repo_daily_cap "$slug"
-			_prefetch_repo_issues "$slug" "$cache_entry" "$sweep_mode"
+			_prefetch_repo_issues "$slug" "$cache_entry" "$sweep_mode" "$issues_snapshot"
 		fi
 	} >"$outfile"
 	return 0
@@ -281,37 +336,31 @@ _prefetch_single_repo_write_output() {
 
 #######################################
 # Persist fresh cache entry for one repo after prefetch output is generated.
-# Arguments: $1=slug, $2=cache_entry, $3=sweep_mode
+# Arguments: $1=slug, $2=cache_entry, $3=sweep_mode,
+#            $4=snapshot_complete, $5=snapshot_generation
 #######################################
 _prefetch_single_repo_update_cache() {
 	local slug="$1"
 	local cache_entry="$2"
 	local sweep_mode="$3"
+	local snapshot_complete="${4:-false}"
+	local snapshot_generation="${5:-}"
 
 	# GH#15286: Update cache with fresh data.
 	# t2041: also persist the state_fingerprint for Layer 1 cache-hit
 	# detection on the next cycle.
 	local now_iso
 	now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-	# If the fingerprint wasn't already computed for cache-hit detection
-	# (e.g. cache entry was empty), compute it now so the cache write is
-	# consistent.
-	if [[ -z "${PREFETCH_CURRENT_FINGERPRINT:-}" ]]; then
-		PREFETCH_CURRENT_FINGERPRINT=$(_compute_repo_state_fingerprint "$slug")
-	fi
 	local fingerprint="${PREFETCH_CURRENT_FINGERPRINT:-}"
-	local new_entry
-	if [[ "$sweep_mode" == "$_PREFETCH_ISSUE_SWEEP_FULL" ]]; then
-		new_entry=$(_prefetch_build_cache_entry \
-			"$now_iso" "$now_iso" "$fingerprint" \
-			"${PREFETCH_UPDATED_PRS:-[]}" "${PREFETCH_UPDATED_ISSUES:-[]}") || new_entry=""
-	else
-		local last_full_sweep
-		last_full_sweep=$(printf '%s\n' "$cache_entry" | jq -r '.last_full_sweep // ""') || last_full_sweep=""
-		new_entry=$(_prefetch_build_cache_entry \
-			"$now_iso" "$last_full_sweep" "$fingerprint" \
-			"${PREFETCH_UPDATED_PRS:-[]}" "${PREFETCH_UPDATED_ISSUES:-[]}") || new_entry=""
+	local new_entry last_full_sweep
+	last_full_sweep=$(printf '%s\n' "$cache_entry" | jq -r '.last_full_sweep // ""') || last_full_sweep=""
+	if [[ "$sweep_mode" == "$_PREFETCH_ISSUE_SWEEP_FULL" && "$snapshot_complete" == "true" ]]; then
+		last_full_sweep="$now_iso"
 	fi
+	new_entry=$(_prefetch_build_cache_entry \
+		"$now_iso" "$last_full_sweep" "$fingerprint" \
+		"${PREFETCH_UPDATED_PRS:-[]}" "${PREFETCH_UPDATED_ISSUES:-[]}" \
+		"$snapshot_complete" "$snapshot_generation") || new_entry=""
 	if [[ -n "$new_entry" && "$new_entry" != "$_PREFETCH_JSON_NULL" ]]; then
 		_prefetch_cache_set "$slug" "$new_entry"
 	else
@@ -346,20 +395,27 @@ _prefetch_single_repo() {
 	# Reset shared output vars (subshell-safe: each repo runs in its own subshell)
 	PREFETCH_UPDATED_PRS="[]"
 	PREFETCH_UPDATED_ISSUES="[]"
+	_prefetch_single_repo_load_snapshots "$slug"
+	local issues_snapshot="$PREFETCH_CANONICAL_ISSUES_SNAPSHOT"
+	local prs_snapshot="$PREFETCH_CANONICAL_PRS_SNAPSHOT"
 
-	# t2041 Layer 1: detect cache hit. When the current state fingerprint
-	# matches the cached one AND the cheap verification query shows nothing
-	# has changed since last_prefetch, emit a compact "cache hit" marker
+	# t2041 Layer 1: detect cache hit. When one complete canonical snapshot
+	# generation hashes to the cached fingerprint, emit a compact "cache hit" marker
 	# the LLM can use to short-circuit deep analysis. We STILL write the
 	# Open PRs / Queued Issues sections (so the LLM has recent state if it
 	# decides to read deeper) but the LLM-facing summary leads with the
 	# cache-hit signal so cheap cycles stay cheap.
-	_prefetch_single_repo_cache_decision "$slug" "$cache_entry" "$sweep_mode"
+	_prefetch_single_repo_cache_decision \
+		"$slug" "$cache_entry" "$sweep_mode" "$issues_snapshot" "$prs_snapshot"
 	local cache_hit="$PREFETCH_CACHE_HIT"
 	sweep_mode="$PREFETCH_SWEEP_MODE"
 
-	_prefetch_single_repo_write_output "$slug" "$path" "$outfile" "$cache_entry" "$sweep_mode" "$cache_hit"
-	_prefetch_single_repo_update_cache "$slug" "$cache_entry" "$sweep_mode"
+	_prefetch_single_repo_write_output \
+		"$slug" "$path" "$outfile" "$cache_entry" "$sweep_mode" "$cache_hit" \
+		"$issues_snapshot" "$prs_snapshot"
+	_prefetch_single_repo_update_cache \
+		"$slug" "$cache_entry" "$sweep_mode" \
+		"$PREFETCH_CANONICAL_SNAPSHOT_COMPLETE" "$PREFETCH_CANONICAL_SNAPSHOT_GENERATION"
 
 	return 0
 }

--- a/.agents/scripts/pulse-prefetch-repo.sh
+++ b/.agents/scripts/pulse-prefetch-repo.sh
@@ -156,7 +156,7 @@ _prefetch_build_cache_entry() {
 	local issues_json="$5"
 	local snapshot_complete="${6:-false}"
 	local snapshot_generation="${7:-}"
-	[[ "$snapshot_complete" == "true" ]] || snapshot_complete=false
+	[[ "$snapshot_complete" == "$_PREFETCH_BOOL_TRUE" ]] || snapshot_complete=false
 
 	[[ -n "$prs_json" && "$prs_json" != "$_PREFETCH_JSON_NULL" ]] || prs_json="[]"
 	[[ -n "$issues_json" && "$issues_json" != "$_PREFETCH_JSON_NULL" ]] || issues_json="[]"
@@ -294,7 +294,7 @@ _prefetch_single_repo_cache_decision() {
 
 	PREFETCH_CACHE_HIT="false"
 	if _prefetch_detect_cache_hit "$slug" "$cache_entry" "$issues_snapshot" "$prs_snapshot"; then
-		PREFETCH_CACHE_HIT="true"
+		PREFETCH_CACHE_HIT="$_PREFETCH_BOOL_TRUE"
 		echo "[pulse-wrapper] _prefetch_single_repo: STATE CACHE HIT for ${slug} (fingerprint=${PREFETCH_CURRENT_FINGERPRINT})" >>"$LOGFILE"
 	fi
 	if [[ "$PREFETCH_CACHE_HIT" == "$_PREFETCH_BOOL_TRUE" ]] && echo "$cache_entry" | _prefetch_cache_entry_issues_lack_state; then
@@ -354,7 +354,7 @@ _prefetch_single_repo_update_cache() {
 	local fingerprint="${PREFETCH_CURRENT_FINGERPRINT:-}"
 	local new_entry last_full_sweep
 	last_full_sweep=$(printf '%s\n' "$cache_entry" | jq -r '.last_full_sweep // ""') || last_full_sweep=""
-	if [[ "$sweep_mode" == "$_PREFETCH_ISSUE_SWEEP_FULL" && "$snapshot_complete" == "true" ]]; then
+	if [[ "$sweep_mode" == "$_PREFETCH_ISSUE_SWEEP_FULL" && "$snapshot_complete" == "$_PREFETCH_BOOL_TRUE" ]]; then
 		last_full_sweep="$now_iso"
 	fi
 	new_entry=$(_prefetch_build_cache_entry \

--- a/.agents/scripts/tests/test-enrich-batch-prefetch.sh
+++ b/.agents/scripts/tests/test-enrich-batch-prefetch.sh
@@ -419,7 +419,7 @@ if [[ "$1" == "api" && "$2" == *"/issues"* ]]; then
 fi
 # gh api repos/{slug}/pulls → simulate REST success
 if [[ "$1" == "api" && "$2" == *"/pulls"* ]]; then
-	printf '[{"number":7,"title":"Test PR","labels":[],"updated_at":"2026-04-22T17:00:00Z","assignees":[],"created_at":"2026-04-22T16:00:00Z","user":{"login":"testuser"}}]\n'
+	printf '[{"number":7,"title":"Test PR","labels":[],"updated_at":"2026-04-22T17:00:00Z","assignees":[],"created_at":"2026-04-22T16:00:00Z","user":{"login":"testuser"},"head":{"sha":"abcdef123456","ref":"feature"}}]\n'
 	exit 0
 fi
 exit 1
@@ -484,6 +484,20 @@ if [[ -f "$_prs_cache" ]]; then
 	else
 		print_result "REST fallback: PRs cache author.login mapped from REST user.login" 1 "(author.login='${_pr_author}', expected 'testuser')"
 	fi
+fi
+
+_issues_snapshot=""
+_prs_snapshot=""
+_issues_snapshot=$(PULSE_BATCH_PREFETCH_CACHE_DIR="$BATCH_CACHE_DIR_TEST" LOGFILE="/dev/null" \
+	bash "$BATCH_PREFETCH_SCRIPT" read-snapshot --kind issues --slug testowner/testrepo 2>/dev/null) || _issues_snapshot="{}"
+_prs_snapshot=$(PULSE_BATCH_PREFETCH_CACHE_DIR="$BATCH_CACHE_DIR_TEST" LOGFILE="/dev/null" \
+	bash "$BATCH_PREFETCH_SCRIPT" read-snapshot --kind prs --slug testowner/testrepo 2>/dev/null) || _prs_snapshot="{}"
+if [[ "$(printf '%s' "$_issues_snapshot" | jq -r '.complete // false')" == "true" ]] \
+	&& [[ "$(printf '%s' "$_issues_snapshot" | jq -r '.generation // ""')" == "$(printf '%s' "$_prs_snapshot" | jq -r '.generation // ""')" ]] \
+	&& [[ "$(printf '%s' "$_prs_snapshot" | jq -r '.items[0].headRefOid // ""')" == "abcdef123456" ]]; then
+	print_result "REST fallback: canonical snapshots preserve completeness, generation, and full head SHA" 0
+else
+	print_result "REST fallback: canonical snapshots preserve completeness, generation, and full head SHA" 1
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-jq-large-json-argv-regression.sh
+++ b/.agents/scripts/tests/test-jq-large-json-argv-regression.sh
@@ -50,7 +50,7 @@ build_large_json() {
 import json
 payload = "x" * 300
 print(json.dumps([
-    {"number": i, "labels": [{"name": "bug"}], "assignees": [{"login": "dev"}], "updatedAt": "2026-06-26T00:00:00Z", "title": payload}
+    {"number": i, "state": "open", "labels": [{"name": "bug"}], "assignees": [{"login": "dev"}], "updatedAt": "2026-06-26T00:00:00Z", "title": payload}
     for i in range(600)
 ]))
 PY
@@ -59,7 +59,7 @@ PY
 import json
 payload = "y" * 300
 print(json.dumps([
-    {"number": i, "labels": [{"name": "ready"}], "assignees": [{"login": "dev"}], "reviewDecision": "APPROVED", "mergeable": "MERGEABLE", "updatedAt": "2026-06-26T00:00:00Z", "title": payload}
+    {"number": i, "labels": [{"name": "ready"}], "assignees": [{"login": "dev"}], "reviewDecision": "APPROVED", "mergeable": "MERGEABLE", "updatedAt": "2026-06-26T00:00:00Z", "headRefOid": f"sha-{i:040d}", "title": payload}
     for i in range(600)
 ]))
 PY
@@ -90,8 +90,18 @@ test_prefetch_fingerprint_accepts_large_lists() {
 	setup_env
 	# shellcheck source=../pulse-prefetch-infra.sh
 	source "$SCRIPTS_DIR/pulse-prefetch-infra.sh"
-	local hash
-	hash=$(_compute_repo_state_fingerprint "owner/repo")
+	local issues_snapshot="" prs_snapshot="" hash=""
+	issues_snapshot=$(printf '%s' "$LARGE_ISSUES_JSON" | jq -c \
+		--arg schema "$_PREFETCH_SNAPSHOT_SCHEMA" --arg projection "$_PREFETCH_ISSUES_PROJECTION" \
+		'{schema:$schema,repository:"owner/repo",collection:"issues",projection:$projection,
+		  auth_scope:"github.com",generation:"large",source:"fixture",
+		  fetched_at:"2026-06-26T00:00:00Z",complete:true,items:.}')
+	prs_snapshot=$(printf '%s' "$LARGE_PRS_JSON" | jq -c \
+		--arg schema "$_PREFETCH_SNAPSHOT_SCHEMA" --arg projection "$_PREFETCH_PRS_PROJECTION" \
+		'{schema:$schema,repository:"owner/repo",collection:"prs",projection:$projection,
+		  auth_scope:"github.com",generation:"large",source:"fixture",
+		  fetched_at:"2026-06-26T00:00:00Z",complete:true,items:.}')
+	hash=$(_compute_repo_state_fingerprint "owner/repo" "$issues_snapshot" "$prs_snapshot")
 	if [[ "$hash" =~ ^[0-9a-f]{16}$ ]]; then
 		print_result "prefetch fingerprint avoids large jq argv" 0
 	else

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -36,6 +36,7 @@ setup_env() {
 	export PULSE_EVENTS_TICKLE_ENABLED=0
 	export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=999999999
 	export PULSE_BATCH_SEARCH_LAST_RESORT=1
+	export PULSE_BATCH_SNAPSHOT_AUTH_SCOPE=github.com
 	unset AIDEVOPS_GH_FORCE_REST_READS
 	unset AIDEVOPS_GH_REST_FIRST_READS
 	mkdir -p "$HOME" "$PULSE_BATCH_PREFETCH_CACHE_DIR" "$TEST_ROOT/bin"
@@ -80,6 +81,14 @@ if [[ "\$1" == "api" ]]; then
 		printf 'HTTP/2 200\\r\\netag: "etag-issue-v2"\\r\\n\\r\\n[{"number":3,"title":"Issue","state":"open","updated_at":"2026-05-02T00:00:00Z","labels":[],"assignees":[]},{"number":4,"title":"PR-shaped issue","pull_request":{},"updated_at":"2026-05-02T00:00:00Z"}]'
     exit 0
   fi
+  if [[ "$mode" == "paginated" ]]; then
+    if [[ "\$*" == *'/pulls?state=open'* ]]; then
+      printf 'HTTP/2 200\r\netag: "etag-pr-page"\r\nlink: <https://api.github.com/repositories/1/pulls?page=2>; rel="next"\r\n\r\n[{"number":8,"title":"PR page","updated_at":"2026-05-02T00:00:00Z","user":{"login":"dev"},"head":{"sha":"def","ref":"branch"}}]'
+      exit 0
+    fi
+    printf 'HTTP/2 200\r\netag: "etag-issue-page"\r\nlink: <https://api.github.com/repositories/1/issues?page=2>; rel="next"\r\n\r\n[{"number":9,"title":"Issue page","state":"open","updated_at":"2026-05-02T00:00:00Z","labels":[],"assignees":[]}]'
+    exit 0
+  fi
   printf 'HTTP/2 500\\r\\n\\r\\n{}'
   exit 1
 fi
@@ -100,10 +109,10 @@ SH
 
 seed_cache() {
 	cat >"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json" <<'JSON'
-{"timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":1,"title":"Cached issue","state":"open","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
+{"schema":"aidevops-pulse-snapshot/v1","repository":"owner/repo","collection":"issues","projection":"number,title,state,labels,updatedAt,assignees","auth_scope":"github.com","generation":"seed","source":"conditional-rest","complete":true,"truncated":false,"fetched_at":"2026-05-01T00:00:00Z","timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":1,"title":"Cached issue","state":"open","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
 JSON
 	cat >"$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json" <<'JSON'
-{"timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":2,"title":"Cached PR","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
+{"schema":"aidevops-pulse-snapshot/v1","repository":"owner/repo","collection":"prs","projection":"number,title,labels,updatedAt,assignees,createdAt,author,headRefOid,headRefName","auth_scope":"github.com","generation":"seed","source":"conditional-rest","complete":true,"truncated":false,"fetched_at":"2026-05-01T00:00:00Z","timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":2,"title":"Cached PR","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z","createdAt":"2026-05-01T00:00:00Z","author":{"login":"dev"},"headRefOid":"seed-sha","headRefName":"seed-branch"}]}
 JSON
 	return 0
 }
@@ -158,7 +167,13 @@ test_unchanged_repo_uses_304_cache() {
 	write_gh_stub not_modified
 	local output
 	output=$("$HELPER" refresh)
-	if grep -q 'conditional_304=2' <<<"$output" && ! grep -q 'search issues' "$TEST_ROOT/gh-calls.log"; then
+	local issues_snapshot="" prs_snapshot=""
+	issues_snapshot=$("$HELPER" read-snapshot --kind issues --slug owner/repo 2>/dev/null) || issues_snapshot="{}"
+	prs_snapshot=$("$HELPER" read-snapshot --kind prs --slug owner/repo 2>/dev/null) || prs_snapshot="{}"
+	if grep -q 'conditional_304=2' <<<"$output" \
+		&& ! grep -q 'search issues' "$TEST_ROOT/gh-calls.log" \
+		&& [[ "$(printf '%s' "$issues_snapshot" | jq -r '.complete')" == "true" ]] \
+		&& [[ "$(printf '%s' "$issues_snapshot" | jq -r '.generation')" == "$(printf '%s' "$prs_snapshot" | jq -r '.generation')" ]]; then
 		print_result "unchanged repo returns conditional 304 and skips search" 0
 	else
 		print_result "unchanged repo returns conditional 304 and skips search" 1
@@ -177,10 +192,33 @@ test_changed_repo_refreshes_cache() {
 	pr_author=$(jq -r '.items[0].author.login' "$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json")
 	local issue_state
 	issue_state=$(jq -r '.items[0].state' "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json")
-	if grep -q 'conditional_refreshes=2' <<<"$output" && [[ "$issue_count" == "1" && "$pr_author" == "dev" && "$issue_state" == "open" ]]; then
+	local issues_snapshot="" prs_snapshot=""
+	issues_snapshot=$("$HELPER" read-snapshot --kind issues --slug owner/repo 2>/dev/null) || issues_snapshot="{}"
+	prs_snapshot=$("$HELPER" read-snapshot --kind prs --slug owner/repo 2>/dev/null) || prs_snapshot="{}"
+	if grep -q 'conditional_refreshes=2' <<<"$output" \
+		&& [[ "$issue_count" == "1" && "$pr_author" == "dev" && "$issue_state" == "open" ]] \
+		&& [[ "$(printf '%s' "$issues_snapshot" | jq -r '.schema')" == "aidevops-pulse-snapshot/v1" ]] \
+		&& [[ "$(printf '%s' "$issues_snapshot" | jq -r '.generation')" == "$(printf '%s' "$prs_snapshot" | jq -r '.generation')" ]] \
+		&& [[ "$(printf '%s' "$prs_snapshot" | jq -r '.items[0].headRefOid')" == "abc" ]]; then
 		print_result "changed repo refreshes normalized issue and PR caches" 0
 	else
 		print_result "changed repo refreshes normalized issue and PR caches" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_paginated_response_is_not_complete() {
+	setup_env
+	write_gh_stub paginated
+	"$HELPER" refresh >/dev/null
+	local issues_complete="" prs_complete=""
+	issues_complete=$(jq -r '.complete' "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json")
+	prs_complete=$(jq -r '.complete' "$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json")
+	if [[ "$issues_complete" == "false" && "$prs_complete" == "false" ]]; then
+		print_result "pagination metadata prevents truncated snapshots from claiming completeness" 0
+	else
+		print_result "pagination metadata prevents truncated snapshots from claiming completeness" 1
 	fi
 	teardown_env
 	return 0
@@ -538,6 +576,7 @@ SH
 
 test_unchanged_repo_uses_304_cache
 test_changed_repo_refreshes_cache
+test_paginated_response_is_not_complete
 test_conditional_failure_routes_to_rest_by_default
 test_search_opt_in_preserves_owner_search
 test_legacy_issue_cache_avoids_search_by_default

--- a/.agents/scripts/tests/test-pulse-prefetch-canonical-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-prefetch-canonical-snapshot.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+print_result() {
+	local name="$1"
+	local passed="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$name"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_env() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="$TEST_ROOT/home"
+	export LOGFILE="$TEST_ROOT/pulse.log"
+	export PULSE_PREFETCH_CACHE_FILE="$TEST_ROOT/prefetch-cache.json"
+	export PULSE_BATCH_PREFETCH_CACHE_DIR="$TEST_ROOT/batch-cache"
+	export PULSE_BATCH_PREFETCH_ENABLED=1
+	export PULSE_BATCH_SNAPSHOT_AUTH_SCOPE=github.com
+	export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=86400
+	export PULSE_PREFETCH_PR_LIMIT=100
+	export PULSE_PREFETCH_ISSUE_LIMIT=100
+	mkdir -p "$HOME" "$PULSE_BATCH_PREFETCH_CACHE_DIR" "$TEST_ROOT/bin"
+	: >"$LOGFILE"
+	: >"$TEST_ROOT/provider-calls.log"
+	: >"$TEST_ROOT/github-list-calls.log"
+	: >"$TEST_ROOT/telemetry.log"
+
+	export CANONICAL_HELPER_REAL="$SCRIPTS_DIR/pulse-batch-prefetch-helper.sh"
+	export CANONICAL_HELPER_LEDGER="$TEST_ROOT/provider-calls.log"
+	cat >"$TEST_ROOT/bin/canonical-helper" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CANONICAL_HELPER_LEDGER"
+exec "$CANONICAL_HELPER_REAL" "$@"
+SH
+	chmod +x "$TEST_ROOT/bin/canonical-helper"
+	export PULSE_BATCH_PREFETCH_HELPER="$TEST_ROOT/bin/canonical-helper"
+	return 0
+}
+
+teardown_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+gh_issue_list() {
+	printf 'issues %s\n' "$*" >>"$TEST_ROOT/github-list-calls.log"
+	printf '[]'
+	return 0
+}
+
+gh_pr_list() {
+	printf 'prs %s\n' "$*" >>"$TEST_ROOT/github-list-calls.log"
+	printf '[]'
+	return 0
+}
+
+pulse_pr_list_get() {
+	printf 'exact-prs %s\n' "$*" >>"$TEST_ROOT/github-list-calls.log"
+	printf '[]'
+	return 0
+}
+
+gh_record_call() {
+	printf '%s\n' "$*" >>"$TEST_ROOT/telemetry.log"
+	return 0
+}
+
+gh_pr_check_status_rest_batch() {
+	printf '[]'
+	return 0
+}
+
+_filter_non_task_issues() {
+	jq -c '.'
+	return 0
+}
+
+SCRIPT_DIR="$SCRIPTS_DIR"
+export SCRIPT_DIR
+# shellcheck source=../pulse-prefetch-infra.sh
+source "$SCRIPTS_DIR/pulse-prefetch-infra.sh"
+# shellcheck source=../pulse-prefetch-fetch.sh
+source "$SCRIPTS_DIR/pulse-prefetch-fetch.sh"
+# shellcheck source=../pulse-prefetch-repo.sh
+source "$SCRIPTS_DIR/pulse-prefetch-repo.sh"
+
+check_repo_tier_skip() {
+	local slug="$1"
+	[[ -n "$slug" ]] || return 1
+	return 0
+}
+
+update_repo_tier_check_timestamp() {
+	local slug="$1"
+	[[ -n "$slug" ]] || return 1
+	return 0
+}
+
+ISSUE_ITEMS='[{"number":3,"title":"Issue","state":"open","labels":[],"updatedAt":"2026-07-18T09:00:00Z","assignees":[]}]'
+PR_ITEMS='[{"number":7,"title":"PR","labels":[],"updatedAt":"2026-07-18T09:00:00Z","assignees":[],"createdAt":"2026-07-17T09:00:00Z","author":{"login":"dev"},"headRefOid":"abcdef123456","headRefName":"feature"}]'
+
+snapshot_path() {
+	local kind="$1"
+	printf '%s/%s-owner__repo.json\n' "$PULSE_BATCH_PREFETCH_CACHE_DIR" "$kind"
+	return 0
+}
+
+write_snapshot() {
+	local kind="$1"
+	local items="$2"
+	local complete="$3"
+	local generation="$4"
+	local projection="$5"
+	local timestamp="${6:-}"
+	local auth_scope="${7:-github.com}"
+	[[ -n "$timestamp" ]] || timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	jq -n --arg schema "$_PREFETCH_SNAPSHOT_SCHEMA" --arg repo "owner/repo" \
+		--arg kind "$kind" --arg projection "$projection" --arg auth_scope "$auth_scope" \
+		--arg generation "$generation" --arg timestamp "$timestamp" \
+		--argjson complete "$complete" --argjson items "$items" \
+		'{schema:$schema,repository:$repo,collection:$kind,projection:$projection,
+		  auth_scope:$auth_scope,generation:$generation,source:"fixture",
+		  complete:$complete,truncated:($complete|not),fetched_at:$timestamp,
+		  timestamp:$timestamp,items:$items}' >"$(snapshot_path "$kind")"
+	return 0
+}
+
+write_complete_pair() {
+	local generation="${1:-generation-a}"
+	local issue_items="${2:-$ISSUE_ITEMS}"
+	local pr_items="${3:-$PR_ITEMS}"
+	write_snapshot issues "$issue_items" true "$generation" "$_PREFETCH_ISSUES_PROJECTION"
+	write_snapshot prs "$pr_items" true "$generation" "$_PREFETCH_PRS_PROJECTION"
+	return 0
+}
+
+test_single_resolution_and_local_reuse() {
+	write_complete_pair
+	: >"$TEST_ROOT/provider-calls.log"
+	: >"$TEST_ROOT/github-list-calls.log"
+	_prefetch_single_repo_load_snapshots owner/repo
+
+	local provider_count=""
+	provider_count=$(wc -l <"$TEST_ROOT/provider-calls.log" | tr -d ' ')
+	local passed=0
+	if [[ "$provider_count" != "2" ]] \
+		|| [[ "$(grep -c '^read-snapshot --kind issues --slug owner/repo$' "$TEST_ROOT/provider-calls.log")" != "1" ]] \
+		|| [[ "$(grep -c '^read-snapshot --kind prs --slug owner/repo$' "$TEST_ROOT/provider-calls.log")" != "1" ]] \
+		|| [[ "$PREFETCH_CANONICAL_SNAPSHOT_COMPLETE" != "true" ]]; then
+		passed=1
+	fi
+	print_result "one provider decision per collection yields a complete pair" "$passed"
+
+	local fingerprint="" cache_entry=""
+	fingerprint=$(_compute_repo_state_fingerprint owner/repo \
+		"$PREFETCH_CANONICAL_ISSUES_SNAPSHOT" "$PREFETCH_CANONICAL_PRS_SNAPSHOT")
+	cache_entry=$(jq -n --arg fp "$fingerprint" \
+		'{state_fingerprint:$fp,state_fingerprint_schema:"canonical-snapshot-v1",prs:[],issues:[]}')
+	if _prefetch_detect_cache_hit owner/repo "$cache_entry" \
+		"$PREFETCH_CANONICAL_ISSUES_SNAPSHOT" "$PREFETCH_CANONICAL_PRS_SNAPSHOT" \
+		&& [[ ! -s "$TEST_ROOT/github-list-calls.log" ]]; then
+		print_result "canonical cache-hit decision is local and transport-free" 0
+	else
+		print_result "canonical cache-hit decision is local and transport-free" 1
+	fi
+
+	local prs_output="$TEST_ROOT/prs-output.txt"
+	local issues_output="$TEST_ROOT/issues-output.txt"
+	_prefetch_repo_prs owner/repo '{}' full "$PREFETCH_CANONICAL_PRS_SNAPSHOT" >"$prs_output"
+	_prefetch_repo_issues owner/repo '{}' full "$PREFETCH_CANONICAL_ISSUES_SNAPSHOT" >"$issues_output"
+	local provider_after=""
+	provider_after=$(wc -l <"$TEST_ROOT/provider-calls.log" | tr -d ' ')
+	if [[ "$provider_after" == "2" && ! -s "$TEST_ROOT/github-list-calls.log" ]] \
+		&& grep -q 'review: UNKNOWN' "$prs_output" \
+		&& grep -q 'Issue #3' "$issues_output"; then
+		print_result "prefetch output reuses loaded snapshots without reopening providers" 0
+	else
+		print_result "prefetch output reuses loaded snapshots without reopening providers" 1
+	fi
+	return 0
+}
+
+test_complete_empty_pair_is_authoritative() {
+	write_complete_pair generation-empty '[]' '[]'
+	_prefetch_single_repo_load_snapshots owner/repo
+	local fingerprint="" cache_entry=""
+	fingerprint=$(_compute_repo_state_fingerprint owner/repo \
+		"$PREFETCH_CANONICAL_ISSUES_SNAPSHOT" "$PREFETCH_CANONICAL_PRS_SNAPSHOT")
+	cache_entry=$(jq -n --arg fp "$fingerprint" \
+		'{state_fingerprint:$fp,state_fingerprint_schema:"canonical-snapshot-v1"}')
+	if [[ "$fingerprint" =~ ^[0-9a-f]{16}$ ]] \
+		&& _prefetch_detect_cache_hit owner/repo "$cache_entry" \
+			"$PREFETCH_CANONICAL_ISSUES_SNAPSHOT" "$PREFETCH_CANONICAL_PRS_SNAPSHOT"; then
+		print_result "complete empty snapshots remain authoritative cache-hit inputs" 0
+	else
+		print_result "complete empty snapshots remain authoritative cache-hit inputs" 1
+	fi
+	return 0
+}
+
+test_single_repo_cycle_threads_one_snapshot_pair() {
+	write_complete_pair generation-cycle
+	_prefetch_single_repo_load_snapshots owner/repo
+	local fingerprint="" now="" entry="" output_file="$TEST_ROOT/repo-output.txt"
+	fingerprint=$(_compute_repo_state_fingerprint owner/repo \
+		"$PREFETCH_CANONICAL_ISSUES_SNAPSHOT" "$PREFETCH_CANONICAL_PRS_SNAPSHOT")
+	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	entry=$(_prefetch_build_cache_entry \
+		"$now" "$now" "$fingerprint" "$PR_ITEMS" "$ISSUE_ITEMS" true generation-cycle)
+	_prefetch_cache_set owner/repo "$entry"
+	: >"$TEST_ROOT/provider-calls.log"
+	: >"$TEST_ROOT/github-list-calls.log"
+	_PULSE_HEALTH_IDLE_REPO_SKIPS=0
+	_prefetch_single_repo owner/repo "$TEST_ROOT/repo" "$output_file"
+
+	local provider_count="" stored_generation=""
+	provider_count=$(wc -l <"$TEST_ROOT/provider-calls.log" | tr -d ' ')
+	stored_generation=$(_prefetch_cache_get owner/repo | jq -r '.snapshot_generation')
+	if [[ "$provider_count" == "2" && ! -s "$TEST_ROOT/github-list-calls.log" ]] \
+		&& grep -q 'State cache hit' "$output_file" \
+		&& grep -q 'PR #7' "$output_file" \
+		&& grep -q 'Issue #3' "$output_file" \
+		&& [[ "$stored_generation" == "generation-cycle" ]]; then
+		print_result "single-repo cycle threads one snapshot pair through hit, output, and persistence" 0
+	else
+		print_result "single-repo cycle threads one snapshot pair through hit, output, and persistence" 1
+	fi
+	return 0
+}
+
+test_local_eviction_invalidates_completeness() {
+	write_complete_pair generation-eviction
+	"$PULSE_BATCH_PREFETCH_HELPER" evict-issue owner/repo 3 >/dev/null
+	local complete="" source=""
+	complete=$(jq -r '.complete' "$(snapshot_path issues)")
+	source=$(jq -r '.source' "$(snapshot_path issues)")
+	_prefetch_single_repo_load_snapshots owner/repo
+	if [[ "$complete" == "false" && "$source" == "local-eviction" ]] \
+		&& [[ "$PREFETCH_CANONICAL_SNAPSHOT_COMPLETE" == "false" ]]; then
+		print_result "local cache eviction invalidates canonical completeness" 0
+	else
+		print_result "local cache eviction invalidates canonical completeness" 1
+	fi
+	return 0
+}
+
+assert_pair_misses() {
+	local name="$1"
+	_prefetch_single_repo_load_snapshots owner/repo
+	local fingerprint=""
+	fingerprint=$(_compute_repo_state_fingerprint owner/repo \
+		"$PREFETCH_CANONICAL_ISSUES_SNAPSHOT" "$PREFETCH_CANONICAL_PRS_SNAPSHOT")
+	if [[ "$PREFETCH_CANONICAL_SNAPSHOT_COMPLETE" == "false" && -z "$fingerprint" ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1
+	fi
+	return 0
+}
+
+test_incomplete_and_incompatible_pairs_miss() {
+	write_complete_pair generation-partial
+	write_snapshot issues "$ISSUE_ITEMS" false generation-partial "$_PREFETCH_ISSUES_PROJECTION"
+	assert_pair_misses "partial snapshots cannot produce cache hits"
+
+	write_complete_pair generation-a
+	write_snapshot prs "$PR_ITEMS" true generation-b "$_PREFETCH_PRS_PROJECTION"
+	assert_pair_misses "mixed snapshot generations cannot produce cache hits"
+
+	write_complete_pair generation-projection
+	write_snapshot prs "$PR_ITEMS" true generation-projection narrow-projection
+	assert_pair_misses "projection-incompatible snapshots cannot produce cache hits"
+
+	write_complete_pair generation-auth
+	write_snapshot issues "$ISSUE_ITEMS" true generation-auth "$_PREFETCH_ISSUES_PROJECTION" "" other-account
+	assert_pair_misses "auth-scope-incompatible snapshots cannot produce cache hits"
+
+	write_complete_pair generation-stale
+	write_snapshot issues "$ISSUE_ITEMS" true generation-stale "$_PREFETCH_ISSUES_PROJECTION" 2026-01-01T00:00:00Z
+	assert_pair_misses "stale snapshots cannot produce cache hits"
+
+	write_complete_pair generation-malformed
+	printf '{malformed\n' >"$(snapshot_path prs)"
+	assert_pair_misses "malformed snapshots cannot produce cache hits"
+	return 0
+}
+
+test_cache_entry_records_snapshot_contract() {
+	local entry=""
+	entry=$(_prefetch_build_cache_entry \
+		2026-07-18T10:00:00Z 2026-07-18T10:00:00Z abcdef1234567890 \
+		"$PR_ITEMS" "$ISSUE_ITEMS" true generation-cache)
+	if printf '%s' "$entry" | jq -e '
+		.state_fingerprint_schema == "canonical-snapshot-v1" and
+		.snapshot_generation == "generation-cache" and .snapshot_complete == true
+	' >/dev/null; then
+		print_result "summary cache records canonical fingerprint schema and generation" 0
+	else
+		print_result "summary cache records canonical fingerprint schema and generation" 1
+	fi
+	return 0
+}
+
+setup_env
+trap teardown_env EXIT
+test_single_resolution_and_local_reuse
+test_complete_empty_pair_is_authoritative
+test_single_repo_cycle_threads_one_snapshot_pair
+test_local_eviction_invalidates_completeness
+test_incomplete_and_incompatible_pairs_miss
+test_cache_entry_records_snapshot_contract
+
+printf 'Tests run: %s\n' "$TESTS_RUN"
+printf 'Tests failed: %s\n' "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-pulse-sweep-budget.sh
+++ b/.agents/scripts/tests/test-pulse-sweep-budget.sh
@@ -6,22 +6,22 @@
 #
 # Asserts the budget-aware LLM sweep primitives work:
 #
-#   Part 1 — _compute_repo_state_fingerprint produces:
+#   Part 1 — _compute_repo_state_fingerprint produces from canonical snapshots:
 #            * Stable output (identical input → identical hash)
-#            * Sensitive to label/assignee/updatedAt changes
+#            * Sensitive to label/assignee/updatedAt/head SHA changes
 #            * 16-char hex output
-#            * Empty string on gh failure (fail-open)
+#            * Empty string for incomplete/incompatible snapshot pairs
 #
-#   Part 2 — _verify_repo_state_unchanged:
-#            * Returns 0 when search returns zero results
-#            * Returns 1 when search returns any hits
-#            * Returns 1 on gh failure (fail-closed)
+#   Part 2 — canonical pair validation:
+#            * Accepts complete empty collections
+#            * Rejects generation/projection/completeness mismatches
 #
 #   Part 3 — _prefetch_detect_cache_hit:
-#            * Cache hit when fingerprint matches AND verification clean
+#            * Cache hit when canonical fingerprint and schema match
 #            * Cache miss when fingerprint differs
-#            * Cache miss when no cached fingerprint exists
+#            * Cache miss when no cached fingerprint schema exists
 #            * Always sets PREFETCH_CURRENT_FINGERPRINT
+#            * Makes no GitHub list calls
 #
 #   Part 4 — prefetch_hygiene_anomalies output:
 #            * "None — label invariants clean" when all counters zero
@@ -66,9 +66,7 @@ export PULSE_PREFETCH_CACHE_FILE="${TEST_ROOT}/prefetch-cache.json"
 STUB_DIR="${TEST_ROOT}/bin"
 mkdir -p "$STUB_DIR"
 
-# Each test may write GH_ISSUE_LIST_PAYLOAD / GH_SEARCH_LIST_PAYLOAD to
-# control what the stub returns. Empty = return []. GH_STUB_FAIL=1 makes
-# the stub exit non-zero.
+# The stub ledger proves local fingerprint/cache decisions make no GitHub calls.
 GH_CALLS_LOG="${TEST_ROOT}/gh-calls.log"
 export GH_CALLS_LOG
 
@@ -88,7 +86,7 @@ case "$1" in
 	issue|pr)
 		case "$2" in
 			list)
-				# Detect --search (verification query) vs plain list
+				# Keep search-shaped fixtures distinguishable if a regression calls them.
 				has_search="false"
 				for arg in "$@"; do
 					if [[ "$arg" == --search* || "$arg" == "--search" ]]; then
@@ -126,12 +124,35 @@ export PATH="${STUB_DIR}:${PATH}"
 # =============================================================================
 # Part 1 — _compute_repo_state_fingerprint
 # =============================================================================
-ISSUES_A='[{"number":1,"labels":[{"name":"tier:standard"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T10:00:00Z"},{"number":2,"labels":[{"name":"tier:simple"}],"assignees":[],"updatedAt":"2026-04-13T11:00:00Z"}]'
+ISSUES_A='[{"number":1,"state":"open","labels":[{"name":"tier:standard"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T10:00:00Z"},{"number":2,"state":"open","labels":[{"name":"tier:simple"}],"assignees":[],"updatedAt":"2026-04-13T11:00:00Z"}]'
+PRS_A='[{"number":7,"labels":[{"name":"ready"}],"assignees":[],"updatedAt":"2026-04-13T11:00:00Z","headRefOid":"abc123"}]'
 
-export GH_ISSUE_LIST_PAYLOAD="$ISSUES_A"
+make_snapshot() {
+	local kind="$1"
+	local items="$2"
+	local complete="${3:-true}"
+	local generation="${4:-generation-a}"
+	local projection=""
+	if [[ "$kind" == "issues" ]]; then
+		projection="$_PREFETCH_ISSUES_PROJECTION"
+	else
+		projection="$_PREFETCH_PRS_PROJECTION"
+	fi
+	jq -cn --arg schema "$_PREFETCH_SNAPSHOT_SCHEMA" --arg repo "test/repo" \
+		--arg kind "$kind" --arg projection "$projection" --arg generation "$generation" \
+		--argjson complete "$complete" --argjson items "$items" \
+		'{schema:$schema,repository:$repo,collection:$kind,projection:$projection,
+		  auth_scope:"github.com",generation:$generation,source:"fixture",
+		  fetched_at:"2026-04-13T10:00:00Z",
+		  complete:$complete,items:$items}'
+	return 0
+}
+
 : >"$GH_CALLS_LOG"
-fp1=$(_compute_repo_state_fingerprint "test/repo")
-fp2=$(_compute_repo_state_fingerprint "test/repo")
+issues_snapshot_a=$(make_snapshot issues "$ISSUES_A")
+prs_snapshot_a=$(make_snapshot prs "$PRS_A")
+fp1=$(_compute_repo_state_fingerprint "test/repo" "$issues_snapshot_a" "$prs_snapshot_a")
+fp2=$(_compute_repo_state_fingerprint "test/repo" "$issues_snapshot_a" "$prs_snapshot_a")
 
 if [[ -n "$fp1" && "$fp1" == "$fp2" ]]; then
 	print_result "fingerprint is deterministic (same input → same hash)" 0
@@ -147,9 +168,9 @@ else
 fi
 
 # Sensitivity: change a label → fingerprint changes
-ISSUES_B='[{"number":1,"labels":[{"name":"tier:thinking"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T10:00:00Z"},{"number":2,"labels":[{"name":"tier:simple"}],"assignees":[],"updatedAt":"2026-04-13T11:00:00Z"}]'
-export GH_ISSUE_LIST_PAYLOAD="$ISSUES_B"
-fp3=$(_compute_repo_state_fingerprint "test/repo")
+ISSUES_B='[{"number":1,"state":"open","labels":[{"name":"tier:thinking"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T10:00:00Z"},{"number":2,"state":"open","labels":[{"name":"tier:simple"}],"assignees":[],"updatedAt":"2026-04-13T11:00:00Z"}]'
+issues_snapshot_b=$(make_snapshot issues "$ISSUES_B")
+fp3=$(_compute_repo_state_fingerprint "test/repo" "$issues_snapshot_b" "$prs_snapshot_a")
 if [[ -n "$fp3" && "$fp3" != "$fp1" ]]; then
 	print_result "fingerprint changes when a label changes" 0
 else
@@ -158,9 +179,9 @@ else
 fi
 
 # Sensitivity: change updatedAt → fingerprint changes
-ISSUES_C='[{"number":1,"labels":[{"name":"tier:standard"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T12:00:00Z"},{"number":2,"labels":[{"name":"tier:simple"}],"assignees":[],"updatedAt":"2026-04-13T11:00:00Z"}]'
-export GH_ISSUE_LIST_PAYLOAD="$ISSUES_C"
-fp4=$(_compute_repo_state_fingerprint "test/repo")
+ISSUES_C='[{"number":1,"state":"open","labels":[{"name":"tier:standard"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T12:00:00Z"},{"number":2,"state":"open","labels":[{"name":"tier:simple"}],"assignees":[],"updatedAt":"2026-04-13T11:00:00Z"}]'
+issues_snapshot_c=$(make_snapshot issues "$ISSUES_C")
+fp4=$(_compute_repo_state_fingerprint "test/repo" "$issues_snapshot_c" "$prs_snapshot_a")
 if [[ -n "$fp4" && "$fp4" != "$fp1" ]]; then
 	print_result "fingerprint changes when updatedAt changes" 0
 else
@@ -170,12 +191,12 @@ fi
 
 # Order independence: labels in different order within a single issue
 # must yield the same fingerprint (we canonicalize via sort)
-ISSUES_D='[{"number":1,"labels":[{"name":"tier:standard"},{"name":"auto-dispatch"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T10:00:00Z"}]'
-ISSUES_D_REORDERED='[{"number":1,"labels":[{"name":"auto-dispatch"},{"name":"tier:standard"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T10:00:00Z"}]'
-export GH_ISSUE_LIST_PAYLOAD="$ISSUES_D"
-fp_d1=$(_compute_repo_state_fingerprint "test/repo")
-export GH_ISSUE_LIST_PAYLOAD="$ISSUES_D_REORDERED"
-fp_d2=$(_compute_repo_state_fingerprint "test/repo")
+ISSUES_D='[{"number":1,"state":"open","labels":[{"name":"tier:standard"},{"name":"auto-dispatch"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T10:00:00Z"}]'
+ISSUES_D_REORDERED='[{"number":1,"state":"open","labels":[{"name":"auto-dispatch"},{"name":"tier:standard"}],"assignees":[{"login":"alice"}],"updatedAt":"2026-04-13T10:00:00Z"}]'
+issues_snapshot_d=$(make_snapshot issues "$ISSUES_D")
+issues_snapshot_d_reordered=$(make_snapshot issues "$ISSUES_D_REORDERED")
+fp_d1=$(_compute_repo_state_fingerprint "test/repo" "$issues_snapshot_d" "$prs_snapshot_a")
+fp_d2=$(_compute_repo_state_fingerprint "test/repo" "$issues_snapshot_d_reordered" "$prs_snapshot_a")
 if [[ -n "$fp_d1" && "$fp_d1" == "$fp_d2" ]]; then
 	print_result "fingerprint is label-order independent (sorted)" 0
 else
@@ -183,63 +204,60 @@ else
 		"(fp_d1='$fp_d1' fp_d2='$fp_d2')"
 fi
 
-# Fail-open: gh failure returns empty string
-export GH_STUB_FAIL=1
-fp_fail=$(_compute_repo_state_fingerprint "test/repo")
-unset GH_STUB_FAIL
-if [[ -z "$fp_fail" ]]; then
-	print_result "fingerprint returns empty string on gh failure (fail-open)" 0
+# Incomplete input forces the full-analysis path.
+issues_snapshot_incomplete=$(make_snapshot issues "$ISSUES_A" false)
+fp_incomplete=$(_compute_repo_state_fingerprint "test/repo" "$issues_snapshot_incomplete" "$prs_snapshot_a")
+if [[ -z "$fp_incomplete" ]]; then
+	print_result "fingerprint returns empty string for incomplete snapshots" 0
 else
-	print_result "fingerprint returns empty string on gh failure (fail-open)" 1 "(got: '$fp_fail')"
+	print_result "fingerprint returns empty string for incomplete snapshots" 1 "(got: '$fp_incomplete')"
 fi
 
 # =============================================================================
-# Part 2 — _verify_repo_state_unchanged
+# Part 2 — canonical pair validation
 # =============================================================================
-export GH_SEARCH_LIST_PAYLOAD="[]"
-if _verify_repo_state_unchanged "test/repo" "2026-04-13T10:00:00Z"; then
-	print_result "verify returns 0 on empty search result" 0
+empty_issues_snapshot=$(make_snapshot issues '[]')
+empty_prs_snapshot=$(make_snapshot prs '[]')
+empty_fp=$(_compute_repo_state_fingerprint "test/repo" "$empty_issues_snapshot" "$empty_prs_snapshot")
+if [[ "$empty_fp" =~ ^[0-9a-f]{16}$ ]]; then
+	print_result "complete empty snapshot pair produces a fingerprint" 0
 else
-	print_result "verify returns 0 on empty search result" 1
+	print_result "complete empty snapshot pair produces a fingerprint" 1
 fi
 
-export GH_SEARCH_LIST_PAYLOAD='[{"number":1}]'
-if ! _verify_repo_state_unchanged "test/repo" "2026-04-13T10:00:00Z"; then
-	print_result "verify returns 1 when search has hits" 0
+prs_generation_b=$(make_snapshot prs "$PRS_A" true generation-b)
+if ! _canonical_snapshot_pair_complete "test/repo" "$issues_snapshot_a" "$prs_generation_b"; then
+	print_result "canonical pair rejects mixed generations" 0
 else
-	print_result "verify returns 1 when search has hits" 1
+	print_result "canonical pair rejects mixed generations" 1
 fi
 
-if ! _verify_repo_state_unchanged "test/repo" ""; then
-	print_result "verify returns 1 on empty last_pass_iso" 0
+issues_wrong_projection=$(printf '%s' "$issues_snapshot_a" | jq '.projection = "narrow"')
+if ! _canonical_snapshot_pair_complete "test/repo" "$issues_wrong_projection" "$prs_snapshot_a"; then
+	print_result "canonical pair rejects incompatible projections" 0
 else
-	print_result "verify returns 1 on empty last_pass_iso" 1
+	print_result "canonical pair rejects incompatible projections" 1
 fi
 
-# Fail-closed: gh failure = miss
-export GH_STUB_FAIL=1
-if ! _verify_repo_state_unchanged "test/repo" "2026-04-13T10:00:00Z"; then
-	print_result "verify returns 1 on gh failure (fail-closed)" 0
+if ! _canonical_snapshot_pair_complete "test/repo" "$issues_snapshot_incomplete" "$prs_snapshot_a"; then
+	print_result "canonical pair rejects incomplete collections" 0
 else
-	print_result "verify returns 1 on gh failure (fail-closed)" 1
+	print_result "canonical pair rejects incomplete collections" 1
 fi
-unset GH_STUB_FAIL
 
 # =============================================================================
 # Part 3 — _prefetch_detect_cache_hit
 # =============================================================================
-export GH_ISSUE_LIST_PAYLOAD="$ISSUES_A"
-export GH_SEARCH_LIST_PAYLOAD="[]"
-# Compute the expected fingerprint for this state
-expected_fp=$(_compute_repo_state_fingerprint "test/repo")
+expected_fp=$(_compute_repo_state_fingerprint "test/repo" "$issues_snapshot_a" "$prs_snapshot_a")
 
-# Case A: cache has matching fingerprint + clean verification → hit
+# Case A: cache has matching canonical fingerprint/schema → hit
 cache_entry_a=$(jq -n --arg fp "$expected_fp" --arg ts "2026-04-13T10:00:00Z" \
-	'{state_fingerprint: $fp, last_prefetch: $ts, last_full_sweep: $ts, prs: [], issues: []}')
-if _prefetch_detect_cache_hit "test/repo" "$cache_entry_a"; then
-	print_result "cache hit when fingerprint matches and verification clean" 0
+	'{state_fingerprint: $fp, state_fingerprint_schema:"canonical-snapshot-v1",
+	  last_prefetch: $ts, last_full_sweep: $ts, prs: [], issues: []}')
+if _prefetch_detect_cache_hit "test/repo" "$cache_entry_a" "$issues_snapshot_a" "$prs_snapshot_a"; then
+	print_result "cache hit when canonical fingerprint and schema match" 0
 else
-	print_result "cache hit when fingerprint matches and verification clean" 1
+	print_result "cache hit when canonical fingerprint and schema match" 1
 fi
 
 # PREFETCH_CURRENT_FINGERPRINT must be set on the caller
@@ -252,8 +270,9 @@ fi
 
 # Case B: cache has different fingerprint → miss
 cache_entry_b=$(jq -n --arg fp "wrongfingerpr" --arg ts "2026-04-13T10:00:00Z" \
-	'{state_fingerprint: $fp, last_prefetch: $ts, last_full_sweep: $ts, prs: [], issues: []}')
-if ! _prefetch_detect_cache_hit "test/repo" "$cache_entry_b"; then
+	'{state_fingerprint: $fp, state_fingerprint_schema:"canonical-snapshot-v1",
+	  last_prefetch: $ts, last_full_sweep: $ts, prs: [], issues: []}')
+if ! _prefetch_detect_cache_hit "test/repo" "$cache_entry_b" "$issues_snapshot_a" "$prs_snapshot_a"; then
 	print_result "cache miss when fingerprint differs" 0
 else
 	print_result "cache miss when fingerprint differs" 1
@@ -261,18 +280,23 @@ fi
 
 # Case C: cache has no fingerprint field → miss
 cache_entry_c='{"last_prefetch":"2026-04-13T10:00:00Z","last_full_sweep":"2026-04-13T10:00:00Z","prs":[],"issues":[]}'
-if ! _prefetch_detect_cache_hit "test/repo" "$cache_entry_c"; then
-	print_result "cache miss when fingerprint field absent" 0
+if ! _prefetch_detect_cache_hit "test/repo" "$cache_entry_c" "$issues_snapshot_a" "$prs_snapshot_a"; then
+	print_result "cache miss when fingerprint schema is absent" 0
 else
-	print_result "cache miss when fingerprint field absent" 1
+	print_result "cache miss when fingerprint schema is absent" 1
 fi
 
-# Case D: fingerprint matches but verification fails → miss
-export GH_SEARCH_LIST_PAYLOAD='[{"number":42}]'
-if ! _prefetch_detect_cache_hit "test/repo" "$cache_entry_a"; then
-	print_result "cache miss when fingerprint matches but state changed" 0
+# Case D: matching cached value cannot authorize an incomplete current pair.
+if ! _prefetch_detect_cache_hit "test/repo" "$cache_entry_a" "$issues_snapshot_incomplete" "$prs_snapshot_a"; then
+	print_result "cache miss when current snapshot is incomplete" 0
 else
-	print_result "cache miss when fingerprint matches but state changed" 1
+	print_result "cache miss when current snapshot is incomplete" 1
+fi
+
+if [[ ! -s "$GH_CALLS_LOG" ]]; then
+	print_result "fingerprint and cache-hit decisions make zero GitHub calls" 0
+else
+	print_result "fingerprint and cache-hit decisions make zero GitHub calls" 1
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Persist versioned canonical issue and PR snapshots, validate completeness/generation/projection/auth scope, and reuse one snapshot pair for fingerprinting, rendering, and cache persistence without duplicate GitHub verification reads.

## Files Changed

.agents/configs/pulse-sweep-budget.json, .agents/scripts/pulse-batch-conditional-cache.py, .agents/scripts/pulse-batch-prefetch-helper.sh, .agents/scripts/pulse-prefetch-fetch.sh, .agents/scripts/pulse-prefetch-infra.sh, .agents/scripts/pulse-prefetch-repo.sh, .agents/scripts/tests/test-enrich-batch-prefetch.sh, .agents/scripts/tests/test-jq-large-json-argv-regression.sh, .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh, .agents/scripts/tests/test-pulse-prefetch-canonical-snapshot.sh, .agents/scripts/tests/test-pulse-sweep-budget.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Changed-file and full local linter gates; 13 canonical snapshot tests; 19 conditional REST tests; 22 sweep/fingerprint tests; 28 enrich tests; 11 delta tests; 7 large-JSON tests; 6 exact-output cache tests; unbound-variable, CI-prefetch, and triage evidence regressions; Bash syntax and Python compilation.

Resolves #27771


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.150 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 1d 6h and 5,584,215 tokens on this with the user in an interactive session.