### PR TITLE
GH#28607: Add fenced social sync routines

### DIFF
--- a/.agents/scripts/_knowledge_social_lease.py
+++ b/.agents/scripts/_knowledge_social_lease.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Deterministic social collector leases, fencing, and run receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from knowledge_social_store import SocialStoreError, connect, migrate, validate_opaque
+
+RUN_KINDS = ("sync", "reconcile")
+TERMINAL_RUN_STATES = (
+    "complete",
+    "failed",
+    "paused",
+    "unavailable",
+    "abandoned",
+)
+
+
+class SocialLeaseBusyError(SocialStoreError):
+    """Raised when another collector owns an unexpired connection lease."""
+
+
+class SocialLeaseLostError(SocialStoreError):
+    """Raised when a stale collector attempts a fenced write."""
+
+
+@dataclass(frozen=True)
+class RunLease:
+    """One collector's time-bounded authority for a connection."""
+
+    connection_id: str
+    stream: str
+    run_kind: str
+    collector_id: str
+    fencing_token: int
+    run_id: str
+    acquired_at: int
+    expires_at: int
+
+
+def social_now(explicit: int | None = None) -> int:
+    """Return one validated clock value, with a deterministic test seam."""
+    if explicit is not None:
+        value: Any = explicit
+    else:
+        override = os.environ.get("AIDEVOPS_SOCIAL_NOW_EPOCH")
+        value = override if override is not None else int(datetime.now(UTC).timestamp())
+    if isinstance(value, bool):
+        raise SocialStoreError("social clock must be a non-negative integer")
+    try:
+        epoch = int(value)
+    except (TypeError, ValueError) as error:
+        raise SocialStoreError("social clock must be a non-negative integer") from error
+    if epoch < 0 or str(value).strip() != str(epoch):
+        raise SocialStoreError("social clock must be a non-negative integer")
+    return epoch
+
+
+def _validate_run_inputs(
+    connection_id: str,
+    stream: str,
+    collector_id: str,
+    run_kind: str,
+    lease_seconds: int,
+) -> tuple[str, str, str]:
+    connection = validate_opaque(connection_id, "connection_id")
+    collector = validate_opaque(collector_id, "collector_id")
+    if not isinstance(stream, str) or not stream or len(stream) > 127:
+        raise SocialStoreError("stream must be non-empty text")
+    if run_kind not in RUN_KINDS:
+        raise SocialStoreError("run_kind must be sync or reconcile")
+    if (
+        isinstance(lease_seconds, bool)
+        or not isinstance(lease_seconds, int)
+        or not 1 <= lease_seconds <= 86_400
+    ):
+        raise SocialStoreError("lease_seconds must be between 1 and 86400")
+    return connection, stream, collector
+
+
+def _run_id(
+    connection_id: str, stream: str, run_kind: str, fencing_token: int
+) -> str:
+    material = (
+        f"social-run-v1\0{connection_id}\0{stream}\0{run_kind}\0{fencing_token}"
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _next_fencing_token(database: sqlite3.Connection, connection_id: str) -> int:
+    row = database.execute(
+        "SELECT last_token FROM collector_lease_generations WHERE connection_id=?",
+        (connection_id,),
+    ).fetchone()
+    token = int(row["last_token"]) + 1 if row else 1
+    database.execute(
+        "INSERT INTO collector_lease_generations(connection_id,last_token) VALUES(?,?) "
+        "ON CONFLICT(connection_id) DO UPDATE SET last_token=excluded.last_token",
+        (connection_id, token),
+    )
+    return token
+
+
+def _abandon_expired_run(
+    database: sqlite3.Connection, row: sqlite3.Row, now_epoch: int
+) -> None:
+    database.execute(
+        "UPDATE sync_runs SET status='abandoned',failure_class='lease_expired',"
+        "completed_at=? WHERE run_id=? AND status='running'",
+        (now_epoch, row["run_id"]),
+    )
+
+
+def acquire_run_lease(
+    root: Path,
+    connection_id: str,
+    stream: str,
+    collector_id: str,
+    run_kind: str,
+    lease_seconds: int,
+    *,
+    now_epoch: int | None = None,
+    request_hash: str | None = None,
+) -> RunLease:
+    """Elect one collector and create its running receipt atomically."""
+    connection_id, stream, collector_id = _validate_run_inputs(
+        connection_id, stream, collector_id, run_kind, lease_seconds
+    )
+    now = social_now(now_epoch)
+    database = connect(root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        current = database.execute(
+            "SELECT * FROM collector_leases WHERE connection_id=?",
+            (connection_id,),
+        ).fetchone()
+        if current is not None and int(current["expires_at"]) > now:
+            raise SocialLeaseBusyError("social connection already has a live collector")
+        if current is not None:
+            _abandon_expired_run(database, current, now)
+        token = _next_fencing_token(database, connection_id)
+        run_id = _run_id(connection_id, stream, run_kind, token)
+        expires_at = now + lease_seconds
+        database.execute(
+            "INSERT INTO collector_leases(connection_id,collector_id,fencing_token,"
+            "run_id,acquired_at,expires_at) VALUES(?,?,?,?,?,?) "
+            "ON CONFLICT(connection_id) DO UPDATE SET "
+            "collector_id=excluded.collector_id,"
+            "fencing_token=excluded.fencing_token,run_id=excluded.run_id,"
+            "acquired_at=excluded.acquired_at,expires_at=excluded.expires_at",
+            (connection_id, collector_id, token, run_id, now, expires_at),
+        )
+        database.execute(
+            "INSERT INTO sync_runs(run_id,connection_id,status,fencing_token,"
+            "diagnostics,stream,run_kind,collector_id,started_at,request_hash) "
+            "VALUES(?,?,?,?,?,?,?,?,?,?)",
+            (
+                run_id,
+                connection_id,
+                "running",
+                token,
+                json.dumps({"stream": stream}, separators=(",", ":")),
+                stream,
+                run_kind,
+                collector_id,
+                now,
+                request_hash,
+            ),
+        )
+        database.execute("COMMIT")
+        return RunLease(
+            connection_id,
+            stream,
+            run_kind,
+            collector_id,
+            token,
+            run_id,
+            now,
+            expires_at,
+        )
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()
+
+
+def assert_run_lease(
+    database: sqlite3.Connection,
+    lease: RunLease,
+    *,
+    now_epoch: int | None = None,
+) -> None:
+    """Fence a write against the current lease inside its transaction."""
+    now = social_now(now_epoch)
+    row = database.execute(
+        "SELECT collector_id,fencing_token,run_id,acquired_at,expires_at "
+        "FROM collector_leases WHERE connection_id=?",
+        (lease.connection_id,),
+    ).fetchone()
+    matches = bool(
+        row
+        and row["collector_id"] == lease.collector_id
+        and int(row["fencing_token"]) == lease.fencing_token
+        and row["run_id"] == lease.run_id
+        and int(row["acquired_at"]) <= now < int(row["expires_at"])
+    )
+    if not matches:
+        raise SocialLeaseLostError("social collector lease is stale or expired")
+
+
+def renew_run_lease(
+    root: Path,
+    lease: RunLease,
+    lease_seconds: int,
+    *,
+    now_epoch: int | None = None,
+) -> RunLease:
+    """Renew only the exact live lease; stale generations cannot revive."""
+    _validate_run_inputs(
+        lease.connection_id,
+        lease.stream,
+        lease.collector_id,
+        lease.run_kind,
+        lease_seconds,
+    )
+    now = social_now(now_epoch)
+    database = connect(root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        assert_run_lease(database, lease, now_epoch=now)
+        expires_at = now + lease_seconds
+        database.execute(
+            "UPDATE collector_leases SET expires_at=? WHERE connection_id=? "
+            "AND collector_id=? AND fencing_token=? AND run_id=?",
+            (
+                expires_at,
+                lease.connection_id,
+                lease.collector_id,
+                lease.fencing_token,
+                lease.run_id,
+            ),
+        )
+        database.execute("COMMIT")
+        return replace(lease, expires_at=expires_at)
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()
+
+
+def update_run_receipt(
+    database: sqlite3.Connection,
+    lease: RunLease,
+    status: str,
+    *,
+    resource_delta: int = 0,
+    failure_class: str | None = None,
+    retry_after: str | None = None,
+    terminal: bool = False,
+    now_epoch: int | None = None,
+) -> None:
+    """Update the receipt in the caller's content/cursor transaction."""
+    if resource_delta < 0:
+        raise SocialStoreError("receipt resource delta cannot be negative")
+    if terminal and status not in TERMINAL_RUN_STATES:
+        raise SocialStoreError("terminal receipt has an invalid status")
+    now = social_now(now_epoch)
+    assert_run_lease(database, lease, now_epoch=now)
+    updated = database.execute(
+        "UPDATE sync_runs SET status=?,resource_count=resource_count+?,"
+        "failure_class=?,retry_after=?,completed_at=? WHERE run_id=? "
+        "AND collector_id=? AND fencing_token=?",
+        (
+            status,
+            resource_delta,
+            failure_class,
+            retry_after,
+            now if terminal else None,
+            lease.run_id,
+            lease.collector_id,
+            lease.fencing_token,
+        ),
+    ).rowcount
+    if updated != 1:
+        raise SocialLeaseLostError("social run receipt is missing or stale")
+
+
+def fail_active_run(
+    root: Path,
+    lease: RunLease,
+    failure_class: str,
+    *,
+    now_epoch: int | None = None,
+) -> None:
+    """Record a privacy-safe failure while the caller owns the lease."""
+    database = connect(root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        update_run_receipt(
+            database,
+            lease,
+            "failed",
+            failure_class=failure_class,
+            terminal=True,
+            now_epoch=now_epoch,
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()
+
+
+def release_run_lease(root: Path, lease: RunLease) -> bool:
+    """Release only the exact generation, never a successor's lease."""
+    database = connect(root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        removed = database.execute(
+            "DELETE FROM collector_leases WHERE connection_id=? AND collector_id=? "
+            "AND fencing_token=? AND run_id=?",
+            (
+                lease.connection_id,
+                lease.collector_id,
+                lease.fencing_token,
+                lease.run_id,
+            ),
+        ).rowcount
+        database.execute("COMMIT")
+        return removed == 1
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()

--- a/.agents/scripts/_knowledge_social_lease.py
+++ b/.agents/scripts/_knowledge_social_lease.py
@@ -71,20 +71,19 @@ class RunReceiptUpdate:
     terminal: bool = False
 
 
+def _clock_value(explicit: int | None) -> Any:
+    """Select the real clock or an authorized deterministic test value."""
+    override = os.environ.get("AIDEVOPS_SOCIAL_NOW_EPOCH")
+    if explicit is None and override is None:
+        return int(datetime.now(UTC).timestamp())
+    if os.environ.get("AIDEVOPS_TEST_MODE") != "1":
+        raise SocialStoreError("social clock override is test-only")
+    return explicit if explicit is not None else override
+
+
 def social_now(explicit: int | None = None) -> int:
     """Return one validated clock value, with a deterministic test seam."""
-    test_mode = os.environ.get("AIDEVOPS_TEST_MODE") == "1"
-    override = os.environ.get("AIDEVOPS_SOCIAL_NOW_EPOCH")
-    if explicit is not None:
-        if not test_mode:
-            raise SocialStoreError("explicit social clock is test-only")
-        value: Any = explicit
-    elif override is not None:
-        if not test_mode:
-            raise SocialStoreError("social clock override is test-only")
-        value = override
-    else:
-        value = int(datetime.now(UTC).timestamp())
+    value = _clock_value(explicit)
     if isinstance(value, bool):
         raise SocialStoreError("social clock must be a non-negative integer")
     try:
@@ -149,6 +148,85 @@ def _abandon_expired_run(
     )
 
 
+def _prepare_connection_lease(
+    database: sqlite3.Connection, connection_id: str, now_epoch: int
+) -> None:
+    current = database.execute(
+        "SELECT * FROM collector_leases WHERE connection_id=?",
+        (connection_id,),
+    ).fetchone()
+    if current is None:
+        return
+    if int(current["expires_at"]) > now_epoch:
+        raise SocialLeaseBusyError("social connection already has a live collector")
+    _abandon_expired_run(database, current, now_epoch)
+
+
+def _upsert_collector_lease(
+    database: sqlite3.Connection, lease: RunLease
+) -> None:
+    database.execute(
+        """INSERT INTO collector_leases(
+           connection_id,collector_id,fencing_token,run_id,acquired_at,expires_at)
+           VALUES(?,?,?,?,?,?) ON CONFLICT(connection_id) DO UPDATE SET
+           collector_id=excluded.collector_id,
+           fencing_token=excluded.fencing_token,run_id=excluded.run_id,
+           acquired_at=excluded.acquired_at,expires_at=excluded.expires_at""",
+        (
+            lease.connection_id,
+            lease.collector_id,
+            lease.fencing_token,
+            lease.run_id,
+            lease.acquired_at,
+            lease.expires_at,
+        ),
+    )
+
+
+def _insert_running_receipt(
+    database: sqlite3.Connection,
+    lease: RunLease,
+    request_hash: str | None,
+) -> None:
+    database.execute(
+        """INSERT INTO sync_runs(
+           run_id,connection_id,status,fencing_token,diagnostics,stream,run_kind,
+           collector_id,started_at,request_hash) VALUES(?,?,?,?,?,?,?,?,?,?)""",
+        (
+            lease.run_id,
+            lease.connection_id,
+            "running",
+            lease.fencing_token,
+            json.dumps({"stream": lease.stream}, separators=(",", ":")),
+            lease.stream,
+            lease.run_kind,
+            lease.collector_id,
+            lease.acquired_at,
+            request_hash,
+        ),
+    )
+
+
+def _create_run_lease(
+    database: sqlite3.Connection, request: RunLeaseRequest, now_epoch: int
+) -> RunLease:
+    _prepare_connection_lease(database, request.connection_id, now_epoch)
+    token = _next_fencing_token(database, request.connection_id)
+    lease = RunLease(
+        request.connection_id,
+        request.stream,
+        request.run_kind,
+        request.collector_id,
+        token,
+        _run_id(request.connection_id, request.stream, request.run_kind, token),
+        now_epoch,
+        now_epoch + request.lease_seconds,
+    )
+    _upsert_collector_lease(database, lease)
+    _insert_running_receipt(database, lease, request.request_hash)
+    return lease
+
+
 def acquire_run_lease(
     root: Path,
     request: RunLeaseRequest,
@@ -162,63 +240,9 @@ def acquire_run_lease(
     try:
         migrate(database)
         database.execute("BEGIN IMMEDIATE")
-        current = database.execute(
-            "SELECT * FROM collector_leases WHERE connection_id=?",
-            (request.connection_id,),
-        ).fetchone()
-        if current is not None and int(current["expires_at"]) > now:
-            raise SocialLeaseBusyError("social connection already has a live collector")
-        if current is not None:
-            _abandon_expired_run(database, current, now)
-        token = _next_fencing_token(database, request.connection_id)
-        run_id = _run_id(
-            request.connection_id, request.stream, request.run_kind, token
-        )
-        expires_at = now + request.lease_seconds
-        database.execute(
-            "INSERT INTO collector_leases(connection_id,collector_id,fencing_token,"
-            "run_id,acquired_at,expires_at) VALUES(?,?,?,?,?,?) "
-            "ON CONFLICT(connection_id) DO UPDATE SET "
-            "collector_id=excluded.collector_id,"
-            "fencing_token=excluded.fencing_token,run_id=excluded.run_id,"
-            "acquired_at=excluded.acquired_at,expires_at=excluded.expires_at",
-            (
-                request.connection_id,
-                request.collector_id,
-                token,
-                run_id,
-                now,
-                expires_at,
-            ),
-        )
-        database.execute(
-            "INSERT INTO sync_runs(run_id,connection_id,status,fencing_token,"
-            "diagnostics,stream,run_kind,collector_id,started_at,request_hash) "
-            "VALUES(?,?,?,?,?,?,?,?,?,?)",
-            (
-                run_id,
-                request.connection_id,
-                "running",
-                token,
-                json.dumps({"stream": request.stream}, separators=(",", ":")),
-                request.stream,
-                request.run_kind,
-                request.collector_id,
-                now,
-                request.request_hash,
-            ),
-        )
+        lease = _create_run_lease(database, request, now)
         database.execute("COMMIT")
-        return RunLease(
-            request.connection_id,
-            request.stream,
-            request.run_kind,
-            request.collector_id,
-            token,
-            run_id,
-            now,
-            expires_at,
-        )
+        return lease
     except Exception:
         if database.in_transaction:
             database.execute("ROLLBACK")

--- a/.agents/scripts/_knowledge_social_lease.py
+++ b/.agents/scripts/_knowledge_social_lease.py
@@ -48,13 +48,43 @@ class RunLease:
     expires_at: int
 
 
+@dataclass(frozen=True)
+class RunLeaseRequest:
+    """Validated inputs for acquiring one connection-scoped run lease."""
+
+    connection_id: str
+    stream: str
+    collector_id: str
+    run_kind: str
+    lease_seconds: int
+    request_hash: str | None = None
+
+
+@dataclass(frozen=True)
+class RunReceiptUpdate:
+    """Privacy-safe state transition for one fenced run receipt."""
+
+    status: str
+    resource_delta: int = 0
+    failure_class: str | None = None
+    retry_after: str | None = None
+    terminal: bool = False
+
+
 def social_now(explicit: int | None = None) -> int:
     """Return one validated clock value, with a deterministic test seam."""
+    test_mode = os.environ.get("AIDEVOPS_TEST_MODE") == "1"
+    override = os.environ.get("AIDEVOPS_SOCIAL_NOW_EPOCH")
     if explicit is not None:
+        if not test_mode:
+            raise SocialStoreError("explicit social clock is test-only")
         value: Any = explicit
+    elif override is not None:
+        if not test_mode:
+            raise SocialStoreError("social clock override is test-only")
+        value = override
     else:
-        override = os.environ.get("AIDEVOPS_SOCIAL_NOW_EPOCH")
-        value = override if override is not None else int(datetime.now(UTC).timestamp())
+        value = int(datetime.now(UTC).timestamp())
     if isinstance(value, bool):
         raise SocialStoreError("social clock must be a non-negative integer")
     try:
@@ -66,26 +96,24 @@ def social_now(explicit: int | None = None) -> int:
     return epoch
 
 
-def _validate_run_inputs(
-    connection_id: str,
-    stream: str,
-    collector_id: str,
-    run_kind: str,
-    lease_seconds: int,
-) -> tuple[str, str, str]:
-    connection = validate_opaque(connection_id, "connection_id")
-    collector = validate_opaque(collector_id, "collector_id")
-    if not isinstance(stream, str) or not stream or len(stream) > 127:
+def _validate_run_request(request: RunLeaseRequest) -> RunLeaseRequest:
+    connection = validate_opaque(request.connection_id, "connection_id")
+    collector = validate_opaque(request.collector_id, "collector_id")
+    if (
+        not isinstance(request.stream, str)
+        or not request.stream
+        or len(request.stream) > 127
+    ):
         raise SocialStoreError("stream must be non-empty text")
-    if run_kind not in RUN_KINDS:
+    if request.run_kind not in RUN_KINDS:
         raise SocialStoreError("run_kind must be sync or reconcile")
     if (
-        isinstance(lease_seconds, bool)
-        or not isinstance(lease_seconds, int)
-        or not 1 <= lease_seconds <= 86_400
+        isinstance(request.lease_seconds, bool)
+        or not isinstance(request.lease_seconds, int)
+        or not 1 <= request.lease_seconds <= 86_400
     ):
         raise SocialStoreError("lease_seconds must be between 1 and 86400")
-    return connection, stream, collector
+    return replace(request, connection_id=connection, collector_id=collector)
 
 
 def _run_id(
@@ -123,19 +151,12 @@ def _abandon_expired_run(
 
 def acquire_run_lease(
     root: Path,
-    connection_id: str,
-    stream: str,
-    collector_id: str,
-    run_kind: str,
-    lease_seconds: int,
+    request: RunLeaseRequest,
     *,
     now_epoch: int | None = None,
-    request_hash: str | None = None,
 ) -> RunLease:
     """Elect one collector and create its running receipt atomically."""
-    connection_id, stream, collector_id = _validate_run_inputs(
-        connection_id, stream, collector_id, run_kind, lease_seconds
-    )
+    request = _validate_run_request(request)
     now = social_now(now_epoch)
     database = connect(root)
     try:
@@ -143,15 +164,17 @@ def acquire_run_lease(
         database.execute("BEGIN IMMEDIATE")
         current = database.execute(
             "SELECT * FROM collector_leases WHERE connection_id=?",
-            (connection_id,),
+            (request.connection_id,),
         ).fetchone()
         if current is not None and int(current["expires_at"]) > now:
             raise SocialLeaseBusyError("social connection already has a live collector")
         if current is not None:
             _abandon_expired_run(database, current, now)
-        token = _next_fencing_token(database, connection_id)
-        run_id = _run_id(connection_id, stream, run_kind, token)
-        expires_at = now + lease_seconds
+        token = _next_fencing_token(database, request.connection_id)
+        run_id = _run_id(
+            request.connection_id, request.stream, request.run_kind, token
+        )
+        expires_at = now + request.lease_seconds
         database.execute(
             "INSERT INTO collector_leases(connection_id,collector_id,fencing_token,"
             "run_id,acquired_at,expires_at) VALUES(?,?,?,?,?,?) "
@@ -159,7 +182,14 @@ def acquire_run_lease(
             "collector_id=excluded.collector_id,"
             "fencing_token=excluded.fencing_token,run_id=excluded.run_id,"
             "acquired_at=excluded.acquired_at,expires_at=excluded.expires_at",
-            (connection_id, collector_id, token, run_id, now, expires_at),
+            (
+                request.connection_id,
+                request.collector_id,
+                token,
+                run_id,
+                now,
+                expires_at,
+            ),
         )
         database.execute(
             "INSERT INTO sync_runs(run_id,connection_id,status,fencing_token,"
@@ -167,23 +197,23 @@ def acquire_run_lease(
             "VALUES(?,?,?,?,?,?,?,?,?,?)",
             (
                 run_id,
-                connection_id,
+                request.connection_id,
                 "running",
                 token,
-                json.dumps({"stream": stream}, separators=(",", ":")),
-                stream,
-                run_kind,
-                collector_id,
+                json.dumps({"stream": request.stream}, separators=(",", ":")),
+                request.stream,
+                request.run_kind,
+                request.collector_id,
                 now,
-                request_hash,
+                request.request_hash,
             ),
         )
         database.execute("COMMIT")
         return RunLease(
-            connection_id,
-            stream,
-            run_kind,
-            collector_id,
+            request.connection_id,
+            request.stream,
+            request.run_kind,
+            request.collector_id,
             token,
             run_id,
             now,
@@ -210,14 +240,17 @@ def assert_run_lease(
         "FROM collector_leases WHERE connection_id=?",
         (lease.connection_id,),
     ).fetchone()
-    matches = bool(
-        row
-        and row["collector_id"] == lease.collector_id
-        and int(row["fencing_token"]) == lease.fencing_token
-        and row["run_id"] == lease.run_id
-        and int(row["acquired_at"]) <= now < int(row["expires_at"])
+    if row is None:
+        raise SocialLeaseLostError("social collector lease is stale or expired")
+    stored_identity = (
+        row["collector_id"],
+        int(row["fencing_token"]),
+        row["run_id"],
     )
-    if not matches:
+    expected_identity = (lease.collector_id, lease.fencing_token, lease.run_id)
+    if stored_identity != expected_identity:
+        raise SocialLeaseLostError("social collector lease is stale or expired")
+    if int(row["acquired_at"]) > now or now >= int(row["expires_at"]):
         raise SocialLeaseLostError("social collector lease is stale or expired")
 
 
@@ -229,12 +262,14 @@ def renew_run_lease(
     now_epoch: int | None = None,
 ) -> RunLease:
     """Renew only the exact live lease; stale generations cannot revive."""
-    _validate_run_inputs(
-        lease.connection_id,
-        lease.stream,
-        lease.collector_id,
-        lease.run_kind,
-        lease_seconds,
+    _validate_run_request(
+        RunLeaseRequest(
+            lease.connection_id,
+            lease.stream,
+            lease.collector_id,
+            lease.run_kind,
+            lease_seconds,
+        )
     )
     now = social_now(now_epoch)
     database = connect(root)
@@ -267,18 +302,14 @@ def renew_run_lease(
 def update_run_receipt(
     database: sqlite3.Connection,
     lease: RunLease,
-    status: str,
+    update: RunReceiptUpdate,
     *,
-    resource_delta: int = 0,
-    failure_class: str | None = None,
-    retry_after: str | None = None,
-    terminal: bool = False,
     now_epoch: int | None = None,
 ) -> None:
     """Update the receipt in the caller's content/cursor transaction."""
-    if resource_delta < 0:
+    if update.resource_delta < 0:
         raise SocialStoreError("receipt resource delta cannot be negative")
-    if terminal and status not in TERMINAL_RUN_STATES:
+    if update.terminal and update.status not in TERMINAL_RUN_STATES:
         raise SocialStoreError("terminal receipt has an invalid status")
     now = social_now(now_epoch)
     assert_run_lease(database, lease, now_epoch=now)
@@ -287,11 +318,11 @@ def update_run_receipt(
         "failure_class=?,retry_after=?,completed_at=? WHERE run_id=? "
         "AND collector_id=? AND fencing_token=?",
         (
-            status,
-            resource_delta,
-            failure_class,
-            retry_after,
-            now if terminal else None,
+            update.status,
+            update.resource_delta,
+            update.failure_class,
+            update.retry_after,
+            now if update.terminal else None,
             lease.run_id,
             lease.collector_id,
             lease.fencing_token,
@@ -316,9 +347,9 @@ def fail_active_run(
         update_run_receipt(
             database,
             lease,
-            "failed",
-            failure_class=failure_class,
-            terminal=True,
+            RunReceiptUpdate(
+                "failed", failure_class=failure_class, terminal=True
+            ),
             now_epoch=now_epoch,
         )
         database.execute("COMMIT")

--- a/.agents/scripts/_knowledge_social_reconcile.py
+++ b/.agents/scripts/_knowledge_social_reconcile.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fenced missing-first reconciliation for social corpus snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_lease import (
+    RunLease,
+    assert_run_lease,
+    social_now,
+    update_run_receipt,
+)
+from knowledge_social_import import canonical_json, reject_credentials, required_text
+from knowledge_social_store import SocialStoreError, connect, migrate, write_raw_batch
+
+
+@dataclass(frozen=True)
+class ReconciliationSnapshot:
+    """Validated complete or partial provider reconciliation evidence."""
+
+    provider: str
+    observed_at: str
+    complete: bool
+    objects: frozenset[tuple[str, str]]
+    activities: frozenset[tuple[str, str]]
+    payload: bytes
+    request_hash: str
+    observed_epoch: float
+
+
+def _records(
+    payload: dict[str, Any], key: str, type_key: str
+) -> frozenset[tuple[str, str]]:
+    value = payload.get(key, [])
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise SocialStoreError(f"reconciliation {key} must be an array of objects")
+    records = {
+        (required_text(record, type_key), required_text(record, "remote_id"))
+        for record in value
+    }
+    if len(records) != len(value):
+        raise SocialStoreError(f"reconciliation {key} contains duplicate identities")
+    return frozenset(records)
+
+
+def _read_private_snapshot(path: Path) -> dict[str, Any]:
+    try:
+        before = path.lstat()
+    except OSError as error:
+        raise SocialStoreError("reconciliation snapshot is unavailable") from error
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise SocialStoreError("reconciliation snapshot must be a regular file")
+    if hasattr(os, "getuid") and before.st_uid != os.getuid():
+        raise SocialStoreError("reconciliation snapshot owner must be the current user")
+    if stat.S_IMODE(before.st_mode) != 0o600:
+        raise SocialStoreError("reconciliation snapshot permissions must be 0600")
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise SocialStoreError("reconciliation snapshot replacement detected") from error
+    try:
+        with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+            after = os.fstat(handle.fileno())
+            if (before.st_dev, before.st_ino) != (after.st_dev, after.st_ino):
+                raise SocialStoreError("reconciliation snapshot replacement detected")
+            parsed = json.load(handle)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SocialStoreError("reconciliation snapshot is not valid UTF-8 JSON") from error
+    if not isinstance(parsed, dict):
+        raise SocialStoreError("reconciliation snapshot root must be an object")
+    return parsed
+
+
+def _observed_epoch(value: str) -> float:
+    try:
+        observed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise SocialStoreError("reconciliation observed_at is invalid") from error
+    if observed.tzinfo is None:
+        raise SocialStoreError("reconciliation observed_at requires a timezone")
+    return observed.timestamp()
+
+
+def load_reconciliation_snapshot(path: Path) -> ReconciliationSnapshot:
+    """Read private evidence and reject credential-shaped material."""
+    parsed = _read_private_snapshot(path)
+    reject_credentials(parsed)
+    complete = parsed.get("complete")
+    if not isinstance(complete, bool):
+        raise SocialStoreError("reconciliation complete must be boolean")
+    observed_at = required_text(parsed, "observed_at")
+    payload = canonical_json(parsed).encode("utf-8")
+    return ReconciliationSnapshot(
+        required_text(parsed, "provider"),
+        observed_at,
+        complete,
+        _records(parsed, "objects", "object_type"),
+        _records(parsed, "activities", "activity_type"),
+        payload,
+        hashlib.sha256(payload).hexdigest(),
+        _observed_epoch(observed_at),
+    )
+
+
+def _connection_provider(
+    database: sqlite3.Connection, connection_id: str, stream: str
+) -> str:
+    row = database.execute(
+        "SELECT provider,enabled_streams FROM connections WHERE connection_id=?",
+        (connection_id,),
+    ).fetchone()
+    if row is None:
+        raise SocialStoreError("reconciliation connection is not configured")
+    try:
+        streams = json.loads(row["enabled_streams"])
+    except json.JSONDecodeError as error:
+        raise SocialStoreError("stored social streams are invalid") from error
+    if not isinstance(streams, list) or stream not in streams:
+        raise SocialStoreError("reconciliation stream is not enabled")
+    return str(row["provider"])
+
+
+def _validate_snapshot_order(
+    database: sqlite3.Connection,
+    lease: RunLease,
+    snapshot: ReconciliationSnapshot,
+) -> None:
+    rows = database.execute(
+        "SELECT completed_at,request_hash FROM fetch_batches WHERE connection_id=? "
+        "AND stream=? AND terminal_status='reconciliation'",
+        (lease.connection_id, f"reconcile:{lease.stream}"),
+    ).fetchall()
+    for row in rows:
+        previous_epoch = _observed_epoch(str(row["completed_at"]))
+        if previous_epoch > snapshot.observed_epoch:
+            raise SocialStoreError("reconciliation snapshot is older than stored evidence")
+        if (
+            previous_epoch == snapshot.observed_epoch
+            and row["request_hash"] != snapshot.request_hash
+        ):
+            raise SocialStoreError("reconciliation snapshot conflicts at observed_at")
+
+
+def _inventory(
+    database: sqlite3.Connection, connection_id: str, stream: str
+) -> set[tuple[str, str, str]]:
+    inventory = {
+        ("object", str(row["object_type"]), str(row["remote_id"]))
+        for row in database.execute(
+            "SELECT o.object_type,o.remote_id FROM objects o "
+            "JOIN fetch_batches b ON b.batch_id=o.batch_id "
+            "WHERE b.connection_id=? AND b.stream=? UNION "
+            "SELECT o.object_type,o.remote_id FROM objects o "
+            "JOIN activities a ON a.provider=o.provider "
+            "AND a.object_remote_id=o.remote_id "
+            "JOIN fetch_batches b ON b.batch_id=a.batch_id "
+            "WHERE b.connection_id=? AND b.stream=?",
+            (connection_id, stream, connection_id, stream),
+        ).fetchall()
+    }
+    inventory.update(
+        {
+            ("activity", str(row["activity_type"]), str(row["remote_id"]))
+            for row in database.execute(
+                "SELECT DISTINCT a.activity_type,a.remote_id FROM activities a "
+                "JOIN fetch_batches b ON b.batch_id=a.batch_id "
+                "WHERE b.connection_id=? AND b.stream=?",
+                (connection_id, stream),
+            ).fetchall()
+        }
+    )
+    return inventory
+
+
+def _previous_missing_at(
+    database: sqlite3.Connection,
+    provider: str,
+    lease: RunLease,
+    item: tuple[str, str, str],
+) -> str | None:
+    row = database.execute(
+        "SELECT first_missing_at FROM reconciliation_items WHERE provider=? "
+        "AND connection_id=? AND stream=? AND item_kind=? AND item_type=? "
+        "AND remote_id=?",
+        (provider, lease.connection_id, lease.stream, *item),
+    ).fetchone()
+    if row and row["first_missing_at"]:
+        return str(row["first_missing_at"])
+    return None
+
+
+def _upsert_state(
+    database: sqlite3.Connection,
+    provider: str,
+    lease: RunLease,
+    snapshot: ReconciliationSnapshot,
+    item: tuple[str, str, str],
+    status: str,
+) -> None:
+    first_missing = None
+    if status == "missing":
+        first_missing = _previous_missing_at(database, provider, lease, item)
+        first_missing = first_missing or snapshot.observed_at
+    database.execute(
+        "INSERT INTO reconciliation_items(provider,connection_id,stream,item_kind,"
+        "item_type,remote_id,status,first_missing_at,last_observed_at,run_id) "
+        "VALUES(?,?,?,?,?,?,?,?,?,?) ON CONFLICT(provider,connection_id,stream,"
+        "item_kind,item_type,remote_id) DO UPDATE SET status=excluded.status,"
+        "first_missing_at=excluded.first_missing_at,"
+        "last_observed_at=excluded.last_observed_at,run_id=excluded.run_id",
+        (
+            provider,
+            lease.connection_id,
+            lease.stream,
+            *item,
+            status,
+            first_missing,
+            snapshot.observed_at,
+            lease.run_id,
+        ),
+    )
+    if item[0] == "activity":
+        database.execute(
+            "UPDATE activities SET state=?,observed_at=? WHERE provider=? "
+            "AND activity_type=? AND remote_id=?",
+            (
+                "active" if status == "present" else "missing",
+                snapshot.observed_at,
+                provider,
+                item[1],
+                item[2],
+            ),
+        )
+
+
+def _evidence_payload(
+    lease: RunLease, snapshot: ReconciliationSnapshot
+) -> bytes:
+    return canonical_json(
+        {
+            "provider": snapshot.provider,
+            "connection_id": lease.connection_id,
+            "stream": lease.stream,
+            "snapshot": json.loads(snapshot.payload),
+        }
+    ).encode("utf-8")
+
+
+def _insert_evidence_batch(
+    database: sqlite3.Connection,
+    root: Path,
+    lease: RunLease,
+    snapshot: ReconciliationSnapshot,
+) -> None:
+    batch_id, blob_ref = write_raw_batch(
+        root,
+        snapshot.provider,
+        lease.connection_id,
+        _evidence_payload(lease, snapshot),
+    )
+    database.execute(
+        "INSERT INTO fetch_batches(batch_id,provider,connection_id,stream,"
+        "request_hash,response_hash,blob_ref,resource_count,budget_units,"
+        "started_at,completed_at,terminal_status) VALUES(?,?,?,?,?,?,?,?,?,?,?,?) "
+        "ON CONFLICT(batch_id) DO NOTHING",
+        (
+            batch_id,
+            snapshot.provider,
+            lease.connection_id,
+            f"reconcile:{lease.stream}",
+            snapshot.request_hash,
+            batch_id,
+            blob_ref,
+            len(snapshot.objects) + len(snapshot.activities),
+            0,
+            snapshot.observed_at,
+            snapshot.observed_at,
+            "reconciliation",
+        ),
+    )
+
+
+def _present_items(
+    snapshot: ReconciliationSnapshot,
+) -> set[tuple[str, str, str]]:
+    present = {
+        ("object", item_type, remote_id)
+        for item_type, remote_id in snapshot.objects
+    }
+    present.update(
+        {
+            ("activity", item_type, remote_id)
+            for item_type, remote_id in snapshot.activities
+        }
+    )
+    return present
+
+
+def _apply_states(
+    database: sqlite3.Connection,
+    provider: str,
+    lease: RunLease,
+    snapshot: ReconciliationSnapshot,
+    inventory: set[tuple[str, str, str]],
+) -> tuple[int, int, int]:
+    present = _present_items(snapshot)
+    present_count = 0
+    missing_count = 0
+    for item in sorted(inventory):
+        if item in present:
+            _upsert_state(database, provider, lease, snapshot, item, "present")
+            present_count += 1
+        elif snapshot.complete:
+            _upsert_state(database, provider, lease, snapshot, item, "missing")
+            missing_count += 1
+    return present_count, missing_count, len(present - inventory)
+
+
+def reconcile_snapshot(
+    root: Path,
+    lease: RunLease,
+    snapshot: ReconciliationSnapshot,
+    *,
+    now_epoch: int | None = None,
+) -> dict[str, Any]:
+    """Commit missing-first state and its receipt under one fence."""
+    now = social_now(now_epoch)
+    database = connect(root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        assert_run_lease(database, lease, now_epoch=now)
+        provider = _connection_provider(
+            database, lease.connection_id, lease.stream
+        )
+        if provider != snapshot.provider:
+            raise SocialStoreError("reconciliation provider does not match connection")
+        _validate_snapshot_order(database, lease, snapshot)
+        _insert_evidence_batch(database, root, lease, snapshot)
+        inventory = _inventory(database, lease.connection_id, lease.stream)
+        present_count, missing_count, unknown_count = _apply_states(
+            database, provider, lease, snapshot, inventory
+        )
+        update_run_receipt(
+            database,
+            lease,
+            "complete",
+            resource_delta=len(inventory),
+            terminal=True,
+            now_epoch=now,
+        )
+        database.execute("COMMIT")
+        return {
+            "status": "complete",
+            "run_id": lease.run_id,
+            "present": present_count,
+            "missing": missing_count,
+            "unknown": unknown_count,
+            "complete_snapshot": snapshot.complete,
+        }
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    finally:
+        database.close()

--- a/.agents/scripts/_knowledge_social_reconcile.py
+++ b/.agents/scripts/_knowledge_social_reconcile.py
@@ -55,7 +55,7 @@ def _records(
     return frozenset(records)
 
 
-def _read_private_snapshot(path: Path) -> dict[str, Any]:
+def _snapshot_stat(path: Path) -> os.stat_result:
     try:
         before = path.lstat()
     except OSError as error:
@@ -66,13 +66,22 @@ def _read_private_snapshot(path: Path) -> dict[str, Any]:
         raise SocialStoreError("reconciliation snapshot owner must be the current user")
     if stat.S_IMODE(before.st_mode) != 0o600:
         raise SocialStoreError("reconciliation snapshot permissions must be 0600")
+    return before
+
+
+def _open_snapshot(path: Path) -> int:
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     try:
-        descriptor = os.open(path, flags)
+        return os.open(path, flags)
     except OSError as error:
         raise SocialStoreError("reconciliation snapshot replacement detected") from error
+
+
+def _load_snapshot_json(
+    descriptor: int, before: os.stat_result
+) -> dict[str, Any]:
     try:
         with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
             after = os.fstat(handle.fileno())
@@ -84,6 +93,11 @@ def _read_private_snapshot(path: Path) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise SocialStoreError("reconciliation snapshot root must be an object")
     return parsed
+
+
+def _read_private_snapshot(path: Path) -> dict[str, Any]:
+    before = _snapshot_stat(path)
+    return _load_snapshot_json(_open_snapshot(path), before)
 
 
 def _observed_epoch(value: str) -> float:
@@ -162,14 +176,14 @@ def _inventory(
     inventory = {
         ("object", str(row["object_type"]), str(row["remote_id"]))
         for row in database.execute(
-            "SELECT o.object_type,o.remote_id FROM objects o "
-            "JOIN fetch_batches b ON b.batch_id=o.batch_id "
-            "WHERE b.connection_id=? AND b.stream=? UNION "
-            "SELECT o.object_type,o.remote_id FROM objects o "
-            "JOIN activities a ON a.provider=o.provider "
-            "AND a.object_remote_id=o.remote_id "
-            "JOIN fetch_batches b ON b.batch_id=a.batch_id "
-            "WHERE b.connection_id=? AND b.stream=?",
+            """SELECT o.object_type,o.remote_id FROM objects o
+               JOIN fetch_batches b ON b.batch_id=o.batch_id
+               WHERE b.connection_id=? AND b.stream=? UNION
+               SELECT o.object_type,o.remote_id FROM objects o
+               JOIN activities a ON a.provider=o.provider
+                 AND a.object_remote_id=o.remote_id
+               JOIN fetch_batches b ON b.batch_id=a.batch_id
+               WHERE b.connection_id=? AND b.stream=?""",
             (connection_id, stream, connection_id, stream),
         ).fetchall()
     }
@@ -177,9 +191,9 @@ def _inventory(
         {
             ("activity", str(row["activity_type"]), str(row["remote_id"]))
             for row in database.execute(
-                "SELECT DISTINCT a.activity_type,a.remote_id FROM activities a "
-                "JOIN fetch_batches b ON b.batch_id=a.batch_id "
-                "WHERE b.connection_id=? AND b.stream=?",
+                """SELECT DISTINCT a.activity_type,a.remote_id FROM activities a
+                   JOIN fetch_batches b ON b.batch_id=a.batch_id
+                   WHERE b.connection_id=? AND b.stream=?""",
                 (connection_id, stream),
             ).fetchall()
         }

--- a/.agents/scripts/_knowledge_social_reconcile.py
+++ b/.agents/scripts/_knowledge_social_reconcile.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from _knowledge_social_lease import (
     RunLease,
+    RunReceiptUpdate,
     assert_run_lease,
     social_now,
     update_run_receipt,
@@ -205,7 +206,6 @@ def _previous_missing_at(
 
 def _upsert_state(
     database: sqlite3.Connection,
-    provider: str,
     lease: RunLease,
     snapshot: ReconciliationSnapshot,
     item: tuple[str, str, str],
@@ -213,7 +213,9 @@ def _upsert_state(
 ) -> None:
     first_missing = None
     if status == "missing":
-        first_missing = _previous_missing_at(database, provider, lease, item)
+        first_missing = _previous_missing_at(
+            database, snapshot.provider, lease, item
+        )
         first_missing = first_missing or snapshot.observed_at
     database.execute(
         "INSERT INTO reconciliation_items(provider,connection_id,stream,item_kind,"
@@ -223,7 +225,7 @@ def _upsert_state(
         "first_missing_at=excluded.first_missing_at,"
         "last_observed_at=excluded.last_observed_at,run_id=excluded.run_id",
         (
-            provider,
+            snapshot.provider,
             lease.connection_id,
             lease.stream,
             *item,
@@ -240,7 +242,7 @@ def _upsert_state(
             (
                 "active" if status == "present" else "missing",
                 snapshot.observed_at,
-                provider,
+                snapshot.provider,
                 item[1],
                 item[2],
             ),
@@ -312,7 +314,6 @@ def _present_items(
 
 def _apply_states(
     database: sqlite3.Connection,
-    provider: str,
     lease: RunLease,
     snapshot: ReconciliationSnapshot,
     inventory: set[tuple[str, str, str]],
@@ -322,10 +323,10 @@ def _apply_states(
     missing_count = 0
     for item in sorted(inventory):
         if item in present:
-            _upsert_state(database, provider, lease, snapshot, item, "present")
+            _upsert_state(database, lease, snapshot, item, "present")
             present_count += 1
         elif snapshot.complete:
-            _upsert_state(database, provider, lease, snapshot, item, "missing")
+            _upsert_state(database, lease, snapshot, item, "missing")
             missing_count += 1
     return present_count, missing_count, len(present - inventory)
 
@@ -353,14 +354,14 @@ def reconcile_snapshot(
         _insert_evidence_batch(database, root, lease, snapshot)
         inventory = _inventory(database, lease.connection_id, lease.stream)
         present_count, missing_count, unknown_count = _apply_states(
-            database, provider, lease, snapshot, inventory
+            database, lease, snapshot, inventory
         )
         update_run_receipt(
             database,
             lease,
-            "complete",
-            resource_delta=len(inventory),
-            terminal=True,
+            RunReceiptUpdate(
+                "complete", resource_delta=len(inventory), terminal=True
+            ),
             now_epoch=now,
         )
         database.execute("COMMIT")

--- a/.agents/scripts/_knowledge_social_schedule.py
+++ b/.agents/scripts/_knowledge_social_schedule.py
@@ -95,6 +95,13 @@ def _cursor_due_at(
     return last_success + interval if last_success is not None else 0
 
 
+def _rate_limit_due_at(run: sqlite3.Row) -> int | None:
+    if run["status"] != "paused" or run["failure_class"] != "rate_limit":
+        return None
+    retry_after = str(run["retry_after"] or "")
+    return int(retry_after) if retry_after.isdigit() else None
+
+
 def _due_at(
     database: sqlite3.Connection,
     connection_id: str,
@@ -103,21 +110,64 @@ def _due_at(
     interval: int,
 ) -> int:
     run = _last_run(database, connection_id, stream, run_kind)
-    if run is not None and run["status"] == "running":
+    if run is None:
+        return _cursor_due_at(database, connection_id, stream, interval) if run_kind == "sync" else 0
+    if run["status"] == "running":
         return _running_due_at(database, connection_id)
-    if run is not None and run["completed_at"] is not None:
+    if run["completed_at"] is not None:
         due_at = int(run["completed_at"]) + interval
-        retry_after = run["retry_after"]
-        if (
-            run["status"] == "paused"
-            and run["failure_class"] == "rate_limit"
-            and str(retry_after or "").isdigit()
-        ):
-            due_at = int(retry_after)
-        return due_at
+        rate_limit_due = _rate_limit_due_at(run)
+        return rate_limit_due if rate_limit_due is not None else due_at
     if run_kind == "sync":
         return _cursor_due_at(database, connection_id, stream, interval)
     return 0
+
+
+def _validate_due_inputs(run_kind: str, interval_seconds: int | None) -> None:
+    if run_kind not in RUN_KINDS:
+        raise SocialStoreError("run_kind must be sync or reconcile")
+    if interval_seconds is not None and (
+        isinstance(interval_seconds, bool) or interval_seconds < 60
+    ):
+        raise SocialStoreError("interval_seconds must be at least 60")
+
+
+def _schedule_settings(run_kind: str) -> tuple[str, int]:
+    if run_kind == "sync":
+        return "sync_interval_seconds", DEFAULT_SYNC_INTERVAL
+    return "reconcile_interval_seconds", DEFAULT_RECONCILE_INTERVAL
+
+
+def _connection_due_plan(
+    database: sqlite3.Connection,
+    row: sqlite3.Row,
+    run_kind: str,
+    now_epoch: int,
+    interval_seconds: int | None,
+) -> list[dict[str, Any]]:
+    key, fallback = _schedule_settings(run_kind)
+    policy = _parse_json_object(row["policy_json"], "policy")
+    interval = (
+        interval_seconds
+        if interval_seconds is not None
+        else _interval(policy, key, fallback)
+    )
+    streams = sorted(set(_parse_json_array(row["enabled_streams"], "streams")))
+    due: list[dict[str, Any]] = []
+    for stream in streams:
+        due_at = _due_at(
+            database, row["connection_id"], stream, run_kind, interval
+        )
+        if due_at <= now_epoch:
+            due.append(
+                {
+                    "connection_id": row["connection_id"],
+                    "stream": stream,
+                    "run_kind": run_kind,
+                    "due_at": due_at,
+                }
+            )
+    return due
 
 
 def due_plan(
@@ -128,12 +178,7 @@ def due_plan(
     interval_seconds: int | None = None,
 ) -> list[dict[str, Any]]:
     """Return a stable list of due opaque connection streams."""
-    if run_kind not in RUN_KINDS:
-        raise SocialStoreError("run_kind must be sync or reconcile")
-    if interval_seconds is not None and (
-        isinstance(interval_seconds, bool) or interval_seconds < 60
-    ):
-        raise SocialStoreError("interval_seconds must be at least 60")
+    _validate_due_inputs(run_kind, interval_seconds)
     now = social_now(now_epoch)
     database = connect_read_only(root)
     try:
@@ -144,38 +189,11 @@ def due_plan(
         ).fetchall()
         due: list[dict[str, Any]] = []
         for row in rows:
-            policy = _parse_json_object(row["policy_json"], "policy")
-            fallback = (
-                DEFAULT_SYNC_INTERVAL
-                if run_kind == "sync"
-                else DEFAULT_RECONCILE_INTERVAL
-            )
-            key = (
-                "sync_interval_seconds"
-                if run_kind == "sync"
-                else "reconcile_interval_seconds"
-            )
-            interval = (
-                interval_seconds
-                if interval_seconds is not None
-                else _interval(policy, key, fallback)
-            )
-            streams = sorted(
-                set(_parse_json_array(row["enabled_streams"], "streams"))
-            )
-            for stream in streams:
-                due_at = _due_at(
-                    database, row["connection_id"], stream, run_kind, interval
+            due.extend(
+                _connection_due_plan(
+                    database, row, run_kind, now, interval_seconds
                 )
-                if due_at <= now:
-                    due.append(
-                        {
-                            "connection_id": row["connection_id"],
-                            "stream": stream,
-                            "run_kind": run_kind,
-                            "due_at": due_at,
-                        }
-                    )
+            )
         return due
     finally:
         database.close()
@@ -192,18 +210,22 @@ def run_receipts(
     database = connect_read_only(root)
     try:
         require_schema(database)
-        query = (
-            "SELECT run_id,connection_id,stream,run_kind,status,resource_count,"
-            "failure_class,retry_after,fencing_token,collector_id,started_at,"
-            "completed_at,request_hash FROM sync_runs"
-        )
-        parameters: list[Any] = []
         if connection_id is not None:
-            query += " WHERE connection_id=?"
-            parameters.append(connection_id)
-        query += " ORDER BY started_at DESC,rowid DESC LIMIT ?"
-        parameters.append(limit)
-        rows = database.execute(query, parameters).fetchall()
+            rows = database.execute(
+                """SELECT run_id,connection_id,stream,run_kind,status,resource_count,
+                   failure_class,retry_after,fencing_token,collector_id,started_at,
+                   completed_at,request_hash FROM sync_runs WHERE connection_id=?
+                   ORDER BY started_at DESC,rowid DESC LIMIT ?""",
+                (connection_id, limit),
+            ).fetchall()
+        else:
+            rows = database.execute(
+                """SELECT run_id,connection_id,stream,run_kind,status,resource_count,
+                   failure_class,retry_after,fencing_token,collector_id,started_at,
+                   completed_at,request_hash FROM sync_runs
+                   ORDER BY started_at DESC,rowid DESC LIMIT ?""",
+                (limit,),
+            ).fetchall()
         return [dict(row) for row in rows]
     finally:
         database.close()

--- a/.agents/scripts/_knowledge_social_schedule.py
+++ b/.agents/scripts/_knowledge_social_schedule.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Privacy-safe deterministic social due plans and receipt reads."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_lease import RUN_KINDS, social_now
+from knowledge_social_store import (
+    SocialStoreError,
+    connect_read_only,
+    require_schema,
+    validate_opaque,
+)
+
+DEFAULT_SYNC_INTERVAL = 86_400
+DEFAULT_RECONCILE_INTERVAL = 604_800
+
+
+def _parse_json_object(value: str, field: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise SocialStoreError(f"stored social {field} is invalid") from error
+    if not isinstance(parsed, dict):
+        raise SocialStoreError(f"stored social {field} must be an object")
+    return parsed
+
+
+def _parse_json_array(value: str, field: str) -> list[str]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise SocialStoreError(f"stored social {field} is invalid") from error
+    if not isinstance(parsed, list) or any(not isinstance(item, str) for item in parsed):
+        raise SocialStoreError(f"stored social {field} must be an array of text")
+    return parsed
+
+
+def _interval(policy: dict[str, Any], key: str, fallback: int) -> int:
+    value = policy.get(key, fallback)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 60:
+        raise SocialStoreError(f"stored social {key} must be an integer of at least 60")
+    return value
+
+
+def _iso_epoch(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise SocialStoreError("stored social timestamp is invalid") from error
+    if parsed.tzinfo is None:
+        raise SocialStoreError("stored social timestamp requires a timezone")
+    return int(parsed.timestamp())
+
+
+def _last_run(
+    database: sqlite3.Connection, connection_id: str, stream: str, run_kind: str
+) -> sqlite3.Row | None:
+    return database.execute(
+        "SELECT status,failure_class,completed_at,retry_after FROM sync_runs "
+        "WHERE connection_id=? AND stream=? AND run_kind=? "
+        "ORDER BY started_at DESC,rowid DESC LIMIT 1",
+        (connection_id, stream, run_kind),
+    ).fetchone()
+
+
+def _running_due_at(database: sqlite3.Connection, connection_id: str) -> int:
+    row = database.execute(
+        "SELECT expires_at FROM collector_leases WHERE connection_id=?",
+        (connection_id,),
+    ).fetchone()
+    return int(row["expires_at"]) if row else 0
+
+
+def _cursor_due_at(
+    database: sqlite3.Connection,
+    connection_id: str,
+    stream: str,
+    interval: int,
+) -> int:
+    cursor = database.execute(
+        "SELECT last_success_at FROM sync_cursors WHERE connection_id=? AND stream=?",
+        (connection_id, stream),
+    ).fetchone()
+    last_success = _iso_epoch(cursor["last_success_at"]) if cursor else None
+    return last_success + interval if last_success is not None else 0
+
+
+def _due_at(
+    database: sqlite3.Connection,
+    connection_id: str,
+    stream: str,
+    run_kind: str,
+    interval: int,
+) -> int:
+    run = _last_run(database, connection_id, stream, run_kind)
+    if run is not None and run["status"] == "running":
+        return _running_due_at(database, connection_id)
+    if run is not None and run["completed_at"] is not None:
+        due_at = int(run["completed_at"]) + interval
+        retry_after = run["retry_after"]
+        if (
+            run["status"] == "paused"
+            and run["failure_class"] == "rate_limit"
+            and str(retry_after or "").isdigit()
+        ):
+            due_at = int(retry_after)
+        return due_at
+    if run_kind == "sync":
+        return _cursor_due_at(database, connection_id, stream, interval)
+    return 0
+
+
+def due_plan(
+    root: Path,
+    run_kind: str,
+    *,
+    now_epoch: int | None = None,
+    interval_seconds: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return a stable list of due opaque connection streams."""
+    if run_kind not in RUN_KINDS:
+        raise SocialStoreError("run_kind must be sync or reconcile")
+    if interval_seconds is not None and (
+        isinstance(interval_seconds, bool) or interval_seconds < 60
+    ):
+        raise SocialStoreError("interval_seconds must be at least 60")
+    now = social_now(now_epoch)
+    database = connect_read_only(root)
+    try:
+        require_schema(database)
+        rows = database.execute(
+            "SELECT connection_id,enabled_streams,policy_json FROM connections "
+            "ORDER BY connection_id"
+        ).fetchall()
+        due: list[dict[str, Any]] = []
+        for row in rows:
+            policy = _parse_json_object(row["policy_json"], "policy")
+            fallback = (
+                DEFAULT_SYNC_INTERVAL
+                if run_kind == "sync"
+                else DEFAULT_RECONCILE_INTERVAL
+            )
+            key = (
+                "sync_interval_seconds"
+                if run_kind == "sync"
+                else "reconcile_interval_seconds"
+            )
+            interval = (
+                interval_seconds
+                if interval_seconds is not None
+                else _interval(policy, key, fallback)
+            )
+            streams = sorted(
+                set(_parse_json_array(row["enabled_streams"], "streams"))
+            )
+            for stream in streams:
+                due_at = _due_at(
+                    database, row["connection_id"], stream, run_kind, interval
+                )
+                if due_at <= now:
+                    due.append(
+                        {
+                            "connection_id": row["connection_id"],
+                            "stream": stream,
+                            "run_kind": run_kind,
+                            "due_at": due_at,
+                        }
+                    )
+        return due
+    finally:
+        database.close()
+
+
+def run_receipts(
+    root: Path, connection_id: str | None = None, *, limit: int = 100
+) -> list[dict[str, Any]]:
+    """Return bounded privacy-safe receipts in deterministic order."""
+    if isinstance(limit, bool) or not 1 <= limit <= 1000:
+        raise SocialStoreError("receipt limit must be between 1 and 1000")
+    if connection_id is not None:
+        connection_id = validate_opaque(connection_id, "connection_id")
+    database = connect_read_only(root)
+    try:
+        require_schema(database)
+        query = (
+            "SELECT run_id,connection_id,stream,run_kind,status,resource_count,"
+            "failure_class,retry_after,fencing_token,collector_id,started_at,"
+            "completed_at,request_hash FROM sync_runs"
+        )
+        parameters: list[Any] = []
+        if connection_id is not None:
+            query += " WHERE connection_id=?"
+            parameters.append(connection_id)
+        query += " ORDER BY started_at DESC,rowid DESC LIMIT ?"
+        parameters.append(limit)
+        rows = database.execute(query, parameters).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        database.close()

--- a/.agents/scripts/_knowledge_social_x_persist.py
+++ b/.agents/scripts/_knowledge_social_x_persist.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from _knowledge_social_lease import (
     RunLease,
+    RunReceiptUpdate,
     assert_run_lease,
     social_now,
     update_run_receipt,
@@ -266,9 +267,11 @@ def persist_page(context: CollectionContext, page: SuccessfulPage) -> int:
         update_run_receipt(
             database,
             lease,
-            "complete" if page.complete else "running",
-            resource_delta=resource_count,
-            terminal=page.complete,
+            RunReceiptUpdate(
+                "complete" if page.complete else "running",
+                resource_delta=resource_count,
+                terminal=page.complete,
+            ),
             now_epoch=now,
         )
         database.execute("COMMIT")
@@ -360,10 +363,12 @@ def record_terminal(
         update_run_receipt(
             database,
             lease,
-            decision.run_status,
-            failure_class=decision.failure_class,
-            retry_after=retry_after,
-            terminal=True,
+            RunReceiptUpdate(
+                decision.run_status,
+                failure_class=decision.failure_class,
+                retry_after=retry_after,
+                terminal=True,
+            ),
             now_epoch=now,
         )
         _upsert_terminal_coverage(database, context, raw, decision)
@@ -393,9 +398,7 @@ def record_bounded_stop(
         update_run_receipt(
             database,
             lease,
-            status,
-            failure_class=failure,
-            terminal=True,
+            RunReceiptUpdate(status, failure_class=failure, terminal=True),
             now_epoch=now,
         )
         updated = database.execute(

--- a/.agents/scripts/_knowledge_social_x_persist.py
+++ b/.agents/scripts/_knowledge_social_x_persist.py
@@ -7,11 +7,16 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
-import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from _knowledge_social_lease import (
+    RunLease,
+    assert_run_lease,
+    social_now,
+    update_run_receipt,
+)
 from _knowledge_social_x import PROVIDER, PageCheckpoint, XAdapterError
 from _knowledge_social_x_normalize import observation_time, page_time_bounds
 from _knowledge_social_x_state import CollectionContext
@@ -66,6 +71,12 @@ class TerminalDecision:
     output_status: str
     run_status: str
     failure_class: str
+
+
+def _run_lease(context: CollectionContext) -> RunLease:
+    if context.lease is None:
+        raise XAdapterError("X persistence requires a collector lease")
+    return context.lease
 
 
 def _assert_connection_binding(
@@ -228,6 +239,9 @@ def persist_page(context: CollectionContext, page: SuccessfulPage) -> int:
     try:
         migrate(database)
         database.execute("BEGIN IMMEDIATE")
+        lease = _run_lease(context)
+        now = social_now()
+        assert_run_lease(database, lease, now_epoch=now)
         _assert_connection_binding(database, context)
         raw = _raw_batch(
             context, page.payload, page.endpoint, page.archive["exported_at"]
@@ -249,6 +263,14 @@ def persist_page(context: CollectionContext, page: SuccessfulPage) -> int:
         )
         _update_cursor(database, context, page)
         _upsert_success_coverage(database, context, page, raw.batch_id)
+        update_run_receipt(
+            database,
+            lease,
+            "complete" if page.complete else "running",
+            resource_delta=resource_count,
+            terminal=page.complete,
+            now_epoch=now,
+        )
         database.execute("COMMIT")
         return resource_count
     except Exception:
@@ -266,27 +288,6 @@ def _retry_after(payload: dict[str, Any]) -> str | None:
     if isinstance(value, bool) or not isinstance(value, (int, str)):
         raise XAdapterError("X retry_after must be text or an integer")
     return str(value)
-
-
-def _record_run(
-    database: sqlite3.Connection,
-    context: CollectionContext,
-    status: str,
-    failure: str,
-    retry_after: str | None,
-) -> None:
-    database.execute(
-        "INSERT INTO sync_runs(run_id,connection_id,status,failure_class,retry_after,diagnostics) "
-        "VALUES(?,?,?,?,?,?)",
-        (
-            uuid.uuid4().hex,
-            context.connection_id,
-            status,
-            failure,
-            retry_after,
-            canonical_json({"stream": context.stream}),
-        ),
-    )
 
 
 def _terminal_coverage_status(decision: TerminalDecision) -> str:
@@ -340,6 +341,9 @@ def record_terminal(
     try:
         migrate(database)
         database.execute("BEGIN IMMEDIATE")
+        lease = _run_lease(context)
+        now = social_now()
+        assert_run_lease(database, lease, now_epoch=now)
         _assert_connection_binding(database, context)
         raw = _raw_batch(context, payload, endpoint, observed_at)
         upsert_connection(
@@ -353,12 +357,14 @@ def record_terminal(
             context,
             FetchRecord(raw, decision.failure_class, 0, context.spec.cost_units),
         )
-        _record_run(
+        update_run_receipt(
             database,
-            context,
+            lease,
             decision.run_status,
-            decision.failure_class,
-            retry_after,
+            failure_class=decision.failure_class,
+            retry_after=retry_after,
+            terminal=True,
+            now_epoch=now,
         )
         _upsert_terminal_coverage(database, context, raw, decision)
         database.execute("COMMIT")
@@ -375,13 +381,23 @@ def record_bounded_stop(
     context: CollectionContext, status: str, failure: str
 ) -> None:
     """Record a budget or capability stop while preserving prior evidence."""
-    observed_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    now = social_now()
+    observed_at = datetime.fromtimestamp(now, UTC).isoformat().replace("+00:00", "Z")
     database = connect(context.root)
     try:
         migrate(database)
         database.execute("BEGIN IMMEDIATE")
+        lease = _run_lease(context)
+        assert_run_lease(database, lease, now_epoch=now)
         _assert_connection_binding(database, context)
-        _record_run(database, context, status, failure, None)
+        update_run_receipt(
+            database,
+            lease,
+            status,
+            failure_class=failure,
+            terminal=True,
+            now_epoch=now,
+        )
         updated = database.execute(
             "UPDATE coverage_records SET status=?,unavailable_reason=?,observed_at=? "
             "WHERE provider=? AND connection_id=? AND stream=?",

--- a/.agents/scripts/_knowledge_social_x_state.py
+++ b/.agents/scripts/_knowledge_social_x_state.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from _knowledge_social_lease import RunLease
 from _knowledge_social_x import PROVIDER, STREAMS, CursorState, StreamSpec, XAdapterError
 from knowledge_social_import import reject_credentials
 from knowledge_social_store import connect, migrate
@@ -36,6 +37,7 @@ class CollectionContext:
     config: ConnectionConfig
     state: CursorState
     spec: StreamSpec
+    lease: RunLease | None = None
 
 
 def _json_array(value: str, field: str) -> list[str]:

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_HELPER="${SCRIPT_DIR}/knowledge_social_import.py"
 X_HELPER="${SCRIPT_DIR}/knowledge_social_x.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
+SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 
 usage() {
 	cat <<'EOF'
@@ -23,11 +24,21 @@ Usage:
     --object-type TYPE --remote-id ID [--annotation-id ID] --body-file FILE
   knowledge-social-helper.sh sync-x [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id ID --stream STREAM [--budget UNITS] \
-    [--media-policy none|metadata] [--app PROFILE] [--username HANDLE]
+    [--media-policy none|metadata] [--app PROFILE] [--username HANDLE] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
+    [--now-epoch EPOCH] [--interval-seconds SECONDS]
+  knowledge-social-helper.sh reconcile-due [--base PATH] [--alias ALIAS] \
+    [--now-epoch EPOCH] [--interval-seconds SECONDS]
+  knowledge-social-helper.sh reconcile [--base PATH] [--alias ALIAS] \
+    --connection-id ID --stream STREAM --snapshot FILE [--collector-id ID] \
+    [--lease-seconds SECONDS] [--now-epoch EPOCH]
+  knowledge-social-helper.sh receipts [--base PATH] [--alias ALIAS] \
+    [--connection-id ID] [--limit 1-1000]
 
 The authenticated corpus catalog resolves ALIAS with knowledge.write for
-mutating operations or knowledge.read for coverage. Physical corpus paths are
-not accepted from callers.
+mutating operations or knowledge.read for coverage, due plans, receipts, and
+queries. Physical corpus paths are not accepted from callers.
 
 Query resolves the authenticated principal and searches the personal corpus plus
 every authorized workspace corpus by default. --alias can narrow but never widen
@@ -45,6 +56,13 @@ X synchronization:
   authored, mentions, likes, bookmarks, followers, or following. --budget is a
   bounded request-cost allowance from 1 to 1000 units. Media policy none stores
   no media rows; metadata stores references only, never binary media.
+
+Deterministic routines:
+  sync-due and reconcile-due return sorted privacy-safe work plans. Every sync or
+  reconciliation owns one expiring connection lease and monotonic fencing token;
+  normalized rows, checkpoints, and the run receipt commit in one transaction.
+  Reconciliation snapshots must be private JSON files and mark remote absence as
+  missing evidence. They never purge canonical content.
 EOF
 	return 0
 }
@@ -86,6 +104,14 @@ main() {
 			return 1
 		fi
 		python3 "$QUERY_HELPER" "$subcommand" "$@" || return 1
+		;;
+	sync-due | reconcile-due | reconcile | receipts)
+		require_runtime || return 1
+		if [[ ! -r "$SYNC_HELPER" ]]; then
+			printf 'ERROR: social sync implementation missing: %s\n' "$SYNC_HELPER" >&2
+			return 1
+		fi
+		python3 "$SYNC_HELPER" "$subcommand" "$@" || return 1
 		;;
 	help | -h | --help)
 		usage

--- a/.agents/scripts/knowledge_social_import.py
+++ b/.agents/scripts/knowledge_social_import.py
@@ -14,6 +14,7 @@ from typing import Any
 from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
 from knowledge_corpus_context import CatalogError
 from knowledge_social_store import (
+    SCHEMA_VERSION,
     SocialStoreError,
     connect,
     connect_read_only,
@@ -320,7 +321,7 @@ def main() -> int:
         root = validate_root(resolve(base, args.alias, capability))
         if args.command == "provision":
             provision(root)
-            result: Any = {"schema_version": 1}
+            result: Any = {"schema_version": SCHEMA_VERSION}
         elif args.command == "import-archive":
             result = import_archive(root, args.archive)
         elif args.command == "rebuild":

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -18,7 +18,7 @@ from knowledge_corpus_context import (
     validate_private_file,
 )
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
 SQLITE_MUTABLE_SIDECARS = ("-journal", "-shm", "-wal")
 
@@ -143,7 +143,25 @@ def _tables() -> tuple[str, ...]:
         """CREATE TABLE IF NOT EXISTS sync_runs (
             run_id TEXT PRIMARY KEY, connection_id TEXT NOT NULL, status TEXT NOT NULL,
             resource_count INTEGER NOT NULL DEFAULT 0, failure_class TEXT, retry_after TEXT,
-            fencing_token TEXT, diagnostics TEXT)""",
+            fencing_token INTEGER, diagnostics TEXT, stream TEXT NOT NULL DEFAULT '',
+            run_kind TEXT NOT NULL DEFAULT 'sync', collector_id TEXT,
+            started_at INTEGER, completed_at INTEGER, request_hash TEXT)""",
+        """CREATE TABLE IF NOT EXISTS collector_lease_generations (
+            connection_id TEXT PRIMARY KEY, last_token INTEGER NOT NULL
+        )""",
+        """CREATE TABLE IF NOT EXISTS collector_leases (
+            connection_id TEXT PRIMARY KEY, collector_id TEXT NOT NULL,
+            fencing_token INTEGER NOT NULL, run_id TEXT NOT NULL,
+            acquired_at INTEGER NOT NULL, expires_at INTEGER NOT NULL
+        )""",
+        """CREATE TABLE IF NOT EXISTS reconciliation_items (
+            provider TEXT NOT NULL, connection_id TEXT NOT NULL, stream TEXT NOT NULL,
+            item_kind TEXT NOT NULL CHECK(item_kind IN ('object','activity')),
+            item_type TEXT NOT NULL, remote_id TEXT NOT NULL,
+            status TEXT NOT NULL CHECK(status IN ('present','missing')),
+            first_missing_at TEXT, last_observed_at TEXT NOT NULL, run_id TEXT NOT NULL,
+            PRIMARY KEY(provider,connection_id,stream,item_kind,item_type,remote_id)
+        )""",
         """CREATE TABLE IF NOT EXISTS tombstones (
             provider TEXT NOT NULL, object_type TEXT NOT NULL, remote_id TEXT NOT NULL,
             observed_at TEXT NOT NULL, reason TEXT NOT NULL, retention_action TEXT NOT NULL,
@@ -161,6 +179,7 @@ def _tables() -> tuple[str, ...]:
         "CREATE INDEX IF NOT EXISTS idx_objects_account ON objects(provider, account_remote_id, created_at)",
         "CREATE INDEX IF NOT EXISTS idx_activities_actor ON activities(provider, actor_remote_id, occurred_at)",
         "CREATE INDEX IF NOT EXISTS idx_coverage_connection ON coverage_records(connection_id, stream)",
+        "CREATE INDEX IF NOT EXISTS idx_reconciliation_status ON reconciliation_items(connection_id, stream, status)",
     )
 
 
@@ -178,17 +197,41 @@ def create_fts(connection: sqlite3.Connection) -> None:
 
 def migrate(connection: sqlite3.Connection) -> None:
     current = connection.execute("PRAGMA user_version").fetchone()[0]
-    if current not in (0, SCHEMA_VERSION):
+    if current < 0 or current > SCHEMA_VERSION:
         raise SocialStoreError(f"unsupported social schema version: {current}")
     connection.execute("BEGIN IMMEDIATE")
     try:
         for statement in _tables():
             connection.execute(statement)
-        create_fts(connection)
+        if current < 2:
+            columns = {
+                str(row["name"])
+                for row in connection.execute("PRAGMA table_info(sync_runs)").fetchall()
+            }
+            additions = (
+                ("stream", "TEXT NOT NULL DEFAULT ''"),
+                ("run_kind", "TEXT NOT NULL DEFAULT 'sync'"),
+                ("collector_id", "TEXT"),
+                ("started_at", "INTEGER"),
+                ("completed_at", "INTEGER"),
+                ("request_hash", "TEXT"),
+            )
+            for name, definition in additions:
+                if name not in columns:
+                    connection.execute(
+                        f"ALTER TABLE sync_runs ADD COLUMN {name} {definition}"
+                    )
         connection.execute(
-            "INSERT OR IGNORE INTO schema_meta(version,applied_at) VALUES(?,strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
-            (SCHEMA_VERSION,),
+            "CREATE INDEX IF NOT EXISTS idx_sync_runs_connection "
+            "ON sync_runs(connection_id,stream,run_kind,started_at)"
         )
+        create_fts(connection)
+        for version in range(1, SCHEMA_VERSION + 1):
+            connection.execute(
+                "INSERT OR IGNORE INTO schema_meta(version,applied_at) "
+                "VALUES(?,strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+                (version,),
+            )
         connection.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
         connection.execute("COMMIT")
     except Exception:

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -195,6 +195,29 @@ def create_fts(connection: sqlite3.Connection) -> None:
         raise SocialStoreError("SQLite runtime does not provide required FTS5") from error
 
 
+def _add_sync_run_v2_columns(connection: sqlite3.Connection) -> None:
+    columns = {
+        str(row["name"])
+        for row in connection.execute("PRAGMA table_info(sync_runs)").fetchall()
+    }
+    if "stream" not in columns:
+        connection.execute(
+            "ALTER TABLE sync_runs ADD COLUMN stream TEXT NOT NULL DEFAULT ''"
+        )
+    if "run_kind" not in columns:
+        connection.execute(
+            "ALTER TABLE sync_runs ADD COLUMN run_kind TEXT NOT NULL DEFAULT 'sync'"
+        )
+    if "collector_id" not in columns:
+        connection.execute("ALTER TABLE sync_runs ADD COLUMN collector_id TEXT")
+    if "started_at" not in columns:
+        connection.execute("ALTER TABLE sync_runs ADD COLUMN started_at INTEGER")
+    if "completed_at" not in columns:
+        connection.execute("ALTER TABLE sync_runs ADD COLUMN completed_at INTEGER")
+    if "request_hash" not in columns:
+        connection.execute("ALTER TABLE sync_runs ADD COLUMN request_hash TEXT")
+
+
 def migrate(connection: sqlite3.Connection) -> None:
     current = connection.execute("PRAGMA user_version").fetchone()[0]
     if current < 0 or current > SCHEMA_VERSION:
@@ -204,23 +227,7 @@ def migrate(connection: sqlite3.Connection) -> None:
         for statement in _tables():
             connection.execute(statement)
         if current < 2:
-            columns = {
-                str(row["name"])
-                for row in connection.execute("PRAGMA table_info(sync_runs)").fetchall()
-            }
-            additions = (
-                ("stream", "TEXT NOT NULL DEFAULT ''"),
-                ("run_kind", "TEXT NOT NULL DEFAULT 'sync'"),
-                ("collector_id", "TEXT"),
-                ("started_at", "INTEGER"),
-                ("completed_at", "INTEGER"),
-                ("request_hash", "TEXT"),
-            )
-            for name, definition in additions:
-                if name not in columns:
-                    connection.execute(
-                        f"ALTER TABLE sync_runs ADD COLUMN {name} {definition}"
-                    )
+            _add_sync_run_v2_columns(connection)
         connection.execute(
             "CREATE INDEX IF NOT EXISTS idx_sync_runs_connection "
             "ON sync_runs(connection_id,stream,run_kind,started_at)"
@@ -232,7 +239,7 @@ def migrate(connection: sqlite3.Connection) -> None:
                 "VALUES(?,strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
                 (version,),
             )
-        connection.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+        connection.execute("PRAGMA user_version=2")
         connection.execute("COMMIT")
     except Exception:
         connection.execute("ROLLBACK")

--- a/.agents/scripts/knowledge_social_sync.py
+++ b/.agents/scripts/knowledge_social_sync.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Plan and reconcile deterministic social corpus synchronization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_lease import (
+    SocialLeaseLostError,
+    acquire_run_lease,
+    fail_active_run,
+    release_run_lease,
+)
+from _knowledge_social_reconcile import (
+    load_reconciliation_snapshot,
+    reconcile_snapshot,
+)
+from _knowledge_social_schedule import due_plan, run_receipts
+from knowledge_corpus_catalog import DEFAULT_ALIAS, authorized_scope, resolve
+from knowledge_corpus_context import CatalogError
+from knowledge_social_store import SocialStoreError, validate_opaque, validate_root
+
+
+def _base(args: argparse.Namespace) -> Path:
+    if args.base is not None:
+        return args.base
+    return Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+
+
+def _write_context(args: argparse.Namespace) -> tuple[str, Path]:
+    principal_id, corpora = authorized_scope(
+        _base(args), "knowledge.write", args.alias
+    )
+    return principal_id, validate_root(corpora[0][1])
+
+
+def _read_root(args: argparse.Namespace) -> Path:
+    return validate_root(resolve(_base(args), args.alias, "knowledge.read"))
+
+
+def _collector(args: argparse.Namespace, principal_id: str) -> str:
+    return validate_opaque(args.collector_id or principal_id, "collector_id")
+
+
+def _run_reconcile(args: argparse.Namespace) -> dict[str, Any]:
+    principal_id, root = _write_context(args)
+    snapshot = load_reconciliation_snapshot(args.snapshot)
+    lease = acquire_run_lease(
+        root,
+        args.connection_id,
+        args.stream,
+        _collector(args, principal_id),
+        "reconcile",
+        args.lease_seconds,
+        now_epoch=args.now_epoch,
+        request_hash=snapshot.request_hash,
+    )
+    try:
+        return reconcile_snapshot(root, lease, snapshot, now_epoch=args.now_epoch)
+    except Exception:
+        try:
+            fail_active_run(
+                root, lease, "reconciliation", now_epoch=args.now_epoch
+            )
+        except SocialLeaseLostError:
+            pass
+        raise
+    finally:
+        release_run_lease(root, lease)
+
+
+def _run_due(args: argparse.Namespace, run_kind: str) -> list[dict[str, Any]]:
+    return due_plan(
+        _read_root(args),
+        run_kind,
+        now_epoch=args.now_epoch,
+        interval_seconds=args.interval_seconds,
+    )
+
+
+def _run_receipts(args: argparse.Namespace) -> list[dict[str, Any]]:
+    return run_receipts(_read_root(args), args.connection_id, limit=args.limit)
+
+
+def _add_scope(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("sync-due", "reconcile-due"):
+        due = subparsers.add_parser(command)
+        _add_scope(due)
+        due.add_argument("--now-epoch", type=int)
+        due.add_argument("--interval-seconds", type=int)
+    reconcile = subparsers.add_parser("reconcile")
+    _add_scope(reconcile)
+    reconcile.add_argument("--connection-id", required=True)
+    reconcile.add_argument("--stream", required=True)
+    reconcile.add_argument("--snapshot", required=True, type=Path)
+    reconcile.add_argument("--collector-id")
+    reconcile.add_argument("--lease-seconds", type=int, default=300)
+    reconcile.add_argument("--now-epoch", type=int)
+    receipts = subparsers.add_parser("receipts")
+    _add_scope(receipts)
+    receipts.add_argument("--connection-id")
+    receipts.add_argument("--limit", type=int, default=100)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "sync-due":
+            result: Any = _run_due(args, "sync")
+        elif args.command == "reconcile-due":
+            result = _run_due(args, "reconcile")
+        elif args.command == "reconcile":
+            result = _run_reconcile(args)
+        else:
+            result = _run_receipts(args)
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (CatalogError, OSError, SocialStoreError, sqlite3.Error, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_sync.py
+++ b/.agents/scripts/knowledge_social_sync.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from _knowledge_social_lease import (
+    RunLeaseRequest,
     SocialLeaseLostError,
     acquire_run_lease,
     fail_active_run,
@@ -54,13 +55,15 @@ def _run_reconcile(args: argparse.Namespace) -> dict[str, Any]:
     snapshot = load_reconciliation_snapshot(args.snapshot)
     lease = acquire_run_lease(
         root,
-        args.connection_id,
-        args.stream,
-        _collector(args, principal_id),
-        "reconcile",
-        args.lease_seconds,
+        RunLeaseRequest(
+            args.connection_id,
+            args.stream,
+            _collector(args, principal_id),
+            "reconcile",
+            args.lease_seconds,
+            snapshot.request_hash,
+        ),
         now_epoch=args.now_epoch,
-        request_hash=snapshot.request_hash,
     )
     try:
         return reconcile_snapshot(root, lease, snapshot, now_epoch=args.now_epoch)
@@ -100,7 +103,7 @@ def parse_args() -> argparse.Namespace:
     for command in ("sync-due", "reconcile-due"):
         due = subparsers.add_parser(command)
         _add_scope(due)
-        due.add_argument("--now-epoch", type=int)
+        due.add_argument("--now-epoch", type=int, help=argparse.SUPPRESS)
         due.add_argument("--interval-seconds", type=int)
     reconcile = subparsers.add_parser("reconcile")
     _add_scope(reconcile)
@@ -109,7 +112,7 @@ def parse_args() -> argparse.Namespace:
     reconcile.add_argument("--snapshot", required=True, type=Path)
     reconcile.add_argument("--collector-id")
     reconcile.add_argument("--lease-seconds", type=int, default=300)
-    reconcile.add_argument("--now-epoch", type=int)
+    reconcile.add_argument("--now-epoch", type=int, help=argparse.SUPPRESS)
     receipts = subparsers.add_parser("receipts")
     _add_scope(receipts)
     receipts.add_argument("--connection-id")

--- a/.agents/scripts/knowledge_social_x.py
+++ b/.agents/scripts/knowledge_social_x.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from _knowledge_social_lease import (
+    RunLeaseRequest,
     SocialLeaseLostError,
     acquire_run_lease,
     fail_active_run,
@@ -196,11 +197,13 @@ def collect(
     account_id = validate_opaque(args.account_id, "account_id")
     lease = acquire_run_lease(
         root,
-        connection_id,
-        args.stream,
-        collector_id,
-        "sync",
-        args.lease_seconds,
+        RunLeaseRequest(
+            connection_id,
+            args.stream,
+            collector_id,
+            "sync",
+            args.lease_seconds,
+        ),
     )
     try:
         runner = xurl_runner(args)

--- a/.agents/scripts/knowledge_social_x.py
+++ b/.agents/scripts/knowledge_social_x.py
@@ -15,6 +15,13 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+from _knowledge_social_lease import (
+    SocialLeaseLostError,
+    acquire_run_lease,
+    fail_active_run,
+    release_run_lease,
+    renew_run_lease,
+)
 from _knowledge_social_x import (
     STREAMS,
     CursorState,
@@ -38,7 +45,7 @@ from _knowledge_social_x_reader import (
     verified_identity,
 )
 from _knowledge_social_x_state import CollectionContext, load_context
-from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
+from knowledge_corpus_catalog import DEFAULT_ALIAS, authorized_scope
 from knowledge_corpus_context import CatalogError
 from knowledge_social_import import reject_credentials
 from knowledge_social_store import (
@@ -112,6 +119,12 @@ def collect_pages(
     resources = 0
     budget_units = 0
     while budget_units + context.spec.cost_units <= args.budget:
+        if context.lease is None:
+            raise XAdapterError("X collection requires a collector lease")
+        renewed = renew_run_lease(
+            context.root, context.lease, args.lease_seconds
+        )
+        context = replace(context, lease=renewed)
         endpoint = stream_endpoint(
             context.stream, context.account["id"], context.state
         )
@@ -127,6 +140,7 @@ def collect_pages(
                 budget_units + context.spec.cost_units,
                 failure_class=decision.failure_class,
                 retry_after=retry_after,
+                run_id=context.lease.run_id,
             )
         checkpoint = page_checkpoint(payload, context.state.watermark)
         archive = normalize_page(payload, _page_context(context))
@@ -147,30 +161,79 @@ def collect_pages(
         )
         context = replace(context, state=state)
         if complete:
-            return _result("complete", pages, resources, budget_units)
+            return _result(
+                "complete",
+                pages,
+                resources,
+                budget_units,
+                run_id=context.lease.run_id,
+            )
     record_bounded_stop(context, "paused", "budget")
-    return _result("budget_exhausted", pages, resources, budget_units)
+    return _result(
+        "budget_exhausted",
+        pages,
+        resources,
+        budget_units,
+        run_id=context.lease.run_id if context.lease else None,
+    )
 
 
-def collect(args: argparse.Namespace, root: Path) -> dict[str, Any]:
+def _failure_class(error: Exception) -> str:
+    if isinstance(error, XAdapterError):
+        return "validation"
+    if isinstance(error, sqlite3.Error):
+        return "storage"
+    if isinstance(error, subprocess.SubprocessError):
+        return "provider"
+    return "runtime"
+
+
+def collect(
+    args: argparse.Namespace, root: Path, collector_id: str
+) -> dict[str, Any]:
     """Verify identity and collect one configured stream."""
     connection_id = validate_opaque(args.connection_id, "connection_id")
     account_id = validate_opaque(args.account_id, "account_id")
-    runner = xurl_runner(args)
-    account = verified_identity(runner.identity(), account_id)
-    context = load_context(
-        root, connection_id, account, args.stream, args.media_policy
+    lease = acquire_run_lease(
+        root,
+        connection_id,
+        args.stream,
+        collector_id,
+        "sync",
+        args.lease_seconds,
     )
-    if context.state.backfill_complete and not context.spec.supports_since_id:
-        record_bounded_stop(context, "unavailable", "delta_not_supported")
-        return _result(
-            "delta_unavailable",
-            0,
-            0,
-            0,
-            failure_class="delta_not_supported",
+    try:
+        runner = xurl_runner(args)
+        account = verified_identity(runner.identity(), account_id)
+        context = replace(
+            load_context(
+                root,
+                connection_id,
+                account,
+                args.stream,
+                args.media_policy,
+            ),
+            lease=lease,
         )
-    return collect_pages(args, runner, context)
+        if context.state.backfill_complete and not context.spec.supports_since_id:
+            record_bounded_stop(context, "unavailable", "delta_not_supported")
+            return _result(
+                "delta_unavailable",
+                0,
+                0,
+                0,
+                failure_class="delta_not_supported",
+                run_id=lease.run_id,
+            )
+        return collect_pages(args, runner, context)
+    except Exception as error:
+        try:
+            fail_active_run(root, lease, _failure_class(error))
+        except SocialLeaseLostError:
+            pass
+        raise
+    finally:
+        release_run_lease(root, lease)
 
 
 def parse_args() -> argparse.Namespace:
@@ -186,10 +249,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--app")
     parser.add_argument("--username")
+    parser.add_argument("--collector-id")
+    parser.add_argument("--lease-seconds", type=int, default=300)
     parser.add_argument("--fixture", type=Path, help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.budget < 1 or args.budget > 1000:
         parser.error("--budget must be between 1 and 1000 request units")
+    if args.lease_seconds < 1 or args.lease_seconds > 86400:
+        parser.error("--lease-seconds must be between 1 and 86400")
     return args
 
 
@@ -201,8 +268,14 @@ def main() -> int:
             if args.base
             else Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
         )
-        root = validate_root(resolve(base, args.alias, "knowledge.write"))
-        print(json.dumps(collect(args, root), sort_keys=True))
+        principal_id, corpora = authorized_scope(
+            base, "knowledge.write", args.alias
+        )
+        root = validate_root(corpora[0][1])
+        collector_id = validate_opaque(
+            args.collector_id or principal_id, "collector_id"
+        )
+        print(json.dumps(collect(args, root, collector_id), sort_keys=True))
         return 0
     except (
         CatalogError,

--- a/.agents/tests/test-knowledge-social-sync.sh
+++ b/.agents/tests/test-knowledge-social-sync.sh
@@ -1,0 +1,480 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-sync.sh — Fenced social routine regression tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+print(connection.execute(sys.argv[2]).fetchone()[0])
+connection.close()
+PY
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Social sync routine tests\n'
+assert_eq "Phase 5 schema is active" "$(sql_value 'PRAGMA user_version')" "2"
+assert_eq "lease and reconciliation tables are provisioned" \
+	"$(sql_value "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('collector_lease_generations','collector_leases','reconciliation_items')")" \
+	"3"
+
+cat >"$TMP_DIR/initial.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42", "username": "private-handle"}},
+  "pages": [{
+    "status": 200,
+    "observed_at": "2026-07-25T06:00:00Z",
+    "data": [{
+      "id": "post101",
+      "author_id": "acct42",
+      "text": "lease fixture",
+      "created_at": "2026-07-25T05:00:00Z"
+    }],
+    "meta": {}
+  }]
+}
+JSON
+
+export AIDEVOPS_SOCIAL_NOW_EPOCH=1000
+sync_result=$("$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_sync --account-id acct42 --stream authored \
+	--collector-id runner_one --fixture "$TMP_DIR/initial.json")
+run_id_length=$(json_field "$sync_result" run_id |
+	python3 -c 'import sys; print(len(sys.stdin.read().strip()))')
+assert_eq "successful sync returns a durable run ID" "$run_id_length" "64"
+assert_eq "successful receipt carries the collector fence" \
+	"$(sql_value "SELECT status || ':' || run_kind || ':' || collector_id || ':' || fencing_token FROM sync_runs WHERE connection_id='conn_sync'")" \
+	"complete:sync:runner_one:1"
+assert_eq "completed invocation releases its live lease" \
+	"$(sql_value "SELECT count(*) FROM collector_leases WHERE connection_id='conn_sync'")" \
+	"0"
+
+not_due=$("$HELPER" sync-due --base "$BASE" \
+	--now-epoch 1000 --interval-seconds 60)
+due=$("$HELPER" sync-due --base "$BASE" \
+	--now-epoch 1060 --interval-seconds 60)
+assert_eq "daily planner omits a stream before its deterministic boundary" \
+	"$not_due" "[]"
+due_summary=$(python3 -c \
+	'import json,sys; d=json.loads(sys.argv[1]); print("{}:{}:{}:{}".format(len(d),d[0]["connection_id"],d[0]["stream"],d[0]["due_at"]))' \
+	"$due")
+assert_eq "daily planner emits one sorted opaque target at the boundary" \
+	"$due_summary" "1:conn_sync:authored:1060"
+
+cat >"$TMP_DIR/rate-limit.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42"}},
+  "pages": [{
+    "status": 429,
+    "observed_at": "2026-07-25T06:05:00Z",
+    "retry_after": 1100
+  }]
+}
+JSON
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_sync --account-id acct42 --stream authored \
+	--collector-id runner_one --fixture "$TMP_DIR/rate-limit.json" >/dev/null
+assert_eq "rate reset suppresses retries before the provider boundary" \
+	"$("$HELPER" sync-due --base "$BASE" --now-epoch 1099 --interval-seconds 86400)" \
+	"[]"
+rate_due=$("$HELPER" sync-due --base "$BASE" \
+	--now-epoch 1100 --interval-seconds 86400)
+assert_eq "rate reset schedules one bounded retry without waiting a full interval" \
+	"$(python3 -c 'import json,sys; d=json.loads(sys.argv[1]); print("{}:{}".format(len(d),d[0]["due_at"]))' "$rate_due")" \
+	"1:1100"
+
+race_summary=$(
+	python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import multiprocessing
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_lease import (
+    SocialLeaseBusyError,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    assert_run_lease,
+    fail_active_run,
+    release_run_lease,
+)
+from _knowledge_social_x import CursorState, PageCheckpoint, STREAMS
+from _knowledge_social_x_persist import SuccessfulPage, persist_page
+from _knowledge_social_x_state import CollectionContext, ConnectionConfig
+
+root = Path(sys.argv[1])
+
+
+def contender(owner, barrier, queue):
+    barrier.wait()
+    try:
+        lease = acquire_run_lease(
+            root, "conn_race", "authored", owner, "sync", 10, now_epoch=2000
+        )
+        queue.put(("writer", owner, lease.fencing_token, lease.run_id))
+    except SocialLeaseBusyError:
+        queue.put(("busy", owner, 0, ""))
+
+
+context = multiprocessing.get_context("fork")
+barrier = context.Barrier(2)
+queue = context.Queue()
+workers = [
+    context.Process(target=contender, args=(owner, barrier, queue))
+    for owner in ("runner_a", "runner_b")
+]
+for worker in workers:
+    worker.start()
+for worker in workers:
+    worker.join(10)
+if any(worker.exitcode != 0 for worker in workers):
+    raise SystemExit("collector contender failed")
+results = [queue.get(timeout=2) for _ in workers]
+if sorted(result[0] for result in results) != ["busy", "writer"]:
+    raise SystemExit("competing collectors did not elect exactly one writer")
+
+stale = acquire_run_lease(
+    root, "conn_stale", "authored", "runner_old", "sync", 10, now_epoch=3000
+)
+fresh = acquire_run_lease(
+    root, "conn_stale", "authored", "runner_new", "sync", 10, now_epoch=3010
+)
+database = sqlite3.connect(root / "index" / "social.db")
+database.row_factory = sqlite3.Row
+database.execute("BEGIN IMMEDIATE")
+try:
+    assert_run_lease(database, stale, now_epoch=3010)
+except SocialLeaseLostError:
+    database.rollback()
+else:
+    raise SystemExit("stale fencing token remained writable")
+finally:
+    database.close()
+release_run_lease(root, fresh)
+
+old = acquire_run_lease(
+    root, "conn_sync", "authored", "runner_old", "sync", 10, now_epoch=4000
+)
+new = acquire_run_lease(
+    root, "conn_sync", "authored", "runner_new", "sync", 10, now_epoch=4010
+)
+database = sqlite3.connect(root / "index" / "social.db")
+stored = database.execute(
+    "SELECT cursor,watermark,backfill_complete FROM sync_cursors "
+    "WHERE connection_id='conn_sync' AND stream='authored'"
+).fetchone()
+database.close()
+collection = CollectionContext(
+    root,
+    "conn_sync",
+    {"id": "acct42"},
+    "authored",
+    "none",
+    ConnectionConfig(("authored",), {"media_hydration": "none"}),
+    CursorState(stored[0], stored[1], bool(stored[2])),
+    STREAMS["authored"],
+    old,
+)
+page = SuccessfulPage(
+    {
+        "status": 200,
+        "observed_at": "2026-07-25T06:01:00Z",
+        "data": [],
+        "meta": {},
+    },
+    "/2/users/acct42/tweets?max_results=100",
+    {
+        "remote_account_id": "acct42",
+        "enabled_streams": ["authored"],
+        "policy": {"media_hydration": "none"},
+        "accounts": [],
+        "objects": [],
+        "activities": [],
+        "media": [],
+        "exported_at": "2026-07-25T06:01:00Z",
+    },
+    PageCheckpoint(None, "post999"),
+    True,
+    1,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "4010"
+try:
+    persist_page(collection, page)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale page unexpectedly advanced a cursor")
+database = sqlite3.connect(root / "index" / "social.db")
+current = database.execute(
+    "SELECT watermark FROM sync_cursors "
+    "WHERE connection_id='conn_sync' AND stream='authored'"
+).fetchone()[0]
+database.close()
+if current != "post101":
+    raise SystemExit("stale page changed the durable cursor")
+fail_active_run(root, new, "test_handoff", now_epoch=4010)
+release_run_lease(root, new)
+
+print("writer:1:stale-rejected:cursor-stable")
+PY
+)
+assert_eq "two competing collectors yield exactly one writer" \
+	"$race_summary" "writer:1:stale-rejected:cursor-stable"
+assert_eq "stale takeover uses a strictly greater token" \
+	"$(sql_value "SELECT last_token FROM collector_lease_generations WHERE connection_id='conn_stale'")" \
+	"2"
+assert_eq "takeover records an abandoned receipt for crash recovery" \
+	"$(sql_value "SELECT status || ':' || failure_class FROM sync_runs WHERE connection_id='conn_stale' AND fencing_token=1")" \
+	"abandoned:lease_expired"
+assert_eq "stale collector cannot advance the committed watermark" \
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_sync' AND stream='authored'")" \
+	"post101"
+
+cat >"$TMP_DIR/missing.json" <<'JSON'
+{
+  "provider": "xapi",
+  "observed_at": "2026-07-25T07:00:00Z",
+  "complete": true,
+  "objects": [],
+  "activities": []
+}
+JSON
+chmod 0644 "$TMP_DIR/missing.json"
+if "$HELPER" reconcile --base "$BASE" --connection-id conn_sync \
+	--stream authored --snapshot "$TMP_DIR/missing.json" \
+	--collector-id runner_reconcile --now-epoch 5000 >/dev/null 2>&1; then
+	assert_eq "group-readable reconciliation evidence fails closed" \
+		"accepted" "rejected"
+else
+	assert_eq "group-readable reconciliation evidence fails closed" \
+		"rejected" "rejected"
+fi
+chmod 0600 "$TMP_DIR/missing.json"
+ln -s "$TMP_DIR/missing.json" "$TMP_DIR/linked.json"
+if "$HELPER" reconcile --base "$BASE" --connection-id conn_sync \
+	--stream authored --snapshot "$TMP_DIR/linked.json" \
+	--collector-id runner_reconcile --now-epoch 5000 >/dev/null 2>&1; then
+	assert_eq "symlinked reconciliation evidence fails closed" "accepted" "rejected"
+else
+	assert_eq "symlinked reconciliation evidence fails closed" "rejected" "rejected"
+fi
+missing_result=$("$HELPER" reconcile --base "$BASE" \
+	--connection-id conn_sync --stream authored --snapshot "$TMP_DIR/missing.json" \
+	--collector-id runner_reconcile --now-epoch 5000)
+assert_eq "complete reconciliation marks absent object and activity evidence missing" \
+	"$(json_field "$missing_result" missing)" "2"
+assert_eq "missing evidence is retained rather than purged" \
+	"$(sql_value "SELECT (SELECT count(*) FROM objects WHERE remote_id='post101') || ':' || (SELECT count(*) FROM reconciliation_items WHERE status='missing')")" \
+	"1:2"
+assert_eq "missing activity is excluded from active query provenance" \
+	"$(sql_value "SELECT state FROM activities WHERE remote_id='acct42-authored-post101'")" \
+	"missing"
+assert_eq "reconciliation never advances the provider cursor" \
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_sync' AND stream='authored'")" \
+	"post101"
+
+cat >"$TMP_DIR/present.json" <<'JSON'
+{
+  "provider": "xapi",
+  "observed_at": "2026-07-25T08:00:00Z",
+  "complete": true,
+  "objects": [{"object_type": "post", "remote_id": "post101"}],
+  "activities": [{
+    "activity_type": "authored",
+    "remote_id": "acct42-authored-post101"
+  }]
+}
+JSON
+chmod 0600 "$TMP_DIR/present.json"
+present_result=$("$HELPER" reconcile --base "$BASE" \
+	--connection-id conn_sync --stream authored --snapshot "$TMP_DIR/present.json" \
+	--collector-id runner_reconcile --now-epoch 6000)
+assert_eq "reappearing evidence clears the missing state" \
+	"$(json_field "$present_result" present):$(sql_value "SELECT count(*) FROM reconciliation_items WHERE status='present' AND first_missing_at IS NULL")" \
+	"2:2"
+assert_eq "reappearing activity restores active provenance" \
+	"$(sql_value "SELECT state FROM activities WHERE remote_id='acct42-authored-post101'")" \
+	"active"
+
+receipts=$("$HELPER" receipts --base "$BASE" --connection-id conn_sync)
+assert_eq "run receipts expose no private account handle" \
+	"$([[ "$receipts" == *private-handle* ]] && printf present || printf absent)" \
+	"absent"
+assert_eq "weekly planner waits from the completed reconciliation receipt" \
+	"$("$HELPER" reconcile-due --base "$BASE" --now-epoch 6059 --interval-seconds 60)" \
+	"[]"
+reconcile_due=$("$HELPER" reconcile-due --base "$BASE" \
+	--now-epoch 6060 --interval-seconds 60)
+reconcile_summary=$(python3 -c \
+	'import json,sys; d=json.loads(sys.argv[1]); print("{}:{}:{}".format(len(d),d[0]["run_kind"],d[0]["due_at"]))' \
+	"$reconcile_due")
+assert_eq "weekly planner emits the stream at its deterministic boundary" \
+	"$reconcile_summary" "1:reconcile:6060"
+
+cat >"$TMP_DIR/stale.json" <<'JSON'
+{
+  "provider": "xapi",
+  "observed_at": "2026-07-25T07:30:00Z",
+  "complete": true,
+  "objects": [],
+  "activities": []
+}
+JSON
+chmod 0600 "$TMP_DIR/stale.json"
+if "$HELPER" reconcile --base "$BASE" --connection-id conn_sync \
+	--stream authored --snapshot "$TMP_DIR/stale.json" \
+	--collector-id runner_reconcile --now-epoch 7000 >/dev/null 2>&1; then
+	assert_eq "older reconciliation evidence cannot roll state backward" \
+		"accepted" "rejected"
+else
+	assert_eq "older reconciliation evidence cannot roll state backward" \
+		"rejected" "rejected"
+fi
+
+cat >"$TMP_DIR/conflict.json" <<'JSON'
+{
+  "provider": "xapi",
+  "observed_at": "2026-07-25T08:00:00Z",
+  "complete": true,
+  "objects": [],
+  "activities": []
+}
+JSON
+chmod 0600 "$TMP_DIR/conflict.json"
+if "$HELPER" reconcile --base "$BASE" --connection-id conn_sync \
+	--stream authored --snapshot "$TMP_DIR/conflict.json" \
+	--collector-id runner_reconcile --now-epoch 7500 >/dev/null 2>&1; then
+	assert_eq "same-time conflicting evidence fails closed" "accepted" "rejected"
+else
+	assert_eq "same-time conflicting evidence fails closed" "rejected" "rejected"
+fi
+if "$HELPER" reconcile --base "$BASE" --connection-id conn_sync \
+	--stream mentions --snapshot "$TMP_DIR/present.json" \
+	--collector-id runner_reconcile --now-epoch 7600 >/dev/null 2>&1; then
+	assert_eq "reconciliation cannot widen into a disabled stream" \
+		"accepted" "rejected"
+else
+	assert_eq "reconciliation cannot widen into a disabled stream" \
+		"rejected" "rejected"
+fi
+replay_result=$("$HELPER" reconcile --base "$BASE" --connection-id conn_sync \
+	--stream authored --snapshot "$TMP_DIR/present.json" \
+	--collector-id runner_reconcile --now-epoch 8000)
+assert_eq "exact reconciliation replay is idempotent" \
+	"$(json_field "$replay_result" present):$(sql_value "SELECT count(*) FROM fetch_batches WHERE terminal_status='reconciliation'")" \
+	"2:2"
+assert_eq "rejected stale and conflicting evidence leaves active state unchanged" \
+	"$(sql_value "SELECT state FROM activities WHERE remote_id='acct42-authored-post101'")" \
+	"active"
+
+MIGRATION_ROOT="${TMP_DIR}/migration"
+mkdir -p "$MIGRATION_ROOT/index"
+chmod 0700 "$MIGRATION_ROOT" "$MIGRATION_ROOT/index"
+python3 - "$MIGRATION_ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import sqlite3
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+path = root / "index" / "social.db"
+database = sqlite3.connect(path)
+database.execute(
+    "CREATE TABLE schema_meta(version INTEGER PRIMARY KEY,applied_at TEXT NOT NULL)"
+)
+database.execute(
+    "CREATE TABLE sync_runs(run_id TEXT PRIMARY KEY,connection_id TEXT NOT NULL,"
+    "status TEXT NOT NULL,resource_count INTEGER NOT NULL DEFAULT 0,"
+    "failure_class TEXT,retry_after TEXT,fencing_token TEXT,diagnostics TEXT)"
+)
+database.execute("INSERT INTO schema_meta VALUES(1,'2026-07-25T00:00:00Z')")
+database.execute("PRAGMA user_version=1")
+database.commit()
+database.close()
+
+sys.path.insert(0, sys.argv[2])
+from knowledge_social_store import connect, migrate
+
+database = connect(root)
+migrate(database)
+columns = {row[1] for row in database.execute("PRAGMA table_info(sync_runs)")}
+if database.execute("PRAGMA user_version").fetchone()[0] != 2:
+    raise SystemExit("v1 database did not migrate to v2")
+required = {
+    "stream",
+    "run_kind",
+    "collector_id",
+    "started_at",
+    "completed_at",
+    "request_hash",
+}
+if not required <= columns:
+    raise SystemExit("v1 receipt table did not gain Phase 5 columns")
+database.close()
+PY
+migration_version=$(
+	python3 - "$MIGRATION_ROOT/index/social.db" <<'PY'
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+print(connection.execute("PRAGMA user_version").fetchone()[0])
+connection.close()
+PY
+)
+assert_eq "existing v1 stores migrate without replacement" "$migration_version" "2"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/tests/test-knowledge-social-sync.sh
+++ b/.agents/tests/test-knowledge-social-sync.sh
@@ -69,6 +69,19 @@ assert_eq "lease and reconciliation tables are provisioned" \
 	"$(sql_value "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('collector_lease_generations','collector_leases','reconciliation_items')")" \
 	"3"
 
+if AIDEVOPS_TEST_MODE='' AIDEVOPS_SOCIAL_NOW_EPOCH='' \
+	"$HELPER" sync-due --base "$BASE" --now-epoch 1000 >/dev/null 2>&1; then
+	assert_eq "explicit clock override is unavailable outside tests" accepted rejected
+else
+	assert_eq "explicit clock override is unavailable outside tests" rejected rejected
+fi
+if AIDEVOPS_TEST_MODE='' AIDEVOPS_SOCIAL_NOW_EPOCH=1000 \
+	"$HELPER" sync-due --base "$BASE" >/dev/null 2>&1; then
+	assert_eq "environment clock override is unavailable outside tests" accepted rejected
+else
+	assert_eq "environment clock override is unavailable outside tests" rejected rejected
+fi
+
 cat >"$TMP_DIR/initial.json" <<'JSON'
 {
   "identity": {"data": {"id": "acct42", "username": "private-handle"}},
@@ -144,6 +157,7 @@ from pathlib import Path
 
 sys.path.insert(0, sys.argv[2])
 from _knowledge_social_lease import (
+    RunLeaseRequest,
     SocialLeaseBusyError,
     SocialLeaseLostError,
     acquire_run_lease,
@@ -162,7 +176,9 @@ def contender(owner, barrier, queue):
     barrier.wait()
     try:
         lease = acquire_run_lease(
-            root, "conn_race", "authored", owner, "sync", 10, now_epoch=2000
+            root,
+            RunLeaseRequest("conn_race", "authored", owner, "sync", 10),
+            now_epoch=2000,
         )
         queue.put(("writer", owner, lease.fencing_token, lease.run_id))
     except SocialLeaseBusyError:
@@ -187,10 +203,14 @@ if sorted(result[0] for result in results) != ["busy", "writer"]:
     raise SystemExit("competing collectors did not elect exactly one writer")
 
 stale = acquire_run_lease(
-    root, "conn_stale", "authored", "runner_old", "sync", 10, now_epoch=3000
+    root,
+    RunLeaseRequest("conn_stale", "authored", "runner_old", "sync", 10),
+    now_epoch=3000,
 )
 fresh = acquire_run_lease(
-    root, "conn_stale", "authored", "runner_new", "sync", 10, now_epoch=3010
+    root,
+    RunLeaseRequest("conn_stale", "authored", "runner_new", "sync", 10),
+    now_epoch=3010,
 )
 database = sqlite3.connect(root / "index" / "social.db")
 database.row_factory = sqlite3.Row
@@ -206,10 +226,14 @@ finally:
 release_run_lease(root, fresh)
 
 old = acquire_run_lease(
-    root, "conn_sync", "authored", "runner_old", "sync", 10, now_epoch=4000
+    root,
+    RunLeaseRequest("conn_sync", "authored", "runner_old", "sync", 10),
+    now_epoch=4000,
 )
 new = acquire_run_lease(
-    root, "conn_sync", "authored", "runner_new", "sync", 10, now_epoch=4010
+    root,
+    RunLeaseRequest("conn_sync", "authored", "runner_new", "sync", 10),
+    now_epoch=4010,
 )
 database = sqlite3.connect(root / "index" / "social.db")
 stored = database.execute(

--- a/.agents/tests/test-knowledge-social.sh
+++ b/.agents/tests/test-knowledge-social.sh
@@ -94,7 +94,7 @@ mkdir -p "$CORPUS_ROOT"
 chmod 0700 "$BASE" "$CORPUS_ROOT"
 "$CORPUS_HELPER" provision --base "$BASE" >/dev/null
 "$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
-assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "1"
+assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "2"
 assert_eq "all provider-neutral tables exist" "$(sql_value "SELECT count(*) FROM sqlite_master WHERE name IN ('connections','accounts','objects','activities','media','fetch_batches','sync_cursors','sync_runs','tombstones','annotations','coverage_records','objects_fts')")" "12"
 
 first_result=$("$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$ARCHIVE")
@@ -219,7 +219,7 @@ python3 - "$CORPUS_ROOT/index/social.db" <<'PY'
 import sqlite3
 import sys
 connection = sqlite3.connect(sys.argv[1])
-connection.execute("PRAGMA user_version=1")
+connection.execute("PRAGMA user_version=2")
 connection.close()
 PY
 


### PR DESCRIPTION
## Summary

- migrate each private social store to schema v2 with monotonic per-connection lease generations, one live collector lease, enriched run receipts, and missing-first reconciliation state
- fence every X page, terminal response, bounded stop, receipt update, and cursor advance inside the same SQLite write transaction
- add deterministic `sync-due`, `reconcile-due`, `reconcile`, and `receipts` commands without accepting physical corpus paths
- preserve immutable reconciliation evidence, deactivate remotely missing activity provenance without purging canonical history, and restore it when evidence reappears

## Key decisions

- Leases are connection-scoped, so streams on the same remote account cannot race each other or duplicate provider cost.
- Fencing generations survive lease expiry and release. A takeover marks a crashed running receipt `abandoned`; a stale generation cannot renew, release its successor, write rows, or advance a cursor.
- Explicit and environment clock overrides fail closed outside the test harness, so a collector cannot bypass lease expiry with a caller-controlled clock.
- Successful content, coverage, cursor state, and receipt progress commit together. Failures and rate-limit resets never advance a cursor.
- Rate-limit resets schedule one deterministic retry at the provider boundary; other due work follows the configured daily/weekly interval.
- Reconciliation accepts only owner-held mode-0600 non-symlink JSON, rejects credential-shaped fields, disabled streams, stale snapshots, and same-time conflicting evidence.
- Complete remote absence becomes auditable `missing` state first. No reconciliation path deletes canonical objects, activities, raw evidence, or media.

## Write surface

- **Schema:** additive v1-to-v2 migration for `sync_runs`, `collector_lease_generations`, `collector_leases`, and `reconciliation_items`.
- **X sync:** existing immutable raw batches, normalized rows, FTS, coverage, and cursors now share the collector fence and receipt transaction.
- **Reconciliation:** writes an immutable evidence batch, reconciliation state, activity active/missing state, and one terminal receipt.
- **Read-only commands:** due plans and receipts return only opaque IDs, hashes, counters, statuses, and timestamps.
- **Rollback:** revert this PR. Existing v2 stores retain additive tables/columns; earlier readers fail closed on the newer schema instead of misreading it.

## Runtime Testing

- `runtime-verified`: exercised real SQLite migrations and transactions, concurrent lease election and takeover, stale-fence rejection, rate-limit retry scheduling, secure snapshot validation, and reconciliation state transitions through the repository integration suites.
- Live X collection was not required for this phase: provider I/O remains behind the existing tested adapter, while the new synchronization, fencing, receipt, and reconciliation paths use deterministic local fixtures.

## Verification

- `./.agents/tests/test-knowledge-social-sync.sh` — 32 passed
- `./.agents/tests/test-knowledge-social.sh` — 31 passed
- `./.agents/tests/test-knowledge-social-x.sh` — 51 passed
- `./.agents/tests/test-knowledge-social-query.sh` — 39 passed
- Python compilation, ShellCheck, shfmt, `git diff --check`, secret scanning, and changed-file complexity gates passed
- Qlty new-file gate — 0 smells; repository smell threshold — 51/53
- Codacy and CodeFactor static-analysis gates passed after in-code remediation

## Release

Release is not requested by this PR.

Resolves #28607

For #28587
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 8h 23m and 6,259,118 tokens on this with the user in an interactive session.