### PR TITLE
GH#28597: add authorized social archive store

### DIFF
--- a/.agents/aidevops/knowledge-plane/01-core-contract.md
+++ b/.agents/aidevops/knowledge-plane/01-core-contract.md
@@ -79,6 +79,34 @@ and paths outside the configured personal base fail closed. Callers cannot
 supply a principal ID or physical corpus ID. Repo mode does not use this catalog
 in Phase 1.
 
+### Per-corpus social store
+
+An authorized personal or workspace corpus may add a private social source and
+local projection without changing repo-mode knowledge:
+
+```text
+<corpus-root>/
+  sources/social/raw/<provider>/<opaque-connection-id>/<sha256>.json.gz
+  index/social.db
+```
+
+`knowledge-social-helper.sh` resolves a logical corpus alias through the
+authenticated catalog before it provisions schema v1, imports a provider-neutral
+archive, reports per-stream coverage, or rebuilds the FTS5 projection. Mutating
+operations require `knowledge.write`; coverage requires `knowledge.read`.
+Callers cannot provide a physical corpus root. Archives
+contain `provider`, opaque `connection_id`, immutable remote account ID,
+`exported_at`, and optional `accounts`, `objects`, `activities`, `media`, and
+`coverage` arrays. Provider-only fields remain in `provider_json`; credential
+keys are rejected before raw persistence.
+
+Canonical JSON bytes are SHA-256 addressed before deterministic compression.
+The raw batch is authoritative and immutable. Normalized rows, coverage, and
+`objects_fts` are projections: repeat import is idempotent, and `rebuild`
+recreates FTS5 from canonical object rows without changing raw evidence. The
+database is mode `0600`, containing directories are `0700`, unsafe IDs and
+symlinks fail closed, and unsupported schema versions reject writes.
+
 **Provision:** `aidevops knowledge init repo` or `aidevops knowledge init personal`.
 **Repair:** `aidevops knowledge provision` is idempotent — safe to re-run.
 

--- a/.agents/aidevops/knowledge-plane/01-core-contract.md
+++ b/.agents/aidevops/knowledge-plane/01-core-contract.md
@@ -94,7 +94,9 @@ local projection without changing repo-mode knowledge:
 authenticated catalog before it provisions schema v1, imports a provider-neutral
 archive, reports per-stream coverage, or rebuilds the FTS5 projection. Mutating
 operations require `knowledge.write`; coverage requires `knowledge.read`.
