### PR TITLE
GH#28320: fix framework issue URL parsing

### DIFF
--- a/.agents/scripts/framework-routing-helper.sh
+++ b/.agents/scripts/framework-routing-helper.sh
@@ -316,6 +316,38 @@ _lfi_check_dedup() {
 	return 0
 }
 
+# _lfi_extract_created_issue_url — extract one canonical target-repo issue URL
+# Arguments: "$issue_output" "$slug"
+# Prints the URL only when the wrapper output contains exactly one valid issue
+# URL and every issue URL belongs to the requested repository.
+_lfi_extract_created_issue_url() {
+	local issue_output="$1"
+	local slug="$2"
+	local expected_prefix="https://github.com/${slug}/issues/"
+	local issue_url=""
+	local issue_url_count=0
+	local line
+
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^https://github\.com/[^/[:space:]]+/[^/[:space:]]+/issues/[^/[:space:]]+$ ]]; then
+			issue_url_count=$((issue_url_count + 1))
+			if [[ "$line" == "${expected_prefix}"* ]]; then
+				local issue_number="${line#"$expected_prefix"}"
+				if [[ "$issue_number" =~ ^[1-9][0-9]*$ ]]; then
+					issue_url="$line"
+				fi
+			fi
+		fi
+	done <<<"$issue_output"
+
+	if [[ "$issue_url_count" -eq 1 && -n "$issue_url" ]]; then
+		printf '%s\n' "$issue_url"
+		return 0
+	fi
+
+	return 1
+}
+
 # _lfi_create_and_record — create issue via gh, append sig footer, record fingerprint
 # Arguments: "$slug" "$title" "$body" "$labels"
 # Sets _LFI_ISSUE_URL on success. Returns: 0=created, 1=error.
@@ -332,19 +364,41 @@ _lfi_create_and_record() {
 	sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer --body "$body" || true)
 	local body_for_api="${body}${sig_footer}"
 
