### PR TITLE
t18131: scope aggregate check evidence by cycle

### DIFF
--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -88,7 +88,7 @@ benchmark's zero-unknown-cost comparability gate.
 ### Evidence sidecar
 
 Each transport aggregate has one sidecar using
-`aidevops-github-api-efficiency-evidence/v1`. `transport_sha256` binds the
+`aidevops-github-api-efficiency-evidence/v2`. `transport_sha256` binds the
 sidecar to the exact aggregate bytes. The result also records the sidecar's own
 SHA-256 digest.
 
@@ -111,7 +111,7 @@ The active transport log remains bounded at 48 hours, one million records, or
 authoritative: unusually high request volume can still exhaust a size bound
 before the requested observation duration and therefore cannot support `PASS`.
 
-Coverage contract `1` starts at a private persisted activation timestamp and is
+Coverage contract `2` starts at a private persisted activation timestamp and is
 re-emitted each cycle so a rolling window becomes bounded only after every
 retained attempt post-dates instrumentation activation. Population, latency,
 cache, single-flight, and path-budget ownership currently emit complete coverage
@@ -120,6 +120,14 @@ remain uncovered—and therefore `null`—until duplicate-action, recovery,
 stale-positive, and dispatch-dependency semantics have complete production
 ownership. Never promote absent events in an uncovered group to observed zero.
 
+Contract `2` also exports one private cycle scope to Pulse child processes. Check
+status evidence hashes that scope with each actionable head and counts physical
+aggregate fetches inside the same scope. This distinguishes duplicate fetches in
+one cycle from freshness-required refreshes of an unchanged head in later cycles.
+The contract uses a new `github-api-efficiency-contract-v2.started-at` activation
+file, so deployment starts a fresh bounded window automatically. Version-1
+sidecars remain immutable historical evidence and are not accepted as version 2.
+
 The following is an intentionally incomplete template. Replace every required
 `null` with a privacy-safe observed value and set `complete` to `true` only when
 the whole fixed window has been reconciled. The transport digest must be 64
@@ -127,7 +135,7 @@ lowercase hexadecimal characters.
 
 ```json
 {
-  "schema": "aidevops-github-api-efficiency-evidence/v1",
+  "schema": "aidevops-github-api-efficiency-evidence/v2",
   "transport_sha256": "<sha256-of-exact-transport-report>",
   "complete": false,
   "population": {
@@ -174,7 +182,9 @@ lowercase hexadecimal characters.
   "path_budgets": {
     "fingerprint_verification_list_calls": null,
     "fresh_empty_live_fallbacks": null,
-    "aggregate_check_fetches": null
+    "aggregate_check_fetches": null,
+    "cycle_scoped_aggregate_check_fetches": null,
+    "unique_cycle_scoped_actionable_heads": null
   }
 }
 ```
@@ -194,7 +204,7 @@ tokens, URLs, or raw log records in the sidecar.
 | `single_flight` | Leader, follower wait, takeover, and duplicate-leader counters. |
 | `webhook` | `pulse-merge-webhook-server.py` emits a protocol-v1 millisecond receive marker; `pulse-merge-webhook-receiver.sh` records successful invalidations, delivery-to-invalidation lag, and invalidations delegated to polling recovery. |
 | `guardrails` | Snapshot/check-cache freshness detections, forced live refreshes, and live required-check preflight mismatches. Unsupported stale-positive and dispatch-dependency fields remain unknown. |
-| `path_budgets` | Deterministic call-site counters from focused request-budget tests/telemetry. |
+| `path_budgets` | Deterministic call-site counters plus cycle-scoped opaque actionable-head/fetch telemetry. Total fetches remain observable while the decision gate compares only identities from the same freshness scope. |
 
 ## Comparability gate
 
@@ -248,7 +258,9 @@ The canary must also have:
 - zero duplicate single-flight leaders, duplicate webhook actions, and missed
   webhook recoveries;
 - zero fingerprint/verification list calls and fresh-empty live fallbacks;
-- no more than one aggregate check fetch per unique actionable head SHA.
+- no more than one cycle-scoped aggregate check fetch per unique
+  cycle-scoped actionable head. Total aggregate fetches remain a trend metric;
+  later-cycle TTL refreshes are not classified as same-cycle duplicates.
 
 Threshold options may make a comparison stricter. Any deliberate relaxation
 requires issue/PR rationale and another canary; do not weaken a threshold merely
@@ -271,15 +283,25 @@ to convert an observed regression into a pass.
 
 ## Current t18131 checkpoint
 
-The retained generation-8 baseline ends at `2026-07-18T06:04:10Z`. Its quota
-cost is unknown for all retained attempts. The later aggregate begins before
-t18130 merged at `2026-07-18T15:49:27Z` (`1784389767`) and also contains unknown
-quota costs. Neither report can produce `PASS`.
+The first homogeneous `v3.32.161` 12-hour aggregate retained 43,199 seconds and
+69,028 exact attempts. Its five owned evidence groups were bounded, but 20,135
+quota costs plus webhook and guardrail semantics remained unknown. The official
+comparison therefore returned `INCONCLUSIVE`.
 
