### PR TITLE
GH#27777: attribute exact direct REST quota costs

### DIFF
--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -61,6 +61,30 @@ The benchmark validates:
 Any unknown quota cost or unclassified transport attempt prevents `PASS`.
 Never derive a benchmark by reading the raw JSONL/log source directly.
 
+### Quota-cost attribution
+
+Quota cost is known only when the operation owns authoritative per-request
+evidence. An explicit operation-provided cost takes precedence. The `gh` shim
+can additionally attribute documented primary-rate cost after a successful,
+uncached, non-conditional direct `gh api` request to `github.com`:
+
+- REST requests cost `1` primary-rate point;
+- `GET /rate_limit` costs `0` primary-rate points.
+
+Failed requests without operation-owned cost evidence remain unknown because
+the exit status does not prove whether GitHub charged the request. Cached and
+conditional requests remain unknown because their result can cost either zero
+or one. Native opaque pagination, GitHub Enterprise hosts, unknown/future
+`gh api` options, GraphQL, and higher-level `gh` commands also remain unknown.
+Explicit REST pagination can record each successful page independently after
+the shim has proved that page boundary.
+
+Do not infer an operation's GraphQL cost by subtracting cumulative rate-limit
+headers: concurrent clients can change those values between observations. A
+GraphQL operation becomes exact only when it returns and owns its own
+`rateLimit { cost }` value. Partial REST attribution does not relax the
+benchmark's zero-unknown-cost comparability gate.
+
 ### Evidence sidecar
 
 Each transport aggregate has one sidecar using
