### PR TITLE
GH#28295: fix: fail closed on issue-sync completion evidence

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -193,6 +193,9 @@ _is_not_planned_state_reason() {
 _mark_todo_done() {
 	local task_id="$1" todo_file="$2" proof_log="${3:-}"
 	local task_id_ere
+	if [[ -n "$proof_log" && ! "$proof_log" =~ ^verified:[0-9]{4}-[0-9]{2}-[0-9]{2}$ && ! "$proof_log" =~ ^pr:#[0-9]+$ ]]; then
+		return 1
+	fi
 	task_id_ere=$(_escape_ere "$task_id")
 	local today
 	today=$(date -u +%Y-%m-%d)
@@ -202,7 +205,10 @@ _mark_todo_done() {
 	# Use [[:space:]] not \s for macOS sed compatibility (bash 3.2)
 	if grep -qE "^[[:space:]]*- \[[ >]\] ${task_id_ere} " "$todo_file" 2>/dev/null; then
 		# Flip checkbox and append completed: date
-		sed -i.bak -E "s/^([[:space:]]*- )\[[ >]\] (${task_id_ere} .*)/\1[x] \2${proof_log} completed:${today}/" "$todo_file"
+		if ! sed -i.bak -E "s/^([[:space:]]*- )\[[ >]\] (${task_id_ere} .*)/\1[x] \2${proof_log} completed:${today}/" "$todo_file"; then
+			rm -f "${todo_file}.bak"
+			return 1
+		fi
 		rm -f "${todo_file}.bak"
 		_dedupe_todo_task_lines "$task_id" "$todo_file" || true
 		log_verbose "Marked $task_id as [x] in TODO.md"
@@ -215,10 +221,8 @@ _closed_issue_worker_complete_date() {
 	local completed_at
 
 	completed_at=$(gh api "repos/${repo}/issues/${issue_number}/comments" \
-		--jq '[.[] | select((.body // "") | contains("CLAIM_RELEASED reason=worker_complete")) | .created_at][0] // ""' || true)
-	if [[ -z "$completed_at" ]]; then
-		return 1
-	fi
+		--jq '[.[] | select((.body // "") | contains("CLAIM_RELEASED reason=worker_complete")) | .created_at][0] // ""' 2>/dev/null) || return 1
+	[[ "$completed_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || return 1
 	printf '%s\n' "${completed_at%%T*}"
 	return 0
 }
@@ -234,6 +238,7 @@ _closed_issue_aidevops_complete_date() {
 	evidence=$(printf '%s' "$issue_json" | jq -r '[.body // "", (.comments[]?.body // "")] | join("\n---\n")' 2>/dev/null) || evidence=""
 
 	[[ "$state_reason" == "COMPLETED" ]] || return 1
+	[[ "$closed_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || return 1
 	if printf '%s' "$evidence" | grep -qE 'aidevops:sig|CLAIM_RELEASED reason=worker_complete|Task t[0-9]+(\.[0-9]+)* done in TODO\.md|Completed via (\[)?PR #[0-9]+'; then
 		printf '%s\n' "${closed_at%%T*}"
 		return 0
@@ -247,7 +252,7 @@ _mark_reopen_completed_task() {
 		print_info "[DRY-RUN] Would mark $tid [x] ($reason on #$ref_num)"
 		return 0
 	fi
-	_mark_todo_done "$tid" "$todo_file" "verified:${proof_date}"
+	_mark_todo_done "$tid" "$todo_file" "verified:${proof_date}" || return 1
 	log_verbose "#$ref_num ($tid) has $reason — marked TODO [x]"
 	return 0
 }
@@ -259,7 +264,7 @@ _mark_reopen_merged_pr_task() {
 		return 0
 	fi
 	add_pr_ref_to_todo "$tid" "$pr_num" "$todo_file" 2>/dev/null || true
-	_mark_todo_done "$tid" "$todo_file"
+	_mark_todo_done "$tid" "$todo_file" || return 1
 	log_verbose "#$ref_num ($tid) has merged PR #$pr_num — marked TODO [x]"
 	return 0
 }
@@ -311,20 +316,20 @@ _reopen_mark_if_completed() {
 	pr_info=$(_reopen_find_merged_pr "$repo" "$tid" "$ref_num" 2>/dev/null || true)
 	if [[ -n "$pr_info" ]]; then
 		local pr_num="${pr_info%%|*}"
-		_mark_reopen_merged_pr_task "$tid" "$todo_file" "$ref_num" "$pr_num"
+		_mark_reopen_merged_pr_task "$tid" "$todo_file" "$ref_num" "$pr_num" || return 1
 		return 0
 	fi
 
 	local completed_date
 	completed_date=$(_closed_issue_worker_complete_date "$repo" "$ref_num" || true)
 	if [[ -n "$completed_date" ]]; then
-		_mark_reopen_completed_task "$tid" "$todo_file" "$ref_num" "$completed_date" "worker_complete evidence"
+		_mark_reopen_completed_task "$tid" "$todo_file" "$ref_num" "$completed_date" "worker_complete evidence" || return 1
 		return 0
 	fi
 
 	completed_date=$(_closed_issue_aidevops_complete_date "$repo" "$ref_num" || true)
 	if [[ -n "$completed_date" ]]; then
-		_mark_reopen_completed_task "$tid" "$todo_file" "$ref_num" "$completed_date" "aidevops close evidence"
+		_mark_reopen_completed_task "$tid" "$todo_file" "$ref_num" "$completed_date" "aidevops close evidence" || return 1
 		return 0
 	fi
 	return 1

--- a/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
+++ b/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
@@ -40,12 +40,24 @@ gh_find_merged_pr() {
 	return 0
 }
 gh() {
+	if [[ "$*" == *"issues/125/comments"* ]]; then
+		printf '%s\n' '{"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}'
+		return 1
+	fi
+	if [[ "$*" == *"issues/126/comments"* ]]; then
+		printf '%s\n' 'not-a-timestamp'
+		return 0
+	fi
 	if [[ "$*" == *"issue view 123"* ]]; then
 		printf '%s\n' '{"state":"CLOSED","stateReason":"COMPLETED","closedAt":"2026-06-30T01:53:39Z","body":"Completed interactively.\n<!-- aidevops:sig -->","comments":[]}'
 		return 0
 	fi
 	if [[ "$*" == *"issue view 124"* ]]; then
 		printf '%s\n' '{"state":"CLOSED","stateReason":"COMPLETED","closedAt":"2026-06-30T01:53:39Z","body":"Closed without aidevops evidence.","comments":[]}'
+		return 0
+	fi
+	if [[ "$*" == *"issue view 127"* ]]; then
+		printf '%s\n' '{"state":"CLOSED","stateReason":"COMPLETED","closedAt":"not-a-timestamp","body":"<!-- aidevops:sig -->","comments":[]}'
 		return 0
 	fi
 	return 1
@@ -145,6 +157,41 @@ if _closed_issue_aidevops_complete_date "owner/repo" "124" >/dev/null; then
 else
 	pass "closed issue without aidevops evidence is not completion evidence"
 fi
+
+if completed_date=$(_closed_issue_worker_complete_date "owner/repo" "125"); then
+	fail "failed GitHub lookup is not worker completion evidence"
+elif [[ -n "$completed_date" ]]; then
+	fail "failed GitHub lookup must not emit its JSON response body"
+else
+	pass "failed GitHub lookup emits no worker completion date"
+fi
+
+if _closed_issue_worker_complete_date "owner/repo" "126" >/dev/null; then
+	fail "malformed worker timestamp is not completion evidence"
+else
+	pass "malformed worker timestamp is rejected"
+fi
+
+if _closed_issue_aidevops_complete_date "owner/repo" "127" >/dev/null; then
+	fail "malformed issue close timestamp is not completion evidence"
+else
+	pass "malformed issue close timestamp is rejected"
+fi
+
+todo_file=$(mktemp)
+printf '%s\n' '- [ ] t9010 retry failed completion lookup ref:GH#125' >"$todo_file"
+todo_before=$(<"$todo_file")
+_reopen_find_merged_pr() {
+	return 1
+}
+if _reopen_mark_if_completed "owner/repo" "t9010" "125" "$todo_file"; then
+	fail "failed completion lookup does not mark reopened task complete"
+elif [[ "$(<"$todo_file")" != "$todo_before" ]]; then
+	fail "failed completion lookup changed reopened TODO content"
+else
+	pass "failed completion lookup leaves reopened TODO content unchanged"
+fi
+rm -f "$todo_file"
 
 if [[ "$FAIL" -eq 0 ]]; then
 	printf 'All %d tests passed\n' "$PASS"

--- a/.agents/tests/test-task-sync-dedupe.sh
+++ b/.agents/tests/test-task-sync-dedupe.sh
@@ -82,6 +82,44 @@ test_mark_done_completes_in_progress_entry() {
 	return 0
 }
 
+test_mark_done_rejects_malformed_proof() {
+	local tmpdir todo_file before
+	tmpdir=$(mktemp -d)
+	todo_file="${tmpdir}/TODO.md"
+	printf '%s\n' '- [ ] t18002 active task ref:GH#25539' >"$todo_file"
+	before=$(<"$todo_file")
+	if _mark_todo_done "t18002" "$todo_file" 'verified:https://docs.github.com/rest'; then
+		fail "expected malformed proof to fail"
+	fi
+	[[ "$(<"$todo_file")" == "$before" ]] || fail "malformed proof changed TODO content"
+	rm -rf "$tmpdir"
+	pass "mark done rejects malformed proof without mutation"
+	return 0
+}
+
+test_mark_done_propagates_sed_failure() {
+	local tmpdir todo_file before
+	tmpdir=$(mktemp -d)
+	todo_file="${tmpdir}/TODO.md"
+	printf '%s\n' '- [ ] t18002 active task ref:GH#25539' >"$todo_file"
+	before=$(<"$todo_file")
+	sed() {
+		local arg="$1"
+		: "$arg"
+		cp "$todo_file" "${todo_file}.bak"
+		return 1
+	}
+	if _mark_todo_done "t18002" "$todo_file" "pr:#25540"; then
+		fail "expected sed mutation failure to propagate"
+	fi
+	unset -f sed
+	[[ "$(<"$todo_file")" == "$before" ]] || fail "failed sed mutation changed TODO content"
+	[[ ! -e "${todo_file}.bak" ]] || fail "failed sed mutation left backup behind"
+	rm -rf "$tmpdir"
+	pass "mark done propagates sed failure and removes backup"
+	return 0
+}
+
 test_dedupe_ignores_markdown_fences() {
 	local tmpdir todo_file count fenced_count canonical_count
 	tmpdir=$(mktemp -d)
@@ -303,6 +341,8 @@ main() {
 	test_dedupe_preserves_canonical_brief_line
 	test_mark_done_dedupes_and_adds_verified_proof
 	test_mark_done_completes_in_progress_entry
+	test_mark_done_rejects_malformed_proof
+	test_mark_done_propagates_sed_failure
 	test_dedupe_ignores_markdown_fences
 	test_dedupe_scores_metadata_individually
 	test_status_counts_duplicate_task_rows_once


### PR DESCRIPTION
## Summary

Reject failed or malformed completion timestamps and proof tokens, propagate TODO mutation failures, and cover GitHub 404 JSON output without mutating TODO.md.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh, .agents/scripts/tests/test-issue-sync-completion-evidence.sh, .agents/tests/test-task-sync-dedupe.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-issue-sync-completion-evidence.sh; bash .agents/tests/test-task-sync-dedupe.sh; shellcheck .agents/scripts/issue-sync-helper-close.sh .agents/scripts/tests/test-issue-sync-completion-evidence.sh .agents/tests/test-task-sync-dedupe.sh; LINTERS_LOCAL_BROAD_GATE_TIMEOUT_SECONDS=300 .agents/scripts/linters-local.sh --changed

Resolves #28295


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 22m and 76,086 tokens on this as a headless worker.