### PR TITLE
GH#28607: Add fenced social synchronization routines

### DIFF
--- a/.agents/aidevops/knowledge-plane/01-core-contract.md
+++ b/.agents/aidevops/knowledge-plane/01-core-contract.md
@@ -91,7 +91,7 @@ local projection without changing repo-mode knowledge:
 ```
 
 `knowledge-social-helper.sh` resolves a logical corpus alias through the
-authenticated catalog before it provisions schema v1, imports a provider-neutral
+authenticated catalog before it provisions schema v2, imports a provider-neutral
 archive, reports per-stream coverage, or rebuilds the FTS5 projection. Mutating
 operations require `knowledge.write`; coverage requires `knowledge.read`.
 Coverage opens only an existing, checkpointed database through SQLite immutable
@@ -108,6 +108,22 @@ The raw batch is authoritative and immutable. Normalized rows, coverage, and
 recreates FTS5 from canonical object rows without changing raw evidence. The
 database is mode `0600`, containing directories are `0700`, unsafe IDs and
 symlinks fail closed, and unsupported schema versions reject writes.
+
+`sync-due` enumerates connection IDs and enabled streams in stable order and
+collects only work outside the configured successful-run interval. A designated
+collector must hold the connection's expiring lease; every takeover increments a
+monotonic fencing token, and the adapter verifies that token inside the same
+transaction that commits normalized evidence and advances the cursor. An active
+lease blocks unfenced writes, stale generations cannot write or release a newer
+lease, provider reset times suppress duplicate retries, and expired leases close
+abandoned `running` receipts as `interrupted` before recovery continues.
+
+Each routine writes a privacy-safe `sync_runs` receipt with opaque connection ID,
+stream, run type, timestamps, counts, terminal status, retry boundary, and fencing
+generation. `reconcile` accepts only a mode `0600`, explicitly complete provider
+snapshot. It deterministically records stable objects as `present` or `missing`;
+remote absence never deletes raw evidence or canonical rows. Purge remains a
+separate retention-policy and audit operation.
 
 `knowledge-social-helper.sh query` derives the authenticated principal and
 searches `personal:default` plus every active workspace corpus carrying an

--- a/.agents/scripts/_knowledge_social_x_persist.py
+++ b/.agents/scripts/_knowledge_social_x_persist.py
@@ -82,6 +82,25 @@ def _assert_connection_binding(
         raise XAdapterError("stored connection does not match the verified X account")
 
 
+def _assert_fence(
+    database: sqlite3.Connection, context: CollectionContext
+) -> None:
+    """Reject stale generations and unfenced writers while a lease is active."""
+    row = database.execute(
+        "SELECT fencing_token,lease_until FROM collector_leases WHERE connection_id=?",
+        (context.connection_id,),
+    ).fetchone()
+    active = row is not None and datetime.fromisoformat(
+        str(row["lease_until"]).replace("Z", "+00:00")
+    ) > datetime.now(UTC)
+    if context.fencing_token is None:
+        if active:
+            raise XAdapterError("connection has an active fenced collector lease")
+        return
+    if not active or int(row["fencing_token"]) != context.fencing_token:
+        raise XAdapterError("collector lease is stale")
+
+
 def _connection_archive(context: CollectionContext) -> dict[str, Any]:
     return {
         "remote_account_id": context.account["id"],
@@ -165,11 +184,12 @@ def _update_cursor(
 ) -> None:
     database.execute(
         """INSERT INTO sync_cursors(
-           connection_id,stream,cursor,watermark,last_success_at,backfill_complete)
-           VALUES(?,?,?,?,?,?) ON CONFLICT(connection_id,stream) DO UPDATE SET
+           connection_id,stream,cursor,watermark,last_success_at,backfill_complete,fencing_token)
+           VALUES(?,?,?,?,?,?,?) ON CONFLICT(connection_id,stream) DO UPDATE SET
            cursor=excluded.cursor,watermark=excluded.watermark,
            last_success_at=excluded.last_success_at,
-           backfill_complete=excluded.backfill_complete""",
+           backfill_complete=excluded.backfill_complete,
+           fencing_token=excluded.fencing_token""",
         (
             context.connection_id,
             context.stream,
@@ -177,6 +197,7 @@ def _update_cursor(
             page.checkpoint.watermark,
             page.archive["exported_at"],
             int(page.complete),
+            context.fencing_token,
         ),
     )
 
@@ -228,6 +249,7 @@ def persist_page(context: CollectionContext, page: SuccessfulPage) -> int:
     try:
         migrate(database)
         database.execute("BEGIN IMMEDIATE")
+        _assert_fence(database, context)
         _assert_connection_binding(database, context)
         raw = _raw_batch(
             context, page.payload, page.endpoint, page.archive["exported_at"]
@@ -275,16 +297,24 @@ def _record_run(
     failure: str,
     retry_after: str | None,
 ) -> None:
+    observed_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
     database.execute(
-        "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,retry_after,diagnostics) "
-        "VALUES(?,?,?,?,?,?)",
+        """INSERT INTO sync_runs(
+           run_id,connection_id,status,failure_class,retry_after,fencing_token,
+           diagnostics,stream,run_type,started_at,completed_at)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?)""",
         (
             uuid.uuid4().hex,
             context.connection_id,
             status,
             failure,
             retry_after,
+            None if context.fencing_token is None else str(context.fencing_token),
             canonical_json({"stream": context.stream}),
+            context.stream,
+            "sync",
+            observed_at,
+            observed_at,
         ),
     )
 
@@ -340,6 +370,7 @@ def record_terminal(
     try:
         migrate(database)
         database.execute("BEGIN IMMEDIATE")
+        _assert_fence(database, context)
         _assert_connection_binding(database, context)
         raw = _raw_batch(context, payload, endpoint, observed_at)
         upsert_connection(
@@ -380,6 +411,7 @@ def record_bounded_stop(
     try:
         migrate(database)
         database.execute("BEGIN IMMEDIATE")
+        _assert_fence(database, context)
         _assert_connection_binding(database, context)
         _record_run(database, context, status, failure, None)
         updated = database.execute(

--- a/.agents/scripts/_knowledge_social_x_state.py
+++ b/.agents/scripts/_knowledge_social_x_state.py
@@ -36,6 +36,7 @@ class CollectionContext:
     config: ConnectionConfig
     state: CursorState
     spec: StreamSpec
+    fencing_token: int | None
 
 
 def _json_array(value: str, field: str) -> list[str]:
@@ -102,6 +103,7 @@ def load_context(
     account: dict[str, Any],
     stream: str,
     media_policy: str,
+    fencing_token: int | None = None,
 ) -> CollectionContext:
     """Read the connection policy and selected stream checkpoint."""
     database = connect(root)
@@ -122,4 +124,5 @@ def load_context(
         config,
         state,
         STREAMS[stream],
+        fencing_token,
     )

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_HELPER="${SCRIPT_DIR}/knowledge_social_import.py"
 X_HELPER="${SCRIPT_DIR}/knowledge_social_x.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
+SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 
 usage() {
 	cat <<'EOF'
@@ -24,6 +25,11 @@ Usage:
   knowledge-social-helper.sh sync-x [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id ID --stream STREAM [--budget UNITS] \
     [--media-policy none|metadata] [--app PROFILE] [--username HANDLE]
+  knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
+    --collector-id ID [--interval-seconds N] [--execute] [--budget UNITS]
+  knowledge-social-helper.sh reconcile [--base PATH] [--alias ALIAS] \
+    --connection-id ID --stream STREAM --collector-id ID --snapshot FILE
+  knowledge-social-helper.sh acquire-lease|release-lease [options]
 
 The authenticated corpus catalog resolves ALIAS with knowledge.write for
 mutating operations or knowledge.read for coverage. Physical corpus paths are
@@ -45,6 +51,12 @@ X synchronization:
   authored, mentions, likes, bookmarks, followers, or following. --budget is a
   bounded request-cost allowance from 1 to 1000 units. Media policy none stores
   no media rows; metadata stores references only, never binary media.
+
+Routine synchronization:
+  sync-due emits a deterministic due-work summary by default; --execute runs the
+  guarded adapter. Shared collectors use expiring leases and monotonic fencing
+  tokens. Reconcile accepts only an explicitly complete provider snapshot and
+  marks remote absence as missing; it never purges evidence.
 EOF
 	return 0
 }
@@ -78,6 +90,14 @@ main() {
 			return 1
 		fi
 		python3 "$X_HELPER" "$@" || return 1
+		;;
+	sync-due | reconcile | acquire-lease | release-lease)
+		require_runtime || return 1
+		if [[ ! -r "$SYNC_HELPER" ]]; then
+			printf 'ERROR: social sync implementation missing: %s\n' "$SYNC_HELPER" >&2
+			return 1
+		fi
+		python3 "$SYNC_HELPER" "$subcommand" "$@" || return 1
 		;;
 	query | annotate)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -18,7 +18,7 @@ from knowledge_corpus_context import (
     validate_private_file,
 )
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
 SQLITE_MUTABLE_SIDECARS = ("-journal", "-shm", "-wal")
 
@@ -139,11 +139,22 @@ def _tables() -> tuple[str, ...]:
         """CREATE TABLE IF NOT EXISTS sync_cursors (
             connection_id TEXT NOT NULL, stream TEXT NOT NULL, cursor TEXT, watermark TEXT,
             last_success_at TEXT, backfill_complete INTEGER NOT NULL DEFAULT 0,
+            fencing_token INTEGER,
             PRIMARY KEY(connection_id, stream))""",
         """CREATE TABLE IF NOT EXISTS sync_runs (
             run_id TEXT PRIMARY KEY, connection_id TEXT NOT NULL, status TEXT NOT NULL,
             resource_count INTEGER NOT NULL DEFAULT 0, failure_class TEXT, retry_after TEXT,
-            fencing_token TEXT, diagnostics TEXT)""",
+            fencing_token TEXT, diagnostics TEXT, stream TEXT, run_type TEXT NOT NULL DEFAULT 'sync',
+            started_at TEXT, completed_at TEXT)""",
+        """CREATE TABLE IF NOT EXISTS collector_leases (
+            connection_id TEXT PRIMARY KEY, holder_id TEXT NOT NULL,
+            fencing_token INTEGER NOT NULL, lease_until TEXT NOT NULL,
+            acquired_at TEXT NOT NULL, updated_at TEXT NOT NULL)""",
+        """CREATE TABLE IF NOT EXISTS reconciliation_observations (
+            provider TEXT NOT NULL, connection_id TEXT NOT NULL, stream TEXT NOT NULL,
+            object_type TEXT NOT NULL, remote_id TEXT NOT NULL, state TEXT NOT NULL,
+            observed_at TEXT NOT NULL, run_id TEXT NOT NULL,
+            PRIMARY KEY(provider, connection_id, stream, object_type, remote_id))""",
         """CREATE TABLE IF NOT EXISTS tombstones (
             provider TEXT NOT NULL, object_type TEXT NOT NULL, remote_id TEXT NOT NULL,
             observed_at TEXT NOT NULL, reason TEXT NOT NULL, retention_action TEXT NOT NULL,
@@ -161,6 +172,7 @@ def _tables() -> tuple[str, ...]:
         "CREATE INDEX IF NOT EXISTS idx_objects_account ON objects(provider, account_remote_id, created_at)",
         "CREATE INDEX IF NOT EXISTS idx_activities_actor ON activities(provider, actor_remote_id, occurred_at)",
         "CREATE INDEX IF NOT EXISTS idx_coverage_connection ON coverage_records(connection_id, stream)",
+        "CREATE INDEX IF NOT EXISTS idx_sync_runs_connection ON sync_runs(connection_id, stream, started_at)",
     )
 
 
@@ -178,10 +190,18 @@ def create_fts(connection: sqlite3.Connection) -> None:
 
 def migrate(connection: sqlite3.Connection) -> None:
     current = connection.execute("PRAGMA user_version").fetchone()[0]
-    if current not in (0, SCHEMA_VERSION):
+    if current not in (0, 1, SCHEMA_VERSION):
         raise SocialStoreError(f"unsupported social schema version: {current}")
     connection.execute("BEGIN IMMEDIATE")
     try:
+        if current == 1:
+            connection.execute("ALTER TABLE sync_cursors ADD COLUMN fencing_token INTEGER")
+            connection.execute("ALTER TABLE sync_runs ADD COLUMN stream TEXT")
+            connection.execute(
+                "ALTER TABLE sync_runs ADD COLUMN run_type TEXT NOT NULL DEFAULT 'sync'"
+            )
+            connection.execute("ALTER TABLE sync_runs ADD COLUMN started_at TEXT")
+            connection.execute("ALTER TABLE sync_runs ADD COLUMN completed_at TEXT")
         for statement in _tables():
             connection.execute(statement)
         create_fts(connection)

--- a/.agents/scripts/knowledge_social_sync.py
+++ b/.agents/scripts/knowledge_social_sync.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Deterministic social sync scheduling, fenced leases, and reconciliation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
+from knowledge_corpus_context import CatalogError, validate_private_file
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import (
+    SocialStoreError,
+    connect,
+    migrate,
+    validate_opaque,
+    validate_root,
+    write_raw_batch,
+)
+
+
+class SyncError(RuntimeError):
+    """Raised when deterministic synchronization cannot proceed safely."""
+
+
+def utc_text(value: datetime) -> str:
+    """Return a canonical UTC timestamp."""
+    return value.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def parse_time(value: str) -> datetime:
+    """Parse a canonical provider or local timestamp."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise SyncError("timestamp must be ISO-8601") from error
+    if parsed.tzinfo is None:
+        raise SyncError("timestamp must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def now_for_args(args: argparse.Namespace) -> datetime:
+    """Resolve the clock, allowing deterministic clocks only in tests."""
+    if args.now:
+        if os.environ.get("AIDEVOPS_TEST_MODE") != "1":
+            raise SyncError("--now is available only in the test harness")
+        return parse_time(args.now)
+    return datetime.now(UTC)
+
+
+def acquire_lease(
+    database: sqlite3.Connection,
+    connection_id: str,
+    holder_id: str,
+    now: datetime,
+    lease_seconds: int,
+) -> int | None:
+    """Acquire or renew one connection lease and return its fencing token."""
+    current_text = utc_text(now)
+    lease_until = utc_text(now + timedelta(seconds=lease_seconds))
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = database.execute(
+            "SELECT holder_id,fencing_token,lease_until FROM collector_leases "
+            "WHERE connection_id=?",
+            (connection_id,),
+        ).fetchone()
+        if row is not None and parse_time(row["lease_until"]) > now:
+            if row["holder_id"] != holder_id:
+                database.execute("ROLLBACK")
+                return None
+            token = int(row["fencing_token"])
+        else:
+            token = 1 if row is None else int(row["fencing_token"]) + 1
+            database.execute(
+                """UPDATE sync_runs SET status='failed',failure_class='interrupted',
+                   completed_at=? WHERE connection_id=? AND status='running'""",
+                (current_text, connection_id),
+            )
+        database.execute(
+            """INSERT INTO collector_leases(
+               connection_id,holder_id,fencing_token,lease_until,acquired_at,updated_at)
+               VALUES(?,?,?,?,?,?) ON CONFLICT(connection_id) DO UPDATE SET
+               holder_id=excluded.holder_id,fencing_token=excluded.fencing_token,
+               lease_until=excluded.lease_until,acquired_at=excluded.acquired_at,
+               updated_at=excluded.updated_at""",
+            (connection_id, holder_id, token, lease_until, current_text, current_text),
+        )
+        database.execute("COMMIT")
+        return token
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+
+
+def release_lease(
+    database: sqlite3.Connection, connection_id: str, holder_id: str, token: int
+) -> bool:
+    """Release only the exact lease generation owned by this collector."""
+    deleted = database.execute(
+        "DELETE FROM collector_leases WHERE connection_id=? AND holder_id=? "
+        "AND fencing_token=?",
+        (connection_id, holder_id, token),
+    ).rowcount
+    return deleted == 1
+
+
+def begin_run(
+    database: sqlite3.Connection,
+    connection_id: str,
+    stream: str,
+    run_type: str,
+    token: int,
+    started_at: str,
+) -> str:
+    """Persist a running receipt before external work begins."""
+    run_id = uuid.uuid4().hex
+    database.execute(
+        """INSERT INTO sync_runs(
+           run_id,connection_id,status,fencing_token,diagnostics,stream,run_type,started_at)
+           VALUES(?,?,?,?,?,?,?,?)""",
+        (
+            run_id,
+            connection_id,
+            "running",
+            str(token),
+            canonical_json({"stream": stream}),
+            stream,
+            run_type,
+            started_at,
+        ),
+    )
+    return run_id
+
+
+def finish_run(
+    database: sqlite3.Connection,
+    run_id: str,
+    status: str,
+    completed_at: str,
+    resource_count: int = 0,
+    failure_class: str | None = None,
+    retry_after: str | None = None,
+    diagnostics: dict[str, Any] | None = None,
+) -> None:
+    """Finalize a durable privacy-safe run receipt."""
+    updated = database.execute(
+        """UPDATE sync_runs SET status=?,resource_count=?,failure_class=?,retry_after=?,
+           diagnostics=?,completed_at=? WHERE run_id=? AND status='running'""",
+        (
+            status,
+            resource_count,
+            failure_class,
+            retry_after,
+            canonical_json(diagnostics or {}),
+            completed_at,
+            run_id,
+        ),
+    ).rowcount
+    if updated != 1:
+        raise SyncError("run receipt is not in the running state")
+
+
+def due_connections(
+    database: sqlite3.Connection, now: datetime, interval_seconds: int
+) -> tuple[list[sqlite3.Row], str]:
+    """Return due connection/stream pairs in a stable order."""
+    cutoff = utc_text(now - timedelta(seconds=interval_seconds))
+    return database.execute(
+        """SELECT c.connection_id,c.remote_account_id,c.enabled_streams,
+                  c.policy_json,c.auth_profile_ref
+           FROM connections c ORDER BY c.connection_id"""
+    ).fetchall(), cutoff
+
+
+def last_success(
+    database: sqlite3.Connection, connection_id: str, stream: str
+) -> str | None:
+    """Return the last terminal successful routine receipt."""
+    row = database.execute(
+        """SELECT completed_at FROM sync_runs
+           WHERE connection_id=? AND stream=? AND status='complete'
+             AND completed_at IS NOT NULL ORDER BY completed_at DESC LIMIT 1""",
+        (connection_id, stream),
+    ).fetchone()
+    return None if row is None else str(row["completed_at"])
+
+
+def retry_is_blocked(
+    database: sqlite3.Connection,
+    connection_id: str,
+    stream: str,
+    now: datetime,
+) -> bool:
+    """Honor the latest provider reset instead of creating a retry storm."""
+    row = database.execute(
+        """SELECT retry_after FROM sync_runs
+           WHERE connection_id=? AND stream=? AND retry_after IS NOT NULL
+           ORDER BY completed_at DESC,rowid DESC LIMIT 1""",
+        (connection_id, stream),
+    ).fetchone()
+    if row is None:
+        return False
+    value = str(row["retry_after"])
+    try:
+        reset = datetime.fromtimestamp(int(value), UTC)
+    except ValueError:
+        reset = parse_time(value)
+    return reset > now
+
+
+def run_adapter(
+    args: argparse.Namespace,
+    connection_id: str,
+    account_id: str,
+    stream: str,
+    token: int,
+) -> dict[str, Any]:
+    """Invoke the guarded provider adapter without passing private values to output."""
+    command = [
+        sys.executable,
+        str(Path(__file__).with_name("knowledge_social_x.py")),
+        "--base",
+        str(args.base),
+        "--alias",
+        args.alias,
+        "--connection-id",
+        connection_id,
+        "--account-id",
+        account_id,
+        "--stream",
+        stream,
+        "--budget",
+        str(args.budget),
+        "--fencing-token",
+        str(token),
+    ]
+    if args.app:
+        command.extend(("--app", args.app))
+    if args.username:
+        command.extend(("--username", args.username))
+    if args.fixture:
+        command.extend(("--fixture", str(args.fixture)))
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    if completed.returncode != 0:
+        raise SyncError("provider adapter failed; inspect private local diagnostics")
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise SyncError("provider adapter returned invalid output") from error
+    if not isinstance(result, dict):
+        raise SyncError("provider adapter returned invalid output")
+    return result
+
+
+def command_sync_due(
+    args: argparse.Namespace, root: Path, database: sqlite3.Connection
+) -> dict[str, Any]:
+    """Run each due private connection deterministically under one fenced lease."""
+    now = now_for_args(args)
+    rows, cutoff = due_connections(database, now, args.interval_seconds)
+    scheduled = 0
+    completed = 0
+    failed = 0
+    for row in rows:
+        try:
+            streams = json.loads(row["enabled_streams"])
+        except json.JSONDecodeError as error:
+            raise SyncError("stored enabled_streams is invalid") from error
+        if not isinstance(streams, list) or any(not isinstance(item, str) for item in streams):
+            raise SyncError("stored enabled_streams must be an array of text")
+        for stream in sorted(set(streams)):
+            previous = last_success(database, row["connection_id"], stream)
+            if (previous is not None and previous >= cutoff) or retry_is_blocked(
+                database, row["connection_id"], stream, now
+            ):
+                continue
+            scheduled += 1
+            if not args.execute:
+                continue
+            token = acquire_lease(
+                database,
+                row["connection_id"],
+                args.collector_id,
+                now,
+                args.lease_seconds,
+            )
+            if token is None:
+                continue
+            run_id = begin_run(
+                database,
+                row["connection_id"],
+                stream,
+                "sync",
+                token,
+                utc_text(now),
+            )
+            try:
+                result = run_adapter(
+                    args,
+                    row["connection_id"],
+                    row["remote_account_id"],
+                    stream,
+                    token,
+                )
+                status = str(result.get("status", "failed"))
+                successful = status == "complete"
+                retry_value = result.get("retry_after")
+                finish_run(
+                    database,
+                    run_id,
+                    "complete" if successful else status,
+                    utc_text(now),
+                    int(result.get("resources", 0)),
+                    None if successful else str(result.get("failure_class", status)),
+                    None if successful or retry_value is None else str(retry_value),
+                    {"stream": stream},
+                )
+                completed += int(successful)
+                failed += int(not successful)
+            except Exception:
+                finish_run(
+                    database,
+                    run_id,
+                    "failed",
+                    utc_text(now),
+                    failure_class="collector",
+                    diagnostics={"stream": stream},
+                )
+                failed += 1
+            finally:
+                release_lease(database, row["connection_id"], args.collector_id, token)
+    return {
+        "status": "complete" if failed == 0 else "partial",
+        "scheduled": scheduled,
+        "completed": completed,
+        "failed": failed,
+    }
+
+
+def snapshot_ids(path: Path) -> tuple[str, str, str, list[str], dict[str, Any]]:
+    """Read a complete provider reconciliation snapshot."""
+    try:
+        validate_private_file(path, "reconciliation snapshot", repair=False)
+    except CatalogError as error:
+        raise SyncError(str(error)) from error
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    reject_credentials(payload)
+    if not isinstance(payload, dict) or payload.get("complete") is not True:
+        raise SyncError("reconciliation requires an explicitly complete snapshot")
+    provider = payload.get("provider")
+    observed_at = payload.get("observed_at")
+    object_type = payload.get("object_type", "post")
+    remote_ids = payload.get("remote_ids")
+    if not all(isinstance(value, str) for value in (provider, observed_at, object_type)):
+        raise SyncError("snapshot metadata must be text")
+    parse_time(observed_at)
+    if not isinstance(remote_ids, list) or any(not isinstance(item, str) for item in remote_ids):
+        raise SyncError("snapshot remote_ids must be an array of text")
+    return provider, observed_at, object_type, sorted(set(remote_ids)), payload
+
+
+def command_reconcile(
+    args: argparse.Namespace, root: Path, database: sqlite3.Connection
+) -> dict[str, Any]:
+    """Mark provider-confirmed presence or absence without destructive purge."""
+    provider, observed_at, object_type, remote_ids, payload = snapshot_ids(args.snapshot)
+    connection_id = validate_opaque(args.connection_id, "connection_id")
+    stream = args.stream
+    token = acquire_lease(
+        database,
+        connection_id,
+        args.collector_id,
+        now_for_args(args),
+        args.lease_seconds,
+    )
+    if token is None:
+        return {"status": "lease_held", "present": 0, "missing": 0}
+    run_id = begin_run(database, connection_id, stream, "reconcile", token, observed_at)
+    try:
+        known = {
+            str(row[0])
+            for row in database.execute(
+                """SELECT DISTINCT o.remote_id FROM objects o
+                   JOIN fetch_batches b ON b.batch_id=o.batch_id
+                   WHERE b.connection_id=? AND b.stream=? AND o.provider=?
+                     AND o.object_type=?""",
+                (connection_id, stream, provider, object_type),
+            )
+        }
+        present = known.intersection(remote_ids)
+        missing = known.difference(remote_ids)
+        database.execute("BEGIN IMMEDIATE")
+        evidence = canonical_json(
+            {
+                "provider": provider,
+                "connection_id": connection_id,
+                "stream": stream,
+                "observed_at": observed_at,
+                "snapshot": payload,
+            }
+        ).encode("utf-8")
+        batch_id, blob_ref = write_raw_batch(root, provider, connection_id, evidence)
+        database.execute(
+            """INSERT INTO fetch_batches(
+               batch_id,provider,connection_id,stream,response_hash,blob_ref,
+               resource_count,budget_units,started_at,completed_at,terminal_status)
+               VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(batch_id) DO NOTHING""",
+            (
+                batch_id,
+                provider,
+                connection_id,
+                stream,
+                batch_id,
+                blob_ref,
+                len(remote_ids),
+                0,
+                observed_at,
+                observed_at,
+                "reconciliation",
+            ),
+        )
+        for remote_id in sorted(known):
+            database.execute(
+                """INSERT INTO reconciliation_observations(
+                   provider,connection_id,stream,object_type,remote_id,state,observed_at,run_id)
+                   VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(
+                   provider,connection_id,stream,object_type,remote_id) DO UPDATE SET
+                   state=excluded.state,observed_at=excluded.observed_at,run_id=excluded.run_id""",
+                (
+                    provider,
+                    connection_id,
+                    stream,
+                    object_type,
+                    remote_id,
+                    "present" if remote_id in present else "missing",
+                    observed_at,
+                    run_id,
+                ),
+            )
+        finish_run(
+            database,
+            run_id,
+            "complete",
+            observed_at,
+            len(known),
+            diagnostics={"missing": len(missing), "present": len(present), "stream": stream},
+        )
+        database.execute("COMMIT")
+        return {"status": "complete", "present": len(present), "missing": len(missing)}
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        finish_run(
+            database,
+            run_id,
+            "failed",
+            utc_text(datetime.now(UTC)),
+            failure_class="reconciliation",
+            diagnostics={"stream": stream},
+        )
+        raise
+    finally:
+        release_lease(database, connection_id, args.collector_id, token)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse deterministic routine arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--base", type=Path)
+    common.add_argument("--alias", default=DEFAULT_ALIAS)
+    common.add_argument("--now", help=argparse.SUPPRESS)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    lease = subparsers.add_parser("acquire-lease", parents=[common])
+    lease.add_argument("--connection-id", required=True)
+    lease.add_argument("--collector-id", required=True)
+    lease.add_argument("--lease-seconds", type=int, default=900)
+
+    release = subparsers.add_parser("release-lease", parents=[common])
+    release.add_argument("--connection-id", required=True)
+    release.add_argument("--collector-id", required=True)
+    release.add_argument("--fencing-token", required=True, type=int)
+
+    due = subparsers.add_parser("sync-due", parents=[common])
+    due.add_argument("--collector-id", required=True)
+    due.add_argument("--lease-seconds", type=int, default=900)
+    due.add_argument("--interval-seconds", type=int, default=86400)
+    due.add_argument("--budget", type=int, default=10)
+    due.add_argument("--app")
+    due.add_argument("--username")
+    due.add_argument("--execute", action="store_true")
+    due.add_argument("--fixture", type=Path, help=argparse.SUPPRESS)
+
+    reconcile = subparsers.add_parser("reconcile", parents=[common])
+    reconcile.add_argument("--connection-id", required=True)
+    reconcile.add_argument("--stream", required=True)
+    reconcile.add_argument("--collector-id", required=True)
+    reconcile.add_argument("--lease-seconds", type=int, default=900)
+    reconcile.add_argument("--snapshot", type=Path, required=True)
+    return parser.parse_args()
+
+
+def validate_bounds(args: argparse.Namespace) -> None:
+    """Reject unsafe or nonsensical routine bounds."""
+    for name in ("lease_seconds", "interval_seconds", "budget"):
+        value = getattr(args, name, None)
+        if value is not None and value < 1:
+            raise SyncError(f"--{name.replace('_', '-')} must be positive")
+    if getattr(args, "budget", 1) > 1000:
+        raise SyncError("--budget must not exceed 1000")
+
+
+def main() -> int:
+    """Run a synchronization control command."""
+    args = parse_args()
+    try:
+        validate_bounds(args)
+        base = args.base or Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+        args.base = base
+        root = validate_root(resolve(base, args.alias, "knowledge.write"))
+        database = connect(root)
+        try:
+            migrate(database)
+            if args.command == "acquire-lease":
+                token = acquire_lease(
+                    database,
+                    validate_opaque(args.connection_id, "connection_id"),
+                    validate_opaque(args.collector_id, "collector_id"),
+                    now_for_args(args),
+                    args.lease_seconds,
+                )
+                result = {"status": "acquired", "fencing_token": token} if token else {"status": "held"}
+            elif args.command == "release-lease":
+                released = release_lease(
+                    database,
+                    validate_opaque(args.connection_id, "connection_id"),
+                    validate_opaque(args.collector_id, "collector_id"),
+                    args.fencing_token,
+                )
+                result = {"status": "released" if released else "stale"}
+            elif args.command == "sync-due":
+                validate_opaque(args.collector_id, "collector_id")
+                result = command_sync_due(args, root, database)
+            else:
+                validate_opaque(args.collector_id, "collector_id")
+                result = command_reconcile(args, root, database)
+        finally:
+            database.close()
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (
+        CatalogError,
+        json.JSONDecodeError,
+        OSError,
+        SocialStoreError,
+        sqlite3.Error,
+        SyncError,
+        ValueError,
+    ) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_x.py
+++ b/.agents/scripts/knowledge_social_x.py
@@ -159,7 +159,12 @@ def collect(args: argparse.Namespace, root: Path) -> dict[str, Any]:
     runner = xurl_runner(args)
     account = verified_identity(runner.identity(), account_id)
     context = load_context(
-        root, connection_id, account, args.stream, args.media_policy
+        root,
+        connection_id,
+        account,
+        args.stream,
+        args.media_policy,
+        args.fencing_token,
     )
     if context.state.backfill_complete and not context.spec.supports_since_id:
         record_bounded_stop(context, "unavailable", "delta_not_supported")
@@ -186,6 +191,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--app")
     parser.add_argument("--username")
+    parser.add_argument("--fencing-token", type=int, help=argparse.SUPPRESS)
     parser.add_argument("--fixture", type=Path, help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.budget < 1 or args.budget > 1000:

--- a/.agents/tests/test-knowledge-social-sync.sh
+++ b/.agents/tests/test-knowledge-social-sync.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-sync.sh — Fenced routine and reconciliation tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' "$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+database = sqlite3.connect(sys.argv[1])
+print(database.execute(sys.argv[2]).fetchone()[0])
+database.close()
+PY
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+migration_result=$(
+	python3 - "$SCRIPT_DIR/../scripts" "$TMP_DIR/migration-root" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[1])
+from knowledge_social_store import connect, migrate
+root = Path(sys.argv[2])
+(root / "index").mkdir(parents=True, mode=0o700)
+os.chmod(root, 0o700)
+database_path = root / "index" / "social.db"
+database = sqlite3.connect(database_path)
+database.execute("CREATE TABLE sync_cursors(connection_id TEXT NOT NULL,stream TEXT NOT NULL,cursor TEXT,watermark TEXT,last_success_at TEXT,backfill_complete INTEGER NOT NULL DEFAULT 0,PRIMARY KEY(connection_id,stream))")
+database.execute("CREATE TABLE sync_runs(run_id TEXT PRIMARY KEY,connection_id TEXT NOT NULL,status TEXT NOT NULL,resource_count INTEGER NOT NULL DEFAULT 0,failure_class TEXT,retry_after TEXT,fencing_token TEXT,diagnostics TEXT)")
+database.execute("PRAGMA user_version=1")
+database.commit()
+database.close()
+os.chmod(database_path, 0o600)
+database = connect(root)
+migrate(database)
+version = database.execute("PRAGMA user_version").fetchone()[0]
+cursor_columns = {row[1] for row in database.execute("PRAGMA table_info(sync_cursors)")}
+run_columns = {row[1] for row in database.execute("PRAGMA table_info(sync_runs)")}
+tables = {row[0] for row in database.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+database.close()
+valid = version == 2 and "fencing_token" in cursor_columns and {"stream", "run_type", "started_at", "completed_at"} <= run_columns and {"collector_leases", "reconciliation_observations"} <= tables
+print("migrated" if valid else "invalid")
+PY
+)
+assert_eq "schema v1 upgrades atomically to fenced schema v2" "$migration_result" "migrated"
+
+cat >"$TMP_DIR/seed.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42"}},
+  "pages": [{
+    "status": 200,
+    "observed_at": "2026-07-25T10:00:00Z",
+    "data": [{"id": "post101", "author_id": "acct42", "text": "fenced evidence", "created_at": "2026-07-25T09:00:00Z"}],
+    "meta": {}
+  }]
+}
+JSON
+
+first=$(
+	"$HELPER" acquire-lease --base "$BASE" --alias personal:default \
+		--connection-id conn_shared --collector-id runner_one --lease-seconds 60 \
+		--now 2099-01-01T00:00:00Z
+)
+token_one=$(json_field "$first" fencing_token)
+assert_eq "first collector receives the first fencing generation" "$token_one" "1"
+
+competing=$(
+	"$HELPER" acquire-lease --base "$BASE" --alias personal:default \
+		--connection-id conn_shared --collector-id runner_two --lease-seconds 60 \
+		--now 2099-01-01T00:00:30Z
+)
+assert_eq "a competing live collector cannot acquire the connection" \
+	"$(json_field "$competing" status)" "held"
+
+second=$(
+	"$HELPER" acquire-lease --base "$BASE" --alias personal:default \
+		--connection-id conn_shared --collector-id runner_two --lease-seconds 300 \
+		--now 2099-01-01T00:02:00Z
+)
+token_two=$(json_field "$second" fencing_token)
+assert_eq "lease takeover increments the fencing generation" "$token_two" "2"
+
+if "$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_shared --account-id acct42 --stream authored \
+	--fencing-token "$token_one" --fixture "$TMP_DIR/seed.json" >/dev/null 2>&1; then
+	assert_eq "a stale collector cannot commit provider content" accepted rejected
+else
+	assert_eq "a stale collector cannot commit provider content" rejected rejected
+fi
+assert_eq "stale fencing leaves the cursor absent" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_shared'")" "0"
+
+fresh_result=$(
+	"$HELPER" sync-x --base "$BASE" --alias personal:default \
+		--connection-id conn_shared --account-id acct42 --stream authored \
+		--fencing-token "$token_two" --fixture "$TMP_DIR/seed.json"
+)
+assert_eq "the current lease generation can complete collection" \
+	"$(json_field "$fresh_result" status)" "complete"
+assert_eq "cursor advancement records the accepted fencing generation" \
+	"$(sql_value "SELECT fencing_token FROM sync_cursors WHERE connection_id='conn_shared'")" "$token_two"
+
+stale_release=$(
+	"$HELPER" release-lease --base "$BASE" --alias personal:default \
+		--connection-id conn_shared --collector-id runner_one --fencing-token "$token_one"
+)
+assert_eq "an old generation cannot release the current lease" \
+	"$(json_field "$stale_release" status)" "stale"
+current_release=$(
+	"$HELPER" release-lease --base "$BASE" --alias personal:default \
+		--connection-id conn_shared --collector-id runner_two --fencing-token "$token_two"
+)
+assert_eq "the current owner can release its exact generation" \
+	"$(json_field "$current_release" status)" "released"
+
+executed=$(
+	"$HELPER" sync-due --base "$BASE" --alias personal:default \
+		--collector-id routine_runner --interval-seconds 86400 --execute \
+		--fixture "$TMP_DIR/seed.json" --now 2099-01-01T00:03:00Z
+)
+assert_eq "sync-due executes the guarded provider route under its lease" \
+	"$(json_field "$executed" completed)" "1"
+assert_eq "successful routine collection persists a fenced run receipt" \
+	"$(sql_value "SELECT count(*) FROM sync_runs WHERE run_type='sync' AND status='complete' AND fencing_token IS NOT NULL")" "1"
+
+due=$(
+	"$HELPER" sync-due --base "$BASE" --alias personal:default \
+		--collector-id routine_runner --interval-seconds 86400 \
+		--now 2099-01-02T00:04:00Z
+)
+assert_eq "sync-due deterministically identifies the configured stream" \
+	"$(json_field "$due" scheduled)" "1"
+assert_eq "a dry routine performs no provider request" \
+	"$(json_field "$due" completed)" "0"
+
+python3 - "$ROOT/index/social.db" <<'PY'
+import sqlite3
+import sys
+import uuid
+database = sqlite3.connect(sys.argv[1])
+database.execute(
+    "INSERT INTO sync_runs(run_id,connection_id,status,retry_after,stream,run_type,started_at,completed_at) VALUES(?,?,?,?,?,?,?,?)",
+    (uuid.uuid4().hex, "conn_shared", "paused", "2099-01-03T00:00:00Z", "authored", "sync", "2099-01-02T00:00:00Z", "2099-01-02T00:00:00Z"),
+)
+database.commit()
+database.close()
+PY
+rate_blocked=$(
+	"$HELPER" sync-due --base "$BASE" --alias personal:default \
+		--collector-id routine_runner --interval-seconds 86400 \
+		--now 2099-01-02T12:00:00Z
+)
+assert_eq "provider reset time suppresses repeated routine retries" \
+	"$(json_field "$rate_blocked" scheduled)" "0"
+
+cat >"$TMP_DIR/snapshot.json" <<'JSON'
+{
+  "provider": "xapi",
+  "observed_at": "2099-01-02T00:00:00Z",
+  "object_type": "post",
+  "remote_ids": [],
+  "complete": true
+}
+JSON
+if "$HELPER" reconcile --base "$BASE" --alias personal:default \
+	--connection-id conn_shared --stream authored --collector-id routine_runner \
+	--snapshot "$TMP_DIR/snapshot.json" --now 2099-01-02T00:00:00Z >/dev/null 2>&1; then
+	assert_eq "reconciliation rejects a group-readable private snapshot" accepted rejected
+else
+	assert_eq "reconciliation rejects a group-readable private snapshot" rejected rejected
+fi
+chmod 0600 "$TMP_DIR/snapshot.json"
+reconciled=$(
+	"$HELPER" reconcile --base "$BASE" --alias personal:default \
+		--connection-id conn_shared --stream authored --collector-id routine_runner \
+		--snapshot "$TMP_DIR/snapshot.json" --now 2099-01-02T00:00:00Z
+)
+assert_eq "complete provider absence is recorded as missing" \
+	"$(json_field "$reconciled" missing)" "1"
+assert_eq "reconciliation is non-destructive" "$(sql_value 'SELECT count(*) FROM objects')" "1"
+assert_eq "missing state remains auditable by stable provider identity" \
+	"$(sql_value "SELECT state FROM reconciliation_observations WHERE remote_id='post101'")" "missing"
+assert_eq "reconciliation produces a terminal run receipt" \
+	"$(sql_value "SELECT status || ':' || run_type || ':' || resource_count FROM sync_runs WHERE run_type='reconcile'")" \
+	"complete:reconcile:1"
+assert_eq "complete reconciliation evidence is retained as an immutable raw batch" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE terminal_status='reconciliation'")" "1"
+
+python3 - "$ROOT/index/social.db" <<'PY'
+import sqlite3
+import uuid
+import sys
+database = sqlite3.connect(sys.argv[1])
+database.execute(
+    "INSERT INTO sync_runs(run_id,connection_id,status,stream,run_type,started_at) VALUES(?,?,?,?,?,?)",
+    (uuid.uuid4().hex, "conn_crash", "running", "authored", "sync", "2099-01-01T00:00:00Z"),
+)
+database.execute(
+    "INSERT INTO collector_leases(connection_id,holder_id,fencing_token,lease_until,acquired_at,updated_at) VALUES(?,?,?,?,?,?)",
+    ("conn_crash", "dead_runner", 4, "2099-01-01T00:01:00Z", "2099-01-01T00:00:00Z", "2099-01-01T00:00:00Z"),
+)
+database.commit()
+database.close()
+PY
+recovered=$(
+	"$HELPER" acquire-lease --base "$BASE" --alias personal:default \
+		--connection-id conn_crash --collector-id recovery_runner --lease-seconds 60 \
+		--now 2099-01-01T00:02:00Z
+)
+assert_eq "crash recovery advances beyond the abandoned generation" \
+	"$(json_field "$recovered" fencing_token)" "5"
+assert_eq "crash recovery closes the abandoned running receipt" \
+	"$(sql_value "SELECT status || ':' || failure_class FROM sync_runs WHERE connection_id='conn_crash'")" \
+	"failed:interrupted"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi

--- a/.agents/tests/test-knowledge-social.sh
+++ b/.agents/tests/test-knowledge-social.sh
@@ -94,8 +94,8 @@ mkdir -p "$CORPUS_ROOT"
 chmod 0700 "$BASE" "$CORPUS_ROOT"
 "$CORPUS_HELPER" provision --base "$BASE" >/dev/null
 "$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
-assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "1"
-assert_eq "all provider-neutral tables exist" "$(sql_value "SELECT count(*) FROM sqlite_master WHERE name IN ('connections','accounts','objects','activities','media','fetch_batches','sync_cursors','sync_runs','tombstones','annotations','coverage_records','objects_fts')")" "12"
+assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "2"
+assert_eq "all provider-neutral tables exist" "$(sql_value "SELECT count(*) FROM sqlite_master WHERE name IN ('connections','accounts','objects','activities','media','fetch_batches','sync_cursors','sync_runs','collector_leases','reconciliation_observations','tombstones','annotations','coverage_records','objects_fts')")" "14"
 
 first_result=$("$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$ARCHIVE")
 first_hash=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["batch_id"])' "$first_result")


### PR DESCRIPTION
## Summary

- Adds deterministic due-work scheduling and complete-snapshot reconciliation.
- Enforces one-collector leases with monotonic fencing tokens at the cursor transaction boundary.
- Persists privacy-safe run receipts and recovers abandoned runs after lease expiry.
- Preserves remote absence as auditable `missing` state without destructive purge.

## Runtime Testing

- **Risk level:** Critical
- **Status:** Runtime-verified.
- **Completed:** 23 fenced sync/reconciliation tests, 51 X adapter tests, 31 social store tests, 39 federated query tests, and 45 corpus authorization tests.
- **Static checks:** Python compilation, ShellCheck, shfmt, TypeScript typecheck, secret scanning, Markdown lint, complexity ratchets, and changed-file lint passed.

## Decisions

- Cursor fencing is checked inside the evidence/cursor transaction, not only when work starts.
- Reconciliation requires a mode `0600`, explicitly complete snapshot and records absence as `missing`; purge remains a separate audited retention action.
- Provider retry boundaries block repeated due-work dispatch until the recorded reset.

Resolves #28607

For #28587

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 11m and 169,258 tokens on this as a headless worker.