-Therefore this implementation does not tune `.agents/configs/pulse-sweep-budget.json`,
-does not tune `.agents/configs/webhook-receiver.conf`, and removes no feature or
-rollback flag. A valid final comparison requires both a new exact baseline and
-a 12–24 hour post-rollout canary with complete sidecars.
+That window recorded 87 aggregate check fetches and 61 globally unique actionable
+head SHAs. Two adjacent completed six-hour diagnostics recorded `47/43` and
+`40/40` fetches/unique heads. Twenty-two heads occurred in both halves, and the
+cache evidence recorded zero duplicate leaders. The original full-window ratio
+therefore mixed legitimate later-cycle TTL refreshes with duplicate fan-out; it
+did not prove 26 redundant fetches.
+
+Evidence schema/coverage contract 2 corrects the scope mismatch without extending
+terminal or actionable TTLs. It keeps total physical fetches visible and adds a
+separate one-fetch-per-cycle/head gate. Deployment of this contract requires a
+fresh exact baseline and non-overlapping 12–24 hour canary. Until those windows
+and the remaining ownership gaps are complete, this implementation does not tune
+`.agents/configs/pulse-sweep-budget.json`, does not tune
+`.agents/configs/webhook-receiver.conf`, and removes no rollback control.
 
 ## Retained controls and rollback triggers
 

