### PR TITLE
GH#28550: ci: migrate actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/auto-deploy-agents.yml
+++ b/.github/workflows/auto-deploy-agents.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 2
 
@@ -153,7 +153,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install ShellCheck
         run: sudo apt-get install -y shellcheck

--- a/.github/workflows/cloudron-package-release-reusable.yml
+++ b/.github/workflows/cloudron-package-release-reusable.yml
@@ -32,13 +32,13 @@ jobs:
 
     steps:
       - name: Checkout package tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           path: package
 
       - name: Checkout aidevops release validator
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository }}
           ref: ${{ inputs.aidevops_ref }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Install ShellCheck (macOS)
       if: runner.os == 'macOS'
@@ -117,7 +117,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0
 
@@ -221,7 +221,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         # Fetch enough history for merge-base detection in safety-policy-check.sh.
         # Without this, stale PR branches that predate new policy markers cause
@@ -440,7 +440,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0
 
@@ -818,7 +818,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0
 
@@ -853,7 +853,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         # Match qlty-regression.yml so git-aware similar-code results are stable.
         fetch-depth: 0
@@ -883,7 +883,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0  # Shallow clones should be disabled for better analysis
 
@@ -949,7 +949,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0
 
@@ -1027,7 +1027,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/code-review-monitoring.yml
+++ b/.github/workflows/code-review-monitoring.yml
@@ -39,7 +39,7 @@ jobs:
     
     steps:
     - name: 📥 Checkout Repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/counter-monotonic.yml
+++ b/.github/workflows/counter-monotonic.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/counter-stack-check.yml
+++ b/.github/workflows/counter-stack-check.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gh-wrapper-guard.yml
+++ b/.github/workflows/gh-wrapper-guard.yml
@@ -37,7 +37,7 @@ jobs:
       has_sh_changes: ${{ steps.detect.outputs.has_sh_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -65,7 +65,7 @@ jobs:
     if: needs.detect-changed-sh.outputs.has_sh_changes == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -71,13 +71,13 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository projection
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout coordinator scripts
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
@@ -199,7 +199,7 @@ jobs:
 
       - name: Checkout
         if: steps.check-author.outputs.skip != 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           # t2166: prefer SYNC_PAT so `git push` of TODO.md updates bypasses
@@ -209,7 +209,7 @@ jobs:
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout aidevops framework scripts
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
@@ -341,14 +341,14 @@ jobs:
 
       - name: Checkout
         if: steps.check-issue.outputs.sync == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           # t2166: prefer SYNC_PAT to bypass branch protection on push.
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout aidevops framework scripts
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
@@ -418,7 +418,7 @@ jobs:
 
     steps:
       - name: Checkout aidevops framework scripts
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
@@ -625,14 +625,14 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           # t2166: prefer SYNC_PAT to bypass branch protection on push.
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout aidevops framework scripts
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
@@ -724,7 +724,7 @@ jobs:
       # only ran later in the job (gated by `if: steps.extract.outputs.task_id`)
       # which is too late for the comment-emitting steps.
       - name: Checkout aidevops framework scripts (early — for gh shim)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops
@@ -811,7 +811,7 @@ jobs:
 
       - name: Checkout repo before closing-hygiene validation
         if: steps.extract.outputs.linked_issues != ''
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 1
@@ -819,7 +819,7 @@ jobs:
 
       - name: Restore framework scripts before task resolution
         if: steps.extract.outputs.linked_issues != ''
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops

--- a/.github/workflows/loc-badge-reusable.yml
+++ b/.github/workflows/loc-badge-reusable.yml
@@ -115,14 +115,14 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-author.outputs.skip != 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout aidevops framework scripts
         if: steps.check-author.outputs.skip != 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           path: __aidevops

--- a/.github/workflows/markdoc-validate.yml
+++ b/.github/workflows/markdoc-validate.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Validate markdoc-validate.sh (ShellCheck)
         run: |

--- a/.github/workflows/mktemp-portability-check.yml
+++ b/.github/workflows/mktemp-portability-check.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -258,7 +258,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           # Use default GITHUB_TOKEN, not a PAT with elevated permissions

--- a/.github/workflows/parent-task-keyword-check.yml
+++ b/.github/workflows/parent-task-keyword-check.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check PR body for parent-task closing keywords
         env:

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -56,7 +56,7 @@ jobs:
       # ---------------------------------------------------------------
       - name: Checkout code
         if: steps.extract.outputs.task_id != ''
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: ${{ github.event.inputs.tag || github.ref }}
         fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
       run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
     
     - name: Setup Bun
-      uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
         bun-version: latest
     

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,7 +23,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -92,7 +92,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       
       - name: Get version and SHA
         id: release

--- a/.github/workflows/pulse-unbound-var-check.yml
+++ b/.github/workflows/pulse-unbound-var-check.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/qlty-new-file-gate.yml
+++ b/.github/workflows/qlty-new-file-gate.yml
@@ -60,7 +60,7 @@ jobs:
       has_new_source: ${{ steps.check.outputs.has_new_source }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -108,7 +108,7 @@ jobs:
     if: needs.detect-new-files.outputs.has_new_source == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -56,7 +56,7 @@ jobs:
       should_scan: ${{ steps.scope.outputs.should_scan }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -110,7 +110,7 @@ jobs:
     if: needs.detect-scope.outputs.should_scan == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ratchet-post-merge.yml
+++ b/.github/workflows/ratchet-post-merge.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -108,7 +108,7 @@ jobs:
         # in PR #20572 never propagated to downstream repos pinned to 73b664a).
         # Repository and ref are controlled by the caller provenance inputs.
         # Pin to @v3.x.y for stability; see .agents/reference/reusable-workflows.md.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository || 'marcusquinn/aidevops' }}
           ref: ${{ inputs.aidevops_ref || 'main' }}

--- a/.github/workflows/shell-init-pattern-check.yml
+++ b/.github/workflows/shell-init-pattern-check.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/shell-portability.yml
+++ b/.github/workflows/shell-portability.yml
@@ -40,7 +40,7 @@ jobs:
       is_pr: ${{ steps.detect.outputs.is_pr }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
     if: needs.detect-changed-sh.outputs.has_sh_changes == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Run portability scanner
         id: scan

--- a/.github/workflows/shellcheckrc-parity.yml
+++ b/.github/workflows/shellcheckrc-parity.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check disable parity
         run: |

--- a/.github/workflows/simplification-outcome-check.yml
+++ b/.github/workflows/simplification-outcome-check.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Checkout merged commit
         if: steps.extract-path.outputs.applicable == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 

--- a/.github/workflows/star-history-reusable.yml
+++ b/.github/workflows/star-history-reusable.yml
@@ -43,13 +43,13 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.SYNC_PAT }}
           fetch-depth: 1
 
       - name: Checkout aidevops chart generator
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ inputs.aidevops_repository }}
           ref: ${{ inputs.aidevops_ref }}

--- a/.github/workflows/stat-portability-check.yml
+++ b/.github/workflows/stat-portability-check.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Configure Git
         run: |

--- a/.github/workflows/task-id-collision-check.yml
+++ b/.github/workflows/task-id-collision-check.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Full history needed for merge-base detection
 

--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -28,7 +28,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.SYNC_PAT }}
           fetch-depth: 1

