### PR TITLE
GH#28080: fix pre-edit timeout side effects

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs
@@ -59,3 +59,68 @@ test("pre-edit tool validates the explicitly targeted Git worktree", async () =>
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("slow loop-mode creation is reported exactly once beyond the former timeout", { timeout: 30000 }, async () => {
+  const root = mkdtempSync(join(tmpdir(), "t28080-pre-edit-slow-"));
+  const repo = join(root, "repo");
+  const linked = join(root, "slow-linked");
+  const fixtureScripts = join(root, "scripts");
+
+  try {
+    mkdirSync(repo);
+    mkdirSync(fixtureScripts);
+    git(repo, ["init", "--initial-branch=main"]);
+    git(repo, ["config", "user.email", "test@example.invalid"]);
+    git(repo, ["config", "user.name", "Test"]);
+    git(repo, ["config", "commit.gpgsign", "false"]);
+    writeFileSync(join(repo, "README.md"), "fixture\n");
+    git(repo, ["add", "README.md"]);
+    git(repo, ["commit", "--no-gpg-sign", "-m", "init"]);
+    writeFileSync(join(fixtureScripts, "pre-edit-check.sh"), `#!/usr/bin/env bash
+set -eu
+linked=${JSON.stringify(linked)}
+if ! /usr/bin/git -C "$PWD" show-ref --verify --quiet refs/heads/bugfix/slow-fixture; then
+  sleep 10.1
+  /usr/bin/git -C "$PWD" worktree add -q -b bugfix/slow-fixture "$linked"
+fi
+printf 'LOOP_DECISION=worktree_created\\nWORKTREE_PATH=%s\\nNEXT_STEP: cd to the worktree path and continue implementation there.\\n' "$linked"
+`);
+
+    const preEditTool = createTools(fixtureScripts, () => "").aidevops_pre_edit_check;
+    const firstResult = await preEditTool.execute({ workdir: repo, task: "fix slow fixture" });
+    const secondResult = await preEditTool.execute({ workdir: repo, task: "fix slow fixture" });
+
+    assert.match(firstResult, /Pre-edit check PASSED \(exit 0\)/);
+    assert.match(firstResult, new RegExp(`WORKTREE_PATH=${linked.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+    assert.match(secondResult, /Pre-edit check PASSED \(exit 0\)/);
+    const worktreeList = git(repo, ["worktree", "list", "--porcelain"]);
+    assert.equal(worktreeList.split("branch refs/heads/bugfix/slow-fixture").length - 1, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("timeout is explicit and terminates the complete fixture process tree", async () => {
+  const root = mkdtempSync(join(tmpdir(), "t28080-pre-edit-timeout-"));
+  const repo = join(root, "repo");
+  const fixtureScripts = join(root, "scripts");
+  const lateMarker = join(root, "late-side-effect");
+
+  try {
+    mkdirSync(repo);
+    mkdirSync(fixtureScripts);
+    git(repo, ["init", "--initial-branch=main"]);
+    writeFileSync(join(fixtureScripts, "pre-edit-check.sh"), `#!/usr/bin/env bash
+sleep 0.2
+touch ${JSON.stringify(lateMarker)}
+`);
+    const preEditTool = createTools(fixtureScripts, () => "", { preEditTimeoutMs: 25 }).aidevops_pre_edit_check;
+    const result = await preEditTool.execute({ workdir: repo, task: "fix timeout fixture" });
+
+    assert.match(result, /Pre-edit check TIMED OUT after 25ms/);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 300));
+    assert.equal(existsSync(lateMarker), false, "timed-out descendants must not complete side effects");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -165,6 +165,61 @@ function createMemoryTool(scriptsDir, run) {
   });
 }
 
+const PRE_EDIT_GUIDANCE = {
+  1: "STOP — you are on main/master branch. Create a worktree first.",
+  2: "Create a worktree before proceeding with edits.",
+  3: "WARNING — proceed with caution.",
+};
+
+/**
+ * Resolve and validate a requested Git worktree path.
+ * @param {string} requestedWorkdir
+ * @returns {string}
+ */
+function resolveGitWorktree(requestedWorkdir) {
+  let targetWorkdir = "";
+  try {
+    const resolvedWorkdir = realpathSync(requestedWorkdir);
+    if (statSync(resolvedWorkdir).isDirectory()) {
+      const insideWorktree = execFileSync(
+        "git",
+        ["-C", resolvedWorkdir, "rev-parse", "--is-inside-work-tree"],
+        {
+          encoding: "utf-8",
+          timeout: 5000,
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      ).trim();
+      if (insideWorktree === "true") targetWorkdir = resolvedWorkdir;
+    }
+  } catch {
+    targetWorkdir = "";
+  }
+  return targetWorkdir;
+}
+
+/**
+ * Format the pre-edit subprocess outcome for the tool response.
+ * @param {{code: number|null, stdout: string, stderr: string, timedOut: boolean, error?: Error}} result
+ * @param {number} timeoutMs
+ * @returns {string}
+ */
+function formatPreEditCheckResult(result, timeoutMs) {
+  const cmdOutput = (result.stdout + result.stderr).trim();
+  let response;
+  if (result.timedOut) {
+    response = `Pre-edit check TIMED OUT after ${timeoutMs}ms: child process tree terminated before returning\n${cmdOutput}`;
+  } else if (result.error) {
+    response = `Pre-edit check failed to start: ${result.error.message}\n${cmdOutput}`;
+  } else {
+    const code = result.code ?? 1;
+    response = code === 0
+      ? `Pre-edit check PASSED (exit 0):\n${cmdOutput}`
+      : `Pre-edit check exit ${code}: ${PRE_EDIT_GUIDANCE[code] || "Unknown"}\n${cmdOutput}`;
+  }
+  return response;
+}
+
 /**
  * Create the pre-edit check tool.
  * @param {string} scriptsDir - Path to scripts directory
@@ -172,12 +227,6 @@ function createMemoryTool(scriptsDir, run) {
  * @returns {object} Tool definition
  */
 function createPreEditCheckTool(scriptsDir, timeoutMs = 120000) {
-  const PRE_EDIT_GUIDANCE = {
-    1: "STOP — you are on main/master branch. Create a worktree first.",
-    2: "Create a worktree before proceeding with edits.",
-    3: "WARNING — proceed with caution.",
-  };
-
   return tool({
     description:
       'Run the pre-edit git safety check before modifying files. Returns exit code and guidance. Args: task (optional string for loop mode), workdir (optional target Git worktree)',
@@ -192,39 +241,13 @@ function createPreEditCheckTool(scriptsDir, timeoutMs = 120000) {
         return "pre-edit-check.sh not found — cannot verify git safety";
       }
       const requestedWorkdir = args.workdir || process.cwd();
-      let targetWorkdir = "";
-      try {
-        targetWorkdir = realpathSync(requestedWorkdir);
-        if (!statSync(targetWorkdir).isDirectory()) targetWorkdir = "";
-        const insideWorktree = targetWorkdir
-          ? execFileSync("git", ["-C", targetWorkdir, "rev-parse", "--is-inside-work-tree"], {
-              encoding: "utf-8",
-              timeout: 5000,
-              stdio: ["ignore", "pipe", "ignore"],
-            }).trim()
-          : "";
-        if (insideWorktree !== "true") targetWorkdir = "";
-      } catch {
-        targetWorkdir = "";
-      }
+      const targetWorkdir = resolveGitWorktree(requestedWorkdir);
       if (!targetWorkdir) {
         return `Pre-edit check exit 1: target workdir must resolve to an existing Git worktree\n${requestedWorkdir}`;
       }
       const taskArgs = args.task ? ["--loop-mode", "--task", args.task] : [];
       const result = await runPreEditCheck(script, taskArgs, targetWorkdir, timeoutMs);
-      const cmdOutput = (result.stdout + result.stderr).trim();
-      let response;
-      if (result.timedOut) {
-        response = `Pre-edit check TIMED OUT after ${timeoutMs}ms: child process tree terminated before returning\n${cmdOutput}`;
-      } else if (result.error) {
-        response = `Pre-edit check failed to start: ${result.error.message}\n${cmdOutput}`;
-      } else {
-        const code = result.code ?? 1;
-        response = code === 0
-          ? `Pre-edit check PASSED (exit 0):\n${cmdOutput}`
-          : `Pre-edit check exit ${code}: ${PRE_EDIT_GUIDANCE[code] || "Unknown"}\n${cmdOutput}`;
-      }
-      return response;
+      return formatPreEditCheckResult(result, timeoutMs);
     },
   });
 }

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -1,4 +1,4 @@
-import { execFileSync, execSync } from "child_process";
+import { execFileSync, execSync, spawn } from "child_process";
 import { existsSync, realpathSync, statSync } from "fs";
 import { join } from "path";
 
@@ -168,9 +168,10 @@ function createMemoryTool(scriptsDir, run) {
 /**
  * Create the pre-edit check tool.
  * @param {string} scriptsDir - Path to scripts directory
+ * @param {number} [timeoutMs=120000] - Maximum check runtime
  * @returns {object} Tool definition
  */
-function createPreEditCheckTool(scriptsDir) {
+function createPreEditCheckTool(scriptsDir, timeoutMs = 120000) {
   const PRE_EDIT_GUIDANCE = {
     1: "STOP — you are on main/master branch. Create a worktree first.",
     2: "Create a worktree before proceeding with edits.",
@@ -210,20 +211,63 @@ function createPreEditCheckTool(scriptsDir) {
         return `Pre-edit check exit 1: target workdir must resolve to an existing Git worktree\n${requestedWorkdir}`;
       }
       const taskArgs = args.task ? ["--loop-mode", "--task", args.task] : [];
-      try {
-        const result = execFileSync("bash", [script, ...taskArgs], {
-          cwd: targetWorkdir,
-          encoding: "utf-8",
-          timeout: 10000,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
-        return `Pre-edit check PASSED (exit 0):\n${result.trim()}`;
-      } catch (err) {
-        const code = err.status || 1;
-        const cmdOutput = (err.stdout || "") + (err.stderr || "");
-        return `Pre-edit check exit ${code}: ${PRE_EDIT_GUIDANCE[code] || "Unknown"}\n${cmdOutput.trim()}`;
+      const result = await runPreEditCheck(script, taskArgs, targetWorkdir, timeoutMs);
+      const cmdOutput = (result.stdout + result.stderr).trim();
+      if (result.timedOut) {
+        return `Pre-edit check TIMED OUT after ${timeoutMs}ms: child process tree terminated before returning\n${cmdOutput}`;
       }
+      if (result.error) {
+        return `Pre-edit check failed to start: ${result.error.message}\n${cmdOutput}`;
+      }
+      if (result.code === 0) {
+        return `Pre-edit check PASSED (exit 0):\n${cmdOutput}`;
+      }
+      const code = result.code ?? 1;
+      return `Pre-edit check exit ${code}: ${PRE_EDIT_GUIDANCE[code] || "Unknown"}\n${cmdOutput}`;
     },
+  });
+}
+
+/**
+ * Run loop-mode checks in their own process group so a timeout cannot leave a
+ * helper running long enough to create a worktree after the tool has returned.
+ * @param {string} script
+ * @param {string[]} args
+ * @param {string} cwd
+ * @param {number} timeoutMs
+ * @returns {Promise<{code: number|null, stdout: string, stderr: string, timedOut: boolean, error?: Error}>}
+ */
+function runPreEditCheck(script, args, cwd, timeoutMs) {
+  return new Promise((resolve) => {
+    const child = spawn("bash", [script, ...args], {
+      cwd,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let spawnError;
+
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => { spawnError = error; });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        process.kill(-child.pid, "SIGKILL");
+      } catch {
+        child.kill("SIGKILL");
+      }
+    }, timeoutMs);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr, timedOut, error: spawnError });
+    });
   });
 }
 
@@ -251,12 +295,13 @@ function createPreEditCheckTool(scriptsDir) {
  *
  * @param {string} scriptsDir - Path to scripts directory
  * @param {function} run - Shell command runner
+ * @param {{preEditTimeoutMs?: number}} [options] - Tool-specific test/runtime overrides
  * @returns {Record<string, object>}
  */
-export function createTools(scriptsDir, run) {
+export function createTools(scriptsDir, run, options = {}) {
   return {
     aidevops: createAidevopsTool(run),
     aidevops_memory: createMemoryTool(scriptsDir, run),
-    aidevops_pre_edit_check: createPreEditCheckTool(scriptsDir),
+    aidevops_pre_edit_check: createPreEditCheckTool(scriptsDir, options.preEditTimeoutMs),
   };
 }

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -213,17 +213,18 @@ function createPreEditCheckTool(scriptsDir, timeoutMs = 120000) {
       const taskArgs = args.task ? ["--loop-mode", "--task", args.task] : [];
       const result = await runPreEditCheck(script, taskArgs, targetWorkdir, timeoutMs);
       const cmdOutput = (result.stdout + result.stderr).trim();
+      let response;
       if (result.timedOut) {
-        return `Pre-edit check TIMED OUT after ${timeoutMs}ms: child process tree terminated before returning\n${cmdOutput}`;
+        response = `Pre-edit check TIMED OUT after ${timeoutMs}ms: child process tree terminated before returning\n${cmdOutput}`;
+      } else if (result.error) {
+        response = `Pre-edit check failed to start: ${result.error.message}\n${cmdOutput}`;
+      } else {
+        const code = result.code ?? 1;
+        response = code === 0
+          ? `Pre-edit check PASSED (exit 0):\n${cmdOutput}`
+          : `Pre-edit check exit ${code}: ${PRE_EDIT_GUIDANCE[code] || "Unknown"}\n${cmdOutput}`;
       }
-      if (result.error) {
-        return `Pre-edit check failed to start: ${result.error.message}\n${cmdOutput}`;
-      }
-      if (result.code === 0) {
-        return `Pre-edit check PASSED (exit 0):\n${cmdOutput}`;
-      }
-      const code = result.code ?? 1;
-      return `Pre-edit check exit ${code}: ${PRE_EDIT_GUIDANCE[code] || "Unknown"}\n${cmdOutput}`;
+      return response;
     },
   });
 }


### PR DESCRIPTION
## Summary

- Run loop-mode pre-edit checks in a detached process group with a 120-second budget, then terminate the complete child tree and report an explicit timeout if that budget expires.
- Preserve successful slow worktree creation output so callers receive the exact `WORKTREE_PATH` and next step, while repeated calls reuse the existing branch/worktree.
- Add regression fixtures for creation beyond the former 10-second timeout, deduplication, and prevention of late child side effects.
- Return the classified result once to remove the `qlty:return-statements` regression captured from PR #28260.

## Files Changed

- `.agents/plugins/opencode-aidevops/tools.mjs`
- `.agents/plugins/opencode-aidevops/tests/test-pre-edit-tool-workdir.mjs`

## Runtime Testing

- **Risk level:** Low (OpenCode plugin infrastructure)
- `node --check tools.mjs`
- `node --test tests/test-pre-edit-tool-workdir.mjs` — 3/3 passed
- `node --test --test-concurrency=4 "tests/*.mjs"` with isolated HOME/XDG/temp state — 461/461 passed
- `.agents/scripts/linters-local.sh` — changed-file gates passed
- `git diff --check`

Resolves #28080


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.155 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 18m and 173,804 tokens on this as a headless worker.
