### PR TITLE
GH#28280: invalidate Pulse PR-list caches after terminal changes

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -1055,10 +1055,14 @@ _close_conflicting_pr_comment_landed() {
 	if [[ -n "$merging_pr" ]]; then
 		landed_via=" (via PR #${merging_pr})"
 	fi
-	gh pr close "$pr_number" --repo "$repo_slug" \
+	if gh pr close "$pr_number" --repo "$repo_slug" \
 		--comment "Closing — this PR has merge conflicts with the base branch. The work for this task (\`${task_id}\`) has already landed on ${base_branch}${landed_via}, so no re-attempt is needed.
 
-_Closed by deterministic merge pass (pulse-wrapper.sh, GH#17574)._" 2>/dev/null || true
+_Closed by deterministic merge pass (pulse-wrapper.sh, GH#17574)._" 2>/dev/null; then
+		if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
+			_pulse_merge_invalidate_pr_list_cache "$repo_slug" "closed conflicting PR #${pr_number}"
+		fi
+	fi
 
 	# GH#17642: Do NOT auto-close the linked issue. Closing a
 	# conflicting PR is safe (PRs are cheap), but closing the ISSUE
@@ -1098,10 +1102,14 @@ _close_conflicting_pr_comment_not_landed() {
 
 	# Use standard message but without the misleading
 	# "remains open for re-attempt" phrasing (GH#17574).
-	gh pr close "$pr_number" --repo "$repo_slug" \
+	if gh pr close "$pr_number" --repo "$repo_slug" \
 		--comment "Closing — this PR has merge conflicts with the base branch. If the linked issue is still open, a worker will be dispatched to re-attempt with a fresh branch.
 
-_Closed by deterministic merge pass (pulse-wrapper.sh)._" 2>/dev/null || true
+_Closed by deterministic merge pass (pulse-wrapper.sh)._" 2>/dev/null; then
+		if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
+			_pulse_merge_invalidate_pr_list_cache "$repo_slug" "closed conflicting PR #${pr_number}"
+		fi
+	fi
 
 	echo "[pulse-wrapper] Deterministic merge: closed conflicting PR #${pr_number} in ${repo_slug}: ${pr_title}" >>"$LOGFILE"
 	return 0

--- a/.agents/scripts/pulse-merge-duplicate-consolidation.sh
+++ b/.agents/scripts/pulse-merge-duplicate-consolidation.sh
@@ -187,13 +187,17 @@ _pmp_close_superseded_sibling_pr() {
 	[[ "$superseded_pr" =~ ^[0-9]+$ && "$candidate_pr" =~ ^[0-9]+$ ]] || return 0
 	[[ "$superseded_pr" != "$candidate_pr" ]] || return 0
 
-	gh pr close "$superseded_pr" --repo "$repo_slug" \
+	if gh pr close "$superseded_pr" --repo "$repo_slug" \
 		--comment "Closing as superseded by PR #${candidate_pr} for issue #${issue_number}.
 
 Pulse selected PR #${candidate_pr} as the newest/healthiest verified worker-owned candidate for this duplicate PR group. Evidence required before this close: same linked issue (#${issue_number}), worker-owned origin labels on both PRs, no maintainer/security gate on the linked issue, and verify-issue-close-helper confirmation that PR #${candidate_pr} matches the issue scope.
 
 _Closed by deterministic merge pass duplicate-PR consolidation (m-20260508-0e27c3 task 2.4)._" \
-		2>/dev/null || true
+		2>/dev/null; then
+		if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
+			_pulse_merge_invalidate_pr_list_cache "$repo_slug" "closed duplicate PR #${superseded_pr}"
+		fi
+	fi
 	echo "[pulse-wrapper] Duplicate PR consolidation: closed PR #${superseded_pr} in ${repo_slug} as superseded by verified candidate PR #${candidate_pr} for issue #${issue_number}" >>"$LOGFILE"
 	return 0
 }

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -236,8 +236,12 @@ _close_and_label_feedback_pr() {
 	local close_comment="$3"
 	local label="$4"
 
-	gh pr close "$pr_number" --repo "$repo_slug" \
-		--comment "$close_comment" >/dev/null 2>&1 || true
+	if gh pr close "$pr_number" --repo "$repo_slug" \
+		--comment "$close_comment" >/dev/null 2>&1; then
+		if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
+			_pulse_merge_invalidate_pr_list_cache "$repo_slug" "closed feedback-routed PR #${pr_number}"
+		fi
+	fi
 	gh pr edit "$pr_number" --repo "$repo_slug" \
 		--add-label "$label" >/dev/null 2>&1 || true
 	return 0

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1163,15 +1163,59 @@ _pm_close_superseded_duplicate_pr_if_issue_solved() {
 	superseding_pr=$(_psh_find_merged_closer_for_closed_issue "$repo_slug" "$linked_issue" "$pr_number" 2>/dev/null) || superseding_pr=""
 	[[ "$superseding_pr" =~ ^[0-9]+$ ]] || return 1
 
-	_gh_with_timeout write gh pr close "$pr_number" --repo "$repo_slug" \
+	if _gh_with_timeout write gh pr close "$pr_number" --repo "$repo_slug" \
 		--comment "Closing as superseded: linked issue #${linked_issue} is already closed by merged PR #${superseding_pr}. This worker PR uses a closing keyword for the same issue, so merging it would duplicate an already-terminal fix.
 
 Intentional follow-ups should use For #${linked_issue} / Ref #${linked_issue} or an explicit follow-up/protection label instead of a closing keyword.
 
-_Closed by deterministic merge pass (GH#24399)._" 2>/dev/null || true
+_Closed by deterministic merge pass (GH#24399)._" 2>/dev/null; then
+		if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
+			_pulse_merge_invalidate_pr_list_cache "$repo_slug" "closed superseded duplicate PR #${pr_number}"
+		fi
+	fi
 	unlock_issue_after_worker "$pr_number" "$repo_slug"
 	echo "[pulse-wrapper] Merge pass: closed superseded duplicate PR #${pr_number} in ${repo_slug} — issue #${linked_issue} already closed by merged PR #${superseding_pr} (GH#24399)" >>"$LOGFILE"
 	return 0
+}
+
+#######################################
+# Invalidate repository-scoped PR-list caches after a confirmed terminal PR
+# mutation. Invalidation is best-effort and never changes merge/close outcomes.
+# Args: $1 = repository slug, $2 = audit reason
+#######################################
+_pulse_merge_invalidate_pr_list_cache() {
+	local repo_slug="$1"
+	local reason="$2"
+	declare -F pulse_pr_list_cache_invalidate_repo >/dev/null 2>&1 || return 0
+	if pulse_pr_list_cache_invalidate_repo "$repo_slug"; then
+		echo "[pulse-wrapper] PR-list cache invalidated for ${repo_slug} after ${reason} (GH#28280)" >>"$LOGFILE"
+	else
+		echo "[pulse-wrapper] PR-list cache invalidation failed for ${repo_slug} after ${reason}; fresh terminal-state guards remain active (GH#28280)" >>"$LOGFILE"
+	fi
+	return 0
+}
+
+#######################################
+# Re-read PR state without wrapper caches after a merge failure. A definitive
+# CLOSED/MERGED result proves that the cached open-list entry is stale, so evict
+# the repository cache and suppress failure remediation for terminal work.
+# Args: $1 = PR number, $2 = repository slug
+# Returns: 0 when terminal, 1 when OPEN/unknown/read failure
+#######################################
+_pulse_merge_failure_is_terminal() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local current_state=""
+	current_state=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh pr view "$pr_number" --repo "$repo_slug" \
+		--json state --jq '.state // ""' 2>/dev/null) || current_state=""
+	case "$current_state" in
+	CLOSED | closed | MERGED | merged)
+		_pulse_merge_invalidate_pr_list_cache "$repo_slug" "fresh terminal state ${current_state} for PR #${pr_number}"
+		echo "[pulse-wrapper] Deterministic merge: suppressing failed merge remediation for PR #${pr_number} in ${repo_slug} — fresh state=${current_state} is terminal (GH#28280)" >>"$LOGFILE"
+		return 0
+		;;
+	esac
+	return 1
 }
 
 #######################################
@@ -1611,6 +1655,9 @@ ${merge_output}"
 
 	if [[ $_merge_exit -eq 0 ]]; then
 		echo "[pulse-wrapper] Deterministic merge: merged PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
+			_pulse_merge_invalidate_pr_list_cache "$repo_slug" "merged PR #${pr_number}"
+		fi
 		_pmp_record_deterministic_progress_now 1 0
 	fi
 
@@ -1639,6 +1686,10 @@ ${merge_output}"
 		_handle_post_merge_actions "$pr_number" "$repo_slug" "$linked_issue" "$merge_summary" "$_ipr_labels" "$pr_base_ref_name"
 		return $?
 	else
+		if declare -F _pulse_merge_failure_is_terminal >/dev/null 2>&1 \
+			&& _pulse_merge_failure_is_terminal "$pr_number" "$repo_slug"; then
+			return 1
+		fi
 		local final_merge_output="$merge_output"
 		[[ -n "$merge_failure_context" ]] && final_merge_output="$merge_failure_context"
 		echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${final_merge_output}" >>"$LOGFILE"

--- a/.agents/scripts/pulse-pr-list-cache.sh
+++ b/.agents/scripts/pulse-pr-list-cache.sh
@@ -55,14 +55,44 @@ _pulse_pr_list_cache_key() {
 }
 
 #######################################
+# Build the repository prefix used by provider cache files. The prefix lets a
+# terminal PR mutation evict every exact-output list shape for one repository
+# while preserving cached reads for unrelated repositories.
+# Args: gh_pr_list-style argv
+# Stdout: repository cache key
+#######################################
+_pulse_pr_list_cache_repo_key() {
+	local repo_slug=""
+	local arg=""
+	local expect_repo=0
+	for arg in "$@"; do
+		if [[ "$expect_repo" -eq 1 ]]; then
+			repo_slug="$arg"
+			expect_repo=0
+			continue
+		fi
+		case "$arg" in
+		--repo | -R) expect_repo=1 ;;
+		--repo=*) repo_slug="${arg#--repo=}" ;;
+		-R?*) repo_slug="${arg#-R}" ;;
+		esac
+	done
+	[[ -n "$repo_slug" ]] || repo_slug="_implicit"
+	_pulse_pr_list_cache_key "$repo_slug"
+	return $?
+}
+
+#######################################
 # Resolve the cache path for an exact gh_pr_list argv shape.
 #######################################
 _pulse_pr_list_cache_path() {
 	local dir="${PULSE_PR_LIST_PROVIDER_CACHE_DIR:-${TMPDIR:-/tmp}/aidevops-pulse-pr-list-provider-${$}}"
+	local repo_key=""
 	local key=""
 	mkdir -p "$dir" 2>/dev/null || return 1
+	repo_key="$(_pulse_pr_list_cache_repo_key "$@")" || return 1
 	key="$(_pulse_pr_list_cache_key "$@")" || return 1
-	printf '%s/pr-list-%s.out' "$dir" "$key"
+	printf '%s/pr-list-%s-%s.out' "$dir" "$repo_key" "$key"
 	return 0
 }
 
@@ -107,6 +137,33 @@ _pulse_pr_list_cache_put() {
 	mv "$tmp" "$path" 2>/dev/null || rm -f "$tmp"
 	_pulse_pr_list_cache_record store
 	return 0
+}
+
+#######################################
+# Invalidate every provider and shared-wrapper open-PR list shape for one
+# repository. This is intentionally repository-scoped: a terminal mutation in
+# one repo must not discard reusable snapshots for unrelated repositories.
+# Args: $1 = repository slug
+#######################################
+pulse_pr_list_cache_invalidate_repo() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 1
+	local dir="${PULSE_PR_LIST_PROVIDER_CACHE_DIR:-${TMPDIR:-/tmp}/aidevops-pulse-pr-list-provider-${$}}"
+	local repo_key=""
+	local path=""
+	local rc=0
+	repo_key="$(_pulse_pr_list_cache_key "$repo_slug")" || return 1
+	if [[ -d "$dir" ]]; then
+		for path in "${dir}/pr-list-${repo_key}-"*.out; do
+			[[ -f "$path" ]] || continue
+			rm -f -- "$path" 2>/dev/null || rc=1
+		done
+	fi
+	_pulse_pr_list_cache_record invalidate
+	if declare -F gh_pr_list_cache_invalidate_repo >/dev/null 2>&1; then
+		gh_pr_list_cache_invalidate_repo "$repo_slug" || rc=1
+	fi
+	return "$rc"
 }
 
 #######################################

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -111,6 +111,35 @@ _gh_pr_list_snapshot_key() {
 }
 
 #######################################
