### PR TITLE
GH#28359: avoid substring replacement in workflow caller test

### DIFF
--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -377,6 +377,7 @@ for actor in supported_actors:
 
 def evaluate(event_name, actor, is_pr, reply_id):
     candidate = expression
+    candidate = re.sub(r"\bnull\b", "None", candidate)
     replacements = {
         "github.event.comment.in_reply_to_id": repr(reply_id),
         "github.event.issue.pull_request": repr(is_pr),
@@ -387,7 +388,6 @@ def evaluate(event_name, actor, is_pr, reply_id):
     }
     for source, target in replacements.items():
         candidate = candidate.replace(source, target)
-    candidate = re.sub(r"\bnull\b", "None", candidate)
     if re.search(r"[^A-Za-z0-9_\s\[\]'\"().=-]", candidate):
         raise ValueError(f"unsupported eligibility token: {candidate}")
     return bool(eval(candidate, {"__builtins__": {}}, {}))

--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -382,12 +382,12 @@ def evaluate(event_name, actor, is_pr, reply_id):
         "github.event.issue.pull_request": repr(is_pr),
         "github.event_name": repr(event_name),
         "github.actor": repr(actor),
-        "null": "None",
         "&&": "and",
         "||": "or",
     }
     for source, target in replacements.items():
         candidate = candidate.replace(source, target)
+    candidate = re.sub(r"\bnull\b", "None", candidate)
     if re.search(r"[^A-Za-z0-9_\s\[\]'\"().=-]", candidate):
         raise ValueError(f"unsupported eligibility token: {candidate}")
     return bool(eval(candidate, {"__builtins__": {}}, {}))


### PR DESCRIPTION
## Summary

Restrict the workflow-expression null conversion to standalone null tokens so actor names and other words containing null remain unchanged.

## Files Changed

.agents/scripts/tests/test-reusable-workflow-caller.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-reusable-workflow-caller.sh; bash .agents/scripts/tests/test-reusable-workflow-caller.sh (26 tests passed)

Resolves #28359


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1m and 36,121 tokens on this as a headless worker.