### PR TITLE
t18176: Enable sequential social phase bootstrap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1202,7 +1202,7 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18175 Clarify self-improvement auto-dispatch authority boundary #documentation ref:GH#28582
 
-- [ ] t18176 Plan secure personal and shared social knowledge corpora #parent-task #no-auto-dispatch #enhancement #framework #knowledge #security ~23h tier:thinking ref:GH#28587 logged:2026-07-25 -> [todo/tasks/t18176-brief.md]
+- [ ] t18176 Plan secure personal and shared social knowledge corpora #parent-task #enhancement #framework #knowledge #security ~23h tier:thinking ref:GH#28587 logged:2026-07-25 -> [todo/tasks/t18176-brief.md]
 
 ## In Progress
 

--- a/todo/tasks/t18176-brief.md
+++ b/todo/tasks/t18176-brief.md
@@ -60,6 +60,10 @@ This is a `parent-task`. Planning and intermediate child PRs use a non-closing
 reference to the parent. Only the final child may close the parent after every
 declared phase is filed, merged, and verified.
 
+Keep the `parent-task` label as the permanent parent dispatch block. Do not add
+`no-auto-dispatch`: `shared-phase-filing.sh` interprets that label as an explicit
+opt-out from both initial phase bootstrap and post-merge sequential auto-filing.
+
 ## Seeded Draft PR
 
 - **Decision:** Skipped
@@ -122,8 +126,8 @@ declared phase is filed, merged, and verified.
 ### Implementation Steps
 
 1. Land this parent plan and brief without changing runtime behavior.
-2. Let parent reconciliation file Phase 1 as a native child issue after the
-   planning state is canonical.
+2. Keep the parent blocked by `parent-task`, without `no-auto-dispatch`, and let
+   parent reconciliation file Phase 1 after the planning state is canonical.
 3. Before each child is dispatchable, re-run memory recall, duplicate discovery,
    file-reference verification, task-tier validation, and brief readiness.
 4. Preserve sequential GitHub dependencies so only one schema-changing leaf is


### PR DESCRIPTION
## Summary

Remove the no-auto-dispatch metadata collision while retaining parent-task as the permanent dispatch block, so shared-phase-filing can bootstrap Phase 1 and continue later phases after prior merges.

## Files Changed

TODO.md, todo/tasks/t18176-brief.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — .agents/scripts/verify-brief.sh todo/tasks/t18176-brief.md; .agents/scripts/verify-brief-helper.sh check-readiness todo/tasks/t18176-brief.md; .agents/scripts/linters-local.sh --changed

For #28587


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 1h 40m and 910,111 tokens on this with the user in an interactive session.