### PR TITLE
t18131: Add fail-closed GitHub API efficiency benchmark

### DIFF
--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -1,0 +1,270 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# GitHub API efficiency benchmark
+
+The GitHub API efficiency benchmark compares two immutable, privacy-safe
+observation windows. It proves request savings only when transport, workload,
+latency, freshness, correctness, and path-budget evidence are all complete and
+comparable.
+
+The benchmark never reads raw API telemetry and never changes runtime defaults.
+An inconclusive result preserves every rollback control and keeps the rollout
+task open.
+
+## Command
+
+```bash
+.agents/scripts/github-api-efficiency-benchmark.sh compare \
+  --baseline-report "${BASELINE_REPORT}" \
+  --baseline-evidence "${BASELINE_EVIDENCE}" \
+  --baseline-label "baseline-before-change" \
+  --canary-report "${CANARY_REPORT}" \
+  --canary-evidence "${CANARY_EVIDENCE}" \
+  --canary-label "canary-after-change" \
+  --canary-not-before "${ROLLOUT_EPOCH}" \
+  --json-out "${RESULT_JSON}" \
+  --markdown-out "${RESULT_MARKDOWN}"
+```
+
+`--canary-not-before` is required. It is the UTC epoch at which the measured
+rollout became active, not the time at which the report was generated.
+
+Exit codes:
+
+| Code | Status | Meaning |
+|---:|---|---|
+| `0` | `PASS` | Comparable evidence meets every savings and guardrail threshold. |
+| `1` | `REGRESSION` | Comparable evidence breaches one or more thresholds. |
+| `2` | `INCONCLUSIVE` | Inputs are invalid, incomplete, unknown, or noncomparable. |
+
+JSON output uses `aidevops-github-api-efficiency-benchmark/v1`. Each output file
+is written through a private temporary file and atomically renamed. Re-running
+with identical inputs and options is byte-stable.
+
+## Input contract
+
+### Transport aggregate
+
+Each transport input must be an immutable JSON report produced by
+`.agents/scripts/gh-api-aggregate.awk` with `_meta.schema_version == 2`.
+The benchmark validates:
+
+- first and last retained attempt timestamps and their effective duration;
+- exact attempt accounting and path reconciliation;
+- quota-cost reconciliation;
+- malformed, legacy, unidentified, duplicate, opaque-pagination, and unknown
+  attempt counters;
+- the supported path set: `graphql`, `rest`, `search-graphql`, `search-rest`,
+  `other`, and `unknown`.
+
+Any unknown quota cost or unclassified transport attempt prevents `PASS`.
+Never derive a benchmark by reading the raw JSONL/log source directly.
+
+### Evidence sidecar
+
+Each transport aggregate has one sidecar using
+`aidevops-github-api-efficiency-evidence/v1`. `transport_sha256` binds the
+sidecar to the exact aggregate bytes. The result also records the sidecar's own
+SHA-256 digest.
+
+The following is an intentionally incomplete template. Replace every required
+`null` with a privacy-safe observed value and set `complete` to `true` only when
+the whole fixed window has been reconciled. The transport digest must be 64
+lowercase hexadecimal characters.
+
+```json
+{
+  "schema": "aidevops-github-api-efficiency-evidence/v1",
+  "transport_sha256": "<sha256-of-exact-transport-report>",
+  "complete": false,
+  "population": {
+    "repository_count": null,
+    "pulse_cycles": null,
+    "unchanged_cycles": null,
+    "actionable_changes": null,
+    "unique_actionable_head_shas": null,
+    "repository_set_sha256": null
+  },
+  "latency": {
+    "p50_ms": null,
+    "p95_ms": null,
+    "peak_attempts_per_minute": null,
+    "completed_action_p95_ms": null
+  },
+  "cache": {
+    "fresh_hits": null,
+    "fresh_empty_hits": null,
+    "misses": null,
+    "stale": null,
+    "invalidated": null
+  },
+  "single_flight": {
+    "leaders": null,
+    "waits": null,
+    "takeovers": null,
+    "duplicate_leaders": null
+  },
+  "webhook": {
+    "invalidations": null,
+    "lag_p50_ms": null,
+    "lag_p95_ms": null,
+    "duplicate_actions": null,
+    "missed_recoveries": null
+  },
+  "guardrails": {
+    "stale_snapshot_detections": null,
+    "forced_live_refreshes": null,
+    "stale_positive_decisions": null,
+    "dispatch_dependency_violations": null,
+    "required_check_merge_preflight_mismatches": null
+  },
+  "path_budgets": {
+    "fingerprint_verification_list_calls": null,
+    "fresh_empty_live_fallbacks": null,
+    "aggregate_check_fetches": null
+  }
+}
+```
+
+Evidence values are non-negative JSON-safe numbers. Counts should remain
+integers. Repository identity is represented only by the SHA-256 digest of the
+sorted fixed repository set; do not put repository names, request payloads,
+tokens, URLs, or raw log records in the sidecar.
+
+### Evidence ownership
+
+| Group | Privacy-safe source |
+|---|---|
+| `population` | Fixed Pulse scope and cycle/outcome counters for the retained window. |
+| `latency` | Aggregate request and completed-action histograms plus peak minute count. |
+| `cache` | Canonical snapshot/check-cache decision counters. |
+| `single_flight` | Leader, follower wait, takeover, and duplicate-leader counters. |
+| `webhook` | Verified invalidation count and aggregate delivery-to-invalidation lag. |
+| `guardrails` | Freshness detections, forced refreshes, dependency checks, and merge-preflight comparisons. |
+| `path_budgets` | Deterministic call-site counters from focused request-budget tests/telemetry. |
+
+## Comparability gate
+
+The benchmark evaluates regressions only after both windows pass all
+completeness checks. It otherwise returns `INCONCLUSIVE`.
+
+Default comparability rules:
+
+- same repository count and repository-set digest;
+- non-overlapping retained attempt windows;
+- canary starts on or after `--canary-not-before`;
+- larger effective duration divided by smaller duration is at most `1.25`;
+- Pulse cycle-rate change is at most `25%`;
+- unchanged-cycle, actionable-change, and unique-actionable-head rates each
+  change by at most `25%`;
+- both reports contain exact attempts, zero unknown quota attempts, zero legacy
+  or malformed records, and no unclassified transport attempts;
+- every sidecar field is known and both sidecars are marked complete;
+- both windows contain at least one repository, Pulse cycle, and transport
+  attempt.
+
+## Metrics and decision thresholds
+
+The JSON and Markdown reports include absolute and normalized transport values
+per repository-hour, Pulse cycle, unchanged cycle, actionable change, and
+unique actionable head SHA where the denominator is non-zero.
+
+Transport metrics are attempts, GraphQL points, GraphQL attempts, REST
+attempts, search attempts, unclassified attempts, retries, pages, additional
+pages, and API errors. `search_attempts` includes both GraphQL and REST search;
+it is intentionally a cross-cutting category rather than a partition of total
+attempts.
+
+Default `PASS` thresholds:
+
+| Decision | Default |
+|---|---:|
+| Attempt reduction per repository-hour | at least `5%` |
+| Attempt reduction per Pulse cycle | at least `5%` |
+| GraphQL-point increase per repository-hour | at most `0%` |
+| GraphQL-point increase per Pulse cycle | at most `0%` |
+| API error-rate increase | at most `0` percentage points |
+| Request/completed-action p95 increase | at most `20%` |
+| Webhook invalidation p95 lag increase | at most `20%` |
+| Peak attempts-per-minute increase | at most `10%` |
+
+The canary must also have:
+
+- zero stale-positive decisions, dispatch dependency violations, and
+  required-check/merge-preflight mismatches;
+- zero duplicate single-flight leaders, duplicate webhook actions, and missed
+  webhook recoveries;
+- zero fingerprint/verification list calls and fresh-empty live fallbacks;
+- no more than one aggregate check fetch per unique actionable head SHA.
+
+Threshold options may make a comparison stricter. Any deliberate relaxation
+requires issue/PR rationale and another canary; do not weaken a threshold merely
+to convert an observed regression into a pass.
+
+## Observation workflow
+
+1. Define a fixed repository population and record its sorted-set SHA-256.
+2. Record the exact rollout epoch.
+3. Copy the completed aggregate to an immutable regular file. Do not benchmark
+   a report that is still being replaced by an active aggregation job.
+4. Reconcile the complete sidecar from privacy-safe aggregate counters.
+5. Collect a non-overlapping canary with a similar retained duration and Pulse
+   cycle rate.
+6. Run the benchmark and attach both generated reports to the rollout task.
+7. On `INCONCLUSIVE`, collect missing evidence without tuning or removing
+   controls. On `REGRESSION`, restore the owning bounded default and repeat the
+   same focused tests. On `PASS`, change at most one bounded default/control at
+   a time and repeat the canary.
+
+## Current t18131 checkpoint
+
+The retained generation-8 baseline ends at `2026-07-18T06:04:10Z`. Its quota
+cost is unknown for all retained attempts. The later aggregate begins before
+t18130 merged at `2026-07-18T15:49:27Z` (`1784389767`) and also contains unknown
+quota costs. Neither report can produce `PASS`.
+
+Therefore this implementation does not tune `.agents/configs/pulse-sweep-budget.json`,
+does not tune `.agents/configs/webhook-receiver.conf`, and removes no feature or
+rollback flag. A valid final comparison requires both a new exact baseline and
+a 12–24 hour post-rollout canary with complete sidecars.
+
+## Retained controls and rollback triggers
+
+Owner for the following controls is the aidevops Pulse maintainers. Review them
+after the first valid t18131 canary, no earlier than `2026-07-20`. A review date
+is not an automatic expiry: unknown evidence retains the control.
+
+| Control/default | Why retained | Rollback trigger and compatibility decision |
+|---|---|---|
+| `state_fingerprint_cache_hit_enabled=true` | Existing baseline is not quota-exact, so the canonical-snapshot saving is not yet proven system-wide. | Set `false` if snapshot cache hits cause stale-positive or dependency/preflight mismatches; keep the reader compatible until a valid canary passes. |
+| `PULSE_BATCH_PREFETCH_ENABLED=1` | Primary bounded batch path remains covered by focused tests but needs real aggregate proof. | Set `0` for freshness/correctness regression; preserve the non-batch path. |
+| `PULSE_BATCH_CONDITIONAL_REST_ENABLED=1` | ETag refresh is bounded and falls back, but incomplete or invalidated snapshots must not be reused. | Set `0` if fresh-empty fallback, stale publication, or conditional-response validation regresses. |
+| `PULSE_BATCH_SEARCH_LAST_RESORT=1` | Owner search currently routes through REST/cache before GraphQL. | Set `0` if REST/search error or secondary-limit evidence regresses; retain the GraphQL fallback. |
+| Snapshot schema `aidevops-pulse-snapshot/v1` | Auth scope, projection, completeness, generation, and invalidation generation fence mixed state. | Reject incompatible/legacy snapshots and live-refresh; do not remove compatibility handling before fleet convergence. |
+| Check cache enabled; terminal TTL `21600s`, actionable TTL `30s` | Exact-head terminal state is immutable, while actionable state remains short-lived. | Set `AIDEVOPS_GH_CHECK_STATUS_CACHE_DISABLE=1` for stale state; retain TTL caps (`604800s` terminal, `300s` actionable). |
+| Shared request state enabled; lease `30s`, wait `10s`, outcome TTL `10s`, rate TTL `20s` | Single-flight and scoped rate snapshots reduce duplicate reads with bounded takeover. | Set `AIDEVOPS_GH_SINGLEFLIGHT_DISABLE=1` or `AIDEVOPS_GH_REQUEST_STATE_DISABLE=1` for duplicate leaders, stuck waits, or publication-fencing defects. |
+| Webhook protocol `v1`; loopback listener; ledger TTL `604800s`; maximum `4096`; dispatch concurrency `4` | Verified invalidation accelerates freshness while the periodic polling backstop remains authoritative. | Disable the receiver service for authentication, replay, lag, duplicate-action, or missed-recovery regression; keep polling and protocol-v1 validation. |
+
+Secure loopback binding, webhook signature verification, request-size bounds, and
+the periodic polling backstop are safety controls, not optimization flags, and
+must not be removed by an efficiency-only canary.
+
+## Verification
+
+```bash
+bash .agents/scripts/tests/test-github-api-efficiency-benchmark.sh
+shellcheck \
+  .agents/scripts/github-api-efficiency-benchmark.sh \
+  .agents/scripts/tests/test-github-api-efficiency-benchmark.sh
+python3 -m py_compile \
+  .agents/scripts/github-api-efficiency-benchmark.py \
+  .agents/scripts/github_api_efficiency_inputs.py \
+  .agents/scripts/github_api_efficiency_metrics.py \
+  .agents/scripts/github_api_efficiency_report.py
+```
+
+The fixture suite covers deterministic pass output, regressions, incomplete
+evidence, materially unequal windows, rollout boundaries, unknown quota costs,
+non-equivalent workload mixes, unclassified attempts, inconsistent counters or
+population relationships, incompatible schemas, and mismatched evidence digests.

