### PR TITLE
GH#28544: prevent r901 supervisor recursion

### DIFF
--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -247,6 +247,20 @@ _RPL_AGENT=""
 _RPL_DESC=""
 
 #######################################
+# Return success when a routine run target would invoke the supervisor that is
+# currently evaluating routines. This protects existing generated TODO files
+# that still carry the pre-GH#28544 cron-form r901 entry.
+#######################################
+_routine_targets_supervisor() {
+	local run_script="$1"
+	local run_command="${run_script%% *}"
+	if [[ "$run_command" == "scripts/pulse-wrapper.sh" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Parse a single routine TODO line into its component fields.
 #
 # Extracts routine_id, repeat expression, run script, agent name, and
@@ -359,6 +373,14 @@ evaluate_routines() {
 		local line
 		while IFS= read -r line; do
 			if ! _routine_parse_line "$line"; then
+				continue
+			fi
+
+			# The supervisor is launched by launchd/systemd and must never be
+			# invoked synchronously from its own evaluator. Keep this runtime
+			# guard for stale generated TODO files that predate GH#28544.
+			if _routine_targets_supervisor "$_RPL_RUN"; then
+				echo "[pulse-wrapper] routine ${_RPL_ID}: skipping self-recursive supervisor target ${_RPL_RUN%% *} (GH#28544)" >>"$LOGFILE"
 				continue
 			fi
 

--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -16,7 +16,7 @@
 # ---------------------------------------------------------------------------
 get_core_routine_entries() {
 	cat <<'ENTRIES'
-r901|x|Supervisor pulse — dispatch tasks across repos|repeat:cron(*/2 * * * *)|~1m|scripts/pulse-wrapper.sh|script
+r901|x|Supervisor pulse — dispatch tasks across repos|repeat:persistent|~1m|scripts/pulse-wrapper.sh|script
 r902|x|Auto-update — check for framework updates|repeat:cron(*/10 * * * *)|~30s|bin/aidevops-auto-update|script
 r903|x|Process guard — kill runaway processes|repeat:cron(*/1 * * * *)|~5s|scripts/process-guard-helper.sh kill-runaways|script
 r904|x|Worker watchdog — monitor headless workers|repeat:cron(*/2 * * * *)|~10s|scripts/worker-watchdog.sh --check|script

--- a/.agents/scripts/tests/test-pulse-routines-cron-extraction.sh
+++ b/.agents/scripts/tests/test-pulse-routines-cron-extraction.sh
@@ -59,7 +59,7 @@ extract_repeat_expr() {
 # ─── Tests ────────────────────────────────────────────────────────────────────
 
 test_cron_multi_space() {
-	local line="- [x] r901 Supervisor pulse — dispatch tasks across repos repeat:cron(*/2 * * * *) ~1m run:scripts/pulse-wrapper.sh"
+	local line="- [x] r904 Worker watchdog repeat:cron(*/2 * * * *) ~10s run:scripts/worker-watchdog.sh --check"
 	local got
 	got=$(extract_repeat_expr "$line")
 	assert_eq "cron(*/2 * * * *): full expression captured (regression t2160)" \

--- a/.agents/scripts/tests/test-pulse-routines-selector.sh
+++ b/.agents/scripts/tests/test-pulse-routines-selector.sh
@@ -18,9 +18,9 @@
 #   routine IDs and their neighbour text passed to the schedule parser.
 #   Observed error: ERROR: unrecognised schedule expression '([^[:space:]]+)`'
 #
-# Bug 2 (t2175) — persistent unsupported: r912 in aidevops-routines/TODO.md
-#   carries repeat:persistent (launchd-supervised daemon). The schedule parser
-#   and the pulse evaluator both rejected this keyword.
+# Bug 2 (t2175) — persistent unsupported: externally supervised services such
+#   as r901 and r912 carry repeat:persistent. The schedule parser and the pulse
+#   evaluator both rejected this keyword.
 #   Observed error: ERROR: unrecognised schedule expression 'persistent'
 #
 # Fixes verified here:
@@ -41,11 +41,15 @@
 #      with distinct error message, no "unrecognised schedule expression"
 #   6. (t2423 Phase D) Full discovery simulation: mixed TODO with t-prefix false-match
 #      lines produces zero "unrecognised schedule expression" errors on stderr
+#   7. (GH#28544) A stale cron-form r901 cannot invoke pulse-wrapper.sh and a
+#      later due routine still executes in the same evaluator pass
 
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 SCHEDULE_HELPER="${SCRIPT_DIR}/../routine-schedule-helper.sh"
+PULSE_ROUTINES="${SCRIPT_DIR}/../pulse-routines.sh"
+CORE_ROUTINES="${SCRIPT_DIR}/../routines/core-routines.sh"
 
 RED=$'\033[0;31m'
 GREEN=$'\033[0;32m'
@@ -99,7 +103,10 @@ _test_selector_cases() {
 	_make_todo "$tmpdir" \
 		"- [x] t2160 fix: \`repeat:([^[:space:]]+)\` (r901, r902) ref:GH#19465"
 	# grep -c prints 0 even on no match; no || fallback needed.
-	count=$(grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null; true)
+	count=$(
+		grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null
+		true
+	)
 	if [[ "$count" -eq 0 ]]; then
 		pass "Case 1: t-prefix false-match prevented by tightened selector"
 	else
@@ -107,10 +114,13 @@ _test_selector_cases() {
 	fi
 
 	# Case 2: r-prefix with repeat:persistent — selector matches, is-due skips.
-	# Mirrors r912 in aidevops-routines/TODO.md (launchd-supervised daemon).
+	# Mirrors r901, which is launched by launchd/systemd rather than by Pulse.
 	_make_todo "$tmpdir" \
-		"- [x] r912 Dashboard server repeat:persistent ~0s run:server/index.ts"
-	count=$(grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null; true)
+		"- [x] r901 Supervisor pulse repeat:persistent ~1m run:scripts/pulse-wrapper.sh"
+	count=$(
+		grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null
+		true
+	)
 	local is_due_exit is_due_output
 	is_due_output=$("$SCHEDULE_HELPER" is-due "persistent" "0" 2>&1)
 	is_due_exit=$?
@@ -123,8 +133,11 @@ _test_selector_cases() {
 
 	# Case 3: r-prefix with cron schedule — selector matches, no parse error.
 	_make_todo "$tmpdir" \
-		"- [x] r901 Supervisor pulse repeat:cron(*/2 * * * *) ~0s agent:Build+"
-	count=$(grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null; true)
+		"- [x] r904 Worker watchdog repeat:cron(*/2 * * * *) ~10s run:scripts/worker-watchdog.sh --check"
+	count=$(
+		grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null
+		true
+	)
 	local cron_output
 	cron_output=$("$SCHEDULE_HELPER" is-due "cron(*/2 * * * *)" "0" 2>&1 >/dev/null)
 	if [[ "$count" -eq 1 ]] && [[ "$cron_output" != *"ERROR"* ]]; then
@@ -137,9 +150,12 @@ _test_selector_cases() {
 	# Case 4: Mixed TODO — selector finds exactly 2 r-prefix entries, excludes t-prefix.
 	_make_todo "$tmpdir" \
 		"- [x] t2160 fix: \`repeat:([^[:space:]]+)\` (r901, r902) ref:GH#19465" \
-		"- [x] r901 Supervisor pulse repeat:cron(*/2 * * * *) ~0s agent:Build+" \
-		"- [x] r912 Dashboard server repeat:persistent ~0s run:server/index.ts"
-	count=$(grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null; true)
+		"- [x] r904 Worker watchdog repeat:cron(*/2 * * * *) ~10s run:scripts/worker-watchdog.sh --check" \
+		"- [x] r901 Supervisor pulse repeat:persistent ~1m run:scripts/pulse-wrapper.sh"
+	count=$(
+		grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null
+		true
+	)
 	if [[ "$count" -eq 2 ]]; then
 		pass "Case 4: mixed TODO — 2 r-prefix routines matched, t-prefix excluded"
 	else
@@ -158,7 +174,7 @@ _test_metachar_guard() {
 	local meta_exit meta_stderr
 	meta_stderr=$("$SCHEDULE_HELPER" is-due '([^[:space:]]+)`' '0' 2>&1 >/dev/null)
 	meta_exit=$?
-	if [[ "$meta_exit" -eq 2 ]] && [[ "$meta_stderr" == *"regex metacharacters"* ]] && \
+	if [[ "$meta_exit" -eq 2 ]] && [[ "$meta_stderr" == *"regex metacharacters"* ]] &&
 		[[ "$meta_stderr" != *"unrecognised schedule expression"* ]]; then
 		pass "Case 5 (t2423 Phase C): metachar guard fires for regex pattern input"
 	else
@@ -180,8 +196,8 @@ _test_e2e_discovery() {
 	_make_todo "$tmpdir" \
 		"- [x] t2160 fix: \`repeat:([^[:space:]]+)\` (r901, r902) ref:GH#19465" \
 		"- [x] t2423 guard: routine-schedule-helper.sh regex metachar guard" \
-		"- [x] r901 Supervisor pulse repeat:cron(*/2 * * * *) ~0s agent:Build+" \
-		"- [x] r912 Dashboard server repeat:persistent ~0s run:server/index.ts"
+		"- [x] r904 Worker watchdog repeat:cron(*/2 * * * *) ~10s run:scripts/worker-watchdog.sh --check" \
+		"- [x] r901 Supervisor pulse repeat:persistent ~1m run:scripts/pulse-wrapper.sh"
 
 	# Store regex in variable — avoids bash misparsing the literal ')' inline.
 	local re_repeat='repeat:(cron\([^)]*\)|[^[:space:]]+)'
@@ -213,15 +229,88 @@ _test_e2e_discovery() {
 	return 0
 }
 
+# _test_supervisor_self_recursion_guard: case 7 — production evaluator path.
+_test_supervisor_self_recursion_guard() {
+	local tmpdir="$1"
+	local guard_root="${tmpdir}/self-recursion"
+	local test_home="${guard_root}/home"
+	local repo_dir="${guard_root}/routines-repo"
+	local fake_scripts="${test_home}/.aidevops/agents/scripts"
+	local schedule_helper="${guard_root}/always-due.sh"
+	local self_marker="${guard_root}/self-invoked"
+	local downstream_marker="${guard_root}/downstream-invoked"
+	local log_file="${guard_root}/pulse.log"
+	local repos_json="${guard_root}/repos.json"
+	local state_file="${guard_root}/routine-state.json"
+
+	mkdir -p "$fake_scripts" "$repo_dir"
+	cat >"${fake_scripts}/pulse-wrapper.sh" <<'SELF_SCRIPT'
+#!/usr/bin/env bash
+: >"${ROUTINE_SELF_MARKER:?}"
+exit 0
+SELF_SCRIPT
+	cat >"${fake_scripts}/downstream.sh" <<'DOWNSTREAM_SCRIPT'
+#!/usr/bin/env bash
+: >"${ROUTINE_DOWNSTREAM_MARKER:?}"
+exit 0
+DOWNSTREAM_SCRIPT
+	cat >"$schedule_helper" <<'SCHEDULE_SCRIPT'
+#!/usr/bin/env bash
+[[ "${1:-}" == "is-due" ]] || exit 2
+exit 0
+SCHEDULE_SCRIPT
+	chmod +x "${fake_scripts}/pulse-wrapper.sh" "${fake_scripts}/downstream.sh" "$schedule_helper"
+
+	_make_todo "$repo_dir" \
+		"- [x] r901 Supervisor pulse repeat:cron(*/2 * * * *) ~1m run:scripts/pulse-wrapper.sh" \
+		"- [x] r916 Downstream monitor repeat:daily(@07:10) ~1m run:scripts/downstream.sh"
+	printf '{"initialized_repos":[{"slug":"example/routines","path":"%s","pulse":true,"local_only":false}]}\n' \
+		"$repo_dir" >"$repos_json"
+
+	if (
+		export HOME="$test_home"
+		export ROUTINE_SELF_MARKER="$self_marker"
+		export ROUTINE_DOWNSTREAM_MARKER="$downstream_marker"
+		ROUTINE_SCHEDULE_HELPER="$schedule_helper"
+		ROUTINE_STATE_FILE="$state_file"
+		ROUTINE_LOG_HELPER="${guard_root}/missing-routine-log-helper.sh"
+		HEADLESS_RUNTIME_HELPER="${guard_root}/missing-headless-helper.sh"
+		REPOS_JSON="$repos_json"
+		LOGFILE="$log_file"
+		PULSE_DIR="$guard_root"
+		unset _PULSE_ROUTINES_LOADED
+		# shellcheck source=../pulse-routines.sh
+		source "$PULSE_ROUTINES"
+		# shellcheck source=../routines/core-routines.sh
+		source "$CORE_ROUTINES"
+		get_core_routine_entries | grep -q '^r901|x|.*|repeat:persistent|.*|scripts/pulse-wrapper.sh|script$' &&
+			evaluate_routines &&
+			[[ ! -e "$self_marker" ]] &&
+			[[ -e "$downstream_marker" ]] &&
+			jq -e '.r916.last_status == "success" and (.r901 | not)' "$state_file" >/dev/null &&
+			grep -q 'routine r901: skipping self-recursive supervisor target scripts/pulse-wrapper.sh (GH#28544)' "$log_file"
+	); then
+		pass "Case 7 (GH#28544): stale r901 self-invocation skipped; later routine executes"
+	else
+		fail "Case 7 (GH#28544): stale r901 self-invocation skipped; later routine executes" \
+			"self_marker=$([[ -e "$self_marker" ]] && printf present || printf absent) downstream_marker=$([[ -e "$downstream_marker" ]] && printf present || printf absent)"
+	fi
+	return 0
+}
+
 main() {
 	local tmpdir
-	tmpdir=$(mktemp -d) || { printf 'FATAL: mktemp failed\n' >&2; exit 1; }
+	tmpdir=$(mktemp -d) || {
+		printf 'FATAL: mktemp failed\n' >&2
+		exit 1
+	}
 	# shellcheck disable=SC2064
 	trap "rm -rf '$tmpdir'" EXIT
 
 	_test_selector_cases "$tmpdir"
 	_test_metachar_guard
 	_test_e2e_discovery "$tmpdir"
+	_test_supervisor_self_recursion_guard "$tmpdir"
 
 	# === Summary ===
 	printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/.agents/scripts/tests/test-routine-systemd-calendar.sh
+++ b/.agents/scripts/tests/test-routine-systemd-calendar.sh
@@ -143,9 +143,9 @@ test_pulse_step_minutes_supported() {
 	output=$("${REPO_SCRIPTS_DIR}/routine-schedule-helper.sh" systemd-calendar 'cron(*/2 * * * *)')
 
 	if [[ "$output" == '*-*-* *:0/2:00' ]]; then
-		print_result "r901 cron step maps to systemd calendar" 0
+		print_result "two-minute cron step maps to systemd calendar" 0
 	else
-		print_result "r901 cron step maps to systemd calendar" 1 \
+		print_result "two-minute cron step maps to systemd calendar" 1 \
 			"Expected *-*-* *:0/2:00, got: $output"
 	fi
 	return 0


### PR DESCRIPTION
## Summary

Marks r901 as externally supervised, blocks stale Pulse self-invocations, and proves later due routines still execute.

## Files Changed

.agents/scripts/pulse-routines.sh, .agents/scripts/routines/core-routines.sh, .agents/scripts/tests/test-pulse-routines-cron-extraction.sh, .agents/scripts/tests/test-pulse-routines-selector.sh, .agents/scripts/tests/test-routine-systemd-calendar.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — ShellCheck clean; selector 7/7, cron extraction 8/8, systemd calendar 7/7, routine calendar 19/19; full local linter passed; production evaluator-path regression runtime-verified.

Resolves #28544


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.175 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1d 19h and 12,538,554 tokens on this with the user in an interactive session.