--- a/.agents/scripts/github-api-efficiency-evidence.py
+++ b/.agents/scripts/github-api-efficiency-evidence.py
@@ -28,7 +28,7 @@ from github_api_efficiency_events import (
 from github_api_efficiency_io import AtomicWriteError, atomic_write_text
 
 
-CONTRACT_VERSION = "1"
+CONTRACT_VERSION = "2"
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _COVERAGE_GROUPS = tuple(("population", *EVIDENCE_GROUPS.keys()))
 
@@ -102,6 +102,24 @@ def _unique_actionable_heads(
     return unique
 
 
+def _unique_cycle_scoped_actionable_heads(
+    events: dict[str, Counter[str]], cycle_scoped_fetches: int
+) -> int | None:
+    failures = _sum_event(
+        events, "path_budgets.cycle_scoped_actionable_head_hash_failures"
+    )
+    if failures:
+        return None
+    tokens = events.get("path_budgets.cycle_scoped_actionable_head_token", {})
+    if any(not _SHA256_RE.fullmatch(token) for token in tokens):
+        raise EvidenceBuildError(
+            "cycle-scoped actionable head tokens must be lowercase SHA-256"
+        )
+    if tokens:
+        return len(tokens)
+    return None if cycle_scoped_fetches else 0
+
+
 def _sample_percentile(
     events: dict[str, Counter[str]], name: str, percent: int
 ) -> int | None:
@@ -132,14 +150,17 @@ def _window_is_bounded(
 def _coverage(
     events: dict[str, Counter[str]], meta: dict[str, Any]
 ) -> tuple[dict[str, bool], int | None, int | None]:
-    start = _extreme_int(events, "coverage-start", min)
+    start = _extreme_int(events, "coverage-start", max)
     end = _extreme_int(events, "coverage-end", max)
-    contract = _snapshot(events, "contract", str)
+    contract_values = _parsed_values(events, "contract", str)
+    contract = CONTRACT_VERSION if CONTRACT_VERSION in contract_values else None
     first = _non_negative_int(meta.get("first_retained_ts"), "first retained timestamp")
     last = _non_negative_int(meta.get("last_retained_ts"), "last retained timestamp")
     bounded = _window_is_bounded(contract, start, end, first, last)
     groups = {
-        group: bounded and _snapshot(events, f"coverage.{group}", str) == CONTRACT_VERSION
+        group: bounded
+        and CONTRACT_VERSION
+        in _parsed_values(events, f"coverage.{group}", str)
         for group in _COVERAGE_GROUPS
     }
     if _non_negative_int(
@@ -210,6 +231,21 @@ def _build_count_group(
     }
 
 
+def _build_path_budgets(
+    events: dict[str, Counter[str]], covered: bool
+) -> dict[str, int | None]:
+    payload = _build_count_group(events, "path_budgets", covered)
+    if not covered:
+        return payload
+    cycle_scoped_fetches = payload["cycle_scoped_aggregate_check_fetches"]
+    if cycle_scoped_fetches is None:
+        return payload
+    payload["unique_cycle_scoped_actionable_heads"] = (
+        _unique_cycle_scoped_actionable_heads(events, cycle_scoped_fetches)
+    )
+    return payload
+
+
 def _build_latency(
     events: dict[str, Counter[str]], meta: dict[str, Any], covered: bool
 ) -> dict[str, int | None]:
@@ -263,8 +299,12 @@ def build_sidecar(report: dict[str, Any], transport_sha256: str) -> dict[str, An
         ),
         "webhook": _build_webhook(events, covered["webhook"]),
     }
-    for group in ("guardrails", "path_budgets"):
-        payload[group] = _build_count_group(events, group, covered[group])
+    payload["guardrails"] = _build_count_group(
+        events, "guardrails", covered["guardrails"]
+    )
+    payload["path_budgets"] = _build_path_budgets(
+        events, covered["path_budgets"]
+    )
     missing = _missing_fields(payload)
     payload["complete"] = not missing and all(covered.values())
     payload["_meta"] = {

--- a/.agents/scripts/github_api_efficiency_inputs.py
+++ b/.agents/scripts/github_api_efficiency_inputs.py
@@ -19,7 +19,7 @@ from github_api_efficiency_metrics import (
 )
 
 
-EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v1"
+EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v2"
 TRANSPORT_SCHEMA_VERSION = 2
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _MAX_SAFE_INTEGER = 9_007_199_254_740_991
@@ -84,6 +84,8 @@ EVIDENCE_GROUPS = {
         "fingerprint_verification_list_calls",
         "fresh_empty_live_fallbacks",
         "aggregate_check_fetches",
+        "cycle_scoped_aggregate_check_fetches",
+        "unique_cycle_scoped_actionable_heads",
     ),
 }
 _MEASURED_EVIDENCE_FIELDS = frozenset(
@@ -275,6 +277,26 @@ def _validate_evidence_groups(payload: dict[str, Any]) -> None:
             )
 
 
+def _validate_path_budget_relationships(payload: dict[str, Any]) -> None:
+    path_budgets = payload["path_budgets"]
+    population = payload["population"]
+    relationships = (
+        (
+            path_budgets["cycle_scoped_aggregate_check_fetches"],
+            path_budgets["aggregate_check_fetches"],
+            "cycle-scoped aggregate check fetches exceed total fetches",
+        ),
+        (
+            path_budgets["unique_cycle_scoped_actionable_heads"],
+            population["actionable_changes"],
+            "cycle-scoped actionable heads exceed actionable observations",
+        ),
+    )
+    for left, right, message in relationships:
+        if None not in (left, right) and left > right:
+            raise BenchmarkInputError(f"evidence {message}")
+
+
 def _validate_evidence(
     payload: dict[str, Any], transport_sha256: str
 ) -> None:
@@ -288,6 +310,7 @@ def _validate_evidence(
         raise BenchmarkInputError("evidence.complete must be boolean")
     _validate_population(payload)
     _validate_evidence_groups(payload)
+    _validate_path_budget_relationships(payload)
 
 
 def load_transport_report(

--- a/.agents/scripts/github_api_efficiency_inputs.py
+++ b/.agents/scripts/github_api_efficiency_inputs.py
@@ -213,22 +213,32 @@ def _validate_report(payload: dict[str, Any]) -> None:
             )
 
 
-def _validate_population_relationships(population: dict[str, Any]) -> None:
+def _validate_evidence_relationships(payload: dict[str, Any]) -> None:
+    population = payload["population"]
+    path_budgets = payload["path_budgets"]
     constraints = (
         (
-            "unchanged_cycles",
-            "pulse_cycles",
+            population["unchanged_cycles"],
+            population["pulse_cycles"],
             "evidence unchanged cycles exceed Pulse cycles",
         ),
         (
-            "unique_actionable_head_shas",
-            "actionable_changes",
+            population["unique_actionable_head_shas"],
+            population["actionable_changes"],
             "evidence unique actionable head SHAs exceed actionable changes",
         ),
+        (
+            path_budgets["cycle_scoped_aggregate_check_fetches"],
+            path_budgets["aggregate_check_fetches"],
+            "evidence cycle-scoped aggregate check fetches exceed total fetches",
+        ),
+        (
+            path_budgets["unique_cycle_scoped_actionable_heads"],
+            population["actionable_changes"],
+            "evidence cycle-scoped actionable heads exceed actionable observations",
+        ),
     )
-    for left_field, right_field, message in constraints:
-        left = population[left_field]
-        right = population[right_field]
+    for left, right, message in constraints:
         if None not in (left, right) and left > right:
             raise BenchmarkInputError(message)
 
@@ -243,7 +253,6 @@ def _validate_population(payload: dict[str, Any]) -> None:
             f"evidence.population.{field}",
             nullable=True,
         )
-    _validate_population_relationships(population)
     if "repository_set_sha256" not in population:
         raise BenchmarkInputError(
             "evidence.population.repository_set_sha256 is required"
@@ -277,26 +286,6 @@ def _validate_evidence_groups(payload: dict[str, Any]) -> None:
             )
 
 
-def _validate_path_budget_relationships(payload: dict[str, Any]) -> None:
-    path_budgets = payload["path_budgets"]
-    population = payload["population"]
-    relationships = (
-        (
-            path_budgets["cycle_scoped_aggregate_check_fetches"],
-            path_budgets["aggregate_check_fetches"],
-            "cycle-scoped aggregate check fetches exceed total fetches",
-        ),
-        (
-            path_budgets["unique_cycle_scoped_actionable_heads"],
-            population["actionable_changes"],
-            "cycle-scoped actionable heads exceed actionable observations",
-        ),
-    )
-    for left, right, message in relationships:
-        if None not in (left, right) and left > right:
-            raise BenchmarkInputError(f"evidence {message}")
-
-
 def _validate_evidence(
     payload: dict[str, Any], transport_sha256: str
 ) -> None:
@@ -310,7 +299,7 @@ def _validate_evidence(
         raise BenchmarkInputError("evidence.complete must be boolean")
     _validate_population(payload)
     _validate_evidence_groups(payload)
-    _validate_path_budget_relationships(payload)
+    _validate_evidence_relationships(payload)
 
 
 def load_transport_report(

--- a/.agents/scripts/github_api_efficiency_report.py
+++ b/.agents/scripts/github_api_efficiency_report.py
@@ -342,15 +342,15 @@ def _budget_regression_reasons(canary: Window) -> list[str]:
             f"canary {group}.{field} is non-zero",
         )
     check_fetches = canary.evidence["path_budgets"][
-        "aggregate_check_fetches"
+        "cycle_scoped_aggregate_check_fetches"
     ]
-    unique_heads = canary.evidence["population"][
-        "unique_actionable_head_shas"
+    unique_heads = canary.evidence["path_budgets"][
+        "unique_cycle_scoped_actionable_heads"
     ]
     _flag(
         reasons,
         check_fetches > unique_heads,
-        "aggregate check fetches exceed unique actionable head SHAs",
+        "cycle-scoped aggregate check fetches exceed cycle-scoped actionable heads",
     )
     return reasons
 

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -35,6 +35,7 @@ fi
 _PULSE_EFFICIENCY_CYCLE_STARTED=0
 _PULSE_EFFICIENCY_CYCLE_START_MS=0
 _PULSE_EFFICIENCY_CYCLE_OUTCOME=idle
+_PULSE_EFFICIENCY_CONTRACT_VERSION=2
 _PULSE_LEGACY_CYCLE_OUTCOME_PENDING=0
 
 _pulse_efficiency_record() {
@@ -65,7 +66,7 @@ _pulse_efficiency_now_ms() {
 
 _pulse_efficiency_coverage_start_seconds() {
 	local now_seconds="$1"
-	local state_file="${AIDEVOPS_GH_API_EVIDENCE_COVERAGE_START_FILE:-${AIDEVOPS_STATE_DIR:-${HOME}/.aidevops/state}/github-api-efficiency-contract-v1.started-at}"
+	local state_file="${AIDEVOPS_GH_API_EVIDENCE_COVERAGE_START_FILE:-${AIDEVOPS_STATE_DIR:-${HOME}/.aidevops/state}/github-api-efficiency-contract-v${_PULSE_EFFICIENCY_CONTRACT_VERSION}.started-at}"
 	local state_dir="${state_file%/*}"
 	local existing=""
 	local temporary=""
@@ -114,6 +115,7 @@ _pulse_efficiency_cycle_start() {
 	local now_ms=""
 	local coverage_start=""
 	local group=""
+	unset AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID
 	now_seconds=$(_pulse_efficiency_now_seconds)
 	now_ms=$(_pulse_efficiency_now_ms) || now_ms=""
 	[[ "$now_seconds" =~ ^[0-9]+$ && "$now_seconds" -gt 0 ]] || return 0
@@ -123,10 +125,12 @@ _pulse_efficiency_cycle_start() {
 	_PULSE_EFFICIENCY_CYCLE_STARTED=1
 	_PULSE_EFFICIENCY_CYCLE_START_MS="$now_ms"
 	_PULSE_EFFICIENCY_CYCLE_OUTCOME=idle
-	_pulse_efficiency_record contract 1
+	AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID="$now_seconds"
+	export AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID
+	_pulse_efficiency_record contract "$_PULSE_EFFICIENCY_CONTRACT_VERSION"
 	_pulse_efficiency_record coverage-start "$coverage_start"
 	for group in population latency cache single_flight path_budgets; do
-		_pulse_efficiency_record "coverage.${group}" 1
+		_pulse_efficiency_record "coverage.${group}" "$_PULSE_EFFICIENCY_CONTRACT_VERSION"
 	done
 	return 0
 }
@@ -136,7 +140,10 @@ _pulse_efficiency_cycle_finish() {
 	local now_seconds=""
 	local now_ms=""
 	local elapsed_ms=0
-	[[ "${_PULSE_EFFICIENCY_CYCLE_STARTED:-0}" == "1" ]] || return 0
+	if [[ "${_PULSE_EFFICIENCY_CYCLE_STARTED:-0}" != "1" ]]; then
+		unset AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID
+		return 0
+	fi
 	now_seconds=$(_pulse_efficiency_now_seconds)
 	now_ms=$(_pulse_efficiency_now_ms) || now_ms=""
 	[[ "$now_seconds" =~ ^[0-9]+$ && "$now_seconds" -gt 0 ]] || now_seconds=0
@@ -162,6 +169,7 @@ _pulse_efficiency_cycle_finish() {
 		gh_trim_log 2>/dev/null || true
 	fi
 	_PULSE_EFFICIENCY_CYCLE_STARTED=0
+	unset AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID
 	return 0
 }
 

--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -102,6 +102,9 @@ _gh_pr_check_status_cache_record() {
 			;;
 		fetch)
 			gh_record_efficiency_evidence path_budgets.aggregate_check_fetches 1 2>/dev/null || true
+			if [[ "${AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID:-}" =~ ^[0-9]+$ ]]; then
+				gh_record_efficiency_evidence path_budgets.cycle_scoped_aggregate_check_fetches 1 2>/dev/null || true
+			fi
 			;;
 		publish-fenced | publish-invalidated)
 			gh_record_efficiency_evidence guardrails.stale_snapshot_detections 1 2>/dev/null || true
@@ -116,6 +119,8 @@ _gh_pr_check_status_record_actionable_head() {
 	local sha="$2"
 	local normalized_sha=""
 	local token=""
+	local cycle_id="${AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID:-}"
+	local cycle_token=""
 	_gh_pr_check_status_cache_identity_valid "$slug" "$sha" || return 0
 	declare -F gh_record_efficiency_evidence >/dev/null 2>&1 || return 0
 	gh_record_efficiency_evidence population.actionable_changes 1 2>/dev/null || true
@@ -127,6 +132,15 @@ _gh_pr_check_status_record_actionable_head() {
 		gh_record_efficiency_evidence population.actionable_head_token "$token" 2>/dev/null || true
 	else
 		gh_record_efficiency_evidence population.actionable_head_hash_failures 1 2>/dev/null || true
+	fi
+	[[ "$cycle_id" =~ ^[0-9]+$ ]] || return 0
+	if declare -F _ghrs_digest >/dev/null 2>&1; then
+		cycle_token=$(_ghrs_digest "${cycle_id}"$'\034'"${normalized_sha}") || cycle_token=""
+	fi
+	if [[ -n "$cycle_token" ]]; then
+		gh_record_efficiency_evidence path_budgets.cycle_scoped_actionable_head_token "$cycle_token" 2>/dev/null || true
+	else
+		gh_record_efficiency_evidence path_budgets.cycle_scoped_actionable_head_hash_failures 1 2>/dev/null || true
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-gh-check-status-cache.sh
+++ b/.agents/scripts/tests/test-gh-check-status-cache.sh
@@ -454,6 +454,7 @@ test_invalidation_fences_all_auth_scopes() {
 test_efficiency_evidence_tracks_exact_decisions() {
 	local result=""
 	: >"$EFFICIENCY_EVENTS"
+	export AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID=1100
 	CHECK_NOW=1100
 	CHECK_API_MODE=success
 	CHECK_SUITES_FIXTURE='{}'
@@ -474,15 +475,20 @@ test_efficiency_evidence_tracks_exact_decisions() {
 		"$(efficiency_event_total cache.invalidated)"
 	assert_eq "one leader transport records one aggregate check fetch" "1" \
 		"$(efficiency_event_total path_budgets.aggregate_check_fetches)"
+	assert_eq "one cycle leader records one cycle-scoped aggregate fetch" "1" \
+		"$(efficiency_event_total path_budgets.cycle_scoped_aggregate_check_fetches)"
 	assert_eq "each batch observation records one actionable change" "2" \
 		"$(efficiency_event_total population.actionable_changes)"
 	assert_eq "repeated actionable heads use one opaque token" "1" \
 		"$(efficiency_event_unique_values population.actionable_head_token)"
+	assert_eq "repeated heads in one cycle use one cycle-scoped token" "1" \
+		"$(efficiency_event_unique_values path_budgets.cycle_scoped_actionable_head_token)"
 	if grep -Fq "$SHA_K" "$EFFICIENCY_EVENTS"; then
 		printf 'FAIL: actionable evidence exposed a raw head SHA\n' >&2
 		return 1
 	fi
 	printf 'PASS: actionable evidence keeps head identities opaque\n'
+	unset AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID
 	return 0
 }
 

--- a/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
+++ b/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
@@ -100,7 +100,7 @@ from pathlib import Path
 import sys
 
 ROOT = Path(sys.argv[1])
-EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v1"
+EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v2"
 REPOSITORY_SET = "a" * 64
 
 
@@ -224,6 +224,8 @@ def evidence(*, p50, p95, burst, completed_p95, webhook_p95, complete=True):
             "fingerprint_verification_list_calls": 0,
             "fresh_empty_live_fallbacks": 0,
             "aggregate_check_fetches": 20,
+            "cycle_scoped_aggregate_check_fetches": 20,
+            "unique_cycle_scoped_actionable_heads": 20,
         },
     }
 
@@ -304,6 +306,8 @@ regression_evidence = evidence(
 regression_evidence["single_flight"]["duplicate_leaders"] = 1
 regression_evidence["webhook"]["duplicate_actions"] = 1
 regression_evidence["path_budgets"]["fingerprint_verification_list_calls"] = 1
+regression_evidence["path_budgets"]["aggregate_check_fetches"] = 21
+regression_evidence["path_budgets"]["cycle_scoped_aggregate_check_fetches"] = 21
 write_case("regression", regression_report, regression_evidence)
 
 incomplete_evidence = copy.deepcopy(PASS_EVIDENCE)
@@ -330,6 +334,8 @@ workload_evidence = copy.deepcopy(PASS_EVIDENCE)
 workload_evidence["population"]["unchanged_cycles"] = 100
 workload_evidence["population"]["actionable_changes"] = 0
 workload_evidence["population"]["unique_actionable_head_shas"] = 0
+workload_evidence["path_budgets"]["cycle_scoped_aggregate_check_fetches"] = 0
+workload_evidence["path_budgets"]["unique_cycle_scoped_actionable_heads"] = 0
 write_case("workload", PASS_REPORT, workload_evidence)
 
 invalid_population_evidence = copy.deepcopy(PASS_EVIDENCE)
@@ -456,6 +462,8 @@ test_regression() {
 		'.status == "REGRESSION" and (.reasons | length) >= 5' "$LAST_JSON"
 	assert_jq "path budget breach is explicit" \
 		'.reasons | any(contains("fingerprint_verification_list_calls"))' "$LAST_JSON"
+	assert_jq "cycle-scoped fetch budget breach is explicit" \
+		'.reasons | any(contains("cycle-scoped aggregate check fetches"))' "$LAST_JSON"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-github-api-efficiency-evidence.sh
+++ b/.agents/scripts/tests/test-github-api-efficiency-evidence.sh
@@ -182,16 +182,16 @@ def transport(events):
 
 
 EVENTS = [
-    ("contract", "1", 1),
+    ("contract", "2", 1),
     ("coverage-start", "900", 1),
     ("coverage-end", "1100", 1),
-    ("coverage.population", "1", 1),
-    ("coverage.latency", "1", 1),
-    ("coverage.cache", "1", 1),
-    ("coverage.single_flight", "1", 1),
-    ("coverage.webhook", "1", 1),
-    ("coverage.guardrails", "1", 1),
-    ("coverage.path_budgets", "1", 1),
+    ("coverage.population", "2", 1),
+    ("coverage.latency", "2", 1),
+    ("coverage.cache", "2", 1),
+    ("coverage.single_flight", "2", 1),
+    ("coverage.webhook", "2", 1),
+    ("coverage.guardrails", "2", 1),
+    ("coverage.path_budgets", "2", 1),
     ("population.repository_count", "10", 1),
     ("population.repository_set_sha256", REPOSITORY_SET, 1),
     ("population.pulse_cycles", "4", 1),
@@ -213,11 +213,24 @@ EVENTS = [
     ("webhook.lag_ms", "30", 2),
     ("guardrails.stale_snapshot_detections", "1", 1),
     ("guardrails.forced_live_refreshes", "1", 1),
-    ("path_budgets.aggregate_check_fetches", "1", 1),
+    ("path_budgets.aggregate_check_fetches", "1", 2),
+    ("path_budgets.cycle_scoped_aggregate_check_fetches", "1", 2),
+    ("path_budgets.cycle_scoped_actionable_head_token", "d" * 64, 1),
+    ("path_budgets.cycle_scoped_actionable_head_token", "e" * 64, 2),
 ]
 
 complete = transport(EVENTS)
 write_json(ROOT / "complete-report.json", complete)
+
+mixed_contract_events = EVENTS + [
+    ("contract", "1", 1),
+    ("coverage-start", "800", 1),
+    *[(f"coverage.{group}", "1", 1) for group in (
+        "population", "latency", "cache", "single_flight", "webhook",
+        "guardrails", "path_budgets",
+    )],
+]
+write_json(ROOT / "mixed-contract-report.json", transport(mixed_contract_events))
 
 incomplete_events = [
     event for event in EVENTS if event[0] != "coverage.webhook"
@@ -232,6 +245,12 @@ head_hash_failure = transport(
     EVENTS + [("population.actionable_head_hash_failures", "1", 1)]
 )
 write_json(ROOT / "head-hash-failure-report.json", head_hash_failure)
+
+cycle_head_hash_failure = transport(
+    EVENTS
+    + [("path_budgets.cycle_scoped_actionable_head_hash_failures", "1", 1)]
+)
+write_json(ROOT / "cycle-head-hash-failure-report.json", cycle_head_hash_failure)
 
 bad_integer = transport(EVENTS)
 bad_integer["by_route_decision"]["evidence:cache.fresh_hits:bad"] = {
@@ -252,6 +271,31 @@ untyped["by_route_decision"]["evidence:cache.fresh_hits:3"][
 write_json(ROOT / "untyped-report.json", untyped)
 PY
 
+test_hash_failure_evidence() {
+    local head_output="${TEST_ROOT}/head-hash-failure-evidence.json"
+    local cycle_output="${TEST_ROOT}/cycle-head-hash-failure-evidence.json"
+
+    run_build "${TEST_ROOT}/head-hash-failure-report.json" "$head_output"
+    assert_eq "actionable head hash failure exits zero" "0" "$LAST_EXIT"
+    assert_contains "actionable head hash failure reports incomplete" "evidence sidecar: incomplete" "$LAST_OUTPUT"
+    assert_jq "actionable head hash failure stays unknown" '.complete == false and .population.actionable_changes == 3 and .population.unique_actionable_head_shas == null and (._meta.missing_fields | index("population.unique_actionable_head_shas")) != null' "$head_output"
+
+    run_build "${TEST_ROOT}/cycle-head-hash-failure-report.json" "$cycle_output"
+    assert_eq "cycle-scoped head hash failure exits zero" "0" "$LAST_EXIT"
+    assert_contains "cycle-scoped head hash failure reports incomplete" "evidence sidecar: incomplete" "$LAST_OUTPUT"
+    assert_jq "cycle-scoped head hash failure stays unknown" '.complete == false and .path_budgets.cycle_scoped_aggregate_check_fetches == 2 and .path_budgets.unique_cycle_scoped_actionable_heads == null and (._meta.missing_fields | index("path_budgets.unique_cycle_scoped_actionable_heads")) != null' "$cycle_output"
+    return 0
+}
+
+test_contract_migration_evidence() {
+    local output="${TEST_ROOT}/mixed-contract-evidence.json"
+    run_build "${TEST_ROOT}/mixed-contract-report.json" "$output"
+    assert_eq "mixed historical contract exits zero" "0" "$LAST_EXIT"
+    assert_contains "current contract survives historical markers" "evidence sidecar: complete" "$LAST_OUTPUT"
+    assert_jq "latest activation bounds migrated evidence" '._meta.contract_version == "2" and ._meta.coverage_start_ts == 900 and .complete == true' "$output"
+    return 0
+}
+
 main() {
     local complete_report="${TEST_ROOT}/complete-report.json"
     local complete_output="${TEST_ROOT}/complete-evidence.json"
@@ -265,9 +309,9 @@ main() {
     run_build "$complete_report" "$complete_output"
     assert_eq "complete evidence exits zero" "0" "$LAST_EXIT"
     assert_contains "complete evidence reports status" "evidence sidecar: complete" "$LAST_OUTPUT"
-    assert_jq "complete evidence populates every group" ".complete and .population.repository_count == 10 and .population.pulse_cycles == 4 and .population.unchanged_cycles == 3 and .population.actionable_changes == 3 and .population.unique_actionable_head_shas == 2 and .latency.p50_ms == 10 and .latency.p95_ms == 30 and .latency.peak_attempts_per_minute == 2 and .latency.completed_action_p95_ms == 200 and .cache.fresh_hits == 3 and .cache.fresh_empty_hits == 1 and .cache.misses == 2 and .cache.stale == 1 and .cache.invalidated == 1 and .single_flight.leaders == 2 and .single_flight.waits == 1 and .single_flight.takeovers == 0 and .single_flight.duplicate_leaders == 0 and .webhook.invalidations == 2 and .webhook.lag_p50_ms == 30 and .webhook.lag_p95_ms == 30 and .webhook.duplicate_actions == 0 and .webhook.missed_recoveries == 0 and (._meta.missing_fields | length) == 0" "$complete_output"
+    assert_jq "complete evidence populates every group" ".complete and .population.repository_count == 10 and .population.pulse_cycles == 4 and .population.unchanged_cycles == 3 and .population.actionable_changes == 3 and .population.unique_actionable_head_shas == 2 and .latency.p50_ms == 10 and .latency.p95_ms == 30 and .latency.peak_attempts_per_minute == 2 and .latency.completed_action_p95_ms == 200 and .cache.fresh_hits == 3 and .cache.fresh_empty_hits == 1 and .cache.misses == 2 and .cache.stale == 1 and .cache.invalidated == 1 and .single_flight.leaders == 2 and .single_flight.waits == 1 and .single_flight.takeovers == 0 and .single_flight.duplicate_leaders == 0 and .webhook.invalidations == 2 and .webhook.lag_p50_ms == 30 and .webhook.lag_p95_ms == 30 and .webhook.duplicate_actions == 0 and .webhook.missed_recoveries == 0 and .path_budgets.aggregate_check_fetches == 2 and .path_budgets.cycle_scoped_aggregate_check_fetches == 2 and .path_budgets.unique_cycle_scoped_actionable_heads == 2 and (._meta.missing_fields | length) == 0" "$complete_output"
     schema=$(jq -r .schema "$complete_output")
-    assert_eq "sidecar schema is versioned" "aidevops-github-api-efficiency-evidence/v1" "$schema"
+    assert_eq "sidecar schema is versioned" "aidevops-github-api-efficiency-evidence/v2" "$schema"
     repository_set=$(jq -r .population.repository_set_sha256 "$complete_output")
     assert_eq "repository population stays digest-only" "$(printf "a%.0s" {1..64})" "$repository_set"
     expected_digest=$(file_sha256 "$complete_report")
@@ -275,6 +319,8 @@ main() {
     assert_eq "sidecar binds exact transport bytes" "$expected_digest" "$actual_digest"
     mode=$(file_mode "$complete_output")
     assert_eq "sidecar output is private" "600" "$mode"
+
+    test_contract_migration_evidence
 
     cp "$complete_output" "$first_output"
     run_build "$complete_report" "$complete_output"
@@ -295,11 +341,7 @@ main() {
     assert_eq "unknown latency evidence exits zero" "0" "$LAST_EXIT"
     assert_jq "unknown latency invalidates only latency coverage" ".complete == false and .latency.p50_ms == null and .latency.p95_ms == null and .latency.peak_attempts_per_minute == null and .latency.completed_action_p95_ms == null and ._meta.coverage_groups.latency == false and (._meta.missing_fields | length) == 4" "$unknown_latency_output"
 
-    local head_hash_failure_output="${TEST_ROOT}/head-hash-failure-evidence.json"
-    run_build "${TEST_ROOT}/head-hash-failure-report.json" "$head_hash_failure_output"
-    assert_eq "actionable head hash failure exits zero" "0" "$LAST_EXIT"
-    assert_contains "actionable head hash failure reports incomplete" "evidence sidecar: incomplete" "$LAST_OUTPUT"
-    assert_jq "actionable head hash failure stays unknown" '.complete == false and .population.actionable_changes == 3 and .population.unique_actionable_head_shas == null and (._meta.missing_fields | index("population.unique_actionable_head_shas")) != null' "$head_hash_failure_output"
+    test_hash_failure_evidence
 
     local bad_output="${TEST_ROOT}/bad-evidence.json"
     run_build "${TEST_ROOT}/bad-integer-report.json" "$bad_output"

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -151,18 +151,21 @@ fi
 : >"$AGGREGATE_FILE"
 : >"$TRIM_FILE"
 _pulse_efficiency_cycle_start
+efficiency_cycle_id="${AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID:-}"
 _PULSE_EFFICIENCY_CYCLE_START_MS=$((_PULSE_EFFICIENCY_CYCLE_START_MS - 25))
 _pulse_efficiency_cycle_finish idle
-if grep -q '^contract=1$' "$EVIDENCE_FILE" \
+if grep -q '^contract=2$' "$EVIDENCE_FILE" \
 	&& grep -q '^coverage-start=[0-9]' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.population=1$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.latency=1$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.cache=1$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.single_flight=1$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.path_budgets=1$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.population=2$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.latency=2$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.cache=2$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.single_flight=2$' "$EVIDENCE_FILE" \
+	&& grep -q '^coverage.path_budgets=2$' "$EVIDENCE_FILE" \
 	&& grep -q '^population.pulse_cycles=1$' "$EVIDENCE_FILE" \
 	&& grep -q '^population.unchanged_cycles=1$' "$EVIDENCE_FILE" \
 	&& grep -q '^coverage-end=[0-9]' "$EVIDENCE_FILE" \
+	&& [[ "$efficiency_cycle_id" =~ ^[0-9]+$ ]] \
+	&& [[ -z "${AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID:-}" ]] \
 	&& ! grep -q '^latency.completed_action_ms=' "$EVIDENCE_FILE"; then
 	pass "idle cycle publishes complete typed evidence"
 else


### PR DESCRIPTION
## Summary

Scope aggregate-check path budgets to each Pulse evidence cycle so legitimate later-cycle TTL refreshes remain visible without being misclassified as duplicate same-cycle fetches. Upgrade the sidecar and coverage contract to v2, retain total fetches as a trend metric, and reset bounded coverage at v2 activation.

This PR delivers the measurement-contract prerequisite; it does not complete the benchmark, rollout, or flag-retirement task.

## Files Changed

.agents/reference/github-api-efficiency.md, .agents/scripts/github-api-efficiency-evidence.py, .agents/scripts/github_api_efficiency_inputs.py, .agents/scripts/github_api_efficiency_report.py, .agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/shared-gh-wrappers-checks.sh, .agents/scripts/tests/test-gh-check-status-cache.sh, .agents/scripts/tests/test-github-api-efficiency-benchmark.sh, .agents/scripts/tests/test-github-api-efficiency-evidence.sh, .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh

## Runtime Testing

- **Risk level:** Low (observability contract and infrastructure scripts)
- **Verification:** Cache regression suite passed; evidence suite 40/40; benchmark suite 36/36; Pulse cycle-gate suite 17/17; ShellCheck and Python byte-compilation passed; changed-file and full local quality gates passed; all PR checks passed.

## Remaining Issue Work

- Deploy contract v2 only with explicit release authorization.
- Collect fresh, non-overlapping comparable windows.
- Complete quota, webhook, and guardrail attribution before any PASS or flag-retirement decision.

For #27777

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 4d 12h and 20,701,014 tokens on this with the user in an interactive session.
