### PR TITLE
GH#28264: fix Pulse freshness and safe write targets

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -88,6 +88,17 @@ test("classifies every apply-patch target instead of trusting linked cwd", () =>
       () => checkCanonicalWriteSafetyGate("", scriptsDir, linked, { invalid: true }),
       /targets could not be classified/,
     );
+
+    const outsideTarget = join(root, "aidevops-issue-body.md");
+    const outsidePatch = `*** Begin Patch\n*** Add File: ${outsideTarget}\n+safe\n*** End Patch\n`;
+    assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate("", scriptsDir, repo, outsidePatch),
+    );
+    const mixedPatch = `*** Begin Patch\n*** Add File: ${outsideTarget}\n+safe\n*** Update File: ${join(repo, "README.md")}\n@@\n-seed\n+unsafe\n*** End Patch\n`;
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate("", scriptsDir, repo, mixedPatch),
+      /canonical write policy.*read-only session mirrors/,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -134,6 +145,21 @@ test("blocks every canonical direct write and preserves linked-worktree writes",
     );
     assert.doesNotThrow(
       () => checkCanonicalWriteSafetyGate("new-file.md", scriptsDir, linked),
+    );
+    const bodyDir = join(root, ".aidevops", ".agent-workspace", "tmp");
+    mkdirSync(bodyDir, { recursive: true });
+    assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate(join(bodyDir, "issue-body.md"), scriptsDir, repo),
+    );
+    assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate(join(linked, "from-canonical.md"), scriptsDir, repo),
+    );
+
+    const canonicalAlias = join(root, "canonical-alias");
+    symlinkSync(repo, canonicalAlias, "dir");
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(join(canonicalAlias, "README.md"), scriptsDir, repo),
+      /canonical write policy.*read-only session mirrors/,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/.agents/scripts/canonical-write-policy-helper.py
+++ b/.agents/scripts/canonical-write-policy-helper.py
@@ -150,6 +150,13 @@ def check_write(cwd: str, file_path: str) -> dict[str, Any]:
     elif target.classification == "canonical":
         decision = "deny"
         reason = "canonical checkouts are read-only session mirrors"
