### PR TITLE
t18128: cache PR check status by head SHA

### DIFF
--- a/.agents/scripts/pulse-batch-conditional-cache.py
+++ b/.agents/scripts/pulse-batch-conditional-cache.py
@@ -188,13 +188,15 @@ def _refresh_cached_response(
             for item in items
             if str(item.get("state") or "open").lower() == "open"
         ]
-    compatible = (
-        payload.get("schema") == _SNAPSHOT_SCHEMA
-        and payload.get("repository") == slug
-        and payload.get("collection") == kind
-        and payload.get("projection") == projection
-        and payload.get("auth_scope") == auth_scope
-        and isinstance(payload.get("complete"), bool)
+    compatible = all(
+        (
+            payload.get("schema") == _SNAPSHOT_SCHEMA,
+            payload.get("repository") == slug,
+            payload.get("collection") == kind,
+            payload.get("projection") == projection,
+            payload.get("auth_scope") == auth_scope,
+            isinstance(payload.get("complete"), bool),
+        )
     )
     payload.update(
         {

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -116,7 +116,10 @@ _prefetch_prs_try_delta() {
 # `statusCheckRollup` field that was the single heaviest payload in the
 # pulse's GraphQL budget).
 #
-# Non-fatal: returns "[]" on failure (caller treats as "no check info").
+# The batch helper caches only this observational aggregate, emits cache/fetch
+# decisions to gh transport telemetry, and preserves live named-check reads for
+# final required-check and merge authority. Non-fatal: returns "[]" on failure
+# (caller treats as "no check info").
 #
 # Arguments:
 #   $1 - repo slug
@@ -250,7 +253,7 @@ _prefetch_repo_prs() {
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_prs: using cycle canonical snapshot for ${slug}" >>"$LOGFILE"
 			_prefetch_record_batch_cache_hit prs "$_canonical_prs"
-			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$((${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1))
 		fi
 	elif [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
 		local _batch_prs
@@ -259,7 +262,7 @@ _prefetch_repo_prs() {
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_prs: using batch cache for ${slug}" >>"$LOGFILE"
 			_prefetch_record_batch_cache_hit prs "$_batch_prs"
-			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$((${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1))
 		fi
 	fi
 
@@ -442,7 +445,7 @@ _prefetch_repo_issues() {
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_issues: using cycle canonical snapshot for ${slug}" >>"$LOGFILE"
 			_prefetch_record_batch_cache_hit issues "$_canonical_issues"
-			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$((${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1))
 		fi
 	elif [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
 		local _batch_issues
@@ -451,7 +454,7 @@ _prefetch_repo_issues() {
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_issues: using batch cache for ${slug}" >>"$LOGFILE"
 			_prefetch_record_batch_cache_hit issues "$_batch_issues"
-			_PULSE_HEALTH_BATCH_CACHE_HITS=$(( ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1 ))
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$((${_PULSE_HEALTH_BATCH_CACHE_HITS:-0} + 1))
 		fi
 	fi
 
@@ -489,7 +492,6 @@ _prefetch_repo_issues() {
 	_prefetch_repo_issues_render "$issue_json"
 	return 0
 }
-
 
 # =============================================================================
 # Issue Delta Fetch Helper (GH#15286)

--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -53,6 +53,262 @@
 [[ -n "${_SHARED_GH_WRAPPERS_CHECKS_LIB_LOADED:-}" ]] && return 0
 _SHARED_GH_WRAPPERS_CHECKS_LIB_LOADED=1
 
+_GH_PR_CHECK_STATUS_SCHEMA="aidevops-gh-pr-check-status/v1"
+_GH_PR_CHECK_STATUS_PROJECTION="check-suites-aggregate/v1"
+_GH_PR_CHECK_STATUS_SOURCE="rest-check-suites"
+_GH_PR_CHECK_STATUS_NONE=none
+
+#######################################
+# Record an observational check-status cache decision without counting an HTTP
+# attempt. The transport wrapper records actual REST attempts separately.
+# Args: $1=decision
+#######################################
+_gh_pr_check_status_cache_record() {
+	local decision="$1"
+	if declare -F gh_record_call >/dev/null 2>&1; then
+		gh_record_call other gh_pr_check_status_cache unknown other "$decision" "" cache 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
+# Resolve the non-secret auth identity used to isolate cache entries.
+#######################################
+_gh_pr_check_status_cache_auth_scope() {
+	printf '%s' "${AIDEVOPS_GH_CHECK_STATUS_CACHE_AUTH_SCOPE:-${GH_HOST:-github.com}|${AIDEVOPS_GH_AUTH_MODE:-gh}|${AIDEVOPS_GH_AUTH_PRINCIPAL:-default}}"
+	return 0
+}
+
+#######################################
+# Emit the current epoch. Kept as a seam for deterministic TTL tests.
+#######################################
+_gh_pr_check_status_cache_now() {
+	date +%s 2>/dev/null || printf '0\n'
+	return 0
+}
+
+#######################################
+# Validate the immutable cache identity. GitHub currently returns full
+# 40-character hex OIDs; 64-character OIDs are accepted for SHA-256 repositories.
+# Args: $1=repo slug, $2=full head SHA
+#######################################
+_gh_pr_check_status_cache_identity_valid() {
+	local slug="$1"
+	local sha="$2"
+	[[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+	[[ "$sha" =~ ^[A-Fa-f0-9]{40}$ || "$sha" =~ ^[A-Fa-f0-9]{64}$ ]] || return 1
+	return 0
+}
+
+#######################################
+# Classify aggregate states for bounded expiry.
+# Args: $1=PASS|FAIL|PENDING|none
+# Stdout: terminal|actionable
+#######################################
+_gh_pr_check_status_cache_class() {
+	local check_state="$1"
+	case "$check_state" in
+	PASS | FAIL) printf 'terminal\n' ;;
+	PENDING | none) printf 'actionable\n' ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+#######################################
+# Resolve a validated bounded TTL. Terminal observations default to six hours
+# (maximum seven days); pending/none observations default to 30 seconds
+# (maximum five minutes) so actionable changes refresh promptly.
+# Args: $1=terminal|actionable
+#######################################
+_gh_pr_check_status_cache_ttl() {
+	local expiry_class="$1"
+	local ttl="" default_ttl="" max_ttl=""
+	case "$expiry_class" in
+	terminal)
+		default_ttl=21600
+		max_ttl=604800
+		ttl="${AIDEVOPS_GH_CHECK_STATUS_CACHE_TERMINAL_TTL:-$default_ttl}"
+		;;
+	actionable)
+		default_ttl=30
+		max_ttl=300
+		ttl="${AIDEVOPS_GH_CHECK_STATUS_CACHE_ACTIONABLE_TTL:-$default_ttl}"
+		;;
+	*) return 1 ;;
+	esac
+	if [[ ! "$ttl" =~ ^[0-9]+$ || "$ttl" -le 0 || "$ttl" -gt "$max_ttl" ]]; then
+		ttl="$default_ttl"
+	fi
+	printf '%s\n' "$ttl"
+	return 0
+}
+
+#######################################
+# Build a collision-resistant cache key from auth scope, repository, exact full
+# head SHA, and aggregate projection version.
+# Args: $1=repo slug, $2=full head SHA
+#######################################
+_gh_pr_check_status_cache_key() {
+	local slug="$1"
+	local sha="$2"
+	local auth_scope="" material="" key=""
+	_gh_pr_check_status_cache_identity_valid "$slug" "$sha" || return 1
+	auth_scope="$(_gh_pr_check_status_cache_auth_scope)"
+	material="${auth_scope}"$'\034'"${slug}"$'\034'"${sha}"$'\034'"${_GH_PR_CHECK_STATUS_PROJECTION}"
+	if command -v shasum >/dev/null 2>&1; then
+		key=$(printf '%s' "$material" | shasum -a 256 | awk '{print $1}')
+	elif command -v openssl >/dev/null 2>&1; then
+		key=$(printf '%s' "$material" | openssl dgst -sha256 | awk '{print $NF}')
+	else
+		key=$(printf '%s' "$material" | cksum | awk '{print $1}')
+	fi
+	[[ -n "$key" ]] || return 1
+	printf '%s\n' "$key"
+	return 0
+}
+
+#######################################
+# Resolve a private disposable cache path.
+# Args: $1=repo slug, $2=full head SHA
+#######################################
+_gh_pr_check_status_cache_path() {
+	local slug="$1"
+	local sha="$2"
+	local dir="${AIDEVOPS_GH_CHECK_STATUS_CACHE_DIR:-${HOME}/.aidevops/cache/gh-pr-check-status}"
+	local key=""
+	key="$(_gh_pr_check_status_cache_key "$slug" "$sha")" || return 1
+	mkdir -p "$dir" 2>/dev/null || return 1
+	chmod 700 "$dir" 2>/dev/null || return 1
+	printf '%s/entry-%s.json\n' "$dir" "$key"
+	return 0
+}
+
+#######################################
+# Emit a fresh validated aggregate state from cache.
+# Args: $1=repo slug, $2=full head SHA
+# Returns: 0=hit, 1=miss/stale/invalid/disabled
+#######################################
+_gh_pr_check_status_cache_get() {
+	local slug="$1"
+	local sha="$2"
+	if [[ "${AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE:-0}" == "1" ]]; then
+		_gh_pr_check_status_cache_record bypass-disabled
+		return 1
+	fi
+	if ! _gh_pr_check_status_cache_identity_valid "$slug" "$sha"; then
+		_gh_pr_check_status_cache_record bypass-invalid-identity
+		return 1
+	fi
+
+	local path="" auth_scope="" entry=""
+	path="$(_gh_pr_check_status_cache_path "$slug" "$sha")" || {
+		_gh_pr_check_status_cache_record bypass
+		return 1
+	}
+	[[ -s "$path" ]] || {
+		_gh_pr_check_status_cache_record miss
+		return 1
+	}
+	auth_scope="$(_gh_pr_check_status_cache_auth_scope)"
+	entry=$(jq -er --arg schema "$_GH_PR_CHECK_STATUS_SCHEMA" \
+		--arg repository "$slug" --arg head_sha "$sha" \
+		--arg projection "$_GH_PR_CHECK_STATUS_PROJECTION" \
+		--arg auth_scope "$auth_scope" --arg source "$_GH_PR_CHECK_STATUS_SOURCE" \
+		--arg none_state "$_GH_PR_CHECK_STATUS_NONE" '
+		select(
+			.schema == $schema and .repository == $repository and
+			.head_sha == $head_sha and .projection == $projection and
+			.auth_scope == $auth_scope and .source == $source and
+			.validation == "validated" and
+			(.fetched_at | type == "number" and floor == .) and
+			(
+				((.state == "PASS" or .state == "FAIL") and .expiry_class == "terminal") or
+				((.state == "PENDING" or .state == $none_state) and .expiry_class == "actionable")
+			)
+		) |
+		[.state, (.fetched_at | tostring), .expiry_class] | @tsv' "$path" 2>/dev/null) || entry=""
+	if [[ -z "$entry" ]]; then
+		_gh_pr_check_status_cache_record invalid
+		return 1
+	fi
+
+	local check_state="" fetched_at="" expiry_class="" ttl="" now="" age=0
+	IFS=$'\t' read -r check_state fetched_at expiry_class <<<"$entry"
+	ttl="$(_gh_pr_check_status_cache_ttl "$expiry_class")" || return 1
+	now="$(_gh_pr_check_status_cache_now)"
+	if [[ ! "$now" =~ ^[0-9]+$ || ! "$fetched_at" =~ ^[0-9]+$ ]]; then
+		_gh_pr_check_status_cache_record invalid-time
+		return 1
+	fi
+	age=$((now - fetched_at))
+	if [[ "$age" -lt 0 || "$age" -gt "$ttl" ]]; then
+		_gh_pr_check_status_cache_record "refresh-${expiry_class}"
+		return 1
+	fi
+	_gh_pr_check_status_cache_record "hit-${expiry_class}"
+	printf '%s\n' "$check_state"
+	return 0
+}
+
+#######################################
+# Atomically store one validated aggregate observation. Concurrent writers use
+# unique temp files; last-writer-wins is safe for the same immutable identity.
+# Args: $1=repo slug, $2=full head SHA, $3=aggregate state
+#######################################
+_gh_pr_check_status_cache_put() {
+	local slug="$1"
+	local sha="$2"
+	local check_state="$3"
+	[[ "${AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE:-0}" != "1" ]] || return 0
+	_gh_pr_check_status_cache_identity_valid "$slug" "$sha" || return 0
+	local expiry_class="" path="" dir="" tmp="" now="" auth_scope=""
+	expiry_class="$(_gh_pr_check_status_cache_class "$check_state")" || return 0
+	path="$(_gh_pr_check_status_cache_path "$slug" "$sha")" || return 0
+	dir="${path%/*}"
+	now="$(_gh_pr_check_status_cache_now)"
+	[[ "$now" =~ ^[0-9]+$ ]] || return 0
+	auth_scope="$(_gh_pr_check_status_cache_auth_scope)"
+	tmp=$(mktemp "${dir}/.pr-check-status.XXXXXX" 2>/dev/null) || return 0
+	chmod 600 "$tmp" 2>/dev/null || {
+		rm -f "$tmp"
+		return 0
+	}
+	if ! jq -n --arg schema "$_GH_PR_CHECK_STATUS_SCHEMA" \
+		--arg repository "$slug" --arg head_sha "$sha" \
+		--arg projection "$_GH_PR_CHECK_STATUS_PROJECTION" \
+		--arg auth_scope "$auth_scope" --arg state "$check_state" \
+		--arg expiry_class "$expiry_class" --arg source "$_GH_PR_CHECK_STATUS_SOURCE" \
+		--argjson fetched_at "$now" \
+		'{schema:$schema,repository:$repository,head_sha:$head_sha,projection:$projection,
+		auth_scope:$auth_scope,state:$state,fetched_at:$fetched_at,
+		expiry_class:$expiry_class,source:$source,validation:"validated"}' >"$tmp"; then
+		rm -f "$tmp"
+		return 0
+	fi
+	if mv "$tmp" "$path" 2>/dev/null; then
+		_gh_pr_check_status_cache_record "store-${expiry_class}"
+	else
+		rm -f "$tmp"
+	fi
+	return 0
+}
+
+#######################################
+# Idempotently invalidate one repository/full-head/projection/auth entry. This
+# interface is intentionally webhook-agnostic for the later invalidation phase.
+# Args: $1=repo slug, $2=full head SHA
+#######################################
+gh_pr_check_status_cache_invalidate() {
+	local slug="$1"
+	local sha="$2"
+	local path=""
+	path="$(_gh_pr_check_status_cache_path "$slug" "$sha")" || return 0
+	rm -f "$path"
+	_gh_pr_check_status_cache_record invalidate
+	return 0
+}
+
 #######################################
 # Internal: invoke a read-only `gh api` request with a wall-clock cap.
 #
@@ -97,34 +353,57 @@ _gh_checks_api_read() {
 #   $1 - repo slug (owner/repo)
 #   $2 - commit SHA (PR's headRefOid)
 #
-# Output (stdout): one of "PASS", "FAIL", "PENDING", "none"
+# Output (stdout): one of "PASS", "FAIL", "PENDING", "none". Valid aggregate
+# observations are cached by repository/auth/full-head/projection identity.
 # Returns: 0 always (returns "none" on missing args / API error — fail-open
 #          since callers treat "none" as "no checks recorded yet")
 #######################################
-gh_pr_check_status_rest() {
+_gh_pr_check_status_rest_fetch() {
 	local slug="$1"
 	local sha="$2"
-
-	if [[ -z "$slug" || -z "$sha" ]]; then
-		echo "none"
-		return 0
-	fi
-
 	# NOTE: variable is `_check_state` not `status` — zsh treats `status` as a
 	# read-only special variable, which would silently fail under zsh-sourced
 	# interactive use even though the script declares `#!/usr/bin/env bash`.
 	local _check_state=""
 	# shellcheck disable=SC2016 # jq program uses $active as a jq variable.
-	_check_state=$(_gh_checks_api_read "repos/${slug}/commits/${sha}/check-suites" --jq '
+	if ! _check_state=$(_gh_checks_api_read "repos/${slug}/commits/${sha}/check-suites" --jq '
 		((.check_suites // []) | map(select(.conclusion != null or .status != "queued"))) as $active |
 		if ($active | length) == 0 then "none"
 		elif ($active | all(.conclusion == "success" or .conclusion == "skipped" or .conclusion == "neutral")) then "PASS"
 		elif ($active | any(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")) then "FAIL"
 		else "PENDING"
-		end' 2>/dev/null) || _check_state=""
+		end' 2>/dev/null); then
+		return 1
+	fi
+	_gh_pr_check_status_cache_class "$_check_state" >/dev/null || return 1
+	printf '%s\n' "$_check_state"
+	return 0
+}
 
-	_check_state="${_check_state:-none}"
-	echo "$_check_state"
+gh_pr_check_status_rest() {
+	local slug="$1"
+	local sha="$2"
+
+	if [[ -z "$slug" || -z "$sha" ]]; then
+		printf 'none\n'
+		return 0
+	fi
+
+	local _check_state=""
+	if _check_state="$(_gh_pr_check_status_cache_get "$slug" "$sha")"; then
+		printf '%s\n' "$_check_state"
+		return 0
+	fi
+
+	_gh_pr_check_status_cache_record fetch
+	if _check_state="$(_gh_pr_check_status_rest_fetch "$slug" "$sha")"; then
+		_gh_pr_check_status_cache_put "$slug" "$sha" "$_check_state"
+		printf '%s\n' "$_check_state"
+		return 0
+	fi
+
+	_gh_pr_check_status_cache_record fetch-failed
+	printf 'none\n'
 	return 0
 }
 
@@ -227,10 +506,9 @@ gh_pr_check_runs_rest() {
 #######################################
 # Batch-enrich a PR list with aggregated REST check status.
 #
-# Loops `gh_pr_check_status_rest` over each PR in the input list and
-# returns a JSON array of {number, status} pairs. Sequential per-PR calls
-# are acceptable here because each REST call is ~1.3KB (much faster than
-# the previous ~21KB GraphQL field per PR, and the REST pool is separate).
+# Resolves each unique full head SHA once, reusing fresh aggregate cache entries
+# and fetching only missing/expired/actionable identities. It then fans the
+# state back out to every input PR in original order.
 #
 # Args:
 #   $1 - repo slug (owner/repo)
@@ -258,21 +536,36 @@ gh_pr_check_status_rest_batch() {
 		return 0
 	fi
 
-	# Build result array. Use a tmpfile rather than a subshell-piped `while`
-	# loop to avoid losing accumulated lines under bash 3.2 (subshell vars
-	# don't propagate out of the pipe).
-	local tmp
-	tmp=$(mktemp)
+	local unique_shas=""
+	unique_shas=$(printf '%s\n' "$pairs" | awk -F '\t' 'NF >= 2 && !seen[$2]++ {print $2}')
+	[[ -n "$unique_shas" ]] || {
+		printf '[]\n'
+		return 0
+	}
+
+	# Build one SHA→state map. A tmpfile avoids bash 3.2 pipeline-subshell
+	# variable loss while keeping duplicate identities transport-free.
+	local tmp=""
+	tmp=$(mktemp 2>/dev/null) || {
+		printf '[]\n'
+		return 0
+	}
 	# NOTE: see gh_pr_check_status_rest above — `status` is read-only in zsh.
-	local pr_num="" pr_sha="" _check_state=""
-	while IFS=$'\t' read -r pr_num pr_sha; do
-		[[ -n "$pr_num" && -n "$pr_sha" ]] || continue
+	local pr_sha="" _check_state=""
+	while IFS= read -r pr_sha; do
+		[[ -n "$pr_sha" ]] || continue
 		_check_state=$(gh_pr_check_status_rest "$slug" "$pr_sha")
-		printf '{"number":%s,"status":"%s"}\n' "$pr_num" "$_check_state" >>"$tmp"
-	done <<<"$pairs"
+		printf '%s\t%s\n' "$pr_sha" "$_check_state" >>"$tmp"
+	done <<<"$unique_shas"
 
 	local result=""
-	result=$(jq -s '.' <"$tmp" 2>/dev/null) || result="[]"
+	result=$(jq -n --argjson prs "$pr_json" --rawfile states "$tmp" \
+		--arg none_state "$_GH_PR_CHECK_STATUS_NONE" '
+		($states | split("\n") |
+			map(select(length > 0) | split("\t") | select(length == 2) | {(.[0]): .[1]}) |
+			add // {}) as $state_map |
+		[$prs[] | select(.number and .headRefOid) |
+			{number: .number, status: ($state_map[.headRefOid] // $none_state)}]' 2>/dev/null) || result="[]"
 	rm -f "$tmp"
 	[[ -n "$result" && "$result" != "null" ]] || result="[]"
 

--- a/.agents/scripts/tests/test-gh-check-status-cache.sh
+++ b/.agents/scripts/tests/test-gh-check-status-cache.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for t18128: aggregate PR check-state caching by exact
+# repository/auth-scope/head-SHA/projection identity. The cached rollup is
+# observational only; named required-check and merge-authority reads stay live.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+CHECKS_LIB="${SCRIPTS_DIR}/shared-gh-wrappers-checks.sh"
+MERGE_REQUIRED_LIB="${SCRIPTS_DIR}/pulse-merge-required-checks.sh"
+TEST_ROOT="$(mktemp -d)"
+ORIGINAL_HOME="${HOME}"
+
+export HOME="${TEST_ROOT}/home"
+export AIDEVOPS_GH_CHECK_STATUS_CACHE_DIR="${TEST_ROOT}/cache"
+export AIDEVOPS_GH_CHECK_STATUS_CACHE_TERMINAL_TTL=60
+export AIDEVOPS_GH_CHECK_STATUS_CACHE_ACTIONABLE_TTL=10
+export AIDEVOPS_GH_AUTH_MODE=gh
+export AIDEVOPS_GH_AUTH_PRINCIPAL=default
+mkdir -p "$HOME"
+
+API_CALLS="${TEST_ROOT}/api-calls.log"
+CHECK_NOW=100
+CHECK_API_MODE=success
+CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+
+SHA_A="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+SHA_B="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+SHA_C="cccccccccccccccccccccccccccccccccccccccc"
+SHA_D="dddddddddddddddddddddddddddddddddddddddd"
+SHA_E="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+SHA_F="ffffffffffffffffffffffffffffffffffffffff"
+SHA_G="1111111111111111111111111111111111111111"
+SHA_H="2222222222222222222222222222222222222222"
+
+# shellcheck source=../shared-gh-wrappers-checks.sh
+source "$CHECKS_LIB"
+
+cleanup() {
+	export HOME="$ORIGINAL_HOME"
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+# Deterministic clock seam used by the cache expiry helpers.
+_gh_pr_check_status_cache_now() {
+	printf '%s\n' "$CHECK_NOW"
+	return 0
+}
+
+# Stub the transport while preserving the production jq projection contract.
+_gh_checks_api_read() {
+	local endpoint="$1"
+	shift
+	printf '%s\n' "$endpoint" >>"$API_CALLS"
+
+	case "$CHECK_API_MODE" in
+	failure)
+		return 1
+		;;
+	malformed)
+		printf 'NOT_A_CHECK_STATE\n'
+		return 0
+		;;
+	success) ;;
+	*)
+		printf 'unexpected CHECK_API_MODE: %s\n' "$CHECK_API_MODE" >&2
+		return 1
+		;;
+	esac
+
+	local jq_filter=""
+	while [[ "$#" -gt 0 ]]; do
+		local arg="$1"
+		shift
+		if [[ "$arg" == "--jq" && "$#" -gt 0 ]]; then
+			jq_filter="$1"
+			shift
+		fi
+	done
+	[[ -n "$jq_filter" ]] || return 1
+	printf '%s\n' "$CHECK_SUITES_FIXTURE" | jq -r "$jq_filter"
+	return $?
+}
+
+api_call_count() {
+	local count=0
+	if [[ -f "$API_CALLS" ]]; then
+		count=$(wc -l <"$API_CALLS")
+		count="${count//[!0-9]/}"
+	fi
+	printf '%s\n' "${count:-0}"
+	return 0
+}
+
+assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" != "$expected" ]]; then
+		printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$name" "$expected" "$actual" >&2
+		return 1
+	fi
+	printf 'PASS: %s\n' "$name"
+	return 0
+}
+
+assert_json_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	local expected_compact="" actual_compact=""
+	expected_compact=$(printf '%s' "$expected" | jq -c '.')
+	actual_compact=$(printf '%s' "$actual" | jq -c '.')
+	assert_eq "$name" "$expected_compact" "$actual_compact"
+	return $?
+}
+
+cache_path() {
+	local slug="$1"
+	local sha="$2"
+	_gh_pr_check_status_cache_path "$slug" "$sha"
+	return $?
+}
+
+file_mode() {
+	local path="$1"
+	local mode=""
+	mode=$(stat -f '%Lp' "$path" 2>/dev/null) || mode=$(stat -c '%a' "$path" 2>/dev/null) || return 1
+	printf '%s\n' "$mode"
+	return 0
+}
+
+test_terminal_reuse_dedup_and_order() {
+	local prs='[{"number":9,"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},{"number":3,"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
+	local result=""
+	result=$(gh_pr_check_status_rest_batch "owner/repo" "$prs")
+	assert_json_eq "duplicate heads preserve PR order and cardinality" \
+		'[{"number":9,"status":"PASS"},{"number":3,"status":"PASS"}]' "$result"
+	assert_eq "duplicate heads make one transport attempt" "1" "$(api_call_count)"
+
+	result=$(gh_pr_check_status_rest_batch "owner/repo" "$prs")
+	assert_json_eq "unchanged terminal heads reuse cached aggregate state" \
+		'[{"number":9,"status":"PASS"},{"number":3,"status":"PASS"}]' "$result"
+	assert_eq "unchanged terminal heads make zero additional attempts" "1" "$(api_call_count)"
+	return 0
+}
+
+test_new_head_repo_and_auth_scope_miss() {
+	local result=""
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"failure"}]}'
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":4,"headRefOid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]')
+	assert_json_eq "new full head SHA misses prior-head cache" '[{"number":4,"status":"FAIL"}]' "$result"
+	assert_eq "new head performs one additional attempt" "2" "$(api_call_count)"
+
+	result=$(gh_pr_check_status_rest_batch "other/repo" \
+		'[{"number":5,"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
+	assert_json_eq "same head does not leak across repositories" '[{"number":5,"status":"FAIL"}]' "$result"
+	assert_eq "repository scope performs one additional attempt" "3" "$(api_call_count)"
+
+	AIDEVOPS_GH_AUTH_PRINCIPAL=alternate
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":6,"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
+	assert_json_eq "same repo and head do not leak across auth scopes" '[{"number":6,"status":"FAIL"}]' "$result"
+	assert_eq "auth scope performs one additional attempt" "4" "$(api_call_count)"
+	AIDEVOPS_GH_AUTH_PRINCIPAL=default
+
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":7,"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]')
+	assert_json_eq "original auth scope retains its terminal entry" '[{"number":7,"status":"PASS"}]' "$result"
+	assert_eq "returning to original auth scope is transport-free" "4" "$(api_call_count)"
+	return 0
+}
+
+test_actionable_and_terminal_expiry() {
+	local result=""
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"in_progress","conclusion":null}]}'
+	CHECK_NOW=200
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":8,"headRefOid":"cccccccccccccccccccccccccccccccccccccccc"}]')
+	assert_json_eq "pending state is cached briefly" '[{"number":8,"status":"PENDING"}]' "$result"
+	assert_eq "initial pending observation is fetched" "5" "$(api_call_count)"
+
+	CHECK_NOW=209
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":8,"headRefOid":"cccccccccccccccccccccccccccccccccccccccc"}]')
+	assert_json_eq "pending state is reused inside actionable TTL" '[{"number":8,"status":"PENDING"}]' "$result"
+	assert_eq "fresh pending entry makes no additional attempt" "5" "$(api_call_count)"
+
+	CHECK_NOW=211
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":8,"headRefOid":"cccccccccccccccccccccccccccccccccccccccc"}]')
+	assert_json_eq "expired pending state refreshes to terminal" '[{"number":8,"status":"PASS"}]' "$result"
+	assert_eq "expired pending entry performs one refresh" "6" "$(api_call_count)"
+
+	CHECK_NOW=300
+	CHECK_SUITES_FIXTURE='{}'
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":10,"headRefOid":"dddddddddddddddddddddddddddddddddddddddd"}]')
+	assert_json_eq "none state remains an explicit actionable observation" '[{"number":10,"status":"none"}]' "$result"
+	assert_eq "initial none observation is fetched" "7" "$(api_call_count)"
+
+	CHECK_NOW=311
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":10,"headRefOid":"dddddddddddddddddddddddddddddddddddddddd"}]')
+	assert_json_eq "expired none state refreshes" '[{"number":10,"status":"PASS"}]' "$result"
+	assert_eq "expired none entry performs one refresh" "8" "$(api_call_count)"
+
+	CHECK_NOW=372
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"failure"}]}'
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":10,"headRefOid":"dddddddddddddddddddddddddddddddddddddddd"}]')
+	assert_json_eq "terminal state refreshes after bounded terminal TTL" '[{"number":10,"status":"FAIL"}]' "$result"
+	assert_eq "expired terminal entry performs one refresh" "9" "$(api_call_count)"
+	return 0
+}
+
+test_corruption_failure_and_invalidation() {
+	local path="" result="" before="" after=""
+	CHECK_NOW=400
+	path=$(cache_path "owner/repo" "$SHA_E")
+	printf '{broken json\n' >"$path"
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_E")
+	assert_eq "malformed cache entry is a miss" "PASS" "$result"
+	assert_eq "malformed cache entry triggers a live fetch" "10" "$(api_call_count)"
+	if ! jq -e --arg sha "$SHA_E" '.head_sha == $sha and .state == "PASS"' "$path" >/dev/null; then
+		printf 'FAIL: malformed cache entry was not replaced atomically\n' >&2
+		return 1
+	fi
+	printf 'PASS: malformed cache entry is replaced with validated schema\n'
+
+	CHECK_NOW=500
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_F")
+	assert_eq "terminal fixture seeds API-failure scenario" "PASS" "$result"
+	path=$(cache_path "owner/repo" "$SHA_F")
+	before=$(jq -c '.' "$path")
+	CHECK_NOW=561
+	CHECK_API_MODE=failure
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_F")
+	assert_eq "API failure returns non-authoritative none" "none" "$result"
+	after=$(jq -c '.' "$path")
+	assert_eq "API failure does not overwrite prior terminal entry" "$before" "$after"
+	assert_eq "failed refresh still records one transport attempt" "12" "$(api_call_count)"
+
+	CHECK_API_MODE=malformed
+	CHECK_NOW=600
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_G")
+	assert_eq "malformed API projection is not trusted" "none" "$result"
+	path=$(cache_path "owner/repo" "$SHA_G")
+	assert_eq "malformed API projection is not stored" "false" "$([[ -f "$path" ]] && printf true || printf false)"
+	assert_eq "malformed API projection performs one attempt" "13" "$(api_call_count)"
+
+	CHECK_API_MODE=success
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+	CHECK_NOW=700
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_H")
+	assert_eq "invalidation fixture starts terminal" "PASS" "$result"
+	gh_pr_check_status_cache_invalidate "owner/repo" "$SHA_H"
+	gh_pr_check_status_cache_invalidate "owner/repo" "$SHA_H"
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"failure"}]}'
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_H")
+	assert_eq "idempotent explicit invalidation forces refresh" "FAIL" "$result"
+	assert_eq "explicit invalidation adds exactly one fetch" "15" "$(api_call_count)"
+	return 0
+}
+
+test_private_atomic_cache_and_authority_boundary() {
+	local path="" dir="" result="" job=""
+	path=$(cache_path "owner/repo" "$SHA_H")
+	dir="${path%/*}"
+	assert_eq "cache directory is private" "700" "$(file_mode "$dir")"
+	assert_eq "cache entry is private" "600" "$(file_mode "$path")"
+
+	gh_pr_check_status_cache_invalidate "owner/repo" "$SHA_H"
+	CHECK_NOW=800
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+	for job in 1 2 3 4; do
+		gh_pr_check_status_rest "owner/repo" "$SHA_H" >/dev/null &
+	done
+	wait
+	path=$(cache_path "owner/repo" "$SHA_H")
+	result=$(jq -r --arg sha "$SHA_H" 'select(.head_sha == $sha and .state == "PASS") | .state' "$path")
+	assert_eq "concurrent last-writer-wins cache remains valid" "PASS" "$result"
+	if compgen -G "${dir}/.pr-check-status.*" >/dev/null; then
+		printf 'FAIL: atomic cache write left temporary files behind\n' >&2
+		return 1
+	fi
+	printf 'PASS: atomic cache writes leave no temporary files\n'
+
+	if grep -q 'gh_pr_check_status_rest' "$MERGE_REQUIRED_LIB"; then
+		printf 'FAIL: final required-check module references aggregate cached status\n' >&2
+		return 1
+	fi
+	if ! grep -q 'gh_pr_check_runs_rest' "$MERGE_REQUIRED_LIB"; then
+		printf 'FAIL: final required-check module lacks live named check-run reads\n' >&2
+		return 1
+	fi
+	printf 'PASS: final required-check authority remains on live named checks\n'
+	return 0
+}
+
+main() {
+	test_terminal_reuse_dedup_and_order
+	test_new_head_repo_and_auth_scope_miss
+	test_actionable_and_terminal_expiry
+	test_corruption_failure_and_invalidation
+	test_private_atomic_cache_and_authority_boundary
+	printf 'PASS: PR check-status cache regression suite\n'
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -312,9 +312,9 @@ test_required_checks_gh_reads_are_timeout_wrapped() {
 		return 0
 	fi
 
-	if { awk '{ if (sub(/\\$/, "")) { printf "%s", $0 } else { print } }' "$required_checks_script" \
-		| sed -E 's/_pmrc_gh_read[[:space:]]+gh[[:space:]]+(api|pr[[:space:]]+checks)//g' \
-		| grep -nE '^[[:space:]]*[^#]*(^|[[:space:]])gh[[:space:]]+(api|pr[[:space:]]+checks)([[:space:]]|$)'; } >/dev/null 2>&1; then
+	if { awk '{ if (sub(/\\$/, "")) { printf "%s", $0 } else { print } }' "$required_checks_script" |
+		sed -E 's/_pmrc_gh_read[[:space:]]+gh[[:space:]]+(api|pr[[:space:]]+checks)//g' |
+		grep -nE '^[[:space:]]*[^#]*(^|[[:space:]])gh[[:space:]]+(api|pr[[:space:]]+checks)([[:space:]]|$)'; } >/dev/null 2>&1; then
 		print_result "required-check gh reads use timeout wrapper" 1
 	else
 		print_result "required-check gh reads use timeout wrapper" 0
@@ -356,6 +356,10 @@ define_function_under_test() {
 	fi
 	# shellcheck disable=SC1090  # dynamic source from sibling lib
 	source "$checks_lib"
+	# Load the required-check module constants before evaluating selected
+	# functions in isolation; extracted functions reference the PMRC_* contract.
+	# shellcheck disable=SC1090  # dynamic source from sibling lib
+	source "$REQUIRED_CHECKS_SCRIPT"
 	gh_pr_view() {
 		if gh pr view "$@"; then
 			return 0


### PR DESCRIPTION
## Summary

Cache observational aggregate check-suite states by repository, auth scope, full head SHA, and projection; deduplicate batch fetches; add bounded TTLs, private atomic writes, idempotent invalidation, and authority-boundary regression coverage.

## Files Changed

.agents/scripts/pulse-prefetch-fetch.sh, .agents/scripts/shared-gh-wrappers-checks.sh, .agents/scripts/tests/test-gh-check-status-cache.sh, .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-check-status-cache.sh; bash .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh; related merge, prefetch, timeout, and null-suite suites; shellcheck; shfmt; .agents/scripts/linters-local.sh --changed

Resolves #27772


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.150 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 1d 7h and 6,499,905 tokens on this with the user in an interactive session.