### PR TITLE
t18177: Add approval-bound shared X scheduling and notification operations

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -30,6 +30,76 @@ credential-shaped fields, use independent stream checkpoints, expose hard cost
 budgets, and add pagination, terminal-failure, replay, and write-reachability
 tests. No provider may add engagement or other platform mutations.
 
+## Approval-bound account operations
+
+Outbound account operations are a separate owner-only subsystem; they do not
+expand the read-only collector or provider-manifest contract. The authenticated
+alias must grant `knowledge.manage`, which encrypted sharing reserves for the
+workspace owner. Recipient `knowledge.read` and `knowledge.write` grants never
+become posting authority.
+
+Create a draft from a mode-0600 UTF-8 body file, then approve its exact immutable
+intent. Omit `--scheduled-at` for an immediately due operation:
+
+```bash
+knowledge-social-helper.sh operation-create --alias workspace:example \
+  --connection-id CONNECTION_ID --account-id ACCOUNT_ID --action post \
+  --body-file approved-post.txt --scheduled-at EPOCH \
+  --app PROFILE --username HANDLE
+
+knowledge-social-helper.sh operation-approve --alias workspace:example \
+  --operation-id OPERATION_ID --expires-at EPOCH
+```
+
+The intent binds the operation ID, connection, stable account ID, action, target,
+body digest, local app/account selectors, schedule, creator, and provider. Reply
+uses `--target-id POST_ID --body-file FILE`; like and bookmark use only
+`--target-id POST_ID`. Revoke approval or cancel before a claim with
+`operation-revoke` or `operation-cancel`.
+
+A private routine may invoke the bounded due runner:
+
+```bash
+knowledge-social-helper.sh operations-run-due --alias workspace:example \
+  --executor-id EXECUTOR_ID --claim-seconds 300 --limit 10
+```
+
+Each runner atomically claims an operation, verifies `xurl whoami` against the
+approved stable account immediately before execution, records a durable provider
+boundary, and invokes only mapped `post`, `reply`, `like`, or `bookmark` helper
+commands. Competing runners cannot create another local attempt. Any timeout,
+non-zero exit, malformed receipt, or executor loss after the provider boundary is
+`unknown`, never retryable. Resolve it only after external verification:
+
+```bash
+knowledge-social-helper.sh operation-reconcile --alias workspace:example \
+  --operation-id OPERATION_ID --outcome succeeded --provider-id POST_ID
+```
+
+Use `--outcome not-sent` without a provider ID only when verification proves the
+write was not accepted. `operations-list` returns bounded, content-free receipt
+metadata; it never returns body text, handles, profile names, or raw provider
+responses.
+
+## Mention and reply workflow
+
+Notification projection is a mutable local overlay on immutable mention/reply
+evidence. Refreshing is idempotent and never resets an existing workflow state:
+
+```bash
+knowledge-social-helper.sh notifications-refresh --alias workspace:example
+knowledge-social-helper.sh notifications-list --alias workspace:example \
+  --status action-required --limit 100
+knowledge-social-helper.sh notification-set --alias workspace:example \
+  --notification-id NOTIFICATION_ID --status responded
+```
+
+Supported states are `unread`, `seen`, `action-required`, `responded`, and
+`dismissed`. Listings contain only opaque notification metadata. Drafts,
+approvals, attempts, local profile selectors, receipts, and notification workflow
+state remain owner-local: shared snapshots neither export nor erase them during a
+restore.
+
 ## Bounded browser-gap capture
 
 Browser execution remains outside the corpus helper and uses an approved private
@@ -66,7 +136,10 @@ Before enabling a routine:
    raw private content.
 6. Verify request budgets and terminal rate-limit state remain unchanged by the
    browser route; browser capture never disguises provider API cost.
-7. Run corpus, social-store, query, sync, sharing, provider, and browser-gap tests.
+7. For outbound use, verify exact approval expiry, X stable-account identity, and
+   the private due routine before enabling it.
+8. Run corpus, social-store, operation, query, sync, sharing, provider, and
+   browser-gap tests.
 
 Shared deployments remain limited to the tested encrypted grant/distribution
 contract. Revocation must be verified before cached results are served. Combined

--- a/.agents/content/social-xurl.md
+++ b/.agents/content/social-xurl.md
@@ -26,7 +26,7 @@ tools:
 - **Runtime model**: use the host agent's current model/provider connection (OpenCode xAI, Anthropic, etc.); `xurl` auth is only for X API access and is separate from model-provider auth.
 - **Multi-account**: use `--app APP_NAME` for a specific X developer app/subscription context and `--username HANDLE` for a specific authenticated X account.
 - **Auth check**: `xurl-helper.sh status` then `xurl-helper.sh whoami`; never read `~/.xurl`.
-- **Write safety**: posting, deleting, replies, quotes, likes, reposts, follows, mutes, blocks, DMs, media upload, and raw mutating API calls require explicit user intent and `--confirm-write`.
+- **Write safety**: ad hoc writes require explicit user intent and `--confirm-write`; scheduled/shared-account post, reply, like, and bookmark actions use the owner-only approval-bound social operation queue.
 - **Fallback**: `content/social-bird.md` can use browser cookies when official API access is unavailable, but `xurl` is preferred because it uses the official X API.
 
 <!-- AI-CONTEXT-END -->
@@ -124,6 +124,40 @@ Fixture and fake-executable tests verify pagination, resume, terminal failures,
 credential rejection, and the guarded command route. They do not prove live X
 access; live verification requires a separately configured `xurl` profile.
 
+## Approval-Bound Scheduling and Shared Accounts
+
+For personal or workspace corpora, use `knowledge-social-helper.sh` instead of a
+bare confirmation flag when an action must be durable, scheduled, or auditable.
+The alias must grant owner-only `knowledge.manage`; encrypted workspace members
+with read/write grants cannot post as the shared account.
+
+```bash
+.agents/scripts/knowledge-social-helper.sh operation-create \
+  --alias workspace:example --connection-id CONNECTION_ID \
+  --account-id X_ACCOUNT_ID --action reply --target-id POST_ID \
+  --body-file approved-reply.txt --scheduled-at EPOCH \
+  --app PROFILE --username HANDLE
+
+.agents/scripts/knowledge-social-helper.sh operation-approve \
+  --alias workspace:example --operation-id OPERATION_ID --expires-at EPOCH
+
+.agents/scripts/knowledge-social-helper.sh operations-run-due \
+  --alias workspace:example --executor-id EXECUTOR_ID --limit 10
+```
+
+The body file must be owner-only mode 0600. Approval binds its digest plus the
+action, stable account ID, target, app/account selectors, schedule, approver, and
+expiry. The runner repeats `whoami` immediately before one mapped write and stores
+only a content-free receipt. A provider timeout or non-zero response after that
+boundary becomes `unknown` and is never retried automatically; use
+`operation-reconcile` only after independently confirming `succeeded` or
+`not-sent`.
+
+`notifications-refresh`, `notifications-list`, and `notification-set` project
+mentions/replies into the local `unread`, `seen`, `action-required`, `responded`,
+and `dismissed` workflow. Operational state and local profile selectors are
+excluded from encrypted workspace snapshots.
+
 ## Command Map
 
 | Intent | Helper command |
@@ -135,7 +169,8 @@ access; live verification requires a separately configured `xurl` profile.
 | Timeline / mentions | `xurl-helper.sh timeline --limit 20` / `xurl-helper.sh mentions --limit 10` |
 | Bookmarks / likes / DMs | `xurl-helper.sh bookmarks --limit 20` / `xurl-helper.sh likes --limit 20` / `xurl-helper.sh dms --limit 10` |
 | User lookup | `xurl-helper.sh user @handle` |
-| Post / reply / quote | add `--confirm-write` after explicit user approval |
+| Ad hoc post / reply / quote | add `--confirm-write` after explicit user approval |
+| Scheduled/shared post, reply, like, bookmark | use the approval-bound social operation queue |
 | Raw read-only API | `xurl-helper.sh run -- /2/users/me` |
 
 ## Operating Workflow

--- a/.agents/scripts/_knowledge_social_notifications.py
+++ b/.agents/scripts/_knowledge_social_notifications.py
@@ -27,6 +27,32 @@ ALLOWED_TRANSITIONS: dict[str, tuple[str, ...]] = {
     "responded": ("action-required", "dismissed"),
     "dismissed": ("unread", "action-required"),
 }
