### PR TITLE
GH#28426: Allow headless pre-edit checks in wrapper-owned worktrees

### DIFF
--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -1269,6 +1269,19 @@ _hrw_transfer_authorized_continuation_owner() {
 	return 0
 }
 
+_hrw_export_worker_worktree_owner_proof() {
+	local session_key="$1"
+	local work_dir="$2"
+	local resolved_work_dir=""
+	resolved_work_dir=$(cd "$work_dir" 2>/dev/null && pwd -P) || return 1
+
+	export AIDEVOPS_WORKTREE_OWNER_PID="$$"
+	export AIDEVOPS_WORKTREE_OWNER_SESSION="$session_key"
+	export AIDEVOPS_WORKTREE_OWNER_TASK="${WORKER_ISSUE_NUMBER:-}"
+	export AIDEVOPS_WORKTREE_OWNER_PATH="$resolved_work_dir"
+	return 0
+}
+
 _hrw_reclaim_stale_worker_worktree_owner() {
 	local session_key="$1"
 	local work_dir="$2"
@@ -1374,6 +1387,7 @@ _hrw_claim_worker_worktree() {
 			return 1
 		fi
 		if _hrw_transfer_authorized_continuation_owner "$session_key" "$work_dir" "$branch"; then
+			_hrw_export_worker_worktree_owner_proof "$session_key" "$work_dir" || return 1
 			print_info "[lifecycle] worker_worktree_claimed session=${session_key} branch=${branch} path=${work_dir} pid=$$ mode=continuation"
 			return 0
 		fi
@@ -1396,6 +1410,7 @@ _hrw_claim_worker_worktree() {
 				--session "$session_key" \
 				--task "${WORKER_ISSUE_NUMBER:-}" \
 				--owner-pid "$$"; then
+			_hrw_export_worker_worktree_owner_proof "$session_key" "$work_dir" || return 1
 			print_info "[lifecycle] worker_worktree_claimed session=${session_key} branch=${branch} path=${work_dir} pid=$$"
 			return 0
 		fi
@@ -1403,6 +1418,7 @@ _hrw_claim_worker_worktree() {
 		return 1
 	fi
 
+	_hrw_export_worker_worktree_owner_proof "$session_key" "$work_dir" || return 1
 	print_info "[lifecycle] worker_worktree_claimed session=${session_key} branch=${branch} path=${work_dir} pid=$$"
 	return 0
 }

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -568,6 +568,43 @@ _handle_ownership_conflict() {
 	exit 1
 }
 
+# Verify that this pre-edit process is running below the exact headless wrapper
+# that owns the worktree registry row. Environment metadata narrows the claim to
+# one worktree/session/task, while process ancestry prevents an unrelated worker
+# from forging authority with copied environment values.
+# Arguments: $1=worktree_path, $2=owner_pid, $3=owner_session, $4=owner_task
+_headless_wrapper_owner_matches() {
+	local wt_path="$1"
+	local owner_pid="$2"
+	local owner_session="$3"
+	local owner_task="$4"
+	local proof_pid="${AIDEVOPS_WORKTREE_OWNER_PID:-}"
+	local proof_session="${AIDEVOPS_WORKTREE_OWNER_SESSION:-}"
+	local proof_task="${AIDEVOPS_WORKTREE_OWNER_TASK:-}"
+	local proof_path="${AIDEVOPS_WORKTREE_OWNER_PATH:-}"
+
+	[[ "${AIDEVOPS_SESSION_ORIGIN:-}" == "worker" ]] || return 1
+	[[ "${AIDEVOPS_HEADLESS:-}" == "true" || "${AIDEVOPS_HEADLESS:-}" == "1" ]] || return 1
+	[[ "$proof_pid" =~ ^[0-9]+$ && "$owner_pid" == "$proof_pid" ]] || return 1
+	[[ -n "$proof_session" && "$owner_session" == "$proof_session" ]] || return 1
+	[[ -n "$proof_task" && "$owner_task" == "$proof_task" ]] || return 1
+	[[ -n "$proof_path" ]] || return 1
+	[[ "$(_wt_normalize_path "$wt_path")" == "$(_wt_normalize_path "$proof_path")" ]] || return 1
+	kill -0 "$owner_pid" 2>/dev/null || return 1
+
+	local current_pid="$$"
+	local parent_pid=""
+	local depth=0
+	while [[ "$current_pid" =~ ^[0-9]+$ && "$current_pid" -gt 1 && "$depth" -lt 64 ]]; do
+		[[ "$current_pid" == "$owner_pid" ]] && return 0
+		parent_pid=$(_get_proc_ppid "$current_pid")
+		[[ "$parent_pid" =~ ^[0-9]+$ && "$parent_pid" -gt 0 && "$parent_pid" != "$current_pid" ]] || return 1
+		current_pid="$parent_pid"
+		depth=$((depth + 1))
+	done
+	return 1
+}
+
 # Handle the canonical repo directory being off the default branch.
 # This state is never writable; branch switching is not a recovery mechanism.
 _handle_main_repo_off_main() {
@@ -689,11 +726,14 @@ if declare -f claim_worktree_ownership >/dev/null 2>&1; then
 		owner_info=$(check_worktree_owner "$worktree_path" 2>/dev/null || true)
 		owner_pid="unknown"
 		owner_session=""
+		owner_task=""
 		owner_created=""
 		if [[ -n "$owner_info" ]]; then
-			IFS='|' read -r owner_pid owner_session _ _ owner_created <<<"$owner_info"
+			IFS='|' read -r owner_pid owner_session _ owner_task owner_created <<<"$owner_info"
 		fi
-		_handle_ownership_conflict "$worktree_path" "$owner_pid" "$owner_session" "$owner_created"
+		if ! _headless_wrapper_owner_matches "$worktree_path" "$owner_pid" "$owner_session" "$owner_task"; then
+			_handle_ownership_conflict "$worktree_path" "$owner_pid" "$owner_session" "$owner_created"
+		fi
 	fi
 fi
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1062,6 +1062,8 @@ test_worker_worktree_claim_transfers_to_runtime_pid() {
 	local proof_session="${AIDEVOPS_WORKTREE_OWNER_SESSION:-}"
 	local proof_task="${AIDEVOPS_WORKTREE_OWNER_TASK:-}"
 	local proof_path="${AIDEVOPS_WORKTREE_OWNER_PATH:-}"
+	local expected_proof_path=""
+	expected_proof_path=$(cd "$worktree_dir" 2>/dev/null && pwd -P)
 
 	unset -f claim_worktree_ownership 2>/dev/null || true
 	unset WORKER_ISSUE_NUMBER AIDEVOPS_WORKTREE_OWNER_PID \
@@ -1076,7 +1078,7 @@ test_worker_worktree_claim_transfers_to_runtime_pid() {
 		[[ "$proof_pid" == "$$" ]] &&
 		[[ "$proof_session" == "issue-22438" ]] &&
 		[[ "$proof_task" == "22438" ]] &&
-		[[ "$proof_path" == "$worktree_dir" ]]; then
+		[[ "$proof_path" == "$expected_proof_path" ]]; then
 		print_result "worker worktree claim exports exact wrapper ownership proof" 0
 		return 0
 	fi

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1058,21 +1058,31 @@ test_worker_worktree_claim_transfers_to_runtime_pid() {
 	}
 
 	_hrw_claim_worker_worktree "issue-22438" "$worktree_dir" >/dev/null
+	local proof_pid="${AIDEVOPS_WORKTREE_OWNER_PID:-}"
+	local proof_session="${AIDEVOPS_WORKTREE_OWNER_SESSION:-}"
+	local proof_task="${AIDEVOPS_WORKTREE_OWNER_TASK:-}"
+	local proof_path="${AIDEVOPS_WORKTREE_OWNER_PATH:-}"
 
 	unset -f claim_worktree_ownership 2>/dev/null || true
-	unset WORKER_ISSUE_NUMBER 2>/dev/null || true
+	unset WORKER_ISSUE_NUMBER AIDEVOPS_WORKTREE_OWNER_PID \
+		AIDEVOPS_WORKTREE_OWNER_SESSION AIDEVOPS_WORKTREE_OWNER_TASK \
+		AIDEVOPS_WORKTREE_OWNER_PATH 2>/dev/null || true
 
 	if [[ "$claimed_path" == "$worktree_dir" ]] &&
 		[[ "$claimed_branch" == "detached" ]] &&
 		[[ "$claimed_session" == "issue-22438" ]] &&
 		[[ "$claimed_task" == "22438" ]] &&
-		[[ "$claimed_pid" == "$$" ]]; then
-		print_result "worker worktree claim transfers ownership to runtime PID" 0
+		[[ "$claimed_pid" == "$$" ]] &&
+		[[ "$proof_pid" == "$$" ]] &&
+		[[ "$proof_session" == "issue-22438" ]] &&
+		[[ "$proof_task" == "22438" ]] &&
+		[[ "$proof_path" == "$worktree_dir" ]]; then
+		print_result "worker worktree claim exports exact wrapper ownership proof" 0
 		return 0
 	fi
 
-	print_result "worker worktree claim transfers ownership to runtime PID" 1 \
-		"path=$claimed_path branch=$claimed_branch session=$claimed_session task=$claimed_task pid=$claimed_pid"
+	print_result "worker worktree claim exports exact wrapper ownership proof" 1 \
+		"path=$claimed_path branch=$claimed_branch session=$claimed_session task=$claimed_task pid=$claimed_pid proof=${proof_pid}|${proof_session}|${proof_task}|${proof_path}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -229,6 +229,120 @@ test_blocks_when_linked_worktree_owned_by_another_live_process() {
 	return 0
 }
 
+test_allows_headless_child_of_exact_wrapper_owner() {
+	local worktree_path="${TEST_ROOT}/wrapper-owned-worktree"
+	"$GIT_BIN" -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/wrapper-owned-worktree >/dev/null 2>&1
+
+	ensure_registry_schema
+	sqlite3 "$TEST_REGISTRY_DB" "
+        INSERT OR REPLACE INTO worktree_owners
+            (worktree_path, branch, owner_pid, owner_session, task_id)
+        VALUES
+            ('$worktree_path', 'bugfix/wrapper-owned-worktree', $$, 'issue-28426', '28426');
+    " >/dev/null 2>&1
+
+	local output=""
+	local exit_code=0
+	output=$(AIDEVOPS_SESSION_ORIGIN=worker AIDEVOPS_HEADLESS=true \
+		AIDEVOPS_WORKTREE_OWNER_PID="$$" \
+		AIDEVOPS_WORKTREE_OWNER_SESSION="issue-28426" \
+		AIDEVOPS_WORKTREE_OWNER_TASK="28426" \
+		AIDEVOPS_WORKTREE_OWNER_PATH="$worktree_path" \
+		PRE_EDIT_OWNER_PID="$BASHPID" run_helper "$worktree_path" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 && "$output" == *"OK"* && "$output" != *"WORKTREE_OWNERSHIP_CONFLICT=true"* ]]; then
+		print_result "allows headless child of exact live wrapper owner" 0
+		return 0
+	fi
+
+	print_result "allows headless child of exact live wrapper owner" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_headless_wrapper_owner_proof_fails_closed() {
+	local worktree_path="${TEST_ROOT}/wrapper-proof-mismatch-worktree"
+	"$GIT_BIN" -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/wrapper-proof-mismatch >/dev/null 2>&1
+
+	ensure_registry_schema
+	sqlite3 "$TEST_REGISTRY_DB" "
+        INSERT OR REPLACE INTO worktree_owners
+            (worktree_path, branch, owner_pid, owner_session, task_id)
+        VALUES
+            ('$worktree_path', 'bugfix/wrapper-proof-mismatch', $$, 'issue-28426', '28426');
+    " >/dev/null 2>&1
+
+	local proof_case=""
+	local proof_pid=""
+	local proof_session=""
+	local proof_task=""
+	local proof_path=""
+	local output=""
+	local exit_code=0
+	for proof_case in missing mismatched-session mismatched-task mismatched-path non-ancestor-pid; do
+		proof_pid="$$"
+		proof_session="issue-28426"
+		proof_task="28426"
+		proof_path="$worktree_path"
+		case "$proof_case" in
+		missing) proof_pid="" ;;
+		mismatched-session) proof_session="issue-99999" ;;
+		mismatched-task) proof_task="99999" ;;
+		mismatched-path) proof_path="$TEST_ROOT" ;;
+		non-ancestor-pid) proof_pid="1" ;;
+		esac
+
+		output=""
+		exit_code=0
+		output=$(AIDEVOPS_SESSION_ORIGIN=worker AIDEVOPS_HEADLESS=true \
+			AIDEVOPS_WORKTREE_OWNER_PID="$proof_pid" \
+			AIDEVOPS_WORKTREE_OWNER_SESSION="$proof_session" \
+			AIDEVOPS_WORKTREE_OWNER_TASK="$proof_task" \
+			AIDEVOPS_WORKTREE_OWNER_PATH="$proof_path" \
+			PRE_EDIT_OWNER_PID="$BASHPID" run_helper "$worktree_path" 2>&1) || exit_code=$?
+		if [[ "$exit_code" -eq 2 && "$output" == *"WORKTREE_OWNERSHIP_CONFLICT=true"* ]]; then
+			print_result "headless wrapper proof fails closed: ${proof_case}" 0
+		else
+			print_result "headless wrapper proof fails closed: ${proof_case}" 1 "exit=${exit_code} output=${output}"
+		fi
+	done
+	return 0
+}
+
+test_rejects_forged_proof_for_unrelated_live_owner() {
+	local worktree_path="${TEST_ROOT}/unrelated-live-owner-worktree"
+	"$GIT_BIN" -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/unrelated-live-owner >/dev/null 2>&1
+
+	local unrelated_pid=""
+	sleep 30 >/dev/null 2>&1 &
+	unrelated_pid=$!
+	ensure_registry_schema
+	sqlite3 "$TEST_REGISTRY_DB" "
+        INSERT OR REPLACE INTO worktree_owners
+            (worktree_path, branch, owner_pid, owner_session, task_id)
+        VALUES
+            ('$worktree_path', 'bugfix/unrelated-live-owner', $unrelated_pid, 'issue-28426', '28426');
+    " >/dev/null 2>&1
+
+	local output=""
+	local exit_code=0
+	output=$(AIDEVOPS_SESSION_ORIGIN=worker AIDEVOPS_HEADLESS=true \
+		AIDEVOPS_WORKTREE_OWNER_PID="$unrelated_pid" \
+		AIDEVOPS_WORKTREE_OWNER_SESSION="issue-28426" \
+		AIDEVOPS_WORKTREE_OWNER_TASK="28426" \
+		AIDEVOPS_WORKTREE_OWNER_PATH="$worktree_path" \
+		PRE_EDIT_OWNER_PID="$BASHPID" run_helper "$worktree_path" 2>&1) || exit_code=$?
+	kill "$unrelated_pid" >/dev/null 2>&1 || true
+	wait "$unrelated_pid" 2>/dev/null || true
+
+	if [[ "$exit_code" -eq 2 && "$output" == *"WORKTREE_OWNERSHIP_CONFLICT=true"* ]]; then
+		print_result "rejects copied proof for unrelated live owner process" 0
+		return 0
+	fi
+
+	print_result "rejects copied proof for unrelated live owner process" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
 test_allows_same_opencode_session_pid_rollover() {
 	local worktree_path="${TEST_ROOT}/same-session-worktree"
 	"$GIT_BIN" -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/same-session-worktree >/dev/null 2>&1
@@ -388,6 +502,9 @@ main() {
 	test_worker_env_does_not_bypass_canonical_guard
 	test_warns_when_canonical_repo_is_off_main
 	test_blocks_when_linked_worktree_owned_by_another_live_process
+	test_allows_headless_child_of_exact_wrapper_owner
+	test_headless_wrapper_owner_proof_fails_closed
+	test_rejects_forged_proof_for_unrelated_live_owner
 	test_allows_same_opencode_session_pid_rollover
 	test_headless_planning_path_requires_worktree
 	test_interactive_allowlisted_path_still_requires_worktree


### PR DESCRIPTION
## Summary

- allow a headless child runtime to recognize its exact dispatcher wrapper as the worktree owner
- bind the exception to registry PID/session/task/path evidence plus live process ancestry
- preserve fail-closed behavior for unrelated owners and missing or mismatched evidence

## Testing

- `shellcheck .agents/scripts/pre-edit-check.sh .agents/scripts/headless-runtime-worker.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-pre-edit-check.sh .agents/scripts/tests/test-headless-runtime-helper.sh`
- `bash .agents/scripts/tests/test-pre-edit-check.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

Low-risk shell ownership-gate change verified through distinct wrapper/runtime PID fixtures, including copied-proof rejection for an unrelated live process.

Resolves #28426
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 12m and 197,037 tokens on this as a headless worker.