### PR TITLE
GH#28265: fix: dispatch required review-thread remediation

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -15,7 +15,10 @@ PMRC_MAINTAINER_GATE_DISPLAY="Maintainer Review & Assignee Gate"
 PMRC_MAINTAINER_GATE_WORKFLOW="gate / Maintainer Review & Assignee Gate"
 PMRC_SUBJECT_HEAD_PREFIX="head "
 PMRC_SUBJECT_PR_PREFIX="PR #"
+PMRC_BLOCKER_REVIEW_BOT_THREADS="review-bot-threads"
+PMRC_BLOCKER_REQUIRED_REVIEW_THREADS="required-review-threads"
 : "${_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON:=[]}"
+: "${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:=}"
 
 _pmrc_gh_read() {
 	local rc=0
@@ -270,12 +273,14 @@ _pmrc_snapshot_review_threads_clear() {
 	bot_count=$(jq -r '.bots' <<<"$counts") || return 1
 	[[ "$total_count" =~ ^[0-9]+$ && "$bot_count" =~ ^[0-9]+$ ]] || return 1
 	if [[ "$bot_count" -gt 0 ]]; then
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REVIEW_BOT_THREADS"
 		echo "[pulse-merge] pre-merge snapshot: PR #${pr_number} in ${repo_slug} has ${bot_count} unresolved review-bot thread(s) — merge blocked until resolved or classified (GH#27137)" >>"$LOGFILE"
 		return 1
 	fi
 	[[ "$total_count" -gt 0 ]] || return 0
 	resolution_required=$(_pmrc_review_thread_resolution_required "$repo_slug" "$base_branch") || return 1
 	if [[ "$resolution_required" == "$PMRC_BOOL_TRUE" ]]; then
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REQUIRED_REVIEW_THREADS"
 		echo "[pulse-merge] pre-merge snapshot: PR #${pr_number} in ${repo_slug} has ${total_count} unresolved review thread(s), and branch ${base_branch} requires thread resolution — merge blocked (GH#28130)" >>"$LOGFILE"
 		return 1
 	fi
@@ -573,6 +578,7 @@ _pulse_merge_preflight_snapshot_gate() {
 	local live_gate_evidence="${_PULSE_REVIEW_GATE_EVIDENCE:-}"
 	local pr_json="" pr_coordinates="" current_head_sha="" base_branch="" required_contexts="" checks_json="" activity_json=""
 	_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON="[]"
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
 
 	pr_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || {
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "pull-request fetch"

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -143,6 +143,25 @@ _pulse_merge_maybe_dispatch_review_thread_remediation() {
 	return 0
 }
 
+_pulse_merge_maybe_dispatch_preflight_remediation() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local blocker_kind="${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-}"
+	local reason=""
+
+	# Consume the marker before any dispatch attempt so a failed or deduplicated
+	# repair cannot leak into an unrelated later final-gate failure.
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
+	[[ "${DRY_RUN:-0}" != "1" ]] || return 0
+	case "$blocker_kind" in
+	"$PMRC_BLOCKER_REVIEW_BOT_THREADS") reason="after unresolved review-bot thread preflight blocker" ;;
+	"$PMRC_BLOCKER_REQUIRED_REVIEW_THREADS") reason="after required unresolved review-thread preflight blocker" ;;
+	*) return 0 ;;
+	esac
+	_pulse_merge_dispatch_review_thread_remediation "$pr_number" "$repo_slug" "$reason" || true
+	return 0
+}
+
 _pulse_merge_changes_requested_thread_remediation_first_enabled() {
 	[[ "${AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST:-0}" == "1" ]] || return 1
 	return 0
@@ -528,6 +547,7 @@ _pulse_merge_final_trust_gate() {
 	local repo_slug="$2"
 	local expected_head_sha="$3"
 
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
 	_pulse_merge_admin_safety_check "$pr_number" "$repo_slug" "$expected_head_sha" || return 1
 	_pulse_merge_refresh_review_gate_evidence "$pr_number" "$repo_slug" "$expected_head_sha" || return 1
 	_pulse_merge_preflight_snapshot_gate "$repo_slug" "$pr_number" "$expected_head_sha" || return 1
@@ -1454,6 +1474,7 @@ _process_single_ready_pr() {
 	# #aidevops:trust-boundary — the combined final gate revalidates external
 	# authority, typed review evidence, and the terminal current-head snapshot.
 	if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+		_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 		if [[ "${_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON:-[]}" != "[]" ]]; then
 			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" \
 				"$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" \
@@ -1481,6 +1502,7 @@ _process_single_ready_pr() {
 			;;
 	esac
 	if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+		_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 		return 1
 	fi
 
@@ -1498,6 +1520,7 @@ _process_single_ready_pr() {
 	if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
 		local _merge_original_output="$merge_output"
 		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+			_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 			return 1
 		fi
 		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin --match-head-commit "$pr_head_ref_oid" 2>&1)
@@ -1538,6 +1561,7 @@ ${_missing_check_update_output}"
 			_auto_merge_exit=1
 		else
 			if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+				_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 				return 1
 			fi
 			_auto_merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
@@ -1553,6 +1577,7 @@ ${_missing_check_update_output}"
 ${_auto_merge_output}"
 		echo "[pulse-wrapper] Deterministic merge: native auto-merge fallback unavailable or failed for PR #${pr_number} in ${repo_slug}; retrying direct merge without --admin (GH#23087): ${_auto_merge_output}" >>"$LOGFILE"
 		if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+			_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 			return 1
 		fi
 		merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --match-head-commit "$pr_head_ref_oid" 2>&1)
@@ -1560,6 +1585,7 @@ ${_auto_merge_output}"
 		if [[ $_merge_exit -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$merge_output" "pulse direct merge PR #${pr_number} in ${repo_slug}" "$LOGFILE"; then
 			local _direct_merge_original_output="$merge_output"
 			if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
+				_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 				return 1
 			fi
 			merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --match-head-commit "$pr_head_ref_oid" 2>&1)

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -82,7 +82,9 @@ _ci_check_url_has_infra_failure_log() {
 }
 
 stub_review_threads() {
-	if [[ "$SNAPSHOT_MODE" == "unresolved" ]]; then
+	if [[ "$SNAPSHOT_MODE" == "review_threads_paginated" ]]; then
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"}}]}}]}}}}}'
+	elif [[ "$SNAPSHOT_MODE" == "unresolved" ]]; then
 		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"}}]}}]}}}}}'
 	elif [[ "$SNAPSHOT_MODE" == human_* ]]; then
 		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"human-reviewer"}}]}}]}}}}}'
