### PR TITLE
GH#28324: fix review-decision backlog enrichment

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -254,6 +254,46 @@ _pmp_refresh_unknown_review_decision_into() {
 	return 0
 }
 
+# Resolve unknown review decisions once before backlog logging and sorting.
+# Both consumers classify the full PR list, so network refreshes inside the
+# classifier would otherwise run twice per unknown PR in one merge pass.
+# Args: $1=repo slug, $2=PR JSON array
+_pmp_enrich_prs_with_review_decisions() {
+	local repo_slug="$1"
+	local pr_json="$2"
+	local enriched_json="$pr_json"
+	local pr_count=""
+	local i=0
+
+	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+	if [[ -z "$repo_slug" || "$pr_count" -eq 0 ]]; then
+		printf '%s' "$pr_json"
+		return 0
+	fi
+
+	while [[ "$i" -lt "$pr_count" ]]; do
+		local pr_obj="" number="" review_decision=""
+		pr_obj=$(printf '%s' "$enriched_json" | jq -c --argjson index "$i" '.[$index]' 2>/dev/null) || pr_obj=""
+		if [[ -n "$pr_obj" ]]; then
+			number=$(printf '%s' "$pr_obj" | jq -r '.number // ""' 2>/dev/null) || number=""
+			review_decision=$(printf '%s' "$pr_obj" | jq -r 'if ((has("reviewDecision") | not) or .reviewDecision == null or (.reviewDecision | tostring | length) == 0) then "UNKNOWN" else .reviewDecision end' 2>/dev/null) || review_decision="UNKNOWN"
+			_pmp_normalize_review_decision_into review_decision "$review_decision"
+			if [[ "$number" =~ ^[0-9]+$ ]] && _pmp_review_decision_is_unknown "$review_decision"; then
+				_pmp_refresh_unknown_review_decision_into review_decision "$number" "$repo_slug" "$review_decision"
+				enriched_json=$(printf '%s' "$enriched_json" | jq --argjson index "$i" --arg review "$review_decision" '.[$index].reviewDecision = $review' 2>/dev/null) || {
+					printf '%s' "$pr_json"
+					return 0
+				}
+			fi
+		fi
+		i=$((i + 1))
+	done
+
+	printf '%s' "$enriched_json"
+	return 0
+}
+
 #######################################
 # Classify one PR object into a scheduling/observability backlog bucket.
 # This is intentionally advisory: it never decides merge eligibility. The
