### PR TITLE
GH#28400: fix: classify complete validator branch ranges

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -535,6 +535,21 @@ _finalize_wip_history() {
 #   _run_node_auto_fix            — format/lint auto-fix + amend
 #   _run_node_typecheck           — typecheck check-only
 
+# Print every file changed between the remote default branch and HEAD.
+# The merge-base range keeps classification aligned with the complete PR diff
+# even when lifecycle synchronization adds a docs-only commit at HEAD.
+_validator_changed_files() {
+	local base_branch=""
+	local base_ref=""
+	base_branch=$(_resolve_remote_default_branch origin) || return 1
+	printf -v base_ref 'origin/%s' "$base_branch"
+	if ! git diff --name-only "${base_ref}...HEAD" 2>/dev/null; then
+		print_error "[validators] cannot inspect changed files relative to ${base_ref}"
+		return 1
+	fi
+	return 0
+}
+
 # Returns 0 if validators should run, 1 if any bypass condition applies.
 # Prints the bypass reason on info as appropriate.
 # Args: $1=skip_hooks (0|1)
@@ -547,8 +562,13 @@ _validators_should_run() {
 		print_info "[validators] AIDEVOPS_SKIP_PROJECT_VALIDATORS=1, skipping"
 		return 1
 	fi
+	local changed_files=""
+	if ! changed_files=$(_validator_changed_files); then
+		print_warning "[validators] changed-file classification failed; running validators fail-closed"
+		return 0
+	fi
 	local non_docs_count
-	non_docs_count=$(git show --name-only --format='' HEAD 2>/dev/null |
+	non_docs_count=$(printf '%s\n' "$changed_files" |
 		grep -cvE '\.(md|txt|rst)$|^LICENSE|^COPYING|^\.gitignore$|^$' || true)
 	# safe_grep_count guard (t2763): zero-match path may emit "0\n0"
 	[[ "$non_docs_count" =~ ^[0-9]+$ ]] || non_docs_count=0
@@ -559,10 +579,15 @@ _validators_should_run() {
 	return 0
 }
 
-# Returns 0 when HEAD changes files that should be covered by Node validators.
+# Returns 0 when the PR range changes files covered by Node validators.
 # This keeps shell-only commits from failing on missing local Node dependencies
 # while preserving fail-closed typecheck behaviour for JS/TS/package changes.
 _commit_touches_node_files() {
+	local changed_files=""
+	if ! changed_files=$(_validator_changed_files); then
+		print_warning "[validators] Node changed-file classification failed; running Node validators fail-closed"
+		return 0
+	fi
 	local changed_file
 	while IFS= read -r changed_file; do
 		case "$changed_file" in
@@ -580,7 +605,7 @@ _commit_touches_node_files() {
 			esac
 			;;
 		esac
-	done < <(git show --name-only --format='' HEAD 2>/dev/null)
+	done <<<"$changed_files"
 	return 1
 }
 

--- a/.agents/scripts/tests/test-full-loop-project-validators-shell-only.sh
+++ b/.agents/scripts/tests/test-full-loop-project-validators-shell-only.sh
@@ -4,10 +4,9 @@
 #
 # test-full-loop-project-validators-shell-only.sh — GH#22007 regression guard.
 #
-# Verifies commit-and-pr project validators skip Node validators for shell-only
-# diffs, so missing local Node dependencies (for example no local tsc binary) do
-# not block shell-only PR creation. Node/TypeScript diffs still run the configured
-# typecheck and fail closed when that command reports an error.
+# Verifies commit-and-pr classifies the complete branch range after docs-only
+# lifecycle commits. Shell-only diffs skip Node validators, while Node/TypeScript
+# diffs still run the configured typecheck and genuinely docs-only branches skip.
 
 # NOTE: not using `set -e` — assertions capture non-zero exits.
 set -uo pipefail
@@ -53,6 +52,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=../full-loop-helper-commit.sh
 source "${SCRIPT_DIR}/full-loop-helper-commit.sh"
 
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
+
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
@@ -80,17 +85,22 @@ make_repo() {
 		git init -q
 		git config commit.gpgsign false
 		git config tag.gpgsign false
+		git branch -M main
 		cat >package.json <<'EOF'
 {"scripts":{"typecheck":"tsc --noEmit"}}
 EOF
 		git add package.json
 		git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'initial'
+		git remote add origin .
+		git update-ref refs/remotes/origin/main HEAD
+		git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+		git switch -qc feature/test
 	) || return 1
 	return 0
 }
 
-# Case 1: shell-only change skips Node validators completely, even though a
-# package.json typecheck script exists and npm would fail if invoked.
+# Case 1: a finalized shell change followed by a docs-only lifecycle commit
+# remains eligible for project validators without invoking Node validators.
 SHELL_REPO="${TEST_ROOT}/shell-only"
 make_repo "$SHELL_REPO"
 NPM_CALL_LOG="${TEST_ROOT}/npm-shell.log"
@@ -100,7 +110,15 @@ export NPM_CALL_LOG NPM_FAKE_RC=127
 	mkdir -p .agents/scripts
 	printf '%s\n' '#!/usr/bin/env bash' 'echo ok' >.agents/scripts/example.sh
 	git add .agents/scripts/example.sh
-	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'shell-only change'
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'wip: shell-only change'
+	_finalize_wip_history 'fix: shell-only change' >/dev/null || exit 1
+	printf '%s\n' 'lifecycle sync' >TODO.md
+	git add TODO.md
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'chore: sync lifecycle'
+	_validators_should_run 0 || exit 1
+	if _commit_touches_node_files; then
+		exit 1
+	fi
 	PATH="${FAKE_BIN}:$PATH" _run_project_validators 0
 )
 case1_rc=$?
@@ -110,8 +128,8 @@ else
 	print_result "shell-only diff skips Node validators" 1 "rc=${case1_rc}, npm_log=$(wc -c <"$NPM_CALL_LOG" 2>/dev/null || printf 0)"
 fi
 
-# Case 2: TypeScript change still runs configured typecheck and fails closed
-# when the command reports an error.
+# Case 2: a TypeScript change beneath a docs-only lifecycle commit still runs
+# configured typecheck and fails closed when the command reports an error.
 TS_REPO="${TEST_ROOT}/typescript-change"
 make_repo "$TS_REPO"
 NPM_CALL_LOG="${TEST_ROOT}/npm-ts.log"
@@ -121,6 +139,9 @@ export NPM_CALL_LOG NPM_FAKE_RC=2
 	printf '%s\n' 'const answer: number = "wrong";' >index.ts
 	git add index.ts
 	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'typescript change'
+	printf '%s\n' 'lifecycle sync' >TODO.md
+	git add TODO.md
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'chore: sync lifecycle'
 	PATH="${FAKE_BIN}:$PATH" _run_project_validators 0
 )
 case2_rc=$?
@@ -130,7 +151,29 @@ else
 	print_result "TypeScript diff runs failing typecheck" 1 "rc=${case2_rc}, npm_log=$(wc -c <"$NPM_CALL_LOG" 2>/dev/null || printf 0)"
 fi
 
-# Case 3: if an auto-fix command removes the process' current subdirectory,
+# Case 3: a genuinely docs-only branch remains bypassed.
+DOCS_REPO="${TEST_ROOT}/docs-only"
+make_repo "$DOCS_REPO"
+NPM_CALL_LOG="${TEST_ROOT}/npm-docs.log"
+export NPM_CALL_LOG NPM_FAKE_RC=127
+(
+	cd "$DOCS_REPO" || exit 1
+	printf '%s\n' '# Documentation' >README.md
+	git add README.md
+	git -c user.name='Test User' -c user.email='test@example.invalid' commit -qm 'docs: add readme'
+	if _validators_should_run 0; then
+		exit 1
+	fi
+	PATH="${FAKE_BIN}:$PATH" _run_project_validators 0
+)
+case3_rc=$?
+if [[ "$case3_rc" -eq 0 && ! -s "$NPM_CALL_LOG" ]]; then
+	print_result "docs-only branch skips project validators" 0
+else
+	print_result "docs-only branch skips project validators" 1 "rc=${case3_rc}, npm_log=$(wc -c <"$NPM_CALL_LOG" 2>/dev/null || printf 0)"
+fi
+
+# Case 4: if an auto-fix command removes the process' current subdirectory,
 # the validator restores the repository root before running git diff/add/amend.
 # This guards the GH#22526 failure class where amend hit getcwd() from a stale
 # cwd and reported: fatal: Unable to read current working directory.
@@ -154,13 +197,13 @@ export NPM_CALL_LOG NPM_FIX_TARGET NPM_DELETE_DIR NPM_FAKE_ACTION=delete-cwd-aft
 	cd "${CWD_REPO}/vanishing" || exit 1
 	PATH="${FAKE_BIN}:$PATH" fix_changes=0 _run_node_auto_fix npm 30 0
 )