@@ -228,6 +230,24 @@ assert_gate() {
 	return 0
 }
 
+assert_gate_blocker() {
+	local description="$1"
+	local mode="$2"
+	local expected_rc="$3"
+	local expected_blocker="$4"
+
+	assert_gate "$description" "$mode" "$expected_rc"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-}" == "$expected_blocker" ]]; then
+		printf 'PASS %s exports blocker %s\n' "$description" "${expected_blocker:-<none>}"
+		return 0
+	fi
+	printf 'FAIL %s exported blocker %s (expected %s)\n' \
+		"$description" "${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-<none>}" "${expected_blocker:-<none>}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
 assert_gate_logged() {
 	local description="$1"
 	local mode="$2"
@@ -260,7 +280,8 @@ assert_snapshot_acquisition_failures_are_audited() {
 }
 
 assert_human_review_thread_rules() {
-	assert_gate "unresolved human thread blocks when effective rules require resolution" human_required 1
+	assert_gate_blocker "unresolved human thread blocks when effective rules require resolution" \
+		human_required 1 "$PMRC_BLOCKER_REQUIRED_REVIEW_THREADS"
 	if grep -q "requires thread resolution" "$LOGFILE"; then
 		printf 'PASS required human thread blocker is audited\n'
 	else
@@ -268,10 +289,11 @@ assert_human_review_thread_rules() {
 		TESTS_FAILED=$((TESTS_FAILED + 1))
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
-	assert_gate "unresolved human thread passes when effective rules do not require resolution" human_not_required 0
-	assert_gate "required human thread supports slash-containing base branches" human_required_slash 1
-	assert_gate "effective-rules API failure with unresolved human thread fails closed" human_rules_error 1
-	assert_gate "malformed effective-rules response with unresolved human thread fails closed" human_rules_malformed 1
+	assert_gate_blocker "unresolved human thread passes when effective rules do not require resolution" human_not_required 0 ""
+	assert_gate_blocker "required human thread supports slash-containing base branches" \
+		human_required_slash 1 "$PMRC_BLOCKER_REQUIRED_REVIEW_THREADS"
+	assert_gate_blocker "effective-rules API failure with unresolved human thread fails closed" human_rules_error 1 ""
+	assert_gate_blocker "malformed effective-rules response with unresolved human thread fails closed" human_rules_malformed 1 ""
 	return 0
 }
 
@@ -352,7 +374,8 @@ assert_review_and_head_snapshot_cases() {
 		TESTS_FAILED=$((TESTS_FAILED + 1))
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
-	assert_gate "unresolved late inline finding blocks merge" unresolved 1
+	assert_gate_blocker "unresolved late inline finding blocks merge" unresolved 1 "$PMRC_BLOCKER_REVIEW_BOT_THREADS"
+	assert_gate_blocker "paginated review-thread snapshot fails closed without actionable remediation" review_threads_paginated 1 ""
 	assert_human_review_thread_rules
 	assert_gate "late review activity invalidates stale gate success" stale_gate 1
 	set_live_evidence PASS sha-reviewed trusted true 2026-01-01T00:00:50Z

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -10,6 +10,8 @@ MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
 TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
+PMRC_BLOCKER_REVIEW_BOT_THREADS="review-bot-threads"
+PMRC_BLOCKER_REQUIRED_REVIEW_THREADS="required-review-threads"
 
 print_result() {
 	local test_name="$1"
@@ -38,14 +40,17 @@ setup_test_env() {
 	cat >"${TEST_ROOT}/scripts/pr-review-thread-response-scanner.sh" <<'SCANNER'
 #!/usr/bin/env bash
 printf 'include_human=%s args=%s\n' "${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN:-false}" "$*" >>"${SCANNER_LOG:?}"
-exit 0
+exit "${SCANNER_RC:-0}"
 SCANNER
 	chmod +x "${TEST_ROOT}/scripts/pr-review-thread-response-scanner.sh"
 	: >"$LOGFILE"
 	: >"$SCANNER_LOG"
 	_PULSE_MERGE_DIR="${TEST_ROOT}/scripts"
 	_OW_LABEL_PAT=",origin:worker,"
+	export SCANNER_RC=0
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
 	unset AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST
+	unset DRY_RUN
 	return 0
 }
 
@@ -58,7 +63,7 @@ teardown_test_env() {
 }
 
 define_helpers_under_test() {
-	local src_repo_path="" src_dispatch="" src_maybe_dispatch="" src_enabled="" src_changes_gate=""
+	local src_repo_path="" src_dispatch="" src_maybe_dispatch="" src_preflight_dispatch="" src_enabled="" src_changes_gate=""
 	src_repo_path=$(awk '
 		/^_pulse_merge_repo_path_for_slug\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$MERGE_SCRIPT")
@@ -68,13 +73,16 @@ define_helpers_under_test() {
 	src_maybe_dispatch=$(awk '
 		/^_pulse_merge_maybe_dispatch_review_thread_remediation\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$MERGE_SCRIPT")
+	src_preflight_dispatch=$(awk '
+		/^_pulse_merge_maybe_dispatch_preflight_remediation\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$MERGE_SCRIPT")
 	src_enabled=$(awk '
 		/^_pulse_merge_changes_requested_thread_remediation_first_enabled\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$MERGE_SCRIPT")
 	src_changes_gate=$(awk '
 		/^_handle_changes_requested_review_gate\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$MERGE_SCRIPT")
-	if [[ -z "$src_repo_path" || -z "$src_dispatch" || -z "$src_maybe_dispatch" || -z "$src_enabled" || -z "$src_changes_gate" ]]; then
+	if [[ -z "$src_repo_path" || -z "$src_dispatch" || -z "$src_maybe_dispatch" || -z "$src_preflight_dispatch" || -z "$src_enabled" || -z "$src_changes_gate" ]]; then
 		printf 'ERROR: could not extract helpers from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
 	fi
@@ -85,9 +93,119 @@ define_helpers_under_test() {
 	# shellcheck disable=SC1090
 	eval "$src_maybe_dispatch"
 	# shellcheck disable=SC1090
+	eval "$src_preflight_dispatch"
+	# shellcheck disable=SC1090
 	eval "$src_enabled"
 	# shellcheck disable=SC1090
 	eval "$src_changes_gate"
+	return 0
+}
+
+test_review_bot_preflight_blocker_dispatches_and_is_consumed() {
+	setup_test_env
+	define_helpers_under_test || {
+		teardown_test_env
+		return 0
+	}
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REVIEW_BOT_THREADS"
+
+	_pulse_merge_maybe_dispatch_preflight_remediation 77 owner/repo
+
+	if grep -q 'include_human=true args=dispatch-pr owner/repo' "$SCANNER_LOG" &&
+		grep -q ' 77$' "$SCANNER_LOG" &&
+		grep -q 'after unresolved review-bot thread preflight blocker' "$LOGFILE" &&
+		[[ -z "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]]; then
+		print_result "typed review-bot preflight blocker queues and consumes remediation" 0
+	else
+		print_result "typed review-bot preflight blocker queues and consumes remediation" 1 \
+			"marker=${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-<none>}, scanner=$(tr '\n' ';' <"$SCANNER_LOG"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_required_review_thread_preflight_blocker_dispatches() {
+	setup_test_env
+	define_helpers_under_test || {
+		teardown_test_env
+		return 0
+	}
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REQUIRED_REVIEW_THREADS"
+
+	_pulse_merge_maybe_dispatch_preflight_remediation 77 owner/repo
+
+	if grep -q 'include_human=true args=dispatch-pr owner/repo' "$SCANNER_LOG" &&
+		grep -q 'after required unresolved review-thread preflight blocker' "$LOGFILE" &&
+		[[ -z "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]]; then
+		print_result "typed required-thread preflight blocker queues remediation" 0
+	else
+		print_result "typed required-thread preflight blocker queues remediation" 1 \
+			"marker=${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-<none>}, scanner=$(tr '\n' ';' <"$SCANNER_LOG"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_unrelated_preflight_blocker_does_not_dispatch() {
+	setup_test_env
+	define_helpers_under_test || {
+		teardown_test_env
+		return 0
+	}
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="required-checks"
+
+	_pulse_merge_maybe_dispatch_preflight_remediation 77 owner/repo
+
+	if [[ ! -s "$SCANNER_LOG" && -z "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]]; then
+		print_result "unrelated preflight blocker is consumed without review remediation" 0
+	else
+		print_result "unrelated preflight blocker is consumed without review remediation" 1 \
+			"marker=${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-<none>}, scanner=$(tr '\n' ';' <"$SCANNER_LOG")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_failed_preflight_dispatch_stays_blocked_and_consumes_marker() {
+	setup_test_env
+	export SCANNER_RC=1
+	define_helpers_under_test || {
+		teardown_test_env
+		return 0
+	}
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REQUIRED_REVIEW_THREADS"
+
+	_pulse_merge_maybe_dispatch_preflight_remediation 77 owner/repo
+
+	if grep -q 'review-thread remediation dispatch failed for PR #77 in owner/repo' "$LOGFILE" &&
+		[[ -z "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]]; then
+		print_result "failed or deduplicated preflight dispatch consumes typed marker" 0
+	else
+		print_result "failed or deduplicated preflight dispatch consumes typed marker" 1 \
+			"marker=${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-<none>}, log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dry_run_preflight_blocker_never_dispatches() {
+	setup_test_env
+	DRY_RUN=1
+	define_helpers_under_test || {
+		teardown_test_env
+		return 0
+	}
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REVIEW_BOT_THREADS"
+
+	_pulse_merge_maybe_dispatch_preflight_remediation 77 owner/repo
+
+	if [[ ! -s "$SCANNER_LOG" && -z "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]]; then
+		print_result "dry-run consumes preflight blocker without write dispatch" 0
+	else
+		print_result "dry-run consumes preflight blocker without write dispatch" 1 \
+			"marker=${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-<none>}, scanner=$(tr '\n' ';' <"$SCANNER_LOG")"
+	fi
+	teardown_test_env
 	return 0
 }
 
@@ -334,6 +452,11 @@ test_changes_requested_label_read_failure_does_not_route() {
 }
 
 main() {
+	test_review_bot_preflight_blocker_dispatches_and_is_consumed
+	test_required_review_thread_preflight_blocker_dispatches
+	test_unrelated_preflight_blocker_does_not_dispatch
+	test_failed_preflight_dispatch_stays_blocked_and_consumes_marker
+	test_dry_run_preflight_blocker_never_dispatches
 	test_unresolved_conversation_dispatches_targeted_human_thread_remediation
 	test_repo_path_lookup_ignores_slug_case
 	test_other_merge_failures_do_not_dispatch_review_thread_remediation

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -55,6 +55,10 @@ setup_test_env() {
 	MERGE_EVENT_LOG="${TEST_ROOT}/merge-events.log"
 	: >"$MERGE_EVENT_LOG"
 	export TEST_ROOT GH_LOG REMEDIATION_LOG MERGE_EVENT_LOG
+	FINAL_GATE_RC=0
+	FINAL_GATE_BLOCKER_KIND=""
+	PREFLIGHT_REMEDIATION_CALLS=0
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
 
 cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
@@ -185,7 +189,11 @@ _check_ruleset_required_reviews_passing() { return 0; }
 _extract_merge_summary() { printf 'summary'; return 0; }
 _retarget_stacked_children() { return 0; }
 _pulse_merge_admin_safety_check() { return 0; }
-_pulse_merge_final_trust_gate() { _PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE=0; return 0; }
+_pulse_merge_final_trust_gate() {
+	_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE=0
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="${FINAL_GATE_BLOCKER_KIND:-}"
+	return "${FINAL_GATE_RC:-0}"
+}
 _set_native_auto_merge_or_skip() { return 1; }
 _repo_allows_auto_merge() { return "${REPO_ALLOWS_AUTO_MERGE_RC:-0}"; }
 _attempt_existing_auto_merge_behind_update_branch() { return 1; }
@@ -212,6 +220,16 @@ _pulse_merge_maybe_dispatch_review_thread_remediation() {
 	local repo_slug="$2"
 	local merge_output="$3"
 	printf 'pr=%s repo=%s\n%s\n' "$pr_number" "$repo_slug" "$merge_output" >>"${REMEDIATION_LOG:?}"
+	return 0
+}
+
+_pulse_merge_maybe_dispatch_preflight_remediation() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	PREFLIGHT_REMEDIATION_CALLS=$((PREFLIGHT_REMEDIATION_CALLS + 1))
+	printf 'preflight pr=%s repo=%s blocker=%s\n' \
+		"$pr_number" "$repo_slug" "${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-}" >>"${REMEDIATION_LOG:?}"
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
 	return 0
 }
 
@@ -532,6 +550,36 @@ test_ruleset_fallback_failure_preserves_admin_conversation_context() {
 	return 0
 }
 
+test_final_preflight_thread_blocker_dispatches_before_merge() {
+	setup_test_env
+	define_function_under_test || {
+		teardown_test_env
+		return 0
+	}
+	FINAL_GATE_RC=1
+	FINAL_GATE_BLOCKER_KIND="required-review-threads"
+
+	local pr_obj='{"number":77,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test","headRefOid":"head-current"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 1 ]]; then
+		print_result "final preflight thread blocker defers merge" 1 \
+			"Expected 1, got ${result}; log: $(tr '\n' ';' <"$LOGFILE")"
+	elif [[ "$PREFLIGHT_REMEDIATION_CALLS" -ne 1 ]] ||
+		! grep -qF 'preflight pr=77 repo=owner/repo blocker=required-review-threads' "$REMEDIATION_LOG"; then
+		print_result "final preflight thread blocker dispatches remediation" 1 \
+			"calls=${PREFLIGHT_REMEDIATION_CALLS}; remediation=$(tr '\n' ';' <"$REMEDIATION_LOG")"
+	elif grep -qE '^gh pr merge ' "$GH_LOG"; then
+		print_result "final preflight thread blocker prevents merge write" 1 \
+			"gh log: $(tr '\n' ';' <"$GH_LOG")"
+	else
+		print_result "final preflight thread blocker dispatches before merge write" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
 main() {
 	test_ruleset_violation_enables_auto_merge_without_admin
 	test_ruleset_violation_skips_native_auto_merge_when_disabled
@@ -539,6 +587,7 @@ main() {
 	test_draft_pr_without_origin_labels_skips_merge_write
 	test_expected_required_check_updates_branch_and_defers
 	test_pending_required_check_updates_branch_and_defers
+	test_final_preflight_thread_blocker_dispatches_before_merge
 	test_stale_cache_401_retries_admin_merge_once
 	test_ruleset_fallback_failure_preserves_admin_conversation_context
 


### PR DESCRIPTION
## Summary

- Export typed preflight blocker outcomes for unresolved review-bot threads and required unresolved human threads.
- Consume those outcomes in merge orchestration after final trust-gate failure and dispatch the existing bounded review-thread remediation scanner.
- Preserve read-only snapshot evaluation, fail-closed malformed/paginated policy handling, scanner deduplication, and zero writes in dry-run mode.

## Root Cause

The required-thread snapshot gate returned only a generic failure. Its caller therefore could not distinguish an actionable review-thread blocker from unrelated trust, policy, or CI failures, so otherwise eligible PRs remained blocked without scheduling remediation.

## Files Changed

- `.agents/scripts/pulse-merge-required-checks.sh`: reset and publish typed review-thread blocker markers.
- `.agents/scripts/pulse-merge.sh`: consume markers after each final trust-gate failure and route only recognized review-thread outcomes.
- `.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh`: cover bot/human markers, reset behavior, malformed rules, and pagination.
- `.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh`: cover dispatch, unrelated blockers, failed dispatch, marker consumption, and dry-run safety.
- `.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh`: prove final preflight failure dispatches remediation before any merge write.

## Safety

- Snapshot helpers remain read-only.
- The marker is cleared before each snapshot/final gate and consumed before dispatch, preventing stale reasons from affecting later PRs or retries.
- Unknown blockers never dispatch review remediation.
- Dispatch failure leaves the merge blocked and relies on the scanner's existing role and deduplication controls.

## Verification

- `bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh` — 76 passed, 0 failed.
- `bash .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh` — 15 passed, 0 failed.
- `bash .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh` — 10 passed, 0 failed.
- `bash .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh` — 17 passed, 0 failed.
- `.agents/scripts/linters-local.sh` — all local checks passed; ShellCheck reported zero warnings.

Resolves #28265
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 14h 37m and 2,323,943 tokens on this with the user in an interactive session.