### PR TITLE
GH#28498: prevent enrichment guards from recovering live owners

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -46,6 +46,10 @@
 #     GH#10521: Ignores repo owner (from slug) and maintainer (from repos.json).
 #     Exit 0 = assigned to another runner (do NOT dispatch), exit 1 = safe to dispatch.
 #
+#   dispatch-dedup-helper.sh is-assigned-read-only <issue> <slug> [self-login]
+#     Run the same assignment guard without stale-assignment recovery writes.
+#     Exit 0 = assignment/guard blocks, exit 1 = no assignment/guard block.
+#
 #   dispatch-dedup-helper.sh list-running-keys
 #     List dedup keys for all currently running workers.
 #
@@ -1831,10 +1835,11 @@ _is_assigned_pre_assignee_guard_blocks() {
 	return 1
 }
 
-is_assigned() {
+_is_assigned_impl() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local self_login="${3:-}"
+	local allow_stale_recovery="${4:-1}"
 
 	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
 		# Missing args — cannot check, allow dispatch
@@ -1920,12 +1925,42 @@ is_assigned() {
 	# permanent deadlock where 0 workers run despite available slots and
 	# open issues. This was observed in production with 370 issues and 0
 	# active workers — 100% dispatch failure rate.
-	if _is_stale_assignment "$issue_number" "$repo_slug" "$blocking_assignees"; then
+	if [[ "$allow_stale_recovery" == "1" ]] \
+		&& _is_stale_assignment "$issue_number" "$repo_slug" "$blocking_assignees"; then
 		return 1
 	fi
 
 	printf 'ASSIGNED: issue #%s in %s is assigned to %s\n' "$issue_number" "$repo_slug" "$blocking_assignees"
 	return 0
+}
+
+#######################################
+# Dispatch assignment guard with stale recovery enabled.
+# Args: $1 = issue number, $2 = repo slug, $3 = self login (optional)
+# Returns: 0 when blocked, 1 when safe to dispatch
+#######################################
+is_assigned() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="${3:-}"
+
+	_is_assigned_impl "$issue_number" "$repo_slug" "$self_login" 1
+	return $?
+}
+
+#######################################
+# Read-only assignment guard for inspection-only callers such as enrichment.
+# Reuses all fail-closed and active-claim logic but never invokes stale recovery.
+# Args: $1 = issue number, $2 = repo slug, $3 = self login (optional)
+# Returns: 0 when blocked, 1 when no assignment/guard block exists
+#######################################
+is_assigned_read_only() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local self_login="${3:-}"
+
+	_is_assigned_impl "$issue_number" "$repo_slug" "$self_login" 0
+	return $?
 }
 
 #######################################
@@ -2601,6 +2636,7 @@ Usage:
                                                      Check for recent "Dispatching worker" comment (exit 0=found, 1=none)
   dispatch-dedup-helper.sh is-assigned <issue> <slug> [self-login]
                                                        Check if assigned to another login (exit 0=blocked, 1=free)
+  dispatch-dedup-helper.sh is-assigned-read-only <issue> <slug> [self-login]  Inspect without recovery writes
   dispatch-dedup-helper.sh enumerate-blockers <issue> <slug> [runner]
                                                        Report ALL structural label blockers (exit 0=blocked, 1=none)
                                                        Emits newline-separated tokens: PARENT_TASK_BLOCKED,
@@ -2625,7 +2661,6 @@ Usage:
   dispatch-dedup-helper.sh list-running-keys        List keys for all running workers
   dispatch-dedup-helper.sh normalize <title>        Normalize a title for comparison
   dispatch-dedup-helper.sh help                     Show this help
-
 Examples:
   # Extract keys from various title formats
   dispatch-dedup-helper.sh extract-keys "Issue #2300: t1337 Simplify infra scripts"
