### PR TITLE
GH#28406: separate compaction operational sections

### DIFF
--- a/.agents/plugins/opencode-aidevops/compaction.mjs
+++ b/.agents/plugins/opencode-aidevops/compaction.mjs
@@ -366,7 +366,7 @@ export async function compactingHook(deps, _input, output, directory) {
         "## Operational State",
         "Include the following state in your compaction summary so the next session can continue seamlessly:",
         "",
-        ...sections,
+        sections.join("\n\n"),
         "",
       ] : []),
       "## Critical Rules to Preserve",

--- a/.agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs
@@ -123,6 +123,11 @@ test("compaction injects only the active repository checkpoint", async () => {
     const payload = output.context.join("\n");
     assert.match(payload, /## Operational State/);
     assert.match(payload, /TARGET_REPO_CHECKPOINT_STATE/);
+    assert.match(
+      payload,
+      /TARGET_REPO_CHECKPOINT_STATE\n\n## Repository Campaign Checkpoint/,
+      "operational state sections must have a blank line between them",
+    );
     assert.doesNotMatch(payload, /UNRELATED_LEGACY_CHECKPOINT_STATE/);
     assert.doesNotMatch(payload, /UNRELATED_SIBLING_CHECKPOINT_STATE/);
     assert.match(payload, /## Repository Campaign Checkpoint/);


### PR DESCRIPTION
## Summary

Render each compaction operational-state section with a Markdown blank line while preserving core framework quality guidance and regression coverage.

## Files Changed

.agents/plugins/opencode-aidevops/compaction.mjs, .agents/plugins/opencode-aidevops/tests/test-compaction-checkpoint-scope.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --test tests/test-compaction-checkpoint-scope.mjs; npm run typecheck

Resolves #28406


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2m and 58,579 tokens on this as a headless worker.