### PR TITLE
GH#28613: Add encrypted social workspace sharing

### DIFF
--- a/.agents/aidevops/knowledge-plane/01-core-contract.md
+++ b/.agents/aidevops/knowledge-plane/01-core-contract.md
@@ -135,6 +135,18 @@ inferred object must carry a finite `provider_json.confidence` score from `0` to
 `1`; malformed or missing confidence fails the query closed, and output retains
 the score with a mandatory-review marker and its evidence citation count.
 
+Workspace owners register X25519 encryption and Ed25519 signing public keys in
+the authenticated catalog before granting a member. Shared raw batches are
+canonicalized, signed by an active workspace principal, and wrapped separately
+for each active recipient with ephemeral X25519, HKDF-SHA256, and AES-256-GCM.
+Transport files contain ciphertext and opaque principal identifiers only; local
+paths and plaintext FTS databases are never included. An authorized recipient
+decrypts in memory, verifies the sender and batch hashes, imports immutable raw
+evidence, and rebuilds its own projection. Revocation atomically disables the
+membership and corpus grants, revokes that corpus-specific public key, and
+advances the corpus key epoch, so stale bundles and cached local queries fail
+before content access.
+
 **Provision:** `aidevops knowledge init repo` or `aidevops knowledge init personal`.
 **Repair:** `aidevops knowledge provision` is idempotent — safe to re-run.
 

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -10,6 +10,7 @@ PYTHON_HELPER="${SCRIPT_DIR}/knowledge_social_import.py"
 X_HELPER="${SCRIPT_DIR}/knowledge_social_x.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
+SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
 
 usage() {
 	cat <<'EOF'
@@ -35,6 +36,13 @@ Usage:
     [--lease-seconds SECONDS] [--now-epoch EPOCH]
   knowledge-social-helper.sh receipts [--base PATH] [--alias ALIAS] \
     [--connection-id ID] [--limit 1-1000]
+  knowledge-social-helper.sh share-keygen --base PATH --private-key FILE --public-key FILE
+  knowledge-social-helper.sh share-grant --base PATH --alias ALIAS --public-key FILE
+  knowledge-social-helper.sh share-export --base PATH --alias ALIAS \
+    --recipient-key FILE --sender-key FILE --output FILE
+  knowledge-social-helper.sh share-import --base PATH --alias ALIAS \
+    --private-key FILE --bundle FILE
+  knowledge-social-helper.sh share-revoke --base PATH --alias ALIAS --principal-id ID
 
 The authenticated corpus catalog resolves ALIAS with knowledge.write for
 mutating operations or knowledge.read for coverage, due plans, receipts, and
@@ -104,6 +112,14 @@ main() {
 			return 1
 		fi
 		python3 "$QUERY_HELPER" "$subcommand" "$@" || return 1
+		;;
+	share-keygen | share-grant | share-export | share-import | share-revoke)
+		require_runtime || return 1
+		if [[ ! -r "$SHARE_HELPER" ]]; then
+			printf 'ERROR: social sharing implementation missing: %s\n' "$SHARE_HELPER" >&2
+			return 1
+		fi
+		python3 "$SHARE_HELPER" "$subcommand" "$@" || return 1
 		;;
 	sync-due | reconcile-due | reconcile | receipts)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_corpus_catalog.py
+++ b/.agents/scripts/knowledge_corpus_catalog.py
@@ -23,7 +23,7 @@ from knowledge_corpus_context import (
     write_context_atomic,
 )
 
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
 DEFAULT_ALIAS = "personal:default"
 DEFAULT_CAPABILITY = "knowledge.read"
 CAPABILITIES = ("knowledge.read", "knowledge.write", "knowledge.manage")