+# Build the repository prefix used by PR-list snapshot cache files. Keeping the
+# repository hash outside the exact-argv hash allows terminal PR mutations to
+# evict every cached open-list shape for one repository without flushing other
+# repositories from the shared cache.
+# Args: gh-style argv
+# Stdout: repository cache key
+#######################################
+_gh_pr_list_snapshot_repo_key() {
+	local _repo_slug=""
+	local _arg=""
+	local _expect_repo=0
+	for _arg in "$@"; do
+		if [[ "$_expect_repo" -eq 1 ]]; then
+			_repo_slug="$_arg"
+			_expect_repo=0
+			continue
+		fi
+		case "$_arg" in
+		--repo | -R) _expect_repo=1 ;;
+		--repo=*) _repo_slug="${_arg#--repo=}" ;;
+		-R?*) _repo_slug="${_arg#-R}" ;;
+		esac
+	done
+	[[ -n "$_repo_slug" ]] || _repo_slug="_implicit"
+	_gh_pr_list_snapshot_key "$_repo_slug"
+	return $?
+}
+
+#######################################
 # Record one lightweight telemetry event for the exact gh_pr_list argv shape.
 # The shape key is the same full-argv hash used by the exact-output caches, so
 # repeated counts identify only semantics-preserving candidates for migration.