@@ -2730,12 +2765,19 @@ _ddh_main_simple_command() {
 
 _ddh_main_issue_command() {
 	local command_name="$1"
+	local assignment_usage="<issue-number> <repo-slug> [self-login]"
 	shift || true
 	case "$command_name" in
 	is-assigned)
-		_require_args is-assigned 2 "$#" "<issue-number> <repo-slug> [self-login]" || return 1
+		_require_args is-assigned 2 "$#" "$assignment_usage" || return 1
 		local assigned_issue="$1" assigned_repo="$2" assigned_runner="${3:-}"
 		is_assigned "$assigned_issue" "$assigned_repo" "$assigned_runner"
+		return $?
+		;;
+	is-assigned-read-only)
+		_require_args is-assigned-read-only 2 "$#" "$assignment_usage" || return 1
+		local readonly_issue="$1" readonly_repo="$2" readonly_runner="${3:-}"
+		is_assigned_read_only "$readonly_issue" "$readonly_repo" "$readonly_runner"
 		return $?
 		;;
 	enumerate-blockers)
@@ -2865,7 +2907,7 @@ main() {
 		_ddh_main_simple_command "$command" "$@"
 		return $?
 		;;
-	is-assigned | enumerate-blockers | check-cost-budget | sum-issue-token-spend | has-dispatch-comment | has-open-pr)
+	is-assigned | is-assigned-read-only | enumerate-blockers | check-cost-budget | sum-issue-token-spend | has-dispatch-comment | has-open-pr)
 		_ddh_main_issue_command "$command" "$@"
 		return $?
 		;;

