### PR TITLE
GH#28247: guard standalone pulse mocks against unset args

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -506,8 +506,8 @@ unlock_issue_after_worker() {
 	return 0
 }
 _pm_issue_api() {
-	local repo_slug="$1"
-	local issue_number="$2"
+	local repo_slug="${1:-}"
+	local issue_number="${2:-}"
 	printf 'repos/%s/issues/%s' "$repo_slug" "$issue_number"
 	return 0
 }
@@ -532,8 +532,8 @@ _gh_with_timeout() {
 	return 0
 }
 reconcile_dependants_after_verified_closure() {
-	local repo_slug="$1"
-	local issue_number="$2"
+	local repo_slug="${1:-}"
+	local issue_number="${2:-}"
 	printf 'reconciled:%s:%s\n' "$repo_slug" "$issue_number"
 	return 0
 }
@@ -574,10 +574,10 @@ _pms_failing_check_bullets() {
 	return 0
 }
 _gh_idempotent_comment() {
-	local entity_number="$1"
-	local repo_slug="$2"
-	local marker="$3"
-	local comment_body="$4"
+	local entity_number="${1:-}"
+	local repo_slug="${2:-}"
+	local marker="${3:-}"
+	local comment_body="${4:-}"
 	local entity_type="${5:-issue}"
 	: "$marker" "$comment_body"
 	printf 'idempotent:%s:%s:%s\n' "$entity_number" "$repo_slug" "$entity_type"


### PR DESCRIPTION
## Summary

Harden the standalone pulse merge source-chain mocks with safe positional-parameter defaults under set -u.

## Files Changed

.agents/scripts/tests/test-pulse-merge-routine-standalone.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-pulse-merge-routine-standalone.sh; bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh (20/20 passed)

Resolves #28247


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.153 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 8m and 47,661 tokens on this as a headless worker.