### PR TITLE
GH#28438: Restore deployed wrapper shim discovery

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -111,11 +111,15 @@ function shellSessionOrigin(env) {
   return headless ? "worker" : "interactive";
 }
 
-function prependScriptsPath(env, scriptsDir) {
-  if (!existsSync(scriptsDir)) return;
+function prependFrameworkPaths(env, scriptsDir, agentsDir) {
+  const binDir = agentsDir ? join(agentsDir, "bin") : "";
+  const preferredPaths = [scriptsDir, binDir].filter((path) => path && existsSync(path));
+  if (preferredPaths.length === 0) return;
   const currentPath = env.PATH || process.env.PATH || "";
-  const pathParts = currentPath.split(":").filter((part) => part && part !== scriptsDir);
-  env.PATH = [scriptsDir, ...pathParts].join(":");
+  const pathParts = currentPath
+    .split(":")
+    .filter((part) => part && !preferredPaths.includes(part));
+  env.PATH = [...preferredPaths, ...pathParts].join(":");
 }
 
 function projectWorkerLineage(env) {
@@ -189,7 +193,7 @@ function normalizeDependencies(deps) {
 }
 
 async function shellEnvHook(config, input, output) {
-  prependScriptsPath(output.env, config.scriptsDir);
+  prependFrameworkPaths(output.env, config.scriptsDir, config.agentsDir);
   projectFrameworkEnvironment(output.env, config);
   projectSessionIdentity(input, output.env);
   projectOtelEnvironment(output.env);

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -92,12 +92,14 @@ test("interactive OpenCode shell overrides stale worker origin", async () => {
 test("shell env moves the Git guard scripts directory to PATH first", async () => {
   const root = mkdtempSync(join(tmpdir(), "aidevops-shell-path-"));
   const scriptsDir = join(root, "scripts");
+  const binDir = join(root, "bin");
   mkdirSync(scriptsDir);
+  mkdirSync(binDir);
   try {
     const hook = createShellEnvHook({ agentsDir: root, scriptsDir, workspaceDir: root });
-    const output = { env: { PATH: `/usr/bin:${scriptsDir}:/bin` } };
+    const output = { env: { PATH: `/usr/bin:${binDir}:${scriptsDir}:/bin` } };
     await hook({ sessionID: "path-test" }, output);
-    assert.equal(output.env.PATH, `${scriptsDir}:/usr/bin:/bin`);
+    assert.equal(output.env.PATH, `${scriptsDir}:${binDir}:/usr/bin:/bin`);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -138,9 +138,9 @@ _is_reserved_agent_namespace() {
 	local namespace="$1"
 
 	case "$namespace" in
-		AGENTS.md|VERSION|advisories|commands|configs|custom|draft|hooks|plugins|prompts|reference|scripts|services|tools|workflows)
-			return 0
-			;;
+	AGENTS.md | VERSION | advisories | commands | configs | custom | draft | hooks | plugins | prompts | reference | scripts | services | tools | workflows)
+		return 0
+		;;
 	esac
 
 	return 1
@@ -1307,6 +1307,37 @@ _write_deployed_agents_sha() {
 	return 0
 }
 
+_sync_agent_bin_shims() {
+	local target_dir="$1"
+	local user_bin_dir="${HOME}/.aidevops/bin"
+	local shim=""
+	local shim_name=""
+	local existing=""
+	local existing_target=""
+
+	[[ -n "$target_dir" ]] || return 1
+	mkdir -p "$user_bin_dir" || return 1
+
+	for existing in "$user_bin_dir"/*; do
+		[[ -L "$existing" ]] || continue
+		existing_target=$(readlink "$existing" 2>/dev/null || true)
+		case "$existing_target" in
+		"${target_dir}/bin/"*)
+			[[ -e "$existing_target" ]] || rm -f "$existing"
+			;;
+		esac
+	done
+
+	if [[ -d "${target_dir}/bin" ]]; then
+		for shim in "${target_dir}/bin/"*; do
+			[[ -f "$shim" ]] || continue
+			shim_name=$(basename "$shim")
+			ln -sfn "$shim" "${user_bin_dir}/${shim_name}" || return 1
+		done
+	fi
+	return 0
+}
+
 _install_canonical_git_guard_shim() {
 	local target_dir="$1"
 	local guard_shim="${target_dir}/scripts/git"
@@ -1349,6 +1380,7 @@ deploy_aidevops_agents() {
 
 	print_success "Deployed agents to $target_dir"
 	_install_canonical_git_guard_shim "$target_dir" || return 1
+	_sync_agent_bin_shims "$target_dir" || return 1
 
 	_write_deployed_agents_sha "$repo_dir"
 

--- a/.agents/scripts/tests/test-agent-bin-shim-sync.sh
+++ b/.agents/scripts/tests/test-agent-bin-shim-sync.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
-DEPLOYMENT_MODULE="${REPO_DIR}/.agents/scripts/setup/_deployment.sh"
+DEPLOYMENT_MODULE="${REPO_DIR}/.agents/scripts/setup/modules/agent-deploy.sh"
 
 PASS=0
 FAIL=0


### PR DESCRIPTION
## Summary

Synchronize active agent bin shims during modular deployment and project the pinned runtime bin directory into OpenCode tool-shell PATH after the Git guard scripts directory.

## Files Changed

.agents/plugins/opencode-aidevops/shell-env.mjs, .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs, .agents/scripts/setup/modules/agent-deploy.sh, .agents/scripts/tests/test-agent-bin-shim-sync.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-agent-bin-shim-sync.sh (7/7), test-shell-env-origin.mjs (14/14), ShellCheck, linters-local.sh --changed

Resolves #28438


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 15m and 248,341 tokens on this with the user in an interactive session.