### PR TITLE
GH#28387: use effective checks for stuck merge outages

### DIFF
--- a/.agents/hooks/pre-push-dup-todo-guard.sh
+++ b/.agents/hooks/pre-push-dup-todo-guard.sh
@@ -4,8 +4,10 @@
 #
 # pre-push-dup-todo-guard.sh — git pre-push hook (t2745).
 #
-# Blocks a push when TODO.md on the pushed commit contains two or more
-# checkbox lines with the same task ID.
+# Blocks a push when TODO.md on the pushed commit introduces a duplicate task
+# ID or increases the occurrence count of a duplicate already present in the
+# remote baseline. Pre-existing duplicates therefore do not block unrelated
+# branches, while any regression remains fail-closed.
 # Example duplicate: two lines starting with "- [ ] t2743 " or "- [x] t2743 ".
 #
 # Root cause this catches: _seed_orphan_todo_line (issue-sync) appends a
@@ -54,12 +56,50 @@ _dbg() {
 	return 0
 }
 
+_compute_baseline() {
+	local _remote="$1"
+	local _local_sha="$2"
+	local _remote_sha="$3"
+	local _candidate
+	local _default_remote_head=""
+	local _baseline=""
+
+	if [[ -n "$_remote_sha" ]] && ! [[ "$_remote_sha" =~ $_zero_sha_pattern ]]; then
+		if git cat-file -e "${_remote_sha}^{commit}" 2>/dev/null; then
+			printf '%s\n' "$_remote_sha"
+			return 0
+		fi
+	fi
+
+	[[ -n "$_remote" ]] || _remote="origin"
+	_default_remote_head=$(git symbolic-ref "refs/remotes/${_remote}/HEAD" 2>/dev/null \
+		| sed "s@^refs/remotes/${_remote}/@@")
+	if [[ -n "$_default_remote_head" ]]; then
+		_default_remote_head="${_remote}/${_default_remote_head}"
+	else
+		for _candidate in "${_remote}/main" "${_remote}/master"; do
+			if git rev-parse --verify "$_candidate" >/dev/null 2>&1; then
+				_default_remote_head="$_candidate"
+				break
+			fi
+		done
+	fi
+
+	[[ -n "$_default_remote_head" ]] || return 1
+	_baseline=$(git merge-base "$_local_sha" "$_default_remote_head" 2>/dev/null) || return 1
+	[[ -n "$_baseline" ]] || return 1
+	printf '%s\n' "$_baseline"
+	return 0
+}
+
 if [[ "${DUP_TODO_GUARD_DISABLE:-0}" == "1" ]]; then
 	_log WARN "DUP_TODO_GUARD_DISABLE=1 — bypassing duplicate TODO check (audit trail: override active)"
 	exit 0
 fi
 
 _exit_code=0
+
+_remote_name="${1:-origin}"
 
 # Pattern for zero-SHA (branch deletion). Use a variable so [[ =~ ]] works
 # consistently across Bash 3.2 (macOS default) and later versions.
@@ -111,9 +151,49 @@ while IFS=' ' read -r _local_ref _local_sha _remote_ref _remote_sha; do
 		continue
 	fi
 
+	# Compare duplicate occurrence counts with the remote baseline. This is a
+	# ratchet: unchanged legacy duplicates are tolerated, but a new duplicate
+	# or an increased count remains blocking. If no baseline can be resolved,
+	# retain the original fail-closed full-snapshot behaviour.
+	_base_task_ids=""
+	_base_sha=""
+	if _base_sha=$(_compute_baseline "$_remote_name" "$_local_sha" "${_remote_sha:-}"); then
+		if git cat-file -e "${_base_sha}:TODO.md" 2>/dev/null; then
+			_base_content=$(git show "${_base_sha}:TODO.md" 2>/dev/null) || _base_content=""
+			if [[ -n "$_base_content" ]]; then
+				_base_task_ids=$(printf '%s\n' "$_base_content" \
+					| grep -E '^[[:space:]]*- \[.\] t[0-9]+(\.[0-9]+)*([[:space:]]|$)' \
+					| sed 's/^[[:space:]]*- \[.\] \(t[0-9][0-9.]*\).*/\1/')
+			fi
+		fi
+		_dbg "baseline for ${_local_ref}: ${_base_sha}"
+	else
+		_dbg "no baseline resolved for ${_local_ref} — enforcing full duplicate scan"
+	fi
+
+	_increased_duplicates=""
+	while IFS= read -r _dup_id; do
+		[[ -n "$_dup_id" ]] || continue
+		_head_count=$(printf '%s\n' "$_task_ids" | grep -Fxc "$_dup_id" || true)
+		_base_count=0
+		if [[ -n "$_base_task_ids" ]]; then
+			_base_count=$(printf '%s\n' "$_base_task_ids" | grep -Fxc "$_dup_id" || true)
+		fi
+		if [[ "$_head_count" -gt "$_base_count" ]]; then
+			_increased_duplicates="${_increased_duplicates}${_increased_duplicates:+$'\n'}${_dup_id}"
+		else
+			_dbg "grandfathering unchanged duplicate ${_dup_id} (${_head_count} occurrences)"
+		fi
+	done <<<"$_duplicates"
+
+	if [[ -z "$_increased_duplicates" ]]; then
+		continue
+	fi
+	_duplicates="$_increased_duplicates"
+
 	# Found duplicates — block and report line numbers for each.
 	_exit_code=1
