### PR TITLE
GH#28401: Reconcile Pulse launchd replacements

### DIFF
--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -37,6 +37,8 @@
 #   AIDEVOPS_ACTIVE_AGENTS_LINK=<path>
 #                                     activation link to resolve under the
 #                                     shared runtime transition lock.
+#   AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN=<regex>
+#                                     test override for stale merge routines.
 #
 # Exit codes:
 #   0  Success (includes no-op cases)
@@ -60,6 +62,7 @@ _PULSE_ACTIVE_AGENTS_LINK="${AIDEVOPS_ACTIVE_AGENTS_LINK:-${HOME}/.aidevops/agen
 # isolate mock pulses from the live user pulse (the mock's path is embedded
 # in the pattern). See tests/test-pulse-lifecycle-helper.sh.
 _PULSE_PATTERN="${AIDEVOPS_PULSE_PROCESS_PATTERN:-(^|/)pulse-wrapper\\.sh( |\$)}"
+_PULSE_MERGE_PATTERN="${AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN:-(^|/)pulse-merge-routine\\.sh( |\$)}"
 
 # Timing
 _PULSE_RESTART_WAIT="${AIDEVOPS_PULSE_RESTART_WAIT:-3}"
@@ -198,26 +201,37 @@ _pulse_start_managed() {
 	local pulse_label="${AIDEVOPS_PULSE_LAUNCHD_LABEL:-com.aidevops.aidevops-supervisor-pulse}"
 	local launchd_target=""
 	local launchd_wait_count=0
+	local baseline_pids=""
+	local active_pid=""
 	launchd_target="gui/$(id -u)/${pulse_label}"
 	if _pulse_launchd_supervisor_present; then
 		_pl_info "Requesting Pulse restart from launchd supervisor ${pulse_label}"
+		# KeepAlive may already have replaced the process stopped by reconciliation.
+		# Snapshot again immediately before kickstart so only a process created by
+		# this managed replacement can satisfy the activation proof below.
+		baseline_pids=$(_pulse_pids)
 		if ! launchctl kickstart -k "$launchd_target" >/dev/null 2>&1; then
 			_pl_err "launchd could not restart Pulse; refusing an unmanaged fallback"
 			return 1
 		fi
 		while [[ "$launchd_wait_count" -lt 5 ]]; do
-			if _is_running; then
-				_pl_ok "Pulse restarted by launchd"
+			if active_pid=$(_pulse_find_active_runtime_pid_since "$baseline_pids"); then
+				_pl_ok "Pulse restarted by launchd from the activated bundle (PID ${active_pid})"
 				return 0
 			fi
 			sleep 1
 			launchd_wait_count=$((launchd_wait_count + 1))
 		done
-		_pl_err "launchd accepted the Pulse restart but no managed process appeared"
+		_pl_err "launchd accepted the Pulse restart but no new activated-bundle process appeared"
 		return 1
 	fi
 	_start || return $?
-	return 0
+	if active_pid=$(_pulse_find_active_runtime_pid_since ""); then
+		_pl_ok "Pulse is running from the activated bundle (PID ${active_pid})"
+		return 0
+	fi
+	_pl_err "Pulse started but its activated runtime bundle could not be verified"
+	return 1
 }
 
 # _pulse_pids_raw: print ALL matching pulse PIDs including subshells of the
