### PR TITLE
GH#28454: pin Qlty installer to the validated CLI version

### DIFF
--- a/.agents/scripts/tests/test-qlty-workflow-version-pin.sh
+++ b/.agents/scripts/tests/test-qlty-workflow-version-pin.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+EXPECTED_VERSION="0.636.0"
+WORKFLOWS=(
+	".github/workflows/code-quality.yml"
+	".github/workflows/qlty-new-file-gate.yml"
+	".github/workflows/qlty-regression.yml"
+	".github/workflows/ratchet-post-merge.yml"
+)
+
+for workflow in "${WORKFLOWS[@]}"; do
+	workflow_path="${ROOT}/${workflow}"
+	install_count=$(grep -c 'uses: qltysh/qlty-action/install@' "$workflow_path" || true)
+	[[ "$install_count" -gt 0 ]]
+	grep -Fq "QLTY_VERSION: \"${EXPECTED_VERSION}\"" "$workflow_path"
+	printf 'PASS %s pins %s Qlty installer step(s) to %s\n' "$workflow" "$install_count" "$EXPECTED_VERSION"
+done
+
+for workflow in ".github/workflows/code-quality.yml" ".github/workflows/qlty-regression.yml"; do
+	workflow_path="${ROOT}/${workflow}"
+	grep -Fq "QLTY_CLI_VERSION: \"${EXPECTED_VERSION}\"" "$workflow_path"
+	printf 'PASS %s keeps installer and validator versions aligned at %s\n' "$workflow" "$EXPECTED_VERSION"
+done
+
+exit 0

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,5 +1,9 @@
 name: Code Quality Analysis
 
+# qlty-action/install otherwise resolves its moving `latest` release.
+env:
+  QLTY_VERSION: "0.636.0"
+
 on:
   push:
     branches: [ main, develop ]

--- a/.github/workflows/qlty-new-file-gate.yml
+++ b/.github/workflows/qlty-new-file-gate.yml
@@ -1,5 +1,9 @@
 name: Qlty New-File Gate
 
+# qlty-action/install otherwise resolves its moving `latest` release.
+env:
+  QLTY_VERSION: "0.636.0"
+
 # t2068: block PRs that add brand-new source files shipping with any
 # qlty smells.
 #

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -1,5 +1,10 @@
 name: Qlty Regression Gate
 
+# qlty-action/install inherits QLTY_VERSION; keep it aligned with the
+# QLTY_CLI_VERSION contract validated by the helper below.
+env:
+  QLTY_VERSION: "0.636.0"
+
 # t2065: block PRs that increase the total qlty smell count.
 #
 # Runs `qlty smells --all --sarif` against (a) the PR merge-base and

--- a/.github/workflows/ratchet-post-merge.yml
+++ b/.github/workflows/ratchet-post-merge.yml
@@ -1,5 +1,9 @@
 name: Ratchet Post-Merge
 
+# qlty-action/install otherwise resolves its moving `latest` release.
+env:
+  QLTY_VERSION: "0.636.0"
+
 # GH#18775 (t2067): post-merge auto-ratchet for QLTY_SMELL_THRESHOLD.
 # When a PR merges to main and the total qlty smell count drops below
 # `threshold - 2`, this workflow bumps the threshold down to `new_count + 2`


### PR DESCRIPTION
## Summary

- pass the validated `0.636.0` version through the Qlty installer's supported `QLTY_VERSION` contract
- pin all five Qlty action install sites instead of allowing the moving `latest` release
- add a regression test that keeps installer and validator versions aligned

## Evidence

- PR #28453 run `29873375661`, job `88778495952` failed because the helper expected `0.636.0` but the installer resolved `0.637.0`.
- The pinned action's `install_qlty.sh` inherits `QLTY_VERSION`; it does not consume `QLTY_CLI_VERSION`.

## Verification

- `.agents/scripts/tests/test-qlty-workflow-version-pin.sh`
- `.agents/scripts/tests/test-qlty-regression-helper.sh`
- `.agents/scripts/tests/test-qlty-smell-threshold-helper.sh`
- `PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" bash .agents/scripts/tests/test-lint-workflows-helper.sh`
- `actionlint .github/workflows/code-quality.yml .github/workflows/qlty-new-file-gate.yml .github/workflows/qlty-regression.yml .github/workflows/ratchet-post-merge.yml`
- `.agents/scripts/linters-local.sh`

Resolves #28454

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1h 19m and 992,941 tokens on this with the user in an interactive session.