### PR TITLE
GH#28602: feat: add guarded X social adapter

### DIFF
--- a/.agents/content/social-xurl.md
+++ b/.agents/content/social-xurl.md
@@ -37,7 +37,7 @@ tools:
 - Never ask the user to paste X credentials, client IDs, client secrets, access tokens, refresh tokens, cookies, or bearer tokens into chat.
 - Never run `xurl auth apps add` with inline secrets from an agent session. The user registers app credentials manually in their terminal.
 - Never pass `--verbose`, `-v`, `--bearer-token`, `--consumer-key`, `--consumer-secret`, `--access-token`, `--token-secret`, `--client-id`, or `--client-secret`.
-- Treat DMs, protected/private account data, bookmarks, and timelines as sensitive; summarize minimally and do not persist raw output unless the user explicitly asks.
+- Treat DMs, protected/private account data, bookmarks, and timelines as sensitive. For ad hoc requests, summarize minimally and do not persist raw output unless the user explicitly asks. An explicitly requested authorized corpus sync stores immutable response evidence under that corpus's policy.
 
 ## User Setup Boundary
 
@@ -85,6 +85,44 @@ Use the helper for normal agent work:
 ```
 
 The helper rejects secret-bearing flags and verbose output, maps common read/write actions to `xurl`, and blocks write actions unless `--confirm-write` is present.
+
+## Authorized Social Corpus Sync
+
+Use the provider-neutral helper to collect one bounded official stream into a
+catalog-resolved corpus:
+
+```bash
+.agents/scripts/knowledge-social-helper.sh sync-x \
+  --alias personal:default --connection-id CONNECTION_ID \
+  --account-id X_ACCOUNT_ID --stream authored --budget 10 \
+  --media-policy metadata --app PROFILE --username HANDLE
+```
+
+The alias must grant `knowledge.write`. `connection-id` is an opaque local ID;
+`account-id` is the stable X account ID expected from `whoami`. The adapter
+rejects an account mismatch before collection and does not allow an existing
+connection to be rebound to another account.
+
+Supported streams are `authored`, `mentions`, `likes`, `bookmarks`, `followers`,
+and `following`. Each stream owns an independent pagination cursor and
+watermark. After initial backfill, authored and mentions use the official
+`since_id` delta parameter. Streams without an official delta parameter report
+`delta_unavailable` and record the coverage gap without issuing a page request.
+
+`--budget` is a bounded request-cost allowance from 1 to 1000 units, not a retry
+count. Terminal authorization, not-found, rate-limit, and provider failures
+store credential-filtered immutable evidence but never advance the stream cursor.
+Command output contains counts and failure classes rather than private provider
+content.
+
+Media policy `none` stores no media rows. `metadata` stores references and
+content links only; the adapter never downloads media binaries. The provider
+route is externally read-only: it can reach only guarded `whoami` and allowlisted
+official raw-read endpoints, never posting or engagement commands.
+
+Fixture and fake-executable tests verify pagination, resume, terminal failures,
+credential rejection, and the guarded command route. They do not prove live X
+access; live verification requires a separately configured `xurl` profile.
 
 ## Command Map
 

--- a/.agents/scripts/_knowledge_social_x.py
+++ b/.agents/scripts/_knowledge_social_x.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""X stream capabilities, response validation, and checkpoint calculation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+from knowledge_social_store import SocialStoreError
+
+PROVIDER = "xapi"
+
+
+class XAdapterError(SocialStoreError):
+    """Raised when guarded X collection cannot continue safely."""
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Static capability and cost policy for one X collection stream."""
+
+    path: str
+    resource_kind: str
+    activity_mode: str
+    supports_since_id: bool
+    cost_units: int = 1
+
+
+STREAMS = {
+    "authored": StreamSpec(
+        "/2/users/{account_id}/tweets", "tweet", "content_author", True
+    ),
+    "mentions": StreamSpec(
+        "/2/users/{account_id}/mentions", "tweet", "content_author", True
+    ),
+    "likes": StreamSpec(
+        "/2/users/{account_id}/liked_tweets", "tweet", "selected_account", False
+    ),
+    "bookmarks": StreamSpec(
+        "/2/users/{account_id}/bookmarks", "tweet", "selected_account", False
+    ),
+    "followers": StreamSpec(
+        "/2/users/{account_id}/followers", "account", "remote_follows_selected", False
+    ),
+    "following": StreamSpec(
+        "/2/users/{account_id}/following", "account", "selected_follows_remote", False
+    ),
+}
+
+
+@dataclass(frozen=True)
+class CursorState:
+    """Durable per-connection/per-stream checkpoint."""
+
+    cursor: str | None
+    watermark: str | None
+    backfill_complete: bool
+
+
+@dataclass(frozen=True)
+class PageCheckpoint:
+    """Checkpoint calculated from a successful provider page."""
+
+    next_cursor: str | None
+    watermark: str | None
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    """Return a validated HTTP-like status from an xurl payload."""
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise XAdapterError("X response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a validated provider data array."""
+    data = payload.get("data", [])
+    if data is None:
+        return []
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise XAdapterError("X page data must be an array")
+    return data
+
+
+def _newest_id(ids: list[str], previous: str | None) -> str | None:
+    candidates = ids + ([previous] if previous else [])
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda value: (1, int(value)) if value.isdigit() else (0, value),
+    )
+
+
+def page_checkpoint(
+    payload: dict[str, Any], previous_watermark: str | None
+) -> PageCheckpoint:
+    """Calculate the next cursor and monotonic provider watermark."""
+    meta = payload.get("meta", {})
+    if not isinstance(meta, dict):
+        raise XAdapterError("X page meta must be an object")
+    next_cursor = meta.get("next_token")
+    if next_cursor is not None and not isinstance(next_cursor, str):
+        raise XAdapterError("X next_token must be text")
+    ids = [item["id"] for item in page_data(payload) if isinstance(item.get("id"), str)]
+    return PageCheckpoint(next_cursor, _newest_id(ids, previous_watermark))
+
+
+def stream_endpoint(stream: str, account_id: str, state: CursorState) -> str:
+    """Build one allowlisted official read endpoint from validated state."""
+    spec = STREAMS[stream]
+    params = {"max_results": "100"}
+    if spec.resource_kind == "tweet":
+        params.update(
+            {
+                "expansions": "author_id,attachments.media_keys",
+                "tweet.fields": (
+                    "author_id,created_at,attachments,public_metrics,referenced_tweets"
+                ),
+                "user.fields": "id,name,username",
+                "media.fields": "media_key,type",
+            }
+        )
+    else:
+        params["user.fields"] = "id,name,username"
+    if state.cursor:
+        params["pagination_token"] = state.cursor
+    elif state.backfill_complete and state.watermark and spec.supports_since_id:
+        params["since_id"] = state.watermark
+    path = spec.path.format(account_id=account_id)
+    return f"{path}?{urlencode(params)}"

--- a/.agents/scripts/_knowledge_social_x_media.py
+++ b/.agents/scripts/_knowledge_social_x_media.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize metadata-only X media references without downloading binaries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_x import XAdapterError
+
+
+def _attachment_keys(item: dict[str, Any]) -> list[str]:
+    attachments = item.get("attachments")
+    if attachments is None:
+        return []
+    if not isinstance(attachments, dict):
+        raise XAdapterError("X post attachments must be an object")
+    keys = attachments.get("media_keys", [])
+    if not isinstance(keys, list) or any(not isinstance(key, str) for key in keys):
+        raise XAdapterError("X post media_keys must be an array of text")
+    return keys
+
+
+def _media_links(data: list[dict[str, Any]]) -> dict[str, str]:
+    links: dict[str, str] = {}
+    for item in data:
+        remote_id = item.get("id")
+        if not isinstance(remote_id, str):
+            continue
+        for media_key in _attachment_keys(item):
+            links.setdefault(media_key, remote_id)
+    return links
+
+
+def page_media(
+    includes: dict[str, Any], data: list[dict[str, Any]], media_policy: str
+) -> list[dict[str, Any]]:
+    """Return media references only when metadata hydration is enabled."""
+    if media_policy != "metadata":
+        return []
+    items = includes.get("media", [])
+    if not isinstance(items, list) or any(not isinstance(item, dict) for item in items):
+        raise XAdapterError("X included media must be an array")
+    links = _media_links(data)
+    media = []
+    for item in items:
+        media_key = item.get("media_key")
+        if not isinstance(media_key, str) or not media_key:
+            raise XAdapterError("X media requires a media_key")
+        media.append(
+            {
+                "remote_id": media_key,
+                "object_remote_id": links.get(media_key),
+                "mime_type": item.get("type"),
+                "hydration_state": "metadata_only",
+            }
+        )
+    return media

--- a/.agents/scripts/_knowledge_social_x_normalize.py
+++ b/.agents/scripts/_knowledge_social_x_normalize.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize validated X pages into provider-neutral social records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_x import PROVIDER, STREAMS, StreamSpec, XAdapterError, page_data
+from _knowledge_social_x_media import page_media
+from knowledge_social_import import reject_credentials
+
+
+@dataclass(frozen=True)
+class PageContext:
+    """Validated connection policy needed to normalize one provider page."""
+
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    media_policy: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def observation_time(payload: dict[str, Any]) -> str:
+    observed_at = payload.get("observed_at")
+    if observed_at is None:
+        return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    if not isinstance(observed_at, str) or not observed_at:
+        raise XAdapterError("X page observed_at must be text")
+    return observed_at
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and not isinstance(value, str):
+        raise XAdapterError(f"X account {key} must be text")
+    return value
+
+
+def account_record(user: dict[str, Any], observed_at: str) -> dict[str, Any]:
+    remote_id = user.get("id")
+    if not isinstance(remote_id, str) or not remote_id:
+        raise XAdapterError("X account requires an ID")
+    return {
+        "remote_id": remote_id,
+        "handle": _optional_text(user, "username"),
+        "display_name": _optional_text(user, "name"),
+        "observed_at": observed_at,
+        "provider_json": {
+            key: value
+            for key, value in user.items()
+            if key not in {"id", "username", "name"}
+        },
+    }
+
+
+def page_includes(payload: dict[str, Any]) -> dict[str, Any]:
+    includes = payload.get("includes", {})
+    if not isinstance(includes, dict):
+        raise XAdapterError("X page includes must be an object")
+    return includes
+
+
+def _included_users(includes: dict[str, Any]) -> list[dict[str, Any]]:
+    users = includes.get("users", [])
+    if not isinstance(users, list) or any(not isinstance(item, dict) for item in users):
+        raise XAdapterError("X included users must be an array")
+    return users
+
+
+def page_accounts(
+    account: dict[str, Any],
+    includes: dict[str, Any],
+    data: list[dict[str, Any]],
+    spec: StreamSpec,
+    observed_at: str,
+) -> list[dict[str, Any]]:
+    users = [account, *_included_users(includes)]
+    if spec.resource_kind == "account":
+        users.extend(data)
+    records = {
+        record["remote_id"]: record
+        for record in (account_record(user, observed_at) for user in users)
+    }
+    return list(records.values())
+
+
+def evidence_class(stream: str) -> str:
+    return {
+        "authored": "authored",
+        "likes": "weak_signal",
+        "bookmarks": "weak_signal",
+    }.get(stream, "observed")
+
+
+def _tweet_object(
+    item: dict[str, Any], remote_id: str, stream: str, observed_at: str
+) -> dict[str, Any]:
+    author_id = item.get("author_id")
+    if not isinstance(author_id, str) or not author_id:
+        raise XAdapterError("X post author_id must be text")
+    return {
+        "object_type": "post",
+        "remote_id": remote_id,
+        "account_remote_id": author_id,
+        "text": item.get("text"),
+        "created_at": item.get("created_at"),
+        "observed_at": observed_at,
+        "evidence_class": evidence_class(stream),
+        "provider_json": {
+            key: value
+            for key, value in item.items()
+            if key not in {"id", "author_id", "text", "created_at"}
+        },
+    }
+
+
+def _activity_participants(
+    spec: StreamSpec, item: dict[str, Any], account_id: str, remote_id: str
+) -> tuple[str, str | None]:
+    if spec.activity_mode == "content_author":
+        author_id = item.get("author_id")
+        if not isinstance(author_id, str) or not author_id:
+            raise XAdapterError("X activity author_id must be text")
+        return author_id, remote_id
+    if spec.activity_mode == "remote_follows_selected":
+        return remote_id, account_id
+    if spec.activity_mode == "selected_follows_remote":
+        return account_id, remote_id
+    return account_id, remote_id
+
+
+def page_resources(
+    data: list[dict[str, Any]], account_id: str, stream: str, observed_at: str
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    spec = STREAMS[stream]
+    objects: list[dict[str, Any]] = []
+    activities: list[dict[str, Any]] = []
+    for item in data:
+        remote_id = item.get("id")
+        if not isinstance(remote_id, str) or not remote_id:
+            raise XAdapterError("X resource requires an ID")
+        object_id = remote_id if spec.resource_kind == "tweet" else None
+        if object_id:
+            objects.append(_tweet_object(item, remote_id, stream, observed_at))
+        actor_id, target_id = _activity_participants(
+            spec, item, account_id, remote_id
+        )
+        activities.append(
+            {
+                "activity_type": stream,
+                "remote_id": f"{account_id}-{stream}-{remote_id}",
+                "actor_remote_id": actor_id,
+                "object_remote_id": target_id,
+                "occurred_at": item.get("created_at"),
+                "observed_at": observed_at,
+                "state": "active",
+            }
+        )
+    return objects, activities
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Validate a successful X page and build provider-neutral import rows."""
+    reject_credentials(payload)
+    data = page_data(payload)
+    includes = page_includes(payload)
+    observed_at = observation_time(payload)
+    spec = STREAMS[context.stream]
+    objects, activities = page_resources(
+        data, context.account["id"], context.stream, observed_at
+    )
+    return {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account["id"],
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": context.policy,
+        "accounts": page_accounts(
+            context.account, includes, data, spec, observed_at
+        ),
+        "objects": objects,
+        "activities": activities,
+        "media": page_media(includes, data, context.media_policy),
+        "coverage": [],
+    }
+
+
+def page_time_bounds(archive: dict[str, Any]) -> tuple[str | None, str | None]:
+    sources = (
+        (archive["objects"], "created_at"),
+        (archive["activities"], "occurred_at"),
+    )
+    timestamps = [
+        value
+        for rows, key in sources
+        for record in rows
+        if isinstance((value := record.get(key)), str) and value
+    ]
+    if not timestamps:
+        return None, None
+    return min(timestamps), max(timestamps)

--- a/.agents/scripts/_knowledge_social_x_persist.py
+++ b/.agents/scripts/_knowledge_social_x_persist.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Atomic raw evidence, normalized rows, coverage, and cursor persistence."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_x import PROVIDER, PageCheckpoint, XAdapterError
+from _knowledge_social_x_normalize import observation_time, page_time_bounds
+from _knowledge_social_x_state import CollectionContext
+from knowledge_social_import import (
+    canonical_json,
+    import_accounts,
+    import_activities,
+    import_media,
+    import_objects,
+    reject_credentials,
+    upsert_connection,
+)
+from knowledge_social_store import connect, migrate, write_raw_batch
+
+
+@dataclass(frozen=True)
+class SuccessfulPage:
+    """Validated page plus its next durable checkpoint."""
+
+    payload: dict[str, Any]
+    endpoint: str
+    archive: dict[str, Any]
+    checkpoint: PageCheckpoint
+    complete: bool
+    budget_units: int
+
+
+@dataclass(frozen=True)
+class RawBatch:
+    """Immutable response-envelope metadata used by fetch_batches."""
+
+    batch_id: str
+    blob_ref: str
+    request_hash: str
+    observed_at: str
+
+
+@dataclass(frozen=True)
+class FetchRecord:
+    """Fetch-batch values independent of success or failure handling."""
+
+    raw: RawBatch
+    terminal_status: str
+    resource_count: int
+    budget_units: int
+
+
+@dataclass(frozen=True)
+class TerminalDecision:
+    """Sanitized handling policy for one terminal provider response."""
+
+    output_status: str
+    run_status: str
+    failure_class: str
+
+
+def _assert_connection_binding(
+    database: sqlite3.Connection, context: CollectionContext
+) -> None:
+    row = database.execute(
+        "SELECT provider,remote_account_id FROM connections WHERE connection_id=?",
+        (context.connection_id,),
+    ).fetchone()
+    if row and (
+        row["provider"] != PROVIDER
+        or row["remote_account_id"] != context.account["id"]
+    ):
+        raise XAdapterError("stored connection does not match the verified X account")
+
+
+def _connection_archive(context: CollectionContext) -> dict[str, Any]:
+    return {
+        "remote_account_id": context.account["id"],
+        "enabled_streams": list(context.config.enabled_streams),
+        "policy": context.config.policy,
+    }
+
+
+def _raw_batch(
+    context: CollectionContext,
+    payload: dict[str, Any],
+    endpoint: str,
+    observed_at: str,
+) -> RawBatch:
+    response = canonical_json(payload).encode("utf-8")
+    request_hash = hashlib.sha256(endpoint.encode("utf-8")).hexdigest()
+    envelope = canonical_json(
+        {
+            "provider": PROVIDER,
+            "connection_id": context.connection_id,
+            "stream": context.stream,
+            "observed_at": observed_at,
+            "request_hash": request_hash,
+            "response_sha256": hashlib.sha256(response).hexdigest(),
+            "response": payload,
+        }
+    ).encode("utf-8")
+    batch_id, blob_ref = write_raw_batch(
+        context.root, PROVIDER, context.connection_id, envelope
+    )
+    return RawBatch(batch_id, blob_ref, request_hash, observed_at)
+
+
+def _insert_fetch_batch(
+    database: sqlite3.Connection,
+    context: CollectionContext,
+    record: FetchRecord,
+) -> None:
+    database.execute(
+        """INSERT INTO fetch_batches(
+           batch_id,provider,connection_id,stream,request_hash,response_hash,blob_ref,
+           resource_count,budget_units,started_at,completed_at,terminal_status)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(batch_id) DO NOTHING""",
+        (
+            record.raw.batch_id,
+            PROVIDER,
+            context.connection_id,
+            context.stream,
+            record.raw.request_hash,
+            record.raw.batch_id,
+            record.raw.blob_ref,
+            record.resource_count,
+            record.budget_units,
+            record.raw.observed_at,
+            record.raw.observed_at,
+            record.terminal_status,
+        ),
+    )
+
+
+def _refresh_fts(database: sqlite3.Connection, archive: dict[str, Any]) -> None:
+    for record in archive["objects"]:
+        identity = (PROVIDER, record["object_type"], record["remote_id"])
+        database.execute(
+            "DELETE FROM objects_fts WHERE provider=? AND object_type=? AND remote_id=?",
+            identity,
+        )
+        database.execute(
+            """INSERT INTO objects_fts(
+               provider,object_type,remote_id,account_remote_id,text_content,evidence_class)
+               SELECT provider,object_type,remote_id,account_remote_id,text_content,evidence_class
+                 FROM objects WHERE provider=? AND object_type=? AND remote_id=?""",
+            identity,
+        )
+
+
+def _update_cursor(
+    database: sqlite3.Connection,
+    context: CollectionContext,
+    page: SuccessfulPage,
+) -> None:
+    database.execute(
+        """INSERT INTO sync_cursors(
+           connection_id,stream,cursor,watermark,last_success_at,backfill_complete)
+           VALUES(?,?,?,?,?,?) ON CONFLICT(connection_id,stream) DO UPDATE SET
+           cursor=excluded.cursor,watermark=excluded.watermark,
+           last_success_at=excluded.last_success_at,
+           backfill_complete=excluded.backfill_complete""",
+        (
+            context.connection_id,
+            context.stream,
+            page.checkpoint.next_cursor,
+            page.checkpoint.watermark,
+            page.archive["exported_at"],
+            int(page.complete),
+        ),
+    )
+
+
+def _upsert_success_coverage(
+    database: sqlite3.Connection,
+    context: CollectionContext,
+    page: SuccessfulPage,
+    batch_id: str,
+) -> None:
+    earliest, latest = page_time_bounds(page.archive)
+    database.execute(
+        """INSERT INTO coverage_records(
+           provider,connection_id,stream,earliest_at,latest_at,cursor_exhausted,
+           retention_limit,unavailable_reason,status,batch_id,observed_at)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(provider,connection_id,stream) DO UPDATE SET
+           earliest_at=CASE
+             WHEN coverage_records.earliest_at IS NULL THEN excluded.earliest_at
+             WHEN excluded.earliest_at IS NULL THEN coverage_records.earliest_at
+             WHEN excluded.earliest_at < coverage_records.earliest_at THEN excluded.earliest_at
+             ELSE coverage_records.earliest_at END,
+           latest_at=CASE
+             WHEN coverage_records.latest_at IS NULL THEN excluded.latest_at
+             WHEN excluded.latest_at IS NULL THEN coverage_records.latest_at
+             WHEN excluded.latest_at > coverage_records.latest_at THEN excluded.latest_at
+             ELSE coverage_records.latest_at END,
+           cursor_exhausted=excluded.cursor_exhausted,
+           unavailable_reason=NULL,status=excluded.status,
+           batch_id=excluded.batch_id,observed_at=excluded.observed_at""",
+        (
+            PROVIDER,
+            context.connection_id,
+            context.stream,
+            earliest,
+            latest,
+            int(page.complete),
+            None,
+            None,
+            "complete" if page.complete else "partial",
+            batch_id,
+            page.archive["exported_at"],
+        ),
+    )
+
+
+def persist_page(context: CollectionContext, page: SuccessfulPage) -> int:
+    """Atomically commit normalized rows, projection, coverage, and cursor."""
+    database = connect(context.root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        _assert_connection_binding(database, context)
+        raw = _raw_batch(
+            context, page.payload, page.endpoint, page.archive["exported_at"]
+        )
+        upsert_connection(database, page.archive, PROVIDER, context.connection_id)
+        import_accounts(database, page.archive, PROVIDER)
+        import_objects(database, page.archive, PROVIDER, raw.batch_id)
+        import_activities(database, page.archive, PROVIDER, raw.batch_id)
+        import_media(database, page.archive, PROVIDER, raw.batch_id)
+        _refresh_fts(database, page.archive)
+        resource_count = sum(
+            len(page.archive[key])
+            for key in ("accounts", "objects", "activities", "media")
+        )
+        _insert_fetch_batch(
+            database,
+            context,
+            FetchRecord(raw, "success", resource_count, page.budget_units),
+        )
+        _update_cursor(database, context, page)
+        _upsert_success_coverage(database, context, page, raw.batch_id)
+        database.execute("COMMIT")
+        return resource_count
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()
+
+
+def _retry_after(payload: dict[str, Any]) -> str | None:
+    value = payload.get("retry_after")
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise XAdapterError("X retry_after must be text or an integer")
+    return str(value)
+
+
+def _record_run(
+    database: sqlite3.Connection,
+    context: CollectionContext,
+    status: str,
+    failure: str,
+    retry_after: str | None,
+) -> None:
+    database.execute(
+        "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,retry_after,diagnostics) "
+        "VALUES(?,?,?,?,?,?)",
+        (
+            uuid.uuid4().hex,
+            context.connection_id,
+            status,
+            failure,
+            retry_after,
+            canonical_json({"stream": context.stream}),
+        ),
+    )
+
+
+def _terminal_coverage_status(decision: TerminalDecision) -> str:
+    if decision.failure_class == "rate_limit":
+        return "paused"
+    if decision.failure_class == "unavailable":
+        return "unavailable"
+    return "failed"
+
+
+def _upsert_terminal_coverage(
+    database: sqlite3.Connection,
+    context: CollectionContext,
+    raw: RawBatch,
+    decision: TerminalDecision,
+) -> None:
+    database.execute(
+        """INSERT INTO coverage_records(
+           provider,connection_id,stream,earliest_at,latest_at,cursor_exhausted,
+           retention_limit,unavailable_reason,status,batch_id,observed_at)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(provider,connection_id,stream) DO UPDATE SET
+           unavailable_reason=excluded.unavailable_reason,status=excluded.status,
+           batch_id=excluded.batch_id,observed_at=excluded.observed_at""",
+        (
+            PROVIDER,
+            context.connection_id,
+            context.stream,
+            None,
+            None,
+            int(context.state.backfill_complete),
+            None,
+            decision.failure_class,
+            _terminal_coverage_status(decision),
+            raw.batch_id,
+            raw.observed_at,
+        ),
+    )
+
+
+def record_terminal(
+    context: CollectionContext,
+    payload: dict[str, Any],
+    endpoint: str,
+    decision: TerminalDecision,
+) -> str | None:
+    """Persist a credential-filtered terminal response without cursor advance."""
+    reject_credentials(payload)
+    observed_at = observation_time(payload)
+    retry_after = _retry_after(payload)
+    database = connect(context.root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        _assert_connection_binding(database, context)
+        raw = _raw_batch(context, payload, endpoint, observed_at)
+        upsert_connection(
+            database,
+            _connection_archive(context),
+            PROVIDER,
+            context.connection_id,
+        )
+        _insert_fetch_batch(
+            database,
+            context,
+            FetchRecord(raw, decision.failure_class, 0, context.spec.cost_units),
+        )
+        _record_run(
+            database,
+            context,
+            decision.run_status,
+            decision.failure_class,
+            retry_after,
+        )
+        _upsert_terminal_coverage(database, context, raw, decision)
+        database.execute("COMMIT")
+        return retry_after
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()
+
+
+def record_bounded_stop(
+    context: CollectionContext, status: str, failure: str
+) -> None:
+    """Record a budget or capability stop while preserving prior evidence."""
+    observed_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    database = connect(context.root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        _assert_connection_binding(database, context)
+        _record_run(database, context, status, failure, None)
+        updated = database.execute(
+            "UPDATE coverage_records SET status=?,unavailable_reason=?,observed_at=? "
+            "WHERE provider=? AND connection_id=? AND stream=?",
+            (
+                status,
+                failure,
+                observed_at,
+                PROVIDER,
+                context.connection_id,
+                context.stream,
+            ),
+        ).rowcount
+        if updated != 1:
+            raise XAdapterError("X stop has no durable coverage checkpoint")
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()

--- a/.agents/scripts/_knowledge_social_x_reader.py
+++ b/.agents/scripts/_knowledge_social_x_reader.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and fixture readers for the read-only X adapter."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_x import XAdapterError, response_status
+from knowledge_social_import import reject_credentials
+
+
+class XReader(Protocol):
+    """Minimal read-only provider surface used by collection."""
+
+    def identity(self) -> dict[str, Any]: ...
+
+    def page(self, endpoint: str) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise XAdapterError("xurl returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise XAdapterError("xurl response root must be an object")
+    return payload
+
+
+class GuardedXurl:
+    """Execute only the two read-only helper surfaces used by this adapter."""
+
+    def __init__(self, helper: Path, app: str | None, username: str | None) -> None:
+        if helper.is_symlink() or not helper.is_file():
+            raise XAdapterError("guarded xurl helper is unavailable")
+        self.helper = helper
+        self.profile_args: list[str] = []
+        if app:
+            self.profile_args.extend(("--app", app))
+        if username:
+            self.profile_args.extend(("--username", username))
+
+    def _json(self, command: list[str]) -> dict[str, Any]:
+        completed = subprocess.run(  # nosec B603 -- fixed helper plus allowlisted read argv
+            command, check=False, capture_output=True, text=True, timeout=120
+        )
+        payload = _decode_output(completed.stdout)
+        if completed.returncode != 0 and response_status(payload) < 400:
+            raise XAdapterError("xurl read request failed")
+        return payload
+
+    def identity(self) -> dict[str, Any]:
+        return self._json([str(self.helper), "whoami", *self.profile_args])
+
+    def page(self, endpoint: str) -> dict[str, Any]:
+        return self._json(
+            [str(self.helper), "run", *self.profile_args, "--", endpoint]
+        )
+
+
+def _load_fixture(path: Path) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise XAdapterError("X fixture must be a regular non-symlink file")
+    try:
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise XAdapterError("X fixture is not valid UTF-8 JSON") from error
+    if not isinstance(fixture, dict) or not isinstance(fixture.get("pages"), list):
+        raise XAdapterError("X fixture requires identity and pages")
+    return fixture
+
+
+def _fixture_page(entry: dict[str, Any], endpoint: str) -> dict[str, Any]:
+    expectations = entry.get("expect_endpoint_contains", [])
+    if not isinstance(expectations, list) or any(
+        not isinstance(value, str) for value in expectations
+    ):
+        raise XAdapterError("X fixture endpoint expectations must be text")
+    if any(value not in endpoint for value in expectations):
+        raise XAdapterError("X request did not resume at the expected checkpoint")
+    response = entry.get("response", entry)
+    if not isinstance(response, dict):
+        raise XAdapterError("X fixture page response must be an object")
+    return response
+
+
+class FixtureXurl:
+    """Deterministic xurl substitute for pagination and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = _load_fixture(path)
+        self.position = 0
+
+    def identity(self) -> dict[str, Any]:
+        identity = self.fixture.get("identity")
+        if not isinstance(identity, dict):
+            raise XAdapterError("X fixture identity must be an object")
+        return identity
+
+    def page(self, endpoint: str) -> dict[str, Any]:
+        pages = self.fixture["pages"]
+        if self.position >= len(pages) or not isinstance(pages[self.position], dict):
+            raise XAdapterError("X fixture has no page for request")
+        page = _fixture_page(pages[self.position], endpoint)
+        self.position += 1
+        return page
+
+
+def _optional_text(record: dict[str, Any], key: str) -> None:
+    value = record.get(key)
+    if value is not None and not isinstance(value, str):
+        raise XAdapterError(f"X account {key} must be text")
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Validate xurl identity without allowing credential-shaped fields through."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise XAdapterError("xurl account verification returned no account")
+    remote_id = data.get("id")
+    if not isinstance(remote_id, str) or not remote_id:
+        raise XAdapterError("xurl account verification returned no account ID")
+    _optional_text(data, "username")
+    _optional_text(data, "name")
+    if remote_id != expected_id:
+        raise XAdapterError(
+            "selected xurl account does not match the configured connection"
+        )
+    return data

--- a/.agents/scripts/_knowledge_social_x_state.py
+++ b/.agents/scripts/_knowledge_social_x_state.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Load and validate durable connection and cursor state for X collection."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_x import PROVIDER, STREAMS, CursorState, StreamSpec, XAdapterError
+from knowledge_social_import import reject_credentials
+from knowledge_social_store import connect, migrate
+
+
+@dataclass(frozen=True)
+class ConnectionConfig:
+    """Merged non-secret policy for an existing or new connection."""
+
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CollectionContext:
+    """Validated state shared by one bounded collection invocation."""
+
+    root: Path
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    media_policy: str
+    config: ConnectionConfig
+    state: CursorState
+    spec: StreamSpec
+
+
+def _json_array(value: str, field: str) -> list[str]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise XAdapterError(f"stored X {field} is invalid") from error
+    if not isinstance(parsed, list) or any(not isinstance(item, str) for item in parsed):
+        raise XAdapterError(f"stored X {field} must be an array of text")
+    return parsed
+
+
+def _json_object(value: str, field: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise XAdapterError(f"stored X {field} is invalid") from error
+    if not isinstance(parsed, dict):
+        raise XAdapterError(f"stored X {field} must be an object")
+    reject_credentials(parsed)
+    return parsed
+
+
+def _connection_config(
+    database: sqlite3.Connection,
+    connection_id: str,
+    account_id: str,
+    stream: str,
+    media_policy: str,
+) -> ConnectionConfig:
+    row = database.execute(
+        "SELECT provider,remote_account_id,enabled_streams,policy_json "
+        "FROM connections WHERE connection_id=?",
+        (connection_id,),
+    ).fetchone()
+    if row is None:
+        return ConnectionConfig((stream,), {"media_hydration": media_policy})
+    if row["provider"] != PROVIDER or row["remote_account_id"] != account_id:
+        raise XAdapterError("stored connection does not match the verified X account")
+    enabled = _json_array(row["enabled_streams"], "enabled_streams")
+    if stream not in enabled:
+        enabled.append(stream)
+    policy = dict(_json_object(row["policy_json"], "policy"))
+    policy["media_hydration"] = media_policy
+    return ConnectionConfig(tuple(enabled), policy)
+
+
+def _cursor_state(
+    database: sqlite3.Connection, connection_id: str, stream: str
+) -> CursorState:
+    row = database.execute(
+        "SELECT cursor,watermark,backfill_complete FROM sync_cursors "
+        "WHERE connection_id=? AND stream=?",
+        (connection_id, stream),
+    ).fetchone()
+    if row is None:
+        return CursorState(None, None, False)
+    return CursorState(row["cursor"], row["watermark"], bool(row["backfill_complete"]))
+
+
+def load_context(
+    root: Path,
+    connection_id: str,
+    account: dict[str, Any],
+    stream: str,
+    media_policy: str,
+) -> CollectionContext:
+    """Read the connection policy and selected stream checkpoint."""
+    database = connect(root)
+    try:
+        migrate(database)
+        config = _connection_config(
+            database, connection_id, account["id"], stream, media_policy
+        )
+        state = _cursor_state(database, connection_id, stream)
+    finally:
+        database.close()
+    return CollectionContext(
+        root,
+        connection_id,
+        account,
+        stream,
+        media_policy,
+        config,
+        state,
+        STREAMS[stream],
+    )

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -17,7 +17,7 @@ Usage:
   knowledge-social-helper.sh rebuild [--base PATH] [--alias ALIAS]
   knowledge-social-helper.sh coverage [--base PATH] [--alias ALIAS]
   knowledge-social-helper.sh sync-x [--base PATH] [--alias ALIAS] \
-    --connection-id ID --account-id ID --stream STREAM [--budget PAGES] \
+    --connection-id ID --account-id ID --stream STREAM [--budget UNITS] \
     [--media-policy none|metadata] [--app PROFILE] [--username HANDLE]
 
 The authenticated corpus catalog resolves ALIAS with knowledge.write for
@@ -29,6 +29,12 @@ Archive format:
   objects, activities, media, and coverage. IDs must be provider-stable IDs;
   connection_id must be an opaque local ID. Unknown provider fields belong in
   provider_json objects. The original canonical payload is stored immutably.
+
+X synchronization:
+  sync-x verifies the selected xurl account, then reads one official stream:
+  authored, mentions, likes, bookmarks, followers, or following. --budget is a
+  bounded request-cost allowance from 1 to 1000 units. Media policy none stores
+  no media rows; metadata stores references only, never binary media.
 EOF
 	return 0
 }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_HELPER="${SCRIPT_DIR}/knowledge_social_import.py"
+X_HELPER="${SCRIPT_DIR}/knowledge_social_x.py"
 
 usage() {
 	cat <<'EOF'
@@ -15,6 +16,9 @@ Usage:
   knowledge-social-helper.sh import-archive [--base PATH] [--alias ALIAS] --archive FILE
   knowledge-social-helper.sh rebuild [--base PATH] [--alias ALIAS]
   knowledge-social-helper.sh coverage [--base PATH] [--alias ALIAS]
+  knowledge-social-helper.sh sync-x [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id ID --stream STREAM [--budget PAGES] \
+    [--media-policy none|metadata] [--app PROFILE] [--username HANDLE]
 
 The authenticated corpus catalog resolves ALIAS with knowledge.write for
 mutating operations or knowledge.read for coverage. Physical corpus paths are
@@ -50,6 +54,14 @@ main() {
 	provision | import-archive | rebuild | coverage)
 		require_runtime || return 1
 		python3 "$PYTHON_HELPER" "$subcommand" "$@" || return 1
+		;;
+	sync-x)
+		require_runtime || return 1
+		if [[ ! -r "$X_HELPER" ]]; then
+			printf 'ERROR: X social adapter missing: %s\n' "$X_HELPER" >&2
+			return 1
+		fi
+		python3 "$X_HELPER" "$@" || return 1
 		;;
 	help | -h | --help)
 		usage

--- a/.agents/scripts/knowledge_social_x.py
+++ b/.agents/scripts/knowledge_social_x.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one read-only X stream into an authorized social corpus."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
+from knowledge_corpus_context import CatalogError
+from knowledge_social_import import (
+    canonical_json,
+    import_accounts,
+    import_activities,
+    import_media,
+    import_objects,
+    reject_credentials,
+    upsert_connection,
+)
+from knowledge_social_store import (
+    SocialStoreError,
+    connect,
+    migrate,
+    validate_opaque,
+    validate_root,
+    write_raw_batch,
+)
+
+PROVIDER = "xapi"
+STREAM_PATHS = {
+    "authored": "/2/users/{account_id}/tweets",
+    "mentions": "/2/users/{account_id}/mentions",
+    "likes": "/2/users/{account_id}/liked_tweets",
+    "bookmarks": "/2/users/{account_id}/bookmarks",
+    "followers": "/2/users/{account_id}/followers",
+    "following": "/2/users/{account_id}/following",
+}
+TWEET_STREAMS = {"authored", "mentions", "likes", "bookmarks"}
+
+
+class XAdapterError(SocialStoreError):
+    """Raised when guarded X collection cannot continue safely."""
+
+
+class GuardedXurl:
+    """Execute only the two read-only helper surfaces used by this adapter."""
+
+    def __init__(self, helper: Path, app: str | None, username: str | None) -> None:
+        self.helper = helper
+        self.profile_args: list[str] = []
+        if app:
+            self.profile_args.extend(("--app", app))
+        if username:
+            self.profile_args.extend(("--username", username))
+
+    def _json(self, command: list[str]) -> dict[str, Any]:
+        completed = subprocess.run(  # nosec B603 -- argv is built from a fixed helper and allowlisted reads
+            command, check=False, capture_output=True, text=True, timeout=120
+        )
+        try:
+            payload = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise XAdapterError("xurl returned no valid JSON") from error
+        if not isinstance(payload, dict):
+            raise XAdapterError("xurl response root must be an object")
+        if completed.returncode != 0 and "status" not in payload:
+            raise XAdapterError("xurl read request failed")
+        return payload
+
+    def identity(self) -> dict[str, Any]:
+        return self._json([str(self.helper), "whoami", *self.profile_args])
+
+    def page(self, endpoint: str) -> dict[str, Any]:
+        return self._json(
+            [str(self.helper), "run", *self.profile_args, "--", endpoint]
+        )
+
+
+class FixtureXurl:
+    """Deterministic xurl substitute for pagination and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        try:
+            fixture = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            raise XAdapterError("X fixture is not valid UTF-8 JSON") from error
+        if not isinstance(fixture, dict) or not isinstance(fixture.get("pages"), list):
+            raise XAdapterError("X fixture requires identity and pages")
+        self.fixture = fixture
+        self.position = 0
+
+    def identity(self) -> dict[str, Any]:
+        identity = self.fixture.get("identity")
+        if not isinstance(identity, dict):
+            raise XAdapterError("X fixture identity must be an object")
+        return identity
+
+    def page(self, endpoint: str) -> dict[str, Any]:
+        del endpoint
+        pages = self.fixture["pages"]
+        if self.position >= len(pages) or not isinstance(pages[self.position], dict):
+            raise XAdapterError("X fixture has no page for request")
+        page = pages[self.position]
+        self.position += 1
+        return page
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise XAdapterError("X response status must be an integer")
+    return status
+
+
+def identity_data(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data", payload)
+    if not isinstance(data, dict) or not isinstance(data.get("id"), str):
+        raise XAdapterError("xurl account verification returned no account ID")
+    return data
+
+
+def account_record(user: dict[str, Any], observed_at: str) -> dict[str, Any]:
+    return {
+        "remote_id": user["id"],
+        "handle": user.get("username"),
+        "display_name": user.get("name"),
+        "observed_at": observed_at,
+        "provider_json": {
+            key: value
+            for key, value in user.items()
+            if key not in {"id", "username", "name"}
+        },
+    }
+
+
+def page_accounts(
+    account: dict[str, Any],
+    includes: dict[str, Any],
+    data: list[dict[str, Any]],
+    stream: str,
+    observed_at: str,
+) -> list[dict[str, Any]]:
+    accounts = [account_record(account, observed_at)]
+    for user in includes.get("users", []):
+        if isinstance(user, dict) and isinstance(user.get("id"), str):
+            accounts.append(account_record(user, observed_at))
+    if stream not in TWEET_STREAMS:
+        for user in data:
+            if isinstance(user.get("id"), str):
+                accounts.append(account_record(user, observed_at))
+    return accounts
+
+
+def evidence_class(stream: str) -> str:
+    if stream == "authored":
+        return "authored"
+    if stream in {"likes", "bookmarks"}:
+        return "weak_signal"
+    return "observed"
+
+
+def page_resources(
+    data: list[dict[str, Any]],
+    account_id: str,
+    stream: str,
+    observed_at: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    objects: list[dict[str, Any]] = []
+    activities: list[dict[str, Any]] = []
+    for item in data:
+        remote_id = item.get("id")
+        if not isinstance(remote_id, str) or not remote_id:
+            raise XAdapterError("X resource requires an ID")
+        actor = item.get("author_id", account_id)
+        if not isinstance(actor, str):
+            raise XAdapterError("X resource author_id must be text")
+        object_id: str | None = None
+        if stream in TWEET_STREAMS:
+            object_id = remote_id
+            objects.append(
+                {
+                    "object_type": "post",
+                    "remote_id": remote_id,
+                    "account_remote_id": actor,
+                    "text": item.get("text"),
+                    "created_at": item.get("created_at"),
+                    "observed_at": observed_at,
+                    "evidence_class": evidence_class(stream),
+                    "provider_json": {
+                        key: value
+                        for key, value in item.items()
+                        if key not in {"id", "author_id", "text", "created_at"}
+                    },
+                }
+            )
+        activities.append(
+            {
+                "activity_type": stream,
+                "remote_id": f"{stream}-{remote_id}",
+                "actor_remote_id": account_id,
+                "object_remote_id": object_id,
+                "occurred_at": item.get("created_at"),
+                "observed_at": observed_at,
+                "state": "active",
+            }
+        )
+    return objects, activities
+
+
+def page_media(includes: dict[str, Any], media_policy: str) -> list[dict[str, Any]]:
+    media: list[dict[str, Any]] = []
+    if media_policy != "metadata":
+        return media
+    for item in includes.get("media", []):
+        if isinstance(item, dict) and isinstance(item.get("media_key"), str):
+            media.append(
+                {
+                    "remote_id": item["media_key"],
+                    "object_remote_id": None,
+                    "mime_type": item.get("type"),
+                    "hydration_state": "metadata_only",
+                }
+            )
+    return media
+
+
+def page_archive(
+    payload: dict[str, Any],
+    connection_id: str,
+    account: dict[str, Any],
+    stream: str,
+    media_policy: str,
+) -> dict[str, Any]:
+    reject_credentials(payload)
+    data = payload.get("data", [])
+    if data is None:
+        data = []
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise XAdapterError("X page data must be an array")
+    observed_at = payload.get("observed_at")
+    if observed_at is None:
+        observed_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    if not isinstance(observed_at, str) or not observed_at:
+        raise XAdapterError("X page observed_at must be text")
+    includes = payload.get("includes", {})
+    if not isinstance(includes, dict):
+        raise XAdapterError("X page includes must be an object")
+
+    accounts = page_accounts(account, includes, data, stream, observed_at)
+    objects, activities = page_resources(data, account["id"], stream, observed_at)
+    media = page_media(includes, media_policy)
+    return {
+        "provider": PROVIDER,
+        "connection_id": connection_id,
+        "remote_account_id": account["id"],
+        "exported_at": observed_at,
+        "enabled_streams": [stream],
+        "policy": {"media_hydration": media_policy},
+        "accounts": accounts,
+        "objects": objects,
+        "activities": activities,
+        "media": media,
+        "coverage": [],
+    }
+
+
+def current_cursor(
+    database: Any, connection_id: str, stream: str
+) -> tuple[str | None, str | None, bool]:
+    row = database.execute(
+        "SELECT cursor,watermark,backfill_complete FROM sync_cursors WHERE connection_id=? AND stream=?",
+        (connection_id, stream),
+    ).fetchone()
+    if row is None:
+        return None, None, False
+    return row["cursor"], row["watermark"], bool(row["backfill_complete"])
+
+
+def persist_page(
+    root: Path,
+    archive: dict[str, Any],
+    payload: dict[str, Any],
+    stream: str,
+    next_cursor: str | None,
+    watermark: str | None,
+    complete: bool,
+) -> int:
+    raw = canonical_json(payload).encode("utf-8")
+    connection_id = archive["connection_id"]
+    database = connect(root)
+    try:
+        migrate(database)
+        batch_id, blob_ref = write_raw_batch(root, PROVIDER, connection_id, raw)
+        database.execute("BEGIN IMMEDIATE")
+        upsert_connection(database, archive, PROVIDER, connection_id)
+        import_accounts(database, archive, PROVIDER)
+        import_objects(database, archive, PROVIDER, batch_id)
+        import_activities(database, archive, PROVIDER, batch_id)
+        import_media(database, archive, PROVIDER, batch_id)
+        count = sum(
+            len(archive[key]) for key in ("accounts", "objects", "activities", "media")
+        )
+        database.execute(
+            """INSERT OR IGNORE INTO fetch_batches(
+               batch_id,provider,connection_id,stream,request_hash,response_hash,blob_ref,
+               resource_count,budget_units,completed_at,terminal_status)
+               VALUES(?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                batch_id,
+                PROVIDER,
+                connection_id,
+                stream,
+                hashlib.sha256(stream.encode()).hexdigest(),
+                batch_id,
+                blob_ref,
+                count,
+                1,
+                archive["exported_at"],
+                "success",
+            ),
+        )
+        database.execute(
+            """INSERT INTO sync_cursors(
+               connection_id,stream,cursor,watermark,last_success_at,backfill_complete)
+               VALUES(?,?,?,?,?,?) ON CONFLICT(connection_id,stream) DO UPDATE SET
+               cursor=excluded.cursor,watermark=excluded.watermark,
+               last_success_at=excluded.last_success_at,
+               backfill_complete=excluded.backfill_complete""",
+            (
+                connection_id,
+                stream,
+                next_cursor,
+                watermark,
+                archive["exported_at"],
+                int(complete),
+            ),
+        )
+        database.execute("COMMIT")
+        return count
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()
+
+
+def record_stop(
+    root: Path,
+    connection_id: str,
+    status: str,
+    failure: str,
+    retry_after: str | None,
+) -> None:
+    database = connect(root)
+    try:
+        migrate(database)
+        database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,retry_after,diagnostics) VALUES(?,?,?,?,?,?)",
+            (uuid.uuid4().hex, connection_id, status, failure, retry_after, "sanitized"),
+        )
+    finally:
+        database.close()
+
+
+def xurl_runner(args: argparse.Namespace) -> Any:
+    if args.fixture and os.environ.get("AIDEVOPS_TEST_MODE") != "1":
+        raise XAdapterError("X fixtures are disabled outside the test harness")
+    if args.fixture:
+        return FixtureXurl(args.fixture)
+    helper = Path(__file__).with_name("xurl-helper.sh")
+    return GuardedXurl(helper, args.app, args.username)
+
+
+def load_stream_state(
+    root: Path, connection_id: str, stream: str
+) -> tuple[str | None, str | None, bool]:
+    database = connect(root)
+    try:
+        migrate(database)
+        return current_cursor(database, connection_id, stream)
+    finally:
+        database.close()
+
+
+def stream_endpoint(
+    stream: str,
+    account_id: str,
+    cursor: str | None,
+    watermark: str | None,
+    backfill_complete: bool,
+) -> str:
+    params = {"max_results": "100"}
+    if stream in TWEET_STREAMS:
+        params.update(
+            {
+                "expansions": "author_id,attachments.media_keys",
+                "tweet.fields": "author_id,created_at,attachments,public_metrics",
+                "user.fields": "id,name,username",
+                "media.fields": "media_key,type",
+            }
+        )
+    else:
+        params["user.fields"] = "id,name,username"
+    if cursor:
+        params["pagination_token"] = cursor
+    elif backfill_complete and watermark:
+        params["since_id"] = watermark
+    return STREAM_PATHS[stream].format(account_id=account_id) + "?" + urlencode(params)
+
+
+def terminal_response(
+    payload: dict[str, Any],
+    root: Path,
+    connection_id: str,
+    pages: int,
+    resources: int,
+) -> dict[str, Any] | None:
+    status = response_status(payload)
+    retry_after = payload.get("retry_after")
+    if retry_after is not None and not isinstance(retry_after, str):
+        raise XAdapterError("X retry_after must be text")
+    if status == 429:
+        record_stop(root, connection_id, "paused", "rate_limit", retry_after)
+        return {
+            "status": "rate_limited",
+            "pages": pages,
+            "resources": resources,
+            "retry_after": retry_after,
+        }
+    if status not in (401, 403, 404) and status < 500:
+        if status != 200:
+            raise XAdapterError("X response has unsupported status")
+        return None
+    if status in (401, 403):
+        failure = "authorization"
+    elif status == 404:
+        failure = "unavailable"
+    else:
+        failure = "provider"
+    record_stop(root, connection_id, "failed", failure, retry_after)
+    return {
+        "status": "failed",
+        "failure_class": failure,
+        "pages": pages,
+        "resources": resources,
+    }
+
+
+def page_checkpoint(
+    payload: dict[str, Any], watermark: str | None
+) -> tuple[str | None, str | None]:
+    meta = payload.get("meta", {})
+    if not isinstance(meta, dict):
+        raise XAdapterError("X page meta must be an object")
+    next_cursor = meta.get("next_token")
+    if next_cursor is not None and not isinstance(next_cursor, str):
+        raise XAdapterError("X next_token must be text")
+    ids = [
+        item.get("id")
+        for item in payload.get("data", [])
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    ]
+    candidates = ids + ([watermark] if watermark else [])
+    newest = (
+        max(
+            candidates,
+            key=lambda value: (1, int(value)) if value.isdigit() else (0, value),
+        )
+        if candidates
+        else None
+    )
+    return next_cursor, newest
+
+
+def collect(args: argparse.Namespace, root: Path) -> dict[str, Any]:
+    connection_id = validate_opaque(args.connection_id, "connection_id")
+    account_id = validate_opaque(args.account_id, "account_id")
+    runner = xurl_runner(args)
+    account = identity_data(runner.identity())
+    if account["id"] != account_id:
+        raise XAdapterError(
+            "selected xurl account does not match the configured connection"
+        )
+    cursor, watermark, backfill_complete = load_stream_state(
+        root, connection_id, args.stream
+    )
+    pages = 0
+    resources = 0
+    while pages < args.budget:
+        endpoint = stream_endpoint(
+            args.stream, account_id, cursor, watermark, backfill_complete
+        )
+        payload = runner.page(endpoint)
+        stopped = terminal_response(payload, root, connection_id, pages, resources)
+        if stopped is not None:
+            return stopped
+        next_cursor, newest = page_checkpoint(payload, watermark)
+        archive = page_archive(
+            payload, connection_id, account, args.stream, args.media_policy
+        )
+        resources += persist_page(
+            root,
+            archive,
+            payload,
+            args.stream,
+            next_cursor,
+            newest,
+            next_cursor is None,
+        )
+        pages += 1
+        cursor = next_cursor
+        watermark = newest
+        if next_cursor is None:
+            return {"status": "complete", "pages": pages, "resources": resources}
+    record_stop(root, connection_id, "paused", "budget", None)
+    return {"status": "budget_exhausted", "pages": pages, "resources": resources}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--connection-id", required=True)
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--stream", required=True, choices=tuple(STREAM_PATHS))
+    parser.add_argument("--budget", type=int, default=10)
+    parser.add_argument(
+        "--media-policy", choices=("none", "metadata"), default="none"
+    )
+    parser.add_argument("--app")
+    parser.add_argument("--username")
+    parser.add_argument("--fixture", type=Path, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.budget < 1 or args.budget > 1000:
+        parser.error("--budget must be between 1 and 1000")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        base = (
+            args.base
+            if args.base
+            else Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+        )
+        root = validate_root(resolve(base, args.alias, "knowledge.write"))
+        print(json.dumps(collect(args, root), sort_keys=True))
+        return 0
+    except (
+        CatalogError,
+        OSError,
+        XAdapterError,
+        ValueError,
+        subprocess.SubprocessError,
+    ) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_x.py
+++ b/.agents/scripts/knowledge_social_x.py
@@ -6,375 +6,50 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
+import sqlite3
 import subprocess
 import sys
-import uuid
-from datetime import UTC, datetime
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlencode
 
+from _knowledge_social_x import (
+    STREAMS,
+    CursorState,
+    XAdapterError,
+    page_checkpoint,
+    response_status,
+    stream_endpoint,
+)
+from _knowledge_social_x_normalize import PageContext, normalize_page
+from _knowledge_social_x_persist import (
+    SuccessfulPage,
+    TerminalDecision,
+    persist_page,
+    record_bounded_stop,
+    record_terminal,
+)
+from _knowledge_social_x_reader import (
+    FixtureXurl,
+    GuardedXurl,
+    XReader,
+    verified_identity,
+)
+from _knowledge_social_x_state import CollectionContext, load_context
 from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
 from knowledge_corpus_context import CatalogError
-from knowledge_social_import import (
-    canonical_json,
-    import_accounts,
-    import_activities,
-    import_media,
-    import_objects,
-    reject_credentials,
-    upsert_connection,
-)
+from knowledge_social_import import reject_credentials
 from knowledge_social_store import (
     SocialStoreError,
-    connect,
-    migrate,
     validate_opaque,
     validate_root,
-    write_raw_batch,
 )
 
-PROVIDER = "xapi"
-STREAM_PATHS = {
-    "authored": "/2/users/{account_id}/tweets",
-    "mentions": "/2/users/{account_id}/mentions",
-    "likes": "/2/users/{account_id}/liked_tweets",
-    "bookmarks": "/2/users/{account_id}/bookmarks",
-    "followers": "/2/users/{account_id}/followers",
-    "following": "/2/users/{account_id}/following",
-}
-TWEET_STREAMS = {"authored", "mentions", "likes", "bookmarks"}
 
-
-class XAdapterError(SocialStoreError):
-    """Raised when guarded X collection cannot continue safely."""
-
-
-class GuardedXurl:
-    """Execute only the two read-only helper surfaces used by this adapter."""
-
-    def __init__(self, helper: Path, app: str | None, username: str | None) -> None:
-        self.helper = helper
-        self.profile_args: list[str] = []
-        if app:
-            self.profile_args.extend(("--app", app))
-        if username:
-            self.profile_args.extend(("--username", username))
-
-    def _json(self, command: list[str]) -> dict[str, Any]:
-        completed = subprocess.run(  # nosec B603 -- argv is built from a fixed helper and allowlisted reads
-            command, check=False, capture_output=True, text=True, timeout=120
-        )
-        try:
-            payload = json.loads(completed.stdout)
-        except json.JSONDecodeError as error:
-            raise XAdapterError("xurl returned no valid JSON") from error
-        if not isinstance(payload, dict):
-            raise XAdapterError("xurl response root must be an object")
-        if completed.returncode != 0 and "status" not in payload:
-            raise XAdapterError("xurl read request failed")
-        return payload
-
-    def identity(self) -> dict[str, Any]:
-        return self._json([str(self.helper), "whoami", *self.profile_args])
-
-    def page(self, endpoint: str) -> dict[str, Any]:
-        return self._json(
-            [str(self.helper), "run", *self.profile_args, "--", endpoint]
-        )
-
-
-class FixtureXurl:
-    """Deterministic xurl substitute for pagination and failure fixtures."""
-
-    def __init__(self, path: Path) -> None:
-        try:
-            fixture = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeError, json.JSONDecodeError) as error:
-            raise XAdapterError("X fixture is not valid UTF-8 JSON") from error
-        if not isinstance(fixture, dict) or not isinstance(fixture.get("pages"), list):
-            raise XAdapterError("X fixture requires identity and pages")
-        self.fixture = fixture
-        self.position = 0
-
-    def identity(self) -> dict[str, Any]:
-        identity = self.fixture.get("identity")
-        if not isinstance(identity, dict):
-            raise XAdapterError("X fixture identity must be an object")
-        return identity
-
-    def page(self, endpoint: str) -> dict[str, Any]:
-        del endpoint
-        pages = self.fixture["pages"]
-        if self.position >= len(pages) or not isinstance(pages[self.position], dict):
-            raise XAdapterError("X fixture has no page for request")
-        page = pages[self.position]
-        self.position += 1
-        return page
-
-
-def response_status(payload: dict[str, Any]) -> int:
-    status = payload.get("status", 200)
-    if isinstance(status, bool) or not isinstance(status, int):
-        raise XAdapterError("X response status must be an integer")
-    return status
-
-
-def identity_data(payload: dict[str, Any]) -> dict[str, Any]:
-    data = payload.get("data", payload)
-    if not isinstance(data, dict) or not isinstance(data.get("id"), str):
-        raise XAdapterError("xurl account verification returned no account ID")
-    return data
-
-
-def account_record(user: dict[str, Any], observed_at: str) -> dict[str, Any]:
-    return {
-        "remote_id": user["id"],
-        "handle": user.get("username"),
-        "display_name": user.get("name"),
-        "observed_at": observed_at,
-        "provider_json": {
-            key: value
-            for key, value in user.items()
-            if key not in {"id", "username", "name"}
-        },
-    }
-
-
-def page_accounts(
-    account: dict[str, Any],
-    includes: dict[str, Any],
-    data: list[dict[str, Any]],
-    stream: str,
-    observed_at: str,
-) -> list[dict[str, Any]]:
-    accounts = [account_record(account, observed_at)]
-    for user in includes.get("users", []):
-        if isinstance(user, dict) and isinstance(user.get("id"), str):
-            accounts.append(account_record(user, observed_at))
-    if stream not in TWEET_STREAMS:
-        for user in data:
-            if isinstance(user.get("id"), str):
-                accounts.append(account_record(user, observed_at))
-    return accounts
-
-
-def evidence_class(stream: str) -> str:
-    if stream == "authored":
-        return "authored"
-    if stream in {"likes", "bookmarks"}:
-        return "weak_signal"
-    return "observed"
-
-
-def page_resources(
-    data: list[dict[str, Any]],
-    account_id: str,
-    stream: str,
-    observed_at: str,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    objects: list[dict[str, Any]] = []
-    activities: list[dict[str, Any]] = []
-    for item in data:
-        remote_id = item.get("id")
-        if not isinstance(remote_id, str) or not remote_id:
-            raise XAdapterError("X resource requires an ID")
-        actor = item.get("author_id", account_id)
-        if not isinstance(actor, str):
-            raise XAdapterError("X resource author_id must be text")
-        object_id: str | None = None
-        if stream in TWEET_STREAMS:
-            object_id = remote_id
-            objects.append(
-                {
-                    "object_type": "post",
-                    "remote_id": remote_id,
-                    "account_remote_id": actor,
-                    "text": item.get("text"),
-                    "created_at": item.get("created_at"),
-                    "observed_at": observed_at,
-                    "evidence_class": evidence_class(stream),
-                    "provider_json": {
-                        key: value
-                        for key, value in item.items()
-                        if key not in {"id", "author_id", "text", "created_at"}
-                    },
-                }
-            )
-        activities.append(
-            {
-                "activity_type": stream,
-                "remote_id": f"{stream}-{remote_id}",
-                "actor_remote_id": account_id,
-                "object_remote_id": object_id,
-                "occurred_at": item.get("created_at"),
-                "observed_at": observed_at,
-                "state": "active",
-            }
-        )
-    return objects, activities
-
-
-def page_media(includes: dict[str, Any], media_policy: str) -> list[dict[str, Any]]:
-    media: list[dict[str, Any]] = []
-    if media_policy != "metadata":
-        return media
-    for item in includes.get("media", []):
-        if isinstance(item, dict) and isinstance(item.get("media_key"), str):
-            media.append(
-                {
-                    "remote_id": item["media_key"],
-                    "object_remote_id": None,
-                    "mime_type": item.get("type"),
-                    "hydration_state": "metadata_only",
-                }
-            )
-    return media
-
-
-def page_archive(
-    payload: dict[str, Any],
-    connection_id: str,
-    account: dict[str, Any],
-    stream: str,
-    media_policy: str,
-) -> dict[str, Any]:
-    reject_credentials(payload)
-    data = payload.get("data", [])
-    if data is None:
-        data = []
-    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
-        raise XAdapterError("X page data must be an array")
-    observed_at = payload.get("observed_at")
-    if observed_at is None:
-        observed_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
-    if not isinstance(observed_at, str) or not observed_at:
-        raise XAdapterError("X page observed_at must be text")
-    includes = payload.get("includes", {})
-    if not isinstance(includes, dict):
-        raise XAdapterError("X page includes must be an object")
-
-    accounts = page_accounts(account, includes, data, stream, observed_at)
-    objects, activities = page_resources(data, account["id"], stream, observed_at)
-    media = page_media(includes, media_policy)
-    return {
-        "provider": PROVIDER,
-        "connection_id": connection_id,
-        "remote_account_id": account["id"],
-        "exported_at": observed_at,
-        "enabled_streams": [stream],
-        "policy": {"media_hydration": media_policy},
-        "accounts": accounts,
-        "objects": objects,
-        "activities": activities,
-        "media": media,
-        "coverage": [],
-    }
-
-
-def current_cursor(
-    database: Any, connection_id: str, stream: str
-) -> tuple[str | None, str | None, bool]:
-    row = database.execute(
-        "SELECT cursor,watermark,backfill_complete FROM sync_cursors WHERE connection_id=? AND stream=?",
-        (connection_id, stream),
-    ).fetchone()
-    if row is None:
-        return None, None, False
-    return row["cursor"], row["watermark"], bool(row["backfill_complete"])
-
-
-def persist_page(
-    root: Path,
-    archive: dict[str, Any],
-    payload: dict[str, Any],
-    stream: str,
-    next_cursor: str | None,
-    watermark: str | None,
-    complete: bool,
-) -> int:
-    raw = canonical_json(payload).encode("utf-8")
-    connection_id = archive["connection_id"]
-    database = connect(root)
-    try:
-        migrate(database)
-        batch_id, blob_ref = write_raw_batch(root, PROVIDER, connection_id, raw)
-        database.execute("BEGIN IMMEDIATE")
-        upsert_connection(database, archive, PROVIDER, connection_id)
-        import_accounts(database, archive, PROVIDER)
-        import_objects(database, archive, PROVIDER, batch_id)
-        import_activities(database, archive, PROVIDER, batch_id)
-        import_media(database, archive, PROVIDER, batch_id)
-        count = sum(
-            len(archive[key]) for key in ("accounts", "objects", "activities", "media")
-        )
-        database.execute(
-            """INSERT OR IGNORE INTO fetch_batches(
-               batch_id,provider,connection_id,stream,request_hash,response_hash,blob_ref,
-               resource_count,budget_units,completed_at,terminal_status)
-               VALUES(?,?,?,?,?,?,?,?,?,?,?)""",
-            (
-                batch_id,
-                PROVIDER,
-                connection_id,
-                stream,
-                hashlib.sha256(stream.encode()).hexdigest(),
-                batch_id,
-                blob_ref,
-                count,
-                1,
-                archive["exported_at"],
-                "success",
-            ),
-        )
-        database.execute(
-            """INSERT INTO sync_cursors(
-               connection_id,stream,cursor,watermark,last_success_at,backfill_complete)
-               VALUES(?,?,?,?,?,?) ON CONFLICT(connection_id,stream) DO UPDATE SET
-               cursor=excluded.cursor,watermark=excluded.watermark,
-               last_success_at=excluded.last_success_at,
-               backfill_complete=excluded.backfill_complete""",
-            (
-                connection_id,
-                stream,
-                next_cursor,
-                watermark,
-                archive["exported_at"],
-                int(complete),
-            ),
-        )
-        database.execute("COMMIT")
-        return count
-    except Exception:
-        if database.in_transaction:
-            database.execute("ROLLBACK")
-        raise
-    finally:
-        database.close()
-
-
-def record_stop(
-    root: Path,
-    connection_id: str,
-    status: str,
-    failure: str,
-    retry_after: str | None,
-) -> None:
-    database = connect(root)
-    try:
-        migrate(database)
-        database.execute(
-            "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,retry_after,diagnostics) VALUES(?,?,?,?,?,?)",
-            (uuid.uuid4().hex, connection_id, status, failure, retry_after, "sanitized"),
-        )
-    finally:
-        database.close()
-
-
-def xurl_runner(args: argparse.Namespace) -> Any:
+def xurl_runner(args: argparse.Namespace) -> XReader:
+    """Select the guarded live reader or a test-only fixture reader."""
     if args.fixture and os.environ.get("AIDEVOPS_TEST_MODE") != "1":
         raise XAdapterError("X fixtures are disabled outside the test harness")
     if args.fixture:
@@ -383,149 +58,119 @@ def xurl_runner(args: argparse.Namespace) -> Any:
     return GuardedXurl(helper, args.app, args.username)
 
 
-def load_stream_state(
-    root: Path, connection_id: str, stream: str
-) -> tuple[str | None, str | None, bool]:
-    database = connect(root)
-    try:
-        migrate(database)
-        return current_cursor(database, connection_id, stream)
-    finally:
-        database.close()
-
-
-def stream_endpoint(
-    stream: str,
-    account_id: str,
-    cursor: str | None,
-    watermark: str | None,
-    backfill_complete: bool,
-) -> str:
-    params = {"max_results": "100"}
-    if stream in TWEET_STREAMS:
-        params.update(
-            {
-                "expansions": "author_id,attachments.media_keys",
-                "tweet.fields": "author_id,created_at,attachments,public_metrics",
-                "user.fields": "id,name,username",
-                "media.fields": "media_key,type",
-            }
-        )
+def terminal_decision(payload: dict[str, Any]) -> TerminalDecision | None:
+    """Map terminal response codes to sanitized local run states."""
+    status = response_status(payload)
+    if status == 200:
+        decision = None
+    elif status == 429:
+        decision = TerminalDecision("rate_limited", "paused", "rate_limit")
+    elif status in (401, 403):
+        decision = TerminalDecision("failed", "failed", "authorization")
+    elif status == 404:
+        decision = TerminalDecision("failed", "failed", "unavailable")
+    elif status >= 500:
+        decision = TerminalDecision("failed", "failed", "provider")
     else:
-        params["user.fields"] = "id,name,username"
-    if cursor:
-        params["pagination_token"] = cursor
-    elif backfill_complete and watermark:
-        params["since_id"] = watermark
-    return STREAM_PATHS[stream].format(account_id=account_id) + "?" + urlencode(params)
+        decision = TerminalDecision("failed", "failed", "request")
+    return decision
 
 
-def terminal_response(
-    payload: dict[str, Any],
-    root: Path,
-    connection_id: str,
+def _page_context(context: CollectionContext) -> PageContext:
+    return PageContext(
+        context.connection_id,
+        context.account,
+        context.stream,
+        context.media_policy,
+        context.config.enabled_streams,
+        context.config.policy,
+    )
+
+
+def _result(
+    status: str,
     pages: int,
     resources: int,
-) -> dict[str, Any] | None:
-    status = response_status(payload)
-    retry_after = payload.get("retry_after")
-    if retry_after is not None and not isinstance(retry_after, str):
-        raise XAdapterError("X retry_after must be text")
-    if status == 429:
-        record_stop(root, connection_id, "paused", "rate_limit", retry_after)
-        return {
-            "status": "rate_limited",
-            "pages": pages,
-            "resources": resources,
-            "retry_after": retry_after,
-        }
-    if status not in (401, 403, 404) and status < 500:
-        if status != 200:
-            raise XAdapterError("X response has unsupported status")
-        return None
-    if status in (401, 403):
-        failure = "authorization"
-    elif status == 404:
-        failure = "unavailable"
-    else:
-        failure = "provider"
-    record_stop(root, connection_id, "failed", failure, retry_after)
+    budget_units: int,
+    **extra: Any,
+) -> dict[str, Any]:
     return {
-        "status": "failed",
-        "failure_class": failure,
+        "status": status,
         "pages": pages,
         "resources": resources,
+        "budget_units": budget_units,
+        **extra,
     }
 
 
-def page_checkpoint(
-    payload: dict[str, Any], watermark: str | None
-) -> tuple[str | None, str | None]:
-    meta = payload.get("meta", {})
-    if not isinstance(meta, dict):
-        raise XAdapterError("X page meta must be an object")
-    next_cursor = meta.get("next_token")
-    if next_cursor is not None and not isinstance(next_cursor, str):
-        raise XAdapterError("X next_token must be text")
-    ids = [
-        item.get("id")
-        for item in payload.get("data", [])
-        if isinstance(item, dict) and isinstance(item.get("id"), str)
-    ]
-    candidates = ids + ([watermark] if watermark else [])
-    newest = (
-        max(
-            candidates,
-            key=lambda value: (1, int(value)) if value.isdigit() else (0, value),
+def collect_pages(
+    args: argparse.Namespace, runner: XReader, initial: CollectionContext
+) -> dict[str, Any]:
+    """Collect successful pages until completion, failure, or budget stop."""
+    context = initial
+    pages = 0
+    resources = 0
+    budget_units = 0
+    while budget_units + context.spec.cost_units <= args.budget:
+        endpoint = stream_endpoint(
+            context.stream, context.account["id"], context.state
         )
-        if candidates
-        else None
-    )
-    return next_cursor, newest
+        payload = runner.page(endpoint)
+        reject_credentials(payload)
+        decision = terminal_decision(payload)
+        if decision:
+            retry_after = record_terminal(context, payload, endpoint, decision)
+            return _result(
+                decision.output_status,
+                pages,
+                resources,
+                budget_units + context.spec.cost_units,
+                failure_class=decision.failure_class,
+                retry_after=retry_after,
+            )
+        checkpoint = page_checkpoint(payload, context.state.watermark)
+        archive = normalize_page(payload, _page_context(context))
+        complete = checkpoint.next_cursor is None
+        page = SuccessfulPage(
+            payload,
+            endpoint,
+            archive,
+            checkpoint,
+            complete,
+            context.spec.cost_units,
+        )
+        resources += persist_page(context, page)
+        pages += 1
+        budget_units += context.spec.cost_units
+        state = CursorState(
+            checkpoint.next_cursor, checkpoint.watermark, complete
+        )
+        context = replace(context, state=state)
+        if complete:
+            return _result("complete", pages, resources, budget_units)
+    record_bounded_stop(context, "paused", "budget")
+    return _result("budget_exhausted", pages, resources, budget_units)
 
 
 def collect(args: argparse.Namespace, root: Path) -> dict[str, Any]:
+    """Verify identity and collect one configured stream."""
     connection_id = validate_opaque(args.connection_id, "connection_id")
     account_id = validate_opaque(args.account_id, "account_id")
     runner = xurl_runner(args)
-    account = identity_data(runner.identity())
-    if account["id"] != account_id:
-        raise XAdapterError(
-            "selected xurl account does not match the configured connection"
-        )
-    cursor, watermark, backfill_complete = load_stream_state(
-        root, connection_id, args.stream
+    account = verified_identity(runner.identity(), account_id)
+    context = load_context(
+        root, connection_id, account, args.stream, args.media_policy
     )
-    pages = 0
-    resources = 0
-    while pages < args.budget:
-        endpoint = stream_endpoint(
-            args.stream, account_id, cursor, watermark, backfill_complete
+    if context.state.backfill_complete and not context.spec.supports_since_id:
+        record_bounded_stop(context, "unavailable", "delta_not_supported")
+        return _result(
+            "delta_unavailable",
+            0,
+            0,
+            0,
+            failure_class="delta_not_supported",
         )
-        payload = runner.page(endpoint)
-        stopped = terminal_response(payload, root, connection_id, pages, resources)
-        if stopped is not None:
-            return stopped
-        next_cursor, newest = page_checkpoint(payload, watermark)
-        archive = page_archive(
-            payload, connection_id, account, args.stream, args.media_policy
-        )
-        resources += persist_page(
-            root,
-            archive,
-            payload,
-            args.stream,
-            next_cursor,
-            newest,
-            next_cursor is None,
-        )
-        pages += 1
-        cursor = next_cursor
-        watermark = newest
-        if next_cursor is None:
-            return {"status": "complete", "pages": pages, "resources": resources}
-    record_stop(root, connection_id, "paused", "budget", None)
-    return {"status": "budget_exhausted", "pages": pages, "resources": resources}
+    return collect_pages(args, runner, context)
 
 
 def parse_args() -> argparse.Namespace:
@@ -534,7 +179,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--alias", default=DEFAULT_ALIAS)
     parser.add_argument("--connection-id", required=True)
     parser.add_argument("--account-id", required=True)
-    parser.add_argument("--stream", required=True, choices=tuple(STREAM_PATHS))
+    parser.add_argument("--stream", required=True, choices=tuple(STREAMS))
     parser.add_argument("--budget", type=int, default=10)
     parser.add_argument(
         "--media-policy", choices=("none", "metadata"), default="none"
@@ -544,7 +189,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--fixture", type=Path, help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.budget < 1 or args.budget > 1000:
-        parser.error("--budget must be between 1 and 1000")
+        parser.error("--budget must be between 1 and 1000 request units")
     return args
 
 
@@ -562,9 +207,10 @@ def main() -> int:
     except (
         CatalogError,
         OSError,
-        XAdapterError,
-        ValueError,
+        SocialStoreError,
+        sqlite3.Error,
         subprocess.SubprocessError,
+        ValueError,
     ) as error:
         print(f"ERROR: {error}", file=sys.stderr)
         return 1

--- a/.agents/tests/test-knowledge-social-x.sh
+++ b/.agents/tests/test-knowledge-social-x.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-x.sh — Guarded X adapter regression tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+connection = sqlite3.connect(sys.argv[1])
+print(connection.execute(sys.argv[2]).fetchone()[0])
+connection.close()
+PY
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+cat >"$TMP_DIR/page-1.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42", "username": "private-handle", "name": "Private Account"}},
+  "pages": [{
+    "status": 200,
+    "observed_at": "2026-07-25T05:00:00Z",
+    "data": [{"id": "102", "author_id": "acct42", "text": "second", "created_at": "2026-07-24T02:00:00Z"}],
+    "includes": {"media": [{"media_key": "media102", "type": "photo", "url": "https://example.invalid/private.jpg"}]},
+    "meta": {"next_token": "cursor-two"}
+  }]
+}
+JSON
+
+first_result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id acct42 --stream authored \
+	--budget 1 --media-policy none --fixture "$TMP_DIR/page-1.json")
+assert_eq "page budget stops a backfill without retrying" \
+	"$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["status"])' "$first_result")" "budget_exhausted"
+assert_eq "first page advances only its stream cursor" \
+	"$(sql_value "SELECT cursor || ':' || backfill_complete FROM sync_cursors WHERE stream='authored'")" "cursor-two:0"
+assert_eq "none media policy persists no media metadata" "$(sql_value 'SELECT count(*) FROM media')" "0"
+
+cat >"$TMP_DIR/page-2.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42", "username": "private-handle"}},
+  "pages": [{
+    "status": 200,
+    "observed_at": "2026-07-25T05:01:00Z",
+    "data": [{"id": "101", "author_id": "acct42", "text": "first", "created_at": "2026-07-24T01:00:00Z"}],
+    "meta": {}
+  }]
+}
+JSON
+
+second_result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id acct42 --stream authored \
+	--budget 2 --fixture "$TMP_DIR/page-2.json")
+assert_eq "resumed pagination reaches exhaustion" \
+	"$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["status"])' "$second_result")" "complete"
+assert_eq "cursor and content commit atomically at exhaustion" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || watermark || ':' || backfill_complete FROM sync_cursors WHERE stream='authored'")" "done:102:1"
+assert_eq "pagination stores both immutable API pages" \
+	"$(sql_value "SELECT (SELECT count(*) FROM objects) || ':' || (SELECT count(*) FROM fetch_batches WHERE stream='authored')")" "2:2"
+
+cat >"$TMP_DIR/mentions.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42", "username": "private-handle"}},
+  "pages": [{
+    "status": 200,
+    "observed_at": "2026-07-25T05:02:00Z",
+    "data": [{"id": "201", "author_id": "other77", "text": "mention", "created_at": "2026-07-25T05:02:00Z"}],
+    "includes": {"media": [{"media_key": "media201", "type": "photo"}]},
+    "meta": {}
+  }]
+}
+JSON
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id acct42 --stream mentions \
+	--media-policy metadata --fixture "$TMP_DIR/mentions.json" >/dev/null
+assert_eq "each stream owns an independent cursor" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_authored'")" "2"
+assert_eq "metadata policy records no media binary reference" \
+	"$(sql_value "SELECT hydration_state || ':' || coalesce(blob_ref,'none') FROM media WHERE remote_id='media201'")" "metadata_only:none"
+
+cursor_before=$(sql_value "SELECT watermark FROM sync_cursors WHERE stream='authored'")
+cat >"$TMP_DIR/rate-limit.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42", "username": "private-handle"}},
+  "pages": [{"status": 429, "retry_after": "2026-07-25T06:00:00Z"}]
+}
+JSON
+rate_result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id acct42 --stream authored \
+	--fixture "$TMP_DIR/rate-limit.json")
+assert_eq "429 is terminal for this invocation" \
+	"$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["status"])' "$rate_result")" "rate_limited"
+assert_eq "terminal rate limit preserves the checkpoint" \
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE stream='authored'")" "$cursor_before"
+assert_eq "rate reset is recorded once without raw diagnostics" \
+	"$(sql_value "SELECT failure_class || ':' || retry_after || ':' || diagnostics FROM sync_runs ORDER BY rowid DESC LIMIT 1")" \
+	"rate_limit:2026-07-25T06:00:00Z:sanitized"
+
+cat >"$TMP_DIR/wrong-account.json" <<'JSON'
+{"identity": {"data": {"id": "other99"}}, "pages": []}
+JSON
+batch_count=$(sql_value 'SELECT count(*) FROM fetch_batches')
+if "$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id acct42 --stream authored \
+	--fixture "$TMP_DIR/wrong-account.json" >/dev/null 2>&1; then
+	assert_eq "account mismatch is rejected before collection" "accepted" "rejected"
+else
+	assert_eq "account mismatch is rejected before collection" "rejected" "rejected"
+fi
+assert_eq "account mismatch persists no raw page" "$(sql_value 'SELECT count(*) FROM fetch_batches')" "$batch_count"
+
+assert_eq "adapter source reaches only guarded read commands" \
+	"$(
+		python3 - "$SCRIPT_DIR/../scripts/knowledge_social_x.py" <<'PY'
+import ast
+import sys
+tree = ast.parse(open(sys.argv[1], encoding="utf-8").read())
+commands = []
+for node in tree.body:
+    if isinstance(node, ast.ClassDef) and node.name == "GuardedXurl":
+        for method in node.body:
+            if isinstance(method, ast.FunctionDef) and method.name in {"identity", "page"}:
+                for child in ast.walk(method):
+                    if isinstance(child, ast.Constant) and child.value in {"post", "reply", "like", "follow", "dm", "media"}:
+                        commands.append(child.value)
+print(",".join(sorted(set(commands))))
+PY
+	)" ""
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/tests/test-knowledge-social-x.sh
+++ b/.agents/tests/test-knowledge-social-x.sh
@@ -35,6 +35,13 @@ assert_eq() {
 	return 0
 }
 
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' "$payload" "$field"
+	return 0
+}
+
 sql_value() {
 	local query="$1"
 	python3 - "$ROOT/index/social.db" "$query" <<'PY'
@@ -47,6 +54,43 @@ PY
 	return 0
 }
 
+raw_count() {
+	python3 - "$ROOT/sources/social/raw" <<'PY'
+import sys
+from pathlib import Path
+print(len(list(Path(sys.argv[1]).rglob("*.json.gz"))))
+PY
+	return 0
+}
+
+run_terminal_fixture() {
+	local name="$1"
+	local status="$2"
+	local expected_failure="$3"
+	local fixture="${TMP_DIR}/${name}.json"
+	python3 - "$fixture" "$status" <<'PY'
+import json
+import sys
+payload = {
+    "identity": {"data": {"id": "acct42", "username": "fixture-handle"}},
+    "pages": [{
+        "status": int(sys.argv[2]),
+        "observed_at": f"2026-07-25T05:{int(sys.argv[2]) % 60:02d}:00Z",
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+	local result=""
+	result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
+		--connection-id conn_authored --account-id acct42 --stream authored \
+		--fixture "$fixture")
+	assert_eq "${status} response is terminal" "$(json_field "$result" status)" "failed"
+	assert_eq "${status} response has a sanitized failure class" \
+		"$(json_field "$result" failure_class)" "$expected_failure"
+	return 0
+}
+
 mkdir -p "$ROOT"
 chmod 0700 "$BASE" "$ROOT"
 "$CORPUS_HELPER" provision --base "$BASE" >/dev/null
@@ -54,13 +98,15 @@ chmod 0700 "$BASE" "$ROOT"
 
 cat >"$TMP_DIR/page-1.json" <<'JSON'
 {
-  "identity": {"data": {"id": "acct42", "username": "private-handle", "name": "Private Account"}},
+  "identity": {"data": {"id": "acct42", "username": "fixture-handle", "name": "Fixture Account"}},
   "pages": [{
-    "status": 200,
-    "observed_at": "2026-07-25T05:00:00Z",
-    "data": [{"id": "102", "author_id": "acct42", "text": "second", "created_at": "2026-07-24T02:00:00Z"}],
-    "includes": {"media": [{"media_key": "media102", "type": "photo", "url": "https://example.invalid/private.jpg"}]},
-    "meta": {"next_token": "cursor-two"}
+    "expect_endpoint_contains": ["/2/users/acct42/tweets?", "max_results=100"],
+    "response": {
+      "status": 200,
+      "observed_at": "2026-07-25T05:00:00Z",
+      "data": [{"id": "102", "author_id": "acct42", "text": "second", "created_at": "2026-07-24T02:00:00Z"}],
+      "meta": {"next_token": "cursor-two"}
+    }
   }]
 }
 JSON
@@ -68,20 +114,31 @@ JSON
 first_result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
 	--connection-id conn_authored --account-id acct42 --stream authored \
 	--budget 1 --media-policy none --fixture "$TMP_DIR/page-1.json")
-assert_eq "page budget stops a backfill without retrying" \
-	"$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["status"])' "$first_result")" "budget_exhausted"
+assert_eq "request-unit budget stops a backfill without retrying" \
+	"$(json_field "$first_result" status)" "budget_exhausted"
+assert_eq "one successful request consumes one budget unit" \
+	"$(json_field "$first_result" budget_units)" "1"
 assert_eq "first page advances only its stream cursor" \
 	"$(sql_value "SELECT cursor || ':' || backfill_complete FROM sync_cursors WHERE stream='authored'")" "cursor-two:0"
 assert_eq "none media policy persists no media metadata" "$(sql_value 'SELECT count(*) FROM media')" "0"
+assert_eq "API objects update the local FTS projection" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'second'")" "1"
+assert_eq "partial coverage is recorded with the durable page" \
+	"$(sql_value "SELECT status || ':' || cursor_exhausted FROM coverage_records WHERE stream='authored'")" "paused:0"
+assert_eq "private account identity is absent from command output" \
+	"$([[ "$first_result" == *fixture-handle* ]] && printf present || printf absent)" "absent"
 
 cat >"$TMP_DIR/page-2.json" <<'JSON'
 {
-  "identity": {"data": {"id": "acct42", "username": "private-handle"}},
+  "identity": {"data": {"id": "acct42", "username": "fixture-handle"}},
   "pages": [{
-    "status": 200,
-    "observed_at": "2026-07-25T05:01:00Z",
-    "data": [{"id": "101", "author_id": "acct42", "text": "first", "created_at": "2026-07-24T01:00:00Z"}],
-    "meta": {}
+    "expect_endpoint_contains": ["pagination_token=cursor-two"],
+    "response": {
+      "status": 200,
+      "observed_at": "2026-07-25T05:01:00Z",
+      "data": [{"id": "101", "author_id": "acct42", "text": "first", "created_at": "2026-07-24T01:00:00Z"}],
+      "meta": {}
+    }
   }]
 }
 JSON
@@ -89,20 +146,44 @@ JSON
 second_result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
 	--connection-id conn_authored --account-id acct42 --stream authored \
 	--budget 2 --fixture "$TMP_DIR/page-2.json")
-assert_eq "resumed pagination reaches exhaustion" \
-	"$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["status"])' "$second_result")" "complete"
+assert_eq "resumed pagination reaches exhaustion" "$(json_field "$second_result" status)" "complete"
 assert_eq "cursor and content commit atomically at exhaustion" \
 	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || watermark || ':' || backfill_complete FROM sync_cursors WHERE stream='authored'")" "done:102:1"
 assert_eq "pagination stores both immutable API pages" \
 	"$(sql_value "SELECT (SELECT count(*) FROM objects) || ':' || (SELECT count(*) FROM fetch_batches WHERE stream='authored')")" "2:2"
+assert_eq "complete coverage preserves the full backfill time range" \
+	"$(sql_value "SELECT earliest_at || ':' || latest_at || ':' || status FROM coverage_records WHERE stream='authored'")" \
+	"2026-07-24T01:00:00Z:2026-07-24T02:00:00Z:complete"
+
+cat >"$TMP_DIR/delta.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42", "username": "fixture-handle"}},
+  "pages": [{
+    "expect_endpoint_contains": ["since_id=102"],
+    "response": {
+      "status": 200,
+      "observed_at": "2026-07-25T05:02:00Z",
+      "data": [{"id": "103", "author_id": "acct42", "text": "delta", "created_at": "2026-07-25T04:00:00Z"}],
+      "meta": {}
+    }
+  }]
+}
+JSON
+
+delta_result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id acct42 --stream authored \
+	--fixture "$TMP_DIR/delta.json")
+assert_eq "delta collection uses the committed watermark" "$(json_field "$delta_result" status)" "complete"
+assert_eq "delta collection advances the watermark" \
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE stream='authored'")" "103"
 
 cat >"$TMP_DIR/mentions.json" <<'JSON'
 {
-  "identity": {"data": {"id": "acct42", "username": "private-handle"}},
+  "identity": {"data": {"id": "acct42", "username": "fixture-handle"}},
   "pages": [{
     "status": 200,
-    "observed_at": "2026-07-25T05:02:00Z",
-    "data": [{"id": "201", "author_id": "other77", "text": "mention", "created_at": "2026-07-25T05:02:00Z"}],
+    "observed_at": "2026-07-25T05:03:00Z",
+    "data": [{"id": "201", "author_id": "other77", "text": "mention", "created_at": "2026-07-25T05:03:00Z", "attachments": {"media_keys": ["media201"]}}],
     "includes": {"media": [{"media_key": "media201", "type": "photo"}]},
     "meta": {}
   }]
@@ -113,57 +194,238 @@ JSON
 	--media-policy metadata --fixture "$TMP_DIR/mentions.json" >/dev/null
 assert_eq "each stream owns an independent cursor" \
 	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_authored'")" "2"
-assert_eq "metadata policy records no media binary reference" \
-	"$(sql_value "SELECT hydration_state || ':' || coalesce(blob_ref,'none') FROM media WHERE remote_id='media201'")" "metadata_only:none"
+assert_eq "enabled streams are merged instead of overwritten" \
+	"$(python3 -c 'import json,sys; print(",".join(json.loads(sys.argv[1])))' "$(sql_value "SELECT enabled_streams FROM connections WHERE connection_id='conn_authored'")")" \
+	"authored,mentions"
+assert_eq "mention provenance records the content author as actor" \
+	"$(sql_value "SELECT actor_remote_id || ':' || object_remote_id FROM activities WHERE activity_type='mentions'")" "other77:201"
+assert_eq "metadata policy links media to its post without a binary blob" \
+	"$(sql_value "SELECT hydration_state || ':' || coalesce(blob_ref,'none') || ':' || object_remote_id FROM media WHERE remote_id='media201'")" \
+	"metadata_only:none:201"
 
-cursor_before=$(sql_value "SELECT watermark FROM sync_cursors WHERE stream='authored'")
+cat >"$TMP_DIR/empty-authored.json" <<'JSON'
+{"identity":{"data":{"id":"acct42"}},"pages":[{"status":200,"observed_at":"2026-07-25T05:04:00Z","data":[],"meta":{}}]}
+JSON
+cat >"$TMP_DIR/empty-mentions.json" <<'JSON'
+{"identity":{"data":{"id":"acct42"}},"pages":[{"status":200,"observed_at":"2026-07-25T05:04:00Z","data":[],"meta":{}}]}
+JSON
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_empty --account-id acct42 --stream authored \
+	--fixture "$TMP_DIR/empty-authored.json" >/dev/null
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_empty --account-id acct42 --stream mentions \
+	--fixture "$TMP_DIR/empty-mentions.json" >/dev/null
+assert_eq "identical provider responses remain distinct per request stream" \
+	"$(sql_value "SELECT count(*) || ':' || count(DISTINCT response_hash) FROM fetch_batches WHERE connection_id='conn_empty'")" "2:2"
+
+cat >"$TMP_DIR/followers.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42"}},
+  "pages": [{
+    "status": 200,
+    "observed_at": "2026-07-25T05:05:00Z",
+    "data": [{"id": "follower77", "username": "follower"}],
+    "meta": {}
+  }]
+}
+JSON
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_relationship --account-id acct42 --stream followers \
+	--fixture "$TMP_DIR/followers.json" >/dev/null
+assert_eq "follower activity preserves relationship direction and account scope" \
+	"$(sql_value "SELECT remote_id || ':' || actor_remote_id || ':' || object_remote_id FROM activities WHERE activity_type='followers'")" \
+	"acct42-followers-follower77:follower77:acct42"
+
+cat >"$TMP_DIR/no-delta.json" <<'JSON'
+{"identity":{"data":{"id":"acct42"}},"pages":[]}
+JSON
+before_relationship_batches=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_relationship'")
+unsupported_result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_relationship --account-id acct42 --stream followers \
+	--fixture "$TMP_DIR/no-delta.json")
+assert_eq "streams without an official delta parameter report the gap" \
+	"$(json_field "$unsupported_result" status)" "delta_unavailable"
+assert_eq "unsupported delta performs no provider page request" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_relationship'")" "$before_relationship_batches"
+assert_eq "unsupported delta is recorded against its stream" \
+	"$(sql_value "SELECT failure_class || ':' || diagnostics FROM sync_runs WHERE connection_id='conn_relationship' ORDER BY rowid DESC LIMIT 1")" \
+	'delta_not_supported:{"stream":"followers"}'
+
+cat >"$TMP_DIR/following.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42"}},
+  "pages": [{"status":200,"observed_at":"2026-07-25T05:06:00Z","data":[{"id":"target88","username":"target"}],"meta":{}}]
+}
+JSON
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_relationship --account-id acct42 --stream following \
+	--fixture "$TMP_DIR/following.json" >/dev/null
+assert_eq "following activity preserves relationship direction" \
+	"$(sql_value "SELECT actor_remote_id || ':' || object_remote_id FROM activities WHERE activity_type='following'")" "acct42:target88"
+
+cursor_before=$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_authored' AND stream='authored'")
 cat >"$TMP_DIR/rate-limit.json" <<'JSON'
 {
-  "identity": {"data": {"id": "acct42", "username": "private-handle"}},
-  "pages": [{"status": 429, "retry_after": "2026-07-25T06:00:00Z"}]
+  "identity": {"data": {"id": "acct42", "username": "fixture-handle"}},
+  "pages": [{"status": 429, "observed_at": "2026-07-25T05:07:00Z", "retry_after": 1784959200}]
 }
 JSON
 rate_result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
 	--connection-id conn_authored --account-id acct42 --stream authored \
 	--fixture "$TMP_DIR/rate-limit.json")
-assert_eq "429 is terminal for this invocation" \
-	"$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["status"])' "$rate_result")" "rate_limited"
+assert_eq "429 is terminal for this invocation" "$(json_field "$rate_result" status)" "rate_limited"
 assert_eq "terminal rate limit preserves the checkpoint" \
-	"$(sql_value "SELECT watermark FROM sync_cursors WHERE stream='authored'")" "$cursor_before"
-assert_eq "rate reset is recorded once without raw diagnostics" \
-	"$(sql_value "SELECT failure_class || ':' || retry_after || ':' || diagnostics FROM sync_runs ORDER BY rowid DESC LIMIT 1")" \
-	"rate_limit:2026-07-25T06:00:00Z:sanitized"
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_authored' AND stream='authored'")" "$cursor_before"
+assert_eq "rate reset is recorded once with stream-only diagnostics" \
+	"$(sql_value "SELECT failure_class || ':' || retry_after || ':' || diagnostics FROM sync_runs WHERE connection_id='conn_authored' ORDER BY rowid DESC LIMIT 1")" \
+	'rate_limit:1784959200:{"stream":"authored"}'
+assert_eq "terminal response is immutable evidence without erasing completion" \
+	"$(sql_value "SELECT status || ':' || cursor_exhausted FROM coverage_records WHERE connection_id='conn_authored' AND stream='authored'")" "paused:1"
+
+run_terminal_fixture unauthorized 401 authorization
+run_terminal_fixture forbidden 403 authorization
+run_terminal_fixture missing 404 unavailable
+run_terminal_fixture provider 500 provider
+assert_eq "terminal failures never advance the cursor" \
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_authored' AND stream='authored'")" "$cursor_before"
+
+cat >"$TMP_DIR/first-terminal.json" <<'JSON'
+{"identity":{"data":{"id":"acct42"}},"pages":[{"status":500,"observed_at":"2026-07-25T05:09:00Z"}]}
+JSON
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_first_terminal --account-id acct42 --stream authored \
+	--fixture "$TMP_DIR/first-terminal.json" >/dev/null
+assert_eq "first terminal response binds the verified account" \
+	"$(sql_value "SELECT remote_account_id FROM connections WHERE connection_id='conn_first_terminal'")" "acct42"
+terminal_batch_count=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_first_terminal'")
+cat >"$TMP_DIR/terminal-rebind.json" <<'JSON'
+{"identity":{"data":{"id":"other99"}},"pages":[]}
+JSON
+if "$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_first_terminal --account-id other99 --stream authored \
+	--fixture "$TMP_DIR/terminal-rebind.json" >/dev/null 2>&1; then
+	assert_eq "terminal-bound connection cannot be rebound" "accepted" "rejected"
+else
+	assert_eq "terminal-bound connection cannot be rebound" "rejected" "rejected"
+fi
+assert_eq "terminal rebind rejection stores no additional raw evidence" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_first_terminal'")" "$terminal_batch_count"
+
+batch_count=$(sql_value 'SELECT count(*) FROM fetch_batches')
+cat >"$TMP_DIR/malformed.json" <<'JSON'
+{"identity":{"data":{"id":"acct42"}},"pages":[{"status":200,"data":{"id":"not-an-array"},"meta":{}}]}
+JSON
+if "$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id acct42 --stream authored \
+	--fixture "$TMP_DIR/malformed.json" >/dev/null 2>&1; then
+	assert_eq "malformed page is rejected before persistence" "accepted" "rejected"
+else
+	assert_eq "malformed page is rejected before persistence" "rejected" "rejected"
+fi
+assert_eq "malformed page advances no batch or checkpoint" \
+	"$(sql_value 'SELECT count(*) FROM fetch_batches'):$([[ "$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_authored' AND stream='authored'")" == "$cursor_before" ]] && printf stable || printf changed)" \
+	"${batch_count}:stable"
+
+cat >"$TMP_DIR/identity-credential.json" <<'JSON'
+{"identity":{"data":{"id":"acct42","access_token":"must-not-persist"}},"pages":[]}
+JSON
+if "$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id acct42 --stream authored \
+	--fixture "$TMP_DIR/identity-credential.json" >/dev/null 2>&1; then
+	assert_eq "credential-shaped identity data is rejected" "accepted" "rejected"
+else
+	assert_eq "credential-shaped identity data is rejected" "rejected" "rejected"
+fi
+assert_eq "rejected identity creates no raw evidence" "$(sql_value 'SELECT count(*) FROM fetch_batches')" "$batch_count"
+
+cat >"$TMP_DIR/page-credential.json" <<'JSON'
+{"identity":{"data":{"id":"acct42"}},"pages":[{"status":200,"authorization":"must-not-persist","data":[],"meta":{}}]}
+JSON
+if "$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id acct42 --stream authored \
+	--fixture "$TMP_DIR/page-credential.json" >/dev/null 2>&1; then
+	assert_eq "credential-shaped page data is rejected" "accepted" "rejected"
+else
+	assert_eq "credential-shaped page data is rejected" "rejected" "rejected"
+fi
+assert_eq "rejected page creates no raw evidence" "$(sql_value 'SELECT count(*) FROM fetch_batches')" "$batch_count"
 
 cat >"$TMP_DIR/wrong-account.json" <<'JSON'
-{"identity": {"data": {"id": "other99"}}, "pages": []}
+{"identity":{"data":{"id":"other99"}},"pages":[]}
 JSON
-batch_count=$(sql_value 'SELECT count(*) FROM fetch_batches')
 if "$HELPER" sync-x --base "$BASE" --alias personal:default \
 	--connection-id conn_authored --account-id acct42 --stream authored \
 	--fixture "$TMP_DIR/wrong-account.json" >/dev/null 2>&1; then
-	assert_eq "account mismatch is rejected before collection" "accepted" "rejected"
+	assert_eq "selected account mismatch is rejected before collection" "accepted" "rejected"
 else
-	assert_eq "account mismatch is rejected before collection" "rejected" "rejected"
+	assert_eq "selected account mismatch is rejected before collection" "rejected" "rejected"
 fi
-assert_eq "account mismatch persists no raw page" "$(sql_value 'SELECT count(*) FROM fetch_batches')" "$batch_count"
 
-assert_eq "adapter source reaches only guarded read commands" \
-	"$(
-		python3 - "$SCRIPT_DIR/../scripts/knowledge_social_x.py" <<'PY'
-import ast
+cat >"$TMP_DIR/rebind-account.json" <<'JSON'
+{"identity":{"data":{"id":"other99"}},"pages":[]}
+JSON
+if "$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_authored --account-id other99 --stream authored \
+	--fixture "$TMP_DIR/rebind-account.json" >/dev/null 2>&1; then
+	assert_eq "existing connection cannot be rebound to another verified account" "accepted" "rejected"
+else
+	assert_eq "existing connection cannot be rebound to another verified account" "rejected" "rejected"
+fi
+assert_eq "account rejection leaves connection and raw evidence unchanged" \
+	"$(sql_value "SELECT remote_account_id FROM connections WHERE connection_id='conn_authored'"):$(sql_value 'SELECT count(*) FROM fetch_batches')" \
+	"acct42:${batch_count}"
+
+mkdir -p "$TMP_DIR/bin"
+cat >"$TMP_DIR/bin/xurl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${XURL_LOG:?}"
+case "$*" in
+*" whoami" | whoami)
+	printf '%s\n' '{"data":{"id":"acct42","username":"fixture-handle"}}'
+	;;
+*"/2/users/acct42/tweets?"*)
+	printf '%s\n' '{"status":200,"observed_at":"2026-07-25T05:08:00Z","data":[{"id":"301","author_id":"acct42","text":"guarded path","created_at":"2026-07-25T05:08:00Z"}],"meta":{}}'
+	;;
+*)
+	exit 7
+	;;
+esac
+SH
+chmod 0700 "$TMP_DIR/bin/xurl"
+XURL_LOG="$TMP_DIR/xurl.log" PATH="$TMP_DIR/bin:$PATH" \
+	"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_guarded --account-id acct42 --stream authored \
+	--app fixture-app --username @fixture >/dev/null
+guard_result=$(
+	python3 - "$TMP_DIR/xurl.log" <<'PY'
 import sys
-tree = ast.parse(open(sys.argv[1], encoding="utf-8").read())
-commands = []
-for node in tree.body:
-    if isinstance(node, ast.ClassDef) and node.name == "GuardedXurl":
-        for method in node.body:
-            if isinstance(method, ast.FunctionDef) and method.name in {"identity", "page"}:
-                for child in ast.walk(method):
-                    if isinstance(child, ast.Constant) and child.value in {"post", "reply", "like", "follow", "dm", "media"}:
-                        commands.append(child.value)
-print(",".join(sorted(set(commands))))
+from pathlib import Path
+lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+writes = {"post", "reply", "quote", "delete", "like", "follow", "dm", "media", "--confirm-write"}
+safe = (
+    len(lines) == 2
+    and lines[0].endswith(" whoami")
+    and "/2/users/acct42/tweets?" in lines[1]
+    and not any(word in line.split() for word in writes for line in lines)
+)
+print("read-only" if safe else "unsafe")
 PY
-	)" ""
+)
+assert_eq "live adapter route reaches only guarded whoami and raw-read commands" "$guard_result" "read-only"
+assert_eq "guarded route persists searchable provider content" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'guarded'")" "1"
+
+assert_eq "all immutable raw paths remain opaque" \
+	"$(
+		python3 - "$ROOT/sources/social/raw" <<'PY'
+import sys
+from pathlib import Path
+root = Path(sys.argv[1])
+bad = [path for path in root.rglob("*.json.gz") if "fixture-handle" in path.as_posix()]
+print("opaque" if not bad else "revealing")
+PY
+	)" "opaque"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- Adds a guarded, externally read-only X adapter with verified account identity.
- Maintains independent stream pagination and supported delta watermarks.
- Stores credential-filtered immutable response evidence with atomic normalized rows, FTS, coverage, and cursor updates.
- Enforces bounded request-cost budgets, terminal failure handling, metadata-only media policy, and immutable connection/account binding.
- Splits transport, state, normalization, media, and persistence concerns so all new Python files pass Qlty smell analysis.

For #28587

## Files Changed

- `.agents/scripts/knowledge-social-helper.sh`
- `.agents/scripts/knowledge_social_x.py`
- `.agents/scripts/_knowledge_social_x.py`
- `.agents/scripts/_knowledge_social_x_reader.py`
- `.agents/scripts/_knowledge_social_x_state.py`
- `.agents/scripts/_knowledge_social_x_normalize.py`
- `.agents/scripts/_knowledge_social_x_media.py`
- `.agents/scripts/_knowledge_social_x_persist.py`
- `.agents/tests/test-knowledge-social-x.sh`
- `.agents/content/social-xurl.md`

## Runtime Testing

- **Risk level:** Critical
- **Adapter verification:** 51 checks passed, covering pagination/resume, independent cursors, official delta limits, request budgets, 401/403/404/429/5xx handling, account binding, credential rejection, immutable raw evidence, FTS, media linkage, and the guarded live command route through a fake `xurl` executable.
- **Store regression:** 31 checks passed.
- **Static verification:** Python compilation, ShellCheck, shfmt, markdownlint, direct Qlty smell analysis for all seven adapter Python files, and `.agents/scripts/linters-local.sh --changed` passed.
- **Live-provider boundary:** No live X request was made because `xurl` is not configured in this environment; deterministic fixtures and the fake executable validate the reachable route without claiming live access.

Resolves #28602
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 5h 57m and 4,155,898 tokens on this with the user in an interactive session.