### PR TITLE
GH#28141: harden private headless worker recovery

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-secret-read.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-secret-read.mjs
@@ -7,6 +7,7 @@ import { basename, normalize } from "path";
 const SECRET_BASENAME_RE = /^(id_(rsa|dsa|ecdsa|ed25519)|\.env(\..*)?|credentials(\.sh|\.json|\.ya?ml)?|service-account(\.json)?|kubeconfig|config\.json|op-vault-export.*|.*password.*|.*passwd.*|.*secret.*)$/i;
 const SECRET_EXTENSION_RE = /\.(pem|key|p12|pfx|kdbx|age|asc|gpg)$/i;
 const PUBLIC_KEY_RE = /\.pub$/i;
+const HOST_RUNTIME_CONFIG_RE = /(^|[/\\])\.config[/\\]opencode[/\\]opencode\.jsonc?$/i;
 const SECRET_PATH_RE = /(^|[/\\])(\.ssh|\.gnupg|\.aws|\.azure|\.config[/\\]gcloud|\.kube|1password|op-vault|password-store)([/\\]|$)/i;
 
 /**
@@ -39,6 +40,7 @@ export function secretReadBlockReason(filePath) {
   if (PUBLIC_KEY_RE.test(base)) return "";
   if (SECRET_BASENAME_RE.test(base)) return "secret-bearing basename";
   if (SECRET_EXTENSION_RE.test(base)) return "secret-bearing file extension";
+  if (HOST_RUNTIME_CONFIG_RE.test(normalized)) return "host runtime config path";
   if (SECRET_PATH_RE.test(normalized)) return "credential-store path";
   return "";
 }

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -386,8 +386,14 @@ _linked_issue_structural_blocker_reasons() {
 			printf 'Issue #%s carries the %s label (decomposition tracker, not a worker target). Decompose into child phase issues, or remove the label if this is no longer a parent.\n' "$issue_num" "\`parent-task\`"
 			;;
 		*NO_AUTO_DISPATCH_BLOCKED*)
+			# no-auto-dispatch is a worker-routing hold, not a prohibition on
+			# explicitly authorized interactive implementation. Keep the hold intact
+			# so Pulse cannot dispatch a parallel worker while local work proceeds.
+			if [[ "${AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION:-0}" == "1" ]] && ! is_headless; then
+				continue
+			fi
 			found=true
-			printf 'Issue #%s carries the %s label (explicit hold). Remove the label if you intentionally want worker dispatch, or work on this issue operationally (post comments, post analysis) without /full-loop.\n' "$issue_num" "\`no-auto-dispatch\`"
+			printf 'Issue #%s carries the %s label (explicit worker-dispatch hold). Remove the label only if you intentionally want worker dispatch, or use the interactive issue-start implementation path.\n' "$issue_num" "\`no-auto-dispatch\`"
 			;;
 		*HOLD_FOR_REVIEW_BLOCKED*)
 			found=true
@@ -406,10 +412,10 @@ _linked_issue_structural_blocker_reasons() {
 # a missing assignee (GH#17810). Interactive maintainer sessions may self-claim
 # an unassigned issue supplied directly in the prompt (GH#22854). Then inherits
 # the pulse-side structural dispatch gates via
-# dispatch-dedup-helper.sh::is-assigned so /full-loop honors parent-task
-# and no-auto-dispatch blocks the same way the pulse does — closing the
-# entry-point asymmetry where /full-loop bypassed gates the pulse refused
-# (t2890). Mirrors the logic in .github/workflows/maintainer-gate.yml.
+# dispatch-dedup-helper.sh::enumerate-blockers so /full-loop honors hard
+# structural holds. no-auto-dispatch remains enforced for workers while the
+# explicit interactive issue-start path may implement locally without removing
+# the worker-routing hold. Mirrors .github/workflows/maintainer-gate.yml.
 #
 # Returns:
 #   0 — gate passes (safe to start)
@@ -556,7 +562,11 @@ _auto_claim_interactive() {
 	# claim comment internally. External upstream repos skip the claim path.
 	local helper="${SCRIPT_DIR}/interactive-session-helper.sh"
 	if [[ -x "$helper" ]]; then
-		"$helper" claim "$issue_num" "$repo" --worktree "$(pwd)" || true
+		local -a claim_args=(claim "$issue_num" "$repo" --worktree "$(pwd)")
+		if [[ "${AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION:-0}" == "1" ]]; then
+			claim_args+=(--implementing)
+		fi
+		"$helper" "${claim_args[@]}" || true
 		print_info "Interactive claim checked: #${issue_num} in ${repo}"
 	else
 		print_warning "interactive-session-helper.sh not found — skipping interactive claim"

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -899,6 +899,9 @@ _hrff_finalize_exit_trap() {
 	_release_dispatch_claim "$session_key" "$reason" "$exit_status" "$session_count"
 	_release_session_lock "$session_key"
 	_update_dispatch_ledger "$session_key" "fail"
+	if declare -F aidevops_runtime_bundle_lease_release >/dev/null 2>&1; then
+		aidevops_runtime_bundle_lease_release || print_warning "Failed to release the worker runtime bundle lease"
+	fi
 	if [[ "$force_nonzero_exit" -eq 1 ]]; then
 		trap - EXIT
 		exit "$exit_status"

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -18,6 +18,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+# shellcheck source=./runtime-bundle-lease.sh
+source "${SCRIPT_DIR}/runtime-bundle-lease.sh"
+if ! aidevops_runtime_bundle_lease_acquire "${SCRIPT_DIR%/scripts}"; then
+	printf "[headless-runtime] FATAL: could not acquire runtime bundle lease for %s\n" "${SCRIPT_DIR%/scripts}" >&2
+	exit 1
+fi
+trap 'aidevops_runtime_bundle_lease_release' EXIT
 # shellcheck source-path=SCRIPTDIR
 # shellcheck source=./shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -674,29 +674,28 @@ build_sandbox_passthrough_csv() {
 		case "$name" in
 		# Session-bound OpenCode env makes isolated canary/worker runs attach to
 		# the parent TUI session and fail with "Session not found" (GH#23065).
-		AIDEVOPS_OPENCODE_SESSION_ID | OPENCODE_SESSION_ID | OPENCODE_PID | OPENCODE_RUN_ID | OPENCODE_PROCESS_ROLE | OPENCODE | OPENCODE_SERVER_PASSWORD) ;;
+		AIDEVOPS_OPENCODE_SESSION_ID | OPENCODE_SESSION_ID | OPENCODE_PID | OPENCODE_RUN_ID | OPENCODE_PROCESS_ROLE | OPENCODE | OPENCODE_SERVER_PASSWORD) continue ;;
 		OPENAI_* | ANTHROPIC_* | GOOGLE_* | CLAUDE_*)
 			if [[ -n "$provider" ]] && ! _headless_provider_env_allowed "$provider" "$name"; then
 				continue
 			fi
-			if [[ "$seen_names" == *" ${name} "* ]]; then
-				continue
-			fi
-			seen_names+="${name} "
-			names+=("$name")
 			;;
+		# Permission and blocker tooling needs this bounded worker identity set.
+		# Keep it explicit: arbitrary WORKER_* values may carry unrelated runtime
+		# configuration and must not cross the clean sandbox boundary.
+		WORKER_ISSUE_NUMBER | WORKER_REPO_SLUG | DISPATCH_REPO_SLUG | WORKER_SESSION_KEY | WORKER_WORKTREE_PATH | WORKER_GITHUB_LOGIN) ;;
 		# OTEL_* is passed through so headless workers under the sandbox
 		# can export OTLP traces when OTEL_EXPORTER_OTLP_ENDPOINT is set.
 		# Without this, opencode never initialises its OTLP exporter and
 		# all aidevops.* plugin span enrichment is silently dropped (t2186).
-		AIDEVOPS_* | PULSE_* | GH_* | GITHUB_* | OPENCODE_* | XDG_* | OTEL_* | REAL_HOME | TMPDIR | TMP | TEMP | RTK_* | VERIFY_*)
-			if [[ "$seen_names" == *" ${name} "* ]]; then
-				continue
-			fi
-			seen_names+="${name} "
-			names+=("$name")
-			;;
+		AIDEVOPS_* | PULSE_* | GH_* | GITHUB_* | OPENCODE_* | XDG_* | OTEL_* | REAL_HOME | TMPDIR | TMP | TEMP | RTK_* | VERIFY_*) ;;
+		*) continue ;;
 		esac
+		if [[ "$seen_names" == *" ${name} "* ]]; then
+			continue
+		fi
+		seen_names+="${name} "
+		names+=("$name")
 	done < <(env)
 
 	local IFS=,

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1719,6 +1719,9 @@ _hrw_finish_cleanup() {
 	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
 		_cleanup_headless_runtime_temp_paths
 	fi
+	if declare -F aidevops_runtime_bundle_lease_release >/dev/null 2>&1; then
+		aidevops_runtime_bundle_lease_release || print_warning "Failed to release the worker runtime bundle lease"
+	fi
 	trap - EXIT
 	return 0
 }
@@ -1857,7 +1860,7 @@ _cmd_run_prepare() {
 	# instead of emitting a fixed 'process_exit' reason for all abnormal exits.
 	# SC2064: session_key is intentionally baked in at trap-set time.
 	# shellcheck disable=SC2064
-	trap "_exit_trap_handler '$session_key'" EXIT
+	trap "_exit_trap_handler '$session_key'; if declare -F aidevops_runtime_bundle_lease_release >/dev/null 2>&1; then aidevops_runtime_bundle_lease_release; fi" EXIT
 
 	# GH#20564: Record worker start time in milliseconds for exit trap classifier.
 	# classify_worker_exit uses this to distinguish crash_during_startup (no

--- a/.agents/scripts/pr-supersession-helper.sh
+++ b/.agents/scripts/pr-supersession-helper.sh
@@ -59,7 +59,7 @@ _psh_fetch_pr_json() {
 	local pr_number="$2"
 
 	gh pr view "$pr_number" --repo "$repo_slug" \
-		--json number,title,body,baseRefName,headRefName,files,author,url \
+		--json number,title,body,baseRefName,headRefName,baseRefOid,headRefOid,files,author,url \
 		2>/dev/null
 	return $?
 }
@@ -91,34 +91,91 @@ _psh_original_files_json() {
 	return 0
 }
 
+_psh_git_repo_available() {
+	local repo_path="$1"
+	[[ -n "$repo_path" ]] || return 1
+	git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1
+	return $?
+}
+
+_psh_delete_temp_refs() {
+	local repo_path="$1"
+	local ref_prefix="$2"
+	[[ -n "$ref_prefix" ]] || return 0
+	git -C "$repo_path" update-ref -d "${ref_prefix}/base" 2>/dev/null || true
+	git -C "$repo_path" update-ref -d "${ref_prefix}/head" 2>/dev/null || true
+	return 0
+}
+
 _psh_diff_files_json() {
 	local repo_path="$1"
 	local base_ref="$2"
 	local head_ref="$3"
+	local pr_number="${4:-}"
+	local expected_head_oid="${5:-}"
+	local base=""
+	local head=""
+	local candidate=""
+	local ref_prefix=""
+	local diff_lines=""
 
-	if [[ -z "$repo_path" || ! -d "$repo_path/.git" ]]; then
+	if ! _psh_git_repo_available "$repo_path"; then
 		printf '[]\n'
 		return 1
 	fi
 
-	git -C "$repo_path" fetch --quiet origin "$base_ref" 2>/dev/null || true
-	git -C "$repo_path" fetch --quiet origin "$head_ref" 2>/dev/null || true
+	if git -C "$repo_path" remote get-url origin >/dev/null 2>&1; then
+		[[ "$pr_number" =~ ^[0-9]+$ ]] || {
+			printf '[]\n'
+			return 1
+		}
+		ref_prefix="refs/aidevops/pr-supersession/${pr_number}-$$"
+		if ! git -C "$repo_path" fetch --quiet origin \
+			"+refs/heads/${base_ref}:${ref_prefix}/base" 2>/dev/null; then
+			_psh_delete_temp_refs "$repo_path" "$ref_prefix"
+			printf '[]\n'
+			return 1
+		fi
+		if ! git -C "$repo_path" fetch --quiet origin \
+			"+refs/pull/${pr_number}/head:${ref_prefix}/head" 2>/dev/null; then
+			_psh_delete_temp_refs "$repo_path" "$ref_prefix"
+			printf '[]\n'
+			return 1
+		fi
+		base=$(git -C "$repo_path" rev-parse "${ref_prefix}/base^{commit}" 2>/dev/null) || base=""
+		head=$(git -C "$repo_path" rev-parse "${ref_prefix}/head^{commit}" 2>/dev/null) || head=""
+		if [[ -z "$base" || -z "$head" ]] || \
+			[[ -n "$expected_head_oid" && "$head" != "$expected_head_oid" ]]; then
+			_psh_delete_temp_refs "$repo_path" "$ref_prefix"
+			printf '[]\n'
+			return 1
+		fi
+	else
+		for candidate in "origin/${base_ref}" "$base_ref"; do
+			if git -C "$repo_path" rev-parse --verify "${candidate}^{commit}" >/dev/null 2>&1; then
+				base="$candidate"
+				break
+			fi
+		done
+		for candidate in "origin/${head_ref}" "$head_ref"; do
+			if git -C "$repo_path" rev-parse --verify "${candidate}^{commit}" >/dev/null 2>&1; then
+				head="$candidate"
+				break
+			fi
+		done
+		if [[ -z "$base" || -z "$head" ]]; then
+			printf '[]\n'
+			return 1
+		fi
+	fi
 
-	local base="origin/${base_ref}"
-	local head="origin/${head_ref}"
-	if ! git -C "$repo_path" rev-parse --verify "$base" >/dev/null 2>&1; then
+	if ! diff_lines=$(git -C "$repo_path" diff --name-only "${base}...${head}" 2>/dev/null); then
+		_psh_delete_temp_refs "$repo_path" "$ref_prefix"
 		printf '[]\n'
 		return 1
 	fi
-	if ! git -C "$repo_path" rev-parse --verify "$head" >/dev/null 2>&1; then
-		head="$head_ref"
-	fi
-	if ! git -C "$repo_path" rev-parse --verify "$head" >/dev/null 2>&1; then
-		printf '[]\n'
-		return 1
-	fi
-
-	git -C "$repo_path" diff --name-only "${base}...${head}" 2>/dev/null | _psh_compact_lines_json
+	_psh_delete_temp_refs "$repo_path" "$ref_prefix"
+	printf '%s\n' "$diff_lines" | _psh_compact_lines_json
 	return 0
 }
 
@@ -140,19 +197,32 @@ _psh_base_term_hits_json() {
 	local repo_path="$1"
 	local base_ref="$2"
 	local terms_json="$3"
-
-	local base="origin/${base_ref}"
+	local expected_base_oid="${4:-}"
+	local base="$expected_base_oid"
+	local candidate=""
 	local terms_count
 	terms_count=$(printf '%s' "$terms_json" | jq 'length' 2>/dev/null) || terms_count=0
 	[[ "$terms_count" =~ ^[0-9]+$ ]] || terms_count=0
-	if [[ "$terms_count" -eq 0 || -z "$repo_path" || ! -d "$repo_path/.git" ]]; then
+	if [[ "$terms_count" -eq 0 ]]; then
 		printf '[]\n'
 		return 0
 	fi
-	git -C "$repo_path" fetch --quiet origin "$base_ref" 2>/dev/null || true
-	if ! git -C "$repo_path" rev-parse --verify "$base" >/dev/null 2>&1; then
+	if ! _psh_git_repo_available "$repo_path"; then
 		printf '[]\n'
-		return 0
+		return 1
+	fi
+	if [[ -z "$base" ]] || ! git -C "$repo_path" rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
+		base=""
+		for candidate in "origin/${base_ref}" "$base_ref"; do
+			if git -C "$repo_path" rev-parse --verify "${candidate}^{commit}" >/dev/null 2>&1; then
+				base="$candidate"
+				break
+			fi
+		done
+	fi
+	if [[ -z "$base" ]]; then
+		printf '[]\n'
+		return 1
 	fi
 
 	local tmp
@@ -182,14 +252,19 @@ _psh_build_comment() {
 	local pr_number="$2"
 	local base_ref="$3"
 	local rationale="$4"
+	local suggested_action="retain this PR until the remaining diff is reviewed"
 
+	case "$classification" in
+	fully_superseded | stale_baseline_only)
+		suggested_action="close this PR only after a maintainer verifies the fetched \`${base_ref}\` comparison represents the intended deliverable"
+		;;
+	esac
 	cat <<EOF
 Supersession check for PR #${pr_number}: **${classification}**.
 
 Rationale: ${rationale}
 
-Suggested action: close this PR as superseded only after a maintainer verifies the current \
-\`${base_ref}\` branch contains the intended deliverable. This helper is advisory and did not close anything.
+Suggested action: ${suggested_action}. This helper is advisory and did not close anything.
 EOF
 	return 0
 }
@@ -249,41 +324,46 @@ _psh_classify_json() {
 	local repo_path="$2"
 	local as_json="$3"
 
-	local pr_number title base_ref head_ref original_files diff_files terms hits
+	local pr_number title base_ref head_ref base_oid head_oid original_files diff_files terms hits
+	local comparison_available=1
 	pr_number=$(printf '%s' "$pr_json" | jq -r '.number // empty')
 	title=$(printf '%s' "$pr_json" | jq -r '.title // empty')
 	base_ref=$(printf '%s' "$pr_json" | jq -r '.baseRefName // empty')
 	head_ref=$(printf '%s' "$pr_json" | jq -r '.headRefName // empty')
+	base_oid=$(printf '%s' "$pr_json" | jq -r '.baseRefOid // empty')
+	head_oid=$(printf '%s' "$pr_json" | jq -r '.headRefOid // empty')
 	original_files=$(_psh_original_files_json "$pr_json")
 	terms=$(_psh_extract_deliverable_terms_json "$pr_json")
-	diff_files=$(_psh_diff_files_json "$repo_path" "$base_ref" "$head_ref" 2>/dev/null) || diff_files="[]"
-	hits=$(_psh_base_term_hits_json "$repo_path" "$base_ref" "$terms")
+	if ! diff_files=$(_psh_diff_files_json "$repo_path" "$base_ref" "$head_ref" \
+		"$pr_number" "$head_oid" 2>/dev/null); then
+		diff_files="[]"
+		comparison_available=0
+	fi
+	hits=$(_psh_base_term_hits_json "$repo_path" "$base_ref" "$terms" "$base_oid" 2>/dev/null) || hits="[]"
 
-	local original_count diff_count terms_count hit_count overlap_count classification rationale comment
+	local original_count diff_count overlap_count classification rationale comment
 	original_count=$(printf '%s' "$original_files" | jq 'length')
 	diff_count=$(printf '%s' "$diff_files" | jq 'length')
-	terms_count=$(printf '%s' "$terms" | jq 'length')
-	hit_count=$(printf '%s' "$hits" | jq 'length')
 	overlap_count=$(_psh_intersection_count "$original_files" "$diff_files")
 
 	classification="still_needed"
-	rationale="base does not yet contain enough deliverable signals, or the current diff still overlaps the PR deliverable"
+	rationale="the exact current PR diff still carries files from the original deliverable"
 
 	if [[ -z "$base_ref" || -z "$head_ref" ]]; then
 		classification="unknown"
 		rationale="PR metadata did not include base/head refs"
-	elif [[ "$diff_count" -eq 0 && "$hit_count" -gt 0 ]]; then
+	elif [[ "$comparison_available" -eq 0 ]]; then
+		classification="unknown"
+		rationale="the exact current PR head could not be compared with its base; an unavailable comparison is not evidence of an empty diff"
+	elif [[ "$diff_count" -eq 0 ]]; then
 		classification="fully_superseded"
-		rationale="current branch has no diff against origin/${base_ref}, and base contains ${hit_count}/${terms_count} deliverable term(s)"
-	elif [[ "$original_count" -gt 0 && "$diff_count" -gt 0 && "$overlap_count" -eq 0 && "$hit_count" -gt 0 ]]; then
+		rationale="the exact fetched PR head has no diff against the fetched ${base_ref} base"
+	elif [[ "$original_count" -gt 0 && "$overlap_count" -eq 0 ]]; then
 		classification="stale_baseline_only"
-		rationale="current diff no longer overlaps the PR's original files, while base contains ${hit_count}/${terms_count} deliverable term(s)"
-	elif [[ "$terms_count" -gt 0 && "$hit_count" -gt 0 && "$hit_count" -lt "$terms_count" ]]; then
+		rationale="the exact current PR diff no longer overlaps any of the PR's original changed files"
+	elif [[ "$original_count" -gt 0 && "$overlap_count" -gt 0 && "$overlap_count" -lt "$original_count" ]]; then
 		classification="partially_superseded"
-		rationale="base contains ${hit_count}/${terms_count} deliverable term(s), but some signals or file overlap remain unresolved"
-	elif [[ "$terms_count" -gt 0 && "$hit_count" -ge "$terms_count" && "$overlap_count" -eq 0 ]]; then
-		classification="fully_superseded"
-		rationale="base contains all deliverable terms and the current diff no longer overlaps original PR files"
+		rationale="the exact PR diff retains ${overlap_count}/${original_count} original changed file(s)"
 	fi
 
 	comment=$(_psh_build_comment "$classification" "$pr_number" "$base_ref" "$rationale")
@@ -294,12 +374,15 @@ _psh_classify_json() {
 			--arg rationale "$rationale" \
 			--arg comment "$comment" \
 			--arg title "$title" \
+			--arg base_oid_at_query "$base_oid" \
+			--arg head_oid "$head_oid" \
 			--argjson pr "${pr_number:-0}" \
+			--argjson comparison_available "$comparison_available" \
 			--argjson original_files "$original_files" \
 			--argjson diff_files "$diff_files" \
 			--argjson deliverable_terms "$terms" \
 			--argjson base_hits "$hits" \
-			'{classification:$classification, rationale:$rationale, suggested_close_comment:$comment, pr:$pr, title:$title, original_files:$original_files, current_diff_files:$diff_files, deliverable_terms:$deliverable_terms, base_hits:$base_hits}'
+			'{classification:$classification, rationale:$rationale, suggested_close_comment:$comment, pr:$pr, title:$title, comparison_available:($comparison_available == 1), base_oid_at_query:$base_oid_at_query, compared_head_oid:$head_oid, original_files:$original_files, current_diff_files:$diff_files, deliverable_terms:$deliverable_terms, base_hits:$base_hits}'
 	else
 		printf 'classification=%s\n' "$classification"
 		printf 'rationale=%s\n' "$rationale"

--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -31,6 +31,7 @@ BLOCKING_LABELS = frozenset({
     "needs-maintainer-review",
     "needs-maintainer-permissions",
     "no-auto-dispatch",
+    "infrastructure",
     "hold-for-review",
     "blocked",
     "status:blocked",
@@ -60,6 +61,7 @@ def _empty_aggregate() -> dict[str, int]:
         "parent_task": 0,
         "nmr": 0,
         "no_auto_dispatch": 0,
+        "infrastructure": 0,
         GH_ERRORS_KEY: 0,
     }
 
@@ -180,6 +182,7 @@ def _count_issue(
     aggregate["parent_task"] += int("parent-task" in labels)
     aggregate["nmr"] += int("needs-maintainer-review" in labels)
     aggregate["no_auto_dispatch"] += int("no-auto-dispatch" in labels)
+    aggregate["infrastructure"] += int("infrastructure" in labels)
     available = "status:available" in labels and not assigned and not blocked and not dependency_inconsistent
     if available:
         aggregate["available_unassigned"] += 1

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -204,7 +204,7 @@ _pulse_available_auto_dispatch_work_exists() {
 		_count=""
 		_query_rc=0
 		_count=$(timeout_sec "$_remaining" gh api -X GET search/issues \
-			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:needs-maintainer-review -label:needs-maintainer-permissions no:assignee" \
+			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:needs-maintainer-review -label:needs-maintainer-permissions -label:infrastructure no:assignee" \
 			-f per_page=1 \
 			--jq '.total_count // 0' 2>/dev/null) || _query_rc=$?
 		if [[ "$_query_rc" -eq 124 ]]; then

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -204,6 +204,15 @@ _pw_bootstrap_script_dir="$(_pulse_wrapper_resolve_script_dir "$_pw_source_path"
 	return 2 2>/dev/null || exit 2
 }
 source "${_pw_bootstrap_script_dir}/portable-stat.sh"
+# shellcheck source=./runtime-bundle-lease.sh
+source "${_pw_bootstrap_script_dir}/runtime-bundle-lease.sh"
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+	if ! aidevops_runtime_bundle_lease_acquire "${_pw_bootstrap_script_dir%/scripts}"; then
+		printf '[pulse-wrapper] FATAL: could not acquire runtime bundle lease for %s\n' "${_pw_bootstrap_script_dir%/scripts}" >&2
+		return 2 2>/dev/null || exit 2
+	fi
+	trap 'aidevops_runtime_bundle_lease_release' EXIT
+fi
 unset _pw_source_path _pw_bootstrap_script_dir
 if [[ "$_pulse_skip_jitter" -eq 0 ]]; then
 	_pw_ffjit_lockdir="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
@@ -1642,7 +1651,7 @@ main() {
 	# Register EXIT trap BEFORE acquiring the lock so the lock is always
 	# released on exit — including set -e aborts, SIGTERM, and return paths.
 	# SIGKILL cannot be trapped; stale-lock detection handles that case.
-	trap '_pulse_efficiency_cycle_finish; release_instance_lock' EXIT
+	trap '_pulse_efficiency_cycle_finish; release_instance_lock; aidevops_runtime_bundle_lease_release' EXIT
 
 	if ! acquire_instance_lock; then
 		return 0
@@ -1680,6 +1689,10 @@ main() {
 		export AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${AIDEVOPS_PULSE_PR_VIEW_CACHE_DIR:-${HOME}/.aidevops/cache/pulse-pr-view-cache}"
 		export AIDEVOPS_GH_PR_VIEW_CACHE_TTL="${AIDEVOPS_PULSE_PR_VIEW_CACHE_TTL:-3600}"
 		_save_cleanup_scope
+		# Register process-lifetime resources first so LIFO cleanup removes
+		# per-cycle caches, records the cycle, releases the lock, then drops the
+		# runtime bundle lease last.
+		push_cleanup 'aidevops_runtime_bundle_lease_release'
 		push_cleanup 'release_instance_lock'
 		push_cleanup '_pulse_efficiency_cycle_finish'
 		# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
@@ -1699,6 +1712,7 @@ main() {
 		export PULSE_PR_LIST_PROVIDER_CACHE_TTL="${AIDEVOPS_PULSE_PR_LIST_CACHE_TTL:-3600}"
 		if [[ "$_pulse_pr_cache_cleanup_scope" -eq 0 ]]; then
 			_save_cleanup_scope
+			push_cleanup 'aidevops_runtime_bundle_lease_release'
 			push_cleanup 'release_instance_lock'
 			push_cleanup '_pulse_efficiency_cycle_finish'
 			# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
@@ -1886,9 +1900,10 @@ main() {
 	#
 	# Lock protocol: we release the instance lock BEFORE exec so the re-exec'd
 	# process can acquire it cleanly. exec does NOT trigger EXIT traps (bash
-	# replaces the process image), so release_instance_lock must be called
-	# explicitly here. The rate-limit t3018 self-heal handles the resulting
-	# state: no live lock holder → stale stamp cleared → proceeds normally.
+	# replaces the process image), so both the instance lock and runtime bundle
+	# lease must be released explicitly here. The rate-limit t3018 self-heal
+	# handles the resulting state: no live lock holder → stale stamp cleared →
+	# proceeds normally.
 	#
 	# In-flight workers: workers are detached via setsid (_dlw_exec_detached)
 	# and survive parent re-exec regardless. No in-flight dispatch is interrupted.
@@ -1904,6 +1919,7 @@ main() {
 			echo "[pulse-wrapper] t3033: source modified (${_pw_mtime_loaded} -> ${_pw_mtime_now}) — releasing lock and re-execing for fresh code" >>"$WRAPPER_LOGFILE"
 			_pulse_efficiency_cycle_finish
 			release_instance_lock
+			aidevops_runtime_bundle_lease_release
 			exec "$_pw_self" "$@"
 			# exec should not return; if it does, log and fall through to normal exit
 			echo "[pulse-wrapper] t3033: exec failed for '${_pw_self}' — continuing with normal exit" >>"$WRAPPER_LOGFILE"

--- a/.agents/scripts/runtime-bundle-lease.sh
+++ b/.agents/scripts/runtime-bundle-lease.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Runtime-bundle PID leases for long-lived Pulse and worker processes.
+
+_AIDEVOPS_RUNTIME_BUNDLE_LEASE_FILE="${_AIDEVOPS_RUNTIME_BUNDLE_LEASE_FILE:-}"
+
+aidevops_runtime_bundle_lease_acquire() {
+	local requested_root="${1:-${AIDEVOPS_AGENTS_DIR:-}}"
+	local bundles_root="${AIDEVOPS_RUNTIME_BUNDLES_DIR:-${HOME:-}/.aidevops/runtime-bundles}"
+	local agents_root=""
+	local physical_bundles_root=""
+	local bundle_dir=""
+	local bundle_id=""
+	local lease_dir=""
+	local lease_file=""
+	local lease_tmp=""
+
+	if [[ -n "$_AIDEVOPS_RUNTIME_BUNDLE_LEASE_FILE" && -f "$_AIDEVOPS_RUNTIME_BUNDLE_LEASE_FILE" ]]; then
+		return 0
+	fi
+	_AIDEVOPS_RUNTIME_BUNDLE_LEASE_FILE=""
+	[[ -n "$requested_root" && -d "$requested_root" ]] || return 0
+	[[ -n "$bundles_root" && -d "$bundles_root" ]] || return 0
+	agents_root=$(cd "$requested_root" && pwd -P) || return 0
+	physical_bundles_root=$(cd "$bundles_root" && pwd -P) || return 0
+	[[ "${agents_root##*/}" == "agents" ]] || return 0
+	bundle_dir="${agents_root%/agents}"
+	[[ "$bundle_dir" != "$agents_root" && "${bundle_dir%/*}" == "$physical_bundles_root" ]] || return 0
+	bundle_id="${bundle_dir##*/}"
+	case "$bundle_id" in
+	"" | .*) return 0 ;;
+	esac
+
+	lease_dir="${physical_bundles_root}/.leases/${bundle_id}"
+	lease_file="${lease_dir}/$$"
+	lease_tmp="${lease_dir}/.$$-${RANDOM}.tmp"
+	mkdir -p "$lease_dir" || return 1
+	: >"$lease_tmp" || return 1
+	chmod 600 "$lease_tmp" 2>/dev/null || {
+		rm -f "$lease_tmp"
+		return 1
+	}
+	if ! printf '%s\n' "$agents_root" >"$lease_tmp" || ! mv "$lease_tmp" "$lease_file"; then
+		rm -f "$lease_tmp"
+		return 1
+	fi
+	_AIDEVOPS_RUNTIME_BUNDLE_LEASE_FILE="$lease_file"
+	return 0
+}
+
+aidevops_runtime_bundle_lease_release() {
+	local lease_file="${_AIDEVOPS_RUNTIME_BUNDLE_LEASE_FILE:-}"
+	local lease_dir=""
+	local leases_root=""
+	[[ -n "$lease_file" ]] || return 0
+	_AIDEVOPS_RUNTIME_BUNDLE_LEASE_FILE=""
+	if [[ "${lease_file##*/}" != "$$" ]]; then
+		return 1
+	fi
+	lease_dir="${lease_file%/*}"
+	leases_root="${lease_dir%/*}"
+	rm -f "$lease_file" 2>/dev/null || return 1
+	rmdir "$lease_dir" 2>/dev/null || true
+	rmdir "$leases_root" 2>/dev/null || true
+	return 0
+}

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1149,7 +1149,14 @@ _run_cleanups() {
 		done <<<"$_CLEANUP_CMDS"
 		while IFS= read -r line; do
 			[[ -z "$line" ]] && continue
-			bash -c "$line" 2>/dev/null || true
+			# Bare function names must run in the current shell so cleanup can
+			# update process-local ownership state before removing resources.
+			# Compound commands remain isolated in a child shell.
+			if [[ "$line" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] && declare -F "$line" >/dev/null 2>&1; then
+				"$line" 2>/dev/null || true
+			else
+				bash -c "$line" 2>/dev/null || true
+			fi
 		done <<<"$reversed"
 	fi
 	# Restore parent scope (pop from save stack)

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -28,6 +28,8 @@ source "$REPO_ROOT/.agents/scripts/setup/modules/agent-deploy.sh"
 source "$REPO_ROOT/.agents/scripts/setup/modules/agent-runtime.sh"
 # shellcheck source=../setup/modules/schedulers-pulse.sh
 source "$REPO_ROOT/.agents/scripts/setup/modules/schedulers-pulse.sh"
+# shellcheck source=../runtime-bundle-lease.sh
+source "$REPO_ROOT/.agents/scripts/runtime-bundle-lease.sh"
 
 _xml_escape() { local value="$1"; printf '%s' "$value"; return 0; }
 
@@ -246,12 +248,9 @@ test_setup_rebinds_stale_process_pin_to_active_bundle() {
 test_live_bundle_lease_survives_three_updates() {
 	local target_dir="$HOME/.aidevops/agents"
 	local leased_root=""
-	local leased_bundle=""
 	local version=""
 	leased_root=$(_runtime_bundle_resolve_root "$target_dir")
-	leased_bundle="${leased_root%/agents}"
-	mkdir -p "$HOME/.aidevops/runtime-bundles/.leases/${leased_bundle##*/}"
-	printf '%s\n' "$leased_root" >"$HOME/.aidevops/runtime-bundles/.leases/${leased_bundle##*/}/$$"
+	aidevops_runtime_bundle_lease_acquire "$leased_root" || fail "runtime process could not acquire its bundle lease"
 
 	for version in 5.0.0 6.0.0 7.0.0; do
 		write_fake_revision "$version" "update-$version"
@@ -260,6 +259,7 @@ test_live_bundle_lease_survives_three_updates() {
 	done
 	[[ -x "$leased_root/scripts/helper.sh" ]] || fail "live first bundle helper survives three updates"
 	pass "live first bundle helper survives three updates"
+	aidevops_runtime_bundle_lease_release || fail "runtime process could not release its bundle lease"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-full-loop-gate-pulse-parity.sh
+++ b/.agents/scripts/tests/test-full-loop-gate-pulse-parity.sh
@@ -7,14 +7,16 @@
 # Asserts that `_check_linked_issue_gate` in `.agents/scripts/full-loop-helper-state.sh`
 # inherits the pulse-side structural dispatch gates via
 # `_linked_issue_structural_blocker_reasons`, which calls `dispatch-dedup-helper.sh
-# enumerate-blockers` and translates PARENT_TASK_BLOCKED, NO_AUTO_DISPATCH_BLOCKED,
-# and HOLD_FOR_REVIEW_BLOCKED signals into hard blocks.
+# enumerate-blockers` and translates PARENT_TASK_BLOCKED and HOLD_FOR_REVIEW_BLOCKED
+# into hard blocks. NO_AUTO_DISPATCH_BLOCKED remains a worker-dispatch hold, but an
+# explicitly marked interactive implementation may proceed without removing it.
 #
 # Background: pre-t2890, the interactive `/full-loop` path only checked
 # needs-maintainer-review + missing assignee. The pulse meanwhile honored
 # parent-task and no-auto-dispatch via dispatch-dedup-helper.sh. A user typing
-# /full-loop on a parent-task, no-auto-dispatch, or hold-for-review issue would bypass those
-# gates entirely. This test prevents accidental regression of the wiring.
+# /full-loop on a parent-task or hold-for-review issue would bypass those gates
+# entirely, while issue-started interactive work was incorrectly blocked by a
+# worker-only no-auto-dispatch hold. This test prevents either asymmetry.
 #
 # This is a static structural check — runtime behaviour is verified at install
 # time via the smoke flow documented in todo/tasks/t2890-brief.md. CI is the
@@ -60,6 +62,7 @@ print_result "helper file exists" 0
 # assertions only see the function we care about.
 GATE_BODY=$(awk '/^_check_linked_issue_gate\(\) \{/,/^}/' "$HELPER_FILE")
 STRUCTURAL_HELPER_BODY=$(awk '/^_linked_issue_structural_blocker_reasons\(\) \{/,/^}/' "$HELPER_FILE")
+AUTO_CLAIM_BODY=$(awk '/^_auto_claim_interactive\(\) \{/,/^}/' "$HELPER_FILE")
 
 if [[ -z "$GATE_BODY" ]]; then
 	print_result "extract _check_linked_issue_gate function body" 1 "function not found in $HELPER_FILE"
@@ -74,6 +77,13 @@ if [[ -z "$STRUCTURAL_HELPER_BODY" ]]; then
 	exit 1
 fi
 print_result "extract _linked_issue_structural_blocker_reasons function body" 0
+
+if [[ -z "$AUTO_CLAIM_BODY" ]]; then
+	print_result "extract _auto_claim_interactive function body" 1 "function not found in $HELPER_FILE"
+	printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	exit 1
+fi
+print_result "extract _auto_claim_interactive function body" 0
 
 assert_in_gate() {
 	local pattern="$1" label="$2"
@@ -91,6 +101,16 @@ assert_in_structural_helper() {
 		print_result "$label" 0
 	else
 		print_result "$label" 1 "pattern '${pattern}' not found in _linked_issue_structural_blocker_reasons body"
+	fi
+	return 0
+}
+
+assert_in_auto_claim() {
+	local pattern="$1" label="$2"
+	if printf '%s\n' "$AUTO_CLAIM_BODY" | grep -qE -- "$pattern"; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "pattern '${pattern}' not found in _auto_claim_interactive body"
 	fi
 	return 0
 }
@@ -119,7 +139,8 @@ assert_in_structural_helper \
 	"structural blocker helper mentions parent-task label in user-facing message"
 
 # -------------------------------------------------------------------
-# Assertion C: NO_AUTO_DISPATCH_BLOCKED case translates to a block
+# Assertion C: NO_AUTO_DISPATCH_BLOCKED remains a worker hold but explicitly
+# marked interactive implementation bypasses that one signal only.
 # -------------------------------------------------------------------
 assert_in_structural_helper \
 	'NO_AUTO_DISPATCH_BLOCKED' \
@@ -127,6 +148,21 @@ assert_in_structural_helper \
 assert_in_structural_helper \
 	'no-auto-dispatch' \
 	"structural blocker helper mentions no-auto-dispatch label in user-facing message"
+assert_in_structural_helper \
+	'AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION' \
+	"structural blocker helper recognizes explicit interactive implementation"
+assert_in_structural_helper \
+	'! is_headless' \
+	"structural blocker helper keeps no-auto-dispatch enforced for headless workers"
+
+# The second claim performed by full-loop must preserve the same explicit
+# implementation authority as interactive-start-helper.sh's first claim.
+assert_in_auto_claim \
+	'AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION' \
+	"auto claim reads the interactive implementation marker"
+assert_in_auto_claim \
+	'--implementing' \
+	"auto claim forwards --implementing for issue-started work"
 
 # -------------------------------------------------------------------
 # Assertion C2: HOLD_FOR_REVIEW_BLOCKED case translates to a block

--- a/.agents/scripts/tests/test-pr-supersession-helper.sh
+++ b/.agents/scripts/tests/test-pr-supersession-helper.sh
@@ -64,8 +64,14 @@ mkpr_json() {
 classify_fixture() {
 	local pr_json="$1"
 	local repo="$2"
-	bash -c 'source "$1"; _psh_classify_json "$2" "$3" 1' _ "$HELPER" "$pr_json" "$repo" \
-		| jq -r '.classification'
+	classify_fixture_json "$pr_json" "$repo" | jq -r '.classification'
+	return 0
+}
+
+classify_fixture_json() {
+	local pr_json="$1"
+	local repo="$2"
+	bash -c 'source "$1"; _psh_classify_json "$2" "$3" 1' _ "$HELPER" "$pr_json" "$repo"
 	return 0
 }
 
@@ -97,11 +103,11 @@ setup_repo "$repo_partial"
 	git add channel.txt && git commit -qm 'branch has remaining work'
 	git update-ref refs/remotes/origin/feature/partial feature/partial
 )
-pr_partial=$(mkpr_json 2 'Add mention_alert_preference new_delivery_channel' 'Core deliverables: mention_alert_preference and new_delivery_channel.' 'feature/partial' 'channel.txt')
+pr_partial=$(mkpr_json 2 'Add mention_alert_preference new_delivery_channel' 'Core deliverables: mention_alert_preference and new_delivery_channel.' 'feature/partial' 'channel.txt' | jq '.files += [{path:"feature.txt"}]')
 got=$(classify_fixture "$pr_partial" "$repo_partial")
 [[ "$got" == "partially_superseded" ]] \
-	&& print_result "partially superseded: base has some deliverable terms" 0 \
-	|| print_result "partially superseded: base has some deliverable terms" 1 "got=$got"
+	&& print_result "partially superseded: exact diff retains only some original files" 0 \
+	|| print_result "partially superseded: exact diff retains only some original files" 1 "got=$got"
 
 repo_needed="${ROOT}/needed"
 setup_repo "$repo_needed"
@@ -117,6 +123,24 @@ got=$(classify_fixture "$pr_needed" "$repo_needed")
 [[ "$got" == "still_needed" ]] \
 	&& print_result "still needed: deliverable only exists on branch" 0 \
 	|| print_result "still needed: deliverable only exists on branch" 1 "got=$got"
+
+repo_term_noise="${ROOT}/term-noise"
+setup_repo "$repo_term_noise"
+(
+	cd "$repo_term_noise" || exit 1
+	printf 'advisory_anchor enabled\n' >advisory.txt
+	git add advisory.txt && git commit -qm 'base has advisory title term'
+	git update-ref refs/remotes/origin/main main
+	git checkout -qb feature/term-noise
+	printf 'actual_delivery_anchor enabled\n' >feature.txt
+	git add feature.txt && git commit -qm 'branch has actual delivery'
+	git update-ref refs/remotes/origin/feature/term-noise feature/term-noise
+)
+pr_term_noise=$(mkpr_json 6 'Add advisory_anchor actual_delivery_anchor' 'Deliverables: advisory_anchor and actual_delivery_anchor.' 'feature/term-noise' 'feature.txt')
+got=$(classify_fixture "$pr_term_noise" "$repo_term_noise")
+[[ "$got" == "still_needed" ]] \
+	&& print_result "advisory title-term hits never override exact overlapping diff evidence" 0 \
+	|| print_result "advisory title-term hits never override exact overlapping diff evidence" 1 "got=$got"
 
 repo_baseline="${ROOT}/baseline"
 setup_repo "$repo_baseline"
@@ -135,6 +159,31 @@ got=$(classify_fixture "$pr_baseline" "$repo_baseline")
 [[ "$got" == "stale_baseline_only" ]] \
 	&& print_result "stale baseline only: base has deliverable, diff no longer overlaps PR files" 0 \
 	|| print_result "stale baseline only: base has deliverable, diff no longer overlaps PR files" 1 "got=$got"
+
+repo_linked_source="${ROOT}/linked-source"
+repo_linked_worktree="${ROOT}/linked-worktree"
+setup_repo "$repo_linked_source"
+(
+	cd "$repo_linked_source" || exit 1
+	git checkout -qb feature/linked
+	printf 'linked_worktree_delivery enabled\n' >feature.txt
+	git add feature.txt && git commit -qm 'branch has linked-worktree deliverable'
+	git update-ref refs/remotes/origin/feature/linked feature/linked
+	git checkout -q main
+	git worktree add -q "$repo_linked_worktree" feature/linked
+)
+pr_linked=$(mkpr_json 5 'Add linked_worktree_delivery' 'Core deliverable: linked_worktree_delivery.' 'feature/linked' 'feature.txt')
+linked_json=$(classify_fixture_json "$pr_linked" "$repo_linked_worktree")
+linked_class=$(printf '%s' "$linked_json" | jq -r '.classification')
+linked_diff=$(printf '%s' "$linked_json" | jq -r '.current_diff_files | join(",")')
+[[ "$linked_class" == "still_needed" && "$linked_diff" == "feature.txt" ]] \
+	&& print_result "linked worktree: real PR diff remains available" 0 \
+	|| print_result "linked worktree: real PR diff remains available" 1 "class=$linked_class diff=$linked_diff"
+
+got=$(classify_fixture "$pr_needed" "${ROOT}/missing-repository")
+[[ "$got" == "unknown" ]] \
+	&& print_result "unavailable git comparison is unknown, never an empty diff" 0 \
+	|| print_result "unavailable git comparison is unknown, never an empty diff" 1 "got=$got"
 
 if [[ "$TESTS_FAILED" -eq 0 ]]; then
 	printf '\nAll %s pr-supersession tests passed.\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -174,7 +174,7 @@ if [[ " $* " == *"private/repo-one"* ]]; then
   {"number":1,"title":"secret one","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
   {"number":2,"title":"secret two","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
   {"number":3,"title":"secret three","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
-  {"number":4,"title":"secret four","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]}
+  {"number":4,"title":"secret four","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"},{"name":"infrastructure"}]}
 ]
 JSON
   exit 0
@@ -227,7 +227,7 @@ printf '%s=== pulse-check-helper.sh tests ===%s\n' "$TEST_BLUE" "$TEST_NC"
 
 OUT=$(env "${COMMON_ENV[@]}" "$HELPER" report 2>&1)
 assert_contains "text report shows empty active capacity" "Active workers: 0 / 6" "$OUT"
-assert_contains "text report shows aggregate queue" "Auto-dispatch queue: 6 available / 6 open" "$OUT"
+assert_contains "text report excludes infrastructure advisories from available work" "Auto-dispatch queue: 5 available / 6 open" "$OUT"
 assert_contains "underfilled finding appears" "pulse-underfilled-auto-dispatch-queue" "$OUT"
 assert_contains "launch accounting finding appears" "pulse-launch-accounting-gap" "$OUT"
 assert_not_contains "text report omits private slug" "private/repo-one" "$OUT"

--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -91,7 +91,7 @@ print_result() {
 # A sandboxed HOME prevents lock directory collisions with a live pulse and
 # ensures the test is fully isolated.
 test_canary_exits_zero() {
-	local sandbox rc output
+	local sandbox rc output lock_retained=0
 	sandbox=$(mktemp -d)
 	mkdir -p "${sandbox}/home"
 	# t3016: seed canonical defaults so bootstrap's _load_config succeeds
@@ -103,14 +103,17 @@ test_canary_exits_zero() {
 			timeout 60 bash "$WRAPPER_SCRIPT" --canary 2>&1
 	)
 	rc=$?
+	if [[ -d "${sandbox}/home/.aidevops/logs/pulse-wrapper.lockdir" ]]; then
+		lock_retained=1
+	fi
 	rm -rf "$sandbox"
 
-	if [[ "$rc" -eq 0 ]]; then
-		print_result "--canary exits 0 (sourcing + self-check + lock passed)" 0
+	if [[ "$rc" -eq 0 && "$lock_retained" -eq 0 ]]; then
+		print_result "--canary exits 0 and releases its instance lock" 0
 		return 0
 	fi
-	print_result "--canary exits 0 (sourcing + self-check + lock passed)" 1 \
-		"Expected exit 0, got $rc. Output: ${output}"
+	print_result "--canary exits 0 and releases its instance lock" 1 \
+		"Expected exit 0 and no retained lock, got rc=$rc lock_retained=$lock_retained. Output: ${output}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -114,10 +114,13 @@ else
 	fail "idle-work query excludes infrastructure advisory issues" "query=$(<"$GH_QUERY_FILE")"
 fi
 
-if [[ "$(<"$TIMEOUT_CALL_FILE")" == "30" ]]; then
+timeout_value=$(<"$TIMEOUT_CALL_FILE")
+if grep -q 'AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK_TIMEOUT:-30' "$SOURCE_SCRIPT" && \
+	[[ "$timeout_value" =~ ^[0-9]+$ ]] && \
+	[[ "$timeout_value" -ge 1 && "$timeout_value" -le 30 ]]; then
 	pass "idle-work query uses bounded default timeout"
 else
-	fail "idle-work query uses bounded default timeout" "timeout=$(<"$TIMEOUT_CALL_FILE")"
+	fail "idle-work query uses bounded default timeout" "timeout=$timeout_value"
 fi
 
 export TIMEOUT_MODE="timeout"

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -108,6 +108,12 @@ else
 	fail "idle-work query excludes NMR-held issues" "query=$(<"$GH_QUERY_FILE")"
 fi
 
+if grep -q -- '-label:infrastructure' "$GH_QUERY_FILE"; then
+	pass "idle-work query excludes infrastructure advisory issues"
+else
+	fail "idle-work query excludes infrastructure advisory issues" "query=$(<"$GH_QUERY_FILE")"
+fi
+
 if [[ "$(<"$TIMEOUT_CALL_FILE")" == "30" ]]; then
 	pass "idle-work query uses bounded default timeout"
 else

--- a/.agents/scripts/tests/test-runtime-bundle-lease.sh
+++ b/.agents/scripts/tests/test-runtime-bundle-lease.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+LEASE_HELPER="${REPO_ROOT}/.agents/scripts/runtime-bundle-lease.sh"
+HEADLESS_HELPER="${REPO_ROOT}/.agents/scripts/headless-runtime-helper.sh"
+PULSE_WRAPPER="${REPO_ROOT}/.agents/scripts/pulse-wrapper.sh"
+TEST_ROOT="$(mktemp -d -t runtime-bundle-lease.XXXXXX)"
+ORIGINAL_HOME="${HOME}"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+cleanup() {
+	HOME="$ORIGINAL_HOME"
+	export HOME
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s %s\n' "$name" "$detail"
+	return 0
+}
+
+if [[ ! -r "$LEASE_HELPER" ]]; then
+	fail "runtime bundle lease helper exists" "missing=$LEASE_HELPER"
+	printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+	exit 1
+fi
+
+# shellcheck source=../runtime-bundle-lease.sh
+source "$LEASE_HELPER"
+HOME="${TEST_ROOT}/home"
+export HOME
+agents_root="${HOME}/.aidevops/runtime-bundles/bundle-one/agents"
+mkdir -p "${agents_root}/scripts"
+agents_root=$(cd "$agents_root" && pwd -P)
+lease_file="${agents_root%/bundle-one/agents}/.leases/bundle-one/$$"
+
+if aidevops_runtime_bundle_lease_acquire "$agents_root" && \
+	[[ -f "$lease_file" ]] && [[ "$(<"$lease_file")" == "$agents_root" ]]; then
+	pass "physical runtime bundle acquisition writes a PID lease"
+else
+	fail "physical runtime bundle acquisition writes a PID lease" "lease=$lease_file"
+fi
+
+aidevops_runtime_bundle_lease_release
+if [[ ! -e "$lease_file" ]]; then
+	pass "runtime bundle lease release removes the PID lease"
+else
+	fail "runtime bundle lease release removes the PID lease" "lease still exists"
+fi
+
+repo_agents="${TEST_ROOT}/repo/.agents"
+mkdir -p "${repo_agents}/scripts"
+if aidevops_runtime_bundle_lease_acquire "$repo_agents" && \
+	[[ -z "${_AIDEVOPS_RUNTIME_BUNDLE_LEASE_FILE:-}" ]]; then
+	pass "non-deployed repository scripts do not create runtime leases"
+else
+	fail "non-deployed repository scripts do not create runtime leases"
+fi
+
+if grep -q 'runtime-bundle-lease.sh' "$HEADLESS_HELPER" && \
+	grep -q 'aidevops_runtime_bundle_lease_acquire' "$HEADLESS_HELPER" && \
+	grep -q 'aidevops_runtime_bundle_lease_release' "$HEADLESS_HELPER"; then
+	pass "headless runtime owns a bundle lease for its process lifetime"
+else
+	fail "headless runtime owns a bundle lease for its process lifetime"
+fi
+
+if grep -q 'runtime-bundle-lease.sh' "$PULSE_WRAPPER" && \
+	grep -q 'aidevops_runtime_bundle_lease_acquire' "$PULSE_WRAPPER" && \
+	grep -q 'aidevops_runtime_bundle_lease_release' "$PULSE_WRAPPER"; then
+	pass "Pulse owns a bundle lease for its process lifetime"
+else
+	fail "Pulse owns a bundle lease for its process lifetime"
+fi
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0

--- a/.agents/scripts/tests/test-sandbox-passthrough-otel.sh
+++ b/.agents/scripts/tests/test-sandbox-passthrough-otel.sh
@@ -30,6 +30,8 @@
 #   5. Previously-covered prefix still works (AIDEVOPS_FOO) — regression guard
 #   6. Canonical worker-origin env is passed through while legacy generic
 #      headless markers are not required past the clean-env boundary.
+#   7. Minimal worker identity crosses the sandbox without allowing arbitrary
+#      WORKER_* variables.
 #
 # Cross-references: t2184 (plugin duration_ms/metadata capture), t2177
 # (OTEL enrichment module), GH#19648 (t2184 issue).
@@ -172,6 +174,34 @@ if [[ ",${csv_out}," == *",AIDEVOPS_SESSION_ORIGIN,"* ]] && \
 	pass "canonical worker-origin env passes through without broad legacy passthrough"
 else
 	fail "canonical worker-origin env passes through without broad legacy passthrough" \
+		"got CSV: ${csv_out}"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 7 — Minimal worker identity is available to sandboxed permission tooling
+# -----------------------------------------------------------------------------
+csv_out=$(run_with_env \
+	WORKER_ISSUE_NUMBER="123" \
+	WORKER_REPO_SLUG="owner/repo" \
+	DISPATCH_REPO_SLUG="owner/repo" \
+	WORKER_SESSION_KEY="issue-123" \
+	WORKER_WORKTREE_PATH="/workspace/repo-123" \
+	WORKER_GITHUB_LOGIN="worker-login" \
+	WORKER_UNRELATED_SECRET="must-not-pass" \
+	bash "$HELPER" passthrough-csv 2>/dev/null)
+
+worker_identity_ok=1
+for required_name in WORKER_ISSUE_NUMBER WORKER_REPO_SLUG DISPATCH_REPO_SLUG \
+	WORKER_SESSION_KEY WORKER_WORKTREE_PATH WORKER_GITHUB_LOGIN; do
+	if [[ ",${csv_out}," != *",${required_name},"* ]]; then
+		worker_identity_ok=0
+	fi
+done
+if [[ "$worker_identity_ok" -eq 1 ]] && \
+	[[ ",${csv_out}," != *",WORKER_UNRELATED_SECRET,"* ]]; then
+	pass "minimal worker identity passes without broad WORKER_* passthrough"
+else
+	fail "minimal worker identity passes without broad WORKER_* passthrough" \
 		"got CSV: ${csv_out}"
 fi
 

--- a/.agents/scripts/tests/test-secret-read-guards.sh
+++ b/.agents/scripts/tests/test-secret-read-guards.sh
@@ -34,14 +34,18 @@ import { secretReadBlockReason } from './.agents/plugins/opencode-aidevops/quali
 if (!secretReadBlockReason('/tmp/.ssh/id_ed25519')) process.exit(1);
 if (!secretReadBlockReason('/tmp/private.pem')) process.exit(2);
 if (secretReadBlockReason('/tmp/id_ed25519.pub')) process.exit(3);
+if (!secretReadBlockReason('/home/test/.config/opencode/opencode.json')) process.exit(4);
+if (!secretReadBlockReason('/home/test/.config/opencode/opencode.jsonc')) process.exit(5);
+if (secretReadBlockReason('/workspace/opencode.json')) process.exit(6);
+if (secretReadBlockReason('/home/test/.config/opencode/AGENTS.md')) process.exit(7);
 NODE
 )
 	local rc=$?
 	set -e
 	if [[ "$rc" -eq 0 ]]; then
-		pass "opencode guard blocks private-key paths and allows .pub"
+		pass "opencode guard blocks keys and host runtime config without blocking safe OpenCode files"
 	else
-		fail "opencode guard blocks private-key paths and allows .pub" "exit=$rc output=$output"
+		fail "opencode guard blocks keys and host runtime config without blocking safe OpenCode files" "exit=$rc output=$output"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-shared-constants-cleanup-stack.sh
+++ b/.agents/scripts/tests/test-shared-constants-cleanup-stack.sh
@@ -59,6 +59,16 @@ _test "Cleanup stack executes in LIFO order" "third second first " "$actual_orde
 _test "Cleanup stack reversal emits no stderr" "" "$actual_stderr"
 _test "Cleanup stack is empty after execution" "" "$_CLEANUP_CMDS"
 
+cleanup_function_probe() {
+	CLEANUP_FUNCTION_PROBE="ran"
+	return 0
+}
+
+CLEANUP_FUNCTION_PROBE="pending"
+push_cleanup 'cleanup_function_probe'
+_run_cleanups
+_test "Bare cleanup function executes in the current shell" "ran" "$CLEANUP_FUNCTION_PROBE"
+
 printf '\nResults: %s passed, %s failed, %s total\n' "$PASS" "$FAIL" "$TESTS"
 
 if [[ $FAIL -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Block host OpenCode credential config reads, preserve bounded worker identity through clean sandboxes, and harden Pulse/worker recovery with evidence-safe supersession, advisory filtering, and runtime bundle leases.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-secret-read.mjs, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/pr-supersession-helper.sh, .agents/scripts/pulse-check-queue-scan.py, .agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/pulse-wrapper.sh, .agents/scripts/runtime-bundle-lease.sh, .agents/scripts/shared-constants.sh, .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh, .agents/scripts/tests/test-full-loop-gate-pulse-parity.sh, .agents/scripts/tests/test-pr-supersession-helper.sh, .agents/scripts/tests/test-pulse-check-helper.sh, .agents/scripts/tests/test-pulse-wrapper-canary.sh, .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh, .agents/scripts/tests/test-runtime-bundle-lease.sh, .agents/scripts/tests/test-sandbox-passthrough-otel.sh, .agents/scripts/tests/test-secret-read-guards.sh, .agents/scripts/tests/test-shared-constants-cleanup-stack.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** linters-local.sh and --full; focused Pulse, headless runtime, bundle lease, deployment, supersession, sandbox, and secret-guard regressions

Resolves #28141


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 23m and 1,386,661 tokens on this with the user in an interactive session.