### PR TITLE
GH#28437: preserve worker and Pulse recovery progress

### DIFF
--- a/.agents/plugins/opencode-aidevops/permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker.mjs
@@ -115,7 +115,7 @@ function recordPermissionToolCall(toolCalls, isHeadless, home, input, output) {
   while (toolCalls.size > 100) toolCalls.delete(toolCalls.keys().next().value);
 }
 
-function recordPermissionBlocker({ loggedEvents, home, blockerLogPath, request, event, reason, detail }) {
+function recordPermissionBlocker({ loggedEvents, home, blockerLogPath, capture, request, event, reason, detail }) {
   const dedupeKey = `${event}:${request?.request_id || "unknown"}`;
   if (loggedEvents.has(dedupeKey)) return;
   loggedEvents.add(dedupeKey);
@@ -126,6 +126,9 @@ function recordPermissionBlocker({ loggedEvents, home, blockerLogPath, request, 
     reason,
     blocking: true,
     source: "opencode-permission-broker",
+    issue_number: capture?.issue || process.env.WORKER_ISSUE_NUMBER || "",
+    repo_slug: capture?.repo || process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "",
+    session_key: capture?.worker_session || process.env.WORKER_SESSION_KEY || "",
     request_id: request?.request_id || "",
     permission: request?.permission || "",
     tool: request?.tool || "",
@@ -168,7 +171,7 @@ function capturePermissionRequest(toolCalls, loggedEvents, home, blockerLogPath,
   request.request_id = stableRequestID({ ...request, issue: capture.issue, repo: capture.repo });
   if (!requestFile) {
     recordPermissionBlocker({
-      loggedEvents, home, blockerLogPath, request, event: "permission_capture_failed",
+      loggedEvents, home, blockerLogPath, capture, request, event: "permission_capture_failed",
       reason: "request_file_unset", detail: "Headless permission request capture path was unavailable",
     });
     return request;
@@ -180,17 +183,17 @@ function capturePermissionRequest(toolCalls, loggedEvents, home, blockerLogPath,
   const written = writeCaptureFile(requestFile, capture);
   if (!written) {
     recordPermissionBlocker({
-      loggedEvents, home, blockerLogPath, request, event: "permission_capture_failed",
+      loggedEvents, home, blockerLogPath, capture, request, event: "permission_capture_failed",
       reason: "capture_file_write_failed", detail: "Permission request could not be persisted",
     });
   } else if (request.risk.grantable) {
     recordPermissionBlocker({
-      loggedEvents, home, blockerLogPath, request, event: "permission_request_captured",
+      loggedEvents, home, blockerLogPath, capture, request, event: "permission_request_captured",
       reason: "permission_required", detail: request.risk.reason,
     });
   } else {
     recordPermissionBlocker({
-      loggedEvents, home, blockerLogPath, request, event: "permission_request_non_grantable",
+      loggedEvents, home, blockerLogPath, capture, request, event: "permission_request_non_grantable",
       reason: "permission_non_grantable", detail: request.risk.reason,
     });
   }

--- a/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
@@ -9,14 +9,33 @@ import { tmpdir } from "os";
 
 import { createPermissionBroker, sanitizePermissionText } from "../permission-broker.mjs";
 
+const WORKER_ENV_KEYS = [
+  "AIDEVOPS_PERMISSION_REQUEST_FILE",
+  "WORKER_ISSUE_NUMBER",
+  "WORKER_REPO_SLUG",
+  "WORKER_SESSION_KEY",
+];
+
+function preserveWorkerEnvironment() {
+  return Object.fromEntries(WORKER_ENV_KEYS.map((key) => [key, process.env[key]]));
+}
+
+function restoreWorkerEnvironment(previous) {
+  for (const key of WORKER_ENV_KEYS) {
+    if (previous[key] === undefined) delete process.env[key];
+    else process.env[key] = previous[key];
+  }
+}
+
 test("headless permission event is sanitized, persisted, and rejected", async () => {
   const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
   const requestFile = join(root, "request.json");
   const blockerLog = join(root, "blockers.jsonl");
-  const previous = process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
+  const previous = preserveWorkerEnvironment();
   process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
   process.env.WORKER_ISSUE_NUMBER = "123";
   process.env.WORKER_REPO_SLUG = "owner/repo";
+  process.env.WORKER_SESSION_KEY = "issue-123";
   const replies = [];
   const broker = createPermissionBroker({
     client: { postSessionIdPermissionsPermissionId: async (value) => replies.push(value) },
@@ -44,9 +63,46 @@ test("headless permission event is sanitized, persisted, and rejected", async ()
   const blocker = JSON.parse(readFileSync(blockerLog, "utf8").trim());
   assert.equal(blocker.reason, "permission_required");
   assert.equal(blocker.blocking, true);
+  assert.equal(blocker.issue_number, 123);
+  assert.equal(blocker.repo_slug, "owner/repo");
+  assert.equal(blocker.session_key, "issue-123");
   assert.doesNotMatch(blocker.detail, /secret-value/);
-  if (previous === undefined) delete process.env.AIDEVOPS_PERMISSION_REQUEST_FILE;
-  else process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = previous;
+  restoreWorkerEnvironment(previous);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("blocker events retain identity from an existing permission capture", async () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));
+  const requestFile = join(root, "request.json");
+  const blockerLog = join(root, "blockers.jsonl");
+  const previous = preserveWorkerEnvironment();
+  process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
+  delete process.env.WORKER_ISSUE_NUMBER;
+  delete process.env.WORKER_REPO_SLUG;
+  delete process.env.WORKER_SESSION_KEY;
+  writeFileSync(requestFile, `${JSON.stringify({
+    schema: "aidevops-permission-capture/v1",
+    issue: "321",
+    repo: "owner/repo",
+    worker_session: "issue-321",
+    requests: [],
+  })}\n`);
+  const broker = createPermissionBroker({
+    client: {},
+    isHeadless: () => true,
+    home: "/Users/example",
+    blockerLogPath: blockerLog,
+  });
+  await broker.permissionAsk({
+    id: "permission-existing-capture",
+    type: "external_directory",
+    pattern: "/Users/example/.cache/opencode/tool/**",
+  }, { status: "ask" });
+  const blocker = JSON.parse(readFileSync(blockerLog, "utf8").trim());
+  assert.equal(blocker.issue_number, 321);
+  assert.equal(blocker.repo_slug, "owner/repo");
+  assert.equal(blocker.session_key, "issue-321");
+  restoreWorkerEnvironment(previous);
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -574,7 +574,8 @@ _fetch_claims() {
 	# lack it and parse as "unknown".
 	local parsed
 	parsed=$(printf '%s' "$claims_only" | jq -c --argjson now "$now_epoch" \
-		--argjson max_age "$DISPATCH_CLAIM_MAX_AGE" --argjson comments "$comments_json" \
+		--argjson max_age "$DISPATCH_CLAIM_MAX_AGE" --argjson include_terminal false \
+		--argjson comments "$comments_json" \
 		-f "${DISPATCH_CLAIM_HELPER_DIR}/dispatch-lease-claims.jq" 2>/dev/null) || {
 		echo "Error: failed to parse claim comments" >&2
 		return 1

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2134,8 +2134,9 @@ _is_dispatch_comment_active() {
 # the comment stays for audit but no longer blocks — allowing a fresh
 # dispatch attempt.
 #
-# A completion or failure comment posted AFTER the dispatch comment
-# cancels the lock early — the worker is done, re-dispatch is safe.
+# A completion or failure comment posted by a trusted repository actor AFTER
+# the dispatch comment cancels the lock early — the worker is done and
+# re-dispatch is safe. Untrusted issue commenters cannot mutate dispatch state.
 # Recognised completion signals: "TASK_COMPLETE", "FULL_LOOP_COMPLETE",
 # "Worker failed", "Worker Watchdog Kill", "BLOCKED",
 # "Stale assignment recovered", "Kill signal sent", "gh pr merge",
@@ -2191,24 +2192,63 @@ _dd_opportunistic_peer_scan() {
 }
 
 #######################################
+# Fetch every issue-comment page and keep only comments posted by repository
+# actors trusted to mutate dispatch coordination state. GitHub supplies
+# author_association; issue-body text cannot forge it.
+# Args: issue number, repo slug
+# Returns: normalized JSON on stdout, 1 on fetch or parse failure
+#######################################
+_dd_fetch_trusted_issue_comments() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local raw_comments=""
+
+	raw_comments=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" \
+		--paginate --slurp 2>/dev/null) || return 1
+	printf '%s' "$raw_comments" | jq -c '
+		def trusted_association:
+			. == "OWNER" or . == "MEMBER" or . == "COLLABORATOR";
+		[ (
+			if (type == "array" and ((.[0]? | type) == "array")) then
+				.[]
+			else
+				.
+			end
+		)[]
+		| {
+			id: .id,
+			body: (.body // ""),
+			body_start: ((.body // "")[:300]),
+			author: .user.login,
+			author_association: (.author_association // ""),
+			created_at: .created_at
+		}
+		| select((.author_association // "") | trusted_association)]
+	' 2>/dev/null || return 1
+	return 0
+}
+
+#######################################
 # Check for a cryptographically-unpredictable lease token whose terminal
-# transition matches the original claim author, device, and session. Both the
-# claim and transition ordering must surround the deterministic dispatch
-# comment, so unrelated or forged terminal text cannot retire its dedup lock.
+# transition matches the trusted dispatch author, original claim author,
+# device, and session. Both the claim and transition ordering must surround the
+# deterministic dispatch comment, so unrelated or forged terminal text cannot
+# retire its dedup lock.
 #
-# Args: comments JSON, dispatch timestamp, dispatch comment ID
+# Args: comments JSON, dispatch timestamp, dispatch comment ID, dispatch author
 # Returns: 0 when a matching terminal lease supersedes dispatch; 1 otherwise
 #######################################
 _dd_has_matching_terminal_lease() {
 	local comments_json="$1"
 	local dispatch_created_at="$2"
 	local dispatch_id="$3"
+	local dispatch_author="$4"
 	local lease_filter="${SCRIPT_DIR}/dispatch-lease-claims.jq"
 	local claims_json="[]"
 	local parsed_claims="[]"
 	local now_epoch=""
 
-	[[ -r "$lease_filter" && -n "$dispatch_created_at" ]] || return 1
+	[[ -r "$lease_filter" && -n "$dispatch_created_at" && -n "$dispatch_author" ]] || return 1
 	[[ "$dispatch_id" =~ ^[0-9]+$ ]] || dispatch_id=0
 	claims_json=$(printf '%s' "$comments_json" | jq -c \
 		'[.[] | select((.body // "") | contains("DISPATCH_CLAIM nonce="))]' \
@@ -2221,11 +2261,48 @@ _dd_has_matching_terminal_lease() {
 		-f "$lease_filter" 2>/dev/null) || return 1
 
 	if printf '%s' "$parsed_claims" | jq -e \
-		--arg dispatch_ts "$dispatch_created_at" --argjson dispatch_id "$dispatch_id" '
+		--arg dispatch_ts "$dispatch_created_at" --argjson dispatch_id "$dispatch_id" \
+		--arg dispatch_author "$dispatch_author" '
 		any(.[];
 			.lease_phase == "terminal" and
+			.claim_author == $dispatch_author and
 			[.created_at, ((.id // 0) | tonumber? // 0)] <= [$dispatch_ts, $dispatch_id] and
 			[.lease_terminal_at, (.lease_terminal_id // 0)] > [$dispatch_ts, $dispatch_id]
+		)' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Check for trusted completion evidence ordered after a dispatch comment.
+#
+# Args: comments JSON, dispatch timestamp, dispatch comment ID
+# Returns: 0 when trusted completion evidence supersedes dispatch; 1 otherwise
+#######################################
+_dd_has_trusted_completion_after_dispatch() {
+	local comments_json="$1"
+	local dispatch_created_at="$2"
+	local dispatch_id="$3"
+
+	[[ -n "$dispatch_created_at" ]] || return 1
+	[[ "$dispatch_id" =~ ^[0-9]+$ ]] || dispatch_id=0
+	if printf '%s' "$comments_json" | jq -e \
+		--arg dispatch_ts "$dispatch_created_at" --argjson dispatch_id "$dispatch_id" '
+		any(.[];
+			[.created_at, ((.id // 0) | tonumber? // 0)] > [$dispatch_ts, $dispatch_id] and (
+				(.body_start | test("TASK_COMPLETE"; "i")) or
+				(.body_start | test("FULL_LOOP_COMPLETE"; "i")) or
+				(.body_start | test("Worker failed"; "i")) or
+				(.body_start | test("Worker Watchdog Kill"; "i")) or
+				(.body_start | test("BLOCKED"; "i")) or
+				(.body_start | test("Kill signal sent"; "i")) or
+				(.body_start | test("Closes #"; "i")) or
+				(.body_start | test("gh pr merge"; "i")) or
+				(.body_start | test("MERGE_SUMMARY"; "i")) or
+				(.body_start | test("Stale assignment recovered"; "i")) or
+				(.body_start | test("CLAIM_RELEASED"; "i"))
+			)
 		)' >/dev/null 2>&1; then
 		return 0
 	fi
@@ -2235,7 +2312,8 @@ _dd_has_matching_terminal_lease() {
 has_dispatch_comment() {
 	local issue_number="$1"
 	local repo_slug="$2"
-	# $3 = self_login — unused since GH#15317 (all dispatch comments checked regardless of author)
+	# $3 = self_login — unused since GH#15317 (trusted dispatch comments from
+	# every repository actor are checked regardless of author identity)
 
 	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
 		return 1
@@ -2250,19 +2328,10 @@ has_dispatch_comment() {
 	local now_epoch
 	now_epoch=$(date -u '+%s')
 
-	# Fetch ALL comments — we need both dispatch and completion signals.
-	# Extract type, author, and timestamp for each relevant comment.
+	# Fetch every comment page because fresh dispatch and terminal evidence on a
+	# long-running issue can be absent from GitHub's oldest-first default page.
 	local comments_json
-	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--jq '[.[] | {
-			id: .id,
-			body: (.body // ""),
-			body_start: (.body[:300]),
-			author: .user.login,
-			author_association: (.author_association // ""),
-			created_at: .created_at
-		}]' \
-		2>/dev/null) || comments_json="[]"
+	comments_json=$(_dd_fetch_trusted_issue_comments "$issue_number" "$repo_slug") || comments_json="[]"
 
 	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
 		return 1
@@ -2276,8 +2345,9 @@ has_dispatch_comment() {
 	# Find the most recent dispatch comment (newest first)
 	local last_dispatch_json
 	last_dispatch_json=$(printf '%s' "$comments_json" | jq -c '
-		[.[] | select((.body_start // "") | test("(^|\\n)Dispatching worker"))]
-		| sort_by(.created_at) | reverse | first // empty
+		[.[]
+		| select((.body_start // "") | test("(^|\\n)Dispatching worker"))]
+		| sort_by(.created_at, ((.id // 0) | tonumber? // 0)) | reverse | first // empty
 	' 2>/dev/null) || last_dispatch_json=""
 
 	if [[ -z "$last_dispatch_json" || "$last_dispatch_json" == "null" ]]; then
@@ -2288,6 +2358,7 @@ has_dispatch_comment() {
 	dispatch_created_at=$(printf '%s' "$last_dispatch_json" | jq -r '.created_at // ""' 2>/dev/null) || dispatch_created_at=""
 	dispatch_author=$(printf '%s' "$last_dispatch_json" | jq -r '.author // ""' 2>/dev/null) || dispatch_author=""
 	dispatch_id=$(printf '%s' "$last_dispatch_json" | jq -r '.id // 0' 2>/dev/null) || dispatch_id=0
+	[[ "$dispatch_id" =~ ^[0-9]+$ ]] || dispatch_id=0
 
 	# Check if the dispatch comment is within TTL
 	if ! _is_dispatch_comment_active "$dispatch_created_at" "$dispatch_author" "$issue_number" "$now_epoch" "$max_age" "${3:-}"; then
@@ -2297,32 +2368,13 @@ has_dispatch_comment() {
 	# A CLAIM_RELEASED write can fail after the worker has already emitted its
 	# structured terminal lease transition. Reconcile that authenticated
 	# transition as equivalent durable completion evidence (GH#28437).
-	if _dd_has_matching_terminal_lease "$comments_json" "$dispatch_created_at" "$dispatch_id"; then
+	if _dd_has_matching_terminal_lease "$comments_json" "$dispatch_created_at" "$dispatch_id" "$dispatch_author"; then
 		return 1
 	fi
 
-	# GH#17503: Check for completion/failure comments posted AFTER the dispatch.
-	# If found, the worker is done — the dispatch comment no longer blocks.
-	local has_completion
-	has_completion=$(printf '%s' "$comments_json" | jq -r --arg dispatch_ts "$dispatch_created_at" '
-		[.[] | select(
-			.created_at > $dispatch_ts and (
-				(.body_start | test("TASK_COMPLETE"; "i")) or
-				(.body_start | test("FULL_LOOP_COMPLETE"; "i")) or
-				(.body_start | test("Worker failed"; "i")) or
-				(.body_start | test("Worker Watchdog Kill"; "i")) or
-				(.body_start | test("BLOCKED"; "i")) or
-				(.body_start | test("Kill signal sent"; "i")) or
-				(.body_start | test("Closes #"; "i")) or
-				(.body_start | test("gh pr merge"; "i")) or
-				(.body_start | test("MERGE_SUMMARY"; "i")) or
-				(.body_start | test("Stale assignment recovered"; "i")) or
-			(.body_start | test("CLAIM_RELEASED"; "i"))
-			)
-		)] | length
-	' 2>/dev/null) || has_completion=0
-
-	if [[ "$has_completion" -gt 0 ]]; then
+	# GH#17503: trusted completion/failure evidence posted after dispatch retires
+	# the lock early; untrusted issue comments cannot mutate coordination state.
+	if _dd_has_trusted_completion_after_dispatch "$comments_json" "$dispatch_created_at" "$dispatch_id"; then
 		# Worker completed or failed — dispatch comment superseded, safe to re-dispatch
 		return 1
 	fi

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2037,26 +2037,11 @@ enumerate_blockers() {
 # PR evidence dedup check functions are in dispatch-dedup-pr.sh (GH#18916).
 
 #######################################
-# Check whether a local process currently covers an issue.
-#######################################
-_dd_has_local_worker_for_issue() {
-	local issue_number="$1"
-	local running_keys=""
-	running_keys=$(list_running_keys 2>/dev/null || true)
-	if printf '%s\n' "$running_keys" | grep -Eq "\|(issue|ref)-${issue_number}$"; then
-		return 0
-	fi
-	return 1
-}
-
-#######################################
 # Check whether a single dispatch comment is still active.
 #
-# GH#16626: Process liveness check — if the comment is within TTL but no
-# worker process is running for this issue locally, the worker completed or
-# crashed without cleanup. Treat as stale and allow re-dispatch.
-# Grace period: comments <5 min old skip the liveness check to avoid racing
-# with worker startup (process may not be visible yet).
+# Local process absence is not completion evidence: the same GitHub login can
+# dispatch from another device. Durable terminal comments or a matching lease
+# transition retire the lock early; otherwise the extended worker TTL applies.
 #
 # Args:
 #   $1 = comment created_at (ISO 8601)
@@ -2064,7 +2049,7 @@ _dd_has_local_worker_for_issue() {
 #   $3 = issue number (for process search)
 #   $4 = now_epoch (seconds since epoch)
 #   $5 = max_age (seconds)
-#   $6 = self login (optional, for local stale-worker reconciliation)
+#   $6 = self login (retained for backward-compatible callers)
 # Returns: exit 0 if comment is active (blocks dispatch), exit 1 if stale/expired
 # Outputs: reason string on stdout when active
 #
@@ -2102,7 +2087,8 @@ _is_dispatch_comment_active() {
 	local issue_number="$3"
 	local now_epoch="$4"
 	local max_age="$5"
-	local self_login="${6:-}"
+	# $6 is intentionally unused: local process state cannot disprove a remote
+	# worker owned by the same GitHub login.
 	local active_worker_max_age="${DISPATCH_ACTIVE_WORKER_MAX_AGE:-7200}"
 	[[ "$active_worker_max_age" =~ ^[0-9]+$ ]] || active_worker_max_age=7200
 
@@ -2120,11 +2106,6 @@ _is_dispatch_comment_active() {
 	# non-terminal worker window expires; after that, a later claim path can emit
 	# an explicit stale-worker takeover reason instead of a bare DISPATCH_CLAIM.
 	if [[ "$age" -ge "$max_age" ]]; then
-		if [[ -n "$self_login" && "$author" == "$self_login" ]]; then
-			if ! _dd_has_local_worker_for_issue "$issue_number"; then
-				return 1
-			fi
-		fi
 		if [[ "$age" -lt "$active_worker_max_age" ]]; then
 			printf 'non-terminal dispatch comment by %s posted %ds ago on issue #%s (soft TTL expired; active-worker window: %ds remaining)\n' \
 				"$author" "$age" "$issue_number" "$((active_worker_max_age - age))"
@@ -2209,6 +2190,48 @@ _dd_opportunistic_peer_scan() {
 	return 0
 }
 
+#######################################
+# Check for a cryptographically-unpredictable lease token whose terminal
+# transition matches the original claim author, device, and session. Both the
+# claim and transition ordering must surround the deterministic dispatch
+# comment, so unrelated or forged terminal text cannot retire its dedup lock.
+#
+# Args: comments JSON, dispatch timestamp, dispatch comment ID
+# Returns: 0 when a matching terminal lease supersedes dispatch; 1 otherwise
+#######################################
+_dd_has_matching_terminal_lease() {
+	local comments_json="$1"
+	local dispatch_created_at="$2"
+	local dispatch_id="$3"
+	local lease_filter="${SCRIPT_DIR}/dispatch-lease-claims.jq"
+	local claims_json="[]"
+	local parsed_claims="[]"
+	local now_epoch=""
+
+	[[ -r "$lease_filter" && -n "$dispatch_created_at" ]] || return 1
+	[[ "$dispatch_id" =~ ^[0-9]+$ ]] || dispatch_id=0
+	claims_json=$(printf '%s' "$comments_json" | jq -c \
+		'[.[] | select((.body // "") | contains("DISPATCH_CLAIM nonce="))]' \
+		2>/dev/null) || return 1
+	[[ "$claims_json" != "[]" ]] || return 1
+	now_epoch=$(date -u '+%s')
+	parsed_claims=$(printf '%s' "$claims_json" | jq -c \
+		--argjson now "$now_epoch" --argjson max_age 2147483647 \
+		--argjson include_terminal true --argjson comments "$comments_json" \
+		-f "$lease_filter" 2>/dev/null) || return 1
+
+	if printf '%s' "$parsed_claims" | jq -e \
+		--arg dispatch_ts "$dispatch_created_at" --argjson dispatch_id "$dispatch_id" '
+		any(.[];
+			.lease_phase == "terminal" and
+			[.created_at, ((.id // 0) | tonumber? // 0)] <= [$dispatch_ts, $dispatch_id] and
+			[.lease_terminal_at, (.lease_terminal_id // 0)] > [$dispatch_ts, $dispatch_id]
+		)' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
 has_dispatch_comment() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -2232,8 +2255,11 @@ has_dispatch_comment() {
 	local comments_json
 	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 		--jq '[.[] | {
+			id: .id,
+			body: (.body // ""),
 			body_start: (.body[:300]),
 			author: .user.login,
+			author_association: (.author_association // ""),
 			created_at: .created_at
 		}]' \
 		2>/dev/null) || comments_json="[]"
@@ -2258,12 +2284,20 @@ has_dispatch_comment() {
 		return 1
 	fi
 
-	local dispatch_created_at dispatch_author
+	local dispatch_created_at dispatch_author dispatch_id
 	dispatch_created_at=$(printf '%s' "$last_dispatch_json" | jq -r '.created_at // ""' 2>/dev/null) || dispatch_created_at=""
 	dispatch_author=$(printf '%s' "$last_dispatch_json" | jq -r '.author // ""' 2>/dev/null) || dispatch_author=""
+	dispatch_id=$(printf '%s' "$last_dispatch_json" | jq -r '.id // 0' 2>/dev/null) || dispatch_id=0
 
 	# Check if the dispatch comment is within TTL
 	if ! _is_dispatch_comment_active "$dispatch_created_at" "$dispatch_author" "$issue_number" "$now_epoch" "$max_age" "${3:-}"; then
+		return 1
+	fi
+
+	# A CLAIM_RELEASED write can fail after the worker has already emitted its
+	# structured terminal lease transition. Reconcile that authenticated
+	# transition as equivalent durable completion evidence (GH#28437).
+	if _dd_has_matching_terminal_lease "$comments_json" "$dispatch_created_at" "$dispatch_id"; then
 		return 1
 	fi
 

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -159,7 +159,8 @@ _stale_recovery_final_evidence_recheck() {
 	comments=$(printf '%s' "$pages" | jq -c '[.[] | .[]?]' 2>/dev/null) || return 1
 	claims=$(printf '%s' "$comments" | jq -c '[.[] | select((.body // "") | contains("DISPATCH_CLAIM nonce="))]' 2>/dev/null) || return 1
 	parsed=$(printf '%s' "$claims" | jq -c --argjson now "$now_epoch" --argjson max_age 2147483647 \
-		--argjson comments "$comments" -f "${SCRIPT_DIR}/dispatch-lease-claims.jq" 2>/dev/null) || return 1
+		--argjson include_terminal false --argjson comments "$comments" \
+		-f "${SCRIPT_DIR}/dispatch-lease-claims.jq" 2>/dev/null) || return 1
 	if printf '%s' "$parsed" | jq -e 'any(.lease_phase == "ready")' >/dev/null 2>&1; then
 		return 1
 	fi

--- a/.agents/scripts/dispatch-lease-claims.jq
+++ b/.agents/scripts/dispatch-lease-claims.jq
@@ -11,6 +11,7 @@
         device: (if $device == "" then "legacy" else $device end),
         session: $session,
         claim_author: (.author // .user.login // ""),
+        claim_author_association: (.author_association // ""),
         lease_expires_at: ($expires | tonumber? // 0),
         created_at: .created_at,
         created_epoch: (.created_at | fromdateiso8601? // 0)
@@ -23,21 +24,26 @@ map(. as $claim |
        | select((.body // "") | contains("DISPATCH_LEASE"))
        | select(($claim.claim_author != "") and ((.author // .user.login // "") == $claim.claim_author))
        | . + ((.body | capture("phase=(?<phase>[^ ]+) lease_token=[^ ]+ device=(?<device>[^ ]+) session=(?<session>[^ ]+) expires_at=(?<expires>[0-9]+)")) as $t
-              | {transition_phase:$t.phase, transition_device:$t.device, transition_session:$t.session,
-                 transition_expires:($t.expires|tonumber), transition_epoch:(.created_at | fromdateiso8601? // 0)})
+               | {transition_phase:$t.phase, transition_device:$t.device, transition_session:$t.session,
+                  transition_expires:($t.expires|tonumber), transition_epoch:(.created_at | fromdateiso8601? // 0),
+                  transition_at:(.created_at // ""), transition_id:(.id | tonumber? // 0)})
        | select(.transition_device == $claim.device and .transition_session == $claim.session)
-     ] | sort_by(.created_at, .id)) as $transitions |
+       | select([.transition_epoch, .transition_id] >= [$claim.created_epoch, ($claim.id | tonumber? // 0)])
+      ] | sort_by(.created_at, .id)) as $transitions |
     (reduce $transitions[] as $event
-      ({phase:"prelaunch", expires:$claim.lease_expires_at};
+      ({phase:"prelaunch", expires:$claim.lease_expires_at, terminal_at:"", terminal_id:0};
        if .phase == "terminal" or .expires < $event.transition_epoch then .
        elif $event.transition_phase == "prelaunch" and .phase == "prelaunch" and $event.transition_expires >= $event.transition_epoch
-         then {phase:"prelaunch", expires:$event.transition_expires}
+         then .phase="prelaunch" | .expires=$event.transition_expires
        elif $event.transition_phase == "ready" and .phase == "prelaunch" and $event.transition_expires >= $event.transition_epoch
-         then {phase:"ready", expires:$event.transition_expires}
+         then .phase="ready" | .expires=$event.transition_expires
        elif $event.transition_phase == "terminal" and (.phase == "prelaunch" or .phase == "ready")
-         then {phase:"terminal", expires:0}
+         then .phase="terminal" | .expires=0 | .terminal_at=$event.transition_at | .terminal_id=$event.transition_id
        else . end)) as $state |
-    $claim + {lease_phase:$state.phase, lease_expires_at:$state.expires}) |
+    $claim + {lease_phase:$state.phase, lease_expires_at:$state.expires,
+              lease_terminal_at:$state.terminal_at, lease_terminal_id:$state.terminal_id}) |
 map(select(.age_seconds >= 0 and (.age_seconds <= $max_age or (.lease_phase == "ready" and .lease_expires_at >= $now)))) |
-map(select(.lease_phase != "terminal" and ((.lease_expires_at // 0) == 0 or .lease_expires_at >= $now))) |
+(if $include_terminal then . else
+    map(select(.lease_phase != "terminal" and ((.lease_expires_at // 0) == 0 or .lease_expires_at >= $now)))
+ end) |
 sort_by([.created_at, .nonce])

--- a/.agents/scripts/dispatch-lease-claims.jq
+++ b/.agents/scripts/dispatch-lease-claims.jq
@@ -11,7 +11,6 @@
         device: (if $device == "" then "legacy" else $device end),
         session: $session,
         claim_author: (.author // .user.login // ""),
-        claim_author_association: (.author_association // ""),
         lease_expires_at: ($expires | tonumber? // 0),
         created_at: .created_at,
         created_epoch: (.created_at | fromdateiso8601? // 0)

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -442,14 +442,31 @@ _hrff_post_claim_released_comment() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local comment_body="$3"
+	local attempts="${AIDEVOPS_CLAIM_RELEASE_POST_ATTEMPTS:-3}"
+	local retry_delay="${AIDEVOPS_CLAIM_RELEASE_POST_RETRY_DELAY:-1}"
+	local attempt=1
+	local post_error=""
 
-	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--method POST \
-		--field body="$comment_body" \
-		>/dev/null 2>&1 || {
-		print_warning "Failed to post CLAIM_RELEASED on #${issue_number} (non-fatal)"
-	}
-	return 0
+	[[ "$attempts" =~ ^[1-9][0-9]*$ ]] || attempts=3
+	[[ "$retry_delay" =~ ^[0-9]+$ ]] || retry_delay=1
+	while [[ "$attempt" -le "$attempts" ]]; do
+		if post_error=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+			--method POST \
+			--field body="$comment_body" \
+			2>&1 >/dev/null); then
+			return 0
+		fi
+		post_error="${post_error//$'\n'/ }"
+		post_error="${post_error:0:240}"
+		if [[ "$attempt" -lt "$attempts" ]]; then
+			print_warning "CLAIM_RELEASED persistence failed on #${issue_number} (attempt ${attempt}/${attempts}): ${post_error:-unknown}; retrying"
+			[[ "$retry_delay" -eq 0 ]] || sleep "$retry_delay"
+		fi
+		attempt=$((attempt + 1))
+	done
+
+	print_warning "Failed to post CLAIM_RELEASED on #${issue_number} after ${attempts} attempt(s): ${post_error:-unknown}"
+	return 1
 }
 
 #######################################
@@ -505,7 +522,10 @@ _release_dispatch_claim() {
 ${machine_readable_part}
 <!-- ops:end -->"
 
-	_hrff_post_claim_released_comment "$issue_number" "$repo_slug" "$comment_body"
+	if ! _hrff_post_claim_released_comment "$issue_number" "$repo_slug" "$comment_body"; then
+		print_warning "Claim release for #${issue_number} remains unpersisted and retryable; retaining issue lifecycle state"
+		return 1
+	fi
 	print_info "Released claim on #${issue_number} (reason: ${reason})"
 
 	# t2420: clear active-lifecycle status labels + worker assignment so the
@@ -870,12 +890,13 @@ _hrff_finalize_exit_trap() {
 	local exit_status="$3"
 	local session_count="$4"
 	local force_nonzero_exit="$5"
+	local checkpoint_reason="${_HRW_REASON_DRAFT_CHECKPOINT:-worker_draft_checkpoint}"
 
 	print_info "[exit-trap] session=$session_key exit=$exit_status reason=$reason session_count=$session_count"
 	_push_wip_commits_on_exit
 	if [[ "${_WORKER_DIRTY_WORK_PRESERVED:-0}" == "1" ]]; then
 		if _recover_dirty_worker_pr "$session_key"; then
-			reason="worker_complete"
+			reason="$checkpoint_reason"
 		else
 			reason="worker_dirty_work_preserved"
 		fi
@@ -883,6 +904,8 @@ _hrff_finalize_exit_trap() {
 	if declare -F _emit_worker_runtime_event >/dev/null 2>&1; then
 		if [[ "$reason" == "worker_complete" ]]; then
 			_emit_worker_runtime_event "worker.completed" "recovered" "$reason"
+		elif [[ "$reason" == "$checkpoint_reason" ]]; then
+			_emit_worker_runtime_event "worker.deferred" "checkpointed" "$reason"
 		else
 			_emit_worker_runtime_event "worker.failed" "failed" "$reason"
 		fi
@@ -891,17 +914,18 @@ _hrff_finalize_exit_trap() {
 		local terminal_outcome="failed"
 		local complete_reason="${_HRW_REASON_WORKER_COMPLETE:-worker_complete}"
 		[[ "$reason" == "$complete_reason" ]] && terminal_outcome="success"
+		[[ "$reason" == "$checkpoint_reason" ]] && terminal_outcome="deferred"
 		_hrw_record_terminal_outcome "$session_key" "$terminal_outcome" "$reason"
 	fi
 	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
 		_cleanup_headless_runtime_temp_paths
 	fi
-	_release_dispatch_claim "$session_key" "$reason" "$exit_status" "$session_count"
+	if ! _release_dispatch_claim "$session_key" "$reason" "$exit_status" "$session_count"; then
+		print_warning "[exit-trap] claim release persistence remains retryable for session=${session_key} reason=${reason}"
+	fi
 	_release_session_lock "$session_key"
 	_update_dispatch_ledger "$session_key" "fail"
-	if declare -F aidevops_runtime_bundle_lease_release >/dev/null 2>&1; then
-		aidevops_runtime_bundle_lease_release || print_warning "Failed to release the worker runtime bundle lease"
-	fi
+	aidevops_runtime_bundle_lease_release || print_warning "Failed to release the worker runtime bundle lease"
 	if [[ "$force_nonzero_exit" -eq 1 ]]; then
 		trap - EXIT
 		exit "$exit_status"

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -44,10 +44,12 @@ _HRW_REASON_UNVERIFIED_HANDOFF="worker_post_pr_handoff_unverified"
 _HRW_REASON_WORKTREE_CONTINUATION_STATE_REJECTED="worker_worktree_continuation_state_rejected"
 _HRW_REASON_WORKTREE_OWNER_CONCURRENT_MUTATION="worker_worktree_owner_concurrent_mutation"
 _HRW_EVENT_FAILED="worker.failed"
+_HRW_EVENT_DEFERRED="worker.deferred"
 _HRW_NMR_LABEL="needs-maintainer-review"
 _HRW_PERMISSION_PERSISTENCE_FAILED="permission_request_persistence_failed"
 _HRW_SPOTLIGHT_MARKER=".metadata_never_index"
 _HRW_RECOVERY_CLASSIFICATION=""
+_HRW_CLAIM_RELEASE_PERSISTENCE_FAILED=0
 
 # Defensive SCRIPT_DIR fallback (test harnesses may not set it)
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -59,6 +61,26 @@ fi
 
 # shellcheck source=shared-runner-identity.sh
 source "${SCRIPT_DIR}/shared-runner-identity.sh"
+
+#######################################
+# Release a claim without allowing a GitHub comment persistence failure to
+# bypass later terminal-lease emission and local cleanup. The underlying
+# helper still returns non-zero to direct callers so the write is observable
+# and retryable; worker lifecycle callers record the failure and continue.
+#######################################
+_hrw_release_dispatch_claim() {
+	local session_key="$1"
+	local reason="${2:-worker_failed}"
+	local exit_code_arg="${3:-}"
+	local session_count_arg="${4:-}"
+
+	if _release_dispatch_claim "$session_key" "$reason" "$exit_code_arg" "$session_count_arg"; then
+		return 0
+	fi
+	_HRW_CLAIM_RELEASE_PERSISTENCE_FAILED=1
+	print_warning "[lifecycle] claim_release_persistence_failed session=${session_key} reason=${reason}; terminal lease/event cleanup remains active"
+	return 0
+}
 
 # =============================================================================
 # Runtime invocation support — auth rotation & rate-limit monitoring
@@ -659,7 +681,7 @@ _escalate_worker_pr_checkpoint() {
 		return 0
 	fi
 
-	_release_dispatch_claim "$session_key" "$release_reason"
+	_hrw_release_dispatch_claim "$session_key" "$release_reason"
 	_HRW_RECOVERY_CLASSIFICATION="$release_reason"
 	print_warning "[lifecycle] worker_pr_checkpoint_escalated session=${session_key} state=${lifecycle_state} — maintainer review required"
 	return 0
@@ -765,11 +787,11 @@ _handle_worker_branch_orphan() {
 
 	if _attempt_orphan_recovery_pr "$session_key" "$work_dir" "$branch_name" "$repo_slug"; then
 		print_info "[lifecycle] Orphan PR auto-created for session=${session_key}"
-		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
+		_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 	else
 		print_info "[lifecycle] Orphan recovery failed for session=${session_key}"
-		_release_dispatch_claim "$session_key" "worker_branch_orphan"
+		_hrw_release_dispatch_claim "$session_key" "worker_branch_orphan"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
 		# Post structured ops comment so the next dispatch knows what happened
 		if [[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]]; then
@@ -837,11 +859,11 @@ _handle_worker_local_branch_unpushed() {
 	if _attempt_orphan_recovery_pr "$session_key" "$work_dir" "$branch_name" "$repo_slug"; then
 		print_info "[lifecycle] Local branch pushed and recovery PR auto-created for session=${session_key}"
 		local complete_reason="worker_"
-		_release_dispatch_claim "$session_key" "${complete_reason}complete"
+		_hrw_release_dispatch_claim "$session_key" "${complete_reason}complete"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 	else
 		print_info "[lifecycle] Local branch recovery failed for session=${session_key}"
-		_release_dispatch_claim "$session_key" "worker_local_branch_unpushed"
+		_hrw_release_dispatch_claim "$session_key" "worker_local_branch_unpushed"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
 		if [[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]]; then
 			local _ops_comment
@@ -880,7 +902,9 @@ _handle_worker_dirty_worktree() {
 	local work_dir="$2"
 	local repo_slug="${DISPATCH_REPO_SLUG:-}"
 	local issue_number=""
-	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
+	if declare -F _scl_worker_issue_number >/dev/null 2>&1; then
+		issue_number=$(_scl_worker_issue_number "$session_key")
+	fi
 
 	local branch_name=""
 	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
@@ -934,13 +958,17 @@ _handle_worker_dirty_worktree() {
 				--changed-paths "$status_summary" \
 				--recoverability "checkpointed" 2>/dev/null || true
 		fi
-		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
-		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
+		_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_DRAFT_CHECKPOINT"
+		_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_CHECKPOINT"
+		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
+		_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
+		_HRW_FINAL_RUNTIME_STATUS="checkpointed"
+		_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_REASON_DRAFT_CHECKPOINT"
 		print_info "[lifecycle] worker_dirty_worktree_checkpointed session=${session_key} branch=${branch_name:-<none>}"
 		return 0
 	fi
 
-	_release_dispatch_claim "$session_key" "worker_dirty_worktree"
+	_hrw_release_dispatch_claim "$session_key" "worker_dirty_worktree"
 	_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_FAILED"
 
 	if [[ -n "$issue_number" && -n "$repo_slug" ]]; then
@@ -1006,7 +1034,7 @@ _recover_worker_output_on_failure() {
 		local pr_state="${pr_handoff%%|*}"
 		if [[ "$pr_state" == "ready" || "$pr_state" == "merged" ]]; then
 			print_info "[lifecycle] worker_failure_recovered_existing_pr session=${session_key} branch=${branch_name}"
-			_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
+			_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
 			_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_WORKER_COMPLETE"
 			return 0
 		fi
@@ -1474,12 +1502,12 @@ _hrw_finish_failed_run() {
 
 	if [[ "$external_terminal_confirmed" -eq 1 ]] || \
 		_worker_external_terminal_complete "$session_key" "$work_dir"; then
-		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
+		_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
 		failure_recovered=1
 	elif _recover_worker_output_on_failure "$session_key" "$work_dir"; then
 		failure_recovered=1
 	else
-		_release_dispatch_claim "$session_key" "worker_failed"
+		_hrw_release_dispatch_claim "$session_key" "worker_failed"
 	fi
 	if [[ "$failure_recovered" -eq 1 && "${_HRW_RECOVERY_CLASSIFICATION:-$_HRW_REASON_WORKER_COMPLETE}" == "$_HRW_REASON_WORKER_COMPLETE" ]]; then
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
@@ -1532,7 +1560,7 @@ _hrw_finish_rate_limit_fast_run() {
 	# (Anthropic 429/overload), not a model capability failure. NMR backoff would
 	# incorrectly penalise the issue for an infrastructure blip. Metric already
 	# recorded by _execute_run_attempt with result=rate_limit_fast.
-	_release_dispatch_claim "$session_key" "rate_limit_transient"
+	_hrw_release_dispatch_claim "$session_key" "rate_limit_transient"
 	return 0
 }
 
@@ -1573,8 +1601,8 @@ _hrw_finish_permission_required_run() {
 		_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_PERMISSION_PERSISTENCE_FAILED"
 		return 1
 	fi
-	_release_dispatch_claim "$session_key" "$permission_status"
-	_HRW_FINAL_RUNTIME_EVENT="worker.deferred"
+	_hrw_release_dispatch_claim "$session_key" "$permission_status"
+	_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
 	_HRW_FINAL_RUNTIME_STATUS="$permission_status"
 	_HRW_FINAL_RUNTIME_CLASSIFICATION="awaiting_maintainer_permission"
 	_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
@@ -1664,7 +1692,7 @@ _hrw_finish_success_run() {
 		(! declare -F _worker_post_pr_handoff_confirmed >/dev/null 2>&1 ||
 			! _worker_post_pr_handoff_confirmed "$session_key" "$work_dir"); then
 		print_warning "[lifecycle] ${_HRW_REASON_UNVERIFIED_HANDOFF} session=${session_key} — exact-head non-draft PR handoff could not be verified; routing as failure"
-		_release_dispatch_claim "$session_key" "$_HRW_REASON_UNVERIFIED_HANDOFF"
+		_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_UNVERIFIED_HANDOFF"
 		_report_failure_to_fast_fail "$session_key" "$_HRW_REASON_UNVERIFIED_HANDOFF" "$_HRW_CRASH_OVERWHELMED"
 		release_needed=0
 		finish_status=1
@@ -1690,7 +1718,7 @@ _hrw_finish_success_run() {
 		case "$output_class" in
 		noop)
 			print_info "[lifecycle] worker_noop session=$session_key — zero commits, no pushed branch, no PR"
-			_release_dispatch_claim "$session_key" "worker_noop"
+			_hrw_release_dispatch_claim "$session_key" "worker_noop"
 			_report_failure_to_fast_fail "$session_key" "worker_noop_zero_output" "$_HRW_CRASH_NO_WORK"
 			release_needed=0
 			_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_CRASH_NO_WORK"
@@ -1718,7 +1746,7 @@ _hrw_finish_success_run() {
 			;;
 		closed_unmerged)
 			print_warning "[lifecycle] ${_HRW_REASON_CLOSED_UNMERGED} session=${session_key} — closed PR is not completion evidence"
-			_release_dispatch_claim "$session_key" "$_HRW_REASON_CLOSED_UNMERGED"
+			_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_CLOSED_UNMERGED"
 			_report_failure_to_fast_fail "$session_key" "$_HRW_REASON_CLOSED_UNMERGED" "$_HRW_CRASH_OVERWHELMED"
 			release_needed=0
 			_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_REASON_CLOSED_UNMERGED"
@@ -1736,7 +1764,7 @@ _hrw_finish_success_run() {
 		# pr_exists or fail-open: normal success path. Post CLAIM_RELEASED with
 		# reason=worker_complete so the audit trail shows the full lifecycle even
 		# when no PR was created.
-		_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
+		_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_WORKER_COMPLETE"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_SUCCESS"
 	fi
 	if [[ "$_HRW_TERMINAL_OUTCOME" == "$_HRW_TELEMETRY_SUCCESS" ]]; then
@@ -1758,9 +1786,7 @@ _hrw_finish_cleanup() {
 	if declare -F _cleanup_headless_runtime_temp_paths >/dev/null 2>&1; then
 		_cleanup_headless_runtime_temp_paths
 	fi
-	if declare -F aidevops_runtime_bundle_lease_release >/dev/null 2>&1; then
-		aidevops_runtime_bundle_lease_release || print_warning "Failed to release the worker runtime bundle lease"
-	fi
+	aidevops_runtime_bundle_lease_release || print_warning "Failed to release the worker runtime bundle lease"
 	trap - EXIT
 	return 0
 }
@@ -1807,7 +1833,7 @@ _cmd_run_finish() {
 		_hrw_finish_failed_run "$session_key" "$work_dir" "$external_terminal_confirmed"
 	elif [[ "$ledger_status" == "rate_limit_fast" ]]; then
 		_hrw_finish_rate_limit_fast_run "$session_key"
-		_HRW_FINAL_RUNTIME_EVENT="worker.deferred"
+		_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
 		_HRW_FINAL_RUNTIME_STATUS="rate_limit_fast"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="rate_limit"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
@@ -1957,7 +1983,7 @@ _cmd_run_prepare() {
 	# instead of emitting a fixed 'process_exit' reason for all abnormal exits.
 	# SC2064: session_key is intentionally baked in at trap-set time.
 	# shellcheck disable=SC2064
-	trap "_exit_trap_handler '$session_key'; if declare -F aidevops_runtime_bundle_lease_release >/dev/null 2>&1; then aidevops_runtime_bundle_lease_release; fi" EXIT
+	trap "_exit_trap_handler '$session_key'; aidevops_runtime_bundle_lease_release" EXIT
 
 	# GH#20564: Record worker start time in milliseconds for exit trap classifier.
 	# classify_worker_exit uses this to distinguish crash_during_startup (no

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1501,7 +1501,7 @@ _rollback_prelaunch_ownership() {
 	fi
 
 	local issue_meta_json=""
-	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+	issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 		--json state,labels,assignees,locked 2>/dev/null) || return 1
 	local owns_queued=""
 	owns_queued=$(printf '%s' "$issue_meta_json" | jq -r --arg self "$self_login" '
@@ -1520,7 +1520,7 @@ _rollback_prelaunch_ownership() {
 		unlock_issue_after_worker "$issue_number" "$repo_slug" || return 1
 	fi
 
-	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+	issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 		--json state,labels,assignees,locked 2>/dev/null) || return 1
 	if ! printf '%s' "$issue_meta_json" | jq -e --arg self "$self_login" '
 		.state == "OPEN" and

--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -16,6 +16,7 @@
 #   - _large_file_gate_create_debt_issue
 #   - _large_file_gate_apply
 #   - _large_file_gate_clear_stale_label
+#   - _large_file_gate_issue_labels
 #   - _issue_targets_large_files
 
 [[ -n "${_PULSE_DISPATCH_LARGE_FILE_GATE_LOADED:-}" ]] && return 0
@@ -758,12 +759,26 @@ _Automated by \`_issue_targets_large_files()\` in pulse-wrapper.sh_"
 # so the original "Held from dispatch" comment doesn't mislead readers (t2042).
 #
 # Arguments: issue_number, repo_slug
+# Returns: 0=label removal confirmed, 1=removal failed or could not be verified
 #######################################
 _large_file_gate_clear_stale_label() {
 	local issue_number="$1"
 	local repo_slug="$2"
-	gh issue edit "$issue_number" --repo "$repo_slug" \
-		--remove-label "needs-simplification" >/dev/null 2>&1 || true
+	local current_labels=""
+	if ! gh issue edit "$issue_number" --repo "$repo_slug" \
+		--remove-label "needs-simplification" >/dev/null 2>&1; then
+		echo "[pulse-wrapper] WARN: failed to clear stale needs-simplification label for #${issue_number} (${repo_slug}); gate remains applied for retry" >>"$LOGFILE"
+		return 1
+	fi
+	if ! current_labels=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
+		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null); then
+		echo "[pulse-wrapper] WARN: could not verify stale needs-simplification label removal for #${issue_number} (${repo_slug}); gate remains applied for retry" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ ",$current_labels," == *",needs-simplification,"* ]]; then
+		echo "[pulse-wrapper] WARN: stale needs-simplification label still present after removal for #${issue_number} (${repo_slug}); gate remains applied for retry" >>"$LOGFILE"
+		return 1
+	fi
 	echo "[pulse-wrapper] Simplification gate cleared for #${issue_number} (${repo_slug}) — no large files after exclusion filter" >>"$LOGFILE"
 	# t2042: post follow-up "CLEARED" comment so the original
 	# "Held from dispatch" comment doesn't mislead readers. Helper
@@ -920,6 +935,41 @@ _large_file_gate_collect_large_files() {
 }
 
 #######################################
+# Resolve current issue labels while allowing callers to reuse prefetched
+# issue JSON. A prefetched positive gate is volatile, so refresh it before
+# dispatch and retain it fail-closed when GitHub cannot provide a snapshot.
+#
+# Arguments: issue_number, repo_slug, pre_fetched_json
+# Outputs: comma-joined issue labels
+#######################################
+_large_file_gate_issue_labels() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local pre_fetched_json="$3"
+	local issue_labels=""
+	local fresh_issue_labels=""
+
+	if [[ -n "$pre_fetched_json" ]] \
+		&& printf '%s' "$pre_fetched_json" | jq -e '.labels' >/dev/null 2>&1; then
+		issue_labels=$(printf '%s' "$pre_fetched_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
+		if [[ ",$issue_labels," == *",needs-simplification,"* ]]; then
+			if fresh_issue_labels=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
+				--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null); then
+				issue_labels="$fresh_issue_labels"
+			else
+				echo "[pulse-wrapper] WARN: could not refresh volatile simplification lifecycle for #${issue_number} (${repo_slug}); retaining prefetched gate state" >>"$LOGFILE"
+			fi
+		fi
+	else
+		issue_labels=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
+			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
+	fi
+
+	printf '%s' "$issue_labels"
+	return 0
+}
+
+#######################################
 # Thin orchestrator for the large-file gate. Delegates label precheck,
 # path extraction, per-target evaluation, gate application, and stale-label
 # cleanup to the `_large_file_gate_*` helpers above. Byte-for-byte
@@ -959,14 +1009,8 @@ _issue_targets_large_files() {
 	[[ -n "$issue_body" ]] || return 1
 	[[ -d "$repo_path" ]] || return 1
 
-	local issue_labels
-	if [[ -n "$pre_fetched_json" ]] \
-		&& printf '%s' "$pre_fetched_json" | jq -e '.labels' >/dev/null 2>&1; then
-		issue_labels=$(printf '%s' "$pre_fetched_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
-	else
-		issue_labels=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
-			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || issue_labels=""
-	fi
+	local issue_labels=""
+	issue_labels=$(_large_file_gate_issue_labels "$issue_number" "$repo_slug" "$pre_fetched_json")
 
 	local _precheck_rc=0
 	_large_file_gate_precheck_labels "$issue_number" "$repo_slug" "$issue_labels" "$force_recheck" || _precheck_rc=$?
@@ -987,7 +1031,7 @@ _issue_targets_large_files() {
 		# pulse restart confirmed the extractor fix worked but the stale label
 		# required human intervention to clear.
 		if [[ ",$issue_labels," == *",needs-simplification,"* ]]; then
-			_large_file_gate_clear_stale_label "$issue_number" "$repo_slug"
+			_large_file_gate_clear_stale_label "$issue_number" "$repo_slug" || return 0
 		fi
 		return 1
 	fi
@@ -1003,6 +1047,9 @@ _issue_targets_large_files() {
 	if _large_file_gate_check_surgical_brief \
 		"$_surgical_title" "$all_paths" "$repo_path"; then
 		echo "[pulse-wrapper] Large-file gate EXEMPTED for #${issue_number} (${repo_slug}): surgical brief with line ranges for ${_LFG_SURGICAL_EXEMPTED_FILES}" >>"$LOGFILE"
+		if [[ ",$issue_labels," == *",needs-simplification,"* ]]; then
+			_large_file_gate_clear_stale_label "$issue_number" "$repo_slug" || return 0
+		fi
 		return 1
 	fi
 
@@ -1018,7 +1065,7 @@ _issue_targets_large_files() {
 	# If was_already_labeled but no large files found (e.g., all files now
 	# excluded by skip pattern or simplified below threshold), auto-clear.
 	if [[ ",$issue_labels," == *",needs-simplification,"* ]]; then
-		_large_file_gate_clear_stale_label "$issue_number" "$repo_slug"
+		_large_file_gate_clear_stale_label "$issue_number" "$repo_slug" || return 0
 	fi
 
 	return 1

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -834,24 +834,17 @@ _dlw_node_modules_restore_release_lock() {
 	return 0
 }
 
-_dlw_restore_root_node_tool_links() {
+_dlw_remove_generated_root_node_tool_link() {
 	local worktree_path="$1"
 	local repo_path="$2"
-	[[ "${WORKTREE_NODE_MODULES_BIN_LINK_ENABLED:-1}" == "1" ]] || return 0
-
 	local _src_bin="${repo_path}/node_modules/.bin"
-	local _dst_nm="${worktree_path}/node_modules"
-	local _dst_bin="${_dst_nm}/.bin"
-	[[ -d "$_src_bin" ]] || return 0
-	if [[ -e "$_dst_bin" || -L "$_dst_bin" ]]; then
-		return 0
-	fi
-	if [[ -e "$_dst_nm" && ! -d "$_dst_nm" ]]; then
-		return 0
-	fi
-	mkdir -p "$_dst_nm" 2>/dev/null || return 0
-	ln -s "$_src_bin" "$_dst_bin" 2>/dev/null || return 0
-	echo "[dispatch_with_dedup] Linked root node_modules/.bin tooling for ${worktree_path} without copying root node_modules" >>"$LOGFILE"
+	local _dst_bin="${worktree_path}/node_modules/.bin"
+	local _link_target=""
+	[[ -L "$_dst_bin" ]] || return 0
+	_link_target=$(readlink "$_dst_bin" 2>/dev/null) || return 0
+	[[ "$_link_target" == "$_src_bin" ]] || return 0
+	rm -f "$_dst_bin" 2>/dev/null || return 0
+	echo "[dispatch_with_dedup] Removed generated cross-boundary node_modules/.bin link from ${worktree_path}" >>"$LOGFILE"
 	return 0
 }
 
@@ -888,7 +881,7 @@ _dlw_restore_worktree_deps() {
 		_rel_dir="${_dir#"$worktree_path"}" || continue
 		# _rel_dir is now e.g. "/.opencode" or "" (for root package.json)
 		if [[ -z "$_rel_dir" && "$_restore_root" != "1" ]]; then
-			_dlw_restore_root_node_tool_links "$worktree_path" "$repo_path"
+			_dlw_remove_generated_root_node_tool_link "$worktree_path" "$repo_path"
 			echo "[dispatch_with_dedup] Skipping root node_modules restore for ${worktree_path} (set WORKTREE_NODE_MODULES_RESTORE_ROOT_ENABLED=1 to enable)" >>"$LOGFILE"
 			continue
 		fi
@@ -1801,6 +1794,17 @@ _dlw_validate_worktree_for_launch() {
 	return 1
 }
 
+_dlw_append_node_tool_env() {
+	local repo_path="$1"
+	local node_tool_bin="${repo_path}/node_modules/.bin"
+	[[ -d "$node_tool_bin" && ! -L "$node_tool_bin" ]] || return 0
+	[[ "$node_tool_bin" != *:* && "$node_tool_bin" != *$'\n'* ]] || return 0
+	# Expose only executable package entrypoints through PATH. Do not place a
+	# canonical-checkout symlink inside the worktree or grant broad file access.
+	worker_cmd+=(PATH="${node_tool_bin}:${PATH:-/usr/bin:/bin}")
+	return 0
+}
+
 _dlw_append_trusted_release_env() {
 	local trusted_priority="${_DLW_TRUSTED_ISSUE_PRIORITY:-}"
 	local trusted_release_type="${_DLW_TRUSTED_RELEASE_TYPE:-}"
@@ -1892,6 +1896,7 @@ _dlw_nohup_launch() {
 		AIDEVOPS_DISPATCH_TIER="$dispatch_model_tier"
 		AIDEVOPS_DISPATCH_MODEL="$selected_model"
 	)
+	_dlw_append_node_tool_env "$repo_path"
 	_dlw_append_trusted_release_env
 	_dlw_append_worktree_transfer_env
 	if _dlw_min_worker_floor_active; then
@@ -1933,6 +1938,36 @@ _dlw_nohup_launch() {
 	fi
 
 	_dlw_exec_detached "$worker_log" "$issue_number" "${worker_cmd[@]}"
+	return 0
+}
+
+#######################################
+# Transition a durably registered live worker from queued to in-progress.
+#
+# Args: issue_number, repo_slug, self_login, worker_pid
+# Returns: 0=transition confirmed by mutation command, 1=worker/status unavailable
+#######################################
+_dlw_mark_worker_in_progress() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="$3"
+	local worker_pid="$4"
+
+	[[ "$worker_pid" =~ ^[0-9]+$ ]] || return 1
+	if ! kill -0 "$worker_pid" 2>/dev/null; then
+		echo "[dispatch_with_dedup] Worker registration for #${issue_number} has non-live PID ${worker_pid}; retaining status:queued for recovery" >>"$LOGFILE"
+		return 1
+	fi
+	if ! declare -F set_issue_status >/dev/null 2>&1; then
+		echo "[dispatch_with_dedup] Cannot transition #${issue_number} to status:in-progress: status helper unavailable" >>"$LOGFILE"
+		return 1
+	fi
+	if ! set_issue_status "$issue_number" "$repo_slug" "in-progress" \
+		--add-assignee "$self_login" >/dev/null 2>&1; then
+		echo "[dispatch_with_dedup] Failed to transition registered worker #${issue_number} to status:in-progress; retaining queued recovery signal" >>"$LOGFILE"
+		return 1
+	fi
+	echo "[dispatch_with_dedup] Registered live worker PID ${worker_pid} for #${issue_number}; transitioned status:queued to status:in-progress" >>"$LOGFILE"
 	return 0
 }
 
@@ -1980,13 +2015,23 @@ _dlw_post_launch_hooks() {
 
 	# Record in dispatch ledger (with tier telemetry)
 	local ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
+	local ledger_registered=0
 	if [[ -x "$ledger_helper" ]]; then
-		"$ledger_helper" register --session-key "$session_key" \
+		if "$ledger_helper" register --session-key "$session_key" \
 			--issue "$issue_number" --repo "$repo_slug" \
 			--pid "$worker_pid" --tier "$dispatch_tier" \
 			--model "$selected_model" --lease-token "${_claim_lease_token:-}" \
 			--attempt-id "$attempt_id" \
-			--device-id "${_claim_lease_device:-}" --worktree "$worker_worktree_path" 2>/dev/null || true
+			--device-id "${_claim_lease_device:-}" --worktree "$worker_worktree_path" 2>/dev/null; then
+			ledger_registered=1
+		else
+			echo "[dispatch_with_dedup] Failed to register worker PID ${worker_pid} for #${issue_number}; retaining status:queued for recovery" >>"$LOGFILE"
+		fi
+	else
+		echo "[dispatch_with_dedup] Dispatch ledger helper unavailable for #${issue_number}; retaining status:queued for recovery" >>"$LOGFILE"
+	fi
+	if [[ "$ledger_registered" -eq 1 ]]; then
+		_dlw_mark_worker_in_progress "$issue_number" "$repo_slug" "$self_login" "$worker_pid" || true
 	fi
 
 	local dispatch_comment_body

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -371,6 +371,11 @@ _ci_actionable_failed_checks_markdown() {
 		link=$(printf '%s' "$checks_json" | jq -r --argjson i "$idx" '.[$i].link // empty' 2>/dev/null) || link=""
 		if _ci_check_url_has_infra_failure_log "$repo_slug" "$link"; then
 			echo "[pulse-wrapper] _dispatch_ci_fix_worker: PR #${pr_number} check '${name}' classified as infrastructure failure from failed log — skipping code redispatch" >>"$LOGFILE"
+			if ! declare -F _pmrc_rerun_infrastructure_check >/dev/null 2>&1; then
+				echo "[pulse-wrapper] _dispatch_ci_fix_worker: bounded infrastructure rerun helper unavailable for PR #${pr_number} check '${name}' — preserving PR for a later merge pass" >>"$LOGFILE"
+			elif ! _pmrc_rerun_infrastructure_check "$repo_slug" "$pr_number" "$name" "$link"; then
+				echo "[pulse-wrapper] _dispatch_ci_fix_worker: bounded infrastructure rerun unavailable for PR #${pr_number} check '${name}' — preserving PR for a later merge pass" >>"$LOGFILE"
+			fi
 		else
 			printf -- '- **%s**: %s — [check URL](%s)\n' "$name" "$conclusion" "$link"
 		fi
@@ -497,11 +502,13 @@ _dispatch_ci_fix_worker() {
 
 	local fallback_reason=""
 	if [[ -z "$pr_head_sha" || -z "$pr_head_ref" ]]; then
-		fallback_reason="current PR head branch metadata is unavailable"
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: current branch metadata unavailable for PR #${pr_number} in ${repo_slug} — preserving PR for a later repair pass" >>"$LOGFILE"
+		return 0
 	elif [[ "$is_cross_repo" == "true" ]]; then
 		fallback_reason="the PR head is in a fork and is not an owned repair branch"
 	elif ! declare -F _pulse_merge_repo_path_for_slug >/dev/null 2>&1; then
-		fallback_reason="the repository-path resolver is unavailable"
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: repository-path resolver unavailable for PR #${pr_number} in ${repo_slug} — preserving PR for a later repair pass" >>"$LOGFILE"
+		return 0
 	elif _dispatch_ci_repair_session "$pr_number" "$repo_slug" "$linked_issue" \
 		"$pr_head_sha" "$pr_head_ref" "$failure_fingerprint" "$failing_checks"; then
 		if [[ "${_CI_REPAIR_DISPATCH_RESULT:-}" == "active" ]]; then
@@ -513,9 +520,11 @@ _dispatch_ci_fix_worker() {
 	elif [[ "${_CI_REPAIR_DISPATCH_RESULT:-}" == "exhausted" ]]; then
 		fallback_reason="the bounded PR-branch repair session exhausted its retry budget"
 	else
-		fallback_reason="the bounded PR-branch repair session could not be launched"
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: retryable in-place repair launch failure for PR #${pr_number} head ${pr_head_sha} in ${repo_slug} (result=${_CI_REPAIR_DISPATCH_RESULT:-unknown}) — preserving PR for a later bounded attempt" >>"$LOGFILE"
+		return 0
 	fi
 
+	echo "[pulse-wrapper] _dispatch_ci_fix_worker: durable fallback authorized for PR #${pr_number} in ${repo_slug}: ${fallback_reason}" >>"$LOGFILE"
 	_route_ci_repair_fallback "$pr_number" "$repo_slug" "$linked_issue" "$pr_head_sha" \
 		"$pr_head_ref" "$failure_fingerprint" "$fallback_reason" "$feedback_section" "$failing_checks"
 	return 0
@@ -718,6 +727,11 @@ _ci_repair_result_active() {
 
 _ci_repair_result_exhausted() {
 	printf 'exhausted'
+	return 0
+}
+
+_ci_repair_result_retryable() {
+	printf 'retryable'
 	return 0
 }
 
@@ -1173,11 +1187,13 @@ _dispatch_ci_repair_session() {
 	local launch_payload=""
 	local active_result=""
 	local exhausted_result=""
+	local retryable_result=""
 	local dispatched_status=""
-	_CI_REPAIR_DISPATCH_RESULT="failed"
 	active_result=$(_ci_repair_result_active)
 	exhausted_result=$(_ci_repair_result_exhausted)
+	retryable_result=$(_ci_repair_result_retryable)
 	dispatched_status=$(_ci_repair_status_dispatched)
+	_CI_REPAIR_DISPATCH_RESULT="$retryable_result"
 
 	repo_path=$(_pulse_merge_repo_path_for_slug "$repo_slug" 2>/dev/null) || repo_path=""
 	helper="${AIDEVOPS_HEADLESS_RUNTIME_HELPER:-${_PULSE_MERGE_DIR:-${BASH_SOURCE[0]%/*}}/headless-runtime-helper.sh}"

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -449,6 +449,31 @@ _create_orphan_recovery_pr() {
 }
 
 #######################################
+# Resolve the authoritative issue number for worker recovery metadata.
+#
+# The explicit worker contract wins. Session-key fallback is deliberately
+# limited to canonical `issue-N` keys because manual/validation session keys
+# can end in timestamps that are not GitHub issue numbers.
+#
+# Args: $1=session key
+# Outputs: issue number, or empty when identity is ambiguous
+#######################################
+_scl_worker_issue_number() {
+	local session_key="$1"
+
+	if [[ "${WORKER_ISSUE_NUMBER:-}" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$WORKER_ISSUE_NUMBER"
+		return 0
+	fi
+	if [[ "$session_key" =~ ^issue-([0-9]+)$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+
+	return 0
+}
+
+#######################################
 # _attempt_orphan_recovery_pr — auto-recover a worker_branch_orphan (GH#20819)
 #
 # Called when a worker pushed a branch but exited without opening a PR.
@@ -469,7 +494,8 @@ _create_orphan_recovery_pr() {
 # worktree misclassifications so the recovery helper does not uselessly try to
 # create a duplicate PR or release the claim as worker_branch_orphan.
 #
-# On success: returns 0 (caller releases as worker_complete)
+# On success: returns 0 (caller records ready recovery as complete, or a draft
+# checkpoint as preserved/deferred according to recovery_mode)
 # On failure: returns 1 (caller releases as worker_branch_orphan)
 #
 # Args:
@@ -495,10 +521,12 @@ _attempt_orphan_recovery_pr() {
 		return 1
 	fi
 
-	# Derive issue number before branch guards so the existing-PR probe can
+	# Resolve issue identity before branch guards so the existing-PR probe can
 	# fall back to issue search when a cleaned worktree leaves branch_name empty.
+	# Never interpret arbitrary trailing digits as an issue: manual session keys
+	# commonly end in timestamps (GH#28437).
 	local issue_number=""
-	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
+	issue_number=$(_scl_worker_issue_number "$session_key")
 
 	# Pre-check (t3195/GH#21889): if a PR already exists for this branch
 	# (or issue), no recovery is needed. Caller releases as worker_complete.

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -8,6 +8,7 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="${TEST_DIR}/.."
 CLAIM="${SCRIPTS_DIR}/dispatch-claim-helper.sh"
 LEDGER="${SCRIPTS_DIR}/dispatch-ledger-helper.sh"
+DEDUP="${SCRIPTS_DIR}/dispatch-dedup-helper.sh"
 SCRIPT_DIR="$SCRIPTS_DIR"
 # shellcheck source=../dispatch-dedup-stale.sh
 source "${SCRIPTS_DIR}/dispatch-dedup-stale.sh"
@@ -41,11 +42,14 @@ fi
 [[ "$endpoint" == repos/*/issues/*/comments* ]] || exit 1
 method=GET
 body=""
+jq_expr=""
+slurp_output=0
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	--method) method="$2"; shift 2 ;;
 	--field) [[ "$2" == body=* ]] && body="${2#body=}"; shift 2 ;;
-	--jq) shift 2 ;;
+	--jq) jq_expr="$2"; shift 2 ;;
+	--slurp) slurp_output=1; shift ;;
 	*) shift ;;
 	esac
 done
@@ -61,7 +65,17 @@ if [[ "$method" == POST ]]; then
 	printf '%s\n' "$id"
 	exit 0
 fi
-jq -sc '[.]' "$comments"
+comments_json=$(jq -sc '.' "$comments")
+if [[ -n "$jq_expr" ]]; then
+	printf '%s' "$comments_json" | jq -c "$jq_expr"
+	return_code=$?
+	exit "$return_code"
+fi
+if [[ "$slurp_output" -eq 1 ]]; then
+	printf '[%s]\n' "$comments_json"
+	exit 0
+fi
+printf '%s\n' "$comments_json"
 MOCK
 	chmod +x "$root/bin/gh"
 	return 0
@@ -146,6 +160,9 @@ test_launch_crash_ready_terminal_race() {
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
 		"$CLAIM" transition ready 44 owner/repo "$token" issue-44 30
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null || fail "ready lease not protected"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		gh api repos/owner/repo/issues/44/comments --method POST \
+		--field body="Dispatching worker (deterministic)." >/dev/null
 	local old_created=""
 	old_created=$(python3 - <<'PY'
 from datetime import datetime, timedelta, timezone
@@ -170,9 +187,12 @@ PY
 		gh api repos/owner/repo/issues/44/comments --method POST --field body="$forged_body" >/dev/null
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null \
 		|| fail "device-mismatched transition terminated ready lease"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
+		"$DEDUP" has-dispatch-comment 44 owner/repo shared-login >/dev/null \
+		|| fail "forged terminal lease released dispatch-comment dedup"
 	pass "remote transitions require claim author device and session"
 	local dispatch_ts=""
-	dispatch_ts=$(jq -sr '[.[] | select(.body | contains("session=issue-44 phase=prelaunch"))] | first.created_at' "$root/state/comments.jsonl")
+	dispatch_ts=$(jq -sr '[.[] | select(.body | contains("Dispatching worker"))] | first.created_at' "$root/state/comments.jsonl")
 	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" _stale_recovery_final_evidence_recheck 44 owner/repo "$dispatch_ts"; then
 		fail "stale recovery ignored active ready lease"
 	fi
@@ -191,6 +211,10 @@ PY
 	fi
 	if ! PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" _stale_recovery_final_evidence_recheck 44 owner/repo "$dispatch_ts"; then
 		fail "terminal did not cancel ready for stale recovery"
+	fi
+	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
+		"$DEDUP" has-dispatch-comment 44 owner/repo shared-login >/dev/null 2>&1; then
+		fail "matching terminal lease did not release dispatch-comment dedup"
 	fi
 	pass "terminal transition defeats concurrent or late ready"
 	return 0

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -28,8 +28,11 @@ create_mock_gh() {
 set -euo pipefail
 state="${MOCK_GH_STATE:?}"
 comments="$state/comments.jsonl"
+calls="$state/calls.log"
 mkdir -p "$state"
 touch "$comments"
+touch "$calls"
+printf '%s\n' "$*" >>"$calls"
 if [[ "${1:-}" == api && "${2:-}" == user ]]; then printf 'shared-login\n'; exit 0; fi
 if [[ "${1:-}" == issue && "${2:-}" == comment ]]; then exit 0; fi
 [[ "${1:-}" == api ]] || exit 1
@@ -60,7 +63,8 @@ if [[ "$method" == POST ]]; then
 	created=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	jq -cn --argjson id "$id" --arg body "$body" --arg created "$created" \
 		--arg login "${MOCK_GH_LOGIN:-shared-login}" \
-		'{id:$id,body:$body,created_at:$created,user:{login:$login},author_association:"MEMBER"}' >>"$comments"
+		--arg association "${MOCK_GH_ASSOCIATION:-MEMBER}" \
+		'{id:$id,body:$body,created_at:$created,user:{login:$login},author_association:$association}' >>"$comments"
 	rmdir "$lock"
 	printf '%s\n' "$id"
 	exit 0
@@ -141,6 +145,7 @@ test_concurrent_same_login_devices() {
 
 test_launch_crash_ready_terminal_race() {
 	local root="${TMP_DIR}/lifecycle" token="" terminal_rc=0 ready_rc=0
+	local forged_token="forged-token" forged_body="" forged_claim="" forged_expires_at=""
 	create_mock_gh "$root"
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
 		DISPATCH_CLAIM_WINDOW=0 DISPATCH_CLAIM_ORPHAN_GRACE=1 \
@@ -160,6 +165,10 @@ test_launch_crash_ready_terminal_race() {
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
 		"$CLAIM" transition ready 44 owner/repo "$token" issue-44 30
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null || fail "ready lease not protected"
+	forged_expires_at=$(($(date -u '+%s') + 600))
+	forged_claim="DISPATCH_CLAIM nonce=${forged_token} runner=attacker ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) max_age_s=600 version=test phase=prelaunch lease_token=${forged_token} device=attacker-device session=issue-44 expires_at=${forged_expires_at}"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=attacker MOCK_GH_ASSOCIATION=NONE \
+		gh api repos/owner/repo/issues/44/comments --method POST --field body="$forged_claim" >/dev/null
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
 		gh api repos/owner/repo/issues/44/comments --method POST \
 		--field body="Dispatching worker (deterministic)." >/dev/null
@@ -176,9 +185,8 @@ PY
 		|| fail "ready lease older than legacy max age was dropped"
 	pass "ready lease survives legacy max age until explicit expiry"
 
-	local forged_body=""
 	forged_body="DISPATCH_LEASE phase=terminal lease_token=${token} device=device-a session=issue-44 expires_at=0 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=attacker \
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=attacker MOCK_GH_ASSOCIATION=NONE \
 		gh api repos/owner/repo/issues/44/comments --method POST --field body="$forged_body" >/dev/null
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null \
 		|| fail "untrusted commenter terminated ready lease"
@@ -187,16 +195,29 @@ PY
 		gh api repos/owner/repo/issues/44/comments --method POST --field body="$forged_body" >/dev/null
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" "$CLAIM" check 44 owner/repo >/dev/null \
 		|| fail "device-mismatched transition terminated ready lease"
+	forged_body="DISPATCH_LEASE phase=terminal lease_token=${forged_token} device=attacker-device session=issue-44 expires_at=0 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=attacker MOCK_GH_ASSOCIATION=NONE \
+		gh api repos/owner/repo/issues/44/comments --method POST --field body="$forged_body" >/dev/null
+	: >"$root/state/calls.log"
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
 		"$DEDUP" has-dispatch-comment 44 owner/repo shared-login >/dev/null \
-		|| fail "forged terminal lease released dispatch-comment dedup"
-	pass "remote transitions require claim author device and session"
+		|| fail "forged claim identity released dispatch-comment dedup"
+	grep -Fq 'api repos/owner/repo/issues/44/comments?per_page=100 --paginate --slurp' "$root/state/calls.log" \
+		|| fail "dispatch-comment reconciliation did not fetch every comment page"
+	pass "remote transitions require trusted dispatch claim author device and session"
 	local dispatch_ts=""
 	dispatch_ts=$(jq -sr '[.[] | select(.body | contains("Dispatching worker"))] | first.created_at' "$root/state/comments.jsonl")
 	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" _stale_recovery_final_evidence_recheck 44 owner/repo "$dispatch_ts"; then
 		fail "stale recovery ignored active ready lease"
 	fi
 	pass "ready transition protects active worker"
+	sleep 1
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=attacker MOCK_GH_ASSOCIATION=NONE \
+		gh api repos/owner/repo/issues/44/comments --method POST --field body="TASK_COMPLETE forged" >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
+		"$DEDUP" has-dispatch-comment 44 owner/repo shared-login >/dev/null \
+		|| fail "untrusted completion identity released dispatch-comment dedup"
+	pass "dispatch dedup ignores untrusted completion identities"
 
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
 		"$CLAIM" transition terminal 44 owner/repo "$token" issue-44 0 >/dev/null 2>&1 &
@@ -217,6 +238,32 @@ PY
 		fail "matching terminal lease did not release dispatch-comment dedup"
 	fi
 	pass "terminal transition defeats concurrent or late ready"
+	return 0
+}
+
+test_untrusted_dispatch_identity_cannot_replace_active_lock() {
+	local root="${TMP_DIR}/forged-dispatch" expires_at="" trusted_claim="" forged_claim="" forged_terminal=""
+	create_mock_gh "$root"
+	expires_at=$(($(date -u '+%s') + 600))
+	trusted_claim="DISPATCH_CLAIM nonce=trusted-token runner=shared-login ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) max_age_s=600 version=test lease_token=trusted-token device=device-a session=issue-48 phase=prelaunch expires_at=${expires_at}"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		gh api repos/owner/repo/issues/48/comments --method POST --field body="$trusted_claim" >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		gh api repos/owner/repo/issues/48/comments --method POST \
+		--field body="Dispatching worker (deterministic)." >/dev/null
+	forged_claim="DISPATCH_CLAIM nonce=forged-token runner=attacker ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) max_age_s=600 version=test lease_token=forged-token device=attacker-device session=issue-48 phase=prelaunch expires_at=${expires_at}"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=attacker MOCK_GH_ASSOCIATION=NONE \
+		gh api repos/owner/repo/issues/48/comments --method POST --field body="$forged_claim" >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=attacker MOCK_GH_ASSOCIATION=NONE \
+		gh api repos/owner/repo/issues/48/comments --method POST \
+		--field body="Dispatching worker (forged)." >/dev/null
+	forged_terminal="DISPATCH_LEASE phase=terminal lease_token=forged-token device=attacker-device session=issue-48 expires_at=0 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" MOCK_GH_LOGIN=attacker MOCK_GH_ASSOCIATION=NONE \
+		gh api repos/owner/repo/issues/48/comments --method POST --field body="$forged_terminal" >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
+		"$DEDUP" has-dispatch-comment 48 owner/repo shared-login >/dev/null \
+		|| fail "untrusted dispatch identity replaced active dispatch-comment dedup"
+	pass "untrusted dispatch identity cannot replace an active dispatch lock"
 	return 0
 }
 
@@ -272,6 +319,7 @@ test_invalid_device_not_public() {
 test_local_ledger_guards
 test_concurrent_same_login_devices
 test_launch_crash_ready_terminal_race
+test_untrusted_dispatch_identity_cannot_replace_active_lock
 test_prelaunch_renewal_covers_slow_startup
 test_invalid_device_not_public
 test_takeover_recheck_precedes_mutation

--- a/.agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh
@@ -26,7 +26,8 @@
 #   3. `_issue_needs_consolidation` accepts an optional pre-fetched JSON
 #      argument and skips the gh call when it's provided.
 #   4. `_issue_targets_large_files` accepts an optional pre-fetched JSON
-#      argument and skips both its labels AND title gh calls when provided.
+#      argument, reuses its title and ordinary labels, and refreshes only a
+#      volatile positive `needs-simplification` gate before blocking dispatch.
 #   5. `_ensure_issue_body_has_brief` accepts an optional pre-fetched JSON
 #      argument and skips the gh call when it's provided.
 #   6. The total `gh issue view` count inside `_dispatch_dedup_check_layers`
@@ -191,28 +192,44 @@ test_issue_needs_consolidation_accepts_meta() {
 
 # ---------------------------------------------------------------------------
 # Test 5: _issue_targets_large_files accepts optional pre_fetched_json
-# (param 6) and skips BOTH labels AND title gh calls when provided.
+# (param 6), derives ordinary labels/title from it, and scopes the correctness-
+# sensitive fresh read to a prefetched `needs-simplification` label.
 # ---------------------------------------------------------------------------
 test_issue_targets_large_files_accepts_meta() {
-	local body
+	local body title_body labels_body
 	body=$(_extract_function_body "$LARGE_FILE_GATE_SH" "_issue_targets_large_files")
+	title_body=$(_extract_function_body "$LARGE_FILE_GATE_SH" "_large_file_gate_issue_title")
+	labels_body=$(_extract_function_body "$LARGE_FILE_GATE_SH" "_large_file_gate_issue_labels")
 	local ok=1
 	if ! printf '%s' "$body" | grep -qE 'pre_fetched_json="\$\{6:-\}"'; then
 		ok=0
 	fi
-	# Must extract labels from JSON when bundle is present.
-	if ! printf '%s' "$body" | grep -qE 'jq -r .*\.labels\[\]\.name'; then
+	# The labels helper must extract from JSON and receive the same bundle.
+	# shellcheck disable=SC2016 # Static source assertion intentionally matches literal variable names.
+	if ! printf '%s' "$labels_body" | grep -qE 'jq -r .*\.labels\[\]\.name' \
+		|| ! printf '%s' "$body" | grep -qF '_large_file_gate_issue_labels "$issue_number" "$repo_slug" "$pre_fetched_json"'; then
 		ok=0
 	fi
-	# Must extract title from JSON when bundle is present.
-	if ! printf '%s' "$body" | grep -qE 'jq -r .*\.title'; then
+	# The title helper must extract from JSON and receive the same bundle.
+	# Static source assertion intentionally matches literal variable names.
+	# shellcheck disable=SC2016
+	if ! printf '%s' "$title_body" | grep -qE 'jq -r .*\.title' \
+		|| ! printf '%s' "$body" | grep -qF '_large_file_gate_issue_title "$issue_number" "$repo_slug" "$pre_fetched_json"'; then
+		ok=0
+	fi
+	# A positive blocking label is volatile across triage/dispatch stages and
+	# therefore must be freshly revalidated before the early-return gate.
+	# Static source assertion intentionally matches literal variable names.
+	# shellcheck disable=SC2016
+	if ! printf '%s' "$labels_body" | grep -qF 'if [[ ",$issue_labels," == *",needs-simplification,"* ]]' \
+		|| ! printf '%s' "$labels_body" | grep -qE 'fresh_issue_labels=.*gh_issue_view'; then
 		ok=0
 	fi
 	if [[ "$ok" -eq 1 ]]; then
-		_print_result "_issue_targets_large_files accepts pre_fetched_json (param 6) + JSON-derives labels & title" 1
+		_print_result "_issue_targets_large_files reuses prefetched metadata and refreshes volatile gate state" 1
 	else
-		_print_result "_issue_targets_large_files accepts pre_fetched_json (param 6) + JSON-derives labels & title" 0 \
-			"expected 'local pre_fetched_json=\"\${6:-}\"' + jq labels + jq title inside the body"
+		_print_result "_issue_targets_large_files reuses prefetched metadata and refreshes volatile gate state" 0 \
+			"expected param-6 metadata reuse plus a scoped fresh read for needs-simplification"
 	fi
 }
 

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -4066,6 +4066,50 @@ test_attempt_orphan_recovery_pr_calls_gh_create() {
 	return 0
 }
 
+test_attempt_orphan_recovery_pr_uses_authoritative_worker_issue() {
+	local work_dir="${TEST_ROOT}/repo-orphan-recovery-authoritative-issue"
+	_setup_test_git_repo "$work_dir" 1
+	git -C "$work_dir" push -q origin "feature/auto-test-issue-99999"
+	local WORKER_ISSUE_NUMBER="28313"
+	local gh_title="" gh_body="" gh_called=0 _last_flag=""
+
+	gh() {
+		local arg=""
+		for arg in "$@"; do
+			case "$_last_flag" in
+			"--title") gh_title="$arg" ;;
+			"--body") gh_body="$arg" ;;
+			esac
+			_last_flag="$arg"
+		done
+		if [[ "${*}" == *"pr list"* ]]; then
+			printf '0'
+		elif [[ "${*}" == *"issue view"* ]]; then
+			printf 'OPEN'
+		elif [[ "${*}" == *"repo view"* ]]; then
+			printf 'main'
+		elif [[ "${*}" == *"pr create"* ]]; then
+			gh_called=1
+		fi
+		return 0
+	}
+
+	_attempt_orphan_recovery_pr \
+		"manual-cli-28313-1784593858" "$work_dir" \
+		"feature/auto-test-issue-99999" "test-owner/test-repo" "draft"
+	unset -f gh 2>/dev/null || true
+
+	if [[ "$gh_called" -eq 1 && "$gh_title" == *"#28313"* && \
+		"$gh_body" == *"Resolves #28313"* && \
+		"$gh_title" != *"1784593858"* && "$gh_body" != *"#1784593858"* ]]; then
+		print_result "orphan recovery prefers authoritative worker issue over session timestamp" 0
+	else
+		print_result "orphan recovery prefers authoritative worker issue over session timestamp" 1 \
+			"called=${gh_called} title=${gh_title:-<empty>} body=${gh_body:-<empty>}"
+	fi
+	return 0
+}
+
 test_ensure_orphan_recovery_rejects_empty_branch() {
 	local work_dir="${TEST_ROOT}/repo-orphan-recovery-empty-branch"
 	_setup_test_git_repo "$work_dir" 1
@@ -4681,6 +4725,85 @@ test_failed_worker_draft_checkpoint_escalates_without_completion() {
 	return 0
 }
 
+test_dirty_worktree_checkpoint_is_deferred_not_complete() {
+	local result=""
+	result=$(
+		(
+			DISPATCH_REPO_SLUG="test-owner/test-repo"
+			WORKER_ISSUE_NUMBER="28313"
+			_HRW_TERMINAL_OUTCOME="unset"
+			_HRW_FINAL_RUNTIME_EVENT="unset"
+			_HRW_FINAL_RUNTIME_STATUS="unset"
+			_HRW_FINAL_RUNTIME_CLASSIFICATION="unset"
+			_HRW_RECOVERY_CLASSIFICATION=""
+			git() {
+				if [[ "${*}" == *"rev-parse --abbrev-ref HEAD"* ]]; then
+					printf 'feature/auto-test-issue-28313'
+				elif [[ "${*}" == *"status --short"* ]]; then
+					printf ' M changed-file.txt\n'
+				fi
+				return 0
+			}
+			runner_identity_key() { printf 'runner-fixture'; return 0; }
+			_push_wip_commits_on_exit() { return 0; }
+			_recover_dirty_worker_pr() { return 0; }
+			_release_dispatch_claim() { printf 'release=%s\n' "$2"; return 0; }
+
+			_handle_worker_dirty_worktree "manual-cli-28313-1784593858" "$TEST_ROOT"
+			printf 'terminal=%s|event=%s|status=%s|classification=%s|recovery=%s\n' \
+				"$_HRW_TERMINAL_OUTCOME" "$_HRW_FINAL_RUNTIME_EVENT" \
+				"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION" \
+				"$_HRW_RECOVERY_CLASSIFICATION"
+		)
+	)
+
+	if [[ "$result" == *"release=worker_draft_checkpoint"* && \
+		"$result" == *"terminal=deferred|event=worker.deferred|status=checkpointed|classification=worker_draft_checkpoint|recovery=worker_draft_checkpoint"* && \
+		"$result" != *"release=worker_complete"* ]]; then
+		print_result "dirty-worktree checkpoint is deferred preserved progress, never completion" 0
+	else
+		print_result "dirty-worktree checkpoint is deferred preserved progress, never completion" 1 "$result"
+	fi
+	return 0
+}
+
+test_exit_trap_dirty_checkpoint_is_deferred_not_complete() {
+	local result=""
+	result=$(
+		(
+			_WORKER_DIRTY_WORK_PRESERVED=1
+			_push_wip_commits_on_exit() { return 0; }
+			_recover_dirty_worker_pr() { return 0; }
+			_emit_worker_runtime_event() {
+				printf 'event=%s|status=%s|classification=%s\n' "$1" "$2" "$3"
+				return 0
+			}
+			_hrw_record_terminal_outcome() {
+				printf 'terminal=%s|reason=%s\n' "$2" "$3"
+				return 0
+			}
+			_cleanup_headless_runtime_temp_paths() { return 0; }
+			_release_dispatch_claim() { printf 'release=%s\n' "$2"; return 0; }
+			_release_session_lock() { return 0; }
+			_update_dispatch_ledger() { return 0; }
+			aidevops_runtime_bundle_lease_release() { return 0; }
+
+			_hrff_finalize_exit_trap "manual-cli-28313-1784593858" \
+				"process_exit" "1" "0" "0"
+		)
+	)
+
+	if [[ "$result" == *"event=worker.deferred|status=checkpointed|classification=worker_draft_checkpoint"* && \
+		"$result" == *"terminal=deferred|reason=worker_draft_checkpoint"* && \
+		"$result" == *"release=worker_draft_checkpoint"* && \
+		"$result" != *"worker_complete"* ]]; then
+		print_result "exit-trap dirty checkpoint emits deferred preserved progress, never completion" 0
+	else
+		print_result "exit-trap dirty checkpoint emits deferred preserved progress, never completion" 1 "$result"
+	fi
+	return 0
+}
+
 test_failed_worker_draft_retains_claim_when_block_not_visible() {
 	local result=""
 	result=$(
@@ -4904,6 +5027,8 @@ test_pr_checkpoint_lifecycle_cases() {
 	test_post_pr_handoff_treats_ci_as_monitoring_state
 	test_post_pr_handoff_rejects_mismatched_head_or_missing_summary
 	test_failed_worker_draft_checkpoint_escalates_without_completion
+	test_dirty_worktree_checkpoint_is_deferred_not_complete
+	test_exit_trap_dirty_checkpoint_is_deferred_not_complete
 	test_failed_worker_draft_retains_claim_when_block_not_visible
 	test_protected_draft_is_not_mutated_or_completed
 	test_checkpoint_terminal_telemetry_is_failed_escalated
@@ -4965,6 +5090,7 @@ run_worker_finish_tests() {
 	test_reconciled_outcome_persistence_retries
 	test_cmd_run_finish_emits_complete_when_no_workdir
 	test_attempt_orphan_recovery_pr_calls_gh_create
+	test_attempt_orphan_recovery_pr_uses_authoritative_worker_issue
 	test_ensure_orphan_recovery_rejects_empty_branch
 	test_build_orphan_recovery_pr_body_tolerates_missing_publish_flag
 	test_cmd_run_finish_orphan_recovery_success_emits_worker_complete

--- a/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
+++ b/.agents/scripts/tests/test-headless-runtime-release-unlock.sh
@@ -68,6 +68,18 @@ gh() {
 			prev="$arg"
 		done
 		printf 'API method=%s path=%s body=%s\n' "$method" "$path" "$body" >>"$CALL_LOG"
+		if [[ "$path" == */comments && "$method" == "POST" ]]; then
+			local attempt_count=0
+			if [[ -f "${TMP_HOME}/comment-attempts" ]]; then
+				attempt_count=$(<"${TMP_HOME}/comment-attempts")
+			fi
+			attempt_count=$((attempt_count + 1))
+			printf '%s\n' "$attempt_count" >"${TMP_HOME}/comment-attempts"
+			if [[ "$attempt_count" -le "${GH_COMMENT_FAILURES_BEFORE_SUCCESS:-0}" ]]; then
+				printf 'temporary comment failure %s\n' "$attempt_count" >&2
+				return 1
+			fi
+		fi
 		printf '{}\n'
 		;;
 	issue)
@@ -128,6 +140,40 @@ if grep -q 'CLAIM_RELEASED reason=worker_noop' "$CALL_LOG" &&
 	printf 'PASS release posts claim, clears assigned GitHub login, and unlocks issue\n'
 else
 	printf 'FAIL release lifecycle missing expected calls\n'
+	sed 's/^/  /' "$CALL_LOG"
+	exit 1
+fi
+
+: >"$CALL_LOG"
+rm -f "${TMP_HOME}/comment-attempts"
+if GH_COMMENT_FAILURES_BEFORE_SUCCESS=2 AIDEVOPS_CLAIM_RELEASE_POST_ATTEMPTS=3 \
+	AIDEVOPS_CLAIM_RELEASE_POST_RETRY_DELAY=0 \
+	_release_dispatch_claim "issue-12345" "worker_noop" "0" "0" && \
+	[[ "$(<"${TMP_HOME}/comment-attempts")" == "3" ]] && \
+	grep -q 'CLEAR issue=12345 repo=owner/repo runner=assigned-bot' "$CALL_LOG" && \
+	grep -q 'UNLOCK issue=12345 repo=owner/repo' "$CALL_LOG"; then
+	printf 'PASS release comment retries transient persistence failures\n'
+else
+	printf 'FAIL release comment did not retry transient persistence failures\n'
+	sed 's/^/  /' "$CALL_LOG"
+	exit 1
+fi
+
+: >"$CALL_LOG"
+rm -f "${TMP_HOME}/comment-attempts"
+if GH_COMMENT_FAILURES_BEFORE_SUCCESS=5 AIDEVOPS_CLAIM_RELEASE_POST_ATTEMPTS=2 \
+	AIDEVOPS_CLAIM_RELEASE_POST_RETRY_DELAY=0 \
+	_release_dispatch_claim "issue-12345" "worker_noop" "0" "0"; then
+	printf 'FAIL exhausted release comment persistence was reported as successful\n'
+	sed 's/^/  /' "$CALL_LOG"
+	exit 1
+fi
+if [[ "$(<"${TMP_HOME}/comment-attempts")" == "2" ]] && \
+	grep -q 'WARN Failed to post CLAIM_RELEASED on #12345 after 2 attempt(s)' "$CALL_LOG" && \
+	! grep -q '^CLEAR ' "$CALL_LOG" && ! grep -q '^UNLOCK ' "$CALL_LOG"; then
+	printf 'PASS exhausted release comment persistence is surfaced and remains retryable\n'
+else
+	printf 'FAIL exhausted release comment persistence was not surfaced safely\n'
 	sed 's/^/  /' "$CALL_LOG"
 	exit 1
 fi

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
@@ -127,8 +127,58 @@ if [[ "$sparse_context" != *"attempt_id: attempt-sparse"* || \
 	fail "sparse retry disposition shifted empty machine fields: ${sparse_context}"
 fi
 
+LEDGER_CALLS_FILE="${TEST_TMP}/ledger-calls"
+export LEDGER_CALLS_FILE
+cat >"${TEST_TMP}/dispatch-ledger-helper.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${LEDGER_CALLS_FILE:?}"
+exit "${TEST_LEDGER_RC:-0}"
+EOF
+chmod +x "${TEST_TMP}/dispatch-ledger-helper.sh" || fail "failed to make dispatch ledger stub executable"
+
+STATUS_MUTATIONS=""
+set_issue_status() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local status_name="$3"
+	shift 3
+	STATUS_MUTATIONS="${issue_number}|${repo_slug}|${status_name}|$*"
+	return 0
+}
+
+original_script_dir="$SCRIPT_DIR"
+SCRIPT_DIR="$TEST_TMP"
+_claim_comment_id=""
+PULSE_DISPATCH_STAGGER_SECONDS=0
+export TEST_LEDGER_RC=0
+LOGFILE="${TEST_TMP}/pulse.log" _dlw_post_launch_hooks \
+	"123" "owner/repo" "runner-a" "$$" "issue-123" "standard" "test-model" "${TEST_TMP}/worktree" "attempt-123"
+if [[ "$STATUS_MUTATIONS" != "123|owner/repo|in-progress|--add-assignee runner-a" ]]; then
+	fail "successful worker registration did not transition queued issue to in-progress: ${STATUS_MUTATIONS:-none}"
+fi
+
+STATUS_MUTATIONS=""
+export TEST_LEDGER_RC=1
+LOGFILE="${TEST_TMP}/pulse.log" _dlw_post_launch_hooks \
+	"123" "owner/repo" "runner-a" "$$" "issue-123-failed" "standard" "test-model" "${TEST_TMP}/worktree" "attempt-124"
+if [[ -n "$STATUS_MUTATIONS" ]]; then
+	fail "failed worker registration transitioned issue lifecycle: ${STATUS_MUTATIONS}"
+fi
+
+STATUS_MUTATIONS=""
+if LOGFILE="${TEST_TMP}/pulse.log" _dlw_mark_worker_in_progress \
+	"123" "owner/repo" "runner-a" "2147483647"; then
+	fail "dead worker PID transitioned issue lifecycle"
+fi
+if [[ -n "$STATUS_MUTATIONS" ]]; then
+	fail "dead worker PID emitted status mutation: ${STATUS_MUTATIONS}"
+fi
+SCRIPT_DIR="$original_script_dir"
+
 printf 'PASS: dispatch prompt reuses comment metrics for zero-output fallback\n'
 printf 'PASS: zero-output evidence detection uses one shared pattern\n'
 printf 'PASS: invalid clean-room snapshots cannot authorize implementation\n'
 printf 'PASS: retry context is bounded, deterministic, and excludes prior prose\n'
+printf 'PASS: registered live workers transition queued issues to in-progress\n'
+printf 'PASS: failed registrations and dead workers preserve queued lifecycle state\n'
 exit 0

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
@@ -52,12 +52,14 @@ fi
 
 repo_dir="${TEST_TMP}/repo"
 wt_dir="${TEST_TMP}/worktree"
-mkdir -p "${repo_dir}/node_modules/example" "${repo_dir}/node_modules/.bin" "${repo_dir}/node_modules/prettier/bin" "$wt_dir" || fail "failed to create restore fixture dirs"
+mkdir -p "${repo_dir}/node_modules/example" "${repo_dir}/node_modules/.bin" "${repo_dir}/node_modules/prettier/bin" "${wt_dir}/node_modules" || fail "failed to create restore fixture dirs"
 printf '{}\n' >"${repo_dir}/package.json" || fail "failed to create repo package.json"
 printf '{}\n' >"${wt_dir}/package.json" || fail "failed to create worktree package.json"
 printf 'fixture\n' >"${repo_dir}/node_modules/example/file.txt" || fail "failed to create node_modules fixture"
-printf '#!/usr/bin/env node\n' >"${repo_dir}/node_modules/prettier/bin/prettier.cjs" || fail "failed to create prettier fixture"
+printf '#!/usr/bin/env bash\nprintf "fixture-tool\\n"\n' >"${repo_dir}/node_modules/prettier/bin/prettier.cjs" || fail "failed to create prettier fixture"
+chmod +x "${repo_dir}/node_modules/prettier/bin/prettier.cjs" || fail "failed to make prettier fixture executable"
 ln -s ../prettier/bin/prettier.cjs "${repo_dir}/node_modules/.bin/prettier" || fail "failed to create prettier bin symlink"
+ln -s "${repo_dir}/node_modules/.bin" "${wt_dir}/node_modules/.bin" || fail "failed to create stale dispatcher tooling link"
 
 LOGFILE="${TEST_TMP}/pulse.log" \
 	AIDEVOPS_WORKSPACE_DIR="$TEST_TMP" \
@@ -70,8 +72,22 @@ if [[ -d "${wt_dir}/node_modules/example" ]]; then
 	fail "root node_modules payload was copied"
 fi
 
-if [[ ! -L "${wt_dir}/node_modules/.bin" ]]; then
-	fail "root node_modules .bin tooling link was not created"
+if [[ -e "${wt_dir}/node_modules/.bin" || -L "${wt_dir}/node_modules/.bin" ]]; then
+	fail "dispatcher-created canonical node_modules .bin link was not removed"
+fi
+
+if ! declare -F _dlw_append_node_tool_env >/dev/null 2>&1; then
+	fail "worker launch does not provide a local command path for canonical Node tools"
+fi
+worker_cmd=(env)
+_dlw_append_node_tool_env "$repo_dir"
+expected_tool_path="PATH=${repo_dir}/node_modules/.bin:${PATH}"
+if [[ "${worker_cmd[1]:-}" != "$expected_tool_path" ]]; then
+	fail "worker launch did not prepend only the canonical node_modules .bin directory"
+fi
+tool_output=$("${worker_cmd[@]}" prettier) || fail "dispatcher-provided Node tool did not execute"
+if [[ "$tool_output" != "fixture-tool" ]]; then
+	fail "dispatcher-provided Node tool returned unexpected output"
 fi
 
 _dlw_zero_output_comment_count() {
@@ -235,7 +251,7 @@ fi
 
 printf 'PASS: stale non-empty node_modules restore lock is reclaimed\n'
 printf 'PASS: root node_modules payload is skipped by default\n'
-printf 'PASS: root node_modules .bin tooling is linked by default\n'
+printf 'PASS: root Node tooling uses PATH without a cross-boundary worktree link\n'
 printf 'PASS: precomputed zero-output evidence count skips redundant lookups\n'
 printf 'PASS: pulse worker launch forwards dispatching GitHub login\n'
 printf 'PASS: systemd PID resolver handles final unterminated property\n'

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -51,6 +51,7 @@ setup_test_env() {
 	export TEST_WORKER_SLEEP_SECONDS="2"
 	unset TEST_INITIAL_PR_HEAD_SHA
 	unset TEST_INITIAL_PR_HEAD_EMPTY
+	unset TEST_WORKTREE_ADD_FAIL
 	export AIDEVOPS_CI_REPAIR_STATE_DIR="${TEST_ROOT}/repair-state"
 	export AIDEVOPS_CI_REPAIR_WORKTREE_BASE_DIR="${TEST_ROOT}/worktrees"
 	export AIDEVOPS_HEADLESS_RUNTIME_DIR="${TEST_ROOT}/headless-runtime"
@@ -78,6 +79,10 @@ case "$action" in
 add)
 	branch="${1:-}"
 	path="${2:-}"
+	if [[ "${TEST_WORKTREE_ADD_FAIL:-0}" == "1" ]]; then
+		printf 'worktree add failed %s %s\n' "$branch" "$path" >>"${GH_LOG}"
+		exit 1
+	fi
 	shift 2
 	base=""
 	while [[ $# -gt 0 ]]; do
@@ -280,6 +285,7 @@ define_process_helper() {
 
 	_resolve_pr_mergeable_status() { local pr_number="$1" repo_slug="$2" mergeable="$3"; [[ -n "$pr_number$repo_slug$mergeable" ]]; RESOLVE_CALLS=$((RESOLVE_CALLS + 1)); return 0; }
 	_pmp_refresh_unknown_mergeable_state_into() { local dest_var="$1" pr_number="$2" repo_slug="$3" mergeable="$4"; [[ -n "$pr_number$repo_slug$mergeable" ]]; printf -v "$dest_var" '%s' "$REFRESHED_MERGEABLE"; return 0; }
+	_pmp_normalize_pr_lifecycle_state_into() { local dest_var="$1"; local raw_state="$2"; local normalized_state=""; case "$raw_state" in [Oo][Pp][Ee][Nn]) normalized_state="OPEN" ;; [Cc][Ll][Oo][Ss][Ee][Dd]) normalized_state="CLOSED" ;; [Mm][Ee][Rr][Gg][Ee][Dd]) normalized_state="MERGED" ;; *) normalized_state="$raw_state" ;; esac; printf -v "$dest_var" '%s' "$normalized_state"; return 0; }
 	_pmp_normalize_review_decision_into() { local dest_var="$1" raw_decision="$2" normalized_decision=""; case "$raw_decision" in CHANGES_REQUESTED|APPROVED|REVIEW_REQUIRED|NONE) normalized_decision="$raw_decision" ;; ''|null|NULL|UNKNOWN|unknown) normalized_decision="UNKNOWN" ;; *) normalized_decision="$raw_decision" ;; esac; printf -v "$dest_var" '%s' "$normalized_decision"; return 0; }
 	_pmp_review_decision_is_unknown() { local raw_decision="$1" _test_normalized_decision=""; _pmp_normalize_review_decision_into _test_normalized_decision "$raw_decision"; [[ "$_test_normalized_decision" == "UNKNOWN" ]]; return $?; }
 	_pmp_refresh_unknown_review_decision_into() { local dest_var="$1" pr_number="$2" repo_slug="$3" review_decision="$4"; [[ -n "$pr_number$repo_slug$review_decision" ]]; REVIEW_REFRESH_CALLS=$((REVIEW_REFRESH_CALLS + 1)); printf -v "$dest_var" '%s' "$REFRESHED_REVIEW_DECISION"; return 0; }
@@ -337,6 +343,7 @@ define_feedback_helpers() {
 		_ci_repair_status_dispatched
 		_ci_repair_result_active
 		_ci_repair_result_exhausted
+		_ci_repair_result_retryable
 		_ci_repair_claim_next_attempt
 		_ci_repair_latest_archive
 		_ci_repair_prepare_attempt
@@ -367,6 +374,7 @@ exit 0
 EOF
 	chmod +x "${TEST_ROOT}/bin/git"
 	gh_issue_edit_safe() { gh issue edit "$@"; return $?; }
+	_pmrc_rerun_infrastructure_check() { local repo_slug="$1"; local pr_number="$2"; local check_name="$3"; local check_url="$4"; printf '%s|%s|%s|%s\n' "$repo_slug" "$pr_number" "$check_name" "$check_url" >>"${TEST_ROOT}/infra-rerun-calls.log"; return 0; }
 	_emit_ci_failure_guidance_blocks() { return 0; }
 	_classify_ci_failures_by_pattern() { local failing_names="$1"; printf '%s' "$failing_names" >"${TEST_ROOT}/classified-names.txt"; return 0; }
 	_pulse_merge_repo_path_for_slug() { local repo_slug="$1"; [[ -n "$repo_slug" ]]; printf '%s\n' "${TEST_ROOT}/repo"; return 0; }
@@ -836,8 +844,34 @@ test_ci_feedback_skips_github_api_rate_limit_failure() {
 		print_result "GitHub API rate limit does not dispatch code repair" 1 "Dispatch log: $(cat "$GH_LOG")"
 	elif ! grep -qF 'classified as infrastructure failure' "$LOGFILE"; then
 		print_result "GitHub API rate limit records infrastructure classification" 1 "Log: $(cat "$LOGFILE")"
+	elif ! grep -qF 'owner/repo|100|Lint|https://github.com/owner/repo/actions/runs/123/job/456' "${TEST_ROOT}/infra-rerun-calls.log" 2>/dev/null; then
+		print_result "GitHub API rate limit requests bounded infrastructure rerun" 1 "Rerun calls missing or incorrect"
 	else
-		print_result "GitHub API installation limit is classified as infrastructure" 0
+		print_result "GitHub API installation limit requests bounded infrastructure rerun" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ci_repair_preserves_pr_until_launch_retries_exhausted() {
+	setup_test_env
+	export TEST_WORKTREE_ADD_FAIL="1"
+	define_feedback_helpers || { print_result "defines feedback helpers for retryable launch failures" 1 "could not extract feedback helpers"; teardown_test_env; return 0; }
+
+	local first_close_count=0 second_close_count=0 final_close_count=0
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+	first_close_count=$(grep -cF 'gh pr close 100' "$GH_LOG" || true)
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+	second_close_count=$(grep -cF 'gh pr close 100' "$GH_LOG" || true)
+	_dispatch_ci_fix_worker "100" "owner/repo" "42"
+	final_close_count=$(grep -cF 'gh pr close 100' "$GH_LOG" || true)
+
+	if [[ "$first_close_count" -ne 0 || "$second_close_count" -ne 0 ]]; then
+		print_result "retryable CI repair failures preserve the PR" 1 "close counts before exhaustion: first=${first_close_count}, second=${second_close_count}"
+	elif [[ "$final_close_count" -ne 1 ]]; then
+		print_result "exhausted CI repair failures take one durable fallback" 1 "final close count=${final_close_count}; GH log: $(cat "$GH_LOG")"
+	else
+		print_result "CI repair preserves the PR until bounded launch retries exhaust" 0
 	fi
 	teardown_test_env
 	return 0
@@ -985,6 +1019,7 @@ main() {
 	test_ci_feedback_skips_registry_rate_limit_failure
 	test_ci_feedback_skips_dockerhub_pull_rate_limit_failure
 	test_ci_feedback_skips_github_api_rate_limit_failure
+	test_ci_repair_preserves_pr_until_launch_retries_exhausted
 	test_ci_repair_recovers_one_stale_lease_then_exhausts
 	test_ci_repair_consumes_abandoned_append_only_claim
 	test_ci_repair_waits_for_prelock_startup_before_retry

--- a/.agents/scripts/tests/test-reeval-stale-continuation.sh
+++ b/.agents/scripts/tests/test-reeval-stale-continuation.sh
@@ -22,15 +22,18 @@
 #   1. Empty extraction + labeled issue → label cleared, return 1
 #   2. Empty extraction + unlabeled issue → no clear, return 1
 #   3. Non-empty extraction + large file → gate applies (return 0)
+#   4. Stale prefetched gate label → fresh lifecycle state wins
+#   5. Label edit failure → gate remains applied, no false CLEARED comment
+#   6. Unconfirmed label removal → gate remains applied, no false CLEARED comment
 #
 #   SECONDARY (_reevaluate_stale_continuations):
-#   4. No gate comment → label preserved (safe fallback)
-#   5. Open continuation → label preserved (work in progress)
-#   6. Closed + simplification-incomplete → label cleared (no wc-l needed)
-#   7. Closed + file over threshold → label cleared (stale citation)
-#   8. Closed + file under threshold → label preserved (prior work effective)
-#   9. Multiple continuations, all stale → label cleared
-#   10. Multiple continuations, one open → label preserved (short-circuit)
+#   7. No gate comment → label preserved (safe fallback)
+#   8. Open continuation → label preserved (work in progress)
+#   9. Closed + simplification-incomplete → label cleared (no wc-l needed)
+#   10. Closed + file over threshold → label cleared (stale citation)
+#   11. Closed + file under threshold → label preserved (prior work effective)
+#   12. Multiple continuations, all stale → label cleared
+#   13. Multiple continuations, one open → label preserved (short-circuit)
 #
 # Cross-references: GH#19415 (stuck label), GH#19499/t2170 (this fix),
 #   t2164 (Fix A/B), t2169 (Fix D — simplification-incomplete label)
@@ -80,6 +83,8 @@ GH_CALLS_LOG="${TMP}/gh_calls.log"
 GH_LABEL_REMOVED=""
 GH_VIEW_JSON=""     # JSON for plain gh issue view (no --comments)
 GH_COMMENTS_JSON="" # JSON for gh issue view --comments ({"comments":[...]})
+GH_EDIT_RC=0
+GH_EDIT_KEEP_LABEL="false"
 
 # =============================================================================
 # Source gate first (defines _large_file_gate_* and _issue_targets_large_files)
@@ -101,7 +106,14 @@ gh() {
 	if [[ "$1" == "issue" && "$2" == "edit" ]]; then
 		local arg
 		for arg in "$@"; do
-			[[ "$arg" == "--remove-label" ]] && GH_LABEL_REMOVED="true" && return 0
+			if [[ "$arg" == "--remove-label" ]]; then
+				[[ "$GH_EDIT_RC" -eq 0 ]] || return "$GH_EDIT_RC"
+				GH_LABEL_REMOVED="true"
+				if [[ "$GH_EDIT_KEEP_LABEL" != "true" ]]; then
+					GH_VIEW_JSON=$(printf '%s' "$GH_VIEW_JSON" | jq -c '.labels = [.labels[]? | select(.name != "needs-simplification")]' 2>/dev/null) || true
+				fi
+				return 0
+			fi
 			[[ "$arg" == "--add-label" ]] && return 0
 		done
 		return 0
@@ -174,6 +186,20 @@ gh() {
 	return 0
 }
 
+gh_issue_view() {
+	gh issue view "$@"
+	return $?
+}
+
+gh_issue_list() {
+	if [[ "$*" == *"--json number,body,state"* ]]; then
+		printf '[]\n'
+		return 0
+	fi
+	gh issue list "$@"
+	return $?
+}
+
 gh_create_issue() {
 	printf '%s\n' "gh_create_issue $*" >>"$GH_CALLS_LOG"
 	return 0
@@ -212,6 +238,8 @@ reset_state() {
 	GH_LABEL_REMOVED=""
 	GH_VIEW_JSON=""
 	GH_COMMENTS_JSON=""
+	GH_EDIT_RC=0
+	GH_EDIT_KEEP_LABEL="false"
 	: >"$GH_CALLS_LOG"
 	: >"$LOGFILE"
 }
@@ -260,6 +288,46 @@ assert_eq \
 	"non-empty extraction + large file → returns 0 (gate applies)" \
 	"0" "$rc"
 
+# ---- Test 4: stale prefetched gate label is refreshed before blocking ----
+reset_state
+GH_VIEW_JSON='{"labels":[{"name":"status:queued"}],"title":"active worker"}'
+stale_meta='{"labels":[{"name":"needs-simplification"}],"title":"stale gate snapshot"}'
+rc=0
+_issue_targets_large_files "9996" "owner/repo" "$large_body" "$TMP" "false" "$stale_meta" || rc=$?
+assert_eq \
+	"stale prefetched needs-simplification label → fresh active lifecycle wins" \
+	"1" "$rc"
+
+# ---- Test 5: failed stale-label removal keeps the gate applied ----
+reset_state
+GH_VIEW_JSON='{"labels":[{"name":"needs-simplification"}]}'
+GH_EDIT_RC=1
+rc=0
+_issue_targets_large_files "9995" "owner/repo" "$empty_body" "$TMP" "true" || rc=$?
+assert_eq \
+	"failed stale-label removal → gate remains applied" \
+	"0" "$rc"
+if grep -qF '_post_simplification_gate_cleared_comment' "$GH_CALLS_LOG"; then
+	assert_eq "failed stale-label removal → no false CLEARED comment" "absent" "present"
+else
+	assert_eq "failed stale-label removal → no false CLEARED comment" "absent" "absent"
+fi
+
+# ---- Test 6: unconfirmed stale-label removal keeps the gate applied ----
+reset_state
+GH_VIEW_JSON='{"labels":[{"name":"needs-simplification"}]}'
+GH_EDIT_KEEP_LABEL="true"
+rc=0
+_issue_targets_large_files "9994" "owner/repo" "$empty_body" "$TMP" "true" || rc=$?
+assert_eq \
+	"unconfirmed stale-label removal → gate remains applied" \
+	"0" "$rc"
+if grep -qF '_post_simplification_gate_cleared_comment' "$GH_CALLS_LOG"; then
+	assert_eq "unconfirmed stale-label removal → no false CLEARED comment" "absent" "present"
+else
+	assert_eq "unconfirmed stale-label removal → no false CLEARED comment" "absent" "absent"
+fi
+
 # =============================================================================
 # SECONDARY fix tests: _reevaluate_stale_continuations
 # =============================================================================
@@ -277,7 +345,7 @@ make_gate_comments() {
 	jq -cn --arg body "$body" '{"comments":[{"body":$body}]}'
 }
 
-# ---- Test 4: no gate comment → label preserved ----
+# ---- Test 7: no gate comment → label preserved ----
 reset_state
 GH_COMMENTS_JSON='{"comments":[]}'
 GH_VIEW_JSON='{"state":"OPEN","labels":[],"title":"some issue"}'
@@ -290,7 +358,7 @@ assert_eq \
 	"no gate comment → label NOT removed" \
 	"" "${GH_LABEL_REMOVED}"
 
-# ---- Test 5: open continuation → label preserved ----
+# ---- Test 8: open continuation → label preserved ----
 reset_state
 GH_COMMENTS_JSON=$(make_gate_comments "#42 (recently-closed — continuation)")
 # gh issue view #42 returns state=OPEN
@@ -304,7 +372,7 @@ assert_eq \
 	"open continuation → label NOT removed" \
 	"" "${GH_LABEL_REMOVED}"
 
-# ---- Test 6: closed + simplification-incomplete → label cleared (no wc-l) ----
+# ---- Test 9: closed + simplification-incomplete → label cleared (no wc-l) ----
 reset_state
 GH_COMMENTS_JSON=$(make_gate_comments "#43 (recently-closed — continuation)")
 GH_VIEW_JSON='{"state":"CLOSED","labels":[{"name":"simplification-incomplete"}],"title":"file-size-debt: large-over.sh exceeds 2000 lines"}'
@@ -317,7 +385,7 @@ assert_eq \
 	"simplification-incomplete → label removed" \
 	"true" "${GH_LABEL_REMOVED:-false}"
 
-# ---- Test 7: closed + file over threshold → label cleared (stale citation) ----
+# ---- Test 10: closed + file over threshold → label cleared (stale citation) ----
 reset_state
 GH_COMMENTS_JSON=$(make_gate_comments "#44 (recently-closed — continuation)")
 GH_VIEW_JSON=$(jq -cn \
@@ -332,7 +400,7 @@ assert_eq \
 	"closed + file over threshold → label removed" \
 	"true" "${GH_LABEL_REMOVED:-false}"
 
-# ---- Test 8: closed + file under threshold → label preserved (work effective) ----
+# ---- Test 11: closed + file under threshold → label preserved (work effective) ----
 reset_state
 GH_COMMENTS_JSON=$(make_gate_comments "#45 (recently-closed — continuation)")
 GH_VIEW_JSON=$(jq -cn \
@@ -347,7 +415,7 @@ assert_eq \
 	"closed + file under threshold → label NOT removed" \
 	"" "${GH_LABEL_REMOVED}"
 
-# ---- Test 9: multiple continuations, all stale → label cleared ----
+# ---- Test 12: multiple continuations, all stale → label cleared ----
 reset_state
 OVER_BASENAME2="large-over2.sh"
 yes ":" 2>/dev/null | head -n 2050 >"${TMP}/${OVER_BASENAME2}"
@@ -484,7 +552,7 @@ gh() {
 	return 0
 }
 
-# ---- Test 10: one open continuation → label preserved (short-circuit) ----
+# ---- Test 13: one open continuation → label preserved (short-circuit) ----
 reset_state
 GH_COMMENTS_JSON=$(make_gate_comments "#48 (recently-closed — continuation), #49 (recently-closed — continuation)")
 # Both view calls return OPEN → first citation valid → should short-circuit

--- a/.agents/scripts/tests/test-runtime-bundle-lease.sh
+++ b/.agents/scripts/tests/test-runtime-bundle-lease.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
 LEASE_HELPER="${REPO_ROOT}/.agents/scripts/runtime-bundle-lease.sh"
 HEADLESS_HELPER="${REPO_ROOT}/.agents/scripts/headless-runtime-helper.sh"
+HEADLESS_FAILURE="${REPO_ROOT}/.agents/scripts/headless-runtime-failure.sh"
+HEADLESS_WORKER="${REPO_ROOT}/.agents/scripts/headless-runtime-worker.sh"
 PULSE_WRAPPER="${REPO_ROOT}/.agents/scripts/pulse-wrapper.sh"
 TEST_ROOT="$(mktemp -d -t runtime-bundle-lease.XXXXXX)"
 ORIGINAL_HOME="${HOME}"
@@ -82,6 +84,13 @@ if grep -q 'runtime-bundle-lease.sh' "$HEADLESS_HELPER" && \
 	pass "headless runtime owns a bundle lease for its process lifetime"
 else
 	fail "headless runtime owns a bundle lease for its process lifetime"
+fi
+
+if ! grep -q 'declare -F aidevops_runtime_bundle_lease_release' "$HEADLESS_FAILURE" && \
+	! grep -q 'declare -F aidevops_runtime_bundle_lease_release' "$HEADLESS_WORKER"; then
+	pass "headless cleanup requires the runtime bundle release invariant"
+else
+	fail "headless cleanup requires the runtime bundle release invariant"
 fi
 
 if grep -q 'runtime-bundle-lease.sh' "$PULSE_WRAPPER" && \

--- a/.agents/scripts/tests/test-worker-permission-helper.sh
+++ b/.agents/scripts/tests/test-worker-permission-helper.sh
@@ -13,6 +13,7 @@ trap 'rm -rf "$test_root"' EXIT
 capture_file="${test_root}/capture.json"
 export AIDEVOPS_WORKER_BLOCKER_LOG_FILE="${test_root}/blockers.jsonl"
 gh_call_log="${test_root}/gh-calls.log"
+posted_comment="${test_root}/permission-comment.md"
 
 cat >"$capture_file" <<'JSON'
 {
@@ -47,6 +48,21 @@ if [[ "$envelope" == *"$PWD"* ]]; then
 	printf 'permission envelope exposed the local worktree path\n' >&2
 	exit 1
 fi
+envelope_file="${test_root}/envelope.json"
+printf '%s\n' "$envelope" >"$envelope_file"
+rendered_capabilities=$(permission_render_capabilities "$envelope_file")
+capability_marker="- **external_directory** via \`read\`"
+target_marker="**Target:** \`owner/repo#123\`"
+session_marker="**Worker session:** \`issue-123\`"
+if [[ "$rendered_capabilities" != *"$capability_marker"* ]]; then
+	printf 'permission capability summary was empty or incomplete\n' >&2
+	exit 1
+fi
+printf '{invalid-json\n' >"${test_root}/invalid-envelope.json"
+if permission_render_capabilities "${test_root}/invalid-envelope.json" >/dev/null 2>&1; then
+	printf 'permission capability rendering hid a jq failure\n' >&2
+	exit 1
+fi
 
 jq '.requests[0].patterns = ["/Users/private/.ssh/id_ed25519"]' "$capture_file" >"${capture_file}.unsafe"
 if permission_validate_capture "${capture_file}.unsafe" 123 owner/repo; then
@@ -66,7 +82,10 @@ gh_issue_view() {
 	return 0
 }
 gh_issue_comment() {
-	return 0
+	local body_file="${5:-}"
+	[[ -f "$body_file" ]] || return 1
+	cp "$body_file" "$posted_comment"
+	return $?
 }
 gh_issue_edit_safe() {
 	return 0
@@ -87,12 +106,25 @@ if ! grep -Fq -- '[.[] | select' "$gh_call_log"; then
 	printf 'permission comment lookup did not use page-local jq input\n' >&2
 	exit 1
 fi
+if ! grep -Fq -- "$capability_marker" "$posted_comment"; then
+	printf 'permission comment omitted the human-readable capability summary\n' >&2
+	exit 1
+fi
+if ! grep -Fq -- "$target_marker" "$posted_comment"; then
+	printf 'permission comment omitted the correlated issue target\n' >&2
+	exit 1
+fi
+if ! grep -Fq -- "$session_marker" "$posted_comment"; then
+	printf 'permission comment omitted the correlated worker session\n' >&2
+	exit 1
+fi
 git_dir=$(git -C "$repo_dir" rev-parse --absolute-git-dir)
 if [[ ! -f "${git_dir}/aidevops-permission-pending" ]]; then
 	printf 'permission pending marker was not written to the target repository git directory\n' >&2
 	exit 1
 fi
-jq -e 'select(.event == "permission_awaiting_approval" and .reason == "needs_maintainer_permissions" and .blocking == true)' \
+jq -e 'select(.event == "permission_awaiting_approval" and .reason == "needs_maintainer_permissions" and .blocking == true
+  and .issue_number == 123 and .repo_slug == "owner/repo" and .session_key == "issue-123")' \
 	"$AIDEVOPS_WORKER_BLOCKER_LOG_FILE" >/dev/null
 
 printf 'worker permission helper tests passed\n'

--- a/.agents/scripts/worker-permission-helper.sh
+++ b/.agents/scripts/worker-permission-helper.sh
@@ -182,8 +182,9 @@ permission_render_capabilities() {
 		+ (if (.patterns | length) == 0 then "(no pattern supplied)" else (.patterns | map(tojson | safe) | join(", ")) end)
 		+ "\n  - Reason: " + (if .intent == "" then "No additional model rationale was available." else (.intent | safe) end)
 		+ "\n  - Risk: **" + .risk.level + "** — " + (.risk.reason | safe)
-		+ (if .risk.grantable then "" else "\n  - **Not grantable:** sensitive scope requires an alternative approach." end)'
-	return 0
+		+ (if .risk.grantable then "" else "\n  - **Not grantable:** sensitive scope requires an alternative approach." end)' \
+		"$envelope_file"
+	return $?
 }
 
 permission_post_request() {
@@ -192,7 +193,7 @@ permission_post_request() {
 	local repo_slug="$3"
 	local session_key="$4"
 	local work_dir="$5"
-	local envelope_file comment_file request_id capability_text changed_text branch resume_json
+	local envelope_file comment_file request_id capability_text changed_text branch resume_json target worker_session
 	envelope_file=$(mktemp)
 	comment_file=$(mktemp)
 	resume_json=$(permission_issue_resume_json "$issue_number" "$repo_slug")
@@ -203,9 +204,18 @@ permission_post_request() {
 		printf '%s\n' "$request_id"
 		return 0
 	fi
-	capability_text=$(permission_render_capabilities "$envelope_file")
+	if ! capability_text=$(permission_render_capabilities "$envelope_file"); then
+		rm -f "$envelope_file" "$comment_file"
+		return 1
+	fi
+	if [[ -z "$capability_text" ]]; then
+		rm -f "$envelope_file" "$comment_file"
+		return 1
+	fi
 	changed_text=$(jq -r 'if (.context.changed_files | length) == 0 then "- No uncommitted repository files detected." else (.context.changed_files[] | "- " + tojson) end' "$envelope_file")
 	branch=$(jq -r '(.worker.branch // "") | tojson' "$envelope_file")
+	target=$(jq -r '.target.repository + "#" + (.target.number | tostring)' "$envelope_file")
+	worker_session=$(jq -r '.worker.session // "not available"' "$envelope_file")
 	cat >"$comment_file" <<EOF
 ${PERMISSION_REQUEST_MARKER}
 ## Maintainer permission required
@@ -213,6 +223,10 @@ ${PERMISSION_REQUEST_MARKER}
 Background work paused instead of waiting indefinitely for an unavailable interactive permission response.
 
 **Request:** ${request_id}
+
+**Target:** \`${target}\`
+
+**Worker session:** \`${worker_session}\`
 
 **Worker stage:** tool execution
 


### PR DESCRIPTION
## Summary

Preserve recoverable worker deliverables across CI repair, permission handoff, dirty-worktree checkpointing, claim release, and cross-runner terminal-lease reconciliation. This consolidates the product fix from PR #28366 with the related Pulse lifecycle corrections tracked by #28437.

## Files Changed

.agents/plugins/opencode-aidevops/permission-broker.mjs, .agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs, .agents/scripts/dispatch-claim-helper.sh, .agents/scripts/dispatch-dedup-helper.sh, .agents/scripts/dispatch-dedup-stale.sh, .agents/scripts/dispatch-lease-claims.jq, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/pulse-dispatch-large-file-gate.sh, .agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/pulse-merge-feedback.sh, .agents/scripts/shared-claim-lifecycle.sh, .agents/scripts/tests/test-dispatch-atomic-lease.sh, .agents/scripts/tests/test-dispatch-dedup-gh-call-budget.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-headless-runtime-release-unlock.sh, .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh, .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh, .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh, .agents/scripts/tests/test-reeval-stale-continuation.sh, .agents/scripts/tests/test-runtime-bundle-lease.sh, .agents/scripts/tests/test-worker-permission-helper.sh, .agents/scripts/worker-permission-helper.sh

## Runtime Testing

- **Risk level:** High (worker lifecycle and distributed dispatch state machines)
- **Verification:** Runtime-verified high-risk lifecycle/state-machine paths with the Pulse canary, full local quality suite, 172 headless-runtime tests, atomic lease concurrency tests, claim/dedup suites, stale-continuation tests, and ShellCheck/Bash 3.2/portability gates.

Resolves #28437

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1h 20m and 1,693,062 tokens on this with the user in an interactive session.
