### PR TITLE
GH#28368: propagate PR handoff classifier failures

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1006,7 +1006,7 @@ _worker_post_pr_handoff_confirmed() {
 	[[ -n "$branch_name" && -n "$local_head" ]] || return 1
 	local handoff_state=""
 	handoff_state=$(_pr_handoff_state_for_branch_or_issue \
-		"$branch_name" "$issue_number" "$repo_slug" "head-only" "$local_head" "1")
+		"$branch_name" "$issue_number" "$repo_slug" "head-only" "$local_head" "1") || return 1
 	[[ "${handoff_state%%|*}" == "ready" ]]
 	return $?
 }

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -4515,6 +4515,26 @@ test_post_pr_handoff_detects_open_pending_pr() {
 	return 0
 }
 
+test_post_pr_handoff_propagates_classifier_failure() {
+	local work_dir="${TEST_ROOT}/repo-post-pr-handoff-classifier-failure"
+	mkdir -p "$work_dir"
+	init_git_worktree "$work_dir"
+	git -C "$work_dir" checkout -q -b "feature/auto-test-issue-99999"
+
+	if (
+		DISPATCH_REPO_SLUG="test-owner/test-repo"
+		gh() { return 0; }
+		_pr_handoff_state_for_branch_or_issue() { printf 'ready|123'; return 1; }
+		_worker_post_pr_handoff_confirmed "issue-99999" "$work_dir"
+	); then
+		print_result "post-PR handoff propagates classifier failure" 1 \
+			"Expected classifier failure to override its ready-looking output"
+	else
+		print_result "post-PR handoff propagates classifier failure" 0
+	fi
+	return 0
+}
+
 test_post_pr_handoff_treats_ci_as_monitoring_state() {
 	local work_dir="${TEST_ROOT}/repo-post-pr-handoff-ci-state"
 	mkdir -p "$work_dir"
@@ -4868,6 +4888,7 @@ test_completion_infrastructure_resumes_without_implementation_penalty() {
 
 test_pr_checkpoint_lifecycle_cases() {
 	test_post_pr_handoff_detects_open_pending_pr
+	test_post_pr_handoff_propagates_classifier_failure
 	test_post_pr_handoff_treats_ci_as_monitoring_state
 	test_post_pr_handoff_rejects_mismatched_head_or_missing_summary
 	test_failed_worker_draft_checkpoint_escalates_without_completion


### PR DESCRIPTION
## Summary

Propagate durable PR handoff classifier failures before interpreting ready-looking output, with a regression test.

## Files Changed

.agents/scripts/headless-runtime-helper.sh, .agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passed for the helper and test; test-headless-runtime-helper.sh passed 169 tests with 0 failures.

Resolves #28368


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 7m and 100,092 tokens on this as a headless worker.