### PR TITLE
GH#28248: fix: parse pulse PR coordinates once

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -564,21 +564,22 @@ _pulse_merge_preflight_snapshot_gate() {
 	local pr_number="$2"
 	local expected_head_sha="$3"
 	local live_gate_evidence="${_PULSE_REVIEW_GATE_EVIDENCE:-}"
-	local pr_json="" current_head_sha="" base_branch="" required_contexts="" checks_json="" activity_json=""
+	local pr_json="" pr_coordinates="" current_head_sha="" base_branch="" required_contexts="" checks_json="" activity_json=""
 	_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON="[]"
 
 	pr_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || {
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "pull-request fetch"
 		return 1
 	}
-	current_head_sha=$(jq -r '.head.sha // ""' <<<"$pr_json" 2>/dev/null) || {
-		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "head parse"
+	if [[ -z "$pr_json" ]]; then
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "pull-request parse"
+		return 1
+	fi
+	pr_coordinates=$(jq -r '[(.head.sha // ""), (.base.ref // "")] | join("\u001f")' <<<"$pr_json") || {
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "pull-request parse"
 		return 1
 	}
-	base_branch=$(jq -r '.base.ref // ""' <<<"$pr_json" 2>/dev/null) || {
-		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "base-branch parse"
-		return 1
-	}
+	IFS=$'\x1f' read -r current_head_sha base_branch <<<"$pr_coordinates"
 	if [[ -z "$current_head_sha" || "$current_head_sha" != "$expected_head_sha" ]]; then
 		echo "[pulse-merge] pre-merge snapshot: head changed for PR #${pr_number} in ${repo_slug} (expected=${expected_head_sha:-unknown}, current=${current_head_sha:-unknown}) — prior gate state revoked (GH#27137)" >>"$LOGFILE"
 		return 1

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -45,6 +45,9 @@ _pmrc_gh_read() {
 		printf '%s\n' '{'
 		return 0
 		;;
+	"pr_empty:repos/owner/repo/pulls/7")
+		return 0
+		;;
 	esac
 	"$@"
 	return $?
@@ -234,7 +237,8 @@ assert_gate_logged() {
 
 assert_snapshot_acquisition_failures_are_audited() {
 	assert_gate_logged "pull-request fetch failure" pr_fetch_error "pull-request fetch failed"
-	assert_gate_logged "pull-request parse failure" pr_parse_error "head parse failed"
+	assert_gate_logged "empty pull-request response" pr_empty "pull-request parse failed"
+	assert_gate_logged "pull-request parse failure" pr_parse_error "pull-request parse failed"
 	assert_gate_logged "required-context lookup failure" required_contexts_error "required-context lookup failed"
 	assert_gate_logged "check-runs fetch failure" check_runs_error "check-runs fetch failed"
 	assert_gate_logged "commit-status fetch failure" status_error "commit-status fetch failed"


### PR DESCRIPTION
## Summary

Parse pull-request head SHA and base branch in one jq invocation, reject empty responses before parsing, preserve jq diagnostics for malformed JSON, and audit both empty and malformed responses with one fail-closed parse outcome.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh (67 tests passed); shellcheck .agents/scripts/pulse-merge-required-checks.sh .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh; git diff --check

Resolves #28248


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.153 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 9m and 63,994 tokens on this as a headless worker.