### PR TITLE
t18170: Standardize Cloudron community publishing lifecycle

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging-skill.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill.md
@@ -25,7 +25,7 @@ Cloudron apps are Docker images plus `CloudronManifest.json`. The platform provi
 
 - **Upstream**: [git.cloudron.io/docs/skills](https://git.cloudron.io/docs/skills) (`cloudron-app-packaging`) | [docs.cloudron.io/packaging](https://docs.cloudron.io/packaging/)
 - **Reference files**: `cloudron-app-packaging-skill/manifest-ref.md`, `cloudron-app-packaging-skill/addons-ref.md`
-- **Also see**: `cloudron-app-packaging.md` (native aidevops guide: helpers, local dev, Dockerfile/start.sh patterns, pre-packaging checks)
+- **Also see**: `cloudron-app-packaging.md` (native aidevops guide: helpers, local dev, Dockerfile/start.sh patterns, pre-packaging checks) and `cloudron-app-publishing-skill.md` (required version catalog, public metadata, visual assets, and publication lifecycle)
 - **Last upstream review**: `fcea39616e6e` ("Update the skill for cloudron sync"); no local import changes required beyond keeping the native guide and skill pointers aligned.
 
 ```bash
@@ -34,6 +34,8 @@ cloudron login my.example.com
 cloudron init                    # creates CloudronManifest.json and Dockerfile
 cloudron install                 # uploads source, builds on server, installs app
 cloudron update                  # re-uploads, rebuilds, updates running app
+# For any independently distributed package, initialize and maintain
+# CloudronVersions.json using cloudron-app-publishing-skill.md.
 ```
 
 <!-- AI-CONTEXT-END -->

--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -37,7 +37,7 @@ tools:
 6. Read env vars fresh on every start (values change across restarts) — never cache at startup
 7. Health check path must return HTTP 200 unauthenticated
 
-**File Structure**: `CloudronManifest.json`, `Dockerfile`, `start.sh`, `logo.png` (256x256).
+**File Structure**: `CloudronManifest.json`, `Dockerfile`, `start.sh`, `logo.png` (256×256). Independently distributed packages also keep `CloudronVersions.json`, a Cloudron-format changelog, a publishing runbook, and at least one privacy-reviewed screenshot or 3:1 hero; follow `cloudron-app-publishing-skill.md`.
 
 **CLI Workflow**:
 
@@ -320,4 +320,11 @@ actions and require explicit authorization.
 
 ## Publishing
 
-Fork https://git.cloudron.io/cloudron/appstore, add your app directory with manifest and icon, submit a merge request. See: https://docs.cloudron.io/packaging/publishing/
+Independent/community packages publish registry images through a hosted
+`CloudronVersions.json`; they are not submitted by forking the official app
+store. Before considering a package complete, initialize the catalog, add the
+required `iconUrl`/packager/media metadata, keep a local 256×256 icon and a
+privacy-reviewed screenshot or 3:1 hero, and document the release workflow.
+Follow `cloudron-app-publishing-skill.md` for testing-state promotion,
+append-only catalog maintenance, revocation, public hosting, and optional
+listing on [Cloudron Community Apps](https://ca.cloudron.io).

--- a/.agents/tools/deployment/cloudron-app-publishing-skill.md
+++ b/.agents/tools/deployment/cloudron-app-publishing-skill.md
@@ -24,6 +24,7 @@ Distribute Cloudron apps independently using a `CloudronVersions.json` version c
 - **Upstream skill**: [git.cloudron.io/docs/skills](https://git.cloudron.io/docs/skills) (`cloudron-app-publishing`)
 - **Prerequisite**: App must be built with `cloudron build` (local or build service) — on-server builds cannot be published
 - **Key file**: `CloudronVersions.json` — version catalog hosted at a public URL
+- **Listing**: [Cloudron Community Apps](https://ca.cloudron.io) accepts a public versions URL after the catalog contains a tested release; listing is optional
 - **Forum**: [App Packaging & Development](https://forum.cloudron.io/category/96/app-packaging-development)
 
 ## Workflow
@@ -31,15 +32,26 @@ Distribute Cloudron apps independently using a `CloudronVersions.json` version c
 ```bash
 cloudron versions init  # creates CloudronVersions.json + DESCRIPTION.md, CHANGELOG, POSTINSTALL.md (edit all placeholders)
 cloudron build          # build and push image (first run prompts for Docker repository, e.g. registry/username/myapp)
-cloudron versions add   # add version to catalog
+cloudron versions add --state testing  # add the registry image without exposing it as stable
+cloudron versions update --version 1.0.0 --state published
 # host CloudronVersions.json at a public URL
 ```
 
 `cloudron versions init` also adds missing publishing fields to `CloudronManifest.json` with placeholder values. Edit all placeholders and scaffolded files before adding a version.
 
-## Required Manifest Fields
+## Repository Baseline
 
-`id`, `title`, `author`, `tagline`, `version`, `website`, `contactEmail`, `iconUrl`, `packagerName`, `packagerUrl`, `tags` (array), `mediaLinks` (array), `description` (`file://DESCRIPTION.md`), `changelog` (`file://CHANGELOG`), `postInstallMessage` (`file://POSTINSTALL.md`), `minBoxVersion` (e.g. `9.1.0`).
+Commit these before the first registry build:
+
+- `CloudronVersions.json` initialized as `{ "stable": true, "versions": {} }`; never fabricate an entry before `cloudron build` records a real registry image.
+- `CloudronManifest.json` publishing metadata: `id`, `title`, `author`, `description`, `tagline`, `version`, `website`, `contactEmail`, `iconUrl`, `packagerName`, `packagerUrl`, non-empty `tags`, non-empty `mediaLinks`, `changelog`, and `minBoxVersion` of at least `9.1.0`.
+- A local square 256×256 PNG icon (`icon` normally points to it) and at least one privacy-reviewed product screenshot or hero. `mediaLinks` must use public HTTPS URLs; Cloudron recommends 3:1 images such as 1200×400.
+- A Cloudron-format changelog file when using `file://`: each release heading must be exactly `[X.Y.Z]`, because `cloudron versions add` does not parse Keep a Changelog headings such as `## [X.Y.Z]`.
+- A short publishing runbook that records the canonical catalog URL, registry/repository ownership, asset provenance, test install, rollback, and Community Apps listing steps without storing credentials.
+
+`packageUrl` is useful package provenance, but it requires `minBoxVersion` 10.0.0. Do not raise the minimum solely for this optional field; `packagerUrl` remains required for version-catalog publishing. `author` and `contactEmail` are deprecated in the manifest reference but are still required by the current CLI version-catalog validator.
+
+Use package-controlled, stable asset URLs where possible. If an upstream asset is used temporarily, preserve a reviewed local copy and replace the remote reference before the upstream URL becomes unstable. Check every URL for an HTTPS 200 response and an image content type before publishing.
 
 ## Build Commands
 
@@ -71,7 +83,7 @@ Build behavior depends on whether a build service is configured:
 | `cloudron versions update --version 1.0.0 --state published` | Change publish state |
 | `cloudron versions revoke` | Mark latest published version as revoked |
 
-**Rules:** Do not change the manifest or image of a published version. To ship changes: revoke, bump version in `CloudronManifest.json`, rebuild, `cloudron versions add`.
+**Rules:** Do not change the manifest or image of a published version. Treat catalog entries as append-only release records. To ship changes: revoke only when necessary, bump the package version, rebuild, and add a new entry. Never copy a Docker tag or digest into the catalog by hand.
 
 Typical release cycle:
 
@@ -80,17 +92,26 @@ Typical release cycle:
 # 2. Build and push
 cloudron build
 
-# 3. Add to catalog
-cloudron versions add
+# 3. Add to catalog as a test candidate
+cloudron versions add --state testing
 
-# 4. Commit and push CloudronVersions.json to hosting
+# 4. Host the catalog and test a clean install/upgrade via its public URL
+cloudron versions list
+
+# 5. Promote the exact tested entry
+cloudron versions update --version 1.1.0 --state published
+
+# 6. Commit and push CloudronVersions.json to hosting
 git add CloudronVersions.json && git commit -m "release 1.1.0" && git push
 ```
+
+Before promotion, verify fresh install, upgrade from the previous published version, restart, backup/restore, health checks, and the public icon/media URLs. Image push, catalog promotion, catalog hosting, and Community Apps submission are publication actions and require explicit authorization.
 
 ## Distribution
 
 - **Dashboard**: add `CloudronVersions.json` URL under Community apps in dashboard settings — updates appear automatically
 - **CLI**: `cloudron install --versions-url <url>`
+- **Community listing**: sign in to [Cloudron Community Apps](https://ca.cloudron.io), open the publisher's apps, add the same versions URL, and confirm the imported title, icon, screenshot, changelog, and install URL. The listing is optional and does not host the catalog.
 
 ## Community Packages (9.1+)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1196,6 +1196,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18162 Report and maintain OpenCode storage through ownership-aware contracts #feat ref:GH#28153
 
+- [ ] t18170 Standardize Cloudron community publishing lifecycle ref:GH#28546
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Teach Cloudron packaging agents to initialize and maintain version catalogs, publishing metadata, immutable release entries, and reviewed visual assets.

## Files Changed

.agents/tools/deployment/cloudron-app-packaging-skill.md, .agents/tools/deployment/cloudron-app-packaging.md, .agents/tools/deployment/cloudron-app-publishing-skill.md, TODO.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — .agents/scripts/linters-local.sh; git diff --check

Resolves #28546


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.175 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 44m and 416,869 tokens on this with the user in an interactive session.