### PR TITLE
GH#28381: allow canonical ref format validation

### DIFF
--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -22,6 +22,7 @@ READ_ONLY = {
     "show-ref",
     "for-each-ref",
     "cat-file",
+    "check-ref-format",
     "ls-files",
     "ls-remote",
     "ls-tree",

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -160,11 +160,16 @@ else
 	fail "PATH shim left canonical symbolic ref changed"
 fi
 
-if (cd "$REPO" && PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" check-ref-format --branch feature/valid-ref >/dev/null) &&
-	! (cd "$REPO" && PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" check-ref-format --branch "invalid ref" >/dev/null 2>&1); then
+VALID_REF_RC=0
+INVALID_REF_RC=0
+NATIVE_INVALID_REF_RC=0
+git check-ref-format --branch "invalid ref" >/dev/null 2>&1 || NATIVE_INVALID_REF_RC=$?
+(cd "$REPO" && PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" check-ref-format --branch feature/valid-ref >/dev/null) || VALID_REF_RC=$?
+(cd "$REPO" && PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" check-ref-format --branch "invalid ref" >/dev/null 2>&1) || INVALID_REF_RC=$?
+if [[ "$VALID_REF_RC" -eq 0 && "$NATIVE_INVALID_REF_RC" -ne 0 && "$INVALID_REF_RC" -eq "$NATIVE_INVALID_REF_RC" ]]; then
 	pass "PATH shim preserves native ref format validation"
 else
-	fail "PATH shim preserves native ref format validation"
+	fail "PATH shim preserves native ref format validation (valid_rc=${VALID_REF_RC}, invalid_rc=${INVALID_REF_RC}, native_invalid_rc=${NATIVE_INVALID_REF_RC})"
 fi
 
 if (cd "$REPO" && PATH="${SCRIPT_DIR}:$PATH" "$SHIM" switch --detach main >/dev/null 2>&1); then

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -123,6 +123,7 @@ assert_allowed "allows canonical status" "$REPO" "git status --short"
 assert_allowed "allows canonical branch listing" "$REPO" "git branch -vv --no-abbrev"
 assert_allowed "allows canonical branch pattern listing" "$REPO" "git branch --list 'feature/*'"
 assert_allowed "allows canonical branch containment query" "$REPO" "git branch --contains main"
+assert_allowed "allows canonical ref format validation" "$REPO" "git check-ref-format --branch feature/valid-ref"
 assert_allowed "allows canonical ls-remote query" "$REPO" "git ls-remote origin refs/heads/main"
 assert_allowed "allows canonical rev-list tag query" "$REPO" "git rev-list -n 1 HEAD"
 assert_allowed "allows canonical rev-list count query" "$REPO" "git rev-list --count HEAD"
@@ -157,6 +158,13 @@ elif [[ "$(git -C "$REPO" symbolic-ref --short refs/remotes/origin/HEAD)" == "or
 	pass "PATH shim blocks symbolic-ref mutation before execution"
 else
 	fail "PATH shim left canonical symbolic ref changed"
+fi
+
+if (cd "$REPO" && PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" check-ref-format --branch feature/valid-ref >/dev/null) &&
+	! (cd "$REPO" && PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" check-ref-format --branch "invalid ref" >/dev/null 2>&1); then
+	pass "PATH shim preserves native ref format validation"
+else
+	fail "PATH shim preserves native ref format validation"
 fi
 
 if (cd "$REPO" && PATH="${SCRIPT_DIR}:$PATH" "$SHIM" switch --detach main >/dev/null 2>&1); then


### PR DESCRIPTION
## Summary

Classify git check-ref-format as read-only in canonical checkouts and add deployed shim regression coverage for valid and invalid branch names.

## Files Changed

.agents/scripts/canonical_git_policy.py, .agents/scripts/tests/test-canonical-git-command-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 57/57 canonical Git guard tests; 39/39 review-thread scanner tests; 50/50 plugin trust tests; ShellCheck, shfmt, Python AST parse, and linters-local.sh --changed passed.

Resolves #28381


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 15m and 486,524 tokens on this with the user in an interactive session.