### PR TITLE
GH#28198: docs: adopt asc cli resolution center release

### DIFF
--- a/.agents/tools/mobile/app-store-connect.md
+++ b/.agents/tools/mobile/app-store-connect.md
@@ -27,7 +27,7 @@ tools:
 - **Project pin**: `asc init --app-id <id>` (saves `.asc/project.json`, auto-used by all commands)
 - **Verify**: `asc auth check` | **Multi-account**: `asc auth use <name>`
 - **Context resolution**: explicit `--app-id` > `.asc/project.json` > prompt user to `asc init` (CI must use `--app-id` or pre-run `asc init`)
-- **GitHub**: https://github.com/tddworks/asc-cli (MIT, Swift, 130+ commands; v0.18.1 adds review-submission item drill-down, sales-report rollups/schema selection, and an app-availability territory-limit fix; checked at `04fde49`, whose post-0.18.1 delta only refreshes homepage app-wall metadata for BetaReels and related app listings)
+- **GitHub**: https://github.com/tddworks/asc-cli (MIT, Swift, 130+ commands; v0.18.2 adds Resolution Center rejection details and attachment downloads through cookie-authenticated iris APIs; checked at release commit `97a60af`)
 - **Website**: https://asccli.app | **Web apps**: [Command Center](https://asccli.app/command-center), [Console](https://asccli.app/console), [Screenshot Studio](https://asccli.app/editor)
 - **Skills**: [Official](https://github.com/tddworks/asc-cli-skills) (27 command-group skills, checked at `6465c10feb89`) | [Community](https://github.com/rudrankriyam/app-store-connect-cli-skills) (23 workflow skills, checked at `0ae3da2`)
 - **Requirements**: macOS 13+, App Store Connect API key, `jq` (workflow scripts use `jq -r`)
@@ -49,7 +49,7 @@ command -v jq >/dev/null || { brew install jq || exit 1; }
 
 | Group | Commands | Purpose |
 |-------|----------|---------|
-| **versions** / **review-submissions** | `list`, `create`, `set-build`, `check-readiness`, `submit`; `review-submissions get`, `review-submissions items list` | Versions, submissions, and per-item review-state inspection |
+| **versions** / **review-submissions** | `list`, `create`, `set-build`, `check-readiness`, `submit`; `review-submissions get`, `review-submissions items list` | Versions, submissions, and per-item review-state inspection; rejected items expose a `getResolutionDetails` affordance in v0.18.2+ |
 | **builds** | `list`, `archive`, `upload`, `add-beta-group`, `update-beta-notes` | Build management |
 | **testflight** | `groups list`, `testers add/remove/import/export` | Beta distribution |
 | **version-localizations** | `list`, `create`, `update` | What's New, description, keywords per locale |
@@ -64,7 +64,7 @@ command -v jq >/dev/null || { brew install jq || exit 1; }
 | **users** / **user-invitations** | `list`, `update`, `remove`, `invite`, `cancel` | Team management |
 | **xcode-cloud** | `products`, `workflows`, `builds` | Xcode Cloud CI/CD |
 | **Apple Ads** | `ads auth`, `ads me`, `ads acls`, `ads campaigns`, `ads ad-groups`, `ads reports`, `ads api request` | Apple Ads auth, user profile, org lookup, campaign/ad-group management, reports, and raw v5 API calls |
-| **Other** | `apps list`, `app-tags`, `game-center`, `perf-metrics`, `diagnostics`, `iris`, `plugins`, `search`, `schema`, `capabilities`, `tui`, `web` | Apps, discoverability tags, Game Center, performance, private API, plugins, discovery, TUI, web-session gaps |
+| **Other** | `apps list`, `app-tags`, `game-center`, `perf-metrics`, `diagnostics`, `iris resolution-center`, `plugins`, `search`, `schema`, `capabilities`, `tui`, `web` | Apps, discoverability tags, Game Center, performance, private API, plugins, discovery, TUI, web-session gaps |
 
 **Discover**: `asc --help`, `asc <cmd> --help`, `asc search "upload build"`, `asc schema --pretty "GET /v1/apps"`, `asc capabilities --area release --output table` | **Output**: `--output json` (default), `--output table`, `--output markdown`, `--pretty`
 
@@ -99,6 +99,10 @@ asc versions submit --version-id "$VERSION_ID"
 SUBMISSION_ID=$(asc review-submissions list --app-id APP_ID | jq -r '.data[0].id // ""')
 asc review-submissions get --submission-id "$SUBMISSION_ID" --output json
 asc review-submissions items list --submission-id "$SUBMISSION_ID" --state REJECTED --output json
+# v0.18.2+: read App Review's message and structured rejection reasons via iris cookie auth
+asc iris resolution-center get --submission-id "$SUBMISSION_ID" --plain-text --output json
+# Optionally download message attachments after inspecting their Apple/CDN URLs
+asc iris resolution-center get --submission-id "$SUBMISSION_ID" --plain-text --out ./resolution-center
 
 # Web-only gap: attach non-renewing IAPs to next app version review when the public API rejects review items
 asc web review iaps attach --app-id APP_ID --iap-id IAP_ID --confirm


### PR DESCRIPTION
## Summary

Document asc-cli v0.18.2 Resolution Center rejection details, CAEOAS affordance, and guarded attachment-download workflow.

## Files Changed

.agents/tools/mobile/app-store-connect.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/linters-local.sh

Resolves #28198


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 11m and 53,894 tokens on this as a headless worker.