### PR TITLE
GH#28519: Replace broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2900,4 +2900,8 @@ bash <(curl -fsSL https://aidevops.sh/install)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=marcusquinn/aidevops&type=Date)](https://star-history.com/#marcusquinn/aidevops&Date)
+[View the aidevops star history on Star History](https://star-history.com/#marcusquinn/aidevops&Date).
+
+> GitHub now restricts historical stargazer data to repository collaborators,
+> so Star History requires an authorised GitHub session instead of supporting a
+> public README chart.


### PR DESCRIPTION
## Summary

Resolves #28519

- remove the Star History image endpoint that now returns HTTP 500
- retain a direct Star History link for authorised repository collaborators
- explain GitHub's historical stargazer access restriction inline

## Files and pattern

- `README.md`: replace the public remote image embed with durable Markdown text
- Pattern: avoid third-party README images when the provider documents that public rendering is no longer supported

## Verification

- `.agents/scripts/linters-local.sh --changed`
- `git diff --check origin/main...HEAD`
- confirmed the removed image endpoint returns HTTP 500
- confirmed the retained Star History page returns HTTP 200

## Runtime Testing

- Self-assessed: documentation-only, low-risk change

## Decisions

- Did not embed an access token in the public README; collaborators can authenticate on Star History when they need the historical chart.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.168 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 6m and 127,045 tokens on this with the user in an interactive session.
