### PR TITLE
GH#28483: Fix Cloudron helper help under nounset

### DIFF
--- a/.agents/scripts/cloudron-helper.sh
+++ b/.agents/scripts/cloudron-helper.sh
@@ -13,6 +13,9 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # String literal constants
 readonly ERROR_SERVER_NAME_REQUIRED="Server name is required"
 readonly ERROR_SERVER_NOT_FOUND="Server not found in configuration"
+readonly HELP_SHOW_MESSAGE="Show this help"
+readonly USAGE_COMMAND_OPTIONS="Usage: $0 [command] [options]"
+readonly HELP_USAGE_INFO="Use '$0 help' for usage information"
 
 # Error message constants
 # readonly USAGE_PREFIX="Usage:"  # Currently unused
@@ -436,9 +439,9 @@ uninstall_app() {
 # Main function
 main() {
 	local command="${1:-help}"
-	local param2="$2"
-	local param3="$3"
-	local param4="$4"
+	local param2="${2:-}"
+	local param3="${3:-}"
+	local param4="${4:-}"
 
 	local server_name="$param2"
 	local command_to_run="$param3"

--- a/.agents/scripts/tests/test-cloudron-helper-help.sh
+++ b/.agents/scripts/tests/test-cloudron-helper-help.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
+HELPER="${SCRIPT_DIR}/../cloudron-helper.sh"
+
+tests_run=0
+tests_failed=0
+
+run_help_case() {
+	local case_name="$1"
+	shift
+	local output=""
+	local status=0
+
+	output=$(bash "$HELPER" "$@" 2>&1) || status=$?
+	tests_run=$((tests_run + 1))
+	if [[ "$status" -eq 0 ]] &&
+		[[ "$output" == *"Cloudron Helper Script"* ]] &&
+		[[ "$output" != *"unbound variable"* ]]; then
+		printf 'PASS: %s\n' "$case_name"
+		return 0
+	fi
+
+	printf 'FAIL: %s (status=%s)\n%s\n' "$case_name" "$status" "$output" >&2
+	tests_failed=$((tests_failed + 1))
+	return 0
+}
+
+run_help_case "no arguments"
+run_help_case "help command" help
+run_help_case "short help flag" -h
+run_help_case "long help flag" --help
+
+printf 'Tests run: %d, failed: %d\n' "$tests_run" "$tests_failed"
+[[ "$tests_failed" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

- guard optional Cloudron helper positional parameters before command dispatch under `set -u`
- define the helper-specific usage strings referenced by help and unknown-command paths
- add no-network coverage for no-argument, `help`, `-h`, and `--help` invocations

## Verification

- `bash .agents/scripts/tests/test-cloudron-helper-help.sh` — 4 passed
- `shellcheck .agents/scripts/cloudron-helper.sh .agents/scripts/tests/test-cloudron-helper-help.sh`
- `.agents/scripts/linters-local.sh` — all local checks passed

Resolves #28483

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.164 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2h 25m and 2,880,827 tokens on this with the user in an interactive session.