### PR TITLE
t18131: Bound production API evidence windows

### DIFF
--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -69,14 +69,23 @@ sidecar to the exact aggregate bytes. The result also records the sidecar's own
 SHA-256 digest.
 
 The Pulse wrapper now publishes this sidecar automatically after each real cycle.
-It writes the transport aggregate first, binds the sidecar to those exact bytes,
-and atomically replaces both private files with mode `600`. Defaults are
+It snapshots the active transport log under the appender lock, applies the
+completed cycle’s inclusive end timestamp, writes the transport aggregate,
+binds the sidecar to those exact bytes, and atomically replaces both private
+files with mode `600`. Attempts appended by concurrent processes after the
+cycle cutoff remain available for the next report instead of extending the
+completed evidence window. Defaults are
 `~/.aidevops/logs/gh-api-calls-by-stage.json` and
 `~/.aidevops/logs/gh-api-efficiency-evidence.json`; override them with
 `AIDEVOPS_GH_API_REPORT` and `AIDEVOPS_GH_API_EVIDENCE`. Set
 `AIDEVOPS_GH_API_EVIDENCE_DISABLE=1` to disable sidecar production without
 disabling transport telemetry. Invalid or insufficient retained windows remove a
 stale sidecar instead of preserving misleading evidence.
+
+The active transport log remains bounded at 48 hours, one million records, or
+128 MiB—whichever limit is reached first. Reported effective duration remains
+authoritative: unusually high request volume can still exhaust a size bound
+before the requested observation duration and therefore cannot support `PASS`.
 
 Coverage contract `1` starts at a private persisted activation timestamp and is
 re-emitted each cycle so a rolling window becomes bounded only after every

--- a/.agents/scripts/gh-api-aggregate.awk
+++ b/.agents/scripts/gh-api-aggregate.awk
@@ -7,7 +7,7 @@
 # gh-api-instrument.sh. Legacy rows remain logical observations; they are never
 # represented as proven network attempts. Designed for BSD awk (macOS default).
 #
-# Required -v variables: now, cutoff, window
+# Required -v variables: now (inclusive fixed-window end), cutoff, window
 # Output: one deterministic JSON document on stdout.
 # =============================================================================
 
