### PR TITLE
t18171: fix: use parse-safe Cloudron promotion options

### DIFF
--- a/.agents/scripts/tests/test-cloudron-package-init.sh
+++ b/.agents/scripts/tests/test-cloudron-package-init.sh
@@ -102,11 +102,19 @@ GITCONFIG
 	return 0
 }
 
+test_cloudron_publishing_command_syntax() {
+	local publishing_skill="${AGENTS_DIR}/tools/deployment/cloudron-app-publishing-skill.md"
+	assert_equal true "$(grep -Fq 'cloudron versions update --version=1.0.0 --state=published' "$publishing_skill" && printf true || printf false)" "publishing guidance uses equals-form options"
+	assert_equal false "$(grep -Fq 'cloudron versions update --version ' "$publishing_skill" && printf true || printf false)" "publishing guidance avoids global version flag collision"
+	return 0
+}
+
 main() {
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
 	test_cloudron_workflow_scaffolding
 	test_cloudron_registration_metadata
+	test_cloudron_publishing_command_syntax
 	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
 	[[ "$FAILED" -eq 0 ]] || return 1
 	return 0

--- a/.agents/tools/deployment/cloudron-app-publishing-skill.md
+++ b/.agents/tools/deployment/cloudron-app-publishing-skill.md
@@ -33,7 +33,7 @@ Distribute Cloudron apps independently using a `CloudronVersions.json` version c
 cloudron versions init  # creates CloudronVersions.json + DESCRIPTION.md, CHANGELOG, POSTINSTALL.md (edit all placeholders)
 cloudron build          # build and push image (first run prompts for Docker repository, e.g. registry/username/myapp)
 cloudron versions add --state testing  # add the registry image without exposing it as stable
-cloudron versions update --version 1.0.0 --state published
+cloudron versions update --version=1.0.0 --state=published
 # host CloudronVersions.json at a public URL
 ```
 
@@ -80,7 +80,7 @@ Build behavior depends on whether a build service is configured:
 |---------|---------|
 | `cloudron versions add` | Add current version (reads manifest + last built image) |
 | `cloudron versions list` | List all versions with date, image, and publish state |
-| `cloudron versions update --version 1.0.0 --state published` | Change publish state |
+| `cloudron versions update --version=1.0.0 --state=published` | Change publish state |
 | `cloudron versions revoke` | Mark latest published version as revoked |
 
 **Rules:** Do not change the manifest or image of a published version. Treat catalog entries as append-only release records. To ship changes: revoke only when necessary, bump the package version, rebuild, and add a new entry. Never copy a Docker tag or digest into the catalog by hand.
@@ -99,7 +99,7 @@ cloudron versions add --state testing
 cloudron versions list
 
 # 5. Promote the exact tested entry
-cloudron versions update --version 1.1.0 --state published
+cloudron versions update --version=1.1.0 --state=published
 
 # 6. Commit and push CloudronVersions.json to hosting
 git add CloudronVersions.json && git commit -m "release 1.1.0" && git push

--- a/TODO.md
+++ b/TODO.md
@@ -1198,6 +1198,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18170 Standardize Cloudron community publishing lifecycle ref:GH#28546
 
+- [ ] t18171 Fix Cloudron 7.0.4 versions update option parsing ref:GH#28556
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Use equals-form --version and --state options in Cloudron publishing guidance so CLI 7.0.4 does not treat the subcommand version value as the global version flag; add a regression test that rejects the broken spaced form.

## Files Changed

.agents/scripts/tests/test-cloudron-package-init.sh, .agents/tools/deployment/cloudron-app-publishing-skill.md, TODO.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/scripts/tests/test-cloudron-package-init.sh; .agents/scripts/linters-local.sh

Resolves #28556


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.177 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2h 48m and 1,151,914 tokens on this with the user in an interactive session.