### PR TITLE
GH#27777: reduce review-gate API requests

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -54,6 +54,8 @@
 #                              Override per-repo or per-tool in repos.json:
 #                              { "review_gate": { "completion_behavior": "strict",
 #                                "tools": { "coderabbitai": { "completion_behavior": "fast" } } } }
+#   REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE — Set to 1 to disable per-check reuse
+#                              of the three review/comment API collections.
 #
 # t1382: https://github.com/marcusquinn/aidevops/issues/2735
 # GH#3827: Rate-limit grace period — pass gate after timeout when bots are
@@ -153,6 +155,16 @@ REVIEW_GATE_COMPLETION_BEHAVIOR="${REVIEW_GATE_COMPLETION_BEHAVIOR:-fast}"
 #   { "review_gate": { "min_edit_lag_seconds": 30,
 #     "tools": { "coderabbitai": { "min_edit_lag_seconds": 60 } } } }
 REVIEW_BOT_MIN_EDIT_LAG_SECONDS="${REVIEW_BOT_MIN_EDIT_LAG_SECONDS:-30}"
+
+# One fresh snapshot per check avoids repeatedly downloading the same reviews,
+# issue comments, and inline comments while classifying multiple bots. The
+# snapshot never survives a new do_check invocation, so polling still observes
+# newly posted or edited reviews without a TTL or cross-cycle stale window.
+_RBG_EVIDENCE_SNAPSHOT_KEY=""
+_RBG_EVIDENCE_REVIEWS_JSON="[]"
+_RBG_EVIDENCE_ISSUE_COMMENTS_JSON="[]"
+_RBG_EVIDENCE_REVIEW_COMMENTS_JSON="[]"
+_RBG_EVIDENCE_SNAPSHOT_READY=0
 
 # --- Functions ---
 
@@ -496,6 +508,100 @@ get_pr_age_seconds() {
 	return 0
 }
 
