### PR TITLE
GH#28301: preserve author filters in REST fallback

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -821,9 +821,10 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# issue/pr list/view fields onto gh-shaped output, and REST-first mode may
 		# use them while GraphQL is healthy when the args are semantically safe.
 		case "$_SHIM_READ_REWRITE" in
-		pr:list) _rest_pr_list_can_preserve_args "$@" || return 1 ;;
-		pr:view) _rest_pr_view_can_preserve_args "$@" || return 1 ;;
-		issue:list | issue:view) ;;
+		pr:list) _rest_pr_list_can_preserve_args "${@:3}" || return 1 ;;
+		pr:view) _rest_pr_view_can_preserve_args "${@:3}" || return 1 ;;
+		issue:list) _rest_issue_list_can_preserve_args "${@:3}" || return 1 ;;
+		issue:view) _rest_issue_view_can_preserve_args "${@:3}" || return 1 ;;
 		*)
 			_shim_read_has_json_flag "$@" && return 1
 			;;
@@ -840,20 +841,19 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# Record the call as REST under the original gh operation. The REST
 		# translator records its own _rest_* label too; this shadow record keeps
 		# before/after ratios visible for the original high-frequency command.
-		gh_record_call rest "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
+		local _route_path="rest"
+		if { [[ "$_SHIM_READ_REWRITE" == "pr:list" ]] && _rest_args_have_author "${_SHIM_REST_ARGS[@]}"; } ||
+			{ [[ "$_SHIM_READ_REWRITE" == "issue:list" ]] && _rest_args_have_search "${_SHIM_REST_ARGS[@]}"; }; then
+			_route_path="search-rest"
+		fi
+		gh_record_call "$_route_path" "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
 
 		# Dispatch to the appropriate REST translator.
 		case "$_SHIM_READ_REWRITE" in
 		pr:view)    _rest_pr_view "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
 		issue:view) _rest_issue_view "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
-		pr:list)    _rest_pr_list "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
-		issue:list)
-			if _rest_args_have_search "${_SHIM_REST_ARGS[@]}"; then
-				_rest_issue_search "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO"
-			else
-				_rest_issue_list "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO"
-			fi
-			;;
+		pr:list)    _rest_pr_list_dispatch "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
+		issue:list) _rest_issue_list_dispatch "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
 		*) return 1 ;;
 		esac
 		return $?

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -14,12 +14,9 @@
 #   _rest_pr_comment, _rest_issue_edit, _rest_pr_create.
 # Read translators (t2689, t2772): _rest_issue_view, _rest_issue_list, _rest_pr_list.
 #
-# Note on field mapping (_rest_issue_view): `gh issue view --json id` returns
-# the GraphQL node_id (e.g. I_kgDO...). The REST endpoint stores this in the
-# `node_id` field, not `id`. Callers that need the node_id for GraphQL mutations
-# should note that those mutations will also fail during GraphQL exhaustion, so
-# the discrepancy is benign in practice. All other fields (state, title, body,
-# labels, assignees, createdAt) map directly between gh and REST responses.
+# Read rewrites are guarded by operation-specific argument and JSON-field
+# validators. Shapes without an exact REST equivalent remain on native gh and
+# never reach the permissive translator path.
 #
 # Loaded by shared-gh-wrappers.sh. Do not source directly.
 #
@@ -29,13 +26,22 @@
 [[ -n "${_SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED:-}" ]] && return 0
 _SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED=1
 
-_gh_rest_fallback_dir="${BASH_SOURCE[0]%/*}"
-[[ "$_gh_rest_fallback_dir" == "${BASH_SOURCE[0]}" ]] && _gh_rest_fallback_dir="."
+_gh_rest_fallback_dir="${_SHARED_GH_WRAPPERS_DIR:-}"
+if [[ -z "$_gh_rest_fallback_dir" && -n "${BASH_SOURCE[0]:-}" ]]; then
+	_gh_rest_fallback_dir="${BASH_SOURCE[0]%/*}"
+	[[ "$_gh_rest_fallback_dir" == "${BASH_SOURCE[0]}" ]] && _gh_rest_fallback_dir="."
+elif [[ -z "$_gh_rest_fallback_dir" && -n "${ZSH_VERSION:-}" && -f "${0:-}" ]]; then
+	_gh_rest_fallback_dir="${0%/*}"
+	[[ "$_gh_rest_fallback_dir" == "$0" ]] && _gh_rest_fallback_dir="."
+fi
 if ! declare -F gh_request_state_rate_json >/dev/null 2>&1 && [[ -f "${_gh_rest_fallback_dir}/shared-gh-request-state.sh" ]]; then
 	# shellcheck source=./shared-gh-request-state.sh
 	# shellcheck disable=SC1091
 	source "${_gh_rest_fallback_dir}/shared-gh-request-state.sh"
 fi
+# shellcheck source=./shared-gh-wrappers-rest-read-semantics.sh
+# shellcheck disable=SC1091
+source "${_gh_rest_fallback_dir}/shared-gh-wrappers-rest-read-semantics.sh"
 unset _gh_rest_fallback_dir
 
 # Threshold below which we route reads/writes through REST instead of GraphQL.
@@ -359,7 +365,7 @@ _rest_args_have_search() {
 	local _arg
 	for _arg in "$@"; do
 		case "$_arg" in
-		--search|--search=*) return 0 ;;
+		--search|--search=*|-S) return 0 ;;
 		esac
 	done
 	return 1
@@ -389,69 +395,6 @@ _rest_args_json_fields() {
 		*) shift ;;
 		esac
 	done
-	return 0
-}
-
-#######################################
-# Return 0 when gh pr list argv is safe to translate to REST proactively.
-# Search and GraphQL-only fields stay on GraphQL unless budget exhaustion forces
-# legacy fallback, preserving workflow correctness over read redistribution.
-# Args: gh-style argv
-#######################################
-_rest_pr_list_can_preserve_args() {
-	_rest_args_have_search "$@" && return 1
-	local fields
-	fields="$(_rest_args_json_fields "$@")"
-	[[ -z "$fields" ]] && return 0
-	local field
-	while IFS= read -r field; do
-		case "$field" in
-		mergeable|reviewDecision|statusCheckRollup|reviews|latestReviews|comments|autoMergeRequest|mergeStateStatus) return 1 ;;
-		*) ;;
-		esac
-	done < <(_rest_split_csv "$fields")
-	return 0
-}
-
-#######################################
-# Return 0 when gh pr view argv is safe to translate to REST proactively.
-# Field classes: stable-within-cycle REST fields may use repo#PR cache; volatile
-# fields like mergeable need caller refetch after mutation; GraphQL-only fields
-# below never use REST projection.
-# Args: gh-style argv
-#######################################
-_rest_pr_view_can_preserve_args() {
-	local fields
-	fields="$(_rest_args_json_fields "$@")"
-	[[ -z "$fields" ]] && return 0
-	local field
-	while IFS= read -r field; do
-		case "$field" in
-		mergeable|statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files|reviewDecision|autoMergeRequest|mergeStateStatus) return 1 ;;
-		*) ;;
-		esac
-	done < <(_rest_split_csv "$fields")
-	return 0
-}
-
-#######################################
-# Return 0 when a failed GraphQL PR view can fall back without fabricating
-# collection fields that the single-PR REST endpoint does not provide. Explicit
-# scalar unknowns (for example reviewDecision: null) remain safe for emergency
-# fallback because callers already distinguish unknown from authoritative data.
-# Args: gh-style argv
-#######################################
-_rest_pr_view_can_emergency_fallback_args() {
-	local fields
-	fields="$(_rest_args_json_fields "$@")"
-	[[ -z "$fields" ]] && return 0
-	local field
-	while IFS= read -r field; do
-		case "$field" in
-		statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files) return 1 ;;
-		*) ;;
-		esac
-	done < <(_rest_split_csv "$fields")
 	return 0
 }
 
@@ -1002,8 +945,7 @@ _rest_pr_create() {
 # proactive REST-first routing can preserve compact gh-shaped output. Field
 # names align with `gh issue view --json` for common fields (state, title,
 # body, labels, assignees, createdAt).
-# Exception: `id` maps to the numeric issue id in REST, not the GraphQL
-# node_id — see the file header for the benign impact of this discrepancy.
+# Fields without an exact projection, including GraphQL `id`, remain native.
 #
 # Returns the underlying gh api exit code.
 #######################################
@@ -1023,17 +965,17 @@ _rest_issue_view() {
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--repo) repo="${2:-}"; shift 2 ;;
+		--repo | -R) [[ $# -ge 2 ]] || return 2; repo="${2:-}"; shift 2 ;;
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
-		--json) json_fields="${2:-}"; shift 2 ;;
+		--json) [[ $# -ge 2 ]] || return 2; json_fields="${2:-}"; shift 2 ;;
 		--json=*) json_fields="${_arg#--json=}"; shift ;;
 		# t3027: accept -q as gh's documented shorthand for --jq. Without this,
 		# callers using `gh issue view ... -q '.field'` (the idiomatic gh form)
 		# silently lost the jq filter on REST fallback and got the full issue
 		# object, breaking downstream string assignments.
-		--jq | -q) jq_expr="${2:-}"; shift 2 ;;
+		--jq | -q) [[ $# -ge 2 ]] || return 2; jq_expr="${2:-}"; shift 2 ;;
 		--jq=* | -q=*) jq_expr="${_arg#*=}"; shift ;;
-		*) shift ;;
+		*) printf '_rest_issue_view: unsupported argument: %s\n' "$_arg" >&2; return 2 ;;
 		esac
 	done
 
@@ -1044,15 +986,23 @@ _rest_issue_view() {
 		printf '_rest_issue_view: issue number and --repo are required\n' >&2
 		return 1
 	fi
+	if ! _rest_repo_slug_supported "$repo"; then
+		printf '_rest_issue_view: invalid --repo value: %s\n' "$repo" >&2
+		return 1
+	fi
 	if [[ ! "$num" =~ ^[0-9]+$ ]]; then
 		printf '_rest_issue_view: invalid issue number: %s\n' "$num" >&2
 		return 1
+	fi
+	if [[ -n "$json_fields" ]] && ! _rest_issue_view_fields_supported "$json_fields"; then
+		printf '_rest_issue_view: unsupported JSON field set: %s\n' "$json_fields" >&2
+		return 2
 	fi
 
 	local _path="/repos/${repo}/issues/${num}"
 	local _gh_cmd=(gh api "$_path")
 	if [[ -n "$json_fields" ]]; then
-		jq_expr="$(_rest_issue_object_json_jq "$json_fields" "$jq_expr")"
+		jq_expr="$(_rest_issue_object_json_jq "$json_fields" "$jq_expr")" || return 1
 	fi
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	_rest_api_call read "${_gh_cmd[@]}"
@@ -1064,22 +1014,29 @@ _rest_issue_object_json_jq() {
 	local user_jq="$2"
 	local projection=""
 	local field=""
+	local actor_projection=""
+	local assignees_projection=""
+	local labels_projection=""
+	actor_projection="$(_rest_jq_actor_projection)"
+	assignees_projection="$(_rest_jq_assignees_projection)"
+	labels_projection="$(_rest_jq_labels_projection)"
 	while IFS= read -r field; do
 		[[ -z "$field" ]] && continue
 		case "$field" in
 		number) projection="${projection}${projection:+,}number: .number" ;;
-		state) projection="${projection}${projection:+,}state: .state" ;;
+		state) projection="${projection}${projection:+,}state: (.state | ascii_upcase)" ;;
 		url) projection="${projection}${projection:+,}url: .html_url" ;;
 		title) projection="${projection}${projection:+,}title: (.title // \"\")" ;;
 		body) projection="${projection}${projection:+,}body: (.body // \"\")" ;;
 		createdAt) projection="${projection}${projection:+,}createdAt: .created_at" ;;
 		updatedAt) projection="${projection}${projection:+,}updatedAt: .updated_at" ;;
 		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
-		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;
-		assignees) projection="${projection}${projection:+,}assignees: (.assignees // [])" ;;
-		author) projection="${projection}${projection:+,}author: (.user // {})" ;;
-		comments) projection="${projection}${projection:+,}comments: .comments" ;;
-		*) projection="${projection}${projection:+,}${field}: .${field}" ;;
+		labels) projection="${projection}${projection:+,}labels: ((.labels // []) | ${labels_projection})" ;;
+		assignees) projection="${projection}${projection:+,}assignees: ((.assignees // []) | ${assignees_projection})" ;;
+		author) projection="${projection}${projection:+,}author: (.user | ${actor_projection})" ;;
+		stateReason) projection="${projection}${projection:+,}stateReason: (if .state_reason == null then null else (.state_reason | ascii_upcase) end)" ;;
+		closed) projection="${projection}${projection:+,}closed: (.state == \"closed\")" ;;
+		*) return 1 ;;
 		esac
 	done < <(_rest_split_csv "$fields")
 	[[ -z "$projection" ]] && projection="number: .number"
@@ -1106,13 +1063,13 @@ _rest_pr_view() {
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--repo) repo="${2:-}"; shift 2 ;;
+		--repo | -R) [[ $# -ge 2 ]] || return 2; repo="${2:-}"; shift 2 ;;
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
-		--json) json_fields="${2:-}"; shift 2 ;;
+		--json) [[ $# -ge 2 ]] || return 2; json_fields="${2:-}"; shift 2 ;;
 		--json=*) json_fields="${_arg#--json=}"; shift ;;
-		--jq | -q) jq_expr="${2:-}"; shift 2 ;;
+		--jq | -q) [[ $# -ge 2 ]] || return 2; jq_expr="${2:-}"; shift 2 ;;
 		--jq=* | -q=*) jq_expr="${_arg#*=}"; shift ;;
-		*) shift ;;
+		*) printf '_rest_pr_view: unsupported argument: %s\n' "$_arg" >&2; return 2 ;;
 		esac
 	done
 
