### PR TITLE
GH#28465: repair targeted forge-event projections

### DIFF
--- a/.agents/scripts/forge-event-mapping-helper.sh
+++ b/.agents/scripts/forge-event-mapping-helper.sh
@@ -11,7 +11,7 @@ main() {
 	local event_kind="${EVENT_NAME:-}"
 	local number="${EVENT_DISPLAY_NUMBER:-}"
 	local subject_id="${EVENT_SUBJECT_ID:-}"
-	local task_id="" issue_json="" issue_id="" issue_number="" issue_state="" issue_cursor=""
+	local task_id="" issue_json="" issue_id="" issue_number="" issue_state="" issue_cursor="" sync_metadata=""
 	[[ "$event_kind" == "issues" ]] || return 0
 	[[ "$number" =~ ^[1-9][0-9]*$ && -n "$subject_id" ]] || return 1
 	task_id=$(grep -E "^[[:space:]]*- \[[ x]\] t[1-9][0-9]*(\.[1-9][0-9]*)* .*ref:GH#${number}([[:space:]]|$)" TODO.md 2>/dev/null |
@@ -23,9 +23,13 @@ main() {
 	issue_state=$(jq -r '.state // empty' <<<"$issue_json")
 	issue_cursor=$(jq -r '.updatedAt // empty' <<<"$issue_json")
 	[[ "$issue_id" == "$subject_id" && "$issue_number" == "$number" ]] || return 1
+	sync_metadata=$(jq -cn --arg state "$issue_state" --arg source event-ref-backfill '{state:$state,source:$source}') || return 1
+	node "$COORDINATOR" adopt-legacy-task --task-id "$task_id" --forge github --repository-id "${REPOSITORY_ID:?}" \
+		--repository-slug "$REPOSITORY_SLUG" --issue-id "$issue_id" --display-number "$issue_number" \
+		--state-cursor "$issue_cursor" --sync-metadata "$sync_metadata" >/dev/null || return 1
 	node "$COORDINATOR" bind-issue --task-id "$task_id" --forge github --repository-id "${REPOSITORY_ID:?}" \
 		--repository-slug "$REPOSITORY_SLUG" --role home --issue-id "$issue_id" --display-number "$issue_number" \
-		--state-cursor "$issue_cursor" --sync-metadata "$(jq -cn --arg state "$issue_state" --arg source event-ref-backfill '{state:$state,source:$source}')" >/dev/null || return 1
+		--state-cursor "$issue_cursor" --sync-metadata "$sync_metadata" >/dev/null || return 1
 	return 0
 }
 

--- a/.agents/scripts/task-coordinator.mjs
+++ b/.agents/scripts/task-coordinator.mjs
@@ -9,12 +9,13 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { canonicalizeSqliteDbPath, sqlEscape } from "./sqlite-process.mjs";
 
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 7;
 const PAYLOAD_MAX_BYTES = 64 * 1024;
 const EVIDENCE_MAX_BYTES = 64 * 1024;
 const CROCKFORD = "0123456789abcdefghjkmnpqrstvwxyz";
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const LEGACY_ID = /^t[1-9][0-9]{0,17}$/;
+const LEGACY_TASK_ID = /^t[1-9][0-9]{0,17}(?:\.[1-9][0-9]{0,17}){0,8}$/;
 const TASK_ID = /^(?:t[1-9][0-9]{0,17}(?:\.[1-9][0-9]{0,17})*|to[0-7][0-9a-hjkmnp-tv-z]{25}-[1-9][0-9]{0,17}(?:\.[1-9][0-9]{0,17})*)$/;
 const STATES = new Set(["active", "read-only", "redirected", "retired", "quarantined"]);
 const RESULTS = new Set(["published", "retryable", "indeterminate", "terminal", "conflict"]);
@@ -92,6 +93,10 @@ CREATE TABLE IF NOT EXISTS issue_mappings (
   UNIQUE(forge, repository_id, issue_id),
   UNIQUE(forge, repository_id, display_number),
   CHECK(forge IN ('github')), CHECK(role IN ('home','implementation','upstream'))
+);
+CREATE TABLE IF NOT EXISTS legacy_task_adoptions (
+  task_id TEXT PRIMARY KEY REFERENCES tasks(task_id), repository_id TEXT NOT NULL,
+  adopted_operation_id TEXT NOT NULL REFERENCES operations(operation_id), adopted_at TEXT NOT NULL
 );
 CREATE TABLE IF NOT EXISTS forge_event_cursors (
   forge TEXT NOT NULL, repository_id TEXT NOT NULL, subject_kind TEXT NOT NULL, subject_id TEXT NOT NULL,
@@ -223,6 +228,15 @@ INSERT INTO migration_history(version,applied_at,backup_path,integrity_result) V
 COMMIT;`);
   if (sqlite(path, "PRAGMA integrity_check;\n") !== "ok") throw new Error("migration integrity verification failed");
 }
+function migrateV6ToV7(path) {
+  const copy = backup(path, "pre-migrate-v7");
+  sqlite(path, `BEGIN IMMEDIATE;
+${SCHEMA}
+UPDATE coordinator_meta SET value='7' WHERE key='schema_version';
+INSERT INTO migration_history(version,applied_at,backup_path,integrity_result) VALUES (7,${sqlEscape(now())},${sqlEscape(copy)},'ok');
+COMMIT;`);
+  if (sqlite(path, "PRAGMA integrity_check;\n") !== "ok") throw new Error("migration integrity verification failed");
+}
 function migrate(path, version) {
   if (version === 1) {
     migrateV1ToV2(path);
@@ -230,19 +244,26 @@ function migrate(path, version) {
     migrateV3ToV4(path);
     migrateV4ToV5(path);
     migrateV5ToV6(path);
+    migrateV6ToV7(path);
   } else if (version === 2) {
     migrateV2ToV3(path);
     migrateV3ToV4(path);
     migrateV4ToV5(path);
     migrateV5ToV6(path);
+    migrateV6ToV7(path);
   } else if (version === 3) {
     migrateV3ToV4(path);
     migrateV4ToV5(path);
     migrateV5ToV6(path);
+    migrateV6ToV7(path);
   } else if (version === 4) {
     migrateV4ToV5(path);
     migrateV5ToV6(path);
-  } else if (version === 5) migrateV5ToV6(path);
+    migrateV6ToV7(path);
+  } else if (version === 5) {
+    migrateV5ToV6(path);
+    migrateV6ToV7(path);
+  } else if (version === 6) migrateV6ToV7(path);
   else if (version !== SCHEMA_VERSION) throw new Error(`unsupported coordinator schema ${version}`);
 }
 function bootstrap(path) {
@@ -391,6 +412,56 @@ INSERT INTO terminal_evidence(operation_id,result_state,evidence_json,occurred_a
   }
   maybeCrash("after-commit");
   return operationResult(path, operationId, payloadHash);
+}
+function durableAdoptionResult(path, operationId, payloadHash) {
+  const result = operationResult(path, operationId, payloadHash);
+  return result ? { ...result, ok: result.status !== "conflict" } : null;
+}
+function adoptLegacyTask(input = {}, path = initialise()) {
+  const value = issueMappingInput({ ...input, role: "home" });
+  const taskId = value.taskId;
+  if (!LEGACY_TASK_ID.test(taskId)) throw new TypeError("task_id is not a canonical legacy identity");
+  const identityText = jsonText({ displayNumber: value.displayNumber, forge: value.forge, issueId: value.issueId, repositoryId: value.repositoryId, role: value.role, taskId }, "legacy adoption identity");
+  const operationId = input.operationId || `legacy-adopt-${createHash("sha256").update(identityText).digest("hex")}`;
+  validId(operationId, "operation_id");
+  const payloadText = identityText;
+  const payloadHash = hashText(payloadText);
+  const prior = durableAdoptionResult(path, operationId, payloadHash);
+  if (prior) return prior;
+  const timestamp = now();
+  try {
+    sqlite(path, `PRAGMA foreign_keys=ON; BEGIN IMMEDIATE;
+CREATE TEMP TABLE adoption_decision(status TEXT NOT NULL CHECK(status IN ('accepted','conflict')));
+INSERT INTO adoption_decision SELECT CASE
+  WHEN EXISTS (SELECT 1 FROM legacy_task_adoptions WHERE task_id=${sqlEscape(taskId)} AND repository_id<>${sqlEscape(value.repositoryId)}) THEN 'conflict'
+  WHEN EXISTS (SELECT 1 FROM issue_mappings WHERE task_id=${sqlEscape(taskId)} AND role='home'
+    AND (forge<>${sqlEscape(value.forge)} OR repository_id<>${sqlEscape(value.repositoryId)} OR issue_id<>${sqlEscape(value.issueId)} OR display_number<>${value.displayNumber})) THEN 'conflict'
+  WHEN EXISTS (SELECT 1 FROM issue_mappings WHERE forge=${sqlEscape(value.forge)} AND repository_id=${sqlEscape(value.repositoryId)}
+    AND (issue_id=${sqlEscape(value.issueId)} OR display_number=${value.displayNumber}) AND task_id<>${sqlEscape(taskId)}) THEN 'conflict'
+  ELSE 'accepted' END;
+INSERT INTO operations(operation_id,kind,task_id,payload_hash,payload_json,status,result_json,created_at,updated_at)
+SELECT ${sqlEscape(operationId)},'task.adopt',${sqlEscape(taskId)},${sqlEscape(payloadHash)},${sqlEscape(payloadText)},CASE WHEN status='accepted' THEN 'terminal' ELSE 'conflict' END,'null',${sqlEscape(timestamp)},${sqlEscape(timestamp)} FROM adoption_decision;
+UPDATE origins SET sequence=sequence+1 WHERE origin_id=(SELECT origin_id FROM origins WHERE state='active' ORDER BY created_at DESC LIMIT 1)
+AND NOT EXISTS (SELECT 1 FROM tasks WHERE task_id=${sqlEscape(taskId)}) AND (SELECT status FROM adoption_decision)='accepted';
+INSERT INTO tasks(task_id,origin_id,sequence,parent_task_id,created_operation_id,payload_hash,payload_json,created_at)
+SELECT ${sqlEscape(taskId)},origin_id,sequence,NULL,${sqlEscape(operationId)},${sqlEscape(payloadHash)},${sqlEscape(payloadText)},${sqlEscape(timestamp)}
+FROM origins WHERE state='active' AND NOT EXISTS (SELECT 1 FROM tasks WHERE task_id=${sqlEscape(taskId)})
+AND (SELECT status FROM adoption_decision)='accepted' ORDER BY created_at DESC LIMIT 1;
+INSERT INTO legacy_task_adoptions(task_id,repository_id,adopted_operation_id,adopted_at)
+SELECT ${sqlEscape(taskId)},${sqlEscape(value.repositoryId)},${sqlEscape(operationId)},${sqlEscape(timestamp)} FROM adoption_decision WHERE status='accepted' ON CONFLICT(task_id) DO NOTHING;
+INSERT INTO issue_mappings(task_id,forge,repository_id,repository_slug,role,issue_id,project_id,display_number,state_cursor,sync_metadata_json,created_at,updated_at)
+SELECT ${sqlEscape(taskId)},${sqlEscape(value.forge)},${sqlEscape(value.repositoryId)},${sqlEscape(value.repositorySlug)},'home',${sqlEscape(value.issueId)},${sqlEscape(value.projectId)},${value.displayNumber},${sqlEscape(value.stateCursor)},${sqlEscape(value.syncMetadataText)},${sqlEscape(timestamp)},${sqlEscape(timestamp)}
+FROM adoption_decision WHERE status='accepted' ON CONFLICT(task_id,forge,repository_id) DO NOTHING;
+UPDATE operations SET result_json=(SELECT json_object('adopted',status='accepted','operationId',${sqlEscape(operationId)},'repositoryId',${sqlEscape(value.repositoryId)},'status',status,'taskId',${sqlEscape(taskId)}) FROM adoption_decision) WHERE operation_id=${sqlEscape(operationId)};
+INSERT INTO terminal_evidence(operation_id,result_state,evidence_json,occurred_at)
+SELECT ${sqlEscape(operationId)},CASE WHEN status='accepted' THEN 'terminal' ELSE 'conflict' END,json_object('adoption',status,'issueId',${sqlEscape(value.issueId)},'repositoryId',${sqlEscape(value.repositoryId)}),${sqlEscape(timestamp)} FROM adoption_decision;
+DROP TABLE adoption_decision; COMMIT;`);
+  } catch (error) {
+    const raced = durableAdoptionResult(path, operationId, payloadHash);
+    if (!raced) throw new Error("legacy task adoption conflict", { cause: error });
+    return raced;
+  }
+  return durableAdoptionResult(path, operationId, payloadHash);
 }
 function publication({ operationId, taskId, repositoryId, repositoryPath, remoteName = "origin", branchName = "main", coalesceKey = "planning", maxAttempts = 5, payload = {} }, path = initialise()) {
   validId(operationId, "operation_id");
@@ -551,6 +622,12 @@ function bindIssue(input, path = initialise()) {
   const timestamp = now();
   try {
     sqlite(path, `BEGIN IMMEDIATE;
+CREATE TEMP TABLE assert_home_repository(value INTEGER CHECK(value=1));
+INSERT INTO assert_home_repository SELECT CASE WHEN ${sqlEscape(value.role)}<>'home' THEN 1
+  WHEN EXISTS (SELECT 1 FROM legacy_task_adoptions WHERE task_id=${sqlEscape(value.taskId)} AND repository_id<>${sqlEscape(value.repositoryId)}) THEN 0
+  WHEN EXISTS (SELECT 1 FROM issue_mappings WHERE task_id=${sqlEscape(value.taskId)} AND role='home' AND repository_id<>${sqlEscape(value.repositoryId)}) THEN 0
+  ELSE 1 END;
+DROP TABLE assert_home_repository;
 INSERT INTO issue_mappings(task_id,forge,repository_id,repository_slug,role,issue_id,project_id,display_number,state_cursor,sync_metadata_json,created_at,updated_at)
 VALUES (${sqlEscape(value.taskId)},${sqlEscape(value.forge)},${sqlEscape(value.repositoryId)},${sqlEscape(value.repositorySlug)},${sqlEscape(value.role)},${sqlEscape(value.issueId)},${sqlEscape(value.projectId)},${value.displayNumber},${sqlEscape(value.stateCursor)},${sqlEscape(value.syncMetadataText)},${sqlEscape(timestamp)},${sqlEscape(timestamp)})
 ON CONFLICT(task_id,forge,repository_id) DO UPDATE SET repository_slug=excluded.repository_slug,project_id=COALESCE(excluded.project_id,issue_mappings.project_id),state_cursor=COALESCE(excluded.state_cursor,issue_mappings.state_cursor),sync_metadata_json=CASE WHEN excluded.state_cursor>issue_mappings.state_cursor OR issue_mappings.state_cursor IS NULL THEN excluded.sync_metadata_json ELSE issue_mappings.sync_metadata_json END,updated_at=excluded.updated_at
@@ -720,6 +797,7 @@ function parseJson(value = "{}") { return JSON.parse(value); }
 function option(args, name, fallback = "") { const index = args.indexOf(name); return index >= 0 && index + 1 < args.length ? args[index + 1] : fallback; }
 const COMMAND_HANDLERS = {
   allocate: (args, path) => allocate({ operationId: option(args, "--operation-id") || randomUUID(), count: Number(option(args, "--count", "1")), legacyId: option(args, "--legacy-id"), payload: parseJson(option(args, "--payload", "{}")) }, path),
+  "adopt-legacy-task": (args, path) => adoptLegacyTask({ operationId: option(args, "--operation-id"), taskId: option(args, "--task-id"), forge: option(args, "--forge", "github"), repositoryId: option(args, "--repository-id"), repositorySlug: option(args, "--repository-slug"), issueId: option(args, "--issue-id"), projectId: option(args, "--project-id"), displayNumber: option(args, "--display-number"), stateCursor: option(args, "--state-cursor"), syncMetadata: parseJson(option(args, "--sync-metadata", "{}")) }, path),
   "publication-intent": (args, path) => publication({ operationId: option(args, "--operation-id"), taskId: option(args, "--task-id"), repositoryId: option(args, "--repository-id"), repositoryPath: option(args, "--repository-path"), remoteName: option(args, "--remote", "origin"), branchName: option(args, "--branch", "main"), coalesceKey: option(args, "--coalesce-key", "planning"), maxAttempts: Number(option(args, "--max-attempts", "5")), payload: parseJson(option(args, "--payload", "{}")) }, path),
   "lease-next": (args, path) => leaseNext({ ownerId: option(args, "--owner-id"), leaseSeconds: Number(option(args, "--lease-seconds", "60")), maxActive: Number(option(args, "--max-active", "4")) }, path),
   "lease-check": (args, path) => checkLease({ ownerId: option(args, "--owner-id"), repositoryId: option(args, "--repository-id"), fencingToken: Number(option(args, "--fencing-token")) }, path),
@@ -739,7 +817,7 @@ const COMMAND_HANDLERS = {
 };
 export function run(args = process.argv.slice(2)) {
   const command = args[0] || "help";
-  if (["help", "--help", "-h"].includes(command)) { process.stdout.write("Usage: task-coordinator.mjs allocate|publication-intent|lease-next|lease-check|lease-renew|lease-finish|publication-metrics|attempt|transition|bind-issue|resolve-issue|forge-event|restore|verify|status\n"); return 0; }
+  if (["help", "--help", "-h"].includes(command)) { process.stdout.write("Usage: task-coordinator.mjs allocate|adopt-legacy-task|publication-intent|lease-next|lease-check|lease-renew|lease-finish|publication-metrics|attempt|transition|bind-issue|resolve-issue|forge-event|restore|verify|status\n"); return 0; }
   const handler = COMMAND_HANDLERS[command];
   const path = initialise();
   if (!handler) throw new TypeError(`unknown task-coordinator command: ${command}`);
@@ -752,4 +830,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   try { process.exitCode = run(); } catch (error) { process.stderr.write(`task-coordinator: ${error.message}\n`); process.exitCode = 1; }
 }
 
-export { allocate, backup, bindIssue, forgeEvent, hashPayload, initialise, leaseNext, publicationMetrics, resolveIssue, restore, verify };
+export { adoptLegacyTask, allocate, backup, bindIssue, forgeEvent, hashPayload, initialise, leaseNext, publicationMetrics, resolveIssue, restore, verify };

--- a/.agents/scripts/task-projection-reducer.mjs
+++ b/.agents/scripts/task-projection-reducer.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { lstatSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const TASK_ID = /^(?:t[1-9][0-9]{0,17}(?:\.[1-9][0-9]{0,17}){0,8}|to[0-7][0-9a-hjkmnp-tv-z]{25}-[1-9][0-9]{0,17}(?:\.[1-9][0-9]{0,17}){0,8})$/;
+const TARGET_CHECKBOX = new Map([
+  ["task.available", " "],
+  ["task.claimed", null],
+  ["task.completed", "x"],
+  ["task.metadata_changed", null],
+  ["task.reconcile_requested", null],
+]);
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 && index + 1 < args.length ? args[index + 1] : "";
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function projectTransition(source, transition) {
+  const taskId = transition?.taskId;
+  const transitionKind = transition?.kind;
+  if (!TASK_ID.test(taskId)) throw new TypeError("task_id is not canonical");
+  if (!TARGET_CHECKBOX.has(transitionKind)) throw new TypeError("unsupported task projection transition");
+  const matcher = new RegExp(`^([ \\t]*-[ \\t]+\\[)([ xX])(\\][ \\t]+${escapeRegExp(taskId)})(?=[ \\t]|$)`, "gm");
+  const matches = [...source.matchAll(matcher)];
+  if (matches.length !== 1) throw new Error(`expected exactly one TODO projection for ${taskId}; found ${matches.length}`);
+  const target = TARGET_CHECKBOX.get(transitionKind);
+  if (target === null || matches[0][2].toLowerCase() === target) return source;
+  return source.replace(matcher, (_line, prefix, _checkbox, suffix) => `${prefix}${target}${suffix}`);
+}
+
+export function reduceTodoTransitions({ repositoryPath, transitions }) {
+  if (typeof repositoryPath !== "string" || !repositoryPath.startsWith("/") || repositoryPath.includes("\0")) throw new TypeError("repository_path must be absolute");
+  if (!Array.isArray(transitions) || transitions.length < 1 || transitions.length > 1000) throw new TypeError("transitions must contain 1..1000 entries");
+  const todoPath = resolve(repositoryPath, "TODO.md");
+  const metadata = lstatSync(todoPath);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) throw new TypeError("TODO.md must be a regular file");
+  const source = readFileSync(todoPath, "utf8");
+  const projected = transitions.reduce(projectTransition, source);
+  if (projected !== source) writeFileSync(todoPath, projected, "utf8");
+  return { changed: projected !== source, transitionCount: transitions.length };
+}
+
+export function run(args = process.argv.slice(2)) {
+  const transitions = JSON.parse(readFileSync(0, "utf8"));
+  const result = reduceTodoTransitions({
+    repositoryPath: option(args, "--repository-path"),
+    transitions,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try { process.exitCode = run(); } catch (error) { process.stderr.write(`task-projection-reducer: ${error.message}\n`); process.exitCode = 1; }
+}

--- a/.agents/scripts/task-publication-worker-helper.sh
+++ b/.agents/scripts/task-publication-worker-helper.sh
@@ -6,12 +6,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 COORDINATOR="${SCRIPT_DIR}/task-coordinator.mjs"
+PROJECTION_REDUCER="${SCRIPT_DIR}/task-projection-reducer.mjs"
 # shellcheck source=./planning-publisher.sh
 source "${SCRIPT_DIR}/planning-publisher.sh"
 
 PUBLICATION_MAX_CONCURRENCY="${AIDEVOPS_PUBLICATION_MAX_CONCURRENCY:-4}"
 PUBLICATION_LEASE_SECONDS="${AIDEVOPS_PUBLICATION_LEASE_SECONDS:-120}"
 PUBLICATION_MAX_BACKOFF="${AIDEVOPS_PUBLICATION_MAX_BACKOFF:-300}"
+PUBLICATION_TRANSITION_RESULT="none"
 
 _publication_evidence() {
 	local result="$1"
@@ -90,6 +92,26 @@ _publication_install_remote_fence() {
 	return 0
 }
 
+_publication_reduce_transitions() {
+	local lease="$1"
+	local repo_path="$2"
+	local transitions="" transition_count=0 reduction=""
+	PUBLICATION_TRANSITION_RESULT="none"
+	transitions=$(jq -ce '[.batch[].payload.transition? // empty]' <<<"$lease") || return 1
+	transition_count=$(jq -r 'length' <<<"$transitions") || return 1
+	[[ "$transition_count" -gt 0 ]] || return 0
+	reduction=$(node "$PROJECTION_REDUCER" --repository-path "$repo_path" <<<"$transitions") || {
+		PUBLICATION_TRANSITION_RESULT="conflict"
+		return 1
+	}
+	if [[ "$(jq -r '.changed' <<<"$reduction")" == "true" ]]; then
+		PUBLICATION_TRANSITION_RESULT="changed"
+	else
+		PUBLICATION_TRANSITION_RESULT="idempotent"
+	fi
+	return 0
+}
+
 _publication_process_lease() {
 	local lease="$1"
 	local owner_id="$2"
@@ -110,10 +132,32 @@ _publication_process_lease() {
 	_publication_install_remote_fence "$lease" "$owner_id" "$repo_path" "$remote_name" "$branch_name" || return 1
 	_publication_heartbeat "$lease" "$owner_id" &
 	heartbeat_pid=$!
-	AIDEVOPS_PLANNING_PUSH_GUARD=_publication_push_guard planning_publish "$repo_path" "plan: publish queued task projections" "$remote_name" "$branch_name" "$paths" || rc=$?
+	_publication_reduce_transitions "$lease" "$repo_path" || rc=$?
+	if [[ "$PUBLICATION_TRANSITION_RESULT" == "conflict" ]]; then
+		kill "$heartbeat_pid" >/dev/null 2>&1 || true
+		wait "$heartbeat_pid" 2>/dev/null || true
+		evidence=$(_publication_evidence "transition_conflict" "$PLANNING_PUBLICATION_ID")
+		_publication_finish "$lease" "$owner_id" terminal "$evidence" || return 1
+		return 0
+	fi
+	if [[ "$PUBLICATION_TRANSITION_RESULT" == "idempotent" ]]; then
+		kill "$heartbeat_pid" >/dev/null 2>&1 || true
+		wait "$heartbeat_pid" 2>/dev/null || true
+		evidence=$(_publication_evidence "idempotent_transition" "$PLANNING_PUBLICATION_ID")
+		_publication_finish "$lease" "$owner_id" terminal "$evidence" || return 1
+		return 0
+	fi
+	if [[ $rc -eq 0 ]]; then
+		AIDEVOPS_PLANNING_PUSH_GUARD=_publication_push_guard planning_publish "$repo_path" "plan: publish queued task projections" "$remote_name" "$branch_name" "$paths" || rc=$?
+	fi
 	kill "$heartbeat_pid" >/dev/null 2>&1 || true
 	wait "$heartbeat_pid" 2>/dev/null || true
 	if [[ $rc -eq 0 ]]; then
+		if [[ "$PUBLICATION_TRANSITION_RESULT" == "changed" && "$PLANNING_PUBLISH_RESULT" == "noop" ]]; then
+			evidence=$(_publication_evidence "idempotent_remote_transition" "$PLANNING_PUBLICATION_ID")
+			_publication_finish "$lease" "$owner_id" terminal "$evidence" || return 1
+			return 0
+		fi
 		commit_sha="$PLANNING_PUBLISHED_COMMIT"
 		evidence=$(_publication_evidence "${PLANNING_PUBLISH_RESULT:-published}" "$PLANNING_PUBLICATION_ID" "$commit_sha")
 		_publication_finish "$lease" "$owner_id" published "$evidence" || return 1

--- a/.agents/scripts/tests/test-forge-event-mapping.sh
+++ b/.agents/scripts/tests/test-forge-event-mapping.sh
@@ -10,13 +10,12 @@ COORDINATOR="${SCRIPT_DIR}/../task-coordinator.mjs"
 TEST_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 export AIDEVOPS_TASK_COORDINATOR_DB="${TEST_ROOT}/coordinator.db"
-node "$COORDINATOR" allocate --operation-id mapped-task --legacy-id t42 >/dev/null
 printf '%s\n' '- [ ] t42 mapped fixture ref:GH#7' >"${TEST_ROOT}/TODO.md"
 mkdir "${TEST_ROOT}/bin"
 cat >"${TEST_ROOT}/bin/gh" <<'GH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$GH_CALL_LOG"
-printf '{"id":"I_7","number":7,"state":"OPEN","updatedAt":"2026-07-12T15:00:00Z"}\n'
+printf '{"id":"I_7","number":7,"state":"OPEN","updatedAt":"%s"}\n' "${GH_UPDATED_AT:-2026-07-12T15:00:00Z}"
 GH
 chmod +x "${TEST_ROOT}/bin/gh"
 export GH_CALL_LOG="${TEST_ROOT}/api.log"
@@ -28,6 +27,35 @@ export GH_CALL_LOG="${TEST_ROOT}/api.log"
 )
 [[ "$(node "$COORDINATOR" resolve-issue --task-id t42 --repository-id R_7 | jq -r '.issueId')" == "I_7" ]]
 [[ "$(grep -c '^issue view 7 --repo owner/repo --json id,number,state,updatedAt$' "$GH_CALL_LOG")" == "1" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT repository_id FROM legacy_task_adoptions WHERE task_id='t42';")" == "R_7" ]]
+
+# Duplicate mapping is idempotent, while the adopted task identity cannot be
+# reused by another immutable repository identity.
+(
+	cd "$TEST_ROOT"
+	env PATH="${TEST_ROOT}/bin:$(dirname "$(command -v node)"):/usr/bin:/bin" EVENT_NAME=issues EVENT_DISPLAY_NUMBER=7 \
+		EVENT_SUBJECT_ID=I_7 REPOSITORY_ID=R_7 REPOSITORY_SLUG=owner/repo bash "$MAPPING_HELPER"
+)
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(*) FROM tasks WHERE task_id='t42';")" == "1" ]]
+
+if (
+	cd "$TEST_ROOT"
+	env PATH="${TEST_ROOT}/bin:$(dirname "$(command -v node)"):/usr/bin:/bin" GH_UPDATED_AT=2026-07-12T14:00:00Z \
+		EVENT_NAME=issues EVENT_DISPLAY_NUMBER=7 EVENT_SUBJECT_ID=I_7 REPOSITORY_ID=R_7 \
+		REPOSITORY_SLUG=owner/repo bash "$MAPPING_HELPER"
+); then
+	printf 'FAIL stale issue mapping was adopted\n' >&2
+	exit 1
+fi
+[[ "$(node "$COORDINATOR" resolve-issue --task-id t42 --repository-id R_7 | jq -r '.stateCursor')" == "2026-07-12T15:00:00.000Z" ]]
+if (
+	cd "$TEST_ROOT"
+	env PATH="${TEST_ROOT}/bin:$(dirname "$(command -v node)"):/usr/bin:/bin" EVENT_NAME=issues EVENT_DISPLAY_NUMBER=7 \
+		EVENT_SUBJECT_ID=I_7 REPOSITORY_ID=R_other REPOSITORY_SLUG=owner/other bash "$MAPPING_HELPER"
+); then
+	printf 'FAIL adopted legacy task crossed repository identities\n' >&2
+	exit 1
+fi
 
 if (
 	cd "$TEST_ROOT"

--- a/.agents/scripts/tests/test-forge-event-workflow.sh
+++ b/.agents/scripts/tests/test-forge-event-workflow.sh
@@ -11,6 +11,7 @@ SELF_CALLER="${REPO_ROOT}/.github/workflows/issue-sync.yml"
 CALLER_TEMPLATE="${REPO_ROOT}/.agents/templates/workflows/issue-sync-caller.yml"
 HELPER="${SCRIPT_DIR}/../forge-event-helper.sh"
 STATE_HELPER="${SCRIPT_DIR}/../forge-coordinator-state-helper.sh"
+PROJECTION_REDUCER="${SCRIPT_DIR}/../task-projection-reducer.mjs"
 
 python3 - "$WORKFLOW" <<'PY'
 import sys, yaml
@@ -36,6 +37,24 @@ for caller in "$SELF_CALLER" "$CALLER_TEMPLATE"; do
 	grep -q 'cursor:' "$caller"
 	grep -q 'task_id:' "$caller"
 done
+
+# Projection reduction is byte-targeted, idempotent, and atomic when any
+# transition in a coalesced batch cannot resolve exactly one task row.
+projection_root=$(mktemp -d)
+printf '# Tasks\n- [ ] t42 mapped task\n- [ ] t42.1 child task\n' >"${projection_root}/TODO.md"
+projection_result=$(node "$PROJECTION_REDUCER" --repository-path "$projection_root" <<<'[{"kind":"task.completed","taskId":"t42"}]')
+[[ "$(jq -r '.changed' <<<"$projection_result")" == "true" ]]
+[[ "$(<"${projection_root}/TODO.md")" == $'# Tasks\n- [x] t42 mapped task\n- [ ] t42.1 child task' ]]
+projection_before=$(cksum "${projection_root}/TODO.md")
+projection_result=$(node "$PROJECTION_REDUCER" --repository-path "$projection_root" <<<'[{"kind":"task.completed","taskId":"t42"}]')
+[[ "$(jq -r '.changed' <<<"$projection_result")" == "false" ]]
+if node "$PROJECTION_REDUCER" --repository-path "$projection_root" \
+	<<<'[{"kind":"task.available","taskId":"t42"},{"kind":"task.completed","taskId":"t99"}]' >/dev/null 2>&1; then
+	printf 'FAIL unresolved coalesced transition changed a partial projection\n' >&2
+	exit 1
+fi
+[[ "$(cksum "${projection_root}/TODO.md")" == "$projection_before" ]]
+rm -rf "$projection_root"
 
 test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT

--- a/.agents/scripts/tests/test-task-coordinator.sh
+++ b/.agents/scripts/tests/test-task-coordinator.sh
@@ -79,6 +79,32 @@ if node "$COORDINATOR" allocate --operation-id too-large --payload "{\"value\":\
 	exit 1
 fi
 
+# Existing legacy TODO identities are adopted atomically and remain bound to
+# one immutable repository identity across duplicate and conflicting intake.
+legacy_adoption=$(node "$COORDINATOR" adopt-legacy-task --operation-id adopt-28465 --task-id t28465 \
+	--repository-id R_adopt --repository-slug owner/adopt --issue-id I_adopt --display-number 28465)
+[[ "$(jq -r '.taskId' <<<"$legacy_adoption")" == "t28465" ]]
+[[ "$(jq -r '.status' <<<"$legacy_adoption")" == "accepted" ]]
+[[ "$(node "$COORDINATOR" adopt-legacy-task --operation-id adopt-28465 --task-id t28465 --repository-id R_adopt --repository-slug owner/adopt --issue-id I_adopt --display-number 28465)" == "$legacy_adoption" ]]
+if node "$COORDINATOR" adopt-legacy-task --operation-id adopt-28465 --task-id t28465 --repository-id R_other \
+	--repository-slug owner/other --issue-id I_adopt --display-number 28465 >/dev/null 2>&1; then
+	printf 'FAIL changed legacy adoption reused an operation ID\n' >&2
+	exit 1
+fi
+if node "$COORDINATOR" adopt-legacy-task --operation-id adopt-cross-repo --task-id t28465 --repository-id R_other \
+	--repository-slug owner/other --issue-id I_other --display-number 28465 >/dev/null 2>&1; then
+	printf 'FAIL legacy task adoption crossed repository identities\n' >&2
+	exit 1
+fi
+if node "$COORDINATOR" adopt-legacy-task --operation-id adopt-issue-conflict --task-id t28465 --repository-id R_adopt \
+	--repository-slug owner/adopt --issue-id I_other --display-number 28466 >/dev/null 2>&1; then
+	printf 'FAIL legacy task adoption replaced immutable issue identity\n' >&2
+	exit 1
+fi
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT COUNT(*) FROM tasks WHERE task_id='t28465';")" == "1" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT status FROM operations WHERE operation_id='adopt-cross-repo';")" == "conflict" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT status FROM operations WHERE operation_id='adopt-issue-conflict';")" == "conflict" ]]
+
 # Independent reinstall/clone state creates a new CSPRNG origin at the same sequence.
 origin_one=$(node "$COORDINATOR" status | jq -r '.origin_id')
 AIDEVOPS_TASK_COORDINATOR_DB="${TEST_ROOT}/clone.db" node "$COORDINATOR" allocate --operation-id clone >/dev/null
@@ -117,9 +143,9 @@ inode_after=$(stat -f '%i' "$AIDEVOPS_TASK_COORDINATOR_DB" 2>/dev/null || stat -
 # A real v1 schema migrates through every version only after verified backups.
 migration_db="${TEST_ROOT}/migration.db"
 AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/null
-sqlite3 "$migration_db" "DROP TABLE issue_mappings; DROP TABLE forge_event_cursors; ALTER TABLE restore_controls DROP COLUMN backup_high_water; UPDATE coordinator_meta SET value='1' WHERE key='schema_version'; DELETE FROM migration_history; INSERT INTO migration_history VALUES(1,'2026-01-01T00:00:00Z',NULL,'ok');"
+sqlite3 "$migration_db" "DROP TABLE legacy_task_adoptions; DROP TABLE issue_mappings; DROP TABLE forge_event_cursors; ALTER TABLE restore_controls DROP COLUMN backup_high_water; UPDATE coordinator_meta SET value='1' WHERE key='schema_version'; DELETE FROM migration_history; INSERT INTO migration_history VALUES(1,'2026-01-01T00:00:00Z',NULL,'ok');"
 AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/null
-[[ "$(sqlite3 "$migration_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "6" ]]
+[[ "$(sqlite3 "$migration_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "7" ]]
 [[ "$(sqlite3 "$migration_db" "SELECT COUNT(*) FROM pragma_table_info('operations') WHERE name='result_hash';")" == "0" ]]
 [[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v2.db)" ]]
 [[ -n "$(ls "${TEST_ROOT}"/migration.db-backup-*-pre-migrate-v3.db)" ]]
@@ -127,11 +153,11 @@ AIDEVOPS_TASK_COORDINATOR_DB="$migration_db" node "$COORDINATOR" status >/dev/nu
 # An untouched v2 database is backed up before any v3 table is applied.
 v2_db="${TEST_ROOT}/v2.db"
 AIDEVOPS_TASK_COORDINATOR_DB="$v2_db" node "$COORDINATOR" status >/dev/null
-sqlite3 "$v2_db" "DROP TABLE issue_mappings; DROP TABLE forge_event_cursors; ALTER TABLE operations ADD COLUMN result_hash TEXT NOT NULL DEFAULT 'unchecked'; UPDATE coordinator_meta SET value='2' WHERE key='schema_version'; DELETE FROM migration_history WHERE version>2; INSERT OR IGNORE INTO migration_history VALUES(2,'2026-01-01T00:00:00Z',NULL,'ok');"
+sqlite3 "$v2_db" "DROP TABLE legacy_task_adoptions; DROP TABLE issue_mappings; DROP TABLE forge_event_cursors; ALTER TABLE operations ADD COLUMN result_hash TEXT NOT NULL DEFAULT 'unchecked'; UPDATE coordinator_meta SET value='2' WHERE key='schema_version'; DELETE FROM migration_history WHERE version>2; INSERT OR IGNORE INTO migration_history VALUES(2,'2026-01-01T00:00:00Z',NULL,'ok');"
 AIDEVOPS_TASK_COORDINATOR_DB="$v2_db" node "$COORDINATOR" status >/dev/null
 v2_backup=$(ls "${TEST_ROOT}"/v2.db-backup-*-pre-migrate-v3.db)
 [[ "$(sqlite3 "$v2_backup" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='issue_mappings';")" == "0" ]]
-[[ "$(sqlite3 "$v2_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "6" ]]
+[[ "$(sqlite3 "$v2_db" "SELECT value FROM coordinator_meta WHERE key='schema_version';")" == "7" ]]
 
 # Immutable task/repository identities isolate equal display numbers and allow
 # one task to retain home, implementation, and upstream issue projections.

--- a/.agents/scripts/tests/test-task-publication-worker.sh
+++ b/.agents/scripts/tests/test-task-publication-worker.sh
@@ -142,7 +142,7 @@ git_root="${TEST_ROOT}/git"
 mkdir -p "$git_root"
 git init --bare --initial-branch=main "${git_root}/remote.git" >/dev/null 2>&1 || git init --bare "${git_root}/remote.git" >/dev/null 2>&1
 git clone "${git_root}/remote.git" "${git_root}/work" >/dev/null 2>&1
-printf '# Tasks\n' >"${git_root}/work/TODO.md"
+printf '# Tasks\n- [ ] %s mapped transition ref:GH#77\n- [ ] %s.1 child remains open\n' "$task_id" "$task_id" >"${git_root}/work/TODO.md"
 printf 'base\n' >"${git_root}/work/README.md"
 git -C "${git_root}/work" add TODO.md README.md
 GIT_AUTHOR_NAME=Test GIT_AUTHOR_EMAIL=test@example.invalid GIT_COMMITTER_NAME=Test GIT_COMMITTER_EMAIL=test@example.invalid \
@@ -195,6 +195,34 @@ if git -C "${git_root}/work" push --atomic \
 fi
 [[ "$(git --git-dir="${git_root}/remote.git" rev-parse main)" == "$after_recovery" ]]
 [[ "$(git --git-dir="${git_root}/remote.git" rev-parse "$fence_ref")" == "$recovered_fence" ]]
+
+# Forge-event transitions are reduced into the repository projection before
+# publication and change only the exact mapped TODO row.
+node "$COORDINATOR" bind-issue --task-id "$task_id" --repository-id repo-git --repository-slug owner/repo \
+	--role home --issue-id I_transition --display-number 77 --state-cursor 2026-07-12T12:00:00Z >/dev/null
+node "$COORDINATOR" forge-event --operation-id transition-closed --delivery-id transition-closed \
+	--cursor-tiebreaker run-closed --repository-id repo-git --repository-slug owner/repo \
+	--repository-path "${git_root}/work" --event-kind issue --action closed --subject-id I_transition \
+	--cursor 2026-07-12T13:00:00Z >/dev/null
+AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true "$WORKER" once
+projected_todo=$(git --git-dir="${git_root}/remote.git" show main:TODO.md)
+expected_todo=$(printf '# Tasks\n- [x] %s mapped transition ref:GH#77\n- [ ] %s.1 child remains open\n- [ ] t001 worker publication\n- [ ] t002 stale publication' "$task_id" "$task_id")
+[[ "$projected_todo" == "$expected_todo" ]]
+closed_sha=$(git --git-dir="${git_root}/remote.git" rev-parse main)
+node "$COORDINATOR" forge-event --operation-id transition-duplicate-closed --delivery-id transition-duplicate-closed \
+	--cursor-tiebreaker run-duplicate-closed --repository-id repo-git --repository-slug owner/repo \
+	--repository-path "${git_root}/work" --event-kind issue --action closed --subject-id I_transition \
+	--cursor 2026-07-12T13:30:00Z >/dev/null
+AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true "$WORKER" once
+[[ "$(git --git-dir="${git_root}/remote.git" rev-parse main)" == "$closed_sha" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT status FROM publication_intents WHERE operation_id='transition-duplicate-closed';")" == "terminal" ]]
+[[ "$(sqlite3 "$AIDEVOPS_TASK_COORDINATOR_DB" "SELECT json_extract(evidence_json,'$.result') FROM terminal_evidence WHERE operation_id='transition-duplicate-closed' ORDER BY id DESC LIMIT 1;")" == "idempotent_transition" ]]
+node "$COORDINATOR" forge-event --operation-id transition-reopened --delivery-id transition-reopened \
+	--cursor-tiebreaker run-reopened --repository-id repo-git --repository-slug owner/repo \
+	--repository-path "${git_root}/work" --event-kind issue --action reopened --subject-id I_transition \
+	--cursor 2026-07-12T14:00:00Z >/dev/null
+AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true "$WORKER" once
+[[ "$(git --git-dir="${git_root}/remote.git" show main:TODO.md)" == "${expected_todo/\[x\]/[ ]}" ]]
 
 # Active initialization lock ownership is never stolen based on age alone.
 mkdir "${AIDEVOPS_TASK_COORDINATOR_DB}.init-lock"


### PR DESCRIPTION
## Summary

Adopt verified legacy tasks atomically, reduce targeted forge transitions into exact TODO bytes, and record idempotent or conflicting projection outcomes without green no-ops.

## Files Changed

.agents/scripts/forge-event-mapping-helper.sh, .agents/scripts/task-coordinator.mjs, .agents/scripts/task-projection-reducer.mjs, .agents/scripts/task-publication-worker-helper.sh, .agents/scripts/tests/test-forge-event-mapping.sh, .agents/scripts/tests/test-forge-event-workflow.sh, .agents/scripts/tests/test-task-coordinator.sh, .agents/scripts/tests/test-task-publication-worker.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Runtime-verified with task coordinator, forge mapping/workflow/reconciliation, issue isolation, publication worker, planning publisher, ShellCheck, Node syntax, and local linter suites.

Resolves #28465


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.163 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 51m and 823,980 tokens on this with the user in an interactive session.