### PR TITLE
GH#28639: Prevent stale task branches from merging duplicate TODO mappings

### DIFF
--- a/.agents/hooks/pre-push-dup-todo-guard.sh
+++ b/.agents/hooks/pre-push-dup-todo-guard.sh
@@ -41,6 +41,9 @@
 set -u
 
 GUARD_NAME="dup-todo-guard"
+HOOK_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || exit 1
+# shellcheck source=../scripts/issue-sync-pr-task-resolver.sh
+source "${HOOK_DIR}/../scripts/issue-sync-pr-task-resolver.sh"
 
 _log() {
 	local _level="$1"
@@ -129,85 +132,46 @@ while IFS=' ' read -r _local_ref _local_sha _remote_ref _remote_sha; do
 		continue
 	}
 
-	# Extract task IDs from checkbox lines only.
-	# Pattern: ^[whitespace]*- [x] tNNN[.N]*<space|EOL> — supports indented
-	# subtasks and hierarchical IDs (e.g., t1271.1). Anchored to checkbox-and-
-	# task-ID prefix to avoid matching prose that mentions a task ID.
-	# BSD sed and GNU sed both support \1 backreference in basic RE.
-	_task_ids=$(printf '%s\n' "$_todo_content" \
-		| grep -E '^[[:space:]]*- \[.\] t[0-9]+(\.[0-9]+)*([[:space:]]|$)' \
-		| sed 's/^[[:space:]]*- \[.\] \(t[0-9][0-9.]*\).*/\1/')
-
-	if [[ -z "$_task_ids" ]]; then
-		_dbg "no task IDs extracted from TODO.md in ${_local_sha}"
-		continue
-	fi
-
-	# Find IDs that appear more than once.
-	_duplicates=$(printf '%s\n' "$_task_ids" | sort | uniq -d)
-
-	if [[ -z "$_duplicates" ]]; then
-		_dbg "no duplicate task IDs in TODO.md at ${_local_sha}"
-		continue
-	fi
-
-	# Compare duplicate occurrence counts with the remote baseline. This is a
-	# ratchet: unchanged legacy duplicates are tolerated, but a new duplicate
-	# or an increased count remains blocking. If no baseline can be resolved,
-	# retain the original fail-closed full-snapshot behaviour.
-	_base_task_ids=""
+	# Compare canonical task-ID and issue-mapping counts with the remote
+	# baseline. The shared detector is also used by the prospective merge gate.
 	_base_sha=""
 	if _base_sha=$(_compute_baseline "$_remote_name" "$_local_sha" "${_remote_sha:-}"); then
 		if git cat-file -e "${_base_sha}:TODO.md" 2>/dev/null; then
 			_base_content=$(git show "${_base_sha}:TODO.md" 2>/dev/null) || _base_content=""
-			if [[ -n "$_base_content" ]]; then
-				_base_task_ids=$(printf '%s\n' "$_base_content" \
-					| grep -E '^[[:space:]]*- \[.\] t[0-9]+(\.[0-9]+)*([[:space:]]|$)' \
-					| sed 's/^[[:space:]]*- \[.\] \(t[0-9][0-9.]*\).*/\1/')
-			fi
+		else
+			_base_content=""
 		fi
 		_dbg "baseline for ${_local_ref}: ${_base_sha}"
 	else
+		_base_content=""
 		_dbg "no baseline resolved for ${_local_ref} — enforcing full duplicate scan"
 	fi
 
