### PR TITLE
GH#28622: Harden NMR authority at workflow and merge boundaries

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -81,6 +81,7 @@ readonly PERMISSION_GRANT_SCHEMA="aidevops-permission-grant/v1"
 readonly PERMISSION_SHA256_PATTERN='^[0-9a-f]{64}$'
 readonly PERMISSION_JSON_ARRAY_TYPE="array"
 readonly PERMISSION_JSON_STRING_TYPE="string"
+readonly _APPROVAL_NMR_LABEL="needs-maintainer-review"
 readonly _APPROVAL_AUTO_DISPATCH_LABEL="auto-dispatch"
 readonly _PERMISSION_BLOCKER_STATUS="blocked"
 readonly _PERMISSION_BLOCKER_TRUE="true"
@@ -637,7 +638,7 @@ _approval_verify_issue_state() {
 		return 1
 	}
 
-	if ! printf '%s' "$issue_json" | jq -e '(.labels // []) | any(.name == "needs-maintainer-review") | not' >/dev/null 2>&1; then
+	if ! printf '%s' "$issue_json" | jq -e --arg label "$_APPROVAL_NMR_LABEL" '(.labels // []) | any(.name == $label) | not' >/dev/null 2>&1; then
 		_print_error "Approval state verification failed: needs-maintainer-review is still present on #$target_number"
 		return 1
 	fi
@@ -666,7 +667,7 @@ _approval_verify_pr_state() {
 		_print_error "Approval state verification failed: could not read PR #$target_number via REST"
 		return 1
 	}
-	if ! printf '%s' "$issue_json" | jq -e '(.labels // []) | any(.name == "needs-maintainer-review") | not' >/dev/null 2>&1; then
+	if ! printf '%s' "$issue_json" | jq -e --arg label "$_APPROVAL_NMR_LABEL" '(.labels // []) | any(.name == $label) | not' >/dev/null 2>&1; then
 		_print_error "Approval state verification failed: needs-maintainer-review is still present on PR #$target_number"
 		return 1
 	fi
