### PR TITLE
GH#28460: Refresh merged evidence after successful full-loop merge

### DIFF
--- a/.agents/scripts/full-loop-helper-evidence.sh
+++ b/.agents/scripts/full-loop-helper-evidence.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Full-Loop Evidence -- fresh, exact remote lifecycle evidence
+# =============================================================================
+# Shared sub-library for full-loop-helper-state.sh and full-loop-helper-merge.sh.
+#
+# Usage: source "${SCRIPT_DIR}/full-loop-helper-evidence.sh"
+
+# Apply strict mode only when executed directly (not when sourced)
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+# Include guard
+[[ -n "${_FULL_LOOP_EVIDENCE_LIB_LOADED:-}" ]] && return 0
+_FULL_LOOP_EVIDENCE_LIB_LOADED=1
+
+# Read complete merged-PR evidence through bounded, cache-disabled requests.
+# Stdout: validated PR JSON with state, mergedAt, and mergeCommit.
+_full_loop_read_fresh_merged_pr_json() {
+	local pr_number="$1"
+	local repo="$2"
+	local max_attempts="${FULL_LOOP_MERGED_EVIDENCE_ATTEMPTS:-4}"
+	local retry_delay="${FULL_LOOP_MERGED_EVIDENCE_DELAY_SECONDS:-2}"
+	local attempt=1
+	local pr_json=""
+
+	[[ "$pr_number" =~ ^[0-9]+$ && "$repo" == */* ]] || return 1
+	[[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] || max_attempts=4
+	[[ "$retry_delay" =~ ^[0-9]+$ ]] || retry_delay=2
+
+	while [[ "$attempt" -le "$max_attempts" ]]; do
+		if pr_json=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh pr view "$pr_number" --repo "$repo" \
+			--json state,mergedAt,mergeCommit 2>/dev/null) &&
+			printf '%s' "$pr_json" | jq -e '
+				def present: ((. // "") | length > 0);
+				(.state == "MERGED")
+				and (.mergedAt | present)
+				and (.mergeCommit | type == "object" and (.oid | present))
+			' >/dev/null; then
+			printf '%s\n' "$pr_json"
+			return 0
+		fi
+		[[ "$attempt" -lt "$max_attempts" && "$retry_delay" -gt 0 ]] && sleep "$retry_delay"
+		attempt=$((attempt + 1))
+	done
+
+	return 1
+}

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -16,6 +16,7 @@
 #   - shared-claim-lifecycle.sh (release_interactive_claim_on_merge)
 #   - shared-phase-filing.sh (auto_file_next_phase)
 #   - full-loop-helper-commit.sh (cmd_pre_merge_gate)
+#   - full-loop-helper-evidence.sh (fresh merged-PR evidence)
 #   - Globals: SCRIPT_DIR
 #
 # Part of aidevops framework: https://aidevops.sh
@@ -50,6 +51,10 @@ if [[ -f "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh" ]]; then
 	# shellcheck source=./full-loop-cleanup-receipt.sh
 	source "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh"
 fi
+
+# shellcheck source=./full-loop-helper-evidence.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
+source "${SCRIPT_DIR}/full-loop-helper-evidence.sh"
 
 # --- Repo Resolution ---
 
@@ -535,17 +540,7 @@ _merge_verify_completed_state() {
 	local pr_number="$1"
 	local repo="$2"
 	local pr_json=""
-	pr_json=$(gh pr view "$pr_number" --repo "$repo" \
-		--json state,mergedAt,mergeCommit 2>/dev/null) || return 1
-
-	if ! printf '%s' "$pr_json" | jq -e '
-		def present: ((. // "") | length > 0);
-		(.state == "MERGED")
-		and (.mergedAt | present)
-		and (.mergeCommit | type == "object" and (.oid | present))
-	' >/dev/null; then
-		return 1
-	fi
+	pr_json=$(_full_loop_read_fresh_merged_pr_json "$pr_number" "$repo") || return 1
 
 	FULL_LOOP_MERGE_SHA=$(printf '%s' "$pr_json" | jq -r '.mergeCommit.oid')
 	export FULL_LOOP_MERGE_SHA

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -12,6 +12,7 @@
 #
 # Dependencies:
 #   - shared-constants.sh (print_error, print_info, print_success, print_warning, etc.)
+#   - full-loop-helper-evidence.sh (fresh merged-PR evidence)
 #   - Globals: STATE_DIR, STATE_FILE, DEFAULT_MAX_*, HEADLESS, _FG_PID_FILE
 #   - Functions: is_headless, print_phase (defined in orchestrator before sourcing)
 #
@@ -47,6 +48,10 @@ if [[ -f "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh" ]]; then
 	# shellcheck source=./full-loop-cleanup-receipt.sh
 	source "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh"
 fi
+
+# shellcheck source=./full-loop-helper-evidence.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
+source "${SCRIPT_DIR}/full-loop-helper-evidence.sh"
 
 # --- State Management ---
 
@@ -1155,13 +1160,7 @@ _full_loop_resolve_repo() {
 _full_loop_verify_merged_pr() {
 	local pr_number="$1"
 	local repo="$2"
-	local pr_json=""
-	pr_json=$(gh pr view "$pr_number" --repo "$repo" --json state,mergedAt,mergeCommit 2>/dev/null) || return 1
-	printf '%s' "$pr_json" | jq -e '
-		(.state == "MERGED")
-		and ((.mergedAt // "") != "")
-		and (.mergeCommit | type == "object" and ((.oid // "") != ""))
-	' >/dev/null
+	_full_loop_read_fresh_merged_pr_json "$pr_number" "$repo" >/dev/null
 	return $?
 }
 

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -14,7 +14,18 @@ cleanup_receipt_dir="${ROOT}/cleanup-receipts"
 
 cat >"${ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
-if [[ "${COMPLETION_PR_STATE:-MERGED}" == "MERGED" ]]; then
+call_count=1
+if [[ -n "${COMPLETION_PR_STATE_CALLS:-}" ]]; then
+	[[ -f "$COMPLETION_PR_STATE_CALLS" ]] && call_count=$(( $(<"$COMPLETION_PR_STATE_CALLS") + 1 ))
+	printf '%s\n' "$call_count" >"$COMPLETION_PR_STATE_CALLS"
+fi
+if [[ -n "${COMPLETION_PR_CACHE_CALLS:-}" ]]; then
+	printf '%s\n' "${AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE:-0}" >>"$COMPLETION_PR_CACHE_CALLS"
+fi
+if [[ "${COMPLETION_PR_STATE:-MERGED}" == "API_FAILURE" ]]; then
+	exit 70
+elif [[ "${COMPLETION_PR_STATE:-MERGED}" == "MERGED" ]] ||
+	[[ "${COMPLETION_PR_STATE:-MERGED}" == "STALE_THEN_MERGED" && "$call_count" -gt 1 ]]; then
 	printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","mergeCommit":{"oid":"merge123"}}'
 else
 	printf '%s\n' '{"state":"OPEN","mergedAt":null,"mergeCommit":null}'
@@ -55,6 +66,8 @@ removed_path="${ROOT}/removed-worktree"
 cleanup_log="${ROOT}/cleanup.log"
 printf '[2026-07-11T00:00:01Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' "$removed_path" >"$cleanup_log"
 export AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir"
+export FULL_LOOP_MERGED_EVIDENCE_ATTEMPTS=2
+export FULL_LOOP_MERGED_EVIDENCE_DELAY_SECONDS=0
 # shellcheck source=../full-loop-cleanup-receipt.sh
 source "${SCRIPTS_DIR}/full-loop-cleanup-receipt.sh"
 full_loop_write_cleanup_deferred testorg/repo 42 "$removed_path" feature/test-cleanup "$$" test-session not-requested >/dev/null
@@ -81,6 +94,28 @@ AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bi
 grep -qx 'not-requested' "${receipt_dir}/marcusquinn_aidevops-42.status"
 AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$record_runner" 42 marcusquinn/aidevops >/dev/null
 printf 'PASS direct merge-only lifecycle records idempotent no-release evidence\n'
+
+rm -f "${receipt_dir}/marcusquinn_aidevops-42.status"
+stale_calls="${ROOT}/stale-evidence-calls.txt"
+cache_calls="${ROOT}/stale-evidence-cache-control.txt"
+COMPLETION_PR_STATE=STALE_THEN_MERGED \
+	COMPLETION_PR_STATE_CALLS="$stale_calls" \
+	COMPLETION_PR_CACHE_CALLS="$cache_calls" \
+	AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$record_runner" 42 marcusquinn/aidevops >/dev/null
+grep -qx 'not-requested' "${receipt_dir}/marcusquinn_aidevops-42.status"
+[[ "$(<"$stale_calls")" == "2" ]]
+[[ "$(grep -c '^1$' "$cache_calls")" == "2" ]]
+printf 'PASS no-release recovers stale evidence through bounded cache-disabled reads\n'
+
+rm -f "${receipt_dir}/marcusquinn_aidevops-42.status"
+if COMPLETION_PR_STATE=API_FAILURE AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$record_runner" 42 marcusquinn/aidevops >/dev/null 2>&1; then
+	printf 'FAIL API-indeterminate evidence created no-release evidence\n'
+	exit 1
+fi
+[[ ! -e "${receipt_dir}/marcusquinn_aidevops-42.status" ]]
+printf 'PASS API-indeterminate evidence cannot create no-release evidence\n'
 
 rm -f "${receipt_dir}/marcusquinn_aidevops-42.status"
 if COMPLETION_PR_STATE=OPEN AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$record_runner" 42 marcusquinn/aidevops >/dev/null 2>&1; then

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -11,6 +11,8 @@
 #   5. Review-gate failures prevent both CLI merge and REST fallback
 #   6. Interactive --auto review-policy blocks fall through to --admin only
 #      after PR readiness and maintainer-review gates pass
+#   7. Post-merge verification retries cache-disabled reads without replaying
+#      the irreversible merge mutation
 #
 # Strategy: stub gh, audit-log-helper.sh, and gh-signature-helper.sh in a temp
 # directory prepended to PATH, then source the merge sub-library.
@@ -145,6 +147,23 @@ write_gh_stub_pr_issue_views() {
 
 	if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "view" ]]; then
 	if [[ "\$*" == *"--json state,mergedAt,mergeCommit"* ]]; then
+		_evidence_count=0
+		if [[ -f "${TEST_ROOT}/logs/evidence-count.txt" ]]; then
+			_evidence_count=\$(<"${TEST_ROOT}/logs/evidence-count.txt")
+		fi
+		_evidence_count=\$((_evidence_count + 1))
+		printf '%s\n' "\$_evidence_count" >"${TEST_ROOT}/logs/evidence-count.txt"
+		printf '%s\n' "\${AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE:-0}" >>"${TEST_ROOT}/logs/evidence-cache-control.txt"
+		case "$mode" in
+		post-merge-api-failure) exit 70 ;;
+		post-merge-unmerged) echo '{"state":"OPEN","mergedAt":null,"mergeCommit":null}'; exit 0 ;;
+		post-merge-stale)
+			if [[ "\$_evidence_count" -eq 1 ]]; then
+				echo '{"state":"OPEN","mergedAt":null,"mergeCommit":null}'
+				exit 0
+			fi
+			;;
+		esac
 		echo '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","mergeCommit":{"oid":"merged123sha"}}'
 		exit 0
 	fi
@@ -335,6 +354,45 @@ RUNNER_EOF
 	env PATH="${TEST_ROOT}/bin:${scripts_dir}:${PATH}" \
 		HOME="${TEST_ROOT}/home" \
 		FULL_LOOP_HEADLESS="${FULL_LOOP_HEADLESS:-}" \
+		AIDEVOPS_MODEL="test-model" \
+		bash "$tmp_runner" 2>&1 || rc=$?
+	rm -f "$tmp_runner"
+	return $rc
+}
+
+# Run cmd_merge with a counted finalizer and bounded evidence retries.
+# Args: pr_number repo
+run_cmd_merge_for_evidence() {
+	local pr_number="$1"
+	local repo="$2"
+	local scripts_dir="${SCRIPT_DIR}/.."
+	local tmp_runner=""
+	tmp_runner=$(mktemp)
+	cat >"$tmp_runner" <<RUNNER_EOF
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${scripts_dir}'
+source '${scripts_dir}/shared-constants.sh'
+source '${scripts_dir}/full-loop-helper-merge.sh'
+cmd_pre_merge_gate() { return 0; }
+_retarget_stacked_children_interactive() { return 0; }
+_merge_report_canonical_sync_state() { return 0; }
+_merge_finalize_post_merge() {
+	local count=0
+	[[ -f '${TEST_ROOT}/logs/finalize-count.txt' ]] && count=\$(<'${TEST_ROOT}/logs/finalize-count.txt')
+	count=\$((count + 1))
+	printf '%s\n' "\$count" >'${TEST_ROOT}/logs/finalize-count.txt'
+	return 0
+}
+cmd_merge '$pr_number' '$repo'
+RUNNER_EOF
+	chmod +x "$tmp_runner"
+
+	local rc=0
+	env PATH="${TEST_ROOT}/bin:${scripts_dir}:${PATH}" \
+		HOME="${TEST_ROOT}/home" \
+		FULL_LOOP_MERGED_EVIDENCE_ATTEMPTS=2 \
+		FULL_LOOP_MERGED_EVIDENCE_DELAY_SECONDS=0 \
 		AIDEVOPS_MODEL="test-model" \
 		bash "$tmp_runner" 2>&1 || rc=$?
 	rm -f "$tmp_runner"
@@ -759,6 +817,62 @@ test_verified_head_lookup_failure_is_not_reported_as_drift() {
 	return 0
 }
 
+# Test 13: stale post-merge evidence converges without replaying the mutation.
+test_post_merge_stale_evidence_retries_fresh_read() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+	create_gh_stub "post-merge-stale"
+
+	local output=""
+	local rc=0
+	output=$(run_cmd_merge_for_evidence "42" "testorg/testrepo") || rc=$?
+	print_result "post-merge evidence: stale first read converges" "$rc" "output=$output"
+
+	local merge_calls=0 evidence_calls=0 cache_disabled_calls=0 finalize_count=0
+	merge_calls=$(grep -c '^gh pr merge' "${TEST_ROOT}/logs/gh-calls.txt" || true)
+	evidence_calls=$(<"${TEST_ROOT}/logs/evidence-count.txt")
+	cache_disabled_calls=$(grep -c '^1$' "${TEST_ROOT}/logs/evidence-cache-control.txt" || true)
+	[[ -f "${TEST_ROOT}/logs/finalize-count.txt" ]] && finalize_count=$(<"${TEST_ROOT}/logs/finalize-count.txt")
+	print_result "post-merge evidence: mutation executes exactly once" "$((merge_calls == 1 ? 0 : 1))" "merge_calls=$merge_calls"
+	print_result "post-merge evidence: retry reads are cache-disabled" "$((evidence_calls == 2 && cache_disabled_calls == 2 ? 0 : 1))" "evidence_calls=$evidence_calls cache_disabled_calls=$cache_disabled_calls"
+	print_result "post-merge evidence: finalizer executes exactly once" "$((finalize_count == 1 ? 0 : 1))" "finalize_count=$finalize_count"
+	print_result "post-merge evidence: lifecycle reports merge SHA" "$([[ "$output" == *"LIFECYCLE_STATE=MERGED merge_sha=merged123sha"* ]] && printf '0' || printf '1')" "output=$output"
+	return 0
+}
+
+# Test 14: persistently unmerged evidence fails closed after bounded reads.
+test_post_merge_unmerged_evidence_fails_closed() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+	create_gh_stub "post-merge-unmerged"
+
+	local rc=0
+	run_cmd_merge_for_evidence "42" "testorg/testrepo" >/dev/null 2>&1 || rc=$?
+	local merge_calls=0 evidence_calls=0 finalize_count=0
+	merge_calls=$(grep -c '^gh pr merge' "${TEST_ROOT}/logs/gh-calls.txt" || true)
+	evidence_calls=$(<"${TEST_ROOT}/logs/evidence-count.txt")
+	[[ -f "${TEST_ROOT}/logs/finalize-count.txt" ]] && finalize_count=$(<"${TEST_ROOT}/logs/finalize-count.txt")
+	print_result "post-merge evidence: persistent OPEN fails closed" "$((rc == 0 ? 1 : 0))"
+	print_result "post-merge evidence: persistent OPEN does not replay merge" "$((merge_calls == 1 && evidence_calls == 2 ? 0 : 1))" "merge_calls=$merge_calls evidence_calls=$evidence_calls"
+	print_result "post-merge evidence: persistent OPEN skips finalizer" "$((finalize_count == 0 ? 0 : 1))" "finalize_count=$finalize_count"
+	return 0
+}
+
+# Test 15: API-indeterminate evidence fails closed without replaying the mutation.
+test_post_merge_api_indeterminate_fails_closed() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+	create_gh_stub "post-merge-api-failure"
+
+	local rc=0
+	run_cmd_merge_for_evidence "42" "testorg/testrepo" >/dev/null 2>&1 || rc=$?
+	local merge_calls=0 evidence_calls=0 finalize_count=0
+	merge_calls=$(grep -c '^gh pr merge' "${TEST_ROOT}/logs/gh-calls.txt" || true)
+	evidence_calls=$(<"${TEST_ROOT}/logs/evidence-count.txt")
+	[[ -f "${TEST_ROOT}/logs/finalize-count.txt" ]] && finalize_count=$(<"${TEST_ROOT}/logs/finalize-count.txt")
+	print_result "post-merge evidence: API-indeterminate state fails closed" "$((rc == 0 ? 1 : 0))"
+	print_result "post-merge evidence: API failure does not replay merge" "$((merge_calls == 1 && evidence_calls == 2 ? 0 : 1))" "merge_calls=$merge_calls evidence_calls=$evidence_calls"
+	print_result "post-merge evidence: API failure skips finalizer" "$((finalize_count == 0 ? 0 : 1))" "finalize_count=$finalize_count"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -781,6 +895,9 @@ main() {
 	test_pr_ready_accepts_prefetched_json
 	test_pr_ready_blocks_nonpassing_rollup
 	test_verified_head_lookup_failure_is_not_reported_as_drift
+	test_post_merge_stale_evidence_retries_fresh_read
+	test_post_merge_unmerged_evidence_fails_closed
+	test_post_merge_api_indeterminate_fails_closed
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Use one bounded cache-disabled evidence reader for post-merge finalization and release:not-requested verification, preserving fail-closed behavior without replaying the merge mutation.

## Files Changed

.agents/scripts/full-loop-helper-evidence.sh, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/tests/test-full-loop-completion-evidence.sh, .agents/scripts/tests/test-full-loop-merge.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Focused merge suite passed 50/50; completion-evidence suite passed; ShellCheck, Bash syntax, git diff --check, and changed-file local quality gates passed.

Resolves #28460


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.164 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3h 51m and 2,384,357 tokens on this with the user in an interactive session.