### PR TITLE
GH#28615: add secure repository-bound hook status

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-hook-status-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-hook-status-tool.mjs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createTools } from "../tools.mjs";
+
+function git(cwd, args) {
+  return execFileSync("/usr/bin/git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function createRepository(root, name) {
+  const repo = join(root, name);
+  mkdirSync(repo);
+  git(repo, ["init", "--initial-branch=main"]);
+  git(repo, ["config", "user.email", "test@example.invalid"]);
+  git(repo, ["config", "user.name", "Test"]);
+  git(repo, ["config", "commit.gpgsign", "false"]);
+  writeFileSync(join(repo, "README.md"), "fixture\n");
+  git(repo, ["add", "README.md"]);
+  git(repo, ["commit", "--no-gpg-sign", "-m", "init"]);
+  return repo;
+}
+
+test("hook status inspects only known markers for the assigned linked worktree", async () => {
+  const root = mkdtempSync(join(tmpdir(), "t28615-hook-status-"));
+  const repo = createRepository(root, "repo");
+  const linked = join(root, "linked");
+  const otherRepo = createRepository(root, "other");
+
+  try {
+    git(repo, ["worktree", "add", "-b", "bugfix/fixture", linked]);
+    const hooksDir = join(repo, ".git", "hooks");
+    writeFileSync(join(hooksDir, "pre-commit"), [
+      "#!/usr/bin/env bash",
+      "# aidevops-pre-commit-hook",
+      "# aidevops-markdoc-validate-hook",
+      "private fixture content must never be returned",
+      "",
+    ].join("\n"));
+    writeFileSync(join(hooksDir, "pre-push"), [
+      "#!/usr/bin/env bash",
+      "# aidevops-gh-wrapper-guard",
+      "# aidevops-pre-push-quality-hook",
+      "",
+    ].join("\n"));
+
+    const hookTool = createTools(root, () => "", { workerWorktree: linked }).aidevops_hook_status;
+    const result = await hookTool.execute({ workdir: linked });
+    const status = JSON.parse(result);
+
+    assert.equal(status.schema, "aidevops-hook-status/v1");
+    assert.equal(status.sharedGitDirectory, true);
+    assert.equal(status.hooksDirectory, "directory");
+    assert.deepEqual(status.hooks["pre-commit"], {
+      status: "regular-file",
+      markers: { quality: true, markdoc: true },
+    });
+    assert.deepEqual(status.hooks["pre-push"], {
+      status: "regular-file",
+      markers: { ghWrapper: true, quality: true },
+    });
+    assert.doesNotMatch(result, /private fixture content/);
+    assert.equal(result.includes(root), false, "status must not expose absolute fixture paths");
+
+    const denied = await hookTool.execute({ workdir: otherRepo });
+    assert.match(denied, /inspect only their assigned worktree/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("hook status rejects symlinked hook files without reading their targets", async () => {
+  const root = mkdtempSync(join(tmpdir(), "t28615-hook-symlink-"));
+  const repo = createRepository(root, "repo");
+  const target = join(root, "outside-hook");
+
+  try {
+    writeFileSync(target, "# aidevops-pre-commit-hook\nprivate target content\n");
+    symlinkSync(target, join(repo, ".git", "hooks", "pre-commit"));
+    const hookTool = createTools(root, () => "").aidevops_hook_status;
+    const result = await hookTool.execute({ workdir: repo });
+    const status = JSON.parse(result);
+
+    assert.equal(status.hooks["pre-commit"].status, "unsafe-symlink");
+    assert.deepEqual(status.hooks["pre-commit"].markers, { quality: false, markdoc: false });
+    assert.doesNotMatch(result, /private target content/);
+    assert.equal(result.includes(root), false, "status must not expose symlink or repository paths");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs
@@ -31,6 +31,7 @@ describe("aidevops plugin tool schemas", () => {
     assert.ok(tools.aidevops.args.command?._zod, "aidevops.command must be Zod");
     assert.ok(tools.aidevops_pre_edit_check.args.task?._zod, "pre-edit task must be Zod");
     assert.ok(tools.aidevops_pre_edit_check.args.workdir?._zod, "pre-edit workdir must be Zod");
+    assert.ok(tools.aidevops_hook_status.args.workdir?._zod, "hook-status workdir must be Zod");
     assert.ok(pool.args.action?._zod, "pool action must be Zod");
     assert.ok(pool.args.provider?._zod, "pool provider must be Zod");
   });

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -1,6 +1,6 @@
 import { execFileSync, execSync, spawn } from "child_process";
-import { existsSync, realpathSync, statSync } from "fs";
-import { join } from "path";
+import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "fs";
+import { isAbsolute, join, resolve } from "path";
 
 export let tool;
 try {
@@ -171,6 +171,18 @@ const PRE_EDIT_GUIDANCE = {
   3: "WARNING — proceed with caution.",
 };
 
+const MAX_HOOK_INSPECTION_BYTES = 1024 * 1024;
+const HOOK_MARKERS = {
+  "pre-commit": {
+    quality: "# aidevops-pre-commit-hook",
+    markdoc: "# aidevops-markdoc-validate-hook",
+  },
+  "pre-push": {
+    ghWrapper: "# aidevops-gh-wrapper-guard",
+    quality: "# aidevops-pre-push-quality-hook",
+  },
+};
+
 /**
  * Resolve and validate a requested Git worktree path.
  * @param {string} requestedWorkdir
@@ -196,6 +208,98 @@ function resolveGitWorktree(requestedWorkdir) {
     targetWorkdir = "";
   }
   return targetWorkdir;
+}
+
+function resolveGitMetadataPath(worktree, selector) {
+  const rawPath = execFileSync(
+    "git",
+    ["-C", worktree, "rev-parse", selector],
+    {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  ).trim();
+  return realpathSync(isAbsolute(rawPath) ? rawPath : resolve(worktree, rawPath));
+}
+
+function inspectHookFile(hooksDir, hookName, markers, directorySafe) {
+  const markerStatus = Object.fromEntries(Object.keys(markers).map((name) => [name, false]));
+  if (!directorySafe) return { status: "unsafe-hooks-directory", markers: markerStatus };
+
+  const hookPath = join(hooksDir, hookName);
+  let hookStat;
+  try {
+    hookStat = lstatSync(hookPath);
+  } catch {
+    return { status: "missing", markers: markerStatus };
+  }
+  if (hookStat.isSymbolicLink()) return { status: "unsafe-symlink", markers: markerStatus };
+  if (!hookStat.isFile()) return { status: "unsupported-file-type", markers: markerStatus };
+  if (hookStat.size > MAX_HOOK_INSPECTION_BYTES) return { status: "oversized", markers: markerStatus };
+
+  const content = readFileSync(hookPath, "utf-8");
+  for (const [name, marker] of Object.entries(markers)) markerStatus[name] = content.includes(marker);
+  return { status: "regular-file", markers: markerStatus };
+}
+
+function inspectGitHooks(worktree) {
+  const gitDir = resolveGitMetadataPath(worktree, "--git-dir");
+  const commonDir = resolveGitMetadataPath(worktree, "--git-common-dir");
+  const hooksDir = join(commonDir, "hooks");
+  let hooksDirectoryStatus = "missing";
+  let directorySafe = false;
+  try {
+    const hooksStat = lstatSync(hooksDir);
+    if (hooksStat.isSymbolicLink()) hooksDirectoryStatus = "unsafe-symlink";
+    else if (hooksStat.isDirectory()) {
+      hooksDirectoryStatus = "directory";
+      directorySafe = true;
+    } else hooksDirectoryStatus = "unsupported-file-type";
+  } catch {
+    hooksDirectoryStatus = "missing";
+  }
+
+  return {
+    schema: "aidevops-hook-status/v1",
+    sharedGitDirectory: gitDir !== commonDir,
+    hooksDirectory: hooksDirectoryStatus,
+    hooks: Object.fromEntries(Object.entries(HOOK_MARKERS).map(([hookName, markers]) => [
+      hookName,
+      inspectHookFile(hooksDir, hookName, markers, directorySafe),
+    ])),
+  };
+}
+
+function createHookStatusTool(options = {}) {
+  return tool({
+    description:
+      "Inspect known aidevops Git hook markers for an existing worktree without reading canonical .git/hooks through file tools. " +
+      "Use this for pre-commit/pre-push hook integrity checks. Returns statuses only—never hook contents or filesystem paths.",
+    args: {
+      workdir: z.string().optional().describe("Optional existing Git worktree; defaults to the current worktree"),
+    },
+    async execute(args) {
+      args = args && typeof args === "object" ? args : {};
+      const requestedWorkdir = args.workdir || process.cwd();
+      const targetWorkdir = resolveGitWorktree(requestedWorkdir);
+      if (!targetWorkdir) return "Hook status unavailable: target must resolve to an existing Git worktree";
+
+      const workerWorktree = options.workerWorktree ?? process.env.WORKER_WORKTREE_PATH ?? "";
+      if (workerWorktree) {
+        const boundWorktree = resolveGitWorktree(workerWorktree);
+        if (!boundWorktree || boundWorktree !== targetWorkdir) {
+          return "Hook status denied: headless workers may inspect only their assigned worktree";
+        }
+      }
+
+      try {
+        return JSON.stringify(inspectGitHooks(targetWorkdir), null, 2);
+      } catch {
+        return "Hook status unavailable: Git metadata could not be validated";
+      }
+    },
+  });
 }
 
 /**
@@ -298,10 +402,11 @@ function runPreEditCheck(script, args, cwd, timeoutMs) {
 /**
  * Create all tool definitions for the plugin.
  *
- * Tools (4 total):
+ * Tools (5 total):
  *   - aidevops              — aidevops CLI runner
  *   - aidevops_memory       — unified recall/store (merged from former recall + store pair)
  *   - aidevops_pre_edit_check — git safety check before file edits
+ *   - aidevops_hook_status — bounded Git hook marker inspection
  *   - model-accounts-pool   — OAuth account pool management (added in index.mjs)
  *
  * NOTE: aidevops_quality_check was removed. Quality checks run automatically
@@ -319,7 +424,7 @@ function runPreEditCheck(script, args, cwd, timeoutMs) {
  *
  * @param {string} scriptsDir - Path to scripts directory
  * @param {function} run - Shell command runner
- * @param {{preEditTimeoutMs?: number}} [options] - Tool-specific test/runtime overrides
+ * @param {{preEditTimeoutMs?: number, workerWorktree?: string}} [options] - Tool-specific test/runtime overrides
  * @returns {Record<string, object>}
  */
 export function createTools(scriptsDir, run, options = {}) {
@@ -327,5 +432,6 @@ export function createTools(scriptsDir, run, options = {}) {
     aidevops: createAidevopsTool(run),
     aidevops_memory: createMemoryTool(scriptsDir, run),
     aidevops_pre_edit_check: createPreEditCheckTool(scriptsDir, options.preEditTimeoutMs),
+    aidevops_hook_status: createHookStatusTool({ workerWorktree: options.workerWorktree }),
   };
 }

--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -30,6 +30,22 @@ Interactive sessions have no `main`/`master` exception: every edit uses a linked
 
 All other paths and all interactive edits require a linked worktree. `pre-edit-check.sh` is authoritative for the mode and path decision; write-time hooks provide additional enforcement where available.
 
+## Git Hook Status Without External-Directory Access
+
+Linked worktrees share Git hooks with their canonical repository through
+`git rev-parse --git-common-dir`. Never inspect that external `.git/hooks`
+directory with generic Read, Glob, Edit, or Write tools.
+
+Use `aidevops_hook_status` to inspect known pre-commit and pre-push marker
+status for the current worktree. The tool is repository-bound for headless
+workers and returns statuses only, never hook content or filesystem paths.
+Until a running OpenCode session has loaded that tool, use the existing bounded
+fallback from the target worktree:
+
+```bash
+bash ~/.aidevops/agents/scripts/install-hooks-helper.sh status
+```
+
 ## Exit Codes
 
 | Code | Meaning | Action |


### PR DESCRIPTION
## Summary

Implementation for issue #28615.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-hook-status-tool.mjs, .agents/plugins/opencode-aidevops/tests/test-tool-args-schema.mjs, .agents/plugins/opencode-aidevops/tools.mjs, .agents/workflows/pre-edit.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #28615


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 1h 50m and 812,304 tokens on this with the user in an interactive session.