### PR TITLE
GH#28325: fix: make canonical updates shim-safe

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
@@ -42,7 +42,7 @@ _update_fetch_main() {
 	git_dir=$("$real_git" -C "$INSTALL_DIR" rev-parse --git-dir 2>/dev/null || true)
 	common_dir=$("$real_git" -C "$INSTALL_DIR" rev-parse --git-common-dir 2>/dev/null || true)
 	if [[ -z "$git_dir" || "$git_dir" != "$common_dir" ]]; then
-		git fetch origin "$branch" --tags --quiet
+		"$real_git" -C "$INSTALL_DIR" fetch origin "$branch" --tags --quiet
 		return $?
 	fi
 

--- a/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
@@ -19,6 +19,7 @@ _AIDEVOPS_UPDATE_LIB_LOADED=1
 
 _update_lib_dir="${BASH_SOURCE[0]%/*}"
 [[ "$_update_lib_dir" == "${BASH_SOURCE[0]}" ]] && _update_lib_dir="."
+_AIDEVOPS_UPDATE_HELPER_DIR="$(cd "${_update_lib_dir}/.." && pwd)"
 # shellcheck source=aidevops-project-config-lib.sh
 source "${_update_lib_dir}/aidevops-project-config-lib.sh"
 unset _update_lib_dir
@@ -31,6 +32,48 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 fi
 
 _AIDEVOPS_UPDATE_TRUE=true
+
+_update_fetch_main() {
+	local branch="$1"
+	_AIDEVOPS_UPDATE_CANONICAL_FAST_FORWARDED=false
+	local real_git="${AIDEVOPS_REAL_GIT_BIN:-/usr/bin/git}"
+	local git_dir=""
+	local common_dir=""
+	git_dir=$("$real_git" -C "$INSTALL_DIR" rev-parse --git-dir 2>/dev/null || true)
+	common_dir=$("$real_git" -C "$INSTALL_DIR" rev-parse --git-common-dir 2>/dev/null || true)
+	if [[ -z "$git_dir" || "$git_dir" != "$common_dir" ]]; then
+		git fetch origin "$branch" --tags --quiet
+		return $?
+	fi
+
+	local helper=""
+	local candidate=""
+	local bundled_helper="${_AIDEVOPS_UPDATE_HELPER_DIR:-}/canonical-recovery-helper.sh"
+	local source_helper="${INSTALL_DIR}/.agents/scripts/canonical-recovery-helper.sh"
+	local stable_helper="${HOME}/.aidevops/agents/scripts/canonical-recovery-helper.sh"
+	for candidate in "$bundled_helper" "$source_helper" "$stable_helper"; do
+		[[ -f "$candidate" ]] || continue
+		if grep -q -- '--reason aidevops-update' "$candidate" 2>/dev/null; then
+			helper="$candidate"
+			break
+		fi
+	done
+	if [[ -z "$helper" ]]; then
+		print_error "A compatible canonical update helper is unavailable (stable path: $stable_helper)"
+		print_info "Reinstall aidevops to restore a helper with aidevops-update maintenance support, then rerun aidevops update."
+		return 1
+	fi
+
+	print_info "Using audited canonical fast-forward for the source checkout..."
+	if ! AIDEVOPS_REAL_GIT_BIN="$real_git" bash "$helper" fast-forward-current \
+		--repo "$INSTALL_DIR" --branch "$branch" --reason aidevops-update \
+		--confirm FAST_FORWARD_CANONICAL_BRANCH; then
+		print_error "Audited canonical fast-forward failed; no update was deployed."
+		return 1
+	fi
+	_AIDEVOPS_UPDATE_CANONICAL_FAST_FORWARDED=true
+	return 0
+}
 
 # Tracked project config is repository-owned policy. Framework updates may read
 # it to refresh local registration metadata, but must not create working-tree

--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -12,6 +12,7 @@ usage() {
 		'Usage:' \
 		'  canonical-recovery-helper.sh restore-default --repo PATH --issue N --confirm RESTORE_CANONICAL_DEFAULT' \
 		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --issue N --confirm FAST_FORWARD_CANONICAL_BRANCH" \
+		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --reason aidevops-update --confirm FAST_FORWARD_CANONICAL_BRANCH" \
 		"  canonical-recovery-helper.sh ${SYNC_MIRROR_CMD} --repo PATH --issue N --confirm SYNCHRONIZE_CANONICAL_MIRROR"
 	return 0
 }
@@ -20,6 +21,7 @@ cmd="${1:-}"
 shift || true
 repo_path=""
 issue_number=""
+maintenance_reason=""
 confirmation=""
 expected_branch=""
 while [[ $# -gt 0 ]]; do
@@ -30,6 +32,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--issue)
 		issue_number="${2:-}"
+		shift 2
+		;;
+	--reason)
+		maintenance_reason="${2:-}"
 		shift 2
 		;;
 	--confirm)
