### PR TITLE
GH#27777: persist merge scheduler environment overrides

### DIFF
--- a/.agents/reference/plist-env-overrides.md
+++ b/.agents/reference/plist-env-overrides.md
@@ -7,8 +7,9 @@ losing them on every `aidevops update` or `setup.sh` run.
 
 `setup.sh` regenerates launchd plists on every run (~every 10 min via
 `aidevops update`). Any manual edits to
-`~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist`
-are silently wiped.
+`~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist` or
+`~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-merge.plist` are
+silently wiped.
 
 The override file survives framework updates because it lives in the stable
 user config root, outside replaceable runtime bundles.
@@ -49,14 +50,16 @@ Keys prefixed with `_` are skipped — they serve as in-file comments.
 
 ## Supported Labels
 
-Currently only the supervisor pulse label is handled:
+The main Pulse and dedicated merge-pass supervisors are handled:
 
 | Label | Plist |
 |-------|-------|
 | `com.aidevops.aidevops-supervisor-pulse` | `~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist` |
+| `com.aidevops.aidevops-supervisor-merge` | `~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-merge.plist` |
 
 Additional labels can be supported by extending
-`_build_plist_env_overrides_xml` in `setup-modules/schedulers.sh`.
+their plist generators to call `_build_plist_env_overrides_xml` from
+`.agents/scripts/setup/modules/schedulers-pulse.sh`.
 
 ## Worked Example: Tune Per-Runner Thresholds
 

--- a/.agents/scripts/setup/modules/schedulers-platform.sh
+++ b/.agents/scripts/setup/modules/schedulers-platform.sh
@@ -344,6 +344,8 @@ _install_pulse_merge_routine_launchd() {
 	_xml_pmr_home=$(_xml_escape "$HOME")
 	_xml_pmr_log_dir=$(_xml_escape "$_pmr_log_dir")
 	_xml_bash_bin=$(_xml_escape "$(_resolve_modern_bash)")
+	local _env_overrides_xml
+	_env_overrides_xml=$(_build_plist_env_overrides_xml "$pmr_label")
 
 	local pmr_plist_content
 	pmr_plist_content=$(
@@ -372,7 +374,7 @@ _install_pulse_merge_routine_launchd() {
 		<string>$(aidevops_launchd_sanitized_path)</string>
 		<key>HOME</key>
 		<string>${_xml_pmr_home}</string>
-	</dict>
+${_env_overrides_xml}	</dict>
 	<key>RunAtLoad</key>
 	<false/>
 	<key>KeepAlive</key>
@@ -389,6 +391,7 @@ PMR_PLIST
 
 	if _launchd_install_if_changed "$pmr_label" "$pmr_plist" "$pmr_plist_content"; then
 		print_info "Pulse merge pass enabled (launchd, every 60s via pulse-merge-routine.sh)"
+		_log_plist_env_overrides "$pmr_label"
 	else
 		print_warning "Failed to load pulse merge pass LaunchAgent"
 	fi

--- a/.agents/scripts/tests/test-plist-env-overrides.sh
+++ b/.agents/scripts/tests/test-plist-env-overrides.sh
@@ -215,6 +215,45 @@ EOF
 	return 0
 }
 
+test_merge_scheduler_injects_label_overrides() {
+	local original_home="$HOME"
+	local label="com.aidevops.aidevops-supervisor-merge"
+	local override_file="$TEST_DIR/home/.config/aidevops/plist-env-overrides.json"
+	local captured_plist=""
+	local ok=0
+	HOME="$TEST_DIR/home"
+	mkdir -p "${override_file%/*}" "$TEST_DIR/logs"
+	cat >"$override_file" <<'EOF'
+{
+  "com.aidevops.aidevops-supervisor-merge": {
+    "AIDEVOPS_GH_EXACT_QUOTA_CAPTURE": "1"
+  }
+}
+EOF
+	_resolve_modern_bash() {
+		printf '/bin/bash'
+		return 0
+	}
+	_launchd_install_if_changed() {
+		local installed_label="$1"
+		local installed_path="$2"
+		local installed_content="$3"
+		[[ "$installed_label" == "$label" ]] || return 1
+		[[ "$installed_path" == "$HOME/Library/LaunchAgents/${label}.plist" ]] || return 1
+		captured_plist="$installed_content"
+		return 0
+	}
+
+	_install_pulse_merge_routine_launchd "$label" "$TEST_DIR/pulse-merge-routine.sh" "$TEST_DIR/logs"
+	[[ "$captured_plist" == *"AIDEVOPS_GH_EXACT_QUOTA_CAPTURE"* ]] || ok=1
+	[[ "$captured_plist" == *"<string>1</string>"* ]] || ok=1
+
+	HOME="$original_home"
+	print_result "merge_scheduler: injects overrides for dedicated merge label" "$ok" \
+		"captured plist was: $captured_plist"
+	return 0
+}
+
 test_xml_structure_valid() {
 	# Check that the output is parseable XML when embedded in a minimal plist.
 	# Only runs if xmllint is available.
@@ -273,6 +312,7 @@ main() {
 	test_malformed_json_logs_warn_and_emits_nothing
 	test_default_path_prefers_stable_config_with_legacy_fallback
 	test_logging_contains_keys_not_values
+	test_merge_scheduler_injects_label_overrides
 	test_xml_structure_valid
 
 	echo ""


### PR DESCRIPTION
## Summary

Inject stable plist environment overrides into the dedicated Pulse merge LaunchAgent so auto-update cannot remove benchmark instrumentation.

## Files Changed

.agents/reference/plist-env-overrides.md, .agents/scripts/setup/modules/schedulers-platform.sh, .agents/scripts/tests/test-plist-env-overrides.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: plist override tests passed 9/9; standalone merge routine tests passed 20/20; Bash syntax, ShellCheck, Markdown, and changed-file linters passed.

For #27777
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 8d 14h and 27,139,953 tokens on this with the user in an interactive session.