-	printf '\n[%s][BLOCK] Push blocked: duplicate task IDs in TODO.md\n\n' "$GUARD_NAME" >&2
+	printf '\n[%s][BLOCK] Push blocked: new or increased duplicate task IDs in TODO.md\n\n' "$GUARD_NAME" >&2
 
 	printf '%s\n' "$_duplicates" | while IFS= read -r _dup_id; do
 		[[ -z "$_dup_id" ]] && continue

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -202,7 +202,7 @@ _pms_is_eligible_stuck() {
 }
 
 #######################################
-# Fetch normalized REST check-runs for a PR head SHA.
+# Fetch the effective normalized check set for a PR head SHA.
 # Args: $1 = repo_slug, $2 = head SHA
 # Stdout: JSON array, [] on missing helper/API failure
 #######################################
@@ -210,7 +210,14 @@ _pms_check_runs_for_head() {
 	local repo_slug="$1"
 	local head_sha="$2"
 	local runs=""
-	if [[ -n "$repo_slug" && -n "$head_sha" ]] && declare -F gh_pr_check_runs_rest >/dev/null 2>&1; then
+	# The merge preflight snapshot collapses superseded runs and logical aliases
+	# to their effective current-head result. Prefer it so an old cancelled or
+	# failed run cannot make a subsequently successful PR look broken forever.
+	# pulse-merge.sh is sourced before this module in production; the REST helper
+	# remains the standalone/test fallback.
+	if [[ -n "$repo_slug" && -n "$head_sha" ]] && declare -F _pmrc_snapshot_checks_json >/dev/null 2>&1; then
+		runs=$(_pmrc_snapshot_checks_json "$repo_slug" "$head_sha" 2>/dev/null) || runs=""
+	elif [[ -n "$repo_slug" && -n "$head_sha" ]] && declare -F gh_pr_check_runs_rest >/dev/null 2>&1; then
 		runs=$(gh_pr_check_runs_rest "$repo_slug" "$head_sha" 2>/dev/null) || runs=""
 	fi
 	[[ -n "$runs" && "$runs" != "null" ]] || runs="[]"
@@ -602,6 +609,22 @@ The existing rebase-nudge family (\`_post_rebase_nudge_on_interactive_conflictin
 # ── Pattern-cluster outage detector ─────────────────────────────────────────
 
 #######################################
+# Format a comma-separated PR list as Markdown bullets. The explicit trailing
+# newline ensures the final PR is consumed by read instead of disappearing at
+# EOF when the input has no trailing comma.
+# Args: $1=comma-separated PR numbers
+#######################################
+_pms_format_pr_markdown_list() {
+	local prs="$1"
+	local pr=""
+	printf '%s\n' "$prs" | tr ',' '\n' | while IFS= read -r pr; do
+		[[ "$pr" =~ ^[0-9]+$ ]] || continue
+		printf -- '- #%s\n' "$pr"
+	done
+	return 0
+}
+
+#######################################
 # Group all stuck PRs in the repo by failure fingerprint. If ≥ AIDEVOPS_MERGE_PATTERN_MIN_PRS
 # share an identical fingerprint, file ONE investigation issue per outage signature.
 # Dedup'd by the fingerprint hash so the same outage doesn't re-file every cycle.
@@ -705,7 +728,7 @@ This is a broken-base outage signal — multiple unrelated PRs failing the same 
 
 ## Affected PRs
 
-$(printf '%s' "$prs" | tr ',' '\n' | while read -r p; do printf -- '- #%s\n' "$p"; done)
+$(_pms_format_pr_markdown_list "$prs")
 
 ## Why
 
@@ -858,7 +881,7 @@ Per-PR escalation comments are SUPPRESSED for these PRs while saturation persist
 
 ## Affected PRs
 
-$(printf '%s' "$affected_prs" | tr ',' '\n' | while read -r p; do [[ -n "$p" ]] && printf -- '- #%s\n' "$p"; done)
+$(_pms_format_pr_markdown_list "$affected_prs")
 
 ## Why
 

--- a/.agents/scripts/tests/test-pre-push-dup-todo-guard.sh
+++ b/.agents/scripts/tests/test-pre-push-dup-todo-guard.sh
@@ -4,7 +4,7 @@
 #
 # test-pre-push-dup-todo-guard.sh — Unit tests for pre-push-dup-todo-guard.sh (t2745).
 #
-# Tests 9 fixtures:
+# Tests 11 fixtures:
 #   1. Clean TODO.md (no duplicates)               → exit 0
 #   2. Single duplicate (t2743 twice)              → exit 1, cites lines
 #   3. Multiple duplicates (t2743 AND t2742)       → exit 1, cites both IDs
@@ -14,6 +14,8 @@
 #   7. --no-verify bypass documentation            → informational (git-level bypass)
 #   8. Hierarchical ID duplicate (t1271.1 twice)   → exit 1, cites lines
 #   9. Indented subtask duplicate                  → exit 1, cites lines
+#  10. Unchanged pre-existing duplicate            → exit 0
+#  11. Increased pre-existing duplicate count      → exit 1
 #
 # Usage: bash .agents/scripts/tests/test-pre-push-dup-todo-guard.sh
 # Exit 0 = all tests passed. Exit 1 = one or more tests failed.
@@ -50,6 +52,7 @@ fi
 _TESTS_PASSED=0
 _TESTS_FAILED=0
 _TEST_TMPDIR=""
+_BASE_SHA=""
 
 _setup_git_repo() {
 	_TEST_TMPDIR=$(mktemp -d)
@@ -66,6 +69,7 @@ _setup_git_repo() {
 	touch TODO.md
 	git add TODO.md
 	git commit -q -m "init"
+	_BASE_SHA=$(git rev-parse HEAD)
 	return 0
 }
 
@@ -73,6 +77,7 @@ _teardown_git_repo() {
 	cd / 2>/dev/null || true
 	[[ -n "${_TEST_TMPDIR:-}" && -d "$_TEST_TMPDIR" ]] && rm -rf "$_TEST_TMPDIR"
 	_TEST_TMPDIR=""
+	_BASE_SHA=""
 	return 0
 }
 
@@ -92,14 +97,23 @@ _commit_todo() {
 _run_hook() {
 	local _sha="$1"
 	local _extra_env="${2:-}"
+	local _remote_sha="${3:-$_BASE_SHA}"
 	local _stdin
-	_stdin="refs/heads/test ${_sha} refs/heads/main 0000000000000000000000000000000000000000"
+	_stdin="refs/heads/test ${_sha} refs/heads/main ${_remote_sha}"
 	if [[ -n "$_extra_env" ]]; then
 		env "$_extra_env" bash "$HOOK" origin "https://github.com/test/repo" <<<"$_stdin"
 	else
 		bash "$HOOK" origin "https://github.com/test/repo" <<<"$_stdin"
 	fi
 	return $?
+}
+
+_commit_unrelated() {
+	printf 'unrelated\n' >"$_TEST_TMPDIR/unrelated.txt"
+	git add unrelated.txt
+	git commit -q -m "unrelated change"
+	git rev-parse HEAD
+	return 0
 }
 
 _pass() {
@@ -420,6 +434,73 @@ test_indented_subtask_duplicate() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 10: an unchanged duplicate already present in the baseline → exit 0
+# ---------------------------------------------------------------------------
+test_unchanged_preexisting_duplicate() {
+	local _name="test_10_unchanged_preexisting_duplicate"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _content
+	_content="## Ready
+- [ ] t2743 First entry ref:GH#20480
+
+## Backlog
+- [ ] t2743 Existing duplicate ref:GH#20480"
+
+	local _duplicate_base _sha
+	_duplicate_base=$(_commit_todo "$_content")
+	_sha=$(_commit_unrelated)
+	_run_hook "$_sha" "" "$_duplicate_base" 2>/dev/null
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -eq 0 ]]; then
+		_pass "$_name"
+	else
+		_fail "$_name" "expected exit 0 for unchanged baseline duplicate, got exit $_rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 11: increasing a duplicate count relative to the baseline → exit 1
+# ---------------------------------------------------------------------------
+test_increased_preexisting_duplicate() {
+	local _name="test_11_increased_preexisting_duplicate"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _base_content _head_content
+	_base_content="## Ready
+- [ ] t2743 First entry ref:GH#20480
+
+## Backlog
+- [ ] t2743 Existing duplicate ref:GH#20480"
+	_head_content="${_base_content}
+- [ ] t2743 Newly added third entry ref:GH#20480"
+
+	local _duplicate_base _sha
+	_duplicate_base=$(_commit_todo "$_base_content")
+	_sha=$(_commit_todo "$_head_content")
+	local _stderr
+	_stderr=$(_run_hook "$_sha" "" "$_duplicate_base" 2>&1 1>/dev/null)
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -ne 1 ]]; then
+		_fail "$_name" "expected exit 1 for increased duplicate count, got exit $_rc"
+		return 0
+	fi
+	if printf '%s\n' "$_stderr" | grep -q "t2743"; then
+		_pass "$_name"
+	else
+		_fail "$_name" "error message did not mention t2743; stderr: $_stderr"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
@@ -434,6 +515,8 @@ main() {
 	test_no_verify_documentation
 	test_hierarchical_id_duplicate
 	test_indented_subtask_duplicate
+	test_unchanged_preexisting_duplicate
+	test_increased_preexisting_duplicate
 
 	printf '\n'
 	printf 'Results: %d passed, %d failed\n' "$_TESTS_PASSED" "$_TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -24,8 +24,10 @@
 #      crypto-approval, stale merged PR-list entries, and unknown authors that
 #      must not bypass the collaborator check) and keeps processing when GitHub
 #      returns a null PR author for deleted users.
-#   8. _detect_pattern_outage de-duplicates repeated PR observations.
-#   9. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
+#   8. Effective preflight snapshots suppress superseded check-run failures.
+#   9. _detect_pattern_outage de-duplicates repeated PR observations and
+#      generated Markdown includes the final affected PR.
+#  10. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
 #
 # The test never makes real network calls; functions that require gh API
 # (_classify_stuck_pr, _escalate_individual_stuck_pr, full pulse_merge_stuck_run_pass)
@@ -613,6 +615,7 @@ gh_pr_view() {
 	207) printf 'sha-legacy-error' ;;
 	208) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean-ruleset"}' ;;
 	209) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean-ruleset-fail"}' ;;
+	210) printf 'sha-superseded-failure' ;;
 	*) printf '{"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha-clean"}' ;;
 	esac
 	return 0
@@ -627,6 +630,7 @@ gh_pr_check_runs_rest() {
 	sha-failing) printf '[{"name":"Format","conclusion":"failure","status":"completed"},{"name":"Lint","conclusion":"timed_out","status":"completed"}]' ;;
 	sha-legacy-failing) printf '[{"context":"legacy-ci","state":"failure"}]' ;;
 	sha-legacy-error) printf '[{"context":"legacy-error","state":"error"}]' ;;
+	sha-superseded-failure) printf '[{"name":"gate / Maintainer Review & Assignee Gate","conclusion":"cancelled","status":"completed"}]' ;;
 	*) printf '[]' ;;
 	esac
 	return 0
@@ -714,6 +718,18 @@ assert_eq "7i: ruleset helper failure reports branch-protection API error" \
 	"STUCK_BRANCHPROTECT_API_ERROR" "$got"
 assert_eq "7j: ruleset helper failure propagates helper exit code" \
 	"7" "$ruleset_fail_rc"
+
+_pmrc_snapshot_checks_json() {
+	local repo_slug="$1"
+	local head_sha="$2"
+	[[ -n "$repo_slug" && -n "$head_sha" ]] || return 1
+	printf '[{"name":"maintainer-gate","conclusion":"success","status":"completed"}]'
+	return 0
+}
+
+got=$(_pms_failure_fingerprint "210" "example/repo")
+assert_eq "7k: effective snapshot suppresses superseded check-run failure" "" "$got"
+unset -f _pmrc_snapshot_checks_json
 echo ""
 
 # ---------------------------------------------------------------------------
@@ -747,6 +763,10 @@ _detect_pattern_outage "example/repo" $'11\n11\n12\n'
 assert_eq "7a: duplicate PR observations counted once" \
 	"example/repo|2|E2E Shard 1/4,E2E Shard 2/4|11,12" \
 	"$PMS_TEST_OUTAGE_ARGS"
+
+got=$(_pms_format_pr_markdown_list "11,12,13")
+assert_eq "7b: affected-PR Markdown retains the final entry" \
+	$'- #11\n- #12\n- #13' "$got"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Normalize merge-stuck fingerprints through the latest effective required-check snapshot so superseded failures do not create false broken-base outages.
- Render affected PR lists through one newline-safe formatter so the final PR is never omitted.
- Ratchet the duplicate-TODO pre-push guard against the remote baseline, allowing unchanged legacy duplicates while still blocking new or increased collisions.

## Testing

- `bash .agents/scripts/tests/test-pulse-merge-stuck.sh`
- `bash .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh`
- `env PATH=/usr/bin:/bin bash .agents/scripts/tests/test-pre-push-dup-todo-guard.sh`
- `shellcheck .agents/scripts/pulse-merge-stuck.sh .agents/scripts/tests/test-pulse-merge-stuck.sh .agents/hooks/pre-push-dup-todo-guard.sh .agents/scripts/tests/test-pre-push-dup-todo-guard.sh`
- `bun run typecheck`
- `git diff --check`

Resolves #28387

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 28m and 725,575 tokens on this as a headless worker.