### PR TITLE
GH#28339: Clarify WP-CLI precise mode support

### DIFF
--- a/.agents/workflows/wordpress-local-clone.md
+++ b/.agents/workflows/wordpress-local-clone.md
@@ -67,7 +67,7 @@ wp db import "<PRIVATE_LOCAL_EXPORT_PATH>" --path="<LOCAL_WORDPRESS_PATH>"
 wp search-replace "<SOURCE_URL>" "<LOCAL_URL>" --all-tables-with-prefix --precise --skip-columns=guid --dry-run --path="<LOCAL_WORDPRESS_PATH>"
 ```
 
-Review the dry-run count and sampled tables. Use `wp search-replace`, not raw SQL, so serialized values remain valid. Check mapped domains and scheme variants separately. Only then run the same command without `--dry-run` against local. Preserve GUIDs unless the project has a documented exception.
+Review the dry-run count and sampled tables. Use `wp search-replace`, not raw SQL, so serialized values remain valid. The supported `--precise` option forces PHP processing for every column instead of using SQL for non-serialized data; keep it for a thorough local clone even though it is slower. Check mapped domains and scheme variants separately. Only then run the same command without `--dry-run` against local. Preserve GUIDs unless the project has a documented exception.
 
 For multisite, enumerate every site and perform dry-run then apply per verified source/target URL mapping. Never substitute one broad domain fragment across unrelated mapped sites.
 


### PR DESCRIPTION
## Summary

Verified against the current WP-CLI search-replace source that --precise is supported, retained the safe clone command, and documented its PHP-processing behavior and performance trade-off.

## Files Changed

.agents/workflows/wordpress-local-clone.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check passed; current wp-cli/search-replace-command source confirms the precise associative argument and implementation; markdownlint could not run locally because the pinned CLI dependency is not installed.

Resolves #28339


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 4m and 40,700 tokens on this as a headless worker.