### PR TITLE
GH#28605: Add authorized federated social query

### DIFF
--- a/.agents/aidevops/knowledge-plane/01-core-contract.md
+++ b/.agents/aidevops/knowledge-plane/01-core-contract.md
@@ -109,6 +109,32 @@ recreates FTS5 from canonical object rows without changing raw evidence. The
 database is mode `0600`, containing directories are `0700`, unsafe IDs and
 symlinks fail closed, and unsupported schema versions reject writes.
 
+`knowledge-social-helper.sh query` derives the authenticated principal and
+searches `personal:default` plus every active workspace corpus carrying an
+explicit `knowledge.read` grant. `--alias` only narrows that resolved set.
+Physical paths and caller-supplied principal/corpus IDs are not accepted. Each
+store is opened independently through the immutable read-only guard; absent
+social stores contribute no candidates, while symlinks, mutable journal state,
+and incompatible schemas fail the whole query closed.
+
+FTS candidates are ranked within each corpus, fused with deterministic
+reciprocal-rank fusion (`k=60`), and deduplicated by provider/object type/stable
+remote ID. A result retains every authorized corpus, batch, object, activity,
+event-time, and observation-time citation. Query output contains logical aliases,
+never physical corpus paths, and creates no cache, journal, index, or database.
+
+Private annotations are written only to the authenticated
+`personal:default` corpus through `knowledge.write`. Combined queries may
+overlay those notes onto the same stable object returned from a workspace
+corpus, but a team-only query never opens or emits the personal overlay. Social
+query semantics permit attributed opinion only from cited `authored` evidence;
+quotes without commentary, reposts, likes, bookmarks, follows, list membership,
+and captured observations remain distribution, weak, relationship, or observed
+signals. Generated inference remains explicitly labelled and reviewable. An
+inferred object must carry a finite `provider_json.confidence` score from `0` to
+`1`; malformed or missing confidence fails the query closed, and output retains
+the score with a mandatory-review marker and its evidence citation count.
+
 **Provision:** `aidevops knowledge init repo` or `aidevops knowledge init personal`.
 **Repair:** `aidevops knowledge provision` is idempotent — safe to re-run.
 

