### PR TITLE
GH#28245: fix ruleset approvals during GraphQL exhaustion

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -804,17 +804,29 @@ _check_ruleset_required_reviews_passing() {
 	[[ "$required_count" =~ ^[0-9]+$ ]] || required_count=0
 	[[ "$required_count" -eq 0 ]] && return 0
 
-	local reviews_json="" approved_count=""
-	reviews_json=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json reviews 2>/dev/null) || reviews_json=""
-	if [[ -z "$reviews_json" || "$reviews_json" == null ]]; then
+	local reviews_pages="" approved_count="" empty_string=""
+	reviews_pages=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}/reviews?per_page=100" --paginate --slurp 2>/dev/null) || reviews_pages=""
+	if [[ -z "$reviews_pages" || "$reviews_pages" == null ]]; then
 		echo "[pulse-merge] _check_ruleset_required_reviews_passing: review fetch failed for PR #${pr_number} in ${repo_slug} with ruleset requiring ${required_count} approval(s) — failing closed (GH#24577)" >>"$LOGFILE"
 		return 1
 	fi
-	approved_count=$(jq -r --arg author "$pr_author" '
-		[.reviews[]?] | sort_by(.submittedAt // "") | group_by(.author.login // "")
-		| map(last) | map(select((.author.login // "") != $author))
-		| map(select((.state // "" | ascii_upcase) == "APPROVED")) | length
-	' <<<"$reviews_json" 2>/dev/null) || approved_count=""
+	approved_count=$(jq -er --arg author "$pr_author" --arg empty "$empty_string" --arg array_type "$PMRC_JSON_ARRAY" '
+		if type != $array_type or any(.[]; type != $array_type) then
+			error("invalid paginated reviews response")
+		else
+			[.[][]? | {
+				login: (.user.login // $empty),
+				state: (.state // $empty),
+				submitted_at: (.submitted_at // $empty),
+				id: (.id // 0)
+			} | select(.login != $empty)]
+			| group_by(.login)
+			| map(max_by([.submitted_at, .id]))
+			| map(select(.login != $author))
+			| map(select((.state | ascii_upcase) == "APPROVED"))
+			| length
+		end
+	' <<<"$reviews_pages" 2>/dev/null) || approved_count=""
 	if [[ ! "$approved_count" =~ ^[0-9]+$ ]]; then
 		echo "[pulse-merge] _check_ruleset_required_reviews_passing: review parse failed for PR #${pr_number} in ${repo_slug} — failing closed (GH#24577)" >>"$LOGFILE"
 		return 1

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -811,7 +811,7 @@ _check_ruleset_required_reviews_passing() {
 		return 1
 	fi
 	approved_count=$(jq -er --arg author "$pr_author" --arg empty "$empty_string" --arg array_type "$PMRC_JSON_ARRAY" '
-		if type != $array_type or any(.[]; type != $array_type) then
+		if type != $array_type or any(.[]; type != $array_type) or any(.[][]?; type != "object") then
 			error("invalid paginated reviews response")
 		else
 			[.[][]? | {

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -435,6 +435,27 @@ _rest_pr_view_can_preserve_args() {
 }
 
 #######################################
+# Return 0 when a failed GraphQL PR view can fall back without fabricating
+# collection fields that the single-PR REST endpoint does not provide. Explicit
+# scalar unknowns (for example reviewDecision: null) remain safe for emergency
+# fallback because callers already distinguish unknown from authoritative data.
+# Args: gh-style argv
+#######################################
+_rest_pr_view_can_emergency_fallback_args() {
+	local fields
+	fields="$(_rest_args_json_fields "$@")"
+	[[ -z "$fields" ]] && return 0
+	local field
+	while IFS= read -r field; do
+		case "$field" in
+		statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files) return 1 ;;
+		*) ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	return 0
+}
+
+#######################################
 # Internal: If first arg looks like a GitHub issue URL, extract the repo slug
 # and issue number. Returns via stdout on two lines (repo, then num) so we
 # stay bash 3.2-compatible (nameref `local -n` is bash 4.3+).

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -675,7 +675,7 @@ gh_pr_view() {
 	gh_record_call graphql gh_pr_view 2>/dev/null || true
 	_out=$(_gh_with_timeout read gh pr view "$@")
 	local rc=$?
-	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
+	if [[ $rc -ne 0 ]] && _rest_pr_view_can_emergency_fallback_args "$@" && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr view #${_first_num}"
 		_out=$(_rest_pr_view "$@")
 		rc=$?

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -1435,6 +1435,26 @@ else
 		"preserve_ok=${unsupported_preserve_ok} rest_calls=${unsupported_rest_calls} graphql_calls=${unsupported_graphql_calls} GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+export STUB_PRIMARY_FAIL=1
+export AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1
+unsupported_fallback_output=""
+unsupported_fallback_rc=0
+unsupported_fallback_output=$(gh_pr_view 123 --repo "owner/repo" --json reviews 2>/dev/null) || unsupported_fallback_rc=$?
+unset STUB_PRIMARY_FAIL AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE
+export STUB_RATE_LIMIT_REMAINING=5000
+
+unsupported_fallback_rest_calls=$(grep -cE '^api /repos/owner/repo/pulls/123$' "$GH_CALLS" 2>/dev/null || true)
+unsupported_fallback_graphql_calls=$(grep -cE '^pr view 123 --repo owner/repo --json reviews$' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$unsupported_fallback_rc" -ne 0 && -z "$unsupported_fallback_output" && "$unsupported_fallback_rest_calls" == "0" && "$unsupported_fallback_graphql_calls" == "1" ]]; then
+	pass "gh_pr_view exhaustion preserves failure for GraphQL-only fields"
+else
+	fail "gh_pr_view exhaustion preserves failure for GraphQL-only fields" \
+		"rc=${unsupported_fallback_rc} output=${unsupported_fallback_output} rest_calls=${unsupported_fallback_rest_calls} graphql_calls=${unsupported_fallback_graphql_calls} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
 if grep -q 'stable-within-cycle' "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" 2>/dev/null &&
 	grep -q 'fields like mergeable' "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" 2>/dev/null &&
 	grep -q 'GraphQL-only fields' "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" 2>/dev/null; then

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -83,6 +83,7 @@ print_result() {
 #   ruleset_review_paginated_approved — later REST page restores approval
 #   ruleset_review_author_only — only the PR author approved
 #   ruleset_review_malformed_response — REST reviews payload is not page arrays
+#   ruleset_review_malformed_element — a REST reviews page contains a non-object
 #   ruleset_review_fetch_error — REST reviews endpoint fails
 #   error           — branch-protection API exits non-zero
 setup_test_env() {
@@ -124,7 +125,7 @@ apply_jq() {
 
 if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets/"* ]]; then
 	case "${MOCK_GH_MODE:-all_pass}" in
-	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_fetch_error)
+	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_malformed_element | ruleset_review_fetch_error)
 		apply_jq '{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"pull_request","parameters":{"required_approving_review_count":1}}]}' "$@"
 		;;
 	ruleset_mixed_review_status)
@@ -145,7 +146,7 @@ fi
 
 if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets"* ]]; then
 	case "${MOCK_GH_MODE:-all_pass}" in
-	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_mixed_review_status | ruleset_review_zero | ruleset_review_malformed_optional | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_fetch_error)
+	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_mixed_review_status | ruleset_review_zero | ruleset_review_malformed_optional | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_malformed_element | ruleset_review_fetch_error)
 		apply_jq '[{"id":101,"enforcement":"active"}]' "$@"
 		;;
 	*)
@@ -171,6 +172,9 @@ if [[ "$1" == "api" && "$2" == repos/*/pulls/*/reviews* ]]; then
 		;;
 	ruleset_review_malformed_response)
 		printf '%s\n' '{"reviews":[]}'
+		;;
+	ruleset_review_malformed_element)
+		printf '%s\n' '[[{"id":1,"state":"APPROVED","submitted_at":"2026-06-01T00:00:00Z","user":{"login":"reviewer"}},null]]'
 		;;
 	ruleset_review_fetch_error)
 		printf 'gh: mock reviews endpoint error\n' >&2
@@ -775,6 +779,16 @@ test_ruleset_malformed_reviews_fail_closed() {
 	return 0
 }
 
+test_ruleset_malformed_review_element_fails_closed() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_malformed_element"
+	assert_ruleset_review_gate_returns 1 "non-object REST review element fails closed"
+	assert_log_contains "review parse failed" \
+		"non-object REST review element: parse failure logged"
+	return 0
+}
+
 test_ruleset_review_fetch_error_fails_closed() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
@@ -857,6 +871,7 @@ main() {
 	test_ruleset_paginated_latest_approval_allows_merge
 	test_ruleset_author_approval_does_not_count
 	test_ruleset_malformed_reviews_fail_closed
+	test_ruleset_malformed_review_element_fails_closed
 	test_ruleset_review_fetch_error_fails_closed
 	test_ruleset_mixed_review_status_preserves_both_gates
 	test_ruleset_review_zero_does_not_require_approval

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -79,6 +79,11 @@ print_result() {
 #      status, and the current head's maintainer-gate CheckRun is successful
 #   pr_checks_empty_failure — PR-level required checks exits non-zero with no JSON
 #   ruleset_review_malformed_optional — ruleset detail has unexpected shapes
+#   ruleset_review_latest_changes_requested — latest review revokes approval
+#   ruleset_review_paginated_approved — later REST page restores approval
+#   ruleset_review_author_only — only the PR author approved
+#   ruleset_review_malformed_response — REST reviews payload is not page arrays
+#   ruleset_review_fetch_error — REST reviews endpoint fails
 #   error           — branch-protection API exits non-zero
 setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
@@ -119,7 +124,7 @@ apply_jq() {
 
 if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets/"* ]]; then
 	case "${MOCK_GH_MODE:-all_pass}" in
-	ruleset_review_only_missing | ruleset_review_only_approved)
+	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_fetch_error)
 		apply_jq '{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"pull_request","parameters":{"required_approving_review_count":1}}]}' "$@"
 		;;
 	ruleset_mixed_review_status)
@@ -140,11 +145,39 @@ fi
 
 if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets"* ]]; then
 	case "${MOCK_GH_MODE:-all_pass}" in
-	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_mixed_review_status | ruleset_review_zero | ruleset_review_malformed_optional)
+	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_mixed_review_status | ruleset_review_zero | ruleset_review_malformed_optional | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_fetch_error)
 		apply_jq '[{"id":101,"enforcement":"active"}]' "$@"
 		;;
 	*)
 		apply_jq '[]' "$@"
+		;;
+	esac
+	exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == repos/*/pulls/*/reviews* ]]; then
+	case "${MOCK_GH_MODE:-all_pass}" in
+	ruleset_review_only_approved | ruleset_mixed_review_status)
+		printf '%s\n' '[[{"id":1,"state":"APPROVED","submitted_at":"2026-06-01T00:00:00Z","user":{"login":"reviewer"}}]]'
+		;;
+	ruleset_review_latest_changes_requested)
+		printf '%s\n' '[[{"id":1,"state":"APPROVED","submitted_at":"2026-06-01T00:00:00Z","user":{"login":"reviewer"}}],[{"id":2,"state":"CHANGES_REQUESTED","submitted_at":"2026-06-02T00:00:00Z","user":{"login":"reviewer"}}]]'
+		;;
+	ruleset_review_paginated_approved)
+		printf '%s\n' '[[{"id":1,"state":"CHANGES_REQUESTED","submitted_at":"2026-06-01T00:00:00Z","user":{"login":"reviewer"}}],[{"id":2,"state":"APPROVED","submitted_at":"2026-06-02T00:00:00Z","user":{"login":"reviewer"}}]]'
+		;;
+	ruleset_review_author_only)
+		printf '%s\n' '[[{"id":1,"state":"APPROVED","submitted_at":"2026-06-01T00:00:00Z","user":{"login":"author"}}]]'
+		;;
+	ruleset_review_malformed_response)
+		printf '%s\n' '{"reviews":[]}'
+		;;
+	ruleset_review_fetch_error)
+		printf 'gh: mock reviews endpoint error\n' >&2
+		exit 1
+		;;
+	*)
+		printf '%s\n' '[[]]'
 		;;
 	esac
 	exit 0
