### PR TITLE
GH#28415: Stream Pulse bot-activity snapshots

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -182,10 +182,17 @@ _pmrc_snapshot_bot_activity_json() {
 		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" "inline-comments fetch"
 		return 1
 	}
-	activity=$(jq -n --argjson reviews "$reviews" --argjson issues "$issue_comments" \
-		--argjson inline "$inline_comments" --arg bots "$bot_re" '
+	# Stream all three paginated API documents over stdin. Review histories can
+	# exceed Linux MAX_ARG_STRLEN, so none of these payloads may enter jq argv.
+	activity=$(printf '%s\n%s\n%s\n' "$reviews" "$issue_comments" "$inline_comments" | jq -s \
+		--arg bots "$bot_re" --arg array_type "$PMRC_JSON_ARRAY" '
+		if length != 3
+			or any(.[]; type != $array_type)
+			or any(.[][]; type != $array_type)
+		then error("invalid paginated bot-activity response")
+		else . end |
 		[
-			$reviews[][]?, $issues[][]?, $inline[][]?
+			.[0][][]?, .[1][][]?, .[2][][]?
 			| select((.user.login // "") | test($bots; "i"))
 			| (.updated_at // .submitted_at // .created_at // "")
 			| select(. != "")

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -110,6 +110,21 @@ stub_effective_rules() {
 	return 0
 }
 
+stub_inline_comments() {
+	if [[ "$SNAPSHOT_MODE" == "stale_gate" || "$SNAPSHOT_MODE" == "unresolved" ]]; then
+		printf '%s\n' '[[{"user":{"login":"gemini-code-assist[bot]"},"created_at":"2026-01-01T00:00:40Z","updated_at":"2026-01-01T00:00:40Z"}]]'
+	elif [[ "$SNAPSHOT_MODE" == "large_bot_activity" ]]; then
+		printf '[[{"user":{"login":"gemini-code-assist[bot]"},"created_at":"2026-01-01T00:00:40Z","body":"'
+		dd if=/dev/zero bs=1024 count=256 2>/dev/null | tr '\000' x
+		printf '"}]]\n'
+	elif [[ "$SNAPSHOT_MODE" == "activity_wrong_shape" ]]; then
+		printf '%s\n' '[{}]'
+	else
+		printf '%s\n' '[[]]'
+	fi
+	return 0
+}
+
 gh() {
 	local command="$1"
 	local endpoint="${2:-}"
@@ -198,11 +213,8 @@ gh() {
 		printf '%s\n' '[[]]'
 		;;
 	*pulls/7/comments*)
-		if [[ "$SNAPSHOT_MODE" == "stale_gate" || "$SNAPSHOT_MODE" == "unresolved" ]]; then
-			printf '%s\n' '[[{"user":{"login":"gemini-code-assist[bot]"},"created_at":"2026-01-01T00:00:40Z","updated_at":"2026-01-01T00:00:40Z"}]]'
-		else
-			printf '%s\n' '[[]]'
-		fi
+		stub_inline_comments
+		return $?
 		;;
 	*)
 		printf 'Unhandled gh endpoint: %s\n' "$endpoint" >&2
@@ -276,6 +288,26 @@ assert_snapshot_acquisition_failures_are_audited() {
 	assert_gate_logged "issue-comments fetch failure" issue_comments_error "issue-comments fetch failed"
 	assert_gate_logged "inline-comments fetch failure" inline_comments_error "inline-comments fetch failed"
 	assert_gate_logged "bot-activity parse failure" activity_parse_error "bot-activity parse failed"
+	assert_gate_logged "wrong-shaped bot-activity response" activity_wrong_shape "bot-activity parse failed"
+	return 0
+}
+
+assert_large_bot_activity_streams() {
+	local activity=""
+	local rc=0
+	SNAPSHOT_MODE="large_bot_activity"
+	: >"$LOGFILE"
+	activity=$(_pmrc_snapshot_bot_activity_json owner/repo 7) || rc=$?
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]] && jq -e \
+		'.count == 2 and .latest_at == "2026-01-01T00:00:40Z"' \
+		<<<"$activity" >/dev/null; then
+		printf 'PASS oversized inline-comment payload contributes bot activity\n'
+		return 0
+	fi
+	printf 'FAIL oversized inline-comment payload did not produce expected activity (rc=%s, output=%s)\n' \
+		"$rc" "$activity"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
 	return 0
 }
 
@@ -405,6 +437,8 @@ main() {
 	assert_infrastructure_rerun_unset_logfile_safe
 	assert_snapshot_acquisition_failures_are_audited
 	assert_gate "large paginated check payload streams without argument overflow" large_payload 0
+	assert_large_bot_activity_streams
+	assert_gate "large inline-comment payload streams through preflight" large_bot_activity 0
 	assert_gate "terminal checks with explicit baseline advisory pass" happy_advisory 0
 	if grep -q "IGNORED non-required baseline advisory failure 'Qlty Smell Threshold'" "$LOGFILE"; then
 		printf 'PASS ignored advisory failure is audited\n'


### PR DESCRIPTION
## Summary

Stream the three paginated review/comment documents into jq instead of placing unbounded payloads in process arguments, while validating the complete input shape before calculating activity.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 80 preflight snapshot tests and 15 required-check tests pass; ShellCheck, bash -n, function-complexity regression, and .agents/scripts/linters-local.sh pass.

Resolves #28415


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3h 36m and 1,157,006 tokens on this with the user in an interactive session.