### PR TITLE
GH#28329: make canonical recovery guidance runnable

### DIFF
--- a/.agents/scripts/canonical-git-command-guard.py
+++ b/.agents/scripts/canonical-git-command-guard.py
@@ -7,11 +7,21 @@ import argparse
 import json
 import os
 import re
+import shlex
 import sys
+from pathlib import Path
 from typing import Optional
 
 from canonical_git_policy import BLOCK_EXIT, classify_git_argv, real_git
 from canonical_shell_parser import git_invocations
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _recovery_helper_command() -> str:
+    helper = SCRIPT_DIR / "canonical-recovery-helper.sh"
+    return shlex.quote(str(helper))
 
 
 def _parse_invocations(
@@ -84,10 +94,11 @@ def main() -> int:
         allowed, reason = classify_command(args.command, args.cwd, real_git_path)
     if allowed:
         return 0
+    recovery_helper = _recovery_helper_command()
     print(
         f"BLOCKED by canonical Git guard: {reason}. Use a linked worktree for edits. "
         "For an explicitly authorized clean canonical fast-forward, use "
-        "canonical-recovery-helper.sh fast-forward-current; use sync-mirror when "
+        f"{recovery_helper} fast-forward-current; use sync-mirror when "
         "verified preservation is required. Direct canonical Git mutation remains prohibited.",
         file=sys.stderr,
     )

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -71,10 +71,11 @@ assert_allowed() {
 
 assert_blocked "blocks canonical detached switch" "git switch --detach main"
 GUIDANCE_OUTPUT=$(python3 "$GUARD" --cwd "$REPO" --command "git pull --ff-only origin main" 2>&1)
-if [[ "$GUIDANCE_OUTPUT" == *"canonical-recovery-helper.sh fast-forward-current"* ]]; then
-	pass "blocked canonical pull points to the audited fast-forward workflow"
+RECOVERY_HELPER="${SCRIPT_DIR}/canonical-recovery-helper.sh"
+if [[ "$GUIDANCE_OUTPUT" == *"${RECOVERY_HELPER} fast-forward-current"* && -x "$RECOVERY_HELPER" ]]; then
+	pass "blocked canonical pull points to an executable audited fast-forward workflow"
 else
-	fail "blocked canonical pull omits audited fast-forward guidance"
+	fail "blocked canonical pull omits executable audited fast-forward guidance"
 fi
 assert_blocked "blocks canonical branch rename" "git branch -m main safety/example"
 assert_blocked "blocks canonical branch creation with reflog flag" "git branch -l feature/new"

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -72,7 +72,8 @@ assert_allowed() {
 assert_blocked "blocks canonical detached switch" "git switch --detach main"
 GUIDANCE_OUTPUT=$(python3 "$GUARD" --cwd "$REPO" --command "git pull --ff-only origin main" 2>&1)
 RECOVERY_HELPER="${SCRIPT_DIR}/canonical-recovery-helper.sh"
-if [[ "$GUIDANCE_OUTPUT" == *"${RECOVERY_HELPER} fast-forward-current"* && -x "$RECOVERY_HELPER" ]]; then
+QUOTED_RECOVERY_HELPER=$(python3 -c 'import shlex, sys; print(shlex.quote(sys.argv[1]))' "$RECOVERY_HELPER")
+if [[ "$GUIDANCE_OUTPUT" == *"${QUOTED_RECOVERY_HELPER} fast-forward-current"* && -x "$RECOVERY_HELPER" ]]; then
 	pass "blocked canonical pull points to an executable audited fast-forward workflow"
 else
 	fail "blocked canonical pull omits executable audited fast-forward guidance"


### PR DESCRIPTION
## Summary

Render the canonical recovery helper's resolved executable path in Git guard remediation and verify that path in the guard smoke test

## Files Changed

.agents/scripts/canonical-git-command-guard.py, .agents/scripts/tests/test-canonical-git-command-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** canonical Git command guard test: 55 passed; ShellCheck and Python compile passed; changed-file local linters passed

Resolves #28329


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.157 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 7m and 92,073 tokens on this as a headless worker.