### PR TITLE
GH#28216: fix: reject stale runtime bundles and recover idle tabs

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-status.mjs
@@ -20,7 +20,14 @@ function isRootSessionInfo(info) {
 
 const ROOT_SESSION_STATUSES = new Set(["busy", "retry", "idle"]);
 const TERMINAL_ASSISTANT_FINISH_REASONS = new Set(["stop", "end_turn", "completed"]);
-const MAX_COMPLETED_ASSISTANT_MESSAGES = 128;
+const MAX_TRACKED_MESSAGE_IDS = 128;
+
+function rememberMessageID(ids, messageID) {
+  if (!messageID || ids.has(messageID)) return false;
+  ids.add(messageID);
+  while (ids.size > MAX_TRACKED_MESSAGE_IDS) ids.delete(ids.values().next().value);
+  return true;
+}
 
 function isTerminalAssistantCompletion(info) {
   if (info?.role !== "assistant" || info.summary === true || info.mode === "compaction") return false;
@@ -55,20 +62,27 @@ function handleSessionDeleted({ sessionID, state, resetState }) {
 function handleMessageUpdated({ info, sessionID, state, setTerminalTitleStatus }) {
   if (sessionID !== state.activeRootSessionID) return;
   if (info?.role === "user") {
-    state.activeUserMessageID = info.id || "";
+    const messageID = info.id || "";
+    if (!rememberMessageID(state.seenUserMessageIDs, messageID)) return;
+    const createdAt = Number.isFinite(info.time?.created) ? info.time.created : null;
+    if (
+      state.activeUserMessageID &&
+      state.activeUserCreatedAt !== null &&
+      (createdAt === null || createdAt < state.activeUserCreatedAt)
+    ) {
+      return;
+    }
+    state.activeUserMessageID = messageID;
+    state.activeUserCreatedAt = createdAt;
+    state.completedUserMessageID = "";
     if (state.pendingPermissionIDs.size === 0) setTerminalTitleStatus("busy");
     return;
   }
   if (!isTerminalAssistantCompletion(info) || state.pendingPermissionIDs.size > 0) return;
+  if (!state.activeUserMessageID) return;
   if (state.activeUserMessageID && info.parentID && info.parentID !== state.activeUserMessageID) return;
-  if (info.id && state.completedAssistantMessageIDs.has(info.id)) return;
-
-  if (info.id) {
-    state.completedAssistantMessageIDs.add(info.id);
-    while (state.completedAssistantMessageIDs.size > MAX_COMPLETED_ASSISTANT_MESSAGES) {
-      state.completedAssistantMessageIDs.delete(state.completedAssistantMessageIDs.values().next().value);
-    }
-  }
+  if (!rememberMessageID(state.completedAssistantMessageIDs, info.id)) return;
+  state.completedUserMessageID = state.activeUserMessageID;
   setTerminalTitleStatus("idle");
 }
 
@@ -76,6 +90,12 @@ function handleSessionStatus({ event, sessionID, state, setTerminalTitleStatus }
   if (sessionID !== state.activeRootSessionID || state.pendingPermissionIDs.size > 0) return;
   const status = event.properties?.status?.type;
   if (!ROOT_SESSION_STATUSES.has(status)) return;
+  if (
+    status === "busy" &&
+    state.completedUserMessageID &&
+    state.completedUserMessageID === state.activeUserMessageID
+  ) return;
+  if (status !== "idle") state.completedUserMessageID = "";
   setTerminalTitleStatus(status);
 }
 
@@ -88,6 +108,7 @@ function handlePermissionAsked({ event, sessionID, state, setTerminalTitleStatus
   if (sessionID !== state.activeRootSessionID) return;
   const requestID = event.properties?.id;
   if (!requestID) return;
+  state.completedUserMessageID = "";
   state.pendingPermissionIDs.add(requestID);
   setTerminalTitleStatus("permission");
 }
@@ -97,6 +118,7 @@ function handlePermissionReplied({ event, sessionID, state, setTerminalTitleStat
   const requestID = event.properties?.requestID || event.properties?.permissionID;
   const wasPending = state.pendingPermissionIDs.delete(requestID);
   if (!wasPending || state.pendingPermissionIDs.size > 0) return;
+  state.completedUserMessageID = "";
   setTerminalTitleStatus("busy");
 }
 
@@ -121,14 +143,20 @@ export function createSessionTitleStatusHandler({
   const state = {
     activeRootSessionID: "",
     activeUserMessageID: "",
+    activeUserCreatedAt: null,
+    completedUserMessageID: "",
     completedAssistantMessageIDs: new Set(),
     pendingPermissionIDs: new Set(),
+    seenUserMessageIDs: new Set(),
   };
 
   const resetState = () => {
     state.activeUserMessageID = "";
+    state.activeUserCreatedAt = null;
+    state.completedUserMessageID = "";
     state.completedAssistantMessageIDs.clear();
     state.pendingPermissionIDs.clear();
+    state.seenUserMessageIDs.clear();
     resetTerminalTitleState();
   };
 

--- a/.agents/plugins/opencode-aidevops/session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-status.mjs
@@ -11,7 +11,7 @@ function getEvent(input) {
 }
 
 function sessionIDFrom(event) {
-  return event.properties?.sessionID || event.properties?.info?.id || "";
+  return event.properties?.sessionID || event.properties?.info?.sessionID || event.properties?.info?.id || "";
 }
 
 function isRootSessionInfo(info) {
@@ -19,6 +19,14 @@ function isRootSessionInfo(info) {
 }
 
 const ROOT_SESSION_STATUSES = new Set(["busy", "retry", "idle"]);
+const TERMINAL_ASSISTANT_FINISH_REASONS = new Set(["stop", "end_turn", "completed"]);
+const MAX_COMPLETED_ASSISTANT_MESSAGES = 128;
+
+function isTerminalAssistantCompletion(info) {
+  if (info?.role !== "assistant" || info.summary === true || info.mode === "compaction") return false;
+  if (typeof info.time?.completed !== "number") return false;
+  return TERMINAL_ASSISTANT_FINISH_REASONS.has(String(info.finish || "").toLowerCase());
+}
 
 function activateRootSession({ sessionID, state, resetState, setTerminalTitleStatus }) {
   state.activeRootSessionID = sessionID;
@@ -45,14 +53,23 @@ function handleSessionDeleted({ sessionID, state, resetState }) {
 }
 
 function handleMessageUpdated({ info, sessionID, state, setTerminalTitleStatus }) {
-  if (
-    sessionID !== state.activeRootSessionID ||
-    info?.role !== "user" ||
-    state.pendingPermissionIDs.size > 0
-  ) {
+  if (sessionID !== state.activeRootSessionID) return;
+  if (info?.role === "user") {
+    state.activeUserMessageID = info.id || "";
+    if (state.pendingPermissionIDs.size === 0) setTerminalTitleStatus("busy");
     return;
   }
-  setTerminalTitleStatus("busy");
+  if (!isTerminalAssistantCompletion(info) || state.pendingPermissionIDs.size > 0) return;
+  if (state.activeUserMessageID && info.parentID && info.parentID !== state.activeUserMessageID) return;
+  if (info.id && state.completedAssistantMessageIDs.has(info.id)) return;
+
+  if (info.id) {
+    state.completedAssistantMessageIDs.add(info.id);
+    while (state.completedAssistantMessageIDs.size > MAX_COMPLETED_ASSISTANT_MESSAGES) {
+      state.completedAssistantMessageIDs.delete(state.completedAssistantMessageIDs.values().next().value);
+    }
+  }
+  setTerminalTitleStatus("idle");
 }
 
 function handleSessionStatus({ event, sessionID, state, setTerminalTitleStatus }) {
@@ -103,10 +120,14 @@ export function createSessionTitleStatusHandler({
 } = {}) {
   const state = {
     activeRootSessionID: "",
+    activeUserMessageID: "",
+    completedAssistantMessageIDs: new Set(),
     pendingPermissionIDs: new Set(),
   };
 
   const resetState = () => {
+    state.activeUserMessageID = "";
+    state.completedAssistantMessageIDs.clear();
     state.pendingPermissionIDs.clear();
     resetTerminalTitleState();
   };

--- a/.agents/plugins/opencode-aidevops/session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/session-title-status.mjs
@@ -59,31 +59,40 @@ function handleSessionDeleted({ sessionID, state, resetState }) {
   resetState();
 }
 
-function handleMessageUpdated({ info, sessionID, state, setTerminalTitleStatus }) {
-  if (sessionID !== state.activeRootSessionID) return;
-  if (info?.role === "user") {
-    const messageID = info.id || "";
-    if (!rememberMessageID(state.seenUserMessageIDs, messageID)) return;
-    const createdAt = Number.isFinite(info.time?.created) ? info.time.created : null;
-    if (
-      state.activeUserMessageID &&
-      state.activeUserCreatedAt !== null &&
-      (createdAt === null || createdAt < state.activeUserCreatedAt)
-    ) {
-      return;
-    }
-    state.activeUserMessageID = messageID;
-    state.activeUserCreatedAt = createdAt;
-    state.completedUserMessageID = "";
-    if (state.pendingPermissionIDs.size === 0) setTerminalTitleStatus("busy");
+function handleUserMessageUpdated({ info, state, setTerminalTitleStatus }) {
+  const messageID = info.id || "";
+  if (!rememberMessageID(state.seenUserMessageIDs, messageID)) return;
+  const createdAt = Number.isFinite(info.time?.created) ? info.time.created : null;
+  if (
+    state.activeUserMessageID &&
+    state.activeUserCreatedAt !== null &&
+    (createdAt === null || createdAt < state.activeUserCreatedAt)
+  ) {
     return;
   }
-  if (!isTerminalAssistantCompletion(info) || state.pendingPermissionIDs.size > 0) return;
-  if (!state.activeUserMessageID) return;
-  if (state.activeUserMessageID && info.parentID && info.parentID !== state.activeUserMessageID) return;
+  state.activeUserMessageID = messageID;
+  state.activeUserCreatedAt = createdAt;
+  state.completedUserMessageID = "";
+  if (state.pendingPermissionIDs.size === 0) setTerminalTitleStatus("busy");
+}
+
+function handleAssistantMessageUpdated({ info, state, setTerminalTitleStatus }) {
+  if (
+    !isTerminalAssistantCompletion(info) ||
+    state.pendingPermissionIDs.size > 0 ||
+    !state.activeUserMessageID ||
+    info.parentID !== state.activeUserMessageID
+  ) return;
   if (!rememberMessageID(state.completedAssistantMessageIDs, info.id)) return;
   state.completedUserMessageID = state.activeUserMessageID;
   setTerminalTitleStatus("idle");
+}
+
+function handleMessageUpdated(context) {
+  const { info, sessionID, state } = context;
+  if (sessionID !== state.activeRootSessionID) return;
+  if (info?.role === "user") handleUserMessageUpdated(context);
+  else handleAssistantMessageUpdated(context);
 }
 
 function handleSessionStatus({ event, sessionID, state, setTerminalTitleStatus }) {

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -132,7 +132,7 @@ test("terminal root assistant completion restores idle without a native idle eve
 
   await handler(event("session.created", { info: { id: "root-completion", title: "Completion" } }));
   await handler(event("message.updated", {
-    info: { id: "user-1", sessionID: "root-completion", role: "user" },
+    info: { id: "user-1", sessionID: "root-completion", role: "user", time: { created: 10 } },
   }));
   await handler(event("message.updated", {
     info: {
@@ -166,8 +166,15 @@ test("terminal root assistant completion restores idle without a native idle eve
   });
   await handler(terminalCompletion);
   await handler(terminalCompletion);
+  await handler(event("session.status", { sessionID: "root-completion", status: { type: "busy" } }));
   await handler(event("message.updated", {
-    info: { id: "user-2", sessionID: "root-completion", role: "user" },
+    info: { id: "user-2", sessionID: "root-completion", role: "user", time: { created: 40 } },
+  }));
+  await handler(event("message.updated", {
+    info: { id: "user-1", sessionID: "root-completion", role: "user", time: { created: 10 } },
+  }));
+  await handler(event("message.updated", {
+    info: { id: "unseen-older-user", sessionID: "root-completion", role: "user", time: { created: 5 } },
   }));
   await handler(terminalCompletion);
   await handler(event("message.updated", {
@@ -282,6 +289,16 @@ test("session status handler supports hot-loaded root sessions and ignores headl
   });
   await interactiveHandler(event("session.updated", { info: { id: "restored-root", title: "Restored" } }));
   await interactiveHandler(event("session.status", { sessionID: "restored-root", status: { type: "busy" } }));
+  await interactiveHandler(event("message.updated", {
+    info: {
+      id: "historical-assistant",
+      sessionID: "restored-root",
+      parentID: "historical-user",
+      role: "assistant",
+      finish: "stop",
+      time: { created: 10, completed: 20 },
+    },
+  }));
 
   const headlessHandler = createSessionTitleStatusHandler({
     isHeadless: () => true,

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -146,6 +146,15 @@ test("terminal root assistant completion restores idle without a native idle eve
   }));
   await handler(event("message.updated", {
     info: {
+      id: "assistant-without-parent",
+      sessionID: "root-completion",
+      role: "assistant",
+      finish: "stop",
+      time: { created: 10, completed: 20 },
+    },
+  }));
+  await handler(event("message.updated", {
+    info: {
       id: "assistant-stale",
       sessionID: "root-completion",
       parentID: "older-user",

--- a/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs
@@ -122,6 +122,68 @@ test("first root user message marks the session busy before native status", asyn
   assert.deepEqual(statuses, ["idle", "busy", "permission"]);
 });
 
+test("terminal root assistant completion restores idle without a native idle event", async () => {
+  const statuses = [];
+  const handler = createSessionTitleStatusHandler({
+    isHeadless: () => false,
+    isEnabled: () => true,
+    setTerminalTitleStatus: (status) => statuses.push(status),
+  });
+
+  await handler(event("session.created", { info: { id: "root-completion", title: "Completion" } }));
+  await handler(event("message.updated", {
+    info: { id: "user-1", sessionID: "root-completion", role: "user" },
+  }));
+  await handler(event("message.updated", {
+    info: {
+      id: "assistant-tools",
+      sessionID: "root-completion",
+      parentID: "user-1",
+      role: "assistant",
+      finish: "tool-calls",
+      time: { created: 10, completed: 20 },
+    },
+  }));
+  await handler(event("message.updated", {
+    info: {
+      id: "assistant-stale",
+      sessionID: "root-completion",
+      parentID: "older-user",
+      role: "assistant",
+      finish: "stop",
+      time: { created: 10, completed: 20 },
+    },
+  }));
+  const terminalCompletion = event("message.updated", {
+    info: {
+      id: "assistant-final",
+      sessionID: "root-completion",
+      parentID: "user-1",
+      role: "assistant",
+      finish: "stop",
+      time: { created: 10, completed: 30 },
+    },
+  });
+  await handler(terminalCompletion);
+  await handler(terminalCompletion);
+  await handler(event("message.updated", {
+    info: { id: "user-2", sessionID: "root-completion", role: "user" },
+  }));
+  await handler(terminalCompletion);
+  await handler(event("message.updated", {
+    info: {
+      id: "assistant-final-2",
+      sessionID: "root-completion",
+      parentID: "user-2",
+      role: "assistant",
+      finish: "end_turn",
+      time: { created: 40, completed: 50 },
+    },
+  }));
+
+  assert.deepEqual(statuses, ["idle", "busy", "idle", "busy", "idle"]);
+});
+
 test("legacy idle and permission events retain lifecycle status compatibility", async () => {
   const statuses = [];
   const handler = createSessionTitleStatusHandler({

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -623,7 +623,7 @@ _runtime_bundle_manifest_value() {
 	local line=""
 
 	[[ -r "$manifest_file" ]] || return 1
-	while IFS= read -r line; do
+	while IFS= read -r line || [[ -n "$line" ]]; do
 		case "$line" in
 		"${key}="*)
 			printf '%s' "${line#*=}"

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -675,9 +675,10 @@ _runtime_bundle_compare_versions() {
 	return 0
 }
 
-# Print a reason and return 0 when setup is attempting to activate a candidate
-# that is older than the active global runtime. Explicit rollback tooling uses
-# its own audited link transition and does not route through setup activation.
+# Print a reason when setup is attempting to activate a candidate that is older
+# than the active global runtime. Missing comparison evidence intentionally
+# prints nothing. Explicit rollback tooling uses its own audited link transition
+# and does not route through setup activation.
 _runtime_bundle_stale_candidate_reason() {
 	local bundle_dir="$1"
 	local active_root="$2"
@@ -687,28 +688,27 @@ _runtime_bundle_stale_candidate_reason() {
 	local candidate_sha="" active_sha=""
 	local repo_dir="${INSTALL_DIR:-}"
 
-	candidate_version=$(_runtime_bundle_manifest_value "$candidate_manifest" framework_version) || candidate_version=""
-	active_version=$(_runtime_bundle_manifest_value "$active_manifest" framework_version) || active_version=""
+	candidate_version=$(_runtime_bundle_manifest_value "$candidate_manifest" framework_version 2>/dev/null || :)
+	active_version=$(_runtime_bundle_manifest_value "$active_manifest" framework_version 2>/dev/null || :)
 	if [[ -n "$candidate_version" && -n "$active_version" ]]; then
-		version_relation=$(_runtime_bundle_compare_versions "$candidate_version" "$active_version") || version_relation=""
+		version_relation=$(_runtime_bundle_compare_versions "$candidate_version" "$active_version" 2>/dev/null || :)
 		if [[ "$version_relation" == "-1" ]]; then
 			printf 'candidate version %s is older than active version %s' "$candidate_version" "$active_version"
 			return 0
 		fi
 	fi
 
-	candidate_sha=$(_runtime_bundle_manifest_value "$candidate_manifest" git_sha) || candidate_sha=""
-	active_sha=$(_runtime_bundle_manifest_value "$active_manifest" git_sha) || active_sha=""
-	[[ -n "$repo_dir" && "$candidate_sha" != "$active_sha" ]] || return 1
-	[[ "$candidate_sha" =~ ^[0-9a-fA-F]{7,64}$ ]] || return 1
-	[[ "$active_sha" =~ ^[0-9a-fA-F]{7,64}$ ]] || return 1
-	git -C "$repo_dir" cat-file -e "${candidate_sha}^{commit}" 2>/dev/null || return 1
-	git -C "$repo_dir" cat-file -e "${active_sha}^{commit}" 2>/dev/null || return 1
+	candidate_sha=$(_runtime_bundle_manifest_value "$candidate_manifest" git_sha 2>/dev/null || :)
+	active_sha=$(_runtime_bundle_manifest_value "$active_manifest" git_sha 2>/dev/null || :)
+	[[ -n "$repo_dir" && "$candidate_sha" != "$active_sha" ]] || return 0
+	[[ "$candidate_sha" =~ ^[0-9a-fA-F]{7,64}$ ]] || return 0
+	[[ "$active_sha" =~ ^[0-9a-fA-F]{7,64}$ ]] || return 0
+	git -C "$repo_dir" cat-file -e "${candidate_sha}^{commit}" 2>/dev/null || return 0
+	git -C "$repo_dir" cat-file -e "${active_sha}^{commit}" 2>/dev/null || return 0
 	if git -C "$repo_dir" merge-base --is-ancestor "$candidate_sha" "$active_sha" 2>/dev/null; then
 		printf 'candidate source %.12s is an ancestor of active source %.12s' "$candidate_sha" "$active_sha"
-		return 0
 	fi
-	return 1
+	return 0
 }
 
 _runtime_bundle_validate() {
@@ -952,7 +952,8 @@ _runtime_bundle_activate_locked() {
 	bundles_dir=$(cd "${bundle_dir%/*}" && pwd -P) || return 1
 
 	if previous_root=$(_runtime_bundle_resolve_root "$target_dir" 2>/dev/null); then
-		if stale_reason=$(_runtime_bundle_stale_candidate_reason "$bundle_dir" "$previous_root"); then
+		stale_reason=$(_runtime_bundle_stale_candidate_reason "$bundle_dir" "$previous_root")
+		if [[ -n "$stale_reason" ]]; then
 			print_error "Refusing stale runtime bundle activation: ${stale_reason}. Use a dedicated audited rollback operation instead of setup."
 			return 1
 		fi

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -617,6 +617,100 @@ _runtime_bundle_write_manifest() {
 	return 0
 }
 
+_runtime_bundle_manifest_value() {
+	local manifest_file="$1"
+	local key="$2"
+	local line=""
+
+	[[ -r "$manifest_file" ]] || return 1
+	while IFS= read -r line; do
+		case "$line" in
+		"${key}="*)
+			printf '%s' "${line#*=}"
+			return 0
+			;;
+		esac
+	done <"$manifest_file"
+	return 1
+}
+
+_runtime_bundle_compare_versions() {
+	local left="$1"
+	local right="$2"
+	local left_major="" left_minor="" left_patch=""
+	local right_major="" right_minor="" right_patch=""
+
+	left="${left#v}"
+	right="${right#v}"
+	[[ "$left" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	[[ "$right" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	IFS='.' read -r left_major left_minor left_patch <<<"$left"
+	IFS='.' read -r right_major right_minor right_patch <<<"$right"
+
+	if ((10#$left_major < 10#$right_major)); then
+		printf '%s' '-1'
+		return 0
+	fi
+	if ((10#$left_major > 10#$right_major)); then
+		printf '%s' '1'
+		return 0
+	fi
+	if ((10#$left_minor < 10#$right_minor)); then
+		printf '%s' '-1'
+		return 0
+	fi
+	if ((10#$left_minor > 10#$right_minor)); then
+		printf '%s' '1'
+		return 0
+	fi
+	if ((10#$left_patch < 10#$right_patch)); then
+		printf '%s' '-1'
+		return 0
+	fi
+	if ((10#$left_patch > 10#$right_patch)); then
+		printf '%s' '1'
+		return 0
+	fi
+	printf '%s' '0'
+	return 0
+}
+
+# Print a reason and return 0 when setup is attempting to activate a candidate
+# that is older than the active global runtime. Explicit rollback tooling uses
+# its own audited link transition and does not route through setup activation.
+_runtime_bundle_stale_candidate_reason() {
+	local bundle_dir="$1"
+	local active_root="$2"
+	local candidate_manifest="$bundle_dir/manifest"
+	local active_manifest="$active_root/.bundle-manifest"
+	local candidate_version="" active_version="" version_relation=""
+	local candidate_sha="" active_sha=""
+	local repo_dir="${INSTALL_DIR:-}"
+
+	candidate_version=$(_runtime_bundle_manifest_value "$candidate_manifest" framework_version) || candidate_version=""
+	active_version=$(_runtime_bundle_manifest_value "$active_manifest" framework_version) || active_version=""
+	if [[ -n "$candidate_version" && -n "$active_version" ]]; then
+		version_relation=$(_runtime_bundle_compare_versions "$candidate_version" "$active_version") || version_relation=""
+		if [[ "$version_relation" == "-1" ]]; then
+			printf 'candidate version %s is older than active version %s' "$candidate_version" "$active_version"
+			return 0
+		fi
+	fi
+
+	candidate_sha=$(_runtime_bundle_manifest_value "$candidate_manifest" git_sha) || candidate_sha=""
+	active_sha=$(_runtime_bundle_manifest_value "$active_manifest" git_sha) || active_sha=""
+	[[ -n "$repo_dir" && "$candidate_sha" != "$active_sha" ]] || return 1
+	[[ "$candidate_sha" =~ ^[0-9a-fA-F]{7,64}$ ]] || return 1
+	[[ "$active_sha" =~ ^[0-9a-fA-F]{7,64}$ ]] || return 1
+	git -C "$repo_dir" cat-file -e "${candidate_sha}^{commit}" 2>/dev/null || return 1
+	git -C "$repo_dir" cat-file -e "${active_sha}^{commit}" 2>/dev/null || return 1
+	if git -C "$repo_dir" merge-base --is-ancestor "$candidate_sha" "$active_sha" 2>/dev/null; then
+		printf 'candidate source %.12s is an ancestor of active source %.12s' "$candidate_sha" "$active_sha"
+		return 0
+	fi
+	return 1
+}
+
 _runtime_bundle_validate() {
 	local bundle_dir="$1"
 	local source_dir="$2"
@@ -853,10 +947,15 @@ _runtime_bundle_activate_locked() {
 	local previous_link="$parent_dir/previous-runtime-bundle"
 	local previous_root=""
 	local legacy_dir=""
+	local stale_reason=""
 	agents_root=$(_runtime_bundle_resolve_root "$bundle_dir/agents") || return 1
 	bundles_dir=$(cd "${bundle_dir%/*}" && pwd -P) || return 1
 
 	if previous_root=$(_runtime_bundle_resolve_root "$target_dir" 2>/dev/null); then
+		if stale_reason=$(_runtime_bundle_stale_candidate_reason "$bundle_dir" "$previous_root"); then
+			print_error "Refusing stale runtime bundle activation: ${stale_reason}. Use a dedicated audited rollback operation instead of setup."
+			return 1
+		fi
 		_AIDEVOPS_PREVIOUS_BUNDLE_ROOT="$previous_root"
 	fi
 	if [[ -d "$target_dir" && ! -L "$target_dir" ]]; then

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -103,6 +103,43 @@ stage_revision() {
 	return 0
 }
 
+set_bundle_manifest_sha() {
+	local bundle_dir="$1"
+	local git_sha="$2"
+	local manifest_file=""
+	local manifest_tmp=""
+	local line=""
+
+	for manifest_file in "$bundle_dir/manifest" "$bundle_dir/agents/.bundle-manifest"; do
+		manifest_tmp="${manifest_file}.tmp"
+		while IFS= read -r line; do
+			if [[ "$line" == git_sha=* ]]; then
+				printf 'git_sha=%s\n' "$git_sha"
+			else
+				printf '%s\n' "$line"
+			fi
+		done <"$manifest_file" >"$manifest_tmp"
+		mv "$manifest_tmp" "$manifest_file"
+	done
+	return 0
+}
+
+install_mock_ancestor_git() {
+	git() {
+		local first_arg="$1"
+		local third_arg="${3:-}"
+		if [[ "$first_arg" == "-C" && "$third_arg" == "cat-file" ]]; then
+			return 0
+		fi
+		if [[ "$first_arg" == "-C" && "$third_arg" == "merge-base" ]]; then
+			return 0
+		fi
+		command git "$@"
+		return $?
+	}
+	return 0
+}
+
 test_initial_activation_and_manifest() {
 	local target_dir="$HOME/.aidevops/agents"
 	local active_root=""
@@ -470,6 +507,61 @@ test_plist_override_survives_two_bundle_activations() {
 	return 0
 }
 
+test_serialized_older_version_refuses_global_activation() {
+	local target_dir="$HOME/.aidevops/agents"
+	local stale_bundle=""
+	local current_bundle=""
+	local active_before=""
+	local active_after=""
+
+	write_fake_revision "12.0.0" "serialized-stale-version"
+	stage_revision "$target_dir"
+	stale_bundle="$_AIDEVOPS_STAGED_BUNDLE_DIR"
+	write_fake_revision "13.0.0" "serialized-current-version"
+	stage_revision "$target_dir"
+	current_bundle="$_AIDEVOPS_STAGED_BUNDLE_DIR"
+	_runtime_bundle_activate "$target_dir" "$current_bundle"
+	active_before=$(_runtime_bundle_resolve_root "$target_dir")
+
+	if _runtime_bundle_activate "$target_dir" "$stale_bundle"; then
+		fail "serialized older candidate unexpectedly replaced the active bundle"
+	fi
+	active_after=$(_runtime_bundle_resolve_root "$target_dir")
+	assert_eq "$active_before" "$active_after" "serialized older candidate preserves the active bundle"
+	assert_eq "13.0.0" "$(tr -d '[:space:]' <"$target_dir/VERSION")" "serialized activation cannot move the global version backwards"
+	return 0
+}
+
+test_same_version_ancestor_refuses_global_activation() {
+	local target_dir="$HOME/.aidevops/agents"
+	local stale_bundle=""
+	local current_bundle=""
+	local active_before=""
+	local active_after=""
+
+	write_fake_revision "14.0.0" "same-version-ancestor"
+	stage_revision "$target_dir"
+	stale_bundle="$_AIDEVOPS_STAGED_BUNDLE_DIR"
+	set_bundle_manifest_sha "$stale_bundle" "1111111111111111111111111111111111111111"
+	write_fake_revision "14.0.0" "same-version-descendant"
+	stage_revision "$target_dir"
+	current_bundle="$_AIDEVOPS_STAGED_BUNDLE_DIR"
+	set_bundle_manifest_sha "$current_bundle" "2222222222222222222222222222222222222222"
+	_runtime_bundle_activate "$target_dir" "$current_bundle"
+	active_before=$(_runtime_bundle_resolve_root "$target_dir")
+
+	install_mock_ancestor_git
+	if _runtime_bundle_activate "$target_dir" "$stale_bundle"; then
+		unset -f git
+		fail "same-version ancestor unexpectedly replaced its active descendant"
+	fi
+	unset -f git
+	active_after=$(_runtime_bundle_resolve_root "$target_dir")
+	assert_eq "$active_before" "$active_after" "same-version ancestor candidate preserves the active descendant"
+	assert_file_contains "$target_dir/scripts/helper.sh" 'same-version-descendant' "same-version ancestry guard preserves active source content"
+	return 0
+}
+
 main() {
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
@@ -500,6 +592,8 @@ main() {
 	test_dependency_install_recovery_activates_candidate
 	test_dependency_install_failure_preserves_active_bundle
 	test_plist_override_survives_two_bundle_activations
+	test_serialized_older_version_refuses_global_activation
+	test_same_version_ancestor_refuses_global_activation
 
 	printf 'Results: %s checks passed\n' "$TESTS_RUN"
 	return 0

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -112,7 +112,7 @@ set_bundle_manifest_sha() {
 
 	for manifest_file in "$bundle_dir/manifest" "$bundle_dir/agents/.bundle-manifest"; do
 		manifest_tmp="${manifest_file}.tmp"
-		while IFS= read -r line; do
+		while IFS= read -r line || [[ -n "$line" ]]; do
 			if [[ "$line" == git_sha=* ]]; then
 				printf 'git_sha=%s\n' "$git_sha"
 			else
@@ -145,6 +145,15 @@ install_mock_ancestor_git() {
 		fi
 		return 1
 	}
+	return 0
+}
+
+test_manifest_value_reads_unterminated_final_line() {
+	local manifest_file="$TEST_ROOT/manifest-without-trailing-newline"
+
+	printf 'schema=1\nframework_version=15.0.0' >"$manifest_file"
+	assert_eq "15.0.0" "$(_runtime_bundle_manifest_value "$manifest_file" framework_version)" \
+		"manifest reader accepts an unterminated final line"
 	return 0
 }
 
@@ -583,6 +592,7 @@ main() {
 	AIDEVOPS_AGENT_DEPLOY_MIN_FILES=1
 	export AIDEVOPS_AGENT_DEPLOY_MIN_FILES
 
+	test_manifest_value_reads_unterminated_final_line
 	test_initial_activation_and_manifest
 	test_interrupted_staging_preserves_active
 	test_failed_activation_rolls_back

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -128,14 +128,22 @@ install_mock_ancestor_git() {
 	git() {
 		local first_arg="$1"
 		local third_arg="${3:-}"
+		local fourth_arg="${4:-}"
+		local fifth_arg="${5:-}"
+		local sixth_arg="${6:-}"
 		if [[ "$first_arg" == "-C" && "$third_arg" == "cat-file" ]]; then
-			return 0
+			case "$fifth_arg" in
+			"1111111111111111111111111111111111111111^{commit}" | "2222222222222222222222222222222222222222^{commit}") return 0 ;;
+			esac
+			return 1
 		fi
 		if [[ "$first_arg" == "-C" && "$third_arg" == "merge-base" ]]; then
-			return 0
+			[[ "$fourth_arg" == "--is-ancestor" &&
+				"$fifth_arg" == "1111111111111111111111111111111111111111" &&
+				"$sixth_arg" == "2222222222222222222222222222222222222222" ]]
+			return $?
 		fi
-		command git "$@"
-		return $?
+		return 1
 	}
 	return 0
 }


### PR DESCRIPTION
## Summary

Implementation for issue #28216.

## Files Changed

.agents/plugins/opencode-aidevops/session-title-status.mjs, .agents/plugins/opencode-aidevops/tests/test-session-title-status.mjs, .agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #28216


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.150 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 17m and 769,438 tokens on this with the user in an interactive session.