@@ -688,7 +689,7 @@ _approval_apply_issue_lifecycle_updates() {
 	fi
 
 	edit_err=$(gh_issue_edit_safe "$target_number" --repo "$slug" \
-		--remove-label "needs-maintainer-review" \
+		--remove-label "$_APPROVAL_NMR_LABEL" \
 		--add-label "$_APPROVAL_AUTO_DISPATCH_LABEL" \
 		--add-assignee "$gh_user" 2>&1 >/dev/null) || {
 		_print_error "Failed to update approval labels/assignee on issue #$target_number"
@@ -747,7 +748,7 @@ _approval_apply_pr_lifecycle_updates() {
 		return 1
 	}
 	edit_err=$(gh_pr_edit_safe "$target_number" --repo "$slug" \
-		--remove-label "needs-maintainer-review" 2>&1 >/dev/null) || {
+		--remove-label "$_APPROVAL_NMR_LABEL" 2>&1 >/dev/null) || {
 		_print_error "Failed to clear needs-maintainer-review on PR #$target_number after approval"
 		[[ -n "$edit_err" ]] && _print_error "$edit_err"
 		return 1

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -657,6 +657,23 @@ _approval_verify_issue_state() {
 	return 0
 }
 
+_approval_verify_pr_state() {
+	local target_number="$1"
+	local slug="$2"
+	local issue_json=""
+
+	issue_json=$(_approval_fetch_issue_json "$target_number" "$slug") || {
+		_print_error "Approval state verification failed: could not read PR #$target_number via REST"
+		return 1
+	}
+	if ! printf '%s' "$issue_json" | jq -e '(.labels // []) | any(.name == "needs-maintainer-review") | not' >/dev/null 2>&1; then
+		_print_error "Approval state verification failed: needs-maintainer-review is still present on PR #$target_number"
+		return 1
+	fi
+	_approval_verify_conversation_locked pr "$target_number" "$slug" "$issue_json"
+	return $?
+}
+
 _approval_apply_issue_lifecycle_updates() {
 	local target_number="$1"
 	local slug="$2"
@@ -715,31 +732,44 @@ _approval_apply_issue_lifecycle_updates() {
 	return $?
 }
 
+_approval_apply_pr_lifecycle_updates() {
+	local target_number="$1"
+	local slug="$2"
+	local lock_err=""
+	local edit_err=""
+
+	# Lock before clearing the live hold so no untrusted comment can land in the
+	# approval-to-merge window. The final merge gate still re-verifies the V2
+	# signature against current content and the exact PR head.
+	lock_err=$(_approval_lock_pr "$target_number" "$slug" 2>&1 >/dev/null) || {
+		_print_error "Approval advisory lock failure: PR #$target_number conversation could not be locked before clearing the NMR hold"
+		[[ -n "$lock_err" ]] && _print_error "$lock_err"
+		return 1
+	}
+	edit_err=$(gh_pr_edit_safe "$target_number" --repo "$slug" \
+		--remove-label "needs-maintainer-review" 2>&1 >/dev/null) || {
+		_print_error "Failed to clear needs-maintainer-review on PR #$target_number after approval"
+		[[ -n "$edit_err" ]] && _print_error "$edit_err"
+		return 1
+	}
+	_approval_verify_pr_state "$target_number" "$slug" || return 1
+	_print_info "PR #$target_number NMR hold cleared and conversation locked"
+	return 0
+}
+
 _post_issue_approval_updates() {
 	local target_type="$1"
 	local target_number="$2"
 	local slug="$3"
 
-	# Label updates and assignee are issue-specific (PRs don't use these labels).
+	# Issues become dispatchable; PRs clear their live NMR hold only after the
+	# signed comment has been posted and verified by _approve_target.
 	if [[ "$target_type" == "issue" ]]; then
 		_approval_apply_issue_lifecycle_updates "$target_number" "$slug"
 		return $?
-	else
-		# GH#17903: Lock PRs at approval time to close the same prompt-injection
-		# window that exists for issues. Without locking, non-collaborators can
-		# add comments to an approved PR between approval and merge, potentially
-		# influencing automated review or merge decisions.
-		local lock_err=""
-		lock_err=$(_approval_lock_pr "$target_number" "$slug" 2>&1 >/dev/null) || {
-			_print_error "Approval advisory lock failure: PR #$target_number conversation could not be locked after approval state updates"
-			[[ -n "$lock_err" ]] && _print_error "$lock_err"
-			return 1
-		}
-		_approval_verify_conversation_locked "$target_type" "$target_number" "$slug" || return 1
-		_print_info "PR #$target_number approval recorded and conversation locked"
 	fi
-
-	return 0
+	_approval_apply_pr_lifecycle_updates "$target_number" "$slug"
+	return $?
 }
 
 #######################################

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -299,10 +299,12 @@ _merge_issue_requires_maintainer_review() {
 	local issue_number="$1"
 	local repo="$2"
 	local labels_csv=""
+	local labels_padded=""
 
 	labels_csv=$(gh issue view "$issue_number" --repo "$repo" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || return 2
-	if [[ ",${labels_csv}," == *",needs-maintainer-review,"* ]]; then
+	printf -v labels_padded ',%s,' "$labels_csv"
+	if [[ "$labels_padded" == *",needs-maintainer-review,"* ]]; then
 		return 0
 	fi
 	return 1
@@ -370,7 +372,7 @@ _merge_guard_admin_merge_maintainer_review() {
 	local pr_number="$1"
 	local repo="$2"
 	local expected_head_sha="${3:-}"
-	local pr_json="" pr_author="" current_head_sha="" labels_csv="" is_fork="false"
+	local pr_json="" pr_author="" current_head_sha="" labels_csv="" labels_padded="" is_fork="false"
 	local issue_numbers=""
 	local issue_number=""
 	local verify_rc=0 author_rc=0 treat_as_external=0
@@ -381,13 +383,14 @@ _merge_guard_admin_merge_maintainer_review() {
 		return 1
 	fi
 	if ! printf '%s' "$pr_json" | jq -e '
+		def is_string: type == "string";
 		type == "object"
-		and (.author.login | type == "string" and length > 0)
-		and (.headRefOid | type == "string" and length > 0)
+		and (.author.login | is_string and length > 0)
+		and (.headRefOid | is_string and length > 0)
 		and (.labels | type == "array")
 		and (.isCrossRepository | type == "boolean")
 		and (.closingIssuesReferences | type == "array")
-		and ((.body == null) or (.body | type == "string"))
+		and ((.body == null) or (.body | is_string))
 	' >/dev/null 2>&1; then
 		print_error "Merge blocked: PR #${pr_number} returned malformed authority metadata"
 		return 1
@@ -396,6 +399,7 @@ _merge_guard_admin_merge_maintainer_review() {
 	pr_author=$(printf '%s' "$pr_json" | jq -r '.author.login') || return 1
 	current_head_sha=$(printf '%s' "$pr_json" | jq -r '.headRefOid') || return 1
 	labels_csv=$(printf '%s' "$pr_json" | jq -r '[.labels[].name] | join(",")') || return 1
+	printf -v labels_padded ',%s,' "$labels_csv"
 	is_fork=$(printf '%s' "$pr_json" | jq -r '.isCrossRepository') || return 1
 	if [[ -n "$expected_head_sha" && "$current_head_sha" != "$expected_head_sha" ]]; then
 		print_error "Merge blocked: PR #${pr_number} head changed before the final authority check"
@@ -404,7 +408,7 @@ _merge_guard_admin_merge_maintainer_review() {
 
 	#aidevops:trust-boundary GH#17671/GH#28622 -- a live PR NMR label is an
 	# explicit hold. Marker text is never merge authority at this boundary.
-	if [[ ",${labels_csv}," == *",needs-maintainer-review,"* ]]; then
+	if [[ "$labels_padded" == *",needs-maintainer-review,"* ]]; then
 		print_error "Merge blocked: PR #${pr_number} still requires maintainer review"
 		return 1
 	fi
@@ -414,7 +418,7 @@ _merge_guard_admin_merge_maintainer_review() {
 		print_error "Merge blocked: unable to verify live repository permission for PR author ${pr_author}"
 		return 1
 	fi
-	if [[ ",${labels_csv}," == *",external-contributor,"* ]] || \
+	if [[ "$labels_padded" == *",external-contributor,"* ]] || \
 		[[ "$is_fork" == "true" ]] || [[ "$author_rc" -ne 0 ]]; then
 		treat_as_external=1
 	fi

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -195,8 +195,9 @@ _merge_try_interactive_admin_auto_fallback() {
 	_merge_output_is_review_policy_block "$merge_output" || return 1
 	_merge_pr_ready_for_interactive_admin_bypass "$pr_number" "$repo" || return 1
 
-	#aidevops:trust-boundary -- interactive admin fallback still enforces linked NMR crypto gate before bypassing review-count protection.
-	_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" || return 2
+	#aidevops:trust-boundary -- interactive admin fallback re-checks exact-head
+	# authority immediately before bypassing review-count protection.
+	_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" "$expected_head_sha" || return 2
 	print_info "Auto-merge is blocked only by review-required branch policy/self-approval; interactive maintainer session is using --admin merge after gates passed."
 	if gh pr merge "$pr_number" --repo "$repo" "$merge_method" --admin --match-head-commit "$expected_head_sha" 2>&1; then
 		print_success "PR #${pr_number} merged with interactive --admin fallback"
@@ -307,16 +308,119 @@ _merge_issue_requires_maintainer_review() {
 	return 1
 }
 
+# Resolve the verifier from the current framework tree first so worktree fixes
+# are exercised before deployment. The public key remains in the user's
+# root-protected aidevops approval-key directory and is read by the helper.
+_merge_approval_helper_path() {
+	local approval_helper="${SCRIPT_DIR}/approval-helper.sh"
+	if [[ ! -f "$approval_helper" ]]; then
+		approval_helper="${HOME}/.aidevops/agents/scripts/approval-helper.sh"
+	fi
+	[[ -f "$approval_helper" ]] || return 1
+	printf '%s\n' "$approval_helper"
+	return 0
+}
+
+_merge_target_crypto_approved() {
+	local target_type="$1"
+	local target_number="$2"
+	local repo="$3"
+	local expected_head_sha="${4:-}"
+	local approval_helper=""
+	local result=""
+
+	approval_helper=$(_merge_approval_helper_path) || return 1
+	if [[ "$target_type" == "pr" ]]; then
+		[[ -n "$expected_head_sha" ]] || return 1
+		result=$(bash "$approval_helper" verify pr "$target_number" "$repo" \
+			--expect-head "$expected_head_sha" 2>/dev/null) || result=""
+	else
+		result=$(bash "$approval_helper" verify issue "$target_number" "$repo" 2>/dev/null) || result=""
+	fi
+	[[ "$result" == "VERIFIED" ]]
+	return $?
+}
+
+# Returns 0 for live admin/maintain/write authority, 1 for a confirmed external
+# author, and 2 when GitHub cannot provide a trustworthy verdict.
+_merge_author_has_write_authority() {
+	local author="$1"
+	local repo="$2"
+	local permission=""
+
+	# shared-constants.sh loads the App-aware helper in normal full-loop use. It
+	# distinguishes a confirmed 404 non-collaborator (permission=none) from API
+	# uncertainty; the direct gh fallback keeps this library sourceable in tests.
+	if declare -F _gh_collaborator_permission_lookup >/dev/null 2>&1; then
+		_gh_collaborator_permission_lookup "$repo" "$author" permission || return 2
+	else
+		permission=$(gh api "repos/${repo}/collaborators/${author}/permission" \
+			--jq '.permission // "none"' 2>/dev/null) || return 2
+	fi
+	case "$permission" in
+	admin | maintain | write) return 0 ;;
+	none | read | triage) return 1 ;;
+	*) return 2 ;;
+	esac
+}
+
+# Legacy name retained for sourced callers and tests. This is now the common
+# final authority guard for every full-loop merge mode, not only --admin.
 _merge_guard_admin_merge_maintainer_review() {
 	local pr_number="$1"
 	local repo="$2"
+	local expected_head_sha="${3:-}"
+	local pr_json="" pr_author="" current_head_sha="" labels_csv="" is_fork="false"
 	local issue_numbers=""
 	local issue_number=""
-	local blocked_issues=""
-	local verify_rc=0
+	local verify_rc=0 author_rc=0 treat_as_external=0
 
-	issue_numbers=$(_merge_linked_issue_numbers "$pr_number" "$repo") || {
-		print_error "Admin merge blocked: unable to verify linked issues for PR #${pr_number}; refusing to override branch protection"
+	if ! pr_json=$(gh pr view "$pr_number" --repo "$repo" \
+		--json author,labels,isCrossRepository,headRefOid,closingIssuesReferences,body 2>/dev/null); then
+		print_error "Merge blocked: unable to verify PR #${pr_number} authority metadata"
+		return 1
+	fi
+	if ! printf '%s' "$pr_json" | jq -e '
+		type == "object"
+		and (.author.login | type == "string" and length > 0)
+		and (.headRefOid | type == "string" and length > 0)
+		and (.labels | type == "array")
+		and (.isCrossRepository | type == "boolean")
+		and (.closingIssuesReferences | type == "array")
+		and ((.body == null) or (.body | type == "string"))
+	' >/dev/null 2>&1; then
+		print_error "Merge blocked: PR #${pr_number} returned malformed authority metadata"
+		return 1
+	fi
+
+	pr_author=$(printf '%s' "$pr_json" | jq -r '.author.login') || return 1
+	current_head_sha=$(printf '%s' "$pr_json" | jq -r '.headRefOid') || return 1
+	labels_csv=$(printf '%s' "$pr_json" | jq -r '[.labels[].name] | join(",")') || return 1
+	is_fork=$(printf '%s' "$pr_json" | jq -r '.isCrossRepository') || return 1
+	if [[ -n "$expected_head_sha" && "$current_head_sha" != "$expected_head_sha" ]]; then
+		print_error "Merge blocked: PR #${pr_number} head changed before the final authority check"
+		return 1
+	fi
+
+	#aidevops:trust-boundary GH#17671/GH#28622 -- a live PR NMR label is an
+	# explicit hold. Marker text is never merge authority at this boundary.
+	if [[ ",${labels_csv}," == *",needs-maintainer-review,"* ]]; then
+		print_error "Merge blocked: PR #${pr_number} still requires maintainer review"
+		return 1
+	fi
+
+	_merge_author_has_write_authority "$pr_author" "$repo" || author_rc=$?
+	if [[ "$author_rc" -eq 2 ]]; then
+		print_error "Merge blocked: unable to verify live repository permission for PR author ${pr_author}"
+		return 1
+	fi
+	if [[ ",${labels_csv}," == *",external-contributor,"* ]] || \
+		[[ "$is_fork" == "true" ]] || [[ "$author_rc" -ne 0 ]]; then
+		treat_as_external=1
+	fi
+
+	issue_numbers=$(_merge_linked_issue_numbers "$pr_number" "$repo" "$pr_json") || {
+		print_error "Merge blocked: unable to verify linked issues for PR #${pr_number}"
 		return 1
 	}
 
@@ -325,17 +429,28 @@ _merge_guard_admin_merge_maintainer_review() {
 		verify_rc=0
 		_merge_issue_requires_maintainer_review "$issue_number" "$repo" || verify_rc=$?
 		if [[ "$verify_rc" -eq 0 ]]; then
-			blocked_issues+=" #${issue_number}"
+			print_error "Merge blocked: linked issue #${issue_number} still requires maintainer review"
+			return 1
 		elif [[ "$verify_rc" -ne 1 ]]; then
-			print_error "Admin merge blocked: unable to verify maintainer-review labels on issue #${issue_number}"
+			print_error "Merge blocked: unable to verify maintainer-review labels on issue #${issue_number}"
+			return 1
+		fi
+		if [[ "$treat_as_external" -eq 1 ]] && \
+			! _merge_target_crypto_approved issue "$issue_number" "$repo"; then
+			print_error "Merge blocked: external/fork PR linked issue #${issue_number} lacks current cryptographic development authority"
 			return 1
 		fi
 	done <<<"$issue_numbers"
 
-	#aidevops:trust-boundary -- admin merge must not bypass signed/maintainer issue approval.
-	if [[ -n "$blocked_issues" ]]; then
-		print_error "Admin merge blocked: linked issue(s)${blocked_issues} still require maintainer review"
-		print_info "Required action: run 'sudo aidevops approve issue <issue_number> ${repo}' or record an equivalent maintainer decision before merging."
+	if [[ "$treat_as_external" -eq 0 ]]; then
+		return 0
+	fi
+	if [[ -z "$issue_numbers" ]]; then
+		print_error "Merge blocked: external/fork PR #${pr_number} has no linked issue"
+		return 1
+	fi
+	if ! _merge_target_crypto_approved pr "$pr_number" "$repo" "$current_head_sha"; then
+		print_error "Merge blocked: external/fork PR #${pr_number} lacks V2 merge authority for the current head"
 		return 1
 	fi
 
@@ -450,9 +565,6 @@ _merge_execute() {
 	local merge_flags=()
 	[[ "$has_admin" -eq 1 ]] && merge_flags+=("--admin")
 	[[ "$has_auto" -eq 1 ]] && merge_flags+=("--auto")
-	if [[ "$has_admin" -eq 1 ]]; then
-		_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" || return 1
-	fi
 
 	local merge_desc="$merge_method"
 	[[ ${#merge_flags[@]} -gt 0 ]] && merge_desc+=" ${merge_flags[*]}"
@@ -463,6 +575,10 @@ _merge_execute() {
 		print_error "Cannot bind merge to a remotely verified PR head SHA"
 		return 1
 	}
+	#aidevops:trust-boundary GH#17671/GH#28622 -- every merge mode, including
+	# --auto and the non-admin REST transport fallback, must pass the same live
+	# external/fork and exact-head cryptographic authority check.
+	_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" "$match_head_sha" || return 1
 	merge_flags+=("--match-head-commit" "$match_head_sha")
 
 	# Capture output AND exit code under set -e. A bare assignment `out=$(cmd)`
@@ -507,7 +623,7 @@ ${_merge_retry_out}"
 		# Only fall back to --admin when caller passed neither --admin nor --auto.
 		elif [[ $has_admin -eq 0 && $has_auto -eq 0 ]] &&
 			printf '%s' "$_merge_out" | grep -qE 'base branch policy prohibits|Required status checks? (is|are) expected|At least [0-9]+ approving review'; then
-			_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" || return 1
+			_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" "$match_head_sha" || return 1
 			print_info "Branch protection blocked plain merge; retrying with --admin (workers share the maintainer's gh auth per GH#18538)..."
 			if gh pr merge "$pr_number" --repo "$repo" "$merge_method" --admin --match-head-commit "$match_head_sha" 2>&1; then
 				print_success "PR #${pr_number} merged with --admin fallback"

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -167,6 +167,8 @@ run_case "PR approval locks conversation with gh pr lock" '
 	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
 	_rest_should_fallback() { return 1; }
 	gh_pr_comment() { return 0; }
+	pr_edit_trace=$(mktemp)
+	gh_pr_edit_safe() { printf "PR_EDIT %s\n" "$*" >"$pr_edit_trace"; return 0; }
 	gh() {
 		local arg1="${1:-}"
 		local arg2="${2:-}"
@@ -177,9 +179,12 @@ run_case "PR approval locks conversation with gh pr lock" '
 		fi
 		return 1
 	}
-	_post_issue_approval_updates pr 456 marcusquinn/aidevops
+	_post_issue_approval_updates pr 456 marcusquinn/aidevops || exit 1
+	cat "$pr_edit_trace"
+	rm -f "$pr_edit_trace"
 ' 0
-assert_contains "PR approval reports real conversation lock" "$LAST_OUTPUT" "PR #456 approval recorded and conversation locked"
+assert_contains "PR approval clears live NMR label" "$LAST_OUTPUT" "PR_EDIT 456 --repo marcusquinn/aidevops --remove-label needs-maintainer-review"
+assert_contains "PR approval reports real conversation lock" "$LAST_OUTPUT" "PR #456 NMR hold cleared and conversation locked"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "conversation lock verification reuses provided issue JSON" '
@@ -199,6 +204,8 @@ run_case "PR approval REST fallback locks conversation" '
 	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
 	_rest_should_fallback() { return 1; }
 	gh_pr_comment() { return 0; }
+	pr_edit_trace=$(mktemp)
+	gh_pr_edit_safe() { printf "PR_EDIT %s\n" "$*" >"$pr_edit_trace"; return 0; }
 	gh() {
 		local arg1="${1:-}"
 		local arg2="${2:-}"
@@ -212,10 +219,25 @@ run_case "PR approval REST fallback locks conversation" '
 		fi
 		return 1
 	}
-	_post_issue_approval_updates pr 456 marcusquinn/aidevops
+	_post_issue_approval_updates pr 456 marcusquinn/aidevops || exit 1
+	cat "$pr_edit_trace"
+	rm -f "$pr_edit_trace"
 ' 0
-assert_contains "PR approval fallback reports real lock" "$LAST_OUTPUT" "PR #456 approval recorded and conversation locked"
+assert_contains "PR approval fallback clears live NMR label" "$LAST_OUTPUT" "PR_EDIT 456 --repo marcusquinn/aidevops --remove-label needs-maintainer-review"
+assert_contains "PR approval fallback reports real lock" "$LAST_OUTPUT" "PR #456 NMR hold cleared and conversation locked"
 assert_not_contains "PR approval fallback avoids advisory failure" "$LAST_OUTPUT" "Approval advisory lock failure"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "PR label-clear failure blocks approval completion" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_lock_pr() { return 0; }
+	gh_pr_edit_safe() { return 1; }
+	_post_issue_approval_updates pr 456 marcusquinn/aidevops
+' 1
+assert_contains "PR label-clear failure is explicit" "$LAST_OUTPUT" "Failed to clear needs-maintainer-review on PR #456 after approval"
+assert_not_contains "PR label-clear failure suppresses success" "$LAST_OUTPUT" "NMR hold cleared and conversation locked"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "genuine lock failure is distinguished" '

--- a/.agents/scripts/tests/test-full-loop-merge-authority-guard.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-authority-guard.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#28622: every full-loop merge mode must apply the
+# same live external/fork authority gate before invoking GitHub's merge API.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MERGE_SCRIPT="${SCRIPT_DIR}/../full-loop-helper-merge.sh"
+TEST_ROOT="$(mktemp -d -t full-loop-merge-authority.XXXXXX)"
+EXTRACTED="${TEST_ROOT}/functions.sh"
+CRYPTO_CALLS="${TEST_ROOT}/crypto-calls.log"
+MERGE_CALLS="${TEST_ROOT}/merge-calls.log"
+GUARD_CALLS="${TEST_ROOT}/guard-calls.log"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+print_result() {
+	local name="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s' "$name"
+	[[ -n "$detail" ]] && printf ': %s' "$detail"
+	printf '\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+extract_function() {
+	local function_name="$1"
+	awk -v fn="$function_name" '
+      index($0, fn "() {") == 1 { capture = 1 }
+      capture { print }
+      capture && $0 == "}" { exit }
+    ' "$MERGE_SCRIPT" >>"$EXTRACTED"
+	return 0
+}
+
+load_functions() {
+	: >"$EXTRACTED"
+	extract_function _merge_linked_issue_numbers
+	extract_function _merge_issue_requires_maintainer_review
+	extract_function _merge_author_has_write_authority
+	extract_function _merge_guard_admin_merge_maintainer_review
+	extract_function _merge_execute
+	# shellcheck source=/dev/null
+	source "$EXTRACTED"
+	return 0
+}
+
+FIXTURE_PR_JSON=""
+FIXTURE_PERMISSION="write"
+FIXTURE_PERMISSION_FAIL=0
+FIXTURE_PR_LOOKUP_FAIL=0
+FIXTURE_ISSUE_LABELS=""
+FIXTURE_ISSUE_LOOKUP_FAIL=0
+FIXTURE_ISSUE_APPROVED=0
+FIXTURE_PR_APPROVED=0
+FIXTURE_GH_MODE="guard"
+AUTHORITY_GUARD_PASS=1
+
+print_error() {
+	local message="$1"
+	printf 'ERROR %s\n' "$message" >&2
+	return 0
+}
+
+print_info() {
+	local message="$1"
+	printf 'INFO %s\n' "$message" >&2
+	return 0
+}
+
+print_success() {
+	local message="$1"
+	printf 'OK %s\n' "$message" >&2
+	return 0
+}
+
+gh() {
+	local command="${1:-}"
+	local subcommand="${2:-}"
+	if [[ "$FIXTURE_GH_MODE" == "merge" && "$command" == "pr" && "$subcommand" == "merge" ]]; then
+		printf '%s\n' "$*" >>"$MERGE_CALLS"
+		printf 'merged\n'
+		return 0
+	fi
+	if [[ "$command" == "pr" && "$subcommand" == "view" ]]; then
+		[[ "$FIXTURE_PR_LOOKUP_FAIL" -eq 0 ]] || return 1
+		printf '%s\n' "$FIXTURE_PR_JSON"
+		return 0
+	fi
+	if [[ "$command" == "issue" && "$subcommand" == "view" ]]; then
+		[[ "$FIXTURE_ISSUE_LOOKUP_FAIL" -eq 0 ]] || return 1
+		printf '%s\n' "$FIXTURE_ISSUE_LABELS"
+		return 0
+	fi
+	if [[ "$command" == "api" && "$subcommand" == *"/collaborators/"*"/permission" ]]; then
+		[[ "$FIXTURE_PERMISSION_FAIL" -eq 0 ]] || return 1
+		printf '%s\n' "$FIXTURE_PERMISSION"
+		return 0
+	fi
+	return 1
+}
+
+# Production full-loop loads the shared App-aware permission helper. Model its
+# contract here, including the `none` verdict used for a confirmed 404.
+_gh_collaborator_permission_lookup() {
+	local repo="$1"
+	local author="$2"
+	local out_var="${3:-}"
+	[[ -n "$repo" && -n "$author" ]] || return 2
+	[[ "$FIXTURE_PERMISSION_FAIL" -eq 0 ]] || return 2
+	if [[ -n "$out_var" ]]; then
+		printf -v "$out_var" '%s' "$FIXTURE_PERMISSION"
+	else
+		printf '%s\n' "$FIXTURE_PERMISSION"
+	fi
+	return 0
+}
+
+_merge_target_crypto_approved() {
+	local target_type="$1"
+	local target_number="$2"
+	local repo="$3"
+	local expected_head_sha="${4:-}"
+	printf '%s %s %s %s\n' "$target_type" "$target_number" "$repo" "$expected_head_sha" >>"$CRYPTO_CALLS"
+	if [[ "$target_type" == "issue" ]]; then
+		[[ "$FIXTURE_ISSUE_APPROVED" -eq 1 ]]
+		return $?
+	fi
+	[[ "$FIXTURE_PR_APPROVED" -eq 1 && -n "$expected_head_sha" ]]
+	return $?
+}
+
+set_pr_fixture() {
+	local author="$1"
+	local labels_json="$2"
+	local is_fork="$3"
+	local issues_json="$4"
+	local body="$5"
+	local head_sha="${6:-head-current}"
+	FIXTURE_PR_JSON=$(jq -nc \
+		--arg author "$author" \
+		--arg head "$head_sha" \
+		--arg body "$body" \
+		--argjson labels "$labels_json" \
+		--argjson fork "$is_fork" \
+		--argjson issues "$issues_json" \
+		'{author:{login:$author},labels:$labels,isCrossRepository:$fork,headRefOid:$head,closingIssuesReferences:$issues,body:$body}')
+	return 0
+}
+
+reset_fixture() {
+	FIXTURE_PERMISSION="write"
+	FIXTURE_PERMISSION_FAIL=0
+	FIXTURE_PR_LOOKUP_FAIL=0
+	FIXTURE_ISSUE_LABELS=""
+	FIXTURE_ISSUE_LOOKUP_FAIL=0
+	FIXTURE_ISSUE_APPROVED=0
+	FIXTURE_PR_APPROVED=0
+	FIXTURE_GH_MODE="guard"
+	AUTHORITY_GUARD_PASS=1
+	: >"$CRYPTO_CALLS"
+	: >"$MERGE_CALLS"
+	: >"$GUARD_CALLS"
+	set_pr_fixture maintainer '[]' false '[]' ''
+	return 0
+}
+
+expect_guard_result() {
+	local name="$1"
+	local expected_rc="$2"
+	local expected_head="${3:-head-current}"
+	local actual_rc=0
+	_merge_guard_admin_merge_maintainer_review 900 owner/repo "$expected_head" >/dev/null 2>&1 || actual_rc=$?
+	if [[ "$actual_rc" -eq "$expected_rc" ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "expected rc=$expected_rc, got rc=$actual_rc"
+	fi
+	return 0
+}
+
+test_authority_guard() {
+	reset_fixture
+	expect_guard_result "internal maintainer PR passes without crypto" 0
+
+	reset_fixture
+	set_pr_fixture external '[{"name":"needs-maintainer-review"}]' false '[]' ''
+	FIXTURE_PERMISSION="none"
+	expect_guard_result "live PR NMR blocks before external authority" 1
+
+	reset_fixture
+	FIXTURE_PERMISSION_FAIL=1
+	expect_guard_result "author permission lookup failure blocks" 1
+
+	reset_fixture
+	set_pr_fixture external '[]' false '[]' ''
+	FIXTURE_PERMISSION="none"
+	expect_guard_result "unlabeled external PR without linked issue blocks" 1
+
+	reset_fixture
+	set_pr_fixture maintainer '[{"name":"external-contributor"}]' false '[]' ''
+	expect_guard_result "external label overrides live write permission" 1
+
+	reset_fixture
+	set_pr_fixture maintainer '[]' true '[]' ''
+	expect_guard_result "fork metadata requires external authority" 1
+
+	reset_fixture
+	set_pr_fixture external '[]' false '[{"number":42}]' 'Resolves #42'
+	FIXTURE_PERMISSION="none"
+	FIXTURE_ISSUE_LABELS="needs-maintainer-review"
+	expect_guard_result "linked issue live NMR blocks" 1
+
+	reset_fixture
+	set_pr_fixture external '[]' false '[{"number":42}]' 'Resolves #42'
+	FIXTURE_PERMISSION="none"
+	expect_guard_result "external linked issue without crypto blocks" 1
+
+	reset_fixture
+	set_pr_fixture external '[]' false '[{"number":42}]' 'Resolves #42'
+	FIXTURE_PERMISSION="none"
+	FIXTURE_ISSUE_APPROVED=1
+	expect_guard_result "external PR without exact-head V2 authority blocks" 1
+
+	reset_fixture
+	set_pr_fixture external '[]' false '[{"number":42}]' 'Resolves #42'
+	FIXTURE_PERMISSION="none"
+	FIXTURE_ISSUE_APPROVED=1
+	FIXTURE_PR_APPROVED=1
+	expect_guard_result "external PR with issue and exact-head authority passes" 0
+	if grep -q '^issue 42 owner/repo ' "$CRYPTO_CALLS" && \
+		grep -q '^pr 900 owner/repo head-current$' "$CRYPTO_CALLS"; then
+		print_result "external success verifies issue and exact PR head" 0
+	else
+		print_result "external success verifies issue and exact PR head" 1 "crypto calls did not bind both authorities"
+	fi
+
+	reset_fixture
+	set_pr_fixture external '[]' false '[{"number":42}]' 'Resolves #42'
+	FIXTURE_PERMISSION="none"
+	FIXTURE_ISSUE_APPROVED=1
+	FIXTURE_PR_APPROVED=1
+	expect_guard_result "head drift blocks before crypto reuse" 1 head-stale
+
+	reset_fixture
+	FIXTURE_ISSUE_LOOKUP_FAIL=1
+	set_pr_fixture maintainer '[]' false '[{"number":42}]' 'Resolves #42'
+	expect_guard_result "linked issue metadata failure blocks" 1
+
+	reset_fixture
+	FIXTURE_PR_JSON='{"author":null}'
+	expect_guard_result "malformed PR authority metadata blocks" 1
+
+	reset_fixture
+	set_pr_fixture maintainer '[]' false '[{"number":42}]' 'Resolves #42'
+	expect_guard_result "internal linked issue without hold passes without crypto" 0
+	if [[ ! -s "$CRYPTO_CALLS" ]]; then
+		print_result "internal PR does not require external crypto" 0
+	else
+		print_result "internal PR does not require external crypto" 1 "unexpected crypto verification"
+	fi
+	return 0
+}
+
+_merge_guard_admin_merge_maintainer_review_for_mode_test() {
+	local pr_number="$1"
+	local repo="$2"
+	local expected_head_sha="${3:-}"
+	printf '%s %s %s\n' "$pr_number" "$repo" "$expected_head_sha" >>"$GUARD_CALLS"
+	[[ "$AUTHORITY_GUARD_PASS" -eq 1 ]]
+	return $?
+}
+
+test_merge_mode() {
+	local name="$1"
+	local has_admin="$2"
+	local has_auto="$3"
+	local actual_rc=0
+	: >"$GUARD_CALLS"
+	: >"$MERGE_CALLS"
+	FIXTURE_GH_MODE="merge"
+	AUTHORITY_GUARD_PASS=1
+	_merge_execute 900 owner/repo --squash "$has_admin" "$has_auto" >/dev/null 2>&1 || actual_rc=$?
+	if [[ "$actual_rc" -eq 0 ]] && grep -q '^900 owner/repo head-current$' "$GUARD_CALLS" && [[ -s "$MERGE_CALLS" ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "rc=$actual_rc guard=$(<"$GUARD_CALLS") merge=$(<"$MERGE_CALLS")"
+	fi
+	return 0
+}
+
+test_all_merge_modes_use_guard() {
+	_merge_guard_admin_merge_maintainer_review() {
+		_merge_guard_admin_merge_maintainer_review_for_mode_test "$@"
+		return $?
+	}
+	_merge_resolve_match_head() {
+		local pr_number="$1"
+		local repo="$2"
+		[[ -n "$pr_number" && -n "$repo" ]] || return 1
+		printf 'head-current\n'
+		return 0
+	}
+	gh_merge_remediate_stale_auth_cache() {
+		return 1
+	}
+
+	test_merge_mode "normal merge applies exact-head authority guard" 0 0
+	test_merge_mode "admin merge applies exact-head authority guard" 1 0
+	test_merge_mode "auto-merge applies exact-head authority guard" 0 1
+
+	: >"$GUARD_CALLS"
+	: >"$MERGE_CALLS"
+	FIXTURE_GH_MODE="merge"
+	AUTHORITY_GUARD_PASS=0
+	local blocked_rc=0
+	_merge_execute 900 owner/repo --squash 0 0 >/dev/null 2>&1 || blocked_rc=$?
+	if [[ "$blocked_rc" -eq 1 && ! -s "$MERGE_CALLS" ]]; then
+		print_result "failed authority guard prevents merge API invocation" 0
+	else
+		print_result "failed authority guard prevents merge API invocation" 1 "rc=$blocked_rc"
+	fi
+	return 0
+}
+
+main() {
+	load_functions
+	test_authority_guard
+	test_all_merge_modes_use_guard
+	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -167,6 +167,14 @@ write_gh_stub_pr_issue_views() {
 		echo '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","mergeCommit":{"oid":"merged123sha"}}'
 		exit 0
 	fi
+	if [[ "\$*" == *"--json author,labels,isCrossRepository,headRefOid,closingIssuesReferences,body"* ]]; then
+		if [[ "$mode" == "fallback-nmr" ]]; then
+			echo '{"author":{"login":"tester"},"labels":[],"isCrossRepository":false,"headRefOid":"abc123headsha","closingIssuesReferences":[{"number":24354}],"body":"Resolves #22621"}'
+		else
+			echo '{"author":{"login":"tester"},"labels":[],"isCrossRepository":false,"headRefOid":"abc123headsha","closingIssuesReferences":[],"body":"Resolves #22621"}'
+		fi
+		exit 0
+	fi
 	if [[ "\$*" == *"--json isDraft,reviewDecision,statusCheckRollup"* ]]; then
 		if [[ "$mode" == "auto-review-required" ]]; then
 			echo '{"isDraft":false,"reviewDecision":"","statusCheckRollup":[{"name":"ci","conclusion":"SUCCESS","status":"COMPLETED"}]}'
@@ -220,6 +228,14 @@ if [[ "\$_gh_cmd" == "api" ]]; then
 	echo "gh api \$*" >> "${TEST_ROOT}/logs/gh-api-calls.txt"
 	if [[ "\$*" == "user" ]]; then
 		echo '{"login":"tester"}'
+		exit 0
+	fi
+	if [[ "\$*" == *"repos/testorg/testrepo/collaborators/tester/permission"* ]]; then
+		if [[ "\$*" == *" -i "* ]]; then
+			printf 'HTTP/2 200\ncontent-type: application/json\n\n{"permission":"write"}\n'
+		else
+			echo 'write'
+		fi
 		exit 0
 	fi
 	if [[ "\$*" == *"repos/testorg/testrepo/pulls/42/merge"* ]]; then

--- a/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression coverage for GH#27611: signed-approval and PR-label API failures
-# must not be coerced into authority decisions or label mutations.
+# Regression coverage for GH#27611/GH#28622: approval API failures and copied
+# marker text must restore NMR, while authenticated maintainer authority passes.
 
 set -euo pipefail
 
@@ -46,6 +46,7 @@ import yaml
 workflow = yaml.safe_load(pathlib.Path(sys.argv[1]).read_text())
 root = pathlib.Path(sys.argv[2])
 for job_name, output_name in (
+    ("check-pr", "check-pr-job.sh"),
     ("protect-labels", "issue-job.sh"),
     ("protect-pr-labels", "pr-job.sh"),
 ):
@@ -62,6 +63,7 @@ printf '%s\n' "$*" >>"$GH_CALLS"
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 	case "${GH_SCENARIO:-}" in
 		pr-label-failure) exit 1 ;;
+		check-pr-nmr) printf 'needs-maintainer-review\n'; exit 0 ;;
 		pr-*) printf 'external-contributor\n'; exit 0 ;;
 	esac
 fi
@@ -70,9 +72,24 @@ if [[ "${1:-}" == "api" && "$*" == *"/comments"* ]]; then
 	case "${GH_SCENARIO:-}" in
 		issue-api-failure|pr-approval-failure) exit 1 ;;
 		issue-invalid|pr-invalid) printf '{"message":"rate limited"}\n'; exit 0 ;;
-		issue-signed|pr-signed) printf '[[{"body":"<!-- aidevops-signed-approval -->"}]]\n'; exit 0 ;;
+		issue-signed|pr-signed) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"maintainer"},"author_association":"OWNER"}]]\n'; exit 0 ;;
+		issue-other-maintainer|pr-other-maintainer) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"owner"},"author_association":"OWNER"}]]\n'; exit 0 ;;
+		issue-collab|pr-collab|issue-permission-failure|pr-permission-failure) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"trusted-collab"},"author_association":"COLLABORATOR"}]]\n'; exit 0 ;;
+		issue-forged|pr-forged) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"external"},"author_association":"NONE"}]]\n'; exit 0 ;;
+		issue-bot|pr-bot) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"github-actions[bot]"},"author_association":"NONE"}]]\n'; exit 0 ;;
 		issue-unsigned|pr-unsigned) printf '[[]]\n'; exit 0 ;;
 	esac
