### PR TITLE
GH#28439: Resolve completion blockers semantically

### DIFF
--- a/.agents/scripts/dependency-event-reconciler.sh
+++ b/.agents/scripts/dependency-event-reconciler.sh
@@ -32,6 +32,31 @@ _der_task_refs() {
 	return 0
 }
 
+_der_todo_blocker_tokens_valid() {
+	local text="$1"
+	local marker=""
+	local value=""
+	local token=""
+	local marker_count=0
+
+	while IFS= read -r marker; do
+		[[ -n "$marker" ]] || continue
+		marker_count=$((marker_count + 1))
+		value="${marker#*blocked-by:}"
+		[[ -n "$value" ]] || return 1
+		while IFS= read -r token; do
+			[[ -n "$token" ]] || return 1
+			if [[ "$token" =~ ^#[0-9]+$ ]]; then
+				continue
+			fi
+			task_identity_validate "$token" || return 1
+		done <<<"${value//,/$'\n'}"
+	done < <(printf '%s\n' "$text" | grep -oE '(^|[[:space:]])blocked-by:[^[:space:]]+' || true)
+
+	[[ "$marker_count" -gt 0 ]] || return 1
+	return 0
+}
+
 _der_has_hold() {
 	local body="$1"
 	local comments="$2"
@@ -262,6 +287,21 @@ _der_native_blockers_closed() {
 		[[ "${blocker#*:}" == "$DER_STATE_CLOSED" ]] || return "$DER_NOT_READY"
 	done < <(printf '%s' "$result" | jq -r '.data.repository.issue.blockedBy.nodes[]? | "\(.number):\(.state)"' 2>/dev/null)
 	return 0
+}
+
+_der_completion_blockers_closed() {
+	local repo="$1"
+	local issue_number="$2"
+	local dependency_text="$3"
+	local candidate_json=""
+
+	[[ "$repo" == */* && "$issue_number" =~ ^[0-9]+$ ]] || return 1
+	_der_todo_blocker_tokens_valid "$dependency_text" || return 1
+	candidate_json=$(jq -cn --arg body "$dependency_text" \
+		'{body: $body, labels: {nodes: []}}') || return 1
+	_der_native_blockers_closed "$repo" "$issue_number" || return $?
+	_der_all_declared_blockers_closed "$repo" "$candidate_json"
+	return $?
 }
 
 _der_try_unblock() {

--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -49,11 +49,12 @@ _is_cancelled_or_deferred() {
 
 _has_evidence() {
 	local text="$1" task_id="$2" repo="$3"
+	local issue_number="${4:-}"
 	local task_line
 	task_line=$(_task_line_from_block "$text" "$task_id")
 	# Cancelled/deferred/declined tasks need no PR or verified: evidence
 	_is_cancelled_or_deferred "$task_line" && return 0
-	if _has_unresolved_blocker "$text" "$task_id" "$task_line"; then
+	if _has_unresolved_blocker "$text" "$task_id" "$task_line" "$repo" "$issue_number"; then
 		return 1
 	fi
 	echo "$text" | grep -qE 'verified:[0-9]{4}-[0-9]{2}-[0-9]{2}|pr:#[0-9]+' && return 0
@@ -78,10 +79,14 @@ _has_unresolved_blocker() {
 	local text="$1"
 	local task_id="${2:-}"
 	local task_line="${3:-}"
+	local repo="${4:-}"
+	local issue_number="${5:-}"
 	local candidate
 	candidate="${task_line:-$(_task_line_from_block "$text" "$task_id")}"
-	printf '%s\n' "$candidate" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+' && return 0
-	return 1
+	printf '%s\n' "$candidate" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+' || return 1
+	[[ -n "$repo" && "$issue_number" =~ ^[0-9]+$ ]] || return 0
+	_der_completion_blockers_closed "$repo" "$issue_number" "$candidate" && return 1
+	return 0
 }
 
 _find_closing_pr() {
@@ -359,7 +364,7 @@ _do_close() {
 		print_info "Skipping #$issue_number ($task_id): parent-task label set — parent issues close via terminal-phase PR with explicit Closes #NNN, not TODO [x] (GH#20828)"
 		return 0
 	fi
-	if ! _is_cancelled_or_deferred "$task_line" && _has_unresolved_blocker "$task_line" "" "$task_line"; then
+	if ! _is_cancelled_or_deferred "$task_line" && _has_unresolved_blocker "$task_line" "" "$task_line" "$repo" "$issue_number"; then
 		print_info "Skipping #$issue_number ($task_id): unresolved blocked-by marker present — completion evidence must wait for dependencies (GH#23516)"
 		return 0
 	fi
@@ -377,7 +382,7 @@ _do_close() {
 	if [[ "$FORCE_CLOSE" == "true" ]]; then
 		print_info "FORCE_CLOSE active — bypassing evidence check for #$issue_number ($task_id) (GH#20146 audit)"
 	fi
-	if [[ "$FORCE_CLOSE" != "true" ]] && ! _has_evidence "$task_with_notes" "$task_id" "$repo"; then
+	if [[ "$FORCE_CLOSE" != "true" ]] && ! _has_evidence "$task_with_notes" "$task_id" "$repo" "$issue_number"; then
 		print_warning "Skipping #$issue_number ($task_id): no merged PR or verified: field"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-dependency-event-reconciler.sh
+++ b/.agents/scripts/tests/test-dependency-event-reconciler.sh
@@ -149,6 +149,25 @@ assert_eq "$namespaced" "$(_der_task_refs "Blocked by: ${namespaced}")" "namespa
 NATIVE_DIRECT=true CLOSED_TITLE="${namespaced}: blocker" BODY20="blocked-by:${namespaced}" EDIT_COUNT=0 REREAD_LABELS="status:blocked"
 assert_eq 1 "$(run_reconcile)" "namespaced task declaration resolves through exact title lookup"
 
+NATIVE_STATE="CLOSED" CLOSED_TITLE="t10: blocker"
+completion_status=0
+_der_completion_blockers_closed "owner/repo" 20 "- [ ] t20 delivered blocked-by:t10" || completion_status=$?
+assert_eq 0 "$completion_status" "completion accepts a positively closed task dependency"
+
+completion_status=0
+_der_completion_blockers_closed "owner/repo" 20 "- [ ] t20 delivered blocked-by:#10,#11" || completion_status=$?
+assert_eq "$DER_NOT_READY" "$completion_status" "completion preserves a mixed closed and open dependency set"
+
+completion_status=0
+_der_completion_blockers_closed "owner/repo" 20 "- [ ] t20 delivered blocked-by:t10,not-a-task" || completion_status=$?
+assert_eq 1 "$completion_status" "completion fails closed on malformed dependency tokens"
+
+NATIVE_STATE="OPEN"
+completion_status=0
+_der_completion_blockers_closed "owner/repo" 20 "- [ ] t20 delivered blocked-by:t10" || completion_status=$?
+assert_eq "$DER_NOT_READY" "$completion_status" "completion preserves an open native dependency"
+NATIVE_STATE="CLOSED"
+
 EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20="Blocked by #10" COMMENTS='[[]]'
 reconcile_stale_blocked_issues owner/repo >/dev/null 2>&1 || true
 assert_eq 1 "$EDIT_COUNT" "periodic stale sweep releases issue after missed close event"

--- a/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
+++ b/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
@@ -88,10 +88,25 @@ else
 fi
 
 blocked_task='- [ ] t9003 blocked implementation pr:#78 tier:standard blocked-by:t9002'
-if _has_evidence "$blocked_task" "t9003" "owner/repo"; then
-	fail "blocked-by marker vetoes otherwise explicit PR evidence"
+_der_completion_blockers_closed() {
+	local repo="$1"
+	local issue_number="$2"
+	local dependency_text="$3"
+	: "$repo" "$issue_number"
+	[[ "$dependency_text" == *"blocked-by:t9002"* ]]
+	return $?
+}
+if _has_evidence "$blocked_task" "t9003" "owner/repo" "9003"; then
+	pass "resolved blocked-by provenance permits explicit PR evidence"
 else
-	pass "blocked-by marker vetoes otherwise explicit PR evidence"
+	fail "resolved blocked-by provenance should not veto explicit PR evidence"
+fi
+
+open_blocked_task='- [ ] t9011 blocked implementation pr:#83 tier:standard blocked-by:t9999'
+if _has_evidence "$open_blocked_task" "t9011" "owner/repo" "9011"; then
+	fail "unresolved blocked-by marker must veto explicit PR evidence"
+else
+	pass "unresolved blocked-by marker still vetoes explicit PR evidence"
 fi
 
 historical_note_task='- [ ] t9004 fixed implementation pr:#79 tier:standard
@@ -137,9 +152,9 @@ fi
 
 precomputed_blocked_task_line='- [ ] t9009 fixed implementation pr:#82 tier:standard blocked-by:t9008'
 if _has_unresolved_blocker "- [ ] t9009 fixed implementation pr:#82 tier:standard" "t9009" "$precomputed_blocked_task_line"; then
-	pass "precomputed blocked task line still vetoes completion"
+	pass "precomputed blocked task line without resolution context fails closed"
 else
-	fail "precomputed blocked task line should veto completion"
+	fail "precomputed blocked task line without resolution context should fail closed"
 fi
 
 if completed_date=$(_closed_issue_aidevops_complete_date "owner/repo" "123"); then


### PR DESCRIPTION
## Summary

Reuse dependency reconciliation state checks during issue-sync completion so preserved blocked-by provenance permits completion only when all native and declared dependencies are positively closed.

## Files Changed

.agents/scripts/dependency-event-reconciler.sh, .agents/scripts/issue-sync-helper-close.sh, .agents/scripts/tests/test-dependency-event-reconciler.sh, .agents/scripts/tests/test-issue-sync-completion-evidence.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-dependency-event-reconciler.sh (22/22), test-issue-sync-completion-evidence.sh (17/17), ShellCheck, shfmt, linters-local.sh --changed

Resolves #28439


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 31m and 306,151 tokens on this with the user in an interactive session.