### PR TITLE
GH#28211: Reap dead claim stamps directly during pulse

### DIFF
--- a/.agents/scripts/interactive-session-helper-scan.sh
+++ b/.agents/scripts/interactive-session-helper-scan.sh
@@ -250,6 +250,10 @@ _isc_release_claim_by_stamp_path() {
 		rm -f "$stamp_path" 2>/dev/null || true
 		return 0
 	fi
+	if ! [[ "$r_issue" =~ ^[1-9][0-9]*$ ]] || ! [[ "$r_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		_isc_warn "_isc_release_claim_by_stamp_path: invalid issue/slug — preserving: $stamp_path"
+		return 0
+	fi
 
 	# Delegate to canonical release flow: stamp deletion + label transition.
 	# --unassign is mandatory here: auto-release is the dead-stamp recovery
@@ -269,7 +273,7 @@ _isc_release_claim_by_stamp_path() {
 _isc_cmd_release_if_dead() {
 	local issue="${1:-}"
 	local slug="${2:-}"
-	if [[ -z "$issue" || -z "$slug" ]]; then
+	if ! [[ "$issue" =~ ^[1-9][0-9]*$ ]] || ! [[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
 		_isc_err "usage: interactive-session-helper.sh release-if-dead <issue> <slug>"
 		return 2
 	fi
@@ -372,12 +376,16 @@ _isc_scan_stampless_phase() {
 #
 # Args:
 #   $1 auto_release_flag — "1" to auto-release, "0" for report-only
+#   $2 stamp_limit       — max stamp files to examine; "0" means unbounded
 #
 # Exit: 0 always.
 _isc_scan_dead_stamps_phase() {
 	local auto_release_flag="${1:-0}"
+	local stamp_limit="${2:-0}"
+	[[ "$stamp_limit" =~ ^[0-9]+$ ]] || stamp_limit=0
 	local stale_count=0
 	local auto_released=0
+	local stamps_examined=0
 	local local_host
 	local_host=$(hostname 2>/dev/null || echo "unknown")
 
@@ -385,13 +393,18 @@ _isc_scan_dead_stamps_phase() {
 		local stamp
 		for stamp in "$CLAIM_STAMP_DIR"/*.json; do
 			[[ -f "$stamp" ]] || continue
+			if [[ "$stamp_limit" -gt 0 && "$stamps_examined" -ge "$stamp_limit" ]]; then
+				break
+			fi
+			stamps_examined=$((stamps_examined + 1))
 			local issue slug worktree pid hostname
 			issue=$(jq -r '.issue // empty' "$stamp" 2>/dev/null || echo "")
 			slug=$(jq -r '.slug // empty' "$stamp" 2>/dev/null || echo "")
 			worktree=$(jq -r '.worktree_path // empty' "$stamp" 2>/dev/null || echo "")
 			pid=$(jq -r '.pid // empty' "$stamp" 2>/dev/null || echo "")
 			hostname=$(jq -r '.hostname // empty' "$stamp" 2>/dev/null || echo "")
-			[[ -z "$issue" || -z "$slug" ]] && continue
+			[[ "$issue" =~ ^[1-9][0-9]*$ ]] || continue
+			[[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || continue
 			# Only consider current-hostname stamps — cross-machine stamps
 			# can't have their PID verified and must not be surfaced as stale.
 			[[ "$hostname" == "$local_host" ]] || continue
@@ -447,6 +460,20 @@ _isc_scan_dead_stamps_phase() {
 			printf 'Total: %d stale claim(s). Release via `aidevops issue release <N>` or reclaim by `cd`-ing into the worktree.\n' "$stale_count"
 		fi
 	fi
+	return 0
+}
+
+# Reap dead local claim stamps without depending on GitHub issue discovery.
+# This is the scheduled-pulse entry point: it reuses the fail-closed Phase 1
+# safety gates while bounding each cycle's filesystem and API work.
+_isc_cmd_reap_dead_stamps() {
+	local stamp_limit="${AIDEVOPS_DEAD_STAMP_REAP_LIMIT:-100}"
+	if ! [[ "$stamp_limit" =~ ^[1-9][0-9]*$ ]]; then
+		_isc_warn "invalid AIDEVOPS_DEAD_STAMP_REAP_LIMIT=${stamp_limit}; using 100"
+		stamp_limit=100
+	fi
+
+	_isc_scan_dead_stamps_phase 1 "$stamp_limit"
 	return 0
 }
 

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -51,6 +51,7 @@
 #   interactive-session-helper.sh unlock <issue> <slug> [--unassign]
 #   interactive-session-helper.sh status [<issue>]
 #   interactive-session-helper.sh scan-stale
+#   interactive-session-helper.sh reap-dead-stamps
 #   interactive-session-helper.sh post-merge <pr_number> [<slug>]
 #   interactive-session-helper.sh help
 
@@ -354,7 +355,7 @@ USAGE:
   interactive-session-helper.sh release-if-dead <issue> <slug>
       Pulse-safe single-claim recovery; releases a dead same-host owner unless
       no-auto-dispatch applies. Live, cross-host, and unknown states fail closed.
-
+  interactive-session-helper.sh reap-dead-stamps  Bounded direct stamp recovery; safety gates fail closed.
   interactive-session-helper.sh post-merge <pr_number> [<slug>]
       Auto-heal two known drift patterns after a planning PR merges (t2225).
       Call after `gh pr merge` succeeds, alongside `release <N>`.
@@ -436,6 +437,9 @@ main() {
 		;;
 	release-if-dead)
 		_isc_cmd_release_if_dead "$@" || rc=$?
+		;;
+	reap-dead-stamps)
+		_isc_cmd_reap_dead_stamps "$@" || rc=$?
 		;;
 	post-merge)
 		_isc_cmd_post_merge "$@" || rc=$?

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -678,7 +678,7 @@ _normalize_reassign_self() {
 # Returns: 0 always (best-effort; logs failures to $LOGFILE)
 #######################################
 _normalize_reap_dead_stamps() {
-	local claim_helper="${AIDEVOPS_INTERACTIVE_SESSION_HELPER:-${SCRIPT_DIR}/interactive-session-helper.sh}"
+	local claim_helper="${AIDEVOPS_INTERACTIVE_SESSION_HELPER:-${_PIR_SCRIPT_DIR}/interactive-session-helper.sh}"
 	[[ -x "$claim_helper" ]] || return 0
 
 	if ! "$claim_helper" reap-dead-stamps >>"$LOGFILE" 2>&1; then

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -24,6 +24,7 @@
 #   - _normalize_get_stale_brief_rewrite_rows (stale zero-output hold recovery)
 #   - _normalize_requeue_stale_brief_rewrite_rows (stale zero-output requeue)
 #   - _normalize_reassign_self          (Phase 12: orphaned active issue → self-assign)
+#   - _normalize_reap_dead_stamps       (direct local claim-stamp recovery)
 #   - _normalize_unassign_stampless_interactive (t2148: stampless claim cleanup)
 #   - normalize_active_issue_assignments (coordinator — calls stale-recovery helpers)
 #   - reconcile_labelless_aidevops_issues (t2112 — >100 lines, identity key preserved)
@@ -666,6 +667,27 @@ _normalize_reassign_self() {
 }
 
 #######################################
+# Reap dead local claim stamps independently of GitHub issue discovery.
+#
+# The stamp directory is the authoritative recovery index: requiring a claim
+# to appear in an origin:interactive + assignee query misses claims created on
+# issues without that label or in repositories outside repos.json. The helper
+# applies the canonical same-host PID/argv, worktree, lockdown, and lookup
+# safety gates, with a bounded per-cycle scan.
+#
+# Returns: 0 always (best-effort; logs failures to $LOGFILE)
+#######################################
+_normalize_reap_dead_stamps() {
+	local claim_helper="${AIDEVOPS_INTERACTIVE_SESSION_HELPER:-${SCRIPT_DIR}/interactive-session-helper.sh}"
+	[[ -x "$claim_helper" ]] || return 0
+
+	if ! "$claim_helper" reap-dead-stamps >>"$LOGFILE" 2>&1; then
+		echo "[pulse-wrapper] Dead stamp reaper failed; preserving claims for a later cycle" >>"$LOGFILE"
+	fi
+	return 0
+}
+
+#######################################
 # (t2148) Auto-recover stampless origin:interactive claims.
 #
 # Closes the leak described on GH#19380: issues created during an
@@ -762,24 +784,14 @@ _normalize_unassign_stampless_interactive() {
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 			stamp="${stamp_dir}/${slug_flat}-${issue_num}.json"
 
-			local labels_csv=""
-			labels_csv=$(printf '%s' "$json" | jq -r --argjson n "$issue_num" '[.[] | select(.number == $n) | .labels[].name] | join(",")' 2>/dev/null) || labels_csv=""
 			if [[ -f "$stamp" ]]; then
-				# A stamp is only durable liveness evidence while its same-host
-				# PID/argv identity remains alive. Scheduled pulse previously
-				# skipped these forever and relied on a future interactive
-				# session to run scan-stale, leaving footprint reservations and
-				# overlapping auto-dispatch work globally blocked. Reap one
-				# already-aged candidate through the bounded helper command.
-				[[ ",${labels_csv}," == *",no-auto-dispatch,"* ]] && continue
-				local claim_helper="${AIDEVOPS_INTERACTIVE_SESSION_HELPER:-${SCRIPT_DIR}/interactive-session-helper.sh}"
-				if [[ -x "$claim_helper" ]] && "$claim_helper" release-if-dead "$issue_num" "$slug" >>"$LOGFILE" 2>&1; then
-					total_released=$((total_released + 1))
-					echo "[pulse-wrapper] Stamped interactive auto-release: released dead same-host claim #${issue_num} in ${slug}" >>"$LOGFILE"
-				fi
+				# Stamped claims are handled once per pulse by the direct bounded
+				# reaper. This pass remains strictly for stampless candidates.
 				continue
 			fi
 
+			local labels_csv=""
+			labels_csv=$(printf '%s' "$json" | jq -r --argjson n "$issue_num" '[.[] | select(.number == $n) | .labels[].name] | join(",")' 2>/dev/null) || labels_csv=""
 			if [[ ",${labels_csv}," == *",status:in-review,"* ]]; then
 				local open_pr_count=0 open_pr_rc=0
 				open_pr_count=$(gh_pr_list --repo "$slug" --state open --search "$issue_num" --json number --jq 'length' 2>/dev/null) || open_pr_rc=$?
@@ -837,6 +849,12 @@ _normalize_unassign_stampless_interactive() {
 #######################################
 normalize_active_issue_assignments() {
 	local repos_json="$REPOS_JSON"
+
+	# Pass 0 (GH#28211): scan the authoritative local stamp index directly.
+	# Run before repos.json and GitHub-user gates so recovery does not depend on
+	# repository registration, origin labels, assignees, or issue-list results.
+	_normalize_reap_dead_stamps
+
 	[[ -f "$repos_json" ]] || return 0
 
 	local runner_user
@@ -858,7 +876,7 @@ normalize_active_issue_assignments() {
 	# Pass 2: reset stale assignments (active label, assignee present, no running worker)
 	_normalize_unassign_stale "$runner_user" "$repos_json" "$now_epoch" "$cross_runner_max_runtime"
 
-	# Pass 2b (t2148/GH#27039): recover aged origin:interactive claims.
+	# Pass 2b (t2148): recover aged stampless origin:interactive claims.
 	# Closes the leak where `claim-task-id.sh` auto-assigns on creation
 	# (per t1970) but the interactive session never runs the formal
 	# claim flow, leaving an `origin:interactive + assignee` pair that
@@ -867,8 +885,7 @@ normalize_active_issue_assignments() {
 	# of a stamp file is itself the liveness signal: a real interactive
 	# session creates a stamp via `interactive-session-helper.sh claim`,
 	# while ad-hoc self-assigns from `claim-task-id.sh` (per t1970)
-	# never produce one. Stamped claims are also checked through the bounded
-	# release-if-dead command, which preserves live and cross-host owners.
+	# never produce one. Stamped claims were already handled by Pass 0.
 	# Override via STAMPLESS_INTERACTIVE_AGE_THRESHOLD
 	# (set to 86400 to restore the original 24h behaviour from t2148).
 	local stampless_age_threshold="${STAMPLESS_INTERACTIVE_AGE_THRESHOLD:-3600}"

--- a/.agents/scripts/tests/test-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-issue-reconcile.sh
@@ -304,10 +304,13 @@ printf '%s\n' "\$*" >>"${DEAD_STAMP_HELPER_LOG}"
 exit 0
 STUB
 chmod +x "$DEAD_STAMP_HELPER"
-export AIDEVOPS_INTERACTIVE_SESSION_HELPER="$DEAD_STAMP_HELPER"
 
 ORIGINAL_REPOS_JSON="$REPOS_JSON"
+ORIGINAL_PIR_SCRIPT_DIR="$_PIR_SCRIPT_DIR"
+ORIGINAL_SCRIPT_DIR="${SCRIPT_DIR:-}"
 export REPOS_JSON="${TEST_ROOT}/missing-repos.json"
+_PIR_SCRIPT_DIR="$STUB_DIR"
+unset SCRIPT_DIR AIDEVOPS_INTERACTIVE_SESSION_HELPER
 rm -f "$DEAD_STAMP_HELPER_LOG"
 normalize_active_issue_assignments
 
@@ -319,7 +322,12 @@ else
 		"(helper log: $(cat "$DEAD_STAMP_HELPER_LOG" 2>/dev/null || echo 'file missing'))"
 fi
 export REPOS_JSON="$ORIGINAL_REPOS_JSON"
-unset AIDEVOPS_INTERACTIVE_SESSION_HELPER
+_PIR_SCRIPT_DIR="$ORIGINAL_PIR_SCRIPT_DIR"
+if [[ -n "$ORIGINAL_SCRIPT_DIR" ]]; then
+	SCRIPT_DIR="$ORIGINAL_SCRIPT_DIR"
+else
+	unset SCRIPT_DIR
+fi
 
 # Clean up
 rm -f "${STAMP_DIR}/owner-testrepo-555.json"

--- a/.agents/scripts/tests/test-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-issue-reconcile.sh
@@ -293,8 +293,8 @@ else
 fi
 
 # =============================================================================
-# Part 6b (GH#27039) — an aged stamped claim is routed through the bounded
-# release-if-dead command instead of being skipped forever.
+# Part 6b (GH#28211) — the coordinator invokes the bounded direct stamp reaper
+# before repos.json or GitHub issue-discovery gates.
 # =============================================================================
 DEAD_STAMP_HELPER_LOG="${TEST_ROOT}/dead-stamp-helper.log"
 DEAD_STAMP_HELPER="${STUB_DIR}/interactive-session-helper.sh"
@@ -306,28 +306,20 @@ STUB
 chmod +x "$DEAD_STAMP_HELPER"
 export AIDEVOPS_INTERACTIVE_SESSION_HELPER="$DEAD_STAMP_HELPER"
 
-cat >"${STUB_DIR}/gh" <<STUB
-#!/usr/bin/env bash
-if [[ "\$1" == "issue" && "\$2" == "list" ]]; then
-    echo '[{"number":557,"updatedAt":"2020-01-01T00:00:00Z","labels":[{"name":"origin:interactive"},{"name":"status:in-review"}]}]'
-    exit 0
-fi
-exit 1
-STUB
-chmod +x "${STUB_DIR}/gh"
-jq -n --arg host "$(hostname 2>/dev/null || echo unknown)" '{
-	issue: 557, slug: "owner/testrepo", pid: 99999, hostname: $host
-}' >"${STAMP_DIR}/owner-testrepo-557.json"
+ORIGINAL_REPOS_JSON="$REPOS_JSON"
+export REPOS_JSON="${TEST_ROOT}/missing-repos.json"
+rm -f "$DEAD_STAMP_HELPER_LOG"
+normalize_active_issue_assignments
 
-_normalize_unassign_stampless_interactive "testrunner" "$REPOS_JSON" "$NOW_EPOCH_P5" "86400"
-if [[ -f "$DEAD_STAMP_HELPER_LOG" ]] && grep -q -- "release-if-dead 557 owner/testrepo" "$DEAD_STAMP_HELPER_LOG"; then
-	print_result "GH#27039: stamped stale claim uses bounded release-if-dead command" 0
+REAPER_CALL_COUNT=$(grep -c '^reap-dead-stamps$' "$DEAD_STAMP_HELPER_LOG" 2>/dev/null || true)
+if [[ "$REAPER_CALL_COUNT" -eq 1 ]]; then
+	print_result "GH#28211: coordinator directly reaps stamps once without repos.json discovery" 0
 else
-	print_result "GH#27039: stamped stale claim uses bounded release-if-dead command" 1 \
+	print_result "GH#28211: coordinator directly reaps stamps once without repos.json discovery" 1 \
 		"(helper log: $(cat "$DEAD_STAMP_HELPER_LOG" 2>/dev/null || echo 'file missing'))"
 fi
+export REPOS_JSON="$ORIGINAL_REPOS_JSON"
 unset AIDEVOPS_INTERACTIVE_SESSION_HELPER
-rm -f "${STAMP_DIR}/owner-testrepo-557.json"
 
 # Clean up
 rm -f "${STAMP_DIR}/owner-testrepo-555.json"

--- a/.agents/scripts/tests/test-scan-stale-auto-release.sh
+++ b/.agents/scripts/tests/test-scan-stale-auto-release.sh
@@ -40,6 +40,10 @@
 #   13. release-if-dead preserves live, cross-host, and lockdown claims.
 #   14. scan-stale preserves lockdown and unverifiable claims.
 #   15. claim stamps record the durable runtime owner rather than the helper PID.
+#   16. direct pulse reaper releases a safe dead stamp without repo discovery.
+#   17. direct pulse reaper preserves a surviving worktree.
+#   18. direct pulse reaper enforces its per-cycle stamp cap.
+#   19. direct pulse reaper preserves stamps with invalid target metadata.
 #
 # Stub strategy: override `_isc_release_claim_by_stamp_path` as a shell function
 # after sourcing the helper to capture auto-release calls without real gh ops.
@@ -493,6 +497,64 @@ else
 	fail "claim stamp records the durable runtime owner"
 fi
 rm -f "$DURABLE_STAMP"
+
+# =============================================================================
+# Test 16 — direct pulse reaper releases a safe dead stamp
+# =============================================================================
+: >"$RELEASE_LOG"
+ISC_LABEL_MODE="absent"
+write_stamp "outside-repos-120.json" "99999" "/nonexistent/path/120" "120" "outside/repo"
+_isc_cmd_reap_dead_stamps >/dev/null 2>/dev/null || true
+if [[ ! -f "${STAMP_DIR}/outside-repos-120.json" ]] && [[ "$(wc -l <"$RELEASE_LOG" | tr -d ' ')" -eq 1 ]]; then
+	pass "direct pulse reaper releases a safe stamp without repo discovery"
+else
+	fail "direct pulse reaper releases a safe stamp without repo discovery"
+fi
+
+# =============================================================================
+# Test 17 — direct pulse reaper preserves a surviving worktree
+# =============================================================================
+: >"$RELEASE_LOG"
+write_stamp "outside-repos-121.json" "99999" "$EXISTING_WORKTREE" "121" "outside/repo"
+_isc_cmd_reap_dead_stamps >/dev/null 2>/dev/null || true
+if [[ -f "${STAMP_DIR}/outside-repos-121.json" ]] && [[ ! -s "$RELEASE_LOG" ]]; then
+	pass "direct pulse reaper preserves a surviving worktree"
+else
+	fail "direct pulse reaper preserves a surviving worktree"
+fi
+rm -f "${STAMP_DIR}/outside-repos-121.json"
+
+# =============================================================================
+# Test 18 — direct pulse reaper bounds stamp examination per cycle
+# =============================================================================
+: >"$RELEASE_LOG"
+write_stamp "a-repo-122.json" "99999" "/nonexistent/path/122" "122" "a/repo"
+write_stamp "b-repo-123.json" "99999" "/nonexistent/path/123" "123" "b/repo"
+AIDEVOPS_DEAD_STAMP_REAP_LIMIT=1 _isc_cmd_reap_dead_stamps >/dev/null 2>/dev/null || true
+if [[ ! -f "${STAMP_DIR}/a-repo-122.json" ]] && \
+	[[ -f "${STAMP_DIR}/b-repo-123.json" ]] && \
+	[[ "$(wc -l <"$RELEASE_LOG" | tr -d ' ')" -eq 1 ]]; then
+	pass "direct pulse reaper enforces its per-cycle stamp cap"
+else
+	fail "direct pulse reaper enforces its per-cycle stamp cap"
+fi
+rm -f "${STAMP_DIR}/a-repo-122.json" "${STAMP_DIR}/b-repo-123.json"
+
+# =============================================================================
+# Test 19 — direct pulse reaper rejects invalid issue and slug metadata
+# =============================================================================
+: >"$RELEASE_LOG"
+write_stamp "invalid-issue.json" "99999" "/nonexistent/path/124" "0" "owner/repo"
+write_stamp "invalid-slug.json" "99999" "/nonexistent/path/125" "125" "owner/repo/extra"
+_isc_cmd_reap_dead_stamps >/dev/null 2>/dev/null || true
+if [[ -f "${STAMP_DIR}/invalid-issue.json" ]] && \
+	[[ -f "${STAMP_DIR}/invalid-slug.json" ]] && \
+	[[ ! -s "$RELEASE_LOG" ]]; then
+	pass "direct pulse reaper preserves stamps with invalid target metadata"
+else
+	fail "direct pulse reaper preserves stamps with invalid target metadata"
+fi
+rm -f "${STAMP_DIR}/invalid-issue.json" "${STAMP_DIR}/invalid-slug.json"
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

Add a bounded pulse-safe command that scans the authoritative local claim-stamp directory, preserves all fail-closed ownership gates, and invoke it independently of issue labels, assignees, and repos.json membership.

## Files Changed

.agents/scripts/interactive-session-helper-scan.sh, .agents/scripts/interactive-session-helper.sh, .agents/scripts/pulse-issue-reconcile.sh, .agents/scripts/tests/test-issue-reconcile.sh, .agents/scripts/tests/test-scan-stale-auto-release.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused reconciliation tests (15/15), dead-stamp lifecycle tests (23/23), interactive-session tests (40/40), pulse reconciliation tests (25/25), ShellCheck, git diff --check, and .agents/scripts/linters-local.sh.

Resolves #28211


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.151 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 47m and 664,804 tokens on this with the user in an interactive session.