### PR TITLE
GH#28464: reuse semantic blocker resolution in merge workflow

### DIFF
--- a/.agents/scripts/tests/test-planning-pr-guard.sh
+++ b/.agents/scripts/tests/test-planning-pr-guard.sh
@@ -5,7 +5,8 @@
 # test-planning-pr-guard.sh — GH#19782 / t2252 regression guard.
 #
 # Validates the two code paths that protect planning-only PRs from
-# incorrectly marking issues as status:done or TODO entries as [x]:
+# incorrectly marking issues as status:done or TODO entries as [x], while
+# allowing blocker provenance after every declared dependency is closed:
 #
 #   Path 1 — Title-fallback (issue labeling):
 #     Fixed in t2219 (PR #19820). When the PR body uses For/Ref #NNN
@@ -86,24 +87,55 @@ should_skip_prooflog() {
 	local linked_issues="$1"
 	local for_ref_issues="$2"
 	local task_line="${3:-}"
+	local repo="${4:-owner/repo}"
+	local task_id="${5:-t900}"
+	local issue_task_pairs="${6-19778:t900}"
+	local issue_task_pair="" mapped_issue_num="" mapping_count=0 blocker_status=0
 	if [[ -z "${linked_issues:-}" ]]; then
-		return 0  # skip (no explicit closing intent)
+		return 0 # skip (no explicit closing intent)
 	fi
 	if echo "$task_line" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+'; then
-		return 0  # skip (blocked task)
+		for issue_task_pair in $issue_task_pairs; do
+			if [[ "${issue_task_pair#*:}" == "$task_id" ]]; then
+				mapped_issue_num="${issue_task_pair%%:*}"
+				mapping_count=$((mapping_count + 1))
+			fi
+		done
+		[[ "$mapping_count" -eq 1 && "$mapped_issue_num" =~ ^[0-9]+$ ]] || return 0
+		_der_completion_blockers_closed "$repo" "$mapped_issue_num" "$task_line" || blocker_status=$?
+		[[ "$blocker_status" -eq 0 ]] || return 0
 	fi
 	if [[ -z "${linked_issues:-}" ]] && [[ -n "${for_ref_issues:-}" ]]; then
-		return 0  # skip (planning-only)
+		return 0 # skip (planning-only)
 	fi
-	return 1  # proceed
+	return 1 # proceed
 }
 
 should_skip_closing_hygiene_for_task() {
 	local task_line="$1"
+	local repo="${2:-owner/repo}"
+	local issue_num="${3:-19778}"
+	local blocker_status=0
 	if echo "$task_line" | grep -qE '^[[:space:]]*- \[ \] .*blocked-by:[^[:space:]]+'; then
-		return 0
+		_der_completion_blockers_closed "$repo" "$issue_num" "$task_line" || blocker_status=$?
+		[[ "$blocker_status" -eq 0 ]] || return 0
 	fi
 	return 1
+}
+
+BLOCKER_RESULT="resolved"
+LAST_BLOCKER_CALL=""
+_der_completion_blockers_closed() {
+	local repo="$1"
+	local issue_num="$2"
+	local task_line="$3"
+	LAST_BLOCKER_CALL="${repo}|${issue_num}|${task_line}"
+	case "$BLOCKER_RESULT" in
+	resolved) return 0 ;;
+	open) return 2 ;;
+	malformed | api-ambiguous | cross-repository) return 1 ;;
+	*) return 1 ;;
+	esac
 }
 
 header "Path 2: TODO.md proof-log guard (t2252)"
@@ -136,17 +168,18 @@ else
 	fail "4. No references → should skip metadata-only title but proceeded"
 fi
 
-# Test 4b: Explicit Closes but TODO task remains blocked
+# Test 4b: Explicit Closes and positively closed blocker provenance
+BLOCKER_RESULT="resolved"
 if should_skip_prooflog "19778" "" "- [ ] t900 blocked task tier:standard blocked-by:t899"; then
-	pass "4b. Explicit close + blocked-by TODO marker → proof-log skipped"
+	fail "4b. Positively closed blocker → proof-log should proceed"
 else
-	fail "4b. Explicit close + blocked-by TODO marker → should skip but proceeded"
+	pass "4b. Positively closed blocker → proof-log proceeds"
 fi
 
 if should_skip_closing_hygiene_for_task "- [ ] t900 blocked task tier:standard blocked-by:t899"; then
-	pass "4c. Current TODO task-line blocked-by marker → closing hygiene skipped"
+	fail "4c. Positively closed blocker → closing hygiene should proceed"
 else
-	fail "4c. Current TODO task-line blocked-by marker → should skip closing hygiene"
+	pass "4c. Positively closed blocker → closing hygiene proceeds"
 fi
 
 issue_body_example='Issue reproducer mentions blocked-by:t899 in prose, not on the current TODO task line.'
