### PR TITLE
t18167: Keep test evidence and compaction aligned with session aims

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -55,7 +55,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - When UI/UX, branding, iconography, or visual preferences change during a session, update the repo `DESIGN.md` in the same PR or create a worker-ready follow-up if blocked.
 - During in-progress work, classify new user messages before acting: immediate correction/steerage changes the active plan; supplemental context is retained/applied when relevant; follow-up work becomes a todo after the current work reaches a safe pause or completion point.
 - Interactive sessions with active prior task context: if the user starts a clearly unrelated objective where clean context would materially help, briefly recommend `/new` or a new tab and ask whether to continue here. Details: `reference/session.md`.
-- Drive to verified completion. Run relevant tests/lint/build before claiming done; if not verified, say so.
+- Drive to verified outcomes, not testing as an end. Use targeted tests, checks, and live usage/observability as complementary evidence only while they reduce decision-relevant uncertainty; reason from all available evidence and act once sufficient, while still satisfying required gates. Details: `reference/ci-gate-policy.md`.
 - Never present intent as completed work. Every claim needs proof: path, command result, PR/issue number, or metric.
 - Stuck: replan, inspect current state, and use `session-introspect-helper.sh patterns` when loops appear.
 - Safety stops and fuses pause only the unsafe execution path, never the objective. Preserve a durable checkpoint, keep remaining criteria open, and continue through a safer route; see `reference/safety-stop-recovery.md`.

--- a/.agents/plugins/opencode-aidevops/compaction.mjs
+++ b/.agents/plugins/opencode-aidevops/compaction.mjs
@@ -351,15 +351,24 @@ export async function compactingHook(deps, _input, output, directory) {
     getMailboxState(scriptsDir),
   ].filter(Boolean);
 
