### PR TITLE
GH#28501: Pin generated Cloudron caller to immutable framework commit

### DIFF
--- a/.agents/scripts/tests/test-cloudron-package-init.sh
+++ b/.agents/scripts/tests/test-cloudron-package-init.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 INSTALL_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
 AGENTS_DIR="${INSTALL_DIR}/.agents"
+CLOUDRON_CALLER_FRAMEWORK_REF="22a6b4b29087ce2fcf3857596a40ff7b2c436482"
 TEST_ROOT=""
 PASSED=0
 FAILED=0
@@ -48,6 +49,11 @@ test_cloudron_workflow_scaffolding() {
 	local workflow="${repo_dir}/.github/workflows/cloudron-package-release.yml"
 	assert_equal true "$([[ -f "$workflow" ]] && printf true || printf false)" "Cloudron caller scaffolded"
 	assert_equal "$(cksum "${AGENTS_DIR}/templates/workflows/cloudron-package-release-caller.yml" | awk '{ print $1, $2 }')" "$(cksum "$workflow" | awk '{ print $1, $2 }')" "caller matches managed template"
+	assert_equal true "$(grep -Fq "cloudron-package-release-reusable.yml@${CLOUDRON_CALLER_FRAMEWORK_REF}" "$workflow" && printf true || printf false)" "caller pins reusable workflow commit"
+	assert_equal true "$(grep -Fq "aidevops_ref: ${CLOUDRON_CALLER_FRAMEWORK_REF}" "$workflow" && printf true || printf false)" "caller pins validator commit"
+	assert_equal false "$(grep -Eq '@main|aidevops_ref:[[:space:]]+main' "$workflow" && printf true || printf false)" "caller contains no mutable main ref"
+	assert_equal true "$(git -C "$INSTALL_DIR" cat-file -e "${CLOUDRON_CALLER_FRAMEWORK_REF}:.github/workflows/cloudron-package-release-reusable.yml" 2>/dev/null && printf true || printf false)" "pinned commit contains reusable workflow"
+	assert_equal true "$(git -C "$INSTALL_DIR" cat-file -e "${CLOUDRON_CALLER_FRAMEWORK_REF}:.agents/scripts/cloudron-package-helper.sh" 2>/dev/null && printf true || printf false)" "pinned commit contains release validator"
 	local before=""
 	before=$(cksum "$workflow")
 	_init_scaffold_cloudron_release_workflow "$repo_dir"

--- a/.agents/templates/workflows/cloudron-package-release-caller.yml
+++ b/.agents/templates/workflows/cloudron-package-release-caller.yml
@@ -13,6 +13,6 @@ jobs:
   release:
     permissions:
       contents: write
-    uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@main
+    uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@22a6b4b29087ce2fcf3857596a40ff7b2c436482
     with:
-      aidevops_ref: main
+      aidevops_ref: 22a6b4b29087ce2fcf3857596a40ff7b2c436482

--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -264,6 +264,9 @@ Track version in `/app/data/.app_version`; compare on start to run per-version m
 `.github/workflows/cloudron-package-release.yml` caller when no file already
 exists. Configure `cloudron_package.upstream_slug` locally to enable daily
 stable-release comparison; compatibility monitoring is enabled by default.
+The generated caller pins both the reusable workflow and checked-out validator
+to the same full framework commit. Updating that revision is an explicit,
+reviewed package change; repeated init never overwrites an existing caller.
 
 Prepare and validate releases without publishing:
 


### PR DESCRIPTION
## Summary

Pin scaffolded Cloudron release callers and validator checkouts to the verified framework merge commit, with regression tests and packaging guidance.

## Files Changed

.agents/scripts/tests/test-cloudron-package-init.sh, .agents/templates/workflows/cloudron-package-release-caller.yml, .agents/tools/deployment/cloudron-app-packaging.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Cloudron init regression tests, ShellCheck, actionlint, git diff validation, and the changed-file local linter suite pass.

Resolves #28501


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.166 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 17h 49m and 8,442,387 tokens on this with the user in an interactive session.