### PR TITLE
GH#28412: recover stuck review-thread remediation

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -44,6 +44,7 @@ PR_REVIEW_THREAD_RESPONSE_BOT_RE="${PR_REVIEW_THREAD_RESPONSE_BOT_RE:-coderabbit
 PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN="${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN:-false}"
 PRRTS_BOOL_TRUE="true"
 PRRTS_BOOL_FALSE="false"
+PRRTS_TSV_FIELD_SEPARATOR=$'\034'
 PRRTS_RC_GRAPHQL_EXHAUSTED=75
 PRRTS_BLOCKED_BY_CODE="code"
 PRRTS_BLOCKED_BY_INFRASTRUCTURE="infrastructure"
@@ -454,14 +455,16 @@ cmd_scan_pr() {
 		--jq '[(.title // "" | gsub("[\t\r\n]"; " ")), (.headRefName // ""), (.headRefOid // ""), (.author.login // "")] | @tsv' \
 		2>/dev/null || true)
 	if [[ -n "$metadata" ]]; then
-		IFS=$'\t' read -r title head_ref head_oid author <<<"$metadata"
+		IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r title head_ref head_oid author \
+			<<<"${metadata//$'\t'/$PRRTS_TSV_FIELD_SEPARATOR}"
 	fi
 	summary="$(_prrts_review_thread_summary "$repo_slug" "$pr_number")" || rc=$?
 	if [[ "$rc" -ne 0 ]]; then
 		_prrts_log "scan-pr: ${repo_slug}#${pr_number} skipped — review-thread fetch failed"
 		return 0
 	fi
-	IFS=$'\t' read -r thread_count fingerprint preview <<<"$summary"
+	IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r thread_count fingerprint preview \
+		<<<"${summary//$'\t'/$PRRTS_TSV_FIELD_SEPARATOR}"
 	[[ "$thread_count" =~ ^[0-9]+$ ]] || thread_count=0
 	if [[ "$thread_count" -gt 0 ]]; then
 		printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
@@ -487,7 +490,7 @@ _prrts_scan_repo_to_files() {
 	local repo_slug="$1"
 	local candidates_file="$2"
 	local status_file="$3"
-	local pr_rows="" summary="" rc=0
+	local pr_rows="" pr_row="" summary="" rc=0
 	local pr_number="" title="" is_draft="" labels="" head_ref="" head_oid="" author=""
 	local thread_count="" fingerprint="" preview=""
 	local checked_count=0 fetch_error_count=0 graphql_exhausted_count=0
@@ -503,7 +506,9 @@ _prrts_scan_repo_to_files() {
 		return 0
 	}
 
-	while IFS=$'\t' read -r pr_number title is_draft labels head_ref head_oid author; do
+	while IFS= read -r pr_row; do
+		IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r pr_number title is_draft labels head_ref head_oid author \
+			<<<"${pr_row//$'\t'/$PRRTS_TSV_FIELD_SEPARATOR}"
 		[[ -n "$pr_number" ]] || continue
 		if [[ "$is_draft" == "$PRRTS_BOOL_TRUE" ]]; then
 			_prrts_log "scan: ${repo_slug}#${pr_number} skipped — draft PR"
@@ -527,7 +532,8 @@ _prrts_scan_repo_to_files() {
 			fi
 			continue
 		fi
-		IFS=$'\t' read -r thread_count fingerprint preview <<<"$summary"
+		IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r thread_count fingerprint preview \
+			<<<"${summary//$'\t'/$PRRTS_TSV_FIELD_SEPARATOR}"
 		[[ "$thread_count" =~ ^[0-9]+$ ]] || thread_count=0
 		if [[ "$thread_count" -gt 0 ]]; then
 			printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
@@ -741,11 +747,13 @@ _prrts_read_state() {
 	local blocked_by_var="${6:-}"
 	local maintainer_attention_var="${7:-}"
 	local head_sha_var="${8:-}"
+	local blocker_reason_var="${9:-}"
 	local key="" value=""
 	local state_fingerprint="" state_dispatched_at="0"
 	local state_attempt_count="0"
 	local state_last_head_sha=""
 	local state_analysis_complete="$PRRTS_BOOL_FALSE" state_blocked_by="" state_maintainer_attention="$PRRTS_BOOL_FALSE"
+	local state_blocker_reason=""
 	if [[ -f "$state_file" ]]; then
 		while IFS='=' read -r key value; do
 			case "$key" in
@@ -756,6 +764,8 @@ _prrts_read_state() {
 			analysis_complete) state_analysis_complete="$value" ;;
 			blocked_by) state_blocked_by="$value" ;;
 			maintainer_attention) state_maintainer_attention="$value" ;;
+			attention_reason) [[ -n "$state_blocker_reason" ]] || state_blocker_reason="$value" ;;
+			blocker_reason) state_blocker_reason="$value" ;;
 			esac
 		done <"$state_file"
 	fi
