### PR TITLE
GH#28208: Prevent stale release runtime convergence

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -257,6 +257,38 @@ regenerate_runtime_config() {
 	return 0
 }
 
+# Route every mutating incremental deployment through setup's transactional
+# runtime-bundle stage. This preserves the previous immutable bundle and only
+# changes the stable agents path via atomic activation after validation.
+run_transactional_incremental_deploy() {
+	local setup_script="$REPO_DIR/setup.sh"
+	local setup_exit=0
+
+	if [[ ! -f "$setup_script" || ! -r "$setup_script" ]]; then
+		log_error "Transactional deployment requires a readable setup helper: $setup_script"
+		return 1
+	fi
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "[dry-run] Would stage and atomically activate a runtime bundle via setup.sh --stage ai-session"
+		return 0
+	fi
+
+	log_info "Staging and atomically activating an immutable runtime bundle..."
+	env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR \
+		AIDEVOPS_NON_INTERACTIVE=true \
+		AIDEVOPS_DEPLOY_TARGET="$TARGET_DIR" \
+		bash "$setup_script" --stage ai-session || setup_exit=$?
+	if [[ "$setup_exit" -eq 75 ]]; then
+		log_warn "setup.sh --stage ai-session is locked by another deployment (exit 75)"
+	fi
+	if [[ "$setup_exit" -ne 0 ]]; then
+		log_error "Transactional runtime bundle deployment failed (exit $setup_exit)"
+		return "$setup_exit"
+	fi
+	log_success "Transactional runtime bundle deployment completed"
+	return 0
+}
+
 runtime_config_changes_detected() {
 	local changed_files="${1:-}"
 	local file
@@ -574,13 +606,42 @@ main() {
 			bash "$REPO_DIR/setup.sh" --non-interactive
 		local _full_rc=$?
 		if [[ "$_full_rc" -eq 75 ]]; then
-			log_warn "setup.sh --non-interactive is locked by another process (exit 75). The lightweight deploy path (deploy-agents-on-merge.sh without --full) is unaffected — re-run without --full for an immediate agent sync while the full setup completes."
+			log_warn "setup.sh --non-interactive is locked by another deployment (exit 75). Re-run after the active transactional deployment completes."
 		fi
 		return "$_full_rc"
 	fi
 
 	# Pull latest (only if on main)
 	pull_latest
+
+	# All mutating incremental paths converge through setup's immutable bundle
+	# staging. Keep the legacy selective functions below for dry-run planning,
+	# but never write through the active agents symlink in place.
+	if [[ "$DRY_RUN" != "true" ]]; then
+		if [[ -n "$DIFF_COMMIT" ]]; then
+			local transactional_changed=""
+			local transactional_count=0
+			local transactional_non_script_count=0
+			if ! transactional_changed=$(detect_changes "$DIFF_COMMIT"); then
+				return 1
+			fi
+			if [[ -z "$transactional_changed" ]]; then
+				log_info "No agent changes since $DIFF_COMMIT"
+				return 2
+			fi
+			transactional_count=$(printf '%s\n' "$transactional_changed" | wc -l | tr -d ' ')
+			if ! transactional_non_script_count=$(printf '%s\n' "$transactional_changed" | grep -cEv '^\.agents/scripts/'); then
+				transactional_non_script_count=0
+			fi
+			if [[ "$transactional_non_script_count" -eq 0 ]]; then
+				log_info "Only scripts changed — using fast scripts-only deploy through atomic setup"
+			else
+				log_info "Deploying $transactional_count changed agent files through atomic setup"
+			fi
+		fi
+		run_transactional_incremental_deploy
+		return $?
+	fi
 
 	# Scripts-only deploy
 	if [[ "$SCRIPTS_ONLY" == "true" ]]; then

--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -587,90 +587,68 @@ deploy_changed_files() {
 	return 0
 }
 
-main() {
-	parse_args "$@" || return 1
-	validate_repo || return 1
-	validate_stable_target || return 1
-	collect_plugin_namespaces || return 1
+_run_full_deploy() {
+	local full_exit=0
 
-	# Full deploy: delegate to setup.sh
-	if [[ "$FULL_DEPLOY" == "true" ]]; then
-		log_info "Running full deploy via setup.sh --non-interactive..."
-		if [[ "$DRY_RUN" == "true" ]]; then
-			log_info "[dry-run] Would run: AIDEVOPS_NON_INTERACTIVE=true $REPO_DIR/setup.sh --non-interactive"
-			return 0
-		fi
-		env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR \
-			AIDEVOPS_NON_INTERACTIVE=true \
-			AIDEVOPS_DEPLOY_TARGET="$TARGET_DIR" \
-			bash "$REPO_DIR/setup.sh" --non-interactive
-		local _full_rc=$?
-		if [[ "$_full_rc" -eq 75 ]]; then
-			log_warn "setup.sh --non-interactive is locked by another deployment (exit 75). Re-run after the active transactional deployment completes."
-		fi
-		return "$_full_rc"
+	log_info "Running full deploy via setup.sh --non-interactive..."
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "[dry-run] Would run: AIDEVOPS_NON_INTERACTIVE=true $REPO_DIR/setup.sh --non-interactive"
+		return 0
 	fi
-
-	# Pull latest (only if on main)
-	pull_latest
-
-	# All mutating incremental paths converge through setup's immutable bundle
-	# staging. Keep the legacy selective functions below for dry-run planning,
-	# but never write through the active agents symlink in place.
-	if [[ "$DRY_RUN" != "true" ]]; then
-		if [[ -n "$DIFF_COMMIT" ]]; then
-			local transactional_changed=""
-			local transactional_count=0
-			local transactional_non_script_count=0
-			if ! transactional_changed=$(detect_changes "$DIFF_COMMIT"); then
-				return 1
-			fi
-			if [[ -z "$transactional_changed" ]]; then
-				log_info "No agent changes since $DIFF_COMMIT"
-				return 2
-			fi
-			transactional_count=$(printf '%s\n' "$transactional_changed" | wc -l | tr -d ' ')
-			if ! transactional_non_script_count=$(printf '%s\n' "$transactional_changed" | grep -cEv '^\.agents/scripts/'); then
-				transactional_non_script_count=0
-			fi
-			if [[ "$transactional_non_script_count" -eq 0 ]]; then
-				log_info "Only scripts changed — using fast scripts-only deploy through atomic setup"
-			else
-				log_info "Deploying $transactional_count changed agent files through atomic setup"
-			fi
-		fi
-		run_transactional_incremental_deploy
-		return $?
+	env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR \
+		AIDEVOPS_NON_INTERACTIVE=true \
+		AIDEVOPS_DEPLOY_TARGET="$TARGET_DIR" \
+		bash "$REPO_DIR/setup.sh" --non-interactive || full_exit=$?
+	if [[ "$full_exit" -eq 75 ]]; then
+		log_warn "setup.sh --non-interactive is locked by another deployment (exit 75). Re-run after the active transactional deployment completes."
 	fi
+	return "$full_exit"
+}
 
-	# Scripts-only deploy
+_validate_transactional_diff() {
+	local changed=""
+	local change_count=0
+	local non_script_count=0
+
+	changed=$(detect_changes "$DIFF_COMMIT") || return 1
+	if [[ -z "$changed" ]]; then
+		log_info "No agent changes since $DIFF_COMMIT"
+		return 2
+	fi
+	change_count=$(printf '%s\n' "$changed" | wc -l | tr -d ' ')
+	if ! non_script_count=$(printf '%s\n' "$changed" | grep -cEv '^\.agents/scripts/'); then
+		non_script_count=0
+	fi
+	if [[ "$non_script_count" -eq 0 ]]; then
+		log_info "Only scripts changed — using fast scripts-only deploy through atomic setup"
+	else
+		log_info "Deploying $change_count changed agent files through atomic setup"
+	fi
+	return 0
+}
+
+_run_dry_run_deploy() {
+	local changed=""
+	local change_count=0
+	local non_script_changes=0
+
 	if [[ "$SCRIPTS_ONLY" == "true" ]]; then
 		deploy_scripts_only
 		return $?
 	fi
 
-	# Diff-based deploy
 	if [[ -n "$DIFF_COMMIT" ]]; then
-		local changed
-		if ! changed=$(detect_changes "$DIFF_COMMIT"); then
-			return 1
-		fi
+		changed=$(detect_changes "$DIFF_COMMIT") || return 1
 		if [[ -z "$changed" ]]; then
 			log_info "No agent changes since $DIFF_COMMIT"
 			return 2
 		fi
-
-		# If many files changed, do a full agent sync instead of file-by-file
-		local change_count
 		change_count=$(echo "$changed" | wc -l | tr -d ' ')
 		if [[ "$change_count" -gt 50 ]]; then
 			log_info "Large changeset ($change_count files) — doing full agent sync"
 			deploy_all_agents
 			return $?
 		fi
-
-		# Check if only scripts changed
-		local non_script_changes
 		if ! non_script_changes=$(printf '%s\n' "$changed" | grep -cEv '^\.agents/scripts/'); then
 			non_script_changes=0
 		fi
@@ -684,17 +662,36 @@ main() {
 		return $?
 	fi
 
-	# Default: version-based detection
-	local changed
-	if ! changed=$(detect_changes ""); then
-		return 1
-	fi
+	changed=$(detect_changes "") || return 1
 	if [[ -z "$changed" ]]; then
 		return 2
 	fi
-
-	# Version mismatch detected — full agent sync
 	deploy_all_agents
+	return $?
+}
+
+main() {
+	local diff_exit=0
+
+	parse_args "$@" || return 1
+	validate_repo || return 1
+	validate_stable_target || return 1
+	collect_plugin_namespaces || return 1
+	if [[ "$FULL_DEPLOY" == "true" ]]; then
+		_run_full_deploy
+		return $?
+	fi
+
+	pull_latest
+	if [[ "$DRY_RUN" == "true" ]]; then
+		_run_dry_run_deploy
+		return $?
+	fi
+	if [[ -n "$DIFF_COMMIT" ]]; then
+		_validate_transactional_diff || diff_exit=$?
+		[[ "$diff_exit" -eq 0 ]] || return "$diff_exit"
+	fi
+	run_transactional_incremental_deploy
 	return $?
 }
 

--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -6,18 +6,18 @@ set -euo pipefail
 # deploy-agents-on-merge.sh - Fast targeted agent deployment after PR merge
 #
 # Called by the supervisor after merging PRs that modify .agents/ files.
-# Much faster than full setup.sh --non-interactive because it only syncs
-# changed agent files instead of running all migrations and optional steps.
+# Uses setup's changed-stage planner, immutable runtime-bundle staging, and
+# atomic activation without running unrelated optional setup steps.
 #
 # Usage:
 #   deploy-agents-on-merge.sh [options]
 #
 # Options:
 #   --repo <path>       Path to the aidevops repo (default: ~/Git/aidevops)
-#   --scripts-only      Only deploy .agents/scripts/ (fastest)
+#   --scripts-only      Compatibility hint for a scripts-only change set
 #   --full              Run full setup.sh --non-interactive instead
 #   --dry-run           Show what would be deployed without doing it
-#   --diff <commit>     Only deploy files changed since <commit>
+#   --diff <commit>     Validate/detect agent changes since <commit>
 #   --quiet             Suppress non-error output
 #   --help              Show this help
 #

--- a/.agents/scripts/runtime-bundle-verifier.sh
+++ b/.agents/scripts/runtime-bundle-verifier.sh
@@ -78,39 +78,16 @@ _runtime_bundle_verify_git_blob_sha256() {
 	return 0
 }
 
-verify_aidevops_runtime_bundle_convergence() {
+_AIDEVOPS_RUNTIME_VERIFY_SOURCE_SHA=""
+_AIDEVOPS_RUNTIME_VERIFY_ACTIVE_ROOT=""
+_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_VERSION=""
+_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_CLI_SHA=""
+
+_runtime_bundle_verify_source() {
 	local repo_dir="$1"
 	local expected_sha="$2"
-	local active_link="${3:-${HOME}/.aidevops/agents}"
-	local stamp_file="${4:-${HOME}/.aidevops/.deployed-sha}"
 	local source_sha=""
 	local resolved_expected_sha=""
-	local active_root=""
-	local bundles_root=""
-	local active_bundle_dir=""
-	local active_bundle_id=""
-	local manifest_file=""
-	local manifest_status=""
-	local manifest_bundle_id=""
-	local manifest_version=""
-	local manifest_sha=""
-	local manifest_cli_sha=""
-	local repo_version=""
-	local active_version=""
-	local deployed_sha=""
-	local expected_short=""
-	local sentinel_pair=""
-	local source_rel=""
-	local active_rel=""
-	local source_hash=""
-	local active_hash=""
-	local -a sentinel_pairs=(
-		"aidevops.sh|aidevops.sh"
-		".agents/scripts/version-manager-release.sh|scripts/version-manager-release.sh"
-		".agents/scripts/deploy-agents-on-merge.sh|scripts/deploy-agents-on-merge.sh"
-		".agents/scripts/runtime-bundle-verifier.sh|scripts/runtime-bundle-verifier.sh"
-		".agents/scripts/setup/modules/agent-deploy.sh|scripts/setup/modules/agent-deploy.sh"
-	)
 
 	if [[ -z "$repo_dir" || ! -d "$repo_dir" ]]; then
 		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source checkout is unavailable"
@@ -128,6 +105,14 @@ verify_aidevops_runtime_bundle_convergence() {
 		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source checkout HEAD ${source_sha:0:12} does not match release commit ${resolved_expected_sha:0:12}"
 		return 1
 	fi
+	_AIDEVOPS_RUNTIME_VERIFY_SOURCE_SHA="$resolved_expected_sha"
+	return 0
+}
+
+_runtime_bundle_verify_active_link() {
+	local active_link="$1"
+	local active_root=""
+	local bundles_root=""
 
 	if [[ ! -L "$active_link" ]]; then
 		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active agents path is not an atomic activation symlink"
@@ -148,10 +133,24 @@ verify_aidevops_runtime_bundle_convergence() {
 		return 1
 		;;
 	esac
+	_AIDEVOPS_RUNTIME_VERIFY_ACTIVE_ROOT="$active_root"
+	return 0
+}
 
-	active_bundle_dir="${active_root%/agents}"
+_runtime_bundle_verify_manifest() {
+	local active_root="$1"
+	local expected_sha="$2"
+	local active_bundle_dir="${active_root%/agents}"
+	local active_bundle_id=""
+	local manifest_file="$active_root/.bundle-manifest"
+	local manifest_status=""
+	local manifest_bundle_id=""
+	local manifest_version=""
+	local manifest_sha=""
+	local manifest_cli_sha=""
+	local expected_short="${expected_sha:0:12}"
+
 	active_bundle_id="${active_bundle_dir##*/}"
-	manifest_file="$active_root/.bundle-manifest"
 	if [[ ! -r "$manifest_file" ]]; then
 		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active bundle manifest is missing"
 		return 1
@@ -161,7 +160,6 @@ verify_aidevops_runtime_bundle_convergence() {
 	manifest_version=$(_runtime_bundle_verify_manifest_value "$manifest_file" framework_version 2>/dev/null) || manifest_version=""
 	manifest_sha=$(_runtime_bundle_verify_manifest_value "$manifest_file" git_sha 2>/dev/null) || manifest_sha=""
 	manifest_cli_sha=$(_runtime_bundle_verify_manifest_value "$manifest_file" cli_sha256 2>/dev/null) || manifest_cli_sha=""
-
 	if [[ "$manifest_status" != "validated" ]]; then
 		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active bundle manifest status is ${manifest_status:-missing}, expected validated"
 		return 1
@@ -170,7 +168,6 @@ verify_aidevops_runtime_bundle_convergence() {
 		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active realpath bundle ID ${active_bundle_id:-missing} does not match manifest bundle ID ${manifest_bundle_id:-missing}"
 		return 1
 	fi
-	expected_short="${resolved_expected_sha:0:12}"
 	case "$active_bundle_id" in
 	*-"$expected_short"-*) ;;
 	*)
@@ -178,31 +175,64 @@ verify_aidevops_runtime_bundle_convergence() {
 		return 1
 		;;
 	esac
+	if [[ "$manifest_sha" != "$expected_sha" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: manifest SHA ${manifest_sha:-missing} does not match release commit $expected_sha"
+		return 1
+	fi
+	_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_VERSION="$manifest_version"
+	_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_CLI_SHA="$manifest_cli_sha"
+	return 0
+}
 
-	repo_version=$(git -C "$repo_dir" show "${resolved_expected_sha}:VERSION" 2>/dev/null) || repo_version=""
+_runtime_bundle_verify_version_and_stamp() {
+	local repo_dir="$1"
+	local expected_sha="$2"
+	local active_root="$3"
+	local stamp_file="$4"
+	local repo_version=""
+	local active_version=""
+	local deployed_sha=""
+
+	repo_version=$(git -C "$repo_dir" show "${expected_sha}:VERSION" 2>/dev/null) || repo_version=""
 	if [[ -r "$active_root/VERSION" ]]; then
 		IFS= read -r active_version <"$active_root/VERSION" || active_version=""
 	fi
-	if [[ -z "$repo_version" || "$repo_version" != "$active_version" || "$repo_version" != "$manifest_version" ]]; then
-		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source version=${repo_version:-missing}, active version=${active_version:-missing}, manifest version=${manifest_version:-missing}"
-		return 1
-	fi
-	if [[ "$manifest_sha" != "$resolved_expected_sha" ]]; then
-		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: manifest SHA ${manifest_sha:-missing} does not match release commit $resolved_expected_sha"
+	if [[ -z "$repo_version" || "$repo_version" != "$active_version" || "$repo_version" != "$_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_VERSION" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source version=${repo_version:-missing}, active version=${active_version:-missing}, manifest version=${_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_VERSION:-missing}"
 		return 1
 	fi
 	if [[ -r "$stamp_file" ]]; then
 		deployed_sha=$(tr -d '[:space:]' <"$stamp_file" 2>/dev/null) || deployed_sha=""
 	fi
-	if [[ "$deployed_sha" != "$resolved_expected_sha" ]]; then
-		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: deployed SHA ${deployed_sha:-missing} does not match release commit $resolved_expected_sha"
+	if [[ "$deployed_sha" != "$expected_sha" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: deployed SHA ${deployed_sha:-missing} does not match release commit $expected_sha"
 		return 1
 	fi
+	return 0
+}
+
+_runtime_bundle_verify_sentinels() {
+	local repo_dir="$1"
+	local expected_sha="$2"
+	local active_root="$3"
+	local expected_short="${expected_sha:0:12}"
+	local sentinel_pair=""
+	local source_rel=""
+	local active_rel=""
+	local source_hash=""
+	local active_hash=""
+	local -a sentinel_pairs=(
+		"aidevops.sh|aidevops.sh"
+		".agents/scripts/version-manager-release.sh|scripts/version-manager-release.sh"
+		".agents/scripts/deploy-agents-on-merge.sh|scripts/deploy-agents-on-merge.sh"
+		".agents/scripts/runtime-bundle-verifier.sh|scripts/runtime-bundle-verifier.sh"
+		".agents/scripts/setup/modules/agent-deploy.sh|scripts/setup/modules/agent-deploy.sh"
+	)
 
 	for sentinel_pair in "${sentinel_pairs[@]}"; do
 		source_rel="${sentinel_pair%%|*}"
 		active_rel="${sentinel_pair#*|}"
-		source_hash=$(_runtime_bundle_verify_git_blob_sha256 "$repo_dir" "$resolved_expected_sha" "$source_rel" 2>/dev/null) || {
+		source_hash=$(_runtime_bundle_verify_git_blob_sha256 "$repo_dir" "$expected_sha" "$source_rel" 2>/dev/null) || {
 			_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: release commit sentinel $source_rel cannot be hashed"
 			return 1
 		}
@@ -214,11 +244,38 @@ verify_aidevops_runtime_bundle_convergence() {
 			_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active sentinel $active_rel does not match release commit $expected_short"
 			return 1
 		fi
-		if [[ "$source_rel" == "aidevops.sh" && "$manifest_cli_sha" != "$active_hash" ]]; then
+		if [[ "$source_rel" == "aidevops.sh" && "$_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_CLI_SHA" != "$active_hash" ]]; then
 			_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: manifest CLI hash does not match the active release sentinel"
 			return 1
 		fi
 	done
 
+	return 0
+}
+
+verify_aidevops_runtime_bundle_convergence() {
+	local repo_dir="$1"
+	local expected_sha="$2"
+	local active_link="${3:-${HOME}/.aidevops/agents}"
+	local stamp_file="${4:-${HOME}/.aidevops/.deployed-sha}"
+
+	_AIDEVOPS_RUNTIME_VERIFY_SOURCE_SHA=""
+	_AIDEVOPS_RUNTIME_VERIFY_ACTIVE_ROOT=""
+	_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_VERSION=""
+	_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_CLI_SHA=""
+	_runtime_bundle_verify_source "$repo_dir" "$expected_sha" || return 1
+	_runtime_bundle_verify_active_link "$active_link" || return 1
+	_runtime_bundle_verify_manifest \
+		"$_AIDEVOPS_RUNTIME_VERIFY_ACTIVE_ROOT" \
+		"$_AIDEVOPS_RUNTIME_VERIFY_SOURCE_SHA" || return 1
+	_runtime_bundle_verify_version_and_stamp \
+		"$repo_dir" \
+		"$_AIDEVOPS_RUNTIME_VERIFY_SOURCE_SHA" \
+		"$_AIDEVOPS_RUNTIME_VERIFY_ACTIVE_ROOT" \
+		"$stamp_file" || return 1
+	_runtime_bundle_verify_sentinels \
+		"$repo_dir" \
+		"$_AIDEVOPS_RUNTIME_VERIFY_SOURCE_SHA" \
+		"$_AIDEVOPS_RUNTIME_VERIFY_ACTIVE_ROOT" || return 1
 	return 0
 }

--- a/.agents/scripts/runtime-bundle-verifier.sh
+++ b/.agents/scripts/runtime-bundle-verifier.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Authoritative post-deployment verifier shared by setup, update, and release
+# paths. The caller supplies the source checkout and expected commit; this
+# helper proves that the stable activation link selects a validated immutable
+# bundle produced from that exact revision.
+
+_runtime_bundle_verify_emit_error() {
+	local message="$1"
+	if declare -F print_error >/dev/null 2>&1; then
+		print_error "$message"
+	else
+		printf 'ERROR: %s\n' "$message" >&2
+	fi
+	return 0
+}
+
+_runtime_bundle_verify_manifest_value() {
+	local manifest_file="$1"
+	local key="$2"
+	local line=""
+
+	[[ -r "$manifest_file" ]] || return 1
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		case "$line" in
+		"${key}="*)
+			printf '%s' "${line#*=}"
+			return 0
+			;;
+		esac
+	done <"$manifest_file"
+	return 1
+}
+
+_runtime_bundle_verify_sha256_file() {
+	local file="$1"
+	local digest=""
+
+	[[ -r "$file" ]] || return 1
+	if command -v sha256sum >/dev/null 2>&1; then
+		digest=$(sha256sum "$file" 2>/dev/null | cut -d' ' -f1) || return 1
+	elif command -v shasum >/dev/null 2>&1; then
+		digest=$(shasum -a 256 "$file" 2>/dev/null | cut -d' ' -f1) || return 1
+	elif command -v openssl >/dev/null 2>&1; then
+		digest=$(openssl dgst -sha256 "$file" 2>/dev/null | sed 's/^.*= //') || return 1
+	else
+		return 1
+	fi
+	case "$digest" in
+	'' | *[!0-9a-fA-F]*) return 1 ;;
+	esac
+	printf '%s' "$digest"
+	return 0
+}
+
+verify_aidevops_runtime_bundle_convergence() {
+	local repo_dir="$1"
+	local expected_sha="$2"
+	local active_link="${3:-${HOME}/.aidevops/agents}"
+	local stamp_file="${4:-${HOME}/.aidevops/.deployed-sha}"
+	local source_sha=""
+	local resolved_expected_sha=""
+	local active_root=""
+	local bundles_root=""
+	local active_bundle_dir=""
+	local active_bundle_id=""
+	local manifest_file=""
+	local manifest_status=""
+	local manifest_bundle_id=""
+	local manifest_version=""
+	local manifest_sha=""
+	local manifest_cli_sha=""
+	local repo_version=""
+	local active_version=""
+	local deployed_sha=""
+	local expected_short=""
+	local sentinel_pair=""
+	local source_rel=""
+	local active_rel=""
+	local source_hash=""
+	local active_hash=""
+	local -a sentinel_pairs=(
+		"aidevops.sh|aidevops.sh"
+		".agents/scripts/version-manager-release.sh|scripts/version-manager-release.sh"
+		".agents/scripts/deploy-agents-on-merge.sh|scripts/deploy-agents-on-merge.sh"
+		".agents/scripts/runtime-bundle-verifier.sh|scripts/runtime-bundle-verifier.sh"
+		".agents/scripts/setup/modules/agent-deploy.sh|scripts/setup/modules/agent-deploy.sh"
+	)
+
+	if [[ -z "$repo_dir" || ! -d "$repo_dir" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source checkout is unavailable"
+		return 1
+	fi
+	resolved_expected_sha=$(git -C "$repo_dir" rev-parse "${expected_sha}^{commit}" 2>/dev/null) || {
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: expected source commit cannot be resolved"
+		return 1
+	}
+	source_sha=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null) || {
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source checkout HEAD cannot be resolved"
+		return 1
+	}
+	if [[ "$source_sha" != "$resolved_expected_sha" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source checkout HEAD ${source_sha:0:12} does not match release commit ${resolved_expected_sha:0:12}"
+		return 1
+	fi
+
+	if [[ ! -L "$active_link" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active agents path is not an atomic activation symlink"
+		return 1
+	fi
+	active_root=$(cd "$active_link" 2>/dev/null && pwd -P) || {
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active agents symlink cannot be resolved"
+		return 1
+	}
+	bundles_root=$(cd "${active_link%/*}/runtime-bundles" 2>/dev/null && pwd -P) || {
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: immutable runtime-bundles directory is unavailable"
+		return 1
+	}
+	case "$active_root" in
+	"$bundles_root"/*/agents) ;;
+	*)
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active agents realpath is outside the immutable runtime-bundles directory"
+		return 1
+		;;
+	esac
+
+	active_bundle_dir="${active_root%/agents}"
+	active_bundle_id="${active_bundle_dir##*/}"
+	manifest_file="$active_root/.bundle-manifest"
+	if [[ ! -r "$manifest_file" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active bundle manifest is missing"
+		return 1
+	fi
+	manifest_status=$(_runtime_bundle_verify_manifest_value "$manifest_file" status 2>/dev/null) || manifest_status=""
+	manifest_bundle_id=$(_runtime_bundle_verify_manifest_value "$manifest_file" bundle_id 2>/dev/null) || manifest_bundle_id=""
+	manifest_version=$(_runtime_bundle_verify_manifest_value "$manifest_file" framework_version 2>/dev/null) || manifest_version=""
+	manifest_sha=$(_runtime_bundle_verify_manifest_value "$manifest_file" git_sha 2>/dev/null) || manifest_sha=""
+	manifest_cli_sha=$(_runtime_bundle_verify_manifest_value "$manifest_file" cli_sha256 2>/dev/null) || manifest_cli_sha=""
+
+	if [[ "$manifest_status" != "validated" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active bundle manifest status is ${manifest_status:-missing}, expected validated"
+		return 1
+	fi
+	if [[ -z "$manifest_bundle_id" || "$manifest_bundle_id" != "$active_bundle_id" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active realpath bundle ID ${active_bundle_id:-missing} does not match manifest bundle ID ${manifest_bundle_id:-missing}"
+		return 1
+	fi
+	expected_short="${resolved_expected_sha:0:12}"
+	case "$active_bundle_id" in
+	*-"$expected_short"-*) ;;
+	*)
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active realpath bundle ID does not identify release commit $expected_short"
+		return 1
+		;;
+	esac
+
+	if [[ -r "$repo_dir/VERSION" ]]; then
+		IFS= read -r repo_version <"$repo_dir/VERSION" || repo_version=""
+	fi
+	if [[ -r "$active_root/VERSION" ]]; then
+		IFS= read -r active_version <"$active_root/VERSION" || active_version=""
+	fi
+	if [[ -z "$repo_version" || "$repo_version" != "$active_version" || "$repo_version" != "$manifest_version" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source version=${repo_version:-missing}, active version=${active_version:-missing}, manifest version=${manifest_version:-missing}"
+		return 1
+	fi
+	if [[ "$manifest_sha" != "$resolved_expected_sha" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: manifest SHA ${manifest_sha:-missing} does not match release commit $resolved_expected_sha"
+		return 1
+	fi
+	if [[ -r "$stamp_file" ]]; then
+		deployed_sha=$(tr -d '[:space:]' <"$stamp_file" 2>/dev/null) || deployed_sha=""
+	fi
+	if [[ "$deployed_sha" != "$resolved_expected_sha" ]]; then
+		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: deployed SHA ${deployed_sha:-missing} does not match release commit $resolved_expected_sha"
+		return 1
+	fi
+
+	for sentinel_pair in "${sentinel_pairs[@]}"; do
+		source_rel="${sentinel_pair%%|*}"
+		active_rel="${sentinel_pair#*|}"
+		source_hash=$(_runtime_bundle_verify_sha256_file "$repo_dir/$source_rel" 2>/dev/null) || {
+			_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source sentinel $source_rel cannot be hashed"
+			return 1
+		}
+		active_hash=$(_runtime_bundle_verify_sha256_file "$active_root/$active_rel" 2>/dev/null) || {
+			_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active sentinel $active_rel cannot be hashed"
+			return 1
+		}
+		if [[ "$source_hash" != "$active_hash" ]]; then
+			_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: active sentinel $active_rel does not match release commit $expected_short"
+			return 1
+		fi
+		if [[ "$source_rel" == "aidevops.sh" && "$manifest_cli_sha" != "$active_hash" ]]; then
+			_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: manifest CLI hash does not match the active release sentinel"
+			return 1
+		fi
+	done
+
+	return 0
+}

--- a/.agents/scripts/runtime-bundle-verifier.sh
+++ b/.agents/scripts/runtime-bundle-verifier.sh
@@ -55,6 +55,29 @@ _runtime_bundle_verify_sha256_file() {
 	return 0
 }
 
+_runtime_bundle_verify_git_blob_sha256() {
+	local repo_dir="$1"
+	local commit_sha="$2"
+	local file_path="$3"
+	local digest=""
+
+	git -C "$repo_dir" cat-file -e "${commit_sha}:${file_path}" 2>/dev/null || return 1
+	if command -v sha256sum >/dev/null 2>&1; then
+		digest=$(git -C "$repo_dir" show "${commit_sha}:${file_path}" 2>/dev/null | sha256sum | cut -d' ' -f1) || return 1
+	elif command -v shasum >/dev/null 2>&1; then
+		digest=$(git -C "$repo_dir" show "${commit_sha}:${file_path}" 2>/dev/null | shasum -a 256 | cut -d' ' -f1) || return 1
+	elif command -v openssl >/dev/null 2>&1; then
+		digest=$(git -C "$repo_dir" show "${commit_sha}:${file_path}" 2>/dev/null | openssl dgst -sha256 | sed 's/^.*= //') || return 1
+	else
+		return 1
+	fi
+	case "$digest" in
+	'' | *[!0-9a-fA-F]*) return 1 ;;
+	esac
+	printf '%s' "$digest"
+	return 0
+}
+
 verify_aidevops_runtime_bundle_convergence() {
 	local repo_dir="$1"
 	local expected_sha="$2"
@@ -156,9 +179,7 @@ verify_aidevops_runtime_bundle_convergence() {
 		;;
 	esac
 
-	if [[ -r "$repo_dir/VERSION" ]]; then
-		IFS= read -r repo_version <"$repo_dir/VERSION" || repo_version=""
-	fi
+	repo_version=$(git -C "$repo_dir" show "${resolved_expected_sha}:VERSION" 2>/dev/null) || repo_version=""
 	if [[ -r "$active_root/VERSION" ]]; then
 		IFS= read -r active_version <"$active_root/VERSION" || active_version=""
 	fi
@@ -181,8 +202,8 @@ verify_aidevops_runtime_bundle_convergence() {
 	for sentinel_pair in "${sentinel_pairs[@]}"; do
 		source_rel="${sentinel_pair%%|*}"
 		active_rel="${sentinel_pair#*|}"
-		source_hash=$(_runtime_bundle_verify_sha256_file "$repo_dir/$source_rel" 2>/dev/null) || {
-			_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source sentinel $source_rel cannot be hashed"
+		source_hash=$(_runtime_bundle_verify_git_blob_sha256 "$repo_dir" "$resolved_expected_sha" "$source_rel" 2>/dev/null) || {
+			_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: release commit sentinel $source_rel cannot be hashed"
 			return 1
 		}
 		active_hash=$(_runtime_bundle_verify_sha256_file "$active_root/$active_rel" 2>/dev/null) || {

--- a/.agents/scripts/runtime-bundle-verifier.sh
+++ b/.agents/scripts/runtime-bundle-verifier.sh
@@ -34,6 +34,18 @@ _runtime_bundle_verify_manifest_value() {
 	return 1
 }
 
+_runtime_bundle_verify_first_line() {
+	local file="$1"
+	local value=""
+
+	[[ -r "$file" ]] || return 1
+	if ! IFS= read -r value <"$file" && [[ -z "$value" ]]; then
+		return 1
+	fi
+	printf '%s' "$value"
+	return 0
+}
+
 _runtime_bundle_verify_sha256_file() {
 	local file="$1"
 	local digest=""
@@ -194,9 +206,7 @@ _runtime_bundle_verify_version_and_stamp() {
 	local deployed_sha=""
 
 	repo_version=$(git -C "$repo_dir" show "${expected_sha}:VERSION" 2>/dev/null) || repo_version=""
-	if [[ -r "$active_root/VERSION" ]]; then
-		IFS= read -r active_version <"$active_root/VERSION" || active_version=""
-	fi
+	active_version=$(_runtime_bundle_verify_first_line "$active_root/VERSION" 2>/dev/null) || active_version=""
 	if [[ -z "$repo_version" || "$repo_version" != "$active_version" || "$repo_version" != "$_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_VERSION" ]]; then
 		_runtime_bundle_verify_emit_error "Runtime bundle convergence failed: source version=${repo_version:-missing}, active version=${active_version:-missing}, manifest version=${_AIDEVOPS_RUNTIME_VERIFY_MANIFEST_VERSION:-missing}"
 		return 1

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -71,7 +71,8 @@ if [[ "${MOCK_DEPLOY_MODE:-current}" == "stale-active" ]]; then
 elif [[ "${MOCK_DEPLOY_MODE:-current}" == "stale-stamp" ]]; then
 	stamp_sha="1111111111111111111111111111111111111111"
 fi
-IFS= read -r framework_version <"$repo_root/VERSION"
+framework_version=""
+IFS= read -r framework_version <"$repo_root/VERSION" || [[ -n "$framework_version" ]]
 bundle_id="${framework_version}-${bundle_sha:0:12}-fixture"
 bundle_root="$HOME/.aidevops/runtime-bundles/$bundle_id/agents"
 rm -rf "${bundle_root%/agents}"
@@ -259,6 +260,23 @@ test_release_sync_propagates_deploy_failure() {
 	return 0
 }
 
+test_release_sync_accepts_version_without_trailing_newline() {
+	: >"$TEST_DIR/sync.log"
+	local repo_path
+	local output=""
+	repo_path=$(create_fake_repo "release-version-no-newline" "https://github.com/marcusquinn/aidevops.git")
+	printf '9.9.9' >"$repo_path/VERSION"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" add VERSION
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" commit -qm "remove version trailing newline"
+
+	if output=$(invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync accepts VERSION without a trailing newline" 0
+	else
+		print_result "release sync accepts VERSION without a trailing newline" 1 "Unterminated VERSION was rejected: $output"
+	fi
+	return 0
+}
+
 test_release_sync_rejects_stale_active_bundle() {
 	: >"$TEST_DIR/sync.log"
 	local repo_path
@@ -331,6 +349,7 @@ main() {
 	test_release_sync_explicit_full
 	test_release_sync_skips_other_remotes
 	test_release_sync_propagates_deploy_failure
+	test_release_sync_accepts_version_without_trailing_newline
 	test_release_sync_rejects_stale_active_bundle
 	test_release_sync_rejects_stale_deployed_sha
 	test_release_sync_rejects_stale_sentinel

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -39,7 +39,7 @@ setup() {
 	TEST_HOME="$TEST_DIR/home"
 	trap teardown EXIT
 	mkdir -p "$TEST_DIR/repo/.agents/scripts" "$TEST_HOME/.aidevops"
-cat >"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" <<'EOF'
+	cat >"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'AIDEVOPS_AGENTS_DIR=%s\n' "${AIDEVOPS_AGENTS_DIR-unset}" >>"${SYNC_ENV_LOG_PATH:?SYNC_ENV_LOG_PATH must be set}"
@@ -312,7 +312,7 @@ test_release_sync_unsets_session_pins() {
 		AGENTS_DIR="$TEST_DIR/.aidevops/runtime-bundles/old/agents" \
 		invoke_release_sync "$repo_path"
 
-	if grep -q '^AIDEVOPS_AGENTS_DIR=unset$' "$TEST_DIR/sync-env.log" && \
+	if grep -q '^AIDEVOPS_AGENTS_DIR=unset$' "$TEST_DIR/sync-env.log" &&
 		grep -q '^AGENTS_DIR=unset$' "$TEST_DIR/sync-env.log"; then
 		print_result "release sync isolates inherited runtime pins" 0
 	else

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -13,6 +13,7 @@ TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
 TEST_DIR=""
+TEST_HOME=""
 
 print_result() {
 	local test_name="$1"
@@ -35,15 +36,81 @@ print_result() {
 
 setup() {
 	TEST_DIR=$(mktemp -d)
+	TEST_HOME="$TEST_DIR/home"
 	trap teardown EXIT
-	mkdir -p "$TEST_DIR/repo/.agents/scripts"
+	mkdir -p "$TEST_DIR/repo/.agents/scripts" "$TEST_HOME/.aidevops"
 cat >"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'AIDEVOPS_AGENTS_DIR=%s\n' "${AIDEVOPS_AGENTS_DIR-unset}" >>"${SYNC_ENV_LOG_PATH:?SYNC_ENV_LOG_PATH must be set}"
 printf 'AGENTS_DIR=%s\n' "${AGENTS_DIR-unset}" >>"$SYNC_ENV_LOG_PATH"
 printf '%s\n' "$*" >>"${SYNC_LOG_PATH:?SYNC_LOG_PATH must be set}"
-exit "${MOCK_DEPLOY_EXIT_CODE:-0}"
+if [[ "${MOCK_DEPLOY_EXIT_CODE:-0}" -ne 0 ]]; then
+	exit "$MOCK_DEPLOY_EXIT_CODE"
+fi
+if [[ "${MOCK_DEPLOY_SKIP_ACTIVATION:-0}" == "1" ]]; then
+	exit 0
+fi
+
+repo_root=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--repo)
+		repo_root="$2"
+		shift 2
+		;;
+	*) shift ;;
+	esac
+done
+[[ -n "$repo_root" ]]
+source_sha=$(git -C "$repo_root" rev-parse HEAD)
+bundle_sha="$source_sha"
+if [[ "${MOCK_DEPLOY_MODE:-current}" == "stale" ]]; then
+	bundle_sha="1111111111111111111111111111111111111111"
+fi
+IFS= read -r framework_version <"$repo_root/VERSION"
+bundle_id="${framework_version}-${bundle_sha:0:12}-fixture"
+bundle_root="$HOME/.aidevops/runtime-bundles/$bundle_id/agents"
+rm -rf "${bundle_root%/agents}"
+mkdir -p "$bundle_root/scripts/setup/modules"
+
+for sentinel_pair in \
+	"aidevops.sh|aidevops.sh" \
+	".agents/scripts/version-manager-release.sh|scripts/version-manager-release.sh" \
+	".agents/scripts/deploy-agents-on-merge.sh|scripts/deploy-agents-on-merge.sh" \
+	".agents/scripts/runtime-bundle-verifier.sh|scripts/runtime-bundle-verifier.sh" \
+	".agents/scripts/setup/modules/agent-deploy.sh|scripts/setup/modules/agent-deploy.sh"; do
+	source_rel="${sentinel_pair%%|*}"
+	active_rel="${sentinel_pair#*|}"
+	mkdir -p "$(dirname "$bundle_root/$active_rel")"
+	cp "$repo_root/$source_rel" "$bundle_root/$active_rel"
+done
+cp "$repo_root/VERSION" "$bundle_root/VERSION"
+if command -v sha256sum >/dev/null 2>&1; then
+	cli_sha=$(sha256sum "$bundle_root/aidevops.sh" | cut -d' ' -f1)
+else
+	cli_sha=$(shasum -a 256 "$bundle_root/aidevops.sh" | cut -d' ' -f1)
+fi
+cat >"$bundle_root/.bundle-manifest" <<EOF_MANIFEST
+schema=1
+status=validated
+bundle_id=$bundle_id
+framework_version=$framework_version
+git_sha=$bundle_sha
+cli_sha256=$cli_sha
+EOF_MANIFEST
+
+active_link="$HOME/.aidevops/agents"
+link_tmp="${active_link}.tmp.$$"
+rm -f "$link_tmp"
+ln -s "$bundle_root" "$link_tmp"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+	mv -f -h "$link_tmp" "$active_link"
+else
+	mv -Tf "$link_tmp" "$active_link"
+fi
+printf '%s\n' "$bundle_sha" >"$HOME/.aidevops/.deployed-sha"
+exit 0
 EOF
 	chmod +x "$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh"
 	: >"$TEST_DIR/sync.log"
@@ -62,6 +129,7 @@ invoke_github_sync() {
 	local repo_slug="$1"
 	AIDEVOPS_SYNC_REPO_PATH="$TEST_DIR/repo" \
 		AIDEVOPS_SYNC_DEPLOY_SCRIPT="$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" \
+		MOCK_DEPLOY_SKIP_ACTIVATION=1 \
 		SYNC_LOG_PATH="$TEST_DIR/sync.log" \
 		SYNC_ENV_LOG_PATH="$TEST_DIR/sync-env.log" \
 		MOCK_DEPLOY_EXIT_CODE="${MOCK_DEPLOY_EXIT_CODE:-0}" \
@@ -75,9 +143,11 @@ invoke_release_sync() {
 	AIDEVOPS_SYNC_REPO_ROOT="$repo_root" \
 		AIDEVOPS_RELEASE_DEPLOY_SCOPE="$deployment_scope" \
 		AIDEVOPS_SYNC_DEPLOY_SCRIPT="$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" \
+		HOME="$TEST_HOME" \
 		SYNC_LOG_PATH="$TEST_DIR/sync.log" \
 		SYNC_ENV_LOG_PATH="$TEST_DIR/sync-env.log" \
 		MOCK_DEPLOY_EXIT_CODE="${MOCK_DEPLOY_EXIT_CODE:-0}" \
+		MOCK_DEPLOY_MODE="${MOCK_DEPLOY_MODE:-current}" \
 		bash -c 'source "$1" && run_post_release_agent_sync' _ "$VERSION_HELPER"
 	return $?
 }
@@ -87,10 +157,21 @@ create_fake_repo() {
 	local remote_url="$2"
 	local repo_path="$TEST_DIR/$repo_name"
 
-	mkdir -p "$repo_path"
+	mkdir -p "$repo_path/.agents/scripts/setup/modules"
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git init -q "$repo_path"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" config user.email test@example.invalid
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" config user.name Test
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" config commit.gpgsign false
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" remote add origin "$remote_url"
 	printf '#!/usr/bin/env bash\nexit 0\n' >"$repo_path/setup.sh"
+	printf '#!/usr/bin/env bash\nprintf "fixture cli\\n"\n' >"$repo_path/aidevops.sh"
+	printf '9.9.9\n' >"$repo_path/VERSION"
+	printf 'release fixture\n' >"$repo_path/.agents/scripts/version-manager-release.sh"
+	printf 'deploy fixture\n' >"$repo_path/.agents/scripts/deploy-agents-on-merge.sh"
+	printf 'verifier fixture\n' >"$repo_path/.agents/scripts/runtime-bundle-verifier.sh"
+	printf 'agent deploy fixture\n' >"$repo_path/.agents/scripts/setup/modules/agent-deploy.sh"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" add .
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" commit -qm fixture
 	printf '%s\n' "$repo_path"
 	return 0
 }
@@ -172,6 +253,21 @@ test_release_sync_propagates_deploy_failure() {
 	return 0
 }
 
+test_release_sync_rejects_stale_provenance() {
+	: >"$TEST_DIR/sync.log"
+	local repo_path
+	local output=""
+	repo_path=$(create_fake_repo "release-stale" "https://github.com/marcusquinn/aidevops.git")
+	if output=$(MOCK_DEPLOY_MODE=stale invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync rejects stale activation provenance" 1 "Stale deployment was reported as converged"
+	elif [[ "$output" == *"does not identify release commit"* && "$output" == *"provenance did not converge"* ]]; then
+		print_result "release sync rejects stale activation provenance" 0
+	else
+		print_result "release sync rejects stale activation provenance" 1 "Missing actionable stale-provenance evidence: $output"
+	fi
+	return 0
+}
+
 test_release_sync_unsets_session_pins() {
 	: >"$TEST_DIR/sync-env.log"
 	local repo_path
@@ -199,6 +295,7 @@ main() {
 	test_release_sync_explicit_full
 	test_release_sync_skips_other_remotes
 	test_release_sync_propagates_deploy_failure
+	test_release_sync_rejects_stale_provenance
 	test_release_sync_unsets_session_pins
 
 	teardown

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -65,8 +65,11 @@ done
 [[ -n "$repo_root" ]]
 source_sha=$(git -C "$repo_root" rev-parse HEAD)
 bundle_sha="$source_sha"
-if [[ "${MOCK_DEPLOY_MODE:-current}" == "stale" ]]; then
+stamp_sha="$source_sha"
+if [[ "${MOCK_DEPLOY_MODE:-current}" == "stale-active" ]]; then
 	bundle_sha="1111111111111111111111111111111111111111"
+elif [[ "${MOCK_DEPLOY_MODE:-current}" == "stale-stamp" ]]; then
+	stamp_sha="1111111111111111111111111111111111111111"
 fi
 IFS= read -r framework_version <"$repo_root/VERSION"
 bundle_id="${framework_version}-${bundle_sha:0:12}-fixture"
@@ -85,6 +88,9 @@ for sentinel_pair in \
 	mkdir -p "$(dirname "$bundle_root/$active_rel")"
 	cp "$repo_root/$source_rel" "$bundle_root/$active_rel"
 done
+if [[ "${MOCK_DEPLOY_MODE:-current}" == "stale-sentinel" ]]; then
+	printf '%s\n' 'stale release helper' >"$bundle_root/scripts/version-manager-release.sh"
+fi
 cp "$repo_root/VERSION" "$bundle_root/VERSION"
 if command -v sha256sum >/dev/null 2>&1; then
 	cli_sha=$(sha256sum "$bundle_root/aidevops.sh" | cut -d' ' -f1)
@@ -109,7 +115,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
 else
 	mv -Tf "$link_tmp" "$active_link"
 fi
-printf '%s\n' "$bundle_sha" >"$HOME/.aidevops/.deployed-sha"
+printf '%s\n' "$stamp_sha" >"$HOME/.aidevops/.deployed-sha"
 exit 0
 EOF
 	chmod +x "$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh"
@@ -253,17 +259,47 @@ test_release_sync_propagates_deploy_failure() {
 	return 0
 }
 
-test_release_sync_rejects_stale_provenance() {
+test_release_sync_rejects_stale_active_bundle() {
 	: >"$TEST_DIR/sync.log"
 	local repo_path
 	local output=""
-	repo_path=$(create_fake_repo "release-stale" "https://github.com/marcusquinn/aidevops.git")
-	if output=$(MOCK_DEPLOY_MODE=stale invoke_release_sync "$repo_path" 2>&1); then
-		print_result "release sync rejects stale activation provenance" 1 "Stale deployment was reported as converged"
+	repo_path=$(create_fake_repo "release-stale-active" "https://github.com/marcusquinn/aidevops.git")
+	if output=$(MOCK_DEPLOY_MODE=stale-active invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync rejects a stale active bundle" 1 "Stale deployment was reported as converged"
 	elif [[ "$output" == *"does not identify release commit"* && "$output" == *"provenance did not converge"* ]]; then
-		print_result "release sync rejects stale activation provenance" 0
+		print_result "release sync rejects a stale active bundle" 0
 	else
-		print_result "release sync rejects stale activation provenance" 1 "Missing actionable stale-provenance evidence: $output"
+		print_result "release sync rejects a stale active bundle" 1 "Missing actionable stale-active evidence: $output"
+	fi
+	return 0
+}
+
+test_release_sync_rejects_stale_deployed_sha() {
+	: >"$TEST_DIR/sync.log"
+	local repo_path
+	local output=""
+	repo_path=$(create_fake_repo "release-stale-stamp" "https://github.com/marcusquinn/aidevops.git")
+	if output=$(MOCK_DEPLOY_MODE=stale-stamp invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync rejects a stale deployed SHA" 1 "Stale deployment stamp was reported as converged"
+	elif [[ "$output" == *"deployed SHA"* && "$output" == *"does not match release commit"* ]]; then
+		print_result "release sync rejects a stale deployed SHA" 0
+	else
+		print_result "release sync rejects a stale deployed SHA" 1 "Missing actionable stale-stamp evidence: $output"
+	fi
+	return 0
+}
+
+test_release_sync_rejects_stale_sentinel() {
+	: >"$TEST_DIR/sync.log"
+	local repo_path
+	local output=""
+	repo_path=$(create_fake_repo "release-stale-sentinel" "https://github.com/marcusquinn/aidevops.git")
+	if output=$(MOCK_DEPLOY_MODE=stale-sentinel invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync rejects a stale sentinel hash" 1 "Stale release sentinel was reported as converged"
+	elif [[ "$output" == *"active sentinel scripts/version-manager-release.sh"* && "$output" == *"does not match release commit"* ]]; then
+		print_result "release sync rejects a stale sentinel hash" 0
+	else
+		print_result "release sync rejects a stale sentinel hash" 1 "Missing actionable stale-sentinel evidence: $output"
 	fi
 	return 0
 }
@@ -295,7 +331,9 @@ main() {
 	test_release_sync_explicit_full
 	test_release_sync_skips_other_remotes
 	test_release_sync_propagates_deploy_failure
-	test_release_sync_rejects_stale_provenance
+	test_release_sync_rejects_stale_active_bundle
+	test_release_sync_rejects_stale_deployed_sha
+	test_release_sync_rejects_stale_sentinel
 	test_release_sync_unsets_session_pins
 
 	teardown

--- a/.agents/scripts/tests/test-incremental-deploy-runtime-config.sh
+++ b/.agents/scripts/tests/test-incremental-deploy-runtime-config.sh
@@ -10,6 +10,8 @@ TEST_ROOT="$(mktemp -d)"
 FIXTURE_REPO="$TEST_ROOT/repo"
 TEST_HOME="$TEST_ROOT/home"
 MARKER="$TEST_ROOT/runtime-config-generated"
+SETUP_CALLS="$TEST_ROOT/setup-calls"
+OLD_BUNDLE="$TEST_HOME/.aidevops/runtime-bundles/old/agents"
 
 cleanup() {
 	rm -rf "$TEST_ROOT"
@@ -17,10 +19,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$FIXTURE_REPO/.agents/scripts" "$TEST_HOME/.aidevops/agents"
+mkdir -p "$FIXTURE_REPO/.agents/scripts" "$OLD_BUNDLE/scripts"
 git -C "$FIXTURE_REPO" init -q
 printf '%s\n' 'ref: refs/heads/fixture' >"$FIXTURE_REPO/.git/HEAD"
 printf '%s\n' '3.32.107' >"$FIXTURE_REPO/VERSION"
+printf '%s\n' 'old immutable sentinel' >"$OLD_BUNDLE/scripts/example-helper.sh"
+ln -s "$OLD_BUNDLE" "$TEST_HOME/.aidevops/agents"
 cat >"$FIXTURE_REPO/.agents/scripts/generate-runtime-config.sh" <<EOF_GENERATOR
 #!/usr/bin/env bash
 printf '%s\n' "\$1" >"$MARKER"
@@ -30,10 +34,47 @@ cat >"$FIXTURE_REPO/.agents/scripts/example-helper.sh" <<'EOF_HELPER'
 #!/usr/bin/env bash
 exit 0
 EOF_HELPER
+cat >"$FIXTURE_REPO/setup.sh" <<'EOF_SETUP'
+#!/usr/bin/env bash
+set -euo pipefail
 
-HOME="$TEST_HOME" bash "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh" \
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+printf '%s\n' "$*" >"${SETUP_CALLS:?SETUP_CALLS must be set}"
+printf 'AIDEVOPS_AGENTS_DIR=%s\n' "${AIDEVOPS_AGENTS_DIR-unset}" >>"$SETUP_CALLS"
+printf 'AGENTS_DIR=%s\n' "${AGENTS_DIR-unset}" >>"$SETUP_CALLS"
+if [[ "${MOCK_SETUP_EXIT_CODE:-0}" -ne 0 ]]; then
+	exit "$MOCK_SETUP_EXIT_CODE"
+fi
+
+bash "$repo_root/.agents/scripts/generate-runtime-config.sh" all
+new_root="$HOME/.aidevops/runtime-bundles/new/agents"
+mkdir -p "$new_root/scripts"
+cp "$repo_root/.agents/scripts/example-helper.sh" "$new_root/scripts/example-helper.sh"
+cp "$repo_root/VERSION" "$new_root/VERSION"
+link_tmp="$HOME/.aidevops/agents.tmp.$$"
+rm -f "$link_tmp"
+ln -s "$new_root" "$link_tmp"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+	mv -f -h "$link_tmp" "$HOME/.aidevops/agents"
+else
+	mv -Tf "$link_tmp" "$HOME/.aidevops/agents"
+fi
+exit 0
+EOF_SETUP
+chmod +x "$FIXTURE_REPO/setup.sh"
+
+HOME="$TEST_HOME" SETUP_CALLS="$SETUP_CALLS" \
+	AIDEVOPS_AGENTS_DIR="$OLD_BUNDLE" AGENTS_DIR="$OLD_BUNDLE" \
+	bash "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh" \
 	--repo "$FIXTURE_REPO" --scripts-only --quiet
 grep -Fxq 'all' "$MARKER"
+grep -Fxq -- '--stage ai-session' "$SETUP_CALLS"
+grep -Fxq 'AIDEVOPS_AGENTS_DIR=unset' "$SETUP_CALLS"
+grep -Fxq 'AGENTS_DIR=unset' "$SETUP_CALLS"
+grep -Fxq 'old immutable sentinel' "$OLD_BUNDLE/scripts/example-helper.sh"
+ACTIVE_ROOT=$(cd "$TEST_HOME/.aidevops/agents" && pwd -P)
+[[ "$ACTIVE_ROOT" != "$OLD_BUNDLE" ]]
+grep -Fxq '#!/usr/bin/env bash' "$ACTIVE_ROOT/scripts/example-helper.sh"
 
 if bash -c 'source "$1"; runtime_config_changes_detected ".agents/scripts/example-helper.sh"' \
 	_ "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh"; then
@@ -50,11 +91,12 @@ cat >"$FIXTURE_REPO/.agents/scripts/generate-runtime-config.sh" <<'EOF_FAILURE'
 #!/usr/bin/env bash
 exit 9
 EOF_FAILURE
-if HOME="$TEST_HOME" bash "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh" \
+if HOME="$TEST_HOME" SETUP_CALLS="$SETUP_CALLS" \
+	bash "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh" \
 	--repo "$FIXTURE_REPO" --scripts-only --quiet; then
 	printf '%s\n' 'FAIL: incremental deploy ignored runtime config regeneration failure' >&2
 	exit 1
 fi
 
-printf '%s\n' 'PASS: incremental deployment regenerates derived runtime config and propagates failures'
+printf '%s\n' 'PASS: incremental deployment stages atomically, preserves the previous bundle, regenerates runtime config, and propagates failures'
 exit 0

--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -167,7 +167,8 @@ test_linked_worktree_checkout_contract() {
 		rm -rf "$tmp_dir"
 		return 0
 	}
-	helper_text=$(python3 - "$SETUP_SH" <<'PY'
+	helper_text=$(
+		python3 - "$SETUP_SH" <<'PY'
 import pathlib
 import re
 import sys

--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REPO_ROOT="${SCRIPT_DIR}/../../.."
 SETUP_SH="${REPO_ROOT}/setup.sh"
 AIDEVOPS_SH="${REPO_ROOT}/aidevops.sh"
+RUNTIME_BUNDLE_VERIFIER="${REPO_ROOT}/.agents/scripts/runtime-bundle-verifier.sh"
 PACKAGE_JSON="${REPO_ROOT}/package.json"
 GUI_WEB_PACKAGE_JSON="${REPO_ROOT}/packages/gui-web/package.json"
 
@@ -92,8 +93,13 @@ PY
 
 test_setup_stage_contract() {
 	local text=""
+	local verifier_text=""
 	text="$(file_text "$SETUP_SH")" || {
 		print_result "setup.sh is readable" 1 "$SETUP_SH"
+		return 0
+	}
+	verifier_text="$(file_text "$RUNTIME_BUNDLE_VERIFIER")" || {
+		print_result "runtime bundle verifier is readable" 1 "$RUNTIME_BUNDLE_VERIFIER"
 		return 0
 	}
 
@@ -112,10 +118,13 @@ test_setup_stage_contract() {
 	# shellcheck disable=SC2016 # Match literal setup.sh expressions.
 	assert_contains "ai-session resolves linked worktree common git dir" "$text" 'git -C "$checkout_root" rev-parse --git-common-dir'
 	assert_contains "ai-session verifies deployed sha" "$text" "_setup_ai_session_verify_deploy \"\$current_sha\""
-	# shellcheck disable=SC2016 # Match literal setup.sh expressions.
-	assert_contains "ai-session verifies active bundle manifest version" "$text" '_setup_bundle_manifest_value "$manifest_file" framework_version'
-	# shellcheck disable=SC2016 # Match literal setup.sh expressions.
-	assert_contains "ai-session verifies active bundle manifest sha" "$text" '_setup_bundle_manifest_value "$manifest_file" git_sha'
+	assert_contains "setup sources the authoritative runtime bundle verifier" "$text" '.agents/scripts/runtime-bundle-verifier.sh'
+	assert_contains "ai-session delegates to the authoritative verifier" "$text" 'verify_aidevops_runtime_bundle_convergence'
+	# shellcheck disable=SC2016 # Match literal verifier expressions.
+	assert_contains "verifier checks active bundle manifest version" "$verifier_text" '_runtime_bundle_verify_manifest_value "$manifest_file" framework_version'
+	# shellcheck disable=SC2016 # Match literal verifier expressions.
+	assert_contains "verifier checks active bundle manifest sha" "$verifier_text" '_runtime_bundle_verify_manifest_value "$manifest_file" git_sha'
+	assert_contains "verifier checks release sentinel hashes" "$verifier_text" '.agents/scripts/version-manager-release.sh|scripts/version-manager-release.sh'
 	assert_contains "ai-session reconciles generated runtime config" "$text" "_time_step \"\$SETUP_STAGE_RUNTIME_CONFIG\" _setup_reconcile_runtime_config"
 	assert_contains "runtime reconciliation updates enabled primary runtimes" "$text" "update_runtime_configs || return \$?"
 	assert_contains "runtime reconciliation deploys commands to remaining runtimes" "$text" "deploy_commands_to_all_runtimes || return \$?"

--- a/.agents/scripts/tests/test-version-manager-release-provenance.sh
+++ b/.agents/scripts/tests/test-version-manager-release-provenance.sh
@@ -18,6 +18,7 @@ git clone -q "$REMOTE" "$REPO"
 git -C "$REPO" switch -q -c main
 git -C "$REPO" config user.name Test
 git -C "$REPO" config user.email test@example.invalid
+git -C "$REPO" config commit.gpgsign false
 git -C "$REPO" commit -q --allow-empty -m seed
 git -C "$REPO" push -q -u origin main
 git -C "$REPO" remote set-head origin main

--- a/.agents/scripts/tests/test-version-manager-release-provenance.sh
+++ b/.agents/scripts/tests/test-version-manager-release-provenance.sh
@@ -4,6 +4,13 @@
 
 set -euo pipefail
 
+# Keep disposable fixture repositories isolated from the developer's guarded
+# Git shim, global hooks, and signing policy.
+PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -358,6 +358,7 @@ validate_release_deployment_readiness() {
 run_post_release_agent_sync() {
 	local sync_repo_root="${AIDEVOPS_SYNC_REPO_ROOT:-$REPO_ROOT}"
 	local remote_url
+	local release_sha=""
 	remote_url=$(git -C "$sync_repo_root" remote get-url origin 2>/dev/null || echo "")
 
 	if [[ "$remote_url" != *"marcusquinn/aidevops"* ]]; then
@@ -380,6 +381,10 @@ run_post_release_agent_sync() {
 		return 1
 	fi
 	validate_release_deployment_readiness || return 1
+	release_sha=$(git -C "$sync_repo_root" rev-parse HEAD 2>/dev/null) || {
+		print_error "Post-release deployment gate cannot resolve the release checkout commit"
+		return 1
+	}
 
 	print_info "Running post-release aidevops agent sync..."
 	local sync_output=""
@@ -388,13 +393,21 @@ run_post_release_agent_sync() {
 		AIDEVOPS_DEPLOY_TARGET="$HOME/.aidevops/agents" \
 		bash "$deploy_script" "${deploy_args[@]}" 2>&1) || sync_exit=$?
 
-	if [[ "$sync_exit" -eq 0 ]]; then
-		print_success "Post-release aidevops deployment and CLI convergence completed"
-		return 0
+	if [[ "$sync_exit" -ne 0 ]]; then
+		print_error "Post-release aidevops deployment or CLI convergence failed: $sync_output"
+		return 1
+	fi
+	if ! verify_aidevops_runtime_bundle_convergence \
+		"$sync_repo_root" \
+		"$release_sha" \
+		"$HOME/.aidevops/agents" \
+		"$HOME/.aidevops/.deployed-sha"; then
+		print_error "Post-release deployment helper exited successfully, but runtime bundle provenance did not converge"
+		return 1
 	fi
 
-	print_error "Post-release aidevops deployment or CLI convergence failed: $sync_output"
-	return 1
+	print_success "Post-release aidevops deployment and CLI convergence completed"
+	return 0
 }
 
 run_post_publication_gates() {

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -429,8 +429,15 @@ _release_dry_run() {
 	local dr_major dr_minor dr_patch planned_version
 	IFS='.' read -r dr_major dr_minor dr_patch <<<"$current_version"
 	case "$bump_type" in
-	"major") dr_major=$((dr_major + 1)); dr_minor=0; dr_patch=0 ;;
-	"minor") dr_minor=$((dr_minor + 1)); dr_patch=0 ;;
+	"major")
+		dr_major=$((dr_major + 1))
+		dr_minor=0
+		dr_patch=0
+		;;
+	"minor")
+		dr_minor=$((dr_minor + 1))
+		dr_patch=0
+		;;
 	"patch") dr_patch=$((dr_patch + 1)) ;;
 	esac
 	planned_version="${dr_major}.${dr_minor}.${dr_patch}"
@@ -444,8 +451,8 @@ _release_dry_run() {
 		print_info "  Runners with auto_hotfix_accept=true will pull within ~5 minutes"
 		print_info "  Runners with auto_hotfix_accept=false will see a session banner"
 	fi
-	print_info "  Force: $( [[ "$force_flag" -eq 1 ]] && echo "yes" || echo "no" )"
-	print_info "  Skip preflight: $( [[ "$skip_preflight" -eq 1 ]] && echo "yes" || echo "no" )"
+	print_info "  Force: $([[ "$force_flag" -eq 1 ]] && echo "yes" || echo "no")"
+	print_info "  Skip preflight: $([[ "$skip_preflight" -eq 1 ]] && echo "yes" || echo "no")"
 	print_info "=== DRY RUN: No changes made ==="
 	return 0
 }
@@ -455,17 +462,38 @@ _release_dry_run() {
 _parse_release_args() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
-		--force) force_flag=1; shift ;;
-		--skip-preflight) skip_preflight=1; shift ;;
-		--allow-dirty) allow_dirty=1; shift ;;
-		--hotfix) hotfix_flag=1; shift ;;
-		--dry-run) dry_run=1; shift ;;
+		--force)
+			force_flag=1
+			shift
+			;;
+		--skip-preflight)
+			skip_preflight=1
+			shift
+			;;
+		--allow-dirty)
+			allow_dirty=1
+			shift
+			;;
+		--hotfix)
+			hotfix_flag=1
+			shift
+			;;
+		--dry-run)
+			dry_run=1
+			shift
+			;;
 		--source-pr)
 			source_pr="${2:-}"
-			[[ -n "$source_pr" ]] || { print_error "--source-pr requires a PR number"; return 1; }
+			[[ -n "$source_pr" ]] || {
+				print_error "--source-pr requires a PR number"
+				return 1
+			}
 			shift 2
 			;;
-		*) print_error "Unknown release option: $1"; return 1 ;;
+		*)
+			print_error "Unknown release option: $1"
+			return 1
+			;;
 		esac
 	done
 	return 0

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -125,6 +125,10 @@ _version_manager_guard_headless_release_scope() {
 }
 
 # Source sub-libraries
+# shellcheck source=./runtime-bundle-verifier.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/runtime-bundle-verifier.sh"
+
 # shellcheck source=./version-manager-changelog.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/version-manager-changelog.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -333,6 +333,8 @@ unset _setup_script_dir
 # helpers loaded early by the root entrypoint; normal setup implementation
 # modules live under modules/ so the repository root has no module directory.
 SETUP_IMPL_MODULES_DIR="${SETUP_MODULES_DIR}/modules"
+# shellcheck source=.agents/scripts/runtime-bundle-verifier.sh
+source "${INSTALL_DIR}/.agents/scripts/runtime-bundle-verifier.sh"
 # shellcheck disable=SC1091  # Dynamic path via $SETUP_IMPL_MODULES_DIR
 source "${SETUP_IMPL_MODULES_DIR}/core.sh"
 # shellcheck disable=SC1091
@@ -1331,68 +1333,14 @@ _setup_git_checkout_available() {
 	return 0
 }
 
-_setup_bundle_manifest_value() {
-	local manifest_file="$1"
-	local key="$2"
-	local value=""
-	value=$(grep -m 1 "^${key}=" "$manifest_file" 2>/dev/null) || return 1
-	printf '%s' "${value#*=}"
-	return 0
-}
-
 _setup_ai_session_verify_deploy() {
 	local expected_sha="$1"
-	local active_link="$HOME/.aidevops/agents"
-	local active_root=""
-	local manifest_file=""
-	local manifest_status=""
-	local manifest_version=""
-	local manifest_sha=""
-	local repo_version=""
-	local deployed_version=""
-	local deployed_sha=""
-
-	if [[ ! -L "$active_link" ]]; then
-		print_warning "AI-session incremental verification failed: active agents path is not an activation symlink"
-		return 1
-	fi
-	active_root=$(resolve_aidevops_runtime_bundle_root "$active_link") || {
-		print_warning "AI-session incremental verification failed: active agents symlink cannot be resolved"
-		return 1
-	}
-	manifest_file="$active_root/.bundle-manifest"
-	if [[ ! -r "$manifest_file" ]]; then
-		print_warning "AI-session incremental verification failed: active bundle manifest is missing"
-		return 1
-	fi
-	manifest_status=$(_setup_bundle_manifest_value "$manifest_file" status) || manifest_status=""
-	manifest_version=$(_setup_bundle_manifest_value "$manifest_file" framework_version) || manifest_version=""
-	manifest_sha=$(_setup_bundle_manifest_value "$manifest_file" git_sha) || manifest_sha=""
-
-	if [[ -f "$INSTALL_DIR/VERSION" ]]; then
-		repo_version=$(tr -d '[:space:]' <"$INSTALL_DIR/VERSION" 2>/dev/null) || repo_version=""
-	fi
-	if [[ -f "$active_root/VERSION" ]]; then
-		deployed_version=$(tr -d '[:space:]' <"$active_root/VERSION" 2>/dev/null) || deployed_version=""
-	fi
-	if [[ -f "$HOME/.aidevops/.deployed-sha" ]]; then
-		deployed_sha=$(tr -d '[:space:]' <"$HOME/.aidevops/.deployed-sha" 2>/dev/null) || deployed_sha=""
-	fi
-
-	if [[ "$manifest_status" != "validated" ]]; then
-		print_warning "AI-session incremental verification failed: active bundle manifest status=${manifest_status:-missing}"
-		return 1
-	fi
-	if [[ -z "$repo_version" || "$repo_version" != "$deployed_version" || "$repo_version" != "$manifest_version" ]]; then
-		print_warning "AI-session incremental verification failed: repo version=${repo_version:-unknown}, active=${deployed_version:-none}, manifest=${manifest_version:-none}"
-		return 1
-	fi
-	if [[ -z "$deployed_sha" || "$deployed_sha" != "$expected_sha" || "$manifest_sha" != "$expected_sha" ]]; then
-		print_warning "AI-session incremental verification failed: stamp SHA=${deployed_sha:-none}, manifest SHA=${manifest_sha:-none}, expected=${expected_sha:0:12}"
-		return 1
-	fi
-
-	return 0
+	verify_aidevops_runtime_bundle_convergence \
+		"$INSTALL_DIR" \
+		"$expected_sha" \
+		"$HOME/.aidevops/agents" \
+		"$HOME/.aidevops/.deployed-sha"
+	return $?
 }
 
 _setup_run_ai_session_incremental() {

--- a/setup.sh
+++ b/setup.sh
@@ -122,10 +122,26 @@ if [[ -d "$SETUP_MODULES_DIR" ]]; then
 	source "$SETUP_MODULES_DIR/_worktree_exclusions.sh"
 fi
 
-print_info() { local _m="$1"; echo -e "${BLUE}[INFO]${NC} $_m"; return 0; }
-print_success() { local _m="$1"; echo -e "${GREEN}[SUCCESS]${NC} $_m"; return 0; }
-print_warning() { local _m="$1"; echo -e "${YELLOW}[WARNING]${NC} $_m"; return 0; }
-print_error() { local _m="$1"; echo -e "${RED}[ERROR]${NC} $_m"; return 0; }
+print_info() {
+	local _m="$1"
+	echo -e "${BLUE}[INFO]${NC} $_m"
+	return 0
+}
+print_success() {
+	local _m="$1"
+	echo -e "${GREEN}[SUCCESS]${NC} $_m"
+	return 0
+}
+print_warning() {
+	local _m="$1"
+	echo -e "${YELLOW}[WARNING]${NC} $_m"
+	return 0
+}
+print_error() {
+	local _m="$1"
+	echo -e "${RED}[ERROR]${NC} $_m"
+	return 0
+}
 
 # Source shared-constants for config support (is_feature_enabled / config_enabled)
 # Try repo-local first, then deployed location
@@ -804,7 +820,7 @@ _setup_lock_pid_is_noninteractive_setup() {
 	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
 	owner_args=$(ps -p "$pid" -o args= 2>/dev/null || true)
 	[[ -n "$owner_args" ]] || return 0
-	[[ "$owner_args" == *"setup.sh"* && ( "$owner_args" == *"--non-interactive"* || "$owner_args" == *"--stage"* ) ]]
+	[[ "$owner_args" == *"setup.sh"* && ("$owner_args" == *"--non-interactive"* || "$owner_args" == *"--stage"*) ]]
 	return $?
 }
 
@@ -839,7 +855,7 @@ _setup_lock_started_age_seconds() {
 	local now_epoch=""
 	if [[ -r "$lock_dir/started_at" ]]; then
 		started_str=$(tr -d '[:space:]' <"$lock_dir/started_at" 2>/dev/null || true)
-		started_epoch=$(date -d "$started_str" +%s 2>/dev/null || \
+		started_epoch=$(date -d "$started_str" +%s 2>/dev/null ||
 			date -u -jf '%Y-%m-%dT%H:%M:%SZ' "$started_str" +%s 2>/dev/null || true)
 		now_epoch=$(date +%s 2>/dev/null || true)
 		if [[ "$started_epoch" =~ ^[0-9]+$ && "$now_epoch" =~ ^[0-9]+$ && "$now_epoch" -ge "$started_epoch" ]]; then
@@ -956,7 +972,7 @@ _setup_run_noncritical_stage_bounded() {
 	pid=$!
 	_setup_register_child_pid "$pid"
 	while _setup_lock_pid_alive "$pid"; do
-		if (( SECONDS - start_s >= timeout_s )); then
+		if ((SECONDS - start_s >= timeout_s)); then
 			_setup_kill_pid_tree TERM "$pid"
 			sleep "${AIDEVOPS_SETUP_CHILD_TERM_GRACE_S:-2}" 2>/dev/null || true
 			_setup_kill_pid_tree KILL "$pid"
@@ -1034,9 +1050,9 @@ _setup_command_key_looks_secret() {
 	key="${key#--}"
 	key="${key#-}"
 	case "$key" in
-		*password*|*passwd*|*secret*|*token*|*credential*|*api-key*|*api_key*|*apikey*|*access-key*|*access_key*|*private-key*|*private_key*|bearer)
-			return 0
-			;;
+	*password* | *passwd* | *secret* | *token* | *credential* | *api-key* | *api_key* | *apikey* | *access-key* | *access_key* | *private-key* | *private_key* | bearer)
+		return 0
+		;;
 	esac
 	return 1
 }
@@ -1179,7 +1195,7 @@ _setup_acquire_noninteractive_setup_lock() {
 		# Emit diagnostics on first block and every diagnostic interval thereafter.
 		if [[ "$waited" -eq 0 ]]; then
 			print_info "Another setup.sh --non-interactive is running (pid ${owner_pid}, age ${owner_age}s${_diag_stage}${owner_cmd:+, command: ${owner_cmd}}). Waiting up to ${wait_ceiling}s (AIDEVOPS_SETUP_WAIT_TIMEOUT_S). Diagnose: ${_diag_stl}"
-		elif [[ $(( waited % _diag_interval_s )) -eq 0 ]]; then
+		elif [[ $((waited % _diag_interval_s)) -eq 0 ]]; then
 			print_info "Still waiting for setup lock (owner pid ${owner_pid}, age ${owner_age}s${_diag_stage}${owner_cmd:+, command: ${owner_cmd}}, waited ${waited}s of ${wait_ceiling}s max). Diagnose: ${_diag_stl}"
 		fi
 
@@ -1491,7 +1507,8 @@ _setup_run_non_interactive() {
 	_time_step "backfill_issue_relationships" backfill_issue_relationships
 	_time_step "cleanup_deprecated_mcps" cleanup_deprecated_mcps
 	_time_step "cleanup_stale_bun_opencode" cleanup_stale_bun_opencode
-	_time_step "cleanup_stale_health_issue_caches" cleanup_stale_health_issue_caches; _time_step "cleanup_legacy_aidevops_temp_artifacts" cleanup_legacy_aidevops_temp_artifacts
+	_time_step "cleanup_stale_health_issue_caches" cleanup_stale_health_issue_caches
+	_time_step "cleanup_legacy_aidevops_temp_artifacts" cleanup_legacy_aidevops_temp_artifacts
 	_time_step "cleanup_worktree_entries_in_repos_json" cleanup_worktree_entries_in_repos_json
 	_time_step "_cleanup_legacy_model_config" _cleanup_legacy_model_config
 	_time_step "cleanup_legacy_dashboard_launchagent" cleanup_legacy_dashboard_launchagent
@@ -1667,11 +1684,18 @@ _setup_run_interactive() {
 	confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
 	confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode
 	# Silent one-shot migrations (idempotent, flag-guarded — no prompt needed).
-	cleanup_stale_health_issue_caches; cleanup_legacy_aidevops_temp_artifacts; cleanup_worktree_entries_in_repos_json; _cleanup_legacy_model_config; cleanup_legacy_dashboard_launchagent
+	cleanup_stale_health_issue_caches
+	cleanup_legacy_aidevops_temp_artifacts
+	cleanup_worktree_entries_in_repos_json
+	_cleanup_legacy_model_config
+	cleanup_legacy_dashboard_launchagent
 	confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config
 	confirm_step "Extract OpenCode prompts" && extract_opencode_prompts
 	confirm_step "Check OpenCode prompt drift" && check_opencode_prompt_drift
-	confirm_step "Deploy aidevops agents to ~/.aidevops/agents/" && { deploy_aidevops_agents; _deploy_hotfix_config; }
+	confirm_step "Deploy aidevops agents to ~/.aidevops/agents/" && {
+		deploy_aidevops_agents
+		_deploy_hotfix_config
+	}
 	# Launcher verification reads the deployed VERSION, so it must follow agent
 	# deployment on first-run interactive setup as it already does non-interactively.
 	confirm_step "Install and verify aidevops CLI command" && install_aidevops_cli

--- a/tests/test-deploy-agents-on-merge.sh
+++ b/tests/test-deploy-agents-on-merge.sh
@@ -57,13 +57,24 @@ assert_contains() {
 
 create_base_repo() {
 	local dir="$1"
-	git init "$dir" >/dev/null 2>&1
-	git -C "$dir" checkout -b main >/dev/null 2>&1 || true
+	/usr/bin/git init "$dir" >/dev/null 2>&1
+	/usr/bin/git -C "$dir" checkout -b main >/dev/null 2>&1 || true
+	/usr/bin/git -C "$dir" config user.email test@example.invalid
+	/usr/bin/git -C "$dir" config user.name Test
+	/usr/bin/git -C "$dir" config commit.gpgsign false
 	mkdir -p "$dir/.agents/scripts"
 	echo "echo ok" >"$dir/.agents/scripts/example.sh"
 	echo "2.0.0" >"$dir/VERSION"
-	git -C "$dir" add . >/dev/null 2>&1
-	git -C "$dir" commit -m "initial" >/dev/null 2>&1
+	cat >"$dir/setup.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'setup:%s\n' "$*"
+[[ -z "${AIDEVOPS_AGENTS_DIR+x}" && -z "${AGENTS_DIR+x}" ]]
+exit "${MOCK_SETUP_EXIT_CODE:-0}"
+EOF
+	chmod +x "$dir/setup.sh"
+	/usr/bin/git -C "$dir" add . >/dev/null 2>&1
+	/usr/bin/git -C "$dir" commit -m "initial" >/dev/null 2>&1
 	return 0
 }
 
@@ -76,6 +87,8 @@ run_script() {
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+export HOME="$TMP_DIR/home"
+mkdir -p "$HOME"
 
 # Test 1: Invalid commit should fail fast (exit 1)
 TEST_REPO_INVALID="$TMP_DIR/repo-invalid"
@@ -131,8 +144,8 @@ TEST_REPO_CHANGED="$TMP_DIR/repo-changed"
 create_base_repo "$TEST_REPO_CHANGED"
 
 echo "echo updated" >"$TEST_REPO_CHANGED/.agents/scripts/example.sh"
-git -C "$TEST_REPO_CHANGED" add .agents/scripts/example.sh >/dev/null 2>&1
-git -C "$TEST_REPO_CHANGED" commit -m "update script" >/dev/null 2>&1
+/usr/bin/git -C "$TEST_REPO_CHANGED" add .agents/scripts/example.sh >/dev/null 2>&1
+/usr/bin/git -C "$TEST_REPO_CHANGED" commit -m "update script" >/dev/null 2>&1
 
 set +e
 changed_output="$(run_script "$TEST_REPO_CHANGED" --diff HEAD~1)"
@@ -141,6 +154,7 @@ set -e
 
 assert_eq "$changed_status" "0" "Changed script deploy exits with status 0"
 assert_contains "$changed_output" "using fast scripts-only deploy" "Changed script deploy selects scripts-only path"
+assert_contains "$changed_output" "setup:--stage ai-session" "Changed script deploy routes through transactional setup"
 
 # Test 4: Full deploy must isolate immutable session pins from setup.sh
 TEST_REPO_FULL="$TMP_DIR/repo-full"


### PR DESCRIPTION
## Summary

Route release deployment through atomic runtime-bundle activation and verify exact release provenance.

## Files Changed

- Add a shared runtime-bundle verifier that binds the active immutable bundle, manifest, deployment stamp, and release sentinels to the exact release commit.
- Route incremental and full deployment paths through transactional staging and activation.
- Make release/update/setup paths share the same convergence checks.
- Add stale-runtime, stale-stamp, stale-sentinel, transactional deployment, linked-worktree, and unterminated `VERSION` regressions.

## Runtime Testing

- `.agents/scripts/linters-local.sh` — all local checks passed for 10 changed shell files.
- ShellCheck and Bash syntax — passed for all 10 changed shell files.
- Focused deployment and release suites — 80 assertions/tests passed.
- Review threads — both verified findings addressed and resolved.

## New File Smell Justification

The failed new-file gate used stale PR base `4aa4714`, while current `main` was `91ab5b1`. Its sole reported smell is in `.agents/scripts/github-api-efficiency-evidence.py`, which is already on `main` and absent from this PR's net diff. The actual new verifier passed ShellCheck, shfmt, local complexity gates, Qlty maintainability checks, and focused regression tests. This override prevents an unrelated stale-base finding from blocking the verified change.

Resolves #28208

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 14h 34m and 3,190,983 tokens on this with the user in an interactive session. Overall, 2d 1h since this issue was created.
