### PR TITLE
GH#28566: clear stale worker blocker state on issue closure

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs
@@ -11,7 +11,9 @@ import { fileURLToPath } from "node:url";
 
 import {
   appendWorkerBlockerEvent,
+  listActiveWorkerBlockerIssues,
   normalizeWorkerBlockerEvent,
+  resolveWorkerBlockersForIssue,
   WORKER_BLOCKER_SCHEMA,
 } from "../../../scripts/worker-blocker-log.mjs";
 
@@ -77,6 +79,99 @@ test("append fails open when the parent path is not a directory", () => {
     { event: "permission_blocked" },
     { logPath: join(parentFile, "events.jsonl") },
   ), false);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("resolve-issue clears every active identity exactly once and preserves correlation", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-blocker-resolve-"));
+  const logPath = join(root, "events.jsonl");
+  const base = {
+    reason: "permission_required",
+    source: "test",
+    issue_number: 123,
+    repo_slug: "Owner/Repo",
+  };
+  assert.equal(appendWorkerBlockerEvent({
+    ...base,
+    event: "permission_request_captured",
+    session_key: "issue-123",
+    request_id: "request-a",
+  }, { logPath, now: new Date("2026-07-24T12:00:00Z") }), true);
+  assert.equal(appendWorkerBlockerEvent({
+    ...base,
+    event: "permission_request_non_grantable",
+    session_key: "issue-123-retry",
+    request_id: "request-b",
+  }, { logPath, now: new Date("2026-07-24T12:00:01Z") }), true);
+  assert.equal(appendWorkerBlockerEvent({
+    ...base,
+    event: "permission_grant_applied",
+    blocking: false,
+    session_key: "issue-123-cleared",
+    request_id: "request-c",
+  }, { logPath, now: new Date("2026-07-24T12:00:02Z") }), true);
+  assert.equal(appendWorkerBlockerEvent({
+    ...base,
+    issue_number: 124,
+    session_key: "issue-124",
+  }, { logPath, now: new Date("2026-07-24T12:00:03Z") }), true);
+
+  const resolution = resolveWorkerBlockersForIssue({
+    issue_number: "123",
+    repo_slug: "OWNER/REPO",
+    event: "issue_terminal_reconciled",
+    reason: "issue_closed_completed",
+    source: "dispatch-label-cleanup",
+  }, { logPath, now: new Date("2026-07-24T12:00:04Z") });
+  assert.deepEqual(resolution, { ok: true, resolvedCount: 2 });
+
+  const events = readFileSync(logPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+  const terminal = events.filter((event) => event.event === "issue_terminal_reconciled");
+  assert.deepEqual(new Set(terminal.map((event) => event.session_key)), new Set(["issue-123", "issue-123-retry"]));
+  assert.deepEqual(new Set(terminal.map((event) => event.request_id)), new Set(["request-a", "request-b"]));
+  assert.equal(terminal.every((event) => event.blocking === false), true);
+  assert.deepEqual(listActiveWorkerBlockerIssues({ repo_slug: "owner/repo", limit: 10 }, { logPath }), {
+    ok: true,
+    issues: [124],
+  });
+
+  const lineCount = events.length;
+  assert.deepEqual(resolveWorkerBlockersForIssue({
+    issue_number: 123,
+    repo_slug: "owner/repo",
+  }, { logPath, now: new Date("2026-07-24T12:00:05Z") }), { ok: true, resolvedCount: 0 });
+  assert.equal(readFileSync(logPath, "utf8").trim().split("\n").length, lineCount);
+
+  assert.equal(appendWorkerBlockerEvent({
+    ...base,
+    event: "permission_request_captured",
+    session_key: "issue-123",
+    request_id: "request-reopened",
+  }, { logPath, now: new Date("2026-07-24T12:00:06Z") }), true);
+  assert.deepEqual(listActiveWorkerBlockerIssues({ repo_slug: "owner/repo", limit: 10 }, { logPath }).issues, [123, 124]);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("resolve-issue leaves the log unchanged when the terminal batch cannot fit", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-worker-blocker-resolve-fail-"));
+  const logPath = join(root, "events.jsonl");
+  for (const sessionKey of ["issue-321-a", "issue-321-b"]) {
+    assert.equal(appendWorkerBlockerEvent({
+      event: "permission_request_captured",
+      reason: "permission_required",
+      source: "test",
+      issue_number: 321,
+      repo_slug: "owner/repo",
+      session_key: sessionKey,
+      detail: "x".repeat(200),
+    }, { logPath, maxBytes: 4096 }), true);
+  }
+  const before = readFileSync(logPath, "utf8");
+  assert.deepEqual(resolveWorkerBlockersForIssue({
+    issue_number: 321,
+    repo_slug: "owner/repo",
+  }, { logPath, maxBytes: 512 }), { ok: false, resolvedCount: 0 });
+  assert.equal(readFileSync(logPath, "utf8"), before);
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs
@@ -11,11 +11,13 @@ import { fileURLToPath } from "node:url";
 
 import {
   appendWorkerBlockerEvent,
-  listActiveWorkerBlockerIssues,
   normalizeWorkerBlockerEvent,
-  resolveWorkerBlockersForIssue,
   WORKER_BLOCKER_SCHEMA,
 } from "../../../scripts/worker-blocker-log.mjs";
+import {
+  listActiveWorkerBlockerIssues,
+  resolveWorkerBlockersForIssue,
+} from "../../../scripts/worker-blocker-reconcile.mjs";
 
 const LOGGER_PATH = fileURLToPath(new URL("../../../scripts/worker-blocker-log.mjs", import.meta.url));
 

--- a/.agents/scripts/dependency-event-reconciler.sh
+++ b/.agents/scripts/dependency-event-reconciler.sh
@@ -10,9 +10,31 @@ DER_NOT_READY=2
 
 _der_dir="${BASH_SOURCE[0]%/*}"
 [[ "$_der_dir" == "${BASH_SOURCE[0]}" ]] && _der_dir="."
+: "${DER_WORKER_BLOCKER_LOGGER:=${_der_dir}/worker-blocker-log.mjs}"
 # shellcheck source=./task-identity-lib.sh
 source "${_der_dir}/task-identity-lib.sh"
 unset _der_dir
+
+_der_reconcile_terminal_worker_blockers() {
+	local repo="$1"
+	local issue_number="$2"
+	local logger="${DER_WORKER_BLOCKER_LOGGER}"
+
+	if [[ "$repo" != */* || ! "$issue_number" =~ ^[0-9]+$ || ! -f "$logger" || -L "$logger" ]]; then
+		return 1
+	fi
+	command -v node >/dev/null 2>&1 || return 1
+	if node "$logger" resolve-issue \
+		--repo-slug "$repo" \
+		--issue-number "$issue_number" \
+		--event "issue_terminal_reconciled" \
+		--status "resolved" \
+		--reason "issue_closed_verified" \
+		--source "dependency-event-reconciler" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
 
 _der_dependency_text() {
 	local body="$1"
@@ -344,6 +366,7 @@ reconcile_dependants_after_verified_closure() {
       and .data.repository.issue.blocking.pageInfo.hasNextPage == false
       and all(.data.repository.issue.blocking.nodes[];
           .repository.nameWithOwner == $repo and .labels.pageInfo.hasNextPage == false)' >/dev/null 2>&1 || return 1
+	_der_reconcile_terminal_worker_blockers "$repo" "$closed_number" || true
 	closed_task_id=$(task_identity_parse_title_prefix "$(printf '%s' "$context" | jq -r '.data.repository.issue.title')" || true)
 	candidates=$(_der_collect_candidates "$repo" "$closed_number" "$closed_task_id" "$context") || return 1
 	while IFS= read -r candidate; do

--- a/.agents/scripts/shared-dispatch-label-cleanup.sh
+++ b/.agents/scripts/shared-dispatch-label-cleanup.sh
@@ -11,6 +11,10 @@ _SHARED_DISPATCH_LABEL_CLEANUP_LOADED=1
 : "${PULSE_STALE_DISPATCH_LABEL_SWEEP_INTERVAL:=86400}"
 : "${PULSE_STALE_DISPATCH_LABEL_SWEEP_LIMIT_PER_REPO:=50}"
 
+_DISPATCH_LABEL_CLEANUP_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$_DISPATCH_LABEL_CLEANUP_DIR" == "${BASH_SOURCE[0]}" ]] && _DISPATCH_LABEL_CLEANUP_DIR="."
+: "${DISPATCH_LABEL_CLEANUP_BLOCKER_LOGGER:=${_DISPATCH_LABEL_CLEANUP_DIR}/worker-blocker-log.mjs}"
+
 _TERMINAL_DISPATCH_LABELS=(
 	"auto-dispatch"
 	"status:available"
@@ -30,12 +34,13 @@ clear_terminal_issue_dispatch_labels() {
 	local repo_slug="$2"
 	local context="${3:-terminal}"
 	local current_labels="${4:-}"
+	local labels_fetched="${5:-false}"
 
 	if [[ ! "$issue_number" =~ ^[0-9]+$ || -z "$repo_slug" ]]; then
 		return 1
 	fi
 
-	if [[ -z "$current_labels" ]] && ! current_labels=$(gh issue view "$issue_number" --repo "$repo_slug" --json labels --jq '.labels[].name'); then
+	if [[ -z "$current_labels" && "$labels_fetched" != "true" ]] && ! current_labels=$(gh issue view "$issue_number" --repo "$repo_slug" --json labels --jq '.labels[].name'); then
 		echo "[pulse-wrapper] dispatch-label-cleanup: failed to fetch labels for ${repo_slug}#${issue_number} (${context})" >>"$LOGFILE"
 		return 1
 	fi
@@ -63,6 +68,64 @@ clear_terminal_issue_dispatch_labels() {
 
 	echo "[pulse-wrapper] dispatch-label-cleanup: failed to strip terminal dispatch labels from ${repo_slug}#${issue_number} (${context}) [exit: ${exit_code}]" >>"$LOGFILE"
 	return "$exit_code"
+}
+
+reconcile_terminal_issue_worker_blockers() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local reason="${3:-issue_terminal}"
+	local source="${4:-dispatch-label-cleanup}"
+	local logger="${DISPATCH_LABEL_CLEANUP_BLOCKER_LOGGER}"
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ || -z "$repo_slug" || ! -f "$logger" || -L "$logger" ]]; then
+		return 1
+	fi
+	command -v node >/dev/null 2>&1 || return 1
+	if node "$logger" resolve-issue \
+		--issue-number "$issue_number" \
+		--repo-slug "$repo_slug" \
+		--event "issue_terminal_reconciled" \
+		--status "resolved" \
+		--reason "$reason" \
+		--source "$source" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+_dispatch_blocker_active_issue_candidates() {
+	local repo_slug="$1"
+	local limit="$2"
+	local logger="${DISPATCH_LABEL_CLEANUP_BLOCKER_LOGGER}"
+
+	if [[ -z "$repo_slug" || ! "$limit" =~ ^[1-9][0-9]*$ || ! -f "$logger" || -L "$logger" ]]; then
+		return 1
+	fi
+	command -v node >/dev/null 2>&1 || return 1
+	if node "$logger" list-active-issues --repo-slug "$repo_slug" --limit "$limit"; then
+		return 0
+	fi
+	return 1
+}
+
+_dispatch_terminal_issue_snapshot() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local snapshot=""
+	local state=""
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ || -z "$repo_slug" ]]; then
+		return 1
+	fi
+	snapshot=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json state,stateReason,labels \
+		--jq '[.state, (.stateReason // ""), ([.labels[].name] | join("|"))] | @tsv' 2>/dev/null) || return 1
+	IFS=$'\t' read -r state _ <<<"$snapshot"
+	if [[ "$state" != "OPEN" && "$state" != "CLOSED" ]]; then
+		return 1
+	fi
+	printf '%s\n' "$snapshot"
+	return 0
 }
 
 _dispatch_label_sweep_due() {
@@ -117,24 +180,40 @@ sweep_closed_auto_dispatch_issues() {
 	[[ "$limit" =~ ^[0-9]+$ ]] || limit=50
 	[[ "$limit" -gt 0 ]] || limit=50
 
-	local total=0 repo_slug issue_number issue_rows labels_csv
+	local total=0 checked=0 open=0 ambiguous=0 logger_failed=0 label_failed=0
+	local repo_slug issue_number issue_rows snapshot state state_reason labels_csv reason
 	while IFS= read -r repo_slug; do
 		[[ -n "$repo_slug" ]] || continue
-		issue_rows=$(gh issue list --repo "$repo_slug" --state closed \
-			--label "auto-dispatch" --limit "$limit" \
-			--json number,labels --jq '.[] | [.number, ([.labels[].name] | join("|"))] | @tsv' 2>/dev/null) || issue_rows=""
+		issue_rows=$(_dispatch_blocker_active_issue_candidates "$repo_slug" "$limit") || {
+			logger_failed=$((logger_failed + 1))
+			continue
+		}
 		[[ -n "$issue_rows" ]] || continue
-		while IFS=$'\t' read -r issue_number labels_csv; do
+		while IFS= read -r issue_number; do
 			[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
-			local exit_code=0
-			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" "closed-issue-sweep" "${labels_csv//|/$'\n'}" || exit_code=$?
-			if [[ "$exit_code" -eq 0 ]]; then
+			snapshot=$(_dispatch_terminal_issue_snapshot "$issue_number" "$repo_slug") || {
+				ambiguous=$((ambiguous + 1))
+				continue
+			}
+			IFS=$'\t' read -r state state_reason labels_csv <<<"$snapshot"
+			checked=$((checked + 1))
+			if [[ "$state" == "OPEN" ]]; then
+				open=$((open + 1))
+				continue
+			fi
+			reason="issue_closed_completed"
+			[[ "$state_reason" == "NOT_PLANNED" ]] && reason="issue_closed_not_planned"
+			clear_terminal_issue_dispatch_labels "$issue_number" "$repo_slug" \
+				"closed-blocker-sweep" "${labels_csv//|/$'\n'}" "true" || label_failed=$((label_failed + 1))
+			if reconcile_terminal_issue_worker_blockers "$issue_number" "$repo_slug" "$reason" "dispatch-label-cleanup-sweep"; then
 				total=$((total + 1))
+			else
+				logger_failed=$((logger_failed + 1))
 			fi
 		done <<<"$issue_rows"
 	done < <(_dispatch_label_sweep_repos "$repos_json" || true)
 
 	_dispatch_label_sweep_mark_run
-	echo "[pulse-wrapper] dispatch-label-cleanup: closed issue sweep stripped labels from ${total} issue(s)" >>"$LOGFILE"
+	echo "[pulse-wrapper] dispatch-label-cleanup: blocker sweep resolved=${total} checked=${checked} open=${open} ambiguous=${ambiguous} logger_failed=${logger_failed} label_failed=${label_failed}" >>"$LOGFILE"
 	return 0
 }

--- a/.agents/scripts/tests/test-dependency-event-reconciler.sh
+++ b/.agents/scripts/tests/test-dependency-event-reconciler.sh
@@ -19,6 +19,13 @@ SEARCH_AMBIGUOUS=false
 EXPLICIT_LABEL=true
 BODY20="Blocked by #10"
 CLOSED_TITLE="t10: blocker"
+CONTEXT_REPO="owner/repo"
+CONTEXT_STATE="CLOSED"
+CONTEXT_HAS_NEXT_PAGE=false
+CLOSED_LIVE_STATE="CLOSED"
+BLOCKER_RECONCILE_FAIL=false
+BLOCKER_RECONCILE_LOG=$(mktemp)
+trap 'rm -f "$BLOCKER_RECONCILE_LOG"' EXIT
 
 pass() {
 	printf 'PASS: %s\n' "$1"
@@ -56,9 +63,33 @@ _der_fetch_closed_context() {
 	if [[ "$NATIVE_DIRECT" == "true" ]]; then
 		native=$(candidate 20 OPEN "t20: direct" "$BODY20" $'status:blocked\nblocked-by:#10' | jq -sc '.')
 	fi
-	jq -cn --arg title "$CLOSED_TITLE" --argjson native "$native" '
-      {data:{repository:{nameWithOwner:"owner/repo",issue:{number:10,state:"CLOSED",title:$title,
-        blocking:{nodes:$native,pageInfo:{hasNextPage:false}}}}}}'
+	jq -cn --arg title "$CLOSED_TITLE" --arg repo "$CONTEXT_REPO" \
+		--arg state "$CONTEXT_STATE" --argjson native "$native" \
+		--argjson has_next_page "$CONTEXT_HAS_NEXT_PAGE" '
+      {data:{repository:{nameWithOwner:$repo,issue:{number:10,state:$state,title:$title,
+        blocking:{nodes:$native,pageInfo:{hasNextPage:$has_next_page}}}}}}'
+	return 0
+}
+
+_der_reconcile_terminal_worker_blockers() {
+	local repo="$1"
+	local issue_number="$2"
+	printf '%s#%s\n' "$repo" "$issue_number" >>"$BLOCKER_RECONCILE_LOG"
+	if [[ "$BLOCKER_RECONCILE_FAIL" == "true" ]]; then
+		return 1
+	fi
+	return 0
+}
+
+reset_blocker_reconcile_log() {
+	: >"$BLOCKER_RECONCILE_LOG"
+	return 0
+}
+
+blocker_reconcile_count() {
+	local count=0
+	count=$(wc -l <"$BLOCKER_RECONCILE_LOG")
+	printf '%s\n' "${count//[[:space:]]/}"
 	return 0
 }
 
@@ -85,7 +116,7 @@ gh() {
 	case "$command $1" in
 	"issue view")
 		if [[ "$*" == *"--json state"* ]]; then
-			[[ "$*" == "view 11 "* ]] && printf 'OPEN\n' || printf 'CLOSED\n'
+			[[ "$*" == "view 11 "* ]] && printf 'OPEN\n' || printf '%s\n' "$CLOSED_LIVE_STATE"
 		else
 			printf '%s\n' "$REREAD_LABELS"
 		fi
@@ -119,7 +150,34 @@ run_reconcile() {
 	return 0
 }
 
+reset_blocker_reconcile_log
 assert_eq 1 "$(run_reconcile)" "repository with 27000 unrelated issues still reconciles targeted child"
+assert_eq 1 "$(blocker_reconcile_count)" "verified terminal issue reconciles its worker blocker identities"
+assert_eq "owner/repo#10" "$(cat "$BLOCKER_RECONCILE_LOG")" "worker blocker reconciliation preserves exact issue identity"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" CONTEXT_HAS_NEXT_PAGE=true
+reset_blocker_reconcile_log
+assert_eq 0 "$(run_reconcile)" "incomplete closure context blocks dependant mutation"
+assert_eq 0 "$(blocker_reconcile_count)" "incomplete closure context cannot resolve worker blockers"
+CONTEXT_HAS_NEXT_PAGE=false
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" CONTEXT_REPO="other/repo"
+reset_blocker_reconcile_log
+assert_eq 0 "$(run_reconcile)" "closure context repository mismatch blocks dependant mutation"
+assert_eq 0 "$(blocker_reconcile_count)" "repository mismatch cannot resolve worker blockers"
+CONTEXT_REPO="owner/repo"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" CLOSED_LIVE_STATE="OPEN"
+reset_blocker_reconcile_log
+assert_eq 0 "$(run_reconcile)" "non-terminal live state blocks dependant mutation"
+assert_eq 0 "$(blocker_reconcile_count)" "non-terminal live state cannot resolve worker blockers"
+CLOSED_LIVE_STATE="CLOSED"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" BLOCKER_RECONCILE_FAIL=true
+reset_blocker_reconcile_log
+assert_eq 1 "$(run_reconcile)" "blocker logger failure remains fail-open for dependency reconciliation"
+assert_eq 1 "$(blocker_reconcile_count)" "fail-open dependency reconciliation attempts blocker resolution once"
+BLOCKER_RECONCILE_FAIL=false
 
 EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20="Blocked by #10 and #11"
 assert_eq 0 "$(run_reconcile)" "multiple blockers remain blocked when one is open"

--- a/.agents/scripts/tests/test-dispatch-label-cleanup.sh
+++ b/.agents/scripts/tests/test-dispatch-label-cleanup.sh
@@ -6,10 +6,12 @@ set -euo pipefail
 
 SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER="${SCRIPT_DIR_TEST}/../shared-dispatch-label-cleanup.sh"
+BLOCKER_LOGGER="${SCRIPT_DIR_TEST}/../worker-blocker-log.mjs"
 
 TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
+BLOCKER_LOG=""
 ORIGINAL_HOME="$HOME"
 
 print_result() {
@@ -32,6 +34,10 @@ setup_env() {
 	export REPOS_JSON="${TEST_ROOT}/repos.json"
 	export PULSE_STALE_DISPATCH_LABEL_SWEEP_FORCE=1
 	export PULSE_STALE_DISPATCH_LABEL_SWEEP_LIMIT_PER_REPO=5
+	BLOCKER_LOG="${TEST_ROOT}/worker-progress-blockers.jsonl"
+	export AIDEVOPS_WORKER_BLOCKER_LOG_FILE="$BLOCKER_LOG"
+	export DISPATCH_LABEL_CLEANUP_BLOCKER_LOGGER="$BLOCKER_LOGGER"
+	unset GH_STUB_FAIL_EDIT GH_STUB_FAIL_VIEW_ISSUE
 	mkdir -p "$HOME/.aidevops/logs"
 	: >"$LOGFILE"
 	: >"${TEST_ROOT}/gh.log"
@@ -53,13 +59,21 @@ install_gh_stub() {
 	gh() {
 		local command_name="$1"
 		local subcommand_name="$2"
+		local issue_number="${3:-}"
 		printf '%s\n' "$*" >>"${TEST_ROOT}/gh.log"
-		if [[ "$command_name" == "issue" && "$subcommand_name" == "list" ]]; then
-			printf '101\tauto-dispatch|status:queued\n102\tauto-dispatch\n'
-			return 0
-		fi
 		if [[ "$command_name" == "issue" && "$subcommand_name" == "view" ]]; then
-			printf 'auto-dispatch\nstatus:queued\n'
+			[[ "${GH_STUB_FAIL_VIEW_ISSUE:-}" != "$issue_number" ]] || return 1
+			if [[ "$*" == *"--json state,stateReason,labels"* ]]; then
+				case "$issue_number" in
+				101) printf 'CLOSED\tCOMPLETED\tauto-dispatch|status:queued\n' ;;
+				102) printf 'OPEN\t\tneeds-maintainer-permissions\n' ;;
+				103) printf 'CLOSED\tNOT_PLANNED\t\n' ;;
+				104) printf 'UNKNOWN\t\t\n' ;;
+				*) printf 'CLOSED\tCOMPLETED\tauto-dispatch|status:queued\n' ;;
+				esac
+			else
+				printf 'auto-dispatch\nstatus:queued\n'
+			fi
 			return 0
 		fi
 		if [[ "$command_name" == "issue" && "$subcommand_name" == "edit" && "${GH_STUB_FAIL_EDIT:-0}" == "1" ]]; then
@@ -68,6 +82,27 @@ install_gh_stub() {
 		return 0
 	}
 	return 0
+}
+
+append_blocker() {
+	local issue_number="$1"
+	local session_key="$2"
+	local request_id="$3"
+	if node "$BLOCKER_LOGGER" append --log-file "$BLOCKER_LOG" \
+		--issue-number "$issue_number" --repo-slug owner/repo \
+		--session-key "$session_key" --request-id "$request_id" \
+		--event permission_request_captured --reason permission_required --source test; then
+		return 0
+	fi
+	return 1
+}
+
+active_issues() {
+	if node "$BLOCKER_LOGGER" list-active-issues --log-file "$BLOCKER_LOG" \
+		--repo-slug owner/repo --limit 20; then
+		return 0
+	fi
+	return 1
 }
 
 test_clear_terminal_labels_removes_dispatch_labels() {
@@ -91,20 +126,83 @@ test_clear_terminal_labels_removes_dispatch_labels() {
 	return 0
 }
 
-test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos() {
+test_sweep_reconciles_closed_active_blocker_candidates() {
 	setup_env
 	install_gh_stub
 	# shellcheck source=../shared-dispatch-label-cleanup.sh
 	source "$HELPER"
+	append_blocker 101 issue-101-a request-a
+	append_blocker 101 issue-101-b request-b
+	append_blocker 102 issue-102 request-open
+	append_blocker 103 issue-103 request-not-planned
 	sweep_closed_auto_dispatch_issues
-	local edit_count list_count view_count
+	local edit_count list_count view_count active terminal_count
 	edit_count=$(grep -c 'issue edit' "${TEST_ROOT}/gh.log" || true)
 	list_count=$(grep -c 'issue list' "${TEST_ROOT}/gh.log" || true)
 	view_count=$(grep -c 'issue view' "${TEST_ROOT}/gh.log" || true)
-	if [[ "$edit_count" == "2" && "$list_count" == "1" && "$view_count" == "0" ]]; then
-		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 0
+	active=$(active_issues | tr '\n' ' ')
+	terminal_count=$(jq -s '[.[] | select(.event == "issue_terminal_reconciled")] | length' "$BLOCKER_LOG")
+	if [[ "$edit_count" == "1" && "$list_count" == "0" && "$view_count" == "3" \
+		&& "$active" == "102 " && "$terminal_count" == "3" ]] &&
+		grep -q 'reason":"issue_closed_not_planned"' "$BLOCKER_LOG" &&
+		grep -q 'blocker sweep resolved=2 checked=3 open=1 ambiguous=0 logger_failed=0' "$LOGFILE"; then
+		print_result "closed blocker sweep resolves every identity without label-dependent discovery" 0
 	else
-		print_result "closed auto-dispatch sweep strips bounded pulse repo issues" 1
+		print_result "closed blocker sweep resolves every identity without label-dependent discovery" 1
+	fi
+	local before_count="$terminal_count"
+	sweep_closed_auto_dispatch_issues
+	terminal_count=$(jq -s '[.[] | select(.event == "issue_terminal_reconciled")] | length' "$BLOCKER_LOG")
+	if [[ "$terminal_count" == "$before_count" ]]; then
+		print_result "closed blocker sweep is idempotent" 0
+	else
+		print_result "closed blocker sweep is idempotent" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_sweep_preserves_blockers_on_api_ambiguity() {
+	setup_env
+	install_gh_stub
+	# shellcheck source=../shared-dispatch-label-cleanup.sh
+	source "$HELPER"
+	append_blocker 104 issue-104 request-ambiguous
+	sweep_closed_auto_dispatch_issues
+	local active=""
+	active=$(active_issues | tr '\n' ' ')
+	if [[ "$active" == "104 " ]] && grep -q 'ambiguous=1' "$LOGFILE"; then
+		print_result "closed blocker sweep preserves state on API ambiguity" 0
+	else
+		print_result "closed blocker sweep preserves state on API ambiguity" 1
+	fi
+	teardown_env
+	return 0
+}
+
+test_sweep_preserves_blockers_on_logger_failure() {
+	setup_env
+	install_gh_stub
+	# shellcheck source=../shared-dispatch-label-cleanup.sh
+	source "$HELPER"
+	append_blocker 101 issue-101 request-logger-failure
+	local failing_logger="${TEST_ROOT}/failing-worker-blocker-log.mjs"
+	cat >"$failing_logger" <<'JS'
+if (process.argv[2] === "list-active-issues") {
+  process.stdout.write("101\n");
+  process.exit(0);
+}
+process.exit(1);
+JS
+	DISPATCH_LABEL_CLEANUP_BLOCKER_LOGGER="$failing_logger"
+	sweep_closed_auto_dispatch_issues
+	DISPATCH_LABEL_CLEANUP_BLOCKER_LOGGER="$BLOCKER_LOGGER"
+	local active=""
+	active=$(active_issues | tr '\n' ' ')
+	if [[ "$active" == "101 " ]] && grep -q 'logger_failed=1' "$LOGFILE"; then
+		print_result "closed blocker sweep preserves state on logger failure" 0
+	else
+		print_result "closed blocker sweep preserves state on logger failure" 1
 	fi
 	teardown_env
 	return 0
@@ -131,7 +229,9 @@ test_clear_terminal_labels_propagates_edit_failures() {
 }
 
 test_clear_terminal_labels_removes_dispatch_labels
-test_sweep_closed_auto_dispatch_issues_scopes_to_pulse_repos
+test_sweep_reconciles_closed_active_blocker_candidates
+test_sweep_preserves_blockers_on_api_ambiguity
+test_sweep_preserves_blockers_on_logger_failure
 test_clear_terminal_labels_propagates_edit_failures
 
 printf 'Tests run: %s\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -115,6 +115,7 @@ cat >"$FIXTURE_BLOCKERS" <<'BLOCKERS'
 {"schema":"aidevops-worker-blocker/v1","ts":100,"timestamp":"2026-04-27T09:00:00Z","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"opencode-permission-broker","issue_number":21860,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21860","request_id":"perm-source"}
 {"schema":"aidevops-worker-blocker/v1","ts":110,"timestamp":"2026-04-27T09:01:00Z","event":"permission_grant_applied","status":"resuming","reason":"scoped_permission_granted","blocking":false,"source":"opencode-config-hook","issue_number":21860,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21860","request_id":"perm-envelope"}
 {"schema":"aidevops-worker-blocker/v1","ts":120,"timestamp":"2026-04-27T09:02:00Z","event":"permission_request_non_grantable","status":"blocked","reason":"permission_non_grantable","blocking":true,"source":"opencode-permission-broker","issue_number":21860,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21860-retry","request_id":"perm-sensitive"}
+{"schema":"aidevops-worker-blocker/v1","ts":130,"timestamp":"2026-04-27T09:03:00Z","event":"issue_terminal_reconciled","status":"resolved","reason":"issue_closed_completed","blocking":false,"source":"dependency-event-reconciler","issue_number":21860,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21860-retry","request_id":"perm-sensitive"}
 malformed-row
 BLOCKERS
 
@@ -437,8 +438,9 @@ assert_contains "shows issue title" "worker re-dispatch" "$output"
 assert_contains "shows issue labels" "auto-dispatch" "$output"
 assert_contains "shows lifecycle comments section" "Lifecycle comments:" "$output"
 assert_contains "shows worker progress blockers section" "Worker progress blockers:" "$output"
-assert_contains "shows current blocker count" "Currently active: 1" "$output"
+assert_contains "shows current blocker count" "Currently active: 0" "$output"
 assert_contains "shows non-grantable blocker reason" "permission_non_grantable" "$output"
+assert_contains "shows terminal blocker lifecycle event" "issue_closed_completed" "$output"
 assert_contains "shows WORKER_BRANCH_ORPHAN comment" "WORKER_BRANCH_ORPHAN" "$output"
 assert_contains "shows repeated attempts section" "Repeated attempts / dispatch backoff:" "$output"
 assert_contains "shows metric attempt count" "Attempts in metrics: 3" "$output"
@@ -515,9 +517,9 @@ if command -v jq >/dev/null 2>&1; then
 		printf '  ✗ JSON repeated_attempts dispatch_log_events has ≥1 entry (got %s)\n' "$json_dispatch_events"
 	fi
 	json_blocker_events=$(echo "$output" | jq '.progress_blockers.event_total' 2>/dev/null || echo 0)
-	assert_eq "JSON progress_blockers event_total" "3" "$json_blocker_events"
+	assert_eq "JSON progress_blockers event_total" "4" "$json_blocker_events"
 	json_active_blockers=$(echo "$output" | jq '.progress_blockers.active_total' 2>/dev/null || echo 0)
-	assert_eq "JSON progress_blockers active_total" "1" "$json_active_blockers"
+	assert_eq "JSON progress_blockers active_total" "0" "$json_active_blockers"
 fi
 
 # --- Test 17: issue --verbose shows raw log lines ---

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -166,6 +166,7 @@ T_FUTURE_SENTINEL_MS=$((T_FUTURE_SENTINEL * 1000))
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"recent","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"test","issue_number":20,"repo_slug":"marcusquinn/aidevops","session_key":"issue-20","request_id":"perm-source"}\n' "$T_2H_AGO"
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"recent","event":"permission_grant_applied","status":"resuming","reason":"scoped_permission_granted","blocking":false,"source":"test","issue_number":20,"repo_slug":"marcusquinn/aidevops","session_key":"issue-20","request_id":"perm-envelope"}\n' "$T_5MIN_AGO"
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"recent","event":"permission_request_non_grantable","status":"blocked","reason":"permission_non_grantable","blocking":true,"source":"test","issue_number":21,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21","request_id":"perm-sensitive"}\n' "$T_5MIN_AGO"
+	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"terminal","event":"issue_terminal_reconciled","status":"resolved","reason":"issue_closed_completed","blocking":false,"source":"test","issue_number":21,"repo_slug":"marcusquinn/aidevops","session_key":"issue-21","request_id":"perm-sensitive"}\n' "$((T_5MIN_AGO + 1))"
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"older","event":"permission_awaiting_approval","status":"blocked","reason":"needs_maintainer_permissions","blocking":true,"source":"test","issue_number":22,"repo_slug":"marcusquinn/aidevops","session_key":"issue-22","request_id":"perm-old"}\n' "$T_25H_AGO"
 	printf '{"schema":"aidevops-worker-blocker/v1","ts":%d,"timestamp":"future","event":"permission_request_captured","status":"blocked","reason":"permission_required","blocking":true,"source":"test","issue_number":23,"repo_slug":"marcusquinn/aidevops","session_key":"issue-23","request_id":"perm-future"}\n' "$T_FUTURE_SENTINEL"
 	printf 'malformed-jsonl-row\n'
@@ -327,12 +328,14 @@ assert_eq "2n: pr check_state = skipped" "skipped" \
 	"$(printf '%s' "$JSON" | jq -r '.worker_solved_issues.check_state')"
 assert_eq "2n2: delivery stages are explicitly skipped" "skipped" \
 	"$(printf '%s' "$JSON" | jq -r '.delivery_stages.check_state')"
-assert_eq "2o: blocker events obey the 24h window" "3" \
+assert_eq "2o: blocker events obey the 24h window" "4" \
 	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.event_total')"
-assert_eq "2p: unresolved old blocker remains active until cleared" "2" \
+assert_eq "2p: unresolved old blocker remains active until cleared" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.active_total')"
 assert_eq "2q: grant event clears the earlier request for the same session" "0" \
 	"$(printf '%s' "$JSON" | jq -r '[.progress_blockers.active_blockers[] | select(.session_key == "issue-20")] | length')"
+assert_eq "2q2: terminal issue event clears a stale blocker identity" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.progress_blockers.active_blockers[] | select(.session_key == "issue-21")] | length')"
 assert_eq "2r: malformed blocker rows fail open" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.reason_counts.permission_non_grantable')"
 
@@ -354,7 +357,7 @@ assert_eq "3d: 1h watchdog_killed = 0" "0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
 assert_eq "3e: 1h recent examples exclude future sentinel" "0" \
 	"$(printf '%s' "$JSON" | jq -r '[.metrics.recent_examples[] | select(.session_key == "issue-9")] | length')"
-assert_eq "3f: 1h blocker event total is bounded" "2" \
+assert_eq "3f: 1h blocker event total is bounded" "3" \
 	"$(printf '%s' "$JSON" | jq -r '.progress_blockers.event_total')"
 
 # ---------------------------------------------------------------------------
@@ -423,7 +426,7 @@ assert_contains "5g: human output shows failure groups" "Failure groups" "$OUT"
 assert_contains "5h: human output shows diagnostic focus" "Diagnostic focus" "$OUT"
 assert_contains "5i: human output shows failure families" "Failure families" "$OUT"
 assert_contains "5j: human output shows bounded blocker evidence" "worker-progress-blockers.jsonl" "$OUT"
-assert_contains "5k: human output shows active blocker count" "Currently active:            2" "$OUT"
+assert_contains "5k: human output shows active blocker count" "Currently active:            1" "$OUT"
 
 # ---------------------------------------------------------------------------
 # Section 6: provider/account diagnostics expose redacted capacity slots.

--- a/.agents/scripts/worker-blocker-log.mjs
+++ b/.agents/scripts/worker-blocker-log.mjs
@@ -120,30 +120,77 @@ function trimBeforeAppend(logPath, incomingBytes, maxBytes) {
   renameSync(temporary, logPath);
 }
 
+function parseWorkerBlockerEvents(content) {
+  const events = [];
+  for (const line of content.toString("utf8").split("\n")) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (event?.schema === WORKER_BLOCKER_SCHEMA) events.push(event);
+    } catch {
+      // Malformed historical rows are ignored, matching the fail-open readers.
+    }
+  }
+  return events;
+}
+
+function workerBlockerIdentity(event) {
+  const sessionKey = typeof event.session_key === "string" ? event.session_key : "";
+  const requestId = event.request_id === null || event.request_id === undefined
+    ? "unknown"
+    : String(event.request_id);
+  return `${event.repo_slug || ""}|${event.issue_number ?? ""}|${sessionKey || requestId}`;
+}
+
+function latestWorkerBlockerEvents(events) {
+  const latest = new Map();
+  for (const event of events) {
+    const identity = workerBlockerIdentity(event);
+    const timestamp = Number.isFinite(Number(event.ts)) ? Number(event.ts) : 0;
+    const current = latest.get(identity);
+    if (!current || timestamp >= current.timestamp) latest.set(identity, { event, timestamp });
+  }
+  return [...latest.values()].map(({ event }) => event);
+}
+
+function scopedWorkerBlockerEvents(content, repoSlug, issueNumber = null) {
+  return parseWorkerBlockerEvents(content).filter((event) => {
+    const eventRepo = String(event.repo_slug || "").toLowerCase();
+    const eventIssue = cleanIssueNumber(event.issue_number);
+    return eventRepo === repoSlug && eventIssue !== null
+      && (issueNumber === null || eventIssue === issueNumber);
+  });
+}
+
+function appendNormalizedEventsUnlocked(logPath, inputs, options, maxBytes) {
+  const content = inputs
+    .map((input) => `${JSON.stringify(normalizeWorkerBlockerEvent(input, options))}\n`)
+    .join("");
+  const incomingBytes = Buffer.byteLength(content);
+  if (!content || incomingBytes > maxBytes) return false;
+  trimBeforeAppend(logPath, incomingBytes, maxBytes);
+  const descriptor = openSync(logPath, constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW, 0o600);
+  try {
+    writeFileSync(descriptor, content);
+    fchmodSync(descriptor, 0o600);
+  } finally {
+    closeSync(descriptor);
+  }
+  return true;
+}
+
 export function appendWorkerBlockerEvent(input, options = {}) {
   let lockPath = "";
   let lockToken = "";
   try {
     const logPath = resolveLogPath(options);
     const maxBytes = resolveMaxBytes(options);
-    const line = `${JSON.stringify(normalizeWorkerBlockerEvent(input, options))}\n`;
-    const incomingBytes = Buffer.byteLength(line);
-    if (incomingBytes > maxBytes) return false;
-
     mkdirSync(dirname(logPath), { recursive: true, mode: 0o700 });
     if (existsSync(logPath) && lstatSync(logPath).isSymbolicLink()) return false;
     lockPath = `${logPath}.lock`;
     lockToken = acquireLock(lockPath);
     if (!lockToken) return false;
-    trimBeforeAppend(logPath, incomingBytes, maxBytes);
-    const descriptor = openSync(logPath, constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW, 0o600);
-    try {
-      writeFileSync(descriptor, line);
-      fchmodSync(descriptor, 0o600);
-    } finally {
-      closeSync(descriptor);
-    }
-    return true;
+    return appendNormalizedEventsUnlocked(logPath, [input], options, maxBytes);
   } catch {
     return false;
   } finally {
@@ -152,6 +199,110 @@ export function appendWorkerBlockerEvent(input, options = {}) {
         releaseLock(lockPath, lockToken);
       } catch {
         // Logging remains best effort and must never stop worker execution.
+      }
+    }
+  }
+}
+
+export function resolveWorkerBlockersForIssue(input = {}, options = {}) {
+  let lockPath = "";
+  let lockToken = "";
+  try {
+    const issueNumber = cleanIssueNumber(input.issue_number);
+    const repoSlug = cleanText(input.repo_slug || "", MAX_FIELD_LENGTH, options).toLowerCase();
+    if (issueNumber === null || !repoSlug.includes("/")) return { ok: false, resolvedCount: 0 };
+
+    const logPath = resolveLogPath(options);
+    const maxBytes = resolveMaxBytes(options);
+    mkdirSync(dirname(logPath), { recursive: true, mode: 0o700 });
+    if (existsSync(logPath) && lstatSync(logPath).isSymbolicLink()) return { ok: false, resolvedCount: 0 };
+    lockPath = `${logPath}.lock`;
+    lockToken = acquireLock(lockPath);
+    if (!lockToken) return { ok: false, resolvedCount: 0 };
+    if (!existsSync(logPath)) return { ok: true, resolvedCount: 0 };
+    if (lstatSync(logPath).isSymbolicLink()) return { ok: false, resolvedCount: 0 };
+
+    const latest = latestWorkerBlockerEvents(
+      scopedWorkerBlockerEvents(readFileSync(logPath), repoSlug, issueNumber),
+    );
+    const active = latest.filter((event) => event.blocking === true);
+    if (active.length === 0) return { ok: true, resolvedCount: 0 };
+
+    const requestedNow = options.now instanceof Date ? options.now : new Date();
+    const latestActiveTimestamp = active.reduce((maximum, event) => {
+      const timestamp = Number.isFinite(Number(event.ts)) ? Number(event.ts) : 0;
+      return Math.max(maximum, timestamp);
+    }, 0);
+    const resolutionEpoch = Math.max(Math.floor(requestedNow.getTime() / 1000), latestActiveTimestamp + 1);
+    const resolutionOptions = { ...options, now: new Date(resolutionEpoch * 1000) };
+    const terminalEvents = active.map((event) => ({
+      event: input.event || "issue_terminal_reconciled",
+      status: input.status || "resolved",
+      reason: input.reason || "issue_terminal",
+      blocking: false,
+      source: input.source || "worker-blocker-log",
+      issue_number: issueNumber,
+      repo_slug: repoSlug,
+      session_key: event.session_key || "",
+      request_id: event.request_id ?? "",
+      permission: event.permission || "",
+      tool: event.tool || "",
+      risk_level: event.risk_level || "",
+      grantable: typeof event.grantable === "boolean" ? event.grantable : null,
+      detail: input.detail || "",
+    }));
+    if (!appendNormalizedEventsUnlocked(logPath, terminalEvents, resolutionOptions, maxBytes)) {
+      return { ok: false, resolvedCount: 0 };
+    }
+    return { ok: true, resolvedCount: terminalEvents.length };
+  } catch {
+    return { ok: false, resolvedCount: 0 };
+  } finally {
+    if (lockToken) {
+      try {
+        releaseLock(lockPath, lockToken);
+      } catch {
+        // Reconciliation remains best effort and must not block closure paths.
+      }
+    }
+  }
+}
+
+export function listActiveWorkerBlockerIssues(input = {}, options = {}) {
+  let lockPath = "";
+  let lockToken = "";
+  try {
+    const repoSlug = cleanText(input.repo_slug || "", MAX_FIELD_LENGTH, options).toLowerCase();
+    const requestedLimit = Number(input.limit ?? 50);
+    const limit = Number.isSafeInteger(requestedLimit) && requestedLimit > 0 ? requestedLimit : 50;
+    if (!repoSlug.includes("/")) return { ok: false, issues: [] };
+
+    const logPath = resolveLogPath(options);
+    if (!existsSync(logPath)) return { ok: true, issues: [] };
+    if (lstatSync(logPath).isSymbolicLink()) return { ok: false, issues: [] };
+    lockPath = `${logPath}.lock`;
+    lockToken = acquireLock(lockPath);
+    if (!lockToken) return { ok: false, issues: [] };
+    if (!existsSync(logPath) || lstatSync(logPath).isSymbolicLink()) return { ok: false, issues: [] };
+
+    const latest = latestWorkerBlockerEvents(
+      scopedWorkerBlockerEvents(readFileSync(logPath), repoSlug),
+    );
+    const issues = [...new Set(latest
+      .filter((event) => event.blocking === true)
+      .map((event) => cleanIssueNumber(event.issue_number))
+      .filter((issueNumber) => issueNumber !== null))]
+      .sort((left, right) => left - right)
+      .slice(0, limit);
+    return { ok: true, issues };
+  } catch {
+    return { ok: false, issues: [] };
+  } finally {
+    if (lockToken) {
+      try {
+        releaseLock(lockPath, lockToken);
+      } catch {
+        // Read-only candidate discovery remains fail open.
       }
     }
   }
@@ -183,9 +334,19 @@ function parseCliArguments(argv) {
 
 function main() {
   const [command, ...args] = process.argv.slice(2);
-  if (command !== "append") return 2;
   const { event, options } = parseCliArguments(args);
-  return appendWorkerBlockerEvent(event, options) ? 0 : 1;
+  if (command === "append") return appendWorkerBlockerEvent(event, options) ? 0 : 1;
+  if (command === "resolve-issue") {
+    const result = resolveWorkerBlockersForIssue(event, options);
+    if (result.ok) process.stdout.write(`${result.resolvedCount}\n`);
+    return result.ok ? 0 : 1;
+  }
+  if (command === "list-active-issues") {
+    const result = listActiveWorkerBlockerIssues(event, options);
+    if (result.ok && result.issues.length > 0) process.stdout.write(`${result.issues.join("\n")}\n`);
+    return result.ok ? 0 : 1;
+  }
+  return 2;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/.agents/scripts/worker-blocker-log.mjs
+++ b/.agents/scripts/worker-blocker-log.mjs
@@ -47,20 +47,24 @@ function cleanText(value, maxLength, options = {}) {
   return text.slice(0, maxLength);
 }
 
-function cleanIssueNumber(value) {
+export function cleanWorkerBlockerIssueNumber(value) {
   const text = String(value ?? "");
   if (!/^[0-9]+$/.test(text)) return null;
   const parsed = Number(text);
   return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
-function resolveLogPath(options = {}) {
+export function normalizeWorkerBlockerRepoSlug(value, options = {}) {
+  return cleanText(value || "", MAX_FIELD_LENGTH, options).toLowerCase();
+}
+
+export function resolveWorkerBlockerLogPath(options = {}) {
   return options.logPath
     || process.env.AIDEVOPS_WORKER_BLOCKER_LOG_FILE
     || resolve(homedir(), ".aidevops", "logs", "worker-progress-blockers.jsonl");
 }
 
-function resolveMaxBytes(options = {}) {
+export function resolveWorkerBlockerMaxBytes(options = {}) {
   const raw = options.maxBytes ?? process.env.AIDEVOPS_WORKER_BLOCKER_LOG_MAX_BYTES;
   const parsed = Number(raw || DEFAULT_WORKER_BLOCKER_LOG_MAX_BYTES);
   if (!Number.isSafeInteger(parsed) || parsed < MIN_LOG_MAX_BYTES) {
@@ -71,7 +75,7 @@ function resolveMaxBytes(options = {}) {
 
 export function normalizeWorkerBlockerEvent(input = {}, options = {}) {
   const now = options.now instanceof Date ? options.now : new Date();
-  const issueNumber = cleanIssueNumber(input.issue_number ?? process.env.WORKER_ISSUE_NUMBER);
+  const issueNumber = cleanWorkerBlockerIssueNumber(input.issue_number ?? process.env.WORKER_ISSUE_NUMBER);
   const grantable = typeof input.grantable === "boolean" ? input.grantable : null;
   return {
     schema: WORKER_BLOCKER_SCHEMA,
@@ -83,7 +87,7 @@ export function normalizeWorkerBlockerEvent(input = {}, options = {}) {
     blocking: input.blocking !== false,
     source: cleanText(input.source || "unknown", MAX_FIELD_LENGTH, options),
     issue_number: issueNumber,
-    repo_slug: cleanText(input.repo_slug || process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "", MAX_FIELD_LENGTH, options).toLowerCase(),
+    repo_slug: normalizeWorkerBlockerRepoSlug(input.repo_slug || process.env.WORKER_REPO_SLUG || process.env.DISPATCH_REPO_SLUG || "", options),
     session_key: cleanText(input.session_key || process.env.WORKER_SESSION_KEY || "", MAX_FIELD_LENGTH, options),
     request_id: cleanText(input.request_id || process.env.AIDEVOPS_PERMISSION_REQUEST_ID || "", MAX_FIELD_LENGTH, options),
     permission: cleanText(input.permission || "", 100, options),
@@ -120,49 +124,7 @@ function trimBeforeAppend(logPath, incomingBytes, maxBytes) {
   renameSync(temporary, logPath);
 }
 
-function parseWorkerBlockerEvents(content) {
-  const events = [];
-  for (const line of content.toString("utf8").split("\n")) {
-    if (!line) continue;
-    try {
-      const event = JSON.parse(line);
-      if (event?.schema === WORKER_BLOCKER_SCHEMA) events.push(event);
-    } catch {
-      // Malformed historical rows are ignored, matching the fail-open readers.
-    }
-  }
-  return events;
-}
-
-function workerBlockerIdentity(event) {
-  const sessionKey = typeof event.session_key === "string" ? event.session_key : "";
-  const requestId = event.request_id === null || event.request_id === undefined
-    ? "unknown"
-    : String(event.request_id);
-  return `${event.repo_slug || ""}|${event.issue_number ?? ""}|${sessionKey || requestId}`;
-}
-
-function latestWorkerBlockerEvents(events) {
-  const latest = new Map();
-  for (const event of events) {
-    const identity = workerBlockerIdentity(event);
-    const timestamp = Number.isFinite(Number(event.ts)) ? Number(event.ts) : 0;
-    const current = latest.get(identity);
-    if (!current || timestamp >= current.timestamp) latest.set(identity, { event, timestamp });
-  }
-  return [...latest.values()].map(({ event }) => event);
-}
-
-function scopedWorkerBlockerEvents(content, repoSlug, issueNumber = null) {
-  return parseWorkerBlockerEvents(content).filter((event) => {
-    const eventRepo = String(event.repo_slug || "").toLowerCase();
-    const eventIssue = cleanIssueNumber(event.issue_number);
-    return eventRepo === repoSlug && eventIssue !== null
-      && (issueNumber === null || eventIssue === issueNumber);
-  });
-}
-
-function appendNormalizedEventsUnlocked(logPath, inputs, options, maxBytes) {
+export function appendNormalizedWorkerBlockerEventsUnlocked(logPath, inputs, options, maxBytes) {
   const content = inputs
     .map((input) => `${JSON.stringify(normalizeWorkerBlockerEvent(input, options))}\n`)
     .join("");
@@ -183,14 +145,14 @@ export function appendWorkerBlockerEvent(input, options = {}) {
   let lockPath = "";
   let lockToken = "";
   try {
-    const logPath = resolveLogPath(options);
-    const maxBytes = resolveMaxBytes(options);
+    const logPath = resolveWorkerBlockerLogPath(options);
+    const maxBytes = resolveWorkerBlockerMaxBytes(options);
     mkdirSync(dirname(logPath), { recursive: true, mode: 0o700 });
     if (existsSync(logPath) && lstatSync(logPath).isSymbolicLink()) return false;
     lockPath = `${logPath}.lock`;
     lockToken = acquireLock(lockPath);
     if (!lockToken) return false;
-    return appendNormalizedEventsUnlocked(logPath, [input], options, maxBytes);
+    return appendNormalizedWorkerBlockerEventsUnlocked(logPath, [input], options, maxBytes);
   } catch {
     return false;
   } finally {
@@ -199,110 +161,6 @@ export function appendWorkerBlockerEvent(input, options = {}) {
         releaseLock(lockPath, lockToken);
       } catch {
         // Logging remains best effort and must never stop worker execution.
-      }
-    }
-  }
-}
-
-export function resolveWorkerBlockersForIssue(input = {}, options = {}) {
-  let lockPath = "";
-  let lockToken = "";
-  try {
-    const issueNumber = cleanIssueNumber(input.issue_number);
-    const repoSlug = cleanText(input.repo_slug || "", MAX_FIELD_LENGTH, options).toLowerCase();
-    if (issueNumber === null || !repoSlug.includes("/")) return { ok: false, resolvedCount: 0 };
-
-    const logPath = resolveLogPath(options);
-    const maxBytes = resolveMaxBytes(options);
-    mkdirSync(dirname(logPath), { recursive: true, mode: 0o700 });
-    if (existsSync(logPath) && lstatSync(logPath).isSymbolicLink()) return { ok: false, resolvedCount: 0 };
-    lockPath = `${logPath}.lock`;
-    lockToken = acquireLock(lockPath);
-    if (!lockToken) return { ok: false, resolvedCount: 0 };
-    if (!existsSync(logPath)) return { ok: true, resolvedCount: 0 };
-    if (lstatSync(logPath).isSymbolicLink()) return { ok: false, resolvedCount: 0 };
-
-    const latest = latestWorkerBlockerEvents(
-      scopedWorkerBlockerEvents(readFileSync(logPath), repoSlug, issueNumber),
-    );
-    const active = latest.filter((event) => event.blocking === true);
-    if (active.length === 0) return { ok: true, resolvedCount: 0 };
-
-    const requestedNow = options.now instanceof Date ? options.now : new Date();
-    const latestActiveTimestamp = active.reduce((maximum, event) => {
-      const timestamp = Number.isFinite(Number(event.ts)) ? Number(event.ts) : 0;
-      return Math.max(maximum, timestamp);
-    }, 0);
-    const resolutionEpoch = Math.max(Math.floor(requestedNow.getTime() / 1000), latestActiveTimestamp + 1);
-    const resolutionOptions = { ...options, now: new Date(resolutionEpoch * 1000) };
-    const terminalEvents = active.map((event) => ({
-      event: input.event || "issue_terminal_reconciled",
-      status: input.status || "resolved",
-      reason: input.reason || "issue_terminal",
-      blocking: false,
-      source: input.source || "worker-blocker-log",
-      issue_number: issueNumber,
-      repo_slug: repoSlug,
-      session_key: event.session_key || "",
-      request_id: event.request_id ?? "",
-      permission: event.permission || "",
-      tool: event.tool || "",
-      risk_level: event.risk_level || "",
-      grantable: typeof event.grantable === "boolean" ? event.grantable : null,
-      detail: input.detail || "",
-    }));
-    if (!appendNormalizedEventsUnlocked(logPath, terminalEvents, resolutionOptions, maxBytes)) {
-      return { ok: false, resolvedCount: 0 };
-    }
-    return { ok: true, resolvedCount: terminalEvents.length };
-  } catch {
-    return { ok: false, resolvedCount: 0 };
-  } finally {
-    if (lockToken) {
-      try {
-        releaseLock(lockPath, lockToken);
-      } catch {
-        // Reconciliation remains best effort and must not block closure paths.
-      }
-    }
-  }
-}
-
-export function listActiveWorkerBlockerIssues(input = {}, options = {}) {
-  let lockPath = "";
-  let lockToken = "";
-  try {
-    const repoSlug = cleanText(input.repo_slug || "", MAX_FIELD_LENGTH, options).toLowerCase();
-    const requestedLimit = Number(input.limit ?? 50);
-    const limit = Number.isSafeInteger(requestedLimit) && requestedLimit > 0 ? requestedLimit : 50;
-    if (!repoSlug.includes("/")) return { ok: false, issues: [] };
-
-    const logPath = resolveLogPath(options);
-    if (!existsSync(logPath)) return { ok: true, issues: [] };
-    if (lstatSync(logPath).isSymbolicLink()) return { ok: false, issues: [] };
-    lockPath = `${logPath}.lock`;
-    lockToken = acquireLock(lockPath);
-    if (!lockToken) return { ok: false, issues: [] };
-    if (!existsSync(logPath) || lstatSync(logPath).isSymbolicLink()) return { ok: false, issues: [] };
-
-    const latest = latestWorkerBlockerEvents(
-      scopedWorkerBlockerEvents(readFileSync(logPath), repoSlug),
-    );
-    const issues = [...new Set(latest
-      .filter((event) => event.blocking === true)
-      .map((event) => cleanIssueNumber(event.issue_number))
-      .filter((issueNumber) => issueNumber !== null))]
-      .sort((left, right) => left - right)
-      .slice(0, limit);
-    return { ok: true, issues };
-  } catch {
-    return { ok: false, issues: [] };
-  } finally {
-    if (lockToken) {
-      try {
-        releaseLock(lockPath, lockToken);
-      } catch {
-        // Read-only candidate discovery remains fail open.
       }
     }
   }
@@ -332,16 +190,18 @@ function parseCliArguments(argv) {
   return { event, options };
 }
 
-function main() {
+async function main() {
   const [command, ...args] = process.argv.slice(2);
   const { event, options } = parseCliArguments(args);
   if (command === "append") return appendWorkerBlockerEvent(event, options) ? 0 : 1;
   if (command === "resolve-issue") {
+    const { resolveWorkerBlockersForIssue } = await import("./worker-blocker-reconcile.mjs");
     const result = resolveWorkerBlockersForIssue(event, options);
     if (result.ok) process.stdout.write(`${result.resolvedCount}\n`);
     return result.ok ? 0 : 1;
   }
   if (command === "list-active-issues") {
+    const { listActiveWorkerBlockerIssues } = await import("./worker-blocker-reconcile.mjs");
     const result = listActiveWorkerBlockerIssues(event, options);
     if (result.ok && result.issues.length > 0) process.stdout.write(`${result.issues.join("\n")}\n`);
     return result.ok ? 0 : 1;
@@ -350,5 +210,7 @@ function main() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  process.exitCode = main();
+  main()
+    .then((exitCode) => { process.exitCode = exitCode; })
+    .catch(() => { process.exitCode = 1; });
 }

--- a/.agents/scripts/worker-blocker-reconcile.mjs
+++ b/.agents/scripts/worker-blocker-reconcile.mjs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+import {
+  acquireWorkerBlockerLock as acquireLock,
+  releaseWorkerBlockerLock as releaseLock,
+} from "./worker-blocker-lock.mjs";
+import {
+  appendNormalizedWorkerBlockerEventsUnlocked,
+  cleanWorkerBlockerIssueNumber,
+  normalizeWorkerBlockerRepoSlug,
+  resolveWorkerBlockerLogPath,
+  resolveWorkerBlockerMaxBytes,
+  WORKER_BLOCKER_SCHEMA,
+} from "./worker-blocker-log.mjs";
+
+function parseWorkerBlockerEvents(content) {
+  const events = [];
+  for (const line of content.toString("utf8").split("\n")) {
+    if (!line) continue;
+    try {
+      const event = JSON.parse(line);
+      if (event?.schema === WORKER_BLOCKER_SCHEMA) events.push(event);
+    } catch {
+      // Malformed historical rows are ignored, matching the fail-open readers.
+    }
+  }
+  return events;
+}
+
+function workerBlockerIdentity(event) {
+  const sessionKey = typeof event.session_key === "string" ? event.session_key : "";
+  const requestId = event.request_id === null || event.request_id === undefined
+    ? "unknown"
+    : String(event.request_id);
+  return `${event.repo_slug || ""}|${event.issue_number ?? ""}|${sessionKey || requestId}`;
+}
+
+function latestWorkerBlockerEvents(events) {
+  const latest = new Map();
+  for (const event of events) {
+    const identity = workerBlockerIdentity(event);
+    const timestamp = Number.isFinite(Number(event.ts)) ? Number(event.ts) : 0;
+    const current = latest.get(identity);
+    if (!current || timestamp >= current.timestamp) latest.set(identity, { event, timestamp });
+  }
+  return [...latest.values()].map(({ event }) => event);
+}
+
+function scopedWorkerBlockerEvents(content, repoSlug, issueNumber = null) {
+  return parseWorkerBlockerEvents(content).filter((event) => {
+    const eventRepo = String(event.repo_slug || "").toLowerCase();
+    const eventIssue = cleanWorkerBlockerIssueNumber(event.issue_number);
+    return eventRepo === repoSlug && eventIssue !== null
+      && (issueNumber === null || eventIssue === issueNumber);
+  });
+}
+
+function activeWorkerBlockerEvents(logPath, repoSlug, issueNumber = null) {
+  const scoped = scopedWorkerBlockerEvents(readFileSync(logPath), repoSlug, issueNumber);
+  return latestWorkerBlockerEvents(scoped).filter((event) => event.blocking === true);
+}
+
+function workerBlockerScope(input, options) {
+  const issueNumber = cleanWorkerBlockerIssueNumber(input.issue_number);
+  const repoSlug = normalizeWorkerBlockerRepoSlug(input.repo_slug, options);
+  if (issueNumber === null || !repoSlug.includes("/")) throw new Error("Invalid worker blocker scope");
+  return { issueNumber, repoSlug };
+}
+
+function safeWorkerBlockerLog(logPath) {
+  if (lstatSync(logPath).isSymbolicLink()) throw new Error("Refusing symlinked blocker log");
+}
+
+function terminalResolutionOptions(active, options) {
+  const requestedNow = options.now instanceof Date ? options.now : new Date();
+  const latestActiveTimestamp = active.reduce((maximum, event) => {
+    const timestamp = Number.isFinite(Number(event.ts)) ? Number(event.ts) : 0;
+    return Math.max(maximum, timestamp);
+  }, 0);
+  const resolutionEpoch = Math.max(Math.floor(requestedNow.getTime() / 1000), latestActiveTimestamp + 1);
+  return { ...options, now: new Date(resolutionEpoch * 1000) };
+}
+
+function terminalWorkerBlockerEvents(active, input, issueNumber, repoSlug) {
+  return active.map((event) => ({
+    event: input.event || "issue_terminal_reconciled",
+    status: input.status || "resolved",
+    reason: input.reason || "issue_terminal",
+    blocking: false,
+    source: input.source || "worker-blocker-log",
+    issue_number: issueNumber,
+    repo_slug: repoSlug,
+    session_key: event.session_key || "",
+    request_id: event.request_id ?? "",
+    permission: event.permission || "",
+    tool: event.tool || "",
+    risk_level: event.risk_level || "",
+    grantable: typeof event.grantable === "boolean" ? event.grantable : null,
+    detail: input.detail || "",
+  }));
+}
+
+function releaseLockSafely(lockPath, lockToken) {
+  if (!lockToken) return;
+  try {
+    releaseLock(lockPath, lockToken);
+  } catch {
+    // Reconciliation is best effort and must not block issue closure.
+  }
+}
+
+function resolutionResult(ok, resolvedCount = 0) {
+  return { ok, resolvedCount };
+}
+
+export function resolveWorkerBlockersForIssue(input = {}, options = {}) {
+  let result = resolutionResult(false);
+  let lockPath = "";
+  let lockToken = "";
+  try {
+    const { issueNumber, repoSlug } = workerBlockerScope(input, options);
+    const logPath = resolveWorkerBlockerLogPath(options);
+    const maxBytes = resolveWorkerBlockerMaxBytes(options);
+    mkdirSync(dirname(logPath), { recursive: true, mode: 0o700 });
+    if (existsSync(logPath)) safeWorkerBlockerLog(logPath);
+    lockPath = `${logPath}.lock`;
+    lockToken = acquireLock(lockPath);
+    if (!lockToken) throw new Error("Worker blocker lock unavailable");
+
+    if (!existsSync(logPath)) {
+      result = resolutionResult(true);
+    } else {
+      safeWorkerBlockerLog(logPath);
+      const active = activeWorkerBlockerEvents(logPath, repoSlug, issueNumber);
+      if (active.length === 0) {
+        result = resolutionResult(true);
+      } else {
+        const terminalEvents = terminalWorkerBlockerEvents(active, input, issueNumber, repoSlug);
+        const resolutionOptions = terminalResolutionOptions(active, options);
+        if (appendNormalizedWorkerBlockerEventsUnlocked(
+          logPath,
+          terminalEvents,
+          resolutionOptions,
+          maxBytes,
+        )) result = resolutionResult(true, terminalEvents.length);
+      }
+    }
+  } catch {
+    // Fail open: closure paths continue while the active record stays visible.
+  } finally {
+    releaseLockSafely(lockPath, lockToken);
+  }
+  return result;
+}
+
+function activeIssueNumbers(logPath, repoSlug, limit) {
+  return [...new Set(activeWorkerBlockerEvents(logPath, repoSlug)
+    .map((event) => cleanWorkerBlockerIssueNumber(event.issue_number))
+    .filter((issueNumber) => issueNumber !== null))]
+    .sort((left, right) => left - right)
+    .slice(0, limit);
+}
+
+function workerBlockerCandidateLimit(value) {
+  const requestedLimit = Number(value ?? 50);
+  return Number.isSafeInteger(requestedLimit) && requestedLimit > 0 ? requestedLimit : 50;
+}
+
+export function listActiveWorkerBlockerIssues(input = {}, options = {}) {
+  let result = { ok: false, issues: [] };
+  let lockPath = "";
+  let lockToken = "";
+  try {
+    const repoSlug = normalizeWorkerBlockerRepoSlug(input.repo_slug, options);
+    if (!repoSlug.includes("/")) throw new Error("Invalid worker blocker repository");
+    const logPath = resolveWorkerBlockerLogPath(options);
+    if (!existsSync(logPath)) {
+      result = { ok: true, issues: [] };
+    } else {
+      safeWorkerBlockerLog(logPath);
+      lockPath = `${logPath}.lock`;
+      lockToken = acquireLock(lockPath);
+      if (!lockToken || !existsSync(logPath)) throw new Error("Worker blocker log unavailable");
+      safeWorkerBlockerLog(logPath);
+      result = {
+        ok: true,
+        issues: activeIssueNumbers(logPath, repoSlug, workerBlockerCandidateLimit(input.limit)),
+      };
+    }
+  } catch {
+    // Fail open: callers skip ambiguous candidate discovery.
+  } finally {
+    releaseLockSafely(lockPath, lockToken);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Add locked identity-preserving terminal reconciliation, invoke it after verified closure, and backfill bounded active blocker candidates without label-dependent discovery.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-worker-blocker-log.mjs, .agents/scripts/dependency-event-reconciler.sh, .agents/scripts/shared-dispatch-label-cleanup.sh, .agents/scripts/tests/test-dependency-event-reconciler.sh, .agents/scripts/tests/test-dispatch-label-cleanup.sh, .agents/scripts/tests/test-pulse-diagnose-helper.sh, .agents/scripts/tests/test-worker-activity-helper.sh, .agents/scripts/worker-blocker-log.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Node blocker logger tests (9), dispatch cleanup tests (6), dependency reconciler tests (32), worker activity tests (108), pulse diagnose tests (95), ShellCheck, bash -n, and linters-local.sh all pass.

Resolves #28566


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3h 12m and 1,795,389 tokens on this with the user in an interactive session.