-Callers cannot provide a physical corpus root. Archives
+Coverage opens only an existing, checkpointed database through SQLite immutable
+read-only mode; it never creates or migrates schema and rejects mutable journal
+sidecars. Callers cannot provide a physical corpus root. Archives
 contain `provider`, opaque `connection_id`, immutable remote account ID,
 `exported_at`, and optional `accounts`, `objects`, `activities`, `media`, and
 `coverage` arrays. Provider-only fields remain in `provider_json`; credential

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# knowledge-social-helper.sh — Provider-neutral social corpus storage CLI
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_HELPER="${SCRIPT_DIR}/knowledge_social_import.py"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  knowledge-social-helper.sh provision [--base PATH] [--alias ALIAS]
+  knowledge-social-helper.sh import-archive [--base PATH] [--alias ALIAS] --archive FILE
+  knowledge-social-helper.sh rebuild [--base PATH] [--alias ALIAS]
+  knowledge-social-helper.sh coverage [--base PATH] [--alias ALIAS]
+
+The authenticated corpus catalog resolves ALIAS with knowledge.write for
+mutating operations or knowledge.read for coverage. Physical corpus paths are
+not accepted from callers.
+
+Archive format:
+  A UTF-8 JSON object with provider, connection_id, and arrays named accounts,
+  objects, activities, media, and coverage. IDs must be provider-stable IDs;
+  connection_id must be an opaque local ID. Unknown provider fields belong in
+  provider_json objects. The original canonical payload is stored immutably.
+EOF
+	return 0
+}
+
+require_runtime() {
+	if ! command -v python3 >/dev/null 2>&1; then
+		printf 'ERROR: python3 is required for social corpus storage\n' >&2
+		return 1
+	fi
+	if [[ ! -r "$PYTHON_HELPER" ]]; then
+		printf 'ERROR: social corpus implementation missing: %s\n' "$PYTHON_HELPER" >&2
+		return 1
+	fi
+	return 0
+}
+
+main() {
+	local subcommand="${1:-help}"
+	if [[ $# -gt 0 ]]; then
+		shift
+	fi
+	case "$subcommand" in
+	provision | import-archive | rebuild | coverage)
+		require_runtime || return 1
+		python3 "$PYTHON_HELPER" "$subcommand" "$@" || return 1
+		;;
+	help | -h | --help)
+		usage
+		;;
+	*)
+		printf 'ERROR: unknown social corpus subcommand: %s\n' "$subcommand" >&2
+		usage >&2
+		return 1
+		;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/knowledge_social_import.py
+++ b/.agents/scripts/knowledge_social_import.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Import provider-neutral archives into a private social corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
+from knowledge_corpus_context import CatalogError
+from knowledge_social_store import (
+    SocialStoreError,
+    connect,
+    connect_read_only,
+    migrate,
+    rebuild_fts,
+    require_schema,
+    validate_opaque,
+    validate_root,
+    write_raw_batch,
+)
+
+FORBIDDEN_CREDENTIAL_KEYS = {
+    "accesstoken",
+    "apikey",
+    "authorization",
+    "clientsecret",
+    "cookie",
+    "cookies",
+    "password",
+    "refreshtoken",
+}
+OBJECT_UPSERT = """INSERT INTO objects(
+    provider,object_type,remote_id,account_remote_id,text_content,created_at,
+    observed_at,evidence_class,provider_json,batch_id) VALUES(?,?,?,?,?,?,?,?,?,?)
+    ON CONFLICT(provider,object_type,remote_id) DO UPDATE SET
+    account_remote_id=excluded.account_remote_id,text_content=excluded.text_content,
+    created_at=excluded.created_at,observed_at=excluded.observed_at,
+    evidence_class=excluded.evidence_class,provider_json=excluded.provider_json,
+    batch_id=excluded.batch_id"""
+ACTIVITY_UPSERT = """INSERT INTO activities(
+    provider,activity_type,remote_id,actor_remote_id,object_remote_id,occurred_at,
+    observed_at,state,provider_json,batch_id) VALUES(?,?,?,?,?,?,?,?,?,?)
+    ON CONFLICT(provider,activity_type,remote_id) DO UPDATE SET
+    actor_remote_id=excluded.actor_remote_id,object_remote_id=excluded.object_remote_id,
+    occurred_at=excluded.occurred_at,
+    observed_at=excluded.observed_at,state=excluded.state,
+    provider_json=excluded.provider_json,batch_id=excluded.batch_id"""
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        raise SocialStoreError(f"archive record requires non-empty {key}")
+    return value
+
+
+def optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SocialStoreError(f"archive record {key} must be text or null")
+    return value
+
+
+def record_list(archive: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    value = archive.get(key, [])
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise SocialStoreError(f"archive {key} must be an array of objects")
+    return value
+
+
+def reject_credentials(value: Any) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized = "".join(character for character in str(key).lower() if character.isalnum())
+            if normalized in FORBIDDEN_CREDENTIAL_KEYS:
+                raise SocialStoreError("archive contains forbidden credential material")
+            reject_credentials(child)
+    elif isinstance(value, list):
+        for child in value:
+            reject_credentials(child)
+
+
+def load_archive(path: Path) -> tuple[dict[str, Any], bytes]:
+    if path.is_symlink() or not path.is_file():
+        raise SocialStoreError("archive must be a regular non-symlink file")
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SocialStoreError("archive is not valid UTF-8 JSON") from error
+    if not isinstance(parsed, dict):
+        raise SocialStoreError("archive root must be an object")
+    reject_credentials(parsed)
+    payload = canonical_json(parsed).encode("utf-8")
+    return parsed, payload
+
+
+def upsert_connection(connection: Any, archive: dict[str, Any], provider: str, connection_id: str) -> None:
+    remote_account_id = required_text(archive, "remote_account_id")
+    enabled_streams = archive.get("enabled_streams", [])
+    policy = archive.get("policy", {})
+    if not isinstance(enabled_streams, list) or not isinstance(policy, dict):
+        raise SocialStoreError("enabled_streams and policy have invalid types")
+    connection.execute(
+        """INSERT INTO connections(
+            connection_id,provider,remote_account_id,auth_profile_ref,enabled_streams,policy_json)
+           VALUES(?,?,?,?,?,?)
+           ON CONFLICT(connection_id) DO UPDATE SET
+             provider=excluded.provider,remote_account_id=excluded.remote_account_id,
+             enabled_streams=excluded.enabled_streams,policy_json=excluded.policy_json""",
+        (connection_id, provider, remote_account_id, None, canonical_json(enabled_streams), canonical_json(policy)),
+    )
+
+
+def import_accounts(connection: Any, archive: dict[str, Any], provider: str) -> None:
+    for record in record_list(archive, "accounts"):
+        connection.execute(
+            """INSERT INTO accounts(provider,remote_id,handle,display_name,observed_at,provider_json)
+               VALUES(?,?,?,?,?,?) ON CONFLICT(provider,remote_id) DO UPDATE SET
+               handle=excluded.handle,display_name=excluded.display_name,
+               observed_at=excluded.observed_at,provider_json=excluded.provider_json""",
+            (provider, required_text(record, "remote_id"), optional_text(record, "handle"),
+             optional_text(record, "display_name"), required_text(record, "observed_at"),
+             canonical_json(record.get("provider_json", {}))),
+        )
+
+
+def import_objects(connection: Any, archive: dict[str, Any], provider: str, batch_id: str) -> None:
+    for record in record_list(archive, "objects"):
+        connection.execute(
+            OBJECT_UPSERT,
+            (provider, required_text(record, "object_type"), required_text(record, "remote_id"),
+             optional_text(record, "account_remote_id"), optional_text(record, "text"),
+             optional_text(record, "created_at"), required_text(record, "observed_at"),
+             required_text(record, "evidence_class"), canonical_json(record.get("provider_json", {})), batch_id),
+        )
+
+
+def import_activities(connection: Any, archive: dict[str, Any], provider: str, batch_id: str) -> None:
+    for record in record_list(archive, "activities"):
+        connection.execute(
+            ACTIVITY_UPSERT,
+            (provider, required_text(record, "activity_type"), required_text(record, "remote_id"),
+             required_text(record, "actor_remote_id"), optional_text(record, "object_remote_id"),
+             optional_text(record, "occurred_at"), required_text(record, "observed_at"),
+             required_text(record, "state"), canonical_json(record.get("provider_json", {})), batch_id),
+        )
+
+
+def import_media(connection: Any, archive: dict[str, Any], provider: str, batch_id: str) -> None:
+    for record in record_list(archive, "media"):
+        byte_size = record.get("byte_size")
+        if byte_size is not None and (not isinstance(byte_size, int) or byte_size < 0):
+            raise SocialStoreError("media byte_size must be a non-negative integer")
+        connection.execute(
+            """INSERT INTO media(
+                provider,remote_id,object_remote_id,content_sha256,mime_type,byte_size,
+                blob_ref,hydration_state,batch_id) VALUES(?,?,?,?,?,?,?,?,?)
+               ON CONFLICT(provider,remote_id) DO UPDATE SET
+                object_remote_id=excluded.object_remote_id,content_sha256=excluded.content_sha256,
+                mime_type=excluded.mime_type,byte_size=excluded.byte_size,blob_ref=excluded.blob_ref,
+                hydration_state=excluded.hydration_state,batch_id=excluded.batch_id""",
+            (provider, required_text(record, "remote_id"), optional_text(record, "object_remote_id"),
+             optional_text(record, "content_sha256"), optional_text(record, "mime_type"), byte_size,
+             optional_text(record, "blob_ref"), required_text(record, "hydration_state"), batch_id),
+        )
+
+
+def import_coverage(connection: Any, archive: dict[str, Any], provider: str, connection_id: str, batch_id: str) -> None:
+    for record in record_list(archive, "coverage"):
+        exhausted = record.get("cursor_exhausted", False)
+        if not isinstance(exhausted, bool):
+            raise SocialStoreError("coverage cursor_exhausted must be boolean")
+        connection.execute(
+            """INSERT INTO coverage_records(
+                provider,connection_id,stream,earliest_at,latest_at,cursor_exhausted,
+                retention_limit,unavailable_reason,status,batch_id,observed_at)
+               VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(provider,connection_id,stream) DO UPDATE SET
+                earliest_at=excluded.earliest_at,latest_at=excluded.latest_at,
+                cursor_exhausted=excluded.cursor_exhausted,retention_limit=excluded.retention_limit,
+                unavailable_reason=excluded.unavailable_reason,status=excluded.status,
+                batch_id=excluded.batch_id,observed_at=excluded.observed_at""",
+            (provider, connection_id, required_text(record, "stream"), optional_text(record, "earliest_at"),
+             optional_text(record, "latest_at"), int(exhausted), optional_text(record, "retention_limit"),
+             optional_text(record, "unavailable_reason"), required_text(record, "status"), batch_id,
+             required_text(record, "observed_at")),
+        )
+
+
+def import_archive(root: Path, archive_path: Path) -> dict[str, Any]:
+    archive, payload = load_archive(archive_path)
+    provider = validate_opaque(required_text(archive, "provider"), "provider")
+    connection_id = validate_opaque(required_text(archive, "connection_id"), "connection_id")
+    completed_at = required_text(archive, "exported_at")
+    database = connect(root)
+    try:
+        migrate(database)
+        batch_id, blob_ref = write_raw_batch(root, provider, connection_id, payload)
+        database.execute("BEGIN IMMEDIATE")
+        upsert_connection(database, archive, provider, connection_id)
+        import_accounts(database, archive, provider)
+        import_objects(database, archive, provider, batch_id)
+        import_activities(database, archive, provider, batch_id)
+        import_media(database, archive, provider, batch_id)
+        import_coverage(database, archive, provider, connection_id, batch_id)
+        resource_count = sum(len(record_list(archive, key)) for key in ("accounts", "objects", "activities", "media"))
+        database.execute(
+            """INSERT OR IGNORE INTO fetch_batches(
+                batch_id,provider,connection_id,stream,response_hash,blob_ref,
+                resource_count,completed_at,terminal_status) VALUES(?,?,?,?,?,?,?,?,?)""",
+            (batch_id, provider, connection_id, "archive", batch_id, blob_ref,
+             resource_count, completed_at, "success"),
+        )
+        database.execute("COMMIT")
+        rebuild_fts(database)
+        return {"batch_id": batch_id, "resource_count": resource_count, "blob_ref": blob_ref}
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()
+
+
+def provision(root: Path) -> None:
+    database = connect(root)
+    try:
+        migrate(database)
+    finally:
+        database.close()
+
+
+def rebuild(root: Path) -> None:
+    database = connect(root)
+    try:
+        migrate(database)
+        rebuild_fts(database)
+    finally:
+        database.close()
+
+
+def coverage(root: Path) -> list[dict[str, Any]]:
+    database = connect_read_only(root)
+    try:
+        require_schema(database)
+        rows = database.execute(
+            """SELECT provider,connection_id,stream,earliest_at,latest_at,cursor_exhausted,
+                      retention_limit,unavailable_reason,status,batch_id,observed_at
+                 FROM coverage_records ORDER BY provider,connection_id,stream"""
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        database.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("provision", "import-archive", "rebuild", "coverage"))
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--archive", type=Path)
+    args = parser.parse_args()
+    if args.command == "import-archive" and args.archive is None:
+        parser.error("import-archive requires --archive")
+    if args.command != "import-archive" and args.archive is not None:
+        parser.error("--archive is only valid with import-archive")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        capability = "knowledge.read" if args.command == "coverage" else "knowledge.write"
+        base = args.base if args.base is not None else Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+        root = validate_root(resolve(base, args.alias, capability))
+        if args.command == "provision":
+            provision(root)
+            result: Any = {"schema_version": 1}
+        elif args.command == "import-archive":
+            result = import_archive(root, args.archive)
+        elif args.command == "rebuild":
+            rebuild(root)
+            result = {"rebuilt": True}
+        else:
+            result = coverage(root)
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (CatalogError, OSError, SocialStoreError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_import.py
+++ b/.agents/scripts/knowledge_social_import.py
@@ -28,13 +28,45 @@ from knowledge_social_store import (
 FORBIDDEN_CREDENTIAL_KEYS = {
     "accesstoken",
     "apikey",
+    "apitoken",
+    "auth",
+    "authentication",
+    "authorization",
+    "bearer",
+    "bearertoken",
+    "clientsecret",
+    "cookie",
+    "cookiejar",
+    "cookies",
+    "credential",
+    "credentials",
+    "csrftoken",
+    "idtoken",
+    "jwt",
+    "oauthtoken",
+    "passphrase",
+    "password",
+    "privatekey",
+    "refreshtoken",
+    "secret",
+    "secretaccesskey",
+    "sessioncookie",
+    "sessiontoken",
+    "setcookie",
+    "token",
+}
+FORBIDDEN_CREDENTIAL_SUFFIXES = (
+    "accesstoken",
+    "apikey",
     "authorization",
     "clientsecret",
     "cookie",
-    "cookies",
     "password",
+    "privatekey",
     "refreshtoken",
-}
+    "secretaccesskey",
+    "sessiontoken",
+)
 OBJECT_UPSERT = """INSERT INTO objects(
     provider,object_type,remote_id,account_remote_id,text_content,created_at,
     observed_at,evidence_class,provider_json,batch_id) VALUES(?,?,?,?,?,?,?,?,?,?)
@@ -84,7 +116,9 @@ def reject_credentials(value: Any) -> None:
     if isinstance(value, dict):
         for key, child in value.items():
             normalized = "".join(character for character in str(key).lower() if character.isalnum())
-            if normalized in FORBIDDEN_CREDENTIAL_KEYS:
+            if normalized in FORBIDDEN_CREDENTIAL_KEYS or normalized.endswith(
+                FORBIDDEN_CREDENTIAL_SUFFIXES
+            ):
                 raise SocialStoreError("archive contains forbidden credential material")
             reject_credentials(child)
     elif isinstance(value, list):

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Private per-corpus social schema and immutable raw-batch storage."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import os
+import re
+import sqlite3
+from pathlib import Path
+
+from knowledge_corpus_context import (
+    CatalogError,
+    validate_directory,
+    validate_private_file,
+)
+
+SCHEMA_VERSION = 1
+OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
+
+
+class SocialStoreError(RuntimeError):
+    """Raised when private social storage cannot be used safely."""
+
+
+def private_directory(root: Path, relative: Path) -> Path:
+    directory = root
+    for component in relative.parts:
+        directory /= component
+        directory.mkdir(mode=0o700, exist_ok=True)
+        try:
+            validate_directory(directory, "social store directory", repair=True)
+        except CatalogError as error:
+            raise SocialStoreError(str(error)) from error
+    return directory
+
+
+def validate_root(root: Path) -> Path:
+    try:
+        return validate_directory(root, "social corpus root", repair=False)
+    except CatalogError as error:
+        raise SocialStoreError(str(error)) from error
+
+
+def database_path(root: Path) -> Path:
+    return root / "index" / "social.db"
+
+
+def connect(root: Path) -> sqlite3.Connection:
+    private_directory(root, Path("index"))
+    path = database_path(root)
+    if path.is_symlink():
+        raise SocialStoreError("social database cannot be a symlink")
+    connection = sqlite3.connect(str(path), isolation_level=None, timeout=5.0)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA busy_timeout=5000")
+    connection.execute("PRAGMA foreign_keys=ON")
+    mode = connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+    if str(mode).lower() != "wal":
+        connection.close()
+        raise SocialStoreError("social database could not enable WAL mode")
+    connection.execute("PRAGMA synchronous=FULL")
+    os.chmod(path, 0o600)
+    return connection
+
+
+def connect_read_only(root: Path) -> sqlite3.Connection:
+    try:
+        validate_directory(root / "index", "social index directory", repair=False)
+        path = database_path(root)
+        validate_private_file(path, "social database", repair=False)
+    except CatalogError as error:
+        raise SocialStoreError(str(error)) from error
+    connection = sqlite3.connect(
+        f"{path.as_uri()}?mode=ro", uri=True, isolation_level=None, timeout=5.0
+    )
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA busy_timeout=5000")
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.execute("PRAGMA query_only=ON")
+    return connection
+
+
+def require_schema(connection: sqlite3.Connection) -> None:
+    current = connection.execute("PRAGMA user_version").fetchone()[0]
+    if current != SCHEMA_VERSION:
+        raise SocialStoreError(f"unsupported social schema version: {current}")
+
+
+def _tables() -> tuple[str, ...]:
+    return (
+        "CREATE TABLE IF NOT EXISTS schema_meta (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)",
+        """CREATE TABLE IF NOT EXISTS connections (
+            connection_id TEXT PRIMARY KEY, provider TEXT NOT NULL,
+            remote_account_id TEXT NOT NULL, auth_profile_ref TEXT,
+            enabled_streams TEXT NOT NULL DEFAULT '[]', policy_json TEXT NOT NULL DEFAULT '{}')""",
+        """CREATE TABLE IF NOT EXISTS accounts (
+            provider TEXT NOT NULL, remote_id TEXT NOT NULL, handle TEXT,
+            display_name TEXT, observed_at TEXT NOT NULL, provider_json TEXT NOT NULL DEFAULT '{}',
+            PRIMARY KEY(provider, remote_id))""",
+        """CREATE TABLE IF NOT EXISTS objects (
+            object_id INTEGER PRIMARY KEY, provider TEXT NOT NULL, object_type TEXT NOT NULL,
+            remote_id TEXT NOT NULL, account_remote_id TEXT, text_content TEXT,
+            created_at TEXT, observed_at TEXT NOT NULL, evidence_class TEXT NOT NULL,
+            provider_json TEXT NOT NULL DEFAULT '{}', batch_id TEXT NOT NULL,
+            UNIQUE(provider, object_type, remote_id))""",
+        """CREATE TABLE IF NOT EXISTS activities (
+            provider TEXT NOT NULL, activity_type TEXT NOT NULL, remote_id TEXT NOT NULL,
+            actor_remote_id TEXT NOT NULL, object_remote_id TEXT, occurred_at TEXT,
+            observed_at TEXT NOT NULL, state TEXT NOT NULL, provider_json TEXT NOT NULL DEFAULT '{}',
+            batch_id TEXT NOT NULL, PRIMARY KEY(provider, activity_type, remote_id))""",
+        """CREATE TABLE IF NOT EXISTS media (
+            provider TEXT NOT NULL, remote_id TEXT NOT NULL, object_remote_id TEXT,
+            content_sha256 TEXT, mime_type TEXT, byte_size INTEGER, blob_ref TEXT,
+            hydration_state TEXT NOT NULL, batch_id TEXT NOT NULL,
+            PRIMARY KEY(provider, remote_id))""",
+        """CREATE TABLE IF NOT EXISTS fetch_batches (
+            batch_id TEXT PRIMARY KEY, provider TEXT NOT NULL, connection_id TEXT NOT NULL,
+            stream TEXT NOT NULL, request_hash TEXT, response_hash TEXT NOT NULL UNIQUE,
+            blob_ref TEXT NOT NULL, resource_count INTEGER NOT NULL, budget_units INTEGER NOT NULL DEFAULT 0,
+            started_at TEXT, completed_at TEXT NOT NULL, terminal_status TEXT NOT NULL)""",
+        """CREATE TABLE IF NOT EXISTS sync_cursors (
+            connection_id TEXT NOT NULL, stream TEXT NOT NULL, cursor TEXT, watermark TEXT,
+            last_success_at TEXT, backfill_complete INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY(connection_id, stream))""",
+        """CREATE TABLE IF NOT EXISTS sync_runs (
+            run_id TEXT PRIMARY KEY, connection_id TEXT NOT NULL, status TEXT NOT NULL,
+            resource_count INTEGER NOT NULL DEFAULT 0, failure_class TEXT, retry_after TEXT,
+            fencing_token TEXT, diagnostics TEXT)""",
+        """CREATE TABLE IF NOT EXISTS tombstones (
+            provider TEXT NOT NULL, object_type TEXT NOT NULL, remote_id TEXT NOT NULL,
+            observed_at TEXT NOT NULL, reason TEXT NOT NULL, retention_action TEXT NOT NULL,
+            batch_id TEXT NOT NULL, PRIMARY KEY(provider, object_type, remote_id))""",
+        """CREATE TABLE IF NOT EXISTS annotations (
+            annotation_id TEXT PRIMARY KEY, object_id INTEGER NOT NULL REFERENCES objects(object_id),
+            principal_id TEXT NOT NULL, visibility TEXT NOT NULL, body TEXT NOT NULL,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL)""",
+        """CREATE TABLE IF NOT EXISTS coverage_records (
+            provider TEXT NOT NULL, connection_id TEXT NOT NULL, stream TEXT NOT NULL,
+            earliest_at TEXT, latest_at TEXT, cursor_exhausted INTEGER NOT NULL DEFAULT 0,
+            retention_limit TEXT, unavailable_reason TEXT, status TEXT NOT NULL,
+            batch_id TEXT NOT NULL, observed_at TEXT NOT NULL,
+            PRIMARY KEY(provider, connection_id, stream))""",
+        "CREATE INDEX IF NOT EXISTS idx_objects_account ON objects(provider, account_remote_id, created_at)",
+        "CREATE INDEX IF NOT EXISTS idx_activities_actor ON activities(provider, actor_remote_id, occurred_at)",
+        "CREATE INDEX IF NOT EXISTS idx_coverage_connection ON coverage_records(connection_id, stream)",
+    )
+
+
+def create_fts(connection: sqlite3.Connection) -> None:
+    try:
+        connection.execute(
+            """CREATE VIRTUAL TABLE IF NOT EXISTS objects_fts USING fts5(
+                provider UNINDEXED, object_type UNINDEXED, remote_id UNINDEXED,
+                account_remote_id UNINDEXED, text_content, evidence_class UNINDEXED,
+                tokenize='unicode61')"""
+        )
+    except sqlite3.OperationalError as error:
+        raise SocialStoreError("SQLite runtime does not provide required FTS5") from error
+
+
+def migrate(connection: sqlite3.Connection) -> None:
+    current = connection.execute("PRAGMA user_version").fetchone()[0]
+    if current not in (0, SCHEMA_VERSION):
+        raise SocialStoreError(f"unsupported social schema version: {current}")
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        for statement in _tables():
+            connection.execute(statement)
+        create_fts(connection)
+        connection.execute(
+            "INSERT OR IGNORE INTO schema_meta(version,applied_at) VALUES(?,strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+            (SCHEMA_VERSION,),
+        )
+        connection.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+        connection.execute("COMMIT")
+    except Exception:
+        connection.execute("ROLLBACK")
+        raise
+
+
+def rebuild_fts(connection: sqlite3.Connection) -> None:
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        connection.execute("DROP TABLE IF EXISTS objects_fts")
+        create_fts(connection)
+        connection.execute(
+            """INSERT INTO objects_fts(
+                provider,object_type,remote_id,account_remote_id,text_content,evidence_class)
+               SELECT provider,object_type,remote_id,account_remote_id,text_content,evidence_class
+                 FROM objects ORDER BY object_id"""
+        )
+        connection.execute("COMMIT")
+    except Exception:
+        connection.execute("ROLLBACK")
+        raise
+
+
+def validate_opaque(value: str, field: str) -> str:
+    if not OPAQUE_ID.fullmatch(value):
+        raise SocialStoreError(f"{field} must be an opaque identifier")
+    return value
+
+
+def write_raw_batch(root: Path, provider: str, connection_id: str, payload: bytes) -> tuple[str, str]:
+    provider = validate_opaque(provider, "provider")
+    connection_id = validate_opaque(connection_id, "connection_id")
+    digest = hashlib.sha256(payload).hexdigest()
+    directory = private_directory(
+        root, Path("sources") / "social" / "raw" / provider / connection_id
+    )
+    path = directory / f"{digest}.json.gz"
+    relative = path.relative_to(root).as_posix()
+    if path.exists():
+        if path.is_symlink():
+            raise SocialStoreError("raw batch cannot be a symlink")
+        with gzip.open(path, "rb") as existing:
+            if hashlib.sha256(existing.read()).hexdigest() != digest:
+                raise SocialStoreError("immutable raw batch hash mismatch")
+        return digest, relative
+    compressed = gzip.compress(payload, compresslevel=9, mtime=0)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        target = os.fdopen(descriptor, "wb")
+        descriptor = -1
+        with target:
+            target.write(compressed)
+            target.flush()
+            os.fsync(target.fileno())
+    except Exception:
+        path.unlink(missing_ok=True)
+        raise
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return digest, relative

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -20,6 +20,7 @@ from knowledge_corpus_context import (
 
 SCHEMA_VERSION = 1
 OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
+SQLITE_MUTABLE_SIDECARS = ("-journal", "-shm", "-wal")
 
 
 class SocialStoreError(RuntimeError):
@@ -49,6 +50,15 @@ def database_path(root: Path) -> Path:
     return root / "index" / "social.db"
 
 
+def require_checkpointed_database(path: Path) -> None:
+    for suffix in SQLITE_MUTABLE_SIDECARS:
+        sidecar = path.with_name(f"{path.name}{suffix}")
+        if sidecar.exists() or sidecar.is_symlink():
+            raise SocialStoreError(
+                "social database has active or uncheckpointed journal state"
+            )
+
+
 def connect(root: Path) -> sqlite3.Connection:
     private_directory(root, Path("index"))
     path = database_path(root)
@@ -74,8 +84,12 @@ def connect_read_only(root: Path) -> sqlite3.Connection:
         validate_private_file(path, "social database", repair=False)
     except CatalogError as error:
         raise SocialStoreError(str(error)) from error
+    require_checkpointed_database(path)
     connection = sqlite3.connect(
-        f"{path.as_uri()}?mode=ro", uri=True, isolation_level=None, timeout=5.0
+        f"{path.as_uri()}?mode=ro&immutable=1",
+        uri=True,
+        isolation_level=None,
+        timeout=5.0,
     )
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA busy_timeout=5000")

--- a/.agents/tests/test-knowledge-social.sh
+++ b/.agents/tests/test-knowledge-social.sh
@@ -176,19 +176,22 @@ else
 	assert_eq "path traversal connection ID is rejected" "rejected" "rejected"
 fi
 
-credential_archive="${TMP_DIR}/credential.json"
-python3 - "$ARCHIVE" "$credential_archive" <<'PY'
+credential_keys=(accessToken clientSecret token secret sessionCookie bearerToken oauthToken setCookie privateKey secretAccessKey x-api-key)
+accepted_credential_keys=""
+for credential_key in "${credential_keys[@]}"; do
+	credential_archive="${TMP_DIR}/credential-${credential_key}.json"
+	python3 - "$ARCHIVE" "$credential_archive" "$credential_key" <<'PY'
 import json
 import sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
-data["provider_json"] = {"accessToken": "must-not-persist", "nested": {"clientSecret": "also-forbidden"}}
+data["provider_json"] = {sys.argv[3]: "must-not-persist"}
 json.dump(data, open(sys.argv[2], "w", encoding="utf-8"))
 PY
-if "$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$credential_archive" >/dev/null 2>&1; then
-	assert_eq "credential material is rejected before raw persistence" "accepted" "rejected"
-else
-	assert_eq "credential material is rejected before raw persistence" "rejected" "rejected"
-fi
+	if "$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$credential_archive" >/dev/null 2>&1; then
+		accepted_credential_keys="${accepted_credential_keys}${credential_key},"
+	fi
+done
+assert_eq "credential key variants are rejected before raw persistence" "$accepted_credential_keys" ""
 assert_eq "rejected archives create no raw batches" "$(python3 -c 'from pathlib import Path; import sys; print(len(list(Path(sys.argv[1]).rglob("*.json.gz"))))' "$CORPUS_ROOT/sources/social/raw")" "2"
 
 unsupported_archive="${TMP_DIR}/unsupported-schema.json"

--- a/.agents/tests/test-knowledge-social.sh
+++ b/.agents/tests/test-knowledge-social.sh
@@ -47,6 +47,32 @@ PY
 	return 0
 }
 
+store_snapshot() {
+	local root="$1"
+	python3 - "$root" <<'PY'
+import hashlib
+import json
+import stat
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+snapshot = {}
+for path in sorted(root.rglob("*")):
+    file_stat = path.lstat()
+    record = {
+        "mode": stat.S_IMODE(file_stat.st_mode),
+        "mtime_ns": file_stat.st_mtime_ns,
+        "size": file_stat.st_size,
+    }
+    if path.is_file():
+        record["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+    snapshot[path.relative_to(root).as_posix()] = record
+print(json.dumps(snapshot, sort_keys=True, separators=(",", ":")))
+PY
+	return 0
+}
+
 cat >"$ARCHIVE" <<'JSON'
 {
   "provider": "xapi",
@@ -92,7 +118,37 @@ connection.close()
 PY
 "$HELPER" rebuild --base "$BASE" --alias personal:default >/dev/null
 assert_eq "projection rebuilds from canonical rows" "$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'evidence'")" "1"
-assert_eq "coverage survives restart and rebuild" "$("$HELPER" coverage --base "$BASE" --alias personal:default | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data[0]["batch_id"] + ":" + data[0]["status"])')" "${first_hash}:complete"
+python3 - "$BASE/catalog.db" <<'PY'
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("UPDATE corpus_grants SET status='inactive' WHERE capability='knowledge.write'")
+connection.commit()
+connection.close()
+PY
+coverage_snapshot_before=$(store_snapshot "$CORPUS_ROOT")
+coverage_result=$("$HELPER" coverage --base "$BASE" --alias personal:default)
+coverage_snapshot_after=$(store_snapshot "$CORPUS_ROOT")
+assert_eq "coverage survives restart with only a read grant" "$(python3 -c 'import json,sys; data=json.loads(sys.argv[1]); print(data[0]["batch_id"] + ":" + data[0]["status"])' "$coverage_result")" "${first_hash}:complete"
+assert_eq "read-only coverage leaves the store unchanged" "$coverage_snapshot_after" "$coverage_snapshot_before"
+: >"$CORPUS_ROOT/index/social.db-wal"
+chmod 0600 "$CORPUS_ROOT/index/social.db-wal"
+if "$HELPER" coverage --base "$BASE" --alias personal:default >/dev/null 2>&1; then
+	assert_eq "coverage rejects active or uncheckpointed journal state" "accepted" "rejected"
+else
+	assert_eq "coverage rejects active or uncheckpointed journal state" "rejected" "rejected"
+fi
+rm "$CORPUS_ROOT/index/social.db-wal"
+python3 - "$BASE/catalog.db" <<'PY'
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("UPDATE corpus_grants SET status='active' WHERE capability='knowledge.write'")
+connection.commit()
+connection.close()
+PY
 assert_eq "database is private" "$(python3 -c 'import os,stat,sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode)))' "$CORPUS_ROOT/index/social.db")" "0o600"
 
 corrected_archive="${TMP_DIR}/corrected.json"

--- a/.agents/tests/test-knowledge-social.sh
+++ b/.agents/tests/test-knowledge-social.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social.sh — Social archive/store regression tests
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+CORPUS_ROOT="${BASE}/_knowledge"
+ARCHIVE="${TMP_DIR}/archive.json"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$CORPUS_ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+connection = sqlite3.connect(sys.argv[1])
+print(connection.execute(sys.argv[2]).fetchone()[0])
+connection.close()
+PY
+	return 0
+}
+
+cat >"$ARCHIVE" <<'JSON'
+{
+  "provider": "xapi",
+  "connection_id": "conn_0123456789abcdef",
+  "remote_account_id": "acct-42",
+  "exported_at": "2026-07-25T00:00:00Z",
+  "enabled_streams": ["authored"],
+  "policy": {"media_hydration": false},
+  "accounts": [{"remote_id": "acct-42", "handle": "mutable", "display_name": "Example", "observed_at": "2026-07-25T00:00:00Z"}],
+  "objects": [{"object_type": "post", "remote_id": "post-1", "account_remote_id": "acct-42", "text": "provider neutral searchable evidence", "created_at": "2024-01-02T00:00:00Z", "observed_at": "2026-07-25T00:00:00Z", "evidence_class": "authored"}],
+  "activities": [{"activity_type": "authored", "remote_id": "activity-1", "actor_remote_id": "acct-42", "object_remote_id": "post-1", "occurred_at": "2024-01-02T00:00:00Z", "observed_at": "2026-07-25T00:00:00Z", "state": "active"}],
+  "media": [],
+  "coverage": [{"stream": "authored", "earliest_at": "2024-01-02T00:00:00Z", "latest_at": "2024-01-02T00:00:00Z", "cursor_exhausted": true, "status": "complete", "observed_at": "2026-07-25T00:00:00Z"}]
+}
+JSON
+
+printf 'Social corpus tests\n'
+mkdir -p "$CORPUS_ROOT"
+chmod 0700 "$BASE" "$CORPUS_ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "1"
+assert_eq "all provider-neutral tables exist" "$(sql_value "SELECT count(*) FROM sqlite_master WHERE name IN ('connections','accounts','objects','activities','media','fetch_batches','sync_cursors','sync_runs','tombstones','annotations','coverage_records','objects_fts')")" "12"
+
+first_result=$("$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$ARCHIVE")
+first_hash=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["batch_id"])' "$first_result")
+assert_eq "archive imports one canonical object" "$(sql_value 'SELECT count(*) FROM objects')" "1"
+assert_eq "archive imports one activity" "$(sql_value 'SELECT count(*) FROM activities')" "1"
+assert_eq "coverage records completeness" "$(sql_value "SELECT status || ':' || cursor_exhausted FROM coverage_records WHERE stream='authored'")" "complete:1"
+assert_eq "FTS projection is searchable" "$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'searchable'")" "1"
+assert_eq "raw evidence hash names immutable batch" "$(sql_value 'SELECT response_hash FROM fetch_batches')" "$first_hash"
+
+"$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$ARCHIVE" >/dev/null
+assert_eq "re-import is idempotent" "$(sql_value "SELECT (SELECT count(*) FROM fetch_batches) || ':' || (SELECT count(*) FROM objects) || ':' || (SELECT count(*) FROM activities)")" "1:1:1"
+
+python3 - "$CORPUS_ROOT/index/social.db" <<'PY'
+import sqlite3
+import sys
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("DELETE FROM objects_fts")
+connection.commit()
+connection.close()
+PY
+"$HELPER" rebuild --base "$BASE" --alias personal:default >/dev/null
+assert_eq "projection rebuilds from canonical rows" "$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'evidence'")" "1"
+assert_eq "coverage survives restart and rebuild" "$("$HELPER" coverage --base "$BASE" --alias personal:default | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data[0]["batch_id"] + ":" + data[0]["status"])')" "${first_hash}:complete"
+assert_eq "database is private" "$(python3 -c 'import os,stat,sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode)))' "$CORPUS_ROOT/index/social.db")" "0o600"
+
+corrected_archive="${TMP_DIR}/corrected.json"
+python3 - "$ARCHIVE" "$corrected_archive" <<'PY'
+import json
+import sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+data["activities"][0]["actor_remote_id"] = "acct-corrected"
+json.dump(data, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+"$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$corrected_archive" >/dev/null
+assert_eq "re-import refreshes an activity actor" "$(sql_value "SELECT actor_remote_id FROM activities WHERE remote_id='activity-1'")" "acct-corrected"
+
+unsafe_archive="${TMP_DIR}/unsafe.json"
+python3 - "$ARCHIVE" "$unsafe_archive" <<'PY'
+import json
+import sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+data["connection_id"] = "../revealing-name"
+json.dump(data, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+if "$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$unsafe_archive" >/dev/null 2>&1; then
+	assert_eq "path traversal connection ID is rejected" "accepted" "rejected"
+else
+	assert_eq "path traversal connection ID is rejected" "rejected" "rejected"
+fi
+
+credential_archive="${TMP_DIR}/credential.json"
+python3 - "$ARCHIVE" "$credential_archive" <<'PY'
+import json
+import sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+data["provider_json"] = {"accessToken": "must-not-persist", "nested": {"clientSecret": "also-forbidden"}}
+json.dump(data, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+if "$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$credential_archive" >/dev/null 2>&1; then
+	assert_eq "credential material is rejected before raw persistence" "accepted" "rejected"
+else
+	assert_eq "credential material is rejected before raw persistence" "rejected" "rejected"
+fi
+assert_eq "rejected archives create no raw batches" "$(python3 -c 'from pathlib import Path; import sys; print(len(list(Path(sys.argv[1]).rglob("*.json.gz"))))' "$CORPUS_ROOT/sources/social/raw")" "2"
+
+unsupported_archive="${TMP_DIR}/unsupported-schema.json"
+python3 - "$ARCHIVE" "$unsupported_archive" <<'PY'
+import json
+import sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+data["objects"][0]["text"] = "must not persist under an unsupported schema"
+json.dump(data, open(sys.argv[2], "w", encoding="utf-8"))
+PY
+python3 - "$CORPUS_ROOT/index/social.db" <<'PY'
+import sqlite3
+import sys
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("PRAGMA user_version=999")
+connection.close()
+PY
+if "$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$unsupported_archive" >/dev/null 2>&1; then
+	assert_eq "unsupported schema rejects import before raw persistence" "accepted" "rejected"
+else
+	assert_eq "unsupported schema rejects import before raw persistence" "rejected" "rejected"
+fi
+assert_eq "unsupported schema creates no raw batch" "$(python3 -c 'from pathlib import Path; import sys; print(len(list(Path(sys.argv[1]).rglob("*.json.gz"))))' "$CORPUS_ROOT/sources/social/raw")" "2"
+python3 - "$CORPUS_ROOT/index/social.db" <<'PY'
+import sqlite3
+import sys
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("PRAGMA user_version=1")
+connection.close()
+PY
+
+AUTH_BASE="${TMP_DIR}/authorization"
+AUTH_ROOT="${AUTH_BASE}/_knowledge"
+AUTH_CATALOG="${AUTH_BASE}/catalog.db"
+mkdir -p "$AUTH_ROOT"
+chmod 0700 "$AUTH_BASE" "$AUTH_ROOT"
+"$CORPUS_HELPER" provision --base "$AUTH_BASE" >/dev/null
+if "$HELPER" coverage --base "$AUTH_BASE" --alias personal:default >/dev/null 2>&1; then
+	assert_eq "coverage rejects an absent store" "accepted" "rejected"
+else
+	assert_eq "coverage rejects an absent store" "rejected" "rejected"
+fi
+assert_eq "coverage creates no database" "$([[ -e "$AUTH_ROOT/index" ]] && printf present || printf absent)" "absent"
+python3 - "$AUTH_CATALOG" <<'PY'
+import sqlite3
+import sys
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("UPDATE corpus_grants SET status='inactive' WHERE capability='knowledge.write'")
+connection.commit()
+connection.close()
+PY
+if "$HELPER" provision --base "$AUTH_BASE" --alias personal:default >/dev/null 2>&1; then
+	assert_eq "inactive write grant fails before store creation" "accepted" "rejected"
+else
+	assert_eq "inactive write grant fails before store creation" "rejected" "rejected"
+fi
+assert_eq "inactive grant creates no database" "$([[ -e "$AUTH_ROOT/index" ]] && printf present || printf absent)" "absent"
+
+python3 - "$AUTH_CATALOG" <<'PY'
+import sqlite3
+import sys
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("DELETE FROM corpus_grants WHERE capability='knowledge.write'")
+connection.commit()
+connection.close()
+PY
+if "$HELPER" provision --base "$AUTH_BASE" --alias personal:default >/dev/null 2>&1; then
+	assert_eq "missing write grant fails before store creation" "accepted" "rejected"
+else
+	assert_eq "missing write grant fails before store creation" "rejected" "rejected"
+fi
+assert_eq "missing grant creates no database" "$([[ -e "$AUTH_ROOT/index" ]] && printf present || printf absent)" "absent"
+
+FORGED_ROOT="${TMP_DIR}/forged-root"
+if "$HELPER" provision --base "$AUTH_BASE" --corpus-root "$FORGED_ROOT" >/dev/null 2>&1; then
+	assert_eq "physical corpus root argument is rejected" "accepted" "rejected"
+else
+	assert_eq "physical corpus root argument is rejected" "rejected" "rejected"
+fi
+assert_eq "forged root creates no directory" "$([[ -e "$FORGED_ROOT" ]] && printf present || printf absent)" "absent"
+
+OUTSIDE="${TMP_DIR}/outside"
+mkdir -p "$OUTSIDE"
+chmod 0700 "$OUTSIDE"
+python3 - "$AUTH_CATALOG" "$OUTSIDE" <<'PY'
+import sqlite3
+import sys
+connection = sqlite3.connect(sys.argv[1])
+connection.execute(
+    "INSERT INTO corpus_grants SELECT corpus_id,principal_id,role,'knowledge.write',scope,'active' "
+    "FROM corpus_grants WHERE capability='knowledge.read'"
+)
+connection.execute("UPDATE corpora SET location_ref=?", (sys.argv[2],))
+connection.commit()
+connection.close()
+PY
+if "$HELPER" provision --base "$AUTH_BASE" --alias personal:default >/dev/null 2>&1; then
+	assert_eq "out-of-base catalog root is rejected" "accepted" "rejected"
+else
+	assert_eq "out-of-base catalog root is rejected" "rejected" "rejected"
+fi
+assert_eq "out-of-base root creates no social store" "$([[ -e "$OUTSIDE/index" ]] && printf present || printf absent)" "absent"
+
+ln -s "$OUTSIDE" "${AUTH_BASE}/linked-root"
+python3 - "$AUTH_CATALOG" "${AUTH_BASE}/linked-root" <<'PY'
+import sqlite3
+import sys
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("UPDATE corpora SET location_ref=?", (sys.argv[2],))
+connection.commit()
+connection.close()
+PY
+if "$HELPER" provision --base "$AUTH_BASE" --alias personal:default >/dev/null 2>&1; then
+	assert_eq "symlinked catalog root is rejected" "accepted" "rejected"
+else
+	assert_eq "symlinked catalog root is rejected" "rejected" "rejected"
+fi
+assert_eq "symlinked root creates no social store" "$([[ -e "$OUTSIDE/index" ]] && printf present || printf absent)" "absent"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Added a provider-neutral per-corpus social schema, immutable canonical archive batches, idempotent normalized projections, FTS5 rebuilds, coverage records, and catalog-authorized alias resolution.

The exact-head review also hardened the storage boundary: rejected writes persist no raw evidence, coverage performs no filesystem or schema mutation under `knowledge.read`, active SQLite journal state fails closed, and common credential-key variants are rejected before raw persistence.

## Files Changed

- `.agents/aidevops/knowledge-plane/01-core-contract.md`
- `.agents/scripts/knowledge-social-helper.sh`
- `.agents/scripts/knowledge_social_import.py`
- `.agents/scripts/knowledge_social_store.py`
- `.agents/tests/test-knowledge-social.sh`

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified
- 31 social-store and archive-import checks passed.
- 45 corpus authorization and compatibility checks passed.
- Python compilation, ShellCheck, shfmt, `git diff --check`, Qlty new-file scanning, and changed-file local linters passed.
- A filesystem snapshot regression proves read-only coverage leaves content hashes, modes, sizes, and modification times unchanged.

## Decisions

- Raw evidence remains authoritative; normalized and FTS data remain rebuildable projections.
- Callers provide a logical alias, never a physical corpus root.
- Coverage requires `knowledge.read`, opens only a checkpointed immutable database, and never provisions or migrates storage.
- Mutating operations and schema migration require `knowledge.write`.

Resolves #28597
For #28587
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 4h 41m and 3,323,095 tokens on this with the user in an interactive session.