@@ -282,6 +306,7 @@ must not be removed by an efficiency-only canary.
 
 ```bash
 bash .agents/scripts/tests/test-gh-api-instrument.sh
+bash .agents/scripts/tests/test-gh-shim.sh
 bash .agents/scripts/tests/test-gh-request-singleflight.sh
 bash .agents/scripts/tests/test-gh-check-status-cache.sh
 bash .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -291,7 +316,9 @@ bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
 bash .agents/scripts/tests/test-github-api-efficiency-evidence.sh
 bash .agents/scripts/tests/test-github-api-efficiency-benchmark.sh
 shellcheck \
+  .agents/scripts/gh \
   .agents/scripts/gh-api-instrument.sh \
+  .agents/scripts/gh-quota-attribution-lib.sh \
   .agents/scripts/pulse-wrapper-cycle-gates.sh \
   .agents/scripts/pulse-batch-prefetch-helper.sh \
   .agents/scripts/pulse-merge-webhook-receiver.sh \

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -219,6 +219,24 @@ if ! type gh_run_transport_attempt >/dev/null 2>&1; then
 fi
 unset _cand _INST_LOADED
 
+# Direct REST calls have documented fixed primary-rate costs, with a documented
+# zero-cost exception for GET /rate_limit. Keep the parser separate from this
+# already-large shim and fail closed when its provenance checks are unavailable.
+_GHQA_LOADED=0
+for _cand in \
+	"$_SHIM_DIR/gh-quota-attribution-lib.sh" \
+	"${HOME:+${HOME}/.aidevops/agents/scripts/gh-quota-attribution-lib.sh}"; do
+	if [[ -n "$_cand" && -f "$_cand" ]]; then
+		# shellcheck source=/dev/null
+		source "$_cand" 2>/dev/null && _GHQA_LOADED=1
+		break
+	fi
+done
+if [[ $_GHQA_LOADED -eq 0 ]]; then
+	_ghqa_exact_success_cost() { return 1; }
+fi
+unset _cand _GHQA_LOADED
+
 # One ID follows the complete wrapper invocation, including REST translation,
 # each explicit page, and any GraphQL fallback retry.
 AIDEVOPS_GH_LOGICAL_ID="${AIDEVOPS_GH_LOGICAL_ID:-$(gh_new_logical_id)}"
@@ -373,11 +391,14 @@ _shim_run_single_transport() {
 	local retry="$1"; shift
 	local page=1
 	local decision="${AIDEVOPS_GH_ROUTE_DECISION:-}"
+	local exact_success_cost=""
 	page=$(_shim_transport_page "$@")
 	if [[ "$page" == "0" ]]; then
 		decision="native-pagination-opaque"
 	fi
-	AIDEVOPS_GH_ROUTE_DECISION="$decision" gh_run_transport_attempt \
+	exact_success_cost=$(_ghqa_exact_success_cost "$path" "$@" 2>/dev/null || true)
+	AIDEVOPS_GH_ROUTE_DECISION="$decision" \
+		AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS="$exact_success_cost" gh_run_transport_attempt \
 		"$path" "$caller" "$AIDEVOPS_GH_LOGICAL_ID" "$page" "$retry" -- "$executable" "$@"
 	return $?
 }

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -484,9 +484,14 @@ gh_run_transport_attempt() {
 	local elapsed_ms=""
 	local rc=0
 	local outcome="success"
+	local quota_cost="${AIDEVOPS_GH_QUOTA_COST:-}"
+	local success_quota_cost="${AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS:-}"
 	start_ms=$(_gh_now_ms) || start_ms=""
 	if "$@"; then
 		rc=0
+		if [[ -z "$quota_cost" && -n "$success_quota_cost" ]]; then
+			quota_cost="$success_quota_cost"
+		fi
 	else
 		rc=$?
 		outcome="$GH_API_ERROR_KEY"
@@ -496,7 +501,7 @@ gh_run_transport_attempt() {
 		elapsed_ms=$((end_ms - start_ms))
 	fi
 	gh_record_attempt "$path" "$caller" "$logical_id" "" "$page" "$retry" "$outcome" \
-		"${AIDEVOPS_GH_HTTP_STATUS:-}" "$elapsed_ms" "${AIDEVOPS_GH_QUOTA_COST:-}" \
+		"${AIDEVOPS_GH_HTTP_STATUS:-}" "$elapsed_ms" "$quota_cost" \
 		"${AIDEVOPS_GH_AUTH_MODE:-}" "${AIDEVOPS_GH_API_POOL:-}" "${AIDEVOPS_GH_ROUTE_DECISION:-}" \
 		"${AIDEVOPS_GH_BUDGET_REMAINING:-${_GH_LAST_GRAPHQL_REMAINING:-}}"
 	return "$rc"

--- a/.agents/scripts/gh-quota-attribution-lib.sh
+++ b/.agents/scripts/gh-quota-attribution-lib.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Conservative primary-rate quota attribution for direct `gh api` REST calls.
+# The caller may record the returned value only after the command succeeds.
+# Ambiguous transports intentionally return no value so benchmark evidence
+# remains fail-closed rather than estimating cost from cumulative headers.
+
+_GHQA_ENDPOINT=""
+_GHQA_HOSTNAME=""
+_GHQA_METHOD=""
+_GHQA_FIELDS_REQUESTED=0
+_GHQA_INPUT_REQUESTED=0
+_GHQA_AMBIGUOUS=0
+
+_ghqa_lower() {
+	local value="$1"
+	printf '%s' "$value" | LC_ALL=C tr '[:upper:]' '[:lower:]'
+	return 0
+}
+
+_ghqa_is_conditional_header() {
+	local header="$1"
+	header=$(_ghqa_lower "$header")
+	[[ "$header" =~ ^[[:space:]]*if-(match|none-match|modified-since|unmodified-since)[[:space:]]*: ]]
+	return $?
+}
+
+_ghqa_apply_option_value() {
+	local option="$1"
+	local value="$2"
+	case "$option" in
+	-X | --method) _GHQA_METHOD=$(_ghqa_lower "$value") ;;
+	-H | --header)
+		_ghqa_is_conditional_header "$value" && _GHQA_AMBIGUOUS=1
+		;;
+	--hostname) _GHQA_HOSTNAME=$(_ghqa_lower "$value") ;;
+	-F | --field | -f | --raw-field) _GHQA_FIELDS_REQUESTED=1 ;;
+	--input) _GHQA_INPUT_REQUESTED=1 ;;
+	--cache) _GHQA_AMBIGUOUS=1 ;;
+	-q | --jq | -p | --preview | -t | --template) ;;
+	*) _GHQA_AMBIGUOUS=1 ;;
+	esac
+	return 0
+}
+
+_ghqa_parse_api_args() {
+	local path="$1"
+	shift
+	local arg=""
+	local option=""
+	local value=""
+	_GHQA_ENDPOINT=""
+	_GHQA_HOSTNAME=$(_ghqa_lower "${GH_HOST:-github.com}")
+	_GHQA_METHOD=""
+	_GHQA_FIELDS_REQUESTED=0
+	_GHQA_INPUT_REQUESTED=0
+	_GHQA_AMBIGUOUS=0
+	[[ ("$path" == "rest" || "$path" == "search-rest") && "${1:-}" == "api" ]] || return 1
+	shift
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		shift
+		case "$arg" in
+		--paginate) _GHQA_AMBIGUOUS=1 ;;
+		--include | -i | --silent | --slurp | --verbose) ;;
+		-X | --method | -H | --header | --hostname | -F | --field | -f | --raw-field | --input | --cache | -q | --jq | -p | --preview | -t | --template)
+			if [[ $# -eq 0 ]]; then
+				_GHQA_AMBIGUOUS=1
+				continue
+			fi
+			value="$1"
+			shift
+			_ghqa_apply_option_value "$arg" "$value"
+			;;
+		--method=* | --header=* | --hostname=* | --field=* | --raw-field=* | --input=* | --cache=* | --jq=* | --preview=* | --template=*)
+			option="${arg%%=*}"
+			value="${arg#*=}"
+			_ghqa_apply_option_value "$option" "$value"
+			;;
+		-X?*) _ghqa_apply_option_value -X "${arg#-X}" ;;
+		-H?*) _ghqa_apply_option_value -H "${arg#-H}" ;;
+		-F?*) _ghqa_apply_option_value -F "${arg#-F}" ;;
+		-f?*) _ghqa_apply_option_value -f "${arg#-f}" ;;
+		-q?*) _ghqa_apply_option_value -q "${arg#-q}" ;;
+		-p?*) _ghqa_apply_option_value -p "${arg#-p}" ;;
+		-t?*) _ghqa_apply_option_value -t "${arg#-t}" ;;
+		-*) _GHQA_AMBIGUOUS=1 ;;
+		*)
+			if [[ -z "$_GHQA_ENDPOINT" ]]; then
+				_GHQA_ENDPOINT="$arg"
+			else
+				_GHQA_AMBIGUOUS=1
+			fi
+			;;
+		esac
+	done
+	[[ -n "$_GHQA_ENDPOINT" ]] || return 1
+	return 0
+}
+
+_ghqa_normalize_endpoint() {
+	local endpoint="$1"
+	case "$endpoint" in
+	https://api.github.com/*) endpoint="${endpoint#https://api.github.com/}" ;;
+	https://github.com/api/v3/*) endpoint="${endpoint#https://github.com/api/v3/}" ;;
+	http://* | https://* | *://*) return 1 ;;
+	esac
+	endpoint="${endpoint#/}"
+	endpoint="${endpoint#api/v3/}"
+	endpoint="${endpoint%%\?*}"
+	endpoint="${endpoint%%#*}"
+	[[ -n "$endpoint" ]] || return 1
+	printf '%s' "$endpoint"
+	return 0
+}
+
+# _ghqa_exact_success_cost <path> <gh argv...>
+# Print an exact documented primary-rate cost only when one direct REST request
+# is attributable after successful execution. Empty output/non-zero is unknown.
+_ghqa_exact_success_cost() {
+	local path="$1"
+	shift
+	local endpoint=""
+	local method=""
+	_ghqa_parse_api_args "$path" "$@" || return 1
+	[[ "$_GHQA_AMBIGUOUS" -eq 0 && "$_GHQA_HOSTNAME" == "github.com" ]] || return 1
+	endpoint=$(_ghqa_normalize_endpoint "$_GHQA_ENDPOINT") || return 1
+	[[ "$endpoint" != "graphql" && "$endpoint" != graphql/* ]] || return 1
+	method="$_GHQA_METHOD"
+	if [[ -z "$method" ]]; then
+		method="get"
+		if [[ "$_GHQA_FIELDS_REQUESTED" -eq 1 || "$_GHQA_INPUT_REQUESTED" -eq 1 ]]; then
+			method="post"
+		fi
+	fi
+	if [[ "$method" == "get" && "$endpoint" == "rate_limit" ]]; then
+		printf '0'
+		return 0
+	fi
+	printf '1'
+	return 0
+}

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -32,6 +32,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 export AIDEVOPS_GH_API_LOG="$TMPDIR/gh-api-calls.log"
 export AIDEVOPS_GH_API_REPORT="$TMPDIR/report.json"
 export AIDEVOPS_GH_API_EVIDENCE="$TMPDIR/evidence.json"
+unset AIDEVOPS_GH_QUOTA_COST AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS
 
 assert_eq() {
 	local label="$1"
@@ -384,6 +385,22 @@ fi
 gh_aggregate_calls
 assert_eq "success and failure attempts recorded" "2" "$(jq -r '._meta.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "failed outcome recorded" "1" "$(jq -r '._meta.failed_attempts' "$AIDEVOPS_GH_API_REPORT")"
+
+# --- Test 11b: inferred quota is recorded only after transport success -------
+gh_clear_log
+AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS=1 \
+	gh_run_transport_attempt rest quota-caller logical-quota 1 0 -- true
+set +e
+AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS=1 \
+	gh_run_transport_attempt rest quota-caller logical-quota 1 1 -- false
+inferred_failure_status=$?
+set -e
+AIDEVOPS_GH_QUOTA_COST=3 AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS=1 \
+	gh_run_transport_attempt rest quota-caller logical-quota 1 0 -- true
+assert_eq "inferred-cost transport failure status preserved" "1" "$inferred_failure_status"
+gh_aggregate_calls
+assert_eq "successful inferred and explicit costs reconcile" "4" "$(jq -r '._meta.known_quota_cost' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "failed inferred cost remains unknown" "1" "$(jq -r '._meta.unknown_quota_cost_attempts' "$AIDEVOPS_GH_API_REPORT")"
 
 # --- Test 12: effective window comes from retained attempt timestamps -----
 gh_clear_log

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -32,6 +32,9 @@ unset GITHUB_ACTIONS
 unset AIDEVOPS_SESSION_ORIGIN
 unset AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE
 unset AIDEVOPS_EXTERNAL_GH_WRITE_ALLOWLIST
+unset AIDEVOPS_GH_QUOTA_COST
+unset AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS
+unset GH_HOST
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
@@ -79,6 +82,9 @@ fi
 for arg in "$@"; do
 	printf '%s\n' "$arg" >>"$STUB_GH_LOG"
 done
+if [[ "${STUB_GH_EXIT_CODE:-0}" =~ ^[1-9][0-9]*$ ]]; then
+	exit "$STUB_GH_EXIT_CODE"
+fi
 if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
 	printf '%s\n' "${STUB_RATE_LIMIT_REMAINING:-5000}"
 	exit 0
@@ -153,6 +159,7 @@ chmod +x "$TMP/scripts/gh-signature-helper.sh"
 cp "$SHIM" "$TMP/scripts/gh"
 chmod +x "$TMP/scripts/gh"
 cp "$REPO_DIR/.agents/scripts/gh-api-instrument.sh" "$TMP/scripts/gh-api-instrument.sh"
+cp "$REPO_DIR/.agents/scripts/gh-quota-attribution-lib.sh" "$TMP/scripts/gh-quota-attribution-lib.sh"
 cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-fallback.sh" "$TMP/scripts/shared-gh-wrappers-rest-fallback.sh"
 cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh" "$TMP/scripts/shared-gh-wrappers-rest-read-semantics.sh"
 
@@ -177,6 +184,17 @@ _read_argv() {
 _reset_log() {
 	: >"$STUB_GH_LOG"
 	[[ -n "${STUB_SIG_LOG:-}" ]] && : >"$STUB_SIG_LOG"
+	return 0
+}
+
+_read_attempt_quota() {
+	local log_file="$1"
+	awk -F '\t' '
+		$9 == "attempt" {
+			quota = ($17 == "" ? "unknown" : $17)
+		}
+		END { print quota }
+	' "$log_file"
 	return 0
 }
 
@@ -849,6 +867,72 @@ for short_opt in -q -p -t; do
 		else
 			_fail "headless REST guard skips $short_opt argument" "argv: $argv err: $(cat "$TMP/guard-api-$short_opt-injection.err" || true)"
 		fi
+	fi
+done
+
+# =============================================================================
+# Test 22: exact quota cost is limited to unambiguous successful REST requests
+# =============================================================================
+echo ""
+echo "Test 22: conservative direct REST quota attribution"
+quota_log="$TMP/quota-attribution.log"
+
+: >"$quota_log"
+AIDEVOPS_GH_API_LOG="$quota_log" "$SHIM_RUN" api --jq . /repos/owner/repo >/dev/null 2>&1
+if [[ "$(_read_attempt_quota "$quota_log")" == "1" ]]; then
+	_pass "successful direct REST request records documented cost one"
+else
+	_fail "direct REST cost attribution" "quota: $(_read_attempt_quota "$quota_log")"
+fi
+
+: >"$quota_log"
+AIDEVOPS_GH_API_LOG="$quota_log" "$SHIM_RUN" api /repos/owner/repo/labels -f name=fixture >/dev/null 2>&1
+if [[ "$(_read_attempt_quota "$quota_log")" == "1" ]]; then
+	_pass "successful direct REST write records documented cost one"
+else
+	_fail "direct REST write cost attribution" "quota: $(_read_attempt_quota "$quota_log")"
+fi
+
+: >"$quota_log"
+AIDEVOPS_GH_API_LOG="$quota_log" "$SHIM_RUN" api rate_limit >/dev/null 2>&1
+if [[ "$(_read_attempt_quota "$quota_log")" == "0" ]]; then
+	_pass "successful GET /rate_limit records documented cost zero"
+else
+	_fail "rate-limit endpoint cost attribution" "quota: $(_read_attempt_quota "$quota_log")"
+fi
+
+for ambiguous_case in conditional cache pagination enterprise graphql unknown-option failure; do
+	: >"$quota_log"
+	case "$ambiguous_case" in
+	conditional)
+		AIDEVOPS_GH_API_LOG="$quota_log" "$SHIM_RUN" api /repos/owner/repo -H 'If-None-Match: fixture' >/dev/null 2>&1
+		;;
+	cache)
+		AIDEVOPS_GH_API_LOG="$quota_log" "$SHIM_RUN" api /repos/owner/repo --cache 1h >/dev/null 2>&1
+		;;
+	pagination)
+		AIDEVOPS_GH_EXPLICIT_PAGINATION_DISABLE=1 AIDEVOPS_GH_API_LOG="$quota_log" \
+			"$SHIM_RUN" api /repos/owner/repo --paginate >/dev/null 2>&1
+		;;
+	enterprise)
+		GH_HOST=enterprise.example AIDEVOPS_GH_API_LOG="$quota_log" "$SHIM_RUN" api /repos/owner/repo >/dev/null 2>&1
+		;;
+	graphql)
+		AIDEVOPS_GH_API_LOG="$quota_log" "$SHIM_RUN" api graphql -f 'query={viewer{login}}' >/dev/null 2>&1
+		;;
+	unknown-option)
+		AIDEVOPS_GH_API_LOG="$quota_log" "$SHIM_RUN" api /repos/owner/repo --future-option >/dev/null 2>&1
+		;;
+	failure)
+		if STUB_GH_EXIT_CODE=1 AIDEVOPS_GH_API_LOG="$quota_log" "$SHIM_RUN" api /repos/owner/repo >/dev/null 2>&1; then
+			_fail "failed REST command status" "stub failure unexpectedly succeeded"
+		fi
+		;;
+	esac
+	if [[ "$(_read_attempt_quota "$quota_log")" == "unknown" ]]; then
+		_pass "$ambiguous_case request keeps quota cost unknown"
+	else
+		_fail "$ambiguous_case quota fail-closed behavior" "quota: $(_read_attempt_quota "$quota_log")"
 	fi
 done
 

--- a/todo/tasks/t18131-brief.md
+++ b/todo/tasks/t18131-brief.md
@@ -20,7 +20,7 @@ Parent: t18124
 - **Session:** OpenCode interactive GitHub API efficiency planning
 - **Created by:** ai-interactive under maintainer direction
 - **Parent task:** t18124
-- **Blocked by:** t18130 through a native GitHub blocked-by relationship
+- **Prerequisite:** t18130 closed on 2026-07-18; remaining progress is evidence-gated, not dependency-blocked.
 - **Conversation context:** The final phase must compare equivalent baseline and canary windows using t18125 transport evidence, verify that request savings did not hide stale or incorrect decisions, tune bounded TTLs/limits, and remove temporary rollout flags only after the data supports doing so.
 
 ## What
@@ -57,7 +57,7 @@ Final leaf task. Its PR closes this child. It may close parent t18124 only when 
 
 - **Decision:** Skipped
 - **Rationale:** Final report fields, feature flags, and cleanup surfaces do not exist until t18125–t18130 merge.
-- **Status:** `blocked`
+- **Status:** `active`
 - **Freshness evidence:** Current telemetry, sweep budget config, webhook config, and test conventions were checked at `313548fc6`.
 - **Verification run:** Brief readiness only; benchmark is unrun.
 - **Stale-assumption warning:** Before implementation, discover every flag/schema/default added by the six preceding PRs and update this issue's exact scope if necessary.
@@ -84,7 +84,10 @@ rg -n 'AIDEVOPS_.*(CACHE|SNAPSHOT|SINGLE|WEBHOOK|GH_API)|feature.flag|rollout|co
 - `NEW: .agents/scripts/github-api-efficiency-benchmark.sh` — validate and compare baseline/canary telemetry with machine-readable and Markdown output.
 - `NEW: .agents/scripts/tests/test-github-api-efficiency-benchmark.sh` — fixtures for comparable, incomplete, unequal-window, regression, and pass outcomes.
 - `NEW: .agents/reference/github-api-efficiency.md` — metric definitions, request budgets, rollout defaults, rollback thresholds, and operator commands.
+- `NEW: .agents/scripts/gh-quota-attribution-lib.sh` — classify only documented exact primary-cost outcomes for direct REST requests; preserve unknown evidence for GraphQL and ambiguous transports.
+- `EDIT: .agents/scripts/gh` — pass defensible direct REST success costs into transport instrumentation without changing command output or status.
 - `EDIT: .agents/scripts/gh-api-instrument.sh` — add only a thin benchmark/report dispatch if needed; do not duplicate aggregation logic.
+- `EDIT: .agents/scripts/tests/test-gh-shim.sh` and `.agents/scripts/tests/test-gh-api-instrument.sh` — cover fixed REST costs, documented zero-cost requests, and fail-closed ambiguous/failure paths.
 - `EDIT: .agents/configs/pulse-sweep-budget.json` — remove obsolete verification settings and tune surviving bounded polling defaults when evidence supports it.
 - `EDIT: .agents/configs/webhook-receiver.conf` — tune ledger/event defaults only from canary evidence; retain secure loopback and bounded limits.
 - `EDIT: exact flag-owning files from t18125–t18130 manifests` — not yet knowable because those flags do not exist; update issue/brief scope with concrete paths before dispatch if they fall outside the paths above.
@@ -93,7 +96,7 @@ rg -n 'AIDEVOPS_.*(CACHE|SNAPSHOT|SINGLE|WEBHOOK|GH_API)|feature.flag|rollout|co
 
 - **Callers/readers:** Operators/CI invoke `.agents/scripts/github-api-efficiency-benchmark.sh`; parent closeout reads its Markdown/JSON result and phase modules read tuned configs.
 - **Writers/mutation paths:** `.agents/scripts/github-api-efficiency-benchmark.sh` writes reports atomically without runtime mutation; cleanup edits only paths discovered in merged child manifests.
-- **Tests/fixtures:** `.agents/scripts/tests/test-github-api-efficiency-benchmark.sh` supplies deterministic telemetry windows with known attempts, points, retries, latency, cache events, errors, and guardrails.
+- **Tests/fixtures:** `.agents/scripts/tests/test-github-api-efficiency-benchmark.sh` supplies deterministic telemetry windows with known attempts, points, retries, latency, cache events, errors, and guardrails; shim/instrument fixtures prove that only authoritative direct REST costs become known.
 - **Schemas/config:** `.agents/reference/github-api-efficiency.md` defines versioned input/output and `.agents/configs/pulse-sweep-budget.json` plus webhook config retain validated fields.
 - **Generated/deployed mirrors:** `.agents/scripts/github-api-efficiency-benchmark.sh`, `.agents/configs/`, and `.agents/reference/github-api-efficiency.md` deploy through setup; reports remain local artifacts.
 - **Migrations/backfills:** `.agents/scripts/github-api-efficiency-benchmark.sh` never rewrites telemetry; incompatible/legacy windows are noncomparable and compatibility readers retain an explicit removal task/date.
@@ -108,6 +111,7 @@ rg -n 'AIDEVOPS_.*(CACHE|SNAPSHOT|SINGLE|WEBHOOK|GH_API)|feature.flag|rollout|co
 5. Compare path-level budgets: no fingerprint/verification list calls, no live fallback after fresh empty hit, at most one aggregate check fetch per unique actionable SHA, one leader per identical concurrent read, and no duplicate webhook actions.
 6. Tune only bounded TTL/limits supported by canary evidence. Remove obsolete flags/dead branches and stale config fields; retain uncertain controls with rationale, owner, and expiry. Run all owning phase tests after cleanup.
 7. Attach a privacy-safe summary to the child/parent, list exact rollback triggers and retained flags, and close the parent only if every criterion is evidenced.
+8. Attribute documented primary cost only for successful direct `github.com` REST calls. Keep cached, conditional, failed, enterprise, opaque-pagination, and GraphQL calls unknown unless their own operation supplies authoritative cost evidence; never use concurrent cumulative-header differencing.
 
 ### Hazards and Compatibility
 
@@ -116,6 +120,7 @@ rg -n 'AIDEVOPS_.*(CACHE|SNAPSHOT|SINGLE|WEBHOOK|GH_API)|feature.flag|rollout|co
 - **Mixed-version/backward compatibility:** Do not compare mixed schemas as equivalent. Retain legacy readers until the observed fleet is converged or document a separate cleanup task.
 - **Idempotency/retry:** Re-running with identical inputs/options yields byte-stable metrics apart from an explicitly separated generation timestamp; source cleanup is independently testable.
 - **Partial failure/recovery:** Missing windows, unknown quota cost, incomplete retention, or failed guardrails yield `INCONCLUSIVE`/`REGRESSION`, never a fabricated pass. Keep the parent open and resume after new observation.
+- **Quota attribution:** REST has documented fixed request charges and zero-cost exceptions, but arbitrary GraphQL and higher-level `gh` operations expose no concurrency-safe per-operation cost. Partial attribution must reduce unknowns without relaxing the benchmark's zero-unknown gate.
 
 ### Complexity Impact
 
@@ -152,16 +157,20 @@ python3 -m json.tool .agents/configs/pulse-sweep-budget.json >/dev/null
 - **Remaining acceptance criteria:** Final implementation, canary, cleanup, and parent closeout criteria below.
 - **Unsafe route not to repeat:** Do not compare unequal retained windows, hide unknown quota cost, or delete rollback flags before canary success.
 - **Next safe route:** Produce an inconclusive report, collect a new fixed window, and rerun without closing the task.
-- **Resume condition:** t18130 is closed and complete baseline/canary telemetry is available.
-- **Owner and status:** Build+ `tier:standard`; blocked by t18130.
+- **Resume condition:** Dependency met; complete comparable baseline/canary telemetry remains required for final tuning and closeout.
+- **Owner and status:** Build+ `tier:standard`; active and evidence-gated.
 
 ### Files Scope
 
 - `.agents/scripts/github-api-efficiency-benchmark.sh`
 - `.agents/scripts/tests/test-github-api-efficiency-benchmark.sh`
 - `.agents/reference/github-api-efficiency.md`
+- `.agents/scripts/gh-quota-attribution-lib.sh`
+- `.agents/scripts/gh`
 - `.agents/scripts/gh-api-instrument.sh`
 - `.agents/scripts/gh-api-aggregate.awk`
+- `.agents/scripts/tests/test-gh-shim.sh`
+- `.agents/scripts/tests/test-gh-api-instrument.sh`
 - `.agents/configs/pulse-sweep-budget.json`
 - `.agents/configs/webhook-receiver.conf`
 - `.agents/scripts/pulse-batch-prefetch-helper.sh`
@@ -185,11 +194,13 @@ python3 -m json.tool .agents/configs/pulse-sweep-budget.json >/dev/null
 - Comparable effective windows matter more than configured window labels.
 - Path-level deterministic budgets complement, but do not replace, real aggregate observation.
 - Inconclusive evidence keeps flags and parent open; it is not a failure to be hidden.
+- Exact universal GraphQL cost attribution is unavailable from cumulative response headers under concurrency; unknown costs remain unknown rather than being estimated or promoted to zero.
 - Publication/release remains outside this task unless separately authorised.
 
 ## Relevant Files
 
 - `.agents/scripts/gh-api-instrument.sh:178-251` — source telemetry and retained-window contract.
+- `.agents/scripts/gh:387-436` — native transport boundary where direct REST cost provenance can be attached without changing command output.
 - `.agents/scripts/gh-api-aggregate.awk:72-130` — machine-readable aggregate source.
 - `.agents/configs/pulse-sweep-budget.json` — current polling/cache defaults and obsolete verification field candidate.
 - `.agents/configs/webhook-receiver.conf` — webhook event/ledger defaults after t18130.
@@ -197,7 +208,7 @@ python3 -m json.tool .agents/configs/pulse-sweep-budget.json >/dev/null
 
 ## Dependencies
 
-- **Blocked by:** t18130.
+- **Blocked by:** No open task dependency; t18130 is closed.
 - **Blocks:** Final closeout of parent t18124.
 - **External:** Fixed baseline/canary observation windows; no paid service or new credential.
 

--- a/todo/tasks/t18131-brief.md
+++ b/todo/tasks/t18131-brief.md
@@ -145,7 +145,7 @@ python3 -m json.tool .agents/configs/pulse-sweep-budget.json >/dev/null
 ### Recoverability Checkpoint
 
 - [x] Focused tests pass: quota instrumentation/shim suites plus benchmark/evidence fixtures
-- [x] WIP commit created before post-rebase broad gates: `b9e981fd4`
+- [x] WIP commit created before post-rebase broad gates: `GH#27777: attribute exact direct REST quota cost`
 - [ ] Evidence-triggered broad verification: changed lint passes; final bounded canary remains pending
 
 ### Safety-Stop Recovery

