### PR TITLE
GH#28485: Fix init help and missing gitignore scaffolding

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -1391,6 +1391,75 @@ SOPSEOF
 	return 0
 }
 
+_init_update_gitignore() {
+	local project_root="$1"
+	local enable_beads="$2"
+	# Add aidevops runtime artifacts to .gitignore
+	# Note: .agents/ itself is NOT ignored — it contains committed project-specific agents.
+	# Only runtime artifacts (loop state, tmp, memory) are ignored.
+	local gitignore="$project_root/.gitignore"
+	if [[ ! -f "$gitignore" ]]; then
+		cat >"$gitignore" <<'GITIGNOREEOF' || return 1
+# aidevops runtime artifacts
+.agents/loop-state/
+.agents/tmp/
+.agents/memory/
+.aidevops.json
+GITIGNOREEOF
+		if [[ "$enable_beads" == "true" ]]; then
+			printf '.beads\n' >>"$gitignore" || return 1
+		fi
+		print_success "Created .gitignore with aidevops runtime artifact ignores"
+		return 0
+	fi
+
+	local gitignore_updated=false
+	if grep -qFx ".agents" "$gitignore" 2>/dev/null; then
+		sed -i '' '/^\.agents$/d' "$gitignore" 2>/dev/null ||
+			sed -i '/^\.agents$/d' "$gitignore" 2>/dev/null || true
+		sed -i '' '/^# aidevops$/{ N; /^# aidevops\n$/d; }' "$gitignore" 2>/dev/null || true
+		print_info "Removed legacy bare .agents from .gitignore (now tracked)"
+		gitignore_updated=true
+	fi
+	if grep -qFx ".agent" "$gitignore" 2>/dev/null; then
+		sed -i '' '/^\.agent$/d' "$gitignore" 2>/dev/null ||
+			sed -i '/^\.agent$/d' "$gitignore" 2>/dev/null || true
+		gitignore_updated=true
+	fi
+
+	local needs_runtime_entries=false
+	local runtime_entry
+	for runtime_entry in ".agents/loop-state/" ".agents/tmp/" ".agents/memory/"; do
+		grep -qFx "$runtime_entry" "$gitignore" 2>/dev/null || needs_runtime_entries=true
+	done
+	if [[ "$needs_runtime_entries" == "true" ]]; then
+		ensure_trailing_newline "$gitignore"
+		if ! grep -qFx "# aidevops runtime artifacts" "$gitignore" 2>/dev/null; then
+			[[ ! -s "$gitignore" ]] || printf '\n' >>"$gitignore"
+			printf '# aidevops runtime artifacts\n' >>"$gitignore" || return 1
+		fi
+		for runtime_entry in ".agents/loop-state/" ".agents/tmp/" ".agents/memory/"; do
+			grep -qFx "$runtime_entry" "$gitignore" 2>/dev/null || printf '%s\n' "$runtime_entry" >>"$gitignore" || return 1
+		done
+		print_success "Added .agents/ runtime artifact ignores to .gitignore"
+		gitignore_updated=true
+	fi
+
+	if ! grep -qFx ".aidevops.json" "$gitignore" 2>/dev/null; then
+		ensure_trailing_newline "$gitignore"
+		printf '.aidevops.json\n' >>"$gitignore" || return 1
+		gitignore_updated=true
+	fi
+	if [[ "$enable_beads" == "true" ]] && ! grep -qFx ".beads" "$gitignore" 2>/dev/null; then
+		ensure_trailing_newline "$gitignore"
+		printf '.beads\n' >>"$gitignore" || return 1
+		print_success "Added .beads to .gitignore"
+		gitignore_updated=true
+	fi
+	[[ "$gitignore_updated" != "true" ]] || print_info "Updated .gitignore"
+	return 0
+}
+
 _init_git_metadata() {
 
 	# Ensure .gitattributes has ai-training=false (opt out of AI model training)
@@ -1417,70 +1486,7 @@ GITATTRSEOF
 		print_success "Created .gitattributes with ai-training=false"
 	fi
 
-	# Add aidevops runtime artifacts to .gitignore
-	# Note: .agents/ itself is NOT ignored — it contains committed project-specific agents.
-	# Only runtime artifacts (loop state, tmp, memory) are ignored.
-	local gitignore="$project_root/.gitignore"
-	if [[ -f "$gitignore" ]]; then
-		local gitignore_updated=false
-
-		# Remove legacy bare ".agents" entry if present (was added by older versions)
-		if grep -q "^\.agents$" "$gitignore" 2>/dev/null; then
-			sed -i '' '/^\.agents$/d' "$gitignore" 2>/dev/null ||
-				sed -i '/^\.agents$/d' "$gitignore" 2>/dev/null || true
-			# Also remove the "# aidevops" comment if it's now orphaned
-			sed -i '' '/^# aidevops$/{ N; /^# aidevops\n$/d; }' "$gitignore" 2>/dev/null || true
-			print_info "Removed legacy bare .agents from .gitignore (now tracked)"
-			gitignore_updated=true
-		fi
-
-		# Remove legacy bare ".agent" entry if present
-		if grep -q "^\.agent$" "$gitignore" 2>/dev/null; then
-			sed -i '' '/^\.agent$/d' "$gitignore" 2>/dev/null ||
-				sed -i '/^\.agent$/d' "$gitignore" 2>/dev/null || true
-			gitignore_updated=true
-		fi
-
-		# Add runtime artifact ignores
-		if ! grep -q "^\.agents/loop-state/" "$gitignore" 2>/dev/null; then
-			# Ensure trailing newline before appending (prevents malformed entries like *.zip.agents/loop-state/)
-			ensure_trailing_newline "$gitignore"
-			{
-				echo ""
-				echo "# aidevops runtime artifacts"
-				echo ".agents/loop-state/"
-				echo ".agents/tmp/"
-				echo ".agents/memory/"
-			} >>"$gitignore"
-			print_success "Added .agents/ runtime artifact ignores to .gitignore"
-			gitignore_updated=true
-		fi
-
-		# Add .aidevops.json to gitignore (local config, not committed).
-		# Tracked legacy configs are migrated earlier only in linked worktrees.
-		# Canonical checkouts receive a worker-ready repair plan and remain untouched.
-		if ! grep -q "^\.aidevops\.json$" "$gitignore" 2>/dev/null; then
-			# Ensure trailing newline before appending
-			ensure_trailing_newline "$gitignore"
-			echo ".aidevops.json" >>"$gitignore"
-			gitignore_updated=true
-		fi
-
-		# Add .beads if beads is enabled
-		if [[ "$enable_beads" == "true" ]]; then
-			if ! grep -q "^\.beads$" "$gitignore" 2>/dev/null; then
-				# Ensure trailing newline before appending
-				ensure_trailing_newline "$gitignore"
-				echo ".beads" >>"$gitignore"
-				print_success "Added .beads to .gitignore"
-				gitignore_updated=true
-			fi
-		fi
-
-		if [[ "$gitignore_updated" == "true" ]]; then
-			print_info "Updated .gitignore"
-		fi
-	fi
+	_init_update_gitignore "$project_root" "$enable_beads" || return 1
 
 	_init_optional_scaffolding || return 1
 	return 0
@@ -1740,9 +1746,37 @@ _init_print_summary() {
 	return 0
 }
 
+# Print init-specific usage before repository validation or project writes.
+_init_print_help() {
+	cat <<'INITHELPEOF'
+Usage: aidevops init [FEATURES]
+
+Initialize aidevops in the current Git repository.
+
+FEATURES may be `all` (the default standard set), one feature, or a
+comma-separated list of features:
+  planning, git-workflow, code-quality, time-tracking, database, beads,
+  sops, security, deployment-context, hosting-context, wordpress-context
+
+Examples:
+  aidevops init
+  aidevops init planning
+  aidevops init planning,git-workflow,code-quality
+
+Run `aidevops features` for feature descriptions.
+INITHELPEOF
+	return 0
+}
+
 # Init command - initialize aidevops in a project
 cmd_init() {
 	local features="${1:-all}"
+	case "$features" in
+	-h | --help | help)
+		_init_print_help
+		return 0
+		;;
+	esac
 
 	print_header "Initialize AI DevOps in Project"
 	echo ""

--- a/.agents/scripts/tests/test-aidevops-init-help-gitignore.sh
+++ b/.agents/scripts/tests/test-aidevops-init-help-gitignore.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression tests for GH#28485: init help and root .gitignore scaffolding.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+TEST_ROOT=""
+PASSED=0
+FAILED=0
+
+print_info() { return 0; }
+print_success() { return 0; }
+print_warning() { return 0; }
+print_error() { return 0; }
+
+ensure_trailing_newline() {
+	local file="$1"
+	local last=""
+	if [[ -s "$file" ]]; then
+		last="$(
+			tail -c 1 "$file"
+			printf x
+		)"
+		[[ "$last" == $'\n'x ]] || printf '\n' >>"$file"
+	fi
+	return 0
+}
+
+INSTALL_DIR="$REPO_ROOT"
+AGENTS_DIR="$REPO_ROOT/.agents"
+CONFIG_DIR="${HOME}/.config/aidevops"
+# shellcheck source=../aidevops-cli/aidevops-init-lib.sh
+source "$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-init-lib.sh"
+
+cleanup() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local name="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		printf 'PASS %s\n' "$name"
+		PASSED=$((PASSED + 1))
+		return 0
+	fi
+	printf 'FAIL %s (expected=%s actual=%s)\n' "$name" "$expected" "$actual" >&2
+	FAILED=$((FAILED + 1))
+	return 0
+}
+
+assert_file_count() {
+	local expected="$1"
+	local pattern="$2"
+	local file="$3"
+	local name="$4"
+	local actual
+	actual=$(grep -cFx "$pattern" "$file" || true)
+	assert_equal "$expected" "$actual" "$name"
+	return 0
+}
+
+test_help_outside_repository() {
+	local non_repo="$TEST_ROOT/non-repo"
+	local help_arg output_file rc
+	mkdir -p "$non_repo"
+	for help_arg in --help -h help; do
+		output_file="$TEST_ROOT/help-${help_arg#-}.txt"
+		rc=0
+		(cd "$non_repo" && bash "$REPO_ROOT/aidevops.sh" init "$help_arg") >"$output_file" 2>&1 || rc=$?
+		assert_equal 0 "$rc" "init $help_arg exits successfully outside a repository"
+		assert_equal 1 "$(grep -cF 'Usage: aidevops init [FEATURES]' "$output_file" || true)" "init $help_arg prints init usage"
+		assert_equal 0 "$(grep -cF 'Not in a git repository' "$output_file" || true)" "init $help_arg bypasses repository validation"
+	done
+	return 0
+}
+
+test_missing_gitignore_is_created() {
+	local repo="$TEST_ROOT/new-gitignore"
+	local before after entry
+	mkdir -p "$repo"
+	_init_update_gitignore "$repo" false
+	assert_equal true "$([[ -f "$repo/.gitignore" ]] && printf true || printf false)" "missing root .gitignore is created"
+	for entry in ".agents/loop-state/" ".agents/tmp/" ".agents/memory/" ".aidevops.json"; do
+		assert_file_count 1 "$entry" "$repo/.gitignore" "new .gitignore contains $entry once"
+	done
+	assert_file_count 0 ".beads" "$repo/.gitignore" "new .gitignore omits .beads when disabled"
+	before=$(cksum "$repo/.gitignore")
+	_init_update_gitignore "$repo" false
+	after=$(cksum "$repo/.gitignore")
+	assert_equal "$before" "$after" "new .gitignore rerun is byte-stable"
+	return 0
+}
+
+test_existing_gitignore_is_preserved() {
+	local repo="$TEST_ROOT/existing-gitignore"
+	local before after entry
+	mkdir -p "$repo"
+	printf 'node_modules/\n.agents\n.agent\n.agents/tmp/\n' >"$repo/.gitignore"
+	_init_update_gitignore "$repo" true
+	assert_file_count 1 "node_modules/" "$repo/.gitignore" "user-owned ignore entry is preserved"
+	assert_file_count 0 ".agents" "$repo/.gitignore" "legacy bare .agents entry is removed"
+	assert_file_count 0 ".agent" "$repo/.gitignore" "legacy bare .agent entry is removed"
+	for entry in ".agents/loop-state/" ".agents/tmp/" ".agents/memory/" ".aidevops.json" ".beads"; do
+		assert_file_count 1 "$entry" "$repo/.gitignore" "existing .gitignore contains $entry once"
+	done
+	before=$(cksum "$repo/.gitignore")
+	_init_update_gitignore "$repo" true
+	after=$(cksum "$repo/.gitignore")
+	assert_equal "$before" "$after" "existing .gitignore rerun is byte-stable"
+	return 0
+}
+
+main() {
+	TEST_ROOT=$(mktemp -d)
+	trap cleanup EXIT
+	test_help_outside_repository
+	test_missing_gitignore_is_created
+	test_existing_gitignore_is_preserved
+	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
+	[[ "$FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add init-specific help before repository validation and create or reconcile root aidevops gitignore entries idempotently.

## Files Changed

- `.agents/scripts/aidevops-cli/aidevops-init-lib.sh`
- `.agents/scripts/tests/test-aidevops-init-help-gitignore.sh`

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — exercised `aidevops init --help`, `-h`, and `help` from outside a Git repository; 25 focused regressions and 95 related init tests passed; ShellCheck, shfmt, Bash syntax, and local linters passed.

## Decisions

- Extracted `.gitignore` reconciliation into a dedicated helper to keep init metadata below complexity limits.
- Preserved user entries and legacy cleanup while keeping `.beads` conditional.

Resolves #28485

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.164 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2h 56m and 3,267,746 tokens on this with the user in an interactive session.
