### PR TITLE
GH#28316: gate review concurrency after eligibility

### DIFF
--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -23,6 +23,8 @@
 #  12.  .agents/templates/workflows/review-bot-gate-caller.yml exists
 #  13.  Downstream caller template references marcusquinn/aidevops reusable path
 #  14.  Reusable workflow uses __aidevops/ path (runtime-fetched, no SHA pin)
+#  GH#28316-A. Both callers and the reusable workflow share one eligibility matrix
+#  GH#28316-B. Concurrency applies only to eligible caller jobs, preserving queued evaluators
 #
 # Strategy: Parse YAML + grep for structural invariants. No network calls, no GitHub API.
 # Skips gracefully if python3 / yaml module missing.
@@ -294,6 +296,138 @@ if [[ -f "$RBG_REUSABLE_WF" ]]; then
 	_pass "review-bot-gate reusable workflow file exists"
 else
 	_fail "review-bot-gate reusable workflow file exists" "missing: $RBG_REUSABLE_WF"
+fi
+
+# ---------------------------------------------------------------------------
+# Review gate eligibility/concurrency matrix (GH#28316)
+# ---------------------------------------------------------------------------
+
+if [[ ! -f "$RBG_REUSABLE_WF" || ! -f "$RBG_SELF_CALLER_WF" || ! -f "$RBG_DOWNSTREAM_TEMPLATE" ]]; then
+	_skip "review-bot eligibility and job concurrency matrix" "workflow file missing"
+elif ! command -v python3 >/dev/null 2>&1 || ! python3 -c "import yaml" 2>/dev/null; then
+	_skip "review-bot eligibility and job concurrency matrix" "python3 or pyyaml unavailable"
+else
+	eligibility_result="$(
+		python3 - "$RBG_SELF_CALLER_WF" "$RBG_DOWNSTREAM_TEMPLATE" "$RBG_REUSABLE_WF" <<'PYEOF' 2>&1
+import re
+import sys
+import yaml
+
+
+def load(path):
+    with open(path) as stream:
+        return yaml.safe_load(stream)
+
+
+def normalize(expression):
+    return re.sub(r"\s+", " ", expression or "").strip()
+
+
+self_caller, downstream, reusable = [load(path) for path in sys.argv[1:]]
+callers = (("self", self_caller), ("downstream", downstream))
+caller_expressions = []
+for name, workflow in callers:
+    if "concurrency" in workflow:
+        print(f"FAIL: {name} caller retains workflow-level concurrency")
+        sys.exit(1)
+    gate = (workflow.get("jobs") or {}).get("gate") or {}
+    concurrency = gate.get("concurrency") or {}
+    if concurrency.get("cancel-in-progress") is not False:
+        print(f"FAIL: {name} caller gate must preserve active evaluators")
+        sys.exit(1)
+    if "review-bot-gate-" not in (concurrency.get("group") or ""):
+        print(f"FAIL: {name} caller gate lacks per-PR concurrency")
+        sys.exit(1)
+    caller_expressions.append(normalize(gate.get("if")))
+
+reusable_job = (reusable.get("jobs") or {}).get("review-bot-gate") or {}
+expressions = caller_expressions + [normalize(reusable_job.get("if"))]
+if not expressions[0] or len(set(expressions)) != 1:
+    print("FAIL: self, downstream, and reusable eligibility expressions drifted")
+    sys.exit(1)
+
+expression = expressions[0]
+supported_actors = [
+    "coderabbitai",
+    "coderabbitai[bot]",
+    "gemini-code-assist",
+    "gemini-code-assist[bot]",
+    "augment-code",
+    "augment-code[bot]",
+    "augmentcode",
+    "augmentcode[bot]",
+    "copilot",
+    "copilot[bot]",
+    "github-actions[bot]",
+]
+fixtures = [
+    ("pull_request", "human", True, None, True),
+    ("pull_request_review", "human", True, None, False),
+    ("pull_request_review_comment", "copilot[bot]", True, 99, False),
+    ("issue_comment", "gemini-code-assist[bot]", False, None, False),
+    ("issue_comment", "human", True, None, False),
+]
+for actor in supported_actors:
+    fixtures.extend([
+        ("pull_request_review", actor, True, None, True),
+        ("pull_request_review_comment", actor, True, None, True),
+        ("pull_request_review_comment", actor, True, 99, False),
+        ("issue_comment", actor, True, None, True),
+    ])
+
+
+def evaluate(event_name, actor, is_pr, reply_id):
+    candidate = expression
+    replacements = {
+        "github.event.comment.in_reply_to_id": repr(reply_id),
+        "github.event.issue.pull_request": repr(is_pr),
+        "github.event_name": repr(event_name),
+        "github.actor": repr(actor),
+        "null": "None",
+        "&&": "and",
+        "||": "or",
+    }
+    for source, target in replacements.items():
+        candidate = candidate.replace(source, target)
+    if re.search(r"[^A-Za-z0-9_\s\[\]'\"().=-]", candidate):
+        raise ValueError(f"unsupported eligibility token: {candidate}")
+    return bool(eval(candidate, {"__builtins__": {}}, {}))
+
+
+for fixture in fixtures:
+    actual = evaluate(*fixture[:4])
+    if actual is not fixture[4]:
+        print(f"FAIL: eligibility fixture {fixture[:4]} => {actual}, expected {fixture[4]}")
+        sys.exit(1)
+
+# GitHub permits one active and one pending run per concurrency group. Simulate
+# an eligible evaluator followed by replacement noise ending in an inline reply:
+# only the evaluator may enter the job-level group, so it remains able to publish
+# the exact-head status from the reusable workflow's always() status step.
+burst = [
+    ("pull_request", "human", True, None, True),
+    ("issue_comment", "human", True, None, False),
+    ("pull_request_review_comment", "copilot[bot]", True, 99, False),
+]
+admitted = [fixture for fixture in burst if evaluate(*fixture[:4])]
+if len(admitted) != 1 or admitted[0] != burst[0]:
+    print(f"FAIL: replacement burst admitted ineligible events: {admitted}")
+    sys.exit(1)
+status_steps = [
+    step for step in (reusable_job.get("steps") or [])
+    if step.get("name") == "Post review-bot-gate commit status"
+]
+if len(status_steps) != 1 or status_steps[0].get("if") != "always()":
+    print("FAIL: eligible evaluator does not retain an always-run exact-head status publisher")
+    sys.exit(1)
+print("OK")
+PYEOF
+	)"
+	if [[ "$eligibility_result" == "OK" ]]; then
+		_pass "review-bot eligibility precedes durable per-PR job concurrency"
+	else
+		_fail "review-bot eligibility precedes durable per-PR job concurrency" "$eligibility_result"
+	fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -307,8 +307,7 @@ if [[ ! -f "$RBG_REUSABLE_WF" || ! -f "$RBG_SELF_CALLER_WF" || ! -f "$RBG_DOWNST
 elif ! command -v python3 >/dev/null 2>&1 || ! python3 -c "import yaml" 2>/dev/null; then
 	_skip "review-bot eligibility and job concurrency matrix" "python3 or pyyaml unavailable"
 else
-	eligibility_result="$(
-		python3 - "$RBG_SELF_CALLER_WF" "$RBG_DOWNSTREAM_TEMPLATE" "$RBG_REUSABLE_WF" <<'PYEOF' 2>&1
+	if python3 - "$RBG_SELF_CALLER_WF" "$RBG_DOWNSTREAM_TEMPLATE" "$RBG_REUSABLE_WF" <<'PYEOF'
 import re
 import sys
 import yaml
@@ -420,13 +419,12 @@ status_steps = [
 if len(status_steps) != 1 or status_steps[0].get("if") != "always()":
     print("FAIL: eligible evaluator does not retain an always-run exact-head status publisher")
     sys.exit(1)
-print("OK")
 PYEOF
-	)"
-	if [[ "$eligibility_result" == "OK" ]]; then
+	then
 		_pass "review-bot eligibility precedes durable per-PR job concurrency"
 	else
-		_fail "review-bot eligibility precedes durable per-PR job concurrency" "$eligibility_result"
+		_fail "review-bot eligibility precedes durable per-PR job concurrency" \
+			"matrix fixture failed; see Python output above"
 	fi
 fi
 

--- a/.agents/templates/workflows/review-bot-gate-caller.yml
+++ b/.agents/templates/workflows/review-bot-gate-caller.yml
@@ -49,17 +49,44 @@ on:
     # on the Phase 2 edit that makes the placeholder a real review.
     types: [created, edited]
 
-# Do NOT cancel in-progress runs. When cancel-in-progress was true, the initial
-# pull_request:opened run was cancelled by the issue_comment:created event (fired
-# when a bot posted). The cancelled run left a permanent stale CANCELLED check on
-# the PR, making mergeStateStatus UNSTABLE even though the re-triggered run passed.
-# With cancel-in-progress: false, both runs complete. GH#2973.
-concurrency:
-  group: review-bot-gate-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: false
-
 jobs:
   gate:
+    # Apply the complete event matrix before concurrency admission. GitHub keeps
+    # only one pending run per group, so a skipped inline reply must never replace
+    # the sole queued evaluator. The reusable job repeats this as defence-in-depth.
+    if: >
+      (
+        github.event_name == 'pull_request' ||
+        (
+          (
+            github.event_name == 'pull_request_review' ||
+            (
+              github.event_name == 'pull_request_review_comment' &&
+              github.event.comment.in_reply_to_id == null
+            ) ||
+            (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+          ) &&
+          (
+            github.actor == 'coderabbitai' ||
+            github.actor == 'coderabbitai[bot]' ||
+            github.actor == 'gemini-code-assist' ||
+            github.actor == 'gemini-code-assist[bot]' ||
+            github.actor == 'augment-code' ||
+            github.actor == 'augment-code[bot]' ||
+            github.actor == 'augmentcode' ||
+            github.actor == 'augmentcode[bot]' ||
+            github.actor == 'copilot' ||
+            github.actor == 'copilot[bot]' ||
+            github.actor == 'github-actions[bot]'
+          )
+        )
+      )
+    # Do not cancel an active evaluator (GH#2973). Job-level placement is
+    # required: ineligible workflow events skip before entering this group and
+    # therefore cannot displace its one pending eligible run (GH#28316).
+    concurrency:
+      group: review-bot-gate-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: false
     uses: marcusquinn/aidevops/.github/workflows/review-bot-gate-reusable.yml@main
     with:
       # Keep this equal to the ref on `uses:` so helper code is pinned with the reusable YAML.

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -4,8 +4,8 @@ name: Review Bot Gate (reusable)
 # See: .agents/templates/workflows/review-bot-gate-caller.yml
 # See: .agents/reference/reusable-workflows.md
 #
-# The caller declares the triggers (pull_request / pull_request_review / issue_comment)
-# and the concurrency group. All gate logic lives here; the framework helper
+# The caller declares the triggers, eligibility guard, and job-level concurrency
+# group. This workflow repeats eligibility as defence-in-depth; the framework helper
 # is fetched at runtime via the coupled aidevops_repository/aidevops_ref inputs.
 #
 # GH#20727: migrated from vendored full-copy (SHA-pinned checkout) to
@@ -65,7 +65,8 @@ jobs:
     # Only run on PRs (issue_comment fires for PR comments too).
     # GH#27137: bot review submissions and inline comments must re-evaluate the
     # gate. Human replies cannot change AI-review evidence and must not replace
-    # a successful exact-head check with an API-quota failure.
+    # a successful exact-head check with an API-quota failure. Keep this matrix
+    # identical to both callers; tests enforce parity (GH#28316).
     if: >
       (
         github.event_name == 'pull_request' ||

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -32,34 +32,44 @@ on:
     # not on the Phase 2 edit that makes the placeholder a real review.
     types: [created, edited]
 
-# Do NOT cancel in-progress runs. When cancel-in-progress was true, the initial
-# pull_request:opened run was cancelled by the issue_comment:created event (fired
-# when a bot posted). The cancelled run left a permanent stale CANCELLED check on
-# the PR, making mergeStateStatus UNSTABLE even though the re-triggered run passed.
-# With cancel-in-progress: false, both runs complete — the first passes early
-# (PR too young) and the second confirms the bot posted. GH#2973.
-concurrency:
-  group: review-bot-gate-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: false
-
 jobs:
   gate:
-    # issue_comment fires for every PR comment/edit. Only bot review comments can
-    # change this gate's verdict; maintainer/user discussion should be skipped
-    # before the reusable workflow starts so it does not create mobile run noise.
+    # Apply the complete event matrix before concurrency admission. GitHub keeps
+    # only one pending run per group, so a skipped inline reply must never replace
+    # the sole queued evaluator. The reusable job repeats this as defence-in-depth.
     if: >
-      github.event_name != 'issue_comment' ||
       (
-        github.event.issue.pull_request &&
+        github.event_name == 'pull_request' ||
         (
-          github.actor == 'coderabbitai' ||
-          github.actor == 'gemini-code-assist[bot]' ||
-          github.actor == 'augment-code[bot]' ||
-          github.actor == 'augmentcode[bot]' ||
-          github.actor == 'copilot[bot]' ||
-          github.actor == 'github-actions[bot]'
+          (
+            github.event_name == 'pull_request_review' ||
+            (
+              github.event_name == 'pull_request_review_comment' &&
+              github.event.comment.in_reply_to_id == null
+            ) ||
+            (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+          ) &&
+          (
+            github.actor == 'coderabbitai' ||
+            github.actor == 'coderabbitai[bot]' ||
+            github.actor == 'gemini-code-assist' ||
+            github.actor == 'gemini-code-assist[bot]' ||
+            github.actor == 'augment-code' ||
+            github.actor == 'augment-code[bot]' ||
+            github.actor == 'augmentcode' ||
+            github.actor == 'augmentcode[bot]' ||
+            github.actor == 'copilot' ||
+            github.actor == 'copilot[bot]' ||
+            github.actor == 'github-actions[bot]'
+          )
         )
       )
+    # Do not cancel an active evaluator (GH#2973). Job-level placement is
+    # required: ineligible workflow events skip before entering this group and
+    # therefore cannot displace its one pending eligible run (GH#28316).
+    concurrency:
+      group: review-bot-gate-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: false
     uses: ./.github/workflows/review-bot-gate-reusable.yml
     # Self-modifying gate PRs must exercise their own helper revision. Without
     # this, the reusable workflow fetches main and cannot validate a new helper


### PR DESCRIPTION
## Summary

Move review-bot event eligibility onto both caller jobs before job-level concurrency admission, retain the reusable guard as defense in depth, and add parity plus replacement-burst regression coverage.

## Files Changed

.agents/scripts/tests/test-reusable-workflow-caller.sh, .agents/templates/workflows/review-bot-gate-caller.yml, .github/workflows/review-bot-gate-reusable.yml, .github/workflows/review-bot-gate.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-reusable-workflow-caller.sh (26/26); actionlint on all three workflows; ShellCheck and bash -n on the test; .agents/scripts/linters-local.sh

Resolves #28316


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2h 36m and 1,568,918 tokens on this with the user in an interactive session.