+    elif (
+        target.classification == "linked"
+        and context.inside_git
+        and target.common_dir != context.common_dir
+    ):
+        decision = "deny"
+        reason = "linked worktree target belongs to a different repository"
     else:
         decision = "allow"
         reason = (

--- a/.agents/scripts/canonical-write-policy-helper.py
+++ b/.agents/scripts/canonical-write-policy-helper.py
@@ -139,22 +139,15 @@ def _target_probe(cwd: str, file_path: str) -> str:
 def check_write(cwd: str, file_path: str) -> dict[str, Any]:
     """Return one fail-closed direct-file-write decision."""
     context = classify_location(cwd)
-    target = classify_location(_target_probe(cwd, file_path))
-    classifications = (context, target)
-    unknown = next(
-        (item for item in classifications if item.classification == "unknown"), None
-    )
+    if not file_path:
+        target = Classification("unknown", False, reason="write target is empty")
+    else:
+        target = classify_location(_target_probe(cwd, file_path))
 
-    if unknown is not None:
+    if target.classification == "unknown":
         decision = "deny"
-        reason = f"worktree classification failed closed: {unknown.reason}"
+        reason = f"write target classification failed closed: {target.reason}"
     elif target.classification == "canonical":
-        decision = "deny"
-        reason = "canonical checkouts are read-only session mirrors"
-    elif context.classification == "canonical" and not (
-        target.classification == "linked"
-        and target.common_dir == context.common_dir
-    ):
         decision = "deny"
         reason = "canonical checkouts are read-only session mirrors"
     else:
@@ -162,7 +155,7 @@ def check_write(cwd: str, file_path: str) -> dict[str, Any]:
         reason = (
             "write target resolves inside an allowed linked worktree"
             if target.classification == "linked"
-            else "write target and process context are outside canonical worktrees"
+            else "write target is outside canonical worktrees"
         )
 
     return {
@@ -194,9 +187,9 @@ def check_patch(cwd: str, patch_text: str) -> dict[str, Any]:
     """Return one fail-closed decision for every target in an apply patch."""
     paths = _patch_paths(patch_text)
     if not paths:
-        context_decision = check_write(cwd, "")
+        empty_decision = check_write(cwd, "")
         return {
-            **context_decision,
+            **empty_decision,
             "decision": "deny",
             "reason": "apply-patch targets could not be classified safely",
             "action": "repair_or_use_linked_worktree",

--- a/.agents/scripts/pulse-session-helper.sh
+++ b/.agents/scripts/pulse-session-helper.sh
@@ -37,6 +37,7 @@ readonly SESSION_FLAG="${HOME}/.aidevops/logs/pulse-session.flag"
 readonly STOP_FLAG="${HOME}/.aidevops/logs/pulse-session.stop"
 readonly LOGFILE="${HOME}/.aidevops/logs/pulse.log"
 readonly WRAPPER_LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
+readonly WRAPPER_LAST_RUN_FILE="${HOME}/.aidevops/logs/pulse-wrapper-last-run.ts"
 readonly PIDFILE="${HOME}/.aidevops/logs/pulse.pid"
 readonly MAX_WORKERS_FILE="${HOME}/.aidevops/logs/pulse-max-workers"
 readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
@@ -226,20 +227,56 @@ get_scheduler_install_cmd() {
 }
 
 #######################################
-# Get last pulse timestamp from log
+# Convert a Unix epoch to an ISO 8601 UTC timestamp on GNU and BSD date.
+#######################################
+_pulse_epoch_to_iso() {
+	local epoch="$1"
+	local iso=""
+
+	iso=$(date -u -d "@${epoch}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || true
+	if [[ -z "$iso" ]]; then
+		iso=$(date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || true
+	fi
+	if [[ -z "$iso" ]]; then
+		return 1
+	fi
+	printf '%s\n' "$iso"
+	return 0
+}
+
+#######################################
+# Get the last admitted deterministic Pulse timestamp. Fall back to the
+# historical optional LLM-cycle log marker for installations that predate the
+# wrapper marker file.
 #######################################
 get_last_pulse_time() {
-	local candidate_log last_line
-	for candidate_log in "$WRAPPER_LOGFILE" "$LOGFILE"; do
-		if [[ -f "$candidate_log" ]]; then
-			last_line=$(grep 'Starting pulse at' "$candidate_log" | tail -1)
-			if [[ -n "$last_line" ]]; then
-				echo "$last_line" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' | tail -1
+	local marker_epoch=""
+	local marker_iso=""
+	if [[ -f "$WRAPPER_LAST_RUN_FILE" ]]; then
+		IFS= read -r marker_epoch <"$WRAPPER_LAST_RUN_FILE" || true
+		if [[ "$marker_epoch" =~ ^[1-9][0-9]*$ ]]; then
+			marker_iso=$(_pulse_epoch_to_iso "$marker_epoch") || marker_iso=""
+			if [[ -n "$marker_iso" ]]; then
+				printf '%s\n' "$marker_iso"
 				return 0
 			fi
 		fi
+	fi
+
+	local candidate_log last_line timestamp
+	for candidate_log in "$WRAPPER_LOGFILE" "$LOGFILE"; do
+		if [[ -f "$candidate_log" ]]; then
+			last_line=$(grep 'Starting pulse at' "$candidate_log" | tail -1 || true)
+			if [[ -n "$last_line" ]]; then
+				timestamp=$(printf '%s\n' "$last_line" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' | tail -1 || true)
+				if [[ -n "$timestamp" ]]; then
+					printf '%s\n' "$timestamp"
+					return 0
+				fi
+			fi
+		fi
 	done
-	echo "never"
+	printf '%s\n' "never"
 	return 0
 }
 

--- a/.agents/scripts/pulse-session-helper.sh
+++ b/.agents/scripts/pulse-session-helper.sh
@@ -263,7 +263,7 @@ get_last_pulse_time() {
 		fi
 	fi
 
-	local candidate_log last_line timestamp
+	local candidate_log="" last_line="" timestamp=""
 	for candidate_log in "$WRAPPER_LOGFILE" "$LOGFILE"; do
 		if [[ -f "$candidate_log" ]]; then
 			last_line=$(grep 'Starting pulse at' "$candidate_log" | tail -1 || true)

--- a/.agents/scripts/tests/test-git-safety-guard.sh
+++ b/.agents/scripts/tests/test-git-safety-guard.sh
@@ -225,7 +225,14 @@ test_off_default_branch_in_linked_worktree_allowed() {
 	local output=""
 	local rc=0
 	for tool_name in Edit Write functions.apply_patch apply_patch; do
-		json=$(printf '{"tool_name":"%s","tool_input":{"filePath":"%s/src/foo.ts"}}' "$tool_name" "$worktree_path")
+		case "$tool_name" in
+		*apply_patch)
+			json=$(printf '{"tool_name":"%s","tool_input":{"patchText":"*** Begin Patch\\n*** Add File: %s/new-file.md\\n+safe\\n*** End Patch\\n"}}' "$tool_name" "$worktree_path")
+			;;
+		*)
+			json=$(printf '{"tool_name":"%s","tool_input":{"filePath":"%s/src/foo.ts"}}' "$tool_name" "$worktree_path")
+			;;
+		esac
 		output=$(run_hook "$worktree_path" "$json") || true
 		[[ -z "$output" ]] || rc=1
 	done

--- a/.agents/scripts/tests/test-pulse-session-last-run.sh
+++ b/.agents/scripts/tests/test-pulse-session-last-run.sh
@@ -92,12 +92,16 @@ _test_portable_date_fallback() {
 _test_status_summary_uses_marker() {
 	_reset_sources
 	printf '%s\n' "1704067200" >"$WRAPPER_LAST_RUN_FILE"
-	get_pulse_repo_count() {
-		printf '%s\n' "0"
-		return 0
-	}
-	local output
-	output=$(_status_print_workers_summary 0)
+	local output=""
+	output=$(
+		# Keep this sourced-function mock inside the command-substitution
+		# subshell so later tests cannot inherit it.
+		get_pulse_repo_count() {
+			printf '%s\n' "0"
+			return 0
+		}
+		_status_print_workers_summary 0
+	)
 	if [[ "$output" == *"Last pulse:  2024-01-01T00:00:00Z"* ]]; then
 		_assert_equal "present" "present" "status displays deterministic wrapper timestamp"
 	else
@@ -112,8 +116,10 @@ main() {
 	_test_portable_date_fallback
 	_test_status_summary_uses_marker
 	printf '1..%d\n' "$_TESTS_RUN"
-	[[ "$_TESTS_FAILED" -eq 0 ]]
-	return $?
+	if [[ "$_TESTS_FAILED" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
 }
 
 main "$@"

--- a/.agents/scripts/tests/test-pulse-session-last-run.sh
+++ b/.agents/scripts/tests/test-pulse-session-last-run.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+_TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_TEST_REPO_ROOT="$(cd "${_TEST_SCRIPT_DIR}/../../.." && pwd)"
+_TEST_TARGET="${_TEST_REPO_ROOT}/.agents/scripts/pulse-session-helper.sh"
+_TEST_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/pulse-session-last-run.XXXXXX")
+export HOME="${_TEST_TMP_DIR}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+_cleanup() {
+	rm -rf "$_TEST_TMP_DIR"
+	return 0
+}
+trap _cleanup EXIT
+
+# Load functions without invoking the CLI. The helper derives all readonly
+# paths from the isolated HOME above.
+# shellcheck source=/dev/null
+source <(sed '/^main "\$@"$/d' "$_TEST_TARGET")
+
+_TESTS_RUN=0
+_TESTS_FAILED=0
+
+_assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local name="$3"
+	_TESTS_RUN=$((_TESTS_RUN + 1))
+	if [[ "$actual" == "$expected" ]]; then
+		printf 'ok %d - %s\n' "$_TESTS_RUN" "$name"
+		return 0
+	fi
+	_TESTS_FAILED=$((_TESTS_FAILED + 1))
+	printf 'not ok %d - %s (expected %q, got %q)\n' "$_TESTS_RUN" "$name" "$expected" "$actual"
+	return 0
+}
+
+_reset_sources() {
+	rm -f "$WRAPPER_LAST_RUN_FILE" "$WRAPPER_LOGFILE" "$LOGFILE"
+	return 0
+}
+
+_test_marker_precedes_optional_cycle_log() {
+	_reset_sources
+	printf '%s\n' "1704067200" >"$WRAPPER_LAST_RUN_FILE"
+	printf '%s\n' '[pulse] Starting pulse at 2023-01-01T00:00:00Z' >"$WRAPPER_LOGFILE"
+	_assert_equal "2024-01-01T00:00:00Z" "$(get_last_pulse_time)" \
+		"deterministic wrapper marker wins over optional LLM-cycle log"
+	return 0
+}
+
+_test_log_fallbacks() {
+	_reset_sources
+	printf '%s\n' "invalid" >"$WRAPPER_LAST_RUN_FILE"
+	printf '%s\n' '[pulse] Starting pulse at 2025-02-03T04:05:06Z' >"$WRAPPER_LOGFILE"
+	_assert_equal "2025-02-03T04:05:06Z" "$(get_last_pulse_time)" \
+		"malformed marker falls back to wrapper log"
+
+	_reset_sources
+	printf '%s\n' '[pulse] Starting pulse at 2025-03-04T05:06:07Z' >"$LOGFILE"
+	_assert_equal "2025-03-04T05:06:07Z" "$(get_last_pulse_time)" \
+		"legacy pulse log remains a final fallback"
+
+	_reset_sources
+	_assert_equal "never" "$(get_last_pulse_time)" "missing marker and logs report never"
+	return 0
+}
+
+_test_portable_date_fallback() {
+	date() {
+		local first="${1:-}"
+		local second="${2:-}"
+		if [[ "$first" == "-u" && "$second" == "-d" ]]; then
+			return 1
+		fi
+		if [[ "$first" == "-u" && "$second" == "-r" ]]; then
+			printf '%s\n' "2024-01-01T00:00:00Z"
+			return 0
+		fi
+		return 1
+	}
+	_assert_equal "2024-01-01T00:00:00Z" "$(_pulse_epoch_to_iso 1704067200)" \
+		"BSD date fallback converts the wrapper epoch"
+	unset -f date
+	return 0
+}
+
+_test_status_summary_uses_marker() {
+	_reset_sources
+	printf '%s\n' "1704067200" >"$WRAPPER_LAST_RUN_FILE"
+	get_pulse_repo_count() {
+		printf '%s\n' "0"
+		return 0
+	}
+	local output
+	output=$(_status_print_workers_summary 0)
+	if [[ "$output" == *"Last pulse:  2024-01-01T00:00:00Z"* ]]; then
+		_assert_equal "present" "present" "status displays deterministic wrapper timestamp"
+	else
+		_assert_equal "present" "missing" "status displays deterministic wrapper timestamp"
+	fi
+	return 0
+}
+
+main() {
+	_test_marker_precedes_optional_cycle_log
+	_test_log_fallbacks
+	_test_portable_date_fallback
+	_test_status_summary_uses_marker
+	printf '1..%d\n' "$_TESTS_RUN"
+	[[ "$_TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -297,23 +297,19 @@ documented in GH#20322. Do not skip it even if Step 3 returned no results.
 
 ### Step 6: Create the Issue
 
-First Bash tool call: create and sign an absolute body file.
+First, use the runtime Write tool—not Bash, a heredoc, or shell redirection—to
+create `aidevops-issue-body.md` at a fully resolved absolute path beneath
+`${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}`. Write only the
+approved `BODY_CONTENT`; the managed GitHub wrapper signs a private copy before
+posting.
 
-```bash
-BODY_FILE="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}/aidevops-issue-body.md"
-cat <<'EOF' > "$BODY_FILE"
-BODY_CONTENT
-EOF
-~/.aidevops/agents/scripts/gh-signature-helper.sh footer >> "$BODY_FILE"
-```
-
-Second Bash tool call: post the already-created file. Do not combine body-file
-creation and the `gh issue create` write in the same Bash tool call.
+Then use a separate Bash tool call to post the already-created file. Do not
+combine body-file creation and the `gh issue create` write in one call.
 
 ```bash
 gh issue create -R marcusquinn/aidevops \
   --title "TITLE" \
-  --body-file "$BODY_FILE" \
+  --body-file "/absolute/path/to/aidevops-issue-body.md" \
   --label "LABEL"
 ```
 

--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -96,6 +96,34 @@ class CanonicalWritePolicyTests(unittest.TestCase):
         self.assertIsNone(self._check(self.repo, outside_target))
         self.assertIsNone(self._check(self.repo, self.linked / "new-file.md"))
 
+    def test_cross_repository_linked_target_is_denied(self):
+        foreign_repo = self.root / "foreign-repo"
+        foreign_linked = self.root / "foreign-linked"
+        foreign_repo.mkdir()
+        self._git(foreign_repo, "init", "-q", "-b", "main")
+        self._git(foreign_repo, "config", "user.name", "Test")
+        self._git(foreign_repo, "config", "user.email", "test@example.invalid")
+        self._git(foreign_repo, "config", "commit.gpgsign", "false")
+        (foreign_repo / "README.md").write_text("foreign\n", encoding="utf-8")
+        self._git(foreign_repo, "add", "README.md")
+        self._git(foreign_repo, "commit", "-q", "-m", "foreign seed")
+        self._git(
+            foreign_repo,
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "feature/foreign",
+            str(foreign_linked),
+        )
+
+        for cwd in (self.repo, self.linked):
+            with self.subTest(cwd=cwd):
+                denial = self._check(cwd, foreign_linked / "README.md")
+                self.assertIsNotNone(denial)
+                reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
+                self.assertIn("different repository", reason)
+
     def test_linked_context_cannot_target_canonical_checkout(self):
         denial = self._check(self.linked, self.repo / "README.md")
         self.assertIsNotNone(denial)

--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -91,7 +91,9 @@ class CanonicalWritePolicyTests(unittest.TestCase):
     def test_linked_worktree_write_is_allowed(self):
         self.assertIsNone(self._check(self.linked, self.linked / "new-file.md"))
 
-    def test_canonical_context_can_target_its_linked_worktree(self):
+    def test_canonical_context_allows_structurally_safe_targets(self):
+        outside_target = self.root / "aidevops-issue-body.md"
+        self.assertIsNone(self._check(self.repo, outside_target))
         self.assertIsNone(self._check(self.repo, self.linked / "new-file.md"))
 
     def test_linked_context_cannot_target_canonical_checkout(self):
@@ -105,8 +107,22 @@ class CanonicalWritePolicyTests(unittest.TestCase):
         self.assertEqual(decision["decision"], "allow")
         self.assertEqual(
             decision["reason"],
-            "write target and process context are outside canonical worktrees",
+            "write target is outside canonical worktrees",
         )
+
+    def test_empty_target_fails_closed(self):
+        denial = self._check(self.repo)
+        self.assertIsNotNone(denial)
+        reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("write target is empty", reason)
+
+    def test_outside_symlink_into_canonical_checkout_is_denied(self):
+        alias = self.root / "canonical-alias"
+        alias.symlink_to(self.repo, target_is_directory=True)
+        denial = self._check(self.repo, alias / "README.md")
+        self.assertIsNotNone(denial)
+        reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("read-only session mirrors", reason)
 
     def test_missing_policy_helper_fails_closed(self):
         with mock.patch.object(
@@ -207,6 +223,29 @@ class CanonicalWritePolicyTests(unittest.TestCase):
 *** End Patch
 """
         denial = self._check(self.linked, patch_text=canonical_patch)
+        self.assertIsNotNone(denial)
+        self.assertIn(
+            "read-only session mirrors",
+            denial["hookSpecificOutput"]["permissionDecisionReason"],
+        )
+
+        outside_patch = f"""*** Begin Patch
+*** Add File: {self.root / 'aidevops-issue-body.md'}
++safe
+*** End Patch
+"""
+        self.assertIsNone(self._check(self.repo, patch_text=outside_patch))
+
+        mixed_patch = f"""*** Begin Patch
+*** Add File: {self.root / 'aidevops-issue-body.md'}
++safe
+*** Update File: {self.repo / 'README.md'}
+@@
+-seed
++unsafe
+*** End Patch
+"""
+        denial = self._check(self.repo, patch_text=mixed_patch)
         self.assertIsNotNone(denial)
         self.assertIn(
             "read-only session mirrors",


### PR DESCRIPTION
## Summary

Report deterministic wrapper activity and authorize writes from canonical runtime contexts solely by structurally classified targets. Resolves #28284.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs, .agents/scripts/canonical-write-policy-helper.py, .agents/scripts/pulse-session-helper.sh, .agents/scripts/tests/test-git-safety-guard.sh, .agents/scripts/tests/test-pulse-session-last-run.sh, .agents/workflows/log-issue-aidevops.md, tests/test-git-safety-guard.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Committed-source Python, Node, and shell safety suites pass; deterministic Pulse timestamp suite passes on BSD-date fallback; ShellCheck, bash -n, Biome, markdownlint, secret scan, portability, complexity, and full local changed-file gates pass; setup runtime smoke confirms linked target allow and canonical target deny.

Resolves #28264


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.157 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 11h 11m and 818,007 tokens on this with the user in an interactive session.