### PR TITLE
GH#28317: make gate refresh transactional

### DIFF
--- a/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
@@ -23,9 +23,8 @@
 #   G. GH#24546/GH#24958 private-org CONTRIBUTOR/COLLABORATOR fallback uses authenticated
 #      collaborator permission metadata and fails closed.
 #
-# Workflow execution cannot be tested locally — this is a static shape
-# check that prevents accidental regressions to the exemption logic
-# during refactoring. CI is the authoritative runtime test.
+# Static shape checks cover the shared trust rules. Job 3's inline shell is also
+# executed below with mocked REST metadata, status publication, and rerun APIs.
 #
 # NOTE: not using `set -e` — assertions capture non-zero exits.
 
@@ -54,6 +53,8 @@ print_result() {
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/maintainer-gate-reusable.yml"
+TEST_TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/test-maintainer-gate-job3-XXXXXX")
+trap 'rm -rf "$TEST_TMP_ROOT"' EXIT
 
 if [[ ! -f "$WORKFLOW_FILE" ]]; then
 	print_result "workflow file exists" 1 "not found: $WORKFLOW_FILE"
@@ -155,8 +156,129 @@ assert_contains "#aidevops:trust-boundary GH#24546" \
 	"trust-boundary marker documents authenticated fallback"
 assert_contains "GH#24546/GH#24958" \
 	"trust-boundary marker covers maintainer-operated collaborator fallback"
-assert_contains "authorAssociation,author" \
-	"Job 3 fetches PR author login with author association"
+assert_contains "pulls/.*PR_NUM" \
+	"Job 3 reads PR metadata from the REST pulls endpoint"
+assert_contains "author_association.*user.login.*head.sha" \
+	"Job 3 projects REST author association, login, and exact head metadata"
+if grep -q 'authorAssociation' "$WORKFLOW_FILE" 2>/dev/null; then
+	print_result "Job 3 avoids unsupported gh authorAssociation projection" 1
+else
+	print_result "Job 3 avoids unsupported gh authorAssociation projection" 0
+fi
+assert_contains "rerun_maintainer_gate_with_retry" \
+	"Job 3 defines bounded rerun scheduling"
+assert_contains "post_maintainer_gate_status_with_retry error" \
+	"Job 3 replaces unresolved pending with terminal error"
+
+# -------------------------------------------------------------------
+# Check H: execute Job 3 inline shell against mocked API fixtures
+# -------------------------------------------------------------------
+JOB3_RUN_SCRIPT=$(python3 -c 'import sys,yaml; data=yaml.safe_load(open(sys.argv[1])); print(data["jobs"]["retrigger-pr-checks"]["steps"][0]["run"])' "$WORKFLOW_FILE" 2>/dev/null || true)
+
+run_job3_fixture() {
+	local fixture_name="$1"
+	local association="$2"
+	local labels_json="$3"
+	local permission="$4"
+	local rerun_failures="$5"
+	local lookup_mode="$6"
+	local expected_rc="$7"
+	local expected_statuses="$8"
+	local expected_reruns="$9"
+	local fixture_dir="${TEST_TMP_ROOT}/${fixture_name//[^A-Za-z0-9]/-}"
+	local status_file="${fixture_dir}/statuses"
+	local rerun_file="${fixture_dir}/reruns"
+	local fixture_rc=0
+
+	rm -rf "$fixture_dir"
+	mkdir -p "$fixture_dir"
+	printf '0' >"$rerun_file"
+	(
+		export ISSUE_NUMBER=42 REPO="owner/repo" REPO_OWNER="owner"
+		export FIXTURE_ASSOCIATION="$association" FIXTURE_LABELS_JSON="$labels_json"
+		export FIXTURE_PERMISSION="$permission" FIXTURE_RERUN_FAILURES="$rerun_failures"
+		export FIXTURE_LOOKUP_MODE="$lookup_mode" FIXTURE_STATUS_FILE="$status_file"
+		export FIXTURE_RERUN_FILE="$rerun_file"
+		gh() {
+			local command="${1:-}"
+			local subcommand="${2:-}"
+			shift 2 2>/dev/null || true
+			local args="$*"
+			if [[ "$command" == "pr" && "$subcommand" == "list" ]]; then
+				printf '%s\n' '[{"number":101,"body":"Resolves #42","title":"fixture"}]'
+				return 0
+			fi
+			if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/pulls/101" ]]; then
+				printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head"}\n' \
+					"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
+				return 0
+			fi
+			if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/collaborators/fixture-author/permission" ]]; then
+				printf '%s\n' "$FIXTURE_PERMISSION"
+				return 0
+			fi
+			if [[ "$command" == "api" && "$subcommand" == repos/owner/repo/statuses/* ]]; then
+				local status=""
+				case "$args" in
+				*"state=success"*) status="success" ;;
+				*"state=pending"*) status="pending" ;;
+				*"state=error"*) status="error" ;;
+				esac
+				[[ -n "$status" ]] && printf '%s\n' "$status" >>"$FIXTURE_STATUS_FILE"
+				return 0
+			fi
+			if [[ "$command" == "api" && "$subcommand" == repos/owner/repo/actions/workflows/maintainer-gate.yml/runs* ]]; then
+				if [[ "$FIXTURE_LOOKUP_MODE" == "missing" ]]; then
+					return 0
+				fi
+				printf '501\tcompleted\n'
+				return 0
+			fi
+			if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/actions/runs/501/rerun" ]]; then
+				local rerun_count=0
+				rerun_count=$(<"$FIXTURE_RERUN_FILE")
+				rerun_count=$((rerun_count + 1))
+				printf '%s' "$rerun_count" >"$FIXTURE_RERUN_FILE"
+				[[ "$rerun_count" -gt "$FIXTURE_RERUN_FAILURES" ]]
+				return $?
+			fi
+			return 1
+		}
+		sleep() {
+			local seconds="$1"
+			[[ -n "$seconds" ]]
+			return 0
+		}
+		export -f gh sleep
+		bash -c "$JOB3_RUN_SCRIPT"
+	) >/dev/null 2>&1 || fixture_rc=$?
+
+	local actual_statuses=""
+	local actual_reruns=0
+	[[ -s "$status_file" ]] && actual_statuses=$(sort -u "$status_file" | tr '\n' ',' | sed 's/,$//')
+	[[ -s "$rerun_file" ]] && actual_reruns=$(<"$rerun_file")
+	if [[ "$fixture_rc" -eq "$expected_rc" && "$actual_statuses" == "$expected_statuses" && "$actual_reruns" -eq "$expected_reruns" ]]; then
+		print_result "Job 3 fixture: $fixture_name" 0
+	else
+		print_result "Job 3 fixture: $fixture_name" 1 \
+			"rc=$fixture_rc statuses=${actual_statuses:-<empty>} reruns=$actual_reruns"
+	fi
+	rm -rf "$fixture_dir"
+	return 0
+}
+
+if [[ -z "$JOB3_RUN_SCRIPT" ]]; then
+	print_result "extracts Job 3 executable shell" 1
+else
+	print_result "extracts Job 3 executable shell" 0
+	run_job3_fixture "OWNER exemption" "OWNER" '["origin:interactive"]' "" 0 "found" 0 "success" 0
+	run_job3_fixture "MEMBER exemption" "MEMBER" '["origin:interactive"]' "" 0 "found" 0 "success" 0
+	run_job3_fixture "COLLABORATOR write exemption" "COLLABORATOR" '["origin:interactive"]' "write" 0 "found" 0 "success" 0
+	run_job3_fixture "accepted rerun" "NONE" '[]' "" 0 "found" 0 "pending" 1
+	run_job3_fixture "already-running bounded retry" "NONE" '[]' "" 2 "found" 0 "pending" 3
+	run_job3_fixture "exhausted rerun becomes terminal" "NONE" '[]' "" 3 "found" 1 "error,pending" 3
+	run_job3_fixture "missing run becomes terminal" "NONE" '[]' "" 0 "missing" 1 "error,pending" 0
+fi
 
 # -------------------------------------------------------------------
 # Summary

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -699,6 +699,46 @@ jobs:
             return 0
           }
 
+          post_maintainer_gate_status_with_retry() {
+            local state="$1"
+            local description="$2"
+
+            post_maintainer_gate_status_once "$state" "$description" 2>/dev/null \
+              || { sleep 5 && post_maintainer_gate_status_once "$state" "$description"; }
+            return $?
+          }
+
+          rerun_maintainer_gate_with_retry() {
+            local run_id="$1"
+            local pr_number="$2"
+            local attempt=1
+            local max_attempts=3
+
+            while [[ "$attempt" -le "$max_attempts" ]]; do
+              if gh api "repos/${REPO}/actions/runs/${run_id}/rerun" \
+                --method POST >/dev/null 2>&1; then
+                echo "Job 1 rerun accepted for PR #$pr_number on attempt $attempt"
+                return 0
+              fi
+              echo "::warning::Job 1 rerun attempt $attempt/$max_attempts was not accepted for PR #$pr_number"
+              attempt=$((attempt + 1))
+              [[ "$attempt" -le "$max_attempts" ]] && sleep 5
+            done
+            return 1
+          }
+
+          mark_rerun_scheduling_failure() {
+            local pr_number="$1"
+            local description="$2"
+
+            echo "::error::${description}"
+            if ! post_maintainer_gate_status_with_retry error "$description"; then
+              echo "::error::Unable to publish terminal maintainer-gate scheduling error for PR #$pr_number"
+            fi
+            RERUN_SCHEDULING_FAILED=true
+            return 0
+          }
+
           pr_author_has_maintainer_authority() {
             local author_association="$1"
             local pr_author="$2"
@@ -777,12 +817,26 @@ jobs:
 
           echo "Found PRs referencing issue #$ISSUE_NUMBER: $OPEN_PRS"
 
+          RERUN_SCHEDULING_FAILED=false
           for PR_NUM in $OPEN_PRS; do
             echo "=== Triggering Job 1 rerun for PR #$PR_NUM ==="
 
-            HEAD_SHA=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
+            #aidevops:trust-boundary GH#17671/GH#28317: use authenticated REST
+            # metadata for labels, author association, login, and exact head.
+            # Unsupported gh GraphQL projections must not silently erase trust
+            # metadata or turn an exemption into an indefinite pending status.
+            PR_INFO=""
+            if ! PR_INFO=$(gh api "repos/${REPO}/pulls/${PR_NUM}" \
+              --jq '{labels: [.labels[].name], assoc: .author_association, author: .user.login, head_sha: .head.sha}' \
+              2>/dev/null); then
+              echo "::error::Could not read REST metadata for PR #$PR_NUM"
+              RERUN_SCHEDULING_FAILED=true
+              continue
+            fi
+            HEAD_SHA=$(printf '%s' "$PR_INFO" | jq -r '.head_sha // empty' 2>/dev/null || true)
             if [[ -z "$HEAD_SHA" ]]; then
-              echo "::warning::Could not get HEAD SHA for PR #$PR_NUM — skipping"
+              echo "::error::Could not get HEAD SHA for PR #$PR_NUM from REST metadata"
+              RERUN_SCHEDULING_FAILED=true
               continue
             fi
 
@@ -800,20 +854,16 @@ jobs:
             # string-only exemption because the fallback verifies repo
             # permission before returning success.
             # -----------------------------------------------------------------
-            PR_INFO=$(gh pr view "$PR_NUM" --repo "$REPO" \
-              --json labels,authorAssociation,author \
-              --jq '{labels: [.labels[].name], assoc: .authorAssociation, author: .author.login}' \
-              2>/dev/null || true)
             PR_LABELS_J3=$(printf '%s' "$PR_INFO" | jq -r '.labels[]' 2>/dev/null || true)
             PR_AUTHOR_ASSOC_J3=$(printf '%s' "$PR_INFO" | jq -r '.assoc' 2>/dev/null || true)
             PR_AUTHOR_J3=$(printf '%s' "$PR_INFO" | jq -r '.author // empty' 2>/dev/null || true)
             if printf '%s' "$PR_LABELS_J3" | grep -q 'origin:interactive'; then
               if pr_author_has_maintainer_authority "$PR_AUTHOR_ASSOC_J3" "$PR_AUTHOR_J3"; then
                 echo "SKIP rerun: PR #$PR_NUM has origin:interactive and author is maintainer ($PR_AUTHOR_ASSOC_J3) — posting success, no Job 1 rerun needed"
-                post_maintainer_gate_status_once \
+                post_maintainer_gate_status_with_retry \
                   success \
                   "origin:interactive by maintainer — implied approval (Job 3 exemption)" \
-                  2>/dev/null || true
+                  || RERUN_SCHEDULING_FAILED=true
                 continue
               fi
             fi
@@ -849,10 +899,10 @@ jobs:
                 fi
                 if [[ "$ISSUE_TRUSTED_J3" == "true" ]]; then
                   echo "SKIP rerun: PR #$PR_NUM has origin:worker, trusted issue author ($ISSUE_AUTHOR_J3), no non-maintainer comments — posting success, no Job 1 rerun needed (t2451)"
-                  post_maintainer_gate_status_once \
+                  post_maintainer_gate_status_with_retry \
                     success \
                     "origin:worker on trusted issue — implied approval (Job 3 exemption, t2451)" \
-                    2>/dev/null || true
+                    || RERUN_SCHEDULING_FAILED=true
                   continue
                 fi
               fi
@@ -860,10 +910,13 @@ jobs:
 
             # Post pending status while Job 1 re-evaluates
             # t2037: Job 3 is pure plumbing — gate evaluation is Job 1's sole responsibility
-            post_maintainer_gate_status_once \
+            if ! post_maintainer_gate_status_with_retry \
               pending \
-              "Refreshing via Job 1 rerun..." \
-              2>/dev/null || true
+              "Refreshing via Job 1 rerun..."; then
+              echo "::error::Could not publish pending maintainer-gate status for PR #$PR_NUM"
+              RERUN_SCHEDULING_FAILED=true
+              continue
+            fi
 
             # -----------------------------------------------------------------
             # t2018 + t2037: Trigger Job 1 rerun so it re-evaluates gate
@@ -880,28 +933,34 @@ jobs:
             # Jobs 2-5 are gated on `github.event_name == 'issues'` and are
             # skipped, so only Job 1 runs in the rerun. No infinite loop risk.
             # -----------------------------------------------------------------
-            RUN_LOOKUP=$(gh api \
+            RUN_LOOKUP=""
+            if ! RUN_LOOKUP=$(gh api \
               "repos/${REPO}/actions/workflows/maintainer-gate.yml/runs?head_sha=${HEAD_SHA}&event=pull_request_target&per_page=1" \
               --jq '.workflow_runs[0] | [.id, .conclusion] | @tsv' \
-              2>/dev/null || true)
+              2>/dev/null); then
+              mark_rerun_scheduling_failure "$PR_NUM" "Maintainer-gate refresh lookup failed"
+              continue
+            fi
 
             if [[ -z "$RUN_LOOKUP" ]]; then
-              echo "No prior maintainer-gate run found for PR #$PR_NUM at $HEAD_SHA — pending status posted; will resolve on next PR push"
+              mark_rerun_scheduling_failure "$PR_NUM" "No prior maintainer-gate run found for refresh"
             else
               RUN_ID=$(printf '%s' "$RUN_LOOKUP" | cut -f1)
               if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
-                echo "::warning::Could not parse run id for PR #$PR_NUM — pending status posted"
+                mark_rerun_scheduling_failure "$PR_NUM" "Could not parse maintainer-gate run id for refresh"
               else
                 RUN_CONCLUSION=$(printf '%s' "$RUN_LOOKUP" | cut -f2)
                 echo "Triggering Job 1 rerun (run_id=$RUN_ID, prior=$RUN_CONCLUSION) for PR #$PR_NUM"
-                gh api \
-                  "repos/${REPO}/actions/runs/${RUN_ID}/rerun" \
-                  --method POST \
-                  2>/dev/null \
-                  || echo "::warning::Failed to re-run Job 1 for PR #$PR_NUM — pending status remains until next PR push"
+                if ! rerun_maintainer_gate_with_retry "$RUN_ID" "$PR_NUM"; then
+                  mark_rerun_scheduling_failure "$PR_NUM" "Maintainer-gate refresh scheduling failed after bounded retries"
+                fi
               fi
             fi
           done
+
+          if [[ "$RERUN_SCHEDULING_FAILED" == "true" ]]; then
+            exit 1
+          fi
 
   # =========================================================================
   # Job 4: Protect PR labels — re-apply needs-maintainer-review if removed


### PR DESCRIPTION
## Summary

Read Job 3 PR trust metadata from REST, retry rerun scheduling, and replace unresolved pending statuses with terminal errors

## Files Changed

.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh, .github/workflows/maintainer-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 36 Job 3 tests, 29 adjacent gate tests, Actionlint, ShellCheck, YAML parsing, and linters-local.sh pass

Resolves #28317


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2h 17m and 1,370,095 tokens on this with the user in an interactive session.