### PR TITLE
GH#28461: report project context scaffold failures

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-project-context-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-project-context-lib.sh
@@ -74,19 +74,34 @@ _init_scaffold_project_context() {
 		return 1
 	}
 
-	mkdir -p "$context_dir"
+	if ! mkdir -p "$context_dir"; then
+		print_error "Failed to create project context directory: $context_dir"
+		return 1
+	fi
 	if [[ ! -f "$context_dir/.gitignore" ]]; then
-		cp "$template_dir/gitignore" "$context_dir/.gitignore"
+		if ! cp "$template_dir/gitignore" "$context_dir/.gitignore"; then
+			print_error "Failed to create .aidevops/.gitignore"
+			return 1
+		fi
 		print_success "Created .aidevops/.gitignore"
 	fi
 	if [[ "$enable_deployment_context" == "$enabled_value" && ! -f "$context_dir/deployments.yaml" ]]; then
-		cp "$template_dir/deployments.yaml" "$context_dir/deployments.yaml"
+		if ! cp "$template_dir/deployments.yaml" "$context_dir/deployments.yaml"; then
+			print_error "Failed to create .aidevops/deployments.yaml"
+			return 1
+		fi
 		print_success "Created .aidevops/deployments.yaml"
 	fi
 	if [[ "$enable_wordpress_context" == "$enabled_value" && ! -f "$context_dir/wordpress.yaml" ]]; then
-		cp "$template_dir/wordpress.yaml" "$context_dir/wordpress.yaml"
+		if ! cp "$template_dir/wordpress.yaml" "$context_dir/wordpress.yaml"; then
+			print_error "Failed to create .aidevops/wordpress.yaml"
+			return 1
+		fi
 		print_success "Created .aidevops/wordpress.yaml"
 	fi
-	_init_update_project_operations_context "$project_root"
+	if ! _init_update_project_operations_context "$project_root"; then
+		print_error "Failed to update project operations context in .agents/AGENTS.md"
+		return 1
+	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-init-project-context.sh
+++ b/.agents/scripts/tests/test-init-project-context.sh
@@ -146,6 +146,29 @@ test_agents_context_write_failures_preserve_original() {
 	return 0
 }
 
+test_scaffold_failures_are_reported() {
+	local mkdir_repo="$TEST_ROOT/mkdir-failure"
+	local copy_repo="$TEST_ROOT/copy-failure"
+	mkdir() { return 1; }
+	if _init_scaffold_project_context "$mkdir_repo" true true; then
+		assert_equal failure success "context directory creation failure is reported"
+	else
+		assert_equal failure failure "context directory creation failure is reported"
+	fi
+	unset -f mkdir
+
+	mkdir -p "$copy_repo"
+	cp() { return 1; }
+	if _init_scaffold_project_context "$copy_repo" true true; then
+		assert_equal failure success "context template copy failure is reported"
+	else
+		assert_equal failure failure "context template copy failure is reported"
+	fi
+	unset -f cp
+	assert_equal false "$([[ -f "$copy_repo/.aidevops/.gitignore" ]] && printf true || printf false)" "failed context template copy is not reported as created"
+	return 0
+}
+
 test_config_booleans() {
 	local config="$TEST_ROOT/config.json"
 	_init_write_project_config "$config" 9.9.9 minimal false false false false false false false false false false true true
@@ -196,6 +219,7 @@ main() {
 	test_feature_parsing
 	test_scaffold_and_idempotency
 	test_agents_context_write_failures_preserve_original
+	test_scaffold_failures_are_reported
 	local full_repo="$TEST_ROOT/full-rerun"
 	mkdir -p "$full_repo"
 	scaffold_agents_md "$full_repo"


### PR DESCRIPTION
## Summary

Fail project context scaffolding when directory creation, template copies, or AGENTS.md updates fail; add regression coverage for directory and copy failures.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-project-context-lib.sh, .agents/scripts/tests/test-init-project-context.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/aidevops-cli/aidevops-project-context-lib.sh .agents/scripts/tests/test-init-project-context.sh; bash .agents/scripts/tests/test-init-project-context.sh (45 tests)

Resolves #28461


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2m and 49,833 tokens on this as a headless worker.