### PR TITLE
GH#28283: fix: archive OpenCode 1.18.3 session graph

### DIFF
--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -50,6 +50,9 @@ readonly DEFAULT_RETENTION_DAYS=30
 readonly DEFAULT_BATCH_SIZE=500
 readonly DEFAULT_MAX_DURATION=60
 readonly EVENT_TABLE_NAME="event"
+readonly SESSION_TABLE_NAME="session"
+readonly ARCHIVE_TEXT_COLUMN_DEFINITION="text"
+readonly ARCHIVE_INTEGER_COLUMN_DEFINITION="integer DEFAULT 0 NOT NULL"
 
 ARCHIVE_BATCH_SIZE="${OPENCODE_DB_ARCHIVE_BATCH_SIZE:-$DEFAULT_BATCH_SIZE}"
 ARCHIVE_BATCH_DELAY_SECONDS="${OPENCODE_DB_ARCHIVE_BATCH_DELAY_SECONDS:-0}"
@@ -196,8 +199,11 @@ _db_holder_count() {
 }
 
 _archive_validate_active_schema() {
+	local diagnostic=""
+
 	if ! opencode_archive_schema_supported "$ACTIVE_DB" optional; then
-		print_error "Unsupported or unavailable OpenCode session schema; active data was left untouched."
+		diagnostic=$(opencode_archive_schema_diagnostic)
+		print_error "Unsupported or unavailable OpenCode session schema: ${diagnostic}; active data was left untouched."
 		return 1
 	fi
 	return 0
@@ -253,10 +259,30 @@ _archive_interrupt() {
 
 # --- Schema creation in archive DB -------------------------------------------
 
+_archive_add_column_if_missing() {
+	local archive_db="$1"
+	local table_name="$2"
+	local column_name="$3"
+	local column_definition="$4"
+	local column_count=""
+
+	column_count=$(sqlite3 "$archive_db" \
+		"SELECT COUNT(*) FROM pragma_table_info('${table_name}') WHERE name='${column_name}';") || return 1
+	if [[ "$column_count" -eq 0 ]]; then
+		sqlite3 "$archive_db" "ALTER TABLE \`${table_name}\` ADD COLUMN \`${column_name}\` ${column_definition};" || return 1
+		print_info "Migrated archive.${table_name} schema: added ${column_name} column"
+	fi
+	return 0
+}
+
 create_archive_schema() {
 	local archive_db="$1"
 
 	sqlite3 "$archive_db" <<'SCHEMA_SQL'
+.bail on
+PRAGMA journal_mode=WAL;
+BEGIN IMMEDIATE;
+
 -- Mirror the active DB schema for archived data
 CREATE TABLE IF NOT EXISTS `project` (
 	`id` text PRIMARY KEY,
@@ -294,6 +320,15 @@ CREATE TABLE IF NOT EXISTS `session` (
 	`time_archived` integer,
 	`workspace_id` text,
 	`path` text,
+	`agent` text,
+	`model` text,
+	`cost` real DEFAULT 0 NOT NULL,
+	`tokens_input` integer DEFAULT 0 NOT NULL,
+	`tokens_output` integer DEFAULT 0 NOT NULL,
+	`tokens_reasoning` integer DEFAULT 0 NOT NULL,
+	`tokens_cache_read` integer DEFAULT 0 NOT NULL,
+	`tokens_cache_write` integer DEFAULT 0 NOT NULL,
+	`metadata` text,
 	CONSTRAINT `fk_session_project_id_project_id_fk` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS `session_project_idx` ON `session` (`project_id`);
@@ -345,6 +380,49 @@ CREATE TABLE IF NOT EXISTS `session_share` (
 	CONSTRAINT `fk_session_share_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS `session_message` (
+	`id` text PRIMARY KEY,
+	`session_id` text NOT NULL,
+	`type` text NOT NULL,
+	`time_created` integer NOT NULL,
+	`time_updated` integer NOT NULL,
+	`data` text NOT NULL,
+	`seq` integer NOT NULL,
+	CONSTRAINT `fk_session_message_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS `session_message_session_seq_idx` ON `session_message` (`session_id`,`seq`);
+CREATE INDEX IF NOT EXISTS `session_message_session_time_created_id_idx` ON `session_message` (`session_id`,`time_created`,`id`);
+CREATE INDEX IF NOT EXISTS `session_message_session_type_seq_idx` ON `session_message` (`session_id`,`type`,`seq`);
+CREATE INDEX IF NOT EXISTS `session_message_time_created_idx` ON `session_message` (`time_created`);
+
+CREATE TABLE IF NOT EXISTS `session_input` (
+	`id` text PRIMARY KEY,
+	`session_id` text NOT NULL,
+	`prompt` text NOT NULL,
+	`delivery` text NOT NULL,
+	`admitted_seq` integer NOT NULL,
+	`promoted_seq` integer,
+	`time_created` integer NOT NULL,
+	CONSTRAINT `fk_session_input_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS `session_input_session_admitted_seq_idx` ON `session_input` (`session_id`,`admitted_seq`);
+CREATE INDEX IF NOT EXISTS `session_input_session_pending_delivery_seq_idx` ON `session_input` (`session_id`,`promoted_seq`,`delivery`,`admitted_seq`);
+CREATE UNIQUE INDEX IF NOT EXISTS `session_input_session_promoted_seq_idx` ON `session_input` (`session_id`,`promoted_seq`);
+
+CREATE TABLE IF NOT EXISTS `session_context_epoch` (
+	`session_id` text PRIMARY KEY,
+	`baseline` text NOT NULL,
+	`snapshot` text NOT NULL,
+	`baseline_seq` integer NOT NULL,
+	CONSTRAINT `fk_session_context_epoch_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS `event_sequence` (
+	`aggregate_id` text PRIMARY KEY,
+	`seq` integer NOT NULL,
+	`owner_id` text
+);
+
 CREATE TABLE IF NOT EXISTS `event` (
 	`id` text PRIMARY KEY,
 	`aggregate_id` text NOT NULL,
@@ -355,31 +433,23 @@ CREATE TABLE IF NOT EXISTS `event` (
 CREATE UNIQUE INDEX IF NOT EXISTS `event_aggregate_seq_idx` ON `event` (`aggregate_id`,`seq`);
 CREATE INDEX IF NOT EXISTS `event_aggregate_type_seq_idx` ON `event` (`aggregate_id`,`type`,`seq`);
 
--- WAL mode for the archive too (better read concurrency)
-PRAGMA journal_mode=WAL;
+COMMIT;
 SCHEMA_SQL
 
-	# Migrate existing archive DBs that predate the icon_url_override column.
-	# CREATE TABLE IF NOT EXISTS won't update an already-existing table, so we
-	# use ALTER TABLE ADD COLUMN guarded by a column-existence check.
-	local has_icon_url_override
-	has_icon_url_override=$(sqlite3 "$archive_db" \
-		"SELECT COUNT(*) FROM pragma_table_info('project') WHERE name='icon_url_override';")
-	if [[ "$has_icon_url_override" -eq 0 ]]; then
-		sqlite3 "$archive_db" "ALTER TABLE project ADD COLUMN icon_url_override text;"
-		print_info "Migrated archive.project schema: added icon_url_override column"
-	fi
-
-	# Migrate existing archive DBs that predate OpenCode's session.path column.
-	# Without this, INSERT ... SELECT across active/archive schemas fails with:
-	# "table archive.session has 19 columns but 20 values were supplied".
-	local has_session_path
-	has_session_path=$(sqlite3 "$archive_db" \
-		"SELECT COUNT(*) FROM pragma_table_info('session') WHERE name='path';")
-	if [[ "$has_session_path" -eq 0 ]]; then
-		sqlite3 "$archive_db" "ALTER TABLE session ADD COLUMN path text;"
-		print_info "Migrated archive.session schema: added path column"
-	fi
+	# CREATE TABLE IF NOT EXISTS does not evolve persisted archives. Add columns
+	# in canonical order so legacy archives converge on the OpenCode 1.18.3
+	# contract without rebuilding or discarding archived rows.
+	_archive_add_column_if_missing "$archive_db" project icon_url_override "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" path "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" agent "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" model "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" cost "real DEFAULT 0 NOT NULL" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_input "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_output "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_reasoning "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_cache_read "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_cache_write "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
+	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" metadata "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
 
 	return 0
 }
@@ -460,18 +530,65 @@ _archive_project_select_columns() {
 }
 
 _archive_session_insert_columns() {
-	printf '%s\n' "id, project_id, parent_id, slug, directory, title, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_created, time_updated, time_compacting, time_archived, workspace_id, path"
+	printf '%s\n' "id, project_id, parent_id, slug, directory, title, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_created, time_updated, time_compacting, time_archived, workspace_id, path, agent, model, cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write, metadata"
 	return 0
 }
 
 _archive_session_select_columns() {
 	local base_columns="id, project_id, parent_id, slug, directory, title, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_created, time_updated, time_compacting, time_archived, workspace_id"
+	local select_columns="$base_columns"
 
-	if _sqlite_has_column "$ACTIVE_DB" "session" "path"; then
-		printf '%s\n' "${base_columns}, path"
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "path"; then
+		select_columns="${select_columns}, path"
 	else
-		printf '%s\n' "${base_columns}, NULL AS path"
+		select_columns="${select_columns}, NULL AS path"
 	fi
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "agent"; then
+		select_columns="${select_columns}, agent"
+	else
+		select_columns="${select_columns}, NULL AS agent"
+	fi
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "model"; then
+		select_columns="${select_columns}, model"
+	else
+		select_columns="${select_columns}, NULL AS model"
+	fi
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "cost"; then
+		select_columns="${select_columns}, cost"
+	else
+		select_columns="${select_columns}, 0 AS cost"
+	fi
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_input"; then
+		select_columns="${select_columns}, tokens_input"
+	else
+		select_columns="${select_columns}, 0 AS tokens_input"
+	fi
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_output"; then
+		select_columns="${select_columns}, tokens_output"
+	else
+		select_columns="${select_columns}, 0 AS tokens_output"
+	fi
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_reasoning"; then
+		select_columns="${select_columns}, tokens_reasoning"
+	else
+		select_columns="${select_columns}, 0 AS tokens_reasoning"
+	fi
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_cache_read"; then
+		select_columns="${select_columns}, tokens_cache_read"
+	else
+		select_columns="${select_columns}, 0 AS tokens_cache_read"
+	fi
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_cache_write"; then
+		select_columns="${select_columns}, tokens_cache_write"
+	else
+		select_columns="${select_columns}, 0 AS tokens_cache_write"
+	fi
+	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "metadata"; then
+		select_columns="${select_columns}, metadata"
+	else
+		select_columns="${select_columns}, NULL AS metadata"
+	fi
+	printf '%s\n' "$select_columns"
 	return 0
 }
 
@@ -750,18 +867,47 @@ cmd_archive() {
 	fi
 
 	print_info "Found $total_eligible sessions eligible for archiving"
+	local has_session_message_table=0
+	local has_session_input_table=0
+	local has_session_context_epoch_table=0
+	local has_event_sequence_table=0
+	local has_event_table=0
+	if _sqlite_has_table "$ACTIVE_DB" session_message; then
+		has_session_message_table=1
+	fi
+	if _sqlite_has_table "$ACTIVE_DB" session_input; then
+		has_session_input_table=1
+	fi
+	if _sqlite_has_table "$ACTIVE_DB" session_context_epoch; then
+		has_session_context_epoch_table=1
+	fi
+	if _sqlite_has_table "$ACTIVE_DB" event_sequence; then
+		has_event_sequence_table=1
+	fi
+	if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
+		has_event_table=1
+	fi
 
 	if ((dry_run)); then
 		# Show what would be archived
 		local msg_count part_count todo_count share_count event_count event_bytes
-		local has_event_table=0
-		if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
-			has_event_table=1
-		fi
+		local session_message_count=0 session_input_count=0 context_epoch_count=0 event_sequence_count=0
 		msg_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM message WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 		part_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM part WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 		todo_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM todo WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 		share_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session_share WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
+		if ((has_session_message_table)); then
+			session_message_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session_message WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
+		fi
+		if ((has_session_input_table)); then
+			session_input_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session_input WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
+		fi
+		if ((has_session_context_epoch_table)); then
+			context_epoch_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session_context_epoch WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
+		fi
+		if ((has_event_sequence_table)); then
+			event_sequence_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM event_sequence WHERE aggregate_id IN (SELECT id FROM session WHERE $candidate_filter);")
+		fi
 		event_count=$(sqlite3 "$ACTIVE_DB" "$(_archive_event_count_sql "$candidate_filter" "$has_event_table")")
 		event_bytes=$(sqlite3 "$ACTIVE_DB" "$(_archive_event_bytes_sql "$candidate_filter" "$has_event_table")")
 
@@ -772,6 +918,10 @@ cmd_archive() {
 		echo "  Parts:          $part_count"
 		echo "  Todos:          $todo_count"
 		echo "  Session shares: $share_count"
+		echo "  Session msgs:   $session_message_count"
+		echo "  Session inputs: $session_input_count"
+		echo "  Context epochs: $context_epoch_count"
+		echo "  Event sequences: $event_sequence_count"
 		echo "  Events:         $event_count ($(format_bytes "$event_bytes"))"
 		echo ""
 		print_info "Run without --dry-run to proceed."
@@ -781,20 +931,18 @@ cmd_archive() {
 	# Create archive DB and schema
 	create_archive_schema "$ARCHIVE_DB"
 	if ! opencode_archive_schema_supported "$ARCHIVE_DB" required; then
-		print_error "Archive schema is unavailable or unsupported; active data was left untouched."
+		local archive_schema_diagnostic=""
+		archive_schema_diagnostic=$(opencode_archive_schema_diagnostic)
+		print_error "Archive schema is unavailable or unsupported: ${archive_schema_diagnostic}; active data was left untouched."
 		return 3
 	fi
 
 	local project_insert_columns project_select_columns
 	local session_insert_columns session_select_columns
-	local has_event_table=0
 	project_insert_columns=$(_archive_project_insert_columns)
 	project_select_columns=$(_archive_project_select_columns)
 	session_insert_columns=$(_archive_session_insert_columns)
 	session_select_columns=$(_archive_session_select_columns)
-	if _sqlite_has_table "$ACTIVE_DB" "$EVENT_TABLE_NAME"; then
-		has_event_table=1
-	fi
 
 	local size_before
 	size_before=$(file_size_bytes "$ACTIVE_DB")
@@ -848,7 +996,27 @@ cmd_archive() {
 		local in_clause=""
 		in_clause=$(printf '%s\n' "$session_ids" | sed "s/.*/'&'/" | tr '\n' ',' | sed 's/,$//')
 
+		local session_message_copy_sql="" session_message_delete_sql=""
+		local session_input_copy_sql="" session_input_delete_sql=""
+		local context_epoch_copy_sql="" context_epoch_delete_sql=""
+		local event_sequence_copy_sql="" event_sequence_delete_sql=""
 		local event_copy_sql="" event_delete_sql=""
+		if ((has_session_message_table)); then
+			session_message_copy_sql="INSERT OR IGNORE INTO archive.session_message SELECT * FROM session_message WHERE session_id IN ($in_clause);"
+			session_message_delete_sql="DELETE FROM session_message WHERE session_id IN ($in_clause);"
+		fi
+		if ((has_session_input_table)); then
+			session_input_copy_sql="INSERT OR IGNORE INTO archive.session_input SELECT * FROM session_input WHERE session_id IN ($in_clause);"
+			session_input_delete_sql="DELETE FROM session_input WHERE session_id IN ($in_clause);"
+		fi
+		if ((has_session_context_epoch_table)); then
+			context_epoch_copy_sql="INSERT OR IGNORE INTO archive.session_context_epoch SELECT * FROM session_context_epoch WHERE session_id IN ($in_clause);"
+			context_epoch_delete_sql="DELETE FROM session_context_epoch WHERE session_id IN ($in_clause);"
+		fi
+		if ((has_event_sequence_table)); then
+			event_sequence_copy_sql="INSERT OR IGNORE INTO archive.event_sequence SELECT * FROM event_sequence WHERE aggregate_id IN ($in_clause);"
+			event_sequence_delete_sql="DELETE FROM event_sequence WHERE aggregate_id IN ($in_clause);"
+		fi
 		if ((has_event_table)); then
 			event_copy_sql="INSERT OR IGNORE INTO archive.event SELECT * FROM event WHERE aggregate_id IN ($in_clause);"
 			event_delete_sql="DELETE FROM event WHERE aggregate_id IN ($in_clause);"
@@ -858,8 +1026,11 @@ cmd_archive() {
 		# ATTACH and DETACH are within the same sqlite3 invocation — the attachment
 		# is released automatically when the process exits. The trap above ensures
 		# the archive WAL is checkpointed on any exit path between batches.
-		# Note: FK enforcement is OFF in opencode.db, so we must delete child rows manually.
+		# Foreign-key mode is connection-local. Enable it explicitly and still use
+		# dependency-safe manual deletes so behavior never depends on OpenCode's
+		# separate connection configuration.
 		sqlite3 "$ACTIVE_DB" <<BATCH_SQL
+PRAGMA foreign_keys = ON;
 ATTACH DATABASE '$ARCHIVE_DB' AS archive;
 
 BEGIN IMMEDIATE;
@@ -889,6 +1060,14 @@ SELECT * FROM todo WHERE session_id IN ($in_clause);
 INSERT OR IGNORE INTO archive.session_share
 SELECT * FROM session_share WHERE session_id IN ($in_clause);
 
+-- Copy OpenCode 1.18.3 session-owned rows when present.
+${session_message_copy_sql}
+${session_input_copy_sql}
+${context_epoch_copy_sql}
+
+-- Copy event sequence parents before their event rows.
+${event_sequence_copy_sql}
+
 -- Copy event stream rows when the active DB has OpenCode's event table.
 -- OpenCode stores session-scoped event history with aggregate_id=session.id.
 -- This table is often the largest object in opencode.db, so leaving it behind
@@ -899,8 +1078,12 @@ ${event_copy_sql}
 DELETE FROM part WHERE session_id IN ($in_clause);
 DELETE FROM todo WHERE session_id IN ($in_clause);
 DELETE FROM session_share WHERE session_id IN ($in_clause);
+${session_message_delete_sql}
+${session_input_delete_sql}
+${context_epoch_delete_sql}
 DELETE FROM message WHERE session_id IN ($in_clause);
 ${event_delete_sql}
+${event_sequence_delete_sql}
 DELETE FROM session WHERE id IN ($in_clause);
 
 COMMIT;

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -259,19 +259,60 @@ _archive_interrupt() {
 
 # --- Schema creation in archive DB -------------------------------------------
 
-_archive_add_column_if_missing() {
-	local archive_db="$1"
-	local table_name="$2"
-	local column_name="$3"
-	local column_definition="$4"
-	local column_count=""
+_archive_column_list_has() {
+	local column_list="$1"
+	local column_name="$2"
 
-	column_count=$(sqlite3 "$archive_db" \
-		"SELECT COUNT(*) FROM pragma_table_info('${table_name}') WHERE name='${column_name}';") || return 1
-	if [[ "$column_count" -eq 0 ]]; then
-		sqlite3 "$archive_db" "ALTER TABLE \`${table_name}\` ADD COLUMN \`${column_name}\` ${column_definition};" || return 1
-		print_info "Migrated archive.${table_name} schema: added ${column_name} column"
-	fi
+	[[ ",${column_list}," == *",${column_name},"* ]]
+	return $?
+}
+
+_archive_migrate_schema_columns() {
+	local archive_db="$1"
+	local project_columns=""
+	local session_columns=""
+	local table_name=""
+	local column_name=""
+	local column_definition=""
+	local table_columns=""
+	local migration_sql=""
+	local migrated_columns=""
+
+	project_columns=$(opencode_db_table_columns "$archive_db" project) || return 1
+	session_columns=$(opencode_db_table_columns "$archive_db" "$SESSION_TABLE_NAME") || return 1
+	while IFS='|' read -r table_name column_name column_definition; do
+		[[ -n "$table_name" && -n "$column_name" && -n "$column_definition" ]] || continue
+		case "$table_name" in
+		project) table_columns="$project_columns" ;;
+		"$SESSION_TABLE_NAME") table_columns="$session_columns" ;;
+		*) return 1 ;;
+		esac
+		if ! _archive_column_list_has "$table_columns" "$column_name"; then
+			migration_sql="${migration_sql}ALTER TABLE ${table_name} ADD COLUMN ${column_name} ${column_definition};"
+			migrated_columns="${migrated_columns}${migrated_columns:+,}${table_name}.${column_name}"
+		fi
+	done <<MIGRATION_COLUMNS
+project|icon_url_override|${ARCHIVE_TEXT_COLUMN_DEFINITION}
+${SESSION_TABLE_NAME}|path|${ARCHIVE_TEXT_COLUMN_DEFINITION}
+${SESSION_TABLE_NAME}|agent|${ARCHIVE_TEXT_COLUMN_DEFINITION}
+${SESSION_TABLE_NAME}|model|${ARCHIVE_TEXT_COLUMN_DEFINITION}
+${SESSION_TABLE_NAME}|cost|real DEFAULT 0 NOT NULL
+${SESSION_TABLE_NAME}|tokens_input|${ARCHIVE_INTEGER_COLUMN_DEFINITION}
+${SESSION_TABLE_NAME}|tokens_output|${ARCHIVE_INTEGER_COLUMN_DEFINITION}
+${SESSION_TABLE_NAME}|tokens_reasoning|${ARCHIVE_INTEGER_COLUMN_DEFINITION}
+${SESSION_TABLE_NAME}|tokens_cache_read|${ARCHIVE_INTEGER_COLUMN_DEFINITION}
+${SESSION_TABLE_NAME}|tokens_cache_write|${ARCHIVE_INTEGER_COLUMN_DEFINITION}
+${SESSION_TABLE_NAME}|metadata|${ARCHIVE_TEXT_COLUMN_DEFINITION}
+MIGRATION_COLUMNS
+
+	[[ -n "$migration_sql" ]] || return 0
+	sqlite3 "$archive_db" <<MIGRATION_SQL
+.bail on
+BEGIN IMMEDIATE;
+${migration_sql}
+COMMIT;
+MIGRATION_SQL
+	print_info "Migrated archive schema columns: ${migrated_columns}"
 	return 0
 }
 
@@ -439,17 +480,7 @@ SCHEMA_SQL
 	# CREATE TABLE IF NOT EXISTS does not evolve persisted archives. Add columns
 	# in canonical order so legacy archives converge on the OpenCode 1.18.3
 	# contract without rebuilding or discarding archived rows.
-	_archive_add_column_if_missing "$archive_db" project icon_url_override "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" path "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" agent "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" model "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" cost "real DEFAULT 0 NOT NULL" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_input "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_output "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_reasoning "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_cache_read "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" tokens_cache_write "$ARCHIVE_INTEGER_COLUMN_DEFINITION" || return 1
-	_archive_add_column_if_missing "$archive_db" "$SESSION_TABLE_NAME" metadata "$ARCHIVE_TEXT_COLUMN_DEFINITION" || return 1
+	_archive_migrate_schema_columns "$archive_db" || return 1
 
 	return 0
 }
@@ -537,53 +568,55 @@ _archive_session_insert_columns() {
 _archive_session_select_columns() {
 	local base_columns="id, project_id, parent_id, slug, directory, title, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_created, time_updated, time_compacting, time_archived, workspace_id"
 	local select_columns="$base_columns"
+	local session_columns=""
 
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "path"; then
+	session_columns=$(opencode_db_table_columns "$ACTIVE_DB" "$SESSION_TABLE_NAME") || return 1
+	if _archive_column_list_has "$session_columns" path; then
 		select_columns="${select_columns}, path"
 	else
 		select_columns="${select_columns}, NULL AS path"
 	fi
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "agent"; then
+	if _archive_column_list_has "$session_columns" agent; then
 		select_columns="${select_columns}, agent"
 	else
 		select_columns="${select_columns}, NULL AS agent"
 	fi
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "model"; then
+	if _archive_column_list_has "$session_columns" model; then
 		select_columns="${select_columns}, model"
 	else
 		select_columns="${select_columns}, NULL AS model"
 	fi
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "cost"; then
+	if _archive_column_list_has "$session_columns" cost; then
 		select_columns="${select_columns}, cost"
 	else
 		select_columns="${select_columns}, 0 AS cost"
 	fi
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_input"; then
+	if _archive_column_list_has "$session_columns" tokens_input; then
 		select_columns="${select_columns}, tokens_input"
 	else
 		select_columns="${select_columns}, 0 AS tokens_input"
 	fi
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_output"; then
+	if _archive_column_list_has "$session_columns" tokens_output; then
 		select_columns="${select_columns}, tokens_output"
 	else
 		select_columns="${select_columns}, 0 AS tokens_output"
 	fi
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_reasoning"; then
+	if _archive_column_list_has "$session_columns" tokens_reasoning; then
 		select_columns="${select_columns}, tokens_reasoning"
 	else
 		select_columns="${select_columns}, 0 AS tokens_reasoning"
 	fi
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_cache_read"; then
+	if _archive_column_list_has "$session_columns" tokens_cache_read; then
 		select_columns="${select_columns}, tokens_cache_read"
 	else
 		select_columns="${select_columns}, 0 AS tokens_cache_read"
 	fi
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "tokens_cache_write"; then
+	if _archive_column_list_has "$session_columns" tokens_cache_write; then
 		select_columns="${select_columns}, tokens_cache_write"
 	else
 		select_columns="${select_columns}, 0 AS tokens_cache_write"
 	fi
-	if _sqlite_has_column "$ACTIVE_DB" "$SESSION_TABLE_NAME" "metadata"; then
+	if _archive_column_list_has "$session_columns" metadata; then
 		select_columns="${select_columns}, metadata"
 	else
 		select_columns="${select_columns}, NULL AS metadata"

--- a/.agents/scripts/opencode-db-safety-lib.sh
+++ b/.agents/scripts/opencode-db-safety-lib.sh
@@ -6,6 +6,9 @@
 # reporting. Callers own policy decisions; this library never mutates a DB.
 
 OPENCODE_DB_STATE_UNKNOWN="${OPENCODE_DB_STATE_UNKNOWN:-unknown}"
+OPENCODE_DB_STATE_MISSING="${OPENCODE_DB_STATE_MISSING:-missing}"
+OPENCODE_ARCHIVE_SCHEMA_MODE_OPTIONAL="optional"
+OPENCODE_ARCHIVE_SCHEMA_MODE_REQUIRED="required"
 
 opencode_db_file_signature() {
 	local file_path="$1"
@@ -13,7 +16,7 @@ opencode_db_file_signature() {
 	local file_mtime=""
 
 	if [[ ! -e "$file_path" && ! -L "$file_path" ]]; then
-		printf '%s' "missing"
+		printf '%s' "$OPENCODE_DB_STATE_MISSING"
 		return 0
 	fi
 	if [[ ! -f "$file_path" ]] || ! declare -F _file_size_bytes >/dev/null 2>&1 || ! declare -F _file_mtime_epoch >/dev/null 2>&1; then
@@ -86,7 +89,7 @@ opencode_db_schema_state() {
 	local table_count=""
 
 	if [[ ! -e "$db_path" && ! -L "$db_path" ]]; then
-		printf '%s' "missing"
+		printf '%s' "$OPENCODE_DB_STATE_MISSING"
 		return 0
 	fi
 	if [[ ! -f "$db_path" || ! -r "$db_path" ]] || ! command -v sqlite3 >/dev/null 2>&1; then
@@ -110,60 +113,162 @@ opencode_db_table_columns() {
 	return $?
 }
 
+opencode_db_table_exists() {
+	local db_path="$1"
+	local table_name="$2"
+	local table_count=""
+
+	table_count=$(sqlite3 "$db_path" \
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='${table_name}';" 2>/dev/null) || return 1
+	[[ "$table_count" == "1" ]]
+	return $?
+}
+
+OPENCODE_ARCHIVE_SCHEMA_ERROR_TABLE=""
+OPENCODE_ARCHIVE_SCHEMA_ERROR_ACTUAL=""
+OPENCODE_ARCHIVE_SCHEMA_ERROR_SUPPORTED=""
+OPENCODE_ARCHIVE_SCHEMA_ERROR_REASON=""
+
+_opencode_archive_schema_set_error() {
+	local table_name="$1"
+	local actual_columns="$2"
+	local supported_columns="$3"
+	local reason="$4"
+
+	OPENCODE_ARCHIVE_SCHEMA_ERROR_TABLE="$table_name"
+	OPENCODE_ARCHIVE_SCHEMA_ERROR_ACTUAL="$actual_columns"
+	OPENCODE_ARCHIVE_SCHEMA_ERROR_SUPPORTED="$supported_columns"
+	OPENCODE_ARCHIVE_SCHEMA_ERROR_REASON="$reason"
+	return 0
+}
+
+opencode_archive_schema_diagnostic() {
+	printf 'table=%s actual_columns=[%s] supported_columns=[%s] reason=%s' \
+		"${OPENCODE_ARCHIVE_SCHEMA_ERROR_TABLE:-unknown}" \
+		"${OPENCODE_ARCHIVE_SCHEMA_ERROR_ACTUAL:-unavailable}" \
+		"${OPENCODE_ARCHIVE_SCHEMA_ERROR_SUPPORTED:-unavailable}" \
+		"${OPENCODE_ARCHIVE_SCHEMA_ERROR_REASON:-unavailable}"
+	return 0
+}
+
+_opencode_archive_columns_match() {
+	local actual_columns="$1"
+	local supported_columns="$2"
+
+	[[ -n "$actual_columns" && "|${supported_columns}|" == *"|${actual_columns}|"* ]]
+	return $?
+}
+
 opencode_archive_table_schema_supported() {
 	local db_path="$1"
 	local table_name="$2"
+	local schema_mode="${3:-$OPENCODE_ARCHIVE_SCHEMA_MODE_OPTIONAL}"
 	local actual=""
-	local expected=""
+	local supported=""
+	local legacy=""
 	local compatible=""
+	local current=""
 
-	actual=$(opencode_db_table_columns "$db_path" "$table_name") || return 1
 	case "$table_name" in
 	project)
-		expected="id,worktree,vcs,name,icon_url,icon_color,time_created,time_updated,time_initialized,sandboxes,commands"
-		compatible="${expected},icon_url_override"
+		legacy="id,worktree,vcs,name,icon_url,icon_color,time_created,time_updated,time_initialized,sandboxes,commands"
+		current="${legacy},icon_url_override"
+		if [[ "$schema_mode" == "$OPENCODE_ARCHIVE_SCHEMA_MODE_REQUIRED" ]]; then
+			supported="$current"
+		else
+			supported="${legacy}|${current}"
+		fi
 		;;
 	session)
-		expected="id,project_id,parent_id,slug,directory,title,version,share_url,summary_additions,summary_deletions,summary_files,summary_diffs,revert,permission,time_created,time_updated,time_compacting,time_archived,workspace_id"
-		compatible="${expected},path"
+		legacy="id,project_id,parent_id,slug,directory,title,version,share_url,summary_additions,summary_deletions,summary_files,summary_diffs,revert,permission,time_created,time_updated,time_compacting,time_archived,workspace_id"
+		compatible="${legacy},path"
+		current="${compatible},agent,model,cost,tokens_input,tokens_output,tokens_reasoning,tokens_cache_read,tokens_cache_write,metadata"
+		if [[ "$schema_mode" == "$OPENCODE_ARCHIVE_SCHEMA_MODE_REQUIRED" ]]; then
+			supported="$current"
+		else
+			supported="${legacy}|${compatible}|${current}"
+		fi
 		;;
-	message) expected="id,session_id,time_created,time_updated,data" ;;
-	part) expected="id,message_id,session_id,time_created,time_updated,data" ;;
-	todo) expected="session_id,content,status,priority,position,time_created,time_updated" ;;
-	session_share) expected="session_id,id,secret,url,time_created,time_updated" ;;
-	event) expected="id,aggregate_id,seq,type,data" ;;
-	*) return 1 ;;
+	message) supported="id,session_id,time_created,time_updated,data" ;;
+	part) supported="id,message_id,session_id,time_created,time_updated,data" ;;
+	todo) supported="session_id,content,status,priority,position,time_created,time_updated" ;;
+	session_share) supported="session_id,id,secret,url,time_created,time_updated" ;;
+	session_message) supported="id,session_id,type,time_created,time_updated,data,seq" ;;
+	session_input) supported="id,session_id,prompt,delivery,admitted_seq,promoted_seq,time_created" ;;
+	session_context_epoch) supported="session_id,baseline,snapshot,baseline_seq" ;;
+	event_sequence) supported="aggregate_id,seq,owner_id" ;;
+	event) supported="id,aggregate_id,seq,type,data" ;;
+	*)
+		_opencode_archive_schema_set_error "$table_name" "unavailable" "no-supported-schema" "unknown-table"
+		return 1
+		;;
 	esac
 
