### PR TITLE
GH#28466: classify PR runtime risk instead of hardcoding Low

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -251,57 +251,81 @@ cmd_pre_merge_gate() {
 
 # Parse commit-and-pr arguments into caller-scoped variables.
 # Expects the caller to have declared: issue_number, commit_message, pr_title,
-# summary_what, summary_testing, summary_decisions, skip_rebase, extra_labels (array).
+# summary_what, summary_testing, summary_decisions, runtime_risk, testing_level,
+# skip_rebase, extra_labels (array).
 # Returns 1 on unknown argument.
 _parse_commit_and_pr_args() {
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
+	local -a args=("$@")
+	local index=0
+	local arg=""
+	local value=""
+	while [[ "$index" -lt "${#args[@]}" ]]; do
+		arg="${args[$index]}"
+		case "$arg" in
+		--issue | --message | --title | --summary | --testing | --risk-level | --testing-level | --decisions | --label)
+			if [[ $((index + 1)) -ge ${#args[@]} ]]; then
+				print_error "${arg} requires a value"
+				return 1
+			fi
+			value="${args[$((index + 1))]}"
+			;;
+		esac
+
+		case "$arg" in
 		--issue)
-			issue_number="$2"
-			shift 2
+			issue_number="$value"
+			index=$((index + 2))
 			;;
 		--message)
-			commit_message="$2"
-			shift 2
+			commit_message="$value"
+			index=$((index + 2))
 			;;
 		--title)
-			pr_title="$2"
-			shift 2
+			pr_title="$value"
+			index=$((index + 2))
 			;;
 		--summary)
-			summary_what="$2"
-			shift 2
+			summary_what="$value"
+			index=$((index + 2))
 			;;
 		--testing)
-			summary_testing="$2"
-			shift 2
+			summary_testing="$value"
+			index=$((index + 2))
+			;;
+		--risk-level)
+			runtime_risk="$value"
+			index=$((index + 2))
+			;;
+		--testing-level)
+			testing_level="$value"
+			index=$((index + 2))
 			;;
 		--decisions)
-			summary_decisions="$2"
-			shift 2
+			summary_decisions="$value"
+			index=$((index + 2))
 			;;
 		--label)
-			extra_labels+=("$2")
-			shift 2
+			extra_labels+=("$value")
+			index=$((index + 2))
 			;;
 		--allow-parent-close)
 			allow_parent_close=1
-			shift
+			index=$((index + 1))
 			;;
 		--skip-hooks)
 			# Pass --no-verify to git push. Use for doc-only PRs when hooks
 			# have been manually verified clean. See GH#20138.
 			skip_hooks=1
-			shift
+			index=$((index + 1))
 			;;
 		--no-rebase)
 			# GH#26627: explicit recovery mode after a failed/aborted rebase.
 			# Pushes only after clean-state and ahead-of-base checks pass.
 			skip_rebase=1
-			shift
+			index=$((index + 1))
 			;;
 		*)
-			print_error "Unknown argument: $1"
+			print_error "Unknown argument: $arg"
 			return 1
 			;;
 		esac
