### PR TITLE
t18165: Unify typed Pulse outcomes and heartbeat-progress state

### DIFF
--- a/.agents/scripts/pulse-current-state-helper.sh
+++ b/.agents/scripts/pulse-current-state-helper.sh
@@ -115,14 +115,16 @@ main() {
 	runtime_state_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-pulse-runtime-state.XXXXXX") || runtime_state_file=""
 	local projection_status=0
 	local projection_output=""
-	AIDEVOPS_ACTIVE_WORKER_PROCESSES="$active_worker_processes" \
-		AIDEVOPS_WORKER_WORKTREE_COUNT="$worker_worktree_count" \
-		AIDEVOPS_GRAPHQL_BUDGET_STATUS="$graphql_budget_status" \
-		AIDEVOPS_OBJECTIVE_STATE_FILE="$objective_state_file" \
-		AIDEVOPS_RUNTIME_STATE_OUTPUT="$runtime_state_file" \
-		projection_output=$(python3 "${SCRIPT_DIR}/pulse-current-state.py" \
-			"$log_dir" "$repo_path" "$window_s" "$as_json" "$SCRIPT_DIR" \
-			"$review_thread_state_dir") || projection_status=$?
+	projection_output=$(
+		AIDEVOPS_ACTIVE_WORKER_PROCESSES="$active_worker_processes" \
+			AIDEVOPS_WORKER_WORKTREE_COUNT="$worker_worktree_count" \
+			AIDEVOPS_GRAPHQL_BUDGET_STATUS="$graphql_budget_status" \
+			AIDEVOPS_OBJECTIVE_STATE_FILE="$objective_state_file" \
+			AIDEVOPS_RUNTIME_STATE_OUTPUT="$runtime_state_file" \
+			python3 "${SCRIPT_DIR}/pulse-current-state.py" \
+				"$log_dir" "$repo_path" "$window_s" "$as_json" "$SCRIPT_DIR" \
+				"$review_thread_state_dir"
+	) || projection_status=$?
 	local overlay_json="{}"
 	overlay_json=$(_observability_overlay_json)
 	if [[ "$projection_status" -eq 0 && "$as_json" -eq 1 ]] && printf '%s' "$projection_output" | jq empty >/dev/null 2>&1; then

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -154,7 +154,7 @@ def build_cycle_state(path):
         with open(path, encoding='utf-8') as handle:
             health = json.load(handle)
     except FileNotFoundError:
-        return unavailable_cycle_state('unavailable')
+        health = {}
     except (OSError, json.JSONDecodeError, TypeError):
         return unavailable_cycle_state('malformed', 'health-json')
     if not isinstance(health, dict):

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -14,6 +14,17 @@ from collections import Counter, defaultdict, deque
 log_dir, repo_path, window_s, as_json, script_dir, review_thread_state_dir = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4] == '1', sys.argv[5], sys.argv[6]
 now = time.time()
 since = now - window_s
+CYCLE_STATE_SCHEMA = 'aidevops.pulse-cycle-state/v1'
+CYCLE_STATE_PHASES = {'admitted', 'preflight', 'deterministic', 'supervising', 'completed'}
+CYCLE_STATE_OUTCOMES = {'running', 'progressed', 'idle', 'blocked', 'interrupted'}
+CYCLE_STATE_PROGRESS_KINDS = {'pr-merged', 'pr-closed-conflicting', 'worker-dispatched'}
+CYCLE_STATE_BLOCKER_KINDS = {
+    'none', 'session-gate', 'dedup', 'preflight-failed', 'stop-requested',
+    'dispatch-no-work-rate', 'runner-health', 'merge-authority', 'review-gate',
+    'review-bot-threads', 'required-review-threads', 'checks-active',
+    'checks-failed', 'quiet-period', 'snapshot-unavailable', 'head-changed',
+    'interrupted',
+}
 
 
 def recent_lines(path, limit=2000):
@@ -65,6 +76,79 @@ def valid_cycle_fingerprint(value):
     return False
 
 
+def valid_nonnegative_int(value):
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def valid_optional_cycle_time(value):
+    if value is None:
+        return True
+    return parse_time(value) > 0
+
+
+def valid_cycle_progress(progress):
+    if not isinstance(progress, dict):
+        return False
+    kinds = progress.get('kinds')
+    if not isinstance(kinds, list):
+        return False
+    return all((
+        all(kind in CYCLE_STATE_PROGRESS_KINDS for kind in kinds),
+        valid_nonnegative_int(progress.get('consecutive_no_progress_cycles')),
+        valid_optional_cycle_time(progress.get('last_at')),
+    ))
+
+
+def valid_cycle_blocker(blocker):
+    if not isinstance(blocker, dict):
+        return False
+    kind = blocker.get('kind')
+    streak = blocker.get('consecutive_same_cycles')
+    fingerprint = blocker.get('fingerprint')
+    if kind not in CYCLE_STATE_BLOCKER_KINDS or not valid_nonnegative_int(streak):
+        return False
+    if kind == 'none':
+        return fingerprint is None and streak == 0
+    return valid_cycle_fingerprint(fingerprint)
+
+
+def valid_terminal_cycle_state(state, progress, blocker):
+    if state.get('phase') != 'completed':
+        return False
+    outcome = state.get('outcome')
+    no_progress = progress['consecutive_no_progress_cycles']
+    if outcome == 'progressed':
+        return all((
+            progress['kinds'], progress['last_at'], no_progress == 0,
+            blocker['kind'] == 'none',
+        ))
+    if no_progress < 1:
+        return False
+    if outcome in {'blocked', 'interrupted'}:
+        return blocker['kind'] != 'none' and blocker['consecutive_same_cycles'] >= 1
+    return outcome == 'idle' and blocker['kind'] == 'none'
+
+
+def valid_cycle_state_contract(state):
+    progress = state.get('progress')
+    blocker = state.get('blocker')
+    cycle_id = state.get('cycle_id')
+    if not all((
+        state.get('schema') == CYCLE_STATE_SCHEMA,
+        isinstance(cycle_id, str),
+        bool(cycle_id),
+        state.get('phase') in CYCLE_STATE_PHASES,
+        state.get('outcome') in CYCLE_STATE_OUTCOMES,
+        parse_time(state.get('heartbeat_at')) > 0,
+        valid_cycle_progress(progress),
+        valid_cycle_blocker(blocker),
+    )):
+        return False
+    if state.get('outcome') == 'running':
+        return state.get('phase') != 'completed'
+    return valid_terminal_cycle_state(state, progress, blocker)
+
+
 def build_cycle_state(path):
     try:
         with open(path, encoding='utf-8') as handle:
@@ -80,55 +164,10 @@ def build_cycle_state(path):
         return unavailable_cycle_state('unavailable')
     if not isinstance(state, dict):
         return unavailable_cycle_state('malformed', 'cycle-state-object')
-
-    phases = {'admitted', 'preflight', 'deterministic', 'supervising', 'completed'}
-    outcomes = {'running', 'progressed', 'idle', 'blocked', 'interrupted'}
-    progress_kinds = {'pr-merged', 'pr-closed-conflicting', 'worker-dispatched'}
-    blocker_kinds = {
-        'none', 'session-gate', 'dedup', 'preflight-failed', 'stop-requested',
-        'dispatch-no-work-rate', 'runner-health', 'merge-authority', 'review-gate',
-        'review-bot-threads', 'required-review-threads', 'checks-active',
-        'checks-failed', 'quiet-period', 'snapshot-unavailable', 'head-changed',
-        'interrupted',
-    }
-    progress = state.get('progress')
-    blocker = state.get('blocker')
-    no_progress = progress.get('consecutive_no_progress_cycles') if isinstance(progress, dict) else None
-    same_blocker = blocker.get('consecutive_same_cycles') if isinstance(blocker, dict) else None
-    kinds = progress.get('kinds') if isinstance(progress, dict) else None
-    blocker_kind = blocker.get('kind') if isinstance(blocker, dict) else None
-    fingerprint = blocker.get('fingerprint') if isinstance(blocker, dict) else None
-    last_at = progress.get('last_at') if isinstance(progress, dict) else None
-    invalid = (
-        state.get('schema') != 'aidevops.pulse-cycle-state/v1'
-        or not isinstance(state.get('cycle_id'), str)
-        or not state.get('cycle_id')
-        or state.get('phase') not in phases
-        or state.get('outcome') not in outcomes
-        or parse_time(state.get('heartbeat_at')) <= 0
-        or not isinstance(progress, dict)
-        or not isinstance(kinds, list)
-        or any(kind not in progress_kinds for kind in kinds)
-        or isinstance(no_progress, bool)
-        or not isinstance(no_progress, int)
-        or no_progress < 0
-        or (last_at is not None and parse_time(last_at) <= 0)
-        or not isinstance(blocker, dict)
-        or blocker_kind not in blocker_kinds
-        or isinstance(same_blocker, bool)
-        or not isinstance(same_blocker, int)
-        or same_blocker < 0
-        or (blocker_kind == 'none' and (fingerprint is not None or same_blocker != 0))
-        or (blocker_kind != 'none' and not valid_cycle_fingerprint(fingerprint))
-        or (state.get('outcome') == 'running' and state.get('phase') == 'completed')
-        or (state.get('outcome') != 'running' and state.get('phase') != 'completed')
-        or (state.get('outcome') == 'progressed' and (not kinds or last_at is None or no_progress != 0))
-        or (state.get('outcome') == 'blocked' and blocker_kind == 'none')
-        or (state.get('outcome') == 'interrupted' and blocker_kind == 'none')
-        or (state.get('outcome') == 'idle' and blocker_kind != 'none')
-    )
-    if invalid:
+    if not valid_cycle_state_contract(state):
         return unavailable_cycle_state('malformed', 'cycle-state-contract')
+    progress = state['progress']
+    blocker = state['blocker']
     return {
         'availability': 'available',
         'schema': state['schema'],
@@ -137,14 +176,14 @@ def build_cycle_state(path):
         'outcome': state['outcome'],
         'heartbeat_at': state['heartbeat_at'],
         'progress': {
-            'last_at': last_at,
-            'kinds': kinds,
-            'consecutive_no_progress_cycles': no_progress,
+            'last_at': progress['last_at'],
+            'kinds': progress['kinds'],
+            'consecutive_no_progress_cycles': progress['consecutive_no_progress_cycles'],
         },
         'blocker': {
-            'kind': blocker_kind,
-            'fingerprint': fingerprint,
-            'consecutive_same_cycles': same_blocker,
+            'kind': blocker['kind'],
+            'fingerprint': blocker['fingerprint'],
+            'consecutive_same_cycles': blocker['consecutive_same_cycles'],
         },
     }
 

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -162,10 +162,9 @@ def build_cycle_state(path):
     state = health.get('cycle_state')
     if state is None:
         return unavailable_cycle_state('unavailable')
