### PR TITLE
t18168: Harden Pulse PR lifecycle-state normalization at merge boundaries

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -99,6 +99,31 @@ readonly _PMP_BACKLOG_OTHER="other"
 # --- Functions ---
 
 #######################################
+# Normalize known PR lifecycle states from mixed GitHub API paths.
+#
+# GraphQL emits uppercase enums while REST and cached projections can emit
+# lowercase strings. Preserve unknown values so exact-state consumers still
+# fail closed instead of accepting an unrecognised lifecycle state (t18168).
+#
+# Args: $1=destination variable name, $2=raw lifecycle state
+#######################################
+_pmp_normalize_pr_lifecycle_state_into() {
+	local dest_var="$1"
+	local raw_state="$2"
+	local normalized_state=""
+
+	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	case "$raw_state" in
+	[Oo][Pp][Ee][Nn]) normalized_state="OPEN" ;;
+	[Cc][Ll][Oo][Ss][Ee][Dd]) normalized_state="CLOSED" ;;
+	[Mm][Ee][Rr][Gg][Ee][Dd]) normalized_state="MERGED" ;;
+	*) normalized_state="$raw_state" ;;
+	esac
+	printf -v "$dest_var" '%s' "$normalized_state"
+	return 0
+}
+
+#######################################
 # Normalize PR mergeable values from mixed GitHub API paths.
 #
 # gh GraphQL returns MERGEABLE/CONFLICTING/UNKNOWN, while REST fallback and

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1266,6 +1266,7 @@ _process_single_ready_pr() {
 		printf '%s' "$pr_obj" | jq -r --arg unknown "$PULSE_UNKNOWN_STATE" \
 			'"\(.number // "")\u001e\(.state // "")\u001e\(.mergeable // $unknown)\u001e\(if ((has("reviewDecision") | not) or .reviewDecision == null or (.reviewDecision | tostring | length) == 0) then $unknown else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")\u001e\(.updatedAt // "")\u001e\(.headRefOid // "")\u001e\(.headRefName // "")\u001e\(.baseRefName // "")\u001e\([(.labels // [])[].name] | join(","))\u001e\(.isDraft // false | tostring)"'
 	)
+	_pmp_normalize_pr_lifecycle_state_into pr_state "$pr_state"
 	_pmp_normalize_mergeable_state_into pr_mergeable "$pr_mergeable"
 	_pmp_normalize_review_decision_into pr_review "$pr_review"
 	[[ -n "$timing_prefix" ]] && _mergeability_start=$(_pmp_now_epoch)