--- a/todo/tasks/t18131-brief.md
+++ b/todo/tasks/t18131-brief.md
@@ -56,11 +56,11 @@ Final leaf task. Its PR closes this child. It may close parent t18124 only when 
 ## Seeded Draft PR
 
 - **Decision:** Skipped
-- **Rationale:** Final report fields, feature flags, and cleanup surfaces do not exist until t18125–t18130 merge.
-- **Status:** `active`
-- **Freshness evidence:** Current telemetry, sweep budget config, webhook config, and test conventions were checked at `313548fc6`.
-- **Verification run:** Brief readiness only; benchmark is unrun.
-- **Stale-assumption warning:** Before implementation, discover every flag/schema/default added by the six preceding PRs and update this issue's exact scope if necessary.
+- **Rationale:** Skipped at planning time because final report fields, feature flags, and cleanup surfaces did not exist before t18125–t18130 merged.
+- **Status:** `not-created`; interactive implementation is active.
+- **Freshness evidence:** Telemetry, shim, benchmark, reference, and test surfaces were rechecked against `659cd3d8f` on 2026-07-20.
+- **Verification run:** Quota instrumentation/shim suites, benchmark/evidence fixtures, ShellCheck, changed lint, and complexity regressions pass; official comparable live evidence remains pending.
+- **Scope refresh:** Direct REST quota attribution paths were added before implementation; ambiguous and GraphQL costs remain fail-closed.
 
 ## How (Approach)
 