@@ -154,6 +187,62 @@ if should_skip_closing_hygiene_for_task "$issue_body_example"; then
 	fail "4d. Issue-body prose blocked-by mention → should not skip closing hygiene"
 else
 	pass "4d. Issue-body prose blocked-by mention → closing hygiene proceeds"
+fi
+
+for blocker_case in open malformed api-ambiguous cross-repository; do
+	BLOCKER_RESULT="$blocker_case"
+	if should_skip_prooflog "19778" "" "- [ ] t900 blocked task tier:standard blocked-by:t899"; then
+		pass "4e. ${blocker_case} blocker result → proof-log fails closed"
+	else
+		fail "4e. ${blocker_case} blocker result → proof-log should skip"
+	fi
+	if should_skip_closing_hygiene_for_task "- [ ] t900 blocked task tier:standard blocked-by:t899"; then
+		pass "4f. ${blocker_case} blocker result → closing hygiene fails closed"
+	else
+		fail "4f. ${blocker_case} blocker result → closing hygiene should skip"
+	fi
+done
+
+BLOCKER_RESULT="resolved"
+if should_skip_prooflog "19779" "" "- [ ] t901 second task tier:standard blocked-by:t899" \
+	"owner/repo" "t901" "19778:t900 19779:t901"; then
+	fail "4g. Multiple task/issue pairs → canonical second mapping should proceed"
+elif [[ "$LAST_BLOCKER_CALL" == "owner/repo|19779|"* ]]; then
+	pass "4g. Multiple task/issue pairs → canonical second mapping proceeds"
+else
+	fail "4g. Multiple task/issue pairs → wrong canonical issue passed to resolver"
+fi
+
+if should_skip_prooflog "19778" "" "- [ ] t900 blocked task tier:standard blocked-by:t899" \
+	"owner/repo" "t900" ""; then
+	pass "4h. Missing task/issue mapping → proof-log fails closed"
+else
+	fail "4h. Missing task/issue mapping → proof-log should skip"
+fi
+if should_skip_prooflog "19778" "" "- [ ] t900 blocked task tier:standard blocked-by:t899" \
+	"owner/repo" "t900" "19778:t900 19779:t900"; then
+	pass "4i. Ambiguous task/issue mapping → proof-log fails closed"
+else
+	fail "4i. Ambiguous task/issue mapping → proof-log should skip"
+fi
+
+WORKFLOW_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/.github/workflows/issue-sync-reusable.yml"
+if python3 - "$WORKFLOW_FILE" <<'PY'; then
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+closing = text[text.index("- name: Apply closing hygiene to linked issues"):text.index("- name: Nudge parent-task issues with remaining phases")]
+proof = text[text.index("- name: Update TODO.md proof-log"):text.index("- name: Sync PLANS.md status")]
+assert "source __aidevops/.agents/scripts/dependency-event-reconciler.sh" in closing
+assert '_der_completion_blockers_closed "$REPO" "$ISSUE_NUM" "$TASK_LINE"' in closing
+assert "ISSUE_TASK_PAIRS:" in proof and "REPO:" in proof
+assert "source __aidevops/.agents/scripts/dependency-event-reconciler.sh" in proof
+assert '_der_completion_blockers_closed "$REPO" "$MAPPED_ISSUE_NUM" "$TASK_LINE"' in proof
+PY
+	pass "4j. Both workflow completion consumers use the shared semantic resolver"
+else
+	fail "4j. Workflow completion consumers are not wired to the shared resolver"
 fi
 
 # -------------------------------------------------------------------
@@ -170,12 +259,12 @@ should_skip_title_fallback() {
 	local found="$1"
 	local for_ref_issues="$2"
 	if [[ -n "$found" ]]; then
-		return 0  # skip: title-only fallback is metadata, not completion intent
+		return 0 # skip: title-only fallback is metadata, not completion intent
 	fi
 	if [[ " $for_ref_issues " == *" $found "* ]]; then
-		return 0  # skip
+		return 0 # skip
 	fi
-	return 1  # proceed
+	return 1 # proceed
 }
 
 header "Path 1: Title-fallback guard (t2219)"

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -915,6 +915,10 @@ jobs:
             exit 0
           fi
 
+          # GH#28464: completion blockers use the shared semantic resolver.
+          # shellcheck source=/dev/null
+          source __aidevops/.agents/scripts/dependency-event-reconciler.sh
+
           echo "Processing issues: $ALL_ISSUES"
 
           COMMENT_FAILED=0
@@ -948,8 +952,12 @@ jobs:
             if [[ -n "$MAPPED_TASK_ID" ]]; then
               TASK_LINE=$(grep -E "^[[:space:]]*- \[ \] ${MAPPED_TASK_ID} " TODO.md | head -1 || true)
               if echo "$TASK_LINE" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+'; then