@@ -1123,9 +1080,17 @@ _rest_pr_view() {
 		printf '_rest_pr_view: PR number and --repo are required\n' >&2
 		return 1
 	fi
+	if ! _rest_repo_slug_supported "$repo"; then
+		printf '_rest_pr_view: invalid --repo value: %s\n' "$repo" >&2
+		return 1
+	fi
 	if [[ ! "$num" =~ ^[0-9]+$ ]]; then
 		printf '_rest_pr_view: invalid PR number: %s\n' "$num" >&2
 		return 1
+	fi
+	if [[ -n "$json_fields" ]] && ! _rest_pr_view_fields_supported emergency "$json_fields"; then
+		printf '_rest_pr_view: unsupported JSON field set: %s\n' "$json_fields" >&2
+		return 2
 	fi
 
 	local cache_path=""
@@ -1175,7 +1140,7 @@ _rest_pr_view() {
 		return $?
 	fi
 	if [[ -n "$json_fields" ]]; then
-		jq_expr="$(_rest_pr_object_json_jq "$json_fields" "$jq_expr")"
+		jq_expr="$(_rest_pr_object_json_jq "$json_fields" "$jq_expr")" || return 1
 	fi
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	_rest_api_call read "${_gh_cmd[@]}"
@@ -1187,6 +1152,10 @@ _rest_pr_object_json_jq() {
 	local user_jq="$2"
 	local projection=""
 	local field=""
+	local actor_projection=""
+	local labels_projection=""
+	actor_projection="$(_rest_jq_actor_projection)"
+	labels_projection="$(_rest_jq_labels_projection)"
 	while IFS= read -r field; do
 		[[ -z "$field" ]] && continue
 		case "$field" in
@@ -1196,12 +1165,11 @@ _rest_pr_object_json_jq() {
 		mergedAt) projection="${projection}${projection:+,}mergedAt: .merged_at" ;;
 		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
 		mergeCommit) projection="${projection}${projection:+,}mergeCommit: (if (.merge_commit_sha // \"\") != \"\" then {oid: .merge_commit_sha} else null end)" ;;
-		mergedBy) projection="${projection}${projection:+,}mergedBy: .merged_by" ;;
+		mergedBy) projection="${projection}${projection:+,}mergedBy: (.merged_by | ${actor_projection})" ;;
 		mergeable) projection="${projection}${projection:+,}mergeable: (.mergeable | if . == true then \"MERGEABLE\" elif . == false then \"CONFLICTING\" else (. // \"UNKNOWN\") end)" ;;
-		reviewDecision) projection="${projection}${projection:+,}reviewDecision: null" ;;
 		isDraft) projection="${projection}${projection:+,}isDraft: (.draft // false)" ;;
-		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;
-		author) projection="${projection}${projection:+,}author: (.user // {})" ;;
+		labels) projection="${projection}${projection:+,}labels: ((.labels // []) | ${labels_projection})" ;;
+		author) projection="${projection}${projection:+,}author: (.user | ${actor_projection})" ;;
 		title) projection="${projection}${projection:+,}title: (.title // \"\")" ;;
 		body) projection="${projection}${projection:+,}body: (.body // \"\")" ;;
 		url) projection="${projection}${projection:+,}url: .html_url" ;;
@@ -1210,9 +1178,7 @@ _rest_pr_object_json_jq() {
 		baseRefName) projection="${projection}${projection:+,}baseRefName: (.base.ref // \"\")" ;;
 		headRefName) projection="${projection}${projection:+,}headRefName: (.head.ref // \"\")" ;;
 		headRefOid) projection="${projection}${projection:+,}headRefOid: (.head.sha // \"\")" ;;
-		autoMergeRequest) projection="${projection}${projection:+,}autoMergeRequest: (.autoMergeRequest // null)" ;;
-		mergeStateStatus) projection="${projection}${projection:+,}mergeStateStatus: (.mergeStateStatus // \"\")" ;;
-		*) projection="${projection}${projection:+,}${field}: .${field}" ;;
+		*) return 1 ;;
 		esac
 	done < <(_rest_split_csv "$fields")
 	[[ -z "$projection" ]] && projection="number: .number"
@@ -1228,10 +1194,9 @@ _rest_pr_object_json_jq() {
 # --json, --jq, -q) and returns a JSON array or jq-filtered output.
 # Mirrors `gh pr list` for state/head/base filtering.
 #
-# The --search flag is not supported by the REST pulls endpoint. The wrapper
-# keeps PR search on the GraphQL path instead of silently degrading semantics.
-# --json FIELDS is accepted for parity but ignored (the REST endpoint
-# returns the full object; use --jq/-q to select).
+# Search-only filters are handled by the sibling read-semantics translator or
+# rejected here. JSON fields are projected to gh-compatible names; unsupported
+# fields fail before any API request.
 #
 # Returns the underlying gh api exit code.
 #######################################
@@ -1241,27 +1206,32 @@ _rest_pr_list_json_jq() {
 	local source_filter="${3:-.}"
 	local projection=""
 	local field=""
+	local actor_projection=""
+	local assignees_projection=""
+	local labels_projection=""
+	actor_projection="$(_rest_jq_actor_projection)"
+	assignees_projection="$(_rest_jq_assignees_projection)"
+	labels_projection="$(_rest_jq_labels_projection)"
 	while IFS= read -r field; do
 		[[ -z "$field" ]] && continue
 		case "$field" in
 		number) projection="${projection}${projection:+,}number: .number" ;;
-		state) projection="${projection}${projection:+,}state: (if .merged_at != null then \"MERGED\" else .state end)" ;;
-		mergeable) projection="${projection}${projection:+,}mergeable: (.mergeable | if . == true then \"MERGEABLE\" elif . == false then \"CONFLICTING\" else (. // \"UNKNOWN\") end)" ;;
-		reviewDecision) projection="${projection}${projection:+,}reviewDecision: null" ;;
+		state) projection="${projection}${projection:+,}state: (if .merged_at != null then \"MERGED\" else (.state | ascii_upcase) end)" ;;
 		isDraft) projection="${projection}${projection:+,}isDraft: (.draft // false)" ;;
-		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;
+		labels) projection="${projection}${projection:+,}labels: ((.labels // []) | ${labels_projection})" ;;
 		mergedAt) projection="${projection}${projection:+,}mergedAt: .merged_at" ;;
 		url) projection="${projection}${projection:+,}url: .html_url" ;;
 		title) projection="${projection}${projection:+,}title: .title" ;;
-		body) projection="${projection}${projection:+,}body: .body" ;;
+		body) projection="${projection}${projection:+,}body: (.body // \"\")" ;;
 		createdAt) projection="${projection}${projection:+,}createdAt: .created_at" ;;
 		updatedAt) projection="${projection}${projection:+,}updatedAt: .updated_at" ;;
 		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
 		baseRefName) projection="${projection}${projection:+,}baseRefName: .base.ref" ;;
 		headRefName) projection="${projection}${projection:+,}headRefName: .head.ref" ;;
 		headRefOid) projection="${projection}${projection:+,}headRefOid: .head.sha" ;;
-		author) projection="${projection}${projection:+,}author: (.user // {})" ;;
-		*) projection="${projection}${projection:+,}${field}: .${field}" ;;
+		author) projection="${projection}${projection:+,}author: (.user | ${actor_projection})" ;;
+		assignees) projection="${projection}${projection:+,}assignees: ((.assignees // []) | ${assignees_projection})" ;;
+		*) return 1 ;;
 		esac
 	done < <(_rest_split_csv "$fields")
 	[[ -z "$projection" ]] && projection="number: .number"
@@ -1281,71 +1251,77 @@ _rest_pr_list() {
 	local head_branch=""
 	local base_branch=""
 	local rest_state=""
-	local source_filter="."
 
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--repo) repo="${2:-}"; shift 2 ;;
+		--repo | -R) [[ $# -ge 2 ]] || return 2; repo="${2:-}"; shift 2 ;;
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
-		--state) state="${2:-}"; shift 2 ;;
+		--state | -s) [[ $# -ge 2 ]] || return 2; state="${2:-}"; shift 2 ;;
 		--state=*) state="${_arg#--state=}"; shift ;;
-		--head) head_branch="${2:-}"; shift 2 ;;
+		--head | -H) [[ $# -ge 2 ]] || return 2; head_branch="${2:-}"; shift 2 ;;
 		--head=*) head_branch="${_arg#--head=}"; shift ;;
-		--base) base_branch="${2:-}"; shift 2 ;;
+		--base | -B) [[ $# -ge 2 ]] || return 2; base_branch="${2:-}"; shift 2 ;;
 		--base=*) base_branch="${_arg#--base=}"; shift ;;
-		--limit) limit="${2:-}"; shift 2 ;;
+		--limit | -L) [[ $# -ge 2 ]] || return 2; limit="${2:-}"; shift 2 ;;
 		--limit=*) limit="${_arg#--limit=}"; shift ;;
-		--json) json_fields="${2:-}"; shift 2 ;;
+		--json) [[ $# -ge 2 ]] || return 2; json_fields="${2:-}"; shift 2 ;;
 		--json=*) json_fields="${_arg#--json=}"; shift ;;
-		--jq) jq_expr="${2:-}"; shift 2 ;;
-		--jq=*) jq_expr="${_arg#--jq=}"; shift ;;
-		-q) jq_expr="${2:-}"; shift 2 ;;
-		--search|--search=*) printf '_rest_pr_list: --search is not supported by REST fallback\n' >&2; return 2 ;;
-		*) shift ;;
+		--jq | -q) [[ $# -ge 2 ]] || return 2; jq_expr="${2:-}"; shift 2 ;;
+		--jq=* | -q=*) jq_expr="${_arg#*=}"; shift ;;
+		--author | -A | --author=* | --assignee | -a | --assignee=* | --label | -l | --label=* | --search | -S | --search=* | --draft | -d)
+			printf '_rest_pr_list: argument requires Search API routing: %s\n' "$_arg" >&2
+			return 2
+			;;
+		*) printf '_rest_pr_list: unsupported argument: %s\n' "$_arg" >&2; return 2 ;;
 		esac
 	done
 
-	if [[ -z "$repo" ]]; then
-		printf '_rest_pr_list: --repo is required\n' >&2
+	if [[ -z "$repo" || ! "$limit" =~ ^[1-9][0-9]*$ ]] || ! _rest_repo_slug_supported "$repo"; then
+		printf '_rest_pr_list: --repo and a positive --limit are required\n' >&2
 		return 1
 	fi
-
-	rest_state="$state"
-	if [[ "$state" == "merged" ]]; then
-		rest_state="closed"
-		source_filter='map(select(.merged_at != null))'
+	if [[ -n "$json_fields" ]] && ! _rest_pr_list_fields_supported direct "$json_fields"; then
+		printf '_rest_pr_list: unsupported JSON field set: %s\n' "$json_fields" >&2
+		return 2
 	fi
 
-	local _query="state=${rest_state}&per_page=${limit}"
+	case "$state" in
+	open | all) rest_state="$state" ;;
+	closed | merged) rest_state="closed" ;;
+	*) printf '_rest_pr_list: unsupported state: %s\n' "$state" >&2; return 2 ;;
+	esac
+
+	local page_size="$limit"
+	[[ "$page_size" -le 100 ]] || page_size=100
+	local _query="state=${rest_state}&per_page=${page_size}"
 	if [[ -n "$head_branch" ]]; then
 		local _head_encoded
 		if [[ "$head_branch" != *:* ]]; then
 			head_branch="${repo%%/*}:${head_branch}"
 		fi
-		_head_encoded=$(jq -rn --arg v "$head_branch" '$v | @uri')
+		_head_encoded=$(jq -rn --arg v "$head_branch" '$v | @uri') || return 1
 		_query="${_query}&head=${_head_encoded}"
 	fi
 	if [[ -n "$base_branch" ]]; then
 		local _base_encoded
-		_base_encoded=$(jq -rn --arg v "$base_branch" '$v | @uri')
+		_base_encoded=$(jq -rn --arg v "$base_branch" '$v | @uri') || return 1
 		_query="${_query}&base=${_base_encoded}"
 	fi
 
-	local _path="/repos/${repo}/pulls?${_query}"
-	local _gh_cmd=(gh api "$_path")
+	local result=""
+	result="$(_rest_pr_list_collect_pages "$repo" "$_query" "$state" "$limit" "$page_size")" || return 1
 	if [[ -n "$json_fields" ]]; then
-		jq_expr="$(_rest_pr_list_json_jq "$json_fields" "$jq_expr" "$source_filter")"
-	elif [[ "$source_filter" != "." ]]; then
-		if [[ -n "$jq_expr" ]]; then
-			jq_expr="${source_filter} | ${jq_expr}"
-		else
-			jq_expr="$source_filter"
-		fi
+		local projection=""
+		projection="$(_rest_pr_list_json_jq "$json_fields" "" ".")" || return 1
+		result=$(printf '%s' "$result" | jq -c "$projection") || return 1
 	fi
-	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
-	_rest_api_call read "${_gh_cmd[@]}"
-	return $?
+	if [[ -n "$jq_expr" ]]; then
+		printf '%s' "$result" | jq -r "$jq_expr"
+		return $?
+	fi
+	printf '%s\n' "$result"
+	return 0
 }
 
 #######################################