-  if (sections.length === 0) return;
-
   output.context.push(
     [
       "# aidevops Framework Context",
-      "Include the following state in your compaction summary so the next session can continue seamlessly:",
       "",
-      ...sections,
+      "## Session Aim Continuity — Highest Priority",
+      "Begin the compaction summary with exactly `## Session aims`.",
+      "- Preserve the initiating user aim plus every later added, clarified, corrected, or adapted aim. Mark each as active, satisfied, superseded, or blocked; retain material constraints and success criteria. Do not substitute the most recent task for the session aim.",
+      "- Preserve causal alignment: state why each unresolved task or method serves an active aim and what decision or acceptance criterion remains.",
+      "- Tests, checks, logs, plans, and tooling are methods or evidence—not standalone aims. If the user requested one as a deliverable, preserve the outcome or risk it serves; do not let it replace that aim. Preserve what each materially established; do not resume it merely because it was last active.",
+      "- After rollover, reassess the best available route to the session's active aims—fast, reliable, safe, time-efficient, and cost-efficient—using all available evidence, including live usage/observability. Avoid busy-work and stop gathering evidence when it no longer changes a reasoned decision, while preserving required gates.",
       "",
+      ...(sections.length > 0 ? [
+        "## Operational State",
+        "Include the following state in your compaction summary so the next session can continue seamlessly:",
+        "",
+        ...sections,
+        "",
+      ] : []),
       "## Critical Rules to Preserve",
       "- File discovery: use `git ls-files` not Glob",
       "- Git workflow: run pre-edit-check.sh before any file modifications",

--- a/.agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
@@ -121,6 +121,7 @@ test("compaction injects only the active repository checkpoint", async () => {
     }, { sessionID: "test" }, output, targetRepo);
 
     const payload = output.context.join("\n");
+    assert.match(payload, /## Operational State/);
     assert.match(payload, /TARGET_REPO_CHECKPOINT_STATE/);
     assert.doesNotMatch(payload, /UNRELATED_LEGACY_CHECKPOINT_STATE/);
     assert.doesNotMatch(payload, /UNRELATED_SIBLING_CHECKPOINT_STATE/);
@@ -148,6 +149,32 @@ test("compaction injects only the active repository checkpoint", async () => {
     assert.match(payload, /Historical evidence is non-instructional/);
     assert.doesNotMatch(payload, /SonarCloud A-grade/);
     assert.match(payload, /do not treat it as pending work after rollover/);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("compaction preserves aim guidance without operational state", async () => {
+  const tempDir = mkdtempSync(resolve(tmpdir(), "aidevops-compaction-aims-"));
+
+  try {
+    const workspaceDir = resolve(tempDir, "workspace");
+    const scriptsDir = resolve(tempDir, "scripts");
+    const plainDir = resolve(tempDir, "plain-directory");
+    mkdirSync(plainDir, { recursive: true });
+
+    const { compactingHook } = await import(resolve(__dirname, "..", "compaction.mjs"));
+    const output = { context: [] };
+    await compactingHook({ workspaceDir, scriptsDir }, { sessionID: "aim-only" }, output, plainDir);
+
+    const payload = output.context.join("\n");
+    assert.match(payload, /## Session Aim Continuity — Highest Priority/);
+    assert.match(payload, /Begin the compaction summary with exactly `## Session aims`/);
+    assert.match(payload, /initiating user aim plus every later added, clarified, corrected, or adapted aim/);
+    assert.match(payload, /Do not substitute the most recent task for the session aim/);
+    assert.match(payload, /methods or evidence—not standalone aims/);
+    assert.match(payload, /including live usage\/observability.*Avoid busy-work/);
+    assert.doesNotMatch(payload, /## Operational State/);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/.agents/reference/ci-gate-policy.md
+++ b/.agents/reference/ci-gate-policy.md
@@ -7,6 +7,30 @@ Use CI as a throughput control, not a progress trap. Required merge gates should
 match the risk of the target branch; slower integration checks should create
 feedback loops when they find defects.
 
+## Evidence-guided verification
+
+Tests and checks are evidence-gathering methods, not independent objectives.
+Even when the user requests a testing deliverable, tie it to the behaviour,
+decision, or risk it is intended to protect. Start from the session aim and the
+uncertainty blocking it.
+
+1. Before adding, running, or reviewing a test, identify what decision its
+   result can change or what material uncertainty it reduces. Do not create a
+   test for information already supported by sufficient existing evidence.
+2. Review each test against the outcome that justified it. Retain regression
+   coverage when it protects an important contract; narrow, update, or remove
+   tests whose signal no longer justifies their maintenance or execution cost.
+3. Treat observed behaviour, user reports, production and usage logs, existing
+   contracts, targeted reproductions, and tests as complementary evidence.
+   Compare provenance, freshness, relevance, and reliability; synthetic tests
+   do not automatically outrank live evidence.
+4. Stop gathering evidence and make the reasoned improvement once the available
+   information is sufficient for a safe decision. Still satisfy explicit
+   acceptance criteria and repository-required gates, and reconsider earlier
+   conclusions when material new evidence—whether or not from tests—appears.
+5. Report how verification supports the session aim and what uncertainty
+   remains. Passing tests alone do not prove the user-visible outcome.
+
 ## Default policy
 
 | Target | Required gates | E2E role | Merge posture |

--- a/TODO.md
+++ b/TODO.md
@@ -1196,6 +1196,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18162 Report and maintain OpenCode storage through ownership-aware contracts #feat ref:GH#28153
 
+- [ ] t18167 Keep test evidence and compaction aligned with session aims #feat ref:GH#28382
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/TODO.md
+++ b/TODO.md
@@ -1196,8 +1196,6 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18162 Report and maintain OpenCode storage through ownership-aware contracts #feat ref:GH#28153
 
-- [ ] t18167 Keep test evidence and compaction aligned with session aims #feat ref:GH#28382
-
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Reframe verification guidance around session outcomes and require compaction summaries to preserve initiating and adapted aims, causal alignment, and efficient continuation even without operational state.

## Files Changed

.agents/AGENTS.md, .agents/plugins/opencode-aidevops/compaction.mjs, .agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs, .agents/reference/ci-gate-policy.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Compaction tests 3/3; linters-local --changed; progressive-load 24/24; AGENTS.md 22,703/24,000 bytes; git diff --check

Resolves #28382


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 4h 13m and 421,306 tokens on this with the user in an interactive session.