### PR TITLE
GH#27777: add expiring Pulse runtime pin

### DIFF
--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -95,6 +95,42 @@ headers: a delta above one cannot distinguish the operation from another client.
 Partial attribution does not relax the benchmark's zero-unknown-cost
 comparability gate.
 
+### Pinning Pulse during controlled windows
+
+Framework releases may continue during a long observation, but Pulse must not
+change revisions inside either immutable window. Pin only Pulse to the current
+validated runtime bundle with a bounded TTL; normal aidevops activation and
+other interactive sessions continue using new releases:
+
+```bash
+~/.aidevops/agents/scripts/pulse-runtime-pin.sh set-current 108000
+./setup.sh --stage pulse --non-interactive
+```
+
+The pin file is private, has a hard 48-hour maximum, expires automatically, and
+protects its bundle from runtime pruning. The stable Pulse launcher, lifecycle
+helper, standalone merge routine, and webhook receiver re-enter the pinned
+bundle after an update or restart. An invalid non-expired pin blocks those
+entrypoints instead of silently running a different revision. Setup preserves
+installed Pulse schedulers while the pin is active. A controlled profile switch
+may refresh them explicitly without changing the pinned runtime:
+
+```bash
+AIDEVOPS_PULSE_RUNTIME_PIN_REFRESH_SCHEDULERS=1 \
+  ./setup.sh --stage pulse --non-interactive
+```
+
+Clear the pin and reconcile Pulse after capture or failure:
+
+```bash
+~/.aidevops/agents/scripts/pulse-runtime-pin.sh clear
+./setup.sh --stage pulse --non-interactive
+```
+
+Collectors must still bind reports to fixed activation/cutoff timestamps and
+fail closed on incomplete evidence. A Pulse pin does not authorize a release,
+relax quota attribution, or make concurrent uninstrumented API traffic exact.
+
 ### Evidence sidecar
 
 Each transport aggregate has one sidecar using

--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -53,9 +53,36 @@ set -euo pipefail
 
 # Paths
 _PULSE_AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}"
+_PULSE_ACTIVE_AGENTS_LINK="${AIDEVOPS_ACTIVE_AGENTS_LINK:-${HOME}/.aidevops/agents}"
+_PULSE_BOOTSTRAP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+_PULSE_RUNTIME_PIN_HELPER="${_PULSE_BOOTSTRAP_SCRIPT_DIR}/pulse-runtime-pin.sh"
+if [[ -r "$_PULSE_RUNTIME_PIN_HELPER" ]]; then
+	# shellcheck source=./pulse-runtime-pin.sh
+	source "$_PULSE_RUNTIME_PIN_HELPER"
+	if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+		pulse_runtime_pin_reexec "${_PULSE_BOOTSTRAP_SCRIPT_DIR%/scripts}" "scripts/pulse-lifecycle-helper.sh" "$@" || {
+			_PULSE_PIN_RC=$?
+			exit "$_PULSE_PIN_RC"
+		}
+	fi
+	_PULSE_PIN_RC=0
+	if _PULSE_PINNED_ROOT=$(pulse_runtime_pin_resolve 2>/dev/null); then
+		_PULSE_AGENTS_DIR="$_PULSE_PINNED_ROOT"
+		_PULSE_ACTIVE_AGENTS_LINK="$_PULSE_PINNED_ROOT"
+	else
+		_PULSE_PIN_RC=$?
+		case "$_PULSE_PIN_RC" in
+		1 | 3) ;;
+		*)
+			printf '[pulse-lifecycle] FATAL: Pulse runtime pin is invalid\n' >&2
+			return 2 2>/dev/null || exit 2
+			;;
+		esac
+	fi
+fi
+unset _PULSE_BOOTSTRAP_SCRIPT_DIR _PULSE_RUNTIME_PIN_HELPER _PULSE_PINNED_ROOT _PULSE_PIN_RC
 _PULSE_SCRIPT="${_PULSE_AGENTS_DIR}/scripts/pulse-wrapper.sh"
 _PULSE_LOG="${HOME}/.aidevops/logs/pulse-wrapper.log"
-_PULSE_ACTIVE_AGENTS_LINK="${AIDEVOPS_ACTIVE_AGENTS_LINK:-${HOME}/.aidevops/agents}"
 
 # Process-match pattern for pgrep. The production default matches any
 # pulse-wrapper.sh script regardless of path. Tests may override this to

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -51,6 +51,14 @@ unset _aidevops_path_prefix
 
 # SCRIPT_DIR resolution — uses BASH_SOURCE[0]:-$0 for zsh portability (GH#3931).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [[ -r "${SCRIPT_DIR}/pulse-runtime-pin.sh" ]]; then
+	# shellcheck source=./pulse-runtime-pin.sh
+	source "${SCRIPT_DIR}/pulse-runtime-pin.sh"
+	pulse_runtime_pin_reexec "${SCRIPT_DIR%/scripts}" "scripts/pulse-merge-routine.sh" "$@" || exit $?
+fi
+AIDEVOPS_AGENTS_DIR="${SCRIPT_DIR%/scripts}"
+AGENTS_DIR="$AIDEVOPS_AGENTS_DIR"
+export AIDEVOPS_AGENTS_DIR AGENTS_DIR
 
 # GH#24900: launchd/cron PATH repair must not bypass the aidevops gh shim.
 # Keep the framework script directory first so standalone merge runs inherit

--- a/.agents/scripts/pulse-merge-webhook-receiver.sh
+++ b/.agents/scripts/pulse-merge-webhook-receiver.sh
@@ -48,6 +48,14 @@ export PATH="${_aidevops_path_prefix}:${PATH}"
 unset _aidevops_path_prefix
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [[ -r "${SCRIPT_DIR}/pulse-runtime-pin.sh" ]]; then
+	# shellcheck source=./pulse-runtime-pin.sh
+	source "${SCRIPT_DIR}/pulse-runtime-pin.sh"
+	pulse_runtime_pin_reexec "${SCRIPT_DIR%/scripts}" "scripts/pulse-merge-webhook-receiver.sh" "$@" || exit $?
+fi
+AIDEVOPS_AGENTS_DIR="${SCRIPT_DIR%/scripts}"
+AGENTS_DIR="$AIDEVOPS_AGENTS_DIR"
+export AIDEVOPS_AGENTS_DIR AGENTS_DIR
 
 # =============================================================================
 # Config + secret loading

