### PR TITLE
GH#28559: Clarify Cloudron package repository links

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md
@@ -49,6 +49,7 @@ The `containerPort` is the port inside the container. `defaultValue` is the sugg
 | `mediaLinks` | URL array | Screenshot URLs (3:1 aspect ratio, HTTPS) |
 | `packagerName` | string | Name of package maintainer |
 | `packagerUrl` | URL | Package maintainer URL |
+| `packageUrl` | URL | Package source repository URL. Requires `minBoxVersion: 10.0.0` |
 | `documentationUrl` | URL | Link to app docs |
 | `forumUrl` | URL | Link to support forum |
 | `upstreamVersion` | string | Upstream app version (display only) |

--- a/.agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref/04-metadata.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref/04-metadata.md
@@ -21,6 +21,7 @@
 | `mediaLinks` | URL array | Screenshot URLs (3:1 aspect ratio, HTTPS) |
 | `packagerName` | string | Name of package maintainer |
 | `packagerUrl` | URL | Package maintainer URL |
+| `packageUrl` | URL | Package source repository URL. Requires `minBoxVersion: 10.0.0` |
 | `documentationUrl` | URL | Link to app docs |
 | `forumUrl` | URL | Link to support forum |
 | `upstreamVersion` | string | Upstream app version (display only) |

--- a/.agents/tools/deployment/cloudron-app-publishing-skill.md
+++ b/.agents/tools/deployment/cloudron-app-publishing-skill.md
@@ -44,12 +44,12 @@ cloudron versions update --version=1.0.0 --state=published
 Commit these before the first registry build:
 
 - `CloudronVersions.json` initialized as `{ "stable": true, "versions": {} }`; never fabricate an entry before `cloudron build` records a real registry image.
-- `CloudronManifest.json` publishing metadata: `id`, `title`, `author`, `description`, `tagline`, `version`, `website`, `contactEmail`, `iconUrl`, `packagerName`, `packagerUrl`, non-empty `tags`, non-empty `mediaLinks`, `changelog`, and `minBoxVersion` of at least `9.1.0`.
+- `CloudronManifest.json` publishing metadata: `id`, `title`, `author`, `description`, `tagline`, `version`, `website`, `contactEmail`, `iconUrl`, `packagerName`, `packagerUrl`, non-empty `tags`, non-empty `mediaLinks`, `changelog`, and `minBoxVersion` of at least `9.1.0`. Add `packageUrl` when the listing must link to the package source repository; this requires `minBoxVersion` 10.0.0.
 - A local square 256×256 PNG icon (`icon` normally points to it) and at least one privacy-reviewed product screenshot or hero. `mediaLinks` must use public HTTPS URLs; Cloudron recommends 3:1 images such as 1200×400.
 - A Cloudron-format changelog file when using `file://`: each release heading must be exactly `[X.Y.Z]`, because `cloudron versions add` does not parse Keep a Changelog headings such as `## [X.Y.Z]`.
 - A short publishing runbook that records the canonical catalog URL, registry/repository ownership, asset provenance, test install, rollback, and Community Apps listing steps without storing credentials.
 
-`packageUrl` is useful package provenance, but it requires `minBoxVersion` 10.0.0. Do not raise the minimum solely for this optional field; `packagerUrl` remains required for version-catalog publishing. `author` and `contactEmail` are deprecated in the manifest reference but are still required by the current CLI version-catalog validator.
+`packageUrl` controls the package-source link in Community Apps and should point to the package repository. It requires `minBoxVersion` 10.0.0. Keep `packagerUrl` pointed at the package maintainer; do not repurpose it as the repository link. Packages that need Cloudron 9.1 compatibility should omit `packageUrl`, while packages that require a repository link should raise the minimum explicitly. `author` and `contactEmail` are deprecated in the manifest reference but are still required by the current CLI version-catalog validator.
 
 Use package-controlled, stable asset URLs where possible. If an upstream asset is used temporarily, preserve a reviewed local copy and replace the remote reference before the upstream URL becomes unstable. Check every URL for an HTTPS 200 response and an image content type before publishing.
 


### PR DESCRIPTION
## Summary

Document packageUrl as the Community Apps package-source link, preserve packagerUrl for maintainer provenance, and record the Cloudron 10 compatibility requirement.

## Files Changed

.agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md, .agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref/04-metadata.md, .agents/tools/deployment/cloudron-app-publishing-skill.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — .agents/scripts/linters-local.sh --changed; git diff --check

Resolves #28559


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.179 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3h 40m and 1,493,661 tokens on this with the user in an interactive session.