### PR TITLE
GH#28473: Extend checkpoint-safe headless sandbox timeout

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -50,7 +50,19 @@ readonly OPENCODE_BIN_DEFAULT="${OPENCODE_BIN:-opencode}"
 readonly SANDBOX_EXEC_HELPER="${SCRIPT_DIR}/sandbox-exec-helper.sh"
 readonly DISPATCH_LEDGER_HELPER="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
 readonly OAUTH_POOL_HELPER="${SCRIPT_DIR}/oauth-pool-helper.sh"
-readonly HEADLESS_SANDBOX_TIMEOUT_DEFAULT="${AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT:-3600}"
+# Full-loop workers checkpoint after 120 minutes. The three-hour default leaves
+# one hour for a graceful handoff, while the six-hour cap stays aligned with the
+# detached lifecycle observer's final safety fuse.
+readonly HEADLESS_SANDBOX_TIMEOUT_BASE_DEFAULT=10800
+readonly HEADLESS_SANDBOX_TIMEOUT_MAX=21600
+_headless_sandbox_timeout_resolved="${AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT:-$HEADLESS_SANDBOX_TIMEOUT_BASE_DEFAULT}"
+if [[ ! "$_headless_sandbox_timeout_resolved" =~ ^[1-9][0-9]*$ ]]; then
+	_headless_sandbox_timeout_resolved="$HEADLESS_SANDBOX_TIMEOUT_BASE_DEFAULT"
+elif ((_headless_sandbox_timeout_resolved > HEADLESS_SANDBOX_TIMEOUT_MAX)); then
+	_headless_sandbox_timeout_resolved="$HEADLESS_SANDBOX_TIMEOUT_MAX"
+fi
+readonly HEADLESS_SANDBOX_TIMEOUT_DEFAULT="$_headless_sandbox_timeout_resolved"
+unset _headless_sandbox_timeout_resolved
 readonly OPENCODE_AUTH_FILE="${HOME}/.local/share/opencode/auth.json"
 readonly LOCK_DIR="${STATE_DIR}/locks"
 readonly METRICS_DIR="${HOME}/.aidevops/logs"

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -319,12 +319,12 @@ _invoke_claude() {
 				exit 126
 			fi
 			if [[ "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" == "1" ]]; then
-				print_info "AIDEVOPS_HEADLESS_SANDBOX_DISABLED=1 — using bare exec (no privilege isolation) (GH#20146 audit)"
+				print_info "AIDEVOPS_HEADLESS_SANDBOX_DISABLED=1 — using bare timeout (no privilege isolation) (GH#20146 audit)"
 			fi
 			if [[ -n "${_HEADLESS_CLAUDE_STDIN_FILE:-}" && -f "${_HEADLESS_CLAUDE_STDIN_FILE:-}" ]]; then
-				"${cmd[@]}" <"$_HEADLESS_CLAUDE_STDIN_FILE" 2>&1 | tee "$output_file"
+				timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" "${cmd[@]}" <"$_HEADLESS_CLAUDE_STDIN_FILE" 2>&1 | tee "$output_file"
 			else
-				"${cmd[@]}" 2>&1 | tee "$output_file"
+				timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" "${cmd[@]}" 2>&1 | tee "$output_file"
 			fi
 			printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 		fi

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -44,7 +44,7 @@ readonly SANDBOX_DIR="${HOME}/.aidevops/.agent-workspace/sandbox"
 readonly SANDBOX_LOG="${SANDBOX_DIR}/executions.jsonl"
 readonly SANDBOX_TMP_BASE="${SANDBOX_DIR}/tmp"
 readonly SANDBOX_DEFAULT_TIMEOUT=120
-readonly SANDBOX_MAX_TIMEOUT=3600
+readonly SANDBOX_MAX_TIMEOUT=21600
 readonly SANDBOX_MAX_OUTPUT_BYTES=10485760 # 10MB per stream
 readonly SECRET_IO_GUARD_DEFAULT="true"
 readonly SANDBOX_ERROR_LEVEL="ERROR"
@@ -1485,7 +1485,10 @@ Commands:
   help                       Show this help
 
 Run options:
-  --timeout N                Timeout in seconds (default: 120, max: 3600)
+HELP
+	printf '  --timeout N                Timeout in seconds (default: %ss, max: %ss)\n' \
+		"$SANDBOX_DEFAULT_TIMEOUT" "$SANDBOX_MAX_TIMEOUT"
+	cat <<'HELP'
   --no-network               Block network access (macOS only, uses seatbelt)
   --network-tiering          Compatibility flag; enforcement is enabled by default
   --egress-mode MODE         Whole-process backend mode: off|auto|required

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -1988,6 +1988,88 @@ test_headless_activity_timeout_default_matches_watchdog() {
 	return 0
 }
 
+test_headless_sandbox_timeout_budget() {
+	local explicit_timeout=""
+	local capped_timeout=""
+	local invalid_timeout=""
+	explicit_timeout=$(
+		AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT=14400 \
+			bash -c 'source "$1" help >/dev/null 2>&1; printf "%s" "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT"' _ "$HELPER_SCRIPT"
+	)
+	capped_timeout=$(
+		AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT=86400 \
+			bash -c 'source "$1" help >/dev/null 2>&1; printf "%s" "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT"' _ "$HELPER_SCRIPT"
+	)
+	invalid_timeout=$(
+		AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT=invalid \
+			bash -c 'source "$1" help >/dev/null 2>&1; printf "%s" "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT"' _ "$HELPER_SCRIPT"
+	)
+
+	if [[ "$HEADLESS_SANDBOX_TIMEOUT_BASE_DEFAULT" == "10800" &&
+		"$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" == "10800" &&
+		"$HEADLESS_SANDBOX_TIMEOUT_MAX" == "21600" &&
+		"$explicit_timeout" == "14400" &&
+		"$capped_timeout" == "21600" &&
+		"$invalid_timeout" == "10800" ]]; then
+		print_result "headless sandbox timeout exceeds checkpoint budget and remains bounded" 0
+		return 0
+	fi
+
+	print_result "headless sandbox timeout exceeds checkpoint budget and remains bounded" 1 \
+		"base=$HEADLESS_SANDBOX_TIMEOUT_BASE_DEFAULT resolved=$HEADLESS_SANDBOX_TIMEOUT_DEFAULT max=$HEADLESS_SANDBOX_TIMEOUT_MAX explicit=$explicit_timeout capped=$capped_timeout invalid=$invalid_timeout"
+	return 0
+}
+
+test_claude_bare_paths_use_resolved_sandbox_timeout() {
+	local timeout_log="${TEST_ROOT}/claude-bare-timeout.log"
+	local direct_output="${TEST_ROOT}/claude-bare-direct.out"
+	local direct_exit="${TEST_ROOT}/claude-bare-direct.exit"
+	local stdin_output="${TEST_ROOT}/claude-bare-stdin.out"
+	local stdin_exit="${TEST_ROOT}/claude-bare-stdin.exit"
+	local stdin_file="${TEST_ROOT}/claude-bare.stdin"
+	local AIDEVOPS_HEADLESS_SANDBOX_DISABLED="1"
+	local AIDEVOPS_WORKER_EGRESS_MODE="off"
+
+	timeout() {
+		local timeout_seconds="$1"
+		shift
+		printf '%s\n' "$timeout_seconds" >>"$timeout_log"
+		"$@"
+		return $?
+	}
+
+	_HEADLESS_CLAUDE_STDIN_FILE=""
+	_invoke_claude "$direct_output" "$direct_exit" "" bash -c 'printf "direct-output\n"' >/dev/null 2>&1
+	printf 'stdin-output\n' >"$stdin_file"
+	_HEADLESS_CLAUDE_STDIN_FILE="$stdin_file"
+	# shellcheck disable=SC2016 # The nested bash expands $line after reading stdin.
+	_invoke_claude "$stdin_output" "$stdin_exit" "" bash -c 'IFS= read -r line; printf "%s\n" "$line"' >/dev/null 2>&1
+
+	local timeout_values=""
+	local direct_status=""
+	local stdin_status=""
+	local direct_value=""
+	local stdin_value=""
+	timeout_values=$(<"$timeout_log")
+	direct_status=$(<"$direct_exit")
+	stdin_status=$(<"$stdin_exit")
+	direct_value=$(<"$direct_output")
+	stdin_value=$(<"$stdin_output")
+	unset -f timeout
+	unset _HEADLESS_CLAUDE_STDIN_FILE
+
+	if [[ "$timeout_values" == $'10800\n10800' &&
+		"$direct_status" == "0" && "$stdin_status" == "0" &&
+		"$direct_value" == "direct-output" && "$stdin_value" == "stdin-output" ]]; then
+		print_result "Claude bare execution paths use the resolved headless timeout" 0
+		return 0
+	fi
+
+	print_result "Claude bare execution paths use the resolved headless timeout" 1 \
+		"timeouts=${timeout_values//$'\n'/,} direct_status=$direct_status stdin_status=$stdin_status direct=$direct_value stdin=$stdin_value"
+	return 0
+}
+
 test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait() {
 	local output_file="${TEST_ROOT}/activity-classifier.out"
 
@@ -5159,6 +5241,8 @@ main() {
 	test_post_pr_handoff_records_distinct_result_label
 	test_missing_context_blocked_requests_brief_recovery
 	test_headless_activity_timeout_default_matches_watchdog
+	test_headless_sandbox_timeout_budget
+	test_claude_bare_paths_use_resolved_sandbox_timeout
 	test_activity_watchdog_classifiers_detect_rate_limit_and_ci_wait
 	test_failure_classifier_records_provenance
 	test_failure_classifier_distinguishes_quota_exhaustion

--- a/.agents/scripts/tests/test-sandbox-timeout-budget.sh
+++ b/.agents/scripts/tests/test-sandbox-timeout-budget.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+SANDBOX_HELPER="${SCRIPT_DIR}/sandbox-exec-helper.sh"
+
+# shellcheck source=../sandbox-exec-helper.sh
+source "$SANDBOX_HELPER"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s: %s\n' "$name" "$detail"
+	return 0
+}
+
+resolve_timeout() {
+	local requested="$1"
+	local timeout_secs="$SANDBOX_DEFAULT_TIMEOUT"
+	local block_network=false
+	local network_tiering=true
+	local allow_secret_io=false
+	local worker_id="timeout-test"
+	local extra_passthrough=""
+	local stream_stdout=false
+	local private_output=false
+	local egress_mode="off"
+	local -a cmd_args=()
+
+	_sandbox_run_parse_args --timeout "$requested" -- true 2>/dev/null
+	printf '%s' "$timeout_secs"
+	return 0
+}
+
+test_timeout_constants() {
+	if [[ "$SANDBOX_DEFAULT_TIMEOUT" == "120" && "$SANDBOX_MAX_TIMEOUT" == "21600" ]]; then
+		pass "direct sandbox default stays short while the safety ceiling is six hours"
+		return 0
+	fi
+
+	fail "direct sandbox default stays short while the safety ceiling is six hours" \
+		"default=$SANDBOX_DEFAULT_TIMEOUT max=$SANDBOX_MAX_TIMEOUT"
+	return 0
+}
+
+test_timeout_parser_preserves_checkpoint_safe_override() {
+	local resolved=""
+	resolved="$(resolve_timeout 10800)"
+	if [[ "$resolved" == "10800" ]]; then
+		pass "sandbox preserves explicit timeout above the former one-hour ceiling"
+		return 0
+	fi
+
+	fail "sandbox preserves explicit timeout above the former one-hour ceiling" "resolved=$resolved"
+	return 0
+}
+
+test_timeout_parser_caps_at_six_hours() {
+	local resolved=""
+	resolved="$(resolve_timeout 86400)"
+	if [[ "$resolved" == "21600" ]]; then
+		pass "sandbox caps explicit timeout at six hours"
+		return 0
+	fi
+
+	fail "sandbox caps explicit timeout at six hours" "resolved=$resolved"
+	return 0
+}
+
+test_timeout_help_and_config_match_constants() {
+	local config_output=""
+	local help_output=""
+	config_output="$(sandbox_config)"
+	help_output="$(sandbox_help)"
+	if [[ "$config_output" == *"Timeout:      120s (max 21600s)"* &&
+		"$help_output" == *"Timeout in seconds (default: 120s, max: 21600s)"* ]]; then
+		pass "sandbox config and help report the active timeout budget"
+		return 0
+	fi
+
+	fail "sandbox config and help report the active timeout budget" \
+		"config/help output did not contain default=120s max=21600s"
+	return 0
+}
+
+main() {
+	test_timeout_constants
+	test_timeout_parser_preserves_checkpoint_safe_override
+	test_timeout_parser_caps_at_six_hours
+	test_timeout_help_and_config_match_constants
+
+	printf '\nTests: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if ((TESTS_FAILED > 0)); then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Raise the productive headless wall-clock budget beyond the two-hour checkpoint, retain a six-hour hard cap, and apply the resolved timeout to Claude fallback execution.

## Files Changed

.agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/sandbox-exec-helper.sh, .agents/scripts/tests/test-headless-runtime-helper.sh, .agents/scripts/tests/test-sandbox-timeout-budget.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — 174 headless runtime tests, 4 timeout-budget tests, 72 related sandbox tests, ShellCheck, bash -n, diff checks, and changed-file local gates passed.

Resolves #28473


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.164 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 4h 26m and 2,838,913 tokens on this with the user in an interactive session.