### PR TITLE
GH#28540: isolate forge projection checkout token

### DIFF
--- a/.agents/scripts/tests/test-forge-event-workflow.sh
+++ b/.agents/scripts/tests/test-forge-event-workflow.sh
@@ -26,8 +26,14 @@ assert "forge-event-mapping-helper.sh" in normal
 assert "task-publication-worker-helper.sh" in normal
 assert "forge-coordinator-state-helper.sh" in normal
 assert "upload-artifact" in normal
+projection_checkout = next(step for step in jobs["forge-event"]["steps"] if step.get("name") == "Checkout repository projection")
+assert projection_checkout["with"]["token"] == "${{ secrets.GITHUB_TOKEN }}"
 ingest = next(step for step in jobs["forge-event"]["steps"] if step.get("name") == "Ingest event and execute publication queue")
 assert ingest["env"]["GH_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
+push_checkout = next(step for step in jobs["sync-on-push"]["steps"] if step.get("name") == "Checkout")
+assert push_checkout["with"]["token"] == "${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}"
+push_warning = next(step for step in jobs["sync-on-push"]["steps"] if step.get("name") == "Check SYNC_PAT visibility (t2166)")
+assert "SYNC_PAT not present in this run" in push_warning["run"]
 PY
 
 for caller in "$SELF_CALLER" "$CALLER_TEMPLATE"; do

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
-          token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout coordinator scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
## Summary

- use the job-scoped `GITHUB_TOKEN` for the read-only forge-event repository projection checkout
- preserve `SYNC_PAT` preference and visibility warnings for protected `TODO.md` push jobs
- add workflow-shape regression assertions for both credential boundaries

## Verification

- `bash .agents/scripts/tests/test-forge-event-workflow.sh`
- `shellcheck .agents/scripts/tests/test-forge-event-workflow.sh`
- pre-commit workflow YAML validation
- `bun run typecheck` via the pre-push repository verification hook

Resolves #28540

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.3
