### PR TITLE
GH#28497: Add managed Cloudron package lifecycle automation

### DIFF
--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -87,6 +87,36 @@ Global equivalent: `orchestration.interactive_pr_auto_merge` in `~/.config/aidev
 | `app_type` | string | FOSS repo type: `wordpress-plugin`, `php-composer`, `node`, `python`, `go`, `macos-app`, `browser-extension`, `cli-tool`, `electron`, `cloudron-package`, `generic` |
 | `foss_config` | object | Per-repo FOSS controls (see below) |
 
+### `cloudron_package` object fields
+
+When `CloudronManifest.json` exists, `aidevops init` safely defaults
+`app_type` to `cloudron-package` and adds lifecycle metadata without replacing
+explicit values. Package slugs and paths remain local to `repos.json`.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `manifest` | `CloudronManifest.json` | Manifest path relative to the registered repository root. Absolute paths and `..` are rejected by monitors. |
+| `release_workflow` | `.github/workflows/cloudron-package-release.yml` | Thin tag-triggered caller scaffolded by `aidevops init`; existing files are never overwritten. |
+| `upstream_slug` | unset | Upstream GitHub `owner/repo` used for stable-release comparison. Monitoring stays disabled until this is explicitly configured. |
+| `monitor_upstream` | `true` when `upstream_slug` is set; otherwise `false` | Include the package in the daily upstream-release routine. |
+| `monitor_compatibility` | `true` | Include the package in the weekly manifest and pinned-base audit. |
+
+```json
+{
+  "app_type": "cloudron-package",
+  "cloudron_package": {
+    "manifest": "CloudronManifest.json",
+    "upstream_slug": "exampleorg/example-upstream",
+    "monitor_upstream": true,
+    "monitor_compatibility": true
+  }
+}
+```
+
+The monitors file deduplicated findings only in the package repository and only
+with `ADMIN` or `MAINTAIN` authority. They never build, tag, publish, deploy, or
+mutate package source. See `tools/deployment/cloudron-app-packaging.md`.
+
 ### `foss_config` object fields
 
 | Key | Default | Description |

--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -1511,6 +1511,7 @@ _init_optional_scaffolding() {
 	_init_scaffold_scope_gated_files "$project_root" "$init_scope" "$repo_name" "$has_interface"
 
 	_init_configure_coderabbit_abort_on_close "$project_root" "$enable_code_quality"
+	_init_scaffold_cloudron_release_workflow "$project_root" || return 1
 
 	# ─── Badge + local repo metrics initialization (t2975) ───────────────────
 	# Seed the canonical README badge block, generate local metrics artifacts,
@@ -1586,6 +1587,25 @@ _init_optional_scaffolding() {
 	fi
 
 	_init_security_and_registration || return 1
+	return 0
+}
+
+_init_scaffold_cloudron_release_workflow() {
+	local target_root="$1"
+	[[ -f "${target_root}/CloudronManifest.json" ]] || return 0
+	local template_path="${AGENTS_DIR}/templates/workflows/cloudron-package-release-caller.yml"
+	local workflow_path="${target_root}/.github/workflows/cloudron-package-release.yml"
+	if [[ -f "$workflow_path" ]]; then
+		print_info ".github/workflows/cloudron-package-release.yml already present"
+		return 0
+	fi
+	if [[ ! -f "$template_path" ]]; then
+		print_warning "Cloudron package release caller template is unavailable"
+		return 1
+	fi
+	mkdir -p "${target_root}/.github/workflows"
+	cp "$template_path" "$workflow_path"
+	print_success "Installed .github/workflows/cloudron-package-release.yml"
 	return 0
 }
 

--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -447,6 +447,46 @@ _repo_registration_maintainer() {
 	return 0
 }
 
+_repo_registration_update_existing() {
+	local repo_path="$1"
+	local version="$2"
+	local features="$3"
+	local slug="$4"
+	local is_local_only="$5"
+	local maintainer="$6"
+	local default_pulse="$7"
+	local default_priority="$8"
+	local default_init_scope="$9"
+	local has_interface="${10}"
+	local app_type_default="${11}"
+	local cloudron_defaults="${12}"
+	local cloudron_app_type="${13}"
+	local temp_file="${REPOS_FILE}.tmp"
+	jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
+		--arg slug "$slug" --argjson local_only "$is_local_only" --arg maintainer "$maintainer" \
+		--argjson pulse_default "$default_pulse" --arg priority_default "$default_priority" \
+		--arg init_scope_default "$default_init_scope" --arg has_interface "$has_interface" \
+		--arg app_type_default "$app_type_default" --argjson cloudron_defaults "$cloudron_defaults" \
+		--arg cloudron_app_type "$cloudron_app_type" \
+		'(.initialized_repos[] | select(.path == $path)) |= (
+			. + {path: $path, version: $version, features: ($features | split(",")), updated: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}
+			| if $slug != "" then .slug = $slug else . end
+			| if $local_only then .local_only = true else del(.local_only) end
+			| if .pulse == null then .pulse = (if $local_only then false else $pulse_default end) else . end
+			| if (.priority == null or .priority == "") and $priority_default != "" then .priority = $priority_default else . end
+			| if (.maintainer == null or .maintainer == "") and $maintainer != "" then .maintainer = $maintainer else . end
+			| if (.init_scope == null or .init_scope == "") then .init_scope = $init_scope_default else . end
+			| if $has_interface == "true" then .has_interface = true elif $has_interface == "false" then .has_interface = false else . end
+			| if (.app_type == null or .app_type == "") and $app_type_default != "" then .app_type = $app_type_default else . end
+			| if .app_type == $cloudron_app_type and $app_type_default == $cloudron_app_type then
+				.cloudron_package = ($cloudron_defaults + (if (.cloudron_package | type) == "object" then .cloudron_package else {} end))
+				| if .cloudron_package.monitor_upstream == null then .cloudron_package.monitor_upstream = ((.cloudron_package.upstream_slug // "") != "") else . end
+			  else . end
+		)' \
+		"$REPOS_FILE" >"$temp_file" && mv "$temp_file" "$REPOS_FILE"
+	return $?
+}
+
 # Register a repo in repos.json
 # Usage: register_repo <path> <version> <features>
 register_repo() {
@@ -504,30 +544,26 @@ register_repo() {
 
 	local has_interface
 	has_interface=$(_repo_config_has_interface_value "$repo_path")
+	local cloudron_app_type="cloudron-package"
+	local app_type_default=""
+	local cloudron_defaults='{}'
+	if [[ -f "${repo_path}/CloudronManifest.json" ]]; then
+		app_type_default="$cloudron_app_type"
+		cloudron_defaults='{"manifest":"CloudronManifest.json","release_workflow":".github/workflows/cloudron-package-release.yml","monitor_compatibility":true}'
+	fi
 
 	if jq -e --arg path "$repo_path" '.initialized_repos[] | select(.path == $path)' "$REPOS_FILE" &>/dev/null; then
-		local temp_file="${REPOS_FILE}.tmp"
-		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
-			--arg slug "$slug" --argjson local_only "$is_local_only" --arg maintainer "$maintainer" \
-			--argjson pulse_default "$DEFAULT_PULSE" --arg priority_default "$DEFAULT_PRIORITY" \
-			--arg init_scope_default "$default_init_scope" --arg has_interface "$has_interface" \
-			'(.initialized_repos[] | select(.path == $path)) |= (
-				. + {path: $path, version: $version, features: ($features | split(",")), updated: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}
-				| if $slug != "" then .slug = $slug else . end
-				| if $local_only then .local_only = true else del(.local_only) end
-				| if .pulse == null then .pulse = (if $local_only then false else $pulse_default end) else . end
-				| if (.priority == null or .priority == "") and $priority_default != "" then .priority = $priority_default else . end
-				| if (.maintainer == null or .maintainer == "") and $maintainer != "" then .maintainer = $maintainer else . end
-				| if (.init_scope == null or .init_scope == "") then .init_scope = $init_scope_default else . end
-				| if $has_interface == "true" then .has_interface = true elif $has_interface == "false" then .has_interface = false else . end
-			)' \
-			"$REPOS_FILE" >"$temp_file" && mv "$temp_file" "$REPOS_FILE"
+		_repo_registration_update_existing "$repo_path" "$version" "$features" "$slug" \
+			"$is_local_only" "$maintainer" "$DEFAULT_PULSE" "$DEFAULT_PRIORITY" \
+			"$default_init_scope" "$has_interface" "$app_type_default" "$cloudron_defaults" "$cloudron_app_type" || return 1
 	else
 		local temp_file="${REPOS_FILE}.tmp"
 		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
 			--arg slug "$slug" --arg maintainer "$maintainer" \
 			--argjson local_only "$is_local_only" --argjson pulse_default "$DEFAULT_PULSE" \
 			--arg priority_default "$DEFAULT_PRIORITY" --arg init_scope "$default_init_scope" --arg has_interface "$has_interface" \
+			--arg app_type_default "$app_type_default" --argjson cloudron_defaults "$cloudron_defaults" \
+			--arg cloudron_app_type "$cloudron_app_type" \
 			'.initialized_repos += [(
 				{
 					path: $path,
@@ -542,6 +578,10 @@ register_repo() {
 				| if $local_only then . + {local_only: true, pulse: false} else . end
 				| if $priority_default != "" then . + {priority: $priority_default} else . end
 				| if $has_interface == "true" then . + {has_interface: true} elif $has_interface == "false" then . + {has_interface: false} else . end
+				| if $app_type_default != "" then . + {app_type: $app_type_default} else . end
+				| if $app_type_default == $cloudron_app_type then
+					.cloudron_package = ($cloudron_defaults + {monitor_upstream: false})
+				  else . end
 			)]' \
 			"$REPOS_FILE" >"$temp_file" && mv "$temp_file" "$REPOS_FILE"
 	fi

--- a/.agents/scripts/cloudron-package-helper.sh
+++ b/.agents/scripts/cloudron-package-helper.sh
@@ -16,10 +16,15 @@
 #   debug-off [app]       Disable debug mode
 #   test [app]            Run validation checklist
 #   scaffold [type]       Generate boilerplate (php|node|python|go|static|multi-process)
+#   prepare-release       Update manifest/changelog without publishing
+#   check-release         Validate manifest/changelog/tag release invariants
+#   check-compatibility   Audit manifest and final Cloudron base image
 #   status                Show current package status
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=cloudron-package-release-lib.sh
+source "${SCRIPT_DIR}/cloudron-package-release-lib.sh"
 
 set -euo pipefail
 
@@ -1012,6 +1017,27 @@ cmd_status() {
 	[[ -f "start.sh" ]] && echo "  [x] start.sh" || echo "  [ ] start.sh"
 	[[ -f "logo.png" ]] && echo "  [x] logo.png" || echo "  [ ] logo.png (recommended)"
 	echo ""
+	return 0
+}
+
+cmd_prepare_release() {
+	cloudron_package_prepare_release "$@"
+	return $?
+}
+
+cmd_check_release() {
+	cloudron_package_check_release "$@"
+	return $?
+}
+
+cmd_check_compatibility() {
+	local findings=""
+	if findings=$(cloudron_package_compatibility_findings "."); then
+		printf 'Cloudron package compatibility validation passed.\n'
+		return 0
+	fi
+	printf '%s\n' "$findings" >&2
+	return 1
 }
 
 # Show help
@@ -1033,6 +1059,10 @@ Commands:
   debug-off [app]       Disable debug mode
   test [app]            Show validation checklist
   scaffold <type>       Generate boilerplate (php|node|python|go|static|multi-process)
+  prepare-release <package-version> <upstream-version> <notes-file>
+                        Update manifest/changelog without publishing
+  check-release <tag>   Validate package, changelog, and vX.Y.Z tag
+  check-compatibility   Audit manifest and final pinned Cloudron base image
   status                Show current package status
   help                  Show this help
 
@@ -1044,6 +1074,8 @@ Examples:
   cloudron-package-helper.sh install testapp
   cloudron-package-helper.sh update
   cloudron-package-helper.sh logs testapp
+  cloudron-package-helper.sh prepare-release 1.2.0 4.5.6 release-notes.md
+  cloudron-package-helper.sh check-release v1.2.0
 
 Documentation:
   https://docs.cloudron.io/packaging/
@@ -1091,6 +1123,15 @@ main() {
 	scaffold)
 		cmd_scaffold "$@"
 		;;
+	prepare-release)
+		cmd_prepare_release "$@"
+		;;
+	check-release)
+		cmd_check_release "$@"
+		;;
+	check-compatibility)
+		cmd_check_compatibility "$@"
+		;;
 	status)
 		cmd_status "$@"
 		;;
@@ -1103,6 +1144,7 @@ main() {
 		return 1
 		;;
 	esac
+	return $?
 }
 
 main "$@"

--- a/.agents/scripts/cloudron-package-monitor-helper.sh
+++ b/.agents/scripts/cloudron-package-monitor-helper.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Monitor registered Cloudron packages and file package-local findings.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=cloudron-package-release-lib.sh
+source "${SCRIPT_DIR}/cloudron-package-release-lib.sh"
+
+REPOS_FILE="${AIDEVOPS_REPOS_FILE:-${HOME}/.config/aidevops/repos.json}"
+
+_cloudron_monitor_error() {
+	local message="$1"
+	printf 'ERROR: %s\n' "$message" >&2
+	return 1
+}
+
+_cloudron_monitor_require_tools() {
+	command -v jq >/dev/null 2>&1 || _cloudron_monitor_error "jq is required." || return 1
+	command -v gh >/dev/null 2>&1 || _cloudron_monitor_error "GitHub CLI is required." || return 1
+	[[ -f "$REPOS_FILE" ]] || _cloudron_monitor_error "repos.json not found: $REPOS_FILE" || return 1
+	jq -e '.initialized_repos | type == "array"' "$REPOS_FILE" >/dev/null 2>&1 || _cloudron_monitor_error "repos.json has no initialized_repos array." || return 1
+	return 0
+}
+
+_cloudron_monitor_version_newer() {
+	local candidate="${1#v}"
+	local current="${2#v}"
+	cloudron_package_is_semver "$candidate" || return 1
+	cloudron_package_is_semver "$current" || return 0
+	local candidate_core="${candidate%%[-+]*}"
+	local current_core="${current%%[-+]*}"
+	local candidate_major=0 candidate_minor=0 candidate_patch=0
+	local current_major=0 current_minor=0 current_patch=0
+	IFS=. read -r candidate_major candidate_minor candidate_patch <<<"$candidate_core"
+	IFS=. read -r current_major current_minor current_patch <<<"$current_core"
+	if ((candidate_major != current_major)); then
+		((candidate_major > current_major))
+		return $?
+	fi
+	if ((candidate_minor != current_minor)); then
+		((candidate_minor > current_minor))
+		return $?
+	fi
+	if ((candidate_patch != current_patch)); then
+		((candidate_patch > current_patch))
+		return $?
+	fi
+	if [[ "$candidate" != *-* && "$current" == *-* ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_cloudron_monitor_has_authority() {
+	local slug="$1"
+	local permission=""
+	permission=$(gh repo view "$slug" --json viewerPermission --jq '.viewerPermission') || return 1
+	case "$permission" in
+	ADMIN | MAINTAIN) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+_cloudron_monitor_issue_exists() {
+	local slug="$1"
+	local fingerprint="$2"
+	local issue_number=""
+	if ! issue_number=$(gh issue list --repo "$slug" --state all --search "${fingerprint} in:body" --limit 1 --json number --jq '.[0].number // empty'); then
+		return 2
+	fi
+	[[ -n "$issue_number" ]]
+	return $?
+}
+
+_cloudron_monitor_create_issue() {
+	local slug="$1"
+	local title="$2"
+	local fingerprint="$3"
+	local summary="$4"
+	local verification="$5"
+	local body_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local body_file=""
+	local issue_wrapper="${CLOUDRON_PACKAGE_ISSUE_WRAPPER:-gh_create_issue}"
+	command -v "$issue_wrapper" >/dev/null 2>&1 || _cloudron_monitor_error "gh_create_issue wrapper is required for managed issue writes." || return 1
+	mkdir -p "$body_dir"
+	body_file=$(mktemp "${body_dir}/cloudron-package-monitor.XXXXXX") || return 1
+	cat >"$body_file" <<EOF
+<!-- aidevops:cloudron-package-monitor ${fingerprint} -->
+## What
+
+${summary}
+
+The monitor did not build, publish, tag, deploy, or modify package source.
+
+## Files to inspect
+
+- \`CloudronManifest.json\` — package and upstream version metadata.
+- \`Dockerfile\` or \`Dockerfile.cloudron\` — final Cloudron base image and packaged upstream artifacts.
+- \`CHANGELOG.md\` — package release notes before any version bump.
+
+## Acceptance criteria
+
+- Reproduce and assess the finding against current upstream and Cloudron packaging guidance.
+- Update package source and tests only when the finding remains actionable.
+- Run the package release check before proposing a tag.
+- Do not publish a release, image, catalog entry, or deployment without separate operator authorization.
+
+## Verification
+
+${verification}
+EOF
+	if "$issue_wrapper" --repo "$slug" --title "$title" --body-file "$body_file" \
+		--label "type:maintenance" --label "tier:standard" --label "auto-dispatch" >/dev/null; then
+		rm -f "$body_file"
+		printf 'Created Cloudron package finding in %s: %s\n' "$slug" "$title"
+		return 0
+	fi
+	rm -f "$body_file"
+	return 1
+}
+
+_cloudron_monitor_apply_finding() {
+	local apply="$1"
+	local slug="$2"
+	local title="$3"
+	local fingerprint="$4"
+	local summary="$5"
+	local verification="$6"
+	local exists_rc=0
+	if _cloudron_monitor_issue_exists "$slug" "$fingerprint"; then
+		printf 'Already handled in %s: %s\n' "$slug" "$fingerprint"
+		return 0
+	else
+		exists_rc=$?
+	fi
+	[[ "$exists_rc" -ne 2 ]] || _cloudron_monitor_error "Could not check issue deduplication for $slug." || return 1
+	if [[ "$apply" != true ]]; then
+		printf 'FINDING %s %s\n' "$slug" "$title"
+		return 0
+	fi
+	_cloudron_monitor_has_authority "$slug" || _cloudron_monitor_error "ADMIN or MAINTAIN issue authority is required for $slug." || return 1
+	_cloudron_monitor_create_issue "$slug" "$title" "$fingerprint" "$summary" "$verification"
+	return $?
+}
+
+_cloudron_monitor_upstream_entry() {
+	local entry="$1"
+	local apply="$2"
+	local slug=""
+	local repo_path=""
+	local manifest_rel=""
+	local upstream_slug=""
+	local monitor_enabled=""
+	slug=$(jq -r '.slug // empty' <<<"$entry")
+	repo_path=$(jq -r '.path // empty' <<<"$entry")
+	manifest_rel=$(jq -r '.cloudron_package.manifest // "CloudronManifest.json"' <<<"$entry")
+	upstream_slug=$(jq -r '.cloudron_package.upstream_slug // empty' <<<"$entry")
+	monitor_enabled=$(jq -r '.cloudron_package.monitor_upstream // ((.cloudron_package.upstream_slug // "") != "")' <<<"$entry")
+	[[ "$monitor_enabled" == true ]] || return 0
+	[[ "$slug" == */* && "$upstream_slug" == */* ]] || _cloudron_monitor_error "Cloudron upstream monitoring requires target and upstream slugs." || return 1
+	[[ "$manifest_rel" != /* && "$manifest_rel" != *..* ]] || _cloudron_monitor_error "Unsafe manifest path configured for $slug." || return 1
+	repo_path="${repo_path/#\~/$HOME}"
+	local manifest_path="${repo_path}/${manifest_rel}"
+	[[ -f "$manifest_path" ]] || _cloudron_monitor_error "Manifest missing for registered Cloudron package $slug." || return 1
+	local latest_tag=""
+	latest_tag=$(gh api "repos/${upstream_slug}/releases/latest" --jq '.tag_name') || return 1
+	local latest_version="${latest_tag#v}"
+	cloudron_package_is_semver "$latest_version" || _cloudron_monitor_error "Latest release tag for $upstream_slug is not semantic versioning: $latest_tag" || return 1
+	local current_version=""
+	current_version=$(jq -r '.upstreamVersion // empty' "$manifest_path") || return 1
+	if [[ -n "$current_version" ]] && ! _cloudron_monitor_version_newer "$latest_version" "$current_version"; then
+		return 0
+	fi
+	local fingerprint="upstream-v${latest_version}"
+	local title="Cloudron upstream v${latest_version} is available"
+	local summary=""
+	local verification=""
+	printf -v summary "Upstream package \`%s\` released \`v%s\`; the manifest currently records \`%s\`." \
+		"$upstream_slug" "$latest_version" "${current_version:-no upstreamVersion}"
+	printf -v verification "Run \`cloudron-package-helper.sh check-release v<package-version>\` after updating and testing the package."
+	_cloudron_monitor_apply_finding "$apply" "$slug" "$title" "$fingerprint" "$summary" "$verification"
+	return $?
+}
+
+_cloudron_monitor_compatibility_entry() {
+	local entry="$1"
+	local apply="$2"
+	local slug=""
+	local repo_path=""
+	local manifest_rel=""
+	local monitor_enabled=""
+	slug=$(jq -r '.slug // empty' <<<"$entry")
+	repo_path=$(jq -r '.path // empty' <<<"$entry")
+	manifest_rel=$(jq -r '.cloudron_package.manifest // "CloudronManifest.json"' <<<"$entry")
+	monitor_enabled=$(jq -r '.cloudron_package.monitor_compatibility // true' <<<"$entry")
+	[[ "$monitor_enabled" == true ]] || return 0
+	[[ "$slug" == */* ]] || _cloudron_monitor_error "Cloudron compatibility monitoring requires a target slug." || return 1
+	[[ "$manifest_rel" != /* && "$manifest_rel" != *..* ]] || _cloudron_monitor_error "Unsafe manifest path configured for $slug." || return 1
+	repo_path="${repo_path/#\~/$HOME}"
+	[[ -d "$repo_path" ]] || _cloudron_monitor_error "Registered Cloudron package path is unavailable for $slug." || return 1
+	local findings=""
+	if findings=$(cloudron_package_compatibility_findings "$repo_path" "$manifest_rel"); then
+		return 0
+	fi
+	[[ -n "$findings" ]] || return 1
+	local checksum=""
+	checksum=$(printf '%s\n' "$findings" | cksum | awk '{ print $1 }')
+	local fingerprint="compatibility-${checksum}"
+	local title="Cloudron package compatibility audit found actionable drift"
+	local summary=""
+	local verification=""
+	printf -v summary 'The weekly compatibility audit reported:\n\n%s' "$findings"
+	printf -v verification "Run \`cloudron-package-helper.sh check-compatibility\` and the package-specific test suite."
+	_cloudron_monitor_apply_finding "$apply" "$slug" "$title" "$fingerprint" "$summary" "$verification"
+	return $?
+}
+
+_cloudron_monitor_run() {
+	local mode="$1"
+	local apply="$2"
+	local failures=0
+	local entry=""
+	while IFS= read -r entry; do
+		if [[ "$mode" == "upstream" ]]; then
+			_cloudron_monitor_upstream_entry "$entry" "$apply" || failures=$((failures + 1))
+		else
+			_cloudron_monitor_compatibility_entry "$entry" "$apply" || failures=$((failures + 1))
+		fi
+	done < <(jq -c '.initialized_repos[] | select(.app_type == "cloudron-package")' "$REPOS_FILE")
+	[[ "$failures" -eq 0 ]] || return 1
+	return 0
+}
+
+show_help() {
+	cat <<'HELP'
+Cloudron Package Monitor
+
+Usage:
+  cloudron-package-monitor-helper.sh upstream [--apply]
+  cloudron-package-monitor-helper.sh compatibility [--apply]
+
+Without --apply, findings are reported without creating issues. With --apply,
+deduplicated issues are created in each registered package repository after an
+ADMIN/MAINTAIN permission check. No package source or release state is changed.
+HELP
+	return 0
+}
+
+main() {
+	local mode="${1:-help}"
+	local apply=false
+	[[ "${2:-}" == "--apply" ]] && apply=true
+	case "$mode" in
+	upstream | compatibility)
+		_cloudron_monitor_require_tools || return 1
+		_cloudron_monitor_run "$mode" "$apply"
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		_cloudron_monitor_error "Unknown command: $mode" || true
+		show_help
+		return 1
+		;;
+	esac
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/cloudron-package-release-lib.sh
+++ b/.agents/scripts/cloudron-package-release-lib.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Release preparation and validation primitives for managed Cloudron packages.
+
+[[ -n "${_CLOUDRON_PACKAGE_RELEASE_LIB_LOADED:-}" ]] && return 0
+_CLOUDRON_PACKAGE_RELEASE_LIB_LOADED=1
+
+CLOUDRON_PINNED_BASE_IMAGE="cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c"
+
+_cloudron_release_error() {
+	local message="$1"
+	printf 'ERROR: %s\n' "$message" >&2
+	return 1
+}
+
+cloudron_package_is_semver() {
+	local version="$1"
+	[[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]
+	return $?
+}
+
+_cloudron_release_preserve_mode() {
+	local source_file="$1"
+	local target_file="$2"
+	local mode=""
+	mode=$(stat -f '%Lp' "$source_file" 2>/dev/null || stat -c '%a' "$source_file" 2>/dev/null || true)
+	if [[ -n "$mode" ]]; then
+		chmod "$mode" "$target_file" || return 1
+	fi
+	return 0
+}
+
+_cloudron_release_cleanup() {
+	local file_path=""
+	for file_path in "$@"; do
+		[[ -z "$file_path" ]] || rm -f "$file_path"
+	done
+	return 0
+}
+
+_cloudron_release_dockerfile() {
+	local repo_path="$1"
+	if [[ -f "${repo_path}/Dockerfile" ]]; then
+		printf '%s\n' "${repo_path}/Dockerfile"
+		return 0
+	fi
+	if [[ -f "${repo_path}/Dockerfile.cloudron" ]]; then
+		printf '%s\n' "${repo_path}/Dockerfile.cloudron"
+		return 0
+	fi
+	return 1
+}
+
+# Print actionable compatibility findings and return non-zero when any exist.
+cloudron_package_compatibility_findings() {
+	local repo_path="${1:-.}"
+	local manifest_rel="${2:-CloudronManifest.json}"
+	local manifest_path="${repo_path}/${manifest_rel}"
+	local findings=0
+
+	if ! command -v jq >/dev/null 2>&1; then
+		printf '%s\n' '- jq is required to validate CloudronManifest.json.'
+		return 1
+	fi
+	if [[ ! -f "$manifest_path" ]]; then
+		printf '%s\n' "- ${manifest_rel} is missing."
+		return 1
+	fi
+	if ! jq empty "$manifest_path" >/dev/null 2>&1; then
+		printf '%s\n' "- ${manifest_rel} is not valid JSON."
+		return 1
+	fi
+	if ! jq -e '
+		def nonempty_string: type == "string" and length > 0;
+		type == "object" and
+		(.id | nonempty_string) and
+		(.title | nonempty_string) and
+		(.version | nonempty_string) and
+		(.healthCheckPath | nonempty_string) and
+		(.httpPort | type == "number" and . > 0) and
+		(.manifestVersion == 2)
+	' "$manifest_path" >/dev/null 2>&1; then
+		printf '%s\n' '- CloudronManifest.json is missing required package fields or manifestVersion is not 2.'
+		findings=$((findings + 1))
+	fi
+	local package_version=""
+	package_version=$(jq -r '.version // empty' "$manifest_path")
+	if ! cloudron_package_is_semver "$package_version"; then
+		printf '%s\n' "- Package version '${package_version:-missing}' is not semantic versioning."
+		findings=$((findings + 1))
+	fi
+
+	local dockerfile=""
+	if ! dockerfile=$(_cloudron_release_dockerfile "$repo_path"); then
+		printf '%s\n' '- Dockerfile or Dockerfile.cloudron is missing.'
+		findings=$((findings + 1))
+	else
+		local final_from=""
+		local final_image=""
+		final_from=$(awk 'toupper($1) == "FROM" { line = $0 } END { print line }' "$dockerfile")
+		final_image=$(printf '%s\n' "$final_from" | awk '{ print $2 }')
+		if [[ "$final_image" != "$CLOUDRON_PINNED_BASE_IMAGE" ]]; then
+			printf '%s\n' "- Final Docker stage must use ${CLOUDRON_PINNED_BASE_IMAGE}."
+			findings=$((findings + 1))
+		fi
+	fi
+
+	[[ "$findings" -eq 0 ]] && return 0
+	return 1
+}
+
+_cloudron_release_changelog_has_version() {
+	local changelog_path="$1"
+	local package_version="$2"
+	grep -Fq "## [${package_version}]" "$changelog_path"
+	return $?
+}
+
+_cloudron_release_changelog_has_notes() {
+	local changelog_path="$1"
+	local package_version="$2"
+	awk -v version="$package_version" '
+		index($0, "## [" version "]") == 1 { in_release = 1; next }
+		in_release && /^## / { exit }
+		in_release && /[^[:space:]]/ { found = 1; exit }
+		END { exit(found ? 0 : 1) }
+	' "$changelog_path"
+	return $?
+}
+
+_cloudron_release_write_changelog() {
+	local changelog_path="$1"
+	local output_path="$2"
+	local package_version="$3"
+	local notes_file="$4"
+	local release_date="$5"
+	local first_line=""
+
+	{
+		if IFS= read -r first_line; then
+			if [[ "$first_line" == "# Changelog"* ]]; then
+				printf '%s\n\n## [%s] - %s\n\n' "$first_line" "$package_version" "$release_date"
+				cat "$notes_file"
+				printf '\n\n'
+				cat
+			else
+				printf '## [%s] - %s\n\n' "$package_version" "$release_date"
+				cat "$notes_file"
+				printf '\n\n%s\n' "$first_line"
+				cat
+			fi
+		else
+			printf '## [%s] - %s\n\n' "$package_version" "$release_date"
+			cat "$notes_file"
+			printf '\n'
+		fi
+	} <"$changelog_path" >"$output_path"
+	return $?
+}
+
+# Atomically prepare CloudronManifest.json and CHANGELOG.md without publishing.
+# Usage: cloudron_package_prepare_release <package-version> <upstream-version> <notes-file> [repo-path]
+cloudron_package_prepare_release() {
+	local package_version="${1:-}"
+	local upstream_version="${2:-}"
+	local notes_file="${3:-}"
+	local repo_path="${4:-.}"
+	upstream_version="${upstream_version#v}"
+
+	cloudron_package_is_semver "$package_version" || _cloudron_release_error "Package version must be semantic versioning (for example 1.2.3)." || return 1
+	cloudron_package_is_semver "$upstream_version" || _cloudron_release_error "Upstream version must be semantic versioning (for example 4.5.6)." || return 1
+	[[ -f "$notes_file" ]] || _cloudron_release_error "Release notes file not found: $notes_file" || return 1
+	grep -q '[^[:space:]]' "$notes_file" || _cloudron_release_error "Release notes must not be empty." || return 1
+
+	local manifest_path="${repo_path}/CloudronManifest.json"
+	local changelog_path="${repo_path}/CHANGELOG.md"
+	[[ -f "$manifest_path" ]] || _cloudron_release_error "CloudronManifest.json not found." || return 1
+	[[ -f "$changelog_path" ]] || _cloudron_release_error "CHANGELOG.md not found." || return 1
+	if ! cloudron_package_compatibility_findings "$repo_path" >/dev/null; then
+		_cloudron_release_error "Package compatibility validation failed before release preparation." || return 1
+	fi
+	if _cloudron_release_changelog_has_version "$changelog_path" "$package_version"; then
+		_cloudron_release_error "CHANGELOG.md already contains package version $package_version." || return 1
+	fi
+
+	local manifest_tmp=""
+	local changelog_tmp=""
+	local manifest_backup=""
+	local changelog_backup=""
+	manifest_tmp=$(mktemp "${manifest_path}.tmp.XXXXXX") || return 1
+	changelog_tmp=$(mktemp "${changelog_path}.tmp.XXXXXX") || {
+		rm -f "$manifest_tmp"
+		return 1
+	}
+	manifest_backup=$(mktemp "${manifest_path}.backup.XXXXXX") || {
+		rm -f "$manifest_tmp" "$changelog_tmp"
+		return 1
+	}
+	changelog_backup=$(mktemp "${changelog_path}.backup.XXXXXX") || {
+		rm -f "$manifest_tmp" "$changelog_tmp" "$manifest_backup"
+		return 1
+	}
+
+	if ! jq --arg version "$package_version" --arg upstream "$upstream_version" \
+		'.version = $version | .upstreamVersion = $upstream' "$manifest_path" >"$manifest_tmp" ||
+		! jq empty "$manifest_tmp" >/dev/null 2>&1 ||
+		! _cloudron_release_write_changelog "$changelog_path" "$changelog_tmp" "$package_version" "$notes_file" "$(date -u +%Y-%m-%d)" ||
+		! _cloudron_release_changelog_has_notes "$changelog_tmp" "$package_version"; then
+		_cloudron_release_cleanup "$manifest_tmp" "$changelog_tmp" "$manifest_backup" "$changelog_backup"
+		_cloudron_release_error "Failed to prepare validated release files." || return 1
+	fi
+	if ! _cloudron_release_preserve_mode "$manifest_path" "$manifest_tmp" ||
+		! _cloudron_release_preserve_mode "$changelog_path" "$changelog_tmp" ||
+		! cp -p "$manifest_path" "$manifest_backup" ||
+		! cp -p "$changelog_path" "$changelog_backup"; then
+		_cloudron_release_cleanup "$manifest_tmp" "$changelog_tmp" "$manifest_backup" "$changelog_backup"
+		return 1
+	fi
+
+	if ! mv "$manifest_tmp" "$manifest_path"; then
+		_cloudron_release_cleanup "$manifest_tmp" "$changelog_tmp" "$manifest_backup" "$changelog_backup"
+		return 1
+	fi
+	if ! mv "$changelog_tmp" "$changelog_path"; then
+		mv "$manifest_backup" "$manifest_path" || true
+		mv "$changelog_backup" "$changelog_path" || true
+		_cloudron_release_cleanup "$manifest_tmp" "$changelog_tmp"
+		_cloudron_release_error "Partial write detected; original release files restored." || return 1
+	fi
+	_cloudron_release_cleanup "$manifest_backup" "$changelog_backup"
+	printf 'Prepared Cloudron package %s for upstream %s. No release was published.\n' "$package_version" "$upstream_version"
+	return 0
+}
+
+# Validate the package, changelog, and tag before a release is published.
+# Usage: cloudron_package_check_release <vX.Y.Z> [repo-path]
+cloudron_package_check_release() {
+	local release_tag="${1:-${GITHUB_REF_NAME:-}}"
+	local repo_path="${2:-.}"
+	local manifest_path="${repo_path}/CloudronManifest.json"
+	local changelog_path="${repo_path}/CHANGELOG.md"
+	local findings=""
+
+	if [[ ! "$release_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+		_cloudron_release_error "Release tag must use vX.Y.Z format." || return 1
+	fi
+	if ! findings=$(cloudron_package_compatibility_findings "$repo_path"); then
+		printf '%s\n' "$findings" >&2
+		_cloudron_release_error "Cloudron package compatibility validation failed." || return 1
+	fi
+	local package_version=""
+	package_version=$(jq -r '.version // empty' "$manifest_path")
+	if [[ "$release_tag" != "v${package_version}" ]]; then
+		_cloudron_release_error "Tag $release_tag does not match manifest version $package_version." || return 1
+	fi
+	[[ -f "$changelog_path" ]] || _cloudron_release_error "CHANGELOG.md not found." || return 1
+	_cloudron_release_changelog_has_version "$changelog_path" "$package_version" || _cloudron_release_error "CHANGELOG.md has no section for $package_version." || return 1
+	_cloudron_release_changelog_has_notes "$changelog_path" "$package_version" || _cloudron_release_error "CHANGELOG.md section for $package_version is empty." || return 1
+	printf 'Cloudron release validation passed for %s.\n' "$release_tag"
+	return 0
+}

--- a/.agents/scripts/detect-app-type.sh
+++ b/.agents/scripts/detect-app-type.sh
@@ -161,7 +161,7 @@ write_cache_to_repos_json() {
 
 	# Check if slug exists in repos.json
 	local existing
-	existing="$(jq -r --arg slug "$slug" '.[] | select(.slug == $slug) | .slug' "$repos_json" 2>/dev/null || echo "")"
+	existing="$(jq -r --arg slug "$slug" '.initialized_repos[]? | select(.slug == $slug) | .slug' "$repos_json" 2>/dev/null || echo "")"
 	if [[ -z "$existing" ]]; then
 		printf '%s\n' "Info: slug $slug not found in repos.json — skipping cache write" >&2
 		return 0
@@ -169,10 +169,13 @@ write_cache_to_repos_json() {
 
 	# Write app_type into the matching entry
 	local tmp_file
-	tmp_file="$(mktemp)"
+	local mode=""
+	tmp_file="$(mktemp "${repos_json}.tmp.XXXXXX")"
 	if jq --arg slug "$slug" --arg app_type "$app_type" \
-		'map(if .slug == $slug then . + {"app_type": $app_type} else . end)' \
+		'(.initialized_repos[] | select(.slug == $slug)) |= (. + {"app_type": $app_type})' \
 		"$repos_json" >"$tmp_file" && jq empty "$tmp_file" 2>/dev/null; then
+		mode=$(stat -f '%Lp' "$repos_json" 2>/dev/null || stat -c '%a' "$repos_json" 2>/dev/null || true)
+		[[ -z "$mode" ]] || chmod "$mode" "$tmp_file"
 		mv "$tmp_file" "$repos_json"
 	else
 		echo "ERROR: repos.json write produced invalid JSON — aborting (GH#16746)" >&2

--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -31,6 +31,8 @@ r912| |Dashboard server|repeat:persistent|~0s|server/index.ts|service
 r913|x|Weekly opencode DB maintenance|repeat:weekly(sun@04:00)|~2m|scripts/opencode-db-maintenance-helper.sh auto|script
 r914|x|Repo aidevops health — bump stale .aidevops.json, detect drift|repeat:daily(@03:30)|~2m|scripts/repo-aidevops-health-helper.sh run|script
 r915|x|Pulse check — worker utilisation and self-improvement recommendations|repeat:daily(@06:20)|~5m|scripts/pulse-check-helper.sh apply|script
+r916|x|Cloudron packages — check upstream releases|repeat:daily(@07:10)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script
+r917|x|Cloudron packages — audit compatibility|repeat:weekly(sun@07:40)|~5m|scripts/cloudron-package-monitor-helper.sh compatibility --apply|script
 ENTRIES
 	return 0
 }
@@ -877,6 +879,68 @@ $(_diag_commands "$os" "sh.aidevops.pulse-check" "sh.aidevops.pulse-check")
 - \`pulse-check-helper.sh report\` — ad-hoc interactive report.
 - \`pulse-check-helper.sh json\` — machine-readable evidence.
 - Open issues carrying \`source:pulse-check\` — deduplicated improvements.
+$(_platform_footnote "$os")
+EOF
+	return 0
+}
+
+describe_r916() {
+	local os="${1:-}"
+	[[ -n "$os" ]] || os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+	cat <<EOF
+# r916: Cloudron package upstream releases
+
+## Overview
+
+Daily read-only comparison of registered Cloudron package upstream versions.
+New releases become deduplicated, worker-ready issues in the package repository.
+
+## Schedule
+
+| Field | Value |
+|-------|-------|
+| Frequency | Daily at 07:10 |
+| Type | script |
+| Expected duration | ~2 minutes |
+| Script | \`scripts/cloudron-package-monitor-helper.sh upstream --apply\` |
+$(_scheduler_row_calendar "$os" "StartCalendarInterval: Hour=7, Minute=10" "sh.aidevops.cloudron-package-upstream" "sh.aidevops.cloudron-package-upstream")
+
+## Safety rails
+
+- Reads only registrations with \`app_type: cloudron-package\` and explicit upstream metadata.
+- Requires ADMIN or MAINTAIN authority before creating a target-local issue.
+- Never changes package source, tags, releases, catalogs, images, or deployments.
+$(_platform_footnote "$os")
+EOF
+	return 0
+}
+
+describe_r917() {
+	local os="${1:-}"
+	[[ -n "$os" ]] || os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+	cat <<EOF
+# r917: Cloudron package compatibility audit
+
+## Overview
+
+Weekly validation of registered Cloudron manifests and final pinned base images.
+Stable finding fingerprints prevent repeated issues for an already handled audit.
+
+## Schedule
+
+| Field | Value |
+|-------|-------|
+| Frequency | Weekly on Sunday at 07:40 |
+| Type | script |
+| Expected duration | ~5 minutes |
+| Script | \`scripts/cloudron-package-monitor-helper.sh compatibility --apply\` |
+$(_scheduler_row_calendar "$os" "StartCalendarInterval: Weekday=0, Hour=7, Minute=40" "sh.aidevops.cloudron-package-compatibility" "sh.aidevops.cloudron-package-compatibility")
+
+## Safety rails
+
+- Audits local package files without building or executing upstream content.
+- Creates issues only after target-local deduplication and authority checks.
+- Never acknowledges a finding when GitHub/API operations fail.
 $(_platform_footnote "$os")
 EOF
 	return 0

--- a/.agents/scripts/tests/test-cloudron-package-init.sh
+++ b/.agents/scripts/tests/test-cloudron-package-init.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+INSTALL_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+AGENTS_DIR="${INSTALL_DIR}/.agents"
+TEST_ROOT=""
+PASSED=0
+FAILED=0
+
+print_info() { return 0; }
+print_success() { return 0; }
+print_warning() { return 0; }
+print_error() { return 0; }
+
+# shellcheck source=../aidevops-cli/aidevops-repos-lib.sh
+source "${INSTALL_DIR}/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh"
+# shellcheck source=../aidevops-cli/aidevops-init-lib.sh
+source "${INSTALL_DIR}/.agents/scripts/aidevops-cli/aidevops-init-lib.sh"
+
+cleanup() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		printf 'PASS %s\n' "$description"
+		PASSED=$((PASSED + 1))
+		return 0
+	fi
+	printf 'FAIL %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual" >&2
+	FAILED=$((FAILED + 1))
+	return 0
+}
+
+test_cloudron_workflow_scaffolding() {
+	local repo_dir="${TEST_ROOT}/cloudron"
+	mkdir -p "$repo_dir"
+	printf '{}\n' >"${repo_dir}/CloudronManifest.json"
+	_init_scaffold_cloudron_release_workflow "$repo_dir"
+	local workflow="${repo_dir}/.github/workflows/cloudron-package-release.yml"
+	assert_equal true "$([[ -f "$workflow" ]] && printf true || printf false)" "Cloudron caller scaffolded"
+	assert_equal "$(cksum "${AGENTS_DIR}/templates/workflows/cloudron-package-release-caller.yml" | awk '{ print $1, $2 }')" "$(cksum "$workflow" | awk '{ print $1, $2 }')" "caller matches managed template"
+	local before=""
+	before=$(cksum "$workflow")
+	_init_scaffold_cloudron_release_workflow "$repo_dir"
+	assert_equal "$before" "$(cksum "$workflow")" "Cloudron caller scaffolding is idempotent"
+
+	local generic_dir="${TEST_ROOT}/generic"
+	mkdir -p "$generic_dir"
+	_init_scaffold_cloudron_release_workflow "$generic_dir"
+	assert_equal false "$([[ -e "${generic_dir}/.github/workflows/cloudron-package-release.yml" ]] && printf true || printf false)" "non-Cloudron repo receives no caller"
+
+	local existing_dir="${TEST_ROOT}/existing"
+	mkdir -p "${existing_dir}/.github/workflows"
+	printf '{}\n' >"${existing_dir}/CloudronManifest.json"
+	printf 'custom\n' >"${existing_dir}/.github/workflows/cloudron-package-release.yml"
+	_init_scaffold_cloudron_release_workflow "$existing_dir"
+	assert_equal custom "$(tr -d '\n' <"${existing_dir}/.github/workflows/cloudron-package-release.yml")" "existing caller is never overwritten"
+	return 0
+}
+
+test_cloudron_registration_metadata() {
+	local home_dir="${TEST_ROOT}/home"
+	local repo_dir="${TEST_ROOT}/registered"
+	CONFIG_DIR="${home_dir}/.config/aidevops"
+	REPOS_FILE="${CONFIG_DIR}/repos.json"
+	mkdir -p "$CONFIG_DIR" "$repo_dir"
+	git -C "$repo_dir" init --quiet
+	cat >>"${repo_dir}/.git/config" <<'GITCONFIG'
+[remote "origin"]
+    url = https://github.com/exampleorg/registered-package.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+GITCONFIG
+	printf '{}\n' >"${repo_dir}/CloudronManifest.json"
+	_repo_registration_maintainer() {
+		printf '%s\n' examplemaintainer
+		return 0
+	}
+	register_repo "$repo_dir" 9.9.9 planning
+	assert_equal cloudron-package "$(jq -r '.initialized_repos[0].app_type' "$REPOS_FILE")" "registration records Cloudron app_type"
+	assert_equal CloudronManifest.json "$(jq -r '.initialized_repos[0].cloudron_package.manifest' "$REPOS_FILE")" "registration records manifest path"
+	assert_equal true "$(jq -r '.initialized_repos[0].cloudron_package.monitor_compatibility' "$REPOS_FILE")" "compatibility monitoring defaults on"
+	jq '.initialized_repos[0].cloudron_package += {"upstream_slug":"exampleorg/upstream","monitor_compatibility":false}' "$REPOS_FILE" >"${REPOS_FILE}.tmp"
+	mv "${REPOS_FILE}.tmp" "$REPOS_FILE"
+	register_repo "$repo_dir" 9.9.10 planning
+	assert_equal exampleorg/upstream "$(jq -r '.initialized_repos[0].cloudron_package.upstream_slug' "$REPOS_FILE")" "explicit upstream metadata preserved"
+	assert_equal false "$(jq -r '.initialized_repos[0].cloudron_package.monitor_compatibility' "$REPOS_FILE")" "explicit monitoring preference preserved"
+	return 0
+}
+
+main() {
+	TEST_ROOT=$(mktemp -d)
+	trap cleanup EXIT
+	test_cloudron_workflow_scaffolding
+	test_cloudron_registration_metadata
+	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
+	[[ "$FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-cloudron-package-monitor.sh
+++ b/.agents/scripts/tests/test-cloudron-package-monitor.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../cloudron-package-monitor-helper.sh"
+TEST_ROOT=""
+PASSED=0
+FAILED=0
+PINNED_BASE='cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c'
+
+cleanup() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		printf 'PASS %s\n' "$description"
+		PASSED=$((PASSED + 1))
+		return 0
+	fi
+	printf 'FAIL %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual" >&2
+	FAILED=$((FAILED + 1))
+	return 0
+}
+
+write_fake_commands() {
+	local bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "api" && "${2:-}" == repos/*/releases/latest ]]; then
+    printf '%s\n' 'v2.0.0'
+    exit 0
+fi
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+    printf '%s\n' 'ADMIN'
+    exit 0
+fi
+if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+    search=""
+    shift 2
+    while [[ $# -gt 0 ]]; do
+        if [[ "$1" == "--search" ]]; then
+            search="${2:-}"
+            break
+        fi
+        shift
+    done
+    marker="${search% in:body}"
+    if [[ -n "$marker" && -f "${MONITOR_TEST_LOG}" ]] && grep -Fq -- "$marker" "${MONITOR_TEST_LOG}"; then
+        printf '%s\n' '101'
+    fi
+    exit 0
+fi
+exit 1
+GH
+	cat >"${bin_dir}/gh_create_issue" <<'WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+repo=""
+body_file=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) repo="${2:-}"; shift 2 ;;
+        --body-file) body_file="${2:-}"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf 'CALL %s\n' "$repo" >>"${MONITOR_TEST_LOG}"
+while IFS= read -r line || [[ -n "$line" ]]; do
+    printf '%s\n' "$line" >>"${MONITOR_TEST_LOG}"
+done <"$body_file"
+WRAPPER
+	chmod +x "${bin_dir}/gh" "${bin_dir}/gh_create_issue"
+	return 0
+}
+
+write_fixture() {
+	local home_dir="$1"
+	local repo_dir="$2"
+	mkdir -p "${home_dir}/.config/aidevops" "$repo_dir"
+	cat >"${repo_dir}/CloudronManifest.json" <<'JSON'
+{
+  "id": "com.example.package",
+  "title": "Example Package",
+  "version": "1.0.0",
+  "upstreamVersion": "1.0.0",
+  "healthCheckPath": "/",
+  "httpPort": 8000,
+  "manifestVersion": 2,
+  "addons": {"localstorage": {}}
+}
+JSON
+	printf 'FROM %s\n' "$PINNED_BASE" >"${repo_dir}/Dockerfile"
+	cat >"${home_dir}/.config/aidevops/repos.json" <<JSON
+{
+  "initialized_repos": [{
+    "slug": "exampleorg/example-package",
+    "path": "${repo_dir}",
+    "app_type": "cloudron-package",
+    "cloudron_package": {
+      "manifest": "CloudronManifest.json",
+      "upstream_slug": "exampleorg/upstream",
+      "monitor_upstream": true,
+      "monitor_compatibility": true
+    }
+  }]
+}
+JSON
+	return 0
+}
+
+test_monitor_deduplicates_and_preserves_source() {
+	local home_dir="${TEST_ROOT}/home"
+	local repo_dir="${TEST_ROOT}/package"
+	local bin_dir="${TEST_ROOT}/bin"
+	local log_file="${TEST_ROOT}/issues.log"
+	write_fake_commands "$bin_dir"
+	write_fixture "$home_dir" "$repo_dir"
+	local manifest_before=""
+	manifest_before=$(cksum "${repo_dir}/CloudronManifest.json")
+
+	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply >/dev/null
+	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply >/dev/null
+	assert_equal 1 "$(grep -c '^CALL exampleorg/example-package$' "$log_file")" "new upstream release creates one target-local issue"
+	grep -Fq 'upstream-v2.0.0' "$log_file" && assert_equal true true "upstream issue carries stable fingerprint" || assert_equal true false "upstream issue carries stable fingerprint"
+	assert_equal "$manifest_before" "$(cksum "${repo_dir}/CloudronManifest.json")" "upstream monitor does not mutate manifest"
+
+	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" compatibility --apply >/dev/null
+	assert_equal 1 "$(grep -c '^CALL ' "$log_file")" "clean compatibility check creates no issue"
+	printf 'FROM cloudron/base:5.0.0\n' >"${repo_dir}/Dockerfile"
+	local docker_before=""
+	docker_before=$(cksum "${repo_dir}/Dockerfile")
+	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" compatibility --apply >/dev/null
+	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" compatibility --apply >/dev/null
+	assert_equal 2 "$(grep -c '^CALL ' "$log_file")" "compatibility finding is deduplicated"
+	assert_equal "$docker_before" "$(cksum "${repo_dir}/Dockerfile")" "compatibility monitor does not mutate package source"
+	return 0
+}
+
+main() {
+	TEST_ROOT=$(mktemp -d)
+	trap cleanup EXIT
+	test_monitor_deduplicates_and_preserves_source
+	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
+	[[ "$FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-cloudron-package-release.sh
+++ b/.agents/scripts/tests/test-cloudron-package-release.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../cloudron-package-helper.sh"
+TEST_ROOT=""
+PASSED=0
+FAILED=0
+PINNED_BASE='cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c'
+
+cleanup() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
+
+pass() {
+	local description="$1"
+	printf 'PASS %s\n' "$description"
+	PASSED=$((PASSED + 1))
+	return 0
+}
+
+fail() {
+	local description="$1"
+	printf 'FAIL %s\n' "$description" >&2
+	FAILED=$((FAILED + 1))
+	return 0
+}
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+	[[ "$expected" == "$actual" ]] && pass "$description" || fail "$description (expected=$expected actual=$actual)"
+	return 0
+}
+
+make_fixture() {
+	local repo_dir="$1"
+	mkdir -p "$repo_dir"
+	cat >"${repo_dir}/CloudronManifest.json" <<'JSON'
+{
+  "id": "com.example.package",
+  "title": "Example Package",
+  "version": "1.0.0",
+  "upstreamVersion": "4.0.0",
+  "healthCheckPath": "/",
+  "httpPort": 8000,
+  "manifestVersion": 2,
+  "addons": {"localstorage": {}}
+}
+JSON
+	printf 'FROM %s\nCMD ["/app/code/start.sh"]\n' "$PINNED_BASE" >"${repo_dir}/Dockerfile"
+	cat >"${repo_dir}/CHANGELOG.md" <<'CHANGELOG'
+# Changelog
+
+## [1.0.0] - 2026-01-01
+
+- Initial package.
+CHANGELOG
+	printf '%s\n' '- Package upstream 4.5.6 and refresh compatibility checks.' >"${repo_dir}/release-notes.md"
+	return 0
+}
+
+run_helper() {
+	local repo_dir="$1"
+	shift
+	(cd "$repo_dir" && bash "$HELPER" "$@")
+	return $?
+}
+
+test_prepare_and_validate_release() {
+	local repo_dir="${TEST_ROOT}/valid"
+	make_fixture "$repo_dir"
+	if run_helper "$repo_dir" prepare-release 1.2.0 4.5.6 release-notes.md >/dev/null; then
+		pass "valid release preparation succeeds"
+	else
+		fail "valid release preparation succeeds"
+	fi
+	assert_equal 1.2.0 "$(jq -r '.version' "${repo_dir}/CloudronManifest.json")" "package version updated"
+	assert_equal 4.5.6 "$(jq -r '.upstreamVersion' "${repo_dir}/CloudronManifest.json")" "upstream version updated"
+	grep -Fq '## [1.2.0]' "${repo_dir}/CHANGELOG.md" && pass "changelog release heading added" || fail "changelog release heading added"
+	grep -Fq 'Package upstream 4.5.6' "${repo_dir}/CHANGELOG.md" && pass "non-empty release notes added" || fail "non-empty release notes added"
+	run_helper "$repo_dir" check-release v1.2.0 >/dev/null && pass "matching tag validates" || fail "matching tag validates"
+	if run_helper "$repo_dir" check-release v1.2.1 >/dev/null 2>&1; then
+		fail "mismatched tag rejected"
+	else
+		pass "mismatched tag rejected"
+	fi
+	return 0
+}
+
+test_invalid_prepare_is_non_mutating() {
+	local repo_dir="${TEST_ROOT}/invalid"
+	make_fixture "$repo_dir"
+	local manifest_before=""
+	local changelog_before=""
+	manifest_before=$(cksum "${repo_dir}/CloudronManifest.json")
+	changelog_before=$(cksum "${repo_dir}/CHANGELOG.md")
+	if run_helper "$repo_dir" prepare-release invalid 4.5.6 release-notes.md >/dev/null 2>&1; then
+		fail "malformed package version rejected"
+	else
+		pass "malformed package version rejected"
+	fi
+	assert_equal "$manifest_before" "$(cksum "${repo_dir}/CloudronManifest.json")" "invalid preparation preserves manifest"
+	assert_equal "$changelog_before" "$(cksum "${repo_dir}/CHANGELOG.md")" "invalid preparation preserves changelog"
+	: >"${repo_dir}/empty-notes.md"
+	if run_helper "$repo_dir" prepare-release 1.2.0 4.5.6 empty-notes.md >/dev/null 2>&1; then
+		fail "empty release notes rejected"
+	else
+		pass "empty release notes rejected"
+	fi
+	assert_equal "$manifest_before" "$(cksum "${repo_dir}/CloudronManifest.json")" "empty notes preserve manifest"
+	return 0
+}
+
+test_release_gate_rejects_package_defects() {
+	local repo_dir="${TEST_ROOT}/defects"
+	make_fixture "$repo_dir"
+	printf 'FROM cloudron/base:5.0.0\n' >"${repo_dir}/Dockerfile"
+	if run_helper "$repo_dir" check-release v1.0.0 >/dev/null 2>&1; then
+		fail "unpinned final Cloudron base rejected"
+	else
+		pass "unpinned final Cloudron base rejected"
+	fi
+	printf '{invalid\n' >"${repo_dir}/CloudronManifest.json"
+	if run_helper "$repo_dir" check-release v1.0.0 >/dev/null 2>&1; then
+		fail "invalid manifest rejected"
+	else
+		pass "invalid manifest rejected"
+	fi
+	return 0
+}
+
+main() {
+	TEST_ROOT=$(mktemp -d)
+	trap cleanup EXIT
+	test_prepare_and_validate_release
+	test_invalid_prepare_is_non_mutating
+	test_release_gate_rejects_package_defects
+	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
+	[[ "$FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-cloudron-package-routines.sh
+++ b/.agents/scripts/tests/test-cloudron-package-routines.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+CORE_ROUTINES="${SCRIPT_DIR}/../routines/core-routines.sh"
+PASSED=0
+FAILED=0
+
+assert_contains() {
+	local haystack="$1"
+	local needle="$2"
+	local description="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		printf 'PASS %s\n' "$description"
+		PASSED=$((PASSED + 1))
+		return 0
+	fi
+	printf 'FAIL %s (missing=%s)\n' "$description" "$needle" >&2
+	FAILED=$((FAILED + 1))
+	return 0
+}
+
+main() {
+	# shellcheck source=../routines/core-routines.sh
+	source "$CORE_ROUTINES"
+	local entries=""
+	entries=$(get_core_routine_entries)
+	assert_contains "$entries" 'r916|x|Cloudron packages — check upstream releases|repeat:daily(@07:10)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script' "daily upstream routine registered"
+	assert_contains "$entries" 'r917|x|Cloudron packages — audit compatibility|repeat:weekly(sun@07:40)|~5m|scripts/cloudron-package-monitor-helper.sh compatibility --apply|script' "weekly compatibility routine registered"
+	declare -F describe_r916 >/dev/null 2>&1 && assert_contains "$(describe_r916 linux)" 'cloudron-package-monitor-helper.sh upstream --apply' "r916 description exposes exact command"
+	declare -F describe_r917 >/dev/null 2>&1 && assert_contains "$(describe_r917 linux)" 'cloudron-package-monitor-helper.sh compatibility --apply' "r917 description exposes exact command"
+	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
+	[[ "$FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-detect-app-type.sh
+++ b/.agents/scripts/tests/test-detect-app-type.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../detect-app-type.sh"
+TEST_ROOT=""
+PASSED=0
+FAILED=0
+
+cleanup() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		printf 'PASS %s\n' "$description"
+		PASSED=$((PASSED + 1))
+		return 0
+	fi
+	printf 'FAIL %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual" >&2
+	FAILED=$((FAILED + 1))
+	return 0
+}
+
+test_cloudron_cache_preserves_root_schema() {
+	local home_dir="${TEST_ROOT}/home"
+	local repo_dir="${TEST_ROOT}/package"
+	local config_dir="${home_dir}/.config/aidevops"
+	mkdir -p "$config_dir" "$repo_dir"
+	git -C "$repo_dir" init --quiet
+	cat >>"${repo_dir}/.git/config" <<'GITCONFIG'
+[remote "origin"]
+    url = https://github.com/exampleorg/example-package.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+GITCONFIG
+	printf '{"id":"com.example.package"}\n' >"${repo_dir}/CloudronManifest.json"
+	cat >"${config_dir}/repos.json" <<JSON
+{
+  "initialized_repos": [
+    {"slug": "exampleorg/example-package", "path": "${repo_dir}", "pulse": true},
+    {"slug": "exampleorg/other", "path": "${TEST_ROOT}/other", "custom": "keep"}
+  ],
+  "git_parent_dirs": ["~/Git"],
+  "custom_root": {"preserve": true}
+}
+JSON
+
+	local output=""
+	output=$(HOME="$home_dir" bash "$HELPER" "$repo_dir" --write-cache)
+	assert_equal cloudron-package "$output" "Cloudron package detected"
+	assert_equal cloudron-package "$(jq -r '.initialized_repos[] | select(.slug == "exampleorg/example-package") | .app_type' "${config_dir}/repos.json")" "matching entry receives app_type"
+	assert_equal keep "$(jq -r '.initialized_repos[] | select(.slug == "exampleorg/other") | .custom' "${config_dir}/repos.json")" "unrelated entry preserved"
+	assert_equal true "$(jq -r '.custom_root.preserve' "${config_dir}/repos.json")" "unrelated root fields preserved"
+	assert_equal object "$(jq -r 'type' "${config_dir}/repos.json")" "repos.json root remains an object"
+	return 0
+}
+
+main() {
+	TEST_ROOT=$(mktemp -d)
+	trap cleanup EXIT
+	test_cloudron_cache_preserves_root_schema
+	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
+	[[ "$FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-repos-add-local-only-convergence.sh
+++ b/.agents/scripts/tests/test-repos-add-local-only-convergence.sh
@@ -42,7 +42,11 @@ register_repo "$repo_path" "1.0.0" "planning"
 [[ "$(jq -r '.initialized_repos[0].local_only' "$REPOS_FILE")" == "true" ]]
 [[ "$(jq -r '.initialized_repos[0].pulse' "$REPOS_FILE")" == "false" ]]
 
-git -C "$repo_path" remote add origin https://github.com/example/remote-backed.git
+cat >>"${repo_path}/.git/config" <<'GITCONFIG'
+[remote "origin"]
+    url = https://github.com/example/remote-backed.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+GITCONFIG
 register_repo "$repo_path" "1.0.1" "planning"
 
 [[ "$(jq -r '.initialized_repos[0].slug' "$REPOS_FILE")" == "example/remote-backed" ]]

--- a/.agents/templates/workflows/cloudron-package-release-caller.yml
+++ b/.agents/templates/workflows/cloudron-package-release-caller.yml
@@ -1,0 +1,18 @@
+name: Cloudron Package Release
+
+# Managed by aidevops. Pushing a vX.Y.Z tag is the explicit publication trigger.
+# The reusable workflow validates the package before creating a GitHub release.
+# It does not publish images, Cloudron catalogs, or deployments.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@main
+    with:
+      aidevops_ref: main

--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -257,6 +257,41 @@ RUN curl -fsSL https://packagecloud.io/cloudamqp/lavinmq/gpgkey | gpg --dearmor 
 
 Track version in `/app/data/.app_version`; compare on start to run per-version migration blocks. Migrations MUST be idempotent — use framework migration tracking (Laravel, Django, Rails) or raw SQL with `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`.
 
+## Managed Package Lifecycle
+
+`aidevops init` detects `CloudronManifest.json`, records
+`app_type: cloudron-package` in local `repos.json`, and installs the thin
+`.github/workflows/cloudron-package-release.yml` caller when no file already
+exists. Configure `cloudron_package.upstream_slug` locally to enable daily
+stable-release comparison; compatibility monitoring is enabled by default.
+
+Prepare and validate releases without publishing:
+
+```bash
+cloudron-package-helper.sh prepare-release 1.2.0 4.5.6 release-notes.md
+cloudron-package-helper.sh check-compatibility
+cloudron-package-helper.sh check-release v1.2.0
+```
+
+`prepare-release` validates first, then updates `CloudronManifest.json` and
+inserts a non-empty `CHANGELOG.md` section with rollback on a partial write.
+`check-release` requires a matching `vX.Y.Z` tag, valid manifest, non-empty
+changelog entry, and the exact pinned final Cloudron base image.
+
+Core routines provide ongoing reporting:
+
+- `r916` runs `cloudron-package-monitor-helper.sh upstream --apply` daily.
+- `r917` runs `cloudron-package-monitor-helper.sh compatibility --apply` weekly.
+
+Both routines deduplicate package-local issues, require maintainer-equivalent
+issue authority, and fail closed on GitHub/API errors. They never execute
+upstream instructions or modify package source.
+
+**Publication boundary:** pushing a `vX.Y.Z` tag is the explicit trigger for the
+managed caller to validate and create a GitHub release. Tag creation, image
+pushes, Cloudron catalog publication, and deployment remain separate operator
+actions and require explicit authorization.
+
 ## Troubleshooting
 
 | Issue | Solution |

--- a/.github/workflows/cloudron-package-release-reusable.yml
+++ b/.github/workflows/cloudron-package-release-reusable.yml
@@ -1,0 +1,65 @@
+name: Cloudron Package Release (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      aidevops_repository:
+        description: 'Repository containing the shared Cloudron release validator'
+        required: false
+        type: string
+        default: 'marcusquinn/aidevops'
+      aidevops_ref:
+        description: 'aidevops ref containing the shared validator'
+        required: false
+        type: string
+        default: 'main'
+      runner:
+        description: 'Runner label override'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+
+jobs:
+  validate-and-release:
+    name: Validate and publish GitHub release
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    concurrency:
+      group: cloudron-package-release-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout package tag
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          path: package
+
+      - name: Checkout aidevops release validator
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: ${{ inputs.aidevops_repository }}
+          ref: ${{ inputs.aidevops_ref }}
+          fetch-depth: 1
+          path: __aidevops
+
+      - name: Validate Cloudron package release
+        working-directory: package
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: bash ../__aidevops/.agents/scripts/cloudron-package-helper.sh check-release "$RELEASE_TAG"
+
+      - name: Publish GitHub release for existing tag
+        working-directory: package
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "GitHub release already exists for $RELEASE_TAG"
+            exit 0
+          fi
+          gh release create "$RELEASE_TAG" --verify-tag --generate-notes --title "$RELEASE_TAG"


### PR DESCRIPTION
## Summary

Add Cloudron package detection, registration metadata, release preparation and validation, package-local monitoring, reusable workflows, routines, tests, and documentation.

## Files Changed

.agents/reference/repos-json-fields.md, .agents/scripts/aidevops-cli/aidevops-init-lib.sh, .agents/scripts/aidevops-cli/aidevops-repos-lib.sh, .agents/scripts/cloudron-package-helper.sh, .agents/scripts/cloudron-package-monitor-helper.sh, .agents/scripts/cloudron-package-release-lib.sh, .agents/scripts/detect-app-type.sh, .agents/scripts/routines/core-routines.sh, .agents/scripts/tests/test-cloudron-package-init.sh, .agents/scripts/tests/test-cloudron-package-monitor.sh, .agents/scripts/tests/test-cloudron-package-release.sh, .agents/scripts/tests/test-cloudron-package-routines.sh, .agents/scripts/tests/test-detect-app-type.sh, .agents/scripts/tests/test-repos-add-local-only-convergence.sh, .agents/templates/workflows/cloudron-package-release-caller.yml, .agents/tools/deployment/cloudron-app-packaging.md, .github/workflows/cloudron-package-release-reusable.yml

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Focused Cloudron lifecycle tests, existing init/repos/upstream/routine regressions, ShellCheck, actionlint, portability checks, and the changed-file local linter suite all pass.

Resolves #28497


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.166 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 17h 20m and 8,307,020 tokens on this with the user in an interactive session.