@@ -780,6 +790,9 @@ _prrts_read_state() {
 	if [[ -n "$head_sha_var" ]]; then
 		printf -v "$head_sha_var" '%s' "$state_last_head_sha"
 	fi
+	if [[ -n "$blocker_reason_var" ]]; then
+		printf -v "$blocker_reason_var" '%s' "$state_blocker_reason"
+	fi
 	return 0
 }
 
@@ -796,10 +809,11 @@ _prrts_should_dispatch() {
 	local last_attempt_count="0" next_attempt_count="1" state_repeated_same_fingerprint="$PRRTS_BOOL_FALSE"
 	local last_head_sha="" state_same_head_sha="$PRRTS_BOOL_FALSE"
 	local analysis_complete="$PRRTS_BOOL_FALSE" blocked_by="" maintainer_attention="$PRRTS_BOOL_FALSE"
+	local blocker_reason="" retry_stale_head_validation="$PRRTS_BOOL_FALSE"
 	state_file="$(_prrts_state_file "$repo_slug" "$pr_number")"
 	cooldown="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_COOLDOWN" "3600" "60")"
 	inflight_ttl="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_INFLIGHT_TTL" "300" "1")"
-	_prrts_read_state "$state_file" last_fingerprint dispatched_at last_attempt_count analysis_complete blocked_by maintainer_attention last_head_sha
+	_prrts_read_state "$state_file" last_fingerprint dispatched_at last_attempt_count analysis_complete blocked_by maintainer_attention last_head_sha blocker_reason
 	if [[ -n "$last_fingerprint" && "$fingerprint" == "$last_fingerprint" ]]; then
 		state_same_head_sha="$PRRTS_BOOL_TRUE"
 		if [[ -n "$last_head_sha" && -n "$current_head_sha" && "$current_head_sha" != "$last_head_sha" ]]; then
@@ -824,8 +838,12 @@ _prrts_should_dispatch() {
 		return 1
 	fi
 	if [[ "$state_repeated_same_fingerprint" == "$PRRTS_BOOL_TRUE" && "$analysis_complete" == "$PRRTS_BOOL_TRUE" && "$maintainer_attention" == "$PRRTS_BOOL_TRUE" ]]; then
-		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — analysis complete and blocked by ${blocked_by:-decision}; maintainer attention pending"
-		return 1
+		if [[ "$last_attempt_count" -eq 1 && ("$blocker_reason" == "pr_head_branch_invalid" || "$blocker_reason" == "pr_head_sha_invalid") ]]; then
+			retry_stale_head_validation="$PRRTS_BOOL_TRUE"
+		else
+			_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — analysis complete and blocked by ${blocked_by:-decision}; maintainer attention pending"
+			return 1
+		fi
 	fi
 	age_seconds=$((now_epoch - dispatched_at))
 	if [[ "$dispatched_at" -gt 0 && "$age_seconds" -lt "$inflight_ttl" ]]; then
@@ -835,6 +853,9 @@ _prrts_should_dispatch() {
 	if [[ "$state_repeated_same_fingerprint" == "$PRRTS_BOOL_TRUE" && "$state_same_head_sha" == "$PRRTS_BOOL_TRUE" && "$age_seconds" -lt "$cooldown" ]]; then
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — same thread fingerprint dispatched ${age_seconds}s ago"
 		return 1
+	fi
+	if [[ "$retry_stale_head_validation" == "$PRRTS_BOOL_TRUE" ]]; then
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} retrying stale PR head validation failure once (${blocker_reason})"
 	fi
 	return 0
 }
