### PR TITLE
t18129: Add cross-process single-flight and shared rate-limit state

### DIFF
--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -60,6 +60,12 @@ SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
 SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
 _PULSE_BATCH_SEARCH_LAST_RESORT_ENV="${PULSE_BATCH_SEARCH_LAST_RESORT-}"
 
+# shellcheck source=./shared-gh-request-state.sh
+if [[ -f "${SCRIPT_DIR}/shared-gh-request-state.sh" ]]; then
+	# shellcheck disable=SC1091
+	source "${SCRIPT_DIR}/shared-gh-request-state.sh"
+fi
+
 # Source shared constants for colors and helpers
 # shellcheck source=./shared-constants.sh
 # shellcheck disable=SC1091
@@ -124,7 +130,9 @@ _SNAPSHOT_SCHEMA="aidevops-pulse-snapshot/v1"
 _SNAPSHOT_ISSUES_PROJECTION="number,title,state,labels,updatedAt,assignees"
 _SNAPSHOT_PRS_PROJECTION="number,title,labels,updatedAt,assignees,createdAt,author,headRefOid,headRefName"
 _BATCH_SNAPSHOT_GENERATION="${PULSE_BATCH_SNAPSHOT_GENERATION:-}"
-_BATCH_SNAPSHOT_AUTH_SCOPE="${PULSE_BATCH_SNAPSHOT_AUTH_SCOPE:-${GH_HOST:-github.com}|${AIDEVOPS_GH_AUTH_MODE:-gh}|${AIDEVOPS_GH_AUTH_PRINCIPAL:-default}}"
+_BATCH_SNAPSHOT_AUTH_SCOPE="${PULSE_BATCH_SNAPSHOT_AUTH_SCOPE:-${GH_HOST:-github.com}|${AIDEVOPS_GH_AUTH_MODE:-gh}|${AIDEVOPS_GH_AUTH_PRINCIPAL:-default}}|${AIDEVOPS_GH_API_POOL:-default}"
+_BATCH_INITIAL_SNAPSHOT_MARKERS=""
+_BATCH_SNAPSHOT_MARKER_MISSING="$_CACHE_SNAPSHOT_STATE"
 
 # --- Feature flag gate ---
 _check_enabled() {
@@ -442,6 +450,64 @@ _conditional_rest_endpoint() {
 	return 0
 }
 
+_conditional_rest_snapshot_marker() {
+	local kind="$1"
+	local slug="$2"
+	local projection=""
+	local cache_file=""
+	projection=$(_snapshot_projection "$kind") || return 1
+	cache_file=$(_cache_file_path "$kind" "$slug")
+	[[ -s "$cache_file" ]] || return 1
+	jq -er --arg schema "$_SNAPSHOT_SCHEMA" --arg slug "$slug" --arg kind "$kind" \
+		--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" \
+		--arg string_type "$_JSON_TYPE_STRING" '
+		select(
+			.schema == $schema and .repository == $slug and .collection == $kind and
+			.projection == $projection and .auth_scope == $auth_scope and
+			.source == "conditional-rest" and .complete == true and
+			(.generation | type == $string_type and length > 0) and
+			(.fetched_at | type == $string_type and length > 0)
+		) |
+		[.generation, .fetched_at, (.etag // "")] | @tsv
+	' "$cache_file" 2>/dev/null
+	return $?
+}
+
+_conditional_rest_capture_initial_markers() {
+	local owner_groups="$1"
+	local owner="" slugs="" slug="" kind="" marker="" record=""
+	_BATCH_INITIAL_SNAPSHOT_MARKERS=""
+	while IFS='|' read -r owner slugs; do
+		[[ -n "$owner" ]] || continue
+		while IFS= read -r slug; do
+			[[ -n "$slug" ]] || continue
+			for kind in "$_KIND_ISSUES" "$_KIND_PRS"; do
+				marker=$(_conditional_rest_snapshot_marker "$kind" "$slug") || marker="$_BATCH_SNAPSHOT_MARKER_MISSING"
+				record="${kind}|${slug}|${marker}"
+				if [[ -n "$_BATCH_INITIAL_SNAPSHOT_MARKERS" ]]; then
+					_BATCH_INITIAL_SNAPSHOT_MARKERS="${_BATCH_INITIAL_SNAPSHOT_MARKERS}"$'\n'"${record}"
+				else
+					_BATCH_INITIAL_SNAPSHOT_MARKERS="$record"
+				fi
+			done
+		done < <(tr ',' '\n' <<<"$slugs")
+	done <<<"$owner_groups"
+	return 0
+}
+
+_conditional_rest_initial_marker() {
+	local kind="$1"
+	local slug="$2"
+	local stored_kind="" stored_slug="" marker=""
+	while IFS='|' read -r stored_kind stored_slug marker; do
+		if [[ "$stored_kind" == "$kind" && "$stored_slug" == "$slug" ]]; then
+			printf '%s\n' "$marker"
+			return 0
+		fi
+	done <<<"$_BATCH_INITIAL_SNAPSHOT_MARKERS"
+	return 1
+}
+
 _conditional_rest_update_cache_from_response() {
 	local kind="$1"
 	local slug="$2"
@@ -457,9 +523,11 @@ _conditional_rest_update_cache_from_response() {
 	return 0
 }
 
-_conditional_rest_refresh_slug() {
+_conditional_rest_refresh_slug_leader() {
 	local kind="$1"
 	local slug="$2"
+	local request_key="${3:-}"
+	local generation="${4:-}"
 	[[ "${PULSE_BATCH_CONDITIONAL_REST_ENABLED:-1}" == "1" ]] || return 1
 	local cache_file
 	cache_file=$(_cache_file_path "$kind" "$slug")
@@ -487,6 +555,10 @@ _conditional_rest_refresh_slug() {
 		_prefetch_gh_read gh api -i -H "Accept: application/vnd.github+json" "$endpoint" >"$response_file" 2>"$err_file" || rc=$?
 	fi
 	local status=""
+	if [[ -n "$request_key" && -n "$generation" ]] && ! gh_request_state_singleflight_is_owner "$request_key" "$generation"; then
+		rm -f "$response_file" "$err_file"
+		return 1
+	fi
 	status=$(_conditional_rest_update_cache_from_response "$kind" "$slug" "$response_file" "$cache_file" 2>/dev/null) || status=""
 	rm -f "$response_file" "$err_file"
 	case "$status" in
@@ -507,6 +579,57 @@ _conditional_rest_refresh_slug() {
 		return 1
 		;;
 	esac
+	return 1
+}
+
+_conditional_rest_refresh_slug() {
+	local kind="$1"
+	local slug="$2"
+	local projection=""
+	local request_key=""
+	local generation=""
+	local initial_marker=""
+	local current_marker=""
+	projection=$(_snapshot_projection "$kind") || return 1
+	initial_marker=$(_conditional_rest_initial_marker "$kind" "$slug") || {
+		initial_marker=$(_conditional_rest_snapshot_marker "$kind" "$slug") || initial_marker="$_BATCH_SNAPSHOT_MARKER_MISSING"
+	}
+	if ! declare -F gh_request_state_singleflight_begin >/dev/null 2>&1; then
+		_conditional_rest_refresh_slug_leader "$kind" "$slug"
+		return $?
+	fi
+	request_key=$(gh_request_state_request_key "$slug" canonical-snapshot "$projection" "$kind" rest-core) || {
+		_conditional_rest_refresh_slug_leader "$kind" "$slug"
+		return $?
+	}
+	gh_request_state_singleflight_begin "$request_key"
+	generation="$_GHRS_BEGIN_GENERATION"
+	case "$_GHRS_BEGIN_ROLE" in
+	leader)
+		current_marker=$(_conditional_rest_snapshot_marker "$kind" "$slug") || current_marker=""
+		if [[ -n "$current_marker" && "$current_marker" != "$initial_marker" ]]; then
+			gh_request_state_singleflight_finish "$request_key" "$generation" success || true
+			_log "conditional REST ${kind}: reused concurrently published snapshot for ${slug}"
+			return 0
+		fi
+		if _conditional_rest_refresh_slug_leader "$kind" "$slug" "$request_key" "$generation"; then
+			gh_request_state_singleflight_finish "$request_key" "$generation" success || true
+			return 0
+		fi
+		gh_request_state_singleflight_finish "$request_key" "$generation" failure || true
+		return 1
+		;;
+	follower-success)
+		_log "conditional REST ${kind}: coalesced shared refresh for ${slug}"
+		return 0
+		;;
+	follower-failure | timeout) return 1 ;;
+	bypass)
+		_conditional_rest_refresh_slug_leader "$kind" "$slug"
+		return $?
+		;;
+	esac
+	return 1
 }
 
 _conditional_rest_per_slug() {
@@ -770,6 +893,7 @@ _cmd_refresh() {
 		_log "no pulse-enabled repos found — nothing to prefetch"
 		return 0
 	fi
+	_conditional_rest_capture_initial_markers "$owner_groups"
 
 	# Shared counters updated by _refresh_owner_issues/_refresh_owner_prs
 	_OWNER_SEARCH_CALLS=0

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -46,15 +46,20 @@
 #   `pulse_dispatch_circuit_broken` in ~/.aidevops/logs/pulse-stats.json
 #   (via pulse-stats-helper.sh). Surfaced by `aidevops status`.
 #
-# Multi-runner: Each runner polls `gh api rate_limit` independently. All runners
-# share the same GitHub token and see the same budget — per-runner polling is
-# correct without shared state files.
+# Multi-runner: concurrent local runners share a short-lived, auth-scoped rate
+# snapshot and single-flight probe. Remote runners retain independent local state.
 #
 # Cost: `gh api rate_limit` is a free endpoint (not counted against quotas).
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+# shellcheck source=./shared-gh-request-state.sh
+if [[ -f "${SCRIPT_DIR}/shared-gh-request-state.sh" ]]; then
+	# shellcheck disable=SC1091
+	source "${SCRIPT_DIR}/shared-gh-request-state.sh"
+fi
 
 # Source pulse-stats-helper.sh for counter support (optional — fail-open if missing).
 # shellcheck source=pulse-stats-helper.sh
@@ -121,6 +126,14 @@ _cb_gh_read() {
 }
 
 #######################################
+# Fetch the full rate-limit projection through the circuit breaker's timeout.
+#######################################
+_cb_rate_limit_transport() {
+	_cb_gh_read gh api rate_limit
+	return $?
+}
+
+#######################################
 # Read GitHub rate-limit state with a short TTL cache.
 #
 # Args:
@@ -130,33 +143,15 @@ _cb_gh_read() {
 #######################################
 _cb_rate_limit_json() {
 	local mode="${1:-normal}"
-	local now="" cached_ts="" age="" rate_json="" tmp=""
-	now=$(date +%s 2>/dev/null) || now=0
-
-	if [[ -f "$_CB_RL_CACHE_FILE" ]]; then
-		cached_ts=$(jq -r '.ts // 0' "$_CB_RL_CACHE_FILE" 2>/dev/null) || cached_ts=0
-		[[ "$cached_ts" =~ ^[0-9]+$ ]] || cached_ts=0
-		age=$((now - cached_ts))
-		if [[ "$mode" == "$_CB_RL_MODE_CACHED_ONLY" ]] || { [[ "$_CB_RL_CACHE_TTL" =~ ^[0-9]+$ ]] && [[ "$age" -ge 0 ]] && [[ "$age" -lt "$_CB_RL_CACHE_TTL" ]]; }; then
-			rate_json=$(jq -c '.rate // empty' "$_CB_RL_CACHE_FILE" 2>/dev/null) || rate_json=""
-			if [[ -n "$rate_json" && "$rate_json" != "null" ]]; then
-				printf '%s\n' "$rate_json"
-				return 0
-			fi
-		fi
+	local ttl="$_CB_RL_CACHE_TTL"
+	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=20
+	if declare -F gh_request_state_rate_json >/dev/null 2>&1; then
+		gh_request_state_rate_json "$mode" "$ttl" _cb_rate_limit_transport
+		return $?
 	fi
-
 	[[ "$mode" == "$_CB_RL_MODE_CACHED_ONLY" ]] && return 1
-
-	rate_json=$(_cb_gh_read gh api rate_limit 2>/dev/null) || return 1
-	[[ -n "$rate_json" ]] || return 1
-	mkdir -p "${_CB_RL_CACHE_FILE%/*}" 2>/dev/null || true
-	tmp=$(mktemp "${_CB_RL_CACHE_FILE}.XXXXXX" 2>/dev/null) || tmp=""
-	if [[ -n "$tmp" ]]; then
-		printf '{"ts":%s,"rate":%s}\n' "$now" "$rate_json" >"$tmp" 2>/dev/null && mv "$tmp" "$_CB_RL_CACHE_FILE" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
-	fi
-	printf '%s\n' "$rate_json"
-	return 0
+	_cb_rate_limit_transport
+	return $?
 }
 
 #######################################

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -953,7 +953,9 @@ _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
 # retry keeps scheduled helpers self-healing without masking persistent install
 # corruption.
 _source_shared_module_with_retry() {
-	local module_path="$1"
+	# `module_path` is a special zsh array used by zmodload. Shadowing it while
+	# evaluating the regex guards below breaks lazy loading of zsh/regex.
+	local module_file="$1"
 	local attempts="${AIDEVOPS_SHARED_SOURCE_ATTEMPTS:-5}"
 	local interval="${AIDEVOPS_SHARED_SOURCE_INTERVAL:-1}"
 	local attempt=1
@@ -963,9 +965,9 @@ _source_shared_module_with_retry() {
 	[[ "$attempts" -gt 0 ]] || attempts=1
 
 	while [[ "$attempt" -le "$attempts" ]]; do
-		if [[ -f "$module_path" ]]; then
+		if [[ -f "$module_file" ]]; then
 			# shellcheck source=/dev/null
-			source "$module_path"
+			source "$module_file"
 			return $?
 		fi
 		if [[ "$attempt" -lt "$attempts" && "$interval" -gt 0 ]]; then
@@ -974,7 +976,7 @@ _source_shared_module_with_retry() {
 		attempt=$((attempt + 1))
 	done
 
-	printf '[ERROR] shared module missing after %s attempt(s): %s\n' "$attempts" "$module_path" >&2
+	printf '[ERROR] shared module missing after %s attempt(s): %s\n' "$attempts" "$module_file" >&2
 	return 1
 }
 

--- a/.agents/scripts/shared-gh-request-state.sh
+++ b/.agents/scripts/shared-gh-request-state.sh
@@ -1,0 +1,644 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Shared GitHub request coordination: scoped rate snapshots and single-flight.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+[[ -n "${_SHARED_GH_REQUEST_STATE_LOADED:-}" ]] && return 0
+_SHARED_GH_REQUEST_STATE_LOADED=1
+
+_GHRS_LEASE_SCHEMA="aidevops-gh-request-lease/v1"
+_GHRS_OUTCOME_SCHEMA="aidevops-gh-request-outcome/v1"
+_GHRS_RATE_SCHEMA="aidevops-gh-rate-limit-state/v1"
+_GHRS_REQUEST_PROJECTION="request-coordination/v1"
+_GHRS_ROLE_BYPASS="bypass"
+_GHRS_STATUS_SUCCESS="success"
+_GHRS_STATUS_FAILURE="failure"
+_GHRS_JSON_TYPE_NUMBER="number"
+_GHRS_JSON_TYPE_OBJECT="object"
+_GHRS_ACQUIRED_GENERATION=""
+_GHRS_BEGIN_ROLE=""
+_GHRS_BEGIN_GENERATION=""
+
+_ghrs_now() {
+	date +%s 2>/dev/null || printf '0\n'
+	return 0
+}
+
+_ghrs_pid() {
+	local process_pid="${BASHPID:-}"
+	if [[ -z "$process_pid" ]]; then
+		process_pid="$(exec sh -c 'printf "%s" "$PPID"')" || return 1
+	fi
+	[[ "$process_pid" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$process_pid"
+	return 0
+}
+
+_ghrs_digest() {
+	local material="$1"
+	local digest=""
+	if command -v shasum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$material" | shasum -a 256 | awk '{print $1}')
+	elif command -v sha256sum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$material" | sha256sum | awk '{print $1}')
+	elif command -v openssl >/dev/null 2>&1; then
+		digest=$(printf '%s' "$material" | openssl dgst -sha256 | awk '{print $NF}')
+	else
+		return 1
+	fi
+	[[ "$digest" =~ ^[A-Fa-f0-9]{64}$ ]] || return 1
+	printf '%s\n' "$digest"
+	return 0
+}
+
+_ghrs_auth_scope() {
+	local pool="${1:-${AIDEVOPS_GH_API_POOL:-default}}"
+	local base_scope="${AIDEVOPS_GH_REQUEST_STATE_AUTH_SCOPE:-${GH_HOST:-github.com}|${AIDEVOPS_GH_AUTH_MODE:-gh}|${AIDEVOPS_GH_AUTH_PRINCIPAL:-default}}"
+	printf '%s|%s\n' "$base_scope" "$pool"
+	return 0
+}
+
+_ghrs_scope_fingerprint() {
+	local pool="${1:-${AIDEVOPS_GH_API_POOL:-default}}"
+	local scope=""
+	scope="$(_ghrs_auth_scope "$pool")" || return 1
+	_ghrs_digest "$scope"
+	return $?
+}
+
+gh_request_state_request_key() {
+	local repository="$1"
+	local operation="$2"
+	local projection="$3"
+	local identity="$4"
+	local pool="${5:-${AIDEVOPS_GH_API_POOL:-default}}"
+	local scope_fingerprint=""
+	local material=""
+	[[ -n "$repository" && -n "$operation" && -n "$projection" && -n "$identity" ]] || return 1
+	scope_fingerprint="$(_ghrs_scope_fingerprint "$pool")" || return 1
+	material=$(printf '%s\034%s\034%s\034%s\034%s\034%s' \
+		"$_GHRS_REQUEST_PROJECTION" "$scope_fingerprint" "$repository" \
+		"$operation" "$projection" "$identity")
+	_ghrs_digest "$material"
+	return $?
+}
+
+_ghrs_base_dir() {
+	local work_dir="${AIDEVOPS_WORK_DIR:-${HOME:+${HOME}/.aidevops/.agent-workspace/work}}"
+	local base_dir="${AIDEVOPS_GH_REQUEST_STATE_DIR:-${work_dir:+${work_dir}/github-request-state}}"
+	[[ -n "$base_dir" ]] || return 1
+	(umask 077 && mkdir -p "$base_dir") 2>/dev/null || return 1
+	chmod 700 "$base_dir" 2>/dev/null || return 1
+	printf '%s\n' "$base_dir"
+	return 0
+}
+
+_ghrs_request_dir() {
+	local key="$1"
+	local base_dir=""
+	local request_dir=""
+	[[ "$key" =~ ^[A-Fa-f0-9]{64}$ ]] || return 1
+	base_dir="$(_ghrs_base_dir)" || return 1
+	request_dir="${base_dir}/requests/${key}"
+	(umask 077 && mkdir -p "$request_dir") 2>/dev/null || return 1
+	chmod 700 "${base_dir}/requests" "$request_dir" 2>/dev/null || return 1
+	printf '%s\n' "$request_dir"
+	return 0
+}
+
+_ghrs_file_mtime() {
+	local path="$1"
+	local modified_at=""
+	if stat -f '%m' "$path" >/dev/null 2>&1; then
+		modified_at=$(stat -f '%m' "$path" 2>/dev/null) || modified_at=""
+	elif stat -c '%Y' "$path" >/dev/null 2>&1; then
+		modified_at=$(stat -c '%Y' "$path" 2>/dev/null) || modified_at=""
+	else
+		return 1
+	fi
+	[[ "$modified_at" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$modified_at"
+	return 0
+}
+
+_ghrs_sleep_jitter() {
+	local base_ms="${AIDEVOPS_GH_SINGLEFLIGHT_WAIT_BASE_MS:-60}"
+	local jitter_ms="${AIDEVOPS_GH_SINGLEFLIGHT_WAIT_JITTER_MS:-90}"
+	[[ "$base_ms" =~ ^[0-9]+$ && "$base_ms" -le 900 ]] || base_ms=60
+	[[ "$jitter_ms" =~ ^[0-9]+$ && "$jitter_ms" -le 900 ]] || jitter_ms=90
+	local jitter_range=$((jitter_ms + 1))
+	local jitter=$((RANDOM % jitter_range))
+	local delay_ms=$((base_ms + jitter))
+	local delay=""
+	if [[ "$delay_ms" -ge 1000 ]]; then
+		delay="1"
+	else
+		delay=$(printf '0.%03d' "$delay_ms")
+	fi
+	sleep "$delay"
+	return 0
+}
+
+_ghrs_record() {
+	local decision="$1"
+	local operation="${2:-request}"
+	if declare -F gh_record_call >/dev/null 2>&1; then
+		gh_record_call other gh_request_singleflight unknown other "$decision" "$operation" coordination 2>/dev/null || true
+	fi
+	return 0
+}
+
+_ghrs_owner_read() {
+	local key="$1"
+	local request_dir=""
+	request_dir="$(_ghrs_request_dir "$key")" || return 1
+	jq -er --arg schema "$_GHRS_LEASE_SCHEMA" --arg key "$key" \
+		--arg number_type "$_GHRS_JSON_TYPE_NUMBER" '
+		select(.schema == $schema and .key == $key) |
+		select(.generation | type == "string" and test("^[A-Za-z0-9:._-]+$")) |
+		select(.pid | type == $number_type and floor == . and . > 0) |
+		select(.created_at | type == $number_type and floor == . and . > 0) |
+		select((.expires_at | type == $number_type and floor == .) and .expires_at >= .created_at) |
+		[.generation, (.pid | tostring), (.created_at | tostring), (.expires_at | tostring)] | @tsv
+	' "${request_dir}/lease/owner.json" 2>/dev/null
+	return $?
+}
+
+_ghrs_owner_is_stale() {
+	local key="$1"
+	local owner_record="$2"
+	local request_dir=""
+	local lease_dir=""
+	local now=""
+	request_dir="$(_ghrs_request_dir "$key")" || return 1
+	lease_dir="${request_dir}/lease"
+	now="$(_ghrs_now)"
+	[[ "$now" =~ ^[0-9]+$ && "$now" -gt 0 ]] || return 1
+
+	if [[ -n "$owner_record" ]]; then
+		local generation="" owner_pid="" created_at="" expires_at=""
+		IFS=$'\t' read -r generation owner_pid created_at expires_at <<<"$owner_record"
+		[[ -n "$generation" && "$owner_pid" =~ ^[0-9]+$ && "$expires_at" =~ ^[0-9]+$ ]] || return 1
+		[[ "$now" -ge "$expires_at" ]] && return 0
+		kill -0 "$owner_pid" 2>/dev/null || return 0
+		return 1
+	fi
+
+	local orphan_grace="${AIDEVOPS_GH_SINGLEFLIGHT_OWNER_GRACE_SECONDS:-2}"
+	local modified_at=""
+	local age=0
+	[[ "$orphan_grace" =~ ^[0-9]+$ ]] || orphan_grace=2
+	modified_at="$(_ghrs_file_mtime "$lease_dir")" || return 1
+	age=$((now - modified_at))
+	[[ "$age" -lt 0 ]] && age=0
+	[[ "$age" -ge "$orphan_grace" ]]
+	return $?
+}
+
+_ghrs_reclaim_lease() {
+	local key="$1"
+	local observed_generation="$2"
+	local request_dir=""
+	local lease_dir=""
+	local reclaim_dir=""
+	local current_owner=""
+	local current_generation=""
+	request_dir="$(_ghrs_request_dir "$key")" || return 1
+	lease_dir="${request_dir}/lease"
+	reclaim_dir="${request_dir}/lease.reclaim"
+	mkdir "$reclaim_dir" 2>/dev/null || return 1
+
+	if [[ ! -d "$lease_dir" ]]; then
+		rmdir "$reclaim_dir" 2>/dev/null || true
+		return 1
+	fi
+	current_owner="$(_ghrs_owner_read "$key")" || current_owner=""
+	if [[ -n "$current_owner" ]]; then
+		current_generation="${current_owner%%$'\t'*}"
+		if [[ -z "$observed_generation" || "$current_generation" != "$observed_generation" ]]; then
+			rmdir "$reclaim_dir" 2>/dev/null || true
+			return 1
+		fi
+	fi
+
+	rm -f "${lease_dir}/owner.json" "${lease_dir}"/.owner.* 2>/dev/null || true
+	if ! rmdir "$lease_dir" 2>/dev/null; then
+		rmdir "$reclaim_dir" 2>/dev/null || true
+		return 1
+	fi
+	rmdir "$reclaim_dir" 2>/dev/null || true
+	_ghrs_record takeover
+	return 0
+}
+
+_ghrs_try_acquire() {
+	local key="$1"
+	local request_dir=""
+	local lease_dir=""
+	local process_pid=""
+	local now=""
+	local lease_seconds="${AIDEVOPS_GH_SINGLEFLIGHT_LEASE_SECONDS:-30}"
+	local expires_at=0
+	local generation=""
+	local owner_tmp=""
+	_GHRS_ACQUIRED_GENERATION=""
+	request_dir="$(_ghrs_request_dir "$key")" || return 1
+	lease_dir="${request_dir}/lease"
+	(umask 077 && mkdir "$lease_dir") 2>/dev/null || return 1
+	process_pid="${BASHPID:-}"
+	if [[ -z "$process_pid" ]]; then
+		process_pid="$(_ghrs_pid)" || process_pid=""
+	fi
+	if [[ ! "$process_pid" =~ ^[0-9]+$ ]]; then
+		rmdir "$lease_dir" 2>/dev/null || true
+		return 1
+	fi
+	now="$(_ghrs_now)"
+	[[ "$now" =~ ^[0-9]+$ && "$now" -gt 0 ]] || {
+		rmdir "$lease_dir" 2>/dev/null || true
+		return 1
+	}
+	[[ "$lease_seconds" =~ ^[1-9][0-9]*$ && "$lease_seconds" -le 300 ]] || lease_seconds=30
+	expires_at=$((now + lease_seconds))
+	generation="${process_pid}:${now}:${RANDOM}:${RANDOM}"
+	owner_tmp=$(mktemp "${lease_dir}/.owner.XXXXXX" 2>/dev/null) || {
+		rmdir "$lease_dir" 2>/dev/null || true
+		return 1
+	}
+	chmod 600 "$owner_tmp" 2>/dev/null || {
+		rm -f "$owner_tmp"
+		rmdir "$lease_dir" 2>/dev/null || true
+		return 1
+	}
+	if ! jq -n --arg schema "$_GHRS_LEASE_SCHEMA" --arg key "$key" \
+		--arg generation "$generation" --argjson pid "$process_pid" \
+		--argjson created_at "$now" --argjson expires_at "$expires_at" \
+		'{schema:$schema,key:$key,generation:$generation,pid:$pid,
+		created_at:$created_at,expires_at:$expires_at}' >"$owner_tmp"; then
+		rm -f "$owner_tmp"
+		rmdir "$lease_dir" 2>/dev/null || true
+		return 1
+	fi
+	if ! mv "$owner_tmp" "${lease_dir}/owner.json" 2>/dev/null; then
+		rm -f "$owner_tmp"
+		rmdir "$lease_dir" 2>/dev/null || true
+		return 1
+	fi
+	_GHRS_ACQUIRED_GENERATION="$generation"
+	return 0
+}
+
+_ghrs_outcome_read() {
+	local key="$1"
+	local generation="$2"
+	local request_dir=""
+	local now=""
+	local outcome_ttl="${AIDEVOPS_GH_SINGLEFLIGHT_OUTCOME_TTL_SECONDS:-10}"
+	local entry=""
+	local status="" completed_at=""
+	request_dir="$(_ghrs_request_dir "$key")" || return 1
+	[[ "$outcome_ttl" =~ ^[1-9][0-9]*$ && "$outcome_ttl" -le 60 ]] || outcome_ttl=10
+	entry=$(jq -er --arg schema "$_GHRS_OUTCOME_SCHEMA" --arg key "$key" \
+		--arg generation "$generation" --arg success "$_GHRS_STATUS_SUCCESS" \
+		--arg failure "$_GHRS_STATUS_FAILURE" \
+		--arg number_type "$_GHRS_JSON_TYPE_NUMBER" '
+		select(.schema == $schema and .key == $key and .generation == $generation) |
+		select(.status == $success or .status == $failure) |
+		select(.completed_at | type == $number_type and floor == . and . > 0) |
+		[.status, (.completed_at | tostring)] | @tsv
+	' "${request_dir}/outcome.json" 2>/dev/null) || entry=""
+	[[ -n "$entry" ]] || return 1
+	IFS=$'\t' read -r status completed_at <<<"$entry"
+	now="$(_ghrs_now)"
+	[[ "$now" =~ ^[0-9]+$ && "$completed_at" =~ ^[0-9]+$ ]] || return 1
+	[[ "$now" -ge "$completed_at" && $((now - completed_at)) -le "$outcome_ttl" ]] || return 1
+	printf '%s\n' "$status"
+	return 0
+}
+
+gh_request_state_singleflight_begin() {
+	local key="$1"
+	_GHRS_BEGIN_ROLE=""
+	_GHRS_BEGIN_GENERATION=""
+	if [[ "${AIDEVOPS_GH_REQUEST_STATE_DISABLE:-0}" == "1" || "${AIDEVOPS_GH_SINGLEFLIGHT_DISABLE:-0}" == "1" ]]; then
+		_GHRS_BEGIN_ROLE="$_GHRS_ROLE_BYPASS"
+		_ghrs_record bypass-disabled
+		return 0
+	fi
+	[[ "$key" =~ ^[A-Fa-f0-9]{64}$ ]] || {
+		_GHRS_BEGIN_ROLE="$_GHRS_ROLE_BYPASS"
+		_ghrs_record bypass-invalid
+		return 0
+	}
+
+	local wait_seconds="${AIDEVOPS_GH_SINGLEFLIGHT_WAIT_SECONDS:-10}"
+	local started_at=""
+	local now=""
+	local generation=""
+	local owner_record=""
+	local observed_generation=""
+	local outcome=""
+	local follower_role=""
+	[[ "$wait_seconds" =~ ^[0-9]+$ && "$wait_seconds" -le 120 ]] || wait_seconds=10
+	started_at="$(_ghrs_now)"
+	[[ "$started_at" =~ ^[0-9]+$ && "$started_at" -gt 0 ]] || {
+		_GHRS_BEGIN_ROLE="$_GHRS_ROLE_BYPASS"
+		return 0
+	}
+
+	while true; do
+		if [[ -n "$observed_generation" ]]; then
+			outcome="$(_ghrs_outcome_read "$key" "$observed_generation")" || outcome=""
+			if [[ "$outcome" == "$_GHRS_STATUS_SUCCESS" || "$outcome" == "$_GHRS_STATUS_FAILURE" ]]; then
+				follower_role="follower-${outcome}"
+				_GHRS_BEGIN_ROLE="$follower_role"
+				_GHRS_BEGIN_GENERATION="$observed_generation"
+				_ghrs_record "$follower_role"
+				return 0
+			fi
+		fi
+		if _ghrs_try_acquire "$key"; then
+			generation="$_GHRS_ACQUIRED_GENERATION"
+			_GHRS_BEGIN_ROLE="leader"
+			_GHRS_BEGIN_GENERATION="$generation"
+			_ghrs_record leader
+			return 0
+		fi
+
+		owner_record="$(_ghrs_owner_read "$key")" || owner_record=""
+		observed_generation=""
+		[[ -n "$owner_record" ]] && observed_generation="${owner_record%%$'\t'*}"
+		if [[ -n "$observed_generation" ]]; then
+			outcome="$(_ghrs_outcome_read "$key" "$observed_generation")" || outcome=""
+			if [[ "$outcome" == "$_GHRS_STATUS_SUCCESS" || "$outcome" == "$_GHRS_STATUS_FAILURE" ]]; then
+				follower_role="follower-${outcome}"
+				_GHRS_BEGIN_ROLE="$follower_role"
+				_GHRS_BEGIN_GENERATION="$observed_generation"
+				_ghrs_record "$follower_role"
+				return 0
+			fi
+		fi
+
+		if _ghrs_owner_is_stale "$key" "$owner_record"; then
+			_ghrs_reclaim_lease "$key" "$observed_generation" || true
+			continue
+		fi
+		now="$(_ghrs_now)"
+		if [[ "$now" =~ ^[0-9]+$ && $((now - started_at)) -ge "$wait_seconds" ]]; then
+			_GHRS_BEGIN_ROLE="timeout"
+			_ghrs_record timeout
+			return 0
+		fi
+		_ghrs_sleep_jitter
+	done
+}
+
+gh_request_state_singleflight_is_owner() {
+	local key="$1"
+	local generation="$2"
+	local owner_record=""
+	local actual_generation="" owner_pid="" created_at="" expires_at=""
+	local now=""
+	owner_record="$(_ghrs_owner_read "$key")" || return 1
+	IFS=$'\t' read -r actual_generation owner_pid created_at expires_at <<<"$owner_record"
+	[[ "$actual_generation" == "$generation" ]] || return 1
+	now="$(_ghrs_now)"
+	[[ "$now" =~ ^[0-9]+$ && "$expires_at" =~ ^[0-9]+$ && "$now" -lt "$expires_at" ]] || return 1
+	return 0
+}
+
+_ghrs_write_outcome() {
+	local key="$1"
+	local generation="$2"
+	local status="$3"
+	local request_dir=""
+	local now=""
+	local outcome_tmp=""
+	request_dir="$(_ghrs_request_dir "$key")" || return 1
+	now="$(_ghrs_now)"
+	[[ "$now" =~ ^[0-9]+$ && "$now" -gt 0 ]] || return 1
+	outcome_tmp=$(mktemp "${request_dir}/.outcome.XXXXXX" 2>/dev/null) || return 1
+	chmod 600 "$outcome_tmp" 2>/dev/null || {
+		rm -f "$outcome_tmp"
+		return 1
+	}
+	if ! jq -n --arg schema "$_GHRS_OUTCOME_SCHEMA" --arg key "$key" \
+		--arg generation "$generation" --arg status "$status" \
+		--argjson completed_at "$now" \
+		'{schema:$schema,key:$key,generation:$generation,status:$status,
+		completed_at:$completed_at}' >"$outcome_tmp"; then
+		rm -f "$outcome_tmp"
+		return 1
+	fi
+	mv "$outcome_tmp" "${request_dir}/outcome.json" 2>/dev/null || {
+		rm -f "$outcome_tmp"
+		return 1
+	}
+	return 0
+}
+
+_ghrs_release_owned_lease() {
+	local key="$1"
+	local generation="$2"
+	local request_dir=""
+	local owner_record=""
+	local actual_generation=""
+	request_dir="$(_ghrs_request_dir "$key")" || return 1
+	owner_record="$(_ghrs_owner_read "$key")" || return 1
+	actual_generation="${owner_record%%$'\t'*}"
+	[[ "$actual_generation" == "$generation" ]] || return 1
+	rm -f "${request_dir}/lease/owner.json" "${request_dir}/lease"/.owner.* 2>/dev/null || true
+	rmdir "${request_dir}/lease" 2>/dev/null || return 1
+	return 0
+}
+
+gh_request_state_singleflight_finish() {
+	local key="$1"
+	local generation="$2"
+	local status="$3"
+	[[ "$status" == "$_GHRS_STATUS_SUCCESS" || "$status" == "$_GHRS_STATUS_FAILURE" ]] || return 1
+	gh_request_state_singleflight_is_owner "$key" "$generation" || return 1
+	_ghrs_write_outcome "$key" "$generation" "$status" || return 1
+	_ghrs_release_owned_lease "$key" "$generation" || return 1
+	_ghrs_record "leader-${status}"
+	return 0
+}
+
+_ghrs_rate_file() {
+	local rate_file="${AIDEVOPS_GH_REQUEST_STATE_RATE_FILE:-${AIDEVOPS_PULSE_RATE_LIMIT_CACHE:-${HOME:+${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json}}}"
+	local rate_dir=""
+	[[ -n "$rate_file" ]] || return 1
+	rate_dir="${rate_file%/*}"
+	(umask 077 && mkdir -p "$rate_dir") 2>/dev/null || return 1
+	chmod 700 "$rate_dir" 2>/dev/null || return 1
+	printf '%s\n' "$rate_file"
+	return 0
+}
+
+_ghrs_rate_json_valid() {
+	local rate_json="$1"
+	printf '%s' "$rate_json" | jq -e --arg number_type "$_GHRS_JSON_TYPE_NUMBER" \
+		--arg object_type "$_GHRS_JSON_TYPE_OBJECT" '
+		type == $object_type and (.resources | type == $object_type) and
+		(.resources.graphql | type == $object_type) and
+		(.resources.graphql.remaining | type == $number_type and floor == . and . >= 0) and
+		(.resources.graphql.limit | type == $number_type and floor == . and . >= 0) and
+		((.resources.graphql.reset // 0) | type == $number_type and floor == . and . >= 0)
+	' >/dev/null 2>&1
+	return $?
+}
+
+gh_request_state_rate_get() {
+	local mode="${1:-normal}"
+	local ttl="${2:-${AIDEVOPS_GH_REQUEST_STATE_RATE_TTL:-20}}"
+	local rate_file=""
+	local scope_fingerprint=""
+	local pool="${AIDEVOPS_GH_API_POOL:-default}"
+	local entry=""
+	local observed_at="" reset_at="" rate_json="" now=""
+	[[ "${AIDEVOPS_GH_REQUEST_STATE_DISABLE:-0}" != "1" && "${AIDEVOPS_GH_REQUEST_STATE_RATE_DISABLE:-0}" != "1" ]] || return 1
+	[[ "$mode" == "normal" || "$mode" == "cached-only" ]] || return 1
+	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=20
+	rate_file="$(_ghrs_rate_file)" || return 1
+	[[ -s "$rate_file" ]] || return 1
+	scope_fingerprint="$(_ghrs_scope_fingerprint "$pool")" || return 1
+	entry=$(jq -cer --arg schema "$_GHRS_RATE_SCHEMA" \
+		--arg scope_fingerprint "$scope_fingerprint" --arg pool "$pool" \
+		--arg number_type "$_GHRS_JSON_TYPE_NUMBER" --arg object_type "$_GHRS_JSON_TYPE_OBJECT" '
+		select(.schema == $schema and .scope_fingerprint == $scope_fingerprint and .pool == $pool) |
+		select(.validation == "validated") |
+		select(.observed_at | type == $number_type and floor == . and . > 0) |
+		select(.rate | type == $object_type) |
+		[.observed_at, (.rate.resources.graphql.reset // 0), .rate]
+	' "$rate_file" 2>/dev/null) || entry=""
+	[[ -n "$entry" ]] || return 1
+	observed_at=$(printf '%s' "$entry" | jq -r '.[0]') || return 1
+	reset_at=$(printf '%s' "$entry" | jq -r '.[1]') || return 1
+	rate_json=$(printf '%s' "$entry" | jq -c '.[2]') || return 1
+	_ghrs_rate_json_valid "$rate_json" || return 1
+	if [[ "$mode" == "normal" ]]; then
+		now="$(_ghrs_now)"
+		[[ "$now" =~ ^[0-9]+$ && "$observed_at" =~ ^[0-9]+$ ]] || return 1
+		[[ "$now" -ge "$observed_at" && "$ttl" -gt 0 && $((now - observed_at)) -lt "$ttl" ]] || return 1
+		if [[ "$reset_at" =~ ^[0-9]+$ && "$reset_at" -gt 0 && "$now" -ge "$reset_at" ]]; then
+			return 1
+		fi
+	fi
+	printf '%s\n' "$rate_json"
+	return 0
+}
+
+gh_request_state_rate_put() {
+	local rate_json="$1"
+	local rate_file=""
+	local rate_dir=""
+	local rate_tmp=""
+	local now=""
+	local pool="${AIDEVOPS_GH_API_POOL:-default}"
+	local scope_fingerprint=""
+	[[ "${AIDEVOPS_GH_REQUEST_STATE_DISABLE:-0}" != "1" && "${AIDEVOPS_GH_REQUEST_STATE_RATE_DISABLE:-0}" != "1" ]] || return 0
+	_ghrs_rate_json_valid "$rate_json" || return 1
+	rate_file="$(_ghrs_rate_file)" || return 1
+	rate_dir="${rate_file%/*}"
+	now="$(_ghrs_now)"
+	[[ "$now" =~ ^[0-9]+$ && "$now" -gt 0 ]] || return 1
+	scope_fingerprint="$(_ghrs_scope_fingerprint "$pool")" || return 1
+	rate_tmp=$(mktemp "${rate_dir}/.gh-rate-limit.XXXXXX" 2>/dev/null) || return 1
+	chmod 600 "$rate_tmp" 2>/dev/null || {
+		rm -f "$rate_tmp"
+		return 1
+	}
+	if ! jq -n --arg schema "$_GHRS_RATE_SCHEMA" --arg scope_fingerprint "$scope_fingerprint" \
+		--arg pool "$pool" --argjson observed_at "$now" --argjson rate "$rate_json" \
+		'{schema:$schema,scope_fingerprint:$scope_fingerprint,pool:$pool,
+		observed_at:$observed_at,rate:$rate,validation:"validated"}' >"$rate_tmp"; then
+		rm -f "$rate_tmp"
+		return 1
+	fi
+	mv "$rate_tmp" "$rate_file" 2>/dev/null || {
+		rm -f "$rate_tmp"
+		return 1
+	}
+	return 0
+}
+
+_ghrs_rate_fetch_direct() {
+	local fetch_function="$1"
+	local rate_json=""
+	declare -F "$fetch_function" >/dev/null 2>&1 || return 1
+	rate_json=$("$fetch_function") || return 1
+	_ghrs_rate_json_valid "$rate_json" || return 1
+	gh_request_state_rate_put "$rate_json" || true
+	printf '%s\n' "$rate_json"
+	return 0
+}
+
+gh_request_state_rate_json() {
+	local mode="${1:-normal}"
+	local ttl="${2:-20}"
+	local fetch_function="$3"
+	local rate_json=""
+	local key=""
+	local role="" generation=""
+	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=20
+	if rate_json="$(gh_request_state_rate_get "$mode" "$ttl")"; then
+		printf '%s\n' "$rate_json"
+		return 0
+	fi
+	[[ "$mode" != "cached-only" ]] || return 1
+	if [[ "$ttl" -eq 0 || "${AIDEVOPS_GH_REQUEST_STATE_DISABLE:-0}" == "1" || "${AIDEVOPS_GH_REQUEST_STATE_RATE_DISABLE:-0}" == "1" ]]; then
+		rate_json=$("$fetch_function") || return 1
+		_ghrs_rate_json_valid "$rate_json" || return 1
+		printf '%s\n' "$rate_json"
+		return 0
+	fi
+	key=$(gh_request_state_request_key global rate-limit resources/v1 all "${AIDEVOPS_GH_API_POOL:-default}") || {
+		_ghrs_rate_fetch_direct "$fetch_function"
+		return $?
+	}
+	if ! gh_request_state_singleflight_begin "$key"; then
+		_GHRS_BEGIN_ROLE="$_GHRS_ROLE_BYPASS"
+	fi
+	role="$_GHRS_BEGIN_ROLE"
+	generation="$_GHRS_BEGIN_GENERATION"
+	case "$role" in
+	leader)
+		if rate_json="$(gh_request_state_rate_get normal "$ttl")"; then
+			gh_request_state_singleflight_finish "$key" "$generation" success || true
+			printf '%s\n' "$rate_json"
+			return 0
+		fi
+		if ! rate_json=$("$fetch_function"); then
+			gh_request_state_singleflight_finish "$key" "$generation" failure || true
+			return 1
+		fi
+		if ! _ghrs_rate_json_valid "$rate_json"; then
+			gh_request_state_singleflight_finish "$key" "$generation" failure || true
+			return 1
+		fi
+		if ! gh_request_state_singleflight_is_owner "$key" "$generation"; then
+			gh_request_state_rate_get cached-only "$ttl"
+			return $?
+		fi
+		gh_request_state_rate_put "$rate_json" || {
+			gh_request_state_singleflight_finish "$key" "$generation" failure || true
+			return 1
+		}
+		gh_request_state_singleflight_finish "$key" "$generation" success || true
+		printf '%s\n' "$rate_json"
+		return 0
+		;;
+	follower-success)
+		gh_request_state_rate_get cached-only "$ttl"
+		return $?
+		;;
+	follower-failure) return 1 ;;
+	timeout | bypass | *)
+		_ghrs_rate_fetch_direct "$fetch_function"
+		return $?
+		;;
+	esac
+	return 1
+}

--- a/.agents/scripts/shared-gh-request-state.sh
+++ b/.agents/scripts/shared-gh-request-state.sh
@@ -6,6 +6,15 @@
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
 
 [[ -n "${_SHARED_GH_REQUEST_STATE_LOADED:-}" ]] && return 0
+
+_GHRS_SELF="${BASH_SOURCE[0]:-${0:-}}"
+if ! declare -F _file_mtime_epoch >/dev/null 2>&1; then
+	# shellcheck source=./portable-stat.sh
+	if ! source "${_GHRS_SELF%/*}/portable-stat.sh"; then
+		[[ "${BASH_SOURCE[0]}" == "${0}" ]] && exit 1
+		return 1
+	fi
+fi
 _SHARED_GH_REQUEST_STATE_LOADED=1
 
 _GHRS_LEASE_SCHEMA="aidevops-gh-request-lease/v1"
@@ -108,21 +117,6 @@ _ghrs_request_dir() {
 	return 0
 }
 
-_ghrs_file_mtime() {
-	local path="$1"
-	local modified_at=""
-	if stat -f '%m' "$path" >/dev/null 2>&1; then
-		modified_at=$(stat -f '%m' "$path" 2>/dev/null) || modified_at=""
-	elif stat -c '%Y' "$path" >/dev/null 2>&1; then
-		modified_at=$(stat -c '%Y' "$path" 2>/dev/null) || modified_at=""
-	else
-		return 1
-	fi
-	[[ "$modified_at" =~ ^[0-9]+$ ]] || return 1
-	printf '%s\n' "$modified_at"
-	return 0
-}
-
 _ghrs_sleep_jitter() {
 	local base_ms="${AIDEVOPS_GH_SINGLEFLIGHT_WAIT_BASE_MS:-60}"
 	local jitter_ms="${AIDEVOPS_GH_SINGLEFLIGHT_WAIT_JITTER_MS:-90}"
@@ -190,7 +184,8 @@ _ghrs_owner_is_stale() {
 	local modified_at=""
 	local age=0
 	[[ "$orphan_grace" =~ ^[0-9]+$ ]] || orphan_grace=2
-	modified_at="$(_ghrs_file_mtime "$lease_dir")" || return 1
+	modified_at="$(_file_mtime_epoch "$lease_dir")" || return 1
+	[[ "$modified_at" =~ ^[0-9]+$ ]] || return 1
 	age=$((now - modified_at))
 	[[ "$age" -lt 0 ]] && age=0
 	[[ "$age" -ge "$orphan_grace" ]]

--- a/.agents/scripts/shared-gh-request-state.sh
+++ b/.agents/scripts/shared-gh-request-state.sh
@@ -461,13 +461,30 @@ gh_request_state_singleflight_finish() {
 	return 0
 }
 
+_ghrs_rate_parent_dir() {
+	local rate_file="$1"
+	local rate_dir="."
+	[[ -n "$rate_file" ]] || return 1
+	if [[ "$rate_file" == */* ]]; then
+		rate_dir="${rate_file%/*}"
+		[[ -n "$rate_dir" ]] || rate_dir="/"
+	fi
+	printf '%s\n' "$rate_dir"
+	return 0
+}
+
 _ghrs_rate_file() {
 	local rate_file="${AIDEVOPS_GH_REQUEST_STATE_RATE_FILE:-${AIDEVOPS_PULSE_RATE_LIMIT_CACHE:-${HOME:+${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json}}}"
 	local rate_dir=""
 	[[ -n "$rate_file" ]] || return 1
-	rate_dir="${rate_file%/*}"
-	(umask 077 && mkdir -p "$rate_dir") 2>/dev/null || return 1
-	chmod 700 "$rate_dir" 2>/dev/null || return 1
+	rate_dir="$(_ghrs_rate_parent_dir "$rate_file")" || return 1
+	case "$rate_dir" in
+	"." | "/") ;;
+	*)
+		(umask 077 && mkdir -p "$rate_dir") 2>/dev/null || return 1
+		chmod 700 "$rate_dir" 2>/dev/null || return 1
+		;;
+	esac
 	printf '%s\n' "$rate_file"
 	return 0
 }
@@ -536,7 +553,7 @@ gh_request_state_rate_put() {
 	[[ "${AIDEVOPS_GH_REQUEST_STATE_DISABLE:-0}" != "1" && "${AIDEVOPS_GH_REQUEST_STATE_RATE_DISABLE:-0}" != "1" ]] || return 0
 	_ghrs_rate_json_valid "$rate_json" || return 1
 	rate_file="$(_ghrs_rate_file)" || return 1
-	rate_dir="${rate_file%/*}"
+	rate_dir="$(_ghrs_rate_parent_dir "$rate_file")" || return 1
 	now="$(_ghrs_now)"
 	[[ "$now" =~ ^[0-9]+$ && "$now" -gt 0 ]] || return 1
 	scope_fingerprint="$(_ghrs_scope_fingerprint "$pool")" || return 1

--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -53,10 +53,20 @@
 [[ -n "${_SHARED_GH_WRAPPERS_CHECKS_LIB_LOADED:-}" ]] && return 0
 _SHARED_GH_WRAPPERS_CHECKS_LIB_LOADED=1
 
+_gh_checks_lib_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_gh_checks_lib_dir" == "${BASH_SOURCE[0]}" ]] && _gh_checks_lib_dir="."
+if ! declare -F gh_request_state_singleflight_begin >/dev/null 2>&1 && [[ -f "${_gh_checks_lib_dir}/shared-gh-request-state.sh" ]]; then
+	# shellcheck source=./shared-gh-request-state.sh
+	# shellcheck disable=SC1091
+	source "${_gh_checks_lib_dir}/shared-gh-request-state.sh"
+fi
+unset _gh_checks_lib_dir
+
 _GH_PR_CHECK_STATUS_SCHEMA="aidevops-gh-pr-check-status/v1"
 _GH_PR_CHECK_STATUS_PROJECTION="check-suites-aggregate/v1"
 _GH_PR_CHECK_STATUS_SOURCE="rest-check-suites"
 _GH_PR_CHECK_STATUS_NONE=none
+_GH_PR_CHECK_STATUS_CACHE_PUT_OK=0
 
 #######################################
 # Record an observational check-status cache decision without counting an HTTP
@@ -75,7 +85,7 @@ _gh_pr_check_status_cache_record() {
 # Resolve the non-secret auth identity used to isolate cache entries.
 #######################################
 _gh_pr_check_status_cache_auth_scope() {
-	printf '%s' "${AIDEVOPS_GH_CHECK_STATUS_CACHE_AUTH_SCOPE:-${GH_HOST:-github.com}|${AIDEVOPS_GH_AUTH_MODE:-gh}|${AIDEVOPS_GH_AUTH_PRINCIPAL:-default}}"
+	printf '%s|%s' "${AIDEVOPS_GH_CHECK_STATUS_CACHE_AUTH_SCOPE:-${GH_HOST:-github.com}|${AIDEVOPS_GH_AUTH_MODE:-gh}|${AIDEVOPS_GH_AUTH_PRINCIPAL:-default}}" "${AIDEVOPS_GH_API_POOL:-default}"
 	return 0
 }
 
@@ -161,7 +171,7 @@ _gh_pr_check_status_cache_key() {
 	elif command -v openssl >/dev/null 2>&1; then
 		key=$(printf '%s' "$material" | openssl dgst -sha256 | awk '{print $NF}')
 	else
-		key=$(printf '%s' "$material" | cksum | awk '{print $1}')
+		return 1
 	fi
 	[[ -n "$key" ]] || return 1
 	printf '%s\n' "$key"
@@ -260,6 +270,7 @@ _gh_pr_check_status_cache_put() {
 	local slug="$1"
 	local sha="$2"
 	local check_state="$3"
+	_GH_PR_CHECK_STATUS_CACHE_PUT_OK=0
 	[[ "${AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE:-0}" != "1" ]] || return 0
 	_gh_pr_check_status_cache_identity_valid "$slug" "$sha" || return 0
 	local expiry_class="" path="" dir="" tmp="" now="" auth_scope=""
@@ -287,6 +298,7 @@ _gh_pr_check_status_cache_put() {
 		return 0
 	fi
 	if mv "$tmp" "$path" 2>/dev/null; then
+		_GH_PR_CHECK_STATUS_CACHE_PUT_OK=1
 		_gh_pr_check_status_cache_record "store-${expiry_class}"
 	else
 		rm -f "$tmp"
@@ -380,6 +392,92 @@ _gh_pr_check_status_rest_fetch() {
 	return 0
 }
 
+#######################################
+# Fetch and publish one aggregate observation. A coordinated leader must still
+# own its generation immediately before the cache write.
+# Args: $1=repo slug, $2=full head SHA, $3=request key (optional),
+#       $4=generation (optional)
+#######################################
+_gh_pr_check_status_fetch_and_cache() {
+	local slug="$1"
+	local sha="$2"
+	local request_key="${3:-}"
+	local generation="${4:-}"
+	local check_state=""
+	_gh_pr_check_status_cache_record fetch
+	if ! check_state="$(_gh_pr_check_status_rest_fetch "$slug" "$sha")"; then
+		_gh_pr_check_status_cache_record fetch-failed
+		return 1
+	fi
+	if [[ -n "$request_key" && -n "$generation" ]] && ! gh_request_state_singleflight_is_owner "$request_key" "$generation"; then
+		_gh_pr_check_status_cache_record publish-fenced
+		return 1
+	fi
+	_gh_pr_check_status_cache_put "$slug" "$sha" "$check_state"
+	if [[ -n "$request_key" && "$_GH_PR_CHECK_STATUS_CACHE_PUT_OK" != "1" ]]; then
+		_gh_pr_check_status_cache_record publish-failed
+		return 1
+	fi
+	printf '%s\n' "$check_state"
+	return 0
+}
+
+#######################################
+# Coordinate only the exact-SHA aggregate check-suites cache miss. Named check
+# runs remain deliberately outside this path because they have different output
+# and freshness semantics.
+# Args: $1=repo slug, $2=full head SHA
+#######################################
+_gh_pr_check_status_singleflight() {
+	local slug="$1"
+	local sha="$2"
+	local request_key=""
+	local generation=""
+	local check_state=""
+	if [[ "${AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE:-0}" == "1" ]] || ! declare -F gh_request_state_singleflight_begin >/dev/null 2>&1; then
+		_gh_pr_check_status_fetch_and_cache "$slug" "$sha" || printf 'none\n'
+		return 0
+	fi
+	request_key=$(gh_request_state_request_key "$slug" check-suites-aggregate "$_GH_PR_CHECK_STATUS_PROJECTION" "$sha" rest-core) || {
+		_gh_pr_check_status_fetch_and_cache "$slug" "$sha" || printf 'none\n'
+		return 0
+	}
+	gh_request_state_singleflight_begin "$request_key"
+	generation="$_GHRS_BEGIN_GENERATION"
+	case "$_GHRS_BEGIN_ROLE" in
+	leader)
+		if check_state="$(_gh_pr_check_status_cache_get "$slug" "$sha")"; then
+			gh_request_state_singleflight_finish "$request_key" "$generation" success || true
+			printf '%s\n' "$check_state"
+			return 0
+		fi
+		if _gh_pr_check_status_fetch_and_cache "$slug" "$sha" "$request_key" "$generation"; then
+			gh_request_state_singleflight_finish "$request_key" "$generation" success || true
+			return 0
+		fi
+		gh_request_state_singleflight_finish "$request_key" "$generation" failure || true
+		printf 'none\n'
+		return 0
+		;;
+	follower-success)
+		_gh_pr_check_status_cache_record coalesced
+		_gh_pr_check_status_cache_get "$slug" "$sha" || printf 'none\n'
+		return 0
+		;;
+	follower-failure | timeout)
+		_gh_pr_check_status_cache_record "coalesced-${_GHRS_BEGIN_ROLE}"
+		printf 'none\n'
+		return 0
+		;;
+	bypass)
+		_gh_pr_check_status_fetch_and_cache "$slug" "$sha" || printf 'none\n'
+		return 0
+		;;
+	esac
+	printf 'none\n'
+	return 0
+}
+
 gh_pr_check_status_rest() {
 	local slug="$1"
 	local sha="$2"
@@ -395,16 +493,8 @@ gh_pr_check_status_rest() {
 		return 0
 	fi
 
-	_gh_pr_check_status_cache_record fetch
-	if _check_state="$(_gh_pr_check_status_rest_fetch "$slug" "$sha")"; then
-		_gh_pr_check_status_cache_put "$slug" "$sha" "$_check_state"
-		printf '%s\n' "$_check_state"
-		return 0
-	fi
-
-	_gh_pr_check_status_cache_record fetch-failed
-	printf 'none\n'
-	return 0
+	_gh_pr_check_status_singleflight "$slug" "$sha"
+	return $?
 }
 
 #######################################

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -29,6 +29,15 @@
 [[ -n "${_SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED:-}" ]] && return 0
 _SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED=1
 
+_gh_rest_fallback_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_gh_rest_fallback_dir" == "${BASH_SOURCE[0]}" ]] && _gh_rest_fallback_dir="."
+if ! declare -F gh_request_state_rate_json >/dev/null 2>&1 && [[ -f "${_gh_rest_fallback_dir}/shared-gh-request-state.sh" ]]; then
+	# shellcheck source=./shared-gh-request-state.sh
+	# shellcheck disable=SC1091
+	source "${_gh_rest_fallback_dir}/shared-gh-request-state.sh"
+fi
+unset _gh_rest_fallback_dir
+
 # Threshold below which we route reads/writes through REST instead of GraphQL.
 # Env override: AIDEVOPS_GH_REST_FALLBACK_THRESHOLD
 #
@@ -60,8 +69,6 @@ _SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED=1
 #                         this only shifts supported read/list/search translators
 #                         to the REST core bucket earlier.
 _GH_REST_FALLBACK_THRESHOLD="${AIDEVOPS_GH_REST_FALLBACK_THRESHOLD:-3000}"
-_GH_REST_FALLBACK_RATE_LIMIT_CACHE=""
-_GH_REST_FALLBACK_RATE_LIMIT_CACHE_TS=0
 _GH_LAST_GRAPHQL_REMAINING=""
 _GH_REST_PR_VIEW_CACHE_DIR=""
 
@@ -290,11 +297,22 @@ _rest_split_csv() {
 }
 
 #######################################
+# Fetch the full rate-limit projection for shared, auth-scoped persistence.
+#######################################
+_rest_rate_limit_json_fetch() {
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read gh api rate_limit
+		return $?
+	fi
+	gh api rate_limit
+	return $?
+}
+
+#######################################
 # Return 0 (true) when GraphQL rate limit remaining is <= threshold.
 # `gh api rate_limit` is a free endpoint (does not count against quotas).
-# Fail-safe: if the response is unparseable (network error, gh auth missing),
-# return 1 (false) so the caller sees the original error rather than triggering
-# an unnecessary REST retry that may also fail.
+# Fail-safe: an unavailable or malformed rate projection does not trigger a
+# second transport path. Callers retain the original GitHub CLI failure.
 #
 # Optional arg: $1=pre-computed remaining count (integer string).
 # When provided, skips the `gh api rate_limit` call — callers that already
@@ -311,28 +329,20 @@ _rest_should_fallback() {
 	[[ "${AIDEVOPS_GH_FORCE_REST_READS:-0}" == "1" ]] && return 0
 	local remaining="${1:-}"
 	if [[ -z "$remaining" ]]; then
-		local _now=0
 		local _ttl="${AIDEVOPS_GH_REST_FALLBACK_CACHE_TTL:-20}"
-		if [[ "${AIDEVOPS_GH_REST_FALLBACK_DISABLE_CACHE:-0}" != "1" && "$_ttl" =~ ^[0-9]+$ && "$_ttl" -gt 0 ]]; then
-			_now=$(date +%s 2>/dev/null || printf '0')
-			if [[ "$_GH_REST_FALLBACK_RATE_LIMIT_CACHE" =~ ^[0-9]+$ && "$_now" -gt 0 && $((_now - _GH_REST_FALLBACK_RATE_LIMIT_CACHE_TS)) -le "$_ttl" ]]; then
-				remaining="$_GH_REST_FALLBACK_RATE_LIMIT_CACHE"
-			else
-				remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null)
-				if [[ "$remaining" =~ ^[0-9]+$ ]]; then
-					_GH_REST_FALLBACK_RATE_LIMIT_CACHE="$remaining"
-					_GH_REST_FALLBACK_RATE_LIMIT_CACHE_TS="$_now"
-				fi
+		[[ "$_ttl" =~ ^[0-9]+$ ]] || _ttl=20
+		[[ "${AIDEVOPS_GH_REST_FALLBACK_DISABLE_CACHE:-0}" != "1" ]] || _ttl=0
+		if declare -F gh_request_state_rate_json >/dev/null 2>&1; then
+			local rate_json=""
+			if ! rate_json=$(gh_request_state_rate_json normal "$_ttl" _rest_rate_limit_json_fetch 2>/dev/null); then
+				return 1
 			fi
+			remaining=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.remaining // ""' 2>/dev/null) || remaining=""
 		else
 			remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null)
 		fi
 	fi
-	# When the rate_limit query itself fails, remaining is empty. Treat that as
-	# exhausted so supported calls can move to REST instead of skipping fallback.
-	if [[ -z "$remaining" ]]; then
-		return 0
-	fi
+	[[ -n "$remaining" ]] || return 1
 	[[ "$remaining" =~ ^[0-9]+$ ]] || return 1
 	_GH_LAST_GRAPHQL_REMAINING="$remaining"
 	if [[ "$remaining" -le "$_GH_REST_FALLBACK_THRESHOLD" ]]; then

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -164,6 +164,10 @@ if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-se
 	# shellcheck source=shared-gh-secondary-cooldown.sh
 	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-secondary-cooldown.sh"
 fi
+if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-request-state.sh" ]]; then
+	# shellcheck source=shared-gh-request-state.sh
+	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-request-state.sh"
+fi
 if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh" ]]; then
 	# shellcheck source=shared-gh-wrappers-rest-fallback.sh
 	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh"

--- a/.agents/scripts/tests/test-gh-check-status-cache.sh
+++ b/.agents/scripts/tests/test-gh-check-status-cache.sh
@@ -26,6 +26,7 @@ mkdir -p "$HOME"
 API_CALLS="${TEST_ROOT}/api-calls.log"
 CHECK_NOW=100
 CHECK_API_MODE=success
+CHECK_API_DELAY=0
 CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
 
 SHA_A="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -58,6 +59,7 @@ _gh_checks_api_read() {
 	local endpoint="$1"
 	shift
 	printf '%s\n' "$endpoint" >>"$API_CALLS"
+	[[ "$CHECK_API_DELAY" == "0" ]] || sleep "$CHECK_API_DELAY"
 
 	case "$CHECK_API_MODE" in
 	failure)
@@ -274,7 +276,7 @@ test_corruption_failure_and_invalidation() {
 }
 
 test_private_atomic_cache_and_authority_boundary() {
-	local path="" dir="" result="" job=""
+	local path="" dir="" result="" job="" before="" after="" expected=""
 	path=$(cache_path "owner/repo" "$SHA_H")
 	dir="${path%/*}"
 	assert_eq "cache directory is private" "700" "$(file_mode "$dir")"
@@ -283,10 +285,16 @@ test_private_atomic_cache_and_authority_boundary() {
 	gh_pr_check_status_cache_invalidate "owner/repo" "$SHA_H"
 	CHECK_NOW=800
 	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+	CHECK_API_DELAY=0.25
+	before=$(api_call_count)
 	for job in 1 2 3 4; do
 		gh_pr_check_status_rest "owner/repo" "$SHA_H" >/dev/null &
 	done
 	wait
+	CHECK_API_DELAY=0
+	after=$(api_call_count)
+	expected=$((before + 1))
+	assert_eq "concurrent aggregate misses perform one transport" "$expected" "$after"
 	path=$(cache_path "owner/repo" "$SHA_H")
 	result=$(jq -r --arg sha "$SHA_H" 'select(.head_sha == $sha and .state == "PASS") | .state' "$path")
 	assert_eq "concurrent last-writer-wins cache remains valid" "PASS" "$result"
@@ -295,6 +303,16 @@ test_private_atomic_cache_and_authority_boundary() {
 		return 1
 	fi
 	printf 'PASS: atomic cache writes leave no temporary files\n'
+
+	before=$(api_call_count)
+	CHECK_API_DELAY=0.1
+	gh_pr_check_runs_rest "owner/repo" "$SHA_H" >/dev/null &
+	gh_pr_check_runs_rest "owner/repo" "$SHA_H" >/dev/null &
+	wait
+	CHECK_API_DELAY=0
+	after=$(api_call_count)
+	expected=$((before + 4))
+	assert_eq "named check reads remain live and uncoalesced" "$expected" "$after"
 
 	if grep -q 'gh_pr_check_status_rest' "$MERGE_REQUIRED_LIB"; then
 		printf 'FAIL: final required-check module references aggregate cached status\n' >&2

--- a/.agents/scripts/tests/test-gh-request-singleflight.sh
+++ b/.agents/scripts/tests/test-gh-request-singleflight.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Cross-process coordination coverage for shared-gh-request-state.sh.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+TEMP_BASE="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_BASE"
+TEST_ROOT="$(mktemp -d "${TEMP_BASE}/gh-request-state.XXXXXXXX")"
+ORIGINAL_HOME="$HOME"
+
+export HOME="${TEST_ROOT}/home"
+export AIDEVOPS_GH_REQUEST_STATE_DIR="${TEST_ROOT}/state"
+export AIDEVOPS_GH_REQUEST_STATE_RATE_FILE="${TEST_ROOT}/rate.json"
+export AIDEVOPS_GH_AUTH_MODE=gh
+export AIDEVOPS_GH_AUTH_PRINCIPAL=default
+export AIDEVOPS_GH_API_POOL=default
+export AIDEVOPS_GH_SINGLEFLIGHT_WAIT_SECONDS=5
+export AIDEVOPS_GH_SINGLEFLIGHT_LEASE_SECONDS=10
+export AIDEVOPS_GH_SINGLEFLIGHT_WAIT_BASE_MS=20
+export AIDEVOPS_GH_SINGLEFLIGHT_WAIT_JITTER_MS=30
+mkdir -p "$HOME"
+
+# shellcheck source=../shared-gh-request-state.sh
+source "${SCRIPTS_DIR}/shared-gh-request-state.sh"
+
+cleanup() {
+	export HOME="$ORIGINAL_HOME"
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" != "$expected" ]]; then
+		printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$name" "$expected" "$actual" >&2
+		return 1
+	fi
+	printf 'PASS: %s\n' "$name"
+	return 0
+}
+
+assert_ne() {
+	local name="$1"
+	local first="$2"
+	local second="$3"
+	if [[ "$first" == "$second" ]]; then
+		printf 'FAIL: %s\n  both values: %s\n' "$name" "$first" >&2
+		return 1
+	fi
+	printf 'PASS: %s\n' "$name"
+	return 0
+}
+
+wait_for_file() {
+	local path="$1"
+	local attempts=0
+	while [[ ! -s "$path" && "$attempts" -lt 100 ]]; do
+		sleep 0.02
+		attempts=$((attempts + 1))
+	done
+	[[ -s "$path" ]]
+	return $?
+}
+
+file_mode() {
+	local path="$1"
+	local mode=""
+	mode=$(stat -f '%Lp' "$path" 2>/dev/null) || mode=$(stat -c '%a' "$path" 2>/dev/null) || return 1
+	printf '%s\n' "$mode"
+	return 0
+}
+
+singleflight_worker() {
+	local key="$1"
+	local result_file="$2"
+	local counter_file="$3"
+	local output_file="$4"
+	local attempts=0
+	local generation=""
+	while [[ "$attempts" -lt 3 ]]; do
+		if [[ -s "$result_file" ]]; then
+			cp "$result_file" "$output_file"
+			return 0
+		fi
+		gh_request_state_singleflight_begin "$key"
+		generation="$_GHRS_BEGIN_GENERATION"
+		case "$_GHRS_BEGIN_ROLE" in
+		leader)
+			if [[ -s "$result_file" ]]; then
+				gh_request_state_singleflight_finish "$key" "$generation" success
+				cp "$result_file" "$output_file"
+				return 0
+			fi
+			printf 'transport\n' >>"$counter_file"
+			sleep 0.25
+			if ! gh_request_state_singleflight_is_owner "$key" "$generation"; then
+				return 1
+			fi
+			local result_tmp="${result_file}.${BASHPID:-$$}"
+			printf 'validated-result\n' >"$result_tmp"
+			mv "$result_tmp" "$result_file"
+			gh_request_state_singleflight_finish "$key" "$generation" success
+			cp "$result_file" "$output_file"
+			return 0
+			;;
+		follower-success)
+			if [[ -s "$result_file" ]]; then
+				cp "$result_file" "$output_file"
+				return 0
+			fi
+			;;
+		follower-failure | timeout) return 1 ;;
+		bypass) return 1 ;;
+		esac
+		attempts=$((attempts + 1))
+	done
+	return 1
+}
+
+test_scope_key_isolation() {
+	local key_default="" key_repeat="" key_repo="" key_projection="" key_identity="" key_principal="" key_pool=""
+	key_default=$(gh_request_state_request_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rest-core)
+	key_repeat=$(gh_request_state_request_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rest-core)
+	key_repo=$(gh_request_state_request_key other/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rest-core)
+	key_projection=$(gh_request_state_request_key owner/repo checks aggregate/v2 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rest-core)
+	key_identity=$(gh_request_state_request_key owner/repo checks aggregate/v1 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb rest-core)
+	AIDEVOPS_GH_AUTH_PRINCIPAL=alternate
+	key_principal=$(gh_request_state_request_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rest-core)
+	AIDEVOPS_GH_AUTH_PRINCIPAL=default
+	key_pool=$(gh_request_state_request_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa graphql)
+
+	assert_eq "identical request scope produces a stable key" "$key_default" "$key_repeat"
+	assert_ne "repository changes the request key" "$key_default" "$key_repo"
+	assert_ne "projection changes the request key" "$key_default" "$key_projection"
+	assert_ne "immutable identity changes the request key" "$key_default" "$key_identity"
+	assert_ne "auth principal changes the request key" "$key_default" "$key_principal"
+	assert_ne "API pool changes the request key" "$key_default" "$key_pool"
+	return 0
+}
+
+test_default_state_root_is_operational() {
+	local configured_root="$AIDEVOPS_GH_REQUEST_STATE_DIR"
+	local actual_root=""
+	unset AIDEVOPS_GH_REQUEST_STATE_DIR
+	actual_root=$(_ghrs_base_dir)
+	export AIDEVOPS_GH_REQUEST_STATE_DIR="$configured_root"
+	assert_eq "default coordination state uses the operational workspace" \
+		"${HOME}/.aidevops/.agent-workspace/work/github-request-state" "$actual_root"
+	return 0
+}
+
+test_concurrent_workers_share_one_result() {
+	local key="" result_file="${TEST_ROOT}/shared-result" counter_file="${TEST_ROOT}/transport-count"
+	local worker=0 pid=0 count=0 output=""
+	local -a pids=()
+	key=$(gh_request_state_request_key owner/repo checks aggregate/v1 cccccccccccccccccccccccccccccccccccccccc rest-core)
+	: >"$counter_file"
+	for worker in 1 2 3 4 5 6; do
+		(singleflight_worker "$key" "$result_file" "$counter_file" "${TEST_ROOT}/worker-${worker}.out") &
+		pids+=("$!")
+	done
+	for pid in "${pids[@]}"; do
+		wait "$pid"
+	done
+	count=$(wc -l <"$counter_file" | tr -d '[:space:]')
+	assert_eq "six concurrent readers perform one leader transport" "1" "$count"
+	for worker in 1 2 3 4 5 6; do
+		output=$(tr -d '\n' <"${TEST_ROOT}/worker-${worker}.out")
+		assert_eq "worker ${worker} reuses the validated result" "validated-result" "$output"
+	done
+	assert_eq "coordination root is private" "700" "$(file_mode "$AIDEVOPS_GH_REQUEST_STATE_DIR")"
+	return 0
+}
+
+test_observed_follower_consumes_matching_outcome() {
+	local key="" generation="" follower_pid=0
+	local waiting_file="${TEST_ROOT}/outcome-follower-waiting"
+	local release_file="${TEST_ROOT}/outcome-follower-release"
+	local result_file="${TEST_ROOT}/outcome-follower-result"
+	local role="" follower_generation=""
+	key=$(gh_request_state_request_key owner/repo checks aggregate/v1 observed-outcome rest-core)
+	gh_request_state_singleflight_begin "$key"
+	assert_eq "matching-outcome fixture elects its initial leader" "leader" "$_GHRS_BEGIN_ROLE"
+	generation="$_GHRS_BEGIN_GENERATION"
+
+	(
+		_ghrs_sleep_jitter() {
+			printf 'waiting\n' >"$waiting_file"
+			while [[ ! -e "$release_file" ]]; do
+				sleep 0.01
+			done
+			return 0
+		}
+		gh_request_state_singleflight_begin "$key"
+		printf '%s\t%s\n' "$_GHRS_BEGIN_ROLE" "$_GHRS_BEGIN_GENERATION" >"$result_file"
+	) &
+	follower_pid=$!
+	wait_for_file "$waiting_file"
+	gh_request_state_singleflight_finish "$key" "$generation" success
+	printf 'release\n' >"$release_file"
+	wait "$follower_pid"
+	IFS=$'\t' read -r role follower_generation <"$result_file"
+	assert_eq "an existing follower consumes the completed typed outcome" "follower-success" "$role"
+	assert_eq "the follower validates the exact observed generation" "$generation" "$follower_generation"
+	return 0
+}
+
+crash_leader() {
+	local key="$1"
+	local generation_file="$2"
+	gh_request_state_singleflight_begin "$key"
+	[[ "$_GHRS_BEGIN_ROLE" == "leader" ]] || return 1
+	printf '%s\n' "$_GHRS_BEGIN_GENERATION" >"$generation_file"
+	sleep 30
+	return 0
+}
+
+test_dead_leader_is_recovered() {
+	local key="" generation_file="${TEST_ROOT}/dead-generation" leader_pid=0 generation=""
+	key=$(gh_request_state_request_key owner/repo canonical issues/v1 dead-owner rest-core)
+	(crash_leader "$key" "$generation_file") &
+	leader_pid=$!
+	wait_for_file "$generation_file"
+	kill -KILL "$leader_pid" 2>/dev/null || true
+	wait "$leader_pid" 2>/dev/null || true
+	gh_request_state_singleflight_begin "$key"
+	assert_eq "dead leader is replaced by a new leader" "leader" "$_GHRS_BEGIN_ROLE"
+	generation="$_GHRS_BEGIN_GENERATION"
+	gh_request_state_singleflight_finish "$key" "$generation" failure
+	return 0
+}
+
+live_expiring_leader() {
+	local key="$1"
+	local generation_file="$2"
+	local fence_file="$3"
+	export AIDEVOPS_GH_SINGLEFLIGHT_LEASE_SECONDS=1
+	gh_request_state_singleflight_begin "$key"
+	[[ "$_GHRS_BEGIN_ROLE" == "leader" ]] || return 1
+	local generation="$_GHRS_BEGIN_GENERATION"
+	printf '%s\n' "$generation" >"$generation_file"
+	sleep 3
+	if gh_request_state_singleflight_is_owner "$key" "$generation"; then
+		printf 'unsafe-owner\n' >"$fence_file"
+	else
+		printf 'fenced\n' >"$fence_file"
+	fi
+	return 0
+}
+
+test_expired_live_leader_is_fenced() {
+	local key="" generation_file="${TEST_ROOT}/live-generation" fence_file="${TEST_ROOT}/fence-result"
+	local old_pid=0 new_generation="" owner_record=""
+	key=$(gh_request_state_request_key owner/repo canonical prs/v1 pid-reuse rest-core)
+	(live_expiring_leader "$key" "$generation_file" "$fence_file") &
+	old_pid=$!
+	wait_for_file "$generation_file"
+	sleep 2
+	export AIDEVOPS_GH_SINGLEFLIGHT_LEASE_SECONDS=10
+	gh_request_state_singleflight_begin "$key"
+	assert_eq "expired live holder is replaced through lease takeover" "leader" "$_GHRS_BEGIN_ROLE"
+	new_generation="$_GHRS_BEGIN_GENERATION"
+	owner_record="$(_ghrs_owner_read "$key")"
+	assert_eq "replacement generation owns the lease" "$new_generation" "${owner_record%%$'\t'*}"
+	wait "$old_pid"
+	assert_eq "late prior generation cannot publish" "fenced" "$(tr -d '\n' <"$fence_file")"
+	owner_record="$(_ghrs_owner_read "$key")"
+	assert_eq "late prior generation cannot delete the replacement lease" "$new_generation" "${owner_record%%$'\t'*}"
+	gh_request_state_singleflight_finish "$key" "$new_generation" success
+	return 0
+}
+
+test_live_leader_wait_is_bounded() {
+	local key="" generation_file="${TEST_ROOT}/timeout-generation" leader_pid=0
+	key=$(gh_request_state_request_key owner/repo canonical issues/v1 bounded-wait rest-core)
+	export AIDEVOPS_GH_SINGLEFLIGHT_LEASE_SECONDS=30
+	(crash_leader "$key" "$generation_file") &
+	leader_pid=$!
+	wait_for_file "$generation_file"
+	export AIDEVOPS_GH_SINGLEFLIGHT_WAIT_SECONDS=1
+	gh_request_state_singleflight_begin "$key"
+	assert_eq "follower wait terminates at its configured bound" "timeout" "$_GHRS_BEGIN_ROLE"
+	kill -KILL "$leader_pid" 2>/dev/null || true
+	wait "$leader_pid" 2>/dev/null || true
+	export AIDEVOPS_GH_SINGLEFLIGHT_WAIT_SECONDS=5
+	return 0
+}
+
+test_ownerless_lease_recovery_and_disabled_mode() {
+	local key="" request_dir="" generation=""
+	key=$(gh_request_state_request_key owner/repo canonical issues/v1 ownerless rest-core)
+	request_dir="$(_ghrs_request_dir "$key")"
+	mkdir "${request_dir}/lease"
+	export AIDEVOPS_GH_SINGLEFLIGHT_OWNER_GRACE_SECONDS=0
+	gh_request_state_singleflight_begin "$key"
+	assert_eq "ownerless lease is recovered after the grace bound" "leader" "$_GHRS_BEGIN_ROLE"
+	generation="$_GHRS_BEGIN_GENERATION"
+	gh_request_state_singleflight_finish "$key" "$generation" failure
+	unset AIDEVOPS_GH_SINGLEFLIGHT_OWNER_GRACE_SECONDS
+
+	export AIDEVOPS_GH_SINGLEFLIGHT_DISABLE=1
+	gh_request_state_singleflight_begin "$key"
+	assert_eq "disabled mode bypasses shared coordination" "bypass" "$_GHRS_BEGIN_ROLE"
+	unset AIDEVOPS_GH_SINGLEFLIGHT_DISABLE
+	return 0
+}
+
+rate_fixture() {
+	local remaining="$1"
+	local reset_at="$2"
+	printf '{"resources":{"graphql":{"remaining":%s,"limit":5000,"reset":%s},"core":{"remaining":4500,"limit":5000,"reset":%s}}}\n' \
+		"$remaining" "$reset_at" "$reset_at"
+	return 0
+}
+
+test_rate_state_validation_scope_and_reset() {
+	local now="" future_reset="" past_reset="" fixture="" result=""
+	now="$(_ghrs_now)"
+	future_reset=$((now + 3600))
+	past_reset=$((now - 1))
+	fixture=$(rate_fixture 0 "$future_reset")
+	gh_request_state_rate_put "$fixture"
+	result=$(gh_request_state_rate_get normal 20)
+	assert_eq "shared rate state preserves exhausted zero distinctly" "0" "$(printf '%s' "$result" | jq -r '.resources.graphql.remaining')"
+	AIDEVOPS_GH_AUTH_PRINCIPAL=alternate
+	if gh_request_state_rate_get normal 20 >/dev/null 2>&1; then
+		printf 'FAIL: shared rate state leaked across auth principals\n' >&2
+		return 1
+	fi
+	printf 'PASS: shared rate state rejects another auth principal\n'
+	AIDEVOPS_GH_AUTH_PRINCIPAL=default
+	fixture=$(rate_fixture 100 "$past_reset")
+	gh_request_state_rate_put "$fixture"
+	if gh_request_state_rate_get normal 20 >/dev/null 2>&1; then
+		printf 'FAIL: normal rate state trusted a snapshot after reset\n' >&2
+		return 1
+	fi
+	printf 'PASS: normal rate state expires at the observed reset boundary\n'
+	result=$(gh_request_state_rate_get cached-only 20)
+	assert_eq "cached-only diagnostics retain validated historical state" "100" "$(printf '%s' "$result" | jq -r '.resources.graphql.remaining')"
+	return 0
+}
+
+rate_transport() {
+	local now="" reset_at=""
+	printf 'transport\n' >>"${TEST_ROOT}/rate-transport-count"
+	sleep 0.25
+	now="$(_ghrs_now)"
+	reset_at=$((now + 3600))
+	rate_fixture 4321 "$reset_at"
+	return 0
+}
+
+test_concurrent_rate_probe_is_singleflight() {
+	local worker=0 pid=0 count=0 output=""
+	local -a pids=()
+	rm -f "$AIDEVOPS_GH_REQUEST_STATE_RATE_FILE"
+	: >"${TEST_ROOT}/rate-transport-count"
+	for worker in 1 2 3 4; do
+		(gh_request_state_rate_json normal 20 rate_transport >"${TEST_ROOT}/rate-${worker}.out") &
+		pids+=("$!")
+	done
+	for pid in "${pids[@]}"; do
+		wait "$pid"
+	done
+	count=$(wc -l <"${TEST_ROOT}/rate-transport-count" | tr -d '[:space:]')
+	assert_eq "concurrent rate-limit readers perform one transport probe" "1" "$count"
+	for worker in 1 2 3 4; do
+		output=$(jq -r '.resources.graphql.remaining' "${TEST_ROOT}/rate-${worker}.out")
+		assert_eq "rate follower ${worker} reuses the shared snapshot" "4321" "$output"
+	done
+	return 0
+}
+
+main() {
+	test_scope_key_isolation
+	test_default_state_root_is_operational
+	test_concurrent_workers_share_one_result
+	test_observed_follower_consumes_matching_outcome
+	test_dead_leader_is_recovered
+	test_expired_live_leader_is_fenced
+	test_live_leader_wait_is_bounded
+	test_ownerless_lease_recovery_and_disabled_mode
+	test_rate_state_validation_scope_and_reset
+	test_concurrent_rate_probe_is_singleflight
+	printf 'PASS: shared GitHub request-state regression suite\n'
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-gh-request-singleflight.sh
+++ b/.agents/scripts/tests/test-gh-request-singleflight.sh
@@ -357,6 +357,29 @@ test_rate_state_validation_scope_and_reset() {
 	return 0
 }
 
+test_relative_rate_path_uses_current_directory() {
+	local relative_file="relative-rate.json"
+	local now="" reset_at="" fixture="" result=""
+	(
+		cd "$TEST_ROOT" || return 1
+		export AIDEVOPS_GH_REQUEST_STATE_RATE_FILE="$relative_file"
+		now="$(_ghrs_now)"
+		reset_at=$((now + 3600))
+		fixture=$(rate_fixture 321 "$reset_at")
+		gh_request_state_rate_put "$fixture"
+		if [[ ! -f "$relative_file" ]]; then
+			printf 'FAIL: relative rate path was not written as a file\n' >&2
+			return 1
+		fi
+		result=$(gh_request_state_rate_get normal 20)
+		assert_eq "relative rate path preserves the validated snapshot" "321" \
+			"$(printf '%s' "$result" | jq -r '.resources.graphql.remaining')"
+		assert_eq "relative rate snapshot remains private" "600" "$(file_mode "$relative_file")"
+		assert_eq "root-level rate paths resolve without chmodding root" "/" "$(_ghrs_rate_parent_dir /rate.json)"
+	)
+	return $?
+}
+
 rate_transport() {
 	local now="" reset_at=""
 	printf 'transport\n' >>"${TEST_ROOT}/rate-transport-count"
@@ -399,6 +422,7 @@ main() {
 	test_live_leader_wait_is_bounded
 	test_ownerless_lease_recovery_and_disabled_mode
 	test_rate_state_validation_scope_and_reset
+	test_relative_rate_path_uses_current_directory
 	test_concurrent_rate_probe_is_singleflight
 	printf 'PASS: shared GitHub request-state regression suite\n'
 	return 0

--- a/.agents/scripts/tests/test-gh-request-singleflight.sh
+++ b/.agents/scripts/tests/test-gh-request-singleflight.sh
@@ -156,6 +156,15 @@ test_default_state_root_is_operational() {
 	return 0
 }
 
+test_portable_mtime_dependency_is_available() {
+	if ! declare -F _file_mtime_epoch >/dev/null 2>&1; then
+		printf 'FAIL: shared request state did not load portable mtime support\n' >&2
+		return 1
+	fi
+	printf 'PASS: shared request state loads portable mtime support\n'
+	return 0
+}
+
 test_concurrent_workers_share_one_result() {
 	local key="" result_file="${TEST_ROOT}/shared-result" counter_file="${TEST_ROOT}/transport-count"
 	local worker=0 pid=0 count=0 output=""
@@ -382,6 +391,7 @@ test_concurrent_rate_probe_is_singleflight() {
 main() {
 	test_scope_key_isolation
 	test_default_state_root_is_operational
+	test_portable_mtime_dependency_is_available
 	test_concurrent_workers_share_one_result
 	test_observed_follower_consumes_matching_outcome
 	test_dead_leader_is_recovered

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -223,7 +223,13 @@ _stub_gh_api() {
 	local path="${2:-}"
 	local remaining="${STUB_RATE_LIMIT_REMAINING:-5000}"
 	if [[ "$subcommand" == "rate_limit" ]]; then
-		printf '%s\n' "$remaining"
+		printf '{"resources":{"graphql":{"remaining":'
+		if [[ "$remaining" =~ ^[0-9]+$ ]]; then
+			printf '%s' "$remaining"
+		else
+			printf '"%s"' "$remaining"
+		fi
+		printf ',"limit":5000}}}\n'
 		return 0
 	fi
 	if [[ "$subcommand" == "user" ]]; then
@@ -971,7 +977,7 @@ export STUB_RATE_LIMIT_REMAINING=0
 issue_list_title=$(gh_issue_list --repo "owner/repo" --state open \
 	--json number,title,url,assignees,labels,updatedAt --jq '.[0].title' 2>/dev/null || true)
 
-if [[ "$issue_list_title" == '"Reduce GraphQL list-call pressure"' ]] &&
+if [[ "$issue_list_title" == "Reduce GraphQL list-call pressure" ]] &&
 	grep -qE '^api /repos/owner/repo/issues\?state=open&per_page=30' "$GH_CALLS" 2>/dev/null &&
 	! grep -qE '^issue list' "$GH_CALLS" 2>/dev/null; then
 	pass "gh_issue_list REST fallback preserves compact --json/--jq shape"

--- a/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
@@ -165,6 +165,7 @@ fi
 	extract_function _gh_with_timeout "$WRAPPERS_FILE"
 	printf '\n'
 	printf '%s\n' '_gh_cooldown_context_from_args(){ return 0; }'
+	printf '%s\n' '_gh_record_cooldown_response_if_needed(){ return 0; }'
 	# shellcheck disable=SC2016 # Intentional: emit zsh function definitions literally.
 	printf '%s\n' 'fake_gh(){ echo "fake-gh-called:$*"; return 0; }'
 	# shellcheck disable=SC2016 # If function detection regresses, this captures the timeout route.

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -60,6 +60,9 @@ if [[ "\$1" == "api" && "\$2" == "rate_limit" ]]; then
 	printf '{"resources":{"graphql":{"remaining":5000}}}'
 	exit 0
 fi
+if [[ "\${STUB_GH_DELAY:-0}" != "0" && "\$1" == "api" && "\$2" == /repos/* ]]; then
+	sleep "\$STUB_GH_DELAY"
+fi
 if [[ "\$1" == "api" ]]; then
   if [[ "\$*" == *'/users/owner --jq .type'* ]]; then
     printf 'User'
@@ -109,10 +112,10 @@ SH
 
 seed_cache() {
 	cat >"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json" <<'JSON'
-{"schema":"aidevops-pulse-snapshot/v1","repository":"owner/repo","collection":"issues","projection":"number,title,state,labels,updatedAt,assignees","auth_scope":"github.com","generation":"seed","source":"conditional-rest","complete":true,"truncated":false,"fetched_at":"2026-05-01T00:00:00Z","timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":1,"title":"Cached issue","state":"open","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
+{"schema":"aidevops-pulse-snapshot/v1","repository":"owner/repo","collection":"issues","projection":"number,title,state,labels,updatedAt,assignees","auth_scope":"github.com|default","generation":"seed","source":"conditional-rest","complete":true,"truncated":false,"fetched_at":"2026-05-01T00:00:00Z","timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":1,"title":"Cached issue","state":"open","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z"}]}
 JSON
 	cat >"$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json" <<'JSON'
-{"schema":"aidevops-pulse-snapshot/v1","repository":"owner/repo","collection":"prs","projection":"number,title,labels,updatedAt,assignees,createdAt,author,headRefOid,headRefName","auth_scope":"github.com","generation":"seed","source":"conditional-rest","complete":true,"truncated":false,"fetched_at":"2026-05-01T00:00:00Z","timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":2,"title":"Cached PR","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z","createdAt":"2026-05-01T00:00:00Z","author":{"login":"dev"},"headRefOid":"seed-sha","headRefName":"seed-branch"}]}
+{"schema":"aidevops-pulse-snapshot/v1","repository":"owner/repo","collection":"prs","projection":"number,title,labels,updatedAt,assignees,createdAt,author,headRefOid,headRefName","auth_scope":"github.com|default","generation":"seed","source":"conditional-rest","complete":true,"truncated":false,"fetched_at":"2026-05-01T00:00:00Z","timestamp":"2026-05-01T00:00:00Z","etag":"\"etag-v1\"","items":[{"number":2,"title":"Cached PR","labels":[],"assignees":[],"updatedAt":"2026-05-01T00:00:00Z","createdAt":"2026-05-01T00:00:00Z","author":{"login":"dev"},"headRefOid":"seed-sha","headRefName":"seed-branch"}]}
 JSON
 	return 0
 }
@@ -542,6 +545,35 @@ test_search_opt_in_preserves_owner_search() {
 	return 0
 }
 
+test_concurrent_refreshes_share_canonical_transport() {
+	setup_env
+	seed_cache
+	write_gh_stub changed
+	export STUB_GH_DELAY=1.5
+	local worker=0 pid=0 issue_calls=0 pr_calls=0
+	local -a pids=()
+	for worker in 1 2 3 4 5 6; do
+		"$HELPER" refresh >"${TEST_ROOT}/refresh-${worker}.out" &
+		pids+=("$!")
+	done
+	for pid in "${pids[@]}"; do
+		wait "$pid"
+	done
+	unset STUB_GH_DELAY
+	issue_calls=$(grep -c '/repos/owner/repo/issues?state=open' "$TEST_ROOT/gh-calls.log" 2>/dev/null || true)
+	pr_calls=$(grep -c '/repos/owner/repo/pulls?state=open' "$TEST_ROOT/gh-calls.log" 2>/dev/null || true)
+	if [[ "$issue_calls" -eq 1 && "$pr_calls" -eq 1 ]] &&
+		jq -e '.source == "conditional-rest" and .items[0].number == 3' "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json" >/dev/null &&
+		jq -e '.source == "conditional-rest" and .items[0].number == 7' "$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json" >/dev/null; then
+		print_result "concurrent refreshes perform one canonical transport per projection" 0
+	else
+		printf '  issue_calls=%s pr_calls=%s\n' "$issue_calls" "$pr_calls" >&2
+		print_result "concurrent refreshes perform one canonical transport per projection" 1
+	fi
+	teardown_env
+	return 0
+}
+
 test_prefetch_gh_reads_are_timeout_wrapped() {
 	if prefetch_raw_gh_read_matches "$HELPER"; then
 		print_result "prefetch gh reads use timeout wrapper" 1
@@ -579,6 +611,7 @@ test_changed_repo_refreshes_cache
 test_paginated_response_is_not_complete
 test_conditional_failure_routes_to_rest_by_default
 test_search_opt_in_preserves_owner_search
+test_concurrent_refreshes_share_canonical_transport
 test_legacy_issue_cache_avoids_search_by_default
 test_read_cache_filters_closed_issues
 test_read_cache_accepts_fresh_empty_arrays

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -59,10 +59,13 @@ trap 'rm -rf "$TMP"' EXIT
 
 export LOGFILE="${TMP}/test-pulse.log"
 export HOME="${TMP}/home"
+export AIDEVOPS_GH_REQUEST_STATE_DIR="${TMP}/request-state"
 mkdir -p "${HOME}/.aidevops/logs"
 
 # Stub pulse-stats-helper.sh — track counter increments.
 STATS_COUNTER_FILE="${TMP}/stats-counter.log"
+GH_RATE_CALLS="${TMP}/rate-calls.log"
+export GH_RATE_CALLS
 pulse_stats_increment() {
 	local counter_name="$1"
 	printf '%s\n' "$counter_name" >>"$STATS_COUNTER_FILE"
@@ -87,6 +90,8 @@ export -f pulse_stats_increment pulse_stats_get_24h
 #   STUB_GH_FAIL      — 1 to make gh api rate_limit fail entirely
 gh() {
 	if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
+		printf 'rate-limit\n' >>"$GH_RATE_CALLS"
+		[[ "${STUB_GH_DELAY:-0}" == "0" ]] || sleep "$STUB_GH_DELAY"
 		if [[ "${STUB_GH_FAIL:-0}" == "1" ]]; then
 			return 1
 		fi
@@ -118,6 +123,8 @@ export -f gh
 # Source the circuit breaker helper.
 # shellcheck source=../pulse-rate-limit-circuit-breaker.sh
 source "${SCRIPTS_DIR}/pulse-rate-limit-circuit-breaker.sh"
+# shellcheck source=../shared-gh-wrappers-rest-fallback.sh
+source "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh"
 
 # Re-override pulse_stats_* AFTER sourcing — the circuit breaker sources
 # the real pulse-stats-helper.sh which replaces our capturing stubs.
@@ -144,6 +151,7 @@ pulse_stats_get_24h() {
 reset_test_state() {
 	: >"$LOGFILE"
 	: >"$STATS_COUNTER_FILE"
+	: >"$GH_RATE_CALLS"
 	rm -f "${HOME}/.aidevops/logs/pulse-graphql-circuit-breaker.state"
 	rm -f "${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json"
 	unset AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER 2>/dev/null || true
@@ -154,6 +162,7 @@ reset_test_state() {
 	unset STUB_GH_CORE_REMAINING 2>/dev/null || true
 	unset STUB_GH_CORE_LIMIT 2>/dev/null || true
 	unset STUB_GH_FAIL 2>/dev/null || true
+	unset STUB_GH_DELAY 2>/dev/null || true
 	STUB_GH_REMAINING=5000
 	STUB_GH_LIMIT=5000
 	export AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD="0.05"
@@ -736,6 +745,34 @@ else
 	unset AIDEVOPS_SKIP_NO_WORK_BREAKER NO_WORK_WINDOW_SECS NO_WORK_WINDOW_MAX 2>/dev/null || true
 fi  # end: no_work breaker tests
 
+test_shared_rate_probe_coalesces_consumers() {
+	reset_test_state
+	export STUB_GH_REMAINING=1000
+	export STUB_GH_DELAY=0.25
+	local pid=0 count=0 output=""
+	local -a pids=()
+	(_cb_rate_limit_json normal >"${TMP}/shared-rate-circuit.json") &
+	pids+=("$!")
+	(_rest_should_fallback >/dev/null || true) &
+	pids+=("$!")
+	(_cb_rate_limit_json normal >"${TMP}/shared-rate-circuit-2.json") &
+	pids+=("$!")
+	(_rest_should_fallback >/dev/null || true) &
+	pids+=("$!")
+	for pid in "${pids[@]}"; do
+		wait "$pid"
+	done
+	count=$(wc -l <"$GH_RATE_CALLS")
+	count="${count//[!0-9]/}"
+	output=$(jq -r '.resources.graphql.remaining' "${TMP}/shared-rate-circuit.json" 2>/dev/null) || output=""
+	if [[ "$count" == "1" && "$output" == "1000" ]]; then
+		pass "REST fallback and circuit breaker share one concurrent rate probe"
+	else
+		fail "REST fallback and circuit breaker share one concurrent rate probe" "calls=${count:-0} remaining=${output:-missing}"
+	fi
+	return 0
+}
+
 # =============================================================================
 # Run all tests
 # =============================================================================
@@ -757,6 +794,7 @@ test_log_message_on_trip
 test_graphql_exhausted_rest_core_healthy_allows_dispatch
 test_graphql_exhausted_rest_core_low_blocks_dispatch
 test_graphql_exhausted_rest_fallback_disabled_blocks_dispatch
+test_shared_rate_probe_coalesces_consumers
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

Add auth-, pool-, repository-, projection-, and immutable-identity-scoped leases with generation fencing for exact cacheable reads. Consolidate REST fallback and circuit-breaker rate snapshots, and cover crash, timeout, takeover, and concurrent reuse paths.

## Files Changed

- `.agents/scripts/shared-gh-request-state.sh`: shared leases, fenced outcomes, and validated rate snapshots.
- `.agents/scripts/shared-gh-wrappers-checks.sh`: exact-SHA aggregate-check single-flight.
- `.agents/scripts/pulse-batch-prefetch-helper.sh`: canonical issue/PR snapshot single-flight.
- `.agents/scripts/shared-gh-wrappers-rest-fallback.sh` and `.agents/scripts/pulse-rate-limit-circuit-breaker.sh`: common rate-state consumers.
- Focused shell fixtures under `.agents/scripts/tests/`: concurrency, crash recovery, timeout, scope isolation, and compatibility coverage.

## Runtime Testing

- **Risk level:** High (cross-process coordination, leases, state machines, and GitHub API routing)
- **Verification:** Runtime-verified request-state concurrency; aggregate check cache; canonical conditional REST 20/20; REST fallback 72/72; circuit breaker 32/32; source and zsh compatibility; ShellCheck and changed-file lint clean; stat portability clean; Qlty new-file gate reports 0 smells.

## Key Decisions

- Only exact immutable/cacheable reads enter single-flight.
- Mutations, named required checks, owner search, arbitrary `gh` calls, and explicit invalidation remain live.
- Operational lease state uses the agent workspace; the validated rate snapshot retains its existing cache path.
- Followers consume outcomes only for a generation they observed, preserving explicit invalidation freshness.

Resolves #27774

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 1d 9h and 8,122,855 tokens on this with the user in an interactive session.
