### PR TITLE
GH#28477: Fix stale full-loop merge test fixtures

### DIFF
--- a/.agents/scripts/tests/test-full-loop-merge-auto-release.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-auto-release.sh
@@ -137,6 +137,13 @@ export -f gh
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${SCRIPT_DIR}/shared-claim-lifecycle.sh"
 
+# Production reads now use the shared gh_pr_view wrapper. Route those reads
+# back through this test's controlled gh fixture instead of live/cache state.
+gh_pr_view() {
+	gh pr view "$@"
+	return $?
+}
+
 printf '%sRunning shared-claim-lifecycle / full-loop merge auto-release tests (t2429)%s\n' \
 	"$TEST_BLUE" "$TEST_NC"
 
@@ -265,7 +272,7 @@ release_interactive_claim_on_merge "54" "marcusquinn/aidevops" "8805"
 release_interactive_claim_on_merge "54" "marcusquinn/aidevops" "8805"
 
 # Count release calls — should be exactly 1 (second call short-circuits on missing stamp)
-CALL_COUNT=$(grep -c "release 8805" "$RELEASE_CALLS" 2>/dev/null || printf '0')
+CALL_COUNT=$(grep -c "release 8805" "$RELEASE_CALLS" 2>/dev/null || true)
 if [[ "$CALL_COUNT" -eq 1 ]]; then
 	pass "idempotency: release called exactly once on double invocation"
 else

--- a/.agents/scripts/tests/test-full-loop-merge-flag-conflict.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-flag-conflict.sh
@@ -125,6 +125,20 @@ load_helper_functions() {
 stub_gates() {
 	# Make pre-merge-gate always pass.
 	cmd_pre_merge_gate() { return 0; }
+	# Keep this flag-focused test independent from the exact-head, post-merge
+	# evidence, canonical-sync, and lifecycle finalization contracts.
+	_retarget_stacked_children_interactive() { return 0; }
+	_merge_guard_admin_merge_maintainer_review() { return 0; }
+	_merge_resolve_match_head() {
+		printf '%s\n' "fixture-head-sha"
+		return 0
+	}
+	_merge_verify_completed_state() {
+		FULL_LOOP_MERGE_SHA="fixture-merge-sha"
+		return 0
+	}
+	_merge_report_canonical_sync_state() { return 0; }
+	_merge_finalize_post_merge() { return 0; }
 	# Make resource unlock a no-op.
 	_merge_unlock_resources() { return 0; }
 	# Resolve repo unconditionally to the test slug.

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AGENTS_SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 TEST_ROOT=""
+FIXTURE_GIT_BIN=""
 TESTS_RUN=0
 TESTS_FAILED=0
 
@@ -28,7 +29,22 @@ print_result() {
 
 teardown() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		if [[ "$PWD" == "$TEST_ROOT" || "$PWD" == "$TEST_ROOT/"* ]]; then
+			cd "$AGENTS_SCRIPTS_DIR" || return 1
+		fi
 		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+resolve_fixture_git() {
+	FIXTURE_GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-}"
+	if [[ -z "$FIXTURE_GIT_BIN" ]]; then
+		FIXTURE_GIT_BIN=$(command -p -v git 2>/dev/null || true)
+	fi
+	if [[ -z "$FIXTURE_GIT_BIN" || ! -x "$FIXTURE_GIT_BIN" ]]; then
+		printf 'ERROR: real Git executable unavailable for disposable fixture\n' >&2
+		return 1
 	fi
 	return 0
 }
@@ -149,16 +165,28 @@ install_subject_stubs() {
 		return 0
 	}
 
+	_merge_capture_session_distill_provenance() { return 0; }
+	_merge_reconcile_closing_issues() { return 0; }
+
 	return 0
 }
 
 setup_subject() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		teardown || return 1
+	fi
 	TEST_ROOT=$(mktemp -d)
 	trap teardown EXIT
 	export HOME="${TEST_ROOT}/home"
 	export AIDEVOPS_SKIP_AUTO_CLAIM=1
 	export AIDEVOPS_FULL_LOOP_CLEANUP_DIR="${TEST_ROOT}/cleanup-receipts"
 	mkdir -p "$HOME" "${TEST_ROOT}/bin"
+	export AIDEVOPS_TEST_REAL_GIT="$FIXTURE_GIT_BIN"
+	cat >"${TEST_ROOT}/bin/git" <<'GIT'
+#!/usr/bin/env bash
+exec "${AIDEVOPS_TEST_REAL_GIT:?}" "$@"
+GIT
+	chmod +x "${TEST_ROOT}/bin/git"
 	cat >"${TEST_ROOT}/bin/trash" <<'TRASH'
 #!/usr/bin/env bash
 exit 1
@@ -305,6 +333,7 @@ test_refresh_canonical_reports_pending_without_mutation() {
 }
 
 main() {
+	resolve_fixture_git
 	setup_subject
 	test_refresh_canonical_reports_pending_without_mutation
 	test_cmd_merge_defers_current_linked_worktree


### PR DESCRIPTION
## Summary

Route claim-lifecycle reads through controlled fixtures, isolate flag-conflict assertions from unrelated merge gates, and pin cleanup fixtures to a stable real Git executable across repeated setup.

## Files Changed

.agents/scripts/tests/test-full-loop-merge-auto-release.sh, .agents/scripts/tests/test-full-loop-merge-flag-conflict.sh, .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** runtime-verified — Auto-release 22/22; flag conflict 3/3; worktree cleanup 3/3; full merge 50/50; claim-release labels 15/15; changed-file local linters; ShellCheck; bash -n; git diff --check.

Resolves #28477


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.164 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 5h 1m and 3,241,773 tokens on this with the user in an interactive session.