### PR TITLE
GH#28263: fix: classify unreadable proc cwd owners

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -117,7 +117,7 @@ _worktree_proc_entry_is_provably_foreign_uid() {
 	local process_uid=""
 
 	[[ "$current_uid" =~ ^[0-9]+$ && -r "$proc_dir/status" ]] || return 1
-	while read -r field real_uid effective_uid saved_uid filesystem_uid _; do
+	while IFS=$' \t' read -r field real_uid effective_uid saved_uid filesystem_uid _; do
 		[[ "$field" == "Uid:" ]] || continue
 		for process_uid in "$real_uid" "$effective_uid" "$saved_uid" "$filesystem_uid"; do
 			[[ "$process_uid" =~ ^[0-9]+$ ]] || return 1

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -106,19 +106,48 @@ log_worktree_removal_event() {
 	return 0
 }
 
+_worktree_proc_entry_is_provably_foreign_uid() {
+	local proc_dir="$1"
+	local current_uid="$2"
+	local field=""
+	local real_uid=""
+	local effective_uid=""
+	local saved_uid=""
+	local filesystem_uid=""
+	local process_uid=""
+
+	[[ "$current_uid" =~ ^[0-9]+$ && -r "$proc_dir/status" ]] || return 1
+	while read -r field real_uid effective_uid saved_uid filesystem_uid _; do
+		[[ "$field" == "Uid:" ]] || continue
+		for process_uid in "$real_uid" "$effective_uid" "$saved_uid" "$filesystem_uid"; do
+			[[ "$process_uid" =~ ^[0-9]+$ ]] || return 1
+			[[ "$process_uid" != "$current_uid" ]] || return 1
+		done
+		return 0
+	done <"$proc_dir/status"
+	return 1
+}
+
 _capture_worktree_proc_cwds() {
 	local proc_root="$1"
 	local cwd_link=""
 	local cwd_target=""
 	local captured_count=0
+	local current_uid=""
+	local proc_dir=""
+
+	current_uid=$(id -u 2>/dev/null) || current_uid=""
 
 	for cwd_link in "$proc_root"/[0-9]*/cwd; do
 		[[ -L "$cwd_link" || -e "$cwd_link" ]] || continue
 		if ! cwd_target=$(readlink "$cwd_link" 2>/dev/null); then
-			# Vanished processes are harmless; persistent unreadability means the
-			# snapshot is incomplete and must fail closed.
-			[[ -L "$cwd_link" || -e "$cwd_link" ]] && return 1
-			continue
+			# Vanished processes are harmless. Linux commonly denies cwd reads for
+			# other users, so skip only entries whose four status UIDs prove they
+			# are foreign; same-user and unknown ownership still fail closed.
+			[[ -L "$cwd_link" || -e "$cwd_link" ]] || continue
+			proc_dir="${cwd_link%/cwd}"
+			_worktree_proc_entry_is_provably_foreign_uid "$proc_dir" "$current_uid" && continue
+			return 1
 		fi
 		if [[ -n "$cwd_target" ]]; then
 			printf '%s\n' "$cwd_target"

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -498,7 +498,128 @@ test_proc_snapshot_rejects_partial_visibility() {
 }
 
 # =============================================================================
-# Test 15: guard refusals expose a machine-readable reason without changing the
+# Linux /proc entries that are unreadable but provably foreign do not invalidate
+# otherwise usable evidence.
+# =============================================================================
+test_proc_snapshot_skips_foreign_uid_unreadable_entry() {
+	local proc_root="${TEST_DIR}/fake-proc-foreign"
+	local current_uid=""
+	local foreign_uid=""
+	local output=""
+	local rc=0
+	current_uid=$(id -u)
+	foreign_uid=$((current_uid + 1))
+	mkdir -p "${proc_root}/1" "${proc_root}/2"
+	ln -s /visible-cwd "${proc_root}/1/cwd"
+	ln -s /foreign-cwd "${proc_root}/2/cwd"
+	printf 'Uid:\t%s\t%s\t%s\t%s\n' \
+		"$foreign_uid" "$foreign_uid" "$foreign_uid" "$foreign_uid" >"${proc_root}/2/status"
+
+	output=$(
+		readlink() {
+			local link_path="$1"
+			[[ "$link_path" == */1/cwd ]] || return 1
+			printf '/visible-cwd\n'
+			return 0
+		}
+		_capture_worktree_proc_cwds "$proc_root"
+	) || rc=1
+	[[ "$output" == "/visible-cwd" ]] || rc=1
+	print_result "proc_snapshot_skips_foreign_uid_unreadable_entry" "$rc" \
+		"Expected foreign unreadable cwd to be skipped without hiding visible evidence"
+	return 0
+}
+
+# =============================================================================
+# Same-UID unreadability remains fail-closed because the hidden cwd may be in a
+# candidate worktree.
+# =============================================================================
+test_proc_snapshot_rejects_same_uid_unreadable_entry() {
+	local proc_root="${TEST_DIR}/fake-proc-same-uid"
+	local current_uid=""
+	local rc=0
+	current_uid=$(id -u)
+	mkdir -p "${proc_root}/1" "${proc_root}/2"
+	ln -s /visible-cwd "${proc_root}/1/cwd"
+	ln -s /same-user-cwd "${proc_root}/2/cwd"
+	printf 'Uid:\t%s\t%s\t%s\t%s\n' \
+		"$current_uid" "$current_uid" "$current_uid" "$current_uid" >"${proc_root}/2/status"
+
+	if (
+		readlink() {
+			local link_path="$1"
+			[[ "$link_path" == */1/cwd ]] || return 1
+			printf '/visible-cwd\n'
+			return 0
+		}
+		_capture_worktree_proc_cwds "$proc_root" >/dev/null
+	); then
+		rc=1
+	fi
+	print_result "proc_snapshot_rejects_same_uid_unreadable_entry" "$rc" \
+		"Expected same-UID unreadability to invalidate the snapshot"
+	return 0
+}
+
+# =============================================================================
+# Foreign skips alone are not usable evidence: an empty snapshot still blocks
+# destructive cleanup.
+# =============================================================================
+test_proc_snapshot_requires_usable_evidence_after_foreign_skips() {
+	local proc_root="${TEST_DIR}/fake-proc-foreign-only"
+	local current_uid=""
+	local foreign_uid=""
+	local rc=0
+	current_uid=$(id -u)
+	foreign_uid=$((current_uid + 1))
+	mkdir -p "${proc_root}/1"
+	ln -s /foreign-cwd "${proc_root}/1/cwd"
+	printf 'Uid:\t%s\t%s\t%s\t%s\n' \
+		"$foreign_uid" "$foreign_uid" "$foreign_uid" "$foreign_uid" >"${proc_root}/1/status"
+
+	if (
+		readlink() { return 1; }
+		_capture_worktree_proc_cwds "$proc_root" >/dev/null
+	); then
+		rc=1
+	fi
+	print_result "proc_snapshot_requires_usable_evidence_after_foreign_skips" "$rc" \
+		"Expected zero captured cwd targets to remain fail-closed"
+	return 0
+}
+
+# =============================================================================
+# A process that vanishes during readlink is ignored when other usable evidence
+# remains in the snapshot.
+# =============================================================================
+test_proc_snapshot_ignores_vanished_entry() {
+	local proc_root="${TEST_DIR}/fake-proc-vanished"
+	local output=""
+	local rc=0
+	mkdir -p "${proc_root}/1" "${proc_root}/2"
+	ln -s /visible-cwd "${proc_root}/1/cwd"
+	ln -s /vanished-cwd "${proc_root}/2/cwd"
+
+	output=$(
+		readlink() {
+			local link_path="$1"
+			if [[ "$link_path" == */1/cwd ]]; then
+				printf '/visible-cwd\n'
+				return 0
+			fi
+			rm -f "$link_path"
+			return 1
+		}
+		_capture_worktree_proc_cwds "$proc_root"
+	) || rc=1
+	[[ "$output" == "/visible-cwd" ]] || rc=1
+	print_result "proc_snapshot_ignores_vanished_entry" "$rc" \
+		"Expected a vanished process to be ignored without losing visible evidence"
+	return 0
+}
+
+# =============================================================================
+# Guard refusals expose a machine-readable reason without changing the
 # exactly-once audit contract.
 # =============================================================================
 test_guard_reason_is_machine_readable() {
@@ -586,6 +707,10 @@ test_process_cwd_guard_refuses_empty_paths
 test_process_cwd_snapshot_failure_is_fail_closed
 test_snapshot_backend_requires_visible_target
 test_proc_snapshot_rejects_partial_visibility
+test_proc_snapshot_skips_foreign_uid_unreadable_entry
+test_proc_snapshot_rejects_same_uid_unreadable_entry
+test_proc_snapshot_requires_usable_evidence_after_foreign_skips
+test_proc_snapshot_ignores_vanished_entry
 test_guard_reason_is_machine_readable
 test_manual_guard_refusal_diagnostics
 


### PR DESCRIPTION
## Summary

Implementation for issue #28263.

## Files Changed

.agents/scripts/audit-worktree-removal-helper.sh, .agents/scripts/tests/test-worktree-removal-audit.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-worktree-removal-audit.sh; bash .agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh; shellcheck .agents/scripts/audit-worktree-removal-helper.sh .agents/scripts/tests/test-worktree-removal-audit.sh; .agents/scripts/linters-local.sh --changed

Resolves #28263


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h and 911,537 tokens on this with the user in an interactive session.