### PR TITLE
GH#28594: fix: validate runtime risk before remote mutation

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -872,13 +872,12 @@ _check_and_handle_shallow_clone() {
 	fi
 }
 
-# Rebase onto the detected origin default branch and force-push the current branch.
-# Args: $1=branch $2=skip_hooks (0|1, optional, default 0) $3=skip_rebase (0|1, optional, default 0)
-# Returns 1 on rebase conflict or push failure.
-_rebase_and_push() {
+# Rebase onto the detected origin default branch without mutating the remote.
+# Args: $1=branch $2=skip_rebase (0|1, optional, default 0)
+# Returns 1 on rebase conflict.
+_rebase_for_push() {
 	local branch="$1"
-	local skip_hooks="${2:-0}"
-	local skip_rebase="${3:-0}"
+	local skip_rebase="${2:-0}"
 	local base_branch="" base_ref=""
 	base_branch=$(_resolve_remote_default_branch origin) || return 1
 	base_ref="origin/${base_branch}"
@@ -927,6 +926,14 @@ _rebase_and_push() {
 			git commit -m "chore: reset .task-counter to ${base_ref} value (t2229 race prevention)" --no-verify
 		fi
 	fi
+	return 0
+}
+
+# Push a branch after all final-diff metadata validation has passed.
+# Args: $1=branch $2=skip_hooks (0|1, optional, default 0)
+_push_branch() {
+	local branch="$1"
+	local skip_hooks="${2:-0}"
 
 	print_info "Pushing to origin/${branch}..."
 
@@ -960,6 +967,16 @@ _rebase_and_push() {
 		print_error "Push failed (exit ${push_rc}). Check remote state and retry."
 		return 1
 	fi
+	return 0
+}
+
+# Compatibility wrapper for callers that do not need a pre-push validation gap.
+_rebase_and_push() {
+	local branch="$1"
+	local skip_hooks="${2:-0}"
+	local skip_rebase="${3:-0}"
+	_rebase_for_push "$branch" "$skip_rebase" || return 1
+	_push_branch "$branch" "$skip_hooks" || return 1
 	return 0
 }
 

--- a/.agents/scripts/full-loop-helper-risk.sh
+++ b/.agents/scripts/full-loop-helper-risk.sh
@@ -88,19 +88,14 @@ _runtime_paths_are_low() {
 	local files_changed="${1:-}"
 	local path=""
 	local saw_path=0
-	local old_ifs="$IFS"
-	IFS=','
-	for path in $files_changed; do
-		IFS="$old_ifs"
+	while IFS= read -r path; do
 		path="${path#"${path%%[![:space:]]*}"}"
 		[[ -z "$path" ]] && continue
 		saw_path=1
 		if ! _runtime_path_is_low "$path"; then
-			IFS="$old_ifs"
 			return 1
 		fi
-	done
-	IFS="$old_ifs"
+	done < <(printf '%s\n' "$files_changed" | tr ',' '\n')
 	[[ "$saw_path" -eq 1 ]] && return 0
 	return 1
 }
@@ -110,17 +105,13 @@ _runtime_paths_are_low() {
 _runtime_paths_keyword_context() {
 	local files_changed="${1:-}"
 	local path=""
-	local old_ifs="$IFS"
-	IFS=','
-	for path in $files_changed; do
-		IFS="$old_ifs"
+	while IFS= read -r path; do
 		path="${path#"${path%%[![:space:]]*}"}"
 		[[ -z "$path" ]] && continue
 		if ! _runtime_path_is_low "$path"; then
 			printf '%s\n' "$path"
 		fi
-	done
-	IFS="$old_ifs"
+	done < <(printf '%s\n' "$files_changed" | tr ',' '\n')
 	return 0
 }
 
@@ -286,7 +277,9 @@ _derive_runtime_risk() {
 		runtime_paths=$(_runtime_paths_keyword_context "$files_changed") || return 1
 		context="${context} ${runtime_paths}"
 		if [[ -n "$base_ref" ]]; then
-			diff_context=$(_runtime_diff_keyword_context "$base_ref" || true)
+			if ! diff_context=$(_runtime_diff_keyword_context "$base_ref"); then
+				return 1
+			fi
 			context="${context} ${diff_context}"
 		fi
 		context=$(printf '%s' "$context" | tr '[:upper:]' '[:lower:]')

--- a/.agents/scripts/full-loop-helper-risk.sh
+++ b/.agents/scripts/full-loop-helper-risk.sh
@@ -105,6 +105,41 @@ _runtime_paths_are_low() {
 	return 1
 }
 
+# Print only runtime-relevant path names from the comma-separated PR file list.
+# Low-only path names must not contribute policy keywords to a mixed diff.
+_runtime_paths_keyword_context() {
+	local files_changed="${1:-}"
+	local path=""
+	local old_ifs="$IFS"
+	IFS=','
+	for path in $files_changed; do
+		IFS="$old_ifs"
+		path="${path#"${path%%[![:space:]]*}"}"
+		[[ -z "$path" ]] && continue
+		if ! _runtime_path_is_low "$path"; then
+			printf '%s\n' "$path"
+		fi
+	done
+	IFS="$old_ifs"
+	return 0
+}
+
+# Print diff hunks only for runtime-relevant files. Documentation, tests,
+# fixtures, and linter configuration remain evidence that the branch changed,
+# but their prose must not raise the risk of unrelated runtime code.
+_runtime_diff_keyword_context() {
+	local base_ref="$1"
+	local path=""
+	git rev-parse --verify "${base_ref}^{commit}" >/dev/null 2>&1 || return 1
+	while IFS= read -r path; do
+		[[ -z "$path" ]] && continue
+		if ! _runtime_path_is_low "$path"; then
+			git diff --unified=0 --no-color --no-ext-diff "${base_ref}..HEAD" -- "$path" 2>/dev/null || true
+		fi
+	done < <(git diff --name-only "${base_ref}..HEAD" 2>/dev/null)
+	return 0
+}
+
 # Return success only when every changed content line is visibly a comment or
 # whitespace. Ambiguous block-comment edits fail upward to Medium.
 _runtime_diff_is_comments_only() {
@@ -238,7 +273,8 @@ _derive_runtime_risk() {
 	local files_changed="${2:-}"
 	local summary_what="${3:-}"
 	local base_ref="${4:-}"
-	local context="${summary_what} ${files_changed}"
+	local runtime_paths=""
+	local context="${summary_what}"
 	local diff_context=""
 	local detected_risk="Medium"
 
@@ -247,8 +283,10 @@ _derive_runtime_risk() {
 	elif [[ -n "$base_ref" ]] && _runtime_diff_is_comments_only "$base_ref"; then
 		detected_risk="Low"
 	else
+		runtime_paths=$(_runtime_paths_keyword_context "$files_changed") || return 1
+		context="${context} ${runtime_paths}"
 		if [[ -n "$base_ref" ]]; then
-			diff_context=$(git diff --unified=0 --no-color --no-ext-diff "${base_ref}..HEAD" 2>/dev/null || true)
+			diff_context=$(_runtime_diff_keyword_context "$base_ref" || true)
 			context="${context} ${diff_context}"
 		fi
 		context=$(printf '%s' "$context" | tr '[:upper:]' '[:lower:]')

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -97,7 +97,18 @@ cmd_commit_and_pr() {
 	# Inserted between commit and push so amends apply to the same commit
 	# the worker just made, and so failures abort BEFORE we push broken code.
 	_run_project_validators "$skip_hooks" || return 1
-	_rebase_and_push "$branch" "$skip_hooks" "$skip_rebase" || return 1
+	_rebase_for_push "$branch" "$skip_rebase" || return 1
+
+	# Derive final-diff metadata after rebase but before any remote mutation.
+	# Invalid risk/testing evidence must not leave a pushed orphan branch.
+	local files_changed=""
+	local base_branch="" base_ref=""
+	local closing_keyword="Resolves"
+	base_branch=$(_resolve_remote_default_branch origin) || return 1
+	base_ref="origin/${base_branch}"
+	files_changed=$(git diff --name-only "${base_ref}..HEAD" 2>/dev/null | tr '\n' ',' | sed 's/,$//; s/,/, /g' || echo "")
+	local pr_body=""
+	pr_body=$(_build_pr_body "$issue_number" "$summary_what" "$summary_testing" "$files_changed" "" "$closing_keyword" "$runtime_risk" "$testing_level" "$base_ref") || return 1
 
 	# Build PR metadata (t2720: prefer tNNN from TODO.md so issue-sync's
 	# PR-merge auto-completion regex can extract a task_id and flip [ ] → [x]).
@@ -125,15 +136,8 @@ cmd_commit_and_pr() {
 		sig_footer=$("$sig_helper" footer 2>/dev/null || echo "")
 	fi
 
-	local files_changed=""
-	local base_branch="" base_ref=""
-	base_branch=$(_resolve_remote_default_branch origin) || return 1
-	base_ref="origin/${base_branch}"
-	files_changed=$(git diff --name-only "${base_ref}..HEAD" 2>/dev/null | tr '\n' ',' | sed 's/,$//; s/,/, /g' || echo "")
-
 	# t2242: Determine closing keyword — auto-swap Resolves to For when linked
 	# issue has parent-task label, unless --allow-parent-close overrides.
-	local closing_keyword="Resolves"
 	if [[ "$allow_parent_close" -eq 1 ]]; then
 		closing_keyword="Resolves"
 	elif _issue_has_parent_task_label "$issue_number" "$repo"; then
@@ -141,7 +145,6 @@ cmd_commit_and_pr() {
 		print_info "Issue #${issue_number} has parent-task label — using 'For' keyword (t2242)"
 	fi
 
-	local pr_body=""
 	pr_body=$(_build_pr_body "$issue_number" "$summary_what" "$summary_testing" "$files_changed" "$sig_footer" "$closing_keyword" "$runtime_risk" "$testing_level" "$base_ref") || return 1
 
 	# t2046: parent-task keyword guard — prevent Resolves/Closes/Fixes on
@@ -188,6 +191,8 @@ Worker aborted PR creation: issue #${issue_number} was already closed by the tim
 			2>/dev/null || true
 		return 1
 	fi
+
+	_push_branch "$branch" "$skip_hooks" || return 1
 
 	local pr_number=""
 	pr_number=$(_create_pr "$repo" "$pr_title" "$pr_body" "$origin_label" "${extra_labels[@]+"${extra_labels[@]}"}") || return 1

--- a/.agents/scripts/tests/test-full-loop-runtime-risk.sh
+++ b/.agents/scripts/tests/test-full-loop-runtime-risk.sh
@@ -82,6 +82,14 @@ low_body=$(_build_pr_body \
 assert_contains "non-runtime files remain Low despite policy terms" "$low_body" "**Risk level:** Low"
 assert_contains "Low fixture is self-assessed" "$low_body" "**Verification:** self-assessed"
 
+GLOB_REPO="${TEST_ROOT}/glob-repo"
+mkdir -p "${GLOB_REPO}/src"
+printf 'fixture\n' >"${GLOB_REPO}/src/a.sh"
+glob_context=$(cd "$GLOB_REPO" && _runtime_paths_keyword_context 'src/[ab].sh')
+assert_contains "runtime path context preserves glob metacharacters" "$glob_context" "src/[ab].sh"
+assert_rejected "invalid diff base fails closed" \
+	_derive_runtime_risk "" "src/app.sh" "Adjust helper behavior" "missing-runtime-base"
+
 author_body=$(_build_pr_body \
 	"4" \
 	"Update author metadata" \
@@ -273,11 +281,11 @@ chmod +x "${MUTATION_BIN}/git" "${MUTATION_BIN}/gh"
 if (cd "$MUTATION_REPO" && PATH="${MUTATION_BIN}:$PATH" MUTATION_TRACE="$MUTATION_TRACE" \
 	"${SCRIPT_DIR_TEST}/full-loop-helper.sh" commit-and-pr --issue 9 --message "fix: update runtime behavior" \
 	--summary "Adjust helper behavior" --testing "unit tests pass" >/dev/null 2>&1); then
-	printf 'FAIL derived runtime evidence is rejected before mutation\n'
+	printf 'FAIL commit-and-pr accepted invalid derived runtime evidence\n'
 	TESTS_FAILED=$((TESTS_FAILED + 1))
 elif grep -Eq '^git push|^gh (pr|api .*POST)' "$MUTATION_TRACE" ||
 	/usr/bin/git --git-dir="$MUTATION_REMOTE" show-ref --verify --quiet refs/heads/feature/risk-order; then
-	printf 'FAIL invalid derived evidence avoids remote mutations\n'
+	printf 'FAIL invalid derived evidence allowed remote mutations\n'
 	TESTS_FAILED=$((TESTS_FAILED + 1))
 else
 	printf 'PASS invalid derived evidence avoids remote mutations\n'

--- a/.agents/scripts/tests/test-full-loop-runtime-risk.sh
+++ b/.agents/scripts/tests/test-full-loop-runtime-risk.sh
@@ -161,7 +161,11 @@ mixed_body=$(cd "$MIXED_REPO" && _build_pr_body \
 	"$mixed_base")
 assert_contains "documentation keywords do not contaminate mixed runtime risk" "$mixed_body" "**Risk level:** Medium"
 
-printf '#!/usr/bin/env bash\ncredential="enabled"\nprintf "%%s\\n" "$credential"\n' >"${MIXED_REPO}/src/helper.sh"
+cat >"${MIXED_REPO}/src/helper.sh" <<'EOF'
+#!/usr/bin/env bash
+credential="enabled"
+printf '%s\n' "$credential"
+EOF
 /usr/bin/git -C "$MIXED_REPO" add src/helper.sh
 /usr/bin/git -C "$MIXED_REPO" -c commit.gpgSign=false commit -qm "fixture: add critical runtime behavior"
 mixed_critical_body=$(cd "$MIXED_REPO" && _build_pr_body \

--- a/.agents/scripts/tests/test-full-loop-runtime-risk.sh
+++ b/.agents/scripts/tests/test-full-loop-runtime-risk.sh
@@ -135,6 +135,47 @@ comment_body=$(cd "$COMMENT_REPO" && _build_pr_body \
 	"$comment_base")
 assert_contains "comment-only source change remains Low" "$comment_body" "**Risk level:** Low"
 
+MIXED_REPO="${TEST_ROOT}/mixed-repo"
+mkdir -p "${MIXED_REPO}/src" "${MIXED_REPO}/docs"
+/usr/bin/git -C "$MIXED_REPO" init -q
+/usr/bin/git -C "$MIXED_REPO" config user.name "Runtime Risk Test"
+/usr/bin/git -C "$MIXED_REPO" config user.email "runtime-risk@example.invalid"
+printf '#!/usr/bin/env bash\nprintf "old\\n"\n' >"${MIXED_REPO}/src/helper.sh"
+printf 'Initial guide.\n' >"${MIXED_REPO}/docs/policy.md"
+/usr/bin/git -C "$MIXED_REPO" add src/helper.sh docs/policy.md
+/usr/bin/git -C "$MIXED_REPO" -c commit.gpgSign=false commit -qm "fixture: add mixed files"
+mixed_base=$(/usr/bin/git -C "$MIXED_REPO" rev-parse HEAD)
+printf '#!/usr/bin/env bash\nprintf "new\\n"\n' >"${MIXED_REPO}/src/helper.sh"
+printf 'Document auth, credentials, sessions, and data deletion policy.\n' >"${MIXED_REPO}/docs/policy.md"
+/usr/bin/git -C "$MIXED_REPO" add src/helper.sh docs/policy.md
+/usr/bin/git -C "$MIXED_REPO" -c commit.gpgSign=false commit -qm "fixture: change runtime and policy docs"
+mixed_body=$(cd "$MIXED_REPO" && _build_pr_body \
+	"8" \
+	"Adjust helper output and policy documentation" \
+	"focused tests pass" \
+	"src/helper.sh, docs/policy.md" \
+	"" \
+	"Resolves" \
+	"" \
+	"" \
+	"$mixed_base")
+assert_contains "documentation keywords do not contaminate mixed runtime risk" "$mixed_body" "**Risk level:** Medium"
+
+printf '#!/usr/bin/env bash\ncredential="enabled"\nprintf "%%s\\n" "$credential"\n' >"${MIXED_REPO}/src/helper.sh"
+/usr/bin/git -C "$MIXED_REPO" add src/helper.sh
+/usr/bin/git -C "$MIXED_REPO" -c commit.gpgSign=false commit -qm "fixture: add critical runtime behavior"
+mixed_critical_body=$(cd "$MIXED_REPO" && _build_pr_body \
+	"9" \
+	"Adjust helper behavior and policy documentation" \
+	"runtime-verified with the credential rotation fixture" \
+	"src/helper.sh, docs/policy.md" \
+	"" \
+	"Resolves" \
+	"" \
+	"" \
+	"$mixed_base")
+assert_contains "critical runtime hunk remains Critical in a mixed diff" "$mixed_critical_body" "**Risk level:** Critical"
+
 runtime_risk=""
 testing_level=""
 issue_number=""
@@ -190,6 +231,54 @@ for invalid_flag in "--testing-level invalid" "--risk-level invalid"; do
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
 done
+
+MUTATION_REMOTE="${TEST_ROOT}/mutation-remote.git"
+MUTATION_REPO="${TEST_ROOT}/mutation-repo"
+MUTATION_BIN="${TEST_ROOT}/mutation-bin"
+MUTATION_TRACE="${TEST_ROOT}/mutation-trace"
+mkdir -p "$MUTATION_BIN"
+/usr/bin/git init -q --bare "$MUTATION_REMOTE"
+/usr/bin/git init -q -b main "$MUTATION_REPO"
+/usr/bin/git -C "$MUTATION_REPO" config user.name "Runtime Risk Test"
+/usr/bin/git -C "$MUTATION_REPO" config user.email "runtime-risk@example.invalid"
+printf 'base\n' >"${MUTATION_REPO}/README.md"
+/usr/bin/git -C "$MUTATION_REPO" add README.md
+/usr/bin/git -C "$MUTATION_REPO" -c commit.gpgSign=false commit -qm "fixture: base"
+/usr/bin/git -C "$MUTATION_REPO" remote add origin "$MUTATION_REMOTE"
+/usr/bin/git -C "$MUTATION_REPO" push -q -u origin main
+/usr/bin/git -C "$MUTATION_REPO" remote set-head origin main
+/usr/bin/git -C "$MUTATION_REPO" switch -q -c feature/risk-order
+mkdir -p "${MUTATION_REPO}/src"
+printf '#!/usr/bin/env bash\ncredential_rotation="enabled"\n' >"${MUTATION_REPO}/src/auth.sh"
+
+cat >"${MUTATION_BIN}/git" <<'EOF'
+#!/usr/bin/env bash
+printf 'git %s\n' "$*" >>"$MUTATION_TRACE"
+exec /usr/bin/git "$@"
+EOF
+cat >"${MUTATION_BIN}/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh %s\n' "$*" >>"$MUTATION_TRACE"
+if [[ "$1" == "repo" && "$2" == "view" ]]; then
+	printf 'example/ordering\n'
+fi
+exit 0
+EOF
+chmod +x "${MUTATION_BIN}/git" "${MUTATION_BIN}/gh"
+: >"$MUTATION_TRACE"
+if (cd "$MUTATION_REPO" && PATH="${MUTATION_BIN}:$PATH" MUTATION_TRACE="$MUTATION_TRACE" \
+	"${SCRIPT_DIR_TEST}/full-loop-helper.sh" commit-and-pr --issue 9 --message "fix: update runtime behavior" \
+	--summary "Adjust helper behavior" --testing "unit tests pass" >/dev/null 2>&1); then
+	printf 'FAIL derived runtime evidence is rejected before mutation\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+elif grep -Eq '^git push|^gh (pr|api .*POST)' "$MUTATION_TRACE" ||
+	/usr/bin/git --git-dir="$MUTATION_REMOTE" show-ref --verify --quiet refs/heads/feature/risk-order; then
+	printf 'FAIL invalid derived evidence avoids remote mutations\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+else
+	printf 'PASS invalid derived evidence avoids remote mutations\n'
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Filter mixed-diff risk keyword evidence to runtime paths and validate final derived metadata before push.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/full-loop-helper-risk.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/tests/test-full-loop-runtime-risk.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified with Bash syntax checks, ShellCheck, test-full-loop-runtime-risk.sh (22 tests), and linters-local.sh --changed

Resolves #28594


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 6m and 94,220 tokens on this as a headless worker.