### PR TITLE
GH#28200: docs: adopt serve-sim preview launch options

### DIFF
--- a/.agents/scripts/tests/test-tool-install-serve-sim.sh
+++ b/.agents/scripts/tests/test-tool-install-serve-sim.sh
@@ -35,6 +35,7 @@ extract_functions() {
 	awk '
 		/^_setup_serve_sim_node_version_ok\(\)/, /^}$/ { print; next }
 		/^_setup_serve_sim_cli_version\(\)/, /^}$/ { print; next }
+		/^_setup_serve_sim_swiftpm_ok\(\)/, /^}$/ { print; next }
 		/^setup_serve_sim\(\)/, /^}$/ { print; next }
 	' "$TOOL_INSTALL" >"$SANDBOX/extract.sh"
 	if ! grep -q '^setup_serve_sim()' "$SANDBOX/extract.sh"; then
@@ -54,9 +55,18 @@ write_shim() {
 }
 
 source_extracted() {
-	print_info() { printf 'INFO: %s\n' "$*"; return 0; }
-	print_success() { printf 'OK: %s\n' "$*"; return 0; }
-	print_warning() { printf 'WARN: %s\n' "$*"; return 0; }
+	print_info() {
+		printf 'INFO: %s\n' "$*"
+		return 0
+	}
+	print_success() {
+		printf 'OK: %s\n' "$*"
+		return 0
+	}
+	print_warning() {
+		printf 'WARN: %s\n' "$*"
+		return 0
+	}
 	setup_prompt() {
 		local var_name="$1"
 		local prompt_text="$2"
@@ -86,9 +96,18 @@ source_extracted() {
 }
 
 source_extracted_with_prompt_failure() {
-	print_info() { printf 'INFO: %s\n' "$*"; return 0; }
-	print_success() { printf 'OK: %s\n' "$*"; return 0; }
-	print_warning() { printf 'WARN: %s\n' "$*"; return 0; }
+	print_info() {
+		printf 'INFO: %s\n' "$*"
+		return 0
+	}
+	print_success() {
+		printf 'OK: %s\n' "$*"
+		return 0
+	}
+	print_warning() {
+		printf 'WARN: %s\n' "$*"
+		return 0
+	}
 	setup_prompt() {
 		return 1
 	}

--- a/.agents/tools/mobile/serve-sim.md
+++ b/.agents/tools/mobile/serve-sim.md
@@ -32,6 +32,8 @@ serve-sim                         # Preview UI at http://localhost:3200
 serve-sim --detach -q             # Start background preview and return JSON with url/streamUrl
 serve-sim --host 0.0.0.0          # Expose preview on a trusted LAN
 serve-sim --codec mjpeg           # Pin stream codec when H.264 is unavailable
+serve-sim --panes devices,tools   # Choose the preview panes opened at startup
+serve-sim --fit --theme dark      # Fit the device and set simulator appearance
 serve-sim --list -q               # List running simulator streams
 serve-sim tap 0.5 0.9             # Tap normalized screen coordinates
 serve-sim button home             # Send hardware button
@@ -76,6 +78,8 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 | Stream only | `serve-sim --no-preview [device...]` | Foreground stream without React preview UI |
 | List streams | `serve-sim --list -q` | Use `-q` for machine-readable output |
 | Force compatibility stream | `serve-sim --codec mjpeg [device...]`, open the preview with `?codec=mjpeg`, or use Stream → Codec | Use MJPEG if H.264/WebCodecs stutters or fails while recording |
+| Set initial preview layout | `serve-sim --panes devices,tools --fit [device...]` | Panes: `devices`, `tools`, `devtools`, or exclusive `none`; `--fit` ignores saved sizing for the initial render |
+| Set simulator appearance | `serve-sim --theme dark [device...]` | Applies `light` or `dark` appearance before opening the preview |
 | Stop streams | `serve-sim --kill [device]` | Stop all streams or one device stream |
 | Tap | `serve-sim tap 0.5 0.9 [-d udid]` | Normalized 0..1 screen coordinates; prefer this over raw gesture JSON for plain taps |
 | Gesture | `serve-sim gesture '<json>' [-d udid]` | Use documented JSON shape; avoid guessing coordinates |
@@ -97,13 +101,14 @@ Do **not** use it for Android emulators, real iOS hardware, building/installing 
 2. Start the preview with `serve-sim --detach -q`.
 3. Parse only JSON/quiet output; do not scrape human-readable output.
 4. Surface the returned `url` to the user. If the current runtime exposes a preview/open-url tool, pass the URL there too.
-5. Use `agent-device snapshot` or `ios-simulator-mcp` for accessibility-aware targeting; use `serve-sim` for the shared visual stream and simulator-specific commands.
-6. If the browser preview stutters, drops frames, or reports an H.264 decoder failure while screen recording, restart with `serve-sim --codec mjpeg`, switch the Stream → Codec control to MJPEG, or append `?codec=mjpeg` to the preview URL.
-7. For plain coordinate taps, use `serve-sim tap <x> <y>` with normalized 0..1 values; reserve `serve-sim gesture '<json>'` for drag, swipe, and multi-touch shapes.
-8. When diagnosing what just happened, open the Event Log panel in the browser tools area or run `serve-sim event-log -n 50 -j` against the active server; printable keyboard input is intentionally redacted while control keys, normalized tap/drag coordinates, command status, and device labels remain visible.
-9. Run shared-simulator Bun suites serially (`bun test --max-concurrency=1 ...`) so one simulator stream, pointer state, or native helper crash does not cascade across concurrent tests.
-10. Treat isolated `ConnectionRefused` / `server not alive`, hook timeout, or `ECONNRESET` failures in shared-simulator suites as possible simulator wedges: reboot the simulator and retry once before attributing the failure to app code.
-11. Clean up with `serve-sim --kill` unless the user asks to keep the simulator stream running.
+5. When review needs a deterministic first view, add `--panes <list>`, `--fit`, or `--theme <light|dark>`; these startup choices do not replace interactive preview controls.
+6. Use `agent-device snapshot` or `ios-simulator-mcp` for accessibility-aware targeting; use `serve-sim` for the shared visual stream and simulator-specific commands.
+7. If the browser preview stutters, drops frames, or reports an H.264 decoder failure while screen recording, restart with `serve-sim --codec mjpeg`, switch the Stream → Codec control to MJPEG, or append `?codec=mjpeg` to the preview URL.
+8. For plain coordinate taps, use `serve-sim tap <x> <y>` with normalized 0..1 values; reserve `serve-sim gesture '<json>'` for drag, swipe, and multi-touch shapes.
+9. When diagnosing what just happened, open the Event Log panel in the browser tools area or run `serve-sim event-log -n 50 -j` against the active server; printable keyboard input is intentionally redacted while control keys, normalized tap/drag coordinates, command status, and device labels remain visible.
+10. Run shared-simulator Bun suites serially (`bun test --max-concurrency=1 ...`) so one simulator stream, pointer state, or native helper crash does not cascade across concurrent tests.
+11. Treat isolated `ConnectionRefused` / `server not alive`, hook timeout, or `ECONNRESET` failures in shared-simulator suites as possible simulator wedges: reboot the simulator and retry once before attributing the failure to app code.
+12. Clean up with `serve-sim --kill` unless the user asks to keep the simulator stream running.
 
 ## Expo / Dev Server Embedding
 


### PR DESCRIPTION
## Summary

Document serve-sim 0.1.45 preview layout, fit, and simulator theme flags; restore setup test extraction for the SwiftPM prerequisite helper and format its local stubs.

## Files Changed

.agents/scripts/tests/test-tool-install-serve-sim.sh, .agents/tools/mobile/serve-sim.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-tool-install-serve-sim.sh; shellcheck .agents/scripts/tests/test-tool-install-serve-sim.sh; shfmt -d .agents/scripts/tests/test-tool-install-serve-sim.sh; .agents/scripts/linters-local.sh

Resolves #28200


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 21m and 103,506 tokens on this as a headless worker.