### PR TITLE
GH#28449: prioritize primary pulse merge attempts

### DIFF
--- a/.agents/scripts/pulse-merge-pass.sh
+++ b/.agents/scripts/pulse-merge-pass.sh
@@ -190,6 +190,48 @@ _pmp_merge_pass_budget_exhausted() {
 	return 0
 }
 
+#######################################
+# Compute a separate graceful deadline for post-primary diagnostics. The
+# default consumes at most 30s of the primary pass's 45s reserve and keeps a
+# final 15s for summary/cleanup before the routine watchdog.
+# Args: $1=overall pass start epoch, $2=diagnostic phase start epoch
+# Stdout: deadline epoch (the start epoch means diagnostics are disabled)
+#######################################
+_pmp_merge_diagnostics_deadline() {
+	local pass_start="$1"
+	local diagnostics_start="$2"
+	local budget_seconds="${PULSE_MERGE_DIAGNOSTIC_BUDGET_SECONDS:-30}"
+	local ceiling_seconds="${PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS:-${PRE_RUN_STAGE_TIMEOUT:-0}}"
+	local final_reserve_seconds="${PULSE_MERGE_DIAGNOSTIC_FINAL_RESERVE_SECONDS:-15}"
+	local deadline_epoch=0 hard_deadline=0
+
+	[[ "$pass_start" =~ ^[0-9]+$ ]] || pass_start=0
+	[[ "$diagnostics_start" =~ ^[0-9]+$ ]] || diagnostics_start=0
+	[[ "$budget_seconds" =~ ^[0-9]+$ ]] || budget_seconds=30
+	[[ "$ceiling_seconds" =~ ^[0-9]+$ ]] || ceiling_seconds=0
+	[[ "$final_reserve_seconds" =~ ^[0-9]+$ ]] || final_reserve_seconds=15
+	deadline_epoch=$((diagnostics_start + budget_seconds))
+	if [[ "$ceiling_seconds" -gt 0 && "$pass_start" -gt 0 ]]; then
+		hard_deadline=$((pass_start + ceiling_seconds - final_reserve_seconds))
+		[[ "$hard_deadline" -lt "$diagnostics_start" ]] && hard_deadline="$diagnostics_start"
+		[[ "$deadline_epoch" -gt "$hard_deadline" ]] && deadline_epoch="$hard_deadline"
+	fi
+	printf '%s' "$deadline_epoch"
+	return 0
+}
+
+_pmp_merge_diagnostics_budget_exhausted() {
+	local deadline_epoch="${_PMP_MERGE_DIAGNOSTIC_DEADLINE_EPOCH:-0}"
+	local now_epoch=""
+
+	[[ "$deadline_epoch" =~ ^[0-9]+$ ]] || deadline_epoch=0
+	[[ "$deadline_epoch" -gt 0 ]] || return 1
+	now_epoch=$(_pmp_now_epoch)
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || now_epoch=0
+	[[ "$now_epoch" -ge "$deadline_epoch" ]] || return 1
+	return 0
+}
+
 _pmp_pause_merge_pr_cursor() {
 	local repo_slug="$1"
 	local pr_json="$2"
@@ -304,6 +346,288 @@ _pmp_add_counter_var() {
 	return 0
 }
 
+#######################################
+# Resolve the pass-local evidence directory for one repository.
+# Args: $1=repo slug
+# Stdout: directory path
+# Returns: 0=available, 1=pass-local evidence disabled/unavailable
+#######################################
+_pmp_same_pass_repo_dir() {
+	local repo_slug="$1"
+	local outcome_root="${AIDEVOPS_PULSE_MERGE_OUTCOME_DIR:-}"
+	local repo_key=""
+
+	[[ -n "$repo_slug" && -n "$outcome_root" && -d "$outcome_root" ]] || return 1
+	repo_key=$(_pmp_cache_key "$repo_slug")
+	[[ -n "$repo_key" ]] || return 1
+	printf '%s/%s' "$outcome_root" "$repo_key"
+	return 0
+}
+
+#######################################
+# Record the authoritative outcome of one PR processed in this merge pass.
+# The key includes repository identity, PR number, and the full head SHA. These
+# records are diagnostic-only: merge trust gates never consume them.
+# Args: $1=repo slug, $2=PR number, $3=full head SHA, $4=outcome
+#######################################
+_pmp_record_same_pass_pr_outcome() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local head_sha="$3"
+	local outcome="$4"
+	local repo_dir=""
+	local sha_key=""
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$head_sha" ]] || return 1
+	case "$outcome" in
+	merged | progress | eligible-unmerged | deferred | blocked) ;;
+	*) return 1 ;;
+	esac
+	repo_dir=$(_pmp_same_pass_repo_dir "$repo_slug") || return 1
+	sha_key=$(_pmp_cache_key "$head_sha")
+	[[ -n "$sha_key" ]] || return 1
+	mkdir -p "${repo_dir}/outcomes" 2>/dev/null || return 1
+	printf '%s\t%s\n' "$pr_number" "$outcome" >"${repo_dir}/outcomes/${pr_number}-${sha_key}.outcome" || return 1
+	return 0
+}
+
+#######################################
+# Mark one repository's same-pass PR outcomes as complete. The marker is only
+# written after every PR in a successful list snapshot was processed.
+# Args: $1=repo slug
+#######################################
+_pmp_mark_same_pass_repo_complete() {
+	local repo_slug="$1"
+	local repo_dir=""
+
+	repo_dir=$(_pmp_same_pass_repo_dir "$repo_slug") || return 1
+	mkdir -p "$repo_dir" 2>/dev/null || return 1
+	: >"${repo_dir}/complete" || return 1
+	return 0
+}
+
+#######################################
+# Count exact merge-attempt failures from a complete same-pass repository
+# snapshot. A return code of 1 means callers must not infer zero eligible PRs.
+# Args: $1=repo slug
+# Stdout: eligible-unmerged count
+#######################################
+_pmp_count_same_pass_eligible_unmerged() {
+	local repo_slug="$1"
+	local repo_dir="" outcome_file="" pr_number="" outcome=""
+	local count=0
+
+	repo_dir=$(_pmp_same_pass_repo_dir "$repo_slug") || return 1
+	[[ -f "${repo_dir}/complete" ]] || return 1
+	for outcome_file in "${repo_dir}/outcomes/"*.outcome; do
+		[[ -f "$outcome_file" ]] || continue
+		IFS=$'\t' read -r pr_number outcome <"$outcome_file" || return 1
+		[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
+		case "$outcome" in
+		eligible-unmerged) count=$((count + 1)) ;;
+		merged | progress | deferred | blocked) ;;
+		*) return 1 ;;
+		esac
+	done
+	printf '%s' "$count"
+	return 0
+}
+
+#######################################
+# Preserve normalized current-head check evidence already fetched by the final
+# trust gate for later diagnostics in this same pass. This cache is deliberately
+# never read by a merge decision.
+# Args: $1=repo slug, $2=full head SHA, $3=normalized checks JSON array
+#######################################
+_pmp_record_same_pass_check_evidence() {
+	local repo_slug="$1"
+	local head_sha="$2"
+	local checks_json="$3"
+	local repo_dir=""
+	local sha_key=""
+
+	[[ -n "$head_sha" && -n "$checks_json" && "$checks_json" != "null" ]] || return 1
+	repo_dir=$(_pmp_same_pass_repo_dir "$repo_slug") || return 1
+	sha_key=$(_pmp_cache_key "$head_sha")
+	[[ -n "$sha_key" ]] || return 1
+	mkdir -p "${repo_dir}/checks" 2>/dev/null || return 1
+	printf '%s\n' "$checks_json" >"${repo_dir}/checks/${sha_key}.json" || return 1
+	return 0
+}
+
+#######################################
+# Read normalized current-head check evidence captured earlier in this pass.
+# Args: $1=repo slug, $2=full head SHA
+# Stdout: normalized checks JSON array
+# Returns: 0=valid evidence found, 1=missing/invalid
+#######################################
+_pmp_same_pass_check_evidence_get() {
+	local repo_slug="$1"
+	local head_sha="$2"
+	local repo_dir=""
+	local sha_key=""
+	local evidence_file=""
+	local checks_json=""
+
+	[[ -n "$head_sha" ]] || return 1
+	repo_dir=$(_pmp_same_pass_repo_dir "$repo_slug") || return 1
+	sha_key=$(_pmp_cache_key "$head_sha")
+	evidence_file="${repo_dir}/checks/${sha_key}.json"
+	[[ -s "$evidence_file" ]] || return 1
+	checks_json=$(<"$evidence_file")
+	printf '%s' "$checks_json" | jq -e 'type == "array"' >/dev/null 2>&1 || return 1
+	printf '%s' "$checks_json"
+	return 0
+}
+
+#######################################
+# Collect the zero-progress denominator from authoritative same-pass outcomes.
+# Production callers require this path and never fall back to O(n) network gate
+# re-evaluation. Standalone callers of the stuck helper retain its fallback.
+# Args: $1=repo rows, $2=log file, $3=total var, $4=complete var
+#######################################
+_pmp_collect_same_pass_eligible_unmerged() {
+	local repo_rows="$1"
+	local logfile="$2"
+	local total_var="$3"
+	local complete_var="$4"
+	local total=0 complete=1
+	local repo_slug=""
+	local repo_path=""
+	local repo_eligible=""
+	local AIDEVOPS_PULSE_REQUIRE_SAME_PASS_OUTCOME=1
+
+	[[ "$total_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	[[ "$complete_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	while IFS='|' read -r repo_slug repo_path; do
+		[[ -n "$repo_slug" ]] || continue
+		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+			|| ! repo_allows_pulse_write_actions "$repo_slug"; then
+			continue
+		fi
+		if ! declare -F _pms_count_eligible_unmerged_for_repo >/dev/null 2>&1 \
+			|| ! repo_eligible=$(_pms_count_eligible_unmerged_for_repo "$repo_slug" 2>/dev/null); then
+			complete=0
+			echo "[pulse-wrapper] Zero-progress snapshot unavailable for ${repo_slug}; aggregate not advanced" >>"$logfile"
+			continue
+		fi
+		[[ "$repo_eligible" =~ ^[0-9]+$ ]] || { complete=0; continue; }
+		total=$((total + repo_eligible))
+	done <<<"$repo_rows"
+	printf -v "$total_var" '%s' "$total"
+	printf -v "$complete_var" '%s' "$complete"
+	return 0
+}
+
+_pmp_diagnostic_seconds_for_repo() {
+	local timing_rows="$1"
+	local target_slug="$2"
+	local row_slug="" elapsed=""
+
+	while IFS='|' read -r row_slug elapsed; do
+		[[ "$row_slug" == "$target_slug" ]] || continue
+		[[ "$elapsed" =~ ^[0-9]+$ ]] || elapsed=0
+		printf '%s' "$elapsed"
+		return 0
+	done <<<"$timing_rows"
+	printf '0'
+	return 0
+}
+
+#######################################
+# Run expensive stuck classification only after every primary merge attempt.
+# The detector receives the separate deadline and reports whether it completed.
+# Args: $1=repo rows, $2=pass start, $3=log file, $4=timing rows var,
+#       $5=complete var
+#######################################
+_pmp_run_stuck_diagnostics_for_repos() {
+	local repo_rows="$1"
+	local pass_start="$2"
+	local logfile="$3"
+	local timing_rows_var="$4"
+	local complete_var="$5"
+	local timing_rows="" complete=1
+	local repo_slug=""
+	local repo_path=""
+	local diagnostics_start=""
+	local stuck_start=""
+	local stuck_seconds=0 repo_complete=1
+
+	[[ "$timing_rows_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	[[ "$complete_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	diagnostics_start=$(_pmp_now_epoch)
+	_PMP_MERGE_DIAGNOSTIC_DEADLINE_EPOCH=$(_pmp_merge_diagnostics_deadline "$pass_start" "$diagnostics_start")
+	while IFS='|' read -r repo_slug repo_path; do
+		[[ -n "$repo_slug" ]] || continue
+		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+			|| ! repo_allows_pulse_write_actions "$repo_slug"; then
+			continue
+		fi
+		if _pmp_merge_diagnostics_budget_exhausted; then
+			complete=0
+			echo "[pulse-wrapper] Merge diagnostics: separate graceful budget exhausted before ${repo_slug}; remaining diagnostics deferred" >>"$logfile"
+			break
+		fi
+		stuck_start=$(_pmp_now_epoch)
+		repo_complete=1
+		if declare -F pulse_merge_stuck_run_pass >/dev/null 2>&1; then
+			pulse_merge_stuck_run_pass "$repo_slug" repo_complete || true
+		fi
+		stuck_seconds=0
+		_pmp_add_elapsed_seconds stuck_seconds "$stuck_start"
+		timing_rows="${timing_rows}${repo_slug}|${stuck_seconds}"$'\n'
+		if [[ "$repo_complete" -ne 1 ]]; then
+			complete=0
+			break
+		fi
+	done <<<"$repo_rows"
+	printf -v "$timing_rows_var" '%s' "$timing_rows"
+	printf -v "$complete_var" '%s' "$complete"
+	return 0
+}
+
+_pmp_log_repo_timing_rows() {
+	local primary_rows="$1"
+	local diagnostic_rows="$2"
+	local repo_slug="" total_s=0 list_s=0 mergeability_s=0 ruleset_s=0 branch_protection_s=0
+	local merged=0 closed=0 failed=0 pr_count=0 stuck_s=0
+
+	while IFS='|' read -r repo_slug total_s list_s mergeability_s ruleset_s branch_protection_s merged closed failed pr_count; do
+		[[ -n "$repo_slug" ]] || continue
+		stuck_s=$(_pmp_diagnostic_seconds_for_repo "$diagnostic_rows" "$repo_slug")
+		[[ "$total_s" =~ ^[0-9]+$ ]] || total_s=0
+		total_s=$((total_s + stuck_s))
+		_pmp_log_repo_timing_summary "$repo_slug" "$total_s" "$list_s" "$mergeability_s" "$ruleset_s" "$branch_protection_s" "$stuck_s" "$merged" "$closed" "$failed" "$pr_count"
+	done <<<"$primary_rows"
+	return 0
+}
+
+#######################################
+# Persist the authoritative zero-progress signal before bounded diagnostics.
+# Positive progress is conclusive even for partial/resumed passes; a no-progress
+# denominator is valid only for a fresh, complete pass-local outcome snapshot.
+# Args: $1=eligible, $2=merged, $3=closed, $4=pass complete,
+#       $5=resumed from checkpoint, $6=outcomes complete
+#######################################
+_pmp_record_pass_zero_progress() {
+	local eligible_unmerged="$1"
+	local merged="$2"
+	local closed="$3"
+	local pass_complete="$4"
+	local resumed_from_checkpoint="$5"
+	local outcomes_complete="$6"
+
+	declare -F pulse_merge_zero_progress_record >/dev/null 2>&1 || return 0
+	if [[ "$merged" -gt 0 || "$closed" -gt 0 ]]; then
+		pulse_merge_zero_progress_record 0 "$merged" "$closed" || true
+		return 0
+	fi
+	if [[ "$pass_complete" -eq 1 && "$resumed_from_checkpoint" -eq 0 && "$outcomes_complete" -eq 1 ]]; then
+		pulse_merge_zero_progress_record "$eligible_unmerged" "$merged" "$closed" || true
+	fi
+	return 0
+}
+
 # Persist conclusive queue-draining progress at the mutation boundary. The
 # outer merge routine can be killed by its watchdog before the all-repo pass
 # returns, so the end-of-pass aggregate remains a fallback rather than the only
@@ -331,8 +655,8 @@ _pmp_process_merge_repo_for_pass() {
 	local total_merged_var="$5"
 	local total_closed_var="$6"
 	local total_failed_var="$7"
-	local total_eligible_var="$8"
-	local completed_all_var="$9"
+	local completed_all_var="$8"
+	_PMP_LAST_REPO_TIMING_ROW=""
 
 	if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
 		|| ! repo_allows_pulse_write_actions "$repo_slug"; then
@@ -342,8 +666,8 @@ _pmp_process_merge_repo_for_pass() {
 	fi
 
 	local repo_merged=0 repo_closed=0 repo_failed=0 _mr_repo_pr_count=0
-	local _mr_repo_list_s=0 _mr_repo_mergeability_s=0 _mr_repo_ruleset_s=0 _mr_repo_branch_protection_s=0 _mr_repo_stuck_detector_s=0
-	local _mr_repo_start _mr_repo_stuck_start _mr_repo_total_s=0
+	local _mr_repo_list_s=0 _mr_repo_mergeability_s=0 _mr_repo_ruleset_s=0 _mr_repo_branch_protection_s=0
+	local _mr_repo_start _mr_repo_total_s=0
 	_mr_repo_start=$(_pmp_now_epoch)
 
 	local _mr_repo_rc=0
@@ -351,26 +675,14 @@ _pmp_process_merge_repo_for_pass() {
 	_pmp_add_counter_var "$total_merged_var" "$repo_merged"
 	_pmp_add_counter_var "$total_closed_var" "$repo_closed"
 	_pmp_add_counter_var "$total_failed_var" "$repo_failed"
+	_pmp_add_elapsed_seconds _mr_repo_total_s "$_mr_repo_start"
+	_PMP_LAST_REPO_TIMING_ROW="${repo_slug}|${_mr_repo_total_s}|${_mr_repo_list_s}|${_mr_repo_mergeability_s}|${_mr_repo_ruleset_s}|${_mr_repo_branch_protection_s}|${repo_merged}|${repo_closed}|${repo_failed}|${_mr_repo_pr_count}"
 	if [[ "$_mr_repo_rc" -eq 5 ]]; then
 		echo "[pulse-wrapper] Deterministic merge pass paused mid-repo ${repo_slug}; PR cursor persisted" >>"$logfile"
 		printf -v "$completed_all_var" '%s' '0'
 		return 0
 	fi
 
-	_mr_repo_stuck_start=$(_pmp_now_epoch)
-	if declare -F pulse_merge_stuck_run_pass >/dev/null 2>&1; then
-		pulse_merge_stuck_run_pass "$repo_slug" || true
-	fi
-	if declare -F _pms_count_eligible_unmerged_for_repo >/dev/null 2>&1; then
-		local _repo_eligible
-		_repo_eligible=$(_pms_count_eligible_unmerged_for_repo "$repo_slug" 2>/dev/null) || _repo_eligible=0
-		[[ "$_repo_eligible" =~ ^[0-9]+$ ]] || _repo_eligible=0
-		_pmp_add_counter_var "$total_eligible_var" "$_repo_eligible"
-	fi
-
-	_pmp_add_elapsed_seconds _mr_repo_stuck_detector_s "$_mr_repo_stuck_start"
-	_pmp_add_elapsed_seconds _mr_repo_total_s "$_mr_repo_start"
-	_pmp_log_repo_timing_summary "$repo_slug" "$_mr_repo_total_s" "$_mr_repo_list_s" "$_mr_repo_mergeability_s" "$_mr_repo_ruleset_s" "$_mr_repo_branch_protection_s" "$_mr_repo_stuck_detector_s" "$repo_merged" "$repo_closed" "$repo_failed" "$_mr_repo_pr_count"
 	_pmp_write_merge_checkpoint "$checkpoint_file" "$repo_slug"
 	_pmp_clear_merge_pr_cursor "${PULSE_MERGE_PR_CURSOR_FILE:-}"
 
@@ -406,17 +718,24 @@ merge_ready_prs_all_repos() {
 		return 0
 	fi
 
-	local total_merged=0
-	local total_closed=0
-	local total_failed=0
+	local total_merged=0 total_closed=0 total_failed=0
 
 	local total_eligible_unmerged=0
+	local AIDEVOPS_PULSE_MERGE_OUTCOME_DIR=""
 	local _mr_repo_rows=""
 	local _mr_checkpoint=""
 	local _mr_resume_pending=0
 	local _mr_resumed_from_checkpoint=0
 	local _mr_completed_all=1
-	local repo_slug="" repo_path=""
+	local _mr_outcomes_complete=1
+	local _mr_diagnostics_complete=1
+	local _mr_primary_timing_rows="" _mr_diagnostic_timing_rows=""
+	local repo_slug=""
+	local repo_path=""
+	AIDEVOPS_PULSE_MERGE_OUTCOME_DIR=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-pulse-merge-outcomes.XXXXXX" 2>/dev/null) || AIDEVOPS_PULSE_MERGE_OUTCOME_DIR=""
+	if [[ -z "$AIDEVOPS_PULSE_MERGE_OUTCOME_DIR" ]]; then
+		echo "[pulse-wrapper] Same-pass merge outcome cache unavailable; zero-progress aggregate will fail closed" >>"$_mr_logfile"
+	fi
 
 	_mr_repo_rows=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$_mr_repos_json" 2>/dev/null) || _mr_repo_rows=""
 	_pmp_prepare_merge_checkpoint_resume "$_mr_repo_rows" "$_mr_checkpoint_file" "$_mr_logfile" \
@@ -428,7 +747,10 @@ merge_ready_prs_all_repos() {
 			continue
 		fi
 		_pmp_process_merge_repo_for_pass "$repo_slug" "$_mr_checkpoint_file" "$_mr_logfile" "$_mr_stop_flag" \
-			total_merged total_closed total_failed total_eligible_unmerged _mr_completed_all
+			total_merged total_closed total_failed _mr_completed_all
+		if [[ -n "${_PMP_LAST_REPO_TIMING_ROW:-}" ]]; then
+			_mr_primary_timing_rows="${_mr_primary_timing_rows}${_PMP_LAST_REPO_TIMING_ROW}"$'\n'
+		fi
 		if [[ "$_mr_completed_all" -eq 0 ]]; then
 			break
 		fi
@@ -438,21 +760,23 @@ merge_ready_prs_all_repos() {
 		_pmp_clear_merge_checkpoint "$_mr_checkpoint_file"
 		_pmp_clear_merge_pr_cursor "$PULSE_MERGE_PR_CURSOR_FILE"
 	fi
-
-	# t3193: positive deterministic progress is conclusive even when a pass pauses
-	# or resumes from a checkpoint, so reset the streak immediately after a merge
-	# or conflict close. A no-progress aggregate is meaningful only after a fresh
-	# full pass; partial tails skip it to avoid distorting the all-repo signal.
-	# Resolves at runtime via bash lazy lookup (pulse-merge-stuck.sh).
-	if declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
-		if [[ "$total_merged" -gt 0 || "$total_closed" -gt 0 ]]; then
-			pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" "$total_closed" || true
-		elif [[ "$_mr_completed_all" -eq 1 && "$_mr_resumed_from_checkpoint" -eq 0 ]]; then
-			pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" "$total_closed" || true
+	if [[ "$_mr_completed_all" -eq 1 ]]; then
+		if [[ "$_mr_resumed_from_checkpoint" -eq 0 ]]; then
+			_pmp_collect_same_pass_eligible_unmerged "$_mr_repo_rows" "$_mr_logfile" \
+				total_eligible_unmerged _mr_outcomes_complete || _mr_outcomes_complete=0
 		fi
 	fi
+	# Record the all-repository throughput signal before expensive diagnostics so
+	# the watchdog cannot erase a completed primary-pass result (t3193).
+	_pmp_record_pass_zero_progress "$total_eligible_unmerged" "$total_merged" "$total_closed" \
+		"$_mr_completed_all" "$_mr_resumed_from_checkpoint" "$_mr_outcomes_complete"
+	if [[ "$_mr_completed_all" -eq 1 ]]; then
+		_pmp_run_stuck_diagnostics_for_repos "$_mr_repo_rows" "$_mr_pass_start" "$_mr_logfile" \
+			_mr_diagnostic_timing_rows _mr_diagnostics_complete || _mr_diagnostics_complete=0
+	fi
+	_pmp_log_repo_timing_rows "$_mr_primary_timing_rows" "$_mr_diagnostic_timing_rows"
 
-	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, closed_conflicting=${total_closed}, failed=${total_failed}, eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"
+	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, closed_conflicting=${total_closed}, failed=${total_failed}, eligible_unmerged=${total_eligible_unmerged}, diagnostics_complete=${_mr_diagnostics_complete}" >>"$_mr_logfile"
 	# Write health counter deltas to a temp file (GH#18571, GH#15107).
 	# run_stage_with_timeout backgrounds this function in a subshell, so
 	# direct updates to _PULSE_HEALTH_* variables are lost on return.
@@ -466,5 +790,6 @@ merge_ready_prs_all_repos() {
 	local _mr_pass_total_s=0
 	_pmp_add_elapsed_seconds _mr_pass_total_s "$_mr_pass_start"
 	echo "[pulse-wrapper] deterministic_merge_pass timing: total_s=${_mr_pass_total_s} merged=${total_merged} closed_conflicting=${total_closed} failed=${total_failed} eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"
+	[[ -n "$AIDEVOPS_PULSE_MERGE_OUTCOME_DIR" ]] && rm -rf -- "$AIDEVOPS_PULSE_MERGE_OUTCOME_DIR"
 	return 0
 }

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -501,6 +501,31 @@ _PULSE_MERGE_PROCESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_PULSE_MERGE_PROCESS_DIR}/pulse-merge-duplicate-consolidation.sh"
 
 #######################################
+# Apply one processed PR result to pass counters and durable same-pass evidence.
+# Args: $1=repo, $2=PR number, $3=head SHA, $4=result code,
+#       $5=merged var, $6=closed var, $7=failed var
+#######################################
+_pmp_record_processed_pr_result() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local head_sha="$3"
+	local result_code="$4"
+	local merged_var="$5"
+	local closed_var="$6"
+	local failed_var="$7"
+	local outcome="blocked"
+
+	case "$result_code" in
+	0) _pmp_add_counter_var "$merged_var" 1 || return 1; outcome="merged" ;;
+	2) _pmp_add_counter_var "$closed_var" 1 || return 1; outcome="progress" ;;
+	3) _pmp_add_counter_var "$failed_var" 1 || return 1; outcome="eligible-unmerged" ;;
+	4) outcome="deferred" ;;
+	esac
+	_pmp_record_same_pass_pr_outcome "$repo_slug" "$pr_number" "$head_sha" "$outcome" || return 1
+	return 0
+}
+
+#######################################
 # Merge ready PRs for a single repo.
 #
 # Fetches the PR list for the repo, iterates, and delegates each PR
@@ -524,6 +549,7 @@ _merge_ready_prs_for_repo() {
 
 	local merged=0 closed=0 failed=0
 	local pr_json="" pr_merge_err="" _list_start="" pr_count=""
+	local pr_list_complete=1 outcomes_complete=1
 	_list_start=$(_pmp_now_epoch)
 	pr_merge_err=$(mktemp)
 	if declare -F pulse_pr_list_get >/dev/null 2>&1; then
@@ -540,11 +566,12 @@ _merge_ready_prs_for_repo() {
 		_pr_merge_err_msg=$(cat "$pr_merge_err" 2>/dev/null || echo "unknown error")
 		echo "[pulse-wrapper] _process_merge_batch: pulse_pr_list_get FAILED for ${repo_slug}: ${_pr_merge_err_msg}" >>"$LOGFILE"
 		pr_json="[]"
+		pr_list_complete=0
 	fi
 	rm -f "$pr_merge_err"
 	[[ -n "$_timing_prefix" ]] && _pmp_add_elapsed_seconds "${_timing_prefix}list_s" "$_list_start"
 
-	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || { pr_count=0; pr_list_complete=0; }
 	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
 	if [[ -n "$_pr_count_var" ]]; then
 		[[ "$_pr_count_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
@@ -553,6 +580,7 @@ _merge_ready_prs_for_repo() {
 
 	if [[ "$pr_count" -eq 0 ]]; then
 		eval "${_merged_var}=0; ${_closed_var}=0; ${_failed_var}=0"
+		if [[ "$pr_list_complete" -eq 1 ]]; then _pmp_mark_same_pass_repo_complete "$repo_slug" 2>/dev/null || true; fi
 		return 0
 	fi
 
@@ -569,7 +597,7 @@ _merge_ready_prs_for_repo() {
 	_pmp_log_pr_backlog_counts "$repo_slug" "$pr_json"
 	pr_json=$(_pmp_sort_prs_by_backlog_priority "$pr_json" "$repo_slug")
 	_pmp_consolidate_duplicate_pr_groups "$repo_slug" "$pr_json" || true
-	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || { pr_count=0; outcomes_complete=0; }
 	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
 
 	local i=0
@@ -589,26 +617,23 @@ _merge_ready_prs_for_repo() {
 		fi
 		local pr_obj
 		pr_obj=$(_pmp_pr_object_at_index "$pr_json" "$i")
-		local _cursor_last_pr="" _cursor_next_pr=""
+		local _cursor_last_pr="" _cursor_next_pr="" _pr_head_sha=""
 		_cursor_last_pr=$(printf '%s' "$pr_obj" | jq -r '.number // empty' 2>/dev/null) || _cursor_last_pr=""
+		_pr_head_sha=$(printf '%s' "$pr_obj" | jq -r '.headRefOid // empty' 2>/dev/null) || _pr_head_sha=""
 		i=$((i + 1))
 		_cursor_next_pr=$(_pmp_pr_number_at_index "$pr_json" "$i") || _cursor_next_pr=""
 		[[ -n "$pr_obj" ]] || continue
 
 		_process_single_ready_pr "$repo_slug" "$pr_obj" "$_timing_prefix"
 		local _pr_rc=$?
-		case "$_pr_rc" in
-		0) merged=$((merged + 1)) ;;
-		2) closed=$((closed + 1)) ;;
-		3) failed=$((failed + 1)) ;;
-		4) ;;
-		esac
+		_pmp_record_processed_pr_result "$repo_slug" "$_cursor_last_pr" "$_pr_head_sha" "$_pr_rc" merged closed failed || outcomes_complete=0
 		_pmp_write_merge_pr_cursor "$PULSE_MERGE_PR_CURSOR_FILE" "$repo_slug" "$i" "$_cursor_last_pr" "$_cursor_next_pr"
 	done
 	_pmp_clear_merge_pr_cursor "$PULSE_MERGE_PR_CURSOR_FILE"
 
 	[[ -n "$AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR" ]] && rm -rf -- "$AIDEVOPS_PULSE_REQUIRED_CONTEXTS_CACHE_DIR"
 	[[ -n "$AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR" ]] && rm -rf -- "$AIDEVOPS_PULSE_AUTHOR_PERMISSION_CACHE_DIR"
+	if [[ "$pr_list_complete" -eq 1 && "$outcomes_complete" -eq 1 ]]; then _pmp_mark_same_pass_repo_complete "$repo_slug" 2>/dev/null || true; fi
 
 	eval "${_merged_var}=${merged}; ${_closed_var}=${closed}; ${_failed_var}=${failed}"
 	return 0
@@ -1635,6 +1660,7 @@ _required_contexts_for_default_branch() {
 _check_required_checks_passing() {
 	local repo_slug="$1"
 	local pr_number="$2"
+	local pr_sha="${3:-}"
 
 	# Resolve required contexts (delegates default-branch lookup + branch
 	# protection API + 404 distinction to the helper). Empty stdout + exit 0
@@ -1663,9 +1689,10 @@ _check_required_checks_passing() {
 	# PR, separate budget pool). check-runs is heavier than check-suites
 	# (~111KB/PR) but exposes per-context .name fields needed for matching
 	# branch-protection required_status_checks. Single-PR path → cost is fine.
-	local pr_sha=""
-	pr_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json headRefOid --jq '.headRefOid' 2>/dev/null) || pr_sha=""
+	if [[ -z "$pr_sha" ]]; then
+		pr_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+			--json headRefOid --jq '.headRefOid' 2>/dev/null) || pr_sha=""
+	fi
 	if [[ -z "$pr_sha" ]]; then
 		echo "[pulse-merge] _check_required_checks_passing: headRefOid fetch failed for PR #${pr_number} in ${repo_slug} — failing closed (t2922, GH#21799)" >>"$LOGFILE"
 		return 1

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -629,6 +629,9 @@ _pulse_merge_preflight_snapshot_gate() {
 		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
 		return 1
 	}
+	if declare -F _pmp_record_same_pass_check_evidence >/dev/null 2>&1; then
+		_pmp_record_same_pass_check_evidence "$repo_slug" "$current_head_sha" "$checks_json" || true
+	fi
 	activity_json=$(_pmrc_snapshot_bot_activity_json "$repo_slug" "$pr_number") || {
 		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
 		return 1

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -138,7 +138,21 @@ readonly _PMS_ISSUE_STATE_OPEN="OPEN"
 # pulse_merge_stuck_run_pass, and the remaining fields gate eligibility.
 #######################################
 _pms_pr_list_json_fields() {
-	printf '%s' 'number,mergeable,reviewDecision,isDraft,labels,author,updatedAt'
+	printf '%s' 'number,mergeable,reviewDecision,isDraft,labels,author,updatedAt,headRefOid'
+	return 0
+}
+
+_pms_head_sha_from_pr_json() {
+	local pr_json="$1"
+	printf '%s' "$pr_json" | jq -r '.headRefOid // empty' 2>/dev/null || true
+	return 0
+}
+
+_pms_head_sha_for_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	gh_pr_view "$pr_number" --repo "$repo_slug" \
+		--json headRefOid --jq '.headRefOid // empty' 2>/dev/null || true
 	return 0
 }
 readonly _PMS_RUNNER_SATURATION_MARKER_TEXT="merge-stuck:runner-queue-saturation"
@@ -211,19 +225,40 @@ _pms_check_runs_for_head() {
 	local repo_slug="$1"
 	local head_sha="$2"
 	local runs=""
+	local fetch_succeeded=0
+	if [[ -n "$repo_slug" && -n "$head_sha" ]] \
+		&& declare -F _pmp_same_pass_check_evidence_get >/dev/null 2>&1 \
+		&& runs=$(_pmp_same_pass_check_evidence_get "$repo_slug" "$head_sha" 2>/dev/null); then
+		printf '%s' "$runs"
+		return 0
+	fi
 	# The merge preflight snapshot collapses superseded runs and logical aliases
 	# to their effective current-head result. Prefer it so an old cancelled or
 	# failed run cannot make a subsequently successful PR look broken forever.
 	# pulse-merge.sh is sourced before this module in production; the REST helper
 	# remains the standalone/test fallback.
 	if [[ -n "$repo_slug" && -n "$head_sha" ]] && declare -F _pmrc_snapshot_checks_json >/dev/null 2>&1; then
-		runs=$(_pmrc_snapshot_checks_json "$repo_slug" "$head_sha" 2>/dev/null) || runs=""
+		if runs=$(_pmrc_snapshot_checks_json "$repo_slug" "$head_sha" 2>/dev/null); then fetch_succeeded=1; fi
 	elif [[ -n "$repo_slug" && -n "$head_sha" ]] && declare -F gh_pr_check_runs_rest >/dev/null 2>&1; then
-		runs=$(gh_pr_check_runs_rest "$repo_slug" "$head_sha" 2>/dev/null) || runs=""
+		if runs=$(gh_pr_check_runs_rest "$repo_slug" "$head_sha" 2>/dev/null); then fetch_succeeded=1; fi
 	fi
-	[[ -n "$runs" && "$runs" != "null" ]] || runs="[]"
+	if [[ -z "$runs" || "$runs" == "null" ]]; then
+		runs="[]"
+		fetch_succeeded=0
+	fi
+	if [[ "$fetch_succeeded" -eq 1 ]] && declare -F _pmp_record_same_pass_check_evidence >/dev/null 2>&1; then
+		_pmp_record_same_pass_check_evidence "$repo_slug" "$head_sha" "$runs" 2>/dev/null || true
+	fi
 	printf '%s' "$runs"
 	return 0
+}
+
+_pms_diagnostic_budget_exhausted() {
+	if declare -F _pmp_merge_diagnostics_budget_exhausted >/dev/null 2>&1; then
+		_pmp_merge_diagnostics_budget_exhausted
+		return $?
+	fi
+	return 1
 }
 
 #######################################
@@ -289,7 +324,7 @@ _pms_failing_check_bullets() {
 # is classified as STUCK_RUNNER_QUEUE_SATURATION (highest priority — the
 # QUEUED check would otherwise mask the actual cause).
 #
-# Args: $1 = pr_number, $2 = repo_slug, $3 = is_saturated (0|1, default 0)
+# Args: $1=pr_number, $2=repo_slug, $3=is_saturated, $4=optional PR metadata
 # Returns: 0 (always; classification is the stdout)
 #######################################
 _classify_stuck_pr() {
@@ -299,14 +334,16 @@ _classify_stuck_pr() {
 
 	# Cheap fast paths first. Fetch labels + mergeable + head SHA once. Check
 	# state comes from REST check-runs below, not GraphQL statusCheckRollup.
-	local pr_meta
-	pr_meta=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json labels,mergeable,headRefOid 2>/dev/null) || pr_meta=""
+	local pr_meta="${4:-}"
+	if [[ -z "$pr_meta" ]]; then
+		pr_meta=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+			--json labels,mergeable,headRefOid 2>/dev/null) || pr_meta=""
+	fi
 
 	local mergeable="" labels="" head_sha="" check_runs=""
 	mergeable=$(printf '%s' "$pr_meta" | jq -r '.mergeable // "UNKNOWN"' 2>/dev/null)
 	labels=$(printf '%s' "$pr_meta" | jq -r '[.labels[].name] | join(",")' 2>/dev/null)
-	head_sha=$(printf '%s' "$pr_meta" | jq -r '.headRefOid // ""' 2>/dev/null)
+	head_sha=$(_pms_head_sha_from_pr_json "$pr_meta")
 	check_runs=$(_pms_check_runs_for_head "$repo_slug" "$head_sha")
 
 	# Runner queue saturation takes priority when the repo is saturated
@@ -396,9 +433,10 @@ _classify_stuck_pr() {
 _pms_failure_fingerprint() {
 	local pr_number="$1"
 	local repo_slug="$2"
-	local head_sha="" runs_json=""
-	head_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json headRefOid --jq '.headRefOid // ""' 2>/dev/null) || head_sha=""
+	local head_sha="${3:-}" runs_json=""
+	if [[ -z "$head_sha" ]]; then
+		head_sha=$(_pms_head_sha_for_pr "$pr_number" "$repo_slug")
+	fi
 	runs_json=$(_pms_check_runs_for_head "$repo_slug" "$head_sha")
 
 	# Extract names of failing checks, normalize, sort, join. Uses the shared
@@ -449,13 +487,15 @@ _pms_default_branch() {
 # escalatable outcome); pattern-cluster outages are handled separately by
 # _detect_pattern_outage.
 #
-# Args: $1=pr_number, $2=repo_slug, $3=classification, $4=linked_issue (may be empty)
+# Args: $1=pr_number, $2=repo_slug, $3=classification, $4=linked_issue,
+#       $5=optional current head SHA
 #######################################
 _escalate_individual_stuck_pr() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local classification="$3"
 	local linked_issue="$4"
+	local head_sha="${5:-}"
 
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 0
 
@@ -468,9 +508,10 @@ _escalate_individual_stuck_pr() {
 
 	# Fetch failing check names for the worker-ready guidance via REST check-runs
 	# to avoid GraphQL statusCheckRollup polling in every pulse cycle.
-	local failing_checks="" head_sha="" runs_json=""
-	head_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json headRefOid --jq '.headRefOid // ""' 2>/dev/null) || head_sha=""
+	local failing_checks="" runs_json=""
+	if [[ -z "$head_sha" ]]; then
+		head_sha=$(_pms_head_sha_for_pr "$pr_number" "$repo_slug")
+	fi
 	runs_json=$(_pms_check_runs_for_head "$repo_slug" "$head_sha")
 	failing_checks=$(_pms_failing_check_bullets "$runs_json")
 	[[ -n "$failing_checks" ]] || failing_checks="- (no FAILURE entries in rollup; check rollup manually)"
@@ -657,11 +698,12 @@ _pms_is_per_pr_gate_fingerprint() {
 # share an identical fingerprint, file ONE investigation issue per outage signature.
 # Dedup'd by the fingerprint hash so the same outage doesn't re-file every cycle.
 #
-# Args: $1=repo_slug, $2=newline-separated list of stuck PR numbers
+# Args: $1=repo_slug, $2=newline-separated stuck PR numbers, $3=optional PR list
 #######################################
 _detect_pattern_outage() {
 	local repo_slug="$1"
 	local stuck_prs="$2"
+	local pr_json="${3:-}"
 
 	[[ -z "$stuck_prs" ]] && return 0
 
@@ -674,8 +716,11 @@ _detect_pattern_outage() {
 
 	while IFS= read -r pr_num; do
 		[[ -n "$pr_num" ]] || continue
-		local fp
-		fp=$(_pms_failure_fingerprint "$pr_num" "$repo_slug")
+		local fp head_sha=""
+		if [[ -n "$pr_json" ]]; then
+			head_sha=$(printf '%s' "$pr_json" | jq -r --argjson number "$pr_num" '.[] | select(.number == $number) | .headRefOid // empty' 2>/dev/null) || head_sha=""
+		fi
+		fp=$(_pms_failure_fingerprint "$pr_num" "$repo_slug" "$head_sha")
 		# Skip PRs with no FAILURE entries — those aren't part of an outage cluster.
 		[[ -n "$fp" ]] || continue
 		if _pms_is_per_pr_gate_fingerprint "$fp"; then
@@ -1229,12 +1274,13 @@ _pms_pr_counts_for_zero_progress() {
 	local pr_number="$2"
 	local labels_str="$3"
 	local pr_author="${4:-}"
+	local head_sha="${5:-}"
 
 	[[ -n "$repo_slug" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
 	local labels_tokenized=",${labels_str},"
 
 	if declare -F _check_required_checks_passing >/dev/null 2>&1; then
-		if ! _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
+		if ! _check_required_checks_passing "$repo_slug" "$pr_number" "$head_sha" >/dev/null 2>&1; then
 			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — required checks are not provably passing" >>"$LOGFILE"
 			return 1
 		fi
@@ -1324,6 +1370,14 @@ _pms_pr_counts_for_zero_progress() {
 _pms_count_eligible_unmerged_for_repo() {
 	local repo_slug="$1"
 	[[ -n "$repo_slug" ]] || { printf '0'; return 0; }
+	local same_pass_count=""
+	if declare -F _pmp_count_same_pass_eligible_unmerged >/dev/null 2>&1 \
+		&& same_pass_count=$(_pmp_count_same_pass_eligible_unmerged "$repo_slug" 2>/dev/null); then
+		[[ "$same_pass_count" =~ ^[0-9]+$ ]] || return 2
+		printf '%s' "$same_pass_count"
+		return 0
+	fi
+	[[ "${AIDEVOPS_PULSE_REQUIRE_SAME_PASS_OUTCOME:-0}" == "1" ]] && return 2
 
 	local pr_json
 	pr_json=$(pulse_pr_list_get --repo "$repo_slug" --state open \
@@ -1344,7 +1398,7 @@ _pms_count_eligible_unmerged_for_repo() {
 			and (.isDraft // false) == false
 			and (([.labels[]?.name] | index("hold-for-review")) == null)
 		  )
-		  | "\(.number // "")\u001e\([.labels[]?.name] | join(","))\u001e\(.author.login? // "unknown")"
+		  | "\(.number // "")\u001e\([.labels[]?.name] | join(","))\u001e\(.author.login? // "unknown")\u001e\(.headRefOid // "")"
 		] | .[]' 2>/dev/null) || candidates=""
 
 	local count=0
@@ -1352,9 +1406,10 @@ _pms_count_eligible_unmerged_for_repo() {
 	local pr_number=""
 	local labels_str=""
 	local pr_author=""
-	while IFS="$_RS" read -r pr_number labels_str pr_author; do
+	local head_sha=""
+	while IFS="$_RS" read -r pr_number labels_str pr_author head_sha; do
 		[[ -n "$pr_number" ]] || continue
-		if _pms_pr_counts_for_zero_progress "$repo_slug" "$pr_number" "$labels_str" "$pr_author"; then
+		if _pms_pr_counts_for_zero_progress "$repo_slug" "$pr_number" "$labels_str" "$pr_author" "$head_sha"; then
 			count=$((count + 1))
 		fi
 	done <<<"$candidates"
@@ -1430,11 +1485,14 @@ _pms_handle_classified_pr() {
 	local pr_num="$1"
 	local repo_slug="$2"
 	local is_saturated="$3"
+	local pr_meta="${4:-}"
+	local head_sha=""
+	head_sha=$(_pms_head_sha_from_pr_json "$pr_meta")
 
 	# Pass is_saturated so the classifier can recognise QUEUED checks
 	# during a runner outage.
 	local classification
-	classification=$(_classify_stuck_pr "$pr_num" "$repo_slug" "$is_saturated")
+	classification=$(_classify_stuck_pr "$pr_num" "$repo_slug" "$is_saturated" "$pr_meta")
 
 	# Fetch linked issue once for the escalation comment.
 	local linked_issue=""
@@ -1457,7 +1515,7 @@ _pms_handle_classified_pr() {
 			printf 'HANDLED'
 			;;
 		STUCK_CHECKS_FAILING|STUCK_BRANCHPROTECT_API_ERROR|STUCK_AUTH|STUCK_OTHER)
-			_escalate_individual_stuck_pr "$pr_num" "$repo_slug" "$classification" "$linked_issue"
+			_escalate_individual_stuck_pr "$pr_num" "$repo_slug" "$classification" "$linked_issue" "$head_sha"
 			printf 'HANDLED'
 			;;
 		*)
@@ -1467,11 +1525,84 @@ _pms_handle_classified_pr() {
 	return 0
 }
 
+#######################################
+# Classify the eligible-stuck subset while the separate diagnostic budget
+# remains available. Partial results are returned for observability only; the
+# caller suppresses aggregate writes unless the completion flag remains 1.
+# Args: $1=repo, $2=PR JSON, $3=count, $4=now, $5=age threshold,
+#       $6=saturated, $7-$11=eligible/stuck/saturation/count/complete vars
+#######################################
+_pms_classify_stuck_prs_within_budget() {
+	local repo_slug="$1"
+	local pr_json="$2"
+	local pr_count="$3"
+	local now_epoch="$4"
+	local age_threshold_secs="$5"
+	local is_saturated="$6"
+	local eligible_var="$7"
+	local stuck_numbers_var="$8"
+	local saturation_prs_var="$9"
+	local saturation_count_var="${10}"
+	local complete_var="${11}"
+	local output_var=""
+	local _classified_eligible=0 _classified_saturation_count=0 _classified_complete=1
+	local _classified_stuck_numbers="" _classified_saturation_prs=""
+	local i=0
+
+	for output_var in "$eligible_var" "$stuck_numbers_var" "$saturation_prs_var" "$saturation_count_var" "$complete_var"; do
+		[[ "$output_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	done
+	while [[ "$i" -lt "$pr_count" ]]; do
+		if _pms_diagnostic_budget_exhausted; then
+			_classified_complete=0
+			break
+		fi
+		local pr_obj="" pr_num="" pr_updated="" pr_age_secs=0 is_stuck=""
+		pr_obj=$(printf '%s' "$pr_json" | jq -c ".[$i]" 2>/dev/null)
+		i=$((i + 1))
+		[[ -n "$pr_obj" ]] || continue
+		pr_num=$(printf '%s' "$pr_obj" | jq -r '.number // empty' 2>/dev/null)
+		[[ "$pr_num" =~ ^[0-9]+$ ]] || continue
+		is_stuck=$(_pms_is_eligible_stuck "$pr_obj")
+		[[ "$is_stuck" == "1" ]] || continue
+		pr_updated=$(printf '%s' "$pr_obj" | jq -r '.updatedAt // empty' 2>/dev/null)
+		[[ -n "$pr_updated" ]] || continue
+		pr_age_secs=$((now_epoch - $(_pms_iso_to_epoch "$pr_updated")))
+		[[ "$pr_age_secs" -ge "$age_threshold_secs" ]] || continue
+		_classified_eligible=$((_classified_eligible + 1))
+		_classified_stuck_numbers="${_classified_stuck_numbers}${pr_num}\n"
+		local route=""
+		route=$(_pms_handle_classified_pr "$pr_num" "$repo_slug" "$is_saturated" "$pr_obj")
+		if [[ "$route" == "SATURATED" ]]; then
+			_classified_saturation_prs="${_classified_saturation_prs}${pr_num},"
+			_classified_saturation_count=$((_classified_saturation_count + 1))
+		fi
+	done
+	if _pms_diagnostic_budget_exhausted; then _classified_complete=0; fi
+	printf -v "$eligible_var" '%s' "$_classified_eligible"
+	printf -v "$stuck_numbers_var" '%s' "$_classified_stuck_numbers"
+	printf -v "$saturation_prs_var" '%s' "$_classified_saturation_prs"
+	printf -v "$saturation_count_var" '%s' "$_classified_saturation_count"
+	printf -v "$complete_var" '%s' "$_classified_complete"
+	return 0
+}
+
 pulse_merge_stuck_run_pass() {
 	local repo_slug="$1"
+	local completion_var="${2:-}"
+	local pass_complete=1
+	if [[ -n "$completion_var" && "$completion_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+		printf -v "$completion_var" '%s' '1'
+	else
+		completion_var=""
+	fi
 
 	[[ -n "$repo_slug" ]] || return 0
 	[[ "$AIDEVOPS_MERGE_STUCK_ENABLED" == "1" ]] || return 0
+	if _pms_diagnostic_budget_exhausted; then
+		[[ -n "$completion_var" ]] && printf -v "$completion_var" '%s' '0'
+		return 0
+	fi
 
 	# Fetch open PRs with the fields the detector needs.
 	local pr_json
@@ -1500,46 +1631,24 @@ pulse_merge_stuck_run_pass() {
 	[[ "$sat_in_progress" =~ ^[0-9]+$ ]] || sat_in_progress=0
 	[[ "$sat_ratio" =~ ^[0-9]+$ ]] || sat_ratio=0
 	[[ "$is_saturated" == "1" ]] || is_saturated=0
+	if _pms_diagnostic_budget_exhausted; then
+		[[ -n "$completion_var" ]] && printf -v "$completion_var" '%s' '0'
+		return 0
+	fi
 
 	# Saturation-blocked PRs aggregated for the meta-issue body (t3211) —
 	# per-PR escalation comments are SUPPRESSED for these.
 	local eligible_stuck_count=0 saturation_blocked_count=0
 	local stuck_pr_numbers="" saturation_blocked_prs=""
 
-	# Iterate each PR — classify, escalate, accumulate fingerprints.
-	local i=0
-	while [[ "$i" -lt "$pr_count" ]]; do
-		local pr_obj="" pr_num="" pr_updated="" pr_age_secs=0 is_stuck=""
-		pr_obj=$(printf '%s' "$pr_json" | jq -c ".[$i]" 2>/dev/null)
-		i=$((i + 1))
-		[[ -n "$pr_obj" ]] || continue
-
-		pr_num=$(printf '%s' "$pr_obj" | jq -r '.number // empty' 2>/dev/null)
-		[[ "$pr_num" =~ ^[0-9]+$ ]] || continue
-
-		# Eligibility gate first (cheap)
-		is_stuck=$(_pms_is_eligible_stuck "$pr_obj")
-		[[ "$is_stuck" == "1" ]] || continue
-
-		# Age gate (also cheap — uses cached updatedAt)
-		pr_updated=$(printf '%s' "$pr_obj" | jq -r '.updatedAt // empty' 2>/dev/null)
-		[[ -n "$pr_updated" ]] || continue
-		pr_age_secs=$(( now_epoch - $(_pms_iso_to_epoch "$pr_updated") ))
-		[[ "$pr_age_secs" -ge "$age_threshold_secs" ]] || continue
-
-		eligible_stuck_count=$((eligible_stuck_count + 1))
-		stuck_pr_numbers="${stuck_pr_numbers}${pr_num}\n"
-
-		# Classify + route via the helper. SATURATED means we must
-		# aggregate the PR for the meta-issue; HANDLED means a per-PR
-		# handler already ran.
-		local route
-		route=$(_pms_handle_classified_pr "$pr_num" "$repo_slug" "$is_saturated")
-		if [[ "$route" == "SATURATED" ]]; then
-			saturation_blocked_prs="${saturation_blocked_prs}${pr_num},"
-			saturation_blocked_count=$((saturation_blocked_count + 1))
-		fi
-	done
+	_pms_classify_stuck_prs_within_budget "$repo_slug" "$pr_json" "$pr_count" "$now_epoch" \
+		"$age_threshold_secs" "$is_saturated" eligible_stuck_count stuck_pr_numbers \
+		saturation_blocked_prs saturation_blocked_count pass_complete || pass_complete=0
+	if [[ "$pass_complete" -ne 1 ]]; then
+		[[ -n "$completion_var" ]] && printf -v "$completion_var" '%s' '0'
+		echo "[pulse-merge-stuck] pulse_merge_stuck_run_pass: ${repo_slug} — separate diagnostic budget exhausted; remaining classification deferred" >>"$LOGFILE"
+		return 0
+	fi
 
 	# Update the gauge for this cycle's count.
 	pulse_stats_set_gauge "pulse_merge_eligible_stuck_pr_count" "$eligible_stuck_count"
@@ -1558,7 +1667,7 @@ pulse_merge_stuck_run_pass() {
 
 	# Pattern-cluster detector over the full stuck set.
 	if [[ "$eligible_stuck_count" -ge "$AIDEVOPS_MERGE_PATTERN_MIN_PRS" ]]; then
-		_detect_pattern_outage "$repo_slug" "$(printf '%b' "$stuck_pr_numbers")" || true
+		_detect_pattern_outage "$repo_slug" "$(printf '%b' "$stuck_pr_numbers")" "$pr_json" || true
 	fi
 
 	echo "[pulse-merge-stuck] pulse_merge_stuck_run_pass: ${repo_slug} — eligible_stuck=${eligible_stuck_count}, threshold=${AIDEVOPS_MERGE_STUCK_AGE_MINUTES}m, saturated=${is_saturated} (queued=${sat_queued}, in_progress=${sat_in_progress}, ratio=${sat_ratio}, blocked_by_saturation=${saturation_blocked_count})" >>"$LOGFILE"

--- a/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
+++ b/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
@@ -172,7 +172,7 @@ MERGE_ON_REPO="org/two"
 PROCESSED_REPOS=""
 ZERO_PROGRESS_CALLS=""
 merge_ready_prs_all_repos
-assert_equals "interrupted pass records conclusive merge progress" "2:1:0 " "$ZERO_PROGRESS_CALLS"
+assert_equals "interrupted pass records conclusive merge progress without a partial denominator" "0:1:0 " "$ZERO_PROGRESS_CALLS"
 rm -f "$STOP_FLAG"
 
 if [[ "$TESTS_FAILED" -eq 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-primary-first-diagnostics.sh
+++ b/.agents/scripts/tests/test-pulse-merge-primary-first-diagnostics.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#28449: primary merge work must precede bounded
+# stuck diagnostics, and zero-progress accounting must reuse same-pass evidence.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
+STUCK_SCRIPT="${SCRIPT_DIR}/../pulse-merge-stuck.sh"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/pulse-primary-first-test-XXXXXX")
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="${TEST_ROOT}/home"
+export LOGFILE="${TEST_ROOT}/pulse.log"
+export STOP_FLAG="${TEST_ROOT}/pulse.stop"
+export REPOS_JSON="${TEST_ROOT}/repos.json"
+export PULSE_MERGE_CHECKPOINT_FILE="${TEST_ROOT}/merge.checkpoint"
+export PULSE_MERGE_PR_CURSOR_FILE="${TEST_ROOT}/merge.cursor"
+export PULSE_MERGE_GRACEFUL_BUDGET_SECONDS=0
+export PULSE_MERGE_DIAGNOSTIC_BUDGET_SECONDS=30
+mkdir -p "$HOME/.aidevops/logs" "$HOME/.config/aidevops"
+
+cat >"$REPOS_JSON" <<'JSON'
+{"initialized_repos":[
+  {"slug":"org/seven","path":"/tmp/seven","pulse":true,"local_only":false},
+  {"slug":"org/empty","path":"/tmp/empty","pulse":true,"local_only":false}
+]}
+JSON
+
+# shellcheck source=/dev/null
+source "$PROCESS_SCRIPT"
+# shellcheck source=/dev/null
+source "$STUCK_SCRIPT"
+REAL_STUCK_RUN_PASS_DEF=$(declare -f pulse_merge_stuck_run_pass)
+
+TESTS_RUN=0
+TESTS_FAILED=0
+EVENTS_FILE="${TEST_ROOT}/events.log"
+NETWORK_FILE="${TEST_ROOT}/network.log"
+ZERO_PROGRESS_CALLS=""
+: >"$EVENTS_FILE"
+: >"$NETWORK_FILE"
+: >"$LOGFILE"
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$name"
+	[[ -n "$detail" ]] && printf '     %s\n' "$detail"
+	return 0
+}
+
+assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected=[${expected}] actual=[${actual}]"
+	fi
+	return 0
+}
+
+record_event() {
+	local event="$1"
+	printf '%s\n' "$event" >>"$EVENTS_FILE"
+	return 0
+}
+
+repo_allows_pulse_write_actions() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 1
+	return 0
+}
+
+_merge_ready_prs_for_repo() {
+	local repo_slug="$1"
+	local merged_var="$2"
+	local closed_var="$3"
+	local failed_var="$4"
+	local pr_count_var="${5:-}"
+	local count=0 pr_number=0
+
+	if [[ "$repo_slug" == "org/seven" ]]; then
+		count=7
+		pr_number=1
+		while [[ "$pr_number" -le "$count" ]]; do
+			record_event "primary:${repo_slug}:${pr_number}"
+			_pmp_record_same_pass_pr_outcome "$repo_slug" "$pr_number" "sha-${pr_number}" "eligible-unmerged"
+			pr_number=$((pr_number + 1))
+		done
+	fi
+	_pmp_mark_same_pass_repo_complete "$repo_slug"
+	printf -v "$merged_var" '%s' '0'
+	printf -v "$closed_var" '%s' '0'
+	printf -v "$failed_var" '%s' "$count"
+	if [[ -n "$pr_count_var" ]]; then
+		printf -v "$pr_count_var" '%s' "$count"
+	fi
+	return 0
+}
+
+pulse_merge_stuck_run_pass() {
+	local repo_slug="$1"
+	local completion_var="${2:-}"
+	record_event "diagnostic:${repo_slug}"
+	if [[ -n "$completion_var" ]]; then
+		printf -v "$completion_var" '%s' '1'
+	fi
+	return 0
+}
+
+pulse_merge_zero_progress_record() {
+	local eligible="$1"
+	local merged="$2"
+	local progress="$3"
+	ZERO_PROGRESS_CALLS="${ZERO_PROGRESS_CALLS}${eligible}:${merged}:${progress} "
+	return 0
+}
+
+pulse_pr_list_get() {
+	printf 'pulse_pr_list_get\n' >>"$NETWORK_FILE"
+	printf '[]'
+	return 0
+}
+
+gh_pr_view() {
+	printf 'gh_pr_view\n' >>"$NETWORK_FILE"
+	return 1
+}
+
+gh_pr_check_runs_rest() {
+	printf 'gh_pr_check_runs_rest\n' >>"$NETWORK_FILE"
+	printf '[]'
+	return 0
+}
+
+merge_ready_prs_all_repos
+
+line_number=0
+last_primary=0
+first_diagnostic=0
+while IFS= read -r event; do
+	line_number=$((line_number + 1))
+	case "$event" in
+	primary:*) last_primary="$line_number" ;;
+	diagnostic:*) [[ "$first_diagnostic" -gt 0 ]] || first_diagnostic="$line_number" ;;
+	esac
+done <"$EVENTS_FILE"
+
+if [[ "$last_primary" -gt 0 && "$first_diagnostic" -gt "$last_primary" ]]; then
+	pass "all primary merge attempts finish before stuck diagnostics"
+else
+	fail "all primary merge attempts finish before stuck diagnostics" "last_primary=${last_primary} first_diagnostic=${first_diagnostic}"
+fi
+assert_eq "seven same-pass merge failures form the zero-progress denominator" "7:0:0 " "$ZERO_PROGRESS_CALLS"
+assert_eq "same-pass zero-progress accounting performs no fallback network reads" "0" "$(wc -l <"$NETWORK_FILE" | tr -d ' ')"
+
+: >"$EVENTS_FILE"
+ZERO_PROGRESS_CALLS=""
+export PULSE_MERGE_DIAGNOSTIC_BUDGET_SECONDS=0
+merge_ready_prs_all_repos
+diagnostic_count=0
+while IFS= read -r event; do
+	case "$event" in diagnostic:*) diagnostic_count=$((diagnostic_count + 1)) ;; esac
+done <"$EVENTS_FILE"
+assert_eq "zero diagnostic budget defers every stuck scan" "0" "$diagnostic_count"
+assert_eq "bounded diagnostics do not suppress authoritative zero-progress accounting" "7:0:0 " "$ZERO_PROGRESS_CALLS"
+eval "$REAL_STUCK_RUN_PASS_DEF"
+
+export AIDEVOPS_PULSE_MERGE_OUTCOME_DIR
+AIDEVOPS_PULSE_MERGE_OUTCOME_DIR=$(mktemp -d "${TEST_ROOT}/evidence-XXXXXX")
+COLLISION_REPO="org/collision"
+_pmp_record_same_pass_pr_outcome "$COLLISION_REPO" 101 sha-shared eligible-unmerged
+_pmp_record_same_pass_pr_outcome "$COLLISION_REPO" 102 sha-shared eligible-unmerged
+_pmp_mark_same_pass_repo_complete "$COLLISION_REPO"
+same_sha_count=$(_pmp_count_same_pass_eligible_unmerged "$COLLISION_REPO")
+assert_eq "same-head PR outcomes remain distinct" "2" "$same_sha_count"
+
+CHECK_FETCH_FILE="${TEST_ROOT}/check-fetch.log"
+: >"$CHECK_FETCH_FILE"
+_pmrc_snapshot_checks_json() {
+	local repo_slug="$1"
+	local head_sha="$2"
+	[[ -n "$repo_slug" && -n "$head_sha" ]] || return 1
+	printf 'fetch\n' >>"$CHECK_FETCH_FILE"
+	printf '[{"name":"Build","status":"completed","conclusion":"success"}]'
+	return 0
+}
+
+first_checks=$(_pms_check_runs_for_head "org/seven" "sha-evidence")
+second_checks=$(_pms_check_runs_for_head "org/seven" "sha-evidence")
+assert_eq "repeated detector consumers share one current-head check fetch" "1" "$(wc -l <"$CHECK_FETCH_FILE" | tr -d ' ')"
+assert_eq "same-pass check evidence remains exact" "$first_checks" "$second_checks"
+
+: >"$CHECK_FETCH_FILE"
+_pmrc_snapshot_checks_json() {
+	local repo_slug="$1"
+	local head_sha="$2"
+	[[ -n "$repo_slug" && -n "$head_sha" ]] || return 1
+	printf 'fetch\n' >>"$CHECK_FETCH_FILE"
+	printf '[]'
+	return 0
+}
+first_empty_checks=$(_pms_check_runs_for_head "org/seven" "sha-empty-evidence")
+second_empty_checks=$(_pms_check_runs_for_head "org/seven" "sha-empty-evidence")
+assert_eq "valid empty check evidence is fetched once" "1" "$(wc -l <"$CHECK_FETCH_FILE" | tr -d ' ')"
+assert_eq "valid empty check evidence remains exact" "[]" "${first_empty_checks}${second_empty_checks:2}"
+
+: >"$NETWORK_FILE"
+_required_contexts_for_default_branch() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 1
+	printf 'Build\n'
+	return 0
+}
+gh_pr_check_runs_rest() {
+	local repo_slug="$1"
+	local head_sha="$2"
+	printf 'check-runs:%s:%s\n' "$repo_slug" "$head_sha" >>"$NETWORK_FILE"
+	printf '[{"name":"Build","status":"completed","conclusion":"success"}]'
+	return 0
+}
+gh_pr_view() {
+	printf 'redundant-head-read\n' >>"$NETWORK_FILE"
+	return 1
+}
+if _check_required_checks_passing "org/seven" "1" "sha-direct"; then
+	pass "provided head SHA preserves name-aware required-check validation"
+else
+	fail "provided head SHA preserves name-aware required-check validation"
+fi
+assert_eq "provided head SHA removes the redundant PR head read" "check-runs:org/seven:sha-direct" "$(<"$NETWORK_FILE")"
+
+MID_PASS_EVENTS="${TEST_ROOT}/mid-pass-events.log"
+: >"$MID_PASS_EVENTS"
+MID_PASS_BUDGET_CHECKS=0
+pulse_pr_list_get() {
+	printf '%s' '[{"number":1,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"updatedAt":"2020-01-01T00:00:00Z","headRefOid":"sha-1"},{"number":2,"mergeable":"MERGEABLE","reviewDecision":"APPROVED","isDraft":false,"labels":[],"updatedAt":"2020-01-01T00:00:00Z","headRefOid":"sha-2"}]'
+	return 0
+}
+_pms_compute_saturation_state() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 1
+	printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+	return 0
+}
+_pms_diagnostic_budget_exhausted() {
+	MID_PASS_BUDGET_CHECKS=$((MID_PASS_BUDGET_CHECKS + 1))
+	[[ "$MID_PASS_BUDGET_CHECKS" -ge 4 ]] && return 0
+	return 1
+}
+_pms_handle_classified_pr() {
+	local pr_num="$1"
+	local repo_slug="$2"
+	local is_saturated="$3"
+	local pr_meta="${4:-}"
+	[[ -n "$repo_slug" && -n "$is_saturated" && -n "$pr_meta" ]] || return 1
+	printf '%s\n' "$pr_num" >>"$MID_PASS_EVENTS"
+	printf 'HANDLED'
+	return 0
+}
+AIDEVOPS_MERGE_STUCK_AGE_MINUTES=1
+AIDEVOPS_MERGE_PATTERN_MIN_PRS=99
+mid_pass_complete=1
+pulse_merge_stuck_run_pass "org/budget" mid_pass_complete >/dev/null 2>&1
+assert_eq "mid-repository budget exhaustion marks diagnostics incomplete" "0" "$mid_pass_complete"
+assert_eq "mid-repository budget exhaustion stops before the second PR" "1" "$(<"$MID_PASS_EVENTS")"
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '\nAll %s primary-first diagnostic tests passed.\n' "$TESTS_RUN"
+	exit 0
+fi
+
+printf '\n%s/%s primary-first diagnostic tests failed.\n' "$TESTS_FAILED" "$TESTS_RUN"
+exit 1

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -550,8 +550,8 @@ _pms_handle_classified_pr() {
 AIDEVOPS_MERGE_STUCK_AGE_MINUTES=1
 AIDEVOPS_MERGE_PATTERN_MIN_PRS=99
 pulse_merge_stuck_run_pass "example/repo" >/dev/null 2>&1
-shape_calls=$(grep -cF -- '--json number,mergeable,reviewDecision,isDraft,labels,author,updatedAt --limit 50' "$PMS_TEST_PR_LIST_CALLS" 2>/dev/null || true)
-assert_eq "6a.2: stuck scans share one provider-cache PR-list shape" "1" "$shape_calls"
+shape_calls=$(grep -cF -- '--json number,mergeable,reviewDecision,isDraft,labels,author,updatedAt,headRefOid --limit 50' "$PMS_TEST_PR_LIST_CALLS" 2>/dev/null || true)
+assert_eq "6a.3: stuck scans share one provider-cache PR-list shape" "1" "$shape_calls"
 AIDEVOPS_MERGE_PATTERN_MIN_PRS=3
 
 PMS_TEST_COUNT_AUTHORS_FILE="$TEST_TMPDIR/count-authors.log"


### PR DESCRIPTION
## Summary

Prioritize deterministic merge attempts across all repositories, then run stuck diagnostics under a separate budget using same-pass evidence for zero-progress accounting.

## Files Changed

.agents/scripts/pulse-merge-pass.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/pulse-merge-stuck.sh, .agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh, .agents/scripts/tests/test-pulse-merge-primary-first-diagnostics.sh, .agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** High (polling loops / state-machine logic)
- **Verification:** Runtime-verified in isolated shell harness: 14 primary-first tests, 66 stuck-detector tests, 12 checkpoint tests, cursor/timing/preflight/required-check suites, and linters-local.sh --changed.

Resolves #28449


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.162 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 54m and 1,502,714 tokens on this with the user in an interactive session.