### PR TITLE
GH#28252: harden pulse prefetch JSON parsing

### DIFF
--- a/.agents/scripts/pulse-batch-conditional-cache.py
+++ b/.agents/scripts/pulse-batch-conditional-cache.py
@@ -10,6 +10,7 @@ import json
 import os
 import re
 import sys
+from dataclasses import dataclass
 from typing import Any
 
 
@@ -27,6 +28,19 @@ def _write_cache(cache_file: str, payload: dict[str, Any]) -> None:
 
 
 _SNAPSHOT_SCHEMA = "aidevops-pulse-snapshot/v1"
+
+
+@dataclass(frozen=True)
+class SnapshotContext:
+    """Identity and freshness metadata shared by snapshot write paths."""
+
+    kind: str
+    slug: str
+    projection: str
+    auth_scope: str
+    generation: str
+    invalidation_generation: str
+    now: str
 
 
 def _split_response(response_file: str) -> tuple[int, str, bool, str]:
@@ -83,14 +97,7 @@ def _normalize_items(kind: str, body: str) -> list[dict[str, Any]]:
 
 
 def _snapshot_payload(
-    kind: str,
-    slug: str,
-    projection: str,
-    auth_scope: str,
-    generation: str,
-    invalidation_generation: str,
-    source: str,
-    now: str,
+    context: SnapshotContext,
     etag: str,
     status: int,
     complete: bool,
@@ -98,18 +105,18 @@ def _snapshot_payload(
 ) -> dict[str, Any]:
     return {
         "schema": _SNAPSHOT_SCHEMA,
-        "repository": slug,
-        "collection": kind,
-        "projection": projection,
-        "auth_scope": auth_scope,
-        "generation": generation,
-        "invalidation_generation": invalidation_generation,
-        "source": source,
+        "repository": context.slug,
+        "collection": context.kind,
+        "projection": context.projection,
+        "auth_scope": context.auth_scope,
+        "generation": context.generation,
+        "invalidation_generation": context.invalidation_generation,
+        "source": "conditional-rest",
         "complete": complete,
         "truncated": not complete,
-        "fetched_at": now,
-        "timestamp": now,
-        "last_success": now,
+        "fetched_at": context.now,
+        "timestamp": context.now,
+        "last_success": context.now,
         "etag": etag,
         "validator": {"etag": etag} if etag else {},
         "conditional_status": status,
@@ -140,32 +147,24 @@ def main(argv: list[str]) -> int:
         ) = argv[1:9]
         status, etag, has_next, body = _split_response(response_file)
         now = _now_iso()
+        context = SnapshotContext(
+            kind=kind,
+            slug=slug,
+            projection=projection,
+            auth_scope=auth_scope,
+            generation=generation,
+            invalidation_generation=invalidation_generation,
+            now=now,
+        )
         if status == 304:
-            result = _refresh_cached_response(
-                kind,
-                slug,
-                cache_file,
-                etag,
-                now,
-                generation,
-                auth_scope,
-                projection,
-                invalidation_generation,
-            )
+            result = _refresh_cached_response(context, cache_file, etag)
         elif status < 200 or status >= 300:
             result = 1
         else:
             _write_cache(
                 cache_file,
                 _snapshot_payload(
-                    kind,
-                    slug,
-                    projection,
-                    auth_scope,
-                    generation,
-                    invalidation_generation,
-                    "conditional-rest",
-                    now,
+                    context,
                     etag,
                     status,
                     not has_next,
@@ -177,15 +176,9 @@ def main(argv: list[str]) -> int:
 
 
 def _refresh_cached_response(
-    kind: str,
-    slug: str,
+    context: SnapshotContext,
     cache_file: str,
     etag: str,
-    now: str,
-    generation: str,
-    auth_scope: str,
-    projection: str,
-    invalidation_generation: str,
 ) -> int:
     if not os.path.exists(cache_file):
         return 1
@@ -194,7 +187,7 @@ def _refresh_cached_response(
     items = payload.get("items")
     if not isinstance(items, list) or any(not isinstance(item, dict) for item in items):
         return 1
-    if kind == "issues":
+    if context.kind == "issues":
         if any("state" not in item for item in items):
             return 1
         payload["items"] = [
@@ -205,28 +198,28 @@ def _refresh_cached_response(
     compatible = all(
         (
             payload.get("schema") == _SNAPSHOT_SCHEMA,
-            payload.get("repository") == slug,
-            payload.get("collection") == kind,
-            payload.get("projection") == projection,
-            payload.get("auth_scope") == auth_scope,
+            payload.get("repository") == context.slug,
+            payload.get("collection") == context.kind,
+            payload.get("projection") == context.projection,
+            payload.get("auth_scope") == context.auth_scope,
             isinstance(payload.get("complete"), bool),
         )
     )
     payload.update(
         {
             "schema": _SNAPSHOT_SCHEMA if compatible else payload.get("schema", "legacy"),
-            "repository": slug,
-            "collection": kind,
-            "projection": projection if compatible else payload.get("projection", "legacy"),
-            "auth_scope": auth_scope,
-            "generation": generation,
-            "invalidation_generation": invalidation_generation,
+            "repository": context.slug,
+            "collection": context.kind,
+            "projection": context.projection if compatible else payload.get("projection", "legacy"),
+            "auth_scope": context.auth_scope,
+            "generation": context.generation,
+            "invalidation_generation": context.invalidation_generation,
             "source": "conditional-rest",
             "complete": payload.get("complete", False) if compatible else False,
             "truncated": not (payload.get("complete", False) if compatible else False),
-            "fetched_at": now,
-            "timestamp": now,
-            "last_success": now,
+            "fetched_at": context.now,
+            "timestamp": context.now,
+            "last_success": context.now,
             "conditional_status": 304,
             "conditional_cache_hit": True,
         }

--- a/.agents/scripts/pulse-prefetch-repo.sh
+++ b/.agents/scripts/pulse-prefetch-repo.sh
@@ -21,6 +21,7 @@ fi
 _PREFETCH_BOOL_TRUE=true
 _PREFETCH_JSON_NULL=null
 _PREFETCH_NONE_LINE="- None"
+_PREFETCH_UNKNOWN=unknown
 
 # =============================================================================
 # Single-Repo Orchestration (GH#5627, GH#18984/t2098)
@@ -49,33 +50,41 @@ _prefetch_single_repo_idle_skip() {
 	local issues_snapshot="${4:-}"
 
 	local _cached_last
-	_cached_last=$(echo "$cache_entry" | jq -r '.last_prefetch // "unknown"' 2>/dev/null) || _cached_last="unknown"
+	if [[ -n "$cache_entry" ]]; then
+		_cached_last=$(printf '%s\n' "$cache_entry" | jq -r --arg unknown "$_PREFETCH_UNKNOWN" '.last_prefetch // $unknown') || _cached_last="$_PREFETCH_UNKNOWN"
+	else
+		_cached_last="$_PREFETCH_UNKNOWN"
+	fi
 	echo "> **State cache hit** — fingerprint unchanged since \`${_cached_last}\`."
 	echo "> No open issues or PRs have been updated since then."
 	echo "> LLM may skip deep analysis of this repo this cycle."
 	echo ""
 
 	local _cached_prs="" _cached_issues="" _cached_pr_count=0 _cached_issue_count=0
-	if [[ -n "$prs_snapshot" ]] && _cached_prs=$(printf '%s' "$prs_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
+	if [[ -n "$prs_snapshot" ]] && _cached_prs=$(printf '%s' "$prs_snapshot" | jq -ce '.items | select(type == "array")'); then
 		:
+	elif [[ -n "$cache_entry" ]]; then
+		_cached_prs=$(printf '%s\n' "$cache_entry" | jq -c '.prs // []') || _cached_prs="[]"
 	else
-		_cached_prs=$(echo "$cache_entry" | jq -c '.prs // []' 2>/dev/null) || _cached_prs="[]"
+		_cached_prs="[]"
 	fi
-	if [[ -n "$issues_snapshot" ]] && _cached_issues=$(printf '%s' "$issues_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
+	if [[ -n "$issues_snapshot" ]] && _cached_issues=$(printf '%s' "$issues_snapshot" | jq -ce '.items | select(type == "array")'); then
 		:
+	elif [[ -n "$cache_entry" ]]; then
+		_cached_issues=$(printf '%s\n' "$cache_entry" | jq -c '.issues // []') || _cached_issues="[]"
 	else
-		_cached_issues=$(echo "$cache_entry" | jq -c '.issues // []' 2>/dev/null) || _cached_issues="[]"
+		_cached_issues="[]"
 	fi
-	_cached_pr_count=$(echo "$_cached_prs" | jq 'length' 2>/dev/null) || _cached_pr_count=0
+	_cached_pr_count=$(printf '%s\n' "$_cached_prs" | jq 'length') || _cached_pr_count=0
 	[[ "$_cached_pr_count" =~ ^[0-9]+$ ]] || _cached_pr_count=0
-	_cached_issues=$(echo "$_cached_issues" | _prefetch_open_issues_only)
-	_cached_issue_count=$(echo "$_cached_issues" | jq 'length' 2>/dev/null) || _cached_issue_count=0
+	_cached_issues=$(printf '%s\n' "$_cached_issues" | _prefetch_open_issues_only)
+	_cached_issue_count=$(printf '%s\n' "$_cached_issues" | jq 'length') || _cached_issue_count=0
 	[[ "$_cached_issue_count" =~ ^[0-9]+$ ]] || _cached_issue_count=0
 
 	# Replay cached PR section
 	echo "### Open PRs (${_cached_pr_count}) [cached]"
 	if [[ "$_cached_pr_count" -gt 0 ]]; then
-		echo "$_cached_prs" | jq -r '.[] | "- PR #\(.number): \(.title) [review: \(if has("reviewDecision") | not then "UNKNOWN" elif .reviewDecision == null or .reviewDecision == "" then "NONE" else .reviewDecision end)] [updated: \(.updatedAt)]"'
+		printf '%s\n' "$_cached_prs" | jq -r '.[] | "- PR #\(.number): \(.title) [review: \(if has("reviewDecision") | not then "UNKNOWN" elif .reviewDecision == null or .reviewDecision == "" then "NONE" else .reviewDecision end)] [updated: \(.updatedAt)]"'
 	else
 		echo "$_PREFETCH_NONE_LINE"
 	fi
@@ -90,7 +99,7 @@ _prefetch_single_repo_idle_skip() {
 		_checks_json=$(_prefetch_prs_enrich_checks "$slug" "$_cached_prs")
 		if [[ -n "$_checks_json" && "$_checks_json" != "[]" && "$_checks_json" != "$_PREFETCH_JSON_NULL" ]]; then
 			echo "### PR Check Status (live)"
-			echo "$_checks_json" | jq -r '.[] | "- PR #\(.number): \(.status // "unknown")"' 2>/dev/null || true
+			printf '%s\n' "$_checks_json" | jq -r '.[] | "- PR #\(.number): \(.status // "unknown")"' || true
 			echo ""
 		fi
 	fi
@@ -103,15 +112,15 @@ _prefetch_single_repo_idle_skip() {
 	# Replay cached issue sections using same filter logic as _prefetch_repo_issues
 	# GH#20048: shared helper replaces inline jq non-task filter
 	local _filtered_cached="" _disp_json="" _sweep_json="" _disp_count=0 _sweep_count=0
-	_filtered_cached=$(echo "$_cached_issues" | _filter_non_task_issues)
-	_disp_json=$(echo "$_filtered_cached" | jq -c '[.[] | select(.labels | map(.name) | (index("source:quality-sweep") or index("source:review-feedback")) | not)]' 2>/dev/null) || _disp_json="[]"
-	_sweep_json=$(echo "$_filtered_cached" | jq -c '[.[] | select(.labels | map(.name) | (index("source:quality-sweep") or index("source:review-feedback")))]' 2>/dev/null) || _sweep_json="[]"
-	_disp_count=$(echo "$_disp_json" | jq 'length' 2>/dev/null) || _disp_count=0
-	_sweep_count=$(echo "$_sweep_json" | jq 'length' 2>/dev/null) || _sweep_count=0
+	_filtered_cached=$(printf '%s\n' "$_cached_issues" | _filter_non_task_issues)
+	_disp_json=$(printf '%s\n' "$_filtered_cached" | jq -c '[.[] | select(.labels | map(.name) | (index("source:quality-sweep") or index("source:review-feedback")) | not)]') || _disp_json="[]"
+	_sweep_json=$(printf '%s\n' "$_filtered_cached" | jq -c '[.[] | select(.labels | map(.name) | (index("source:quality-sweep") or index("source:review-feedback")))]') || _sweep_json="[]"
+	_disp_count=$(printf '%s\n' "$_disp_json" | jq 'length') || _disp_count=0
+	_sweep_count=$(printf '%s\n' "$_sweep_json" | jq 'length') || _sweep_count=0
 
 	if [[ "$_disp_count" -gt 0 ]]; then
 		echo "### Open Issues (${_disp_count}) [cached]"
-		echo "$_disp_json" | jq -r '.[] | "- Issue #\(.number): \(.title) [labels: \(if (.labels | length) == 0 then "none" else (.labels | map(.name) | join(", ")) end)] [assignees: \(if (.assignees | length) == 0 then "none" else (.assignees | map(.login) | join(", ")) end)] [updated: \(.updatedAt)]"'
+		printf '%s\n' "$_disp_json" | jq -r '.[] | "- Issue #\(.number): \(.title) [labels: \(if (.labels | length) == 0 then "none" else (.labels | map(.name) | join(", ")) end)] [assignees: \(if (.assignees | length) == 0 then "none" else (.assignees | map(.login) | join(", ")) end)] [updated: \(.updatedAt)]"'
 	else
 		echo "### Open Issues (0) [cached]"
 		echo "$_PREFETCH_NONE_LINE"
@@ -119,7 +128,7 @@ _prefetch_single_repo_idle_skip() {
 	echo ""
 	if [[ "$_sweep_count" -gt 0 ]]; then
 		echo "### Quality-Tracked Issues (${_sweep_count}) [cached]"
-		echo "$_sweep_json" | jq -r '.[] | "- Issue #\(.number): \(.title)"'
+		printf '%s\n' "$_sweep_json" | jq -r '.[] | "- Issue #\(.number): \(.title)"'
 		echo ""
 	fi
 

--- a/.agents/scripts/tests/test-pulse-prefetch-idle-skip-json.sh
+++ b/.agents/scripts/tests/test-pulse-prefetch-idle-skip-json.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_SCRIPT_DIR}/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL %s\n' "$message" >&2
+	return 1
+}
+
+_prefetch_open_issues_only() {
+	jq -c '[.[] | select((.state // "open") == "open")]'
+	return 0
+}
+
+_filter_non_task_issues() {
+	jq -c '.'
+	return 0
+}
+
+_prefetch_prs_enrich_checks() {
+	printf '[]\n'
+	return 0
+}
+
+main() {
+	local cache_entry='{"last_prefetch":"2026-07-18T10:00:00Z","prs":[{"number":9,"title":"C:\temp","updatedAt":"2026-07-18T09:00:00Z"}],"issues":[]}'
+	local output_file="$TEST_ROOT/output.txt"
+	local stderr_file="$TEST_ROOT/stderr.txt"
+	local xpg_echo_was_set=false
+	local LOGFILE="$TEST_ROOT/pulse.log"
+	local _PULSE_HEALTH_IDLE_REPO_SKIPS=0
+
+	# shellcheck source=../pulse-prefetch-repo.sh
+	source "$SCRIPTS_DIR/pulse-prefetch-repo.sh"
+
+	if shopt -q xpg_echo; then
+		xpg_echo_was_set=true
+	fi
+	shopt -s xpg_echo
+	_prefetch_single_repo_idle_skip owner/repo "$cache_entry" "" "" >"$output_file" 2>"$stderr_file" ||
+		fail "valid idle-skip JSON could not be rendered"
+	if [[ "$xpg_echo_was_set" == false ]]; then
+		shopt -u xpg_echo
+	fi
+	grep -q 'PR #9' "$output_file" || fail "idle-skip JSON changed under xpg_echo semantics"
+	[[ ! -s "$stderr_file" ]] || fail "valid idle-skip JSON produced jq errors"
+
+	_prefetch_single_repo_idle_skip owner/repo "" "" "" >"$output_file" 2>"$stderr_file" ||
+		fail "empty idle-skip input could not be rendered"
+	grep -q 'Open PRs (0)' "$output_file" || fail "empty PR input did not become an empty array"
+	grep -q 'Open Issues (0)' "$output_file" || fail "empty issue input did not become an empty array"
+	[[ ! -s "$stderr_file" ]] || fail "empty idle-skip input produced jq errors"
+
+	_prefetch_single_repo_idle_skip owner/repo '{malformed' "" "" >"$output_file" 2>"$stderr_file" ||
+		fail "malformed cache fallback could not be rendered"
+	grep -q 'Open PRs (0)' "$output_file" || fail "malformed cache did not fall back safely"
+	[[ -s "$stderr_file" ]] || fail "malformed non-empty JSON error was suppressed"
+
+	printf 'PASS idle-skip JSON uses printf, handles empty input, and exposes malformed input\n'
+	return 0
+}
+
+trap cleanup EXIT
+main "$@"


### PR DESCRIPTION
## Summary

Harden idle-cache JSON pipelines and consolidate conditional snapshot metadata to eliminate five Qlty smells exposed by the terminal CI threshold gate.

## Files Changed

- `.agents/scripts/pulse-prefetch-repo.sh`
- `.agents/scripts/pulse-batch-conditional-cache.py`
- `.agents/scripts/tests/test-pulse-prefetch-idle-skip-json.sh`

## Runtime Testing

- **Risk level:** Low (infrastructure scripts)
- **Verification:** Focused idle-skip regression; 22 conditional snapshot tests; full changed-file local lint suite; Qlty all-files count 54 below threshold 57; Python compilation; ShellCheck; shfmt; Bash syntax; diff checks.

Resolves #28252

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.153 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 45m and 243,685 tokens on this as a headless worker.