--- a/.agents/scripts/issue-sync-helper-enrich.sh
+++ b/.agents/scripts/issue-sync-helper-enrich.sh
@@ -395,15 +395,16 @@ _enrich_check_active_claim() {
 	local num="$1" repo="$2" task_id="$3" pre_fetched_json="${4:-}"
 	local _dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
 	if [[ -x "$_dedup_helper" ]]; then
-		# GH#19922: resolve runner login so is-assigned can apply the self-login
+		# GH#19922: resolve runner login so the assignment guard can apply the self-login
 		# exemption — without it the runner blocks its own enrichment when it is
 		# also an assignee (e.g. single-user setups).
 		local _user="${AIDEVOPS_SESSION_USER:-}"
 		[[ -z "$_user" ]] && _user=$(gh api user --jq '.login // ""' 2>/dev/null || echo "")
 		local _dedup_result=""
 		# GH#19922: pass pre-fetched JSON via ISSUE_META_JSON env var to avoid
-		# a redundant gh issue view call inside is_assigned().
-		_dedup_result=$(ISSUE_META_JSON="$pre_fetched_json" "$_dedup_helper" is-assigned "$num" "$repo" "$_user" 2>/dev/null) || true
+		# a redundant metadata read. GH#28498: inspection must never invoke stale
+		# recovery, which can mutate a live interactive owner's claim.
+		_dedup_result=$(ISSUE_META_JSON="$pre_fetched_json" "$_dedup_helper" is-assigned-read-only "$num" "$repo" "$_user" 2>/dev/null) || true
 		if [[ -n "$_dedup_result" ]]; then
 			print_warning "Skipping enrich for #$num ($task_id) — active claim detected: $_dedup_result (GH#19856)"
 			return 0

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1954,9 +1954,9 @@ _ensure_issue_body_has_brief() {
 	dedup_helper="${BASH_SOURCE[0]%/*}/dispatch-dedup-helper.sh"
 	if [[ -x "$dedup_helper" ]]; then
 		local _dedup_out=""
-		# GH#19922: pass AIDEVOPS_SESSION_USER as self_login so the runner
-		# does not block its own enrichment via the self-login exemption.
-		_dedup_out=$("$dedup_helper" is-assigned "$issue_number" "$repo_slug" "${AIDEVOPS_SESSION_USER:-}" 2>/dev/null) || true
+		# GH#19922/GH#28498: preserve the self-login exemption while using the
+		# read-only guard so enrichment cannot stale-recover active ownership.
+		_dedup_out=$("$dedup_helper" is-assigned-read-only "$issue_number" "$repo_slug" "${AIDEVOPS_SESSION_USER:-}" 2>/dev/null) || true
 		if [[ -n "$_dedup_out" ]]; then
 			echo "[dispatch_with_dedup] GH#19856: skipping force-enrich for #${issue_number} — active claim: ${_dedup_out}" >>"$LOGFILE"
 			return 0

--- a/.agents/scripts/tests/test-dispatch-dedup-multi-operator.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-multi-operator.sh
@@ -92,13 +92,13 @@ teardown_test_env() {
 #   $2 = comma-separated label names (or "" for none)
 #   $3 = issue state (default OPEN)
 #
-# The stub returns a recent "Dispatching worker" comment to prevent the
-# stale-assignment recovery path from firing during tests.
+# The stub returns a recent issue creation time and "Dispatching worker"
+# comment to prevent stale-assignment recovery during active-claim tests.
 create_gh_stub() {
 	local assignees_csv="$1"
 	local labels_csv="${2:-}"
 	local state="${3:-OPEN}"
-	local assignees_json labels_json recent_ts
+	local assignees_json labels_json recent_ts issue_created_ts
 
 	assignees_json=$(
 		ASSIGNEES_CSV="$assignees_csv" python3 - <<'PY'
@@ -115,13 +115,14 @@ print(json.dumps([{"name": i} for i in items]))
 PY
 	)
 	recent_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	issue_created_ts=$(date -u -v-120S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '120 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
 
 	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
 #!/usr/bin/env bash
 set -euo pipefail
 
 if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
-	printf '%s\n' '{"state":"${state}","assignees":${assignees_json},"labels":${labels_json}}'
+	printf '%s\n' '{"state":"${state}","assignees":${assignees_json},"labels":${labels_json},"createdAt":"${issue_created_ts}"}'
 	exit 0
 fi
 
@@ -377,19 +378,19 @@ test_interactive_on_worker_origin_blocks() {
 #
 # GH#18956 / t2091 — The classic single-user failure mode.
 #
-# Scenario: an interactive session filed issue #100 with origin:interactive
-# and self-assigned it (user=testorg=repo owner). The pulse runner is ALSO
+# Scenario: an interactive session owns issue #100 with origin:interactive,
+# status:in-review, and a self-assignment (user=testorg=repo owner). Pulse is ALSO
 # authenticated as testorg (single-user setup). The old code's self-login
 # exemption fired first → blocking_assignees was empty → pulse dispatched a
 # duplicate worker.
 #
 # Fix (t2091): the self-login exemption is skipped when active_claim=="true".
-# origin:interactive is an active claim signal, so the issue must block
-# dispatch even when assignee==self_login.
+# The lifecycle status keeps the claim active even when auto-dispatch remains
+# present, so the issue must block dispatch when assignee==self_login.
 test_single_user_interactive_self_assigned_blocks() {
 	# Interactive session: owner self-assigned, origin:interactive present.
 	# Pulse runner login == owner (single-user setup).
-	create_gh_stub "testorg" "origin:interactive,auto-dispatch,tier:standard"
+	create_gh_stub "testorg" "origin:interactive,status:in-review,auto-dispatch,tier:standard"
 
 	local output=""
 	# Pulse calls is_assigned() with self_login=testorg (same as assignee)

--- a/.agents/scripts/tests/test-enrich-dedup-guard.sh
+++ b/.agents/scripts/tests/test-enrich-dedup-guard.sh
@@ -5,7 +5,7 @@
 # test-enrich-dedup-guard.sh — GH#19856 regression guard.
 #
 # Asserts that the enrich path in issue-sync-helper.sh respects the
-# dispatch-dedup-helper.sh is-assigned guard before modifying issue
+# dispatch-dedup-helper.sh read-only assignment guard before modifying issue
 # labels, title, or body. Also verifies that coordination-signal labels
 # are protected by _is_protected_label.
 #
@@ -32,6 +32,7 @@ print_result() {
 		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
 		TESTS_FAILED=$((TESTS_FAILED + 1))
 	fi
+	return 0
 }
 
 # Sandbox HOME so sourcing is side-effect-free
@@ -89,32 +90,43 @@ for lbl in "bug" "enhancement" "simplification" "architecture"; do
 done
 
 # =============================================================================
-# Part 2 — dispatch-dedup-helper.sh is-assigned blocks on active claims
+# Part 2 — read-only assignment inspection blocks on active claims
 # =============================================================================
 # Stub the `gh` CLI to return synthetic issue payloads.
 STUB_DIR="${TEST_ROOT}/bin"
 mkdir -p "$STUB_DIR"
+GH_WRITE_LOG="${TEST_ROOT}/gh-writes.log"
+: >"$GH_WRITE_LOG"
+export GH_WRITE_LOG
 
 write_stub_gh() {
 	local payload="$1"
+	local fail_reads="${2:-false}"
 	cat >"${STUB_DIR}/gh" <<STUB
 #!/usr/bin/env bash
 # Stub gh for test — returns pre-configured JSON for issue view
 _main() {
 	local cmd="\$1" sub="\$2"
+	if [[ "\$cmd" == "issue" && ("\$sub" == "edit" || "\$sub" == "comment") ]]; then
+		printf '%s\n' "\$*" >>"\${GH_WRITE_LOG}"
+		return 0
+	fi
 	if [[ "\$cmd" == "issue" && "\$sub" == "view" ]]; then
+		[[ "${fail_reads}" == "true" ]] && return 1
 		echo '${payload}'
-		exit 0
+		return 0
 	fi
 	if [[ "\$cmd" == "api" ]]; then
+		[[ "${fail_reads}" == "true" ]] && return 1
 		echo '{"login": "testbot"}'
-		exit 0
+		return 0
 	fi
-	exit 1
+	return 1
 }
 _main "\$@"
 STUB
 	chmod +x "${STUB_DIR}/gh"
+	return 0
 }
 
 # Prepend stub dir so our stub shadows the real gh
@@ -122,7 +134,7 @@ export PATH="${STUB_DIR}:${PATH}"
 
 # Test: issue with status:in-review + assignee should block (return 0)
 write_stub_gh '{"state":"OPEN","assignees":[{"login":"runnerA"}],"labels":[{"name":"status:in-review"}]}'
-_dedup_result=$("${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" is-assigned 123 "test/repo" "runnerB" 2>/dev/null) || true
+_dedup_result=$("${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" is-assigned-read-only 123 "test/repo" "runnerB" 2>/dev/null) || true
 if [[ -n "$_dedup_result" ]]; then
 	print_result "is-assigned blocks when status:in-review + other assignee" 0
 else
@@ -131,7 +143,7 @@ fi
 
 # Test: issue with origin:interactive + assignee should block
 write_stub_gh '{"state":"OPEN","assignees":[{"login":"maintainer"}],"labels":[{"name":"origin:interactive"}]}'
-_dedup_result=$("${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" is-assigned 123 "test/repo" "runnerB" 2>/dev/null) || true
+_dedup_result=$("${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" is-assigned-read-only 123 "test/repo" "runnerB" 2>/dev/null) || true
 if [[ -n "$_dedup_result" ]]; then
 	print_result "is-assigned blocks when origin:interactive + assignee" 0
 else
@@ -140,7 +152,7 @@ fi
 
 # Test: issue with status:claimed + assignee should block
 write_stub_gh '{"state":"OPEN","assignees":[{"login":"runnerA"}],"labels":[{"name":"status:claimed"}]}'
-_dedup_result=$("${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" is-assigned 123 "test/repo" "runnerB" 2>/dev/null) || true
+_dedup_result=$("${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" is-assigned-read-only 123 "test/repo" "runnerB" 2>/dev/null) || true
 if [[ -n "$_dedup_result" ]]; then
 	print_result "is-assigned blocks when status:claimed + other assignee" 0
 else
@@ -149,7 +161,7 @@ fi
 
 # Test: issue with no active labels + no assignee should pass (return 1)
 write_stub_gh '{"state":"OPEN","assignees":[],"labels":[{"name":"bug"}]}'
-_dedup_result=$("${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" is-assigned 123 "test/repo" "runnerB" 2>/dev/null) || true
+_dedup_result=$("${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" is-assigned-read-only 123 "test/repo" "runnerB" 2>/dev/null) || true
 if [[ -z "$_dedup_result" ]]; then
 	print_result "is-assigned allows when no claim + no assignee" 0
 else
@@ -159,28 +171,44 @@ fi
 # =============================================================================
 # Part 3 — _enrich_process_task aborts when dedup guard fires
 # =============================================================================
-# This is a structural check: verify the guard code exists in the function body.
-# A live test would require too much scaffolding (TODO.md, brief files, etc.).
 # Check that the extracted helper function exists
-if grep -q '_enrich_check_active_claim()' "${TEST_SCRIPTS_DIR}/issue-sync-helper.sh"; then
+if grep -q '_enrich_check_active_claim()' "${TEST_SCRIPTS_DIR}/issue-sync-helper-enrich.sh"; then
 	print_result "_enrich_check_active_claim function exists (GH#19856)" 0
 else
 	print_result "_enrich_check_active_claim function exists (GH#19856)" 1 "(function not found)"
 fi
 
 # Check that _enrich_process_task calls the guard
-if grep -q '_enrich_check_active_claim' "${TEST_SCRIPTS_DIR}/issue-sync-helper.sh" | grep -v '^_enrich_check_active_claim()' >/dev/null 2>&1; then
-	# Fallback: just check the function is called somewhere in the file besides its own definition
-	true
-fi
-if grep -c '_enrich_check_active_claim' "${TEST_SCRIPTS_DIR}/issue-sync-helper.sh" | grep -q '^[2-9]'; then
+if grep -q 'if _enrich_check_active_claim' "${TEST_SCRIPTS_DIR}/issue-sync-helper.sh"; then
 	print_result "_enrich_process_task calls GH#19856 dedup guard" 0
 else
 	print_result "_enrich_process_task calls GH#19856 dedup guard" 1 "(guard call not found in _enrich_process_task)"
 fi
 
+# Exercise the real enrich guard with an old interactive claim. The read-only
+# path must block enrichment without edit/comment recovery writes (GH#28498).
+: >"$GH_WRITE_LOG"
+export AIDEVOPS_SESSION_USER="runnerB"
+active_claim_json='{"state":"OPEN","assignees":[{"login":"runnerA"}],"labels":[{"name":"origin:interactive"},{"name":"status:in-review"}]}'
+if _enrich_check_active_claim 123 "test/repo" "t28498" "$active_claim_json" >/dev/null 2>&1 \
+	&& [[ ! -s "$GH_WRITE_LOG" ]]; then
+	print_result "enrich guard blocks active interactive claim with zero GitHub writes" 0
+else
+	print_result "enrich guard blocks active interactive claim with zero GitHub writes" 1 "(guard passed or emitted a write)"
+fi
+
+# Metadata uncertainty must also fail closed without trying recovery writes.
+: >"$GH_WRITE_LOG"
+write_stub_gh '{}' true
+if _enrich_check_active_claim 123 "test/repo" "t28498" "" >/dev/null 2>&1 \
+	&& [[ ! -s "$GH_WRITE_LOG" ]]; then
+	print_result "enrich guard fails closed on uncertain metadata with zero GitHub writes" 0
+else
+	print_result "enrich guard fails closed on uncertain metadata with zero GitHub writes" 1 "(guard passed or emitted a write)"
+fi
+
 # Part 3b — _ensure_issue_body_has_brief also has the guard
-if grep -q 'GH#19856.*skipping force-enrich' "${TEST_SCRIPTS_DIR}/pulse-dispatch-core.sh"; then
+if grep -q 'is-assigned-read-only' "${TEST_SCRIPTS_DIR}/pulse-dispatch-core.sh"; then
 	print_result "_ensure_issue_body_has_brief contains GH#19856 dedup guard" 0
 else
 	print_result "_ensure_issue_body_has_brief contains GH#19856 dedup guard" 1 "(guard code not found)"


### PR DESCRIPTION
## Summary

Added a read-only assignment inspection command and routed both enrichment safety guards through it so stale recovery remains dispatch-only.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh, .agents/scripts/issue-sync-helper-enrich.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/tests/test-dispatch-dedup-multi-operator.sh, .agents/scripts/tests/test-enrich-dedup-guard.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Targeted enrich guard 35/35, stale recovery 6/6, multi-operator dedup 10/10, ShellCheck, Bash syntax, portability, complexity, secret, and local lint gates passed.

Resolves #28498


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.166 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 58m and 871,842 tokens on this with the user in an interactive session.