### PR TITLE
GH#28493: fix: align Pulse evidence cutoff timestamps

### DIFF
--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -331,9 +331,16 @@ _gh_append_v2() {
 	local elapsed_ms="$1"
 	shift
 	local quota_cost="$1"
+	shift
+	local recorded_at="${1:-}"
 	local ts=""
 	local record=""
-	ts=$(_gh_now_seconds) || return 0
+	if [[ -n "$recorded_at" ]]; then
+		[[ "$recorded_at" =~ ^[1-9][0-9]*$ ]] || return 1
+		ts="$recorded_at"
+	else
+		ts=$(_gh_now_seconds) || return 0
+	fi
 	caller=$(_gh_resolve_caller "$caller")
 	path=$(_gh_safe_text "$path" other)
 	auth_mode=$(_gh_safe_text "$auth_mode" unknown)
@@ -398,14 +405,18 @@ gh_record_call() {
 	return 0
 }
 
-# --- gh_record_efficiency_evidence <name> [value] -----------------------
+# --- gh_record_efficiency_evidence <name> [value] [recorded_at] ---------
 # Append a typed, privacy-safe benchmark evidence event. Names and values are
 # restricted to bounded identifiers; repository names, URLs, payloads, and
-# credentials are never accepted. Returns 1 for an invalid event.
+# credentials are never accepted. The optional epoch aligns a completed-cycle
+# boundary's record timestamp with its already-captured inclusive cutoff and is
+# rejected if it is in the future. Returns 1 for an invalid event.
 gh_record_efficiency_evidence() {
 	[[ "${AIDEVOPS_GH_API_INSTRUMENT_DISABLE:-0}" == "1" ]] && return 0
 	local name="$1"
 	local value="${2:-1}"
+	local recorded_at="${3:-}"
+	local current_now=""
 	local decision=""
 	if [[ ! "$name" =~ ^[a-z][a-z0-9_.-]{0,95}$ ]]; then
 		return 1
@@ -413,10 +424,15 @@ gh_record_efficiency_evidence() {
 	if [[ ! "$value" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
 		return 1
 	fi
+	if [[ -n "$recorded_at" ]]; then
+		[[ "$recorded_at" =~ ^[1-9][0-9]*$ ]] || return 1
+		current_now=$(_gh_now_seconds) || return 1
+		[[ "$recorded_at" -le "$current_now" ]] || return 1
+	fi
 	decision="evidence:${name}:${value}"
 	_gh_append_v2 evidence github-api-efficiency other unknown other "$decision" \
-		"" "" "" "" "" "" "" "" ""
-	return 0
+		"" "" "" "" "" "" "" "" "" "$recorded_at"
+	return $?
 }
 
 # --- gh_record_attempt ---------------------------------------------------

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -41,8 +41,9 @@ _PULSE_LEGACY_CYCLE_OUTCOME_PENDING=0
 _pulse_efficiency_record() {
 	local name="$1"
 	local value="${2:-1}"
+	local recorded_at="${3:-}"
 	if declare -F gh_record_efficiency_evidence >/dev/null 2>&1; then
-		gh_record_efficiency_evidence "$name" "$value" 2>/dev/null || true
+		gh_record_efficiency_evidence "$name" "$value" "$recorded_at" 2>/dev/null || true
 	fi
 	return 0
 }
@@ -157,7 +158,10 @@ _pulse_efficiency_cycle_finish() {
 	else
 		_pulse_efficiency_record population.unchanged_cycles 1
 	fi
-	[[ "$now_seconds" -gt 0 ]] && _pulse_efficiency_record coverage-end "$now_seconds"
+	# Use the completed-cycle cutoff for both the marker value and its outer
+	# record timestamp. A second rollover inside the recorder must not place the
+	# marker outside the exact inclusive aggregate it bounds (GH#28493).
+	[[ "$now_seconds" -gt 0 ]] && _pulse_efficiency_record coverage-end "$now_seconds" "$now_seconds"
 	if declare -F gh_aggregate_calls >/dev/null 2>&1; then
 		if [[ "$now_seconds" -gt 0 ]]; then
 			gh_aggregate_calls "${GH_API_REPORT:-}" 86400 "$now_seconds" 2>/dev/null || true

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -475,7 +475,41 @@ future_cutoff_status=$?
 set -e
 assert_eq "future report cutoff is rejected" "1" "$future_cutoff_status"
 
-# --- Test 12d: typed evidence and latency completeness stay explicit --------
+# --- Test 12d: completed marker timestamp survives a second rollover --------
+# Freeze the recorder one second after the cycle cutoff. The bounded override
+# must place the marker at the captured cutoff while a later attempt remains
+# outside the fixed aggregate. Future overrides still fail closed (GH#28493).
+gh_clear_log
+rollover_cutoff=$((now - 2))
+rollover_append_now=$((rollover_cutoff + 1))
+_gh_now_seconds() {
+	printf '%s\n' "$rollover_append_now"
+	return 0
+}
+printf "%s\tpre-cycle-caller\trest\tgh-pat\trest-core\trest-selected\t4999\tv2\tattempt\tlogical-pre-cycle\tattempt-before-boundary\t1\t0\tsuccess\t200\t10\t1\n" \
+	"$rollover_cutoff" >>"$AIDEVOPS_GH_API_LOG"
+gh_record_efficiency_evidence coverage-end "$rollover_cutoff" "$rollover_cutoff"
+gh_record_attempt rest rollover-caller logical-rollover attempt-after-cycle 1 0 success 200 10 1 gh-pat rest-core rest-selected 4999
+marker_record_ts=$(awk -F'\t' -v decision="evidence:coverage-end:${rollover_cutoff}" '$6 == decision { print $1 }' "$AIDEVOPS_GH_API_LOG")
+assert_eq "explicit evidence timestamp matches completed cutoff" "$rollover_cutoff" "$marker_record_ts"
+gh_aggregate_calls "$AIDEVOPS_GH_API_REPORT" 60 "$rollover_cutoff"
+assert_eq "rollover report retains the aligned coverage marker" "1" "$(jq -r --arg key "evidence:coverage-end:${rollover_cutoff}" '.by_route_decision[$key].evidence_events' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "rollover report excludes post-cycle attempts" "1" "$(jq -r '._meta.attempted_requests' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "rollover report omits the post-cycle caller" "0" "$(jq -r '(.by_caller["rollover-caller"].attempted_requests // 0)' "$AIDEVOPS_GH_API_REPORT")"
+assert_eq "rollover report ends at the completed cutoff" "$rollover_cutoff" "$(jq -r '._meta.last_retained_ts' "$AIDEVOPS_GH_API_REPORT")"
+set +e
+gh_record_efficiency_evidence coverage-end "$((rollover_append_now + 1))" "$((rollover_append_now + 1))"
+future_evidence_status=$?
+set -e
+assert_eq "future evidence timestamp is rejected" "1" "$future_evidence_status"
+assert_eq "rejected future evidence is not appended" "3" "$(wc -l <"$AIDEVOPS_GH_API_LOG" | tr -d ' ')"
+
+# Restore the production clock implementation for the remaining tests.
+unset _GH_API_INSTRUMENT_LOADED
+# shellcheck source=../gh-api-instrument.sh
+source "${PARENT_DIR}/gh-api-instrument.sh"
+
+# --- Test 12e: typed evidence and latency completeness stay explicit --------
 gh_clear_log
 latency_ts=$((now - 5))
 gh_record_efficiency_evidence cache.fresh_hits 1
@@ -495,7 +529,7 @@ invalid_evidence_status=0
 gh_record_efficiency_evidence "Invalid Name" 1 || invalid_evidence_status=$?
 assert_eq "invalid evidence identifiers are rejected" "1" "$invalid_evidence_status"
 
-# --- Test 12e: CLI reports the actual custom aggregate destination -----------
+# --- Test 12f: CLI reports the actual custom aggregate destination -----------
 custom_report="$TMPDIR/custom-report.json"
 custom_report_message=$("${PARENT_DIR}/gh-api-instrument.sh" report "$custom_report" 60 2>&1 >/dev/null)
 assert_file_exists "CLI custom report is created" "$custom_report"

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -69,16 +69,20 @@ EOF
 chmod +x "${SCRIPT_DIR}/pulse-idle-backoff-helper.sh"
 
 EVIDENCE_FILE="${TMP}/evidence.log"
+EVIDENCE_TIMESTAMP_FILE="${TMP}/evidence-timestamps.log"
 AGGREGATE_FILE="${TMP}/aggregate.log"
 TRIM_FILE="${TMP}/trim.log"
 : >"$EVIDENCE_FILE"
+: >"$EVIDENCE_TIMESTAMP_FILE"
 : >"$AGGREGATE_FILE"
 : >"$TRIM_FILE"
 
 gh_record_efficiency_evidence() {
 	local name="$1"
 	local value="$2"
+	local recorded_at="${3:-${EVIDENCE_APPEND_NOW:-}}"
 	printf '%s=%s\n' "$name" "$value" >>"$EVIDENCE_FILE"
+	printf '%s=%s\n' "$name" "$recorded_at" >>"$EVIDENCE_TIMESTAMP_FILE"
 	return 0
 }
 
@@ -148,6 +152,7 @@ else
 fi
 
 : >"$EVIDENCE_FILE"
+: >"$EVIDENCE_TIMESTAMP_FILE"
 : >"$AGGREGATE_FILE"
 : >"$TRIM_FILE"
 _pulse_efficiency_cycle_start
@@ -179,6 +184,37 @@ if grep -q -- "^|86400|${coverage_end_value}$" "$AGGREGATE_FILE"; then
 else
 	fail "cycle aggregate uses the completed coverage cutoff" "args=$(<"$AGGREGATE_FILE")"
 fi
+
+# Simulate the recorder entering the next second after cycle finish captured its
+# cutoff. The explicit record timestamp must stay aligned with the marker value
+# and aggregate cutoff instead of widening the completed window (GH#28493).
+: >"$EVIDENCE_FILE"
+: >"$EVIDENCE_TIMESTAMP_FILE"
+: >"$AGGREGATE_FILE"
+: >"$TRIM_FILE"
+EVIDENCE_APPEND_NOW=2001
+_pulse_efficiency_now_seconds() {
+	printf '2000\n'
+	return 0
+}
+_pulse_efficiency_cycle_start
+_pulse_efficiency_cycle_finish idle
+rollover_marker=$(grep '^coverage-end=' "$EVIDENCE_FILE")
+rollover_record_ts=$(grep '^coverage-end=' "$EVIDENCE_TIMESTAMP_FILE")
+rollover_aggregate=$(<"$AGGREGATE_FILE")
+if [[ "$rollover_marker" == "coverage-end=2000" \
+	&& "$rollover_record_ts" == "coverage-end=2000" \
+	&& "$rollover_aggregate" == "|86400|2000" ]]; then
+	pass "second rollover keeps coverage marker inside completed cutoff"
+else
+	fail "second rollover keeps coverage marker inside completed cutoff" \
+		"marker=${rollover_marker} record=${rollover_record_ts} aggregate=${rollover_aggregate} append_now=${EVIDENCE_APPEND_NOW}"
+fi
+unset EVIDENCE_APPEND_NOW
+_pulse_efficiency_now_seconds() {
+	date +%s 2>/dev/null || printf '0\n'
+	return 0
+}
 
 _pulse_efficiency_cycle_finish idle
 if [[ "$(wc -l <"$AGGREGATE_FILE" | tr -d ' ')" == "1" ]] \


### PR DESCRIPTION
## Summary

Align coverage-end evidence record timestamps with the already captured completed-cycle cutoff, reject future timestamp overrides, and keep post-cycle attempts outside fixed aggregates.

## Files Changed

.agents/scripts/gh-api-instrument.sh, .agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime boundary regression: test-pulse-wrapper-cycle-gates.sh (18/18), test-gh-api-instrument.sh (152/152), test-github-api-efficiency-evidence.sh (40/40), test-pulse-cycle-state-contract.sh (14/14), ShellCheck, and changed-file local lint including Bash 3.2 compatibility.

Resolves #28493


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.165 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.5 spent 5d 14h and 22,436,328 tokens on this with the user in an interactive session.