### PR TITLE
GH#28617: Add bounded social browser gaps

### DIFF
--- a/.agents/aidevops/knowledge-plane/01-core-contract.md
+++ b/.agents/aidevops/knowledge-plane/01-core-contract.md
@@ -147,6 +147,13 @@ membership and corpus grants, revokes that corpus-specific public key, and
 advances the corpus key epoch, so stale bundles and cached local queries fail
 before content access.
 
+Provider extensions and browser-gap ingestion follow
+`05-social-operations.md`. The provider contract permits no platform writes and
+fixes collection priority at API, archive, then browser gap. A browser artifact
+requires an explicit API/archive coverage gap, matching tested selector version,
+private mode-0600 inputs, hard item/byte limits, and a resumable checkpoint.
+Canonical replay is idempotent and consumes no provider request budget.
+
 **Provision:** `aidevops knowledge init repo` or `aidevops knowledge init personal`.
 **Repair:** `aidevops knowledge provision` is idempotent — safe to re-run.
 

--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -1,0 +1,74 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Social Corpus Operations
+
+Social collection is read-only and follows a fixed order: official API, account
+archive, then browser-gap capture. A browser artifact is not accepted merely
+because it is available; an explicit private gap record must first identify a
+provider stream whose API/archive coverage is partial or unavailable.
+
+## Provider extension contract
+
+Each provider manifest is private mode-0600 JSON. Contract version 1 requires:
+
+- an opaque `provider` ID and unique provider-neutral `streams`;
+- `collection_routes` exactly `api`, `archive`, `browser_gap` in that order;
+- an empty `write_operations` array;
+- `browser_gap.read_only` and `browser_gap.checkpointed` set to `true`.
+
+Validate a manifest before implementation or collection:
+
+```bash
+knowledge-social-helper.sh provider-validate --manifest provider.json
+```
+
+Provider adapters normalize records into the existing account, object, activity,
+media, coverage, and raw-batch schema. Provider-only fields remain inside
+`provider_json`. New adapters must preserve opaque local connection IDs, reject
+credential-shaped fields, use independent stream checkpoints, expose hard cost
+budgets, and add pagination, terminal-failure, replay, and write-reachability
+tests. No provider may add engagement or other platform mutations.
+
+## Bounded browser-gap capture
+
+Browser execution remains outside the corpus helper and uses an approved private
+profile through the Reach contract. Export only a sanitized mode-0600 JSON
+artifact. The importer cannot launch a browser, submit a form, or reuse cookies.
+
+The private gap record identifies `provider`, `stream`, `status` (`partial` or
+`unavailable`), `official_routes_exhausted: true`, a sanitized `reason`, and
+`observed_at`, and the tested `selector_version`. The capture identifies the same
+scope and selector version, opaque connection/account IDs, `read_only: true`,
+`checkpoint`, `observed_at`, completion state, and provider-neutral records.
+
+```bash
+knowledge-social-helper.sh capture-browser-gap \
+  --manifest provider.json --gap gap.json --capture capture.json \
+  --max-items 100 --max-bytes 1048576
+```
+
+The limits are hard stops. Interrupted captures retain their external checkpoint
+and record paused coverage. Replaying the same canonical artifact returns the
+same content-addressed batch and does not duplicate objects. Selector drift,
+authentication loss, CAPTCHA, or a changed account scope stops that route; it
+does not authorize a profile, proxy, or identity change.
+
+## Operator verification
+
+Before enabling a routine:
+
+1. Confirm the corpus alias resolves only for the authenticated principal.
+2. Run API/archive coverage and record the exact remaining stream gap.
+3. Validate the provider manifest and dry-run the browser extraction manually.
+4. Import one bounded artifact, then replay it to prove idempotency.
+5. Inspect coverage, receipts, and citations without printing handles, paths, or
+   raw private content.
+6. Verify request budgets and terminal rate-limit state remain unchanged by the
+   browser route; browser capture never disguises provider API cost.
+7. Run corpus, social-store, query, sync, sharing, provider, and browser-gap tests.
+
+Shared deployments remain limited to the tested encrypted grant/distribution
+contract. Revocation must be verified before cached results are served. Combined
+personal/workspace retrieval runs on the authorized user device, and public
+diagnostics contain neither private content nor local paths.

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -11,6 +11,7 @@ X_HELPER="${SCRIPT_DIR}/knowledge_social_x.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
+BROWSER_HELPER="${SCRIPT_DIR}/knowledge_social_browser.py"
 
 usage() {
 	cat <<'EOF'
@@ -43,6 +44,10 @@ Usage:
   knowledge-social-helper.sh share-import --base PATH --alias ALIAS \
     --private-key FILE --bundle FILE
   knowledge-social-helper.sh share-revoke --base PATH --alias ALIAS --principal-id ID
+  knowledge-social-helper.sh provider-validate --manifest FILE
+  knowledge-social-helper.sh capture-browser-gap [--base PATH] [--alias ALIAS] \
+    --manifest FILE --gap FILE --capture FILE [--max-items 1-1000] \
+    [--max-bytes 1024-10485760]
 
 The authenticated corpus catalog resolves ALIAS with knowledge.write for
 mutating operations or knowledge.read for coverage, due plans, receipts, and
@@ -71,6 +76,13 @@ Deterministic routines:
   normalized rows, checkpoints, and the run receipt commit in one transaction.
   Reconciliation snapshots must be private JSON files and mark remote absence as
   missing evidence. They never purge canonical content.
+
+Browser gap capture:
+  Browser input is accepted only for a provider-declared stream after a private
+  gap record proves official API/archive coverage is unavailable or partial.
+  Capture files are read-only artifacts from an approved profile; this helper
+  cannot launch a browser or perform a platform write. Item and byte limits are
+  hard bounds, and replay is content-addressed and idempotent.
 EOF
 	return 0
 }
