### PR TITLE
t18131: Add production GitHub API efficiency evidence

### DIFF
--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -68,6 +68,25 @@ Each transport aggregate has one sidecar using
 sidecar to the exact aggregate bytes. The result also records the sidecar's own
 SHA-256 digest.
 
+The Pulse wrapper now publishes this sidecar automatically after each real cycle.
+It writes the transport aggregate first, binds the sidecar to those exact bytes,
+and atomically replaces both private files with mode `600`. Defaults are
+`~/.aidevops/logs/gh-api-calls-by-stage.json` and
+`~/.aidevops/logs/gh-api-efficiency-evidence.json`; override them with
+`AIDEVOPS_GH_API_REPORT` and `AIDEVOPS_GH_API_EVIDENCE`. Set
+`AIDEVOPS_GH_API_EVIDENCE_DISABLE=1` to disable sidecar production without
+disabling transport telemetry. Invalid or insufficient retained windows remove a
+stale sidecar instead of preserving misleading evidence.
+
+Coverage contract `1` starts at a private persisted activation timestamp and is
+re-emitted each cycle so a rolling window becomes bounded only after every
+retained attempt post-dates instrumentation activation. Population, latency,
+cache, single-flight, and path-budget ownership currently emit complete coverage
+markers. Webhook and guardrail events are collected, but those groups deliberately
+remain uncovered—and therefore `null`—until duplicate-action, recovery,
+stale-positive, and dispatch-dependency semantics have complete production
+ownership. Never promote absent events in an uncovered group to observed zero.
+
 The following is an intentionally incomplete template. Replace every required
 `null` with a privacy-safe observed value and set `complete` to `true` only when
 the whole fixed window has been reconciled. The transport digest must be 64
@@ -140,8 +159,8 @@ tokens, URLs, or raw log records in the sidecar.
 | `latency` | Aggregate request and completed-action histograms plus peak minute count. |
 | `cache` | Canonical snapshot/check-cache decision counters. |
 | `single_flight` | Leader, follower wait, takeover, and duplicate-leader counters. |
-| `webhook` | Verified invalidation count and aggregate delivery-to-invalidation lag. |
-| `guardrails` | Freshness detections, forced refreshes, dependency checks, and merge-preflight comparisons. |
+| `webhook` | `pulse-merge-webhook-server.py` emits a protocol-v1 millisecond receive marker; `pulse-merge-webhook-receiver.sh` records successful invalidations, delivery-to-invalidation lag, and invalidations delegated to polling recovery. |
+| `guardrails` | Snapshot/check-cache freshness detections, forced live refreshes, and live required-check preflight mismatches. Unsupported stale-positive and dispatch-dependency fields remain unknown. |
 | `path_budgets` | Deterministic call-site counters from focused request-budget tests/telemetry. |
 
 ## Comparability gate
@@ -253,15 +272,30 @@ must not be removed by an efficiency-only canary.
 ## Verification
 
 ```bash
+bash .agents/scripts/tests/test-gh-api-instrument.sh
+bash .agents/scripts/tests/test-gh-request-singleflight.sh
+bash .agents/scripts/tests/test-gh-check-status-cache.sh
+bash .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+bash .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+python3 .agents/scripts/tests/test-pulse-merge-webhook-invalidation.py
+bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+bash .agents/scripts/tests/test-github-api-efficiency-evidence.sh
 bash .agents/scripts/tests/test-github-api-efficiency-benchmark.sh
 shellcheck \
+  .agents/scripts/gh-api-instrument.sh \
+  .agents/scripts/pulse-wrapper-cycle-gates.sh \
+  .agents/scripts/pulse-batch-prefetch-helper.sh \
+  .agents/scripts/pulse-merge-webhook-receiver.sh \
   .agents/scripts/github-api-efficiency-benchmark.sh \
   .agents/scripts/tests/test-github-api-efficiency-benchmark.sh
 python3 -m py_compile \
+  .agents/scripts/github-api-efficiency-evidence.py \
   .agents/scripts/github-api-efficiency-benchmark.py \
+  .agents/scripts/github_api_efficiency_events.py \
   .agents/scripts/github_api_efficiency_inputs.py \
   .agents/scripts/github_api_efficiency_metrics.py \
-  .agents/scripts/github_api_efficiency_report.py
+  .agents/scripts/github_api_efficiency_report.py \
+  .agents/scripts/pulse-merge-webhook-server.py
 ```
 
 The fixture suite covers deterministic pass output, regressions, incomplete