@@ -107,6 +107,18 @@ def _create_schema(connection: sqlite3.Connection) -> None:
             collector_principal_id TEXT NOT NULL REFERENCES principals(principal_id),
             runner_ref TEXT NOT NULL
         )""",
+        """CREATE TABLE IF NOT EXISTS social_share_principals (
+            corpus_id TEXT NOT NULL REFERENCES corpora(corpus_id),
+            principal_id TEXT NOT NULL REFERENCES principals(principal_id),
+            encryption_public TEXT NOT NULL,
+            signing_public TEXT NOT NULL,
+            status TEXT NOT NULL CHECK(status IN ('active','revoked')),
+            PRIMARY KEY(corpus_id, principal_id)
+        )""",
+        """CREATE TABLE IF NOT EXISTS social_share_epochs (
+            corpus_id TEXT PRIMARY KEY REFERENCES corpora(corpus_id),
+            key_epoch INTEGER NOT NULL DEFAULT 1 CHECK(key_epoch > 0)
+        )""",
         """CREATE INDEX IF NOT EXISTS idx_memberships_principal
             ON workspace_memberships(principal_id, status)""",
         """CREATE INDEX IF NOT EXISTS idx_corpora_workspace
@@ -119,10 +131,11 @@ def _create_schema(connection: sqlite3.Connection) -> None:
     row = connection.execute(
         "SELECT value FROM schema_meta WHERE key='schema_version'"
     ).fetchone()
-    if row is not None and row["value"] != SCHEMA_VERSION:
+    if row is not None and row["value"] not in ("1", SCHEMA_VERSION):
         raise CatalogError(f"unsupported catalog schema version: {row['value']}")
     connection.execute(
-        "INSERT OR IGNORE INTO schema_meta(key,value) VALUES('schema_version',?)",
+        "INSERT INTO schema_meta(key,value) VALUES('schema_version',?) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
         (SCHEMA_VERSION,),
     )
     connection.execute(f"PRAGMA user_version={SCHEMA_VERSION}")

