### PR TITLE
fix: resolve review-gate author trust via REST

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -168,6 +168,41 @@ _RBG_EVIDENCE_SNAPSHOT_READY=0
 
 # --- Functions ---
 
+_get_pr_rest_field() {
+	local pr_number="$1"
+	local repo="$2"
+	local jq_filter="$3"
+
+	if gh api "repos/${repo}/pulls/${pr_number}" --jq "$jq_filter" 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+_resolve_pr_author_association() {
+	local pr_number="$1"
+	local repo="$2"
+	local pr_metadata_json="${3:-}"
+	local author_association=""
+
+	if [[ -n "$pr_metadata_json" ]]; then
+		author_association=$(jq -r '.author_association // .authorAssociation // empty' \
+			<<<"$pr_metadata_json" 2>/dev/null || true)
+	fi
+
+	if [[ -z "$author_association" ]]; then
+		# #aidevops:trust-boundary — author association controls whether missing
+		# add-on review evidence is advisory or mandatory. Resolve it from the REST
+		# pull-request shape, which exposes author_association across gh versions;
+		# missing or malformed evidence remains empty and therefore fails closed.
+		author_association=$(_get_pr_rest_field \
+			"$pr_number" "$repo" '.author_association // empty' || true)
+	fi
+
+	printf '%s' "$author_association"
+	return 0
+}
+
 usage() {
 	echo "Usage: $(basename "$0") {check|event-check|classify-infra-rate-limit|wait|list|request-retry|status-json|batch-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
 	echo ""
@@ -490,8 +525,7 @@ get_pr_age_seconds() {
 	if [[ -z "$created_at" ]]; then
 		# GH#4361: GraphQL rate-limited — fall back to REST API which has a
 		# separate rate limit and is typically available when GraphQL is exhausted.
-		created_at=$(gh api "repos/${repo}/pulls/${pr_number}" \
-			--jq '.created_at' 2>/dev/null || echo "")
+		created_at=$(_get_pr_rest_field "$pr_number" "$repo" '.created_at' || echo "")
 	fi
 	if [[ -z "$created_at" ]]; then
 		echo "0"
@@ -935,8 +969,7 @@ _get_success_status_contexts() {
 	fi
 	if [[ -z "$head_sha" ]]; then
 		# GH#4361: GraphQL rate-limited — fall back to REST API.
-		head_sha=$(gh api "repos/${repo}/pulls/${pr_number}" \
-			--jq '.head.sha' 2>/dev/null || echo "")
+		head_sha=$(_get_pr_rest_field "$pr_number" "$repo" '.head.sha' || echo "")
 	fi
 	if [[ -z "$head_sha" ]]; then
 		return 1
@@ -1196,13 +1229,9 @@ do_check() {
 	local REVIEW_GATE_NON_REVIEW_BOTS=""
 	_rbg_reset_evidence_snapshot
 
-	if [[ -z "$REVIEW_GATE_AUTHOR_ASSOCIATION" && -n "$pr_metadata_json" ]]; then
-		REVIEW_GATE_AUTHOR_ASSOCIATION=$(jq -r '.author_association // .authorAssociation // empty' \
-			<<<"$pr_metadata_json" 2>/dev/null || true)
-	fi
 	if [[ -z "$REVIEW_GATE_AUTHOR_ASSOCIATION" ]]; then
-		REVIEW_GATE_AUTHOR_ASSOCIATION=$(gh pr view "$pr_number" --repo "$repo" \
-			--json authorAssociation --jq '.authorAssociation // empty' 2>/dev/null || true)
+		REVIEW_GATE_AUTHOR_ASSOCIATION=$(_resolve_pr_author_association \
+			"$pr_number" "$repo" "$pr_metadata_json")
 	fi
 
 	# #aidevops:trust-boundary — skip labels are an internal exception. Resolve

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -998,6 +998,56 @@ test_notice_category_propagates_api_failure() {
 
 # ---------- Integration tests: do_check decision buckets (GH#22802) ----------
 
+test_do_check_resolves_trusted_author_via_rest() {
+	check_for_skip_label() { return 1; }
+	get_all_bot_commenters() { return 0; }
+	_get_success_status_contexts() { return 1; }
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "repos/testorg/otherrepo/pulls/123" ]]; then
+			printf '%s\n' 'MEMBER'
+			return 0
+		fi
+		return 1
+	}
+
+	local output status
+	if output=$(do_check 123 'testorg/otherrepo' 2>/dev/null); then
+		status=0
+	else
+		status=$?
+	fi
+
+	if [[ "$status" -eq 0 && "$output" == "PASS_ADVISORY" ]]; then
+		print_result "do_check resolves trusted author association through REST" 0
+	else
+		print_result "do_check resolves trusted author association through REST" 1 \
+			"status=${status} output=${output}"
+	fi
+	return 0
+}
+
+test_do_check_fails_closed_when_author_lookup_fails() {
+	check_for_skip_label() { return 1; }
+	get_all_bot_commenters() { return 0; }
+	_get_success_status_contexts() { return 1; }
+	gh() { return 1; }
+
+	local output status
+	if output=$(do_check 123 'testorg/otherrepo' 2>/dev/null); then
+		status=0
+	else
+		status=$?
+	fi
+
+	if [[ "$status" -eq 1 && "$output" == "WAITING" ]]; then
+		print_result "do_check fails closed when author association is unavailable" 0
+	else
+		print_result "do_check fails closed when author association is unavailable" 1 \
+			"status=${status} output=${output}"
+	fi
+	return 0
+}
+
 test_do_check_passes_true_rate_limit_only() {
 	check_for_skip_label() { return 1; }
 	get_all_bot_commenters() {
@@ -1471,6 +1521,10 @@ main() {
 	test_do_check_fetches_success_status_contexts_once
 	test_do_check_honors_skip_for_trusted_author
 	test_do_check_denies_skip_for_external_author
+
+	printf '\n=== Author association compatibility ===\n'
+	test_do_check_resolves_trusted_author_via_rest
+	test_do_check_fails_closed_when_author_lookup_fails
 
 	echo ""
 	echo "=== Typed current-head evidence ==="


### PR DESCRIPTION
## Summary

- resolve pull-request author association through the REST API instead of assuming `gh pr view --json authorAssociation` is available
- centralise REST pull-request field reads to avoid duplicate endpoint literals
- preserve fail-closed behaviour when author metadata is unavailable
- add regression coverage for trusted-author fallback and unavailable metadata

## Evidence

Some GitHub CLI versions do not expose `authorAssociation` as a `gh pr view --json` field. The previous direct check suppressed that error, left the association empty, and incorrectly applied the external-contributor strict-review boundary to trusted owners and members. The typed `status-json` path already used REST and returned the correct advisory decision.

## Verification

- `.agents/scripts/linters-local.sh`
- `bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh` — 65 passed
- `bash .agents/scripts/tests/test-review-bot-gate-api-snapshot.sh` — 5 passed
- `shellcheck .agents/scripts/review-bot-gate-helper.sh .agents/scripts/tests/test-review-bot-gate-completion-signal.sh`
- live direct-check reproduction now returns `PASS_ADVISORY` for a trusted owner while retaining the no-review-bot advisory message

Resolves #28413
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 with gpt-5.5 spent 14d 6h and 17,684,337 tokens on this with the user in an interactive session.