### PR TITLE
GH#28584: fix: validate commit-and-pr metadata before mutation

### DIFF
--- a/.agents/scripts/full-loop-helper-risk.sh
+++ b/.agents/scripts/full-loop-helper-risk.sh
@@ -26,6 +26,36 @@ _normalize_runtime_risk() {
 	return 0
 }
 
+# Normalize an explicit testing-evidence level to the spelling used in PR bodies.
+_normalize_runtime_testing_level() {
+	local requested_testing_level="${1:-}"
+	local normalized=""
+	normalized=$(printf '%s' "$requested_testing_level" | tr '[:upper:]' '[:lower:]')
+	case "$normalized" in
+	"$_full_loop_runtime_verified_marker" | self-assessed) printf '%s\n' "$normalized" ;;
+	*)
+		print_error "Invalid --testing-level '${requested_testing_level}'. Expected ${_full_loop_runtime_verified_marker} or self-assessed."
+		return 1
+		;;
+	esac
+	return 0
+}
+
+# Reject invalid caller-supplied metadata before commit-and-pr mutates Git state.
+# Empty values remain deferred because their defaults require the final diff.
+_validate_explicit_pr_metadata() {
+	local requested_risk="${1:-}"
+	local requested_testing_level="${2:-}"
+
+	if [[ -n "$requested_risk" ]]; then
+		_normalize_runtime_risk "$requested_risk" >/dev/null || return 1
+	fi
+	if [[ -n "$requested_testing_level" ]]; then
+		_normalize_runtime_testing_level "$requested_testing_level" >/dev/null || return 1
+	fi
+	return 0
+}
+
 _runtime_risk_rank() {
 	local runtime_risk="$1"
 	case "$runtime_risk" in
@@ -280,20 +310,12 @@ _resolve_runtime_testing_level() {
 	local testing_level=""
 
 	if [[ -n "$requested_testing_level" ]]; then
-		testing_level=$(printf '%s' "$requested_testing_level" | tr '[:upper:]' '[:lower:]')
+		testing_level=$(_normalize_runtime_testing_level "$requested_testing_level") || return 1
 	elif _summary_declares_runtime_verified "$summary_testing"; then
 		testing_level="$_full_loop_runtime_verified_marker"
 	else
 		testing_level="self-assessed"
 	fi
-
-	case "$testing_level" in
-	"$_full_loop_runtime_verified_marker" | self-assessed) ;;
-	*)
-		print_error "Invalid --testing-level '${requested_testing_level}'. Expected ${_full_loop_runtime_verified_marker} or self-assessed."
-		return 1
-		;;
-	esac
 
 	if [[ "$testing_level" == "$_full_loop_runtime_verified_marker" ]] && ! _runtime_evidence_is_substantive "$summary_testing"; then
 		print_error "${_full_loop_runtime_verified_marker} requires non-empty testing evidence; PR body generation blocked."

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -86,6 +86,7 @@ cmd_commit_and_pr() {
 	# Validate inputs and detect repo/branch (sets $repo and $branch in this scope)
 	local repo="" branch=""
 	_validate_commit_and_pr_inputs "$issue_number" "$commit_message" || return 1
+	_validate_explicit_pr_metadata "$runtime_risk" "$testing_level" || return 1
 
 	_stage_and_commit "$commit_message" || return 1
 	# GH#27902: WIP commits are durable checkpoints, not publishable history.

--- a/.agents/scripts/tests/test-full-loop-runtime-risk.sh
+++ b/.agents/scripts/tests/test-full-loop-runtime-risk.sh
@@ -118,11 +118,11 @@ mkdir -p "${COMMENT_REPO}/src"
 /usr/bin/git -C "$COMMENT_REPO" config user.email "runtime-risk@example.invalid"
 printf '#!/usr/bin/env bash\nprintf "ok\\n"\n# Old credential comment.\n' >"${COMMENT_REPO}/src/app.sh"
 /usr/bin/git -C "$COMMENT_REPO" add src/app.sh
-/usr/bin/git -C "$COMMENT_REPO" commit -qm "fixture: add runtime file"
+/usr/bin/git -C "$COMMENT_REPO" -c commit.gpgSign=false commit -qm "fixture: add runtime file"
 comment_base=$(/usr/bin/git -C "$COMMENT_REPO" rev-parse HEAD)
 printf '#!/usr/bin/env bash\nprintf "ok\\n"\n# New credential comment.\n' >"${COMMENT_REPO}/src/app.sh"
 /usr/bin/git -C "$COMMENT_REPO" add src/app.sh
-/usr/bin/git -C "$COMMENT_REPO" commit -qm "docs: update source comment"
+/usr/bin/git -C "$COMMENT_REPO" -c commit.gpgSign=false commit -qm "docs: update source comment"
 comment_body=$(cd "$COMMENT_REPO" && _build_pr_body \
 	"7" \
 	"Update a source comment" \
@@ -150,6 +150,46 @@ extra_labels=()
 _parse_commit_and_pr_args --issue 4 --message "test" --risk-level High --testing-level runtime-verified
 assert_contains "risk level flag is accepted" "$runtime_risk" "High"
 assert_contains "testing level flag is accepted" "$testing_level" "runtime-verified"
+
+ORDERING_BIN="${TEST_ROOT}/ordering-bin"
+ORDERING_TRACE="${TEST_ROOT}/ordering-trace"
+mkdir -p "$ORDERING_BIN"
+cat >"${ORDERING_BIN}/git" <<'EOF'
+#!/usr/bin/env bash
+printf 'git %s\n' "$*" >>"$ORDERING_TRACE"
+if [[ "$1" == "branch" && "$2" == "--show-current" ]]; then
+	printf 'feature/metadata-ordering\n'
+fi
+exit 0
+EOF
+cat >"${ORDERING_BIN}/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh %s\n' "$*" >>"$ORDERING_TRACE"
+if [[ "$1" == "repo" && "$2" == "view" ]]; then
+	printf 'example/ordering\n'
+fi
+exit 0
+EOF
+chmod +x "${ORDERING_BIN}/git" "${ORDERING_BIN}/gh"
+
+for invalid_flag in "--testing-level invalid" "--risk-level invalid"; do
+	invalid_option="${invalid_flag%% *}"
+	invalid_value="${invalid_flag#* }"
+	: >"$ORDERING_TRACE"
+	if PATH="${ORDERING_BIN}:$PATH" ORDERING_TRACE="$ORDERING_TRACE" \
+		"${SCRIPT_DIR_TEST}/full-loop-helper.sh" commit-and-pr --issue 4 --message "fix: validate metadata" "$invalid_option" "$invalid_value" >/dev/null 2>&1; then
+		printf 'FAIL invalid metadata is rejected before mutation: %s\n' "$invalid_flag"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	else
+		if grep -Eq '^git (add|commit|rebase|push)|^gh (pr|api .*POST)' "$ORDERING_TRACE"; then
+			printf 'FAIL invalid metadata avoids Git and GitHub mutations: %s\n' "$invalid_flag"
+			TESTS_FAILED=$((TESTS_FAILED + 1))
+		else
+			printf 'PASS invalid metadata avoids Git and GitHub mutations: %s\n' "$invalid_flag"
+		fi
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
+done
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Validate explicit risk and testing metadata before any Git or GitHub mutation.

## Files Changed

.agents/scripts/full-loop-helper-risk.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/tests/test-full-loop-runtime-risk.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with bash .agents/scripts/tests/test-full-loop-runtime-risk.sh, ShellCheck, and .agents/scripts/linters-local.sh

Resolves #28584


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 4m and 79,439 tokens on this as a headless worker.