### PR TITLE
GH#28532: Fix exact cleanup lease identity checks

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -948,13 +948,10 @@ _wt_owner_live_pid_reused_or_untrusted() {
 	return 1
 }
 
-# Check if a worktree is owned by a DIFFERENT process or quarantined stale owner.
-# Arguments:
-#   $1 - worktree path
-# Returns: 0 if owned by another live process or within stale-owner cooldown,
-#          1 if safe to remove
-is_worktree_owned_by_others() {
+# Compare a registry owner against an already-resolved caller PID.
+_wt_is_worktree_owned_by_others_for_resolved_pid() {
 	local wt_path="$1"
+	local my_pid="$2"
 
 	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 1
 	_init_registry_db
@@ -969,13 +966,6 @@ is_worktree_owned_by_others() {
 	# No owner registered
 	[[ -z "$owner_pid" ]] && return 1
 
-	# We own it — use the same PID resolution as register_worktree so that
-	# transient bash subprocess PIDs ($$) match the stored stable AI runtime PID.
-	# GH#21740: previously compared against raw $$ which is always a transient
-	# bash subprocess PID in AI runtime sessions (OpenCode, Claude Code), and
-	# can never match the OPENCODE_PID/grandparent PID stored at registration.
-	local my_pid
-	my_pid=$(_resolve_worktree_owner_pid "")
 	[[ "$owner_pid" == "$my_pid" ]] && return 1
 
 	# Owner process is dead. Keep the ownership row quarantined for a cooldown
@@ -1005,6 +995,37 @@ is_worktree_owned_by_others() {
 
 	# Owner process is alive and it's not us — NOT safe to remove
 	return 0
+}
+
+# Check if a worktree is owned by a DIFFERENT process or quarantined stale owner.
+# Generic callers use the stable runtime identity so transient shell subprocesses
+# match registrations created by the same interactive runtime (GH#21740).
+# Arguments:
+#   $1 - worktree path
+# Returns: 0 if owned by another live process or within stale-owner cooldown,
+#          1 if safe to remove
+is_worktree_owned_by_others() {
+	local wt_path="$1"
+	local my_pid=""
+	my_pid=$(_resolve_worktree_owner_pid "")
+	_wt_is_worktree_owned_by_others_for_resolved_pid "$wt_path" "$my_pid"
+	return $?
+}
+
+# Check ownership against an explicit short-lived lease holder. Destructive
+# cleanup uses this capability-aware path after claiming a lease under its leaf
+# executor PID; generic interactive ownership resolution remains unchanged.
+# Arguments:
+#   $1 - worktree path
+#   $2 - exact expected lease-holder PID
+# Returns: 0 if owned by another process (or input is invalid), 1 if this exact
+#          PID owns the lease or no blocking owner remains
+is_worktree_owned_by_others_for_pid() {
+	local wt_path="$1"
+	local expected_owner_pid="$2"
+	[[ "$expected_owner_pid" =~ ^[0-9]+$ ]] || return 0
+	_wt_is_worktree_owned_by_others_for_resolved_pid "$wt_path" "$expected_owner_pid"
+	return $?
 }
 
 # Delete registry paths in one sqlite transaction.

--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -1021,6 +1021,7 @@ is_worktree_owned_by_others() {
 # Returns: 0 if owned by another process (or input is invalid), 1 if this exact
 #          PID owns the lease or no blocking owner remains
 is_worktree_owned_by_others_for_pid() {
+	[[ $# -eq 2 ]] || return 0
 	local wt_path="$1"
 	local expected_owner_pid="$2"
 	[[ "$expected_owner_pid" =~ ^[0-9]+$ ]] || return 0

--- a/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
@@ -22,10 +22,14 @@ trap teardown EXIT
 export HOME="${TEST_ROOT}/home"
 export AIDEVOPS_FULL_LOOP_CLEANUP_DIR="${TEST_ROOT}/cleanup-receipts"
 export AIDEVOPS_CLEANUP_LOG="${TEST_ROOT}/cleanup.log"
+export WORKTREE_REGISTRY_DIR="${TEST_ROOT}/registry"
+export WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DIR}/worktree-registry.db"
 mkdir -p "$HOME" "${TEST_ROOT}/worktree-one" "${TEST_ROOT}/worktree-two"
 
 # shellcheck source=../full-loop-cleanup-receipt.sh
 source "${SCRIPTS_DIR}/full-loop-cleanup-receipt.sh"
+# shellcheck source=../shared-worktree-registry.sh
+source "${SCRIPTS_DIR}/shared-worktree-registry.sh"
 
 sleep 30 &
 OWNER_PID=$!
@@ -48,9 +52,6 @@ _WTAR_WH_CALLER="test"
 _WT_CLEAN_MODE_SKIPPED="skipped"
 _WT_CLEAN_REASON_OWNED_SKIP="owned-skip"
 log_worktree_removal_event() { return 0; }
-claim_worktree_ownership() { return 0; }
-unregister_worktree_if_owner_pid() { return 0; }
-is_worktree_owned_by_others() { return 1; }
 # shellcheck source=../worktree-clean-lib.sh
 source "${SCRIPTS_DIR}/worktree-clean-lib.sh"
 _clean_deferred_parent_alive "${TEST_ROOT}/worktree-one"
@@ -71,11 +72,21 @@ printf 'PASS guarded cleanup treats PID reuse as an expired owner generation\n'
 
 receipt_one=$(full_loop_write_cleanup_deferred example/repo 101 "${TEST_ROOT}/worktree-one" feature/one \
 	"$OWNER_PID" session-one not-requested)
+export OPENCODE_PID="$OWNER_PID"
 _clean_acquire_removal_lease "${TEST_ROOT}/worktree-one" feature/one
+if _clean_removal_lease_owned_by_others "${TEST_ROOT}/worktree-one"; then
+	printf 'FAIL cleanup exact-PID owner check rejected its own registry lease\n'
+	exit 1
+fi
+if ! is_worktree_owned_by_others "${TEST_ROOT}/worktree-one"; then
+	printf 'FAIL generic stable-runtime owner check unexpectedly matched the leaf cleanup lease\n'
+	exit 1
+fi
 jq -e --argjson lease_pid "$$" \
 	'.resource_cleanup_state == "CLEANUP_LEASED" and .cleanup_lease.state == "acquired" and .cleanup_lease.pid == $lease_pid' \
 	"$receipt_one" >/dev/null
 printf 'PASS cleanup supervisor acquires a durable lease\n'
+printf 'PASS cleanup lease survives a real registry round trip with distinct runtime and leaf PIDs\n'
 
 printf '[2026-07-21T00:00:00Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' \
 	"${TEST_ROOT}/worktree-one" >>"$AIDEVOPS_CLEANUP_LOG"

--- a/.agents/scripts/tests/test-worktree-metadata-prune.sh
+++ b/.agents/scripts/tests/test-worktree-metadata-prune.sh
@@ -24,8 +24,13 @@ FAILING_GIT="${TEST_ROOT}/failing-git"
 QUERY_FAILING_GIT="${TEST_ROOT}/query-failing-git"
 POST_PRUNE_QUERY_FAILING_GIT="${TEST_ROOT}/post-prune-query-failing-git"
 POST_PRUNE_QUERY_STATE="${TEST_ROOT}/post-prune-query-state"
+RUNTIME_PID=""
 
 teardown() {
+	if [[ "$RUNTIME_PID" =~ ^[0-9]+$ ]]; then
+		kill "$RUNTIME_PID" 2>/dev/null || true
+		wait "$RUNTIME_PID" 2>/dev/null || true
+	fi
 	rm -rf "$TEST_ROOT"
 	return 0
 }
@@ -375,6 +380,17 @@ if (
 	exit 1
 fi
 printf 'PASS degraded cleanup requires terminal PR proof\n'
+
+# Replace the focused ownership stubs with the production registry before the
+# integrated pass. A distinct stable runtime PID forces cleanup to prove that
+# both post-acquisition checks use the exact leaf-PID lease it just claimed.
+export WORKTREE_REGISTRY_DIR="${TEST_ROOT}/registry"
+export WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DIR}/worktree-registry.db"
+sleep 30 &
+RUNTIME_PID=$!
+export OPENCODE_PID="$RUNTIME_PID"
+# shellcheck source=../shared-worktree-registry.sh
+source "${SCRIPT_DIR}/shared-worktree-registry.sh"
 
 integration_output=$(
 	cd "$REPO" || exit 1

--- a/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
+++ b/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
@@ -212,6 +212,31 @@ test_recent_live_pid_without_comm_still_blocks() {
 	return 0
 }
 
+test_explicit_cleanup_lease_identity() {
+	local wt_path
+	wt_path=$(make_worktree_dir "explicit-cleanup-lease")
+	local distinct_live_pid
+	sleep 30 &
+	distinct_live_pid=$!
+	claim_worktree_ownership "$wt_path" "feature/explicit-cleanup-lease" \
+		--owner-pid "$$" --session "cleanup:$$" --task "worktree-removal"
+
+	local rc=0
+	if is_worktree_owned_by_others_for_pid "$wt_path" "$$" >/dev/null 2>&1; then
+		rc=1
+	fi
+	if ! is_worktree_owned_by_others_for_pid "$wt_path" "$distinct_live_pid" >/dev/null 2>&1; then
+		rc=1
+	fi
+	if ! is_worktree_owned_by_others_for_pid "$wt_path" "invalid" >/dev/null 2>&1; then
+		rc=1
+	fi
+	kill "$distinct_live_pid" 2>/dev/null || true
+	wait "$distinct_live_pid" 2>/dev/null || true
+	print_result "explicit cleanup lease distinguishes exact holder and other runtimes" "$rc"
+	return 0
+}
+
 test_legacy_registry_schema_migrates_on_owner_check() {
 	local wt_path
 	wt_path=$(make_worktree_dir "legacy-schema-owner-check")
@@ -284,11 +309,12 @@ main() {
 	printf 'Running worktree registry dead-owner tests\n'
 	test_dead_owner_first_pass_quarantines
 	test_dead_owner_within_cooldown_keeps_skip
-	test_dead_owner_after_cooldown_unregisters
-	test_owner_pid_override_rejects_sql_payload
-	test_stale_live_pid_comm_mismatch_unregisters
-	test_recent_live_pid_without_comm_still_blocks
-	test_legacy_registry_schema_migrates_on_owner_check
+test_dead_owner_after_cooldown_unregisters
+test_owner_pid_override_rejects_sql_payload
+test_stale_live_pid_comm_mismatch_unregisters
+test_recent_live_pid_without_comm_still_blocks
+test_explicit_cleanup_lease_identity
+test_legacy_registry_schema_migrates_on_owner_check
 	test_should_skip_cleanup_branch_merged_within_grace
 	printf 'Results: %s/%s passed, %s failed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]] && return 0

--- a/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
+++ b/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
@@ -309,12 +309,12 @@ main() {
 	printf 'Running worktree registry dead-owner tests\n'
 	test_dead_owner_first_pass_quarantines
 	test_dead_owner_within_cooldown_keeps_skip
-test_dead_owner_after_cooldown_unregisters
-test_owner_pid_override_rejects_sql_payload
-test_stale_live_pid_comm_mismatch_unregisters
-test_recent_live_pid_without_comm_still_blocks
-test_explicit_cleanup_lease_identity
-test_legacy_registry_schema_migrates_on_owner_check
+	test_dead_owner_after_cooldown_unregisters
+	test_owner_pid_override_rejects_sql_payload
+	test_stale_live_pid_comm_mismatch_unregisters
+	test_recent_live_pid_without_comm_still_blocks
+	test_explicit_cleanup_lease_identity
+	test_legacy_registry_schema_migrates_on_owner_check
 	test_should_skip_cleanup_branch_merged_within_grace
 	printf 'Results: %s/%s passed, %s failed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]] && return 0

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -100,6 +100,18 @@ _clean_acquire_removal_lease() {
 	return 0
 }
 
+_clean_removal_lease_owned_by_others() {
+	local wt_path="$1"
+	if declare -F is_worktree_owned_by_others_for_pid >/dev/null 2>&1; then
+		is_worktree_owned_by_others_for_pid "$wt_path" "$$"
+		return $?
+	fi
+	# Compatibility for focused tests and older embedders that stub only the
+	# generic ownership API. Production registry loads always use the exact PID.
+	is_worktree_owned_by_others "$wt_path"
+	return $?
+}
+
 _clean_terminal_owner_blocks_cleanup() {
 	local wt_path="$1"
 	local deferred_parent_state=0
@@ -1046,7 +1058,7 @@ _clean_degraded_visibility_fallback_allowed() {
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "active-claim" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
 		return 1
 	fi
-	if is_worktree_owned_by_others "$worktree_path"; then
+	if _clean_removal_lease_owned_by_others "$worktree_path"; then
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "$_WT_CLEAN_REASON_OWNED_SKIP" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
 		return 1
 	fi
@@ -1093,7 +1105,7 @@ _clean_remove_classified_worktree() {
 		fi
 		worktree_has_changes "$worktree_path" && return 1
 		_branch_has_active_interactive_claim "$worktree_path" "$worktree_branch" && return 1
-		is_worktree_owned_by_others "$worktree_path" && return 1
+		_clean_removal_lease_owned_by_others "$worktree_path" && return 1
 	elif [[ "$guard_status" -ne 0 ]]; then
 		return "$guard_status"
 	fi


### PR DESCRIPTION
## Summary

- Preserve exact leaf-PID cleanup lease identity during post-acquisition ownership checks.
- Keep generic stable-runtime ownership resolution unchanged for interactive subprocesses.
- Add real SQLite registry round-trip and integrated degraded-cleanup coverage with distinct stable-runtime and leaf PIDs.

## Verification

- `bash .agents/scripts/tests/test-worktree-metadata-prune.sh`
- `bash .agents/scripts/tests/test-full-loop-cleanup-receipt.sh`
- `bash .agents/scripts/tests/test-worktree-registry-dead-owner.sh` — 9/9
- `bash .agents/scripts/tests/test-worktree-removal-audit.sh` — 22/22
- `shellcheck` on all five changed shell files
- `.agents/scripts/linters-local.sh --changed`

## Runtime Testing

`runtime-verified`: the integrated metadata-prune test runs the production cleanup and SQLite registry functions against temporary Git worktrees, forces distinct stable-runtime and leaf cleanup PIDs, enters the synthetic degraded-CWD path, and verifies recoverable removal plus exact metadata absence. Separate tests prove distinct live owners, active CWDs, dead-owner cooldown, and PID-generation mismatch remain blocking.

## Decisions

- Use a dedicated fail-closed exact-PID ownership API for destructive cleanup leases instead of changing generic runtime PID resolution.
- Keep pre-lease ownership checks on stable-runtime identity; only post-acquisition checks use the exact leaf PID.
- Avoid a new token/schema because acquisition and consumption occur in the same live executor process.

Resolves #28532
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.171 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 52m and 434,298 tokens on this with the user in an interactive session.