@@ -120,6 +132,14 @@ main() {
 			return 1
 		fi
 		python3 "$SHARE_HELPER" "$subcommand" "$@" || return 1
+		;;
+	provider-validate | capture-browser-gap)
+		require_runtime || return 1
+		if [[ ! -r "$BROWSER_HELPER" ]]; then
+			printf 'ERROR: social browser adapter missing: %s\n' "$BROWSER_HELPER" >&2
+			return 1
+		fi
+		python3 "$BROWSER_HELPER" "$subcommand" "$@" || return 1
 		;;
 	sync-due | reconcile-due | reconcile | receipts)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_social_browser.py
+++ b/.agents/scripts/knowledge_social_browser.py
@@ -18,7 +18,7 @@ from knowledge_social_import import canonical_json, import_archive_payload, reje
 from knowledge_social_store import SocialStoreError, validate_opaque, validate_root
 
 CONTRACT_VERSION = 1
-GAP_STATES = {"partial", "unavailable"}
+GAP_STATES = ("partial", "unavailable")
 
 
 def private_json(path: Path, label: str, max_bytes: int) -> dict[str, Any]:

--- a/.agents/scripts/knowledge_social_browser.py
+++ b/.agents/scripts/knowledge_social_browser.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate social providers and import bounded browser-gap evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
+from knowledge_corpus_context import CatalogError
+from knowledge_social_import import canonical_json, import_archive_payload, reject_credentials
+from knowledge_social_store import SocialStoreError, validate_opaque, validate_root
+
+CONTRACT_VERSION = 1
+GAP_STATES = {"partial", "unavailable"}
+
+
+def private_json(path: Path, label: str, max_bytes: int) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise SocialStoreError(f"{label} must be a regular non-symlink file")
+    if stat.S_IMODE(path.stat().st_mode) & 0o077:
+        raise SocialStoreError(f"{label} must have mode 0600")
+    if path.stat().st_size > max_bytes:
+        raise SocialStoreError(f"{label} exceeds the byte budget")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SocialStoreError(f"{label} is not valid UTF-8 JSON") from error
+    if not isinstance(value, dict):
+        raise SocialStoreError(f"{label} root must be an object")
+    reject_credentials(value)
+    return value
+
+
+def text(value: dict[str, Any], key: str) -> str:
+    result = value.get(key)
+    if not isinstance(result, str) or not result:
+        raise SocialStoreError(f"provider contract requires non-empty {key}")
+    return result
+
+
+def validate_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    if manifest.get("contract_version") != CONTRACT_VERSION:
+        raise SocialStoreError("unsupported provider contract version")
+    provider = validate_opaque(text(manifest, "provider"), "provider")
+    streams = manifest.get("streams")
+    writes = manifest.get("write_operations")
+    routes = manifest.get("collection_routes")
+    if not isinstance(streams, list) or not streams:
+        raise SocialStoreError("provider contract requires at least one stream")
+    if any(not isinstance(item, str) or not item for item in streams):
+        raise SocialStoreError("provider streams must be non-empty strings")
+    if len(set(streams)) != len(streams):
+        raise SocialStoreError("provider streams must be unique")
+    if writes != []:
+        raise SocialStoreError("social providers must declare no write operations")
+    if routes != ["api", "archive", "browser_gap"]:
+        raise SocialStoreError("collection routes must preserve API/archive/browser order")
+    browser = manifest.get("browser_gap")
+    if not isinstance(browser, dict) or browser.get("checkpointed") is not True:
+        raise SocialStoreError("browser gap route must declare checkpointed capture")
+    if browser.get("read_only") is not True:
+        raise SocialStoreError("browser gap route must be read-only")
+    return {"contract_version": CONTRACT_VERSION, "provider": provider, "streams": sorted(streams)}
+
+
+def validate_gap(
+    gap: dict[str, Any], provider: str, streams: list[str]
+) -> tuple[str, str, str]:
+    if gap.get("provider") != provider:
+        raise SocialStoreError("gap provider does not match the provider contract")
+    stream = text(gap, "stream")
+    if stream not in streams:
+        raise SocialStoreError("gap stream is not declared by the provider")
+    if gap.get("status") not in GAP_STATES:
+        raise SocialStoreError("browser capture requires a partial or unavailable gap")
+    if gap.get("official_routes_exhausted") is not True:
+        raise SocialStoreError("API/archive routes must be exhausted before browser capture")
+    text(gap, "reason")
+    return stream, text(gap, "observed_at"), text(gap, "selector_version")
+
+
+def capture_records(capture: dict[str, Any], max_items: int) -> dict[str, list[dict[str, Any]]]:
+    records: dict[str, list[dict[str, Any]]] = {}
+    total = 0
+    for key in ("accounts", "objects", "activities", "media"):
+        value = capture.get(key, [])
+        if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+            raise SocialStoreError(f"capture {key} must be an array of objects")
+        records[key] = value
+        total += len(value)
+    if total > max_items:
+        raise SocialStoreError("capture exceeds the item budget")
+    return records
+
+
+def build_archive(
+    manifest: dict[str, Any], gap: dict[str, Any], capture: dict[str, Any], max_items: int
+) -> dict[str, Any]:
+    contract = validate_manifest(manifest)
+    stream, gap_observed_at, selector_version = validate_gap(
+        gap, contract["provider"], contract["streams"]
+    )
+    if capture.get("read_only") is not True:
+        raise SocialStoreError("browser capture must attest read-only operation")
+    if capture.get("provider") != contract["provider"] or capture.get("stream") != stream:
+        raise SocialStoreError("capture scope does not match the approved gap")
+    if capture.get("selector_version") != selector_version:
+        raise SocialStoreError("browser selector version drifted from the approved gap")
+    if not isinstance(capture.get("complete"), bool):
+        raise SocialStoreError("capture complete must be boolean")
+    records = capture_records(capture, max_items)
+    checkpoint = text(capture, "checkpoint")
+    observed_at = text(capture, "observed_at")
+    coverage_status = "complete" if capture.get("complete") is True else "paused"
+    return {
+        "provider": contract["provider"],
+        "connection_id": validate_opaque(text(capture, "connection_id"), "connection_id"),
+        "remote_account_id": text(capture, "remote_account_id"),
+        "enabled_streams": [stream],
+        "policy": {"collector": "browser_gap", "read_only": True},
+        "exported_at": observed_at,
+        **records,
+        "coverage": [{
+            "stream": stream,
+            "cursor_exhausted": capture.get("complete") is True,
+            "retention_limit": None,
+            "unavailable_reason": gap.get("reason"),
+            "status": coverage_status,
+            "observed_at": observed_at,
+            "provider_json": {"checkpoint": checkpoint, "gap_observed_at": gap_observed_at},
+        }],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("provider-validate", "capture-browser-gap"))
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--gap", type=Path)
+    parser.add_argument("--capture", type=Path)
+    parser.add_argument("--max-items", type=int, default=100)
+    parser.add_argument("--max-bytes", type=int, default=1_048_576)
+    args = parser.parse_args()
+    if not 1 <= args.max_items <= 1000:
+        parser.error("--max-items must be between 1 and 1000")
+    if not 1024 <= args.max_bytes <= 10_485_760:
+        parser.error("--max-bytes must be between 1024 and 10485760")
+    if args.command == "capture-browser-gap" and (args.gap is None or args.capture is None):
+        parser.error("capture-browser-gap requires --gap and --capture")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        manifest = private_json(args.manifest, "provider manifest", args.max_bytes)
+        if args.command == "provider-validate":
+            result = validate_manifest(manifest)
+        else:
+            gap = private_json(args.gap, "gap record", args.max_bytes)
+            capture = private_json(args.capture, "browser capture", args.max_bytes)
+            archive = build_archive(manifest, gap, capture, args.max_items)
+            base = args.base or Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+            root = validate_root(resolve(base, args.alias, "knowledge.write"))
+            result = import_archive_payload(root, archive, canonical_json(archive).encode("utf-8"))
+            result.update({"route": "browser_gap", "checkpoint": capture["checkpoint"]})
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (CatalogError, OSError, SocialStoreError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-browser.sh
+++ b/.agents/tests/test-knowledge-social-browser.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-browser.sh — Browser-gap and provider contract tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_pass() {
+	local description="$1"
+	shift
+	if "$@"; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s\n' "$description"
+	fi
+	return 0
+}
+
+assert_fail() {
+	local description="$1"
+	shift
+	if "$@" >/dev/null 2>&1; then
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (unexpected success)\n' "$description"
+	else
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	fi
+	return 0
+}
+
+json_eq() {
+	local left="$1"
+	local right="$2"
+	local field="$3"
+	python3 -c 'import json,sys; a=json.loads(sys.argv[1]); b=json.loads(sys.argv[2]); assert a[sys.argv[3]] == b[sys.argv[3]]' \
+		"$left" "$right" "$field"
+	return 0
+}
+
+sql_is() {
+	local query="$1"
+	local expected="$2"
+	python3 - "$ROOT/index/social.db" "$query" "$expected" <<'PY'
+import sqlite3
+import sys
+db = sqlite3.connect(sys.argv[1])
+actual = str(db.execute(sys.argv[2]).fetchone()[0])
+db.close()
+assert actual == sys.argv[3], (actual, sys.argv[3])
+PY
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+cat >"$TMP_DIR/provider.json" <<'JSON'
+{"contract_version":1,"provider":"fixture","streams":["saved"],"collection_routes":["api","archive","browser_gap"],"write_operations":[],"browser_gap":{"read_only":true,"checkpointed":true}}
+JSON
+cat >"$TMP_DIR/gap.json" <<'JSON'
+{"provider":"fixture","stream":"saved","status":"unavailable","official_routes_exhausted":true,"reason":"official export omits saved items","observed_at":"2026-07-25T10:00:00Z","selector_version":"v1"}
+JSON
+cat >"$TMP_DIR/capture.json" <<'JSON'
+{"provider":"fixture","stream":"saved","connection_id":"conn_fixture","remote_account_id":"acct_fixture","read_only":true,"checkpoint":"page_001","selector_version":"v1","observed_at":"2026-07-25T10:01:00Z","complete":false,"objects":[{"object_type":"post","remote_id":"post_001","account_remote_id":"acct_fixture","text":"bounded evidence","created_at":"2026-07-24T10:00:00Z","observed_at":"2026-07-25T10:01:00Z","evidence_class":"observed","provider_json":{"selector_version":"v1"}}]}
+JSON
+chmod 0600 "$TMP_DIR/provider.json" "$TMP_DIR/gap.json" "$TMP_DIR/capture.json"
+
+printf 'Social browser-gap tests\n'
+assert_pass "provider extension contract validates" \
+	"$SOCIAL_HELPER" provider-validate --manifest "$TMP_DIR/provider.json"
+
+first=$({ "$SOCIAL_HELPER" capture-browser-gap --base "$BASE" \
+	--manifest "$TMP_DIR/provider.json" --gap "$TMP_DIR/gap.json" \
+	--capture "$TMP_DIR/capture.json" --max-items 1; })
+second=$({ "$SOCIAL_HELPER" capture-browser-gap --base "$BASE" \
+	--manifest "$TMP_DIR/provider.json" --gap "$TMP_DIR/gap.json" \
+	--capture "$TMP_DIR/capture.json" --max-items 1; })
+assert_pass "capture replay keeps the same immutable batch" json_eq "$first" "$second" batch_id
+assert_pass "capture replay does not duplicate objects" sql_is "SELECT count(*) FROM objects" 1
+assert_pass "interrupted capture records paused gap coverage" sql_is \
+	"SELECT status || ':' || cursor_exhausted FROM coverage_records WHERE stream='saved'" "paused:0"
+assert_pass "browser route consumes no provider request budget" sql_is \
+	"SELECT sum(budget_units) FROM fetch_batches" 0
+
+python3 - "$TMP_DIR/capture.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+value = json.load(open(path, encoding="utf-8"))
+value["selector_version"] = "v2"
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(value, target)
+PY
+assert_fail "selector drift stops browser capture before persistence" \
+	"$SOCIAL_HELPER" capture-browser-gap --base "$BASE" --manifest "$TMP_DIR/provider.json" \
+	--gap "$TMP_DIR/gap.json" --capture "$TMP_DIR/capture.json"
+python3 - "$TMP_DIR/capture.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+value = json.load(open(path, encoding="utf-8"))
+value["selector_version"] = "v1"
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(value, target)
+PY
+
+python3 - "$TMP_DIR/gap.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+value = json.load(open(path, encoding="utf-8"))
+value["official_routes_exhausted"] = False
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(value, target)
+PY
+assert_fail "browser route remains disabled while official routes exist" \
+	"$SOCIAL_HELPER" capture-browser-gap --base "$BASE" --manifest "$TMP_DIR/provider.json" \
+	--gap "$TMP_DIR/gap.json" --capture "$TMP_DIR/capture.json"
+
+python3 - "$TMP_DIR/provider.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+value = json.load(open(path, encoding="utf-8"))
+value["write_operations"] = ["like"]
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(value, target)
+PY
+assert_fail "provider contract rejects platform writes" \
+	"$SOCIAL_HELPER" provider-validate --manifest "$TMP_DIR/provider.json"
+
+python3 - "$TMP_DIR/capture.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+value = json.load(open(path, encoding="utf-8"))
+value["cookie"] = "forbidden"
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(value, target)
+PY
+assert_fail "capture rejects credential-shaped material" \
+	"$SOCIAL_HELPER" capture-browser-gap --base "$BASE" --manifest "$TMP_DIR/provider.json" \
+	--gap "$TMP_DIR/gap.json" --capture "$TMP_DIR/capture.json"
+
+printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- add a provider extension contract that permits no social-platform writes
- import bounded browser-gap artifacts only after explicit API/archive gaps
- preserve content-addressed replay, checkpoints, privacy, cost, and coverage evidence
- document provider implementation and operator verification

## Testing

- 212 existing corpus/social assertions passed
- 9 browser-gap assertions passed
- Python and TypeScript compilation passed
- ShellCheck, shfmt, markdownlint, secret scanning, Qlty new-file analysis, and changed-file lint passed

Resolves #28617
For #28587
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 12m and 149,761 tokens on this as a headless worker.