### PR TITLE
GH#28572: defer queued ownership until launch boundary

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -2568,23 +2568,11 @@ _dispatch_launch_worker() {
 		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "claim_lock_failed" 2 || return $?
 	fi
 
-	_ds_t0=$(_ds_now_ns)
-	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json" || {
-		_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
-		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "assignment_failed" 2 || return $?
-	}
-	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
-
 	local zero_output_comment_metrics=""
 	zero_output_comment_metrics=$(_dlw_comment_bloat_metrics "$issue_number" "$repo_slug")
 	if _dlw_hold_repeated_zero_output "$issue_number" "$repo_slug" "$zero_output_comment_metrics"; then
 		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "repeated_zero_output_hold" 2 || return $?
 	fi
-
-	# t1894/t1934: Lock issue and linked PRs during worker execution
-	_ds_t0=$(_ds_now_ns)
-	lock_issue_for_worker "$issue_number" "$repo_slug"
-	_ds_record "$issue_number" "$repo_slug" "lock_issue" "$_ds_t0"
 
 	# t2981: capture pre-creation return code — skip dispatch on failure
 	# instead of falling back to canonical repo on the default branch.
@@ -2600,12 +2588,29 @@ _dispatch_launch_worker() {
 	_dlw_final_worker_spawn_gates "$issue_number" "$repo_slug" "$worker_worktree_branch" "$worker_worktree_reused" \
 		"${repo_path}/TODO.md" "$worker_worktree_path" "$issue_meta_json" "$repo_path" || return $?
 
-	_ds_t0=$(_ds_now_ns)
 	local worker_pid attempt_id="" attempt_started_at=""
 	attempt_id=$(aidevops_generate_execution_id "attempt")
 	attempt_started_at=$(_worker_attempt_start_marker)
 	local launch_prompt=""
 	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt" "$zero_output_comment_metrics")
+
+	# GH#28572: the cross-runner claim is sufficient ownership while expected
+	# pre-launch no-op gates run. Publish queued ownership and lock the issue plus
+	# linked PRs only at the final runtime boundary so those aborts cannot leak the
+	# dispatcher assignment or require avoidable rollback.
+	_ds_t0=$(_ds_now_ns)
+	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json" || {
+		_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "assignment_failed" 2 || return $?
+	}
+	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
+
+	# t1894/t1934: Lock issue and linked PRs during worker execution.
+	_ds_t0=$(_ds_now_ns)
+	lock_issue_for_worker "$issue_number" "$repo_slug"
+	_ds_record "$issue_number" "$repo_slug" "lock_issue" "$_ds_t0"
+
+	_ds_t0=$(_ds_now_ns)
 	if ! worker_pid=$(_dlw_nohup_launch "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
 		"$session_key" "$worker_log" "$launch_prompt" "$repo_path" \
 		"$dispatch_model_tier" "$selected_model" \

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -2509,8 +2509,8 @@ DLW_STAGE_CANARY_PREFLIGHT="canary_preflight"
 # Thin orchestrator for worker launch. Delegates each distinct concern
 # (assignment + labels, log files, model resolution, issue lock, repo pull,
 # worktree pre-creation, nohup launch, post-launch bookkeeping) to dedicated
-# `_dlw_*` helpers. Byte-for-byte behaviourally equivalent to the
-# pre-GH#18654 monolithic implementation.
+# `_dlw_*` helpers. GH#28572 keeps deterministic no-op gates under the
+# cross-runner claim and publishes queued ownership only at the runtime boundary.
 #
 # Arguments:
 #   $1  - issue_number
@@ -2594,10 +2594,6 @@ _dispatch_launch_worker() {
 	local launch_prompt=""
 	launch_prompt=$(_dlw_prepare_prompt_for_launch "$issue_number" "$repo_slug" "$issue_title" "$prompt" "$zero_output_comment_metrics")
 
-	# GH#28572: the cross-runner claim is sufficient ownership while expected
-	# pre-launch no-op gates run. Publish queued ownership and lock the issue plus
-	# linked PRs only at the final runtime boundary so those aborts cannot leak the
-	# dispatcher assignment or require avoidable rollback.
 	_ds_t0=$(_ds_now_ns)
 	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json" || {
 		_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -241,6 +241,7 @@ _dlw_min_worker_floor_active() { return 1; }
 _dlw_bundle_agent_name() { return 1; }
 _worker_attempt_start_marker() { printf '123\n'; return 0; }
 _dlw_exec_detached() {
+	[[ -z "${ORCHESTRATOR_CALLS_FILE:-}" ]] || printf 'spawn\n' >>"$ORCHESTRATOR_CALLS_FILE"
 	echo "SETSID_CALLED" >>"${TMP}/setsid-calls.txt"
 	printf '%s\n' "$@" >"${TMP}/launch-args.txt"
 	echo "12345"
@@ -620,14 +621,62 @@ fi
 STUB_REFRESH_STATE="OPEN"
 
 # =============================================================================
-# Test 8: assignment failure aborts before lock, worktree, and spawn
+# Tests 8-12: queued ownership starts only at the final runtime boundary
 # =============================================================================
-: >"${TMP}/lock-calls.txt"
-: >"${TMP}/precreate-calls.txt"
+ORCHESTRATOR_CALLS_FILE="${TMP}/orchestrator-calls.txt"
+ORCHESTRATOR_WORKTREE="${TMP}/orchestrator-worktree"
+mkdir -p "$ORCHESTRATOR_WORKTREE"
+STUB_HOLD_RC=1
+STUB_PRECREATE_RC=0
+STUB_FINAL_GATES_RC=0
+STUB_ASSIGN_RC=0
+
+_dlw_comment_bloat_metrics() { printf '0\t0\t0\t0\n'; return 0; }
+_dlw_hold_repeated_zero_output() {
+	printf 'hold\n' >>"$ORCHESTRATOR_CALLS_FILE"
+	return "$STUB_HOLD_RC"
+}
+_dlw_precreate_worktree() {
+	printf 'precreate\n' >>"$ORCHESTRATOR_CALLS_FILE"
+	_DLW_WORKTREE_PATH=""
+	_DLW_WORKTREE_BRANCH=""
+	_DLW_WORKTREE_REUSED=0
+	if [[ "$STUB_PRECREATE_RC" -ne 0 ]]; then
+		return "$STUB_PRECREATE_RC"
+	fi
+	_DLW_WORKTREE_PATH="$ORCHESTRATOR_WORKTREE"
+	_DLW_WORKTREE_BRANCH="feature/auto-test"
+	return 0
+}
+_dlw_final_worker_spawn_gates() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	printf 'final-gates\n' >>"$ORCHESTRATOR_CALLS_FILE"
+	if [[ "$STUB_FINAL_GATES_RC" -ne 0 ]]; then
+		_dlw_pre_runtime_failure "$issue_number" "$repo_slug" "final_dependency_recheck" "$STUB_FINAL_GATES_RC" || return $?
+	fi
+	return 0
+}
+_dlw_prepare_prompt_for_launch() {
+	printf 'prompt\n' >>"$ORCHESTRATOR_CALLS_FILE"
+	printf 'test prompt'
+	return 0
+}
+_dlw_assign_and_label() {
+	printf 'assign\n' >>"$ORCHESTRATOR_CALLS_FILE"
+	return "$STUB_ASSIGN_RC"
+}
+lock_issue_for_worker() {
+	printf 'lock\n' >>"$ORCHESTRATOR_CALLS_FILE"
+	return 0
+}
+_dlw_post_launch_hooks() { return 0; }
+
+# Assignment failure occurs after deterministic gates and prompt preparation,
+# but still before the issue lock and runtime spawn.
+: >"$ORCHESTRATOR_CALLS_FILE"
 : >"${TMP}/setsid-calls.txt"
-_dlw_assign_and_label() { return 1; }
-lock_issue_for_worker() { printf 'lock\n' >>"${TMP}/lock-calls.txt"; return 0; }
-_dlw_precreate_worktree() { printf 'precreate\n' >>"${TMP}/precreate-calls.txt"; return 0; }
+STUB_ASSIGN_RC=1
 
 assignment_failure_rc=0
 _dispatch_launch_worker "77779" "owner/repo" "test-dispatch" "Test Issue" \
@@ -637,30 +686,35 @@ if [[ "$assignment_failure_rc" -eq 2 ]]; then
 else
 	fail "assignment failure returns explicit no-op rc=2" "got rc=$assignment_failure_rc"
 fi
-if [[ ! -s "${TMP}/lock-calls.txt" && ! -s "${TMP}/precreate-calls.txt" && ! -s "${TMP}/setsid-calls.txt" ]]; then
-	pass "assignment failure prevents lock, worktree creation, and spawn"
+actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
+if [[ "$actual_calls" == "hold precreate final-gates prompt assign " && ! -s "${TMP}/setsid-calls.txt" ]]; then
+	pass "assignment failure occurs at final boundary before lock and spawn"
 else
-	fail "assignment failure prevents lock, worktree creation, and spawn"
+	fail "assignment failure occurs at final boundary before lock and spawn" "calls='$actual_calls'"
 fi
-_dlw_assign_and_label() { return 0; }
-lock_issue_for_worker() { return 0; }
+STUB_ASSIGN_RC=0
 
-# =============================================================================
-# Test 8: _dispatch_launch_worker skips dispatch when pre-creation fails
-# =============================================================================
-_dlw_canary_preflight() { return 0; }
+# A repeated-zero-output hold must stop before worktree, ownership, lock, or spawn.
+: >"$ORCHESTRATOR_CALLS_FILE"
+: >"${TMP}/setsid-calls.txt"
+STUB_HOLD_RC=0
+hold_rc=0
+_dispatch_launch_worker "77780" "owner/repo" "test-dispatch" "Test Issue" \
+	"testuser" "$FAKE_REPO" "test prompt" "session-key-hold" "" "{}" || hold_rc=$?
+actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
+if [[ "$hold_rc" -eq 2 && "$actual_calls" == "hold " && ! -s "${TMP}/setsid-calls.txt" ]]; then
+	pass "repeated-zero-output hold stops before queued ownership"
+else
+	fail "repeated-zero-output hold stops before queued ownership" "rc=$hold_rc calls='$actual_calls'"
+fi
+STUB_HOLD_RC=1
 
-# Override _dlw_precreate_worktree to simulate failure
-_dlw_precreate_worktree() {
-	_DLW_WORKTREE_PATH=""
-	_DLW_WORKTREE_BRANCH=""
-	_DLW_WORKTREE_REUSED=0
-	return 1
-}
-
+# Worktree-precreation failure must retain only the cross-runner claim.
 : >"$LOGFILE"
 : >"${TMP}/setsid-calls.txt"
 : >"$CLAIM_LOCK_CALLS_FILE"
+: >"$ORCHESTRATOR_CALLS_FILE"
+STUB_PRECREATE_RC=1
 # Reset stats file
 printf '{"counters":{}}\n' >"$PULSE_STATS_FILE"
 
@@ -680,6 +734,13 @@ else
 	fail "dispatch skip returns explicit no-op rc=2" "got rc=$launch_rc"
 fi
 
+actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
+if [[ "$actual_calls" == "hold precreate " ]]; then
+	pass "pre-creation failure stops before final gates and queued ownership"
+else
+	fail "pre-creation failure stops before final gates and queued ownership" "calls='$actual_calls'"
+fi
+
 if [[ "${_DLW_LAST_PRE_RUNTIME_FAILURE:-}" == "worktree_precreation_failed" ]] && \
 	grep -q "PRE_RUNTIME_FAILURE issue=77777 repo=owner/repo reason=worktree_precreation_failed" "$LOGFILE" 2>/dev/null; then
 	pass "pre-runtime failure records issue-correlated worktree reason"
@@ -692,9 +753,38 @@ if grep -q '^77777$' "$CLAIM_LOCK_CALLS_FILE" 2>/dev/null; then
 else
 	fail "pre-creation failure happens after claim lock" "claim lock not called"
 fi
+STUB_PRECREATE_RC=0
+
+# Final dependency/orphan gate failures likewise stop before queued ownership.
+: >"$ORCHESTRATOR_CALLS_FILE"
+: >"${TMP}/setsid-calls.txt"
+STUB_FINAL_GATES_RC=2
+final_gate_rc=0
+_dispatch_launch_worker "77781" "owner/repo" "test-dispatch" "Test Issue" \
+	"testuser" "$FAKE_REPO" "test prompt" "session-key-final-gate" "" "{}" || final_gate_rc=$?
+actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
+if [[ "$final_gate_rc" -eq 2 && "$actual_calls" == "hold precreate final-gates " && ! -s "${TMP}/setsid-calls.txt" ]]; then
+	pass "final spawn gate failure stops before queued ownership"
+else
+	fail "final spawn gate failure stops before queued ownership" "rc=$final_gate_rc calls='$actual_calls'"
+fi
+STUB_FINAL_GATES_RC=0
+
+# The successful path publishes ownership and locks only immediately before spawn.
+: >"$ORCHESTRATOR_CALLS_FILE"
+: >"${TMP}/setsid-calls.txt"
+success_rc=0
+_dispatch_launch_worker "77782" "owner/repo" "test-dispatch" "Test Issue" \
+	"testuser" "$FAKE_REPO" "test prompt" "session-key-success" "" "{}" || success_rc=$?
+actual_calls=$(tr '\n' ' ' <"$ORCHESTRATOR_CALLS_FILE")
+if [[ "$success_rc" -eq 0 && "$actual_calls" == "hold precreate final-gates prompt assign lock spawn " && -s "${TMP}/setsid-calls.txt" ]]; then
+	pass "successful launch acquires queued ownership at final boundary"
+else
+	fail "successful launch acquires queued ownership at final boundary" "rc=$success_rc calls='$actual_calls'"
+fi
 
 # =============================================================================
-# Test 9: worktree_precreation_failed_count counter is incremented
+# Worktree-precreation failure observability remains intact
 # =============================================================================
 local_count=""
 if command -v jq &>/dev/null; then


### PR DESCRIPTION
## Summary

Defers dispatcher assignment, status:queued, and issue/linked-PR locking until repeated-zero-output, worktree, final dependency, and prompt gates pass; adds focused call-order regressions.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/tests/test-precreation-failure-skip.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified by 42 launch/precreation tests, 16 lifecycle rollback tests, and 6 stale no-worker tests; ShellCheck, bash -n, git diff --check, and linters-local passed.

Resolves #28572


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1h 13m and 1,075,649 tokens on this with the user in an interactive session.