### PR TITLE
GH#1214: fix(dispatch): prevent stale assignment from tripping t2769 no_work circuit breaker

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1503,37 +1503,59 @@ _rollback_prelaunch_ownership() {
 	local issue_meta_json=""
 	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
 		--json state,labels,assignees,locked 2>/dev/null) || return 1
-	local owns_queued=""
-	owns_queued=$(printf '%s' "$issue_meta_json" | jq -r --arg self "$self_login" '
+
+	# GH#1214 / t2769 fix: separate the "should we change status?" question from
+	# "should we unassign?". Previously, both were gated on owns_queued; when
+	# status:queued was absent (race, label inconsistency), the function returned 0
+	# without unassigning — leaving a stale assignment that fed the no_work circuit
+	# breaker through stale-recovery→fast-fail→t2769 over 4 cycles.
+	#
+	# New logic: always unassign self if assigned, regardless of status label.
+	# Only transition status:queued → status:available if status:queued is present.
+	local is_assigned=""
+	is_assigned=$(printf '%s' "$issue_meta_json" | jq -r --arg self "$self_login" '
 		(.state == "OPEN") and
-		(([.labels[].name] | index("status:queued")) != null) and
 		(([.assignees[].login] | index($self)) != null)
 	' 2>/dev/null) || return 1
-	[[ "$owns_queued" == "true" ]] || return 0
+	[[ "$is_assigned" == "true" ]] || return 0
 
-	if ! set_issue_status "$issue_number" "$repo_slug" "available" \
-		--remove-assignee "$self_login" >/dev/null 2>&1; then
-		echo "[dispatch_with_dedup] Pre-launch rollback failed for #${issue_number}: unable to restore available ownership" >>"$LOGFILE"
-		return 1
+	local has_queued=""
+	has_queued=$(printf '%s' "$issue_meta_json" | jq -r '
+		([.labels[].name] | index("status:queued")) != null
+	' 2>/dev/null) || has_queued="false"
+
+	if [[ "$has_queued" == "true" ]]; then
+		if ! set_issue_status "$issue_number" "$repo_slug" "available" \
+			--remove-assignee "$self_login" >/dev/null 2>&1; then
+			echo "[dispatch_with_dedup] Pre-launch rollback failed for #${issue_number}: unable to restore available ownership" >>"$LOGFILE"
+			return 1
+		fi
+	else
+		# Status label isn't queued (race or prior mutation); unassign only.
+		if ! gh issue edit "$issue_number" --repo "$repo_slug" \
+			--remove-assignee "$self_login" >/dev/null 2>&1; then
+			echo "[dispatch_with_dedup] Pre-launch rollback unassign-only failed for #${issue_number}" >>"$LOGFILE"
+			return 1
+		fi
+		echo "[dispatch_with_dedup] Pre-launch rollback: unassigned ${self_login} from #${issue_number} without status change (status:queued absent)" >>"$LOGFILE"
 	fi
 	if declare -F unlock_issue_after_worker >/dev/null 2>&1; then
 		unlock_issue_after_worker "$issue_number" "$repo_slug" || return 1
 	fi
 
+	# Verification: self must no longer be assigned. Status and lock checks
+	# are conditional — the issue may have been mutated by a concurrent runner
+	# or locked state may persist if unlock_issue_after_worker is unavailable.
 	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
 		--json state,labels,assignees,locked 2>/dev/null) || return 1
-	if ! printf '%s' "$issue_meta_json" | jq -e --arg self "$self_login" '
-		.state == "OPEN" and
-		(([.labels[].name] | index("status:queued")) == null) and
-		(([.labels[].name] | index("status:available")) != null) and
-		(([.assignees[].login] | index($self)) == null) and
-		(.locked != true)
+	if printf '%s' "$issue_meta_json" | jq -e --arg self "$self_login" '
+		([.assignees[].login] | index($self)) != null
 	' >/dev/null 2>&1; then
-		echo "[dispatch_with_dedup] Pre-launch rollback verification failed for #${issue_number}; retaining claim for stale recovery" >>"$LOGFILE"
+		echo "[dispatch_with_dedup] Pre-launch rollback verification failed for #${issue_number}: self still assigned; retaining claim for stale recovery" >>"$LOGFILE"
 		return 1
 	fi
 
-	echo "[dispatch_with_dedup] Pre-launch rollback verified for #${issue_number}: queued ownership removed and issue unlocked" >>"$LOGFILE"
+	echo "[dispatch_with_dedup] Pre-launch rollback verified for #${issue_number}: assignee removed" >>"$LOGFILE"
 	return 0
 }
 

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -85,8 +85,35 @@ _classify_stale_recovery_crash_type() {
 		return 0
 	fi
 
-	# No PR, no branch — the worker died before producing any durable
-	# artifact. Classify as no_work so the cascade tier escalation
+	# GH#1214 / t2769 defence-in-depth: check the most recent ops comment for
+	# pre-launch abort evidence. When the last dispatch was a pre-launch abort
+	# (orphan branch hold, canary fail, worktree failure, etc.), the claim was
+	# deleted by t3549 but a prior dispatch claim still exists. Without this
+	# check, the stale-recovery classifier returns no_work and the fast-fail
+	# counter increments, eventually tripping the t2769 circuit breaker.
+	# Classify these as "prelaunch" so the caller can skip fast-fail accrual.
+	local _latest_ops_marker=""
+	_latest_ops_marker=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--paginate --jq '
+		[.[] | select((.body // "") | test("<!-- ops:start"))
+		| {body: .body, created_at: .created_at}]
+		| sort_by(.created_at) | last
+		| .body // empty
+		' 2>/dev/null) || _latest_ops_marker=""
+	if [[ -n "$_latest_ops_marker" ]]; then
+		if [[ "$_latest_ops_marker" == *"worker-branch-orphan"* ]] ||
+			[[ "$_latest_ops_marker" == *"WORKER_BRANCH_ORPHAN"* ]] ||
+			[[ "$_latest_ops_marker" == *"canary preflight failed"* ]] ||
+			[[ "$_latest_ops_marker" == *"worktree pre-creation failed"* ]] ||
+			[[ "$_latest_ops_marker" == *"precreation failed"* ]] ||
+			[[ "$_latest_ops_marker" == *"pre-launch abort"* ]]; then
+			printf 'prelaunch'
+			return 0
+		fi
+	fi
+
+	# No PR, no branch, no pre-launch marker — the worker died before producing
+	# any durable artifact. Classify as no_work so the cascade tier escalation
 	# comment renders the "Likely infrastructure/transient failure" line.
 	printf 'no_work'
 	return 0
@@ -302,8 +329,17 @@ _dedup_layer6_assignee_and_stale() {
 			# instead of a bare "Reason: stale_timeout" with no signal.
 			local _stale_crash_type
 			_stale_crash_type=$(_classify_stale_recovery_crash_type "$issue_number" "$repo_slug")
-			echo "[pulse-wrapper] Dedup: stale recovery detected for #${issue_number} in ${repo_slug} crash_type=${_stale_crash_type} — recording fast-fail (t1927/t2042)" >>"$LOGFILE"
-			fast_fail_record "$issue_number" "$repo_slug" "stale_timeout" "" "$_stale_crash_type" || true
+			# GH#1214 / t2769 defence-in-depth: when the classifier finds
+			# pre-launch abort evidence (orphan, canary, worktree failure),
+			# it returns "prelaunch" instead of "no_work". Pre-launch aborts
+			# are not worker failures and must not accrue toward the t2769
+			# no_work circuit breaker. Skip fast-fail recording entirely.
+			if [[ "$_stale_crash_type" == "prelaunch" ]]; then
+				echo "[pulse-wrapper] Dedup: stale recovery for #${issue_number} in ${repo_slug} classified as prelaunch — skipping fast-fail record (GH#1214)" >>"$LOGFILE"
+			else
+				echo "[pulse-wrapper] Dedup: stale recovery detected for #${issue_number} in ${repo_slug} crash_type=${_stale_crash_type} — recording fast-fail (t1927/t2042)" >>"$LOGFILE"
+				fast_fail_record "$issue_number" "$repo_slug" "stale_timeout" "" "$_stale_crash_type" || true
+			fi
 		fi
 		if [[ "$assigned_output" == *STALE_BLOCKED_BY_DEPENDENCY* ]]; then
 			echo "[pulse-wrapper] Dedup: stale recovery for #${issue_number} in ${repo_slug} found unresolved blocked-by dependency — blocking re-dispatch (GH#23932)" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
@@ -60,6 +60,10 @@ if [[ "$cmd" == "is-assigned" ]]; then
 		printf '%s\n' 'STALE_RECOVERED: issue #2905 in exampleorg/examplerepo - unassigned runner (no dispatch claim comment found, worker canary preflight failed before worktree pre-creation; will retry next cycle)'
 		exit 1
 		;;
+	prelaunch_orphan)
+		printf '%s\n' 'STALE_RECOVERED: issue #2905 in exampleorg/examplerepo - unassigned runner (dispatch claim 900s old, last activity 900s old (threshold=600s, interactive=false))'
+		exit 1
+		;;
 	worker)
 		printf '%s\n' 'STALE_RECOVERED: issue #2905 in exampleorg/examplerepo - unassigned runner (dispatch claim 900s old, last activity 900s old (threshold=600s, interactive=false))'
 		exit 1
@@ -137,7 +141,11 @@ _classify_stale_recovery_crash_type() {
 	local repo_slug="$2"
 	: "$issue_number" "$repo_slug"
 	printf '%s|%s\n' "$issue_number" "$repo_slug" >>"$CLASSIFY_LOG"
-	printf 'no_work'
+	if [[ "${TEST_STALE_MODE:-no_worker}" == "prelaunch_orphan" ]]; then
+		printf 'prelaunch'
+	else
+		printf 'no_work'
+	fi
 	return 0
 }
 
@@ -279,8 +287,35 @@ test_terminal_pr_checkpoint_routes_existing_consolidation_guard() {
 	return 0
 }
 
+# GH#1214 / t2769 regression: a pre-launch abort (orphan branch hold) that
+# leaves a stale assignment with a prior dispatch claim should not record a
+# no_work fast-fail. The classifier detects the orphan ops marker and returns
+# "prelaunch", which the recording path skips.
+test_prelaunch_orphan_stale_recovery_skips_fast_fail() {
+	export TEST_STALE_MODE="prelaunch_orphan"
+	reset_observations
+	local rc=0
+	_dedup_layer6_assignee_and_stale "2905" "exampleorg/examplerepo" "runner" || rc=$?
+
+	if [[ "$rc" -ne 1 ]]; then
+		fail "prelaunch orphan stale recovery continues dispatch" "expected rc=1, got rc=${rc}"
+		return 0
+	fi
+	if [[ "$FAST_FAIL_CALLS" -ne 0 ]]; then
+		fail "prelaunch orphan stale recovery skips fast-fail" "fast_fail_record called ${FAST_FAIL_CALLS} time(s): ${LAST_FAST_FAIL}"
+		return 0
+	fi
+	if ! grep -q 'classified as prelaunch' "$LOGFILE" 2>/dev/null; then
+		fail "prelaunch orphan stale recovery logs prelaunch skip" "log: $(tr '\n' ' ' <"$LOGFILE")"
+		return 0
+	fi
+	pass "prelaunch orphan stale recovery skips no_work fast-fail (GH#1214)"
+	return 0
+}
+
 test_stale_recovery_without_claim_skips_fast_fail
 test_prelaunch_canary_stale_recovery_skips_fast_fail
+test_prelaunch_orphan_stale_recovery_skips_fast_fail
 test_stale_recovery_with_dispatch_claim_records_fast_fail
 test_stale_recovery_blocked_by_dependency_blocks_redispatch
 test_terminal_stale_recovery_routes_consolidation_and_blocks

--- a/.agents/scripts/tests/test-prelaunch-rollback-unassign.sh
+++ b/.agents/scripts/tests/test-prelaunch-rollback-unassign.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#1214 / t2769 root cause.
+#
+# When a pre-launch abort (worker_branch_orphan_hold, canary fail, etc.) fires
+# AFTER the dispatch has claimed and assigned the issue, _rollback_prelaunch_ownership
+# must unassign self regardless of whether the issue still has status:queued.
+#
+# Previously, the function checked `owns_queued` (status:queued AND assigned)
+# and returned 0 without unassigning when the status label was absent. This left
+# a stale assignment that fed the stale-recovery→fast-fail→t2769 circuit breaker.
+#
+# The fix separates "should I unassign?" (always if assigned) from "should I
+# change status labels?" (only if status:queued is present).
+#
+# shellcheck disable=SC1090,SC1091,SC2034
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+SCRIPT_DIR="$SCRIPTS_DIR"
+
+TMP_HOME=$(mktemp -d -t prelaunch-rollback.XXXXXX) || exit 1
+trap 'rm -rf "$TMP_HOME"' EXIT
+export HOME="$TMP_HOME"
+export LOGFILE="${TMP_HOME}/test.log"
+export REPOS_JSON="${TMP_HOME}/repos.json"
+printf '{"initialized_repos":[]}' >"$REPOS_JSON"
+
+# Source dependencies
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/pulse-dispatch-core.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+	return 0
+}
+
+# ── Mock infrastructure ──────────────────────────────────────────────────────
+GH_COMMENT_LOG="${TMP_HOME}/gh-comment.log"
+GH_API_COMMENTS_RESPONSE="${TMP_HOME}/gh-api-comments.json"
+GH_ISSUE_RESPONSE="${TMP_HOME}/gh-issue.json"
+GH_EDIT_LOG="${TMP_HOME}/gh-edit.log"
+
+reset_state() {
+	: >"$GH_COMMENT_LOG"
+	: >"$GH_EDIT_LOG"
+	: >"$LOGFILE"
+	printf '[]' >"$GH_API_COMMENTS_RESPONSE"
+	printf '{}' >"$GH_ISSUE_RESPONSE"
+	return 0
+}
+
+_extract_jq_filter() {
+	local prev=""
+	local arg
+	for arg in "$@"; do
+		[[ "$prev" == "--jq" ]] && { printf '%s' "$arg"; return 0; }
+		prev="$arg"
+	done
+	return 1
+}
+
+_mock_gh_response() {
+	local response_file="$1"
+	shift
+	local jq_filter
+	if jq_filter=$(_extract_jq_filter "$@"); then
+		jq -r "$jq_filter" <"$response_file" 2>/dev/null || cat "$response_file"
+	else
+		cat "$response_file"
+	fi
+	return 0
+}
+
+STATUS_MUTATION_FAIL=0
+EDIT_SHOULD_UPDATE=1
+
+gh() {
+	local cmd="${1:-}"
+	shift || true
+	case "$cmd" in
+	api)
+		local path="${1:-}"
+		shift || true
+		case "$path" in
+		repos/*/issues/*/comments | repos/*/issues/*/comments\?*)
+			local is_post=0
+			local arg prev=""
+			for arg in "$@"; do
+				[[ "$prev" == "--method" && "$arg" == "POST" ]] && is_post=1
+				prev="$arg"
+			done
+			if [[ "$is_post" -eq 1 ]]; then
+				printf '{"id":123456}\n'
+				return 0
+			fi
+			_mock_gh_response "$GH_API_COMMENTS_RESPONSE" "$@"
+			;;
+		repos/*/issues/comments/*)
+			local is_delete=0 prev=""
+			local arg
+			for arg in "$@"; do
+				[[ "$prev" == "--method" && "$arg" == "DELETE" ]] && is_delete=1
+				prev="$arg"
+			done
+			if [[ "$is_delete" -eq 1 ]]; then
+				printf '%s\n' 'DELETE_COMMENT' >>"$GH_COMMENT_LOG"
+			fi
+			printf '{}\n'
+			;;
+		*)
+			echo "{}"
+			;;
+		esac
+		;;
+	issue)
+		local sub="${1:-}"
+		shift || true
+		case "$sub" in
+		view)
+			cat "$GH_ISSUE_RESPONSE"
+			;;
+		edit)
+			# Log the edit call for assertions.
+			printf 'EDIT %s\n' "$*" >>"$GH_EDIT_LOG"
+			# Simulate successful unassign: update the response to remove assignee.
+			if [[ "$EDIT_SHOULD_UPDATE" -eq 1 ]]; then
+				local current_response=""
+				current_response=$(cat "$GH_ISSUE_RESPONSE")
+				printf '%s' "$current_response" | jq '.assignees = []' >"$GH_ISSUE_RESPONSE"
+			fi
+			return 0
+			;;
+		*) ;;
+		esac
+		;;
+	*) ;;
+	esac
+	return 0
+}
+
+set_issue_status() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local status_name="$3"
+	: "$issue_number" "$repo_slug" "$status_name"
+	[[ "$STATUS_MUTATION_FAIL" -eq 0 ]] || return 1
+	printf '{"state":"OPEN","labels":[{"name":"status:%s"}],"assignees":[],"locked":false}' "$status_name" >"$GH_ISSUE_RESPONSE"
+	return 0
+}
+
+unlock_issue_after_worker() {
+	return 0
+}
+
+sleep() {
+	return 0
+}
+
+# ── Test 1: status:queued present → full rollback (existing behaviour) ───────
+test_rollback_with_queued() {
+	reset_state
+	_claim_comment_id="claim-queued"
+	printf '[{"id":"claim-queued","body":"DISPATCH_CLAIM nonce=test runner=runner-a"}]' >"$GH_API_COMMENTS_RESPONSE"
+	printf '{"state":"OPEN","labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}],"locked":false}' >"$GH_ISSUE_RESPONSE"
+
+	_release_dispatch_claim_on_abort "100" "owner/repo" "runner-a" "worker_launch_rc_2"
+
+	if grep -q 'Pre-launch rollback verified' "$LOGFILE"; then
+		pass "rollback with status:queued present → full rollback (existing)"
+	else
+		fail "rollback with status:queued present → full rollback (existing)" "log: $(cat "$LOGFILE")"
+	fi
+	if grep -q '^DELETE_COMMENT$' "$GH_COMMENT_LOG"; then
+		pass "rollback with status:queued present → claim deleted"
+	else
+		fail "rollback with status:queued present → claim deleted" "log: $(cat "$GH_COMMENT_LOG")"
+	fi
+	return 0
+}
+
+# ── Test 2: status:queued ABSENT, self assigned → unassign-only (GH#1214) ───
+test_rollback_without_queued() {
+	reset_state
+	_claim_comment_id="claim-no-queued"
+	printf '[{"id":"claim-no-queued","body":"DISPATCH_CLAIM nonce=test runner=runner-a"}]' >"$GH_API_COMMENTS_RESPONSE"
+	# Issue has status:in-review (NOT queued) but IS assigned to self.
+	printf '{"state":"OPEN","labels":[{"name":"status:in-review"}],"assignees":[{"login":"runner-a"}],"locked":false}' >"$GH_ISSUE_RESPONSE"
+
+	_release_dispatch_claim_on_abort "200" "owner/repo" "runner-a" "worker_launch_rc_2"
+
+	if grep -q 'Pre-launch rollback.*unassigned\|Pre-launch rollback verified\|Pre-launch rollback: unassigned' "$LOGFILE"; then
+		pass "rollback without status:queued → unassign-only (GH#1214)"
+	else
+		fail "rollback without status:queued → unassign-only (GH#1214)" "log: $(cat "$LOGFILE")"
+	fi
+	if grep -q 'remove-assignee' "$GH_EDIT_LOG"; then
+		pass "rollback without status:queued → gh issue edit --remove-assignee called"
+	else
+		fail "rollback without status:queued → gh issue edit --remove-assignee called" "edit log: $(cat "$GH_EDIT_LOG")"
+	fi
+	if grep -q '^DELETE_COMMENT$' "$GH_COMMENT_LOG"; then
+		pass "rollback without status:queued → claim deleted after unassign"
+	else
+		fail "rollback without status:queued → claim deleted after unassign" "comment log: $(cat "$GH_COMMENT_LOG")"
+	fi
+	return 0
+}
+
+# ── Test 3: self NOT assigned → no-op, claim deleted ─────────────────────────
+test_rollback_not_assigned() {
+	reset_state
+	_claim_comment_id="claim-not-assigned"
+	printf '[{"id":"claim-not-assigned","body":"DISPATCH_CLAIM nonce=test runner=runner-a"}]' >"$GH_API_COMMENTS_RESPONSE"
+	# Issue is open but assigned to someone else, not to runner-a.
+	printf '{"state":"OPEN","labels":[{"name":"status:queued"}],"assignees":[{"login":"other-runner"}],"locked":false}' >"$GH_ISSUE_RESPONSE"
+
+	_release_dispatch_claim_on_abort "300" "owner/repo" "runner-a" "worker_launch_rc_2"
+
+	# Should return 0 without attempting unassign (self not assigned).
+	if ! grep -q 'remove-assignee' "$GH_EDIT_LOG" && ! grep -q 'set_issue_status' "$GH_EDIT_LOG"; then
+		pass "rollback when not assigned → no unassign attempted"
+	else
+		fail "rollback when not assigned → no unassign attempted" "edit log: $(cat "$GH_EDIT_LOG")"
+	fi
+	if grep -q '^DELETE_COMMENT$' "$GH_COMMENT_LOG"; then
+		pass "rollback when not assigned → claim deleted (no-op rollback)"
+	else
+		fail "rollback when not assigned → claim deleted (no-op rollback)" "comment log: $(cat "$GH_COMMENT_LOG")"
+	fi
+	return 0
+}
+
+test_rollback_with_queued
+test_rollback_without_queued
+test_rollback_not_assigned
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Root Cause (Majowka/mesh-manager#1214)

**File/function/race**: `pulse-dispatch-core.sh::_rollback_prelaunch_ownership` returned 0 (success) without unassigning the worker when the issue's status label didn't match `status:queued`.

### Failure chain (forensics from Majowka/mesh-manager#48)

1. Dispatch claimed #48, assigned runner, set `status:queued`
2. Orphan check found existing worktree with zero-commit branch → `WORKER_BRANCH_ORPHAN_UNRECOVERABLE_BLOCKED`
3. Pre-launch abort (rc=2): `_rollback_prelaunch_ownership` checked `owns_queued` — the combined `status:queued + assigned` check returned false (label race or jq evaluation edge case) → returned 0 **without unassigning**
4. Claim comment deleted (t3549 noise elimination) — caller assumed cleanup succeeded
5. Next pulse: `dedup_active_claim` blocked (assignment still present)
6. 10 minutes later: stale recovery fired, classified `crash_type=no_work`, recorded `stale_timeout` fast-fail
7. After 4 cycles of steps 5-6: `t2769 no_work NMR circuit breaker` tripped

### Fix 1 — Root cause (`pulse-dispatch-core.sh`)

`_rollback_prelaunch_ownership` now separates "should I unassign?" from "should I change status?":

- **Always unassign** self if assigned, regardless of status label
- Only transition `status:queued → status:available` if `status:queued` is present
- When `status:queued` is absent: uses bare `gh issue edit --remove-assignee` instead of `set_issue_status`
- Relaxed verification: only checks assignee removal, not status/lock state (avoids false negatives from locked issues or concurrent label mutations)

### Fix 2 — Defence-in-depth (`pulse-dispatch-dedup-layers.sh`)

Even if Fix 1 fails (API error, race), the stale recovery path now detects pre-launch abort evidence:

- `_classify_stale_recovery_crash_type` checks issue comments for pre-launch abort ops markers (`WORKER_BRANCH_ORPHAN`, canary failure, worktree failure)
- Returns `prelaunch` instead of `no_work` when markers found
- Stale-recovery fast-fail recording skips `prelaunch` crash type
- This prevents the t2769 circuit breaker from firing on pre-launch aborts

### Tests

- `test-prelaunch-rollback-unassign.sh` (new): 7 tests covering queued/non-queued/not-assigned rollback paths
- `test-dispatch-dedup-stale-no-worker.sh`: added `prelaunch_orphan` test case verifying classifier skip
- `test-dispatch-lifecycle-comms.sh`: all 16 existing tests pass
- `test-no-work-prelaunch-skip.sh`: all 4 existing tests pass

### Verification

```bash
bash .agents/scripts/tests/test-prelaunch-rollback-unassign.sh
bash .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
bash .agents/scripts/tests/test-dispatch-lifecycle-comms.sh
bash .agents/scripts/tests/test-no-work-prelaunch-skip.sh
```

For Majowka/mesh-manager#1214

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with claude-opus-4-6.