-	_increased_duplicates=""
-	while IFS= read -r _dup_id; do
-		[[ -n "$_dup_id" ]] || continue
-		_head_count=$(printf '%s\n' "$_task_ids" | grep -Fxc "$_dup_id" || true)
-		_base_count=0
-		if [[ -n "$_base_task_ids" ]]; then
-			_base_count=$(printf '%s\n' "$_base_task_ids" | grep -Fxc "$_dup_id" || true)
-		fi
-		if [[ "$_head_count" -gt "$_base_count" ]]; then
-			_increased_duplicates="${_increased_duplicates}${_increased_duplicates:+$'\n'}${_dup_id}"
-		else
-			_dbg "grandfathering unchanged duplicate ${_dup_id} (${_head_count} occurrences)"
-		fi
-	done <<<"$_duplicates"
-
-	if [[ -z "$_increased_duplicates" ]]; then
+	_guard_tmp=$(mktemp -d) || {
+		_log ERROR "could not create duplicate-check workspace — blocking push"
+		_exit_code=1
+		continue
+	}
+	printf '%s\n' "$_todo_content" >"${_guard_tmp}/candidate"
+	printf '%s\n' "$_base_content" >"${_guard_tmp}/baseline"
+	_report=""
+	_report_rc=0
+	_report=$(todo_duplicate_report "${_guard_tmp}/candidate" "${_guard_tmp}/baseline") || _report_rc=$?
+	rm -rf "$_guard_tmp"
+	if [[ "$_report_rc" -eq 0 ]]; then
+		_dbg "no new duplicate TODO mappings at ${_local_sha}"
 		continue
 	fi
-	_duplicates="$_increased_duplicates"
+	if [[ "$_report_rc" -ne 1 ]]; then
+		_log ERROR "duplicate evidence could not be evaluated — blocking push"
+		_exit_code=1
+		continue
+	fi
 
 	# Found duplicates — block and report line numbers for each.
 	_exit_code=1
-	printf '\n[%s][BLOCK] Push blocked: new or increased duplicate task IDs in TODO.md\n\n' "$GUARD_NAME" >&2
-
-	printf '%s\n' "$_duplicates" | while IFS= read -r _dup_id; do
-		[[ -z "$_dup_id" ]] && continue
-		# Find line numbers of the duplicate entries (1-indexed, matching the
-		# checkbox-and-ID anchor so description-only mentions are excluded).
-		# Dots in the task ID must be escaped for ERE to prevent false positives.
-		_dup_id_esc=$(printf '%s' "$_dup_id" | sed 's/\./\\./g')
-		_line_nums=$(printf '%s\n' "$_todo_content" \
-			| grep -nE '^[[:space:]]*- \[.\] '"${_dup_id_esc}"'([[:space:]]|$)' \
-			| cut -d: -f1 \
-			| tr '\n' ',' \
-			| sed 's/,$//')
-		printf '  Duplicate task ID: %s  (TODO.md lines: %s)\n' "$_dup_id" "$_line_nums" >&2
-	done
+	printf '\n[%s][BLOCK] Push blocked: new or increased duplicate TODO mappings\n\n' "$GUARD_NAME" >&2
+	printf '%s\n' "$_report" >&2
 
 	printf '\n' >&2
 	printf '  Fix: remove the duplicate entry from TODO.md, amend the commit,\n' >&2

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -56,6 +56,11 @@ fi
 # shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
 source "${SCRIPT_DIR}/full-loop-helper-evidence.sh"
 
+# Canonical TODO task/issue mapping parser shared with issue-sync and pre-push.
+# shellcheck source=./issue-sync-pr-task-resolver.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
+source "${SCRIPT_DIR}/issue-sync-pr-task-resolver.sh"
+
 # --- Repo Resolution ---
 
 # _merge_resolve_repo — resolve repo slug from argument or auto-detect from git remote.
@@ -473,6 +478,118 @@ _merge_fetch_head_sha_rest() {
 	return 0
 }
 
