### PR TITLE
GH#27777: refresh merge scheduler in Pulse setup scope

### DIFF
--- a/.agents/aidevops/setup.md
+++ b/.agents/aidevops/setup.md
@@ -46,7 +46,7 @@ Use scoped setup when the change is isolated and a full deploy would add avoidab
 | OpenCode CLI/shim/setup logic | `./setup.sh --stage opencode` or `aidevops setup --scope opencode` |
 | Hook change | `./setup.sh --stage hooks` or `aidevops setup --scope hooks` |
 | Tabby profile change | `./setup.sh --stage tabby` or `aidevops setup --scope tabby` |
-| launchd/routine/pulse plist change | `./setup.sh --stage pulse` or `aidevops setup --scope pulse` |
+| Pulse or merge-scheduler plist change | `./setup.sh --stage pulse` or `aidevops setup --scope pulse` |
 | AI session after release/update | `./setup.sh --stage ai-session` or `aidevops setup --scope ai-session` |
 
 `./setup.sh --stage` also accepts the canonical stage names: `setup_opencode_cli`,
@@ -54,7 +54,8 @@ Use scoped setup when the change is isolated and a full deploy would add avoidab
 `setup_supervisor_pulse`. The `ai-session` scope compares `~/.aidevops/.deployed-sha`
 with the current checkout, runs the changed deploy stages, verifies `VERSION` and
 `.deployed-sha`, and then runs full non-interactive setup only when incremental setup
-is unsafe or fails. Unknown stages fail non-zero and print the valid list.
+is unsafe or fails. The Pulse scope refreshes both the main supervisor and the
+dedicated merge scheduler. Unknown stages fail non-zero and print the valid list.
 
 ## Manual Configuration
 

--- a/.agents/scripts/tests/test-setup-scoped-dispatch.sh
+++ b/.agents/scripts/tests/test-setup-scoped-dispatch.sh
@@ -110,6 +110,8 @@ test_setup_stage_contract() {
 	assert_contains "hooks scope maps to setup_safety_hooks" "$text" "hooks | \"\$SETUP_STAGE_HOOKS\") printf '%s' \"\$SETUP_STAGE_HOOKS\""
 	assert_contains "tabby scope maps to setup_tabby" "$text" "tabby | \"\$SETUP_STAGE_TABBY\") printf '%s' \"\$SETUP_STAGE_TABBY\""
 	assert_contains "pulse scope maps to setup_supervisor_pulse" "$text" "pulse | \"\$SETUP_STAGE_PULSE\") printf '%s' \"\$SETUP_STAGE_PULSE\""
+	assert_occurrence_count "pulse scoped and full setup refresh merge scheduler" "$text" \
+		'_time_step "setup_pulse_merge_routine"' 2
 	assert_contains "gui-desktop scope maps to native app installer" "$text" "gui-desktop | gui | app | \"\$SETUP_STAGE_GUI_DESKTOP\") printf '%s' \"\$SETUP_STAGE_GUI_DESKTOP\""
 	assert_contains "ai-session scope maps to incremental setup" "$text" "ai-session | ai | \"\$SETUP_STAGE_AI_SESSION\") printf '%s' \"\$SETUP_STAGE_AI_SESSION\""
 	assert_contains "ai-session scoped stage falls back to full setup" "$text" "AI-session incremental setup unavailable or failed; falling back to full setup"

--- a/setup.sh
+++ b/setup.sh
@@ -1460,6 +1460,7 @@ _setup_run_scoped_stage() {
 		;;
 	"$SETUP_STAGE_PULSE")
 		_time_step "$SETUP_STAGE_PULSE" setup_supervisor_pulse "$os"
+		_time_step "setup_pulse_merge_routine" setup_pulse_merge_routine
 		;;
 	"$SETUP_STAGE_GUI_DESKTOP")
 		_time_step "$SETUP_STAGE_GUI_DESKTOP" setup_gui_desktop_app


### PR DESCRIPTION
## Summary

Make the scoped Pulse setup regenerate both the main and dedicated merge LaunchAgents so profile switches stay atomic.

## Files Changed

.agents/aidevops/setup.md, .agents/scripts/tests/test-setup-scoped-dispatch.sh, setup.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: scoped setup dispatch tests passed 54/54; Bash syntax, ShellCheck, Markdown, and changed-file linters passed.

For #27777
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 8d 14h and 27,200,441 tokens on this with the user in an interactive session.