-    if not isinstance(state, dict):
-        return unavailable_cycle_state('malformed', 'cycle-state-object')
-    if not valid_cycle_state_contract(state):
-        return unavailable_cycle_state('malformed', 'cycle-state-contract')
+    if not isinstance(state, dict) or not valid_cycle_state_contract(state):
+        reason = 'cycle-state-object' if not isinstance(state, dict) else 'cycle-state-contract'
+        return unavailable_cycle_state('malformed', reason)
     progress = state['progress']
     blocker = state['blocker']
     return {

--- a/.agents/scripts/pulse-current-state.py
+++ b/.agents/scripts/pulse-current-state.py
@@ -38,6 +38,117 @@ def parse_time(value):
         return 0.0
 
 
+def unavailable_cycle_state(availability, reason=None):
+    state = {
+        'availability': availability,
+        'schema': None,
+        'cycle_id': None,
+        'phase': None,
+        'outcome': None,
+        'heartbeat_at': None,
+        'progress': None,
+        'blocker': None,
+    }
+    if reason:
+        state['reason'] = reason
+    return state
+
+
+def valid_cycle_fingerprint(value):
+    if not isinstance(value, str):
+        return False
+    if value.startswith('sha256:'):
+        digest = value[len('sha256:'):]
+        return len(digest) == 64 and all(char in '0123456789abcdef' for char in digest)
+    if value.startswith('cksum:'):
+        return value[len('cksum:'):].isdigit()
+    return False
+
+
+def build_cycle_state(path):
+    try:
+        with open(path, encoding='utf-8') as handle:
+            health = json.load(handle)
+    except FileNotFoundError:
+        return unavailable_cycle_state('unavailable')
+    except (OSError, json.JSONDecodeError, TypeError):
+        return unavailable_cycle_state('malformed', 'health-json')
+    if not isinstance(health, dict):
+        return unavailable_cycle_state('malformed', 'health-object')
+    state = health.get('cycle_state')
+    if state is None:
+        return unavailable_cycle_state('unavailable')
+    if not isinstance(state, dict):
+        return unavailable_cycle_state('malformed', 'cycle-state-object')
+
+    phases = {'admitted', 'preflight', 'deterministic', 'supervising', 'completed'}
+    outcomes = {'running', 'progressed', 'idle', 'blocked', 'interrupted'}
+    progress_kinds = {'pr-merged', 'pr-closed-conflicting', 'worker-dispatched'}
+    blocker_kinds = {
+        'none', 'session-gate', 'dedup', 'preflight-failed', 'stop-requested',
+        'dispatch-no-work-rate', 'runner-health', 'merge-authority', 'review-gate',
+        'review-bot-threads', 'required-review-threads', 'checks-active',
+        'checks-failed', 'quiet-period', 'snapshot-unavailable', 'head-changed',
+        'interrupted',
+    }
+    progress = state.get('progress')
+    blocker = state.get('blocker')
+    no_progress = progress.get('consecutive_no_progress_cycles') if isinstance(progress, dict) else None
+    same_blocker = blocker.get('consecutive_same_cycles') if isinstance(blocker, dict) else None
+    kinds = progress.get('kinds') if isinstance(progress, dict) else None
+    blocker_kind = blocker.get('kind') if isinstance(blocker, dict) else None
+    fingerprint = blocker.get('fingerprint') if isinstance(blocker, dict) else None
+    last_at = progress.get('last_at') if isinstance(progress, dict) else None
+    invalid = (
+        state.get('schema') != 'aidevops.pulse-cycle-state/v1'
+        or not isinstance(state.get('cycle_id'), str)
+        or not state.get('cycle_id')
+        or state.get('phase') not in phases
+        or state.get('outcome') not in outcomes
+        or parse_time(state.get('heartbeat_at')) <= 0
+        or not isinstance(progress, dict)
+        or not isinstance(kinds, list)
+        or any(kind not in progress_kinds for kind in kinds)
+        or isinstance(no_progress, bool)
+        or not isinstance(no_progress, int)
+        or no_progress < 0
+        or (last_at is not None and parse_time(last_at) <= 0)
+        or not isinstance(blocker, dict)
+        or blocker_kind not in blocker_kinds
+        or isinstance(same_blocker, bool)
+        or not isinstance(same_blocker, int)
+        or same_blocker < 0
+        or (blocker_kind == 'none' and (fingerprint is not None or same_blocker != 0))
+        or (blocker_kind != 'none' and not valid_cycle_fingerprint(fingerprint))
+        or (state.get('outcome') == 'running' and state.get('phase') == 'completed')
+        or (state.get('outcome') != 'running' and state.get('phase') != 'completed')
+        or (state.get('outcome') == 'progressed' and (not kinds or last_at is None or no_progress != 0))
+        or (state.get('outcome') == 'blocked' and blocker_kind == 'none')
+        or (state.get('outcome') == 'interrupted' and blocker_kind == 'none')
+        or (state.get('outcome') == 'idle' and blocker_kind != 'none')
+    )
+    if invalid:
+        return unavailable_cycle_state('malformed', 'cycle-state-contract')
+    return {
+        'availability': 'available',
+        'schema': state['schema'],
+        'cycle_id': state['cycle_id'],
+        'phase': state['phase'],
+        'outcome': state['outcome'],
+        'heartbeat_at': state['heartbeat_at'],
+        'progress': {
+            'last_at': last_at,
+            'kinds': kinds,
+            'consecutive_no_progress_cycles': no_progress,
+        },
+        'blocker': {
+            'kind': blocker_kind,
+            'fingerprint': fingerprint,
+            'consecutive_same_cycles': same_blocker,
+        },
+    }
+
+
 def parse_stage(line):
     parts = line.split('\t')
     if not parts:
@@ -409,6 +520,7 @@ prefetch_cache = {
     'conditional_misses': 0,
 }
 health_path = os.path.join(log_dir, 'pulse-health.json')
+cycle_state = build_cycle_state(health_path)
 if os.path.exists(health_path):
     try:
         with open(health_path, encoding='utf-8') as health_file:
@@ -497,6 +609,7 @@ result = {
     'top_graphql_consumers': api_consumers,
     'api_call_pressure': api_pressure,
     'prefetch_cache': prefetch_cache,
+    'cycle_state': cycle_state,
     'review_thread_attention': review_thread_attention,
     'objective_reconciliation': objective_reconciliation,
 }
@@ -518,6 +631,7 @@ runtime_state = {
     'dispatch_stage_counts': dict(stage_counts),
     'graphql_budget': graphql_budget,
     'prefetch_cache': prefetch_cache,
+    'cycle_state': cycle_state,
     'pre_launch_blockers': pre_launch_blockers,
     'pulse_counter_hits': counter_hits,
     'pulse_gauges': gauge_values,
@@ -555,6 +669,7 @@ else:
     print(f'- Pulse counter hits: {json.dumps(counter_hits, sort_keys=True)}')
     print(f'- GraphQL budget: {graphql_budget_status}')
     print(f'- Prefetch cache: {json.dumps(prefetch_cache, sort_keys=True)}')
+    print(f'- Cycle state: {json.dumps(cycle_state, sort_keys=True)}')
     print(f'- Dispatch API blocked by GraphQL: {str(dispatch_api_blocked).lower()}')
     print(f'- Active worker processes: {active_worker_processes if active_worker_processes is not None else "unknown"}')
     if api_consumers:

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -328,10 +328,18 @@ _pulse_cycle_state_health_is_current() {
 	[[ -n "$current_cycle_id" && "$current_cycle_id" == "${_PULSE_CYCLE_ID:-}" ]]
 }
 
+_pulse_cycle_state_commit_legacy_outcome() {
+	if declare -F _pulse_commit_legacy_cycle_outcome >/dev/null 2>&1; then
+		_pulse_commit_legacy_cycle_outcome || true
+	fi
+	return 0
+}
+
 _pulse_cycle_state_write_terminal_if_current() {
 	local reacquired_lock=0
 	[[ "${_PULSE_CYCLE_STATE_TERMINAL:-0}" == "1" ]] || return 1
 	if [[ "${_LOCK_OWNED:-false}" == "true" ]]; then
+		_pulse_cycle_state_commit_legacy_outcome
 		write_pulse_health_file
 		return $?
 	fi
@@ -345,6 +353,7 @@ _pulse_cycle_state_write_terminal_if_current() {
 		reacquired_lock=1
 	fi
 	if _pulse_cycle_state_health_is_current; then
+		_pulse_cycle_state_commit_legacy_outcome
 		write_pulse_health_file || true
 	else
 		printf '[pulse-wrapper] Cycle state: skipped stale terminal publish for cycle %s because current health belongs to another cycle\n' \

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -336,21 +336,22 @@ _pulse_cycle_state_commit_legacy_outcome() {
 }
 
 _pulse_cycle_state_write_terminal_if_current() {
-	local reacquired_lock=0
 	[[ "${_PULSE_CYCLE_STATE_TERMINAL:-0}" == "1" ]] || return 1
 	if [[ "${_LOCK_OWNED:-false}" == "true" ]]; then
 		_pulse_cycle_state_commit_legacy_outcome
 		write_pulse_health_file
 		return $?
 	fi
-	if declare -F acquire_instance_lock >/dev/null 2>&1 \
-		&& declare -F release_instance_lock >/dev/null 2>&1; then
-		if ! acquire_instance_lock; then
-			printf '[pulse-wrapper] Cycle state: skipped terminal publish for cycle %s because a newer cycle owns the instance lock\n' \
-				"${_PULSE_CYCLE_ID:-unknown}" >>"${WRAPPER_LOGFILE:-/dev/null}"
-			return 0
-		fi
-		reacquired_lock=1
+	if ! declare -F acquire_instance_lock >/dev/null 2>&1 \
+		|| ! declare -F release_instance_lock >/dev/null 2>&1; then
+		printf '[pulse-wrapper] Cycle state: skipped terminal publish for cycle %s because instance lock functions are unavailable\n' \
+			"${_PULSE_CYCLE_ID:-unknown}" >>"${WRAPPER_LOGFILE:-/dev/null}"
+		return 0
+	fi
+	if ! acquire_instance_lock; then
+		printf '[pulse-wrapper] Cycle state: skipped terminal publish for cycle %s because a newer cycle owns the instance lock\n' \
+			"${_PULSE_CYCLE_ID:-unknown}" >>"${WRAPPER_LOGFILE:-/dev/null}"
+		return 0
 	fi
 	if _pulse_cycle_state_health_is_current; then
 		_pulse_cycle_state_commit_legacy_outcome
@@ -359,9 +360,7 @@ _pulse_cycle_state_write_terminal_if_current() {
 		printf '[pulse-wrapper] Cycle state: skipped stale terminal publish for cycle %s because current health belongs to another cycle\n' \
 			"${_PULSE_CYCLE_ID:-unknown}" >>"${WRAPPER_LOGFILE:-/dev/null}"
 	fi
-	if [[ "$reacquired_lock" -eq 1 ]]; then
-		release_instance_lock
-	fi
+	release_instance_lock
 	return 0
 }
 

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -28,6 +28,9 @@
 _PULSE_LOGGING_LOADED=1
 
 PULSE_CYCLE_STATE_SCHEMA="aidevops.pulse-cycle-state/v1"
+PULSE_CYCLE_STATE_ARRAY_TYPE="array"
+PULSE_CYCLE_STATE_BLOCKER_NONE="none"
+PULSE_CYCLE_STATE_OBJECT_TYPE="object"
 _PULSE_CYCLE_STATE_INITIALIZED=0
 _PULSE_CYCLE_STATE_TERMINAL=0
 _PULSE_CYCLE_ID=""
@@ -37,13 +40,13 @@ _PULSE_CYCLE_HEARTBEAT_AT=""
 _PULSE_CYCLE_PROGRESS_LAST_AT=""
 _PULSE_CYCLE_PROGRESS_KINDS_JSON="[]"
 _PULSE_CYCLE_NO_PROGRESS_CYCLES=0
-_PULSE_CYCLE_BLOCKER_KIND="none"
+_PULSE_CYCLE_BLOCKER_KIND="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 _PULSE_CYCLE_BLOCKER_FINGERPRINT=""
 _PULSE_CYCLE_SAME_BLOCKER_CYCLES=0
 _PULSE_CYCLE_PRIOR_PROGRESS_LAST_AT=""
 _PULSE_CYCLE_PRIOR_PROGRESS_KINDS_JSON="[]"
 _PULSE_CYCLE_PRIOR_NO_PROGRESS_CYCLES=0
-_PULSE_CYCLE_PRIOR_BLOCKER_KIND="none"
+_PULSE_CYCLE_PRIOR_BLOCKER_KIND="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 _PULSE_CYCLE_PRIOR_BLOCKER_FINGERPRINT=""
 _PULSE_CYCLE_PRIOR_SAME_BLOCKER_CYCLES=0
 
@@ -55,7 +58,7 @@ _pulse_cycle_state_now() {
 _pulse_cycle_state_blocker_is_valid() {
 	local kind="$1"
 	case "$kind" in
-	none | session-gate | dedup | preflight-failed | stop-requested | \
+	"$PULSE_CYCLE_STATE_BLOCKER_NONE" | session-gate | dedup | preflight-failed | stop-requested | \
 		dispatch-no-work-rate | runner-health | merge-authority | review-gate | \
 		review-bot-threads | required-review-threads | checks-active | \
 		checks-failed | quiet-period | snapshot-unavailable | head-changed | interrupted)
@@ -89,22 +92,24 @@ _pulse_cycle_state_start() {
 	local prior_progress_last_at=""
 	local prior_progress_kinds_json="[]"
 	local prior_no_progress="0"
-	local prior_blocker_kind="none"
+	local prior_blocker_kind="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 	local prior_blocker_fingerprint=""
 	local prior_same_blocker="0"
 	now=$(_pulse_cycle_state_now)
 	if [[ -f "${PULSE_HEALTH_FILE:-}" ]]; then
-		previous_fields=$(jq -r --arg schema "$PULSE_CYCLE_STATE_SCHEMA" '
+		previous_fields=$(jq -r --arg schema "$PULSE_CYCLE_STATE_SCHEMA" \
+			--arg array_type "$PULSE_CYCLE_STATE_ARRAY_TYPE" \
+			--arg object_type "$PULSE_CYCLE_STATE_OBJECT_TYPE" '
 			.cycle_state as $state
 			| select(
-				($state | type) == "object"
+				($state | type) == $object_type
 				and $state.schema == $schema
-				and ($state.progress | type) == "object"
-				and ($state.progress.kinds | type) == "array"
+				and ($state.progress | type) == $object_type
+				and ($state.progress.kinds | type) == $array_type
 				and all($state.progress.kinds[]; type == "string")
 				and ($state.progress.consecutive_no_progress_cycles | type) == "number"
 				and $state.progress.consecutive_no_progress_cycles >= 0
-				and ($state.blocker | type) == "object"
+				and ($state.blocker | type) == $object_type
 				and ($state.blocker.kind | type) == "string"
 				and ($state.blocker.consecutive_same_cycles | type) == "number"
 				and $state.blocker.consecutive_same_cycles >= 0
@@ -125,19 +130,21 @@ _pulse_cycle_state_start() {
 			prior_no_progress prior_blocker_kind prior_blocker_fingerprint \
 			prior_same_blocker <<<"$previous_fields"
 	fi
-	printf '%s' "$prior_progress_kinds_json" | jq -e 'type == "array"' >/dev/null 2>&1 || prior_progress_kinds_json="[]"
+	printf '%s' "$prior_progress_kinds_json" \
+		| jq -e --arg array_type "$PULSE_CYCLE_STATE_ARRAY_TYPE" 'type == $array_type' \
+			>/dev/null 2>&1 || prior_progress_kinds_json="[]"
 	[[ "$prior_no_progress" =~ ^[0-9]+$ ]] || prior_no_progress=0
 	[[ "$prior_same_blocker" =~ ^[0-9]+$ ]] || prior_same_blocker=0
 	if ! _pulse_cycle_state_blocker_is_valid "$prior_blocker_kind"; then
-		prior_blocker_kind="none"
+		prior_blocker_kind="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 		prior_blocker_fingerprint=""
 		prior_same_blocker=0
 	fi
-	if [[ "$prior_blocker_kind" == "none" ]]; then
+	if [[ "$prior_blocker_kind" == "$PULSE_CYCLE_STATE_BLOCKER_NONE" ]]; then
 		prior_blocker_fingerprint=""
 		prior_same_blocker=0
 	elif [[ ! "$prior_blocker_fingerprint" =~ ^(sha256:[0-9a-f]{64}|cksum:[0-9]+)$ ]]; then
-		prior_blocker_kind="none"
+		prior_blocker_kind="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 		prior_blocker_fingerprint=""
 		prior_same_blocker=0
 	fi
@@ -157,7 +164,7 @@ _pulse_cycle_state_start() {
 	_PULSE_CYCLE_PROGRESS_LAST_AT="$prior_progress_last_at"
 	_PULSE_CYCLE_PROGRESS_KINDS_JSON="$prior_progress_kinds_json"
 	_PULSE_CYCLE_NO_PROGRESS_CYCLES="$prior_no_progress"
-	_PULSE_CYCLE_BLOCKER_KIND="none"
+	_PULSE_CYCLE_BLOCKER_KIND="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 	_PULSE_CYCLE_BLOCKER_FINGERPRINT=""
 	_PULSE_CYCLE_SAME_BLOCKER_CYCLES=0
 	return 0
@@ -183,15 +190,16 @@ _pulse_cycle_state_set_blocker() {
 	local candidate=""
 	local current=""
 	_pulse_cycle_state_blocker_is_valid "$kind" || return 1
-	if [[ "$kind" == "none" ]]; then
-		_PULSE_CYCLE_BLOCKER_KIND="none"
+	if [[ "$kind" == "$PULSE_CYCLE_STATE_BLOCKER_NONE" ]]; then
+		_PULSE_CYCLE_BLOCKER_KIND="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 		_PULSE_CYCLE_BLOCKER_FINGERPRINT=""
 		return 0
 	fi
 	[[ "$fingerprint" =~ ^(sha256:[0-9a-f]{64}|cksum:[0-9]+)$ ]] || return 1
 	candidate="${kind}:${fingerprint}"
-	current="${_PULSE_CYCLE_BLOCKER_KIND:-none}:${_PULSE_CYCLE_BLOCKER_FINGERPRINT:-}"
-	if [[ "${_PULSE_CYCLE_BLOCKER_KIND:-none}" == "none" || "$candidate" < "$current" ]]; then
+	current="${_PULSE_CYCLE_BLOCKER_KIND:-$PULSE_CYCLE_STATE_BLOCKER_NONE}:${_PULSE_CYCLE_BLOCKER_FINGERPRINT:-}"
+	if [[ "${_PULSE_CYCLE_BLOCKER_KIND:-$PULSE_CYCLE_STATE_BLOCKER_NONE}" == "$PULSE_CYCLE_STATE_BLOCKER_NONE" \
+		|| "$candidate" < "$current" ]]; then
 		_PULSE_CYCLE_BLOCKER_KIND="$kind"
 		_PULSE_CYCLE_BLOCKER_FINGERPRINT="$fingerprint"
 	fi
@@ -218,8 +226,9 @@ _pulse_cycle_state_finalize() {
 	progressed | idle | blocked | interrupted) ;;
 	*) return 1 ;;
 	esac
-	printf '%s' "$progress_kinds_json" | jq -e '
-		type == "array"
+	printf '%s' "$progress_kinds_json" | jq -e \
+		--arg array_type "$PULSE_CYCLE_STATE_ARRAY_TYPE" '
+		type == $array_type
 		and all(.[]; . == "pr-merged" or . == "pr-closed-conflicting" or . == "worker-dispatched")
 	' >/dev/null 2>&1 || return 1
 	now=$(_pulse_cycle_state_now)
@@ -227,7 +236,7 @@ _pulse_cycle_state_finalize() {
 		_PULSE_CYCLE_PROGRESS_LAST_AT="$now"
 		_PULSE_CYCLE_PROGRESS_KINDS_JSON="$progress_kinds_json"
 		_PULSE_CYCLE_NO_PROGRESS_CYCLES=0
-		_PULSE_CYCLE_BLOCKER_KIND="none"
+		_PULSE_CYCLE_BLOCKER_KIND="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 		_PULSE_CYCLE_BLOCKER_FINGERPRINT=""
 		_PULSE_CYCLE_SAME_BLOCKER_CYCLES=0
 	else
@@ -235,7 +244,7 @@ _pulse_cycle_state_finalize() {
 		_PULSE_CYCLE_PROGRESS_KINDS_JSON="${_PULSE_CYCLE_PRIOR_PROGRESS_KINDS_JSON:-[]}"
 		_PULSE_CYCLE_NO_PROGRESS_CYCLES=$((${_PULSE_CYCLE_PRIOR_NO_PROGRESS_CYCLES:-0} + 1))
 		if [[ "$outcome" == "blocked" || "$outcome" == "interrupted" ]]; then
-			if [[ "${_PULSE_CYCLE_BLOCKER_KIND:-none}" == "${_PULSE_CYCLE_PRIOR_BLOCKER_KIND:-none}" \
+			if [[ "${_PULSE_CYCLE_BLOCKER_KIND:-$PULSE_CYCLE_STATE_BLOCKER_NONE}" == "${_PULSE_CYCLE_PRIOR_BLOCKER_KIND:-$PULSE_CYCLE_STATE_BLOCKER_NONE}" \
 				&& "${_PULSE_CYCLE_BLOCKER_FINGERPRINT:-}" == "${_PULSE_CYCLE_PRIOR_BLOCKER_FINGERPRINT:-}" ]]; then
 				same_blocker=$((${_PULSE_CYCLE_PRIOR_SAME_BLOCKER_CYCLES:-0} + 1))
 			else
@@ -243,7 +252,7 @@ _pulse_cycle_state_finalize() {
 			fi
 			_PULSE_CYCLE_SAME_BLOCKER_CYCLES="$same_blocker"
 		else
-			_PULSE_CYCLE_BLOCKER_KIND="none"
+			_PULSE_CYCLE_BLOCKER_KIND="$PULSE_CYCLE_STATE_BLOCKER_NONE"
 			_PULSE_CYCLE_BLOCKER_FINGERPRINT=""
 			_PULSE_CYCLE_SAME_BLOCKER_CYCLES=0
 		fi
@@ -259,7 +268,8 @@ _pulse_cycle_state_json() {
 	if [[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" != "1" ]]; then
 		if [[ -f "${PULSE_HEALTH_FILE:-}" ]]; then
 			jq -ce --arg schema "$PULSE_CYCLE_STATE_SCHEMA" \
-				'.cycle_state | select(type == "object" and .schema == $schema)' \
+				--arg object_type "$PULSE_CYCLE_STATE_OBJECT_TYPE" \
+				'.cycle_state | select(type == $object_type and .schema == $schema)' \
 				"$PULSE_HEALTH_FILE" 2>/dev/null && return 0
 		fi
 		printf 'null\n'
@@ -308,8 +318,9 @@ _pulse_cycle_state_health_is_current() {
 	local current_cycle_id=""
 	[[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" ]] || return 1
 	[[ -f "${PULSE_HEALTH_FILE:-}" ]] || return 1
-	current_cycle_id=$(jq -r --arg schema "$PULSE_CYCLE_STATE_SCHEMA" '
-		if (.cycle_state | type) == "object" and .cycle_state.schema == $schema
+	current_cycle_id=$(jq -r --arg schema "$PULSE_CYCLE_STATE_SCHEMA" \
+		--arg object_type "$PULSE_CYCLE_STATE_OBJECT_TYPE" '
+		if (.cycle_state | type) == $object_type and .cycle_state.schema == $schema
 		then .cycle_state.cycle_id // ""
 		else ""
 		end
@@ -349,7 +360,8 @@ _pulse_cycle_state_finish_if_needed() {
 	local outcome="${1:-interrupted}"
 	[[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" ]] || return 0
 	[[ "${_PULSE_CYCLE_STATE_TERMINAL:-0}" != "1" ]] || return 0
-	if [[ "$outcome" == "interrupted" && "${_PULSE_CYCLE_BLOCKER_KIND:-none}" == "none" ]]; then
+	if [[ "$outcome" == "interrupted" \
+		&& "${_PULSE_CYCLE_BLOCKER_KIND:-$PULSE_CYCLE_STATE_BLOCKER_NONE}" == "$PULSE_CYCLE_STATE_BLOCKER_NONE" ]]; then
 		_pulse_cycle_state_note_blocker interrupted pulse-wrapper exit || true
 	fi
 	_pulse_cycle_state_finalize "$outcome" "[]" || return 0
@@ -602,9 +614,9 @@ append_cycle_index() {
 write_pulse_health_file() {
 	local ts
 	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-	local cycle_state_json="null"
-	cycle_state_json=$(_pulse_cycle_state_json) || cycle_state_json="null"
-	printf '%s' "$cycle_state_json" | jq empty >/dev/null 2>&1 || cycle_state_json="null"
+	local cycle_state_json=null
+	cycle_state_json=$(_pulse_cycle_state_json) || cycle_state_json=null
+	printf '%s' "$cycle_state_json" | jq empty >/dev/null 2>&1 || cycle_state_json=null
 
 	# t3032: declare ledger helper once — used for both workers reconciliation
 	# and issues_dispatched. The ledger is written synchronously at dispatch

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -14,6 +14,7 @@
 # _PULSE_HEALTH_* counters in the bootstrap section.
 #
 # Functions in this module (in source order):
+#   - cycle-state lifecycle and projection helpers
 #   - rotate_pulse_log
 #   - append_cycle_index
 #   - write_pulse_health_file
@@ -25,6 +26,295 @@
 # Include guard — prevent double-sourcing.
 [[ -n "${_PULSE_LOGGING_LOADED:-}" ]] && return 0
 _PULSE_LOGGING_LOADED=1
+
+PULSE_CYCLE_STATE_SCHEMA="aidevops.pulse-cycle-state/v1"
+_PULSE_CYCLE_STATE_INITIALIZED=0
+_PULSE_CYCLE_STATE_TERMINAL=0
+_PULSE_CYCLE_ID=""
+_PULSE_CYCLE_PHASE=""
+_PULSE_CYCLE_OUTCOME=""
+_PULSE_CYCLE_HEARTBEAT_AT=""
+_PULSE_CYCLE_PROGRESS_LAST_AT=""
+_PULSE_CYCLE_PROGRESS_KINDS_JSON="[]"
+_PULSE_CYCLE_NO_PROGRESS_CYCLES=0
+_PULSE_CYCLE_BLOCKER_KIND="none"
+_PULSE_CYCLE_BLOCKER_FINGERPRINT=""
+_PULSE_CYCLE_SAME_BLOCKER_CYCLES=0
+_PULSE_CYCLE_PRIOR_PROGRESS_LAST_AT=""
+_PULSE_CYCLE_PRIOR_PROGRESS_KINDS_JSON="[]"
+_PULSE_CYCLE_PRIOR_NO_PROGRESS_CYCLES=0
+_PULSE_CYCLE_PRIOR_BLOCKER_KIND="none"
+_PULSE_CYCLE_PRIOR_BLOCKER_FINGERPRINT=""
+_PULSE_CYCLE_PRIOR_SAME_BLOCKER_CYCLES=0
+
+_pulse_cycle_state_now() {
+	date -u +%Y-%m-%dT%H:%M:%SZ
+	return 0
+}
+
+_pulse_cycle_state_blocker_is_valid() {
+	local kind="$1"
+	case "$kind" in
+	none | session-gate | dedup | preflight-failed | stop-requested | \
+		dispatch-no-work-rate | runner-health | merge-authority | review-gate | \
+		review-bot-threads | required-review-threads | checks-active | \
+		checks-failed | quiet-period | snapshot-unavailable | head-changed | interrupted)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+_pulse_cycle_state_hash() {
+	local value="$1"
+	local digest=""
+	if command -v sha256sum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$value" | sha256sum 2>/dev/null | awk '{print $1}') || digest=""
+	elif command -v shasum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$value" | shasum -a 256 2>/dev/null | awk '{print $1}') || digest=""
+	fi
+	if [[ "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+		printf 'sha256:%s\n' "$digest"
+		return 0
+	fi
+	digest=$(printf '%s' "$value" | cksum 2>/dev/null | awk '{print $1}') || digest=""
+	[[ "$digest" =~ ^[0-9]+$ ]] || return 1
+	printf 'cksum:%s\n' "$digest"
+	return 0
+}
+
+_pulse_cycle_state_start() {
+	local now=""
+	local previous_fields=""
+	local prior_progress_last_at=""
+	local prior_progress_kinds_json="[]"
+	local prior_no_progress="0"
+	local prior_blocker_kind="none"
+	local prior_blocker_fingerprint=""
+	local prior_same_blocker="0"
+	now=$(_pulse_cycle_state_now)
+	if [[ -f "${PULSE_HEALTH_FILE:-}" ]]; then
+		previous_fields=$(jq -r --arg schema "$PULSE_CYCLE_STATE_SCHEMA" '
+			.cycle_state as $state
+			| select(
+				($state | type) == "object"
+				and $state.schema == $schema
+				and ($state.progress | type) == "object"
+				and ($state.progress.kinds | type) == "array"
+				and all($state.progress.kinds[]; type == "string")
+				and ($state.progress.consecutive_no_progress_cycles | type) == "number"
+				and $state.progress.consecutive_no_progress_cycles >= 0
+				and ($state.blocker | type) == "object"
+				and ($state.blocker.kind | type) == "string"
+				and ($state.blocker.consecutive_same_cycles | type) == "number"
+				and $state.blocker.consecutive_same_cycles >= 0
+			)
+			| [
+				($state.progress.last_at // ""),
+				($state.progress.kinds | tojson),
+				($state.progress.consecutive_no_progress_cycles | tostring),
+				$state.blocker.kind,
+				($state.blocker.fingerprint // ""),
+				($state.blocker.consecutive_same_cycles | tostring)
+			]
+			| join("\u001f")
+		' "$PULSE_HEALTH_FILE" 2>/dev/null) || previous_fields=""
+	fi
+	if [[ -n "$previous_fields" ]]; then
+		IFS=$'\x1f' read -r prior_progress_last_at prior_progress_kinds_json \
+			prior_no_progress prior_blocker_kind prior_blocker_fingerprint \
+			prior_same_blocker <<<"$previous_fields"
+	fi
+	printf '%s' "$prior_progress_kinds_json" | jq -e 'type == "array"' >/dev/null 2>&1 || prior_progress_kinds_json="[]"
+	[[ "$prior_no_progress" =~ ^[0-9]+$ ]] || prior_no_progress=0
+	[[ "$prior_same_blocker" =~ ^[0-9]+$ ]] || prior_same_blocker=0
+	if ! _pulse_cycle_state_blocker_is_valid "$prior_blocker_kind"; then
+		prior_blocker_kind="none"
+		prior_blocker_fingerprint=""
+		prior_same_blocker=0
+	fi
+	if [[ "$prior_blocker_kind" == "none" ]]; then
+		prior_blocker_fingerprint=""
+		prior_same_blocker=0
+	elif [[ ! "$prior_blocker_fingerprint" =~ ^(sha256:[0-9a-f]{64}|cksum:[0-9]+)$ ]]; then
+		prior_blocker_kind="none"
+		prior_blocker_fingerprint=""
+		prior_same_blocker=0
+	fi
+
+	_PULSE_CYCLE_STATE_INITIALIZED=1
+	_PULSE_CYCLE_STATE_TERMINAL=0
+	_PULSE_CYCLE_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+	_PULSE_CYCLE_PHASE="admitted"
+	_PULSE_CYCLE_OUTCOME="running"
+	_PULSE_CYCLE_HEARTBEAT_AT="$now"
+	_PULSE_CYCLE_PRIOR_PROGRESS_LAST_AT="$prior_progress_last_at"
+	_PULSE_CYCLE_PRIOR_PROGRESS_KINDS_JSON="$prior_progress_kinds_json"
+	_PULSE_CYCLE_PRIOR_NO_PROGRESS_CYCLES="$prior_no_progress"
+	_PULSE_CYCLE_PRIOR_BLOCKER_KIND="$prior_blocker_kind"
+	_PULSE_CYCLE_PRIOR_BLOCKER_FINGERPRINT="$prior_blocker_fingerprint"
+	_PULSE_CYCLE_PRIOR_SAME_BLOCKER_CYCLES="$prior_same_blocker"
+	_PULSE_CYCLE_PROGRESS_LAST_AT="$prior_progress_last_at"
+	_PULSE_CYCLE_PROGRESS_KINDS_JSON="$prior_progress_kinds_json"
+	_PULSE_CYCLE_NO_PROGRESS_CYCLES="$prior_no_progress"
+	_PULSE_CYCLE_BLOCKER_KIND="none"
+	_PULSE_CYCLE_BLOCKER_FINGERPRINT=""
+	_PULSE_CYCLE_SAME_BLOCKER_CYCLES=0
+	return 0
+}
+
+_pulse_cycle_state_transition() {
+	local phase="$1"
+	[[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" ]] || return 1
+	[[ "${_PULSE_CYCLE_STATE_TERMINAL:-0}" != "1" ]] || return 0
+	case "$phase" in
+	admitted | preflight | deterministic | supervising) ;;
+	*) return 1 ;;
+	esac
+	_PULSE_CYCLE_PHASE="$phase"
+	_PULSE_CYCLE_OUTCOME="running"
+	_PULSE_CYCLE_HEARTBEAT_AT=$(_pulse_cycle_state_now)
+	return 0
+}
+
+_pulse_cycle_state_set_blocker() {
+	local kind="$1"
+	local fingerprint="${2:-}"
+	local candidate=""
+	local current=""
+	_pulse_cycle_state_blocker_is_valid "$kind" || return 1
+	if [[ "$kind" == "none" ]]; then
+		_PULSE_CYCLE_BLOCKER_KIND="none"
+		_PULSE_CYCLE_BLOCKER_FINGERPRINT=""
+		return 0
+	fi
+	[[ "$fingerprint" =~ ^(sha256:[0-9a-f]{64}|cksum:[0-9]+)$ ]] || return 1
+	candidate="${kind}:${fingerprint}"
+	current="${_PULSE_CYCLE_BLOCKER_KIND:-none}:${_PULSE_CYCLE_BLOCKER_FINGERPRINT:-}"
+	if [[ "${_PULSE_CYCLE_BLOCKER_KIND:-none}" == "none" || "$candidate" < "$current" ]]; then
+		_PULSE_CYCLE_BLOCKER_KIND="$kind"
+		_PULSE_CYCLE_BLOCKER_FINGERPRINT="$fingerprint"
+	fi
+	return 0
+}
+
+_pulse_cycle_state_note_blocker() {
+	local kind="$1"
+	local scope="${2:-global}"
+	local subject="${3:-pulse}"
+	local fingerprint=""
+	fingerprint=$(_pulse_cycle_state_hash "${kind}|${scope}|${subject}") || return 1
+	_pulse_cycle_state_set_blocker "$kind" "$fingerprint"
+	return $?
+}
+
+_pulse_cycle_state_finalize() {
+	local outcome="$1"
+	local progress_kinds_json="${2:-[]}"
+	local now=""
+	local same_blocker=0
+	[[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" ]] || return 1
+	case "$outcome" in
+	progressed | idle | blocked | interrupted) ;;
+	*) return 1 ;;
+	esac
+	printf '%s' "$progress_kinds_json" | jq -e '
+		type == "array"
+		and all(.[]; . == "pr-merged" or . == "pr-closed-conflicting" or . == "worker-dispatched")
+	' >/dev/null 2>&1 || return 1
+	now=$(_pulse_cycle_state_now)
+	if [[ "$outcome" == "progressed" ]]; then
+		_PULSE_CYCLE_PROGRESS_LAST_AT="$now"
+		_PULSE_CYCLE_PROGRESS_KINDS_JSON="$progress_kinds_json"
+		_PULSE_CYCLE_NO_PROGRESS_CYCLES=0
+		_PULSE_CYCLE_BLOCKER_KIND="none"
+		_PULSE_CYCLE_BLOCKER_FINGERPRINT=""
+		_PULSE_CYCLE_SAME_BLOCKER_CYCLES=0
+	else
+		_PULSE_CYCLE_PROGRESS_LAST_AT="${_PULSE_CYCLE_PRIOR_PROGRESS_LAST_AT:-}"
+		_PULSE_CYCLE_PROGRESS_KINDS_JSON="${_PULSE_CYCLE_PRIOR_PROGRESS_KINDS_JSON:-[]}"
+		_PULSE_CYCLE_NO_PROGRESS_CYCLES=$((${_PULSE_CYCLE_PRIOR_NO_PROGRESS_CYCLES:-0} + 1))
+		if [[ "$outcome" == "blocked" || "$outcome" == "interrupted" ]]; then
+			if [[ "${_PULSE_CYCLE_BLOCKER_KIND:-none}" == "${_PULSE_CYCLE_PRIOR_BLOCKER_KIND:-none}" \
+				&& "${_PULSE_CYCLE_BLOCKER_FINGERPRINT:-}" == "${_PULSE_CYCLE_PRIOR_BLOCKER_FINGERPRINT:-}" ]]; then
+				same_blocker=$((${_PULSE_CYCLE_PRIOR_SAME_BLOCKER_CYCLES:-0} + 1))
+			else
+				same_blocker=1
+			fi
+			_PULSE_CYCLE_SAME_BLOCKER_CYCLES="$same_blocker"
+		else
+			_PULSE_CYCLE_BLOCKER_KIND="none"
+			_PULSE_CYCLE_BLOCKER_FINGERPRINT=""
+			_PULSE_CYCLE_SAME_BLOCKER_CYCLES=0
+		fi
+	fi
+	_PULSE_CYCLE_PHASE="completed"
+	_PULSE_CYCLE_OUTCOME="$outcome"
+	_PULSE_CYCLE_HEARTBEAT_AT="$now"
+	_PULSE_CYCLE_STATE_TERMINAL=1
+	return 0
+}
+
+_pulse_cycle_state_json() {
+	if [[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" != "1" ]]; then
+		if [[ -f "${PULSE_HEALTH_FILE:-}" ]]; then
+			jq -ce --arg schema "$PULSE_CYCLE_STATE_SCHEMA" \
+				'.cycle_state | select(type == "object" and .schema == $schema)' \
+				"$PULSE_HEALTH_FILE" 2>/dev/null && return 0
+		fi
+		printf 'null\n'
+		return 0
+	fi
+	jq -cn \
+		--arg schema "$PULSE_CYCLE_STATE_SCHEMA" \
+		--arg cycle_id "$_PULSE_CYCLE_ID" \
+		--arg phase "$_PULSE_CYCLE_PHASE" \
+		--arg outcome "$_PULSE_CYCLE_OUTCOME" \
+		--arg heartbeat_at "$_PULSE_CYCLE_HEARTBEAT_AT" \
+		--arg progress_last_at "$_PULSE_CYCLE_PROGRESS_LAST_AT" \
+		--argjson progress_kinds "$_PULSE_CYCLE_PROGRESS_KINDS_JSON" \
+		--argjson no_progress_cycles "$_PULSE_CYCLE_NO_PROGRESS_CYCLES" \
+		--arg blocker_kind "$_PULSE_CYCLE_BLOCKER_KIND" \
+		--arg blocker_fingerprint "$_PULSE_CYCLE_BLOCKER_FINGERPRINT" \
+		--argjson same_blocker_cycles "$_PULSE_CYCLE_SAME_BLOCKER_CYCLES" '
+		{
+			schema: $schema,
+			cycle_id: $cycle_id,
+			phase: $phase,
+			outcome: $outcome,
+			heartbeat_at: $heartbeat_at,
+			progress: {
+				last_at: (if $progress_last_at == "" then null else $progress_last_at end),
+				kinds: $progress_kinds,
+				consecutive_no_progress_cycles: $no_progress_cycles
+			},
+			blocker: {
+				kind: $blocker_kind,
+				fingerprint: (if $blocker_fingerprint == "" then null else $blocker_fingerprint end),
+				consecutive_same_cycles: $same_blocker_cycles
+			}
+		}'
+	return $?
+}
+
+_pulse_cycle_state_publish() {
+	local phase="$1"
+	_pulse_cycle_state_transition "$phase" || return 1
+	write_pulse_health_file
+	return $?
+}
+
+_pulse_cycle_state_finish_if_needed() {
+	local outcome="${1:-interrupted}"
+	[[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" ]] || return 0
+	[[ "${_PULSE_CYCLE_STATE_TERMINAL:-0}" != "1" ]] || return 0
+	if [[ "$outcome" == "interrupted" && "${_PULSE_CYCLE_BLOCKER_KIND:-none}" == "none" ]]; then
+		_pulse_cycle_state_note_blocker interrupted pulse-wrapper exit || true
+	fi
+	_pulse_cycle_state_finalize "$outcome" "[]" || return 0
+	write_pulse_health_file || true
+	return 0
+}
 
 #######################################
 # _rotate_single_log — gzip-compress and truncate a single log file.
@@ -266,6 +556,9 @@ append_cycle_index() {
 write_pulse_health_file() {
 	local ts
 	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	local cycle_state_json="null"
+	cycle_state_json=$(_pulse_cycle_state_json) || cycle_state_json="null"
+	printf '%s' "$cycle_state_json" | jq empty >/dev/null 2>&1 || cycle_state_json="null"
 
 	# t3032: declare ledger helper once — used for both workers reconciliation
 	# and issues_dispatched. The ledger is written synchronously at dispatch
@@ -305,12 +598,19 @@ write_pulse_health_file() {
 		[[ "$_backoff_rows" =~ ^[0-9]+$ ]] && models_backed_off="$_backoff_rows"
 	fi
 
+	local health_dir="${PULSE_HEALTH_FILE%/*}"
+	[[ "$health_dir" != "$PULSE_HEALTH_FILE" ]] || health_dir="."
+	mkdir -p "$health_dir" 2>/dev/null || {
+		echo "[pulse-wrapper] write_pulse_health_file: cannot create health directory ${health_dir}" >>"$LOGFILE"
+		return 0
+	}
 	local tmp_health
 	# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
-	tmp_health=$(mktemp "${HOME}/.aidevops/logs/.pulse-health-XXXXXX") || {
+	tmp_health=$(mktemp "${health_dir}/.pulse-health-XXXXXX") || {
 		echo "[pulse-wrapper] write_pulse_health_file: mktemp failed — skipping health write" >>"$LOGFILE"
 		return 0
 	}
+	chmod 0600 "$tmp_health" 2>/dev/null || true
 
 	cat >"$tmp_health" <<EOF
 {
@@ -332,9 +632,15 @@ write_pulse_health_file() {
   "prefetch_conditional_refreshes": ${_PULSE_HEALTH_CONDITIONAL_REFRESHES:-0},
   "prefetch_conditional_misses": ${_PULSE_HEALTH_CONDITIONAL_MISSES:-0},
   "prefetch_throttled": ${_PULSE_HEALTH_PREFETCH_THROTTLED:-0},
-  "idle_cycle_skipped": ${_PULSE_HEALTH_IDLE_CYCLE_SKIPPED:-0}
+  "idle_cycle_skipped": ${_PULSE_HEALTH_IDLE_CYCLE_SKIPPED:-0},
+  "cycle_state": ${cycle_state_json}
 }
 EOF
+	if ! jq empty "$tmp_health" >/dev/null 2>&1; then
+		rm -f "$tmp_health"
+		echo "[pulse-wrapper] write_pulse_health_file: JSON validation failed — preserving prior health file" >>"$LOGFILE"
+		return 0
+	fi
 
 	mv "$tmp_health" "$PULSE_HEALTH_FILE" || {
 		rm -f "$tmp_health"

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -304,6 +304,47 @@ _pulse_cycle_state_publish() {
 	return $?
 }
 
+_pulse_cycle_state_health_is_current() {
+	local current_cycle_id=""
+	[[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" ]] || return 1
+	[[ -f "${PULSE_HEALTH_FILE:-}" ]] || return 1
+	current_cycle_id=$(jq -r --arg schema "$PULSE_CYCLE_STATE_SCHEMA" '
+		if (.cycle_state | type) == "object" and .cycle_state.schema == $schema
+		then .cycle_state.cycle_id // ""
+		else ""
+		end
+	' "$PULSE_HEALTH_FILE" 2>/dev/null) || current_cycle_id=""
+	[[ -n "$current_cycle_id" && "$current_cycle_id" == "${_PULSE_CYCLE_ID:-}" ]]
+}
+
+_pulse_cycle_state_write_terminal_if_current() {
+	local reacquired_lock=0
+	[[ "${_PULSE_CYCLE_STATE_TERMINAL:-0}" == "1" ]] || return 1
+	if [[ "${_LOCK_OWNED:-false}" == "true" ]]; then
+		write_pulse_health_file
+		return $?
+	fi
+	if declare -F acquire_instance_lock >/dev/null 2>&1 \
+		&& declare -F release_instance_lock >/dev/null 2>&1; then
+		if ! acquire_instance_lock; then
+			printf '[pulse-wrapper] Cycle state: skipped terminal publish for cycle %s because a newer cycle owns the instance lock\n' \
+				"${_PULSE_CYCLE_ID:-unknown}" >>"${WRAPPER_LOGFILE:-/dev/null}"
+			return 0
+		fi
+		reacquired_lock=1
+	fi
+	if _pulse_cycle_state_health_is_current; then
+		write_pulse_health_file || true
+	else
+		printf '[pulse-wrapper] Cycle state: skipped stale terminal publish for cycle %s because current health belongs to another cycle\n' \
+			"${_PULSE_CYCLE_ID:-unknown}" >>"${WRAPPER_LOGFILE:-/dev/null}"
+	fi
+	if [[ "$reacquired_lock" -eq 1 ]]; then
+		release_instance_lock
+	fi
+	return 0
+}
+
 _pulse_cycle_state_finish_if_needed() {
 	local outcome="${1:-interrupted}"
 	[[ "${_PULSE_CYCLE_STATE_INITIALIZED:-0}" == "1" ]] || return 0
@@ -312,7 +353,12 @@ _pulse_cycle_state_finish_if_needed() {
 		_pulse_cycle_state_note_blocker interrupted pulse-wrapper exit || true
 	fi
 	_pulse_cycle_state_finalize "$outcome" "[]" || return 0
-	write_pulse_health_file || true
+	_pulse_cycle_state_write_terminal_if_current || true
+	return 0
+}
+
+_pulse_cycle_state_finish_interrupted() {
+	_pulse_cycle_state_finish_if_needed interrupted
 	return 0
 }
 

--- a/.agents/scripts/pulse-merge-pass.sh
+++ b/.agents/scripts/pulse-merge-pass.sh
@@ -458,7 +458,11 @@ merge_ready_prs_all_repos() {
 	# direct updates to _PULSE_HEALTH_* variables are lost on return.
 	# The parent process reads this file after the stage completes.
 	local _health_delta_file="${TMPDIR:-/tmp}/pulse-health-merge-$$.tmp"
-	printf '%s %s\n' "$total_merged" "$total_closed" >"$_health_delta_file" || true
+	printf '%s %s %s %s\n' \
+		"$total_merged" "$total_closed" \
+		"${_PULSE_CYCLE_BLOCKER_KIND:-none}" \
+		"${_PULSE_CYCLE_BLOCKER_FINGERPRINT:--}" \
+		>"$_health_delta_file" || true
 	local _mr_pass_total_s=0
 	_pmp_add_elapsed_seconds _mr_pass_total_s "$_mr_pass_start"
 	echo "[pulse-wrapper] deterministic_merge_pass timing: total_s=${_mr_pass_total_s} merged=${total_merged} closed_conflicting=${total_closed} failed=${total_failed} eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -17,6 +17,13 @@ PMRC_SUBJECT_HEAD_PREFIX="head "
 PMRC_SUBJECT_PR_PREFIX="PR #"
 PMRC_BLOCKER_REVIEW_BOT_THREADS="review-bot-threads"
 PMRC_BLOCKER_REQUIRED_REVIEW_THREADS="required-review-threads"
+PMRC_BLOCKER_MERGE_AUTHORITY="merge-authority"
+PMRC_BLOCKER_REVIEW_GATE="review-gate"
+PMRC_BLOCKER_CHECKS_ACTIVE="checks-active"
+PMRC_BLOCKER_CHECKS_FAILED="checks-failed"
+PMRC_BLOCKER_QUIET_PERIOD="quiet-period"
+PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE="snapshot-unavailable"
+PMRC_BLOCKER_HEAD_CHANGED="head-changed"
 : "${_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON:=[]}"
 : "${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:=}"
 
@@ -493,6 +500,11 @@ _pmrc_snapshot_checks_acceptable() {
 		' <<<"$checks_json" 2>/dev/null) || _PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON="[]"
 	fi
 	if [[ "$pending" -gt 0 || "$blockers" -gt 0 ]]; then
+		if [[ "$blockers" -gt 0 ]]; then
+			_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_CHECKS_FAILED"
+		else
+			_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_CHECKS_ACTIVE"
+		fi
 		echo "[pulse-merge] pre-merge snapshot: PR #${pr_number} in ${repo_slug} not ready (active=${pending}, blocking_failures=${blockers}, advisory_failures=${advisory}) (GH#27137)" >>"$LOGFILE"
 		return 1
 	fi
@@ -581,38 +593,61 @@ _pulse_merge_preflight_snapshot_gate() {
 	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
 
 	pr_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || {
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "pull-request fetch"
 		return 1
 	}
 	if [[ -z "$pr_json" ]]; then
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "pull-request parse"
 		return 1
 	fi
 	pr_coordinates=$(jq -r '[(.head.sha // ""), (.base.ref // "")] | join("\u001f")' <<<"$pr_json") || {
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "pull-request parse"
 		return 1
 	}
 	IFS=$'\x1f' read -r current_head_sha base_branch <<<"$pr_coordinates"
 	if [[ -z "$current_head_sha" || "$current_head_sha" != "$expected_head_sha" ]]; then
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_HEAD_CHANGED"
 		echo "[pulse-merge] pre-merge snapshot: head changed for PR #${pr_number} in ${repo_slug} (expected=${expected_head_sha:-unknown}, current=${current_head_sha:-unknown}) — prior gate state revoked (GH#27137)" >>"$LOGFILE"
 		return 1
 	fi
 	required_contexts=$(_required_contexts_for_default_branch "$repo_slug") || {
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "required-context lookup"
 		return 1
 	}
-	checks_json=$(_pmrc_snapshot_checks_json "$repo_slug" "$current_head_sha") || return 1
-	activity_json=$(_pmrc_snapshot_bot_activity_json "$repo_slug" "$pr_number") || return 1
+	checks_json=$(_pmrc_snapshot_checks_json "$repo_slug" "$current_head_sha") || {
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+		return 1
+	}
+	activity_json=$(_pmrc_snapshot_bot_activity_json "$repo_slug" "$pr_number") || {
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+		return 1
+	}
 	_pmrc_review_evidence_permits_advisory "$live_gate_evidence" "$repo_slug" "$pr_number" "$current_head_sha" || live_gate_evidence=""
-	_pmrc_snapshot_review_gate_fresh "$repo_slug" "$pr_number" "$checks_json" "$activity_json" "$live_gate_evidence" || return 1
-	_pmrc_snapshot_review_threads_clear "$repo_slug" "$pr_number" "$base_branch" || return 1
+	if ! _pmrc_snapshot_review_gate_fresh "$repo_slug" "$pr_number" "$checks_json" "$activity_json" "$live_gate_evidence"; then
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REVIEW_GATE"
+		return 1
+	fi
+	if ! _pmrc_snapshot_review_threads_clear "$repo_slug" "$pr_number" "$base_branch"; then
+		[[ -n "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]] || \
+			_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+		return 1
+	fi
 	if ! _pmrc_snapshot_checks_acceptable \
 		"$repo_slug" "$pr_number" "$checks_json" "$required_contexts" \
 		"$live_gate_evidence" "$current_head_sha"; then
+		[[ -n "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]] || \
+			_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_CHECKS_FAILED"
 		_pmrc_record_preflight_check_mismatch
 		return 1
 	fi
-	_pmrc_snapshot_quiet_period_passes "$repo_slug" "$pr_number" "$checks_json" "$activity_json" || return 1
+	if ! _pmrc_snapshot_quiet_period_passes "$repo_slug" "$pr_number" "$checks_json" "$activity_json"; then
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_QUIET_PERIOD"
+		return 1
+	fi
 	echo "[pulse-merge] pre-merge snapshot: current head ${current_head_sha:0:12}, fresh review gate, merge-policy-compatible review threads, terminal checks, and quiet period verified for PR #${pr_number} in ${repo_slug} (GH#27137)" >>"$LOGFILE"
 	return 0
 }

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -149,6 +149,9 @@ _pulse_merge_maybe_dispatch_preflight_remediation() {
 	local blocker_kind="${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-}"
 	local reason=""
 
+	if [[ -n "$blocker_kind" ]] && declare -F _pulse_cycle_state_note_blocker >/dev/null 2>&1; then
+		_pulse_cycle_state_note_blocker "$blocker_kind" "$repo_slug" "$pr_number" || true
+	fi
 	# Consume the marker before any dispatch attempt so a failed or deduplicated
 	# repair cannot leak into an unrelated later final-gate failure.
 	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
@@ -548,8 +551,14 @@ _pulse_merge_final_trust_gate() {
 	local expected_head_sha="$3"
 
 	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
-	_pulse_merge_admin_safety_check "$pr_number" "$repo_slug" "$expected_head_sha" || return 1
-	_pulse_merge_refresh_review_gate_evidence "$pr_number" "$repo_slug" "$expected_head_sha" || return 1
+	if ! _pulse_merge_admin_safety_check "$pr_number" "$repo_slug" "$expected_head_sha"; then
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_MERGE_AUTHORITY"
+		return 1
+	fi
+	if ! _pulse_merge_refresh_review_gate_evidence "$pr_number" "$repo_slug" "$expected_head_sha"; then
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REVIEW_GATE"
+		return 1
+	fi
 	_pulse_merge_preflight_snapshot_gate "$repo_slug" "$pr_number" "$expected_head_sha" || return 1
 	return 0
 }

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -35,6 +35,7 @@ fi
 _PULSE_EFFICIENCY_CYCLE_STARTED=0
 _PULSE_EFFICIENCY_CYCLE_START_MS=0
 _PULSE_EFFICIENCY_CYCLE_OUTCOME=idle
+_PULSE_LEGACY_CYCLE_OUTCOME_PENDING=0
 
 _pulse_efficiency_record() {
 	local name="$1"
@@ -366,9 +367,9 @@ _pulse_run_fix_the_fixer_detector_if_stale() {
 # ---------------------------------------------------------------------------
 # _pulse_record_cycle_outcome (t3027 / GH#21584 / GH#28361)
 #
-# Computes one typed terminal outcome from durable queue-changing evidence,
-# projects it to the legacy active/idle contract, and records the latter with
-# pulse-idle-backoff-helper.sh. Heartbeats never participate in this decision.
+# Computes one typed terminal outcome from durable queue-changing evidence and
+# stages its legacy active/idle projection. The projection is committed only
+# while this cycle still owns current state. Heartbeats never participate.
 #
 # Active definition (any one suffices):
 #   - merged ≥ 1 PR (_PULSE_HEALTH_PRS_MERGED)
@@ -384,7 +385,6 @@ _pulse_run_fix_the_fixer_detector_if_stale() {
 _pulse_record_cycle_outcome() {
 	local _dispatch_before="${1:-0}"
 	[[ "$_dispatch_before" =~ ^[0-9]+$ ]] || _dispatch_before=0
-	local _ib_helper="${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
 	local _dispatch_after=0
 	local _dispatch_delta=0
 	local _merged="${_PULSE_HEALTH_PRS_MERGED:-0}"
@@ -416,13 +416,22 @@ _pulse_record_cycle_outcome() {
 	fi
 	_PULSE_TYPED_CYCLE_OUTCOME="$_typed_outcome"
 	_PULSE_EFFICIENCY_CYCLE_OUTCOME="$_legacy_outcome"
+	_PULSE_LEGACY_CYCLE_OUTCOME_PENDING=1
 	if declare -F _pulse_cycle_state_finalize >/dev/null 2>&1; then
 		_pulse_cycle_state_finalize "$_typed_outcome" "$_progress_kinds" || true
 	fi
+	echo "[pulse-wrapper] Cycle outcome: typed=${_typed_outcome} legacy=${_legacy_outcome} (merged=${_merged} closed=${_closed} dispatch_registrations=${_dispatch_before}→${_dispatch_after}) (GH#28361)" >>"${LOGFILE:-/dev/null}"
+	return 0
+}
+
+_pulse_commit_legacy_cycle_outcome() {
+	local _ib_helper="${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
+	local _legacy_outcome="${_PULSE_EFFICIENCY_CYCLE_OUTCOME:-idle}"
+	[[ "${_PULSE_LEGACY_CYCLE_OUTCOME_PENDING:-0}" == "1" ]] || return 0
+	_PULSE_LEGACY_CYCLE_OUTCOME_PENDING=0
 	if [[ -x "$_ib_helper" ]]; then
 		"$_ib_helper" record-cycle "$_legacy_outcome" >/dev/null 2>&1 || true
 	fi
-	echo "[pulse-wrapper] Cycle outcome: typed=${_typed_outcome} legacy=${_legacy_outcome} (merged=${_merged} closed=${_closed} dispatch_registrations=${_dispatch_before}→${_dispatch_after}) (GH#28361)" >>"${LOGFILE:-/dev/null}"
 	return 0
 }
 
@@ -442,25 +451,5 @@ _pulse_capture_dispatch_total() {
 	fi
 	[[ "$_total" =~ ^[0-9]+$ ]] || _total=0
 	printf '%s\n' "$_total"
-	return 0
-}
-
-# ---------------------------------------------------------------------------
-# _pulse_capture_ledger_count (t3027 / GH#21584)
-#
-# Returns current dispatch ledger count via stdout. Caller captures with $().
-# Used by main() to snapshot ledger state at cycle start for outcome detection.
-# ---------------------------------------------------------------------------
-_pulse_capture_ledger_count() {
-	local _ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
-	if [[ -x "$_ledger_helper" ]]; then
-		local _lc
-		_lc=$("$_ledger_helper" count 2>/dev/null || echo "0")
-		if [[ "$_lc" =~ ^[0-9]+$ ]]; then
-			printf '%d\n' "$_lc"
-			return 0
-		fi
-	fi
-	printf '0\n'
 	return 0
 }

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -364,46 +364,84 @@ _pulse_run_fix_the_fixer_detector_if_stale() {
 }
 
 # ---------------------------------------------------------------------------
-# _pulse_record_cycle_outcome (t3027 / GH#21584)
+# _pulse_record_cycle_outcome (t3027 / GH#21584 / GH#28361)
 #
-# Determines whether this cycle was active (did meaningful work) or idle
-# (no merges, no closes, no new dispatches) and records the outcome with
-# pulse-idle-backoff-helper.sh. The helper accumulates consecutive_idle,
-# which the next cycle's _pulse_check_idle_backoff_gate consults.
+# Computes one typed terminal outcome from durable queue-changing evidence,
+# projects it to the legacy active/idle contract, and records the latter with
+# pulse-idle-backoff-helper.sh. Heartbeats never participate in this decision.
 #
 # Active definition (any one suffices):
 #   - merged ≥ 1 PR (_PULSE_HEALTH_PRS_MERGED)
 #   - closed ≥ 1 conflicting PR (_PULSE_HEALTH_PRS_CLOSED_CONFLICTING)
-#   - dispatched ≥ 1 new worker (ledger_after > ledger_before)
+#   - dispatched ≥ 1 new worker (cumulative registrations increased)
 #
 # Workers completing without new dispatches counts as IDLE — bookkeeping
 # alone is not "useful work".
 #
 # Arguments:
-#   $1 — ledger_count_before (captured at cycle start)
+#   $1 — cumulative dispatch registrations before (captured at cycle start)
 # ---------------------------------------------------------------------------
 _pulse_record_cycle_outcome() {
-	local _ledger_before="${1:-0}"
-	[[ "$_ledger_before" =~ ^[0-9]+$ ]] || _ledger_before=0
+	local _dispatch_before="${1:-0}"
+	[[ "$_dispatch_before" =~ ^[0-9]+$ ]] || _dispatch_before=0
 	local _ib_helper="${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
-	local _ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
-	local _ledger_after=0
-	if [[ -x "$_ledger_helper" ]]; then
-		local _lc
-		_lc=$("$_ledger_helper" count 2>/dev/null || echo "0")
-		[[ "$_lc" =~ ^[0-9]+$ ]] && _ledger_after="$_lc"
+	local _dispatch_after=0
+	local _dispatch_delta=0
+	local _merged="${_PULSE_HEALTH_PRS_MERGED:-0}"
+	local _closed="${_PULSE_HEALTH_PRS_CLOSED_CONFLICTING:-0}"
+	local _progress_kinds="[]"
+	local _typed_outcome="idle"
+	local _legacy_outcome="idle"
+	[[ "$_merged" =~ ^[0-9]+$ ]] || _merged=0
+	[[ "$_closed" =~ ^[0-9]+$ ]] || _closed=0
+	_dispatch_after=$(_pulse_capture_dispatch_total)
+	[[ "$_dispatch_after" =~ ^[0-9]+$ ]] || _dispatch_after=0
+	if [[ "$_dispatch_after" -gt "$_dispatch_before" ]]; then
+		_dispatch_delta=$((_dispatch_after - _dispatch_before))
 	fi
-	local _outcome="idle"
-	if [[ "${_PULSE_HEALTH_PRS_MERGED:-0}" -gt 0 ]] \
-		|| [[ "${_PULSE_HEALTH_PRS_CLOSED_CONFLICTING:-0}" -gt 0 ]] \
-		|| [[ "$_ledger_after" -gt "$_ledger_before" ]]; then
-		_outcome="active"
+	_progress_kinds=$(jq -cn \
+		--argjson merged "$_merged" \
+		--argjson closed "$_closed" \
+		--argjson dispatched "$_dispatch_delta" '
+		[
+			if $merged > 0 then "pr-merged" else empty end,
+			if $closed > 0 then "pr-closed-conflicting" else empty end,
+			if $dispatched > 0 then "worker-dispatched" else empty end
+		]') || _progress_kinds="[]"
+	if [[ "$(printf '%s' "$_progress_kinds" | jq 'length' 2>/dev/null || printf '0')" -gt 0 ]]; then
+		_typed_outcome="progressed"
+		_legacy_outcome="active"
+	elif [[ "${_PULSE_CYCLE_BLOCKER_KIND:-none}" != "none" ]]; then
+		_typed_outcome="blocked"
 	fi
-	_PULSE_EFFICIENCY_CYCLE_OUTCOME="$_outcome"
+	_PULSE_TYPED_CYCLE_OUTCOME="$_typed_outcome"
+	_PULSE_EFFICIENCY_CYCLE_OUTCOME="$_legacy_outcome"
+	if declare -F _pulse_cycle_state_finalize >/dev/null 2>&1; then
+		_pulse_cycle_state_finalize "$_typed_outcome" "$_progress_kinds" || true
+	fi
 	if [[ -x "$_ib_helper" ]]; then
-		"$_ib_helper" record-cycle "$_outcome" >/dev/null 2>&1 || true
+		"$_ib_helper" record-cycle "$_legacy_outcome" >/dev/null 2>&1 || true
 	fi
-	echo "[pulse-wrapper] Cycle outcome: ${_outcome} (merged=${_PULSE_HEALTH_PRS_MERGED:-0} closed=${_PULSE_HEALTH_PRS_CLOSED_CONFLICTING:-0} ledger=${_ledger_before}→${_ledger_after}) (t3027)" >>"${LOGFILE:-/dev/null}"
+	echo "[pulse-wrapper] Cycle outcome: typed=${_typed_outcome} legacy=${_legacy_outcome} (merged=${_merged} closed=${_closed} dispatch_registrations=${_dispatch_before}→${_dispatch_after}) (GH#28361)" >>"${LOGFILE:-/dev/null}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _pulse_capture_dispatch_total (GH#28361)
+#
+# Returns the cumulative number of successful worker registrations. Unlike the
+# live ledger count, this monotonic projection still detects a new dispatch
+# when another worker completes during the same cycle.
+# ---------------------------------------------------------------------------
+_pulse_capture_dispatch_total() {
+	local _ledger_file="${AIDEVOPS_DISPATCH_LEDGER_FILE:-${AIDEVOPS_DISPATCH_LEDGER_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}/dispatch-ledger.jsonl}"
+	local _total=0
+	if [[ -s "$_ledger_file" ]]; then
+		_total=$(jq -Rsc '[split("\n")[] | fromjson? | select(.lease_phase == "prelaunch" and (.dispatched_at // "") != "")] | length' \
+			"$_ledger_file" 2>/dev/null) || _total=0
+	fi
+	[[ "$_total" =~ ^[0-9]+$ ]] || _total=0
+	printf '%s\n' "$_total"
 	return 0
 }
 

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -258,6 +258,25 @@ gathered by pulse-wrapper.sh BEFORE this session started."
 # run_pulse() with the appropriate trigger_mode. Records the run epoch and
 # kicks off the early-exit recycle loop on completion.
 # ---------------------------------------------------------------------------
+_PULSE_LLM_LOCKDIR_OWNED="${_PULSE_LLM_LOCKDIR_OWNED:-}"
+
+_pulse_release_llm_lock() {
+	local llm_lockdir="${_PULSE_LLM_LOCKDIR_OWNED:-}"
+	local lock_pid=""
+	[[ -n "$llm_lockdir" ]] || return 0
+	_PULSE_LLM_LOCKDIR_OWNED=""
+	if [[ -f "${llm_lockdir}/pid" ]]; then
+		read -r lock_pid <"${llm_lockdir}/pid" || lock_pid=""
+	fi
+	if [[ "$lock_pid" != "$$" ]]; then
+		printf '[pulse-wrapper] LLM lock cleanup skipped: owner changed from PID %s to %s\n' \
+			"$$" "${lock_pid:-unknown}" >>"${WRAPPER_LOGFILE:-/dev/null}"
+		return 0
+	fi
+	rm -rf "$llm_lockdir" 2>/dev/null || true
+	return 0
+}
+
 _pulse_record_llm_attempt() {
 	local trigger_mode="$1"
 	local attempt_epoch
@@ -312,13 +331,17 @@ _pulse_maybe_run_llm_supervisor() {
 			_llm_lock_acquired=1
 		fi
 	fi
+	if [[ "$_llm_lock_acquired" -eq 1 ]]; then
+		_PULSE_LLM_LOCKDIR_OWNED="$llm_lockdir"
+		printf '%s\n' "$$" >"${llm_lockdir}/pid" 2>/dev/null || true
+	fi
 
 	if [[ "$skip_llm" == "true" ]]; then
 		if [[ "$_llm_lock_acquired" -eq 1 ]]; then
 			# GH#26550: skip cycles only perform cleanup. _handle_stale_llm_lock
 			# re-acquires after clearing, so release the reclaimed LLM lock instead
 			# of leaving a self-created lock behind until the next eligible cycle.
-			rm -rf "$llm_lockdir" 2>/dev/null || true
+			_pulse_release_llm_lock
 		fi
 		return 0
 	fi
@@ -335,9 +358,8 @@ _pulse_maybe_run_llm_supervisor() {
 	fi
 
 	if [[ "$_llm_lock_acquired" -eq 1 ]]; then
-		echo "$$" >"${llm_lockdir}/pid" 2>/dev/null || true
-		# shellcheck disable=SC2064
-		trap "rm -rf '$llm_lockdir' 2>/dev/null; release_instance_lock" EXIT
+		_PULSE_LLM_LOCKDIR_OWNED="$llm_lockdir"
+		printf '%s\n' "$$" >"${llm_lockdir}/pid" 2>/dev/null || true
 
 		local underfill_output
 		underfill_output=$(_compute_initial_underfill)
@@ -360,7 +382,7 @@ _pulse_maybe_run_llm_supervisor() {
 		else
 			_pulse_record_llm_failure "$llm_trigger_mode" "$pulse_rc"
 		fi
-		rm -rf "$llm_lockdir" 2>/dev/null || true
+		_pulse_release_llm_lock
 	fi
 	return 0
 }

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1198,29 +1198,20 @@ source "${SCRIPT_DIR}/pulse-wrapper-cycle-gates.sh"
 # _pulse_run_deterministic_pipeline
 #
 # Deterministic cycle stages: merge pass, dependency graph, blocked-status
-# refresh, fill floor, routine evaluation, health snapshot, cycle index, and
-# instance lock release. Extracted from main() (GH#18689) to reduce function
-# length below the 100-line threshold.
-#
-# Arguments:
-#   $1 — cycle_start_epoch (seconds since epoch, captured in main())
-#   $2 — ledger_count_before (snapshot at cycle start, used by t3027 outcome
-#        detection — defaults to 0 if not supplied for back-compat)
+# refresh, fill floor, routine evaluation, and instance lock release. Extracted
+# from main() (GH#18689) to reduce function length below the 100-line threshold.
 #
 # Side effects:
 #   - merges ready PRs across all repos
-#   - writes health snapshot and cycle index JSONL record
 #   - releases the instance lock so the LLM session runs lock-free
-#   - records cycle outcome to pulse-idle-backoff-helper.sh (t3027)
 #
 # Exit code: always 0
 # ---------------------------------------------------------------------------
 _pulse_run_deterministic_pipeline() {
-	local cycle_start_epoch="$1"
-	local _ledger_before="${2:-0}"
-	[[ "$_ledger_before" =~ ^[0-9]+$ ]] || _ledger_before=0
-
 	_pulse_drain_prefetch_counters # t3027: bridge subshell counters
+	if [[ -f "$STOP_FLAG" ]]; then
+		_pulse_cycle_state_note_blocker stop-requested pulse-wrapper stop-flag || true
+	fi
 
 	# GH#21604 (t3035): Orphan worker reaper — runs at the start of every cycle
 	# to detect workers that survived a pulse restart (no ledger entry) and
@@ -1292,12 +1283,15 @@ _pulse_run_deterministic_pipeline() {
 	# updates are lost. Read the temp file it writes and accumulate here.
 	local _merge_health_file="${TMPDIR:-/tmp}/pulse-health-merge-$$.tmp"
 	if [[ -f "$_merge_health_file" ]]; then
-		local _mhf_merged=0 _mhf_closed=0
-		read -r _mhf_merged _mhf_closed <"$_merge_health_file" || true
+		local _mhf_merged=0 _mhf_closed=0 _mhf_blocker_kind="none" _mhf_blocker_fingerprint="-"
+		read -r _mhf_merged _mhf_closed _mhf_blocker_kind _mhf_blocker_fingerprint <"$_merge_health_file" || true
 		[[ "$_mhf_merged" =~ ^[0-9]+$ ]] || _mhf_merged=0
 		[[ "$_mhf_closed" =~ ^[0-9]+$ ]] || _mhf_closed=0
 		_PULSE_HEALTH_PRS_MERGED=$((_PULSE_HEALTH_PRS_MERGED + _mhf_merged))
 		_PULSE_HEALTH_PRS_CLOSED_CONFLICTING=$((_PULSE_HEALTH_PRS_CLOSED_CONFLICTING + _mhf_closed))
+		if [[ "$_mhf_blocker_kind" != "none" && "$_mhf_blocker_fingerprint" != "-" ]]; then
+			_pulse_cycle_state_set_blocker "$_mhf_blocker_kind" "$_mhf_blocker_fingerprint" || true
+		fi
 		rm -f "$_merge_health_file" || true
 	fi
 
@@ -1359,8 +1353,10 @@ _pulse_run_deterministic_pipeline() {
 		fi
 		if [[ "$_nw_rc" -eq 1 ]]; then
 			echo "[pulse-wrapper] Dispatch_max skipped: no_work rate circuit breaker tripped (t2770)" >>"$LOGFILE"
+			_pulse_cycle_state_note_blocker dispatch-no-work-rate pulse-wrapper no-work-rate || true
 		elif [[ "$_rh_rc" -eq 0 ]]; then
 			echo "[pulse-wrapper] Dispatch_max skipped: runner-health circuit breaker tripped (t2897)" >>"$LOGFILE"
+			_pulse_cycle_state_note_blocker runner-health pulse-wrapper runner-health || true
 			if declare -F pulse_stats_increment >/dev/null 2>&1; then
 				pulse_stats_increment "pulse_dispatch_runner_health_breaker_tripped" 2>/dev/null || true
 				pulse_stats_increment "dispatch_candidate_failed" 2>/dev/null || true
@@ -1421,17 +1417,6 @@ _pulse_run_deterministic_pipeline() {
 		run_stage_with_timeout "dashboard_freshness_check" "$PRE_RUN_STAGE_TIMEOUT" \
 			bash "$_dfc_script" scan || true
 	fi
-
-	# Write structured health snapshot for instant diagnosis (GH#15107)
-	write_pulse_health_file || true
-
-	# Append one JSONL record to the cycle index (t1886)
-	local _cycle_end_epoch
-	_cycle_end_epoch=$(date +%s)
-	local _cycle_duration=$((_cycle_end_epoch - cycle_start_epoch))
-	append_cycle_index "$_cycle_duration" || true
-
-	_pulse_record_cycle_outcome "$_ledger_before" # t3027: drives next-cycle backoff
 
 	# Release the instance lock BEFORE the LLM session so the next 2-min
 	# cycle can run deterministic ops (merge pass + fill floor) concurrently.
@@ -1651,7 +1636,7 @@ main() {
 	# Register EXIT trap BEFORE acquiring the lock so the lock is always
 	# released on exit — including set -e aborts, SIGTERM, and return paths.
 	# SIGKILL cannot be trapped; stale-lock detection handles that case.
-	trap '_pulse_efficiency_cycle_finish; release_instance_lock; aidevops_runtime_bundle_lease_release' EXIT
+	trap '_pulse_cycle_state_finish_if_needed interrupted; _pulse_efficiency_cycle_finish; release_instance_lock; aidevops_runtime_bundle_lease_release' EXIT
 
 	if ! acquire_instance_lock; then
 		return 0
@@ -1695,6 +1680,7 @@ main() {
 		push_cleanup 'aidevops_runtime_bundle_lease_release'
 		push_cleanup 'release_instance_lock'
 		push_cleanup '_pulse_efficiency_cycle_finish'
+		push_cleanup '_pulse_cycle_state_finish_if_needed interrupted'
 		# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
 		# register release_instance_lock before replacing the direct EXIT trap.
 		trap '_run_cleanups' EXIT
@@ -1715,6 +1701,7 @@ main() {
 			push_cleanup 'aidevops_runtime_bundle_lease_release'
 			push_cleanup 'release_instance_lock'
 			push_cleanup '_pulse_efficiency_cycle_finish'
+			push_cleanup '_pulse_cycle_state_finish_if_needed interrupted'
 			# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
 			# register release_instance_lock before replacing the direct EXIT trap.
 			trap '_run_cleanups' EXIT
@@ -1747,6 +1734,10 @@ main() {
 		printf 'canary: ok (sourcing + _pulse_handle_self_check + acquire_instance_lock passed)\n'
 		return 0
 	fi
+	if [[ "${PULSE_DRY_RUN:-0}" != "1" ]]; then
+		_pulse_cycle_state_start
+		write_pulse_health_file || true
+	fi
 
 	# GH#22631: `circuit-breaker-helper.sh status` can report an overdue
 	# supervisor breaker until `check` is invoked. Refresh once per real pulse
@@ -1754,10 +1745,14 @@ main() {
 	_pulse_refresh_supervisor_circuit_breaker || true
 
 	if ! check_session_gate; then
+		_pulse_cycle_state_note_blocker session-gate pulse-wrapper session-gate || true
+		_pulse_cycle_state_finish_if_needed blocked
 		return 0
 	fi
 
 	if ! check_dedup; then
+		_pulse_cycle_state_note_blocker dedup pulse-wrapper dedup || true
+		_pulse_cycle_state_finish_if_needed blocked
 		return 0
 	fi
 
@@ -1847,6 +1842,9 @@ main() {
 	# unexpected set -e exits publish a conservative partial cycle rather than
 	# silently dropping the observation window.
 	_pulse_efficiency_cycle_start
+	local _cycle_dispatch_before
+	_cycle_dispatch_before=$(_pulse_capture_dispatch_total)
+	_pulse_cycle_state_publish preflight || true
 
 	# t3068: drain any pending approval-trigger records before the regular
 	# cycle. Backstop for the dedicated 60s --merge-only plist; if an
@@ -1857,6 +1855,9 @@ main() {
 
 	# Run pre-flight stages (cleanup, prefetch, normalization)
 	if ! _run_preflight_stages; then
+		_pulse_cycle_state_note_blocker preflight-failed pulse-wrapper preflight || true
+		_pulse_record_cycle_outcome "$_cycle_dispatch_before"
+		write_pulse_health_file || true
 		_pulse_efficiency_cycle_finish idle
 		return 0
 	fi
@@ -1865,30 +1866,34 @@ main() {
 	# been issued during the prefetch/cleanup phase above (t2943)
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared during setup — aborting before run_pulse()" >>"$LOGFILE"
+		_pulse_cycle_state_note_blocker stop-requested pulse-wrapper stop-flag || true
+		_pulse_record_cycle_outcome "$_cycle_dispatch_before"
+		write_pulse_health_file || true
 		_pulse_efficiency_cycle_finish idle
 		return 0
 	fi
 
-	# t3027: snapshot ledger for idle/active outcome detection.
-	local _cycle_ledger_before
-	_cycle_ledger_before=$(_pulse_capture_ledger_count)
-
-	# Run deterministic pipeline: merge pass, dep graph, blocked-status
-	# refresh, fill floor, routine evaluation, health snapshot, cycle index,
-	# and instance lock release. GH#18689: extracted to helper.
-	_pulse_run_deterministic_pipeline "$_cycle_start_epoch" "$_cycle_ledger_before"
+	# Run deterministic pipeline: merge pass, dep graph, blocked-status refresh,
+	# fill floor, routine evaluation, and instance lock release. GH#18689:
+	# extracted to helper.
+	_pulse_cycle_state_publish deterministic || true
+	_pulse_run_deterministic_pipeline
 
 	# Run LLM supervisor if stall/daily-sweep/force conditions are met.
 	# GH#18689: extracted to _pulse_maybe_run_llm_supervisor().
+	_pulse_cycle_state_publish supervising || true
 	_pulse_run_optional_stage "llm_supervisor" _pulse_maybe_run_llm_supervisor || true
 
-	# t3032: post-LLM health snapshot — captures workers dispatched by the
-	# LLM supervisor session, which runs after the deterministic pipeline's
-	# own health write (in _pulse_run_deterministic_pipeline). Without this
-	# second write, the health file would reflect pre-LLM state (often 0
-	# workers) until the NEXT cycle, even when the LLM supervisor launched
-	# 9-25 workers. Non-fatal — failures are silently ignored.
+	# GH#28361: compute one terminal typed outcome after both deterministic and
+	# LLM dispatch paths, then project it through the existing health/index
+	# contracts. A cumulative registration count detects launches even when a
+	# different worker completes during the same cycle.
+	_pulse_record_cycle_outcome "$_cycle_dispatch_before"
 	write_pulse_health_file || true
+	local _cycle_end_epoch
+	_cycle_end_epoch=$(date +%s)
+	local _cycle_duration=$((_cycle_end_epoch - _cycle_start_epoch))
+	append_cycle_index "$_cycle_duration" || true
 
 	# t3033: self-respawn when source file was modified during this cycle.
 	#

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1198,12 +1198,11 @@ source "${SCRIPT_DIR}/pulse-wrapper-cycle-gates.sh"
 # _pulse_run_deterministic_pipeline
 #
 # Deterministic cycle stages: merge pass, dependency graph, blocked-status
-# refresh, fill floor, routine evaluation, and instance lock release. Extracted
+# refresh, fill floor, and routine evaluation. Extracted
 # from main() (GH#18689) to reduce function length below the 100-line threshold.
 #
 # Side effects:
 #   - merges ready PRs across all repos
-#   - releases the instance lock so the LLM session runs lock-free
 #
 # Exit code: always 0
 # ---------------------------------------------------------------------------
@@ -1418,12 +1417,6 @@ _pulse_run_deterministic_pipeline() {
 			bash "$_dfc_script" scan || true
 	fi
 
-	# Release the instance lock BEFORE the LLM session so the next 2-min
-	# cycle can run deterministic ops (merge pass + fill floor) concurrently.
-	# The LLM session is protected by its own stall/daily-sweep gating,
-	# and workers are protected by 7-layer dedup guards (assignee labels,
-	# DISPATCH_CLAIM comments, ledger checks). No risk of duplication.
-	release_instance_lock
 	return 0
 }
 
@@ -1636,7 +1629,7 @@ main() {
 	# Register EXIT trap BEFORE acquiring the lock so the lock is always
 	# released on exit — including set -e aborts, SIGTERM, and return paths.
 	# SIGKILL cannot be trapped; stale-lock detection handles that case.
-	trap '_pulse_cycle_state_finish_if_needed interrupted; _pulse_efficiency_cycle_finish; release_instance_lock; aidevops_runtime_bundle_lease_release' EXIT
+	trap '_pulse_release_llm_lock; _pulse_cycle_state_finish_interrupted; _pulse_efficiency_cycle_finish; release_instance_lock; aidevops_runtime_bundle_lease_release' EXIT
 
 	if ! acquire_instance_lock; then
 		return 0
@@ -1680,7 +1673,8 @@ main() {
 		push_cleanup 'aidevops_runtime_bundle_lease_release'
 		push_cleanup 'release_instance_lock'
 		push_cleanup '_pulse_efficiency_cycle_finish'
-		push_cleanup '_pulse_cycle_state_finish_if_needed interrupted'
+		push_cleanup '_pulse_cycle_state_finish_interrupted'
+		push_cleanup '_pulse_release_llm_lock'
 		# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
 		# register release_instance_lock before replacing the direct EXIT trap.
 		trap '_run_cleanups' EXIT
@@ -1701,7 +1695,8 @@ main() {
 			push_cleanup 'aidevops_runtime_bundle_lease_release'
 			push_cleanup 'release_instance_lock'
 			push_cleanup '_pulse_efficiency_cycle_finish'
-			push_cleanup '_pulse_cycle_state_finish_if_needed interrupted'
+			push_cleanup '_pulse_cycle_state_finish_interrupted'
+			push_cleanup '_pulse_release_llm_lock'
 			# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
 			# register release_instance_lock before replacing the direct EXIT trap.
 			trap '_run_cleanups' EXIT
@@ -1874,7 +1869,7 @@ main() {
 	fi
 
 	# Run deterministic pipeline: merge pass, dep graph, blocked-status refresh,
-	# fill floor, routine evaluation, and instance lock release. GH#18689:
+	# fill floor and routine evaluation. GH#18689:
 	# extracted to helper.
 	_pulse_cycle_state_publish deterministic || true
 	_pulse_run_deterministic_pipeline
@@ -1882,6 +1877,11 @@ main() {
 	# Run LLM supervisor if stall/daily-sweep/force conditions are met.
 	# GH#18689: extracted to _pulse_maybe_run_llm_supervisor().
 	_pulse_cycle_state_publish supervising || true
+	# Release the instance lock BEFORE the LLM session so the next 2-min cycle
+	# can run deterministic ops concurrently. Terminal publication briefly
+	# reacquires this lock and writes only when health still names this cycle,
+	# preventing a slow supervisor from overwriting a newer cycle (GH#28361).
+	release_instance_lock
 	_pulse_run_optional_stage "llm_supervisor" _pulse_maybe_run_llm_supervisor || true
 
 	# GH#28361: compute one terminal typed outcome after both deterministic and
@@ -1889,7 +1889,7 @@ main() {
 	# contracts. A cumulative registration count detects launches even when a
 	# different worker completes during the same cycle.
 	_pulse_record_cycle_outcome "$_cycle_dispatch_before"
-	write_pulse_health_file || true
+	_pulse_cycle_state_write_terminal_if_current || true
 	local _cycle_end_epoch
 	_cycle_end_epoch=$(date +%s)
 	local _cycle_duration=$((_cycle_end_epoch - _cycle_start_epoch))

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1852,7 +1852,7 @@ main() {
 	if ! _run_preflight_stages; then
 		_pulse_cycle_state_note_blocker preflight-failed pulse-wrapper preflight || true
 		_pulse_record_cycle_outcome "$_cycle_dispatch_before"
-		write_pulse_health_file || true
+		_pulse_cycle_state_write_terminal_if_current || true
 		_pulse_efficiency_cycle_finish idle
 		return 0
 	fi
@@ -1863,7 +1863,7 @@ main() {
 		echo "[pulse-wrapper] Stop flag appeared during setup — aborting before run_pulse()" >>"$LOGFILE"
 		_pulse_cycle_state_note_blocker stop-requested pulse-wrapper stop-flag || true
 		_pulse_record_cycle_outcome "$_cycle_dispatch_before"
-		write_pulse_health_file || true
+		_pulse_cycle_state_write_terminal_if_current || true
 		_pulse_efficiency_cycle_finish idle
 		return 0
 	fi
@@ -1877,6 +1877,10 @@ main() {
 	# Run LLM supervisor if stall/daily-sweep/force conditions are met.
 	# GH#18689: extracted to _pulse_maybe_run_llm_supervisor().
 	_pulse_cycle_state_publish supervising || true
+	local _cycle_index_epoch
+	_cycle_index_epoch=$(date +%s)
+	local _cycle_index_duration=$((_cycle_index_epoch - _cycle_start_epoch))
+	append_cycle_index "$_cycle_index_duration" || true
 	# Release the instance lock BEFORE the LLM session so the next 2-min cycle
 	# can run deterministic ops concurrently. Terminal publication briefly
 	# reacquires this lock and writes only when health still names this cycle,
@@ -1885,15 +1889,11 @@ main() {
 	_pulse_run_optional_stage "llm_supervisor" _pulse_maybe_run_llm_supervisor || true
 
 	# GH#28361: compute one terminal typed outcome after both deterministic and
-	# LLM dispatch paths, then project it through the existing health/index
+	# LLM dispatch paths, then project it through health and idle-backoff
 	# contracts. A cumulative registration count detects launches even when a
 	# different worker completes during the same cycle.
 	_pulse_record_cycle_outcome "$_cycle_dispatch_before"
 	_pulse_cycle_state_write_terminal_if_current || true
-	local _cycle_end_epoch
-	_cycle_end_epoch=$(date +%s)
-	local _cycle_duration=$((_cycle_end_epoch - _cycle_start_epoch))
-	append_cycle_index "$_cycle_duration" || true
 
 	# t3033: self-respawn when source file was modified during this cycle.
 	#

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELPER="$SCRIPT_DIR/../pulse-current-state-helper.sh"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
+export HOME="$TMP_DIR/home"
+mkdir -p "$HOME"
 
 python3 - "$TMP_DIR" <<'PY'
 import json, os, sys, time
@@ -57,6 +59,23 @@ json.dump({
     'prefetch_conditional_304': 3,
     'prefetch_conditional_refreshes': 2,
     'prefetch_conditional_misses': 1,
+    'cycle_state': {
+        'schema': 'aidevops.pulse-cycle-state/v1',
+        'cycle_id': '20260101T000000Z-123',
+        'phase': 'completed',
+        'outcome': 'progressed',
+        'heartbeat_at': iso,
+        'progress': {
+            'last_at': iso,
+            'kinds': ['worker-dispatched'],
+            'consecutive_no_progress_cycles': 0,
+        },
+        'blocker': {
+            'kind': 'none',
+            'fingerprint': None,
+            'consecutive_same_cycles': 0,
+        },
+    },
 }, open(os.path.join(root, 'pulse-health.json'), 'w'))
 json.dump({
     'objectives': [
@@ -93,15 +112,22 @@ PY
 output="$TMP_DIR/out.txt"
 export AIDEVOPS_OBS_DB_OVERRIDE="$TMP_DIR/runtime-events.db"
 export AIDEVOPS_PULSE_RATE_LIMIT_CACHE="$TMP_DIR/rate-limit-cache.json"
+export AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL=300
+export AIDEVOPS_GH_REQUEST_STATE_AUTH_SCOPE="pulse-current-state-test"
+export AIDEVOPS_GH_API_POOL="default"
 export AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR="$TMP_DIR/review-thread-state"
 export AIDEVOPS_OBJECTIVE_STATE_FILE="$TMP_DIR/objective-reconciliation.json"
-python3 - "$AIDEVOPS_PULSE_RATE_LIMIT_CACHE" <<'PY'
-import json, sys, time
-json.dump({
-    'ts': int(time.time()),
-    'rate': {'resources': {'graphql': {'remaining': 4980, 'limit': 5000, 'reset': int(time.time()) + 3600}}},
-}, open(sys.argv[1], 'w'))
-PY
+# shellcheck source=../shared-gh-request-state.sh
+source "${SCRIPT_DIR}/../shared-gh-request-state.sh"
+rate_reset=$(($(date +%s) + 3600))
+rate_fixture=$(jq -cn --argjson reset "$rate_reset" \
+	'{resources:{graphql:{remaining:4980,limit:5000,reset:$reset}}}')
+gh_request_state_rate_put "$rate_fixture"
+cache_status=$("${SCRIPT_DIR}/../pulse-rate-limit-circuit-breaker.sh" status --cached)
+if [[ "$cache_status" != OK:* ]]; then
+	printf 'FAIL canonical rate-cache fixture is unreadable: %s\n' "$cache_status" >&2
+	exit 1
+fi
 "$HELPER" --log-dir "$TMP_DIR" --repo-path "$PWD" --window 15m >"$output"
 
 grep -q 'Dispatch alive: true' "$output"
@@ -109,9 +135,13 @@ grep -q 'Worker terminal events: 4' "$output"
 grep -q 'dispatch_backoff_skipped' "$output"
 grep -q 'GraphQL budget:' "$output"
 grep -q 'Top pre-launch blockers:' "$output"
-grep -q 'Dispatch API blocked by GraphQL: false' "$output"
+if ! grep -q 'Dispatch API blocked by GraphQL: false' "$output"; then
+	printf 'FAIL expected unblocked GraphQL dispatch state:\n%s\n' "$(<"$output")" >&2
+	exit 1
+fi
 grep -q 'API call pressure:' "$output"
 grep -q 'Prefetch cache:' "$output"
+grep -q 'Cycle state:' "$output"
 grep -q 'Review-thread maintainer attention:' "$output"
 grep -q 'needs_decision' "$output"
 grep -q 'worker_launch_total' "$output"
@@ -148,6 +178,9 @@ jq -e '.api_call_pressure.read_rest_ratio == 0.4706' "$json_output" >/dev/null
 jq -e '.prefetch_cache.conditional_304 == 3' "$json_output" >/dev/null
 jq -e '.prefetch_cache.conditional_refreshes == 2' "$json_output" >/dev/null
 jq -e '.prefetch_cache.conditional_misses == 1' "$json_output" >/dev/null
+jq -e '.cycle_state.availability == "available"' "$json_output" >/dev/null
+jq -e '.cycle_state.outcome == "progressed"' "$json_output" >/dev/null
+jq -e '.cycle_state.progress.kinds == ["worker-dispatched"]' "$json_output" >/dev/null
 jq -e '.review_thread_attention[0].blocked_by == "maintainer"' "$json_output" >/dev/null
 jq -e '.review_thread_attention[0].pr_number == 12' "$json_output" >/dev/null
 jq -e '.review_thread_attention[0].reason == "needs_decision"' "$json_output" >/dev/null
@@ -175,9 +208,28 @@ assert 'def build_pre_launch_blockers' in implementation_source
 assert 'def build_graphql_budget' in implementation_source
 assert 'def build_current_state_guardrails' in implementation_source
 assert 'def build_objective_reconciliation' in implementation_source
+assert 'def build_cycle_state' in implementation_source
 assert "graphql_budget_status = (" not in implementation_source
 assert 'import subprocess' not in implementation_source
 assert 'subprocess.check_output' not in implementation_source
 PY
+
+missing_dir="$TMP_DIR/missing-cycle-state"
+mkdir -p "$missing_dir"
+missing_json="$TMP_DIR/missing-cycle-state.json"
+"$HELPER" --log-dir "$missing_dir" --repo-path "$PWD" --window 15m --json >"$missing_json"
+jq -e '.cycle_state.availability == "unavailable"' "$missing_json" >/dev/null
+
+printf '{malformed\n' >"$missing_dir/pulse-health.json"
+malformed_health_json="$TMP_DIR/malformed-health-state.json"
+"$HELPER" --log-dir "$missing_dir" --repo-path "$PWD" --window 15m --json >"$malformed_health_json"
+jq -e '.cycle_state.availability == "malformed" and .cycle_state.reason == "health-json"' \
+	"$malformed_health_json" >/dev/null
+
+printf '{"cycle_state":{"schema":"wrong"}}\n' >"$missing_dir/pulse-health.json"
+malformed_cycle_json="$TMP_DIR/malformed-cycle-state.json"
+"$HELPER" --log-dir "$missing_dir" --repo-path "$PWD" --window 15m --json >"$malformed_cycle_json"
+jq -e '.cycle_state.availability == "malformed" and .cycle_state.reason == "cycle-state-contract"' \
+	"$malformed_cycle_json" >/dev/null
 
 printf 'PASS pulse-current-state-helper\n'

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -232,4 +232,14 @@ malformed_cycle_json="$TMP_DIR/malformed-cycle-state.json"
 jq -e '.cycle_state.availability == "malformed" and .cycle_state.reason == "cycle-state-contract"' \
 	"$malformed_cycle_json" >/dev/null
 
+jq '.cycle_state.blocker = {
+	kind: "review-gate",
+	fingerprint: "cksum:123",
+	consecutive_same_cycles: 1
+}' "$TMP_DIR/pulse-health.json" >"$missing_dir/pulse-health.json"
+inconsistent_cycle_json="$TMP_DIR/inconsistent-cycle-state.json"
+"$HELPER" --log-dir "$missing_dir" --repo-path "$PWD" --window 15m --json >"$inconsistent_cycle_json"
+jq -e '.cycle_state.availability == "malformed" and .cycle_state.reason == "cycle-state-contract"' \
+	"$inconsistent_cycle_json" >/dev/null
+
 printf 'PASS pulse-current-state-helper\n'

--- a/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
+++ b/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
@@ -79,6 +79,16 @@ source "${SOURCE_DIR}/pulse-logging.sh"
 # shellcheck source=../pulse-wrapper-cycle-gates.sh
 source "${SOURCE_DIR}/pulse-wrapper-cycle-gates.sh"
 
+_LOCK_OWNED=false
+acquire_instance_lock() {
+	_LOCK_OWNED=true
+	return 0
+}
+release_instance_lock() {
+	_LOCK_OWNED=false
+	return 0
+}
+
 _pulse_cycle_state_start
 write_pulse_health_file
 assert_health "real health writer emits additive running lifecycle state" '
@@ -209,6 +219,20 @@ if [[ ! -e "${HOME}/.aidevops/logs/pulse-cycle-state.json" ]]; then
 	pass "lifecycle state does not create a parallel runtime artifact"
 else
 	fail "lifecycle state does not create a parallel runtime artifact"
+fi
+
+_pulse_cycle_state_start
+write_pulse_health_file
+_pulse_cycle_state_finalize idle '[]'
+_PULSE_LEGACY_CYCLE_OUTCOME_PENDING=1
+cp "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-missing-lock-terminal.json"
+unset -f acquire_instance_lock release_instance_lock
+_pulse_cycle_state_write_terminal_if_current
+if cmp -s "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-missing-lock-terminal.json" \
+	&& [[ "$_PULSE_LEGACY_CYCLE_OUTCOME_PENDING" -eq 1 ]]; then
+	pass "terminal publication fails closed when lock functions are unavailable"
+else
+	fail "terminal publication fails closed when lock functions are unavailable"
 fi
 
 _pulse_cycle_state_start

--- a/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
+++ b/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
@@ -118,12 +118,18 @@ assert_health "actual dispatch registration produces typed progress" '
 	and .cycle_state.progress.consecutive_no_progress_cycles == 0
 	and .cycle_state.blocker.kind == "none"
 '
+if [[ "${_PULSE_LEGACY_CYCLE_OUTCOME_PENDING:-1}" -eq 0 ]]; then
+	pass "current terminal publication commits the legacy outcome once"
+else
+	fail "current terminal publication commits the legacy outcome once"
+fi
 last_progress_at=$(jq -r '.cycle_state.progress.last_at' "$PULSE_HEALTH_FILE")
 
 _pulse_cycle_state_start
+write_pulse_health_file
 _pulse_cycle_state_note_blocker review-gate owner/repo 7
 _pulse_record_cycle_outcome 1
-write_pulse_health_file
+_pulse_cycle_state_write_terminal_if_current
 assert_health "first typed blocker starts both no-progress streaks" '
 	.cycle_state.outcome == "blocked"
 	and .cycle_state.progress.consecutive_no_progress_cycles == 1
@@ -138,9 +144,10 @@ else
 fi
 
 _pulse_cycle_state_start
+write_pulse_health_file
 _pulse_cycle_state_note_blocker review-gate owner/repo 7
 _pulse_record_cycle_outcome 1
-write_pulse_health_file
+_pulse_cycle_state_write_terminal_if_current
 assert_health "repeated blocker increments stable streak without moving progress" "
 	.cycle_state.progress.last_at == \"${last_progress_at}\"
 	and .cycle_state.progress.consecutive_no_progress_cycles == 2
@@ -148,9 +155,10 @@ assert_health "repeated blocker increments stable streak without moving progress
 "
 
 _pulse_cycle_state_start
+write_pulse_health_file
 _pulse_cycle_state_note_blocker head-changed owner/repo 7
 _pulse_record_cycle_outcome 1
-write_pulse_health_file
+_pulse_cycle_state_write_terminal_if_current
 assert_health "changed blocker restarts only blocker streak" '
 	.cycle_state.progress.consecutive_no_progress_cycles == 3
 	and .cycle_state.blocker.kind == "head-changed"
@@ -158,9 +166,10 @@ assert_health "changed blocker restarts only blocker streak" '
 '
 
 _pulse_cycle_state_start
+write_pulse_health_file
 _PULSE_HEALTH_PRS_MERGED=1
 _pulse_record_cycle_outcome 1
-write_pulse_health_file
+_pulse_cycle_state_write_terminal_if_current
 assert_health "meaningful progress resets blocker and no-progress streaks" '
 	.cycle_state.outcome == "progressed"
 	and .cycle_state.progress.kinds == ["pr-merged"]
@@ -205,6 +214,7 @@ fi
 _pulse_cycle_state_start
 write_pulse_health_file
 _pulse_cycle_state_finalize idle '[]'
+_PULSE_LEGACY_CYCLE_OUTCOME_PENDING=1
 LOCK_ACQUIRE_CALLS=0
 LOCK_RELEASE_CALLS=0
 _LOCK_OWNED=false
@@ -224,7 +234,8 @@ cp "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-stale-terminal.json"
 _pulse_cycle_state_write_terminal_if_current
 if cmp -s "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-stale-terminal.json" \
 	&& [[ "$LOCK_ACQUIRE_CALLS" -eq 1 && "$LOCK_RELEASE_CALLS" -eq 1 \
-		&& "$_LOCK_OWNED" == "false" ]]; then
+		&& "$_LOCK_OWNED" == "false" \
+		&& "$_PULSE_LEGACY_CYCLE_OUTCOME_PENDING" -eq 1 ]]; then
 	pass "older terminal publication cannot overwrite newer cycle health"
 else
 	fail "older terminal publication cannot overwrite newer cycle health"

--- a/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
+++ b/.agents/scripts/tests/test-pulse-cycle-state-contract.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+TMP_DIR="$(mktemp -d -t pulse-cycle-state.XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s %s\n' "$name" "$detail"
+	return 0
+}
+
+assert_health() {
+	local name="$1"
+	local filter="$2"
+	if jq -e "$filter" "$PULSE_HEALTH_FILE" >/dev/null; then
+		pass "$name"
+	else
+		fail "$name" "health=$(jq -c . "$PULSE_HEALTH_FILE" 2>/dev/null || printf malformed)"
+	fi
+	return 0
+}
+
+export HOME="${TMP_DIR}/home"
+export SCRIPT_DIR="$SOURCE_DIR"
+export AIDEVOPS_DISPATCH_LEDGER_FILE="${TMP_DIR}/dispatch-ledger.jsonl"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/tmp"
+
+PULSE_HEALTH_FILE="${HOME}/.aidevops/logs/pulse-health.json"
+PULSE_CYCLE_INDEX_FILE="${HOME}/.aidevops/logs/pulse-cycle-index.jsonl"
+PULSE_CYCLE_INDEX_MAX_LINES=100
+LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+WRAPPER_LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
+HEADLESS_RUNTIME_HELPER="${TMP_DIR}/missing-headless-runtime-helper"
+_PULSE_HEALTH_PRS_MERGED=0
+_PULSE_HEALTH_PRS_CLOSED_CONFLICTING=0
+_PULSE_HEALTH_STALLED_KILLED=0
+_PULSE_HEALTH_PREFETCH_ERRORS=0
+_PULSE_HEALTH_IDLE_REPO_SKIPS=0
+_PULSE_HEALTH_BATCH_SEARCH_CALLS=0
+_PULSE_HEALTH_BATCH_CACHE_HITS=0
+_PULSE_HEALTH_EVENTS_TICKLE_FRESH=0
+_PULSE_HEALTH_EVENTS_TICKLE_STALE=0
+_PULSE_HEALTH_CONDITIONAL_304=0
+_PULSE_HEALTH_CONDITIONAL_REFRESHES=0
+_PULSE_HEALTH_CONDITIONAL_MISSES=0
+_PULSE_HEALTH_PREFETCH_THROTTLED=0
+_PULSE_HEALTH_IDLE_CYCLE_SKIPPED=0
+
+count_active_workers() {
+	printf '0\n'
+	return 0
+}
+
+get_max_workers_target() {
+	printf '4\n'
+	return 0
+}
+
+# shellcheck source=../pulse-logging.sh
+source "${SOURCE_DIR}/pulse-logging.sh"
+# shellcheck source=../pulse-wrapper-cycle-gates.sh
+source "${SOURCE_DIR}/pulse-wrapper-cycle-gates.sh"
+
+_pulse_cycle_state_start
+write_pulse_health_file
+assert_health "real health writer emits additive running lifecycle state" '
+	.timestamp != null
+	and .workers_active == 0
+	and .workers_max == 4
+	and .prs_merged_this_cycle == 0
+	and .cycle_state.schema == "aidevops.pulse-cycle-state/v1"
+	and .cycle_state.phase == "admitted"
+	and .cycle_state.outcome == "running"
+	and .cycle_state.progress.last_at == null
+	and .cycle_state.progress.consecutive_no_progress_cycles == 0
+	and .cycle_state.blocker.kind == "none"
+'
+
+initial_heartbeat=$(jq -r '.cycle_state.heartbeat_at' "$PULSE_HEALTH_FILE")
+initial_progress=$(jq -c '.cycle_state.progress' "$PULSE_HEALTH_FILE")
+sleep 1
+_pulse_cycle_state_publish preflight
+if [[ "$(jq -c '.cycle_state.progress' "$PULSE_HEALTH_FILE")" == "$initial_progress" \
+	&& "$(jq -r '.cycle_state.heartbeat_at' "$PULSE_HEALTH_FILE")" > "$initial_heartbeat" ]]; then
+	pass "heartbeat-only transition advances liveness without changing progress"
+else
+	fail "heartbeat-only transition advances liveness without changing progress"
+fi
+
+dispatch_before=$(_pulse_capture_dispatch_total)
+printf '%s\n' '{"lease_phase":"prelaunch","dispatched_at":"2026-01-01T00:00:00Z"}' \
+	>"$AIDEVOPS_DISPATCH_LEDGER_FILE"
+_pulse_record_cycle_outcome "$dispatch_before"
+_pulse_cycle_state_write_terminal_if_current
+assert_health "actual dispatch registration produces typed progress" '
+	.cycle_state.phase == "completed"
+	and .cycle_state.outcome == "progressed"
+	and .cycle_state.progress.kinds == ["worker-dispatched"]
+	and .cycle_state.progress.last_at != null
+	and .cycle_state.progress.consecutive_no_progress_cycles == 0
+	and .cycle_state.blocker.kind == "none"
+'
+last_progress_at=$(jq -r '.cycle_state.progress.last_at' "$PULSE_HEALTH_FILE")
+
+_pulse_cycle_state_start
+_pulse_cycle_state_note_blocker review-gate owner/repo 7
+_pulse_record_cycle_outcome 1
+write_pulse_health_file
+assert_health "first typed blocker starts both no-progress streaks" '
+	.cycle_state.outcome == "blocked"
+	and .cycle_state.progress.consecutive_no_progress_cycles == 1
+	and .cycle_state.blocker.kind == "review-gate"
+	and .cycle_state.blocker.consecutive_same_cycles == 1
+'
+first_fingerprint=$(jq -r '.cycle_state.blocker.fingerprint' "$PULSE_HEALTH_FILE")
+if [[ "$first_fingerprint" != *"owner/repo"* && "$first_fingerprint" != *"#7"* ]]; then
+	pass "blocker fingerprint does not expose source coordinates"
+else
+	fail "blocker fingerprint does not expose source coordinates"
+fi
+
+_pulse_cycle_state_start
+_pulse_cycle_state_note_blocker review-gate owner/repo 7
+_pulse_record_cycle_outcome 1
+write_pulse_health_file
+assert_health "repeated blocker increments stable streak without moving progress" "
+	.cycle_state.progress.last_at == \"${last_progress_at}\"
+	and .cycle_state.progress.consecutive_no_progress_cycles == 2
+	and .cycle_state.blocker.consecutive_same_cycles == 2
+"
+
+_pulse_cycle_state_start
+_pulse_cycle_state_note_blocker head-changed owner/repo 7
+_pulse_record_cycle_outcome 1
+write_pulse_health_file
+assert_health "changed blocker restarts only blocker streak" '
+	.cycle_state.progress.consecutive_no_progress_cycles == 3
+	and .cycle_state.blocker.kind == "head-changed"
+	and .cycle_state.blocker.consecutive_same_cycles == 1
+'
+
+_pulse_cycle_state_start
+_PULSE_HEALTH_PRS_MERGED=1
+_pulse_record_cycle_outcome 1
+write_pulse_health_file
+assert_health "meaningful progress resets blocker and no-progress streaks" '
+	.cycle_state.outcome == "progressed"
+	and .cycle_state.progress.kinds == ["pr-merged"]
+	and .cycle_state.progress.consecutive_no_progress_cycles == 0
+	and .cycle_state.blocker.kind == "none"
+	and .cycle_state.blocker.consecutive_same_cycles == 0
+'
+
+cp "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-failed-write.json"
+mv() {
+	return 1
+}
+write_pulse_health_file
+unset -f mv
+if cmp -s "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-failed-write.json"; then
+	pass "failed atomic rename preserves the last valid health record"
+else
+	fail "failed atomic rename preserves the last valid health record"
+fi
+
+consumer_output="${TMP_DIR}/consumer.json"
+python3 "${SOURCE_DIR}/pulse-current-state.py" \
+	"${HOME}/.aidevops/logs" "$PWD" 900 1 "$SOURCE_DIR" "${TMP_DIR}/review-state" \
+	>"$consumer_output"
+if jq -e '
+	.cycle_state.availability == "available"
+	and .cycle_state.schema == "aidevops.pulse-cycle-state/v1"
+	and .cycle_state.outcome == "progressed"
+	and .cycle_state.progress.kinds == ["pr-merged"]
+' "$consumer_output" >/dev/null; then
+	pass "production consumer accepts the real producer output"
+else
+	fail "production consumer accepts the real producer output"
+fi
+
+if [[ ! -e "${HOME}/.aidevops/logs/pulse-cycle-state.json" ]]; then
+	pass "lifecycle state does not create a parallel runtime artifact"
+else
+	fail "lifecycle state does not create a parallel runtime artifact"
+fi
+
+_pulse_cycle_state_start
+write_pulse_health_file
+_pulse_cycle_state_finalize idle '[]'
+LOCK_ACQUIRE_CALLS=0
+LOCK_RELEASE_CALLS=0
+_LOCK_OWNED=false
+acquire_instance_lock() {
+	LOCK_ACQUIRE_CALLS=$((LOCK_ACQUIRE_CALLS + 1))
+	_LOCK_OWNED=true
+	return 0
+}
+release_instance_lock() {
+	LOCK_RELEASE_CALLS=$((LOCK_RELEASE_CALLS + 1))
+	_LOCK_OWNED=false
+	return 0
+}
+jq '.cycle_state.cycle_id = "newer-cycle"' "$PULSE_HEALTH_FILE" >"${TMP_DIR}/newer-health.json"
+mv "${TMP_DIR}/newer-health.json" "$PULSE_HEALTH_FILE"
+cp "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-stale-terminal.json"
+_pulse_cycle_state_write_terminal_if_current
+if cmp -s "$PULSE_HEALTH_FILE" "${TMP_DIR}/health-before-stale-terminal.json" \
+	&& [[ "$LOCK_ACQUIRE_CALLS" -eq 1 && "$LOCK_RELEASE_CALLS" -eq 1 \
+		&& "$_LOCK_OWNED" == "false" ]]; then
+	pass "older terminal publication cannot overwrite newer cycle health"
+else
+	fail "older terminal publication cannot overwrite newer cycle health"
+fi
+
+printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -292,8 +292,10 @@ assert_human_review_thread_rules() {
 	assert_gate_blocker "unresolved human thread passes when effective rules do not require resolution" human_not_required 0 ""
 	assert_gate_blocker "required human thread supports slash-containing base branches" \
 		human_required_slash 1 "$PMRC_BLOCKER_REQUIRED_REVIEW_THREADS"
-	assert_gate_blocker "effective-rules API failure with unresolved human thread fails closed" human_rules_error 1 ""
-	assert_gate_blocker "malformed effective-rules response with unresolved human thread fails closed" human_rules_malformed 1 ""
+	assert_gate_blocker "effective-rules API failure with unresolved human thread fails closed" \
+		human_rules_error 1 "$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+	assert_gate_blocker "malformed effective-rules response with unresolved human thread fails closed" \
+		human_rules_malformed 1 "$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
 	return 0
 }
 
@@ -375,7 +377,8 @@ assert_review_and_head_snapshot_cases() {
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
 	assert_gate_blocker "unresolved late inline finding blocks merge" unresolved 1 "$PMRC_BLOCKER_REVIEW_BOT_THREADS"
-	assert_gate_blocker "paginated review-thread snapshot fails closed without actionable remediation" review_threads_paginated 1 ""
+	assert_gate_blocker "paginated review-thread snapshot fails closed without actionable remediation" \
+		review_threads_paginated 1 "$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
 	assert_human_review_thread_rules
 	assert_gate "late review activity invalidates stale gate success" stale_gate 1
 	set_live_evidence PASS sha-reviewed trusted true 2026-01-01T00:00:50Z

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -201,6 +201,62 @@ else
 	fail "active cycle records completed-action latency"
 fi
 
+FINAL_TYPED_OUTCOME=""
+FINAL_PROGRESS_KINDS="[]"
+_pulse_cycle_state_finalize() {
+	local outcome="$1"
+	local progress_kinds="$2"
+	FINAL_TYPED_OUTCOME="$outcome"
+	FINAL_PROGRESS_KINDS="$progress_kinds"
+	return 0
+}
+
+export AIDEVOPS_DISPATCH_LEDGER_FILE="${TMP}/dispatch-ledger.jsonl"
+printf '%s\n' \
+	'{"lease_phase":"prelaunch","dispatched_at":"2026-01-01T00:00:00Z"}' \
+	'{malformed' \
+	'{"lease_phase":"ready","dispatched_at":"2026-01-01T00:00:01Z"}' \
+	'{"lease_phase":"prelaunch","dispatched_at":"2026-01-01T00:00:02Z"}' \
+	>"$AIDEVOPS_DISPATCH_LEDGER_FILE"
+if [[ "$(_pulse_capture_dispatch_total)" == "2" ]]; then
+	pass "dispatch total counts successful registrations and ignores malformed rows"
+else
+	fail "dispatch total counts successful registrations and ignores malformed rows"
+fi
+
+_PULSE_HEALTH_PRS_MERGED=0
+_PULSE_HEALTH_PRS_CLOSED_CONFLICTING=0
+_PULSE_CYCLE_BLOCKER_KIND="none"
+_PULSE_EFFICIENCY_CYCLE_OUTCOME="idle"
+_pulse_record_cycle_outcome 1
+if [[ "$FINAL_TYPED_OUTCOME" == "progressed" \
+	&& "$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "active" ]] \
+	&& printf '%s' "$FINAL_PROGRESS_KINDS" | jq -e '. == ["worker-dispatched"]' >/dev/null; then
+	pass "worker registration maps to typed progress and legacy active"
+else
+	fail "worker registration maps to typed progress and legacy active"
+fi
+
+_PULSE_CYCLE_BLOCKER_KIND="review-gate"
+_pulse_record_cycle_outcome 2
+if [[ "$FINAL_TYPED_OUTCOME" == "blocked" \
+	&& "$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "idle" \
+	&& "$FINAL_PROGRESS_KINDS" == "[]" ]]; then
+	pass "typed blocker maps to blocked and legacy idle"
+else
+	fail "typed blocker maps to blocked and legacy idle"
+fi
+
+_PULSE_CYCLE_BLOCKER_KIND="none"
+_pulse_record_cycle_outcome 2
+if [[ "$FINAL_TYPED_OUTCOME" == "idle" \
+	&& "$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "idle" \
+	&& "$FINAL_PROGRESS_KINDS" == "[]" ]]; then
+	pass "no durable evidence maps to typed and legacy idle"
+else
+	fail "no durable evidence maps to typed and legacy idle"
+fi
+
 PREFETCH_INFRA="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/pulse-prefetch-infra.sh"
 # shellcheck disable=SC1090
 source "$PREFETCH_INFRA"


### PR DESCRIPTION
## Summary

- extend the atomic `pulse-health.json` writer with the additive `aidevops.pulse-cycle-state/v1` lifecycle object
- distinguish admission and heartbeat liveness from durable merge, close, and worker-dispatch progress
- persist typed blockers and cross-cycle streaks while protecting terminal health and legacy idle-backoff writes from stale cycle generations
- make `pulse-current-state.py` consume and validate real producer output, including explicit unavailable and malformed states

## Implementation

- `.agents/scripts/pulse-logging.sh`, `.agents/scripts/pulse-wrapper.sh`, `.agents/scripts/pulse-wrapper-cycle-gates.sh`, and `.agents/scripts/pulse-wrapper-cycle.sh`: lifecycle transitions, atomic publication, generation ownership, progress aggregation, and lock-safe cleanup
- `.agents/scripts/pulse-merge.sh`, `.agents/scripts/pulse-merge-pass.sh`, and `.agents/scripts/pulse-merge-required-checks.sh`: stable typed merge blockers propagated across subprocess boundaries
- `.agents/scripts/pulse-current-state.py` and `.agents/scripts/pulse-current-state-helper.sh`: production consumer contract and corrected environment propagation
- `.agents/scripts/tests/test-pulse-cycle-state-contract.sh` plus focused existing suites: real producer-consumer, heartbeat, streak, malformed-state, generation-race, and compatibility coverage

## Compatibility

- keeps existing `pulse-health.json` fields, admission timestamps, PID sentinels, and cycle-index key types unchanged
- creates no parallel lifecycle artifact
- advances `progress.last_at` only for durable queue changes; heartbeats only advance liveness
- commits legacy active/idle state only after the cycle still owns current health

## Verification

- `python3 -m py_compile .agents/scripts/pulse-current-state.py`
- 218 focused lifecycle/current-state/merge/lock/canary/characterization/dry-run/singleton assertions passed
- `.agents/scripts/linters-local.sh` passed, including ShellCheck, secretlint, portability, Bash 3.2, complexity, nesting, and whitespace gates

Resolves #28361

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 18h 47m and 1,054,437 tokens on this with the user in an interactive session. Overall, 1h 6m since this issue was created.