@@ -161,9 +190,10 @@ _gh_pr_list_snapshot_get() {
 	[[ "${AIDEVOPS_GH_PR_LIST_CACHE_DISABLE:-0}" == "1" ]] && return 1
 	[[ "$_ttl" =~ ^[0-9]+$ && "$_ttl" -gt 0 ]] || return 1
 	_gh_pr_list_snapshot_cacheable "$@" || { _gh_read_cache_record gh_pr_list_cache bypass; return 1; }
-	local _key _path _now _mtime _age
+	local _repo_key _key _path _now _mtime _age
+	_repo_key="$(_gh_pr_list_snapshot_repo_key "$@")" || return 1
 	_key="$(_gh_pr_list_snapshot_key "$@")"
-	_path="${AIDEVOPS_GH_PR_LIST_CACHE_DIR:-${HOME}/.aidevops/cache/gh-pr-list-snapshots}/${_key}.json"
+	_path="${AIDEVOPS_GH_PR_LIST_CACHE_DIR:-${HOME}/.aidevops/cache/gh-pr-list-snapshots}/${_repo_key}-${_key}.json"
 	[[ -f "$_path" ]] || { _gh_read_cache_record gh_pr_list_cache miss; return 1; }
 	_now=$(date +%s 2>/dev/null || printf '0')
 	_mtime=$(perl -e 'print((stat($ARGV[0]))[9] || 0)' "$_path" 2>/dev/null || printf '0')
@@ -189,16 +219,40 @@ _gh_pr_list_snapshot_put() {
 	[[ "${AIDEVOPS_GH_PR_LIST_CACHE_DISABLE:-0}" == "1" ]] && return 0
 	[[ "$_ttl" =~ ^[0-9]+$ && "$_ttl" -gt 0 ]] || return 0
 	_gh_pr_list_snapshot_cacheable "$@" || return 0
-	local _dir _key _path _tmp
+	local _dir _repo_key _key _path _tmp
 	_dir="${AIDEVOPS_GH_PR_LIST_CACHE_DIR:-${HOME}/.aidevops/cache/gh-pr-list-snapshots}"
 	mkdir -p "$_dir" 2>/dev/null || return 0
+	_repo_key="$(_gh_pr_list_snapshot_repo_key "$@")" || return 0
 	_key="$(_gh_pr_list_snapshot_key "$@")"
-	_path="${_dir}/${_key}.json"
+	_path="${_dir}/${_repo_key}-${_key}.json"
 	_tmp=$(mktemp "${_dir}/.pr-list-${_key}.XXXXXX" 2>/dev/null) || return 0
 	printf '%s' "$_body" >"$_tmp" 2>/dev/null || { rm -f "$_tmp"; return 0; }
 	mv "$_tmp" "$_path" 2>/dev/null || rm -f "$_tmp"
 	_gh_read_cache_record gh_pr_list_cache store
 	return 0
+}
+
+#######################################
+# Invalidate all cached open-PR list shapes for one repository. Terminal merge
+# and close paths call this after GitHub confirms that a PR is no longer open.
+# Args: $1 = repository slug
+#######################################
+gh_pr_list_cache_invalidate_repo() {
+	local _repo_slug="$1"
+	[[ -n "$_repo_slug" ]] || return 1
+	local _dir="${AIDEVOPS_GH_PR_LIST_CACHE_DIR:-${HOME}/.aidevops/cache/gh-pr-list-snapshots}"
+	local _repo_key=""
+	local _path=""
+	local _rc=0
+	_repo_key="$(_gh_pr_list_snapshot_key "$_repo_slug")" || return 1
+	if [[ -d "$_dir" ]]; then
+		for _path in "${_dir}/${_repo_key}-"*.json; do
+			[[ -f "$_path" ]] || continue
+			rm -f -- "$_path" 2>/dev/null || _rc=1
+		done
+	fi
+	_gh_read_cache_record gh_pr_list_cache invalidate
+	return "$_rc"
 }
 
 #######################################

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -1314,6 +1314,30 @@ unset AIDEVOPS_GH_PR_LIST_CACHE_DIR AIDEVOPS_GH_PR_LIST_CACHE_TTL
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
 : >"$AIDEVOPS_GH_API_LOG"
+export AIDEVOPS_GH_PR_LIST_CACHE_DIR="$TMP/pr-list-repo-invalidation-cache"
+export AIDEVOPS_GH_PR_LIST_CACHE_TTL=30
+gh_pr_list --repo "owner/repo" --state open --json number --limit 200 >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/repo" --state open --json number --limit 200 >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/other" --state open --json number --limit 200 >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/other" --state open --json number --limit 200 >/dev/null 2>&1 || true
+gh_pr_list_cache_invalidate_repo "owner/repo"
+gh_pr_list --repo "owner/repo" --state open --json number --limit 200 >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/other" --state open --json number --limit 200 >/dev/null 2>&1 || true
+
+invalidated_repo_calls=$(grep -cE '^api /repos/owner/repo/pulls\?' "$GH_CALLS" 2>/dev/null || true)
+preserved_repo_calls=$(grep -cE '^api /repos/owner/other/pulls\?' "$GH_CALLS" 2>/dev/null || true)
+list_invalidation_events=$(grep -c $'gh_pr_list_cache\tother\tunknown\tother\tinvalidate' "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)
+if [[ "$invalidated_repo_calls" == "2" && "$preserved_repo_calls" == "1" && "$list_invalidation_events" == "1" ]]; then
+	pass "gh_pr_list repo invalidation evicts only the mutated repository"
+else
+	fail "gh_pr_list repo invalidation evicts only the mutated repository" \
+		"invalidated_repo_calls=${invalidated_repo_calls} preserved_repo_calls=${preserved_repo_calls} invalidations=${list_invalidation_events} GH_CALLS=$(cat "$GH_CALLS") API_LOG=$(cat "$AIDEVOPS_GH_API_LOG")"
+fi
+unset AIDEVOPS_GH_PR_LIST_CACHE_DIR AIDEVOPS_GH_PR_LIST_CACHE_TTL
+
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+: >"$AIDEVOPS_GH_API_LOG"
 unset AIDEVOPS_GH_REST_FIRST_READS
 export AIDEVOPS_GH_PR_LIST_CACHE_DIR="$TMP/pr-list-empty-cache"
 export AIDEVOPS_GH_PR_LIST_CACHE_TTL=30

--- a/.agents/scripts/tests/test-pulse-merge-carry-forward-diff.sh
+++ b/.agents/scripts/tests/test-pulse-merge-carry-forward-diff.sh
@@ -120,6 +120,14 @@ GHEOF
 	return 0
 }
 
+# Production routes issue body writes through the GraphQL/REST-safe wrapper.
+# Keep this focused fixture forwarding to the local gh binary stub so the test
+# still observes the exact body passed by _carry_forward_pr_diff.
+gh_issue_edit_safe() {
+	gh issue edit "$@"
+	return $?
+}
+
 # Extract _carry_forward_pr_diff from pulse-merge.sh and eval into this shell.
 define_helper_under_test() {
 	local helper_src

--- a/.agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh
@@ -109,6 +109,12 @@ install_stubs() {
 		printf 'verify %s %s %s\n' "$linked_issue" "$superseding_pr" "$repo_slug" >>"$GH_CALL_LOG"
 		return "$TEST_VERIFY_RC"
 	}
+	_pulse_merge_invalidate_pr_list_cache() {
+		local repo_slug="$1"
+		local reason="$2"
+		printf 'invalidate %s %s\n' "$repo_slug" "$reason" >>"$GH_CALL_LOG"
+		return 0
+	}
 	return 0
 }
 
@@ -281,6 +287,7 @@ test_close_is_comment_only_and_keeps_branch() {
 	]'
 	_pmp_consolidate_duplicate_pr_groups "owner/repo" "$pr_json"
 	assert_log_contains "$GH_CALL_LOG" "pr close 701" "superseded PR close command is used"
+	assert_log_contains "$GH_CALL_LOG" "invalidate owner/repo closed duplicate PR #701" "successful duplicate close invalidates repository PR-list caches"
 	assert_log_contains "$GH_CALL_LOG" "--comment" "superseded close carries evidence comment"
 	assert_log_not_contains "$GH_CALL_LOG" "--delete-branch" "superseded close does not delete branches"
 	assert_log_not_contains "$GH_CALL_LOG" "issue close" "superseded duplicate consolidation never closes issues"

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -22,6 +22,7 @@ TEST_ROOT=""
 GH_LOG=""
 REMEDIATION_LOG=""
 MERGE_EVENT_LOG=""
+CACHE_INVALIDATION_LOG=""
 _OW_LABEL_PAT=",origin:worker,"
 
 print_result() {
@@ -41,25 +42,7 @@ print_result() {
 	return 0
 }
 
-setup_test_env() {
-	TEST_ROOT=$(mktemp -d)
-	mkdir -p "${TEST_ROOT}/bin"
-	export PATH="${TEST_ROOT}/bin:${PATH}"
-	export GH_STUB_MODE="${GH_STUB_MODE:-ruleset}"
-	export LOGFILE="${TEST_ROOT}/pulse.log"
-	: >"$LOGFILE"
-	GH_LOG="${TEST_ROOT}/gh-calls.log"
-	: >"$GH_LOG"
-	REMEDIATION_LOG="${TEST_ROOT}/remediation.log"
-	: >"$REMEDIATION_LOG"
-	MERGE_EVENT_LOG="${TEST_ROOT}/merge-events.log"
-	: >"$MERGE_EVENT_LOG"
-	export TEST_ROOT GH_LOG REMEDIATION_LOG MERGE_EVENT_LOG
-	FINAL_GATE_RC=0
-	FINAL_GATE_BLOCKER_KIND=""
-	PREFLIGHT_REMEDIATION_CALLS=0
-	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
-
+_install_ruleset_gh_stub() {
 cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
 printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
@@ -83,6 +66,16 @@ if [[ "$mode" == "stale-cache-401" && "$1" == "pr" && "$2" == "merge" && "$*" ==
 		printf '%s\n' 'non-200 OK status code: 401 Unauthorized body: "{ \"message\": \"Requires authentication\" }"' >&2
 		exit 1
 	fi
+	exit 0
+fi
+
+if [[ "$mode" == "terminal-closed" && "$1" == "pr" && "$2" == "merge" ]]; then
+	printf '%s\n' 'X Pull request owner/repo#77 is not mergeable: the pull request is closed.' >&2
+	exit 1
+fi
+
+if [[ "$mode" == "terminal-closed" && "$1" == "pr" && "$2" == "view" && "$*" == *"--json state"* ]]; then
+	printf '%s\n' 'CLOSED'
 	exit 0
 fi
 
@@ -136,6 +129,30 @@ GHEOF
 	return 0
 }
 
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export GH_STUB_MODE="${GH_STUB_MODE:-ruleset}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+	GH_LOG="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_LOG"
+	REMEDIATION_LOG="${TEST_ROOT}/remediation.log"
+	: >"$REMEDIATION_LOG"
+	MERGE_EVENT_LOG="${TEST_ROOT}/merge-events.log"
+	: >"$MERGE_EVENT_LOG"
+	CACHE_INVALIDATION_LOG="${TEST_ROOT}/cache-invalidations.log"
+	: >"$CACHE_INVALIDATION_LOG"
+	export TEST_ROOT GH_LOG REMEDIATION_LOG MERGE_EVENT_LOG CACHE_INVALIDATION_LOG
+	FINAL_GATE_RC=0
+	FINAL_GATE_BLOCKER_KIND=""
+	PREFLIGHT_REMEDIATION_CALLS=0
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
+	_install_ruleset_gh_stub
+	return 0
+}
+
 teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
@@ -144,16 +161,28 @@ teardown_test_env() {
 }
 
 define_function_under_test() {
+	local src_invalidate
+	local src_terminal
 	local src_process
+	src_invalidate=$(awk '
+		/^_pulse_merge_invalidate_pr_list_cache\(\) \{/,/^\}$/ { print }
+	' "$MERGE_SCRIPT")
+	src_terminal=$(awk '
+		/^_pulse_merge_failure_is_terminal\(\) \{/,/^\}$/ { print }
+	' "$MERGE_SCRIPT")
 	src_process=$(awk '
 		/^_process_single_ready_pr\(\) \{/,/^\}$/ { print }
 	' "$MERGE_SCRIPT")
-	if [[ -z "$src_process" ]]; then
-		printf 'ERROR: could not extract _process_single_ready_pr from %s\n' "$MERGE_SCRIPT" >&2
+	if [[ -z "$src_invalidate" || -z "$src_terminal" || -z "$src_process" ]]; then
+		printf 'ERROR: could not extract cache invalidation, terminal-state, or process helper from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090
 	source "${SCRIPT_DIR}/../gh-merge-cache-remediation-lib.sh"
+	# shellcheck disable=SC1090
+	eval "$src_invalidate"
+	# shellcheck disable=SC1090
+	eval "$src_terminal"
 	# shellcheck disable=SC1090
 	eval "$src_process"
 	return 0
@@ -214,6 +243,12 @@ _handle_post_merge_actions() {
 	return 0
 }
 gh_pr_view() { printf '{"labels":[]}'; return 0; }
+
+pulse_pr_list_cache_invalidate_repo() {
+	local repo_slug="$1"
+	printf '%s\n' "$repo_slug" >>"${CACHE_INVALIDATION_LOG:?}"
+	return 0
+}
 
 _pulse_merge_maybe_dispatch_review_thread_remediation() {
 	local pr_number="$1"
@@ -495,6 +530,14 @@ test_stale_cache_401_retries_admin_merge_once() {
 		return 0
 	fi
 	print_result "successful merge records recovery before interruptible post-merge work" 0
+	if [[ "$(<"$CACHE_INVALIDATION_LOG")" != "owner/repo" ]]; then
+		print_result "successful merge invalidates repository PR-list caches" 1 \
+			"invalidations=$(tr '\n' ';' <"$CACHE_INVALIDATION_LOG")"
+		teardown_test_env
+		unset GH_STUB_MODE
+		return 0
+	fi
+	print_result "successful merge invalidates repository PR-list caches" 0
 
 	if [[ -f "${HOME}/.cache/gh/graphql-401.cache" ]] || \
 		! find "${HOME}/.cache/gh" -path '*/aidevops-quarantine-*/*graphql-401.cache*' -type f | grep -q .; then
@@ -519,6 +562,38 @@ test_stale_cache_401_retries_admin_merge_once() {
 	fi
 
 	print_result "stale cache 401 retries admin merge once and succeeds" 0
+	teardown_test_env
+	unset GH_STUB_MODE
+	return 0
+}
+
+test_terminal_merge_failure_refreshes_state_and_invalidates_cache() {
+	GH_STUB_MODE="terminal-closed"
+	setup_test_env
+	define_function_under_test || { teardown_test_env; unset GH_STUB_MODE; return 0; }
+
+	local pr_obj='{"number":77,"state":"OPEN","mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"test","headRefOid":"head-current"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 1 ]]; then
+		print_result "terminal merge failure becomes a stale-cache skip" 1 \
+			"Expected 1, got ${result}; log: $(tr '\n' ';' <"$LOGFILE")"
+	elif ! grep -qE '^gh pr view 77 --repo owner/repo --json state --jq ' "$GH_LOG"; then
+		print_result "terminal merge failure performs uncached state refresh" 1 \
+			"gh log: $(tr '\n' ';' <"$GH_LOG")"
+	elif [[ "$(<"$CACHE_INVALIDATION_LOG")" != "owner/repo" ]]; then
+		print_result "terminal merge failure invalidates repository PR-list caches" 1 \
+			"invalidations=$(tr '\n' ';' <"$CACHE_INVALIDATION_LOG")"
+	elif [[ -s "$REMEDIATION_LOG" ]]; then
+		print_result "terminal merge failure suppresses stale remediation" 1 \
+			"remediation=$(tr '\n' ';' <"$REMEDIATION_LOG")"
+	elif ! grep -qF 'fresh state=CLOSED is terminal (GH#28280)' "$LOGFILE"; then
+		print_result "terminal merge failure writes stale-cache audit log" 1 \
+			"pulse log: $(tr '\n' ';' <"$LOGFILE")"
+	else
+		print_result "terminal merge failure refreshes state, invalidates cache, and skips remediation" 0
+	fi
 	teardown_test_env
 	unset GH_STUB_MODE
 	return 0
@@ -612,6 +687,7 @@ main() {
 	test_pending_required_check_updates_branch_and_defers
 	test_final_preflight_thread_blocker_dispatches_before_merge
 	test_stale_cache_401_retries_admin_merge_once
+	test_terminal_merge_failure_refreshes_state_and_invalidates_cache
 	test_ruleset_fallback_failure_preserves_admin_conversation_context
 
 	printf '\n=================================\n'

--- a/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
+++ b/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
@@ -159,6 +159,18 @@ install_stubs() {
 		printf '%s %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" "$kind" >>"$ROUTE_LOG"
 		return 0
 	}
+	_get_pr_branch_refs_for_conflict_comment() {
+		local pr_number="$1"
+		printf 'feature/pr-%s\tmain\n' "$pr_number"
+		return 0
+	}
+	_gh_with_timeout() {
+		local operation_class="$1"
+		shift
+		[[ -n "$operation_class" ]] || return 1
+		"$@"
+		return $?
+	}
 	_post_rebase_nudge_on_worker_conflicting() { return 0; }
 	_carry_forward_pr_diff() { return 0; }
 	set_solved_label() {

--- a/.agents/scripts/tests/test-pulse-pr-list-cache.sh
+++ b/.agents/scripts/tests/test-pulse-pr-list-cache.sh
@@ -32,7 +32,15 @@ trap 'rm -rf "$TMP_DIR" 2>/dev/null || true' EXIT
 
 GH_CALLS="${TMP_DIR}/gh-calls.log"
 : >"$GH_CALLS"
+SHARED_INVALIDATIONS="${TMP_DIR}/shared-invalidations.log"
+: >"$SHARED_INVALIDATIONS"
 unset PULSE_PR_LIST_PROVIDER_CACHE_DISABLE
+
+gh_pr_list_cache_invalidate_repo() {
+	local repo_slug="$1"
+	printf '%s\n' "$repo_slug" >>"$SHARED_INVALIDATIONS"
+	return 0
+}
 
 gh_pr_list() {
 	printf '%s\n' "$*" >>"$GH_CALLS"
@@ -119,6 +127,27 @@ if [[ "$wrapper_disabled_calls" == "2" ]]; then
 else
 	fail "provider cache remains disabled when wrapper exports disable without cache dir" \
 		"wrapper_disabled_calls=${wrapper_disabled_calls} calls=$(<"$GH_CALLS")"
+fi
+
+: >"$GH_CALLS"
+: >"$SHARED_INVALIDATIONS"
+export PULSE_PR_LIST_PROVIDER_CACHE_DIR="${TMP_DIR}/invalidate-cache"
+export PULSE_PR_LIST_PROVIDER_CACHE_TTL=3600
+pulse_pr_list_get --repo owner/repo --state open --json number --limit 10 >/dev/null
+pulse_pr_list_get --repo owner/repo --state open --json number --limit 10 >/dev/null
+pulse_pr_list_get --repo owner/other --state open --json number --limit 10 >/dev/null
+pulse_pr_list_get --repo owner/other --state open --json number --limit 10 >/dev/null
+pulse_pr_list_cache_invalidate_repo "owner/repo"
+pulse_pr_list_get --repo owner/repo --state open --json number --limit 10 >/dev/null
+pulse_pr_list_get --repo owner/other --state open --json number --limit 10 >/dev/null
+repo_backend_calls=$(grep -cF -- '--repo owner/repo --state open --json number --limit 10' "$GH_CALLS" 2>/dev/null || true)
+other_backend_calls=$(grep -cF -- '--repo owner/other --state open --json number --limit 10' "$GH_CALLS" 2>/dev/null || true)
+shared_invalidation_calls=$(grep -cFx 'owner/repo' "$SHARED_INVALIDATIONS" 2>/dev/null || true)
+if [[ "$repo_backend_calls" == "2" && "$other_backend_calls" == "1" && "$shared_invalidation_calls" == "1" ]]; then
+	pass "provider invalidation evicts every shape for one repo and delegates to shared cache"
+else
+	fail "provider invalidation evicts every shape for one repo and delegates to shared cache" \
+		"repo_calls=${repo_backend_calls} other_calls=${other_backend_calls} shared_invalidations=${shared_invalidation_calls} calls=$(<"$GH_CALLS")"
 fi
 
 printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Add repository-scoped invalidation for both Pulse provider and shared gh_pr_list caches; invalidate after successful merge/close mutations; refresh uncached PR state after merge failures and suppress stale remediation when GitHub reports CLOSED or MERGED; repair adjacent extracted-function test fixtures.

## Files Changed

.agents/scripts/pulse-merge-conflict.sh, .agents/scripts/pulse-merge-duplicate-consolidation.sh, .agents/scripts/pulse-merge-feedback.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/pulse-pr-list-cache.sh, .agents/scripts/shared-gh-wrappers-status.sh, .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh, .agents/scripts/tests/test-pulse-merge-carry-forward-diff.sh, .agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh, .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh, .agents/scripts/tests/test-pulse-pr-list-cache.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Provider cache 7/7; gh wrapper REST fallback 74/74; ruleset fallback 13/13; duplicate consolidation 22/22; carry-forward 8/8; superseded duplicates 22/22; CI repair 27/27; merge stuck 59/59; local changed-file lint gates passed.

Resolves #28280


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 15h 43m and 3,096,887 tokens on this with the user in an interactive session.