-	if [[ "$actual" == "$expected" || (-n "$compatible" && "$actual" == "$compatible") ]]; then
+	if ! actual=$(opencode_db_table_columns "$db_path" "$table_name"); then
+		_opencode_archive_schema_set_error "$table_name" "unavailable" "$supported" "column-query-failed"
+		return 1
+	fi
+	if _opencode_archive_columns_match "$actual" "$supported"; then
 		return 0
 	fi
+	[[ -n "$actual" ]] || actual="$OPENCODE_DB_STATE_MISSING"
+	_opencode_archive_schema_set_error "$table_name" "$actual" "$supported" "column-mismatch"
 	return 1
 }
 
-# Validate only the complete logical-session schema supported by the existing
-# archive contract. event_mode is optional for active DBs and required for the
-# aidevops-owned archive schema.
+# Validate only complete logical-session schemas supported by the archive
+# contract. Optional mode accepts known active-DB generations; required mode
+# enforces the current aidevops-owned archive schema.
 opencode_archive_schema_supported() {
 	local db_path="$1"
-	local event_mode="${2:-optional}"
+	local schema_mode="${2:-$OPENCODE_ARCHIVE_SCHEMA_MODE_OPTIONAL}"
 	local table_name=""
-	local event_exists=""
+	local session_columns=""
+	local current_session_columns="id,project_id,parent_id,slug,directory,title,version,share_url,summary_additions,summary_deletions,summary_files,summary_diffs,revert,permission,time_created,time_updated,time_compacting,time_archived,workspace_id,path,agent,model,cost,tokens_input,tokens_output,tokens_reasoning,tokens_cache_read,tokens_cache_write,metadata"
 	local unknown_session_tables=""
+	local unknown_aggregate_tables=""
+	local unknown_columns=""
 
-	for table_name in project session message part todo session_share; do
-		opencode_archive_table_schema_supported "$db_path" "$table_name" || return 1
-	done
-	event_exists=$(sqlite3 "$db_path" \
-		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='event';" 2>/dev/null || true)
-	if [[ "$event_exists" == "1" ]]; then
-		opencode_archive_table_schema_supported "$db_path" event || return 1
-	elif [[ "$event_mode" == "required" ]]; then
+	OPENCODE_ARCHIVE_SCHEMA_ERROR_TABLE=""
+	OPENCODE_ARCHIVE_SCHEMA_ERROR_ACTUAL=""
+	OPENCODE_ARCHIVE_SCHEMA_ERROR_SUPPORTED=""
+	OPENCODE_ARCHIVE_SCHEMA_ERROR_REASON=""
+	if [[ "$schema_mode" != "$OPENCODE_ARCHIVE_SCHEMA_MODE_OPTIONAL" && "$schema_mode" != "$OPENCODE_ARCHIVE_SCHEMA_MODE_REQUIRED" ]]; then
+		_opencode_archive_schema_set_error "schema" "$schema_mode" "optional|required" "invalid-validation-mode"
 		return 1
 	fi
 
+	for table_name in project session message part todo session_share; do
+		opencode_archive_table_schema_supported "$db_path" "$table_name" "$schema_mode" || return 1
+	done
+
+	session_columns=$(opencode_db_table_columns "$db_path" session) || return 1
+	if [[ "$schema_mode" == "$OPENCODE_ARCHIVE_SCHEMA_MODE_REQUIRED" || "$session_columns" == "$current_session_columns" ]]; then
+		for table_name in session_message session_input session_context_epoch event_sequence event; do
+			opencode_archive_table_schema_supported "$db_path" "$table_name" "$OPENCODE_ARCHIVE_SCHEMA_MODE_REQUIRED" || return 1
+		done
+	else
+		for table_name in session_message session_input session_context_epoch event_sequence event; do
+			if opencode_db_table_exists "$db_path" "$table_name"; then
+				opencode_archive_table_schema_supported "$db_path" "$table_name" optional || return 1
+			fi
+		done
+	fi
+
 	unknown_session_tables=$(sqlite3 "$db_path" \
-		"SELECT DISTINCT m.name FROM sqlite_master m JOIN pragma_table_info(m.name) p WHERE m.type='table' AND p.name='session_id' AND m.name NOT IN ('message','part','todo','session_share') ORDER BY m.name;" 2>/dev/null) || return 1
-	[[ -z "$unknown_session_tables" ]] || return 1
+		"SELECT DISTINCT m.name FROM sqlite_master m JOIN pragma_table_info(m.name) p WHERE m.type='table' AND p.name='session_id' AND m.name NOT IN ('message','part','todo','session_share','session_message','session_input','session_context_epoch') ORDER BY m.name LIMIT 1;" 2>/dev/null) || return 1
+	if [[ -n "$unknown_session_tables" ]]; then
+		unknown_columns=$(opencode_db_table_columns "$db_path" "$unknown_session_tables" 2>/dev/null || printf 'unavailable')
+		_opencode_archive_schema_set_error "$unknown_session_tables" "$unknown_columns" "no-additional-session-id-table" "unknown-session-table"
+		return 1
+	fi
+
+	unknown_aggregate_tables=$(sqlite3 "$db_path" \
+		"SELECT DISTINCT m.name FROM sqlite_master m JOIN pragma_table_info(m.name) p WHERE m.type='table' AND p.name='aggregate_id' AND m.name NOT IN ('event','event_sequence') ORDER BY m.name LIMIT 1;" 2>/dev/null) || return 1
+	if [[ -n "$unknown_aggregate_tables" ]]; then
+		unknown_columns=$(opencode_db_table_columns "$db_path" "$unknown_aggregate_tables" 2>/dev/null || printf 'unavailable')
+		_opencode_archive_schema_set_error "$unknown_aggregate_tables" "$unknown_columns" "no-additional-aggregate-id-table" "unknown-aggregate-table"
+		return 1
+	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-opencode-db-archive.sh
+++ b/.agents/scripts/tests/test-opencode-db-archive.sh
@@ -146,6 +146,145 @@ SQL
 	return 0
 }
 
