### PR TITLE
GH#28549: Recover abandoned active rebase metadata

### DIFF
--- a/.agents/reference/dirty-worktree-preservation.md
+++ b/.agents/reference/dirty-worktree-preservation.md
@@ -84,6 +84,36 @@ remote refs, the index tree, or worktree content. Run `restore-default` with its
 own confirmation token after this command succeeds. Never use direct
 `git rebase --quit`, reset, clean, or metadata deletion on a canonical checkout.
 
+## Abandoned active rebase recovery
+
+Use the distinct abandoned-state operation only when a clean canonical mirror
+is detached at the pinned remote default tip but old interactive-rebase markers
+still describe an incomplete stopped sequence:
+
+```bash
+.agents/scripts/canonical-recovery-helper.sh clear-abandoned-rebase \
+  --repo /path/to/canonical-checkout \
+  --issue 123 \
+  --confirm CLEAR_ABANDONED_STALE_REBASE
+```
+
+This command does not relax `clear-stale-rebase`. It requires complete stopped
+`rebase-merge` metadata for the configured default branch, a matching
+`REBASE_HEAD` and `stopped-sha`, metadata whose newest marker is at least 24
+hours old, HEAD at the exact pinned remote tip and beyond the stopped commit,
+and a local default ref that remains an ancestor of that tip. Fresh, attached,
+dirty, divergent, malformed, ambiguous, or changing state fails closed.
+
+Before removal, the helper copies and fingerprints the complete metadata plus
+`REBASE_HEAD`. It resolves full or abbreviated commit IDs from todo, done,
+backup, stopped, and rewritten metadata and creates durable issue-scoped refs
+for every reference. After a final HEAD/ref/index/worktree check, it
+compare-deletes only the expected `REBASE_HEAD`, quarantines the metadata,
+re-fingerprints the quarantined snapshot, and restores it if concurrent state
+appears. After success, run the separately confirmed `restore-default`
+operation to attach and fast-forward the configured default branch. Never
+substitute `git rebase --quit` or manual `.git` deletion.
+
 Restore preserved state only to a clean checkout on the recorded branch:
 
 ```bash

--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -7,21 +7,254 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 FAST_FORWARD_CMD="fast-forward-current"
 SYNC_MIRROR_CMD="sync-mirror"
 CLEAR_STALE_REBASE_CMD="clear-stale-rebase"
+CLEAR_ABANDONED_REBASE_CMD="clear-abandoned-rebase"
+ABANDONED_REBASE_MIN_AGE_SECONDS=86400
+ABANDONED_REBASE_KIND="abandoned"
 HEAD_COMMIT_EXPR='HEAD^{commit}'
+NULL_SHA1="0000000000000000000000000000000000000000"
 
 rebase_state_fingerprint() {
 	local state_dir="$1"
-	local entry=""
-	local entry_hash=""
-	local entry_name=""
-	local manifest=""
-	for entry in "$state_dir"/*; do
-		[[ -f "$entry" ]] || return 1
-		entry_name=${entry##*/}
-		entry_hash=$("$REAL_GIT" hash-object "$entry") || return 1
-		manifest="${manifest}${entry_name} ${entry_hash}"$'\n'
-	done
-	printf '%s' "$manifest" | "$REAL_GIT" hash-object --stdin
+	local fingerprint=""
+	fingerprint=$(
+		python3 - "$state_dir" <<'PY'
+import hashlib
+import os
+import stat
+import sys
+
+state_dir = sys.argv[1]
+root_stat = os.lstat(state_dir)
+if not stat.S_ISDIR(root_stat.st_mode) or stat.S_ISLNK(root_stat.st_mode):
+    raise RuntimeError("rebase state root is not a plain directory")
+
+digest = hashlib.sha256()
+
+
+def add_field(value):
+    data = value.encode("utf-8", "surrogateescape")
+    digest.update(len(data).to_bytes(8, "big"))
+    digest.update(data)
+
+
+def walk(path, relative):
+    for entry in sorted(os.scandir(path), key=lambda item: item.name):
+        entry_relative = os.path.join(relative, entry.name) if relative else entry.name
+        entry_stat = entry.stat(follow_symlinks=False)
+        if stat.S_ISDIR(entry_stat.st_mode) and not stat.S_ISLNK(entry_stat.st_mode):
+            digest.update(b"D")
+            add_field(entry_relative)
+            walk(entry.path, entry_relative)
+        elif stat.S_ISREG(entry_stat.st_mode):
+            digest.update(b"F")
+            add_field(entry_relative)
+            digest.update(entry_stat.st_size.to_bytes(8, "big"))
+            with open(entry.path, "rb") as handle:
+                for chunk in iter(lambda: handle.read(65536), b""):
+                    digest.update(chunk)
+        else:
+            raise RuntimeError("rebase state contains a non-regular entry")
+
+
+walk(state_dir, "")
+print(digest.hexdigest())
+PY
+	) || return 1
+	printf '%s\n' "$fingerprint"
+	return 0
+}
+
+rebase_marker_fingerprint() {
+	local state_dir="$1"
+	local rebase_head_path="$2"
+	local state_hash=""
+	local rebase_head_hash="absent"
+	state_hash=$(rebase_state_fingerprint "$state_dir") || return 1
+	if [[ -f "$rebase_head_path" ]]; then
+		rebase_head_hash=$("$REAL_GIT" hash-object "$rebase_head_path") || return 1
+	elif [[ -e "$rebase_head_path" ]]; then
+		return 1
+	fi
+	printf '%s\n%s\n' "$state_hash" "$rebase_head_hash" | "$REAL_GIT" hash-object --stdin
+	return 0
+}
+
+rebase_state_latest_mtime() {
+	local state_dir="$1"
+	local rebase_head_path="$2"
+	local latest_mtime=""
+	latest_mtime=$(
+		python3 - "$state_dir" "$rebase_head_path" <<'PY'
+import os
+import sys
+
+state_dir, rebase_head_path = sys.argv[1:]
+paths = [state_dir]
+for root, dirs, files in os.walk(state_dir):
+    paths.extend(os.path.join(root, name) for name in dirs)
+    paths.extend(os.path.join(root, name) for name in files)
+if os.path.exists(rebase_head_path):
+    paths.append(rebase_head_path)
+print(int(max(os.lstat(path).st_mtime for path in paths)))
+PY
+	) || return 1
+	printf '%s\n' "$latest_mtime"
+	return 0
+}
+
+preserve_rebase_commit_ref() {
+	local repo="$1"
+	local issue="$2"
+	local namespace="$3"
+	local commitish="$4"
+	local commit=""
+	local existing_commit=""
+	local preservation_ref=""
+	[[ "$commitish" =~ ^[0-9a-fA-F]{4,40}$ ]] || return 1
+	commit=$("$REAL_GIT" -C "$repo" rev-parse --verify "${commitish}^{commit}" 2>/dev/null) || return 1
+	[[ "$commit" =~ ^[0-9a-fA-F]{40}$ ]] || return 1
+	preservation_ref="refs/aidevops/canonical-recovery/issue-${issue}/${namespace}/${commit}"
+	existing_commit=$("$REAL_GIT" -C "$repo" rev-parse --verify "${preservation_ref}^{commit}" 2>/dev/null || true)
+	[[ -z "$existing_commit" || "$existing_commit" == "$commit" ]] || return 1
+	if [[ -z "$existing_commit" ]]; then
+		"$REAL_GIT" -C "$repo" update-ref "$preservation_ref" "$commit" \
+			"0000000000000000000000000000000000000000" || return 1
+	fi
+	[[ "$("$REAL_GIT" -C "$repo" rev-parse --verify "${preservation_ref}^{commit}")" == "$commit" ]] || return 1
+	return 0
+}
+
+preserve_rebase_sequence_refs() {
+	local repo="$1"
+	local issue="$2"
+	local namespace="$3"
+	local sequence_file="$4"
+	local sequence_action=""
+	local sequence_commit=""
+	local sequence_rest=""
+	[[ -f "$sequence_file" ]] || return 1
+	while read -r sequence_action sequence_commit sequence_rest ||
+		[[ -n "$sequence_action" || -n "$sequence_commit" || -n "$sequence_rest" ]]; do
+		case "$sequence_action" in
+		"" | \#* | exec | x | break | b | label | l | reset | t | update-ref | u | noop)
+			continue
+			;;
+		pick | p | reword | r | edit | e | squash | s | drop | d)
+			preserve_rebase_commit_ref "$repo" "$issue" "$namespace" "$sequence_commit" || return 1
+			;;
+		fixup | f)
+			if [[ "$sequence_commit" == "-C" || "$sequence_commit" == "-c" ]]; then
+				read -r sequence_commit _ <<<"$sequence_rest"
+			fi
+			preserve_rebase_commit_ref "$repo" "$issue" "$namespace" "$sequence_commit" || return 1
+			;;
+		merge | m)
+			if [[ "$sequence_commit" == "-C" || "$sequence_commit" == "-c" ]]; then
+				read -r sequence_commit _ <<<"$sequence_rest"
+				preserve_rebase_commit_ref "$repo" "$issue" "$namespace" "$sequence_commit" || return 1
+			fi
+			;;
+		*)
+			return 1
+			;;
+		esac
+	done <"$sequence_file"
+	return 0
+}
+
+preserve_rewritten_rebase_refs() {
+	local repo="$1"
+	local issue="$2"
+	local namespace="$3"
+	local state_dir="$4"
+	local extra=""
+	local new_commit=""
+	local old_commit=""
+	local pending_commit=""
+	if [[ -f "${state_dir}/rewritten-list" ]]; then
+		while read -r old_commit new_commit extra ||
+			[[ -n "$old_commit" || -n "$new_commit" || -n "$extra" ]]; do
+			[[ -n "$old_commit" && -n "$new_commit" && -z "$extra" ]] || return 1
+			preserve_rebase_commit_ref "$repo" "$issue" "$namespace" "$old_commit" || return 1
+			preserve_rebase_commit_ref "$repo" "$issue" "$namespace" "$new_commit" || return 1
+		done <"${state_dir}/rewritten-list"
+	fi
+	if [[ -f "${state_dir}/rewritten-pending" ]]; then
+		while read -r pending_commit extra || [[ -n "$pending_commit" || -n "$extra" ]]; do
+			[[ -n "$pending_commit" && -z "$extra" ]] || return 1
+			preserve_rebase_commit_ref "$repo" "$issue" "$namespace" "$pending_commit" || return 1
+		done <"${state_dir}/rewritten-pending"
+	fi
+	return 0
+}
+
+preserve_rebase_object_file_refs() {
+	local repo="$1"
+	local issue="$2"
+	local namespace="$3"
+	local object_file="$4"
+	local object_line=""
+	local object_token=""
+	local -a object_tokens=()
+	[[ -f "$object_file" ]] || return 0
+	while IFS= read -r object_line || [[ -n "$object_line" ]]; do
+		object_tokens=()
+		read -r -a object_tokens <<<"$object_line"
+		for object_token in "${object_tokens[@]}"; do
+			[[ "$object_token" =~ ^[0-9a-fA-F]{4,40}$ ]] || continue
+			[[ "$object_token" =~ ^0+$ ]] && continue
+			preserve_rebase_commit_ref "$repo" "$issue" "$namespace" "$object_token" || return 1
+		done
+	done <"$object_file"
+	return 0
+}
+
+restore_deleted_rebase_head() {
+	local repo="$1"
+	local rebase_head_path="$2"
+	local stopped_sha="$3"
+	local current_rebase_head=""
+	if [[ -e "$rebase_head_path" ]]; then
+		[[ -f "$rebase_head_path" ]] || return 1
+		current_rebase_head=$("$REAL_GIT" -C "$repo" rev-parse --verify 'REBASE_HEAD^{commit}' 2>/dev/null || true)
+		[[ -n "$current_rebase_head" ]] || return 1
+		return 0
+	fi
+	"$REAL_GIT" -C "$repo" update-ref REBASE_HEAD "$stopped_sha" "$NULL_SHA1" || return 1
+	[[ "$("$REAL_GIT" -C "$repo" rev-parse --verify 'REBASE_HEAD^{commit}')" == "$stopped_sha" ]] || return 1
+	return 0
+}
+
+restore_deleted_rebase_head_copy() {
+	local repo="$1"
+	local rebase_head_path="$2"
+	local stopped_sha="$3"
+	local quarantine_head_path="$4"
+	restore_deleted_rebase_head "$repo" "$rebase_head_path" "$stopped_sha" || return 1
+	rm -f "$quarantine_head_path" || return 1
+	return 0
+}
+
+restore_quarantined_rebase_state() {
+	local repo="$1"
+	local state_dir="$2"
+	local rebase_head_path="$3"
+	local quarantine_dir="$4"
+	local quarantine_head_path="$5"
+	local cleanup_kind="$6"
+	local stopped_sha="$7"
+	[[ -d "$quarantine_dir" && ! -e "$state_dir" ]] || return 1
+	if [[ "$cleanup_kind" == "$ABANDONED_REBASE_KIND" ]]; then
+		[[ -f "$quarantine_head_path" ]] || return 1
+	fi
+	mv "$quarantine_dir" "$state_dir" || return 1
+	if [[ "$cleanup_kind" == "$ABANDONED_REBASE_KIND" ]]; then
+		if ! restore_deleted_rebase_head "$repo" "$rebase_head_path" "$stopped_sha"; then
+			mv "$state_dir" "$quarantine_dir" >/dev/null 2>&1 || true
+			return 1
+		fi
+		rm -f "$quarantine_head_path" || return 1
+	fi
 	return 0
 }
 
@@ -30,6 +263,7 @@ usage() {
 		'Usage:' \
 		'  canonical-recovery-helper.sh restore-default --repo PATH --issue N --confirm RESTORE_CANONICAL_DEFAULT' \
 		"  canonical-recovery-helper.sh ${CLEAR_STALE_REBASE_CMD} --repo PATH --issue N --confirm CLEAR_CONVERGED_STALE_REBASE" \
+		"  canonical-recovery-helper.sh ${CLEAR_ABANDONED_REBASE_CMD} --repo PATH --issue N --confirm CLEAR_ABANDONED_STALE_REBASE" \
 		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --issue N --confirm FAST_FORWARD_CANONICAL_BRANCH" \
 		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --reason aidevops-update --confirm FAST_FORWARD_CANONICAL_BRANCH" \
 		"  canonical-recovery-helper.sh ${SYNC_MIRROR_CMD} --repo PATH --issue N --confirm SYNCHRONIZE_CANONICAL_MIRROR"
@@ -82,6 +316,13 @@ restore-default)
 	;;
 "$CLEAR_STALE_REBASE_CMD")
 	expected_confirmation="CLEAR_CONVERGED_STALE_REBASE"
+	[[ -z "$expected_branch" ]] || {
+		usage
+		exit 2
+	}
+	;;
+"$CLEAR_ABANDONED_REBASE_CMD")
+	expected_confirmation="CLEAR_ABANDONED_STALE_REBASE"
 	[[ -z "$expected_branch" ]] || {
 		usage
 		exit 2
@@ -148,7 +389,8 @@ target_branch_source=$(python3 "$policy_helper" resolve-branch --cwd "$repo_path
 	exit 1
 }
 
-if [[ "$cmd" != "restore-default" && "$cmd" != "$CLEAR_STALE_REBASE_CMD" ]]; then
+if [[ "$cmd" != "restore-default" && "$cmd" != "$CLEAR_STALE_REBASE_CMD" &&
+	"$cmd" != "$CLEAR_ABANDONED_REBASE_CMD" ]]; then
 	current_branch=$("$REAL_GIT" -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 	[[ -n "$current_branch" ]] || {
 		printf 'BLOCKED: canonical worktree is detached\n' >&2
@@ -208,7 +450,10 @@ stale_rebase_fingerprint=""
 stale_rebase_preservation_dir=""
 stale_head_sha=""
 stale_index_tree=""
-if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]]; then
+stale_rebase_cleanup_kind=""
+stale_rebase_ref_namespace=""
+stale_rebase_stopped_sha=""
+if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" || "$cmd" == "$CLEAR_ABANDONED_REBASE_CMD" ]]; then
 	rebase_merge_dir=$("$REAL_GIT" -C "$repo_path" rev-parse --path-format=absolute --git-path rebase-merge)
 	rebase_apply_dir=$("$REAL_GIT" -C "$repo_path" rev-parse --path-format=absolute --git-path rebase-apply)
 	rebase_head_path=$("$REAL_GIT" -C "$repo_path" rev-parse --path-format=absolute --git-path REBASE_HEAD)
@@ -231,16 +476,8 @@ if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]]; then
 		printf 'BLOCKED: stale rebase belongs to a different branch\n' >&2
 		exit 1
 	}
-	[[ "$rebase_msgnum" =~ ^[0-9]+$ && "$rebase_end" =~ ^[0-9]+$ && "$rebase_msgnum" == "$rebase_end" ]] || {
-		printf 'BLOCKED: rebase sequence is active or malformed\n' >&2
-		exit 1
-	}
-	[[ ! -s "${rebase_merge_dir}/git-rebase-todo" && -s "${rebase_merge_dir}/done" ]] || {
-		printf 'BLOCKED: rebase sequence still has active work\n' >&2
-		exit 1
-	}
-	[[ ! -e "$rebase_head_path" && ! -e "${rebase_merge_dir}/stopped-sha" ]] || {
-		printf 'BLOCKED: rebase is stopped on an active commit\n' >&2
+	[[ "$rebase_msgnum" =~ ^[0-9]+$ && "$rebase_end" =~ ^[0-9]+$ ]] || {
+		printf 'BLOCKED: rebase sequence counters are malformed\n' >&2
 		exit 1
 	}
 	"$REAL_GIT" -C "$repo_path" rev-parse --verify "${rebase_onto}^{commit}" >/dev/null 2>&1 &&
@@ -253,14 +490,76 @@ if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]]; then
 		exit 1
 	}
 	stale_head_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "$HEAD_COMMIT_EXPR")
-	[[ "$stale_head_sha" == "$local_sha" && "$local_sha" == "$target_sha" ]] || {
-		printf 'BLOCKED: HEAD, local default, and pinned origin default have not converged\n' >&2
-		exit 1
-	}
 	stale_index_tree=$("$REAL_GIT" -C "$repo_path" write-tree)
 	stale_rebase_dir="$rebase_merge_dir"
-	stale_rebase_fingerprint=$(rebase_state_fingerprint "$stale_rebase_dir")
-	stale_rebase_preservation_dir="${AIDEVOPS_CANONICAL_RECOVERY_ROOT:-${HOME}/.aidevops/.agent-workspace/recovery/canonical}/${issue_number}/stale-rebase-${stale_head_sha}"
+	if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]]; then
+		[[ "$rebase_msgnum" == "$rebase_end" ]] || {
+			printf 'BLOCKED: rebase sequence is active or malformed\n' >&2
+			exit 1
+		}
+		[[ ! -s "${rebase_merge_dir}/git-rebase-todo" && -s "${rebase_merge_dir}/done" ]] || {
+			printf 'BLOCKED: rebase sequence still has active work\n' >&2
+			exit 1
+		}
+		[[ ! -e "$rebase_head_path" && ! -e "${rebase_merge_dir}/stopped-sha" ]] || {
+			printf 'BLOCKED: rebase is stopped on an active commit\n' >&2
+			exit 1
+		}
+		[[ "$stale_head_sha" == "$local_sha" && "$local_sha" == "$target_sha" ]] || {
+			printf 'BLOCKED: HEAD, local default, and pinned origin default have not converged\n' >&2
+			exit 1
+		}
+		stale_rebase_cleanup_kind="converged"
+		stale_rebase_ref_namespace="stale-rebase"
+		stale_rebase_fingerprint=$(rebase_state_fingerprint "$stale_rebase_dir")
+		stale_rebase_preservation_dir="${AIDEVOPS_CANONICAL_RECOVERY_ROOT:-${HOME}/.aidevops/.agent-workspace/recovery/canonical}/${issue_number}/stale-rebase-${stale_head_sha}"
+	else
+		[[ "$rebase_msgnum" -ge 1 && "$rebase_msgnum" -lt "$rebase_end" ]] || {
+			printf 'BLOCKED: abandoned rebase must retain an incomplete active sequence\n' >&2
+			exit 1
+		}
+		[[ -s "${rebase_merge_dir}/git-rebase-todo" && -s "${rebase_merge_dir}/done" &&
+			-f "${rebase_merge_dir}/stopped-sha" && -f "$rebase_head_path" ]] || {
+			printf 'BLOCKED: abandoned rebase metadata is not a complete stopped sequence\n' >&2
+			exit 1
+		}
+		stale_rebase_stopped_sha=$(<"${rebase_merge_dir}/stopped-sha")
+		rebase_head_sha=$(<"$rebase_head_path")
+		stale_rebase_stopped_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${stale_rebase_stopped_sha}^{commit}" 2>/dev/null || true)
+		rebase_head_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${rebase_head_sha}^{commit}" 2>/dev/null || true)
+		[[ -n "$stale_rebase_stopped_sha" && "$stale_rebase_stopped_sha" == "$rebase_head_sha" ]] || {
+			printf 'BLOCKED: stopped rebase commit metadata is invalid or inconsistent\n' >&2
+			exit 1
+		}
+		abandoned_current_branch=$("$REAL_GIT" -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+		[[ -z "$abandoned_current_branch" ]] || {
+			printf 'BLOCKED: abandoned rebase recovery requires a detached canonical HEAD\n' >&2
+			exit 1
+		}
+		[[ "$stale_head_sha" == "$target_sha" && "$stale_head_sha" != "$stale_rebase_stopped_sha" ]] || {
+			printf 'BLOCKED: HEAD has not independently converged beyond the stopped rebase commit\n' >&2
+			exit 1
+		}
+		"$REAL_GIT" -C "$repo_path" merge-base --is-ancestor "$local_sha" "$target_sha" || {
+			printf 'BLOCKED: local default branch has diverged from the pinned origin default\n' >&2
+			exit 1
+		}
+		rebase_latest_mtime=$(rebase_state_latest_mtime "$stale_rebase_dir" "$rebase_head_path") || {
+			printf 'BLOCKED: abandoned rebase age cannot be established\n' >&2
+			exit 1
+		}
+		current_epoch=$(date +%s)
+		[[ "$rebase_latest_mtime" =~ ^[0-9]+$ && "$current_epoch" =~ ^[0-9]+$ &&
+			"$current_epoch" -ge "$rebase_latest_mtime" &&
+			$((current_epoch - rebase_latest_mtime)) -ge "$ABANDONED_REBASE_MIN_AGE_SECONDS" ]] || {
+			printf 'BLOCKED: active rebase metadata is too recent to prove abandonment\n' >&2
+			exit 1
+		}
+		stale_rebase_cleanup_kind="$ABANDONED_REBASE_KIND"
+		stale_rebase_ref_namespace="abandoned-rebase"
+		stale_rebase_fingerprint=$(rebase_marker_fingerprint "$stale_rebase_dir" "$rebase_head_path")
+		stale_rebase_preservation_dir="${AIDEVOPS_CANONICAL_RECOVERY_ROOT:-${HOME}/.aidevops/.agent-workspace/recovery/canonical}/${issue_number}/abandoned-rebase-${stale_head_sha}"
+	fi
 fi
 
 sync_backup_id=""
@@ -361,6 +660,7 @@ audit_message="Canonical default-branch recovery authorized"
 [[ "$cmd" == "$FAST_FORWARD_CMD" ]] && audit_message="Canonical current-branch fast-forward authorized"
 [[ "$cmd" == "$SYNC_MIRROR_CMD" ]] && audit_message="Canonical mirror synchronization authorized"
 [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]] && audit_message="Converged stale rebase cleanup authorized"
+[[ "$cmd" == "$CLEAR_ABANDONED_REBASE_CMD" ]] && audit_message="Abandoned stale rebase cleanup authorized"
 AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log operation.verify "$audit_message" \
 	--detail "issue=${issue_number:-none}" --detail "reason=${maintenance_reason:-none}" --detail "repo=${repo_path}" \
 	--detail "operation=${cmd}" --detail "target=${target_branch}" --detail "target_source=${target_branch_source}" \
@@ -380,50 +680,97 @@ AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log opera
 	printf 'BLOCKED: local %s tip changed during recovery\n' "$target_branch" >&2
 	exit 1
 }
-if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]]; then
+if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" || "$cmd" == "$CLEAR_ABANDONED_REBASE_CMD" ]]; then
 	preservation_parent=${stale_rebase_preservation_dir%/*}
 	mkdir -p "$preservation_parent"
 	if [[ -d "$stale_rebase_preservation_dir" ]]; then
-		[[ "$(rebase_state_fingerprint "$stale_rebase_preservation_dir")" == "$stale_rebase_fingerprint" ]] || {
+		preserved_rebase_fingerprint=""
+		if [[ "$stale_rebase_cleanup_kind" == "$ABANDONED_REBASE_KIND" ]]; then
+			preserved_rebase_fingerprint=$(rebase_marker_fingerprint \
+				"${stale_rebase_preservation_dir}/rebase-merge" \
+				"${stale_rebase_preservation_dir}/REBASE_HEAD") || true
+		else
+			preserved_rebase_fingerprint=$(rebase_state_fingerprint "$stale_rebase_preservation_dir") || true
+		fi
+		[[ "$preserved_rebase_fingerprint" == "$stale_rebase_fingerprint" ]] || {
 			printf 'BLOCKED: existing stale rebase preservation evidence differs\n' >&2
 			exit 1
 		}
 	else
 		preservation_temp="${stale_rebase_preservation_dir}.tmp.$$"
 		mkdir "$preservation_temp"
-		cp -R "${stale_rebase_dir}/." "$preservation_temp/"
-		[[ "$(rebase_state_fingerprint "$preservation_temp")" == "$stale_rebase_fingerprint" ]] || {
+		if [[ "$stale_rebase_cleanup_kind" == "$ABANDONED_REBASE_KIND" ]]; then
+			mkdir "${preservation_temp}/rebase-merge"
+			cp -R "${stale_rebase_dir}/." "${preservation_temp}/rebase-merge/"
+			cp "$rebase_head_path" "${preservation_temp}/REBASE_HEAD"
+			preserved_rebase_fingerprint=$(rebase_marker_fingerprint \
+				"${preservation_temp}/rebase-merge" "${preservation_temp}/REBASE_HEAD") || true
+		else
+			cp -R "${stale_rebase_dir}/." "$preservation_temp/"
+			preserved_rebase_fingerprint=$(rebase_state_fingerprint "$preservation_temp") || true
+		fi
+		[[ "$preserved_rebase_fingerprint" == "$stale_rebase_fingerprint" ]] || {
 			printf 'BLOCKED: stale rebase metadata copy could not be verified\n' >&2
 			rm -rf "$preservation_temp"
 			exit 1
 		}
 		mv "$preservation_temp" "$stale_rebase_preservation_dir"
 	fi
-	while IFS= read -r metadata_line; do
-		for metadata_word in $metadata_line; do
-			if [[ "$metadata_word" =~ ^[0-9a-fA-F]{40}$ ]] &&
-				metadata_commit=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${metadata_word}^{commit}" 2>/dev/null); then
-				metadata_ref="refs/aidevops/canonical-recovery/issue-${issue_number}/stale-rebase/${metadata_commit}"
-				existing_metadata_commit=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${metadata_ref}^{commit}" 2>/dev/null || true)
-				[[ -z "$existing_metadata_commit" || "$existing_metadata_commit" == "$metadata_commit" ]] || {
-					printf 'BLOCKED: stale rebase preservation ref points elsewhere\n' >&2
-					exit 1
-				}
-				[[ -n "$existing_metadata_commit" ]] || "$REAL_GIT" -C "$repo_path" update-ref "$metadata_ref" "$metadata_commit" \
-					"0000000000000000000000000000000000000000"
-			fi
-		done
-	done < <(
-		printf '%s\n' "$stale_head_sha" "$rebase_onto" "$rebase_orig_head"
-		cat "${stale_rebase_dir}/done" "${stale_rebase_dir}/rewritten-list" 2>/dev/null || true
-	)
+	for metadata_commit in "$stale_head_sha" "$local_sha" "$target_sha" "$rebase_onto" \
+		"$rebase_orig_head" "$stale_rebase_stopped_sha"; do
+		[[ -n "$metadata_commit" ]] || continue
+		preserve_rebase_commit_ref "$repo_path" "$issue_number" \
+			"$stale_rebase_ref_namespace" "$metadata_commit" || {
+			printf 'BLOCKED: stale rebase commit reference could not be preserved\n' >&2
+			exit 1
+		}
+	done
+	for sequence_file in "${stale_rebase_dir}/git-rebase-todo" "${stale_rebase_dir}/done"; do
+		preserve_rebase_sequence_refs "$repo_path" "$issue_number" \
+			"$stale_rebase_ref_namespace" "$sequence_file" || {
+			printf 'BLOCKED: stale rebase sequence references are malformed or could not be preserved\n' >&2
+			exit 1
+		}
+	done
+	if [[ -f "${stale_rebase_dir}/git-rebase-todo.backup" ]]; then
+		preserve_rebase_sequence_refs "$repo_path" "$issue_number" \
+			"$stale_rebase_ref_namespace" "${stale_rebase_dir}/git-rebase-todo.backup" || {
+			printf 'BLOCKED: stale rebase backup references are malformed or could not be preserved\n' >&2
+			exit 1
+		}
+	fi
+	preserve_rewritten_rebase_refs "$repo_path" "$issue_number" \
+		"$stale_rebase_ref_namespace" "$stale_rebase_dir" || {
+		printf 'BLOCKED: rewritten rebase references are malformed or could not be preserved\n' >&2
+		exit 1
+	}
+	for object_metadata_file in "amend" "squash-onto" "update-refs"; do
+		preserve_rebase_object_file_refs "$repo_path" "$issue_number" \
+			"$stale_rebase_ref_namespace" "${stale_rebase_dir}/${object_metadata_file}" || {
+			printf 'BLOCKED: auxiliary rebase object references could not be preserved\n' >&2
+			exit 1
+		}
+	done
+	if [[ -f "${stale_rebase_dir}/current-fixups" ]]; then
+		preserve_rebase_sequence_refs "$repo_path" "$issue_number" \
+			"$stale_rebase_ref_namespace" "${stale_rebase_dir}/current-fixups" || {
+			printf 'BLOCKED: current rebase fixup references are malformed or could not be preserved\n' >&2
+			exit 1
+		}
+	fi
 	if [[ -n "${AIDEVOPS_CANONICAL_BEFORE_REBASE_CLEANUP_HOOK:-}" ]]; then
 		"$AIDEVOPS_CANONICAL_BEFORE_REBASE_CLEANUP_HOOK" "$repo_path" "$stale_rebase_dir" || {
 			printf 'BLOCKED: canonical pre-rebase-cleanup hook failed\n' >&2
 			exit 1
 		}
 	fi
-	[[ "$(rebase_state_fingerprint "$stale_rebase_dir")" == "$stale_rebase_fingerprint" ]] &&
+	current_rebase_fingerprint=""
+	if [[ "$stale_rebase_cleanup_kind" == "$ABANDONED_REBASE_KIND" ]]; then
+		current_rebase_fingerprint=$(rebase_marker_fingerprint "$stale_rebase_dir" "$rebase_head_path") || true
+	else
+		current_rebase_fingerprint=$(rebase_state_fingerprint "$stale_rebase_dir") || true
+	fi
+	[[ "$current_rebase_fingerprint" == "$stale_rebase_fingerprint" ]] &&
 		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "$HEAD_COMMIT_EXPR")" == "$stale_head_sha" ]] &&
 		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}")" == "$local_sha" ]] &&
 		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] &&
@@ -432,8 +779,91 @@ if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]]; then
 		printf 'BLOCKED: canonical or rebase state changed before cleanup\n' >&2
 		exit 1
 	}
-	rm -rf "$stale_rebase_dir"
+	stale_rebase_quarantine_dir="${stale_rebase_dir}.aidevops-quarantine.${issue_number}.$$"
+	stale_rebase_quarantine_head="${rebase_head_path}.aidevops-quarantine.${issue_number}.$$"
+	[[ ! -e "$stale_rebase_quarantine_dir" && ! -e "$stale_rebase_quarantine_head" ]] || {
+		printf 'BLOCKED: stale rebase quarantine path already exists\n' >&2
+		exit 1
+	}
+	if [[ -n "${AIDEVOPS_CANONICAL_BEFORE_REBASE_QUARANTINE_HOOK:-}" ]]; then
+		"$AIDEVOPS_CANONICAL_BEFORE_REBASE_QUARANTINE_HOOK" "$repo_path" "$stale_rebase_dir" || {
+			printf 'BLOCKED: canonical pre-rebase-quarantine hook failed\n' >&2
+			exit 1
+		}
+	fi
+	if [[ "$stale_rebase_cleanup_kind" == "$ABANDONED_REBASE_KIND" ]]; then
+		cp "$rebase_head_path" "$stale_rebase_quarantine_head" || {
+			printf 'BLOCKED: REBASE_HEAD could not be copied for quarantine\n' >&2
+			exit 1
+		}
+		[[ "$("$REAL_GIT" hash-object "$stale_rebase_quarantine_head")" == "$("$REAL_GIT" hash-object "$rebase_head_path")" ]] || {
+			printf 'BLOCKED: REBASE_HEAD quarantine copy could not be verified\n' >&2
+			rm -f "$stale_rebase_quarantine_head"
+			exit 1
+		}
+		if ! "$REAL_GIT" -C "$repo_path" update-ref -d REBASE_HEAD "$stale_rebase_stopped_sha"; then
+			printf 'BLOCKED: REBASE_HEAD changed before compare-and-delete\n' >&2
+			rm -f "$stale_rebase_quarantine_head"
+			exit 1
+		fi
+		[[ ! -e "$rebase_head_path" ]] || {
+			printf 'BLOCKED: REBASE_HEAD remained after compare-and-delete\n' >&2
+			rm -f "$stale_rebase_quarantine_head"
+			exit 1
+		}
+		if [[ -n "${AIDEVOPS_CANONICAL_BEFORE_REBASE_DIRECTORY_QUARANTINE_HOOK:-}" ]]; then
+			if ! "$AIDEVOPS_CANONICAL_BEFORE_REBASE_DIRECTORY_QUARANTINE_HOOK" \
+				"$repo_path" "$stale_rebase_dir" "$rebase_head_path" "$target_sha"; then
+				if restore_deleted_rebase_head_copy "$repo_path" "$rebase_head_path" \
+					"$stale_rebase_stopped_sha" "$stale_rebase_quarantine_head"; then
+					printf 'BLOCKED: canonical pre-directory-quarantine hook failed\n' >&2
+				else
+					printf 'CRITICAL: pre-directory-quarantine hook failed and REBASE_HEAD recovery evidence was retained\n' >&2
+				fi
+				exit 1
+			fi
+		fi
+	fi
+	mv "$stale_rebase_dir" "$stale_rebase_quarantine_dir" || {
+		if [[ "$stale_rebase_cleanup_kind" == "$ABANDONED_REBASE_KIND" ]]; then
+			if ! restore_deleted_rebase_head_copy "$repo_path" "$rebase_head_path" \
+				"$stale_rebase_stopped_sha" "$stale_rebase_quarantine_head"; then
+				printf 'CRITICAL: directory quarantine failed and REBASE_HEAD recovery evidence was retained\n' >&2
+				exit 1
+			fi
+		fi
+		printf 'BLOCKED: stale rebase metadata could not be quarantined\n' >&2
+		exit 1
+	}
+	quarantined_rebase_fingerprint=""
+	if [[ "$stale_rebase_cleanup_kind" == "$ABANDONED_REBASE_KIND" ]]; then
+		quarantined_rebase_fingerprint=$(rebase_marker_fingerprint \
+			"$stale_rebase_quarantine_dir" "$stale_rebase_quarantine_head") || true
+	else
+		quarantined_rebase_fingerprint=$(rebase_state_fingerprint "$stale_rebase_quarantine_dir") || true
+	fi
+	quarantine_valid=1
+	[[ "$quarantined_rebase_fingerprint" == "$stale_rebase_fingerprint" ]] || quarantine_valid=0
+	[[ ! -e "$stale_rebase_dir" && ! -e "$rebase_apply_dir" && ! -e "$rebase_head_path" ]] || quarantine_valid=0
+	[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "$HEAD_COMMIT_EXPR")" == "$stale_head_sha" ]] || quarantine_valid=0
+	[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}")" == "$local_sha" ]] || quarantine_valid=0
+	[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] || quarantine_valid=0
+	[[ "$("$REAL_GIT" -C "$repo_path" write-tree)" == "$stale_index_tree" ]] || quarantine_valid=0
+	[[ -z "$("$REAL_GIT" -C "$repo_path" status --porcelain)" ]] || quarantine_valid=0
+	if [[ "$quarantine_valid" -ne 1 ]]; then
+		if restore_quarantined_rebase_state "$repo_path" "$stale_rebase_dir" "$rebase_head_path" \
+			"$stale_rebase_quarantine_dir" "$stale_rebase_quarantine_head" \
+			"$stale_rebase_cleanup_kind" "$stale_rebase_stopped_sha"; then
+			printf 'BLOCKED: canonical or rebase state changed during quarantine; metadata restored\n' >&2
+		else
+			printf 'CRITICAL: quarantined stale rebase metadata requires manual recovery\n' >&2
+		fi
+		exit 1
+	fi
+	rm -rf "$stale_rebase_quarantine_dir"
+	[[ "$stale_rebase_cleanup_kind" != "$ABANDONED_REBASE_KIND" ]] || rm -f "$stale_rebase_quarantine_head"
 	[[ ! -e "$stale_rebase_dir" && ! -e "$rebase_apply_dir" && ! -e "$rebase_head_path" ]] &&
+		[[ ! -e "$stale_rebase_quarantine_dir" && ! -e "$stale_rebase_quarantine_head" ]] &&
 		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "$HEAD_COMMIT_EXPR")" == "$stale_head_sha" ]] &&
 		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}")" == "$local_sha" ]] &&
 		[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] &&
@@ -442,7 +872,11 @@ if [[ "$cmd" == "$CLEAR_STALE_REBASE_CMD" ]]; then
 		printf 'CRITICAL: stale rebase cleanup changed canonical repository state\n' >&2
 		exit 1
 	}
-	printf 'CLEARED_CONVERGED_STALE_REBASE=true\n'
+	if [[ "$stale_rebase_cleanup_kind" == "$ABANDONED_REBASE_KIND" ]]; then
+		printf 'CLEARED_ABANDONED_STALE_REBASE=true\n'
+	else
+		printf 'CLEARED_CONVERGED_STALE_REBASE=true\n'
+	fi
 	printf 'PRESERVED_REBASE_DIR=%s\n' "$stale_rebase_preservation_dir"
 	exit 0
 fi

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -320,6 +320,371 @@ else
 	exit 1
 fi
 
+age_rebase_state_fixture() {
+	local metadata_path="$1"
+	local rebase_head_path="$2"
+	python3 - "$metadata_path" "$rebase_head_path" <<'PY'
+import os
+import sys
+import time
+
+old = time.time() - 172800
+for root_path in sys.argv[1:]:
+    paths = [root_path]
+    if os.path.isdir(root_path):
+        for root, dirs, files in os.walk(root_path):
+            paths.extend(os.path.join(root, name) for name in dirs)
+            paths.extend(os.path.join(root, name) for name in files)
+    for path in paths:
+        os.utime(path, (old, old))
+PY
+	return 0
+}
+
+rebase_fixture_snapshot() {
+	local repo="$1"
+	local metadata_path="$2"
+	local rebase_head_path="$3"
+	local content_fingerprint=""
+	local current_head_ref=""
+	content_fingerprint=$(
+		python3 - "$repo" "$metadata_path" "$rebase_head_path" <<'PY'
+import hashlib
+import os
+import stat
+import sys
+
+repo, metadata_path, rebase_head_path = sys.argv[1:]
+digest = hashlib.sha256()
+
+
+def add_field(value):
+    data = value.encode("utf-8", "surrogateescape")
+    digest.update(len(data).to_bytes(8, "big"))
+    digest.update(data)
+
+
+def add_file(path, label):
+    entry_stat = os.lstat(path)
+    if not stat.S_ISREG(entry_stat.st_mode):
+        raise RuntimeError("fixture contains a non-regular file")
+    digest.update(b"F")
+    add_field(label)
+    digest.update(entry_stat.st_size.to_bytes(8, "big"))
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+
+
+def add_tree(root, label, excluded_roots=()):
+    for current, dirs, files in os.walk(root):
+        if current == root:
+            dirs[:] = sorted(name for name in dirs if name not in excluded_roots)
+        else:
+            dirs.sort()
+        files.sort()
+        relative_root = os.path.relpath(current, root)
+        for name in files:
+            relative = name if relative_root == "." else os.path.join(relative_root, name)
+            add_file(os.path.join(current, name), os.path.join(label, relative))
+
+
+add_tree(repo, "worktree", (".git",))
+add_tree(metadata_path, "rebase-merge")
+add_file(rebase_head_path, "REBASE_HEAD")
+print(digest.hexdigest())
+PY
+	) || return 1
+	current_head_ref=$(/usr/bin/git -C "$repo" symbolic-ref --quiet HEAD 2>/dev/null || true)
+	printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
+		"$content_fingerprint" \
+		"$(/usr/bin/git -C "$repo" rev-parse HEAD)" \
+		"${current_head_ref:-detached}" \
+		"$(/usr/bin/git -C "$repo" rev-parse main)" \
+		"$(/usr/bin/git -C "$repo" rev-parse origin/main)" \
+		"$(/usr/bin/git -C "$repo" write-tree)"
+	return 0
+}
+
+ABANDONED_REPO="${ROOT}/abandoned-repo"
+ABANDONED_REMOTE="${ROOT}/abandoned-remote.git"
+ABANDONED_UPDATER="${ROOT}/abandoned-updater"
+ABANDONED_RECOVERY="${ROOT}/abandoned-recovery"
+mkdir -p "$ABANDONED_REPO"
+/usr/bin/git init -q --bare "$ABANDONED_REMOTE"
+/usr/bin/git -C "$ABANDONED_REPO" init -q -b main
+/usr/bin/git -C "$ABANDONED_REPO" config user.name Test
+/usr/bin/git -C "$ABANDONED_REPO" config user.email test@example.invalid
+/usr/bin/git -C "$ABANDONED_REPO" config commit.gpgsign false
+printf 'abandoned seed\n' >"${ABANDONED_REPO}/README.md"
+/usr/bin/git -C "$ABANDONED_REPO" add README.md
+/usr/bin/git -C "$ABANDONED_REPO" commit -q -m seed
+/usr/bin/git -C "$ABANDONED_REPO" remote add origin "$ABANDONED_REMOTE"
+/usr/bin/git -C "$ABANDONED_REPO" push -q -u origin main
+/usr/bin/git -C "$ABANDONED_REMOTE" symbolic-ref HEAD refs/heads/main
+/usr/bin/git -C "$ABANDONED_REPO" remote set-head origin main
+abandoned_local_tip=$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse main)
+/usr/bin/git -C "$ABANDONED_REPO" switch -q -c abandoned-sequence
+printf 'stopped sequence\n' >"${ABANDONED_REPO}/sequence.txt"
+/usr/bin/git -C "$ABANDONED_REPO" add sequence.txt
+/usr/bin/git -C "$ABANDONED_REPO" commit -q -m 'stopped sequence'
+abandoned_stopped_sha=$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse HEAD)
+printf 'remaining sequence\n' >"${ABANDONED_REPO}/remaining.txt"
+/usr/bin/git -C "$ABANDONED_REPO" add remaining.txt
+/usr/bin/git -C "$ABANDONED_REPO" commit -q -m 'remaining sequence'
+abandoned_todo_sha=$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse HEAD)
+abandoned_todo_abbrev=$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse --short "$abandoned_todo_sha")
+/usr/bin/git -C "$ABANDONED_REPO" switch -q main
+/usr/bin/git clone -q "$ABANDONED_REMOTE" "$ABANDONED_UPDATER"
+/usr/bin/git -C "$ABANDONED_UPDATER" config user.name Test
+/usr/bin/git -C "$ABANDONED_UPDATER" config user.email test@example.invalid
+printf 'remote recovery tip\n' >>"${ABANDONED_UPDATER}/README.md"
+/usr/bin/git -C "$ABANDONED_UPDATER" commit -q -am 'remote recovery tip'
+/usr/bin/git -C "$ABANDONED_UPDATER" push -q origin main
+/usr/bin/git -C "$ABANDONED_REPO" fetch -q origin main
+abandoned_target_sha=$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse origin/main)
+/usr/bin/git -C "$ABANDONED_REPO" switch -q --detach "$abandoned_target_sha"
+abandoned_index_tree=$(/usr/bin/git -C "$ABANDONED_REPO" write-tree)
+abandoned_rewritten_sha=$(printf 'rewritten sequence\n' |
+	/usr/bin/git -C "$ABANDONED_REPO" commit-tree "$abandoned_index_tree" -p "$abandoned_local_tip")
+abandoned_amend_sha=$(printf 'amend sequence\n' |
+	/usr/bin/git -C "$ABANDONED_REPO" commit-tree "$abandoned_index_tree" -p "$abandoned_local_tip")
+abandoned_squash_sha=$(printf 'squash sequence\n' |
+	/usr/bin/git -C "$ABANDONED_REPO" commit-tree "$abandoned_index_tree" -p "$abandoned_local_tip")
+abandoned_update_ref_sha=$(printf 'update-ref sequence\n' |
+	/usr/bin/git -C "$ABANDONED_REPO" commit-tree "$abandoned_index_tree" -p "$abandoned_local_tip")
+abandoned_fixup_sha=$(printf 'current fixup sequence\n' |
+	/usr/bin/git -C "$ABANDONED_REPO" commit-tree "$abandoned_index_tree" -p "$abandoned_local_tip")
+abandoned_metadata="${ABANDONED_REPO}/.git/rebase-merge"
+abandoned_rebase_head="${ABANDONED_REPO}/.git/REBASE_HEAD"
+mkdir "$abandoned_metadata"
+printf 'refs/heads/main\n' >"${abandoned_metadata}/head-name"
+printf '%s\n' "$abandoned_local_tip" >"${abandoned_metadata}/onto"
+printf '%s\n' "$abandoned_stopped_sha" >"${abandoned_metadata}/orig-head"
+printf 'pick %s remaining-sequence\n' "$abandoned_todo_abbrev" >"${abandoned_metadata}/git-rebase-todo"
+cp "${abandoned_metadata}/git-rebase-todo" "${abandoned_metadata}/git-rebase-todo.backup"
+printf 'pick %s stopped-sequence\n' "$abandoned_stopped_sha" >"${abandoned_metadata}/done"
+printf '%s %s\n' "$abandoned_stopped_sha" "$abandoned_rewritten_sha" >"${abandoned_metadata}/rewritten-list"
+printf '%s\n' "$abandoned_amend_sha" >"${abandoned_metadata}/amend"
+printf '%s\n' "$abandoned_squash_sha" >"${abandoned_metadata}/squash-onto"
+printf 'refs/heads/example\n%s\n%s\n' "$abandoned_local_tip" "$abandoned_update_ref_sha" >"${abandoned_metadata}/update-refs"
+printf 'fixup %s subject dead cafe\n' "$abandoned_fixup_sha" >"${abandoned_metadata}/current-fixups"
+printf 'hidden marker\n' >"${abandoned_metadata}/.hidden-marker"
+printf '1\n' >"${abandoned_metadata}/msgnum"
+printf '2\n' >"${abandoned_metadata}/end"
+printf '%s\n' "$abandoned_stopped_sha" >"${abandoned_metadata}/stopped-sha"
+printf '%s\n' "$abandoned_stopped_sha" >"$abandoned_rebase_head"
+
+fresh_abandoned_snapshot=$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")
+if AIDEVOPS_CANONICAL_RECOVERY_ROOT="$ABANDONED_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-abandoned-rebase --repo "$ABANDONED_REPO" --issue 28549 \
+	--confirm CLEAR_ABANDONED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL abandoned rebase cleanup accepted fresh active metadata\n'
+	exit 1
+elif [[ -d "$abandoned_metadata" ]] && [[ -f "$abandoned_rebase_head" ]] &&
+	[[ "$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")" == "$fresh_abandoned_snapshot" ]]; then
+	printf 'PASS abandoned rebase cleanup rejects fresh active metadata without mutation\n'
+else
+	printf 'FAIL fresh abandoned rebase refusal changed repository state\n'
+	exit 1
+fi
+
+age_rebase_state_fixture "$abandoned_metadata" "$abandoned_rebase_head"
+
+/usr/bin/git -C "$ABANDONED_REPO" update-ref refs/heads/ambiguous-recovery "$abandoned_target_sha"
+/usr/bin/git -C "$ABANDONED_REPO" symbolic-ref HEAD refs/heads/ambiguous-recovery
+attached_abandoned_snapshot=$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")
+if AIDEVOPS_CANONICAL_RECOVERY_ROOT="$ABANDONED_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-abandoned-rebase --repo "$ABANDONED_REPO" --issue 28549 \
+	--confirm CLEAR_ABANDONED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL abandoned rebase cleanup accepted an attached non-default HEAD\n'
+	exit 1
+elif [[ -d "$abandoned_metadata" ]] &&
+	[[ "$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")" == "$attached_abandoned_snapshot" ]]; then
+	printf 'PASS abandoned rebase cleanup rejects ambiguous attached HEAD state\n'
+else
+	printf 'FAIL attached-HEAD refusal changed abandoned rebase state\n'
+	exit 1
+fi
+/usr/bin/git -C "$ABANDONED_REPO" update-ref --no-deref HEAD "$abandoned_target_sha"
+/usr/bin/git -C "$ABANDONED_REPO" update-ref -d refs/heads/ambiguous-recovery "$abandoned_target_sha"
+
+printf '%s\n' "$abandoned_target_sha" >"$abandoned_rebase_head"
+age_rebase_state_fixture "$abandoned_metadata" "$abandoned_rebase_head"
+malformed_abandoned_snapshot=$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")
+if AIDEVOPS_CANONICAL_RECOVERY_ROOT="$ABANDONED_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-abandoned-rebase --repo "$ABANDONED_REPO" --issue 28549 \
+	--confirm CLEAR_ABANDONED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL abandoned rebase cleanup accepted mismatched stopped commit metadata\n'
+	exit 1
+elif [[ -d "$abandoned_metadata" ]] &&
+	[[ "$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")" == "$malformed_abandoned_snapshot" ]]; then
+	printf 'PASS abandoned rebase cleanup rejects malformed stopped commit metadata\n'
+else
+	printf 'FAIL malformed-metadata refusal changed abandoned rebase state\n'
+	exit 1
+fi
+printf '%s\n' "$abandoned_stopped_sha" >"$abandoned_rebase_head"
+age_rebase_state_fixture "$abandoned_metadata" "$abandoned_rebase_head"
+
+abandoned_output=""
+abandoned_output=$(AIDEVOPS_CANONICAL_RECOVERY_ROOT="$ABANDONED_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-abandoned-rebase --repo "$ABANDONED_REPO" --issue 28549 \
+	--confirm CLEAR_ABANDONED_STALE_REBASE)
+abandoned_preserved_dir="${ABANDONED_RECOVERY}/28549/abandoned-rebase-${abandoned_target_sha}"
+abandoned_ref_base="refs/aidevops/canonical-recovery/issue-28549/abandoned-rebase"
+if [[ "$abandoned_output" == *"CLEARED_ABANDONED_STALE_REBASE=true"* ]] &&
+	[[ ! -e "$abandoned_metadata" && ! -e "$abandoned_rebase_head" ]] &&
+	[[ -d "${abandoned_preserved_dir}/rebase-merge" && -f "${abandoned_preserved_dir}/REBASE_HEAD" ]] &&
+	[[ "$(<"${abandoned_preserved_dir}/rebase-merge/.hidden-marker")" == "hidden marker" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse HEAD)" == "$abandoned_target_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse main)" == "$abandoned_local_tip" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" write-tree)" == "$abandoned_index_tree" ]] &&
+	[[ -z "$(/usr/bin/git -C "$ABANDONED_REPO" status --porcelain)" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse "${abandoned_ref_base}/${abandoned_local_tip}")" == "$abandoned_local_tip" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse "${abandoned_ref_base}/${abandoned_target_sha}")" == "$abandoned_target_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse "${abandoned_ref_base}/${abandoned_stopped_sha}")" == "$abandoned_stopped_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse "${abandoned_ref_base}/${abandoned_todo_sha}")" == "$abandoned_todo_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse "${abandoned_ref_base}/${abandoned_rewritten_sha}")" == "$abandoned_rewritten_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse "${abandoned_ref_base}/${abandoned_amend_sha}")" == "$abandoned_amend_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse "${abandoned_ref_base}/${abandoned_squash_sha}")" == "$abandoned_squash_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse "${abandoned_ref_base}/${abandoned_update_ref_sha}")" == "$abandoned_update_ref_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse "${abandoned_ref_base}/${abandoned_fixup_sha}")" == "$abandoned_fixup_sha" ]] &&
+	grep -q 'Abandoned stale rebase cleanup authorized' "$HOME/.aidevops/logs/canonical-recovery-audit.jsonl" &&
+	AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" restore-default --repo "$ABANDONED_REPO" --issue 28549 --confirm RESTORE_CANONICAL_DEFAULT >/dev/null &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" branch --show-current)" == "main" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse HEAD)" == "$abandoned_target_sha" ]]; then
+	printf 'PASS abandoned active rebase is preserved, cleared without tree changes, and restored\n'
+else
+	printf 'FAIL abandoned active rebase recovery violated preservation invariants\n'
+	exit 1
+fi
+
+/usr/bin/git -C "$ABANDONED_REPO" switch -q --detach "$abandoned_target_sha"
+mkdir "$abandoned_metadata"
+cp -R "${abandoned_preserved_dir}/rebase-merge/." "$abandoned_metadata/"
+cp "${abandoned_preserved_dir}/REBASE_HEAD" "$abandoned_rebase_head"
+age_rebase_state_fixture "$abandoned_metadata" "$abandoned_rebase_head"
+printf 'dirty\n' >"${ABANDONED_REPO}/DIRTY.md"
+dirty_abandoned_snapshot=$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")
+if AIDEVOPS_CANONICAL_RECOVERY_ROOT="$ABANDONED_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-abandoned-rebase --repo "$ABANDONED_REPO" --issue 28549 \
+	--confirm CLEAR_ABANDONED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL abandoned rebase cleanup accepted a dirty canonical worktree\n'
+	exit 1
+elif [[ "$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")" != "$dirty_abandoned_snapshot" ]]; then
+	printf 'FAIL dirty-worktree refusal changed abandoned rebase state\n'
+	exit 1
+fi
+rm "${ABANDONED_REPO}/DIRTY.md"
+printf 'PASS abandoned rebase cleanup rejects a dirty canonical worktree\n'
+
+abandoned_diverged_tip=$(printf 'local divergence\n' |
+	/usr/bin/git -C "$ABANDONED_REPO" commit-tree "$abandoned_index_tree" -p "$abandoned_target_sha")
+/usr/bin/git -C "$ABANDONED_REPO" update-ref refs/heads/main "$abandoned_diverged_tip" "$abandoned_target_sha"
+diverged_abandoned_snapshot=$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")
+if AIDEVOPS_CANONICAL_RECOVERY_ROOT="$ABANDONED_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-abandoned-rebase --repo "$ABANDONED_REPO" --issue 28549 \
+	--confirm CLEAR_ABANDONED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL abandoned rebase cleanup accepted local default divergence\n'
+	exit 1
+elif [[ -d "$abandoned_metadata" ]] &&
+	[[ "$(rebase_fixture_snapshot "$ABANDONED_REPO" "$abandoned_metadata" "$abandoned_rebase_head")" == "$diverged_abandoned_snapshot" ]]; then
+	printf 'PASS abandoned rebase cleanup rejects local default divergence without mutation\n'
+else
+	printf 'FAIL divergence refusal changed abandoned rebase state\n'
+	exit 1
+fi
+/usr/bin/git -C "$ABANDONED_REPO" update-ref refs/heads/main "$abandoned_target_sha" "$abandoned_diverged_tip"
+
+abandoned_race_hook="${ROOT}/mutate-abandoned-rebase.sh"
+# Generated hook expands its own positional argument.
+# shellcheck disable=SC2016
+printf '%s\n' '#!/usr/bin/env bash' 'printf "2\n" >"$2/msgnum"' >"$abandoned_race_hook"
+chmod +x "$abandoned_race_hook"
+if AIDEVOPS_CANONICAL_BEFORE_REBASE_CLEANUP_HOOK="$abandoned_race_hook" \
+	AIDEVOPS_CANONICAL_RECOVERY_ROOT="$ABANDONED_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-abandoned-rebase --repo "$ABANDONED_REPO" --issue 28549 \
+	--confirm CLEAR_ABANDONED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL abandoned rebase cleanup accepted concurrently changing metadata\n'
+	exit 1
+elif [[ -d "$abandoned_metadata" ]] && [[ "$(<"${abandoned_metadata}/msgnum")" == "2" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse HEAD)" == "$abandoned_target_sha" ]]; then
+	printf 'PASS abandoned rebase cleanup rejects concurrent metadata changes without cleanup\n'
+else
+	printf 'FAIL concurrent abandoned rebase refusal changed repository state\n'
+	exit 1
+fi
+
+printf '1\n' >"${abandoned_metadata}/msgnum"
+age_rebase_state_fixture "$abandoned_metadata" "$abandoned_rebase_head"
+abandoned_quarantine_race_hook="${ROOT}/mutate-quarantined-abandoned-rebase.sh"
+# Generated hook expands its own positional argument.
+# shellcheck disable=SC2016
+printf '%s\n' '#!/usr/bin/env bash' 'printf "changed after validation\n" >"$2/.hidden-marker"' \
+	>"$abandoned_quarantine_race_hook"
+chmod +x "$abandoned_quarantine_race_hook"
+if AIDEVOPS_CANONICAL_BEFORE_REBASE_QUARANTINE_HOOK="$abandoned_quarantine_race_hook" \
+	AIDEVOPS_CANONICAL_RECOVERY_ROOT="$ABANDONED_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-abandoned-rebase --repo "$ABANDONED_REPO" --issue 28549 \
+	--confirm CLEAR_ABANDONED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL abandoned rebase cleanup accepted a post-validation metadata race\n'
+	exit 1
+fi
+abandoned_quarantine_count=0
+for abandoned_quarantine_path in "${abandoned_metadata}.aidevops-quarantine."* \
+	"${abandoned_rebase_head}.aidevops-quarantine."*; do
+	[[ -e "$abandoned_quarantine_path" ]] || continue
+	abandoned_quarantine_count=$((abandoned_quarantine_count + 1))
+done
+if [[ -d "$abandoned_metadata" && -f "$abandoned_rebase_head" ]] &&
+	[[ "$(<"${abandoned_metadata}/.hidden-marker")" == "changed after validation" ]] &&
+	[[ "$abandoned_quarantine_count" -eq 0 ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse HEAD)" == "$abandoned_target_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse main)" == "$abandoned_target_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse origin/main)" == "$abandoned_target_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" write-tree)" == "$abandoned_index_tree" ]] &&
+	[[ -z "$(/usr/bin/git -C "$ABANDONED_REPO" status --porcelain)" ]]; then
+	printf 'PASS post-validation metadata races are quarantined, detected, and restored\n'
+else
+	printf 'FAIL post-validation race recovery lost or changed canonical state\n'
+	exit 1
+fi
+
+printf 'hidden marker\n' >"${abandoned_metadata}/.hidden-marker"
+age_rebase_state_fixture "$abandoned_metadata" "$abandoned_rebase_head"
+abandoned_inter_move_hook="${ROOT}/replace-rebase-head-before-directory-quarantine.sh"
+# Generated hook expands its own positional arguments.
+# shellcheck disable=SC2016
+printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "$4" >"$3"' >"$abandoned_inter_move_hook"
+chmod +x "$abandoned_inter_move_hook"
+if AIDEVOPS_CANONICAL_BEFORE_REBASE_DIRECTORY_QUARANTINE_HOOK="$abandoned_inter_move_hook" \
+	AIDEVOPS_CANONICAL_RECOVERY_ROOT="$ABANDONED_RECOVERY" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" clear-abandoned-rebase --repo "$ABANDONED_REPO" --issue 28549 \
+	--confirm CLEAR_ABANDONED_STALE_REBASE >/dev/null 2>&1; then
+	printf 'FAIL abandoned rebase cleanup accepted a replacement REBASE_HEAD race\n'
+	exit 1
+fi
+abandoned_quarantine_count=0
+for abandoned_quarantine_path in "${abandoned_metadata}.aidevops-quarantine."* \
+	"${abandoned_rebase_head}.aidevops-quarantine."*; do
+	[[ -e "$abandoned_quarantine_path" ]] || continue
+	abandoned_quarantine_count=$((abandoned_quarantine_count + 1))
+done
+if [[ -d "$abandoned_metadata" && -f "$abandoned_rebase_head" ]] &&
+	[[ "$(<"$abandoned_rebase_head")" == "$abandoned_target_sha" ]] &&
+	[[ "$abandoned_quarantine_count" -eq 0 ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse HEAD)" == "$abandoned_target_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse main)" == "$abandoned_target_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" rev-parse origin/main)" == "$abandoned_target_sha" ]] &&
+	[[ "$(/usr/bin/git -C "$ABANDONED_REPO" write-tree)" == "$abandoned_index_tree" ]] &&
+	[[ -z "$(/usr/bin/git -C "$ABANDONED_REPO" status --porcelain)" ]]; then
+	printf 'PASS replacement REBASE_HEAD races are preserved without marker theft\n'
+else
+	printf 'FAIL replacement REBASE_HEAD race lost concurrent canonical state\n'
+	exit 1
+fi
+
 SYNC_REPO="${ROOT}/sync-repo"
 SYNC_REMOTE="${ROOT}/sync-remote.git"
 SYNC_UPDATER="${ROOT}/sync-updater"


### PR DESCRIPTION
## Summary

- add a separately confirmed `clear-abandoned-rebase` operation without weakening converged cleanup
- require old, clean, detached, non-divergent stopped state and preserve complete metadata plus every referenced commit
- compare-delete the expected `REBASE_HEAD`, quarantine and re-fingerprint metadata, and restore or retain evidence on races and failures
- document the operator contract and add realistic success, refusal, preservation, and race fixtures

## Verification

- `bash .agents/scripts/tests/test-canonical-recovery-helper.sh`
- `shellcheck .agents/scripts/canonical-recovery-helper.sh .agents/scripts/tests/test-canonical-recovery-helper.sh`
- `.agents/scripts/linters-local.sh`
- independent destructive-safety review: no actionable defects remain

## Safety decisions

- fresh, attached, dirty, divergent, malformed, ambiguous, and concurrently changing state fails closed
- full and abbreviated todo, done, backup, rewritten, stopped, amend, squash, update-ref, and current-fixup commit references receive durable recovery refs
- branch, HEAD, remote ref, index tree, and worktree content remain unchanged by metadata cleanup
- `restore-default` remains a separate, explicitly confirmed follow-up operation

Resolves #28549

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.177 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1d 21h and 13,199,442 tokens on this with the user in an interactive session.