-case3_rc=$?
-case3_head_subject=$(git -C "$CWD_REPO" log -1 --format=%s 2>/dev/null || printf '')
-case3_file=$(git -C "$CWD_REPO" show HEAD:tracked.txt 2>/dev/null || printf '')
-if [[ "$case3_rc" -eq 0 && "$case3_head_subject" == "node project" && "$case3_file" == $'before\nfixed' ]]; then
+case4_rc=$?
+case4_head_subject=$(git -C "$CWD_REPO" log -1 --format=%s 2>/dev/null || printf '')
+case4_file=$(git -C "$CWD_REPO" show HEAD:tracked.txt 2>/dev/null || printf '')
+if [[ "$case4_rc" -eq 0 && "$case4_head_subject" == "node project" && "$case4_file" == $'before\nfixed' ]]; then
 	print_result "auto-fix restores repo root before amend when cwd disappears" 0
 else
-	print_result "auto-fix restores repo root before amend when cwd disappears" 1 "rc=${case3_rc}, subject=${case3_head_subject}, file=${case3_file}"
+	print_result "auto-fix restores repo root before amend when cwd disappears" 1 "rc=${case4_rc}, subject=${case4_head_subject}, file=${case4_file}"
 fi
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Classify project and Node validator eligibility from the complete default-branch-to-HEAD diff, and cover lifecycle commits, WIP finalization, shell-only, TypeScript, and docs-only branches.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/tests/test-full-loop-project-validators-shell-only.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-full-loop-project-validators-shell-only.sh; shellcheck .agents/scripts/full-loop-helper-commit.sh .agents/scripts/tests/test-full-loop-project-validators-shell-only.sh

Resolves #28400


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 4m and 75,399 tokens on this as a headless worker.