@@ -1294,7 +1315,7 @@ _prrts_dispatch_repo() {
 	local repo_slug="$1"
 	local repo_path="$2"
 	local dry_run="$3"
-	local candidates="" candidates_file="" status_file="" now_epoch="" max_per_repo="" dispatched=0
+	local candidates="" candidate_row="" candidates_file="" status_file="" now_epoch="" max_per_repo="" dispatched=0
 	local pr_number="" thread_count="" fingerprint="" title="" head_ref="" head_oid="" author="" preview=""
 	local checked_count=0 fetch_error_count=0 graphql_exhausted_count=0 list_failed=0
 	local status_key="" status_value=""
@@ -1345,7 +1366,9 @@ _prrts_dispatch_repo() {
 	if [[ -n "$cursor" ]]; then
 		_prrts_log "dispatch: ${repo_slug} rotated candidates after cursor PR #${cursor}"
 	fi
-	while IFS=$'\t' read -r pr_number thread_count fingerprint title head_ref head_oid author preview; do
+	while IFS= read -r candidate_row; do
+		IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r pr_number thread_count fingerprint title head_ref head_oid author preview \
+			<<<"${candidate_row//$'\t'/$PRRTS_TSV_FIELD_SEPARATOR}"
 		[[ -n "$pr_number" ]] || continue
 		last_considered="$pr_number"
 		if _prrts_dispatch_guarded "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview" "$now_epoch" "$dry_run" "dispatch" "$head_ref" "$head_oid" "$author"; then
@@ -1383,20 +1406,22 @@ _prrts_dispatch_pr() {
 
 	if [[ -z "$repo_path" || ! -d "${repo_path/#\~/$HOME}" || ! "$pr_number" =~ ^[0-9]+$ ]]; then
 		_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} skipped — repo path missing/invalid or PR number invalid (${repo_path})"
-		return 0
+		return 1
 	fi
 	repo_path="${repo_path/#\~/$HOME}"
 	candidate="$(cmd_scan_pr "$repo_slug" "$pr_number")"
 	[[ -n "$candidate" ]] || {
 		_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} has no unresolved review threads matching current filters"
-		return 0
+		return 1
 	}
 	now_epoch="$(date +%s)"
-	IFS=$'\t' read -r pr_number thread_count fingerprint title head_ref head_oid author preview <<<"$candidate"
-	if _prrts_dispatch_guarded "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview" "$now_epoch" "$dry_run" "dispatch-pr" "$head_ref" "$head_oid" "$author"; then
-		if [[ "$dry_run" != "$PRRTS_BOOL_TRUE" ]]; then
-			_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} completed, dispatched=1, include_human=${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN}"
-		fi
+	IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r pr_number thread_count fingerprint title head_ref head_oid author preview \
+		<<<"${candidate//$'\t'/$PRRTS_TSV_FIELD_SEPARATOR}"
+	if ! _prrts_dispatch_guarded "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview" "$now_epoch" "$dry_run" "dispatch-pr" "$head_ref" "$head_oid" "$author"; then
+		return 1
+	fi
+	if [[ "$dry_run" != "$PRRTS_BOOL_TRUE" ]]; then
+		_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} completed, dispatched=1, include_human=${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN}"
 	fi
 	return 0
 }
@@ -1428,7 +1453,9 @@ main() {
 			_prrts_usage >&2
 			return 2
 		fi
-		_prrts_dispatch_pr "$repo_slug" "$repo_path" "${4:-}" "$PRRTS_BOOL_FALSE"
+		if ! _prrts_dispatch_pr "$repo_slug" "$repo_path" "${4:-}" "$PRRTS_BOOL_FALSE"; then
+			return 1
+		fi
 		;;
 	dry-run)
 		if [[ -z "$repo_slug" ]]; then

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -482,6 +482,26 @@ test_dispatch_launches_worker_and_writes_state() {
 	return 0
 }
 
