### PR TITLE
GH#28555: Use package names in Cloudron upstream issue titles

### DIFF
--- a/.agents/scripts/cloudron-package-monitor-helper.sh
+++ b/.agents/scripts/cloudron-package-monitor-helper.sh
@@ -167,6 +167,10 @@ _cloudron_monitor_upstream_entry() {
 	repo_path="${repo_path/#\~/$HOME}"
 	local manifest_path="${repo_path}/${manifest_rel}"
 	[[ -f "$manifest_path" ]] || _cloudron_monitor_error "Manifest missing for registered Cloudron package $slug." || return 1
+	local package_title=""
+	if ! package_title=$(jq -er '.title | select(type == "string" and test("\\S"))' "$manifest_path"); then
+		_cloudron_monitor_error "Manifest title is missing or blank for registered Cloudron package $slug." || return 1
+	fi
 	local latest_tag=""
 	latest_tag=$(gh api "repos/${upstream_slug}/releases/latest" --jq '.tag_name') || return 1
 	local latest_version="${latest_tag#v}"
@@ -177,7 +181,7 @@ _cloudron_monitor_upstream_entry() {
 		return 0
 	fi
 	local fingerprint="upstream-v${latest_version}"
-	local title="Cloudron upstream v${latest_version} is available"
+	local title="${package_title} upstream v${latest_version} is available"
 	local summary=""
 	local verification=""
 	printf -v summary "Upstream package \`%s\` released \`v%s\`; the manifest currently records \`%s\`." \

--- a/.agents/scripts/tests/test-cloudron-package-monitor.sh
+++ b/.agents/scripts/tests/test-cloudron-package-monitor.sh
@@ -67,14 +67,17 @@ GH
 set -euo pipefail
 repo=""
 body_file=""
+title=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --repo) repo="${2:-}"; shift 2 ;;
         --body-file) body_file="${2:-}"; shift 2 ;;
+        --title) title="${2:-}"; shift 2 ;;
         *) shift ;;
     esac
 done
 printf 'CALL %s\n' "$repo" >>"${MONITOR_TEST_LOG}"
+printf 'TITLE %s\n' "$title" >>"${MONITOR_TEST_LOG}"
 while IFS= read -r line || [[ -n "$line" ]]; do
     printf '%s\n' "$line" >>"${MONITOR_TEST_LOG}"
 done <"$body_file"
@@ -131,6 +134,7 @@ test_monitor_deduplicates_and_preserves_source() {
 	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply >/dev/null
 	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply >/dev/null
 	assert_equal 1 "$(grep -c '^CALL exampleorg/example-package$' "$log_file")" "new upstream release creates one target-local issue"
+	assert_equal 1 "$(grep -c '^TITLE Example Package upstream v2.0.0 is available$' "$log_file")" "upstream issue title uses package manifest title"
 	grep -Fq 'upstream-v2.0.0' "$log_file" && assert_equal true true "upstream issue carries stable fingerprint" || assert_equal true false "upstream issue carries stable fingerprint"
 	assert_equal "$manifest_before" "$(cksum "${repo_dir}/CloudronManifest.json")" "upstream monitor does not mutate manifest"
 
@@ -146,10 +150,34 @@ test_monitor_deduplicates_and_preserves_source() {
 	return 0
 }
 
+test_monitor_rejects_blank_package_title() {
+	local home_dir="${TEST_ROOT}/blank-title-home"
+	local repo_dir="${TEST_ROOT}/blank-title-package"
+	local bin_dir="${TEST_ROOT}/blank-title-bin"
+	local log_file="${TEST_ROOT}/blank-title-issues.log"
+	local manifest_tmp="${TEST_ROOT}/blank-title-manifest.json"
+	write_fake_commands "$bin_dir"
+	write_fixture "$home_dir" "$repo_dir"
+	jq '.title = ""' "${repo_dir}/CloudronManifest.json" >"$manifest_tmp"
+	mv "$manifest_tmp" "${repo_dir}/CloudronManifest.json"
+	local output=""
+	local rc=0
+	if output=$(HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply 2>&1); then
+		rc=0
+	else
+		rc=$?
+	fi
+	assert_equal 1 "$rc" "blank package title fails closed"
+	[[ "$output" == *"Manifest title is missing or blank for registered Cloudron package exampleorg/example-package."* ]] && assert_equal true true "blank package title reports actionable error" || assert_equal true false "blank package title reports actionable error"
+	[[ ! -f "$log_file" ]] && assert_equal true true "blank package title creates no issue" || assert_equal true false "blank package title creates no issue"
+	return 0
+}
+
 main() {
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
 	test_monitor_deduplicates_and_preserves_source
+	test_monitor_rejects_blank_package_title
 	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
 	[[ "$FAILED" -eq 0 ]] || return 1
 	return 0


### PR DESCRIPTION
## Summary

Read each Cloudron package title from its manifest and use it in upstream-update issue titles while preserving stable deduplication fingerprints.

## Files Changed

.agents/scripts/cloudron-package-monitor-helper.sh, .agents/scripts/tests/test-cloudron-package-monitor.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused Cloudron monitor tests, ShellCheck, shfmt, default local linters, and full local linters passed.

Resolves #28555


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.177 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1d 22h and 13,585,790 tokens on this with the user in an interactive session.