### PR TITLE
GH#28614: Make interactive claim idempotency ownership-aware

### DIFF
--- a/.agents/scripts/interactive-session-helper-commands.sh
+++ b/.agents/scripts/interactive-session-helper-commands.sh
@@ -14,7 +14,8 @@
 #   - interactive-session-helper-stamp.sh (_isc_write_stamp, _isc_delete_stamp, _isc_post_claim_comment)
 #   - Logging/utility functions from orchestrator (_isc_info, _isc_warn, _isc_err,
 #     _isc_gh_reachable, _isc_current_user, _isc_can_manage_issue_state,
-#     _isc_has_in_review, _isc_has_label, _isc_carve_out_required, _isc_cmd_help)
+#     _isc_read_claim_metadata, _isc_has_label, _isc_carve_out_required,
+#     _isc_cmd_help)
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -116,12 +117,13 @@ _isc_claim_closed_issue_guard() {
 # Behaviour:
 #   - Offline gh: warn-and-continue (exit 0). A collision with a pulse worker
 #     is harmless — the interactive work naturally becomes its own issue/PR.
-#   - Idempotent: re-calling on an already-claimed issue refreshes the stamp
-#     timestamp but does not re-transition the label (saves an API round-trip).
-#   - Non-blocking on gh failures: best-effort label transition; all gh
-#     errors are swallowed so the caller's interactive workflow never stalls.
+#   - Idempotent: a re-call by the sole current assignee refreshes the stamp
+#     without a redundant GitHub edit.
+#   - Ownership failures fail closed: unavailable metadata, a foreign live
+#     interactive owner, or an unverifiable takeover never writes a stamp.
 #
-# Exit: 0 always (warn-and-continue contract).
+# Exit: 0 on a verified claim/idempotent skip, 1 on ownership conflict or
+# unverifiable metadata/transition, 2 on invalid arguments.
 _isc_existing_stamp_worktree() {
 	local issue="$1"
 	local slug="$2"
@@ -149,22 +151,133 @@ _isc_refresh_existing_claim() {
 	return 0
 }
 
+_isc_claim_ownership_class() {
+	local metadata="$1"
+	local user="$2"
+	local now_epoch=""
+	now_epoch=$(date +%s)
+	printf '%s' "$metadata" | jq -r --arg user "$user" --argjson now "$now_epoch" '
+		(.state // "" | ascii_downcase) as $state |
+		([.labels[]?.name] | index("status:in-review") != null) as $in_review |
+		[.assignees[]?.login] as $assignees |
+		[.comments[]?
+			| select((.body // "") | contains("Interactive session claimed by @"))
+			| select((.author.login // "") as $author
+				| ($assignees | index($author)) != null
+				and ((.body // "") | contains("Interactive session claimed by @\($author)")))
+			| select((.createdAt // "" | fromdateiso8601?) as $created
+				| $created != null and ($now - $created) >= 0 and ($now - $created) < 7200)
+		] | sort_by(.createdAt) | reverse | first as $live_claim |
+		if $state != "open" then "invalid-state"
+		elif ($in_review | not) then "unclaimed"
+		elif ($assignees | length) == 1 and $assignees[0] == $user then "own"
+		elif $live_claim != null then "foreign-interactive:" + $live_claim.author.login
+		else "foreign-worker" end
+	' 2>/dev/null
+	return $?
+}
+
+_isc_verified_caller_owns_claim() {
+	local issue="$1"
+	local slug="$2"
+	local user="$3"
+	local metadata=""
+	metadata=$(_isc_read_claim_metadata "$issue" "$slug") || return 1
+	printf '%s' "$metadata" | jq -e --arg user "$user" '
+		(.state | ascii_downcase) == "open" and
+		([.labels[]?.name] | index("status:in-review") != null) and
+		([.assignees[]?.login] == [$user])
+	' >/dev/null 2>&1
+	return $?
+}
+
 _isc_apply_new_claim() {
 	local issue="$1"
 	local slug="$2"
 	local worktree_path="$3"
 	local user="$4"
 	local defer_comment="$5"
-	if set_issue_status "$issue" "$slug" "in-review" --add-assignee "$user" >/dev/null 2>&1; then
-		_isc_info "claim: #$issue in $slug → status:in-review + assigned $user"
-		_isc_write_stamp "$issue" "$slug" "$worktree_path" "$user"
-		if [[ "$defer_comment" -eq 0 || -n "$worktree_path" ]]; then
-			_isc_post_claim_comment "$issue" "$slug" "$user" "$worktree_path"
-		fi
-		return 0
+	shift 5
+	local -a transition_args=(--add-assignee "$user" "$@")
+	if ! set_issue_status "$issue" "$slug" "in-review" "${transition_args[@]}" >/dev/null 2>&1; then
+		_isc_err "claim: ownership transition failed on #$issue; no stamp written"
+		return 1
 	fi
-	_isc_warn "claim: gh failed on #$issue — continuing without lock (collision is harmless)"
+	if ! _isc_verified_caller_owns_claim "$issue" "$slug" "$user"; then
+		_isc_err "claim: ownership transition on #$issue could not be verified; no stamp written"
+		return 1
+	fi
+	_isc_info "claim: #$issue in $slug → status:in-review + sole assignee $user"
+	_isc_write_stamp "$issue" "$slug" "$worktree_path" "$user"
+	if [[ "$defer_comment" -eq 0 || -n "$worktree_path" ]]; then
+		_isc_post_claim_comment "$issue" "$slug" "$user" "$worktree_path"
+	fi
 	return 0
+}
+
+_isc_take_over_worker_claim() {
+	local issue="$1"
+	local slug="$2"
+	local worktree_path="$3"
+	local user="$4"
+	local defer_comment="$5"
+	local assignees_csv="$6"
+	local -a remove_args=()
+	local -a assignees=()
+	local saved_ifs="${IFS:-}"
+	IFS=',' read -ra assignees <<<"$assignees_csv"
+	IFS="$saved_ifs"
+	local assignee=""
+	for assignee in "${assignees[@]}"; do
+		[[ -n "$assignee" && "$assignee" != "$user" ]] && remove_args+=(--remove-assignee "$assignee")
+	done
+	_isc_apply_new_claim "$issue" "$slug" "$worktree_path" "$user" "$defer_comment" "${remove_args[@]}"
+	return $?
+}
+
+_isc_handle_existing_claim_ownership() {
+	local issue="$1"
+	local slug="$2"
+	local worktree_path="$3"
+	local user="$4"
+	local defer_comment="$5"
+	local implementing="$6"
+	local claim_metadata="$7"
+	local ownership_class=""
+	if ! ownership_class=$(_isc_claim_ownership_class "$claim_metadata" "$user"); then
+		_isc_err "claim: ownership metadata invalid for #$issue; no stamp written"
+		return 1
+	fi
+	case "$ownership_class" in
+	own)
+		_isc_info "claim: #$issue already belongs to $user — refreshing stamp"
+		_isc_refresh_existing_claim "$issue" "$slug" "$worktree_path" "$user" "$defer_comment"
+		return 0
+		;;
+	foreign-interactive:*)
+		_isc_err "claim: #$issue has a live interactive owner @${ownership_class#*:}; refusing takeover"
+		return 1
+		;;
+	foreign-worker)
+		if [[ "$implementing" -eq 0 ]]; then
+			_isc_err "claim: #$issue is assigned to another principal; re-run with --implementing for an explicit worker takeover"
+			return 1
+		fi
+		local foreign_assignees=""
+		foreign_assignees=$(printf '%s' "$claim_metadata" | jq -r \
+			'[.assignees[]?.login] | join(",")' 2>/dev/null) || return 1
+		_isc_info "claim: #$issue has foreign worker ownership (${foreign_assignees:-unassigned}) — performing verified interactive takeover"
+		_isc_take_over_worker_claim "$issue" "$slug" "$worktree_path" "$user" "$defer_comment" "$foreign_assignees"
+		return $?
+		;;
+	unclaimed)
+		return 3
+		;;
+	*)
+		_isc_err "claim: unrecognized ownership state for #$issue; no stamp written"
+		return 1
+		;;
+	esac
 }
 
 _isc_cmd_claim() {
@@ -233,15 +346,19 @@ _isc_cmd_claim() {
 
 	_isc_claim_closed_issue_guard "$issue" "$slug" && return 0
 
-	# Idempotency: if already in-review, refresh stamp and exit. The `if`
-	# conditional consumes any non-zero return so set -e doesn't propagate
-	# rc=2 (lookup failed) up the call stack — see _isc_has_in_review header
-	# for the full set -e foot-gun (GH#18770/GH#18784/GH#18786 sibling class).
-	if _isc_has_in_review "$issue" "$slug"; then
-		_isc_info "claim: #$issue already has status:in-review — refreshing stamp"
-		_isc_refresh_existing_claim "$issue" "$slug" "$worktree_path" "$user" "$defer_comment"
-		return 0
+	local claim_metadata=""
+	if ! claim_metadata=$(_isc_read_claim_metadata "$issue" "$slug"); then
+		_isc_err "claim: ownership metadata unavailable for #$issue; no stamp written"
+		return 1
 	fi
+	local ownership_rc=0
+	_isc_handle_existing_claim_ownership "$issue" "$slug" "$worktree_path" "$user" \
+		"$defer_comment" "$implementing" "$claim_metadata" || ownership_rc=$?
+	case "$ownership_rc" in
+	0) return 0 ;;
+	3) ;;
+	*) return "$ownership_rc" ;;
+	esac
 
 	# Auto-dispatch carve-out (GH#20946): refuse to claim auto-dispatch issues
 	# unless --implementing was passed or the issue is also a parent-task.

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -174,28 +174,37 @@ _isc_gh_reachable() {
 	return 0
 }
 
-# Check whether an issue already carries `status:in-review`. Returns 0 when
-# present, 1 when absent, 2 when the metadata lookup failed.
-#
-# NOTE on the jq query: the two-argument form `any(generator; condition)`
-# passed `.name` as the generator on `(.labels // [])`, which tries to
-# index the *array itself* with string "name" and raises
-# "Cannot index array with string". The single-argument form
-# `any(condition)` iterates over the array automatically, which is both
-# shorter and correct. This was a latent bug that masked the bug fixed
-# in GH#18786 — the jq error (exit 5) was swallowed by `>/dev/null 2>&1`
-# and the function always returned 1 ("label absent"), so the idempotency
-# branch was dead code even before the set -e exit propagation killed
-# the whole claim flow.
+# Read the authoritative state needed to classify interactive ownership in one
+# bounded request. Labels alone are workflow state, not principal ownership.
+# Comments are included so a recent compatible interactive claim can protect a
+# foreign human owner even when immutable origin provenance says worker.
+# Returns 0 with JSON on stdout, 2 when metadata is unavailable or malformed.
+_isc_read_claim_metadata() {
+	local issue="$1"
+	local slug="$2"
+	local json=""
+	local array_type="array"
+	json=$(gh issue view "$issue" --repo "$slug" \
+		--json state,labels,assignees,comments 2>/dev/null) || return 2
+	printf '%s' "$json" | jq -e --arg array_type "$array_type" '
+		type == "object" and
+		((.labels // []) | type == $array_type) and
+		((.assignees // []) | type == $array_type) and
+		((.comments // []) | type == $array_type)
+	' >/dev/null 2>&1 || return 2
+	printf '%s' "$json"
+	return 0
+}
+
+# Compatibility label probe used by release paths and focused regression tests.
+# Claim acquisition intentionally uses the richer ownership metadata above.
 _isc_has_in_review() {
 	local issue="$1"
 	local slug="$2"
-	local json
+	local json=""
 	json=$(gh issue view "$issue" --repo "$slug" --json labels 2>/dev/null) || return 2
-	if printf '%s' "$json" | jq -e '(.labels // []) | any(.name == "status:in-review")' >/dev/null 2>&1; then
-		return 0
-	fi
-	return 1
+	printf '%s' "$json" | jq -e '(.labels // []) | any(.name == "status:in-review")' >/dev/null 2>&1
+	return $?
 }
 
 # Generic label probe — returns 0 if the issue carries the named label, 1 if

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -62,13 +62,14 @@ mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace"
 # -----------------------------------------------------------------------------
 STUB_BIN="${TEST_ROOT}/stub-bin"
 STUB_LOG="${TEST_ROOT}/stub-calls.log"
-mkdir -p "$STUB_BIN"
+STUB_STATE_DIR="${TEST_ROOT}/stub-state"
+mkdir -p "$STUB_BIN" "$STUB_STATE_DIR"
 : >"$STUB_LOG"
 # Export STUB_LOG so subprocess invocations of the stub gh see it. Without
 # the export, subprocesses spawned by `"$HELPER_PATH" claim ...` inherit an
 # unset STUB_LOG and the stub logs to /dev/null, making subprocess-driven
 # assertions blind. Added in the GH#18786 regression coverage.
-export STUB_LOG
+export STUB_LOG STUB_STATE_DIR
 
 # Default stub mode — override via STUB_GH_MODE
 #   online   — gh returns successful responses
@@ -131,7 +132,7 @@ issue)
 		# response used by the release closed-issue check. Defaults to OPEN.
 		# When args include "--json state", return the state string directly.
 		case "$*" in
-		*"--json state"*)
+		*"--json state --jq .state"*)
 			printf '%s\n' "${STUB_ISSUE_STATE:-OPEN}"
 			exit 0
 			;;
@@ -151,6 +152,26 @@ issue)
 		if [[ "${STUB_ISSUE_HAS_PARENT_TASK:-0}" == "1" ]]; then
 			labels_arr="${labels_arr:+$labels_arr,}{\"name\":\"parent-task\"}"
 		fi
+		if [[ "$*" == *"--json state,labels,assignees,comments"* ]]; then
+			state_file="${STUB_STATE_DIR:?}/${3}.json"
+			if [[ -f "$state_file" ]]; then
+				cat "$state_file"
+				exit 0
+			fi
+			assignees_json=""
+			assignees_csv="${STUB_ISSUE_ASSIGNEES:-testuser}"
+			while IFS= read -r assignee; do
+				[[ -n "$assignee" ]] && assignees_json="${assignees_json:+$assignees_json,}{\"login\":\"${assignee}\"}"
+			done < <(printf '%s' "$assignees_csv" | tr ',' '\n')
+			comments_json=""
+			if [[ -n "${STUB_INTERACTIVE_CLAIM_USER:-}" ]]; then
+				claim_time="${STUB_INTERACTIVE_CLAIM_TIME:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+				comments_json="{\"author\":{\"login\":\"${STUB_INTERACTIVE_CLAIM_USER}\"},\"createdAt\":\"${claim_time}\",\"body\":\"> Interactive session claimed by @${STUB_INTERACTIVE_CLAIM_USER} on test-host.\"}"
+			fi
+			printf '{"state":"%s","labels":[%s],"assignees":[%s],"comments":[%s]}\n' \
+				"${STUB_ISSUE_STATE:-OPEN}" "$labels_arr" "$assignees_json" "$comments_json"
+			exit 0
+		fi
 		printf '{"labels":[%s]}\n' "$labels_arr"
 		exit 0
 		;;
@@ -159,6 +180,21 @@ issue)
 		if [[ "${STUB_GH_EDIT_FAILS:-0}" == "1" ]]; then
 			printf 'simulated issue edit failure\n' >&2
 			exit 1
+		fi
+		if [[ -n "${STUB_STATE_DIR:-}" && "${STUB_GH_EDIT_NO_MUTATE:-0}" != "1" ]]; then
+			new_assignee=""
+			previous=""
+			for argument in "$@"; do
+				if [[ "$previous" == "--add-assignee" ]]; then
+					new_assignee="$argument"
+					break
+				fi
+				previous="$argument"
+			done
+			if [[ -n "$new_assignee" ]]; then
+				printf '{"state":"OPEN","labels":[{"name":"status:in-review"}],"assignees":[{"login":"%s"}],"comments":[]}\n' \
+					"$new_assignee" >"${STUB_STATE_DIR}/${3}.json"
+			fi
 		fi
 		exit 0
 		;;
@@ -499,7 +535,7 @@ idempotent_out=$(STUB_ISSUE_HAS_IN_REVIEW=1 STUB_GH_MODE=online \
 	2>&1)
 idempotent_rc=$?
 
-if [[ $idempotent_rc -eq 0 ]] && printf '%s' "$idempotent_out" | grep -q 'already has status:in-review'; then
+if [[ $idempotent_rc -eq 0 ]] && printf '%s' "$idempotent_out" | grep -q 'already belongs to testuser'; then
 	print_result "GH#18786: claim idempotent when label already present (subprocess)" 0
 else
 	print_result "GH#18786: claim idempotent when label already present (subprocess)" 1 \
@@ -513,6 +549,60 @@ if ! grep -q 'issue edit' "$STUB_LOG"; then
 else
 	print_result "GH#18786: idempotent claim skips gh issue edit" 1 \
 		"(stub log: $(tr '\n' '|' <"$STUB_LOG"))"
+fi
+
+# --- Case (d2): explicit worker takeover replaces and verifies ownership ---
+rm -f "${claim_dir}"/*.json 2>/dev/null || true
+: >"$STUB_LOG"
+printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:in-review"},{"name":"origin:worker"}],"assignees":[{"login":"worker-runner"}],"comments":[]}' \
+	>"${STUB_STATE_DIR}/56004.json"
+
+takeover_out=$("$HELPER_PATH" claim 56004 regress/test --implementing --worktree /tmp/takeover-wt 2>&1)
+takeover_rc=$?
+takeover_stamp="${claim_dir}/regress-test-56004.json"
+takeover_owner=$(jq -r '.assignees | map(.login) | join(",")' "${STUB_STATE_DIR}/56004.json")
+if [[ $takeover_rc -eq 0 && "$takeover_owner" == "testuser" && -f "$takeover_stamp" ]] &&
+	grep -q 'remove-assignee worker-runner' "$STUB_LOG" &&
+	grep -q 'add-assignee testuser' "$STUB_LOG"; then
+	print_result "foreign worker claim transfers to verified interactive owner" 0
+else
+	print_result "foreign worker claim transfers to verified interactive owner" 1 \
+		"(rc=$takeover_rc owner=$takeover_owner stamp=$([[ -f "$takeover_stamp" ]] && echo yes || echo no) log=$(tr '\n' '|' <"$STUB_LOG") out=${takeover_out:0:120})"
+fi
+
+# --- Case (d3): a recent compatible foreign interactive claim is protected ---
+rm -f "${claim_dir}"/*.json 2>/dev/null || true
+: >"$STUB_LOG"
+claim_now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+printf '{"state":"OPEN","labels":[{"name":"status:in-review"}],"assignees":[{"login":"other-human"}],"comments":[{"author":{"login":"other-human"},"createdAt":"%s","body":"> Interactive session claimed by @other-human on other-host."}]}\n' \
+	"$claim_now" >"${STUB_STATE_DIR}/56005.json"
+
+foreign_out=$("$HELPER_PATH" claim 56005 regress/test --implementing --worktree /tmp/foreign-wt 2>&1)
+foreign_rc=$?
+foreign_stamp="${claim_dir}/regress-test-56005.json"
+if [[ $foreign_rc -eq 1 && ! -f "$foreign_stamp" ]] &&
+	! grep -q 'issue edit 56005' "$STUB_LOG" &&
+	printf '%s' "$foreign_out" | grep -q 'live interactive owner @other-human'; then
+	print_result "live foreign interactive claim is never stolen" 0
+else
+	print_result "live foreign interactive claim is never stolen" 1 \
+		"(rc=$foreign_rc stamp=$([[ -f "$foreign_stamp" ]] && echo yes || echo no) out=${foreign_out:0:160})"
+fi
+
+# --- Case (d4): a transition that cannot be verified writes no stamp ---
+rm -f "${claim_dir}"/*.json 2>/dev/null || true
+: >"$STUB_LOG"
+printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:in-review"}],"assignees":[{"login":"worker-runner"}],"comments":[]}' \
+	>"${STUB_STATE_DIR}/56006.json"
+unverified_out=$(STUB_GH_EDIT_NO_MUTATE=1 "$HELPER_PATH" claim 56006 regress/test --implementing 2>&1)
+unverified_rc=$?
+unverified_stamp="${claim_dir}/regress-test-56006.json"
+if [[ $unverified_rc -eq 1 && ! -f "$unverified_stamp" ]] &&
+	printf '%s' "$unverified_out" | grep -q 'could not be verified'; then
+	print_result "unverified worker takeover writes no stamp" 0
+else
+	print_result "unverified worker takeover writes no stamp" 1 \
+		"(rc=$unverified_rc stamp=$([[ -f "$unverified_stamp" ]] && echo yes || echo no) out=${unverified_out:0:160})"
 fi
 
 # --- Case (e): release subprocess also survives set -euo pipefail ---
@@ -807,16 +897,11 @@ export STUB_ISSUE_HAS_AUTO_DISPATCH=0
 export STUB_ISSUE_HAS_PARENT_TASK=0
 
 # =============================================================================
-# Test 20 — GH#20946 PR #20977 review: claim proceeds when carve-out probe
-# fails (fail-OPEN integration test).
+# Test 20 — ownership metadata failure fails closed without a stamp.
 #
-# Direct caller-side verification of the `&& _isc_carve_out_required` short-
-# circuit semantics — when the probe returns rc=2 (gh lookup failed), the
-# `&&` short-circuit evaluates false and the claim falls through to the
-# normal `set_issue_status` path. This was the exact failure mode flagged
-# by augmentcode in the original two-call pattern: rc=2 on the inner
-# parent-task check entered the warning branch and silently blocked a
-# legitimate claim. The new single-call form fails OPEN consistently.
+# Ownership-aware idempotency cannot safely classify the incumbent when the
+# bounded metadata read fails. It must not mutate GitHub or write caller-owned
+# stamp evidence in that state.
 # =============================================================================
 fo_stamp=$(_isc_stamp_path 60006 carveout/failopen)
 rm -f "$fo_stamp" >/dev/null 2>&1 || true
@@ -826,14 +911,13 @@ fo_out=$(STUB_ISSUE_HAS_IN_REVIEW=0 STUB_ISSUE_HAS_AUTO_DISPATCH=1 STUB_ISSUE_HA
 	_isc_cmd_claim 60006 carveout/failopen 2>&1)
 fo_rc=$?
 
-if [[ $fo_rc -eq 0 ]] &&
-	! grep -q "skipping to avoid permanent dispatch block" <<<"$fo_out" &&
-	grep -q 'issue edit 60006' "$STUB_LOG" &&
-	grep -q 'add-label status:in-review' "$STUB_LOG" &&
-	[[ -f "$fo_stamp" ]]; then
-	print_result "GH#20946 review: claim proceeds (fail-OPEN) when carve-out probe gh fails" 0
+if [[ $fo_rc -eq 1 ]] &&
+	! grep -q 'issue edit 60006' "$STUB_LOG" &&
+	[[ ! -f "$fo_stamp" ]] &&
+	printf '%s' "$fo_out" | grep -q 'ownership metadata unavailable'; then
+	print_result "ownership metadata failure writes no stamp or GitHub state" 0
 else
-	print_result "GH#20946 review: claim proceeds (fail-OPEN) when carve-out probe gh fails" 1 \
+	print_result "ownership metadata failure writes no stamp or GitHub state" 1 \
 		"(rc=$fo_rc, stamp=$([[ -f "$fo_stamp" ]] && echo yes || echo no), out=${fo_out:0:200})"
 fi
 

--- a/.agents/scripts/tests/test-interactive-start-helper.sh
+++ b/.agents/scripts/tests/test-interactive-start-helper.sh
@@ -37,6 +37,12 @@ assert_log_line() {
 git init -q -b main "$canonical_root" || fail "could not initialize canonical fixture"
 git -C "$canonical_root" worktree add -q --orphan -b feature/interactive-start-test "$linked_worktree" ||
 	fail "could not create linked-worktree fixture"
+canonical_root=$(cd "$canonical_root" && pwd -P) || fail "could not resolve canonical fixture"
+linked_worktree=$(cd "$linked_worktree" && pwd -P) || fail "could not resolve linked fixture"
+unregistered_path=$(cd "$unregistered_path" && pwd -P) || fail "could not resolve unregistered fixture"
+export CANONICAL_ROOT="$canonical_root"
+export LINKED_WORKTREE="$linked_worktree"
+export UNREGISTERED_PATH="$unregistered_path"
 
 headless_out=$(AIDEVOPS_INTERACTIVE_ISSUE_IMPLEMENTATION=1 \
 	"$full_loop_helper" start "GH#42 local fix" --headless 2>&1)


### PR DESCRIPTION
## Summary

Classify in-review claims by verified assignee and recent interactive evidence; preserve same-owner idempotency; perform remove/add/verify worker takeovers before writing stamps; fail closed on foreign human or metadata uncertainty; normalize macOS interactive-start fixtures.

## Files Changed

.agents/scripts/interactive-session-helper-commands.sh, .agents/scripts/interactive-session-helper.sh, .agents/scripts/tests/test-interactive-session-claim.sh, .agents/scripts/tests/test-interactive-start-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-executed claim lifecycle fixtures covered same-owner refresh, worker takeover, live foreign-human conflict, transition verification failure, and metadata failure (45/45 passed); interactive-start worktree handoff suite passed; ShellCheck clean; changed-file lint passed.

Resolves #28614


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 17m and 338,027 tokens on this with the user in an interactive session.