### PR TITLE
GH#28503: fix: recover converged stale canonical rebases

### DIFF
--- a/.agents/reference/dirty-worktree-preservation.md
+++ b/.agents/reference/dirty-worktree-preservation.md
@@ -58,6 +58,32 @@ operation IDs reuse matching evidence rather than overwriting it. A failed
 compare-and-swap rolls the local ref back. Never bypass the helper with direct
 `git pull`, reset, or clean.
 
+## Converged stale rebase recovery
+
+When a clean canonical checkout has completed an interactive rebase but stale
+metadata still blocks `restore-default`, use the separately confirmed cleanup:
+
+```bash
+.agents/scripts/canonical-recovery-helper.sh clear-stale-rebase \
+  --repo /path/to/canonical-checkout \
+  --issue 123 \
+  --confirm CLEAR_CONVERGED_STALE_REBASE
+```
+
+Under the canonical recovery lock, the helper fetches and pins the configured
+default branch, verifies the audit chain, and requires `HEAD`, the local default
+ref, and the pinned remote tip to be identical. It accepts only a completed,
+clean, structurally valid `rebase-merge` state for that default branch. Active,
+dirty, divergent, branch-mismatched, malformed, or changing state fails closed.
+
+Before cleanup, the helper copies and fingerprints all rebase metadata under
+`~/.aidevops/.agent-workspace/recovery/canonical/` and creates durable
+`refs/aidevops/canonical-recovery/issue-<N>/stale-rebase/<sha>` refs for commit
+IDs found in that metadata. It then proves cleanup did not change HEAD, local or
+remote refs, the index tree, or worktree content. Run `restore-default` with its
+own confirmation token after this command succeeds. Never use direct
+`git rebase --quit`, reset, clean, or metadata deletion on a canonical checkout.
+
 Restore preserved state only to a clean checkout on the recorded branch:
 
 ```bash

--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -6,11 +6,30 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 FAST_FORWARD_CMD="fast-forward-current"
 SYNC_MIRROR_CMD="sync-mirror"
+CLEAR_STALE_REBASE_CMD="clear-stale-rebase"
+HEAD_COMMIT_EXPR='HEAD^{commit}'
+
+rebase_state_fingerprint() {
+	local state_dir="$1"
+	local entry=""
+	local entry_hash=""
+	local entry_name=""
+	local manifest=""
+	for entry in "$state_dir"/*; do
+		[[ -f "$entry" ]] || return 1
+		entry_name=${entry##*/}
+		entry_hash=$("$REAL_GIT" hash-object "$entry") || return 1
+		manifest="${manifest}${entry_name} ${entry_hash}"$'\n'
+	done
+	printf '%s' "$manifest" | "$REAL_GIT" hash-object --stdin
+	return 0
+}
 
 usage() {
 	printf '%s\n' \
 		'Usage:' \
 		'  canonical-recovery-helper.sh restore-default --repo PATH --issue N --confirm RESTORE_CANONICAL_DEFAULT' \
+		"  canonical-recovery-helper.sh ${CLEAR_STALE_REBASE_CMD} --repo PATH --issue N --confirm CLEAR_CONVERGED_STALE_REBASE" \
 		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --issue N --confirm FAST_FORWARD_CANONICAL_BRANCH" \
 		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --reason aidevops-update --confirm FAST_FORWARD_CANONICAL_BRANCH" \
 		"  canonical-recovery-helper.sh ${SYNC_MIRROR_CMD} --repo PATH --issue N --confirm SYNCHRONIZE_CANONICAL_MIRROR"
@@ -56,6 +75,13 @@ done
 case "$cmd" in
 restore-default)
 	expected_confirmation="RESTORE_CANONICAL_DEFAULT"
+	[[ -z "$expected_branch" ]] || {
+		usage
+		exit 2
+	}
+	;;
+"$CLEAR_STALE_REBASE_CMD")
+	expected_confirmation="CLEAR_CONVERGED_STALE_REBASE"
 	[[ -z "$expected_branch" ]] || {
 		usage
 		exit 2
@@ -122,7 +148,7 @@ target_branch_source=$(python3 "$policy_helper" resolve-branch --cwd "$repo_path
 	exit 1
 }
 
-if [[ "$cmd" != "restore-default" ]]; then
+if [[ "$cmd" != "restore-default" && "$cmd" != "$CLEAR_STALE_REBASE_CMD" ]]; then
 	current_branch=$("$REAL_GIT" -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 	[[ -n "$current_branch" ]] || {
 		printf 'BLOCKED: canonical worktree is detached\n' >&2
@@ -176,6 +202,66 @@ local_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit
 	printf 'BLOCKED: local %s tip cannot be resolved\n' "$target_branch" >&2
 	exit 1
 }
+
+stale_rebase_dir=""
+stale_rebase_fingerprint=""
+stale_rebase_preservation_dir=""
+stale_head_sha=""
+stale_index_tree=""
+if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]]; then
+	rebase_merge_dir=$("$REAL_GIT" -C "$repo_path" rev-parse --path-format=absolute --git-path rebase-merge)
+	rebase_apply_dir=$("$REAL_GIT" -C "$repo_path" rev-parse --path-format=absolute --git-path rebase-apply)
+	rebase_head_path=$("$REAL_GIT" -C "$repo_path" rev-parse --path-format=absolute --git-path REBASE_HEAD)
+	[[ -d "$rebase_merge_dir" && ! -e "$rebase_apply_dir" ]] || {
+		printf 'BLOCKED: exactly one supported interactive rebase state is required\n' >&2
+		exit 1
+	}
+	for required_file in "head-name" "onto" "orig-head" "git-rebase-todo" "done" "msgnum" "end"; do
+		[[ -f "${rebase_merge_dir}/${required_file}" ]] || {
+			printf 'BLOCKED: stale rebase metadata is malformed or incomplete\n' >&2
+			exit 1
+		}
+	done
+	rebase_head_name=$(<"${rebase_merge_dir}/head-name")
+	rebase_onto=$(<"${rebase_merge_dir}/onto")
+	rebase_orig_head=$(<"${rebase_merge_dir}/orig-head")
+	rebase_msgnum=$(<"${rebase_merge_dir}/msgnum")
+	rebase_end=$(<"${rebase_merge_dir}/end")
+	[[ "$rebase_head_name" == "$local_ref" ]] || {
+		printf 'BLOCKED: stale rebase belongs to a different branch\n' >&2
+		exit 1
+	}
+	[[ "$rebase_msgnum" =~ ^[0-9]+$ && "$rebase_end" =~ ^[0-9]+$ && "$rebase_msgnum" == "$rebase_end" ]] || {
+		printf 'BLOCKED: rebase sequence is active or malformed\n' >&2
+		exit 1
+	}
+	[[ ! -s "${rebase_merge_dir}/git-rebase-todo" && -s "${rebase_merge_dir}/done" ]] || {
+		printf 'BLOCKED: rebase sequence still has active work\n' >&2
+		exit 1
+	}
+	[[ ! -e "$rebase_head_path" && ! -e "${rebase_merge_dir}/stopped-sha" ]] || {
+		printf 'BLOCKED: rebase is stopped on an active commit\n' >&2
+		exit 1
+	}
+	"$REAL_GIT" -C "$repo_path" rev-parse --verify "${rebase_onto}^{commit}" >/dev/null 2>&1 &&
+		"$REAL_GIT" -C "$repo_path" rev-parse --verify "${rebase_orig_head}^{commit}" >/dev/null 2>&1 || {
+		printf 'BLOCKED: stale rebase commit metadata is invalid\n' >&2
+		exit 1
+	}
+	[[ -z "$("$REAL_GIT" -C "$repo_path" diff --name-only --diff-filter=U)" ]] || {
+		printf 'BLOCKED: rebase has unresolved index entries\n' >&2
+		exit 1
+	}
+	stale_head_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "$HEAD_COMMIT_EXPR")
+	[[ "$stale_head_sha" == "$local_sha" && "$local_sha" == "$target_sha" ]] || {
+		printf 'BLOCKED: HEAD, local default, and pinned origin default have not converged\n' >&2
+		exit 1
+	}
+	stale_index_tree=$("$REAL_GIT" -C "$repo_path" write-tree)
+	stale_rebase_dir="$rebase_merge_dir"
+	stale_rebase_fingerprint=$(rebase_state_fingerprint "$stale_rebase_dir")
+	stale_rebase_preservation_dir="${AIDEVOPS_CANONICAL_RECOVERY_ROOT:-${HOME}/.aidevops/.agent-workspace/recovery/canonical}/${issue_number}/stale-rebase-${stale_head_sha}"
+fi
 
 sync_backup_id=""
 sync_backup_dir=""
@@ -274,11 +360,14 @@ AUDIT_LOG_FILE="$recovery_audit_file" "$audit_helper" verify --quiet || {
 audit_message="Canonical default-branch recovery authorized"
 [[ "$cmd" == "$FAST_FORWARD_CMD" ]] && audit_message="Canonical current-branch fast-forward authorized"
 [[ "$cmd" == "$SYNC_MIRROR_CMD" ]] && audit_message="Canonical mirror synchronization authorized"
+[[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]] && audit_message="Converged stale rebase cleanup authorized"
 AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log operation.verify "$audit_message" \
 	--detail "issue=${issue_number:-none}" --detail "reason=${maintenance_reason:-none}" --detail "repo=${repo_path}" \
 	--detail "operation=${cmd}" --detail "target=${target_branch}" --detail "target_source=${target_branch_source}" \
 	--detail "target_sha=${target_sha}" --detail "local_sha=${local_sha}" \
-	--detail "preservation_ref=${preservation_ref:-none}" --detail "backup_id=${sync_backup_id:-none}" >/dev/null || {
+	--detail "preservation_ref=${preservation_ref:-none}" --detail "backup_id=${sync_backup_id:-none}" \
+	--detail "stale_rebase_fingerprint=${stale_rebase_fingerprint:-none}" \
+	--detail "stale_rebase_preservation=${stale_rebase_preservation_dir:-none}" >/dev/null || {
 	printf 'BLOCKED: recovery audit record could not be written\n' >&2
 	exit 1
 }
@@ -291,6 +380,72 @@ AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log opera
 	printf 'BLOCKED: local %s tip changed during recovery\n' "$target_branch" >&2
 	exit 1
 }
+if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]]; then
+	preservation_parent=${stale_rebase_preservation_dir%/*}
+	mkdir -p "$preservation_parent"
+	if [[ -d "$stale_rebase_preservation_dir" ]]; then
+		[[ "$(rebase_state_fingerprint "$stale_rebase_preservation_dir")" == "$stale_rebase_fingerprint" ]] || {
+			printf 'BLOCKED: existing stale rebase preservation evidence differs\n' >&2
+			exit 1
+		}
+	else
+		preservation_temp="${stale_rebase_preservation_dir}.tmp.$$"
+		mkdir "$preservation_temp"
+		cp -R "${stale_rebase_dir}/." "$preservation_temp/"
+		[[ "$(rebase_state_fingerprint "$preservation_temp")" == "$stale_rebase_fingerprint" ]] || {
+			printf 'BLOCKED: stale rebase metadata copy could not be verified\n' >&2
+			rm -rf "$preservation_temp"
+			exit 1
+		}
+		mv "$preservation_temp" "$stale_rebase_preservation_dir"
+	fi
+	while IFS= read -r metadata_line; do
+		for metadata_word in $metadata_line; do
+			if [[ "$metadata_word" =~ ^[0-9a-fA-F]{40}$ ]] &&
+				metadata_commit=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${metadata_word}^{commit}" 2>/dev/null); then
+				metadata_ref="refs/aidevops/canonical-recovery/issue-${issue_number}/stale-rebase/${metadata_commit}"
+				existing_metadata_commit=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${metadata_ref}^{commit}" 2>/dev/null || true)
+				[[ -z "$existing_metadata_commit" || "$existing_metadata_commit" == "$metadata_commit" ]] || {
+					printf 'BLOCKED: stale rebase preservation ref points elsewhere\n' >&2
+					exit 1
+				}
+				[[ -n "$existing_metadata_commit" ]] || "$REAL_GIT" -C "$repo_path" update-ref "$metadata_ref" "$metadata_commit" \
+					"0000000000000000000000000000000000000000"
+			fi
+		done
+	done < <(
+		printf '%s\n' "$stale_head_sha" "$rebase_onto" "$rebase_orig_head"
+		cat "${stale_rebase_dir}/done" "${stale_rebase_dir}/rewritten-list" 2>/dev/null || true
+	)
+	if [[ -n "${AIDEVOPS_CANONICAL_BEFORE_REBASE_CLEANUP_HOOK:-}" ]]; then
+		"$AIDEVOPS_CANONICAL_BEFORE_REBASE_CLEANUP_HOOK" "$repo_path" "$stale_rebase_dir" || {
+			printf 'BLOCKED: canonical pre-rebase-cleanup hook failed\n' >&2
+			exit 1
+		}
+	fi
+	[[ "$(rebase_state_fingerprint "$stale_rebase_dir")" == "$stale_rebase_fingerprint" ]] &&
+		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "$HEAD_COMMIT_EXPR")" == "$stale_head_sha" ]] &&
+		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}")" == "$local_sha" ]] &&
+		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] &&
+		[[ "$("$REAL_GIT" -C "$repo_path" write-tree)" == "$stale_index_tree" ]] &&
+		[[ -z "$("$REAL_GIT" -C "$repo_path" status --porcelain)" ]] || {
+		printf 'BLOCKED: canonical or rebase state changed before cleanup\n' >&2
+		exit 1
+	}
+	rm -rf "$stale_rebase_dir"
+	[[ ! -e "$stale_rebase_dir" && ! -e "$rebase_apply_dir" && ! -e "$rebase_head_path" ]] &&
+		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "$HEAD_COMMIT_EXPR")" == "$stale_head_sha" ]] &&
+		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}")" == "$local_sha" ]] &&
+		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] &&
+		[[ "$("$REAL_GIT" -C "$repo_path" write-tree)" == "$stale_index_tree" ]] &&
+		[[ -z "$("$REAL_GIT" -C "$repo_path" status --porcelain)" ]] || {
+		printf 'CRITICAL: stale rebase cleanup changed canonical repository state\n' >&2
+		exit 1
+	}
+	printf 'CLEARED_CONVERGED_STALE_REBASE=true\n'
+	printf 'PRESERVED_REBASE_DIR=%s\n' "$stale_rebase_preservation_dir"
+	exit 0
+fi
 if [[ "$cmd" == "$SYNC_MIRROR_CMD" && -n "$preservation_ref" ]]; then
 	existing_preservation_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${preservation_ref}^{commit}" 2>/dev/null || true)
 	if [[ -n "$existing_preservation_sha" && "$existing_preservation_sha" != "$local_sha" ]]; then
@@ -381,7 +536,7 @@ if [[ "$cmd" == "$FAST_FORWARD_CMD" || "$cmd" == "$SYNC_MIRROR_CMD" ]]; then
 		if [[ "$post_update_branch" == "$target_branch" ]]; then
 			restore_worktree_sha="$local_sha"
 		else
-			restore_worktree_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "HEAD^{commit}" 2>/dev/null || true)
+			restore_worktree_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "$HEAD_COMMIT_EXPR" 2>/dev/null || true)
 		fi
 		if ! "$REAL_GIT" -C "$repo_path" update-ref \
 			-m "${fast_forward_reflog} rollback for issue ${issue_number}" \
@@ -395,7 +550,7 @@ if [[ "$cmd" == "$FAST_FORWARD_CMD" || "$cmd" == "$SYNC_MIRROR_CMD" ]]; then
 			printf 'CRITICAL: canonical ref was rolled back but the concurrent branch worktree could not be restored\n' >&2
 			exit 1
 		fi
-		current_head_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "HEAD^{commit}" 2>/dev/null || true)
+		current_head_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "$HEAD_COMMIT_EXPR" 2>/dev/null || true)
 		if [[ "$current_head_sha" != "$restore_worktree_sha" ]] ||
 			[[ -n "$("$REAL_GIT" -C "$repo_path" status --porcelain)" ]]; then
 			printf 'CRITICAL: canonical ref was rolled back but the concurrent branch remains inconsistent\n' >&2

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -238,6 +238,88 @@ else
 	exit 1
 fi
 
+STALE_REPO="${ROOT}/stale-repo"
+STALE_REMOTE="${ROOT}/stale-remote.git"
+STALE_RECOVERY="${ROOT}/stale-recovery"
+mkdir -p "$STALE_REPO"
+/usr/bin/git init -q --bare "$STALE_REMOTE"
+/usr/bin/git -C "$STALE_REPO" init -q -b main
+/usr/bin/git -C "$STALE_REPO" config user.name Test
+/usr/bin/git -C "$STALE_REPO" config user.email test@example.invalid
+/usr/bin/git -C "$STALE_REPO" config commit.gpgsign false
+printf 'stale seed\n' >"${STALE_REPO}/README.md"
+/usr/bin/git -C "$STALE_REPO" add README.md
+/usr/bin/git -C "$STALE_REPO" commit -q -m seed
+/usr/bin/git -C "$STALE_REPO" remote add origin "$STALE_REMOTE"
+/usr/bin/git -C "$STALE_REPO" push -q -u origin main
+/usr/bin/git -C "$STALE_REMOTE" symbolic-ref HEAD refs/heads/main
+/usr/bin/git -C "$STALE_REPO" remote set-head origin main
+stale_tip=$(/usr/bin/git -C "$STALE_REPO" rev-parse HEAD)
+/usr/bin/git -C "$STALE_REPO" switch -q --detach "$stale_tip"
+stale_metadata="${STALE_REPO}/.git/rebase-merge"
+mkdir "$stale_metadata"
+printf 'refs/heads/main\n' >"${stale_metadata}/head-name"
+printf '%s\n' "$stale_tip" >"${stale_metadata}/onto"
+printf '%s\n' "$stale_tip" >"${stale_metadata}/orig-head"
+: >"${stale_metadata}/git-rebase-todo"
+printf 'pick %s seed\n' "$stale_tip" >"${stale_metadata}/done"
+printf '1\n' >"${stale_metadata}/msgnum"
+printf '1\n' >"${stale_metadata}/end"
+stale_index_tree=$(/usr/bin/git -C "$STALE_REPO" write-tree)
+stale_output=""
+if stale_output=$(AIDEVOPS_CANONICAL_RECOVERY_ROOT="$STALE_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-stale-rebase --repo "$STALE_REPO" --issue 28503 \
+	--confirm CLEAR_CONVERGED_STALE_REBASE) &&
+	[[ "$stale_output" == *"CLEARED_CONVERGED_STALE_REBASE=true"* ]] &&
+	[[ ! -e "$stale_metadata" ]] &&
+	[[ "$(/usr/bin/git -C "$STALE_REPO" rev-parse HEAD)" == "$stale_tip" ]] &&
+	[[ "$(/usr/bin/git -C "$STALE_REPO" rev-parse main)" == "$stale_tip" ]] &&
+	[[ "$(/usr/bin/git -C "$STALE_REPO" write-tree)" == "$stale_index_tree" ]] &&
+	[[ -z "$(/usr/bin/git -C "$STALE_REPO" status --porcelain)" ]] &&
+	[[ "$(/usr/bin/git -C "$STALE_REPO" rev-parse "refs/aidevops/canonical-recovery/issue-28503/stale-rebase/${stale_tip}")" == "$stale_tip" ]] &&
+	AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$STALE_REPO" --issue 28503 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null &&
+	[[ "$(/usr/bin/git -C "$STALE_REPO" branch --show-current)" == "main" ]]; then
+	printf 'PASS converged stale rebase is preserved, cleared without tree changes, and restore-default succeeds\n'
+else
+	printf 'FAIL converged stale rebase recovery did not preserve invariant state\n'
+	exit 1
+fi
+
+cp -R "${STALE_RECOVERY}/28503/stale-rebase-${stale_tip}" "$stale_metadata"
+printf 'pick %s still-active\n' "$stale_tip" >"${stale_metadata}/git-rebase-todo"
+if AIDEVOPS_CANONICAL_RECOVERY_ROOT="$STALE_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-stale-rebase --repo "$STALE_REPO" --issue 28503 \
+	--confirm CLEAR_CONVERGED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL stale rebase cleanup accepted active todo entries\n'
+	exit 1
+elif [[ -s "${stale_metadata}/git-rebase-todo" ]] &&
+	[[ "$(/usr/bin/git -C "$STALE_REPO" rev-parse HEAD)" == "$stale_tip" ]]; then
+	printf 'PASS stale rebase cleanup rejects active state without mutation\n'
+else
+	printf 'FAIL active stale rebase refusal changed repository state\n'
+	exit 1
+fi
+rm -rf "$stale_metadata"
+cp -R "${STALE_RECOVERY}/28503/stale-rebase-${stale_tip}" "$stale_metadata"
+stale_race_hook="${ROOT}/mutate-stale-rebase.sh"
+# Generated hook expands its own positional argument.
+# shellcheck disable=SC2016
+printf '%s\n' '#!/usr/bin/env bash' 'printf "2\n" >"$2/msgnum"' >"$stale_race_hook"
+chmod +x "$stale_race_hook"
+if AIDEVOPS_CANONICAL_BEFORE_REBASE_CLEANUP_HOOK="$stale_race_hook" \
+	AIDEVOPS_CANONICAL_RECOVERY_ROOT="$STALE_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-stale-rebase --repo "$STALE_REPO" --issue 28503 \
+	--confirm CLEAR_CONVERGED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL stale rebase cleanup accepted concurrently changing metadata\n'
+	exit 1
+elif [[ -d "$stale_metadata" ]] && [[ "$(<"${stale_metadata}/msgnum")" == "2" ]] &&
+	[[ "$(/usr/bin/git -C "$STALE_REPO" rev-parse HEAD)" == "$stale_tip" ]]; then
+	printf 'PASS stale rebase cleanup rejects concurrent metadata changes without cleanup\n'
+else
+	printf 'FAIL concurrent stale rebase refusal removed or changed canonical state\n'
+	exit 1
+fi
+
 SYNC_REPO="${ROOT}/sync-repo"
 SYNC_REMOTE="${ROOT}/sync-remote.git"
 SYNC_UPDATER="${ROOT}/sync-updater"


### PR DESCRIPTION
## Summary

Add a separately confirmed canonical recovery command that verifies converged stale rebase state, preserves metadata and commit refs, clears only unchanged completed metadata, and documents the audited workflow.

## Files Changed

.agents/reference/dirty-worktree-preservation.md, .agents/scripts/canonical-recovery-helper.sh, .agents/scripts/tests/test-canonical-recovery-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-canonical-recovery-helper.sh; shellcheck .agents/scripts/canonical-recovery-helper.sh .agents/scripts/tests/test-canonical-recovery-helper.sh; .agents/scripts/linters-local.sh

Resolves #28503


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.166 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 13m and 124,066 tokens on this as a headless worker.