@@ -1356,11 +1332,9 @@ _rest_pr_list() {
 #
 # Multiple --label flags are collected and joined into a comma-separated
 # `?labels=` query parameter (GitHub REST AND semantics — same as gh CLI).
-# The --search flag is not supported by this REST translator and is silently
-# skipped; callers that require full-text search semantics must use the
-# GraphQL / Search API path. --json FIELDS maps common gh field names onto
-# REST field names so low-budget list polling can avoid GraphQL without
-# breaking compact JSON callers.
+# Search is handled by the sibling Search API translator. Unknown flags and
+# unsupported JSON fields fail before any API request rather than broadening the
+# result set.
 #
 # Returns the underlying gh api exit code.
 #######################################
@@ -1369,22 +1343,29 @@ _rest_issue_list_json_jq() {
 	local user_jq="$2"
 	local projection=""
 	local field=""
+	local actor_projection=""
+	local assignees_projection=""
+	local labels_projection=""
+	actor_projection="$(_rest_jq_actor_projection)"
+	assignees_projection="$(_rest_jq_assignees_projection)"
+	labels_projection="$(_rest_jq_labels_projection)"
 	while IFS= read -r field; do
 		[[ -z "$field" ]] && continue
 		case "$field" in
 		number) projection="${projection}${projection:+,}number: .number" ;;
-		state) projection="${projection}${projection:+,}state: .state" ;;
+		state) projection="${projection}${projection:+,}state: (.state | ascii_upcase)" ;;
 		url) projection="${projection}${projection:+,}url: .html_url" ;;
 		title) projection="${projection}${projection:+,}title: .title" ;;
-		body) projection="${projection}${projection:+,}body: .body" ;;
+		body) projection="${projection}${projection:+,}body: (.body // \"\")" ;;
 		createdAt) projection="${projection}${projection:+,}createdAt: .created_at" ;;
 		updatedAt) projection="${projection}${projection:+,}updatedAt: .updated_at" ;;
 		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
-		labels) projection="${projection}${projection:+,}labels: (.labels // [])" ;;
-		assignees) projection="${projection}${projection:+,}assignees: (.assignees // [])" ;;
-		author) projection="${projection}${projection:+,}author: (.user // {})" ;;
-		comments) projection="${projection}${projection:+,}comments: .comments" ;;
-		*) projection="${projection}${projection:+,}${field}: .${field}" ;;
+		labels) projection="${projection}${projection:+,}labels: ((.labels // []) | ${labels_projection})" ;;
+		assignees) projection="${projection}${projection:+,}assignees: ((.assignees // []) | ${assignees_projection})" ;;
+		author) projection="${projection}${projection:+,}author: (.user | ${actor_projection})" ;;
+		stateReason) projection="${projection}${projection:+,}stateReason: (if .state_reason == null then null else (.state_reason | ascii_upcase) end)" ;;
+		closed) projection="${projection}${projection:+,}closed: (.state == \"closed\")" ;;
+		*) return 1 ;;
 		esac
 	done < <(_rest_split_csv "$fields")
 	[[ -z "$projection" ]] && projection="number: .number"
@@ -1406,6 +1387,7 @@ _rest_issue_list() {
 	local user_jq=""
 	local json_fields=""
 	local assignee=""
+	local author=""
 	local -a labels
 	local _tok
 	labels=()
@@ -1413,33 +1395,42 @@ _rest_issue_list() {
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--repo) repo="${2:-}"; shift 2 ;;
+		--repo | -R) [[ $# -ge 2 ]] || return 2; repo="${2:-}"; shift 2 ;;
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
-		--state) state="${2:-}"; shift 2 ;;
+		--state | -s) [[ $# -ge 2 ]] || return 2; state="${2:-}"; shift 2 ;;
 		--state=*) state="${_arg#--state=}"; shift ;;
-		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${2:-}"); shift 2 ;;
+		--label | -l) [[ $# -ge 2 ]] || return 2; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${2:-}"); shift 2 ;;
 		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${_arg#--label=}"); shift ;;
-		--assignee) assignee="${2:-}"; shift 2 ;;
+		--assignee | -a) [[ $# -ge 2 ]] || return 2; assignee="${2:-}"; shift 2 ;;
 		--assignee=*) assignee="${_arg#--assignee=}"; shift ;;
-		--limit) limit="${2:-}"; shift 2 ;;
+		--author | -A) [[ $# -ge 2 ]] || return 2; author="${2:-}"; shift 2 ;;
+		--author=*) author="${_arg#--author=}"; shift ;;
+		--limit | -L) [[ $# -ge 2 ]] || return 2; limit="${2:-}"; shift 2 ;;
 		--limit=*) limit="${_arg#--limit=}"; shift ;;
-		--json) json_fields="${2:-}"; shift 2 ;;
+		--json) [[ $# -ge 2 ]] || return 2; json_fields="${2:-}"; shift 2 ;;
 		--json=*) json_fields="${_arg#--json=}"; shift ;;
-		--jq) jq_expr="${2:-}"; shift 2 ;;
-		--jq=*) jq_expr="${_arg#--jq=}"; shift ;;
-		-q) jq_expr="${2:-}"; shift 2 ;;
-		-q=*) jq_expr="${_arg#*=}"; shift ;;
-		--search) shift 2 ;;
-		--search=*) shift ;;
-		*) shift ;;
+		--jq | -q) [[ $# -ge 2 ]] || return 2; jq_expr="${2:-}"; shift 2 ;;
+		--jq=* | -q=*) jq_expr="${_arg#*=}"; shift ;;
+		--search | -S | --search=*) printf '_rest_issue_list: --search requires Search API routing\n' >&2; return 2 ;;
+		*) printf '_rest_issue_list: unsupported argument: %s\n' "$_arg" >&2; return 2 ;;
 		esac
 	done
 	user_jq="$jq_expr"
 
-	if [[ -z "$repo" ]]; then
-		printf '_rest_issue_list: --repo is required\n' >&2
+	if [[ -z "$repo" || ! "$limit" =~ ^[1-9][0-9]*$ ]] || ! _rest_repo_slug_supported "$repo"; then
+		printf '_rest_issue_list: --repo and a positive --limit are required\n' >&2
 		return 1
 	fi
+	if [[ -n "$json_fields" ]] && ! _rest_issue_list_fields_supported "$json_fields"; then
+		printf '_rest_issue_list: unsupported JSON field set: %s\n' "$json_fields" >&2
+		return 2
+	fi
+	case "$state" in
+	open | closed | all) ;;
+	*) printf '_rest_issue_list: unsupported state: %s\n' "$state" >&2; return 2 ;;
+	esac
+	[[ -z "$author" ]] || author="$(_rest_resolve_actor_filter "$author")" || return 1
+	[[ -z "$assignee" ]] || assignee="$(_rest_resolve_actor_filter "$assignee")" || return 1
 
 	local page_size="$limit"
 	if [[ "$page_size" -gt 100 ]]; then
