### PR TITLE
GH#27777: avoid synthetic zero-frame quota attempts

### DIFF
--- a/.agents/scripts/gh-quota-attribution-lib.sh
+++ b/.agents/scripts/gh-quota-attribution-lib.sh
@@ -636,8 +636,9 @@ _ghqa_capture_locked() {
 		if [[ "$rc" -ne 0 ]]; then
 			printf '[aidevops] native gh command failed before an HTTP request\n' >&2
 		fi
-		_ghqa_write_fallback_attempt "$result_file" "$path" 0 \
-			"$([[ "$rc" -eq 0 ]] && printf success || printf error)" "$elapsed_ms" ""
+		# A valid parser header with zero response frames proves this invocation
+		# made no HTTP request. Keep its logical event, but do not fabricate an
+		# unknown transport attempt for local or cache-only gh behavior.
 		return "$rc"
 	fi
 	if [[ "$version" == v1 && "$frame_count" =~ ^[1-9][0-9]*$ ]] \

--- a/.agents/scripts/gh-quota-debug-filter.py
+++ b/.agents/scripts/gh-quota-debug-filter.py
@@ -103,6 +103,12 @@ def main() -> int:
     lines = data.splitlines(keepends=True)
     ranges = _frame_ranges(lines)
     _write_sanitized_stderr(lines, ranges)
+    if data and not ranges:
+        # Non-empty stderr without a recognized request frame may be a changed
+        # GH_DEBUG format containing private request or response data. Keep it
+        # suppressed and mark capture invalid rather than claiming no request.
+        print("v1\tinvalid")
+        return 0
     print(f"v1\t{len(ranges)}")
     for frame_index, (start, end) in enumerate(ranges, start=1):
         frame = lines[start:end]

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -1058,6 +1058,19 @@ else
 	_fail "debug framing drift handling" "log: $(cat "$drift_log" 2>/dev/null || true) stderr: $(cat "$drift_err" 2>/dev/null || true)"
 fi
 
+zero_frame_log="$TMP/exact-zero-frame.log"
+zero_frame_state="$TMP/exact-zero-frame-state"
+: >"$zero_frame_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$zero_frame_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$zero_frame_log" "$SHIM_RUN" auth status >/dev/null 2>/dev/null
+if [[ "$(grep -c $'\tgh-quota-bootstrap\t.*\tattempt\t' "$zero_frame_log" || true)" == "1" \
+	&& "$(grep -c $'\tgh_auth_status\t.*\tattempt\t' "$zero_frame_log" || true)" == "0" ]]; then
+	_pass "valid zero-response capture adds no synthetic transport attempt"
+else
+	_fail "zero-response exact capture" "log: $(cat "$zero_frame_log" 2>/dev/null || true)"
+fi
+
 local_log="$TMP/exact-local-command.log"
 local_state="$TMP/exact-local-command-state"
 : >"$local_log"


### PR DESCRIPTION
## Summary

Treat valid zero-response GH_DEBUG captures as no transport attempts while failing closed on non-empty unframed debug output.

## Files Changed

.agents/scripts/gh-quota-attribution-lib.sh, .agents/scripts/gh-quota-debug-filter.py, .agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: test-gh-shim.sh passed 69 assertions; Python byte-compile, Bash syntax, ShellCheck, and changed-file linters passed.

For #27777
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 8d 13h and 27,027,496 tokens on this with the user in an interactive session.