--- a/.agents/scripts/pulse-runtime-pin.sh
+++ b/.agents/scripts/pulse-runtime-pin.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Resolve and manage an expiring operator pin for the Pulse runtime only.
+# Normal aidevops activation continues while Pulse remains on one validated
+# immutable bundle for controlled observations and other bounded diagnostics.
+
+if [[ "${_AIDEVOPS_PULSE_RUNTIME_PIN_LOADED:-0}" == "1" ]]; then
+	return 0 2>/dev/null || exit 0
+fi
+_AIDEVOPS_PULSE_RUNTIME_PIN_LOADED=1
+
+_PULSE_RUNTIME_PIN_SCHEMA=""
+_PULSE_RUNTIME_PIN_ROOT=""
+_PULSE_RUNTIME_PIN_CREATED=""
+_PULSE_RUNTIME_PIN_EXPIRES=""
+_PULSE_RUNTIME_PIN_MAX_SECONDS=172800
+
+pulse_runtime_pin_config_path() {
+	printf '%s\n' "${AIDEVOPS_PULSE_RUNTIME_PIN_FILE:-${HOME:?HOME must be set}/.config/aidevops/pulse-runtime-pin.conf}"
+	return 0
+}
+
+_pulse_runtime_pin_stat_value() {
+	local bsd_format="$1"
+	local gnu_format="$2"
+	local path="$3"
+	local value=""
+	value=$(stat -f "$bsd_format" "$path" 2>/dev/null) || value=$(stat -c "$gnu_format" "$path" 2>/dev/null) || return 1
+	printf '%s\n' "$value"
+	return 0
+}
+
+_pulse_runtime_pin_file_is_private() {
+	local config_path="$1"
+	local mode=""
+	local owner=""
+	local current_uid=""
+	mode=$(_pulse_runtime_pin_stat_value '%Lp' '%a' "$config_path") || return 1
+	owner=$(_pulse_runtime_pin_stat_value '%u' '%u' "$config_path") || return 1
+	current_uid=$(id -u) || return 1
+	[[ "$owner" == "$current_uid" ]] || return 1
+	case "$mode" in
+	400 | 600) return 0 ;;
+	esac
+	return 1
+}
+
+_pulse_runtime_pin_parse_config() {
+	local config_path="$1"
+	local line=""
+	local key=""
+	local value=""
+	local schema_seen=0
+	local root_seen=0
+	local created_seen=0
+	local expires_seen=0
+	_PULSE_RUNTIME_PIN_SCHEMA=""
+	_PULSE_RUNTIME_PIN_ROOT=""
+	_PULSE_RUNTIME_PIN_CREATED=""
+	_PULSE_RUNTIME_PIN_EXPIRES=""
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		case "$line" in
+		'' | \#*) continue ;;
+		*=*) ;;
+		*) return 2 ;;
+		esac
+		key="${line%%=*}"
+		value="${line#*=}"
+		case "$key" in
+		schema)
+			[[ "$schema_seen" -eq 0 ]] || return 2
+			_PULSE_RUNTIME_PIN_SCHEMA="$value"
+			schema_seen=1
+			;;
+		agents_root)
+			[[ "$root_seen" -eq 0 ]] || return 2
+			_PULSE_RUNTIME_PIN_ROOT="$value"
+			root_seen=1
+			;;
+		created_epoch)
+			[[ "$created_seen" -eq 0 ]] || return 2
+			_PULSE_RUNTIME_PIN_CREATED="$value"
+			created_seen=1
+			;;
+		expires_epoch)
+			[[ "$expires_seen" -eq 0 ]] || return 2
+			_PULSE_RUNTIME_PIN_EXPIRES="$value"
+			expires_seen=1
+			;;
+		*) return 2 ;;
+		esac
+	done <"$config_path"
+	[[ "$schema_seen" -eq 1 && "$root_seen" -eq 1 && "$created_seen" -eq 1 && "$expires_seen" -eq 1 ]] || return 2
+	[[ "$_PULSE_RUNTIME_PIN_SCHEMA" == "1" ]] || return 2
+	case "$_PULSE_RUNTIME_PIN_CREATED" in
+	'' | *[!0-9]*) return 2 ;;
+	esac
+	case "$_PULSE_RUNTIME_PIN_EXPIRES" in
+	'' | *[!0-9]*) return 2 ;;
+	esac
+	return 0
+}
+
+_pulse_runtime_pin_read_config() {
+	local config_path=""
+	local now=""
+	config_path=$(pulse_runtime_pin_config_path) || return 2
+	[[ -f "$config_path" ]] || return 1
+	[[ ! -L "$config_path" ]] || return 2
+	_pulse_runtime_pin_file_is_private "$config_path" || return 2
+	_pulse_runtime_pin_parse_config "$config_path" || return $?
+	now=$(date +%s) || return 2
+	[[ "${#_PULSE_RUNTIME_PIN_CREATED}" -le 12 && "${#_PULSE_RUNTIME_PIN_EXPIRES}" -le 12 ]] || return 2
+	_PULSE_RUNTIME_PIN_CREATED=$((10#$_PULSE_RUNTIME_PIN_CREATED))
+	_PULSE_RUNTIME_PIN_EXPIRES=$((10#$_PULSE_RUNTIME_PIN_EXPIRES))
+	[[ "$_PULSE_RUNTIME_PIN_CREATED" -le "$_PULSE_RUNTIME_PIN_EXPIRES" ]] || return 2
+	[[ "$_PULSE_RUNTIME_PIN_CREATED" -le "$now" ]] || return 2
+	[[ $((_PULSE_RUNTIME_PIN_EXPIRES - _PULSE_RUNTIME_PIN_CREATED)) -le "$_PULSE_RUNTIME_PIN_MAX_SECONDS" ]] || return 2
+	[[ "$_PULSE_RUNTIME_PIN_EXPIRES" -gt "$now" ]] || return 3
+	return 0
+}
+
+_pulse_runtime_pin_validate_root() {
+	local requested_root="$1"
+	local agents_root=""
+	local bundles_root=""
+	local bundle_dir=""
+	local bundle_id=""
+	local manifest_bundle_id=""
+	local manifest_status=""
+	local required_entrypoint=""
+	case "$requested_root" in
+	/*) ;;
+	*) return 2 ;;
+	esac
+	[[ "$requested_root" != *$'\n'* && "$requested_root" != *$'\t'* ]] || return 2
+	for required_entrypoint in \
+		pulse-runtime-pin.sh \
+		pulse-wrapper.sh \
+		pulse-lifecycle-helper.sh \
+		pulse-merge-routine.sh \
+		pulse-merge-webhook-receiver.sh; do
+		[[ -f "$requested_root/scripts/$required_entrypoint" && ! -L "$requested_root/scripts/$required_entrypoint" && -x "$requested_root/scripts/$required_entrypoint" ]] || return 2
+	done
+	[[ -f "$requested_root/.bundle-manifest" && ! -L "$requested_root/.bundle-manifest" && -r "$requested_root/.bundle-manifest" ]] || return 2
+	agents_root=$(cd "$requested_root" 2>/dev/null && pwd -P) || return 2
+	bundles_root=$(cd "${HOME:?HOME must be set}/.aidevops/runtime-bundles" 2>/dev/null && pwd -P) || return 2
+	[[ "${agents_root##*/}" == "agents" ]] || return 2
+	bundle_dir="${agents_root%/agents}"
+	[[ "$bundle_dir" != "$agents_root" && "${bundle_dir%/*}" == "$bundles_root" ]] || return 2
+	bundle_id="${bundle_dir##*/}"
+	while IFS='=' read -r key value; do
+		case "$key" in
+		bundle_id) manifest_bundle_id="$value" ;;
+		status) manifest_status="$value" ;;
+		esac
+	done <"$agents_root/.bundle-manifest"
+	[[ "$manifest_status" == "validated" && "$manifest_bundle_id" == "$bundle_id" ]] || return 2
+	printf '%s\n' "$agents_root"
+	return 0
+}
+
+pulse_runtime_pin_resolve() {
+	local agents_root=""
+	_pulse_runtime_pin_read_config || return $?
+	agents_root=$(_pulse_runtime_pin_validate_root "$_PULSE_RUNTIME_PIN_ROOT") || return $?
+	printf '%s\n' "$agents_root"
+	return 0
+}
+
+pulse_runtime_pin_reexec() {
+	local current_root="$1"
+	local relative_entrypoint="$2"
+	local pinned_root=""
+	local physical_current_root=""
+	local resolve_rc=0
+	shift 2
+	case "$relative_entrypoint" in
+	scripts/*.sh) ;;
+	*) return 2 ;;
+	esac
+	pinned_root=$(pulse_runtime_pin_resolve 2>/dev/null) || resolve_rc=$?
+	case "$resolve_rc" in
+	0) ;;
+	1 | 3) return 0 ;;
+	*)
+		printf 'Pulse runtime pin is invalid; refusing to start %s\n' "${relative_entrypoint##*/}" >&2
+		return 2
+		;;
+	esac
+	physical_current_root=$(cd "$current_root" 2>/dev/null && pwd -P) || return 2
+	[[ "$pinned_root" != "$physical_current_root" ]] || return 0
+	if [[ ! -f "$pinned_root/$relative_entrypoint" || -L "$pinned_root/$relative_entrypoint" || ! -x "$pinned_root/$relative_entrypoint" ]]; then
+		printf 'Pinned Pulse runtime is missing the required %s entrypoint\n' "${relative_entrypoint##*/}" >&2
+		return 2
+	fi
+	exec "$BASH" "$pinned_root/$relative_entrypoint" "$@"
+	return 1
+}
+
+pulse_runtime_pin_set() {
+	local requested_root="$1"
+	local expires_epoch="$2"
+	local agents_root=""
+	local now=""
+	local config_path=""
+	local config_dir=""
+	local temporary=""
+	case "$expires_epoch" in
+	'' | *[!0-9]*) return 2 ;;
+	esac
+	[[ "${#expires_epoch}" -le 12 ]] || return 2
+	expires_epoch=$((10#$expires_epoch))
+	now=$(date +%s) || return 1
+	[[ "$expires_epoch" -gt "$now" && $((expires_epoch - now)) -le "$_PULSE_RUNTIME_PIN_MAX_SECONDS" ]] || return 2
+	agents_root=$(_pulse_runtime_pin_validate_root "$requested_root") || return $?
+	config_path=$(pulse_runtime_pin_config_path) || return 1
+	config_dir="${config_path%/*}"
+	mkdir -p "$config_dir" || return 1
+	temporary=$(mktemp "$config_dir/.pulse-runtime-pin.XXXXXX") || return 1
+	chmod 600 "$temporary" || {
+		rm -f "$temporary"
+		return 1
+	}
+	if ! printf 'schema=1\nagents_root=%s\ncreated_epoch=%s\nexpires_epoch=%s\n' \
+		"$agents_root" "$now" "$expires_epoch" >"$temporary"; then
+		rm -f "$temporary"
+		return 1
+	fi
+	mv "$temporary" "$config_path" || {
+		rm -f "$temporary"
+		return 1
+	}
+	return 0
+}
+
+pulse_runtime_pin_set_current() {
+	local ttl_seconds="$1"
+	local active_link="${AIDEVOPS_ACTIVE_AGENTS_LINK:-${HOME:?HOME must be set}/.aidevops/agents}"
+	local active_root=""
+	local now=""
+	case "$ttl_seconds" in
+	'' | *[!0-9]*) return 2 ;;
+	esac
+	[[ "${#ttl_seconds}" -le 6 ]] || return 2
+	ttl_seconds=$((10#$ttl_seconds))
+	[[ "$ttl_seconds" -gt 0 && "$ttl_seconds" -le "$_PULSE_RUNTIME_PIN_MAX_SECONDS" ]] || return 2
+	active_root=$(cd "$active_link" 2>/dev/null && pwd -P) || return 1
+	now=$(date +%s) || return 1
+	pulse_runtime_pin_set "$active_root" "$((now + ttl_seconds))"
+	return $?
+}
+
+pulse_runtime_pin_clear() {
+	local config_path=""
+	config_path=$(pulse_runtime_pin_config_path) || return 1
+	rm -f "$config_path" || return 1
+	return 0
+}
+
+pulse_runtime_pin_status() {
+	local agents_root=""
+	local bundle_id=""
+	local read_rc=0
+	_pulse_runtime_pin_read_config || read_rc=$?
+	if [[ "$read_rc" -eq 0 ]]; then
+		agents_root=$(_pulse_runtime_pin_validate_root "$_PULSE_RUNTIME_PIN_ROOT") || read_rc=$?
+	fi
+	if [[ "$read_rc" -eq 0 ]]; then
+		bundle_id="${agents_root%/agents}"
+		bundle_id="${bundle_id##*/}"
+		printf 'Pulse runtime pin: active (bundle=%s expires_epoch=%s)\n' "$bundle_id" "$_PULSE_RUNTIME_PIN_EXPIRES"
+		return 0
+	fi
+	case "$read_rc" in
+	1) printf 'Pulse runtime pin: not configured\n' ;;
+	3) printf 'Pulse runtime pin: expired\n' ;;
+	*) printf 'Pulse runtime pin: invalid\n' ;;
+	esac
+	return "$read_rc"
+}
+
+pulse_runtime_pin_main() {
+	local command_name="${1:-status}"
+	case "$command_name" in
+	resolve)
+		pulse_runtime_pin_resolve
+		return $?
+		;;
+	set-current)
+		[[ "$#" -eq 2 ]] || return 2
+		pulse_runtime_pin_set_current "$2" || return $?
+		pulse_runtime_pin_status
+		return $?
+		;;
+	set)
+		[[ "$#" -eq 3 ]] || return 2
+		pulse_runtime_pin_set "$2" "$3" || return $?
+		pulse_runtime_pin_status
+		return $?
+		;;
+	clear)
+		[[ "$#" -eq 1 ]] || return 2
+		pulse_runtime_pin_clear || return $?
+		printf 'Pulse runtime pin: cleared\n'
+		return 0
+		;;
+	status)
+		pulse_runtime_pin_status
+		return $?
+		;;
+	*)
+		printf 'Usage: pulse-runtime-pin.sh [status|resolve|set-current <ttl-seconds>|set <agents-root> <expires-epoch>|clear]\n' >&2
+		return 2
+		;;
+	esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	pulse_runtime_pin_main "$@"
+	exit $?
+fi
+
+return 0

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -203,6 +203,15 @@ _pw_bootstrap_script_dir="$(_pulse_wrapper_resolve_script_dir "$_pw_source_path"
 	printf '[pulse-wrapper] FATAL: cannot resolve script directory for %s\n' "$_pw_source_path" >&2
 	return 2 2>/dev/null || exit 2
 }
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" && -r "${_pw_bootstrap_script_dir}/pulse-runtime-pin.sh" ]]; then
+	# shellcheck source=./pulse-runtime-pin.sh
+	source "${_pw_bootstrap_script_dir}/pulse-runtime-pin.sh"
+	pulse_runtime_pin_reexec "${_pw_bootstrap_script_dir%/scripts}" "scripts/pulse-wrapper.sh" "$@" || {
+		_pw_pin_rc=$?
+		return "$_pw_pin_rc" 2>/dev/null || exit "$_pw_pin_rc"
+	}
+	unset _pw_pin_rc
+fi
 source "${_pw_bootstrap_script_dir}/portable-stat.sh"
 # shellcheck source=./runtime-bundle-lease.sh
 source "${_pw_bootstrap_script_dir}/runtime-bundle-lease.sh"

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -897,6 +897,8 @@ _runtime_bundle_prune() {
 	local modified=""
 	local bundle_bytes=""
 	local candidate_rows=""
+	local pinned_root=""
+	local pin_rc=0
 	local total_count=0
 	local total_bytes=0
 	local bytes_known=1
@@ -906,6 +908,16 @@ _runtime_bundle_prune() {
 	max_count=$(_runtime_bundle_numeric_limit "${AIDEVOPS_RUNTIME_BUNDLE_MAX_COUNT:-30}" 30)
 	max_bytes=$(_runtime_bundle_numeric_limit "${AIDEVOPS_RUNTIME_BUNDLE_MAX_BYTES:-8589934592}" 8589934592)
 	now=$(date +%s) || return 1
+	if declare -F pulse_runtime_pin_resolve >/dev/null 2>&1; then
+		pinned_root=$(pulse_runtime_pin_resolve 2>/dev/null) || pin_rc=$?
+		case "$pin_rc" in
+		0 | 1 | 3) ;;
+		*)
+			print_warning "Skipping runtime bundle pruning because the Pulse runtime pin is invalid"
+			return 0
+			;;
+		esac
+	fi
 
 	for candidate_dir in "$bundles_dir"/*; do
 		[[ -d "$candidate_dir/agents" ]] || continue
@@ -917,7 +929,7 @@ _runtime_bundle_prune() {
 			bundle_bytes=0
 			bytes_known=0
 		fi
-		[[ "$candidate_agents_root" == "$active_root" || "$candidate_agents_root" == "$previous_root" ]] && continue
+		[[ "$candidate_agents_root" == "$active_root" || "$candidate_agents_root" == "$previous_root" || "$candidate_agents_root" == "$pinned_root" ]] && continue
 		bundle_id="${candidate_dir##*/}"
 		if _runtime_bundle_has_live_lease "$bundles_dir/.leases/$bundle_id"; then
 			continue