+_make_active_db_1_18_3() {
+	sqlite3 "$ACTIVE_DB" <<'SQL'
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+CREATE TABLE project (
+  id text PRIMARY KEY,
+  worktree text NOT NULL,
+  vcs text,
+  name text,
+  icon_url text,
+  icon_color text,
+  time_created integer NOT NULL,
+  time_updated integer NOT NULL,
+  time_initialized integer,
+  sandboxes text NOT NULL,
+  commands text,
+  icon_url_override text
+);
+CREATE TABLE session (
+  id text PRIMARY KEY,
+  project_id text NOT NULL,
+  parent_id text,
+  slug text NOT NULL,
+  directory text NOT NULL,
+  title text NOT NULL,
+  version text NOT NULL,
+  share_url text,
+  summary_additions integer,
+  summary_deletions integer,
+  summary_files integer,
+  summary_diffs text,
+  revert text,
+  permission text,
+  time_created integer NOT NULL,
+  time_updated integer NOT NULL,
+  time_compacting integer,
+  time_archived integer,
+  workspace_id text,
+  path text,
+  agent text,
+  model text,
+  cost real DEFAULT 0 NOT NULL,
+  tokens_input integer DEFAULT 0 NOT NULL,
+  tokens_output integer DEFAULT 0 NOT NULL,
+  tokens_reasoning integer DEFAULT 0 NOT NULL,
+  tokens_cache_read integer DEFAULT 0 NOT NULL,
+  tokens_cache_write integer DEFAULT 0 NOT NULL,
+  metadata text,
+  FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE
+);
+CREATE INDEX session_project_idx ON session (project_id);
+CREATE INDEX session_parent_idx ON session (parent_id);
+CREATE INDEX session_workspace_idx ON session (workspace_id);
+CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE);
+CREATE INDEX message_session_time_created_id_idx ON message (session_id, time_created, id);
+CREATE TABLE part (id text PRIMARY KEY, message_id text NOT NULL, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL, FOREIGN KEY (message_id) REFERENCES message(id) ON DELETE CASCADE);
+CREATE INDEX part_session_idx ON part (session_id);
+CREATE INDEX part_message_id_id_idx ON part (message_id, id);
+CREATE TABLE todo (session_id text NOT NULL, content text NOT NULL, status text NOT NULL, priority text NOT NULL, position integer NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, PRIMARY KEY(session_id, position), FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE);
+CREATE INDEX todo_session_idx ON todo (session_id);
+CREATE TABLE session_share (session_id text PRIMARY KEY, id text NOT NULL, secret text NOT NULL, url text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE);
+CREATE TABLE session_message (id text PRIMARY KEY, session_id text NOT NULL, type text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL, seq integer NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE);
+CREATE UNIQUE INDEX session_message_session_seq_idx ON session_message (session_id, seq);
+CREATE INDEX session_message_session_time_created_id_idx ON session_message (session_id, time_created, id);
+CREATE INDEX session_message_session_type_seq_idx ON session_message (session_id, type, seq);
+CREATE INDEX session_message_time_created_idx ON session_message (time_created);
+CREATE TABLE session_input (id text PRIMARY KEY, session_id text NOT NULL, prompt text NOT NULL, delivery text NOT NULL, admitted_seq integer NOT NULL, promoted_seq integer, time_created integer NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE);
+CREATE UNIQUE INDEX session_input_session_admitted_seq_idx ON session_input (session_id, admitted_seq);
+CREATE INDEX session_input_session_pending_delivery_seq_idx ON session_input (session_id, promoted_seq, delivery, admitted_seq);
+CREATE UNIQUE INDEX session_input_session_promoted_seq_idx ON session_input (session_id, promoted_seq);
+CREATE TABLE session_context_epoch (session_id text PRIMARY KEY, baseline text NOT NULL, snapshot text NOT NULL, baseline_seq integer NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE);
+CREATE TABLE event_sequence (aggregate_id text PRIMARY KEY, seq integer NOT NULL, owner_id text);
+CREATE TABLE event (id text PRIMARY KEY, aggregate_id text NOT NULL, seq integer NOT NULL, type text NOT NULL, data text NOT NULL, FOREIGN KEY (aggregate_id) REFERENCES event_sequence(aggregate_id) ON DELETE CASCADE);
+CREATE UNIQUE INDEX event_aggregate_seq_idx ON event (aggregate_id, seq);
+CREATE INDEX event_aggregate_type_seq_idx ON event (aggregate_id, type, seq);
+
+INSERT INTO project VALUES ('proj-1183', '/fixture/worktree', 'git', 'fixture', NULL, '#abcdef', 10, 20, 15, '{"sandboxes":[]}', '{"build":"run"}', 'fixture-icon');
+INSERT INTO session VALUES ('ses-1183', 'proj-1183', NULL, 'slug-1183', '/fixture/directory', 'Fixture title', '1.18.3', NULL, 3, 4, 5, '{"files":["a"]}', '{"snapshot":"r"}', '{"allow":"all"}', 100, 200, 150, NULL, 'workspace-1183', '/fixture/session', 'fixture-agent', 'fixture/model', 12.75, 101, 202, 303, 404, 505, '{"meta":"value"}');
+INSERT INTO message VALUES ('msg-1183', 'ses-1183', 101, 201, '{"role":"assistant"}');
+INSERT INTO part VALUES ('part-1183', 'msg-1183', 'ses-1183', 102, 202, '{"text":"payload"}');
+INSERT INTO todo VALUES ('ses-1183', 'archive fixture', 'pending', 'high', 0, 103, 203);
+INSERT INTO session_share VALUES ('ses-1183', 'share-1183', 'fixture-secret', 'fixture-url', 104, 204);
+INSERT INTO session_message VALUES ('session-msg-1183', 'ses-1183', 'assistant', 105, 205, '{"content":"session-message"}', 7);
+INSERT INTO session_input VALUES ('input-1183', 'ses-1183', 'fixture prompt', 'promoted', 8, 9, 106);
+INSERT INTO session_context_epoch VALUES ('ses-1183', '{"baseline":1}', '{"snapshot":2}', 6);
+INSERT INTO event_sequence VALUES ('ses-1183', 11, 'owner-1183');
+INSERT INTO event VALUES ('event-1183', 'ses-1183', 11, 'session.updated.1', '{"event":"value"}');
+SQL
+	return 0
+}
+
+_add_second_active_1_18_3_session() {
+	sqlite3 "$ACTIVE_DB" <<'SQL'
+PRAGMA foreign_keys = ON;
+INSERT INTO session VALUES ('ses-1183-b', 'proj-1183', NULL, 'slug-1183-b', '/fixture/directory-b', 'Fixture title B', '1.18.3', NULL, 13, 14, 15, '{"files":["b"]}', '{"snapshot":"s"}', '{"allow":"all"}', 110, 210, 160, NULL, 'workspace-1183-b', '/fixture/session-b', 'fixture-agent', 'fixture/model', 22.5, 111, 212, 313, 414, 515, '{"meta":"value-b"}');
+INSERT INTO message VALUES ('msg-1183-b', 'ses-1183-b', 111, 211, '{"role":"user"}');
+INSERT INTO part VALUES ('part-1183-b', 'msg-1183-b', 'ses-1183-b', 112, 212, '{"text":"payload-b"}');
+INSERT INTO todo VALUES ('ses-1183-b', 'archive fixture b', 'pending', 'medium', 0, 113, 213);
+INSERT INTO session_share VALUES ('ses-1183-b', 'share-1183-b', 'fixture-secret-b', 'fixture-url-b', 114, 214);
+INSERT INTO session_message VALUES ('session-msg-1183-b', 'ses-1183-b', 'user', 115, 215, '{"content":"session-message-b"}', 17);
+INSERT INTO session_input VALUES ('input-1183-b', 'ses-1183-b', 'fixture prompt b', 'pending', 18, NULL, 116);
+INSERT INTO session_context_epoch VALUES ('ses-1183-b', '{"baseline":11}', '{"snapshot":12}', 16);
+INSERT INTO event_sequence VALUES ('ses-1183-b', 21, 'owner-1183-b');
+INSERT INTO event VALUES ('event-1183-b', 'ses-1183-b', 21, 'session.updated.1', '{"event":"value-b"}');
+SQL
+	return 0
+}
+
+_fixture_graph_fingerprint() {
+	local db_path="$1"
+
+	sqlite3 "$db_path" <<'SQL'
+SELECT row_value FROM (
+  SELECT 'project|' || quote(id) || '|' || quote(worktree) || '|' || quote(vcs) || '|' || quote(name) || '|' || quote(icon_url) || '|' || quote(icon_color) || '|' || quote(time_created) || '|' || quote(time_updated) || '|' || quote(time_initialized) || '|' || quote(sandboxes) || '|' || quote(commands) || '|' || quote(icon_url_override) AS row_value FROM project
+  UNION ALL
+  SELECT 'session|' || quote(id) || '|' || quote(project_id) || '|' || quote(parent_id) || '|' || quote(slug) || '|' || quote(directory) || '|' || quote(title) || '|' || quote(version) || '|' || quote(share_url) || '|' || quote(summary_additions) || '|' || quote(summary_deletions) || '|' || quote(summary_files) || '|' || quote(summary_diffs) || '|' || quote(revert) || '|' || quote(permission) || '|' || quote(time_created) || '|' || quote(time_updated) || '|' || quote(time_compacting) || '|' || quote(time_archived) || '|' || quote(workspace_id) || '|' || quote(path) || '|' || quote(agent) || '|' || quote(model) || '|' || quote(cost) || '|' || quote(tokens_input) || '|' || quote(tokens_output) || '|' || quote(tokens_reasoning) || '|' || quote(tokens_cache_read) || '|' || quote(tokens_cache_write) || '|' || quote(metadata) FROM session
+  UNION ALL
+  SELECT 'message|' || quote(id) || '|' || quote(session_id) || '|' || quote(time_created) || '|' || quote(time_updated) || '|' || quote(data) FROM message
+  UNION ALL
+  SELECT 'part|' || quote(id) || '|' || quote(message_id) || '|' || quote(session_id) || '|' || quote(time_created) || '|' || quote(time_updated) || '|' || quote(data) FROM part
+  UNION ALL
+  SELECT 'todo|' || quote(session_id) || '|' || quote(content) || '|' || quote(status) || '|' || quote(priority) || '|' || quote(position) || '|' || quote(time_created) || '|' || quote(time_updated) FROM todo
+  UNION ALL
+  SELECT 'session_share|' || quote(session_id) || '|' || quote(id) || '|' || quote(secret) || '|' || quote(url) || '|' || quote(time_created) || '|' || quote(time_updated) FROM session_share
+  UNION ALL
+  SELECT 'session_message|' || quote(id) || '|' || quote(session_id) || '|' || quote(type) || '|' || quote(time_created) || '|' || quote(time_updated) || '|' || quote(data) || '|' || quote(seq) FROM session_message
+  UNION ALL
+  SELECT 'session_input|' || quote(id) || '|' || quote(session_id) || '|' || quote(prompt) || '|' || quote(delivery) || '|' || quote(admitted_seq) || '|' || quote(promoted_seq) || '|' || quote(time_created) FROM session_input
+  UNION ALL
+  SELECT 'session_context_epoch|' || quote(session_id) || '|' || quote(baseline) || '|' || quote(snapshot) || '|' || quote(baseline_seq) FROM session_context_epoch
+  UNION ALL
+  SELECT 'event_sequence|' || quote(aggregate_id) || '|' || quote(seq) || '|' || quote(owner_id) FROM event_sequence
+  UNION ALL
+  SELECT 'event|' || quote(id) || '|' || quote(aggregate_id) || '|' || quote(seq) || '|' || quote(type) || '|' || quote(data) FROM event
+) ORDER BY row_value;
+SQL
+	return $?
+}
+
 _make_active_db_with_sessions() {
 	local sessions_csv="$1"
 
@@ -260,6 +399,59 @@ if [[ "$archived_event_count" == "1" && "$active_event_count" == "0" ]]; then
 	_pass "session event rows moved from active DB to archive DB"
 else
 	_fail "event archive mismatch: archived=${archived_event_count}, active=${active_event_count}"
+fi
+
+expected_session_columns="id,project_id,parent_id,slug,directory,title,version,share_url,summary_additions,summary_deletions,summary_files,summary_diffs,revert,permission,time_created,time_updated,time_compacting,time_archived,workspace_id,path,agent,model,cost,tokens_input,tokens_output,tokens_reasoning,tokens_cache_read,tokens_cache_write,metadata"
+archive_session_columns=$(sqlite3 "$ARCHIVE_DB" "SELECT group_concat(name, ',') FROM pragma_table_info('session');")
+archive_current_table_count=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('session_message','session_input','session_context_epoch','event_sequence');")
+legacy_default_count=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session WHERE id='ses1' AND agent IS NULL AND model IS NULL AND cost=0 AND tokens_input=0 AND tokens_output=0 AND tokens_reasoning=0 AND tokens_cache_read=0 AND tokens_cache_write=0 AND metadata IS NULL;")
+if [[ "$archive_session_columns" == "$expected_session_columns" && "$archive_current_table_count" == "4" && "$legacy_default_count" == "1" ]]; then
+	_pass "legacy archive migrates losslessly to the complete 1.18.3 contract"
+else
+	_fail "legacy archive migration mismatch: columns=${archive_session_columns}, tables=${archive_current_table_count}, defaults=${legacy_default_count}"
+fi
+
+# Exact OpenCode 1.18.3 fixture: dry-run reporting, schema acceptance, full
+# session graph movement, value fidelity, and orphan checks.
+_reset_dbs
+_make_active_db_1_18_3
+source_graph=$(_fixture_graph_fingerprint "$ACTIVE_DB")
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
+	OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=0 "$HELPER" archive --dry-run --retention-days 0 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 && "$out" == *"Session msgs:   1"* && "$out" == *"Session inputs: 1"* && "$out" == *"Context epochs: 1"* && "$out" == *"Event sequences: 1"* && ! -e "$ARCHIVE_DB" ]]; then
+	_pass "1.18.3 dry run reports the complete graph without creating an archive"
+else
+	_fail "1.18.3 dry-run mismatch: rc=${rc}, output=${out}"
+fi
+
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
+	OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=0 "$HELPER" archive --retention-days 0 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+	_pass "archive accepts the exact populated OpenCode 1.18.3 schema"
+else
+	_fail "1.18.3 archive failed with rc=${rc} — output: ${out}"
+fi
+
+archive_graph=$(_fixture_graph_fingerprint "$ARCHIVE_DB")
+if [[ "$archive_graph" == "$source_graph" ]]; then
+	_pass "1.18.3 archive preserves every fixture value byte-for-byte"
+else
+	_fail "1.18.3 archive graph differs from the source fixture"
+fi
+
+active_owned_count=$(sqlite3 "$ACTIVE_DB" "SELECT (SELECT COUNT(*) FROM session) + (SELECT COUNT(*) FROM message) + (SELECT COUNT(*) FROM part) + (SELECT COUNT(*) FROM todo) + (SELECT COUNT(*) FROM session_share) + (SELECT COUNT(*) FROM session_message) + (SELECT COUNT(*) FROM session_input) + (SELECT COUNT(*) FROM session_context_epoch) + (SELECT COUNT(*) FROM event_sequence) + (SELECT COUNT(*) FROM event);")
+archive_orphan_count=$(sqlite3 "$ARCHIVE_DB" "SELECT (SELECT COUNT(*) FROM message c LEFT JOIN session p ON p.id=c.session_id WHERE p.id IS NULL) + (SELECT COUNT(*) FROM part c LEFT JOIN session p ON p.id=c.session_id WHERE p.id IS NULL) + (SELECT COUNT(*) FROM part c LEFT JOIN message p ON p.id=c.message_id WHERE p.id IS NULL) + (SELECT COUNT(*) FROM todo c LEFT JOIN session p ON p.id=c.session_id WHERE p.id IS NULL) + (SELECT COUNT(*) FROM session_share c LEFT JOIN session p ON p.id=c.session_id WHERE p.id IS NULL) + (SELECT COUNT(*) FROM session_message c LEFT JOIN session p ON p.id=c.session_id WHERE p.id IS NULL) + (SELECT COUNT(*) FROM session_input c LEFT JOIN session p ON p.id=c.session_id WHERE p.id IS NULL) + (SELECT COUNT(*) FROM session_context_epoch c LEFT JOIN session p ON p.id=c.session_id WHERE p.id IS NULL) + (SELECT COUNT(*) FROM event_sequence c LEFT JOIN session p ON p.id=c.aggregate_id WHERE p.id IS NULL) + (SELECT COUNT(*) FROM event c LEFT JOIN event_sequence p ON p.aggregate_id=c.aggregate_id WHERE p.aggregate_id IS NULL);")
+archive_foreign_key_violations=$(sqlite3 "$ARCHIVE_DB" "PRAGMA foreign_key_check;")
+if [[ "$active_owned_count" == "0" && "$archive_orphan_count" == "0" && -z "$archive_foreign_key_violations" ]]; then
+	_pass "1.18.3 copy/delete ordering leaves no active rows or archive orphans"
+else
+	_fail "1.18.3 orphan mismatch: active=${active_owned_count}, archive=${archive_orphan_count}, foreign_keys=${archive_foreign_key_violations}"
 fi
 
 _reset_dbs
