### PR TITLE
GH#28446: accept generated HTML in brief readiness

### DIFF
--- a/.agents/scripts/brief-readiness-parser.awk
+++ b/.agents/scripts/brief-readiness-parser.awk
@@ -26,6 +26,18 @@ function update_fence(text, trimmed, marker_char, marker_len, remainder) {
 	return 0
 }
 
+# Remove only the GitHub HTML wrappers emitted by issue-sync composition.
+# Recompute the lowercase copy after each removal so matching remains portable
+# without IGNORECASE. Unknown tags stay visible to placeholder classification.
+function strip_generated_tags(text, lower) {
+	lower = tolower(text)
+	while (match(lower, /<\/?(details|summary|code)([[:space:]][^>]*)?>/)) {
+		text = substr(text, 1, RSTART - 1) substr(text, RSTART + RLENGTH)
+		lower = tolower(text)
+	}
+	return text
+}
+
 BEGIN {
 	if (mode == "section") {
 		target = tolower(target)
@@ -88,6 +100,7 @@ mode == "prose" {
 	if (in_fence) next
 	line = $0
 	gsub(/`[^`]*`/, "", line)
+	line = strip_generated_tags(line)
 	print line
 	next
 }

--- a/.agents/scripts/tests/test-brief-inline-classifier.sh
+++ b/.agents/scripts/tests/test-brief-inline-classifier.sh
@@ -68,13 +68,14 @@ SCRIPTS_DIR="$(cd "${TEST_SCRIPT_DIR}/.." && pwd)" || exit 1
 LIB="${SCRIPTS_DIR}/issue-sync-lib.sh"
 CLAIM="${SCRIPTS_DIR}/claim-task-id.sh"
 HELPER="${SCRIPTS_DIR}/issue-sync-helper.sh"
+READINESS_HELPER="${SCRIPTS_DIR}/brief-readiness-helper.sh"
 
 # Sourced libraries use SCRIPT_DIR to resolve sibling scripts. Keep that value
 # pointed at .agents/scripts rather than this tests/ directory.
 SCRIPT_DIR="$SCRIPTS_DIR"
 export SCRIPT_DIR
 
-for f in "$LIB" "$CLAIM" "$HELPER"; do
+for f in "$LIB" "$CLAIM" "$HELPER" "$READINESS_HELPER"; do
 	if [[ ! -f "$f" ]]; then
 		printf 'test harness cannot find %s\n' "$f" >&2
 		exit 1
@@ -277,12 +278,34 @@ else
 	fail "A5 incomplete schema-v2 promotion gate" "expected unchanged body"
 fi
 
-# Test A6: no brief file → returns input unchanged
+# Test A6: composed related-file HTML remains schema-v2 worker-ready
+composed_body=$(
+	(
+		find_related_files() {
+			printf '%s\n' "$TMP/related-plan.md"
+			return 0
+		}
+		extract_file_summary() {
+			printf '%s\n' "Related architecture context remains available to the worker."
+			return 0
+		}
+		_compose_issue_related_files "$(<"$TMP/brief-schema-v2.md")" "t9005" "$TMP"
+	)
+)
+readiness_output=$("$READINESS_HELPER" check --body "$composed_body" 2>/dev/null)
+readiness_rc=$?
+if [[ $readiness_rc -eq 0 && "$composed_body" == *"<details><summary><code>related-plan.md</code></summary>"* && "$readiness_output" == *"WORKER_READY=true"* && "$readiness_output" == *"VALIDATION_ERRORS=none"* ]]; then
+	pass "A6 composed related-file HTML round trip remains worker-ready"
+else
+	fail "A6 composed schema-v2 readiness round trip" "exit=$readiness_rc output=$readiness_output"
+fi
+
+# Test A7: no brief file → returns input unchanged
 result=$(_compose_issue_worker_guidance "base body" "$TMP/nonexistent.md")
 if [[ "$result" == "base body" ]]; then
-	pass "A6 no brief file returns input body unchanged"
+	pass "A7 no brief file returns input body unchanged"
 else
-	fail "A6 no brief file" "expected 'base body', got '$result'"
+	fail "A7 no brief file" "expected 'base body', got '$result'"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-brief-readiness.sh
+++ b/.agents/scripts/tests/test-brief-readiness.sh
@@ -424,6 +424,24 @@ const record = { path: configPath, command: runCommand };
 \`\`\`
 "
 
+# Generated GitHub wrappers are prose structure, not unfinished placeholders.
+# Their inner text must remain available to normal readiness checks.
+BODY_V2_WITH_GENERATED_HTML="${BODY_V2_COMPLETE}
+
+<details open class=\"generated-context\"><summary data-kind=\"related-file\"><code dir=\"ltr\">src/related.sh</code></summary>
+Generated architecture context remains part of the composed issue body.
+<details><summary>Nested context</summary>Nested evidence remains visible.</details>
+</details>
+"
+
+BODY_V2_WITH_PATH_PLACEHOLDER="${BODY_V2_COMPLETE}
+
+The implementation still needs <path> before dispatch."
+
+BODY_V2_WITH_COMMAND_PLACEHOLDER="${BODY_V2_COMPLETE}
+
+<details><summary>Verification still required</summary>Run <command> before dispatch.</details>"
+
 # Short concrete paths remain substantive, and Bun is a supported verifier.
 # shellcheck disable=SC2016
 BODY_V2_SHORT_PATH_BUN=$(printf '%s\n' "$BODY_V2_COMPLETE" | sed \
@@ -801,6 +819,31 @@ if [[ "$output" == *"WORKER_READY=true"* && "$output" == *"SCHEMA=legacy"* ]]; t
 	pass "T28: fenced schema marker remains a legacy example"
 else
 	fail "T28: fence-aware schema marker detection" "output: $output"
+fi
+
+# --- Test 29: generated HTML wrappers, attributes, and nesting are accepted ---
+output=$("$HELPER" check --body "$BODY_V2_WITH_GENERATED_HTML" 2>/dev/null)
+rc=$?
+if [[ $rc -eq 0 && "$output" == *"WORKER_READY=true"* && "$output" == *"VALIDATION_ERRORS=none"* ]]; then
+	pass "T29: generated HTML wrappers are normalized without losing inner text"
+else
+	fail "T29: generated HTML wrapper normalization" "got exit $rc, output: $output"
+fi
+
+# --- Test 30: unknown path placeholders remain rejectable prose ---
+output=$("$HELPER" check --body "$BODY_V2_WITH_PATH_PLACEHOLDER" 2>/dev/null)
+if [[ "$output" == *"WORKER_READY=false"* && "$output" == *"placeholder:unfilled"* ]]; then
+	pass "T30: unknown <path> placeholder remains rejected"
+else
+	fail "T30: unknown path placeholder rejection" "output: $output"
+fi
+
+# --- Test 31: generated wrappers preserve unknown placeholders in inner prose ---
+output=$("$HELPER" check --body "$BODY_V2_WITH_COMMAND_PLACEHOLDER" 2>/dev/null)
+if [[ "$output" == *"WORKER_READY=false"* && "$output" == *"placeholder:unfilled"* ]]; then
+	pass "T31: generated wrappers preserve and reject inner <command> placeholders"
+else
+	fail "T31: generated wrapper inner-text preservation" "output: $output"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Normalize only generated details, summary, and code tag tokens before placeholder detection; preserve inner prose and unknown placeholders; add isolated and producer/consumer round-trip regressions.

## Files Changed

.agents/scripts/brief-readiness-parser.awk, .agents/scripts/tests/test-brief-inline-classifier.sh, .agents/scripts/tests/test-brief-readiness.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-brief-readiness.sh (38 passed); .agents/scripts/tests/test-brief-inline-classifier.sh (20 passed); shellcheck and bash -n clean for modified shell tests.

Resolves #28446


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 6m and 107,096 tokens on this as a headless worker.