+fi
+
+if [[ "${1:-}" == "api" && "$*" == *"collaborators/trusted-collab/permission"* ]]; then
+	case "${GH_SCENARIO:-}" in
+		issue-permission-failure|pr-permission-failure) exit 1 ;;
+		*) printf 'write\n'; exit 0 ;;
+	esac
+fi
+
+if [[ "${1:-}" == "api" && "$*" == *"/statuses/"* ]]; then
+	exit 0
 fi
 
 if [[ "${1:-}" == "issue" && ( "${2:-}" == "edit" || "${2:-}" == "comment" ) ]]; then
@@ -98,10 +115,11 @@ teardown_test_env() {
 
 run_issue_job() {
 	local scenario="$1"
+	local actor="${2:-maintainer}"
 	GH_SCENARIO="$scenario" \
 		ISSUE_NUMBER=42 \
 		ISSUE_AUTHOR=external \
-		ACTOR=maintainer \
+		ACTOR="$actor" \
 		ACTOR_ASSOCIATION=OWNER \
 		REPO=owner/repo \
 		GH_TOKEN=test-token \
@@ -111,10 +129,11 @@ run_issue_job() {
 
 run_pr_job() {
 	local scenario="$1"
+	local actor="${2:-maintainer}"
 	GH_SCENARIO="$scenario" \
 		PR_NUMBER=43 \
 		PR_AUTHOR=external \
-		ACTOR=maintainer \
+		ACTOR="$actor" \
 		REPO=owner/repo \
 		GH_TOKEN=test-token \
 		PATH="${TEST_ROOT}/bin:${PATH}" \
@@ -131,31 +150,37 @@ assert_no_mutation() {
 	return 0
 }
 
-assert_job_fails_without_mutation() {
+assert_job_restores_nmr() {
 	local target="$1"
 	local scenario="$2"
 	local test_prefix="$3"
+	local actor="${4:-maintainer}"
 	: >"$GH_CALLS"
 	if [[ "$target" == "issue" ]]; then
-		if run_issue_job "$scenario" >/dev/null 2>&1; then
-			print_result "$test_prefix fails the job" 1 "expected non-zero exit"
+		run_issue_job "$scenario" "$actor" >/dev/null 2>&1 || true
+		if grep -q '^issue edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then
+			print_result "$test_prefix restores NMR" 0
 		else
-			print_result "$test_prefix fails the job" 0
+			print_result "$test_prefix restores NMR" 1 "expected issue edit"
 		fi
 	else
-		if run_pr_job "$scenario" >/dev/null 2>&1; then
-			print_result "$test_prefix fails the job" 1 "expected non-zero exit"
+		run_pr_job "$scenario" "$actor" >/dev/null 2>&1 || true
+		if grep -q '^pr edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then
+			print_result "$test_prefix restores NMR" 0
 		else
-			print_result "$test_prefix fails the job" 0
+			print_result "$test_prefix restores NMR" 1 "expected PR edit"
 		fi
 	fi
-	assert_no_mutation "$test_prefix leaves labels unchanged"
 	return 0
 }
 
 test_issue_approval_paths() {
-	assert_job_fails_without_mutation issue issue-api-failure "issue approval API failure"
-	assert_job_fails_without_mutation issue issue-invalid "invalid issue approval response"
+	assert_job_restores_nmr issue issue-api-failure "issue approval API failure"
+	assert_job_restores_nmr issue issue-invalid "invalid issue approval response"
+	assert_job_restores_nmr issue issue-forged "forged external issue marker"
+	assert_job_restores_nmr issue issue-permission-failure "unverifiable collaborator issue marker" "trusted-collab"
+	assert_job_restores_nmr issue issue-bot "bot-authored issue marker" "github-actions[bot]"
+	assert_job_restores_nmr issue issue-other-maintainer "different actor's issue marker"
 	: >"$GH_CALLS"
 	if run_issue_job issue-signed >/dev/null 2>&1; then
 		print_result "signed issue approval is accepted" 0
@@ -163,6 +188,13 @@ test_issue_approval_paths() {
 		print_result "signed issue approval is accepted" 1 "job returned non-zero"
 	fi
 	assert_no_mutation "signed issue approval does not restore NMR"
+	: >"$GH_CALLS"
+	if run_issue_job issue-collab trusted-collab >/dev/null 2>&1; then
+		print_result "write-collaborator issue approval is accepted" 0
+	else
+		print_result "write-collaborator issue approval is accepted" 1 "job returned non-zero"
+	fi
+	assert_no_mutation "write-collaborator issue approval does not restore NMR"
 	: >"$GH_CALLS"
 	run_issue_job issue-unsigned >/dev/null 2>&1 || true
 	if grep -q '^issue edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then
@@ -174,9 +206,13 @@ test_issue_approval_paths() {
 }
 
 test_pr_approval_paths() {
-	assert_job_fails_without_mutation pr pr-label-failure "PR label API failure"
-	assert_job_fails_without_mutation pr pr-approval-failure "PR approval API failure"
-	assert_job_fails_without_mutation pr pr-invalid "invalid PR approval response"
+	assert_job_restores_nmr pr pr-label-failure "PR label API failure"
+	assert_job_restores_nmr pr pr-approval-failure "PR approval API failure"
+	assert_job_restores_nmr pr pr-invalid "invalid PR approval response"
+	assert_job_restores_nmr pr pr-forged "forged external PR marker"
+	assert_job_restores_nmr pr pr-permission-failure "unverifiable collaborator PR marker" "trusted-collab"
+	assert_job_restores_nmr pr pr-bot "bot-authored PR marker" "github-actions[bot]"
+	assert_job_restores_nmr pr pr-other-maintainer "different actor's PR marker"
 	: >"$GH_CALLS"
 	if run_pr_job pr-signed >/dev/null 2>&1; then
 		print_result "signed PR approval is accepted" 0
@@ -185,11 +221,47 @@ test_pr_approval_paths() {
 	fi
 	assert_no_mutation "signed PR approval does not restore NMR"
 	: >"$GH_CALLS"
+	if run_pr_job pr-collab trusted-collab >/dev/null 2>&1; then
+		print_result "write-collaborator PR approval is accepted" 0
+	else
+		print_result "write-collaborator PR approval is accepted" 1 "job returned non-zero"
+	fi
+	assert_no_mutation "write-collaborator PR approval does not restore NMR"
+	: >"$GH_CALLS"
 	run_pr_job pr-unsigned >/dev/null 2>&1 || true
 	if grep -q '^pr edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then
 		print_result "confirmed unsigned external PR restores NMR" 0
 	else
 		print_result "confirmed unsigned external PR restores NMR" 1 "expected PR edit"
+	fi
+	return 0
+}
+
+test_live_pr_nmr_blocks_before_comments() {
+	local output_file="${TEST_ROOT}/check-pr-output"
+	: >"$GH_CALLS"
+	: >"$output_file"
+	if GH_SCENARIO=check-pr-nmr \
+		PR_TITLE="External change" \
+		PR_BODY="" \
+		PR_NUMBER=44 \
+		PR_AUTHOR=external \
+		HEAD_SHA=fixture-head \
+		PR_AUTHOR_ASSOCIATION=NONE \
+		REPO=owner/repo \
+		REPO_OWNER=owner \
+		GH_TOKEN=test-token \
+		MAINTAINER_GATE_DEBUG=false \
+		GITHUB_OUTPUT="$output_file" \
+		PATH="${TEST_ROOT}/bin:${PATH}" \
+		bash -e "${TEST_ROOT}/check-pr-job.sh" >/dev/null 2>&1; then
+		if grep -q '^blocked=true$' "$output_file" && ! grep -q '/comments' "$GH_CALLS"; then
+			print_result "live PR NMR blocks without consulting comment markers" 0
+		else
+			print_result "live PR NMR blocks without consulting comment markers" 1 "missing blocked output or comments API was queried"
+		fi
+	else
+		print_result "live PR NMR blocks without consulting comment markers" 1 "check-pr job returned non-zero"
 	fi
 	return 0
 }
@@ -231,6 +303,7 @@ main() {
 	trap teardown_test_env EXIT
 	test_issue_approval_paths
 	test_pr_approval_paths
+	test_live_pr_nmr_blocks_before_comments
 	test_slurp_and_jq_are_separate
 	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -214,8 +214,8 @@ jobs:
           # GH#17671 post-mortem: external PRs without linked issues bypassed
           # the gate because only linked-issue labels were checked. This block
           # catches that case — the PR's own labels are the primary signal for
-          # external contributor PRs. Requires cryptographic approval on the
-          # PR's comments (same pattern as issue approval).
+          # external contributor PRs. A live label is an explicit hold; approval
+          # marker text never overrides current label state at the merge gate.
           # ---------------------------------------------------------------
           #aidevops:trust-boundary GH#17671/GH#27611: a failed PR-label read
           # cannot be treated as an empty trusted label set.
@@ -227,44 +227,18 @@ jobs:
             exit 1
           fi
 
+          #aidevops:trust-boundary GH#17671/GH#28622: comment bodies are
+          # attacker-controlled. The approval command must clear the live hold;
+          # copying its marker into a comment can never make this check pass.
           if echo "$PR_LABELS" | grep -q 'needs-maintainer-review'; then
-            # Check for signed approval comment on the PR itself
-            #aidevops:trust-boundary GH#17671/GH#27611: an API failure is not
-            # evidence that a signed approval is absent. Fail the check rather
-            # than silently converting infrastructure uncertainty into a trust
-            # verdict.
-            APPROVAL_COMMENTS=""
-            SIGNED_APPROVAL=""
-            if ! APPROVAL_COMMENTS=$(gh api --paginate --slurp \
-              "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null); then
-              echo "::error::Unable to verify signed approvals for PR #$PR_NUMBER"
-              post_maintainer_gate_status_with_retry failure "Unable to verify signed maintainer approval"
-              exit 1
-            fi
-            if ! SIGNED_APPROVAL=$(printf '%s' "$APPROVAL_COMMENTS" | jq -r \
-              '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' 2>/dev/null); then
-              echo "::error::Unable to parse signed approvals for PR #$PR_NUMBER"
-              post_maintainer_gate_status_with_retry failure "Unable to parse signed maintainer approval"
-              exit 1
-            fi
-            if [[ ! "$SIGNED_APPROVAL" =~ ^[0-9]+$ ]]; then
-              echo "::error::Invalid signed-approval response for PR #$PR_NUMBER"
-              post_maintainer_gate_status_with_retry failure "Invalid signed maintainer approval response"
-              exit 1
-            fi
-
-            if [[ "$SIGNED_APPROVAL" -gt 0 ]]; then
-              echo "PR #$PR_NUMBER has needs-maintainer-review but signed approval found — continuing"
-            else
-              echo "BLOCKED: PR #$PR_NUMBER has needs-maintainer-review label with no signed approval"
-              echo "blocked=true" >> "$GITHUB_OUTPUT"
-              printf 'PR #%s has \x60needs-maintainer-review\x60 label — a maintainer must cryptographically approve it before merge.\n' "$PR_NUMBER" > /tmp/gate-reasons.txt
-              echo "has_reasons=true" >> "$GITHUB_OUTPUT"
-              post_maintainer_gate_status_with_retry \
-                failure \
-                "PR has needs-maintainer-review — requires cryptographic approval"
-              exit 0
-            fi
+            echo "BLOCKED: PR #$PR_NUMBER has needs-maintainer-review label"
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            printf 'PR #%s has \x60needs-maintainer-review\x60 label — a maintainer must cryptographically approve it and clear the live hold before merge.\n' "$PR_NUMBER" > /tmp/gate-reasons.txt
+            echo "has_reasons=true" >> "$GITHUB_OUTPUT"
+            post_maintainer_gate_status_with_retry \
+              failure \
+              "PR has needs-maintainer-review — live hold blocks merge"
+            exit 0
           fi
 
           # Collect linked issue numbers from PR body
@@ -573,7 +547,7 @@ jobs:
       issues: write
 
     steps:
-      - name: Re-apply label if no signed approval exists (t1894)
+      - name: Re-apply label unless approval marker has maintainer authority (t1894)
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
@@ -584,44 +558,68 @@ jobs:
         run: |
           echo "Label 'needs-maintainer-review' removed from issue #$ISSUE_NUMBER by $ACTOR"
 
-          # Always allow the bot — the approval-helper.sh removes labels after
-          # posting a signed approval comment, so this is the legitimate path.
-          if [[ "$ACTOR" == "github-actions[bot]" ]] || [[ "$ACTOR" == "github-actions" ]]; then
-            echo "ALLOWED: GitHub Actions bot — label removal accepted"
-            exit 0
-          fi
+          approval_comments_have_maintainer_authority() {
+            local comments_json="$1"
+            local identities=""
+            local commenter=""
+            local association=""
+            local permission=""
 
-          # t1894: Check for a cryptographic signed approval comment.
-          # Even admin/maintainer actors must use the approval command —
-          # manual label removal alone is insufficient because it leaves
-          # no auditable cryptographic proof of approval.
-          #aidevops:trust-boundary GH#1894/GH#27611: comments API failures are
-          # infrastructure uncertainty, not proof that approval is absent.
-          # Never create/recreate an irreversible ever-NMR authority record from
-          # a failed lookup.
+            if ! identities=$(printf '%s' "$comments_json" | jq -r --arg actor "$ACTOR" '
+              if type == "array" and all(.[]; type == "array") then
+                [.[][]
+                  | select((.body // "") | contains("<!-- aidevops-signed-approval -->"))
+                  | select(((.user.login // "") | ascii_downcase) == ($actor | ascii_downcase))
+                  | [(.user.login // ""), (.author_association // "")]
+                  | @tsv
+                ] | .[]
+              else error("invalid paginated comments response") end
+            ' 2>/dev/null); then
+              return 2
+            fi
+
+            while IFS=$'\t' read -r commenter association; do
+              [[ -n "$commenter" ]] || continue
+              case "$association" in
+                OWNER|MEMBER) return 0 ;;
+                CONTRIBUTOR|COLLABORATOR) ;;
+                *) continue ;;
+              esac
+              permission=""
+              if ! permission=$(gh api "repos/${REPO}/collaborators/${commenter}/permission" \
+                --jq '.permission // "none"' 2>/dev/null); then
+                echo "::warning::Unable to verify repository permission for approval commenter $commenter"
+                continue
+              fi
+              case "$permission" in
+                admin|maintain|write) return 0 ;;
+              esac
+            done <<< "$identities"
+            return 1
+          }
+
+          #aidevops:trust-boundary GH#1894/GH#27611/GH#28622: marker text is
+          # attacker-controlled and bot identity alone is not approval. Require
+          # authenticated maintainer authority on a marker authored by the same
+          # actor who removed the label. Any lookup uncertainty restores the
+          # existing hold instead of converting missing evidence into authority.
           APPROVAL_COMMENTS=""
-          SIGNED_APPROVAL=""
           if ! APPROVAL_COMMENTS=$(gh api --paginate --slurp \
             "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" 2>/dev/null); then
-            echo "::error::Unable to verify signed approvals for issue #$ISSUE_NUMBER — leaving labels unchanged"
-            exit 1
-          fi
-          if ! SIGNED_APPROVAL=$(printf '%s' "$APPROVAL_COMMENTS" | jq -r \
-            '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' 2>/dev/null); then
-            echo "::error::Unable to parse signed approvals for issue #$ISSUE_NUMBER — leaving labels unchanged"
-            exit 1
-          fi
-          if [[ ! "$SIGNED_APPROVAL" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid signed-approval response for issue #$ISSUE_NUMBER — leaving labels unchanged"
-            exit 1
-          fi
-
-          if [[ "$SIGNED_APPROVAL" -gt 0 ]]; then
-            echo "ALLOWED: Signed approval comment found — label removal accepted"
-            exit 0
+            echo "::error::Unable to read approval comments for issue #$ISSUE_NUMBER — restoring NMR"
+          else
+            APPROVAL_RC=0
+            approval_comments_have_maintainer_authority "$APPROVAL_COMMENTS" || APPROVAL_RC=$?
+            if [[ "$APPROVAL_RC" -eq 0 ]]; then
+              echo "ALLOWED: Label-removal actor authored an approval marker with authenticated maintainer authority"
+              exit 0
+            fi
+            if [[ "$APPROVAL_RC" -eq 2 ]]; then
+              echo "::error::Unable to parse approval comments for issue #$ISSUE_NUMBER — restoring NMR"
+            fi
           fi
 
-          echo "DENIED: No signed approval found — re-applying label (actor: $ACTOR)"
+          echo "DENIED: Label-removal actor lacks a marker with authenticated maintainer authority — re-applying label (actor: $ACTOR)"
 
           # Re-apply the label
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs-maintainer-review"
@@ -983,7 +981,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Re-apply label if no signed approval exists
+      - name: Re-apply label unless approval marker has maintainer authority
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -993,12 +991,45 @@ jobs:
         run: |
           echo "Label 'needs-maintainer-review' removed from PR #$PR_NUMBER by $ACTOR"
 
-          # Always allow the bot — the approval-helper.sh removes labels after
-          # posting a signed approval comment, so this is the legitimate path.
-          if [[ "$ACTOR" == "github-actions[bot]" ]] || [[ "$ACTOR" == "github-actions" ]]; then
-            echo "ALLOWED: GitHub Actions bot — label removal accepted"
-            exit 0
-          fi
+          approval_comments_have_maintainer_authority() {
+            local comments_json="$1"
+            local identities=""
+            local commenter=""
+            local association=""
+            local permission=""
+
+            if ! identities=$(printf '%s' "$comments_json" | jq -r --arg actor "$ACTOR" '
+              if type == "array" and all(.[]; type == "array") then
+                [.[][]
+                  | select((.body // "") | contains("<!-- aidevops-signed-approval -->"))
+                  | select(((.user.login // "") | ascii_downcase) == ($actor | ascii_downcase))
+                  | [(.user.login // ""), (.author_association // "")]
+                  | @tsv
+                ] | .[]
+              else error("invalid paginated comments response") end
+            ' 2>/dev/null); then
+              return 2
+            fi
+
+            while IFS=$'\t' read -r commenter association; do
+              [[ -n "$commenter" ]] || continue
+              case "$association" in
+                OWNER|MEMBER) return 0 ;;
+                CONTRIBUTOR|COLLABORATOR) ;;
+                *) continue ;;
+              esac
+              permission=""
+              if ! permission=$(gh api "repos/${REPO}/collaborators/${commenter}/permission" \
+                --jq '.permission // "none"' 2>/dev/null); then
+                echo "::warning::Unable to verify repository permission for approval commenter $commenter"
+                continue
+              fi
+              case "$permission" in
+                admin|maintain|write) return 0 ;;
+              esac
+            done <<< "$identities"
+            return 1
+          }
 
           # Only protect PRs that were labelled external-contributor.
           # Internal PRs (from collaborators) should never have had NMR in
@@ -1009,8 +1040,9 @@ jobs:
           PR_LABELS=""
           if ! PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json labels --jq '.labels[].name' 2>/dev/null); then
-            echo "::error::Unable to verify labels for PR #$PR_NUMBER — leaving labels unchanged"
-            exit 1
+            echo "::error::Unable to verify labels for PR #$PR_NUMBER — restoring NMR"
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "needs-maintainer-review"
+            exit 0
           fi
 
           if ! echo "$PR_LABELS" | grep -q 'external-contributor'; then
@@ -1018,31 +1050,28 @@ jobs:
             exit 0
           fi
 
-          # Check for a cryptographic signed approval comment on the PR.
-          # PRs use the same issues API endpoint for comments.
+          #aidevops:trust-boundary GH#17671/GH#27611/GH#28622: PR comments use
+          # the issues endpoint, but marker text remains attacker-controlled.
+          # Require authenticated maintainer authority on a marker authored by
+          # the label-removal actor; bot identity, malformed data, and lookup
+          # uncertainty restore NMR.
           APPROVAL_COMMENTS=""
-          SIGNED_APPROVAL=""
           if ! APPROVAL_COMMENTS=$(gh api --paginate --slurp \
             "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null); then
-            echo "::error::Unable to verify signed approvals for PR #$PR_NUMBER — leaving labels unchanged"
-            exit 1
-          fi
-          if ! SIGNED_APPROVAL=$(printf '%s' "$APPROVAL_COMMENTS" | jq -r \
-            '[.[][] | select(.body | contains("<!-- aidevops-signed-approval -->"))] | length' 2>/dev/null); then
-            echo "::error::Unable to parse signed approvals for PR #$PR_NUMBER — leaving labels unchanged"
-            exit 1
-          fi
-          if [[ ! "$SIGNED_APPROVAL" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid signed-approval response for PR #$PR_NUMBER — leaving labels unchanged"
-            exit 1
-          fi
-
-          if [[ "$SIGNED_APPROVAL" -gt 0 ]]; then
-            echo "ALLOWED: Signed approval comment found — label removal accepted"
-            exit 0
+            echo "::error::Unable to read approval comments for PR #$PR_NUMBER — restoring NMR"
+          else
+            APPROVAL_RC=0
+            approval_comments_have_maintainer_authority "$APPROVAL_COMMENTS" || APPROVAL_RC=$?
+            if [[ "$APPROVAL_RC" -eq 0 ]]; then
+              echo "ALLOWED: Label-removal actor authored an approval marker with authenticated maintainer authority"
+              exit 0
+            fi
+            if [[ "$APPROVAL_RC" -eq 2 ]]; then
+              echo "::error::Unable to parse approval comments for PR #$PR_NUMBER — restoring NMR"
+            fi
           fi
 
-          echo "DENIED: No signed approval found — re-applying label (actor: $ACTOR)"
+          echo "DENIED: Label-removal actor lacks a marker with authenticated maintainer authority — re-applying label (actor: $ACTOR)"
 
           # Re-apply the label
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "needs-maintainer-review"


### PR DESCRIPTION
## Summary

Hardened live NMR enforcement, authenticated label-removal provenance, exact-head external/fork merge authority, and approval lifecycle locking.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh, .agents/scripts/tests/test-full-loop-merge-authority-guard.sh, .agents/scripts/tests/test-full-loop-merge.sh, .agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh, .github/workflows/maintainer-gate-reusable.yml

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — linters-local.sh; ShellCheck; actionlint; 20-case authority guard; 50-case merge suite; 26-case maintainer-gate suite; approval-helper and pulse safety suites.

Resolves #28622


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 57m and 934,831 tokens on this with the user in an interactive session.