### PR TITLE
GH#28531: load Homebrew packaged CLI modules

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -66,6 +66,14 @@ elif [[ -n "$_AIDEVOPS_SOURCE_DIR" && -f "$_AIDEVOPS_SOURCE_DIR/scripts/aidevops
 	# canonical checkout.
 	_AIDEVOPS_CLI_ROOT="$_AIDEVOPS_SOURCE_DIR"
 	_AIDEVOPS_CLI_MODULES_SUBDIR="scripts/aidevops-cli"
+elif [[ -n "${AIDEVOPS_SHARE:-}" &&
+	-f "$AIDEVOPS_SHARE/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh" &&
+	-f "$AIDEVOPS_SHARE/.agents/scripts/runtime-bundle-verifier.sh" &&
+	-f "$AIDEVOPS_SHARE/VERSION" ]]; then
+	# Homebrew installs the coherent package snapshot under share/aidevops and
+	# exports AIDEVOPS_SHARE from its wrapper. Keep repository operations pointed
+	# at INSTALL_DIR while loading packaged CLI modules and VERSION from there.
+	_AIDEVOPS_CLI_ROOT="$AIDEVOPS_SHARE"
 fi
 unset _AIDEVOPS_SOURCE_PATH _AIDEVOPS_SOURCE_DIR _AIDEVOPS_LINK_TARGET _AIDEVOPS_LINK_DIR
 AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-$_AIDEVOPS_REAL_HOME/.aidevops/agents}"

--- a/tests/test-cli-deployment-coherence.sh
+++ b/tests/test-cli-deployment-coherence.sh
@@ -53,6 +53,41 @@ result=$(cd "$TEST_HOME" && HOME="$TEST_HOME" PATH="$TEST_HOME/bin:$PATH" bash "
 	exit 1
 }
 
+# Exercise the Homebrew package layout without relying on post_install to clone
+# a canonical checkout. The formula places the launcher in libexec and exports
+# a separate share/aidevops tree containing .agents and VERSION.
+BREW_HOME="$TEST_HOME/brew-home"
+BREW_LIBEXEC="$TEST_HOME/brew/libexec"
+BREW_SHARE="$TEST_HOME/brew/share/aidevops"
+mkdir -p "$BREW_HOME" "$BREW_LIBEXEC" "$BREW_SHARE"
+cp "$REPO_DIR/aidevops.sh" "$BREW_LIBEXEC/aidevops.sh"
+cp -R "$REPO_DIR/.agents" "$BREW_SHARE/.agents"
+cp "$REPO_DIR/VERSION" "$BREW_SHARE/VERSION"
+result=$(HOME="$BREW_HOME" AIDEVOPS_SHARE="$BREW_SHARE" bash "$BREW_LIBEXEC/aidevops.sh" --version)
+[[ "$result" == "aidevops $(tr -d '\n' <"$REPO_DIR/VERSION")" ]] || {
+	printf 'FAIL: Homebrew package root selected %s\n' "$result" >&2
+	exit 1
+}
+
+# An incomplete package root must not become a source location merely because
+# it carries one expected module. This keeps the package trust boundary fail
+# closed before any partial snapshot can execute.
+INVALID_SHARE="$TEST_HOME/brew/invalid-share"
+mkdir -p "$INVALID_SHARE/.agents/scripts/aidevops-cli"
+cat >"$INVALID_SHARE/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'FAIL: incomplete Homebrew package root was sourced\n' >&2
+exit 42
+EOF
+invalid_share_output=""
+invalid_share_rc=0
+invalid_share_output=$(HOME="$BREW_HOME" AIDEVOPS_SHARE="$INVALID_SHARE" \
+	bash "$BREW_LIBEXEC/aidevops.sh" --version 2>&1) || invalid_share_rc=$?
+if [[ "$invalid_share_rc" -eq 0 || "$invalid_share_output" == *"incomplete Homebrew package root was sourced"* ]]; then
+	printf 'FAIL: incomplete Homebrew package root was accepted: %s\n' "$invalid_share_output" >&2
+	exit 1
+fi
+
 MOCK_BIN="$TEST_HOME/mock-bin"
 REAL_USER_HOME="$TEST_HOME/real-user"
 mkdir -p "$MOCK_BIN" "$REAL_USER_HOME/.aidevops/agents"


### PR DESCRIPTION
## Summary

Teach the CLI launcher to consume the coherent Homebrew share/aidevops snapshot when no checkout or deployed runtime is adjacent, while preserving canonical update semantics; add complete and incomplete package-root regressions.

## Files Changed

aidevops.sh, tests/test-cli-deployment-coherence.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Homebrew deployment coherence regression; CLI portability; setup CLI install; updater transaction; ShellCheck; bash syntax; git diff check; linters-local --changed.

Resolves #28531


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.170 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 34m and 500,190 tokens on this with the user in an interactive session.