### PR TITLE
GH#28209: audit pulse snapshot failures

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -13,6 +13,8 @@ PMRC_JSON_ARRAY="array"
 PMRC_MAINTAINER_GATE="maintainer-gate"
 PMRC_MAINTAINER_GATE_DISPLAY="Maintainer Review & Assignee Gate"
 PMRC_MAINTAINER_GATE_WORKFLOW="gate / Maintainer Review & Assignee Gate"
+PMRC_SUBJECT_HEAD_PREFIX="head "
+PMRC_SUBJECT_PR_PREFIX="PR #"
 : "${_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON:=[]}"
 
 _pmrc_gh_read() {
@@ -36,14 +38,30 @@ _pmrc_iso_to_epoch() {
 	return 0
 }
 
+_pmrc_snapshot_log_failure() {
+	local repo_slug="$1"
+	local subject="$2"
+	local stage="$3"
+	local log_target="${LOGFILE:-/dev/stderr}"
+
+	echo "[pulse-merge] pre-merge snapshot: ${stage} failed for ${subject} in ${repo_slug} — failing closed (GH#28209)" >>"$log_target"
+	return 0
+}
+
 _pmrc_snapshot_checks_json() {
 	local repo_slug="$1"
 	local head_sha="$2"
 	local runs_pages="" statuses_json="" checks_json=""
 
 	runs_pages=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/check-runs?per_page=100" \
-		--paginate --slurp 2>/dev/null) || return 1
-	statuses_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/status" 2>/dev/null) || return 1
+		--paginate --slurp 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_HEAD_PREFIX}${head_sha:0:12}" "check-runs fetch"
+		return 1
+	}
+	statuses_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/commits/${head_sha}/status" 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_HEAD_PREFIX}${head_sha:0:12}" "commit-status fetch"
+		return 1
+	}
 	# Stream API documents over stdin instead of passing large check-run payloads
 	# through --argjson, which can exceed the OS per-argument limit (GH#28164).
 	checks_json=$(printf '%s\n%s\n' "$runs_pages" "$statuses_json" | jq -s \
@@ -118,7 +136,10 @@ _pmrc_snapshot_checks_json() {
 			end
 		)
 		| sort_by(.name)
-	' 2>/dev/null) || return 1
+	' 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_HEAD_PREFIX}${head_sha:0:12}" "check-set parse"
+		return 1
+	}
 	printf '%s\n' "$checks_json"
 	return 0
 }