@@ -226,6 +240,250 @@ _pulse_start_managed() {
 _pulse_pids_raw() {
 	pgrep -f "$_PULSE_PATTERN" 2>/dev/null || true
 	return 0
+}
+
+# _pulse_merge_pids_raw: print standalone merge-routine PIDs. These routines
+# source the runtime once at startup just like pulse-wrapper.sh, so setup-time
+# reconciliation must retire pre-activation instances as well.
+_pulse_merge_pids_raw() {
+	pgrep -f "$_PULSE_MERGE_PATTERN" 2>/dev/null || true
+	return 0
+}
+
+_pulse_pid_list_contains() {
+	local _pids="$1"
+	local _wanted="$2"
+	local _pid=""
+	while IFS= read -r _pid; do
+		[[ -n "$_pid" && "$_pid" == "$_wanted" ]] && return 0
+	done <<<"$_pids"
+	return 1
+}
+
+# Snapshot every runtime process whose sourced code must be replaced. The
+# snapshot is deliberate: a launchd KeepAlive replacement created after this
+# point belongs to the activated bundle and is not a failed-stop residual.
+_pulse_reconciliation_pids_raw() {
+	local _wrapper_pids=""
+	local _merge_pids=""
+	local _emitted=""
+	local _pid=""
+	_wrapper_pids=$(_pulse_pids_raw)
+	_merge_pids=$(_pulse_merge_pids_raw)
+	while IFS= read -r _pid; do
+		[[ "$_pid" =~ ^[0-9]+$ ]] || continue
+		if ! _pulse_pid_list_contains "$_emitted" "$_pid"; then
+			printf '%s\n' "$_pid"
+			_emitted="${_emitted}${_emitted:+$'\n'}${_pid}"
+		fi
+	done <<<"$_wrapper_pids"
+	while IFS= read -r _pid; do
+		[[ "$_pid" =~ ^[0-9]+$ ]] || continue
+		if ! _pulse_pid_list_contains "$_emitted" "$_pid"; then
+			printf '%s\n' "$_pid"
+			_emitted="${_emitted}${_emitted:+$'\n'}${_pid}"
+		fi
+	done <<<"$_merge_pids"
+	return 0
+}
+
+_pulse_process_start_token() {
+	local _pid="$1"
+	local _stat_content=""
+	local _stat_after_comm=""
+	local _start_token=""
+	[[ "$_pid" =~ ^[0-9]+$ ]] || return 1
+	if [[ -r "/proc/${_pid}/stat" ]]; then
+		_stat_content=$(<"/proc/${_pid}/stat") || _stat_content=""
+		[[ -n "$_stat_content" ]] || return 1
+		_stat_after_comm="${_stat_content##*) }"
+		_start_token=$(printf '%s\n' "$_stat_after_comm" | awk '{print $20}') || _start_token=""
+	else
+		_start_token=$(LC_ALL=C ps -p "$_pid" -o lstart= 2>/dev/null | tr -s ' ') || _start_token=""
+		_start_token="${_start_token#"${_start_token%%[![:space:]]*}"}"
+		_start_token="${_start_token%"${_start_token##*[![:space:]]}"}"
+	fi
+	[[ -n "$_start_token" ]] || return 1
+	printf '%s\n' "$_start_token"
+	return 0
+}
+
+# Capture PID plus process start time before signalling. A numeric PID alone is
+# not a stable identity: a fast exit followed by PID reuse could otherwise let
+# reconciliation signal an unrelated process during the TERM/KILL windows.
+_pulse_reconciliation_identities() {
+	local _pids=""
+	local _pid=""
+	local _start_token=""
+	_pids=$(_pulse_reconciliation_pids_raw)
+	while IFS= read -r _pid; do
+		[[ "$_pid" =~ ^[0-9]+$ ]] || continue
+		if ! _start_token=$(_pulse_process_start_token "$_pid"); then
+			if kill -0 "$_pid" 2>/dev/null; then
+				_pl_err "Unable to capture stable identity for Pulse PID ${_pid}; refusing to signal it"
+				return 1
+			fi
+			continue
+		fi
+		printf '%s\t%s\n' "$_pid" "$_start_token"
+	done <<<"$_pids"
+	return 0
+}
+
+_pulse_identity_is_reconciliation_process() {
+	local _pid="$1"
+	local _expected_start="$2"
+	local _current_start=""
+	local _command=""
+	[[ "$_pid" =~ ^[0-9]+$ && -n "$_expected_start" ]] || return 1
+	kill -0 "$_pid" 2>/dev/null || return 1
+	_current_start=$(_pulse_process_start_token "$_pid") || return 1
+	[[ "$_current_start" == "$_expected_start" ]] || return 1
+	_command=$(ps -p "$_pid" -o command= 2>/dev/null || true)
+	[[ "$_command" =~ $_PULSE_PATTERN || "$_command" =~ $_PULSE_MERGE_PATTERN ]] || return 1
+	return 0
+}
+
+# Return only snapshot identities that are still alive, retain their original
+# process start time, and still identify as Pulse runtime processes.
+_pulse_snapshot_survivors() {
+	local _identities="$1"
+	local _pid=""
+	local _start_token=""
+	while IFS=$'\t' read -r _pid _start_token; do
+		[[ -n "$_pid" && -n "$_start_token" ]] || continue
+		if _pulse_identity_is_reconciliation_process "$_pid" "$_start_token"; then
+			printf '%s\t%s\n' "$_pid" "$_start_token"
+		fi
+	done <<<"$_identities"
+	return 0
+}
+
+_pulse_signal_snapshot() {
+	local _signal="$1"
+	local _identities="$2"
+	local _pid=""
+	local _start_token=""
+	while IFS=$'\t' read -r _pid _start_token; do
+		[[ -n "$_pid" && -n "$_start_token" ]] || continue
+		_pulse_identity_is_reconciliation_process "$_pid" "$_start_token" || continue
+		kill "-${_signal}" "$_pid" 2>/dev/null || true
+	done <<<"$_identities"
+	return 0
+}
+
+_pulse_identity_pids() {
+	local _identities="$1"
+	local _pid=""
+	local _start_token=""
+	while IFS=$'\t' read -r _pid _start_token; do
+		[[ -n "$_pid" && -n "$_start_token" ]] || continue
+		printf '%s\n' "$_pid"
+	done <<<"$_identities"
+	return 0
+}
+
+_pulse_pid_invokes_script() {
+	local _pid="$1"
+	local _script_path="$2"
+	local _command_line=""
+	local _command_arg=""
+	local _command_name=""
+	local _arg_index=0
+	local _options_done=false
+	[[ "$_pid" =~ ^[0-9]+$ && -n "$_script_path" ]] || return 1
+
+	if [[ -r "/proc/${_pid}/cmdline" ]]; then
+		while IFS= read -r -d '' _command_arg; do
+			if [[ "$_arg_index" -eq 0 ]]; then
+				[[ "$_command_arg" == "$_script_path" ]] && return 0
+				_command_name="${_command_arg##*/}"
+				case "$_command_name" in
+				bash | dash | ksh | sh | zsh) ;;
+				*) return 1 ;;
+				esac
+				_arg_index=1
+				continue
+			fi
+			if [[ "$_options_done" == "false" ]]; then
+				case "$_command_arg" in
+				--)
+					_options_done=true
+					continue
+					;;
+				-*c*) return 1 ;;
+				-*) continue ;;
+				esac
+			fi
+			[[ "$_command_arg" == "$_script_path" ]] && return 0
+			return 1
+		done <"/proc/${_pid}/cmdline"
+		return 1
+	fi
+
+	_command_line=$(ps -p "$_pid" -o command= 2>/dev/null) || _command_line=""
+	case "$_command_line" in
+	"$_script_path" | "$_script_path "*) return 0 ;;
+	esac
+	for _command_name in bash dash ksh sh zsh; do
+		case "$_command_line" in
+		"${_command_name} ${_script_path}" | "${_command_name} ${_script_path} "* | */"${_command_name} ${_script_path}" | */"${_command_name} ${_script_path} "*)
+			return 0
+			;;
+		esac
+	done
+	return 1
+}
+
+# Verify a candidate PID against the activated runtime. Immutable production
+# bundles expose an authoritative PID lease. All roots also require exact
+# script invocation so an observer that merely mentions the wrapper path cannot
+# satisfy setup's activated-runtime proof.
+_pulse_pid_uses_active_runtime() {
+	local _pid="$1"
+	local _active_root=""
+	local _bundles_root="${AIDEVOPS_RUNTIME_BUNDLES_DIR:-${HOME}/.aidevops/runtime-bundles}"
+	local _physical_bundles_root=""
+	local _bundle_dir=""
+	local _bundle_id=""
+	local _lease_file=""
+	local _lease_root=""
+	local _active_link_script="${_PULSE_ACTIVE_AGENTS_LINK%/}/scripts/pulse-wrapper.sh"
+	[[ "$_pid" =~ ^[0-9]+$ ]] || return 1
+	if ! _pulse_pid_invokes_script "$_pid" "$_PULSE_SCRIPT" &&
+		! _pulse_pid_invokes_script "$_pid" "$_active_link_script"; then
+		return 1
+	fi
+	_active_root=$(cd "$_PULSE_AGENTS_DIR" 2>/dev/null && pwd -P) || return 1
+	if [[ -d "$_bundles_root" ]]; then
+		_physical_bundles_root=$(cd "$_bundles_root" 2>/dev/null && pwd -P) || return 1
+		_bundle_dir="${_active_root%/agents}"
+		if [[ "$_bundle_dir" != "$_active_root" && "${_bundle_dir%/*}" == "$_physical_bundles_root" ]]; then
+			_bundle_id="${_bundle_dir##*/}"
+			_lease_file="${_physical_bundles_root}/.leases/${_bundle_id}/${_pid}"
+			[[ -r "$_lease_file" ]] || return 1
+			IFS= read -r _lease_root <"$_lease_file" || return 1
+			[[ "$_lease_root" == "$_active_root" ]] && return 0
+			return 1
+		fi
+	fi
+	return 0
+}
+
+_pulse_find_active_runtime_pid_since() {
+	local _baseline_pids="$1"
+	local _current_pids=""
+	local _pid=""
+	_current_pids=$(_pulse_pids)
+	while IFS= read -r _pid; do
+		[[ "$_pid" =~ ^[0-9]+$ ]] || continue
+		_pulse_pid_list_contains "$_baseline_pids" "$_pid" && continue
+		if _pulse_pid_uses_active_runtime "$_pid"; then
+			printf '%s\n' "$_pid"
+			return 0
+		fi
+	done <<<"$_current_pids"
+	return 1
 }
 
 # _pulse_emit_pid: print one PID while tolerating early-closing consumers.