@@ -893,10 +917,10 @@ _rebase_and_push() {
 		local branch_counter="" base_counter=""
 		branch_counter=$(tr -d '[:space:]' <.task-counter 2>/dev/null) || true
 		base_counter=$(git show "${base_ref}:.task-counter" 2>/dev/null | tr -d '[:space:]') || true
-		if [[ -n "$branch_counter" && -n "$base_counter" ]] \
-			&& [[ "$branch_counter" =~ ^[0-9]+$ ]] \
-			&& [[ "$base_counter" =~ ^[0-9]+$ ]] \
-			&& [[ "$((10#$branch_counter))" -lt "$((10#$base_counter))" ]]; then
+		if [[ -n "$branch_counter" && -n "$base_counter" ]] &&
+			[[ "$branch_counter" =~ ^[0-9]+$ ]] &&
+			[[ "$base_counter" =~ ^[0-9]+$ ]] &&
+			[[ "$((10#$branch_counter))" -lt "$((10#$base_counter))" ]]; then
 			print_info "Auto-resetting .task-counter: ${branch_counter} → ${base_counter} (base drifted during rebase)"
 			printf '%s\n' "$base_counter" >.task-counter
 			git add .task-counter
@@ -971,11 +995,20 @@ _issue_has_parent_task_label() {
 
 # Build the PR body string and print it to stdout.
 # Arguments: issue_number, summary_what, summary_testing, files_changed,
-#            sig_footer, closing_keyword (default: Resolves)
+#            sig_footer, closing_keyword (default: Resolves), requested_risk,
+#            requested_testing_level, base_ref
 _build_pr_body() {
 	local issue_number="$1" summary_what="$2" summary_testing="$3"
 	local files_changed="$4" sig_footer="$5"
 	local closing_keyword="${6:-Resolves}"
+	local requested_risk="${7:-}"
+	local requested_testing_level="${8:-}"
+	local base_ref="${9:-}"
+	local runtime_risk=""
+	local testing_level=""
+
+	runtime_risk=$(_derive_runtime_risk "$requested_risk" "$files_changed" "$summary_what" "$base_ref") || return 1
+	testing_level=$(_resolve_runtime_testing_level "$runtime_risk" "$requested_testing_level" "$summary_testing") || return 1
 
 	printf '%s\n' "## Summary
 
@@ -987,8 +1020,8 @@ ${files_changed:-See diff}
 
 ## Runtime Testing
 
-- **Risk level:** Low (agent prompts / infrastructure scripts)
-- **Verification:** ${summary_testing:-shellcheck clean, self-assessed}
+- **Risk level:** ${runtime_risk}
+- **Verification:** ${testing_level} — ${summary_testing:-no additional evidence supplied}
 
 ${closing_keyword} #${issue_number}
 
@@ -1117,11 +1150,11 @@ _derive_pr_title_prefix() {
 	# Match "- [ ] tNNN ... ref:GH#<issue_number>" with a non-digit or EOL
 	# boundary after the number so ref:GH#123 doesn't match ref:GH#12345.
 	local task_id=""
-	task_id=$(grep -E "^- \[[ x]\] t[0-9]+ .*ref:GH#${issue_number}([^0-9]|\$)" "$todo_file" 2>/dev/null \
-		| head -1 \
-		| grep -oE '^- \[[ x]\] t[0-9]+' \
-		| grep -oE 't[0-9]+$' \
-		|| true)
+	task_id=$(grep -E "^- \[[ x]\] t[0-9]+ .*ref:GH#${issue_number}([^0-9]|\$)" "$todo_file" 2>/dev/null |
+		head -1 |
+		grep -oE '^- \[[ x]\] t[0-9]+' |
+		grep -oE 't[0-9]+$' ||
+		true)
 
 	if [[ -n "$task_id" ]]; then
 		printf '%s\n' "$task_id"

--- a/.agents/scripts/full-loop-helper-risk.sh
+++ b/.agents/scripts/full-loop-helper-risk.sh
@@ -6,65 +6,58 @@
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
 [[ -n "${_FULL_LOOP_RISK_LIB_LOADED:-}" ]] && return 0
 _FULL_LOOP_RISK_LIB_LOADED=1
+_full_loop_runtime_verified_marker="runtime-verified"
 
-# Derive the most conservative runtime-risk level supported by the supplied
-# metadata and branch diff. An explicit level remains available for cases that
-# cannot be inferred reliably from text. Low is reserved for policy-listed
-# non-runtime paths; other unmatched changes fail upward to Medium.
-# Arguments: requested_risk, files_changed, summary_what, base_ref (optional)
-_derive_runtime_risk() {
+# Normalize a caller-supplied risk level to the spelling used in PR bodies.
+_normalize_runtime_risk() {
 	local requested_risk="${1:-}"
-	local files_changed="${2:-}"
-	local summary_what="${3:-}"
-	local base_ref="${4:-}"
 	local normalized=""
+	normalized=$(printf '%s' "$requested_risk" | tr '[:upper:]' '[:lower:]')
+	case "$normalized" in
+	critical) printf 'Critical\n' ;;
+	high) printf 'High\n' ;;
+	medium) printf 'Medium\n' ;;
+	low) printf 'Low\n' ;;
+	*)
+		print_error "Invalid --risk-level '${requested_risk}'. Expected Critical, High, Medium, or Low."
+		return 1
+		;;
+	esac
+	return 0
+}
 
-	if [[ -n "$requested_risk" ]]; then
-		normalized=$(printf '%s' "$requested_risk" | tr '[:upper:]' '[:lower:]')
-		case "$normalized" in
-		critical)
-			printf 'Critical\n'
-			return 0
-			;;
-		high)
-			printf 'High\n'
-			return 0
-			;;
-		medium)
-			printf 'Medium\n'
-			return 0
-			;;
-		low)
-			printf 'Low\n'
-			return 0
-			;;
-		*)
-			print_error "Invalid --risk-level '${requested_risk}'. Expected Critical, High, Medium, or Low."
-			return 1
-			;;
-		esac
-	fi
+_runtime_risk_rank() {
+	local runtime_risk="$1"
+	case "$runtime_risk" in
+	Critical) printf '4\n' ;;
+	High) printf '3\n' ;;
+	Medium) printf '2\n' ;;
+	Low) printf '1\n' ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
 
