### PR TITLE
GH#28276: fix: preserve cross-user inventory leases

### DIFF
--- a/.agents/scripts/storage-inventory-helper.sh
+++ b/.agents/scripts/storage-inventory-helper.sh
@@ -355,7 +355,10 @@ _storage_bundle_lease_is_live() {
 		case "$lease_pid" in
 		'' | *[!0-9]*) continue ;;
 		esac
-		kill -0 "$lease_pid" 2>/dev/null && return 0
+		# kill -0 can report EPERM for a live process owned by another user.
+		if kill -0 "$lease_pid" 2>/dev/null || [[ -d "/proc/$lease_pid" ]] || ps -p "$lease_pid" >/dev/null 2>&1; then
+			return 0
+		fi
 	done
 	return 1
 }

--- a/.agents/scripts/tests/test-storage-inventory-helper.sh
+++ b/.agents/scripts/tests/test-storage-inventory-helper.sh
@@ -96,6 +96,24 @@ report=$(bash "$HELPER" json)
 rm "$HOME/.aidevops/runtime-bundles"
 mv "$HOME/.aidevops/runtime-bundles-real" "$HOME/.aidevops/runtime-bundles"
 
+rm -rf "$HOME/.aidevops/runtime-bundles"
+mkdir -p \
+	"$HOME/.aidevops/runtime-bundles/active/agents" \
+	"$HOME/.aidevops/runtime-bundles/cross-user/agents" \
+	"$HOME/.aidevops/runtime-bundles/candidate/agents" \
+	"$HOME/.aidevops/runtime-bundles/.leases/cross-user"
+printf 'active\n' >"$HOME/.aidevops/runtime-bundles/active/agents/data"
+dd if=/dev/zero of="$HOME/.aidevops/runtime-bundles/cross-user/agents/data" bs=1024 count=64 2>/dev/null
+printf 'candidate\n' >"$HOME/.aidevops/runtime-bundles/candidate/agents/data"
+printf 'lease\n' >"$HOME/.aidevops/runtime-bundles/.leases/cross-user/$$"
+ln -s "$HOME/.aidevops/runtime-bundles/active/agents" "$HOME/.aidevops/agents"
+KILL_EPERM_ENV="$TEST_ROOT/kill-eperm-env"
+printf '%s\n' 'kill() { return 1; }' >"$KILL_EPERM_ENV"
+report=$(BASH_ENV="$KILL_EPERM_ENV" bash "$HELPER" json)
+runtime_protected=$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protected_bytes')
+runtime_reclaimable=$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .reclaimable_bytes')
+[[ "$runtime_protected" -gt "$runtime_reclaimable" ]] || fail "ps fallback did not protect a cross-user runtime bundle lease"
+
 FAILING_DU="$TEST_ROOT/failing-du"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$FAILING_DU"
 chmod +x "$FAILING_DU"

--- a/.agents/scripts/tests/test-storage-inventory-helper.sh
+++ b/.agents/scripts/tests/test-storage-inventory-helper.sh
@@ -111,8 +111,7 @@ KILL_EPERM_ENV="$TEST_ROOT/kill-eperm-env"
 printf '%s\n' 'kill() { return 1; }' >"$KILL_EPERM_ENV"
 report=$(BASH_ENV="$KILL_EPERM_ENV" bash "$HELPER" json)
 [[ -n "$report" ]] || fail "ps fallback returned an empty storage report"
-lease_bytes_are_protected=$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protected_bytes > .reclaimable_bytes')
-[[ "$lease_bytes_are_protected" == "true" ]] || fail "ps fallback did not protect a cross-user runtime bundle lease"
+printf '%s' "$report" | jq -e '.stores[] | select(.store_id == "runtime-bundles") | .protected_bytes > .reclaimable_bytes' >/dev/null || fail "ps fallback did not protect a cross-user runtime bundle lease"
 
 FAILING_DU="$TEST_ROOT/failing-du"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$FAILING_DU"

--- a/.agents/scripts/tests/test-storage-inventory-helper.sh
+++ b/.agents/scripts/tests/test-storage-inventory-helper.sh
@@ -110,9 +110,7 @@ ln -s "$HOME/.aidevops/runtime-bundles/active/agents" "$HOME/.aidevops/agents"
 KILL_EPERM_ENV="$TEST_ROOT/kill-eperm-env"
 printf '%s\n' 'kill() { return 1; }' >"$KILL_EPERM_ENV"
 report=$(BASH_ENV="$KILL_EPERM_ENV" bash "$HELPER" json)
-runtime_protected=$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protected_bytes')
-runtime_reclaimable=$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .reclaimable_bytes')
-[[ "$runtime_protected" -gt "$runtime_reclaimable" ]] || fail "ps fallback did not protect a cross-user runtime bundle lease"
+[[ -n "$report" ]] && [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protected_bytes > .reclaimable_bytes')" == "true" ]] || fail "ps fallback did not protect a cross-user runtime bundle lease"
 
 FAILING_DU="$TEST_ROOT/failing-du"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$FAILING_DU"

--- a/.agents/scripts/tests/test-storage-inventory-helper.sh
+++ b/.agents/scripts/tests/test-storage-inventory-helper.sh
@@ -110,7 +110,9 @@ ln -s "$HOME/.aidevops/runtime-bundles/active/agents" "$HOME/.aidevops/agents"
 KILL_EPERM_ENV="$TEST_ROOT/kill-eperm-env"
 printf '%s\n' 'kill() { return 1; }' >"$KILL_EPERM_ENV"
 report=$(BASH_ENV="$KILL_EPERM_ENV" bash "$HELPER" json)
-[[ -n "$report" ]] && [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protected_bytes > .reclaimable_bytes')" == "true" ]] || fail "ps fallback did not protect a cross-user runtime bundle lease"
+[[ -n "$report" ]] || fail "ps fallback returned an empty storage report"
+lease_bytes_are_protected=$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protected_bytes > .reclaimable_bytes')
+[[ "$lease_bytes_are_protected" == "true" ]] || fail "ps fallback did not protect a cross-user runtime bundle lease"
 
 FAILING_DU="$TEST_ROOT/failing-du"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$FAILING_DU"


### PR DESCRIPTION
## Summary

Treat a lease as live when kill -0 is permission-denied but /proc or ps still observes the process, matching runtime pruning behavior. Add an integration regression that simulates EPERM and verifies the leased bundle remains protected.

## Files Changed

.agents/scripts/storage-inventory-helper.sh, .agents/scripts/tests/test-storage-inventory-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/storage-inventory-helper.sh .agents/scripts/tests/test-storage-inventory-helper.sh; bash .agents/scripts/tests/test-storage-inventory-helper.sh; bash .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh; git diff --check

Resolves #28276


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.155 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 4m and 62,014 tokens on this as a headless worker.