@@ -175,18 +208,6 @@ fi
 
 if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"headRefOid"* ]]; then
 	apply_jq '{"headRefOid":"abc123def456789000000000000000000000abcd"}' "$@"
-	exit 0
-fi
-
-if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"reviews"* ]]; then
-	case "${MOCK_GH_MODE:-all_pass}" in
-	ruleset_review_only_approved | ruleset_mixed_review_status)
-		apply_jq '{"reviews":[{"state":"APPROVED","submittedAt":"2026-06-01T00:00:00Z","author":{"login":"reviewer"}}]}' "$@"
-		;;
-	*)
-		apply_jq '{"reviews":[]}' "$@"
-		;;
-	esac
 	exit 0
 fi
 
@@ -460,6 +481,17 @@ assert_gh_call_absent() {
 	return 0
 }
 
+assert_gh_call_contains() {
+	local pattern="$1"
+	local label="$2"
+	if grep -Fq -- "$pattern" "$GH_CALL_LOG" 2>/dev/null; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "Expected gh invocation containing: $pattern"
+	fi
+	return 0
+}
+
 assert_ruleset_contexts_output() {
 	local expected_output="$1"
 	local label="$2"
@@ -700,6 +732,56 @@ test_ruleset_review_only_approved_allows_merge() {
 	assert_ruleset_review_gate_returns 0 "ruleset-only satisfied approval → merge allowed (GH#24577)"
 	assert_log_contains "satisfies 1/1 ruleset-required approval" \
 		"ruleset-only satisfied approval: pass logged"
+	assert_gh_call_contains "pulls/19023/reviews?per_page=100 --paginate --slurp" \
+		"ruleset approval gate uses paginated REST reviews endpoint"
+	assert_gh_call_absent "pr view 19023 --repo marcusquinn/aidevops --json reviews" \
+		"ruleset approval gate avoids GraphQL review fetch"
+	return 0
+}
+
+test_ruleset_latest_review_state_controls_approval() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_latest_changes_requested"
+	assert_ruleset_review_gate_returns 1 "latest CHANGES_REQUESTED revokes prior approval"
+	assert_log_contains "0/1 ruleset-required approval" \
+		"latest review state: revoked approval logged"
+	return 0
+}
+
+test_ruleset_paginated_latest_approval_allows_merge() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_paginated_approved"
+	assert_ruleset_review_gate_returns 0 "later REST page approval supersedes prior change request"
+	return 0
+}
+
+test_ruleset_author_approval_does_not_count() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_author_only"
+	assert_ruleset_review_gate_returns 1 "PR author approval does not satisfy ruleset"
+	return 0
+}
+
+test_ruleset_malformed_reviews_fail_closed() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_malformed_response"
+	assert_ruleset_review_gate_returns 1 "malformed REST review pages fail closed"
+	assert_log_contains "review parse failed" \
+		"malformed REST review pages: parse failure logged"
+	return 0
+}
+
+test_ruleset_review_fetch_error_fails_closed() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="ruleset_review_fetch_error"
+	assert_ruleset_review_gate_returns 1 "REST review fetch error fails closed"
+	assert_log_contains "review fetch failed" \
+		"REST review fetch error: failure logged"
 	return 0
 }
 