@@ -382,6 +640,41 @@ _stop_all() {
 	return 0
 }
 
+# Stop only the processes present at the beginning of setup reconciliation.
+# Unlike _stop_all, the final check intentionally ignores later PIDs: launchd
+# KeepAlive may immediately create the intended active-bundle replacement.
+_stop_reconciliation_processes() {
+	local _identities=""
+	local _survivors=""
+	local _residual=""
+	local _display_pids=""
+	if ! _identities=$(_pulse_reconciliation_identities); then
+		return 1
+	fi
+	[[ -n "$_identities" ]] || return 0
+
+	_display_pids=$(_pulse_identity_pids "$_identities" | tr '\n' ' ')
+	_pl_info "Stopping pre-reconciliation Pulse process(es): ${_display_pids}"
+	_survivors=$(_pulse_snapshot_survivors "$_identities")
+	_pulse_signal_snapshot TERM "$_survivors"
+	sleep "$_PULSE_SIGTERM_WAIT"
+	_survivors=$(_pulse_snapshot_survivors "$_identities")
+	if [[ -n "$_survivors" ]]; then
+		_display_pids=$(_pulse_identity_pids "$_survivors" | tr '\n' ' ')
+		_pl_warn "SIGTERM timeout, escalating pre-reconciliation PIDs to SIGKILL: ${_display_pids}"
+		_pulse_signal_snapshot KILL "$_survivors"
+		sleep 1
+	fi
+
+	_residual=$(_pulse_snapshot_survivors "$_identities")
+	if [[ -n "$_residual" ]]; then
+		_display_pids=$(_pulse_identity_pids "$_residual" | tr '\n' ' ')
+		_pl_err "Failed to retire pre-reconciliation Pulse processes after SIGKILL — residual PIDs: ${_display_pids}"
+		return 1
+	fi
+	return 0
+}
+
 # _start: launch pulse in background via nohup. No-op if already running.
 _start() {
 	if _is_running; then
@@ -461,6 +754,7 @@ _reconcile_managed() {
 	local reconcile_rc=0
 	local bundle_id=""
 	local supervisor_disabled=false
+	local disabled_residual=""
 
 	if [[ ! -r "$runtime_module" ]]; then
 		_pl_err "Runtime transition support is missing from the activated bundle"
@@ -483,10 +777,15 @@ _reconcile_managed() {
 		_pl_err "Unable to resolve the active runtime bundle"
 		reconcile_rc=1
 	elif [[ "$supervisor_disabled" == "true" ]]; then
-		_stop_all || reconcile_rc=$?
+		_stop_reconciliation_processes || reconcile_rc=$?
+		disabled_residual=$(_pulse_reconciliation_pids_raw)
+		if [[ "$reconcile_rc" -eq 0 && -n "$disabled_residual" ]]; then
+			_pl_err "Pulse supervisor is disabled but runtime processes remain: $(printf '%s\n' "$disabled_residual" | tr '\n' ' ')"
+			reconcile_rc=1
+		fi
 		[[ "$reconcile_rc" -eq 0 ]] && _pl_info "Pulse remains stopped because its supervisor is disabled"
 	else
-		_stop_all || reconcile_rc=$?
+		_stop_reconciliation_processes || reconcile_rc=$?
 		if [[ "$reconcile_rc" -eq 0 ]]; then
 			sleep "$_PULSE_RESTART_WAIT"
 			if ! _pulse_refresh_active_runtime; then
@@ -625,6 +924,7 @@ Env:
   AIDEVOPS_AGENTS_DIR=<path>               Override ~/.aidevops/agents.
   AIDEVOPS_ACTIVE_AGENTS_LINK=<path>        Active runtime link for reconciliation.
   AIDEVOPS_PULSE_MANAGED_ENABLED=true       Allow reconcile-managed to start Pulse.
+  AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN=...  Override merge-routine match (tests).
 
 Exit codes:
   0  Success

--- a/.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh
+++ b/.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh
@@ -263,6 +263,7 @@ main() {
 	: >"$PULSE_START_LOG"
 	export PULSE_START_LOG
 	export AIDEVOPS_PULSE_PROCESS_PATTERN="$PULSE_PATTERN"
+	export AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN="${escaped_root}/runtime-bundles/.*/agents/scripts/pulse-merge-routine\\.sh"
 	export AIDEVOPS_PULSE_RESTART_WAIT=0
 	export AIDEVOPS_PULSE_SIGTERM_WAIT=1
 	export AIDEVOPS_PULSE_OS_NAME=Linux

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -25,6 +25,10 @@
 #   13. AIDEVOPS_SKIP_PULSE_RESTART=1 skips restart-if-running
 #   14. AIDEVOPS_SKIP_PULSE_RESTART=1 skips restart
 #   15. Missing pulse-wrapper.sh → start exits 2
+#   16. Reconciliation tolerates an immediate KeepAlive replacement
+#   17. Reconciliation retires a detached stale merge routine
+#   18. Genuine unkillable snapshot PIDs fail closed with PID evidence
+#   19. Managed replacement requires a new active-bundle PID lease
 #
 # No real pulse is touched. We use a unique mock filename and match pattern
 # on pulse-wrapper.sh which we control inside TEST_ROOT.
@@ -42,6 +46,10 @@ TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
 MOCK_PIDS=()
+KEEPALIVE_SUPERVISOR_PID=""
+KEEPALIVE_STOP_FILE=""
+KEEPALIVE_PID_FILE=""
+LAST_MOCK_PID=""
 
 _print_result() {
 	local name="$1"
@@ -79,6 +87,12 @@ _setup() {
 while true; do sleep 10; done
 SH
 	chmod +x "${TEST_ROOT}/scripts/pulse-wrapper.sh"
+	cat >"${TEST_ROOT}/scripts/pulse-merge-routine.sh" <<'SH'
+#!/usr/bin/env bash
+# Mock standalone merge routine — retains its script argv while running.
+while true; do sleep 10; done
+SH
+	chmod +x "${TEST_ROOT}/scripts/pulse-merge-routine.sh"
 
 	# Point helper at our temp dir.
 	export AIDEVOPS_AGENTS_DIR="$TEST_ROOT"
@@ -91,6 +105,7 @@ SH
 	# is sufficient.
 	local _escaped_root="${TEST_ROOT//./\\.}"
 	export AIDEVOPS_PULSE_PROCESS_PATTERN="${_escaped_root}/scripts/pulse-wrapper\\.sh"
+	export AIDEVOPS_PULSE_MERGE_PROCESS_PATTERN="${_escaped_root}/scripts/pulse-merge-routine\\.sh"
 
 	# Ensure env overrides don't leak between tests.
 	unset AIDEVOPS_SKIP_PULSE_RESTART 2>/dev/null || true
@@ -100,9 +115,11 @@ SH
 }
 
 _teardown() {
+	_stop_keepalive_supervisor
 	# Kill any mock pulses this suite spawned.
 	if [[ -n "${TEST_ROOT:-}" ]]; then
 		pkill -f "${TEST_ROOT}/scripts/pulse-wrapper.sh" 2>/dev/null || true
+		pkill -f "${TEST_ROOT}/scripts/pulse-merge-routine.sh" 2>/dev/null || true
 	fi
 	# Also catch any residual mock PIDs we noted.
 	local _pid
@@ -111,6 +128,7 @@ _teardown() {
 	done
 	sleep 1
 	[[ -n "${TEST_ROOT:-}" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
 }
 
 trap _teardown EXIT
@@ -146,8 +164,80 @@ _wait_for_no_mock_pulse() {
 }
 
 _kill_mocks() {
+	_stop_keepalive_supervisor
 	pkill -KILL -f "${TEST_ROOT}/scripts/pulse-wrapper.sh" 2>/dev/null || true
+	pkill -KILL -f "${TEST_ROOT}/scripts/pulse-merge-routine.sh" 2>/dev/null || true
 	_wait_for_no_mock_pulse 20 || true
+	return 0
+}
+
+_start_keepalive_supervisor() {
+	KEEPALIVE_STOP_FILE="${TEST_ROOT}/keepalive.stop"
+	KEEPALIVE_PID_FILE="${TEST_ROOT}/keepalive.pid"
+	rm -f "$KEEPALIVE_STOP_FILE"
+	rm -f "$KEEPALIVE_PID_FILE"
+	(
+		local _child_pid=""
+		trap 'exit 0' TERM INT
+		while [[ ! -f "$KEEPALIVE_STOP_FILE" ]]; do
+			if [[ ! "$_child_pid" =~ ^[0-9]+$ ]] || ! kill -0 "$_child_pid" 2>/dev/null; then
+				bash "${TEST_ROOT}/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
+				_child_pid=$!
+				printf '%s\n' "$_child_pid" >"$KEEPALIVE_PID_FILE"
+				disown "$_child_pid" 2>/dev/null || true
+			fi
+			sleep 0.05
+		done
+	) &
+	KEEPALIVE_SUPERVISOR_PID=$!
+	return 0
+}
+
+_stop_keepalive_supervisor() {
+	if [[ -n "${KEEPALIVE_STOP_FILE:-}" ]]; then
+		: >"$KEEPALIVE_STOP_FILE" 2>/dev/null || true
+	fi
+	if [[ "${KEEPALIVE_SUPERVISOR_PID:-}" =~ ^[0-9]+$ ]]; then
+		kill -TERM "$KEEPALIVE_SUPERVISOR_PID" 2>/dev/null || true
+		wait "$KEEPALIVE_SUPERVISOR_PID" 2>/dev/null || true
+	fi
+	KEEPALIVE_SUPERVISOR_PID=""
+	KEEPALIVE_STOP_FILE=""
+	KEEPALIVE_PID_FILE=""
+	return 0
+}
+
+_wait_for_keepalive_pid_change() {
+	local _previous_pid="$1"
+	local _tries="${2:-40}"
+	local _current_pid=""
+	while [[ "$_tries" -gt 0 ]]; do
+		if [[ -r "$KEEPALIVE_PID_FILE" ]]; then
+			IFS= read -r _current_pid <"$KEEPALIVE_PID_FILE" || true
+			if [[ "$_current_pid" =~ ^[0-9]+$ && "$_current_pid" != "$_previous_pid" ]] && kill -0 "$_current_pid" 2>/dev/null; then
+				printf '%s\n' "$_current_pid"
+				return 0
+			fi
+		fi
+		sleep 0.05
+		_tries=$((_tries - 1))
+	done
+	return 1
+}
+
+_spawn_detached_mock_merge_routine() {
+	nohup bash "${TEST_ROOT}/scripts/pulse-merge-routine.sh" run >/dev/null 2>&1 &
+	LAST_MOCK_PID=$!
+	MOCK_PIDS+=("$LAST_MOCK_PID")
+	return 0
+}
+
+_first_mock_pulse_pid() {
+	local _pids=""
+	_pids=$(pgrep -f "${TEST_ROOT}/scripts/pulse-wrapper.sh" 2>/dev/null || true)
+	[[ -n "$_pids" ]] || return 1
+	printf '%s\n' "${_pids%%$'\n'*}"
+	return 0
 }
 
 # _spawn_extra_mock_pulse: launch ONE additional mock pulse-wrapper.sh process
@@ -397,6 +487,197 @@ test_stop_idempotent_when_stopped() {
 	local rc=0
 	"$HELPER" stop >/dev/null 2>&1 || rc=$?
 	_assert_eq "stop idempotent when stopped" "0" "$rc"
+	return 0
+}
+
+test_reconciliation_tolerates_launchd_keepalive_respawn() {
+	_kill_mocks
+	_start_keepalive_supervisor
+	local first_pid=""
+	local replacement_pid=""
+	if ! first_pid=$(_wait_for_keepalive_pid_change ""); then
+		_print_result "reconcile tolerates launchd KeepAlive replacement (fixture did not start)" 0
+		_stop_keepalive_supervisor
+		return 0
+	fi
+	local output=""
+	local rc=0
+	output=$(
+		# shellcheck source=../pulse-lifecycle-helper.sh
+		source "$HELPER"
+		_stop_reconciliation_processes 2>&1
+	) || rc=$?
+	replacement_pid=$(_wait_for_keepalive_pid_change "$first_pid" 2>/dev/null || true)
+	_stop_keepalive_supervisor
+	if [[ "$rc" -eq 0 && -n "$first_pid" && -n "$replacement_pid" && "$replacement_pid" != "$first_pid" && "$output" != *"Failed to retire"* ]]; then
+		_print_result "reconcile tolerates launchd KeepAlive replacement PID" 1
+	else
+		_print_result "reconcile tolerates launchd KeepAlive replacement (first=$first_pid replacement=$replacement_pid rc=$rc output=$output)" 0
+	fi
+	_kill_mocks
+	return 0
+}
+
+test_reconciliation_retires_detached_merge_routine() {
+	_kill_mocks
+	_spawn_detached_mock_merge_routine
+	local merge_pid="$LAST_MOCK_PID"
+	local output=""
+	local rc=0
+	local tries=20
+	while ! kill -0 "$merge_pid" 2>/dev/null && [[ "$tries" -gt 0 ]]; do
+		sleep 0.1
+		tries=$((tries - 1))
+	done
+	output=$(
+		# shellcheck source=../pulse-lifecycle-helper.sh
+		source "$HELPER"
+		_stop_reconciliation_processes 2>&1
+	) || rc=$?
+	tries=20
+	while kill -0 "$merge_pid" 2>/dev/null && [[ "$tries" -gt 0 ]]; do
+		sleep 0.1
+		tries=$((tries - 1))
+	done
+	if [[ "$rc" -eq 0 ]] && ! kill -0 "$merge_pid" 2>/dev/null; then
+		_print_result "reconcile retires detached stale pulse-merge-routine" 1
+	else
+		_print_result "reconcile retires detached stale pulse-merge-routine (pid=$merge_pid rc=$rc output=$output)" 0
+	fi
+	wait "$merge_pid" 2>/dev/null || true
+	_kill_mocks
+	return 0
+}
+
+test_reconciliation_fails_closed_on_unkillable_snapshot() {
+	local output=""
+	local rc=0
+	output=$(
+		# shellcheck source=../pulse-lifecycle-helper.sh
+		source "$HELPER"
+		_pulse_reconciliation_identities() {
+			printf '424242\tstart-a\n'
+			return 0
+		}
+		_pulse_snapshot_survivors() {
+			local _identities="$1"
+			printf '%s\n' "$_identities"
+			return 0
+		}
+		_pulse_signal_snapshot() {
+			local _signal="$1"
+			local _identities="$2"
+			: "$_signal" "$_identities"
+			return 0
+		}
+		sleep() {
+			local _seconds="$1"
+			: "$_seconds"
+			return 0
+		}
+		_stop_reconciliation_processes 2>&1
+	) || rc=$?
+	if [[ "$rc" -eq 1 && "$output" == *"residual PIDs: 424242"* ]]; then
+		_print_result "reconcile fails closed on unkillable PID with evidence" 1
+	else
+		_print_result "reconcile fails closed on unkillable PID (rc=$rc output=$output)" 0
+	fi
+	return 0
+}
+
+test_reconciliation_skips_reused_snapshot_pid() {
+	local signal_log="${TEST_ROOT}/reused-identity-signals.log"
+	local signal_state=""
+	local rc=0
+	: >"$signal_log"
+	(
+		# shellcheck source=../pulse-lifecycle-helper.sh
+		source "$HELPER"
+		_pulse_process_start_token() {
+			local _pid="$1"
+			: "$_pid"
+			printf 'start-b\n'
+			return 0
+		}
+		kill() {
+			local _signal="$1"
+			local _pid="$2"
+			if [[ "$_signal" != "-0" ]]; then
+				printf '%s %s\n' "$_signal" "$_pid" >>"$signal_log"
+			fi
+			return 0
+		}
+		_pulse_signal_snapshot TERM $'424242\tstart-a'
+	) || rc=$?
+	signal_state=$(<"$signal_log")
+	if [[ "$rc" -eq 0 && -z "$signal_state" ]]; then
+		_print_result "reconcile skips a PID whose stable identity was reused" 1
+	else
+		_print_result "reconcile signalled a reused PID identity (rc=$rc signals=$signal_state)" 0
+	fi
+	return 0
+}
+
+test_managed_replacement_requires_new_active_bundle_lease() {
+	local bundles_root="${TEST_ROOT}/runtime-bundles"
+	local active_root="${bundles_root}/bundle-active/agents"
+	local stale_root="${bundles_root}/bundle-stale/agents"
+	local result=""
+	local rc=0
+	mkdir -p "$active_root" "$stale_root" \
+		"${bundles_root}/.leases/bundle-active" \
+		"${bundles_root}/.leases/bundle-stale"
+	active_root=$(cd "$active_root" && pwd -P)
+	stale_root=$(cd "$stale_root" && pwd -P)
+	printf '%s\n' "$stale_root" >"${bundles_root}/.leases/bundle-stale/101"
+	printf '%s\n' "$active_root" >"${bundles_root}/.leases/bundle-active/202"
+	result=$(
+		export AIDEVOPS_RUNTIME_BUNDLES_DIR="$bundles_root"
+		# shellcheck source=../pulse-lifecycle-helper.sh
+		source "$HELPER"
+		_PULSE_AGENTS_DIR="$active_root"
+		_pulse_pid_invokes_script() {
+			local candidate_pid="$1"
+			local script_path="$2"
+			: "$candidate_pid" "$script_path"
+			return 0
+		}
+		_pulse_pids() {
+			printf '101\n202\n'
+			return 0
+		}
+		_pulse_find_active_runtime_pid_since "101"
+	) || rc=$?
+	if [[ "$rc" -eq 0 && "$result" == "202" ]]; then
+		_print_result "managed replacement requires a new active-bundle PID lease" 1
+	else
+		_print_result "managed replacement active-bundle lease proof (rc=$rc result=$result)" 0
+	fi
+	return 0
+}
+
+test_active_runtime_proof_rejects_observer_argv() {
+	local observer_pid=""
+	local rc=0
+	bash -c 'while :; do sleep 1; done' pulse-observer "${TEST_ROOT}/scripts/pulse-wrapper.sh" &
+	observer_pid=$!
+	MOCK_PIDS+=("$observer_pid")
+	sleep 0.2
+	(
+		# shellcheck source=../pulse-lifecycle-helper.sh
+		source "$HELPER"
+		_PULSE_AGENTS_DIR="$TEST_ROOT"
+		_PULSE_SCRIPT="${TEST_ROOT}/scripts/pulse-wrapper.sh"
+		_PULSE_ACTIVE_AGENTS_LINK="$TEST_ROOT"
+		_pulse_pid_uses_active_runtime "$observer_pid"
+	) || rc=$?
+	if [[ "$rc" -eq 1 ]] && kill -0 "$observer_pid" 2>/dev/null; then
+		_print_result "active runtime proof rejects an observer that only mentions the wrapper" 1
+	else
+		_print_result "active runtime proof accepted an observer argv (pid=$observer_pid rc=$rc)" 0
+	fi
+	kill -KILL "$observer_pid" 2>/dev/null || true
+	wait "$observer_pid" 2>/dev/null || true
 	return 0
 }
 
@@ -896,6 +1177,12 @@ main() {
 	test_start_is_idempotent
 	test_stop_terminates_running
 	test_stop_idempotent_when_stopped
+	test_reconciliation_tolerates_launchd_keepalive_respawn
+	test_reconciliation_retires_detached_merge_routine
+	test_reconciliation_fails_closed_on_unkillable_snapshot
+	test_reconciliation_skips_reused_snapshot_pid
+	test_managed_replacement_requires_new_active_bundle_lease
+	test_active_runtime_proof_rejects_observer_argv
 	test_restart_if_running_noop_when_stopped
 	test_restart_if_running_replaces_pid
 	test_skip_env_honoured_in_restart_if_running

--- a/.agents/scripts/tests/test-release-ensures-pulse-running.sh
+++ b/.agents/scripts/tests/test-release-ensures-pulse-running.sh
@@ -64,7 +64,9 @@ run_restart_helper_with_stub() {
 	local pulse_enabled="$2"
 	local pulse_consent="$3"
 	local output_dir="$4"
+	local restart_rc="${5:-0}"
 	local log_path="${output_dir}/pulse-helper.log"
+	local helper_rc=0
 	mkdir -p "${output_dir}/.aidevops/agents/scripts"
 
 	(
@@ -76,6 +78,7 @@ run_restart_helper_with_stub() {
 			PULSE_ENABLED="$pulse_enabled"
 		fi
 		print_warning() { printf 'warning: %s\n' "$*"; return 0; }
+		print_error() { printf 'error: %s\n' "$*" >&2; return 0; }
 		_resolve_pulse_consent() { printf '%s' "$pulse_consent"; return 0; }
 		resolve_aidevops_runtime_bundle_root() {
 			local requested_root="$1"
@@ -87,16 +90,16 @@ run_restart_helper_with_stub() {
 			local managed_enabled="$2"
 			local active_link="$3"
 			printf '%s|%s|%s\n' "$activated_root" "$managed_enabled" "$active_link" >>"$log_path"
-			return 0
+			return "$restart_rc"
 		}
 		load_setup_restart_helper
 		_setup_restart_pulse_if_running
-	)
+	) || helper_rc=$?
 
 	if [[ -f "$log_path" ]]; then
 		tr '\n' ' ' <"$log_path"
 	fi
-	return 0
+	return "$helper_rc"
 }
 
 test_release_path_starts_stopped_pulse() {
@@ -151,6 +154,20 @@ test_skip_flag_suppresses_restart_and_start() {
 	return 0
 }
 
+test_reconciliation_failure_blocks_setup_success() {
+	local output=""
+	local rc=0
+	output="$(run_restart_helper_with_stub "0" "true" "" "${TEST_DIR}/failure" "1")" || rc=$?
+
+	if [[ "$rc" -eq 1 && "$output" == *"|true|"* ]]; then
+		print_result "release deploy fails closed when Pulse runtime proof fails" 0
+		return 0
+	fi
+
+	print_result "release deploy fails closed when Pulse runtime proof fails" 1 "rc=${rc} helper calls=${output}"
+	return 0
+}
+
 main() {
 	TEST_DIR="$(mktemp -d)"
 	trap cleanup EXIT
@@ -159,6 +176,7 @@ main() {
 	test_disabled_supervisor_is_forwarded_to_reconcile
 	test_scoped_deploy_resolves_existing_consent
 	test_skip_flag_suppresses_restart_and_start
+	test_reconciliation_failure_blocks_setup_success
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -1904,13 +1904,16 @@ _setup_restart_pulse_if_running() {
 		activated_root="$current_root"
 	fi
 	if [[ -z "$activated_root" ]]; then
-		print_warning "Pulse restart skipped because the activated runtime bundle could not be resolved"
-		return 0
+		print_error "Pulse reconciliation failed because the activated runtime bundle could not be resolved"
+		return 1
 	fi
-	_restart_pulse_if_running \
+	if ! _restart_pulse_if_running \
 		"$activated_root" \
 		"$managed_enabled" \
-		"${HOME}/.aidevops/agents" || print_warning "Pulse reconciliation failed (non-fatal)"
+		"${HOME}/.aidevops/agents"; then
+		print_error "Pulse reconciliation failed; setup cannot verify the activated runtime bundle"
+		return 1
+	fi
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- snapshot pre-reconciliation Pulse wrapper and merge-routine identities so launchd KeepAlive replacements are not false residuals
- retire detached stale merge routines while revalidating PID start time before every signal
- require exact wrapper invocation plus activated-bundle lease evidence before reporting restart success
- fail setup before its success sentinel when managed runtime convergence cannot be proven

## Files

- `.agents/scripts/pulse-lifecycle-helper.sh`
- `.agents/scripts/tests/test-pulse-lifecycle-helper.sh`
- `.agents/scripts/tests/test-agent-deploy-pulse-runtime.sh`
- `.agents/scripts/tests/test-release-ensures-pulse-running.sh`
- `setup.sh`

## Testing

- `bash .agents/scripts/tests/test-pulse-lifecycle-helper.sh` (48 checks)
- `bash .agents/scripts/tests/test-agent-deploy-pulse-runtime.sh` (8 checks)
- `bash .agents/scripts/tests/test-release-ensures-pulse-running.sh` (5 checks)
- `bash .agents/scripts/tests/test-deploy-runtimes-bounded.sh` (10 checks)
- `bash tests/test-setup-completion-sentinel.sh`
- `shellcheck .agents/scripts/pulse-lifecycle-helper.sh .agents/scripts/tests/test-pulse-lifecycle-helper.sh .agents/scripts/tests/test-agent-deploy-pulse-runtime.sh .agents/scripts/tests/test-release-ensures-pulse-running.sh setup.sh`
- `.agents/scripts/linters-local.sh`

## Runtime Testing

- runtime-verified with real process spawn, TERM/KILL, KeepAlive replacement, detached merge-routine, PID-reuse, and activated-runtime fixtures

Resolves #28401
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 28m and 271,891 tokens on this as a headless worker.