### PR TITLE
t18166: fix: stabilize pulse cycle-health fixtures

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -880,7 +880,7 @@ _ch_now_epoch() {
 # Tries macOS date -r syntax first; falls back to GNU date -d.
 _ch_cutoff_ts() {
 	local window_secs="$1"
-	local ts now_epoch cutoff_epoch
+	local ts="" now_epoch="" cutoff_epoch=""
 	now_epoch=$(_ch_now_epoch)
 	cutoff_epoch=$(( now_epoch - window_secs ))
 	if ts=$(date -u -r "$cutoff_epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null); then

--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -859,18 +859,35 @@ _ch_parse_window_secs() {
 	return 0
 }
 
+# Return the current epoch, with a validated test-only clock override.
+_ch_now_epoch() {
+	local override="${PULSE_DIAGNOSE_NOW_EPOCH:-}"
+	local now_epoch
+	if [[ -n "$override" ]]; then
+		if [[ "$override" =~ ^[0-9]+$ ]]; then
+			printf '%s' "$override"
+			return 0
+		fi
+		printf 'warning: ignoring invalid PULSE_DIAGNOSE_NOW_EPOCH override\n' >&2
+	fi
+	now_epoch=$(date '+%s' 2>/dev/null) || now_epoch=0
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || now_epoch=0
+	printf '%s' "$now_epoch"
+	return 0
+}
+
 # Compute ISO 8601 UTC cutoff timestamp (window_secs ago from now).
-# Tries macOS date -v syntax first; falls back to GNU date -d.
+# Tries macOS date -r syntax first; falls back to GNU date -d.
 _ch_cutoff_ts() {
 	local window_secs="$1"
-	local ts
-	if ts=$(date -u -v"-${window_secs}S" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null); then
+	local ts now_epoch cutoff_epoch
+	now_epoch=$(_ch_now_epoch)
+	cutoff_epoch=$(( now_epoch - window_secs ))
+	if ts=$(date -u -r "$cutoff_epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null); then
 		printf '%s' "$ts"
 		return 0
 	fi
-	local now_epoch
-	now_epoch=$(date '+%s' 2>/dev/null) || now_epoch=0
-	if ts=$(date -u -d "@$(( now_epoch - window_secs ))" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null); then
+	if ts=$(date -u -d "@$cutoff_epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null); then
 		printf '%s' "$ts"
 		return 0
 	fi
@@ -885,7 +902,7 @@ _ch_ts_ago() {
 	local ts_epoch now_epoch diff
 	ts_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" '+%s' 2>/dev/null) ||
 		ts_epoch=$(date -u -d "$ts" '+%s' 2>/dev/null) || { printf '%s' "$ts"; return 0; }
-	now_epoch=$(date '+%s' 2>/dev/null) || { printf '%s' "$ts"; return 0; }
+	now_epoch=$(_ch_now_epoch) || { printf '%s' "$ts"; return 0; }
 	diff=$(( now_epoch - ts_epoch ))
 	if [[ "$diff" -lt 60 ]]; then
 		printf '%ds ago' "$diff"

--- a/.agents/scripts/tests/test-pulse-diagnose-cycle-health.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-cycle-health.sh
@@ -67,6 +67,8 @@ trap 'rm -rf "$TMPDIR_TEST"' EXIT
 
 FIXTURE_TIMINGS="${TMPDIR_TEST}/pulse-stage-timings.log"
 FIXTURE_WRAPPER="${TMPDIR_TEST}/pulse-wrapper.log"
+TEST_NOW_EPOCH=1782262800 # 2026-06-24T01:00:00Z
+export PULSE_DIAGNOSE_NOW_EPOCH="$TEST_NOW_EPOCH"
 
 # Build a fixture with two complete and two incomplete cycles.
 #
@@ -75,8 +77,7 @@ FIXTURE_WRAPPER="${TMPDIR_TEST}/pulse-wrapper.log"
 # Cycle 3 (PID 33333) — complete: reaches preflight_early_dispatch exit 0
 # Cycle 4 (PID 44444) — incomplete: cleanup_worktrees exits 124, stops (after last dispatch)
 #
-# All timestamps are recent enough that the default 1h window captures them.
-# We use a fixed reference point relative to "now" via env override + 24h window.
+# The test-only clock override makes the fixed fixture recent in the 24h window.
 
 cat > "$FIXTURE_TIMINGS" <<'TIMINGS'
 2026-06-24T00:00:01Z	cleanup_orphans	2	0	11111


### PR DESCRIPTION
## Summary

Added a validated PULSE_DIAGNOSE_NOW_EPOCH clock override shared by cutoff and age calculations, and pinned the cycle-health fixture clock.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh, .agents/scripts/tests/test-pulse-diagnose-cycle-health.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-pulse-diagnose-cycle-health.sh; shellcheck .agents/scripts/pulse-diagnose-helper.sh .agents/scripts/tests/test-pulse-diagnose-cycle-health.sh; .agents/scripts/linters-local.sh

Resolves #28376


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 9m and 49,678 tokens on this as a headless worker.