@@ -539,27 +731,47 @@ out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
 rc=$?
 set -e
 future_payload=$(sqlite3 "$ACTIVE_DB" "SELECT future_payload FROM session WHERE id='ses1';")
-if [[ "$rc" -eq 3 && "$future_payload" == "preserve-me" && ! -e "$ARCHIVE_DB" ]]; then
-	_pass "unknown future session schema remains active and untouched"
+if [[ "$rc" -eq 3 && "$future_payload" == "preserve-me" && ! -e "$ARCHIVE_DB" && "$out" == *"table=session"* && "$out" == *"actual_columns="* && "$out" == *"supported_columns="* && "$out" == *"reason=column-mismatch"* ]]; then
+	_pass "future session columns fail closed with structured mismatch diagnostics"
 else
 	_fail "future-schema fail-closed mismatch: rc=${rc}, payload=${future_payload}, output=${out}"
+fi
+
+_reset_dbs
+_make_active_db_1_18_3
+sqlite3 "$ACTIVE_DB" "CREATE TABLE future_session_data (session_id text NOT NULL, payload blob NOT NULL); INSERT INTO future_session_data VALUES ('ses-1183', X'00FF10');"
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
+	OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=0 "$HELPER" archive --retention-days 0 2>&1)
+rc=$?
+set -e
+future_table_payload=$(sqlite3 "$ACTIVE_DB" "SELECT hex(payload) FROM future_session_data WHERE session_id='ses-1183';")
+if [[ "$rc" -eq 3 && "$future_table_payload" == "00FF10" && ! -e "$ARCHIVE_DB" && "$out" == *"table=future_session_data"* && "$out" == *"actual_columns=[session_id,payload]"* && "$out" == *"supported_columns=[no-additional-session-id-table]"* && "$out" == *"reason=unknown-session-table"* ]]; then
+	_pass "unknown future session tables are named and left untouched"
+else
+	_fail "future-table fail-closed mismatch: rc=${rc}, payload=${future_table_payload}, output=${out}"
 fi
 
 # A signal between committed batches leaves both databases queryable and every
 # logical session present in exactly one database.
 _reset_dbs
