### PR TITLE
GH#28422: Transfer review scanner worktree ownership safely

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -49,8 +49,15 @@ PRRTS_RC_GRAPHQL_EXHAUSTED=75
 PRRTS_BLOCKED_BY_CODE="code"
 PRRTS_BLOCKED_BY_INFRASTRUCTURE="infrastructure"
 PRRTS_REASON_HEAD_FETCH_FAILED="pr_head_fetch_failed"
+PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED="review_worktree_ownership_unverified"
 PRRTS_WORKTREE_FAILURE_BLOCKED_BY="$PRRTS_BLOCKED_BY_INFRASTRUCTURE"
 PRRTS_WORKTREE_FAILURE_REASON="review_worktree_preparation_failed"
+PRRTS_WORKTREE_TRANSFER_MODE=""
+PRRTS_WORKTREE_EXPECTED_OWNER_PID=""
+PRRTS_WORKTREE_EXPECTED_OWNER_SESSION=""
+PRRTS_WORKTREE_EXPECTED_OWNER_BATCH=""
+PRRTS_WORKTREE_EXPECTED_OWNER_TASK=""
+PRRTS_WORKTREE_EXPECTED_OWNER_CREATED_AT=""
 
 _prrts_ensure_dirs() {
 	local log_dir=""
@@ -1207,6 +1214,182 @@ _prrts_fetch_exact_worker_head() {
 	return 0
 }
 
+_prrts_reset_worktree_transfer_context() {
+	PRRTS_WORKTREE_TRANSFER_MODE=""
+	PRRTS_WORKTREE_EXPECTED_OWNER_PID=""
+	PRRTS_WORKTREE_EXPECTED_OWNER_SESSION=""
+	PRRTS_WORKTREE_EXPECTED_OWNER_BATCH=""
+	PRRTS_WORKTREE_EXPECTED_OWNER_TASK=""
+	PRRTS_WORKTREE_EXPECTED_OWNER_CREATED_AT=""
+	return 0
+}
+
+_prrts_read_worktree_owner_snapshot() {
+	local worktree_path="$1"
+	local owner_pid_var="$2"
+	local owner_session_var="$3"
+	local owner_batch_var="$4"
+	local owner_task_var="$5"
+	local owner_created_at_var="$6"
+	local owner_info=""
+	local parsed_pid="" parsed_session="" parsed_batch="" parsed_task="" parsed_created_at=""
+
+	declare -F check_worktree_owner >/dev/null 2>&1 || return 1
+	owner_info=$(check_worktree_owner "$worktree_path" 2>/dev/null || true)
+	[[ -n "$owner_info" ]] || return 1
+	IFS='|' read -r parsed_pid parsed_session parsed_batch parsed_task parsed_created_at <<<"$owner_info"
+	printf -v "$owner_pid_var" '%s' "$parsed_pid"
+	printf -v "$owner_session_var" '%s' "$parsed_session"
+	printf -v "$owner_batch_var" '%s' "$parsed_batch"
+	printf -v "$owner_task_var" '%s' "$parsed_task"
+	printf -v "$owner_created_at_var" '%s' "$parsed_created_at"
+	return 0
+}
+
+_prrts_apply_expected_worktree_owner() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local worktree_path="$3"
+	local owner_pid="$4"
+	local owner_session="$5"
+	local owner_batch="$6"
+	local owner_task="$7"
+	local owner_created_at="$8"
+	local required_session="$9"
+
+	if [[ -z "$owner_task" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED"
+	elif [[ "$owner_task" != "$pr_number" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="review_worktree_owned_by_other_task"
+	elif [[ ! "$owner_pid" =~ ^[0-9]+$ || -z "$owner_session" || -z "$owner_created_at" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED"
+	elif [[ -n "$required_session" && "$owner_session" != "$required_session" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED"
+	else
+		PRRTS_WORKTREE_TRANSFER_MODE="continuation"
+		PRRTS_WORKTREE_EXPECTED_OWNER_PID="$owner_pid"
+		PRRTS_WORKTREE_EXPECTED_OWNER_SESSION="$owner_session"
+		PRRTS_WORKTREE_EXPECTED_OWNER_BATCH="$owner_batch"
+		PRRTS_WORKTREE_EXPECTED_OWNER_TASK="$owner_task"
+		PRRTS_WORKTREE_EXPECTED_OWNER_CREATED_AT="$owner_created_at"
+		return 0
+	fi
+
+	_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — worktree ownership cannot be transferred safely (${PRRTS_WORKTREE_FAILURE_REASON}, path=${worktree_path})"
+	return 1
+}
+
+_prrts_capture_expected_worktree_owner() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local worktree_path="$3"
+	local required_session="${4:-}"
+	local owner_pid=""
+	local owner_session=""
+	local owner_batch=""
+	local owner_task=""
+	local owner_created_at=""
+
+	if ! _prrts_read_worktree_owner_snapshot "$worktree_path" owner_pid owner_session owner_batch owner_task owner_created_at; then
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — worktree has no verifiable ownership record (${worktree_path})"
+		return 1
+	fi
+	_prrts_apply_expected_worktree_owner "$repo_slug" "$pr_number" "$worktree_path" \
+		"$owner_pid" "$owner_session" "$owner_batch" "$owner_task" "$owner_created_at" "$required_session" || return 1
+	return 0
+}
+
+_prrts_claim_dispatch_precreate_owner() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local worktree_path="$3"
+	local head_ref="$4"
+	local precreate_session="dispatch-precreate-${pr_number}"
+
+	if ! declare -F claim_worktree_ownership >/dev/null 2>&1; then
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — atomic worktree ownership claim is unavailable"
+		return 1
+	fi
+	if ! claim_worktree_ownership "$worktree_path" "$head_ref" \
+		--task "$pr_number" --session "$precreate_session" --owner-pid "$$" 2>/dev/null; then
+		PRRTS_WORKTREE_FAILURE_REASON="review_worktree_ownership_conflict"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — atomic worktree ownership claim was rejected (${worktree_path})"
+		return 1
+	fi
+	_prrts_capture_expected_worktree_owner "$repo_slug" "$pr_number" "$worktree_path" "$precreate_session" || return 1
+	return 0
+}
+
+_prrts_prepare_reused_worktree_owner() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local worktree_path="$3"
+	local head_ref="$4"
+	local owner_pid=""
+	local owner_session=""
+	local owner_batch=""
+	local owner_task=""
+	local owner_created_at=""
+
+	if ! _prrts_read_worktree_owner_snapshot "$worktree_path" owner_pid owner_session owner_batch owner_task owner_created_at; then
+		_prrts_claim_dispatch_precreate_owner "$repo_slug" "$pr_number" "$worktree_path" "$head_ref" || return 1
+		return 0
+	fi
+	_prrts_apply_expected_worktree_owner "$repo_slug" "$pr_number" "$worktree_path" \
+		"$owner_pid" "$owner_session" "$owner_batch" "$owner_task" "$owner_created_at" "" || return 1
+	_prrts_log "dispatch: ${repo_slug}#${pr_number} preserved reused worktree owner for exact continuation transfer (${worktree_path})"
+	return 0
+}
+
+_prrts_prepare_created_worktree_owner() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local worktree_path="$3"
+	local head_ref="$4"
+	local precreate_session="dispatch-precreate-${pr_number}"
+	local owner_pid=""
+	local owner_session=""
+	local owner_batch=""
+	local owner_task=""
+	local owner_created_at=""
+
+	if ! _prrts_read_worktree_owner_snapshot "$worktree_path" owner_pid owner_session owner_batch owner_task owner_created_at; then
+		_prrts_claim_dispatch_precreate_owner "$repo_slug" "$pr_number" "$worktree_path" "$head_ref" || return 1
+		return 0
+	fi
+	if [[ -z "$owner_task" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED"
+	elif [[ "$owner_task" != "$pr_number" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="review_worktree_owned_by_other_task"
+	elif [[ ! "$owner_pid" =~ ^[0-9]+$ || -z "$owner_created_at" ]]; then
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED"
+	else
+		PRRTS_WORKTREE_FAILURE_REASON=""
+	fi
+	if [[ -n "$PRRTS_WORKTREE_FAILURE_REASON" ]]; then
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — created worktree ownership cannot be transferred safely (${PRRTS_WORKTREE_FAILURE_REASON}, path=${worktree_path})"
+		return 1
+	fi
+	if ! declare -F transfer_worktree_ownership_if_expected >/dev/null 2>&1; then
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — atomic worktree ownership transfer is unavailable"
+		return 1
+	fi
+	if ! transfer_worktree_ownership_if_expected "$worktree_path" "$head_ref" \
+		--task "$pr_number" --session "$precreate_session" --owner-pid "$$" \
+		--expected-owner-pid "$owner_pid" --expected-session "$owner_session" \
+		--expected-batch "$owner_batch" --expected-task "$owner_task" \
+		--expected-created-at "$owner_created_at" 2>/dev/null; then
+		PRRTS_WORKTREE_FAILURE_REASON="review_worktree_ownership_concurrent_mutation"
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — created worktree owner changed before transfer (${worktree_path})"
+		return 1
+	fi
+	_prrts_capture_expected_worktree_owner "$repo_slug" "$pr_number" "$worktree_path" "$precreate_session" || return 1
+	return 0
+}
+
 _prrts_prepare_worker_worktree() {
 	local repo_slug="$1"
 	local repo_path="$2"
@@ -1217,6 +1400,7 @@ _prrts_prepare_worker_worktree() {
 	local existing_path="" repo_name="" safe_ref="" worktree_path="" resolved_path=""
 	local actual_head=""
 
+	_prrts_reset_worktree_transfer_context
 	PRRTS_WORKTREE_FAILURE_BLOCKED_BY="$PRRTS_BLOCKED_BY_INFRASTRUCTURE"
 	PRRTS_WORKTREE_FAILURE_REASON="review_worktree_preparation_failed"
 	_prrts_validate_worker_head "$repo_slug" "$repo_path" "$pr_number" "$head_ref" "$head_oid" || return 1
@@ -1233,6 +1417,7 @@ _prrts_prepare_worker_worktree() {
 			PRRTS_WORKTREE_FAILURE_REASON="existing_review_worktree_head_mismatch"
 			return 1
 		fi
+		_prrts_prepare_reused_worktree_owner "$repo_slug" "$pr_number" "$existing_path" "$head_ref" || return 1
 		printf -v "$output_var" '%s' "$existing_path"
 		return 0
 	fi
@@ -1263,6 +1448,7 @@ _prrts_prepare_worker_worktree() {
 		PRRTS_WORKTREE_FAILURE_REASON="review_worktree_exact_head_verification_failed"
 		return 1
 	fi
+	_prrts_prepare_created_worktree_owner "$repo_slug" "$pr_number" "$resolved_path" "$head_ref" || return 1
 	printf -v "$output_var" '%s' "$resolved_path"
 	return 0
 }
@@ -1302,7 +1488,13 @@ _prrts_dispatch_worker() {
 		cmd+=(--model "$model")
 	fi
 	HEADLESS=1 WORKER_ISSUE_NUMBER="$pr_number" WORKER_REPO_SLUG="$repo_slug" WORKER_WORKTREE_PATH="$worker_worktree_path" \
-		GITHUB_REPOSITORY="$repo_slug" WORKER_NO_EXIT_PUSH=1 AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1 \
+		GITHUB_REPOSITORY="$repo_slug" WORKER_NO_EXIT_PUSH=1 \
+		AIDEVOPS_WORKTREE_OWNER_TRANSFER_MODE="$PRRTS_WORKTREE_TRANSFER_MODE" \
+		AIDEVOPS_WORKTREE_EXPECTED_OWNER_PID="$PRRTS_WORKTREE_EXPECTED_OWNER_PID" \
+		AIDEVOPS_WORKTREE_EXPECTED_OWNER_SESSION="$PRRTS_WORKTREE_EXPECTED_OWNER_SESSION" \
+		AIDEVOPS_WORKTREE_EXPECTED_OWNER_BATCH="$PRRTS_WORKTREE_EXPECTED_OWNER_BATCH" \
+		AIDEVOPS_WORKTREE_EXPECTED_OWNER_TASK="$PRRTS_WORKTREE_EXPECTED_OWNER_TASK" \
+		AIDEVOPS_WORKTREE_EXPECTED_OWNER_CREATED_AT="$PRRTS_WORKTREE_EXPECTED_OWNER_CREATED_AT" \
 		AIDEVOPS_PR_REPAIR_NUMBER="$pr_number" AIDEVOPS_PR_REPAIR_HEAD_SHA="$head_oid" AIDEVOPS_PR_REPAIR_HEAD_REF="$head_ref" \
 		"${cmd[@]}" </dev/null >>"$LOGFILE" 2>&1 &
 	_prrts_log "dispatch: launched response worker for ${repo_slug}#${pr_number} in ${worker_worktree_path} session_key=${session_key} pid=$!"

--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -1359,6 +1359,9 @@ _prrts_prepare_created_worktree_owner() {
 		_prrts_claim_dispatch_precreate_owner "$repo_slug" "$pr_number" "$worktree_path" "$head_ref" || return 1
 		return 0
 	fi
+	# worktree-helper can register outside a runtime session. The exact PID,
+	# task, and timestamp still authorize this CAS; the resulting precreate
+	# snapshot captured below must have a non-empty session before worker launch.
 	if [[ -z "$owner_task" ]]; then
 		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED"
 	elif [[ "$owner_task" != "$pr_number" ]]; then

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -207,13 +207,19 @@ printf '%s\n' "${WORKER_WORKTREE_PATH:-}" >"${HEADLESS_ENV_CAPTURE}"
 printf 'WORKER_ISSUE_NUMBER=%s\n' "${WORKER_ISSUE_NUMBER:-}" >>"${HEADLESS_ENV_CAPTURE}"
 printf 'WORKER_NO_EXIT_PUSH=%s\n' "${WORKER_NO_EXIT_PUSH:-}" >>"${HEADLESS_ENV_CAPTURE}"
 printf 'AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=%s\n' "${AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER:-}" >>"${HEADLESS_ENV_CAPTURE}"
+printf 'AIDEVOPS_WORKTREE_OWNER_TRANSFER_MODE=%s\n' "${AIDEVOPS_WORKTREE_OWNER_TRANSFER_MODE:-}" >>"${HEADLESS_ENV_CAPTURE}"
+printf 'AIDEVOPS_WORKTREE_EXPECTED_OWNER_PID=%s\n' "${AIDEVOPS_WORKTREE_EXPECTED_OWNER_PID:-}" >>"${HEADLESS_ENV_CAPTURE}"
+printf 'AIDEVOPS_WORKTREE_EXPECTED_OWNER_SESSION=%s\n' "${AIDEVOPS_WORKTREE_EXPECTED_OWNER_SESSION:-}" >>"${HEADLESS_ENV_CAPTURE}"
+printf 'AIDEVOPS_WORKTREE_EXPECTED_OWNER_BATCH=%s\n' "${AIDEVOPS_WORKTREE_EXPECTED_OWNER_BATCH:-}" >>"${HEADLESS_ENV_CAPTURE}"
+printf 'AIDEVOPS_WORKTREE_EXPECTED_OWNER_TASK=%s\n' "${AIDEVOPS_WORKTREE_EXPECTED_OWNER_TASK:-}" >>"${HEADLESS_ENV_CAPTURE}"
+printf 'AIDEVOPS_WORKTREE_EXPECTED_OWNER_CREATED_AT=%s\n' "${AIDEVOPS_WORKTREE_EXPECTED_OWNER_CREATED_AT:-}" >>"${HEADLESS_ENV_CAPTURE}"
 printf 'AIDEVOPS_PR_REPAIR_NUMBER=%s\n' "${AIDEVOPS_PR_REPAIR_NUMBER:-}" >>"${HEADLESS_ENV_CAPTURE}"
 printf 'AIDEVOPS_PR_REPAIR_HEAD_SHA=%s\n' "${AIDEVOPS_PR_REPAIR_HEAD_SHA:-}" >>"${HEADLESS_ENV_CAPTURE}"
 printf 'AIDEVOPS_PR_REPAIR_HEAD_REF=%s\n' "${AIDEVOPS_PR_REPAIR_HEAD_REF:-}" >>"${HEADLESS_ENV_CAPTURE}"
-printf '%s\n' "${prompt_file}" >>"${HEADLESS_LOG}"
 if [[ -n "$prompt_file" && -f "$prompt_file" ]]; then
 	cp "$prompt_file" "${HEADLESS_PROMPT_CAPTURE}"
 fi
+printf '%s\n' "${prompt_file}" >>"${HEADLESS_LOG}"
 exit 0
 HEADLESS_STUB
 	chmod +x "${TEST_ROOT}/headless-runtime-helper.sh"
@@ -241,10 +247,14 @@ if [[ "${1:-}" != "add" || -z "$branch" || -z "$path" || "${STUB_WORKTREE_HELPER
 	exit 1
 fi
 base=""
+issue=""
 shift 3
 while [[ $# -gt 0 ]]; do
 	if [[ "$1" == "--base" ]]; then
 		base="${2:-}"
+		shift 2
+	elif [[ "$1" == "--issue" ]]; then
+		issue="${2:-}"
 		shift 2
 	else
 		shift
@@ -252,6 +262,13 @@ while [[ $# -gt 0 ]]; do
 done
 mkdir -p "$path"
 printf '%s\t%s\t%s\n' "$path" "$branch" "${STUB_WORKTREE_ACTUAL_HEAD:-$base}" >>"${GIT_WORKTREE_REGISTRY}"
+if [[ "${STUB_WORKTREE_REGISTER_OWNER:-false}" == "true" ]]; then
+	source "${SHARED_CONSTANTS_PATH}"
+	register_worktree "$path" "$branch" --task "$issue" \
+		--session "${STUB_WORKTREE_OWNER_SESSION:-worktree-helper-created}" \
+		--owner-pid "${STUB_WORKTREE_OWNER_PID:-$$}"
+	check_worktree_owner "$path" >"${WORKTREE_CREATED_OWNER_CAPTURE}"
+fi
 exit 0
 WORKTREE_STUB
 	chmod +x "${TEST_ROOT}/worktree-helper.sh"
@@ -262,6 +279,7 @@ setup_test_env() {
 	unset STUB_PR_LIST STUB_PR_VIEW STUB_THREADS_MODE STUB_CROSS_REPOSITORY STUB_REMOTE_HEAD
 	unset STUB_GIT_INVALID_BRANCH STUB_GIT_FETCH_FAIL STUB_GIT_CANONICAL_FETCH_FAIL
 	unset STUB_REMOTE_HEAD_INITIAL STUB_REMOTE_HEAD_AFTER_FETCH STUB_WORKTREE_ACTUAL_HEAD STUB_WORKTREE_HELPER_FAIL
+	unset STUB_WORKTREE_REGISTER_OWNER STUB_WORKTREE_OWNER_PID STUB_WORKTREE_OWNER_SESSION
 	unset PR_REVIEW_THREAD_RESPONSE_ESCALATE_AFTER
 	TEST_ROOT="$(mktemp -d -t prrts.XXXXXX)"
 	export HOME="${TEST_ROOT}/home"
@@ -272,10 +290,14 @@ setup_test_env() {
 	export HEADLESS_ENV_CAPTURE="${TEST_ROOT}/headless-env.txt"
 	export HEADLESS_PROMPT_CAPTURE="${TEST_ROOT}/prompt.md"
 	export WORKTREE_HELPER_LOG="${TEST_ROOT}/worktree-helper.log"
+	export WORKTREE_CREATED_OWNER_CAPTURE="${TEST_ROOT}/worktree-created-owner.txt"
 	export GIT_WORKTREE_REGISTRY="${TEST_ROOT}/git-worktrees.tsv"
 	export GIT_FETCH_CWD_LOG="${TEST_ROOT}/git-fetch-cwd.log"
 	export GIT_FETCHED_HEAD_STATE="${TEST_ROOT}/git-fetched-head.state"
 	export GIT_CANONICAL_REPO_PATH="${TEST_ROOT}/repo"
+	export WORKTREE_REGISTRY_DIR="${TEST_ROOT}/ownership-registry"
+	export WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DIR}/worktree-registry.db"
+	export SHARED_CONSTANTS_PATH="${TEST_SCRIPT_DIR}/../shared-constants.sh"
 	mkdir -p "${HOME}" "${TEST_ROOT}/bin" "${TEST_ROOT}/repo" "${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}"
 	mkdir -p "${TEST_ROOT}/fetch-worktree"
 	printf '%s\t%s\t%s\n' "${TEST_ROOT}/fetch-worktree" 'support/fetch' "$TEST_HEAD_OID_1" >"$GIT_WORKTREE_REGISTRY"
@@ -297,6 +319,30 @@ setup_test_env() {
 	: >"$HEADLESS_LOG"
 	: >"$GIT_FETCH_CWD_LOG"
 	rm -f "$GIT_FETCHED_HEAD_STATE"
+	return 0
+}
+
+register_test_worktree_owner() {
+	local worktree_path="$1"
+	local branch="$2"
+	local task_id="$3"
+	local session_id="$4"
+	local batch_id="${5:-}"
+	local owner_pid="$$"
+
+	if ! bash -c 'source "$1"; register_worktree "$2" "$3" --task "$4" --session "$5" --batch "$6" --owner-pid "$7"' \
+		_ "${TEST_SCRIPT_DIR}/../shared-constants.sh" "$worktree_path" "$branch" "$task_id" "$session_id" "$batch_id" "$owner_pid"; then
+		return 1
+	fi
+	return 0
+}
+
+read_test_worktree_owner() {
+	local worktree_path="$1"
+	if ! bash -c 'source "$1"; check_worktree_owner "$2"' \
+		_ "${TEST_SCRIPT_DIR}/../shared-constants.sh" "$worktree_path"; then
+		return 1
+	fi
 	return 0
 }
 
@@ -364,13 +410,130 @@ test_dispatch_exports_worktree_ownership_context() {
 	wait_for_headless_log || true
 	if grep -Fxq 'WORKER_ISSUE_NUMBER=1' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
 		grep -Fxq 'WORKER_NO_EXIT_PUSH=1' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
-		grep -Fxq 'AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=1' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq 'AIDEVOPS_ALLOW_WORKER_WORKTREE_OWNER_TRANSFER=' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq 'AIDEVOPS_WORKTREE_OWNER_TRANSFER_MODE=continuation' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Eq '^AIDEVOPS_WORKTREE_EXPECTED_OWNER_PID=[0-9]+$' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq 'AIDEVOPS_WORKTREE_EXPECTED_OWNER_SESSION=dispatch-precreate-1' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq 'AIDEVOPS_WORKTREE_EXPECTED_OWNER_TASK=1' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Eq '^AIDEVOPS_WORKTREE_EXPECTED_OWNER_CREATED_AT=.+$' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
 		grep -Fxq 'AIDEVOPS_PR_REPAIR_NUMBER=1' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
 		grep -Fxq "AIDEVOPS_PR_REPAIR_HEAD_SHA=${TEST_HEAD_OID_1}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
 		grep -Fxq 'AIDEVOPS_PR_REPAIR_HEAD_REF=feature/review' "$HEADLESS_ENV_CAPTURE" 2>/dev/null; then
-		print_result "dispatch exports worker ownership and exact-head context" 0
+		print_result "dispatch exports exact owner-transfer and exact-head context" 0
 	else
-		print_result "dispatch exports worker ownership and exact-head context" 1 "env=$(tr '\n' ';' <"$HEADLESS_ENV_CAPTURE" 2>/dev/null || printf '')"
+		print_result "dispatch exports exact owner-transfer and exact-head context" 1 "env=$(tr '\n' ';' <"$HEADLESS_ENV_CAPTURE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_registers_created_worktree_as_transferable_precreate_owner() {
+	local expected_path=""
+	local initial_owner_info="" owner_info=""
+	local initial_owner_pid="" initial_owner_session="" initial_owner_batch="" initial_owner_task="" initial_owner_created_at=""
+	local owner_pid="" owner_session="" owner_batch="" owner_task="" owner_created_at=""
+
+	setup_test_env
+	export STUB_WORKTREE_REGISTER_OWNER="true"
+	export STUB_WORKTREE_OWNER_PID="$$"
+	export STUB_WORKTREE_OWNER_SESSION="worktree-helper-created"
+	expected_path="${TEST_ROOT}/worktrees/repo-pr1-review-feature-review-${TEST_HEAD_OID_1:0:12}"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	initial_owner_info=$(<"$WORKTREE_CREATED_OWNER_CAPTURE")
+	IFS='|' read -r initial_owner_pid initial_owner_session initial_owner_batch initial_owner_task initial_owner_created_at <<<"$initial_owner_info"
+	owner_info=$(read_test_worktree_owner "$expected_path" 2>/dev/null || true)
+	IFS='|' read -r owner_pid owner_session owner_batch owner_task owner_created_at <<<"$owner_info"
+	if [[ "$initial_owner_pid" == "$$" && "$initial_owner_session" == "worktree-helper-created" && "$initial_owner_task" == "1" && -n "$initial_owner_created_at" ]] &&
+		[[ "$owner_pid" =~ ^[0-9]+$ && "$owner_pid" != "$initial_owner_pid" && "$owner_session" == "dispatch-precreate-1" && "$owner_task" == "1" && -n "$owner_created_at" ]] &&
+		grep -Fxq "AIDEVOPS_WORKTREE_EXPECTED_OWNER_PID=${owner_pid}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq "AIDEVOPS_WORKTREE_EXPECTED_OWNER_CREATED_AT=${owner_created_at}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null; then
+		print_result "dispatch atomically registers a created worktree as an exact transferable owner" 0
+	else
+		print_result "dispatch atomically registers a created worktree as an exact transferable owner" 1 \
+			"initial_owner=${initial_owner_info}, owner=${owner_info}, env=$(tr '\n' ';' <"$HEADLESS_ENV_CAPTURE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_preserves_reused_same_task_owner_snapshot() {
+	local existing_path=""
+	local owner_before="" owner_after=""
+	local owner_pid="" owner_session="" owner_batch="" owner_task="" owner_created_at=""
+
+	setup_test_env
+	existing_path="${TEST_ROOT}/existing-review-worktree"
+	mkdir -p "$existing_path"
+	printf '%s\t%s\t%s\n' "$existing_path" 'feature/review' "$TEST_HEAD_OID_1" >"$GIT_WORKTREE_REGISTRY"
+	register_test_worktree_owner "$existing_path" 'feature/review' '1' 'existing-review-session' 'existing-review-batch'
+	owner_before=$(read_test_worktree_owner "$existing_path")
+	IFS='|' read -r owner_pid owner_session owner_batch owner_task owner_created_at <<<"$owner_before"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	owner_after=$(read_test_worktree_owner "$existing_path")
+	if [[ "$owner_after" == "$owner_before" ]] &&
+		grep -Fxq 'AIDEVOPS_WORKTREE_OWNER_TRANSFER_MODE=continuation' "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq "AIDEVOPS_WORKTREE_EXPECTED_OWNER_PID=${owner_pid}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq "AIDEVOPS_WORKTREE_EXPECTED_OWNER_SESSION=${owner_session}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq "AIDEVOPS_WORKTREE_EXPECTED_OWNER_BATCH=${owner_batch}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq "AIDEVOPS_WORKTREE_EXPECTED_OWNER_TASK=${owner_task}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq "AIDEVOPS_WORKTREE_EXPECTED_OWNER_CREATED_AT=${owner_created_at}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		! grep -q '^add ' "$WORKTREE_HELPER_LOG" 2>/dev/null; then
+		print_result "dispatch preserves a reused same-task owner for exact continuation transfer" 0
+	else
+		print_result "dispatch preserves a reused same-task owner for exact continuation transfer" 1 \
+			"before=${owner_before}, after=${owner_after}, env=$(tr '\n' ';' <"$HEADLESS_ENV_CAPTURE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_rejects_reused_other_task_owner() {
+	local existing_path=""
+	local owner_before="" owner_after=""
+	local state_file=""
+
+	setup_test_env
+	existing_path="${TEST_ROOT}/existing-review-worktree"
+	state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	mkdir -p "$existing_path"
+	printf '%s\t%s\t%s\n' "$existing_path" 'feature/review' "$TEST_HEAD_OID_1" >"$GIT_WORKTREE_REGISTRY"
+	register_test_worktree_owner "$existing_path" 'feature/review' '999' 'unrelated-session'
+	owner_before=$(read_test_worktree_owner "$existing_path")
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo" || true
+	owner_after=$(read_test_worktree_owner "$existing_path")
+	if [[ ! -s "$HEADLESS_LOG" && "$owner_after" == "$owner_before" ]] &&
+		grep -q '^blocker_reason=review_worktree_owned_by_other_task$' "$state_file" 2>/dev/null; then
+		print_result "dispatch rejects a reused worktree owned by another task" 0
+	else
+		print_result "dispatch rejects a reused worktree owned by another task" 1 \
+			"before=${owner_before}, after=${owner_after}, state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_rejects_reused_unverified_owner() {
+	local existing_path=""
+	local owner_before="" owner_after=""
+	local state_file=""
+
+	setup_test_env
+	existing_path="${TEST_ROOT}/existing-review-worktree"
+	state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	mkdir -p "$existing_path"
+	printf '%s\t%s\t%s\n' "$existing_path" 'feature/review' "$TEST_HEAD_OID_1" >"$GIT_WORKTREE_REGISTRY"
+	register_test_worktree_owner "$existing_path" 'feature/review' '' 'unverified-session'
+	owner_before=$(read_test_worktree_owner "$existing_path")
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo" || true
+	owner_after=$(read_test_worktree_owner "$existing_path")
+	if [[ ! -s "$HEADLESS_LOG" && "$owner_after" == "$owner_before" ]] &&
+		grep -q '^blocker_reason=review_worktree_ownership_unverified$' "$state_file" 2>/dev/null; then
+		print_result "dispatch rejects a reused worktree with unverified ownership" 0
+	else
+		print_result "dispatch rejects a reused worktree with unverified ownership" 1 \
+			"before=${owner_before}, after=${owner_after}, state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf '')"
 	fi
 	teardown_test_env
 	return 0
@@ -604,6 +767,9 @@ test_dispatch_prompt_uses_stable_deployed_scanner_path() {
 	local stable_scanner="${HOME}/.aidevops/agents/scripts/pr-review-thread-response-scanner.sh"
 	mkdir -p "$(dirname "$bundled_scanner")"
 	cp "$SCANNER" "$bundled_scanner"
+	cat >"$(dirname "$bundled_scanner")/shared-constants.sh" <<SHARED_CONSTANTS
+source "${TEST_SCRIPT_DIR}/../shared-constants.sh"
+SHARED_CONSTANTS
 	chmod +x "$bundled_scanner"
 	"$bundled_scanner" dispatch owner/repo "${TEST_ROOT}/repo"
 	wait_for_headless_log || true
@@ -1270,6 +1436,10 @@ main() {
 	test_dispatch_fetches_head_from_linked_worktree_context
 	test_dispatch_bootstraps_fetch_context_without_linked_worktree
 	test_dispatch_exports_worktree_ownership_context
+	test_dispatch_registers_created_worktree_as_transferable_precreate_owner
+	test_dispatch_preserves_reused_same_task_owner_snapshot
+	test_dispatch_rejects_reused_other_task_owner
+	test_dispatch_rejects_reused_unverified_owner
 	test_dispatch_blocks_cross_repository_head
 	test_dispatch_blocks_remote_head_drift
 	test_dispatch_blocks_existing_worktree_head_mismatch

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -264,8 +264,8 @@ mkdir -p "$path"
 printf '%s\t%s\t%s\n' "$path" "$branch" "${STUB_WORKTREE_ACTUAL_HEAD:-$base}" >>"${GIT_WORKTREE_REGISTRY}"
 if [[ "${STUB_WORKTREE_REGISTER_OWNER:-false}" == "true" ]]; then
 	source "${SHARED_CONSTANTS_PATH}"
-	register_worktree "$path" "$branch" --task "$issue" \
-		--session "${STUB_WORKTREE_OWNER_SESSION:-worktree-helper-created}" \
+	OPENCODE_SESSION_ID="" CLAUDE_SESSION_ID="" register_worktree "$path" "$branch" --task "$issue" \
+		--session "${STUB_WORKTREE_OWNER_SESSION-worktree-helper-created}" \
 		--owner-pid "${STUB_WORKTREE_OWNER_PID:-$$}"
 	check_worktree_owner "$path" >"${WORKTREE_CREATED_OWNER_CAPTURE}"
 fi
@@ -436,7 +436,7 @@ test_dispatch_registers_created_worktree_as_transferable_precreate_owner() {
 	setup_test_env
 	export STUB_WORKTREE_REGISTER_OWNER="true"
 	export STUB_WORKTREE_OWNER_PID="$$"
-	export STUB_WORKTREE_OWNER_SESSION="worktree-helper-created"
+	export STUB_WORKTREE_OWNER_SESSION=""
 	expected_path="${TEST_ROOT}/worktrees/repo-pr1-review-feature-review-${TEST_HEAD_OID_1:0:12}"
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
 	wait_for_headless_log || true
@@ -444,7 +444,7 @@ test_dispatch_registers_created_worktree_as_transferable_precreate_owner() {
 	IFS='|' read -r initial_owner_pid initial_owner_session initial_owner_batch initial_owner_task initial_owner_created_at <<<"$initial_owner_info"
 	owner_info=$(read_test_worktree_owner "$expected_path" 2>/dev/null || true)
 	IFS='|' read -r owner_pid owner_session owner_batch owner_task owner_created_at <<<"$owner_info"
-	if [[ "$initial_owner_pid" == "$$" && "$initial_owner_session" == "worktree-helper-created" && "$initial_owner_task" == "1" && -n "$initial_owner_created_at" ]] &&
+	if [[ "$initial_owner_pid" == "$$" && -z "$initial_owner_session" && "$initial_owner_task" == "1" && -n "$initial_owner_created_at" ]] &&
 		[[ "$owner_pid" =~ ^[0-9]+$ && "$owner_pid" != "$initial_owner_pid" && "$owner_session" == "dispatch-precreate-1" && "$owner_task" == "1" && -n "$owner_created_at" ]] &&
 		grep -Fxq "AIDEVOPS_WORKTREE_EXPECTED_OWNER_PID=${owner_pid}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
 		grep -Fxq "AIDEVOPS_WORKTREE_EXPECTED_OWNER_CREATED_AT=${owner_created_at}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null; then


### PR DESCRIPTION
## Summary

Register scanner-created exact-head worktrees under a transferable precreate owner, preserve exact same-task owner snapshots for atomic worker handoff, and reject cross-task or unverified ownership.

## Files Changed

- `.agents/scripts/pr-review-thread-response-scanner.sh`
- `.agents/scripts/tests/test-pr-review-thread-response-scanner.sh`

## Runtime Testing

- **Risk level:** High (ownership state transition and detached worker launch)
- **Automated verification:** 51 scanner tests; 169 headless runtime tests; ShellCheck; `.agents/scripts/linters-local.sh`
- **Live verification:** A targeted retry for PR #28372 at exact head `f9589bed527d8e997d7fbe3e11e8d238817358e0` preserved the same-task owner snapshot, atomically transferred ownership, and progressed through `pre_runtime_launch` to `worker_start` with the configured model.

Resolves #28422

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 14h 47m and 2,358,118 tokens on this with the user in an interactive session.
