### PR TITLE
GH#28527: Standardize managed README star history and attribution

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -1519,6 +1519,7 @@ _init_optional_scaffolding() {
 	# references relative docs/metrics assets, so freshly initialised READMEs do
 	# not depend on remote badge services or a delayed GitHub Actions commit.
 	local _badges_helper="$AGENTS_DIR/scripts/readme-badges-helper.sh"
+	local _managed_readme_helper="$AGENTS_DIR/scripts/managed-readme-helper.sh"
 	local _metrics_helper="$AGENTS_DIR/scripts/repo-metrics-helper.sh"
 	local _label_sync_helper="$AGENTS_DIR/scripts/label-sync-helper.sh"
 	local _wf_template="$AGENTS_DIR/templates/workflows/loc-badge-caller.yml"
@@ -1553,6 +1554,19 @@ _init_optional_scaffolding() {
 			print_info "No README.md found — skipping badge block injection (create README.md first)"
 		fi
 
+		# Seed the managed Star History chart, weekly caller, and verified
+		# Built with aidevops section. Authentication or metadata failures are
+		# fail-soft so initialization never invents ownership or emits a broken embed.
+		if [[ "$_is_local_only" != "true" && -f "$_managed_readme_helper" && -f "$_readme_path" ]]; then
+			if bash "$_managed_readme_helper" sync --repo "$repo_slug" --root "$project_root"; then
+				print_success "Seeded managed Star History and aidevops README sections"
+			else
+				print_warning "Managed README sections skipped — verify GitHub ownership, then run: managed-readme-helper.sh sync --repo $repo_slug --root $project_root"
+			fi
+		elif [[ "$_is_local_only" == "true" ]]; then
+			print_info "Skipping managed Star History and aidevops attribution for local-only repo"
+		fi
+
 		# Generate committed local metrics after README injection so LOC/language
 		# numbers include the final README badge block.
 		if [[ -f "$_metrics_helper" ]]; then
@@ -1582,7 +1596,7 @@ _init_optional_scaffolding() {
 
 		# Remind about SYNC_PAT if the repo has a remote and isn't local_only
 		if [[ "$_is_local_only" != "true" ]]; then
-			print_info "Reminder: set SYNC_PAT secret so GitHub Actions can refresh repo metrics — see: aidevops --help sync-pat"
+			print_info "Reminder: set SYNC_PAT so GitHub Actions can refresh repo metrics and Star History — see: aidevops --help sync-pat"
 		fi
 	fi
 

--- a/.agents/scripts/managed-readme-helper.sh
+++ b/.agents/scripts/managed-readme-helper.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Synchronize managed Star History and aidevops attribution README sections.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+usage() {
+	printf '%s\n' 'Usage: managed-readme-helper.sh sync|check --repo OWNER/REPO [--root PATH]'
+	return 0
+}
+
+main() {
+	local command="${1:-}"
+	case "$command" in
+	sync | check)
+		shift
+		;;
+	help | --help | -h)
+		usage
+		return 0
+		;;
+	*)
+		usage >&2
+		return 2
+		;;
+	esac
+	command -v python3 >/dev/null 2>&1 || {
+		printf '%s\n' 'managed-readme: python3 is required' >&2
+		return 1
+	}
+	python3 "$SCRIPT_DIR/managed_readme.py" "$command" "$@"
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/managed_readme.py
+++ b/.agents/scripts/managed_readme.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Synchronize managed Star History and aidevops attribution README sections."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+MARKER_START = "<!-- aidevops:managed-readme:start -->"
+MARKER_END = "<!-- aidevops:managed-readme:end -->"
+PERMISSIONS = {"ADMIN", "MAINTAIN", "WRITE"}
+SLUG_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+LEGACY_SECTION = re.compile(
+    r"(?ms)^## (?:Star History|Built with aidevops|Created with aidevops)\s*$.*?(?=^## |\Z)"
+)
+TRAILING_METADATA = re.compile(
+    r"(?ms)(\n(?:\s*\[[^\]\n]+\]:[^\n]*\n|\s*<!--.*?-->\s*)+)\Z"
+)
+
+
+def repos_file() -> Path:
+    return Path(os.environ.get("AIDEVOPS_REPOS_FILE", "~/.config/aidevops/repos.json")).expanduser()
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def registry_entry(root: Path, slug: str) -> dict[str, Any] | None:
+    payload = load_json(repos_file())
+    if not isinstance(payload, dict):
+        return None
+    resolved_root = root.resolve()
+    for item in payload.get("initialized_repos", []):
+        if not isinstance(item, dict):
+            continue
+        raw_path = str(item.get("path", ""))
+        item_path = Path(raw_path).expanduser() if raw_path else None
+        slug_match = item.get("slug") == slug
+        path_match = item_path is not None and item_path.resolve() == resolved_root
+        if slug_match or path_match:
+            return item
+    return None
+
+
+def is_managed(root: Path, slug: str) -> tuple[bool, str]:
+    entry = registry_entry(root, slug)
+    if entry:
+        if entry.get("local_only") is True:
+            return False, "local-only repository"
+        if entry.get("contributed") is True:
+            return False, "external contributed repository"
+        return True, "repos.json"
+    if (root / ".aidevops.json").is_file():
+        return True, ".aidevops.json"
+    return False, "repository is not managed by aidevops"
+
+
+def run_json(command: list[str]) -> Any:
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    return json.loads(completed.stdout)
+
+
+def verified_owner(slug: str) -> tuple[str, str]:
+    metadata = run_json(["gh", "repo", "view", slug, "--json", "nameWithOwner,viewerPermission"])
+    if metadata.get("nameWithOwner") != slug:
+        raise RuntimeError("GitHub repository identity did not match the requested slug")
+    if metadata.get("viewerPermission") not in PERMISSIONS:
+        raise RuntimeError("maintainer-equivalent GitHub access is required")
+    owner = run_json(["gh", "api", f"repos/{slug}"])
+    owner_url = owner.get("owner", {}).get("html_url") if isinstance(owner, dict) else None
+    if not isinstance(owner_url, str) or not owner_url.startswith("https://github.com/"):
+        raise RuntimeError("GitHub owner URL could not be verified")
+    return slug.split("/", 1)[0], owner_url
+
+
+def render_block(slug: str, owner: str, owner_url: str) -> str:
+    return f"""{MARKER_START}
+<!-- managed by aidevops; refresh with managed-readme-helper.sh sync -->
+## Star History
+
+![{slug} stars over time](docs/assets/star-history.svg)
+
+## Built with aidevops
+
+This project was created and is maintained with
+[aidevops.sh](https://aidevops.sh).
+
+[View {owner} on GitHub]({owner_url}) ·
+[aidevops repository](https://github.com/marcusquinn/aidevops)
+{MARKER_END}"""
+
+
+def replace_block(readme: Path, block: str) -> bool:
+    original = readme.read_text(encoding="utf-8")
+    marker_pattern = re.compile(
+        rf"(?ms)^{re.escape(MARKER_START)}$.*?^{re.escape(MARKER_END)}\s*"
+    )
+    content = marker_pattern.sub("", original).rstrip()
+    trailing = ""
+    trailing_match = TRAILING_METADATA.search(content)
+    if trailing_match:
+        trailing = trailing_match.group(1).strip()
+        content = content[: trailing_match.start()].rstrip()
+    content = LEGACY_SECTION.sub("", content).rstrip()
+    updated = f"{content}\n\n{block}"
+    if trailing:
+        updated = f"{updated}\n\n{trailing}"
+    updated = f"{updated}\n"
+    if updated == original:
+        return False
+    readme.write_text(updated, encoding="utf-8")
+    return True
+
+
+def generate_chart(chart: Path, slug: str, script_dir: Path) -> bool:
+    before = chart.read_bytes() if chart.exists() else None
+    base_command = [
+        "bash",
+        str(script_dir / "star-history-helper.sh"),
+    ]
+    try:
+        subprocess.run(
+            base_command + ["fetch", "--repo", slug, "--output", str(chart)],
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        if chart.exists():
+            print("managed-readme: live Star History refresh failed; preserving existing chart", file=sys.stderr)
+            return False
+        subprocess.run(
+            base_command + ["seed", "--repo", slug, "--output", str(chart)],
+            check=True,
+        )
+    return before != chart.read_bytes()
+
+
+def ensure_assets(root: Path, slug: str, script_dir: Path, template: Path) -> list[str]:
+    changed: list[str] = []
+    chart = root / "docs/assets/star-history.svg"
+    if generate_chart(chart, slug, script_dir):
+        changed.append("docs/assets/star-history.svg")
+    workflow = root / ".github/workflows/star-history.yml"
+    if not workflow.exists():
+        workflow.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(template, workflow)
+        changed.append(".github/workflows/star-history.yml")
+    return changed
+
+
+def sync(root: Path, slug: str, script_dir: Path, template: Path) -> int:
+    managed, reason = is_managed(root, slug)
+    if not managed:
+        print(f"managed-readme: skipped {slug}: {reason}", file=sys.stderr)
+        return 0
+    readme = root / "README.md"
+    if not readme.is_file():
+        print(f"managed-readme: README.md not found in {root}", file=sys.stderr)
+        return 1
+    try:
+        owner, owner_url = verified_owner(slug)
+        changed = ensure_assets(root, slug, script_dir, template)
+        if replace_block(readme, render_block(slug, owner, owner_url)):
+            changed.append("README.md")
+    except (FileNotFoundError, OSError, RuntimeError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        print(f"managed-readme: {exc}", file=sys.stderr)
+        return 1
+    state = ", ".join(changed) if changed else "already current"
+    print(f"managed-readme: {slug}: {state}", file=sys.stderr)
+    return 0
+
+
+def check(root: Path, slug: str) -> int:
+    managed, reason = is_managed(root, slug)
+    if not managed:
+        print(f"managed-readme: skipped {slug}: {reason}", file=sys.stderr)
+        return 0
+    readme = root / "README.md"
+    required = [
+        readme,
+        root / "docs/assets/star-history.svg",
+        root / ".github/workflows/star-history.yml",
+    ]
+    missing = [str(path.relative_to(root)) for path in required if not path.is_file()]
+    text = readme.read_text(encoding="utf-8") if readme.is_file() else ""
+    if text.count(MARKER_START) != 1 or text.count(MARKER_END) != 1:
+        missing.append("one managed README marker block")
+    if missing:
+        print(f"managed-readme: drift: {', '.join(missing)}", file=sys.stderr)
+        return 3
+    print(f"managed-readme: {slug}: current", file=sys.stderr)
+    return 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("sync", "check"))
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--root", default=".")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if not SLUG_PATTERN.fullmatch(args.repo):
+        print("managed-readme: invalid repository slug", file=sys.stderr)
+        return 2
+    root = Path(args.root).resolve()
+    script_dir = Path(__file__).resolve().parent
+    template = script_dir.parent / "templates/workflows/star-history-caller.yml"
+    if args.command == "check":
+        return check(root, args.repo)
+    if not template.is_file():
+        print(f"managed-readme: missing workflow template: {template}", file=sys.stderr)
+        return 1
+    return sync(root, args.repo, script_dir, template)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.agents/scripts/star-history-helper.sh
+++ b/.agents/scripts/star-history-helper.sh
@@ -12,13 +12,14 @@ usage() {
 	printf '%s\n' 'Usage:'
 	printf '%s\n' '  star-history-helper.sh fetch --repo OWNER/REPO --output FILE'
 	printf '%s\n' '  star-history-helper.sh render --repo OWNER/REPO --input FILE --output FILE'
+	printf '%s\n' '  star-history-helper.sh seed --repo OWNER/REPO --output FILE'
 	return 0
 }
 
 main() {
 	local command="${1:-}"
 	case "$command" in
-	fetch | render)
+	fetch | render | seed)
 		shift
 		;;
 	help | --help | -h)