--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -451,8 +451,26 @@ _install_pulse_merge_routine_linux() {
 setup_pulse_merge_routine() {
 	local pmr_wrapper="$HOME/.aidevops/agents/scripts/pulse-merge-routine.sh"
 	local pmr_label="com.aidevops.aidevops-supervisor-merge"
+	local legacy_pmr_label="sh.aidevops.pulse-merge-routine"
+	local pmr_installed=false
+	local pin_scheduler_rc=0
 	if ! [[ -x "$pmr_wrapper" ]]; then
 		return 0
+	fi
+	if _launchd_has_agent "$pmr_label" || _launchd_has_agent "$legacy_pmr_label"; then
+		pmr_installed=true
+	elif command -v crontab >/dev/null 2>&1 && crontab -l 2>/dev/null | grep -qF "pulse-merge-routine"; then
+		pmr_installed=true
+	elif command -v systemctl >/dev/null 2>&1 && systemctl --user is-enabled "aidevops-pulse-merge.timer" >/dev/null 2>&1; then
+		pmr_installed=true
+	fi
+	_pulse_runtime_pin_preserves_scheduler "$pmr_installed" || pin_scheduler_rc=$?
+	if [[ "$pin_scheduler_rc" -eq 0 ]]; then
+		print_info "Pulse merge scheduler preserved while its bounded runtime pin is active"
+		return 0
+	elif [[ "$pin_scheduler_rc" -ne 1 ]]; then
+		print_error "Pulse merge scheduler refused an invalid runtime pin"
+		return 1
 	fi
 
 	# Reuse contribution-watch's log-dir resolver (same logic, same config key).

--- a/.agents/scripts/setup/modules/schedulers-pulse.sh
+++ b/.agents/scripts/setup/modules/schedulers-pulse.sh
@@ -618,6 +618,24 @@ _schedulers_record_template_hash() {
 	return 0
 }
 
+_pulse_runtime_pin_preserves_scheduler() {
+	local pulse_installed="$1"
+	local pinned_root=""
+	local pin_rc=0
+	declare -F pulse_runtime_pin_resolve >/dev/null 2>&1 || return 1
+	pinned_root=$(pulse_runtime_pin_resolve 2>/dev/null) || pin_rc=$?
+	case "$pin_rc" in
+	0)
+		[[ "${AIDEVOPS_PULSE_RUNTIME_PIN_REFRESH_SCHEDULERS:-0}" != "1" ]] || return 1
+		[[ -n "$pinned_root" && "$pulse_installed" == "true" ]] || return 1
+		return 0
+		;;
+	1 | 3) return 1 ;;
+	*) return 2 ;;
+	esac
+	return 1
+}
+
 setup_supervisor_pulse() {
 	local _os="$1"
 
@@ -653,6 +671,7 @@ setup_supervisor_pulse() {
 	# Detect if pulse is already installed (for upgrade messaging)
 	# Uses shared helper to check launchd, cron, and systemd (GH#17381)
 	local _pulse_installed=false
+	local _pin_scheduler_rc=0
 	if _is_pulse_installed "$pulse_label"; then
 		_pulse_installed=true
 	fi
@@ -662,7 +681,15 @@ setup_supervisor_pulse() {
 	opencode_bin=$(_resolve_pulse_runtime_binary)
 
 	if [[ "$_do_install" == "true" ]]; then
-		_install_supervisor_pulse "$_os" "$pulse_label" "$wrapper_script" "$opencode_bin" "$_pulse_installed"
+		_pulse_runtime_pin_preserves_scheduler "$_pulse_installed" || _pin_scheduler_rc=$?
+		if [[ "$_pin_scheduler_rc" -eq 0 ]]; then
+			print_info "Supervisor pulse scheduler preserved while its bounded runtime pin is active"
+		elif [[ "$_pin_scheduler_rc" -eq 1 ]]; then
+			_install_supervisor_pulse "$_os" "$pulse_label" "$wrapper_script" "$opencode_bin" "$_pulse_installed"
+		else
+			print_error "Supervisor pulse scheduler refused an invalid runtime pin"
+			return 1
+		fi
 	elif [[ "$_pulse_lower" == "false" && "$_pulse_installed" == "true" ]]; then
 		# User explicitly disabled but pulse is still installed — clean up
 		_uninstall_pulse "$_os" "$pulse_label"

--- a/.agents/scripts/storage-inventory-helper.sh
+++ b/.agents/scripts/storage-inventory-helper.sh
@@ -9,6 +9,10 @@ if [[ -f "$SCRIPT_DIR/shared-constants.sh" ]]; then
 	# shellcheck source=shared-constants.sh
 	source "$SCRIPT_DIR/shared-constants.sh"
 fi
+if [[ -f "$SCRIPT_DIR/pulse-runtime-pin.sh" ]]; then
+	# shellcheck source=pulse-runtime-pin.sh
+	source "$SCRIPT_DIR/pulse-runtime-pin.sh"
+fi
 # Read-only policy classifiers are sourced from each producer. Their apply
 # functions are never called by this inventory helper.
 # shellcheck source=setup/_backup.sh
@@ -393,6 +397,23 @@ _storage_bundle_lease_is_live() {
 	return 1
 }
 
+_storage_resolve_pinned_runtime_bundle() {
+	local pinned_agents_root=""
+	local pin_rc=1
+	[[ -n "${HOME:-}" ]] || return 1
+	declare -F pulse_runtime_pin_resolve >/dev/null 2>&1 || return 1
+	pinned_agents_root=$(pulse_runtime_pin_resolve 2>/dev/null) || pin_rc=$?
+	case "$pin_rc" in
+	0)
+		printf '%s\n' "${pinned_agents_root%/agents}"
+		return 0
+		;;
+	1 | 3) return 1 ;;
+	*) return 2 ;;
+	esac
+	return 1
+}
+
 _storage_emit_runtime_bundle_record() {
 	local bundles_dir="${HOME:+$HOME/.aidevops/runtime-bundles}"
 	local measured=""
@@ -404,6 +425,8 @@ _storage_emit_runtime_bundle_record() {
 	local unknown_bytes="null"
 	local active_bundle=""
 	local previous_bundle=""
+	local pinned_bundle=""
+	local pin_rc=1
 	local protected_list=$'\n'
 	local lease_dir=""
 	local leased_bundle=""
@@ -415,6 +438,8 @@ _storage_emit_runtime_bundle_record() {
 
 	measured=$(_storage_measure_path "$bundles_dir")
 	IFS='|' read -r total_bytes confidence error <<<"$measured"
+	pinned_bundle=$(_storage_resolve_pinned_runtime_bundle) || pin_rc=$?
+	[[ "$pin_rc" -ne 2 ]] || error="pulse-pin-reference-invalid"
 	if [[ "$total_bytes" == "0" ]]; then
 		unknown_bytes=0
 	elif [[ "$total_bytes" != "null" ]]; then
@@ -423,6 +448,9 @@ _storage_emit_runtime_bundle_record() {
 			unknown_bytes="$total_bytes"
 		else
 			protected_list+="${active_bundle}"$'\n'
+			if [[ -n "$pinned_bundle" ]]; then
+				[[ "$protected_list" == *$'\n'"${pinned_bundle}"$'\n'* ]] || protected_list+="${pinned_bundle}"$'\n'
+			fi
 			if [[ -L "${HOME}/.aidevops/previous-runtime-bundle" ]]; then
 				if previous_bundle=$(_storage_bundle_root_from_link "${HOME}/.aidevops/previous-runtime-bundle" "$bundles_dir"); then
 					[[ "$protected_list" == *$'\n'"${previous_bundle}"$'\n'* ]] || protected_list+="${previous_bundle}"$'\n'
@@ -483,7 +511,7 @@ _storage_emit_runtime_bundle_record() {
 		--argjson protected_bytes "$protected_bytes" \
 		--argjson reclaimable_bytes "$reclaimable_bytes" \
 		--argjson unknown_bytes "$unknown_bytes" \
-		'{store_id:"runtime-bundles",producer:"agent-deploy",path:"~/.aidevops/runtime-bundles",owner:$owner,safety_class:$safety_class,policy:"30-day age, 30-bundle count, and 8 GiB soft limits; references and live leases veto deletion",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:$reclaimable_bytes,unknown_bytes:$unknown_bytes,protection_reasons:["current bundle, previous rollback bundle, live leases, and lease metadata"],sizing_confidence:$confidence,next_action:"Use setup activation for policy-owned pruning; do not delete protected bundles manually",error:(if $error == "" or $error == "missing" then null else $error end)}'
+		'{store_id:"runtime-bundles",producer:"agent-deploy",path:"~/.aidevops/runtime-bundles",owner:$owner,safety_class:$safety_class,policy:"30-day age, 30-bundle count, and 8 GiB soft limits; references, an active Pulse runtime pin, and live leases veto deletion",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:$reclaimable_bytes,unknown_bytes:$unknown_bytes,protection_reasons:["current bundle, previous rollback bundle, active Pulse runtime pin, live leases, and lease metadata"],sizing_confidence:$confidence,next_action:"Use setup activation for policy-owned pruning; do not delete protected bundles manually",error:(if $error == "" or $error == "missing" then null else $error end)}'
 	return 0
 }
 

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -30,6 +30,8 @@ source "$REPO_ROOT/.agents/scripts/setup/modules/agent-runtime.sh"
 source "$REPO_ROOT/.agents/scripts/setup/modules/schedulers-pulse.sh"
 # shellcheck source=../runtime-bundle-lease.sh
 source "$REPO_ROOT/.agents/scripts/runtime-bundle-lease.sh"
+# shellcheck source=../pulse-runtime-pin.sh
+source "$REPO_ROOT/.agents/scripts/pulse-runtime-pin.sh"
 
 _xml_escape() { local value="$1"; printf '%s' "$value"; return 0; }
 
@@ -66,6 +68,24 @@ assert_file_contains() {
 	local message="$3"
 	grep -q "$pattern" "$file" || fail "$message"
 	pass "$message"
+	return 0
+}
+
+write_pinnable_bundle_fixture() {
+	local agents_root="$1"
+	local bundle_id="$2"
+	local entrypoint=""
+	mkdir -p "$agents_root/scripts"
+	for entrypoint in \
+		pulse-runtime-pin.sh \
+		pulse-wrapper.sh \
+		pulse-lifecycle-helper.sh \
+		pulse-merge-routine.sh \
+		pulse-merge-webhook-receiver.sh; do
+		printf '#!/usr/bin/env bash\nexit 0\n' >"$agents_root/scripts/$entrypoint"
+		chmod +x "$agents_root/scripts/$entrypoint"
+	done
+	printf 'schema=1\nstatus=validated\nbundle_id=%s\n' "$bundle_id" >"$agents_root/.bundle-manifest"
 	return 0
 }
 
@@ -321,6 +341,7 @@ test_count_and_byte_pressure_preserve_protected_bundles() {
 	local active_root=""
 	local previous_root=""
 	local live_bundle="$bundles_dir/pressure-live"
+	local pinned_bundle="$bundles_dir/pressure-pinned"
 	local before_checksum=""
 	local after_checksum=""
 	active_root=$(_runtime_bundle_resolve_root "$target_dir")
@@ -332,17 +353,19 @@ test_count_and_byte_pressure_preserve_protected_bundles() {
 	mkdir -p "$live_bundle/agents" "$bundles_dir/.leases/pressure-live"
 	printf 'live\n' >"$live_bundle/agents/marker"
 	printf '%s\n' "$live_bundle/agents" >"$bundles_dir/.leases/pressure-live/$$"
+	write_pinnable_bundle_fixture "$pinned_bundle/agents" "pressure-pinned"
+	pulse_runtime_pin_set "$pinned_bundle/agents" "$(($(date +%s) + 600))" || fail "pressure fixture could not pin a runtime bundle"
 	mkdir -p "$bundles_dir/pressure-count-a/agents" "$bundles_dir/pressure-count-b/agents"
 	printf 'candidate-a\n' >"$bundles_dir/pressure-count-a/agents/marker"
 	printf 'candidate-b\n' >"$bundles_dir/pressure-count-b/agents/marker"
-	before_checksum=$(cksum "$active_root/scripts/helper.sh" "$previous_root/scripts/helper.sh" "$live_bundle/agents/marker")
+	before_checksum=$(cksum "$active_root/scripts/helper.sh" "$previous_root/scripts/helper.sh" "$live_bundle/agents/marker" "$pinned_bundle/agents/.bundle-manifest")
 
 	AIDEVOPS_RUNTIME_BUNDLE_RETENTION_SECONDS=999999999 \
 		AIDEVOPS_RUNTIME_BUNDLE_MAX_COUNT=3 \
 		AIDEVOPS_RUNTIME_BUNDLE_MAX_BYTES=999999999999 \
 		_runtime_bundle_prune "$bundles_dir" "$active_root" "$previous_root"
 	[[ ! -d "$bundles_dir/pressure-count-a" && ! -d "$bundles_dir/pressure-count-b" ]] || fail "count pressure did not converge unprotected bundles"
-	[[ -d "$active_root" && -d "$previous_root" && -d "$live_bundle" ]] || fail "count pressure removed a protected bundle"
+	[[ -d "$active_root" && -d "$previous_root" && -d "$live_bundle" && -d "$pinned_bundle" ]] || fail "count pressure removed a protected bundle"
 
 	mkdir -p "$bundles_dir/pressure-bytes/agents"
 	printf 'byte-pressure-candidate\n' >"$bundles_dir/pressure-bytes/agents/marker"
@@ -351,19 +374,23 @@ test_count_and_byte_pressure_preserve_protected_bundles() {
 		AIDEVOPS_RUNTIME_BUNDLE_MAX_BYTES=1 \
 		_runtime_bundle_prune "$bundles_dir" "$active_root" "$previous_root"
 	[[ ! -d "$bundles_dir/pressure-bytes" ]] || fail "byte pressure did not prune the unprotected candidate"
-	after_checksum=$(cksum "$active_root/scripts/helper.sh" "$previous_root/scripts/helper.sh" "$live_bundle/agents/marker")
+	after_checksum=$(cksum "$active_root/scripts/helper.sh" "$previous_root/scripts/helper.sh" "$live_bundle/agents/marker" "$pinned_bundle/agents/.bundle-manifest")
 	assert_eq "$before_checksum" "$after_checksum" "count and byte pressure preserve protected bundle byte identity"
+	pulse_runtime_pin_clear
 	return 0
 }
 
 test_runtime_bundle_inventory_explains_protection() {
 	local bundles_dir="$HOME/.aidevops/runtime-bundles"
 	local report_candidate="$bundles_dir/report-candidate"
+	local report_pinned="$bundles_dir/report-pinned"
 	local report=""
 	local before_checksum=""
 	local after_checksum=""
 	mkdir -p "$report_candidate/agents"
 	printf 'reclaimable-candidate\n' >"$report_candidate/agents/marker"
+	write_pinnable_bundle_fixture "$report_pinned/agents" "report-pinned"
+	pulse_runtime_pin_set "$report_pinned/agents" "$(($(date +%s) + 600))" || fail "inventory fixture could not pin a runtime bundle"
 	before_checksum=$(cksum "$report_candidate/agents/marker")
 	report=$(bash "$REPO_ROOT/.agents/scripts/storage-inventory-helper.sh" json)
 	after_checksum=$(cksum "$report_candidate/agents/marker")
@@ -371,6 +398,8 @@ test_runtime_bundle_inventory_explains_protection() {
 	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protected_bytes > 0')" == "true" ]] || fail "runtime inventory omitted protected bytes"
 	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .reclaimable_bytes > 0')" == "true" ]] || fail "runtime inventory omitted unreferenced reclaimable bytes"
 	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .unknown_bytes')" == "0" ]] || fail "runtime inventory left classified bundles unknown"
+	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protection_reasons[]' | grep -c 'active Pulse runtime pin')" -eq 1 ]] || fail "runtime inventory omitted the active Pulse pin reason"
+	pulse_runtime_pin_clear
 	pass "runtime inventory explains protected and reclaimable bundle bytes"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-runtime-pin.sh
+++ b/.agents/scripts/tests/test-pulse-runtime-pin.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SCHEDULERS_PULSE="$REPO_ROOT/.agents/scripts/setup/modules/schedulers-pulse.sh"
+SCHEDULERS_PLATFORM="$REPO_ROOT/.agents/scripts/setup/modules/schedulers-platform.sh"
+TEST_ROOT=""
+TESTS_RUN=0
+
+# shellcheck source=../pulse-runtime-pin.sh
+source "$REPO_ROOT/.agents/scripts/pulse-runtime-pin.sh"
+
+cleanup() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+pass() {
+	local message="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+write_bundle() {
+	local bundle_id="$1"
+	local agents_root="$HOME/.aidevops/runtime-bundles/$bundle_id/agents"
+	local entrypoint=""
+	mkdir -p "$agents_root/scripts"
+	for entrypoint in \
+		pulse-wrapper.sh \
+		pulse-lifecycle-helper.sh \
+		pulse-merge-routine.sh \
+		pulse-merge-webhook-receiver.sh; do
+		cat >"$agents_root/scripts/$entrypoint" <<'SH'
+#!/usr/bin/env bash
+printf '%s|%s\n' "$0" "$*" >>"${PULSE_PIN_EXEC_LOG:?}"
+SH
+	done
+	cat >"$agents_root/scripts/pulse-runtime-pin.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+	chmod +x "$agents_root/scripts/"*.sh
+	printf 'schema=1\nstatus=validated\nbundle_id=%s\n' "$bundle_id" >"$agents_root/.bundle-manifest"
+	(cd "$agents_root" && pwd -P)
+	return 0
+}
+
+test_set_resolve_and_clear() {
+	local agents_root="$1"
+	local now=""
+	local resolved=""
+	local config_path=""
+	now=$(date +%s)
+	pulse_runtime_pin_set "$agents_root" "$((now + 600))" || fail "valid runtime pin was rejected"
+	resolved=$(pulse_runtime_pin_resolve) || fail "valid runtime pin did not resolve"
+	[[ "$resolved" == "$agents_root" ]] || fail "runtime pin resolved the wrong bundle"
+	config_path=$(pulse_runtime_pin_config_path)
+	[[ "$(_pulse_runtime_pin_stat_value '%Lp' '%a' "$config_path")" == "600" ]] || fail "runtime pin is not mode 600"
+	pulse_runtime_pin_clear || fail "runtime pin could not be cleared"
+	[[ ! -e "$config_path" ]] || fail "runtime pin clear left its config behind"
+	pass "valid runtime pin resolves privately and clears cleanly"
+	return 0
+}
+
+test_rejects_unsafe_and_expired_configs() {
+	local agents_root="$1"
+	local outside_root="$TEST_ROOT/outside/agents"
+	local config_path=""
+	local now=""
+	local rc=0
+	mkdir -p "$outside_root/scripts"
+	printf '#!/usr/bin/env bash\n' >"$outside_root/scripts/pulse-wrapper.sh"
+	chmod +x "$outside_root/scripts/pulse-wrapper.sh"
+	printf 'status=validated\nbundle_id=outside\n' >"$outside_root/.bundle-manifest"
+	now=$(date +%s)
+	pulse_runtime_pin_set "$outside_root" "$((now + 600))" >/dev/null 2>&1 && fail "outside runtime root was accepted"
+	config_path=$(pulse_runtime_pin_config_path)
+	mkdir -p "${config_path%/*}"
+	printf 'schema=1\nagents_root=%s\ncreated_epoch=%s\nexpires_epoch=%s\n' \
+		"$agents_root" "$((now - 120))" "$((now - 60))" >"$config_path"
+	chmod 600 "$config_path"
+	pulse_runtime_pin_resolve >/dev/null 2>&1 || rc=$?
+	[[ "$rc" -eq 3 ]] || fail "expired pin did not return the expiry status"
+	chmod 644 "$config_path"
+	rc=0
+	pulse_runtime_pin_resolve >/dev/null 2>&1 || rc=$?
+	[[ "$rc" -eq 2 ]] || fail "publicly readable pin did not fail validation"
+	printf 'schema=1\nagents_root=%s\ncreated_epoch=%s\nexpires_epoch=%s\n' \
+		"$agents_root" "$now" "$((now + _PULSE_RUNTIME_PIN_MAX_SECONDS + 1))" >"$config_path"
+	chmod 600 "$config_path"
+	rc=0
+	pulse_runtime_pin_resolve >/dev/null 2>&1 || rc=$?
+	[[ "$rc" -eq 2 ]] || fail "overlong pin config bypassed the bounded TTL"
+	rm -f "$config_path"
+	printf 'schema=1\nagents_root=%s\ncreated_epoch=%s\nexpires_epoch=%s\n' \
+		"$agents_root" "$now" "$((now + 600))" >"$TEST_ROOT/pin-target.conf"
+	chmod 600 "$TEST_ROOT/pin-target.conf"
+	ln -s "$TEST_ROOT/pin-target.conf" "$config_path"
+	rc=0
+	pulse_runtime_pin_resolve >/dev/null 2>&1 || rc=$?
+	[[ "$rc" -eq 2 ]] || fail "symlinked pin config was accepted"
+	pulse_runtime_pin_clear
+	pass "unsafe and expired runtime pin configs fail closed"
+	return 0
+}
+
+test_direct_entrypoints_reexec_pinned_bundle() {
+	local agents_root="$1"
+	local now=""
+	local exec_log="$TEST_ROOT/pin-exec.log"
+	now=$(date +%s)
+	pulse_runtime_pin_set "$agents_root" "$((now + 600))"
+	PULSE_PIN_EXEC_LOG="$exec_log" bash "$REPO_ROOT/.agents/scripts/pulse-wrapper.sh" --self-check
+	PULSE_PIN_EXEC_LOG="$exec_log" bash "$REPO_ROOT/.agents/scripts/pulse-lifecycle-helper.sh" status
+	PULSE_PIN_EXEC_LOG="$exec_log" bash "$REPO_ROOT/.agents/scripts/pulse-merge-routine.sh" --help
+	PULSE_PIN_EXEC_LOG="$exec_log" bash "$REPO_ROOT/.agents/scripts/pulse-merge-webhook-receiver.sh" --check
+	grep -qF "$agents_root/scripts/pulse-wrapper.sh|--self-check" "$exec_log" || fail "stable wrapper did not re-enter the pinned bundle"
+	grep -qF "$agents_root/scripts/pulse-lifecycle-helper.sh|status" "$exec_log" || fail "lifecycle helper did not re-enter the pinned bundle"
+	grep -qF "$agents_root/scripts/pulse-merge-routine.sh|--help" "$exec_log" || fail "standalone merge routine did not re-enter the pinned bundle"
+	grep -qF "$agents_root/scripts/pulse-merge-webhook-receiver.sh|--check" "$exec_log" || fail "webhook receiver did not re-enter the pinned bundle"
+	pulse_runtime_pin_clear
+	pass "all direct Pulse entrypoints re-enter an active pinned bundle"
+	return 0
+}
+
+test_invalid_pin_blocks_direct_entrypoint() {
+	local agents_root="$1"
+	local now=""
+	local config_path=""
+	local rc=0
+	now=$(date +%s)
+	config_path=$(pulse_runtime_pin_config_path)
+	mkdir -p "${config_path%/*}"
+	printf 'schema=1\nagents_root=%s\ncreated_epoch=%s\nexpires_epoch=%s\n' \
+		"$agents_root" "$now" "$((now + 600))" >"$config_path"
+	chmod 644 "$config_path"
+	PULSE_PIN_EXEC_LOG="$TEST_ROOT/invalid-exec.log" bash "$REPO_ROOT/.agents/scripts/pulse-wrapper.sh" --self-check >/dev/null 2>&1 || rc=$?
+	[[ "$rc" -eq 2 ]] || fail "invalid pin did not block the stable Pulse entrypoint"
+	[[ ! -e "$TEST_ROOT/invalid-exec.log" ]] || fail "invalid pin executed a Pulse runtime"
+	pulse_runtime_pin_clear
+	pass "invalid runtime pin blocks direct Pulse entrypoints"
+	return 0
+}
+
+test_set_current_rejects_overlong_ttl() {
+	local agents_root="$1"
+	if AIDEVOPS_ACTIVE_AGENTS_LINK="$agents_root" pulse_runtime_pin_set_current "$((_PULSE_RUNTIME_PIN_MAX_SECONDS + 1))" >/dev/null 2>&1; then
+		fail "set-current accepted a TTL above the hard maximum"
+	fi
+	pass "set-current enforces the bounded TTL"
+	return 0
+}
+
+test_active_pin_preserves_installed_scheduler() {
+	local rc=0
+	# shellcheck source=../setup/modules/schedulers-pulse.sh
+	source "$SCHEDULERS_PULSE"
+	(
+		pulse_runtime_pin_resolve() { printf '%s\n' '/validated/pinned/agents'; return 0; }
+		_pulse_runtime_pin_preserves_scheduler true
+	) || fail "installed scheduler was not preserved for an active pin"
+	if (
+		pulse_runtime_pin_resolve() { return 1; }
+		_pulse_runtime_pin_preserves_scheduler true
+	); then
+		fail "scheduler was preserved without an active pin"
+	fi
+	if (
+		pulse_runtime_pin_resolve() { printf '%s\n' '/validated/pinned/agents'; return 0; }
+		_pulse_runtime_pin_preserves_scheduler false
+	); then
+		fail "missing scheduler was treated as preservable"
+	fi
+	if (
+		AIDEVOPS_PULSE_RUNTIME_PIN_REFRESH_SCHEDULERS=1
+		export AIDEVOPS_PULSE_RUNTIME_PIN_REFRESH_SCHEDULERS
+		pulse_runtime_pin_resolve() { printf '%s\n' '/validated/pinned/agents'; return 0; }
+		_pulse_runtime_pin_preserves_scheduler true
+	); then
+		fail "explicit controlled scheduler refresh was ignored"
+	fi
+	(
+		pulse_runtime_pin_resolve() { return 2; }
+		_pulse_runtime_pin_preserves_scheduler true
+	) || rc=$?
+	[[ "$rc" -eq 2 ]] || fail "invalid pin was treated as an inactive scheduler pin"
+	pass "scheduler preservation requires both an installation and an active pin"
+	return 0
+}
+
+test_active_pin_preserves_merge_scheduler() {
+	# shellcheck source=../setup/modules/schedulers-platform.sh
+	source "$SCHEDULERS_PLATFORM"
+	(
+		_launchd_has_agent() { return 0; }
+		_pulse_runtime_pin_preserves_scheduler() { local installed="$1"; [[ "$installed" == "true" ]] || return 1; return 0; }
+		print_info() { local message="$1"; : "$message"; return 0; }
+		print_error() { local message="$1"; : "$message"; return 0; }
+		setup_pulse_merge_routine
+	) || fail "active pin did not preserve the installed merge scheduler"
+	if (
+		_launchd_has_agent() { return 0; }
+		_pulse_runtime_pin_preserves_scheduler() { local installed="$1"; : "$installed"; return 2; }
+		print_info() { local message="$1"; : "$message"; return 0; }
+		print_error() { local message="$1"; : "$message"; return 0; }
+		setup_pulse_merge_routine
+	); then
+		fail "invalid pin did not block merge scheduler reconciliation"
+	fi
+	pass "active pin preserves the standalone merge scheduler"
+	return 0
+}
+
+main() {
+	local agents_root=""
+	TEST_ROOT=$(mktemp -d)
+	trap cleanup EXIT
+	HOME="$TEST_ROOT/home"
+	export HOME
+	agents_root=$(write_bundle "bundle-pinned")
+	ln -s "$agents_root" "$HOME/.aidevops/agents"
+	test_set_resolve_and_clear "$agents_root"
+	test_rejects_unsafe_and_expired_configs "$agents_root"
+	test_direct_entrypoints_reexec_pinned_bundle "$agents_root"
+	test_invalid_pin_blocks_direct_entrypoint "$agents_root"
+	test_set_current_rejects_overlong_ttl "$agents_root"
+	test_active_pin_preserves_installed_scheduler
+	test_active_pin_preserves_merge_scheduler
+	printf 'Results: %s checks passed\n' "$TESTS_RUN"
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-release-ensures-pulse-running.sh
+++ b/.agents/scripts/tests/test-release-ensures-pulse-running.sh
@@ -66,6 +66,8 @@ run_restart_helper_with_stub() {
 	local output_dir="$4"
 	local restart_rc="${5:-0}"
 	local log_path="${output_dir}/pulse-helper.log"
+	local pin_root="${6:-}"
+	local stub_pin_rc="${7:-1}"
 	local helper_rc=0
 	mkdir -p "${output_dir}/.aidevops/agents/scripts"
 
@@ -83,6 +85,11 @@ run_restart_helper_with_stub() {
 		resolve_aidevops_runtime_bundle_root() {
 			local requested_root="$1"
 			printf '%s\n' "$requested_root"
+			return 0
+		}
+		pulse_runtime_pin_resolve() {
+			[[ -n "$pin_root" ]] || return "$stub_pin_rc"
+			printf '%s\n' "$pin_root"
 			return 0
 		}
 		_restart_pulse_if_running() {
@@ -154,6 +161,18 @@ test_skip_flag_suppresses_restart_and_start() {
 	return 0
 }
 
+test_active_runtime_pin_overrides_release_bundle() {
+	local output=""
+	local root="${TEST_DIR}/pinned/.aidevops/runtime-bundles/pinned/agents"
+	output="$(run_restart_helper_with_stub "0" "true" "" "${TEST_DIR}/pinned" "0" "$root")"
+	if [[ "$output" == "${root}|true|${root} " ]]; then
+		print_result "release deploy reconciles Pulse against its active runtime pin" 0
+		return 0
+	fi
+	print_result "release deploy reconciles Pulse against its active runtime pin" 1 "helper calls=${output}"
+	return 0
+}
+
 test_reconciliation_failure_blocks_setup_success() {
 	local output=""
 	local rc=0
@@ -168,6 +187,20 @@ test_reconciliation_failure_blocks_setup_success() {
 	return 0
 }
 
+test_invalid_runtime_pin_blocks_reconciliation() {
+	local output=""
+	local rc=0
+	output="$(run_restart_helper_with_stub "0" "true" "" "${TEST_DIR}/invalid-pin" "0" "" "2")" || rc=$?
+
+	if [[ "$rc" -eq 1 && -z "$output" ]]; then
+		print_result "release deploy fails closed on an invalid Pulse runtime pin" 0
+		return 0
+	fi
+
+	print_result "release deploy fails closed on an invalid Pulse runtime pin" 1 "rc=${rc} helper calls=${output}"
+	return 0
+}
+
 main() {
 	TEST_DIR="$(mktemp -d)"
 	trap cleanup EXIT
@@ -176,7 +209,9 @@ main() {
 	test_disabled_supervisor_is_forwarded_to_reconcile
 	test_scoped_deploy_resolves_existing_consent
 	test_skip_flag_suppresses_restart_and_start
+	test_active_runtime_pin_overrides_release_bundle
 	test_reconciliation_failure_blocks_setup_success
+	test_invalid_runtime_pin_blocks_reconciliation
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -351,6 +351,8 @@ unset _setup_script_dir
 SETUP_IMPL_MODULES_DIR="${SETUP_MODULES_DIR}/modules"
 # shellcheck source=.agents/scripts/runtime-bundle-verifier.sh
 source "${INSTALL_DIR}/.agents/scripts/runtime-bundle-verifier.sh"
+# shellcheck source=.agents/scripts/pulse-runtime-pin.sh
+source "${INSTALL_DIR}/.agents/scripts/pulse-runtime-pin.sh"
 # shellcheck disable=SC1091  # Dynamic path via $SETUP_IMPL_MODULES_DIR
 source "${SETUP_IMPL_MODULES_DIR}/core.sh"
 # shellcheck disable=SC1091
@@ -1889,6 +1891,8 @@ _setup_restart_pulse_if_running() {
 
 	local activated_root="${_AIDEVOPS_ACTIVE_BUNDLE_ROOT:-}"
 	local current_root=""
+	local pin_rc=0
+	local pulse_active_link="${HOME}/.aidevops/agents"
 	local managed_enabled="${PULSE_ENABLED:-}"
 	local configured_pulse_consent=""
 	if [[ "$managed_enabled" != "true" && "$managed_enabled" != "false" ]]; then
@@ -1900,8 +1904,22 @@ _setup_restart_pulse_if_running() {
 		*) managed_enabled=false ;;
 		esac
 	fi
-	if current_root=$(resolve_aidevops_runtime_bundle_root "${HOME}/.aidevops/agents"); then
+	if current_root=$(pulse_runtime_pin_resolve 2>/dev/null); then
 		activated_root="$current_root"
+		pulse_active_link="$current_root"
+	else
+		pin_rc=$?
+		case "$pin_rc" in
+		1 | 3)
+			if current_root=$(resolve_aidevops_runtime_bundle_root "${HOME}/.aidevops/agents"); then
+				activated_root="$current_root"
+			fi
+			;;
+		*)
+			print_error "Pulse reconciliation refused an invalid runtime pin; clear or repair the private pin file"
+			return 1
+			;;
+		esac
 	fi
 	if [[ -z "$activated_root" ]]; then
 		print_error "Pulse reconciliation failed because the activated runtime bundle could not be resolved"
@@ -1910,7 +1928,7 @@ _setup_restart_pulse_if_running() {
 	if ! _restart_pulse_if_running \
 		"$activated_root" \
 		"$managed_enabled" \
-		"${HOME}/.aidevops/agents"; then
+		"$pulse_active_link"; then
 		print_error "Pulse reconciliation failed; setup cannot verify the activated runtime bundle"
 		return 1
 	fi


### PR DESCRIPTION
## Summary

- add a private, validated, expiring Pulse-only runtime pin so controlled observations can remain on one immutable bundle while normal aidevops activation continues
- re-enter the pinned bundle from every direct Pulse entrypoint, preserve installed Pulse schedulers, and protect the pinned bundle from pruning
- fail closed on invalid non-expired pins, retain automatic expiry, and document the explicit scheduler-refresh path for controlled profile changes

For #27777

This support change enables a fresh controlled baseline/canary observation. It does not complete the benchmark or justify closing #27777.

## Runtime Testing

- **Risk level:** high
- **Testing level:** runtime-verified
- Executed all direct Pulse entrypoints against an isolated pinned runtime fixture.
- Verified private config validation, expiry, hard TTL bounds, symlink rejection, invalid-pin blocking, scheduler preservation, explicit scheduler refresh, deployment reconciliation, bundle-pruning protection, and storage reporting.
- Passed `.agents/scripts/linters-local.sh --changed`, Bash syntax checks, ShellCheck, Bash 3.2 compatibility, the 7-check runtime-pin suite, the 7-test release-reconciliation suite, and the broader lifecycle/deployment/Pulse regression suites.

## Key Decisions

- Cap pins at 48 hours and use a 30-hour operator TTL for the planned 12-hour matched windows plus restoration margin.
- Treat malformed, unsafe, or unverifiable non-expired pin state as a startup/reconciliation error rather than silently drifting runtime revisions.
- Preserve existing scheduler definitions by default while pinned; require `AIDEVOPS_PULSE_RUNTIME_PIN_REFRESH_SCHEDULERS=1` for deliberate controlled profile switches.
- Keep quota-attribution completeness independent from runtime pinning: unknown API cost still prevents a passing benchmark verdict.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 8d 12h and 26,632,927 tokens on this with the user in an interactive session.