--- a/.agents/scripts/gh-api-aggregate.awk
+++ b/.agents/scripts/gh-api-aggregate.awk
@@ -15,6 +15,7 @@ BEGIN {
 	total_calls = 0
 	logical_events = 0
 	cache_events = 0
+	evidence_events = 0
 	legacy_events = 0
 	attempted_requests = 0
 	opaque_paginated_attempts = 0
@@ -37,6 +38,18 @@ function metric_add_dimensions(caller, path, auth, pool, decision, metric, amoun
 	metric_add("auth", auth, metric, amount)
 	metric_add("pool", pool, metric, amount)
 	metric_add("decision", decision, metric, amount)
+}
+
+function percentile(histogram, total, percent,    target, cumulative, key, values, n, i) {
+	if (total < 1) return 0
+	for (key in histogram) values[++n] = key + 0
+	sort_values(values, n)
+	target = int((total * percent + 99) / 100)
+	for (i = 1; i <= n; i++) {
+		cumulative += histogram[values[i]]
+		if (cumulative >= target) return values[i]
+	}
+	return values[n] + 0
 }
 
 function sort_values(values, n,    i, j, swap) {
@@ -69,6 +82,7 @@ function emit_group(title, group,    pair, parts, values, n, i, value) {
 		printf "      \"total\": %d,\n", metric_get(group, value, "total")
 		printf "      \"logical_events\": %d,\n", metric_get(group, value, "logical_events")
 		printf "      \"cache_events\": %d,\n", metric_get(group, value, "cache_events")
+		printf "      \"evidence_events\": %d,\n", metric_get(group, value, "evidence_events")
 		printf "      \"legacy_events\": %d,\n", metric_get(group, value, "legacy_events")
 		printf "      \"attempted_requests\": %d,\n", metric_get(group, value, "attempted_requests")
 		printf "      \"opaque_paginated_attempts\": %d,\n", metric_get(group, value, "opaque_paginated_attempts")
@@ -78,6 +92,7 @@ function emit_group(title, group,    pair, parts, values, n, i, value) {
 		printf "      \"successful_attempts\": %d,\n", metric_get(group, value, "successful_attempts")
 		printf "      \"failed_attempts\": %d,\n", metric_get(group, value, "failed_attempts")
 		printf "      \"elapsed_ms\": %d,\n", metric_get(group, value, "elapsed_ms")
+		printf "      \"unknown_elapsed_attempts\": %d,\n", metric_get(group, value, "unknown_elapsed_attempts")
 		printf "      \"known_quota_cost\": %d,\n", metric_get(group, value, "known_quota_cost")
 		printf "      \"unknown_quota_cost_attempts\": %d\n", metric_get(group, value, "unknown_quota_cost_attempts")
 		printf "    }"
@@ -167,26 +182,38 @@ $1 !~ /^[0-9]+$/ || NF < 3 {
 		if (attempt_id == "" || attempt_id == "unknown") {
 			retained_unidentified_attempts++
 			attempt_unidentified = 1
-		} else if (attempt_id in seen_attempt_id) {
+		} else if (attempt_id in seen_retained_attempt_id) {
 			retained_duplicate_attempt_ids++
-			attempt_duplicate = 1
 		} else {
-			seen_attempt_id[attempt_id] = 1
+			seen_retained_attempt_id[attempt_id] = 1
 		}
 		if (page !~ /^[0-9]+$/ || page + 0 < 1) {
 			retained_unknown_page_attempts++
 			attempt_page_unknown = 1
 		}
-		if (first_retained_attempt_ts == 0 || ts < first_retained_attempt_ts) first_retained_attempt_ts = ts
-		if (ts > last_retained_attempt_ts) last_retained_attempt_ts = ts
+		if (first_observed_attempt_ts == 0 || ts < first_observed_attempt_ts) first_observed_attempt_ts = ts
+		if (ts > last_observed_attempt_ts) last_observed_attempt_ts = ts
 	}
 
 	if (ts < cutoff) next
 	window_records++
+	if (kind == "attempt" && !attempt_unidentified) {
+		if (attempt_id in seen_window_attempt_id) {
+			attempt_duplicate = 1
+		} else {
+			seen_window_attempt_id[attempt_id] = 1
+		}
+	}
 	record_budget(pool, budget, ts)
 	if (logical_id != "" && logical_id != "unknown" && !(logical_id in seen_window_logical_id)) {
 		seen_window_logical_id[logical_id] = 1
 		logical_operations++
+	}
+
+	if (kind == "evidence") {
+		evidence_events++
+		metric_add_dimensions(caller, path, auth, pool, decision, "evidence_events", 1)
+		next
 	}
 
 	if (kind != "attempt") {
@@ -215,9 +242,16 @@ $1 !~ /^[0-9]+$/ || NF < 3 {
 		duplicate_attempt_ids++
 		next
 	}
+	if (first_window_attempt_ts == 0 || ts < first_window_attempt_ts) first_window_attempt_ts = ts
+	if (ts > last_window_attempt_ts) last_window_attempt_ts = ts
 	if (attempt_page_unknown) unknown_page_attempts++
 
 	attempted_requests++
+	minute = int(ts / 60)
+	minute_attempts[minute]++
+	if (minute_attempts[minute] > peak_attempts_per_minute) {
+		peak_attempts_per_minute = minute_attempts[minute]
+	}
 	metric_add_dimensions(caller, path, auth, pool, decision, "attempted_requests", 1)
 	metric_add("outcome", outcome, "attempted_requests", 1)
 	if (decision == "native-pagination-opaque") {
@@ -245,8 +279,14 @@ $1 !~ /^[0-9]+$/ || NF < 3 {
 		metric_add_dimensions(caller, path, auth, pool, decision, "failed_attempts", 1)
 	}
 	if (elapsed_ms ~ /^[0-9]+$/) {
-		elapsed_ms_total += elapsed_ms
+		elapsed_value = elapsed_ms + 0
+		elapsed_ms_total += elapsed_value
+		latency_hist[elapsed_value]++
+		latency_count++
 		metric_add_dimensions(caller, path, auth, pool, decision, "elapsed_ms", elapsed_ms)
+	} else {
+		unknown_elapsed_attempts++
+		metric_add_dimensions(caller, path, auth, pool, decision, "unknown_elapsed_attempts", 1)
 	}
 	if (quota_cost ~ /^[0-9]+$/) {
 		known_quota_cost += quota_cost
@@ -260,9 +300,11 @@ $1 !~ /^[0-9]+$/ || NF < 3 {
 
 END {
 	effective_window_seconds = 0
-	if (first_retained_attempt_ts > 0 && last_retained_attempt_ts >= first_retained_attempt_ts) {
-		effective_window_seconds = last_retained_attempt_ts - first_retained_attempt_ts
+	if (first_window_attempt_ts > 0 && last_window_attempt_ts >= first_window_attempt_ts) {
+		effective_window_seconds = last_window_attempt_ts - first_window_attempt_ts
 	}
+	request_p50_ms = percentile(latency_hist, latency_count, 50)
+	request_p95_ms = percentile(latency_hist, latency_count, 95)
 	attempts_exact = (duplicate_attempt_ids == 0 && unidentified_attempts == 0 && unknown_page_attempts == 0 && window_malformed_v2_records == 0) ? "true" : "false"
 
 	print "{"
@@ -272,9 +314,11 @@ END {
 	printf "    \"since_ts\": %d,\n", cutoff
 	printf "    \"requested_window_seconds\": %d,\n", window
 	printf "    \"window_seconds\": %d,\n", window
-	printf "    \"first_retained_ts\": %d,\n", first_retained_attempt_ts + 0
-	printf "    \"last_retained_ts\": %d,\n", last_retained_attempt_ts + 0
+	printf "    \"first_retained_ts\": %d,\n", first_window_attempt_ts + 0
+	printf "    \"last_retained_ts\": %d,\n", last_window_attempt_ts + 0
 	printf "    \"effective_window_seconds\": %d,\n", effective_window_seconds
+	printf "    \"first_observed_attempt_ts\": %d,\n", first_observed_attempt_ts + 0
+	printf "    \"last_observed_attempt_ts\": %d,\n", last_observed_attempt_ts + 0
 	printf "    \"first_retained_record_ts\": %d,\n", first_retained_record_ts + 0
 	printf "    \"last_retained_record_ts\": %d,\n", last_retained_record_ts + 0
 	printf "    \"retained_records\": %d,\n", retained_records + 0
@@ -283,6 +327,7 @@ END {
 	printf "    \"logical_operations\": %d,\n", logical_operations + 0
 	printf "    \"logical_events\": %d,\n", logical_events
 	printf "    \"cache_events\": %d,\n", cache_events
+	printf "    \"evidence_events\": %d,\n", evidence_events
 	printf "    \"legacy_events\": %d,\n", legacy_events
 	printf "    \"attempted_requests\": %d,\n", attempted_requests
 	printf "    \"opaque_paginated_attempts\": %d,\n", opaque_paginated_attempts + 0
@@ -292,6 +337,10 @@ END {
 	printf "    \"successful_attempts\": %d,\n", successful_attempts + 0
 	printf "    \"failed_attempts\": %d,\n", failed_attempts + 0
 	printf "    \"elapsed_ms\": %d,\n", elapsed_ms_total + 0
+	printf "    \"unknown_elapsed_attempts\": %d,\n", unknown_elapsed_attempts + 0
+	printf "    \"request_p50_ms\": %d,\n", request_p50_ms + 0
+	printf "    \"request_p95_ms\": %d,\n", request_p95_ms + 0
+	printf "    \"peak_attempts_per_minute\": %d,\n", peak_attempts_per_minute + 0
 	printf "    \"known_quota_cost\": %d,\n", known_quota_cost + 0
 	printf "    \"unknown_quota_cost_attempts\": %d,\n", unknown_quota_cost_attempts + 0
 	printf "    \"duplicate_attempt_ids\": %d,\n", duplicate_attempt_ids + 0

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -53,6 +53,9 @@
 #                                   ~/.aidevops/logs/gh-api-calls.log)
 #   AIDEVOPS_GH_API_REPORT       — path to the JSON report (default
 #                                   ~/.aidevops/logs/gh-api-calls-by-stage.json)
+#   AIDEVOPS_GH_API_EVIDENCE     — path to the digest-bound evidence sidecar
+#                                   (default ~/.aidevops/logs/gh-api-efficiency-evidence.json)
+#   AIDEVOPS_GH_API_EVIDENCE_DISABLE=1 — skip automatic sidecar generation
 #   AIDEVOPS_GH_API_LOG_MAX_LINES — when set and exceeded, trim() retains
 #                                   the newest bounded records (default 50000)
 #   AIDEVOPS_GH_API_LOG_MAX_BYTES — maximum retained log bytes (default 16 MiB)
@@ -104,6 +107,7 @@ case "$_GH_API_HOME" in
 esac
 GH_API_LOG="${AIDEVOPS_GH_API_LOG:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls.log}"
 GH_API_REPORT="${AIDEVOPS_GH_API_REPORT:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls-by-stage.json}"
+GH_API_EVIDENCE="${AIDEVOPS_GH_API_EVIDENCE:-${_GH_API_HOME}/.aidevops/logs/gh-api-efficiency-evidence.json}"
 GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"
 GH_API_LOG_MAX_BYTES="${AIDEVOPS_GH_API_LOG_MAX_BYTES:-16777216}"
 GH_API_RETENTION_SECONDS="${AIDEVOPS_GH_API_RETENTION_SECONDS:-172800}"
@@ -391,6 +395,27 @@ gh_record_call() {
 	return 0
 }
 
+# --- gh_record_efficiency_evidence <name> [value] -----------------------
+# Append a typed, privacy-safe benchmark evidence event. Names and values are
+# restricted to bounded identifiers; repository names, URLs, payloads, and
+# credentials are never accepted. Returns 1 for an invalid event.
+gh_record_efficiency_evidence() {
+	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
+	local name="$1"
+	local value="${2:-1}"
+	local decision=""
+	if [[ ! "$name" =~ ^[a-z][a-z0-9_.-]{0,95}$ ]]; then
+		return 1
+	fi
+	if [[ ! "$value" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+		return 1
+	fi
+	decision="evidence:${name}:${value}"
+	_gh_append_v2 evidence github-api-efficiency other unknown other "$decision" \
+		"" "" "" "" "" "" "" "" ""
+	return 0
+}
+
 # --- gh_record_attempt ---------------------------------------------------
 # Record one completed native transport try/page. Arguments are metadata only;
 # command argv never enters the record.
@@ -474,65 +499,76 @@ gh_run_transport_attempt() {
 	return "$rc"
 }
 
+# Generate a digest-bound sidecar for the production aggregate. Evidence build
+# failures remain fail-open for the host process and fail-closed for comparison.
+_gh_write_efficiency_sidecar() {
+	local report="$1"
+	local output="${2:-$GH_API_EVIDENCE}"
+	local script_dir="${BASH_SOURCE[0]%/*}"
+	local producer="${script_dir}/github-api-efficiency-evidence.sh"
+	[[ "${AIDEVOPS_GH_API_EVIDENCE_DISABLE:-0}" != "1" ]] || return 0
+	[[ -f "$report" && -x "$producer" ]] || return 0
+	if ! "$producer" build --transport-report "$report" --output "$output" >/dev/null 2>&1; then
+		rm -f "$output" 2>/dev/null || true
+	fi
+	return 0
+}
+
 # --- gh_aggregate_calls [out_path] [window_secs] -------------------------
-# Read the log, write a JSON report keyed by caller. Counts entries newer
-# than `now - window_secs` (default 86400 = 24h). awk-only aggregation
-# keeps this independent of jq for the hot path; jq is used only if a
-# downstream caller decides to post-process the file.
-#
-# Output JSON shape:
-#   {
-#     "_meta": {
-#       "generated_at_ts": 1730000000,
-#       "since_ts":        1729913600,
-#       "window_seconds":  86400,
-#       "total_calls":     123
-#     },
-#     "by_caller": {
-#       "pulse-batch-prefetch-helper.sh": {
-#         "graphql_calls":        0,
-#         "rest_calls":           48,
-#         "search_graphql_calls": 0,
-#         "search_rest_calls":    24,
-#         "other_calls":          0,
-#         "total":                72
-#       }
-#     }
-#   }
-#
-# Args:
-#   $1 out_path    — defaults to $GH_API_REPORT
-#   $2 window_secs — defaults to 86400 (24 hours)
-#
-# Returns: 0 on success, 1 if log missing.
+# Read the log and atomically publish a deterministic JSON report. Successful
+# production reports automatically receive a SHA-256-bound evidence sidecar.
 gh_aggregate_calls() {
 	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
 	local out="${1:-$GH_API_REPORT}"
 	local window="${2:-86400}"
-	local now cutoff
-	now=$(date +%s)
+	local now=""
+	local cutoff=0
+	local out_dir="."
+	local tmp=""
+	local awk_script=""
+	[[ "$window" =~ ^[1-9][0-9]*$ ]] || window=86400
+	now=$(_gh_now_seconds) || return 1
 	cutoff=$((now - window))
-	mkdir -p "${out%/*}" 2>/dev/null || true
+	if [[ "$out" == */* ]]; then
+		out_dir="${out%/*}"
+	fi
+	mkdir -p "$out_dir" 2>/dev/null || return 1
+	tmp=$(mktemp "${out}.tmp.XXXXXX" 2>/dev/null) || return 1
+	chmod 600 "$tmp" 2>/dev/null || {
+		rm -f "$tmp"
+		return 1
+	}
 	if [[ ! -f "$GH_API_LOG" ]]; then
 		printf '{"_meta":{"%s":"no-log","schema_version":2,"requested_window_seconds":%d,"window_seconds":%d},"by_caller":{}}\n' \
-			"$GH_API_ERROR_KEY" \
-			"$window" \
-			"$window" >"$out" 2>/dev/null || true
+			"$GH_API_ERROR_KEY" "$window" "$window" >"$tmp" 2>/dev/null || {
+			rm -f "$tmp"
+			return 1
+		}
+		mv "$tmp" "$out" 2>/dev/null || {
+			rm -f "$tmp"
+			return 1
+		}
 		return 1
 	fi
-	# The awk aggregator lives in a sibling file so the line-based
-	# pre-commit positional-param validator does not flag awk's `$1` field
-	# references as bash positional params (they live inside multi-line
-	# single-quoted blocks the validator can't see).
-	local awk_script
-	awk_script="$(dirname "${BASH_SOURCE[0]}")/gh-api-aggregate.awk"
+	awk_script="${BASH_SOURCE[0]%/*}/gh-api-aggregate.awk"
 	if [[ ! -f "$awk_script" ]]; then
 		printf '{"_meta":{"%s":"missing-awk-script","path":"%s"},"by_caller":{}}\n' \
-			"$GH_API_ERROR_KEY" "$awk_script" >"$out" 2>/dev/null || true
+			"$GH_API_ERROR_KEY" "$awk_script" >"$tmp" 2>/dev/null || true
+		mv "$tmp" "$out" 2>/dev/null || rm -f "$tmp"
 		return 1
 	fi
-	awk -F'\t' -v now="$now" -v cutoff="$cutoff" -v window="$window" \
-		-f "$awk_script" "$GH_API_LOG" >"$out" 2>/dev/null || return 1
+	if ! awk -F'\t' -v now="$now" -v cutoff="$cutoff" -v window="$window" \
+		-f "$awk_script" "$GH_API_LOG" >"$tmp" 2>/dev/null; then
+		rm -f "$tmp"
+		return 1
+	fi
+	if ! mv "$tmp" "$out" 2>/dev/null; then
+		rm -f "$tmp"
+		return 1
+	fi
+	if [[ "$out" == "$GH_API_REPORT" ]]; then
+		_gh_write_efficiency_sidecar "$out" "$GH_API_EVIDENCE"
+	fi
 	return 0
 }
 
@@ -585,7 +621,7 @@ gh_trim_log() {
 # --- gh_clear_log ---------------------------------------------------------
 # Remove the log + report. Used by tests and by the `clear` subcommand.
 gh_clear_log() {
-	rm -f "$GH_API_LOG" "$GH_API_REPORT" 2>/dev/null
+	rm -f "$GH_API_LOG" "$GH_API_REPORT" "$GH_API_EVIDENCE" 2>/dev/null
 	return 0
 }
 
@@ -597,6 +633,9 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 	case "$cmd" in
 	record)
 		gh_record_call "$@"
+		;;
+	evidence)
+		gh_record_efficiency_evidence "$@"
 		;;
 	report | aggregate)
 		gh_aggregate_calls "$@"
@@ -614,7 +653,8 @@ gh-api-instrument.sh — gh API call instrumentation (t2902)
 
 Subcommands:
   record <path> [caller] [auth] [pool] [decision] [budget]
-                          Append one record to ${GH_API_LOG##*/}
+                          Append one routing/cache record
+  evidence <name> [value] Append one typed benchmark evidence record
   report [out] [window_s]  Aggregate to JSON (default ${GH_API_REPORT##*/}, 24h)
   trim                     Atomically apply age, line, and byte retention bounds
   clear                    Remove log + report

--- a/.agents/scripts/github-api-efficiency-benchmark.py
+++ b/.agents/scripts/github-api-efficiency-benchmark.py
@@ -8,13 +8,12 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import os
 from pathlib import Path
 import re
 import sys
-import tempfile
 
 from github_api_efficiency_inputs import BenchmarkInputError, build_window
+from github_api_efficiency_io import AtomicWriteError, atomic_write_text
 from github_api_efficiency_report import (
     EXIT_INCONCLUSIVE,
     EXIT_REGRESSION,
@@ -30,38 +29,10 @@ _LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._ -]{0,63}$")
 
 
 def _atomic_write(path: Path, content: str) -> None:
-    descriptor = -1
-    temporary_name = ""
     try:
-        if path.is_symlink():
-            raise BenchmarkInputError("output path must not be a symlink")
-        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        descriptor, temporary_name = tempfile.mkstemp(
-            prefix=f".{path.name}.", dir=path.parent
-        )
-        if hasattr(os, "fchmod"):
-            os.fchmod(descriptor, 0o600)
-        handle = os.fdopen(descriptor, "w", encoding="utf-8")
-        descriptor = -1
-        with handle:
-            handle.write(content)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temporary_name, path)
-    except BenchmarkInputError:
-        raise
-    except OSError as exc:
-        raise BenchmarkInputError(
-            "could not atomically write an output report"
-        ) from exc
-    finally:
-        if descriptor >= 0:
-            os.close(descriptor)
-        if temporary_name:
-            try:
-                os.unlink(temporary_name)
-            except FileNotFoundError:
-                pass
+        atomic_write_text(path, content)
+    except AtomicWriteError as exc:
+        raise BenchmarkInputError(str(exc)) from exc
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/.agents/scripts/github-api-efficiency-evidence.py
+++ b/.agents/scripts/github-api-efficiency-evidence.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Build a digest-bound GitHub API efficiency evidence sidecar."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any, Callable
+
+from github_api_efficiency_inputs import (
+    BenchmarkInputError,
+    EVIDENCE_GROUPS,
+    EVIDENCE_SCHEMA,
+    POPULATION_FIELDS,
+    load_transport_report,
+)
+from github_api_efficiency_events import (
+    EvidenceBuildError,
+    _event_map,
+    _non_negative_int,
+)
+from github_api_efficiency_io import AtomicWriteError, atomic_write_text
+
+
+CONTRACT_VERSION = "1"
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_COVERAGE_GROUPS = tuple(("population", *EVIDENCE_GROUPS.keys()))
+
+
+
+def _parsed_values(
+    events: dict[str, Counter[str]], name: str, parser: Callable[[str], Any]
+) -> list[Any]:
+    try:
+        return [parser(value) for value in events.get(name, {})]
+    except (TypeError, ValueError) as exc:
+        raise EvidenceBuildError(f"evidence {name} contains an invalid value") from exc
+
+
+def _snapshot(
+    events: dict[str, Counter[str]], name: str, parser: Callable[[str], Any]
+) -> Any | None:
+    values = _parsed_values(events, name, parser)
+    if not values:
+        return None
+    if len(set(values)) != 1:
+        raise EvidenceBuildError(f"evidence {name} contains conflicting snapshots")
+    return values[0]
+
+
+def _extreme_int(
+    events: dict[str, Counter[str]], name: str, selector: Callable[[list[int]], int]
+) -> int | None:
+    values = _parsed_values(events, name, int)
+    if any(value < 0 for value in values):
+        raise EvidenceBuildError(f"evidence {name} must be non-negative")
+    return selector(values) if values else None
+
+
+def _sum_event(events: dict[str, Counter[str]], name: str) -> int:
+    total = 0
+    for value, count in events.get(name, {}).items():
+        try:
+            parsed = int(value)
+        except ValueError as exc:
+            raise EvidenceBuildError(
+                f"evidence {name} contains an invalid integer"
+            ) from exc
+        number = _non_negative_int(parsed, f"evidence {name}")
+        total += number * count
+    return total
+
+
+def _unique_actionable_heads(
+    events: dict[str, Counter[str]], actionable: int
+) -> int | None:
+    failures = _sum_event(events, "population.actionable_head_hash_failures")
+    if failures:
+        return None
+    tokens = events.get("population.actionable_head_token", {})
+    legacy = events.get("population.unique_actionable_head_shas", {})
+    if tokens and legacy:
+        raise EvidenceBuildError("actionable head evidence mixes tokens and legacy counts")
+    if tokens:
+        if any(not _SHA256_RE.fullmatch(token) for token in tokens):
+            raise EvidenceBuildError("actionable head tokens must be lowercase SHA-256")
+        unique = len(tokens)
+    elif legacy:
+        unique = _sum_event(events, "population.unique_actionable_head_shas")
+    elif actionable:
+        return None
+    else:
+        unique = 0
+    if unique > actionable:
+        raise EvidenceBuildError("unique actionable heads exceed actionable changes")
+    return unique
+
+
+def _sample_percentile(
+    events: dict[str, Counter[str]], name: str, percent: int
+) -> int | None:
+    samples = events.get(name, {})
+    total = sum(samples.values())
+    if total < 1:
+        return None
+    target = (total * percent + 99) // 100
+    cumulative = 0
+    for value in sorted(samples, key=int):
+        number = _non_negative_int(int(value), f"evidence {name}")
+        cumulative += samples[value]
+        if cumulative >= target:
+            return number
+    raise EvidenceBuildError(f"evidence {name} percentile could not be computed")
+
+
+def _window_is_bounded(
+    contract: Any, start: int | None, end: int | None, first: int, last: int
+) -> bool:
+    if contract != CONTRACT_VERSION or start is None or end is None:
+        return False
+    if start > first:
+        return False
+    return end >= last
+
+
+def _coverage(
+    events: dict[str, Counter[str]], meta: dict[str, Any]
+) -> tuple[dict[str, bool], int | None, int | None]:
+    start = _extreme_int(events, "coverage-start", min)
+    end = _extreme_int(events, "coverage-end", max)
+    contract = _snapshot(events, "contract", str)
+    first = _non_negative_int(meta.get("first_retained_ts"), "first retained timestamp")
+    last = _non_negative_int(meta.get("last_retained_ts"), "last retained timestamp")
+    bounded = _window_is_bounded(contract, start, end, first, last)
+    groups = {
+        group: bounded and _snapshot(events, f"coverage.{group}", str) == CONTRACT_VERSION
+        for group in _COVERAGE_GROUPS
+    }
+    if _non_negative_int(
+        meta.get("unknown_elapsed_attempts"), "unknown elapsed attempts"
+    ):
+        groups["latency"] = False
+    return groups, start, end
+
+
+def _covered_count(
+    events: dict[str, Counter[str]], name: str, covered: bool
+) -> int | None:
+    return _sum_event(events, name) if covered else None
+
+
+def _meta_count(meta: dict[str, Any], name: str, covered: bool) -> int | None:
+    if not covered:
+        return None
+    value = meta.get(name)
+    if type(value) is not int or value < 0:
+        return None
+    return value
+
+
+def _build_population(
+    events: dict[str, Counter[str]], covered: bool
+) -> dict[str, int | str | None]:
+    if not covered:
+        return {**{field: None for field in POPULATION_FIELDS}, "repository_set_sha256": None}
+    repository_count = _snapshot(events, "population.repository_count", int)
+    repository_hash = _snapshot(events, "population.repository_set_sha256", str)
+    if repository_count is not None:
+        _non_negative_int(repository_count, "repository count")
+    if repository_hash is not None and not _SHA256_RE.fullmatch(repository_hash):
+        raise EvidenceBuildError("repository set digest must be lowercase SHA-256")
+    actionable = _sum_event(events, "population.actionable_changes")
+    return {
+        "repository_count": repository_count,
+        "pulse_cycles": _sum_event(events, "population.pulse_cycles"),
+        "unchanged_cycles": _sum_event(events, "population.unchanged_cycles"),
+        "actionable_changes": actionable,
+        "unique_actionable_head_shas": _unique_actionable_heads(
+            events, actionable
+        ),
+        "repository_set_sha256": repository_hash,
+    }
+
+
+def _missing_fields(payload: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+    population = payload["population"]
+    for field in (*POPULATION_FIELDS, "repository_set_sha256"):
+        if population[field] is None:
+            missing.append(f"population.{field}")
+    for group, fields in EVIDENCE_GROUPS.items():
+        for field in fields:
+            if payload[group][field] is None:
+                missing.append(f"{group}.{field}")
+    return missing
+
+
+def _build_count_group(
+    events: dict[str, Counter[str]], group: str, covered: bool
+) -> dict[str, int | None]:
+    return {
+        field: _covered_count(events, f"{group}.{field}", covered)
+        for field in EVIDENCE_GROUPS[group]
+    }
+
+
+def _build_latency(
+    events: dict[str, Counter[str]], meta: dict[str, Any], covered: bool
+) -> dict[str, int | None]:
+    return {
+        "p50_ms": _meta_count(meta, "request_p50_ms", covered),
+        "p95_ms": _meta_count(meta, "request_p95_ms", covered),
+        "peak_attempts_per_minute": _meta_count(
+            meta, "peak_attempts_per_minute", covered
+        ),
+        "completed_action_p95_ms": (
+            _sample_percentile(events, "latency.completed_action_ms", 95)
+            if covered
+            else None
+        ),
+    }
+
+
+def _build_webhook(
+    events: dict[str, Counter[str]], covered: bool
+) -> dict[str, int | None]:
+    return {
+        "invalidations": _covered_count(events, "webhook.invalidations", covered),
+        "lag_p50_ms": (
+            _sample_percentile(events, "webhook.lag_ms", 50) if covered else None
+        ),
+        "lag_p95_ms": (
+            _sample_percentile(events, "webhook.lag_ms", 95) if covered else None
+        ),
+        "duplicate_actions": _covered_count(
+            events, "webhook.duplicate_actions", covered
+        ),
+        "missed_recoveries": _covered_count(
+            events, "webhook.missed_recoveries", covered
+        ),
+    }
+
+
+def build_sidecar(report: dict[str, Any], transport_sha256: str) -> dict[str, Any]:
+    meta = report["_meta"]
+    events = _event_map(report)
+    covered, start, end = _coverage(events, meta)
+    payload: dict[str, Any] = {
+        "schema": EVIDENCE_SCHEMA,
+        "transport_sha256": transport_sha256,
+        "complete": False,
+        "population": _build_population(events, covered["population"]),
+        "latency": _build_latency(events, meta, covered["latency"]),
+        "cache": _build_count_group(events, "cache", covered["cache"]),
+        "single_flight": _build_count_group(
+            events, "single_flight", covered["single_flight"]
+        ),
+        "webhook": _build_webhook(events, covered["webhook"]),
+    }
+    for group in ("guardrails", "path_budgets"):
+        payload[group] = _build_count_group(events, group, covered[group])
+    missing = _missing_fields(payload)
+    payload["complete"] = not missing and all(covered.values())
+    payload["_meta"] = {
+        "contract_version": CONTRACT_VERSION,
+        "coverage_start_ts": start,
+        "coverage_end_ts": end,
+        "coverage_groups": covered,
+        "missing_fields": missing,
+    }
+    return payload
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("build",))
+    parser.add_argument("--transport-report", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        if args.transport_report.resolve(strict=False) == args.output.resolve(strict=False):
+            raise EvidenceBuildError("output must be distinct from the transport report")
+        report, transport_sha256 = load_transport_report(args.transport_report)
+        payload = build_sidecar(report, transport_sha256)
+        content = json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+        atomic_write_text(args.output, content)
+    except (AtomicWriteError, BenchmarkInputError, EvidenceBuildError) as exc:
+        print(f"github-api-efficiency-evidence: {exc}", file=sys.stderr)
+        return 2
+    status = "complete" if payload["complete"] else "incomplete"
+    print(f"evidence sidecar: {status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/github-api-efficiency-evidence.sh
+++ b/.agents/scripts/github-api-efficiency-evidence.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Thin, dependency-free entrypoint for the GitHub API efficiency sidecar producer.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
+readonly EVIDENCE_ENGINE="${SCRIPT_DIR}/github-api-efficiency-evidence.py"
+
+main() {
+	if ! command -v python3 >/dev/null 2>&1; then
+		printf 'github-api-efficiency-evidence: python3 is required\n' >&2
+		return 2
+	fi
+	if [[ ! -r "$EVIDENCE_ENGINE" ]]; then
+		printf 'github-api-efficiency-evidence: evidence engine is unavailable\n' >&2
+		return 2
+	fi
+	python3 "$EVIDENCE_ENGINE" "$@"
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/github_api_efficiency_events.py
+++ b/.agents/scripts/github_api_efficiency_events.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Parse typed, privacy-safe GitHub API efficiency evidence events."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+import re
+from typing import Any
+
+
+_EVENT_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,95}$")
+_VALUE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+class EvidenceBuildError(ValueError):
+    """Raised when evidence events contradict the sidecar contract."""
+
+
+def _non_negative_int(value: Any, context: str) -> int:
+    if type(value) is not int or value < 0:
+        raise EvidenceBuildError(f"{context} must be a non-negative integer")
+    return value
+
+
+def _event_map(report: dict[str, Any]) -> dict[str, Counter[str]]:
+    decisions = report.get("by_route_decision")
+    if not isinstance(decisions, dict):
+        raise EvidenceBuildError("transport by_route_decision must be an object")
+    events: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    for decision, metrics in decisions.items():
+        if not isinstance(decision, str) or not decision.startswith("evidence:"):
+            continue
+        parts = decision.split(":", 2)
+        if len(parts) != 3 or not _EVENT_RE.fullmatch(parts[1]):
+            raise EvidenceBuildError("transport contains an invalid evidence event name")
+        if not _VALUE_RE.fullmatch(parts[2]):
+            raise EvidenceBuildError("transport contains an invalid evidence event value")
+        if not isinstance(metrics, dict):
+            raise EvidenceBuildError("transport evidence metrics must be objects")
+        count = _non_negative_int(
+            metrics.get("evidence_events"), f"evidence event {parts[1]} count"
+        )
+        if count < 1:
+            raise EvidenceBuildError(
+                "evidence-prefixed decisions must be typed evidence events"
+            )
+        events[parts[1]][parts[2]] += count
+    return dict(events)

--- a/.agents/scripts/github_api_efficiency_inputs.py
+++ b/.agents/scripts/github_api_efficiency_inputs.py
@@ -40,6 +40,7 @@ REPORT_COUNTERS = (
     "successful_attempts",
     "failed_attempts",
     "elapsed_ms",
+    "unknown_elapsed_attempts",
     "known_quota_cost",
     "unknown_quota_cost_attempts",
     "duplicate_attempt_ids",
@@ -289,16 +290,24 @@ def _validate_evidence(
     _validate_evidence_groups(payload)
 
 
+def load_transport_report(
+    path: Path, role: str = "transport report"
+) -> tuple[dict[str, Any], str]:
+    """Load and validate one immutable schema-v2 transport report."""
+    report, transport_sha256 = _load_object(path, role)
+    _validate_report(report)
+    return report, transport_sha256
+
+
 def build_window(
     label: str, report_path: Path, evidence_path: Path
 ) -> Window:
-    report, transport_sha256 = _load_object(
+    report, transport_sha256 = load_transport_report(
         report_path, f"{label} transport report"
     )
     evidence, evidence_sha256 = _load_object(
         evidence_path, f"{label} evidence"
     )
-    _validate_report(report)
     _validate_evidence(evidence, transport_sha256)
     totals, normalized = build_transport_metrics(report, evidence)
     return Window(

--- a/.agents/scripts/github_api_efficiency_io.py
+++ b/.agents/scripts/github_api_efficiency_io.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Atomic output helpers shared by GitHub API efficiency tools."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import tempfile
+
+
+class AtomicWriteError(OSError):
+    """Raised when an output cannot be written atomically."""
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Write private UTF-8 text and atomically replace the target."""
+    descriptor = -1
+    temporary_name = ""
+    try:
+        if path.is_symlink():
+            raise AtomicWriteError("output path must not be a symlink")
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{path.name}.", dir=path.parent
+        )
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, 0o600)
+        handle = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        with handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except AtomicWriteError:
+        raise
+    except OSError as exc:
+        raise AtomicWriteError("could not atomically write output") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if temporary_name:
+            try:
+                os.unlink(temporary_name)
+            except FileNotFoundError:
+                pass

--- a/.agents/scripts/github_api_efficiency_report.py
+++ b/.agents/scripts/github_api_efficiency_report.py
@@ -90,6 +90,7 @@ def _window_inconclusive_reasons(window: Window) -> list[str]:
     )
     health_fields = {
         "unknown_quota_cost_attempts": "quota cost is unknown",
+        "unknown_elapsed_attempts": "request latency is unknown",
         "duplicate_attempt_ids": "duplicate attempt IDs exist",
         "unidentified_attempts": "unidentified attempts exist",
         "unknown_page_attempts": "unknown page attempts exist",

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -73,6 +73,14 @@ if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
 	source "${SCRIPT_DIR}/shared-constants.sh"
 fi
 
+# Source privacy-safe efficiency instrumentation for cache/single-flight events.
+# shellcheck source=./gh-api-instrument.sh
+# shellcheck disable=SC1091
+if ! declare -F gh_record_efficiency_evidence >/dev/null 2>&1 \
+	&& [[ -f "${SCRIPT_DIR}/gh-api-instrument.sh" ]]; then
+	source "${SCRIPT_DIR}/gh-api-instrument.sh"
+fi
+
 # Source L1 events ETag tickle helper (t2830, GH#20868).
 # Provides events_tickle <owner> — skips batch search on 304 ETag match.
 # Fail-open: if the file is absent, events_tickle is a no-op stub below.
@@ -125,6 +133,8 @@ _JSON_TYPE_STRING=string
 _STATE_OPEN="open"
 _CACHE_STATE_MALFORMED="malformed"
 _CACHE_STATE_INVALIDATED="invalidated"
+_CACHE_CARDINALITY_EMPTY=empty
+_CACHE_CARDINALITY_UNKNOWN=unknown
 _CACHE_SNAPSHOT_STATE="missing"
 _CACHE_SNAPSHOT_PATH=""
 _SNAPSHOT_SCHEMA="aidevops-pulse-snapshot/v1"
@@ -1179,11 +1189,43 @@ _resolve_cache_snapshot() {
 	return 0
 }
 
+_record_cache_state_evidence() {
+	local state="$1"
+	local cardinality="${2:-$_CACHE_CARDINALITY_UNKNOWN}"
+	declare -F gh_record_efficiency_evidence >/dev/null 2>&1 || return 0
+	case "$state" in
+	hit)
+		if [[ "$cardinality" == "$_CACHE_CARDINALITY_EMPTY" ]]; then
+			gh_record_efficiency_evidence cache.fresh_empty_hits 1 2>/dev/null || true
+		else
+			gh_record_efficiency_evidence cache.fresh_hits 1 2>/dev/null || true
+		fi
+		;;
+	stale | malformed | incompatible)
+		gh_record_efficiency_evidence cache.misses 1 2>/dev/null || true
+		gh_record_efficiency_evidence cache.stale 1 2>/dev/null || true
+		gh_record_efficiency_evidence guardrails.stale_snapshot_detections 1 2>/dev/null || true
+		gh_record_efficiency_evidence guardrails.forced_live_refreshes 1 2>/dev/null || true
+		;;
+	invalidated)
+		gh_record_efficiency_evidence cache.misses 1 2>/dev/null || true
+		gh_record_efficiency_evidence cache.invalidated 1 2>/dev/null || true
+		gh_record_efficiency_evidence guardrails.forced_live_refreshes 1 2>/dev/null || true
+		;;
+	missing | disabled)
+		gh_record_efficiency_evidence cache.misses 1 2>/dev/null || true
+		gh_record_efficiency_evidence guardrails.forced_live_refreshes 1 2>/dev/null || true
+		;;
+	esac
+	return 0
+}
+
 _emit_cache_state() {
 	local state="$1"
 	local kind="$2"
 	local slug="$3"
-	local cardinality="${4:-unknown}"
+	local cardinality="${4:-$_CACHE_CARDINALITY_UNKNOWN}"
+	_record_cache_state_evidence "$state" "$cardinality"
 	printf 'cache_state=%s kind=%s slug=%s cardinality=%s\n' \
 		"$state" "$kind" "$slug" "$cardinality" >&2
 	return 0
@@ -1294,7 +1336,7 @@ _cmd_read_cache() {
 	fi
 
 	local cardinality="nonempty"
-	[[ "$items" == "$_JSON_EMPTY_ARR" ]] && cardinality="empty"
+	[[ "$items" == "$_JSON_EMPTY_ARR" ]] && cardinality="$_CACHE_CARDINALITY_EMPTY"
 	_emit_cache_state "$_CACHE_SNAPSHOT_STATE" "$kind" "$slug" "$cardinality"
 	printf '%s\n' "$items"
 	return 0
@@ -1372,7 +1414,7 @@ _cmd_read_snapshot() {
 	}
 
 	local cardinality="nonempty"
-	[[ "$(printf '%s' "$envelope" | jq -c '.items')" == "$_JSON_EMPTY_ARR" ]] && cardinality="empty"
+	[[ "$(printf '%s' "$envelope" | jq -c '.items')" == "$_JSON_EMPTY_ARR" ]] && cardinality="$_CACHE_CARDINALITY_EMPTY"
 	_emit_cache_state "$_CACHE_SNAPSHOT_STATE" "$kind" "$slug" "$cardinality"
 	printf '%s\n' "$envelope"
 	return 0

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -48,6 +48,13 @@ _pmrc_snapshot_log_failure() {
 	return 0
 }
 
+_pmrc_record_preflight_check_mismatch() {
+	if declare -F gh_record_efficiency_evidence >/dev/null 2>&1; then
+		gh_record_efficiency_evidence guardrails.required_check_merge_preflight_mismatches 1 2>/dev/null || true
+	fi
+	return 0
+}
+
 _pmrc_snapshot_checks_json() {
 	local repo_slug="$1"
 	local head_sha="$2"
@@ -593,7 +600,12 @@ _pulse_merge_preflight_snapshot_gate() {
 	_pmrc_review_evidence_permits_advisory "$live_gate_evidence" "$repo_slug" "$pr_number" "$current_head_sha" || live_gate_evidence=""
 	_pmrc_snapshot_review_gate_fresh "$repo_slug" "$pr_number" "$checks_json" "$activity_json" "$live_gate_evidence" || return 1
 	_pmrc_snapshot_review_threads_clear "$repo_slug" "$pr_number" "$base_branch" || return 1
-	_pmrc_snapshot_checks_acceptable "$repo_slug" "$pr_number" "$checks_json" "$required_contexts" "$live_gate_evidence" "$current_head_sha" || return 1
+	if ! _pmrc_snapshot_checks_acceptable \
+		"$repo_slug" "$pr_number" "$checks_json" "$required_contexts" \
+		"$live_gate_evidence" "$current_head_sha"; then
+		_pmrc_record_preflight_check_mismatch
+		return 1
+	fi
 	_pmrc_snapshot_quiet_period_passes "$repo_slug" "$pr_number" "$checks_json" "$activity_json" || return 1
 	echo "[pulse-merge] pre-merge snapshot: current head ${current_head_sha:0:12}, fresh review gate, merge-policy-compatible review threads, terminal checks, and quiet period verified for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
 	return 0

--- a/.agents/scripts/pulse-merge-webhook-receiver.sh
+++ b/.agents/scripts/pulse-merge-webhook-receiver.sh
@@ -106,6 +106,7 @@ WEBHOOK_DELIVERY_MAX_ENTRIES="${WEBHOOK_DELIVERY_MAX_ENTRIES:-4096}"
 WEBHOOK_DISPATCH_MAX_CONCURRENCY="${WEBHOOK_DISPATCH_MAX_CONCURRENCY:-4}"
 WEBHOOK_ACTION_PROTOCOL_VERSION="${WEBHOOK_ACTION_PROTOCOL_VERSION:-v1}"
 _WEBHOOK_INVALIDATION_FAILED=0
+_WEBHOOK_DELIVERY_RECEIVED_MS=0
 mkdir -p "$(dirname "$WEBHOOK_LOG_FILE")"
 
 _whlog() {
@@ -114,6 +115,40 @@ _whlog() {
 	local ts
 	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	printf '[%s] [%s] %s\n' "$ts" "$level" "$*" >>"$WEBHOOK_LOG_FILE"
+	return 0
+}
+
+_webhook_now_ms() {
+	local now_ms=""
+	if declare -F _gh_now_ms >/dev/null 2>&1; then
+		_gh_now_ms || return 1
+		return 0
+	fi
+	now_ms=$(date +%s 2>/dev/null) || return 1
+	[[ "$now_ms" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$((now_ms * 1000))"
+	return 0
+}
+
+_webhook_record_invalidation_evidence() {
+	local received_ms="${_WEBHOOK_DELIVERY_RECEIVED_MS:-0}"
+	local now_ms=""
+	local lag_ms=""
+	declare -F gh_record_efficiency_evidence >/dev/null 2>&1 || return 0
+	gh_record_efficiency_evidence webhook.invalidations 1 2>/dev/null || true
+	[[ "$received_ms" =~ ^[0-9]+$ && "$received_ms" -gt 0 ]] || return 0
+	now_ms=$(_webhook_now_ms) || return 0
+	[[ "$now_ms" =~ ^[0-9]+$ && "$now_ms" -ge "$received_ms" ]] || return 0
+	lag_ms=$((now_ms - received_ms))
+	[[ "$lag_ms" -le 604800000 ]] || return 0
+	gh_record_efficiency_evidence webhook.lag_ms "$lag_ms" 2>/dev/null || true
+	return 0
+}
+
+_webhook_record_missed_recovery() {
+	if declare -F gh_record_efficiency_evidence >/dev/null 2>&1; then
+		gh_record_efficiency_evidence webhook.missed_recoveries 1 2>/dev/null || true
+	fi
 	return 0
 }
 
@@ -200,26 +235,53 @@ _dispatch_webhook_action_line() {
 	case "$line" in
 	'#'*)
 		_whlog INFO "${line#'# '}"
-		[[ "$line" == '# accepted '* ]] && _WEBHOOK_INVALIDATION_FAILED=0
+		if [[ "$line" == '# accepted '* ]]; then
+			_WEBHOOK_INVALIDATION_FAILED=0
+			_WEBHOOK_DELIVERY_RECEIVED_MS=0
+		fi
 		return 0
 		;;
 	'') return 0 ;;
 	esac
 	IFS=' ' read -r verb version scope first second extra <<<"$line"
 	case "${verb} ${version} ${scope}" in
+	"DELIVERY v1 received-ms")
+		if [[ "$first" =~ ^[0-9]+$ && "$first" -gt 0 \
+			&& -z "$second" && -z "$extra" ]]; then
+			_WEBHOOK_DELIVERY_RECEIVED_MS="$first"
+			_WEBHOOK_INVALIDATION_FAILED=0
+		else
+			_WEBHOOK_DELIVERY_RECEIVED_MS=0
+			_WEBHOOK_INVALIDATION_FAILED=1
+			_whlog ERROR "Rejected malformed delivery timing record"
+		fi
+		return 0
+		;;
 	"INVALIDATE v1 collection")
 		_WEBHOOK_INVALIDATION_FAILED=0
-		if [[ -n "$extra" ]] || ! _webhook_invalidate_collection "$first" "$second"; then
+		if [[ -n "$extra" ]]; then
 			_WEBHOOK_INVALIDATION_FAILED=1
-			_whlog ERROR "Rejected or failed collection invalidation record"
+			_whlog ERROR "Rejected malformed collection invalidation record"
+		elif ! _webhook_invalidate_collection "$first" "$second"; then
+			_WEBHOOK_INVALIDATION_FAILED=1
+			_webhook_record_missed_recovery
+			_whlog ERROR "Failed collection invalidation; polling recovery remains active"
+		else
+			_webhook_record_invalidation_evidence
 		fi
 		return 0
 		;;
 	"INVALIDATE v1 checks")
 		_WEBHOOK_INVALIDATION_FAILED=0
-		if [[ -n "$extra" ]] || ! _webhook_invalidate_checks "$first" "$second"; then
+		if [[ -n "$extra" ]]; then
 			_WEBHOOK_INVALIDATION_FAILED=1
-			_whlog ERROR "Rejected or failed check invalidation record"
+			_whlog ERROR "Rejected malformed check invalidation record"
+		elif ! _webhook_invalidate_checks "$first" "$second"; then
+			_WEBHOOK_INVALIDATION_FAILED=1
+			_webhook_record_missed_recovery
+			_whlog ERROR "Failed check invalidation; polling recovery remains active"
+		else
+			_webhook_record_invalidation_evidence
 		fi
 		return 0
 		;;
@@ -347,6 +409,8 @@ cmd_run() {
 	# callable from the dispatch loop below. We mirror pulse-merge-routine.sh.
 	# shellcheck source=/dev/null
 	source "${SCRIPT_DIR}/shared-constants.sh"
+	# shellcheck source=/dev/null
+	source "${SCRIPT_DIR}/gh-api-instrument.sh"
 	# shellcheck source=/dev/null
 	source "${SCRIPT_DIR}/shared-gh-wrappers-checks.sh"
 	# shellcheck source=/dev/null

--- a/.agents/scripts/pulse-merge-webhook-server.py
+++ b/.agents/scripts/pulse-merge-webhook-server.py
@@ -470,8 +470,11 @@ def _record_delivery(
     return "accepted"
 
 
-def _emit_records(invalidations: list[str], actions: list[tuple[str, int]]) -> None:
+def _emit_records(
+    invalidations: list[str], actions: list[tuple[str, int]], received_ms: int
+) -> None:
     with _OUTPUT_LOCK:
+        sys.stdout.write(f"DELIVERY {_ACTION_PROTOCOL} received-ms {received_ms}\n")
         for record in invalidations:
             sys.stdout.write(f"{record}\n")
         for slug, number in actions:
@@ -573,6 +576,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     def _accept_delivery(
         self, body: bytes, delivery_id: str, event: str, payload: dict[str, Any]
     ) -> None:
+        received_ms = time.time_ns() // 1_000_000
         invalidations = _invalidation_records(event, payload)
         actions = _process_pr_actions(event, payload)
         fingerprint = hashlib.sha256(body).hexdigest()
@@ -588,7 +592,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             return
         if self._respond_to_replay(decision, event, delivery_id):
             return
-        _emit_records(invalidations, actions)
+        _emit_records(invalidations, actions, received_ms)
         _log(
             f"accepted event={event} delivery={delivery_id} "
             f"invalidations={len(invalidations)} actions={len(actions)}"

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -48,6 +48,7 @@ fi
 _PREFETCH_PR_SWEEP_FULL=full
 _PREFETCH_BOOL_TRUE=true
 _PREFETCH_JSON_NULL=null
+_PREFETCH_JSON_TYPE_ARRAY=array
 _PREFETCH_UNKNOWN=unknown
 _PREFETCH_UNKNOWN_ERROR="unknown error"
 
@@ -216,6 +217,61 @@ _prefetch_log_batch_cache_state() {
 	return 0
 }
 
+#######################################
+# Read a validated item array from a canonical snapshot envelope.
+# Arguments: $1=canonical snapshot envelope
+#######################################
+_prefetch_snapshot_items() {
+	local canonical_snapshot="$1"
+	printf '%s' "$canonical_snapshot" |
+		jq -ce --arg array_type "$_PREFETCH_JSON_TYPE_ARRAY" \
+			'.items | select(type == $array_type)' 2>/dev/null
+	return $?
+}
+
+#######################################
+# Record an invariant violation only when a live fallback follows an
+# authoritative fresh-empty canonical snapshot.
+# Arguments: $1=snapshot-supplied bool, $2=canonical snapshot envelope
+#######################################
+_prefetch_record_fresh_empty_live_fallback() {
+	local snapshot_supplied="$1"
+	local canonical_snapshot="$2"
+	local items=""
+	[[ "$snapshot_supplied" == "$_PREFETCH_BOOL_TRUE" ]] || return 0
+	items=$(_prefetch_snapshot_items "$canonical_snapshot") || return 0
+	[[ "$items" == "[]" ]] || return 0
+	if declare -F gh_record_efficiency_evidence >/dev/null 2>&1; then
+		gh_record_efficiency_evidence path_budgets.fresh_empty_live_fallbacks 1 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
+# Fetch the complete open-PR projection while preserving rate-limit state.
+# Arguments: $1=slug, $2=error file
+# Sets PREFETCH_PR_RESULT.
+#######################################
+_prefetch_prs_fetch_full() {
+	local slug="$1"
+	local pr_err="$2"
+	local err_msg=""
+
+	PREFETCH_PR_RESULT=$(gh_pr_list --repo "$slug" --state open \
+		--json number,title,reviewDecision,updatedAt,headRefName,headRefOid,createdAt,author \
+		--limit "$PULSE_PREFETCH_PR_LIMIT" 2>"$pr_err") || PREFETCH_PR_RESULT=""
+	if [[ -z "$PREFETCH_PR_RESULT" || "$PREFETCH_PR_RESULT" == "$_PREFETCH_JSON_NULL" ]]; then
+		err_msg=$(cat "$pr_err" 2>/dev/null || echo "$_PREFETCH_UNKNOWN_ERROR")
+		if _pulse_gh_err_is_rate_limit "$pr_err"; then
+			_pulse_mark_rate_limited "_prefetch_repo_prs:${slug}"
+		fi
+		echo "[pulse-wrapper] _prefetch_repo_prs: gh_pr_list FAILED for ${slug}: ${err_msg}" >>"$LOGFILE"
+		_prefetch_log_batch_cache_state fetch-failed prs "$slug"
+		PREFETCH_PR_RESULT="[]"
+	fi
+	return 0
+}
+
 _prefetch_repo_prs() {
 	local slug="$1"
 	local cache_entry="${2:-}"
@@ -248,7 +304,7 @@ _prefetch_repo_prs() {
 	local _used_batch_cache=false
 	if [[ "$canonical_snapshot_supplied" == "$_PREFETCH_BOOL_TRUE" ]]; then
 		local _canonical_prs=""
-		if _canonical_prs=$(printf '%s' "$canonical_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
+		if _canonical_prs=$(_prefetch_snapshot_items "$canonical_snapshot"); then
 			pr_json="$_canonical_prs"
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_prs: using cycle canonical snapshot for ${slug}" >>"$LOGFILE"
@@ -267,6 +323,8 @@ _prefetch_repo_prs() {
 	fi
 
 	if [[ "$_used_batch_cache" == "false" ]]; then
+		_prefetch_record_fresh_empty_live_fallback \
+			"$canonical_snapshot_supplied" "$canonical_snapshot"
 		# Delta fetch: try merging recent changes into cache (GH#15286)
 		PREFETCH_PR_SWEEP_MODE="$sweep_mode"
 		PREFETCH_PR_RESULT=""
@@ -277,23 +335,9 @@ _prefetch_repo_prs() {
 		fi
 
 		# Full fetch: either requested directly or delta fell back.
-		# headRefOid required for REST check-suites lookup (GH#21799).
 		if [[ "$sweep_mode" == "$_PREFETCH_PR_SWEEP_FULL" ]]; then
-			pr_json=$(gh_pr_list --repo "$slug" --state open \
-				--json number,title,reviewDecision,updatedAt,headRefName,headRefOid,createdAt,author \
-				--limit "$PULSE_PREFETCH_PR_LIMIT" 2>"$pr_err") || pr_json=""
-
-			if [[ -z "$pr_json" || "$pr_json" == "$_PREFETCH_JSON_NULL" ]]; then
-				local err_msg
-				err_msg=$(cat "$pr_err" 2>/dev/null || echo "$_PREFETCH_UNKNOWN_ERROR")
-				# GH#18979 (t2097): classify rate-limit errors and flag the cycle
-				if _pulse_gh_err_is_rate_limit "$pr_err"; then
-					_pulse_mark_rate_limited "_prefetch_repo_prs:${slug}"
-				fi
-				echo "[pulse-wrapper] _prefetch_repo_prs: gh_pr_list FAILED for ${slug}: ${err_msg}" >>"$LOGFILE"
-				_prefetch_log_batch_cache_state fetch-failed prs "$slug"
-				pr_json="[]"
-			fi
+			_prefetch_prs_fetch_full "$slug" "$pr_err"
+			pr_json="$PREFETCH_PR_RESULT"
 		fi
 	fi
 	rm -f "$pr_err"
@@ -440,7 +484,7 @@ _prefetch_repo_issues() {
 	local _used_batch_cache=false
 	if [[ "$canonical_snapshot_supplied" == "$_PREFETCH_BOOL_TRUE" ]]; then
 		local _canonical_issues=""
-		if _canonical_issues=$(printf '%s' "$canonical_snapshot" | jq -ce '.items | select(type == "array")' 2>/dev/null); then
+		if _canonical_issues=$(_prefetch_snapshot_items "$canonical_snapshot"); then
 			issue_json="$_canonical_issues"
 			_used_batch_cache=true
 			echo "[pulse-wrapper] _prefetch_repo_issues: using cycle canonical snapshot for ${slug}" >>"$LOGFILE"
@@ -459,6 +503,8 @@ _prefetch_repo_issues() {
 	fi
 
 	if [[ "$_used_batch_cache" == "false" ]]; then
+		_prefetch_record_fresh_empty_live_fallback \
+			"$canonical_snapshot_supplied" "$canonical_snapshot"
 		# Delta fetch: try merging recent changes into cache (GH#15286)
 		PREFETCH_ISSUE_SWEEP_MODE="$sweep_mode"
 		PREFETCH_ISSUE_RESULT=""

--- a/.agents/scripts/pulse-prefetch-infra.sh
+++ b/.agents/scripts/pulse-prefetch-infra.sh
@@ -176,6 +176,40 @@ _PREFETCH_ISSUES_PROJECTION="number,title,state,labels,updatedAt,assignees"
 _PREFETCH_PRS_PROJECTION="number,title,labels,updatedAt,assignees,createdAt,author,headRefOid,headRefName"
 _PREFETCH_FINGERPRINT_SCHEMA="canonical-snapshot-v1"
 
+#######################################
+# Hash stdin with SHA-256 without exposing repository identities.
+#######################################
+_prefetch_sha256_stdin() {
+	local hash=""
+	if command -v shasum >/dev/null 2>&1; then
+		hash=$(shasum -a 256 2>/dev/null | awk '{print $1}') || hash=""
+	elif command -v sha256sum >/dev/null 2>&1; then
+		hash=$(sha256sum 2>/dev/null | awk '{print $1}') || hash=""
+	fi
+	[[ "$hash" =~ ^[0-9a-f]{64}$ ]] || return 1
+	printf '%s\n' "$hash"
+	return 0
+}
+
+#######################################
+# Record the active repository population using count + opaque set digest.
+# Arguments: $1=newline-delimited slug|path entries
+#######################################
+_prefetch_record_efficiency_population() {
+	local repo_entries="$1"
+	local repo_slugs=""
+	local repo_count=""
+	local repo_set_hash=""
+	declare -F gh_record_efficiency_evidence >/dev/null 2>&1 || return 0
+	repo_slugs=$(printf '%s\n' "$repo_entries" | awk -F'|' 'NF && $1 != "" {print $1}' | LC_ALL=C sort -u) || return 0
+	repo_count=$(printf '%s\n' "$repo_slugs" | awk 'NF {count++} END {print count + 0}') || return 0
+	[[ "$repo_count" =~ ^[0-9]+$ && "$repo_count" -gt 0 ]] || return 0
+	repo_set_hash=$(printf '%s\n' "$repo_slugs" | _prefetch_sha256_stdin) || return 0
+	gh_record_efficiency_evidence population.repository_count "$repo_count" 2>/dev/null || true
+	gh_record_efficiency_evidence population.repository_set_sha256 "$repo_set_hash" 2>/dev/null || true
+	return 0
+}
+
 # Load the budget config once per process. Called lazily from the t2041
 # helpers. Reads `.agents/configs/pulse-sweep-budget.json` relative to
 # the aidevops repo deploy. Per-repo overrides override default values;

--- a/.agents/scripts/pulse-prefetch-repo.sh
+++ b/.agents/scripts/pulse-prefetch-repo.sh
@@ -274,6 +274,13 @@ _prefetch_single_repo_load_snapshots() {
 	PREFETCH_CANONICAL_SNAPSHOT_GENERATION=""
 
 	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" != "1" || ! -x "$helper" ]]; then
+		if declare -F gh_record_efficiency_evidence >/dev/null 2>&1; then
+			local collection=""
+			for collection in issues prs; do
+				gh_record_efficiency_evidence cache.misses 1 2>/dev/null || true
+				gh_record_efficiency_evidence guardrails.forced_live_refreshes 1 2>/dev/null || true
+			done
+		fi
 		return 0
 	fi
 	PREFETCH_CANONICAL_ISSUES_SNAPSHOT=$("$helper" read-snapshot --kind issues --slug "$slug" 2>>"$LOGFILE") || PREFETCH_CANONICAL_ISSUES_SNAPSHOT="{}"

--- a/.agents/scripts/pulse-prefetch.sh
+++ b/.agents/scripts/pulse-prefetch.sh
@@ -97,6 +97,9 @@ prefetch_state() {
 		return 1
 	fi
 
+	# GH#27777: record only count + deterministic digest, never raw repo names.
+	_prefetch_record_efficiency_population "$repo_entries"
+
 	# GH#19963: Batch prefetch via org-level gh search (L3 cache layer).
 	_prefetch_batch_refresh
 

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -32,6 +32,134 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+_PULSE_EFFICIENCY_CYCLE_STARTED=0
+_PULSE_EFFICIENCY_CYCLE_START_MS=0
+_PULSE_EFFICIENCY_CYCLE_OUTCOME=idle
+
+_pulse_efficiency_record() {
+	local name="$1"
+	local value="${2:-1}"
+	if declare -F gh_record_efficiency_evidence >/dev/null 2>&1; then
+		gh_record_efficiency_evidence "$name" "$value" 2>/dev/null || true
+	fi
+	return 0
+}
+
+_pulse_efficiency_now_seconds() {
+	date +%s 2>/dev/null || printf '0\n'
+	return 0
+}
+
+_pulse_efficiency_now_ms() {
+	local now_seconds=""
+	if declare -F _gh_now_ms >/dev/null 2>&1; then
+		_gh_now_ms || return 1
+		return 0
+	fi
+	now_seconds=$(_pulse_efficiency_now_seconds)
+	[[ "$now_seconds" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$((now_seconds * 1000))"
+	return 0
+}
+
+_pulse_efficiency_coverage_start_seconds() {
+	local now_seconds="$1"
+	local state_file="${AIDEVOPS_GH_API_EVIDENCE_COVERAGE_START_FILE:-${AIDEVOPS_STATE_DIR:-${HOME}/.aidevops/state}/github-api-efficiency-contract-v1.started-at}"
+	local state_dir="${state_file%/*}"
+	local existing=""
+	local temporary=""
+	[[ "$state_dir" != "$state_file" ]] || state_dir="."
+	if [[ -f "$state_file" && ! -L "$state_file" ]]; then
+		IFS= read -r existing <"$state_file" || existing=""
+		if [[ "$existing" =~ ^[0-9]+$ && "$existing" -gt 0 \
+			&& "$existing" -le "$now_seconds" ]]; then
+			printf '%s\n' "$existing"
+			return 0
+		fi
+	fi
+	mkdir -p "$state_dir" 2>/dev/null || {
+		printf '%s\n' "$now_seconds"
+		return 0
+	}
+	temporary=$(mktemp "${state_dir}/.github-api-efficiency-coverage.XXXXXX" 2>/dev/null) || {
+		printf '%s\n' "$now_seconds"
+		return 0
+	}
+	chmod 0600 "$temporary" 2>/dev/null || true
+	if ! printf '%s\n' "$now_seconds" >"$temporary"; then
+		rm -f "$temporary"
+		printf '%s\n' "$now_seconds"
+		return 0
+	fi
+	if [[ -e "$state_file" || -L "$state_file" ]]; then
+		rm -f "$temporary"
+	else
+		mv "$temporary" "$state_file" 2>/dev/null || rm -f "$temporary"
+	fi
+	if [[ -f "$state_file" && ! -L "$state_file" ]]; then
+		IFS= read -r existing <"$state_file" || existing=""
+	fi
+	if [[ "$existing" =~ ^[0-9]+$ && "$existing" -gt 0 \
+		&& "$existing" -le "$now_seconds" ]]; then
+		printf '%s\n' "$existing"
+	else
+		printf '%s\n' "$now_seconds"
+	fi
+	return 0
+}
+
+_pulse_efficiency_cycle_start() {
+	local now_seconds=""
+	local now_ms=""
+	local coverage_start=""
+	local group=""
+	now_seconds=$(_pulse_efficiency_now_seconds)
+	now_ms=$(_pulse_efficiency_now_ms) || now_ms=""
+	[[ "$now_seconds" =~ ^[0-9]+$ && "$now_seconds" -gt 0 ]] || return 0
+	[[ "$now_ms" =~ ^[0-9]+$ ]] || now_ms=$((now_seconds * 1000))
+	coverage_start=$(_pulse_efficiency_coverage_start_seconds "$now_seconds")
+	[[ "$coverage_start" =~ ^[0-9]+$ ]] || coverage_start="$now_seconds"
+	_PULSE_EFFICIENCY_CYCLE_STARTED=1
+	_PULSE_EFFICIENCY_CYCLE_START_MS="$now_ms"
+	_PULSE_EFFICIENCY_CYCLE_OUTCOME=idle
+	_pulse_efficiency_record contract 1
+	_pulse_efficiency_record coverage-start "$coverage_start"
+	for group in population latency cache single_flight path_budgets; do
+		_pulse_efficiency_record "coverage.${group}" 1
+	done
+	return 0
+}
+
+_pulse_efficiency_cycle_finish() {
+	local outcome="${1:-${_PULSE_EFFICIENCY_CYCLE_OUTCOME:-idle}}"
+	local now_seconds=""
+	local now_ms=""
+	local elapsed_ms=0
+	[[ "${_PULSE_EFFICIENCY_CYCLE_STARTED:-0}" == "1" ]] || return 0
+	now_seconds=$(_pulse_efficiency_now_seconds)
+	now_ms=$(_pulse_efficiency_now_ms) || now_ms=""
+	[[ "$now_seconds" =~ ^[0-9]+$ && "$now_seconds" -gt 0 ]] || now_seconds=0
+	if [[ "$now_ms" =~ ^[0-9]+$ && "${_PULSE_EFFICIENCY_CYCLE_START_MS:-0}" =~ ^[0-9]+$ \
+		&& "$now_ms" -ge "${_PULSE_EFFICIENCY_CYCLE_START_MS:-0}" ]]; then
+		elapsed_ms=$((now_ms - _PULSE_EFFICIENCY_CYCLE_START_MS))
+	fi
+	_pulse_efficiency_record population.pulse_cycles 1
+	if [[ "$outcome" == "active" ]]; then
+		_pulse_efficiency_record latency.completed_action_ms "$elapsed_ms"
+	else
+		_pulse_efficiency_record population.unchanged_cycles 1
+	fi
+	[[ "$now_seconds" -gt 0 ]] && _pulse_efficiency_record coverage-end "$now_seconds"
+	if declare -F gh_aggregate_calls >/dev/null 2>&1; then
+		gh_aggregate_calls 2>/dev/null || true
+	fi
+	if declare -F gh_trim_log >/dev/null 2>&1; then
+		gh_trim_log 2>/dev/null || true
+	fi
+	_PULSE_EFFICIENCY_CYCLE_STARTED=0
+	return 0
+}
+
 _pulse_scope_repos_for_available_work_gate() {
 	local _scope="${PULSE_SCOPE_REPOS:-}"
 	if [[ -z "$_scope" && -f "${SCOPE_FILE:-}" ]]; then
@@ -254,7 +382,6 @@ _pulse_record_cycle_outcome() {
 	local _ledger_before="${1:-0}"
 	[[ "$_ledger_before" =~ ^[0-9]+$ ]] || _ledger_before=0
 	local _ib_helper="${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
-	[[ -x "$_ib_helper" ]] || return 0
 	local _ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
 	local _ledger_after=0
 	if [[ -x "$_ledger_helper" ]]; then
@@ -268,7 +395,10 @@ _pulse_record_cycle_outcome() {
 		|| [[ "$_ledger_after" -gt "$_ledger_before" ]]; then
 		_outcome="active"
 	fi
-	"$_ib_helper" record-cycle "$_outcome" >/dev/null 2>&1 || true
+	_PULSE_EFFICIENCY_CYCLE_OUTCOME="$_outcome"
+	if [[ -x "$_ib_helper" ]]; then
+		"$_ib_helper" record-cycle "$_outcome" >/dev/null 2>&1 || true
+	fi
 	echo "[pulse-wrapper] Cycle outcome: ${_outcome} (merged=${_PULSE_HEALTH_PRS_MERGED:-0} closed=${_PULSE_HEALTH_PRS_CLOSED_CONFLICTING:-0} ledger=${_ledger_before}→${_ledger_after}) (t3027)" >>"${LOGFILE:-/dev/null}"
 	return 0
 }

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1642,7 +1642,7 @@ main() {
 	# Register EXIT trap BEFORE acquiring the lock so the lock is always
 	# released on exit — including set -e aborts, SIGTERM, and return paths.
 	# SIGKILL cannot be trapped; stale-lock detection handles that case.
-	trap 'release_instance_lock' EXIT
+	trap '_pulse_efficiency_cycle_finish; release_instance_lock' EXIT
 
 	if ! acquire_instance_lock; then
 		return 0
@@ -1681,6 +1681,7 @@ main() {
 		export AIDEVOPS_GH_PR_VIEW_CACHE_TTL="${AIDEVOPS_PULSE_PR_VIEW_CACHE_TTL:-3600}"
 		_save_cleanup_scope
 		push_cleanup 'release_instance_lock'
+		push_cleanup '_pulse_efficiency_cycle_finish'
 		# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
 		# register release_instance_lock before replacing the direct EXIT trap.
 		trap '_run_cleanups' EXIT
@@ -1699,6 +1700,7 @@ main() {
 		if [[ "$_pulse_pr_cache_cleanup_scope" -eq 0 ]]; then
 			_save_cleanup_scope
 			push_cleanup 'release_instance_lock'
+			push_cleanup '_pulse_efficiency_cycle_finish'
 			# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
 			# register release_instance_lock before replacing the direct EXIT trap.
 			trap '_run_cleanups' EXIT
@@ -1826,6 +1828,12 @@ main() {
 		return 0
 	fi
 
+	# GH#27777: bracket every real pulse cycle with typed production evidence.
+	# The fail-open finish hook is also registered in the EXIT cleanup path so
+	# unexpected set -e exits publish a conservative partial cycle rather than
+	# silently dropping the observation window.
+	_pulse_efficiency_cycle_start
+
 	# t3068: drain any pending approval-trigger records before the regular
 	# cycle. Backstop for the dedicated 60s --merge-only plist; if an
 	# approval landed since the last merge-only tick, we pick it up here
@@ -1835,6 +1843,7 @@ main() {
 
 	# Run pre-flight stages (cleanup, prefetch, normalization)
 	if ! _run_preflight_stages; then
+		_pulse_efficiency_cycle_finish idle
 		return 0
 	fi
 
@@ -1842,6 +1851,7 @@ main() {
 	# been issued during the prefetch/cleanup phase above (t2943)
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared during setup — aborting before run_pulse()" >>"$LOGFILE"
+		_pulse_efficiency_cycle_finish idle
 		return 0
 	fi
 
@@ -1892,6 +1902,7 @@ main() {
 			[[ "$_pw_mtime_now" -gt 0 ]] &&
 			[[ "$_pw_mtime_now" != "$_pw_mtime_loaded" ]]; then
 			echo "[pulse-wrapper] t3033: source modified (${_pw_mtime_loaded} -> ${_pw_mtime_now}) — releasing lock and re-execing for fresh code" >>"$WRAPPER_LOGFILE"
+			_pulse_efficiency_cycle_finish
 			release_instance_lock
 			exec "$_pw_self" "$@"
 			# exec should not return; if it does, log and fall through to normal exit
@@ -1899,6 +1910,7 @@ main() {
 		fi
 	fi
 
+	_pulse_efficiency_cycle_finish
 	return 0
 }
 

--- a/.agents/scripts/shared-gh-request-state.sh
+++ b/.agents/scripts/shared-gh-request-state.sh
@@ -243,6 +243,20 @@ _ghrs_record() {
 	if declare -F gh_record_call >/dev/null 2>&1; then
 		gh_record_call other gh_request_singleflight unknown other "$decision" "$operation" coordination 2>/dev/null || true
 	fi
+	if declare -F gh_record_efficiency_evidence >/dev/null 2>&1; then
+		case "$decision" in
+		leader)
+			gh_record_efficiency_evidence single_flight.leaders 1 2>/dev/null || true
+			;;
+		follower-success | follower-failure | timeout)
+			gh_record_efficiency_evidence single_flight.waits 1 2>/dev/null || true
+			;;
+		takeover)
+			gh_record_efficiency_evidence single_flight.waits 1 2>/dev/null || true
+			gh_record_efficiency_evidence single_flight.takeovers 1 2>/dev/null || true
+			;;
+		esac
+	fi
 	return 0
 }
 

--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -80,6 +80,54 @@ _gh_pr_check_status_cache_record() {
 	if declare -F gh_record_call >/dev/null 2>&1; then
 		gh_record_call other gh_pr_check_status_cache unknown other "$decision" "" cache 2>/dev/null || true
 	fi
+	if declare -F gh_record_efficiency_evidence >/dev/null 2>&1; then
+		case "$decision" in
+		hit-empty)
+			gh_record_efficiency_evidence cache.fresh_empty_hits 1 2>/dev/null || true
+			;;
+		hit-*)
+			gh_record_efficiency_evidence cache.fresh_hits 1 2>/dev/null || true
+			;;
+		miss | bypass | bypass-disabled)
+			gh_record_efficiency_evidence cache.misses 1 2>/dev/null || true
+			;;
+		invalid | invalid-* | refresh-*)
+			gh_record_efficiency_evidence cache.misses 1 2>/dev/null || true
+			gh_record_efficiency_evidence cache.stale 1 2>/dev/null || true
+			gh_record_efficiency_evidence guardrails.stale_snapshot_detections 1 2>/dev/null || true
+			gh_record_efficiency_evidence guardrails.forced_live_refreshes 1 2>/dev/null || true
+			;;
+		invalidate)
+			gh_record_efficiency_evidence cache.invalidated 1 2>/dev/null || true
+			;;
+		fetch)
+			gh_record_efficiency_evidence path_budgets.aggregate_check_fetches 1 2>/dev/null || true
+			;;
+		publish-fenced | publish-invalidated)
+			gh_record_efficiency_evidence guardrails.stale_snapshot_detections 1 2>/dev/null || true
+			;;
+		esac
+	fi
+	return 0
+}
+
+_gh_pr_check_status_record_actionable_head() {
+	local slug="$1"
+	local sha="$2"
+	local normalized_sha=""
+	local token=""
+	_gh_pr_check_status_cache_identity_valid "$slug" "$sha" || return 0
+	declare -F gh_record_efficiency_evidence >/dev/null 2>&1 || return 0
+	gh_record_efficiency_evidence population.actionable_changes 1 2>/dev/null || true
+	normalized_sha=$(printf '%s' "$sha" | tr '[:upper:]' '[:lower:]')
+	if declare -F _ghrs_digest >/dev/null 2>&1; then
+		token=$(_ghrs_digest "$normalized_sha") || token=""
+	fi
+	if [[ -n "$token" ]]; then
+		gh_record_efficiency_evidence population.actionable_head_token "$token" 2>/dev/null || true
+	else
+		gh_record_efficiency_evidence population.actionable_head_hash_failures 1 2>/dev/null || true
+	fi
 	return 0
 }
 
@@ -306,7 +354,11 @@ _gh_pr_check_status_cache_get() {
 		_gh_pr_check_status_cache_record "refresh-${expiry_class}"
 		return 1
 	fi
-	_gh_pr_check_status_cache_record "hit-${expiry_class}"
+	if [[ "$check_state" == "$_GH_PR_CHECK_STATUS_NONE" ]]; then
+		_gh_pr_check_status_cache_record hit-empty
+	else
+		_gh_pr_check_status_cache_record "hit-${expiry_class}"
+	fi
 	printf '%s\n' "$check_state"
 	return 0
 }
@@ -741,6 +793,7 @@ gh_pr_check_status_rest_batch() {
 	local pr_sha="" _check_state=""
 	while IFS= read -r pr_sha; do
 		[[ -n "$pr_sha" ]] || continue
+		_gh_pr_check_status_record_actionable_head "$slug" "$pr_sha"
 		_check_state=$(gh_pr_check_status_rest "$slug" "$pr_sha")
 		printf '%s\t%s\n' "$pr_sha" "$_check_state" >>"$tmp"
 	done <<<"$unique_shas"

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -31,6 +31,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 export AIDEVOPS_GH_API_LOG="$TMPDIR/gh-api-calls.log"
 export AIDEVOPS_GH_API_REPORT="$TMPDIR/report.json"
+export AIDEVOPS_GH_API_EVIDENCE="$TMPDIR/evidence.json"
 
 assert_eq() {
 	local label="$1"
@@ -85,6 +86,8 @@ assert_eq "log has 6 lines" "6" "$line_count"
 gh_aggregate_calls
 
 assert_file_exists "report file created" "$AIDEVOPS_GH_API_REPORT"
+report_mode=$(stat -f '%Lp' "$AIDEVOPS_GH_API_REPORT" 2>/dev/null || stat -c '%a' "$AIDEVOPS_GH_API_REPORT" 2>/dev/null)
+assert_eq "atomic report is private" "600" "$report_mode"
 
 if ! jq -e '.' "$AIDEVOPS_GH_API_REPORT" >/dev/null 2>&1; then
 	echo "  FAIL: report is not valid JSON"
@@ -145,6 +148,13 @@ if [[ -f "$AIDEVOPS_GH_API_REPORT" ]]; then
 	FAIL=$((FAIL + 1))
 else
 	echo "  PASS: clear removed report"
+	PASS=$((PASS + 1))
+fi
+if [[ -f "$AIDEVOPS_GH_API_EVIDENCE" ]]; then
+	echo "  FAIL: clear left evidence behind: $AIDEVOPS_GH_API_EVIDENCE"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: clear removed evidence"
 	PASS=$((PASS + 1))
 fi
 
@@ -386,18 +396,63 @@ assert_eq "requested window retained separately" "3600" "$(jq -r '._meta.request
 assert_eq "first retained attempt timestamp" "$first_ts" "$(jq -r '._meta.first_retained_ts' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "last retained attempt timestamp" "$last_ts" "$(jq -r '._meta.last_retained_ts' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "effective window uses observed range" "20" "$(jq -r '._meta.effective_window_seconds' "$AIDEVOPS_GH_API_REPORT")"
+assert_file_exists "digest-bound evidence sidecar created" "$AIDEVOPS_GH_API_EVIDENCE"
+report_digest=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$AIDEVOPS_GH_API_REPORT")
+evidence_digest=$(jq -r '.transport_sha256' "$AIDEVOPS_GH_API_EVIDENCE")
+assert_eq "evidence sidecar is bound to report bytes" "$report_digest" "$evidence_digest"
+assert_eq "incomplete production evidence fails closed" "false" "$(jq -r '.complete' "$AIDEVOPS_GH_API_EVIDENCE")"
+evidence_mode=$(stat -f '%Lp' "$AIDEVOPS_GH_API_EVIDENCE" 2>/dev/null || stat -c '%a' "$AIDEVOPS_GH_API_EVIDENCE" 2>/dev/null)
+assert_eq "evidence sidecar is private" "600" "$evidence_mode"
+rm -f "$AIDEVOPS_GH_API_LOG"
+gh_record_call rest invalid-window-caller
+gh_aggregate_calls
+if [[ -f "$AIDEVOPS_GH_API_EVIDENCE" ]]; then
+	echo "  FAIL: invalid aggregate left a stale evidence sidecar"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: invalid aggregate removed stale evidence sidecar"
+	PASS=$((PASS + 1))
+fi
 
 # --- Test 12b: retained opaque history does not poison a fresh window -------
 gh_clear_log
 outside_ts=$((now - 120))
 inside_ts=$((now - 10))
-printf '%s\topaque-caller\trest\tgh-pat\trest-core\tnative-pagination-opaque\t\tv2\tattempt\tlogical-old\tattempt-old\t0\t0\tsuccess\t200\t10\t\n' "$outside_ts" >>"$AIDEVOPS_GH_API_LOG"
-printf '%s\texact-caller\trest\tgh-pat\trest-core\trest-selected\t\tv2\tattempt\tlogical-new\tattempt-new\t1\t0\tsuccess\t200\t10\t\n' "$inside_ts" >>"$AIDEVOPS_GH_API_LOG"
+inside_last_ts=$((now - 5))
+printf '%s\topaque-caller\trest\tgh-pat\trest-core\tnative-pagination-opaque\t\tv2\tattempt\tlogical-old\tattempt-shared\t0\t0\tsuccess\t200\t10\t\n' "$outside_ts" >>"$AIDEVOPS_GH_API_LOG"
+printf '%s\texact-caller\trest\tgh-pat\trest-core\trest-selected\t\tv2\tattempt\tlogical-new\tattempt-shared\t1\t0\tsuccess\t200\t10\t\n' "$inside_ts" >>"$AIDEVOPS_GH_API_LOG"
+printf '%s\texact-caller\trest\tgh-pat\trest-core\trest-selected\t\tv2\tattempt\tlogical-new\tattempt-new\t2\t0\tsuccess\t200\t20\t\n' "$inside_last_ts" >>"$AIDEVOPS_GH_API_LOG"
 gh_aggregate_calls "$AIDEVOPS_GH_API_REPORT" 60
 assert_eq "fresh window excludes retained unknown pages" "0" "$(jq -r '._meta.unknown_page_attempts' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "retained unknown page remains auditable" "1" "$(jq -r '._meta.retained_unknown_page_attempts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "old duplicate ID does not poison fresh attempts" "2" "$(jq -r '._meta.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "retained duplicate remains auditable" "1" "$(jq -r '._meta.retained_duplicate_attempt_ids' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "fresh window duplicate count stays scoped" "0" "$(jq -r '._meta.duplicate_attempt_ids' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "fresh exact window ignores old opaque call" "0" "$(jq -r '._meta.opaque_paginated_attempts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "fresh window first timestamp excludes history" "$inside_ts" "$(jq -r '._meta.first_retained_ts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "fresh window last timestamp excludes history" "$inside_last_ts" "$(jq -r '._meta.last_retained_ts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "fresh effective window excludes history" "5" "$(jq -r '._meta.effective_window_seconds' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "fresh window exactness is true" "true" "$(jq -r '._meta.attempts_exact' "$AIDEVOPS_GH_API_REPORT")"
+
+# --- Test 12c: typed evidence and latency completeness stay explicit --------
+gh_clear_log
+latency_ts=$((now - 5))
+gh_record_efficiency_evidence cache.fresh_hits 1
+printf '%s\tlatency-caller\trest\tgh-pat\trest-core\trest-selected\t\tv2\tattempt\tlogical-latency\tattempt-latency-1\t1\t0\tsuccess\t200\t10\t\n' "$latency_ts" >>"$AIDEVOPS_GH_API_LOG"
+printf '%s\tlatency-caller\trest\tgh-pat\trest-core\trest-selected\t\tv2\tattempt\tlogical-latency\tattempt-latency-2\t2\t0\tsuccess\t200\t30\t\n' "$latency_ts" >>"$AIDEVOPS_GH_API_LOG"
+printf '%s\tlatency-caller\trest\tgh-pat\trest-core\trest-selected\t\tv2\tattempt\tlogical-latency\tattempt-latency-3\t3\t0\tsuccess\t200\t20\t\n' "$latency_ts" >>"$AIDEVOPS_GH_API_LOG"
+printf '%s\tlatency-caller\trest\tgh-pat\trest-core\trest-selected\t\tv2\tattempt\tlogical-latency\tattempt-latency-4\t4\t0\tsuccess\t200\t\t\n' "$latency_ts" >>"$AIDEVOPS_GH_API_LOG"
+gh_aggregate_calls "$AIDEVOPS_GH_API_REPORT" 60
+assert_eq "typed evidence is not a logical call" "0" "$(jq -r '._meta.total_calls' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "typed evidence event is counted" "1" "$(jq -r '._meta.evidence_events' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "typed evidence route remains parseable" "1" "$(jq -r '.by_route_decision["evidence:cache.fresh_hits:1"].evidence_events' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "nearest-rank request p50 uses known samples" "20" "$(jq -r '._meta.request_p50_ms' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "nearest-rank request p95 uses known samples" "30" "$(jq -r '._meta.request_p95_ms' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "missing elapsed values stay explicit" "1" "$(jq -r '._meta.unknown_elapsed_attempts' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "peak attempts per minute uses transport attempts" "4" "$(jq -r '._meta.peak_attempts_per_minute' "$AIDEVOPS_GH_API_REPORT")"
+invalid_evidence_status=0
+gh_record_efficiency_evidence "Invalid Name" 1 || invalid_evidence_status=$?
+assert_eq "invalid evidence identifiers are rejected" "1" "$invalid_evidence_status"
 
 # --- Test 13: time/line/byte retention is atomic and bounded -------------
 export AIDEVOPS_GH_API_LOG_MAX_LINES=3

--- a/.agents/scripts/tests/test-gh-check-status-cache.sh
+++ b/.agents/scripts/tests/test-gh-check-status-cache.sh
@@ -42,9 +42,31 @@ SHA_G="1111111111111111111111111111111111111111"
 SHA_H="2222222222222222222222222222222222222222"
 SHA_I="3333333333333333333333333333333333333333"
 SHA_J="4444444444444444444444444444444444444444"
+SHA_K="5555555555555555555555555555555555555555"
 
 # shellcheck source=../shared-gh-wrappers-checks.sh
 source "$CHECKS_LIB"
+
+EFFICIENCY_EVENTS="${TEST_ROOT}/efficiency-events.tsv"
+: >"$EFFICIENCY_EVENTS"
+gh_record_efficiency_evidence() {
+	local name="$1"
+	local value="${2:-1}"
+	printf '%s\t%s\n' "$name" "$value" >>"$EFFICIENCY_EVENTS"
+	return 0
+}
+
+efficiency_event_total() {
+	local name="$1"
+	awk -F'\t' -v expected="$name" '$1 == expected { total += $2 } END { print total + 0 }' "$EFFICIENCY_EVENTS"
+	return 0
+}
+
+efficiency_event_unique_values() {
+	local name="$1"
+	awk -F'\t' -v expected="$name" '$1 == expected && !seen[$2]++ { total++ } END { print total + 0 }' "$EFFICIENCY_EVENTS"
+	return 0
+}
 
 cleanup() {
 	export HOME="$ORIGINAL_HOME"
@@ -429,6 +451,41 @@ test_invalidation_fences_all_auth_scopes() {
 	return 0
 }
 
+test_efficiency_evidence_tracks_exact_decisions() {
+	local result=""
+	: >"$EFFICIENCY_EVENTS"
+	CHECK_NOW=1100
+	CHECK_API_MODE=success
+	CHECK_SUITES_FIXTURE='{}'
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":11,"headRefOid":"5555555555555555555555555555555555555555"}]')
+	assert_json_eq "empty aggregate fixture remains an explicit none state" \
+		'[{"number":11,"status":"none"}]' "$result"
+	result=$(gh_pr_check_status_rest_batch "owner/repo" \
+		'[{"number":11,"headRefOid":"5555555555555555555555555555555555555555"}]')
+	assert_json_eq "fresh empty aggregate is reused without transport" \
+		'[{"number":11,"status":"none"}]' "$result"
+	gh_pr_check_status_cache_invalidate "owner/repo" "$SHA_K"
+	assert_eq "cold leader path records both cache lookup misses" "2" \
+		"$(efficiency_event_total cache.misses)"
+	assert_eq "fresh empty cache decision is distinct" "1" \
+		"$(efficiency_event_total cache.fresh_empty_hits)"
+	assert_eq "successful invalidation is counted" "1" \
+		"$(efficiency_event_total cache.invalidated)"
+	assert_eq "one leader transport records one aggregate check fetch" "1" \
+		"$(efficiency_event_total path_budgets.aggregate_check_fetches)"
+	assert_eq "each batch observation records one actionable change" "2" \
+		"$(efficiency_event_total population.actionable_changes)"
+	assert_eq "repeated actionable heads use one opaque token" "1" \
+		"$(efficiency_event_unique_values population.actionable_head_token)"
+	if grep -Fq "$SHA_K" "$EFFICIENCY_EVENTS"; then
+		printf 'FAIL: actionable evidence exposed a raw head SHA\n' >&2
+		return 1
+	fi
+	printf 'PASS: actionable evidence keeps head identities opaque\n'
+	return 0
+}
+
 main() {
 	test_terminal_reuse_dedup_and_order
 	test_new_head_repo_and_auth_scope_miss
@@ -437,6 +494,7 @@ main() {
 	test_private_atomic_cache_and_authority_boundary
 	test_invalidation_fences_inflight_publication
 	test_invalidation_fences_all_auth_scopes
+	test_efficiency_evidence_tracks_exact_decisions
 	printf 'PASS: PR check-status cache regression suite\n'
 	return 0
 }

--- a/.agents/scripts/tests/test-gh-request-singleflight.sh
+++ b/.agents/scripts/tests/test-gh-request-singleflight.sh
@@ -27,6 +27,21 @@ mkdir -p "$HOME"
 # shellcheck source=../shared-gh-request-state.sh
 source "${SCRIPTS_DIR}/shared-gh-request-state.sh"
 
+EFFICIENCY_EVENTS="${TEST_ROOT}/efficiency-events.tsv"
+: >"$EFFICIENCY_EVENTS"
+gh_record_efficiency_evidence() {
+	local name="$1"
+	local value="${2:-1}"
+	printf '%s\t%s\n' "$name" "$value" >>"$EFFICIENCY_EVENTS"
+	return 0
+}
+
+efficiency_event_total() {
+	local name="$1"
+	awk -F'\t' -v expected="$name" '$1 == expected { total += $2 } END { print total + 0 }' "$EFFICIENCY_EVENTS"
+	return 0
+}
+
 cleanup() {
 	export HOME="$ORIGINAL_HOME"
 	rm -rf "$TEST_ROOT"
@@ -122,6 +137,24 @@ singleflight_worker() {
 		attempts=$((attempts + 1))
 	done
 	return 1
+}
+
+test_efficiency_event_mapping() {
+	: >"$EFFICIENCY_EVENTS"
+	_ghrs_record leader
+	_ghrs_record follower-success
+	_ghrs_record follower-failure
+	_ghrs_record takeover
+	_ghrs_record timeout
+	assert_eq "leader acquisition emits one efficiency event" "1" \
+		"$(efficiency_event_total single_flight.leaders)"
+	assert_eq "followers, takeover, and timeout emit bounded waits" "4" \
+		"$(efficiency_event_total single_flight.waits)"
+	assert_eq "lease recovery emits one takeover" "1" \
+		"$(efficiency_event_total single_flight.takeovers)"
+	assert_eq "duplicate leaders stay absent without an observed violation" "0" \
+		"$(efficiency_event_total single_flight.duplicate_leaders)"
+	return 0
 }
 
 test_scope_key_isolation() {
@@ -477,6 +510,7 @@ test_concurrent_rate_probe_is_singleflight() {
 }
 
 main() {
+	test_efficiency_event_mapping
 	test_scope_key_isolation
 	test_default_state_root_is_operational
 	test_portable_mtime_dependency_is_available

--- a/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
+++ b/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
@@ -133,6 +133,7 @@ def transport(
     additional_pages,
     elapsed_ms,
     unknown_quota=0,
+    unknown_elapsed=0,
     other_attempts=0,
     schema=2,
 ):
@@ -153,6 +154,7 @@ def transport(
             "successful_attempts": attempts - errors,
             "failed_attempts": errors,
             "elapsed_ms": elapsed_ms,
+            "unknown_elapsed_attempts": unknown_elapsed,
             "known_quota_cost": graphql_points,
             "unknown_quota_cost_attempts": unknown_quota,
             "duplicate_attempt_ids": 0,
@@ -350,6 +352,22 @@ unknown_quota_report = transport(
 )
 write_case("unknown-quota", unknown_quota_report, PASS_EVIDENCE)
 
+unknown_latency_report = transport(
+    50_000,
+    43_200,
+    800,
+    160,
+    180,
+    560,
+    80,
+    errors=5,
+    retries=8,
+    additional_pages=25,
+    elapsed_ms=360_000,
+    unknown_elapsed=1,
+)
+write_case("unknown-latency", unknown_latency_report, PASS_EVIDENCE)
+
 incompatible_report = copy.deepcopy(PASS_REPORT)
 incompatible_report["_meta"]["schema_version"] = 1
 write_case("incompatible", incompatible_report, PASS_EVIDENCE)
@@ -469,6 +487,11 @@ test_fail_closed_transport() {
 	assert_eq "unknown quota evidence exits two" "2" "$LAST_EXIT"
 	assert_jq "unknown quota evidence cannot pass" \
 		'.status == "INCONCLUSIVE" and (.reasons | any(contains("quota cost is unknown")))' "$LAST_JSON"
+
+	run_case unknown-latency
+	assert_eq "unknown latency evidence exits two" "2" "$LAST_EXIT"
+	assert_jq "unknown latency evidence cannot pass" \
+		'.status == "INCONCLUSIVE" and (.reasons | any(contains("request latency is unknown")))' "$LAST_JSON"
 
 	run_case unclassified
 	assert_eq "unclassified transport exits two" "2" "$LAST_EXIT"

--- a/.agents/scripts/tests/test-github-api-efficiency-evidence.sh
+++ b/.agents/scripts/tests/test-github-api-efficiency-evidence.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Deterministic coverage for the GitHub API efficiency sidecar producer.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+readonly PRODUCER="${SCRIPT_DIR}/../github-api-efficiency-evidence.sh"
+readonly TEMP_BASE="${AIDEVOPS_TEMP_DIR:-${HOME:+$HOME/.aidevops/.agent-workspace/tmp}}"
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+LAST_EXIT=0
+LAST_OUTPUT=""
+
+cleanup() {
+    if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+        rm -rf "$TEST_ROOT"
+    fi
+    return 0
+}
+
+record_result() {
+    local label="$1"
+    local passed="$2"
+    local detail="${3:-}"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$passed" -eq 0 ]]; then
+        printf "PASS: %s\n" "$label"
+        return 0
+    fi
+    printf "FAIL: %s\n" "$label"
+    if [[ -n "$detail" ]]; then
+        printf "      %s\n" "$detail"
+    fi
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 0
+}
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        record_result "$label" 0
+        return 0
+    fi
+    record_result "$label" 1 "expected=${expected}, actual=${actual}"
+    return 0
+}
+
+assert_jq() {
+    local label="$1"
+    local filter="$2"
+    local file="$3"
+    if [[ -f "$file" ]] && jq -e "$filter" "$file" >/dev/null 2>&1; then
+        record_result "$label" 0
+        return 0
+    fi
+    record_result "$label" 1 "jq assertion failed: ${filter}"
+    return 0
+}
+
+assert_contains() {
+    local label="$1"
+    local needle="$2"
+    local haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        record_result "$label" 0
+        return 0
+    fi
+    record_result "$label" 1 "missing text: ${needle}"
+    return 0
+}
+
+assert_missing() {
+    local label="$1"
+    local file="$2"
+    if [[ ! -e "$file" ]]; then
+        record_result "$label" 0
+        return 0
+    fi
+    record_result "$label" 1 "unexpected file: ${file}"
+    return 0
+}
+
+file_sha256() {
+    local file="$1"
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" | cut -d " " -f 1
+        return 0
+    fi
+    openssl dgst -sha256 "$file" | awk "{print \$NF}"
+    return 0
+}
+
+file_mode() {
+    local file="$1"
+    stat -f "%Lp" "$file" 2>/dev/null || stat -c "%a" "$file"
+    return 0
+}
+
+run_build() {
+    local report="$1"
+    local output="$2"
+    set +e
+    LAST_OUTPUT=$("$PRODUCER" build --transport-report "$report" --output "$output" 2>&1)
+    LAST_EXIT=$?
+    set -e
+    return 0
+}
+
+mkdir -p "$TEMP_BASE"
+TEST_ROOT=$(mktemp -d "${TEMP_BASE}/github-api-efficiency-evidence-test.XXXXXX")
+trap cleanup EXIT
+
+python3 - "$TEST_ROOT" <<"PY"
+import copy
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(sys.argv[1])
+REPOSITORY_SET = "a" * 64
+
+
+def write_json(path, payload):
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def path_metrics(attempts, quota=0, unknown_quota=0):
+    return {
+        "attempted_requests": attempts,
+        "known_quota_cost": quota,
+        "unknown_quota_cost_attempts": unknown_quota,
+    }
+
+
+def decision_map(events):
+    return {
+        f"evidence:{name}:{value}": {"evidence_events": count}
+        for name, value, count in events
+    }
+
+
+def transport(events):
+    return {
+        "_meta": {
+            "schema_version": 2,
+            "first_retained_ts": 1000,
+            "last_retained_ts": 1060,
+            "effective_window_seconds": 60,
+            "attempted_requests": 3,
+            "retries": 0,
+            "pages": 3,
+            "additional_pages": 0,
+            "successful_attempts": 3,
+            "failed_attempts": 0,
+            "elapsed_ms": 60,
+            "unknown_elapsed_attempts": 0,
+            "request_p50_ms": 10,
+            "request_p95_ms": 30,
+            "peak_attempts_per_minute": 2,
+            "known_quota_cost": 0,
+            "unknown_quota_cost_attempts": 0,
+            "duplicate_attempt_ids": 0,
+            "unidentified_attempts": 0,
+            "unknown_page_attempts": 0,
+            "window_malformed_v2_records": 0,
+            "legacy_events": 0,
+            "opaque_paginated_attempts": 0,
+            "attempts_exact": True,
+        },
+        "by_path": {"rest": path_metrics(3)},
+        "by_route_decision": decision_map(events),
+    }
+
+
+EVENTS = [
+    ("contract", "1", 1),
+    ("coverage-start", "900", 1),
+    ("coverage-end", "1100", 1),
+    ("coverage.population", "1", 1),
+    ("coverage.latency", "1", 1),
+    ("coverage.cache", "1", 1),
+    ("coverage.single_flight", "1", 1),
+    ("coverage.webhook", "1", 1),
+    ("coverage.guardrails", "1", 1),
+    ("coverage.path_budgets", "1", 1),
+    ("population.repository_count", "10", 1),
+    ("population.repository_set_sha256", REPOSITORY_SET, 1),
+    ("population.pulse_cycles", "4", 1),
+    ("population.unchanged_cycles", "3", 1),
+    ("population.actionable_changes", "3", 1),
+    ("population.actionable_head_token", "b" * 64, 2),
+    ("population.actionable_head_token", "c" * 64, 1),
+    ("latency.completed_action_ms", "100", 1),
+    ("latency.completed_action_ms", "200", 2),
+    ("cache.fresh_hits", "3", 1),
+    ("cache.fresh_empty_hits", "1", 1),
+    ("cache.misses", "2", 1),
+    ("cache.stale", "1", 1),
+    ("cache.invalidated", "1", 1),
+    ("single_flight.leaders", "2", 1),
+    ("single_flight.waits", "1", 1),
+    ("webhook.invalidations", "2", 1),
+    ("webhook.lag_ms", "10", 1),
+    ("webhook.lag_ms", "30", 2),
+    ("guardrails.stale_snapshot_detections", "1", 1),
+    ("guardrails.forced_live_refreshes", "1", 1),
+    ("path_budgets.aggregate_check_fetches", "1", 1),
+]
+
+complete = transport(EVENTS)
+write_json(ROOT / "complete-report.json", complete)
+
+incomplete_events = [
+    event for event in EVENTS if event[0] != "coverage.webhook"
+]
+write_json(ROOT / "incomplete-report.json", transport(incomplete_events))
+
+unknown_latency = transport(EVENTS)
+unknown_latency["_meta"]["unknown_elapsed_attempts"] = 1
+write_json(ROOT / "unknown-latency-report.json", unknown_latency)
+
+head_hash_failure = transport(
+    EVENTS + [("population.actionable_head_hash_failures", "1", 1)]
+)
+write_json(ROOT / "head-hash-failure-report.json", head_hash_failure)
+
+bad_integer = transport(EVENTS)
+bad_integer["by_route_decision"]["evidence:cache.fresh_hits:bad"] = {
+    "evidence_events": 1
+}
+write_json(ROOT / "bad-integer-report.json", bad_integer)
+
+conflicting = transport(EVENTS)
+conflicting["by_route_decision"]["evidence:population.repository_count:11"] = {
+    "evidence_events": 1
+}
+write_json(ROOT / "conflicting-report.json", conflicting)
+
+untyped = copy.deepcopy(complete)
+untyped["by_route_decision"]["evidence:cache.fresh_hits:3"][
+    "evidence_events"
+] = 0
+write_json(ROOT / "untyped-report.json", untyped)
+PY
+
+main() {
+    local complete_report="${TEST_ROOT}/complete-report.json"
+    local complete_output="${TEST_ROOT}/complete-evidence.json"
+    local first_output="${TEST_ROOT}/complete-first.json"
+    local expected_digest=""
+    local actual_digest=""
+    local schema=""
+    local repository_set=""
+    local mode=""
+
+    run_build "$complete_report" "$complete_output"
+    assert_eq "complete evidence exits zero" "0" "$LAST_EXIT"
+    assert_contains "complete evidence reports status" "evidence sidecar: complete" "$LAST_OUTPUT"
+    assert_jq "complete evidence populates every group" ".complete and .population.repository_count == 10 and .population.pulse_cycles == 4 and .population.unchanged_cycles == 3 and .population.actionable_changes == 3 and .population.unique_actionable_head_shas == 2 and .latency.p50_ms == 10 and .latency.p95_ms == 30 and .latency.peak_attempts_per_minute == 2 and .latency.completed_action_p95_ms == 200 and .cache.fresh_hits == 3 and .cache.fresh_empty_hits == 1 and .cache.misses == 2 and .cache.stale == 1 and .cache.invalidated == 1 and .single_flight.leaders == 2 and .single_flight.waits == 1 and .single_flight.takeovers == 0 and .single_flight.duplicate_leaders == 0 and .webhook.invalidations == 2 and .webhook.lag_p50_ms == 30 and .webhook.lag_p95_ms == 30 and .webhook.duplicate_actions == 0 and .webhook.missed_recoveries == 0 and (._meta.missing_fields | length) == 0" "$complete_output"
+    schema=$(jq -r .schema "$complete_output")
+    assert_eq "sidecar schema is versioned" "aidevops-github-api-efficiency-evidence/v1" "$schema"
+    repository_set=$(jq -r .population.repository_set_sha256 "$complete_output")
+    assert_eq "repository population stays digest-only" "$(printf "a%.0s" {1..64})" "$repository_set"
+    expected_digest=$(file_sha256 "$complete_report")
+    actual_digest=$(jq -r .transport_sha256 "$complete_output")
+    assert_eq "sidecar binds exact transport bytes" "$expected_digest" "$actual_digest"
+    mode=$(file_mode "$complete_output")
+    assert_eq "sidecar output is private" "600" "$mode"
+
+    cp "$complete_output" "$first_output"
+    run_build "$complete_report" "$complete_output"
+    if cmp -s "$first_output" "$complete_output"; then
+        record_result "identical input produces byte-stable sidecar" 0
+    else
+        record_result "identical input produces byte-stable sidecar" 1
+    fi
+
+    local incomplete_output="${TEST_ROOT}/incomplete-evidence.json"
+    run_build "${TEST_ROOT}/incomplete-report.json" "$incomplete_output"
+    assert_eq "partial coverage exits zero" "0" "$LAST_EXIT"
+    assert_contains "partial coverage reports incomplete" "evidence sidecar: incomplete" "$LAST_OUTPUT"
+    assert_jq "unsupported group stays null" ".complete == false and .webhook.invalidations == null and .webhook.lag_p50_ms == null and ._meta.coverage_groups.webhook == false and (._meta.missing_fields | length) == 5" "$incomplete_output"
+
+    local unknown_latency_output="${TEST_ROOT}/unknown-latency-evidence.json"
+    run_build "${TEST_ROOT}/unknown-latency-report.json" "$unknown_latency_output"
+    assert_eq "unknown latency evidence exits zero" "0" "$LAST_EXIT"
+    assert_jq "unknown latency invalidates only latency coverage" ".complete == false and .latency.p50_ms == null and .latency.p95_ms == null and .latency.peak_attempts_per_minute == null and .latency.completed_action_p95_ms == null and ._meta.coverage_groups.latency == false and (._meta.missing_fields | length) == 4" "$unknown_latency_output"
+
+    local head_hash_failure_output="${TEST_ROOT}/head-hash-failure-evidence.json"
+    run_build "${TEST_ROOT}/head-hash-failure-report.json" "$head_hash_failure_output"
+    assert_eq "actionable head hash failure exits zero" "0" "$LAST_EXIT"
+    assert_contains "actionable head hash failure reports incomplete" "evidence sidecar: incomplete" "$LAST_OUTPUT"
+    assert_jq "actionable head hash failure stays unknown" '.complete == false and .population.actionable_changes == 3 and .population.unique_actionable_head_shas == null and (._meta.missing_fields | index("population.unique_actionable_head_shas")) != null' "$head_hash_failure_output"
+
+    local bad_output="${TEST_ROOT}/bad-evidence.json"
+    run_build "${TEST_ROOT}/bad-integer-report.json" "$bad_output"
+    assert_eq "invalid numeric evidence exits two" "2" "$LAST_EXIT"
+    assert_contains "invalid numeric evidence explains rejection" "invalid integer" "$LAST_OUTPUT"
+    assert_missing "invalid numeric evidence writes no sidecar" "$bad_output"
+
+    run_build "${TEST_ROOT}/conflicting-report.json" "$bad_output"
+    assert_eq "conflicting snapshots exit two" "2" "$LAST_EXIT"
+    assert_contains "conflicting snapshots explain rejection" "conflicting snapshots" "$LAST_OUTPUT"
+    assert_missing "conflicting snapshots write no sidecar" "$bad_output"
+
+    run_build "${TEST_ROOT}/untyped-report.json" "$bad_output"
+    assert_eq "untyped evidence decision exits two" "2" "$LAST_EXIT"
+    assert_contains "untyped evidence decision explains rejection" "typed evidence events" "$LAST_OUTPUT"
+    assert_missing "untyped evidence decision writes no sidecar" "$bad_output"
+
+    local symlink_target="${TEST_ROOT}/symlink-target.json"
+    local symlink_output="${TEST_ROOT}/symlink-output.json"
+    local target_contents=""
+    printf "sentinel\n" >"$symlink_target"
+    ln -s "$symlink_target" "$symlink_output"
+    run_build "$complete_report" "$symlink_output"
+    assert_eq "symlink output exits two" "2" "$LAST_EXIT"
+    assert_contains "symlink output explains rejection" "must not be a symlink" "$LAST_OUTPUT"
+    target_contents=$(<"$symlink_target")
+    assert_eq "symlink target remains unchanged" "sentinel" "$target_contents"
+
+    local before_digest=""
+    local after_digest=""
+    before_digest=$(file_sha256 "$complete_report")
+    run_build "$complete_report" "$complete_report"
+    after_digest=$(file_sha256 "$complete_report")
+    assert_eq "identical input and output exits two" "2" "$LAST_EXIT"
+    assert_contains "identical path explains rejection" "must be distinct" "$LAST_OUTPUT"
+    assert_eq "identical path leaves input unchanged" "$before_digest" "$after_digest"
+
+    local input_link="${TEST_ROOT}/input-link.json"
+    local linked_output="${TEST_ROOT}/linked-input-evidence.json"
+    ln -s "$complete_report" "$input_link"
+    run_build "$input_link" "$linked_output"
+    assert_eq "symlink input exits two" "2" "$LAST_EXIT"
+    assert_contains "symlink input explains rejection" "regular, non-symlink file" "$LAST_OUTPUT"
+    assert_missing "symlink input writes no sidecar" "$linked_output"
+
+    printf "\nTests run: %d\n" "$TESTS_RUN"
+    if [[ "$TESTS_FAILED" -gt 0 ]]; then
+        printf "Tests failed: %d\n" "$TESTS_FAILED"
+        return 1
+    fi
+    printf "All tests passed\n"
+    return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
+++ b/.agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh
@@ -37,6 +37,10 @@ setup_env() {
 	export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=999999999
 	export PULSE_BATCH_SEARCH_LAST_RESORT=1
 	export PULSE_BATCH_SNAPSHOT_AUTH_SCOPE=github.com
+	export AIDEVOPS_GH_API_LOG="$TEST_ROOT/gh-api-calls.log"
+	export AIDEVOPS_GH_API_REPORT="$TEST_ROOT/gh-api-report.json"
+	export AIDEVOPS_GH_API_EVIDENCE="$TEST_ROOT/gh-api-evidence.json"
+	unset AIDEVOPS_GH_API_INSTRUMENT_DISABLE
 	unset AIDEVOPS_GH_FORCE_REST_READS
 	unset AIDEVOPS_GH_REST_FIRST_READS
 	mkdir -p "$HOME" "$PULSE_BATCH_PREFETCH_CACHE_DIR" "$TEST_ROOT/bin"
@@ -335,6 +339,34 @@ test_read_cache_rejects_non_hit_states() {
 	return 0
 }
 
+test_cache_states_record_private_efficiency_evidence() {
+	setup_env
+	local cache_file="$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json"
+	local state_meta="$TEST_ROOT/cache-evidence-state.log"
+	local now=""
+	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	printf '{"timestamp":"%s","items":[]}\n' "$now" >"$cache_file"
+	"$HELPER" read-cache --kind prs --slug owner/repo >/dev/null 2>"$state_meta"
+	local passed=0
+	if ! grep -q 'evidence:cache.fresh_empty_hits:1' "$AIDEVOPS_GH_API_LOG" \
+		|| grep -q 'owner/repo' "$AIDEVOPS_GH_API_LOG"; then
+		passed=1
+	fi
+	: >"$AIDEVOPS_GH_API_LOG"
+	export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=1
+	printf '{"timestamp":"2026-01-01T00:00:00Z","items":[]}\n' >"$cache_file"
+	if "$HELPER" read-cache --kind prs --slug owner/repo >/dev/null 2>"$state_meta"; then
+		passed=1
+	fi
+	local event=""
+	for event in cache.misses cache.stale guardrails.stale_snapshot_detections guardrails.forced_live_refreshes; do
+		grep -q "evidence:${event}:1" "$AIDEVOPS_GH_API_LOG" || passed=1
+	done
+	print_result "cache states emit typed evidence without repository identities" "$passed"
+	teardown_env
+	return 0
+}
+
 test_read_cache_recovers_after_atomic_replacement() {
 	setup_env
 	local cache_file="$PULSE_BATCH_PREFETCH_CACHE_DIR/prs-owner__repo.json"
@@ -484,6 +516,36 @@ run_prefetch_consumer_case() (
 	fi
 	return 0
 )
+
+fresh_empty_fallback_guardrail_case() (
+	setup_env
+	local scripts_dir=""
+	scripts_dir=$(cd "$SCRIPT_DIR/.." && pwd)
+	SCRIPT_DIR="$scripts_dir"
+	local evidence_calls="$TEST_ROOT/fallback-evidence.log"
+	gh_record_efficiency_evidence() {
+		local name="$1"
+		local value="$2"
+		printf '%s=%s\n' "$name" "$value" >>"$evidence_calls"
+		return 0
+	}
+	unset _PULSE_PREFETCH_FETCH_LOADED
+	# shellcheck source=../pulse-prefetch-fetch.sh
+	source "$scripts_dir/pulse-prefetch-fetch.sh"
+	_prefetch_record_fresh_empty_live_fallback true '{"items":[]}'
+	_prefetch_record_fresh_empty_live_fallback true '{"items":[{"number":1}]}'
+	_prefetch_record_fresh_empty_live_fallback false '{"items":[]}'
+	[[ "$(grep -c '^path_budgets.fresh_empty_live_fallbacks=1$' "$evidence_calls")" == "1" ]]
+)
+
+test_fresh_empty_fallback_guardrail_is_narrow() {
+	if fresh_empty_fallback_guardrail_case; then
+		print_result "fresh-empty live fallback guardrail records only violations" 0
+	else
+		print_result "fresh-empty live fallback guardrail records only violations" 1
+	fi
+	return 0
+}
 
 test_prefetch_consumers_accept_fresh_empty_hits() {
 	if run_prefetch_consumer_case empty; then
@@ -678,7 +740,9 @@ test_legacy_issue_cache_avoids_search_by_default
 test_read_cache_filters_closed_issues
 test_read_cache_accepts_fresh_empty_arrays
 test_read_cache_rejects_non_hit_states
+test_cache_states_record_private_efficiency_evidence
 test_read_cache_recovers_after_atomic_replacement
+test_fresh_empty_fallback_guardrail_is_narrow
 test_prefetch_consumers_accept_fresh_empty_hits
 test_prefetch_consumers_accept_nonempty_legacy_and_versioned_hits
 test_prefetch_consumers_fallback_on_non_hit_states

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -22,6 +22,15 @@ SNAPSHOT_MODE="happy_advisory"
 RERUN_CALLS=0
 TESTS_RUN=0
 TESTS_FAILED=0
+EVIDENCE_LOG="${TEST_ROOT}/efficiency-evidence.log"
+: >"$EVIDENCE_LOG"
+
+gh_record_efficiency_evidence() {
+	local name="$1"
+	local value="$2"
+	printf '%s=%s\n' "$name" "$value" >>"$EVIDENCE_LOG"
+	return 0
+}
 
 cleanup() {
 	rm -rf "$TEST_ROOT"
@@ -379,7 +388,15 @@ main() {
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
 	assert_gate "skipped rerun preserves successful baseline companion" skipped_companion_rerun 0
+	: >"$EVIDENCE_LOG"
 	assert_gate "active broad check blocks merge" pending 1
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$(grep -c '^guardrails.required_check_merge_preflight_mismatches=1$' "$EVIDENCE_LOG")" == "1" ]]; then
+		printf 'PASS live preflight mismatch emits typed guardrail evidence\n'
+	else
+		printf 'FAIL live preflight mismatch did not emit typed guardrail evidence\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
 	assert_gate "terminal failed required check blocks merge" required_fail 1
 	assert_gate "infrastructure-failed required check requests rerun and stays blocked" required_infra_fail 1
 	if [[ "$RERUN_CALLS" -eq 1 ]] && grep -q "requested infrastructure rerun.*run=303" "$LOGFILE"; then

--- a/.agents/scripts/tests/test-pulse-merge-webhook-invalidation.py
+++ b/.agents/scripts/tests/test-pulse-merge-webhook-invalidation.py
@@ -69,6 +69,8 @@ class WebhookInvalidationTests(unittest.TestCase):
         self.secret = b"signed-fixture-secret"
         self.records: list[str] = []
         self.logs: list[str] = []
+        self.received_markers: list[int] = []
+        self.dispatch_evidence: list[str] = []
         self.original_emit = SERVER._emit_records
         self.original_log = SERVER._log
         SERVER.SECRET = self.secret
@@ -89,7 +91,10 @@ class WebhookInvalidationTests(unittest.TestCase):
             "workflow_run",
         }
 
-        def capture_records(invalidations: list[str], actions: list[tuple[str, int]]) -> None:
+        def capture_records(
+            invalidations: list[str], actions: list[tuple[str, int]], received_ms: int
+        ) -> None:
+            self.received_markers.append(received_ms)
             self.records.extend(invalidations)
             self.records.extend(f"PROCESS_PR {slug} {number}" for slug, number in actions)
 
@@ -236,6 +241,8 @@ class WebhookInvalidationTests(unittest.TestCase):
             ["INVALIDATE v1 collection issues owner/repo"],
             self.records,
         )
+        self.assertEqual(1, len(self.received_markers))
+        self.assertGreater(self.received_markers[0], 0)
         self.assertEqual(0o600, stat.S_IMODE(self.ledger.stat().st_mode))
         ledger_text = self.ledger.read_text(encoding="utf-8")
         self.assertNotIn("RAW-BODY-SENTINEL", ledger_text)
@@ -548,8 +555,15 @@ class WebhookInvalidationTests(unittest.TestCase):
         actions = self.root / "actions.txt"
         actions.write_text("\n".join(records) + "\n", encoding="utf-8")
         call_log = self.root / "dispatch.log"
+        evidence_log = self.root / "dispatch-evidence.log"
         script = r'''
 source "$RECEIVER_PATH"
+gh_record_efficiency_evidence() {
+    local name="$1"
+    local value="$2"
+    printf '%s|%s\n' "$name" "$value" >>"$EVIDENCE_LOG"
+    return 0
+}
 _webhook_invalidate_collection() {
     local kind="$1"
     local slug="$2"
@@ -579,6 +593,7 @@ wait
             {
                 "ACTIONS_FILE": str(actions),
                 "CALL_LOG": str(call_log),
+                "EVIDENCE_LOG": str(evidence_log),
                 "FAIL_COLLECTION": "1" if fail_collection else "0",
                 "HOME": str(self.root / "home"),
                 "RECEIVER_PATH": str(RECEIVER_PATH),
@@ -594,13 +609,20 @@ wait
             check=False,
         )  # nosec B603 B607
         self.assertEqual(0, result.returncode, result.stderr or result.stdout)
+        self.dispatch_evidence = (
+            evidence_log.read_text(encoding="utf-8").splitlines()
+            if evidence_log.exists()
+            else []
+        )
         if not call_log.exists():
             return []
         return call_log.read_text(encoding="utf-8").splitlines()
 
     def test_receiver_dispatches_invalidation_before_process_pr(self) -> None:
+        received_ms = int(time.time() * 1000) - 2_000
         calls = self._dispatch_receiver_records(
             [
+                f"DELIVERY v1 received-ms {received_ms}",
                 "INVALIDATE v1 collection prs owner/repo",
                 f"INVALIDATE v1 checks owner/repo {'c' * 40}",
                 "PROCESS_PR owner/repo 12",
@@ -614,10 +636,19 @@ wait
             ],
             calls,
         )
+        self.assertEqual(2, self.dispatch_evidence.count("webhook.invalidations|1"))
+        lag_samples = [
+            int(value.split("|", 1)[1])
+            for value in self.dispatch_evidence
+            if value.startswith("webhook.lag_ms|")
+        ]
+        self.assertEqual(2, len(lag_samples))
+        self.assertTrue(all(value >= 0 for value in lag_samples))
 
     def test_receiver_skips_process_when_invalidation_fails(self) -> None:
         calls = self._dispatch_receiver_records(
             [
+                f"DELIVERY v1 received-ms {int(time.time() * 1000) - 2_000}",
                 "INVALIDATE v1 collection prs owner/repo",
                 "PROCESS_PR owner/repo 12",
                 "# accepted event=pull_request delivery=fixture invalidations=1 actions=1",
@@ -629,6 +660,8 @@ wait
             ["collection|prs|owner/repo", "process|owner/repo|13"],
             calls,
         )
+        self.assertIn("webhook.missed_recoveries|1", self.dispatch_evidence)
+        self.assertNotIn("webhook.invalidations|1", self.dispatch_evidence)
 
     def test_receiver_rejects_unknown_protocol_before_process_pr(self) -> None:
         calls = self._dispatch_receiver_records(

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -27,6 +27,7 @@ fail() {
 
 export SCRIPT_DIR="${TMP}/scripts"
 export WRAPPER_LOGFILE="${TMP}/wrapper.log"
+export AIDEVOPS_GH_API_EVIDENCE_COVERAGE_START_FILE="${TMP}/coverage-start"
 export PULSE_SCOPE_REPOS="owner/repo"
 mkdir -p "$SCRIPT_DIR"
 : >"$WRAPPER_LOGFILE"
@@ -65,6 +66,30 @@ state)
 esac
 EOF
 chmod +x "${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
+
+EVIDENCE_FILE="${TMP}/evidence.log"
+AGGREGATE_FILE="${TMP}/aggregate.log"
+TRIM_FILE="${TMP}/trim.log"
+: >"$EVIDENCE_FILE"
+: >"$AGGREGATE_FILE"
+: >"$TRIM_FILE"
+
+gh_record_efficiency_evidence() {
+	local name="$1"
+	local value="$2"
+	printf '%s=%s\n' "$name" "$value" >>"$EVIDENCE_FILE"
+	return 0
+}
+
+gh_aggregate_calls() {
+	printf 'aggregate\n' >>"$AGGREGATE_FILE"
+	return 0
+}
+
+gh_trim_log() {
+	printf 'trim\n' >>"$TRIM_FILE"
+	return 0
+}
 
 SOURCE_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/pulse-wrapper-cycle-gates.sh"
 # shellcheck disable=SC1090
@@ -110,6 +135,85 @@ if grep -q 'timed out after 30s' "$WRAPPER_LOGFILE"; then
 	pass "idle-work timeout is logged"
 else
 	fail "idle-work timeout is logged"
+fi
+
+: >"$EVIDENCE_FILE"
+: >"$AGGREGATE_FILE"
+: >"$TRIM_FILE"
+_pulse_efficiency_cycle_start
+_PULSE_EFFICIENCY_CYCLE_START_MS=$((_PULSE_EFFICIENCY_CYCLE_START_MS - 25))
+_pulse_efficiency_cycle_finish idle
+if grep -q '^contract=1$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage-start=[0-9]' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.population=1$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.latency=1$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.cache=1$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.single_flight=1$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.path_budgets=1$' "$EVIDENCE_FILE" \
+	&& grep -q '^population.pulse_cycles=1$' "$EVIDENCE_FILE" \
+	&& grep -q '^population.unchanged_cycles=1$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage-end=[0-9]' "$EVIDENCE_FILE" \
+	&& ! grep -q '^latency.completed_action_ms=' "$EVIDENCE_FILE"; then
+	pass "idle cycle publishes complete typed evidence"
+else
+	fail "idle cycle publishes complete typed evidence"
+fi
+
+_pulse_efficiency_cycle_finish idle
+if [[ "$(wc -l <"$AGGREGATE_FILE" | tr -d ' ')" == "1" ]] \
+	&& [[ "$(wc -l <"$TRIM_FILE" | tr -d ' ')" == "1" ]]; then
+	pass "cycle finish aggregates and trims exactly once"
+else
+	fail "cycle finish aggregates and trims exactly once"
+fi
+
+: >"$EVIDENCE_FILE"
+_PULSE_HEALTH_PRS_MERGED=1
+_PULSE_HEALTH_PRS_CLOSED_CONFLICTING=0
+_PULSE_EFFICIENCY_CYCLE_OUTCOME=idle
+_pulse_efficiency_cycle_start
+_PULSE_EFFICIENCY_CYCLE_START_MS=$((_PULSE_EFFICIENCY_CYCLE_START_MS - 25))
+_pulse_record_cycle_outcome 0
+_pulse_efficiency_cycle_finish
+if [[ "$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "active" ]] \
+	&& grep -Eq '^latency.completed_action_ms=[1-9][0-9]*$' "$EVIDENCE_FILE" \
+	&& ! grep -q '^population.unchanged_cycles=' "$EVIDENCE_FILE"; then
+	pass "active cycle records completed-action latency"
+else
+	fail "active cycle records completed-action latency"
+fi
+
+PREFETCH_INFRA="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/pulse-prefetch-infra.sh"
+# shellcheck disable=SC1090
+source "$PREFETCH_INFRA"
+local_entries_a=$'beta/repo|/private/beta\nalpha/repo|/private/alpha\nbeta/repo|/duplicate'
+local_entries_b=$'alpha/repo|/changed/path\nbeta/repo|/other/path'
+: >"$EVIDENCE_FILE"
+_prefetch_record_efficiency_population "$local_entries_a"
+repo_hash_a=$(awk -F= '$1 == "population.repository_set_sha256" {print $2}' "$EVIDENCE_FILE")
+first_population_log=$(<"$EVIDENCE_FILE")
+: >"$EVIDENCE_FILE"
+_prefetch_record_efficiency_population "$local_entries_b"
+repo_hash_b=$(awk -F= '$1 == "population.repository_set_sha256" {print $2}' "$EVIDENCE_FILE")
+if [[ "$repo_hash_a" =~ ^[0-9a-f]{64}$ && "$repo_hash_a" == "$repo_hash_b" ]] \
+	&& printf '%s\n' "$first_population_log" | grep -q '^population.repository_count=2$' \
+	&& ! printf '%s\n' "$first_population_log" | grep -qE 'alpha/repo|beta/repo|/private/'; then
+	pass "repository population evidence is deterministic and private"
+else
+	fail "repository population evidence is deterministic and private"
+fi
+
+PREFETCH_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/pulse-prefetch-repo.sh"
+# shellcheck disable=SC1090
+source "$PREFETCH_REPO"
+: >"$EVIDENCE_FILE"
+PULSE_BATCH_PREFETCH_ENABLED=0
+_prefetch_single_repo_load_snapshots alpha/repo
+if [[ "$(grep -c '^cache.misses=1$' "$EVIDENCE_FILE")" == "2" ]] \
+	&& [[ "$(grep -c '^guardrails.forced_live_refreshes=1$' "$EVIDENCE_FILE")" == "2" ]]; then
+	pass "disabled canonical cache records forced live decisions"
+else
+	fail "disabled canonical cache records forced live decisions"
 fi
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Add digest-bound production evidence sidecars, exact-window benchmark inputs, privacy-safe Pulse/cache/single-flight/webhook telemetry, and fail-closed coverage ownership.

## Files Changed

.agents/reference/github-api-efficiency.md, .agents/scripts/gh-api-aggregate.awk, .agents/scripts/gh-api-instrument.sh, .agents/scripts/github-api-efficiency-benchmark.py, .agents/scripts/github-api-efficiency-evidence.py, .agents/scripts/github-api-efficiency-evidence.sh, .agents/scripts/github_api_efficiency_events.py, .agents/scripts/github_api_efficiency_inputs.py, .agents/scripts/github_api_efficiency_io.py, .agents/scripts/github_api_efficiency_report.py, .agents/scripts/pulse-batch-prefetch-helper.sh, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/pulse-merge-webhook-receiver.sh, .agents/scripts/pulse-merge-webhook-server.py, .agents/scripts/pulse-prefetch-fetch.sh, .agents/scripts/pulse-prefetch-infra.sh, .agents/scripts/pulse-prefetch-repo.sh, .agents/scripts/pulse-prefetch.sh, .agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/pulse-wrapper.sh, .agents/scripts/shared-gh-request-state.sh, .agents/scripts/shared-gh-wrappers-checks.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-gh-check-status-cache.sh, .agents/scripts/tests/test-gh-request-singleflight.sh, .agents/scripts/tests/test-github-api-efficiency-benchmark.sh, .agents/scripts/tests/test-github-api-efficiency-evidence.sh, .agents/scripts/tests/test-pulse-batch-prefetch-conditional-rest.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh, .agents/scripts/tests/test-pulse-merge-webhook-invalidation.py, .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh

## Runtime Testing

- **Risk level:** High (shared polling, cache state, and webhook paths)
- **Verification:** Runtime-verified by executing the API instrumentation, concurrent single-flight, check-cache, Pulse-cycle, canonical-cache, webhook receiver, merge-preflight, evidence, and benchmark integration suites; changed and full local quality gates pass.

## Decisions

- Keep rollout defaults and flags unchanged.
- Keep incomplete webhook and guardrail ownership as `null` until deployed complete 12–24h evidence supports tuning or retirement.
- This implementation PR advances #27777 but does not claim the required production canary.

For #27777


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.154 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 1d 22h and 13,466,151 tokens on this with the user in an interactive session.