@@ -130,11 +151,20 @@ _pmrc_snapshot_bot_activity_json() {
 	local bot_re="coderabbitai|gemini-code-assist|augment-code|augmentcode|copilot"
 
 	reviews=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}/reviews?per_page=100" \
-		--paginate --slurp 2>/dev/null) || return 1
+		--paginate --slurp 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "reviews fetch"
+		return 1
+	}
 	issue_comments=$(_pmrc_gh_read gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
-		--paginate --slurp 2>/dev/null) || return 1
+		--paginate --slurp 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "issue-comments fetch"
+		return 1
+	}
 	inline_comments=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}/comments?per_page=100" \
-		--paginate --slurp 2>/dev/null) || return 1
+		--paginate --slurp 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "inline-comments fetch"
+		return 1
+	}
 	activity=$(jq -n --argjson reviews "$reviews" --argjson issues "$issue_comments" \
 		--argjson inline "$inline_comments" --arg bots "$bot_re" '
 		[
@@ -144,7 +174,10 @@ _pmrc_snapshot_bot_activity_json() {
 			| select(. != "")
 		] as $events
 		| {count: ($events | length), latest_at: ($events | max // "")}
-	' 2>/dev/null) || return 1
+	' 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "bot-activity parse"
+		return 1
+	}
 	printf '%s\n' "$activity"
 	return 0
 }
@@ -479,8 +512,8 @@ _pmrc_snapshot_review_gate_fresh() {
 		# the caller immediately revalidates that head before reaching this check.
 		# Its caller-observed timestamp must also cover the latest bot activity so
 		# activity racing after the live helper remains fail-closed.
-		if [[ "$evidence_epoch" =~ ^[0-9]+$ ]] \
-			&& { [[ -z "$activity_epoch" ]] || [[ "$evidence_epoch" -ge "$activity_epoch" ]]; }; then
+		if [[ "$evidence_epoch" =~ ^[0-9]+$ ]] &&
+			{ [[ -z "$activity_epoch" ]] || [[ "$evidence_epoch" -ge "$activity_epoch" ]]; }; then
 			echo "[pulse-merge] pre-merge snapshot: accepted live review-bot gate bound to the current head for PR #${pr_number} in ${repo_slug}; no status context is installed (GH#27483)" >>"$LOGFILE"
 			return 0
 		fi
@@ -534,14 +567,26 @@ _pulse_merge_preflight_snapshot_gate() {
 	local pr_json="" current_head_sha="" base_branch="" required_contexts="" checks_json="" activity_json=""
 	_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON="[]"
 
-	pr_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || return 1
-	current_head_sha=$(jq -r '.head.sha // ""' <<<"$pr_json" 2>/dev/null) || return 1
-	base_branch=$(jq -r '.base.ref // ""' <<<"$pr_json" 2>/dev/null) || return 1
+	pr_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "pull-request fetch"
+		return 1
+	}
+	current_head_sha=$(jq -r '.head.sha // ""' <<<"$pr_json" 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "head parse"
+		return 1
+	}
+	base_branch=$(jq -r '.base.ref // ""' <<<"$pr_json" 2>/dev/null) || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "base-branch parse"
+		return 1
+	}
 	if [[ -z "$current_head_sha" || "$current_head_sha" != "$expected_head_sha" ]]; then
 		echo "[pulse-merge] pre-merge snapshot: head changed for PR #${pr_number} in ${repo_slug} (expected=${expected_head_sha:-unknown}, current=${current_head_sha:-unknown}) — prior gate state revoked (GH#27137)" >>"$LOGFILE"
 		return 1
 	fi
-	required_contexts=$(_required_contexts_for_default_branch "$repo_slug") || return 1
+	required_contexts=$(_required_contexts_for_default_branch "$repo_slug") || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "required-context lookup"
+		return 1
+	}
 	checks_json=$(_pmrc_snapshot_checks_json "$repo_slug" "$current_head_sha") || return 1
 	activity_json=$(_pmrc_snapshot_bot_activity_json "$repo_slug" "$pr_number") || return 1
 	_pmrc_review_evidence_permits_advisory "$live_gate_evidence" "$repo_slug" "$pr_number" "$current_head_sha" || live_gate_evidence=""

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -29,9 +29,31 @@ cleanup() {
 }
 trap cleanup EXIT
 
+_pmrc_gh_read() {
+	local command="$1"
+	local subcommand="${2:-}"
+	local endpoint="${3:-}"
+
+	[[ "$command" == "gh" && "$subcommand" == "api" ]] || return 1
+	case "${SNAPSHOT_MODE}:${endpoint}" in
+	"pr_fetch_error:repos/owner/repo/pulls/7" | "check_runs_error:"*check-runs* | \
+		"status_error:"*commits/sha-reviewed/status* | "reviews_error:"*pulls/7/reviews* | \
+		"issue_comments_error:"*issues/7/comments* | "inline_comments_error:"*pulls/7/comments*)
+		return 1
+		;;
+	"pr_parse_error:repos/owner/repo/pulls/7" | "activity_parse_error:"*pulls/7/comments*)
+		printf '%s\n' '{'
+		return 0
+		;;
+	esac
+	"$@"
+	return $?
+}
+
 _required_contexts_for_default_branch() {
 	local repo_slug="$1"
 	[[ -n "$repo_slug" ]] || return 1
+	[[ "$SNAPSHOT_MODE" == "required_contexts_error" ]] && return 1
 	printf 'required-a\n'
 	[[ "$SNAPSHOT_MODE" == "maintainer_alias_fail" || "$SNAPSHOT_MODE" == "maintainer_infra_fail" ]] && printf 'Maintainer Review & Assignee Gate\n'
 	return 0
@@ -194,6 +216,36 @@ assert_gate() {
 	return 0
 }
 
+assert_gate_logged() {
+	local description="$1"
+	local mode="$2"
+	local expected_log="$3"
+
+	assert_gate "$description" "$mode" 1
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -q "$expected_log" "$LOGFILE"; then
+		printf 'PASS %s is audited\n' "$description"
+		return 0
+	fi
+	printf 'FAIL %s did not log: %s\n' "$description" "$expected_log"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_snapshot_acquisition_failures_are_audited() {
+	assert_gate_logged "pull-request fetch failure" pr_fetch_error "pull-request fetch failed"
+	assert_gate_logged "pull-request parse failure" pr_parse_error "head parse failed"
+	assert_gate_logged "required-context lookup failure" required_contexts_error "required-context lookup failed"
+	assert_gate_logged "check-runs fetch failure" check_runs_error "check-runs fetch failed"
+	assert_gate_logged "commit-status fetch failure" status_error "commit-status fetch failed"
+	assert_gate_logged "check-set parse failure" empty_check_runs "check-set parse failed"
+	assert_gate_logged "reviews fetch failure" reviews_error "reviews fetch failed"
+	assert_gate_logged "issue-comments fetch failure" issue_comments_error "issue-comments fetch failed"
+	assert_gate_logged "inline-comments fetch failure" inline_comments_error "inline-comments fetch failed"
+	assert_gate_logged "bot-activity parse failure" activity_parse_error "bot-activity parse failed"
+	return 0
+}
+
 assert_human_review_thread_rules() {
 	assert_gate "unresolved human thread blocks when effective rules require resolution" human_required 1
 	if grep -q "requires thread resolution" "$LOGFILE"; then
@@ -312,8 +364,8 @@ assert_review_and_head_snapshot_cases() {
 main() {
 	assert_infrastructure_rerun_unset_defaults_safe
 	assert_infrastructure_rerun_unset_logfile_safe
+	assert_snapshot_acquisition_failures_are_audited
 	assert_gate "large paginated check payload streams without argument overflow" large_payload 0
-	assert_gate "empty check-run response fails closed" empty_check_runs 1
 	assert_gate "terminal checks with explicit baseline advisory pass" happy_advisory 0
 	if grep -q "IGNORED non-required baseline advisory failure 'Qlty Smell Threshold'" "$LOGFILE"; then
 		printf 'PASS ignored advisory failure is audited\n'


### PR DESCRIPTION
## Summary

Add bounded, stage-specific diagnostics for pre-merge snapshot acquisition and parsing failures while preserving fail-closed merge safety.

## Files Changed

- `.agents/scripts/pulse-merge-required-checks.sh`
- `.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh`

## Runtime Testing

- **Risk level:** High (deterministic merge state machine and GitHub API safety gate)
- **Verification:** Runtime-verified through 65 preflight snapshot scenarios, including ten injected acquisition/parse failures; 15 static required-check assertions; ShellCheck; changed-file linters; full local linter suite.

## Decisions

- Keep every unverifiable snapshot failure fail-closed.
- Log only bounded repository, PR/head, and stage context; never API payload data.
- Defer speculative retry, timeout, or payload rewrites until the new diagnostics identify a concrete transport defect.

Resolves #28209


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.150 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 17m and 399,180 tokens on this with the user in an interactive session.