+test_dispatch_preserves_head_fields_when_labels_are_empty() {
+	setup_test_env
+	export STUB_PR_LIST=$'1\tFix active PR\tfalse\t\tfeature/review\t'"${TEST_HEAD_OID_1}"$'\tworker-bot'
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	if [[ -s "$HEADLESS_LOG" ]] &&
+		grep -Fxq "AIDEVOPS_PR_REPAIR_HEAD_REF=feature/review" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq "AIDEVOPS_PR_REPAIR_HEAD_SHA=${TEST_HEAD_OID_1}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -q "^last_head_sha=${TEST_HEAD_OID_1}$" "$state_file" 2>/dev/null &&
+		! grep -q 'PR head branch is invalid' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch preserves PR head metadata when labels are empty" 0
+	else
+		print_result "dispatch preserves PR head metadata when labels are empty" 1 \
+			"headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_dispatch_prompt_includes_full_thread_command_signatures() {
 	setup_test_env
 	local stable_scanner="${HOME}/.aidevops/agents/scripts/pr-review-thread-response-scanner.sh"
@@ -715,6 +735,67 @@ test_mark_blocked_skips_same_fingerprint_without_retry() {
 	return 0
 }
 
+test_dispatch_retries_stale_branch_validation_blocker_once() {
+	setup_test_env
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local old_epoch=""
+	old_epoch="$(($(date +%s) - 4000))"
+	{
+		printf 'fingerprint=THREAD1:https://example.invalid/thread\n'
+		printf 'dispatched_at=%s\n' "$old_epoch"
+		printf 'thread_count=1\n'
+		printf 'attempt_count=1\n'
+		printf 'last_head_sha=%s\n' "$TEST_HEAD_OID_1"
+		printf 'analysis_complete=true\n'
+		printf 'blocked_by=code\n'
+		printf 'maintainer_attention=true\n'
+		printf 'attention_reason=pr_head_branch_invalid\n'
+		printf 'blocker_reason=pr_head_branch_invalid\n'
+	} >"$state_file"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	if [[ -s "$HEADLESS_LOG" ]] &&
+		grep -q '^attempt_count=2$' "$state_file" 2>/dev/null &&
+		! grep -q '^analysis_complete=' "$state_file" 2>/dev/null &&
+		grep -q 'retrying stale PR head validation failure once' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch retries a stale branch-validation blocker once" 0
+	else
+		print_result "dispatch retries a stale branch-validation blocker once" 1 \
+			"headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_does_not_repeat_branch_validation_recovery() {
+	setup_test_env
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local old_epoch=""
+	old_epoch="$(($(date +%s) - 4000))"
+	{
+		printf 'fingerprint=THREAD1:https://example.invalid/thread\n'
+		printf 'dispatched_at=%s\n' "$old_epoch"
+		printf 'thread_count=1\n'
+		printf 'attempt_count=2\n'
+		printf 'last_head_sha=%s\n' "$TEST_HEAD_OID_1"
+		printf 'analysis_complete=true\n'
+		printf 'blocked_by=code\n'
+		printf 'maintainer_attention=true\n'
+		printf 'blocker_reason=pr_head_branch_invalid\n'
+	} >"$state_file"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	if [[ ! -s "$HEADLESS_LOG" ]] &&
+		grep -q '^attempt_count=2$' "$state_file" 2>/dev/null &&
+		grep -q 'analysis complete and blocked by code' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch does not repeat stale branch-validation recovery" 0
+	else
+		print_result "dispatch does not repeat stale branch-validation recovery" 1 \
+			"state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_no_marker_retry_behavior_is_preserved() {
 	setup_test_env
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
@@ -779,16 +860,35 @@ test_mark_blocked_sanitizes_reason_and_details() {
 test_dispatch_pr_skips_when_pr_lock_held() {
 	setup_test_env
 	local lock_dir="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.lock"
+	local dispatch_rc=0
 	mkdir -p "$lock_dir"
 	{
 		printf 'pid=%s\n' "$$"
 		printf 'created_at=%s\n' "$(date +%s)"
 	} >"${lock_dir}/metadata"
-	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
-	if [[ ! -s "$HEADLESS_LOG" ]]; then
-		print_result "dispatch-pr skips when repo PR lock is held" 0
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1 || dispatch_rc=$?
+	if [[ "$dispatch_rc" -ne 0 && ! -s "$HEADLESS_LOG" ]]; then
+		print_result "dispatch-pr reports when repo PR lock is held" 0
 	else
-		print_result "dispatch-pr skips when repo PR lock is held" 1 "lock-held dispatch unexpectedly launched"
+		print_result "dispatch-pr reports when repo PR lock is held" 1 "rc=${dispatch_rc}, lock-held dispatch unexpectedly launched"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_pr_reports_deduplicated_dispatch() {
+	setup_test_env
+	PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true $SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
+	wait_for_headless_log || true
+	: >"$HEADLESS_LOG"
+	local dispatch_rc=0
+	PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true $SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1 || dispatch_rc=$?
+	if [[ "$dispatch_rc" -ne 0 && ! -s "$HEADLESS_LOG" ]] &&
+		grep -Eq 'dispatch state active|same thread fingerprint dispatched' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch-pr reports a deduplicated targeted dispatch" 0
+	else
+		print_result "dispatch-pr reports a deduplicated targeted dispatch" 1 \
+			"rc=${dispatch_rc}, headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
 	fi
 	teardown_test_env
 	return 0
@@ -1023,6 +1123,7 @@ main() {
 	test_scan_pr_excludes_human_threads_by_default
 	test_scan_pr_can_include_human_threads_with_opt_in
 	test_dispatch_launches_worker_and_writes_state
+	test_dispatch_preserves_head_fields_when_labels_are_empty
 	test_dispatch_uses_linked_pr_branch_worktree
 	test_dispatch_exports_worktree_ownership_context
 	test_dispatch_blocks_cross_repository_head
@@ -1041,10 +1142,13 @@ main() {
 	test_dispatch_escalates_repeated_same_fingerprint_without_worker_loop
 	test_new_head_sha_resets_repeated_fingerprint_attempts
 	test_mark_blocked_skips_same_fingerprint_without_retry
+	test_dispatch_retries_stale_branch_validation_blocker_once
+	test_dispatch_does_not_repeat_branch_validation_recovery
 	test_no_marker_retry_behavior_is_preserved
 	test_old_state_file_without_completion_fields_still_retries
 	test_mark_blocked_sanitizes_reason_and_details
 	test_dispatch_pr_skips_when_pr_lock_held
+	test_dispatch_pr_reports_deduplicated_dispatch
 	test_dispatch_pr_reclaims_stale_lock
 	test_dispatch_reports_graphql_budget_exhaustion_when_scan_blind
 	test_dispatch_reports_fetch_errors_when_scan_blind

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -178,6 +178,7 @@ test_failed_preflight_dispatch_stays_blocked_and_consumes_marker() {
 	_pulse_merge_maybe_dispatch_preflight_remediation 77 owner/repo
 
 	if grep -q 'review-thread remediation dispatch failed for PR #77 in owner/repo' "$LOGFILE" &&
+		! grep -q 'review-thread remediation queued for PR #77 in owner/repo' "$LOGFILE" &&
 		[[ -z "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]]; then
 		print_result "failed or deduplicated preflight dispatch consumes typed marker" 0
 	else

--- a/.agents/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/tests/test-pr-review-thread-response-scanner.sh
@@ -44,7 +44,16 @@ _write_fake_gh() {
 set -euo pipefail
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
-	printf '123\tReview thread fixture\tfalse\t\tfixture-branch\tcollaborator\n'
+	printf '123\tReview thread fixture\tfalse\t\tfixture-branch\t1111111111111111111111111111111111111111\tcollaborator\n'
+	exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	if [[ "$*" == *"--json isCrossRepository"* ]]; then
+		printf 'false\n'
+	else
+		printf 'Review thread fixture\tfixture-branch\t1111111111111111111111111111111111111111\tcollaborator\n'
+	fi
 	exit 0
 fi
 
@@ -83,6 +92,30 @@ printf 'unexpected gh invocation: %s\n' "$*" >&2
 exit 2
 FAKE_GH
 	chmod +x "${fake_bin}/gh"
+	return 0
+}
+
+_write_fake_git() {
+	local fake_bin="$1"
+	cat >"${fake_bin}/git" <<'FAKE_GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *"check-ref-format --branch"* ]]; then
+	exit 0
+fi
+if [[ "$*" == *"worktree list --porcelain"* ]]; then
+	printf 'worktree %s\nHEAD %s\nbranch refs/heads/fixture-branch\n\n' \
+		"${FAKE_WORKTREE_PATH:?}" '1111111111111111111111111111111111111111'
+	exit 0
+fi
+if [[ "$*" == *"rev-parse HEAD"* ]]; then
+	printf '1111111111111111111111111111111111111111\n'
+	exit 0
+fi
+exit 1
+FAKE_GIT
+	chmod +x "${fake_bin}/git"
 	return 0
 }
 
@@ -178,8 +211,11 @@ test_dispatch_prompt_includes_thread_fingerprint() {
 	local fake_headless="${TEST_TMPDIR}/headless-runtime-helper.sh"
 	local state_dir="${TEST_TMPDIR}/state"
 	local prompt_file="${state_dir}/marcusquinn-aidevops-123-prompt.md"
+	local worker_path="${TEST_TMPDIR}/existing-review-worktree"
 	_write_fake_gh "$fake_bin"
+	_write_fake_git "$fake_bin"
 	mkdir -p "$(dirname "$fake_headless")"
+	mkdir -p "$worker_path"
 	cat >"$fake_headless" <<'FAKE_HEADLESS'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -188,6 +224,7 @@ FAKE_HEADLESS
 	chmod +x "$fake_headless"
 
 	if FAKE_GH_CAPTURE="$capture" \
+		FAKE_WORKTREE_PATH="$worker_path" \
 		AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR="$state_dir" \
 		HEADLESS_RUNTIME_HELPER="$fake_headless" \
 		PATH="${fake_bin}:$PATH" \


### PR DESCRIPTION
## Summary

Preserve empty PR-list fields, retry one stale head-validation blocker, and make targeted dispatch report deduplicated or failed launches.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh, .agents/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck; scanner tests (43/43); Pulse remediation tests (15/15); legacy scanner tests (8/8); linters-local.sh.

Resolves #28412


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 27m and 645,830 tokens on this as a headless worker.