-_make_active_db_with_sessions $'interrupt-a,1\ninterrupt-b,2'
+_make_active_db_1_18_3
+_add_second_active_1_18_3_session
 interrupt_output="${SANDBOX}/interrupt-output.log"
 OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" \
 	OPENCODE_DB_WAL_STABILITY_DELAY_SECONDS=0 OPENCODE_DB_ARCHIVE_BATCH_SIZE=1 \
 	OPENCODE_DB_ARCHIVE_BATCH_DELAY_SECONDS=10 \
 	"$HELPER" archive --retention-days 0 --max-duration-seconds 30 >"$interrupt_output" 2>&1 &
 archive_pid=$!
-archive_rows=0
+archive_progress=0
+interrupt_log=""
 for _attempt in {1..100}; do
-	if [[ -f "$ARCHIVE_DB" ]]; then
-		archive_rows=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM session;" 2>/dev/null || printf '0')
-		[[ "$archive_rows" -gt 0 ]] && break
+	if [[ -f "$interrupt_output" ]]; then
+		interrupt_log=$(<"$interrupt_output")
+		if [[ "$interrupt_log" == *"Archived 1/2 sessions"* ]]; then
+			archive_progress=1
+			break
+		fi
 	fi
 	sleep 0.05
 done
@@ -571,10 +783,11 @@ set -e
 active_quick_check=$(sqlite3 "$ACTIVE_DB" "PRAGMA quick_check;" 2>/dev/null || true)
 archive_quick_check=$(sqlite3 "$ARCHIVE_DB" "PRAGMA quick_check;" 2>/dev/null || true)
 preserved_sessions=$(sqlite3 "$ACTIVE_DB" "ATTACH DATABASE '$ARCHIVE_DB' AS archive; SELECT COUNT(*) FROM (SELECT id FROM main.session UNION SELECT id FROM archive.session);" 2>/dev/null || printf '0')