@@ -1451,39 +1442,27 @@ _rest_issue_list() {
 		local _label
 		for _label in "${labels[@]}"; do
 			local _enc
-			_enc=$(jq -rn --arg v "$_label" '$v | @uri')
+			_enc=$(jq -rn --arg v "$_label" '$v | @uri') || return 1
 			_labels_encoded="${_labels_encoded:+${_labels_encoded}%2C}${_enc}"
 		done
 		_query="${_query}&labels=${_labels_encoded}"
 	fi
 	if [[ -n "$assignee" ]]; then
 		local _assignee_encoded
-		_assignee_encoded=$(jq -rn --arg v "$assignee" '$v | @uri')
+		_assignee_encoded=$(jq -rn --arg v "$assignee" '$v | @uri') || return 1
 		_query="${_query}&assignee=${_assignee_encoded}"
 	fi
+	if [[ -n "$author" ]]; then
+		local _author_encoded
+		_author_encoded=$(jq -rn --arg v "$author" '$v | @uri') || return 1
+		_query="${_query}&creator=${_author_encoded}"
+	fi
 
-	local page=1
-	local raw_page=""
-	local raw_count=0
-	local issue_count=0
-	local combined='[]'
-	while [[ "$issue_count" -lt "$limit" ]]; do
-		local _path="/repos/${repo}/issues?${_query}&page=${page}"
-		if ! raw_page=$(_rest_api_call read gh api "$_path"); then
-			return 1
-		fi
-		raw_count=$(printf '%s' "$raw_page" | jq 'length' 2>/dev/null) || return 1
-		combined=$(printf '%s\n%s\n' "$combined" "$raw_page" | jq -sc \
-			'.[0] + [.[1][] | select(.pull_request == null)]') || return 1
-		issue_count=$(printf '%s' "$combined" | jq 'length' 2>/dev/null) || return 1
-		if [[ "$raw_count" -lt "$page_size" ]]; then
-			break
-		fi
-		page=$((page + 1))
-	done
+	local combined=""
+	combined="$(_rest_issue_list_collect_pages "$repo" "$_query" "$limit" "$page_size")" || return 1
 
 	if [[ -n "$json_fields" ]]; then
-		jq_expr="$(_rest_issue_list_json_jq "$json_fields" "")"
+		jq_expr="$(_rest_issue_list_json_jq "$json_fields" "")" || return 1
 	else
 		jq_expr='[.[] | select(.pull_request == null)]'
 	fi
@@ -1494,105 +1473,5 @@ _rest_issue_list() {
 	else
 		printf '%s\n' "$result"
 	fi
-	return $?
-}
-
-#######################################
-# _rest_issue_search: GET /search/issues?q=...  (t2995)
-# REST-side equivalent of `gh issue list --search`; preserves full-text search
-# semantics because /repos/{owner}/{repo}/issues does not support --search.
-#
-# Translation:
-#   gh issue list --repo OWNER/REPO --state open \
-#     --label LABEL --search QUERY --json number --jq '.[0].number'
-# becomes:
-#   gh api /search/issues?q=QUERY+repo:OWNER/REPO+is:issue+is:open+label:LABEL \
-#     --jq '.items[0].number'
-#
-# Notes: Search has its own quota; caller jq expressions are applied to `.items`.
-#
-# Returns the underlying gh api exit code.
-#######################################
-_rest_issue_search() {
-	gh_record_call search-rest _rest_issue_search 2>/dev/null || true
-	local repo=""
-	local state=""
-	local search=""
-	local limit=30
-	local jq_expr=""
-	local -a labels
-	local _tok
-	labels=()
-
-	while [[ $# -gt 0 ]]; do
-		local _arg="$1"
-		case "$_arg" in
-		--repo) repo="${2:-}"; shift 2 ;;
-		--repo=*) repo="${_arg#--repo=}"; shift ;;
-		--state) state="${2:-}"; shift 2 ;;
-		--state=*) state="${_arg#--state=}"; shift ;;
-		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${2:-}"); shift 2 ;;
-		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${_arg#--label=}"); shift ;;
-		--limit) limit="${2:-}"; shift 2 ;;
-		--limit=*) limit="${_arg#--limit=}"; shift ;;
-		--search) search="${2:-}"; shift 2 ;;
-		--search=*) search="${_arg#--search=}"; shift ;;
-		--json) shift 2 ;;
-		--json=*) shift ;;
-		--jq) jq_expr="${2:-}"; shift 2 ;;
-		--jq=*) jq_expr="${_arg#--jq=}"; shift ;;
-		*) shift ;;
-		esac
-	done
-
-	if [[ -z "$repo" || -z "$search" ]]; then
-		printf '_rest_issue_search: --repo and --search are required\n' >&2
-		return 1
-	fi
-
-	# Build the q= parameter. Each token is URI-encoded individually then
-	# joined with `+`. The repo:/is:issue/state qualifiers go AFTER the
-	# user-supplied search to preserve the user's term ordering.
-	local _q
-	_q=$(jq -rn --arg v "$search" '$v | @uri')
-	local _repo_enc
-	_repo_enc=$(jq -rn --arg v "$repo" '$v | @uri')
-	_q="${_q}+repo:${_repo_enc}+is:issue"
-	if [[ -n "$state" && "$state" != "all" ]]; then
-		# /search/issues uses `is:open` / `is:closed`, not `state:`.
-		_q="${_q}+is:${state}"
-	fi
-	local _label
-	for _label in "${labels[@]}"; do
-		local _label_enc
-		_label_enc=$(jq -rn --arg v "$_label" '$v | @uri')
-		_q="${_q}+label:%22${_label_enc}%22"
-	done
-
-	local _path="/search/issues?q=${_q}&per_page=${limit}"
-
-	# Translate caller's jq (which expects a flat array) into one that
-	# operates on .items. If no --jq, just return .items as a JSON array.
-	local _final_jq
-	if [[ -n "$jq_expr" ]]; then
-		_final_jq=".items | ${jq_expr}"
-	else
-		_final_jq=".items"
-	fi
-
-	local _raw_response=""
-	local _body=""
-	local _rc=0
-	local _gh_cmd=(gh api -i "$_path")
-	_raw_response="$(_rest_api_call read "${_gh_cmd[@]}")"
-	_rc=$?
-	if [[ "$_rc" -ne 0 ]]; then
-		return "$_rc"
-	fi
-
-	_body="$(awk 'BEGIN { body = 0 } { line = $0; sub(/\r$/, "", line); if (body) { print; next } if (line == "") { body = 1 } }' <<<"$_raw_response")"
-	[[ -z "$_body" && "$_raw_response" != HTTP/* ]] && _body="$_raw_response"
-	[[ -z "$_body" ]] && { printf '[]\n'; return 0; }
-	printf '%s\n' "$_body" | jq -r "$_final_jq"
 	return $?
 }

--- a/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
@@ -1,0 +1,671 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Exact argument validation and Search API translation for gh REST reads.
+
+[[ -n "${_SHARED_GH_WRAPPERS_REST_READ_SEMANTICS_LOADED:-}" ]] && return 0
+_SHARED_GH_WRAPPERS_REST_READ_SEMANTICS_LOADED=1
+
+_REST_READ_STATE_OPEN="open"
+_REST_READ_MODE_SEARCH="search"
+
+_rest_args_have_author() {
+	local arg=""
+	for arg in "$@"; do
+		case "$arg" in
+		--author|--author=*|-A) return 0 ;;
+		esac
+	done
+	return 1
+}
+
+_rest_resolve_actor_filter() {
+	local actor="$1"
+	if [[ "$actor" == "@me" ]]; then
+		if command -v _gh_with_timeout >/dev/null 2>&1; then
+			actor=$(_gh_with_timeout read gh api user --jq '.login // ""' 2>/dev/null) || actor=""
+		else
+			actor=$(gh api user --jq '.login // ""' 2>/dev/null) || actor=""
+		fi
+	fi
+	# GitHub.com user logins use alphanumerics and hyphens; Enterprise Managed
+	# Users may include an underscore suffix, and app identities use [bot].
+	if [[ ! "$actor" =~ ^[A-Za-z0-9_-]+(\[bot\])?$ ]]; then
+		printf '_rest_resolve_actor_filter: unable to resolve a concrete login\n' >&2
+		return 1
+	fi
+	printf '%s' "$actor"
+	return 0
+}
+
+_rest_repo_slug_supported() {
+	local repo="$1"
+	[[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+	return $?
+}
+
+_rest_jq_actor_projection() {
+	printf '(if . == null then null else {id: .node_id, is_bot: (.type == "Bot"), login: .login, name: (.name // null)} end)'
+	return 0
+}
+
+_rest_jq_assignees_projection() {
+	printf '[.[] | {databaseId: .id, id: .node_id, login: .login, name: (.name // null)}]'
+	return 0
+}
+
+_rest_jq_labels_projection() {
+	printf '[.[] | {id: .node_id, name: .name, description: .description, color: .color}]'
+	return 0
+}
+
+_rest_limit_array_json() {
+	local limit="$1"
+	jq -c ".[:${limit}]"
+	return $?
+}
+
+_rest_search_quoted_qualifier() {
+	local name="$1"
+	local value="$2"
+	[[ "$name" =~ ^[a-z]+$ && -n "$value" ]] || return 1
+	case "$value" in
+	*\"* | *\\* | *$'\n'* | *$'\r'*) return 1 ;;
+	esac
+	printf '%s:"%s"' "$name" "$value"
+	return 0
+}
+
+_rest_issue_list_fields_supported() {
+	local fields="$1"
+	local field=""
+	while IFS= read -r field; do
+		case "$field" in
+		number|state|url|title|body|createdAt|updatedAt|closedAt|labels|assignees|author|stateReason|closed) ;;
+		*) return 1 ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	return 0
+}
+
+_rest_issue_list_can_preserve_args() {
+	local has_json=0
+	local has_search=0
+	local repo=""
+	local fields=""
+	local limit=30
+	local state="$_REST_READ_STATE_OPEN"
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--repo|-R)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			repo="$2"
+			shift 2
+			;;
+		--label|-l|--assignee|-a|--author|-A|--jq|-q)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			shift 2
+			;;
+		--state|-s)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			state="$2"
+			shift 2
+			;;
+		--limit|-L)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			limit="$2"
+			shift 2
+			;;
+		--search|-S)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			has_search=1
+			shift 2
+			;;
+		--json)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			has_json=1
+			fields="$2"
+			shift 2
+			;;
+		--repo=*)
+			repo="${arg#--repo=}"
+			[[ -n "$repo" ]] || return 1
+			shift
+			;;
+		--label=*|--assignee=*|--author=*|--jq=*|-q=*)
+			[[ -n "${arg#*=}" ]] || return 1
+			shift
+			;;
+		--state=*) state="${arg#--state=}"; shift ;;
+		--limit=*) limit="${arg#--limit=}"; shift ;;
+		--search=*)
+			[[ -n "${arg#--search=}" ]] || return 1
+			has_search=1
+			shift
+			;;
+		--json=*)
+			fields="${arg#--json=}"
+			[[ -n "$fields" ]] || return 1
+			has_json=1
+			shift
+			;;
+		*) return 1 ;;
+		esac
+	done
+	_rest_repo_slug_supported "$repo" || return 1
+	[[ "$has_json" -eq 1 ]] || return 1
+	[[ "$state" == "$_REST_READ_STATE_OPEN" || "$state" == "closed" || "$state" == "all" ]] || return 1
+	[[ "$limit" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ "$has_search" -eq 0 || "$limit" -le 1000 ]] || return 1
+	_rest_issue_list_fields_supported "$fields" || return 1
+	return 0
+}
+
+_rest_issue_view_fields_supported() {
+	local fields="$1"
+	local field=""
+	while IFS= read -r field; do
+		case "$field" in
+		number|state|url|title|body|createdAt|updatedAt|closedAt|labels|assignees|author|stateReason|closed) ;;
+		*) return 1 ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	return 0
+}
+
+_rest_view_reference_supported() {
+	local reference="$1"
+	[[ "$reference" =~ ^[0-9]+$ || "$reference" =~ ^https?://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(issues|pull)/[0-9]+ ]]
+	return $?
+}
+
+_rest_view_args_supported() {
+	local operation="$1"
+	local field_mode="$2"
+	shift 2
+	local reference="${1:-}"
+	_rest_view_reference_supported "$reference" || return 1
+	shift
+	local has_json=0
+	local fields=""
+	local repo=""
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--repo|-R)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			repo="$2"
+			shift 2
+			;;
+		--jq|-q)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			shift 2
+			;;
+		--json)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			has_json=1
+			fields="$2"
+			shift 2
+			;;
+		--repo=*)
+			repo="${arg#--repo=}"
+			[[ -n "$repo" ]] || return 1
+			shift
+			;;
+		--jq=*|-q=*)
+			[[ -n "${arg#*=}" ]] || return 1
+			shift
+			;;
+		--json=*)
+			fields="${arg#--json=}"
+			[[ -n "$fields" ]] || return 1
+			has_json=1
+			shift
+			;;
+		*) return 1 ;;
+		esac
+	done
+	[[ "$has_json" -eq 1 ]] || return 1
+	if [[ "$reference" =~ ^[0-9]+$ ]]; then
+		_rest_repo_slug_supported "$repo" || return 1
+	elif [[ -n "$repo" ]]; then
+		_rest_repo_slug_supported "$repo" || return 1
+	fi
+	case "${operation}:${field_mode}" in
+	issue:*) _rest_issue_view_fields_supported "$fields" ;;
+	pr:structural) return 0 ;;
+	pr:*) _rest_pr_view_fields_supported "$field_mode" "$fields" ;;
+	*) return 1 ;;
+	esac
+	return $?
+}
+
+_rest_issue_view_can_preserve_args() {
+	_rest_view_args_supported issue exact "$@"
+	return $?
+}
+
+_rest_pr_list_fields_supported() {
+	local mode="$1"
+	local fields="$2"
+	local field=""
+	while IFS= read -r field; do
+		case "$mode:$field" in
+		direct:number|direct:state|direct:isDraft|direct:labels|direct:mergedAt|direct:url|direct:title|direct:body|direct:createdAt|direct:updatedAt|direct:closedAt|direct:baseRefName|direct:headRefName|direct:headRefOid|direct:author|direct:assignees) ;;
+		search:number|search:state|search:isDraft|search:labels|search:mergedAt|search:url|search:title|search:body|search:createdAt|search:updatedAt|search:closedAt|search:author|search:assignees) ;;
+		*) return 1 ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	return 0
+}
+
+_rest_pr_view_fields_supported() {
+	local mode="$1"
+	local fields="$2"
+	local field=""
+	while IFS= read -r field; do
+		case "$field" in
+		number|state|merged|mergedAt|closedAt|mergeCommit|mergedBy|isDraft|labels|author|title|body|url|createdAt|updatedAt|baseRefName|headRefName|headRefOid) ;;
+		mergeable) [[ "$mode" == "emergency" ]] || return 1 ;;
+		*) return 1 ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	return 0
+}
+
+_rest_pr_view_args_supported() {
+	local mode="${1:-exact}"
+	shift
+	_rest_view_args_supported pr "$mode" "$@"
+	return $?
+}
+
+_rest_pr_view_can_preserve_args() {
+	_rest_pr_view_args_supported exact "$@"
+	return $?
+}
+
+_rest_pr_view_can_emergency_fallback_args() {
+	_rest_pr_view_args_supported emergency "$@"
+	return $?
+}
+
+_rest_pr_list_can_preserve_args() {
+	local mode="direct"
+	local has_json=0
+	local repo=""
+	local fields=""
+	local limit=30
+	local state="$_REST_READ_STATE_OPEN"
+	_rest_args_have_author "$@" && mode="$_REST_READ_MODE_SEARCH"
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--repo|-R)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			repo="$2"
+			shift 2
+			;;
+		--base|-B|--head|-H|--jq|-q)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			shift 2
+			;;
+		--state|-s)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			state="$2"
+			shift 2
+			;;
+		--limit|-L)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			limit="$2"
+			shift 2
+			;;
+		--json)
+			[[ $# -ge 2 && -n "${2:-}" ]] || return 1
+			has_json=1
+			fields="$2"
+			shift 2
+			;;
+		--author|-A|--assignee|-a|--label|-l|--search|-S)
+			[[ "$mode" == "$_REST_READ_MODE_SEARCH" && $# -ge 2 && -n "${2:-}" ]] || return 1
+			shift 2
+			;;
+		--draft|-d)
+			[[ "$mode" == "$_REST_READ_MODE_SEARCH" ]] || return 1
+			shift
+			;;
+		--repo=*)
+			repo="${arg#--repo=}"
+			[[ -n "$repo" ]] || return 1
+			shift
+			;;
+		--base=*|--head=*|--jq=*|-q=*)
+			[[ -n "${arg#*=}" ]] || return 1
+			shift
+			;;
+		--state=*) state="${arg#--state=}"; shift ;;
+		--limit=*) limit="${arg#--limit=}"; shift ;;
+		--json=*)
+			fields="${arg#--json=}"
+			[[ -n "$fields" ]] || return 1
+			has_json=1
+			shift
+			;;
+		--author=*|--assignee=*|--label=*|--search=*)
+			[[ "$mode" == "$_REST_READ_MODE_SEARCH" && -n "${arg#*=}" ]] || return 1
+			shift
+			;;
+		*) return 1 ;;
+		esac
+	done
+	_rest_repo_slug_supported "$repo" || return 1
+	[[ "$has_json" -eq 1 ]] || return 1
+	[[ "$state" == "$_REST_READ_STATE_OPEN" || "$state" == "closed" || "$state" == "merged" || "$state" == "all" ]] || return 1
+	[[ "$limit" =~ ^[1-9][0-9]*$ ]] || return 1
+	if [[ "$mode" == "$_REST_READ_MODE_SEARCH" ]]; then
+		[[ "$limit" -le 1000 ]] || return 1
+	fi
+	_rest_pr_list_fields_supported "$mode" "$fields" || return 1
+	return 0
+}
+
+_rest_search_response_body() {
+	local raw_response="$1"
+	local body=""
+	body="$(awk 'BEGIN { body = 0 } { line = $0; sub(/\r$/, "", line); if (body) { print; next } if (line == "") { body = 1 } }' <<<"$raw_response")"
+	[[ -z "$body" && "$raw_response" != HTTP/* ]] && body="$raw_response"
+	[[ -n "$body" ]] || body='{"items":[]}'
+	printf '%s' "$body"
+	return 0
+}
+
+_rest_pr_list_collect_pages() {
+	local repo="$1"
+	local query="$2"
+	local state="$3"
+	local limit="$4"
+	local page_size="$5"
+	local page=1
+	local raw_page=""
+	local raw_count=0
+	local match_count=0
+	local page_matches='[]'
+	local combined='[]'
+	while [[ "$match_count" -lt "$limit" ]]; do
+		raw_page=$(_rest_api_call read gh api "/repos/${repo}/pulls?${query}&page=${page}") || return 1
+		raw_count=$(printf '%s' "$raw_page" | jq 'length' 2>/dev/null) || return 1
+		case "$state" in
+		merged) page_matches=$(printf '%s' "$raw_page" | jq -c '[.[] | select(.merged_at != null)]') || return 1 ;;
+		closed) page_matches=$(printf '%s' "$raw_page" | jq -c '[.[] | select(.merged_at == null)]') || return 1 ;;
+		*) page_matches="$raw_page" ;;
+		esac
+		combined=$(printf '%s\n%s\n' "$combined" "$page_matches" | jq -sc '.[0] + .[1]') || return 1
+		match_count=$(printf '%s' "$combined" | jq 'length' 2>/dev/null) || return 1
+		[[ "$raw_count" -ge "$page_size" ]] || break
+		page=$((page + 1))
+	done
+	printf '%s' "$combined" | _rest_limit_array_json "$limit"
+	return $?
+}
+
+_rest_issue_list_collect_pages() {
+	local repo="$1"
+	local query="$2"
+	local limit="$3"
+	local page_size="$4"
+	local page=1
+	local raw_page=""
+	local raw_count=0
+	local issue_count=0
+	local combined='[]'
+	while [[ "$issue_count" -lt "$limit" ]]; do
+		raw_page=$(_rest_api_call read gh api "/repos/${repo}/issues?${query}&page=${page}") || return 1
+		raw_count=$(printf '%s' "$raw_page" | jq 'length' 2>/dev/null) || return 1
+		combined=$(printf '%s\n%s\n' "$combined" "$raw_page" | jq -sc \
+			'.[0] + [.[1][] | select(.pull_request == null)]') || return 1
+		issue_count=$(printf '%s' "$combined" | jq 'length' 2>/dev/null) || return 1
+		[[ "$raw_count" -ge "$page_size" ]] || break
+		page=$((page + 1))
+	done
+	printf '%s' "$combined" | _rest_limit_array_json "$limit"
+	return $?
+}
+
+_rest_search_collect_items() {
+	local base_path="$1"
+	local limit="$2"
+	[[ "$limit" =~ ^[1-9][0-9]*$ && "$limit" -le 1000 ]] || return 1
+	local page_size="$limit"
+	[[ "$page_size" -le 100 ]] || page_size=100
+	local page=1
+	local count=0
+	local page_count=0
+	local combined='[]'
+	while [[ "$count" -lt "$limit" ]]; do
+		local raw_response=""
+		local body=""
+		raw_response=$(_rest_api_call read gh api -i "${base_path}&per_page=${page_size}&page=${page}") || return 1
+		body="$(_rest_search_response_body "$raw_response")" || return 1
+		page_count=$(printf '%s' "$body" | jq '.items | length' 2>/dev/null) || return 1
+		combined=$(printf '%s\n%s\n' "$combined" "$body" | jq -sc '.[0] + (.[1].items // [])') || return 1
+		count=$(printf '%s' "$combined" | jq 'length' 2>/dev/null) || return 1
+		[[ "$page_count" -ge "$page_size" ]] || break
+		page=$((page + 1))
+	done
+	printf '%s' "$combined" | _rest_limit_array_json "$limit"
+	return $?
+}
+
+_rest_issue_search() {
+	gh_record_call search-rest _rest_issue_search 2>/dev/null || true
+	local repo="" state="$_REST_READ_STATE_OPEN" author="" assignee="" search="" limit=30
+	local json_fields="" jq_expr=""
+	local -a labels
+	local token=""
+	labels=()
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--repo | -R) [[ $# -ge 2 ]] || return 2; repo="${2:-}"; shift 2 ;;
+		--repo=*) repo="${arg#--repo=}"; shift ;;
+		--state | -s) [[ $# -ge 2 ]] || return 2; state="${2:-}"; shift 2 ;;
+		--state=*) state="${arg#--state=}"; shift ;;
+		--author | -A) [[ $# -ge 2 ]] || return 2; author="${2:-}"; shift 2 ;;
+		--author=*) author="${arg#--author=}"; shift ;;
+		--assignee | -a) [[ $# -ge 2 ]] || return 2; assignee="${2:-}"; shift 2 ;;
+		--assignee=*) assignee="${arg#--assignee=}"; shift ;;
+		--label | -l)
+			[[ $# -ge 2 ]] || return 2
+			while IFS= read -r token; do
+				[[ -n "$token" ]] && labels+=("$token")
+			done < <(_rest_split_csv "${2:-}")
+			shift 2
+			;;
+		--label=*)
+			while IFS= read -r token; do
+				[[ -n "$token" ]] && labels+=("$token")
+			done < <(_rest_split_csv "${arg#--label=}")
+			shift
+			;;
+		--search | -S) [[ $# -ge 2 ]] || return 2; search="${2:-}"; shift 2 ;;
+		--search=*) search="${arg#--search=}"; shift ;;
+		--limit | -L) [[ $# -ge 2 ]] || return 2; limit="${2:-}"; shift 2 ;;
+		--limit=*) limit="${arg#--limit=}"; shift ;;
+		--json) [[ $# -ge 2 ]] || return 2; json_fields="${2:-}"; shift 2 ;;
+		--json=*) json_fields="${arg#--json=}"; shift ;;
+		--jq | -q) [[ $# -ge 2 ]] || return 2; jq_expr="${2:-}"; shift 2 ;;
+		--jq=* | -q=*) jq_expr="${arg#*=}"; shift ;;
+		*) printf '_rest_issue_search: unsupported argument: %s\n' "$arg" >&2; return 2 ;;
+		esac
+	done
+	[[ -n "$repo" && -n "$search" && "$limit" =~ ^[1-9][0-9]*$ && "$limit" -le 1000 ]] &&
+		_rest_repo_slug_supported "$repo" || {
+		printf '_rest_issue_search: --repo, --search, and a limit <= 1000 are required\n' >&2
+		return 1
+	}
+	if [[ -n "$json_fields" ]] && ! _rest_issue_list_fields_supported "$json_fields"; then
+		printf '_rest_issue_search: unsupported JSON field set: %s\n' "$json_fields" >&2
+		return 2
+	fi
+	[[ -z "$author" ]] || author="$(_rest_resolve_actor_filter "$author")" || return 1
+	[[ -z "$assignee" ]] || assignee="$(_rest_resolve_actor_filter "$assignee")" || return 1
+	local query="${search} repo:${repo} is:issue"
+	case "$state" in
+	open | closed) query="${query} is:${state}" ;;
+	all) ;;
+	*) printf '_rest_issue_search: unsupported state: %s\n' "$state" >&2; return 2 ;;
+	esac
+	[[ -z "$author" ]] || query="${query} author:${author}"
+	[[ -z "$assignee" ]] || query="${query} assignee:${assignee}"
+	local label=""
+	local qualifier=""
+	for label in "${labels[@]}"; do
+		qualifier="$(_rest_search_quoted_qualifier label "$label")" || return 2
+		query="${query} ${qualifier}"
+	done
+	local encoded=""
+	encoded=$(jq -rn --arg value "$query" '$value | @uri') || return 1
+	local items=""
+	items="$(_rest_search_collect_items "/search/issues?q=${encoded}" "$limit")" || return 1
+	local projection='[.[] | select(.pull_request == null)]'
+	if [[ -n "$json_fields" ]]; then
+		projection="$(_rest_issue_list_json_jq "$json_fields" "")" || return 1
+	fi
+	local result=""
+	result=$(printf '%s' "$items" | jq -c "$projection") || return 1
+	if [[ -n "$jq_expr" ]]; then
+		printf '%s' "$result" | jq -r "$jq_expr"
+		return $?
+	fi
+	printf '%s\n' "$result"
+	return 0
+}
+
+_rest_pr_search_json_jq() {
+	local fields="$1"
+	local user_jq="$2"
+	local projection=""
+	local field=""
+	local actor_projection=""
+	local assignees_projection=""
+	local labels_projection=""
+	actor_projection="$(_rest_jq_actor_projection)"
+	assignees_projection="$(_rest_jq_assignees_projection)"
+	labels_projection="$(_rest_jq_labels_projection)"
+	while IFS= read -r field; do
+		case "$field" in
+		number) projection="${projection}${projection:+,}number: .number" ;;
+		state) projection="${projection}${projection:+,}state: (if .pull_request.merged_at != null then \"MERGED\" else (.state | ascii_upcase) end)" ;;
+		isDraft) projection="${projection}${projection:+,}isDraft: (.draft // false)" ;;
+		labels) projection="${projection}${projection:+,}labels: ((.labels // []) | ${labels_projection})" ;;
+		mergedAt) projection="${projection}${projection:+,}mergedAt: .pull_request.merged_at" ;;
+		url) projection="${projection}${projection:+,}url: .html_url" ;;
+		title) projection="${projection}${projection:+,}title: .title" ;;
+		body) projection="${projection}${projection:+,}body: (.body // \"\")" ;;
+		createdAt) projection="${projection}${projection:+,}createdAt: .created_at" ;;
+		updatedAt) projection="${projection}${projection:+,}updatedAt: .updated_at" ;;
+		closedAt) projection="${projection}${projection:+,}closedAt: .closed_at" ;;
+		author) projection="${projection}${projection:+,}author: (.user | ${actor_projection})" ;;
+		assignees) projection="${projection}${projection:+,}assignees: ((.assignees // []) | ${assignees_projection})" ;;
+		*) return 1 ;;
+		esac
+	done < <(_rest_split_csv "$fields")
+	local filter="[.[] | {${projection}}]"
+	[[ -n "$user_jq" ]] && filter="${filter} | ${user_jq}"
+	printf '%s' "$filter"
+	return 0
+}
+
+_rest_pr_search() {
+	gh_record_call search-rest _rest_pr_search 2>/dev/null || true
+	local repo="" state="$_REST_READ_STATE_OPEN" author="" assignee="" search="" limit=30
+	local base_branch="" head_branch="" json_fields="" jq_expr="" draft=0
+	local -a labels
+	local tok=""
+	labels=()
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--repo | -R) [[ $# -ge 2 ]] || return 2; repo="${2:-}"; shift 2 ;; --repo=*) repo="${arg#--repo=}"; shift ;;
+		--state | -s) [[ $# -ge 2 ]] || return 2; state="${2:-}"; shift 2 ;; --state=*) state="${arg#--state=}"; shift ;;
+		--author | -A) [[ $# -ge 2 ]] || return 2; author="${2:-}"; shift 2 ;; --author=*) author="${arg#--author=}"; shift ;;
+		--assignee | -a) [[ $# -ge 2 ]] || return 2; assignee="${2:-}"; shift 2 ;; --assignee=*) assignee="${arg#--assignee=}"; shift ;;
+		--label | -l) [[ $# -ge 2 ]] || return 2; while IFS= read -r tok; do [[ -n "$tok" ]] && labels+=("$tok"); done < <(_rest_split_csv "${2:-}"); shift 2 ;;
+		--label=*) while IFS= read -r tok; do [[ -n "$tok" ]] && labels+=("$tok"); done < <(_rest_split_csv "${arg#--label=}"); shift ;;
+		--search | -S) [[ $# -ge 2 ]] || return 2; search="${2:-}"; shift 2 ;; --search=*) search="${arg#--search=}"; shift ;;
+		--base | -B) [[ $# -ge 2 ]] || return 2; base_branch="${2:-}"; shift 2 ;; --base=*) base_branch="${arg#--base=}"; shift ;;
+		--head | -H) [[ $# -ge 2 ]] || return 2; head_branch="${2:-}"; shift 2 ;; --head=*) head_branch="${arg#--head=}"; shift ;;
+		--draft | -d) draft=1; shift ;;
+		--limit | -L) [[ $# -ge 2 ]] || return 2; limit="${2:-}"; shift 2 ;; --limit=*) limit="${arg#--limit=}"; shift ;;
+		--json) [[ $# -ge 2 ]] || return 2; json_fields="${2:-}"; shift 2 ;; --json=*) json_fields="${arg#--json=}"; shift ;;
+		--jq | -q) [[ $# -ge 2 ]] || return 2; jq_expr="${2:-}"; shift 2 ;; --jq=* | -q=*) jq_expr="${arg#*=}"; shift ;;
+		*) printf '_rest_pr_search: unsupported argument: %s\n' "$arg" >&2; return 2 ;;
+		esac
+	done
+	[[ -n "$repo" && -n "$author" && "$limit" =~ ^[1-9][0-9]*$ && "$limit" -le 1000 ]] &&
+		_rest_repo_slug_supported "$repo" || {
+		printf '_rest_pr_search: --repo, --author, and a limit <= 1000 are required\n' >&2
+		return 1
+	}
+	if [[ -n "$json_fields" ]] && ! _rest_pr_list_fields_supported search "$json_fields"; then
+		printf '_rest_pr_search: unsupported JSON field set: %s\n' "$json_fields" >&2
+		return 2
+	fi
+	author="$(_rest_resolve_actor_filter "$author")" || return 1
+	[[ -z "$assignee" ]] || assignee="$(_rest_resolve_actor_filter "$assignee")" || return 1
+	local query="${search}${search:+ }repo:${repo} is:pr author:${author}"
+	case "$state" in
+	open) query="${query} is:open" ;;
+	closed) query="${query} is:closed is:unmerged" ;;
+	merged) query="${query} is:merged" ;;
+	all) ;;
+	*) printf '_rest_pr_search: unsupported state: %s\n' "$state" >&2; return 2 ;;
+	esac
+	[[ -z "$assignee" ]] || query="${query} assignee:${assignee}"
+	local qualifier=""
+	if [[ -n "$base_branch" ]]; then
+		qualifier="$(_rest_search_quoted_qualifier base "$base_branch")" || return 2
+		query="${query} ${qualifier}"
+	fi
+	if [[ -n "$head_branch" ]]; then
+		qualifier="$(_rest_search_quoted_qualifier head "$head_branch")" || return 2
+		query="${query} ${qualifier}"
+	fi
+	[[ "$draft" -eq 0 ]] || query="${query} draft:true"
+	local label=""
+	for label in "${labels[@]}"; do
+		qualifier="$(_rest_search_quoted_qualifier label "$label")" || return 2
+		query="${query} ${qualifier}"
+	done
+	local encoded=""
+	encoded=$(jq -rn --arg value "$query" '$value | @uri') || return 1
+	local items=""
+	items="$(_rest_search_collect_items "/search/issues?q=${encoded}" "$limit")" || return 1
+	if [[ -n "$json_fields" ]]; then
+		jq_expr="$(_rest_pr_search_json_jq "$json_fields" "$jq_expr")" || return 1
+	fi
+	[[ -n "$jq_expr" ]] && { printf '%s' "$items" | jq -r "$jq_expr"; return $?; }
+	printf '%s\n' "$items"
+	return 0
+}
+
+_rest_pr_list_dispatch() {
+	if _rest_args_have_author "$@"; then
+		_rest_pr_search "$@"
+	else
+		_rest_pr_list "$@"
+	fi
+	return $?
+}
+
+_rest_issue_list_dispatch() {
+	if _rest_args_have_search "$@"; then
+		_rest_issue_search "$@"
+	else
+		_rest_issue_list "$@"
+	fi
+	return $?
+}
+
+return 0

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -599,12 +599,14 @@ set_issue_status() {
 #######################################
 gh_issue_view() {
 	local _first_num="${1:-}"
-	if _rest_read_first_enabled; then
+	local _rest_capable=0
+	_rest_issue_view_can_preserve_args "$@" && _rest_capable=1
+	if [[ $_rest_capable -eq 1 ]] && _rest_read_first_enabled; then
 		print_info "[INFO] gh-wrapper: REST-first read mode, routing issue view #${_first_num} to REST"
 		_rest_issue_view "$@"
 		return $?
 	fi
-	if { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_issue_view; } || _rest_should_fallback; then
+	if [[ $_rest_capable -eq 1 ]] && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_issue_view; } || _rest_should_fallback; }; then
 		print_info "[INFO] gh-wrapper: GraphQL budget low, routing issue view #${_first_num} to REST"
 		_rest_issue_view "$@"
 		return $?
@@ -612,7 +614,7 @@ gh_issue_view() {
 	gh_record_call graphql gh_issue_view 2>/dev/null || true
 	_gh_with_timeout read gh issue view "$@"
 	local rc=$?
-	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
+	if [[ $rc -ne 0 && $_rest_capable -eq 1 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue view #${_first_num}"
 		_rest_issue_view "$@"
 		rc=$?
@@ -624,9 +626,9 @@ gh_issue_view() {
 # gh_pr_list — drop-in replacement for gh pr list.  (t2772)
 # Routes directly to REST (`gh api GET /repos/{owner}/{repo}/pulls`) when
 # GraphQL remaining is below the fallback threshold, and still falls back to
-# REST if the primary call fails during an exhaustion window. Supports --state,
-# --head, --base, --limit, --json, --jq, -q. --search remains GraphQL-only
-# because the REST pulls endpoint has no equivalent search semantics.
+# REST if the primary call fails during an exhaustion window. Direct list reads
+# use /pulls; --author reads use pagination-complete Search API qualifiers.
+# Unsupported argument or JSON-field shapes remain on native GraphQL.
 #
 #   gh_pr_list --repo owner/repo --state open --json number,title
 #   gh_pr_list --repo owner/repo --state open --limit 200 --json number --jq 'length'
@@ -635,8 +637,14 @@ gh_issue_view() {
 # when both paths ran).
 #######################################
 gh_pr_list() {
-	local _has_search=1
-	_rest_args_have_search "$@" || _has_search=0
+	local _rest_capable=0
+	local _uses_search=0
+	local _pool="rest-core"
+	_rest_pr_list_can_preserve_args "$@" && _rest_capable=1
+	if _rest_args_have_author "$@"; then
+		_uses_search=1
+		_pool="rest-search"
+	fi
 	_gh_pr_list_shape_record "$@"
 	local _cached_output=""
 	if _cached_output=$(_gh_pr_list_snapshot_get "$@" 2>/dev/null); then
@@ -644,9 +652,13 @@ gh_pr_list() {
 		return 0
 	fi
 	local _out="" _rc=0
-	if [[ $_has_search -eq 0 ]] && _rest_read_first_enabled && _rest_pr_list_can_preserve_args "$@"; then
-		print_info "[INFO] gh-wrapper: REST-first read mode, routing pr list to REST"
-		_out=$(_rest_pr_list "$@")
+	if [[ $_rest_capable -eq 1 ]] && _rest_read_first_enabled; then
+		if [[ $_uses_search -eq 1 ]]; then
+			print_info "[INFO] gh-wrapper: REST-first read mode, routing author-filtered pr list to /search/issues"
+		else
+			print_info "[INFO] gh-wrapper: REST-first read mode, routing pr list to REST"
+		fi
+		_out=$(_rest_pr_list_dispatch "$@")
 		_rc=$?
 		if [[ $_rc -eq 0 ]]; then
 			_gh_pr_list_snapshot_put "$_out" "$@"
@@ -654,9 +666,13 @@ gh_pr_list() {
 		fi
 		return $_rc
 	fi
-	if [[ $_has_search -eq 0 ]] && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest rest-core gh_pr_list; } || _rest_should_fallback; }; then
-		print_info "[INFO] gh-wrapper: GraphQL budget low, routing pr list to REST"
-		_out=$(_rest_pr_list "$@")
+	if [[ $_rest_capable -eq 1 ]] && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest "$_pool" gh_pr_list; } || _rest_should_fallback; }; then
+		if [[ $_uses_search -eq 1 ]]; then
+			print_info "[INFO] gh-wrapper: GraphQL budget low, routing author-filtered pr list to /search/issues"
+		else
+			print_info "[INFO] gh-wrapper: GraphQL budget low, routing pr list to REST"
+		fi
+		_out=$(_rest_pr_list_dispatch "$@")
 		_rc=$?
 		if [[ $_rc -eq 0 ]]; then
 			_gh_pr_list_snapshot_put "$_out" "$@"
@@ -667,9 +683,13 @@ gh_pr_list() {
 	gh_record_call graphql gh_pr_list 2>/dev/null || true
 	_out=$(_gh_with_timeout read gh pr list "$@")
 	local rc=$?
-	if [[ $rc -ne 0 && $_has_search -eq 0 ]] && _rest_should_fallback; then
-		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr list"
-		_out=$(_rest_pr_list "$@")
+	if [[ $rc -ne 0 && $_rest_capable -eq 1 ]] && _rest_should_fallback; then
+		if [[ $_uses_search -eq 1 ]]; then
+			print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to /search/issues for author-filtered pr list"
+		else
+			print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr list"
+		fi
+		_out=$(_rest_pr_list_dispatch "$@")
 		rc=$?
 	fi
 	if [[ $rc -eq 0 ]]; then
@@ -695,13 +715,15 @@ gh_pr_list() {
 #######################################
 gh_pr_view() {
 	local _first_num="${1:-}"
+	local _rest_shape_valid=0
+	_rest_pr_view_args_supported structural "$@" && _rest_shape_valid=1
 	local _cached_output=""
 	if _cached_output=$(_gh_pr_view_snapshot_get "$@" 2>/dev/null); then
 		printf '%s' "$_cached_output"
 		return 0
 	fi
 	local _out="" _rc=0
-	if _out=$(_gh_pr_view_try_mixed_split "$@" 2>/dev/null); then
+	if [[ $_rest_shape_valid -eq 1 ]] && _out=$(_gh_pr_view_try_mixed_split "$@" 2>/dev/null); then
 		_gh_pr_view_snapshot_put "$_out" "$@"
 		printf '%s' "$_out"
 		return 0
@@ -746,8 +768,8 @@ gh_pr_view() {
 # Routes directly to REST when GraphQL remaining is below the fallback threshold,
 # and still falls back to REST if the primary call fails during an exhaustion
 # window.
-# Supports --state, --label (multiple), --assignee, --limit, --json, --jq,
-# --search.
+# Supports --state, --label (multiple), --assignee, --author, --limit, --json,
+# --jq, and --search when their complete argument shape can be preserved.
 #
 # Routing (t2995):
 #   - --search non-empty → _rest_issue_search uses /search/issues?q=...
@@ -768,42 +790,40 @@ gh_pr_view() {
 gh_issue_list() {
 	local _has_search=1
 	_rest_args_have_search "$@" || _has_search=0
+	local _rest_capable=0
+	_rest_issue_list_can_preserve_args "$@" && _rest_capable=1
 	local _pool="rest-core"
 	[[ $_has_search -eq 1 ]] && _pool="rest-search"
-	if _rest_read_first_enabled; then
+	if [[ $_rest_capable -eq 1 ]] && _rest_read_first_enabled; then
 		if [[ $_has_search -eq 1 ]]; then
 			print_info "[INFO] gh-wrapper: REST-first read mode, routing issue list to /search/issues (--search preserved, t2995)"
-			_rest_issue_search "$@"
 		else
 			print_info "[INFO] gh-wrapper: REST-first read mode, routing issue list to REST"
-			_rest_issue_list "$@"
 		fi
+		_rest_issue_list_dispatch "$@"
 		return $?
 	fi
-	if { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest "$_pool" gh_issue_list; } || _rest_should_fallback; then
+	if [[ $_rest_capable -eq 1 ]] && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest "$_pool" gh_issue_list; } || _rest_should_fallback; }; then
 		if [[ $_has_search -eq 1 ]]; then
 			print_info "[INFO] gh-wrapper: GraphQL budget low, routing issue list to /search/issues (--search preserved, t2995)"
-			_rest_issue_search "$@"
 		else
 			print_info "[INFO] gh-wrapper: GraphQL budget low, routing issue list to REST"
-			_rest_issue_list "$@"
 		fi
+		_rest_issue_list_dispatch "$@"
 		return $?
 	fi
 	gh_record_call graphql gh_issue_list 2>/dev/null || true
 	_gh_with_timeout read gh issue list "$@"
 	local rc=$?
-	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
+	if [[ $rc -ne 0 && $_rest_capable -eq 1 ]] && _rest_should_fallback; then
 		# t2995: use search-aware REST fallback when --search is supplied.
 		if [[ $_has_search -eq 1 ]]; then
 			print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to /search/issues for issue list (--search preserved, t2995)"
-			_rest_issue_search "$@"
-			rc=$?
 		else
 			print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue list"
-			_rest_issue_list "$@"
-			rc=$?
 		fi
+		_rest_issue_list_dispatch "$@"
+		rc=$?
 	fi
 	return $rc
 }

--- a/.agents/scripts/tests/test-gh-api-sig-footer.sh
+++ b/.agents/scripts/tests/test-gh-api-sig-footer.sh
@@ -214,10 +214,12 @@ SIG_HELPER="$_STUB_SIG_HELPER"
 # Strategy: use eval to extract the function bodies from the shim.
 _SHIM_SCRIPT="${SCRIPTS_DIR}/gh"
 
-# Extract and define only the two helper functions we need.
+# Extract and define the helper plus its direct signature dependencies.
 # This avoids executing the shim's main body which calls exec.
 _SHIM_FUNCS=$(awk '
 	/^_shim_api_is_write_endpoint\(\)/ { printing=1; depth=0 }
+	/^_shim_body_is_ops_audit\(\)/      { printing=1; depth=0 }
+	/^_shim_sig_footer_for_body\(\)/    { printing=1; depth=0 }
 	/^_shim_api_inject_body_sig\(\)/   { printing=1; depth=0 }
 	printing {
 		print

--- a/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
@@ -36,7 +36,7 @@
 #  15. gh_issue_list falls back to REST when primary fails AND GraphQL exhausted
 #  16. gh_issue_list does NOT fall back when primary succeeds
 #  17. gh_issue_list does NOT fall back when primary fails but GraphQL healthy
-#  18. _rest_issue_list handles --search flag without error (silently skipped)
+#  18. _rest_issue_list rejects unsupported search and unknown semantic flags
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -102,6 +102,7 @@ export -f print_info print_warning print_error print_success log_verbose
 
 export AIDEVOPS_SESSION_ORIGIN=interactive
 export AIDEVOPS_SESSION_USER=testuser
+export AIDEVOPS_GH_REST_FALLBACK_DISABLE_CACHE=1
 
 stub_rest_list_result() {
 	local path="$1"
@@ -140,13 +141,13 @@ gh() {
 	# gh api rate_limit — returns configurable value
 	if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
 		local remaining="${STUB_RATE_LIMIT_REMAINING:-5000}"
-		printf '%s\n' "$remaining"
+		printf '{"resources":{"graphql":{"remaining":%s,"limit":5000,"reset":0}}}\n' "$remaining"
 		return 0
 	fi
 
 	# gh api user — returns testuser
 	if [[ "$1" == "api" && "$2" == "user" ]]; then
-		printf '"testuser"\n'
+		printf 'testuser\n'
 		return 0
 	fi
 
@@ -423,6 +424,49 @@ else
 fi
 
 # =============================================================================
+# Test 13: _rest_issue_list preserves author as the REST creator filter
+# =============================================================================
+: >"$GH_CALLS"
+
+_rest_issue_list --repo "owner/repo" --state all --author "alice" >/dev/null 2>&1 || true
+
+if grep -qE 'creator=alice' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list maps --author to creator"
+else
+	fail "_rest_issue_list maps --author to creator" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 14: _rest_issue_list resolves --author @me before REST translation
+# =============================================================================
+: >"$GH_CALLS"
+
+_rest_issue_list --repo "owner/repo" --state all --author "@me" >/dev/null 2>&1 || true
+
+if grep -qE '^api user --jq ' "$GH_CALLS" 2>/dev/null &&
+	grep -qE 'creator=testuser' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list resolves --author @me"
+else
+	fail "_rest_issue_list resolves --author @me" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 15: concrete bot identities remain valid author filters
+# =============================================================================
+: >"$GH_CALLS"
+
+_rest_issue_list --repo "owner/repo" --state all --author "dependabot[bot]" >/dev/null 2>&1 || true
+
+if grep -qE 'creator=dependabot%5Bbot%5D' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list preserves bot author logins"
+else
+	fail "_rest_issue_list preserves bot author logins" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
 # Test 11: _rest_issue_list returns error when --repo is missing
 # =============================================================================
 _err_output=$(_rest_issue_list --state open 2>&1)
@@ -435,7 +479,7 @@ else
 fi
 
 # =============================================================================
-# Test 11: gh_issue_view falls back to REST when primary fails AND GraphQL exhausted
+# Test 11: gh_issue_view routes proactively when GraphQL is exhausted
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
@@ -444,13 +488,13 @@ export STUB_RATE_LIMIT_REMAINING=0
 
 gh_issue_view 42 --repo "owner/repo" --json state --jq '.state' >/dev/null 2>&1 || true
 
-if grep -qE '^issue view' "$GH_CALLS" 2>/dev/null &&
-	grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
+if grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
 	grep -qE '^api /repos/owner/repo/issues/42' "$GH_CALLS" 2>/dev/null &&
-	grep -q 'GraphQL exhausted.*issue view' "$GH_INFO_OUTPUT" 2>/dev/null; then
-	pass "gh_issue_view falls back to REST when primary fails AND exhausted"
+	! grep -qE '^issue view' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'GraphQL budget low.*issue view' "$GH_INFO_OUTPUT" 2>/dev/null; then
+	pass "gh_issue_view proactively routes to REST when exhausted"
 else
-	fail "gh_issue_view falls back to REST when primary fails AND exhausted" \
+	fail "gh_issue_view proactively routes to REST when exhausted" \
 		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 
@@ -496,7 +540,7 @@ unset STUB_PRIMARY_FAIL
 export STUB_RATE_LIMIT_REMAINING=5000
 
 # =============================================================================
-# Test 14: gh_issue_list falls back to REST when primary fails AND GraphQL exhausted
+# Test 14: gh_issue_list routes proactively when GraphQL is exhausted
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
@@ -505,13 +549,13 @@ export STUB_RATE_LIMIT_REMAINING=0
 
 gh_issue_list --repo "owner/repo" --state open --json number >/dev/null 2>&1 || true
 
-if grep -qE '^issue list' "$GH_CALLS" 2>/dev/null &&
-	grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
+if grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
 	grep -qE '^api /repos/owner/repo/issues\?' "$GH_CALLS" 2>/dev/null &&
-	grep -q 'GraphQL exhausted.*issue list' "$GH_INFO_OUTPUT" 2>/dev/null; then
-	pass "gh_issue_list falls back to REST when primary fails AND exhausted"
+	! grep -qE '^issue list' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'GraphQL budget low.*issue list' "$GH_INFO_OUTPUT" 2>/dev/null; then
+	pass "gh_issue_list proactively routes to REST when exhausted"
 else
-	fail "gh_issue_list falls back to REST when primary fails AND exhausted" \
+	fail "gh_issue_list proactively routes to REST when exhausted" \
 		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 
@@ -545,11 +589,10 @@ export STUB_RATE_LIMIT_REMAINING=5000
 gh_issue_list --repo "owner/repo" --state open >/dev/null 2>&1 || true
 
 if grep -qE '^issue list' "$GH_CALLS" 2>/dev/null &&
-	grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
 	! grep -qE '^api /repos/owner/repo/issues\?' "$GH_CALLS" 2>/dev/null; then
-	pass "gh_issue_list does NOT fall back when primary fails but GraphQL healthy"
+	pass "gh_issue_list does NOT broaden a non-JSON primary failure"
 else
-	fail "gh_issue_list does NOT fall back when primary fails but GraphQL healthy" \
+	fail "gh_issue_list does NOT broaden a non-JSON primary failure" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
@@ -557,7 +600,7 @@ unset STUB_PRIMARY_FAIL
 export STUB_RATE_LIMIT_REMAINING=5000
 
 # =============================================================================
-# Test 17: _rest_issue_list handles --search flag without error (silently skipped)
+# Test 17: _rest_issue_list rejects search instead of silently broadening
 # =============================================================================
 : >"$GH_CALLS"
 
@@ -565,12 +608,64 @@ _result=$(_rest_issue_list --repo "owner/repo" --state open \
 	--search "in:title [Supervisor:" 2>&1)
 _rc=$?
 
-if [[ $_rc -eq 0 ]]; then
-	pass "_rest_issue_list handles --search flag without error (silently skipped)"
+if [[ $_rc -ne 0 ]] && ! grep -qE '^api /repos/.+/issues\?' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list rejects --search instead of silently dropping it"
 else
-	fail "_rest_issue_list handles --search flag without error (silently skipped)" \
+	fail "_rest_issue_list rejects --search instead of silently dropping it" \
 		"rc=${_rc} output=${_result}"
 fi
+
+# =============================================================================
+# Test 18: _rest_issue_list rejects unknown flag-value pairs before API access
+# =============================================================================
+: >"$GH_CALLS"
+
+_result=$(_rest_issue_list --repo "owner/repo" --state open \
+	--milestone "future" 2>&1)
+_rc=$?
+
+if [[ $_rc -ne 0 ]] && ! grep -qE '^api /repos/.+/issues\?' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list fails closed for unknown semantic flags"
+else
+	fail "_rest_issue_list fails closed for unknown semantic flags" \
+		"rc=${_rc} output=${_result} calls=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 19: direct issue view rejects unknown semantic flags before API access
+# =============================================================================
+: >"$GH_CALLS"
+
+_result=$(_rest_issue_view 42 --repo "owner/repo" --comments --json number 2>&1)
+_rc=$?
+
+if [[ $_rc -ne 0 ]] && ! grep -qE '^api /repos/.+/issues/42' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_view fails closed for unknown semantic flags"
+else
+	fail "_rest_issue_view fails closed for unknown semantic flags" \
+		"rc=${_rc} output=${_result} calls=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 20: low-budget issue view keeps unsupported shapes on native GraphQL
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_PRIMARY_FAIL=1
+export STUB_RATE_LIMIT_REMAINING=0
+
+unsupported_view_rc=0
+gh_issue_view 42 --repo "owner/repo" --comments --json number >/dev/null 2>&1 || unsupported_view_rc=$?
+
+if [[ "$unsupported_view_rc" -ne 0 ]] && grep -qE '^issue view' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/.+/issues/42' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_view never rewrites unsupported arguments to REST"
+else
+	fail "gh_issue_view never rewrites unsupported arguments to REST" \
+		"rc=${unsupported_view_rc} calls=$(cat "$GH_CALLS")"
+fi
+unset STUB_PRIMARY_FAIL
+export STUB_RATE_LIMIT_REMAINING=5000
 
 # =============================================================================
 # Summary

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -83,6 +83,11 @@ if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
 	printf '%s\n' "${STUB_RATE_LIMIT_REMAINING:-5000}"
 	exit 0
 fi
+if [[ "$1" == "api" && "$2" == "-i" && "$3" =~ ^/search/issues\? ]]; then
+	fixture='{"items":[{"number":22350,"state":"open","title":"Authored PR","html_url":"https://github.com/owner/repo/pull/22350","user":{"login":"managed"},"pull_request":{"merged_at":null}}]}'
+	printf 'HTTP/2 200\r\nX-RateLimit-Resource: search\r\n\r\n%s\n' "$fixture"
+	exit 0
+fi
 if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/pulls\? ]]; then
 	jq_filter=""
 	i=3
@@ -116,7 +121,7 @@ if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/issues\? ]]; then
 		fi
 		i=$((i + 1))
 	done
-	fixture='[{"number":22430,"state":"open","title":"Reduce GraphQL list-call pressure","html_url":"https://github.com/owner/repo/issues/22430","updated_at":"2026-05-02T17:52:48Z","labels":[{"name":"auto-dispatch"}],"assignees":[{"login":"worker"}]}]'
+	fixture='[{"number":22430,"state":"open","title":"Reduce GraphQL list-call pressure","html_url":"https://github.com/owner/repo/issues/22430","updated_at":"2026-05-02T17:52:48Z","labels":[{"name":"auto-dispatch"}],"assignees":[{"login":"worker"}],"user":{"login":"managed"}}]'
 	if [[ -n "$jq_filter" ]]; then
 		printf '%s\n' "$fixture" | jq -c "$jq_filter"
 	else
@@ -149,6 +154,7 @@ cp "$SHIM" "$TMP/scripts/gh"
 chmod +x "$TMP/scripts/gh"
 cp "$REPO_DIR/.agents/scripts/gh-api-instrument.sh" "$TMP/scripts/gh-api-instrument.sh"
 cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-fallback.sh" "$TMP/scripts/shared-gh-wrappers-rest-fallback.sh"
+cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh" "$TMP/scripts/shared-gh-wrappers-rest-read-semantics.sh"
 
 # Put stub gh in PATH (for shim's REAL_GH discovery) and the shim in
 # $TMP/scripts (for direct invocation in tests).
@@ -512,6 +518,66 @@ if [[ "$argv" == $'pr\nlist\n--repo\nowner/repo\n--state\nopen\n--json\nnumber,r
 	_pass "REST-first leaves GraphQL-only pr list fields on GraphQL"
 else
 	_fail "REST-first GraphQL-only pr list preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+echo ""
+echo "Test 15a: issue --author @me maps to REST creator"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-issue-author.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+output=$(AIDEVOPS_GH_FORCE_REST_READS=1 STUB_GH_USER=managed "$SHIM_RUN" issue list --repo owner/repo \
+	--author @me --state all --json number,author --jq '.[0].author.login' 2>/dev/null || true)
+argv=$(_read_argv)
+if [[ "$output" == "managed" ]] && [[ "$argv" == *"creator=managed"* ]] &&
+	grep -q $'\tgh_issue_list\trest' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "forced REST issue author preserves @me through creator filtering"
+else
+	_fail "forced REST issue author filtering" "output: $output argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+echo ""
+echo "Test 15b: PR --author uses Search API qualifiers"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-pr-author.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+output=$(AIDEVOPS_GH_FORCE_REST_READS=1 "$SHIM_RUN" pr list --repo owner/repo \
+	--author managed --state all --json number,author --jq '.[0].author.login' 2>/dev/null || true)
+argv=$(_read_argv)
+if [[ "$output" == "managed" ]] && [[ "$argv" == *$'api\n-i\n/search/issues?'* ]] &&
+	[[ "$argv" == *"author%3Amanaged"* ]] && grep -q $'\tgh_pr_list\tsearch-rest' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "forced REST PR author routes through exact Search qualifiers"
+else
+	_fail "forced REST PR author filtering" "output: $output argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+echo ""
+echo "Test 15c: unsupported issue filters stay on native gh"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-unsupported-issue-list.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+AIDEVOPS_GH_FORCE_REST_READS=1 "$SHIM_RUN" issue list --repo owner/repo \
+	--milestone future --state open --json number 2>/dev/null || true
+argv=$(_read_argv)
+if [[ "$argv" == $'issue\nlist\n--repo\nowner/repo\n--milestone\nfuture\n--state\nopen\n--json\nnumber' ]] &&
+	grep -q $'\tgh_issue_list\tgraphql' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "unsupported issue filter is never silently dropped by REST rewrite"
+else
+	_fail "unsupported issue filter GraphQL preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+echo ""
+echo "Test 15d: unsupported view flags stay on native gh"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-unsupported-issue-view.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+AIDEVOPS_GH_FORCE_REST_READS=1 "$SHIM_RUN" issue view 42 --repo owner/repo \
+	--comments --json number 2>/dev/null || true
+argv=$(_read_argv)
+if [[ "$argv" == $'issue\nview\n42\n--repo\nowner/repo\n--comments\n--json\nnumber' ]] &&
+	grep -q $'\tgh_issue_view\tgraphql' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "unsupported issue view flag is never silently dropped by REST rewrite"
+else
+	_fail "unsupported issue view GraphQL preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -178,6 +178,7 @@ _stub_print_fixture_with_jq() {
 _stub_gh_api_issues_list() {
 	local jq_filter=""
 	local fixture='[{"number":22430,"state":"open","title":"Reduce GraphQL list-call pressure","html_url":"https://github.com/owner/repo/issues/22430","updated_at":"2026-05-02T17:52:48Z","labels":[{"name":"auto-dispatch"}],"assignees":[{"login":"worker"}],"user":{"login":"maintainer"}}]'
+	fixture="${STUB_ISSUE_LIST_FIXTURE:-$fixture}"
 	jq_filter="$(_stub_jq_filter_arg 3 "$@")"
 	_stub_print_fixture_with_jq "$fixture" "$jq_filter" -c
 	return $?
@@ -205,12 +206,19 @@ _stub_gh_api_pr_list() {
 }
 _stub_gh_api_search_issues() {
 	local option="$1"
+	local path="${2:-$1}"
 	local fixture='{"items":[{"number":22430,"state":"open","title":"Reduce GraphQL list-call pressure"}]}'
 	if [[ -n "${STUB_SEARCH_RAW_RESPONSE:-}" ]]; then
 		printf '%s' "$STUB_SEARCH_RAW_RESPONSE"
 		return 0
 	fi
-	fixture="${STUB_SEARCH_FIXTURE:-$fixture}"
+	if [[ "${STUB_SEARCH_PAGINATED:-0}" == "1" && "$path" == *"page=1" ]]; then
+		fixture=$(jq -cn '{items: [range(1; 101) | {number: ., state: "open", title: "PR", user: {login: "alice"}, pull_request: {merged_at: null}}]}')
+	elif [[ "${STUB_SEARCH_PAGINATED:-0}" == "1" && "$path" == *"page=2" ]]; then
+		fixture=$(jq -cn '{items: [range(101; 151) | {number: ., state: "open", title: "PR", user: {login: "alice"}, pull_request: {merged_at: null}}]}')
+	else
+		fixture="${STUB_SEARCH_FIXTURE:-$fixture}"
+	fi
 	if [[ "$option" == "-i" ]]; then
 		printf 'HTTP/2 200\r\nX-RateLimit-Remaining: 29\r\nX-RateLimit-Resource: search\r\nX-GitHub-Request-Id: SEARCH-REQ\r\n\r\n%s\n' "$fixture"
 		return 0
@@ -233,7 +241,7 @@ _stub_gh_api() {
 		return 0
 	fi
 	if [[ "$subcommand" == "user" ]]; then
-		printf '"testuser"\n'
+		printf 'testuser\n'
 		return 0
 	fi
 	if [[ "$subcommand" == "-i" && "$path" =~ ^/repos/[^/]+/[^/]+/collaborators/[^/]+/permission$ ]]; then
@@ -257,7 +265,7 @@ _stub_gh_api() {
 		return $?
 	fi
 	if [[ "$subcommand" =~ ^/search/issues || ( "$subcommand" == "-i" && "$path" =~ ^/search/issues ) ]]; then
-		_stub_gh_api_search_issues "$subcommand"
+		_stub_gh_api_search_issues "$subcommand" "$path"
 		return 0
 	fi
 	if [[ "$subcommand" =~ ^/repos/[^/]+/[^/]+$ ]]; then
@@ -880,10 +888,10 @@ fi
 STUB_SEARCH_RAW_RESPONSE=$'HTTP/2 204\r\nX-RateLimit-Remaining: 29\r\n\r\n'
 search_output=$(_rest_issue_search --repo "owner/repo" --search "fallback" --state open --json number --jq '.[0].number')
 unset STUB_SEARCH_RAW_RESPONSE
-if [[ "$search_output" == "[]" ]] && grep -qE '^api -i /search/issues\?' "$GH_CALLS" 2>/dev/null; then
-	pass "_rest_issue_search emits an empty JSON array for empty response bodies"
+if [[ "$search_output" == "null" ]] && grep -qE '^api -i /search/issues\?' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_search applies caller jq to an empty result array"
 else
-	fail "_rest_issue_search emits an empty JSON array for empty response bodies" \
+	fail "_rest_issue_search applies caller jq to an empty result array" \
 		"output=${search_output} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 
@@ -985,6 +993,123 @@ else
 	fail "gh_issue_list REST fallback preserves compact --json/--jq shape" \
 		"output=${issue_list_title} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
+
+# =============================================================================
+# Test 23d: issue author filters map exactly to the REST creator parameter
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+export STUB_ISSUE_LIST_FIXTURE='[{"number":22431,"state":"open","title":"Authored issue","html_url":"https://github.com/owner/repo/issues/22431","user":{"login":"alice"}}]'
+
+issue_author=$(gh_issue_list --repo "owner/repo" --state all --author alice \
+	--json number,author --jq '.[0].author.login' 2>/dev/null || true)
+
+if [[ "$issue_author" == "alice" ]] &&
+	grep -qE '^api /repos/owner/repo/issues\?state=all&per_page=30&creator=alice&page=1' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^issue list' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_list preserves --author with REST creator filtering"
+else
+	fail "gh_issue_list preserves --author with REST creator filtering" \
+		"output=${issue_author} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_ISSUE_LIST_FIXTURE
+
+# =============================================================================
+# Test 23e: issue author @me resolves before the creator request
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_ISSUE_LIST_FIXTURE='[{"number":22432,"state":"open","title":"Own issue","html_url":"https://github.com/owner/repo/issues/22432","user":{"login":"testuser"}}]'
+
+issue_author=$(gh_issue_list --repo "owner/repo" --state all --author @me \
+	--json number,author --jq '.[0].author.login' 2>/dev/null || true)
+
+if [[ "$issue_author" == "testuser" ]] && grep -qE '^api user --jq ' "$GH_CALLS" 2>/dev/null &&
+	grep -qE 'creator=testuser' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_list resolves --author @me before REST routing"
+else
+	fail "gh_issue_list resolves --author @me before REST routing" \
+		"output=${issue_author} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_ISSUE_LIST_FIXTURE
+
+# =============================================================================
+# Test 23f: PR author filters route through exact Search API qualifiers
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_SEARCH_FIXTURE='{"items":[{"number":22433,"state":"closed","title":"Authored PR","html_url":"https://github.com/owner/repo/pull/22433","user":{"login":"alice"},"pull_request":{"merged_at":"2026-05-20T00:00:00Z"}}]}'
+
+pr_author=$(gh_pr_list --repo "owner/repo" --state merged --author alice --limit 30 \
+	--json number,state,author,mergedAt --jq '.[0].author.login + ":" + .[0].state' 2>/dev/null || true)
+
+if [[ "$pr_author" == "alice:MERGED" ]] && grep -qE '^api -i /search/issues\?' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'author%3Aalice' "$GH_CALLS" 2>/dev/null && grep -q 'is%3Amerged' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^pr list' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list preserves --author through Search API qualifiers"
+else
+	fail "gh_pr_list preserves --author through Search API qualifiers" \
+		"output=${pr_author} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_SEARCH_FIXTURE
+
+# =============================================================================
+# Test 23g: PR author @me resolves before Search API routing
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_SEARCH_FIXTURE='{"items":[{"number":22434,"state":"open","title":"Own PR","html_url":"https://github.com/owner/repo/pull/22434","user":{"login":"testuser"},"pull_request":{"merged_at":null}}]}'
+
+pr_author=$(gh_pr_list --repo "owner/repo" --state all --author @me --limit 30 \
+	--json number,author --jq '.[0].author.login' 2>/dev/null || true)
+
+if [[ "$pr_author" == "testuser" ]] && grep -qE '^api user --jq ' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'author%3Atestuser' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list resolves --author @me before Search API routing"
+else
+	fail "gh_pr_list resolves --author @me before Search API routing" \
+		"output=${pr_author} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_SEARCH_FIXTURE
+
+# =============================================================================
+# Test 23h: PR Search pagination reaches the requested matching result count
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_SEARCH_PAGINATED=1
+
+pr_author_count=$(_rest_pr_search --repo "owner/repo" --state all --author alice \
+	--limit 150 --json number --jq 'length' 2>/dev/null || true)
+pr_author_pages=$(grep -cE '^api -i /search/issues\?' "$GH_CALLS" 2>/dev/null || true)
+
+if [[ "$pr_author_count" == "150" && "$pr_author_pages" == "2" ]]; then
+	pass "_rest_pr_search paginates to the requested matching result count"
+else
+	fail "_rest_pr_search paginates to the requested matching result count" \
+		"count=${pr_author_count} pages=${pr_author_pages} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_SEARCH_PAGINATED
+
+# =============================================================================
+# Test 23i: unsupported low-budget filters fail closed after GraphQL failure
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_PRIMARY_FAIL=1
+
+gh_issue_list --repo "owner/repo" --state open --milestone future --json number >/dev/null 2>&1
+unsupported_rc=$?
+
+if [[ "$unsupported_rc" -ne 0 ]] && grep -qE '^issue list' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api (/repos/.+/issues\?|(-i )?/search/issues\?)' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_list fails closed when REST cannot preserve an unknown filter"
+else
+	fail "gh_issue_list fails closed when REST cannot preserve an unknown filter" \
+		"rc=${unsupported_rc} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_PRIMARY_FAIL
 
 # =============================================================================
 # Test 24: gh_pr_list keeps --search on GraphQL path when budget is low
@@ -1114,7 +1239,7 @@ unset AIDEVOPS_GH_PR_VIEW_CACHE
 unset AIDEVOPS_GH_PR_VIEW_CACHE_DIR
 
 # =============================================================================
-# Test 25f: REST PR view marks unavailable reviewDecision as null, not empty
+# Test 25f: unavailable reviewDecision remains on GraphQL and fails closed
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
@@ -1122,19 +1247,22 @@ export STUB_RATE_LIMIT_REMAINING=0
 export STUB_PR_VIEW_FIXTURE='{"number":123,"title":"review state unavailable from REST"}'
 export STUB_PRIMARY_FAIL=1
 
-pr_view_review_decision=$(gh_pr_view 123 --repo "owner/repo" --json reviewDecision --jq '.reviewDecision == null' 2>/dev/null || true)
+pr_view_review_decision_rc=0
+pr_view_review_decision=$(gh_pr_view 123 --repo "owner/repo" --json reviewDecision --jq '.reviewDecision == null' 2>/dev/null) || pr_view_review_decision_rc=$?
 unset STUB_PRIMARY_FAIL
 
-if [[ "$pr_view_review_decision" == "true" ]]; then
-	pass "gh_pr_view REST fallback leaves GraphQL-only reviewDecision null"
+if [[ "$pr_view_review_decision_rc" -ne 0 && -z "$pr_view_review_decision" ]] &&
+	grep -qE '^pr view 123 .*--json reviewDecision' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/pulls/123$' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_view fails closed instead of fabricating reviewDecision"
 else
-	fail "gh_pr_view REST fallback leaves GraphQL-only reviewDecision null" \
-		"output=${pr_view_review_decision} GH_CALLS=$(cat "$GH_CALLS")"
+	fail "gh_pr_view fails closed instead of fabricating reviewDecision" \
+		"rc=${pr_view_review_decision_rc} output=${pr_view_review_decision} GH_CALLS=$(cat "$GH_CALLS")"
 fi
 unset STUB_PR_VIEW_FIXTURE
 
 # =============================================================================
-# Test 25c: REST PR list normalizes REST boolean mergeable to gh GraphQL enum
+# Test 25c: mergeable stays on GraphQL because list REST omits reliable values
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
@@ -1143,16 +1271,17 @@ export STUB_PR_LIST_FIXTURE='[{"number":22337,"mergeable":false,"state":"open","
 
 pr_list_mergeable=$(gh_pr_list --repo "owner/repo" --state open --json mergeable --jq '.[0].mergeable' 2>/dev/null || true)
 
-if [[ "$pr_list_mergeable" == "CONFLICTING" || "$pr_list_mergeable" == '"CONFLICTING"' ]]; then
-	pass "gh_pr_list REST fallback normalizes mergeable=false to CONFLICTING"
+if grep -qE '^pr list .*--json mergeable' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/pulls\?' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list keeps mergeable on GraphQL instead of fabricating REST state"
 else
-	fail "gh_pr_list REST fallback normalizes mergeable=false to CONFLICTING" \
+	fail "gh_pr_list keeps mergeable on GraphQL instead of fabricating REST state" \
 		"output=${pr_list_mergeable} GH_CALLS=$(cat "$GH_CALLS")"
 fi
 unset STUB_PR_LIST_FIXTURE
 
 # =============================================================================
-# Test 25e: REST PR list normalizes missing mergeable to UNKNOWN
+# Test 25e: missing REST mergeable still stays on GraphQL
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
@@ -1161,16 +1290,17 @@ export STUB_PR_LIST_FIXTURE='[{"number":22337,"state":"open","merged_at":null,"h
 
 pr_list_mergeable=$(gh_pr_list --repo "owner/repo" --state open --json mergeable --jq '.[0].mergeable' 2>/dev/null || true)
 
-if [[ "$pr_list_mergeable" == "UNKNOWN" || "$pr_list_mergeable" == '"UNKNOWN"' ]]; then
-	pass "gh_pr_list REST fallback normalizes missing mergeable to UNKNOWN"
+if grep -qE '^pr list .*--json mergeable' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/pulls\?' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list does not translate unavailable mergeable fields"
 else
-	fail "gh_pr_list REST fallback normalizes missing mergeable to UNKNOWN" \
+	fail "gh_pr_list does not translate unavailable mergeable fields" \
 		"output=${pr_list_mergeable} GH_CALLS=$(cat "$GH_CALLS")"
 fi
 unset STUB_PR_LIST_FIXTURE
 
 # =============================================================================
-# Test 25g: REST PR list marks unavailable reviewDecision as null, not empty
+# Test 25g: reviewDecision stays on GraphQL instead of becoming synthetic null
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
@@ -1179,10 +1309,11 @@ export STUB_PR_LIST_FIXTURE='[{"number":22337,"state":"open","merged_at":null,"h
 
 pr_list_review_decision=$(gh_pr_list --repo "owner/repo" --state open --json number,reviewDecision --jq '.[0].reviewDecision == null' 2>/dev/null || true)
 
-if [[ "$pr_list_review_decision" == "true" ]]; then
-	pass "gh_pr_list REST fallback leaves GraphQL-only reviewDecision null"
+if grep -qE '^pr list .*--json number,reviewDecision' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/pulls\?' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list keeps reviewDecision on GraphQL"
 else
-	fail "gh_pr_list REST fallback leaves GraphQL-only reviewDecision null" \
+	fail "gh_pr_list keeps reviewDecision on GraphQL" \
 		"output=${pr_list_review_decision} GH_CALLS=$(cat "$GH_CALLS")"
 fi
 unset STUB_PR_LIST_FIXTURE
@@ -1479,13 +1610,32 @@ else
 		"rc=${unsupported_fallback_rc} output=${unsupported_fallback_output} rest_calls=${unsupported_fallback_rest_calls} graphql_calls=${unsupported_fallback_graphql_calls} GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
-if grep -q 'stable-within-cycle' "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" 2>/dev/null &&
-	grep -q 'fields like mergeable' "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" 2>/dev/null &&
-	grep -q 'GraphQL-only fields' "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" 2>/dev/null; then
-	pass "gh_pr_view freshness classes document stable, volatile, and GraphQL-only fields"
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=0
+export STUB_PRIMARY_FAIL=1
+unsupported_view_arg_rc=0
+gh_pr_view 123 --repo "owner/repo" --web --json number >/dev/null 2>&1 || unsupported_view_arg_rc=$?
+unset STUB_PRIMARY_FAIL
+export STUB_RATE_LIMIT_REMAINING=5000
+
+if [[ "$unsupported_view_arg_rc" -ne 0 ]] &&
+	grep -qE '^pr view 123 .*--web --json number' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/pulls/123$' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_view never rewrites unknown semantic flags to REST"
 else
-	fail "gh_pr_view freshness classes document stable, volatile, and GraphQL-only fields" \
-		"missing freshness class comments in shared-gh-wrappers-rest-fallback.sh"
+	fail "gh_pr_view never rewrites unknown semantic flags to REST" \
+		"rc=${unsupported_view_arg_rc} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+if _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json title &&
+	! _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json mergeable &&
+	_rest_pr_view_can_emergency_fallback_args 123 --repo "owner/repo" --json mergeable &&
+	! _rest_pr_view_can_emergency_fallback_args 123 --repo "owner/repo" --json reviewDecision; then
+	pass "gh_pr_view validators distinguish stable, volatile, and GraphQL-only fields"
+else
+	fail "gh_pr_view validators distinguish stable, volatile, and GraphQL-only fields" \
+		"unexpected proactive or emergency field classification"
 fi
 
 : >"$GH_CALLS"


### PR DESCRIPTION
## Summary

- Preserve `gh issue list --author` through REST `creator` filtering, including `@me` resolution.
- Preserve `gh pr list --author` with bounded `/search/issues` pagination and gh-compatible JSON projection.
- Fail closed when list or view arguments cannot be represented exactly instead of silently broadening results.

## Implementation

- Add operation-specific read validators and pagination/projection helpers in `.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh`.
- Route only semantically equivalent reads from `.agents/scripts/gh` and `.agents/scripts/shared-gh-wrappers-status.sh`.
- Extend issue, PR, shim, source, and signature-footer regressions for author filters, unsupported flags, pagination, and shell compatibility.

## Verification

- `.agents/scripts/linters-local.sh --changed --no-cache`
- `bash .agents/scripts/tests/test-gh-issue-read-rest-fallback.sh` — 27/27
- `bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh` — 81/81
- `bash .agents/scripts/tests/test-gh-shim.sh` — 52/52
- `bash .agents/scripts/tests/test-gh-wrapper-shell-compat.sh` — 9/9
- `bash .agents/scripts/tests/test-shared-gh-wrappers-source.sh` — 4/4
- `bash .agents/scripts/tests/test-gh-api-sig-footer.sh` — 6/6
- Live native-versus-forced-REST checks returned identical issue and PR number sets.

Resolves #28301

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 17h 13m and 4,495,973 tokens on this with the user in an interactive session.