@@ -1758,6 +1759,7 @@ process_pr() {
 	# Verify state is OPEN — closed/merged PRs should not be re-processed.
 	local pr_state
 	pr_state=$(printf '%s' "$pr_obj" | jq -r '.state // ""' 2>/dev/null) || pr_state=""
+	_pmp_normalize_pr_lifecycle_state_into pr_state "$pr_state"
 	if [[ "$pr_state" != "OPEN" ]]; then
 		echo "[pulse-merge] process_pr: PR ${repo_slug}#${pr_number} is not OPEN (state=${pr_state}) — skipping" >>"$LOGFILE"
 		return 1

--- a/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
@@ -97,19 +97,23 @@ test_callers_use_shared_field_helper() {
 }
 
 test_process_pr_runtime_reuses_one_view() {
-	local helper_src process_src call_log payload_log log_file call_count payload failure=""
+	local helper_src normalize_src process_src call_log payload_log log_file call_count payload failure=""
 	helper_src=$(awk '
 		/^_pulse_merge_ready_pr_json_fields\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
+	normalize_src=$(awk '
+		/^_pmp_normalize_pr_lifecycle_state_into\(\) \{/,/^}$/ { print }
+	' "$MERGE_PROCESS")
 	process_src=$(awk '
 		/^process_pr\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
-	if [[ -z "$helper_src" || -z "$process_src" ]]; then
+	if [[ -z "$helper_src" || -z "$normalize_src" || -z "$process_src" ]]; then
 		print_result "process_pr runtime source exists" 1 "could not extract helper functions"
 		return 0
 	fi
 	# shellcheck disable=SC1090 # Test intentionally evaluates extracted functions.
 	eval "$helper_src"
+	eval "$normalize_src"
 	eval "$process_src"
 
 	call_log=$(mktemp)
@@ -117,16 +121,16 @@ test_process_pr_runtime_reuses_one_view() {
 	log_file=$(mktemp)
 	PROCESS_PR_TEST_CALL_LOG="$call_log"
 	PROCESS_PR_TEST_PAYLOAD_LOG="$payload_log"
-	PROCESS_PR_TEST_STATE="OPEN"
+	PROCESS_PR_TEST_STATE="open"
 	LOGFILE="$log_file"
 
 	if ! process_pr "owner/repo" "42"; then
-		failure="process_pr rejected an OPEN prefetched state"
+		failure="process_pr rejected a lowercase open prefetched state"
 	else
 		call_count=$(wc -l <"$call_log" | tr -d ' ')
 		payload=$(<"$payload_log")
 		[[ "$call_count" == "1" ]] || failure="gh_pr_view calls=${call_count}"
-		[[ "$payload" == *'"state":"OPEN"'* ]] || failure="prefetched state was not forwarded"
+		[[ "$payload" == *'"state":"open"'* ]] || failure="prefetched state was not forwarded"
 	fi
 	if [[ -z "$failure" ]]; then
 		: >"$call_log"

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+MERGE_PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -162,19 +163,27 @@ teardown_test_env() {
 
 define_function_under_test() {
 	local src_invalidate
+	local src_normalize_pr_state
 	local src_terminal
 	local src_process
+	local src_webhook_process
 	src_invalidate=$(awk '
 		/^_pulse_merge_invalidate_pr_list_cache\(\) \{/,/^\}$/ { print }
 	' "$MERGE_SCRIPT")
+	src_normalize_pr_state=$(awk '
+		/^_pmp_normalize_pr_lifecycle_state_into\(\) \{/,/^\}$/ { print }
+	' "$MERGE_PROCESS_SCRIPT")
 	src_terminal=$(awk '
 		/^_pulse_merge_failure_is_terminal\(\) \{/,/^\}$/ { print }
 	' "$MERGE_SCRIPT")
 	src_process=$(awk '
 		/^_process_single_ready_pr\(\) \{/,/^\}$/ { print }
 	' "$MERGE_SCRIPT")
-	if [[ -z "$src_invalidate" || -z "$src_terminal" || -z "$src_process" ]]; then
-		printf 'ERROR: could not extract cache invalidation, terminal-state, or process helper from %s\n' "$MERGE_SCRIPT" >&2
+	src_webhook_process=$(awk '
+		/^process_pr\(\) \{/,/^\}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$src_invalidate" || -z "$src_normalize_pr_state" || -z "$src_terminal" || -z "$src_process" || -z "$src_webhook_process" ]]; then
+		printf 'ERROR: could not extract merge helpers from %s and %s\n' "$MERGE_SCRIPT" "$MERGE_PROCESS_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090
@@ -182,9 +191,13 @@ define_function_under_test() {
 	# shellcheck disable=SC1090
 	eval "$src_invalidate"
 	# shellcheck disable=SC1090
+	eval "$src_normalize_pr_state"
+	# shellcheck disable=SC1090
 	eval "$src_terminal"
 	# shellcheck disable=SC1090
 	eval "$src_process"
+	# shellcheck disable=SC1090
+	eval "$src_webhook_process"
 	return 0
 }
 
@@ -242,7 +255,22 @@ _handle_post_merge_actions() {
 	printf 'post-merge\n' >>"$MERGE_EVENT_LOG"
 	return 0
 }
-gh_pr_view() { printf '{"labels":[]}'; return 0; }
+_pulse_merge_ready_pr_json_fields() {
+	printf 'number,state,mergeable,reviewDecision,author,title,updatedAt,headRefOid,headRefName,baseRefName,labels,isDraft'
+	return 0
+}
+
+gh_pr_view() {
+	local pr_number="$1"
+	shift
+	if [[ -n "${PR_VIEW_STATE:-}" ]]; then
+		printf '{"number":%s,"state":"%s","mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"webhook test","headRefOid":"head-current"}' \
+			"$pr_number" "$PR_VIEW_STATE"
+		return 0
+	fi
+	printf '{"labels":[]}'
+	return 0
+}
 
 pulse_pr_list_cache_invalidate_repo() {
 	local repo_slug="$1"
@@ -407,12 +435,55 @@ test_draft_pr_without_origin_labels_skips_merge_write() {
 	return 0
 }
 
-test_non_open_pr_skips_before_merge_pipeline() {
+test_lowercase_open_pr_enters_merge_pipeline() {
+	setup_test_env
+	define_function_under_test || { teardown_test_env; return 0; }
+
+	local pr_obj='{"number":78,"state":"open","mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"lowercase open test","labels":[],"isDraft":false,"headRefOid":"head-current"}'
+	local result=0
+	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "lowercase open PR enters batch merge pipeline" 1 "Expected 0, got ${result}; log: $(<"$LOGFILE")"
+	elif ! grep -qE 'gh pr merge 78 ' "$GH_LOG"; then
+		print_result "lowercase open PR enters batch merge pipeline" 1 "gh log: $(<"$GH_LOG")"
+	elif grep -qF 'state=open is not OPEN' "$LOGFILE"; then
+		print_result "lowercase open PR enters batch merge pipeline" 1 "pulse log: $(<"$LOGFILE")"
+	else
+		print_result "lowercase open PR enters batch merge pipeline" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_lowercase_open_pr_enters_webhook_merge_pipeline() {
+	PR_VIEW_STATE="open"
+	setup_test_env
+	define_function_under_test || { teardown_test_env; unset PR_VIEW_STATE; return 0; }
+
+	local result=0
+	process_pr "owner/repo" "79" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "lowercase open PR enters webhook merge pipeline" 1 "Expected 0, got ${result}; log: $(<"$LOGFILE")"
+	elif ! grep -qF 'webhook-triggered merge attempt for owner/repo#79' "$LOGFILE"; then
+		print_result "lowercase open PR enters webhook merge pipeline" 1 "pulse log: $(<"$LOGFILE")"
+	elif ! grep -qE 'gh pr merge 79 ' "$GH_LOG"; then
+		print_result "lowercase open PR enters webhook merge pipeline" 1 "gh log: $(<"$GH_LOG")"
+	else
+		print_result "lowercase open PR enters webhook merge pipeline" 0
+	fi
+	teardown_test_env
+	unset PR_VIEW_STATE
+	return 0
+}
+
+test_lowercase_closed_pr_skips_before_merge_pipeline() {
 	unset GH_STUB_MODE
 	setup_test_env
 	define_function_under_test || { teardown_test_env; return 0; }
 
-	local pr_obj='{"number":89,"state":"CLOSED","mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"closed test","labels":[],"isDraft":false}'
+	local pr_obj='{"number":89,"state":"closed","mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"closed test","labels":[],"isDraft":false}'
 	local result=0
 	_process_single_ready_pr "owner/repo" "$pr_obj" || result=$?
 
@@ -424,6 +495,32 @@ test_non_open_pr_skips_before_merge_pipeline() {
 		print_result "non-OPEN PR writes skip audit log" 1 "pulse log: $(<"$LOGFILE")"
 	else
 		print_result "non-OPEN PR is blocked before merge pipeline" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_unknown_and_missing_pr_states_skip_before_merge_pipeline() {
+	unset GH_STUB_MODE
+	setup_test_env
+	define_function_under_test || { teardown_test_env; return 0; }
+
+	local unknown_obj='{"number":90,"state":"unexpected","mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"unknown state test","labels":[],"isDraft":false}'
+	local missing_obj='{"number":91,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","author":{"login":"owner"},"title":"missing state test","labels":[],"isDraft":false}'
+	local unknown_result=0
+	local missing_result=0
+	_process_single_ready_pr "owner/repo" "$unknown_obj" || unknown_result=$?
+	_process_single_ready_pr "owner/repo" "$missing_obj" || missing_result=$?
+
+	if [[ "$unknown_result" -ne 1 || "$missing_result" -ne 1 ]]; then
+		print_result "unknown and missing PR states remain blocked" 1 \
+			"unknown=${unknown_result} missing=${missing_result}; log: $(<"$LOGFILE")"
+	elif [[ -s "$GH_LOG" ]]; then
+		print_result "unknown and missing PR states remain blocked" 1 "gh log: $(<"$GH_LOG")"
+	elif ! grep -qF 'state=unexpected is not OPEN' "$LOGFILE" || ! grep -qF 'state=missing is not OPEN' "$LOGFILE"; then
+		print_result "unknown and missing PR states remain blocked" 1 "pulse log: $(<"$LOGFILE")"
+	else
+		print_result "unknown and missing PR states remain blocked" 0
 	fi
 	teardown_test_env
 	return 0
@@ -682,7 +779,10 @@ main() {
 	test_ruleset_violation_skips_native_auto_merge_when_disabled
 	test_green_behind_update_defers_before_merge_attempts
 	test_draft_pr_without_origin_labels_skips_merge_write
-	test_non_open_pr_skips_before_merge_pipeline
+	test_lowercase_open_pr_enters_merge_pipeline
+	test_lowercase_open_pr_enters_webhook_merge_pipeline
+	test_lowercase_closed_pr_skips_before_merge_pipeline
+	test_unknown_and_missing_pr_states_skip_before_merge_pipeline
 	test_expected_required_check_updates_branch_and_defers
 	test_pending_required_check_updates_branch_and_defers
 	test_final_preflight_thread_blocker_dispatches_before_merge

--- a/TODO.md
+++ b/TODO.md
@@ -1196,8 +1196,6 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18162 Report and maintain OpenCode storage through ownership-aware contracts #feat ref:GH#28153
 
-- [ ] t18168 Harden Pulse PR lifecycle-state normalization at merge boundaries #bug ref:GH#28396
-
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/TODO.md
+++ b/TODO.md
@@ -1196,6 +1196,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18162 Report and maintain OpenCode storage through ownership-aware contracts #feat ref:GH#28153
 
+- [ ] t18168 Harden Pulse PR lifecycle-state normalization at merge boundaries #bug ref:GH#28396
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Normalize known PR lifecycle states at both Pulse merge consumer boundaries while preserving unknown and missing values for fail-closed handling. This adds defense beyond the REST projection fix reported in #28357.

## Files Changed

.agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 16 ruleset-fallback tests, 5 PR-field tests, 4 REST-readiness tests, 20 standalone-routine tests, 24 webhook tests, ShellCheck, and linters-local all pass.

Resolves #28396


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 27m and 520,405 tokens on this with the user in an interactive session.