+# Return the fresh base ref, base SHA, and head SHA that GitHub currently binds
+# to the PR. The three fields form the pinned evidence boundary for a local
+# prospective merge-tree check.
+_merge_fetch_pr_refs_rest() {
+	local pr_number="$1"
+	local repo="$2"
+	local refs=""
+	refs=$(gh api "repos/${repo}/pulls/${pr_number}" \
+		--jq '[.base.ref // empty, .base.sha // empty, .head.sha // empty] | @tsv' 2>/dev/null) || return 1
+	[[ "$refs" == *$'\t'*$'\t'* ]] || return 1
+	printf '%s\n' "$refs"
+	return 0
+}
+
+_merge_fetch_pinned_commit_objects() {
+	local pr_number="$1"
+	local base_ref="$2"
+	local base_sha="$3"
+	local head_sha="$4"
+
+	if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+		git fetch --quiet --no-tags origin "refs/heads/${base_ref}" || return 1
+	fi
+	if ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+		git fetch --quiet --no-tags origin "refs/pull/${pr_number}/head" || return 1
+	fi
+	git cat-file -e "${base_sha}^{commit}" 2>/dev/null || return 1
+	git cat-file -e "${head_sha}^{commit}" 2>/dev/null || return 1
+	return 0
+}
+
+# Fail closed unless the exact current PR head can be merged prospectively into
+# the fresh base without introducing duplicate TODO task IDs or issue mappings.
+_merge_guard_prospective_todo() {
+	local pr_number="$1"
+	local repo="$2"
+	local refs=""
+	local base_ref=""
+	local base_sha=""
+	local head_sha=""
+	local merge_tree_output=""
+	local merge_tree_sha=""
+	local temp_dir=""
+	local report=""
+	local report_rc="0"
+
+	refs=$(_merge_fetch_pr_refs_rest "$pr_number" "$repo") || {
+		print_error "Merge blocked: unable to pin fresh PR base/head evidence for prospective TODO validation"
+		return 1
+	}
+	IFS=$'\t' read -r base_ref base_sha head_sha <<<"$refs"
+	if [[ -z "$base_ref" || -z "$base_sha" || -z "$head_sha" ]]; then
+		print_error "Merge blocked: incomplete PR base/head evidence for prospective TODO validation"
+		return 1
+	fi
+	if [[ -n "${FULL_LOOP_VERIFIED_PR_HEAD_SHA:-}" && "$head_sha" != "$FULL_LOOP_VERIFIED_PR_HEAD_SHA" ]]; then
+		print_error "Merge blocked: PR head changed before prospective TODO validation"
+		return 1
+	fi
+	_merge_fetch_pinned_commit_objects "$pr_number" "$base_ref" "$base_sha" "$head_sha" || {
+		print_error "Merge blocked: unable to materialize pinned PR commits for prospective TODO validation"
+		return 1
+	}
+
+	if ! merge_tree_output=$(git merge-tree --write-tree "$base_sha" "$head_sha" 2>&1); then
+		print_error "Merge blocked: prospective merge-tree evidence is indeterminate"
+		printf '%s\n' "$merge_tree_output" >&2
+		return 1
+	fi
+	merge_tree_sha=$(printf '%s\n' "$merge_tree_output" | sed -n '1p')
+	if ! [[ "$merge_tree_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] || \
+		! git cat-file -e "${merge_tree_sha}^{tree}" 2>/dev/null; then
+		print_error "Merge blocked: prospective merge-tree did not produce a verifiable tree"
+		return 1
+	fi
+
+	# Repositories without TODO.md have no task mapping surface to validate.
+	if ! git cat-file -e "${merge_tree_sha}:TODO.md" 2>/dev/null; then
+		return 0
+	fi
+	temp_dir=$(mktemp -d) || {
+		print_error "Merge blocked: unable to create prospective TODO validation workspace"
+		return 1
+	}
+	if ! git show "${merge_tree_sha}:TODO.md" >"${temp_dir}/merged"; then
+		rm -rf "$temp_dir"
+		print_error "Merge blocked: unable to read prospective TODO evidence"
+		return 1
+	fi
+	if git cat-file -e "${base_sha}:TODO.md" 2>/dev/null; then
+		if ! git show "${base_sha}:TODO.md" >"${temp_dir}/base"; then
+			rm -rf "$temp_dir"
+			print_error "Merge blocked: unable to read base TODO evidence"
+			return 1
+		fi
+	else
+		: >"${temp_dir}/base"
+	fi
+	report=$(todo_duplicate_report "${temp_dir}/merged" "${temp_dir}/base") || report_rc=$?
+	rm -rf "$temp_dir"
+	if [[ "$report_rc" -eq 0 ]]; then
+		return 0
+	fi
+	if [[ "$report_rc" -eq 1 ]]; then
+		print_error "Merge blocked: prospective merge introduces duplicate TODO mappings"
+		printf '%s\n' "$report" >&2
+		return 1
+	fi
+	print_error "Merge blocked: prospective TODO duplicate evidence is indeterminate"
+	return 1
+}
+
 # _merge_rest_fallback — squash/merge/rebase a PR via the REST pull merge endpoint.
 #
 # This is a transport fallback only. It is called after review-bot-gate has
@@ -583,6 +700,7 @@ _merge_execute() {
 	# --auto and the non-admin REST transport fallback, must pass the same live
 	# external/fork and exact-head cryptographic authority check.
 	_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" "$match_head_sha" || return 1
+	_merge_guard_prospective_todo "$pr_number" "$repo" || return 1
 	merge_flags+=("--match-head-commit" "$match_head_sha")
 
 	# Capture output AND exit code under set -e. A bare assignment `out=$(cmd)`
@@ -1039,7 +1157,6 @@ cmd_merge() {
 		print_error "Merge blocked by review bot gate. Address bot findings or wait for reviews."
 		return 1
 	}
-
 	# Retarget any open PRs stacked on this branch before the head branch is
 	# deleted post-merge. GitHub auto-closes stacked children when their base
 	# branch disappears; retargeting to the default branch prevents this.

--- a/.agents/scripts/issue-sync-pr-task-resolver.sh
+++ b/.agents/scripts/issue-sync-pr-task-resolver.sh
@@ -2,7 +2,90 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 Marcus Quinn
 
-set -euo pipefail
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && set -euo pipefail
+
+# Emit one canonical key per task ID and issue mapping on TODO checkbox rows.
+# Keeping this parser here makes issue-sync resolution, push guards, and merge
+# guards agree about what constitutes a mapping.
+todo_mapping_keys() {
+	local todo_file="$1"
+	local line=""
+	local task_id=""
+	local issue_refs=""
+
+	[[ -f "$todo_file" ]] || return 1
+	while IFS= read -r line; do
+		if ! [[ "$line" =~ ^[[:space:]]*-[[:space:]]\[.\][[:space:]]+(t[0-9]+(\.[0-9]+)*)([[:space:]]|$) ]]; then
+			continue
+		fi
+		task_id="${BASH_REMATCH[1]}"
+		printf 'task:%s\n' "$task_id"
+		issue_refs=$(printf '%s\n' "$line" | grep -oE 'ref:GH#[0-9]+' || true)
+		if [[ -n "$issue_refs" ]]; then
+			printf '%s\n' "$issue_refs" | sed 's/^ref:GH#/issue:/'
+		fi
+	done <"$todo_file"
+	return 0
+}
+
+# Report duplicate task IDs and issue mappings introduced relative to a
+# baseline TODO snapshot. Return 0 for no regression, 1 for duplicates, and 2
+# when evidence cannot be read. Output is suitable for push/merge diagnostics.
+todo_duplicate_report() {
+	local todo_file="$1"
+	local baseline_file="${2:-}"
+	local temp_dir=""
+	local candidate_keys=""
+	local baseline_keys=""
+	local duplicates=""
+	local key=""
+	local candidate_count="0"
+	local baseline_count="0"
+	local value=""
+	local escaped=""
+	local line_numbers=""
+	local found_regression="0"
+
+	[[ -f "$todo_file" ]] || return 2
+	temp_dir=$(mktemp -d) || return 2
+	candidate_keys="${temp_dir}/candidate-keys"
+	baseline_keys="${temp_dir}/baseline-keys"
+	if ! todo_mapping_keys "$todo_file" >"$candidate_keys"; then
+		rm -rf "$temp_dir"
+		return 2
+	fi
+	: >"$baseline_keys"
+	if [[ -n "$baseline_file" ]]; then
+		if [[ ! -f "$baseline_file" ]] || ! todo_mapping_keys "$baseline_file" >"$baseline_keys"; then
+			rm -rf "$temp_dir"
+			return 2
+		fi
+	fi
+
+	duplicates=$(sort "$candidate_keys" | uniq -d)
+	while IFS= read -r key; do
+		[[ -n "$key" ]] || continue
+		candidate_count=$(grep -Fxc "$key" "$candidate_keys" || true)
+		baseline_count=$(grep -Fxc "$key" "$baseline_keys" || true)
+		[[ "$candidate_count" -gt "$baseline_count" ]] || continue
+		found_regression="1"
+		value="${key#*:}"
+		if [[ "$key" == task:* ]]; then
+			escaped=$(printf '%s' "$value" | sed 's/\./\\./g')
+			line_numbers=$(grep -nE '^[[:space:]]*- \[.\] '"${escaped}"'([[:space:]]|$)' "$todo_file" \
+				| cut -d: -f1 | tr '\n' ',' | sed 's/,$//')
+			printf '  Duplicate task ID: %s  (TODO.md lines: %s)\n' "$value" "$line_numbers"
+		else
+			line_numbers=$(grep -nE 'ref:GH#'"${value}"'([[:space:]]|$)' "$todo_file" \
+				| cut -d: -f1 | tr '\n' ',' | sed 's/,$//')
+			printf '  Duplicate issue mapping: ref:GH#%s  (TODO.md lines: %s)\n' "$value" "$line_numbers"
+		fi
+	done <<<"$duplicates"
+
+	rm -rf "$temp_dir"
+	[[ "$found_regression" -eq 1 ]] && return 1
+	return 0
+}
 
 collect_effective_issues() {
 	local todo_file="$1"
@@ -100,4 +183,6 @@ main() {
 	return $?
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -324,6 +324,7 @@ set -euo pipefail
 SCRIPT_DIR='${scripts_dir}'
 source '${scripts_dir}/shared-constants.sh'
 source '${scripts_dir}/full-loop-helper-merge.sh'
+_merge_guard_prospective_todo() { return 0; }
 _merge_execute '$pr_number' '$repo' '$merge_method' '$has_admin' '$has_auto'
 RUNNER_EOF
 	chmod +x "$tmp_runner"
@@ -359,6 +360,7 @@ SCRIPT_DIR='${scripts_dir}'
 source '${scripts_dir}/shared-constants.sh'
 source '${scripts_dir}/full-loop-helper-merge.sh'
 cmd_pre_merge_gate() { return '${gate_rc}'; }
+_merge_guard_prospective_todo() { return 0; }
 _retarget_stacked_children_interactive() { return 0; }
 release_interactive_claim_on_merge() { return 0; }
 auto_file_next_phase() { printf '%s %s\n' "\$1" "\$2" >> "${TEST_ROOT}/logs/phase-autofile.txt"; return 0; }
@@ -391,6 +393,7 @@ SCRIPT_DIR='${scripts_dir}'
 source '${scripts_dir}/shared-constants.sh'
 source '${scripts_dir}/full-loop-helper-merge.sh'
 cmd_pre_merge_gate() { return 0; }
+_merge_guard_prospective_todo() { return 0; }
 _retarget_stacked_children_interactive() { return 0; }
 _merge_report_canonical_sync_state() { return 0; }
 _merge_finalize_post_merge() {
@@ -889,6 +892,84 @@ test_post_merge_api_indeterminate_fails_closed() {
 	return 0
 }
 
+run_prospective_todo_guard() {
+	local fixture_dir="$1"
+	local base_sha="$2"
+	local head_sha="$3"
+	local scripts_dir="${SCRIPT_DIR}/.."
+	local tmp_runner=""
+	tmp_runner=$(mktemp)
+	cat >"$tmp_runner" <<RUNNER_EOF
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${scripts_dir}'
+source '${scripts_dir}/shared-constants.sh'
+source '${scripts_dir}/full-loop-helper-merge.sh'
+_merge_fetch_pr_refs_rest() { printf 'main\t%s\t%s\n' '${base_sha}' '${head_sha}'; return 0; }
+_merge_fetch_pinned_commit_objects() { return 0; }
+cd '${fixture_dir}'
+_merge_guard_prospective_todo '42' 'testorg/testrepo'
+RUNNER_EOF
+	chmod +x "$tmp_runner"
+	local rc=0
+	env PATH="${TEST_ROOT}/bin:/usr/bin:/bin:${scripts_dir}:${PATH}" bash "$tmp_runner" 2>&1 || rc=$?
+	rm -f "$tmp_runner"
+	[[ "$rc" -eq 0 ]] && return 0
+	return 1
+}
+
+create_prospective_fixture() {
+	local mode="$1"
+	local fixture_dir="${TEST_ROOT}/prospective-${mode}"
+	mkdir -p "$fixture_dir"
+	(
+		cd "$fixture_dir" || exit 1
+		/usr/bin/git init -q
+		/usr/bin/git config user.email test@test.local
+		/usr/bin/git config user.name Test
+		printf '## Base tasks\n- [ ] t1 Root ref:GH#1\n\n## Branch tasks\n' >TODO.md
+		/usr/bin/git add TODO.md
+		/usr/bin/git commit -q -m root
+		local root_sha=""
+		root_sha=$(/usr/bin/git rev-parse HEAD)
+		printf '## Base tasks\n- [ ] t1 Root ref:GH#1\n- [ ] t2 Base addition ref:GH#2\n\n## Branch tasks\n' >TODO.md
+		/usr/bin/git commit -q -am base
+		/usr/bin/git rev-parse HEAD >base.sha
+		/usr/bin/git checkout -q --detach "$root_sha"
+		if [[ "$mode" == "collision" ]]; then
+			printf '## Base tasks\n- [ ] t1 Root ref:GH#1\n\n## Branch tasks\n- [ ] t2 Head addition ref:GH#2\n' >TODO.md
+		else
+			printf '## Base tasks\n- [ ] t1 Root ref:GH#1\n\n## Branch tasks\n- [ ] t3 Unique head addition ref:GH#3\n' >TODO.md
+		fi
+		/usr/bin/git commit -q -am head
+		/usr/bin/git rev-parse HEAD >head.sha
+	)
+	printf '%s\n' "$fixture_dir"
+	return 0
+}
+
+test_prospective_todo_merge_guard() {
+	local fixture_dir="" base_sha="" head_sha="" output="" rc=0
+	fixture_dir=$(create_prospective_fixture collision)
+	base_sha=$(<"${fixture_dir}/base.sha")
+	head_sha=$(<"${fixture_dir}/head.sha")
+	output=$(run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha") || rc=$?
+	print_result "prospective TODO: merge-only collision is blocked" "$((rc == 0 ? 1 : 0))" "output=$output"
+	print_result "prospective TODO: task and issue duplicates are reported" "$([[ "$output" == *"Duplicate task ID: t2"* && "$output" == *"Duplicate issue mapping: ref:GH#2"* ]] && printf '0' || printf '1')" "output=$output"
+
+	rc=0
+	fixture_dir=$(create_prospective_fixture unique)
+	base_sha=$(<"${fixture_dir}/base.sha")
+	head_sha=$(<"${fixture_dir}/head.sha")
+	run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha" >/dev/null || rc=$?
+	print_result "prospective TODO: unique stale branch passes" "$rc"
+
+	rc=0
+	output=$(run_prospective_todo_guard "$fixture_dir" deadbeef deadbeef) || rc=$?
+	print_result "prospective TODO: indeterminate merge-tree fails closed" "$((rc == 0 ? 1 : 0))" "output=$output"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -914,6 +995,7 @@ main() {
 	test_post_merge_stale_evidence_retries_fresh_read
 	test_post_merge_unmerged_evidence_fails_closed
 	test_post_merge_api_indeterminate_fails_closed
+	test_prospective_todo_merge_guard
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pre-push-dup-todo-guard.sh
+++ b/.agents/scripts/tests/test-pre-push-dup-todo-guard.sh
@@ -4,7 +4,7 @@
 #
 # test-pre-push-dup-todo-guard.sh — Unit tests for pre-push-dup-todo-guard.sh (t2745).
 #
-# Tests 11 fixtures:
+# Tests 12 fixtures:
 #   1. Clean TODO.md (no duplicates)               → exit 0
 #   2. Single duplicate (t2743 twice)              → exit 1, cites lines
 #   3. Multiple duplicates (t2743 AND t2742)       → exit 1, cites both IDs
@@ -16,6 +16,7 @@
 #   9. Indented subtask duplicate                  → exit 1, cites lines
 #  10. Unchanged pre-existing duplicate            → exit 0
 #  11. Increased pre-existing duplicate count      → exit 1
+#  12. Duplicate issue mapping on distinct tasks    → exit 1
 #
 # Usage: bash .agents/scripts/tests/test-pre-push-dup-todo-guard.sh
 # Exit 0 = all tests passed. Exit 1 = one or more tests failed.
@@ -501,6 +502,33 @@ test_increased_preexisting_duplicate() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 12: one issue mapped by two distinct task IDs is also a duplicate.
+# ---------------------------------------------------------------------------
+test_duplicate_issue_mapping() {
+	local _name="test_12_duplicate_issue_mapping"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _base_content _head_content
+	_base_content="## Ready
+- [ ] t2743 First task ref:GH#20480"
+	_head_content="${_base_content}
+- [ ] t2744 Different task, same issue ref:GH#20480"
+	local _base_sha _head_sha _stderr _rc
+	_base_sha=$(_commit_todo "$_base_content")
+	_head_sha=$(_commit_todo "$_head_content")
+	_stderr=$(_run_hook "$_head_sha" "" "$_base_sha" 2>&1 1>/dev/null)
+	_rc=$?
+
+	_teardown_git_repo
+	if [[ "$_rc" -eq 1 && "$_stderr" == *"Duplicate issue mapping: ref:GH#20480"* ]]; then
+		_pass "$_name"
+	else
+		_fail "$_name" "expected duplicate issue mapping diagnostic; rc=${_rc}, stderr=${_stderr}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
@@ -517,6 +545,7 @@ main() {
 	test_indented_subtask_duplicate
 	test_unchanged_preexisting_duplicate
 	test_increased_preexisting_duplicate
+	test_duplicate_issue_mapping
 
 	printf '\n'
 	printf 'Results: %d passed, %d failed\n' "$_TESTS_PASSED" "$_TESTS_FAILED"


### PR DESCRIPTION
## Summary

- add a shared canonical detector for duplicate TODO task IDs and issue mappings
- add an exact-head prospective merge-tree guard before full-loop merge mutations
- reuse the detector in the pre-push TODO guard

## Verification

- `PATH=/usr/bin:/bin bash .agents/scripts/tests/test-full-loop-merge.sh`
- `PATH=/usr/bin:/bin bash .agents/scripts/tests/test-pre-push-dup-todo-guard.sh`
- `bash .agents/scripts/tests/test-issue-sync-pr-task-resolver.sh`
- ShellCheck on all changed helpers and tests

Resolves #28639
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 18m and 233,597 tokens on this as a headless worker.