### PR TITLE
GH#28323: Bound Pulse paginated API reads

### DIFF
--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -1935,7 +1935,7 @@ _dispatch_pr_fix_worker() {
 
 	# --- Fetch bot/human reviews (substantive: CHANGES_REQUESTED or long body) ---
 	local reviews_json
-	reviews_json=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
+	reviews_json=$(_gh_with_timeout read gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
 		--paginate \
 		--jq '[.[] | select(.state == "CHANGES_REQUESTED" or ((.body // "") | length) > 30)
 			| {author: (.user.login // "unknown"), state: .state,
@@ -1945,7 +1945,7 @@ _dispatch_pr_fix_worker() {
 
 	# --- Fetch inline review comments (file:line citations) ---
 	local inline_json
-	inline_json=$(gh api "repos/${repo_slug}/pulls/${pr_number}/comments" \
+	inline_json=$(_gh_with_timeout read gh api "repos/${repo_slug}/pulls/${pr_number}/comments" \
 		--paginate \
 		--jq '[.[] | {author: (.user.login // "unknown"),
 			path: (.path // ""),

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -215,7 +215,8 @@ _pmp_rest_review_decision_from_reviews() {
 	local repo_slug="$2"
 	local reviews_json=""
 
-	reviews_json=$(gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/reviews" 2>/dev/null) || return 1
+	reviews_json=$(_gh_with_timeout read gh api --paginate \
+		"repos/${repo_slug}/pulls/${pr_number}/reviews" 2>/dev/null) || return 1
 	printf '%s' "$reviews_json" | jq -rs '
 		flatten
 		| map(select((.user.login // "") != "" and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")))

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -677,7 +677,7 @@ _pm_reconcile_pr_closeout_comments() {
 
 	while ((attempt < max_attempts)); do
 		attempt=$((attempt + 1))
-		comments_json=$(gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
+		comments_json=$(_gh_with_timeout read gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
 			--paginate --slurp 2>/dev/null) || comments_json=""
 		if [[ -z "$comments_json" ]]; then
 			((attempt < max_attempts)) && sleep 1
@@ -784,7 +784,7 @@ _pm_upsert_pr_closing_comment() {
 
 	marked_comment="<!-- PULSE_MERGE_CLOSEOUT:PR#${pr_number} -->
 ${closing_comment}"
-	comments_json=$(gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
+	comments_json=$(_gh_with_timeout read gh api "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
 		--paginate --slurp 2>/dev/null) || comments_json=""
 	if [[ -n "$comments_json" ]]; then
 		existing_comment_id=$(_pm_select_pr_closeout_comment_id "$comments_json" "$pr_number")

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -26,6 +26,7 @@ TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
 GH_LOG=""
+TIMEOUT_CALL_LOG=""
 
 print_result() {
 	local test_name="$1"
@@ -49,6 +50,8 @@ print_result() {
 # Mock state that each test resets before running.
 reset_mock_state() {
 	: >"$GH_LOG"
+	: >"$TIMEOUT_CALL_LOG"
+	unset TEST_TIMEOUT_FAIL_PATTERN
 	: >"${TEST_ROOT}/issue-body.txt"
 	: >"${TEST_ROOT}/reviews.json"
 	: >"${TEST_ROOT}/comments.json"
@@ -69,9 +72,22 @@ setup_test_paths() {
 	export LOGFILE="${TEST_ROOT}/pulse.log"
 	: >"$LOGFILE"
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
+	TIMEOUT_CALL_LOG="${TEST_ROOT}/timeout-calls.log"
 	: >"$GH_LOG"
-	export TEST_ROOT GH_LOG
+	: >"$TIMEOUT_CALL_LOG"
+	export TEST_ROOT GH_LOG TIMEOUT_CALL_LOG
 	return 0
+}
+
+_gh_with_timeout() {
+	local operation="$1"
+	shift
+	printf '%s %s\n' "$operation" "$*" >>"$TIMEOUT_CALL_LOG"
+	if [[ -n "${TEST_TIMEOUT_FAIL_PATTERN:-}" && "$*" == *"$TEST_TIMEOUT_FAIL_PATTERN"* ]]; then
+		return 124
+	fi
+	"$@"
+	return $?
 }
 
 write_gh_mock_command_cases() {
@@ -359,6 +375,35 @@ test_dispatch_appends_to_issue_body_and_closes_pr() {
 	return 0
 }
 
+test_dispatch_wraps_paginated_feedback_reads() {
+	reset_mock_state
+	_dispatch_pr_fix_worker "100" "owner/repo" "42"
+	if grep -Fq 'read gh api repos/owner/repo/pulls/100/reviews --paginate' "$TIMEOUT_CALL_LOG" &&
+		grep -Fq 'read gh api repos/owner/repo/pulls/100/comments --paginate' "$TIMEOUT_CALL_LOG"; then
+		print_result "dispatch wraps paginated review and inline-comment reads" 0
+	else
+		print_result "dispatch wraps paginated review and inline-comment reads" 1 \
+			"timeout calls=$(tr '\n' ';' <"$TIMEOUT_CALL_LOG")"
+	fi
+	return 0
+}
+
+test_dispatch_timeout_fails_open_without_routing_empty_feedback() {
+	reset_mock_state
+	export TEST_TIMEOUT_FAIL_PATTERN="repos/owner/repo/pulls/100/"
+	_dispatch_pr_fix_worker "100" "owner/repo" "42"
+	unset TEST_TIMEOUT_FAIL_PATTERN
+	if [[ "$(<"${TEST_ROOT}/issue-body.txt")" == "Original issue body." ]] &&
+		! grep -qF 'gh pr close 100' "$GH_LOG" &&
+		[[ "$(grep -c '^read gh api repos/owner/repo/pulls/100/' "$TIMEOUT_CALL_LOG" 2>/dev/null || true)" == "2" ]]; then
+		print_result "timed-out feedback reads fail open without closing the PR" 0
+	else
+		print_result "timed-out feedback reads fail open without closing the PR" 1 \
+			"gh=$(tr '\n' ';' <"$GH_LOG"), timeout=$(tr '\n' ';' <"$TIMEOUT_CALL_LOG")"
+	fi
+	return 0
+}
+
 test_dispatch_idempotent_when_marker_already_present() {
 	reset_mock_state
 	# Pre-seed the issue body with the marker.
@@ -587,6 +632,8 @@ main() {
 	test_build_section_includes_marker_and_citations
 	test_build_section_empty_when_no_content
 	test_dispatch_appends_to_issue_body_and_closes_pr
+	test_dispatch_wraps_paginated_feedback_reads
+	test_dispatch_timeout_fails_open_without_routing_empty_feedback
 	test_dispatch_idempotent_when_marker_already_present
 	test_dispatch_noop_when_no_substantive_feedback
 	test_dispatch_noop_on_invalid_inputs

--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -42,11 +42,13 @@ setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
 	export LOGFILE="${TEST_ROOT}/pulse.log"
 	export GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
+	export TIMEOUT_CALL_LOG="${TEST_ROOT}/timeout-calls.log"
 	export SOLVED_LABEL_LOG="${TEST_ROOT}/solved-labels.log"
 	export TEST_PR_COMMENTS_FILE="${TEST_ROOT}/pr-comments.json"
 	export TEST_PR_SNAPSHOT_QUEUE_FILE="${TEST_ROOT}/pr-comment-snapshots.ndjson"
 	: >"$LOGFILE"
 	: >"$GH_CALL_LOG"
+	: >"$TIMEOUT_CALL_LOG"
 	: >"$SOLVED_LABEL_LOG"
 	: >"$TEST_PR_SNAPSHOT_QUEUE_FILE"
 	printf '[]\n' >"$TEST_PR_COMMENTS_FILE"
@@ -214,7 +216,7 @@ install_helper_stubs() {
 	_gh_with_timeout() {
 		local access_mode="$1"
 		shift
-		: "$access_mode"
+		printf '%s %s\n' "$access_mode" "$*" >>"$TIMEOUT_CALL_LOG"
 		"$@"
 		return $?
 	}
@@ -356,6 +358,7 @@ test_closing_comment_defaults_to_main_for_legacy_callers() {
 
 test_pr_closeout_reuses_merge_summary_comment() {
 	: >"$GH_CALL_LOG"
+	: >"$TIMEOUT_CALL_LOG"
 	set_pr_comments '[{"id":101,"created_at":"2026-07-13T16:00:00Z","body":"<!-- MERGE_SUMMARY --> original"}]'
 
 	_handle_post_merge_actions "755" "marcusquinn/aidevops" "" "merged" "origin:worker"
@@ -368,6 +371,15 @@ test_pr_closeout_reuses_merge_summary_comment() {
 		"PR closeout does not append when MERGE_SUMMARY exists"
 	assert_completion_candidate_count 1 755 \
 		"MERGE_SUMMARY upsert leaves exactly one completion candidate"
+	local bounded_read_count=""
+	bounded_read_count=$(grep -cF 'read gh api repos/marcusquinn/aidevops/issues/755/comments?per_page=100 --paginate --slurp' \
+		"$TIMEOUT_CALL_LOG" 2>/dev/null || true)
+	if [[ "$bounded_read_count" -ge 3 ]]; then
+		pass "PR closeout initial and reconciliation pagination reads are bounded"
+	else
+		fail "PR closeout initial and reconciliation pagination reads are bounded" \
+			"Expected at least 3 bounded reads, found ${bounded_read_count}"
+	fi
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-rest-review-decision.sh
+++ b/.agents/scripts/tests/test-pulse-merge-rest-review-decision.sh
@@ -16,6 +16,7 @@ readonly TEST_RESET='\033[0m'
 TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
+TIMEOUT_LOG=""
 
 print_result() {
 	local test_name="$1"
@@ -34,11 +35,31 @@ print_result() {
 
 setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
+	TIMEOUT_LOG="${TEST_ROOT}/timeout.log"
+	export TIMEOUT_LOG
+	: >"$TIMEOUT_LOG"
+	unset TEST_TIMEOUT_FAIL
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	write_gh_mock
 	# shellcheck source=/dev/null
 	source "$MERGE_PROCESS_SCRIPT"
+	return 0
+}
+
+_gh_with_timeout() {
+	local operation="$1"
+	shift
+	printf '%s %s\n' "$operation" "$*" >>"$TIMEOUT_LOG"
+	if [[ "${TEST_TIMEOUT_FAIL:-false}" == "true" ]]; then
+		return 124
+	fi
+	"$@"
+	return $?
+}
+
+gh_pr_view() {
+	printf ''
 	return 0
 }
 
@@ -94,12 +115,41 @@ assert_review_decision() {
 	return 0
 }
 
+test_review_fetch_uses_bounded_read() {
+	: >"$TIMEOUT_LOG"
+	assert_review_decision "REST fallback still derives active review state" "123" "CHANGES_REQUESTED"
+	if grep -Fqx 'read gh api --paginate repos/owner/repo/pulls/123/reviews' "$TIMEOUT_LOG"; then
+		print_result "REST fallback wraps paginated reviews in a bounded read" 0
+	else
+		print_result "REST fallback wraps paginated reviews in a bounded read" 1 \
+			"timeout calls=$(tr '\n' ';' <"$TIMEOUT_LOG")"
+	fi
+	return 0
+}
+
+test_timeout_failure_preserves_unknown_decision() {
+	: >"$TIMEOUT_LOG"
+	export TEST_TIMEOUT_FAIL="true"
+	local decision=""
+	_pmp_refresh_unknown_review_decision_into decision "125" "owner/repo" "UNKNOWN"
+	unset TEST_TIMEOUT_FAIL
+	if [[ "$decision" == "UNKNOWN" ]] &&
+		grep -Fqx 'read gh api --paginate repos/owner/repo/pulls/125/reviews' "$TIMEOUT_LOG"; then
+		print_result "timed-out REST review fetch returns UNKNOWN without blocking" 0
+	else
+		print_result "timed-out REST review fetch returns UNKNOWN without blocking" 1 \
+			"decision=${decision}, timeout calls=$(tr '\n' ';' <"$TIMEOUT_LOG")"
+	fi
+	return 0
+}
+
 main() {
 	setup_test_env
 	trap cleanup_test_env EXIT
 
-	assert_review_decision "COMMENTED review does not clear active changes requested" "123" "CHANGES_REQUESTED"
+	test_review_fetch_uses_bounded_read
 	assert_review_decision "DISMISSED review clears prior changes requested" "124" "NONE"
+	test_timeout_failure_preserves_unknown_decision
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-pulse-merge-routine-timeout.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-timeout.sh
@@ -111,36 +111,52 @@ else
 fi
 
 # =============================================================================
-# Test 1c: cmd_run wraps merge_ready_prs_all_repos via _pmr_run_with_timeout
+# Test 1c: cmd_run wraps the merge scope via _pmr_run_with_timeout
 # =============================================================================
 # Use awk to find _pmr_run_with_timeout invocation within cmd_run() body.
 if awk '
 	BEGIN { in_cmd_run=0; found=0 }
 	/^cmd_run\(\)/ { in_cmd_run=1; next }
 	in_cmd_run && /^\}/ { in_cmd_run=0 }
-	in_cmd_run && /_pmr_run_with_timeout.*merge_ready_prs_all_repos/ { found=1; exit }
+	in_cmd_run && /_pmr_run_with_timeout.*_pmr_run_merge_scope/ { found=1; exit }
 	END { exit (found) ? 0 : 1 }
 ' "$ROUTINE_FILE"; then
-	pass "1c: cmd_run wraps merge_ready_prs_all_repos via _pmr_run_with_timeout"
+	pass "1c: cmd_run wraps the merge scope via _pmr_run_with_timeout"
 else
-	fail "1c: cmd_run wraps merge_ready_prs_all_repos via _pmr_run_with_timeout" \
-		"cmd_run body does not invoke '_pmr_run_with_timeout ... merge_ready_prs_all_repos'"
+	fail "1c: cmd_run wraps the merge scope via _pmr_run_with_timeout" \
+		"cmd_run body does not invoke '_pmr_run_with_timeout ... _pmr_run_merge_scope'"
 fi
 
 # =============================================================================
-# Test 1d: cmd_dry_run wraps merge_ready_prs_all_repos via _pmr_run_with_timeout
+# Test 1d: cmd_dry_run wraps the merge scope via _pmr_run_with_timeout
 # =============================================================================
 if awk '
 	BEGIN { in_cmd=0; found=0 }
 	/^cmd_dry_run\(\)/ { in_cmd=1; next }
 	in_cmd && /^\}/ { in_cmd=0 }
-	in_cmd && /_pmr_run_with_timeout.*merge_ready_prs_all_repos/ { found=1; exit }
+	in_cmd && /_pmr_run_with_timeout.*_pmr_run_merge_scope/ { found=1; exit }
 	END { exit (found) ? 0 : 1 }
 ' "$ROUTINE_FILE"; then
-	pass "1d: cmd_dry_run wraps merge_ready_prs_all_repos via _pmr_run_with_timeout"
+	pass "1d: cmd_dry_run wraps the merge scope via _pmr_run_with_timeout"
 else
-	fail "1d: cmd_dry_run wraps merge_ready_prs_all_repos via _pmr_run_with_timeout" \
-		"cmd_dry_run body does not invoke '_pmr_run_with_timeout ... merge_ready_prs_all_repos'"
+	fail "1d: cmd_dry_run wraps the merge scope via _pmr_run_with_timeout" \
+		"cmd_dry_run body does not invoke '_pmr_run_with_timeout ... _pmr_run_merge_scope'"
+fi
+
+# The wrapped scope must still delegate the normal, non-targeted path to the
+# full repository merge pass; otherwise the wrapper checks above could pass
+# while protecting an empty or unrelated function.
+if awk '
+	BEGIN { in_scope=0; found=0 }
+	/^_pmr_run_merge_scope\(\)/ { in_scope=1; next }
+	in_scope && /^\}/ { in_scope=0 }
+	in_scope && /merge_ready_prs_all_repos/ { found=1; exit }
+	END { exit (found) ? 0 : 1 }
+' "$ROUTINE_FILE"; then
+	pass "1d2: bounded merge scope delegates the normal path to the full merge pass"
+else
+	fail "1d2: bounded merge scope delegates the normal path to the full merge pass" \
+		"_pmr_run_merge_scope does not invoke merge_ready_prs_all_repos"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Route five paginated review, inline-comment, and closeout reads through _gh_with_timeout so a stalled GitHub API call cannot hang the merge routine.

## Files Changed

.agents/scripts/pulse-merge-feedback.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh, .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh, .agents/scripts/tests/test-pulse-merge-rest-review-decision.sh, .agents/scripts/tests/test-pulse-merge-routine-timeout.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused Pulse suites pass: REST decision 4/4, fix-worker dispatch 11/11, post-merge closeout 33/33, routine timeout 9/9, routine standalone 20/20; ShellCheck, bash -n, git diff --check, and linters-local.sh pass.

Resolves #28323


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 7h 2m and 2,502,863 tokens on this with the user in an interactive session.