### PR TITLE
fix: harden lifecycle evidence and routine scheduling (#28513, #28516, #28517, #28526)

### DIFF
--- a/.agents/reference/routines.md
+++ b/.agents/reference/routines.md
@@ -50,6 +50,17 @@ material, dispatch paths, and logs remain private with restrictive modes.
 | `monthly(N@HH:MM)` | `monthly(1@09:00)` | Day N of each month |
 | `cron(expr)` | `cron(15 2 * * *)` | Complex schedules only |
 
+Calendar expressions use the host-local timezone by default. Set
+`AIDEVOPS_SCHEDULE_TIMEZONE` to an IANA timezone when a fleet needs an explicit
+shared contract. `is-due` and `next-run` use the same local-calendar boundaries:
+a run is due when its last successful/terminal run predates the latest boundary.
+This catches up missed slots and prevents an off-slot bootstrap or manual run from
+suppressing the next boundary. Repeated fall-back hours belong to their first
+occurrence; nonexistent spring-forward local times fail closed with a diagnostic.
+Only successful runs advance `last_run`. Active runs remain blocked for up to six
+hours, and failures retry after 15 minutes by default
+(`AIDEVOPS_ROUTINE_FAILURE_RETRY_SECONDS`) rather than waiting a full period.
+
 ## Dispatch rules
 
 1. `run:` present → execute script directly (deterministic-first)
@@ -58,6 +69,17 @@ material, dispatch paths, and logs remain private with restrictive modes.
 4. Neither → try `custom/scripts/{routine_id}.sh` (e.g. `r001.sh`), else `agent:Build+`
 
 Use `run:` for scripts, exports, health checks. Use `agent:` when judgment or summarisation is needed.
+
+## Scheduler ownership
+
+Enabled `repeat:` routines in registered repositories are normally evaluated by
+the shared supervisor Pulse. Their schedule definition and enabled state live in
+the repository `TODO.md`; they do not receive a dedicated launchd or systemd unit.
+Check the Pulse service plus the routine state file when diagnosing a missed run.
+
+Only routines explicitly documented as persistent or externally scheduled use a
+dedicated platform unit. Generated routine descriptions name that unit when one
+exists; do not derive a service label from the routine title or ID.
 
 ## Anti-patterns
 

--- a/.agents/scripts/audit-log-helper.sh
+++ b/.agents/scripts/audit-log-helper.sh
@@ -781,10 +781,10 @@ _audit_verify_entry() {
 	return "$entry_errors"
 }
 
-# Verify the integrity of one audit log file.
+# Verify the integrity of one audit log file with the legacy shell path.
 # Arguments: $1=log_file $2=quiet (true|false)
 # Returns: 0 if chain is valid, 1 if tampered/broken
-_audit_verify_file() {
+_audit_verify_file_legacy() {
 	local log_file="$1"
 	local quiet="$2"
 
@@ -839,6 +839,34 @@ _audit_verify_file() {
 	fi
 
 	return 0
+}
+
+# Verify one segment in a bounded single process. The legacy verifier remains a
+# correctness-preserving fallback when Python or the deployed helper is absent.
+_audit_verify_file() {
+	local log_file="$1"
+	local quiet="$2"
+	local verifier="${SCRIPT_DIR}/audit-log-verify-helper.py"
+
+	if [[ ! -f "$log_file" ]]; then
+		_audit_info "No audit log found — nothing to verify"
+		return 0
+	fi
+	if [[ ! -s "$log_file" ]]; then
+		_audit_info "Audit log is empty — nothing to verify"
+		return 0
+	fi
+	if [[ "${AUDIT_FORCE_LEGACY_VERIFIER:-false}" == "true" ]]; then
+		_audit_verify_file_legacy "$log_file" "$quiet"
+		return $?
+	fi
+	if command -v python3 >/dev/null 2>&1 && [[ -f "$verifier" ]]; then
+		python3 "$verifier" "$log_file" "$AUDIT_GENESIS_HASH" "$quiet"
+		return $?
+	fi
+	_audit_warn "Single-process audit verifier unavailable; using the slower fail-closed legacy verifier"
+	_audit_verify_file_legacy "$log_file" "$quiet"
+	return $?
 }
 
 # Verify the integrity of the active audit log hash chain.

--- a/.agents/scripts/audit-log-verify-helper.py
+++ b/.agents/scripts/audit-log-verify-helper.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Single-process verifier for aidevops schema-1 audit JSONL segments."""
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _error(message: str) -> None:
+    print(f"[AUDIT ERROR] {message}", file=sys.stderr)
+
+
+def _canonical_without_hash(entry: dict[str, Any]) -> bytes:
+    content = dict(entry)
+    content.pop("hash", None)
+    return json.dumps(
+        content,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def verify(path: Path, genesis_hash: str, quiet: bool) -> int:
+    expected_prev_hash = genesis_hash
+    errors = 0
+    total_lines = 0
+
+    try:
+        stream = path.open("r", encoding="utf-8", errors="strict")
+    except (OSError, UnicodeError) as exc:
+        _error(f"Cannot read audit segment: {exc}")
+        return 2
+
+    with stream:
+        for line_number, raw_line in enumerate(stream, start=1):
+            total_lines = line_number
+            line = raw_line.rstrip("\r\n")
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, UnicodeError):
+                _error(f"Entry {line_number}: Invalid JSON")
+                errors += 1
+                continue
+            if not isinstance(entry, dict):
+                _error(f"Entry {line_number}: Invalid JSON object")
+                errors += 1
+                continue
+
+            stored_hash = entry.get("hash")
+            stored_prev_hash = entry.get("prev_hash")
+            if not isinstance(stored_hash, str) or not stored_hash:
+                _error(f"Entry {line_number}: Missing hash field")
+                errors += 1
+                continue
+
+            if stored_prev_hash != expected_prev_hash:
+                _error(f"Entry {line_number}: Chain broken — prev_hash mismatch")
+                _error(f"  Expected: {expected_prev_hash}")
+                _error(f"  Found:    {stored_prev_hash or ''}")
+                errors += 1
+
+            try:
+                computed_hash = hashlib.sha256(
+                    _canonical_without_hash(entry)
+                ).hexdigest()
+            except (TypeError, ValueError):
+                _error(f"Entry {line_number}: Invalid JSON value")
+                errors += 1
+                expected_prev_hash = stored_hash
+                continue
+            if computed_hash != stored_hash:
+                _error(
+                    f"Entry {line_number}: Hash mismatch — entry has been tampered with"
+                )
+                _error(f"  Stored:   {stored_hash}")
+                _error(f"  Computed: {computed_hash}")
+                errors += 1
+
+            expected_prev_hash = stored_hash
+
+    if errors:
+        _error(f"Verification FAILED: {errors} error(s) in {total_lines} entries")
+        return 1
+    if not quiet:
+        print(
+            f"[AUDIT] Verification PASSED: {total_lines} entries, chain intact",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("path", type=Path)
+    parser.add_argument("genesis_hash")
+    parser.add_argument("quiet", choices=("true", "false"))
+    args = parser.parse_args()
+    return verify(args.path, args.genesis_hash, args.quiet == "true")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -14,6 +14,10 @@ _FULL_LOOP_CLEANUP_RECEIPT_LOADED=1
 _FULL_LOOP_CLEANUP_DEFERRED="CLEANUP_DEFERRED"
 _FULL_LOOP_CLEANUP_LEASED="CLEANUP_LEASED"
 _FULL_LOOP_CLEANUP_CLEANED="CLEANED"
+_FULL_LOOP_EXECUTOR_COMPLETE="COMPLETE"
+_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED="published"
+_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED="not-requested"
+_FULL_LOOP_RECEIPT_LOCK=""
 
 _full_loop_cleanup_receipt_dir() {
 	printf '%s\n' "${AIDEVOPS_FULL_LOOP_CLEANUP_DIR:-${HOME}/.aidevops/state/full-loop-cleanup}"
@@ -43,6 +47,44 @@ _full_loop_process_identity() {
 	return 0
 }
 
+_full_loop_receipt_lock_acquire() {
+	local receipt_dir=""
+	local lock_dir=""
+	local owner_pid=""
+	local attempt=0
+	receipt_dir=$(_full_loop_cleanup_receipt_dir) || return 1
+	mkdir -p "$receipt_dir" || return 1
+	lock_dir="${receipt_dir}/.mutation.lock.d"
+	while [[ "$attempt" -lt 200 ]]; do
+		if mkdir "$lock_dir" 2>/dev/null; then
+			printf '%s\n' "$$" >"${lock_dir}/owner" || {
+				rmdir "$lock_dir" 2>/dev/null || true
+				return 1
+			}
+			_FULL_LOOP_RECEIPT_LOCK="$lock_dir"
+			return 0
+		fi
+		owner_pid=""
+		[[ -f "${lock_dir}/owner" ]] && IFS= read -r owner_pid <"${lock_dir}/owner" || true
+		if [[ "$owner_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+			rm -f "${lock_dir}/owner" 2>/dev/null || true
+			rmdir "$lock_dir" 2>/dev/null || true
+			continue
+		fi
+		sleep 0.05
+		attempt=$((attempt + 1))
+	done
+	return 1
+}
+
+_full_loop_receipt_lock_release() {
+	[[ -n "$_FULL_LOOP_RECEIPT_LOCK" ]] || return 0
+	rm -f "${_FULL_LOOP_RECEIPT_LOCK}/owner" 2>/dev/null || true
+	rmdir "$_FULL_LOOP_RECEIPT_LOCK" 2>/dev/null || true
+	_FULL_LOOP_RECEIPT_LOCK=""
+	return 0
+}
+
 full_loop_write_cleanup_deferred() {
 	local repo="$1"
 	local pr_number="$2"
@@ -51,13 +93,13 @@ full_loop_write_cleanup_deferred() {
 	local owner_pid="$5"
 	local owner_session="$6"
 	local release_status="${7:-pending}"
-	local executor_completion_state="${8:-COMPLETE}"
+	local executor_completion_state="${8:-$_FULL_LOOP_EXECUTOR_COMPLETE}"
 	local receipt_path=""
 	local owner_identity=""
 	local now=""
 
 	[[ -n "$worktree" && -n "$branch" && "$owner_pid" =~ ^[0-9]+$ ]] || return 1
-	[[ "$executor_completion_state" == "FINALIZATION_PENDING" || "$executor_completion_state" == "COMPLETE" ]] || return 1
+	[[ "$executor_completion_state" == "FINALIZATION_PENDING" || "$executor_completion_state" == "$_FULL_LOOP_EXECUTOR_COMPLETE" ]] || return 1
 	command -v jq >/dev/null 2>&1 || return 1
 	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
 	owner_identity=$(_full_loop_process_identity "$owner_pid") || return 1
@@ -87,6 +129,8 @@ full_loop_cleanup_receipt_for_worktree() {
 	local selected_path=""
 	local selected_created_at=""
 	local candidate_created_at=""
+	local selected_is_migrated=0
+	local candidate_is_migrated=0
 
 	[[ -n "$worktree" ]] || return 1
 	receipt_dir=$(_full_loop_cleanup_receipt_dir) || return 1
@@ -95,9 +139,13 @@ full_loop_cleanup_receipt_for_worktree() {
 		[[ -f "$receipt_path" ]] || continue
 		if jq -e --arg worktree "$worktree" '.worktree == $worktree' "$receipt_path" >/dev/null 2>&1; then
 			candidate_created_at=$(jq -r '.created_at // empty' "$receipt_path" 2>/dev/null || true)
-			if [[ -z "$selected_path" || "$candidate_created_at" > "$selected_created_at" ]]; then
+			candidate_is_migrated=0
+			jq -e '.migration.from_repository | type == "string" and length > 0' "$receipt_path" >/dev/null 2>&1 && candidate_is_migrated=1
+			if [[ -z "$selected_path" || "$candidate_created_at" > "$selected_created_at" ]] ||
+				[[ "$candidate_created_at" == "$selected_created_at" && "$candidate_is_migrated" -eq 1 && "$selected_is_migrated" -ne 1 ]]; then
 				selected_path="$receipt_path"
 				selected_created_at="$candidate_created_at"
+				selected_is_migrated="$candidate_is_migrated"
 			fi
 		fi
 	done
@@ -130,9 +178,13 @@ full_loop_transition_cleanup_receipt() {
 	local now=""
 
 	[[ -f "$receipt_path" ]] || return 1
+	_full_loop_receipt_lock_acquire || return 1
 	case "$target_state" in
 	"$_FULL_LOOP_CLEANUP_DEFERRED" | "$_FULL_LOOP_CLEANUP_LEASED" | "$_FULL_LOOP_CLEANUP_CLEANED") ;;
-	*) return 1 ;;
+	*)
+		_full_loop_receipt_lock_release
+		return 1
+		;;
 	esac
 	current_state=$(jq -r '.resource_cleanup_state // empty' "$receipt_path" 2>/dev/null || true)
 	case "${current_state}:${target_state}" in
@@ -142,12 +194,21 @@ full_loop_transition_cleanup_receipt() {
 		"${_FULL_LOOP_CLEANUP_LEASED}:${_FULL_LOOP_CLEANUP_LEASED}" | \
 		"${_FULL_LOOP_CLEANUP_LEASED}:${_FULL_LOOP_CLEANUP_CLEANED}" | \
 		"${_FULL_LOOP_CLEANUP_CLEANED}:${_FULL_LOOP_CLEANUP_CLEANED}") ;;
-	*) return 1 ;;
+	*)
+		_full_loop_receipt_lock_release
+		return 1
+		;;
 	esac
 	if [[ "$target_state" == "$_FULL_LOOP_CLEANUP_LEASED" ]]; then
-		[[ "$lease_pid" =~ ^[0-9]+$ ]] || return 1
+		if [[ ! "$lease_pid" =~ ^[0-9]+$ ]]; then
+			_full_loop_receipt_lock_release
+			return 1
+		fi
 	fi
-	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
 	jq --arg state "$target_state" --arg now "$now" --arg lease_pid "$lease_pid" '
 		.resource_cleanup_state = $state
 		| .updated_at = $now
@@ -156,8 +217,158 @@ full_loop_transition_cleanup_receipt() {
 		  elif $state == "CLEANED" then
 			.cleanup_lease.state = "released" | .cleaned_at = $now
 		  else . end
-	' "$receipt_path" >"${receipt_path}.tmp.$$" || return 1
-	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
+	' "$receipt_path" >"${receipt_path}.tmp.$$" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	mv "${receipt_path}.tmp.$$" "$receipt_path" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	_full_loop_receipt_lock_release
+	return 0
+}
+
+full_loop_finalize_cleanup_receipt() {
+	local repo="$1"
+	local pr_number="$2"
+	local release_status="$3"
+	local receipt_path=""
+	local current_release=""
+	local current_executor=""
+	local now=""
+	[[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED" || "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED" ]] || return 1
+	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
+	[[ -f "$receipt_path" ]] || return 1
+	_full_loop_receipt_lock_acquire || return 1
+	if ! jq -e --arg repo "$repo" --argjson pr "$pr_number" \
+		'.repository == $repo and .pr_number == $pr' "$receipt_path" >/dev/null 2>&1; then
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	current_executor=$(jq -r '.executor_completion_state // empty' "$receipt_path" 2>/dev/null || true)
+	current_release=$(jq -r '.release_status // empty' "$receipt_path" 2>/dev/null || true)
+	if [[ "$current_executor" != "FINALIZATION_PENDING" && "$current_executor" != "$_FULL_LOOP_EXECUTOR_COMPLETE" ]]; then
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	if [[ "$current_release" == "$_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED" || "$current_release" == "$_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED" ]] &&
+		[[ "$current_release" != "$release_status" ]]; then
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	if [[ "$current_executor" == "$_FULL_LOOP_EXECUTOR_COMPLETE" && "$current_release" == "$release_status" ]]; then
+		_full_loop_receipt_lock_release
+		return 0
+	fi
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	jq --arg release_status "$release_status" --arg now "$now" --arg executor_complete "$_FULL_LOOP_EXECUTOR_COMPLETE" '
+		.executor_completion_state = $executor_complete
+		| .release_status = $release_status
+		| .updated_at = $now
+	' "$receipt_path" >"${receipt_path}.tmp.$$" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	mv "${receipt_path}.tmp.$$" "$receipt_path" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	_full_loop_receipt_lock_release
+	return 0
+}
+
+full_loop_migrate_cleanup_receipt() {
+	local old_repo="$1"
+	local new_repo="$2"
+	local pr_number="$3"
+	local source_release="$4"
+	local destination_release="$5"
+	local release_status="$6"
+	local source_receipt=""
+	local destination_receipt=""
+	local destination_status=""
+	local now=""
+	[[ "$old_repo" != "$new_repo" ]] || return 1
+	[[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED" || "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED" ]] || return 1
+	source_receipt=$(_full_loop_cleanup_receipt_path "$old_repo" "$pr_number") || return 1
+	destination_receipt=$(_full_loop_cleanup_receipt_path "$new_repo" "$pr_number") || return 1
+	_full_loop_receipt_lock_acquire || return 1
+
+	if [[ -f "$destination_receipt" ]]; then
+		destination_status=""
+		[[ -f "$destination_release" ]] && IFS= read -r destination_status <"$destination_release" || true
+		if jq -e --arg repo "$new_repo" --arg old_repo "$old_repo" --argjson pr "$pr_number" '
+			.repository == $repo and .pr_number == $pr and .migration.from_repository == $old_repo
+		' "$destination_receipt" >/dev/null 2>&1 && [[ "$destination_status" == "$release_status" ]]; then
+			if [[ -f "$source_receipt" ]] && jq -e --slurpfile destination "$destination_receipt" '
+				.worktree == $destination[0].worktree
+				and .branch == $destination[0].branch
+				and .created_at == $destination[0].created_at
+				and .owner.process_identity == $destination[0].owner.process_identity
+			' "$source_receipt" >/dev/null 2>&1; then
+				rm -f "$source_release" "$source_receipt"
+			fi
+			_full_loop_receipt_lock_release
+			return 0
+		fi
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	if [[ ! -f "$source_receipt" || ! -f "$source_release" ]]; then
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	if ! jq -e --arg repo "$old_repo" --argjson pr "$pr_number" \
+		'.repository == $repo and .pr_number == $pr' "$source_receipt" >/dev/null 2>&1; then
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	local source_status=""
+	IFS= read -r source_status <"$source_release" || true
+	if [[ "$source_status" != "$release_status" ]]; then
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	mkdir -p "${destination_release%/*}" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	jq --arg repo "$new_repo" --arg old_repo "$old_repo" --arg now "$now" '
+		.repository = $repo
+		| .updated_at = $now
+		| .migration = {from_repository:$old_repo,to_repository:$repo,migrated_at:$now}
+	' "$source_receipt" >"${destination_receipt}.tmp.$$" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	printf '%s\n' "$release_status" >"${destination_release}.tmp.$$" || {
+		rm -f "${destination_receipt}.tmp.$$"
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	mv "${destination_receipt}.tmp.$$" "$destination_receipt" || {
+		rm -f "${destination_release}.tmp.$$"
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	if ! mv "${destination_release}.tmp.$$" "$destination_release"; then
+		rm -f "$destination_receipt"
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	rm -f "$source_release" "$source_receipt" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	_full_loop_receipt_lock_release
 	return 0
 }
 
@@ -170,11 +381,22 @@ full_loop_update_cleanup_release_status() {
 
 	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
 	[[ -f "$receipt_path" ]] || return 0
-	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	_full_loop_receipt_lock_acquire || return 1
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
 	jq --arg release_status "$release_status" --arg now "$now" \
 		'.release_status = $release_status | .updated_at = $now' \
-		"$receipt_path" >"${receipt_path}.tmp.$$" || return 1
-	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
+		"$receipt_path" >"${receipt_path}.tmp.$$" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	mv "${receipt_path}.tmp.$$" "$receipt_path" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	_full_loop_receipt_lock_release
 	return 0
 }
 

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -1261,6 +1261,79 @@ cmd_record_no_release() {
 	return 0
 }
 
+_full_loop_terminal_release_status() {
+	local repo="$1"
+	local pr_number="$2"
+	local receipt_path=""
+	local release_status=""
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
+	[[ -f "$receipt_path" ]] || return 1
+	IFS= read -r release_status <"$receipt_path" || return 1
+	[[ "$release_status" == "$_FULL_LOOP_RELEASE_PUBLISHED" || "$release_status" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" ]] || return 1
+	printf '%s\n' "$release_status"
+	return 0
+}
+
+cmd_finalize_receipt() {
+	local pr_number="${1:-}"
+	local repo=""
+	local release_status=""
+	[[ $# -ge 1 && $# -le 2 && "$pr_number" =~ ^[0-9]+$ ]] || {
+		print_error "Usage: full-loop-helper.sh finalize-receipt <PR> [REPO]"
+		return 1
+	}
+	repo=$(_full_loop_resolve_repo "${2:-}") || return 1
+	_full_loop_verify_merged_pr "$pr_number" "$repo" || {
+		print_error "Finalization blocked: PR #${pr_number} lacks merged evidence"
+		return 1
+	}
+	release_status=$(_full_loop_terminal_release_status "$repo" "$pr_number") || {
+		print_error "Finalization blocked: terminal release evidence is missing"
+		return 1
+	}
+	full_loop_finalize_cleanup_receipt "$repo" "$pr_number" "$release_status" || {
+		print_error "Finalization blocked: cleanup receipt is missing or conflicts with terminal evidence"
+		return 1
+	}
+	print_success "Cleanup receipt finalized for merged PR #${pr_number} (release:${release_status})"
+	return 0
+}
+
+cmd_migrate_repository_receipt() {
+	local pr_number="${1:-}"
+	local old_repo="${2:-}"
+	local new_repo="${3:-}"
+	local source_release=""
+	local destination_release=""
+	local release_status=""
+	if [[ $# -ne 3 || ! "$pr_number" =~ ^[0-9]+$ || "$old_repo" != */* || "$new_repo" != */* || "$old_repo" == "$new_repo" ]]; then
+		print_error "Usage: full-loop-helper.sh migrate-repository-receipt <PR> <OLD_REPO> <NEW_REPO>"
+		return 1
+	fi
+	_full_loop_verify_merged_pr "$pr_number" "$new_repo" || {
+		print_error "Migration blocked: PR #${pr_number} lacks merged evidence in ${new_repo}"
+		return 1
+	}
+	source_release=$(_full_loop_release_receipt_path "$old_repo" "$pr_number") || return 1
+	destination_release=$(_full_loop_release_receipt_path "$new_repo" "$pr_number") || return 1
+	if [[ -f "$source_release" ]]; then
+		IFS= read -r release_status <"$source_release" || true
+	elif [[ -f "$destination_release" ]]; then
+		IFS= read -r release_status <"$destination_release" || true
+	fi
+	[[ "$release_status" == "$_FULL_LOOP_RELEASE_PUBLISHED" || "$release_status" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" ]] || {
+		print_error "Migration blocked: terminal release evidence is missing"
+		return 1
+	}
+	full_loop_migrate_cleanup_receipt "$old_repo" "$new_repo" "$pr_number" \
+		"$source_release" "$destination_release" "$release_status" || {
+		print_error "Migration blocked: source evidence is missing or destination evidence conflicts"
+		return 1
+	}
+	print_success "Migrated full-loop receipts from ${old_repo} to ${new_repo} for PR #${pr_number}"
+	return 0
+}
+
 _full_loop_verify_aidevops_release_deploy() {
 	local repo="$1"
 	local pr_number="$2"

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -239,6 +239,9 @@ Commands:
                                  gh CLI level; if both are given, --admin wins and
                                   --auto is dropped (GH#19310).
   record-no-release <PR> [REPO]  Verify merged evidence and record release:not-requested.
+  finalize-receipt <PR> [REPO]   Finalize a direct-merge cleanup receipt without local state.
+  migrate-repository-receipt <PR> <OLD_REPO> <NEW_REPO>
+                                 Migrate cleanup and release identity after a repo rename.
   complete                       Persist CLEANUP_DEFERRED and hand cleanup to a supervisor.
   complete-after-cleanup <PR> <removed-worktree-path> [REPO]
                                  Verify merged, released/deployed, and cleaned evidence.
@@ -273,6 +276,8 @@ main() {
 	wait-checks) cmd_wait_checks "$@" ;;
 	merge) cmd_merge "$@" ;;
 	record-no-release) cmd_record_no_release "$@" ;;
+	finalize-receipt) cmd_finalize_receipt "$@" ;;
+	migrate-repository-receipt) cmd_migrate_repository_receipt "$@" ;;
 	complete) cmd_complete "$@" ;;
 	complete-after-cleanup) cmd_complete_after_cleanup "$@" ;;
 	help | --help | -h) show_help ;;

--- a/.agents/scripts/init-routines-helper.sh
+++ b/.agents/scripts/init-routines-helper.sh
@@ -67,9 +67,10 @@ Fields:
 
 ## Core Routines (framework-managed)
 
-<!-- These routines are managed by aidevops setup. They reflect the launchd
-     jobs installed by setup.sh. Edit the enabled/disabled state here;
-     the schedule and script are authoritative in the launchd plist. -->
+<!-- These routines are managed by aidevops setup. Enabled state, repeat:
+     expressions, and scripts are version controlled here. Pulse evaluates
+     most entries; routines documented as persistent may use a dedicated
+     launchd or systemd unit. Edit only the enabled/disabled state here. -->
 
 TODOEOF
 

--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -29,6 +29,8 @@
 # verify idempotency.
 [[ -n "${_PULSE_ROUTINES_LOADED:-}" ]] && return 0
 _PULSE_ROUTINES_LOADED=1
+_ROUTINE_STATUS_SUCCESS="success"
+_ROUTINE_STATUS_FAILURE="failure"
 
 #######################################
 # Read last-run epoch for a routine ID from state file
@@ -76,14 +78,44 @@ _routine_update_state() {
 
 	local tmp_file
 	tmp_file=$(mktemp "$(dirname "$ROUTINE_STATE_FILE")/.routine-state.XXXXXX")
-	if echo "$existing" | jq --arg id "$routine_id" --arg ts "$now_iso" --arg st "$status" \
-		'.[$id] = {"last_run": $ts, "last_status": $st}' >"$tmp_file" 2>/dev/null; then
+	if echo "$existing" | jq --arg id "$routine_id" --arg ts "$now_iso" --arg st "$status" --arg success "$_ROUTINE_STATUS_SUCCESS" '
+		.[$id] = ((.[$id] // {}) + {"last_attempt": $ts, "last_status": $st})
+		| if $st == $success then .[$id].last_run = $ts else . end
+	' >"$tmp_file" 2>/dev/null; then
 		mv "$tmp_file" "$ROUTINE_STATE_FILE"
 	else
 		rm -f "$tmp_file"
 		echo "[pulse-wrapper] _routine_update_state: failed to write state for ${routine_id}" >>"$LOGFILE"
 	fi
 	return 0
+}
+
+#######################################
+# Block duplicate active executions and apply an explicit short failure retry
+# cooldown without moving the successful calendar boundary marker.
+#######################################
+_routine_retry_blocked() {
+	local routine_id="$1"
+	local retry_seconds="${AIDEVOPS_ROUTINE_FAILURE_RETRY_SECONDS:-900}"
+	local running_seconds="${AIDEVOPS_ROUTINE_RUNNING_TIMEOUT_SECONDS:-21600}"
+	local status=""
+	local attempt_iso=""
+	local attempt_epoch=0
+	local now_epoch=0
+	[[ "$retry_seconds" =~ ^[0-9]+$ ]] || retry_seconds=900
+	[[ "$running_seconds" =~ ^[0-9]+$ ]] || running_seconds=21600
+	[[ -f "$ROUTINE_STATE_FILE" ]] || return 1
+	status=$(jq -r --arg id "$routine_id" '.[$id].last_status // empty' "$ROUTINE_STATE_FILE" 2>/dev/null || true)
+	attempt_iso=$(jq -r --arg id "$routine_id" '.[$id].last_attempt // empty' "$ROUTINE_STATE_FILE" 2>/dev/null || true)
+	[[ -n "$attempt_iso" ]] || return 1
+	attempt_epoch=$(date -d "$attempt_iso" +%s 2>/dev/null) || attempt_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$attempt_iso" +%s 2>/dev/null) || return 1
+	now_epoch=$(date +%s)
+	case "$status" in
+	running) [[ $((now_epoch - attempt_epoch)) -lt "$running_seconds" ]] ;;
+	failure) [[ $((now_epoch - attempt_epoch)) -lt "$retry_seconds" ]] ;;
+	*) return 1 ;;
+	esac
+	return $?
 }
 
 _routine_record_lifecycle() {
@@ -127,13 +159,13 @@ _routine_dispatch_agent() {
 	_routine_record_lifecycle "$routine_id" "running" 0 "$session_key"
 	if [[ ! -x "$HEADLESS_RUNTIME_HELPER" ]]; then
 		echo "[pulse-wrapper] routine ${routine_id}: headless runtime helper unavailable" >>"$LOGFILE"
-		_routine_finalize_terminal "$routine_id" "failure" "$started_epoch" "$session_key"
+		_routine_finalize_terminal "$routine_id" "$_ROUTINE_STATUS_FAILURE" "$started_epoch" "$session_key"
 		return 1
 	fi
 	echo "[pulse-wrapper] routine ${routine_id}: dispatching agent '${agent_name}' for '${description}'" >>"$LOGFILE"
 	(
 		local exit_code=0
-		local status="success"
+		local status="$_ROUTINE_STATUS_SUCCESS"
 		"$HEADLESS_RUNTIME_HELPER" run \
 			--role worker \
 			--session-key "$session_key" \
@@ -142,7 +174,7 @@ _routine_dispatch_agent() {
 			--title "Routine ${routine_id}: ${description}" \
 			--prompt "Execute routine ${routine_id}: ${description}" >>"$LOGFILE" 2>&1 || exit_code=$?
 		if [[ "$exit_code" -ne 0 ]]; then
-			status="failure"
+			status="$_ROUTINE_STATUS_FAILURE"
 			echo "[pulse-wrapper] routine ${routine_id}: agent exited with code ${exit_code}" >>"$LOGFILE"
 		else
 			echo "[pulse-wrapper] routine ${routine_id}: agent completed successfully" >>"$LOGFILE"
@@ -165,7 +197,7 @@ _routine_execute() {
 	local agent_name="$4"
 	local repo_path="$5"
 	local agents_dir="${HOME}/.aidevops/agents"
-	local status="success"
+	local status="$_ROUTINE_STATUS_SUCCESS"
 	local started_epoch=0
 	local exit_code=0
 	started_epoch=$(date +%s)
@@ -177,13 +209,13 @@ _routine_execute() {
 		local script_args=("${run_parts[@]:1}")
 		if [[ ! -x "$script_path" ]]; then
 			echo "[pulse-wrapper] routine ${routine_id}: script not found or not executable: ${script_path}" >>"$LOGFILE"
-			_routine_finalize_terminal "$routine_id" "failure" "$started_epoch"
+			_routine_finalize_terminal "$routine_id" "$_ROUTINE_STATUS_FAILURE" "$started_epoch"
 			return 1
 		fi
 		echo "[pulse-wrapper] routine ${routine_id}: executing script ${script_path} ${script_args[*]}" >>"$LOGFILE"
 		"$script_path" "${script_args[@]}" >>"$LOGFILE" 2>&1 || exit_code=$?
 		if [[ "$exit_code" -ne 0 ]]; then
-			status="failure"
+			status="$_ROUTINE_STATUS_FAILURE"
 			echo "[pulse-wrapper] routine ${routine_id}: script exited with code ${exit_code}" >>"$LOGFILE"
 		else
 			echo "[pulse-wrapper] routine ${routine_id}: script completed successfully" >>"$LOGFILE"
@@ -196,7 +228,7 @@ _routine_execute() {
 	if [[ -z "$agent_name" && -x "$custom_script" ]]; then
 		echo "[pulse-wrapper] routine ${routine_id}: executing custom script ${custom_script}" >>"$LOGFILE"
 		"$custom_script" >>"$LOGFILE" 2>&1 || exit_code=$?
-		[[ "$exit_code" -eq 0 ]] || status="failure"
+		[[ "$exit_code" -eq 0 ]] || status="$_ROUTINE_STATUS_FAILURE"
 		_routine_finalize_terminal "$routine_id" "$status" "$started_epoch"
 		return 0
 	fi
@@ -327,6 +359,12 @@ evaluate_routines() {
 		local line
 		while IFS= read -r line; do
 			if ! _routine_parse_line "$line"; then
+				continue
+			fi
+
+			# Active runs and recent failures have their own bounded retry policy;
+			# only successful runs advance the calendar boundary marker.
+			if _routine_retry_blocked "$_RPL_ID"; then
 				continue
 			fi
 

--- a/.agents/scripts/routine-schedule-helper.sh
+++ b/.agents/scripts/routine-schedule-helper.sh
@@ -4,7 +4,7 @@
 # routine-schedule-helper.sh — Deterministic schedule parser for routine evaluation
 #
 # Supports: daily(@HH:MM), weekly(day@HH:MM), monthly(N@HH:MM), cron(5-field-expr), persistent
-# Pure bash date arithmetic, no external deps beyond `date`.
+# Calendar arithmetic uses the host `date` implementation on macOS and Linux.
 #
 # Commands:
 #   is-due <expression> <last-run-epoch>  → exit 0 if due, exit 1 if not
@@ -17,6 +17,8 @@ set -euo pipefail
 readonly SCHEDULE_ERROR_PREFIX="ERROR"
 readonly SCHEDULE_TYPE_PERSISTENT="per""sistent"
 readonly SCHEDULE_UNKNOWN_TYPE_MESSAGE="unknown schedule type"
+readonly SCHEDULE_BOUNDARY_LATEST="latest"
+readonly SCHEDULE_BOUNDARY_NEXT="next"
 
 #######################################
 # Day name to cron weekday number (0=Sun, 1=Mon, ..., 6=Sat)
@@ -46,10 +48,27 @@ _day_to_number() {
 }
 
 #######################################
-# Get current epoch (UTC)
+# Resolve the scheduler timezone. An explicit IANA timezone is optional; when
+# omitted, date(1) uses the host-local timezone consistently.
+#######################################
+_schedule_timezone() {
+	printf '%s' "${AIDEVOPS_SCHEDULE_TIMEZONE:-${TZ:-}}"
+	return 0
+}
+
+#######################################
+# Get current epoch. Tests may inject a fixed epoch explicitly.
 #######################################
 _now_epoch() {
-	date -u +%s
+	if [[ -n "${AIDEVOPS_SCHEDULE_NOW_EPOCH:-}" ]]; then
+		[[ "$AIDEVOPS_SCHEDULE_NOW_EPOCH" =~ ^[0-9]+$ ]] || {
+			printf '%s: %s\n' "$SCHEDULE_ERROR_PREFIX" "invalid injected scheduler epoch" >&2
+			return 1
+		}
+		printf '%s' "$AIDEVOPS_SCHEDULE_NOW_EPOCH"
+		return 0
+	fi
+	date +%s
 	return 0
 }
 
@@ -95,34 +114,115 @@ _epoch_to_iso() {
 }
 
 #######################################
-# Get current hour and minute as integers
+# Format an epoch in the scheduler timezone.
 #######################################
-_current_hm() {
-	local hour minute
-	hour=$(date -u +%H)
-	minute=$(date -u +%M)
-	# Strip leading zeros for arithmetic
-	hour=$((10#$hour))
-	minute=$((10#$minute))
-	printf '%d %d' "$hour" "$minute"
+_calendar_at_epoch() {
+	local epoch="$1"
+	local format="$2"
+	local timezone=""
+	local output=""
+	timezone=$(_schedule_timezone)
+	output=$(TZ="$timezone" date -d "@${epoch}" "+${format}" 2>/dev/null) || true
+	if [[ -z "$output" ]]; then
+		output=$(TZ="$timezone" date -r "$epoch" "+${format}" 2>/dev/null) || true
+	fi
+	[[ -n "$output" ]] || {
+		printf '%s: %s\n' "$SCHEDULE_ERROR_PREFIX" "cannot format epoch '${epoch}' in timezone '${timezone:-host-local}'" >&2
+		return 1
+	}
+	printf '%s' "$output"
 	return 0
 }
 
 #######################################
-# Get current day of week (0=Sun, 1=Mon, ..., 6=Sat)
+# Convert a scheduler-local date/time to epoch and reject DST normalization.
 #######################################
-_current_dow() {
-	date -u +%w
+_calendar_local_to_epoch() {
+	local local_date="$1"
+	local local_time="$2"
+	local timezone=""
+	local epoch=""
+	local round_trip=""
+	timezone=$(_schedule_timezone)
+	if [[ -n "$timezone" ]] && command -v python3 >/dev/null 2>&1; then
+		epoch=$(
+			python3 - "$local_date" "$local_time" "$timezone" <<'PY'
+import datetime as dt
+import sys
+from zoneinfo import ZoneInfo
+
+try:
+    naive = dt.datetime.strptime(f"{sys.argv[1]} {sys.argv[2]}", "%Y-%m-%d %H:%M:%S")
+    zone = ZoneInfo(sys.argv[3])
+except (ValueError, OSError, KeyError):
+    raise SystemExit(1)
+
+# fold=0 is the explicit contract for a repeated fall-back hour: the first
+# occurrence owns the boundary. A round trip rejects nonexistent spring times.
+aware = naive.replace(tzinfo=zone, fold=0)
+epoch = int(aware.timestamp())
+if dt.datetime.fromtimestamp(epoch, zone).replace(tzinfo=None) != naive:
+    raise SystemExit(1)
+print(epoch)
+PY
+		) || epoch=""
+	fi
+	if [[ -z "$epoch" ]]; then
+		epoch=$(TZ="$timezone" date -d "${local_date} ${local_time}" +%s 2>/dev/null) || true
+		if [[ -z "$epoch" ]]; then
+			epoch=$(TZ="$timezone" date -j -f "%Y-%m-%d %H:%M:%S" "${local_date} ${local_time}" +%s 2>/dev/null) || true
+		fi
+	fi
+	[[ "$epoch" =~ ^[0-9]+$ ]] || {
+		printf '%s: %s\n' "$SCHEDULE_ERROR_PREFIX" "cannot resolve local time '${local_date} ${local_time}' in timezone '${timezone:-host-local}'" >&2
+		return 1
+	}
+	round_trip=$(_calendar_at_epoch "$epoch" '%Y-%m-%d %H:%M:%S') || return 1
+	[[ "$round_trip" == "${local_date} ${local_time}" ]] || {
+		printf '%s: %s\n' "$SCHEDULE_ERROR_PREFIX" "nonexistent or normalized local time '${local_date} ${local_time}' in timezone '${timezone:-host-local}'" >&2
+		return 1
+	}
+	printf '%s' "$epoch"
 	return 0
 }
 
 #######################################
-# Get current day of month
+# Shift a scheduler-local calendar date without assuming 86400-second days.
 #######################################
-_current_dom() {
-	local dom
-	dom=$(date -u +%d)
-	printf '%d' "$((10#$dom))"
+_calendar_shift_date() {
+	local local_date="$1"
+	local day_delta="$2"
+	local timezone=""
+	local shifted=""
+	local bsd_delta="$day_delta"
+	[[ "$day_delta" -lt 0 ]] || bsd_delta="+${day_delta}"
+	timezone=$(_schedule_timezone)
+	shifted=$(TZ="$timezone" date -d "${local_date} ${day_delta} day" +%Y-%m-%d 2>/dev/null) || true
+	if [[ -z "$shifted" ]]; then
+		shifted=$(TZ="$timezone" date -j -v"${bsd_delta}"d -f "%Y-%m-%d" "$local_date" +%Y-%m-%d 2>/dev/null) || true
+	fi
+	[[ -n "$shifted" ]] || return 1
+	printf '%s' "$shifted"
+	return 0
+}
+
+#######################################
+# Shift a YYYY-MM month key while preserving calendar month boundaries.
+#######################################
+_calendar_shift_month() {
+	local year_month="$1"
+	local month_delta="$2"
+	local timezone=""
+	local shifted=""
+	local bsd_delta="$month_delta"
+	[[ "$month_delta" -lt 0 ]] || bsd_delta="+${month_delta}"
+	timezone=$(_schedule_timezone)
+	shifted=$(TZ="$timezone" date -d "${year_month}-01 ${month_delta} month" +%Y-%m 2>/dev/null) || true
+	if [[ -z "$shifted" ]]; then
+		shifted=$(TZ="$timezone" date -j -v"${bsd_delta}"m -f "%Y-%m-%d" "${year_month}-01" +%Y-%m 2>/dev/null) || true
+	fi
+	[[ -n "$shifted" ]] || return 1
+	printf '%s' "$shifted"
 	return 0
 }
 
@@ -423,22 +523,22 @@ _cron_field_matches() {
 }
 
 #######################################
-# Check if a cron expression matches the current time
+# Check if a cron expression matches one scheduler-local minute.
 #######################################
-_cron_matches_now() {
+_cron_matches_epoch() {
 	local cron_expr="$1"
+	local epoch="$2"
 	local cron_minute cron_hour cron_dom cron_month cron_dow
 	# shellcheck disable=SC2086
 	read -r cron_minute cron_hour cron_dom cron_month cron_dow <<<"$cron_expr"
 
-	local now_hour now_minute
-	read -r now_hour now_minute <<<"$(_current_hm)"
-	local now_dow
-	now_dow=$(_current_dow)
-	local now_dom
-	now_dom=$(_current_dom)
-	local now_month
-	now_month=$(date -u +%m)
+	local calendar_fields=""
+	local now_hour now_minute now_dow now_dom now_month
+	calendar_fields=$(_calendar_at_epoch "$epoch" '%H %M %w %d %m') || return 2
+	read -r now_hour now_minute now_dow now_dom now_month <<<"$calendar_fields"
+	now_hour=$((10#$now_hour))
+	now_minute=$((10#$now_minute))
+	now_dom=$((10#$now_dom))
 	now_month=$((10#$now_month))
 
 	_cron_field_matches "$cron_minute" "$now_minute" || return 1
@@ -451,22 +551,167 @@ _cron_matches_now() {
 }
 
 #######################################
-# Calculate the interval in seconds for a schedule type
-# Used to determine if enough time has passed since last run
+# Find the latest matching cron minute after the last run. A single Python
+# process bounds the search without spawning date/jq processes per minute.
 #######################################
-_schedule_interval_seconds() {
-	local sched_type="$1"
+_cron_latest_boundary() {
+	local cron_expr="$1"
+	local last_run_epoch="$2"
+	local now_epoch="$3"
+	local mode="${4:-$SCHEDULE_BOUNDARY_LATEST}"
+	local timezone=""
+	timezone=$(_schedule_timezone)
+	command -v python3 >/dev/null 2>&1 || {
+		printf '%s: %s\n' "$SCHEDULE_ERROR_PREFIX" "python3 is required for bounded cron catch-up evaluation" >&2
+		return 2
+	}
+	python3 - "$cron_expr" "$last_run_epoch" "$now_epoch" "$timezone" "$mode" \
+		"$SCHEDULE_BOUNDARY_LATEST" "$SCHEDULE_BOUNDARY_NEXT" <<'PY'
+import datetime as dt
+import sys
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    ZoneInfo = None
+
+expression, last_text, now_text, timezone, mode, latest_mode, next_mode = sys.argv[1:]
+fields = expression.split()
+if len(fields) != 5:
+    raise SystemExit(2)
+
+try:
+    last_run = int(last_text)
+    now_epoch = int(now_text)
+    candidate = now_epoch // 60 * 60
+    zone = ZoneInfo(timezone) if timezone and ZoneInfo else None
+except (ValueError, TypeError, OSError):
+    raise SystemExit(2)
+
+if mode == next_mode:
+    candidate += 60
+    step = 60
+elif mode == latest_mode:
+    step = -60
+else:
+    raise SystemExit(2)
+
+def matches(field, value):
+    if field == "*":
+        return True
+    if field.startswith("*/"):
+        try:
+            step = int(field[2:])
+        except ValueError:
+            return False
+        return step > 0 and value % step == 0
+    for item in field.split(","):
+        if "-" in item:
+            try:
+                start, end = (int(part) for part in item.split("-", 1))
+            except ValueError:
+                return False
+            if start <= value <= end:
+                return True
+        else:
+            try:
+                if int(item) == value:
+                    return True
+            except ValueError:
+                return False
+    return False
+
+limit = 527040  # one leap-year of minute boundaries
+for _ in range(limit):
+    if mode == latest_mode and candidate <= last_run:
+        raise SystemExit(1)
+    instant = dt.datetime.fromtimestamp(candidate, zone) if zone else dt.datetime.fromtimestamp(candidate).astimezone()
+    cron_dow = (instant.weekday() + 1) % 7
+    values = (instant.minute, instant.hour, instant.day, instant.month, cron_dow)
+    if all(matches(field, value) for field, value in zip(fields, values)):
+        print(candidate)
+        raise SystemExit(0)
+    candidate += step
+raise SystemExit(2)
+PY
+	return 0
+}
+
+#######################################
+# Calculate the latest or next calendar boundary for parsed daily/weekly/monthly
+# schedules using scheduler-local calendar dates.
+#######################################
+_calendar_boundary_epoch() {
+	local parsed="$1"
+	local mode="$2"
+	local now_epoch="$3"
+	local sched_type sched_hour sched_minute sched_value
+	read -r sched_type sched_hour sched_minute sched_value <<<"$parsed"
+	local local_time=""
+	local today=""
+	local candidate_date=""
+	local candidate_epoch=""
+	local delta=0
+	local attempts=0
+	local_time=$(printf '%02d:%02d:00' "$sched_hour" "$sched_minute")
+	today=$(_calendar_at_epoch "$now_epoch" '%Y-%m-%d') || return 2
 
 	case "$sched_type" in
-	daily) printf '%d' 86400 ;;        # 24 hours
-	weekly) printf '%d' 604800 ;;      # 7 days
-	monthly) printf '%d' 2592000 ;;    # 30 days (approximate)
-	cron) printf '%d' 60 ;;            # 1 minute (cron granularity)
-	persistent) printf '%d' 2147483647 ;; # max int — never due via interval check
-	*)
-		printf '%d' 86400
+	daily)
+		candidate_date="$today"
+		candidate_epoch=$(_calendar_local_to_epoch "$candidate_date" "$local_time") || return 2
+		if [[ "$mode" == "$SCHEDULE_BOUNDARY_LATEST" && "$candidate_epoch" -gt "$now_epoch" ]]; then
+			candidate_date=$(_calendar_shift_date "$candidate_date" -1) || return 2
+			candidate_epoch=$(_calendar_local_to_epoch "$candidate_date" "$local_time") || return 2
+		elif [[ "$mode" == "$SCHEDULE_BOUNDARY_NEXT" && "$candidate_epoch" -le "$now_epoch" ]]; then
+			candidate_date=$(_calendar_shift_date "$candidate_date" 1) || return 2
+			candidate_epoch=$(_calendar_local_to_epoch "$candidate_date" "$local_time") || return 2
+		fi
 		;;
+	weekly)
+		local now_dow=""
+		now_dow=$(_calendar_at_epoch "$now_epoch" '%w') || return 2
+		delta=$(((10#$now_dow - sched_value + 7) % 7))
+		candidate_date=$(_calendar_shift_date "$today" "$((-delta))") || return 2
+		candidate_epoch=$(_calendar_local_to_epoch "$candidate_date" "$local_time") || return 2
+		if [[ "$mode" == "$SCHEDULE_BOUNDARY_LATEST" && "$candidate_epoch" -gt "$now_epoch" ]]; then
+			candidate_date=$(_calendar_shift_date "$candidate_date" -7) || return 2
+			candidate_epoch=$(_calendar_local_to_epoch "$candidate_date" "$local_time") || return 2
+		elif [[ "$mode" == "$SCHEDULE_BOUNDARY_NEXT" && "$candidate_epoch" -le "$now_epoch" ]]; then
+			candidate_date=$(_calendar_shift_date "$candidate_date" 7) || return 2
+			candidate_epoch=$(_calendar_local_to_epoch "$candidate_date" "$local_time") || return 2
+		fi
+		;;
+	monthly)
+		local year_month=""
+		year_month=$(_calendar_at_epoch "$now_epoch" '%Y-%m') || return 2
+		delta=0
+		while [[ "$attempts" -lt 24 ]]; do
+			local target_month=""
+			target_month=$(_calendar_shift_month "$year_month" "$delta") || return 2
+			candidate_date=$(printf '%s-%02d' "$target_month" "$sched_value")
+			candidate_epoch=$(_calendar_local_to_epoch "$candidate_date" "$local_time" 2>/dev/null) || candidate_epoch=""
+			if [[ -n "$candidate_epoch" ]]; then
+				if [[ "$mode" == "$SCHEDULE_BOUNDARY_LATEST" && "$candidate_epoch" -le "$now_epoch" ]]; then
+					break
+				fi
+				if [[ "$mode" == "$SCHEDULE_BOUNDARY_NEXT" && "$candidate_epoch" -gt "$now_epoch" ]]; then
+					break
+				fi
+			fi
+			if [[ "$mode" == "$SCHEDULE_BOUNDARY_LATEST" ]]; then
+				delta=$((delta - 1))
+			else
+				delta=$((delta + 1))
+			fi
+			attempts=$((attempts + 1))
+		done
+		[[ -n "$candidate_epoch" && "$attempts" -lt 24 ]] || return 2
+		;;
+	*) return 2 ;;
 	esac
+
+	printf '%s' "$candidate_epoch"
 	return 0
 }
 
@@ -497,81 +742,32 @@ cmd_is_due() {
 		return 1
 	fi
 
-	local now_epoch
-	now_epoch=$(_now_epoch)
+	local now_epoch=""
+	now_epoch=$(_now_epoch) || return 2
 
 	# If never run (epoch 0), it's always due
 	if [[ "$last_run_epoch" -eq 0 ]]; then
 		return 0
 	fi
 
-	local interval
-	interval=$(_schedule_interval_seconds "$sched_type")
-
-	# Minimum interval check: don't re-run if less than 90% of the interval
-	# has passed. This prevents double-runs when the pulse fires slightly
-	# before and after the scheduled time.
-	local min_elapsed=$((interval * 90 / 100))
-	local elapsed=$((now_epoch - last_run_epoch))
-	if [[ "$elapsed" -lt "$min_elapsed" ]]; then
+	if [[ ! "$last_run_epoch" =~ ^[0-9]+$ ]] || [[ "$last_run_epoch" -gt "$now_epoch" ]]; then
 		return 1
 	fi
 
 	case "$sched_type" in
-	daily)
-		local sched_hour sched_minute
-		sched_hour=$(printf '%s' "$parsed" | awk '{print $2}')
-		sched_minute=$(printf '%s' "$parsed" | awk '{print $3}')
-		local now_hour now_minute
-		read -r now_hour now_minute <<<"$(_current_hm)"
-		# Due if current time is at or past the scheduled time
-		if [[ "$now_hour" -gt "$sched_hour" ]] ||
-			{ [[ "$now_hour" -eq "$sched_hour" ]] && [[ "$now_minute" -ge "$sched_minute" ]]; }; then
-			return 0
-		fi
-		return 1
-		;;
-	weekly)
-		local sched_hour sched_minute sched_dow
-		sched_hour=$(printf '%s' "$parsed" | awk '{print $2}')
-		sched_minute=$(printf '%s' "$parsed" | awk '{print $3}')
-		sched_dow=$(printf '%s' "$parsed" | awk '{print $4}')
-		local now_dow
-		now_dow=$(_current_dow)
-		local now_hour now_minute
-		read -r now_hour now_minute <<<"$(_current_hm)"
-		if [[ "$now_dow" -eq "$sched_dow" ]]; then
-			if [[ "$now_hour" -gt "$sched_hour" ]] ||
-				{ [[ "$now_hour" -eq "$sched_hour" ]] && [[ "$now_minute" -ge "$sched_minute" ]]; }; then
-				return 0
-			fi
-		fi
-		return 1
-		;;
-	monthly)
-		local sched_hour sched_minute sched_dom
-		sched_hour=$(printf '%s' "$parsed" | awk '{print $2}')
-		sched_minute=$(printf '%s' "$parsed" | awk '{print $3}')
-		sched_dom=$(printf '%s' "$parsed" | awk '{print $4}')
-		local now_dom
-		now_dom=$(_current_dom)
-		local now_hour now_minute
-		read -r now_hour now_minute <<<"$(_current_hm)"
-		if [[ "$now_dom" -eq "$sched_dom" ]]; then
-			if [[ "$now_hour" -gt "$sched_hour" ]] ||
-				{ [[ "$now_hour" -eq "$sched_hour" ]] && [[ "$now_minute" -ge "$sched_minute" ]]; }; then
-				return 0
-			fi
-		fi
-		return 1
+	daily | weekly | monthly)
+		local latest_boundary=""
+		latest_boundary=$(_calendar_boundary_epoch "$parsed" "$SCHEDULE_BOUNDARY_LATEST" "$now_epoch") || return 2
+		[[ "$last_run_epoch" -lt "$latest_boundary" ]]
+		return $?
 		;;
 	cron)
 		local cron_expr
 		cron_expr=$(printf '%s' "$parsed" | sed 's/^cron //')
-		if _cron_matches_now "$cron_expr"; then
-			return 0
-		fi
-		return 1
+		local cron_boundary=""
+		cron_boundary=$(_cron_latest_boundary "$cron_expr" "$last_run_epoch" "$now_epoch") || return $?
+		[[ "$cron_boundary" =~ ^[0-9]+$ ]]
+		return $?
 		;;
 	*)
 		printf '%s: %s %s\n' "$SCHEDULE_ERROR_PREFIX" "$SCHEDULE_UNKNOWN_TYPE_MESSAGE" "$sched_type" >&2
@@ -588,99 +784,6 @@ cmd_is_due() {
 #
 # Output: ISO timestamp of next scheduled run
 #######################################
-_next_run_daily() {
-	local parsed="$1"
-	local now_epoch="$2"
-	local sched_hour sched_minute
-	sched_hour=$(printf '%s' "$parsed" | awk '{print $2}')
-	sched_minute=$(printf '%s' "$parsed" | awk '{print $3}')
-
-	local today_date
-	today_date=$(date -u +%Y-%m-%d)
-	local sched_iso
-	sched_iso="${today_date}T$(printf '%02d:%02d:00Z' "$sched_hour" "$sched_minute")"
-	local sched_epoch
-	sched_epoch=$(_iso_to_epoch "$sched_iso") || return 2
-
-	if [[ "$now_epoch" -lt "$sched_epoch" ]]; then
-		_epoch_to_iso "$sched_epoch"
-	else
-		_epoch_to_iso $((sched_epoch + 86400))
-	fi
-	printf '\n'
-	return 0
-}
-
-_next_run_weekly() {
-	local parsed="$1"
-	local now_epoch="$2"
-	local sched_hour sched_minute sched_dow
-	sched_hour=$(printf '%s' "$parsed" | awk '{print $2}')
-	sched_minute=$(printf '%s' "$parsed" | awk '{print $3}')
-	sched_dow=$(printf '%s' "$parsed" | awk '{print $4}')
-	local now_dow
-	now_dow=$(_current_dow)
-
-	local days_ahead=$(((sched_dow - now_dow + 7) % 7))
-	if [[ "$days_ahead" -eq 0 ]]; then
-		local now_hour now_minute
-		read -r now_hour now_minute <<<"$(_current_hm)"
-		if [[ "$now_hour" -gt "$sched_hour" ]] ||
-			{ [[ "$now_hour" -eq "$sched_hour" ]] && [[ "$now_minute" -ge "$sched_minute" ]]; }; then
-			days_ahead=7
-		fi
-	fi
-
-	local next_epoch=$((now_epoch + days_ahead * 86400))
-	local next_date
-	next_date=$(_epoch_to_iso "$next_epoch") || return 2
-	next_date="${next_date%%T*}"
-	local next_iso
-	next_iso="${next_date}T$(printf '%02d:%02d:00Z' "$sched_hour" "$sched_minute")"
-	printf '%s\n' "$next_iso"
-	return 0
-}
-
-_next_run_monthly() {
-	local parsed="$1"
-	local sched_hour sched_minute sched_dom
-	sched_hour=$(printf '%s' "$parsed" | awk '{print $2}')
-	sched_minute=$(printf '%s' "$parsed" | awk '{print $3}')
-	sched_dom=$(printf '%s' "$parsed" | awk '{print $4}')
-
-	local now_dom
-	now_dom=$(_current_dom)
-	local now_year now_month_num
-	now_year=$(date -u +%Y)
-	now_month_num=$(date -u +%m)
-	now_month_num=$((10#$now_month_num))
-
-	local target_year="$now_year"
-	local target_month="$now_month_num"
-
-	if [[ "$now_dom" -gt "$sched_dom" ]]; then
-		target_month=$((target_month + 1))
-		if [[ "$target_month" -gt 12 ]]; then
-			target_month=1
-			target_year=$((target_year + 1))
-		fi
-	elif [[ "$now_dom" -eq "$sched_dom" ]]; then
-		local now_hour now_minute
-		read -r now_hour now_minute <<<"$(_current_hm)"
-		if [[ "$now_hour" -gt "$sched_hour" ]] ||
-			{ [[ "$now_hour" -eq "$sched_hour" ]] && [[ "$now_minute" -ge "$sched_minute" ]]; }; then
-			target_month=$((target_month + 1))
-			if [[ "$target_month" -gt 12 ]]; then
-				target_month=1
-				target_year=$((target_year + 1))
-			fi
-		fi
-	fi
-
-	printf '%04d-%02d-%02dT%02d:%02d:00Z\n' "$target_year" "$target_month" "$sched_dom" "$sched_hour" "$sched_minute"
-	return 0
-}
-
 cmd_next_run() {
 	local expression="$1"
 
@@ -691,16 +794,21 @@ cmd_next_run() {
 	sched_type=$(printf '%s' "$parsed" | awk '{print $1}')
 
 	local now_epoch
-	now_epoch=$(_now_epoch)
+	now_epoch=$(_now_epoch) || return 2
 
 	case "$sched_type" in
-	daily) _next_run_daily "$parsed" "$now_epoch" ;;
-	weekly) _next_run_weekly "$parsed" "$now_epoch" ;;
-	monthly) _next_run_monthly "$parsed" ;;
+	daily | weekly | monthly)
+		local next_boundary=""
+		next_boundary=$(_calendar_boundary_epoch "$parsed" "$SCHEDULE_BOUNDARY_NEXT" "$now_epoch") || return 2
+		_epoch_to_iso "$next_boundary"
+		printf '\n'
+		;;
 	cron)
-		# For cron, report "next minute" as approximation
-		local next_epoch=$((now_epoch + 60 - (now_epoch % 60)))
-		_epoch_to_iso "$next_epoch"
+		local cron_expr=""
+		local next_boundary=""
+		cron_expr=$(printf '%s' "$parsed" | sed 's/^cron //')
+		next_boundary=$(_cron_latest_boundary "$cron_expr" "$now_epoch" "$now_epoch" "$SCHEDULE_BOUNDARY_NEXT") || return 2
+		_epoch_to_iso "$next_boundary"
 		printf '\n'
 		;;
 	persistent)

--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -114,6 +114,38 @@ _scheduler_row_calendar() {
 }
 
 # ---------------------------------------------------------------------------
+# _scheduler_row_pulse <repeat_expression>
+# Outputs the scheduler row for routines evaluated by the supervisor Pulse.
+# ---------------------------------------------------------------------------
+_scheduler_row_pulse() {
+	local repeat_expression="$1"
+	echo "| Scheduler | Supervisor Pulse evaluates version-controlled \`${repeat_expression}\` |"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _pulse_diag_commands <os>
+# Outputs diagnostics for the real shared Pulse scheduler and routine state.
+# ---------------------------------------------------------------------------
+_pulse_diag_commands() {
+	local os="$1"
+	if _is_darwin_os "$os"; then
+		cat <<'EOF'
+- `launchctl print "gui/${UID}/com.aidevops.aidevops-supervisor-pulse"` — shared Pulse service health
+EOF
+	else
+		cat <<'EOF'
+- `systemctl --user status sh.aidevops.pulse` — shared Pulse service health
+EOF
+	fi
+	cat <<'EOF'
+- `jq '.r916, .r917' ~/.aidevops/.agent-workspace/pulse/routine-state.json` — last-run state
+- `aidevops status` — framework and supervisor overview
+EOF
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # _diag_commands <os> <plist_label> <systemd_unit>
 # Outputs OS-specific diagnostic commands.
 # ---------------------------------------------------------------------------
@@ -903,13 +935,17 @@ New releases become deduplicated, worker-ready issues in the package repository.
 | Type | script |
 | Expected duration | ~2 minutes |
 | Script | \`scripts/cloudron-package-monitor-helper.sh upstream --apply\` |
-$(_scheduler_row_calendar "$os" "StartCalendarInterval: Hour=7, Minute=10" "sh.aidevops.cloudron-package-upstream" "sh.aidevops.cloudron-package-upstream")
+$(_scheduler_row_pulse "repeat:daily(@07:10)")
+
+Pulse reads the enabled routine from registered \`TODO.md\` files and evaluates
+the version-controlled \`repeat:\` expression; r916 has no dedicated platform unit.
 
 ## Safety rails
 
 - Reads only registrations with \`app_type: cloudron-package\` and explicit upstream metadata.
 - Requires ADMIN or MAINTAIN authority before creating a target-local issue.
 - Never changes package source, tags, releases, catalogs, images, or deployments.
+$(_pulse_diag_commands "$os")
 $(_platform_footnote "$os")
 EOF
 	return 0
@@ -934,13 +970,17 @@ Stable finding fingerprints prevent repeated issues for an already handled audit
 | Type | script |
 | Expected duration | ~5 minutes |
 | Script | \`scripts/cloudron-package-monitor-helper.sh compatibility --apply\` |
-$(_scheduler_row_calendar "$os" "StartCalendarInterval: Weekday=0, Hour=7, Minute=40" "sh.aidevops.cloudron-package-compatibility" "sh.aidevops.cloudron-package-compatibility")
+$(_scheduler_row_pulse "repeat:weekly(sun@07:40)")
+
+Pulse reads the enabled routine from registered \`TODO.md\` files and evaluates
+the version-controlled \`repeat:\` expression; r917 has no dedicated platform unit.
 
 ## Safety rails
 
 - Audits local package files without building or executing upstream content.
 - Creates issues only after target-local deduplication and authority checks.
 - Never acknowledges a finding when GitHub/API operations fail.
+$(_pulse_diag_commands "$os")
 $(_platform_footnote "$os")
 EOF
 	return 0

--- a/.agents/scripts/tests/test-audit-log-recovery.sh
+++ b/.agents/scripts/tests/test-audit-log-recovery.sh
@@ -59,6 +59,56 @@ create_broken_log() {
 	return 0
 }
 
+create_large_broken_log() {
+	local log_file="$1"
+	local count="$2"
+	python3 - "$log_file" "$count" <<'PY'
+import hashlib
+import json
+import sys
+
+path, count_text = sys.argv[1:]
+count = int(count_text)
+previous = "0" * 64
+with open(path, "w", encoding="utf-8") as stream:
+    for index in range(1, count + 1):
+        entry = {
+            "seq": index,
+            "ts": "2026-07-23T00:00:00Z",
+            "type": "operation.verify",
+            "msg": f"large fixture {index} — café",
+            "detail": {"nested": {"index": str(index)}, "escaped": "line\\nvalue"},
+            "actor": "test",
+            "host": "fixture",
+            "prev_hash": "f" * 64 if count > 2 and index == count // 2 else previous,
+        }
+        canonical = json.dumps(entry, ensure_ascii=False, separators=(",", ":"))
+        entry["hash"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        stream.write(json.dumps(entry, ensure_ascii=False, separators=(",", ":")) + "\n")
+        previous = entry["hash"]
+PY
+	return $?
+}
+
+assert_verifier_parity() {
+	local description="$1"
+	local log_file="$2"
+	local fast_rc=0
+	local legacy_rc=0
+	local fast_output=""
+	local legacy_output=""
+	fast_output=$(AUDIT_LOG_FILE="$log_file" AUDIT_QUIET=true "$AUDIT_HELPER" verify --quiet 2>&1) || fast_rc=$?
+	legacy_output=$(AUDIT_FORCE_LEGACY_VERIFIER=true AUDIT_LOG_FILE="$log_file" AUDIT_QUIET=true \
+		"$AUDIT_HELPER" verify --quiet 2>&1) || legacy_rc=$?
+	if [[ "$fast_rc" -eq "$legacy_rc" ]] &&
+		[[ "$fast_output" == *"Entry "* || "$legacy_output" != *"Entry "* || "$fast_rc" -eq 0 ]]; then
+		pass "$description"
+	else
+		fail "${description}: fast_rc=${fast_rc} legacy_rc=${legacy_rc}"
+	fi
+	return 0
+}
+
 assert_chain_intact() {
 	local description="$1"
 	local log_file="$2"
@@ -253,6 +303,18 @@ else
 	fail "recovery changed or accepted an intact chain"
 fi
 
+PARITY_VALID_LOG="${TEST_ROOT}/parity-valid.jsonl"
+create_large_broken_log "$PARITY_VALID_LOG" 2
+assert_verifier_parity "single-process verifier matches legacy valid Unicode/nested verdict" "$PARITY_VALID_LOG"
+
+PARITY_BROKEN_LOG="${TEST_ROOT}/parity-broken.jsonl"
+create_broken_log "$PARITY_BROKEN_LOG"
+assert_verifier_parity "single-process verifier matches legacy broken-link diagnostics" "$PARITY_BROKEN_LOG"
+
+PARITY_MALFORMED_LOG="${TEST_ROOT}/parity-malformed.jsonl"
+printf '{"broken":true}\nnot-json\n' >"$PARITY_MALFORMED_LOG"
+assert_verifier_parity "single-process verifier matches legacy malformed verdict" "$PARITY_MALFORMED_LOG"
+
 AMBIGUOUS_LOG="${TEST_ROOT}/ambiguous.jsonl"
 printf '{"broken":true}\n' >"$AMBIGUOUS_LOG"
 ambiguous_sha256="$(sha256_file "$AMBIGUOUS_LOG")"
@@ -265,6 +327,31 @@ if [[ "$ambiguous_rc" -ne 0 && "$(sha256_file "$AMBIGUOUS_LOG")" == "$ambiguous_
 else
 	fail "recovery changed or accepted ambiguous evidence"
 fi
+
+LARGE_LOG="${TEST_ROOT}/large.jsonl"
+create_large_broken_log "$LARGE_LOG" 30000
+large_source_sha256="$(sha256_file "$LARGE_LOG")"
+SECONDS=0
+large_verify_rc=0
+AUDIT_LOG_FILE="$LARGE_LOG" AUDIT_QUIET=true "$AUDIT_HELPER" verify --quiet >/dev/null 2>&1 || large_verify_rc=$?
+large_verify_seconds=$SECONDS
+if [[ "$large_verify_rc" -ne 0 && "$large_verify_seconds" -lt 30 ]]; then
+	pass "30,000-entry verification is bounded below 30 seconds"
+else
+	fail "30,000-entry verification exceeded the bound or accepted the broken chain"
+fi
+SECONDS=0
+AUDIT_LOG_FILE="$LARGE_LOG" AUDIT_QUIET=true "$AUDIT_HELPER" recover --reason "large bounded fixture"
+large_recovery_seconds=$SECONDS
+large_archive="$(first_archive "$LARGE_LOG")"
+if [[ "$large_recovery_seconds" -lt 30 ]] &&
+	[[ "$(sha256_file "$large_archive")" == "$large_source_sha256" ]] &&
+	[[ ! -w "$large_archive" ]]; then
+	pass "30,000-entry recovery preserves byte-identical read-only evidence below 30 seconds"
+else
+	fail "30,000-entry recovery violated performance or forensic guarantees"
+fi
+assert_chain_intact "large recovery activates an independently verifying successor" "$LARGE_LOG"
 
 CONCURRENT_LOG="${TEST_ROOT}/concurrent.jsonl"
 create_broken_log "$CONCURRENT_LOG"

--- a/.agents/scripts/tests/test-cloudron-package-routines.sh
+++ b/.agents/scripts/tests/test-cloudron-package-routines.sh
@@ -23,6 +23,20 @@ assert_contains() {
 	return 0
 }
 
+assert_not_contains() {
+	local haystack="$1"
+	local needle="$2"
+	local description="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		printf 'PASS %s\n' "$description"
+		PASSED=$((PASSED + 1))
+		return 0
+	fi
+	printf 'FAIL %s (unexpected=%s)\n' "$description" "$needle" >&2
+	FAILED=$((FAILED + 1))
+	return 0
+}
+
 main() {
 	# shellcheck source=../routines/core-routines.sh
 	source "$CORE_ROUTINES"
@@ -30,8 +44,19 @@ main() {
 	entries=$(get_core_routine_entries)
 	assert_contains "$entries" 'r916|x|Cloudron packages — check upstream releases|repeat:daily(@07:10)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script' "daily upstream routine registered"
 	assert_contains "$entries" 'r917|x|Cloudron packages — audit compatibility|repeat:weekly(sun@07:40)|~5m|scripts/cloudron-package-monitor-helper.sh compatibility --apply|script' "weekly compatibility routine registered"
-	declare -F describe_r916 >/dev/null 2>&1 && assert_contains "$(describe_r916 linux)" 'cloudron-package-monitor-helper.sh upstream --apply' "r916 description exposes exact command"
-	declare -F describe_r917 >/dev/null 2>&1 && assert_contains "$(describe_r917 linux)" 'cloudron-package-monitor-helper.sh compatibility --apply' "r917 description exposes exact command"
+	local r916_description=""
+	local r917_description=""
+	r916_description=$(describe_r916 linux)
+	r917_description=$(describe_r917 linux)
+	assert_contains "$r916_description" 'cloudron-package-monitor-helper.sh upstream --apply' "r916 description exposes exact command"
+	assert_contains "$r917_description" 'cloudron-package-monitor-helper.sh compatibility --apply' "r917 description exposes exact command"
+	# shellcheck disable=SC2016  # Markdown backticks are literal expected output.
+	assert_contains "$r916_description" 'Supervisor Pulse evaluates version-controlled `repeat:daily(@07:10)`' "r916 names Pulse as scheduler"
+	# shellcheck disable=SC2016  # Markdown backticks are literal expected output.
+	assert_contains "$r917_description" 'Supervisor Pulse evaluates version-controlled `repeat:weekly(sun@07:40)`' "r917 names Pulse as scheduler"
+	assert_contains "$r916_description" 'systemctl --user status sh.aidevops.pulse' "r916 exposes shared Pulse diagnostics"
+	assert_not_contains "$r916_description" 'sh.aidevops.cloudron-package-upstream' "r916 omits fictional dedicated service"
+	assert_not_contains "$r917_description" 'sh.aidevops.cloudron-package-compatibility' "r917 omits fictional dedicated service"
 	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
 	[[ "$FAILED" -eq 0 ]] || return 1
 	return 0

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -89,11 +89,127 @@ cmd_record_no_release "\$@"
 RUNNER
 chmod +x "$record_runner"
 
+finalize_runner="${ROOT}/finalize-runner.sh"
+cat >"$finalize_runner" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${SCRIPTS_DIR}'
+STATE_DIR='${ROOT}/state'
+STATE_FILE='${ROOT}/state/full-loop.state'
+DEFAULT_MAX_TASK_ITERATIONS=50
+DEFAULT_MAX_PREFLIGHT_ITERATIONS=5
+DEFAULT_MAX_PR_ITERATIONS=20
+HEADLESS=false
+source '${SCRIPTS_DIR}/shared-constants.sh'
+source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
+cmd_finalize_receipt "\$@"
+RUNNER
+chmod +x "$finalize_runner"
+
+migration_runner="${ROOT}/migration-runner.sh"
+cat >"$migration_runner" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${SCRIPTS_DIR}'
+STATE_DIR='${ROOT}/state'
+STATE_FILE='${ROOT}/state/full-loop.state'
+DEFAULT_MAX_TASK_ITERATIONS=50
+DEFAULT_MAX_PREFLIGHT_ITERATIONS=5
+DEFAULT_MAX_PR_ITERATIONS=20
+HEADLESS=false
+source '${SCRIPTS_DIR}/shared-constants.sh'
+source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
+cmd_migrate_repository_receipt "\$@"
+RUNNER
+chmod +x "$migration_runner"
+
 rm -f "${receipt_dir}/marcusquinn_aidevops-42.status"
 AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$record_runner" 42 marcusquinn/aidevops >/dev/null
 grep -qx 'not-requested' "${receipt_dir}/marcusquinn_aidevops-42.status"
 AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$record_runner" 42 marcusquinn/aidevops >/dev/null
 printf 'PASS direct merge-only lifecycle records idempotent no-release evidence\n'
+
+direct_worktree="${ROOT}/direct-merge-worktree"
+mkdir -p "$direct_worktree"
+direct_receipt=$(full_loop_write_cleanup_deferred marcusquinn/aidevops 42 "$direct_worktree" feature/direct \
+	"$$" direct-session pending FINALIZATION_PENDING)
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$finalize_runner" 42 marcusquinn/aidevops >/dev/null
+jq -e '.executor_completion_state == "COMPLETE" and .release_status == "not-requested"' "$direct_receipt" >/dev/null
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$finalize_runner" 42 marcusquinn/aidevops >/dev/null
+printf 'PASS direct merge-only receipt finalizes idempotently without local lifecycle state\n'
+
+cp "$direct_receipt" "${ROOT}/direct-receipt-before.json"
+if COMPLETION_PR_STATE=OPEN AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+	AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$finalize_runner" 42 marcusquinn/aidevops >/dev/null 2>&1; then
+	printf 'FAIL open PR finalized a direct-merge receipt\n'
+	exit 1
+fi
+cmp -s "$direct_receipt" "${ROOT}/direct-receipt-before.json"
+printf 'PASS rejected finalization leaves cleanup evidence unchanged\n'
+
+migration_worktree="${ROOT}/migration-worktree"
+mkdir -p "$migration_worktree"
+migration_receipt=$(full_loop_write_cleanup_deferred example/old-repo 44 "$migration_worktree" feature/migrate \
+	"$$" migration-session not-requested FINALIZATION_PENDING)
+full_loop_transition_cleanup_receipt "$migration_receipt" "$_FULL_LOOP_CLEANUP_LEASED" "$$"
+migration_created=$(jq -r '.created_at' "$migration_receipt")
+mkdir -p "$receipt_dir"
+printf '%s\n' not-requested >"${receipt_dir}/example_old-repo-44.status"
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$migration_runner" 44 example/old-repo example/renamed-repo >/dev/null
+migrated_receipt="${cleanup_receipt_dir}/example_renamed-repo-44.json"
+[[ ! -e "${cleanup_receipt_dir}/example_old-repo-44.json" ]]
+[[ ! -e "${receipt_dir}/example_old-repo-44.status" ]]
+grep -qx 'not-requested' "${receipt_dir}/example_renamed-repo-44.status"
+jq -e --arg created "$migration_created" --argjson lease_pid "$$" '
+	.repository == "example/renamed-repo"
+	and .created_at == $created
+	and .owner.session == "migration-session"
+	and .resource_cleanup_state == "CLEANUP_LEASED"
+	and .cleanup_lease.pid == $lease_pid
+	and .migration.from_repository == "example/old-repo"
+' "$migrated_receipt" >/dev/null
+full_loop_cleanup_owner_alive "$migrated_receipt"
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$migration_runner" 44 example/old-repo example/renamed-repo >/dev/null
+printf 'PASS repository migration preserves owner, lease, creation, cleanup, and release evidence idempotently\n'
+
+successor_worktree="${ROOT}/successor-worktree"
+mkdir -p "$successor_worktree"
+full_loop_write_cleanup_deferred example/old-repo 44 "$successor_worktree" feature/successor \
+	"$$" successor-session pending FINALIZATION_PENDING >/dev/null
+selected_predecessor=$(full_loop_cleanup_receipt_for_worktree "$migration_worktree")
+[[ "$selected_predecessor" == "$migrated_receipt" ]]
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$migration_runner" 44 example/old-repo example/renamed-repo >/dev/null
+[[ -f "${cleanup_receipt_dir}/example_old-repo-44.json" ]]
+printf 'PASS old-slug reuse cannot associate the predecessor worktree with the successor receipt\n'
+
+conflict_source_worktree="${ROOT}/conflict-source"
+conflict_destination_worktree="${ROOT}/conflict-destination"
+mkdir -p "$conflict_source_worktree" "$conflict_destination_worktree"
+full_loop_write_cleanup_deferred example/conflict-old 45 "$conflict_source_worktree" feature/conflict-old \
+	"$$" conflict-old-session not-requested FINALIZATION_PENDING >/dev/null
+full_loop_write_cleanup_deferred example/conflict-new 45 "$conflict_destination_worktree" feature/conflict-new \
+	"$$" conflict-new-session not-requested FINALIZATION_PENDING >/dev/null
+printf '%s\n' not-requested >"${receipt_dir}/example_conflict-old-45.status"
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$migration_runner" 45 example/conflict-old example/conflict-new >/dev/null 2>&1; then
+	printf 'FAIL repository migration accepted conflicting destination evidence\n'
+	exit 1
+fi
+[[ -f "${cleanup_receipt_dir}/example_conflict-old-45.json" ]]
+[[ -f "${cleanup_receipt_dir}/example_conflict-new-45.json" ]]
+[[ -f "${receipt_dir}/example_conflict-old-45.status" ]]
+printf 'PASS repository migration fails closed and preserves conflicting source and destination evidence\n'
 
 rm -f "${receipt_dir}/marcusquinn_aidevops-42.status"
 stale_calls="${ROOT}/stale-evidence-calls.txt"

--- a/.agents/scripts/tests/test-routine-calendar-scheduling.sh
+++ b/.agents/scripts/tests/test-routine-calendar-scheduling.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../routine-schedule-helper.sh"
+PULSE_ROUTINES="${SCRIPT_DIR}/../pulse-routines.sh"
+PASSED=0
+FAILED=0
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+iso_epoch() {
+	local iso="$1"
+	local epoch=""
+	epoch=$(date -u -d "$iso" +%s 2>/dev/null) || true
+	if [[ -z "$epoch" ]]; then
+		epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) || true
+	fi
+	[[ "$epoch" =~ ^[0-9]+$ ]] || return 1
+	printf '%s' "$epoch"
+	return 0
+}
+
+record_result() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		printf 'PASS %s\n' "$description"
+		PASSED=$((PASSED + 1))
+		return 0
+	fi
+	printf 'FAIL %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual" >&2
+	FAILED=$((FAILED + 1))
+	return 0
+}
+
+assert_due_rc() {
+	local description="$1"
+	local timezone="$2"
+	local now_iso="$3"
+	local expression="$4"
+	local last_iso="$5"
+	local expected_rc="$6"
+	local now_epoch=""
+	local last_epoch=""
+	local actual_rc=0
+	now_epoch=$(iso_epoch "$now_iso") || return 1
+	if [[ "$last_iso" == "never" ]]; then
+		last_epoch=0
+	else
+		last_epoch=$(iso_epoch "$last_iso") || return 1
+	fi
+	env AIDEVOPS_SCHEDULE_TIMEZONE="$timezone" AIDEVOPS_SCHEDULE_NOW_EPOCH="$now_epoch" \
+		"$HELPER" is-due "$expression" "$last_epoch" >/dev/null 2>&1 || actual_rc=$?
+	record_result "$description" "$actual_rc" "$expected_rc"
+	return 0
+}
+
+assert_next_run() {
+	local description="$1"
+	local timezone="$2"
+	local now_iso="$3"
+	local expression="$4"
+	local expected="$5"
+	local now_epoch=""
+	local actual=""
+	now_epoch=$(iso_epoch "$now_iso") || return 1
+	actual=$(env AIDEVOPS_SCHEDULE_TIMEZONE="$timezone" AIDEVOPS_SCHEDULE_NOW_EPOCH="$now_epoch" \
+		"$HELPER" next-run "$expression" 2>/dev/null) || actual="rc:$?"
+	record_result "$description" "$actual" "$expected"
+	return 0
+}
+
+assert_pulse_state_policy() {
+	ROUTINE_STATE_FILE="${TEST_ROOT}/routine-state.json"
+	LOGFILE="${TEST_ROOT}/pulse.log"
+	# shellcheck source=../pulse-routines.sh
+	source "$PULSE_ROUTINES"
+	_routine_update_state r001 failure
+	local failure_shape=""
+	failure_shape=$(jq -r '.r001 | [has("last_run"), .last_status, has("last_attempt")] | @tsv' "$ROUTINE_STATE_FILE")
+	record_result "failed run preserves the prior calendar marker" "$failure_shape" $'false\tfailure\ttrue'
+	local blocked_rc=0
+	_routine_retry_blocked r001 || blocked_rc=$?
+	record_result "recent failure observes explicit retry cooldown" "$blocked_rc" 0
+	_routine_update_state r001 success
+	local success_shape=""
+	success_shape=$(jq -r '.r001 | [has("last_run"), .last_status] | @tsv' "$ROUTINE_STATE_FILE")
+	record_result "successful run advances the calendar marker" "$success_shape" $'true\tsuccess'
+	return 0
+}
+
+main() {
+	assert_due_rc "off-schedule bootstrap does not suppress next daily boundary" \
+		UTC 2026-07-23T13:34:14Z 'daily(@07:10)' 2026-07-22T22:03:25Z 0
+	assert_due_rc "run after daily boundary prevents duplicate" \
+		UTC 2026-07-23T13:34:14Z 'daily(@07:10)' 2026-07-23T07:10:00Z 1
+	assert_due_rc "never-run routine remains immediately due" \
+		UTC 2026-07-23T01:00:00Z 'daily(@07:10)' never 0
+	assert_due_rc "clock rollback fails closed" \
+		UTC 2026-07-23T01:00:00Z 'daily(@07:10)' 2026-07-23T02:00:00Z 1
+	assert_due_rc "missed weekly boundary catches up" \
+		UTC 2026-07-23T13:34:14Z 'weekly(sun@07:40)' 2026-07-18T12:00:00Z 0
+	assert_due_rc "weekly boundary executes once" \
+		UTC 2026-07-23T13:34:14Z 'weekly(sun@07:40)' 2026-07-19T07:40:00Z 1
+	assert_due_rc "leap-day monthly boundary catches up" \
+		UTC 2024-03-01T12:00:00Z 'monthly(29@09:00)' 2024-02-01T12:00:00Z 0
+	assert_due_rc "missing day in a short month is skipped" \
+		UTC 2026-03-01T12:00:00Z 'monthly(31@09:00)' 2026-01-31T09:00:00Z 1
+	assert_due_rc "cron catches a boundary missed after an off-slot run" \
+		UTC 2026-07-23T13:34:14Z 'cron(10 7 * * *)' 2026-07-22T22:03:25Z 0
+
+	assert_next_run "UTC daily next-run uses the same boundary" \
+		UTC 2026-07-23T13:34:14Z 'daily(@07:10)' 2026-07-24T07:10:00Z
+	assert_next_run "Europe/Jersey local schedule converts to BST" \
+		Europe/Jersey 2026-07-23T13:34:14Z 'daily(@07:10)' 2026-07-24T06:10:00Z
+	assert_next_run "America/New_York local schedule converts to EDT" \
+		America/New_York 2026-07-23T13:34:14Z 'daily(@07:10)' 2026-07-24T11:10:00Z
+	assert_next_run "monthly next-run uses the next valid calendar date" \
+		UTC 2026-03-01T12:00:00Z 'monthly(31@09:00)' 2026-03-31T09:00:00Z
+	assert_next_run "cron next-run uses the next matching minute boundary" \
+		UTC 2026-07-23T13:34:14Z 'cron(10 7 * * *)' 2026-07-24T07:10:00Z
+	assert_next_run "fall-back repeated hour selects its first occurrence" \
+		Europe/Jersey 2026-10-24T12:00:00Z 'daily(@01:30)' 2026-10-25T00:30:00Z
+	assert_next_run "spring-forward nonexistent local time fails closed" \
+		Europe/Jersey 2026-03-28T12:00:00Z 'daily(@01:30)' 'rc:2'
+	assert_pulse_state_policy
+
+	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
+	[[ "$FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/tools/security/tamper-evident-audit.md
+++ b/.agents/tools/security/tamper-evident-audit.md
@@ -111,6 +111,14 @@ audit-log-helper.sh log operation.verify "Force push verified by cross-provider 
 
 Run `audit-log-helper.sh verify` before log rotation, during security audits, or when investigating suspicious activity. Exit: 0 = intact, 1 = broken (tampered/corrupted).
 
+Verification streams the segment through one Python standard-library process,
+so runtime and process count scale linearly without spawning `jq`, `sed`, and
+SHA-256 commands per entry. Canonicalization matches the compact UTF-8 JSON used
+by the writer. If Python or the deployed verifier is unavailable, the helper
+warns and falls back to the slower shell verifier without weakening the verdict.
+Recovery keeps the writer lock across verification, byte-identical archival,
+successor activation, and rollback; the bounded verifier minimizes that lock hold.
+
 If verification reports a historical break, preserve the affected file as forensic evidence. Do not rewrite or truncate it. After investigation and explicit operator approval, rotate/archive the broken segment and begin a new chain; the rotation event records the prior segment hash.
 
 ## Log Rotation

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -213,6 +213,14 @@ Check gate without merging: `full-loop-helper.sh pre-merge-gate "$PR_NUMBER" "$R
 
 **4.6 Conditional Detached Release (aidevops only):** Without explicit trusted release intent, run `full-loop-helper.sh record-no-release "$PR_NUMBER" "$REPO"` after verified merge to record `release:not-requested`, then continue directly to closing and guarded cleanup. The command verifies merged evidence, is idempotent, and refuses to replace `release:published` or `release:failed`. Authorized releases use a fresh detached release worktree at `origin/main`; omitted type defaults to patch and omitted deployment scope defaults to incremental. Major/minor and full deployment must be selected explicitly. Record terminal publication as `release:published` or `release:failed`; do not repeat publication gates after publication succeeds.
 
+Direct merge-wrapper flows without local lifecycle state use
+`full-loop-helper.sh finalize-receipt <PR> [REPO]` after terminal release evidence
+exists. The command re-verifies merged evidence and idempotently changes only the
+receipt's executor finalization fields. After an explicit repository rename, use
+`migrate-repository-receipt <PR> <OLD_REPO> <NEW_REPO>`; it verifies the PR at the
+new identity and migrates cleanup plus release receipts while preserving owner,
+lease, worktree, branch, creation time, and irreversible cleanup state.
+
 **4.7 Maintained-App Local Base Synchronization (MANDATORY):** After a maintained non-aidevops merge, read the merged PR's verified `baseRefName`, resolve the registered canonical checkout, and use the clean `fast-forward-current` or lossless `sync-mirror` operation documented in `workflows/git-workflow.md`. Full-loop consent authorizes this guarded synchronization. Verify local `HEAD` equals `origin/<baseRefName>` before recording `LOCAL_BASE_SYNCED`.
 
 **4.8 Closing Comments:** Managed repos receive structured issue and PR closing comments with the normal pre-close verification. External sessions do not close the upstream issue; follow upstream conventions and leave at most one concise issue comment linking the PR when useful.


### PR DESCRIPTION
## Summary

Harden cleanup receipt finalization and migration with fresh evidence and locking. Replace audit-chain verification with a bounded single-process verifier. Schedule recurring routines by calendar boundaries and correct Cloudron scheduler ownership documentation.

Resolves #28516
Resolves #28517
Resolves #28526

## Files Changed

.agents/reference/routines.md, .agents/scripts/audit-log-helper.sh, .agents/scripts/audit-log-verify-helper.py, .agents/scripts/full-loop-cleanup-receipt.sh, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/init-routines-helper.sh, .agents/scripts/pulse-routines.sh, .agents/scripts/routine-schedule-helper.sh, .agents/scripts/routines/core-routines.sh, .agents/scripts/tests/test-audit-log-recovery.sh, .agents/scripts/tests/test-cloudron-package-routines.sh, .agents/scripts/tests/test-full-loop-completion-evidence.sh, .agents/scripts/tests/test-routine-calendar-scheduling.sh, .agents/tools/security/tamper-evident-audit.md, .agents/workflows/full-loop.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified through executable integration tests in isolated repositories and temporary state roots:
bash .agents/scripts/tests/test-full-loop-completion-evidence.sh
bash .agents/scripts/tests/test-audit-log-recovery.sh
bash .agents/scripts/tests/test-routine-calendar-scheduling.sh
bash .agents/scripts/tests/test-cloudron-package-routines.sh
.agents/scripts/linters-local.sh
.agents/scripts/linters-local.sh --full

Resolves #28513


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.172 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 38m and 672,740 tokens on this with the user in an interactive session.