### PR TITLE
GH#28337: fix: preserve project context on write failures

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-project-context-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-project-context-lib.sh
@@ -23,7 +23,7 @@ _init_update_project_operations_context() {
 		return 1
 	}
 
-	grep -qF "$start" "$agents_md" || command_status=$?
+	grep -qF -- "$start" "$agents_md" || command_status=$?
 	if [[ "$command_status" -eq 0 ]]; then
 		awk -v start="$start" -v end="$end" -v block="$block_file" 'function emit(){while((getline line < block)>0) print line; close(block)} index($0,start)==1 {if(!inserted){emit(); inserted=1}; managed=1; next} managed && index($0,end)==1 {managed=0; next} !managed {print}' "$agents_md" >"$tmp_file" || {
 			rm -f "$block_file" "$tmp_file"

--- a/.agents/scripts/aidevops-cli/aidevops-project-context-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-project-context-lib.sh
@@ -10,6 +10,7 @@ _init_update_project_operations_context() {
 	local block_file="${agents_md}.project-context-block.$$"
 	local tmp_file="${agents_md}.project-context.$$"
 	local line_format="%s\n"
+	local command_status=0
 	[[ -f "$agents_md" ]] || return 0
 
 	{
@@ -17,20 +18,45 @@ _init_update_project_operations_context() {
 		[[ -f "$project_root/.aidevops/deployments.yaml" ]] && printf "$line_format" "- Deployment manifest: \`.aidevops/deployments.yaml\`"
 		[[ -f "$project_root/.aidevops/wordpress.yaml" ]] && printf "$line_format" "- WordPress manifest: \`.aidevops/wordpress.yaml\`"
 		printf "$line_format" "$end"
-	} >"$block_file"
+	} >"$block_file" || {
+		rm -f "$block_file"
+		return 1
+	}
 
-	if grep -qF "$start" "$agents_md" 2>/dev/null; then
-		awk -v start="$start" -v end="$end" -v block="$block_file" 'function emit(){while((getline line < block)>0) print line; close(block)} index($0,start)==1 {if(!inserted){emit(); inserted=1}; managed=1; next} managed && index($0,end)==1 {managed=0; next} !managed {print}' "$agents_md" >"$tmp_file"
+	grep -qF "$start" "$agents_md" || command_status=$?
+	if [[ "$command_status" -eq 0 ]]; then
+		awk -v start="$start" -v end="$end" -v block="$block_file" 'function emit(){while((getline line < block)>0) print line; close(block)} index($0,start)==1 {if(!inserted){emit(); inserted=1}; managed=1; next} managed && index($0,end)==1 {managed=0; next} !managed {print}' "$agents_md" >"$tmp_file" || {
+			rm -f "$block_file" "$tmp_file"
+			return 1
+		}
+	elif [[ "$command_status" -eq 1 ]]; then
+		cp "$agents_md" "$tmp_file" &&
+			{ [[ ! -s "$tmp_file" ]] || printf "\n" >>"$tmp_file"; } &&
+			cat "$block_file" >>"$tmp_file" || {
+			rm -f "$block_file" "$tmp_file"
+			return 1
+		}
 	else
-		cp "$agents_md" "$tmp_file"
-		[[ ! -s "$tmp_file" ]] || printf "\n" >>"$tmp_file"
-		cat "$block_file" >>"$tmp_file"
+		rm -f "$block_file" "$tmp_file"
+		return 1
 	fi
 	rm -f "$block_file"
-	if cmp -s "$agents_md" "$tmp_file"; then
+	[[ -s "$tmp_file" ]] || {
 		rm -f "$tmp_file"
+		return 1
+	}
+	command_status=0
+	cmp -s "$agents_md" "$tmp_file" || command_status=$?
+	if [[ "$command_status" -eq 0 ]]; then
+		rm -f "$tmp_file"
+	elif [[ "$command_status" -eq 1 ]]; then
+		mv "$tmp_file" "$agents_md" || {
+			rm -f "$tmp_file"
+			return 1
+		}
 	else
-		mv "$tmp_file" "$agents_md"
+		rm -f "$tmp_file"
+		return 1
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-init-project-context.sh
+++ b/.agents/scripts/tests/test-init-project-context.sh
@@ -99,6 +99,50 @@ test_scaffold_and_idempotency() {
 	return 0
 }
 
+test_agents_context_write_failures_preserve_original() {
+	local repo="$TEST_ROOT/write-failures"
+	local agents_md="$repo/.agents/AGENTS.md"
+	local original
+	mkdir -p "$repo/.agents" "$repo/.aidevops"
+	printf "before\n<!-- aidevops:project-operations-context:start -->\nold\n<!-- aidevops:project-operations-context:end -->\nafter\n" >"$agents_md"
+	original=$(cksum "$agents_md")
+
+	awk() { return 1; }
+	if _init_update_project_operations_context "$repo"; then
+		assert_equal failure success "awk failure is reported"
+	else
+		assert_equal failure failure "awk failure is reported"
+	fi
+	unset -f awk
+	assert_equal "$original" "$(cksum "$agents_md")" "awk failure preserves AGENTS.md"
+	assert_equal false "$(compgen -G "${agents_md}.project-context*" >/dev/null && printf true || printf false)" "awk failure removes temporary files"
+
+	printf "before\n" >"$agents_md"
+	original=$(cksum "$agents_md")
+	cp() { return 1; }
+	if _init_update_project_operations_context "$repo"; then
+		assert_equal failure success "cp failure is reported"
+	else
+		assert_equal failure failure "cp failure is reported"
+	fi
+	unset -f cp
+	assert_equal "$original" "$(cksum "$agents_md")" "cp failure preserves AGENTS.md"
+	assert_equal false "$(compgen -G "${agents_md}.project-context*" >/dev/null && printf true || printf false)" "cp failure removes temporary files"
+
+	printf "before\n" >"$agents_md"
+	original=$(cksum "$agents_md")
+	cat() { return 1; }
+	if _init_update_project_operations_context "$repo"; then
+		assert_equal failure success "cat failure is reported"
+	else
+		assert_equal failure failure "cat failure is reported"
+	fi
+	unset -f cat
+	assert_equal "$original" "$(cksum "$agents_md")" "cat failure preserves AGENTS.md"
+	assert_equal false "$(compgen -G "${agents_md}.project-context*" >/dev/null && printf true || printf false)" "cat failure removes temporary files"
+	return 0
+}
+
 test_config_booleans() {
 	local config="$TEST_ROOT/config.json"
 	_init_write_project_config "$config" 9.9.9 minimal false false false false false false false false false false true true
@@ -148,6 +192,7 @@ main() {
 	trap cleanup EXIT
 	test_feature_parsing
 	test_scaffold_and_idempotency
+	test_agents_context_write_failures_preserve_original
 	local full_repo="$TEST_ROOT/full-rerun"
 	mkdir -p "$full_repo"
 	scaffold_agents_md "$full_repo"


### PR DESCRIPTION
## Summary

Fail closed when building or replacing the managed project-operations block so command errors cannot corrupt AGENTS.md, and clean temporary artifacts on failure.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-project-context-lib.sh, .agents/scripts/tests/test-init-project-context.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-init-project-context.sh (42 tests); targeted ShellCheck; .agents/scripts/linters-local.sh

Resolves #28337


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 15m and 67,065 tokens on this as a headless worker.