@@ -144,19 +144,19 @@ python3 -m json.tool .agents/configs/pulse-sweep-budget.json >/dev/null
 
 ### Recoverability Checkpoint
 
-- [ ] Focused tests pass: benchmark fixtures plus every changed flag owner's focused suite
-- [ ] WIP commit created before broad gates: `wip: benchmark GitHub API efficiency rollout`
-- [ ] Evidence-triggered broad verification then run: `.agents/scripts/linters-local.sh --changed` and final bounded canary
+- [x] Focused tests pass: quota instrumentation/shim suites plus benchmark/evidence fixtures
+- [x] WIP commit created before post-rebase broad gates: `b9e981fd4`
+- [ ] Evidence-triggered broad verification: changed lint passes; final bounded canary remains pending
 
 ### Safety-Stop Recovery
 
 - **Original objective:** Prove and safely finalise lower GitHub API use without correctness or freshness regression.
 - **Preserved user directions:** Compare real baseline/canary evidence, tune incrementally, and let Pulse complete the chain.
 - **Trigger and evidence:** Not triggered at brief creation.
-- **Completed and verified:** Current report/config surfaces and observation requirements identified.
-- **Remaining acceptance criteria:** Final implementation, canary, cleanup, and parent closeout criteria below.
+- **Completed and verified:** Benchmark/report tooling and bounded exact direct REST quota attribution are implemented with focused and changed-file gates passing.
+- **Remaining acceptance criteria:** Comparable live windows, complete sidecars/guardrails, evidence-led tuning or control retention, and parent closeout criteria below.
 - **Unsafe route not to repeat:** Do not compare unequal retained windows, hide unknown quota cost, or delete rollback flags before canary success.
