### PR TITLE
GH#28309: fix: clear stale local-only repo state

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -514,7 +514,7 @@ register_repo() {
 			'(.initialized_repos[] | select(.path == $path)) |= (
 				. + {path: $path, version: $version, features: ($features | split(",")), updated: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}
 				| if $slug != "" then .slug = $slug else . end
-				| if $local_only then .local_only = true else . end
+				| if $local_only then .local_only = true else del(.local_only) end
 				| if .pulse == null then .pulse = (if $local_only then false else $pulse_default end) else . end
 				| if (.priority == null or .priority == "") and $priority_default != "" then .priority = $priority_default else . end
 				| if (.maintainer == null or .maintainer == "") and $maintainer != "" then .maintainer = $maintainer else . end

--- a/.agents/scripts/tests/test-repos-add-local-only-convergence.sh
+++ b/.agents/scripts/tests/test-repos-add-local-only-convergence.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aidevops-repos-local-only.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="${TEST_ROOT}/home"
+INSTALL_DIR="$REPO_ROOT"
+AGENTS_DIR="$REPO_ROOT/.agents"
+CONFIG_DIR="${HOME}/.config/aidevops"
+REPOS_FILE="${CONFIG_DIR}/repos.json"
+AIDEVOPS_REPOS_FILE="$REPOS_FILE"
+export INSTALL_DIR AGENTS_DIR CONFIG_DIR REPOS_FILE AIDEVOPS_REPOS_FILE
+
+mkdir -p "$CONFIG_DIR"
+
+print_info() { return 0; }
+print_warning() { return 0; }
+
+# shellcheck source=../aidevops-cli/aidevops-repos-lib.sh
+source "$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh"
+# shellcheck source=../dispatch-single-issue-helper.sh
+source "$REPO_ROOT/.agents/scripts/dispatch-single-issue-helper.sh"
+
+_repo_registration_maintainer() {
+	printf '\n'
+	return 0
+}
+
+repo_path="${TEST_ROOT}/repo"
+mkdir -p "$repo_path"
+git -C "$repo_path" init -q
+repo_path="$(cd "$repo_path" && pwd -P)"
+
+register_repo "$repo_path" "1.0.0" "planning"
+
+[[ "$(jq -r '.initialized_repos[0].local_only' "$REPOS_FILE")" == "true" ]]
+[[ "$(jq -r '.initialized_repos[0].pulse' "$REPOS_FILE")" == "false" ]]
+
+printf '\n[remote "origin"]\n\turl = https://github.com/example/remote-backed.git\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n' \
+	>>"$repo_path/.git/config"
+register_repo "$repo_path" "1.0.1" "planning"
+
+[[ "$(jq -r '.initialized_repos[0].slug' "$REPOS_FILE")" == "example/remote-backed" ]]
+[[ "$(jq -r '.initialized_repos[0] | has("local_only")' "$REPOS_FILE")" == "false" ]]
+[[ "$(jq -r '.initialized_repos[0].pulse' "$REPOS_FILE")" == "false" ]]
+[[ "$(_dsi_repo_path_for_slug "example/remote-backed")" == "$repo_path" ]]
+
+printf 'PASS repos add clears stale local_only, preserves pulse, and restores dispatch path resolution\n'


### PR DESCRIPTION
## Summary

Make repository re-registration converge local_only to current GitHub-origin detection while preserving existing pulse preferences; add a hermetic regression test proving manual dispatch path resolution is restored.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-repos-lib.sh, .agents/scripts/tests/test-repos-add-local-only-convergence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-repos-add-local-only-convergence.sh; bash .agents/scripts/tests/test-update-project-config-safety.sh; bash .agents/scripts/tests/test-init-scope.sh; shellcheck .agents/scripts/aidevops-cli/aidevops-repos-lib.sh .agents/scripts/tests/test-repos-add-local-only-convergence.sh

Resolves #28309


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 4m and 97,595 tokens on this as a headless worker.