### PR TITLE
GH#28079: fix: enforce signed merge summary posting

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -1196,7 +1196,9 @@ _reconcile_pr_origin_label() {
 	local origin_name="$3"
 	local origin_error=""
 	origin_error=$(mktemp) || return 1
-	if ! set_origin_label "$pr_number" "$repo" "$origin_name" --pr 2>"$origin_error"; then
+	# set_origin_label may print the PR URL after a successful REST mutation.
+	# _create_pr is a machine-output function, so keep that status off stdout.
+	if ! set_origin_label "$pr_number" "$repo" "$origin_name" --pr >/dev/null 2>"$origin_error"; then
 		local failure_kind="GitHub label write failed"
 		if grep -qiE 'permission|forbidden|Resource not accessible|HTTP 403' "$origin_error" 2>/dev/null; then
 			failure_kind="credential lacks PR label permission"
@@ -1320,28 +1322,67 @@ _post_merge_summary() {
 	# Counter safety: validate result is a number before comparing (t2763).
 	local _existing_count=0
 	local _tmp_count=""
-	_tmp_count=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
-		--jq '[.[] | select(.body | test("<!-- MERGE_SUMMARY -->"))] | length' 2>/dev/null || true)
-	[[ "$_tmp_count" =~ ^[0-9]+$ ]] && _existing_count="$_tmp_count"
-	if [[ "$_existing_count" -gt 0 ]]; then
+	if ! _tmp_count=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
+		--jq '[.[] | select(.body | test("<!-- MERGE_SUMMARY -->"))] | length'); then
+		print_error "Could not verify existing merge summary comments on PR #${pr_number}; refusing a potentially duplicate post"
+		return 1
+	fi
+	if [[ ! "$_tmp_count" =~ ^[0-9]+$ ]]; then
+		print_error "Invalid merge summary count for PR #${pr_number}: ${_tmp_count:-empty}"
+		return 1
+	fi
+	_existing_count="$_tmp_count"
+	if [[ "$_existing_count" -eq 1 ]]; then
 		print_info "Merge summary comment already exists on PR #${pr_number} — skipping duplicate (t2767)"
 		return 0
 	fi
+	if [[ "$_existing_count" -gt 1 ]]; then
+		print_error "PR #${pr_number} has ${_existing_count} canonical merge summary comments; expected exactly one"
+		return 1
+	fi
 
-	local merge_summary="<!-- MERGE_SUMMARY -->
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local merge_summary_file=""
+	if ! mkdir -p "$temp_root"; then
+		print_error "Could not create merge summary workspace: ${temp_root}"
+		return 1
+	fi
+	if ! merge_summary_file=$(mktemp "${temp_root}/aidevops-merge-summary.XXXXXX"); then
+		print_error "Could not create merge summary body file in ${temp_root}"
+		return 1
+	fi
+	if ! printf '%s\n' "<!-- MERGE_SUMMARY -->
 ## Completion Summary
 
 - **What**: ${summary_what:-Implementation for issue #${issue_number}}
 - **Issue**: #${issue_number}
 - **Files changed**: ${files_changed:-see diff}
 - **Testing**: ${summary_testing:-shellcheck clean, self-assessed}
-- **Key decisions**: ${summary_decisions:-none}"
-
-	if gh_pr_comment "$pr_number" --repo "$repo" --body "$merge_summary" >/dev/null 2>&1; then
-		print_success "Merge summary comment posted on PR #${pr_number}"
-	else
-		print_warning "Failed to post merge summary comment — post it manually"
+- **Key decisions**: ${summary_decisions:-none}" >"$merge_summary_file"; then
+		print_error "Could not write merge summary body file for PR #${pr_number}"
+		rm -f "$merge_summary_file"
+		return 1
 	fi
+
+	# gh_pr_comment signs a private copy of --body-file before posting. Keep
+	# stderr visible so policy or GitHub failures retain actionable diagnostics.
+	if ! gh_pr_comment "$pr_number" --repo "$repo" --body-file "$merge_summary_file" >/dev/null; then
+		print_error "Failed to post signed merge summary comment on PR #${pr_number}"
+		rm -f "$merge_summary_file"
+		return 1
+	fi
+	rm -f "$merge_summary_file"
+
+	_tmp_count=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
+		--jq '[.[] | select(.body | test("<!-- MERGE_SUMMARY -->"))] | length') || {
+		print_error "Merge summary posted on PR #${pr_number}, but verification failed"
+		return 1
+	}
+	if [[ "$_tmp_count" != "1" ]]; then
+		print_error "Merge summary postcondition failed on PR #${pr_number}: expected 1 canonical comment, found ${_tmp_count:-unknown}"
+		return 1
+	fi
+	print_success "Signed merge summary comment posted and verified on PR #${pr_number}"
 	return 0
 }
 

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -185,7 +185,7 @@ Worker aborted PR creation: issue #${issue_number} was already closed by the tim
 	local pr_number=""
 	pr_number=$(_create_pr "$repo" "$pr_title" "$pr_body" "$origin_label" "${extra_labels[@]+"${extra_labels[@]}"}") || return 1
 
