### PR TITLE
GH#28494: Scope remote-only repository authorization to workspace

### DIFF
--- a/.agents/configs/command-policy.json
+++ b/.agents/configs/command-policy.json
@@ -32,9 +32,11 @@
       "id": "github.account-mutation",
       "kind": "trusted_account_mutation",
       "authorization_env": "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION",
+      "workspace_root_env": "AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT",
       "command_paths": [
         ["repo", "create"],
-        ["repo", "fork"]
+        ["repo", "fork"],
+        ["repo", "new"]
       ],
       "decision": "forbid"
     }

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -386,12 +386,14 @@ test("blocks account mutations unless inherited authorization matches exactly", 
   const helper = join(scriptsDir, "command-policy-helper.py");
   const command = "gh repo fork owner/source --clone=false";
   const previousAuthorization = process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION;
-  const authorization = execFileSync(
-    "python3",
-    [helper, "authorization-digest", "--cwd", cwd, "--command", command],
-    { encoding: "utf8" },
-  ).trim();
+  const previousWorkspaceRoot = process.env.AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT;
   try {
+    process.env.AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT = "";
+    const authorization = execFileSync(
+      "python3",
+      [helper, "authorization-digest", "--cwd", cwd, "--command", command],
+      { encoding: "utf8" },
+    ).trim();
     delete process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION;
     assert.throws(
       () => checkCommandSafetyGate(command, scriptsDir, cwd),
@@ -431,6 +433,70 @@ test("blocks account mutations unless inherited authorization matches exactly", 
     } else {
       process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION = previousAuthorization;
     }
+    if (previousWorkspaceRoot === undefined) {
+      delete process.env.AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT;
+    } else {
+      process.env.AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT = previousWorkspaceRoot;
+    }
+  }
+});
+
+test("scopes remote-only account mutation authorization to the projects workspace", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-account-workspace-"));
+  const workspace = join(root, "projects");
+  const repoA = join(workspace, "repo-a");
+  const repoB = join(workspace, "repo-b");
+  const outside = join(root, "outside");
+  const escape = join(workspace, "escape");
+  const helper = join(scriptsDir, "command-policy-helper.py");
+  const command = "gh repo fork owner/source --clone=false";
+  const previousAuthorization = process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION;
+  const previousWorkspaceRoot = process.env.AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT;
+  mkdirSync(repoA, { recursive: true });
+  mkdirSync(repoB, { recursive: true });
+  mkdirSync(outside, { recursive: true });
+  symlinkSync(outside, escape);
+  try {
+    process.env.AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT = workspace;
+    const authorization = execFileSync(
+      "python3",
+      [helper, "authorization-digest", "--cwd", repoA, "--command", command],
+      { encoding: "utf8" },
+    ).trim();
+    process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION = authorization;
+    assert.doesNotThrow(() => checkCommandSafetyGate(command, scriptsDir, repoB));
+    assert.throws(
+      () => checkCommandSafetyGate(command, scriptsDir, outside),
+      /github\.account-mutation/,
+    );
+    assert.throws(
+      () => checkCommandSafetyGate(command, scriptsDir, escape),
+      /github\.account-mutation/,
+    );
+
+    const localCommand = "gh repo fork owner/source";
+    process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION = execFileSync(
+      "python3",
+      [helper, "authorization-digest", "--cwd", repoA, "--command", localCommand],
+      { encoding: "utf8" },
+    ).trim();
+    assert.doesNotThrow(() => checkCommandSafetyGate(localCommand, scriptsDir, repoA));
+    assert.throws(
+      () => checkCommandSafetyGate(localCommand, scriptsDir, repoB),
+      /github\.account-mutation/,
+    );
+  } finally {
+    if (previousAuthorization === undefined) {
+      delete process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION;
+    } else {
+      process.env.AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION = previousAuthorization;
+    }
+    if (previousWorkspaceRoot === undefined) {
+      delete process.env.AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT;
+    } else {
+      process.env.AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT = previousWorkspaceRoot;
+    }
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/.agents/reference/gh-command-discipline.md
+++ b/.agents/reference/gh-command-discipline.md
@@ -18,8 +18,26 @@ For prompt-economy reasons these rules live here rather than in always-on AGENTS
 
 Generic Bash permission does not authorize GitHub account or repository resource
 creation. The shared command policy denies protected commands such as `gh repo
-fork` and `gh repo create` before execution unless the runtime process inherits an
-authorization digest for that exact parsed argv and working directory.
+fork`, `gh repo create`, and the `gh repo new` alias before execution unless the
+runtime process inherits an authorization digest for that exact parsed argv and
+location binding.
+
+The location binding is workspace-scoped only for CWD-independent forms:
+
+- `gh repo fork <owner>/<repo> --clone=false`, with only allowlisted remote
+  options.
+- `gh repo create|new <name> --public|--private|--internal`, with only allowlisted
+  API options and no local source, clone, push, or remote setup.
+
+For those forms, the digest binds to the canonical projects root from
+`AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT`, defaulting to `~/Git`, and the same
+exact command may run from another real directory beneath that root. Realpath and
+path-component containment prevent symlink escapes and sibling-prefix matches.
+All other protected forms remain bound to the exact canonical working directory.
+An empty workspace-root value explicitly selects exact-CWD mode; root, home, and
+nonexistent workspace roots fail safely back to exact-CWD binding. Existing v1
+digests remain exact-CWD-bound during compatibility migration. Help-only forms do
+not require authorization.
 
 Generate the digest without executing the command:
 
@@ -29,11 +47,14 @@ python3 ~/.aidevops/agents/scripts/command-policy-helper.py \
 ```
 
 The trusted operator or dispatcher may then set the returned value as
-`AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION` when launching the runtime. Never add
-that assignment to the Bash command being authorized: command-local attempts are
-rejected as a parse error. Any argv, quoting result, command chain, or working
-directory change requires a new authorization. Read-only `gh` commands and the
-normal issue/PR implementation workflow retain their existing behavior.
+`AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION` when launching the runtime and may set
+`AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT` to the trusted projects root. Never
+add either assignment to the Bash command being authorized: command-local
+attempts are rejected as parse errors. Any argv, quoting result, or command chain
+change requires a new authorization. A working-directory change also requires a
+new authorization unless the command qualifies for the same workspace binding.
+Read-only `gh` commands and the normal issue/PR implementation workflow retain
+their existing behavior.
 
 ## Signature footer hallucination (t2685)
 

--- a/.agents/scripts/command-policy-helper.py
+++ b/.agents/scripts/command-policy-helper.py
@@ -13,6 +13,11 @@ from typing import Any
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
+from command_policy_account_mutation import (
+    _account_mutation_guard,
+    _is_protected_account_mutation,
+    account_mutation_authorization,
+)
 from command_policy_config import (
     PolicyError,
     _default_policy_path,
@@ -21,11 +26,8 @@ from command_policy_config import (
 )
 from command_policy_evaluation import (
     _evaluate_static,
-    _account_mutation_guard,
-    account_mutation_authorization,
     evaluate_invocations,
 )
-from command_policy_matchers import _matches_gh_command_path
 from command_policy_dispatch import (
     CommandParseError,
     _validate_argv,
@@ -144,7 +146,7 @@ def _authorization_action(
     authorization_source: dict[str, Any] | None,
 ) -> int:
     guard = _account_mutation_guard(policy)
-    if len(invocations) != 1 or not _matches_gh_command_path(
+    if len(invocations) != 1 or not _is_protected_account_mutation(
         invocations[0], guard["command_paths"]
     ):
         print(
@@ -158,7 +160,10 @@ def _authorization_action(
         return FORBID_EXIT
     print(
         account_mutation_authorization(
-            invocations[0], args.cwd, authorization_source
+            invocations[0],
+            args.cwd,
+            authorization_source,
+            args.account_mutation_workspace_root,
         )
     )
     return 0
@@ -187,6 +192,7 @@ def _check_action(
         args.runtime_pid,
         args.runtime_process_identity,
         args.process_table_fixture,
+        args.account_mutation_workspace_root,
     )
     print(json.dumps(result, sort_keys=True))
     return 0 if result["decision"] == "allow" else FORBID_EXIT

--- a/.agents/scripts/command_policy_account_mutation.py
+++ b/.agents/scripts/command_policy_account_mutation.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Trusted authorization for protected GitHub account mutations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from command_policy_config import _decision
+from command_policy_matchers import _matches_gh_command_path
+
+WORKSPACE_ROOT_ENV = "AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT"
+
+
+@dataclass(frozen=True)
+class _RemoteOptionPolicy:
+    boolean_options: frozenset[str]
+    value_options: frozenset[str]
+    exact_options: frozenset[str] = frozenset()
+    explicit_remote_value_options: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class _AccountMutationContext:
+    authorization: str
+    source: dict[str, Any] | None
+    workspace_root: str | None
+
+
+_FORK_OPTIONS = _RemoteOptionPolicy(
+    boolean_options=frozenset({"--default-branch-only"}),
+    value_options=frozenset({"--fork-name", "--org"}),
+    exact_options=frozenset({"--clone=false"}),
+)
+_CREATE_OPTIONS = _RemoteOptionPolicy(
+    boolean_options=frozenset(
+        {
+            "--add-readme",
+            "--disable-issues",
+            "--disable-wiki",
+            "--include-all-branches",
+            "--internal",
+            "--private",
+            "--public",
+        }
+    ),
+    value_options=frozenset(
+        {
+            "--description",
+            "--gitignore",
+            "--homepage",
+            "--license",
+            "--team",
+            "--template",
+            "-d",
+            "-g",
+            "-h",
+            "-l",
+            "-p",
+            "-t",
+        }
+    ),
+    explicit_remote_value_options=frozenset({"--template", "-p"}),
+)
+_CREATE_VISIBILITY = frozenset({"--internal", "--private", "--public"})
+
+
+def account_mutation_workspace_root_from_environment() -> str:
+    """Return the inherited workspace root, defaulting to the projects directory."""
+    if WORKSPACE_ROOT_ENV in os.environ:
+        return os.environ[WORKSPACE_ROOT_ENV]
+    return str(Path.home() / "Git")
+
+
+def _account_mutation_guard(policy: dict[str, Any]) -> dict[str, Any]:
+    return next(
+        guard
+        for guard in policy["dynamic_guards"]
+        if guard["kind"] == "trusted_account_mutation"
+    )
+
+
+def _is_protected_account_mutation(
+    argv: list[str], command_paths: list[list[str]]
+) -> bool:
+    help_only = len(argv) == 4 and argv[3] == "--help"
+    return _matches_gh_command_path(argv, command_paths) and not help_only
+
+
+def _is_explicit_remote(repository: str) -> bool:
+    return re.fullmatch(
+        r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?/[A-Za-z0-9_.-]+",
+        repository,
+    ) is not None
+
+
+def _consume_remote_only_options(
+    args: list[str], policy: _RemoteOptionPolicy
+) -> set[str] | None:
+    seen: set[str] = set()
+    index = 0
+    while index < len(args):
+        consumed = _consume_remote_only_option(args, index, policy)
+        if consumed is None:
+            return None
+        option, index = consumed
+        seen.add(option)
+    return seen
+
+
+def _consume_remote_only_option(
+    args: list[str], index: int, policy: _RemoteOptionPolicy
+) -> tuple[str, int] | None:
+    option = args[index]
+    if option in policy.exact_options or option in policy.boolean_options:
+        return option, index + 1
+    if "=" in option:
+        normalized = _normalize_attached_option(option, policy)
+        return (normalized, index + 1) if normalized else None
+    if option not in policy.value_options or index + 1 >= len(args):
+        return None
+    if not _is_remote_only_option_value(option, args[index + 1], policy):
+        return None
+    return option, index + 2
+
+
+def _normalize_attached_option(
+    option: str, policy: _RemoteOptionPolicy
+) -> str | None:
+    name, _, value = option.partition("=")
+    if name in policy.boolean_options:
+        return name if value == "true" else None
+    if name in policy.value_options and _is_remote_only_option_value(
+        name, value, policy
+    ):
+        return name
+    return None
+
+
+def _is_remote_only_option_value(
+    option: str, value: str, policy: _RemoteOptionPolicy
+) -> bool:
+    if not value:
+        return False
+    return (
+        option not in policy.explicit_remote_value_options
+        or _is_explicit_remote(value)
+    )
+
+
+def _is_workspace_safe_fork(argv: list[str]) -> bool:
+    if len(argv) < 5 or not _is_explicit_remote(argv[3]):
+        return False
+    seen = _consume_remote_only_options(argv[4:], _FORK_OPTIONS)
+    return seen is not None and "--clone=false" in seen
+
+
+def _is_workspace_safe_create(argv: list[str]) -> bool:
+    if len(argv) < 5 or argv[3].startswith("-") or argv[3] in {".", ".."}:
+        return False
+    seen = _consume_remote_only_options(argv[4:], _CREATE_OPTIONS)
+    return seen is not None and bool(seen & _CREATE_VISIBILITY)
+
+
+def _is_workspace_safe_account_mutation(argv: list[str]) -> bool:
+    if len(argv) < 3 or argv[1] != "repo":
+        return False
+    if argv[2] == "fork":
+        return _is_workspace_safe_fork(argv)
+    if argv[2] in {"create", "new"}:
+        return _is_workspace_safe_create(argv)
+    return False
+
+
+def _canonical_workspace_root(workspace_root: str) -> str:
+    if not workspace_root:
+        return ""
+    root = os.path.realpath(os.path.expanduser(workspace_root))
+    home = os.path.realpath(str(Path.home()))
+    if root in {os.path.abspath(os.sep), home} or not os.path.isdir(root):
+        return ""
+    return root
+
+
+def _is_within_workspace(cwd: str, workspace_root: str) -> bool:
+    if not os.path.isdir(cwd):
+        return False
+    try:
+        return os.path.commonpath([cwd, workspace_root]) == workspace_root
+    except ValueError:
+        return False
+
+
+def _account_mutation_location(
+    argv: list[str], cwd: str, workspace_root: str
+) -> dict[str, str]:
+    canonical_cwd = os.path.realpath(cwd)
+    canonical_root = _canonical_workspace_root(workspace_root)
+    if (
+        canonical_root
+        and _is_workspace_safe_account_mutation(argv)
+        and _is_within_workspace(canonical_cwd, canonical_root)
+    ):
+        return {"kind": "workspace", "path": canonical_root}
+    return {"kind": "cwd", "path": canonical_cwd}
+
+
+def _authorization_digest(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+def account_mutation_authorization(
+    argv: list[str],
+    cwd: str,
+    source: dict[str, Any] | None = None,
+    workspace_root: str | None = None,
+) -> str:
+    if workspace_root is None:
+        workspace_root = account_mutation_workspace_root_from_environment()
+    return _authorization_digest(
+        {
+            "argv": argv,
+            "location": _account_mutation_location(argv, cwd, workspace_root),
+            "schema": "aidevops-command-authorization/v2",
+            "source": source or {"kind": "invocations", "value": [argv]},
+        }
+    )
+
+
+def _legacy_account_mutation_authorization(
+    argv: list[str], cwd: str, source: dict[str, Any] | None = None
+) -> str:
+    return _authorization_digest(
+        {
+            "argv": argv,
+            "cwd": os.path.realpath(cwd),
+            "schema": "aidevops-command-authorization/v1",
+            "source": source or {"kind": "invocations", "value": [argv]},
+        }
+    )
+
+
+def _authorization_matches(
+    context: _AccountMutationContext,
+    argv: list[str],
+    cwd: str,
+) -> bool:
+    if not context.authorization:
+        return False
+    current = account_mutation_authorization(
+        argv, cwd, context.source, context.workspace_root
+    )
+    legacy = _legacy_account_mutation_authorization(argv, cwd, context.source)
+    return secrets.compare_digest(
+        context.authorization, current
+    ) or secrets.compare_digest(
+        context.authorization, legacy
+    )
+
+
+def _evaluate_account_mutation(
+    invocations: list[list[str]],
+    cwd: str,
+    policy: dict[str, Any],
+    context: _AccountMutationContext,
+) -> dict[str, Any]:
+    guard = _account_mutation_guard(policy)
+    mutations = [
+        argv
+        for argv in invocations
+        if _is_protected_account_mutation(argv, guard["command_paths"])
+    ]
+    if not mutations:
+        return _decision(
+            "allow",
+            "github.no-account-mutation",
+            "No protected GitHub account mutation detected",
+        )
+    if len(invocations) != 1 or len(mutations) != 1:
+        return _decision(
+            "forbid",
+            guard["id"],
+            "Protected GitHub account mutations must be authorized as one exact command",
+        )
+    # #aidevops:trust-boundary — only inherited authorization and workspace
+    # context can cross this gate; command-local assignments are rejected.
+    if _authorization_matches(context, mutations[0], cwd):
+        return _decision(
+            "allow",
+            "github.account-mutation-authorized",
+            "Exact GitHub account mutation matches trusted authorization",
+        )
+    return _decision(
+        "forbid",
+        guard["id"],
+        "GitHub account mutation requires exact trusted authorization",
+    )

--- a/.agents/scripts/command_policy_config.py
+++ b/.agents/scripts/command_policy_config.py
@@ -123,6 +123,11 @@ def _validate_account_mutation_guard(guards: Any) -> None:
         )
     guard = matches[0]
     command_paths = guard.get("command_paths")
+    required_paths = {
+        ("repo", "create"),
+        ("repo", "fork"),
+        ("repo", "new"),
+    }
     valid_paths = (
         isinstance(command_paths, list)
         and bool(command_paths)
@@ -137,8 +142,10 @@ def _validate_account_mutation_guard(guards: Any) -> None:
         guard.get("decision") != "forbid"
         or guard.get("authorization_env")
         != "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION"
+        or guard.get("workspace_root_env")
+        != "AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT"
         or not valid_paths
-        or ["repo", "fork"] not in command_paths
+        or not required_paths.issubset(map(tuple, command_paths))
     ):
         raise PolicyError("trusted account-mutation guard is malformed")
 

--- a/.agents/scripts/command_policy_config.py
+++ b/.agents/scripts/command_policy_config.py
@@ -128,6 +128,14 @@ def _validate_account_mutation_guard(guards: Any) -> None:
         ("repo", "fork"),
         ("repo", "new"),
     }
+    required_values = {
+        "decision": "forbid",
+        "authorization_env": "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION",
+        "workspace_root_env": "AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT",
+    }
+    valid_values = all(
+        guard.get(key) == expected for key, expected in required_values.items()
+    )
     valid_paths = (
         isinstance(command_paths, list)
         and bool(command_paths)
@@ -138,15 +146,10 @@ def _validate_account_mutation_guard(guards: Any) -> None:
             for path in command_paths
         )
     )
-    if (
-        guard.get("decision") != "forbid"
-        or guard.get("authorization_env")
-        != "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION"
-        or guard.get("workspace_root_env")
-        != "AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT"
-        or not valid_paths
-        or not required_paths.issubset(map(tuple, command_paths))
-    ):
+    has_required_paths = valid_paths and required_paths.issubset(
+        map(tuple, command_paths)
+    )
+    if not valid_values or not has_required_paths:
         raise PolicyError("trusted account-mutation guard is malformed")
 
 

--- a/.agents/scripts/command_policy_evaluation.py
+++ b/.agents/scripts/command_policy_evaluation.py
@@ -5,18 +5,22 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
-import secrets
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from command_policy_account_mutation import (
+    _AccountMutationContext,
+    _account_mutation_guard as _account_mutation_guard,
+    _evaluate_account_mutation,
+    account_mutation_authorization as account_mutation_authorization,
+)
 from command_policy_config import _decision
-from command_policy_matchers import _matches, _matches_gh_command_path
+from command_policy_matchers import _matches
 from command_policy_process_termination import (
     _evaluate_process_termination,
     _process_termination_guard_path,
@@ -37,6 +41,7 @@ class _EvaluationOptions:
     runtime_pid: int = 0
     runtime_process_identity: str = ""
     process_table_fixture: str = ""
+    account_mutation_workspace_root: str | None = None
 
 
 def _evaluate_static(
@@ -192,70 +197,6 @@ def _evaluate_worker_network(
     )
 
 
-def _account_mutation_guard(policy: dict[str, Any]) -> dict[str, Any]:
-    return next(
-        guard
-        for guard in policy["dynamic_guards"]
-        if guard["kind"] == "trusted_account_mutation"
-    )
-
-
-def account_mutation_authorization(
-    argv: list[str], cwd: str, source: dict[str, Any] | None = None
-) -> str:
-    payload = {
-        "argv": argv,
-        "cwd": os.path.realpath(cwd),
-        "schema": "aidevops-command-authorization/v1",
-        "source": source or {"kind": "invocations", "value": [argv]},
-    }
-    canonical = json.dumps(
-        payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
-    ).encode("utf-8")
-    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
-
-
-def _evaluate_account_mutation(
-    invocations: list[list[str]],
-    cwd: str,
-    policy: dict[str, Any],
-    authorization: str,
-    source: dict[str, Any] | None,
-) -> dict[str, Any]:
-    guard = _account_mutation_guard(policy)
-    mutations = [
-        argv
-        for argv in invocations
-        if _matches_gh_command_path(argv, guard["command_paths"])
-    ]
-    if not mutations:
-        return _decision(
-            "allow",
-            "github.no-account-mutation",
-            "No protected GitHub account mutation detected",
-        )
-    if len(invocations) != 1 or len(mutations) != 1:
-        return _decision(
-            "forbid",
-            guard["id"],
-            "Protected GitHub account mutations must be authorized as one exact command",
-        )
-    expected = account_mutation_authorization(mutations[0], cwd, source)
-    # #aidevops:trust-boundary — only an authorization inherited by the policy
-    # process can cross this gate; command-local attempts are rejected while parsing.
-    if authorization and secrets.compare_digest(authorization, expected):
-        return _decision(
-            "allow",
-            "github.account-mutation-authorized",
-            "Exact GitHub account mutation matches trusted authorization",
-        )
-    return _decision(
-        "forbid",
-        guard["id"],
-        "GitHub account mutation requires exact trusted authorization",
-    )
-
-
 def evaluate_invocations(
     invocations: list[list[str]],
     cwd: str,
@@ -276,8 +217,11 @@ def evaluate_invocations(
             invocations,
             cwd,
             policy,
-            options.account_mutation_authorization,
-            options.account_mutation_source,
+            _AccountMutationContext(
+                authorization=options.account_mutation_authorization,
+                source=options.account_mutation_source,
+                workspace_root=options.account_mutation_workspace_root,
+            ),
         ),
         _evaluate_process_termination(
             invocations,
@@ -315,6 +259,7 @@ def _evaluation_options(
         "runtime_pid",
         "runtime_process_identity",
         "process_table_fixture",
+        "account_mutation_workspace_root",
     )
     if len(legacy_options) > len(names):
         maximum_arguments = len(names) + 3

--- a/.agents/scripts/command_policy_evaluation.py
+++ b/.agents/scripts/command_policy_evaluation.py
@@ -17,7 +17,7 @@ from command_policy_account_mutation import (
     _AccountMutationContext,
     _account_mutation_guard as _account_mutation_guard,
     _evaluate_account_mutation,
-    account_mutation_authorization as account_mutation_authorization,
+    account_mutation_authorization as _account_mutation_authorization,
 )
 from command_policy_config import _decision
 from command_policy_matchers import _matches
@@ -27,6 +27,16 @@ from command_policy_process_termination import (
 )
 
 DECISION_RANK = {"allow": 0, "forbid": 1}
+
+
+def account_mutation_authorization(
+    argv: list[str],
+    cwd: str,
+    source: dict[str, Any] | None = None,
+    workspace_root: str | None = None,
+) -> str:
+    """Preserve the original command-policy evaluation import surface."""
+    return _account_mutation_authorization(argv, cwd, source, workspace_root)
 
 
 @dataclass(frozen=True)

--- a/.agents/scripts/command_policy_runtime.py
+++ b/.agents/scripts/command_policy_runtime.py
@@ -10,6 +10,9 @@ import json
 import os
 import sys
 
+from command_policy_account_mutation import (
+    account_mutation_workspace_root_from_environment,
+)
 from command_policy_config import PolicyError, _policy_error
 from command_policy_dispatch import analyze_network_argv
 
@@ -62,6 +65,10 @@ def _argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--account-mutation-authorization",
         default=os.environ.get("AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION", ""),
+    )
+    parser.add_argument(
+        "--account-mutation-workspace-root",
+        default=account_mutation_workspace_root_from_environment(),
     )
     return parser
 

--- a/.agents/scripts/command_policy_wrapper_options.py
+++ b/.agents/scripts/command_policy_wrapper_options.py
@@ -117,6 +117,7 @@ def _is_safety_sensitive_assignment(name: str) -> bool:
     upper = name.upper()
     return upper.endswith("_PROXY") or upper.startswith("GIT_CONFIG_") or upper in {
         "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION",
+        "AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT",
         "ALL_PROXY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR",
         "GIT_CONFIG_PARAMETERS", "GIT_DIR", "GIT_EXEC_PATH", "GIT_OBJECT_DIRECTORY",
         "GIT_PROXY_COMMAND", "GIT_SSH", "GIT_SSH_COMMAND", "GIT_WORK_TREE",

--- a/.agents/scripts/tests/test-command-policy-helper.sh
+++ b/.agents/scripts/tests/test-command-policy-helper.sh
@@ -110,10 +110,11 @@ assert_authorized_decision() {
 	local expected_status="$4"
 	local expected_pattern="$5"
 	local cwd="${6:-/work}"
+	local workspace_root="${7-}"
 	local output=""
 	local status=0
 
-	output="$(AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION="$authorization" python3 "$HELPER" check-command --cwd "$cwd" --command "$command_text")" || status=$?
+	output="$(AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION="$authorization" AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace_root" python3 "$HELPER" check-command --cwd "$cwd" --command "$command_text")" || status=$?
 	if [[ "$status" -eq "$expected_status" && "$output" == *"$expected_pattern"* ]]; then
 		pass "$name"
 	else
@@ -209,15 +210,22 @@ test_account_mutation_authorization() {
 	assert_decision "blocks shell-launched repository fork" "bash -lc 'gh repo fork owner/source --clone=false'" forbid github.account-mutation 20 "/work"
 	assert_argv_decision "blocks path-qualified repository fork" forbid github.account-mutation 20 "/work" /usr/local/bin/gh repo fork owner/source --clone=false
 	assert_decision "blocks equivalent repository creation" "gh repo create owner/new-repo --public" forbid github.account-mutation 20 "/work"
+	assert_decision "blocks repository new alias" "gh repo new owner/new-repo --public" forbid github.account-mutation 20 "/work"
 	assert_decision "allows read-only repository view" "gh repo view owner/source" allow command.default-allow 0 "/work"
 	assert_decision "allows read-only issue view" "gh issue view 123" allow command.default-allow 0 "/work"
 	assert_decision "allows read-only pull request view" "gh pr view 456" allow command.default-allow 0 "/work"
+	assert_decision "allows repository fork help" "gh repo fork --help" allow command.default-allow 0 "/work"
+	assert_decision "allows repository create help" "gh repo create --help" allow command.default-allow 0 "/work"
+	assert_decision "allows repository new help" "gh repo new --help" allow command.default-allow 0 "/work"
+	assert_decision "does not mistake an option value for help-only invocation" "gh repo create owner/new-repo --description --help --public" forbid github.account-mutation 20 "/work"
 	assert_decision "fails closed on malformed repository fork" "gh repo fork 'owner/source" forbid command.parse-error 20 "/work"
 	assert_decision "rejects inline authorization injection" "AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION=sha256:fake gh repo fork owner/source" forbid command.parse-error 20 "/work"
 	assert_decision "rejects wrapped authorization injection" "env AIDEVOPS_ACCOUNT_MUTATION_AUTHORIZATION=sha256:fake gh repo fork owner/source" forbid command.parse-error 20 "/work"
+	assert_decision "rejects inline workspace-root override" "AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT=/tmp gh repo fork owner/source --clone=false" forbid command.parse-error 20 "/work"
+	assert_decision "rejects wrapped workspace-root override" "env AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT=/tmp gh repo fork owner/source --clone=false" forbid command.parse-error 20 "/work"
 	assert_decision "rejects GitHub target environment override" "GH_REPO=other/target gh repo fork owner/source" forbid command.parse-error 20 "/work"
 
-	authorization="$(python3 "$HELPER" authorization-digest --cwd /work --command "$command_text")" || status=$?
+	authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="" python3 "$HELPER" authorization-digest --cwd /work --command "$command_text")" || status=$?
 	if [[ "$status" -eq 0 && "$authorization" =~ ^sha256:[a-f0-9]{64}$ ]]; then
 		pass "generates a content-bound account-mutation authorization"
 	else
@@ -231,6 +239,129 @@ test_account_mutation_authorization() {
 	assert_authorized_decision "authorization remains bound to the approved working directory" "$authorization" "$command_text" 20 "github.account-mutation" "/different"
 	assert_authorized_decision "fork authorization does not grant another account write" "$authorization" "gh repo create owner/new-repo --public" 20 "github.account-mutation"
 	assert_authorized_decision "authorization cannot widen a compound command" "$authorization" "$command_text && printf done" 20 "github.account-mutation"
+	return 0
+}
+
+test_account_mutation_workspace_authorization() {
+	local workspace="${TEST_ROOT}/projects"
+	local repo_a="${workspace}/repo-a"
+	local repo_b="${workspace}/repo-b"
+	local outside="${TEST_ROOT}/outside"
+	local sibling="${workspace}-sibling"
+	local escape="${workspace}/escape"
+	local command_text="gh repo fork owner/source --clone=false"
+	local authorization=""
+	local exact_authorization=""
+	local legacy_authorization=""
+
+	mkdir -p "$repo_a" "$repo_b" "$outside" "$sibling"
+	ln -s "$outside" "$escape"
+
+	if env -u AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT python3 - "$SCRIPT_DIR" <<'PY'; then
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[1])
+from command_policy_account_mutation import account_mutation_workspace_root_from_environment
+
+assert account_mutation_workspace_root_from_environment() == str(Path.home() / "Git")
+PY
+		pass "defaults account-mutation workspace to the projects root"
+	else
+		fail "defaults account-mutation workspace to the projects root"
+	fi
+
+	authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$command_text")"
+	assert_authorized_decision "workspace authorization permits the same remote-only fork from a sibling repository" "$authorization" "$command_text" 0 '"decision": "allow"' "$repo_b" "$workspace"
+	assert_authorized_decision "workspace authorization rejects a directory outside the root" "$authorization" "$command_text" 20 "github.account-mutation" "$outside" "$workspace"
+	assert_authorized_decision "workspace authorization rejects a sibling-prefix directory" "$authorization" "$command_text" 20 "github.account-mutation" "$sibling" "$workspace"
+	assert_authorized_decision "workspace authorization rejects a symlink escape" "$authorization" "$command_text" 20 "github.account-mutation" "$escape" "$workspace"
+
+	local create_command="gh repo create owner/new-repo --public"
+	authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$create_command")"
+	assert_authorized_decision "workspace authorization permits explicit remote-only repository creation" "$authorization" "$create_command" 0 '"decision": "allow"' "$repo_b" "$workspace"
+
+	local new_command="gh repo new owner/new-alias --private"
+	authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$new_command")"
+	assert_authorized_decision "workspace authorization permits the repository new alias" "$authorization" "$new_command" 0 '"decision": "allow"' "$repo_b" "$workspace"
+
+	local template_command="gh repo create owner/from-template --private --template owner/base"
+	authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$template_command")"
+	assert_authorized_decision "workspace authorization permits an explicit remote template" "$authorization" "$template_command" 0 '"decision": "allow"' "$repo_b" "$workspace"
+
+	local local_template_command="gh repo create owner/from-local --private --template ."
+	exact_authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$local_template_command")"
+	assert_authorized_decision "ambiguous repository templates remain exact-CWD-bound" "$exact_authorization" "$local_template_command" 20 "github.account-mutation" "$repo_b" "$workspace"
+
+	local local_fork_command="gh repo fork owner/source"
+	exact_authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$local_fork_command")"
+	assert_authorized_decision "exact authorization permits a clone-capable fork only in its original directory" "$exact_authorization" "$local_fork_command" 0 '"decision": "allow"' "$repo_a" "$workspace"
+	assert_authorized_decision "clone-capable fork authorization remains exact-CWD-bound" "$exact_authorization" "$local_fork_command" 20 "github.account-mutation" "$repo_b" "$workspace"
+
+	local local_create_command="gh repo create owner/local-source --public --source=."
+	exact_authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$local_create_command")"
+	assert_authorized_decision "source-based repository creation remains exact-CWD-bound" "$exact_authorization" "$local_create_command" 20 "github.account-mutation" "$repo_b" "$workspace"
+
+	local false_visibility_command="gh repo create owner/ambiguous --public=false"
+	exact_authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$false_visibility_command")"
+	assert_authorized_decision "false visibility does not qualify for workspace scope" "$exact_authorization" "$false_visibility_command" 20 "github.account-mutation" "$repo_b" "$workspace"
+
+	local url_fork_command="gh repo fork https://github.com/owner/source --clone=false"
+	exact_authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$workspace" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$url_fork_command")"
+	assert_authorized_decision "non-owner-repository fork targets remain exact-CWD-bound" "$exact_authorization" "$url_fork_command" 20 "github.account-mutation" "$repo_b" "$workspace"
+
+	local invalid_root="${TEST_ROOT}/missing-projects"
+	for invalid_root in "" "/" "$HOME" "${TEST_ROOT}/missing-projects"; do
+		exact_authorization="$(AIDEVOPS_ACCOUNT_MUTATION_WORKSPACE_ROOT="$invalid_root" python3 "$HELPER" authorization-digest --cwd "$repo_a" --command "$command_text")"
+		assert_authorized_decision "invalid or disabled workspace root preserves exact-CWD binding: ${invalid_root:-empty}" "$exact_authorization" "$command_text" 20 "github.account-mutation" "$repo_b" "$invalid_root"
+	done
+
+	legacy_authorization="$(
+		python3 - "$SCRIPT_DIR" "$command_text" "$repo_a" <<'PY'
+import sys
+
+script_dir, command, cwd = sys.argv[1:]
+sys.path.insert(0, script_dir)
+from command_policy_account_mutation import _legacy_account_mutation_authorization
+
+argv = ["gh", "repo", "fork", "owner/source", "--clone=false"]
+source = {"kind": "command", "value": command}
+print(_legacy_account_mutation_authorization(argv, cwd, source))
+PY
+	)"
+	assert_authorized_decision "legacy v1 authorization remains valid in its original directory" "$legacy_authorization" "$command_text" 0 '"decision": "allow"' "$repo_a" "$workspace"
+	assert_authorized_decision "legacy v1 authorization does not gain workspace scope" "$legacy_authorization" "$command_text" 20 "github.account-mutation" "$repo_b" "$workspace"
+	return 0
+}
+
+test_account_mutation_guard_validation() {
+	local malformed_guard="${TEST_ROOT}/malformed-account-guard.json"
+	local output=""
+	local status=0
+
+	python3 - "$POLICY" "$malformed_guard" <<'PY'
+import json
+import sys
+
+source, target = sys.argv[1:]
+with open(source, encoding="utf-8") as handle:
+    candidate = json.load(handle)
+candidate["dynamic_guards"] = [dict(guard) for guard in candidate["dynamic_guards"]]
+account_guard = next(
+    guard
+    for guard in candidate["dynamic_guards"]
+    if guard.get("kind") == "trusted_account_mutation"
+)
+account_guard.pop("workspace_root_env")
+with open(target, "w", encoding="utf-8") as handle:
+    json.dump(candidate, handle)
+PY
+	output="$(python3 "$HELPER" check-command --policy "$malformed_guard" --command "printf safe")" || status=$?
+	if [[ "$status" -eq 21 && "$output" == *policy.invalid* && "$output" == *account-mutation* ]]; then
+		pass "malformed account-mutation workspace guard fails closed"
+	else
+		fail "malformed account-mutation workspace guard fails closed" "status=${status} output=${output}"
+	fi
 	return 0
 }
 
@@ -638,6 +769,8 @@ main() {
 	test_process_table_parser
 	test_process_termination_policy
 	test_account_mutation_authorization
+	test_account_mutation_workspace_authorization
+	test_account_mutation_guard_validation
 	test_canonical_delegation
 	test_worker_network_policy
 	test_policy_fail_closed

--- a/.agents/scripts/tests/test-command-policy-helper.sh
+++ b/.agents/scripts/tests/test-command-policy-helper.sh
@@ -176,6 +176,7 @@ spec = importlib.util.spec_from_file_location("command_policy_helper", helper_pa
 module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
+evaluation = sys.modules["command_policy_evaluation"]
 policy = module._load_policy(policy_path)
 expected = module.evaluate_invocations([["printf", "safe"]], "/work", policy)
 positional = module.evaluate_invocations(
@@ -191,6 +192,11 @@ keyword = module.evaluate_invocations(
     network_helper="",
 )
 assert expected == positional == keyword
+assert evaluation.account_mutation_authorization(
+    ["gh", "repo", "fork", "owner/source", "--clone=false"],
+    "/work",
+    workspace_root="",
+).startswith("sha256:")
 PY
 		pass "evaluate_invocations preserves positional and keyword interfaces"
 	else


### PR DESCRIPTION
## Summary

Scope exact GitHub repository-mutation authorization across trusted project directories only for explicit remote-only commands, while preserving exact-CWD protection for local-effect forms.

## Files Changed

.agents/configs/command-policy.json, .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs, .agents/reference/gh-command-discipline.md, .agents/scripts/command-policy-helper.py, .agents/scripts/command_policy_account_mutation.py, .agents/scripts/command_policy_config.py, .agents/scripts/command_policy_evaluation.py, .agents/scripts/command_policy_runtime.py, .agents/scripts/command_policy_wrapper_options.py, .agents/scripts/tests/test-command-policy-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with command-policy CLI tests (129/129), OpenCode safety-gate tests (17/17), full OpenCode plugin tests (468/468), changed and full local linter suites, Python compilation, ShellCheck, shfmt, and zero Qlty smells in the new module.

Resolves #28494


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.165 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 45m and 540,015 tokens on this with the user in an interactive session.