-if [[ "$rc" -eq 143 && "$active_quick_check" == "ok" && "$archive_quick_check" == "ok" && "$preserved_sessions" == "2" ]]; then
-	_pass "interrupted archive preserves queryable active and archive databases"
+preserved_graph_rows=$(sqlite3 "$ACTIVE_DB" "ATTACH DATABASE '$ARCHIVE_DB' AS archive; SELECT (SELECT COUNT(*) FROM main.session) + (SELECT COUNT(*) FROM archive.session) + (SELECT COUNT(*) FROM main.message) + (SELECT COUNT(*) FROM archive.message) + (SELECT COUNT(*) FROM main.part) + (SELECT COUNT(*) FROM archive.part) + (SELECT COUNT(*) FROM main.todo) + (SELECT COUNT(*) FROM archive.todo) + (SELECT COUNT(*) FROM main.session_share) + (SELECT COUNT(*) FROM archive.session_share) + (SELECT COUNT(*) FROM main.session_message) + (SELECT COUNT(*) FROM archive.session_message) + (SELECT COUNT(*) FROM main.session_input) + (SELECT COUNT(*) FROM archive.session_input) + (SELECT COUNT(*) FROM main.session_context_epoch) + (SELECT COUNT(*) FROM archive.session_context_epoch) + (SELECT COUNT(*) FROM main.event_sequence) + (SELECT COUNT(*) FROM archive.event_sequence) + (SELECT COUNT(*) FROM main.event) + (SELECT COUNT(*) FROM archive.event);" 2>/dev/null || printf '0')
+if [[ "$archive_progress" -eq 1 && "$rc" -eq 143 && "$active_quick_check" == "ok" && "$archive_quick_check" == "ok" && "$preserved_sessions" == "2" && "$preserved_graph_rows" == "20" ]]; then
+	_pass "interrupted archive preserves every 1.18.3 graph row in exactly one database"
 else