-	_post_merge_summary "$pr_number" "$repo" "$issue_number" "$summary_what" "$files_changed" "$summary_testing" "$summary_decisions"
+	_post_merge_summary "$pr_number" "$repo" "$issue_number" "$summary_what" "$files_changed" "$summary_testing" "$summary_decisions" || return 1
 	_label_issue_in_review "$issue_number" "$repo"
 	_label_pr_in_review "$pr_number" "$repo"
 	if is_loop_active; then

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -362,25 +362,26 @@ if os.path.exists(api_report):
         read_caller_names = {'gh_issue_list', 'gh_pr_list', 'gh_issue_view', 'gh_pr_view'}
         rest_read_caller_names = {'_rest_issue_list', '_rest_pr_list', '_rest_issue_view', '_rest_pr_view'}
         for caller, data in (report.get('by_caller') or {}).items():
-            if isinstance(data, dict):
-                gql = int(data.get('graphql_calls') or 0) + int(data.get('search_graphql_calls') or 0)
-                if gql > 0:
-                    api_consumers.append({'caller': caller, 'graphql_calls': gql})
-                graphql_calls = int(data.get('graphql_calls') or 0)
-                rest_calls = int(data.get('rest_calls') or 0)
-                search_graphql_calls = int(data.get('search_graphql_calls') or 0)
-                search_rest_calls = int(data.get('search_rest_calls') or 0)
-                if caller in read_caller_names:
-                    api_pressure['graphql_read_calls'] += graphql_calls
-                    api_pressure['rest_read_calls'] += rest_calls
-                    if graphql_calls > 0:
-                        read_graphql_callers.append({'caller': caller, 'graphql_calls': graphql_calls})
-                elif caller in rest_read_caller_names:
-                    api_pressure['rest_read_calls'] += rest_calls
-                else:
-                    api_pressure['graphql_other_calls'] += graphql_calls
-                api_pressure['graphql_search_calls'] += search_graphql_calls
-                api_pressure['rest_search_calls'] += search_rest_calls
+            if not isinstance(data, dict):
+                continue
+            gql = int(data.get('graphql_calls') or 0) + int(data.get('search_graphql_calls') or 0)
+            if gql > 0:
+                api_consumers.append({'caller': caller, 'graphql_calls': gql})
+            graphql_calls = int(data.get('graphql_calls') or 0)
+            rest_calls = int(data.get('rest_calls') or 0)
+            search_graphql_calls = int(data.get('search_graphql_calls') or 0)
+            search_rest_calls = int(data.get('search_rest_calls') or 0)
+            if caller in read_caller_names:
+                api_pressure['graphql_read_calls'] += graphql_calls
+                api_pressure['rest_read_calls'] += rest_calls
+                if graphql_calls > 0:
+                    read_graphql_callers.append({'caller': caller, 'graphql_calls': graphql_calls})
+            elif caller in rest_read_caller_names:
+                api_pressure['rest_read_calls'] += rest_calls
+            else:
+                api_pressure['graphql_other_calls'] += graphql_calls
+            api_pressure['graphql_search_calls'] += search_graphql_calls
+            api_pressure['rest_search_calls'] += search_rest_calls
         api_consumers = sorted(api_consumers, key=lambda item: item['graphql_calls'], reverse=True)[:5]
         read_total = api_pressure['graphql_read_calls'] + api_pressure['rest_read_calls']
         if read_total > 0:

--- a/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
+++ b/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
@@ -290,9 +290,39 @@ else
 fi
 ORIGIN_API_FAIL=0
 
-# Stub: gh_pr_comment — records call, returns 0
+# Stub: gh_pr_comment — records body-file use and can simulate policy failure.
+GH_PR_COMMENT_FAIL=0
 gh_pr_comment() {
-	printf 'gh_pr_comment pr=%s\n' "${1:-}" >>"$STUB_LOG"
+	local pr_number="${1:-}"
+	local body_file=""
+	shift || return 1
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--body-file)
+			body_file="${2:-}"
+			shift 2 || return 1
+			;;
+		--body-file=*)
+			body_file="${1#--body-file=}"
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+	printf 'gh_pr_comment pr=%s body_file=%s\n' "$pr_number" "$body_file" >>"$STUB_LOG"
+	if [[ "$GH_PR_COMMENT_FAIL" -eq 1 ]]; then
+		printf 'signature gate: comments require --body-file\n' >&2
+		return 1
+	fi
+	if [[ -z "$body_file" || ! -r "$body_file" ]]; then
+		printf 'missing readable merge summary body file\n' >&2
+		return 1
+	fi
+	if ! grep -q '<!-- MERGE_SUMMARY -->' "$body_file"; then
+		printf 'missing canonical merge summary marker\n' >&2
+		return 1
+	fi
+	GH_EXISTING_MERGE_SUMMARY_COUNT=1
 	return 0
 }
 export -f gh_pr_comment
@@ -314,6 +344,7 @@ set_origin_label() {
 		printf 'GraphQL: Resource not accessible by integration\n' >&2
 		return 1
 	fi
+	printf 'https://github.com/%s/pull/%s\n' "$repo_slug" "$issue_num"
 	return 0
 }
 export -f set_origin_label
@@ -701,6 +732,44 @@ else
 	fail "first post: gh_pr_comment IS called when no MERGE_SUMMARY exists" \
 		"gh_pr_comment was NOT called; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
 fi
+
+if grep -q 'gh_pr_comment pr=999 body_file=' "$STUB_LOG" 2>/dev/null; then
+	pass "first post: canonical merge summary is posted through --body-file"
+else
+	fail "first post: canonical merge summary is posted through --body-file" \
+		"body-file call missing; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+# =============================================================================
+# Test 6: posting failure is a lifecycle failure with preserved diagnostics
+# The signature gate rejects the write. Expected: _post_merge_summary returns 1,
+# keeps the gate's stderr visible, and cmd_commit_and_pr propagates the failure.
+# =============================================================================
+: >"$STUB_LOG"
+GH_EXISTING_MERGE_SUMMARY_COUNT=0
+GH_PR_COMMENT_FAIL=1
+post_failure_rc=0
+post_failure_stderr=""
+post_failure_stderr=$(_post_merge_summary "999" "owner/repo" "42" "impl" "file.sh" "shellcheck" "none" 2>&1) || post_failure_rc=$?
+
+if [[ "$post_failure_rc" -eq 1 ]]; then
+	pass "post failure: _post_merge_summary returns non-success"
+else
+	fail "post failure: _post_merge_summary returns non-success" "got exit ${post_failure_rc}"
+fi
+
+if [[ "$post_failure_stderr" == *"signature gate: comments require --body-file"* ]]; then
+	pass "post failure: policy diagnostics remain visible"
+else
+	fail "post failure: policy diagnostics remain visible" "stderr: ${post_failure_stderr}"
+fi
+
+if grep -q '_post_merge_summary .* || return 1' "${SCRIPTS_DIR}/full-loop-helper.sh"; then
+	pass "post failure: commit-and-pr propagates merge-summary failure"
+else
+	fail "post failure: commit-and-pr propagates merge-summary failure"
+fi
+GH_PR_COMMENT_FAIL=0
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

Post commit-and-pr merge summaries through signed body files, verify exactly one canonical comment, and fail the lifecycle with preserved diagnostics when posting fails

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/tests/test-commit-and-pr-partial-success.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-commit-and-pr-partial-success.sh; test-gh-wrapper-auto-sig-body-file.sh; ShellCheck; linters-local.sh --changed

Resolves #28079


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.154 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 6m and 95,772 tokens on this as a headless worker.