--- a/.github/workflows/update-website-docs.yml
+++ b/.github/workflows/update-website-docs.yml
@@ -20,10 +20,10 @@ jobs:
     
     steps:
       - name: Checkout aidevops repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
@@ -207,7 +207,7 @@ jobs:
           FOOTER
 
       - name: Checkout website repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: marcusquinn/aidevops.sh
           path: website

--- a/.github/workflows/version-validation.yml
+++ b/.github/workflows/version-validation.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/workflow-cascade-lint.yml
+++ b/.github/workflows/workflow-cascade-lint.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Pin actions/checkout v7.0.1 and oven-sh/setup-bun v2.2.0 across workflows so both actions run on Node.js 24

## Files Changed

.github/workflows/auto-deploy-agents.yml, .github/workflows/cloudron-package-release-reusable.yml, .github/workflows/code-quality.yml, .github/workflows/code-review-monitoring.yml, .github/workflows/counter-monotonic.yml, .github/workflows/counter-stack-check.yml, .github/workflows/gh-wrapper-guard.yml, .github/workflows/issue-sync-reusable.yml, .github/workflows/loc-badge-reusable.yml, .github/workflows/markdoc-validate.yml, .github/workflows/mktemp-portability-check.yml, .github/workflows/opencode-agent.yml, .github/workflows/parent-task-keyword-check.yml, .github/workflows/post-merge-verify.yml, .github/workflows/postflight.yml, .github/workflows/publish-packages.yml, .github/workflows/pulse-unbound-var-check.yml, .github/workflows/qlty-new-file-gate.yml, .github/workflows/qlty-regression.yml, .github/workflows/ratchet-post-merge.yml, .github/workflows/release.yml, .github/workflows/review-bot-gate-reusable.yml, .github/workflows/shell-init-pattern-check.yml, .github/workflows/shell-portability.yml, .github/workflows/shellcheckrc-parity.yml, .github/workflows/simplification-outcome-check.yml, .github/workflows/star-history-reusable.yml, .github/workflows/stat-portability-check.yml, .github/workflows/sync-wiki.yml, .github/workflows/task-id-collision-check.yml, .github/workflows/update-star-history.yml, .github/workflows/update-website-docs.yml, .github/workflows/version-validation.yml, .github/workflows/workflow-cascade-lint.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Verified upstream release SHAs and node24 action metadata; old SHA search returned zero matches; workflow YAML lint passed for all 55 workflows; pre-commit and pre-push gates passed

Resolves #28550


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.177 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 5m and 111,869 tokens on this as a headless worker.