### PR TITLE
GH#28335: fix: clean up supersession refs on return

### DIFF
--- a/.agents/scripts/pr-supersession-helper.sh
+++ b/.agents/scripts/pr-supersession-helper.sh
@@ -107,6 +107,12 @@ _psh_delete_temp_refs() {
 	return 0
 }
 
+_psh_cleanup_temp_refs() {
+	# Bash's dynamic scope exposes the caller's local values to RETURN cleanup.
+	_psh_delete_temp_refs "$repo_path" "$ref_prefix"
+	return 0
+}
+
 _psh_diff_files_json() {
 	local repo_path="$1"
 	local base_ref="$2"
@@ -130,6 +136,9 @@ _psh_diff_files_json() {
 			return 1
 		}
 		ref_prefix="refs/aidevops/pr-supersession/${pr_number}-$$"
+		_save_cleanup_scope
+		trap '_run_cleanups' RETURN
+		push_cleanup _psh_cleanup_temp_refs
 		if ! git -C "$repo_path" fetch --quiet origin \
 			"+refs/heads/${base_ref}:${ref_prefix}/base" 2>/dev/null; then
 			_psh_delete_temp_refs "$repo_path" "$ref_prefix"

--- a/.agents/scripts/pr-supersession-helper.sh
+++ b/.agents/scripts/pr-supersession-helper.sh
@@ -109,6 +109,8 @@ _psh_delete_temp_refs() {
 
 _psh_cleanup_temp_refs() {
 	# Bash's dynamic scope exposes the caller's local values to RETURN cleanup.
+	local repo_path="${1:-${repo_path:-}}"
+	local ref_prefix="${2:-${ref_prefix:-}}"
 	_psh_delete_temp_refs "$repo_path" "$ref_prefix"
 	return 0
 }

--- a/.agents/scripts/tests/test-pr-supersession-helper.sh
+++ b/.agents/scripts/tests/test-pr-supersession-helper.sh
@@ -185,6 +185,16 @@ got=$(classify_fixture "$pr_needed" "${ROOT}/missing-repository")
 	&& print_result "unavailable git comparison is unknown, never an empty diff" 0 \
 	|| print_result "unavailable git comparison is unknown, never an empty diff" 1 "got=$got"
 
+cleanup_contract=$(bash -c 'source "$1"; declare -f _psh_diff_files_json' _ "$HELPER")
+if [[ "$cleanup_contract" == *"_save_cleanup_scope"* \
+	&& "$cleanup_contract" == *"trap '_run_cleanups' RETURN"* \
+	&& "$cleanup_contract" == *"push_cleanup _psh_cleanup_temp_refs"* \
+	&& "$cleanup_contract" == *"_psh_delete_temp_refs \"\$repo_path\" \"\$ref_prefix\""* ]]; then
+	print_result "temporary PR refs have return-trap and fast-path cleanup" 0
+else
+	print_result "temporary PR refs have return-trap and fast-path cleanup" 1 "cleanup contract missing"
+fi
+
 if [[ "$TESTS_FAILED" -eq 0 ]]; then
 	printf '\nAll %s pr-supersession tests passed.\n' "$TESTS_RUN"
 	exit 0

--- a/.agents/scripts/tests/test-pr-supersession-helper.sh
+++ b/.agents/scripts/tests/test-pr-supersession-helper.sh
@@ -186,10 +186,16 @@ got=$(classify_fixture "$pr_needed" "${ROOT}/missing-repository")
 	|| print_result "unavailable git comparison is unknown, never an empty diff" 1 "got=$got"
 
 cleanup_contract=$(bash -c 'source "$1"; declare -f _psh_diff_files_json' _ "$HELPER")
+cleanup_callback=$(bash -c 'source "$1"; declare -f _psh_cleanup_temp_refs' _ "$HELPER")
+cleanup_noargs_rc=0
+bash -uc 'source "$1"; _psh_cleanup_temp_refs' _ "$HELPER" || cleanup_noargs_rc=$?
 if [[ "$cleanup_contract" == *"_save_cleanup_scope"* \
 	&& "$cleanup_contract" == *"trap '_run_cleanups' RETURN"* \
 	&& "$cleanup_contract" == *"push_cleanup _psh_cleanup_temp_refs"* \
-	&& "$cleanup_contract" == *"_psh_delete_temp_refs \"\$repo_path\" \"\$ref_prefix\""* ]]; then
+	&& "$cleanup_callback" == *"local repo_path=\"\${1:-\${repo_path:-}}\""* \
+	&& "$cleanup_callback" == *"local ref_prefix=\"\${2:-\${ref_prefix:-}}\""* \
+	&& "$cleanup_callback" == *"_psh_delete_temp_refs \"\$repo_path\" \"\$ref_prefix\""* \
+	&& "$cleanup_noargs_rc" -eq 0 ]]; then
 	print_result "temporary PR refs have return-trap and fast-path cleanup" 0
 else
 	print_result "temporary PR refs have return-trap and fast-path cleanup" 1 "cleanup contract missing"


### PR DESCRIPTION
## Summary

Register temporary PR comparison refs with the shared RETURN cleanup stack while preserving explicit fast-path deletion; add a regression contract covering both cleanup paths.

## Files Changed

.agents/scripts/pr-supersession-helper.sh, .agents/scripts/tests/test-pr-supersession-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin bash .agents/scripts/tests/test-pr-supersession-helper.sh; shellcheck .agents/scripts/pr-supersession-helper.sh .agents/scripts/tests/test-pr-supersession-helper.sh; git diff --check

Resolves #28335


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 15m and 96,064 tokens on this as a headless worker.