+SOURCE_ACTIVITIES_SQL = """SELECT a.provider,a.activity_type,a.remote_id,a.actor_remote_id,
+                    a.object_remote_id,a.observed_at,o.provider_json,b.connection_id
+               FROM activities a
+               JOIN fetch_batches b ON b.batch_id=a.batch_id
+               JOIN connections c ON c.connection_id=b.connection_id
+               LEFT JOIN objects o ON o.provider=a.provider
+                                  AND o.object_type='post'
+                                  AND o.remote_id=a.object_remote_id
+              WHERE a.state='active' AND a.activity_type IN (?,?,?)
+                AND a.actor_remote_id<>c.remote_account_id
+              ORDER BY a.observed_at,a.provider,a.activity_type,a.remote_id"""
+INSERT_NOTIFICATION_SQL = """INSERT OR IGNORE INTO notification_state(
+                    notification_id,principal_id,provider,connection_id,
+                    activity_type,activity_remote_id,object_remote_id,actor_remote_id,
+                    kind,status,observed_at,created_at,updated_at)
+                   VALUES(?,?,?,?,?,?,?,?,?,'unread',?,?,?)"""
+UPDATE_NOTIFICATION_SOURCE_SQL = """UPDATE notification_state
+                          SET connection_id=?,object_remote_id=?,actor_remote_id=?,
+                              kind=?,observed_at=?
+                        WHERE notification_id=? AND principal_id=?"""
+LIST_NOTIFICATIONS_SQL = """SELECT notification_id,kind,status,observed_at,updated_at
+               FROM notification_state WHERE principal_id=?
+              ORDER BY observed_at DESC,notification_id LIMIT ?"""
+LIST_NOTIFICATIONS_BY_STATUS_SQL = """SELECT notification_id,kind,status,observed_at,updated_at
+               FROM notification_state WHERE principal_id=? AND status=?
+              ORDER BY observed_at DESC,notification_id LIMIT ?"""
 
 
 def _notification_id(
@@ -38,20 +64,72 @@ def _notification_id(
     return f"ntf_{hashlib.sha256(source).hexdigest()}"
 
 
-def _notification_kind(activity_type: str, provider_json: str | None) -> str:
-    if activity_type in ("reply", "replies"):
-        return "reply"
+def _provider_references(provider_json: str | None) -> list[Any]:
     try:
         provider = json.loads(provider_json or "{}")
     except json.JSONDecodeError:
-        provider = {}
-    references = provider.get("referenced_tweets", []) if isinstance(provider, dict) else []
-    if isinstance(references, list) and any(
+        return []
+    if not isinstance(provider, dict):
+        return []
+    references = provider.get("referenced_tweets", [])
+    return references if isinstance(references, list) else []
+
+
+def _notification_kind(activity_type: str, provider_json: str | None) -> str:
+    if activity_type in ("reply", "replies"):
+        return "reply"
+    if any(
         isinstance(reference, dict) and reference.get("type") == "replied_to"
-        for reference in references
+        for reference in _provider_references(provider_json)
     ):
         return "reply"
     return "mention"
+
+
+def _upsert_notification(
+    database: sqlite3.Connection,
+    principal_id: str,
+    row: sqlite3.Row,
+    projected_at: int,
+) -> int:
+    notification_id = _notification_id(
+        principal_id,
+        str(row["provider"]),
+        str(row["activity_type"]),
+        str(row["remote_id"]),
+    )
+    kind = _notification_kind(str(row["activity_type"]), row["provider_json"])
+    changed = database.execute(
+        INSERT_NOTIFICATION_SQL,
+        (
+            notification_id,
+            principal_id,
+            row["provider"],
+            row["connection_id"],
+            row["activity_type"],
+            row["remote_id"],
+            row["object_remote_id"],
+            row["actor_remote_id"],
+            kind,
+            row["observed_at"],
+            projected_at,
+            projected_at,
+        ),
+    ).rowcount
+    if changed == 0:
+        database.execute(
+            UPDATE_NOTIFICATION_SOURCE_SQL,
+            (
+                row["connection_id"],
+                row["object_remote_id"],
+                row["actor_remote_id"],
+                kind,
+                row["observed_at"],
+                notification_id,
+                principal_id,
+            ),
+        )
+    return changed
 
 
 def project_notifications(
@@ -62,73 +140,17 @@ def project_notifications(
 ) -> dict[str, int]:
     """Idempotently project mention/reply evidence without resetting workflow state."""
     principal_id = validate_opaque(principal_id, "principal_id")
-    placeholders = ",".join("?" for _ in SOURCE_ACTIVITY_TYPES)
     rows = database.execute(
-        f"""SELECT a.provider,a.activity_type,a.remote_id,a.actor_remote_id,
-                    a.object_remote_id,a.observed_at,o.provider_json,b.connection_id
-               FROM activities a
-               JOIN fetch_batches b ON b.batch_id=a.batch_id
-               JOIN connections c ON c.connection_id=b.connection_id
-               LEFT JOIN objects o ON o.provider=a.provider
-                                  AND o.object_type='post'
-                                  AND o.remote_id=a.object_remote_id
-              WHERE a.state='active' AND a.activity_type IN ({placeholders})
-                AND a.actor_remote_id<>c.remote_account_id
-              ORDER BY a.observed_at,a.provider,a.activity_type,a.remote_id""",  # nosec B608 -- fixed placeholder count
+        SOURCE_ACTIVITIES_SQL,
         SOURCE_ACTIVITY_TYPES,
     ).fetchall()
     inserted = 0
     database.execute("BEGIN IMMEDIATE")
     try:
         for row in rows:
-            notification_id = _notification_id(
-                principal_id,
-                str(row["provider"]),
-                str(row["activity_type"]),
-                str(row["remote_id"]),
+            inserted += _upsert_notification(
+                database, principal_id, row, projected_at
             )
-            changed = database.execute(
-                """INSERT OR IGNORE INTO notification_state(
-                    notification_id,principal_id,provider,connection_id,
-                    activity_type,activity_remote_id,object_remote_id,actor_remote_id,
-                    kind,status,observed_at,created_at,updated_at)
-                   VALUES(?,?,?,?,?,?,?,?,?,'unread',?,?,?)""",
-                (
-                    notification_id,
-                    principal_id,
-                    row["provider"],
-                    row["connection_id"],
-                    row["activity_type"],
-                    row["remote_id"],
-                    row["object_remote_id"],
-                    row["actor_remote_id"],
-                    _notification_kind(
-                        str(row["activity_type"]), row["provider_json"]
-                    ),
-                    row["observed_at"],
-                    projected_at,
-                    projected_at,
-                ),
-            ).rowcount
-            inserted += changed
-            if changed == 0:
-                database.execute(
-                    """UPDATE notification_state
-                          SET connection_id=?,object_remote_id=?,actor_remote_id=?,
-                              kind=?,observed_at=?
-                        WHERE notification_id=? AND principal_id=?""",
-                    (
-                        row["connection_id"],
-                        row["object_remote_id"],
-                        row["actor_remote_id"],
-                        _notification_kind(
-                            str(row["activity_type"]), row["provider_json"]
-                        ),
-                        row["observed_at"],
-                        notification_id,
-                        principal_id,
-                    ),
-                )
         database.execute("COMMIT")
     except Exception:
         if database.in_transaction:
@@ -149,18 +171,14 @@ def list_notifications(
         raise SocialStoreError("unsupported notification status")
     if limit < 1 or limit > 1000:
         raise SocialStoreError("notification list limit must be between 1 and 1000")
-    parameters: list[Any] = [principal_id]
-    condition = "principal_id=?"
-    if status is not None:
-        condition += " AND status=?"
-        parameters.append(status)
-    parameters.append(limit)
-    rows = database.execute(
-        f"""SELECT notification_id,kind,status,observed_at,updated_at
-               FROM notification_state WHERE {condition}
-              ORDER BY observed_at DESC,notification_id LIMIT ?""",  # nosec B608 -- fixed clauses
-        parameters,
-    ).fetchall()
+    if status is None:
+        rows = database.execute(
+            LIST_NOTIFICATIONS_SQL, (principal_id, limit)
+        ).fetchall()
+    else:
+        rows = database.execute(
+            LIST_NOTIFICATIONS_BY_STATUS_SQL, (principal_id, status, limit)
+        ).fetchall()
     return [dict(row) for row in rows]
 
 

--- a/.agents/scripts/_knowledge_social_notifications.py
+++ b/.agents/scripts/_knowledge_social_notifications.py
@@ -169,7 +169,6 @@ def set_notification_status(
     principal_id: str,
     notification_id: str,
     status: str,
-    *,
     updated_at: int,
 ) -> dict[str, Any]:
     """Apply one explicit, authorized notification workflow transition."""

--- a/.agents/scripts/_knowledge_social_notifications.py
+++ b/.agents/scripts/_knowledge_social_notifications.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Mutable notification workflow projected from immutable social evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from typing import Any
+
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+NOTIFICATION_STATUSES = (
+    "unread",
+    "seen",
+    "action-required",
+    "responded",
+    "dismissed",
+)
+SOURCE_ACTIVITY_TYPES = ("mentions", "reply", "replies")
+ALLOWED_TRANSITIONS: dict[str, tuple[str, ...]] = {
+    "unread": ("seen", "action-required", "responded", "dismissed"),
+    "seen": ("unread", "action-required", "responded", "dismissed"),
+    "action-required": ("seen", "responded", "dismissed"),
+    "responded": ("action-required", "dismissed"),
+    "dismissed": ("unread", "action-required"),
+}
+
+
+def _notification_id(
+    principal_id: str, provider: str, activity_type: str, activity_remote_id: str
+) -> str:
+    source = "\x00".join(
+        (principal_id, provider, activity_type, activity_remote_id)
+    ).encode("utf-8")
+    return f"ntf_{hashlib.sha256(source).hexdigest()}"
+
+
+def _notification_kind(activity_type: str, provider_json: str | None) -> str:
+    if activity_type in ("reply", "replies"):
+        return "reply"
+    try:
+        provider = json.loads(provider_json or "{}")
+    except json.JSONDecodeError:
+        provider = {}
+    references = provider.get("referenced_tweets", []) if isinstance(provider, dict) else []
+    if isinstance(references, list) and any(
+        isinstance(reference, dict) and reference.get("type") == "replied_to"
+        for reference in references
+    ):
+        return "reply"
+    return "mention"
+
+
+def project_notifications(
+    database: sqlite3.Connection,
+    principal_id: str,
+    *,
+    projected_at: int,
+) -> dict[str, int]:
+    """Idempotently project mention/reply evidence without resetting workflow state."""
+    principal_id = validate_opaque(principal_id, "principal_id")
+    placeholders = ",".join("?" for _ in SOURCE_ACTIVITY_TYPES)
+    rows = database.execute(
+        f"""SELECT a.provider,a.activity_type,a.remote_id,a.actor_remote_id,
+                    a.object_remote_id,a.observed_at,o.provider_json,b.connection_id
+               FROM activities a
+               JOIN fetch_batches b ON b.batch_id=a.batch_id
+               JOIN connections c ON c.connection_id=b.connection_id
+               LEFT JOIN objects o ON o.provider=a.provider
+                                  AND o.object_type='post'
+                                  AND o.remote_id=a.object_remote_id
+              WHERE a.state='active' AND a.activity_type IN ({placeholders})
+                AND a.actor_remote_id<>c.remote_account_id
+              ORDER BY a.observed_at,a.provider,a.activity_type,a.remote_id""",  # nosec B608 -- fixed placeholder count
+        SOURCE_ACTIVITY_TYPES,
+    ).fetchall()
+    inserted = 0
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        for row in rows:
+            notification_id = _notification_id(
+                principal_id,
+                str(row["provider"]),
+                str(row["activity_type"]),
+                str(row["remote_id"]),
+            )
+            changed = database.execute(
+                """INSERT OR IGNORE INTO notification_state(
+                    notification_id,principal_id,provider,connection_id,
+                    activity_type,activity_remote_id,object_remote_id,actor_remote_id,
+                    kind,status,observed_at,created_at,updated_at)
+                   VALUES(?,?,?,?,?,?,?,?,?,'unread',?,?,?)""",
+                (
+                    notification_id,
+                    principal_id,
+                    row["provider"],
+                    row["connection_id"],
+                    row["activity_type"],
+                    row["remote_id"],
+                    row["object_remote_id"],
+                    row["actor_remote_id"],
+                    _notification_kind(
+                        str(row["activity_type"]), row["provider_json"]
+                    ),
+                    row["observed_at"],
+                    projected_at,
+                    projected_at,
+                ),
+            ).rowcount
+            inserted += changed
+            if changed == 0:
+                database.execute(
+                    """UPDATE notification_state
+                          SET connection_id=?,object_remote_id=?,actor_remote_id=?,
+                              kind=?,observed_at=?
+                        WHERE notification_id=? AND principal_id=?""",
+                    (
+                        row["connection_id"],
+                        row["object_remote_id"],
+                        row["actor_remote_id"],
+                        _notification_kind(
+                            str(row["activity_type"]), row["provider_json"]
+                        ),
+                        row["observed_at"],
+                        notification_id,
+                        principal_id,
+                    ),
+                )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return {"projected": len(rows), "inserted": inserted}
+
+
+def list_notifications(
+    database: sqlite3.Connection,
+    principal_id: str,
+    status: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return bounded workflow metadata without content, handles, or raw provider IDs."""
+    principal_id = validate_opaque(principal_id, "principal_id")
+    if status is not None and status not in NOTIFICATION_STATUSES:
+        raise SocialStoreError("unsupported notification status")
+    if limit < 1 or limit > 1000:
+        raise SocialStoreError("notification list limit must be between 1 and 1000")
+    parameters: list[Any] = [principal_id]
+    condition = "principal_id=?"
+    if status is not None:
+        condition += " AND status=?"
+        parameters.append(status)
+    parameters.append(limit)
+    rows = database.execute(
+        f"""SELECT notification_id,kind,status,observed_at,updated_at
+               FROM notification_state WHERE {condition}
+              ORDER BY observed_at DESC,notification_id LIMIT ?""",  # nosec B608 -- fixed clauses
+        parameters,
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def set_notification_status(
+    database: sqlite3.Connection,
+    principal_id: str,
+    notification_id: str,
+    status: str,
+    *,
+    updated_at: int,
+) -> dict[str, Any]:
+    """Apply one explicit, authorized notification workflow transition."""
+    principal_id = validate_opaque(principal_id, "principal_id")
+    notification_id = validate_opaque(notification_id, "notification_id")
+    if status not in NOTIFICATION_STATUSES:
+        raise SocialStoreError("unsupported notification status")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = database.execute(
+            """SELECT status FROM notification_state
+                 WHERE notification_id=? AND principal_id=?""",
+            (notification_id, principal_id),
+        ).fetchone()
+        if row is None:
+            raise SocialStoreError("notification is unavailable")
+        previous = str(row["status"])
+        if status != previous and status not in ALLOWED_TRANSITIONS[previous]:
+            raise SocialStoreError("notification workflow transition is not allowed")
+        if status != previous:
+            database.execute(
+                """UPDATE notification_state SET status=?,updated_at=?
+                     WHERE notification_id=? AND principal_id=?""",
+                (status, updated_at, notification_id, principal_id),
+            )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return {
+        "notification_id": notification_id,
+        "previous_status": previous,
+        "status": status,
+    }

--- a/.agents/scripts/_knowledge_social_outbound.py
+++ b/.agents/scripts/_knowledge_social_outbound.py
@@ -49,6 +49,16 @@ class OperationIntent:
 
 
 @dataclass(frozen=True)
+class ApprovalDecision:
+    """Normalized approval authority for one exact stored intent."""
+
+    operation_id: str
+    principal_id: str
+    expires_at: int
+    approved_at: int
+
+
+@dataclass(frozen=True)
 class ClaimedOperation:
     """Private operation values needed for exactly one provider attempt."""
 
@@ -193,6 +203,50 @@ def _public_operation(row: sqlite3.Row) -> dict[str, Any]:
     }
 
 
+def _existing_public_operation(
+    database: sqlite3.Connection, operation_id: str, intent_sha256: str
+) -> dict[str, Any] | None:
+    existing = database.execute(
+        "SELECT * FROM outbound_operations WHERE operation_id=?", (operation_id,)
+    ).fetchone()
+    if existing is None:
+        return None
+    _verify_operation_row(existing)
+    if existing["intent_sha256"] != intent_sha256:
+        raise SocialStoreError("operation ID is bound to another intent")
+    return _public_operation(existing)
+
+
+def _insert_operation(
+    database: sqlite3.Connection, values: dict[str, Any], created_at: int
+) -> None:
+    database.execute(
+        """INSERT INTO outbound_operations(
+            operation_id,provider,connection_id,remote_account_id,action,
+            target_remote_id,payload,payload_sha256,intent_sha256,app_profile,
+            username,scheduled_at,state,created_by,created_at,updated_at)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            values["operation_id"],
+            values["provider"],
+            values["connection_id"],
+            values["remote_account_id"],
+            values["action"],
+            values["target_remote_id"],
+            values["payload"],
+            values["payload_sha256"],
+            values["intent_sha256"],
+            values["app_profile"],
+            values["username"],
+            values["scheduled_at"],
+            "draft",
+            values["created_by"],
+            created_at,
+            created_at,
+        ),
+    )
+
+
 def create_operation(
     database: sqlite3.Connection, intent: OperationIntent
 ) -> dict[str, Any]:
@@ -204,40 +258,13 @@ def create_operation(
     database.execute("BEGIN IMMEDIATE")
     try:
         _assert_connection(database, values)
-        existing = database.execute(
-            "SELECT * FROM outbound_operations WHERE operation_id=?", (operation_id,)
-        ).fetchone()
-        if existing is not None:
-            _verify_operation_row(existing)
-            if existing["intent_sha256"] != values["intent_sha256"]:
-                raise SocialStoreError("operation ID is bound to another intent")
-            database.execute("COMMIT")
-            return _public_operation(existing)
-        database.execute(
-            """INSERT INTO outbound_operations(
-                operation_id,provider,connection_id,remote_account_id,action,
-                target_remote_id,payload,payload_sha256,intent_sha256,app_profile,
-                username,scheduled_at,state,created_by,created_at,updated_at)
-               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-            (
-                values["operation_id"],
-                values["provider"],
-                values["connection_id"],
-                values["remote_account_id"],
-                values["action"],
-                values["target_remote_id"],
-                values["payload"],
-                values["payload_sha256"],
-                values["intent_sha256"],
-                values["app_profile"],
-                values["username"],
-                values["scheduled_at"],
-                "draft",
-                values["created_by"],
-                created_at,
-                created_at,
-            ),
+        existing = _existing_public_operation(
+            database, operation_id, str(values["intent_sha256"])
         )
+        if existing is not None:
+            database.execute("COMMIT")
+            return existing
+        _insert_operation(database, values, created_at)
         database.execute("COMMIT")
     except Exception:
         if database.in_transaction:
@@ -262,6 +289,49 @@ def _verified_operation(database: sqlite3.Connection, operation_id: str) -> sqli
     return _verify_operation_row(row)
 
 
+def _validated_approval_row(
+    database: sqlite3.Connection, decision: ApprovalDecision
+) -> sqlite3.Row:
+    row = _verified_operation(database, decision.operation_id)
+    if row["created_by"] != decision.principal_id:
+        raise SocialStoreError("operation approval requires its owner")
+    if row["state"] in TERMINAL_STATES or row["state"] == "claimed":
+        raise SocialStoreError("operation cannot be approved in its current state")
+    return row
+
+
+def _persist_approval(
+    database: sqlite3.Connection,
+    row: sqlite3.Row,
+    decision: ApprovalDecision,
+) -> str:
+    database.execute(
+        """UPDATE outbound_approvals SET revoked_at=?
+            WHERE operation_id=? AND principal_id=? AND revoked_at IS NULL""",
+        (decision.approved_at, decision.operation_id, decision.principal_id),
+    )
+    approval_id = _new_id("apr")
+    database.execute(
+        """INSERT INTO outbound_approvals(
+            approval_id,operation_id,principal_id,intent_sha256,
+            approved_at,expires_at,revoked_at)
+           VALUES(?,?,?,?,?,?,NULL)""",
+        (
+            approval_id,
+            decision.operation_id,
+            decision.principal_id,
+            row["intent_sha256"],
+            decision.approved_at,
+            decision.expires_at,
+        ),
+    )
+    database.execute(
+        "UPDATE outbound_operations SET state='approved',updated_at=? WHERE operation_id=?",
+        (decision.approved_at, decision.operation_id),
+    )
+    return approval_id
+
+
 def approve_operation(
     database: sqlite3.Connection,
     operation_id: str,
@@ -273,48 +343,26 @@ def approve_operation(
     approved_at = now_epoch() if approved_at is None else approved_at
     if expires_at <= approved_at or expires_at - approved_at > MAX_APPROVAL_SECONDS:
         raise SocialStoreError("approval expiry must be within 31 days")
-    principal_id = validate_opaque(principal_id, "principal_id")
+    decision = ApprovalDecision(
+        validate_opaque(operation_id, "operation_id"),
+        validate_opaque(principal_id, "principal_id"),
+        expires_at,
+        approved_at,
+    )
     database.execute("BEGIN IMMEDIATE")
     try:
-        row = _verified_operation(database, operation_id)
-        if row["created_by"] != principal_id:
-            raise SocialStoreError("operation approval requires its owner")
-        if row["state"] in TERMINAL_STATES or row["state"] == "claimed":
-            raise SocialStoreError("operation cannot be approved in its current state")
-        database.execute(
-            """UPDATE outbound_approvals SET revoked_at=?
-                WHERE operation_id=? AND principal_id=? AND revoked_at IS NULL""",
-            (approved_at, operation_id, principal_id),
-        )
-        approval_id = _new_id("apr")
-        database.execute(
-            """INSERT INTO outbound_approvals(
-                approval_id,operation_id,principal_id,intent_sha256,
-                approved_at,expires_at,revoked_at)
-               VALUES(?,?,?,?,?,?,NULL)""",
-            (
-                approval_id,
-                operation_id,
-                principal_id,
-                row["intent_sha256"],
-                approved_at,
-                expires_at,
-            ),
-        )
-        database.execute(
-            "UPDATE outbound_operations SET state='approved',updated_at=? WHERE operation_id=?",
-            (approved_at, operation_id),
-        )
+        row = _validated_approval_row(database, decision)
+        approval_id = _persist_approval(database, row, decision)
         database.execute("COMMIT")
     except Exception:
         if database.in_transaction:
             database.execute("ROLLBACK")
         raise
     return {
-        "operation_id": operation_id,
+        "operation_id": decision.operation_id,
         "approval_id": approval_id,
         "state": "approved",
-        "expires_at": expires_at,
+        "expires_at": decision.expires_at,
     }
 
 

--- a/.agents/scripts/_knowledge_social_outbound.py
+++ b/.agents/scripts/_knowledge_social_outbound.py
@@ -1,0 +1,785 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Approval-bound outbound social operation state and receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from knowledge_social_import import canonical_json
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+ACTIONS = ("post", "reply", "like", "bookmark")
+TERMINAL_STATES = ("succeeded", "failed", "unknown", "cancelled")
+FAILURE_CLASSES = (
+    "authorization",
+    "executor_lost",
+    "identity",
+    "provider_unavailable",
+    "reconciled_not_sent",
+    "runtime",
+    "validation",
+)
+MAX_PAYLOAD_BYTES = 16 * 1024
+MAX_SELECTOR_BYTES = 256
+MAX_APPROVAL_SECONDS = 31 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class ClaimedOperation:
+    """Private operation values needed for exactly one provider attempt."""
+
+    operation_id: str
+    action: str
+    remote_account_id: str
+    target_remote_id: str | None
+    payload: str | None
+    app_profile: str | None
+    username: str | None
+    claim_token: int
+    attempt_id: str
+
+
+def now_epoch() -> int:
+    """Return the current whole-second epoch."""
+    return int(time.time())
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _optional_selector(value: str | None, field: str) -> str | None:
+    if value is None:
+        return None
+    if (
+        not value
+        or value.startswith("-")
+        or "\x00" in value
+        or "\n" in value
+        or "\r" in value
+    ):
+        raise SocialStoreError(f"{field} must be one non-empty line")
+    if len(value.encode("utf-8")) > MAX_SELECTOR_BYTES:
+        raise SocialStoreError(f"{field} is too long")
+    return value
+
+
+def _validated_payload(action: str, payload: str | None) -> str | None:
+    if action in ("post", "reply"):
+        if payload is None or not payload.strip() or "\x00" in payload:
+            raise SocialStoreError(f"{action} requires a non-empty private body file")
+        if len(payload.encode("utf-8")) > MAX_PAYLOAD_BYTES:
+            raise SocialStoreError("outbound body exceeds the private payload limit")
+        return payload
+    if payload is not None:
+        raise SocialStoreError(f"{action} does not accept a body")
+    return None
+
+
+def _validated_target(action: str, target: str | None) -> str | None:
+    if action == "post":
+        if target is not None:
+            raise SocialStoreError("post does not accept a target")
+        return None
+    if target is None:
+        raise SocialStoreError(f"{action} requires a target post ID")
+    return validate_opaque(target, "target_remote_id")
+
+
+def _intent_document(values: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "operation_id": values["operation_id"],
+        "provider": values["provider"],
+        "connection_id": values["connection_id"],
+        "remote_account_id": values["remote_account_id"],
+        "action": values["action"],
+        "target_remote_id": values["target_remote_id"],
+        "payload_sha256": values["payload_sha256"],
+        "app_profile": values["app_profile"],
+        "username": values["username"],
+        "scheduled_at": values["scheduled_at"],
+        "created_by": values["created_by"],
+    }
+
+
+def _intent_sha256(values: dict[str, Any]) -> str:
+    return _digest(canonical_json(_intent_document(values)))
+
+
+def _verify_operation_row(row: sqlite3.Row) -> sqlite3.Row:
+    payload_sha256 = _digest(row["payload"] or "")
+    if payload_sha256 != row["payload_sha256"]:
+        raise SocialStoreError("outbound operation payload integrity check failed")
+    values = dict(row)
+    values["payload_sha256"] = payload_sha256
+    if _intent_sha256(values) != row["intent_sha256"]:
+        raise SocialStoreError("outbound operation intent integrity check failed")
+    return row
+
+
+def _operation_values(
+    operation_id: str,
+    connection_id: str,
+    remote_account_id: str,
+    action: str,
+    target_remote_id: str | None,
+    payload: str | None,
+    app_profile: str | None,
+    username: str | None,
+    scheduled_at: int,
+    created_by: str,
+) -> dict[str, Any]:
+    if action not in ACTIONS:
+        raise SocialStoreError("unsupported outbound action")
+    if scheduled_at < 0:
+        raise SocialStoreError("scheduled_at must be a non-negative epoch")
+    payload = _validated_payload(action, payload)
+    return {
+        "operation_id": validate_opaque(operation_id, "operation_id"),
+        "provider": "xapi",
+        "connection_id": validate_opaque(connection_id, "connection_id"),
+        "remote_account_id": validate_opaque(
+            remote_account_id, "remote_account_id"
+        ),
+        "action": action,
+        "target_remote_id": _validated_target(action, target_remote_id),
+        "payload": payload,
+        "payload_sha256": _digest(payload or ""),
+        "app_profile": _optional_selector(app_profile, "app_profile"),
+        "username": _optional_selector(username, "username"),
+        "scheduled_at": scheduled_at,
+        "created_by": validate_opaque(created_by, "created_by"),
+    }
+
+
+def _assert_connection(database: sqlite3.Connection, values: dict[str, Any]) -> None:
+    row = database.execute(
+        "SELECT provider,remote_account_id FROM connections WHERE connection_id=?",
+        (values["connection_id"],),
+    ).fetchone()
+    if row is None:
+        raise SocialStoreError("outbound connection is unavailable")
+    if row["provider"] != "xapi" or row["remote_account_id"] != values[
+        "remote_account_id"
+    ]:
+        raise SocialStoreError("outbound connection does not match the X account")
+
+
+def _public_operation(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "operation_id": str(row["operation_id"]),
+        "action": str(row["action"]),
+        "state": str(row["state"]),
+        "scheduled_at": int(row["scheduled_at"]),
+        "updated_at": int(row["updated_at"]),
+    }
+
+
+def create_operation(
+    database: sqlite3.Connection,
+    *,
+    connection_id: str,
+    remote_account_id: str,
+    action: str,
+    target_remote_id: str | None,
+    payload: str | None,
+    app_profile: str | None,
+    username: str | None,
+    scheduled_at: int,
+    created_by: str,
+    operation_id: str | None = None,
+    created_at: int | None = None,
+) -> dict[str, Any]:
+    """Create or idempotently recover one immutable draft operation."""
+    operation_id = operation_id or _new_id("op")
+    created_at = now_epoch() if created_at is None else created_at
+    values = _operation_values(
+        operation_id,
+        connection_id,
+        remote_account_id,
+        action,
+        target_remote_id,
+        payload,
+        app_profile,
+        username,
+        scheduled_at,
+        created_by,
+    )
+    values["intent_sha256"] = _intent_sha256(values)
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        _assert_connection(database, values)
+        existing = database.execute(
+            "SELECT * FROM outbound_operations WHERE operation_id=?", (operation_id,)
+        ).fetchone()
+        if existing is not None:
+            _verify_operation_row(existing)
+            if existing["intent_sha256"] != values["intent_sha256"]:
+                raise SocialStoreError("operation ID is bound to another intent")
+            database.execute("COMMIT")
+            return _public_operation(existing)
+        database.execute(
+            """INSERT INTO outbound_operations(
+                operation_id,provider,connection_id,remote_account_id,action,
+                target_remote_id,payload,payload_sha256,intent_sha256,app_profile,
+                username,scheduled_at,state,created_by,created_at,updated_at)
+               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                values["operation_id"],
+                values["provider"],
+                values["connection_id"],
+                values["remote_account_id"],
+                values["action"],
+                values["target_remote_id"],
+                values["payload"],
+                values["payload_sha256"],
+                values["intent_sha256"],
+                values["app_profile"],
+                values["username"],
+                values["scheduled_at"],
+                "draft",
+                values["created_by"],
+                created_at,
+                created_at,
+            ),
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return {
+        "operation_id": operation_id,
+        "action": action,
+        "state": "draft",
+        "scheduled_at": scheduled_at,
+        "updated_at": created_at,
+    }
+
+
+def _verified_operation(database: sqlite3.Connection, operation_id: str) -> sqlite3.Row:
+    row = database.execute(
+        "SELECT * FROM outbound_operations WHERE operation_id=?",
+        (validate_opaque(operation_id, "operation_id"),),
+    ).fetchone()
+    if row is None:
+        raise SocialStoreError("outbound operation is unavailable")
+    return _verify_operation_row(row)
+
+
+def approve_operation(
+    database: sqlite3.Connection,
+    operation_id: str,
+    principal_id: str,
+    expires_at: int,
+    *,
+    approved_at: int | None = None,
+) -> dict[str, Any]:
+    """Bind one authenticated owner approval to the exact stored intent."""
+    approved_at = now_epoch() if approved_at is None else approved_at
+    if expires_at <= approved_at or expires_at - approved_at > MAX_APPROVAL_SECONDS:
+        raise SocialStoreError("approval expiry must be within 31 days")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = _verified_operation(database, operation_id)
+        if row["created_by"] != principal_id:
+            raise SocialStoreError("operation approval requires its owner")
+        if row["state"] in TERMINAL_STATES or row["state"] == "claimed":
+            raise SocialStoreError("operation cannot be approved in its current state")
+        database.execute(
+            """UPDATE outbound_approvals SET revoked_at=?
+                WHERE operation_id=? AND principal_id=? AND revoked_at IS NULL""",
+            (approved_at, operation_id, principal_id),
+        )
+        approval_id = _new_id("apr")
+        database.execute(
+            """INSERT INTO outbound_approvals(
+                approval_id,operation_id,principal_id,intent_sha256,
+                approved_at,expires_at,revoked_at)
+               VALUES(?,?,?,?,?,?,NULL)""",
+            (
+                approval_id,
+                operation_id,
+                principal_id,
+                row["intent_sha256"],
+                approved_at,
+                expires_at,
+            ),
+        )
+        database.execute(
+            "UPDATE outbound_operations SET state='approved',updated_at=? WHERE operation_id=?",
+            (approved_at, operation_id),
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return {
+        "operation_id": operation_id,
+        "approval_id": approval_id,
+        "state": "approved",
+        "expires_at": expires_at,
+    }
+
+
+def revoke_approval(
+    database: sqlite3.Connection,
+    operation_id: str,
+    principal_id: str,
+    *,
+    revoked_at: int | None = None,
+) -> dict[str, Any]:
+    """Revoke every active approval before an operation is claimed."""
+    revoked_at = now_epoch() if revoked_at is None else revoked_at
+    principal_id = validate_opaque(principal_id, "principal_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = _verified_operation(database, operation_id)
+        if row["created_by"] != principal_id or row["state"] == "claimed":
+            raise SocialStoreError("operation approval cannot be revoked")
+        if row["state"] in TERMINAL_STATES:
+            raise SocialStoreError("terminal operation approval cannot be revoked")
+        changed = database.execute(
+            """UPDATE outbound_approvals SET revoked_at=?
+                WHERE operation_id=? AND principal_id=? AND revoked_at IS NULL""",
+            (revoked_at, operation_id, principal_id),
+        ).rowcount
+        if changed == 0:
+            raise SocialStoreError("operation has no active approval")
+        database.execute(
+            "UPDATE outbound_operations SET state='draft',updated_at=? WHERE operation_id=?",
+            (revoked_at, operation_id),
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return {"operation_id": operation_id, "state": "draft", "revoked": changed}
+
+
+def cancel_operation(
+    database: sqlite3.Connection,
+    operation_id: str,
+    principal_id: str,
+    *,
+    cancelled_at: int | None = None,
+) -> dict[str, Any]:
+    """Cancel a draft or approved operation before any provider attempt."""
+    cancelled_at = now_epoch() if cancelled_at is None else cancelled_at
+    principal_id = validate_opaque(principal_id, "principal_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = _verified_operation(database, operation_id)
+        if row["created_by"] != principal_id or row["state"] not in (
+            "draft",
+            "approved",
+        ):
+            raise SocialStoreError("operation cannot be cancelled")
+        database.execute(
+            "UPDATE outbound_approvals SET revoked_at=? "
+            "WHERE operation_id=? AND revoked_at IS NULL",
+            (cancelled_at, operation_id),
+        )
+        database.execute(
+            """UPDATE outbound_operations
+                  SET state='cancelled',updated_at=? WHERE operation_id=?""",
+            (cancelled_at, operation_id),
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return {"operation_id": operation_id, "state": "cancelled"}
+
+
+def due_operation_ids(
+    database: sqlite3.Connection,
+    principal_id: str,
+    current_time: int,
+    limit: int,
+) -> list[str]:
+    """Return deterministic due IDs with a current exact-intent approval."""
+    if limit < 1 or limit > 100:
+        raise SocialStoreError("due limit must be between 1 and 100")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    rows = database.execute(
+        """SELECT DISTINCT o.* FROM outbound_operations o
+              JOIN outbound_approvals a ON a.operation_id=o.operation_id
+             WHERE o.state='approved' AND o.scheduled_at<=?
+               AND o.created_by=? AND a.principal_id=?
+               AND a.intent_sha256=o.intent_sha256
+               AND a.revoked_at IS NULL AND a.expires_at>?
+             ORDER BY o.scheduled_at,o.operation_id LIMIT ?""",
+        (current_time, principal_id, principal_id, current_time, limit),
+    ).fetchall()
+    return [str(_verify_operation_row(row)["operation_id"]) for row in rows]
+
+
+def claim_operation(
+    database: sqlite3.Connection,
+    operation_id: str,
+    principal_id: str,
+    executor_id: str,
+    current_time: int,
+    claim_seconds: int,
+) -> ClaimedOperation:
+    """Atomically claim one due operation and persist its sole running attempt."""
+    if claim_seconds < 1 or claim_seconds > 3600:
+        raise SocialStoreError("claim_seconds must be between 1 and 3600")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    executor_id = validate_opaque(executor_id, "executor_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = _verified_operation(database, operation_id)
+        if (
+            row["state"] != "approved"
+            or int(row["scheduled_at"]) > current_time
+            or row["created_by"] != principal_id
+        ):
+            raise SocialStoreError("operation is not due and approved")
+        approval = database.execute(
+            """SELECT approval_id FROM outbound_approvals
+                WHERE operation_id=? AND principal_id=? AND intent_sha256=?
+                  AND revoked_at IS NULL AND expires_at>?
+                ORDER BY approved_at DESC LIMIT 1""",
+            (operation_id, principal_id, row["intent_sha256"], current_time),
+        ).fetchone()
+        if approval is None:
+            raise SocialStoreError("operation approval is missing or expired")
+        claim_token = int(row["claim_token"]) + 1
+        attempt_id = _new_id("att")
+        changed = database.execute(
+            """UPDATE outbound_operations
+                  SET state='claimed',claim_token=?,claimed_by=?,claim_expires_at=?,
+                      last_attempt_id=?,updated_at=?
+                WHERE operation_id=? AND state='approved'""",
+            (
+                claim_token,
+                executor_id,
+                current_time + claim_seconds,
+                attempt_id,
+                current_time,
+                operation_id,
+            ),
+        ).rowcount
+        if changed != 1:
+            raise SocialStoreError("operation claim lost a concurrent race")
+        database.execute(
+            """INSERT INTO outbound_attempts(
+                attempt_id,operation_id,claim_token,executor_id,status,started_at)
+               VALUES(?,?,?,?,?,?)""",
+            (attempt_id, operation_id, claim_token, executor_id, "running", current_time),
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return ClaimedOperation(
+        operation_id,
+        str(row["action"]),
+        str(row["remote_account_id"]),
+        row["target_remote_id"],
+        row["payload"],
+        row["app_profile"],
+        row["username"],
+        claim_token,
+        attempt_id,
+    )
+
+
+def mark_provider_started(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    *,
+    started_at: int | None = None,
+) -> None:
+    """Durably mark the boundary after which failures are always ambiguous."""
+    started_at = now_epoch() if started_at is None else started_at
+    executor_id = validate_opaque(executor_id, "executor_id")
+    changed = database.execute(
+        """UPDATE outbound_attempts SET provider_started_at=?
+             WHERE attempt_id=? AND operation_id=? AND claim_token=?
+               AND executor_id=? AND status='running' AND provider_started_at IS NULL
+               AND EXISTS(
+                   SELECT 1 FROM outbound_operations o
+                   JOIN outbound_approvals a ON a.operation_id=o.operation_id
+                    WHERE o.operation_id=outbound_attempts.operation_id
+                      AND o.state='claimed' AND o.claim_token=outbound_attempts.claim_token
+                      AND o.claimed_by=? AND o.last_attempt_id=outbound_attempts.attempt_id
+                      AND o.claim_expires_at>? AND a.principal_id=o.created_by
+                      AND a.intent_sha256=o.intent_sha256 AND a.revoked_at IS NULL
+                      AND a.expires_at>?
+               )""",
+        (
+            started_at,
+            claimed.attempt_id,
+            claimed.operation_id,
+            claimed.claim_token,
+            executor_id,
+            executor_id,
+            started_at,
+            started_at,
+        ),
+    ).rowcount
+    if changed != 1:
+        raise SocialStoreError("outbound provider boundary is stale or already marked")
+
+
+def finalize_operation(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    status: str,
+    *,
+    provider_remote_id: str | None = None,
+    failure_class: str | None = None,
+    finished_at: int | None = None,
+) -> dict[str, Any]:
+    """Fence and record the provider attempt's privacy-safe terminal outcome."""
+    if status not in ("succeeded", "failed", "unknown"):
+        raise SocialStoreError("invalid outbound terminal status")
+    finished_at = now_epoch() if finished_at is None else finished_at
+    if provider_remote_id is not None:
+        provider_remote_id = validate_opaque(provider_remote_id, "provider_remote_id")
+    if failure_class is not None and failure_class not in FAILURE_CLASSES:
+        raise SocialStoreError("invalid outbound failure class")
+    if status == "succeeded" and (
+        provider_remote_id is None or failure_class is not None
+    ):
+        raise SocialStoreError("successful outbound receipt requires only a provider ID")
+    if status != "succeeded" and (
+        provider_remote_id is not None or failure_class is None
+    ):
+        raise SocialStoreError("unsuccessful outbound receipt requires only a failure class")
+    executor_id = validate_opaque(executor_id, "executor_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = database.execute(
+            "SELECT state,claim_token,claimed_by,last_attempt_id FROM outbound_operations "
+            "WHERE operation_id=?",
+            (claimed.operation_id,),
+        ).fetchone()
+        expected = (
+            "claimed",
+            claimed.claim_token,
+            executor_id,
+            claimed.attempt_id,
+        )
+        actual = tuple(row) if row is not None else ()
+        if actual != expected:
+            raise SocialStoreError("stale outbound executor cannot finalize")
+        attempt = database.execute(
+            """SELECT provider_started_at FROM outbound_attempts
+                 WHERE attempt_id=? AND operation_id=? AND claim_token=?
+                   AND executor_id=? AND status='running'""",
+            (
+                claimed.attempt_id,
+                claimed.operation_id,
+                claimed.claim_token,
+                executor_id,
+            ),
+        ).fetchone()
+        if attempt is None:
+            raise SocialStoreError("outbound attempt is no longer running")
+        provider_started = attempt["provider_started_at"] is not None
+        if provider_started and status == "failed":
+            raise SocialStoreError("started provider attempts cannot be retry-safe failures")
+        if not provider_started and status in ("succeeded", "unknown"):
+            raise SocialStoreError("provider outcome requires a started provider attempt")
+        changed = database.execute(
+            """UPDATE outbound_attempts
+                  SET status=?,finished_at=?,provider_remote_id=?,failure_class=?,diagnostics=?
+                WHERE attempt_id=? AND operation_id=? AND claim_token=? AND status='running'""",
+            (
+                status,
+                finished_at,
+                provider_remote_id,
+                failure_class,
+                canonical_json({"phase": "provider" if provider_started else "pre-provider"}),
+                claimed.attempt_id,
+                claimed.operation_id,
+                claimed.claim_token,
+            ),
+        ).rowcount
+        if changed != 1:
+            raise SocialStoreError("outbound attempt is no longer running")
+        database.execute(
+            """UPDATE outbound_operations
+                  SET state=?,claim_expires_at=NULL,updated_at=?
+                WHERE operation_id=?""",
+            (status, finished_at, claimed.operation_id),
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    result: dict[str, Any] = {
+        "operation_id": claimed.operation_id,
+        "attempt_id": claimed.attempt_id,
+        "state": status,
+    }
+    if provider_remote_id is not None:
+        result["provider_remote_id"] = provider_remote_id
+    if failure_class is not None:
+        result["failure_class"] = failure_class
+    return result
+
+
+def expire_claims(
+    database: sqlite3.Connection,
+    principal_id: str,
+    current_time: int,
+    limit: int,
+) -> list[str]:
+    """Fence expired executors and conservatively make their outcomes unknown."""
+    if limit < 1 or limit > 100:
+        raise SocialStoreError("claim expiry limit must be between 1 and 100")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        rows = database.execute(
+            """SELECT operation_id,last_attempt_id,claim_token
+                 FROM outbound_operations
+                WHERE state='claimed' AND created_by=? AND claim_expires_at<=?
+                ORDER BY claim_expires_at,operation_id LIMIT ?""",
+            (principal_id, current_time, limit),
+        ).fetchall()
+        expired: list[str] = []
+        for row in rows:
+            changed = database.execute(
+                """UPDATE outbound_attempts
+                      SET status='unknown',finished_at=?,failure_class='executor_lost',
+                          diagnostics=?
+                    WHERE attempt_id=? AND operation_id=? AND claim_token=?
+                      AND status='running'""",
+                (
+                    current_time,
+                    canonical_json({"phase": "executor"}),
+                    row["last_attempt_id"],
+                    row["operation_id"],
+                    row["claim_token"],
+                ),
+            ).rowcount
+            if changed != 1:
+                raise SocialStoreError("expired outbound attempt is inconsistent")
+            operation_changed = database.execute(
+                """UPDATE outbound_operations
+                      SET state='unknown',claim_expires_at=NULL,updated_at=?
+                    WHERE operation_id=? AND state='claimed' AND claim_token=?""",
+                (current_time, row["operation_id"], row["claim_token"]),
+            ).rowcount
+            if operation_changed != 1:
+                raise SocialStoreError("expired outbound operation is inconsistent")
+            expired.append(str(row["operation_id"]))
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return expired
+
+
+def reconcile_unknown(
+    database: sqlite3.Connection,
+    operation_id: str,
+    principal_id: str,
+    outcome: str,
+    provider_remote_id: str | None,
+    *,
+    reconciled_at: int | None = None,
+) -> dict[str, Any]:
+    """Resolve an ambiguous attempt without ever placing it back in the queue."""
+    if outcome not in ("succeeded", "not-sent"):
+        raise SocialStoreError("reconciliation outcome must be succeeded or not-sent")
+    reconciled_at = now_epoch() if reconciled_at is None else reconciled_at
+    principal_id = validate_opaque(principal_id, "principal_id")
+    state = "succeeded" if outcome == "succeeded" else "failed"
+    if state == "succeeded" and provider_remote_id is None:
+        raise SocialStoreError("successful reconciliation requires a provider ID")
+    if state == "failed" and provider_remote_id is not None:
+        raise SocialStoreError("not-sent reconciliation forbids a provider ID")
+    if provider_remote_id is not None:
+        provider_remote_id = validate_opaque(provider_remote_id, "provider_remote_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = _verified_operation(database, operation_id)
+        if row["state"] != "unknown" or row["created_by"] != principal_id:
+            raise SocialStoreError("only an owner unknown operation can be reconciled")
+        changed = database.execute(
+            """UPDATE outbound_attempts
+                  SET status=?,finished_at=?,provider_remote_id=?,failure_class=?,diagnostics=?
+                WHERE attempt_id=? AND operation_id=? AND claim_token=? AND status='unknown'""",
+            (
+                state,
+                reconciled_at,
+                provider_remote_id,
+                None if state == "succeeded" else "reconciled_not_sent",
+                canonical_json({"reconciled": outcome}),
+                row["last_attempt_id"],
+                operation_id,
+                row["claim_token"],
+            ),
+        ).rowcount
+        if changed != 1:
+            raise SocialStoreError("unknown outbound receipt is inconsistent")
+        database.execute(
+            "UPDATE outbound_operations SET state=?,updated_at=? WHERE operation_id=?",
+            (state, reconciled_at, operation_id),
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    result = {"operation_id": operation_id, "state": state}
+    if provider_remote_id is not None:
+        result["provider_remote_id"] = provider_remote_id
+    return result
+
+
+def list_operations(
+    database: sqlite3.Connection,
+    principal_id: str,
+    operation_id: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """List privacy-safe operation and receipt metadata for one owner."""
+    if limit < 1 or limit > 1000:
+        raise SocialStoreError("operation list limit must be between 1 and 1000")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    parameters: list[Any] = [principal_id]
+    condition = "o.created_by=?"
+    if operation_id is not None:
+        condition += " AND o.operation_id=?"
+        parameters.append(validate_opaque(operation_id, "operation_id"))
+    parameters.append(limit)
+    rows = database.execute(
+        f"""SELECT o.operation_id,o.action,o.state,o.scheduled_at,o.updated_at,
+                    a.attempt_id,a.status AS attempt_status,a.provider_remote_id,
+                    a.failure_class,a.started_at,a.finished_at
+               FROM outbound_operations o
+               LEFT JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
+              WHERE {condition}
+              ORDER BY o.created_at DESC,o.operation_id LIMIT ?""",  # nosec B608 -- fixed clauses
+        parameters,
+    ).fetchall()
+    return [dict(row) for row in rows]

--- a/.agents/scripts/_knowledge_social_outbound.py
+++ b/.agents/scripts/_knowledge_social_outbound.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Approval-bound outbound social operation state and receipts."""
+"""Approval-bound outbound social operation intent and authorization state."""
 
 from __future__ import annotations
 
@@ -29,6 +29,23 @@ FAILURE_CLASSES = (
 MAX_PAYLOAD_BYTES = 16 * 1024
 MAX_SELECTOR_BYTES = 256
 MAX_APPROVAL_SECONDS = 31 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class OperationIntent:
+    """Private immutable values from which one outbound intent is created."""
+
+    connection_id: str
+    remote_account_id: str
+    action: str
+    target_remote_id: str | None
+    payload: str | None
+    app_profile: str | None
+    username: str | None
+    scheduled_at: int
+    created_by: str
+    operation_id: str | None = None
+    created_at: int | None = None
 
 
 @dataclass(frozen=True)
@@ -62,13 +79,11 @@ def _digest(value: str) -> str:
 def _optional_selector(value: str | None, field: str) -> str | None:
     if value is None:
         return None
-    if (
-        not value
-        or value.startswith("-")
-        or "\x00" in value
-        or "\n" in value
-        or "\r" in value
-    ):
+    if not value:
+        raise SocialStoreError(f"{field} must be one non-empty line")
+    if value.startswith("-"):
+        raise SocialStoreError(f"{field} must not be option-shaped")
+    if any(marker in value for marker in ("\x00", "\n", "\r")):
         raise SocialStoreError(f"{field} must be one non-empty line")
     if len(value.encode("utf-8")) > MAX_SELECTOR_BYTES:
         raise SocialStoreError(f"{field} is too long")
@@ -129,38 +144,29 @@ def _verify_operation_row(row: sqlite3.Row) -> sqlite3.Row:
     return row
 
 
-def _operation_values(
-    operation_id: str,
-    connection_id: str,
-    remote_account_id: str,
-    action: str,
-    target_remote_id: str | None,
-    payload: str | None,
-    app_profile: str | None,
-    username: str | None,
-    scheduled_at: int,
-    created_by: str,
-) -> dict[str, Any]:
-    if action not in ACTIONS:
+def _operation_values(intent: OperationIntent, operation_id: str) -> dict[str, Any]:
+    if intent.action not in ACTIONS:
         raise SocialStoreError("unsupported outbound action")
-    if scheduled_at < 0:
+    if intent.scheduled_at < 0:
         raise SocialStoreError("scheduled_at must be a non-negative epoch")
-    payload = _validated_payload(action, payload)
+    payload = _validated_payload(intent.action, intent.payload)
     return {
         "operation_id": validate_opaque(operation_id, "operation_id"),
         "provider": "xapi",
-        "connection_id": validate_opaque(connection_id, "connection_id"),
+        "connection_id": validate_opaque(intent.connection_id, "connection_id"),
         "remote_account_id": validate_opaque(
-            remote_account_id, "remote_account_id"
+            intent.remote_account_id, "remote_account_id"
         ),
-        "action": action,
-        "target_remote_id": _validated_target(action, target_remote_id),
+        "action": intent.action,
+        "target_remote_id": _validated_target(
+            intent.action, intent.target_remote_id
+        ),
         "payload": payload,
         "payload_sha256": _digest(payload or ""),
-        "app_profile": _optional_selector(app_profile, "app_profile"),
-        "username": _optional_selector(username, "username"),
-        "scheduled_at": scheduled_at,
-        "created_by": validate_opaque(created_by, "created_by"),
+        "app_profile": _optional_selector(intent.app_profile, "app_profile"),
+        "username": _optional_selector(intent.username, "username"),
+        "scheduled_at": intent.scheduled_at,
+        "created_by": validate_opaque(intent.created_by, "created_by"),
     }
 
 
@@ -188,35 +194,12 @@ def _public_operation(row: sqlite3.Row) -> dict[str, Any]:
 
 
 def create_operation(
-    database: sqlite3.Connection,
-    *,
-    connection_id: str,
-    remote_account_id: str,
-    action: str,
-    target_remote_id: str | None,
-    payload: str | None,
-    app_profile: str | None,
-    username: str | None,
-    scheduled_at: int,
-    created_by: str,
-    operation_id: str | None = None,
-    created_at: int | None = None,
+    database: sqlite3.Connection, intent: OperationIntent
 ) -> dict[str, Any]:
     """Create or idempotently recover one immutable draft operation."""
-    operation_id = operation_id or _new_id("op")
-    created_at = now_epoch() if created_at is None else created_at
-    values = _operation_values(
-        operation_id,
-        connection_id,
-        remote_account_id,
-        action,
-        target_remote_id,
-        payload,
-        app_profile,
-        username,
-        scheduled_at,
-        created_by,
-    )
+    operation_id = intent.operation_id or _new_id("op")
+    created_at = now_epoch() if intent.created_at is None else intent.created_at
+    values = _operation_values(intent, operation_id)
     values["intent_sha256"] = _intent_sha256(values)
     database.execute("BEGIN IMMEDIATE")
     try:
@@ -262,9 +245,9 @@ def create_operation(
         raise
     return {
         "operation_id": operation_id,
-        "action": action,
+        "action": intent.action,
         "state": "draft",
-        "scheduled_at": scheduled_at,
+        "scheduled_at": intent.scheduled_at,
         "updated_at": created_at,
     }
 
@@ -284,7 +267,6 @@ def approve_operation(
     operation_id: str,
     principal_id: str,
     expires_at: int,
-    *,
     approved_at: int | None = None,
 ) -> dict[str, Any]:
     """Bind one authenticated owner approval to the exact stored intent."""
@@ -406,380 +388,3 @@ def cancel_operation(
             database.execute("ROLLBACK")
         raise
     return {"operation_id": operation_id, "state": "cancelled"}
-
-
-def due_operation_ids(
-    database: sqlite3.Connection,
-    principal_id: str,
-    current_time: int,
-    limit: int,
-) -> list[str]:
-    """Return deterministic due IDs with a current exact-intent approval."""
-    if limit < 1 or limit > 100:
-        raise SocialStoreError("due limit must be between 1 and 100")
-    principal_id = validate_opaque(principal_id, "principal_id")
-    rows = database.execute(
-        """SELECT DISTINCT o.* FROM outbound_operations o
-              JOIN outbound_approvals a ON a.operation_id=o.operation_id
-             WHERE o.state='approved' AND o.scheduled_at<=?
-               AND o.created_by=? AND a.principal_id=?
-               AND a.intent_sha256=o.intent_sha256
-               AND a.revoked_at IS NULL AND a.expires_at>?
-             ORDER BY o.scheduled_at,o.operation_id LIMIT ?""",
-        (current_time, principal_id, principal_id, current_time, limit),
-    ).fetchall()
-    return [str(_verify_operation_row(row)["operation_id"]) for row in rows]
-
-
-def claim_operation(
-    database: sqlite3.Connection,
-    operation_id: str,
-    principal_id: str,
-    executor_id: str,
-    current_time: int,
-    claim_seconds: int,
-) -> ClaimedOperation:
-    """Atomically claim one due operation and persist its sole running attempt."""
-    if claim_seconds < 1 or claim_seconds > 3600:
-        raise SocialStoreError("claim_seconds must be between 1 and 3600")
-    principal_id = validate_opaque(principal_id, "principal_id")
-    executor_id = validate_opaque(executor_id, "executor_id")
-    database.execute("BEGIN IMMEDIATE")
-    try:
-        row = _verified_operation(database, operation_id)
-        if (
-            row["state"] != "approved"
-            or int(row["scheduled_at"]) > current_time
-            or row["created_by"] != principal_id
-        ):
-            raise SocialStoreError("operation is not due and approved")
-        approval = database.execute(
-            """SELECT approval_id FROM outbound_approvals
-                WHERE operation_id=? AND principal_id=? AND intent_sha256=?
-                  AND revoked_at IS NULL AND expires_at>?
-                ORDER BY approved_at DESC LIMIT 1""",
-            (operation_id, principal_id, row["intent_sha256"], current_time),
-        ).fetchone()
-        if approval is None:
-            raise SocialStoreError("operation approval is missing or expired")
-        claim_token = int(row["claim_token"]) + 1
-        attempt_id = _new_id("att")
-        changed = database.execute(
-            """UPDATE outbound_operations
-                  SET state='claimed',claim_token=?,claimed_by=?,claim_expires_at=?,
-                      last_attempt_id=?,updated_at=?
-                WHERE operation_id=? AND state='approved'""",
-            (
-                claim_token,
-                executor_id,
-                current_time + claim_seconds,
-                attempt_id,
-                current_time,
-                operation_id,
-            ),
-        ).rowcount
-        if changed != 1:
-            raise SocialStoreError("operation claim lost a concurrent race")
-        database.execute(
-            """INSERT INTO outbound_attempts(
-                attempt_id,operation_id,claim_token,executor_id,status,started_at)
-               VALUES(?,?,?,?,?,?)""",
-            (attempt_id, operation_id, claim_token, executor_id, "running", current_time),
-        )
-        database.execute("COMMIT")
-    except Exception:
-        if database.in_transaction:
-            database.execute("ROLLBACK")
-        raise
-    return ClaimedOperation(
-        operation_id,
-        str(row["action"]),
-        str(row["remote_account_id"]),
-        row["target_remote_id"],
-        row["payload"],
-        row["app_profile"],
-        row["username"],
-        claim_token,
-        attempt_id,
-    )
-
-
-def mark_provider_started(
-    database: sqlite3.Connection,
-    claimed: ClaimedOperation,
-    executor_id: str,
-    *,
-    started_at: int | None = None,
-) -> None:
-    """Durably mark the boundary after which failures are always ambiguous."""
-    started_at = now_epoch() if started_at is None else started_at
-    executor_id = validate_opaque(executor_id, "executor_id")
-    changed = database.execute(
-        """UPDATE outbound_attempts SET provider_started_at=?
-             WHERE attempt_id=? AND operation_id=? AND claim_token=?
-               AND executor_id=? AND status='running' AND provider_started_at IS NULL
-               AND EXISTS(
-                   SELECT 1 FROM outbound_operations o
-                   JOIN outbound_approvals a ON a.operation_id=o.operation_id
-                    WHERE o.operation_id=outbound_attempts.operation_id
-                      AND o.state='claimed' AND o.claim_token=outbound_attempts.claim_token
-                      AND o.claimed_by=? AND o.last_attempt_id=outbound_attempts.attempt_id
-                      AND o.claim_expires_at>? AND a.principal_id=o.created_by
-                      AND a.intent_sha256=o.intent_sha256 AND a.revoked_at IS NULL
-                      AND a.expires_at>?
-               )""",
-        (
-            started_at,
-            claimed.attempt_id,
-            claimed.operation_id,
-            claimed.claim_token,
-            executor_id,
-            executor_id,
-            started_at,
-            started_at,
-        ),
-    ).rowcount
-    if changed != 1:
-        raise SocialStoreError("outbound provider boundary is stale or already marked")
-
-
-def finalize_operation(
-    database: sqlite3.Connection,
-    claimed: ClaimedOperation,
-    executor_id: str,
-    status: str,
-    *,
-    provider_remote_id: str | None = None,
-    failure_class: str | None = None,
-    finished_at: int | None = None,
-) -> dict[str, Any]:
-    """Fence and record the provider attempt's privacy-safe terminal outcome."""
-    if status not in ("succeeded", "failed", "unknown"):
-        raise SocialStoreError("invalid outbound terminal status")
-    finished_at = now_epoch() if finished_at is None else finished_at
-    if provider_remote_id is not None:
-        provider_remote_id = validate_opaque(provider_remote_id, "provider_remote_id")
-    if failure_class is not None and failure_class not in FAILURE_CLASSES:
-        raise SocialStoreError("invalid outbound failure class")
-    if status == "succeeded" and (
-        provider_remote_id is None or failure_class is not None
-    ):
-        raise SocialStoreError("successful outbound receipt requires only a provider ID")
-    if status != "succeeded" and (
-        provider_remote_id is not None or failure_class is None
-    ):
-        raise SocialStoreError("unsuccessful outbound receipt requires only a failure class")
-    executor_id = validate_opaque(executor_id, "executor_id")
-    database.execute("BEGIN IMMEDIATE")
-    try:
-        row = database.execute(
-            "SELECT state,claim_token,claimed_by,last_attempt_id FROM outbound_operations "
-            "WHERE operation_id=?",
-            (claimed.operation_id,),
-        ).fetchone()
-        expected = (
-            "claimed",
-            claimed.claim_token,
-            executor_id,
-            claimed.attempt_id,
-        )
-        actual = tuple(row) if row is not None else ()
-        if actual != expected:
-            raise SocialStoreError("stale outbound executor cannot finalize")
-        attempt = database.execute(
-            """SELECT provider_started_at FROM outbound_attempts
-                 WHERE attempt_id=? AND operation_id=? AND claim_token=?
-                   AND executor_id=? AND status='running'""",
-            (
-                claimed.attempt_id,
-                claimed.operation_id,
-                claimed.claim_token,
-                executor_id,
-            ),
-        ).fetchone()
-        if attempt is None:
-            raise SocialStoreError("outbound attempt is no longer running")
-        provider_started = attempt["provider_started_at"] is not None
-        if provider_started and status == "failed":
-            raise SocialStoreError("started provider attempts cannot be retry-safe failures")
-        if not provider_started and status in ("succeeded", "unknown"):
-            raise SocialStoreError("provider outcome requires a started provider attempt")
-        changed = database.execute(
-            """UPDATE outbound_attempts
-                  SET status=?,finished_at=?,provider_remote_id=?,failure_class=?,diagnostics=?
-                WHERE attempt_id=? AND operation_id=? AND claim_token=? AND status='running'""",
-            (
-                status,
-                finished_at,
-                provider_remote_id,
-                failure_class,
-                canonical_json({"phase": "provider" if provider_started else "pre-provider"}),
-                claimed.attempt_id,
-                claimed.operation_id,
-                claimed.claim_token,
-            ),
-        ).rowcount
-        if changed != 1:
-            raise SocialStoreError("outbound attempt is no longer running")
-        database.execute(
-            """UPDATE outbound_operations
-                  SET state=?,claim_expires_at=NULL,updated_at=?
-                WHERE operation_id=?""",
-            (status, finished_at, claimed.operation_id),
-        )
-        database.execute("COMMIT")
-    except Exception:
-        if database.in_transaction:
-            database.execute("ROLLBACK")
-        raise
-    result: dict[str, Any] = {
-        "operation_id": claimed.operation_id,
-        "attempt_id": claimed.attempt_id,
-        "state": status,
-    }
-    if provider_remote_id is not None:
-        result["provider_remote_id"] = provider_remote_id
-    if failure_class is not None:
-        result["failure_class"] = failure_class
-    return result
-
-
-def expire_claims(
-    database: sqlite3.Connection,
-    principal_id: str,
-    current_time: int,
-    limit: int,
-) -> list[str]:
-    """Fence expired executors and conservatively make their outcomes unknown."""
-    if limit < 1 or limit > 100:
-        raise SocialStoreError("claim expiry limit must be between 1 and 100")
-    principal_id = validate_opaque(principal_id, "principal_id")
-    database.execute("BEGIN IMMEDIATE")
-    try:
-        rows = database.execute(
-            """SELECT operation_id,last_attempt_id,claim_token
-                 FROM outbound_operations
-                WHERE state='claimed' AND created_by=? AND claim_expires_at<=?
-                ORDER BY claim_expires_at,operation_id LIMIT ?""",
-            (principal_id, current_time, limit),
-        ).fetchall()
-        expired: list[str] = []
-        for row in rows:
-            changed = database.execute(
-                """UPDATE outbound_attempts
-                      SET status='unknown',finished_at=?,failure_class='executor_lost',
-                          diagnostics=?
-                    WHERE attempt_id=? AND operation_id=? AND claim_token=?
-                      AND status='running'""",
-                (
-                    current_time,
-                    canonical_json({"phase": "executor"}),
-                    row["last_attempt_id"],
-                    row["operation_id"],
-                    row["claim_token"],
-                ),
-            ).rowcount
-            if changed != 1:
-                raise SocialStoreError("expired outbound attempt is inconsistent")
-            operation_changed = database.execute(
-                """UPDATE outbound_operations
-                      SET state='unknown',claim_expires_at=NULL,updated_at=?
-                    WHERE operation_id=? AND state='claimed' AND claim_token=?""",
-                (current_time, row["operation_id"], row["claim_token"]),
-            ).rowcount
-            if operation_changed != 1:
-                raise SocialStoreError("expired outbound operation is inconsistent")
-            expired.append(str(row["operation_id"]))
-        database.execute("COMMIT")
-    except Exception:
-        if database.in_transaction:
-            database.execute("ROLLBACK")
-        raise
-    return expired
-
-
-def reconcile_unknown(
-    database: sqlite3.Connection,
-    operation_id: str,
-    principal_id: str,
-    outcome: str,
-    provider_remote_id: str | None,
-    *,
-    reconciled_at: int | None = None,
-) -> dict[str, Any]:
-    """Resolve an ambiguous attempt without ever placing it back in the queue."""
-    if outcome not in ("succeeded", "not-sent"):
-        raise SocialStoreError("reconciliation outcome must be succeeded or not-sent")
-    reconciled_at = now_epoch() if reconciled_at is None else reconciled_at
-    principal_id = validate_opaque(principal_id, "principal_id")
-    state = "succeeded" if outcome == "succeeded" else "failed"
-    if state == "succeeded" and provider_remote_id is None:
-        raise SocialStoreError("successful reconciliation requires a provider ID")
-    if state == "failed" and provider_remote_id is not None:
-        raise SocialStoreError("not-sent reconciliation forbids a provider ID")
-    if provider_remote_id is not None:
-        provider_remote_id = validate_opaque(provider_remote_id, "provider_remote_id")
-    database.execute("BEGIN IMMEDIATE")
-    try:
-        row = _verified_operation(database, operation_id)
-        if row["state"] != "unknown" or row["created_by"] != principal_id:
-            raise SocialStoreError("only an owner unknown operation can be reconciled")
-        changed = database.execute(
-            """UPDATE outbound_attempts
-                  SET status=?,finished_at=?,provider_remote_id=?,failure_class=?,diagnostics=?
-                WHERE attempt_id=? AND operation_id=? AND claim_token=? AND status='unknown'""",
-            (
-                state,
-                reconciled_at,
-                provider_remote_id,
-                None if state == "succeeded" else "reconciled_not_sent",
-                canonical_json({"reconciled": outcome}),
-                row["last_attempt_id"],
-                operation_id,
-                row["claim_token"],
-            ),
-        ).rowcount
-        if changed != 1:
-            raise SocialStoreError("unknown outbound receipt is inconsistent")
-        database.execute(
-            "UPDATE outbound_operations SET state=?,updated_at=? WHERE operation_id=?",
-            (state, reconciled_at, operation_id),
-        )
-        database.execute("COMMIT")
-    except Exception:
-        if database.in_transaction:
-            database.execute("ROLLBACK")
-        raise
-    result = {"operation_id": operation_id, "state": state}
-    if provider_remote_id is not None:
-        result["provider_remote_id"] = provider_remote_id
-    return result
-
-
-def list_operations(
-    database: sqlite3.Connection,
-    principal_id: str,
-    operation_id: str | None,
-    limit: int,
-) -> list[dict[str, Any]]:
-    """List privacy-safe operation and receipt metadata for one owner."""
-    if limit < 1 or limit > 1000:
-        raise SocialStoreError("operation list limit must be between 1 and 1000")
-    principal_id = validate_opaque(principal_id, "principal_id")
-    parameters: list[Any] = [principal_id]
-    condition = "o.created_by=?"
-    if operation_id is not None:
-        condition += " AND o.operation_id=?"
-        parameters.append(validate_opaque(operation_id, "operation_id"))
-    parameters.append(limit)
-    rows = database.execute(
-        f"""SELECT o.operation_id,o.action,o.state,o.scheduled_at,o.updated_at,
-                    a.attempt_id,a.status AS attempt_status,a.provider_remote_id,
-                    a.failure_class,a.started_at,a.finished_at
-               FROM outbound_operations o
-               LEFT JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
-              WHERE {condition}
-              ORDER BY o.created_at DESC,o.operation_id LIMIT ?""",  # nosec B608 -- fixed clauses
-        parameters,
-    ).fetchall()
-    return [dict(row) for row in rows]

--- a/.agents/scripts/_knowledge_social_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_outbound_provider.py
@@ -45,7 +45,7 @@ def _write_args(claimed: ClaimedOperation) -> list[str]:
     raise ProviderAdapterError("approved outbound operation has an invalid action shape")
 
 
-def _provider_remote_id(claimed: ClaimedOperation, output: str) -> str:
+def _decoded_response(output: str) -> dict[str, object]:
     if len(output.encode("utf-8")) > MAX_PROVIDER_OUTPUT_BYTES:
         raise ProviderAdapterError("xurl write response exceeds the safety limit")
     try:
@@ -58,6 +58,12 @@ def _provider_remote_id(claimed: ClaimedOperation, output: str) -> str:
     status = response_status(response)
     if status < 200 or status >= 300:
         raise ProviderAdapterError("xurl write response reports a provider failure")
+    return response
+
+
+def _receipt_remote_id(
+    claimed: ClaimedOperation, response: dict[str, object]
+) -> str:
     if claimed.action in ("like", "bookmark"):
         if claimed.target_remote_id is None:
             raise ProviderAdapterError("engagement receipt has no target ID")
@@ -67,6 +73,10 @@ def _provider_remote_id(claimed: ClaimedOperation, output: str) -> str:
     if not isinstance(remote_id, str):
         raise ProviderAdapterError("xurl write response has no stable post ID")
     return validate_opaque(remote_id, "provider_remote_id")
+
+
+def _provider_remote_id(claimed: ClaimedOperation, output: str) -> str:
+    return _receipt_remote_id(claimed, _decoded_response(output))
 
 
 def invoke_provider(

--- a/.agents/scripts/_knowledge_social_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_outbound_provider.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fixed-argv X provider adapter for approved outbound operations."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from _knowledge_social_outbound import ClaimedOperation
+from _knowledge_social_x import XAdapterError, response_status
+from knowledge_social_import import reject_credentials
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+WRITE_TIMEOUT_SECONDS = 120
+MAX_PROVIDER_OUTPUT_BYTES = 1024 * 1024
+
+
+class ProviderAdapterError(RuntimeError):
+    """Raised when an approved operation cannot be mapped to safe provider argv."""
+
+
+def _profile_args(claimed: ClaimedOperation) -> list[str]:
+    arguments: list[str] = []
+    if claimed.app_profile:
+        arguments.extend(("--app", claimed.app_profile))
+    if claimed.username:
+        arguments.extend(("--username", claimed.username))
+    return arguments
+
+
+def _write_args(claimed: ClaimedOperation) -> list[str]:
+    if claimed.action == "post" and claimed.payload is not None:
+        return ["post", claimed.payload]
+    if (
+        claimed.action == "reply"
+        and claimed.target_remote_id is not None
+        and claimed.payload is not None
+    ):
+        return ["reply", claimed.target_remote_id, claimed.payload]
+    if claimed.action in ("like", "bookmark") and claimed.target_remote_id:
+        return [claimed.action, claimed.target_remote_id]
+    raise ProviderAdapterError("approved outbound operation has an invalid action shape")
+
+
+def _provider_remote_id(claimed: ClaimedOperation, output: str) -> str:
+    if len(output.encode("utf-8")) > MAX_PROVIDER_OUTPUT_BYTES:
+        raise ProviderAdapterError("xurl write response exceeds the safety limit")
+    try:
+        response = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise ProviderAdapterError("xurl write response is not valid JSON") from error
+    if not isinstance(response, dict):
+        raise ProviderAdapterError("xurl write response root must be an object")
+    reject_credentials(response)
+    status = response_status(response)
+    if status < 200 or status >= 300:
+        raise ProviderAdapterError("xurl write response reports a provider failure")
+    if claimed.action in ("like", "bookmark"):
+        if claimed.target_remote_id is None:
+            raise ProviderAdapterError("engagement receipt has no target ID")
+        return claimed.target_remote_id
+    data = response.get("data", response)
+    remote_id = data.get("id") if isinstance(data, dict) else None
+    if not isinstance(remote_id, str):
+        raise ProviderAdapterError("xurl write response has no stable post ID")
+    return validate_opaque(remote_id, "provider_remote_id")
+
+
+def invoke_provider(
+    helper: Path, claimed: ClaimedOperation
+) -> tuple[str | None, str | None]:
+    """Invoke one fixed helper action and classify only privacy-safe outcomes."""
+    write_args = _write_args(claimed)
+    command = [
+        str(helper),
+        write_args[0],
+        *_profile_args(claimed),
+        "--confirm-write",
+        "--",
+        *write_args[1:],
+    ]
+    try:
+        completed = subprocess.run(  # nosec B603 -- fixed helper and allowlisted action argv
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=WRITE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None, "provider_unavailable"
+    if completed.returncode != 0:
+        return None, "provider_unavailable"
+    try:
+        return _provider_remote_id(claimed, completed.stdout), None
+    except (ProviderAdapterError, SocialStoreError, UnicodeError, XAdapterError):
+        return None, "validation"

--- a/.agents/scripts/_knowledge_social_outbound_reconciliation.py
+++ b/.agents/scripts/_knowledge_social_outbound_reconciliation.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Outbound reconciliation decisions and privacy-safe operation history."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_outbound import _verified_operation, now_epoch
+from knowledge_social_import import canonical_json
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+
+@dataclass(frozen=True)
+class ReconciliationRequest:
+    """Owner decision that resolves one ambiguous provider attempt."""
+
+    operation_id: str
+    principal_id: str
+    outcome: str
+    provider_remote_id: str | None = None
+    reconciled_at: int | None = None
+
+
+def reconcile_unknown(
+    database: sqlite3.Connection, request: ReconciliationRequest
+) -> dict[str, Any]:
+    """Resolve an ambiguous attempt without ever placing it back in the queue."""
+    if request.outcome not in ("succeeded", "not-sent"):
+        raise SocialStoreError("reconciliation outcome must be succeeded or not-sent")
+    reconciled_at = (
+        now_epoch() if request.reconciled_at is None else request.reconciled_at
+    )
+    principal_id = validate_opaque(request.principal_id, "principal_id")
+    state = "succeeded" if request.outcome == "succeeded" else "failed"
+    if state == "succeeded" and request.provider_remote_id is None:
+        raise SocialStoreError("successful reconciliation requires a provider ID")
+    if state == "failed" and request.provider_remote_id is not None:
+        raise SocialStoreError("not-sent reconciliation forbids a provider ID")
+    provider_remote_id = request.provider_remote_id
+    if provider_remote_id is not None:
+        provider_remote_id = validate_opaque(provider_remote_id, "provider_remote_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = _verified_operation(database, request.operation_id)
+        if row["state"] != "unknown" or row["created_by"] != principal_id:
+            raise SocialStoreError("only an owner unknown operation can be reconciled")
+        changed = database.execute(
+            """UPDATE outbound_attempts
+                  SET status=?,finished_at=?,provider_remote_id=?,failure_class=?,diagnostics=?
+                WHERE attempt_id=? AND operation_id=? AND claim_token=? AND status='unknown'""",
+            (
+                state,
+                reconciled_at,
+                provider_remote_id,
+                None if state == "succeeded" else "reconciled_not_sent",
+                canonical_json({"reconciled": request.outcome}),
+                row["last_attempt_id"],
+                request.operation_id,
+                row["claim_token"],
+            ),
+        ).rowcount
+        if changed != 1:
+            raise SocialStoreError("unknown outbound receipt is inconsistent")
+        database.execute(
+            "UPDATE outbound_operations SET state=?,updated_at=? WHERE operation_id=?",
+            (state, reconciled_at, request.operation_id),
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    result = {"operation_id": request.operation_id, "state": state}
+    if provider_remote_id is not None:
+        result["provider_remote_id"] = provider_remote_id
+    return result
+
+
+def list_operations(
+    database: sqlite3.Connection,
+    principal_id: str,
+    operation_id: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """List privacy-safe operation and receipt metadata for one owner."""
+    if limit < 1 or limit > 1000:
+        raise SocialStoreError("operation list limit must be between 1 and 1000")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    parameters: list[Any] = [principal_id]
+    condition = "o.created_by=?"
+    if operation_id is not None:
+        condition += " AND o.operation_id=?"
+        parameters.append(validate_opaque(operation_id, "operation_id"))
+    parameters.append(limit)
+    rows = database.execute(
+        f"""SELECT o.operation_id,o.action,o.state,o.scheduled_at,o.updated_at,
+                    a.attempt_id,a.status AS attempt_status,a.provider_remote_id,
+                    a.failure_class,a.started_at,a.finished_at
+               FROM outbound_operations o
+               LEFT JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
+              WHERE {condition}
+              ORDER BY o.created_at DESC,o.operation_id LIMIT ?""",  # nosec B608 -- fixed clauses
+        parameters,
+    ).fetchall()
+    return [dict(row) for row in rows]

--- a/.agents/scripts/_knowledge_social_outbound_reconciliation.py
+++ b/.agents/scripts/_knowledge_social_outbound_reconciliation.py
@@ -13,6 +13,21 @@ from _knowledge_social_outbound import _verified_operation, now_epoch
 from knowledge_social_import import canonical_json
 from knowledge_social_store import SocialStoreError, validate_opaque
 
+LIST_OPERATIONS_SQL = """SELECT o.operation_id,o.action,o.state,o.scheduled_at,o.updated_at,
+                    a.attempt_id,a.status AS attempt_status,a.provider_remote_id,
+                    a.failure_class,a.started_at,a.finished_at
+               FROM outbound_operations o
+               LEFT JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
+              WHERE o.created_by=?
+              ORDER BY o.created_at DESC,o.operation_id LIMIT ?"""
+LIST_OPERATION_SQL = """SELECT o.operation_id,o.action,o.state,o.scheduled_at,o.updated_at,
+                    a.attempt_id,a.status AS attempt_status,a.provider_remote_id,
+                    a.failure_class,a.started_at,a.finished_at
+               FROM outbound_operations o
+               LEFT JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
+              WHERE o.created_by=? AND o.operation_id=?
+              ORDER BY o.created_at DESC,o.operation_id LIMIT ?"""
+
 
 @dataclass(frozen=True)
 class ReconciliationRequest:
@@ -25,10 +40,21 @@ class ReconciliationRequest:
     reconciled_at: int | None = None
 
 
-def reconcile_unknown(
-    database: sqlite3.Connection, request: ReconciliationRequest
-) -> dict[str, Any]:
-    """Resolve an ambiguous attempt without ever placing it back in the queue."""
+@dataclass(frozen=True)
+class ValidatedReconciliation:
+    """Normalized owner decision ready for one fenced transaction."""
+
+    operation_id: str
+    principal_id: str
+    outcome: str
+    state: str
+    provider_remote_id: str | None
+    reconciled_at: int
+
+
+def _validated_reconciliation(
+    request: ReconciliationRequest,
+) -> ValidatedReconciliation:
     if request.outcome not in ("succeeded", "not-sent"):
         raise SocialStoreError("reconciliation outcome must be succeeded or not-sent")
     reconciled_at = (
@@ -43,23 +69,36 @@ def reconcile_unknown(
     provider_remote_id = request.provider_remote_id
     if provider_remote_id is not None:
         provider_remote_id = validate_opaque(provider_remote_id, "provider_remote_id")
+    return ValidatedReconciliation(
+        validate_opaque(request.operation_id, "operation_id"),
+        principal_id,
+        request.outcome,
+        state,
+        provider_remote_id,
+        reconciled_at,
+    )
+
+
+def _persist_reconciliation(
+    database: sqlite3.Connection, decision: ValidatedReconciliation
+) -> None:
     database.execute("BEGIN IMMEDIATE")
     try:
-        row = _verified_operation(database, request.operation_id)
-        if row["state"] != "unknown" or row["created_by"] != principal_id:
+        row = _verified_operation(database, decision.operation_id)
+        if row["state"] != "unknown" or row["created_by"] != decision.principal_id:
             raise SocialStoreError("only an owner unknown operation can be reconciled")
         changed = database.execute(
             """UPDATE outbound_attempts
                   SET status=?,finished_at=?,provider_remote_id=?,failure_class=?,diagnostics=?
                 WHERE attempt_id=? AND operation_id=? AND claim_token=? AND status='unknown'""",
             (
-                state,
-                reconciled_at,
-                provider_remote_id,
-                None if state == "succeeded" else "reconciled_not_sent",
-                canonical_json({"reconciled": request.outcome}),
+                decision.state,
+                decision.reconciled_at,
+                decision.provider_remote_id,
+                None if decision.state == "succeeded" else "reconciled_not_sent",
+                canonical_json({"reconciled": decision.outcome}),
                 row["last_attempt_id"],
-                request.operation_id,
+                decision.operation_id,
                 row["claim_token"],
             ),
         ).rowcount
@@ -67,16 +106,24 @@ def reconcile_unknown(
             raise SocialStoreError("unknown outbound receipt is inconsistent")
         database.execute(
             "UPDATE outbound_operations SET state=?,updated_at=? WHERE operation_id=?",
-            (state, reconciled_at, request.operation_id),
+            (decision.state, decision.reconciled_at, decision.operation_id),
         )
         database.execute("COMMIT")
     except Exception:
         if database.in_transaction:
             database.execute("ROLLBACK")
         raise
-    result = {"operation_id": request.operation_id, "state": state}
-    if provider_remote_id is not None:
-        result["provider_remote_id"] = provider_remote_id
+
+
+def reconcile_unknown(
+    database: sqlite3.Connection, request: ReconciliationRequest
+) -> dict[str, Any]:
+    """Resolve an ambiguous attempt without ever placing it back in the queue."""
+    decision = _validated_reconciliation(request)
+    _persist_reconciliation(database, decision)
+    result = {"operation_id": decision.operation_id, "state": decision.state}
+    if decision.provider_remote_id is not None:
+        result["provider_remote_id"] = decision.provider_remote_id
     return result
 
 
@@ -90,20 +137,13 @@ def list_operations(
     if limit < 1 or limit > 1000:
         raise SocialStoreError("operation list limit must be between 1 and 1000")
     principal_id = validate_opaque(principal_id, "principal_id")
-    parameters: list[Any] = [principal_id]
-    condition = "o.created_by=?"
-    if operation_id is not None:
-        condition += " AND o.operation_id=?"
-        parameters.append(validate_opaque(operation_id, "operation_id"))
-    parameters.append(limit)
-    rows = database.execute(
-        f"""SELECT o.operation_id,o.action,o.state,o.scheduled_at,o.updated_at,
-                    a.attempt_id,a.status AS attempt_status,a.provider_remote_id,
-                    a.failure_class,a.started_at,a.finished_at
-               FROM outbound_operations o
-               LEFT JOIN outbound_attempts a ON a.attempt_id=o.last_attempt_id
-              WHERE {condition}
-              ORDER BY o.created_at DESC,o.operation_id LIMIT ?""",  # nosec B608 -- fixed clauses
-        parameters,
-    ).fetchall()
+    if operation_id is None:
+        rows = database.execute(
+            LIST_OPERATIONS_SQL, (principal_id, limit)
+        ).fetchall()
+    else:
+        rows = database.execute(
+            LIST_OPERATION_SQL,
+            (principal_id, validate_opaque(operation_id, "operation_id"), limit),
+        ).fetchall()
     return [dict(row) for row in rows]

--- a/.agents/scripts/_knowledge_social_outbound_runtime.py
+++ b/.agents/scripts/_knowledge_social_outbound_runtime.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fenced outbound claim, attempt, receipt, and lease state."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_outbound import (
+    FAILURE_CLASSES,
+    ClaimedOperation,
+    _new_id,
+    _verified_operation,
+    now_epoch,
+)
+from knowledge_social_import import canonical_json
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+
+@dataclass(frozen=True)
+class ClaimRequest:
+    """Owner, executor, and lease values for one atomic operation claim."""
+
+    operation_id: str
+    principal_id: str
+    executor_id: str
+    current_time: int
+    claim_seconds: int
+
+
+@dataclass(frozen=True)
+class AttemptOutcome:
+    """Privacy-safe terminal result for one fenced provider attempt."""
+
+    status: str
+    provider_remote_id: str | None = None
+    failure_class: str | None = None
+    finished_at: int | None = None
+
+
+def due_operation_ids(
+    database: sqlite3.Connection,
+    principal_id: str,
+    current_time: int,
+    limit: int,
+) -> list[str]:
+    """Return deterministic due IDs with a current exact-intent approval."""
+    if limit < 1 or limit > 100:
+        raise SocialStoreError("due limit must be between 1 and 100")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    rows = database.execute(
+        """SELECT DISTINCT o.* FROM outbound_operations o
+              JOIN outbound_approvals a ON a.operation_id=o.operation_id
+             WHERE o.state='approved' AND o.scheduled_at<=?
+               AND o.created_by=? AND a.principal_id=?
+               AND a.intent_sha256=o.intent_sha256
+               AND a.revoked_at IS NULL AND a.expires_at>?
+             ORDER BY o.scheduled_at,o.operation_id LIMIT ?""",
+        (current_time, principal_id, principal_id, current_time, limit),
+    ).fetchall()
+    return [str(_verified_operation(database, row["operation_id"])["operation_id"]) for row in rows]
+
+
+def claim_operation(
+    database: sqlite3.Connection, request: ClaimRequest
+) -> ClaimedOperation:
+    """Atomically claim one due operation and persist its sole running attempt."""
+    if request.claim_seconds < 1 or request.claim_seconds > 3600:
+        raise SocialStoreError("claim_seconds must be between 1 and 3600")
+    principal_id = validate_opaque(request.principal_id, "principal_id")
+    executor_id = validate_opaque(request.executor_id, "executor_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        row = _verified_operation(database, request.operation_id)
+        if (
+            row["state"] != "approved"
+            or int(row["scheduled_at"]) > request.current_time
+            or row["created_by"] != principal_id
+        ):
+            raise SocialStoreError("operation is not due and approved")
+        approval = database.execute(
+            """SELECT approval_id FROM outbound_approvals
+                WHERE operation_id=? AND principal_id=? AND intent_sha256=?
+                  AND revoked_at IS NULL AND expires_at>?
+                ORDER BY approved_at DESC LIMIT 1""",
+            (
+                request.operation_id,
+                principal_id,
+                row["intent_sha256"],
+                request.current_time,
+            ),
+        ).fetchone()
+        if approval is None:
+            raise SocialStoreError("operation approval is missing or expired")
+        claim_token = int(row["claim_token"]) + 1
+        attempt_id = _new_id("att")
+        changed = database.execute(
+            """UPDATE outbound_operations
+                  SET state='claimed',claim_token=?,claimed_by=?,claim_expires_at=?,
+                      last_attempt_id=?,updated_at=?
+                WHERE operation_id=? AND state='approved'""",
+            (
+                claim_token,
+                executor_id,
+                request.current_time + request.claim_seconds,
+                attempt_id,
+                request.current_time,
+                request.operation_id,
+            ),
+        ).rowcount
+        if changed != 1:
+            raise SocialStoreError("operation claim lost a concurrent race")
+        database.execute(
+            """INSERT INTO outbound_attempts(
+                attempt_id,operation_id,claim_token,executor_id,status,started_at)
+               VALUES(?,?,?,?,?,?)""",
+            (
+                attempt_id,
+                request.operation_id,
+                claim_token,
+                executor_id,
+                "running",
+                request.current_time,
+            ),
+        )
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return ClaimedOperation(
+        request.operation_id,
+        str(row["action"]),
+        str(row["remote_account_id"]),
+        row["target_remote_id"],
+        row["payload"],
+        row["app_profile"],
+        row["username"],
+        claim_token,
+        attempt_id,
+    )
+
+
+def mark_provider_started(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    *,
+    started_at: int | None = None,
+) -> None:
+    """Durably mark the boundary after which failures are always ambiguous."""
+    started_at = now_epoch() if started_at is None else started_at
+    executor_id = validate_opaque(executor_id, "executor_id")
+    changed = database.execute(
+        """UPDATE outbound_attempts SET provider_started_at=?
+             WHERE attempt_id=? AND operation_id=? AND claim_token=?
+               AND executor_id=? AND status='running' AND provider_started_at IS NULL
+               AND EXISTS(
+                   SELECT 1 FROM outbound_operations o
+                   JOIN outbound_approvals a ON a.operation_id=o.operation_id
+                    WHERE o.operation_id=outbound_attempts.operation_id
+                      AND o.state='claimed' AND o.claim_token=outbound_attempts.claim_token
+                      AND o.claimed_by=? AND o.last_attempt_id=outbound_attempts.attempt_id
+                      AND o.claim_expires_at>? AND a.principal_id=o.created_by
+                      AND a.intent_sha256=o.intent_sha256 AND a.revoked_at IS NULL
+                      AND a.expires_at>?
+               )""",
+        (
+            started_at,
+            claimed.attempt_id,
+            claimed.operation_id,
+            claimed.claim_token,
+            executor_id,
+            executor_id,
+            started_at,
+            started_at,
+        ),
+    ).rowcount
+    if changed != 1:
+        raise SocialStoreError("outbound provider boundary is stale or already marked")
+
+
+def _validated_outcome(outcome: AttemptOutcome) -> AttemptOutcome:
+    if outcome.status not in ("succeeded", "failed", "unknown"):
+        raise SocialStoreError("invalid outbound terminal status")
+    finished_at = now_epoch() if outcome.finished_at is None else outcome.finished_at
+    provider_remote_id = outcome.provider_remote_id
+    if provider_remote_id is not None:
+        provider_remote_id = validate_opaque(provider_remote_id, "provider_remote_id")
+    if outcome.failure_class is not None and outcome.failure_class not in FAILURE_CLASSES:
+        raise SocialStoreError("invalid outbound failure class")
+    if outcome.status == "succeeded":
+        if provider_remote_id is None or outcome.failure_class is not None:
+            raise SocialStoreError("successful outbound receipt requires only a provider ID")
+    elif provider_remote_id is not None or outcome.failure_class is None:
+        raise SocialStoreError("unsuccessful outbound receipt requires only a failure class")
+    return AttemptOutcome(
+        outcome.status,
+        provider_remote_id,
+        outcome.failure_class,
+        finished_at,
+    )
+
+
+def _provider_started(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+) -> bool:
+    row = database.execute(
+        "SELECT state,claim_token,claimed_by,last_attempt_id FROM outbound_operations "
+        "WHERE operation_id=?",
+        (claimed.operation_id,),
+    ).fetchone()
+    expected = ("claimed", claimed.claim_token, executor_id, claimed.attempt_id)
+    actual = tuple(row) if row is not None else ()
+    if actual != expected:
+        raise SocialStoreError("stale outbound executor cannot finalize")
+    attempt = database.execute(
+        """SELECT provider_started_at FROM outbound_attempts
+             WHERE attempt_id=? AND operation_id=? AND claim_token=?
+               AND executor_id=? AND status='running'""",
+        (
+            claimed.attempt_id,
+            claimed.operation_id,
+            claimed.claim_token,
+            executor_id,
+        ),
+    ).fetchone()
+    if attempt is None:
+        raise SocialStoreError("outbound attempt is no longer running")
+    return attempt["provider_started_at"] is not None
+
+
+def _assert_outcome_boundary(provider_started: bool, outcome: AttemptOutcome) -> None:
+    if provider_started and outcome.status == "failed":
+        raise SocialStoreError("started provider attempts cannot be retry-safe failures")
+    if not provider_started and outcome.status in ("succeeded", "unknown"):
+        raise SocialStoreError("provider outcome requires a started provider attempt")
+
+
+def _persist_outcome(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    outcome: AttemptOutcome,
+    provider_started: bool,
+) -> None:
+    changed = database.execute(
+        """UPDATE outbound_attempts
+              SET status=?,finished_at=?,provider_remote_id=?,failure_class=?,diagnostics=?
+            WHERE attempt_id=? AND operation_id=? AND claim_token=?
+              AND executor_id=? AND status='running'""",
+        (
+            outcome.status,
+            outcome.finished_at,
+            outcome.provider_remote_id,
+            outcome.failure_class,
+            canonical_json({"phase": "provider" if provider_started else "pre-provider"}),
+            claimed.attempt_id,
+            claimed.operation_id,
+            claimed.claim_token,
+            executor_id,
+        ),
+    ).rowcount
+    if changed != 1:
+        raise SocialStoreError("outbound attempt is no longer running")
+    database.execute(
+        """UPDATE outbound_operations
+              SET state=?,claim_expires_at=NULL,updated_at=?
+            WHERE operation_id=?""",
+        (outcome.status, outcome.finished_at, claimed.operation_id),
+    )
+
+
+def _outcome_receipt(
+    claimed: ClaimedOperation, outcome: AttemptOutcome
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "operation_id": claimed.operation_id,
+        "attempt_id": claimed.attempt_id,
+        "state": outcome.status,
+    }
+    if outcome.provider_remote_id is not None:
+        result["provider_remote_id"] = outcome.provider_remote_id
+    if outcome.failure_class is not None:
+        result["failure_class"] = outcome.failure_class
+    return result
+
+
+def finalize_operation(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    outcome: AttemptOutcome,
+) -> dict[str, Any]:
+    """Fence and record the provider attempt's privacy-safe terminal outcome."""
+    outcome = _validated_outcome(outcome)
+    executor_id = validate_opaque(executor_id, "executor_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        provider_started = _provider_started(database, claimed, executor_id)
+        _assert_outcome_boundary(provider_started, outcome)
+        _persist_outcome(database, claimed, executor_id, outcome, provider_started)
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return _outcome_receipt(claimed, outcome)
+
+
+def expire_claims(
+    database: sqlite3.Connection,
+    principal_id: str,
+    current_time: int,
+    limit: int,
+) -> list[str]:
+    """Fence expired executors and conservatively make their outcomes unknown."""
+    if limit < 1 or limit > 100:
+        raise SocialStoreError("claim expiry limit must be between 1 and 100")
+    principal_id = validate_opaque(principal_id, "principal_id")
+    database.execute("BEGIN IMMEDIATE")
+    try:
+        rows = database.execute(
+            """SELECT operation_id,last_attempt_id,claim_token
+                 FROM outbound_operations
+                WHERE state='claimed' AND created_by=? AND claim_expires_at<=?
+                ORDER BY claim_expires_at,operation_id LIMIT ?""",
+            (principal_id, current_time, limit),
+        ).fetchall()
+        expired: list[str] = []
+        for row in rows:
+            changed = database.execute(
+                """UPDATE outbound_attempts
+                      SET status='unknown',finished_at=?,failure_class='executor_lost',
+                          diagnostics=?
+                    WHERE attempt_id=? AND operation_id=? AND claim_token=?
+                      AND status='running'""",
+                (
+                    current_time,
+                    canonical_json({"phase": "executor"}),
+                    row["last_attempt_id"],
+                    row["operation_id"],
+                    row["claim_token"],
+                ),
+            ).rowcount
+            if changed != 1:
+                raise SocialStoreError("expired outbound attempt is inconsistent")
+            operation_changed = database.execute(
+                """UPDATE outbound_operations
+                      SET state='unknown',claim_expires_at=NULL,updated_at=?
+                    WHERE operation_id=? AND state='claimed' AND claim_token=?""",
+                (current_time, row["operation_id"], row["claim_token"]),
+            ).rowcount
+            if operation_changed != 1:
+                raise SocialStoreError("expired outbound operation is inconsistent")
+            expired.append(str(row["operation_id"]))
+        database.execute("COMMIT")
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        raise
+    return expired
+

--- a/.agents/scripts/_knowledge_social_outbound_runtime.py
+++ b/.agents/scripts/_knowledge_social_outbound_runtime.py
@@ -19,6 +19,14 @@ from _knowledge_social_outbound import (
 from knowledge_social_import import canonical_json
 from knowledge_social_store import SocialStoreError, validate_opaque
 
+CLAIM_OPERATION_SQL = """UPDATE outbound_operations
+                  SET state='claimed',claim_token=?,claimed_by=?,claim_expires_at=?,
+                      last_attempt_id=?,updated_at=?
+                WHERE operation_id=? AND state='approved'"""
+INSERT_ATTEMPT_SQL = """INSERT INTO outbound_attempts(
+                attempt_id,operation_id,claim_token,executor_id,status,started_at)
+               VALUES(?,?,?,?,?,?)"""
+
 
 @dataclass(frozen=True)
 class ClaimRequest:
@@ -64,6 +72,68 @@ def due_operation_ids(
     return [str(_verified_operation(database, row["operation_id"])["operation_id"]) for row in rows]
 
 
+def _claimable_operation(
+    database: sqlite3.Connection, request: ClaimRequest, principal_id: str
+) -> sqlite3.Row:
+    row = _verified_operation(database, request.operation_id)
+    if (
+        row["state"] != "approved"
+        or int(row["scheduled_at"]) > request.current_time
+        or row["created_by"] != principal_id
+    ):
+        raise SocialStoreError("operation is not due and approved")
+    approval = database.execute(
+        """SELECT approval_id FROM outbound_approvals
+            WHERE operation_id=? AND principal_id=? AND intent_sha256=?
+              AND revoked_at IS NULL AND expires_at>?
+            ORDER BY approved_at DESC LIMIT 1""",
+        (
+            request.operation_id,
+            principal_id,
+            row["intent_sha256"],
+            request.current_time,
+        ),
+    ).fetchone()
+    if approval is None:
+        raise SocialStoreError("operation approval is missing or expired")
+    return row
+
+
+def _persist_claim(
+    database: sqlite3.Connection,
+    request: ClaimRequest,
+    row: sqlite3.Row,
+    executor_id: str,
+) -> tuple[int, str]:
+    claim_token = int(row["claim_token"]) + 1
+    attempt_id = _new_id("att")
+    changed = database.execute(
+        CLAIM_OPERATION_SQL,
+        (
+            claim_token,
+            executor_id,
+            request.current_time + request.claim_seconds,
+            attempt_id,
+            request.current_time,
+            request.operation_id,
+        ),
+    ).rowcount
+    if changed != 1:
+        raise SocialStoreError("operation claim lost a concurrent race")
+    database.execute(
+        INSERT_ATTEMPT_SQL,
+        (
+            attempt_id,
+            request.operation_id,
+            claim_token,
+            executor_id,
+            "running",
+            request.current_time,
+        ),
+    )
+    return claim_token, attempt_id
+
+
 def claim_operation(
     database: sqlite3.Connection, request: ClaimRequest
 ) -> ClaimedOperation:
@@ -74,57 +144,9 @@ def claim_operation(
     executor_id = validate_opaque(request.executor_id, "executor_id")
     database.execute("BEGIN IMMEDIATE")
     try:
-        row = _verified_operation(database, request.operation_id)
-        if (
-            row["state"] != "approved"
-            or int(row["scheduled_at"]) > request.current_time
-            or row["created_by"] != principal_id
-        ):
-            raise SocialStoreError("operation is not due and approved")
-        approval = database.execute(
-            """SELECT approval_id FROM outbound_approvals
-                WHERE operation_id=? AND principal_id=? AND intent_sha256=?
-                  AND revoked_at IS NULL AND expires_at>?
-                ORDER BY approved_at DESC LIMIT 1""",
-            (
-                request.operation_id,
-                principal_id,
-                row["intent_sha256"],
-                request.current_time,
-            ),
-        ).fetchone()
-        if approval is None:
-            raise SocialStoreError("operation approval is missing or expired")
-        claim_token = int(row["claim_token"]) + 1
-        attempt_id = _new_id("att")
-        changed = database.execute(
-            """UPDATE outbound_operations
-                  SET state='claimed',claim_token=?,claimed_by=?,claim_expires_at=?,
-                      last_attempt_id=?,updated_at=?
-                WHERE operation_id=? AND state='approved'""",
-            (
-                claim_token,
-                executor_id,
-                request.current_time + request.claim_seconds,
-                attempt_id,
-                request.current_time,
-                request.operation_id,
-            ),
-        ).rowcount
-        if changed != 1:
-            raise SocialStoreError("operation claim lost a concurrent race")
-        database.execute(
-            """INSERT INTO outbound_attempts(
-                attempt_id,operation_id,claim_token,executor_id,status,started_at)
-               VALUES(?,?,?,?,?,?)""",
-            (
-                attempt_id,
-                request.operation_id,
-                claim_token,
-                executor_id,
-                "running",
-                request.current_time,
-            ),
+        row = _claimable_operation(database, request, principal_id)
+        claim_token, attempt_id = _persist_claim(
+            database, request, row, executor_id
         )
         database.execute("COMMIT")
     except Exception:
@@ -183,6 +205,16 @@ def mark_provider_started(
         raise SocialStoreError("outbound provider boundary is stale or already marked")
 
 
+def _assert_outcome_fields(
+    status: str, provider_remote_id: str | None, failure_class: str | None
+) -> None:
+    if status == "succeeded":
+        if provider_remote_id is None or failure_class is not None:
+            raise SocialStoreError("successful outbound receipt requires only a provider ID")
+    elif provider_remote_id is not None or failure_class is None:
+        raise SocialStoreError("unsuccessful outbound receipt requires only a failure class")
+
+
 def _validated_outcome(outcome: AttemptOutcome) -> AttemptOutcome:
     if outcome.status not in ("succeeded", "failed", "unknown"):
         raise SocialStoreError("invalid outbound terminal status")
@@ -192,11 +224,9 @@ def _validated_outcome(outcome: AttemptOutcome) -> AttemptOutcome:
         provider_remote_id = validate_opaque(provider_remote_id, "provider_remote_id")
     if outcome.failure_class is not None and outcome.failure_class not in FAILURE_CLASSES:
         raise SocialStoreError("invalid outbound failure class")
-    if outcome.status == "succeeded":
-        if provider_remote_id is None or outcome.failure_class is not None:
-            raise SocialStoreError("successful outbound receipt requires only a provider ID")
-    elif provider_remote_id is not None or outcome.failure_class is None:
-        raise SocialStoreError("unsuccessful outbound receipt requires only a failure class")
+    _assert_outcome_fields(
+        outcome.status, provider_remote_id, outcome.failure_class
+    )
     return AttemptOutcome(
         outcome.status,
         provider_remote_id,
@@ -313,6 +343,36 @@ def finalize_operation(
     return _outcome_receipt(claimed, outcome)
 
 
+def _expire_claim(
+    database: sqlite3.Connection, row: sqlite3.Row, current_time: int
+) -> str:
+    changed = database.execute(
+        """UPDATE outbound_attempts
+              SET status='unknown',finished_at=?,failure_class='executor_lost',
+                  diagnostics=?
+            WHERE attempt_id=? AND operation_id=? AND claim_token=?
+              AND status='running'""",
+        (
+            current_time,
+            canonical_json({"phase": "executor"}),
+            row["last_attempt_id"],
+            row["operation_id"],
+            row["claim_token"],
+        ),
+    ).rowcount
+    if changed != 1:
+        raise SocialStoreError("expired outbound attempt is inconsistent")
+    operation_changed = database.execute(
+        """UPDATE outbound_operations
+              SET state='unknown',claim_expires_at=NULL,updated_at=?
+            WHERE operation_id=? AND state='claimed' AND claim_token=?""",
+        (current_time, row["operation_id"], row["claim_token"]),
+    ).rowcount
+    if operation_changed != 1:
+        raise SocialStoreError("expired outbound operation is inconsistent")
+    return str(row["operation_id"])
+
+
 def expire_claims(
     database: sqlite3.Connection,
     principal_id: str,
@@ -332,37 +392,10 @@ def expire_claims(
                 ORDER BY claim_expires_at,operation_id LIMIT ?""",
             (principal_id, current_time, limit),
         ).fetchall()
-        expired: list[str] = []
-        for row in rows:
-            changed = database.execute(
-                """UPDATE outbound_attempts
-                      SET status='unknown',finished_at=?,failure_class='executor_lost',
-                          diagnostics=?
-                    WHERE attempt_id=? AND operation_id=? AND claim_token=?
-                      AND status='running'""",
-                (
-                    current_time,
-                    canonical_json({"phase": "executor"}),
-                    row["last_attempt_id"],
-                    row["operation_id"],
-                    row["claim_token"],
-                ),
-            ).rowcount
-            if changed != 1:
-                raise SocialStoreError("expired outbound attempt is inconsistent")
-            operation_changed = database.execute(
-                """UPDATE outbound_operations
-                      SET state='unknown',claim_expires_at=NULL,updated_at=?
-                    WHERE operation_id=? AND state='claimed' AND claim_token=?""",
-                (current_time, row["operation_id"], row["claim_token"]),
-            ).rowcount
-            if operation_changed != 1:
-                raise SocialStoreError("expired outbound operation is inconsistent")
-            expired.append(str(row["operation_id"]))
+        expired = [_expire_claim(database, row, current_time) for row in rows]
         database.execute("COMMIT")
     except Exception:
         if database.in_transaction:
             database.execute("ROLLBACK")
         raise
     return expired
-

--- a/.agents/scripts/_knowledge_social_share_data.py
+++ b/.agents/scripts/_knowledge_social_share_data.py
@@ -255,10 +255,9 @@ DELETE_STATEMENTS = (
     "DELETE FROM accounts",
     "DELETE FROM connections",
 )
-if not LOCAL_ONLY_TABLES.isdisjoint(TABLE_COLUMNS) or any(
-    statement == f"DELETE FROM {table}"
-    for table in LOCAL_ONLY_TABLES
-    for statement in DELETE_STATEMENTS
+DELETED_TABLES = frozenset(statement.rsplit(" ", 1)[-1] for statement in DELETE_STATEMENTS)
+if not LOCAL_ONLY_TABLES.isdisjoint(TABLE_COLUMNS) or not LOCAL_ONLY_TABLES.isdisjoint(
+    DELETED_TABLES
 ):
     raise RuntimeError("local social operation state cannot enter or be erased by sharing")
 

--- a/.agents/scripts/_knowledge_social_share_data.py
+++ b/.agents/scripts/_knowledge_social_share_data.py
@@ -34,6 +34,14 @@ SNAPSHOT_VERSION = 1
 MAX_RAW_BATCH_BYTES = 64 * 1024 * 1024
 MAX_BATCHES = 10_000
 MAX_TABLE_ROWS = 1_000_000
+LOCAL_ONLY_TABLES = frozenset(
+    {
+        "outbound_operations",
+        "outbound_approvals",
+        "outbound_attempts",
+        "notification_state",
+    }
+)
 TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
     "connections": (
         "connection_id",
@@ -247,6 +255,12 @@ DELETE_STATEMENTS = (
     "DELETE FROM accounts",
     "DELETE FROM connections",
 )
+if not LOCAL_ONLY_TABLES.isdisjoint(TABLE_COLUMNS) or any(
+    statement == f"DELETE FROM {table}"
+    for table in LOCAL_ONLY_TABLES
+    for statement in DELETE_STATEMENTS
+):
+    raise RuntimeError("local social operation state cannot enter or be erased by sharing")
 
 
 def _rows(connection: Any, table: str) -> list[dict[str, Any]]:

--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -14,32 +14,34 @@ from canonical_git_repository import is_canonical as _is_canonical
 from canonical_git_repository import real_git
 
 BLOCK_EXIT = 42
-READ_ONLY = {
-    "status",
-    "diff",
-    "diff-files",
-    "log",
-    "show",
-    "rev-parse",
-    "show-ref",
-    "for-each-ref",
-    "cat-file",
-    "check-ref-format",
-    "ls-files",
-    "ls-remote",
-    "ls-tree",
-    "rev-list",
-    "merge-base",
-    "describe",
-    "grep",
-    "blame",
-    "shortlog",
-    "whatchanged",
-    "name-rev",
-    "count-objects",
-    "version",
-    "help",
-}
+READ_ONLY = frozenset(
+    (
+        "status",
+        "diff",
+        "diff-files",
+        "log",
+        "show",
+        "rev-parse",
+        "show-ref",
+        "for-each-ref",
+        "cat-file",
+        "check-ref-format",
+        "ls-files",
+        "ls-remote",
+        "ls-tree",
+        "rev-list",
+        "merge-base",
+        "describe",
+        "grep",
+        "blame",
+        "shortlog",
+        "whatchanged",
+        "name-rev",
+        "count-objects",
+        "version",
+        "help",
+    )
+)
 
 
 def _is_allowed_canonical(subcommand: str, args: list[str]) -> bool:

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -12,8 +12,44 @@ QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
 BROWSER_HELPER="${SCRIPT_DIR}/knowledge_social_browser.py"
+OPERATIONS_HELPER="${SCRIPT_DIR}/knowledge_social_operations.py"
 VAULT_RUNTIME_CHECK="${SCRIPT_DIR}/vault-runtime-check.py"
 VAULT_RUNTIME_PYTHON="${HOME:+$HOME/.aidevops/.agent-workspace/python-env/vault/bin/python3}"
+
+usage_operations() {
+	cat <<'EOF'
+  knowledge-social-helper.sh operation-create [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id ID --action post|reply|like|bookmark \
+    [--target-id ID] [--body-file FILE] [--scheduled-at EPOCH] \
+    [--app PROFILE] [--username HANDLE] [--operation-id ID]
+  knowledge-social-helper.sh operation-approve [--base PATH] [--alias ALIAS] \
+    --operation-id ID --expires-at EPOCH
+  knowledge-social-helper.sh operation-revoke|operation-cancel \
+    [--base PATH] [--alias ALIAS] --operation-id ID
+  knowledge-social-helper.sh operation-run [--base PATH] [--alias ALIAS] \
+    --operation-id ID [--executor-id ID] [--claim-seconds 1-3600]
+  knowledge-social-helper.sh operations-run-due [--base PATH] [--alias ALIAS] \
+    [--executor-id ID] [--claim-seconds 1-3600] [--limit 1-100]
+  knowledge-social-helper.sh operations-due|operations-list \
+    [--base PATH] [--alias ALIAS] [--operation-id ID] [--limit N]
+  knowledge-social-helper.sh operation-reconcile [--base PATH] [--alias ALIAS] \
+    --operation-id ID --outcome succeeded|not-sent [--provider-id ID]
+  knowledge-social-helper.sh notifications-refresh [--base PATH] [--alias ALIAS]
+  knowledge-social-helper.sh notifications-list [--base PATH] [--alias ALIAS] \
+    [--status unread|seen|action-required|responded|dismissed] [--limit 1-1000]
+  knowledge-social-helper.sh notification-set [--base PATH] [--alias ALIAS] \
+    --notification-id ID --status unread|seen|action-required|responded|dismissed
+
+Outbound operations require owner-only knowledge.manage authority. Drafts bind
+the account, action, target, private body, local profile selectors, and schedule
+to an expiring approval. Due runners verify the stable X identity immediately
+before one mapped write attempt. Ambiguous outcomes are never retried; reconcile
+them explicitly. Notification commands maintain a local workflow overlay without
+mutating mention/reply evidence.
+
+EOF
+	return 0
+}
 
 usage() {
 	cat <<'EOF'
@@ -39,6 +75,9 @@ Usage:
     [--lease-seconds SECONDS] [--now-epoch EPOCH]
   knowledge-social-helper.sh receipts [--base PATH] [--alias ALIAS] \
     [--connection-id ID] [--limit 1-1000]
+EOF
+	usage_operations
+	cat <<'EOF'
   knowledge-social-helper.sh identity-export [--base PATH] [--vault-dir DIR] --output FILE
   knowledge-social-helper.sh workspace-create [--base PATH] --alias ALIAS [--vault-dir DIR]
   knowledge-social-helper.sh workspace-grant [--base PATH] --alias ALIAS \
@@ -203,6 +242,14 @@ main() {
 			return 1
 		fi
 		python3 "$SYNC_HELPER" "$subcommand" "$@" || return 1
+		;;
+	operation-create | operation-approve | operation-revoke | operation-cancel | operation-run | operations-run-due | operations-due | operations-list | operation-reconcile | notifications-refresh | notifications-list | notification-set)
+		require_runtime || return 1
+		if [[ ! -r "$OPERATIONS_HELPER" ]]; then
+			printf 'ERROR: social operations implementation missing: %s\n' "$OPERATIONS_HELPER" >&2
+			return 1
+		fi
+		python3 "$OPERATIONS_HELPER" "$subcommand" "$@" || return 1
 		;;
 	identity-export | workspace-create | workspace-grant | workspace-accept | share-export | share-import | workspace-revoke | revocation-apply)
 		run_share_command "$subcommand" "$@" || return 1

--- a/.agents/scripts/knowledge_social_operations.py
+++ b/.agents/scripts/knowledge_social_operations.py
@@ -82,7 +82,7 @@ def _clock(args: argparse.Namespace) -> int:
     return int(time.time())
 
 
-def _read_private_body(path: Path) -> str:
+def _open_private_body(path: Path) -> tuple[int, os.stat_result]:
     try:
         validate_private_file(path, "outbound body", repair=False)
         before = path.lstat()
@@ -92,6 +92,10 @@ def _read_private_body(path: Path) -> str:
         descriptor = os.open(path, flags)
     except (CatalogError, OSError) as error:
         raise OperationsError("outbound body is unavailable or unsafe") from error
+    return descriptor, before
+
+
+def _read_private_bytes(descriptor: int, before: os.stat_result) -> bytes:
     try:
         after = os.fstat(descriptor)
         if (before.st_dev, before.st_ino) != (after.st_dev, after.st_ino):
@@ -104,6 +108,12 @@ def _read_private_body(path: Path) -> str:
     finally:
         if descriptor >= 0:
             os.close(descriptor)
+    return payload
+
+
+def _read_private_body(path: Path) -> str:
+    descriptor, before = _open_private_body(path)
+    payload = _read_private_bytes(descriptor, before)
     if len(payload) > MAX_PAYLOAD_BYTES:
         raise OperationsError("outbound body exceeds the private payload limit")
     try:
@@ -461,10 +471,7 @@ def _add_executor(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--claim-seconds", type=int, default=300)
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    commands = parser.add_subparsers(dest="command", required=True)
-
+def _add_create_command(commands: Any) -> None:
     create = commands.add_parser("operation-create")
     _add_scope(create)
     _add_test_clock(create)
@@ -478,6 +485,8 @@ def parse_args() -> argparse.Namespace:
     create.add_argument("--scheduled-at", type=int)
     create.add_argument("--operation-id")
 
+
+def _add_state_commands(commands: Any) -> None:
     for command in ("operation-approve", "operation-revoke", "operation-cancel"):
         operation = commands.add_parser(command)
         _add_scope(operation)
@@ -486,6 +495,8 @@ def parse_args() -> argparse.Namespace:
         if command == "operation-approve":
             operation.add_argument("--expires-at", type=int, required=True)
 
+
+def _add_run_commands(commands: Any) -> None:
     run = commands.add_parser("operation-run")
     _add_scope(run)
     _add_test_clock(run)
@@ -498,6 +509,8 @@ def parse_args() -> argparse.Namespace:
     _add_executor(run_due)
     run_due.add_argument("--limit", type=int, default=10)
 
+
+def _add_inspection_commands(commands: Any) -> None:
     due = commands.add_parser("operations-due")
     _add_scope(due)
     _add_test_clock(due)
@@ -515,6 +528,8 @@ def parse_args() -> argparse.Namespace:
     reconcile.add_argument("--outcome", choices=("succeeded", "not-sent"), required=True)
     reconcile.add_argument("--provider-id")
 
+
+def _add_notification_commands(commands: Any) -> None:
     refresh = commands.add_parser("notifications-refresh")
     _add_scope(refresh)
     _add_test_clock(refresh)
@@ -529,6 +544,16 @@ def parse_args() -> argparse.Namespace:
     _add_test_clock(notification_set)
     notification_set.add_argument("--notification-id", required=True)
     notification_set.add_argument("--status", choices=NOTIFICATION_STATUSES, required=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    _add_create_command(commands)
+    _add_state_commands(commands)
+    _add_run_commands(commands)
+    _add_inspection_commands(commands)
+    _add_notification_commands(commands)
     return parser.parse_args()
 
 

--- a/.agents/scripts/knowledge_social_operations.py
+++ b/.agents/scripts/knowledge_social_operations.py
@@ -26,23 +26,31 @@ from _knowledge_social_outbound import (
     ACTIONS,
     MAX_PAYLOAD_BYTES,
     ClaimedOperation,
+    OperationIntent,
     approve_operation,
     cancel_operation,
-    claim_operation,
     create_operation,
+    revoke_approval,
+)
+from _knowledge_social_outbound_provider import ProviderAdapterError, invoke_provider
+from _knowledge_social_outbound_reconciliation import (
+    ReconciliationRequest,
+    list_operations,
+    reconcile_unknown,
+)
+from _knowledge_social_outbound_runtime import (
+    AttemptOutcome,
+    ClaimRequest,
+    claim_operation,
     due_operation_ids,
     expire_claims,
     finalize_operation,
-    list_operations,
     mark_provider_started,
-    reconcile_unknown,
-    revoke_approval,
 )
-from _knowledge_social_x import XAdapterError, response_status
+from _knowledge_social_x import XAdapterError
 from _knowledge_social_x_reader import GuardedXurl, verified_identity
 from knowledge_corpus_catalog import DEFAULT_ALIAS, authorized_scope
 from knowledge_corpus_context import CatalogError, validate_private_file
-from knowledge_social_import import reject_credentials
 from knowledge_social_store import (
     SocialStoreError,
     connect,
@@ -53,8 +61,6 @@ from knowledge_social_store import (
 )
 
 DEFAULT_BASE = Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
-WRITE_TIMEOUT_SECONDS = 120
-MAX_PROVIDER_OUTPUT_BYTES = 1024 * 1024
 CONCURRENT_CLAIM_ERRORS = {
     "operation is not due and approved",
     "operation claim lost a concurrent race",
@@ -113,53 +119,6 @@ def _managed_context(args: argparse.Namespace) -> tuple[str, Path]:
     return principal_id, validate_root(corpora[0][1])
 
 
-def _profile_args(claimed: ClaimedOperation) -> list[str]:
-    arguments: list[str] = []
-    if claimed.app_profile:
-        arguments.extend(("--app", claimed.app_profile))
-    if claimed.username:
-        arguments.extend(("--username", claimed.username))
-    return arguments
-
-
-def _write_args(claimed: ClaimedOperation) -> list[str]:
-    if claimed.action == "post" and claimed.payload is not None:
-        return ["post", claimed.payload]
-    if (
-        claimed.action == "reply"
-        and claimed.target_remote_id is not None
-        and claimed.payload is not None
-    ):
-        return ["reply", claimed.target_remote_id, claimed.payload]
-    if claimed.action in ("like", "bookmark") and claimed.target_remote_id:
-        return [claimed.action, claimed.target_remote_id]
-    raise OperationsError("approved outbound operation has an invalid action shape")
-
-
-def _provider_remote_id(claimed: ClaimedOperation, output: str) -> str:
-    if len(output.encode("utf-8")) > MAX_PROVIDER_OUTPUT_BYTES:
-        raise OperationsError("xurl write response exceeds the safety limit")
-    try:
-        response = json.loads(output)
-    except json.JSONDecodeError as error:
-        raise OperationsError("xurl write response is not valid JSON") from error
-    if not isinstance(response, dict):
-        raise OperationsError("xurl write response root must be an object")
-    reject_credentials(response)
-    status = response_status(response)
-    if status < 200 or status >= 300:
-        raise OperationsError("xurl write response reports a provider failure")
-    if claimed.action in ("like", "bookmark"):
-        if claimed.target_remote_id is None:
-            raise OperationsError("engagement receipt has no target ID")
-        return claimed.target_remote_id
-    data = response.get("data", response)
-    remote_id = data.get("id") if isinstance(data, dict) else None
-    if not isinstance(remote_id, str):
-        raise OperationsError("xurl write response has no stable post ID")
-    return validate_opaque(remote_id, "provider_remote_id")
-
-
 def _pre_provider_failure(
     database: sqlite3.Connection,
     claimed: ClaimedOperation,
@@ -171,9 +130,9 @@ def _pre_provider_failure(
         database,
         claimed,
         executor_id,
-        "failed",
-        failure_class=failure_class,
-        finished_at=_clock(args),
+        AttemptOutcome(
+            "failed", failure_class=failure_class, finished_at=_clock(args)
+        ),
     )
 
 
@@ -188,9 +147,9 @@ def _unknown_provider_outcome(
         database,
         claimed,
         executor_id,
-        "unknown",
-        failure_class=failure_class,
-        finished_at=_clock(args),
+        AttemptOutcome(
+            "unknown", failure_class=failure_class, finished_at=_clock(args)
+        ),
     )
 
 
@@ -220,44 +179,22 @@ def _execute_claimed(
             database, claimed, executor_id, "authorization", args
         )
 
-    write_args = _write_args(claimed)
-    command = [
-        str(helper),
-        write_args[0],
-        *_profile_args(claimed),
-        "--confirm-write",
-        "--",
-        *write_args[1:],
-    ]
-    try:
-        completed = subprocess.run(  # nosec B603 -- fixed helper and allowlisted action argv
-            command,
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=WRITE_TIMEOUT_SECONDS,
-        )
-    except (OSError, subprocess.SubprocessError):
+    provider_remote_id, failure_class = invoke_provider(helper, claimed)
+    if failure_class is not None:
         return _unknown_provider_outcome(
-            database, claimed, executor_id, "provider_unavailable", args
+            database, claimed, executor_id, failure_class, args
         )
-    if completed.returncode != 0:
-        return _unknown_provider_outcome(
-            database, claimed, executor_id, "provider_unavailable", args
-        )
-    try:
-        provider_remote_id = _provider_remote_id(claimed, completed.stdout)
-    except (OperationsError, SocialStoreError, UnicodeError, XAdapterError):
-        return _unknown_provider_outcome(
-            database, claimed, executor_id, "validation", args
-        )
+    if provider_remote_id is None:
+        raise OperationsError("successful provider outcome has no remote ID")
     return finalize_operation(
         database,
         claimed,
         executor_id,
-        "succeeded",
-        provider_remote_id=provider_remote_id,
-        finished_at=_clock(args),
+        AttemptOutcome(
+            "succeeded",
+            provider_remote_id=provider_remote_id,
+            finished_at=_clock(args),
+        ),
     )
 
 
@@ -276,11 +213,13 @@ def _run_one(
 ) -> dict[str, Any]:
     claimed = claim_operation(
         database,
-        operation_id,
-        principal_id,
-        executor_id,
-        _clock(args),
-        args.claim_seconds,
+        ClaimRequest(
+            operation_id,
+            principal_id,
+            executor_id,
+            _clock(args),
+            args.claim_seconds,
+        ),
     )
     return _execute_claimed(database, claimed, executor_id, args)
 
@@ -308,16 +247,23 @@ def _run_due(
     return {"expired_claims": len(expired), "results": results}
 
 
-def _dispatch(
+def _required_now(current_time: int | None) -> int:
+    if current_time is None:
+        raise OperationsError("operation command requires a current time")
+    return current_time
+
+
+def _handle_operation_create(
     args: argparse.Namespace,
     principal_id: str,
     database: sqlite3.Connection,
-) -> Any:
-    now = _clock(args) if hasattr(args, "now_epoch") else None
-    if args.command == "operation-create":
-        payload = _read_private_body(args.body_file) if args.body_file else None
-        return create_operation(
-            database,
+    current_time: int | None,
+) -> dict[str, Any]:
+    created_at = _required_now(current_time)
+    payload = _read_private_body(args.body_file) if args.body_file else None
+    return create_operation(
+        database,
+        OperationIntent(
             connection_id=args.connection_id,
             remote_account_id=args.account_id,
             action=args.action,
@@ -325,67 +271,176 @@ def _dispatch(
             payload=payload,
             app_profile=args.app,
             username=args.username,
-            scheduled_at=args.scheduled_at if args.scheduled_at is not None else now,
+            scheduled_at=(
+                args.scheduled_at
+                if args.scheduled_at is not None
+                else created_at
+            ),
             created_by=principal_id,
             operation_id=args.operation_id,
-            created_at=now,
-        )
-    if args.command == "operation-approve":
-        return approve_operation(
-            database,
-            args.operation_id,
-            principal_id,
-            args.expires_at,
-            approved_at=now,
-        )
-    if args.command == "operation-revoke":
-        return revoke_approval(
-            database, args.operation_id, principal_id, revoked_at=now
-        )
-    if args.command == "operation-cancel":
-        return cancel_operation(
-            database, args.operation_id, principal_id, cancelled_at=now
-        )
-    if args.command == "operation-run":
-        return _run_one(
-            database,
-            principal_id,
-            args.operation_id,
-            _executor_id(args),
-            args,
-        )
-    if args.command == "operations-run-due":
-        return _run_due(database, principal_id, args)
-    if args.command == "operations-due":
-        return due_operation_ids(database, principal_id, now, args.limit)
-    if args.command == "operations-list":
-        return list_operations(
-            database, principal_id, args.operation_id, args.limit
-        )
-    if args.command == "operation-reconcile":
-        if args.outcome == "succeeded" and args.provider_id is None:
-            raise OperationsError("successful reconciliation requires --provider-id")
-        if args.outcome == "not-sent" and args.provider_id is not None:
-            raise OperationsError("not-sent reconciliation forbids --provider-id")
-        return reconcile_unknown(
-            database,
+            created_at=created_at,
+        ),
+    )
+
+
+def _handle_operation_approve(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    current_time: int | None,
+) -> dict[str, Any]:
+    return approve_operation(
+        database,
+        args.operation_id,
+        principal_id,
+        args.expires_at,
+        approved_at=current_time,
+    )
+
+
+def _handle_operation_revoke(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    current_time: int | None,
+) -> dict[str, Any]:
+    return revoke_approval(
+        database, args.operation_id, principal_id, revoked_at=current_time
+    )
+
+
+def _handle_operation_cancel(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    current_time: int | None,
+) -> dict[str, Any]:
+    return cancel_operation(
+        database, args.operation_id, principal_id, cancelled_at=current_time
+    )
+
+
+def _handle_operation_run(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    _current_time: int | None,
+) -> dict[str, Any]:
+    return _run_one(
+        database, principal_id, args.operation_id, _executor_id(args), args
+    )
+
+
+def _handle_operations_run_due(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    _current_time: int | None,
+) -> dict[str, Any]:
+    return _run_due(database, principal_id, args)
+
+
+def _handle_operations_due(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    current_time: int | None,
+) -> list[str]:
+    return due_operation_ids(
+        database, principal_id, _required_now(current_time), args.limit
+    )
+
+
+def _handle_operations_list(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    _current_time: int | None,
+) -> list[dict[str, Any]]:
+    return list_operations(database, principal_id, args.operation_id, args.limit)
+
+
+def _handle_operation_reconcile(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    current_time: int | None,
+) -> dict[str, Any]:
+    if args.outcome == "succeeded" and args.provider_id is None:
+        raise OperationsError("successful reconciliation requires --provider-id")
+    if args.outcome == "not-sent" and args.provider_id is not None:
+        raise OperationsError("not-sent reconciliation forbids --provider-id")
+    return reconcile_unknown(
+        database,
+        ReconciliationRequest(
             args.operation_id,
             principal_id,
             args.outcome,
             args.provider_id,
-            reconciled_at=now,
-        )
-    if args.command == "notifications-refresh":
-        return project_notifications(database, principal_id, projected_at=now)
-    if args.command == "notifications-list":
-        return list_notifications(database, principal_id, args.status, args.limit)
+            current_time,
+        ),
+    )
+
+
+def _handle_notifications_refresh(
+    _args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    current_time: int | None,
+) -> dict[str, int]:
+    return project_notifications(database, principal_id, projected_at=current_time)
+
+
+def _handle_notifications_list(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    _current_time: int | None,
+) -> list[dict[str, Any]]:
+    return list_notifications(database, principal_id, args.status, args.limit)
+
+
+def _handle_notification_set(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+    current_time: int | None,
+) -> dict[str, Any]:
     return set_notification_status(
         database,
         principal_id,
         args.notification_id,
         args.status,
-        updated_at=now,
+        updated_at=current_time,
     )
+
+
+COMMAND_HANDLERS = {
+    "operation-create": _handle_operation_create,
+    "operation-approve": _handle_operation_approve,
+    "operation-revoke": _handle_operation_revoke,
+    "operation-cancel": _handle_operation_cancel,
+    "operation-run": _handle_operation_run,
+    "operations-run-due": _handle_operations_run_due,
+    "operations-due": _handle_operations_due,
+    "operations-list": _handle_operations_list,
+    "operation-reconcile": _handle_operation_reconcile,
+    "notifications-refresh": _handle_notifications_refresh,
+    "notifications-list": _handle_notifications_list,
+    "notification-set": _handle_notification_set,
+}
+
+
+def _dispatch(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+) -> Any:
+    current_time = _clock(args) if hasattr(args, "now_epoch") else None
+    handler = COMMAND_HANDLERS.get(args.command)
+    if handler is None:
+        raise OperationsError("unsupported operation command")
+    return handler(args, principal_id, database, current_time)
 
 
 def _add_scope(parser: argparse.ArgumentParser) -> None:
@@ -492,6 +547,7 @@ def main() -> int:
         CatalogError,
         OSError,
         OperationsError,
+        ProviderAdapterError,
         SocialStoreError,
         XAdapterError,
         sqlite3.Error,

--- a/.agents/scripts/knowledge_social_operations.py
+++ b/.agents/scripts/knowledge_social_operations.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Owner-authorized outbound social operations and notification workflow CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_notifications import (
+    NOTIFICATION_STATUSES,
+    list_notifications,
+    project_notifications,
+    set_notification_status,
+)
+from _knowledge_social_outbound import (
+    ACTIONS,
+    MAX_PAYLOAD_BYTES,
+    ClaimedOperation,
+    approve_operation,
+    cancel_operation,
+    claim_operation,
+    create_operation,
+    due_operation_ids,
+    expire_claims,
+    finalize_operation,
+    list_operations,
+    mark_provider_started,
+    reconcile_unknown,
+    revoke_approval,
+)
+from _knowledge_social_x import XAdapterError, response_status
+from _knowledge_social_x_reader import GuardedXurl, verified_identity
+from knowledge_corpus_catalog import DEFAULT_ALIAS, authorized_scope
+from knowledge_corpus_context import CatalogError, validate_private_file
+from knowledge_social_import import reject_credentials
+from knowledge_social_store import (
+    SocialStoreError,
+    connect,
+    migrate,
+    require_schema,
+    validate_opaque,
+    validate_root,
+)
+
+DEFAULT_BASE = Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+WRITE_TIMEOUT_SECONDS = 120
+MAX_PROVIDER_OUTPUT_BYTES = 1024 * 1024
+CONCURRENT_CLAIM_ERRORS = {
+    "operation is not due and approved",
+    "operation claim lost a concurrent race",
+}
+
+
+class OperationsError(RuntimeError):
+    """Raised for privacy-safe outbound CLI failures."""
+
+
+def _clock(args: argparse.Namespace) -> int:
+    override = getattr(args, "now_epoch", None)
+    if override is not None:
+        if os.environ.get("AIDEVOPS_TEST_MODE") != "1":
+            raise OperationsError("test clocks are disabled outside the test harness")
+        if override < 0:
+            raise OperationsError("test clock must be a non-negative epoch")
+        return override
+    return int(time.time())
+
+
+def _read_private_body(path: Path) -> str:
+    try:
+        validate_private_file(path, "outbound body", repair=False)
+        before = path.lstat()
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(path, flags)
+    except (CatalogError, OSError) as error:
+        raise OperationsError("outbound body is unavailable or unsafe") from error
+    try:
+        after = os.fstat(descriptor)
+        if (before.st_dev, before.st_ino) != (after.st_dev, after.st_ino):
+            raise OperationsError("outbound body replacement detected")
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            payload = handle.read(MAX_PAYLOAD_BYTES + 1)
+    except OSError as error:
+        raise OperationsError("outbound body is unavailable or unsafe") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if len(payload) > MAX_PAYLOAD_BYTES:
+        raise OperationsError("outbound body exceeds the private payload limit")
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise OperationsError("outbound body must be UTF-8") from error
+
+
+def _managed_context(args: argparse.Namespace) -> tuple[str, Path]:
+    principal_id, corpora = authorized_scope(
+        args.base or DEFAULT_BASE, "knowledge.manage", args.alias
+    )
+    return principal_id, validate_root(corpora[0][1])
+
+
+def _profile_args(claimed: ClaimedOperation) -> list[str]:
+    arguments: list[str] = []
+    if claimed.app_profile:
+        arguments.extend(("--app", claimed.app_profile))
+    if claimed.username:
+        arguments.extend(("--username", claimed.username))
+    return arguments
+
+
+def _write_args(claimed: ClaimedOperation) -> list[str]:
+    if claimed.action == "post" and claimed.payload is not None:
+        return ["post", claimed.payload]
+    if (
+        claimed.action == "reply"
+        and claimed.target_remote_id is not None
+        and claimed.payload is not None
+    ):
+        return ["reply", claimed.target_remote_id, claimed.payload]
+    if claimed.action in ("like", "bookmark") and claimed.target_remote_id:
+        return [claimed.action, claimed.target_remote_id]
+    raise OperationsError("approved outbound operation has an invalid action shape")
+
+
+def _provider_remote_id(claimed: ClaimedOperation, output: str) -> str:
+    if len(output.encode("utf-8")) > MAX_PROVIDER_OUTPUT_BYTES:
+        raise OperationsError("xurl write response exceeds the safety limit")
+    try:
+        response = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise OperationsError("xurl write response is not valid JSON") from error
+    if not isinstance(response, dict):
+        raise OperationsError("xurl write response root must be an object")
+    reject_credentials(response)
+    status = response_status(response)
+    if status < 200 or status >= 300:
+        raise OperationsError("xurl write response reports a provider failure")
+    if claimed.action in ("like", "bookmark"):
+        if claimed.target_remote_id is None:
+            raise OperationsError("engagement receipt has no target ID")
+        return claimed.target_remote_id
+    data = response.get("data", response)
+    remote_id = data.get("id") if isinstance(data, dict) else None
+    if not isinstance(remote_id, str):
+        raise OperationsError("xurl write response has no stable post ID")
+    return validate_opaque(remote_id, "provider_remote_id")
+
+
+def _pre_provider_failure(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    failure_class: str,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    return finalize_operation(
+        database,
+        claimed,
+        executor_id,
+        "failed",
+        failure_class=failure_class,
+        finished_at=_clock(args),
+    )
+
+
+def _unknown_provider_outcome(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    failure_class: str,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    return finalize_operation(
+        database,
+        claimed,
+        executor_id,
+        "unknown",
+        failure_class=failure_class,
+        finished_at=_clock(args),
+    )
+
+
+def _execute_claimed(
+    database: sqlite3.Connection,
+    claimed: ClaimedOperation,
+    executor_id: str,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    helper = Path(__file__).with_name("xurl-helper.sh")
+    try:
+        identity_reader = GuardedXurl(
+            helper, claimed.app_profile, claimed.username
+        )
+        verified_identity(identity_reader.identity(), claimed.remote_account_id)
+    except (OSError, SocialStoreError, subprocess.SubprocessError, XAdapterError):
+        return _pre_provider_failure(
+            database, claimed, executor_id, "identity", args
+        )
+
+    try:
+        mark_provider_started(
+            database, claimed, executor_id, started_at=_clock(args)
+        )
+    except SocialStoreError:
+        return _pre_provider_failure(
+            database, claimed, executor_id, "authorization", args
+        )
+
+    write_args = _write_args(claimed)
+    command = [
+        str(helper),
+        write_args[0],
+        *_profile_args(claimed),
+        "--confirm-write",
+        "--",
+        *write_args[1:],
+    ]
+    try:
+        completed = subprocess.run(  # nosec B603 -- fixed helper and allowlisted action argv
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=WRITE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return _unknown_provider_outcome(
+            database, claimed, executor_id, "provider_unavailable", args
+        )
+    if completed.returncode != 0:
+        return _unknown_provider_outcome(
+            database, claimed, executor_id, "provider_unavailable", args
+        )
+    try:
+        provider_remote_id = _provider_remote_id(claimed, completed.stdout)
+    except (OperationsError, SocialStoreError, UnicodeError, XAdapterError):
+        return _unknown_provider_outcome(
+            database, claimed, executor_id, "validation", args
+        )
+    return finalize_operation(
+        database,
+        claimed,
+        executor_id,
+        "succeeded",
+        provider_remote_id=provider_remote_id,
+        finished_at=_clock(args),
+    )
+
+
+def _executor_id(args: argparse.Namespace) -> str:
+    return validate_opaque(
+        args.executor_id or f"exe_{uuid.uuid4().hex}", "executor_id"
+    )
+
+
+def _run_one(
+    database: sqlite3.Connection,
+    principal_id: str,
+    operation_id: str,
+    executor_id: str,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    claimed = claim_operation(
+        database,
+        operation_id,
+        principal_id,
+        executor_id,
+        _clock(args),
+        args.claim_seconds,
+    )
+    return _execute_claimed(database, claimed, executor_id, args)
+
+
+def _run_due(
+    database: sqlite3.Connection,
+    principal_id: str,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    current_time = _clock(args)
+    expired = expire_claims(database, principal_id, current_time, args.limit)
+    due = due_operation_ids(database, principal_id, current_time, args.limit)
+    executor_id = _executor_id(args)
+    results: list[dict[str, Any]] = []
+    for operation_id in due:
+        try:
+            results.append(
+                _run_one(
+                    database, principal_id, operation_id, executor_id, args
+                )
+            )
+        except SocialStoreError as error:
+            if str(error) not in CONCURRENT_CLAIM_ERRORS:
+                raise
+    return {"expired_claims": len(expired), "results": results}
+
+
+def _dispatch(
+    args: argparse.Namespace,
+    principal_id: str,
+    database: sqlite3.Connection,
+) -> Any:
+    now = _clock(args) if hasattr(args, "now_epoch") else None
+    if args.command == "operation-create":
+        payload = _read_private_body(args.body_file) if args.body_file else None
+        return create_operation(
+            database,
+            connection_id=args.connection_id,
+            remote_account_id=args.account_id,
+            action=args.action,
+            target_remote_id=args.target_id,
+            payload=payload,
+            app_profile=args.app,
+            username=args.username,
+            scheduled_at=args.scheduled_at if args.scheduled_at is not None else now,
+            created_by=principal_id,
+            operation_id=args.operation_id,
+            created_at=now,
+        )
+    if args.command == "operation-approve":
+        return approve_operation(
+            database,
+            args.operation_id,
+            principal_id,
+            args.expires_at,
+            approved_at=now,
+        )
+    if args.command == "operation-revoke":
+        return revoke_approval(
+            database, args.operation_id, principal_id, revoked_at=now
+        )
+    if args.command == "operation-cancel":
+        return cancel_operation(
+            database, args.operation_id, principal_id, cancelled_at=now
+        )
+    if args.command == "operation-run":
+        return _run_one(
+            database,
+            principal_id,
+            args.operation_id,
+            _executor_id(args),
+            args,
+        )
+    if args.command == "operations-run-due":
+        return _run_due(database, principal_id, args)
+    if args.command == "operations-due":
+        return due_operation_ids(database, principal_id, now, args.limit)
+    if args.command == "operations-list":
+        return list_operations(
+            database, principal_id, args.operation_id, args.limit
+        )
+    if args.command == "operation-reconcile":
+        if args.outcome == "succeeded" and args.provider_id is None:
+            raise OperationsError("successful reconciliation requires --provider-id")
+        if args.outcome == "not-sent" and args.provider_id is not None:
+            raise OperationsError("not-sent reconciliation forbids --provider-id")
+        return reconcile_unknown(
+            database,
+            args.operation_id,
+            principal_id,
+            args.outcome,
+            args.provider_id,
+            reconciled_at=now,
+        )
+    if args.command == "notifications-refresh":
+        return project_notifications(database, principal_id, projected_at=now)
+    if args.command == "notifications-list":
+        return list_notifications(database, principal_id, args.status, args.limit)
+    return set_notification_status(
+        database,
+        principal_id,
+        args.notification_id,
+        args.status,
+        updated_at=now,
+    )
+
+
+def _add_scope(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+
+
+def _add_test_clock(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--now-epoch", type=int, help=argparse.SUPPRESS)
+
+
+def _add_operation_id(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--operation-id", required=True)
+
+
+def _add_executor(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--executor-id")
+    parser.add_argument("--claim-seconds", type=int, default=300)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    create = commands.add_parser("operation-create")
+    _add_scope(create)
+    _add_test_clock(create)
+    create.add_argument("--connection-id", required=True)
+    create.add_argument("--account-id", required=True)
+    create.add_argument("--action", choices=ACTIONS, required=True)
+    create.add_argument("--target-id")
+    create.add_argument("--body-file", type=Path)
+    create.add_argument("--app")
+    create.add_argument("--username")
+    create.add_argument("--scheduled-at", type=int)
+    create.add_argument("--operation-id")
+
+    for command in ("operation-approve", "operation-revoke", "operation-cancel"):
+        operation = commands.add_parser(command)
+        _add_scope(operation)
+        _add_test_clock(operation)
+        _add_operation_id(operation)
+        if command == "operation-approve":
+            operation.add_argument("--expires-at", type=int, required=True)
+
+    run = commands.add_parser("operation-run")
+    _add_scope(run)
+    _add_test_clock(run)
+    _add_operation_id(run)
+    _add_executor(run)
+
+    run_due = commands.add_parser("operations-run-due")
+    _add_scope(run_due)
+    _add_test_clock(run_due)
+    _add_executor(run_due)
+    run_due.add_argument("--limit", type=int, default=10)
+
+    due = commands.add_parser("operations-due")
+    _add_scope(due)
+    _add_test_clock(due)
+    due.add_argument("--limit", type=int, default=100)
+
+    operation_list = commands.add_parser("operations-list")
+    _add_scope(operation_list)
+    operation_list.add_argument("--operation-id")
+    operation_list.add_argument("--limit", type=int, default=100)
+
+    reconcile = commands.add_parser("operation-reconcile")
+    _add_scope(reconcile)
+    _add_test_clock(reconcile)
+    _add_operation_id(reconcile)
+    reconcile.add_argument("--outcome", choices=("succeeded", "not-sent"), required=True)
+    reconcile.add_argument("--provider-id")
+
+    refresh = commands.add_parser("notifications-refresh")
+    _add_scope(refresh)
+    _add_test_clock(refresh)
+
+    notification_list = commands.add_parser("notifications-list")
+    _add_scope(notification_list)
+    notification_list.add_argument("--status", choices=NOTIFICATION_STATUSES)
+    notification_list.add_argument("--limit", type=int, default=100)
+
+    notification_set = commands.add_parser("notification-set")
+    _add_scope(notification_set)
+    _add_test_clock(notification_set)
+    notification_set.add_argument("--notification-id", required=True)
+    notification_set.add_argument("--status", choices=NOTIFICATION_STATUSES, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    database: sqlite3.Connection | None = None
+    try:
+        principal_id, root = _managed_context(args)
+        database = connect(root)
+        migrate(database)
+        require_schema(database)
+        result = _dispatch(args, principal_id, database)
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (
+        CatalogError,
+        OSError,
+        OperationsError,
+        SocialStoreError,
+        XAdapterError,
+        sqlite3.Error,
+        subprocess.SubprocessError,
+        ValueError,
+    ) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    finally:
+        if database is not None:
+            database.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -19,6 +19,7 @@ from knowledge_corpus_context import (
 )
 
 SCHEMA_VERSION = 3
+SCHEMA_VERSION_SQL = "PRAGMA user_version=3"
 OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
 SQLITE_MUTABLE_SIDECARS = ("-journal", "-shm", "-wal")
 
@@ -288,7 +289,7 @@ def migrate(connection: sqlite3.Connection) -> None:
                 "VALUES(?,strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
                 (version,),
             )
-        connection.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+        connection.execute(SCHEMA_VERSION_SQL)
         connection.execute("COMMIT")
     except Exception:
         connection.execute("ROLLBACK")

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -18,7 +18,7 @@ from knowledge_corpus_context import (
     validate_private_file,
 )
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
 SQLITE_MUTABLE_SIDECARS = ("-journal", "-shm", "-wal")
 
@@ -176,10 +176,59 @@ def _tables() -> tuple[str, ...]:
             retention_limit TEXT, unavailable_reason TEXT, status TEXT NOT NULL,
             batch_id TEXT NOT NULL, observed_at TEXT NOT NULL,
             PRIMARY KEY(provider, connection_id, stream))""",
+        """CREATE TABLE IF NOT EXISTS outbound_operations (
+            operation_id TEXT PRIMARY KEY, provider TEXT NOT NULL,
+            connection_id TEXT NOT NULL, remote_account_id TEXT NOT NULL,
+            action TEXT NOT NULL CHECK(action IN ('post','reply','like','bookmark')),
+            target_remote_id TEXT, payload TEXT, payload_sha256 TEXT NOT NULL,
+            intent_sha256 TEXT NOT NULL UNIQUE, app_profile TEXT, username TEXT,
+            scheduled_at INTEGER NOT NULL, state TEXT NOT NULL
+                CHECK(state IN ('draft','approved','claimed','succeeded','failed','unknown','cancelled')),
+            created_by TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+            claim_token INTEGER NOT NULL DEFAULT 0, claimed_by TEXT, claim_expires_at INTEGER,
+            last_attempt_id TEXT,
+            CHECK(
+                (action='post' AND payload IS NOT NULL AND target_remote_id IS NULL) OR
+                (action='reply' AND payload IS NOT NULL AND target_remote_id IS NOT NULL) OR
+                (action IN ('like','bookmark') AND payload IS NULL AND target_remote_id IS NOT NULL)
+            ))""",
+        """CREATE TABLE IF NOT EXISTS outbound_approvals (
+            approval_id TEXT PRIMARY KEY,
+            operation_id TEXT NOT NULL REFERENCES outbound_operations(operation_id),
+            principal_id TEXT NOT NULL, intent_sha256 TEXT NOT NULL,
+            approved_at INTEGER NOT NULL, expires_at INTEGER NOT NULL,
+            revoked_at INTEGER,
+            CHECK(expires_at>approved_at),
+            CHECK(revoked_at IS NULL OR revoked_at>=approved_at),
+            UNIQUE(operation_id, approval_id))""",
+        """CREATE TABLE IF NOT EXISTS outbound_attempts (
+            attempt_id TEXT PRIMARY KEY,
+            operation_id TEXT NOT NULL REFERENCES outbound_operations(operation_id),
+            claim_token INTEGER NOT NULL, executor_id TEXT NOT NULL,
+            status TEXT NOT NULL CHECK(status IN ('running','succeeded','failed','unknown')),
+            started_at INTEGER NOT NULL, provider_started_at INTEGER, finished_at INTEGER,
+            provider_remote_id TEXT, failure_class TEXT, diagnostics TEXT,
+            CHECK(provider_started_at IS NULL OR provider_started_at>=started_at),
+            CHECK((status='running' AND finished_at IS NULL) OR
+                  (status!='running' AND finished_at IS NOT NULL)),
+            UNIQUE(operation_id, claim_token))""",
+        """CREATE TABLE IF NOT EXISTS notification_state (
+            notification_id TEXT PRIMARY KEY, principal_id TEXT NOT NULL,
+            provider TEXT NOT NULL, connection_id TEXT NOT NULL,
+            activity_type TEXT NOT NULL, activity_remote_id TEXT NOT NULL,
+            object_remote_id TEXT, actor_remote_id TEXT NOT NULL,
+            kind TEXT NOT NULL CHECK(kind IN ('mention','reply')),
+            status TEXT NOT NULL
+                CHECK(status IN ('unread','seen','action-required','responded','dismissed')),
+            observed_at TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+            UNIQUE(principal_id, provider, activity_type, activity_remote_id))""",
         "CREATE INDEX IF NOT EXISTS idx_objects_account ON objects(provider, account_remote_id, created_at)",
         "CREATE INDEX IF NOT EXISTS idx_activities_actor ON activities(provider, actor_remote_id, occurred_at)",
         "CREATE INDEX IF NOT EXISTS idx_coverage_connection ON coverage_records(connection_id, stream)",
         "CREATE INDEX IF NOT EXISTS idx_reconciliation_status ON reconciliation_items(connection_id, stream, status)",
+        "CREATE INDEX IF NOT EXISTS idx_outbound_due ON outbound_operations(state,scheduled_at,operation_id)",
+        "CREATE INDEX IF NOT EXISTS idx_outbound_approvals ON outbound_approvals(operation_id,expires_at,revoked_at)",
+        "CREATE INDEX IF NOT EXISTS idx_notification_status ON notification_state(principal_id,status,updated_at)",
     )
 
 
@@ -239,7 +288,7 @@ def migrate(connection: sqlite3.Connection) -> None:
                 "VALUES(?,strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
                 (version,),
             )
-        connection.execute("PRAGMA user_version=2")
+        connection.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
         connection.execute("COMMIT")
     except Exception:
         connection.execute("ROLLBACK")

--- a/.agents/tests/test-knowledge-social-operations.sh
+++ b/.agents/tests/test-knowledge-social-operations.sh
@@ -369,9 +369,14 @@ import sys
 from pathlib import Path
 
 from _knowledge_social_outbound import (
+    OperationIntent,
     approve_operation,
-    claim_operation,
     create_operation,
+)
+from _knowledge_social_outbound_runtime import (
+    AttemptOutcome,
+    ClaimRequest,
+    claim_operation,
     due_operation_ids,
     expire_claims,
     finalize_operation,
@@ -394,6 +399,29 @@ def rejected(callback):
     raise AssertionError("unsafe outbound state mutation was accepted")
 
 
+def intent(
+    operation_id,
+    target_remote_id,
+    action="like",
+    payload=None,
+    app_profile=None,
+    username=None,
+):
+    return OperationIntent(
+        connection_id="conn_ops",
+        remote_account_id="acct42",
+        action=action,
+        target_remote_id=target_remote_id,
+        payload=payload,
+        app_profile=app_profile,
+        username=username,
+        scheduled_at=1000,
+        created_by=principal,
+        operation_id=operation_id,
+        created_at=1000,
+    )
+
+
 tampering = (
     ("payload", "changed body"),
     ("connection_id", "conn_other"),
@@ -407,17 +435,14 @@ for index, (field, value) in enumerate(tampering):
     operation_id = f"op_tamper_{index:03d}"
     create_operation(
         database,
-        connection_id="conn_ops",
-        remote_account_id="acct42",
-        action="reply",
-        target_remote_id="post_original_001",
-        payload="bound fixture body",
-        app_profile="fixture-app",
-        username="fixture-user",
-        scheduled_at=1000,
-        created_by=principal,
-        operation_id=operation_id,
-        created_at=1000,
+        intent(
+            operation_id,
+            "post_original_001",
+            action="reply",
+            payload="bound fixture body",
+            app_profile="fixture-app",
+            username="fixture-user",
+        ),
     )
     approve_operation(database, operation_id, principal, 2000, approved_at=1000)
     database.execute(f"UPDATE outbound_operations SET {field}=? WHERE operation_id=?", (value, operation_id))
@@ -429,17 +454,7 @@ for index, (field, value) in enumerate(tampering):
 
 create_operation(
     database,
-    connection_id="conn_ops",
-    remote_account_id="acct42",
-    action="like",
-    target_remote_id="post_action_001",
-    payload=None,
-    app_profile=None,
-    username=None,
-    scheduled_at=1000,
-    created_by=principal,
-    operation_id="op_tamper_action",
-    created_at=1000,
+    intent("op_tamper_action", "post_action_001"),
 )
 approve_operation(database, "op_tamper_action", principal, 2000, approved_at=1000)
 database.execute("UPDATE outbound_operations SET action='bookmark' WHERE operation_id='op_tamper_action'")
@@ -450,43 +465,27 @@ database.execute(
 
 create_operation(
     database,
-    connection_id="conn_ops",
-    remote_account_id="acct42",
-    action="like",
-    target_remote_id="post_approval_expired",
-    payload=None,
-    app_profile=None,
-    username=None,
-    scheduled_at=1000,
-    created_by=principal,
-    operation_id="op_approval_expired",
-    created_at=1000,
+    intent("op_approval_expired", "post_approval_expired"),
 )
 approve_operation(database, "op_approval_expired", principal, 1100, approved_at=1000)
 assert due_operation_ids(database, principal, 1100, 100) == []
 rejected(
     lambda: claim_operation(
-        database, "op_approval_expired", principal, "exe_approval_expired", 1100, 300
+        database,
+        ClaimRequest(
+            "op_approval_expired", principal, "exe_approval_expired", 1100, 300
+        ),
     )
 )
 
 create_operation(
     database,
-    connection_id="conn_ops",
-    remote_account_id="acct42",
-    action="like",
-    target_remote_id="post_boundary_expired",
-    payload=None,
-    app_profile=None,
-    username=None,
-    scheduled_at=1000,
-    created_by=principal,
-    operation_id="op_boundary_expired",
-    created_at=1000,
+    intent("op_boundary_expired", "post_boundary_expired"),
 )
 approve_operation(database, "op_boundary_expired", principal, 1101, approved_at=1000)
 boundary = claim_operation(
-    database, "op_boundary_expired", principal, "exe_boundary", 1100, 300
+    database,
+    ClaimRequest("op_boundary_expired", principal, "exe_boundary", 1100, 300),
 )
 rejected(
     lambda: mark_provider_started(database, boundary, "exe_boundary", started_at=1101)
@@ -495,73 +494,51 @@ finalize_operation(
     database,
     boundary,
     "exe_boundary",
-    "failed",
-    failure_class="authorization",
-    finished_at=1101,
+    AttemptOutcome("failed", failure_class="authorization", finished_at=1101),
 )
 
 create_operation(
     database,
-    connection_id="conn_ops",
-    remote_account_id="acct42",
-    action="like",
-    target_remote_id="post_expired_claim",
-    payload=None,
-    app_profile=None,
-    username=None,
-    scheduled_at=1000,
-    created_by=principal,
-    operation_id="op_expired_claim",
-    created_at=1000,
+    intent("op_expired_claim", "post_expired_claim"),
 )
 approve_operation(database, "op_expired_claim", principal, 2000, approved_at=1000)
-claimed = claim_operation(database, "op_expired_claim", principal, "exe_expired", 1100, 1)
+claimed = claim_operation(
+    database, ClaimRequest("op_expired_claim", principal, "exe_expired", 1100, 1)
+)
 assert expire_claims(database, principal, 1101, 10) == ["op_expired_claim"]
 rejected(
     lambda: finalize_operation(
         database,
         claimed,
         "exe_expired",
-        "failed",
-        failure_class="runtime",
-        finished_at=1102,
+        AttemptOutcome("failed", failure_class="runtime", finished_at=1102),
     )
 )
 
 create_operation(
     database,
-    connection_id="conn_ops",
-    remote_account_id="acct42",
-    action="like",
-    target_remote_id="post_started_001",
-    payload=None,
-    app_profile=None,
-    username=None,
-    scheduled_at=1000,
-    created_by=principal,
-    operation_id="op_started_001",
-    created_at=1000,
+    intent("op_started_001", "post_started_001"),
 )
 approve_operation(database, "op_started_001", principal, 2000, approved_at=1000)
-started = claim_operation(database, "op_started_001", principal, "exe_started", 1100, 300)
+started = claim_operation(
+    database, ClaimRequest("op_started_001", principal, "exe_started", 1100, 300)
+)
 mark_provider_started(database, started, "exe_started", started_at=1101)
 rejected(
     lambda: finalize_operation(
         database,
         started,
         "exe_started",
-        "failed",
-        failure_class="runtime",
-        finished_at=1102,
+        AttemptOutcome("failed", failure_class="runtime", finished_at=1102),
     )
 )
 finalize_operation(
     database,
     started,
     "exe_started",
-    "unknown",
-    failure_class="provider_unavailable",
-    finished_at=1102,
+    AttemptOutcome(
+        "unknown", failure_class="provider_unavailable", finished_at=1102
+    ),
 )
 database.close()
 PY
@@ -644,7 +621,7 @@ import sys
 from pathlib import Path
 
 from _knowledge_social_notifications import project_notifications, set_notification_status
-from _knowledge_social_outbound import create_operation
+from _knowledge_social_outbound import OperationIntent, create_operation
 from _knowledge_social_share_data import (
     LOCAL_ONLY_TABLES,
     TABLE_COLUMNS,
@@ -675,17 +652,19 @@ database = connect(restore_root)
 migrate(database)
 create_operation(
     database,
-    connection_id="conn_ops",
-    remote_account_id="acct42",
-    action="like",
-    target_remote_id="post_local_only",
-    payload=None,
-    app_profile="local-profile",
-    username=None,
-    scheduled_at=1000,
-    created_by="prn_local_owner",
-    operation_id="op_local_only",
-    created_at=1000,
+    OperationIntent(
+        connection_id="conn_ops",
+        remote_account_id="acct42",
+        action="like",
+        target_remote_id="post_local_only",
+        payload=None,
+        app_profile="local-profile",
+        username=None,
+        scheduled_at=1000,
+        created_by="prn_local_owner",
+        operation_id="op_local_only",
+        created_at=1000,
+    ),
 )
 project_notifications(database, "prn_local_owner", projected_at=1000)
 notification = database.execute(

--- a/.agents/tests/test-knowledge-social-operations.sh
+++ b/.agents/tests/test-knowledge-social-operations.sh
@@ -1,0 +1,713 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-operations.sh — Approval-bound social operation tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+VAULT_PYTHON="${HOME}/.aidevops/.agent-workspace/python-env/vault/bin/python3"
+export PYTHONPATH="${SCRIPT_DIR}/../scripts"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+RESTORE_ROOT="${TMP_DIR}/restored"
+MIGRATION_BASE="${TMP_DIR}/migration"
+MIGRATION_ROOT="${MIGRATION_BASE}/_knowledge"
+FAKE_BIN="${TMP_DIR}/bin"
+XURL_LOG="${TMP_DIR}/xurl.log"
+ARCHIVE="${TMP_DIR}/archive.json"
+POST_BODY="${TMP_DIR}/post.txt"
+REPLY_BODY="${TMP_DIR}/reply.txt"
+OPTION_BODY="${TMP_DIR}/option.txt"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == *"$expected"* ]]; then
+		assert_eq "$description" "present" "present"
+	else
+		assert_eq "$description" "absent" "present"
+	fi
+	return 0
+}
+
+assert_absent() {
+	local description="$1"
+	local actual="$2"
+	local forbidden="$3"
+	if [[ "$actual" == *"$forbidden"* ]]; then
+		assert_eq "$description" "present" "absent"
+	else
+		assert_eq "$description" "absent" "absent"
+	fi
+	return 0
+}
+
+expect_failure() {
+	local description="$1"
+	local expected="$2"
+	shift 2
+	local output=""
+	if output=$("$@" 2>&1); then
+		assert_eq "$description" "accepted" "rejected"
+	else
+		assert_contains "$description" "$output" "$expected"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local database="$1"
+	local query="$2"
+	python3 - "$database" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+log_count() {
+	local needle="$1"
+	python3 - "$XURL_LOG" "$needle" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+print(sum(sys.argv[2] in line for line in lines))
+PY
+	return 0
+}
+
+create_and_approve() {
+	local operation_id="$1"
+	local action="$2"
+	local target_id="$3"
+	local body_file="$4"
+	local arguments=(
+		operation-create --base "$BASE" --connection-id conn_ops
+		--account-id acct42 --action "$action" --scheduled-at 1000
+		--operation-id "$operation_id" --app fixture-app --username fixture-user
+		--now-epoch 1000
+	)
+	if [[ "$target_id" != "none" ]]; then
+		arguments+=(--target-id "$target_id")
+	fi
+	if [[ "$body_file" != "none" ]]; then
+		arguments+=(--body-file "$body_file")
+	fi
+	"$HELPER" "${arguments[@]}" >/dev/null
+	"$HELPER" operation-approve --base "$BASE" --operation-id "$operation_id" \
+		--expires-at 2000 --now-epoch 1000 >/dev/null
+	return 0
+}
+
+mkdir -p "$ROOT" "$FAKE_BIN" "$RESTORE_ROOT" "$MIGRATION_ROOT"
+chmod 0700 "$BASE" "$ROOT" "$FAKE_BIN" "$RESTORE_ROOT" \
+	"$MIGRATION_BASE" "$MIGRATION_ROOT"
+: >"$XURL_LOG"
+chmod 0600 "$XURL_LOG"
+
+cat >"${FAKE_BIN}/xurl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${XURL_LOG:?}"
+case " $* " in
+*" whoami "*)
+	if [[ "${XURL_MODE:-success}" == "identity-mismatch" ]]; then
+		printf '%s\n' '{"data":{"id":"acct_other"}}'
+	else
+		printf '%s\n' '{"data":{"id":"acct42"}}'
+	fi
+	exit 0
+	;;
+esac
+if [[ -n "${XURL_DELAY:-}" ]]; then
+	sleep "$XURL_DELAY"
+fi
+case "${XURL_MODE:-success}" in
+write-fail)
+	printf '%s\n' '{"status":503}'
+	exit 1
+	;;
+invalid-output)
+	printf '%s\n' 'not-json'
+	exit 0
+	;;
+status-error)
+	printf '%s\n' '{"status":403}'
+	exit 0
+	;;
+*)
+	printf '%s\n' '{"data":{"id":"post_created_001"}}'
+	exit 0
+	;;
+esac
+FAKE
+chmod 0700 "${FAKE_BIN}/xurl"
+export XURL_LOG
+export PATH="${FAKE_BIN}:${PATH}"
+
+cat >"$ARCHIVE" <<'JSON'
+{
+  "provider": "xapi",
+  "connection_id": "conn_ops",
+  "remote_account_id": "acct42",
+  "exported_at": "2026-07-25T12:00:00Z",
+  "enabled_streams": ["mentions"],
+  "policy": {},
+  "accounts": [
+    {"remote_id":"acct42","observed_at":"2026-07-25T12:00:00Z"},
+    {"remote_id":"acct_other","observed_at":"2026-07-25T12:00:00Z"}
+  ],
+  "objects": [
+    {
+      "object_type":"post","remote_id":"post_mention_001",
+      "account_remote_id":"acct_other","text":"mention fixture marker",
+      "observed_at":"2026-07-25T12:00:00Z","evidence_class":"observed",
+      "provider_json":{}
+    },
+    {
+      "object_type":"post","remote_id":"post_reply_001",
+      "account_remote_id":"acct_other","text":"reply fixture marker",
+      "observed_at":"2026-07-25T12:01:00Z","evidence_class":"observed",
+      "provider_json":{"referenced_tweets":[{"type":"replied_to","id":"post_parent_001"}]}
+    }
+  ],
+  "activities": [
+    {
+      "activity_type":"mentions","remote_id":"activity_mention_001",
+      "actor_remote_id":"acct_other","object_remote_id":"post_mention_001",
+      "observed_at":"2026-07-25T12:00:00Z","state":"active"
+    },
+    {
+      "activity_type":"mentions","remote_id":"activity_reply_001",
+      "actor_remote_id":"acct_other","object_remote_id":"post_reply_001",
+      "observed_at":"2026-07-25T12:01:00Z","state":"active"
+    }
+  ],
+  "media": [],
+  "coverage": []
+}
+JSON
+printf '%s\n' 'private post fixture marker' >"$POST_BODY"
+printf '%s\n' 'private reply fixture marker' >"$REPLY_BODY"
+printf '%s' '--app' >"$OPTION_BODY"
+chmod 0600 "$ARCHIVE" "$POST_BODY" "$REPLY_BODY" "$OPTION_BODY"
+
+printf 'Approval-bound social operations tests\n'
+"$CORPUS_HELPER" provision --base "$MIGRATION_BASE" >/dev/null
+"$HELPER" provision --base "$MIGRATION_BASE" >/dev/null
+python3 - "$MIGRATION_ROOT/index/social.db" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as database:
+    database.execute("DROP TABLE notification_state")
+    database.execute("DROP TABLE outbound_attempts")
+    database.execute("DROP TABLE outbound_approvals")
+    database.execute("DROP TABLE outbound_operations")
+    database.execute("DELETE FROM schema_meta WHERE version=3")
+    database.execute("PRAGMA user_version=2")
+PY
+"$HELPER" provision --base "$MIGRATION_BASE" >/dev/null
+assert_eq "schema v2 migrates additively to all local operation tables" \
+	"$(sql_value "$MIGRATION_ROOT/index/social.db" "SELECT (SELECT user_version FROM pragma_user_version) || ':' || count(*) FROM sqlite_master WHERE name IN ('outbound_operations','outbound_approvals','outbound_attempts','notification_state')")" \
+	"3:4"
+
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" import-archive --base "$BASE" --archive "$ARCHIVE" >/dev/null
+
+create_result=$("$HELPER" operation-create --base "$BASE" \
+	--connection-id conn_ops --account-id acct42 --action post \
+	--body-file "$POST_BODY" --scheduled-at 1000 --operation-id op_post_001 \
+	--app fixture-app --username fixture-user --now-epoch 1000)
+assert_eq "draft creation returns no private body" \
+	"$([[ "$create_result" == *"private post"* ]] && printf leaked || printf private)" "private"
+assert_eq "draft creation records the approved action" \
+	"$(json_field "$create_result" action)" "post"
+
+duplicate_result=$("$HELPER" operation-create --base "$BASE" \
+	--connection-id conn_ops --account-id acct42 --action post \
+	--body-file "$POST_BODY" --scheduled-at 1000 --operation-id op_post_001 \
+	--app fixture-app --username fixture-user --now-epoch 1000)
+assert_eq "matching operation IDs recover idempotently" \
+	"$(json_field "$duplicate_result" state)" "draft"
+printf '%s\n' 'substituted fixture body' >"$POST_BODY"
+expect_failure "operation IDs reject payload substitution" "another intent" \
+	"$HELPER" operation-create --base "$BASE" --connection-id conn_ops \
+	--account-id acct42 --action post --body-file "$POST_BODY" --scheduled-at 1000 \
+	--operation-id op_post_001 --app fixture-app --username fixture-user --now-epoch 1000
+printf '%s\n' 'private post fixture marker' >"$POST_BODY"
+
+"$HELPER" operation-approve --base "$BASE" --operation-id op_post_001 \
+	--expires-at 2000 --now-epoch 1000 >/dev/null
+"$HELPER" operation-approve --base "$BASE" --operation-id op_post_001 \
+	--expires-at 1500 --now-epoch 1100 >/dev/null
+assert_eq "reapproval replaces authority with the exact requested expiry" \
+	"$(sql_value "$ROOT/index/social.db" "SELECT count(*) || ':' || max(expires_at) FROM outbound_approvals WHERE operation_id='op_post_001' AND revoked_at IS NULL")" \
+	"1:1500"
+
+post_result=$("$HELPER" operation-run --base "$BASE" --operation-id op_post_001 \
+	--executor-id exe_post_001 --claim-seconds 300 --now-epoch 1200)
+assert_eq "approved immediate posts reach one successful receipt" \
+	"$(json_field "$post_result" state)" "succeeded"
+assert_absent "post receipts omit private text" "$post_result" "private post fixture marker"
+assert_absent "post receipts omit local profile selectors" "$post_result" "fixture-app"
+assert_eq "provider start is durable before success" \
+	"$(sql_value "$ROOT/index/social.db" "SELECT count(*) FROM outbound_attempts WHERE operation_id='op_post_001' AND provider_started_at IS NOT NULL AND status='succeeded'")" "1"
+assert_eq "post executes once through the mapped helper" \
+	"$(log_count ' post private post fixture marker')" "1"
+
+create_and_approve op_option_body post none "$OPTION_BODY"
+option_result=$("$HELPER" operation-run --base "$BASE" \
+	--operation-id op_option_body --executor-id exe_option_body --now-epoch 1200)
+assert_eq "option-shaped body text cannot alter approved profile selection" \
+	"$(json_field "$option_result" state)" "succeeded"
+assert_eq "option-shaped body reaches xurl as post content" \
+	"$(log_count ' post --app')" "1"
+
+create_and_approve op_reply_001 reply post_target_001 "$REPLY_BODY"
+create_and_approve op_like_001 like post_target_002 none
+create_and_approve op_bookmark_001 bookmark post_target_003 none
+due_result=$("$HELPER" operations-run-due --base "$BASE" --executor-id exe_due_001 \
+	--limit 10 --claim-seconds 300 --now-epoch 1200)
+assert_eq "reply, like, and bookmark share one due queue" \
+	"$(python3 -c 'import json,sys; print(len(json.loads(sys.argv[1])["results"]))' "$due_result")" "3"
+assert_eq "all mapped due actions succeed" \
+	"$(python3 -c 'import json,sys; print(all(row["state"] == "succeeded" for row in json.loads(sys.argv[1])["results"]))' "$due_result")" "True"
+assert_eq "reply mapping preserves target and private body" \
+	"$(log_count ' reply post_target_001 private reply fixture marker')" "1"
+assert_eq "like mapping executes once" "$(log_count ' like post_target_002')" "1"
+assert_eq "bookmark mapping executes once" "$(log_count ' bookmark post_target_003')" "1"
+
+create_and_approve op_identity_001 like post_target_004 none
+identity_result=$(XURL_MODE=identity-mismatch "$HELPER" operation-run --base "$BASE" \
+	--operation-id op_identity_001 --executor-id exe_identity_001 --now-epoch 1200)
+assert_eq "identity mismatch is terminal before provider execution" \
+	"$(json_field "$identity_result" state):$(json_field "$identity_result" failure_class)" \
+	"failed:identity"
+assert_eq "identity mismatch performs no like" "$(log_count ' like post_target_004')" "0"
+
+create_and_approve op_unknown_001 like post_target_005 none
+unknown_result=$(XURL_MODE=write-fail "$HELPER" operation-run --base "$BASE" \
+	--operation-id op_unknown_001 --executor-id exe_unknown_001 --now-epoch 1200)
+assert_eq "post-invocation non-zero outcomes are ambiguous" \
+	"$(json_field "$unknown_result" state)" "unknown"
+unknown_writes=$(log_count ' like post_target_005')
+expect_failure "unknown outcomes cannot be blindly rerun" "not due and approved" \
+	"$HELPER" operation-run --base "$BASE" --operation-id op_unknown_001 \
+	--executor-id exe_unknown_002 --now-epoch 1300
+assert_eq "blocked retry makes no second provider write" \
+	"$(log_count ' like post_target_005')" "$unknown_writes"
+reconciled=$("$HELPER" operation-reconcile --base "$BASE" \
+	--operation-id op_unknown_001 --outcome not-sent --now-epoch 1300)
+assert_eq "unknown outcomes require explicit reconciliation" \
+	"$(json_field "$reconciled" state)" "failed"
+
+create_and_approve op_status_001 like post_target_status none
+status_result=$(XURL_MODE=status-error "$HELPER" operation-run --base "$BASE" \
+	--operation-id op_status_001 --executor-id exe_status_001 --now-epoch 1200)
+assert_eq "provider error JSON cannot masquerade as engagement success" \
+	"$(json_field "$status_result" state)" "unknown"
+
+create_and_approve op_cancel_001 bookmark post_target_006 none
+"$HELPER" operation-revoke --base "$BASE" --operation-id op_cancel_001 \
+	--now-epoch 1100 >/dev/null
+assert_eq "revocation returns approved work to a non-due draft" \
+	"$(sql_value "$ROOT/index/social.db" "SELECT state FROM outbound_operations WHERE operation_id='op_cancel_001'")" "draft"
+"$HELPER" operation-cancel --base "$BASE" --operation-id op_cancel_001 \
+	--now-epoch 1200 >/dev/null
+assert_eq "cancelled work remains terminal without an attempt" \
+	"$(sql_value "$ROOT/index/social.db" "SELECT state || ':' || (SELECT count(*) FROM outbound_attempts WHERE operation_id='op_cancel_001') FROM outbound_operations WHERE operation_id='op_cancel_001'")" \
+	"cancelled:0"
+
+python3 - "$BASE" "$ROOT" <<'PY'
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+from _knowledge_social_outbound import (
+    approve_operation,
+    claim_operation,
+    create_operation,
+    due_operation_ids,
+    expire_claims,
+    finalize_operation,
+    mark_provider_started,
+)
+from knowledge_social_store import SocialStoreError, connect, migrate
+
+base = Path(sys.argv[1])
+root = Path(sys.argv[2])
+principal = json.loads((base / "_config" / "principal.json").read_text())["principal_id"]
+database = connect(root)
+migrate(database)
+
+
+def rejected(callback):
+    try:
+        callback()
+    except (SocialStoreError, sqlite3.IntegrityError):
+        return
+    raise AssertionError("unsafe outbound state mutation was accepted")
+
+
+tampering = (
+    ("payload", "changed body"),
+    ("connection_id", "conn_other"),
+    ("remote_account_id", "acct_other"),
+    ("target_remote_id", "post_changed_001"),
+    ("app_profile", "changed-profile"),
+    ("username", "changed-user"),
+    ("scheduled_at", 999),
+)
+for index, (field, value) in enumerate(tampering):
+    operation_id = f"op_tamper_{index:03d}"
+    create_operation(
+        database,
+        connection_id="conn_ops",
+        remote_account_id="acct42",
+        action="reply",
+        target_remote_id="post_original_001",
+        payload="bound fixture body",
+        app_profile="fixture-app",
+        username="fixture-user",
+        scheduled_at=1000,
+        created_by=principal,
+        operation_id=operation_id,
+        created_at=1000,
+    )
+    approve_operation(database, operation_id, principal, 2000, approved_at=1000)
+    database.execute(f"UPDATE outbound_operations SET {field}=? WHERE operation_id=?", (value, operation_id))
+    rejected(lambda: due_operation_ids(database, principal, 1200, 100))
+    database.execute(
+        "UPDATE outbound_operations SET state='cancelled' WHERE operation_id=?",
+        (operation_id,),
+    )
+
+create_operation(
+    database,
+    connection_id="conn_ops",
+    remote_account_id="acct42",
+    action="like",
+    target_remote_id="post_action_001",
+    payload=None,
+    app_profile=None,
+    username=None,
+    scheduled_at=1000,
+    created_by=principal,
+    operation_id="op_tamper_action",
+    created_at=1000,
+)
+approve_operation(database, "op_tamper_action", principal, 2000, approved_at=1000)
+database.execute("UPDATE outbound_operations SET action='bookmark' WHERE operation_id='op_tamper_action'")
+rejected(lambda: due_operation_ids(database, principal, 1200, 100))
+database.execute(
+    "UPDATE outbound_operations SET state='cancelled' WHERE operation_id='op_tamper_action'"
+)
+
+create_operation(
+    database,
+    connection_id="conn_ops",
+    remote_account_id="acct42",
+    action="like",
+    target_remote_id="post_approval_expired",
+    payload=None,
+    app_profile=None,
+    username=None,
+    scheduled_at=1000,
+    created_by=principal,
+    operation_id="op_approval_expired",
+    created_at=1000,
+)
+approve_operation(database, "op_approval_expired", principal, 1100, approved_at=1000)
+assert due_operation_ids(database, principal, 1100, 100) == []
+rejected(
+    lambda: claim_operation(
+        database, "op_approval_expired", principal, "exe_approval_expired", 1100, 300
+    )
+)
+
+create_operation(
+    database,
+    connection_id="conn_ops",
+    remote_account_id="acct42",
+    action="like",
+    target_remote_id="post_boundary_expired",
+    payload=None,
+    app_profile=None,
+    username=None,
+    scheduled_at=1000,
+    created_by=principal,
+    operation_id="op_boundary_expired",
+    created_at=1000,
+)
+approve_operation(database, "op_boundary_expired", principal, 1101, approved_at=1000)
+boundary = claim_operation(
+    database, "op_boundary_expired", principal, "exe_boundary", 1100, 300
+)
+rejected(
+    lambda: mark_provider_started(database, boundary, "exe_boundary", started_at=1101)
+)
+finalize_operation(
+    database,
+    boundary,
+    "exe_boundary",
+    "failed",
+    failure_class="authorization",
+    finished_at=1101,
+)
+
+create_operation(
+    database,
+    connection_id="conn_ops",
+    remote_account_id="acct42",
+    action="like",
+    target_remote_id="post_expired_claim",
+    payload=None,
+    app_profile=None,
+    username=None,
+    scheduled_at=1000,
+    created_by=principal,
+    operation_id="op_expired_claim",
+    created_at=1000,
+)
+approve_operation(database, "op_expired_claim", principal, 2000, approved_at=1000)
+claimed = claim_operation(database, "op_expired_claim", principal, "exe_expired", 1100, 1)
+assert expire_claims(database, principal, 1101, 10) == ["op_expired_claim"]
+rejected(
+    lambda: finalize_operation(
+        database,
+        claimed,
+        "exe_expired",
+        "failed",
+        failure_class="runtime",
+        finished_at=1102,
+    )
+)
+
+create_operation(
+    database,
+    connection_id="conn_ops",
+    remote_account_id="acct42",
+    action="like",
+    target_remote_id="post_started_001",
+    payload=None,
+    app_profile=None,
+    username=None,
+    scheduled_at=1000,
+    created_by=principal,
+    operation_id="op_started_001",
+    created_at=1000,
+)
+approve_operation(database, "op_started_001", principal, 2000, approved_at=1000)
+started = claim_operation(database, "op_started_001", principal, "exe_started", 1100, 300)
+mark_provider_started(database, started, "exe_started", started_at=1101)
+rejected(
+    lambda: finalize_operation(
+        database,
+        started,
+        "exe_started",
+        "failed",
+        failure_class="runtime",
+        finished_at=1102,
+    )
+)
+finalize_operation(
+    database,
+    started,
+    "exe_started",
+    "unknown",
+    failure_class="provider_unavailable",
+    finished_at=1102,
+)
+database.close()
+PY
+assert_eq "tampering, fencing, and ambiguous-outcome state checks pass" "verified" "verified"
+
+create_and_approve op_race_001 like post_target_race none
+race_before=$(log_count ' like post_target_race')
+set +e
+XURL_DELAY=1 "$HELPER" operation-run --base "$BASE" --operation-id op_race_001 \
+	--executor-id exe_race_a --now-epoch 1200 >"${TMP_DIR}/race-a.out" 2>&1 &
+race_a=$!
+XURL_DELAY=1 "$HELPER" operation-run --base "$BASE" --operation-id op_race_001 \
+	--executor-id exe_race_b --now-epoch 1200 >"${TMP_DIR}/race-b.out" 2>&1 &
+race_b=$!
+wait "$race_a"
+race_a_status=$?
+wait "$race_b"
+race_b_status=$?
+set -e
+race_after=$(log_count ' like post_target_race')
+assert_eq "concurrent runners make at most one provider attempt" \
+	"$((race_after - race_before))" "1"
+assert_eq "exactly one concurrent runner owns the claim" \
+	"$((race_a_status + race_b_status > 0 ? 1 : 0))" "1"
+
+refresh_result=$("$HELPER" notifications-refresh --base "$BASE" --now-epoch 1200)
+assert_eq "mention/reply projection creates two notifications" \
+	"$(json_field "$refresh_result" inserted)" "2"
+second_refresh=$("$HELPER" notifications-refresh --base "$BASE" --now-epoch 1300)
+assert_eq "notification projection is idempotent" \
+	"$(json_field "$second_refresh" inserted)" "0"
+notifications=$("$HELPER" notifications-list --base "$BASE")
+assert_eq "notification kinds distinguish mentions and replies" \
+	"$(python3 -c 'import json,sys; print(",".join(sorted(row["kind"] for row in json.loads(sys.argv[1]))))' "$notifications")" \
+	"mention,reply"
+assert_absent "notification listings omit private content" "$notifications" "fixture marker"
+assert_absent "notification listings omit actor IDs" "$notifications" "acct_other"
+notification_id=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])[0]["notification_id"])' "$notifications")
+"$HELPER" notification-set --base "$BASE" --notification-id "$notification_id" \
+	--status seen --now-epoch 1300 >/dev/null
+"$HELPER" notification-set --base "$BASE" --notification-id "$notification_id" \
+	--status responded --now-epoch 1301 >/dev/null
+"$HELPER" notifications-refresh --base "$BASE" --now-epoch 1400 >/dev/null
+assert_eq "evidence refresh preserves explicit workflow state" \
+	"$(sql_value "$ROOT/index/social.db" "SELECT status FROM notification_state WHERE notification_id='${notification_id}'")" \
+	"responded"
+expect_failure "invalid notification regressions fail closed" "transition is not allowed" \
+	"$HELPER" notification-set --base "$BASE" --notification-id "$notification_id" \
+	--status seen --now-epoch 1401
+
+python3 - "$BASE/catalog.db" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    connection.execute(
+        "UPDATE corpus_grants SET status='inactive' WHERE capability='knowledge.manage'"
+    )
+PY
+expect_failure "ordinary write authority cannot manage shared-account operations" \
+	"access denied" "$HELPER" operations-list --base "$BASE"
+python3 - "$BASE/catalog.db" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    connection.execute(
+        "UPDATE corpus_grants SET status='active' WHERE capability='knowledge.manage'"
+    )
+PY
+
+if [[ ! -x "$VAULT_PYTHON" ]]; then
+	printf 'FAIL: managed Vault Python is unavailable: %s\n' "$VAULT_PYTHON" >&2
+	exit 1
+fi
+"$VAULT_PYTHON" - "$ROOT" "$RESTORE_ROOT" <<'PY'
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+from _knowledge_social_notifications import project_notifications, set_notification_status
+from _knowledge_social_outbound import create_operation
+from _knowledge_social_share_data import (
+    LOCAL_ONLY_TABLES,
+    TABLE_COLUMNS,
+    build_snapshot,
+    restore_snapshot,
+)
+from knowledge_social_store import connect, migrate
+
+root = Path(sys.argv[1]).resolve()
+restore_root = Path(sys.argv[2]).resolve()
+local_only = LOCAL_ONLY_TABLES
+assert local_only.isdisjoint(TABLE_COLUMNS)
+database = sqlite3.connect(root / "index" / "social.db")
+try:
+    database.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+finally:
+    database.close()
+workspace_id = "wsp_00000000000000000000000000000001"
+corpus_id = "cor_00000000000000000000000000000001"
+snapshot = build_snapshot(root, workspace_id, corpus_id)
+serialized = json.dumps(snapshot, sort_keys=True)
+assert "private post fixture marker" not in serialized
+assert "fixture-app" not in serialized
+assert local_only.isdisjoint(snapshot["tables"])
+
+restore_snapshot(restore_root, snapshot, workspace_id, corpus_id)
+database = connect(restore_root)
+migrate(database)
+create_operation(
+    database,
+    connection_id="conn_ops",
+    remote_account_id="acct42",
+    action="like",
+    target_remote_id="post_local_only",
+    payload=None,
+    app_profile="local-profile",
+    username=None,
+    scheduled_at=1000,
+    created_by="prn_local_owner",
+    operation_id="op_local_only",
+    created_at=1000,
+)
+project_notifications(database, "prn_local_owner", projected_at=1000)
+notification = database.execute(
+    "SELECT notification_id FROM notification_state ORDER BY notification_id LIMIT 1"
+).fetchone()[0]
+set_notification_status(
+    database,
+    "prn_local_owner",
+    notification,
+    "responded",
+    updated_at=1001,
+)
+database.close()
+restore_snapshot(restore_root, snapshot, workspace_id, corpus_id)
+with sqlite3.connect(restore_root / "index" / "social.db") as database:
+    assert database.execute("SELECT count(*) FROM outbound_operations").fetchone()[0] == 1
+    assert database.execute(
+        "SELECT status FROM notification_state WHERE notification_id=?", (notification,)
+    ).fetchone()[0] == "responded"
+PY
+assert_eq "sharing excludes and restore preserves owner-local operational state" \
+	"verified" "verified"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/tests/test-knowledge-social-sync.sh
+++ b/.agents/tests/test-knowledge-social-sync.sh
@@ -64,7 +64,7 @@ chmod 0700 "$BASE" "$ROOT"
 "$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
 
 printf 'Social sync routine tests\n'
-assert_eq "Phase 5 schema is active" "$(sql_value 'PRAGMA user_version')" "2"
+assert_eq "current schema is active" "$(sql_value 'PRAGMA user_version')" "3"
 assert_eq "lease and reconciliation tables are provisioned" \
 	"$(sql_value "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('collector_lease_generations','collector_leases','reconciliation_items')")" \
 	"3"
@@ -474,8 +474,8 @@ from knowledge_social_store import connect, migrate
 database = connect(root)
 migrate(database)
 columns = {row[1] for row in database.execute("PRAGMA table_info(sync_runs)")}
-if database.execute("PRAGMA user_version").fetchone()[0] != 2:
-    raise SystemExit("v1 database did not migrate to v2")
+if database.execute("PRAGMA user_version").fetchone()[0] != 3:
+    raise SystemExit("v1 database did not migrate to the current schema")
 required = {
     "stream",
     "run_kind",
@@ -498,7 +498,7 @@ print(connection.execute("PRAGMA user_version").fetchone()[0])
 connection.close()
 PY
 )
-assert_eq "existing v1 stores migrate without replacement" "$migration_version" "2"
+assert_eq "existing v1 stores migrate without replacement" "$migration_version" "3"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/tests/test-knowledge-social.sh
+++ b/.agents/tests/test-knowledge-social.sh
@@ -94,8 +94,8 @@ mkdir -p "$CORPUS_ROOT"
 chmod 0700 "$BASE" "$CORPUS_ROOT"
 "$CORPUS_HELPER" provision --base "$BASE" >/dev/null
 "$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
-assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "2"
-assert_eq "all provider-neutral tables exist" "$(sql_value "SELECT count(*) FROM sqlite_master WHERE name IN ('connections','accounts','objects','activities','media','fetch_batches','sync_cursors','sync_runs','tombstones','annotations','coverage_records','objects_fts')")" "12"
+assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "3"
+assert_eq "all provider-neutral and local-operation tables exist" "$(sql_value "SELECT count(*) FROM sqlite_master WHERE name IN ('connections','accounts','objects','activities','media','fetch_batches','sync_cursors','sync_runs','tombstones','annotations','coverage_records','objects_fts','outbound_operations','outbound_approvals','outbound_attempts','notification_state')")" "16"
 
 first_result=$("$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$ARCHIVE")
 first_hash=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["batch_id"])' "$first_result")
@@ -219,7 +219,7 @@ python3 - "$CORPUS_ROOT/index/social.db" <<'PY'
 import sqlite3
 import sys
 connection = sqlite3.connect(sys.argv[1])
-connection.execute("PRAGMA user_version=2")
+connection.execute("PRAGMA user_version=3")
 connection.close()
 PY
 

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ See `.agents/tools/terminal/terminal-title.md` for customization options.
 
 - **SimpleX bot** - Channel-agnostic gateway with SimpleX Chat as first adapter for AI agent dispatch (`simplex-bot/`)
 - **Matterbridge** - Multi-platform chat bridge connecting 20+ platforms including Matrix, Discord, Telegram, Slack, IRC, WhatsApp, XMPP (`matterbridge-helper.sh`)
-- **X API via xurl** - Official X/Twitter API operations through guarded `xurl` workflows for search, timelines, bookmarks, posting, replies, DMs, media, and raw API reads. Supports multiple X developer apps/subscription tiers with `--app` and multiple authenticated accounts with `--username`; model-provider auth such as OpenCode xAI/Grok remains separate from X API OAuth (`content/social-xurl.md`, `xurl-helper.sh`)
+- **X API via xurl** - Official X/Twitter API operations through guarded `xurl` workflows for search, timelines, bookmarks, posting, replies, DMs, media, and raw API reads, plus an owner-only approval-bound queue for immediate/scheduled shared-account posts, replies, likes, bookmarks, receipts, and mention/reply workflow state. Supports multiple X developer apps/subscription tiers with `--app` and multiple authenticated accounts with `--username`; model-provider auth such as OpenCode xAI/Grok remains separate from X API OAuth (`content/social-xurl.md`, `knowledge-social-helper.sh`, `xurl-helper.sh`)
 - **Localdev** - Local development environment manager with dnsmasq, Traefik, mkcert for production-like `.local` domains with HTTPS (`localdev-helper.sh`)
 
 **MCP Toolkit:**

--- a/TODO.md
+++ b/TODO.md
@@ -1204,6 +1204,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18176 Plan secure personal and shared social knowledge corpora #parent-task #enhancement #framework #knowledge #security ~23h tier:thinking ref:GH#28587 logged:2026-07-25 -> [todo/tasks/t18176-brief.md]
 
+- [ ] t18177 Add approval-bound shared X scheduling and notification operations #feat #framework #knowledge #security ~8h tier:thinking ref:GH#28627 -> [todo/tasks/t18177-brief.md]
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/todo/tasks/t18177-brief.md
+++ b/todo/tasks/t18177-brief.md
@@ -82,7 +82,10 @@ ambiguous outcomes, and must preserve encrypted-sharing and read-only boundaries
 ### Files to Modify
 
 - `EDIT: .agents/scripts/knowledge_social_store.py` — additive schema migration.
-- `NEW: .agents/scripts/_knowledge_social_outbound.py` — canonical intent, approvals, claims, attempts, and transitions.
+- `NEW: .agents/scripts/_knowledge_social_outbound.py` — canonical intent and approval state.
+- `NEW: .agents/scripts/_knowledge_social_outbound_runtime.py` — fenced claims, attempts, receipts, and lease expiry.
+- `NEW: .agents/scripts/_knowledge_social_outbound_reconciliation.py` — explicit unknown-outcome reconciliation and privacy-safe history.
+- `NEW: .agents/scripts/_knowledge_social_outbound_provider.py` — fixed-argv X write mapping and response validation.
 - `NEW: .agents/scripts/_knowledge_social_notifications.py` — idempotent notification projection and state changes.
 - `NEW: .agents/scripts/knowledge_social_operations.py` — authenticated CLI and mapped X executor.
 - `EDIT: .agents/scripts/knowledge-social-helper.sh` — operator command dispatch.
@@ -93,12 +96,12 @@ ambiguous outcomes, and must preserve encrypted-sharing and read-only boundaries
 ### Complete Write Surface
 
 - **Callers/readers:** `knowledge-social-helper.sh`, authenticated corpus catalog, private scheduler/routine invocation, `xurl-helper.sh`, operators reading due work/receipts/notifications, and sharing export/import.
-- **Writers/mutation paths:** `.agents/scripts/knowledge_social_operations.py` owns create/approve/cancel, one atomic due executor, operation reconciliation, notification projection, and per-principal notification transitions.
+- **Writers/mutation paths:** `.agents/scripts/knowledge_social_operations.py` dispatches create/approve/cancel, one atomic due executor, operation reconciliation, notification projection, and per-principal notification transitions through the split outbound state modules.
 - **Tests/fixtures:** new fake-`xurl` runtime suite plus existing corpus, X, sync, query, sharing, and browser suites.
 - **Schemas/config:** additive per-corpus `social.db` migration; local app/profile selection is private and excluded from transport. No credentials are stored.
 - **Generated/deployed mirrors:** `.agents/` remains the setup source; no top-level path or independent deployed mirror is added.
 - **Migrations/backfills:** schema migration creates empty operational tables. Existing mention evidence is projected idempotently on explicit refresh; no provider backfill is triggered automatically.
-- **Cleanup/rollback paths:** `.agents/scripts/_knowledge_social_outbound.py` uses monotonic tokens, terminal attempts, explicit cancellation, and unknown-outcome reconciliation; it never auto-retries.
+- **Cleanup/rollback paths:** `_knowledge_social_outbound_runtime.py` and `_knowledge_social_outbound_reconciliation.py` use monotonic tokens, terminal attempts, explicit cancellation, and unknown-outcome reconciliation; they never auto-retry.
 
 ### Implementation Steps
 
@@ -131,7 +134,7 @@ bash .agents/tests/test-knowledge-social-query.sh
 bash .agents/tests/test-knowledge-social-sharing.sh
 bash .agents/tests/test-knowledge-social-browser.sh
 shellcheck .agents/scripts/knowledge-social-helper.sh .agents/scripts/xurl-helper.sh
-python3 -m py_compile .agents/scripts/knowledge_social_store.py .agents/scripts/knowledge_social_operations.py .agents/scripts/_knowledge_social_outbound.py .agents/scripts/_knowledge_social_notifications.py
+python3 -m py_compile .agents/scripts/knowledge_social_store.py .agents/scripts/knowledge_social_operations.py .agents/scripts/_knowledge_social_outbound.py .agents/scripts/_knowledge_social_outbound_runtime.py .agents/scripts/_knowledge_social_outbound_reconciliation.py .agents/scripts/_knowledge_social_outbound_provider.py .agents/scripts/_knowledge_social_notifications.py
 .agents/scripts/linters-local.sh --changed
 ```
 

--- a/todo/tasks/t18177-brief.md
+++ b/todo/tasks/t18177-brief.md
@@ -1,0 +1,207 @@
+---
+mode: subagent
+---
+
+<!-- aidevops:brief-schema=v2 -->
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t18177: Add approval-bound shared X scheduling and notification operations
+
+## Pre-flight
+
+- [x] Memory recall: `X shared account scheduled posts notifications outbound queue approval idempotency xurl social operations` → 0 hits.
+- [x] Discovery: no related open issue or PR; recent social corpus phases and PR #28621 reviewed.
+- [x] File refs verified against current `origin/main` in the linked worktree.
+- [x] Installed dependency check: `xurl` is not installed; fake-executable runtime tests are required and live X verification remains credential-gated.
+- [x] Tier: `tier:thinking` — security-sensitive state machine, scheduler, provider writes, migration, and cross-surface tests.
+
+## Origin
+
+- **Created:** 2026-07-25
+- **Session:** OpenCode interactive follow-up to t18176
+- **Created by:** ai-interactive
+- **Parent task:** none
+- **Blocked by:** no implementation blocker; live provider verification requires a separately configured `xurl` installation/profile.
+- **Conversation context:** The user requested shared-account storage plus posting, scheduled publishing, notification tracking, likes, bookmarks, and replies.
+
+## What
+
+Add a provider-neutral outbound operations layer for owner-managed personal or
+workspace corpora, with X as the first execution adapter. Support immediate and
+scheduled `post`, `reply`, `like`, and `bookmark` actions through one durable,
+approval-bound queue. Project inbound mentions/replies into a mutable local
+notification workflow without changing immutable social evidence.
+
+The outbound subsystem remains separate from the API/archive/browser knowledge
+collector, whose provider contract stays read-only.
+
+## Why
+
+`xurl-helper.sh` can execute individual writes after `--confirm-write`, but that
+boolean is not bound to a durable payload, account, target, approver, or expiry.
+The content calendar records dates without publishing, and mention activities
+have no unread/action-required/responded lifecycle. Directly joining these
+surfaces would permit approval substitution, duplicate writes after timeouts,
+competing schedulers, or shared-member access becoming posting authority.
+
+## Tier
+
+**Selected tier:** `tier:thinking`
+
+**Tier rationale:** The task creates a new security-sensitive state machine,
+migrates private SQLite stores, executes external writes, handles concurrency and
+ambiguous outcomes, and must preserve encrypted-sharing and read-only boundaries.
+
+## Seeded Draft PR
+
+- **Decision:** Skipped
+- **Rationale:** The queue/approval transition design must be verified with focused tests before any implementation is published.
+- **Status:** `not-created`
+- **Freshness evidence:** memory, duplicate, target history, file-reference, dependency, and implementation-map discovery completed on 2026-07-25.
+- **Verification run:** all seven social suites pass 247 tests; changed-file lint passes.
+- **Stale-assumption warning:** re-check `xurl-helper.sh`, social schema version, and sharing table allowlist after rebasing.
+
+## How (Approach)
+
+### Progressive Context Plan
+
+- **Read first:** `.agents/scripts/knowledge_social_store.py`, `.agents/scripts/xurl-helper.sh`, and `.agents/aidevops/knowledge-plane/05-social-operations.md`.
+- **Then load:** `_knowledge_social_share_data.py`, X persistence/normalization, catalog authorization, and the focused social tests.
+- **Load only if:** scheduler mechanics need a precedent — `deferred-job-helper.sh` and `reference/routines.md`.
+- **Why:** preserve collection/sharing invariants while keeping outbound state independently reviewable.
+- **Stop when:** all acceptance criteria have exact tests and the fake-X runtime proves mapped command arguments and identity binding.
+
+### Reference Patterns
+
+- `.agents/scripts/deferred-job-helper.sh:282-330` — versioned queued/claimed/running/terminal state shape.
+- `.agents/scripts/_knowledge_social_x_persist.py:237-284` — one transaction for lease assertion, durable state, cursor, and receipt.
+- `.agents/scripts/xurl-helper.sh:11-97` — mapped writes, forbidden secret flags, and explicit write confirmation.
+- `.agents/scripts/_knowledge_social_share_data.py:37-142` — explicit snapshot table allowlist that must continue excluding local operational state.
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/knowledge_social_store.py` — additive schema migration.
+- `NEW: .agents/scripts/_knowledge_social_outbound.py` — canonical intent, approvals, claims, attempts, and transitions.
+- `NEW: .agents/scripts/_knowledge_social_notifications.py` — idempotent notification projection and state changes.
+- `NEW: .agents/scripts/knowledge_social_operations.py` — authenticated CLI and mapped X executor.
+- `EDIT: .agents/scripts/knowledge-social-helper.sh` — operator command dispatch.
+- `EDIT: .agents/scripts/_knowledge_social_share_data.py` — explicit exclusion assertions/restore preservation.
+- `NEW: .agents/tests/test-knowledge-social-operations.sh` — positive and negative runtime fixtures.
+- `EDIT: .agents/content/social-xurl.md`, `.agents/aidevops/knowledge-plane/05-social-operations.md`, `README.md` — user/operator contract.
+
+### Complete Write Surface
+
+- **Callers/readers:** `knowledge-social-helper.sh`, authenticated corpus catalog, private scheduler/routine invocation, `xurl-helper.sh`, operators reading due work/receipts/notifications, and sharing export/import.
+- **Writers/mutation paths:** `.agents/scripts/knowledge_social_operations.py` owns create/approve/cancel, one atomic due executor, operation reconciliation, notification projection, and per-principal notification transitions.
+- **Tests/fixtures:** new fake-`xurl` runtime suite plus existing corpus, X, sync, query, sharing, and browser suites.
+- **Schemas/config:** additive per-corpus `social.db` migration; local app/profile selection is private and excluded from transport. No credentials are stored.
+- **Generated/deployed mirrors:** `.agents/` remains the setup source; no top-level path or independent deployed mirror is added.
+- **Migrations/backfills:** schema migration creates empty operational tables. Existing mention evidence is projected idempotently on explicit refresh; no provider backfill is triggered automatically.
+- **Cleanup/rollback paths:** `.agents/scripts/_knowledge_social_outbound.py` uses monotonic tokens, terminal attempts, explicit cancellation, and unknown-outcome reconciliation; it never auto-retries.
+
+### Implementation Steps
+
+1. Add operations, approvals, attempts, and notification state to schema v3.
+2. Canonicalize each intent and bind approval to operation/action/account/target/payload/profile/schedule digest, authenticated approver, and expiry.
+3. Make operation `scheduled_at` the only execution clock; the content calendar remains planning metadata.
+4. Resolve owner `knowledge.manage`, verify local X identity immediately before every write, and invoke mapped helper commands only.
+5. Claim due operations atomically; record one running attempt before provider execution and one privacy-safe terminal receipt afterward.
+6. Treat every post-write non-zero/transport failure as `unknown`; never blind-retry.
+7. Project mention activities into deduplicated mention/reply notifications and support unread, seen, action-required, responded, and dismissed transitions.
+8. Prove sharing excludes local operational state and read-only collection cannot call writes.
+
+### Hazards and Compatibility
+
+- **Concurrency/atomicity:** one `BEGIN IMMEDIATE` claim increments a fencing token; stale executors cannot finalize. Cancellation only succeeds before claim.
+- **Migration/rollback:** schema v3 is additive. Mixed-version writes fail closed; existing v2 data migrates without moving raw evidence.
+- **Mixed-version/backward compatibility:** existing archive/API/browser/query commands and corpus defaults remain unchanged.
+- **Idempotency/retry:** operation IDs and intent digests deduplicate local writes. Ambiguous external outcomes are terminal until operator reconciliation.
+- **Partial failure/recovery:** identity or authorization failure occurs before a provider attempt. Provider invocation failure preserves a durable unknown receipt and the original objective remains open.
+- **Privacy:** payloads stay in mode-0600 databases; public output contains opaque IDs/status only. Operational tables and local auth selectors never enter encrypted snapshots.
+
+### Verification Before Dispatch
+
+```bash
+bash .agents/tests/test-knowledge-social-operations.sh
+bash .agents/tests/test-knowledge-social.sh
+bash .agents/tests/test-knowledge-social-x.sh
+bash .agents/tests/test-knowledge-social-sync.sh
+bash .agents/tests/test-knowledge-social-query.sh
+bash .agents/tests/test-knowledge-social-sharing.sh
+bash .agents/tests/test-knowledge-social-browser.sh
+shellcheck .agents/scripts/knowledge-social-helper.sh .agents/scripts/xurl-helper.sh
+python3 -m py_compile .agents/scripts/knowledge_social_store.py .agents/scripts/knowledge_social_operations.py .agents/scripts/_knowledge_social_outbound.py .agents/scripts/_knowledge_social_notifications.py
+.agents/scripts/linters-local.sh --changed
+```
+
+- **Surface mapping:** focused operations tests cover the state machine/provider route; existing suites cover migration, read-only collection, sharing, query, and browser regressions.
+- **Broad verification trigger:** changed-file lint is required because the shell dispatch surface and user-facing docs change; full-repository lint is not required.
+
+### Recoverability Checkpoint
+
+- [x] Focused operation/schema tests pass.
+- [x] WIP task-tracking commit exists before implementation.
+- [x] Create a second WIP commit after focused runtime verification and before broad regression/lint gates.
+
+### Safety-Stop Recovery
+
+- **Original objective:** shared-account posting, scheduling, notifications, likes, bookmarks, and replies.
+- **Preserved user directions:** support every named X capability through a safe owner-managed operational path.
+- **Trigger and evidence:** not triggered.
+- **Completed and verified:** schema, exact approvals, mapped queue execution, notification workflow, sharing exclusions, docs, all seven social suites, and changed-file lint.
+- **Remaining acceptance criteria:** PR review and merge lifecycle.
+- **Unsafe route not to repeat:** no raw mutating API calls, caller-only confirmation booleans, competing scheduling clocks, or retries after unknown provider acceptance.
+- **Next safe route:** publish the verified branch for review, then merge without releasing.
+- **Resume condition:** linked worktree and issue #28627 remain active with a clean WIP checkpoint.
+- **Owner and status:** interactive primary session; in progress.
+
+### Files Scope
+
+- `TODO.md`
+- `todo/tasks/t18177-brief.md`
+- `.agents/scripts/knowledge_social_store.py`
+- `.agents/scripts/_knowledge_social_outbound.py`
+- `.agents/scripts/_knowledge_social_notifications.py`
+- `.agents/scripts/knowledge_social_operations.py`
+- `.agents/scripts/knowledge-social-helper.sh`
+- `.agents/scripts/_knowledge_social_share_data.py`
+- `.agents/tests/test-knowledge-social-operations.sh`
+- `.agents/tests/test-knowledge-social-sync.sh`
+- `.agents/content/social-xurl.md`
+- `.agents/aidevops/knowledge-plane/05-social-operations.md`
+- `README.md`
+
+## Acceptance Criteria
+
+- [x] Exact approval binding rejects payload/account/action/target/profile substitution, expiry, and revocation.
+- [x] Immediate and scheduled post, reply, like, and bookmark intents execute through one idempotent queue with privacy-safe receipts.
+- [x] Concurrent due runners make at most one provider attempt; stale claims, cancellation races, and ambiguous outcomes cannot duplicate a write.
+- [x] X identity mismatch or unavailable local profile fails before a provider write.
+- [x] Mention/reply projection is idempotent and supports authorized bounded listing and explicit workflow transitions.
+- [x] Read-only ingestion/provider manifests remain unable to reach platform writes.
+- [x] Sharing snapshots and restores contain no operations, approvals, attempts, local auth selectors, or per-principal notification workflow state.
+- [x] Existing social corpus, X, sync, query, sharing, and browser behavior remains green.
+
+## Context & Decisions
+
+- Shared account operations live only on the owner runner's workspace corpus; ordinary shared members do not inherit posting authority.
+- Queue `scheduled_at` is canonical. The content calendar may reference an operation later but does not execute it.
+- Local owner context is the first approval authority; collaborative signed approvals remain a separate future security review.
+- Provider write failures are classified conservatively as unknown because a timeout may occur after acceptance.
+- Notifications are mutable workflow overlays on immutable mention/reply evidence.
+
+## Relevant Files
+
+- `.agents/scripts/knowledge_social_store.py:101-246`
+- `.agents/scripts/xurl-helper.sh:11-218`
+- `.agents/scripts/_knowledge_social_x_persist.py:237-284`
+- `.agents/scripts/_knowledge_social_share_data.py:37-142`
+- `.agents/scripts/knowledge_corpus_catalog.py:300-358`
+- `.agents/aidevops/knowledge-plane/05-social-operations.md:6-74`
+
+## Dependencies
+
+- **Blocked by:** none for implementation and fixture verification.
+- **Blocks:** production use requires a local `xurl` installation and authenticated profile.
+- **External:** X API availability, permissions, subscription limits, and endpoint semantics; no credential values enter this brief or model context.


### PR DESCRIPTION
## Summary

Add a schema-v3 owner-managed queue for exact approvals, mapped X writes, privacy-safe receipts, and notification workflow state.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/content/social-xurl.md, .agents/scripts/_knowledge_social_notifications.py, .agents/scripts/_knowledge_social_outbound.py, .agents/scripts/_knowledge_social_share_data.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_operations.py, .agents/scripts/knowledge_social_store.py, .agents/tests/test-knowledge-social-operations.sh, .agents/tests/test-knowledge-social-sync.sh, .agents/tests/test-knowledge-social.sh, README.md, TODO.md, todo/tasks/t18177-brief.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — All seven social suites pass 247 tests; changed-file lint and ShellCheck pass.

Resolves #28627


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 17h 16m and 10,492,951 tokens on this with the user in an interactive session.