### PR TITLE
GH#28440: persist owner-safe deferred cleanup handoffs

### DIFF
--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Durable, external lifecycle receipts for owner-safe full-loop cleanup.
+# The receipt survives removal of the linked worktree and lets a later guarded
+# cleanup process assume the lease and record the terminal CLEANED transition.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+[[ -n "${_FULL_LOOP_CLEANUP_RECEIPT_LOADED:-}" ]] && return 0
+_FULL_LOOP_CLEANUP_RECEIPT_LOADED=1
+
+_FULL_LOOP_CLEANUP_DEFERRED="CLEANUP_DEFERRED"
+_FULL_LOOP_CLEANUP_LEASED="CLEANUP_LEASED"
+_FULL_LOOP_CLEANUP_CLEANED="CLEANED"
+
+_full_loop_cleanup_receipt_dir() {
+	printf '%s\n' "${AIDEVOPS_FULL_LOOP_CLEANUP_DIR:-${HOME}/.aidevops/state/full-loop-cleanup}"
+	return 0
+}
+
+_full_loop_cleanup_receipt_path() {
+	local repo="$1"
+	local pr_number="$2"
+	local receipt_dir=""
+	local safe_repo="${repo//\//_}"
+
+	[[ -n "$repo" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	receipt_dir=$(_full_loop_cleanup_receipt_dir) || return 1
+	printf '%s/%s-%s.json\n' "$receipt_dir" "$safe_repo" "$pr_number"
+	return 0
+}
+
+_full_loop_process_identity() {
+	local owner_pid="$1"
+	local identity=""
+
+	[[ "$owner_pid" =~ ^[0-9]+$ ]] || return 1
+	identity=$(ps -p "$owner_pid" -o lstart= 2>/dev/null || true)
+	[[ -n "$identity" ]] || return 1
+	printf '%s\n' "$identity"
+	return 0
+}
+
+full_loop_write_cleanup_deferred() {
+	local repo="$1"
+	local pr_number="$2"
+	local worktree="$3"
+	local branch="$4"
+	local owner_pid="$5"
+	local owner_session="$6"
+	local release_status="${7:-pending}"
+	local executor_completion_state="${8:-COMPLETE}"
+	local receipt_path=""
+	local owner_identity=""
+	local now=""
+
+	[[ -n "$worktree" && -n "$branch" && "$owner_pid" =~ ^[0-9]+$ ]] || return 1
+	[[ "$executor_completion_state" == "FINALIZATION_PENDING" || "$executor_completion_state" == "COMPLETE" ]] || return 1
+	command -v jq >/dev/null 2>&1 || return 1
+	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
+	owner_identity=$(_full_loop_process_identity "$owner_pid") || return 1
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	mkdir -p "${receipt_path%/*}" || return 1
+	jq -cn \
+		--arg repo "$repo" --argjson pr_number "$pr_number" \
+		--arg worktree "$worktree" --arg branch "$branch" \
+		--argjson owner_pid "$owner_pid" --arg owner_identity "$owner_identity" \
+		--arg owner_session "$owner_session" --arg release_status "$release_status" \
+		--arg executor_completion_state "$executor_completion_state" \
+		--arg state "$_FULL_LOOP_CLEANUP_DEFERRED" --arg now "$now" \
+		'{schema_version:1,repository:$repo,pr_number:$pr_number,worktree:$worktree,branch:$branch,
+		  executor_completion_state:$executor_completion_state,resource_cleanup_state:$state,release_status:$release_status,
+		  owner:{pid:$owner_pid,process_identity:$owner_identity,session:$owner_session},
+		  cleanup_lease:{state:"pending",pid:null,acquired_at:null},created_at:$now,updated_at:$now,cleaned_at:null}' \
+		>"${receipt_path}.tmp.$$" || return 1
+	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
+	printf '%s\n' "$receipt_path"
+	return 0
+}
+
+full_loop_cleanup_receipt_for_worktree() {
+	local worktree="$1"
+	local receipt_dir=""
+	local receipt_path=""
+
+	[[ -n "$worktree" ]] || return 1
+	receipt_dir=$(_full_loop_cleanup_receipt_dir) || return 1
+	[[ -d "$receipt_dir" ]] || return 1
+	for receipt_path in "$receipt_dir"/*.json; do
+		[[ -f "$receipt_path" ]] || continue
+		if jq -e --arg worktree "$worktree" '.worktree == $worktree' "$receipt_path" >/dev/null 2>&1; then
+			printf '%s\n' "$receipt_path"
+			return 0
+		fi
+	done
+	return 1
+}
+
+full_loop_cleanup_owner_alive() {
+	local receipt_path="$1"
+	local owner_pid=""
+	local expected_identity=""
+	local observed_identity=""
+
+	[[ -f "$receipt_path" ]] || return 1
+	owner_pid=$(jq -r '.owner.pid // empty' "$receipt_path" 2>/dev/null || true)
+	expected_identity=$(jq -r '.owner.process_identity // empty' "$receipt_path" 2>/dev/null || true)
+	[[ "$owner_pid" =~ ^[0-9]+$ && -n "$expected_identity" ]] || return 1
+	kill -0 "$owner_pid" 2>/dev/null || return 1
+	observed_identity=$(_full_loop_process_identity "$owner_pid") || return 1
+	[[ "$observed_identity" == "$expected_identity" ]] || return 1
+	return 0
+}
+
+full_loop_transition_cleanup_receipt() {
+	local receipt_path="$1"
+	local target_state="$2"
+	local lease_pid="${3:-}"
+	local current_state=""
+	local now=""
+
+	[[ -f "$receipt_path" ]] || return 1
+	case "$target_state" in
+	"$_FULL_LOOP_CLEANUP_DEFERRED" | "$_FULL_LOOP_CLEANUP_LEASED" | "$_FULL_LOOP_CLEANUP_CLEANED") ;;
+	*) return 1 ;;
+	esac
+	current_state=$(jq -r '.resource_cleanup_state // empty' "$receipt_path" 2>/dev/null || true)
+	case "${current_state}:${target_state}" in
+	"${_FULL_LOOP_CLEANUP_DEFERRED}:${_FULL_LOOP_CLEANUP_DEFERRED}" | \
+		"${_FULL_LOOP_CLEANUP_DEFERRED}:${_FULL_LOOP_CLEANUP_LEASED}" | \
+		"${_FULL_LOOP_CLEANUP_DEFERRED}:${_FULL_LOOP_CLEANUP_CLEANED}" | \
+		"${_FULL_LOOP_CLEANUP_LEASED}:${_FULL_LOOP_CLEANUP_LEASED}" | \
+		"${_FULL_LOOP_CLEANUP_LEASED}:${_FULL_LOOP_CLEANUP_CLEANED}" | \
+		"${_FULL_LOOP_CLEANUP_CLEANED}:${_FULL_LOOP_CLEANUP_CLEANED}") ;;
+	*) return 1 ;;
+	esac
+	if [[ "$target_state" == "$_FULL_LOOP_CLEANUP_LEASED" ]]; then
+		[[ "$lease_pid" =~ ^[0-9]+$ ]] || return 1
+	fi
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	jq --arg state "$target_state" --arg now "$now" --arg lease_pid "$lease_pid" '
+		.resource_cleanup_state = $state
+		| .updated_at = $now
+		| if $state == "CLEANUP_LEASED" then
+			.cleanup_lease = {state:"acquired",pid:($lease_pid | tonumber),acquired_at:$now}
+		  elif $state == "CLEANED" then
+			.cleanup_lease.state = "released" | .cleaned_at = $now
+		  else . end
+	' "$receipt_path" >"${receipt_path}.tmp.$$" || return 1
+	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
+	return 0
+}
+
+full_loop_update_cleanup_release_status() {
+	local repo="$1"
+	local pr_number="$2"
+	local release_status="$3"
+	local receipt_path=""
+	local now=""
+
+	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
+	[[ -f "$receipt_path" ]] || return 0
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	jq --arg release_status "$release_status" --arg now "$now" \
+		'.release_status = $release_status | .updated_at = $now' \
+		"$receipt_path" >"${receipt_path}.tmp.$$" || return 1
+	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
+	return 0
+}
+
+full_loop_mark_cleanup_cleaned_for_worktree() {
+	local worktree="$1"
+	local cleanup_log="${2:-${AIDEVOPS_CLEANUP_LOG:-${HOME}/.aidevops/logs/cleanup_worktrees.log}}"
+	local receipt_path=""
+
+	[[ -n "$worktree" && ! -e "$worktree" && -f "$cleanup_log" ]] || return 1
+	grep -Fq "worktree-removed: ${worktree} —" "$cleanup_log" || return 1
+	receipt_path=$(full_loop_cleanup_receipt_for_worktree "$worktree") || return 1
+	full_loop_transition_cleanup_receipt "$receipt_path" "$_FULL_LOOP_CLEANUP_CLEANED"
+	return $?
+}
+
+full_loop_reconcile_cleanup_receipts() {
+	local receipt_dir=""
+	local receipt_path=""
+	local worktree=""
+	local state=""
+	local cleanup_log="${AIDEVOPS_CLEANUP_LOG:-${HOME}/.aidevops/logs/cleanup_worktrees.log}"
+
+	receipt_dir=$(_full_loop_cleanup_receipt_dir) || return 0
+	[[ -d "$receipt_dir" && -f "$cleanup_log" ]] || return 0
+	for receipt_path in "$receipt_dir"/*.json; do
+		[[ -f "$receipt_path" ]] || continue
+		state=$(jq -r '.resource_cleanup_state // empty' "$receipt_path" 2>/dev/null || true)
+		[[ "$state" != "$_FULL_LOOP_CLEANUP_CLEANED" ]] || continue
+		worktree=$(jq -r '.worktree // empty' "$receipt_path" 2>/dev/null || true)
+		[[ -n "$worktree" && ! -e "$worktree" ]] || continue
+		grep -Fq "worktree-removed: ${worktree} —" "$cleanup_log" || continue
+		full_loop_transition_cleanup_receipt "$receipt_path" "$_FULL_LOOP_CLEANUP_CLEANED" || true
+	done
+	return 0
+}

--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -84,6 +84,9 @@ full_loop_cleanup_receipt_for_worktree() {
 	local worktree="$1"
 	local receipt_dir=""
 	local receipt_path=""
+	local selected_path=""
+	local selected_created_at=""
+	local candidate_created_at=""
 
 	[[ -n "$worktree" ]] || return 1
 	receipt_dir=$(_full_loop_cleanup_receipt_dir) || return 1
@@ -91,11 +94,16 @@ full_loop_cleanup_receipt_for_worktree() {
 	for receipt_path in "$receipt_dir"/*.json; do
 		[[ -f "$receipt_path" ]] || continue
 		if jq -e --arg worktree "$worktree" '.worktree == $worktree' "$receipt_path" >/dev/null 2>&1; then
-			printf '%s\n' "$receipt_path"
-			return 0
+			candidate_created_at=$(jq -r '.created_at // empty' "$receipt_path" 2>/dev/null || true)
+			if [[ -z "$selected_path" || "$candidate_created_at" > "$selected_created_at" ]]; then
+				selected_path="$receipt_path"
+				selected_created_at="$candidate_created_at"
+			fi
 		fi
 	done
-	return 1
+	[[ -n "$selected_path" ]] || return 1
+	printf '%s\n' "$selected_path"
+	return 0
 }
 
 full_loop_cleanup_owner_alive() {

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -46,6 +46,11 @@ source "${SCRIPT_DIR}/shared-phase-filing.sh"
 # shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
 source "${SCRIPT_DIR}/gh-merge-cache-remediation-lib.sh"
 
+if [[ -f "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh" ]]; then
+	# shellcheck source=./full-loop-cleanup-receipt.sh
+	source "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh"
+fi
+
 # --- Repo Resolution ---
 
 # _merge_resolve_repo — resolve repo slug from argument or auto-detect from git remote.
@@ -750,7 +755,9 @@ _merge_cleanup_linked_worktree() {
 }
 
 _merge_record_deferred_cleanup_owner() {
-	local cleanup_plan="$1"
+	local pr_number="$1"
+	local repo="$2"
+	local cleanup_plan="$3"
 	local worktree_path="" branch_name="" canonical_dir=""
 	IFS=$'\t' read -r worktree_path branch_name canonical_dir <<<"$cleanup_plan"
 	[[ -n "$worktree_path" && -n "$branch_name" ]] || return 1
@@ -766,8 +773,17 @@ _merge_record_deferred_cleanup_owner() {
 	local marker_dir="${worktree_path}/.agents"
 	local marker_path="${marker_dir}/.full-loop-cleanup-deferred"
 	mkdir -p "$marker_dir" || return 1
+	# Keep the legacy marker during rollout so an older deployed cleanup
+	# supervisor still preserves the live owner. The external receipt below is
+	# the durable source of lifecycle truth and survives worktree removal.
 	printf '%s\n' "$owner_pid" >"${marker_path}.tmp.$$" || return 1
 	mv "${marker_path}.tmp.$$" "$marker_path" || return 1
+	local owner_session="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-full-loop-merge}}}"
+	if ! declare -F full_loop_write_cleanup_deferred >/dev/null 2>&1; then
+		return 1
+	fi
+	full_loop_write_cleanup_deferred "$repo" "$pr_number" "$worktree_path" "$branch_name" \
+		"$owner_pid" "$owner_session" "pending" "FINALIZATION_PENDING" >/dev/null || return 1
 
 	if declare -F claim_worktree_ownership >/dev/null 2>&1; then
 		claim_worktree_ownership "$worktree_path" "$branch_name" \
@@ -819,10 +835,10 @@ _merge_finalize_post_merge() {
 
 	_merge_unlock_resources "$pr_number" "$repo"
 	if [[ "$has_auto" -eq 0 && -n "$cleanup_plan" ]]; then
-		if _merge_record_deferred_cleanup_owner "$cleanup_plan"; then
-			print_info "Post-merge worktree cleanup deferred until the parent runtime exits"
+		if _merge_record_deferred_cleanup_owner "$pr_number" "$repo" "$cleanup_plan"; then
+			print_info "LIFECYCLE_STATE=CLEANUP_DEFERRED; guarded cleanup ownership persisted outside the worktree"
 		else
-			print_warning "Post-merge worktree cleanup deferred, but parent-runtime marker could not be recorded"
+			print_warning "Post-merge worktree cleanup deferred, but durable handoff evidence could not be recorded"
 		fi
 	fi
 	return 0

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -26,10 +26,12 @@ _FULL_LOOP_STATE_LIB_LOADED=1
 _FULL_LOOP_RELEASE_NOT_REQUESTED="not-requested"
 _FULL_LOOP_RELEASE_PUBLISHED="published"
 _FULL_LOOP_EXECUTOR_INITIALIZED="initialized-only"
+_FULL_LOOP_EXECUTOR_IN_PROGRESS="in-progress"
 _FULL_LOOP_PHASE_FAILED="failed"
 _FULL_LOOP_PHASE_RUNNING="running"
 _FULL_LOOP_PHASE_WAITING="waiting"
 _FULL_LOOP_PHASE_TASK="task"
+_FULL_LOOP_RESOURCE_NONE="none"
 FULL_LOOP_TRANSITION_LOCK_TOKEN=""
 FULL_LOOP_TRANSITION_LOCK_DEPTH=0
 
@@ -41,6 +43,11 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+if [[ -f "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh" ]]; then
+	# shellcheck source=./full-loop-cleanup-receipt.sh
+	source "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh"
+fi
+
 # --- State Management ---
 
 save_state() {
@@ -49,7 +56,7 @@ save_state() {
 	now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 	local tmp_file="${STATE_FILE}.tmp.$$"
 	RUN_ID="${RUN_ID:-run-$(date -u '+%Y%m%dT%H%M%SZ')-$$}"
-	STATE_REVISION=$(( ${STATE_REVISION:-0} + 1 ))
+	STATE_REVISION=$((${STATE_REVISION:-0} + 1))
 	mkdir -p "$STATE_DIR"
 	cat >"$tmp_file" <<EOF
 ---
@@ -645,14 +652,22 @@ _parse_start_options() {
 			;;
 		--release-type)
 			RELEASE_TYPE="${2:-}"
-			case "$RELEASE_TYPE" in patch | minor | major) ;; *) print_error "Invalid release type: $RELEASE_TYPE"; return 1 ;; esac
+			case "$RELEASE_TYPE" in patch | minor | major) ;; *)
+				print_error "Invalid release type: $RELEASE_TYPE"
+				return 1
+				;;
+			esac
 			RELEASE_INTENT=true
 			RELEASE_STATUS=authorized
 			shift 2
 			;;
 		--deployment-scope)
 			DEPLOYMENT_SCOPE="${2:-}"
-			case "$DEPLOYMENT_SCOPE" in incremental | full) ;; *) print_error "Invalid deployment scope: $DEPLOYMENT_SCOPE"; return 1 ;; esac
+			case "$DEPLOYMENT_SCOPE" in incremental | full) ;; *)
+				print_error "Invalid deployment scope: $DEPLOYMENT_SCOPE"
+				return 1
+				;;
+			esac
 			shift 2
 			;;
 		--headless)
@@ -972,7 +987,7 @@ _full_loop_record_merged_pr() {
 cmd_status() {
 	is_loop_active || {
 		if [[ "${1:-}" == "--json" ]]; then
-			printf '{"active":false,"executor_status":"inactive"}\n'
+			printf '{"active":false,"executor_status":"inactive","executor_completion_state":"inactive","resource_cleanup_state":"%s"}\n' "$_FULL_LOOP_RESOURCE_NONE"
 			return 0
 		fi
 		echo "No active full loop"
@@ -980,6 +995,10 @@ cmd_status() {
 	}
 	load_state
 	local observed_status="$EXECUTOR_STATUS"
+	local executor_completion_state="$_FULL_LOOP_EXECUTOR_IN_PROGRESS"
+	local resource_cleanup_state="$_FULL_LOOP_RESOURCE_NONE"
+	local cleanup_worktree=""
+	local cleanup_receipt=""
 	if [[ "$observed_status" == "$_FULL_LOOP_PHASE_RUNNING" ]]; then
 		local observed_command=""
 		local heartbeat_file="${STATE_DIR}/full-loop.heartbeat"
@@ -990,24 +1009,38 @@ cmd_status() {
 		now_epoch=$(date +%s)
 		[[ "$max_heartbeat_age" =~ ^[1-9][0-9]*$ ]] || max_heartbeat_age=120
 		[[ "$EXECUTOR_PID" =~ ^[0-9]+$ ]] && observed_command=$(ps -p "$EXECUTOR_PID" -o command= 2>/dev/null || true)
-		if [[ ! "$EXECUTOR_PID" =~ ^[0-9]+$ ]] || ! kill -0 "$EXECUTOR_PID" 2>/dev/null || \
-			[[ -z "$EXECUTOR_IDENTITY" || "$observed_command" != *"$EXECUTOR_IDENTITY"* || "$heartbeat_run" != "$RUN_ID" ]] || \
+		if [[ ! "$EXECUTOR_PID" =~ ^[0-9]+$ ]] || ! kill -0 "$EXECUTOR_PID" 2>/dev/null ||
+			[[ -z "$EXECUTOR_IDENTITY" || "$observed_command" != *"$EXECUTOR_IDENTITY"* || "$heartbeat_run" != "$RUN_ID" ]] ||
 			[[ "$heartbeat_epoch" -eq 0 || $((now_epoch - heartbeat_epoch)) -gt "$max_heartbeat_age" ]]; then
 			observed_status="stale"
 		fi
 	fi
+	if [[ "${PR_NUMBER:-}" =~ ^[0-9]+$ ]]; then
+		local status_repo=""
+		status_repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}" 2>/dev/null || true)
+		if [[ -n "$status_repo" ]] && declare -F _full_loop_cleanup_receipt_path >/dev/null 2>&1; then
+			cleanup_receipt=$(_full_loop_cleanup_receipt_path "$status_repo" "$PR_NUMBER" 2>/dev/null || true)
+		fi
+	fi
+	if [[ -n "$cleanup_receipt" && -f "$cleanup_receipt" ]]; then
+		executor_completion_state=$(jq -r --arg fallback "$_FULL_LOOP_EXECUTOR_IN_PROGRESS" '.executor_completion_state // $fallback' "$cleanup_receipt" 2>/dev/null || printf '%s' "$_FULL_LOOP_EXECUTOR_IN_PROGRESS")
+		resource_cleanup_state=$(jq -r --arg fallback "$_FULL_LOOP_RESOURCE_NONE" '.resource_cleanup_state // $fallback' "$cleanup_receipt" 2>/dev/null || printf '%s' "$_FULL_LOOP_RESOURCE_NONE")
+		cleanup_worktree=$(jq -r '.worktree // empty' "$cleanup_receipt" 2>/dev/null || true)
+	fi
 	if [[ "${1:-}" == "--json" ]]; then
 		jq -cn --arg run_id "$RUN_ID" --arg phase "$CURRENT_PHASE" --arg phase_status "$PHASE_STATUS" \
 			--arg executor_status "$observed_status" --arg next_action "$NEXT_ACTION" --arg pr_number "${PR_NUMBER:-}" \
+			--arg executor_completion_state "$executor_completion_state" --arg resource_cleanup_state "$resource_cleanup_state" \
+			--arg cleanup_worktree "$cleanup_worktree" \
 			--arg heartbeat_at "${heartbeat_timestamp:-${HEARTBEAT_AT:-}}" \
 			--argjson revision "$STATE_REVISION" --argjson attempts "$PHASE_ATTEMPT" --argjson manual_resumes "$MANUAL_RESUME_COUNT" \
-			'{run_id:$run_id,phase:$phase,phase_status:$phase_status,executor_status:$executor_status,heartbeat_at:$heartbeat_at,next_action:$next_action,pr_number:$pr_number,state_revision:$revision,phase_attempts:$attempts,manual_resumes:$manual_resumes}'
+			'{run_id:$run_id,phase:$phase,phase_status:$phase_status,executor_status:$executor_status,executor_completion_state:$executor_completion_state,resource_cleanup_state:$resource_cleanup_state,cleanup_worktree:$cleanup_worktree,heartbeat_at:$heartbeat_at,next_action:$next_action,pr_number:$pr_number,state_revision:$revision,phase_attempts:$attempts,manual_resumes:$manual_resumes}'
 		return 0
 	fi
 	printf "\n${BOLD}Full Loop Status${NC}\nPhase: ${CYAN}%s${NC} | Started: %s | PR: %s | Headless: %s\nPrompt: %s\n\n" \
 		"$CURRENT_PHASE" "$STARTED_AT" "${PR_NUMBER:-none}" "$HEADLESS" "$(echo "$SAVED_PROMPT" | head -3)"
-	printf 'Executor: %s | Phase status: %s | Attempts: %s | Next: %s\n' \
-		"$observed_status" "$PHASE_STATUS" "$PHASE_ATTEMPT" "$NEXT_ACTION"
+	printf 'Executor: %s (%s) | Resource cleanup: %s | Phase status: %s | Attempts: %s | Next: %s\n' \
+		"$observed_status" "$executor_completion_state" "$resource_cleanup_state" "$PHASE_STATUS" "$PHASE_ATTEMPT" "$NEXT_ACTION"
 	return 0
 }
 
@@ -1078,9 +1111,33 @@ cmd_complete() {
 	esac
 	local current_root=""
 	current_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-	print_warning "LIFECYCLE_STATE=DEPLOYED cleanup remains pending for ${current_root:-unknown-worktree}"
-	print_info "After guarded cleanup, run: full-loop-helper.sh complete-after-cleanup ${PR_NUMBER} '${current_root}'"
-	return 1
+	local current_branch=""
+	local repo=""
+	local owner_pid=""
+	local owner_session="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-full-loop-complete}}}"
+	current_branch=$(git branch --show-current 2>/dev/null || true)
+	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || {
+		print_error "Cannot resolve repository for deferred cleanup handoff"
+		return 1
+	}
+	owner_pid="${PPID:-}"
+	if declare -F _resolve_worktree_owner_pid >/dev/null 2>&1; then
+		owner_pid=$(_resolve_worktree_owner_pid "" 2>/dev/null || printf '%s' "${PPID:-}")
+	fi
+	if [[ -n "$current_root" && -n "$current_branch" ]] && declare -F full_loop_write_cleanup_deferred >/dev/null 2>&1; then
+		full_loop_write_cleanup_deferred "$repo" "$PR_NUMBER" "$current_root" "$current_branch" \
+			"$owner_pid" "$owner_session" "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" >/dev/null || {
+			print_error "Cannot persist durable deferred-cleanup handoff"
+			return 1
+		}
+	else
+		print_error "Cannot persist durable deferred-cleanup handoff without worktree and branch evidence"
+		return 1
+	fi
+	print_warning "LIFECYCLE_STATE=CLEANUP_DEFERRED worktree=${current_root}"
+	print_info "Executor complete; guarded cleanup supervisor owns the remaining CLEANED transition"
+	echo "<promise>FULL_LOOP_CLEANUP_DEFERRED</promise>"
+	return 0
 }
 
 _full_loop_resolve_repo() {
@@ -1132,6 +1189,9 @@ cmd_record_no_release() {
 	fi
 	case "$release_status" in
 	"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
+		if declare -F full_loop_update_cleanup_release_status >/dev/null 2>&1; then
+			full_loop_update_cleanup_release_status "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_NOT_REQUESTED" || return 1
+		fi
 		print_info "release:not-requested already recorded for PR #${pr_number}"
 		return 0
 		;;
@@ -1146,6 +1206,9 @@ cmd_record_no_release() {
 		;;
 	esac
 	_full_loop_write_release_receipt "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_NOT_REQUESTED" || return 1
+	if declare -F full_loop_update_cleanup_release_status >/dev/null 2>&1; then
+		full_loop_update_cleanup_release_status "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_NOT_REQUESTED" || return 1
+	fi
 	print_success "release:not-requested recorded for merged PR #${pr_number}"
 	return 0
 }
@@ -1209,6 +1272,12 @@ cmd_complete_after_cleanup() {
 		print_error "Completion blocked: no removal audit evidence for ${removed_worktree}"
 		return 1
 	}
+	if declare -F full_loop_mark_cleanup_cleaned_for_worktree >/dev/null 2>&1; then
+		full_loop_mark_cleanup_cleaned_for_worktree "$removed_worktree" || {
+			print_error "Completion blocked: durable cleanup receipt is not CLEANED for ${removed_worktree}"
+			return 1
+		}
+	fi
 	_full_loop_verify_merged_pr "$pr_number" "$repo" || {
 		print_error "Completion blocked: PR #${pr_number} lacks merged evidence"
 		return 1

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -233,6 +233,7 @@ Commands:
                                  gh CLI level; if both are given, --admin wins and
                                   --auto is dropped (GH#19310).
   record-no-release <PR> [REPO]  Verify merged evidence and record release:not-requested.
+  complete                       Persist CLEANUP_DEFERRED and hand cleanup to a supervisor.
   complete-after-cleanup <PR> <removed-worktree-path> [REPO]
                                  Verify merged, released/deployed, and cleaned evidence.
   help                          Show this help
@@ -266,6 +267,7 @@ main() {
 	wait-checks) cmd_wait_checks "$@" ;;
 	merge) cmd_merge "$@" ;;
 	record-no-release) cmd_record_no_release "$@" ;;
+	complete) cmd_complete "$@" ;;
 	complete-after-cleanup) cmd_complete_after_cleanup "$@" ;;
 	help | --help | -h) show_help ;;
 	*)

--- a/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+OWNER_PID=""
+
+teardown() {
+	if [[ "$OWNER_PID" =~ ^[0-9]+$ ]]; then
+		kill "$OWNER_PID" 2>/dev/null || true
+		wait "$OWNER_PID" 2>/dev/null || true
+	fi
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap teardown EXIT
+
+export HOME="${TEST_ROOT}/home"
+export AIDEVOPS_FULL_LOOP_CLEANUP_DIR="${TEST_ROOT}/cleanup-receipts"
+export AIDEVOPS_CLEANUP_LOG="${TEST_ROOT}/cleanup.log"
+mkdir -p "$HOME" "${TEST_ROOT}/worktree-one" "${TEST_ROOT}/worktree-two"
+
+# shellcheck source=../full-loop-cleanup-receipt.sh
+source "${SCRIPTS_DIR}/full-loop-cleanup-receipt.sh"
+
+sleep 30 &
+OWNER_PID=$!
+
+receipt_one=$(full_loop_write_cleanup_deferred example/repo 101 "${TEST_ROOT}/worktree-one" feature/one \
+	"$OWNER_PID" session-one not-requested)
+jq -e --argjson owner_pid "$OWNER_PID" '
+	.schema_version == 1
+	and .executor_completion_state == "COMPLETE"
+	and .resource_cleanup_state == "CLEANUP_DEFERRED"
+	and .cleanup_lease.state == "pending"
+	and .owner.pid == $owner_pid
+	and (.owner.process_identity | length > 0)
+' "$receipt_one" >/dev/null
+full_loop_cleanup_owner_alive "$receipt_one"
+printf 'PASS deferred receipt persists external owner identity and pending lease\n'
+
+_WTAR_SKIPPED="skipped"
+_WTAR_WH_CALLER="test"
+_WT_CLEAN_MODE_SKIPPED="skipped"
+_WT_CLEAN_REASON_OWNED_SKIP="owned-skip"
+log_worktree_removal_event() { return 0; }
+claim_worktree_ownership() { return 0; }
+unregister_worktree_if_owner_pid() { return 0; }
+is_worktree_owned_by_others() { return 1; }
+# shellcheck source=../worktree-clean-lib.sh
+source "${SCRIPTS_DIR}/worktree-clean-lib.sh"
+_clean_deferred_parent_alive "${TEST_ROOT}/worktree-one"
+printf 'PASS guarded cleanup observes the external live-owner receipt\n'
+
+jq '.owner.process_identity = "different process generation"' "$receipt_one" >"${receipt_one}.tmp"
+mv "${receipt_one}.tmp" "$receipt_one"
+if full_loop_cleanup_owner_alive "$receipt_one"; then
+	printf 'FAIL PID reuse identity mismatch was accepted as the original owner\n'
+	exit 1
+fi
+printf 'PASS process-generation mismatch prevents PID reuse from extending ownership\n'
+
+deferred_state=0
+_clean_deferred_parent_alive "${TEST_ROOT}/worktree-one" || deferred_state=$?
+[[ "$deferred_state" -eq 2 ]]
+printf 'PASS guarded cleanup treats PID reuse as an expired owner generation\n'
+
+receipt_one=$(full_loop_write_cleanup_deferred example/repo 101 "${TEST_ROOT}/worktree-one" feature/one \
+	"$OWNER_PID" session-one not-requested)
+_clean_acquire_removal_lease "${TEST_ROOT}/worktree-one" feature/one
+jq -e --argjson lease_pid "$$" \
+	'.resource_cleanup_state == "CLEANUP_LEASED" and .cleanup_lease.state == "acquired" and .cleanup_lease.pid == $lease_pid' \
+	"$receipt_one" >/dev/null
+printf 'PASS cleanup supervisor acquires a durable lease\n'
+
+printf '[2026-07-21T00:00:00Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' \
+	"${TEST_ROOT}/worktree-one" >>"$AIDEVOPS_CLEANUP_LOG"
+rm -rf "${TEST_ROOT}/worktree-one"
+full_loop_mark_cleanup_cleaned_for_worktree "${TEST_ROOT}/worktree-one"
+full_loop_mark_cleanup_cleaned_for_worktree "${TEST_ROOT}/worktree-one"
+jq -e '.resource_cleanup_state == "CLEANED" and .cleanup_lease.state == "released" and (.cleaned_at | length > 0)' \
+	"$receipt_one" >/dev/null
+if full_loop_transition_cleanup_receipt "$receipt_one" "$_FULL_LOOP_CLEANUP_DEFERRED"; then
+	printf 'FAIL terminal CLEANED receipt regressed to CLEANUP_DEFERRED\n'
+	exit 1
+fi
+printf 'PASS CLEANED transition is idempotent and irreversible\n'
+
+receipt_two=$(full_loop_write_cleanup_deferred example/repo 102 "${TEST_ROOT}/worktree-two" feature/two \
+	"$OWNER_PID" session-two not-requested)
+full_loop_transition_cleanup_receipt "$receipt_two" "$_FULL_LOOP_CLEANUP_LEASED" "$$"
+printf '[2026-07-21T00:00:01Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' \
+	"${TEST_ROOT}/worktree-two" >>"$AIDEVOPS_CLEANUP_LOG"
+rm -rf "${TEST_ROOT}/worktree-two"
+full_loop_reconcile_cleanup_receipts
+jq -e '.resource_cleanup_state == "CLEANED"' "$receipt_two" >/dev/null
+printf 'PASS audit reconciliation repairs a crash between removal and CLEANED persistence\n'
+
+exit 0

--- a/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
@@ -90,6 +90,13 @@ if full_loop_transition_cleanup_receipt "$receipt_one" "$_FULL_LOOP_CLEANUP_DEFE
 fi
 printf 'PASS CLEANED transition is idempotent and irreversible\n'
 
+sleep 1
+newest_receipt=$(full_loop_write_cleanup_deferred example/repo 103 "${TEST_ROOT}/worktree-one" feature/reused \
+	"$OWNER_PID" session-reused not-requested)
+selected_receipt=$(full_loop_cleanup_receipt_for_worktree "${TEST_ROOT}/worktree-one")
+[[ "$selected_receipt" == "$newest_receipt" ]]
+printf 'PASS reused worktree paths select the newest lifecycle receipt\n'
+
 receipt_two=$(full_loop_write_cleanup_deferred example/repo 102 "${TEST_ROOT}/worktree-two" feature/two \
 	"$OWNER_PID" session-two not-requested)
 full_loop_transition_cleanup_receipt "$receipt_two" "$_FULL_LOOP_CLEANUP_LEASED" "$$"

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -10,6 +10,7 @@ ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
 mkdir -p "${ROOT}/bin"
 receipt_dir="${ROOT}/receipts"
+cleanup_receipt_dir="${ROOT}/cleanup-receipts"
 
 cat >"${ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -53,6 +54,10 @@ chmod +x "$runner"
 removed_path="${ROOT}/removed-worktree"
 cleanup_log="${ROOT}/cleanup.log"
 printf '[2026-07-11T00:00:01Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' "$removed_path" >"$cleanup_log"
+export AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir"
+# shellcheck source=../full-loop-cleanup-receipt.sh
+source "${SCRIPTS_DIR}/full-loop-cleanup-receipt.sh"
+full_loop_write_cleanup_deferred testorg/repo 42 "$removed_path" feature/test-cleanup "$$" test-session not-requested >/dev/null
 
 record_runner="${ROOT}/record-runner.sh"
 cat >"$record_runner" <<RUNNER
@@ -179,14 +184,49 @@ if bash "$complete_runner" >/dev/null 2>&1; then
 fi
 printf 'PASS release:failed blocks cleanup before worktree removal\n'
 
+handoff_runner="${ROOT}/handoff-runner.sh"
+cat >"$handoff_runner" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${SCRIPTS_DIR}'
+STATE_DIR='${ROOT}/handoff-state'
+STATE_FILE='${ROOT}/handoff-state/full-loop.state'
+DEFAULT_MAX_TASK_ITERATIONS=50
+DEFAULT_MAX_PREFLIGHT_ITERATIONS=5
+DEFAULT_MAX_PR_ITERATIONS=20
+HEADLESS=false
+source '${SCRIPTS_DIR}/shared-constants.sh'
+source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
+CURRENT_PHASE=complete
+SAVED_PROMPT=test
+PR_NUMBER=43
+STARTED_AT=2026-07-11T00:00:00Z
+RELEASE_STATUS=not-requested
+save_state complete test 43 "\$STARTED_AT"
+cmd_complete
+cmd_status --json
+RUNNER
+chmod +x "$handoff_runner"
+handoff_output=$(AIDEVOPS_FULL_LOOP_REPO=testorg/repo AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" bash "$handoff_runner")
+printf '%s\n' "$handoff_output" | grep -q '<promise>FULL_LOOP_CLEANUP_DEFERRED</promise>'
+handoff_json="${handoff_output##*$'\n'}"
+printf '%s' "$handoff_json" | jq -e \
+	'.executor_completion_state == "COMPLETE" and .resource_cleanup_state == "CLEANUP_DEFERRED"' >/dev/null
+jq -e '.executor_completion_state == "COMPLETE" and .release_status == "not-requested"' \
+	"${cleanup_receipt_dir}/testorg_repo-43.json" >/dev/null
+printf 'PASS interactive completion emits durable executor handoff and machine-readable cleanup state\n'
+
 AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null || {
 	printf 'FAIL complete merged and cleaned evidence was rejected\n'
 	exit 1
 }
+jq -e '.resource_cleanup_state == "CLEANED" and .cleanup_lease.state == "released" and (.cleaned_at | length > 0)' \
+	"${cleanup_receipt_dir}/testorg_repo-42.json" >/dev/null
 printf 'PASS merged and cleaned evidence completes lifecycle\n'
 
 rm -f "${receipt_dir}/marcusquinn_aidevops-42.status"
 AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$record_runner" 42 marcusquinn/aidevops >/dev/null
+full_loop_write_cleanup_deferred marcusquinn/aidevops 42 "$removed_path" feature/test-cleanup "$$" test-session not-requested >/dev/null
 AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" marcusquinn/aidevops >/dev/null || {
 	printf 'FAIL merge-only aidevops lifecycle did not complete with release:not-requested\n'
 	exit 1

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -157,6 +157,7 @@ setup_subject() {
 	trap teardown EXIT
 	export HOME="${TEST_ROOT}/home"
 	export AIDEVOPS_SKIP_AUTO_CLAIM=1
+	export AIDEVOPS_FULL_LOOP_CLEANUP_DIR="${TEST_ROOT}/cleanup-receipts"
 	mkdir -p "$HOME" "${TEST_ROOT}/bin"
 	cat >"${TEST_ROOT}/bin/trash" <<'TRASH'
 #!/usr/bin/env bash
@@ -212,6 +213,9 @@ test_cmd_merge_defers_current_linked_worktree() {
 	local rc=0
 	local marker_path="${worktree_path}/.agents/.full-loop-cleanup-deferred"
 	local marker_pid=""
+	local receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	local receipt_worktree=""
+	receipt_worktree=$(git -C "$worktree_path" rev-parse --show-toplevel)
 	git -C "$canonical_repo" worktree list --porcelain | grep -q "$worktree_path" || rc=1
 	[[ -d "$worktree_path" ]] || rc=1
 	git -C "$canonical_repo" show-ref --verify --quiet refs/heads/feature/full-loop-cleanup || rc=1
@@ -219,6 +223,12 @@ test_cmd_merge_defers_current_linked_worktree() {
 	IFS= read -r marker_pid <"$marker_path" || rc=1
 	[[ "$marker_pid" =~ ^[0-9]+$ ]] || rc=1
 	kill -0 "$marker_pid" 2>/dev/null || rc=1
+	[[ -f "$receipt_path" ]] || rc=1
+	jq -e --arg worktree "$receipt_worktree" --arg branch "feature/full-loop-cleanup" \
+		'.resource_cleanup_state == "CLEANUP_DEFERRED" and .executor_completion_state == "FINALIZATION_PENDING"
+		 and .cleanup_lease.state == "pending" and .worktree == $worktree and .branch == $branch
+		 and (.owner.pid | type == "number") and (.owner.process_identity | length > 0)' \
+		"$receipt_path" >/dev/null || rc=1
 	if [[ "$(git -C "$canonical_repo" branch --show-current)" != "feature/active" ]]; then
 		rc=1
 	fi
@@ -228,7 +238,7 @@ test_cmd_merge_defers_current_linked_worktree() {
 	# Cleanup is deferred before canonical refresh because the parent runtime may
 	# still use this logical project directory.
 	if [[ "$(git -C "$canonical_repo" rev-parse main)" == "$remote_main" ]]; then rc=1; fi
-	print_result "cmd_merge defers current linked worktree until parent runtime exits" "$rc"
+	print_result "cmd_merge persists external deferred-cleanup ownership" "$rc"
 	return 0
 }
 

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -46,12 +46,31 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+if [[ -f "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh" ]]; then
+	# shellcheck source=./full-loop-cleanup-receipt.sh
+	source "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh"
+fi
+
 # --- Functions ---
 
 _clean_deferred_parent_alive() {
 	local wt_path="$1"
 	local marker_path="${wt_path}/${_WT_CLEAN_DEFERRED_MARKER}"
+	local receipt_path=""
 	_WT_CLEAN_DEFERRED_OWNER_PID=""
+	_WT_CLEAN_DEFERRED_RECEIPT=""
+	if declare -F full_loop_cleanup_receipt_for_worktree >/dev/null 2>&1; then
+		receipt_path=$(full_loop_cleanup_receipt_for_worktree "$wt_path" 2>/dev/null || true)
+	fi
+	if [[ -n "$receipt_path" && -f "$receipt_path" ]]; then
+		_WT_CLEAN_DEFERRED_RECEIPT="$receipt_path"
+		_WT_CLEAN_DEFERRED_OWNER_PID=$(jq -r '.owner.pid // empty' "$receipt_path" 2>/dev/null || true)
+		if full_loop_cleanup_owner_alive "$receipt_path"; then
+			return 0
+		fi
+		rm -f "$marker_path" 2>/dev/null || true
+		return 2
+	fi
 	[[ -f "$marker_path" ]] || return 1
 
 	local owner_pid=""
@@ -70,6 +89,14 @@ _clean_acquire_removal_lease() {
 	declare -F claim_worktree_ownership >/dev/null 2>&1 || return 1
 	claim_worktree_ownership "$wt_path" "$wt_branch" \
 		--owner-pid "$$" --session "cleanup:$$" --task "worktree-removal" >/dev/null 2>&1 || return 1
+	local receipt_path=""
+	if declare -F full_loop_cleanup_receipt_for_worktree >/dev/null 2>&1; then
+		receipt_path=$(full_loop_cleanup_receipt_for_worktree "$wt_path" 2>/dev/null || true)
+	fi
+	if [[ -n "$receipt_path" ]] && ! full_loop_transition_cleanup_receipt "$receipt_path" "$_FULL_LOOP_CLEANUP_LEASED" "$$"; then
+		unregister_worktree_if_owner_pid "$wt_path" "$$" 2>/dev/null || true
+		return 1
+	fi
 	return 0
 }
 
@@ -82,7 +109,7 @@ _clean_terminal_owner_blocks_cleanup() {
 		return 0
 	fi
 	if [[ "$deferred_parent_state" -eq 2 ]]; then
-		if [[ -n "$_WT_CLEAN_DEFERRED_OWNER_PID" ]] && \
+		if [[ -n "$_WT_CLEAN_DEFERRED_OWNER_PID" ]] &&
 			unregister_worktree_if_owner_pid "$wt_path" "$_WT_CLEAN_DEFERRED_OWNER_PID" 2>/dev/null; then
 			return 1
 		fi
@@ -299,7 +326,7 @@ _skip_cleanup_for_owner() {
 		_skip_cleanup_emit "$wt_branch" "$wt_path" "dead owner PID $owner_pid in cooldown since $owner_dead_seen_at" "owner-pid-dead"
 		return 0
 	fi
-		_skip_cleanup_emit "$wt_branch" "$wt_path" "owned by active session PID $owner_pid" "$_WT_CLEAN_REASON_OWNED_SKIP"
+	_skip_cleanup_emit "$wt_branch" "$wt_path" "owned by active session PID $owner_pid" "$_WT_CLEAN_REASON_OWNED_SKIP"
 	return 0
 }
 
@@ -785,8 +812,8 @@ _clean_select_merge_type() {
 	local merged_prs="$4"
 	local closed_prs="$5"
 
-	if git branch --merged "$default_br" 2>/dev/null | grep -q "^\s*$wt_branch$" \
-		&& ! branch_has_zero_commits_ahead "$wt_branch" "$default_br"; then
+	if git branch --merged "$default_br" 2>/dev/null | grep -q "^\s*$wt_branch$" &&
+		! branch_has_zero_commits_ahead "$wt_branch" "$default_br"; then
 		printf '%s\n' "merged"
 		return 0
 	fi
@@ -1115,6 +1142,9 @@ _clean_remove_classified_worktree() {
 		git branch -D "$worktree_branch" 2>/dev/null || true
 	fi
 	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$worktree_path" "$audit_reason" "$completed_mode" "$audit_context"
+	if declare -F full_loop_mark_cleanup_cleaned_for_worktree >/dev/null 2>&1; then
+		full_loop_mark_cleanup_cleaned_for_worktree "$worktree_path" || true
+	fi
 	printf '%s\n' "$_WT_CLEAN_COMPLETED_EVENT"
 	return 0
 }
@@ -1322,6 +1352,9 @@ cmd_clean() {
 	if ! main_worktree_path=$(_clean_preflight_main_worktree); then
 		return 1
 	fi
+	if declare -F full_loop_reconcile_cleanup_receipts >/dev/null 2>&1; then
+		full_loop_reconcile_cleanup_receipts
+	fi
 
 	echo -e "${BOLD}Checking for worktrees with merged branches...${NC}" >&2
 	echo "" >&2
@@ -1372,6 +1405,9 @@ cmd_clean() {
 	if [[ "$response" =~ ^[Yy]$ ]]; then
 		# Second pass: remove merged worktrees
 		_clean_remove_merged "$default_branch" "$main_worktree_path" "$remote_state_unknown" "$merged_pr_branches" "$open_pr_branches" "$force_merged" "$closed_pr_branches"
+		if declare -F full_loop_reconcile_cleanup_receipts >/dev/null 2>&1; then
+			full_loop_reconcile_cleanup_receipts
+		fi
 		echo -e "${GREEN}Cleanup complete${NC}" >&2
 	else
 		echo "Cancelled" >&2

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -11,13 +11,13 @@ Task/Prompt: $ARGUMENTS
 
 ## Lifecycle Gate (t5096 + GH#5317 — MANDATORY)
 
-`WORKTREE → LOCAL_VERIFIED → PR_OPEN → REMOTE_VERIFIED → {CONTRIBUTION_READY | MERGED → LOCAL_BASE_SYNCED | MERGED → [RELEASED → DEPLOYED]} → CLEANED`
+`WORKTREE → LOCAL_VERIFIED → PR_OPEN → REMOTE_VERIFIED → {CONTRIBUTION_READY | MERGED → LOCAL_BASE_SYNCED | MERGED → [RELEASED → DEPLOYED]} → CLEANUP_DEFERRED → CLEANED`
 
 The terminal path is authority-aware. External contributions stop at a verified ready PR; maintained non-aidevops repositories merge and safely synchronize the local canonical checkout's merged PR base branch; aidevops may continue through release/deploy only with explicit publication intent. Generic full-loop, merge, or "ship the PR" consent is not publication consent. Interactive publication requires explicit trusted release intent in the current issue-started session. Headless publication additionally requires explicit trusted brief scope and trusted `priority:high` or `priority:critical` metadata.
 
 Fatal modes: **GH#5317** (exits without PR), **GH#5096** (exits after PR). Do NOT skip any step:
 
-**Interactive continuity (MANDATORY):** A user's full-loop instruction assigns this entire lifecycle to the primary conversation that received it. Keep the critical path in that session through `FULL_LOOP_COMPLETE`; do not launch a background worker or delegate completion unless the user explicitly requests background execution. Continue autonomously from the current stage and do not stop after setup, implementation, PR creation, merge, or release merely to report progress. Pause only for a material blocker requiring user input. Progress reports must name the last verified stage and current action.
+**Interactive continuity (MANDATORY):** A user's full-loop instruction assigns the executor lifecycle to the primary conversation that received it. Keep the critical path in that session through either observed `FULL_LOOP_COMPLETE` or a durable `CLEANUP_DEFERRED` handoff; do not launch a background worker or delegate implementation, verification, review, or merge unless the user explicitly requests background execution. `CLEANUP_DEFERRED` is terminal for the interactive executor only: a guarded cleanup supervisor owns the remaining resource transition and `FULL_LOOP_COMPLETE` remains reserved for observed `CLEANED`. Continue autonomously from the current stage and do not stop after setup, implementation, PR creation, merge, or release merely to report progress. Pause only for a material blocker requiring user input. Progress reports must name the last verified stage and current action.
 
 **Dual-mode executor contract:** Interactive and headless runs share persisted lifecycle transitions and terminal evidence. Foreground is the interactive default. Explicit `start --background` stays local to the authorizing session and reports `FULL_LOOP_START_RESULT=running` only for a live executor, otherwise `FULL_LOOP_START_RESULT=initialized-only`; it is not permission for remote/headless dispatch. Headless runs never prompt and resume within their brief and budgets. Custom adapters receive `AIDEVOPS_FULL_LOOP_RUN_ID` and `AIDEVOPS_FULL_LOOP_HEARTBEAT_FILE`; `status --json` is authoritative.
 
@@ -46,7 +46,8 @@ For a maintained non-aidevops repo, resolve the synchronization branch from the 
 | 6 | Maintained non-aidevops only — audited local PR-base fast-forward | `LOCAL_BASE_SYNCED` |
 | 7 | Authorized aidevops release/postflight/deploy only | `release:published` or `release:failed` |
 | 8 | Managed closing comments or external upstream hand-off | |
-| 9 | Guarded cleanup after the owner exits | `FULL_LOOP_COMPLETE` |
+| 9 | Persist external cleanup receipt and transfer ownership | `FULL_LOOP_CLEANUP_DEFERRED` |
+| 10 | Supervisor cleanup after owner exit | `FULL_LOOP_COMPLETE` |
 
 ---
 
@@ -218,7 +219,7 @@ Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$R
 
 **4.9 Conditional Postflight + Deploy:** only after `release:published`, verify the tag, GitHub release, required checks, and deployed agent version. Reuse `deploy-agents-on-merge.sh`; incremental is default and `--full` is explicit only. `release:not-requested` skips these stages and still completes closing/cleanup. `release:failed` keeps the lifecycle open.
 
-**4.10 Worktree Cleanup (GH#6740 — MANDATORY):** Immediate merges defer current-worktree removal until the parent runtime exits. External worktrees may be cleaned after the ready PR head is verified and pushed. Never force-remove an actively owned worktree. Confirm guarded cleanup once, then emit `<promise>FULL_LOOP_COMPLETE</promise>` with terminal authority and PR state.
+**4.10 Worktree Cleanup (GH#6740/GH#28440 — MANDATORY):** Immediate merges persist an external `CLEANUP_DEFERRED` receipt before deferring current-worktree removal until the parent runtime exits. The receipt records PR/release state, worktree, branch, PID plus process identity, session owner, and pending cleanup lease. `status --json` exposes executor completion separately from resource-cleanup state. The interactive executor may terminate after `<promise>FULL_LOOP_CLEANUP_DEFERRED</promise>`; this is an auditable ownership transfer, not a claim that the worktree is gone. Pulse or another guarded supervisor may acquire the lease only after owner identity is no longer live, remove the worktree, preserve removal-audit evidence, and idempotently transition the receipt to `CLEANED`. Never force-remove an actively owned worktree. Emit `<promise>FULL_LOOP_COMPLETE</promise>` only after absent-worktree, removal-audit, merged-PR, release, and durable `CLEANED` evidence are all observed.
 
 ---
 


### PR DESCRIPTION
## Summary

- persist deferred full-loop cleanup ownership outside the worktree
- validate process generation to prevent PID reuse from extending ownership
- add durable cleanup leasing, terminal `CLEANED` transitions, and removal-audit reconciliation
- expose executor and resource-cleanup states through machine-readable lifecycle status
- retain the legacy in-worktree marker temporarily for deployed supervisor compatibility

## Verification

- `.agents/scripts/linters-local.sh`
- `bash .agents/scripts/tests/test-full-loop-cleanup-receipt.sh`
- `bash .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh`
- `bash .agents/scripts/tests/test-full-loop-completion-evidence.sh`
- `bash .agents/scripts/tests/test-full-loop-efficient-orchestration.sh`
- `bash .agents/scripts/tests/test-full-loop-doc-spelling.sh`
- `git diff --check`

Resolves #28440

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1h 8m and 876,999 tokens on this with the user in an interactive session.