--- a/.agents/scripts/github-api-efficiency-benchmark.py
+++ b/.agents/scripts/github-api-efficiency-benchmark.py
@@ -18,7 +18,7 @@ from github_api_efficiency_inputs import BenchmarkInputError, build_window
 from github_api_efficiency_report import (
     EXIT_INCONCLUSIVE,
     EXIT_REGRESSION,
-    STATUS_PASS,
+    STATUS_OK,
     STATUS_REGRESSION,
     Thresholds,
     build_result,
@@ -159,7 +159,7 @@ def main() -> int:
         print(f"github-api-efficiency-benchmark: {exc}", file=sys.stderr)
         return EXIT_INCONCLUSIVE
     print(f"{result['status']}: {len(result['reasons'])} decision reason(s)")
-    if result["status"] == STATUS_PASS:
+    if result["status"] == STATUS_OK:
         return 0
     if result["status"] == STATUS_REGRESSION:
         return EXIT_REGRESSION

--- a/.agents/scripts/github-api-efficiency-benchmark.py
+++ b/.agents/scripts/github-api-efficiency-benchmark.py
@@ -39,7 +39,8 @@ def _atomic_write(path: Path, content: str) -> None:
         descriptor, temporary_name = tempfile.mkstemp(
             prefix=f".{path.name}.", dir=path.parent
         )
-        os.fchmod(descriptor, 0o600)
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, 0o600)
         handle = os.fdopen(descriptor, "w", encoding="utf-8")
         descriptor = -1
         with handle:

--- a/.agents/scripts/github-api-efficiency-benchmark.py
+++ b/.agents/scripts/github-api-efficiency-benchmark.py
@@ -58,7 +58,10 @@ def _atomic_write(path: Path, content: str) -> None:
         if descriptor >= 0:
             os.close(descriptor)
         if temporary_name:
-            Path(temporary_name).unlink(missing_ok=True)
+            try:
+                os.unlink(temporary_name)
+            except FileNotFoundError:
+                pass
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/.agents/scripts/github-api-efficiency-benchmark.py
+++ b/.agents/scripts/github-api-efficiency-benchmark.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Compare privacy-safe GitHub API baseline and canary evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+import re
+import sys
+import tempfile
+
+from github_api_efficiency_inputs import BenchmarkInputError, build_window
+from github_api_efficiency_report import (
+    EXIT_INCONCLUSIVE,
+    EXIT_REGRESSION,
+    STATUS_PASS,
+    STATUS_REGRESSION,
+    Thresholds,
+    build_result,
+    render_markdown,
+)
+
+
+_LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._ -]{0,63}$")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    descriptor = -1
+    temporary_name = ""
+    try:
+        if path.is_symlink():
+            raise BenchmarkInputError("output path must not be a symlink")
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{path.name}.", dir=path.parent
+        )
+        os.fchmod(descriptor, 0o600)
+        handle = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        with handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except BenchmarkInputError:
+        raise
+    except OSError as exc:
+        raise BenchmarkInputError(
+            "could not atomically write an output report"
+        ) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if temporary_name:
+            Path(temporary_name).unlink(missing_ok=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("compare",))
+    parser.add_argument("--baseline-report", required=True, type=Path)
+    parser.add_argument("--baseline-evidence", required=True, type=Path)
+    parser.add_argument("--baseline-label", required=True)
+    parser.add_argument("--canary-report", required=True, type=Path)
+    parser.add_argument("--canary-evidence", required=True, type=Path)
+    parser.add_argument("--canary-label", required=True)
+    parser.add_argument("--json-out", required=True, type=Path)
+    parser.add_argument("--markdown-out", required=True, type=Path)
+    parser.add_argument("--max-window-ratio", type=float, default=1.25)
+    parser.add_argument("--max-cycle-rate-change-pct", type=float, default=25.0)
+    parser.add_argument("--min-attempt-reduction-pct", type=float, default=5.0)
+    parser.add_argument("--max-graphql-point-increase-pct", type=float, default=0.0)
+    parser.add_argument("--max-error-rate-increase-points", type=float, default=0.0)
+    parser.add_argument("--max-latency-increase-pct", type=float, default=20.0)
+    parser.add_argument("--max-burst-increase-pct", type=float, default=10.0)
+    parser.add_argument("--canary-not-before", type=int, required=True)
+    return parser
+
+
+def _thresholds(args: argparse.Namespace) -> Thresholds:
+    values = (
+        args.max_window_ratio,
+        args.max_cycle_rate_change_pct,
+        args.min_attempt_reduction_pct,
+        args.max_graphql_point_increase_pct,
+        args.max_error_rate_increase_points,
+        args.max_latency_increase_pct,
+        args.max_burst_increase_pct,
+    )
+    invalid = any(not math.isfinite(value) or value < 0 for value in values)
+    if invalid or args.max_window_ratio < 1 or args.canary_not_before <= 0:
+        raise BenchmarkInputError(
+            "thresholds must be finite and non-negative; "
+            "max-window-ratio must be at least 1 and "
+            "canary-not-before must be positive"
+        )
+    return Thresholds(*values, args.canary_not_before)
+
+
+def _validate_labels(args: argparse.Namespace) -> None:
+    labels = (args.baseline_label, args.canary_label)
+    labels_are_safe = all(_LABEL_RE.fullmatch(label) for label in labels)
+    if labels[0] == labels[1] or not labels_are_safe:
+        raise BenchmarkInputError(
+            "labels must be distinct safe text of at most 64 characters"
+        )
+
+
+def _canonical_path(path: Path) -> Path:
+    try:
+        return path.resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        raise BenchmarkInputError("could not resolve an input or output path") from exc
+
+
+def _validate_cli_paths(args: argparse.Namespace) -> None:
+    _validate_labels(args)
+    input_paths = (
+        args.baseline_report,
+        args.baseline_evidence,
+        args.canary_report,
+        args.canary_evidence,
+    )
+    inputs = {_canonical_path(path) for path in input_paths}
+    outputs = (
+        _canonical_path(args.json_out),
+        _canonical_path(args.markdown_out),
+    )
+    if outputs[0] == outputs[1] or any(path in inputs for path in outputs):
+        raise BenchmarkInputError(
+            "output paths must be distinct from each other and every input"
+        )
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        _validate_cli_paths(args)
+        thresholds = _thresholds(args)
+        baseline = build_window(
+            args.baseline_label, args.baseline_report, args.baseline_evidence
+        )
+        canary = build_window(
+            args.canary_label, args.canary_report, args.canary_evidence
+        )
+        result = build_result(baseline, canary, thresholds)
+        json_content = json.dumps(
+            result, indent=2, sort_keys=True, allow_nan=False
+        ) + "\n"
+        markdown_content = render_markdown(result)
+        _atomic_write(args.json_out, json_content)
+        _atomic_write(args.markdown_out, markdown_content)
+    except BenchmarkInputError as exc:
+        print(f"github-api-efficiency-benchmark: {exc}", file=sys.stderr)
+        return EXIT_INCONCLUSIVE
+    print(f"{result['status']}: {len(result['reasons'])} decision reason(s)")
+    if result["status"] == STATUS_PASS:
+        return 0
+    if result["status"] == STATUS_REGRESSION:
+        return EXIT_REGRESSION
+    return EXIT_INCONCLUSIVE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/github-api-efficiency-benchmark.sh
+++ b/.agents/scripts/github-api-efficiency-benchmark.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Thin, dependency-free entrypoint for the GitHub API efficiency comparator.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
+readonly BENCHMARK_ENGINE="${SCRIPT_DIR}/github-api-efficiency-benchmark.py"
+
+main() {
+	if ! command -v python3 >/dev/null 2>&1; then
+		printf 'github-api-efficiency-benchmark: python3 is required\n' >&2
+		return 2
+	fi
+	if [[ ! -r "$BENCHMARK_ENGINE" ]]; then
+		printf 'github-api-efficiency-benchmark: comparison engine is unavailable\n' >&2
+		return 2
+	fi
+	python3 "$BENCHMARK_ENGINE" "$@"
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/github_api_efficiency_inputs.py
+++ b/.agents/scripts/github_api_efficiency_inputs.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validated input model for the GitHub API efficiency benchmark."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+from typing import Any
+
+from github_api_efficiency_metrics import (
+    build_transport_metrics,
+    counter_relationship_error,
+)
+
+
+EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v1"
+TRANSPORT_SCHEMA_VERSION = 2
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+_ALLOWED_PATHS = frozenset(
+    ("graphql", "rest", "search-graphql", "search-rest", "other", "unknown")
+)
+_RECONCILED_PATH_METRICS = (
+    "attempted_requests",
+    "known_quota_cost",
+    "unknown_quota_cost_attempts",
+)
+
+REPORT_COUNTERS = (
+    "attempted_requests",
+    "retries",
+    "pages",
+    "additional_pages",
+    "successful_attempts",
+    "failed_attempts",
+    "elapsed_ms",
+    "known_quota_cost",
+    "unknown_quota_cost_attempts",
+    "duplicate_attempt_ids",
+    "unidentified_attempts",
+    "unknown_page_attempts",
+    "window_malformed_v2_records",
+    "legacy_events",
+    "opaque_paginated_attempts",
+)
+POPULATION_FIELDS = (
+    "repository_count",
+    "pulse_cycles",
+    "unchanged_cycles",
+    "actionable_changes",
+    "unique_actionable_head_shas",
+)
+EVIDENCE_GROUPS = {
+    "latency": (
+        "p50_ms",
+        "p95_ms",
+        "peak_attempts_per_minute",
+        "completed_action_p95_ms",
+    ),
+    "cache": ("fresh_hits", "fresh_empty_hits", "misses", "stale", "invalidated"),
+    "single_flight": ("leaders", "waits", "takeovers", "duplicate_leaders"),
+    "webhook": (
+        "invalidations",
+        "lag_p50_ms",
+        "lag_p95_ms",
+        "duplicate_actions",
+        "missed_recoveries",
+    ),
+    "guardrails": (
+        "stale_snapshot_detections",
+        "forced_live_refreshes",
+        "stale_positive_decisions",
+        "dispatch_dependency_violations",
+        "required_check_merge_preflight_mismatches",
+    ),
+    "path_budgets": (
+        "fingerprint_verification_list_calls",
+        "fresh_empty_live_fallbacks",
+        "aggregate_check_fetches",
+    ),
+}
+_MEASURED_EVIDENCE_FIELDS = frozenset(
+    (
+        ("latency", "p50_ms"),
+        ("latency", "p95_ms"),
+        ("latency", "completed_action_p95_ms"),
+        ("webhook", "lag_p50_ms"),
+        ("webhook", "lag_p95_ms"),
+    )
+)
+
+
+class BenchmarkInputError(ValueError):
+    """Raised when a report or evidence sidecar violates its schema."""
+
+
+@dataclass(frozen=True)
+class Window:
+    label: str
+    report: dict[str, Any]
+    evidence: dict[str, Any]
+    transport_sha256: str
+    evidence_sha256: str
+    totals: dict[str, int]
+    normalized: dict[str, dict[str, float | None]]
+
+
+def _load_object(path: Path, role: str) -> tuple[dict[str, Any], str]:
+    if path.is_symlink() or not path.is_file():
+        raise BenchmarkInputError(
+            f"{role} must be a regular, non-symlink file"
+        )
+    try:
+        raw = path.read_bytes()
+        payload = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BenchmarkInputError(f"{role} is not readable JSON") from exc
+    if not isinstance(payload, dict):
+        raise BenchmarkInputError(f"{role} root must be an object")
+    return payload, hashlib.sha256(raw).hexdigest()
+
+
+def _object(payload: dict[str, Any], key: str, context: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise BenchmarkInputError(f"{context}.{key} must be an object")
+    return value
+
+
+def _number(
+    value: Any,
+    context: str,
+    *,
+    integer: bool = True,
+    nullable: bool = False,
+) -> int | float | None:
+    if value is None:
+        if nullable:
+            return None
+        raise BenchmarkInputError(f"{context} must be a non-negative number")
+    expected = (int,) if integer else (int, float)
+    if type(value) not in expected:
+        raise BenchmarkInputError(f"{context} must be a non-negative number")
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise BenchmarkInputError(
+                f"{context} must be a non-negative safe JSON number"
+            )
+    if not 0 <= value <= _MAX_SAFE_INTEGER:
+        raise BenchmarkInputError(
+            f"{context} must be a non-negative safe JSON number"
+        )
+    return value
+
+
+def _validate_retained_window(meta: dict[str, Any]) -> None:
+    first = _number(meta.get("first_retained_ts"), "transport._meta.first_retained_ts")
+    last = _number(meta.get("last_retained_ts"), "transport._meta.last_retained_ts")
+    duration = _number(
+        meta.get("effective_window_seconds"),
+        "transport._meta.effective_window_seconds",
+    )
+    if first <= 0 or last <= first or duration != last - first:
+        raise BenchmarkInputError(
+            "transport retained timestamps and effective duration are inconsistent"
+        )
+    if not isinstance(meta.get("attempts_exact"), bool):
+        raise BenchmarkInputError("transport._meta.attempts_exact must be boolean")
+
+
+def _validate_path_metrics(by_path: dict[str, Any]) -> dict[str, int]:
+    totals = {metric: 0 for metric in _RECONCILED_PATH_METRICS}
+    for path_name, path_metrics in by_path.items():
+        if path_name not in _ALLOWED_PATHS:
+            raise BenchmarkInputError("transport.by_path contains an unsupported path")
+        if not isinstance(path_metrics, dict):
+            raise BenchmarkInputError("transport.by_path entries must be objects")
+        for metric in _RECONCILED_PATH_METRICS:
+            value = _number(
+                path_metrics.get(metric),
+                f"transport.by_path.{path_name}.{metric}",
+            )
+            totals[metric] += int(value)
+    return totals
+
+
+def _validate_report(payload: dict[str, Any]) -> None:
+    meta = _object(payload, "_meta", "transport")
+    schema = _number(meta.get("schema_version"), "transport._meta.schema_version")
+    if schema != TRANSPORT_SCHEMA_VERSION:
+        raise BenchmarkInputError("transport report schema_version must be 2")
+    for field in REPORT_COUNTERS:
+        _number(meta.get(field), f"transport._meta.{field}")
+    _validate_retained_window(meta)
+    counter_error = counter_relationship_error(meta)
+    if counter_error:
+        raise BenchmarkInputError(counter_error)
+    by_path = _object(payload, "by_path", "transport")
+    path_totals = _validate_path_metrics(by_path)
+    for metric, path_total in path_totals.items():
+        if path_total != meta[metric]:
+            raise BenchmarkInputError(
+                f"transport {metric} does not reconcile by path"
+            )
+
+
+def _validate_population_relationships(population: dict[str, Any]) -> None:
+    constraints = (
+        (
+            "unchanged_cycles",
+            "pulse_cycles",
+            "evidence unchanged cycles exceed Pulse cycles",
+        ),
+        (
+            "unique_actionable_head_shas",
+            "actionable_changes",
+            "evidence unique actionable head SHAs exceed actionable changes",
+        ),
+    )
+    for left_field, right_field, message in constraints:
+        left = population[left_field]
+        right = population[right_field]
+        if None not in (left, right) and left > right:
+            raise BenchmarkInputError(message)
+
+
+def _validate_population(payload: dict[str, Any]) -> None:
+    population = _object(payload, "population", "evidence")
+    for field in POPULATION_FIELDS:
+        if field not in population:
+            raise BenchmarkInputError(f"evidence.population.{field} is required")
+        _number(
+            population[field],
+            f"evidence.population.{field}",
+            nullable=True,
+        )
+    _validate_population_relationships(population)
+    if "repository_set_sha256" not in population:
+        raise BenchmarkInputError(
+            "evidence.population.repository_set_sha256 is required"
+        )
+    population_hash = population["repository_set_sha256"]
+    if population_hash is None:
+        return
+    if not isinstance(population_hash, str):
+        raise BenchmarkInputError(
+            "evidence.population.repository_set_sha256 must be null or lowercase SHA-256"
+        )
+    if not _SHA256_RE.fullmatch(population_hash):
+        raise BenchmarkInputError(
+            "evidence.population.repository_set_sha256 must be null or lowercase SHA-256"
+        )
+
+
+def _validate_evidence_groups(payload: dict[str, Any]) -> None:
+    for group_name, fields in EVIDENCE_GROUPS.items():
+        group = _object(payload, group_name, "evidence")
+        for field in fields:
+            if field not in group:
+                raise BenchmarkInputError(
+                    f"evidence.{group_name}.{field} is required"
+                )
+            _number(
+                group[field],
+                f"evidence.{group_name}.{field}",
+                integer=(group_name, field) not in _MEASURED_EVIDENCE_FIELDS,
+                nullable=True,
+            )
+
+
+def _validate_evidence(
+    payload: dict[str, Any], transport_sha256: str
+) -> None:
+    if payload.get("schema") != EVIDENCE_SCHEMA:
+        raise BenchmarkInputError(f"evidence schema must be {EVIDENCE_SCHEMA}")
+    if payload.get("transport_sha256") != transport_sha256:
+        raise BenchmarkInputError(
+            "evidence transport_sha256 does not match the transport report"
+        )
+    if not isinstance(payload.get("complete"), bool):
+        raise BenchmarkInputError("evidence.complete must be boolean")
+    _validate_population(payload)
+    _validate_evidence_groups(payload)
+
+
+def build_window(
+    label: str, report_path: Path, evidence_path: Path
+) -> Window:
+    report, transport_sha256 = _load_object(
+        report_path, f"{label} transport report"
+    )
+    evidence, evidence_sha256 = _load_object(
+        evidence_path, f"{label} evidence"
+    )
+    _validate_report(report)
+    _validate_evidence(evidence, transport_sha256)
+    totals, normalized = build_transport_metrics(report, evidence)
+    return Window(
+        label,
+        report,
+        evidence,
+        transport_sha256,
+        evidence_sha256,
+        totals,
+        normalized,
+    )

--- a/.agents/scripts/github_api_efficiency_metrics.py
+++ b/.agents/scripts/github_api_efficiency_metrics.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Transport metric normalization for the GitHub API efficiency benchmark."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+TRANSPORT_METRICS = (
+    "attempted_requests",
+    "graphql_points",
+    "graphql_attempts",
+    "rest_attempts",
+    "search_attempts",
+    "other_attempts",
+    "retries",
+    "pages",
+    "additional_pages",
+    "api_errors",
+)
+
+
+def counter_relationship_error(meta: dict[str, Any]) -> str | None:
+    attempts = meta["attempted_requests"]
+    checks = (
+        (
+            meta["successful_attempts"] + meta["failed_attempts"] == attempts,
+            "transport successful and failed attempts do not reconcile",
+        ),
+        (meta["retries"] <= attempts, "transport retries exceed attempts"),
+        (meta["pages"] <= attempts, "transport pages exceed attempts"),
+        (
+            meta["additional_pages"] <= meta["pages"],
+            "transport additional pages exceed pages",
+        ),
+        (
+            meta["unknown_quota_cost_attempts"] <= attempts,
+            "transport unknown quota attempts exceed attempts",
+        ),
+    )
+    for valid, message in checks:
+        if not valid:
+            return message
+    return None
+
+
+def _path_metric(
+    report: dict[str, Any], path_name: str, metric: str
+) -> int:
+    path_metrics = report["by_path"].get(path_name, {})
+    value = path_metrics.get(metric, 0)
+    return int(value) if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _transport_totals(report: dict[str, Any]) -> dict[str, int]:
+    meta = report["_meta"]
+    graphql_paths = ("graphql", "search-graphql")
+    graphql_points = sum(
+        _path_metric(report, path, "known_quota_cost")
+        for path in graphql_paths
+    )
+    graphql_attempts = sum(
+        _path_metric(report, path, "attempted_requests")
+        for path in graphql_paths
+    )
+    search_attempts = sum(
+        _path_metric(report, path, "attempted_requests")
+        for path in ("search-graphql", "search-rest")
+    )
+    return {
+        "attempted_requests": meta["attempted_requests"],
+        "graphql_points": graphql_points,
+        "graphql_attempts": graphql_attempts,
+        "rest_attempts": _path_metric(report, "rest", "attempted_requests"),
+        "search_attempts": search_attempts,
+        "other_attempts": sum(
+            _path_metric(report, path, "attempted_requests")
+            for path in ("other", "unknown")
+        ),
+        "retries": meta["retries"],
+        "pages": meta["pages"],
+        "additional_pages": meta["additional_pages"],
+        "api_errors": meta["failed_attempts"],
+    }
+
+
+def _divide(
+    value: int, denominator: float | int | None
+) -> float | None:
+    if denominator is None or denominator <= 0:
+        return None
+    return value / denominator
+
+
+def _normalise(
+    report: dict[str, Any],
+    evidence: dict[str, Any],
+    totals: dict[str, int],
+) -> dict[str, dict[str, float | None]]:
+    population = evidence["population"]
+    duration_hours = report["_meta"]["effective_window_seconds"] / 3600
+    repository_count = population["repository_count"]
+    repo_hours = (
+        repository_count * duration_hours
+        if repository_count is not None
+        else None
+    )
+    denominators = {
+        "per_repo_hour": repo_hours,
+        "per_pulse_cycle": population["pulse_cycles"],
+        "per_unchanged_cycle": population["unchanged_cycles"],
+        "per_actionable_change": population["actionable_changes"],
+        "per_unique_head_sha": population["unique_actionable_head_shas"],
+    }
+    return {
+        name: {
+            metric: _divide(totals[metric], denominator)
+            for metric in TRANSPORT_METRICS
+        }
+        for name, denominator in denominators.items()
+    }
+
+
+def build_transport_metrics(
+    report: dict[str, Any], evidence: dict[str, Any]
+) -> tuple[dict[str, int], dict[str, dict[str, float | None]]]:
+    totals = _transport_totals(report)
+    return totals, _normalise(report, evidence, totals)

--- a/.agents/scripts/github_api_efficiency_report.py
+++ b/.agents/scripts/github_api_efficiency_report.py
@@ -18,7 +18,7 @@ from github_api_efficiency_metrics import TRANSPORT_METRICS
 
 
 BENCHMARK_SCHEMA = "aidevops-github-api-efficiency-benchmark/v1"
-STATUS_PASS = "PASS"
+STATUS_OK = "PASS"
 STATUS_REGRESSION = "REGRESSION"
 STATUS_INCONCLUSIVE = "INCONCLUSIVE"
 EXIT_REGRESSION = 1
@@ -438,7 +438,7 @@ def build_result(
     status = STATUS_INCONCLUSIVE
     if not reasons:
         reasons = _regression_reasons(baseline, canary, thresholds)
-        status = STATUS_REGRESSION if reasons else STATUS_PASS
+        status = STATUS_REGRESSION if reasons else STATUS_OK
     return {
         "schema": BENCHMARK_SCHEMA,
         "status": status,

--- a/.agents/scripts/github_api_efficiency_report.py
+++ b/.agents/scripts/github_api_efficiency_report.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Decision and rendering layer for GitHub API efficiency evidence."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from github_api_efficiency_inputs import (
+    EVIDENCE_GROUPS,
+    POPULATION_FIELDS,
+    Window,
+)
+from github_api_efficiency_metrics import TRANSPORT_METRICS
+
+
+BENCHMARK_SCHEMA = "aidevops-github-api-efficiency-benchmark/v1"
+STATUS_PASS = "PASS"
+STATUS_REGRESSION = "REGRESSION"
+STATUS_INCONCLUSIVE = "INCONCLUSIVE"
+EXIT_REGRESSION = 1
+EXIT_INCONCLUSIVE = 2
+
+_DENOMINATOR_LABELS = {
+    "per_repo_hour": "Per repository-hour",
+    "per_pulse_cycle": "Per Pulse cycle",
+    "per_unchanged_cycle": "Per unchanged cycle",
+    "per_actionable_change": "Per actionable change",
+    "per_unique_head_sha": "Per unique actionable head SHA",
+}
+
+
+@dataclass(frozen=True)
+class Thresholds:
+    max_window_ratio: float
+    max_cycle_rate_change_pct: float
+    min_attempt_reduction_pct: float
+    max_graphql_point_increase_pct: float
+    max_error_rate_increase_points: float
+    max_latency_increase_pct: float
+    max_burst_increase_pct: float
+    canary_not_before: int
+
+
+def _flag(reasons: list[str], condition: bool, message: str) -> None:
+    if condition:
+        reasons.append(message)
+
+
+def _unknown_evidence(window: Window) -> list[str]:
+    reasons: list[str] = []
+    population = window.evidence["population"]
+    for field in POPULATION_FIELDS:
+        _flag(
+            reasons,
+            population[field] is None,
+            f"{window.label}: population.{field} is unknown",
+        )
+    _flag(
+        reasons,
+        population["repository_set_sha256"] is None,
+        f"{window.label}: repository population fingerprint is unknown",
+    )
+    for group_name, fields in EVIDENCE_GROUPS.items():
+        for field in fields:
+            _flag(
+                reasons,
+                window.evidence[group_name][field] is None,
+                f"{window.label}: {group_name}.{field} is unknown",
+            )
+    return reasons
+
+
+def _window_inconclusive_reasons(window: Window) -> list[str]:
+    meta = window.report["_meta"]
+    population = window.evidence["population"]
+    reasons = _unknown_evidence(window)
+    _flag(
+        reasons,
+        not window.evidence["complete"],
+        f"{window.label}: evidence is marked incomplete",
+    )
+    _flag(
+        reasons,
+        not meta["attempts_exact"],
+        f"{window.label}: transport attempts are not exact",
+    )
+    health_fields = {
+        "unknown_quota_cost_attempts": "quota cost is unknown",
+        "duplicate_attempt_ids": "duplicate attempt IDs exist",
+        "unidentified_attempts": "unidentified attempts exist",
+        "unknown_page_attempts": "unknown page attempts exist",
+        "window_malformed_v2_records": "malformed v2 records exist",
+        "legacy_events": "legacy events exist",
+        "opaque_paginated_attempts": "opaque pagination attempts exist",
+    }
+    for field, message in health_fields.items():
+        _flag(reasons, meta[field] > 0, f"{window.label}: {message}")
+    _flag(
+        reasons,
+        meta["attempted_requests"] == 0,
+        f"{window.label}: no transport attempts were observed",
+    )
+    _flag(
+        reasons,
+        window.totals["other_attempts"] > 0,
+        f"{window.label}: unclassified transport attempts exist",
+    )
+    _flag(
+        reasons,
+        population["repository_count"] == 0,
+        f"{window.label}: repository population is empty",
+    )
+    _flag(
+        reasons,
+        population["pulse_cycles"] == 0,
+        f"{window.label}: no Pulse cycles were observed",
+    )
+    return reasons
+
+
+def _pct_change(
+    baseline: float | int | None, canary: float | int | None
+) -> float | None:
+    if baseline is None or canary is None:
+        return None
+    if baseline == 0:
+        return 0.0 if canary == 0 else None
+    return round(((canary - baseline) / baseline) * 100, 6)
+
+
+def _growth_exceeds(
+    baseline: float, canary: float, maximum_pct: float
+) -> bool:
+    if baseline == 0:
+        return canary > 0
+    return ((canary - baseline) / baseline) * 100 > maximum_pct
+
+
+def _empty_comparability() -> dict[str, Any]:
+    return {
+        "duration_ratio": None,
+        "pulse_cycle_rate_change_pct": None,
+        "population_rate_change_pct": {
+            "unchanged_cycles": None,
+            "actionable_changes": None,
+            "unique_actionable_head_shas": None,
+        },
+        "repository_population_match": False,
+        "workload_rates_equivalent": False,
+        "windows_do_not_overlap": False,
+    }
+
+
+def _comparability(
+    baseline: Window, canary: Window, thresholds: Thresholds
+) -> tuple[dict[str, Any], list[str]]:
+    base_meta = baseline.report["_meta"]
+    canary_meta = canary.report["_meta"]
+    base_population = baseline.evidence["population"]
+    canary_population = canary.evidence["population"]
+    durations = (
+        base_meta["effective_window_seconds"],
+        canary_meta["effective_window_seconds"],
+    )
+    duration_ratio = max(durations) / min(durations)
+    base_cycle_rate = base_population["pulse_cycles"] / (durations[0] / 3600)
+    canary_cycle_rate = canary_population["pulse_cycles"] / (durations[1] / 3600)
+    cycle_rate_change_pct = _pct_change(base_cycle_rate, canary_cycle_rate)
+    workload_fields = (
+        "unchanged_cycles",
+        "actionable_changes",
+        "unique_actionable_head_shas",
+    )
+    population_rate_changes = {
+        field: _pct_change(
+            base_population[field] / (durations[0] / 3600),
+            canary_population[field] / (durations[1] / 3600),
+        )
+        for field in workload_fields
+    }
+    reasons: list[str] = []
+    _flag(
+        reasons,
+        base_population["repository_count"]
+        != canary_population["repository_count"],
+        "repository population counts differ",
+    )
+    _flag(
+        reasons,
+        base_population["repository_set_sha256"]
+        != canary_population["repository_set_sha256"],
+        "repository population fingerprints differ",
+    )
+    _flag(
+        reasons,
+        duration_ratio > thresholds.max_window_ratio,
+        "effective retained windows are materially unequal",
+    )
+    _flag(
+        reasons,
+        canary_meta["first_retained_ts"] <= base_meta["last_retained_ts"],
+        "baseline and canary retained windows overlap",
+    )
+    _flag(
+        reasons,
+        canary_meta["first_retained_ts"] < thresholds.canary_not_before,
+        "canary begins before the required rollout boundary",
+    )
+    cycle_rate_differs = (
+        cycle_rate_change_pct is None
+        or abs(cycle_rate_change_pct) > thresholds.max_cycle_rate_change_pct
+    )
+    _flag(
+        reasons,
+        cycle_rate_differs,
+        "Pulse cycle rates are materially non-equivalent",
+    )
+    for field, change_pct in population_rate_changes.items():
+        rate_differs = (
+            change_pct is None
+            or abs(change_pct) > thresholds.max_cycle_rate_change_pct
+        )
+        _flag(
+            reasons,
+            rate_differs,
+            f"{field} rates are materially non-equivalent",
+        )
+    details = {
+        "duration_ratio": round(duration_ratio, 6),
+        "pulse_cycle_rate_change_pct": cycle_rate_change_pct,
+        "population_rate_change_pct": population_rate_changes,
+        "repository_population_match": not any(
+            "repository population" in reason for reason in reasons
+        ),
+        "workload_rates_equivalent": not any(
+            "rates are materially non-equivalent" in reason for reason in reasons
+        ),
+        "windows_do_not_overlap": (
+            canary_meta["first_retained_ts"] > base_meta["last_retained_ts"]
+        ),
+    }
+    return details, reasons
+
+
+def _transport_regression_reasons(
+    baseline: Window, canary: Window, thresholds: Thresholds
+) -> list[str]:
+    reasons: list[str] = []
+    normalisations = (
+        ("per_repo_hour", "repository-hour"),
+        ("per_pulse_cycle", "Pulse cycle"),
+    )
+    for denominator, label in normalisations:
+        base_rate = baseline.normalized[denominator]
+        canary_rate = canary.normalized[denominator]
+        attempt_change = _pct_change(
+            base_rate["attempted_requests"], canary_rate["attempted_requests"]
+        )
+        attempt_reduction = -float(attempt_change or 0)
+        _flag(
+            reasons,
+            attempt_reduction < thresholds.min_attempt_reduction_pct,
+            f"attempt reduction per {label} is below the required minimum",
+        )
+        graphql_regressed = _growth_exceeds(
+            float(base_rate["graphql_points"]),
+            float(canary_rate["graphql_points"]),
+            thresholds.max_graphql_point_increase_pct,
+        )
+        _flag(
+            reasons,
+            graphql_regressed,
+            f"GraphQL points per {label} regressed",
+        )
+    base_error_rate = (
+        baseline.totals["api_errors"]
+        / baseline.totals["attempted_requests"]
+    )
+    canary_error_rate = (
+        canary.totals["api_errors"] / canary.totals["attempted_requests"]
+    )
+    _flag(
+        reasons,
+        (canary_error_rate - base_error_rate) * 100
+        > thresholds.max_error_rate_increase_points,
+        "API error rate regressed",
+    )
+    return reasons
+
+
+def _latency_regression_reasons(
+    baseline: Window, canary: Window, thresholds: Thresholds
+) -> list[str]:
+    reasons: list[str] = []
+    for field in ("p95_ms", "completed_action_p95_ms"):
+        regressed = _growth_exceeds(
+            baseline.evidence["latency"][field],
+            canary.evidence["latency"][field],
+            thresholds.max_latency_increase_pct,
+        )
+        _flag(reasons, regressed, f"{field} regressed")
+    burst_regressed = _growth_exceeds(
+        baseline.evidence["latency"]["peak_attempts_per_minute"],
+        canary.evidence["latency"]["peak_attempts_per_minute"],
+        thresholds.max_burst_increase_pct,
+    )
+    _flag(
+        reasons, burst_regressed, "peak short-window API burst regressed"
+    )
+    webhook_lag_regressed = _growth_exceeds(
+        baseline.evidence["webhook"]["lag_p95_ms"],
+        canary.evidence["webhook"]["lag_p95_ms"],
+        thresholds.max_latency_increase_pct,
+    )
+    _flag(
+        reasons, webhook_lag_regressed, "webhook invalidation lag regressed"
+    )
+    return reasons
+
+
+def _budget_regression_reasons(canary: Window) -> list[str]:
+    reasons: list[str] = []
+    violation_fields = (
+        ("guardrails", "stale_positive_decisions"),
+        ("guardrails", "dispatch_dependency_violations"),
+        ("guardrails", "required_check_merge_preflight_mismatches"),
+        ("path_budgets", "fingerprint_verification_list_calls"),
+        ("path_budgets", "fresh_empty_live_fallbacks"),
+        ("single_flight", "duplicate_leaders"),
+        ("webhook", "duplicate_actions"),
+        ("webhook", "missed_recoveries"),
+    )
+    for group, field in violation_fields:
+        _flag(
+            reasons,
+            canary.evidence[group][field] > 0,
+            f"canary {group}.{field} is non-zero",
+        )
+    check_fetches = canary.evidence["path_budgets"][
+        "aggregate_check_fetches"
+    ]
+    unique_heads = canary.evidence["population"][
+        "unique_actionable_head_shas"
+    ]
+    _flag(
+        reasons,
+        check_fetches > unique_heads,
+        "aggregate check fetches exceed unique actionable head SHAs",
+    )
+    return reasons
+
+
+def _regression_reasons(
+    baseline: Window, canary: Window, thresholds: Thresholds
+) -> list[str]:
+    return (
+        _transport_regression_reasons(baseline, canary, thresholds)
+        + _latency_regression_reasons(baseline, canary, thresholds)
+        + _budget_regression_reasons(canary)
+    )
+
+
+def _window_projection(window: Window) -> dict[str, Any]:
+    meta = window.report["_meta"]
+    return {
+        "label": window.label,
+        "transport_sha256": window.transport_sha256,
+        "evidence_sha256": window.evidence_sha256,
+        "first_retained_ts": meta["first_retained_ts"],
+        "last_retained_ts": meta["last_retained_ts"],
+        "effective_window_seconds": meta["effective_window_seconds"],
+        "population": window.evidence["population"],
+        "transport": window.totals,
+        "normalized": window.normalized,
+        **{group: window.evidence[group] for group in EVIDENCE_GROUPS},
+    }
+
+
+def _deltas(baseline: Window, canary: Window) -> dict[str, Any]:
+    base_repo_hour = baseline.normalized["per_repo_hour"]
+    canary_repo_hour = canary.normalized["per_repo_hour"]
+    repo_hour_change = {
+        metric: _pct_change(base_repo_hour[metric], canary_repo_hour[metric])
+        for metric in TRANSPORT_METRICS
+    }
+    base_cycle = baseline.normalized["per_pulse_cycle"]
+    canary_cycle = canary.normalized["per_pulse_cycle"]
+    cycle_change = {
+        metric: _pct_change(base_cycle[metric], canary_cycle[metric])
+        for metric in TRANSPORT_METRICS
+    }
+    return {
+        "per_repo_hour_change_pct": repo_hour_change,
+        "per_pulse_cycle_change_pct": cycle_change,
+        "attempt_reduction_pct": {
+            "per_repo_hour": _reduction(repo_hour_change["attempted_requests"]),
+            "per_pulse_cycle": _reduction(cycle_change["attempted_requests"]),
+        },
+        "p95_latency_change_pct": _pct_change(
+            baseline.evidence["latency"]["p95_ms"],
+            canary.evidence["latency"]["p95_ms"],
+        ),
+        "completed_action_latency_change_pct": _pct_change(
+            baseline.evidence["latency"]["completed_action_p95_ms"],
+            canary.evidence["latency"]["completed_action_p95_ms"],
+        ),
+        "peak_burst_change_pct": _pct_change(
+            baseline.evidence["latency"]["peak_attempts_per_minute"],
+            canary.evidence["latency"]["peak_attempts_per_minute"],
+        ),
+        "webhook_lag_p95_change_pct": _pct_change(
+            baseline.evidence["webhook"]["lag_p95_ms"],
+            canary.evidence["webhook"]["lag_p95_ms"],
+        ),
+    }
+
+
+def _reduction(change: float | None) -> float | None:
+    return None if change is None else round(-change, 6)
+
+
+def build_result(
+    baseline: Window, canary: Window, thresholds: Thresholds
+) -> dict[str, Any]:
+    reasons = _window_inconclusive_reasons(
+        baseline
+    ) + _window_inconclusive_reasons(canary)
+    comparability = _empty_comparability()
+    if not reasons:
+        comparability, comparability_reasons = _comparability(
+            baseline, canary, thresholds
+        )
+        reasons.extend(comparability_reasons)
+    status = STATUS_INCONCLUSIVE
+    if not reasons:
+        reasons = _regression_reasons(baseline, canary, thresholds)
+        status = STATUS_REGRESSION if reasons else STATUS_PASS
+    return {
+        "schema": BENCHMARK_SCHEMA,
+        "status": status,
+        "thresholds": asdict(thresholds),
+        "comparability": comparability,
+        "windows": {
+            "baseline": _window_projection(baseline),
+            "canary": _window_projection(canary),
+        },
+        "deltas": _deltas(baseline, canary),
+        "reasons": reasons,
+    }
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def _utc(timestamp: int) -> str:
+    return datetime.fromtimestamp(
+        timestamp, tz=timezone.utc
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _metric_table(
+    lines: list[str],
+    title: str,
+    baseline: dict[str, Any],
+    canary: dict[str, Any],
+) -> None:
+    lines.extend(
+        (
+            f"### {title}",
+            "",
+            "| Metric | Baseline | Canary |",
+            "|---|---:|---:|",
+        )
+    )
+    for metric in baseline:
+        lines.append(
+            f"| `{metric}` | {_fmt(baseline[metric])} | "
+            f"{_fmt(canary[metric])} |"
+        )
+    lines.append("")
+
+
+def _window_table(lines: list[str], result: dict[str, Any]) -> None:
+    lines.extend(
+        (
+            "## Retained windows",
+            "",
+            "| Window | Label | First attempt | Last attempt | "
+            "Effective seconds | Repositories | Pulse cycles |",
+            "|---|---|---|---|---:|---:|---:|",
+        )
+    )
+    for name in ("baseline", "canary"):
+        window = result["windows"][name]
+        label = window["label"].replace("|", "\\|")
+        lines.append(
+            f"| {name.title()} | {label} | "
+            f"{_utc(window['first_retained_ts'])} | "
+            f"{_utc(window['last_retained_ts'])} | "
+            f"{window['effective_window_seconds']} | "
+            f"{_fmt(window['population']['repository_count'])} | "
+            f"{_fmt(window['population']['pulse_cycles'])} |"
+        )
+    lines.append("")
+
+
+def render_markdown(result: dict[str, Any]) -> str:
+    baseline = result["windows"]["baseline"]
+    canary = result["windows"]["canary"]
+    lines = [
+        "# GitHub API Efficiency Benchmark",
+        "",
+        f"**Status:** `{result['status']}`",
+        "",
+    ]
+    _window_table(lines, result)
+    lines.extend(("## Transport totals", ""))
+    _metric_table(
+        lines, "Absolute", baseline["transport"], canary["transport"]
+    )
+    lines.extend(("## Normalized transport", ""))
+    for denominator, title in _DENOMINATOR_LABELS.items():
+        _metric_table(
+            lines,
+            title,
+            baseline["normalized"][denominator],
+            canary["normalized"][denominator],
+        )
+    lines.extend(("## Outcomes and guardrails", ""))
+    groups = (
+        "latency",
+        "cache",
+        "single_flight",
+        "webhook",
+        "guardrails",
+        "path_budgets",
+    )
+    for group in groups:
+        _metric_table(
+            lines,
+            group.replace("_", " ").title(),
+            baseline[group],
+            canary[group],
+        )
+    lines.extend(("## Decision", ""))
+    if result["reasons"]:
+        lines.extend(f"- {reason}" for reason in result["reasons"])
+    else:
+        lines.append(
+            "- Comparable evidence meets the savings, freshness, "
+            "correctness, latency, burst, and path-budget thresholds."
+        )
+    lines.append("")
+    return "\n".join(lines)

--- a/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
+++ b/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
@@ -1,0 +1,515 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Deterministic PASS/REGRESSION/INCONCLUSIVE coverage for GH#27777.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+readonly BENCHMARK="${SCRIPT_DIR}/../github-api-efficiency-benchmark.sh"
+readonly TEMP_BASE="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+LAST_EXIT=0
+LAST_OUTPUT=""
+LAST_JSON=""
+LAST_MARKDOWN=""
+
+cleanup() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+record_result() {
+	local label="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS: %s\n' "$label"
+		return 0
+	fi
+	printf 'FAIL: %s\n' "$label"
+	if [[ -n "$detail" ]]; then
+		printf '      %s\n' "$detail"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_eq() {
+	local label="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		record_result "$label" 0
+		return 0
+	fi
+	record_result "$label" 1 "expected=${expected}, actual=${actual}"
+	return 0
+}
+
+assert_jq() {
+	local label="$1"
+	local filter="$2"
+	local file="$3"
+	if [[ -f "$file" ]] && jq -e "$filter" "$file" >/dev/null 2>&1; then
+		record_result "$label" 0
+		return 0
+	fi
+	record_result "$label" 1 "jq assertion failed: ${filter}"
+	return 0
+}
+
+assert_contains() {
+	local label="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		record_result "$label" 0
+		return 0
+	fi
+	record_result "$label" 1 "missing text: ${needle}"
+	return 0
+}
+
+assert_missing() {
+	local label="$1"
+	local file="$2"
+	if [[ ! -e "$file" ]]; then
+		record_result "$label" 0
+		return 0
+	fi
+	record_result "$label" 1 "unexpected file: ${file}"
+	return 0
+}
+
+mkdir -p "$TEMP_BASE"
+TEST_ROOT=$(mktemp -d "${TEMP_BASE}/github-api-efficiency-test.XXXXXX")
+trap cleanup EXIT
+
+python3 - "$TEST_ROOT" <<'PY'
+import copy
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(sys.argv[1])
+EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v1"
+REPOSITORY_SET = "a" * 64
+
+
+def write_json(path, payload):
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def path_metrics(attempts, quota=0, unknown_quota=0):
+    return {
+        "attempted_requests": attempts,
+        "known_quota_cost": quota,
+        "unknown_quota_cost_attempts": unknown_quota,
+    }
+
+
+def transport(
+    first,
+    duration,
+    attempts,
+    graphql_attempts,
+    graphql_points,
+    rest_attempts,
+    search_attempts,
+    *,
+    errors,
+    retries,
+    additional_pages,
+    elapsed_ms,
+    unknown_quota=0,
+    other_attempts=0,
+    schema=2,
+):
+    assert (
+        graphql_attempts + rest_attempts + search_attempts + other_attempts
+        == attempts
+    )
+    return {
+        "_meta": {
+            "schema_version": schema,
+            "first_retained_ts": first,
+            "last_retained_ts": first + duration,
+            "effective_window_seconds": duration,
+            "attempted_requests": attempts,
+            "retries": retries,
+            "pages": attempts,
+            "additional_pages": additional_pages,
+            "successful_attempts": attempts - errors,
+            "failed_attempts": errors,
+            "elapsed_ms": elapsed_ms,
+            "known_quota_cost": graphql_points,
+            "unknown_quota_cost_attempts": unknown_quota,
+            "duplicate_attempt_ids": 0,
+            "unidentified_attempts": 0,
+            "unknown_page_attempts": 0,
+            "window_malformed_v2_records": 0,
+            "legacy_events": 0,
+            "opaque_paginated_attempts": 0,
+            "attempts_exact": True,
+        },
+        "by_path": {
+            "graphql": path_metrics(graphql_attempts, graphql_points),
+            "rest": path_metrics(rest_attempts, 0, unknown_quota),
+            "search-rest": path_metrics(search_attempts),
+            "other": path_metrics(other_attempts),
+        },
+    }
+
+
+def evidence(*, p50, p95, burst, completed_p95, webhook_p95, complete=True):
+    return {
+        "schema": EVIDENCE_SCHEMA,
+        "transport_sha256": "",
+        "complete": complete,
+        "population": {
+            "repository_count": 10,
+            "pulse_cycles": 100,
+            "unchanged_cycles": 80,
+            "actionable_changes": 20,
+            "unique_actionable_head_shas": 20,
+            "repository_set_sha256": REPOSITORY_SET,
+        },
+        "latency": {
+            "p50_ms": p50,
+            "p95_ms": p95,
+            "peak_attempts_per_minute": burst,
+            "completed_action_p95_ms": completed_p95,
+        },
+        "cache": {
+            "fresh_hits": 80,
+            "fresh_empty_hits": 20,
+            "misses": 10,
+            "stale": 2,
+            "invalidated": 5,
+        },
+        "single_flight": {
+            "leaders": 30,
+            "waits": 10,
+            "takeovers": 1,
+            "duplicate_leaders": 0,
+        },
+        "webhook": {
+            "invalidations": 10,
+            "lag_p50_ms": 100,
+            "lag_p95_ms": webhook_p95,
+            "duplicate_actions": 0,
+            "missed_recoveries": 0,
+        },
+        "guardrails": {
+            "stale_snapshot_detections": 1,
+            "forced_live_refreshes": 1,
+            "stale_positive_decisions": 0,
+            "dispatch_dependency_violations": 0,
+            "required_check_merge_preflight_mismatches": 0,
+        },
+        "path_budgets": {
+            "fingerprint_verification_list_calls": 0,
+            "fresh_empty_live_fallbacks": 0,
+            "aggregate_check_fetches": 20,
+        },
+    }
+
+
+BASELINE_REPORT = transport(
+    1_000,
+    43_200,
+    1_000,
+    200,
+    200,
+    700,
+    100,
+    errors=10,
+    retries=20,
+    additional_pages=50,
+    elapsed_ms=500_000,
+)
+BASELINE_EVIDENCE = evidence(
+    p50=100, p95=500, burst=50, completed_p95=1_000, webhook_p95=400
+)
+PASS_REPORT = transport(
+    50_000,
+    43_200,
+    800,
+    160,
+    180,
+    560,
+    80,
+    errors=5,
+    retries=8,
+    additional_pages=25,
+    elapsed_ms=360_000,
+)
+PASS_EVIDENCE = evidence(
+    p50=90, p95=450, burst=45, completed_p95=900, webhook_p95=350
+)
+
+
+def write_case(name, canary_report, canary_evidence):
+    baseline_report_path = ROOT / f"{name}-baseline-report.json"
+    baseline_evidence_path = ROOT / f"{name}-baseline-evidence.json"
+    canary_report_path = ROOT / f"{name}-canary-report.json"
+    canary_evidence_path = ROOT / f"{name}-canary-evidence.json"
+
+    write_json(baseline_report_path, BASELINE_REPORT)
+    baseline_sidecar = copy.deepcopy(BASELINE_EVIDENCE)
+    baseline_sidecar["transport_sha256"] = hashlib.sha256(
+        baseline_report_path.read_bytes()
+    ).hexdigest()
+    write_json(baseline_evidence_path, baseline_sidecar)
+
+    write_json(canary_report_path, canary_report)
+    canary_sidecar = copy.deepcopy(canary_evidence)
+    canary_sidecar["transport_sha256"] = hashlib.sha256(
+        canary_report_path.read_bytes()
+    ).hexdigest()
+    write_json(canary_evidence_path, canary_sidecar)
+
+
+write_case("pass", PASS_REPORT, PASS_EVIDENCE)
+
+regression_report = transport(
+    50_000,
+    43_200,
+    1_200,
+    260,
+    260,
+    820,
+    120,
+    errors=30,
+    retries=40,
+    additional_pages=80,
+    elapsed_ms=900_000,
+)
+regression_evidence = evidence(
+    p50=150, p95=700, burst=70, completed_p95=1_400, webhook_p95=700
+)
+regression_evidence["single_flight"]["duplicate_leaders"] = 1
+regression_evidence["webhook"]["duplicate_actions"] = 1
+regression_evidence["path_budgets"]["fingerprint_verification_list_calls"] = 1
+write_case("regression", regression_report, regression_evidence)
+
+incomplete_evidence = copy.deepcopy(PASS_EVIDENCE)
+incomplete_evidence["complete"] = False
+incomplete_evidence["latency"]["p95_ms"] = None
+write_case("incomplete", PASS_REPORT, incomplete_evidence)
+
+unequal_report = transport(
+    50_000,
+    10_000,
+    800,
+    160,
+    180,
+    560,
+    80,
+    errors=5,
+    retries=8,
+    additional_pages=25,
+    elapsed_ms=360_000,
+)
+write_case("unequal", unequal_report, PASS_EVIDENCE)
+
+workload_evidence = copy.deepcopy(PASS_EVIDENCE)
+workload_evidence["population"]["unchanged_cycles"] = 100
+workload_evidence["population"]["actionable_changes"] = 0
+workload_evidence["population"]["unique_actionable_head_shas"] = 0
+write_case("workload", PASS_REPORT, workload_evidence)
+
+invalid_population_evidence = copy.deepcopy(PASS_EVIDENCE)
+invalid_population_evidence["population"]["unchanged_cycles"] = 101
+write_case("population-invalid", PASS_REPORT, invalid_population_evidence)
+
+unknown_quota_report = transport(
+    50_000,
+    43_200,
+    800,
+    160,
+    180,
+    560,
+    80,
+    errors=5,
+    retries=8,
+    additional_pages=25,
+    elapsed_ms=360_000,
+    unknown_quota=1,
+)
+write_case("unknown-quota", unknown_quota_report, PASS_EVIDENCE)
+
+incompatible_report = copy.deepcopy(PASS_REPORT)
+incompatible_report["_meta"]["schema_version"] = 1
+write_case("incompatible", incompatible_report, PASS_EVIDENCE)
+
+counter_mismatch_report = copy.deepcopy(PASS_REPORT)
+counter_mismatch_report["_meta"]["successful_attempts"] = 800
+write_case("counter-mismatch", counter_mismatch_report, PASS_EVIDENCE)
+
+unclassified_report = transport(
+    50_000,
+    43_200,
+    800,
+    160,
+    180,
+    559,
+    80,
+    errors=5,
+    retries=8,
+    additional_pages=25,
+    elapsed_ms=360_000,
+    other_attempts=1,
+)
+write_case("unclassified", unclassified_report, PASS_EVIDENCE)
+
+write_case("digest", PASS_REPORT, PASS_EVIDENCE)
+digest_path = ROOT / "digest-canary-evidence.json"
+digest_payload = json.loads(digest_path.read_text(encoding="utf-8"))
+digest_payload["transport_sha256"] = "0" * 64
+write_json(digest_path, digest_payload)
+PY
+
+run_case() {
+	local scenario="$1"
+	local canary_not_before="${2:-45000}"
+	LAST_JSON="${TEST_ROOT}/${scenario}-result.json"
+	LAST_MARKDOWN="${TEST_ROOT}/${scenario}-result.md"
+	rm -f "$LAST_JSON" "$LAST_MARKDOWN"
+	set +e
+	LAST_OUTPUT=$(
+		"$BENCHMARK" compare \
+			--baseline-report "${TEST_ROOT}/${scenario}-baseline-report.json" \
+			--baseline-evidence "${TEST_ROOT}/${scenario}-baseline-evidence.json" \
+			--baseline-label "baseline-${scenario}" \
+			--canary-report "${TEST_ROOT}/${scenario}-canary-report.json" \
+			--canary-evidence "${TEST_ROOT}/${scenario}-canary-evidence.json" \
+			--canary-label "canary-${scenario}" \
+			--canary-not-before "$canary_not_before" \
+			--json-out "$LAST_JSON" \
+			--markdown-out "$LAST_MARKDOWN" 2>&1
+	)
+	LAST_EXIT=$?
+	set -e
+	return 0
+}
+
+test_pass_and_determinism() {
+	run_case pass
+	assert_eq "comparable fixture exits zero" "0" "$LAST_EXIT"
+	assert_jq "comparable fixture reports PASS" \
+		'.schema == "aidevops-github-api-efficiency-benchmark/v1" and .status == "PASS" and .reasons == []' "$LAST_JSON"
+	assert_jq "PASS reports normalized attempt savings" \
+		'.deltas.attempt_reduction_pct.per_repo_hour == 20 and .deltas.attempt_reduction_pct.per_pulse_cycle == 20' "$LAST_JSON"
+	assert_jq "PASS records both evidence digests" \
+		'(.windows.baseline.evidence_sha256 | length) == 64 and (.windows.canary.evidence_sha256 | length) == 64' "$LAST_JSON"
+	local markdown=""
+	markdown=$(<"$LAST_MARKDOWN")
+	assert_contains "Markdown reports PASS" "**Status:** \`PASS\`" "$markdown"
+
+	local first_json="${TEST_ROOT}/pass-first.json"
+	local first_markdown="${TEST_ROOT}/pass-first.md"
+	cp "$LAST_JSON" "$first_json"
+	cp "$LAST_MARKDOWN" "$first_markdown"
+	run_case pass
+	if cmp -s "$first_json" "$LAST_JSON" && cmp -s "$first_markdown" "$LAST_MARKDOWN"; then
+		record_result "identical inputs produce byte-stable reports" 0
+	else
+		record_result "identical inputs produce byte-stable reports" 1
+	fi
+	return 0
+}
+
+test_regression() {
+	run_case regression
+	assert_eq "regression exits one" "1" "$LAST_EXIT"
+	assert_jq "regression fixture reports REGRESSION" \
+		'.status == "REGRESSION" and (.reasons | length) >= 5' "$LAST_JSON"
+	assert_jq "path budget breach is explicit" \
+		'.reasons | any(contains("fingerprint_verification_list_calls"))' "$LAST_JSON"
+	return 0
+}
+
+test_inconclusive_windows() {
+	run_case incomplete
+	assert_eq "incomplete evidence exits two" "2" "$LAST_EXIT"
+	assert_jq "incomplete evidence is INCONCLUSIVE" \
+		'.status == "INCONCLUSIVE" and (.reasons | any(contains("marked incomplete"))) and (.reasons | any(contains("latency.p95_ms is unknown")))' "$LAST_JSON"
+
+	run_case unequal
+	assert_eq "unequal retained windows exit two" "2" "$LAST_EXIT"
+	assert_jq "unequal retained windows are INCONCLUSIVE" \
+		'.status == "INCONCLUSIVE" and (.reasons | any(contains("materially unequal")))' "$LAST_JSON"
+
+	run_case workload
+	assert_eq "non-equivalent workload exits two" "2" "$LAST_EXIT"
+	assert_jq "workload mix is part of comparability" \
+		'.status == "INCONCLUSIVE" and (.comparability.workload_rates_equivalent == false) and (.reasons | any(contains("actionable_changes rates")))' "$LAST_JSON"
+
+	run_case pass 60000
+	assert_eq "pre-rollout canary exits two" "2" "$LAST_EXIT"
+	assert_jq "rollout boundary is enforced" \
+		'.status == "INCONCLUSIVE" and (.reasons | any(contains("before the required rollout boundary")))' "$LAST_JSON"
+	return 0
+}
+
+test_fail_closed_transport() {
+	run_case unknown-quota
+	assert_eq "unknown quota evidence exits two" "2" "$LAST_EXIT"
+	assert_jq "unknown quota evidence cannot pass" \
+		'.status == "INCONCLUSIVE" and (.reasons | any(contains("quota cost is unknown")))' "$LAST_JSON"
+
+	run_case unclassified
+	assert_eq "unclassified transport exits two" "2" "$LAST_EXIT"
+	assert_jq "unclassified transport cannot pass" \
+		'.status == "INCONCLUSIVE" and (.reasons | any(contains("unclassified transport attempts")))' "$LAST_JSON"
+
+	run_case incompatible
+	assert_eq "incompatible schema exits two" "2" "$LAST_EXIT"
+	assert_contains "incompatible schema explains rejection" "schema_version must be 2" "$LAST_OUTPUT"
+	assert_missing "incompatible schema writes no JSON" "$LAST_JSON"
+
+	run_case counter-mismatch
+	assert_eq "inconsistent counters exit two" "2" "$LAST_EXIT"
+	assert_contains "inconsistent counters explain rejection" "do not reconcile" "$LAST_OUTPUT"
+	assert_missing "inconsistent counters write no JSON" "$LAST_JSON"
+
+	run_case population-invalid
+	assert_eq "inconsistent population exits two" "2" "$LAST_EXIT"
+	assert_contains "inconsistent population explains rejection" "exceed Pulse cycles" "$LAST_OUTPUT"
+	assert_missing "inconsistent population writes no JSON" "$LAST_JSON"
+
+	run_case digest
+	assert_eq "mismatched evidence digest exits two" "2" "$LAST_EXIT"
+	assert_contains "digest mismatch explains rejection" "does not match" "$LAST_OUTPUT"
+	assert_missing "digest mismatch writes no JSON" "$LAST_JSON"
+	return 0
+}
+
+main() {
+	test_pass_and_determinism
+	test_regression
+	test_inconclusive_windows
+	test_fail_closed_transport
+
+	printf '\nTests run: %d\n' "$TESTS_RUN"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		printf 'Tests failed: %d\n' "$TESTS_FAILED"
+		return 1
+	fi
+	printf 'All tests passed\n'
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
+++ b/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 readonly BENCHMARK="${SCRIPT_DIR}/../github-api-efficiency-benchmark.sh"
-readonly TEMP_BASE="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+readonly TEMP_BASE="${AIDEVOPS_TEMP_DIR:-${HOME:+$HOME/.aidevops/.agent-workspace/tmp}}"
 
 TEST_ROOT=""
 TESTS_RUN=0


### PR DESCRIPTION
## Summary

Add a deterministic, fail-closed comparator for immutable GitHub API transport aggregates and SHA-256-bound evidence sidecars. It emits byte-stable JSON and Markdown decisions across comparable retained windows.

The implementation includes:

- strict schema, digest, counter, population, and retained-window validation;
- absolute and normalized transport, workload, latency, cache, single-flight, webhook, guardrail, and path-budget reporting;
- explicit `PASS`, `REGRESSION`, and `INCONCLUSIVE` outcomes;
- deterministic fixtures plus an operator contract with retained controls and rollback triggers.

## Evidence status

Current retained aggregates have unknown quota costs, and the available later window begins before t18130 merged. This infrastructure PR therefore changes no rollout default, config value, or rollback flag. #27777 stays open until a new exact baseline and complete 12–24 hour post-rollout canary are comparable.

## Files changed

- `.agents/scripts/github-api-efficiency-benchmark.sh`
- `.agents/scripts/github-api-efficiency-benchmark.py`
- `.agents/scripts/github_api_efficiency_inputs.py`
- `.agents/scripts/github_api_efficiency_metrics.py`
- `.agents/scripts/github_api_efficiency_report.py`
- `.agents/scripts/tests/test-github-api-efficiency-benchmark.sh`
- `.agents/reference/github-api-efficiency.md`

## Verification

- 33 deterministic fixture assertions
- ShellCheck and Bash syntax
- Python compilation
- Radon complexity at or below `B (8)`
- Qlty zero-smell scan
- `.agents/scripts/linters-local.sh --changed`

For #27777

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 1d 12h and 10,737,870 tokens on this with the user in an interactive session.