-	local context="${summary_what} ${files_changed}"
-	if [[ -n "$base_ref" ]]; then
-		local diff_context=""
-		diff_context=$(git diff --unified=0 "${base_ref}..HEAD" 2>/dev/null || true)
-		context="${context} ${diff_context}"
-	fi
-	context=$(printf '%s' "$context" | tr '[:upper:]' '[:lower:]')
-
-	if [[ "$context" =~ payment|billing|auth(entication|orization)?[[:space:]_/-]*(session)?|session[[:space:]_/-]*auth|data[[:space:]_/-]*delet|cryptograph|credential ]]; then
-		printf 'Critical\n'
+# Low-risk paths are the non-runtime categories listed in full-loop.md.
+_runtime_path_is_low() {
+	local path="$1"
+	case "$path" in
+	*.md | *.mdx | *.rst | *.adoc | docs/*.txt | */docs/*.txt | README | README.* | */README | */README.* | CHANGELOG* | */CHANGELOG* | LICENSE | LICENSE.* | */LICENSE | */LICENSE.* | \
+		*.d.ts | *.d.mts | *.d.cts | *.pyi | */tests/* | */test/* | */__tests__/* | test-* | test_* | *_test.* | *.test.* | *.spec.* | \
+		.github/* | .qlty/* | .shellcheckrc | */.shellcheckrc | .markdownlint* | */.markdownlint* | .yamllint* | */.yamllint* | \
+		.eslintrc* | */.eslintrc* | eslint.config.* | */eslint.config.* | .prettierrc* | */.prettierrc* | prettier.config.* | */prettier.config.* | \
+		.stylelintrc* | */.stylelintrc* | stylelint.config.* | */stylelint.config.* | biome.json | */biome.json | *lint*.config.* | *linters*.conf | \
+		.agents/prompts/*)
 		return 0
-	fi
-	if [[ "$context" =~ poll(ing)?[[:space:]_/-]*(loop|interval)|websocket|server[[:space:]_/-]*sent[[:space:]_/-]*event|state[[:space:]_/-]*machine|form[[:space:]_/-]*handler|api[[:space:]_/-]*endpoint ]]; then
-		printf 'High\n'
-		return 0
-	fi
+		;;
+	*) return 1 ;;
+	esac
+}
 
+_runtime_paths_are_low() {
+	local files_changed="${1:-}"
 	local path=""
 	local saw_path=0
-	local all_low=1
 	local old_ifs="$IFS"
 	IFS=','
 	for path in $files_changed; do
@@ -72,24 +65,213 @@ _derive_runtime_risk() {
 		path="${path#"${path%%[![:space:]]*}"}"
 		[[ -z "$path" ]] && continue
 		saw_path=1
-		case "$path" in
-		*.md | *.mdx | *.rst | *.txt | *.d.ts | */tests/* | */test/* | test-* | *.test.* | *.spec.* | .github/* | *lint*.config.* | *linters*.conf | .agents/prompts/*) ;;
-		*) all_low=0 ;;
-		esac
+		if ! _runtime_path_is_low "$path"; then
+			IFS="$old_ifs"
+			return 1
+		fi
 	done
 	IFS="$old_ifs"
+	[[ "$saw_path" -eq 1 ]] && return 0
+	return 1
+}
 
-	if [[ "$saw_path" -eq 1 && "$all_low" -eq 1 ]]; then
-		printf 'Low\n'
+# Return success only when every changed content line is visibly a comment or
+# whitespace. Ambiguous block-comment edits fail upward to Medium.
+_runtime_diff_is_comments_only() {
+	local base_ref="$1"
+	local line="" content="" trimmed="" trailing="" current_path=""
+	local block_kind="" c_block_end="*/" html_block_end="-->"
+	local saw_change=0
+	git rev-parse --verify "${base_ref}^{commit}" >/dev/null 2>&1 || return 1
+
+	while IFS= read -r line; do
+		case "$line" in
+		"+++ b/"*)
+			[[ -n "$block_kind" ]] && return 1
+			current_path="${line#+++ b/}"
+			continue
+			;;
+		"@@"*)
+			[[ -n "$block_kind" ]] && return 1
+			continue
+			;;
+		"+++ /dev/null" | "--- /dev/null" | "--- a/"* | "diff --git "* | "index "* | "new file mode "* | "deleted file mode "*) continue ;;
+		+* | -*) ;;
+		*) continue ;;
+		esac
+
+		saw_change=1
+		content="${line:1}"
+		trimmed="${content#"${content%%[![:space:]]*}"}"
+		[[ -z "$trimmed" ]] && continue
+
+		if [[ -n "$block_kind" ]]; then
+			if [[ "$block_kind" == "c" && "$trimmed" == *"$c_block_end"* ]]; then
+				trailing="${trimmed#*"$c_block_end"}"
+				block_kind=""
+			elif [[ "$block_kind" == "html" && "$trimmed" == *"$html_block_end"* ]]; then
+				trailing="${trimmed#*"$html_block_end"}"
+				block_kind=""
+			else
+				continue
+			fi
+			trailing="${trailing#"${trailing%%[![:space:]]*}"}"
+			[[ -z "$trailing" ]] && continue
+			return 1
+		fi
+
+		case "$trimmed" in
+		\#!* | \#include* | \#define* | \#if* | \#elif* | \#else* | \#endif* | \#pragma* | \#error* | \#undef*) return 1 ;;
+		\#* | //* | -- | --[[:space:]]*) continue ;;
+		\;*)
+			case "$current_path" in
+			*.ini | *.cfg | *.conf) continue ;;
+			esac
+			return 1
+			;;
+		"/*"*)
+			if [[ "$trimmed" == *"$c_block_end"* ]]; then
+				trailing="${trimmed#*"$c_block_end"}"
+				trailing="${trailing#"${trailing%%[![:space:]]*}"}"
+				[[ -z "$trailing" ]] && continue
+				return 1
+			fi
+			block_kind="c"
+			;;
+		"<!--"*)
+			if [[ "$trimmed" == *"$html_block_end"* ]]; then
+				trailing="${trimmed#*"$html_block_end"}"
+				trailing="${trailing#"${trailing%%[![:space:]]*}"}"
+				[[ -z "$trailing" ]] && continue
+				return 1
+			fi
+			block_kind="html"
+			;;
+		*) return 1 ;;
+		esac
+	done < <(git diff --unified=0 --no-color --no-ext-diff "${base_ref}..HEAD" -- 2>/dev/null)
+
+	[[ "$saw_change" -eq 1 && -z "$block_kind" ]] && return 0
+	return 1
+}
+
+_runtime_context_has_critical_pattern() {
+	local context="$1"
+	if [[ "$context" =~ (^|[^[:alnum:]_])(payments?|billing|auth|authentication|authorization|sessions?|credentials?|crypto|cryptograph(y|ic|ical)?)([^[:alnum:]_]|$) ]] ||
+		[[ "$context" =~ (^|[^[:alnum:]_])data[[:space:]_/-]*delet(e|es|ed|ing|ion)([^[:alnum:]_]|$) ]] ||
+		[[ "$context" =~ (^|[^[:alnum:]_])delet(e|es|ed|ing|ion)[[:space:]_/-]*data([^[:alnum:]_]|$) ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_runtime_context_has_high_pattern() {
+	local context="$1"
+	if [[ "$context" =~ (^|[^[:alnum:]_])(websockets?|sse)([^[:alnum:]_]|$) ]] ||
+		[[ "$context" =~ (^|[^[:alnum:]_])server[[:space:]_/-]*sent[[:space:]_/-]*events?([^[:alnum:]_]|$) ]] ||
+		[[ "$context" =~ (^|[^[:alnum:]_])poll(ing)?[[:space:]_/-]*(loops?|intervals?)([^[:alnum:]_]|$) ]] ||
+		[[ "$context" =~ (^|[^[:alnum:]_])state[[:space:]_/-]*machines?([^[:alnum:]_]|$) ]] ||
+		[[ "$context" =~ (^|[^[:alnum:]_])form[[:space:]_/-]*handlers?([^[:alnum:]_]|$) ]] ||
+		[[ "$context" =~ (^|[^[:alnum:]_])api[[:space:]_/-]*endpoints?([^[:alnum:]_]|$) ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_select_conservative_runtime_risk() {
+	local detected_risk="$1"
+	local requested_risk="${2:-}"
+	local normalized="" detected_rank="" requested_rank=""
+	if [[ -z "$requested_risk" ]]; then
+		printf '%s\n' "$detected_risk"
+		return 0
+	fi
+
+	normalized=$(_normalize_runtime_risk "$requested_risk") || return 1
+	detected_rank=$(_runtime_risk_rank "$detected_risk") || return 1
+	requested_rank=$(_runtime_risk_rank "$normalized") || return 1
+	if [[ "$requested_rank" -gt "$detected_rank" ]]; then
+		printf '%s\n' "$normalized"
 	else
-		printf 'Medium\n'
+		printf '%s\n' "$detected_risk"
 	fi
 	return 0
 }
 
+# Derive the most conservative runtime-risk level supported by the supplied
+# metadata and branch diff. Explicit levels can raise ambiguous classifications
+# but cannot downgrade policy patterns. Unmatched runtime changes fail upward to
+# Medium; policy-listed non-runtime and comment-only changes remain Low.
+# Arguments: requested_risk, files_changed, summary_what, base_ref (optional)
+_derive_runtime_risk() {
+	local requested_risk="${1:-}"
+	local files_changed="${2:-}"
+	local summary_what="${3:-}"
+	local base_ref="${4:-}"
+	local context="${summary_what} ${files_changed}"
+	local diff_context=""
+	local detected_risk="Medium"
+
+	if _runtime_paths_are_low "$files_changed"; then
+		detected_risk="Low"
+	elif [[ -n "$base_ref" ]] && _runtime_diff_is_comments_only "$base_ref"; then
+		detected_risk="Low"
+	else
+		if [[ -n "$base_ref" ]]; then
+			diff_context=$(git diff --unified=0 --no-color --no-ext-diff "${base_ref}..HEAD" 2>/dev/null || true)
+			context="${context} ${diff_context}"
+		fi
+		context=$(printf '%s' "$context" | tr '[:upper:]' '[:lower:]')
+		if _runtime_context_has_critical_pattern "$context"; then
+			detected_risk="Critical"
+		elif _runtime_context_has_high_pattern "$context"; then
+			detected_risk="High"
+		fi
+	fi
+
+	if ! _select_conservative_runtime_risk "$detected_risk" "$requested_risk"; then
+		return 1
+	fi
+	return 0
+}
+
+_summary_declares_runtime_verified() {
+	local summary_testing="${1:-}"
+	local normalized=""
+	normalized=$(printf '%s' "$summary_testing" | tr '[:upper:]' '[:lower:]')
+	if [[ "$normalized" == *"not ${_full_loop_runtime_verified_marker}"* ]] ||
+		[[ "$normalized" == *"not runtime verified"* ]] ||
+		[[ "$normalized" == *"no ${_full_loop_runtime_verified_marker}"* ]] ||
+		[[ "$normalized" == *"without ${_full_loop_runtime_verified_marker}"* ]]; then
+		return 1
+	fi
+	[[ "$normalized" == *"$_full_loop_runtime_verified_marker"* ]] && return 0
+	return 1
+}
+
+_runtime_evidence_is_substantive() {
+	local summary_testing="${1:-}"
+	local normalized="" detail=""
+	normalized=$(printf '%s' "$summary_testing" | tr '[:upper:]' '[:lower:]')
+	case "$normalized" in
+	"" | none | n/a | na | self-assessed) return 1 ;;
+	esac
+	if [[ "$normalized" == *"no additional evidence"* ]] ||
+		[[ "$normalized" == *"no evidence"* ]] ||
+		[[ "$normalized" == *"no runtime evidence"* ]] ||
+		[[ "$normalized" == *"not ${_full_loop_runtime_verified_marker}"* ]] ||
+		[[ "$normalized" == *"not runtime verified"* ]]; then
+		return 1
+	fi
+	detail="${normalized//$_full_loop_runtime_verified_marker/}"
+	detail=$(printf '%s' "$detail" | tr -d '[:space:][:punct:]')
+	[[ -n "$detail" ]] && return 0
+	return 1
+}
+
 # Resolve testing evidence and enforce the runtime gate. The literal evidence
-# marker is intentionally machine-readable so a prose-only claim cannot satisfy
-# Critical/High requirements accidentally.
+# marker is machine-readable, while a non-empty detail prevents a bare marker
+# from claiming runtime verification without any supporting evidence.
 # Arguments: runtime_risk, requested_testing_level, summary_testing
 _resolve_runtime_testing_level() {
 	local runtime_risk="$1"
@@ -99,23 +281,28 @@ _resolve_runtime_testing_level() {
 
 	if [[ -n "$requested_testing_level" ]]; then
 		testing_level=$(printf '%s' "$requested_testing_level" | tr '[:upper:]' '[:lower:]')
-	elif [[ "$summary_testing" == *runtime-verified* ]]; then
-		testing_level="runtime-verified"
+	elif _summary_declares_runtime_verified "$summary_testing"; then
+		testing_level="$_full_loop_runtime_verified_marker"
 	else
 		testing_level="self-assessed"
 	fi
 
 	case "$testing_level" in
-	runtime-verified | self-assessed) ;;
+	"$_full_loop_runtime_verified_marker" | self-assessed) ;;
 	*)
-		print_error "Invalid --testing-level '${requested_testing_level}'. Expected runtime-verified or self-assessed."
+		print_error "Invalid --testing-level '${requested_testing_level}'. Expected ${_full_loop_runtime_verified_marker} or self-assessed."
 		return 1
 		;;
 	esac
 
+	if [[ "$testing_level" == "$_full_loop_runtime_verified_marker" ]] && ! _runtime_evidence_is_substantive "$summary_testing"; then
+		print_error "${_full_loop_runtime_verified_marker} requires non-empty testing evidence; PR body generation blocked."
+		return 1
+	fi
+
 	if [[ "$runtime_risk" == "Critical" || "$runtime_risk" == "High" ]] &&
-		[[ "$testing_level" != "runtime-verified" ]]; then
-		print_error "${runtime_risk} runtime risk requires runtime-verified evidence; PR body generation blocked."
+		[[ "$testing_level" != "$_full_loop_runtime_verified_marker" ]]; then
+		print_error "${runtime_risk} runtime risk requires ${_full_loop_runtime_verified_marker} evidence; PR body generation blocked."
 		return 1
 	fi
 

--- a/.agents/scripts/full-loop-helper-risk.sh
+++ b/.agents/scripts/full-loop-helper-risk.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Runtime-risk and testing-evidence classification for full-loop PR bodies.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ -n "${_FULL_LOOP_RISK_LIB_LOADED:-}" ]] && return 0
+_FULL_LOOP_RISK_LIB_LOADED=1
+
+# Derive the most conservative runtime-risk level supported by the supplied
+# metadata and branch diff. An explicit level remains available for cases that
+# cannot be inferred reliably from text. Low is reserved for policy-listed
+# non-runtime paths; other unmatched changes fail upward to Medium.
+# Arguments: requested_risk, files_changed, summary_what, base_ref (optional)
+_derive_runtime_risk() {
+	local requested_risk="${1:-}"
+	local files_changed="${2:-}"
+	local summary_what="${3:-}"
+	local base_ref="${4:-}"
+	local normalized=""
+
+	if [[ -n "$requested_risk" ]]; then
+		normalized=$(printf '%s' "$requested_risk" | tr '[:upper:]' '[:lower:]')
+		case "$normalized" in
+		critical)
+			printf 'Critical\n'
+			return 0
+			;;
+		high)
+			printf 'High\n'
+			return 0
+			;;
+		medium)
+			printf 'Medium\n'
+			return 0
+			;;
+		low)
+			printf 'Low\n'
+			return 0
+			;;
+		*)
+			print_error "Invalid --risk-level '${requested_risk}'. Expected Critical, High, Medium, or Low."
+			return 1
+			;;
+		esac
+	fi
+
+	local context="${summary_what} ${files_changed}"
+	if [[ -n "$base_ref" ]]; then
+		local diff_context=""
+		diff_context=$(git diff --unified=0 "${base_ref}..HEAD" 2>/dev/null || true)
+		context="${context} ${diff_context}"
+	fi
+	context=$(printf '%s' "$context" | tr '[:upper:]' '[:lower:]')
+
+	if [[ "$context" =~ payment|billing|auth(entication|orization)?[[:space:]_/-]*(session)?|session[[:space:]_/-]*auth|data[[:space:]_/-]*delet|cryptograph|credential ]]; then
+		printf 'Critical\n'
+		return 0
+	fi
+	if [[ "$context" =~ poll(ing)?[[:space:]_/-]*(loop|interval)|websocket|server[[:space:]_/-]*sent[[:space:]_/-]*event|state[[:space:]_/-]*machine|form[[:space:]_/-]*handler|api[[:space:]_/-]*endpoint ]]; then
+		printf 'High\n'
+		return 0
+	fi
+
+	local path=""
+	local saw_path=0
+	local all_low=1
+	local old_ifs="$IFS"
+	IFS=','
+	for path in $files_changed; do
+		IFS="$old_ifs"
+		path="${path#"${path%%[![:space:]]*}"}"
+		[[ -z "$path" ]] && continue
+		saw_path=1
+		case "$path" in
+		*.md | *.mdx | *.rst | *.txt | *.d.ts | */tests/* | */test/* | test-* | *.test.* | *.spec.* | .github/* | *lint*.config.* | *linters*.conf | .agents/prompts/*) ;;
+		*) all_low=0 ;;
+		esac
+	done
+	IFS="$old_ifs"
+
+	if [[ "$saw_path" -eq 1 && "$all_low" -eq 1 ]]; then
+		printf 'Low\n'
+	else
+		printf 'Medium\n'
+	fi
+	return 0
+}
+
+# Resolve testing evidence and enforce the runtime gate. The literal evidence
+# marker is intentionally machine-readable so a prose-only claim cannot satisfy
+# Critical/High requirements accidentally.
+# Arguments: runtime_risk, requested_testing_level, summary_testing
+_resolve_runtime_testing_level() {
+	local runtime_risk="$1"
+	local requested_testing_level="${2:-}"
+	local summary_testing="${3:-}"
+	local testing_level=""
+
+	if [[ -n "$requested_testing_level" ]]; then
+		testing_level=$(printf '%s' "$requested_testing_level" | tr '[:upper:]' '[:lower:]')
+	elif [[ "$summary_testing" == *runtime-verified* ]]; then
+		testing_level="runtime-verified"
+	else
+		testing_level="self-assessed"
+	fi
+
+	case "$testing_level" in
+	runtime-verified | self-assessed) ;;
+	*)
+		print_error "Invalid --testing-level '${requested_testing_level}'. Expected runtime-verified or self-assessed."
+		return 1
+		;;
+	esac
+
+	if [[ "$runtime_risk" == "Critical" || "$runtime_risk" == "High" ]] &&
+		[[ "$testing_level" != "runtime-verified" ]]; then
+		print_error "${runtime_risk} runtime risk requires runtime-verified evidence; PR body generation blocked."
+		return 1
+	fi
+
+	printf '%s\n' "$testing_level"
+	return 0
+}

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -9,6 +9,7 @@
 #
 # Sub-libraries (sourced below):
 #   full-loop-helper-state.sh   -- state persistence, phase emitters, lifecycle commands
+#   full-loop-helper-risk.sh    -- PR runtime-risk and testing-evidence classification
 #   full-loop-helper-commit.sh  -- staging, validators, PR creation, merge summary
 #   full-loop-helper-merge.sh   -- merge execution, admin fallback, resource unlocking
 
@@ -41,6 +42,10 @@ print_phase() {
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/full-loop-helper-state.sh"
 
+# shellcheck source=./full-loop-helper-risk.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/full-loop-helper-risk.sh"
+
 # shellcheck source=./full-loop-helper-commit.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/full-loop-helper-commit.sh"
@@ -58,7 +63,7 @@ source "${SCRIPT_DIR}/full-loop-helper-merge.sh"
 # Collapses full-loop steps 4.1-4.2.1 into a single deterministic call.
 # Workers and interactive sessions both use this — no parallel logic.
 #
-# Usage: full-loop-helper.sh commit-and-pr|create-pr --issue <N> --message <msg> [--title <title>] [--summary <what>] [--testing <how>] [--decisions <notes>] [--label <label>...] [--allow-parent-close] [--skip-hooks] [--no-rebase]
+# Usage: full-loop-helper.sh commit-and-pr|create-pr --issue <N> --message <msg> [--title <title>] [--summary <what>] [--testing <how>] [--risk-level <level>] [--testing-level <level>] [--decisions <notes>] [--label <label>...] [--allow-parent-close] [--skip-hooks] [--no-rebase]
 # Exit codes: 0 = PR created (prints PR number to stdout), 1 = failure
 # --allow-parent-close: skip the parent-task keyword guard (final-phase PR only)
 # --skip-hooks: pass --no-verify to git push (bypasses pre-push hooks). Use for doc-only PRs
@@ -71,6 +76,7 @@ source "${SCRIPT_DIR}/full-loop-helper-merge.sh"
 # can create the PR manually.
 cmd_commit_and_pr() {
 	local issue_number="" commit_message="" pr_title="" summary_what="" summary_testing="" summary_decisions=""
+	local runtime_risk="" testing_level=""
 	local -a extra_labels=()
 	local allow_parent_close=0
 	local skip_hooks=0 skip_rebase=0
@@ -135,7 +141,7 @@ cmd_commit_and_pr() {
 	fi
 
 	local pr_body=""
-	pr_body=$(_build_pr_body "$issue_number" "$summary_what" "$summary_testing" "$files_changed" "$sig_footer" "$closing_keyword")
+	pr_body=$(_build_pr_body "$issue_number" "$summary_what" "$summary_testing" "$files_changed" "$sig_footer" "$closing_keyword" "$runtime_risk" "$testing_level" "$base_ref") || return 1
 
 	# t2046: parent-task keyword guard — prevent Resolves/Closes/Fixes on
 	# parent-task issues. The parent must stay open until all phase children merge.

--- a/.agents/scripts/tests/test-full-loop-parent-task.sh
+++ b/.agents/scripts/tests/test-full-loop-parent-task.sh
@@ -143,9 +143,9 @@ print_success() {
 # Extract _issue_has_parent_task_label from the helper
 eval "$(sed -n '/_issue_has_parent_task_label()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper-commit.sh")"
 
-# Extract _build_pr_body from the helper
-eval "$(sed -n '/_derive_runtime_risk()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper-risk.sh")"
-eval "$(sed -n '/_resolve_runtime_testing_level()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper-risk.sh")"
+# Load the runtime-risk library and extract _build_pr_body from the commit helper.
+# shellcheck source=../full-loop-helper-risk.sh
+source "${TEST_SCRIPTS_DIR}/full-loop-helper-risk.sh"
 eval "$(sed -n '/_build_pr_body()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper-commit.sh")"
 
 # =============================================================================

--- a/.agents/scripts/tests/test-full-loop-parent-task.sh
+++ b/.agents/scripts/tests/test-full-loop-parent-task.sh
@@ -120,19 +120,33 @@ if [[ -z "${NC+x}" ]]; then
 fi
 
 # Stub the print functions that full-loop-helper.sh uses
-print_info() { printf '[INFO] %s\n' "$*" >&2; return 0; }
-print_error() { printf '[ERROR] %s\n' "$*" >&2; return 0; }
-print_warning() { printf '[WARN] %s\n' "$*" >&2; return 0; }
-print_success() { printf '[OK] %s\n' "$*" >&2; return 0; }
+print_info() {
+	printf '[INFO] %s\n' "$*" >&2
+	return 0
+}
+print_error() {
+	printf '[ERROR] %s\n' "$*" >&2
+	return 0
+}
+print_warning() {
+	printf '[WARN] %s\n' "$*" >&2
+	return 0
+}
+print_success() {
+	printf '[OK] %s\n' "$*" >&2
+	return 0
+}
 
 # We need to extract and eval just the functions we're testing.
 # Source the functions by extracting them directly.
 
 # Extract _issue_has_parent_task_label from the helper
-eval "$(sed -n '/_issue_has_parent_task_label()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper.sh")"
+eval "$(sed -n '/_issue_has_parent_task_label()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper-commit.sh")"
 
 # Extract _build_pr_body from the helper
-eval "$(sed -n '/_build_pr_body()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper.sh")"
+eval "$(sed -n '/_derive_runtime_risk()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper-risk.sh")"
+eval "$(sed -n '/_resolve_runtime_testing_level()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper-risk.sh")"
+eval "$(sed -n '/_build_pr_body()/,/^}/p' "${TEST_SCRIPTS_DIR}/full-loop-helper-commit.sh")"
 
 # =============================================================================
 # Case 1 — parent-task issue → _build_pr_body with "For" keyword

--- a/.agents/scripts/tests/test-full-loop-runtime-risk.sh
+++ b/.agents/scripts/tests/test-full-loop-runtime-risk.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#28466 runtime-risk PR body classification.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "$0")/.." && pwd)" || exit 1
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_error() {
+	local message="$1"
+	printf 'ERROR %s\n' "$message" >&2
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local actual="$2"
+	local expected="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$actual" == *"$expected"* ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s: missing %s\n' "$name" "$expected"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# shellcheck source=../full-loop-helper-risk.sh
+source "${SCRIPT_DIR_TEST}/full-loop-helper-risk.sh"
+# shellcheck source=../full-loop-helper-commit.sh
+source "${SCRIPT_DIR_TEST}/full-loop-helper-commit.sh"
+
+high_body=$(_build_pr_body \
+	"28466" \
+	"Fix polling-loop state-machine behavior" \
+	"runtime-verified with a polling fixture" \
+	"src/poller.sh, tests/test-poller.sh" \
+	"<!-- aidevops:sig -->" \
+	"Resolves")
+assert_contains "polling fixture derives High" "$high_body" "**Risk level:** High"
+assert_contains "High fixture records runtime evidence" "$high_body" "**Verification:** runtime-verified"
+assert_contains "closing keyword remains compatible" "$high_body" "Resolves #28466"
+assert_contains "signature remains compatible" "$high_body" "<!-- aidevops:sig -->"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if _build_pr_body "1" "API endpoint" "unit tests pass" "src/api.sh" "" >/dev/null 2>&1; then
+	printf 'FAIL High without runtime evidence is rejected\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+else
+	printf 'PASS High without runtime evidence is rejected\n'
+fi
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if _build_pr_body "2" "Credential rotation" "self-assessed" "src/auth.sh" "" "Resolves" "Critical" "self-assessed" >/dev/null 2>&1; then
+	printf 'FAIL Critical without runtime evidence is rejected\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+else
+	printf 'PASS Critical without runtime evidence is rejected\n'
+fi
+
+low_body=$(_build_pr_body \
+	"3" \
+	"Update documentation and tests" \
+	"focused tests pass" \
+	"docs/runtime.md, .agents/scripts/tests/test-docs.sh" \
+	"" \
+	"Resolves")
+assert_contains "docs and tests remain Low" "$low_body" "**Risk level:** Low"
+assert_contains "Low fixture is self-assessed" "$low_body" "**Verification:** self-assessed"
+
+runtime_risk=""
+testing_level=""
+issue_number=""
+commit_message=""
+pr_title=""
+summary_what=""
+summary_testing=""
+summary_decisions=""
+allow_parent_close=0
+skip_hooks=0
+skip_rebase=0
+extra_labels=()
+_parse_commit_and_pr_args --issue 4 --message "test" --risk-level High --testing-level runtime-verified
+assert_contains "risk level flag is accepted" "$runtime_risk" "High"
+assert_contains "testing level flag is accepted" "$testing_level" "runtime-verified"
+
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0

--- a/.agents/scripts/tests/test-full-loop-runtime-risk.sh
+++ b/.agents/scripts/tests/test-full-loop-runtime-risk.sh
@@ -8,6 +8,8 @@ set -uo pipefail
 SCRIPT_DIR_TEST="$(cd "$(dirname "$0")/.." && pwd)" || exit 1
 TESTS_RUN=0
 TESTS_FAILED=0
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
 
 print_error() {
 	local message="$1"
@@ -29,6 +31,19 @@ assert_contains() {
 	return 0
 }
 
+assert_rejected() {
+	local name="$1"
+	shift
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if "$@" >/dev/null 2>&1; then
+		printf 'FAIL %s\n' "$name"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	else
+		printf 'PASS %s\n' "$name"
+	fi
+	return 0
+}
+
 # shellcheck source=../full-loop-helper-risk.sh
 source "${SCRIPT_DIR_TEST}/full-loop-helper-risk.sh"
 # shellcheck source=../full-loop-helper-commit.sh
@@ -46,31 +61,79 @@ assert_contains "High fixture records runtime evidence" "$high_body" "**Verifica
 assert_contains "closing keyword remains compatible" "$high_body" "Resolves #28466"
 assert_contains "signature remains compatible" "$high_body" "<!-- aidevops:sig -->"
 
-TESTS_RUN=$((TESTS_RUN + 1))
-if _build_pr_body "1" "API endpoint" "unit tests pass" "src/api.sh" "" >/dev/null 2>&1; then
-	printf 'FAIL High without runtime evidence is rejected\n'
-	TESTS_FAILED=$((TESTS_FAILED + 1))
-else
-	printf 'PASS High without runtime evidence is rejected\n'
-fi
-
-TESTS_RUN=$((TESTS_RUN + 1))
-if _build_pr_body "2" "Credential rotation" "self-assessed" "src/auth.sh" "" "Resolves" "Critical" "self-assessed" >/dev/null 2>&1; then
-	printf 'FAIL Critical without runtime evidence is rejected\n'
-	TESTS_FAILED=$((TESTS_FAILED + 1))
-else
-	printf 'PASS Critical without runtime evidence is rejected\n'
-fi
+assert_rejected "High without runtime evidence is rejected" \
+	_build_pr_body "1" "API endpoint" "unit tests pass" "src/api.sh" ""
+assert_rejected "Critical without runtime evidence is rejected" \
+	_build_pr_body "2" "Credential rotation" "self-assessed" "src/auth.sh" "" "Resolves" "Critical" "self-assessed"
+assert_rejected "explicit Low cannot bypass Critical runtime evidence" \
+	_build_pr_body "2" "Delete data" "self-assessed" "src/storage.sh" "" "Resolves" "Low" "self-assessed"
+assert_rejected "bare runtime marker is not evidence" \
+	_build_pr_body "2" "Credential rotation" "runtime-verified" "src/auth.sh" ""
+assert_rejected "explicit runtime level still requires evidence" \
+	_build_pr_body "2" "Credential rotation" "" "src/auth.sh" "" "Resolves" "Critical" "runtime-verified"
 
 low_body=$(_build_pr_body \
 	"3" \
-	"Update documentation and tests" \
+	"Document credential and polling-loop behavior" \
 	"focused tests pass" \
-	"docs/runtime.md, .agents/scripts/tests/test-docs.sh" \
+	"docs/runtime.md, .agents/scripts/tests/test-docs.sh, .qlty/qlty.toml, stubs/client.pyi" \
 	"" \
 	"Resolves")
-assert_contains "docs and tests remain Low" "$low_body" "**Risk level:** Low"
+assert_contains "non-runtime files remain Low despite policy terms" "$low_body" "**Risk level:** Low"
 assert_contains "Low fixture is self-assessed" "$low_body" "**Verification:** self-assessed"
+
+author_body=$(_build_pr_body \
+	"4" \
+	"Update author metadata" \
+	"focused tests pass" \
+	"src/metadata.sh" \
+	"" \
+	"Resolves")
+assert_contains "author does not false-match auth" "$author_body" "**Risk level:** Medium"
+
+critical_body=$(_build_pr_body \
+	"5" \
+	"Change credential rotation" \
+	"runtime-verified with a credential rotation fixture" \
+	"src/auth.sh" \
+	"" \
+	"Resolves" \
+	"Low")
+assert_contains "explicit Low cannot downgrade Critical" "$critical_body" "**Risk level:** Critical"
+
+raised_body=$(_build_pr_body \
+	"6" \
+	"Change ambiguous runtime behavior" \
+	"runtime-verified with an integration fixture" \
+	"src/worker.sh" \
+	"" \
+	"Resolves" \
+	"High")
+assert_contains "explicit risk can raise an ambiguous change" "$raised_body" "**Risk level:** High"
+
+COMMENT_REPO="${TEST_ROOT}/comment-repo"
+mkdir -p "${COMMENT_REPO}/src"
+/usr/bin/git -C "$COMMENT_REPO" init -q
+/usr/bin/git -C "$COMMENT_REPO" config user.name "Runtime Risk Test"
+/usr/bin/git -C "$COMMENT_REPO" config user.email "runtime-risk@example.invalid"
+printf '#!/usr/bin/env bash\nprintf "ok\\n"\n# Old credential comment.\n' >"${COMMENT_REPO}/src/app.sh"
+/usr/bin/git -C "$COMMENT_REPO" add src/app.sh
+/usr/bin/git -C "$COMMENT_REPO" commit -qm "fixture: add runtime file"
+comment_base=$(/usr/bin/git -C "$COMMENT_REPO" rev-parse HEAD)
+printf '#!/usr/bin/env bash\nprintf "ok\\n"\n# New credential comment.\n' >"${COMMENT_REPO}/src/app.sh"
+/usr/bin/git -C "$COMMENT_REPO" add src/app.sh
+/usr/bin/git -C "$COMMENT_REPO" commit -qm "docs: update source comment"
+comment_body=$(cd "$COMMENT_REPO" && _build_pr_body \
+	"7" \
+	"Update a source comment" \
+	"diff reviewed" \
+	"src/app.sh" \
+	"" \
+	"Resolves" \
+	"" \
+	"" \
+	"$comment_base")
+assert_contains "comment-only source change remains Low" "$comment_body" "**Risk level:** Low"
 
 runtime_risk=""
 testing_level=""


### PR DESCRIPTION
## Summary

Recover and harden the runtime-risk classifier for generated full-loop PR bodies.

## Files Changed

- `.agents/scripts/full-loop-helper-commit.sh`
- `.agents/scripts/full-loop-helper-risk.sh`
- `.agents/scripts/full-loop-helper.sh`
- `.agents/scripts/tests/test-full-loop-parent-task.sh`
- `.agents/scripts/tests/test-full-loop-runtime-risk.sh`

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — focused runtime-risk and parent-task fixtures, Bash syntax, ShellCheck, and changed-file linters pass

Resolves #28466

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.4
