### PR TITLE
t18130: Invalidate canonical GitHub state from verified webhooks

### DIFF
--- a/.agents/configs/webhook-receiver.conf
+++ b/.agents/configs/webhook-receiver.conf
@@ -2,9 +2,8 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # webhook-receiver.conf — pulse-merge-webhook-receiver.sh (t3038)
 #
-# Configuration for the webhook receiver that triggers immediate
-# pulse-merge attempts on GitHub `check_suite.completed`,
-# `pull_request_review.submitted`, and `pull_request.labeled` events.
+# Configuration for the webhook receiver that invalidates narrow canonical
+# GitHub state before triggering eligible immediate pulse-merge attempts.
 #
 # CRITICAL: this file MUST NOT contain the webhook secret itself. Secrets
 # come from gopass (`aidevops secret set GITHUB_WEBHOOK_SECRET`) or
@@ -29,9 +28,23 @@ WEBHOOK_SECRET_ENV="GITHUB_WEBHOOK_SECRET"
 # typically <50 KB; cap at 1 MB as a DoS guard.
 WEBHOOK_MAX_BODY_BYTES="1048576"
 
-# Comma-separated list of GitHub event types the receiver acts on.
-# All other events return 204 No Content without invoking process_pr.
-WEBHOOK_HANDLED_EVENTS="check_suite,pull_request_review,pull_request"
+# Comma-separated list of GitHub event types the receiver acts on. Collection
+# events invalidate issue/PR snapshots; check events invalidate exact head SHAs.
+# All other authenticated events return 204 without mutating the delivery ledger.
+WEBHOOK_HANDLED_EVENTS="check_run,check_suite,status,workflow_run,issues,issue_comment,pull_request,pull_request_review,pull_request_review_comment,pull_request_review_thread"
+
+# Strict server-to-receiver line protocol. Unknown versions fail closed.
+WEBHOOK_ACTION_PROTOCOL_VERSION="v1"
+
+# Private, restart-safe delivery-ID ledger. Entries contain only event metadata
+# and payload fingerprints, never raw webhook bodies. Retention bounds prevent
+# replay while keeping local state finite.
+WEBHOOK_DELIVERY_LEDGER_FILE="${HOME}/.aidevops/state/pulse-merge-webhook-deliveries.json"
+WEBHOOK_DELIVERY_TTL_SECONDS="604800"
+WEBHOOK_DELIVERY_MAX_ENTRIES="4096"
+
+# Maximum concurrent process_pr dispatches after synchronous invalidation.
+WEBHOOK_DISPATCH_MAX_CONCURRENCY="4"
 
 # Log file for receiver activity (incoming events, signature failures,
 # merge dispatches). Rotated externally by logrotate / launchd.

