### PR TITLE
GH#28564: Reap orphaned GitHub API scratch files

### DIFF
--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -62,6 +62,9 @@
 #   AIDEVOPS_GH_API_RETENTION_SECONDS — maximum record age (default 172800)
 #   AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES — 10ms waits before reclaiming an
 #                                   empty lock directory (default 100)
+#   AIDEVOPS_GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS — minimum age before exact
+#                                   legacy .source/.tmp/.trim files are reaped
+#                                   (default 3600)
 #   AIDEVOPS_GH_API_INSTRUMENT_DISABLE=1 — make all calls no-ops
 #
 # Part of aidevops framework: https://aidevops.sh
@@ -117,6 +120,9 @@ GH_API_RETENTION_SECONDS="${AIDEVOPS_GH_API_RETENTION_SECONDS:-$_GH_API_DEFAULT_
 GH_API_ERROR_KEY="error"
 _GH_API_EMPTY_LOCK_GRACE_TRIES="${AIDEVOPS_GH_API_EMPTY_LOCK_GRACE_TRIES:-100}"
 [[ "$_GH_API_EMPTY_LOCK_GRACE_TRIES" =~ ^[0-9]+$ ]] || _GH_API_EMPTY_LOCK_GRACE_TRIES=100
+_GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS="${AIDEVOPS_GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS:-3600}"
+[[ "$_GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS" =~ ^[0-9]+$ ]] || _GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS=3600
+_GH_API_SCRATCH_DIR=""
 
 _gh_now_seconds() {
 	local now=""
@@ -137,6 +143,115 @@ _gh_now_ms() {
 		now=$((now * 1000))
 	fi
 	printf '%s\n' "$now"
+	return 0
+}
+
+_gh_file_mtime_epoch() {
+	local file="$1"
+	local modified=""
+	modified=$(stat --format='%Y' "$file" 2>/dev/null) || modified=$(stat -f '%m' "$file" 2>/dev/null) || return 1
+	[[ "$modified" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$modified"
+	return 0
+}
+
+_gh_managed_scratch_owner_pid() {
+	local basename="$1"
+	if [[ "$basename" =~ ^(report|source|trim)\.([1-9][0-9]*)\.[[:alnum:]]{6}$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[2]}"
+		return 0
+	fi
+	return 1
+}
+
+# Remove only framework-owned scratch files whose filename carries a dead
+# creator PID. The private directory and exact basename grammar keep unrelated
+# files and symlinks outside the deletion boundary.
+_gh_cleanup_managed_scratch() {
+	local scratch_dir="$1"
+	local candidate=""
+	local basename=""
+	local owner_pid=""
+	[[ -d "$scratch_dir" && ! -L "$scratch_dir" && -O "$scratch_dir" ]] || return 1
+	for candidate in \
+		"$scratch_dir"/report.*.* \
+		"$scratch_dir"/source.*.* \
+		"$scratch_dir"/trim.*.*; do
+		[[ -f "$candidate" && ! -L "$candidate" && -O "$candidate" ]] || continue
+		basename="${candidate##*/}"
+		owner_pid=$(_gh_managed_scratch_owner_pid "$basename") || continue
+		if ! kill -0 "$owner_pid" 2>/dev/null; then
+			rm -f "$candidate" 2>/dev/null || true
+		fi
+	done
+	return 0
+}
+
+# Scratch files that must be renamed atomically live in a private child of the
+# destination directory. This preserves same-filesystem rename semantics while
+# keeping transient files out of the durable log namespace.
+_gh_prepare_scratch_dir() {
+	local target="$1"
+	local target_dir="."
+	local scratch_dir=""
+	[[ -n "$target" ]] || return 1
+	if [[ "$target" == */* ]]; then
+		target_dir="${target%/*}"
+		[[ -n "$target_dir" ]] || target_dir="/"
+	fi
+	[[ -d "$target_dir" && ! -L "$target_dir" && -O "$target_dir" ]] || return 1
+	scratch_dir="${target_dir%/}/.gh-api-instrument-scratch"
+	[[ -n "$scratch_dir" ]] || return 1
+	if [[ ! -e "$scratch_dir" && ! -L "$scratch_dir" ]]; then
+		if ! (umask 077 && mkdir "$scratch_dir" 2>/dev/null); then
+			[[ -d "$scratch_dir" && ! -L "$scratch_dir" ]] || return 1
+		fi
+	fi
+	[[ -d "$scratch_dir" && ! -L "$scratch_dir" && -O "$scratch_dir" ]] || return 1
+	chmod 0700 "$scratch_dir" 2>/dev/null || return 1
+	_GH_API_SCRATCH_DIR="$scratch_dir"
+	_gh_cleanup_managed_scratch "$scratch_dir" || return 1
+	return 0
+}
+
+# Migrate exact pre-owner scratch names left by older releases. These files do
+# not encode a PID, so deletion is restricted to regular user-owned files under
+# configured output prefixes and a conservative age floor.
+_gh_cleanup_legacy_scratch() {
+	local candidate=""
+	local candidate_dir="."
+	local legacy_prefix=""
+	local legacy_suffix=""
+	local modified=""
+	local now=""
+	local age=0
+	now=$(_gh_now_seconds) || return 0
+	for candidate in \
+		"${GH_API_REPORT}.source."* \
+		"${GH_API_REPORT}.tmp."* \
+		"${GH_API_LOG}.trim."*; do
+		[[ -f "$candidate" && ! -L "$candidate" && -O "$candidate" ]] || continue
+		case "$candidate" in
+		"${GH_API_REPORT}.source."*) legacy_prefix="${GH_API_REPORT}.source." ;;
+		"${GH_API_REPORT}.tmp."*) legacy_prefix="${GH_API_REPORT}.tmp." ;;
+		"${GH_API_LOG}.trim."*) legacy_prefix="${GH_API_LOG}.trim." ;;
+		*) continue ;;
+		esac
+		legacy_suffix="${candidate#"$legacy_prefix"}"
+		[[ "$legacy_suffix" =~ ^[[:alnum:]]{6}$ ]] || continue
+		if [[ "$candidate" == */* ]]; then
+			candidate_dir="${candidate%/*}"
+			[[ -n "$candidate_dir" ]] || candidate_dir="/"
+		else
+			candidate_dir="."
+		fi
+		[[ -d "$candidate_dir" && ! -L "$candidate_dir" && -O "$candidate_dir" ]] || continue
+		modified=$(_gh_file_mtime_epoch "$candidate") || continue
+		[[ "$now" -ge "$modified" ]] || continue
+		age=$((now - modified))
+		[[ "$age" -ge "$_GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS" ]] || continue
+		rm -f "$candidate" 2>/dev/null || true
+	done
 	return 0
 }
 
@@ -584,7 +699,9 @@ gh_aggregate_calls() {
 	local tmp=""
 	local snapshot=""
 	local awk_script=""
+	local owner_pid="${BASHPID:-$$}"
 	[[ "$window" =~ ^[1-9][0-9]*$ ]] || window=86400
+	[[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || return 1
 	current_now=$(_gh_now_seconds) || return 1
 	now="$current_now"
 	if [[ -n "$requested_end" ]]; then
@@ -596,7 +713,9 @@ gh_aggregate_calls() {
 		out_dir="${out%/*}"
 	fi
 	mkdir -p "$out_dir" 2>/dev/null || return 1
-	tmp=$(mktemp "${out}.tmp.XXXXXX" 2>/dev/null) || return 1
+	_gh_cleanup_legacy_scratch || true
+	_gh_prepare_scratch_dir "$out" || return 1
+	tmp=$(mktemp "${_GH_API_SCRATCH_DIR}/report.${owner_pid}.XXXXXX" 2>/dev/null) || return 1
 	chmod 600 "$tmp" 2>/dev/null || {
 		rm -f "$tmp"
 		return 1
@@ -620,7 +739,7 @@ gh_aggregate_calls() {
 		mv "$tmp" "$out" 2>/dev/null || rm -f "$tmp"
 		return 1
 	fi
-	snapshot=$(mktemp "${out}.source.XXXXXX" 2>/dev/null) || {
+	snapshot=$(mktemp "${_GH_API_SCRATCH_DIR}/source.${owner_pid}.XXXXXX" 2>/dev/null) || {
 		rm -f "$tmp"
 		return 1
 	}
@@ -650,17 +769,26 @@ gh_aggregate_calls() {
 # bounds. Appenders share the same short-lived lock so replacement cannot lose
 # a concurrent record. The original remains untouched if filtering fails.
 gh_trim_log() {
-	[[ -f "$GH_API_LOG" ]] || return 0
 	local now=""
 	local cutoff=0
 	local tmp=""
+	local owner_pid="${BASHPID:-$$}"
+	_gh_cleanup_legacy_scratch || true
+	[[ -f "$GH_API_LOG" ]] || return 0
+	[[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || return 0
 	[[ "$GH_API_LOG_MAX_LINES" =~ ^[0-9]+$ && "$GH_API_LOG_MAX_LINES" -gt 0 ]] || GH_API_LOG_MAX_LINES="$_GH_API_DEFAULT_LOG_MAX_LINES"
 	[[ "$GH_API_LOG_MAX_BYTES" =~ ^[0-9]+$ && "$GH_API_LOG_MAX_BYTES" -gt 0 ]] || GH_API_LOG_MAX_BYTES="$_GH_API_DEFAULT_LOG_MAX_BYTES"
 	[[ "$GH_API_RETENTION_SECONDS" =~ ^[0-9]+$ && "$GH_API_RETENTION_SECONDS" -gt 0 ]] || GH_API_RETENTION_SECONDS="$_GH_API_DEFAULT_RETENTION_SECONDS"
 	now=$(_gh_now_seconds) || return 0
 	cutoff=$((now - GH_API_RETENTION_SECONDS))
+	_gh_prepare_scratch_dir "$GH_API_LOG" || return 0
 	_gh_log_lock_acquire || return 0
-	tmp=$(mktemp "${GH_API_LOG}.trim.XXXXXX") || {
+	tmp=$(mktemp "${_GH_API_SCRATCH_DIR}/trim.${owner_pid}.XXXXXX") || {
+		_gh_log_lock_release
+		return 0
+	}
+	chmod 0600 "$tmp" 2>/dev/null || {
+		rm -f "$tmp" 2>/dev/null || true
 		_gh_log_lock_release
 		return 0
 	}

--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -77,6 +77,18 @@ _GH_API_INSTRUMENT_LOADED=1
 # Apply strict mode only when executed directly (not when sourced).
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
 
+# Legacy scratch cleanup needs portable file timestamps, but this helper is
+# also sourced standalone by the gh shim. Load only the focused stat library;
+# sourcing shared-constants.sh here would create a circular dependency through
+# shared-gh-wrappers.sh.
+_GH_API_INSTRUMENT_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$_GH_API_INSTRUMENT_DIR" == "${BASH_SOURCE[0]}" ]] && _GH_API_INSTRUMENT_DIR="."
+if ! command -v _file_mtime_epoch >/dev/null 2>&1 &&
+	[[ -f "${_GH_API_INSTRUMENT_DIR}/portable-stat.sh" ]]; then
+	# shellcheck source=portable-stat.sh
+	source "${_GH_API_INSTRUMENT_DIR}/portable-stat.sh"
+fi
+
 # --- Configuration --------------------------------------------------------
 _GH_API_HOME="${HOME:-}"
 if [[ -z "$_GH_API_HOME" ]]; then
@@ -143,15 +155,6 @@ _gh_now_ms() {
 		now=$((now * 1000))
 	fi
 	printf '%s\n' "$now"
-	return 0
-}
-
-_gh_file_mtime_epoch() {
-	local file="$1"
-	local modified=""
-	modified=$(stat --format='%Y' "$file" 2>/dev/null) || modified=$(stat -f '%m' "$file" 2>/dev/null) || return 1
-	[[ "$modified" =~ ^[0-9]+$ ]] || return 1
-	printf '%s\n' "$modified"
 	return 0
 }
 
@@ -225,6 +228,7 @@ _gh_cleanup_legacy_scratch() {
 	local modified=""
 	local now=""
 	local age=0
+	command -v _file_mtime_epoch >/dev/null 2>&1 || return 0
 	now=$(_gh_now_seconds) || return 0
 	for candidate in \
 		"${GH_API_REPORT}.source."* \
@@ -246,7 +250,7 @@ _gh_cleanup_legacy_scratch() {
 			candidate_dir="."
 		fi
 		[[ -d "$candidate_dir" && ! -L "$candidate_dir" && -O "$candidate_dir" ]] || continue
-		modified=$(_gh_file_mtime_epoch "$candidate") || continue
+		modified=$(_file_mtime_epoch "$candidate") || continue
 		[[ "$now" -ge "$modified" ]] || continue
 		age=$((now - modified))
 		[[ "$age" -ge "$_GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS" ]] || continue

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -63,6 +63,19 @@ assert_file_exists() {
 	return 1
 }
 
+assert_path_absent() {
+	local label="$1"
+	local path="$2"
+	if [[ ! -e "$path" && ! -L "$path" ]]; then
+		echo "  PASS: $label"
+		PASS=$((PASS + 1))
+		return 0
+	fi
+	echo "  FAIL: $label (unexpected path: $path)"
+	FAIL=$((FAIL + 1))
+	return 1
+}
+
 echo "Test: gh-api-instrument.sh recording and aggregation"
 echo "===================================================="
 echo ""
@@ -906,6 +919,215 @@ PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
 	GH_SHIM_FIXTURE="$SHIM_FIXTURE/gh" \
 	bash -euo pipefail "$SHIM_FIXTURE/parent-caller.sh"
 assert_eq "interpreter flags preserve framework caller attribution" "2" "$(awk -F'\t' '$9 == "attempt" && $2 == "parent-caller.sh" { count++ } END { print count + 0 }' "$AIDEVOPS_GH_API_LOG")"
+
+# --- Test 16: managed scratch cleanup is owner-aware and exact ---------------
+scratch_fixture="$TMPDIR/managed-scratch"
+mkdir -p "$scratch_fixture"
+export AIDEVOPS_GH_API_LOG="$scratch_fixture/gh-api-calls.log"
+export AIDEVOPS_GH_API_REPORT="$scratch_fixture/report.json"
+export AIDEVOPS_GH_API_EVIDENCE="$scratch_fixture/evidence.json"
+export AIDEVOPS_GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS=3600
+unset _GH_API_INSTRUMENT_LOADED
+# shellcheck source=../gh-api-instrument.sh
+source "${PARENT_DIR}/gh-api-instrument.sh"
+
+_gh_prepare_scratch_dir "$GH_API_REPORT"
+scratch_dir="$scratch_fixture/.gh-api-instrument-scratch"
+assert_eq "managed scratch is target-adjacent for atomic rename" "$scratch_dir" "$_GH_API_SCRATCH_DIR"
+scratch_mode=$(stat -f '%Lp' "$scratch_dir" 2>/dev/null || stat -c '%a' "$scratch_dir" 2>/dev/null)
+assert_eq "managed scratch directory is private" "700" "$scratch_mode"
+
+dead_pid=999999999
+while kill -0 "$dead_pid" 2>/dev/null; do
+	dead_pid=$((dead_pid - 1))
+done
+live_pid="${BASHPID:-$$}"
+dead_report="$scratch_dir/report.${dead_pid}.ABC123"
+dead_source="$scratch_dir/source.${dead_pid}.DEF456"
+dead_trim="$scratch_dir/trim.${dead_pid}.GHI789"
+live_source="$scratch_dir/source.${live_pid}.LIV123"
+invalid_suffix="$scratch_dir/report.${dead_pid}.ABC12_"
+unrelated_file="$scratch_dir/unrelated.${dead_pid}.ABC123"
+symlink_target="$scratch_fixture/symlink-target"
+scratch_symlink="$scratch_dir/source.${dead_pid}.SYM123"
+printf 'dead report\n' >"$dead_report"
+printf 'dead source\n' >"$dead_source"
+printf 'dead trim\n' >"$dead_trim"
+printf 'live source\n' >"$live_source"
+printf 'invalid suffix\n' >"$invalid_suffix"
+printf 'unrelated\n' >"$unrelated_file"
+printf 'target\n' >"$symlink_target"
+ln -s "$symlink_target" "$scratch_symlink"
+
+assert_eq "managed scratch parser returns creator PID" "$dead_pid" "$(_gh_managed_scratch_owner_pid "report.${dead_pid}.ABC123")"
+invalid_owner_status=0
+_gh_managed_scratch_owner_pid "report.${dead_pid}.ABC12_" >/dev/null || invalid_owner_status=$?
+assert_eq "managed scratch parser rejects non-exact suffixes" "1" "$invalid_owner_status"
+_gh_cleanup_managed_scratch "$scratch_dir"
+assert_path_absent "dead-owner report scratch is reaped" "$dead_report"
+assert_path_absent "dead-owner source scratch is reaped" "$dead_source"
+assert_path_absent "dead-owner trim scratch is reaped" "$dead_trim"
+assert_file_exists "live-owner scratch is preserved" "$live_source"
+assert_file_exists "non-exact managed filename is preserved" "$invalid_suffix"
+assert_file_exists "unrelated managed-directory file is preserved" "$unrelated_file"
+assert_eq "managed scratch symlink is preserved" "yes" "$([[ -L "$scratch_symlink" ]] && printf 'yes' || printf 'no')"
+assert_file_exists "managed scratch symlink target is untouched" "$symlink_target"
+
+# SIGKILL aggregate fixture: replace cp in the child only. The wrapper copies
+# the snapshot, then kills its parent before normal report/source cleanup.
+kill_bin="$scratch_fixture/kill-bin"
+aggregate_marker="$scratch_fixture/aggregate-killed.marker"
+aggregate_owner_pid_file="$scratch_fixture/aggregate-owner.pid"
+mkdir -p "$kill_bin"
+cat >"$kill_bin/cp" <<'EOF_KILL_CP'
+#!/usr/bin/env bash
+set -euo pipefail
+/bin/cp "$@"
+printf 'ready\n' >"$GH_API_KILL_MARKER"
+kill -KILL "$PPID"
+exit 137
+EOF_KILL_CP
+chmod +x "$kill_bin/cp"
+cat >"$kill_bin/run-sigkill-fixture" <<'EOF_SIGKILL_RUNNER'
+#!/usr/bin/env bash
+set +e
+bash -c '
+	printf "%s\n" "${BASHPID:-$$}" >"$GH_API_OWNER_PID_FILE"
+	unset _GH_API_INSTRUMENT_LOADED
+	source "$1"
+	case "$2" in
+	aggregate) gh_aggregate_calls "$GH_API_REPORT_PATH" ;;
+	trim) gh_trim_log ;;
+	*) exit 2 ;;
+	esac
+' _ "$GH_API_INSTRUMENT_SCRIPT" "$GH_API_KILL_MODE"
+fixture_status=$?
+exit "$fixture_status"
+EOF_SIGKILL_RUNNER
+chmod +x "$kill_bin/run-sigkill-fixture"
+gh_clear_log
+gh_record_call rest scratch-sigkill-aggregate
+set +e
+PATH="$kill_bin:$PATH" GH_API_KILL_MARKER="$aggregate_marker" \
+	AIDEVOPS_GH_API_LOG="$GH_API_LOG" AIDEVOPS_GH_API_REPORT="$GH_API_REPORT" \
+	GH_API_OWNER_PID_FILE="$aggregate_owner_pid_file" GH_API_KILL_MODE=aggregate \
+	GH_API_INSTRUMENT_SCRIPT="${PARENT_DIR}/gh-api-instrument.sh" GH_API_REPORT_PATH="$GH_API_REPORT" \
+	"$kill_bin/run-sigkill-fixture" >/dev/null 2>&1
+aggregate_kill_status=$?
+set -e
+aggregate_kill_pid=$(<"$aggregate_owner_pid_file")
+assert_eq "aggregate SIGKILL fixture reached snapshot copy" "yes" "$([[ -f "$aggregate_marker" ]] && printf 'yes' || printf 'no')"
+assert_eq "aggregate fixture exits from SIGKILL" "137" "$aggregate_kill_status"
+shopt -s nullglob
+aggregate_orphans=(
+	"$scratch_dir/report.${aggregate_kill_pid}."*
+	"$scratch_dir/source.${aggregate_kill_pid}."*
+)
+shopt -u nullglob
+assert_eq "aggregate SIGKILL leaves owner-tagged report and source scratch" "2" "${#aggregate_orphans[@]}"
+for aggregate_orphan in "${aggregate_orphans[@]}"; do
+	aggregate_orphan_mode=$(stat -f '%Lp' "$aggregate_orphan" 2>/dev/null || stat -c '%a' "$aggregate_orphan" 2>/dev/null)
+	assert_eq "aggregate scratch remains private after SIGKILL" "600" "$aggregate_orphan_mode"
+done
+_gh_cleanup_managed_scratch "$scratch_dir"
+shopt -s nullglob
+aggregate_orphans=(
+	"$scratch_dir/report.${aggregate_kill_pid}."*
+	"$scratch_dir/source.${aggregate_kill_pid}."*
+)
+shopt -u nullglob
+assert_eq "next cleanup reaps aggregate SIGKILL scratch" "0" "${#aggregate_orphans[@]}"
+gh_record_call rest scratch-post-aggregate-recovery
+assert_eq "aggregate SIGKILL lock is recoverable" "2" "$(wc -l <"$GH_API_LOG" | tr -d ' ')"
+
+# SIGKILL trim fixture: replace awk in the child so the process dies after its
+# owner-tagged trim file and lock exist but before atomic replacement.
+trim_marker="$scratch_fixture/trim-killed.marker"
+trim_owner_pid_file="$scratch_fixture/trim-owner.pid"
+cat >"$kill_bin/awk" <<'EOF_KILL_AWK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ready\n' >"$GH_API_KILL_MARKER"
+kill -KILL "$PPID"
+exit 137
+EOF_KILL_AWK
+chmod +x "$kill_bin/awk"
+set +e
+PATH="$kill_bin:$PATH" GH_API_KILL_MARKER="$trim_marker" \
+	AIDEVOPS_GH_API_LOG="$GH_API_LOG" AIDEVOPS_GH_API_REPORT="$GH_API_REPORT" \
+	GH_API_OWNER_PID_FILE="$trim_owner_pid_file" GH_API_KILL_MODE=trim \
+	GH_API_INSTRUMENT_SCRIPT="${PARENT_DIR}/gh-api-instrument.sh" GH_API_REPORT_PATH="$GH_API_REPORT" \
+	"$kill_bin/run-sigkill-fixture" >/dev/null 2>&1
+trim_kill_status=$?
+set -e
+trim_kill_pid=$(<"$trim_owner_pid_file")
+assert_eq "trim SIGKILL fixture reached retention filter" "yes" "$([[ -f "$trim_marker" ]] && printf 'yes' || printf 'no')"
+assert_eq "trim fixture exits from SIGKILL" "137" "$trim_kill_status"
+shopt -s nullglob
+trim_orphans=("$scratch_dir/trim.${trim_kill_pid}."*)
+shopt -u nullglob
+assert_eq "trim SIGKILL leaves one owner-tagged scratch file" "1" "${#trim_orphans[@]}"
+trim_orphan_mode=$(stat -f '%Lp' "${trim_orphans[0]}" 2>/dev/null || stat -c '%a' "${trim_orphans[0]}" 2>/dev/null)
+assert_eq "trim scratch remains private after SIGKILL" "600" "$trim_orphan_mode"
+_gh_cleanup_managed_scratch "$scratch_dir"
+shopt -s nullglob
+trim_orphans=("$scratch_dir/trim.${trim_kill_pid}."*)
+shopt -u nullglob
+assert_eq "next cleanup reaps trim SIGKILL scratch" "0" "${#trim_orphans[@]}"
+gh_trim_log
+assert_eq "trim SIGKILL lock is recoverable" "no" "$([[ -d "${GH_API_LOG}.lock" ]] && printf 'yes' || printf 'no')"
+trimmed_log_mode=$(stat -f '%Lp' "$GH_API_LOG" 2>/dev/null || stat -c '%a' "$GH_API_LOG" 2>/dev/null)
+assert_eq "trim replacement keeps the durable log private" "600" "$trimmed_log_mode"
+
+# Legacy migration is age-gated and accepts only the exact historical six-
+# character mktemp suffixes. Symlinks, recent files, and near-matches survive.
+legacy_source="${GH_API_REPORT}.source.LEG123"
+legacy_report="${GH_API_REPORT}.tmp.LEG456"
+legacy_trim="${GH_API_LOG}.trim.LEG789"
+legacy_recent="${GH_API_REPORT}.source.NEW123"
+legacy_near_match="${GH_API_REPORT}.source.TOOLONG"
+legacy_symlink_target="$scratch_fixture/legacy-symlink-target"
+legacy_symlink="${GH_API_LOG}.trim.SYM123"
+printf 'legacy source\n' >"$legacy_source"
+printf 'legacy report\n' >"$legacy_report"
+printf 'legacy trim\n' >"$legacy_trim"
+printf 'recent\n' >"$legacy_recent"
+printf 'near match\n' >"$legacy_near_match"
+printf 'target\n' >"$legacy_symlink_target"
+ln -s "$legacy_symlink_target" "$legacy_symlink"
+python3 - "$legacy_source" "$legacy_report" "$legacy_trim" "$legacy_near_match" <<'PY_LEGACY_MTIME'
+import os
+import sys
+import time
+
+old = time.time() - 7200
+for path in sys.argv[1:]:
+    os.utime(path, (old, old))
+PY_LEGACY_MTIME
+_gh_cleanup_legacy_scratch
+assert_path_absent "old exact legacy source scratch is removed" "$legacy_source"
+assert_path_absent "old exact legacy report scratch is removed" "$legacy_report"
+assert_path_absent "old exact legacy trim scratch is removed" "$legacy_trim"
+assert_file_exists "recent exact legacy scratch is preserved" "$legacy_recent"
+assert_file_exists "old near-match legacy file is preserved" "$legacy_near_match"
+assert_eq "legacy scratch symlink is preserved" "yes" "$([[ -L "$legacy_symlink" ]] && printf 'yes' || printf 'no')"
+assert_file_exists "legacy scratch symlink target is untouched" "$legacy_symlink_target"
+invalid_legacy_age=$(AIDEVOPS_GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS=invalid bash -c '
+	# shellcheck source=/dev/null
+	source "$1"
+	printf "%s\n" "$_GH_API_LEGACY_SCRATCH_MIN_AGE_SECONDS"
+' _ "${PARENT_DIR}/gh-api-instrument.sh")
+assert_eq "invalid legacy scratch age uses the safe default" "3600" "$invalid_legacy_age"
+
+# A pre-created symlink cannot redirect the managed scratch directory.
+bad_scratch_parent="$TMPDIR/bad-scratch-parent"
+bad_scratch_target="$TMPDIR/bad-scratch-target"
+mkdir -p "$bad_scratch_parent" "$bad_scratch_target"
+ln -s "$bad_scratch_target" "$bad_scratch_parent/.gh-api-instrument-scratch"
+bad_scratch_status=0
+_gh_prepare_scratch_dir "$bad_scratch_parent/report.json" || bad_scratch_status=$?
+assert_eq "managed scratch rejects a pre-created directory symlink" "1" "$bad_scratch_status"
+assert_eq "rejected scratch symlink target stays empty" "0" "$(ls -A "$bad_scratch_target" | wc -l | tr -d ' ')"
 
 # --- Summary ----------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Move report, snapshot, and trim scratch files into a private owner-tagged directory and reap only exact dead-owner or age-qualified legacy artifacts.

## Files Changed

.agents/scripts/gh-api-instrument.sh, .agents/scripts/tests/test-gh-api-instrument.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — 188 focused tests passed; ShellCheck passed for implementation and tests; changed-file local quality gates passed, including Bash 3.2 compatibility, portability, complexity, secret, and whitespace checks.

Resolves #28564


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 1h 42m and 742,893 tokens on this with the user in an interactive session.