--- a/.agents/scripts/knowledge_social_import.py
+++ b/.agents/scripts/knowledge_social_import.py
@@ -235,6 +235,16 @@ def import_coverage(connection: Any, archive: dict[str, Any], provider: str, con
 
 def import_archive(root: Path, archive_path: Path) -> dict[str, Any]:
     archive, payload = load_archive(archive_path)
+    return import_archive_payload(root, archive, payload)
+
+
+def import_archive_payload(
+    root: Path, archive: dict[str, Any], payload: bytes
+) -> dict[str, Any]:
+    """Import an already-validated in-memory archive without plaintext staging."""
+    reject_credentials(archive)
+    if payload != canonical_json(archive).encode("utf-8"):
+        raise SocialStoreError("archive payload is not canonical")
     provider = validate_opaque(required_text(archive, "provider"), "provider")
     connection_id = validate_opaque(required_text(archive, "connection_id"), "connection_id")
     completed_at = required_text(archive, "exported_at")

--- a/.agents/scripts/knowledge_social_share.py
+++ b/.agents/scripts/knowledge_social_share.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Encrypted workspace social-batch distribution and grant revocation."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import hashlib
+import json
+import os
+import secrets
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature, InvalidTag
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey, X25519PublicKey
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from knowledge_corpus_catalog import (
+    _connect_catalog,
+    _open_authorized_catalog,
+    _authorized_rows,
+    resolve,
+)
+from knowledge_corpus_context import CatalogError, validate_private_file
+from knowledge_social_import import import_archive_payload
+from knowledge_social_store import SocialStoreError, validate_root
+
+FORMAT_VERSION = 1
+AAD = b"aidevops-social-share-v1"
+
+
+class ShareError(RuntimeError):
+    """Raised when a social sharing boundary fails closed."""
+
+
+def b64e(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def b64d(value: str) -> bytes:
+    return base64.b64decode((value + "=" * (-len(value) % 4)).encode("ascii"), altchars=b"-_", validate=True)
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def read_json(path: Path, *, private: bool = False) -> dict[str, Any]:
+    if private:
+        validate_private_file(path, "social share private key", repair=False)
+    elif path.is_symlink() or not path.is_file():
+        raise ShareError("social share input must be a regular non-symlink file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ShareError("social share input is not valid UTF-8 JSON") from error
+    if not isinstance(value, dict):
+        raise ShareError("social share input must contain a JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any], mode: int) -> None:
+    if path.exists() or path.is_symlink():
+        raise ShareError("refusing to replace an existing social share file")
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        json.dump(value, handle, sort_keys=True, separators=(",", ":"))
+        handle.write("\n")
+
+
+def keygen(base: Path, private_path: Path, public_path: Path) -> dict[str, Any]:
+    _resolved, principal_id, read_connection = _open_authorized_catalog(base)
+    read_connection.close()
+    encryption = X25519PrivateKey.generate()
+    signing = Ed25519PrivateKey.generate()
+    public = {
+        "format": FORMAT_VERSION,
+        "principal_id": principal_id,
+        "encryption_public": b64e(encryption.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)),
+        "signing_public": b64e(signing.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)),
+    }
+    private = dict(public)
+    private["encryption_private"] = b64e(encryption.private_bytes(serialization.Encoding.Raw, serialization.PrivateFormat.Raw, serialization.NoEncryption()))
+    private["signing_private"] = b64e(signing.private_bytes(serialization.Encoding.Raw, serialization.PrivateFormat.Raw, serialization.NoEncryption()))
+    write_json(private_path, private, 0o600)
+    write_json(public_path, public, 0o644)
+    return {"principal_id": principal_id, "public_key": str(public_path)}
+
+
+def writable_catalog(base: Path, alias: str) -> tuple[str, sqlite3.Connection, sqlite3.Row]:
+    resolved, principal_id, read_connection = _open_authorized_catalog(base)
+    try:
+        rows = _authorized_rows(read_connection, principal_id, "knowledge.manage", alias)
+        if len(rows) != 1:
+            raise ShareError("access denied: workspace management grant required")
+        row = rows[0]
+    finally:
+        read_connection.close()
+    connection = _connect_catalog(resolved / "catalog.db", read_only=False)
+    return principal_id, connection, row
+
+
+def grant(base: Path, alias: str, public_path: Path) -> dict[str, Any]:
+    public = read_json(public_path)
+    target = str(public.get("principal_id", ""))
+    if not target.startswith("prn_") or len(target) != 36:
+        raise ShareError("recipient public key has invalid principal identity")
+    try:
+        X25519PublicKey.from_public_bytes(b64d(str(public["encryption_public"])))
+        Ed25519PublicKey.from_public_bytes(b64d(str(public["signing_public"])))
+    except (KeyError, ValueError) as error:
+        raise ShareError("recipient public key has invalid key material") from error
+    owner, connection, corpus = writable_catalog(base, alias)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        workspace = connection.execute("SELECT kind,status FROM workspaces WHERE workspace_id=?", (corpus["workspace_id"],)).fetchone()
+        if workspace is None or workspace["kind"] != "workspace" or workspace["status"] != "active":
+            raise ShareError("sharing requires an active workspace corpus")
+        if target != owner:
+            connection.execute("INSERT INTO principals(principal_id,kind,status) VALUES(?, 'human', 'active') ON CONFLICT(principal_id) DO UPDATE SET status='active'", (target,))
+            connection.execute("INSERT INTO workspace_memberships(workspace_id,principal_id,role,status) VALUES(?,?,'member','active') ON CONFLICT(workspace_id,principal_id) DO UPDATE SET role='member',status='active'", (corpus["workspace_id"], target))
+            for capability in ("knowledge.read", "knowledge.write"):
+                connection.execute("INSERT INTO corpus_grants(corpus_id,principal_id,role,capability,scope,status) VALUES(?,?,'member',?,'corpus','active') ON CONFLICT(corpus_id,principal_id,capability,scope) DO UPDATE SET role='member',status='active'", (corpus["corpus_id"], target, capability))
+        connection.execute("INSERT INTO social_share_principals(corpus_id,principal_id,encryption_public,signing_public,status) VALUES(?,?,?,?,'active') ON CONFLICT(corpus_id,principal_id) DO UPDATE SET encryption_public=excluded.encryption_public,signing_public=excluded.signing_public,status='active'", (corpus["corpus_id"], target, str(public["encryption_public"]), str(public["signing_public"])))
+        connection.execute("INSERT OR IGNORE INTO social_share_epochs(corpus_id,key_epoch) VALUES(?,1)", (corpus["corpus_id"],))
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+    return {"alias": alias, "principal_id": target, "status": "active"}
+
+
+def active_share_record(base: Path, alias: str, principal_id: str) -> tuple[sqlite3.Row, int]:
+    resolved, _current, connection = _open_authorized_catalog(base)
+    try:
+        row = connection.execute("""SELECT s.*,c.corpus_id FROM social_share_principals s
+            JOIN corpus_grants g ON g.principal_id=s.principal_id AND g.corpus_id=s.corpus_id AND g.status='active' AND g.capability='knowledge.read'
+            JOIN corpora c ON c.corpus_id=g.corpus_id JOIN corpus_aliases a ON a.corpus_id=c.corpus_id
+            JOIN workspace_memberships m ON m.workspace_id=c.workspace_id AND m.principal_id=s.principal_id AND m.status='active'
+            WHERE a.alias=? AND s.principal_id=? AND s.status='active'""", (alias, principal_id)).fetchone()
+        if row is None:
+            raise ShareError("recipient is not an active authorized workspace principal")
+        epoch_row = connection.execute("SELECT key_epoch FROM social_share_epochs WHERE corpus_id=?", (row["corpus_id"],)).fetchone()
+        return row, int(epoch_row["key_epoch"] if epoch_row else 1)
+    finally:
+        connection.close()
+
+
+def export_bundle(base: Path, alias: str, recipient_path: Path, sender_path: Path, output: Path) -> dict[str, Any]:
+    recipient = read_json(recipient_path)
+    sender = read_json(sender_path, private=True)
+    root = validate_root(resolve(base, alias, "knowledge.read"))
+    recipient_record, epoch = active_share_record(base, alias, str(recipient.get("principal_id", "")))
+    if str(recipient.get("encryption_public")) != recipient_record["encryption_public"]:
+        raise ShareError("recipient key does not match the active workspace grant")
+    sender_record, sender_epoch = active_share_record(base, alias, str(sender.get("principal_id", "")))
+    if sender_epoch != epoch or str(sender.get("signing_public")) != sender_record["signing_public"]:
+        raise ShareError("sender key does not match an active workspace grant")
+    raw_root = root / "sources" / "social" / "raw"
+    batches = []
+    if raw_root.exists():
+        for path in sorted(raw_root.glob("*/*/*.json.gz")):
+            if path.is_symlink() or not path.is_file():
+                raise ShareError("raw batch tree contains an unsafe entry")
+            payload = gzip.decompress(path.read_bytes())
+            batches.append({"sha256": hashlib.sha256(payload).hexdigest(), "archive": json.loads(payload)})
+    plaintext = canonical({"alias": alias, "epoch": epoch, "batches": batches})
+    ephemeral = X25519PrivateKey.generate()
+    shared = ephemeral.exchange(X25519PublicKey.from_public_bytes(b64d(recipient_record["encryption_public"])))
+    salt = secrets.token_bytes(16)
+    key = HKDF(algorithm=hashes.SHA256(), length=32, salt=salt, info=AAD).derive(shared)
+    nonce = secrets.token_bytes(12)
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, AAD)
+    unsigned = {"format": FORMAT_VERSION, "recipient": recipient_record["principal_id"], "sender": sender["principal_id"], "epoch": epoch, "ephemeral_public": b64e(ephemeral.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)), "salt": b64e(salt), "nonce": b64e(nonce), "ciphertext": b64e(ciphertext)}
+    signature = Ed25519PrivateKey.from_private_bytes(b64d(str(sender["signing_private"]))).sign(canonical(unsigned))
+    bundle = dict(unsigned, signature=b64e(signature))
+    write_json(output, bundle, 0o600)
+    return {"batches": len(batches), "epoch": epoch, "recipient": recipient_record["principal_id"]}
+
+
+def import_bundle(base: Path, alias: str, private_path: Path, bundle_path: Path) -> dict[str, Any]:
+    private = read_json(private_path, private=True)
+    bundle = read_json(bundle_path)
+    _resolved, current, connection = _open_authorized_catalog(base)
+    connection.close()
+    if bundle.get("recipient") != current or private.get("principal_id") != current:
+        raise ShareError("bundle recipient does not match the authenticated principal")
+    sender_record, epoch = active_share_record(base, alias, str(bundle.get("sender", "")))
+    if int(bundle.get("epoch", 0)) != epoch:
+        raise ShareError("bundle key epoch is stale or revoked")
+    unsigned = {key: value for key, value in bundle.items() if key != "signature"}
+    try:
+        Ed25519PublicKey.from_public_bytes(
+            b64d(sender_record["signing_public"])
+        ).verify(b64d(str(bundle["signature"])), canonical(unsigned))
+    except InvalidSignature as error:
+        raise ShareError("bundle sender signature verification failed") from error
+    recipient_private = X25519PrivateKey.from_private_bytes(b64d(str(private["encryption_private"])))
+    shared = recipient_private.exchange(X25519PublicKey.from_public_bytes(b64d(str(bundle["ephemeral_public"]))))
+    key = HKDF(algorithm=hashes.SHA256(), length=32, salt=b64d(str(bundle["salt"])), info=AAD).derive(shared)
+    try:
+        plaintext = AESGCM(key).decrypt(
+            b64d(str(bundle["nonce"])), b64d(str(bundle["ciphertext"])), AAD
+        )
+    except InvalidTag as error:
+        raise ShareError("bundle authenticated decryption failed") from error
+    payload = json.loads(plaintext)
+    if not isinstance(payload, dict) or payload.get("alias") != alias or payload.get("epoch") != epoch:
+        raise ShareError("decrypted bundle scope does not match the authorized corpus")
+    batches = payload.get("batches")
+    if not isinstance(batches, list) or any(not isinstance(batch, dict) for batch in batches):
+        raise ShareError("decrypted bundle has invalid batch records")
+    root = validate_root(resolve(base, alias, "knowledge.write"))
+    imported = 0
+    for batch in batches:
+        archive_bytes = canonical(batch["archive"])
+        if hashlib.sha256(archive_bytes).hexdigest() != batch["sha256"]:
+            raise ShareError("decrypted batch hash mismatch")
+        import_archive_payload(root, batch["archive"], archive_bytes)
+        imported += 1
+    return {"imported": imported, "epoch": epoch}
+
+
+def revoke(base: Path, alias: str, principal_id: str) -> dict[str, Any]:
+    _owner, connection, corpus = writable_catalog(base, alias)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        membership = connection.execute("UPDATE workspace_memberships SET status='inactive' WHERE workspace_id=? AND principal_id=? AND status='active'", (corpus["workspace_id"], principal_id)).rowcount
+        grants = connection.execute("UPDATE corpus_grants SET status='inactive' WHERE corpus_id=? AND principal_id=? AND status='active'", (corpus["corpus_id"], principal_id)).rowcount
+        share_key = connection.execute("UPDATE social_share_principals SET status='revoked' WHERE corpus_id=? AND principal_id=? AND status='active'", (corpus["corpus_id"], principal_id)).rowcount
+        if membership != 1 or grants < 1 or share_key != 1:
+            raise ShareError("principal did not have an active complete workspace grant")
+        connection.execute("INSERT INTO social_share_epochs(corpus_id,key_epoch) VALUES(?,2) ON CONFLICT(corpus_id) DO UPDATE SET key_epoch=key_epoch+1", (corpus["corpus_id"],))
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+    return {"principal_id": principal_id, "status": "revoked"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("share-keygen", "share-grant", "share-export", "share-import", "share-revoke"))
+    parser.add_argument("--base", type=Path, required=True)
+    parser.add_argument("--alias", default="personal:default")
+    parser.add_argument("--private-key", type=Path)
+    parser.add_argument("--public-key", type=Path)
+    parser.add_argument("--recipient-key", type=Path)
+    parser.add_argument("--sender-key", type=Path)
+    parser.add_argument("--bundle", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--principal-id")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "share-keygen" and args.private_key and args.public_key:
+            result = keygen(args.base, args.private_key, args.public_key)
+        elif args.command == "share-grant" and args.public_key:
+            result = grant(args.base, args.alias, args.public_key)
+        elif args.command == "share-export" and args.recipient_key and args.sender_key and args.output:
+            result = export_bundle(args.base, args.alias, args.recipient_key, args.sender_key, args.output)
+        elif args.command == "share-import" and args.private_key and args.bundle:
+            result = import_bundle(args.base, args.alias, args.private_key, args.bundle)
+        elif args.command == "share-revoke" and args.principal_id:
+            result = revoke(args.base, args.alias, args.principal_id)
+        else:
+            raise ShareError("required command arguments are missing")
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (CatalogError, InvalidSignature, InvalidTag, KeyError, OSError, ShareError, SocialStoreError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-corpus.sh
+++ b/.agents/tests/test-knowledge-corpus.sh
@@ -199,8 +199,8 @@ assert_eq "1.8 read grant resolves legacy root" "$resolved" "$LEGACY_ROOT"
 listed=$(bash "$CORPUS_HELPER" list --base "$BASE" --capability knowledge.read)
 assert_contains "1.9 authorized list includes personal alias" "$listed" "personal:default"
 assert_contains "1.10 authorized list includes legacy path" "$listed" "$LEGACY_ROOT"
-assert_eq "1.11 schema version is 1" \
-	"$(db_query "$CATALOG" "SELECT value FROM schema_meta WHERE key='schema_version'")" "1"
+assert_eq "1.11 schema version is 2" \
+	"$(db_query "$CATALOG" "SELECT value FROM schema_meta WHERE key='schema_version'")" "2"
 assert_eq "1.12 bootstrap graph has one row per ownership edge" \
 	"$(db_query "$CATALOG" "SELECT (SELECT count(*) FROM principals),(SELECT count(*) FROM workspaces),(SELECT count(*) FROM workspace_memberships),(SELECT count(*) FROM corpora),(SELECT count(*) FROM corpus_aliases)")" \
 	"1|1|1|1|1"

--- a/.agents/tests/test-knowledge-social-share.sh
+++ b/.agents/tests/test-knowledge-social-share.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-share.sh — Encrypted social workspace isolation tests
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+TMP_DIR=$(mktemp -d)
+OWNER_BASE="${TMP_DIR}/owner"
+MEMBER_BASE="${TMP_DIR}/member"
+OWNER_TEAM="${OWNER_BASE}/team-corpus"
+MEMBER_TEAM="${MEMBER_BASE}/team-corpus"
+ARCHIVE="${TMP_DIR}/archive.json"
+BUNDLE="${TMP_DIR}/bundle.json"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_pass() {
+	local description="$1"
+	shift
+	if "$@"; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s\n' "$description"
+	fi
+	return 0
+}
+
+assert_fail() {
+	local description="$1"
+	shift
+	if "$@"; then
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (unexpected success)\n' "$description"
+	else
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	fi
+	return 0
+}
+
+contains_no_plaintext() {
+	local bundle="$1"
+	if rg -q 'workspace secret evidence|team-corpus|/owner|/member' "$bundle"; then
+		return 1
+	fi
+	return 0
+}
+
+query_has_result() {
+	local base="$1"
+	local result
+	result=$("$SOCIAL_HELPER" query --base "$base" --alias workspace:team --query secret)
+	python3 -c 'import json,sys; assert len(json.loads(sys.argv[1])["results"]) == 1' "$result"
+	return 0
+}
+
+printf 'Encrypted social workspace tests\n'
+for base in "$OWNER_BASE" "$MEMBER_BASE"; do
+	mkdir -p "$base/_knowledge"
+	chmod 0700 "$base" "$base/_knowledge"
+	"$CORPUS_HELPER" provision --base "$base" >/dev/null
+done
+
+"$SOCIAL_HELPER" share-keygen --base "$OWNER_BASE" \
+	--private-key "$OWNER_BASE/owner-private.json" --public-key "$OWNER_BASE/owner-public.json" >/dev/null
+"$SOCIAL_HELPER" share-keygen --base "$MEMBER_BASE" \
+	--private-key "$MEMBER_BASE/member-private.json" --public-key "$MEMBER_BASE/member-public.json" >/dev/null
+
+mkdir -p "$OWNER_TEAM" "$MEMBER_TEAM"
+chmod 0700 "$OWNER_TEAM" "$MEMBER_TEAM"
+python3 - "$OWNER_BASE" "$OWNER_TEAM" <<'PY'
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+base = Path(sys.argv[1])
+root = Path(sys.argv[2])
+principal = json.loads((base / "_config/principal.json").read_text())["principal_id"]
+db = sqlite3.connect(base / "catalog.db")
+db.execute("INSERT INTO workspaces VALUES('wsp_team','workspace','active')")
+db.execute("INSERT INTO workspace_memberships VALUES('wsp_team',?,'owner','active')", (principal,))
+db.execute("INSERT INTO corpora VALUES('cor_team','wsp_team',?,'confidential','active')", (str(root),))
+db.execute("INSERT INTO corpus_aliases VALUES('workspace:team','cor_team')")
+for capability in ("knowledge.read", "knowledge.write", "knowledge.manage"):
+    db.execute("INSERT INTO corpus_grants VALUES('cor_team',?,'owner',?,'corpus','active')", (principal, capability))
+db.commit()
+db.close()
+PY
+
+cat >"$ARCHIVE" <<'JSON'
+{"provider":"xapi","connection_id":"conn_shared_001","remote_account_id":"acct-shared","exported_at":"2026-07-25T00:00:00Z","accounts":[],"objects":[{"object_type":"post","remote_id":"shared-post-1","account_remote_id":"acct-shared","text":"workspace secret evidence","observed_at":"2026-07-25T00:00:00Z","evidence_class":"authored"}],"activities":[],"media":[],"coverage":[]}
+JSON
+chmod 0600 "$ARCHIVE"
+"$SOCIAL_HELPER" provision --base "$OWNER_BASE" --alias workspace:team >/dev/null
+"$SOCIAL_HELPER" import-archive --base "$OWNER_BASE" --alias workspace:team --archive "$ARCHIVE" >/dev/null
+"$SOCIAL_HELPER" share-grant --base "$OWNER_BASE" --alias workspace:team \
+	--public-key "$OWNER_BASE/owner-public.json" >/dev/null
+"$SOCIAL_HELPER" share-grant --base "$OWNER_BASE" --alias workspace:team \
+	--public-key "$MEMBER_BASE/member-public.json" >/dev/null
+"$SOCIAL_HELPER" share-export --base "$OWNER_BASE" --alias workspace:team \
+	--recipient-key "$MEMBER_BASE/member-public.json" --sender-key "$OWNER_BASE/owner-private.json" \
+	--output "$BUNDLE" >/dev/null
+
+assert_pass "transport contains ciphertext without plaintext or private paths" contains_no_plaintext "$BUNDLE"
+
+# Simulate authenticated membership-state delivery to a second trusted device.
+cp "$OWNER_BASE/catalog.db" "$MEMBER_BASE/catalog.db"
+chmod 0600 "$MEMBER_BASE/catalog.db"
+python3 - "$MEMBER_BASE/catalog.db" "$MEMBER_TEAM" <<'PY'
+import sqlite3
+import sys
+db = sqlite3.connect(sys.argv[1])
+db.execute("UPDATE corpora SET location_ref=? WHERE corpus_id='cor_team'", (sys.argv[2],))
+db.commit()
+db.close()
+PY
+
+tampered_bundle="${TMP_DIR}/tampered-bundle.json"
+cp "$BUNDLE" "$tampered_bundle"
+python3 - "$tampered_bundle" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+bundle = json.load(open(path, encoding="utf-8"))
+bundle["signature"] = ("A" if bundle["signature"][0] != "A" else "B") + bundle["signature"][1:]
+json.dump(bundle, open(path, "w", encoding="utf-8"), sort_keys=True, separators=(",", ":"))
+PY
+assert_fail "tampered sender signature is rejected before local import" \
+	"$SOCIAL_HELPER" share-import --base "$MEMBER_BASE" --alias workspace:team \
+	--private-key "$MEMBER_BASE/member-private.json" --bundle "$tampered_bundle"
+
+"$SOCIAL_HELPER" share-import --base "$MEMBER_BASE" --alias workspace:team \
+	--private-key "$MEMBER_BASE/member-private.json" --bundle "$BUNDLE" >/dev/null
+assert_pass "authorized member decrypts and rebuilds a local searchable index" query_has_result "$MEMBER_BASE"
+
+member_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["principal_id"])' "$MEMBER_BASE/member-public.json")
+"$SOCIAL_HELPER" share-revoke --base "$OWNER_BASE" --alias workspace:team --principal-id "$member_id" >/dev/null
+cp "$OWNER_BASE/catalog.db" "$MEMBER_BASE/catalog.db"
+chmod 0600 "$MEMBER_BASE/catalog.db"
+python3 - "$MEMBER_BASE/catalog.db" "$MEMBER_TEAM" <<'PY'
+import sqlite3
+import sys
+db = sqlite3.connect(sys.argv[1])
+db.execute("UPDATE corpora SET location_ref=? WHERE corpus_id='cor_team'", (sys.argv[2],))
+db.commit()
+db.close()
+PY
+
+assert_fail "revoked member cannot query a locally cached index" \
+	"$SOCIAL_HELPER" query --base "$MEMBER_BASE" --alias workspace:team --query secret
+assert_fail "revoked member cannot replay an old encrypted bundle" \
+	"$SOCIAL_HELPER" share-import --base "$MEMBER_BASE" --alias workspace:team \
+	--private-key "$MEMBER_BASE/member-private.json" --bundle "$BUNDLE"
+
+printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- add authenticated workspace member grants and revocation
- distribute signed social raw batches with per-recipient X25519/AES-256-GCM envelopes
- rebuild each authorized recipient's local FTS projection after import

## Testing

- `test-knowledge-social-share.sh`: 5 passed (ciphertext privacy, signature tamper, local rebuild, cached-query revocation, stale-bundle replay)
- `test-knowledge-corpus.sh`: 45 passed
- `test-knowledge-social.sh`: 31 passed
- `test-knowledge-social-query.sh`: 39 passed
- `test-knowledge-social-sync.sh`: 32 passed
- `linters-local.sh --changed`: passed

Resolves #28613
For #28587

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4
