### PR TITLE
GH#28285: fix: persist pulse merge recovery before watchdog timeout

### DIFF
--- a/.agents/scripts/pulse-merge-pass.sh
+++ b/.agents/scripts/pulse-merge-pass.sh
@@ -304,6 +304,25 @@ _pmp_add_counter_var() {
 	return 0
 }
 
+# Persist conclusive queue-draining progress at the mutation boundary. The
+# outer merge routine can be killed by its watchdog before the all-repo pass
+# returns, so the end-of-pass aggregate remains a fallback rather than the only
+# place that resets the zero-progress streak (GH#28285).
+_pmp_record_deterministic_progress_now() {
+	local merged_count="$1"
+	local progress_count="$2"
+
+	[[ "$merged_count" =~ ^[0-9]+$ ]] || merged_count=0
+	[[ "$progress_count" =~ ^[0-9]+$ ]] || progress_count=0
+	if [[ "$merged_count" -le 0 && "$progress_count" -le 0 ]]; then
+		return 0
+	fi
+	if declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
+		pulse_merge_zero_progress_record 0 "$merged_count" "$progress_count" || true
+	fi
+	return 0
+}
+
 _pmp_process_merge_repo_for_pass() {
 	local repo_slug="$1"
 	local checkpoint_file="$2"

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1579,12 +1579,16 @@ ${merge_output}"
 		fi
 	fi
 
-	# Rate-limit: 1 second between merges to avoid GitHub API abuse
-	sleep 1
-
 	if [[ $_merge_exit -eq 0 ]]; then
 		echo "[pulse-wrapper] Deterministic merge: merged PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
 		_pmp_record_deterministic_progress_now 1 0
+	fi
+
+	# Rate-limit: 1 second between merges to avoid GitHub API abuse. Persist a
+	# successful mutation before this interruptible wait (GH#28285).
+	sleep 1
+
+	if [[ $_merge_exit -eq 0 ]]; then
 		# t2411: emit audit log for origin:interactive auto-merges
 		local _ipr_labels="$pr_labels"
 		if [[ "$_ipr_labels" == *"origin:interactive"* ]]; then

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1584,6 +1584,7 @@ ${merge_output}"
 
 	if [[ $_merge_exit -eq 0 ]]; then
 		echo "[pulse-wrapper] Deterministic merge: merged PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		_pmp_record_deterministic_progress_now 1 0
 		# t2411: emit audit log for origin:interactive auto-merges
 		local _ipr_labels="$pr_labels"
 		if [[ "$_ipr_labels" == *"origin:interactive"* ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
+++ b/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
@@ -129,6 +129,10 @@ pulse_merge_zero_progress_record() {
 
 printf '%sRunning pulse merge checkpoint resume tests (GH#25697)%s\n' "$TEST_GREEN" "$TEST_NC"
 
+_pmp_record_deterministic_progress_now 1 0
+assert_equals "successful merge persists zero-progress recovery immediately" "0:1:0 " "$ZERO_PROGRESS_CALLS"
+ZERO_PROGRESS_CALLS=""
+
 STOP_AFTER_REPO="org/two"
 merge_ready_prs_all_repos
 assert_equals "first pass stops after repo two" "org/one org/two " "$PROCESSED_REPOS"

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -190,6 +190,11 @@ _set_native_auto_merge_or_skip() { return 1; }
 _repo_allows_auto_merge() { return "${REPO_ALLOWS_AUTO_MERGE_RC:-0}"; }
 _attempt_existing_auto_merge_behind_update_branch() { return 1; }
 _attempt_green_behind_update_branch() { return "${GREEN_BEHIND_UPDATE_RC:-1}"; }
+sleep() {
+	local seconds="$1"
+	printf 'sleep:%s\n' "$seconds" >>"$MERGE_EVENT_LOG"
+	return 0
+}
 _pmp_record_deterministic_progress_now() {
 	local merged_count="$1"
 	local progress_count="$2"
@@ -442,14 +447,14 @@ test_stale_cache_401_retries_admin_merge_once() {
 
 	local merge_events=""
 	merge_events=$(tr '\n' ' ' <"$MERGE_EVENT_LOG")
-	if [[ "$merge_events" != "progress:1:0 post-merge " ]]; then
-		print_result "successful merge records recovery before post-merge actions" 1 \
+	if [[ "$merge_events" != "progress:1:0 sleep:1 post-merge " ]]; then
+		print_result "successful merge records recovery before interruptible post-merge work" 1 \
 			"event order: ${merge_events:-none}"
 		teardown_test_env
 		unset GH_STUB_MODE
 		return 0
 	fi
-	print_result "successful merge records recovery before post-merge actions" 0
+	print_result "successful merge records recovery before interruptible post-merge work" 0
 
 	if [[ -f "${HOME}/.cache/gh/graphql-401.cache" ]] || \
 		! find "${HOME}/.cache/gh" -path '*/aidevops-quarantine-*/*graphql-401.cache*' -type f | grep -q .; then

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -21,6 +21,7 @@ TESTS_FAILED=0
 TEST_ROOT=""
 GH_LOG=""
 REMEDIATION_LOG=""
+MERGE_EVENT_LOG=""
 _OW_LABEL_PAT=",origin:worker,"
 
 print_result() {
@@ -51,7 +52,9 @@ setup_test_env() {
 	: >"$GH_LOG"
 	REMEDIATION_LOG="${TEST_ROOT}/remediation.log"
 	: >"$REMEDIATION_LOG"
-	export TEST_ROOT GH_LOG REMEDIATION_LOG
+	MERGE_EVENT_LOG="${TEST_ROOT}/merge-events.log"
+	: >"$MERGE_EVENT_LOG"
+	export TEST_ROOT GH_LOG REMEDIATION_LOG MERGE_EVENT_LOG
 
 cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
@@ -187,7 +190,16 @@ _set_native_auto_merge_or_skip() { return 1; }
 _repo_allows_auto_merge() { return "${REPO_ALLOWS_AUTO_MERGE_RC:-0}"; }
 _attempt_existing_auto_merge_behind_update_branch() { return 1; }
 _attempt_green_behind_update_branch() { return "${GREEN_BEHIND_UPDATE_RC:-1}"; }
-_handle_post_merge_actions() { return 0; }
+_pmp_record_deterministic_progress_now() {
+	local merged_count="$1"
+	local progress_count="$2"
+	printf 'progress:%s:%s\n' "$merged_count" "$progress_count" >>"$MERGE_EVENT_LOG"
+	return 0
+}
+_handle_post_merge_actions() {
+	printf 'post-merge\n' >>"$MERGE_EVENT_LOG"
+	return 0
+}
 gh_pr_view() { printf '{"labels":[]}'; return 0; }
 
 _pulse_merge_maybe_dispatch_review_thread_remediation() {
@@ -427,6 +439,17 @@ test_stale_cache_401_retries_admin_merge_once() {
 		unset GH_STUB_MODE
 		return 0
 	fi
+
+	local merge_events=""
+	merge_events=$(tr '\n' ' ' <"$MERGE_EVENT_LOG")
+	if [[ "$merge_events" != "progress:1:0 post-merge " ]]; then
+		print_result "successful merge records recovery before post-merge actions" 1 \
+			"event order: ${merge_events:-none}"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+	print_result "successful merge records recovery before post-merge actions" 0
 
 	if [[ -f "${HOME}/.cache/gh/graphql-401.cache" ]] || \
 		! find "${HOME}/.cache/gh" -path '*/aidevops-quarantine-*/*graphql-401.cache*' -type f | grep -q .; then


### PR DESCRIPTION
## Summary

Reset the pulse zero-progress streak at the successful merge mutation boundary so a later merge-routine watchdog timeout cannot erase observed throughput.

## Files Changed

.agents/scripts/pulse-merge-pass.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck 0.11.0; checkpoint-resume tests (12/12); ruleset fallback tests (9/9); merge-stuck tests (59/59).

Resolves #28285


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 13m and 269,822 tokens on this as a headless worker.