@@ -771,6 +853,11 @@ main() {
 	test_ruleset_review_only_missing_blocks_merge
 	test_ruleset_review_count_accepts_prefetched_rulesets_json
 	test_ruleset_review_only_approved_allows_merge
+	test_ruleset_latest_review_state_controls_approval
+	test_ruleset_paginated_latest_approval_allows_merge
+	test_ruleset_author_approval_does_not_count
+	test_ruleset_malformed_reviews_fail_closed
+	test_ruleset_review_fetch_error_fails_closed
 	test_ruleset_mixed_review_status_preserves_both_gates
 	test_ruleset_review_zero_does_not_require_approval
 	test_ruleset_review_malformed_optional_does_not_fail_parse


### PR DESCRIPTION
## Summary

Use paginated REST review data for pulse ruleset approval decisions, select each reviewer's latest state, exclude the pull request author, and reject unsupported collection fields in emergency REST fallback.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/shared-gh-wrappers-rest-fallback.sh, .agents/scripts/shared-gh-wrappers-status.sh, .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh, .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused pulse filter tests; GitHub wrapper fallback tests; static required-check tests; ShellCheck; runtime REST/JQ verification; git diff --check; local repository linter suite.

Resolves #28245


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.153 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 31m and 411,821 tokens on this with the user in an interactive session.