-                echo "Task $MAPPED_TASK_ID has unresolved blocked-by marker — skipping closing hygiene for #$ISSUE_NUM (GH#23516)"
-                continue
+                BLOCKER_STATUS=0
+                _der_completion_blockers_closed "$REPO" "$ISSUE_NUM" "$TASK_LINE" || BLOCKER_STATUS=$?
+                if [[ "$BLOCKER_STATUS" -ne 0 ]]; then
+                  echo "Task $MAPPED_TASK_ID blockers are not positively closed — skipping closing hygiene for #$ISSUE_NUM (GH#28464)"
+                  continue
+                fi
               fi
             fi
 
@@ -1165,6 +1173,8 @@ jobs:
         if: steps.resolve-tasks.outputs.task_backed == 'true' && steps.extract.outputs.range_syntax != 'true'
         env:
           TASK_IDS: ${{ steps.resolve-tasks.outputs.task_ids }}
+          ISSUE_TASK_PAIRS: ${{ steps.resolve-tasks.outputs.issue_task_pairs }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           # GH#19782 / t2252: pass For/Ref and closing-keyword issue lists
           # so the proof-log step can distinguish planning-only PRs from
@@ -1241,6 +1251,11 @@ jobs:
             echo "::warning::SYNC_PAT not set — falling back to GITHUB_TOKEN, which will be rejected by branch protection (GH006). Fix: gh secret set SYNC_PAT --repo ${GITHUB_REPOSITORY:-REPO} --body \"<FINE_GRAINED_PAT>\" (Contents: Read and write)"
           fi
 
+          # GH#28464: use the same fail-closed completion predicate as direct
+          # issue closure rather than treating blocker provenance as unresolved.
+          # shellcheck source=/dev/null
+          source __aidevops/.agents/scripts/dependency-event-reconciler.sh
+
           TODAY=$(date +%Y-%m-%d)
           PROOF="pr:#${PR_NUMBER} completed:${TODAY}"
 
@@ -1248,8 +1263,24 @@ jobs:
           for RESOLVED_TASK_ID in $TASK_IDS; do
             TASK_LINE=$(grep -E "^[[:space:]]*- \[[ x]\] ${RESOLVED_TASK_ID} " TODO.md | head -1 || true)
             if echo "$TASK_LINE" | grep -qE '(^|[[:space:]])blocked-by:[^[:space:]]+'; then
-              echo "::notice::Task $RESOLVED_TASK_ID has unresolved blocked-by marker — skipping TODO.md proof-log (GH#23516)"
-              continue
+              MAPPED_ISSUE_NUM=""
+              MAPPING_COUNT=0
+              for ISSUE_TASK_PAIR in $ISSUE_TASK_PAIRS; do
+                if [[ "${ISSUE_TASK_PAIR#*:}" == "$RESOLVED_TASK_ID" ]]; then
+                  MAPPED_ISSUE_NUM="${ISSUE_TASK_PAIR%%:*}"
+                  MAPPING_COUNT=$((MAPPING_COUNT + 1))
+                fi
+              done
+              if [[ "$MAPPING_COUNT" -ne 1 || ! "$MAPPED_ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+                echo "::notice::Task $RESOLVED_TASK_ID does not have one canonical issue mapping — skipping TODO.md proof-log (GH#28464)"
+                continue
+              fi
+              BLOCKER_STATUS=0
+              _der_completion_blockers_closed "$REPO" "$MAPPED_ISSUE_NUM" "$TASK_LINE" || BLOCKER_STATUS=$?
+              if [[ "$BLOCKER_STATUS" -ne 0 ]]; then
+                echo "::notice::Task $RESOLVED_TASK_ID blockers are not positively closed — skipping TODO.md proof-log (GH#28464)"
+                continue
+              fi
             fi
             if grep -qE "^[[:space:]]*- \[x\] ${RESOLVED_TASK_ID} .*pr:#${PR_NUMBER}" TODO.md; then
               echo "Task $RESOLVED_TASK_ID already has proof-log for PR #${PR_NUMBER}"


### PR DESCRIPTION
## Summary

Route both reusable PR-merge completion consumers through the shared dependency resolver so resolved blockers permit completion while open, malformed, ambiguous, cross-repository, or unmapped blockers remain fail-closed.

## Files Changed

.agents/scripts/tests/test-planning-pr-guard.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Runtime-verified with 26 planning-guard, 22 dependency-reconciler, 17 completion-evidence, 14 task-resolver, 26 reusable-workflow, and 12 checkout-order tests; actionlint, ShellCheck, shfmt, YAML parsing, and local linters passed.

Resolves #28464


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.163 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1h 27m and 971,352 tokens on this with the user in an interactive session.