### PR TITLE
GH#28223: fix: stabilize Qlty cache-sensitive scans

### DIFF
--- a/.agents/scripts/qlty-regression-helper.sh
+++ b/.agents/scripts/qlty-regression-helper.sh
@@ -41,26 +41,11 @@ BASE_WORKTREE=""
 HEAD_WORKTREE=""
 QLTY_BIN=""
 QLTY_VERSION=""
+GIT_BIN=""
 UNKNOWN_VALUE="unknown"
 DIRECT_SCAN_MODE="direct-checkout"
 
 cleanup() {
-	if [ -n "$BASE_WORKTREE" ] && [ -d "$BASE_WORKTREE" ]; then
-		# Path-shape assertion (t2974): only remove paths matching the fixture pattern
-		if [[ "$BASE_WORKTREE" != */base-worktree ]]; then
-			log "WARN: Path '$BASE_WORKTREE' does not match fixture pattern — skipping remove"
-		else
-			git worktree remove --force "$BASE_WORKTREE" >/dev/null 2>&1 || true
-		fi
-	fi
-	if [ -n "$HEAD_WORKTREE" ] && [ -d "$HEAD_WORKTREE" ]; then
-		# Path-shape assertion (t2974): only remove paths matching the fixture pattern
-		if [[ "$HEAD_WORKTREE" != */head-worktree ]]; then
-			log "WARN: Path '$HEAD_WORKTREE' does not match fixture pattern — skipping remove"
-		else
-			git worktree remove --force "$HEAD_WORKTREE" >/dev/null 2>&1 || true
-		fi
-	fi
 	if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
 		rm -rf "$TMP_DIR"
 	fi
@@ -97,6 +82,22 @@ find_qlty() {
 	return 1
 }
 
+resolve_git() {
+	local _candidate=""
+	if [ -n "${AIDEVOPS_REAL_GIT_BIN:-}" ] && [ -x "$AIDEVOPS_REAL_GIT_BIN" ]; then
+		printf '%s\n' "$AIDEVOPS_REAL_GIT_BIN"
+		return 0
+	fi
+	while IFS= read -r _candidate; do
+		case "$_candidate" in
+		*/.aidevops/*/agents/scripts/git | */.aidevops/bin/git | */.agents/scripts/git) continue ;;
+		esac
+		printf '%s\n' "$_candidate"
+		return 0
+	done < <(type -a -p git 2>/dev/null || true)
+	return 1
+}
+
 # run_qlty_sarif <working-dir> <output-file>
 run_qlty_sarif() {
 	local _dir="$1"
@@ -110,6 +111,11 @@ run_qlty_sarif() {
 	# --all: scan all files; --sarif: JSON output;
 	# --no-snippets: compact; --quiet: suppress progress.
 	# qlty exits non-zero when smells exist — SARIF still written to stdout.
+	# Qlty 0.619.0 and 0.635.0 can emit extra similar-code findings on the
+	# first scan of an empty cache. Warm that per-ref cache, then retain only
+	# the second scan so cold/warm runner state cannot change gate results.
+	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
+		>/dev/null 2>/dev/null || true
 	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
 		>"$_out" 2>/dev/null || true
 	if [ ! -s "$_out" ]; then
@@ -127,8 +133,8 @@ create_scan_clone() {
 	local _destination="$1"
 	local _sha="$2"
 	local _repo_root="$3"
-	git clone --quiet --shared --no-checkout "$_repo_root" "$_destination" || return 1
-	git -C "$_destination" checkout --detach --quiet "$_sha" || return 1
+	"$GIT_BIN" clone --quiet --shared --no-checkout "$_repo_root" "$_destination" || return 1
+	"$GIT_BIN" -C "$_destination" checkout --detach --quiet "$_sha" || return 1
 	return 0
 }
 
@@ -404,6 +410,7 @@ HEAD_TREE=$(git rev-parse "$HEAD^{tree}")
 REPO_ROOT=$(git rev-parse --show-toplevel)
 QLTY_BIN=$(find_qlty) || die "qlty CLI not found"
 QLTY_VERSION=$("$QLTY_BIN" --version 2>/dev/null) || QLTY_VERSION="$UNKNOWN_VALUE"
+GIT_BIN=$(resolve_git) || die "native git executable not found"
 if [ -n "${QLTY_CLI_VERSION:-}" ] && [[ "$QLTY_VERSION" != *" ${QLTY_CLI_VERSION}"* ]]; then
 	die "Qlty CLI version mismatch: expected ${QLTY_CLI_VERSION}, resolved $QLTY_VERSION"
 fi

--- a/.agents/scripts/qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/qlty-smell-threshold-helper.sh
@@ -167,7 +167,9 @@ run_threshold_check() {
 	local _conf="${1:-.agents/configs/complexity-thresholds.conf}"
 	local _threshold=""
 	local _qlty_bin=""
+	local _cache_dir=""
 	local _diag_file=""
+	local _warmup_file=""
 	local _sarif=""
 	local _count=""
 	local _headroom=""
@@ -187,10 +189,23 @@ run_threshold_check() {
 	_qlty_version=$(qlty_version "$_qlty_bin")
 	verify_qlty_version "$_qlty_version" || return 1
 
-	printf 'Counting total qlty smells across all files...\n'
+	printf 'Warming isolated qlty cache before authoritative scan...\n'
 	_diag_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-threshold.XXXXXX") || return 1
-	_sarif=$("$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>"$_diag_file")
+	_warmup_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-warmup.XXXXXX") || {
+		rm -f "$_diag_file"
+		return 1
+	}
+	_cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/qlty-smell-cache.XXXXXX") || {
+		rm -f "$_diag_file" "$_warmup_file"
+		return 1
+	}
+	XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet \
+		>"$_warmup_file" 2>/dev/null || true
+	printf 'Counting total qlty smells across all files...\n'
+	_sarif=$(XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>"$_diag_file")
 	_qlty_rc=$?
+	rm -f "$_warmup_file"
+	rm -rf "$_cache_dir"
 	if is_blank_output "$_sarif"; then
 		emit_sarif_warning "empty" "$_diag_file" "$_qlty_bin" "" "$_qlty_rc"
 		rm -f "$_diag_file"

--- a/.agents/scripts/tests/test-qlty-regression-helper.sh
+++ b/.agents/scripts/tests/test-qlty-regression-helper.sh
@@ -76,6 +76,19 @@ if [ "${QLTY_STUB_MODE:-parity}" = "head-fail" ] && [ "$(basename "$PWD")" = "re
 	printf 'simulated head failure\n' >&2
 	exit 2
 fi
+if [ "${QLTY_STUB_MODE:-parity}" = "cache-sensitive" ]; then
+	if [ -z "${XDG_CACHE_HOME:-}" ]; then
+		printf 'missing isolated cache\n' >&2
+		exit 2
+	fi
+	if [ ! -f "$XDG_CACHE_HOME/warmed" ]; then
+		: >"$XDG_CACHE_HOME/warmed"
+		printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"cold-a.sh"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"cold-b.sh"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"cold-c.sh"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.sh"}}}]}]}]}'
+	else
+		printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.sh"}}}]}]}]}'
+	fi
+	exit 0
+fi
 printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.sh"}}}]}]}]}'
 exit 0
 STUB
@@ -111,6 +124,20 @@ assert_contains "head metadata identifies direct checkout" "mode=direct-checkout
 assert_contains "same-tree identity parity is explicit" "identical normalized SARIF identities" "$parity_output"
 assert_contains "resolved Qlty version is logged" "version=qlty 0.635.0 linux-x64" "$parity_output"
 assert_contains "per-rule counts are logged" $'1\tqlty:similar-code' "$parity_output"
+
+QLTY_STUB_MODE=cache-sensitive
+export QLTY_STUB_MODE
+cache_sensitive_output=$(cd "$REPO" && "$HELPER" --base HEAD --head HEAD 2>&1)
+cache_sensitive_rc=$?
+assert_rc "cold-cache-only similar-code findings do not affect same-tree scans" "0" "$cache_sensitive_rc"
+assert_contains "both authoritative scans use warm-cache counts" "base: 1  head: 1  delta: 0" "$cache_sensitive_output"
+
+printf 'metadata only\n' >"$REPO/VERSION"
+(cd "$REPO" && "$GIT_PATH" add VERSION && "$GIT_PATH" commit --quiet -m "metadata fixture") || exit 1
+metadata_output=$(cd "$REPO" && "$HELPER" --base HEAD^ --head HEAD 2>&1)
+metadata_rc=$?
+assert_rc "metadata-only commit preserves unchanged source findings" "0" "$metadata_rc"
+assert_contains "metadata-only scan reports zero delta" "base: 1  head: 1  delta: 0" "$metadata_output"
 
 QLTY_STUB_MODE=mismatch
 export QLTY_STUB_MODE

--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -94,6 +94,19 @@ case "${QLTY_STUB_MODE:-empty}" in
 		printf '{"runs":[{"results":[{"ruleId":"file-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"ok.py"}}}]}]}]}'
 		exit 0
 		;;
+	cache-sensitive)
+		if [ -z "${XDG_CACHE_HOME:-}" ]; then
+			printf 'missing isolated cache\n' >&2
+			exit 2
+		fi
+		if [ ! -f "$XDG_CACHE_HOME/warmed" ]; then
+			: >"$XDG_CACHE_HOME/warmed"
+			printf '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"cold-a.py"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"cold-b.py"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"cold-c.py"}}}]}]}]}'
+		else
+			printf '{"runs":[{"results":[{"ruleId":"file-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"stable.py"}}}]}]}]}'
+		fi
+		exit 0
+		;;
 	fail)
 		printf '{"runs":[{"results":[{"ruleId":"file-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.py"}}}]},{"ruleId":"function-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"b.py"}}}]},{"ruleId":"function-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"b.py"}}}]}]}]}'
 		exit 0
@@ -174,6 +187,19 @@ assert_contains "valid SARIF reports scan mode" "Scan mode: direct-checkout" "$p
 assert_contains "valid SARIF reports logical root" "Scan root: repository-root" "$pass_output"
 assert_contains "valid SARIF reports normalized count" "Normalized result count: 1" "$pass_output"
 assert_contains "valid SARIF reports per-rule counts" $'  1\tfile-complexity' "$pass_output"
+
+write_stub_qlty cache-sensitive "$BIN_DIR"
+cache_sensitive_output=$($HELPER "$CONF" 2>&1)
+cache_sensitive_rc=$?
+assert_rc "cold-cache-only similar-code findings do not affect the gate" "0" "$cache_sensitive_rc"
+assert_contains "absolute scan warms an isolated cache" "Warming isolated qlty cache" "$cache_sensitive_output"
+assert_contains "authoritative scan uses the stable warm-cache count" "Normalized result count: 1" "$cache_sensitive_output"
+assert_not_contains "cold-cache-only similar-code identities are discarded" "cold-a.py" "$cache_sensitive_output"
+
+repeated_cache_output=$($HELPER "$CONF" 2>&1)
+repeated_cache_rc=$?
+assert_rc "repeated isolated-cache scan remains stable" "0" "$repeated_cache_rc"
+assert_contains "repeated scan retains stable count" "Normalized result count: 1" "$repeated_cache_output"
 
 write_stub_qlty fail "$BIN_DIR"
 fail_output=$("$HELPER" "$CONF" 2>&1)


### PR DESCRIPTION
## Summary

Warm a fresh isolated Qlty cache before each authoritative absolute and regression scan, use the native Git binary for disposable scan clones, and add cold-cache plus metadata-only regressions.

## Files Changed

.agents/scripts/qlty-regression-helper.sh, .agents/scripts/qlty-smell-threshold-helper.sh, .agents/scripts/tests/test-qlty-regression-helper.sh, .agents/scripts/tests/test-qlty-smell-threshold-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-qlty-smell-threshold-helper.sh; bash .agents/scripts/tests/test-qlty-regression-helper.sh; shellcheck on both helpers and tests; actionlint on both Qlty workflows; git diff --check

Resolves #28223


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.155 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 6m and 65,876 tokens on this as a headless worker.