### PR TITLE
GH#28420: classify review scanner launch failures

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -816,6 +816,12 @@ _prrts_retryable_prelaunch_failure_once() {
 	esac
 }
 
+_prrts_prelaunch_failure_needs_maintainer_attention() {
+	local blocked_by="$1"
+	[[ "$blocked_by" == "$PRRTS_BLOCKED_BY_CODE" ]]
+	return $?
+}
+
 _prrts_should_dispatch() {
 	local repo_slug="$1"
 	local pr_number="$2"
@@ -1520,6 +1526,7 @@ _prrts_dispatch_guarded() {
 	local author="${13:-}"
 	local lock_dir=""
 	local attempt_count="1" repeated_same_fingerprint="$PRRTS_BOOL_FALSE" same_head_sha="$PRRTS_BOOL_FALSE" maintainer_attention="$PRRTS_BOOL_FALSE"
+	local failure_maintainer_attention="$PRRTS_BOOL_FALSE"
 	if ! _prrts_acquire_dispatch_lock "$repo_slug" "$pr_number" lock_dir; then
 		return 1
 	fi
@@ -1549,9 +1556,12 @@ _prrts_dispatch_guarded() {
 		return 0
 	fi
 	if ! _prrts_dispatch_worker "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview" "$head_ref" "$head_oid"; then
+		if _prrts_prelaunch_failure_needs_maintainer_attention "$PRRTS_WORKTREE_FAILURE_BLOCKED_BY"; then
+			failure_maintainer_attention="$PRRTS_BOOL_TRUE"
+		fi
 		_prrts_write_state "$repo_slug" "$pr_number" "$fingerprint" "$thread_count" "$now_epoch" "$attempt_count" "$PRRTS_BOOL_FALSE" "$head_oid"
 		_prrts_write_analysis_state "$repo_slug" "$pr_number" "$PRRTS_BOOL_TRUE" \
-			"$PRRTS_WORKTREE_FAILURE_BLOCKED_BY" "$PRRTS_BOOL_TRUE" "$PRRTS_WORKTREE_FAILURE_REASON"
+			"$PRRTS_WORKTREE_FAILURE_BLOCKED_BY" "$failure_maintainer_attention" "$PRRTS_WORKTREE_FAILURE_REASON"
 		_prrts_remove_lock_dir "$lock_dir"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -544,10 +544,16 @@ test_dispatch_blocks_cross_repository_head() {
 	export STUB_CROSS_REPOSITORY="true"
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
 	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local old_epoch=""
+	old_epoch="$(($(date +%s) - 4000))"
+	expire_state_dispatch_time "$state_file" "$old_epoch"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
 	if [[ ! -s "$HEADLESS_LOG" ]] &&
 		grep -q '^analysis_complete=true$' "$state_file" 2>/dev/null &&
 		grep -q '^blocked_by=code$' "$state_file" 2>/dev/null &&
-		grep -q '^blocker_reason=cross_repository_head_unwritable$' "$state_file" 2>/dev/null; then
+		grep -q '^maintainer_attention=true$' "$state_file" 2>/dev/null &&
+		grep -q '^blocker_reason=cross_repository_head_unwritable$' "$state_file" 2>/dev/null &&
+		grep -q 'analysis complete and blocked by code' "$LOGFILE" 2>/dev/null; then
 		print_result "dispatch blocks an unwritable fork head without retrying" 0
 	else
 		print_result "dispatch blocks an unwritable fork head without retrying" 1 "state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf '')"
@@ -1075,6 +1081,36 @@ test_dispatch_retries_transient_head_fetch_failure_once() {
 	return 0
 }
 
+test_dispatch_retries_generic_infrastructure_launch_failure() {
+	setup_test_env
+	chmod -x "$HEADLESS_RUNTIME_HELPER"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local first_failure_ok="false"
+	if grep -q '^analysis_complete=true$' "$state_file" 2>/dev/null &&
+		grep -q '^blocked_by=infrastructure$' "$state_file" 2>/dev/null &&
+		grep -q '^maintainer_attention=false$' "$state_file" 2>/dev/null &&
+		grep -q '^blocker_reason=review_worker_launch_failed$' "$state_file" 2>/dev/null; then
+		first_failure_ok="true"
+	fi
+	local old_epoch=""
+	old_epoch="$(($(date +%s) - 4000))"
+	expire_state_dispatch_time "$state_file" "$old_epoch"
+	chmod +x "$HEADLESS_RUNTIME_HELPER"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	if [[ "$first_failure_ok" == "true" && -s "$HEADLESS_LOG" ]] &&
+		grep -q '^attempt_count=2$' "$state_file" 2>/dev/null &&
+		! grep -q '^analysis_complete=' "$state_file" 2>/dev/null; then
+		print_result "dispatch retries a generic infrastructure launch failure" 0
+	else
+		print_result "dispatch retries a generic infrastructure launch failure" 1 \
+			"first_failure_ok=${first_failure_ok}, headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_dispatch_does_not_repeat_branch_validation_recovery() {
 	setup_test_env
 	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
@@ -1459,6 +1495,7 @@ main() {
 	test_dispatch_retries_stale_branch_validation_blocker_once
 	test_dispatch_retries_stale_branch_unavailable_blocker_once
 	test_dispatch_retries_transient_head_fetch_failure_once
+	test_dispatch_retries_generic_infrastructure_launch_failure
 	test_dispatch_does_not_repeat_branch_validation_recovery
 	test_no_marker_retry_behavior_is_preserved
 	test_old_state_file_without_completion_fields_still_retries


### PR DESCRIPTION
## Summary

Retry generic pre-launch infrastructure failures while preserving terminal code and policy blockers.

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 52 focused scanner tests, 8 legacy scanner tests, ShellCheck, Bash syntax, and changed-file local linters passed.

Resolves #28420


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 38m and 355,967 tokens on this with the user in an interactive session.