### PR TITLE
GH#28336: use git to configure convergence fixture remote

### DIFF
--- a/.agents/scripts/tests/test-repos-add-local-only-convergence.sh
+++ b/.agents/scripts/tests/test-repos-add-local-only-convergence.sh
@@ -42,8 +42,7 @@ register_repo "$repo_path" "1.0.0" "planning"
 [[ "$(jq -r '.initialized_repos[0].local_only' "$REPOS_FILE")" == "true" ]]
 [[ "$(jq -r '.initialized_repos[0].pulse' "$REPOS_FILE")" == "false" ]]
 
-printf '\n[remote "origin"]\n\turl = https://github.com/example/remote-backed.git\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n' \
-	>>"$repo_path/.git/config"
+git -C "$repo_path" remote add origin https://github.com/example/remote-backed.git
 register_repo "$repo_path" "1.0.1" "planning"
 
 [[ "$(jq -r '.initialized_repos[0].slug' "$REPOS_FILE")" == "example/remote-backed" ]]


### PR DESCRIPTION
## Summary

Replace direct .git/config text appends with the portable git remote add command in the local-only convergence fixture.

## Files Changed

.agents/scripts/tests/test-repos-add-local-only-convergence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PATH=/usr/bin:/bin /bin/bash .agents/scripts/tests/test-repos-add-local-only-convergence.sh; shellcheck .agents/scripts/tests/test-repos-add-local-only-convergence.sh

Resolves #28336


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 4m and 48,862 tokens on this as a headless worker.