### PR TITLE
GH#28413: Fix trusted review author classification

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -1043,6 +1043,35 @@ any_bot_has_success_status() {
 	return 1
 }
 
+_resolve_pr_author_association() {
+	local pr_number="$1"
+	local repo="$2"
+	local pr_metadata_json="${3:-}"
+	local association=""
+	local association_filter='if type == "object" and (.author_association | type == "string") then .author_association else empty end'
+	local pr_api=""
+
+	# Internal callers can pass the live REST pull payload they already fetched.
+	# Only the REST field is authoritative; login, labels, and runner identity do
+	# not establish author trust.
+	if [[ -n "$pr_metadata_json" ]] &&
+		association=$(jq -r "$association_filter" <<<"$pr_metadata_json" 2>/dev/null); then
+		if [[ -n "$association" ]]; then
+			printf '%s\n' "$association"
+			return 0
+		fi
+	fi
+
+	# GitHub CLI does not export authorAssociation through `gh pr view --json`.
+	# Reuse the canonical pull REST field and collapse all API/parse failures to
+	# unknown so the trust checks below continue to fail closed.
+	pr_api=$(printf 'repos/%s/pulls/%s' "$repo" "$pr_number")
+	association=$(gh api "$pr_api" \
+		--jq "$association_filter" 2>/dev/null) || association=""
+	printf '%s\n' "$association"
+	return 0
+}
+
 check_for_skip_label() {
 	local pr_number="$1"
 	local repo="$2"
@@ -1196,13 +1225,9 @@ do_check() {
 	local REVIEW_GATE_NON_REVIEW_BOTS=""
 	_rbg_reset_evidence_snapshot
 
-	if [[ -z "$REVIEW_GATE_AUTHOR_ASSOCIATION" && -n "$pr_metadata_json" ]]; then
-		REVIEW_GATE_AUTHOR_ASSOCIATION=$(jq -r '.author_association // .authorAssociation // empty' \
-			<<<"$pr_metadata_json" 2>/dev/null || true)
-	fi
 	if [[ -z "$REVIEW_GATE_AUTHOR_ASSOCIATION" ]]; then
-		REVIEW_GATE_AUTHOR_ASSOCIATION=$(gh pr view "$pr_number" --repo "$repo" \
-			--json authorAssociation --jq '.authorAssociation // empty' 2>/dev/null || true)
+		REVIEW_GATE_AUTHOR_ASSOCIATION=$(_resolve_pr_author_association \
+			"$pr_number" "$repo" "$pr_metadata_json")
 	fi
 
 	# #aidevops:trust-boundary — skip labels are an internal exception. Resolve
@@ -1301,14 +1326,14 @@ do_status_json() {
 	pr_api=$(printf 'repos/%s/pulls/%s' "$repo" "$pr_number")
 	pr_json_before=$(gh api "$pr_api" 2>/dev/null) || pr_json_before=""
 	head_sha_before=$(jq -r '.head.sha // ""' <<<"$pr_json_before" 2>/dev/null) || head_sha_before=""
-	author_association_before=$(jq -r '.author_association // ""' <<<"$pr_json_before" 2>/dev/null) || author_association_before=""
+	author_association_before=$(_resolve_pr_author_association "$pr_number" "$repo" "$pr_json_before")
 	output=$(REVIEW_GATE_EXPECTED_HEAD_SHA="$head_sha_before" REVIEW_GATE_AUTHOR_ASSOCIATION="$author_association_before" do_check "$pr_number" "$repo" "$pr_json_before" 2>/dev/null) || rc=$?
 	pr_json=$(gh api "$pr_api" 2>/dev/null) || pr_json=""
 	if [[ -n "$pr_json" ]]; then
 		head_sha=$(jq -r '.head.sha // ""' <<<"$pr_json" 2>/dev/null) || head_sha=""
 		author_login=$(jq -r '.user.login // ""' <<<"$pr_json" 2>/dev/null) || author_login=""
-		author_association=$(jq -r '.author_association // ""' <<<"$pr_json" 2>/dev/null) || author_association=""
 	fi
+	author_association=$(_resolve_pr_author_association "$pr_number" "$repo" "$pr_json")
 	if [[ -n "$head_sha_before" && "$head_sha_before" == "$head_sha" ]]; then
 		head_stable="true"
 	fi

--- a/.agents/scripts/tests/test-review-bot-gate-api-snapshot.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-api-snapshot.sh
@@ -83,13 +83,16 @@ if [[ "$scenario" == "fail-once" && "$mode" == "snapshot" &&
 	: >"$failure_marker"
 	exit 42
 fi
+if [[ "$scenario" == "metadata-failure" && "$endpoint" == "repos/testorg/testrepo/pulls/123" ]]; then
+	exit 42
+fi
 
 emit_pages() {
 	local target_endpoint="$1"
 	local current_scenario="$2"
 	case "$target_endpoint" in
 	repos/testorg/testrepo/pulls/123/reviews | repos/testorg/testrepo/pulls/123/reviews?per_page=100)
-		if [[ "$current_scenario" == "empty" ]]; then
+		if [[ "$current_scenario" == "empty" || "$current_scenario" == "metadata-failure" ]]; then
 			printf '%s\n' '[]'
 		else
 			# Two pages prove that the snapshot collector preserves pagination.
@@ -142,6 +145,25 @@ run_check() {
 	RUN_STATUS=0
 	if REVIEW_GATE_AUTHOR_ASSOCIATION=MEMBER \
 		REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE="$snapshot_disabled" \
+		do_check 123 'testorg/testrepo' >"$output_file" 2>"$error_file"; then
+		RUN_STATUS=0
+	else
+		RUN_STATUS=$?
+	fi
+	RUN_OUTPUT=""
+	IFS= read -r RUN_OUTPUT <"$output_file" || true
+	return 0
+}
+
+run_check_without_association() {
+	local scenario="$1"
+	local output_file="${TEST_ROOT}/check-output"
+	local error_file="${TEST_ROOT}/check-error"
+	printf '%s\n' "$scenario" >"$SCENARIO_FILE"
+	: >"$output_file"
+	: >"$error_file"
+	RUN_STATUS=0
+	if REVIEW_GATE_AUTHOR_ASSOCIATION='' REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE=0 \
 		do_check 123 'testorg/testrepo' >"$output_file" 2>"$error_file"; then
 		RUN_STATUS=0
 	else
@@ -277,6 +299,40 @@ test_snapshot_failure_falls_back_without_losing_capability() {
 	return 0
 }
 
+test_missing_metadata_uses_rest_association_without_graphql_projection() {
+	: >"$CALL_LOG"
+	run_check_without_association real
+	local calls command_calls pull_metadata_calls
+	calls=$(call_count)
+	command_calls=$(matching_call_count 'command:')
+	pull_metadata_calls=$(exact_call_count 'direct:repos/testorg/testrepo/pulls/123')
+	if [[ "$RUN_STATUS" -eq 0 && "$RUN_OUTPUT" == "PASS" && "$calls" == "4" &&
+		"$command_calls" == "0" && "$pull_metadata_calls" == "1" ]]; then
+		print_result "missing association uses one REST pull lookup without gh pr projection" 0
+	else
+		print_result "missing association uses one REST pull lookup without gh pr projection" 1 \
+			"status=${RUN_STATUS} output=${RUN_OUTPUT} calls=${calls} command=${command_calls} pull=${pull_metadata_calls}"
+	fi
+	return 0
+}
+
+test_rest_association_failure_remains_blocked() {
+	: >"$CALL_LOG"
+	run_check_without_association metadata-failure
+	local calls command_calls pull_metadata_calls
+	calls=$(call_count)
+	command_calls=$(matching_call_count 'command:')
+	pull_metadata_calls=$(exact_call_count 'direct:repos/testorg/testrepo/pulls/123')
+	if [[ "$RUN_STATUS" -eq 1 && "$RUN_OUTPUT" == "WAITING" && "$calls" == "4" &&
+		"$command_calls" == "0" && "$pull_metadata_calls" == "1" ]]; then
+		print_result "REST association failure keeps unknown authors blocked" 0
+	else
+		print_result "REST association failure keeps unknown authors blocked" 1 \
+			"status=${RUN_STATUS} output=${RUN_OUTPUT} calls=${calls} command=${command_calls} pull=${pull_metadata_calls}"
+	fi
+	return 0
+}
+
 install_gh_stub
 load_helper_functions
 test_preloaded_metadata_avoids_duplicate_lookups
@@ -301,6 +357,8 @@ test_snapshot_reuses_three_paginated_collections
 test_snapshot_refreshes_between_decisions
 test_disable_toggle_restores_direct_queries
 test_snapshot_failure_falls_back_without_losing_capability
+test_missing_metadata_uses_rest_association_without_graphql_projection
+test_rest_association_failure_remains_blocked
 
 printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -664,6 +664,28 @@ test_trusted_default_does_not_require_completed_review() {
 	return 0
 }
 
+test_owner_rest_association_does_not_require_completed_review() {
+	gh() {
+		if [[ "${1:-}" == "api" && "${2:-}" == "repos/testorg/otherrepo/pulls/123" ]]; then
+			printf '%s\n' 'OWNER'
+			return 0
+		fi
+		return 2
+	}
+
+	local association=""
+	association=$(_resolve_pr_author_association 123 'testorg/otherrepo')
+	unset -f gh
+	if [[ "$association" == "OWNER" ]] &&
+		! REVIEW_GATE_AUTHOR_ASSOCIATION="$association" _review_gate_requires_completed_review 'testorg/otherrepo'; then
+		print_result "REST resolver restores trusted OWNER advisory behavior" 0
+	else
+		print_result "REST resolver restores trusted OWNER advisory behavior" 1 \
+			"association=${association:-<empty>}"
+	fi
+	return 0
+}
+
 test_trusted_strict_repo_requires_completed_review() {
 	if REVIEW_GATE_AUTHOR_ASSOCIATION=MEMBER _review_gate_requires_completed_review 'testorg/strictrepo'; then
 		print_result "trusted strict repo requires completed add-on review" 0
@@ -678,6 +700,41 @@ test_external_default_requires_completed_review() {
 		print_result "external author preserves completed-review trust boundary" 0
 	else
 		print_result "external author preserves completed-review trust boundary" 1
+	fi
+	return 0
+}
+
+test_untrusted_association_matrix_requires_completed_review() {
+	local association=""
+	local failures=""
+	for association in CONTRIBUTOR NONE FIRST_TIMER FIRST_TIME_CONTRIBUTOR FUTURE_ENUM ""; do
+		if ! REVIEW_GATE_AUTHOR_ASSOCIATION="$association" _review_gate_requires_completed_review 'testorg/otherrepo'; then
+			failures="${failures}${association:-<empty>} "
+		fi
+	done
+	if [[ -z "$failures" ]]; then
+		print_result "external, unknown, and empty associations fail closed" 0
+	else
+		print_result "external, unknown, and empty associations fail closed" 1 \
+			"unexpected advisory associations: ${failures}"
+	fi
+	return 0
+}
+
+test_malformed_metadata_and_rest_failure_fail_closed() {
+	gh() {
+		return 42
+	}
+
+	local association=""
+	association=$(_resolve_pr_author_association 123 'testorg/otherrepo' '{malformed-json')
+	unset -f gh
+	if [[ -z "$association" ]] &&
+		REVIEW_GATE_AUTHOR_ASSOCIATION="$association" _review_gate_requires_completed_review 'testorg/otherrepo'; then
+		print_result "malformed metadata plus REST failure remains unknown" 0
+	else
+		print_result "malformed metadata plus REST failure remains unknown" 1 \
+			"association=${association:-<empty>}"
 	fi
 	return 0
 }
@@ -1369,8 +1426,11 @@ test_status_json_fails_closed_without_pr_metadata() {
 
 run_completion_requirement_tests() {
 	test_trusted_default_does_not_require_completed_review
+	test_owner_rest_association_does_not_require_completed_review
 	test_trusted_strict_repo_requires_completed_review
 	test_external_default_requires_completed_review
+	test_untrusted_association_matrix_requires_completed_review
+	test_malformed_metadata_and_rest_failure_fail_closed
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Resolve pull-request author associations from live REST metadata and reuse preloaded snapshots so trusted owners and members are classified correctly without weakening external-author gates.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh, .agents/scripts/tests/test-review-bot-gate-api-snapshot.sh, .agents/scripts/tests/test-review-bot-gate-completion-signal.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 66 completion-signal tests and 7 API-snapshot tests pass; ShellCheck, bash -n, and .agents/scripts/linters-local.sh pass.

Resolves #28413


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3h 17m and 1,016,488 tokens on this with the user in an interactive session.