### PR TITLE
GH#28272: fix: harden simplification branch fallback

### DIFF
--- a/.agents/scripts/pulse-simplification-state.sh
+++ b/.agents/scripts/pulse-simplification-state.sh
@@ -335,7 +335,8 @@ _simplification_state_push() {
 		# shellcheck source=./planning-publisher.sh
 		source "${module_dir}/planning-publisher.sh"
 	fi
-	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch="main"
+	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+	main_branch="${main_branch:-main}"
 	base_sha=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null) || return 1
 
 	AIDEVOPS_PLANNING_BASE_SHA="$base_sha" \

--- a/.agents/scripts/pulse-simplification-state.sh
+++ b/.agents/scripts/pulse-simplification-state.sh
@@ -335,7 +335,7 @@ _simplification_state_push() {
 		# shellcheck source=./planning-publisher.sh
 		source "${module_dir}/planning-publisher.sh"
 	fi
-	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch=""
 	main_branch="${main_branch:-main}"
 	base_sha=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null) || return 1
 

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -177,7 +177,7 @@ test_simplification_state_scope_preserves_checkout() {
 
 test_simplification_state_defaults_to_main_without_origin_head() {
 	local name="defaults simplification-state publication to main when origin/HEAD is unavailable"
-	local root="" repo="" remote_state=""
+	local root="" repo="" remote_state="" publish_rc=0
 	root=$(mktemp -d) || return 0
 	setup_repo "$root" || {
 		fail "$name" setup
@@ -187,11 +187,15 @@ test_simplification_state_defaults_to_main_without_origin_head() {
 	mkdir -p "${repo}/.agents/configs" || return 0
 	printf '%s\n' '{"files":{"fallback.sh":{"passes":1}}}' >"${repo}/.agents/configs/simplification-state.json"
 	git -C "$repo" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
-	run_simplification_publish "$repo" || {
+	LOGFILE=/dev/null AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+		bash -c 'set -eo pipefail; source "$1"; _simplification_state_push "$2"' \
+		_ "$STATE_SCRIPT" "$repo"
+	publish_rc=$?
+	if [[ "$publish_rc" -ne 0 ]]; then
 		fail "$name" publish
 		rm -rf "$root"
 		return 0
-	}
+	fi
 	remote_state=$(git --git-dir="${root}/remote.git" show main:.agents/configs/simplification-state.json 2>/dev/null) || remote_state=""
 	if [[ "$remote_state" == *"fallback.sh"* ]]; then
 		pass "$name"

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -175,6 +175,33 @@ test_simplification_state_scope_preserves_checkout() {
 	return 0
 }
 
+test_simplification_state_defaults_to_main_without_origin_head() {
+	local name="defaults simplification-state publication to main when origin/HEAD is unavailable"
+	local root="" repo="" remote_state=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	mkdir -p "${repo}/.agents/configs" || return 0
+	printf '%s\n' '{"files":{"fallback.sh":{"passes":1}}}' >"${repo}/.agents/configs/simplification-state.json"
+	git -C "$repo" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+	run_simplification_publish "$repo" || {
+		fail "$name" publish
+		rm -rf "$root"
+		return 0
+	}
+	remote_state=$(git --git-dir="${root}/remote.git" show main:.agents/configs/simplification-state.json 2>/dev/null) || remote_state=""
+	if [[ "$remote_state" == *"fallback.sh"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "fallback publication did not reach main"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
 test_simplification_state_conflict_is_retryable() {
 	local name="simplification-state contention fails retryably without overwriting remote state"
 	local root="" repo="" hook="" before="" after="" rc=0 remote_state=""
@@ -542,6 +569,7 @@ main() {
 	test_git_binary_availability_is_validated
 	test_state_allowlist_and_idempotence
 	test_simplification_state_scope_preserves_checkout
+	test_simplification_state_defaults_to_main_without_origin_head
 	test_simplification_state_conflict_is_retryable
 	test_validation_failure_pushes_nothing
 	test_contention_replay_and_conflict


### PR DESCRIPTION
## Summary

Ensure simplification-state publication falls back to main when origin/HEAD cannot be resolved, even when pipefail is disabled; add a regression test for the missing origin/HEAD path.

## Files Changed

.agents/scripts/pulse-simplification-state.sh, .agents/scripts/tests/test-planning-publisher.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-simplification-state.sh .agents/scripts/tests/test-planning-publisher.sh; bash .agents/scripts/tests/test-planning-publisher.sh (13 passed, 0 failed)

Resolves #28272


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.155 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 14m and 54,663 tokens on this as a headless worker.