-	local issue_url
-	if ! issue_url=$(gh_create_issue --repo "$slug" \
+	local issue_output
+	if ! issue_output=$(gh_create_issue --repo "$slug" \
 		--title "$title" \
 		--body "$body_for_api" \
 		--label "$labels" 2>&1); then
-		log_error "Failed to create issue: $issue_url"
+		log_error "Failed to create issue: $issue_output"
 		return 1
 	fi
 
+	local issue_url
+	if ! issue_url=$(_lfi_extract_created_issue_url "$issue_output" "$slug"); then
+		log_error "Issue create output did not contain one canonical ${slug} issue URL"
+		printf '%s\n' "$issue_output" >&2
+		return 1
+	fi
+
+	# Preserve wrapper diagnostics without allowing them to contaminate stdout.
+	local output_line
+	while IFS= read -r output_line; do
+		if [[ -n "$output_line" && "$output_line" != "$issue_url" ]]; then
+			printf '%s\n' "$output_line" >&2
+		fi
+	done <<<"$issue_output"
+
 	# Record fingerprint for future cross-path dedup (body without sig footer)
 	local issue_number
-	issue_number=$(printf '%s' "$issue_url" | sed 's|.*/||')
-	record_filing "$title" "$body" "$issue_number"
+	issue_number="${issue_url##*/}"
+	local fingerprint_output
+	if ! fingerprint_output=$(record_filing "$title" "$body" "$issue_number"); then
+		log_error "Issue #${issue_number} was created but its fingerprint could not be recorded"
+		return 1
+	fi
+	if [[ -n "$fingerprint_output" ]]; then
+		printf '%s\n' "$fingerprint_output" >&2
+	fi
 
 	log_success "Framework issue created: $issue_url"
 	_LFI_ISSUE_URL="$issue_url"

--- a/.agents/scripts/framework-routing-helper.sh
+++ b/.agents/scripts/framework-routing-helper.sh
@@ -324,15 +324,20 @@ _lfi_extract_created_issue_url() {
 	local issue_output="$1"
 	local slug="$2"
 	local expected_prefix="https://github.com/${slug}/issues/"
+	local expected_prefix_lower=""
 	local issue_url=""
 	local issue_url_count=0
-	local line
+	local line=""
+	local line_lower=""
+	local issue_number=""
+	expected_prefix_lower=$(printf '%s' "$expected_prefix" | tr '[:upper:]' '[:lower:]')
 
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^https://github\.com/[^/[:space:]]+/[^/[:space:]]+/issues/[^/[:space:]]+$ ]]; then
 			issue_url_count=$((issue_url_count + 1))
-			if [[ "$line" == "${expected_prefix}"* ]]; then
-				local issue_number="${line#"$expected_prefix"}"
+			line_lower=$(printf '%s' "$line" | tr '[:upper:]' '[:lower:]')
+			if [[ "$line_lower" == "${expected_prefix_lower}"* ]]; then
+				issue_number="${line_lower#"$expected_prefix_lower"}"
 				if [[ "$issue_number" =~ ^[1-9][0-9]*$ ]]; then
 					issue_url="$line"
 				fi

--- a/.agents/scripts/tests/test-framework-routing-helper.sh
+++ b/.agents/scripts/tests/test-framework-routing-helper.sh
@@ -78,6 +78,8 @@ run_log_framework_issue_case() {
 	local trace_file="$3"
 	local tmp_home="$4"
 	local stub_dir="$5"
+	local create_output="${6:-https://github.com/marcusquinn/aidevops/issues/9104}"
+	local error_file="${7:-${output_file}.stderr}"
 
 	mkdir -p "$stub_dir"
 	cat >"${stub_dir}/gh" <<'EOF'
@@ -99,7 +101,7 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
 fi
 
 if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
-	printf '%s\n' "https://github.com/marcusquinn/aidevops/issues/9104"
+	printf '%s\n' "${TEST_CREATE_OUTPUT}"
 	exit 0
 fi
 
@@ -120,12 +122,13 @@ EOF
 	if HOME="$tmp_home" \
 		PATH="${stub_dir}:$PATH" \
 		TEST_DUPLICATE_VALUE="$duplicate_value" \
+		TEST_CREATE_OUTPUT="$create_output" \
 		TEST_GH_TRACE="$trace_file" \
 		LOG_ISSUE_DEDUP_FILE="${tmp_home}/dedup.jsonl" \
 		"$HELPER" log-framework-issue \
-			--title "fix: no result dedup" \
-			--body "body" \
-			--labels "bug" >"$output_file" 2>&1; then
+		--title "fix: no result dedup" \
+		--body "body" \
+		--labels "bug" >"$output_file" 2>"$error_file"; then
 		return 0
 	fi
 
@@ -251,6 +254,58 @@ else
 	echo "  FAIL: null issue-list result creates issue"
 	cat "$null_output" 2>/dev/null || true
 fi
+
+informational_output="${TMP_DIR}/informational.out"
+informational_error="${TMP_DIR}/informational.err"
+informational_home="${TMP_DIR}/home-informational"
+informational_fixture="[INFO] auto-dispatch label present — skipping self-assignment
+[INFO] Privacy scan passed
+https://github.com/marcusquinn/aidevops/issues/9105"
+if run_log_framework_issue_case "[]" "$informational_output" "${TMP_DIR}/informational.trace" \
+	"$informational_home" "${TMP_DIR}/stub-informational" "$informational_fixture" "$informational_error"; then
+	informational_text=$(<"$informational_output")
+	informational_diagnostics=$(<"$informational_error")
+	informational_fingerprint=$(<"${informational_home}/.aidevops/state/log-issue-fingerprints.jsonl")
+	if [[ "$informational_text" == "https://github.com/marcusquinn/aidevops/issues/9105" ]]; then
+		PASS=$((PASS + 1))
+		echo "  PASS: informational create output returns one clean URL on stdout"
+	else
+		FAIL=$((FAIL + 1))
+		echo "  FAIL: informational create output did not return one clean URL: $informational_text"
+	fi
+	assert_contains "$informational_diagnostics" "Privacy scan passed" "informational create diagnostics are preserved on stderr"
+	assert_contains "$informational_fingerprint" '"issue":9105' "informational create output records numeric fingerprint"
+else
+	FAIL=$((FAIL + 1))
+	echo "  FAIL: informational create output succeeds"
+fi
+
+invalid_create_fixtures=(
+	"create completed without a URL"
+	"https://github.com/marcusquinn/aidevops/issues/not-a-number"
+	$'https://github.com/marcusquinn/aidevops/issues/9106\nhttps://github.com/marcusquinn/aidevops/issues/9107'
+	"https://github.com/example/project/issues/9108"
+)
+invalid_create_descriptions=("missing" "malformed" "multiple" "wrong-repository")
+for index in "${!invalid_create_fixtures[@]}"; do
+	case_home="${TMP_DIR}/home-invalid-${index}"
+	if run_log_framework_issue_case "[]" "${TMP_DIR}/invalid-${index}.out" \
+		"${TMP_DIR}/invalid-${index}.trace" "$case_home" "${TMP_DIR}/stub-invalid-${index}" \
+		"${invalid_create_fixtures[$index]}" "${TMP_DIR}/invalid-${index}.err"; then
+		FAIL=$((FAIL + 1))
+		echo "  FAIL: ${invalid_create_descriptions[$index]} issue URL output fails closed"
+	else
+		PASS=$((PASS + 1))
+		echo "  PASS: ${invalid_create_descriptions[$index]} issue URL output fails closed"
+	fi
+	if [[ -s "${case_home}/.aidevops/state/log-issue-fingerprints.jsonl" ]]; then
+		FAIL=$((FAIL + 1))
+		echo "  FAIL: ${invalid_create_descriptions[$index]} issue URL output recorded a fingerprint"
+	else
+		PASS=$((PASS + 1))
+		echo "  PASS: ${invalid_create_descriptions[$index]} issue URL output does not record a fingerprint"
+	fi
+done
 
 echo ""
 

--- a/.agents/scripts/tests/test-framework-routing-helper.sh
+++ b/.agents/scripts/tests/test-framework-routing-helper.sh
@@ -280,6 +280,26 @@ else
 	echo "  FAIL: informational create output succeeds"
 fi
 
+mixed_case_output="${TMP_DIR}/mixed-case.out"
+mixed_case_home="${TMP_DIR}/home-mixed-case"
+mixed_case_fixture="https://github.com/MarcusQuinn/Aidevops/issues/9106"
+if run_log_framework_issue_case "[]" "$mixed_case_output" "${TMP_DIR}/mixed-case.trace" \
+	"$mixed_case_home" "${TMP_DIR}/stub-mixed-case" "$mixed_case_fixture"; then
+	mixed_case_text=$(<"$mixed_case_output")
+	mixed_case_fingerprint=$(<"${mixed_case_home}/.aidevops/state/log-issue-fingerprints.jsonl")
+	if [[ "$mixed_case_text" == "$mixed_case_fixture" ]]; then
+		PASS=$((PASS + 1))
+		echo "  PASS: mixed-case repository URL preserves canonical output"
+	else
+		FAIL=$((FAIL + 1))
+		echo "  FAIL: mixed-case repository URL was not preserved: $mixed_case_text"
+	fi
+	assert_contains "$mixed_case_fingerprint" '"issue":9106' "mixed-case repository URL records numeric fingerprint"
+else
+	FAIL=$((FAIL + 1))
+	echo "  FAIL: mixed-case repository URL matches configured slug"
+fi
+
 invalid_create_fixtures=(
 	"create completed without a URL"
 	"https://github.com/marcusquinn/aidevops/issues/not-a-number"


### PR DESCRIPTION
## Summary

- extract exactly one canonical target-repository issue URL from wrapped create output
- preserve informational diagnostics on stderr while keeping stdout machine-readable
- fail closed without recording a fingerprint for missing, malformed, multiple, or wrong-repository URLs
- add regression coverage in `.agents/scripts/tests/test-framework-routing-helper.sh`

## Testing

- `bash .agents/scripts/tests/test-framework-routing-helper.sh`
- `shellcheck .agents/scripts/framework-routing-helper.sh .agents/scripts/tests/test-framework-routing-helper.sh`

Resolves #28320

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3
