### PR TITLE
GH#28535: Reconcile published release receipts before completion

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -311,6 +311,15 @@ _full_loop_invoke_authorized_release() {
 		print_error "Authorized release requires a persisted PR number"
 		return 1
 	}
+	local reconciliation_status=0
+	_full_loop_reconcile_detached_publication_receipt || reconciliation_status=$?
+	case "$reconciliation_status" in
+	0) return 0 ;;
+	2)
+		print_error "release:published receipt could not be reconciled into lifecycle state"
+		return 1
+		;;
+	esac
 	local runner="${AIDEVOPS_FULL_LOOP_RELEASE_RUNNER:-${SCRIPT_DIR}/full-loop-release-helper.sh}"
 	[[ -x "$runner" ]] || {
 		print_error "Authorized release runner is unavailable: $runner"
@@ -1094,6 +1103,40 @@ cmd_logs() {
 	tail -n "$lines" "$log_file"
 }
 
+_full_loop_reconcile_published_release_receipt() {
+	local repo="$1"
+	local pr_number="$2"
+	local receipt_path=""
+	local receipt_status=""
+	local previous_status="${RELEASE_STATUS:-}"
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
+	[[ -f "$receipt_path" ]] || return 1
+	IFS= read -r receipt_status <"$receipt_path" || return 1
+	[[ "$receipt_status" == "$_FULL_LOOP_RELEASE_PUBLISHED" ]] || return 1
+	RELEASE_STATUS="$_FULL_LOOP_RELEASE_PUBLISHED"
+	if ! save_state "${CURRENT_PHASE:-${PHASE:-complete}}" "$SAVED_PROMPT" "$pr_number" \
+		"${STARTED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}"; then
+		RELEASE_STATUS="$previous_status"
+		return 1
+	fi
+	return 0
+}
+
+_full_loop_reconcile_detached_publication_receipt() {
+	local receipt_repo=""
+	local receipt_path=""
+	local receipt_status=""
+	[[ "${PR_NUMBER:-}" =~ ^[0-9]+$ ]] || return 1
+	receipt_repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}" 2>/dev/null || true)
+	[[ -n "$receipt_repo" ]] || return 1
+	receipt_path=$(_full_loop_release_receipt_path "$receipt_repo" "$PR_NUMBER") || return 1
+	[[ -f "$receipt_path" ]] || return 1
+	IFS= read -r receipt_status <"$receipt_path" || return 1
+	[[ "$receipt_status" == "$_FULL_LOOP_RELEASE_PUBLISHED" ]] || return 1
+	_full_loop_reconcile_published_release_receipt "$receipt_repo" "$PR_NUMBER" || return 2
+	return 0
+}
+
 cmd_complete() {
 	load_state 2>/dev/null || {
 		print_error "Cannot complete full loop without persisted lifecycle state"
@@ -1102,6 +1145,17 @@ cmd_complete() {
 	if [[ ! "${PR_NUMBER:-}" =~ ^[0-9]+$ ]]; then
 		print_error "Cannot complete full loop without a verified PR number"
 		return 1
+	fi
+	local repo=""
+	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || {
+		print_error "Cannot resolve repository for deferred cleanup handoff"
+		return 1
+	}
+	if [[ "${RELEASE_STATUS:-}" == "authorized" ]]; then
+		_full_loop_reconcile_published_release_receipt "$repo" "$PR_NUMBER" || {
+			print_error "Cleanup blocked: release:${RELEASE_STATUS} is not terminal-success"
+			return 1
+		}
 	fi
 	case "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" in
 	failed | authorized)
@@ -1117,14 +1171,9 @@ cmd_complete() {
 	local current_root=""
 	current_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
 	local current_branch=""
-	local repo=""
 	local owner_pid=""
 	local owner_session="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-full-loop-complete}}}"
 	current_branch=$(git branch --show-current 2>/dev/null || true)
-	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || {
-		print_error "Cannot resolve repository for deferred cleanup handoff"
-		return 1
-	}
 	owner_pid="${PPID:-}"
 	if declare -F _resolve_worktree_owner_pid >/dev/null 2>&1; then
 		owner_pid=$(_resolve_worktree_owner_pid "" 2>/dev/null || printf '%s' "${PPID:-}")

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -155,7 +155,9 @@ print_info() { return 0; }
 print_warning() { return 0; }
 print_success() { return 0; }
 print_phase() { return 0; }
-is_headless() { return 1; }
+is_headless() {
+	return 1
+}
 source '${SCRIPTS_DIR}/shared-constants.sh'
 source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
 mkdir -p "\$STATE_DIR"
@@ -174,6 +176,7 @@ printf '%s\n' "\$RELEASE_STATUS"
 RUNNER
 chmod +x "$state_runner"
 
+rm -f "${receipt_dir}/marcusquinn_aidevops-42.status"
 : >"${ROOT}/release-calls.log"
 flow_env=(AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops AIDEVOPS_FULL_LOOP_RELEASE_RUNNER="${ROOT}/release-runner.sh" RELEASE_CALL_LOG="${ROOT}/release-calls.log")
 output=$(env "${flow_env[@]}" TEST_RELEASE_TYPE=minor TEST_DEPLOYMENT_SCOPE=full bash "$state_runner")
@@ -182,6 +185,12 @@ status="${output##*$'\n'}"
 grep -qx 'minor 42 full' "${ROOT}/release-calls.log"
 grep -qx 'published' "${receipt_dir}/marcusquinn_aidevops-42.status"
 printf 'PASS authorized lifecycle invokes release and persists published status\n'
+
+: >"${ROOT}/release-calls.log"
+output=$(env "${flow_env[@]}" bash "$state_runner")
+status="${output##*$'\n'}"
+[[ "$status" == "published" && ! -s "${ROOT}/release-calls.log" ]]
+printf 'PASS published detached-release receipt prevents duplicate publication\n'
 
 : >"${ROOT}/release-calls.log"
 output=$(env "${flow_env[@]}" TEST_RELEASE_INTENT=false TEST_RELEASE_STATUS=not-requested bash "$state_runner")
@@ -234,10 +243,10 @@ source '${SCRIPTS_DIR}/shared-constants.sh'
 source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
 CURRENT_PHASE=complete
 SAVED_PROMPT=test
-PR_NUMBER=43
+PR_NUMBER="\${TEST_PR_NUMBER:-43}"
 STARTED_AT=2026-07-11T00:00:00Z
-RELEASE_STATUS=not-requested
-save_state complete test 43 "\$STARTED_AT"
+RELEASE_STATUS="\${TEST_RELEASE_STATUS:-not-requested}"
+save_state complete test "\$PR_NUMBER" "\$STARTED_AT"
 cmd_complete
 cmd_status --json
 RUNNER
@@ -250,6 +259,33 @@ printf '%s' "$handoff_json" | jq -e \
 jq -e '.executor_completion_state == "COMPLETE" and .release_status == "not-requested"' \
 	"${cleanup_receipt_dir}/testorg_repo-43.json" >/dev/null
 printf 'PASS interactive completion emits durable executor handoff and machine-readable cleanup state\n'
+
+printf '%s\n' published >"${receipt_dir}/marcusquinn_aidevops-44.status"
+published_handoff_output=$(AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
+	AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	TEST_PR_NUMBER=44 TEST_RELEASE_STATUS=authorized bash "$handoff_runner")
+printf '%s\n' "$published_handoff_output" | grep -q '<promise>FULL_LOOP_CLEANUP_DEFERRED</promise>'
+grep -q '^release_status: published$' "${ROOT}/handoff-state/full-loop.state"
+jq -e '.executor_completion_state == "COMPLETE" and .release_status == "published"' \
+	"${cleanup_receipt_dir}/marcusquinn_aidevops-44.json" >/dev/null
+printf 'PASS matching published receipt atomically promotes stale authorized lifecycle state\n'
+
+for invalid_case in missing failed mismatched; do
+	invalid_pr=45
+	rm -f "${receipt_dir}/marcusquinn_aidevops-45.status"
+	case "$invalid_case" in
+	failed) printf '%s\n' failed >"${receipt_dir}/marcusquinn_aidevops-45.status" ;;
+	mismatched) printf '%s\n' published >"${receipt_dir}/other_repo-45.status" ;;
+	esac
+	if AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+		AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" TEST_PR_NUMBER="$invalid_pr" \
+		TEST_RELEASE_STATUS=authorized bash "$handoff_runner" >/dev/null 2>&1; then
+		printf 'FAIL %s release receipt allowed stale authorized lifecycle completion\n' "$invalid_case"
+		exit 1
+	fi
+	grep -q '^release_status: authorized$' "${ROOT}/handoff-state/full-loop.state"
+done
+printf 'PASS missing failed and mismatched receipts keep authorized lifecycle blocked\n'
 
 AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null || {
 	printf 'FAIL complete merged and cleaned evidence was rejected\n'


### PR DESCRIPTION
Resolves #28535. Summary: reconcile the canonical repository/PR release receipt into stale authorized lifecycle state before cleanup handoff; skip duplicate detached publication when a matching published receipt exists; keep missing, failed, unknown, and mismatched evidence fail-closed. Files: .agents/scripts/full-loop-helper-state.sh and .agents/scripts/tests/test-full-loop-completion-evidence.sh. Verification: bash .agents/scripts/tests/test-full-loop-completion-evidence.sh; bash .agents/scripts/tests/test-full-loop-release-helper.sh; ShellCheck changed files; .agents/scripts/linters-local.sh --changed.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.172 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 10m and 137,226 tokens on this as a headless worker.