+_rbg_evidence_endpoint() {
+	local pr_number="$1"
+	local repo="$2"
+	local source="$3"
+
+	case "$source" in
+	reviews) printf 'repos/%s/pulls/%s/reviews\n' "$repo" "$pr_number" ;;
+	issue-comments) printf 'repos/%s/issues/%s/comments\n' "$repo" "$pr_number" ;;
+	review-comments) printf 'repos/%s/pulls/%s/comments\n' "$repo" "$pr_number" ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+_rbg_reset_evidence_snapshot() {
+	_RBG_EVIDENCE_SNAPSHOT_KEY=""
+	_RBG_EVIDENCE_REVIEWS_JSON="[]"
+	_RBG_EVIDENCE_ISSUE_COMMENTS_JSON="[]"
+	_RBG_EVIDENCE_REVIEW_COMMENTS_JSON="[]"
+	_RBG_EVIDENCE_SNAPSHOT_READY=0
+	return 0
+}
+
+_rbg_fetch_evidence_collection() {
+	local pr_number="$1"
+	local repo="$2"
+	local source="$3"
+	local endpoint=""
+	local paginated_endpoint=""
+	local records_json=""
+
+	endpoint=$(_rbg_evidence_endpoint "$pr_number" "$repo" "$source") || return 1
+	paginated_endpoint="${endpoint}?per_page=100"
+	if ! records_json=$(gh api "$paginated_endpoint" --paginate | jq -sce \
+		'[.[] | if type == "array" then .[] else error("review evidence page must be an array") end]'); then
+		return 1
+	fi
+	printf '%s\n' "$records_json"
+	return 0
+}
+
+_rbg_prepare_evidence_snapshot() {
+	local pr_number="$1"
+	local repo="$2"
+	local reviews_json=""
+	local issue_comments_json=""
+	local review_comments_json=""
+
+	reviews_json=$(_rbg_fetch_evidence_collection "$pr_number" "$repo" reviews) || return $?
+	issue_comments_json=$(_rbg_fetch_evidence_collection "$pr_number" "$repo" issue-comments) || return $?
+	review_comments_json=$(_rbg_fetch_evidence_collection "$pr_number" "$repo" review-comments) || return $?
+
+	_RBG_EVIDENCE_REVIEWS_JSON="$reviews_json"
+	_RBG_EVIDENCE_ISSUE_COMMENTS_JSON="$issue_comments_json"
+	_RBG_EVIDENCE_REVIEW_COMMENTS_JSON="$review_comments_json"
+	_RBG_EVIDENCE_SNAPSHOT_KEY="${repo}#${pr_number}"
+	_RBG_EVIDENCE_SNAPSHOT_READY=1
+	return 0
+}
+
+_rbg_evidence_snapshot_matches() {
+	local pr_number="$1"
+	local repo="$2"
+	if [[ "$_RBG_EVIDENCE_SNAPSHOT_READY" -eq 1 && "$_RBG_EVIDENCE_SNAPSHOT_KEY" == "${repo}#${pr_number}" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_rbg_query_evidence_collection() {
+	local pr_number="$1"
+	local repo="$2"
+	local source="$3"
+	local jq_filter="$4"
+	local records_json=""
+	local endpoint=""
+
+	if [[ "${REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE:-0}" != "1" ]] &&
+		_rbg_evidence_snapshot_matches "$pr_number" "$repo"; then
+		case "$source" in
+		reviews) records_json="$_RBG_EVIDENCE_REVIEWS_JSON" ;;
+		issue-comments) records_json="$_RBG_EVIDENCE_ISSUE_COMMENTS_JSON" ;;
+		review-comments) records_json="$_RBG_EVIDENCE_REVIEW_COMMENTS_JSON" ;;
+		*) return 1 ;;
+		esac
+		printf '%s\n' "$records_json" | jq -r "$jq_filter"
+		return $?
+	fi
+
+	endpoint=$(_rbg_evidence_endpoint "$pr_number" "$repo" "$source") || return 1
+	gh api "$endpoint" --paginate --jq "$jq_filter"
+	return $?
+}
+
 get_all_bot_commenters() {
 	local pr_number="$1"
 	local repo="$2"
@@ -503,22 +609,23 @@ get_all_bot_commenters() {
 	# Collect reviewers from three sources:
 	# 1. PR reviews (formal GitHub reviews)
 	local reviews
-	reviews=$(gh api "repos/${repo}/pulls/${pr_number}/reviews" \
-		--paginate --jq '.[].user.login' || echo "")
+	reviews=$(_rbg_query_evidence_collection "$pr_number" "$repo" reviews \
+		'.[].user.login' || echo "")
 
 	# 2. Issue comments (some bots post as comments, not reviews)
 	local comments
-	comments=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
-		--paginate --jq '.[].user.login' || echo "")
+	comments=$(_rbg_query_evidence_collection "$pr_number" "$repo" issue-comments \
+		'.[].user.login' || echo "")
 
 	# 3. Review comments (inline code comments)
 	local review_comments
-	review_comments=$(gh api "repos/${repo}/pulls/${pr_number}/comments" \
-		--paginate --jq '.[].user.login' || echo "")
+	review_comments=$(_rbg_query_evidence_collection "$pr_number" "$repo" review-comments \
+		'.[].user.login' || echo "")
 
 	# Combine, deduplicate, lowercase
 	echo -e "${reviews}\n${comments}\n${review_comments}" |
 		tr '[:upper:]' '[:lower:]' | sort -u | grep -v '^$' || true
+	return 0
 }
 
 is_non_review_comment() {
@@ -624,15 +731,10 @@ bot_has_rate_limit_notice() {
 	local jq_filter
 	jq_filter=$(bot_body_base64_jq_filter "$bot_login")
 
-	local api_endpoints=(
-		"repos/${repo}/pulls/${pr_number}/reviews"
-		"repos/${repo}/issues/${pr_number}/comments"
-		"repos/${repo}/pulls/${pr_number}/comments"
-	)
-
-	local endpoint records encoded body
-	for endpoint in "${api_endpoints[@]}"; do
-		records=$(gh api "$endpoint" --paginate --jq "$jq_filter" || echo "")
+	local sources=(reviews issue-comments review-comments)
+	local source records encoded body
+	for source in "${sources[@]}"; do
+		records=$(_rbg_query_evidence_collection "$pr_number" "$repo" "$source" "$jq_filter" || echo "")
 		[[ -z "$records" ]] && continue
 		while IFS= read -r encoded; do
 			[[ -z "$encoded" ]] && continue
@@ -657,15 +759,10 @@ bot_has_non_rate_limit_non_review_notice() {
 	local jq_filter
 	jq_filter=$(bot_body_base64_jq_filter "$bot_login")
 
-	local api_endpoints=(
-		"repos/${repo}/pulls/${pr_number}/reviews"
-		"repos/${repo}/issues/${pr_number}/comments"
-		"repos/${repo}/pulls/${pr_number}/comments"
-	)
-
-	local endpoint records encoded body
-	for endpoint in "${api_endpoints[@]}"; do
-		records=$(gh api "$endpoint" --paginate --jq "$jq_filter" || echo "")
+	local sources=(reviews issue-comments review-comments)
+	local source records encoded body
+	for source in "${sources[@]}"; do
+		records=$(_rbg_query_evidence_collection "$pr_number" "$repo" "$source" "$jq_filter" || echo "")
 		[[ -z "$records" ]] && continue
 		while IFS= read -r encoded; do
 			[[ -z "$encoded" ]] && continue
@@ -691,16 +788,11 @@ bot_get_notice_category() {
 	local jq_filter
 	jq_filter=$(bot_body_base64_jq_filter "$bot_login")
 
-	local api_endpoints=(
-		"repos/${repo}/pulls/${pr_number}/reviews"
-		"repos/${repo}/issues/${pr_number}/comments"
-		"repos/${repo}/pulls/${pr_number}/comments"
-	)
-
 	local category="none"
-	local endpoint records rc encoded body
-	for endpoint in "${api_endpoints[@]}"; do
-		if records=$(gh api "$endpoint" --paginate --jq "$jq_filter"); then
+	local sources=(reviews issue-comments review-comments)
+	local source records rc encoded body
+	for source in "${sources[@]}"; do
+		if records=$(_rbg_query_evidence_collection "$pr_number" "$repo" "$source" "$jq_filter"); then
 			:
 		else
 			rc=$?
@@ -761,15 +853,10 @@ bot_has_real_review() {
 	fi
 	jq_filter="${jq_filter} | [(.created_at // .submitted_at // \"\"), (.updated_at // .submitted_at // .created_at // \"\"), (.body // \"\" | @base64)] | @tsv"
 
-	local api_endpoints=(
-		"repos/${repo}/pulls/${pr_number}/reviews"
-		"repos/${repo}/issues/${pr_number}/comments"
-		"repos/${repo}/pulls/${pr_number}/comments"
-	)
-
-	local endpoint records created_at updated_at encoded body
-	for endpoint in "${api_endpoints[@]}"; do
-		records=$(gh api "$endpoint" --paginate --jq "$jq_filter" || echo "")
+	local sources=(reviews issue-comments review-comments)
+	local source records created_at updated_at encoded body
+	for source in "${sources[@]}"; do
+		records=$(_rbg_query_evidence_collection "$pr_number" "$repo" "$source" "$jq_filter" || echo "")
 		[[ -z "$records" ]] && continue
 		while IFS=$'\t' read -r created_at updated_at encoded; do
 			[[ -z "$encoded" ]] && continue
@@ -839,9 +926,13 @@ _get_success_status_contexts() {
 	local pr_number="$1"
 	local repo="$2"
 
-	local head_sha
-	head_sha=$(gh pr view "$pr_number" --repo "$repo" \
-		--json headRefOid -q '.headRefOid' 2>/dev/null || echo "")
+	# status-json already resolves and later revalidates the expected head. Reuse
+	# that typed value instead of spending another GraphQL request on the same SHA.
+	local head_sha="${REVIEW_GATE_EXPECTED_HEAD_SHA:-}"
+	if [[ -z "$head_sha" ]]; then
+		head_sha=$(gh pr view "$pr_number" --repo "$repo" \
+			--json headRefOid -q '.headRefOid' 2>/dev/null || echo "")
+	fi
 	if [[ -z "$head_sha" ]]; then
 		# GH#4361: GraphQL rate-limited — fall back to REST API.
 		head_sha=$(gh api "repos/${repo}/pulls/${pr_number}" \
@@ -955,10 +1046,16 @@ any_bot_has_success_status() {
 check_for_skip_label() {
 	local pr_number="$1"
 	local repo="$2"
+	local pr_metadata_json="${3:-}"
 
-	local labels
-	labels=$(gh pr view "$pr_number" --repo "$repo" \
-		--json labels -q '.labels[].name' || echo "")
+	local labels=""
+	if [[ -n "$pr_metadata_json" ]] &&
+		labels=$(jq -r '.labels[]?.name // empty' <<<"$pr_metadata_json" 2>/dev/null); then
+		:
+	else
+		labels=$(gh pr view "$pr_number" --repo "$repo" \
+			--json labels -q '.labels[].name' || echo "")
+	fi
 
 	if echo "$labels" | grep -q "$SKIP_LABEL"; then
 		return 0
@@ -1086,7 +1183,9 @@ _emit_review_gate_check_result() {
 do_check() {
 	local pr_number="$1"
 	local repo="$2"
+	local pr_metadata_json="${3:-}"
 	local REVIEW_GATE_AUTHOR_ASSOCIATION="${REVIEW_GATE_AUTHOR_ASSOCIATION:-}"
+	local result_rc=0
 	# These caller-local accumulators are populated/read by helpers through Bash
 	# dynamic scoping; keep targeted ShellCheck suppressions beside each local.
 	# shellcheck disable=SC2034
@@ -1095,7 +1194,12 @@ do_check() {
 	local REVIEW_GATE_RATE_LIMITED_BOTS=""
 	# shellcheck disable=SC2034
 	local REVIEW_GATE_NON_REVIEW_BOTS=""
+	_rbg_reset_evidence_snapshot
 
+	if [[ -z "$REVIEW_GATE_AUTHOR_ASSOCIATION" && -n "$pr_metadata_json" ]]; then
+		REVIEW_GATE_AUTHOR_ASSOCIATION=$(jq -r '.author_association // .authorAssociation // empty' \
+			<<<"$pr_metadata_json" 2>/dev/null || true)
+	fi
 	if [[ -z "$REVIEW_GATE_AUTHOR_ASSOCIATION" ]]; then
 		REVIEW_GATE_AUTHOR_ASSOCIATION=$(gh pr view "$pr_number" --repo "$repo" \
 			--json authorAssociation --jq '.authorAssociation // empty' 2>/dev/null || true)
@@ -1104,7 +1208,7 @@ do_check() {
 	# #aidevops:trust-boundary — skip labels are an internal exception. Resolve
 	# immutable author trust before honoring one so every caller, not only the
 	# reusable workflow, fails closed for external or unknown authors.
-	if check_for_skip_label "$pr_number" "$repo"; then
+	if check_for_skip_label "$pr_number" "$repo" "$pr_metadata_json"; then
 		case "$REVIEW_GATE_AUTHOR_ASSOCIATION" in
 		OWNER | MEMBER | COLLABORATOR)
 			echo "SKIP"
@@ -1114,6 +1218,13 @@ do_check() {
 		echo "WAITING"
 		echo "skip-review-gate denied for external or unknown author association." >&2
 		return 1
+	fi
+
+	if [[ "${REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE:-0}" != "1" ]]; then
+		if ! _rbg_prepare_evidence_snapshot "$pr_number" "$repo"; then
+			echo "Review evidence snapshot unavailable for PR #${pr_number}; falling back to direct endpoint queries." >&2
+			_rbg_reset_evidence_snapshot
+		fi
 	fi
 
 	local all_commenters
@@ -1126,9 +1237,16 @@ do_check() {
 		prepared_status_contexts=$(_prepare_success_status_contexts "$status_contexts" || true)
 	fi
 
-	_collect_review_gate_bot_states "$pr_number" "$repo" "$all_commenters" "$prepared_status_contexts" || return $?
-	_emit_review_gate_check_result "$pr_number" "$repo" "$prepared_status_contexts"
-	return $?
+	if _collect_review_gate_bot_states "$pr_number" "$repo" "$all_commenters" "$prepared_status_contexts"; then
+		:
+	else
+		result_rc=$?
+		_rbg_reset_evidence_snapshot
+		return "$result_rc"
+	fi
+	_emit_review_gate_check_result "$pr_number" "$repo" "$prepared_status_contexts" || result_rc=$?
+	_rbg_reset_evidence_snapshot
+	return "$result_rc"
 }
 
 do_wait() {
@@ -1173,23 +1291,18 @@ do_wait() {
 do_status_json() {
 	local pr_number="$1"
 	local repo="$2"
-	local output=""
-	local rc=0
-	local state="waiting"
-	local blocked_prefix="bloc"
-	local merge_gate="${blocked_prefix}ked"
-	local status_pass
+	local output="" rc=0 state="waiting" blocked_prefix="bloc" status_pass="" pr_api=""
+	local merge_gate=""
 	local pr_json_before="" pr_json="" head_sha_before="" head_sha="" author_login="" author_association_before="" author_association="" author_class="external"
-	local head_stable="$RBG_FALSE"
-	local permitted="$RBG_FALSE" reason="outcome_not_permitted"
+	local head_stable="$RBG_FALSE" skip_label_present_after="$RBG_FALSE" permitted="$RBG_FALSE" reason="outcome_not_permitted"
+	merge_gate="${blocked_prefix}ked"
 	status_pass=$(printf 'P%s' 'ASS')
 
-	local pr_api=""
 	pr_api=$(printf 'repos/%s/pulls/%s' "$repo" "$pr_number")
 	pr_json_before=$(gh api "$pr_api" 2>/dev/null) || pr_json_before=""
 	head_sha_before=$(jq -r '.head.sha // ""' <<<"$pr_json_before" 2>/dev/null) || head_sha_before=""
 	author_association_before=$(jq -r '.author_association // ""' <<<"$pr_json_before" 2>/dev/null) || author_association_before=""
-	output=$(REVIEW_GATE_EXPECTED_HEAD_SHA="$head_sha_before" REVIEW_GATE_AUTHOR_ASSOCIATION="$author_association_before" do_check "$pr_number" "$repo" 2>/dev/null) || rc=$?
+	output=$(REVIEW_GATE_EXPECTED_HEAD_SHA="$head_sha_before" REVIEW_GATE_AUTHOR_ASSOCIATION="$author_association_before" do_check "$pr_number" "$repo" "$pr_json_before" 2>/dev/null) || rc=$?
 	pr_json=$(gh api "$pr_api" 2>/dev/null) || pr_json=""
 	if [[ -n "$pr_json" ]]; then
 		head_sha=$(jq -r '.head.sha // ""' <<<"$pr_json" 2>/dev/null) || head_sha=""
@@ -1199,6 +1312,7 @@ do_status_json() {
 	if [[ -n "$head_sha_before" && "$head_sha_before" == "$head_sha" ]]; then
 		head_stable="true"
 	fi
+	jq -e --arg label "$SKIP_LABEL" '[.labels[]?.name] | index($label) != null' <<<"$pr_json" >/dev/null 2>&1 && skip_label_present_after="true"
 	case "$author_association" in
 	OWNER | MEMBER | COLLABORATOR) author_class="trusted" ;;
 	esac
@@ -1214,7 +1328,7 @@ do_status_json() {
 		fi
 		;;
 	SKIP)
-		if [[ "$author_class" == "trusted" && "$head_stable" == "true" ]]; then
+		if [[ "$author_class" == "trusted" && "$head_stable" == "true" && "$skip_label_present_after" == "true" ]]; then
 			permitted="true"
 			reason="trusted_skip"
 		else
@@ -1293,16 +1407,11 @@ _classify_bot_state() {
 	local jq_filter
 	jq_filter=".[] | select(.user.login | ascii_downcase | test(\"${bot_login}\")) | [(.created_at // .submitted_at // \"\"), (.updated_at // .submitted_at // .created_at // \"\"), (.body // \"\" | @base64)] | @tsv"
 
-	local api_endpoints=(
-		"repos/${repo}/pulls/${pr_number}/reviews"
-		"repos/${repo}/issues/${pr_number}/comments"
-		"repos/${repo}/pulls/${pr_number}/comments"
-	)
-
 	local saw_any=0 saw_non_review=0 saw_placeholder=0
-	local endpoint records created_at updated_at encoded body
-	for endpoint in "${api_endpoints[@]}"; do
-		records=$(gh api "$endpoint" --paginate --jq "$jq_filter" || echo "")
+	local sources=(reviews issue-comments review-comments)
+	local source records created_at updated_at encoded body
+	for source in "${sources[@]}"; do
+		records=$(_rbg_query_evidence_collection "$pr_number" "$repo" "$source" "$jq_filter" || echo "")
 		[[ -z "$records" ]] && continue
 		while IFS=$'\t' read -r created_at updated_at encoded; do
 			[[ -z "$encoded" ]] && continue
@@ -1407,8 +1516,8 @@ has_retry_comment() {
 
 	local marker="<!-- review-bot-retry-requested -->"
 	local comments
-	comments=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
-		--paginate --jq '.[].body' || echo "")
+	comments=$(_rbg_query_evidence_collection "$pr_number" "$repo" issue-comments \
+		'.[].body' || echo "")
 	if echo "$comments" | grep -qF "$marker"; then
 		return 0
 	fi

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -571,7 +571,7 @@ _rbg_prepare_evidence_snapshot() {
 _rbg_evidence_snapshot_matches() {
 	local pr_number="$1"
 	local repo="$2"
-	if [[ "$_RBG_EVIDENCE_SNAPSHOT_READY" -eq 1 && "$_RBG_EVIDENCE_SNAPSHOT_KEY" == "${repo}#${pr_number}" ]]; then
+	if [[ "$_RBG_EVIDENCE_SNAPSHOT_READY" == "1" && "$_RBG_EVIDENCE_SNAPSHOT_KEY" == "${repo}#${pr_number}" ]]; then
 		return 0
 	fi
 	return 1

--- a/.agents/scripts/tests/test-review-bot-gate-api-snapshot.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-api-snapshot.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Regression coverage for per-decision review evidence snapshot reuse.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
+HELPER_SCRIPT="${SCRIPT_DIR}/../review-bot-gate-helper.sh"
+TEST_ROOT="$(mktemp -d)"
+TESTS_RUN=0
+TESTS_FAILED=0
+RUN_STATUS=0
+RUN_OUTPUT=""
+CALL_LOG="${TEST_ROOT}/gh-calls.log"
+SCENARIO_FILE="${TEST_ROOT}/scenario"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$test_name"
+	[[ -n "$detail" ]] && printf '     %s\n' "$detail"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+load_helper_functions() {
+	local source_copy="${TEST_ROOT}/review-bot-gate-helper.sh"
+	grep -v '^main "\$@"' "$HELPER_SCRIPT" >"$source_copy"
+	# shellcheck disable=SC1090
+	source "$source_copy"
+	return 0
+}
+
+install_gh_stub() {
+	local bin_dir="${TEST_ROOT}/bin"
+	mkdir -p "$bin_dir" "${TEST_ROOT}/home/.config/aidevops"
+	cat >"${bin_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+call_log="${REVIEW_GATE_SNAPSHOT_CALL_LOG:?}"
+scenario_file="${REVIEW_GATE_SNAPSHOT_SCENARIO_FILE:?}"
+failure_marker="${REVIEW_GATE_SNAPSHOT_FAILURE_MARKER:?}"
+scenario=""
+IFS= read -r scenario <"$scenario_file"
+
+if [[ "${1:-}" != "api" ]]; then
+	printf 'command:%s\n' "$*" >>"$call_log"
+	exit 2
+fi
+endpoint="${2:-}"
+jq_filter=""
+shift 2
+while [[ "$#" -gt 0 ]]; do
+	case "${1:-}" in
+	--jq)
+		jq_filter="${2:-}"
+		shift 2
+		;;
+	*) shift ;;
+	esac
+done
+
+mode="snapshot"
+[[ -n "$jq_filter" ]] && mode="direct"
+printf '%s:%s\n' "$mode" "$endpoint" >>"$call_log"
+
+if [[ "$scenario" == "fail-once" && "$mode" == "snapshot" &&
+	"$endpoint" == "repos/testorg/testrepo/pulls/123/reviews?per_page=100" && ! -e "$failure_marker" ]]; then
+	: >"$failure_marker"
+	exit 42
+fi
+
+emit_pages() {
+	local target_endpoint="$1"
+	local current_scenario="$2"
+	case "$target_endpoint" in
+	repos/testorg/testrepo/pulls/123/reviews | repos/testorg/testrepo/pulls/123/reviews?per_page=100)
+		if [[ "$current_scenario" == "empty" ]]; then
+			printf '%s\n' '[]'
+		else
+			# Two pages prove that the snapshot collector preserves pagination.
+			printf '%s\n' '[]'
+			printf '%s\n' '[{"user":{"login":"gemini-code-assist[bot]"},"commit_id":"head-123","submitted_at":"2020-01-01T00:00:00Z","body":"Substantive review of the current change."}]'
+		fi
+		;;
+	repos/testorg/testrepo/issues/123/comments | repos/testorg/testrepo/issues/123/comments?per_page=100 | \
+		repos/testorg/testrepo/pulls/123/comments | repos/testorg/testrepo/pulls/123/comments?per_page=100)
+		printf '%s\n' '[]'
+		;;
+	repos/testorg/testrepo/commits/head-123/status?per_page=100)
+		printf '%s\n' '{"statuses":[]}'
+		;;
+	repos/testorg/testrepo/commits/head-123/check-runs?per_page=100)
+		printf '%s\n' '{"check_runs":[]}'
+		;;
+	repos/testorg/testrepo/pulls/123)
+		printf '%s\n' '{"head":{"sha":"head-123"},"author_association":"MEMBER","labels":[]}'
+		;;
+	*) return 2 ;;
+	esac
+	return 0
+}
+
+if [[ -n "$jq_filter" ]]; then
+	emit_pages "$endpoint" "$scenario" | jq -r "$jq_filter"
+	exit $?
+fi
+emit_pages "$endpoint" "$scenario"
+exit $?
+EOF
+	chmod +x "${bin_dir}/gh"
+	export PATH="${bin_dir}:${PATH}"
+	export HOME="${TEST_ROOT}/home"
+	export REVIEW_GATE_SNAPSHOT_CALL_LOG="$CALL_LOG"
+	export REVIEW_GATE_SNAPSHOT_SCENARIO_FILE="$SCENARIO_FILE"
+	export REVIEW_GATE_SNAPSHOT_FAILURE_MARKER="${TEST_ROOT}/failed-once"
+	return 0
+}
+
+run_check() {
+	local scenario="$1"
+	local snapshot_disabled="$2"
+	local output_file="${TEST_ROOT}/check-output"
+	local error_file="${TEST_ROOT}/check-error"
+	printf '%s\n' "$scenario" >"$SCENARIO_FILE"
+	: >"$output_file"
+	: >"$error_file"
+	RUN_STATUS=0
+	if REVIEW_GATE_AUTHOR_ASSOCIATION=MEMBER \
+		REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE="$snapshot_disabled" \
+		do_check 123 'testorg/testrepo' >"$output_file" 2>"$error_file"; then
+		RUN_STATUS=0
+	else
+		RUN_STATUS=$?
+	fi
+	RUN_OUTPUT=""
+	IFS= read -r RUN_OUTPUT <"$output_file" || true
+	return 0
+}
+
+call_count() {
+	local count="0"
+	count=$(wc -l <"$CALL_LOG" | tr -d '[:space:]')
+	printf '%s\n' "$count"
+	return 0
+}
+
+matching_call_count() {
+	local pattern="$1"
+	local count="0"
+	count=$(grep -cF -- "$pattern" "$CALL_LOG" 2>/dev/null || true)
+	printf '%s\n' "$count"
+	return 0
+}
+
+exact_call_count() {
+	local pattern="$1"
+	local count="0"
+	count=$(grep -cFx -- "$pattern" "$CALL_LOG" 2>/dev/null || true)
+	printf '%s\n' "$count"
+	return 0
+}
+
+test_preloaded_metadata_avoids_duplicate_lookups() {
+	local pr_metadata='{"head":{"sha":"head-123"},"author_association":"MEMBER","labels":[]}'
+	local output_file="${TEST_ROOT}/metadata-output"
+	local status=0 output="" calls command_calls pull_metadata_calls status_calls check_calls
+	printf '%s\n' real >"$SCENARIO_FILE"
+	: >"$CALL_LOG"
+	if REVIEW_GATE_EXPECTED_HEAD_SHA=head-123 REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE=0 \
+		do_check 123 'testorg/testrepo' "$pr_metadata" >"$output_file" 2>/dev/null; then
+		status=0
+	else
+		status=$?
+	fi
+	IFS= read -r output <"$output_file" || true
+	calls=$(call_count)
+	command_calls=$(matching_call_count 'command:')
+	pull_metadata_calls=$(exact_call_count 'direct:repos/testorg/testrepo/pulls/123')
+	status_calls=$(exact_call_count 'direct:repos/testorg/testrepo/commits/head-123/status?per_page=100')
+	check_calls=$(exact_call_count 'direct:repos/testorg/testrepo/commits/head-123/check-runs?per_page=100')
+	if [[ "$status" -eq 0 && "$output" == "PASS" && "$calls" == "5" &&
+		"$command_calls" == "0" && "$pull_metadata_calls" == "0" &&
+		"$status_calls" == "1" && "$check_calls" == "1" ]]; then
+		print_result "preloaded PR metadata and head avoid duplicate metadata lookups" 0
+	else
+		print_result "preloaded PR metadata and head avoid duplicate metadata lookups" 1 \
+			"status=${status} output=${output} calls=${calls} command=${command_calls} pull=${pull_metadata_calls} statuses=${status_calls}/${check_calls}"
+	fi
+	return 0
+}
+
+test_snapshot_reuses_three_paginated_collections() {
+	: >"$CALL_LOG"
+	run_check real 0
+	local calls reviews issue_comments review_comments
+	calls=$(call_count)
+	reviews=$(matching_call_count 'snapshot:repos/testorg/testrepo/pulls/123/reviews?per_page=100')
+	issue_comments=$(matching_call_count 'snapshot:repos/testorg/testrepo/issues/123/comments?per_page=100')
+	review_comments=$(matching_call_count 'snapshot:repos/testorg/testrepo/pulls/123/comments?per_page=100')
+	if [[ "$RUN_STATUS" -eq 0 && "$RUN_OUTPUT" == "PASS" && "$calls" == "3" &&
+		"$reviews" == "1" && "$issue_comments" == "1" && "$review_comments" == "1" &&
+		"$_RBG_EVIDENCE_SNAPSHOT_READY" -eq 0 ]]; then
+		print_result "one check reuses exactly three paginated evidence collections" 0
+	else
+		print_result "one check reuses exactly three paginated evidence collections" 1 \
+			"status=${RUN_STATUS} output=${RUN_OUTPUT} calls=${calls} endpoint_counts=${reviews}/${issue_comments}/${review_comments} ready=${_RBG_EVIDENCE_SNAPSHOT_READY}"
+	fi
+	return 0
+}
+
+test_snapshot_refreshes_between_decisions() {
+	: >"$CALL_LOG"
+	run_check real 0
+	local first_status="$RUN_STATUS"
+	local first_output="$RUN_OUTPUT"
+	run_check empty 0
+	local calls
+	calls=$(call_count)
+	if [[ "$first_status" -eq 0 && "$first_output" == "PASS" &&
+		"$RUN_STATUS" -eq 0 && "$RUN_OUTPUT" == "PASS_ADVISORY" && "$calls" == "6" ]]; then
+		print_result "a later decision fetches fresh evidence instead of reusing stale state" 0
+	else
+		print_result "a later decision fetches fresh evidence instead of reusing stale state" 1 \
+			"first=${first_status}/${first_output} second=${RUN_STATUS}/${RUN_OUTPUT} calls=${calls}"
+	fi
+	return 0
+}
+
+test_disable_toggle_restores_direct_queries() {
+	: >"$CALL_LOG"
+	run_check real 1
+	local calls snapshot_calls direct_calls
+	calls=$(call_count)
+	snapshot_calls=$(matching_call_count 'snapshot:')
+	direct_calls=$(matching_call_count 'direct:')
+	if [[ "$RUN_STATUS" -eq 0 && "$RUN_OUTPUT" == "PASS" && "$calls" == "4" &&
+		"$snapshot_calls" == "0" && "$direct_calls" == "4" ]]; then
+		print_result "rollback toggle restores the direct-query path" 0
+	else
+		print_result "rollback toggle restores the direct-query path" 1 \
+			"status=${RUN_STATUS} output=${RUN_OUTPUT} calls=${calls} snapshot=${snapshot_calls} direct=${direct_calls}"
+	fi
+	return 0
+}
+
+test_snapshot_failure_falls_back_without_losing_capability() {
+	: >"$CALL_LOG"
+	rm -f "${TEST_ROOT}/failed-once"
+	run_check fail-once 0
+	local calls snapshot_calls direct_calls
+	calls=$(call_count)
+	snapshot_calls=$(matching_call_count 'snapshot:')
+	direct_calls=$(matching_call_count 'direct:')
+	if [[ "$RUN_STATUS" -eq 0 && "$RUN_OUTPUT" == "PASS" && "$calls" == "5" &&
+		"$snapshot_calls" == "1" && "$direct_calls" == "4" &&
+		$(grep -cF 'falling back to direct endpoint queries' "${TEST_ROOT}/check-error" || true) -eq 1 ]]; then
+		print_result "snapshot failure preserves the direct-query fallback" 0
+	else
+		print_result "snapshot failure preserves the direct-query fallback" 1 \
+			"status=${RUN_STATUS} output=${RUN_OUTPUT} calls=${calls} snapshot=${snapshot_calls} direct=${direct_calls}"
+	fi
+	return 0
+}
+
+install_gh_stub
+load_helper_functions
+test_preloaded_metadata_avoids_duplicate_lookups
+
+# Install narrow test doubles after sourcing so they replace the helper's API
+# metadata lookups without replacing the evidence collection under test.
+check_for_skip_label() {
+	local pr_number="$1"
+	local repo="$2"
+	: "$pr_number" "$repo"
+	return 1
+}
+
+_get_success_status_contexts() {
+	local pr_number="$1"
+	local repo="$2"
+	: "$pr_number" "$repo"
+	return 1
+}
+
+test_snapshot_reuses_three_paginated_collections
+test_snapshot_refreshes_between_decisions
+test_disable_toggle_restores_direct_queries
+test_snapshot_failure_falls_back_without_losing_capability
+
+printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/tests/test-review-bot-gate-api-snapshot.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-api-snapshot.sh
@@ -182,7 +182,7 @@ test_preloaded_metadata_avoids_duplicate_lookups() {
 	printf '%s\n' real >"$SCENARIO_FILE"
 	: >"$CALL_LOG"
 	if REVIEW_GATE_EXPECTED_HEAD_SHA=head-123 REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE=0 \
-		do_check 123 'testorg/testrepo' "$pr_metadata" >"$output_file" 2>/dev/null; then
+		do_check 123 'testorg/testrepo' "$pr_metadata" >"$output_file"; then
 		status=0
 	else
 		status=$?

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -64,6 +64,9 @@ setup_test_env() {
 	mkdir -p "${TEST_ROOT}/config/aidevops"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export HOME="${TEST_ROOT}"
+	# This suite exercises the legacy direct-query classifiers with narrow gh
+	# stubs. Snapshot request counts and freshness have a dedicated regression.
+	export REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE=1
 	mkdir -p "${TEST_ROOT}/.config/aidevops"
 
 	# Minimal repos.json for resolver tests
@@ -1306,7 +1309,7 @@ test_status_json_allows_trusted_skip() {
 		return 0
 	}
 	gh() {
-		printf '%s\n' '{"head":{"sha":"head-123"},"user":{"login":"maintainer"},"author_association":"MEMBER"}'
+		printf '%s\n' '{"head":{"sha":"head-123"},"user":{"login":"maintainer"},"author_association":"MEMBER","labels":[{"name":"skip-review-gate"}]}'
 		return 0
 	}
 	local output=""
@@ -1315,6 +1318,35 @@ test_status_json_allows_trusted_skip() {
 		print_result "status-json permits trusted current-head skip" 0
 	else
 		print_result "status-json permits trusted current-head skip" 1 "output=${output}"
+	fi
+	return 0
+}
+
+test_status_json_denies_skip_removed_during_decision() {
+	do_check() {
+		printf 'SKIP\n'
+		return 0
+	}
+	local gh_count_file="${TEST_ROOT}/status-json-skip-gh-count"
+	printf '0\n' >"$gh_count_file"
+	gh() {
+		local gh_calls=0
+		IFS= read -r gh_calls <"$gh_count_file" || gh_calls=0
+		gh_calls=$((gh_calls + 1))
+		printf '%s\n' "$gh_calls" >"$gh_count_file"
+		if [[ "$gh_calls" -eq 1 ]]; then
+			printf '%s\n' '{"head":{"sha":"head-123"},"user":{"login":"maintainer"},"author_association":"MEMBER","labels":[{"name":"skip-review-gate"}]}'
+		else
+			printf '%s\n' '{"head":{"sha":"head-123"},"user":{"login":"maintainer"},"author_association":"MEMBER","labels":[]}'
+		fi
+		return 0
+	}
+	local output=""
+	output=$(do_status_json 123 'testorg/otherrepo')
+	if jq -e '.status == "SKIP" and .author.class == "trusted" and .permitted == false and .merge_gate == "blocked"' <<<"$output" >/dev/null; then
+		print_result "status-json denies a skip label removed during the decision" 0
+	else
+		print_result "status-json denies a skip label removed during the decision" 1 "output=${output}"
 	fi
 	return 0
 }
@@ -1339,6 +1371,16 @@ run_completion_requirement_tests() {
 	test_trusted_default_does_not_require_completed_review
 	test_trusted_strict_repo_requires_completed_review
 	test_external_default_requires_completed_review
+	return 0
+}
+
+run_status_json_tests() {
+	test_status_json_denies_external_rate_limit_grace
+	test_status_json_allows_trusted_advisory_default
+	test_status_json_denies_external_advisory_default
+	test_status_json_allows_trusted_skip
+	test_status_json_denies_skip_removed_during_decision
+	test_status_json_fails_closed_without_pr_metadata
 	return 0
 }
 
@@ -1432,11 +1474,7 @@ main() {
 
 	echo ""
 	echo "=== Typed current-head evidence ==="
-	test_status_json_denies_external_rate_limit_grace
-	test_status_json_allows_trusted_advisory_default
-	test_status_json_denies_external_advisory_default
-	test_status_json_allows_trusted_skip
-	test_status_json_fails_closed_without_pr_metadata
+	run_status_json_tests
 
 	echo ""
 	echo "Tests run: ${TESTS_RUN}, failed: ${TESTS_FAILED}"


### PR DESCRIPTION
## Summary

Reuse one fresh paginated reviews/comments snapshot per review-gate decision, reuse status-json PR metadata and head SHA, retain direct-query fallback and a rollback toggle, and revalidate skip labels before permitting SKIP.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh, .agents/scripts/tests/test-review-bot-gate-api-snapshot.sh, .agents/scripts/tests/test-review-bot-gate-completion-signal.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-review-bot-gate-api-snapshot.sh; bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh; .agents/scripts/linters-local.sh; live status-json smoke test against PR #28314.

For #27777

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.5 spent 3d 15h and 17,333,606 tokens on this with the user in an interactive session.
