### PR TITLE
GH#28514: repair Remotion chapter references

### DIFF
--- a/.agents/configs/skill-sources.json
+++ b/.agents/configs/skill-sources.json
@@ -25,7 +25,7 @@
       "imported_at": "2026-01-21T04:58:00Z",
       "last_checked": "2026-01-21T04:58:00Z",
       "merge_strategy": "added",
-      "notes": "Includes 29 rule files in .agents/tools/video/remotion/",
+      "notes": "Includes 28 flat chapter files alongside .agents/tools/video/remotion.md",
       "context7_id": "/remotion-dev/remotion"
     },
     {

--- a/.agents/content/heygen-skill/rules-remotion-integration.md
+++ b/.agents/content/heygen-skill/rules-remotion-integration.md
@@ -166,7 +166,7 @@ WebM doesn't support `circle` style — use `normal`/`closeUp` with CSS circular
 
 ## Dynamic Duration
 
-Use `calculateMetadata` to set composition duration from the avatar video. See `tools/video/remotion/calculate-metadata.md` for full patterns.
+Use `calculateMetadata` to set composition duration from the avatar video. See `tools/video/remotion-calculate-metadata.md` for full patterns.
 
 ```tsx
 import { CalculateMetadataFunction } from "remotion";

--- a/.agents/tests/test-remotion-chapter-references.sh
+++ b/.agents/tests/test-remotion-chapter-references.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+repo_root=$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)
+index_file="$repo_root/.agents/tools/video/remotion.md"
+consumer_file="$repo_root/.agents/content/heygen-skill/rules-remotion-integration.md"
+registry_file="$repo_root/.agents/configs/skill-sources.json"
+expected_count=28
+
+if grep -Fq "tools/video/remotion/" "$index_file" "$consumer_file" "$registry_file"; then
+	printf 'Stale nested Remotion chapter path found:\n' >&2
+	grep -Fn "tools/video/remotion/" "$index_file" "$consumer_file" "$registry_file" >&2
+	exit 1
+fi
+
+chapter_refs=$(grep -oE 'tools/video/remotion-[[:alnum:]-]+\.md' "$index_file" | LC_ALL=C sort -u)
+chapter_count=$(printf '%s\n' "$chapter_refs" | grep -c '.')
+
+if [[ "$chapter_count" -ne "$expected_count" ]]; then
+	printf 'Expected %d unique Remotion chapter references, found %d\n' "$expected_count" "$chapter_count" >&2
+	exit 1
+fi
+
+while IFS= read -r chapter_ref; do
+	[[ -n "$chapter_ref" ]] || continue
+	tracked_path=".agents/$chapter_ref"
+	if [[ ! -f "$repo_root/$tracked_path" ]]; then
+		printf 'Remotion chapter reference does not exist: %s\n' "$tracked_path" >&2
+		exit 1
+	fi
+	if ! git -C "$repo_root" ls-files --error-unmatch "$tracked_path" >/dev/null 2>&1; then
+		printf 'Remotion chapter reference is not tracked: %s\n' "$tracked_path" >&2
+		exit 1
+	fi
+done <<<"$chapter_refs"
+
+printf 'PASS: %d flat Remotion chapter references resolve to tracked files\n' "$chapter_count"

--- a/.agents/tools/video/remotion.md
+++ b/.agents/tools/video/remotion.md
@@ -37,28 +37,28 @@ Programmatic video creation using React with frame-by-frame control.
 
 ## Chapter Files
 
-Detailed patterns and code in `tools/video/remotion/`:
+Paths below are relative to the active agent root (`~/.aidevops/agents/` by default; source checkout: `.agents/`):
 
 **Core animation & timing:**
-`animations.md` | `timing.md` | `sequencing.md` | `trimming.md` | `transitions.md`
+`tools/video/remotion-animations.md` | `tools/video/remotion-timing.md` | `tools/video/remotion-sequencing.md` | `tools/video/remotion-trimming.md` | `tools/video/remotion-transitions.md`
 
 **Compositions & metadata:**
-`compositions.md` | `calculate-metadata.md`
+`tools/video/remotion-compositions.md` | `tools/video/remotion-calculate-metadata.md`
 
 **Media embedding:**
-`videos.md` | `audio.md` | `images.md` | `assets.md` | `fonts.md` | `gifs.md`
+`tools/video/remotion-videos.md` | `tools/video/remotion-audio.md` | `tools/video/remotion-images.md` | `tools/video/remotion-assets.md` | `tools/video/remotion-fonts.md` | `tools/video/remotion-gifs.md`
 
 **Text & data visualization:**
-`text-animations.md` | `charts.md` | `lottie.md` | `3d.md`
+`tools/video/remotion-text-animations.md` | `tools/video/remotion-charts.md` | `tools/video/remotion-lottie.md` | `tools/video/remotion-3d.md`
 
 **Captions & subtitles:**
-`transcribe-captions.md` | `display-captions.md` | `import-srt-captions.md`
+`tools/video/remotion-transcribe-captions.md` | `tools/video/remotion-display-captions.md` | `tools/video/remotion-import-srt-captions.md`
 
 **Utilities:**
-`can-decode.md` | `extract-frames.md` | `get-audio-duration.md` | `get-video-duration.md` | `get-video-dimensions.md` | `measuring-dom-nodes.md` | `measuring-text.md`
+`tools/video/remotion-can-decode.md` | `tools/video/remotion-extract-frames.md` | `tools/video/remotion-get-audio-duration.md` | `tools/video/remotion-get-video-duration.md` | `tools/video/remotion-get-video-dimensions.md` | `tools/video/remotion-measuring-dom-nodes.md` | `tools/video/remotion-measuring-text.md`
 
 **Setup:**
-`tailwind.md`
+`tools/video/remotion-tailwind.md`
 
 ## CLI Commands
 


### PR DESCRIPTION
## Summary

Replace stale pre-flatten Remotion chapter paths across the skill index, HeyGen consumer, and skill registry; add a contract test covering all 28 chapters.

## Files Changed

.agents/configs/skill-sources.json, .agents/content/heygen-skill/rules-remotion-integration.md, .agents/tests/test-remotion-chapter-references.sh, .agents/tools/video/remotion.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Remotion contract test passed; shellcheck passed; jq validation passed; changed-file linters-local gate passed.

Resolves #28514


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.167 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 20m and 564,330 tokens on this with the user in an interactive session.