### PR TITLE
GH#28270: fix: localize headless runtime test mock parameters

### DIFF
--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -2761,8 +2761,10 @@ test_permission_finish_failure_recovers_draft_and_runs_cleanup() {
 			_emit_worker_runtime_event() { return 0; }
 			_hrw_record_reconciled_outcome() { return 0; }
 			_hrw_finish_cleanup() {
+				local session_key="$1"
+				local ledger_status="$2"
 				cleanup_called=1
-				printf "cleanup_ledger=%s\n" "$2"
+				printf "cleanup_ledger=%s\n" "$ledger_status"
 				return 0
 			}
 
@@ -2795,8 +2797,18 @@ test_permission_finish_failure_without_output_releases_and_cleans_up() {
 			}
 			_worker_external_terminal_complete() { return 1; }
 			_recover_worker_output_on_failure() { recovery_called=1; return 1; }
-			_release_dispatch_claim() { released_reason="$2"; return 0; }
-			_report_failure_to_fast_fail() { fast_fail_reason="$2"; return 0; }
+			_release_dispatch_claim() {
+				local session_key="$1"
+				local reason="$2"
+				released_reason="$reason"
+				return 0
+			}
+			_report_failure_to_fast_fail() {
+				local session_key="$1"
+				local reason="$2"
+				fast_fail_reason="$reason"
+				return 0
+			}
 			_hrw_record_terminal_outcome() { return 0; }
 			_emit_worker_runtime_event() { return 0; }
 			_hrw_record_reconciled_outcome() { return 0; }


### PR DESCRIPTION
## Summary

Declare callback parameters locally in permission-failure test mocks and consume named reason/status variables, preventing Bash dynamic-scoping leaks.

## Files Changed

.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-headless-runtime-helper.sh; bash .agents/scripts/tests/test-headless-runtime-helper.sh (143 tests, 0 failures)

Resolves #28270


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.155 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 13m and 39,122 tokens on this as a headless worker.