### PR TITLE
GH#28433: recover Yama-blocked worktree cleanup

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -129,7 +129,7 @@ _worktree_proc_entry_is_provably_foreign_uid() {
 		for process_uid in "$real_uid" "$effective_uid" "$saved_uid" "$filesystem_uid"; do
 			[[ "$process_uid" =~ ^[0-9]+$ ]] || return 1
 			[[ "$process_uid" != "$current_uid" ]] || return 1
-	done
+		done
 		return 0
 	done <"$proc_dir/status"
 	return 1
@@ -163,7 +163,7 @@ _capture_worktree_proc_cwds() {
 			printf '%s\n' "$cwd_target"
 			captured_count=$((captured_count + 1))
 		fi
-		done
+	done
 	if [[ "$visibility_degraded" -eq 1 ]]; then
 		return "$_WT_CWD_CAPTURE_DEGRADED_RC"
 	fi

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -51,6 +51,13 @@ _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED=1
 _WTAR_REMOVED="removed"
 _WTAR_SKIPPED="skipped"
 _WTAR_FIXTURE_REMOVED="fixture-removed"
+_WT_CWD_VISIBILITY_COMPLETE="complete"
+_WT_CWD_VISIBILITY_DEGRADED="degraded"
+_WT_CWD_VISIBILITY_UNUSABLE="unusable"
+_WT_CWD_CAPTURE_DEGRADED_RC=2
+_WT_CWD_MATCH_UNUSABLE_RC=3
+_WT_CWD_REASON_DEGRADED="cwd-visibility-degraded"
+_WT_CWD_REASON_UNUSABLE="cwd-visibility-unusable"
 
 # =============================================================================
 # log_worktree_removal_event — write one structured log line per event
@@ -122,7 +129,7 @@ _worktree_proc_entry_is_provably_foreign_uid() {
 		for process_uid in "$real_uid" "$effective_uid" "$saved_uid" "$filesystem_uid"; do
 			[[ "$process_uid" =~ ^[0-9]+$ ]] || return 1
 			[[ "$process_uid" != "$current_uid" ]] || return 1
-		done
+	done
 		return 0
 	done <"$proc_dir/status"
 	return 1
@@ -134,6 +141,7 @@ _capture_worktree_proc_cwds() {
 	local cwd_target=""
 	local captured_count=0
 	local current_uid=""
+	local visibility_degraded=0
 	local proc_dir=""
 
 	current_uid=$(id -u 2>/dev/null) || current_uid=""
@@ -143,29 +151,62 @@ _capture_worktree_proc_cwds() {
 		if ! cwd_target=$(readlink "$cwd_link" 2>/dev/null); then
 			# Vanished processes are harmless. Linux commonly denies cwd reads for
 			# other users, so skip only entries whose four status UIDs prove they
-			# are foreign; same-user and unknown ownership still fail closed.
+			# are foreign. Persistent same-user or unknown-ownership denials make
+			# visibility degraded without discarding readable cwd evidence.
 			[[ -L "$cwd_link" || -e "$cwd_link" ]] || continue
 			proc_dir="${cwd_link%/cwd}"
 			_worktree_proc_entry_is_provably_foreign_uid "$proc_dir" "$current_uid" && continue
-			return 1
+			visibility_degraded=1
+			continue
 		fi
 		if [[ -n "$cwd_target" ]]; then
 			printf '%s\n' "$cwd_target"
 			captured_count=$((captured_count + 1))
 		fi
-	done
+		done
+	if [[ "$visibility_degraded" -eq 1 ]]; then
+		return "$_WT_CWD_CAPTURE_DEGRADED_RC"
+	fi
 	[[ "$captured_count" -gt 0 ]] || return 1
 	return 0
 }
 
-# Capture every visible live-process cwd. Callers may supply the resulting
-# snapshot to the guard so one safety check performs only one platform scan.
-capture_worktree_process_cwds() {
+_capture_worktree_lsof_cwds() {
 	local cwd_target=""
 	local captured_count=0
 	local lsof_line=""
 	local lsof_output=""
+	local lsof_status=0
 
+	if lsof_output=$(lsof -n -F n -d cwd 2>/dev/null); then
+		lsof_status=0
+	else
+		lsof_status=$?
+	fi
+	while IFS= read -r lsof_line; do
+		case "$lsof_line" in
+		n*)
+			cwd_target="${lsof_line#n}"
+			if [[ -n "$cwd_target" ]]; then
+				printf '%s\n' "$cwd_target"
+				captured_count=$((captured_count + 1))
+			fi
+			;;
+		esac
+	done <<<"$lsof_output"
+	[[ "$captured_count" -gt 0 ]] || return 1
+	if [[ "$lsof_status" -ne 0 ]]; then
+		return "$_WT_CWD_CAPTURE_DEGRADED_RC"
+	fi
+	return 0
+}
+
+# Capture every visible live-process cwd. stdout always preserves readable
+# targets. Return 0 for complete visibility, 2 for degraded visibility with
+# same-UID/unknown denials, and 1 when no usable snapshot can be established.
+# Callers may supply the resulting snapshot and visibility to the guard so one
+# safety check performs only one platform scan.
+capture_worktree_process_cwds() {
 	if [[ -d /proc ]]; then
 		_capture_worktree_proc_cwds /proc
 		return $?
@@ -174,22 +215,9 @@ capture_worktree_process_cwds() {
 	if command -v lsof >/dev/null 2>&1; then
 		# macOS lacks /proc, but `lsof +D <worktree>` recursively walks the
 		# whole tree (including node_modules). Query only cwd descriptors once.
-		lsof_output=$(lsof -n -F n -d cwd 2>/dev/null) || return 1
-		while IFS= read -r lsof_line; do
-			case "$lsof_line" in
-			n*)
-				cwd_target="${lsof_line#n}"
-				if [[ -n "$cwd_target" ]]; then
-					printf '%s\n' "$cwd_target"
-					captured_count=$((captured_count + 1))
-				fi
-				;;
-			esac
-		done <<<"$lsof_output"
-		[[ "$captured_count" -gt 0 ]] || return 1
-		return 0
+		_capture_worktree_lsof_cwds
+		return $?
 	fi
-
 	return 1
 }
 
@@ -221,15 +249,24 @@ _worktree_has_process_cwd() {
 	local wt_path="$1"
 	local wt_path_real="$2"
 	local cwd_snapshot=""
+	local capture_status=0
 
 	if [[ -z "$wt_path" || -z "$wt_path_real" ]]; then
 		return 1
 	fi
-	# Fail closed when the platform cannot provide a process-CWD snapshot.
-	# Returning 0 means "unsafe to remove" to this predicate's callers.
-	cwd_snapshot=$(capture_worktree_process_cwds) || return 0
-	_worktree_cwd_snapshot_contains_path "$wt_path" "$wt_path_real" "$cwd_snapshot"
-	return $?
+	if cwd_snapshot=$(capture_worktree_process_cwds); then
+		capture_status=0
+	else
+		capture_status=$?
+	fi
+	if _worktree_cwd_snapshot_contains_path "$wt_path" "$wt_path_real" "$cwd_snapshot"; then
+		return 0
+	fi
+	case "$capture_status" in
+	0) return 1 ;;
+	"$_WT_CWD_CAPTURE_DEGRADED_RC") return "$_WT_CWD_CAPTURE_DEGRADED_RC" ;;
+	*) return "$_WT_CWD_MATCH_UNUSABLE_RC" ;;
+	esac
 }
 
 # =============================================================================
@@ -240,20 +277,25 @@ _worktree_has_process_cwd() {
 #   $2  caller   — audit caller constant
 #   $3  reason   — reason to log on skip
 #   $4  cwd_snapshot — optional newline-separated live-process cwd snapshot
+#   $5  cwd_visibility — complete, degraded, or unusable (default: complete)
 #
 # Refuses registered canonical repos, the caller's current working directory,
 # and worktrees that still have any live process cwd inside them. On refusal,
 # WORKTREE_REMOVAL_GUARD_REASON contains the short audit reason for callers that
 # opt into a user-facing diagnostic. The guard itself remains silent.
-# Returns 0 when callers may continue, 1 when removal must be skipped.
+# Returns 0 for complete no-match, 2 for degraded no-match (recoverable path
+# required), and 1 for every hard refusal or unusable snapshot.
 # =============================================================================
 worktree_removal_guard() {
 	local wt_path="$1"
 	local caller="$2"
 	local reason="$3"
 	local cwd_snapshot="${4:-}"
+	local cwd_visibility="${5:-$_WT_CWD_VISIBILITY_COMPLETE}"
 	local cwd_snapshot_provided=0
+	local cwd_match_status=0
 	WORKTREE_REMOVAL_GUARD_REASON=""
+	WORKTREE_REMOVAL_GUARD_VISIBILITY=""
 	[[ "$#" -ge 4 ]] && cwd_snapshot_provided=1
 
 	if [[ -z "$wt_path" ]]; then
@@ -287,14 +329,42 @@ worktree_removal_guard() {
 		esac
 	fi
 
-	if { [[ "$cwd_snapshot_provided" -eq 1 ]] &&
-		_worktree_cwd_snapshot_contains_path "$wt_path" "$wt_path_real" "$cwd_snapshot"; } ||
-		{ [[ "$cwd_snapshot_provided" -eq 0 ]] && _worktree_has_process_cwd "$wt_path" "$wt_path_real"; }; then
+	if [[ "$cwd_snapshot_provided" -eq 1 ]]; then
+		if _worktree_cwd_snapshot_contains_path "$wt_path" "$wt_path_real" "$cwd_snapshot"; then
+			cwd_match_status=0
+		else
+			case "$cwd_visibility" in
+			"$_WT_CWD_VISIBILITY_COMPLETE") cwd_match_status=1 ;;
+			"$_WT_CWD_VISIBILITY_DEGRADED") cwd_match_status="$_WT_CWD_CAPTURE_DEGRADED_RC" ;;
+			*) cwd_match_status="$_WT_CWD_MATCH_UNUSABLE_RC" ;;
+			esac
+		fi
+	elif _worktree_has_process_cwd "$wt_path" "$wt_path_real"; then
+		cwd_match_status=0
+	else
+		cwd_match_status=$?
+	fi
+
+	if [[ "$cwd_match_status" -eq 0 ]]; then
+		WORKTREE_REMOVAL_GUARD_VISIBILITY="$cwd_visibility"
 		WORKTREE_REMOVAL_GUARD_REASON="active-cwd"
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "active-cwd" "skipped"
 		return 1
 	fi
+	if [[ "$cwd_match_status" -eq "$_WT_CWD_CAPTURE_DEGRADED_RC" ]]; then
+		WORKTREE_REMOVAL_GUARD_VISIBILITY="$_WT_CWD_VISIBILITY_DEGRADED"
+		WORKTREE_REMOVAL_GUARD_REASON="$_WT_CWD_REASON_DEGRADED"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "$_WT_CWD_REASON_DEGRADED" "recoverable-required"
+		return "$_WT_CWD_CAPTURE_DEGRADED_RC"
+	fi
+	if [[ "$cwd_match_status" -eq "$_WT_CWD_MATCH_UNUSABLE_RC" ]]; then
+		WORKTREE_REMOVAL_GUARD_VISIBILITY="$_WT_CWD_VISIBILITY_UNUSABLE"
+		WORKTREE_REMOVAL_GUARD_REASON="$_WT_CWD_REASON_UNUSABLE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "$_WT_CWD_REASON_UNUSABLE" "skipped"
+		return 1
+	fi
 
+	WORKTREE_REMOVAL_GUARD_VISIBILITY="$_WT_CWD_VISIBILITY_COMPLETE"
 	: "$reason"
 	return 0
 }

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -482,6 +482,20 @@ _pc_move_orphan_dir_to_trash_bucket() {
 # Safety: skips worktrees owned by active sessions (handled by
 # worktree-helper.sh ownership registry, t189).
 #######################################
+_pc_count_verified_worktree_removals() {
+	local clean_output="$1"
+	local completed_event="AIDEVOPS_WORKTREE_REMOVAL_COMPLETED=1"
+	local output_line=""
+	local completed_count=0
+
+	while IFS= read -r output_line; do
+		[[ "$output_line" == "$completed_event" ]] || continue
+		completed_count=$((completed_count + 1))
+	done <<<"$clean_output"
+	printf '%s\n' "$completed_count"
+	return 0
+}
+
 _cleanup_merged_prs_for_all_repos() {
 	# t2559 Layer 3: fail-loud when git is missing from PATH. This runs before
 	# we invoke worktree-helper.sh clean across every repo — if git isn't
@@ -539,7 +553,7 @@ _cleanup_merged_prs_for_all_repos() {
 			clean_result=$(cd "$repo_path" && bash "$helper" clean --auto --force-merged 2>&1) || true
 
 			local count
-			count=$(echo "$clean_result" | grep -c 'Removing') || count=0
+			count=$(_pc_count_verified_worktree_removals "$clean_result")
 			if [[ "$count" -gt 0 ]]; then
 				local repo_name
 				repo_name=$(basename "$repo_path")
@@ -558,7 +572,7 @@ _cleanup_merged_prs_for_all_repos() {
 		local clean_result
 		clean_result=$(bash "$helper" clean --auto --force-merged 2>&1) || true
 		local fallback_count
-		fallback_count=$(echo "$clean_result" | grep -c 'Removing') || fallback_count=0
+		fallback_count=$(_pc_count_verified_worktree_removals "$clean_result")
 		if [[ "$fallback_count" -gt 0 ]]; then
 			echo "[pulse-wrapper] Worktree cleanup: $fallback_count worktree(s) removed" >>"$LOGFILE"
 			total_removed=$((total_removed + fallback_count))

--- a/.agents/scripts/pulse-temp-worktree-cleanup.sh
+++ b/.agents/scripts/pulse-temp-worktree-cleanup.sh
@@ -382,6 +382,8 @@ _ptwc_remove_candidate() {
 	local audit_context=""
 	local current_head=""
 	local cwd_snapshot=""
+	local cwd_capture_status=0
+	local cwd_visibility="${_WT_CWD_VISIBILITY_UNUSABLE:-unusable}"
 
 	[[ "$detached" == "1" ]] || return 1
 	_ptwc_is_temp_fixture_path "$wt_path" || return 1
@@ -403,9 +405,18 @@ _ptwc_remove_candidate() {
 	_worktree_owner_alive "$wt_path" "" && return 1
 	_ptwc_worktree_is_clean "$wt_path" || return 1
 	_ptwc_head_reachable_from_remote "$repo_path" "$current_head" || return 1
-	cwd_snapshot=$(capture_worktree_process_cwds) || return 1
+	if cwd_snapshot=$(capture_worktree_process_cwds); then
+		cwd_capture_status=0
+	else
+		cwd_capture_status=$?
+	fi
+	case "$cwd_capture_status" in
+	0) cwd_visibility="${_WT_CWD_VISIBILITY_COMPLETE:-complete}" ;;
+	"${_WT_CWD_CAPTURE_DEGRADED_RC:-2}") cwd_visibility="${_WT_CWD_VISIBILITY_DEGRADED:-degraded}" ;;
+	*) cwd_visibility="${_WT_CWD_VISIBILITY_UNUSABLE:-unusable}" ;;
+	esac
 	worktree_removal_guard "$wt_path" "pulse-temp-worktree-cleanup.sh" "$_PTWC_REASON" \
-		"$cwd_snapshot" || return 1
+		"$cwd_snapshot" "$cwd_visibility" || return 1
 	# Keep the post-snapshot window minimal while still proving HEAD did not move.
 	git -C "$wt_path" symbolic-ref --quiet HEAD >/dev/null 2>&1 && return 1
 	[[ "$(git -C "$wt_path" rev-parse --verify HEAD 2>/dev/null)" == "$current_head" ]] || return 1

--- a/.agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh
@@ -66,7 +66,43 @@ test_worktree_helper_skips_non_git_cwd() {
 	return 0
 }
 
+test_pulse_counts_only_verified_removal_events() {
+	local fixture_repo="${TEST_ROOT}/accounting-repo"
+	local helper_dir="${TEST_ROOT}/helper-bin"
+	local helper_path="${helper_dir}/worktree-helper.sh"
+	local output=""
+	mkdir -p "$fixture_repo" "$helper_dir"
+	git -C "$fixture_repo" init -q -b main
+	rm -f "${HOME}/.config/aidevops/repos.json"
+	_PULSE_CLEANUP_SCRIPT_DIR="$helper_dir"
+
+	cat >"$helper_path" <<'EOF'
+#!/usr/bin/env bash
+printf 'Removing feature/refused...\n'
+printf 'Skipped feature/refused - removal guard refused path\n'
+exit 1
+EOF
+	chmod +x "$helper_path"
+	output=$(cd "$fixture_repo" && _cleanup_merged_prs_for_all_repos)
+	[[ "$output" == "0" ]] || fail "progress-only refused removal counted as completed: $output"
+
+	cat >"$helper_path" <<'EOF'
+#!/usr/bin/env bash
+printf 'Removing feature/completed...\n'
+printf 'AIDEVOPS_WORKTREE_REMOVAL_COMPLETED=1\n'
+printf 'AIDEVOPS_WORKTREE_REMOVAL_COMPLETED=1 suffix-must-not-count\n'
+exit 0
+EOF
+	chmod +x "$helper_path"
+	output=$(cd "$fixture_repo" && _cleanup_merged_prs_for_all_repos)
+	[[ "$output" == "1" ]] || fail "verified completion event produced unexpected count: $output"
+	_PULSE_CLEANUP_SCRIPT_DIR="$SCRIPT_DIR"
+	pass "pulse cleanup counts only exact post-verification removal events"
+	return 0
+}
+
 test_pulse_fallback_skips_non_git_cwd
 test_worktree_helper_skips_non_git_cwd
+test_pulse_counts_only_verified_removal_events
 
 exit 0

--- a/.agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh
@@ -228,6 +228,31 @@ test_cleanup_bounds_fresh_snapshots() {
 	return 0
 }
 
+test_degraded_visibility_preserves_temp_candidate() {
+	teardown
+	setup_subject || return 1
+	local repo_path="${TEST_ROOT}/repo-degraded"
+	local remote_path="${TEST_ROOT}/remote-degraded.git"
+	local wt_path="${TEST_ROOT}/tmp.degraded-visibility"
+	local removed=0
+	local rc=0
+	create_repo_with_remote "$repo_path" "$remote_path" || return 1
+	git -C "$repo_path" worktree add -q --detach "$wt_path" origin/main || return 1
+	age_gitfile "$wt_path/.git" 2 || return 1
+	capture_worktree_process_cwds() {
+		printf '%s\n' "/unrelated-readable-cwd"
+		return "${_WT_CWD_CAPTURE_DEGRADED_RC:-2}"
+	}
+
+	removed=$(cleanup_stale_temp_worktrees) || rc=1
+	[[ "$removed" == "0" ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q 'cwd-visibility-degraded' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "temp cleanup blocks degraded absence-only visibility" "$rc" \
+		"removed=$removed candidate_exists=$([[ -d "$wt_path" ]] && printf y || printf n)"
+	return 0
+}
+
 test_cleanup_lock_race_guards() {
 	teardown
 	setup_subject || return 1
@@ -365,6 +390,7 @@ run_test() {
 run_test test_fast_temp_cleanup_guards
 run_test test_local_only_repo_is_excluded
 run_test test_cleanup_bounds_fresh_snapshots
+run_test test_degraded_visibility_preserves_temp_candidate
 run_test test_cleanup_lock_race_guards
 run_test test_stale_local_main_uses_remote_default
 run_test test_path_classifier_rejects_normal_linked_worktree

--- a/.agents/scripts/tests/test-worktree-metadata-prune.sh
+++ b/.agents/scripts/tests/test-worktree-metadata-prune.sh
@@ -7,9 +7,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
 GIT_SHIM="${SCRIPT_DIR}/git"
 TEST_ROOT=$(mktemp -d)
+TEST_ROOT=$(cd "$TEST_ROOT" && pwd -P)
 REPO="${TEST_ROOT}/repo"
 LINKED="${TEST_ROOT}/linked"
 FAILED_LINKED="${TEST_ROOT}/failed-linked"
+RECOVERABLE_LINKED="${TEST_ROOT}/recoverable-linked"
+MOVE_FAILED_LINKED="${TEST_ROOT}/move-failed-linked"
+PRUNE_FAILED_LINKED="${TEST_ROOT}/prune-failed-linked"
+DIRTY_LINKED="${TEST_ROOT}/dirty-linked"
+OWNERSHIP_LINKED="${TEST_ROOT}/ownership-linked"
+INTEGRATION_LINKED="${TEST_ROOT}/integration-linked"
+RECOVERABLE_TRASH="${TEST_ROOT}/recoverable-trash"
 SHIM_BIN="${TEST_ROOT}/bin"
 TEST_PATH="${SHIM_BIN}:/usr/bin:/bin:/usr/sbin:/sbin"
 FAILING_GIT="${TEST_ROOT}/failing-git"
@@ -33,6 +41,12 @@ printf 'seed\n' >"${REPO}/README.md"
 /usr/bin/git -C "$REPO" commit -q -m seed
 /usr/bin/git -C "$REPO" worktree add -q -b feature/prune-test "$LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/prune-failure "$FAILED_LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-success "$RECOVERABLE_LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-move-failure "$MOVE_FAILED_LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-prune-failure "$PRUNE_FAILED_LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-dirty "$DIRTY_LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-ownership "$OWNERSHIP_LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-integration "$INTEGRATION_LINKED"
 ln -s "$GIT_SHIM" "${SHIM_BIN}/git"
 
 if PATH="$TEST_PATH" git -C "$REPO" worktree prune >/dev/null 2>&1; then
@@ -143,3 +157,240 @@ if AIDEVOPS_REAL_GIT_BIN="$POST_PRUNE_QUERY_FAILING_GIT" \
 	exit 1
 fi
 printf 'PASS post-prune metadata query failure cannot report cleanup success\n'
+
+# Exercise the degraded-visibility removal primitive with native Git. The
+# candidate must be moved recoverably, metadata must be proven absent, and only
+# then may the stable completion event be emitted.
+git() {
+	/usr/bin/git "$@"
+	return $?
+}
+is_registered_canonical() {
+	local worktree_path="$1"
+	: "$worktree_path"
+	return 1
+}
+worktree_has_changes() {
+	local worktree_path="$1"
+	if /usr/bin/git -C "$worktree_path" status --porcelain 2>/dev/null | grep -q .; then
+		return 0
+	fi
+	return 1
+}
+is_worktree_owned_by_others() {
+	local worktree_path="$1"
+	: "$worktree_path"
+	return 1
+}
+unregister_worktree() {
+	local worktree_path="$1"
+	: "$worktree_path"
+	return 0
+}
+claim_worktree_ownership() {
+	local worktree_path="$1"
+	local worktree_branch="$2"
+	: "$worktree_path" "$worktree_branch"
+	return 0
+}
+localdev_auto_branch_rm() {
+	local worktree_branch="$1"
+	: "$worktree_branch"
+	return 0
+}
+capture_worktree_process_cwds() {
+	printf '%s\n' "/unrelated-readable-cwd"
+	return "${_WT_CWD_CAPTURE_DEGRADED_RC:-2}"
+}
+
+[[ -z "${RED+x}" ]] && RED=""
+[[ -z "${YELLOW+x}" ]] && YELLOW=""
+[[ -z "${BLUE+x}" ]] && BLUE=""
+[[ -z "${NC+x}" ]] && NC=""
+_WTAR_WH_CALLER="worktree-helper.sh"
+# shellcheck source=../worktree-clean-lib.sh
+source "${SCRIPT_DIR}/worktree-clean-lib.sh"
+worktree_is_in_grace_period() {
+	local worktree_path="$1"
+	: "$worktree_path"
+	return 1
+}
+_branch_has_active_interactive_claim() {
+	local worktree_path="$1"
+	local worktree_branch="$2"
+	: "$worktree_path" "$worktree_branch"
+	return 1
+}
+_clean_branch_has_exact_merged_pr() {
+	local worktree_branch="$1"
+	local merged_prs="${2:-}"
+	_clean_branch_list_contains_exact "$worktree_branch" "$merged_prs"
+	return $?
+}
+branch_was_pushed() {
+	local worktree_branch="$1"
+	: "$worktree_branch"
+	return 1
+}
+_branch_exists_on_any_remote() {
+	local worktree_branch="$1"
+	: "$worktree_branch"
+	return 0
+}
+
+recovery_output=$(
+	cd "$REPO" || exit 1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$RECOVERABLE_TRASH" \
+		_clean_remove_classified_worktree "$RECOVERABLE_LINKED" "feature/recoverable-success" \
+		"false" "false" "visibility=degraded" "$REPO" "$_WT_CLEAN_MODE_RECOVERABLE" "true"
+)
+[[ "$(printf '%s\n' "$recovery_output" | grep -cFx "$_WT_CLEAN_COMPLETED_EVENT")" -eq 1 ]] || {
+	printf 'FAIL recoverable cleanup did not emit exactly one verified completion event: %s\n' "$recovery_output"
+	exit 1
+}
+[[ ! -e "$RECOVERABLE_LINKED" ]] || {
+	printf 'FAIL recoverable cleanup left original candidate path in place\n'
+	exit 1
+}
+if /usr/bin/git -C "$REPO" worktree list --porcelain | grep -Fqx "worktree $RECOVERABLE_LINKED"; then
+	printf 'FAIL recoverable cleanup left exact Git worktree metadata registered\n'
+	exit 1
+fi
+compgen -G "${RECOVERABLE_TRASH}/*/recoverable-linked" >/dev/null || {
+	printf 'FAIL recoverable cleanup did not preserve candidate files in trash\n'
+	exit 1
+}
+printf 'PASS degraded cleanup emits completion only after recoverable move and exact metadata absence\n'
+
+move_failure_output=""
+if move_failure_output=$(
+	cd "$REPO" || exit 1
+	_clean_move_worktree_recoverably() {
+		local worktree_path="$1"
+		: "$worktree_path"
+		return 1
+	}
+	_clean_remove_classified_worktree "$MOVE_FAILED_LINKED" "feature/recoverable-move-failure" \
+		"false" "false" "visibility=degraded" "$REPO" "$_WT_CLEAN_MODE_RECOVERABLE" "true"
+); then
+	printf 'FAIL recoverable move failure reported cleanup success\n'
+	exit 1
+fi
+[[ -d "$MOVE_FAILED_LINKED" && "$move_failure_output" != *"$_WT_CLEAN_COMPLETED_EVENT"* ]] || {
+	printf 'FAIL recoverable move failure removed candidate or emitted completion\n'
+	exit 1
+}
+printf 'PASS recoverable move failure remains fail-closed with zero completion events\n'
+
+prune_failure_output=""
+if prune_failure_output=$(
+	cd "$REPO" || exit 1
+	prune_missing_worktree_metadata() {
+		local repo_context="$1"
+		local worktree_path="$2"
+		: "$repo_context" "$worktree_path"
+		return 1
+	}
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$RECOVERABLE_TRASH" \
+		_clean_remove_classified_worktree "$PRUNE_FAILED_LINKED" "feature/recoverable-prune-failure" \
+		"false" "false" "visibility=degraded" "$REPO" "$_WT_CLEAN_MODE_RECOVERABLE" "true"
+); then
+	printf 'FAIL metadata prune failure reported cleanup success\n'
+	exit 1
+fi
+[[ ! -e "$PRUNE_FAILED_LINKED" && "$prune_failure_output" != *"$_WT_CLEAN_COMPLETED_EVENT"* ]] || {
+	printf 'FAIL metadata prune failure emitted completion or left an irreversible state\n'
+	exit 1
+}
+/usr/bin/git -C "$REPO" worktree list --porcelain | grep -Fqx "worktree $PRUNE_FAILED_LINKED" || {
+	printf 'FAIL metadata prune failure fixture did not preserve stale metadata for recovery\n'
+	exit 1
+}
+printf 'PASS metadata prune failure remains recoverable and emits zero completion events\n'
+
+printf 'dirty state\n' >"${DIRTY_LINKED}/dirty.txt"
+dirty_output=""
+if dirty_output=$(
+	cd "$REPO" || exit 1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$RECOVERABLE_TRASH" \
+		_clean_remove_classified_worktree "$DIRTY_LINKED" "feature/recoverable-dirty" \
+		"true" "false" "visibility=degraded" "$REPO" "$_WT_CLEAN_MODE_RECOVERABLE" "true"
+); then
+	printf 'FAIL --force-merged authorized dirty degraded cleanup\n'
+	exit 1
+fi
+[[ -f "${DIRTY_LINKED}/dirty.txt" && "$dirty_output" != *"$_WT_CLEAN_COMPLETED_EVENT"* ]] || {
+	printf 'FAIL dirty degraded candidate was altered or reported complete\n'
+	exit 1
+}
+printf 'PASS --force-merged cannot authorize dirty degraded cleanup\n'
+
+owned_output=""
+if owned_output=$(
+	cd "$REPO" || exit 1
+	is_worktree_owned_by_others() {
+		local worktree_path="$1"
+		: "$worktree_path"
+		return 0
+	}
+	_clean_remove_classified_worktree "$OWNERSHIP_LINKED" "feature/recoverable-ownership" \
+		"false" "false" "visibility=degraded" "$REPO" "$_WT_CLEAN_MODE_RECOVERABLE" "true"
+); then
+	printf 'FAIL owned degraded candidate reported cleanup success\n'
+	exit 1
+fi
+[[ -d "$OWNERSHIP_LINKED" && "$owned_output" != *"$_WT_CLEAN_COMPLETED_EVENT"* ]] || {
+	printf 'FAIL owned degraded candidate was altered or reported complete\n'
+	exit 1
+}
+
+claimed_output=""
+if claimed_output=$(
+	cd "$REPO" || exit 1
+	_branch_has_active_interactive_claim() {
+		local worktree_path="$1"
+		local worktree_branch="$2"
+		: "$worktree_path" "$worktree_branch"
+		return 0
+	}
+	_clean_remove_classified_worktree "$OWNERSHIP_LINKED" "feature/recoverable-ownership" \
+		"false" "false" "visibility=degraded" "$REPO" "$_WT_CLEAN_MODE_RECOVERABLE" "true"
+); then
+	printf 'FAIL claimed degraded candidate reported cleanup success\n'
+	exit 1
+fi
+[[ -d "$OWNERSHIP_LINKED" && "$claimed_output" != *"$_WT_CLEAN_COMPLETED_EVENT"* ]] || {
+	printf 'FAIL claimed degraded candidate was altered or reported complete\n'
+	exit 1
+}
+printf 'PASS owned and claimed degraded candidates remain blocked\n'
+
+if (
+	WORKTREE_REMOVAL_GUARD_REASON="$_WT_CWD_REASON_DEGRADED"
+	_clean_branch_has_exact_merged_pr() { return 1; }
+	_clean_degraded_visibility_fallback_allowed "$OWNERSHIP_LINKED" "feature/recoverable-ownership" \
+		"merged" "" "" "" "visibility=degraded"
+); then
+	printf 'FAIL degraded cleanup accepted a candidate without terminal PR proof\n'
+	exit 1
+fi
+printf 'PASS degraded cleanup requires terminal PR proof\n'
+
+integration_output=$(
+	cd "$REPO" || exit 1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$RECOVERABLE_TRASH" \
+		_clean_remove_merged "main" "$REPO" "false" "feature/recoverable-integration" "" "true" ""
+)
+[[ ! -e "$INTEGRATION_LINKED" ]] || {
+	printf 'FAIL degraded terminal-PR candidate was not removed by the integrated cleanup pass\n'
+	exit 1
+}
+[[ "$(printf '%s\n' "$integration_output" | grep -cFx "$_WT_CLEAN_COMPLETED_EVENT")" -eq 1 ]] || {
+	printf 'FAIL integrated degraded cleanup did not emit one verified completion event: %s\n' "$integration_output"
+	exit 1
+}
+if /usr/bin/git -C "$REPO" worktree list --porcelain | grep -Fqx "worktree $INTEGRATION_LINKED"; then
+	printf 'FAIL integrated degraded cleanup left exact metadata registered\n'
+	exit 1
+fi
+printf 'PASS integrated degraded cleanup removes a clean terminal-PR candidate recoverably\n'

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -534,12 +534,10 @@ test_proc_snapshot_preserves_degraded_visibility() {
 	if output=$(
 		readlink() {
 			local link_path="$1"
-			case "$link_path" in
-			*/1/cwd)
+			if [[ "$link_path" == */1/cwd ]]; then
 				printf '/visible-cwd\n'
 				return 0
-				;;
-			esac
+			fi
 			return 1
 		}
 		_capture_worktree_proc_cwds "$proc_root"

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -428,7 +428,7 @@ test_process_cwd_snapshot_failure_is_fail_closed() {
 	if worktree_removal_guard "$wt_path" "test.sh" "manual"; then
 		rc=1
 	fi
-	assert_file_contains "$log_file" "worktree-skipped.*active-cwd" || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*cwd-visibility-unusable" || rc=1
 	if ! worktree_removal_guard "$wt_path" "test.sh" "manual" ""; then
 		rc=1
 	fi
@@ -468,16 +468,70 @@ test_snapshot_backend_requires_visible_target() {
 }
 
 # =============================================================================
-# Test 14: a partially visible /proc snapshot is incomplete and fails closed.
+# The macOS lsof backend distinguishes complete output, partial/permission-
+# limited output, and empty unusable output. Absence-only output never proves a
+# candidate inactive.
 # =============================================================================
-test_proc_snapshot_rejects_partial_visibility() {
+test_lsof_snapshot_visibility_states() {
+	local output=""
+	local capture_status=0
+	local rc=0
+
+	if output=$(
+		lsof() { return 0; }
+		_capture_worktree_lsof_cwds
+	); then
+		capture_status=0
+	else
+		capture_status=$?
+	fi
+	[[ "$capture_status" -eq 1 && -z "$output" ]] || rc=1
+
+	if output=$(
+		lsof() {
+			printf 'p123\nn/visible-lsof-cwd\n'
+			return 1
+		}
+		_capture_worktree_lsof_cwds
+	); then
+		capture_status=0
+	else
+		capture_status=$?
+	fi
+	[[ "$capture_status" -eq "$_WT_CWD_CAPTURE_DEGRADED_RC" ]] || rc=1
+	[[ "$output" == "/visible-lsof-cwd" ]] || rc=1
+
+	if output=$(
+		lsof() {
+			printf 'p123\nn/complete-lsof-cwd\n'
+			return 0
+		}
+		_capture_worktree_lsof_cwds
+	); then
+		capture_status=0
+	else
+		capture_status=$?
+	fi
+	[[ "$capture_status" -eq 0 && "$output" == "/complete-lsof-cwd" ]] || rc=1
+	print_result "lsof_snapshot_visibility_states" "$rc" \
+		"Expected empty lsof to be unusable and partial lsof output to be degraded"
+	return 0
+}
+
+# =============================================================================
+# Test 14: a partially visible /proc snapshot preserves readable evidence and
+# reports degraded visibility instead of aliasing it to a total failure.
+# =============================================================================
+test_proc_snapshot_preserves_degraded_visibility() {
 	local proc_root="${TEST_DIR}/fake-proc"
+	local output=""
+	local capture_status=0
 	local rc=0
 	mkdir -p "${proc_root}/1" "${proc_root}/2"
 	ln -s /visible-cwd "${proc_root}/1/cwd"
 	ln -s /hidden-cwd "${proc_root}/2/cwd"
 
-	if (
+	if output=$(
 		readlink() {
 			local link_path="$1"
 			case "$link_path" in
@@ -488,12 +542,16 @@ test_proc_snapshot_rejects_partial_visibility() {
 			esac
 			return 1
 		}
-		_capture_worktree_proc_cwds "$proc_root" >/dev/null
+		_capture_worktree_proc_cwds "$proc_root"
 	); then
-		rc=1
+		capture_status=0
+	else
+		capture_status=$?
 	fi
-	print_result "proc_snapshot_rejects_partial_visibility" "$rc" \
-		"Expected one unreadable persistent cwd link to invalidate the snapshot"
+	[[ "$capture_status" -eq "$_WT_CWD_CAPTURE_DEGRADED_RC" ]] || rc=1
+	[[ "$output" == "/visible-cwd" ]] || rc=1
+	print_result "proc_snapshot_preserves_degraded_visibility" "$rc" \
+		"Expected unreadable unknown ownership to preserve visible cwd evidence with degraded status"
 	return 0
 }
 
@@ -531,12 +589,14 @@ test_proc_snapshot_skips_foreign_uid_unreadable_entry() {
 }
 
 # =============================================================================
-# Same-UID unreadability remains fail-closed because the hidden cwd may be in a
-# candidate worktree.
+# Same-UID unreadability is explicitly degraded while preserving readable cwd
+# evidence for candidate-specific positive matching.
 # =============================================================================
-test_proc_snapshot_rejects_same_uid_unreadable_entry() {
+test_proc_snapshot_marks_same_uid_unreadable_entry_degraded() {
 	local proc_root="${TEST_DIR}/fake-proc-same-uid"
 	local current_uid=""
+	local output=""
+	local capture_status=0
 	local rc=0
 	current_uid=$(id -u)
 	mkdir -p "${proc_root}/1" "${proc_root}/2"
@@ -545,19 +605,59 @@ test_proc_snapshot_rejects_same_uid_unreadable_entry() {
 	printf 'Uid:\t%s\t%s\t%s\t%s\n' \
 		"$current_uid" "$current_uid" "$current_uid" "$current_uid" >"${proc_root}/2/status"
 
-	if (
+	if output=$(
 		readlink() {
 			local link_path="$1"
 			[[ "$link_path" == */1/cwd ]] || return 1
 			printf '/visible-cwd\n'
 			return 0
 		}
-		_capture_worktree_proc_cwds "$proc_root" >/dev/null
+		_capture_worktree_proc_cwds "$proc_root"
 	); then
-		rc=1
+		capture_status=0
+	else
+		capture_status=$?
 	fi
-	print_result "proc_snapshot_rejects_same_uid_unreadable_entry" "$rc" \
-		"Expected same-UID unreadability to invalidate the snapshot"
+	[[ "$capture_status" -eq "$_WT_CWD_CAPTURE_DEGRADED_RC" ]] || rc=1
+	[[ "$output" == "/visible-cwd" ]] || rc=1
+	print_result "proc_snapshot_marks_same_uid_unreadable_entry_degraded" "$rc" \
+		"Expected simulated same-UID EACCES to return degraded status with visible evidence intact"
+	return 0
+}
+
+# =============================================================================
+# Degraded visibility is candidate-specific: unrelated readable CWDs require a
+# recoverable path, while any readable target inside the candidate hard-blocks.
+# =============================================================================
+test_degraded_visibility_preserves_positive_candidate_match() {
+	local log_file="${TEST_DIR}/degraded-candidate-cleanup.log"
+	local wt_path="${TEST_DIR}/degraded-candidate"
+	local guard_status=0
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	mkdir -p "$wt_path"
+
+	if worktree_removal_guard "$wt_path" "test.sh" "manual" "/unrelated-readable-cwd" \
+		"$_WT_CWD_VISIBILITY_DEGRADED"; then
+		guard_status=0
+	else
+		guard_status=$?
+	fi
+	[[ "$guard_status" -eq "$_WT_CWD_CAPTURE_DEGRADED_RC" ]] || rc=1
+	[[ "${WORKTREE_REMOVAL_GUARD_REASON:-}" == "$_WT_CWD_REASON_DEGRADED" ]] || rc=1
+
+	if worktree_removal_guard "$wt_path" "test.sh" "manual" "$wt_path/active-shell" \
+		"$_WT_CWD_VISIBILITY_DEGRADED"; then
+		guard_status=0
+	else
+		guard_status=$?
+	fi
+	[[ "$guard_status" -eq 1 ]] || rc=1
+	[[ "${WORKTREE_REMOVAL_GUARD_REASON:-}" == "active-cwd" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*cwd-visibility-degraded.*mode=recoverable-required" || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*active-cwd.*mode=skipped" || rc=1
+	print_result "degraded_visibility_preserves_positive_candidate_match" "$rc" \
+		"Expected unrelated denial to be recoverable-only and readable candidate CWD to hard-block"
 	return 0
 }
 
@@ -706,9 +806,11 @@ test_optional_guard_context_logged
 test_process_cwd_guard_refuses_empty_paths
 test_process_cwd_snapshot_failure_is_fail_closed
 test_snapshot_backend_requires_visible_target
-test_proc_snapshot_rejects_partial_visibility
+test_lsof_snapshot_visibility_states
+test_proc_snapshot_preserves_degraded_visibility
 test_proc_snapshot_skips_foreign_uid_unreadable_entry
-test_proc_snapshot_rejects_same_uid_unreadable_entry
+test_proc_snapshot_marks_same_uid_unreadable_entry_degraded
+test_degraded_visibility_preserves_positive_candidate_match
 test_proc_snapshot_requires_usable_evidence_after_foreign_skips
 test_proc_snapshot_ignores_vanished_entry
 test_guard_reason_is_machine_readable

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -614,6 +614,8 @@ _WT_CLEAN_TYPE_CLOSED_ISSUE_ARCHIVE="closed issue branch archive"
 _WT_CLEAN_MODE_SKIPPED="skipped"
 _WT_CLEAN_MODE_BRANCH_PRESERVED="branch-preserved"
 _WT_CLEAN_MODE_PERMANENT="permanent"
+_WT_CLEAN_MODE_RECOVERABLE="recoverable-trash"
+_WT_CLEAN_COMPLETED_EVENT="AIDEVOPS_WORKTREE_REMOVAL_COMPLETED=1"
 _WT_CLEAN_BOOL_TRUE=true
 _WT_CLEAN_BOOL_FALSE=false
 _WT_CLEAN_LAST_PRESERVE_BRANCH="${_WT_CLEAN_LAST_PRESERVE_BRANCH:-$_WT_CLEAN_BOOL_FALSE}"
@@ -947,27 +949,147 @@ _clean_scan_merged() {
 	return 1
 }
 
+_clean_move_worktree_to_trash_bucket() {
+	local worktree_path="$1"
+	local trash_root="$2"
+	local trash_bucket=""
+	local worktree_basename=""
+
+	worktree_basename=$(basename "$worktree_path") || return 1
+	[[ -n "$worktree_basename" && "$worktree_basename" != "." && "$worktree_basename" != "/" ]] || return 1
+	trash_bucket="${trash_root}/aidevops-worktree-cleanup-$(date -u '+%Y%m%dT%H%M%SZ')-$$"
+	mkdir -p "$trash_bucket" 2>/dev/null || return 1
+	mv "$worktree_path" "$trash_bucket/$worktree_basename" 2>/dev/null || return 1
+	[[ ! -e "$worktree_path" ]] || return 1
+	return 0
+}
+
+# Move a worktree to recoverable trash without any rm -rf fallback. This is the
+# only physical-removal primitive permitted when process-CWD visibility is
+# degraded, so a false absence inference remains recoverable.
+_clean_move_worktree_recoverably() {
+	local worktree_path="$1"
+	local trash_root="${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}"
+
+	[[ -n "$worktree_path" ]] || return 1
+	[[ -e "$worktree_path" ]] || return 1
+	if [[ -n "$trash_root" ]]; then
+		_clean_move_worktree_to_trash_bucket "$worktree_path" "$trash_root"
+		return $?
+	fi
+	if command -v trash >/dev/null 2>&1; then
+		trash "$worktree_path" 2>/dev/null || return 1
+		[[ ! -e "$worktree_path" ]] || return 1
+		return 0
+	fi
+	if command -v gio >/dev/null 2>&1; then
+		gio trash "$worktree_path" 2>/dev/null || return 1
+		[[ ! -e "$worktree_path" ]] || return 1
+		return 0
+	fi
+	_clean_move_worktree_to_trash_bucket "$worktree_path" "${HOME}/.Trash"
+	return $?
+}
+
+_clean_merge_type_has_terminal_pr_state() {
+	local merge_type="$1"
+	case "$merge_type" in
+	"$_WT_CLEAN_TYPE_SQUASH_MERGED_PR" | "$_WT_CLEAN_TYPE_CLOSED_PR") return 0 ;;
+	esac
+	return 1
+}
+
+# A degraded process snapshot can authorize only a candidate-local recoverable
+# move. Every mutable predicate is rechecked after the cleanup lease is held.
+_clean_degraded_visibility_fallback_allowed() {
+	local worktree_path="$1"
+	local worktree_branch="$2"
+	local merge_type="$3"
+	local merged_prs="$4"
+	local closed_prs="$5"
+	local open_prs="$6"
+	local audit_context="$7"
+
+	[[ "${WORKTREE_REMOVAL_GUARD_REASON:-}" == "${_WT_CWD_REASON_DEGRADED:-cwd-visibility-degraded}" ]] || return 1
+	if worktree_has_changes "$worktree_path"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "degraded-cwd-dirty-skip" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
+		return 1
+	fi
+	if _branch_has_active_interactive_claim "$worktree_path" "$worktree_branch"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "active-claim" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
+		return 1
+	fi
+	if is_worktree_owned_by_others "$worktree_path"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "$_WT_CLEAN_REASON_OWNED_SKIP" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
+		return 1
+	fi
+	if _clean_branch_list_contains_exact "$worktree_branch" "$open_prs"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "open-pr" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
+		return 1
+	fi
+	if worktree_is_in_grace_period "$worktree_path"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "grace-period" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
+		return 1
+	fi
+	if _clean_merge_type_has_terminal_pr_state "$merge_type" ||
+		_clean_branch_has_terminal_pr_proof "$worktree_branch" "$merged_prs" "$closed_prs"; then
+		return 0
+	fi
+	log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "degraded-cwd-pr-proof-required" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
+	return 1
+}
+
 _clean_remove_classified_worktree() {
 	local worktree_path="$1"
 	local worktree_branch="$2"
 	local force_merged="$3"
 	local preserve_branch="$4"
 	local audit_context="$5"
+	local repo_context="$6"
+	local removal_mode="${7:-$_WT_CLEAN_MODE_PERMANENT}"
+	local recovery_authorized="${8:-$_WT_CLEAN_BOOL_FALSE}"
 	local use_force="$_WT_CLEAN_BOOL_FALSE"
 	local removed="$_WT_CLEAN_BOOL_FALSE"
+	local guard_status=0
+	local audit_reason="$_WT_CLEAN_REASON_BRANCH_MERGED"
+	local completed_mode="$_WT_CLEAN_MODE_PERMANENT"
+
+	if worktree_removal_guard "$worktree_path" "$_WTAR_WH_CALLER" "$_WT_CLEAN_REASON_BRANCH_MERGED"; then
+		guard_status=0
+	else
+		guard_status=$?
+	fi
+	if [[ "$removal_mode" == "$_WT_CLEAN_MODE_RECOVERABLE" ]]; then
+		[[ "$recovery_authorized" == "$_WT_CLEAN_BOOL_TRUE" ]] || return 1
+		if [[ "$guard_status" -ne 0 && "$guard_status" -ne "${_WT_CWD_CAPTURE_DEGRADED_RC:-2}" ]]; then
+			return 1
+		fi
+		worktree_has_changes "$worktree_path" && return 1
+		_branch_has_active_interactive_claim "$worktree_path" "$worktree_branch" && return 1
+		is_worktree_owned_by_others "$worktree_path" && return 1
+	elif [[ "$guard_status" -ne 0 ]]; then
+		return "$guard_status"
+	fi
 
 	if worktree_has_changes "$worktree_path" && [[ "$force_merged" == "$_WT_CLEAN_BOOL_TRUE" ]]; then
 		use_force="$_WT_CLEAN_BOOL_TRUE"
 	fi
-	if [[ "$preserve_branch" == "$_WT_CLEAN_BOOL_TRUE" ]]; then
+	if [[ "$removal_mode" == "$_WT_CLEAN_MODE_RECOVERABLE" ]]; then
+		if _clean_move_worktree_recoverably "$worktree_path"; then
+			removed="$_WT_CLEAN_BOOL_TRUE"
+			completed_mode="$_WT_CLEAN_MODE_RECOVERABLE"
+		else
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "recoverable-move-failed" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
+			return 1
+		fi
+	elif [[ "$preserve_branch" == "$_WT_CLEAN_BOOL_TRUE" ]]; then
 		_clean_archive_dirty_worktree_stash "$worktree_path" "$worktree_branch" || return 1
 		if git worktree remove --force "$worktree_path" 2>/dev/null; then
-			git worktree prune 2>/dev/null || true
-			log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$worktree_path" "$_WT_CLEAN_REASON_CLOSED_ISSUE_ARCHIVE" "$_WT_CLEAN_MODE_BRANCH_PRESERVED" "$audit_context"
 			removed="$_WT_CLEAN_BOOL_TRUE"
+			audit_reason="$_WT_CLEAN_REASON_CLOSED_ISSUE_ARCHIVE"
+			completed_mode="$_WT_CLEAN_MODE_BRANCH_PRESERVED"
 		fi
-	elif remove_worktree_path_permanently "$worktree_path" "$_WTAR_WH_CALLER" "$_WT_CLEAN_REASON_BRANCH_MERGED" "$audit_context"; then
-		git worktree prune 2>/dev/null || true
+	elif rm -rf "$worktree_path" 2>/dev/null; then
 		removed="$_WT_CLEAN_BOOL_TRUE"
 	else
 		local remove_flag
@@ -976,7 +1098,6 @@ _clean_remove_classified_worktree() {
 		fi
 		# shellcheck disable=SC2086
 		if git worktree remove $remove_flag "$worktree_path" 2>/dev/null; then
-			log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$worktree_path" "$_WT_CLEAN_REASON_BRANCH_MERGED" "$_WT_CLEAN_MODE_PERMANENT" "$audit_context"
 			removed="$_WT_CLEAN_BOOL_TRUE"
 		fi
 	fi
@@ -984,12 +1105,63 @@ _clean_remove_classified_worktree() {
 		echo -e "${RED}Failed to remove $worktree_branch - may have uncommitted changes${NC}" >&2
 		return 1
 	fi
+	if ! prune_missing_worktree_metadata "$repo_context" "$worktree_path"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "metadata-prune-failed" "partial-cleanup" "$audit_context"
+		return 1
+	fi
 	unregister_worktree "$worktree_path"
 	if [[ "$preserve_branch" != "$_WT_CLEAN_BOOL_TRUE" ]]; then
 		localdev_auto_branch_rm "$worktree_branch"
 		git branch -D "$worktree_branch" 2>/dev/null || true
 	fi
+	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$worktree_path" "$audit_reason" "$completed_mode" "$audit_context"
+	printf '%s\n' "$_WT_CLEAN_COMPLETED_EVENT"
 	return 0
+}
+
+_clean_remove_candidate_after_lease() {
+	local worktree_path="$1"
+	local worktree_branch="$2"
+	local force_merged="$3"
+	local preserve_branch="$4"
+	local audit_context="$5"
+	local main_wt_path="$6"
+	local merge_type="$7"
+	local merged_prs="$8"
+	local closed_prs="$9"
+	local open_prs="${10}"
+	local guard_status=0
+	local removal_status=0
+	local removal_mode="$_WT_CLEAN_MODE_PERMANENT"
+	local recovery_authorized="$_WT_CLEAN_BOOL_FALSE"
+
+	if worktree_removal_guard "$worktree_path" "$_WTAR_WH_CALLER" "$_WT_CLEAN_REASON_BRANCH_MERGED"; then
+		guard_status=0
+	else
+		guard_status=$?
+	fi
+	if [[ "$guard_status" -eq "${_WT_CWD_CAPTURE_DEGRADED_RC:-2}" ]] &&
+		_clean_degraded_visibility_fallback_allowed "$worktree_path" "$worktree_branch" "$merge_type" "$merged_prs" "$closed_prs" "$open_prs" "$audit_context"; then
+		removal_mode="$_WT_CLEAN_MODE_RECOVERABLE"
+		recovery_authorized="$_WT_CLEAN_BOOL_TRUE"
+	elif [[ "$guard_status" -ne 0 ]]; then
+		unregister_worktree_if_owner_pid "$worktree_path" "$$" 2>/dev/null || true
+		echo -e "${YELLOW}Skipped $worktree_branch - removal guard refused path${NC}" >&2
+		return 1
+	fi
+
+	if _clean_remove_classified_worktree "$worktree_path" "$worktree_branch" "$force_merged" "$preserve_branch" "$audit_context" "$main_wt_path" "$removal_mode" "$recovery_authorized"; then
+		return 0
+	else
+		removal_status=$?
+	fi
+	if [[ "$removal_status" -eq "${_WT_CWD_CAPTURE_DEGRADED_RC:-2}" ]] &&
+		_clean_degraded_visibility_fallback_allowed "$worktree_path" "$worktree_branch" "$merge_type" "$merged_prs" "$closed_prs" "$open_prs" "$audit_context" &&
+		_clean_remove_classified_worktree "$worktree_path" "$worktree_branch" "$force_merged" "$preserve_branch" "$audit_context" "$main_wt_path" "$_WT_CLEAN_MODE_RECOVERABLE" "$_WT_CLEAN_BOOL_TRUE"; then
+		return 0
+	fi
+	unregister_worktree_if_owner_pid "$worktree_path" "$$" 2>/dev/null || true
+	return 1
 }
 
 # Remove worktrees that are eligible for cleanup (second pass after user confirmation).
@@ -1054,21 +1226,8 @@ _clean_remove_merged() {
 						worktree_branch=""
 						continue
 					fi
-					if ! worktree_removal_guard "$worktree_path" "$_WTAR_WH_CALLER" "$_WT_CLEAN_REASON_BRANCH_MERGED"; then
-						unregister_worktree_if_owner_pid "$worktree_path" "$$" 2>/dev/null || true
-						echo -e "${YELLOW}Skipped $worktree_branch - removal guard refused path${NC}" >&2
-						worktree_path=""
-						worktree_branch=""
-						continue
-					fi
-					# Clean up heavy reproducible directories first to speed up removal
-					# (node_modules, .next, .turbo can have 100k+ files — rm -rf is faster than trash)
-					rm -rf "$worktree_path/node_modules" 2>/dev/null || true
-					rm -rf "$worktree_path/.next" 2>/dev/null || true
-					rm -rf "$worktree_path/.turbo" 2>/dev/null || true
-					if ! _clean_remove_classified_worktree "$worktree_path" "$worktree_branch" "$force_merged" "$preserve_branch" "$audit_context"; then
-						unregister_worktree_if_owner_pid "$worktree_path" "$$" 2>/dev/null || true
-					fi
+					_clean_remove_candidate_after_lease "$worktree_path" "$worktree_branch" "$force_merged" "$preserve_branch" \
+						"$audit_context" "$main_wt_path" "$merge_type" "$merged_prs" "$closed_prs" "$open_prs" || true
 				fi
 			fi
 			worktree_path=""


### PR DESCRIPTION
## Summary

- Preserve all readable process-CWD evidence when Linux Yama blocks unrelated `/proc/<pid>/cwd` links.
- Model process-CWD visibility as complete, degraded, or unusable instead of discarding partial evidence.
- Allow degraded absence-only evidence to use only a terminal-PR-gated recoverable trash move after all existing clean-state, ownership, claim, lease, current/canonical, and positive-CWD guards pass.
- Count cleanup only after exact Git metadata absence is verified.

## Safety invariants

- Any readable CWD inside a candidate remains an unconditional `active-cwd` block.
- Unusable visibility remains fail-closed.
- Recoverable mode has no direct-delete fallback.
- Pulse increments removed-worktree totals only for `AIDEVOPS_WORKTREE_REMOVAL_COMPLETED=1` events.

## Files

- `.agents/scripts/audit-worktree-removal-helper.sh`
- `.agents/scripts/worktree-clean-lib.sh`
- `.agents/scripts/pulse-cleanup.sh`
- `.agents/scripts/pulse-temp-worktree-cleanup.sh`
- `.agents/scripts/tests/test-worktree-removal-audit.sh`
- `.agents/scripts/tests/test-worktree-metadata-prune.sh`
- `.agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh`
- `.agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh`

## Verification

- `bash .agents/scripts/tests/test-worktree-removal-audit.sh` — 22/22
- `bash .agents/scripts/tests/test-worktree-metadata-prune.sh` — all recovery and fail-closed scenarios pass
- `bash .agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh` — 7/7
- `bash .agents/scripts/tests/test-pulse-cleanup-non-git-cwd.sh` — 3/3
- `bash .agents/scripts/shell-init-pattern-check.sh --scan-files .agents/scripts/tests/test-worktree-metadata-prune.sh` — clean
- ShellCheck — all 8 changed shell files pass
- `.agents/scripts/linters-local.sh --changed` — pass

Resolves #28433

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 42m and 658,420 tokens on this as a headless worker.