--- a/.agents/scripts/star_history.py
+++ b/.agents/scripts/star_history.py
@@ -225,7 +225,7 @@ def write_if_changed(path: Path, content: str) -> bool:
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate a static repository star-history SVG")
     subparsers = parser.add_subparsers(dest="command", required=True)
-    for command in ("fetch", "render"):
+    for command in ("fetch", "render", "seed"):
         subparser = subparsers.add_parser(command)
         subparser.add_argument("--repo", required=True, help="repository slug (owner/name)")
         subparser.add_argument("--output", required=True, help="SVG output path")
@@ -239,9 +239,11 @@ def main(argv: list[str]) -> int:
     try:
         if args.command == "fetch":
             timestamps = fetch_timestamps(args.repo)
-        else:
+        elif args.command == "render":
             payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
             timestamps = extract_timestamps(payload)
+        else:
+            timestamps = []
         changed = write_if_changed(Path(args.output), render_svg(args.repo, timestamps))
     except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
         print(f"star-history: {exc}", file=sys.stderr)

--- a/.agents/scripts/tests/test-managed-readme-helper.sh
+++ b/.agents/scripts/tests/test-managed-readme-helper.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression tests for managed README Star History and provenance sections.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+HELPER="$REPO_ROOT/.agents/scripts/managed-readme-helper.sh"
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+cleanup() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+trap cleanup EXIT
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n     %s\n' "$name" "$detail" >&2
+	return 0
+}
+
+assert_file() {
+	local name="$1"
+	local file="$2"
+	if [[ -f "$file" ]]; then
+		pass "$name"
+		return 0
+	fi
+	fail "$name" "missing file: $file"
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local file="$2"
+	local pattern="$3"
+	if grep -Fq -- "$pattern" "$file"; then
+		pass "$name"
+		return 0
+	fi
+	fail "$name" "missing pattern: $pattern"
+	return 0
+}
+
+assert_count() {
+	local name="$1"
+	local file="$2"
+	local pattern="$3"
+	local expected="$4"
+	local actual=""
+	actual=$(grep -Fc -- "$pattern" "$file" || true)
+	if [[ "$actual" == "$expected" ]]; then
+		pass "$name"
+		return 0
+	fi
+	fail "$name" "expected $expected occurrences of $pattern, got $actual"
+	return 0
+}
+
+write_gh_stub() {
+	local bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"$bin_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+  slug="${3:-}"
+  permission="${GH_STUB_PERMISSION:-ADMIN}"
+  printf '{"nameWithOwner":"%s","viewerPermission":"%s"}\n' "$slug" "$permission"
+  exit 0
+fi
+if [[ "${1:-}" == "api" ]]; then
+  if [[ "${2:-}" == "--paginate" && "${GH_STUB_FETCH_FAIL:-0}" == "1" ]]; then
+    exit 1
+  fi
+  printf '{"owner":{"html_url":"https://github.com/exampleorg"}}\n'
+  exit 0
+fi
+exit 1
+STUB
+	chmod +x "$bin_dir/gh"
+	return 0
+}
+
+test_created_repo_sync() {
+	local root="$TEST_ROOT/created"
+	local bin_dir="$TEST_ROOT/bin"
+	mkdir -p "$root"
+	write_gh_stub "$bin_dir"
+	printf '{}\n' >"$root/.aidevops.json"
+	cat >"$root/README.md" <<'README'
+# Example
+
+Custom project content.
+
+## Star History
+
+Old chart.
+
+## Built with aidevops
+
+Old attribution.
+
+[custom-reference]: https://example.com/docs
+
+<!-- generated: keep -->
+README
+	GH_STUB_FETCH_FAIL=1 PATH="$bin_dir:$PATH" \
+		bash "$HELPER" sync --repo exampleorg/example --root "$root"
+	assert_file "created repo receives static chart" "$root/docs/assets/star-history.svg"
+	assert_contains "failed live fetch falls back to a valid placeholder" "$root/docs/assets/star-history.svg" "No star history available"
+	assert_file "created repo receives refresh caller" "$root/.github/workflows/star-history.yml"
+	assert_contains "custom README content is preserved" "$root/README.md" "Custom project content."
+	assert_contains "verified owner root is rendered" "$root/README.md" "https://github.com/exampleorg"
+	assert_contains "trailing link definitions are preserved" "$root/README.md" "[custom-reference]: https://example.com/docs"
+	assert_contains "trailing generated comments are preserved" "$root/README.md" "<!-- generated: keep -->"
+	assert_count "Star History is unique" "$root/README.md" "## Star History" 1
+	assert_count "aidevops attribution is unique" "$root/README.md" "## Built with aidevops" 1
+	local first=""
+	first=$(cksum "$root/README.md" "$root/docs/assets/star-history.svg" "$root/.github/workflows/star-history.yml")
+	PATH="$bin_dir:$PATH" bash "$HELPER" sync --repo exampleorg/example --root "$root"
+	local second=""
+	second=$(cksum "$root/README.md" "$root/docs/assets/star-history.svg" "$root/.github/workflows/star-history.yml")
+	if [[ "$first" == "$second" ]]; then
+		pass "managed README sync is idempotent"
+	else
+		fail "managed README sync is idempotent" "checksums changed on the second run"
+	fi
+	PATH="$bin_dir:$PATH" bash "$HELPER" check --repo exampleorg/example --root "$root"
+	pass "managed README check accepts current files"
+	return 0
+}
+
+test_registry_and_exclusions() {
+	local managed="$TEST_ROOT/managed"
+	local local_only="$TEST_ROOT/local"
+	local contributed="$TEST_ROOT/contributed"
+	local bin_dir="$TEST_ROOT/bin"
+	mkdir -p "$managed" "$local_only" "$contributed"
+	printf '# Managed\n' >"$managed/README.md"
+	printf '# Local\n' >"$local_only/README.md"
+	printf '# Contributed\n' >"$contributed/README.md"
+	cat >"$TEST_ROOT/repos.json" <<JSON
+{"initialized_repos":[
+  {"slug":"exampleorg/managed","path":"$managed"},
+  {"slug":"exampleorg/local","path":"$local_only","local_only":true},
+  {"slug":"upstream/contributed","path":"$contributed","contributed":true}
+]}
+JSON
+	AIDEVOPS_REPOS_FILE="$TEST_ROOT/repos.json" PATH="$bin_dir:$PATH" \
+		bash "$HELPER" sync --repo exampleorg/managed --root "$managed"
+	assert_file "repos.json managed repo is synchronized" "$managed/docs/assets/star-history.svg"
+	AIDEVOPS_REPOS_FILE="$TEST_ROOT/repos.json" PATH="$bin_dir:$PATH" \
+		bash "$HELPER" sync --repo exampleorg/local --root "$local_only"
+	AIDEVOPS_REPOS_FILE="$TEST_ROOT/repos.json" PATH="$bin_dir:$PATH" \
+		bash "$HELPER" sync --repo upstream/contributed --root "$contributed"
+	if [[ ! -e "$local_only/docs/assets/star-history.svg" && ! -e "$contributed/docs/assets/star-history.svg" ]]; then
+		pass "local-only and contributed repos remain unchanged"
+	else
+		fail "local-only and contributed repos remain unchanged" "an excluded chart was created"
+	fi
+	return 0
+}
+
+test_permission_failure() {
+	local root="$TEST_ROOT/read-only"
+	local bin_dir="$TEST_ROOT/bin"
+	mkdir -p "$root"
+	printf '{}\n' >"$root/.aidevops.json"
+	printf '# Read only\n' >"$root/README.md"
+	if GH_STUB_PERMISSION=READ PATH="$bin_dir:$PATH" \
+		bash "$HELPER" sync --repo exampleorg/read-only --root "$root" >/dev/null 2>&1; then
+		fail "read-only GitHub access fails closed" "sync unexpectedly succeeded"
+	else
+		pass "read-only GitHub access fails closed"
+	fi
+	if [[ ! -e "$root/docs/assets/star-history.svg" ]]; then
+		pass "permission failure creates no public artifact"
+	else
+		fail "permission failure creates no public artifact" "chart was created"
+	fi
+	return 0
+}
+
+main() {
+	TEST_ROOT=$(mktemp -d)
+	test_created_repo_sync
+	test_registry_and_exclusions
+	test_permission_failure
+	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-star-history-helper.sh
+++ b/.agents/scripts/tests/test-star-history-helper.sh
@@ -9,6 +9,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
 HELPER="$REPO_ROOT/.agents/scripts/star-history-helper.sh"
 WORKFLOW="$REPO_ROOT/.github/workflows/update-star-history.yml"
+REUSABLE_WORKFLOW="$REPO_ROOT/.github/workflows/star-history-reusable.yml"
+CALLER_TEMPLATE="$REPO_ROOT/.agents/templates/workflows/star-history-caller.yml"
 DOCS_WORKFLOW="$REPO_ROOT/.github/workflows/update-website-docs.yml"
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -84,6 +86,9 @@ test_empty_and_single_point() {
 	bash "$HELPER" render --repo marcusquinn/aidevops --input "$single" --output "$single_svg"
 	assert_contains "empty input renders a stable placeholder" "$empty_svg" "No star history available"
 	assert_contains "single point renders without division errors" "$single_svg" "1 star"
+	local seeded_svg="$temp_dir/seeded.svg"
+	bash "$HELPER" seed --repo exampleorg/example --output "$seeded_svg"
+	assert_contains "seed command creates an immediate placeholder" "$seeded_svg" "No star history available"
 	return 0
 }
 
@@ -103,9 +108,15 @@ test_safe_input_handling() {
 test_workflow_contract() {
 	# shellcheck disable=SC2016 # GitHub expression is an intentional literal contract.
 	local token_contract='GH_TOKEN: ${{ secrets.SYNC_PAT }}'
+	# shellcheck disable=SC2016 # GitHub expression is an intentional literal contract.
+	local caller_token_contract='SYNC_PAT: ${{ secrets.SYNC_PAT }}'
 	assert_contains "workflow has a weekly schedule" "$WORKFLOW" "cron: '17 3 * * 0'"
 	assert_contains "workflow requires owner-authorised token" "$WORKFLOW" "$token_contract"
 	assert_contains "workflow generates only the static asset" "$WORKFLOW" "docs/assets/star-history.svg"
+	assert_contains "reusable workflow uses caller repository identity" "$REUSABLE_WORKFLOW" 'GITHUB_REPOSITORY'
+	assert_contains "reusable workflow requires SYNC_PAT" "$REUSABLE_WORKFLOW" 'required: true'
+	assert_contains "caller schedules weekly refresh" "$CALLER_TEMPLATE" "cron: '17 3 * * 0'"
+	assert_contains "caller maps owner-authorised token" "$CALLER_TEMPLATE" "$caller_token_contract"
 	assert_contains "docs sync watches chart updates" "$DOCS_WORKFLOW" "'docs/assets/star-history.svg'"
 	assert_contains "docs conversion uses the published website asset" "$DOCS_WORKFLOW" "'](/star-history.svg)'"
 	assert_contains "docs sync publishes chart asset" "$DOCS_WORKFLOW" "cp docs/assets/star-history.svg website/star-history.svg"

--- a/.agents/templates/workflows/star-history-caller.yml
+++ b/.agents/templates/workflows/star-history-caller.yml
@@ -1,0 +1,17 @@
+name: Update Star History
+
+on:
+  schedule:
+    - cron: '17 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    uses: marcusquinn/aidevops/.github/workflows/star-history-reusable.yml@main
+    with:
+      aidevops_ref: main
+    secrets:
+      SYNC_PAT: ${{ secrets.SYNC_PAT }}

--- a/.agents/workflows/readme-create-update.md
+++ b/.agents/workflows/readme-create-update.md
@@ -33,8 +33,8 @@ tools:
 - Prioritize maintainability over exhaustive detail
 - Avoid staleness: no hardcoded counts, version numbers, or full file listings
 - Use generated `docs/metrics` artifacts for LOC, language, and dependency badges; use approximate prose counts (`~15 agents`, `100+ scripts`) elsewhere
-- End managed GitHub repository READMEs with one verified owner and aidevops
-  provenance section
+- Give eligible managed GitHub READMEs one static Star History chart followed
+  by one verified owner and aidevops provenance section
 
 **Dynamic Counts (aidevops repo)**:
 
@@ -55,6 +55,17 @@ This writes `docs/metrics/repo-metrics.json`, `docs/metrics/repo-metrics.md`,
 and local SVG badges for lines of code, languages, and dependencies. README
 badge sections should reference those relative files instead of remote LOC or
 GitHub language badge services.
+
+**Managed README sections (aidevops-created and `repos.json` repositories)**:
+
+```bash
+~/.aidevops/agents/scripts/managed-readme-helper.sh sync \
+  --repo VERIFIED_OWNER/VERIFIED_REPO --root .
+```
+
+The helper verifies maintainer-equivalent GitHub access, seeds a local
+`docs/assets/star-history.svg`, installs the weekly reusable workflow caller,
+and maintains marker-bounded Star History and aidevops attribution sections.
 
 **Commands**:
 
@@ -108,6 +119,11 @@ current account lacks maintainer-equivalent access, omit the provenance footer
 unless the user explicitly requests and confirms the attribution. Never claim
 that an external upstream was created or maintained with aidevops.
 
+Treat the repository as README-managed when it has `.aidevops.json` or a
+matching `initialized_repos` entry in `~/.config/aidevops/repos.json`. Exclude
+entries marked `local_only: true` or `contributed: true`. Registration alone
+never overrides the verified GitHub permission and owner checks above.
+
 ### Step 3: Check Existing README
 
 If README.md exists: read fully, identify accurate vs outdated sections, preserve custom content and structure, update only what needs updating. Don't reorganize unless requested.
@@ -130,13 +146,29 @@ Only ask if you cannot determine: what the project does, specific deployment cre
 10. **Deployment** — production setup (platform-specific)
 11. **Troubleshooting** — common issues with cause + fix commands
 12. **License & Credits**
-13. **Built with aidevops** — mandatory final reader-facing section for managed
+13. **Star History** — local static SVG for eligible managed GitHub repositories
+14. **Built with aidevops** — mandatory final reader-facing section for managed
     GitHub repositories
+
+## Managed Star History
+
+Do not embed a third-party chart URL. For each eligible managed repository, run
+`managed-readme-helper.sh sync` after the prose update. It creates a stable
+placeholder immediately and installs `.github/workflows/star-history.yml`,
+which calls the central reusable workflow weekly and on manual dispatch. The
+workflow requires the repository's `SYNC_PAT` because GitHub restricts
+timestamped stargazer history to collaborators. Public SVGs contain only
+timestamps and cumulative counts, never stargazer identities or token data.
+
+Keep exactly one **Star History** section directly before **Built with
+aidevops**. Omit both managed sections for external, contributed, local-only,
+unverified, or read-only repositories unless the user explicitly confirms the
+attribution and has authority to install the workflow.
 
 ## Repository Provenance Footer
 
 For a managed GitHub repository, add or refresh this final reader-facing
-section during every full or targeted README update:
+section after Star History during every full or targeted README update:
 
 ```markdown
 ## Built with aidevops
@@ -201,9 +233,10 @@ This project was created and is maintained with
 
 When using `/readme --sections`: read the entire existing README first,
 preserve its structure and custom content, update only specified sections, and
-maintain consistent style. For managed GitHub repositories, also add or refresh
-the provenance footer because it is a README invariant rather than optional
-section scope. See `scripts/commands/readme.md` for the section mapping table.
+maintain consistent style. For managed GitHub repositories, also run
+`managed-readme-helper.sh sync` so Star History and the provenance footer remain
+invariants rather than optional section scope. See `scripts/commands/readme.md`
+for the section mapping table.
 
 ## Quality Checklist
 
@@ -217,7 +250,8 @@ Before finalizing, verify:
 - Troubleshooting covers common issues?
 - Environment variables documented with examples?
 - License clearly stated?
-- Managed GitHub repository has exactly one final provenance section with a
+- Eligible managed GitHub repository has one local Star History chart, its
+  reusable refresh caller, and exactly one final provenance section with a
   verified owner-root link and both aidevops links?
 - External upstream attribution omitted unless explicitly confirmed?
 

--- a/.agents/workflows/readme.md
+++ b/.agents/workflows/readme.md
@@ -23,10 +23,12 @@ Use `--sections` for targeted updates (adding a feature, changing install/config
 2. **Load voice guidance when relevant** — if the request mentions humanise, writing style, tone, voice, less AI writing, or marketing/intro copy, read `content/humanise.md`
 3. **Explore codebase** — detect project type, deployment platform, existing README, key info
 4. **Generate/update** — follow workflow section order; preserve structure for
-   partial updates; use local `docs/metrics` badges for
-   LOC/languages/dependencies; add or refresh the final aidevops provenance
-   section for managed GitHub repositories
-5. **Confirm changes** — present diff and ask before writing (interactive only)
+   partial updates; use local `docs/metrics` badges for LOC/languages/dependencies
+5. **Synchronize managed sections** — for an aidevops-created repository or an
+   eligible `repos.json` entry, run `managed-readme-helper.sh sync --repo
+   VERIFIED_SLUG --root .` to seed or refresh the static Star History chart,
+   caller workflow, and final aidevops attribution
+6. **Confirm changes** — present diff and ask before writing (interactive only)
 
 ## Section Mapping
 
@@ -39,15 +41,17 @@ Use `--sections` for targeted updates (adding a feature, changing install/config
 | `troubleshooting` | Troubleshooting |
 | `deployment` | Deployment, Production Setup |
 | `badges` | Badge section only |
+| `star-history` | Static Star History chart and managed refresh caller |
 | `provenance` | Final owner and aidevops credit section |
 | `all` | Full regeneration (same as no flag) |
 
-The provenance section is a managed-repository invariant: full and targeted
-updates keep exactly one copy at the end. Ownership, URL derivation, and
-external-upstream exceptions are defined in `workflows/readme-create-update.md`.
+Star History and provenance are managed-repository invariants: full and targeted
+updates keep exactly one of each. Ownership, `repos.json` eligibility, and
+external/local-only exceptions are defined in `workflows/readme-create-update.md`.
 
 **Dynamic counts (aidevops repo):** `readme-helper.sh check|update|update --apply`
 **Repo metrics (all repos):** `repo-metrics-helper.sh generate` or `aidevops metrics generate`
+**Managed README sections:** `managed-readme-helper.sh sync|check --repo OWNER/REPO --root .`
 
 ## Related
 

--- a/.github/workflows/star-history-reusable.yml
+++ b/.github/workflows/star-history-reusable.yml
@@ -1,0 +1,88 @@
+name: Star History (reusable) — generate static README chart
+
+on:
+  workflow_call:
+    inputs:
+      aidevops_repository:
+        description: Repository containing the shared chart generator
+        required: false
+        type: string
+        default: marcusquinn/aidevops
+      aidevops_ref:
+        description: Ref containing the shared chart generator
+        required: false
+        type: string
+        default: main
+      runner:
+        description: Runner label
+        required: false
+        type: string
+        default: ubuntu-latest
+    secrets:
+      SYNC_PAT:
+        description: Owner-authorised token for stargazer history and protected pushes
+        required: true
+
+jobs:
+  update:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 10
+    concurrency:
+      group: star-history-${{ github.repository }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    steps:
+      - name: Require owner-authorised repository token
+        env:
+          SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
+        run: |
+          if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
+            echo "::error::SYNC_PAT is required because GitHub restricts timestamped stargazer history to repository collaborators."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.SYNC_PAT }}
+          fetch-depth: 1
+
+      - name: Checkout aidevops chart generator
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: ${{ inputs.aidevops_repository }}
+          ref: ${{ inputs.aidevops_ref }}
+          path: __aidevops
+          fetch-depth: 1
+
+      - name: Generate static Star History chart
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: |
+          bash __aidevops/.agents/scripts/star-history-helper.sh fetch \
+            --repo "$GITHUB_REPOSITORY" \
+            --output docs/assets/star-history.svg
+
+      - name: Commit changed chart
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- docs/assets/star-history.svg; then
+            echo "Star History chart is already current"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/assets/star-history.svg
+          git commit -m "docs: refresh static star history"
+          for attempt in 1 2 3; do
+            git pull --rebase origin "$DEFAULT_BRANCH"
+            if git push origin "HEAD:$DEFAULT_BRANCH"; then
+              exit 0
+            fi
+            sleep $((attempt * 3))
+          done
+          echo "::error::Unable to push the refreshed Star History chart"
+          exit 1


### PR DESCRIPTION
## Summary

Add owner-verified, idempotent Star History and Built with aidevops README invariants for aidevops-created and repos.json-managed repositories, including reusable workflow scaffolding and init integration.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-init-lib.sh, .agents/scripts/managed-readme-helper.sh, .agents/scripts/managed_readme.py, .agents/scripts/star-history-helper.sh, .agents/scripts/star_history.py, .agents/scripts/tests/test-managed-readme-helper.sh, .agents/scripts/tests/test-star-history-helper.sh, .agents/templates/workflows/star-history-caller.yml, .agents/workflows/readme-create-update.md, .agents/workflows/readme.md, .github/workflows/star-history-reusable.yml

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with 33 focused assertions, init-scope and Cloudron init regressions, ShellCheck, Python compile, actionlint, changed/full local linters, and a live authenticated 344-star fixture.

Resolves #28527


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.169 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 13h 1m and 1,300,266 tokens on this with the user in an interactive session.