### PR TITLE
GH#28214: use stable review scanner path

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -961,7 +961,7 @@ _prrts_write_prompt_file() {
 	safe_slug="$(_prrts_safe_slug "$repo_slug")"
 	safe_title="$(_prrts_prompt_metadata_line "$title" 300)"
 	safe_preview="$(_prrts_prompt_metadata_line "$preview" 500)"
-	scanner_path="${SCRIPT_DIR}/pr-review-thread-response-scanner.sh"
+	scanner_path="${HOME}/.aidevops/agents/scripts/pr-review-thread-response-scanner.sh"
 	prompt_file="${STATE_DIR}/${safe_slug}-${pr_number}-prompt.md"
 	cat >"$prompt_file" <<PROMPT_EOF
 # PR REVIEW THREAD RESPONSE — BOUNDED WORKER

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -273,14 +273,37 @@ test_dispatch_launches_worker_and_writes_state() {
 
 test_dispatch_prompt_includes_full_thread_command_signatures() {
 	setup_test_env
+	local stable_scanner="${HOME}/.aidevops/agents/scripts/pr-review-thread-response-scanner.sh"
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
 	wait_for_headless_log || true
-	if grep -Fq "${SCANNER} reply owner/repo <thread_id> <body_file>" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
-		grep -Fq "${SCANNER} resolve owner/repo <thread_id>" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+	if grep -Fq "${stable_scanner} reply owner/repo <thread_id> <body_file>" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		grep -Fq "${stable_scanner} resolve owner/repo <thread_id>" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
 		grep -Fq 'Write each reply to a local temporary file and pass that path as <body_file>' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
 		print_result "dispatch prompt includes full reply and resolve signatures" 0
 	else
 		print_result "dispatch prompt includes full reply and resolve signatures" 1 "prompt=$(tr '\n' ' ' <"$HEADLESS_PROMPT_CAPTURE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_prompt_uses_stable_deployed_scanner_path() {
+	setup_test_env
+	local bundled_scanner="${TEST_ROOT}/runtime-bundles/old/agents/scripts/pr-review-thread-response-scanner.sh"
+	local stable_scanner="${HOME}/.aidevops/agents/scripts/pr-review-thread-response-scanner.sh"
+	mkdir -p "$(dirname "$bundled_scanner")"
+	cp "$SCANNER" "$bundled_scanner"
+	chmod +x "$bundled_scanner"
+	"$bundled_scanner" dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	if grep -Fq "${stable_scanner} reply owner/repo <thread_id> <body_file>" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		grep -Fq "${stable_scanner} resolve owner/repo <thread_id>" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		grep -Fq "${stable_scanner} mark-complete owner/repo 1" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		grep -Fq "${stable_scanner} mark-blocked owner/repo 1" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		! grep -Fq '/runtime-bundles/' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
+		print_result "dispatch prompt uses stable deployed scanner path" 0
+	else
+		print_result "dispatch prompt uses stable deployed scanner path" 1 "prompt=$(tr '\n' ' ' <"$HEADLESS_PROMPT_CAPTURE" 2>/dev/null || printf '')"
 	fi
 	teardown_test_env
 	return 0
@@ -304,10 +327,11 @@ test_dispatch_prompt_mentions_graphql_only_thread_operations() {
 
 test_dispatch_prompt_requires_machine_readable_completion_state() {
 	setup_test_env
+	local stable_scanner="${HOME}/.aidevops/agents/scripts/pr-review-thread-response-scanner.sh"
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
 	wait_for_headless_log || true
-	if grep -q "${SCANNER} mark-complete owner/repo 1" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null && \
-		grep -q "${SCANNER} mark-blocked owner/repo 1" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null && \
+	if grep -Fq "${stable_scanner} mark-complete owner/repo 1" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null && \
+		grep -Fq "${stable_scanner} mark-blocked owner/repo 1" "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null && \
 		grep -q 'readable scanner state' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
 		print_result "dispatch prompt requires machine-readable completion state" 0
 	else
@@ -777,6 +801,7 @@ main() {
 	test_scan_pr_can_include_human_threads_with_opt_in
 	test_dispatch_launches_worker_and_writes_state
 	test_dispatch_prompt_includes_full_thread_command_signatures
+	test_dispatch_prompt_uses_stable_deployed_scanner_path
 	test_dispatch_prompt_mentions_graphql_only_thread_operations
 	test_dispatch_prompt_requires_machine_readable_completion_state
 	test_dispatch_prompt_marks_dynamic_metadata_untrusted


### PR DESCRIPTION
## Summary

Render review-thread worker commands through the stable deployed scanner path and cover runtime-bundle dispatch with a regression test.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 32 focused scanner tests passed; 8 compatibility tests passed; Bash syntax and ShellCheck passed; linters-local.sh passed.

Resolves #28214


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 44m and 254,711 tokens on this with the user in an interactive session.