@@ -74,10 +80,18 @@ restore-default)
 	exit 2
 	;;
 esac
-[[ -d "$repo_path" && "$issue_number" =~ ^[0-9]+$ ]] || {
+[[ -d "$repo_path" ]] || {
 	usage
 	exit 2
 }
+if [[ "$issue_number" =~ ^[0-9]+$ && -z "$maintenance_reason" ]]; then
+	audit_reference="issue ${issue_number}"
+elif [[ -z "$issue_number" && "$cmd" == "$FAST_FORWARD_CMD" && "$maintenance_reason" == "aidevops-update" ]]; then
+	audit_reference="reason ${maintenance_reason}"
+else
+	usage
+	exit 2
+fi
 repo_path=$(cd "$repo_path" && pwd -P) || exit 2
 [[ "$confirmation" == "$expected_confirmation" ]] || {
 	printf 'BLOCKED: exact recovery confirmation is required\n' >&2
@@ -261,7 +275,7 @@ audit_message="Canonical default-branch recovery authorized"
 [[ "$cmd" == "$FAST_FORWARD_CMD" ]] && audit_message="Canonical current-branch fast-forward authorized"
 [[ "$cmd" == "$SYNC_MIRROR_CMD" ]] && audit_message="Canonical mirror synchronization authorized"
 AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log operation.verify "$audit_message" \
-	--detail "issue=${issue_number}" --detail "repo=${repo_path}" \
+	--detail "issue=${issue_number:-none}" --detail "reason=${maintenance_reason:-none}" --detail "repo=${repo_path}" \
 	--detail "operation=${cmd}" --detail "target=${target_branch}" --detail "target_source=${target_branch_source}" \
 	--detail "target_sha=${target_sha}" --detail "local_sha=${local_sha}" \
 	--detail "preservation_ref=${preservation_ref:-none}" --detail "backup_id=${sync_backup_id:-none}" >/dev/null || {
@@ -323,7 +337,7 @@ if [[ "$cmd" == "$FAST_FORWARD_CMD" || "$cmd" == "$SYNC_MIRROR_CMD" ]]; then
 		"update ${local_ref} ${target_sha} ${local_sha}" \
 		'prepare' \
 		'commit' | "$REAL_GIT" -C "$repo_path" update-ref \
-		-m "${fast_forward_reflog} for issue ${issue_number}" --stdin >/dev/null; then
+		-m "${fast_forward_reflog} for ${audit_reference}" --stdin >/dev/null; then
 		printf 'BLOCKED: canonical local or origin ref changed during fast-forward\n' >&2
 		exit 1
 	fi

--- a/.agents/scripts/tests/test-aidevops-update-transaction.sh
+++ b/.agents/scripts/tests/test-aidevops-update-transaction.sh
@@ -260,6 +260,17 @@ AGENTS_DIR="$HOME/.aidevops/agents"
 AIDEVOPS_SKIP_PULSE_RESTART=1
 _AIDEVOPS_UPDATE_TRUE=true
 
+INTEGRATION_LINKED="$TEST_ROOT/integration-linked"
+/usr/bin/git -C "$INTEGRATION_REPO" worktree add -q -b linked-update-test "$INTEGRATION_LINKED"
+INSTALL_DIR="$INTEGRATION_LINKED"
+if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git _update_fetch_main main &&
+	[[ "$(/usr/bin/git -C "$INTEGRATION_LINKED" rev-parse refs/remotes/origin/main)" == "$REMOTE_SHA" ]]; then
+	pass "linked checkout fetch bypasses the canonical Git guard shim"
+else
+	fail "linked checkout fetch bypasses the canonical Git guard shim" "fetch did not use the resolved Git binary"
+fi
+INSTALL_DIR="$INTEGRATION_REPO"
+
 if integration_output=$(cmd_update --skip-project-sync --compact) &&
 	[[ "$(/usr/bin/git -C "$INTEGRATION_REPO" rev-parse HEAD)" == "$REMOTE_SHA" ]] &&
 	grep -q -- '--reason aidevops-update' "$CANONICAL_HELPER_CALLS" &&

--- a/.agents/scripts/tests/test-aidevops-update-transaction.sh
+++ b/.agents/scripts/tests/test-aidevops-update-transaction.sh
@@ -29,6 +29,7 @@ fail() {
 extract_function() {
 	local function_name="$1"
 	local output_file="$2"
+	local source_file="${3:-$REPO_ROOT/aidevops.sh}"
 	awk -v function_name="$function_name" '
 		$0 ~ "^" function_name "\\(\\)[[:space:]]*\\{" { capturing = 1 }
 		capturing {
@@ -40,7 +41,7 @@ extract_function() {
 			depth += open_count - close_count
 			if (depth == 0) exit
 		}
-	' "$REPO_ROOT/aidevops.sh" >"$output_file"
+	' "$source_file" >"$output_file"
 	[[ -s "$output_file" ]]
 	return 0
 }
@@ -50,6 +51,10 @@ for function_name in _update_verify_deployment_state _run_update_setup_transacti
 	# shellcheck source=/dev/null
 	source "$TEST_ROOT/$function_name.sh"
 done
+extract_function _update_fetch_main "$TEST_ROOT/_update_fetch_main.sh" \
+	"$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
+# shellcheck source=/dev/null
+source "$TEST_ROOT/_update_fetch_main.sh"
 
 print_error() {
 	local message="$1"
@@ -64,6 +69,13 @@ print_info() {
 }
 
 git() {
+	local arg=""
+	for arg in "$@"; do
+		if [[ "$arg" == "fetch" || "$arg" == "merge" ]]; then
+			printf 'BLOCKED by canonical Git guard: canonical mutation via git %s\n' "$arg" >&2
+			return 42
+		fi
+	done
 	/usr/bin/git "$@"
 	return $?
 }
@@ -191,6 +203,7 @@ INTEGRATION_REMOTE="$TEST_ROOT/integration.git"
 INTEGRATION_REPO="$TEST_ROOT/integration-repo"
 INTEGRATION_PEER="$TEST_ROOT/integration-peer"
 SETUP_CALLS="$TEST_ROOT/setup-calls"
+CANONICAL_HELPER_CALLS="$TEST_ROOT/canonical-helper-calls"
 /usr/bin/git init -q --bare -b main "$INTEGRATION_REMOTE"
 /usr/bin/git init -q -b main "$INTEGRATION_REPO"
 /usr/bin/git -C "$INTEGRATION_REPO" config user.email test@example.invalid
@@ -210,6 +223,27 @@ printf 'updated\n' >"$INTEGRATION_PEER/runtime.txt"
 /usr/bin/git -C "$INTEGRATION_PEER" push -q origin main
 REMOTE_SHA=$(/usr/bin/git -C "$INTEGRATION_PEER" rev-parse HEAD)
 
+mkdir -p "$INTEGRATION_REPO/.agents/scripts"
+cat >"$INTEGRATION_REPO/.agents/scripts/canonical-recovery-helper.sh" <<'EOF'
+#!/usr/bin/env bash
+# Supports: --reason aidevops-update
+set -euo pipefail
+printf '%s\n' "$*" >>"$CANONICAL_HELPER_CALLS"
+repo=""
+branch=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--repo) repo="$2"; shift 2 ;;
+	--branch) branch="$2"; shift 2 ;;
+	*) shift ;;
+	esac
+done
+/usr/bin/git -C "$repo" fetch origin "$branch" --tags --quiet
+/usr/bin/git -C "$repo" merge --ff-only "origin/$branch" --quiet
+EOF
+chmod +x "$INTEGRATION_REPO/.agents/scripts/canonical-recovery-helper.sh"
+export CANONICAL_HELPER_CALLS
+
 INSTALL_DIR="$INTEGRATION_REPO"
 SETUP_RC=0
 SETUP_SHA="$REMOTE_SHA"
@@ -228,12 +262,36 @@ _AIDEVOPS_UPDATE_TRUE=true
 
 if integration_output=$(cmd_update --skip-project-sync --compact) &&
 	[[ "$(/usr/bin/git -C "$INTEGRATION_REPO" rev-parse HEAD)" == "$REMOTE_SHA" ]] &&
+	grep -q -- '--reason aidevops-update' "$CANONICAL_HELPER_CALLS" &&
 	[[ -s "$SETUP_CALLS" ]] &&
 	[[ "$integration_output" == *"t18162: task-prefixed update"* ]] &&
 	[[ "$integration_output" == *"agents deployed"* ]]; then
-	pass "task-prefixed fast-forward reaches setup and verifies activation"
+	pass "shim-safe audited canonical fast-forward reaches setup and verifies activation"
 else
-	fail "task-prefixed fast-forward reaches setup and verifies activation" "$integration_output"
+	fail "shim-safe audited canonical fast-forward reaches setup and verifies activation" "$integration_output"
+fi
+
+printf 'dirty update fixture\n' >>"$INTEGRATION_REPO/runtime.txt"
+helper_calls_before=$(wc -l <"$CANONICAL_HELPER_CALLS")
+if dirty_output=$(cmd_update --skip-project-sync --compact 2>&1); then
+	fail "dirty canonical checkout remains non-destructive" "unexpected success"
+elif [[ "$dirty_output" == *"tracked local changes exist"* ]] &&
+	[[ "$(wc -l <"$CANONICAL_HELPER_CALLS")" -eq "$helper_calls_before" ]] &&
+	[[ "$(/usr/bin/git -C "$INTEGRATION_REPO" rev-parse HEAD)" == "$REMOTE_SHA" ]]; then
+	pass "dirty canonical checkout remains non-destructive"
+else
+	fail "dirty canonical checkout remains non-destructive" "$dirty_output"
+fi
+/usr/bin/git -C "$INTEGRATION_REPO" checkout -q -- runtime.txt
+
+rm "$INTEGRATION_REPO/.agents/scripts/canonical-recovery-helper.sh"
+if missing_helper_output=$(_update_fetch_main main 2>&1); then
+	fail "missing canonical helper fails with stable-path guidance" "unexpected success"
+elif [[ "$missing_helper_output" == *"$HOME/.aidevops/agents/scripts/canonical-recovery-helper.sh"* ]] &&
+	[[ "$missing_helper_output" == *"Reinstall aidevops"* ]]; then
+	pass "missing canonical helper fails with stable-path guidance"
+else
+	fail "missing canonical helper fails with stable-path guidance" "$missing_helper_output"
 fi
 
 printf '%s passed, %s failed\n' "$PASS_COUNT" "$FAIL_COUNT"

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -83,6 +83,14 @@ else
 	exit 1
 fi
 
+if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" fast-forward-current --repo "$REPO" --branch develop --reason aidevops-update --confirm FAST_FORWARD_CANONICAL_BRANCH >/dev/null &&
+	grep -q '"reason":"aidevops-update"' "$HOME/.aidevops/logs/canonical-recovery-audit.jsonl"; then
+	printf 'PASS routine update fast-forward records an audited reason without an invented issue number\n'
+else
+	printf 'FAIL routine update fast-forward did not record its maintenance reason\n'
+	exit 1
+fi
+
 develop_local_tip=$(/usr/bin/git -C "$REPO" rev-parse HEAD)
 mkdir "${REPO}/.git/aidevops-canonical-recovery.lock"
 if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" fast-forward-current --repo "$REPO" --branch develop --issue 28032 --confirm FAST_FORWARD_CANONICAL_BRANCH >/dev/null 2>&1; then

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -845,7 +845,7 @@ jobs:
     name: Qlty Smell Threshold
     runs-on: ubuntu-latest
     env:
-      QLTY_CLI_VERSION: "0.635.0"
+      QLTY_CLI_VERSION: "0.636.0"
 
     steps:
     - name: Checkout code

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -100,7 +100,7 @@ jobs:
     name: Qlty Smell Regression
     runs-on: ubuntu-latest
     env:
-      QLTY_CLI_VERSION: "0.635.0"
+      QLTY_CLI_VERSION: "0.636.0"
     needs: detect-scope
     if: needs.detect-scope.outputs.should_scan == 'true'
     steps:

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -337,12 +337,12 @@ cmd_update() {
 				return 1
 			fi
 		fi
-		if ! git fetch origin main --tags --quiet; then
+		local local_hash
+		local_hash=$(git rev-parse HEAD) || return 1
+		if ! _update_fetch_main main; then
 			print_error "Failed to fetch origin/main; no update was applied."
 			return 1
 		fi
-		local local_hash
-		local_hash=$(git rev-parse HEAD) || return 1
 		local remote_hash
 		remote_hash=$(git rev-parse origin/main) || return 1
 		if [[ "$local_hash" != "$remote_hash" ]] && git merge-base --is-ancestor "$remote_hash" "$local_hash" 2>/dev/null; then
@@ -396,8 +396,10 @@ cmd_update() {
 		else
 			print_info "Applying latest changes..."
 			local old_hash
-			old_hash=$(git rev-parse HEAD)
-			if git merge --ff-only "$remote_hash" --quiet; then
+			old_hash="$local_hash"
+			if [[ "${_AIDEVOPS_UPDATE_CANONICAL_FAST_FORWARDED:-false}" == "true" ]]; then
+				:
+			elif git merge --ff-only "$remote_hash" --quiet; then
 				:
 			else
 				print_error "Fast-forward update failed; preserving local history."
@@ -1587,6 +1589,7 @@ _cmd_email() {
 
 # Route 'aidevops client-format [subcommand]' to appropriate helpers
 _cmd_client_format() {
+	local canary_helper="cch-canary.sh"
 	case "${1:-status}" in
 	extract | refresh)
 		_dispatch_helper "cch-extract.sh" "cch-extract.sh" --cache
@@ -1596,14 +1599,14 @@ _cmd_client_format() {
 		;;
 	canary | test)
 		shift || true
-		_dispatch_helper "cch-canary.sh" "cch-canary.sh" --verbose "$@"
+		_dispatch_helper "$canary_helper" "$canary_helper" --verbose "$@"
 		;;
 	monitor)
 		shift || true
 		_dispatch_helper "cch-traffic-monitor.sh" "cch-traffic-monitor.sh" "$@"
 		;;
 	install-canary)
-		_dispatch_helper "cch-canary.sh" "cch-canary.sh" --install
+		_dispatch_helper "$canary_helper" "$canary_helper" --install
 		;;
 	status | "")
 		echo ""
@@ -1817,15 +1820,17 @@ main() {
 		# P4 asset binary: asset → campaign-asset-helper.sh
 		# P2+P6: all other subcommands → campaign-helper.sh
 		local _camp_cmd="${1:-help}"
+		local _camp_helper="campaign-helper.sh"
+		local _camp_provision_helper="campaigns-provision-helper.sh"
 		case "$_camp_cmd" in
 		init | provision | ls)
-			_dispatch_helper "campaigns-provision-helper.sh" "campaigns-provision-helper.sh" "$@"
+			_dispatch_helper "$_camp_provision_helper" "$_camp_provision_helper" "$@"
 			;;
 		status)
 			if [[ $# -le 1 || -d "${2:-}" || "${2:-}" == .* || "${2:-}" == /* || "${2:-}" == ~* ]]; then
-				_dispatch_helper "campaigns-provision-helper.sh" "campaigns-provision-helper.sh" "$@"
+				_dispatch_helper "$_camp_provision_helper" "$_camp_provision_helper" "$@"
 			else
-				_dispatch_helper "campaign-helper.sh" "campaign-helper.sh" "$@"
+				_dispatch_helper "$_camp_helper" "$_camp_helper" "$@"
 			fi
 			;;
 		asset | assets)
@@ -1833,7 +1838,7 @@ main() {
 			_dispatch_helper "campaign-asset-helper.sh" "campaign-asset-helper.sh" "$@"
 			;;
 		*)
-			_dispatch_helper "campaign-helper.sh" "campaign-helper.sh" "$@"
+			_dispatch_helper "$_camp_helper" "$_camp_helper" "$@"
 			;;
 		esac
 		;;


### PR DESCRIPTION
## Summary

Rebased the canonical update integration onto current main, retained the audited fast-forward path and maintenance-reason audit trail, incorporated the runnable helper guidance from #28330, and removed the Git 2.31-only path-format option flagged in prior review.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-update-lib.sh, .agents/scripts/canonical-recovery-helper.sh, .agents/scripts/tests/test-aidevops-update-transaction.sh, .agents/scripts/tests/test-canonical-recovery-helper.sh, aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-aidevops-update-transaction.sh; bash .agents/scripts/tests/test-cmd-update-sha-drift.sh; bash .agents/scripts/tests/test-canonical-recovery-helper.sh; bash .agents/scripts/tests/test-canonical-git-command-guard.sh; .agents/scripts/linters-local.sh --changed; bash setup.sh --non-interactive

Resolves #28325


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 4h 9m and 482,709 tokens on this as a headless worker.