@@ -280,11 +320,9 @@ _pmp_classify_pr_backlog_state() {
 
 	[[ "$failed_count" =~ ^[0-9]+$ ]] || failed_count=0
 	[[ "$pending_count" =~ ^[0-9]+$ ]] || pending_count=0
-	if [[ "$failed_count" -gt 0 && -n "$repo_slug" && "$number" =~ ^[0-9]+$ ]] && _pmp_review_decision_is_unknown "$review_decision"; then
-		_pmp_refresh_unknown_review_decision_into review_decision "$number" "$repo_slug" "$review_decision"
-	fi
 
-	if [[ "$is_draft" == "true" || ",${labels}," == *",hold-for-review,"* || "$review_decision" == "CHANGES_REQUESTED" ]]; then
+	if [[ "$is_draft" == "true" || ",${labels}," == *",hold-for-review,"* || "$review_decision" == "CHANGES_REQUESTED" ]] ||
+		_pmp_review_decision_is_unknown "$review_decision"; then
 		printf '%s' "$_PMP_BACKLOG_HUMAN_APPROVAL_NEEDED"
 		return 0
 	fi
@@ -493,6 +531,7 @@ _merge_ready_prs_for_repo() {
 	fi
 
 	pr_json=$(_pmp_enrich_prs_with_rest_check_status "$repo_slug" "$pr_json")
+	pr_json=$(_pmp_enrich_prs_with_review_decisions "$repo_slug" "$pr_json")
 
 	_pmp_log_pr_backlog_counts "$repo_slug" "$pr_json"
 	pr_json=$(_pmp_sort_prs_by_backlog_priority "$pr_json" "$repo_slug")

--- a/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
@@ -49,13 +49,21 @@ set +e
 set +o pipefail 2>/dev/null || true
 
 REFRESHED_REVIEW_DECISION="CHANGES_REQUESTED"
+REFRESH_SHOULD_FAIL=0
 : >"${TEST_TMPDIR}/review-refresh.log"
 gh_pr_view() {
 	local pr_number="$1" repo_flag="$2" repo_slug="$3"
 	[[ -n "$pr_number$repo_flag$repo_slug" ]]
 	printf '%s|%s|%s\n' "$pr_number" "$repo_flag" "$repo_slug" >>"${TEST_TMPDIR}/review-refresh.log"
+	[[ "$REFRESH_SHOULD_FAIL" -eq 0 ]] || return 1
 	printf '%s\n' "$REFRESHED_REVIEW_DECISION"
 	return 0
+}
+
+gh() {
+	local subcommand="$1"
+	[[ -n "$subcommand" ]]
+	return 1
 }
 
 printf '%s=== GH#22303: PR backlog priority tests ===%s\n' "$TEST_BLUE" "$TEST_NC"
@@ -65,6 +73,7 @@ legacy_success_pr='{"number":6,"mergeable":"MERGEABLE","reviewDecision":"APPROVE
 checks_in_progress_pr='{"number":2,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"statusCheckRollup":[{"status":"IN_PROGRESS","conclusion":null}]}'
 small_fix_pr='{"number":3,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}'
 unknown_review_failed_pr='{"number":7,"mergeable":"MERGEABLE","reviewDecision":null,"isDraft":false,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}'
+unknown_review_passing_pr='{"number":8,"mergeable":"MERGEABLE","reviewDecision":null,"isDraft":false,"labels":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
 dirty_pr='{"number":4,"mergeable":"CONFLICTING","reviewDecision":"APPROVED","isDraft":false,"labels":[],"statusCheckRollup":[]}'
 human_pr='{"number":5,"mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","isDraft":false,"labels":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
 
@@ -78,14 +87,33 @@ assert_eq "1c: failed checks classify as small-fix-needed" \
 	"small-fix-needed" "$(_pmp_classify_pr_backlog_state "$small_fix_pr")"
 : >"${TEST_TMPDIR}/review-refresh.log"
 REFRESHED_REVIEW_DECISION="CHANGES_REQUESTED"
-assert_eq "1c.1: failed checks with unknown reviewDecision refresh to human-approval-needed" \
-	"human-approval-needed" "$(_pmp_classify_pr_backlog_state "$unknown_review_failed_pr" "owner/repo")"
-assert_eq "1c.2: unknown reviewDecision classification performs one authoritative refresh" \
+REFRESH_SHOULD_FAIL=0
+enriched_review_json=$(_pmp_enrich_prs_with_review_decisions "owner/repo" "[$unknown_review_passing_pr]")
+enriched_review_pr=$(printf '%s' "$enriched_review_json" | jq -c '.[0]')
+assert_eq "1c.1: passing checks with refreshed CHANGES_REQUESTED classify as human-approval-needed" \
+	"human-approval-needed" "$(_pmp_classify_pr_backlog_state "$enriched_review_pr")"
+assert_eq "1c.2: passing unknown reviewDecision performs one authoritative enrichment refresh" \
 	"1" "$(wc -l <"${TEST_TMPDIR}/review-refresh.log" | tr -d '[:space:]')"
 : >"${TEST_TMPDIR}/review-refresh.log"
 REFRESHED_REVIEW_DECISION="NONE"
-assert_eq "1c.3: failed checks with refreshed NONE stay small-fix-needed" \
-	"small-fix-needed" "$(_pmp_classify_pr_backlog_state "$unknown_review_failed_pr" "owner/repo")"
+enriched_review_json=$(_pmp_enrich_prs_with_review_decisions "owner/repo" "[$unknown_review_passing_pr]")
+enriched_review_pr=$(printf '%s' "$enriched_review_json" | jq -c '.[0]')
+assert_eq "1c.3: passing checks with refreshed NONE classify as merge-ready" \
+	"merge-ready" "$(_pmp_classify_pr_backlog_state "$enriched_review_pr")"
+REFRESH_SHOULD_FAIL=1
+enriched_review_json=$(_pmp_enrich_prs_with_review_decisions "owner/repo" "[$unknown_review_passing_pr]")
+enriched_review_pr=$(printf '%s' "$enriched_review_json" | jq -c '.[0]')
+assert_eq "1c.4: failed review refresh preserves conservative human-approval classification" \
+	"human-approval-needed" "$(_pmp_classify_pr_backlog_state "$enriched_review_pr")"
+assert_eq "1c.5: failed review refresh preserves UNKNOWN state" \
+	"UNKNOWN" "$(printf '%s' "$enriched_review_pr" | jq -r '.reviewDecision')"
+REFRESH_SHOULD_FAIL=0
+: >"${TEST_TMPDIR}/review-refresh.log"
+enriched_review_json=$(_pmp_enrich_prs_with_review_decisions "owner/repo" "[$unknown_review_failed_pr,$unknown_review_passing_pr]")
+_pmp_log_pr_backlog_counts "owner/repo" "$enriched_review_json"
+_pmp_sort_prs_by_backlog_priority "$enriched_review_json" "owner/repo" >/dev/null
+assert_eq "1c.6: log plus sort do not repeat per-pass authoritative refreshes" \
+	"2" "$(wc -l <"${TEST_TMPDIR}/review-refresh.log" | tr -d '[:space:]')"
 assert_eq "1d: conflicting PR classifies as dirty-conflicted" \
 	"dirty-conflicted" "$(_pmp_classify_pr_backlog_state "$dirty_pr")"
 assert_eq "1e: changes requested classifies as human-approval-needed" \
@@ -96,6 +124,7 @@ sorted_numbers=$(_pmp_sort_prs_by_backlog_priority "$unsorted_json" | jq -r '[.[
 assert_eq "2: backlog sort processes merge-ready then fix-needed before lower-value buckets" \
 	"1,3,2,4,5" "$sorted_numbers"
 
+: >"$LOGFILE"
 _pmp_log_pr_backlog_counts "owner/repo" "$unsorted_json"
 log_line=$(grep 'PR backlog owner/repo:' "$LOGFILE" 2>/dev/null || true)
 assert_eq "3: backlog log exposes all category counts" \


### PR DESCRIPTION
## Summary

Resolve unknown review decisions once per pulse pass before backlog logging and sorting; preserve unresolved state as human-approval-needed

## Files Changed

.agents/scripts/pulse-merge-process.sh, .agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 14 backlog-priority tests pass; ShellCheck and bash syntax clean; linters-local.sh passes

Resolves #28324


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1h 43m and 1,017,928 tokens on this with the user in an interactive session.