-	_fail "interrupted archive mismatch: rc=${rc}, active=${active_quick_check}, archive=${archive_quick_check}, sessions=${preserved_sessions}"
+	_fail "interrupted archive mismatch: progress=${archive_progress}, rc=${rc}, active=${active_quick_check}, archive=${archive_quick_check}, sessions=${preserved_sessions}, graph_rows=${preserved_graph_rows}, output=${interrupt_log}"
 fi
 
 # VACUUM is bracketed by idle-only checkpoints and leaves both DBs verified.


### PR DESCRIPTION
## Summary

- Model the exact OpenCode 1.18.3 `session` columns and session-owned tables.
- Migrate persisted legacy archives forward without rebuilding or discarding rows.
- Copy and delete `session_message`, `session_input`, `session_context_epoch`, `event_sequence`, and `event` rows in dependency-safe transaction order.
- Report the first unsupported table with actual and supported columns while continuing to reject unknown future schema.

## Files Changed

- `.agents/scripts/opencode-db-safety-lib.sh`: versioned schema profiles, future-table detection, and structured mismatch diagnostics.
- `.agents/scripts/opencode-db-archive.sh`: canonical archive schema/migrations, complete copy/delete graph, and explicit foreign-key handling.
- `.agents/scripts/tests/test-opencode-db-archive.sh`: exact populated 1.18.3 fixture, legacy migration, value-fidelity, orphan, future-schema, and interruption regressions.

## Safety and Compatibility

- Legacy 19/20-column active databases remain supported.
- Persisted archives gain additive columns with deterministic defaults and the four new tables.
- Unknown session- or aggregate-owned tables still fail closed before archive creation or active-data mutation.
- Validation queried local OpenCode 1.18.3 schema metadata only; no live user rows were selected or mutated.

## Verification

- `bash .agents/scripts/tests/test-opencode-db-archive.sh` — 34 passed, 0 failed.
- `.agents/scripts/linters-local.sh` — all changed-file gates passed.
- `bash -n` and `shellcheck` passed for all three changed shell files.
- Installed OpenCode version and schema metadata verified as 1.18.3 before implementation.

Resolves #28283
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 12h 35m and 1,490,248 tokens on this with the user in an interactive session.