--- a/.agents/scripts/pulse-batch-conditional-cache.py
+++ b/.agents/scripts/pulse-batch-conditional-cache.py
@@ -88,6 +88,7 @@ def _snapshot_payload(
     projection: str,
     auth_scope: str,
     generation: str,
+    invalidation_generation: str,
     source: str,
     now: str,
     etag: str,
@@ -102,6 +103,7 @@ def _snapshot_payload(
         "projection": projection,
         "auth_scope": auth_scope,
         "generation": generation,
+        "invalidation_generation": invalidation_generation,
         "source": source,
         "complete": complete,
         "truncated": not complete,
@@ -118,15 +120,24 @@ def _snapshot_payload(
 
 def main(argv: list[str]) -> int:
     result = 0
-    if len(argv) != 8:
+    if len(argv) != 9:
         print(
             "usage: pulse-batch-conditional-cache.py KIND SLUG RESPONSE_FILE "
-            "CACHE_FILE GENERATION AUTH_SCOPE PROJECTION",
+            "CACHE_FILE GENERATION AUTH_SCOPE PROJECTION INVALIDATION_GENERATION",
             file=sys.stderr,
         )
         result = 2
     else:
-        kind, slug, response_file, cache_file, generation, auth_scope, projection = argv[1:8]
+        (
+            kind,
+            slug,
+            response_file,
+            cache_file,
+            generation,
+            auth_scope,
+            projection,
+            invalidation_generation,
+        ) = argv[1:9]
         status, etag, has_next, body = _split_response(response_file)
         now = _now_iso()
         if status == 304:
@@ -139,6 +150,7 @@ def main(argv: list[str]) -> int:
                 generation,
                 auth_scope,
                 projection,
+                invalidation_generation,
             )
         elif status < 200 or status >= 300:
             result = 1
@@ -151,6 +163,7 @@ def main(argv: list[str]) -> int:
                     projection,
                     auth_scope,
                     generation,
+                    invalidation_generation,
                     "conditional-rest",
                     now,
                     etag,
@@ -172,6 +185,7 @@ def _refresh_cached_response(
     generation: str,
     auth_scope: str,
     projection: str,
+    invalidation_generation: str,
 ) -> int:
     if not os.path.exists(cache_file):
         return 1
@@ -206,6 +220,7 @@ def _refresh_cached_response(
             "projection": projection if compatible else payload.get("projection", "legacy"),
             "auth_scope": auth_scope,
             "generation": generation,
+            "invalidation_generation": invalidation_generation,
             "source": "conditional-rest",
             "complete": payload.get("complete", False) if compatible else False,
             "truncated": not (payload.get("complete", False) if compatible else False),

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -124,6 +124,7 @@ _JSON_TYPE_BOOLEAN=boolean
 _JSON_TYPE_STRING=string
 _STATE_OPEN="open"
 _CACHE_STATE_MALFORMED="malformed"
+_CACHE_STATE_INVALIDATED="invalidated"
 _CACHE_SNAPSHOT_STATE="missing"
 _CACHE_SNAPSHOT_PATH=""
 _SNAPSHOT_SCHEMA="aidevops-pulse-snapshot/v1"
@@ -132,7 +133,9 @@ _SNAPSHOT_PRS_PROJECTION="number,title,labels,updatedAt,assignees,createdAt,auth
 _BATCH_SNAPSHOT_GENERATION="${PULSE_BATCH_SNAPSHOT_GENERATION:-}"
 _BATCH_SNAPSHOT_AUTH_SCOPE="${PULSE_BATCH_SNAPSHOT_AUTH_SCOPE:-${GH_HOST:-github.com}|${AIDEVOPS_GH_AUTH_MODE:-gh}|${AIDEVOPS_GH_AUTH_PRINCIPAL:-default}}|${AIDEVOPS_GH_API_POOL:-default}"
 _BATCH_INITIAL_SNAPSHOT_MARKERS=""
+_BATCH_INITIAL_INVALIDATION_GENERATIONS=""
 _BATCH_SNAPSHOT_MARKER_MISSING="$_CACHE_SNAPSHOT_STATE"
+_BATCH_INVALIDATION_INITIAL="${_GHRS_INVALIDATION_INITIAL:-0000000000000000000000000000000000000000000000000000000000000000}"
 
 # --- Feature flag gate ---
 _check_enabled() {
@@ -150,6 +153,63 @@ _snapshot_projection() {
 	*) return 1 ;;
 	esac
 	return 0
+}
+
+_snapshot_request_key() {
+	local kind="$1"
+	local slug="$2"
+	local projection=""
+	projection=$(_snapshot_projection "$kind") || return 1
+	declare -F gh_request_state_request_key >/dev/null 2>&1 || return 1
+	gh_request_state_request_key "$slug" canonical-snapshot "$projection" "$kind" rest-core
+	return $?
+}
+
+_snapshot_invalidation_key() {
+	local kind="$1"
+	local slug="$2"
+	local projection=""
+	projection=$(_snapshot_projection "$kind") || return 1
+	declare -F gh_request_state_invalidation_key >/dev/null 2>&1 || return 1
+	gh_request_state_invalidation_key "$slug" canonical-snapshot "$projection" "$kind"
+	return $?
+}
+
+_snapshot_invalidation_generation() {
+	local kind="$1"
+	local slug="$2"
+	local request_key=""
+	if ! declare -F gh_request_state_invalidation_generation_get >/dev/null 2>&1; then
+		printf '%s\n' "$_BATCH_INVALIDATION_INITIAL"
+		return 0
+	fi
+	request_key="$(_snapshot_invalidation_key "$kind" "$slug")" || return 1
+	gh_request_state_invalidation_generation_get "$request_key"
+	return $?
+}
+
+_snapshot_invalidation_generation_is_current() {
+	local kind="$1"
+	local slug="$2"
+	local generation="$3"
+	local request_key=""
+	request_key="$(_snapshot_invalidation_key "$kind" "$slug")" || return 1
+	gh_request_state_invalidation_generation_is_current "$request_key" "$generation"
+	return $?
+}
+
+_snapshot_initial_invalidation_generation() {
+	local kind="$1"
+	local slug="$2"
+	local stored_kind="" stored_slug="" generation=""
+	while IFS='|' read -r stored_kind stored_slug generation; do
+		if [[ "$stored_kind" == "$kind" && "$stored_slug" == "$slug" && -n "$generation" ]]; then
+			printf '%s\n' "$generation"
+			return 0
+		fi
+	done <<<"$_BATCH_INITIAL_INVALIDATION_GENERATIONS"
+	_snapshot_invalidation_generation "$kind" "$slug"
+	return $?
 }
 
 _snapshot_collection_complete() {
@@ -198,6 +258,8 @@ _is_search_rate_limited() {
 # Returns: 0 on success (cache written), 1 on failure (REST also failed/no data)
 _prefetch_rest_issues_for_slug() {
 	local slug="$1"
+	local invalidation_generation=""
+	invalidation_generation="$(_snapshot_initial_invalidation_generation "$_KIND_ISSUES" "$slug")" || return 1
 	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rest_issues || true
 	local rest_json
 	rest_json=$(_prefetch_gh_read gh api "/repos/${slug}/issues?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
@@ -215,16 +277,18 @@ _prefetch_rest_issues_for_slug() {
 	projection=$(_snapshot_projection "$_KIND_ISSUES") || return 1
 	local tmp_file=""
 	tmp_file=$(mktemp "${BATCH_CACHE_DIR}/.issues-snapshot.XXXXXX") || return 1
-	echo "$rest_json" | jq --arg ts "$ts" --arg state_open "$_STATE_OPEN" \
+	if ! printf '%s\n' "$rest_json" | jq --arg ts "$ts" --arg state_open "$_STATE_OPEN" \
 		--arg schema "$_SNAPSHOT_SCHEMA" --arg slug "$slug" --arg collection "$_KIND_ISSUES" \
 		--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" \
-		--arg generation "$_BATCH_SNAPSHOT_GENERATION" --argjson complete "$complete" '{
+		--arg generation "$_BATCH_SNAPSHOT_GENERATION" \
+		--arg invalidation_generation "$invalidation_generation" --argjson complete "$complete" '{
 		schema: $schema,
 		repository: $slug,
 		collection: $collection,
 		projection: $projection,
 		auth_scope: $auth_scope,
 		generation: $generation,
+		invalidation_generation: $invalidation_generation,
 		source: "rest-fallback",
 		complete: $complete,
 		truncated: ($complete | not),
@@ -238,11 +302,21 @@ _prefetch_rest_issues_for_slug() {
 			updatedAt: .updated_at,
 			assignees: (.assignees // [])
 		}]
-	}' >"$tmp_file" 2>/dev/null && mv "$tmp_file" "$cache_file" || {
+	}' >"$tmp_file" 2>/dev/null; then
 		rm -f "$tmp_file"
 		_log "REST issues fallback: failed to write cache for ${slug}"
 		return 1
+	fi
+	if ! _snapshot_invalidation_generation_is_current "$_KIND_ISSUES" "$slug" "$invalidation_generation"; then
+		rm -f "$tmp_file"
+		_log "REST issues fallback: publication fenced for ${slug}"
+		return 1
+	fi
+	mv "$tmp_file" "$cache_file" || {
+		rm -f "$tmp_file"
+		return 1
 	}
+	_snapshot_invalidation_generation_is_current "$_KIND_ISSUES" "$slug" "$invalidation_generation" || return 1
 	local item_count
 	item_count=$(jq '.items | length' "$cache_file" 2>/dev/null) || item_count=0
 	_log "REST issues fallback: wrote ${item_count} items to cache for ${slug}"
@@ -259,6 +333,8 @@ _prefetch_rest_issues_for_slug() {
 # Returns: 0 on success (cache written), 1 on failure (REST also failed/no data)
 _prefetch_rest_prs_for_slug() {
 	local slug="$1"
+	local invalidation_generation=""
+	invalidation_generation="$(_snapshot_initial_invalidation_generation "$_KIND_PRS" "$slug")" || return 1
 	declare -F gh_record_call >/dev/null && gh_record_call rest pulse_batch_prefetch_rest_prs || true
 	local rest_json
 	rest_json=$(_prefetch_gh_read gh api "/repos/${slug}/pulls?state=open&per_page=${BATCH_SEARCH_LIMIT}" 2>/dev/null) || rest_json=""
@@ -276,9 +352,10 @@ _prefetch_rest_prs_for_slug() {
 	projection=$(_snapshot_projection "$_KIND_PRS") || return 1
 	local tmp_file=""
 	tmp_file=$(mktemp "${BATCH_CACHE_DIR}/.prs-snapshot.XXXXXX") || return 1
-	echo "$rest_json" | jq --arg ts "$ts" --arg schema "$_SNAPSHOT_SCHEMA" \
+	if ! printf '%s\n' "$rest_json" | jq --arg ts "$ts" --arg schema "$_SNAPSHOT_SCHEMA" \
 		--arg slug "$slug" --arg collection "$_KIND_PRS" --arg projection "$projection" \
 		--arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" --arg generation "$_BATCH_SNAPSHOT_GENERATION" \
+		--arg invalidation_generation "$invalidation_generation" \
 		--argjson complete "$complete" '{
 		schema: $schema,
 		repository: $slug,
@@ -286,6 +363,7 @@ _prefetch_rest_prs_for_slug() {
 		projection: $projection,
 		auth_scope: $auth_scope,
 		generation: $generation,
+		invalidation_generation: $invalidation_generation,
 		source: "rest-fallback",
 		complete: $complete,
 		truncated: ($complete | not),
@@ -302,11 +380,21 @@ _prefetch_rest_prs_for_slug() {
 			headRefOid: (.head.sha // null),
 			headRefName: (.head.ref // null)
 		}]
-	}' >"$tmp_file" 2>/dev/null && mv "$tmp_file" "$cache_file" || {
+	}' >"$tmp_file" 2>/dev/null; then
 		rm -f "$tmp_file"
 		_log "REST PRs fallback: failed to write cache for ${slug}"
 		return 1
+	fi
+	if ! _snapshot_invalidation_generation_is_current "$_KIND_PRS" "$slug" "$invalidation_generation"; then
+		rm -f "$tmp_file"
+		_log "REST PRs fallback: publication fenced for ${slug}"
+		return 1
+	fi
+	mv "$tmp_file" "$cache_file" || {
+		rm -f "$tmp_file"
+		return 1
 	}
+	_snapshot_invalidation_generation_is_current "$_KIND_PRS" "$slug" "$invalidation_generation" || return 1
 	local item_count
 	item_count=$(jq '.items | length' "$cache_file" 2>/dev/null) || item_count=0
 	_log "REST PRs fallback: wrote ${item_count} items to cache for ${slug}"
@@ -455,15 +543,20 @@ _conditional_rest_snapshot_marker() {
 	local slug="$2"
 	local projection=""
 	local cache_file=""
+	local invalidation_generation=""
 	projection=$(_snapshot_projection "$kind") || return 1
+	invalidation_generation="$(_snapshot_invalidation_generation "$kind" "$slug")" || return 1
 	cache_file=$(_cache_file_path "$kind" "$slug")
 	[[ -s "$cache_file" ]] || return 1
 	jq -er --arg schema "$_SNAPSHOT_SCHEMA" --arg slug "$slug" --arg kind "$kind" \
 		--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" \
-		--arg string_type "$_JSON_TYPE_STRING" '
+		--arg string_type "$_JSON_TYPE_STRING" \
+		--arg invalidation_generation "$invalidation_generation" \
+		--arg invalidation_initial "$_BATCH_INVALIDATION_INITIAL" '
 		select(
 			.schema == $schema and .repository == $slug and .collection == $kind and
 			.projection == $projection and .auth_scope == $auth_scope and
+			(.invalidation_generation // $invalidation_initial) == $invalidation_generation and
 			.source == "conditional-rest" and .complete == true and
 			(.generation | type == $string_type and length > 0) and
 			(.fetched_at | type == $string_type and length > 0)
@@ -476,18 +569,27 @@ _conditional_rest_snapshot_marker() {
 _conditional_rest_capture_initial_markers() {
 	local owner_groups="$1"
 	local owner="" slugs="" slug="" kind="" marker="" record=""
+	local invalidation_generation="" invalidation_record=""
 	_BATCH_INITIAL_SNAPSHOT_MARKERS=""
+	_BATCH_INITIAL_INVALIDATION_GENERATIONS=""
 	while IFS='|' read -r owner slugs; do
 		[[ -n "$owner" ]] || continue
 		while IFS= read -r slug; do
 			[[ -n "$slug" ]] || continue
 			for kind in "$_KIND_ISSUES" "$_KIND_PRS"; do
 				marker=$(_conditional_rest_snapshot_marker "$kind" "$slug") || marker="$_BATCH_SNAPSHOT_MARKER_MISSING"
+				invalidation_generation=$(_snapshot_invalidation_generation "$kind" "$slug") || invalidation_generation=""
 				record="${kind}|${slug}|${marker}"
+				invalidation_record="${kind}|${slug}|${invalidation_generation}"
 				if [[ -n "$_BATCH_INITIAL_SNAPSHOT_MARKERS" ]]; then
 					_BATCH_INITIAL_SNAPSHOT_MARKERS="${_BATCH_INITIAL_SNAPSHOT_MARKERS}"$'\n'"${record}"
 				else
 					_BATCH_INITIAL_SNAPSHOT_MARKERS="$record"
+				fi
+				if [[ -n "$_BATCH_INITIAL_INVALIDATION_GENERATIONS" ]]; then
+					_BATCH_INITIAL_INVALIDATION_GENERATIONS="${_BATCH_INITIAL_INVALIDATION_GENERATIONS}"$'\n'"${invalidation_record}"
+				else
+					_BATCH_INITIAL_INVALIDATION_GENERATIONS="$invalidation_record"
 				fi
 			done
 		done < <(tr ',' '\n' <<<"$slugs")
@@ -513,13 +615,15 @@ _conditional_rest_update_cache_from_response() {
 	local slug="$2"
 	local response_file="$3"
 	local cache_file="$4"
+	local invalidation_generation="$5"
 	# Keep response parsing in Python so this shell library stays below the
 	# function-complexity gate while preserving atomic cache writes.
 	local projection=""
 	projection=$(_snapshot_projection "$kind") || return 1
 	python3 "${SCRIPT_DIR}/pulse-batch-conditional-cache.py" \
 		"$kind" "$slug" "$response_file" "$cache_file" \
-		"$_BATCH_SNAPSHOT_GENERATION" "$_BATCH_SNAPSHOT_AUTH_SCOPE" "$projection"
+		"$_BATCH_SNAPSHOT_GENERATION" "$_BATCH_SNAPSHOT_AUTH_SCOPE" "$projection" \
+		"$invalidation_generation"
 	return 0
 }
 
@@ -528,7 +632,11 @@ _conditional_rest_refresh_slug_leader() {
 	local slug="$2"
 	local request_key="${3:-}"
 	local generation="${4:-}"
+	local invalidation_generation="${5:-}"
 	[[ "${PULSE_BATCH_CONDITIONAL_REST_ENABLED:-1}" == "1" ]] || return 1
+	if [[ -z "$invalidation_generation" ]]; then
+		invalidation_generation="$(_snapshot_initial_invalidation_generation "$kind" "$slug")" || return 1
+	fi
 	local cache_file
 	cache_file=$(_cache_file_path "$kind" "$slug")
 	local endpoint
@@ -538,9 +646,13 @@ _conditional_rest_refresh_slug_leader() {
 	local etag=""
 	if [[ -f "$cache_file" ]]; then
 		etag=$(jq -r --arg schema "$_SNAPSHOT_SCHEMA" --arg kind "$kind" \
-			--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" '
+			--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" \
+			--arg invalidation_generation "$invalidation_generation" \
+			--arg invalidation_initial "$_BATCH_INVALIDATION_INITIAL" '
 			select(.schema == $schema and .collection == $kind and .projection == $projection) |
-			select(.auth_scope == $auth_scope and .complete == true) | .etag // ""
+			select(.auth_scope == $auth_scope and .complete == true) |
+			select((.invalidation_generation // $invalidation_initial) == $invalidation_generation) |
+			.etag // ""
 		' "$cache_file" 2>/dev/null) || etag=""
 		[[ "$etag" == "$_JSON_NULL" ]] && etag=""
 	fi
@@ -559,8 +671,16 @@ _conditional_rest_refresh_slug_leader() {
 		rm -f "$response_file" "$err_file"
 		return 1
 	fi
-	status=$(_conditional_rest_update_cache_from_response "$kind" "$slug" "$response_file" "$cache_file" 2>/dev/null) || status=""
+	if ! _snapshot_invalidation_generation_is_current "$kind" "$slug" "$invalidation_generation"; then
+		rm -f "$response_file" "$err_file"
+		return 1
+	fi
+	status=$(_conditional_rest_update_cache_from_response "$kind" "$slug" "$response_file" "$cache_file" "$invalidation_generation" 2>/dev/null) || status=""
 	rm -f "$response_file" "$err_file"
+	if [[ -n "$status" ]] && ! _snapshot_invalidation_generation_is_current "$kind" "$slug" "$invalidation_generation"; then
+		_log "conditional REST ${kind}: publication invalidated for ${slug}"
+		return 1
+	fi
 	case "$status" in
 	304)
 		_OWNER_CONDITIONAL_304=$((_OWNER_CONDITIONAL_304 + 1))
@@ -588,18 +708,20 @@ _conditional_rest_refresh_slug() {
 	local projection=""
 	local request_key=""
 	local generation=""
+	local invalidation_generation=""
 	local initial_marker=""
 	local current_marker=""
 	projection=$(_snapshot_projection "$kind") || return 1
+	invalidation_generation="$(_snapshot_initial_invalidation_generation "$kind" "$slug")" || return 1
 	initial_marker=$(_conditional_rest_initial_marker "$kind" "$slug") || {
 		initial_marker=$(_conditional_rest_snapshot_marker "$kind" "$slug") || initial_marker="$_BATCH_SNAPSHOT_MARKER_MISSING"
 	}
 	if ! declare -F gh_request_state_singleflight_begin >/dev/null 2>&1; then
-		_conditional_rest_refresh_slug_leader "$kind" "$slug"
+		_conditional_rest_refresh_slug_leader "$kind" "$slug" "" "" "$invalidation_generation"
 		return $?
 	fi
-	request_key=$(gh_request_state_request_key "$slug" canonical-snapshot "$projection" "$kind" rest-core) || {
-		_conditional_rest_refresh_slug_leader "$kind" "$slug"
+	request_key="$(_snapshot_request_key "$kind" "$slug")" || {
+		_conditional_rest_refresh_slug_leader "$kind" "$slug" "" "" "$invalidation_generation"
 		return $?
 	}
 	gh_request_state_singleflight_begin "$request_key"
@@ -612,7 +734,7 @@ _conditional_rest_refresh_slug() {
 			_log "conditional REST ${kind}: reused concurrently published snapshot for ${slug}"
 			return 0
 		fi
-		if _conditional_rest_refresh_slug_leader "$kind" "$slug" "$request_key" "$generation"; then
+		if _conditional_rest_refresh_slug_leader "$kind" "$slug" "$request_key" "$generation" "$invalidation_generation"; then
 			gh_request_state_singleflight_finish "$request_key" "$generation" success || true
 			return 0
 		fi
@@ -620,12 +742,15 @@ _conditional_rest_refresh_slug() {
 		return 1
 		;;
 	follower-success)
-		_log "conditional REST ${kind}: coalesced shared refresh for ${slug}"
-		return 0
+		if _conditional_rest_snapshot_marker "$kind" "$slug" >/dev/null 2>&1; then
+			_log "conditional REST ${kind}: coalesced shared refresh for ${slug}"
+			return 0
+		fi
+		return 1
 		;;
 	follower-failure | timeout) return 1 ;;
 	bypass)
-		_conditional_rest_refresh_slug_leader "$kind" "$slug"
+		_conditional_rest_refresh_slug_leader "$kind" "$slug" "" "" "$invalidation_generation"
 		return $?
 		;;
 	esac
@@ -659,32 +784,47 @@ _write_per_slug_caches() {
 	local slug
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
+		local invalidation_generation=""
+		invalidation_generation="$(_snapshot_initial_invalidation_generation "$kind" "$slug")" || continue
 		local cache_file
 		cache_file=$(_cache_file_path "$kind" "$slug")
 		local ts
 		ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 		local tmp_file=""
 		tmp_file=$(mktemp "${BATCH_CACHE_DIR}/.search-snapshot.XXXXXX") || continue
-		echo "$normalized_json" | jq --arg slug "$slug" --arg ts "$ts" \
+		if ! printf '%s\n' "$normalized_json" | jq --arg slug "$slug" --arg ts "$ts" \
 			--arg schema "$_SNAPSHOT_SCHEMA" --arg collection "$kind" \
 			--arg projection "$projection" --arg auth_scope "$_BATCH_SNAPSHOT_AUTH_SCOPE" \
-			--arg generation "$_BATCH_SNAPSHOT_GENERATION" '{
+			--arg generation "$_BATCH_SNAPSHOT_GENERATION" \
+			--arg invalidation_generation "$invalidation_generation" '{
 			schema: $schema,
 			repository: $slug,
 			collection: $collection,
 			projection: $projection,
 			auth_scope: $auth_scope,
 			generation: $generation,
+			invalidation_generation: $invalidation_generation,
 			source: "owner-search",
 			complete: false,
 			truncated: true,
 			fetched_at: $ts,
 			timestamp: $ts,
 			items: .[$slug]
-		}' >"$tmp_file" 2>/dev/null && mv "$tmp_file" "$cache_file" || {
+		}' >"$tmp_file" 2>/dev/null; then
 			rm -f "$tmp_file"
 			_log "WARNING: failed to write cache for ${kind}/${slug}"
+			continue
+		fi
+		if ! _snapshot_invalidation_generation_is_current "$kind" "$slug" "$invalidation_generation"; then
+			rm -f "$tmp_file"
+			_log "WARNING: fenced stale cache publication for ${kind}/${slug}"
+			continue
+		fi
+		mv "$tmp_file" "$cache_file" || {
+			rm -f "$tmp_file"
+			continue
 		}
+		_snapshot_invalidation_generation_is_current "$kind" "$slug" "$invalidation_generation" || true
 	done <<<"$slugs"
 	return 0
 }
@@ -978,6 +1118,8 @@ _resolve_cache_snapshot() {
 	local cache_epoch=0
 	local now_epoch=0
 	local age=0
+	local invalidation_generation=""
+	local stored_invalidation_generation=""
 
 	_CACHE_SNAPSHOT_STATE="missing"
 	_CACHE_SNAPSHOT_PATH=""
@@ -989,6 +1131,19 @@ _resolve_cache_snapshot() {
 	cache_file=$(_cache_file_path "$kind" "$slug")
 	_CACHE_SNAPSHOT_PATH="$cache_file"
 	[[ -f "$cache_file" ]] || return 1
+	invalidation_generation="$(_snapshot_invalidation_generation "$kind" "$slug")" || {
+		_CACHE_SNAPSHOT_STATE="$_CACHE_STATE_INVALIDATED"
+		return 1
+	}
+	stored_invalidation_generation=$(jq -er --arg initial "$_BATCH_INVALIDATION_INITIAL" \
+		'.invalidation_generation // $initial' "$cache_file" 2>/dev/null) || {
+		_CACHE_SNAPSHOT_STATE="$_CACHE_STATE_MALFORMED"
+		return 1
+	}
+	if [[ "$stored_invalidation_generation" != "$invalidation_generation" ]]; then
+		_CACHE_SNAPSHOT_STATE="$_CACHE_STATE_INVALIDATED"
+		return 1
+	fi
 
 	cache_ts=$(jq -er '
 		select((.timestamp | type) == "string" and (.timestamp | length) > 0) |
@@ -1265,6 +1420,45 @@ _cmd_evict_issue() {
 }
 
 # =============================================================================
+# Subcommand: invalidate-collection
+# Advance the canonical request generation before removing one repository cache.
+# =============================================================================
+_cmd_invalidate_collection() {
+	local kind=""
+	local slug=""
+	local request_key=""
+	local cache_file=""
+	local _args=("$@")
+	local _i=0
+	while [[ $_i -lt ${#_args[@]} ]]; do
+		case "${_args[$_i]}" in
+		--kind)
+			kind="${_args[$_i+1]:-}"
+			_i=$((_i + 2))
+			;;
+		--slug)
+			slug="${_args[$_i+1]:-}"
+			_i=$((_i + 2))
+			;;
+		*) _i=$((_i + 1)) ;;
+		esac
+	done
+	case "$kind" in
+	"$_KIND_ISSUES" | "$_KIND_PRS") ;;
+	*) return 1 ;;
+	esac
+	[[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+	request_key="$(_snapshot_invalidation_key "$kind" "$slug")" || return 1
+	declare -F gh_request_state_invalidate >/dev/null 2>&1 || return 1
+	gh_request_state_invalidate "$request_key" || return 1
+	cache_file=$(_cache_file_path "$kind" "$slug")
+	rm -f "$cache_file" || return 1
+	_log "invalidated canonical ${kind} snapshot for ${slug}"
+	gh_request_state_invalidation_generation_get "$request_key" || return 1
+	return 0
+}
+
+# =============================================================================
 # Subcommand: clear
 # =============================================================================
 _cmd_clear() {
@@ -1354,6 +1548,9 @@ main() {
 	read-snapshot)
 		_cmd_read_snapshot "$@"
 		;;
+	invalidate-collection)
+		_cmd_invalidate_collection "$@"
+		;;
 	evict-issue)
 		_cmd_evict_issue "$@"
 		;;
@@ -1371,6 +1568,7 @@ main() {
 		echo "  cache-path --kind K --slug S     Return cache path if fresh, exit 1 if stale"
 		echo "  read-cache --kind K --slug S     Read cached items as JSON array"
 		echo "  read-snapshot --kind K --slug S  Read a canonical snapshot envelope"
+		echo "  invalidate-collection --kind K --slug S  Invalidate one canonical collection"
 		echo "  evict-issue owner/repo N         Remove one issue from the issues cache"
 		echo "  clear                            Wipe batch cache directory"
 		echo "  status                           Show cache file ages and counts"

--- a/.agents/scripts/pulse-merge-webhook-receiver.sh
+++ b/.agents/scripts/pulse-merge-webhook-receiver.sh
@@ -13,11 +13,10 @@
 #   - Configuration loaded from .agents/configs/webhook-receiver.conf.
 #   - Secret loaded from the env var named in WEBHOOK_SECRET_ENV
 #     (e.g. GITHUB_WEBHOOK_SECRET, set via gopass or credentials.sh).
-#   - Embedded Python HTTP server (stdlib only) handles request loop:
-#     reads body, validates HMAC, parses JSON, prints ACTION lines on
-#     stdout that the bash parent reads via FIFO and dispatches.
-#   - Each ACTION line: "PROCESS_PR <slug> <pr_number>".
-#   - Unknown events / bad signatures → server returns 4xx, no ACTION.
+#   - Python HTTP server (stdlib only) handles the request loop, records
+#     authenticated delivery IDs, and prints versioned invalidation records
+#     before existing "PROCESS_PR <slug> <pr_number>" action lines.
+#   - Unknown events return 204; bad signatures return 401; neither mutates state.
 #
 # This split (Python parses, bash dispatches) keeps the gh + process_pr
 # call path identical to the polling routine — no duplicated merge logic.
@@ -35,7 +34,7 @@
 #   - Payload URL: https://<your-tunnel>/webhook (Cloudflare Tunnel etc.)
 #   - Content type: application/json
 #   - Secret: the value stored in WEBHOOK_SECRET_ENV
-#   - Events: Check suites, Pull request reviews, Pull requests
+#   - Events: Issues/comments, pull requests/reviews, checks/status/workflows
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -72,6 +71,11 @@ _WEBHOOK_OVERRIDE_EVENTS="${WEBHOOK_HANDLED_EVENTS:-}"
 _WEBHOOK_OVERRIDE_MAX="${WEBHOOK_MAX_BODY_BYTES:-}"
 _WEBHOOK_OVERRIDE_SECRET_ENV="${WEBHOOK_SECRET_ENV:-}"
 _WEBHOOK_OVERRIDE_LOG="${WEBHOOK_LOG_FILE:-}"
+_WEBHOOK_OVERRIDE_LEDGER="${WEBHOOK_DELIVERY_LEDGER_FILE:-}"
+_WEBHOOK_OVERRIDE_LEDGER_TTL="${WEBHOOK_DELIVERY_TTL_SECONDS:-}"
+_WEBHOOK_OVERRIDE_LEDGER_MAX="${WEBHOOK_DELIVERY_MAX_ENTRIES:-}"
+_WEBHOOK_OVERRIDE_CONCURRENCY="${WEBHOOK_DISPATCH_MAX_CONCURRENCY:-}"
+_WEBHOOK_OVERRIDE_PROTOCOL="${WEBHOOK_ACTION_PROTOCOL_VERSION:-}"
 
 # shellcheck source=/dev/null
 source "$WEBHOOK_CONF"
@@ -82,6 +86,11 @@ source "$WEBHOOK_CONF"
 [[ -n "$_WEBHOOK_OVERRIDE_MAX" ]] && WEBHOOK_MAX_BODY_BYTES="$_WEBHOOK_OVERRIDE_MAX"
 [[ -n "$_WEBHOOK_OVERRIDE_SECRET_ENV" ]] && WEBHOOK_SECRET_ENV="$_WEBHOOK_OVERRIDE_SECRET_ENV"
 [[ -n "$_WEBHOOK_OVERRIDE_LOG" ]] && WEBHOOK_LOG_FILE="$_WEBHOOK_OVERRIDE_LOG"
+[[ -n "$_WEBHOOK_OVERRIDE_LEDGER" ]] && WEBHOOK_DELIVERY_LEDGER_FILE="$_WEBHOOK_OVERRIDE_LEDGER"
+[[ -n "$_WEBHOOK_OVERRIDE_LEDGER_TTL" ]] && WEBHOOK_DELIVERY_TTL_SECONDS="$_WEBHOOK_OVERRIDE_LEDGER_TTL"
+[[ -n "$_WEBHOOK_OVERRIDE_LEDGER_MAX" ]] && WEBHOOK_DELIVERY_MAX_ENTRIES="$_WEBHOOK_OVERRIDE_LEDGER_MAX"
+[[ -n "$_WEBHOOK_OVERRIDE_CONCURRENCY" ]] && WEBHOOK_DISPATCH_MAX_CONCURRENCY="$_WEBHOOK_OVERRIDE_CONCURRENCY"
+[[ -n "$_WEBHOOK_OVERRIDE_PROTOCOL" ]] && WEBHOOK_ACTION_PROTOCOL_VERSION="$_WEBHOOK_OVERRIDE_PROTOCOL"
 
 # Load credentials.sh (provides the webhook secret env var if not from gopass).
 if [[ -f "${HOME}/.config/aidevops/credentials.sh" ]]; then
@@ -90,6 +99,13 @@ if [[ -f "${HOME}/.config/aidevops/credentials.sh" ]]; then
 fi
 
 WEBHOOK_LOG_FILE="${WEBHOOK_LOG_FILE:-${HOME}/.aidevops/logs/pulse-merge-webhook.log}"
+WEBHOOK_HANDLED_EVENTS="${WEBHOOK_HANDLED_EVENTS:-check_run,check_suite,status,workflow_run,issues,issue_comment,pull_request,pull_request_review,pull_request_review_comment,pull_request_review_thread}"
+WEBHOOK_DELIVERY_LEDGER_FILE="${WEBHOOK_DELIVERY_LEDGER_FILE:-${HOME}/.aidevops/state/pulse-merge-webhook-deliveries.json}"
+WEBHOOK_DELIVERY_TTL_SECONDS="${WEBHOOK_DELIVERY_TTL_SECONDS:-604800}"
+WEBHOOK_DELIVERY_MAX_ENTRIES="${WEBHOOK_DELIVERY_MAX_ENTRIES:-4096}"
+WEBHOOK_DISPATCH_MAX_CONCURRENCY="${WEBHOOK_DISPATCH_MAX_CONCURRENCY:-4}"
+WEBHOOK_ACTION_PROTOCOL_VERSION="${WEBHOOK_ACTION_PROTOCOL_VERSION:-v1}"
+_WEBHOOK_INVALIDATION_FAILED=0
 mkdir -p "$(dirname "$WEBHOOK_LOG_FILE")"
 
 _whlog() {
@@ -105,6 +121,7 @@ _whlog() {
 # We never log the secret itself — only whether it is set.
 _resolve_secret() {
 	local env_var_name="${WEBHOOK_SECRET_ENV:-GITHUB_WEBHOOK_SECRET}"
+	[[ "$env_var_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
 	# shellcheck disable=SC2086
 	local secret_val="${!env_var_name:-}"
 	if [[ -z "$secret_val" ]]; then
@@ -117,6 +134,125 @@ _resolve_secret() {
 	return 0
 }
 
+_clear_webhook_secret_env() {
+	local env_var_name="${WEBHOOK_SECRET_ENV:-GITHUB_WEBHOOK_SECRET}"
+	[[ "$env_var_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	unset "$env_var_name"
+	return 0
+}
+
+_webhook_positive_integer() {
+	local value="$1"
+	[[ "$value" =~ ^[0-9]+$ && "$value" -gt 0 ]]
+	return $?
+}
+
+_webhook_valid_slug() {
+	local slug="$1"
+	local owner="${slug%%/*}"
+	local name="${slug#*/}"
+	[[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+	[[ "$owner" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] || return 1
+	[[ "$name" != "." && "$name" != ".." ]]
+	return $?
+}
+
+_webhook_invalidate_collection() {
+	local kind="$1"
+	local slug="$2"
+	local helper="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
+	case "$kind" in
+	issues | prs) ;;
+	*) return 1 ;;
+	esac
+	_webhook_valid_slug "$slug" || return 1
+	[[ -x "$helper" ]] || return 1
+	if ! "$helper" invalidate-collection --kind "$kind" --slug "$slug" >/dev/null 2>>"$WEBHOOK_LOG_FILE"; then
+		return 1
+	fi
+	_whlog INFO "Invalidated canonical ${kind} snapshot for ${slug}"
+	return 0
+}
+
+_webhook_invalidate_checks() {
+	local slug="$1"
+	local sha="$2"
+	_webhook_valid_slug "$slug" || return 1
+	[[ "$sha" =~ ^[A-Fa-f0-9]{40}$ ]] || return 1
+	declare -F gh_pr_check_status_cache_invalidate >/dev/null 2>&1 || return 1
+	gh_pr_check_status_cache_invalidate "$slug" "$sha" || return 1
+	_whlog INFO "Invalidated exact-SHA check snapshot for ${slug}"
+	return 0
+}
+
+_webhook_wait_for_dispatch_slot() {
+	local max_concurrency="${WEBHOOK_DISPATCH_MAX_CONCURRENCY:-4}"
+	_webhook_positive_integer "$max_concurrency" || max_concurrency=4
+	while [[ "$(jobs -rp | wc -l)" -ge "$max_concurrency" ]]; do
+		sleep 0.2
+	done
+	return 0
+}
+
+_dispatch_webhook_action_line() {
+	local line="$1"
+	local verb="" version="" scope="" first="" second="" extra=""
+	case "$line" in
+	'#'*)
+		_whlog INFO "${line#'# '}"
+		[[ "$line" == '# accepted '* ]] && _WEBHOOK_INVALIDATION_FAILED=0
+		return 0
+		;;
+	'') return 0 ;;
+	esac
+	IFS=' ' read -r verb version scope first second extra <<<"$line"
+	case "${verb} ${version} ${scope}" in
+	"INVALIDATE v1 collection")
+		_WEBHOOK_INVALIDATION_FAILED=0
+		if [[ -n "$extra" ]] || ! _webhook_invalidate_collection "$first" "$second"; then
+			_WEBHOOK_INVALIDATION_FAILED=1
+			_whlog ERROR "Rejected or failed collection invalidation record"
+		fi
+		return 0
+		;;
+	"INVALIDATE v1 checks")
+		_WEBHOOK_INVALIDATION_FAILED=0
+		if [[ -n "$extra" ]] || ! _webhook_invalidate_checks "$first" "$second"; then
+			_WEBHOOK_INVALIDATION_FAILED=1
+			_whlog ERROR "Rejected or failed check invalidation record"
+		fi
+		return 0
+		;;
+	esac
+	if [[ "$verb" == "PROCESS_PR" && -n "$version" && -n "$scope" \
+		&& -z "$first" && -z "$second" && -z "$extra" ]]; then
+		local slug="$version"
+		local pr_number="$scope"
+		if ! _webhook_valid_slug "$slug" \
+			|| [[ ! "$pr_number" =~ ^[0-9]+$ || "$pr_number" -le 0 ]]; then
+			_whlog WARN "Malformed PROCESS_PR action"
+			return 0
+		fi
+		if [[ "$_WEBHOOK_INVALIDATION_FAILED" == "1" ]]; then
+			_whlog WARN "Skipped process_pr because canonical invalidation failed; polling remains active"
+			return 0
+		fi
+		_whlog INFO "Dispatching process_pr ${slug}#${pr_number}"
+		(
+			set +e
+			process_pr "$slug" "$pr_number"
+			_whlog INFO "process_pr ${slug}#${pr_number} returned ${?}"
+		) &
+		_webhook_wait_for_dispatch_slot
+		return 0
+	fi
+	if [[ "$verb" == "INVALIDATE" || "$verb" == "DELIVERY" ]]; then
+		_WEBHOOK_INVALIDATION_FAILED=1
+	fi
+	_whlog WARN "Unknown line from server"
+	return 0
+}
+
 # =============================================================================
 # Subcommand: --check (config + secret validation, no listener)
 # =============================================================================
@@ -125,8 +261,34 @@ cmd_check() {
 	local errors=0
 	printf 'webhook-receiver config: %s\n' "$WEBHOOK_CONF"
 	printf '  listen:  %s:%s\n' "${WEBHOOK_LISTEN_HOST:-127.0.0.1}" "${WEBHOOK_LISTEN_PORT:-9301}"
-	printf '  events:  %s\n' "${WEBHOOK_HANDLED_EVENTS:-check_suite,pull_request_review,pull_request}"
+	printf '  events:  %s\n' "${WEBHOOK_HANDLED_EVENTS}"
+	printf '  protocol: %s\n' "$WEBHOOK_ACTION_PROTOCOL_VERSION"
 	printf '  log:     %s\n' "$WEBHOOK_LOG_FILE"
+	printf '  ledger:  %s (ttl=%ss, max=%s)\n' \
+		"$WEBHOOK_DELIVERY_LEDGER_FILE" "$WEBHOOK_DELIVERY_TTL_SECONDS" "$WEBHOOK_DELIVERY_MAX_ENTRIES"
+	case "${WEBHOOK_LISTEN_HOST:-127.0.0.1}" in
+	127.0.0.1 | ::1) ;;
+	*)
+		printf '  listen:  INVALID — loopback host required\n' >&2
+		errors=$((errors + 1))
+		;;
+	esac
+	if [[ "$WEBHOOK_ACTION_PROTOCOL_VERSION" != "v1" ]]; then
+		printf '  protocol: INVALID — expected v1\n' >&2
+		errors=$((errors + 1))
+	fi
+	local numeric_value=""
+	for numeric_value in \
+		"${WEBHOOK_LISTEN_PORT:-9301}" \
+		"${WEBHOOK_MAX_BODY_BYTES:-1048576}" \
+		"$WEBHOOK_DELIVERY_TTL_SECONDS" \
+		"$WEBHOOK_DELIVERY_MAX_ENTRIES" \
+		"$WEBHOOK_DISPATCH_MAX_CONCURRENCY"; do
+		if ! _webhook_positive_integer "$numeric_value"; then
+			printf '  numeric config: INVALID (%s)\n' "$numeric_value" >&2
+			errors=$((errors + 1))
+		fi
+	done
 
 	local secret
 	secret=$(_resolve_secret)
@@ -158,21 +320,26 @@ cmd_check() {
 
 cmd_run() {
 	local secret
+	if [[ "$WEBHOOK_ACTION_PROTOCOL_VERSION" != "v1" ]]; then
+		printf 'webhook-receiver: unsupported action protocol %s\n' "$WEBHOOK_ACTION_PROTOCOL_VERSION" >&2
+		return 1
+	fi
 	secret=$(_resolve_secret)
 	if [[ -z "$secret" ]]; then
 		_whlog ERROR "Cannot start: webhook secret env var ${WEBHOOK_SECRET_ENV} not set"
 		printf 'webhook-receiver: secret %s not set; refusing to start\n' "${WEBHOOK_SECRET_ENV}" >&2
 		return 1
 	fi
+	_clear_webhook_secret_env || return 1
 
 	# Make config available to the Python child via env vars (avoid arg leakage).
 	export WEBHOOK_LISTEN_HOST="${WEBHOOK_LISTEN_HOST:-127.0.0.1}"
 	export WEBHOOK_LISTEN_PORT="${WEBHOOK_LISTEN_PORT:-9301}"
-	export WEBHOOK_HANDLED_EVENTS="${WEBHOOK_HANDLED_EVENTS:-check_suite,pull_request_review,pull_request}"
+	export WEBHOOK_HANDLED_EVENTS
 	export WEBHOOK_MAX_BODY_BYTES="${WEBHOOK_MAX_BODY_BYTES:-1048576}"
-	export WEBHOOK_LOG_FILE
-	# Pass the secret only via env to the python child (single-process; not exec'd).
-	export _PULSE_WEBHOOK_SECRET="$secret"
+	export WEBHOOK_LOG_FILE WEBHOOK_DELIVERY_LEDGER_FILE
+	export WEBHOOK_DELIVERY_TTL_SECONDS WEBHOOK_DELIVERY_MAX_ENTRIES
+	export WEBHOOK_ACTION_PROTOCOL_VERSION
 
 	_whlog INFO "Starting receiver on ${WEBHOOK_LISTEN_HOST}:${WEBHOOK_LISTEN_PORT} (events=${WEBHOOK_HANDLED_EVENTS})"
 
@@ -180,6 +347,8 @@ cmd_run() {
 	# callable from the dispatch loop below. We mirror pulse-merge-routine.sh.
 	# shellcheck source=/dev/null
 	source "${SCRIPT_DIR}/shared-constants.sh"
+	# shellcheck source=/dev/null
+	source "${SCRIPT_DIR}/shared-gh-wrappers-checks.sh"
 	# shellcheck source=/dev/null
 	source "${SCRIPT_DIR}/config-helper.sh" 2>/dev/null || true
 	# shellcheck source=/dev/null
@@ -195,47 +364,11 @@ cmd_run() {
 	# shellcheck source=/dev/null
 	source "${SCRIPT_DIR}/pulse-merge-feedback.sh"
 
-	# The Python server prints one ACTION line per accepted webhook to stdout:
-	#   PROCESS_PR <slug> <pr_number>
-	# Lines starting with "#" are diagnostic logs we forward to the log file.
-	# We pipe its stdout into a while-read loop that calls process_pr.
+	# Invalidation records are emitted before PROCESS_PR lines for each delivery.
+	# The secret is scoped only to the Python server process.
 	while IFS= read -r line; do
-		case "$line" in
-		'#'*)
-			_whlog INFO "${line#'# '}"
-			;;
-		PROCESS_PR\ *)
-			# Parse: PROCESS_PR <slug> <pr_number>
-			# shellcheck disable=SC2086
-			set -- $line
-			local _slug="${2:-}"
-			local _pr="${3:-}"
-			if [[ -z "$_slug" || -z "$_pr" ]]; then
-				_whlog WARN "Malformed ACTION line: ${line}"
-				continue
-			fi
-			_whlog INFO "Dispatching process_pr ${_slug}#${_pr}"
-			# Run in a subshell so a failure inside process_pr cannot
-			# crash the receiver loop (set -e considerations, etc.).
-			(
-				set +e
-				process_pr "$_slug" "$_pr"
-				_whlog INFO "process_pr ${_slug}#${_pr} returned ${?}"
-			) &
-			# Cap concurrency at 4 in-flight dispatches to avoid
-			# saturating the GitHub API on bursty webhook deliveries.
-			while [[ "$(jobs -rp | wc -l)" -ge 4 ]]; do
-				sleep 0.2
-			done
-			;;
-		'')
-			:
-			;;
-		*)
-			_whlog WARN "Unknown line from server: ${line}"
-			;;
-		esac
-	done < <(python3 -u "${SCRIPT_DIR}/pulse-merge-webhook-receiver.sh" --__server)
+		_dispatch_webhook_action_line "$line"
+	done < <(_PULSE_WEBHOOK_SECRET="$secret" python3 -u "${SCRIPT_DIR}/pulse-merge-webhook-server.py")
 
 	_whlog WARN "Server stdout loop exited"
 	wait
@@ -249,7 +382,7 @@ cmd_run() {
 # under the function-complexity gate. Stdout = ACTION protocol.
 
 cmd_server() {
-	exec python3 "${SCRIPT_DIR}/pulse-merge-webhook-server.py"
+	exec python3 -u "${SCRIPT_DIR}/pulse-merge-webhook-server.py"
 }
 
 # =============================================================================
@@ -274,9 +407,10 @@ Secret:
   Or in ~/.config/aidevops/credentials.sh (mode 600).
 
 Events handled:
-  - check_suite.completed (conclusion=success)
-  - pull_request_review.submitted (state in: approved, changes_requested)
-  - pull_request.labeled (auto-dispatch, coderabbit-nits-ok, ai-approved)
+  - Issue and issue-comment mutations invalidate the issue or PR collection.
+  - Pull-request and review mutations invalidate the PR collection.
+  - Check-run, check-suite, status, and workflow changes invalidate an exact SHA.
+  - Eligible successful checks, approvals, and merge labels may also call process_pr.
 
 Backstop:
   pulse-merge-routine.sh's 120s polling loop continues to run regardless
@@ -290,7 +424,7 @@ GitHub-side setup:
     - Payload URL: https://<your-tunnel>/webhook
     - Content type: application/json
     - Secret: same value as the env var above
-    - Events: Check suites, Pull request reviews, Pull requests
+    - Events: ${WEBHOOK_HANDLED_EVENTS}
 
 Logs:
   ${WEBHOOK_LOG_FILE}
@@ -312,7 +446,7 @@ main() {
 		cmd_check
 		;;
 	--__server)
-		# Internal: invoked by cmd_run via the python pipe.
+		# Internal diagnostic entry point for the Python server.
 		cmd_server
 		;;
 	help | -h | --help)
@@ -327,5 +461,7 @@ main() {
 	return 0
 }
 
-main "$@"
-exit $?
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+	exit $?
+fi

--- a/.agents/scripts/pulse-merge-webhook-server.py
+++ b/.agents/scripts/pulse-merge-webhook-server.py
@@ -65,6 +65,7 @@ LEDGER_FILE = Path(
 )
 
 _LEDGER_SCHEMA = "aidevops-webhook-deliveries/v1"
+_LEDGER_STRING_FIELDS = ("id", "event", "payload_sha256", "outcome")
 _ACTION_PROTOCOL = os.environ.get("WEBHOOK_ACTION_PROTOCOL_VERSION", "v1")
 _DELIVERY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _EVENT_RE = re.compile(r"^[a-z0-9_]{1,64}$")
@@ -362,6 +363,14 @@ def _invalidation_records(event: str, payload: dict[str, Any]) -> list[str]:
     return records
 
 
+def _ledger_entry_is_valid(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    if not isinstance(entry.get("received_at"), int):
+        return False
+    return all(isinstance(entry.get(field), str) for field in _LEDGER_STRING_FIELDS)
+
+
 def _load_ledger() -> dict[str, Any]:
     if not LEDGER_FILE.exists():
         return {"schema": _LEDGER_SCHEMA, "deliveries": []}
@@ -373,14 +382,7 @@ def _load_ledger() -> dict[str, Any]:
     if not isinstance(deliveries, list):
         raise ValueError("invalid delivery ledger entries")
     for entry in deliveries:
-        if (
-            not isinstance(entry, dict)
-            or not isinstance(entry.get("id"), str)
-            or not isinstance(entry.get("received_at"), int)
-            or not isinstance(entry.get("event"), str)
-            or not isinstance(entry.get("payload_sha256"), str)
-            or not isinstance(entry.get("outcome"), str)
-        ):
+        if not _ledger_entry_is_valid(entry):
             raise ValueError("invalid delivery ledger entry")
     return ledger
 

--- a/.agents/scripts/pulse-merge-webhook-server.py
+++ b/.agents/scripts/pulse-merge-webhook-server.py
@@ -1,217 +1,645 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Embedded HTTP server for pulse-merge-webhook-receiver.sh (t3038).
+"""Authenticated GitHub webhook receiver for pulse merge invalidation.
 
-Reads webhook deliveries on the loopback address, validates the GitHub
-HMAC SHA-256 signature, decodes the JSON payload, and prints one
-``PROCESS_PR <slug> <pr_number>`` line per affected PR on stdout. The
-parent shell script reads stdout and dispatches to ``process_pr``.
-
-Lines starting with ``# `` are diagnostic logs the parent forwards to
-``WEBHOOK_LOG_FILE``.
-
-This file is split out of the receiver to keep the shell wrapper small
-enough for the function-complexity gate (<= 100 lines per function).
+The HTTP boundary verifies the raw request body before parsing or persisting
+request-derived data. Accepted deliveries are recorded in a private, bounded,
+atomic ledger before versioned invalidation records and PROCESS_PR actions are
+written to stdout for the Bash dispatcher.
 """
 
+from __future__ import annotations
+
+from contextlib import contextmanager
+import fcntl
 import hashlib
 import hmac
 import json
 import os
 import re
+import socket
 import sys
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Iterator
 
-LISTEN_HOST = os.environ.get("WEBHOOK_LISTEN_HOST", "127.0.0.1")
-LISTEN_PORT = int(os.environ.get("WEBHOOK_LISTEN_PORT", "9301"))
-HANDLED_EVENTS = {
-    e.strip()
-    for e in os.environ.get(
+
+def _env_int(name: str, default: int, minimum: int, maximum: int) -> int:
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+    return min(maximum, max(minimum, value))
+
+
+HOST = os.environ.get("WEBHOOK_LISTEN_HOST", "127.0.0.1")
+PORT = _env_int("WEBHOOK_LISTEN_PORT", 9301, 1, 65535)
+MAX_BODY = _env_int("WEBHOOK_MAX_BODY_BYTES", 1_048_576, 1, 10_485_760)
+HANDLED = {
+    event.strip()
+    for event in os.environ.get(
         "WEBHOOK_HANDLED_EVENTS",
-        "check_suite,pull_request_review,pull_request",
+        "check_run,check_suite,status,workflow_run,issues,issue_comment,"
+        "pull_request,pull_request_review,pull_request_review_comment,"
+        "pull_request_review_thread",
     ).split(",")
-    if e.strip()
+    if event.strip()
 }
-MAX_BODY_BYTES = int(os.environ.get("WEBHOOK_MAX_BODY_BYTES", "1048576"))
 SECRET = os.environ.get("_PULSE_WEBHOOK_SECRET", "").encode("utf-8")
+LEDGER_TTL_SECONDS = _env_int("WEBHOOK_DELIVERY_TTL_SECONDS", 604_800, 60, 31_536_000)
+LEDGER_MAX_ENTRIES = _env_int("WEBHOOK_DELIVERY_MAX_ENTRIES", 4096, 16, 100_000)
+_DEFAULT_STATE_DIR = os.environ.get(
+    "AIDEVOPS_STATE_DIR", str(Path.home() / ".aidevops" / "state")
+)
+LEDGER_FILE = Path(
+    os.path.expanduser(
+        os.environ.get(
+            "WEBHOOK_DELIVERY_LEDGER_FILE",
+            str(Path(_DEFAULT_STATE_DIR) / "pulse-merge-webhook-deliveries.json"),
+        )
+    )
+)
 
-LABEL_TRIGGERS = {"auto-dispatch", "coderabbit-nits-ok", "ai-approved"}
+_LEDGER_SCHEMA = "aidevops-webhook-deliveries/v1"
+_ACTION_PROTOCOL = os.environ.get("WEBHOOK_ACTION_PROTOCOL_VERSION", "v1")
+_DELIVERY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_EVENT_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_SHA_RE = re.compile(r"^[A-Fa-f0-9]{40}$")
+_ALLOWED_LABELS = {"auto-dispatch", "coderabbit-nits-ok", "ai-approved"}
+_EVENT_ACTIONS = {
+    "check_run": {"completed", "created", "requested_action", "rerequested"},
+    "check_suite": {"completed", "requested", "rerequested"},
+    "issue_comment": {"created", "deleted", "edited"},
+    "issues": {
+        "assigned",
+        "closed",
+        "deleted",
+        "demilestoned",
+        "edited",
+        "labeled",
+        "locked",
+        "milestoned",
+        "opened",
+        "pinned",
+        "reopened",
+        "transferred",
+        "typed",
+        "unassigned",
+        "unlabeled",
+        "unlocked",
+        "unpinned",
+        "untyped",
+    },
+    "pull_request": {
+        "assigned",
+        "auto_merge_disabled",
+        "auto_merge_enabled",
+        "closed",
+        "converted_to_draft",
+        "dequeued",
+        "demilestoned",
+        "edited",
+        "enqueued",
+        "labeled",
+        "locked",
+        "milestoned",
+        "opened",
+        "ready_for_review",
+        "reopened",
+        "review_request_removed",
+        "review_requested",
+        "synchronize",
+        "unassigned",
+        "unlabeled",
+        "unlocked",
+    },
+    "pull_request_review": {"dismissed", "edited", "submitted"},
+    "pull_request_review_comment": {"created", "deleted", "edited"},
+    "pull_request_review_thread": {"resolved", "unresolved"},
+    "workflow_run": {"completed", "in_progress", "requested"},
+}
+_STATUS_STATES = {"error", "failure", "pending", "success"}
+_LEDGER_LOCK = threading.Lock()
+_OUTPUT_LOCK = threading.Lock()
 
-# Payload key constants (deduplicated to satisfy aidevops string-literal ratchet).
-KEY_ACTION = "action"
-KEY_NUMBER = "number"
-KEY_PR = "pull_request"
-KEY_REVIEW = "review"
-KEY_REPO = "repository"
-KEY_CHECK_SUITE = "check_suite"
-KEY_LABEL = "label"
-KEY_NAME = "name"
+
+def _log(message: str) -> None:
+    with _OUTPUT_LOCK:
+        sys.stdout.write(f"# {message}\n")
+        sys.stdout.flush()
 
 
-def _emit_log(msg):
-    """Forward a diagnostic line to the parent shell log."""
-    sys.stdout.write(f"# {msg}\n")
-    sys.stdout.flush()
+def _repository_slug(payload: dict[str, Any]) -> str | None:
+    repository = payload.get("repository")
+    if not isinstance(repository, dict):
+        return None
+    slug = repository.get("full_name")
+    if not isinstance(slug, str) or not _SLUG_RE.fullmatch(slug):
+        return None
+    owner, name = slug.split("/", 1)
+    if not owner[0].isalnum() or owner in {".", ".."} or name in {".", ".."}:
+        return None
+    return slug
 
 
-def _emit_action(slug, pr_number):
-    """Print one ACTION line that the bash dispatcher reads."""
-    sys.stdout.write(f"PROCESS_PR {slug} {pr_number}\n")
-    sys.stdout.flush()
-
-
-def _verify_signature(body_bytes, header_sig):
-    if not SECRET:
-        return False
-    if not header_sig or not header_sig.startswith("sha256="):
-        return False
-    expected = "sha256=" + hmac.new(SECRET, body_bytes, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, header_sig)
-
-
-def _slug_from_payload(payload):
-    repo = payload.get(KEY_REPO) or {}
-    full = repo.get("full_name")
-    if isinstance(full, str) and "/" in full:
-        if re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", full):
-            return full
+def _pull_number(value: Any) -> int | None:
+    if not isinstance(value, dict):
+        return None
+    number = value.get("number")
+    if isinstance(number, int) and number > 0:
+        return number
     return None
 
 
-def _pr_num(obj):
-    num = obj.get(KEY_NUMBER) if isinstance(obj, dict) else None
-    return num if isinstance(num, int) and num > 0 else None
-
-
-def _prs_check_suite(payload, slug):
-    if payload.get(KEY_ACTION) != "completed":
+def _attached_pull_numbers(payload: dict[str, Any], key: str) -> list[int]:
+    container = payload.get(key)
+    if not isinstance(container, dict):
         return []
-    cs = payload.get(KEY_CHECK_SUITE) or {}
-    if cs.get("conclusion") != "success":
+    pulls = container.get("pull_requests")
+    if not isinstance(pulls, list):
         return []
-    out = []
-    for pr in cs.get("pull_requests") or []:
-        num = _pr_num(pr)
-        if num:
-            out.append((slug, num))
-    return out
+    numbers = {_pull_number(pull) for pull in pulls}
+    return sorted(number for number in numbers if number is not None)
 
 
-def _prs_review(payload, slug):
-    if payload.get(KEY_ACTION) != "submitted":
-        return []
-    review = payload.get(KEY_REVIEW) or {}
-    state = (review.get("state") or "").lower()
-    if state not in ("approved", "changes_requested"):
-        return []
-    num = _pr_num(payload.get(KEY_PR))
-    return [(slug, num)] if num else []
+def _attached_pulls_are_valid(payload: dict[str, Any], key: str) -> bool:
+    container = payload.get(key)
+    if not isinstance(container, dict):
+        return False
+    pulls = container.get("pull_requests", [])
+    return isinstance(pulls, list) and all(_pull_number(pull) is not None for pull in pulls)
 
 
-def _prs_pr_labeled(payload, slug):
-    if payload.get(KEY_ACTION) != "labeled":
-        return []
-    label = (payload.get(KEY_LABEL) or {}).get(KEY_NAME) or ""
-    if label not in LABEL_TRIGGERS:
-        return []
-    num = _pr_num(payload.get(KEY_PR))
-    return [(slug, num)] if num else []
+def _label_payload_is_valid(payload: dict[str, Any]) -> bool:
+    label = payload.get("label")
+    if not isinstance(label, dict):
+        return False
+    return isinstance(label.get("name"), str)
 
 
-def _prs_from_event(event, payload):
-    """Return list of (slug, pr_number) tuples to dispatch."""
-    slug = _slug_from_payload(payload)
-    if not slug:
-        return []
-    if event == KEY_CHECK_SUITE:
-        return _prs_check_suite(payload, slug)
+def _issue_event_payload_is_valid(event: str, payload: dict[str, Any]) -> bool:
+    if _pull_number(payload.get("issue")) is None:
+        return False
+    if event != "issues":
+        return True
+    if payload.get("action") not in {"labeled", "unlabeled"}:
+        return True
+    return _label_payload_is_valid(payload)
+
+
+def _review_payload_is_valid(payload: dict[str, Any]) -> bool:
+    review = payload.get("review")
+    if not isinstance(review, dict):
+        return False
+    if payload.get("action") != "submitted":
+        return True
+    return str(review.get("state", "")).lower() in {
+        "approved",
+        "changes_requested",
+        "commented",
+        "dismissed",
+        "pending",
+    }
+
+
+def _pull_event_payload_is_valid(event: str, payload: dict[str, Any]) -> bool:
+    if _pull_number(payload.get("pull_request")) is None:
+        return False
     if event == "pull_request_review":
-        return _prs_review(payload, slug)
-    if event == KEY_PR:
-        return _prs_pr_labeled(payload, slug)
-    return []
+        return _review_payload_is_valid(payload)
+    if event != "pull_request":
+        return True
+    if payload.get("action") not in {"labeled", "unlabeled"}:
+        return True
+    return _label_payload_is_valid(payload)
+
+
+def _check_event_payload_is_valid(event: str, payload: dict[str, Any]) -> bool:
+    if _check_sha(event, payload) is None:
+        return False
+    return _attached_pulls_are_valid(payload, event)
+
+
+def _status_event_payload_is_valid(_event: str, payload: dict[str, Any]) -> bool:
+    if payload.get("state") not in _STATUS_STATES:
+        return False
+    return _check_sha("status", payload) is not None
+
+
+def _workflow_event_payload_is_valid(event: str, payload: dict[str, Any]) -> bool:
+    return _check_sha(event, payload) is not None
+
+
+_EVENT_PAYLOAD_VALIDATORS = {
+    "check_run": _check_event_payload_is_valid,
+    "check_suite": _check_event_payload_is_valid,
+    "issue_comment": _issue_event_payload_is_valid,
+    "issues": _issue_event_payload_is_valid,
+    "pull_request": _pull_event_payload_is_valid,
+    "pull_request_review": _pull_event_payload_is_valid,
+    "pull_request_review_comment": _pull_event_payload_is_valid,
+    "pull_request_review_thread": _pull_event_payload_is_valid,
+    "status": _status_event_payload_is_valid,
+    "workflow_run": _workflow_event_payload_is_valid,
+}
+
+
+def _event_payload_is_valid(event: str, payload: dict[str, Any]) -> bool:
+    if _repository_slug(payload) is None:
+        return False
+    if event != "status" and payload.get("action") not in _EVENT_ACTIONS.get(event, set()):
+        return False
+    validator = _EVENT_PAYLOAD_VALIDATORS.get(event)
+    if validator is None:
+        return False
+    return validator(event, payload)
+
+
+def _successful_check_pull_numbers(event: str, payload: dict[str, Any]) -> list[int]:
+    if payload.get("action") != "completed":
+        return []
+    check = payload.get(event)
+    if not isinstance(check, dict):
+        return []
+    if check.get("conclusion") != "success":
+        return []
+    return _attached_pull_numbers(payload, event)
+
+
+def _review_process_pull_numbers(_event: str, payload: dict[str, Any]) -> list[int]:
+    if payload.get("action") != "submitted":
+        return []
+    review = payload.get("review")
+    if not isinstance(review, dict):
+        return []
+    if str(review.get("state", "")).lower() not in {"approved", "changes_requested"}:
+        return []
+    number = _pull_number(payload.get("pull_request"))
+    if number is None:
+        return []
+    return [number]
+
+
+def _label_process_pull_numbers(_event: str, payload: dict[str, Any]) -> list[int]:
+    if payload.get("action") != "labeled":
+        return []
+    label = payload.get("label")
+    if not isinstance(label, dict) or label.get("name") not in _ALLOWED_LABELS:
+        return []
+    number = _pull_number(payload.get("pull_request"))
+    if number is None:
+        return []
+    return [number]
+
+
+_PROCESS_PR_RESOLVERS = {
+    "check_run": _successful_check_pull_numbers,
+    "check_suite": _successful_check_pull_numbers,
+    "pull_request": _label_process_pull_numbers,
+    "pull_request_review": _review_process_pull_numbers,
+}
+
+
+def _process_pr_actions(event: str, payload: dict[str, Any]) -> list[tuple[str, int]]:
+    slug = _repository_slug(payload)
+    if slug is None:
+        return []
+    resolver = _PROCESS_PR_RESOLVERS.get(event)
+    if resolver is None:
+        return []
+    numbers = resolver(event, payload)
+    return [(slug, number) for number in numbers]
+
+
+def _check_sha(event: str, payload: dict[str, Any]) -> str | None:
+    sha: Any = None
+    if event == "check_suite":
+        suite = payload.get("check_suite")
+        sha = suite.get("head_sha") if isinstance(suite, dict) else None
+    elif event == "check_run":
+        check_run = payload.get("check_run")
+        if isinstance(check_run, dict):
+            sha = check_run.get("head_sha")
+            if sha is None and isinstance(check_run.get("check_suite"), dict):
+                sha = check_run["check_suite"].get("head_sha")
+    elif event == "status":
+        sha = payload.get("sha")
+    elif event == "workflow_run":
+        workflow_run = payload.get("workflow_run")
+        sha = workflow_run.get("head_sha") if isinstance(workflow_run, dict) else None
+    if not isinstance(sha, str) or not _SHA_RE.fullmatch(sha):
+        return None
+    return sha.lower()
+
+
+def _invalidation_records(event: str, payload: dict[str, Any]) -> list[str]:
+    slug = _repository_slug(payload)
+    if slug is None:
+        return []
+    records: list[str] = []
+    if event == "issues":
+        records.append(f"INVALIDATE {_ACTION_PROTOCOL} collection issues {slug}")
+    elif event == "issue_comment":
+        issue = payload.get("issue")
+        kind = "prs" if isinstance(issue, dict) and "pull_request" in issue else "issues"
+        records.append(f"INVALIDATE {_ACTION_PROTOCOL} collection {kind} {slug}")
+    elif event in {
+        "pull_request",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "pull_request_review_thread",
+    }:
+        records.append(f"INVALIDATE {_ACTION_PROTOCOL} collection prs {slug}")
+    elif event in {"check_run", "check_suite", "status", "workflow_run"}:
+        sha = _check_sha(event, payload)
+        if sha is not None:
+            records.append(f"INVALIDATE {_ACTION_PROTOCOL} checks {slug} {sha}")
+    return records
+
+
+def _load_ledger() -> dict[str, Any]:
+    if not LEDGER_FILE.exists():
+        return {"schema": _LEDGER_SCHEMA, "deliveries": []}
+    with LEDGER_FILE.open("r", encoding="utf-8") as ledger_handle:
+        ledger = json.load(ledger_handle)
+    if not isinstance(ledger, dict) or ledger.get("schema") != _LEDGER_SCHEMA:
+        raise ValueError("unsupported delivery ledger schema")
+    deliveries = ledger.get("deliveries")
+    if not isinstance(deliveries, list):
+        raise ValueError("invalid delivery ledger entries")
+    for entry in deliveries:
+        if (
+            not isinstance(entry, dict)
+            or not isinstance(entry.get("id"), str)
+            or not isinstance(entry.get("received_at"), int)
+            or not isinstance(entry.get("event"), str)
+            or not isinstance(entry.get("payload_sha256"), str)
+            or not isinstance(entry.get("outcome"), str)
+        ):
+            raise ValueError("invalid delivery ledger entry")
+    return ledger
+
+
+def _write_ledger(ledger: dict[str, Any]) -> None:
+    parent = LEDGER_FILE.parent
+    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=".webhook-ledger.", dir=str(parent))
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as ledger_handle:
+            json.dump(ledger, ledger_handle, separators=(",", ":"), sort_keys=True)
+            ledger_handle.write("\n")
+            ledger_handle.flush()
+            os.fsync(ledger_handle.fileno())
+        os.replace(temporary_path, LEDGER_FILE)
+        try:
+            parent_descriptor = os.open(parent, os.O_RDONLY)
+            try:
+                os.fsync(parent_descriptor)
+            finally:
+                os.close(parent_descriptor)
+        except OSError:
+            # The 0600 temp file is already atomically committed. Some network
+            # filesystems reject directory fsync; do not turn that into a false
+            # pre-action ledger failure after the durable replace succeeded.
+            pass
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+@contextmanager
+def _ledger_process_lock() -> Iterator[None]:
+    parent = LEDGER_FILE.parent
+    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    lock_path = parent / f".{LEDGER_FILE.name}.lock"
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _record_delivery(
+    delivery_id: str,
+    event: str,
+    payload_sha256: str,
+    outcome: str,
+) -> str:
+    now = int(time.time())
+    oldest = now - LEDGER_TTL_SECONDS
+    with _LEDGER_LOCK:
+        with _ledger_process_lock():
+            ledger = _load_ledger()
+            deliveries = [
+                entry
+                for entry in ledger["deliveries"]
+                if oldest <= entry["received_at"] <= now + 300
+            ]
+            deliveries.sort(key=lambda entry: entry["received_at"], reverse=True)
+            for entry in deliveries:
+                if entry["id"] != delivery_id:
+                    continue
+                if entry["payload_sha256"] == payload_sha256 and entry["event"] == event:
+                    return "duplicate"
+                return "conflict"
+            deliveries = deliveries[: max(0, LEDGER_MAX_ENTRIES - 1)]
+            deliveries.insert(
+                0,
+                {
+                    "event": event,
+                    "id": delivery_id,
+                    "outcome": outcome,
+                    "payload_sha256": payload_sha256,
+                    "received_at": now,
+                },
+            )
+            ledger["deliveries"] = deliveries
+            _write_ledger(ledger)
+    return "accepted"
+
+
+def _emit_records(invalidations: list[str], actions: list[tuple[str, int]]) -> None:
+    with _OUTPUT_LOCK:
+        for record in invalidations:
+            sys.stdout.write(f"{record}\n")
+        for slug, number in actions:
+            sys.stdout.write(f"PROCESS_PR {slug} {number}\n")
+        sys.stdout.flush()
+
+
+def _signature_is_valid(body: bytes, signature: str) -> bool:
+    if not signature.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(SECRET, body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(signature, expected)
 
 
 class WebhookHandler(BaseHTTPRequestHandler):
-    def log_message(self, fmt, *args):
-        return  # silence default stderr access log
+    """Verify one delivery and emit its narrow cache invalidations."""
 
-    def _reply(self, code, msg=b""):
-        self.send_response(code)
-        self.send_header("Content-Length", str(len(msg)))
+    server_version = "aidevops-webhook"
+    sys_version = ""
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _send(self, status: int, body: bytes = b"") -> None:
+        self.send_response(status)
         self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
         self.end_headers()
-        if msg:
-            self.wfile.write(msg)
+        if body:
+            self.wfile.write(body)
 
-    def do_POST(self):
-        length, length_error = _content_length(self.headers)
-        if length_error:
-            self._reply(400, length_error)
-            return
-        if length <= 0 or length > MAX_BODY_BYTES:
-            self._reply(413, b"payload too large or empty")
-            return
-
-        body = self.rfile.read(length)
-        sig = self.headers.get("X-Hub-Signature-256", "")
-        event = self.headers.get("X-GitHub-Event", "")
-        delivery = self.headers.get("X-GitHub-Delivery", "-")
-
-        if not _verify_signature(body, sig):
-            _emit_log(f"signature rejected (event={event}, delivery={delivery})")
-            self._reply(401, b"bad signature")
-            return
-
-        if event not in HANDLED_EVENTS:
-            self._reply(204, b"")
-            return
-
-        try:
-            payload = json.loads(body.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            _emit_log(f"json decode failed: {exc!r}")
-            self._reply(400, b"bad json")
-            return
-
-        actions = _prs_from_event(event, payload)
-        if not actions:
-            self._reply(204, b"")
-            return
-
-        for slug, num in actions:
-            _emit_log(f"accepted {event} -> {slug}#{num} (delivery={delivery})")
-            _emit_action(slug, num)
-        self._reply(202, b"accepted")
-
-    def do_GET(self):
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
         if self.path == "/health":
-            self._reply(200, b"ok")
+            self._send(200, b"ok\n")
             return
-        self._reply(404, b"not found")
+        self._send(404)
+
+    def _read_request_body(self) -> bytes | None:
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._send(400)
+            return None
+        if content_length <= 0:
+            self._send(413)
+            return None
+        if content_length > MAX_BODY:
+            self._send(413)
+            return None
+        body = self.rfile.read(content_length)
+        if len(body) != content_length:
+            self._send(400)
+            return None
+        return body
+
+    def _authenticated_identity(self, body: bytes) -> tuple[str, str] | None:
+        signature = self.headers.get("X-Hub-Signature-256", "")
+        if not _signature_is_valid(body, signature):
+            self._send(401)
+            return None
+        delivery_id = self.headers.get("X-GitHub-Delivery", "")
+        if not _DELIVERY_RE.fullmatch(delivery_id):
+            self._send(400)
+            return None
+        event = self.headers.get("X-GitHub-Event", "")
+        if not _EVENT_RE.fullmatch(event):
+            self._send(400)
+            return None
+        return delivery_id, event
+
+    def _validated_payload(self, event: str, body: bytes) -> dict[str, Any] | None:
+        if event not in HANDLED:
+            self._send(204)
+            return None
+        try:
+            payload = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self._send(400)
+            return None
+        if not isinstance(payload, dict):
+            self._send(400)
+            return None
+        if not _event_payload_is_valid(event, payload):
+            self._send(400)
+            return None
+        return payload
+
+    def _respond_to_replay(self, decision: str, event: str, delivery_id: str) -> bool:
+        if decision == "conflict":
+            _log(f"rejected delivery-id conflict event={event} delivery={delivery_id}")
+            self._send(409)
+            return True
+        if decision == "duplicate":
+            _log(f"duplicate event={event} delivery={delivery_id}")
+            self._send(200, b"duplicate\n")
+            return True
+        return False
+
+    def _accept_delivery(
+        self, body: bytes, delivery_id: str, event: str, payload: dict[str, Any]
+    ) -> None:
+        invalidations = _invalidation_records(event, payload)
+        actions = _process_pr_actions(event, payload)
+        fingerprint = hashlib.sha256(body).hexdigest()
+        outcome = "accepted" if invalidations or actions else "authenticated-noop"
+        # Durable ownership intentionally precedes the one-way shell protocol.
+        # This keeps side effects at-most-once. If local invalidation later
+        # fails, the receiver suppresses process_pr and periodic polling/TTL
+        # supplies the documented recovery path rather than webhook replay.
+        try:
+            decision = _record_delivery(delivery_id, event, fingerprint, outcome)
+        except (OSError, ValueError, json.JSONDecodeError):
+            self._send(500)
+            return
+        if self._respond_to_replay(decision, event, delivery_id):
+            return
+        _emit_records(invalidations, actions)
+        _log(
+            f"accepted event={event} delivery={delivery_id} "
+            f"invalidations={len(invalidations)} actions={len(actions)}"
+        )
+        self._send(200, b"accepted\n")
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        if self.path != "/webhook":
+            self._send(404)
+            return
+        body = self._read_request_body()
+        if body is None:
+            return
+        identity = self._authenticated_identity(body)
+        if identity is None:
+            return
+        delivery_id, event = identity
+        payload = self._validated_payload(event, body)
+        if payload is None:
+            return
+        self._accept_delivery(body, delivery_id, event, payload)
 
 
-def _content_length(headers):
-    try:
-        return int(headers.get("Content-Length", "0") or "0"), b""
-    except (TypeError, ValueError):
-        return 0, b"bad content-length"
+class WebhookServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
 
 
-def main():
+class IPv6WebhookServer(WebhookServer):
+    address_family = socket.AF_INET6
+
+
+def main() -> int:
     if not SECRET:
-        _emit_log("FATAL: secret unavailable in child env")
-        sys.exit(2)
-    server = HTTPServer((LISTEN_HOST, LISTEN_PORT), WebhookHandler)
-    _emit_log(f"listening on {LISTEN_HOST}:{LISTEN_PORT}")
+        print("webhook-server: secret not set", file=sys.stderr)
+        return 1
+    if HOST not in {"127.0.0.1", "::1"}:
+        print("webhook-server: refusing non-loopback listen host", file=sys.stderr)
+        return 1
+    if _ACTION_PROTOCOL != "v1":
+        print("webhook-server: unsupported action protocol", file=sys.stderr)
+        return 1
+    server_class = IPv6WebhookServer if HOST == "::1" else WebhookServer
+    server = server_class((HOST, PORT), WebhookHandler)
+    _log(f"webhook receiver listening on {HOST}:{PORT}")
     try:
         server.serve_forever()
     except KeyboardInterrupt:
-        _emit_log("shutting down (SIGINT)")
+        pass
     finally:
         server.server_close()
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/.agents/scripts/shared-gh-request-state.sh
+++ b/.agents/scripts/shared-gh-request-state.sh
@@ -19,8 +19,11 @@ _SHARED_GH_REQUEST_STATE_LOADED=1
 
 _GHRS_LEASE_SCHEMA="aidevops-gh-request-lease/v1"
 _GHRS_OUTCOME_SCHEMA="aidevops-gh-request-outcome/v1"
+_GHRS_INVALIDATION_SCHEMA="aidevops-gh-request-invalidation/v1"
+_GHRS_INVALIDATION_INITIAL="0000000000000000000000000000000000000000000000000000000000000000"
 _GHRS_RATE_SCHEMA="aidevops-gh-rate-limit-state/v1"
 _GHRS_REQUEST_PROJECTION="request-coordination/v1"
+_GHRS_INVALIDATION_KEY_PROJECTION="request-invalidation-key/v1"
 _GHRS_ROLE_BYPASS="bypass"
 _GHRS_STATUS_SUCCESS="success"
 _GHRS_STATUS_FAILURE="failure"
@@ -94,6 +97,24 @@ gh_request_state_request_key() {
 	return $?
 }
 
+# Return an auth-independent invalidation identity. Request coalescing remains
+# credential-scoped, while a verified repository event fences stale envelopes
+# written by any rotated principal or API pool for the same canonical state.
+gh_request_state_invalidation_key() {
+	local repository="$1"
+	local operation="$2"
+	local projection="$3"
+	local identity="$4"
+	local host="${GH_HOST:-github.com}"
+	local material=""
+	[[ -n "$repository" && -n "$operation" && -n "$projection" && -n "$identity" ]] || return 1
+	material=$(printf '%s\034%s\034%s\034%s\034%s\034%s' \
+		"$_GHRS_INVALIDATION_KEY_PROJECTION" "$host" "$repository" \
+		"$operation" "$projection" "$identity")
+	_ghrs_digest "$material"
+	return $?
+}
+
 _ghrs_base_dir() {
 	local work_dir="${AIDEVOPS_WORK_DIR:-${HOME:+${HOME}/.aidevops/.agent-workspace/work}}"
 	local base_dir="${AIDEVOPS_GH_REQUEST_STATE_DIR:-${work_dir:+${work_dir}/github-request-state}}"
@@ -114,6 +135,87 @@ _ghrs_request_dir() {
 	(umask 077 && mkdir -p "$request_dir") 2>/dev/null || return 1
 	chmod 700 "${base_dir}/requests" "$request_dir" 2>/dev/null || return 1
 	printf '%s\n' "$request_dir"
+	return 0
+}
+
+_ghrs_invalidation_generation_valid() {
+	local generation="$1"
+	[[ "$generation" =~ ^[A-Fa-f0-9]{64}$ ]]
+	return $?
+}
+
+# Return the current invalidation generation for one exact request identity.
+# Missing markers map to a stable initial generation so pre-marker cache entries
+# remain compatible until the first explicit invalidation.
+gh_request_state_invalidation_generation_get() {
+	local key="$1"
+	local request_dir=""
+	local marker_file=""
+	local generation=""
+	[[ "$key" =~ ^[A-Fa-f0-9]{64}$ ]] || return 1
+	request_dir="$(_ghrs_request_dir "$key")" || return 1
+	marker_file="${request_dir}/invalidation.json"
+	if [[ ! -e "$marker_file" ]]; then
+		printf '%s\n' "$_GHRS_INVALIDATION_INITIAL"
+		return 0
+	fi
+	generation=$(jq -er --arg schema "$_GHRS_INVALIDATION_SCHEMA" --arg key "$key" '
+		select(.schema == $schema and .key == $key) |
+		select((.invalidated_at | type) == "number" and (.invalidated_at | floor) == .invalidated_at) |
+		.invalidation_generation
+	' "$marker_file" 2>/dev/null) || return 1
+	_ghrs_invalidation_generation_valid "$generation" || return 1
+	printf '%s\n' "$generation"
+	return 0
+}
+
+gh_request_state_invalidation_generation_is_current() {
+	local key="$1"
+	local generation="$2"
+	local current_generation=""
+	_ghrs_invalidation_generation_valid "$generation" || return 1
+	current_generation=$(gh_request_state_invalidation_generation_get "$key") || return 1
+	[[ "$current_generation" == "$generation" ]]
+	return $?
+}
+
+# Atomically advance one exact request identity before providers remove their
+# cache entry. Late writers retain the old generation in their envelopes and
+# therefore become safe misses even if they publish after the invalidation.
+gh_request_state_invalidate() {
+	local key="$1"
+	local request_dir=""
+	local marker_tmp=""
+	local generation=""
+	local now=""
+	local process_pid=""
+	[[ "$key" =~ ^[A-Fa-f0-9]{64}$ ]] || return 1
+	request_dir="$(_ghrs_request_dir "$key")" || return 1
+	now="$(_ghrs_now)"
+	process_pid="$(_ghrs_pid)" || return 1
+	[[ "$now" =~ ^[0-9]+$ && "$now" -gt 0 ]] || return 1
+	marker_tmp=$(mktemp "${request_dir}/.invalidation.XXXXXX" 2>/dev/null) || return 1
+	generation="$(_ghrs_digest "${key}:${now}:${process_pid}:${marker_tmp}")" || {
+		rm -f "$marker_tmp"
+		return 1
+	}
+	chmod 600 "$marker_tmp" 2>/dev/null || {
+		rm -f "$marker_tmp"
+		return 1
+	}
+	if ! jq -n --arg schema "$_GHRS_INVALIDATION_SCHEMA" --arg key "$key" \
+		--arg generation "$generation" --argjson invalidated_at "$now" \
+		'{schema:$schema,key:$key,invalidation_generation:$generation,
+		invalidated_at:$invalidated_at}' >"$marker_tmp"; then
+		rm -f "$marker_tmp"
+		return 1
+	fi
+	mv "$marker_tmp" "${request_dir}/invalidation.json" 2>/dev/null || {
+		rm -f "$marker_tmp"
+		return 1
+	}
+	rm -f "${request_dir}/outcome.json" 2>/dev/null || true
+	_ghrs_record invalidate
 	return 0
 }
 

--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -67,6 +67,8 @@ _GH_PR_CHECK_STATUS_PROJECTION="check-suites-aggregate/v1"
 _GH_PR_CHECK_STATUS_SOURCE="rest-check-suites"
 _GH_PR_CHECK_STATUS_NONE=none
 _GH_PR_CHECK_STATUS_CACHE_PUT_OK=0
+_GH_PR_CHECK_STATUS_FETCH_INVALIDATED=0
+_GH_PR_CHECK_STATUS_INVALIDATION_INITIAL="${_GHRS_INVALIDATION_INITIAL:-0000000000000000000000000000000000000000000000000000000000000000}"
 
 #######################################
 # Record an observational check-status cache decision without counting an HTTP
@@ -178,6 +180,47 @@ _gh_pr_check_status_cache_key() {
 	return 0
 }
 
+_gh_pr_check_status_request_key() {
+	local slug="$1"
+	local sha="$2"
+	declare -F gh_request_state_request_key >/dev/null 2>&1 || return 1
+	gh_request_state_request_key "$slug" check-suites-aggregate \
+		"$_GH_PR_CHECK_STATUS_PROJECTION" "$sha" rest-core
+	return $?
+}
+
+_gh_pr_check_status_invalidation_key() {
+	local slug="$1"
+	local sha="$2"
+	declare -F gh_request_state_invalidation_key >/dev/null 2>&1 || return 1
+	gh_request_state_invalidation_key "$slug" check-suites-aggregate \
+		"$_GH_PR_CHECK_STATUS_PROJECTION" "$sha"
+	return $?
+}
+
+_gh_pr_check_status_invalidation_generation() {
+	local slug="$1"
+	local sha="$2"
+	local request_key=""
+	if ! declare -F gh_request_state_invalidation_generation_get >/dev/null 2>&1; then
+		printf '%s\n' "$_GH_PR_CHECK_STATUS_INVALIDATION_INITIAL"
+		return 0
+	fi
+	request_key="$(_gh_pr_check_status_invalidation_key "$slug" "$sha")" || return 1
+	gh_request_state_invalidation_generation_get "$request_key"
+	return $?
+}
+
+_gh_pr_check_status_invalidation_generation_is_current() {
+	local slug="$1"
+	local sha="$2"
+	local generation="$3"
+	local invalidation_key=""
+	invalidation_key="$(_gh_pr_check_status_invalidation_key "$slug" "$sha")" || return 1
+	gh_request_state_invalidation_generation_is_current "$invalidation_key" "$generation"
+	return $?
+}
+
 #######################################
 # Resolve a private disposable cache path.
 # Args: $1=repo slug, $2=full head SHA
@@ -211,7 +254,7 @@ _gh_pr_check_status_cache_get() {
 		return 1
 	fi
 
-	local path="" auth_scope="" entry=""
+	local path="" auth_scope="" entry="" invalidation_generation=""
 	path="$(_gh_pr_check_status_cache_path "$slug" "$sha")" || {
 		_gh_pr_check_status_cache_record bypass
 		return 1
@@ -221,15 +264,22 @@ _gh_pr_check_status_cache_get() {
 		return 1
 	}
 	auth_scope="$(_gh_pr_check_status_cache_auth_scope)"
+	invalidation_generation="$(_gh_pr_check_status_invalidation_generation "$slug" "$sha")" || {
+		_gh_pr_check_status_cache_record invalid-invalidation-marker
+		return 1
+	}
 	entry=$(jq -er --arg schema "$_GH_PR_CHECK_STATUS_SCHEMA" \
 		--arg repository "$slug" --arg head_sha "$sha" \
 		--arg projection "$_GH_PR_CHECK_STATUS_PROJECTION" \
 		--arg auth_scope "$auth_scope" --arg source "$_GH_PR_CHECK_STATUS_SOURCE" \
-		--arg none_state "$_GH_PR_CHECK_STATUS_NONE" '
+		--arg none_state "$_GH_PR_CHECK_STATUS_NONE" \
+		--arg invalidation_generation "$invalidation_generation" \
+		--arg invalidation_initial "$_GH_PR_CHECK_STATUS_INVALIDATION_INITIAL" '
 		select(
 			.schema == $schema and .repository == $repository and
 			.head_sha == $head_sha and .projection == $projection and
 			.auth_scope == $auth_scope and .source == $source and
+			(.invalidation_generation // $invalidation_initial) == $invalidation_generation and
 			.validation == "validated" and
 			(.fetched_at | type == "number" and floor == .) and
 			(
@@ -264,17 +314,22 @@ _gh_pr_check_status_cache_get() {
 #######################################
 # Atomically store one validated aggregate observation. Concurrent writers use
 # unique temp files; last-writer-wins is safe for the same immutable identity.
-# Args: $1=repo slug, $2=full head SHA, $3=aggregate state
+# Args: $1=repo slug, $2=full head SHA, $3=aggregate state,
+#       $4=request invalidation generation (optional)
 #######################################
 _gh_pr_check_status_cache_put() {
 	local slug="$1"
 	local sha="$2"
 	local check_state="$3"
+	local invalidation_generation="${4:-}"
 	_GH_PR_CHECK_STATUS_CACHE_PUT_OK=0
 	[[ "${AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE:-0}" != "1" ]] || return 0
 	_gh_pr_check_status_cache_identity_valid "$slug" "$sha" || return 0
 	local expiry_class="" path="" dir="" tmp="" now="" auth_scope=""
 	expiry_class="$(_gh_pr_check_status_cache_class "$check_state")" || return 0
+	if [[ -z "$invalidation_generation" ]]; then
+		invalidation_generation="$(_gh_pr_check_status_invalidation_generation "$slug" "$sha")" || return 0
+	fi
 	path="$(_gh_pr_check_status_cache_path "$slug" "$sha")" || return 0
 	dir="${path%/*}"
 	now="$(_gh_pr_check_status_cache_now)"
@@ -290,10 +345,12 @@ _gh_pr_check_status_cache_put() {
 		--arg projection "$_GH_PR_CHECK_STATUS_PROJECTION" \
 		--arg auth_scope "$auth_scope" --arg state "$check_state" \
 		--arg expiry_class "$expiry_class" --arg source "$_GH_PR_CHECK_STATUS_SOURCE" \
+		--arg invalidation_generation "$invalidation_generation" \
 		--argjson fetched_at "$now" \
 		'{schema:$schema,repository:$repository,head_sha:$head_sha,projection:$projection,
 		auth_scope:$auth_scope,state:$state,fetched_at:$fetched_at,
-		expiry_class:$expiry_class,source:$source,validation:"validated"}' >"$tmp"; then
+		expiry_class:$expiry_class,source:$source,validation:"validated",
+		invalidation_generation:$invalidation_generation}' >"$tmp"; then
 		rm -f "$tmp"
 		return 0
 	fi
@@ -315,8 +372,12 @@ gh_pr_check_status_cache_invalidate() {
 	local slug="$1"
 	local sha="$2"
 	local path=""
+	local request_key=""
+	request_key="$(_gh_pr_check_status_invalidation_key "$slug" "$sha")" || return 1
+	declare -F gh_request_state_invalidate >/dev/null 2>&1 || return 1
+	gh_request_state_invalidate "$request_key" || return 1
 	path="$(_gh_pr_check_status_cache_path "$slug" "$sha")" || return 0
-	rm -f "$path"
+	rm -f "$path" || return 1
 	_gh_pr_check_status_cache_record invalidate
 	return 0
 }
@@ -396,14 +457,22 @@ _gh_pr_check_status_rest_fetch() {
 # Fetch and publish one aggregate observation. A coordinated leader must still
 # own its generation immediately before the cache write.
 # Args: $1=repo slug, $2=full head SHA, $3=request key (optional),
-#       $4=generation (optional)
+#       $4=lease generation (optional), $5=invalidation generation (optional)
 #######################################
 _gh_pr_check_status_fetch_and_cache() {
 	local slug="$1"
 	local sha="$2"
 	local request_key="${3:-}"
 	local generation="${4:-}"
+	local invalidation_generation="${5:-}"
 	local check_state=""
+	_GH_PR_CHECK_STATUS_FETCH_INVALIDATED=0
+	if [[ -z "$request_key" ]]; then
+		request_key="$(_gh_pr_check_status_request_key "$slug" "$sha")" || return 1
+	fi
+	if [[ -z "$invalidation_generation" ]]; then
+		invalidation_generation=$(_gh_pr_check_status_invalidation_generation "$slug" "$sha") || return 1
+	fi
 	_gh_pr_check_status_cache_record fetch
 	if ! check_state="$(_gh_pr_check_status_rest_fetch "$slug" "$sha")"; then
 		_gh_pr_check_status_cache_record fetch-failed
@@ -413,9 +482,23 @@ _gh_pr_check_status_fetch_and_cache() {
 		_gh_pr_check_status_cache_record publish-fenced
 		return 1
 	fi
-	_gh_pr_check_status_cache_put "$slug" "$sha" "$check_state"
+	if ! _gh_pr_check_status_invalidation_generation_is_current "$slug" "$sha" "$invalidation_generation"; then
+		_GH_PR_CHECK_STATUS_FETCH_INVALIDATED=1
+		_gh_pr_check_status_cache_record publish-invalidated
+		return 1
+	fi
+	if [[ "${AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE:-0}" == "1" ]]; then
+		printf '%s\n' "$check_state"
+		return 0
+	fi
+	_gh_pr_check_status_cache_put "$slug" "$sha" "$check_state" "$invalidation_generation"
 	if [[ -n "$request_key" && "$_GH_PR_CHECK_STATUS_CACHE_PUT_OK" != "1" ]]; then
 		_gh_pr_check_status_cache_record publish-failed
+		return 1
+	fi
+	if ! _gh_pr_check_status_invalidation_generation_is_current "$slug" "$sha" "$invalidation_generation"; then
+		_GH_PR_CHECK_STATUS_FETCH_INVALIDATED=1
+		_gh_pr_check_status_cache_record publish-invalidated
 		return 1
 	fi
 	printf '%s\n' "$check_state"
@@ -433,35 +516,48 @@ _gh_pr_check_status_singleflight() {
 	local sha="$2"
 	local request_key=""
 	local generation=""
+	local invalidation_generation=""
 	local check_state=""
+	local attempts=0
 	if [[ "${AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE:-0}" == "1" ]] || ! declare -F gh_request_state_singleflight_begin >/dev/null 2>&1; then
 		_gh_pr_check_status_fetch_and_cache "$slug" "$sha" || printf 'none\n'
 		return 0
 	fi
-	request_key=$(gh_request_state_request_key "$slug" check-suites-aggregate "$_GH_PR_CHECK_STATUS_PROJECTION" "$sha" rest-core) || {
+	request_key="$(_gh_pr_check_status_request_key "$slug" "$sha")" || {
 		_gh_pr_check_status_fetch_and_cache "$slug" "$sha" || printf 'none\n'
 		return 0
 	}
-	gh_request_state_singleflight_begin "$request_key"
-	generation="$_GHRS_BEGIN_GENERATION"
-	case "$_GHRS_BEGIN_ROLE" in
+	while [[ "$attempts" -lt 2 ]]; do
+		attempts=$((attempts + 1))
+		gh_request_state_singleflight_begin "$request_key"
+		generation="$_GHRS_BEGIN_GENERATION"
+		case "$_GHRS_BEGIN_ROLE" in
 	leader)
 		if check_state="$(_gh_pr_check_status_cache_get "$slug" "$sha")"; then
 			gh_request_state_singleflight_finish "$request_key" "$generation" success || true
 			printf '%s\n' "$check_state"
 			return 0
 		fi
-		if _gh_pr_check_status_fetch_and_cache "$slug" "$sha" "$request_key" "$generation"; then
+		invalidation_generation=$(_gh_pr_check_status_invalidation_generation "$slug" "$sha") || invalidation_generation=""
+		if [[ -n "$invalidation_generation" ]] && \
+			_gh_pr_check_status_fetch_and_cache "$slug" "$sha" "$request_key" "$generation" "$invalidation_generation"; then
 			gh_request_state_singleflight_finish "$request_key" "$generation" success || true
 			return 0
 		fi
 		gh_request_state_singleflight_finish "$request_key" "$generation" failure || true
+		if [[ "$_GH_PR_CHECK_STATUS_FETCH_INVALIDATED" == "1" && "$attempts" -lt 2 ]]; then
+			continue
+		fi
 		printf 'none\n'
 		return 0
 		;;
 	follower-success)
 		_gh_pr_check_status_cache_record coalesced
-		_gh_pr_check_status_cache_get "$slug" "$sha" || printf 'none\n'
+		if _gh_pr_check_status_cache_get "$slug" "$sha"; then
+			return 0
+		fi
+		[[ "$attempts" -lt 2 ]] && continue
+		printf 'none\n'
 		return 0
 		;;
 	follower-failure | timeout)
@@ -473,7 +569,8 @@ _gh_pr_check_status_singleflight() {
 		_gh_pr_check_status_fetch_and_cache "$slug" "$sha" || printf 'none\n'
 		return 0
 		;;
-	esac
+		esac
+	done
 	printf 'none\n'
 	return 0
 }

--- a/.agents/scripts/tests/test-gh-check-status-cache.sh
+++ b/.agents/scripts/tests/test-gh-check-status-cache.sh
@@ -27,6 +27,9 @@ API_CALLS="${TEST_ROOT}/api-calls.log"
 CHECK_NOW=100
 CHECK_API_MODE=success
 CHECK_API_DELAY=0
+CHECK_API_FIXTURE_FILE=""
+CHECK_API_WAIT_FILE=""
+CHECK_API_RELEASE_FILE=""
 CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
 
 SHA_A="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -37,6 +40,8 @@ SHA_E="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 SHA_F="ffffffffffffffffffffffffffffffffffffffff"
 SHA_G="1111111111111111111111111111111111111111"
 SHA_H="2222222222222222222222222222222222222222"
+SHA_I="3333333333333333333333333333333333333333"
+SHA_J="4444444444444444444444444444444444444444"
 
 # shellcheck source=../shared-gh-wrappers-checks.sh
 source "$CHECKS_LIB"
@@ -59,6 +64,16 @@ _gh_checks_api_read() {
 	local endpoint="$1"
 	shift
 	printf '%s\n' "$endpoint" >>"$API_CALLS"
+	local fixture="$CHECK_SUITES_FIXTURE"
+	if [[ -n "$CHECK_API_FIXTURE_FILE" && -f "$CHECK_API_FIXTURE_FILE" ]]; then
+		fixture=$(<"$CHECK_API_FIXTURE_FILE")
+	fi
+	if [[ -n "$CHECK_API_WAIT_FILE" && ! -e "$CHECK_API_RELEASE_FILE" ]]; then
+		printf 'waiting\n' >"$CHECK_API_WAIT_FILE"
+		while [[ ! -e "$CHECK_API_RELEASE_FILE" ]]; do
+			sleep 0.01
+		done
+	fi
 	[[ "$CHECK_API_DELAY" == "0" ]] || sleep "$CHECK_API_DELAY"
 
 	case "$CHECK_API_MODE" in
@@ -86,7 +101,18 @@ _gh_checks_api_read() {
 		fi
 	done
 	[[ -n "$jq_filter" ]] || return 1
-	printf '%s\n' "$CHECK_SUITES_FIXTURE" | jq -r "$jq_filter"
+	printf '%s\n' "$fixture" | jq -r "$jq_filter"
+	return $?
+}
+
+wait_for_file() {
+	local path="$1"
+	local attempts=0
+	while [[ ! -s "$path" && "$attempts" -lt 200 ]]; do
+		sleep 0.01
+		attempts=$((attempts + 1))
+	done
+	[[ -s "$path" ]]
 	return $?
 }
 
@@ -326,12 +352,91 @@ test_private_atomic_cache_and_authority_boundary() {
 	return 0
 }
 
+test_invalidation_fences_inflight_publication() {
+	local fixture_file="${TEST_ROOT}/race-fixture.json"
+	local wait_file="${TEST_ROOT}/race-waiting"
+	local release_file="${TEST_ROOT}/race-release"
+	local output_file="${TEST_ROOT}/race-output"
+	local before="" after="" expected="" worker_pid=0 path=""
+	local current_generation="" stored_generation="" result=""
+	CHECK_NOW=900
+	CHECK_API_MODE=success
+	printf '%s\n' '{"check_suites":[{"status":"completed","conclusion":"success"}]}' >"$fixture_file"
+	CHECK_API_FIXTURE_FILE="$fixture_file"
+	CHECK_API_WAIT_FILE="$wait_file"
+	CHECK_API_RELEASE_FILE="$release_file"
+	gh_pr_check_status_cache_invalidate "owner/repo" "$SHA_I"
+	before=$(api_call_count)
+	(gh_pr_check_status_rest "owner/repo" "$SHA_I" >"$output_file") &
+	worker_pid=$!
+	wait_for_file "$wait_file"
+	printf '%s\n' '{"check_suites":[{"status":"completed","conclusion":"failure"}]}' >"$fixture_file"
+	gh_pr_check_status_cache_invalidate "owner/repo" "$SHA_I"
+	printf 'release\n' >"$release_file"
+	wait "$worker_pid"
+	result=$(tr -d '\n' <"$output_file")
+	assert_eq "invalidation fences an in-flight stale publication" "FAIL" "$result"
+	after=$(api_call_count)
+	expected=$((before + 2))
+	assert_eq "fenced publication retries with one fresh transport" "$expected" "$after"
+	path=$(cache_path "owner/repo" "$SHA_I")
+	current_generation=$(_gh_pr_check_status_invalidation_generation "owner/repo" "$SHA_I")
+	stored_generation=$(jq -r '.invalidation_generation' "$path")
+	assert_eq "refreshed cache stores the current invalidation generation" \
+		"$current_generation" "$stored_generation"
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_I")
+	assert_eq "post-invalidation reader reuses only the fresh observation" "FAIL" "$result"
+	assert_eq "fresh post-invalidation read is transport-free" "$after" "$(api_call_count)"
+
+	CHECK_API_FIXTURE_FILE=""
+	CHECK_API_WAIT_FILE=""
+	CHECK_API_RELEASE_FILE=""
+	export AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE=1
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_I")
+	assert_eq "disabled cache still returns the live aggregate observation" "PASS" "$result"
+	unset AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE
+	return 0
+}
+
+test_invalidation_fences_all_auth_scopes() {
+	local before="" after="" expected="" result=""
+	CHECK_NOW=1000
+	CHECK_API_MODE=success
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+	before=$(api_call_count)
+	AIDEVOPS_GH_AUTH_PRINCIPAL=default
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_J")
+	assert_eq "default auth scope seeds a terminal check observation" "PASS" "$result"
+	AIDEVOPS_GH_AUTH_PRINCIPAL=alternate
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"failure"}]}'
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_J")
+	assert_eq "alternate auth scope retains an isolated cache entry" "FAIL" "$result"
+	after=$(api_call_count)
+	expected=$((before + 2))
+	assert_eq "two auth scopes perform two initial transports" "$expected" "$after"
+
+	AIDEVOPS_GH_AUTH_PRINCIPAL=default
+	gh_pr_check_status_cache_invalidate "owner/repo" "$SHA_J"
+	AIDEVOPS_GH_AUTH_PRINCIPAL=alternate
+	CHECK_SUITES_FIXTURE='{"check_suites":[{"status":"completed","conclusion":"success"}]}'
+	result=$(gh_pr_check_status_rest "owner/repo" "$SHA_J")
+	assert_eq "default-scope invalidation fences the alternate scope" "PASS" "$result"
+	after=$(api_call_count)
+	expected=$((expected + 1))
+	assert_eq "alternate scope refreshes after shared invalidation" "$expected" "$after"
+	AIDEVOPS_GH_AUTH_PRINCIPAL=default
+	return 0
+}
+
 main() {
 	test_terminal_reuse_dedup_and_order
 	test_new_head_repo_and_auth_scope_miss
 	test_actionable_and_terminal_expiry
 	test_corruption_failure_and_invalidation
 	test_private_atomic_cache_and_authority_boundary
+	test_invalidation_fences_inflight_publication
+	test_invalidation_fences_all_auth_scopes
 	printf 'PASS: PR check-status cache regression suite\n'
 	return 0
 }

--- a/.agents/scripts/tests/test-gh-request-singleflight.sh
+++ b/.agents/scripts/tests/test-gh-request-singleflight.sh
@@ -126,6 +126,7 @@ singleflight_worker() {
 
 test_scope_key_isolation() {
 	local key_default="" key_repeat="" key_repo="" key_projection="" key_identity="" key_principal="" key_pool=""
+	local invalidation_default="" invalidation_principal="" invalidation_pool="" invalidation_repo=""
 	key_default=$(gh_request_state_request_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rest-core)
 	key_repeat=$(gh_request_state_request_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rest-core)
 	key_repo=$(gh_request_state_request_key other/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rest-core)
@@ -135,6 +136,14 @@ test_scope_key_isolation() {
 	key_principal=$(gh_request_state_request_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rest-core)
 	AIDEVOPS_GH_AUTH_PRINCIPAL=default
 	key_pool=$(gh_request_state_request_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa graphql)
+	invalidation_default=$(gh_request_state_invalidation_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+	invalidation_repo=$(gh_request_state_invalidation_key other/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+	AIDEVOPS_GH_AUTH_PRINCIPAL=alternate
+	invalidation_principal=$(gh_request_state_invalidation_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+	AIDEVOPS_GH_AUTH_PRINCIPAL=default
+	AIDEVOPS_GH_API_POOL=graphql
+	invalidation_pool=$(gh_request_state_invalidation_key owner/repo checks aggregate/v1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+	AIDEVOPS_GH_API_POOL=default
 
 	assert_eq "identical request scope produces a stable key" "$key_default" "$key_repeat"
 	assert_ne "repository changes the request key" "$key_default" "$key_repo"
@@ -142,6 +151,9 @@ test_scope_key_isolation() {
 	assert_ne "immutable identity changes the request key" "$key_default" "$key_identity"
 	assert_ne "auth principal changes the request key" "$key_default" "$key_principal"
 	assert_ne "API pool changes the request key" "$key_default" "$key_pool"
+	assert_ne "repository changes the invalidation key" "$invalidation_default" "$invalidation_repo"
+	assert_eq "auth rotation preserves the canonical invalidation key" "$invalidation_default" "$invalidation_principal"
+	assert_eq "API pool rotation preserves the canonical invalidation key" "$invalidation_default" "$invalidation_pool"
 	return 0
 }
 
@@ -321,6 +333,59 @@ test_ownerless_lease_recovery_and_disabled_mode() {
 	return 0
 }
 
+test_request_invalidation_generations_are_atomic() {
+	local key="" initial="" first="" second="" final="" request_dir="" generation=""
+	local job=0 pid=0
+	local -a pids=()
+	key=$(gh_request_state_request_key owner/repo canonical-snapshot issues/v1 issues rest-core)
+	initial=$(gh_request_state_invalidation_generation_get "$key")
+	assert_eq "missing invalidation marker uses the stable initial generation" \
+		"$_GHRS_INVALIDATION_INITIAL" "$initial"
+
+	gh_request_state_invalidate "$key"
+	first=$(gh_request_state_invalidation_generation_get "$key")
+	assert_ne "explicit invalidation advances the request generation" "$initial" "$first"
+	if ! gh_request_state_invalidation_generation_is_current "$key" "$first"; then
+		printf 'FAIL: current invalidation generation was rejected\n' >&2
+		return 1
+	fi
+	printf 'PASS: current invalidation generation is accepted\n'
+	if gh_request_state_invalidation_generation_is_current "$key" "$initial"; then
+		printf 'FAIL: invalidation retained the prior generation\n' >&2
+		return 1
+	fi
+	printf 'PASS: prior invalidation generation is fenced\n'
+
+	gh_request_state_singleflight_begin "$key"
+	assert_eq "invalidation outcome fixture elects a leader" "leader" "$_GHRS_BEGIN_ROLE"
+	generation="$_GHRS_BEGIN_GENERATION"
+	gh_request_state_singleflight_finish "$key" "$generation" success
+	request_dir="$(_ghrs_request_dir "$key")"
+	[[ -f "${request_dir}/outcome.json" ]] || return 1
+	gh_request_state_invalidate "$key"
+	second=$(gh_request_state_invalidation_generation_get "$key")
+	assert_ne "repeated invalidation cannot reuse a generation" "$first" "$second"
+	assert_eq "invalidation marker remains private" "600" "$(file_mode "${request_dir}/invalidation.json")"
+	assert_eq "invalidation removes stale single-flight outcomes" "false" \
+		"$([[ -e "${request_dir}/outcome.json" ]] && printf true || printf false)"
+
+	for job in 1 2 3 4; do
+		(gh_request_state_invalidate "$key") &
+		pids+=("$!")
+	done
+	for pid in "${pids[@]}"; do
+		wait "$pid"
+	done
+	final=$(gh_request_state_invalidation_generation_get "$key")
+	assert_ne "concurrent invalidations advance beyond the prior marker" "$second" "$final"
+	if compgen -G "${request_dir}/.invalidation.*" >/dev/null; then
+		printf 'FAIL: concurrent invalidation left temporary files behind\n' >&2
+		return 1
+	fi
+	printf 'PASS: concurrent invalidation leaves no temporary files\n'
+	return 0
+}
+
 rate_fixture() {
 	local remaining="$1"
 	local reset_at="$2"
@@ -421,6 +486,7 @@ main() {
 	test_expired_live_leader_is_fenced
 	test_live_leader_wait_is_bounded
 	test_ownerless_lease_recovery_and_disabled_mode
+	test_request_invalidation_generations_are_atomic
 	test_rate_state_validation_scope_and_reset
 	test_relative_rate_path_uses_current_directory
 	test_concurrent_rate_probe_is_singleflight

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -574,6 +574,66 @@ test_concurrent_refreshes_share_canonical_transport() {
 	return 0
 }
 
+test_collection_invalidation_is_narrow_and_refreshable() {
+	setup_env
+	seed_cache
+	local invalidation_generation=""
+	invalidation_generation=$("$HELPER" invalidate-collection --kind issues --slug owner/repo) || invalidation_generation=""
+	local prs_snapshot=""
+	prs_snapshot=$("$HELPER" read-snapshot --kind prs --slug owner/repo 2>/dev/null) || prs_snapshot="{}"
+	local passed=0
+	if [[ -z "$invalidation_generation" ]] \
+		|| [[ -f "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json" ]] \
+		|| "$HELPER" read-snapshot --kind issues --slug owner/repo >/dev/null 2>&1 \
+		|| [[ "$(printf '%s' "$prs_snapshot" | jq -r '.items[0].number // 0')" != "2" ]]; then
+		passed=1
+	fi
+	write_gh_stub changed
+	"$HELPER" refresh >/dev/null
+	local refreshed_generation=""
+	refreshed_generation=$(jq -r '.invalidation_generation // ""' \
+		"$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json")
+	if [[ "$refreshed_generation" != "$invalidation_generation" ]] \
+		|| ! "$HELPER" read-snapshot --kind issues --slug owner/repo >/dev/null 2>&1; then
+		passed=1
+	fi
+	print_result "issue invalidation preserves PR cache and permits a current-generation refresh" "$passed"
+	teardown_env
+	return 0
+}
+
+test_inflight_invalidation_fences_stale_publication() {
+	setup_env
+	seed_cache
+	write_gh_stub changed
+	export STUB_GH_DELAY=1.5
+	local refresh_pid=0 attempts=0
+	"$HELPER" refresh >"$TEST_ROOT/raced-refresh.out" &
+	refresh_pid=$!
+	while ! grep -q '/repos/owner/repo/issues?state=open' "$TEST_ROOT/gh-calls.log" 2>/dev/null; do
+		sleep 0.05
+		attempts=$((attempts + 1))
+		if [[ "$attempts" -ge 100 ]]; then
+			break
+		fi
+	done
+	local invalidation_generation=""
+	if [[ "$attempts" -lt 100 ]]; then
+		invalidation_generation=$("$HELPER" invalidate-collection --kind issues --slug owner/repo) || invalidation_generation=""
+	fi
+	wait "$refresh_pid" || true
+	unset STUB_GH_DELAY
+	local passed=0
+	if [[ -z "$invalidation_generation" ]] \
+		|| [[ -f "$PULSE_BATCH_PREFETCH_CACHE_DIR/issues-owner__repo.json" ]] \
+		|| "$HELPER" read-snapshot --kind issues --slug owner/repo >/dev/null 2>&1; then
+		passed=1
+	fi
+	print_result "in-flight issue invalidation fences stale canonical publication" "$passed"
+	teardown_env
+	return 0
+}
+
 test_prefetch_gh_reads_are_timeout_wrapped() {
 	if prefetch_raw_gh_read_matches "$HELPER"; then
 		print_result "prefetch gh reads use timeout wrapper" 1
@@ -612,6 +672,8 @@ test_paginated_response_is_not_complete
 test_conditional_failure_routes_to_rest_by_default
 test_search_opt_in_preserves_owner_search
 test_concurrent_refreshes_share_canonical_transport
+test_collection_invalidation_is_narrow_and_refreshable
+test_inflight_invalidation_fences_stale_publication
 test_legacy_issue_cache_avoids_search_by_default
 test_read_cache_filters_closed_issues
 test_read_cache_accepts_fresh_empty_arrays

--- a/.agents/scripts/tests/test-pulse-merge-webhook-invalidation.py
+++ b/.agents/scripts/tests/test-pulse-merge-webhook-invalidation.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Signed-fixture tests for webhook deduplication and invalidation ordering."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import hashlib
+import hmac
+import http.client
+import importlib.util
+import json
+import multiprocessing
+import os
+from pathlib import Path
+import socket
+import stat
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+from typing import Any
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = TEST_DIR.parent
+SERVER_PATH = SCRIPTS_DIR / "pulse-merge-webhook-server.py"
+RECEIVER_PATH = SCRIPTS_DIR / "pulse-merge-webhook-receiver.sh"
+
+SERVER_SPEC = importlib.util.spec_from_file_location("pulse_merge_webhook_server", SERVER_PATH)
+if SERVER_SPEC is None or SERVER_SPEC.loader is None:
+    raise RuntimeError("unable to load webhook server module")
+SERVER = importlib.util.module_from_spec(SERVER_SPEC)
+SERVER_SPEC.loader.exec_module(SERVER)
+
+
+def _record_delivery_in_process(arguments: tuple[str, int]) -> str:
+    ledger_path, worker = arguments
+    SERVER.LEDGER_FILE = Path(ledger_path)
+    SERVER.LEDGER_TTL_SECONDS = 3600
+    SERVER.LEDGER_MAX_ENTRIES = 32
+    return SERVER._record_delivery(
+        f"process-delivery-{worker}",
+        "issues",
+        hashlib.sha256(str(worker).encode("utf-8")).hexdigest(),
+        "accepted",
+    )
+
+
+def _record_shared_delivery_in_process(ledger_path: str) -> str:
+    SERVER.LEDGER_FILE = Path(ledger_path)
+    SERVER.LEDGER_TTL_SECONDS = 3600
+    SERVER.LEDGER_MAX_ENTRIES = 32
+    return SERVER._record_delivery(
+        "process-shared-delivery",
+        "issues",
+        hashlib.sha256(b"shared-delivery").hexdigest(),
+        "accepted",
+    )
+
+
+class WebhookInvalidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.ledger = self.root / "state" / "deliveries.json"
+        self.secret = b"signed-fixture-secret"
+        self.records: list[str] = []
+        self.logs: list[str] = []
+        self.original_emit = SERVER._emit_records
+        self.original_log = SERVER._log
+        SERVER.SECRET = self.secret
+        SERVER.LEDGER_FILE = self.ledger
+        SERVER.LEDGER_TTL_SECONDS = 3600
+        SERVER.LEDGER_MAX_ENTRIES = 16
+        SERVER.MAX_BODY = 1_048_576
+        SERVER.HANDLED = {
+            "check_run",
+            "check_suite",
+            "issue_comment",
+            "issues",
+            "pull_request",
+            "pull_request_review",
+            "pull_request_review_comment",
+            "pull_request_review_thread",
+            "status",
+            "workflow_run",
+        }
+
+        def capture_records(invalidations: list[str], actions: list[tuple[str, int]]) -> None:
+            self.records.extend(invalidations)
+            self.records.extend(f"PROCESS_PR {slug} {number}" for slug, number in actions)
+
+        SERVER._emit_records = capture_records
+        SERVER._log = self.logs.append
+        self._start_server()
+
+    def tearDown(self) -> None:
+        self._stop_server()
+        SERVER._emit_records = self.original_emit
+        SERVER._log = self.original_log
+        self.temporary_directory.cleanup()
+
+    def _start_server(self) -> None:
+        self.server = SERVER.WebhookServer(("127.0.0.1", 0), SERVER.WebhookHandler)
+        self.server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.server_thread.start()
+
+    def _stop_server(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.server_thread.join(timeout=5)
+
+    def _request(
+        self,
+        event: str,
+        delivery_id: str,
+        payload: dict[str, Any] | bytes,
+        *,
+        valid_signature: bool = True,
+    ) -> tuple[int, bytes]:
+        body = (
+            payload
+            if isinstance(payload, bytes)
+            else json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        )
+        signature = hmac.new(self.secret, body, hashlib.sha256).hexdigest()
+        if not valid_signature:
+            signature = "0" * 64
+        connection = http.client.HTTPConnection(
+            self.server.server_address[0], self.server.server_address[1], timeout=5
+        )
+        connection.request(
+            "POST",
+            "/webhook",
+            body=body,
+            headers={
+                "Content-Length": str(len(body)),
+                "Content-Type": "application/json",
+                "X-GitHub-Delivery": delivery_id,
+                "X-GitHub-Event": event,
+                "X-Hub-Signature-256": f"sha256={signature}",
+            },
+        )
+        response = connection.getresponse()
+        response_body = response.read()
+        connection.close()
+        return response.status, response_body
+
+    @staticmethod
+    def _repository_payload() -> dict[str, Any]:
+        return {"repository": {"full_name": "owner/repo"}}
+
+    def _issue_payload(self, number: int, **issue_fields: Any) -> dict[str, Any]:
+        payload = self._repository_payload()
+        payload["action"] = "edited"
+        payload["issue"] = {"number": number, **issue_fields}
+        return payload
+
+    def test_health_endpoint_remains_local_and_payload_free(self) -> None:
+        connection = http.client.HTTPConnection(
+            self.server.server_address[0], self.server.server_address[1], timeout=5
+        )
+        connection.request("GET", "/health")
+        response = connection.getresponse()
+        self.assertEqual(200, response.status)
+        self.assertEqual(b"ok\n", response.read())
+        connection.close()
+        self.assertFalse(self.ledger.exists())
+
+    def test_ipv6_loopback_server_uses_the_ipv6_address_family(self) -> None:
+        if not socket.has_ipv6:
+            self.skipTest("IPv6 unavailable")
+        try:
+            server = SERVER.IPv6WebhookServer(("::1", 0), SERVER.WebhookHandler)
+        except OSError as error:
+            self.skipTest(f"IPv6 loopback unavailable: {error}")
+        self.assertEqual(socket.AF_INET6, server.address_family)
+        server.server_close()
+
+    def test_signature_and_json_validation_precede_logs_and_ledger(self) -> None:
+        payload = self._repository_payload()
+        status, _ = self._request("issues", "delivery-invalid-signature", payload, valid_signature=False)
+        self.assertEqual(401, status)
+        self.assertFalse(self.ledger.exists())
+        self.assertEqual([], self.records)
+        self.assertEqual([], self.logs)
+
+    def test_body_delivery_slug_and_id_validation_fail_before_ledger(self) -> None:
+        payload = self._issue_payload(1)
+        original_max_body = SERVER.MAX_BODY
+        SERVER.MAX_BODY = 8
+        try:
+            status, _ = self._request("issues", "delivery-oversized", payload)
+        finally:
+            SERVER.MAX_BODY = original_max_body
+        self.assertEqual(413, status)
+
+        status, _ = self._request("issues", "", payload)
+        self.assertEqual(400, status)
+        invalid_slug = self._issue_payload(2)
+        invalid_slug["repository"] = {"full_name": "../invalid"}
+        status, _ = self._request("issues", "delivery-invalid-slug", invalid_slug)
+        self.assertEqual(400, status)
+        invalid_id = self._issue_payload(0)
+        status, _ = self._request("issues", "delivery-invalid-id", invalid_id)
+        self.assertEqual(400, status)
+        status, _ = self._request("push", "delivery-unhandled", self._repository_payload())
+        self.assertEqual(204, status)
+        status, _ = self._request("push", "delivery-unhandled-json", b"{invalid")
+        self.assertEqual(204, status)
+        invalid_action = self._issue_payload(3)
+        invalid_action["action"] = "unknown_action"
+        status, _ = self._request("issues", "delivery-invalid-action", invalid_action)
+        self.assertEqual(400, status)
+        invalid_sha = self._repository_payload()
+        invalid_sha.update({"sha": "short", "state": "success"})
+        status, _ = self._request("status", "delivery-invalid-sha", invalid_sha)
+        self.assertEqual(400, status)
+        self.assertFalse(self.ledger.exists())
+        self.assertEqual([], self.records)
+        self.assertEqual([], self.logs)
+
+        status, _ = self._request("issues", "delivery-invalid-json", b"{invalid")
+        self.assertEqual(400, status)
+        self.assertFalse(self.ledger.exists())
+        self.assertEqual([], self.records)
+
+    def test_issue_invalidation_is_private_narrow_and_body_free(self) -> None:
+        payload = self._issue_payload(3, title="RAW-BODY-SENTINEL")
+        status, _ = self._request("issues", "delivery-issue-1", payload)
+        self.assertEqual(200, status)
+        self.assertEqual(
+            ["INVALIDATE v1 collection issues owner/repo"],
+            self.records,
+        )
+        self.assertEqual(0o600, stat.S_IMODE(self.ledger.stat().st_mode))
+        ledger_text = self.ledger.read_text(encoding="utf-8")
+        self.assertNotIn("RAW-BODY-SENTINEL", ledger_text)
+        self.assertNotIn("RAW-BODY-SENTINEL", "\n".join(self.logs))
+        ledger = json.loads(ledger_text)
+        self.assertEqual("aidevops-webhook-deliveries/v1", ledger["schema"])
+        self.assertEqual("accepted", ledger["deliveries"][0]["outcome"])
+        self.assertEqual([], list(self.ledger.parent.glob(".webhook-ledger.*")))
+
+    def test_duplicate_and_conflicting_delivery_ids_do_not_retrigger(self) -> None:
+        payload = self._issue_payload(4)
+        first_status, _ = self._request("issues", "delivery-dedup-1", payload)
+        ledger_before = self.ledger.read_bytes()
+        mtime_before = self.ledger.stat().st_mtime_ns
+        duplicate_status, duplicate_body = self._request(
+            "issues", "delivery-dedup-1", payload
+        )
+        changed_payload = self._issue_payload(5)
+        conflict_status, _ = self._request(
+            "issues", "delivery-dedup-1", changed_payload
+        )
+        self.assertEqual(200, first_status)
+        self.assertEqual(200, duplicate_status)
+        self.assertEqual(b"duplicate\n", duplicate_body)
+        self.assertEqual(409, conflict_status)
+        self.assertEqual(ledger_before, self.ledger.read_bytes())
+        self.assertEqual(mtime_before, self.ledger.stat().st_mtime_ns)
+        self.assertEqual(
+            ["INVALIDATE v1 collection issues owner/repo"],
+            self.records,
+        )
+        ledger = json.loads(self.ledger.read_text(encoding="utf-8"))
+        self.assertEqual(1, len(ledger["deliveries"]))
+
+    def test_duplicate_remains_suppressed_after_server_restart(self) -> None:
+        payload = self._issue_payload(6)
+        status, _ = self._request("issues", "delivery-restart-1", payload)
+        self.assertEqual(200, status)
+        self._stop_server()
+        self._start_server()
+        status, response_body = self._request("issues", "delivery-restart-1", payload)
+        self.assertEqual(200, status)
+        self.assertEqual(b"duplicate\n", response_body)
+        self.assertEqual(1, len(self.records))
+
+    def test_simultaneous_duplicate_deliveries_have_one_atomic_owner(self) -> None:
+        payload = self._issue_payload(7)
+
+        def deliver(_worker: int) -> int:
+            status, _ = self._request("issues", "delivery-concurrent-1", payload)
+            return status
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            statuses = list(executor.map(deliver, range(8)))
+        self.assertEqual([200] * 8, statuses)
+        self.assertEqual(
+            ["INVALIDATE v1 collection issues owner/repo"],
+            self.records,
+        )
+        ledger = json.loads(self.ledger.read_text(encoding="utf-8"))
+        self.assertEqual(1, len(ledger["deliveries"]))
+
+    def test_pr_and_check_records_precede_process_actions(self) -> None:
+        pull_payload = self._repository_payload()
+        pull_payload.update(
+            {
+                "action": "labeled",
+                "label": {"name": "ai-approved"},
+                "pull_request": {"number": 7},
+            }
+        )
+        status, _ = self._request("pull_request", "delivery-pr-1", pull_payload)
+        self.assertEqual(200, status)
+
+        check_payload = self._repository_payload()
+        check_payload.update(
+            {
+                "action": "completed",
+                "check_suite": {
+                    "conclusion": "success",
+                    "head_sha": "a" * 40,
+                    "pull_requests": [{"number": 8}, {"number": 8}, {"number": 9}],
+                },
+            }
+        )
+        status, _ = self._request("check_suite", "delivery-check-1", check_payload)
+        self.assertEqual(200, status)
+        self.assertEqual(
+            [
+                "INVALIDATE v1 collection prs owner/repo",
+                "PROCESS_PR owner/repo 7",
+                f"INVALIDATE v1 checks owner/repo {'a' * 40}",
+                "PROCESS_PR owner/repo 8",
+                "PROCESS_PR owner/repo 9",
+            ],
+            self.records,
+        )
+
+    def test_review_and_check_run_map_to_pr_and_exact_sha(self) -> None:
+        review_payload = self._repository_payload()
+        review_payload.update(
+            {
+                "action": "submitted",
+                "pull_request": {"number": 11},
+                "review": {"state": "approved"},
+            }
+        )
+        status, _ = self._request(
+            "pull_request_review", "delivery-review-1", review_payload
+        )
+        self.assertEqual(200, status)
+
+        check_run_payload = self._repository_payload()
+        check_run_payload.update(
+            {
+                "action": "completed",
+                "check_run": {
+                    "conclusion": "success",
+                    "head_sha": "d" * 40,
+                    "pull_requests": [{"number": 11}],
+                },
+            }
+        )
+        status, _ = self._request("check_run", "delivery-check-run-1", check_run_payload)
+        self.assertEqual(200, status)
+        self.assertEqual(
+            [
+                "INVALIDATE v1 collection prs owner/repo",
+                "PROCESS_PR owner/repo 11",
+                f"INVALIDATE v1 checks owner/repo {'d' * 40}",
+                "PROCESS_PR owner/repo 11",
+            ],
+            self.records,
+        )
+
+    def test_issue_comments_select_only_the_affected_collection(self) -> None:
+        issue_comment = self._repository_payload()
+        issue_comment.update({"action": "created", "issue": {"number": 12}})
+        status, _ = self._request("issue_comment", "delivery-comment-1", issue_comment)
+        self.assertEqual(200, status)
+
+        pr_comment = self._repository_payload()
+        pr_comment.update(
+            {"action": "edited", "issue": {"number": 13, "pull_request": {}}}
+        )
+        status, _ = self._request("issue_comment", "delivery-comment-2", pr_comment)
+        self.assertEqual(200, status)
+        self.assertEqual(
+            [
+                "INVALIDATE v1 collection issues owner/repo",
+                "INVALIDATE v1 collection prs owner/repo",
+            ],
+            self.records,
+        )
+
+    def test_review_thread_mutation_invalidates_only_the_pr_collection(self) -> None:
+        payload = self._repository_payload()
+        payload.update({"action": "resolved", "pull_request": {"number": 15}})
+        status, _ = self._request(
+            "pull_request_review_thread", "delivery-thread-1", payload
+        )
+        self.assertEqual(200, status)
+        self.assertEqual(
+            ["INVALIDATE v1 collection prs owner/repo"],
+            self.records,
+        )
+
+    def test_review_comment_and_workflow_run_map_to_narrow_invalidations(self) -> None:
+        review_comment = self._repository_payload()
+        review_comment.update({"action": "edited", "pull_request": {"number": 18}})
+        status, _ = self._request(
+            "pull_request_review_comment", "delivery-review-comment-1", review_comment
+        )
+        self.assertEqual(200, status)
+
+        workflow_run = self._repository_payload()
+        workflow_run.update(
+            {"action": "completed", "workflow_run": {"head_sha": "e" * 40}}
+        )
+        status, _ = self._request(
+            "workflow_run", "delivery-workflow-run-1", workflow_run
+        )
+        self.assertEqual(200, status)
+        self.assertEqual(
+            [
+                "INVALIDATE v1 collection prs owner/repo",
+                f"INVALIDATE v1 checks owner/repo {'e' * 40}",
+            ],
+            self.records,
+        )
+
+    def test_out_of_order_unique_events_remain_safe_invalidations(self) -> None:
+        newer = self._issue_payload(14, updated_at="2026-07-18T12:00:00Z")
+        newer["action"] = "closed"
+        older = self._issue_payload(14, updated_at="2026-07-18T11:00:00Z")
+        older["action"] = "reopened"
+        first_status, _ = self._request("issues", "delivery-newer", newer)
+        second_status, _ = self._request("issues", "delivery-older", older)
+        self.assertEqual((200, 200), (first_status, second_status))
+        self.assertEqual(
+            [
+                "INVALIDATE v1 collection issues owner/repo",
+                "INVALIDATE v1 collection issues owner/repo",
+            ],
+            self.records,
+        )
+
+    def test_status_invalidation_is_exact_sha_and_has_no_process_action(self) -> None:
+        payload = self._repository_payload()
+        payload["sha"] = "b" * 40
+        payload["state"] = "success"
+        status, _ = self._request("status", "delivery-status-1", payload)
+        self.assertEqual(200, status)
+        self.assertEqual(
+            [f"INVALIDATE v1 checks owner/repo {'b' * 40}"],
+            self.records,
+        )
+
+    def test_delivery_ledger_is_bounded(self) -> None:
+        SERVER.LEDGER_MAX_ENTRIES = 2
+        for number in range(1, 4):
+            payload = self._issue_payload(number)
+            status, _ = self._request("issues", f"delivery-bound-{number}", payload)
+            self.assertEqual(200, status)
+        ledger = json.loads(self.ledger.read_text(encoding="utf-8"))
+        self.assertEqual(2, len(ledger["deliveries"]))
+        self.assertEqual(
+            ["delivery-bound-3", "delivery-bound-2"],
+            [entry["id"] for entry in ledger["deliveries"]],
+        )
+
+    def test_expired_and_implausibly_future_entries_are_pruned(self) -> None:
+        SERVER.LEDGER_TTL_SECONDS = 60
+        now = int(time.time())
+        self.ledger.parent.mkdir(parents=True)
+        self.ledger.write_text(
+            json.dumps(
+                {
+                    "schema": "aidevops-webhook-deliveries/v1",
+                    "deliveries": [
+                        {
+                            "event": "issues",
+                            "id": "delivery-expired",
+                            "outcome": "accepted",
+                            "payload_sha256": "a" * 64,
+                            "received_at": now - 3600,
+                        },
+                        {
+                            "event": "issues",
+                            "id": "delivery-future",
+                            "outcome": "accepted",
+                            "payload_sha256": "b" * 64,
+                            "received_at": now + 3600,
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        status, _ = self._request("issues", "delivery-expired", self._issue_payload(16))
+        self.assertEqual(200, status)
+        ledger = json.loads(self.ledger.read_text(encoding="utf-8"))
+        self.assertEqual(["delivery-expired"], [entry["id"] for entry in ledger["deliveries"]])
+
+    def test_delivery_ledger_updates_are_atomic_across_processes(self) -> None:
+        self._stop_server()
+        try:
+            context = multiprocessing.get_context("spawn")
+            with context.Pool(processes=4) as pool:
+                outcomes = pool.map(
+                    _record_delivery_in_process,
+                    [(str(self.ledger), worker) for worker in range(12)],
+                )
+        finally:
+            self._start_server()
+        self.assertEqual(["accepted"] * 12, outcomes)
+        ledger = json.loads(self.ledger.read_text(encoding="utf-8"))
+        self.assertEqual(12, len(ledger["deliveries"]))
+
+    def test_delivery_ledger_claims_one_owner_across_processes(self) -> None:
+        self._stop_server()
+        try:
+            context = multiprocessing.get_context("spawn")
+            with context.Pool(processes=4) as pool:
+                outcomes = pool.map(
+                    _record_shared_delivery_in_process,
+                    [str(self.ledger)] * 8,
+                )
+        finally:
+            self._start_server()
+        self.assertEqual(1, outcomes.count("accepted"))
+        self.assertEqual(7, outcomes.count("duplicate"))
+        ledger = json.loads(self.ledger.read_text(encoding="utf-8"))
+        self.assertEqual(
+            ["process-shared-delivery"],
+            [entry["id"] for entry in ledger["deliveries"]],
+        )
+
+    def test_malformed_ledger_fails_closed_without_actions(self) -> None:
+        self.ledger.parent.mkdir(parents=True)
+        self.ledger.write_text("{malformed\n", encoding="utf-8")
+        payload = self._issue_payload(10)
+        status, _ = self._request("issues", "delivery-ledger-failure", payload)
+        self.assertEqual(500, status)
+        self.assertEqual([], self.records)
+
+    def _dispatch_receiver_records(
+        self, records: list[str], *, fail_collection: bool = False
+    ) -> list[str]:
+        actions = self.root / "actions.txt"
+        actions.write_text("\n".join(records) + "\n", encoding="utf-8")
+        call_log = self.root / "dispatch.log"
+        script = r'''
+source "$RECEIVER_PATH"
+_webhook_invalidate_collection() {
+    local kind="$1"
+    local slug="$2"
+    printf 'collection|%s|%s\n' "$kind" "$slug" >>"$CALL_LOG"
+    [[ "$FAIL_COLLECTION" == "1" ]] && return 1
+    return 0
+}
+_webhook_invalidate_checks() {
+    local slug="$1"
+    local sha="$2"
+    printf 'checks|%s|%s\n' "$slug" "$sha" >>"$CALL_LOG"
+    return 0
+}
+process_pr() {
+    local slug="$1"
+    local number="$2"
+    printf 'process|%s|%s\n' "$slug" "$number" >>"$CALL_LOG"
+    return 0
+}
+while IFS= read -r action_line; do
+    _dispatch_webhook_action_line "$action_line"
+done <"$ACTIONS_FILE"
+wait
+'''
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "ACTIONS_FILE": str(actions),
+                "CALL_LOG": str(call_log),
+                "FAIL_COLLECTION": "1" if fail_collection else "0",
+                "HOME": str(self.root / "home"),
+                "RECEIVER_PATH": str(RECEIVER_PATH),
+                "WEBHOOK_CONF": str(SCRIPTS_DIR.parent / "configs" / "webhook-receiver.conf"),
+                "WEBHOOK_LOG_FILE": str(self.root / "receiver.log"),
+            }
+        )
+        result = subprocess.run(
+            ["bash", "-c", script],
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )  # nosec B603 B607
+        self.assertEqual(0, result.returncode, result.stderr or result.stdout)
+        if not call_log.exists():
+            return []
+        return call_log.read_text(encoding="utf-8").splitlines()
+
+    def test_receiver_dispatches_invalidation_before_process_pr(self) -> None:
+        calls = self._dispatch_receiver_records(
+            [
+                "INVALIDATE v1 collection prs owner/repo",
+                f"INVALIDATE v1 checks owner/repo {'c' * 40}",
+                "PROCESS_PR owner/repo 12",
+            ]
+        )
+        self.assertEqual(
+            [
+                "collection|prs|owner/repo",
+                f"checks|owner/repo|{'c' * 40}",
+                "process|owner/repo|12",
+            ],
+            calls,
+        )
+
+    def test_receiver_skips_process_when_invalidation_fails(self) -> None:
+        calls = self._dispatch_receiver_records(
+            [
+                "INVALIDATE v1 collection prs owner/repo",
+                "PROCESS_PR owner/repo 12",
+                "# accepted event=pull_request delivery=fixture invalidations=1 actions=1",
+                "PROCESS_PR owner/repo 13",
+            ],
+            fail_collection=True,
+        )
+        self.assertEqual(
+            ["collection|prs|owner/repo", "process|owner/repo|13"],
+            calls,
+        )
+
+    def test_receiver_rejects_unknown_protocol_before_process_pr(self) -> None:
+        calls = self._dispatch_receiver_records(
+            [
+                "INVALIDATE v2 collection prs owner/repo",
+                "PROCESS_PR owner/repo 12",
+                "# accepted event=pull_request delivery=fixture invalidations=1 actions=1",
+                "PROCESS_PR owner/repo 13",
+            ]
+        )
+        self.assertEqual(["process|owner/repo|13"], calls)
+
+    def test_receiver_removes_original_secret_from_child_environment(self) -> None:
+        script = r'''
+source "$RECEIVER_PATH"
+resolved_secret=$(_resolve_secret)
+[[ -n "$resolved_secret" ]]
+_clear_webhook_secret_env
+[[ -z "${GITHUB_WEBHOOK_SECRET+x}" ]]
+'''
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GITHUB_WEBHOOK_SECRET": self.secret.decode("utf-8"),
+                "HOME": str(self.root / "home"),
+                "RECEIVER_PATH": str(RECEIVER_PATH),
+                "WEBHOOK_CONF": str(SCRIPTS_DIR.parent / "configs" / "webhook-receiver.conf"),
+                "WEBHOOK_LOG_FILE": str(self.root / "secret-scope.log"),
+            }
+        )
+        result = subprocess.run(
+            ["bash", "-c", script],
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )  # nosec B603 B607
+        self.assertEqual(0, result.returncode, result.stderr or result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add authenticated, deduplicated webhook invalidation for canonical issue, PR, and exact-SHA state before eligible pulse dispatches.

## Files Changed

.agents/configs/webhook-receiver.conf, .agents/scripts/pulse-batch-conditional-cache.py, .agents/scripts/pulse-batch-prefetch-helper.sh, .agents/scripts/pulse-merge-webhook-receiver.sh, .agents/scripts/pulse-merge-webhook-server.py, .agents/scripts/shared-gh-request-state.sh, .agents/scripts/shared-gh-wrappers-checks.sh, .agents/scripts/tests/test-gh-check-status-cache.sh, .agents/scripts/tests/test-gh-request-singleflight.sh, .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh, .agents/scripts/tests/test-pulse-merge-webhook-invalidation.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused request-state, check-cache, conditional REST, and 24 signed webhook fixtures pass; changed-file local linters pass.

Resolves #27776


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 1d 11h and 9,455,354 tokens on this with the user in an interactive session.