-- **Next safe route:** Produce an inconclusive report, collect a new fixed window, and rerun without closing the task.
+- **Next safe route:** Merge and deploy bounded attribution, collect a new fixed window, and rerun the fail-closed benchmark without closing the task prematurely.
 - **Resume condition:** Dependency met; complete comparable baseline/canary telemetry remains required for final tuning and closeout.
 - **Owner and status:** Build+ `tier:standard`; active and evidence-gated.
 


### PR DESCRIPTION
## Summary

- Attribute exact primary-rate cost for successful, unambiguous direct `gh api` REST requests.
- Record `GET /rate_limit` as zero cost while leaving failed, cached, conditional, enterprise, opaque-pagination, GraphQL, and higher-level CLI requests unknown.
- Preserve the benchmark's zero-unknown comparability gate and document why cumulative GraphQL headers are not safe per-operation evidence.

For #27777

## Implementation

- Add `.agents/scripts/gh-quota-attribution-lib.sh` as a conservative argument/provenance classifier.
- Pass success-only inferred cost through `.agents/scripts/gh` into `.agents/scripts/gh-api-instrument.sh`; explicit operation-owned cost retains precedence.
- Extend shim and instrumentation regression coverage and refresh the t18131 evidence checkpoint.

## Testing

- `bash .agents/scripts/tests/test-gh-api-instrument.sh` — 143 passed.
- `bash .agents/scripts/tests/test-gh-shim.sh` — 62 passed.
- `bash .agents/scripts/tests/test-github-api-efficiency-benchmark.sh` — 35 passed.
- `bash .agents/scripts/tests/test-github-api-efficiency-evidence.sh` — 34 passed.
- `.agents/scripts/linters-local.sh --changed` — passed.
- Function, nesting, Bash 3.2, and file-size complexity regression gates — passed.

## Runtime Testing

`runtime-verified`: the committed worktree shim executed authenticated live `GET /rate_limit` and repository REST requests through the native transport boundary. Private telemetry recorded exact costs `0` and `1`, respectively, while command status and output handling remained intact.

## Decisions

- Do not estimate GraphQL cost from cumulative headers under concurrency.
- Do not treat partial REST attribution as completion of the official benchmark.
- Keep #27777 open for comparable live windows, complete guardrail evidence, and evidence-led control retirement.
- Release is not requested.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.5 spent 3d 19h and 18,393,365 tokens on this with the user in an interactive session. Overall, 5d 20h since this issue was created.
