### PR TITLE
GH#28538: allow canonical diff-files queries

### DIFF
--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -16,6 +16,7 @@ BLOCK_EXIT = 42
 READ_ONLY = {
     "status",
     "diff",
+    "diff-files",
     "log",
     "show",
     "rev-parse",

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -120,6 +120,7 @@ else
 fi
 
 assert_allowed "allows canonical status" "$REPO" "git status --short"
+assert_allowed "allows canonical diff-files query" "$REPO" "git diff-files --name-only"
 assert_allowed "allows canonical branch listing" "$REPO" "git branch -vv --no-abbrev"
 assert_allowed "allows canonical branch pattern listing" "$REPO" "git branch --list 'feature/*'"
 assert_allowed "allows canonical branch containment query" "$REPO" "git branch --contains main"


### PR DESCRIPTION
## Summary

Allow the read-only git diff-files plumbing command in canonical checkouts and add focused guard regression coverage.

## Files Changed

.agents/scripts/canonical_git_policy.py, .agents/scripts/tests/test-canonical-git-command-guard.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 58/58 canonical Git guard tests; ShellCheck; shfmt; Python AST parse; linters-local.sh --changed.

Resolves #28538


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.173 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 15m and 346,751 tokens on this with the user in an interactive session.