### PR TITLE
GH#28369: reduce review enrichment jq spawns

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -262,33 +262,38 @@ _pmp_enrich_prs_with_review_decisions() {
 	local repo_slug="$1"
 	local pr_json="$2"
 	local enriched_json="$pr_json"
-	local pr_count=""
-	local i=0
+	local pr_rows=""
+	local i="" number="" review_decision=""
 
-	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-	if [[ -z "$repo_slug" || "$pr_count" -eq 0 ]]; then
+	if [[ -z "$repo_slug" ]]; then
 		printf '%s' "$pr_json"
 		return 0
 	fi
 
-	while [[ "$i" -lt "$pr_count" ]]; do
-		local pr_obj="" number="" review_decision=""
-		pr_obj=$(printf '%s' "$enriched_json" | jq -c --argjson index "$i" '.[$index]' 2>/dev/null) || pr_obj=""
-		if [[ -n "$pr_obj" ]]; then
-			number=$(printf '%s' "$pr_obj" | jq -r '.number // ""' 2>/dev/null) || number=""
-			review_decision=$(printf '%s' "$pr_obj" | jq -r 'if ((has("reviewDecision") | not) or .reviewDecision == null or (.reviewDecision | tostring | length) == 0) then "UNKNOWN" else .reviewDecision end' 2>/dev/null) || review_decision="UNKNOWN"
-			_pmp_normalize_review_decision_into review_decision "$review_decision"
-			if [[ "$number" =~ ^[0-9]+$ ]] && _pmp_review_decision_is_unknown "$review_decision"; then
-				_pmp_refresh_unknown_review_decision_into review_decision "$number" "$repo_slug" "$review_decision"
-				enriched_json=$(printf '%s' "$enriched_json" | jq --argjson index "$i" --arg review "$review_decision" '.[$index].reviewDecision = $review' 2>/dev/null) || {
-					printf '%s' "$pr_json"
-					return 0
-				}
-			fi
+	pr_rows=$(printf '%s' "$pr_json" | jq -r '
+		if type != "array" then error("expected PR array")
+		else to_entries[] | [
+			.key,
+			(.value.number // ""),
+			(if ((.value | has("reviewDecision") | not) or .value.reviewDecision == null or (.value.reviewDecision | tostring | length) == 0)
+			 then "UNKNOWN" else .value.reviewDecision end)
+		] | @tsv
+		end' 2>/dev/null) || {
+		printf '%s' "$pr_json"
+		return 0
+	}
+
+	while IFS=$'\t' read -r i number review_decision; do
+		[[ -n "$i" ]] || continue
+		_pmp_normalize_review_decision_into review_decision "$review_decision"
+		if [[ "$number" =~ ^[0-9]+$ ]] && _pmp_review_decision_is_unknown "$review_decision"; then
+			_pmp_refresh_unknown_review_decision_into review_decision "$number" "$repo_slug" "$review_decision"
+			enriched_json=$(printf '%s' "$enriched_json" | jq --argjson index "$i" --arg review "$review_decision" '.[$index].reviewDecision = $review' 2>/dev/null) || {
+				printf '%s' "$pr_json"
+				return 0
+			}
 		fi
-		i=$((i + 1))
-	done
+	done <<<"$pr_rows"
 
 	printf '%s' "$enriched_json"
 	return 0

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -263,6 +263,7 @@ _pmp_enrich_prs_with_review_decisions() {
 	local pr_json="$2"
 	local enriched_json="$pr_json"
 	local pr_rows=""
+	local _US=$'\x1f'
 	local i="" number="" review_decision=""
 
 	if [[ -z "$repo_slug" ]]; then
@@ -273,17 +274,18 @@ _pmp_enrich_prs_with_review_decisions() {
 	pr_rows=$(printf '%s' "$pr_json" | jq -r '
 		if type != "array" then error("expected PR array")
 		else to_entries[] | [
-			.key,
-			(.value.number // ""),
+			(.key | tostring),
+			(if ((.value | has("number") | not) or .value.number == null or (.value.number | tostring | length) == 0)
+			 then "" else (.value.number | tostring) end),
 			(if ((.value | has("reviewDecision") | not) or .value.reviewDecision == null or (.value.reviewDecision | tostring | length) == 0)
 			 then "UNKNOWN" else .value.reviewDecision end)
-		] | @tsv
+		] | join("\u001f")
 		end' 2>/dev/null) || {
 		printf '%s' "$pr_json"
 		return 0
 	}
 
-	while IFS=$'\t' read -r i number review_decision; do
+	while IFS="$_US" read -r i number review_decision; do
 		[[ -n "$i" ]] || continue
 		_pmp_normalize_review_decision_into review_decision "$review_decision"
 		if [[ "$number" =~ ^[0-9]+$ ]] && _pmp_review_decision_is_unknown "$review_decision"; then

--- a/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
@@ -109,11 +109,13 @@ assert_eq "1c.5: failed review refresh preserves UNKNOWN state" \
 	"UNKNOWN" "$(printf '%s' "$enriched_review_pr" | jq -r '.reviewDecision')"
 REFRESH_SHOULD_FAIL=0
 : >"${TEST_TMPDIR}/review-refresh.log"
-enriched_review_json=$(_pmp_enrich_prs_with_review_decisions "owner/repo" "[$unknown_review_failed_pr,$unknown_review_passing_pr]")
+enriched_review_json=$(_pmp_enrich_prs_with_review_decisions "owner/repo" "[$merge_ready_pr,$unknown_review_failed_pr,$unknown_review_passing_pr]")
 _pmp_log_pr_backlog_counts "owner/repo" "$enriched_review_json"
 _pmp_sort_prs_by_backlog_priority "$enriched_review_json" "owner/repo" >/dev/null
 assert_eq "1c.6: log plus sort do not repeat per-pass authoritative refreshes" \
 	"2" "$(wc -l <"${TEST_TMPDIR}/review-refresh.log" | tr -d '[:space:]')"
+assert_eq "1c.7: enrichment preserves an existing known review decision" \
+	"APPROVED" "$(printf '%s' "$enriched_review_json" | jq -r '.[0].reviewDecision')"
 assert_eq "1d: conflicting PR classifies as dirty-conflicted" \
 	"dirty-conflicted" "$(_pmp_classify_pr_backlog_state "$dirty_pr")"
 assert_eq "1e: changes requested classifies as human-approval-needed" \

--- a/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
@@ -74,6 +74,7 @@ checks_in_progress_pr='{"number":2,"mergeable":"MERGEABLE","reviewDecision":"APP
 small_fix_pr='{"number":3,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}'
 unknown_review_failed_pr='{"number":7,"mergeable":"MERGEABLE","reviewDecision":null,"isDraft":false,"labels":[{"name":"origin:worker"}],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}'
 unknown_review_passing_pr='{"number":8,"mergeable":"MERGEABLE","reviewDecision":null,"isDraft":false,"labels":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
+missing_number_pr='{"mergeable":"MERGEABLE","reviewDecision":"9","isDraft":false,"labels":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
 dirty_pr='{"number":4,"mergeable":"CONFLICTING","reviewDecision":"APPROVED","isDraft":false,"labels":[],"statusCheckRollup":[]}'
 human_pr='{"number":5,"mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","isDraft":false,"labels":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}'
 
@@ -94,6 +95,12 @@ assert_eq "1c.1: passing checks with refreshed CHANGES_REQUESTED classify as hum
 	"human-approval-needed" "$(_pmp_classify_pr_backlog_state "$enriched_review_pr")"
 assert_eq "1c.2: passing unknown reviewDecision performs one authoritative enrichment refresh" \
 	"1" "$(wc -l <"${TEST_TMPDIR}/review-refresh.log" | tr -d '[:space:]')"
+: >"${TEST_TMPDIR}/review-refresh.log"
+enriched_review_json=$(_pmp_enrich_prs_with_review_decisions "owner/repo" "[$missing_number_pr]")
+assert_eq "1c.2.1: missing PR number does not shift reviewDecision into the number field" \
+	"0" "$(wc -l <"${TEST_TMPDIR}/review-refresh.log" | tr -d '[:space:]')"
+assert_eq "1c.2.2: missing PR number preserves the original review decision" \
+	"9" "$(printf '%s' "$enriched_review_json" | jq -r '.[0].reviewDecision')"
 : >"${TEST_TMPDIR}/review-refresh.log"
 REFRESHED_REVIEW_DECISION="NONE"
 enriched_review_json=$(_pmp_enrich_prs_with_review_decisions "owner/repo" "[$unknown_review_passing_pr]")


### PR DESCRIPTION
## Summary

Prefetch PR indices, numbers, and review decisions with one jq pass, then update only refreshed unknown decisions.

## Files Changed

.agents/scripts/pulse-merge-process.sh, .agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh; bash .agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh (15 passed)

Resolves #28369


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 5m and 72,457 tokens on this as a headless worker.