### PR TITLE
GH#28225: Publish simplification state without mutating canonical checkout

### DIFF
--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# Checkout-free publication of TODO.md and todo/** changes.
+# Checkout-free publication of narrowly allowlisted repository state.
 
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
 [[ -n "${_PLANNING_PUBLISHER_LOADED:-}" ]] && return 0
@@ -42,11 +42,13 @@ _planning_publish_log_retryable_conflict() {
 
 _planning_publish_path_allowed() {
 	local path="$1"
-	case "$path" in
-	TODO.md | todo/*)
+	local scope="${AIDEVOPS_PLANNING_PUBLISH_SCOPE:-planning}"
+	case "${scope}:${path}" in
+	planning:TODO.md | planning:todo/*)
 		[[ "$path" != *'..'* && "$path" != *'//'* && "$path" != */ ]]
 		return $?
 		;;
+	simplification-state:.agents/configs/simplification-state.json) return 0 ;;
 	*) return 1 ;;
 	esac
 }
@@ -70,11 +72,11 @@ _planning_publish_snapshot() {
 	while IFS= read -r path; do
 		[[ -n "$path" ]] || continue
 		_planning_publish_path_allowed "$path" || {
-			_planning_publish_log error "Unauthorized planning path: $path"
+			_planning_publish_log error "Unauthorized publication path: $path"
 			return 1
 		}
 		if [[ -L "${repo_path}/${path}" ]] || [[ -d "${repo_path}/${path}" ]]; then
-			_planning_publish_log error "Planning paths must be regular files: $path"
+			_planning_publish_log error "Publication paths must be regular files: $path"
 			return 1
 		fi
 		if [[ -f "${repo_path}/${path}" ]]; then
@@ -280,6 +282,24 @@ planning_publish() {
 		}
 		latest_sha="${parent_resolution%%|*}"
 		expected_sha="${parent_resolution#*|}"
+		_planning_publish_build_index "$repo_path" "$latest_sha" "$snapshot_file" "$index_file" || {
+			rm -rf "$temp_dir"
+			return 1
+		}
+		_planning_publish_verify_index "$repo_path" "$latest_sha" "$snapshot_file" "$index_file" || {
+			rm -rf "$temp_dir"
+			return 1
+		}
+		tree_sha=$(GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" write-tree) || {
+			rm -rf "$temp_dir"
+			return 1
+		}
+		if [[ "$tree_sha" == "$(_planning_git -C "$repo_path" rev-parse "${latest_sha}^{tree}")" ]]; then
+			PLANNING_PUBLISH_RESULT="noop"
+			PLANNING_PUBLISHED_COMMIT="$latest_sha"
+			rm -rf "$temp_dir"
+			return 0
+		fi
 		if [[ -z "$parent_sha" && -n "$base_sha" && "$base_sha" != "$latest_sha" ]] && \
 			_planning_publish_parent_conflicts "$repo_path" "$base_sha" "$latest_sha" "$snapshot_file"; then
 			_planning_publish_log_retryable_conflict "$publication_id"
@@ -292,24 +312,6 @@ planning_publish() {
 			return 2
 		fi
 		parent_sha="$latest_sha"
-		_planning_publish_build_index "$repo_path" "$parent_sha" "$snapshot_file" "$index_file" || {
-			rm -rf "$temp_dir"
-			return 1
-		}
-		_planning_publish_verify_index "$repo_path" "$parent_sha" "$snapshot_file" "$index_file" || {
-			rm -rf "$temp_dir"
-			return 1
-		}
-		tree_sha=$(GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" write-tree) || {
-			rm -rf "$temp_dir"
-			return 1
-		}
-		if [[ "$tree_sha" == "$(_planning_git -C "$repo_path" rev-parse "${parent_sha}^{tree}")" ]]; then
-			PLANNING_PUBLISH_RESULT="noop"
-			PLANNING_PUBLISHED_COMMIT="$parent_sha"
-			rm -rf "$temp_dir"
-			return 0
-		fi
 		candidate_sha=$(printf '%s\n\nPlanning-Publication-ID: %s\n' "$commit_msg" "$publication_id" | _planning_git -C "$repo_path" commit-tree "$tree_sha" -p "$parent_sha") || {
 			rm -rf "$temp_dir"
 			return 1
@@ -336,7 +338,7 @@ planning_publish() {
 		if [[ $push_rc -eq 0 ]]; then
 			PLANNING_PUBLISH_RESULT="published"
 			PLANNING_PUBLISHED_COMMIT="$candidate_sha"
-			_planning_publish_log success "Published planning files (${publication_id})"
+			_planning_publish_log success "Published allowlisted files (${publication_id})"
 			rm -rf "$temp_dir"
 			return 0
 		fi

--- a/.agents/scripts/pulse-simplification-orchestration.sh
+++ b/.agents/scripts/pulse-simplification-orchestration.sh
@@ -274,7 +274,7 @@ _check_ci_nesting_threshold_proximity() {
 }
 
 # _complexity_scan_state_refresh — prune/refresh/backfill simplification state (t1754, t1855, t2001)
-# Updates state file and pushes to main if any entries changed.
+# Updates state and publishes it checkout-free if any entries changed.
 _complexity_scan_state_refresh() {
 	local aidevops_path="$1"
 	local state_file="$2"
@@ -328,7 +328,7 @@ _complexity_scan_state_refresh() {
 		echo "[pulse-wrapper] simplification-state: closed $spurious_closed spurious zero-smell re-queue issues (GH#18795)" >>"$LOGFILE"
 	fi
 
-	# Push state file if updated (planning data — direct to main)
+	# Publish state without staging or committing in the canonical checkout.
 	if [[ "$state_updated" == true ]]; then
 		_simplification_state_push "$aidevops_path"
 	fi

--- a/.agents/scripts/pulse-simplification-state.sh
+++ b/.agents/scripts/pulse-simplification-state.sh
@@ -8,7 +8,7 @@
 # (t1993: schedule post-merge-review-scanner.sh).
 #
 # This module contains the self-contained sub-cluster of functions that read,
-# write, refresh, prune, push, and backfill .agents/configs/simplification-state.json
+# write, refresh, prune, publish, and backfill .agents/configs/simplification-state.json
 # — the shared hash registry the simplification routine uses to detect which
 # files have been processed, how many passes they have been through, and whether
 # they have converged.
@@ -320,30 +320,34 @@ _simplification_state_prune() {
 	return 0
 }
 
-# Commit and push simplification state to main (planning data, not code).
+# Publish simplification state without mutating the source checkout.
 # Arguments: $1 - repo_path
 _simplification_state_push() {
 	local repo_path="$1"
 	local state_rel=".agents/configs/simplification-state.json"
+	local module_dir="${BASH_SOURCE[0]%/*}"
+	local main_branch="" base_sha="" publication_rc=0
 
-	# Only push from the canonical (main) worktree
-	local main_branch
+	if ! declare -F planning_publish >/dev/null 2>&1; then
+		[[ "$module_dir" != "${BASH_SOURCE[0]}" ]] || module_dir="."
+		module_dir=$(cd "$module_dir" && pwd) || return 1
+		[[ -f "${module_dir}/planning-publisher.sh" ]] || return 1
+		# shellcheck source=./planning-publisher.sh
+		source "${module_dir}/planning-publisher.sh"
+	fi
 	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch="main"
-	local current_branch
-	current_branch=$(git -C "$repo_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || current_branch=""
+	base_sha=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null) || return 1
 
-	if [[ "$current_branch" != "$main_branch" ]]; then
-		echo "[pulse-wrapper] simplification-state: skipping push — not on $main_branch (on $current_branch)" >>"$LOGFILE"
-		return 0
-	fi
-
-	if ! git -C "$repo_path" diff --quiet -- "$state_rel" 2>/dev/null; then
-		git -C "$repo_path" add "$state_rel" 2>/dev/null || return 1
-		git -C "$repo_path" commit -m "chore: update simplification state registry" --no-verify 2>/dev/null || return 1
-		git -C "$repo_path" push origin "$main_branch" 2>/dev/null || return 1
-		echo "[pulse-wrapper] simplification-state: pushed updated state to $main_branch" >>"$LOGFILE"
-	fi
-	return 0
+	AIDEVOPS_PLANNING_BASE_SHA="$base_sha" \
+		AIDEVOPS_PLANNING_PUBLISH_SCOPE="simplification-state" \
+		planning_publish "$repo_path" "chore: update simplification state registry" \
+			origin "$main_branch" "$state_rel" || publication_rc=$?
+	case "$publication_rc" in
+	0) echo "[pulse-wrapper] simplification-state: ${PLANNING_PUBLISH_RESULT:-published} on $main_branch" >>"${LOGFILE:-/dev/null}" ;;
+	2) echo "[pulse-wrapper] simplification-state: retryable publication conflict on $main_branch" >>"${LOGFILE:-/dev/null}" ;;
+	*) echo "[pulse-wrapper] simplification-state: publication failed on $main_branch (rc=$publication_rc)" >>"${LOGFILE:-/dev/null}" ;;
+	esac
+	return "$publication_rc"
 }
 
 # Create a follow-up function-complexity-debt issue when Qlty smells persist after

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -8,6 +8,7 @@ PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 export PATH
 SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 PUBLISHER="${SCRIPT_DIR_TEST}/../planning-publisher.sh"
+STATE_SCRIPT="${SCRIPT_DIR_TEST}/../pulse-simplification-state.sh"
 PASS=0
 FAIL=0
 
@@ -65,6 +66,20 @@ run_publish() {
 	return $?
 }
 
+run_simplification_publish() {
+	local repo="$1"
+	local hook="${2:-}"
+	(
+		LOGFILE="/dev/null"
+		# shellcheck source=../pulse-simplification-state.sh
+		source "$STATE_SCRIPT"
+		AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+			AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK="$hook" \
+			_simplification_state_push "$repo"
+	)
+	return $?
+}
+
 test_git_binary_availability_is_validated() {
 	local name="rejects an unavailable Git command with a controlled error"
 	local output="" rc=0
@@ -111,6 +126,91 @@ test_state_allowlist_and_idempotence() {
 	if [[ "$before" == "$after" && "$first_remote" == "$second_remote" && "$count" -eq 1 ]] &&
 		git --git-dir="${root}/remote.git" show main:TODO.md | grep -q t001 &&
 		[[ "$(git --git-dir="${root}/remote.git" show main:README.md)" == "base" ]]; then pass "$name"; else fail "$name" invariant; fi
+	rm -rf "$root"
+	return 0
+}
+
+test_simplification_state_scope_preserves_checkout() {
+	local name="publishes only simplification state without changing the source checkout"
+	local root="" repo="" before="" after="" first_remote="" second_remote="" rejected_rc=0 count=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	mkdir -p "${repo}/.agents/configs" || return 0
+	printf '%s\n' '{"files":{"example.sh":{"passes":1}}}' >"${repo}/.agents/configs/simplification-state.json"
+	printf 'local-only\n' >>"${repo}/README.md"
+	git -C "$repo" add README.md
+	before=$(state_digest "$repo")
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+			planning_publish "$repo" "reject state without scope" origin main \
+			".agents/configs/simplification-state.json"
+	) >/dev/null 2>&1 || rejected_rc=$?
+	run_simplification_publish "$repo" || {
+		fail "$name" publish
+		return 0
+	}
+	after=$(state_digest "$repo")
+	first_remote=$(git --git-dir="${root}/remote.git" rev-parse main)
+	run_simplification_publish "$repo" || {
+		fail "$name" replay
+		return 0
+	}
+	second_remote=$(git --git-dir="${root}/remote.git" rev-parse main)
+	count=$(git --git-dir="${root}/remote.git" log --format=%B main | grep -c 'Planning-Publication-ID:' || true)
+	if [[ "$rejected_rc" -ne 0 && "$before" == "$after" && "$first_remote" == "$second_remote" && "$count" -eq 1 ]] &&
+		git --git-dir="${root}/remote.git" show main:.agents/configs/simplification-state.json | grep -q 'example.sh' &&
+		[[ "$(git --git-dir="${root}/remote.git" show main:README.md)" == "base" ]]; then
+		pass "$name"
+	else
+		fail "$name" "scope or checkout invariant failed (reject_rc=$rejected_rc count=$count)"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
+test_simplification_state_conflict_is_retryable() {
+	local name="simplification-state contention fails retryably without overwriting remote state"
+	local root="" repo="" hook="" before="" after="" rc=0 remote_state=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	mkdir -p "${repo}/.agents/configs" || return 0
+	printf '%s\n' '{"files":{"local.sh":{"passes":1}}}' >"${repo}/.agents/configs/simplification-state.json"
+	hook="${root}/state-rival.sh"
+	cat >"$hook" <<'HOOK'
+#!/usr/bin/env bash
+repo="$1"; remote="$2"; branch="$3"; attempt="$6"
+[[ "$attempt" == "1" ]] || exit 0
+tmp=$(mktemp -d)
+git clone -q "$(git -C "$repo" remote get-url "$remote")" "$tmp/work"
+mkdir -p "$tmp/work/.agents/configs"
+printf '%s\n' '{"files":{"rival.sh":{"passes":2}}}' >"$tmp/work/.agents/configs/simplification-state.json"
+git -C "$tmp/work" add .agents/configs/simplification-state.json
+GIT_AUTHOR_NAME=Rival GIT_AUTHOR_EMAIL=rival@example.invalid GIT_COMMITTER_NAME=Rival GIT_COMMITTER_EMAIL=rival@example.invalid git -C "$tmp/work" -c commit.gpgsign=false commit -qm rival
+git -C "$tmp/work" push -q origin "$branch"
+rm -rf "$tmp"
+exit 0
+HOOK
+	chmod +x "$hook"
+	before=$(state_digest "$repo")
+	run_simplification_publish "$repo" "$hook" || rc=$?
+	after=$(state_digest "$repo")
+	remote_state=$(git --git-dir="${root}/remote.git" show main:.agents/configs/simplification-state.json)
+	if [[ "$rc" -eq 2 && "$before" == "$after" && "$remote_state" == *"rival.sh"* && "$remote_state" != *"local.sh"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "conflict invariant failed (rc=$rc)"
+	fi
 	rm -rf "$root"
 	return 0
 }
@@ -441,6 +541,8 @@ test_explicit_git_capability_preserves_guarded_checkout() {
 main() {
 	test_git_binary_availability_is_validated
 	test_state_allowlist_and_idempotence
+	test_simplification_state_scope_preserves_checkout
+	test_simplification_state_conflict_is_retryable
 	test_validation_failure_pushes_nothing
 	test_contention_replay_and_conflict
 	test_crash_replay_is_single_publication


### PR DESCRIPTION
## Summary

Route simplification-state updates through the checkout-free publisher with an explicit single-path scope, idempotent replay, and lease-protected conflict handling.

## Files Changed

.agents/scripts/planning-publisher.sh, .agents/scripts/pulse-simplification-orchestration.sh, .agents/scripts/pulse-simplification-state.sh, .agents/scripts/tests/test-planning-publisher.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Planning publisher 12/12; simplification-state preserve 6/6; pulse characterization 30/30; issue-sync workspace contract; ShellCheck; local linters.

Resolves #28225


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 38m and 1,078,096 tokens on this with the user in an interactive session.