### PR TITLE
GH#28282: fix: authorize explicit linked-worktree targets

### DIFF
--- a/.agents/hooks/git_safety_guard.py
+++ b/.agents/hooks/git_safety_guard.py
@@ -4,8 +4,8 @@
 """Claude Code adapter for shared command and direct-write safety.
 
 Shell-command decisions are delegated to command-policy-helper.py. Direct file
-mutations are delegated to canonical-write-policy-helper.py so every canonical
-checkout is read-only regardless of branch name or target path.
+mutations are delegated to canonical-write-policy-helper.py so canonical
+checkout targets stay read-only while explicit linked-worktree targets work.
 
 This hook runs before Bash/Edit/Write tool calls execute. It is registered under
 both the Bash and direct-file-tool PreToolUse matchers.

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
@@ -72,6 +72,15 @@ test("classifies every apply-patch target instead of trusting linked cwd", () =>
       () => checkCanonicalWriteSafetyGate("", scriptsDir, linked, { invalid: true }),
       /targets could not be classified/,
     );
+    const targetLedPatch = `*** Begin Patch\n*** Update File: ${join(linked, "README.md")}\n@@\n-seed\n+safe\n*** End Patch\n`;
+    assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate("", scriptsDir, repo, targetLedPatch),
+    );
+    const mixedPatch = `*** Begin Patch\n*** Update File: ${join(linked, "README.md")}\n@@\n-seed\n+safe\n*** Update File: ${join(repo, "README.md")}\n@@\n-seed\n+unsafe\n*** End Patch\n`;
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate("", scriptsDir, repo, mixedPatch),
+      /canonical write policy.*read-only session mirrors/,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -95,7 +104,7 @@ test("fails closed when canonical policy returns a non-object payload", () => {
   }
 });
 
-test("blocks every canonical direct write and preserves linked-worktree writes", () => {
+test("uses explicit same-repository linked targets without weakening canonical writes", () => {
   const { root, repo, linked } = setupRepo();
   try {
     assert.throws(
@@ -111,6 +120,13 @@ test("blocks every canonical direct write and preserves linked-worktree writes",
       /canonical write policy/,
     );
     assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate(join(linked, "new-file.md"), scriptsDir, repo),
+    );
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(relative(repo, join(linked, "new-file.md")), scriptsDir, repo),
+      /canonical write policy/,
+    );
+    assert.doesNotThrow(
       () => checkCanonicalWriteSafetyGate(join(linked, "README.md"), scriptsDir, linked),
     );
     assert.doesNotThrow(
@@ -118,6 +134,20 @@ test("blocks every canonical direct write and preserves linked-worktree writes",
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects an absolute linked target from a different repository", () => {
+  const primary = setupRepo();
+  const foreign = setupRepo();
+  try {
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(join(foreign.linked, "README.md"), scriptsDir, primary.repo),
+      /canonical write policy.*read-only session mirrors/,
+    );
+  } finally {
+    rmSync(primary.root, { recursive: true, force: true });
+    rmSync(foreign.root, { recursive: true, force: true });
   }
 });
 

--- a/.agents/scripts/canonical-write-policy-helper.py
+++ b/.agents/scripts/canonical-write-policy-helper.py
@@ -147,16 +147,28 @@ def check_write(cwd: str, file_path: str) -> dict[str, Any]:
     canonical = next(
         (item for item in classifications if item.classification == "canonical"), None
     )
+    target_led_linked_write = (
+        bool(file_path)
+        and Path(file_path).is_absolute()
+        and context.classification == "canonical"
+        and target.classification == "linked"
+        and bool(context.common_dir)
+        and context.common_dir == target.common_dir
+    )
 
     if unknown is not None:
         decision = "deny"
         reason = f"worktree classification failed closed: {unknown.reason}"
-    elif canonical is not None:
+    elif canonical is not None and not target_led_linked_write:
         decision = "deny"
         reason = "canonical checkouts are read-only session mirrors"
     else:
         decision = "allow"
-        reason = "write target and process context are outside canonical worktrees"
+        reason = (
+            "explicit absolute target is a linked worktree in the canonical repository"
+            if target_led_linked_write
+            else "write target and process context are outside canonical worktrees"
+        )
 
     return {
         "policy": POLICY_VERSION,
@@ -185,11 +197,9 @@ def _patch_paths(patch_text: str) -> list[str]:
 
 def check_patch(cwd: str, patch_text: str) -> dict[str, Any]:
     """Return one fail-closed decision for every target in an apply patch."""
-    context_decision = check_write(cwd, "")
-    if context_decision["decision"] != "allow":
-        return context_decision
     paths = _patch_paths(patch_text)
     if not paths:
+        context_decision = check_write(cwd, "")
         return {
             **context_decision,
             "decision": "deny",
@@ -197,11 +207,14 @@ def check_patch(cwd: str, patch_text: str) -> dict[str, Any]:
             "action": "repair_or_use_linked_worktree",
             "patch_paths": [],
         }
-    for path in paths:
+    allowed_decision = check_write(cwd, paths[0])
+    if allowed_decision["decision"] != "allow":
+        return {**allowed_decision, "patch_paths": paths}
+    for path in paths[1:]:
         decision = check_write(cwd, path)
         if decision["decision"] != "allow":
             return {**decision, "patch_paths": paths}
-    return {**context_decision, "patch_paths": paths}
+    return {**allowed_decision, "patch_paths": paths}
 
 
 def resolve_canonical_branch(cwd: str) -> dict[str, str]:

--- a/.agents/scripts/canonical-write-policy-helper.py
+++ b/.agents/scripts/canonical-write-policy-helper.py
@@ -136,6 +136,19 @@ def _target_probe(cwd: str, file_path: str) -> str:
     return str(target.resolve(strict=False))
 
 
+def _is_target_led_linked_write(
+    file_path: str, context: Classification, target: Classification
+) -> bool:
+    """Return whether a canonical context names a trusted linked target."""
+    if not file_path or not Path(file_path).is_absolute():
+        return False
+    if context.classification != "canonical":
+        return False
+    if target.classification != "linked" or not context.common_dir:
+        return False
+    return context.common_dir == target.common_dir
+
+
 def check_write(cwd: str, file_path: str) -> dict[str, Any]:
     """Return one fail-closed direct-file-write decision."""
     context = classify_location(cwd)
@@ -147,14 +160,7 @@ def check_write(cwd: str, file_path: str) -> dict[str, Any]:
     canonical = next(
         (item for item in classifications if item.classification == "canonical"), None
     )
-    target_led_linked_write = (
-        bool(file_path)
-        and Path(file_path).is_absolute()
-        and context.classification == "canonical"
-        and target.classification == "linked"
-        and bool(context.common_dir)
-        and context.common_dir == target.common_dir
-    )
+    target_led_linked_write = _is_target_led_linked_write(file_path, context, target)
 
     if unknown is not None:
         decision = "deny"

--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -91,6 +91,30 @@ class CanonicalWritePolicyTests(unittest.TestCase):
     def test_linked_worktree_write_is_allowed(self):
         self.assertIsNone(self._check(self.linked, self.linked / "new-file.md"))
 
+    def test_canonical_context_may_target_same_repository_linked_absolute_path(self):
+        self.assertIsNone(self._check(self.repo, self.linked / "new-file.md"))
+
+    def test_canonical_context_denies_relative_path_that_resolves_into_linked(self):
+        target = Path("..") / self.linked.name / "new-file.md"
+        self.assertIsNotNone(self._check(self.repo, target))
+
+    def test_canonical_context_denies_linked_target_from_different_repository(self):
+        context = canonical_write_policy.Classification(
+            "canonical", True, common_dir="/primary/.git"
+        )
+        target = canonical_write_policy.Classification(
+            "linked", True, common_dir="/foreign/.git"
+        )
+        with mock.patch.object(
+            canonical_write_policy,
+            "classify_location",
+            side_effect=(context, target),
+        ):
+            decision = canonical_write_policy.check_write(
+                "/primary", "/foreign/linked/README.md"
+            )
+        self.assertEqual(decision["decision"], "deny")
+
     def test_linked_context_cannot_target_canonical_checkout(self):
         denial = self._check(self.linked, self.repo / "README.md")
         self.assertIsNotNone(denial)
@@ -188,6 +212,31 @@ class CanonicalWritePolicyTests(unittest.TestCase):
 *** End Patch
 """
         denial = self._check(self.linked, patch_text=canonical_patch)
+        self.assertIsNotNone(denial)
+        self.assertIn(
+            "read-only session mirrors",
+            denial["hookSpecificOutput"]["permissionDecisionReason"],
+        )
+        target_led_patch = f"""*** Begin Patch
+*** Update File: {self.linked / 'README.md'}
+@@
+-seed
++safe
+*** End Patch
+"""
+        self.assertIsNone(self._check(self.repo, patch_text=target_led_patch))
+        mixed_patch = f"""*** Begin Patch
+*** Update File: {self.linked / 'README.md'}
+@@
+-seed
++safe
+*** Update File: {self.repo / 'README.md'}
+@@
+-seed
++unsafe
+*** End Patch
+"""
+        denial = self._check(self.repo, patch_text=mixed_patch)
         self.assertIsNotNone(denial)
         self.assertIn(
             "read-only session mirrors",


### PR DESCRIPTION
## Summary

Implementation for issue #28282.

## Files Changed

.agents/hooks/git_safety_guard.py, .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs, .agents/scripts/canonical-write-policy-helper.py, tests/test-git-safety-guard.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 tests/test-git-safety-guard.py; node --test .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs; .agents/scripts/linters-local.sh --changed

Resolves #28282


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 54m and 854,106 tokens on this with the user in an interactive session.