### PR TITLE
GH#28249: fix: guard pulse snapshot command argument

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -30,7 +30,7 @@ cleanup() {
 trap cleanup EXIT
 
 _pmrc_gh_read() {
-	local command="$1"
+	local command="${1:-}"
 	local subcommand="${2:-}"
 	local endpoint="${3:-}"
 


### PR DESCRIPTION
## Summary

Make the pulse merge preflight snapshot's GitHub read stub tolerate a missing command argument under set -u.

## Files Changed

.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh; shellcheck .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh; bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh (65 tests passed)

Resolves #28249


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.153 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 10m and 50,074 tokens on this as a headless worker.