@@ -133,6 +133,7 @@ $1 !~ /^[0-9]+$/ || NF < 3 {
 
 {
 	ts = $1 + 0
+	if (ts > now) next
 	caller = ($2 != "") ? $2 : "unknown"
 	path = ($3 != "") ? $3 : "other"
 	auth = (NF >= 4 && $4 != "") ? $4 : "unknown"

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -57,8 +57,8 @@
 #                                   (default ~/.aidevops/logs/gh-api-efficiency-evidence.json)
 #   AIDEVOPS_GH_API_EVIDENCE_DISABLE=1 — skip automatic sidecar generation
 #   AIDEVOPS_GH_API_LOG_MAX_LINES — when set and exceeded, trim() retains
-#                                   the newest bounded records (default 50000)
-#   AIDEVOPS_GH_API_LOG_MAX_BYTES — maximum retained log bytes (default 16 MiB)
+#                                   the newest bounded records (default 1000000)
+#   AIDEVOPS_GH_API_LOG_MAX_BYTES — maximum retained log bytes (default 128 MiB)
 #   AIDEVOPS_GH_API_RETENTION_SECONDS — maximum record age (default 172800)
 #   AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES — 10ms waits before reclaiming an
 #                                   empty lock directory (default 100)
@@ -108,9 +108,12 @@ esac
 GH_API_LOG="${AIDEVOPS_GH_API_LOG:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls.log}"
 GH_API_REPORT="${AIDEVOPS_GH_API_REPORT:-${_GH_API_HOME}/.aidevops/logs/gh-api-calls-by-stage.json}"
 GH_API_EVIDENCE="${AIDEVOPS_GH_API_EVIDENCE:-${_GH_API_HOME}/.aidevops/logs/gh-api-efficiency-evidence.json}"
-GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-50000}"
-GH_API_LOG_MAX_BYTES="${AIDEVOPS_GH_API_LOG_MAX_BYTES:-16777216}"
-GH_API_RETENTION_SECONDS="${AIDEVOPS_GH_API_RETENTION_SECONDS:-172800}"
+_GH_API_DEFAULT_LOG_MAX_LINES=1000000
+_GH_API_DEFAULT_LOG_MAX_BYTES=134217728
+_GH_API_DEFAULT_RETENTION_SECONDS=172800
+GH_API_LOG_MAX_LINES="${AIDEVOPS_GH_API_LOG_MAX_LINES:-$_GH_API_DEFAULT_LOG_MAX_LINES}"
+GH_API_LOG_MAX_BYTES="${AIDEVOPS_GH_API_LOG_MAX_BYTES:-$_GH_API_DEFAULT_LOG_MAX_BYTES}"
+GH_API_RETENTION_SECONDS="${AIDEVOPS_GH_API_RETENTION_SECONDS:-$_GH_API_DEFAULT_RETENTION_SECONDS}"
 GH_API_ERROR_KEY="error"
 _GH_API_EMPTY_LOCK_GRACE_TRIES="${AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES:-100}"
 [[ "$_GH_API_EMPTY_LOCK_GRACE_TRIES" =~ ^[0-9]+$ ]] || _GH_API_EMPTY_LOCK_GRACE_TRIES=100
@@ -514,20 +517,44 @@ _gh_write_efficiency_sidecar() {
 	return 0
 }
 
-# --- gh_aggregate_calls [out_path] [window_secs] -------------------------
-# Read the log and atomically publish a deterministic JSON report. Successful
-# production reports automatically receive a SHA-256-bound evidence sidecar.
+# Copy one stable input while holding the same short-lived lock as appenders.
+# Aggregation then reads the private snapshot without chasing a growing log.
+_gh_snapshot_log() {
+	local destination="$1"
+	_gh_log_lock_acquire || return 1
+	if ! cp "$GH_API_LOG" "$destination" 2>/dev/null; then
+		_gh_log_lock_release
+		return 1
+	fi
+	_gh_log_lock_release
+	chmod 0600 "$destination" 2>/dev/null || true
+	return 0
+}
+
+# --- gh_aggregate_calls [out_path] [window_secs] [end_ts] ----------------
+# Snapshot the active log and atomically publish a deterministic JSON report.
+# An explicit end timestamp creates a completed-cycle cutoff even while other
+# processes keep appending. Successful production reports automatically receive
+# a SHA-256-bound evidence sidecar.
 gh_aggregate_calls() {
 	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
 	local out="${1:-$GH_API_REPORT}"
 	local window="${2:-86400}"
+	local requested_end="${3:-}"
+	local current_now=""
 	local now=""
 	local cutoff=0
 	local out_dir="."
 	local tmp=""
+	local snapshot=""
 	local awk_script=""
 	[[ "$window" =~ ^[1-9][0-9]*$ ]] || window=86400
-	now=$(_gh_now_seconds) || return 1
+	current_now=$(_gh_now_seconds) || return 1
+	now="$current_now"
+	if [[ -n "$requested_end" ]]; then
+		[[ "$requested_end" =~ ^[1-9][0-9]*$ && "$requested_end" -le "$current_now" ]] || return 1
+		now="$requested_end"
+	fi
 	cutoff=$((now - window))
 	if [[ "$out" == */* ]]; then
 		out_dir="${out%/*}"
@@ -557,11 +584,21 @@ gh_aggregate_calls() {
 		mv "$tmp" "$out" 2>/dev/null || rm -f "$tmp"
 		return 1
 	fi
-	if ! awk -F'\t' -v now="$now" -v cutoff="$cutoff" -v window="$window" \
-		-f "$awk_script" "$GH_API_LOG" >"$tmp" 2>/dev/null; then
+	snapshot=$(mktemp "${out}.source.XXXXXX" 2>/dev/null) || {
 		rm -f "$tmp"
 		return 1
+	}
+	chmod 0600 "$snapshot" 2>/dev/null || true
+	if ! _gh_snapshot_log "$snapshot"; then
+		rm -f "$tmp" "$snapshot"
+		return 1
 	fi
+	if ! awk -F'\t' -v now="$now" -v cutoff="$cutoff" -v window="$window" \
+		-f "$awk_script" "$snapshot" >"$tmp" 2>/dev/null; then
+		rm -f "$tmp" "$snapshot"
+		return 1
+	fi
+	rm -f "$snapshot"
 	if ! mv "$tmp" "$out" 2>/dev/null; then
 		rm -f "$tmp"
 		return 1
@@ -581,9 +618,9 @@ gh_trim_log() {
 	local now=""
 	local cutoff=0
 	local tmp=""
-	[[ "$GH_API_LOG_MAX_LINES" =~ ^[0-9]+$ && "$GH_API_LOG_MAX_LINES" -gt 0 ]] || GH_API_LOG_MAX_LINES=50000
-	[[ "$GH_API_LOG_MAX_BYTES" =~ ^[0-9]+$ && "$GH_API_LOG_MAX_BYTES" -gt 0 ]] || GH_API_LOG_MAX_BYTES=16777216
-	[[ "$GH_API_RETENTION_SECONDS" =~ ^[0-9]+$ && "$GH_API_RETENTION_SECONDS" -gt 0 ]] || GH_API_RETENTION_SECONDS=172800
+	[[ "$GH_API_LOG_MAX_LINES" =~ ^[0-9]+$ && "$GH_API_LOG_MAX_LINES" -gt 0 ]] || GH_API_LOG_MAX_LINES="$_GH_API_DEFAULT_LOG_MAX_LINES"
+	[[ "$GH_API_LOG_MAX_BYTES" =~ ^[0-9]+$ && "$GH_API_LOG_MAX_BYTES" -gt 0 ]] || GH_API_LOG_MAX_BYTES="$_GH_API_DEFAULT_LOG_MAX_BYTES"
+	[[ "$GH_API_RETENTION_SECONDS" =~ ^[0-9]+$ && "$GH_API_RETENTION_SECONDS" -gt 0 ]] || GH_API_RETENTION_SECONDS="$_GH_API_DEFAULT_RETENTION_SECONDS"
 	now=$(_gh_now_seconds) || return 0
 	cutoff=$((now - GH_API_RETENTION_SECONDS))
 	_gh_log_lock_acquire || return 0
@@ -655,7 +692,9 @@ Subcommands:
   record <path> [caller] [auth] [pool] [decision] [budget]
                           Append one routing/cache record
   evidence <name> [value] Append one typed benchmark evidence record
-  report [out] [window_s]  Aggregate to JSON (default ${GH_API_REPORT##*/}, 24h)
+  report [out] [window_s] [end_ts]
+                          Aggregate a fixed-cutoff JSON window
+                          (default ${GH_API_REPORT##*/}, 24h, current time)
   trim                     Atomically apply age, line, and byte retention bounds
   clear                    Remove log + report
 

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -151,7 +151,11 @@ _pulse_efficiency_cycle_finish() {
 	fi
 	[[ "$now_seconds" -gt 0 ]] && _pulse_efficiency_record coverage-end "$now_seconds"
 	if declare -F gh_aggregate_calls >/dev/null 2>&1; then
-		gh_aggregate_calls 2>/dev/null || true
+		if [[ "$now_seconds" -gt 0 ]]; then
+			gh_aggregate_calls "${GH_API_REPORT:-}" 86400 "$now_seconds" 2>/dev/null || true
+		else
+			gh_aggregate_calls 2>/dev/null || true
+		fi
 	fi
 	if declare -F gh_trim_log >/dev/null 2>&1; then
 		gh_trim_log 2>/dev/null || true

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -434,7 +434,31 @@ assert_eq "fresh window last timestamp excludes history" "$inside_last_ts" "$(jq
 assert_eq "fresh effective window excludes history" "5" "$(jq -r '._meta.effective_window_seconds' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "fresh window exactness is true" "true" "$(jq -r '._meta.attempts_exact' "$AIDEVOPS_GH_API_REPORT")"
 
-# --- Test 12c: typed evidence and latency completeness stay explicit --------
+# --- Test 12c: fixed cutoffs exclude concurrent post-cycle appends ----------
+gh_clear_log
+fixed_end_ts=$((now - 5))
+post_cycle_ts=$((fixed_end_ts + 1))
+printf "%s\tfixed-caller\trest\tgh-pat\trest-core\trest-selected\t4999\tv2\tattempt\tlogical-fixed\tattempt-fixed-1\t1\t0\tsuccess\t200\t10\t1\n" "$fixed_end_ts" >>"$AIDEVOPS_GH_API_LOG"
+printf "%s\tfuture-caller\trest\tgh-pat\trest-core\trest-selected\t4998\tv2\tattempt\tlogical-future\tattempt-future-1\t1\t0\tsuccess\t200\t10\t1\n" "$post_cycle_ts" >>"$AIDEVOPS_GH_API_LOG"
+gh_aggregate_calls "$AIDEVOPS_GH_API_REPORT" 60 "$fixed_end_ts"
+assert_eq "explicit cutoff becomes report timestamp" "$fixed_end_ts" "$(jq -r "._meta.generated_at_ts" "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "post-cutoff attempt is excluded" "1" "$(jq -r "._meta.attempted_requests" "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "post-cutoff attempt is excluded from retained audit" "1" "$(jq -r "._meta.retained_records" "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "fixed report ends at the completed cutoff" "$fixed_end_ts" "$(jq -r "._meta.last_retained_ts" "$AIDEVOPS_GH_API_REPORT")"
+if compgen -G "${AIDEVOPS_GH_API_REPORT}.source.*" >/dev/null; then
+	echo "  FAIL: aggregate left a private source snapshot behind"
+	FAIL=$((FAIL + 1))
+else
+	echo "  PASS: aggregate removed its private source snapshot"
+	PASS=$((PASS + 1))
+fi
+set +e
+gh_aggregate_calls "$AIDEVOPS_GH_API_REPORT" 60 "$((now + 60))"
+future_cutoff_status=$?
+set -e
+assert_eq "future report cutoff is rejected" "1" "$future_cutoff_status"
+
+# --- Test 12d: typed evidence and latency completeness stay explicit --------
 gh_clear_log
 latency_ts=$((now - 5))
 gh_record_efficiency_evidence cache.fresh_hits 1

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -82,7 +82,7 @@ gh_record_efficiency_evidence() {
 }
 
 gh_aggregate_calls() {
-	printf 'aggregate\n' >>"$AGGREGATE_FILE"
+	printf "%s|%s|%s\n" "${1:-}" "${2:-}" "${3:-}" >>"$AGGREGATE_FILE"
 	return 0
 }
 
@@ -157,6 +157,14 @@ if grep -q '^contract=1$' "$EVIDENCE_FILE" \
 	pass "idle cycle publishes complete typed evidence"
 else
 	fail "idle cycle publishes complete typed evidence"
+fi
+
+coverage_end_value=$(grep "^coverage-end=" "$EVIDENCE_FILE")
+coverage_end_value="${coverage_end_value#*=}"
+if grep -q "^|86400|${coverage_end_value}$" "$AGGREGATE_FILE"; then
+	pass "cycle aggregate uses the completed coverage cutoff"
+else
+	fail "cycle aggregate uses the completed coverage cutoff" "args=$(<"$AGGREGATE_FILE")"
 fi
 
 _pulse_efficiency_cycle_finish idle

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -29,6 +29,7 @@ export SCRIPT_DIR="${TMP}/scripts"
 export WRAPPER_LOGFILE="${TMP}/wrapper.log"
 export AIDEVOPS_GH_API_EVIDENCE_COVERAGE_START_FILE="${TMP}/coverage-start"
 export PULSE_SCOPE_REPOS="owner/repo"
+unset GH_API_REPORT
 mkdir -p "$SCRIPT_DIR"
 : >"$WRAPPER_LOGFILE"
 
@@ -161,7 +162,7 @@ fi
 
 coverage_end_value=$(grep "^coverage-end=" "$EVIDENCE_FILE")
 coverage_end_value="${coverage_end_value#*=}"
-if grep -q "^|86400|${coverage_end_value}$" "$AGGREGATE_FILE"; then
+if grep -q -- "^|86400|${coverage_end_value}$" "$AGGREGATE_FILE"; then
 	pass "cycle aggregate uses the completed coverage cutoff"
 else
 	fail "cycle aggregate uses the completed coverage cutoff" "args=$(<"$AGGREGATE_FILE")"


### PR DESCRIPTION
## Summary

Snapshot active telemetry under its appender lock, cut each report off at the completed Pulse cycle timestamp, exclude later concurrent attempts, and increase bounded retention to one million records or 128 MiB so 12-24 hour observations are practical.

## Files Changed

.agents/reference/github-api-efficiency.md, .agents/scripts/gh-api-aggregate.awk, .agents/scripts/gh-api-instrument.sh, .agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 140 transport instrumentation assertions; 12 Pulse cycle-gate assertions; scoped ShellCheck; changed and full local quality gates; live private-log replay proved five supported coverage groups become bounded at the cycle cutoff.

For #27777


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.155 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.5 spent 2d 11h and 14,045,951 tokens on this with the user in an interactive session.