--- a/.agents/scripts/_knowledge_social_annotation.py
+++ b/.agents/scripts/_knowledge_social_annotation.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Owner-only private social annotation persistence and query overlays."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from knowledge_corpus_context import CatalogError, validate_private_file
+from knowledge_social_store import (
+    SocialStoreError,
+    connect,
+    connect_read_only,
+    database_path,
+    require_schema,
+)
+
+MAX_ANNOTATION_CHARACTERS = 65_536
+MAX_IDENTIFIER_CHARACTERS = 512
+
+
+def _identifier(value: str, field: str) -> str:
+    if not value or len(value) > MAX_IDENTIFIER_CHARACTERS or any(
+        character.isspace() or ord(character) < 32 for character in value
+    ):
+        raise SocialStoreError(f"{field} must be a bounded stable identifier")
+    return value
+
+
+def read_private_body(path: Path) -> str:
+    try:
+        validate_private_file(path, "annotation body file", repair=False)
+        body = path.read_text(encoding="utf-8")
+    except (CatalogError, OSError, UnicodeError) as error:
+        raise SocialStoreError("annotation body must be a private UTF-8 file") from error
+    if not body.strip() or len(body) > MAX_ANNOTATION_CHARACTERS:
+        raise SocialStoreError("annotation body must contain 1 to 65536 characters")
+    return body
+
+
+def _require_store(root: Path) -> None:
+    path = database_path(root)
+    if path.is_symlink() or not path.is_file():
+        raise SocialStoreError("personal social store is unavailable")
+
+
+def _object_id(
+    connection: sqlite3.Connection, provider: str, object_type: str, remote_id: str
+) -> int:
+    row = connection.execute(
+        """SELECT object_id FROM objects
+            WHERE provider=? AND object_type=? AND remote_id=?""",
+        (provider, object_type, remote_id),
+    ).fetchone()
+    if row is None:
+        raise SocialStoreError("annotation target is absent from the personal corpus")
+    return int(row["object_id"])
+
+
+def _validate_existing_annotation(
+    connection: sqlite3.Connection,
+    annotation_id: str,
+    principal_id: str,
+    object_id: int,
+) -> str | None:
+    row = connection.execute(
+        """SELECT principal_id,object_id,visibility,created_at
+             FROM annotations WHERE annotation_id=?""",
+        (annotation_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    if (
+        row["principal_id"] != principal_id
+        or int(row["object_id"]) != object_id
+        or row["visibility"] != "private"
+    ):
+        raise SocialStoreError("annotation ID conflicts with another private target")
+    return str(row["created_at"])
+
+
+def write_private_annotation(
+    root: Path,
+    principal_id: str,
+    target: tuple[str, str, str],
+    body: str,
+    annotation_id: str | None,
+) -> dict[str, Any]:
+    provider, object_type, remote_id = (
+        _identifier(target[0], "provider"),
+        _identifier(target[1], "object_type"),
+        _identifier(target[2], "remote_id"),
+    )
+    chosen_id = (
+        _identifier(annotation_id, "annotation_id")
+        if annotation_id
+        else f"ann_{uuid.uuid4().hex}"
+    )
+    _require_store(root)
+    connection = connect(root)
+    try:
+        require_schema(connection)
+        connection.execute("BEGIN IMMEDIATE")
+        object_id = _object_id(connection, provider, object_type, remote_id)
+        created_at = _validate_existing_annotation(
+            connection, chosen_id, principal_id, object_id
+        )
+        now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        if created_at is None:
+            connection.execute(
+                """INSERT INTO annotations(
+                    annotation_id,object_id,principal_id,visibility,body,created_at,updated_at)
+                   VALUES(?,?,?,?,?,?,?)""",
+                (chosen_id, object_id, principal_id, "private", body, now, now),
+            )
+            created_at = now
+        else:
+            connection.execute(
+                "UPDATE annotations SET body=?,updated_at=? WHERE annotation_id=?",
+                (body, now, chosen_id),
+            )
+        connection.execute("COMMIT")
+        return {
+            "annotation_id": chosen_id,
+            "provider": provider,
+            "object_type": object_type,
+            "remote_id": remote_id,
+            "visibility": "private",
+            "created_at": created_at,
+            "updated_at": now,
+        }
+    except (sqlite3.Error, SocialStoreError):
+        if connection.in_transaction:
+            connection.execute("ROLLBACK")
+        raise
+    finally:
+        connection.close()
+
+
+def load_private_annotations(
+    root: Path, principal_id: str, keys: set[tuple[str, str, str]]
+) -> dict[tuple[str, str, str], list[dict[str, Any]]]:
+    if not keys:
+        return {}
+    if not database_path(root).exists() and not database_path(root).is_symlink():
+        return {}
+    connection = connect_read_only(root)
+    try:
+        require_schema(connection)
+        rows = [
+            row
+            for provider, object_type, remote_id in sorted(keys)
+            for row in connection.execute(
+                """SELECT o.provider,o.object_type,o.remote_id,a.annotation_id,
+                          a.body,a.created_at,a.updated_at
+                     FROM annotations a JOIN objects o ON o.object_id=a.object_id
+                    WHERE a.principal_id=? AND a.visibility='private'
+                      AND o.provider=? AND o.object_type=? AND o.remote_id=?
+                    ORDER BY a.annotation_id""",
+                (principal_id, provider, object_type, remote_id),
+            ).fetchall()
+        ]
+    except sqlite3.Error as error:
+        raise SocialStoreError("private annotations could not be read safely") from error
+    finally:
+        connection.close()
+    overlays: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for row in rows:
+        key = (str(row["provider"]), str(row["object_type"]), str(row["remote_id"]))
+        overlays.setdefault(key, []).append(
+            {
+                "annotation_id": str(row["annotation_id"]),
+                "body": str(row["body"]),
+                "visibility": "private",
+                "created_at": str(row["created_at"]),
+                "updated_at": str(row["updated_at"]),
+            }
+        )
+    return overlays

--- a/.agents/scripts/_knowledge_social_query.py
+++ b/.agents/scripts/_knowledge_social_query.py
@@ -172,20 +172,21 @@ def _citation_classification(citation: dict[str, Any]) -> str:
         str(activity["activity_type"]).lower()
         for activity in citation.get("activities", [])
     }
+    classification = "observed"
     if evidence_class in AUTHORED_CLASSES:
-        return "authored"
-    if evidence_class in INFERRED_CLASSES:
-        return "inferred"
-    if evidence_class == "weak_signal" or activity_types & WEAK_ACTIVITY_TYPES:
-        return "weak_signal"
-    if (
+        classification = "authored"
+    elif evidence_class in INFERRED_CLASSES:
+        classification = "inferred"
+    elif evidence_class == "weak_signal" or activity_types & WEAK_ACTIVITY_TYPES:
+        classification = "weak_signal"
+    elif (
         evidence_class in {"distributed", "quoted", "reposted"}
         or activity_types & DISTRIBUTION_ACTIVITY_TYPES
     ):
-        return "distribution"
-    if evidence_class == "relationship" or activity_types & RELATIONSHIP_ACTIVITY_TYPES:
-        return "relationship"
-    return "observed"
+        classification = "distribution"
+    elif evidence_class == "relationship" or activity_types & RELATIONSHIP_ACTIVITY_TYPES:
+        classification = "relationship"
+    return classification
 
 
 def opinion_semantics(citations: list[dict[str, Any]]) -> dict[str, Any]:

--- a/.agents/scripts/_knowledge_social_query.py
+++ b/.agents/scripts/_knowledge_social_query.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Read-only per-corpus social search and deterministic result fusion."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from knowledge_social_store import (
+    SocialStoreError,
+    connect_read_only,
+    database_path,
+    require_schema,
+)
+
+RRF_K = 60
+MAX_QUERY_CHARACTERS = 1024
+MAX_QUERY_TERMS = 32
+MAX_CANDIDATES = 500
+INVALID_INFERENCE_CONFIDENCE = (
+    "inferred evidence is missing a valid confidence score"
+)
+AUTHORED_CLASSES = {"authored"}
+INFERRED_CLASSES = {"generated", "inferred"}
+WEAK_ACTIVITY_TYPES = {"bookmark", "bookmarked", "bookmarks", "like", "liked", "likes"}
+DISTRIBUTION_ACTIVITY_TYPES = {"quote", "quoted", "repost", "reposted", "reposts"}
+RELATIONSHIP_ACTIVITY_TYPES = {
+    "follow",
+    "followed",
+    "followers",
+    "following",
+    "listed",
+    "lists",
+}
+
+
+def social_store_exists(root: Path) -> bool:
+    path = database_path(root)
+    if path.is_symlink():
+        raise SocialStoreError("social database cannot be a symlink")
+    if not path.exists():
+        return False
+    if not path.is_file():
+        raise SocialStoreError("social database is not a regular file")
+    return True
+
+
+def build_fts_query(query: str) -> str:
+    if not query or len(query) > MAX_QUERY_CHARACTERS:
+        raise SocialStoreError("query must contain 1 to 1024 characters")
+    terms = re.findall(r"\w+", query, flags=re.UNICODE)
+    if not terms:
+        raise SocialStoreError("query must contain searchable text")
+    if len(terms) > MAX_QUERY_TERMS:
+        raise SocialStoreError("query contains too many terms")
+    return " AND ".join(f'"{term}"' for term in terms)
+
+
+def candidate_limit(result_limit: int) -> int:
+    return min(MAX_CANDIDATES, max(result_limit, result_limit * 5))
+
+
+def _activities(
+    connection: sqlite3.Connection, provider: str, remote_id: str
+) -> list[dict[str, Any]]:
+    rows = connection.execute(
+        """SELECT activity_type,remote_id,actor_remote_id,occurred_at,
+                  observed_at,state,batch_id
+             FROM activities
+            WHERE provider=? AND object_remote_id=? AND state='active'
+            ORDER BY activity_type,remote_id""",
+        (provider, remote_id),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _batch_stream(connection: sqlite3.Connection, batch_id: str) -> str | None:
+    row = connection.execute(
+        "SELECT stream FROM fetch_batches WHERE batch_id=?", (batch_id,)
+    ).fetchone()
+    return str(row["stream"]) if row is not None else None
+
+
+def _inference_confidence(row: sqlite3.Row) -> float | None:
+    if str(row["evidence_class"]).lower() not in INFERRED_CLASSES:
+        return None
+    try:
+        metadata = json.loads(str(row["provider_json"]))
+    except (json.JSONDecodeError, TypeError) as error:
+        raise SocialStoreError(INVALID_INFERENCE_CONFIDENCE) from error
+    confidence = metadata.get("confidence") if isinstance(metadata, dict) else None
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+        raise SocialStoreError(INVALID_INFERENCE_CONFIDENCE)
+    try:
+        score = float(confidence)
+    except (OverflowError, ValueError) as error:
+        raise SocialStoreError(INVALID_INFERENCE_CONFIDENCE) from error
+    if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+        raise SocialStoreError(INVALID_INFERENCE_CONFIDENCE)
+    return score
+
+
+def _citation(
+    connection: sqlite3.Connection, alias: str, row: sqlite3.Row
+) -> dict[str, Any]:
+    provider = str(row["provider"])
+    remote_id = str(row["remote_id"])
+    batch_id = str(row["batch_id"])
+    return {
+        "corpus_alias": alias,
+        "provider": provider,
+        "object_type": str(row["object_type"]),
+        "remote_id": remote_id,
+        "account_remote_id": row["account_remote_id"],
+        "evidence_class": str(row["evidence_class"]),
+        "inference_confidence": _inference_confidence(row),
+        "created_at": row["created_at"],
+        "observed_at": str(row["observed_at"]),
+        "batch_id": batch_id,
+        "batch_stream": _batch_stream(connection, batch_id),
+        "activities": _activities(connection, provider, remote_id),
+    }
+
+
+def search_corpus(
+    alias: str, root: Path, fts_query: str, limit: int
+) -> list[dict[str, Any]]:
+    connection = connect_read_only(root)
+    try:
+        require_schema(connection)
+        rows = connection.execute(
+            """SELECT o.provider,o.object_type,o.remote_id,o.account_remote_id,
+                       o.text_content,o.created_at,o.observed_at,o.evidence_class,
+                       o.provider_json,o.batch_id,bm25(objects_fts) AS bm25_score
+                 FROM objects_fts
+                 JOIN objects o
+                   ON o.provider=objects_fts.provider
+                  AND o.object_type=objects_fts.object_type
+                  AND o.remote_id=objects_fts.remote_id
+                WHERE objects_fts MATCH ?
+                ORDER BY bm25_score,o.provider,o.object_type,o.remote_id
+                LIMIT ?""",
+            (fts_query, limit),
+        ).fetchall()
+        return [
+            {
+                "key": (
+                    str(row["provider"]),
+                    str(row["object_type"]),
+                    str(row["remote_id"]),
+                ),
+                "text": row["text_content"],
+                "citation": _citation(connection, alias, row),
+            }
+            for row in rows
+        ]
+    except sqlite3.Error as error:
+        raise SocialStoreError("social query could not be evaluated safely") from error
+    finally:
+        connection.close()
+
+
+def _citation_classification(citation: dict[str, Any]) -> str:
+    evidence_class = str(citation["evidence_class"]).lower()
+    activity_types = {
+        str(activity["activity_type"]).lower()
+        for activity in citation.get("activities", [])
+    }
+    if evidence_class in AUTHORED_CLASSES:
+        return "authored"
+    if evidence_class in INFERRED_CLASSES:
+        return "inferred"
+    if evidence_class == "weak_signal" or activity_types & WEAK_ACTIVITY_TYPES:
+        return "weak_signal"
+    if (
+        evidence_class in {"distributed", "quoted", "reposted"}
+        or activity_types & DISTRIBUTION_ACTIVITY_TYPES
+    ):
+        return "distribution"
+    if evidence_class == "relationship" or activity_types & RELATIONSHIP_ACTIVITY_TYPES:
+        return "relationship"
+    return "observed"
+
+
+def opinion_semantics(citations: list[dict[str, Any]]) -> dict[str, Any]:
+    classifications = [
+        (_citation_classification(citation), citation) for citation in citations
+    ]
+    labels = sorted({classification for classification, _ in classifications})
+    inferred_citations = [
+        citation
+        for classification, citation in classifications
+        if classification == "inferred"
+    ]
+    supports_opinion = "authored" in labels
+    if supports_opinion:
+        guidance = "Attribute opinions only to cited authored evidence."
+    elif "inferred" in labels:
+        guidance = (
+            "Keep inference labelled, confidence-scored, reviewable, "
+            "and evidence-linked."
+        )
+    else:
+        guidance = (
+            "Do not present distribution, weak, relationship, or observed signals "
+            "as opinion."
+        )
+    return {
+        "evidence_labels": labels,
+        "supports_attributed_opinion": supports_opinion,
+        "inference_review": {
+            "required": bool(inferred_citations),
+            "confidence_complete": (
+                all(
+                    citation.get("inference_confidence") is not None
+                    for citation in inferred_citations
+                )
+                if inferred_citations
+                else None
+            ),
+            "evidence_citation_count": len(inferred_citations),
+        },
+        "guidance": guidance,
+    }
+
+
+def fuse_results(
+    corpus_results: list[tuple[str, list[dict[str, Any]]]], limit: int
+) -> list[dict[str, Any]]:
+    fused: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for alias, hits in sorted(corpus_results, key=lambda item: item[0]):
+        for rank, hit in enumerate(hits, start=1):
+            key = hit["key"]
+            result = fused.setdefault(
+                key,
+                {
+                    "provider": key[0],
+                    "object_type": key[1],
+                    "remote_id": key[2],
+                    "text": hit["text"],
+                    "rrf_score": 0.0,
+                    "citations": [],
+                    "_best_source": (rank, alias),
+                },
+            )
+            result["rrf_score"] += 1.0 / (RRF_K + rank)
+            result["citations"].append(hit["citation"])
+            if (rank, alias) < result["_best_source"]:
+                result["text"] = hit["text"]
+                result["_best_source"] = (rank, alias)
+
+    ordered = sorted(
+        fused.values(),
+        key=lambda item: (
+            -float(item["rrf_score"]),
+            str(item["provider"]),
+            str(item["object_type"]),
+            str(item["remote_id"]),
+        ),
+    )[:limit]
+    for result in ordered:
+        result.pop("_best_source")
+        result["rrf_score"] = round(float(result["rrf_score"]), 12)
+        result["citations"].sort(key=lambda item: str(item["corpus_alias"]))
+        result["opinion_semantics"] = opinion_semantics(result["citations"])
+    return ordered

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_HELPER="${SCRIPT_DIR}/knowledge_social_import.py"
 X_HELPER="${SCRIPT_DIR}/knowledge_social_x.py"
+QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 
 usage() {
 	cat <<'EOF'
@@ -16,6 +17,10 @@ Usage:
   knowledge-social-helper.sh import-archive [--base PATH] [--alias ALIAS] --archive FILE
   knowledge-social-helper.sh rebuild [--base PATH] [--alias ALIAS]
   knowledge-social-helper.sh coverage [--base PATH] [--alias ALIAS]
+  knowledge-social-helper.sh query [--base PATH] [--alias ALIAS] \
+    (--query TEXT | --query-file FILE) [--limit 1-100]
+  knowledge-social-helper.sh annotate [--base PATH] --provider PROVIDER \
+    --object-type TYPE --remote-id ID [--annotation-id ID] --body-file FILE
   knowledge-social-helper.sh sync-x [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id ID --stream STREAM [--budget UNITS] \
     [--media-policy none|metadata] [--app PROFILE] [--username HANDLE]
@@ -23,6 +28,11 @@ Usage:
 The authenticated corpus catalog resolves ALIAS with knowledge.write for
 mutating operations or knowledge.read for coverage. Physical corpus paths are
 not accepted from callers.
+
+Query resolves the authenticated principal and searches the personal corpus plus
+every authorized workspace corpus by default. --alias can narrow but never widen
+that scope. Annotate writes an owner-only private note to personal:default; the
+body file must be a non-symlink UTF-8 file with mode 0600.
 
 Archive format:
   A UTF-8 JSON object with provider, connection_id, and arrays named accounts,
@@ -68,6 +78,14 @@ main() {
 			return 1
 		fi
 		python3 "$X_HELPER" "$@" || return 1
+		;;
+	query | annotate)
+		require_runtime || return 1
+		if [[ ! -r "$QUERY_HELPER" ]]; then
+			printf 'ERROR: social query implementation missing: %s\n' "$QUERY_HELPER" >&2
+			return 1
+		fi
+		python3 "$QUERY_HELPER" "$subcommand" "$@" || return 1
 		;;
 	help | -h | --help)
 		usage

--- a/.agents/scripts/knowledge_corpus_catalog.py
+++ b/.agents/scripts/knowledge_corpus_catalog.py
@@ -318,26 +318,33 @@ def _authorized_rows(
     return list(connection.execute(query, parameters).fetchall())
 
 
-def resolve(base: Path, alias: str, capability: str) -> Path:
+def authorized_scope(
+    base: Path, capability: str, alias: str | None = None
+) -> tuple[str, list[tuple[str, Path]]]:
     resolved_base, principal_id, connection = _open_authorized_catalog(base)
     try:
         rows = _authorized_rows(connection, principal_id, capability, alias)
-        if len(rows) != 1:
+        if alias is not None and len(rows) != 1:
             raise CatalogError(
                 f"access denied: alias {alias} is unavailable or ambiguous"
             )
-        return safe_location(resolved_base, str(rows[0]["location_ref"]))
+        corpora = [
+            (
+                str(row["alias"]),
+                safe_location(resolved_base, str(row["location_ref"])),
+            )
+            for row in rows
+        ]
+        return principal_id, corpora
     finally:
         connection.close()
+
+
+def resolve(base: Path, alias: str, capability: str) -> Path:
+    _, corpora = authorized_scope(base, capability, alias)
+    return corpora[0][1]
 
 
 def list_authorized(base: Path, capability: str) -> Iterable[tuple[str, Path]]:
-    resolved_base, principal_id, connection = _open_authorized_catalog(base)
-    try:
-        rows = _authorized_rows(connection, principal_id, capability, None)
-        return [
-            (str(row["alias"]), safe_location(resolved_base, row["location_ref"]))
-            for row in rows
-        ]
-    finally:
-        connection.close()
+    _, corpora = authorized_scope(base, capability)
+    return corpora

--- a/.agents/scripts/knowledge_social_query.py
+++ b/.agents/scripts/knowledge_social_query.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Query authorized social corpora or write a private personal annotation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_annotation import (
+    load_private_annotations,
+    read_private_body,
+    write_private_annotation,
+)
+from _knowledge_social_query import (
+    build_fts_query,
+    candidate_limit,
+    fuse_results,
+    search_corpus,
+    social_store_exists,
+)
+from knowledge_corpus_catalog import DEFAULT_ALIAS, authorized_scope
+from knowledge_corpus_context import CatalogError, validate_private_file
+from knowledge_social_store import SocialStoreError, validate_root
+
+DEFAULT_BASE = Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+MAX_RESULTS = 100
+
+
+def _base_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--base", type=Path, default=DEFAULT_BASE)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    query = subparsers.add_parser("query", help="search authorized social corpora")
+    _base_argument(query)
+    query.add_argument("--alias", help="narrow the authorized scope to one alias")
+    query_input = query.add_mutually_exclusive_group(required=True)
+    query_input.add_argument("--query")
+    query_input.add_argument("--query-file", type=Path)
+    query.add_argument("--limit", type=int, default=10)
+
+    annotate = subparsers.add_parser(
+        "annotate", help="write a private annotation in personal:default"
+    )
+    _base_argument(annotate)
+    annotate.add_argument("--provider", required=True)
+    annotate.add_argument("--object-type", required=True)
+    annotate.add_argument("--remote-id", required=True)
+    annotate.add_argument("--annotation-id")
+    annotate.add_argument("--body-file", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _read_query(args: argparse.Namespace) -> str:
+    if args.query is not None:
+        return str(args.query)
+    validate_private_file(args.query_file, "query file", repair=False)
+    return str(args.query_file.read_text(encoding="utf-8"))
+
+
+def _authorized_roots(
+    base: Path, capability: str, alias: str | None
+) -> tuple[str, list[tuple[str, Path]]]:
+    principal_id, corpora = authorized_scope(base, capability, alias)
+    authorized = [
+        (corpus_alias, validate_root(root)) for corpus_alias, root in corpora
+    ]
+    if not authorized:
+        raise CatalogError("access denied: no authorized corpora")
+    return principal_id, authorized
+
+
+def query_social(args: argparse.Namespace) -> dict[str, Any]:
+    if args.limit < 1 or args.limit > MAX_RESULTS:
+        raise SocialStoreError("limit must be between 1 and 100")
+    principal_id, corpora = _authorized_roots(
+        args.base, "knowledge.read", args.alias
+    )
+    fts_query = build_fts_query(_read_query(args))
+    per_corpus = [
+        (
+            alias,
+            search_corpus(alias, root, fts_query, candidate_limit(args.limit)),
+        )
+        for alias, root in corpora
+        if social_store_exists(root)
+    ]
+    results = fuse_results(per_corpus, args.limit)
+    roots = dict(corpora)
+    if DEFAULT_ALIAS in roots:
+        keys = {
+            (result["provider"], result["object_type"], result["remote_id"])
+            for result in results
+        }
+        overlays = load_private_annotations(roots[DEFAULT_ALIAS], principal_id, keys)
+        for result in results:
+            key = (result["provider"], result["object_type"], result["remote_id"])
+            result["private_annotations"] = overlays.get(key, [])
+    else:
+        for result in results:
+            result["private_annotations"] = []
+    return {
+        "version": 1,
+        "scope": {"aliases": [alias for alias, _ in corpora]},
+        "results": results,
+    }
+
+
+def annotate_social(args: argparse.Namespace) -> dict[str, Any]:
+    principal_id, corpora = _authorized_roots(
+        args.base, "knowledge.write", DEFAULT_ALIAS
+    )
+    body = read_private_body(args.body_file)
+    return write_private_annotation(
+        corpora[0][1],
+        principal_id,
+        (args.provider, args.object_type, args.remote_id),
+        body,
+        args.annotation_id,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = query_social(args) if args.command == "query" else annotate_social(args)
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return 0
+    except (CatalogError, OSError, SocialStoreError, UnicodeError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-query.sh
+++ b/.agents/tests/test-knowledge-social-query.sh
@@ -1,0 +1,486 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-query.sh — Authorized federated social query tests
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+TMP_DIR="$(cd "$TMP_DIR" && pwd -P)"
+BASE="${TMP_DIR}/knowledge"
+PERSONAL_ROOT="${BASE}/_knowledge"
+TEAM_ROOT="${BASE}/workspace-alpha"
+CATALOG="${BASE}/catalog.db"
+PERSONAL_ARCHIVE="${TMP_DIR}/personal.json"
+TEAM_ARCHIVE="${TMP_DIR}/team.json"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+expect_failure() {
+	local description="$1"
+	local expected="$2"
+	shift 2
+	local output=""
+	if output=$("$@" 2>&1); then
+		assert_eq "$description" "accepted" "rejected"
+	elif [[ "$output" == *"$expected"* ]]; then
+		assert_eq "$description" "rejected" "rejected"
+	else
+		assert_eq "$description" "$output" "error containing: $expected"
+	fi
+	return 0
+}
+
+json_summary() {
+	local payload="$1"
+	local selector="$2"
+	python3 - "$payload" "$selector" <<'PY' || return 1
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+selector = sys.argv[2]
+results = data.get("results", [])
+
+def result(remote_id):
+    return next(item for item in results if item["remote_id"] == remote_id)
+
+if selector == "scope":
+    print(",".join(data["scope"]["aliases"]))
+elif selector == "ids":
+    print(",".join(item["remote_id"] for item in results))
+elif selector == "count":
+    print(len(results))
+elif selector == "common-citations":
+    print(",".join(item["corpus_alias"] for item in result("post-common")["citations"]))
+elif selector == "common-labels":
+    print(",".join(result("post-common")["opinion_semantics"]["evidence_labels"]))
+elif selector == "common-support":
+    print(str(result("post-common")["opinion_semantics"]["supports_attributed_opinion"]).lower())
+elif selector == "common-private-count":
+    print(len(result("post-common")["private_annotations"]))
+elif selector == "common-private-body":
+    print("|".join(item["body"] for item in result("post-common")["private_annotations"]))
+elif selector == "provenance":
+    citations = result("post-common")["citations"]
+    valid = all(
+        citation["batch_id"]
+        and citation["batch_stream"]
+        and citation["observed_at"]
+        and citation["provider"] == "xapi"
+        and citation["object_type"] == "post"
+        and citation["remote_id"] == "post-common"
+        and citation["activities"]
+        for citation in citations
+    )
+    print("complete" if valid else "incomplete")
+elif selector == "weak-semantics":
+    semantics = result("post-team-weak")["opinion_semantics"]
+    print(",".join(semantics["evidence_labels"]) + ":" + str(semantics["supports_attributed_opinion"]).lower())
+elif selector == "inferred-semantics":
+    inferred = result("post-personal-inferred")
+    semantics = inferred["opinion_semantics"]
+    labelled = "inference" in semantics["guidance"].lower()
+    review = semantics["inference_review"]
+    confidence = inferred["citations"][0]["inference_confidence"]
+    print(",".join(semantics["evidence_labels"]) + ":" + str(semantics["supports_attributed_opinion"]).lower() + ":" + str(labelled).lower() + ":" + str(review["required"]).lower() + ":" + str(review["confidence_complete"]).lower() + ":" + str(confidence))
+elif selector == "annotation":
+    print(data["annotation_id"] + ":" + data["visibility"] + ":" + data["remote_id"])
+else:
+    raise SystemExit(f"unknown selector: {selector}")
+PY
+	return 0
+}
+
+sql_value() {
+	local database="$1"
+	local query="$2"
+	python3 - "$database" "$query" <<'PY' || return 1
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+catalog_status() {
+	local target="$1"
+	local status="$2"
+	python3 - "$CATALOG" "$target" "$status" <<'PY' || return 1
+import sqlite3
+import sys
+
+database, target, status = sys.argv[1:]
+with sqlite3.connect(database) as connection:
+    if target == "team-membership":
+        connection.execute(
+            "UPDATE workspace_memberships SET status=? WHERE workspace_id=?",
+            (status, "wsp_" + "a" * 32),
+        )
+    elif target == "team-read":
+        connection.execute(
+            "UPDATE corpus_grants SET status=? WHERE corpus_id=? AND capability='knowledge.read'",
+            (status, "cor_" + "b" * 32),
+        )
+    elif target == "team-workspace":
+        connection.execute(
+            "UPDATE workspaces SET status=? WHERE workspace_id=?",
+            (status, "wsp_" + "a" * 32),
+        )
+    elif target == "team-corpus":
+        connection.execute(
+            "UPDATE corpora SET status=? WHERE corpus_id=?",
+            (status, "cor_" + "b" * 32),
+        )
+    elif target == "personal-write":
+        connection.execute(
+            "UPDATE corpus_grants SET status=? WHERE corpus_id=(SELECT corpus_id FROM corpus_aliases WHERE alias='personal:default') AND capability='knowledge.write'",
+            (status,),
+        )
+    elif target == "principal":
+        connection.execute("UPDATE principals SET status=?", (status,))
+    else:
+        raise SystemExit(f"unknown catalog target: {target}")
+PY
+	return 0
+}
+
+store_snapshot() {
+	local root="$1"
+	python3 - "$root" <<'PY' || return 1
+import hashlib
+import json
+import stat
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+snapshot = {}
+for path in sorted(root.rglob("*")):
+    file_stat = path.lstat()
+    record = {
+        "mode": stat.S_IMODE(file_stat.st_mode),
+        "mtime_ns": file_stat.st_mtime_ns,
+        "size": file_stat.st_size,
+    }
+    if path.is_file():
+        record["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+    snapshot[path.relative_to(root).as_posix()] = record
+print(json.dumps(snapshot, sort_keys=True, separators=(",", ":")))
+PY
+	return 0
+}
+
+evidence_matrix() {
+	PYTHONPATH="${SCRIPT_DIR}/../scripts" python3 <<'PY' || return 1
+from _knowledge_social_query import opinion_semantics
+
+cases = (
+    ("bookmark", "observed", "weak_signal"),
+    ("follow", "observed", "relationship"),
+    ("listed", "observed", "relationship"),
+    ("captured", "captured", "observed"),
+)
+labels = []
+for activity_type, evidence_class, expected in cases:
+    citation = {
+        "evidence_class": evidence_class,
+        "activities": [] if activity_type == "captured" else [{"activity_type": activity_type}],
+        "inference_confidence": None,
+    }
+    semantics = opinion_semantics([citation])
+    actual = semantics["evidence_labels"][0]
+    labels.append(actual if actual == expected else f"unexpected:{actual}")
+print(",".join(labels))
+PY
+	return 0
+}
+
+printf 'Authorized federated social query tests\n'
+mkdir -p "$PERSONAL_ROOT" "$TEAM_ROOT"
+chmod 0700 "$BASE" "$PERSONAL_ROOT" "$TEAM_ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+
+python3 - "$CATALOG" "$BASE" "$TEAM_ROOT" <<'PY'
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+database, base, team_root = sys.argv[1:]
+context = json.loads((Path(base) / "_config" / "principal.json").read_text(encoding="utf-8"))
+principal = context["principal_id"]
+workspace_id = "wsp_" + "a" * 32
+corpus_id = "cor_" + "b" * 32
+with sqlite3.connect(database) as connection:
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.execute(
+        "INSERT INTO workspaces(workspace_id,kind,status) VALUES(?,?,?)",
+        (workspace_id, "shared", "active"),
+    )
+    connection.execute(
+        "INSERT INTO workspace_memberships(workspace_id,principal_id,role,status) VALUES(?,?,?,?)",
+        (workspace_id, principal, "member", "active"),
+    )
+    connection.execute(
+        "INSERT INTO corpora(corpus_id,workspace_id,location_ref,sensitivity,status) VALUES(?,?,?,?,?)",
+        (corpus_id, workspace_id, team_root, "internal", "active"),
+    )
+    connection.execute(
+        "INSERT INTO corpus_aliases(alias,corpus_id) VALUES(?,?)",
+        ("workspace:alpha", corpus_id),
+    )
+    for capability in ("knowledge.read", "knowledge.write"):
+        connection.execute(
+            "INSERT INTO corpus_grants(corpus_id,principal_id,role,capability,scope,status) VALUES(?,?,?,?,?,?)",
+            (corpus_id, principal, "member", capability, "corpus", "active"),
+        )
+PY
+
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+"$HELPER" provision --base "$BASE" --alias workspace:alpha >/dev/null
+
+cat >"$PERSONAL_ARCHIVE" <<'JSON'
+{
+  "provider": "xapi",
+  "connection_id": "conn_personal",
+  "remote_account_id": "acct-personal",
+  "exported_at": "2026-07-25T07:00:00Z",
+  "enabled_streams": ["authored"],
+  "policy": {"media_hydration": false},
+  "accounts": [{"remote_id": "acct-personal", "handle": "private-handle", "display_name": "Personal", "observed_at": "2026-07-25T07:00:00Z"}],
+  "objects": [
+    {"object_type": "post", "remote_id": "post-common", "account_remote_id": "acct-personal", "text": "federated common evidence", "created_at": "2026-07-24T01:00:00Z", "observed_at": "2026-07-25T07:00:00Z", "evidence_class": "authored"},
+    {"object_type": "post", "remote_id": "post-personal-inferred", "account_remote_id": "acct-personal", "text": "federated personal inference", "created_at": "2026-07-24T02:00:00Z", "observed_at": "2026-07-25T07:00:00Z", "evidence_class": "inferred", "provider_json": {"confidence": 0.72}}
+  ],
+  "activities": [{"activity_type": "authored", "remote_id": "activity-personal-common", "actor_remote_id": "acct-personal", "object_remote_id": "post-common", "occurred_at": "2026-07-24T01:00:00Z", "observed_at": "2026-07-25T07:00:00Z", "state": "active"}],
+  "media": [],
+  "coverage": [{"stream": "authored", "earliest_at": "2026-07-24T01:00:00Z", "latest_at": "2026-07-24T02:00:00Z", "cursor_exhausted": true, "status": "complete", "observed_at": "2026-07-25T07:00:00Z"}]
+}
+JSON
+
+cat >"$TEAM_ARCHIVE" <<'JSON'
+{
+  "provider": "xapi",
+  "connection_id": "conn_team",
+  "remote_account_id": "acct-team",
+  "exported_at": "2026-07-25T07:01:00Z",
+  "enabled_streams": ["reposts", "likes"],
+  "policy": {"media_hydration": false},
+  "accounts": [{"remote_id": "acct-team", "handle": "team-handle", "display_name": "Team", "observed_at": "2026-07-25T07:01:00Z"}],
+  "objects": [
+    {"object_type": "post", "remote_id": "post-common", "account_remote_id": "acct-team", "text": "federated common team evidence", "created_at": "2026-07-24T01:00:00Z", "observed_at": "2026-07-25T07:01:00Z", "evidence_class": "distributed"},
+    {"object_type": "post", "remote_id": "post-team-weak", "account_remote_id": "acct-team", "text": "federated team weak signal", "created_at": "2026-07-24T03:00:00Z", "observed_at": "2026-07-25T07:01:00Z", "evidence_class": "weak_signal"}
+  ],
+  "activities": [
+    {"activity_type": "reposted", "remote_id": "activity-team-common", "actor_remote_id": "acct-team", "object_remote_id": "post-common", "occurred_at": "2026-07-24T01:00:00Z", "observed_at": "2026-07-25T07:01:00Z", "state": "active"},
+    {"activity_type": "liked", "remote_id": "activity-team-weak", "actor_remote_id": "acct-team", "object_remote_id": "post-team-weak", "occurred_at": "2026-07-24T03:00:00Z", "observed_at": "2026-07-25T07:01:00Z", "state": "active"}
+  ],
+  "media": [],
+  "coverage": [
+    {"stream": "reposts", "earliest_at": "2026-07-24T01:00:00Z", "latest_at": "2026-07-24T01:00:00Z", "cursor_exhausted": true, "status": "complete", "observed_at": "2026-07-25T07:01:00Z"},
+    {"stream": "likes", "earliest_at": "2026-07-24T03:00:00Z", "latest_at": "2026-07-24T03:00:00Z", "cursor_exhausted": true, "status": "complete", "observed_at": "2026-07-25T07:01:00Z"}
+  ]
+}
+JSON
+chmod 0600 "$PERSONAL_ARCHIVE" "$TEAM_ARCHIVE"
+
+"$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$PERSONAL_ARCHIVE" >/dev/null
+"$HELPER" import-archive --base "$BASE" --alias workspace:alpha --archive "$TEAM_ARCHIVE" >/dev/null
+
+query_result=$("$HELPER" query --base "$BASE" --query federated --limit 10)
+repeat_result=$("$HELPER" query --base "$BASE" --query federated --limit 10)
+assert_eq "default query searches every authorized corpus" \
+	"$(json_summary "$query_result" scope)" "personal:default,workspace:alpha"
+assert_eq "query output contains no physical corpus path" \
+	"$([[ "$query_result" == *"$BASE"* ]] && printf present || printf absent)" "absent"
+assert_eq "query output omits mutable account handles" \
+	"$([[ "$query_result" == *-handle* ]] && printf present || printf absent)" "absent"
+assert_eq "RRF ranks the cross-corpus duplicate ahead of single-source hits" \
+	"$(json_summary "$query_result" ids)" "post-common,post-personal-inferred,post-team-weak"
+assert_eq "federated ranking and serialization are deterministic" "$repeat_result" "$query_result"
+assert_eq "deduplication retains one citation per contributing corpus" \
+	"$(json_summary "$query_result" common-citations)" "personal:default,workspace:alpha"
+assert_eq "citations retain batch, stream, object, and activity provenance" \
+	"$(json_summary "$query_result" provenance)" "complete"
+assert_eq "authored and distribution evidence remain explicitly distinct" \
+	"$(json_summary "$query_result" common-labels)" "authored,distribution"
+assert_eq "authored evidence alone permits attributed opinion semantics" \
+	"$(json_summary "$query_result" common-support)" "true"
+
+weak_result=$("$HELPER" query --base "$BASE" --alias workspace:alpha --query "weak signal")
+assert_eq "weak activity evidence cannot be presented as opinion" \
+	"$(json_summary "$weak_result" weak-semantics)" "weak_signal:false"
+inferred_result=$("$HELPER" query --base "$BASE" --alias personal:default --query inference)
+assert_eq "inferred evidence stays labelled, reviewable, and non-opinion" \
+	"$(json_summary "$inferred_result" inferred-semantics)" "inferred:false:true:true:true:0.72"
+assert_eq "bookmark, follow, list, and captured evidence remain non-opinion signals" \
+	"$(evidence_matrix)" "weak_signal,relationship,relationship,observed"
+
+python3 - "$PERSONAL_ROOT/index/social.db" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    connection.execute(
+        "UPDATE objects SET provider_json='{}' WHERE remote_id='post-personal-inferred'"
+    )
+PY
+expect_failure "inferred evidence without confidence fails closed" "valid confidence score" \
+	"$HELPER" query --base "$BASE" --alias personal:default --query inference
+python3 - "$PERSONAL_ROOT/index/social.db" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    connection.execute(
+        "UPDATE objects SET provider_json=? WHERE remote_id='post-personal-inferred'",
+        ('{"confidence":0.72}',),
+    )
+PY
+
+body_file="${TMP_DIR}/annotation.txt"
+printf 'private personal interpretation\n' >"$body_file"
+chmod 0600 "$body_file"
+annotation_result=$("$HELPER" annotate --base "$BASE" --provider xapi \
+	--object-type post --remote-id post-common --annotation-id ann_common \
+	--body-file "$body_file")
+assert_eq "annotation writes are owner-only and explicitly private" \
+	"$(json_summary "$annotation_result" annotation)" "ann_common:private:post-common"
+
+default_common=$("$HELPER" query --base "$BASE" --query common)
+team_common=$("$HELPER" query --base "$BASE" --alias workspace:alpha --query common)
+assert_eq "default personal scope overlays private annotations" \
+	"$(json_summary "$default_common" common-private-body)" "private personal interpretation"
+assert_eq "team-only scope never loads a personal private annotation" \
+	"$(json_summary "$team_common" common-private-count)" "0"
+assert_eq "team-only output contains no personal citation or account identity" \
+	"$([[ "$team_common" == *personal:default* || "$team_common" == *acct-personal* ]] && printf present || printf absent)" "absent"
+assert_eq "team corpus stores no private annotation rows" \
+	"$(sql_value "$TEAM_ROOT/index/social.db" 'SELECT count(*) FROM annotations')" "0"
+
+printf 'updated private interpretation\n' >"$body_file"
+"$HELPER" annotate --base "$BASE" --provider xapi --object-type post \
+	--remote-id post-common --annotation-id ann_common --body-file "$body_file" >/dev/null
+assert_eq "stable annotation IDs update idempotently in one row" \
+	"$(sql_value "$PERSONAL_ROOT/index/social.db" "SELECT count(*) || ':' || body FROM annotations WHERE annotation_id='ann_common'")" \
+	"1:updated private interpretation"
+
+chmod 0644 "$body_file"
+expect_failure "group-readable annotation input fails closed" "private UTF-8 file" \
+	"$HELPER" annotate --base "$BASE" --provider xapi --object-type post \
+	--remote-id post-common --body-file "$body_file"
+chmod 0600 "$body_file"
+
+query_file="${TMP_DIR}/query.txt"
+printf 'common\n' >"$query_file"
+chmod 0600 "$query_file"
+private_query=$("$HELPER" query --base "$BASE" --query-file "$query_file")
+assert_eq "private query files reach the same authorized query path" \
+	"$(json_summary "$private_query" common-citations)" "personal:default,workspace:alpha"
+chmod 0644 "$query_file"
+expect_failure "group-readable query input fails closed" "query file" \
+	"$HELPER" query --base "$BASE" --query-file "$query_file"
+
+catalog_status team-membership inactive
+membership_result=$("$HELPER" query --base "$BASE" --query common)
+assert_eq "inactive workspace membership removes that corpus from default scope" \
+	"$(json_summary "$membership_result" scope)" "personal:default"
+assert_eq "inactive workspace membership removes team citations" \
+	"$(json_summary "$membership_result" common-citations)" "personal:default"
+expect_failure "alias narrowing cannot bypass an inactive membership" "access denied" \
+	"$HELPER" query --base "$BASE" --alias workspace:alpha --query common
+catalog_status team-membership active
+
+catalog_status team-read inactive
+grant_result=$("$HELPER" query --base "$BASE" --query common)
+assert_eq "inactive read grants remove corpora from default scope" \
+	"$(json_summary "$grant_result" scope)" "personal:default"
+expect_failure "alias narrowing cannot bypass an inactive read grant" "access denied" \
+	"$HELPER" query --base "$BASE" --alias workspace:alpha --query common
+catalog_status team-read active
+
+catalog_status team-workspace inactive
+workspace_result=$("$HELPER" query --base "$BASE" --query common)
+assert_eq "inactive workspaces cannot influence default query results" \
+	"$(json_summary "$workspace_result" scope)" "personal:default"
+catalog_status team-workspace active
+
+catalog_status team-corpus inactive
+corpus_result=$("$HELPER" query --base "$BASE" --query common)
+assert_eq "inactive corpora cannot influence default query results" \
+	"$(json_summary "$corpus_result" scope)" "personal:default"
+catalog_status team-corpus active
+
+catalog_status principal inactive
+expect_failure "an inactive authenticated principal has no query scope" "access denied" \
+	"$HELPER" query --base "$BASE" --query common
+catalog_status principal active
+
+catalog_status personal-write inactive
+expect_failure "a revoked personal write grant blocks annotation" "access denied" \
+	"$HELPER" annotate --base "$BASE" --provider xapi --object-type post \
+	--remote-id post-common --body-file "$body_file"
+catalog_status personal-write active
+
+personal_before=$(store_snapshot "$PERSONAL_ROOT")
+team_before=$(store_snapshot "$TEAM_ROOT")
+"$HELPER" query --base "$BASE" --query federated >/dev/null
+assert_eq "query leaves the personal store byte-for-byte unchanged" \
+	"$(store_snapshot "$PERSONAL_ROOT")" "$personal_before"
+assert_eq "query leaves the team store byte-for-byte unchanged" \
+	"$(store_snapshot "$TEAM_ROOT")" "$team_before"
+
+: >"$TEAM_ROOT/index/social.db-wal"
+chmod 0600 "$TEAM_ROOT/index/social.db-wal"
+expect_failure "federated query rejects uncheckpointed state in any corpus" \
+	"uncheckpointed journal state" "$HELPER" query --base "$BASE" --query common
+rm "$TEAM_ROOT/index/social.db-wal"
+
+mv "$TEAM_ROOT/index/social.db" "$TEAM_ROOT/index/social.db.saved"
+absent_result=$("$HELPER" query --base "$BASE" --query common)
+assert_eq "a truly absent social store contributes no candidates" \
+	"$(json_summary "$absent_result" common-citations)" "personal:default"
+ln -s "social.db.saved" "$TEAM_ROOT/index/social.db"
+expect_failure "symlinked social stores fail the federated query closed" \
+	"cannot be a symlink" "$HELPER" query --base "$BASE" --query common
+rm "$TEAM_ROOT/index/social.db"
+mkdir "$TEAM_ROOT/index/social.db"
+expect_failure "malformed social stores are not mistaken for absent stores" \
+	"not a regular file" "$HELPER" query --base "$BASE" --query common
+rmdir "$TEAM_ROOT/index/social.db"
+mv "$TEAM_ROOT/index/social.db.saved" "$TEAM_ROOT/index/social.db"
+
+operator_result=$("$HELPER" query --base "$BASE" --query 'federated OR personal')
+assert_eq "FTS operators are treated as quoted search terms" \
+	"$(json_summary "$operator_result" count)" "0"
+expect_failure "query result limits are bounded" "limit must be between 1 and 100" \
+	"$HELPER" query --base "$BASE" --query common --limit 0
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Added immutable per-corpus FTS retrieval, deterministic RRF deduplication with complete citations, private personal annotations, and fail-closed evidence semantics.

## Files Changed

.agents/aidevops/knowledge-plane/01-core-contract.md, .agents/scripts/_knowledge_social_annotation.py, .agents/scripts/_knowledge_social_query.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_corpus_catalog.py, .agents/scripts/knowledge_social_query.py, .agents/tests/test-knowledge-social-query.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: 39 Phase 4 query tests, 45 corpus tests, 31 social-store tests, and 51 guarded-X tests passed; py_compile, ShellCheck, shfmt, markdownlint, secret scanning, complexity gates, and changed-file linters passed.

## Decisions

- Physical stores remain isolated.
- Inferred evidence requires a finite confidence score.
- Team-only queries never open personal annotation overlays.

Resolves #28605

For #28587

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 6h 51m and 4,953,183 tokens on this with the user in an interactive session.
