### PR TITLE
GH#28625: Harden release provenance and publication boundaries

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Release Publication Controls
+
+This reference is the impact matrix and rollout boundary for repository release
+settings. Code hardening and live-setting mutation are separate checkpoints.
+Changing repository, environment, npm, or tag-policy settings requires explicit
+maintainer operation approval after this matrix has been reviewed.
+
+## Code-enforced provenance
+
+The canonical release path records these trailers in a signed annotated tag:
+
+- `Aidevops-Version`
+- `Aidevops-Source-PR`
+- `Aidevops-Source-Merge`
+
+`.agents/scripts/release-provenance-helper.sh` verifies the same evidence before
+GitHub release creation, npm OIDC publication, and Homebrew update work:
+
+1. tag, `VERSION`, `package.json`, checkout, and bump-commit subject agree;
+2. the local and GitHub tag-object SHA agree, and the annotated tag is
+   GitHub-verified and points at the checked-out commit;
+3. the tag commit is reachable from `origin/main`;
+4. the recorded source PR is merged into `main`, its merge SHA matches, and that
+   merge is the direct parent of the release commit.
+
+Manual arbitrary-version package publication is intentionally unsupported. A
+recovery operation must use an existing tag that passes the same verifier.
+
+## Actions default-permission impact matrix
+
+Repository default permissions can move from `write` to `read` only after every
+workflow declares its needs. The repository audit found eight callers without an
+explicit `permissions` block; this code checkpoint makes all eight explicit.
+
+| Workflow | Required permission | Reason |
+|---|---|---|
+| `update-website-docs.yml` | `contents: read` | Reads this repository; its separate website PAT owns the external write. |
+| `plugin-import-check.yml` | `contents: read` | Read-only pull-request validation. |
+| `counter-monotonic.yml` | `contents: read` | Reads Git history and `.task-counter`. |
+| `markdoc-validate.yml` | `contents: read` | Read-only schema validation. |
+| `version-validation.yml` | `contents: read` | Reads versions and existing tags. |
+| `task-id-collision-check.yml` | `contents: read`, `pull-requests: read` | Reads commit history and PR metadata. |
+| `review-bot-gate.yml` | `contents: read`, `pull-requests: read`, `statuses: write` | Matches the reusable gate contract and publishes its status. |
+| `issue-sync.yml` | `actions: read`, `contents: write`, `issues: write`, `pull-requests: write` | Union required by its job-scoped reusable workflow permissions. |
+
+Existing workflows with explicit job or workflow permissions retain their
+current least-privilege declarations. No workflow was found that requires the
+repository setting allowing GitHub Actions to approve pull-request reviews; the
+setting can be disabled after the read-default change is verified.
+
+## Live rollout checkpoint
+
+Apply these operations only through an audited, explicitly approved settings
+session. Do not create a release, package, deployment, or test tag as validation.
+
+1. Re-run actionlint and required CI after the explicit-permission changes merge.
+2. Set default Actions workflow permissions to read and disable workflow-authored
+   pull-request approval. Verify required workflows still receive their declared
+   permissions through completed non-release runs.
+3. Create a protected `v*` tag ruleset that blocks creation, update, and deletion
+   except for the narrowly documented maintainer release authority. Record the
+   prior ruleset response and the exact rollback operation before mutation.
+4. Create a `release` environment with required maintainer review and a deployment
+   ref policy limited to protected release tags.
+5. In a follow-up code checkpoint, bind GitHub release, npm, and Homebrew jobs to
+   the `release` environment. Configure npm Trusted Publisher to require the same
+   workflow and environment identity where the registry supports that binding.
+6. Verify Actions defaults, rulesets, environment protection, and Trusted Publisher
+   identity through read-only APIs. Negative verification must use fixture or
+   non-publishing paths.
+
+Rollback restores only values captured in the pre-mutation matrix. Code changes
+are reverted normally; live settings are never guessed or broadly reset.

--- a/.agents/scripts/release-provenance-helper.sh
+++ b/.agents/scripts/release-provenance-helper.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+_release_provenance_error() {
+	local message="$1"
+	printf 'release-provenance: %s\n' "$message" >&2
+	return 1
+}
+
+_release_provenance_usage() {
+	cat <<'USAGE'
+Usage:
+  release-provenance-helper.sh verify --tag TAG --repo OWNER/REPO [--branch BRANCH]
+
+Verifies that a release tag is signed, version-consistent, reachable from the
+canonical branch, and bound to a merged source PR through immutable tag trailers.
+USAGE
+	return 0
+}
+
+_release_provenance_trailer() {
+	local tag_name="$1"
+	local trailer_key="$2"
+	local trailer_value=""
+
+	trailer_value=$(git for-each-ref --format='%(contents:body)' "refs/tags/${tag_name}" |
+		awk -v prefix="${trailer_key}: " 'index($0, prefix) == 1 { print substr($0, length(prefix) + 1); exit }')
+	[[ -n "$trailer_value" ]] || return 1
+	printf '%s\n' "$trailer_value"
+	return 0
+}
+
+_release_provenance_verify_github_tag() {
+	local repo_slug="$1"
+	local tag_name="$2"
+	local tag_commit="$3"
+	local local_tag_object="$4"
+	local ref_json=""
+	local tag_object_sha=""
+	local tag_json=""
+
+	ref_json=$(gh api "repos/${repo_slug}/git/ref/tags/${tag_name}" 2>/dev/null) || {
+		_release_provenance_error "cannot read GitHub tag ref ${tag_name}"
+		return 1
+	}
+	if ! jq -e '.object.type == "tag" and (.object.sha | type == "string" and length > 0)' <<<"$ref_json" >/dev/null; then
+		_release_provenance_error "${tag_name} is not an annotated GitHub tag"
+		return 1
+	fi
+	tag_object_sha=$(jq -r '.object.sha' <<<"$ref_json")
+	[[ "$tag_object_sha" == "$local_tag_object" ]] || {
+		_release_provenance_error "local and GitHub tag objects differ for ${tag_name}"
+		return 1
+	}
+	tag_json=$(gh api "repos/${repo_slug}/git/tags/${tag_object_sha}" 2>/dev/null) || {
+		_release_provenance_error "cannot read GitHub tag object ${tag_name}"
+		return 1
+	}
+	if ! jq -e --arg tag "$tag_name" --arg commit "$tag_commit" '
+		.tag == $tag
+		and .object.type == "commit"
+		and .object.sha == $commit
+		and .verification.verified == true
+	' <<<"$tag_json" >/dev/null; then
+		_release_provenance_error "${tag_name} is unsigned, unverified, or targets the wrong commit"
+		return 1
+	fi
+	return 0
+}
+
+_release_provenance_verify_source_pr() {
+	local repo_slug="$1"
+	local branch_name="$2"
+	local source_pr="$3"
+	local source_merge="$4"
+	local tag_commit="$5"
+	local pr_json=""
+	local tag_parent=""
+
+	pr_json=$(gh pr view "$source_pr" --repo "$repo_slug" \
+		--json state,mergedAt,mergeCommit,baseRefName 2>/dev/null) || {
+		_release_provenance_error "cannot read source PR #${source_pr}"
+		return 1
+	}
+	if ! jq -e --arg branch "$branch_name" --arg merge "$source_merge" '
+		.state == "MERGED"
+		and ((.mergedAt // "") | length > 0)
+		and .baseRefName == $branch
+		and .mergeCommit.oid == $merge
+	' <<<"$pr_json" >/dev/null; then
+		_release_provenance_error "source PR #${source_pr} does not match recorded merge provenance"
+		return 1
+	fi
+	if ! git merge-base --is-ancestor "$source_merge" "$tag_commit" 2>/dev/null; then
+		_release_provenance_error "recorded source merge is not an ancestor of ${tag_commit}"
+		return 1
+	fi
+	tag_parent=$(git rev-parse "${tag_commit}^" 2>/dev/null) || {
+		_release_provenance_error "release commit has no source parent"
+		return 1
+	}
+	[[ "$source_merge" == "$tag_parent" ]] || {
+		_release_provenance_error "recorded source merge is not the direct release parent"
+		return 1
+	}
+	return 0
+}
+
+_RELEASE_PROVENANCE_VERSION=""
+_RELEASE_PROVENANCE_TAG_COMMIT=""
+_RELEASE_PROVENANCE_TAG_OBJECT=""
+_RELEASE_PROVENANCE_SOURCE_PR=""
+_RELEASE_PROVENANCE_SOURCE_MERGE=""
+
+_release_provenance_verify_versions() {
+	local tag_name="$1"
+	local version=""
+	local expected_tag=""
+	local package_version=""
+
+	[[ -f VERSION ]] || {
+		_release_provenance_error "VERSION is missing"
+		return 1
+	}
+	IFS= read -r version <VERSION || {
+		_release_provenance_error "cannot read VERSION"
+		return 1
+	}
+	expected_tag="v${version}"
+	[[ "$tag_name" == "$expected_tag" ]] || {
+		_release_provenance_error "tag ${tag_name} does not match VERSION ${version}"
+		return 1
+	}
+	if [[ -f package.json ]]; then
+		package_version=$(jq -er '.version' package.json 2>/dev/null) || {
+			_release_provenance_error "cannot read package.json version"
+			return 1
+		}
+		[[ "$package_version" == "$version" ]] || {
+			_release_provenance_error "package.json ${package_version} does not match VERSION ${version}"
+			return 1
+		}
+	fi
+	_RELEASE_PROVENANCE_VERSION="$version"
+	return 0
+}
+
+_release_provenance_verify_local_tag() {
+	local tag_name="$1"
+	local tag_ref="refs/tags/${tag_name}"
+	local tag_type=""
+	local tag_object=""
+	local tag_commit=""
+	local head_commit=""
+	local commit_subject=""
+
+	tag_type=$(git cat-file -t "$tag_ref" 2>/dev/null) || {
+		_release_provenance_error "local tag ${tag_name} is missing"
+		return 1
+	}
+	[[ "$tag_type" == "tag" ]] || {
+		_release_provenance_error "${tag_name} must be annotated"
+		return 1
+	}
+	tag_object=$(git rev-parse "$tag_ref" 2>/dev/null) || {
+		_release_provenance_error "cannot resolve ${tag_name} tag object"
+		return 1
+	}
+	tag_commit=$(git rev-parse "${tag_ref}^{commit}" 2>/dev/null) || {
+		_release_provenance_error "cannot resolve ${tag_name} commit"
+		return 1
+	}
+	head_commit=$(git rev-parse HEAD 2>/dev/null) || {
+		_release_provenance_error "cannot resolve HEAD"
+		return 1
+	}
+	[[ "$head_commit" == "$tag_commit" ]] || {
+		_release_provenance_error "checkout HEAD does not equal ${tag_name} commit"
+		return 1
+	}
+	commit_subject=$(git log -1 --format='%s' "$tag_commit" 2>/dev/null) || {
+		_release_provenance_error "cannot read release commit"
+		return 1
+	}
+	[[ "$commit_subject" == "chore(release): bump version to ${_RELEASE_PROVENANCE_VERSION}" ]] || {
+		_release_provenance_error "tag does not target the expected release bump commit"
+		return 1
+	}
+	_RELEASE_PROVENANCE_TAG_COMMIT="$tag_commit"
+	_RELEASE_PROVENANCE_TAG_OBJECT="$tag_object"
+	return 0
+}
+
+_release_provenance_load_trailers() {
+	local tag_name="$1"
+	local recorded_version=""
+	local source_pr=""
+	local source_merge=""
+
+	recorded_version=$(_release_provenance_trailer "$tag_name" "Aidevops-Version") || {
+		_release_provenance_error "tag lacks Aidevops-Version provenance"
+		return 1
+	}
+	source_pr=$(_release_provenance_trailer "$tag_name" "Aidevops-Source-PR") || {
+		_release_provenance_error "tag lacks Aidevops-Source-PR provenance"
+		return 1
+	}
+	source_merge=$(_release_provenance_trailer "$tag_name" "Aidevops-Source-Merge") || {
+		_release_provenance_error "tag lacks Aidevops-Source-Merge provenance"
+		return 1
+	}
+	[[ "$recorded_version" == "$_RELEASE_PROVENANCE_VERSION" ]] || {
+		_release_provenance_error "recorded tag version does not match VERSION"
+		return 1
+	}
+	[[ "$source_pr" =~ ^[0-9]+$ ]] || {
+		_release_provenance_error "source PR is not numeric"
+		return 1
+	}
+	[[ "$source_merge" =~ ^[0-9a-f]{40}$ ]] || {
+		_release_provenance_error "source merge is not a full commit SHA"
+		return 1
+	}
+	_RELEASE_PROVENANCE_SOURCE_PR="$source_pr"
+	_RELEASE_PROVENANCE_SOURCE_MERGE="$source_merge"
+	return 0
+}
+
+_release_provenance_verify() {
+	local tag_name="$1"
+	local repo_slug="$2"
+	local branch_name="$3"
+
+	[[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+		_release_provenance_error "tag must be a complete semantic version"
+		return 1
+	}
+	[[ "$repo_slug" =~ ^[^/]+/[^/]+$ ]] || {
+		_release_provenance_error "repository must be OWNER/REPO"
+		return 1
+	}
+	[[ "$branch_name" =~ ^[A-Za-z0-9._/-]+$ ]] || {
+		_release_provenance_error "invalid canonical branch"
+		return 1
+	}
+	_release_provenance_verify_versions "$tag_name" || return 1
+	_release_provenance_verify_local_tag "$tag_name" || return 1
+	_release_provenance_load_trailers "$tag_name" || return 1
+
+	git fetch origin "$branch_name" --quiet 2>/dev/null || {
+		_release_provenance_error "cannot refresh origin/${branch_name}"
+		return 1
+	}
+	if ! git merge-base --is-ancestor "$_RELEASE_PROVENANCE_TAG_COMMIT" "origin/${branch_name}" 2>/dev/null; then
+		_release_provenance_error "release tag commit is not reachable from origin/${branch_name}"
+		return 1
+	fi
+	_release_provenance_verify_source_pr \
+		"$repo_slug" "$branch_name" "$_RELEASE_PROVENANCE_SOURCE_PR" \
+		"$_RELEASE_PROVENANCE_SOURCE_MERGE" "$_RELEASE_PROVENANCE_TAG_COMMIT" || return 1
+	_release_provenance_verify_github_tag \
+		"$repo_slug" "$tag_name" "$_RELEASE_PROVENANCE_TAG_COMMIT" \
+		"$_RELEASE_PROVENANCE_TAG_OBJECT" || return 1
+
+	printf 'release-provenance: verified %s at %s from PR #%s\n' \
+		"$tag_name" "$_RELEASE_PROVENANCE_TAG_COMMIT" "$_RELEASE_PROVENANCE_SOURCE_PR"
+	return 0
+}
+
+main() {
+	local command="${1:-}"
+	shift || true
+	local tag_name=""
+	local repo_slug=""
+	local branch_name="main"
+
+	case "$command" in
+	verify) ;;
+	help | --help | -h)
+		_release_provenance_usage
+		return 0
+		;;
+	*)
+		_release_provenance_usage >&2
+		return 1
+		;;
+	esac
+
+	while [[ $# -gt 0 ]]; do
+		local option="$1"
+		shift
+		case "$option" in
+		--tag)
+			tag_name="${1:-}"
+			shift || true
+			;;
+		--repo)
+			repo_slug="${1:-}"
+			shift || true
+			;;
+		--branch)
+			branch_name="${1:-}"
+			shift || true
+			;;
+		*) return 1 ;;
+		esac
+	done
+
+	[[ -n "$tag_name" && -n "$repo_slug" && -n "$branch_name" ]] || return 1
+	_release_provenance_verify "$tag_name" "$repo_slug" "$branch_name"
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-override-flags.sh
+++ b/.agents/scripts/tests/test-override-flags.sh
@@ -288,7 +288,7 @@ else
 	fi
 
 	# Verify the floor still exists (tag creation is after the bypass)
-	if grep -qF "git tag -a" "$VERSION_MGMT_RELEASE"; then
+	if grep -qF "git tag -s" "$VERSION_MGMT_RELEASE"; then
 		pass "AIDEVOPS_VM_SKIP_BUMP_VERIFY floor: git tag command still present after bypass site"
 	else
 		fail "AIDEVOPS_VM_SKIP_BUMP_VERIFY floor: git tag command missing from version-manager-release.sh"

--- a/.agents/scripts/tests/test-release-provenance-helper.sh
+++ b/.agents/scripts/tests/test-release-provenance-helper.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+# Keep disposable fixture repositories isolated from the developer Git shim,
+# hooks, signing policy, and global branch defaults.
+PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/release-provenance-helper.sh"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+REMOTE="${TEST_ROOT}/remote.git"
+REPO="${TEST_ROOT}/repo"
+BIN="${TEST_ROOT}/bin"
+
+mkdir -p "$BIN"
+git init -q --bare "$REMOTE"
+git clone -q "$REMOTE" "$REPO"
+git -C "$REPO" switch -q -c main
+git -C "$REPO" config user.name Test
+git -C "$REPO" config user.email test@example.invalid
+git -C "$REPO" commit -q --allow-empty -m 'historical merge'
+HISTORICAL_MERGE=$(git -C "$REPO" rev-parse HEAD)
+git -C "$REPO" commit -q --allow-empty -m 'source merge'
+SOURCE_MERGE=$(git -C "$REPO" rev-parse HEAD)
+printf '1.2.3\n' >"${REPO}/VERSION"
+printf '{"name":"fixture","version":"1.2.3"}\n' >"${REPO}/package.json"
+git -C "$REPO" add VERSION package.json
+git -C "$REPO" commit -q -m 'chore(release): bump version to 1.2.3'
+TAG_COMMIT=$(git -C "$REPO" rev-parse HEAD)
+git -C "$REPO" tag -a v1.2.3 -m "Release v1.2.3 - fixture
+
+Aidevops-Version: 1.2.3
+Aidevops-Source-PR: 42
+Aidevops-Source-Merge: ${SOURCE_MERGE}"
+git -C "$REPO" push -q -u origin main --tags
+
+cat >"${BIN}/gh" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "pr" ]]; then
+	case "\${PROVENANCE_MODE:-valid}" in
+	pr-mismatch) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-25T00:00:00Z","baseRefName":"main","mergeCommit":{"oid":"0000000000000000000000000000000000000000"}}' ;;
+	stale-source) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-25T00:00:00Z","baseRefName":"main","mergeCommit":{"oid":"${HISTORICAL_MERGE}"}}' ;;
+	*) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-25T00:00:00Z","baseRefName":"main","mergeCommit":{"oid":"${SOURCE_MERGE}"}}' ;;
+	esac
+	exit 0
+fi
+case "\${2:-}" in
+repos/test/repo/git/ref/tags/v1.2.3)
+	if [[ "\${PROVENANCE_MODE:-valid}" == "tag-object-mismatch" ]]; then
+		printf '%s\n' '{"object":{"type":"tag","sha":"0000000000000000000000000000000000000000"}}'
+	else
+		printf '{"object":{"type":"tag","sha":"%s"}}\n' "\$(git -C "${REPO}" rev-parse refs/tags/v1.2.3)"
+	fi
+	;;
+repos/test/repo/git/tags/*)
+	if [[ "\${PROVENANCE_MODE:-valid}" == "unverified" ]]; then
+		printf '%s\n' '{"tag":"v1.2.3","object":{"type":"commit","sha":"${TAG_COMMIT}"},"verification":{"verified":false}}'
+	else
+		printf '%s\n' '{"tag":"v1.2.3","object":{"type":"commit","sha":"${TAG_COMMIT}"},"verification":{"verified":true}}'
+	fi
+	;;
+*) exit 1 ;;
+esac
+STUB
+chmod +x "${BIN}/gh"
+
+run_helper() {
+	local mode="${1:-valid}"
+	(
+		cd "$REPO" || exit 1
+		export PROVENANCE_MODE="$mode"
+		PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+			bash "$HELPER" verify --tag v1.2.3 --repo test/repo
+	)
+	return $?
+}
+
+assert_rejected() {
+	local name="$1"
+	local mode="$2"
+	if run_helper "$mode" >/dev/null 2>&1; then
+		printf 'FAIL %s\n' "$name"
+		return 1
+	fi
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+run_helper >/dev/null || {
+	printf 'FAIL valid release provenance was rejected\n'
+	exit 1
+}
+printf 'PASS valid release provenance is accepted\n'
+
+assert_rejected "unverified GitHub tag is rejected" "unverified"
+assert_rejected "local and GitHub tag-object mismatch is rejected" "tag-object-mismatch"
+assert_rejected "source PR merge mismatch is rejected" "pr-mismatch"
+
+printf '1.2.4\n' >"${REPO}/VERSION"
+if run_helper >/dev/null 2>&1; then
+	printf 'FAIL version drift was accepted\n'
+	exit 1
+fi
+printf 'PASS version drift is rejected\n'
+printf '1.2.3\n' >"${REPO}/VERSION"
+
+git -C "$REPO" push -q --force origin "${SOURCE_MERGE}:main"
+if run_helper >/dev/null 2>&1; then
+	printf 'FAIL non-main release commit was accepted\n'
+	exit 1
+fi
+printf 'PASS non-main release commit is rejected\n'
+git -C "$REPO" push -q --force origin "${TAG_COMMIT}:main"
+
+git -C "$REPO" tag -d v1.2.3 >/dev/null
+git -C "$REPO" tag -a v1.2.3 -m "Release v1.2.3 - fixture
+
+Aidevops-Version: 1.2.3
+Aidevops-Source-PR: 42
+Aidevops-Source-Merge: ${HISTORICAL_MERGE}"
+assert_rejected "historical source PR ancestor is rejected" "stale-source"
+
+git -C "$REPO" tag -a v1.2.4 -m 'Release without provenance'
+if (
+	cd "$REPO" || exit 1
+	PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+		bash "$HELPER" verify --tag v1.2.4 --repo test/repo
+) >/dev/null 2>&1; then
+	printf 'FAIL malformed tag was accepted\n'
+	exit 1
+fi
+printf 'PASS malformed tag is rejected\n'
+
+exit 0

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)" || exit 1
+RELEASE_WORKFLOW="${REPO_ROOT}/.github/workflows/release.yml"
+PACKAGE_WORKFLOW="${REPO_ROOT}/.github/workflows/publish-packages.yml"
+
+assert_contains() {
+	local name="$1"
+	local pattern="$2"
+	local file="$3"
+	if ! grep -qF -- "$pattern" "$file"; then
+		printf 'FAIL %s\n' "$name"
+		return 1
+	fi
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+assert_absent() {
+	local name="$1"
+	local pattern="$2"
+	local file="$3"
+	if grep -qF -- "$pattern" "$file"; then
+		printf 'FAIL %s\n' "$name"
+		return 1
+	fi
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+assert_order() {
+	local name="$1"
+	local first_pattern="$2"
+	local second_pattern="$3"
+	local file="$4"
+	local first_line=""
+	local second_line=""
+
+	first_line=$(grep -nF -- "$first_pattern" "$file" | cut -d: -f1 | head -1)
+	second_line=$(grep -nF -- "$second_pattern" "$file" | cut -d: -f1 | head -1)
+	if [[ ! "$first_line" =~ ^[0-9]+$ || ! "$second_line" =~ ^[0-9]+$ || "$first_line" -ge "$second_line" ]]; then
+		printf 'FAIL %s\n' "$name"
+		return 1
+	fi
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+assert_absent "manual arbitrary-version publication is removed" "workflow_dispatch:" "$PACKAGE_WORKFLOW"
+assert_absent "package metadata is not rewritten before publish" "--no-git-tag-version" "$PACKAGE_WORKFLOW"
+assert_contains "release workflow verifies provenance" "release-provenance-helper.sh verify" "$RELEASE_WORKFLOW"
+# shellcheck disable=SC2016 # Intentional literal GitHub Actions expression.
+assert_contains "package workflow checks out release tag" 'ref: ${{ github.event.release.tag_name }}' "$PACKAGE_WORKFLOW"
+assert_contains "Homebrew job has read-only repository permission" "contents: read" "$PACKAGE_WORKFLOW"
+assert_order "release provenance precedes release creation" \
+	"release-provenance-helper.sh verify" "github-release-helper.sh create" "$RELEASE_WORKFLOW"
+assert_order "package provenance precedes npm publication" \
+	"release-provenance-helper.sh verify" "npm publish --provenance" "$PACKAGE_WORKFLOW"
+
+verification_count=$(grep -cF 'release-provenance-helper.sh verify' "$PACKAGE_WORKFLOW" || true)
+if [[ "$verification_count" -ne 2 ]]; then
+	printf 'FAIL npm and Homebrew jobs must each verify provenance\n'
+	exit 1
+fi
+printf 'PASS npm and Homebrew jobs each verify provenance\n'
+
+exit 0

--- a/.agents/scripts/tests/test-version-manager-release-provenance.sh
+++ b/.agents/scripts/tests/test-version-manager-release-provenance.sh
@@ -27,6 +27,8 @@ git -C "$REPO" config user.name Test
 git -C "$REPO" config user.email test@example.invalid
 git -C "$REPO" config commit.gpgsign false
 git -C "$REPO" commit -q --allow-empty -m seed
+HISTORICAL_MERGE=$(git -C "$REPO" rev-parse HEAD)
+git -C "$REPO" commit -q --allow-empty -m 'current source merge'
 git -C "$REPO" push -q -u origin main
 git -C "$REPO" remote set-head origin main
 MERGE_SHA=$(git -C "$REPO" rev-parse HEAD)
@@ -36,7 +38,7 @@ cat >"${BIN}/gh" <<STUB
 #!/usr/bin/env bash
 case "\${PROVENANCE_MODE:-merged}" in
 	open) printf '%s\n' '{"state":"OPEN","mergedAt":null,"baseRefName":"main","headRefOid":"head123","mergeCommit":null}' ;;
-	stale) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","baseRefName":"main","headRefOid":"head123","mergeCommit":{"oid":"0000000000000000000000000000000000000000"}}' ;;
+	stale) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","baseRefName":"main","headRefOid":"head123","mergeCommit":{"oid":"${HISTORICAL_MERGE}"}}' ;;
 	*) printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","baseRefName":"main","headRefOid":"head123","mergeCommit":{"oid":"${MERGE_SHA}"}}' ;;
 esac
 exit 0
@@ -49,6 +51,33 @@ print_warning() { return 0; }
 print_success() { return 0; }
 export SCRIPT_DIR REPO_ROOT="$LINKED"
 source "${SCRIPT_DIR}/version-manager-git.sh"
+source "${SCRIPT_DIR}/version-manager-release.sh"
+
+release_source_pr_required() { return 0; }
+VERSION_MANAGER_SOURCE_PR=42
+VERSION_MANAGER_SOURCE_MERGE_SHA="$MERGE_SHA"
+tag_message=$(_release_tag_message 1.2.3) || {
+	printf 'FAIL release tag provenance message was rejected\n'
+	exit 1
+}
+for expected_trailer in \
+	'Aidevops-Version: 1.2.3' \
+	'Aidevops-Source-PR: 42' \
+	"Aidevops-Source-Merge: ${MERGE_SHA}"; do
+	if [[ "$tag_message" != *"$expected_trailer"* ]]; then
+		printf 'FAIL release tag message lacks %s\n' "$expected_trailer"
+		exit 1
+	fi
+done
+printf 'PASS release tag message records immutable source provenance\n'
+
+VERSION_MANAGER_SOURCE_PR=""
+if _release_tag_message 1.2.3 >/dev/null 2>&1; then
+	printf 'FAIL release tag message accepted missing source PR provenance\n'
+	exit 1
+fi
+printf 'PASS release tag message rejects missing source PR provenance\n'
+VERSION_MANAGER_SOURCE_PR=42
 
 PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin" verify_release_source_pr 42 main testorg/aidevops || {
 	printf 'FAIL merged source PR provenance was rejected\n'
@@ -63,10 +92,10 @@ fi
 printf 'PASS open source PR is rejected\n'
 
 if PROVENANCE_MODE=stale PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin" verify_release_source_pr 42 main testorg/aidevops; then
-	printf 'FAIL unreachable merge SHA was accepted\n'
+	printf 'FAIL stale historical source PR was accepted\n'
 	exit 1
 fi
-printf 'PASS unreachable merge SHA is rejected\n'
+printf 'PASS stale historical source PR is rejected\n'
 
 git -C "$REPO" switch -q -c safety/release-test
 printf 'canonical human work\n' >>"${REPO}/README.md"
@@ -86,5 +115,31 @@ if grep -qF 'verify_canonical_default_synced' "${SCRIPT_DIR}/version-manager.sh"
 	exit 1
 fi
 printf 'PASS release path has no canonical synchronization dependency\n'
+
+CONCURRENT="${ROOT}/concurrent"
+git clone -q -b main "$REMOTE" "$CONCURRENT"
+git -C "$CONCURRENT" config user.name Test
+git -C "$CONCURRENT" config user.email test@example.invalid
+git -C "$CONCURRENT" commit -q --allow-empty -m 'concurrent main update'
+git -C "$CONCURRENT" push -q origin HEAD:main
+
+printf '1.2.3\n' >"${LINKED}/VERSION"
+git -C "$LINKED" add VERSION
+git -C "$LINKED" commit -q -m 'chore(release): bump version to 1.2.3'
+git -C "$LINKED" tag -a v1.2.3 -m "Release v1.2.3 - fixture
+
+Aidevops-Version: 1.2.3
+Aidevops-Source-PR: 42
+Aidevops-Source-Merge: ${MERGE_SHA}"
+if push_changes 1.2.3 >/dev/null 2>&1; then
+	printf 'FAIL concurrent main update was rebased into release publication\n'
+	exit 1
+fi
+if git -C "$LINKED" show-ref --verify --quiet refs/tags/v1.2.3 ||
+	git -C "$REMOTE" show-ref --verify --quiet refs/tags/v1.2.3; then
+	printf 'FAIL concurrent main update left a release tag behind\n'
+	exit 1
+fi
+printf 'PASS concurrent main update aborts without publishing a release tag\n'
 
 exit 0

--- a/.agents/scripts/tests/test-version-manager-release-rest-fallback.sh
+++ b/.agents/scripts/tests/test-version-manager-release-rest-fallback.sh
@@ -9,6 +9,12 @@
 
 set -uo pipefail
 
+# Keep the disposable fixture repository isolated from the developer Git shim.
+PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
 TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_RED=$'\033[0;31m'
 TEST_GREEN=$'\033[0;32m'
@@ -96,6 +102,16 @@ export FAKE_GH_LOG="${TEST_ROOT}/gh.log"
 export FAKE_GH_RELEASE_MARKER="${TEST_ROOT}/release-created.marker"
 
 rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+_verify_github_release_provenance() { return 1; }
+rc=0
+create_github_release '1.2.4' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 && ! -s "$FAKE_GH_LOG" ]]; then
+	print_result 'GitHub release creation fails closed before publication' 0
+else
+	print_result 'GitHub release creation fails closed before publication' 1 "rc=$rc"
+fi
+
+_verify_github_release_provenance() { return 0; }
 export FAKE_REST_VIEW_SUCCEEDS=1
 rc=0
 output=$(create_github_release '1.2.4' 2>&1) || rc=$?

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -160,11 +160,20 @@ verify_release_source_pr() {
 	fi
 
 	local merge_sha=""
+	local release_head=""
 	merge_sha=$(printf '%s' "$pr_json" | jq -r '.mergeCommit.oid')
 	if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$merge_sha" "origin/${branch}" 2>/dev/null; then
 		print_error "Source PR #${source_pr} merge SHA is not reachable from origin/${branch}"
 		return 1
 	fi
+	release_head=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null) || {
+		print_error "Cannot resolve release checkout HEAD"
+		return 1
+	}
+	[[ "$merge_sha" == "$release_head" ]] || {
+		print_error "Source PR #${source_pr} must be the direct source of the release checkout"
+		return 1
+	}
 	VERSION_MANAGER_SOURCE_PR="$source_pr"
 	VERSION_MANAGER_SOURCE_MERGE_SHA="$merge_sha"
 	export VERSION_MANAGER_SOURCE_PR VERSION_MANAGER_SOURCE_MERGE_SHA
@@ -591,7 +600,12 @@ commit_version_changes() {
 push_changes() {
 	local version="$1" # version string, e.g. "3.8.71"
 	local tag_name="v$version"
+	local release_parent=""
 	cd "$REPO_ROOT" || exit 1
+	release_parent=$(git rev-parse HEAD^ 2>/dev/null) || {
+		print_error "Cannot resolve release source parent"
+		return 1
+	}
 
 	local attempt=0 max_attempts=10 delay=2
 	while [[ $attempt -lt $max_attempts ]]; do
@@ -604,46 +618,19 @@ push_changes() {
 			return 0
 		fi
 
-		# Non-fast-forward: rebase and retry
-		print_info "Push failed (conflict). Fetching and rebasing..."
+		# A release tag's signed provenance binds the bump commit directly to its
+		# source merge. Never rebase and recreate that tag after concurrent main
+		# movement; doing so would invalidate both the signature and provenance.
+		print_info "Push failed. Refreshing remote state before retry..."
 		if ! git fetch origin main --quiet; then
 			print_error "Fetch failed, cannot retry"
 			return 1
 		fi
-
-		if ! git rebase origin/main; then
-			print_error "Rebase conflict, manual intervention needed"
-			git rebase --abort 2>/dev/null || true
-			return 1
-		fi
-
-		# CRITICAL (t2437/GH#20073): Verify the rebase did NOT silently drop our
-		# bump commit before retagging HEAD. A rebase can lose the bump commit
-		# without a conflict if (a) Git treats it as already applied (duplicate
-		# patch upstream), (b) an interactive rebase drops it, or (c) the remote
-		# fast-forwards past it in a way that makes our commit empty. In every
-		# such case, HEAD becomes origin/main and retagging HEAD would place
-		# the release tag on the wrong commit — exactly the symptom observed
-		# in the broken v3.8.82 release (GH#20073).
-		if ! _verify_bump_commit_at_ref HEAD "$version"; then
-			print_error "Rebase silently dropped the bump commit for v$version"
-			print_info "HEAD is now $(git rev-parse HEAD), not a bump-version commit"
-			print_info "Recovery:"
-			print_info "  1. Inspect: git log --oneline origin/main..HEAD"
-			print_info "  2. Discard this release worktree and create a fresh detached worktree from origin/main"
-			print_info "  3. Delete local tag: git tag -d $tag_name"
-			print_info "  4. Re-run: $0 release <bump-type>"
-			# Clean up the stale local tag to avoid divergence on next attempt.
+		if [[ "$(git rev-parse origin/main 2>/dev/null)" != "$release_parent" ]]; then
+			print_error "origin/main advanced after release provenance was recorded"
+			print_info "Discard this release worktree and rerun from the latest merged source PR"
 			git tag -d "$tag_name" 2>/dev/null || true
 			return 1
-		fi
-
-		# Tag must be recreated on the new HEAD after rebase (HEAD has been
-		# verified above to be the bump commit for $version).
-		if git show-ref --tags "$tag_name" &>/dev/null; then
-			print_info "Recreating tag $tag_name on rebased HEAD..."
-			git tag -d "$tag_name"
-			git tag -a "$tag_name" -m "$tag_name"
 		fi
 
 		if [[ $attempt -lt $max_attempts ]]; then

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -48,6 +48,27 @@ _version_manager_repo_slug() {
 	return 0
 }
 
+_verify_github_release_provenance() {
+	local version="$1"
+	local tag_name="v${version}"
+	local slug=""
+
+	slug=$(_version_manager_repo_slug)
+	[[ -n "$slug" ]] || {
+		print_error "Cannot verify GitHub release provenance: cannot determine repo slug from origin"
+		return 1
+	}
+	if ! (
+		cd "$REPO_ROOT" || exit 1
+		bash "${SCRIPT_DIR}/release-provenance-helper.sh" verify \
+			--tag "$tag_name" --repo "$slug"
+	); then
+		print_error "GitHub release provenance verification failed for ${tag_name}"
+		return 1
+	fi
+	return 0
+}
+
 _github_release_rest_view() {
 	local slug="$1"
 	local tag_name="$2"
@@ -107,10 +128,36 @@ _github_release_recover_with_rest() {
 	return 1
 }
 
+_release_tag_message() {
+	local version="$1"
+	local source_pr="${VERSION_MANAGER_SOURCE_PR:-}"
+	local source_merge="${VERSION_MANAGER_SOURCE_MERGE_SHA:-}"
+
+	if release_source_pr_required; then
+		[[ "$source_pr" =~ ^[0-9]+$ ]] || {
+			print_error "Release tag requires verified source-PR provenance"
+			return 1
+		}
+		[[ "$source_merge" =~ ^[0-9a-f]{40}$ ]] || {
+			print_error "Release tag requires a verified source merge SHA"
+			return 1
+		}
+	fi
+
+	printf 'Release v%s - AI DevOps Framework\n\n' "$version"
+	printf 'Aidevops-Version: %s\n' "$version"
+	if [[ -n "$source_pr" && -n "$source_merge" ]]; then
+		printf 'Aidevops-Source-PR: %s\n' "$source_pr"
+		printf 'Aidevops-Source-Merge: %s\n' "$source_merge"
+	fi
+	return 0
+}
+
 # Function to create git tag
 create_git_tag() {
 	local version="$1"
 	local tag_name="v$version"
+	local tag_message=""
 
 	print_info "Creating git tag: $tag_name"
 
@@ -165,7 +212,8 @@ create_git_tag() {
 		fi
 	fi
 
-	if git tag -a "$tag_name" -m "Release $tag_name - AI DevOps Framework"; then
+	tag_message=$(_release_tag_message "$version") || return 1
+	if git tag -s "$tag_name" -m "$tag_message"; then
 		print_success "Created git tag: $tag_name"
 		return 0
 	else
@@ -181,6 +229,10 @@ create_github_release() {
 	local tag_name="v$version"
 
 	print_info "Creating GitHub release: $tag_name"
+	if ! _verify_github_release_provenance "$version"; then
+		print_error "Refusing to create or reconcile an unverified GitHub release"
+		return 1
+	fi
 
 	# Try GitHub CLI first
 	if command -v gh &>/dev/null && gh auth status &>/dev/null; then

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -341,11 +341,9 @@ _release_handle_push_failure() {
 	print_warning "Rolling back local tag v$new_version due to push failure"
 	git tag -d "v$new_version" 2>/dev/null || true
 	echo ""
-	print_info "The version commit exists locally. To complete the release:"
-	print_info "  1. Fix the issue (e.g., git fetch origin && git rebase origin/main)"
-	print_info "  2. Re-create tag: git tag -a v$new_version -m 'Release v$new_version'"
-	print_info "  3. Push: git push --atomic origin main --tags"
-	print_info "  4. Create release: $0 github-release"
+	print_info "The unpushed version commit remains local for diagnosis only."
+	print_info "Discard this release worktree and rerun the release from current origin/main"
+	print_info "with the latest merged source PR; never recreate the provenance tag manually."
 	exit 1
 }
 

--- a/.github/workflows/counter-monotonic.yml
+++ b/.github/workflows/counter-monotonic.yml
@@ -18,6 +18,9 @@ on:
     branches: [main]
     paths: ['.task-counter']
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -49,6 +49,12 @@ on:
         required: false
         type: string
 
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   sync:
     uses: ./.github/workflows/issue-sync-reusable.yml

--- a/.github/workflows/markdoc-validate.yml
+++ b/.github/workflows/markdoc-validate.yml
@@ -26,6 +26,9 @@ on:
       - '.agents/tools/markdoc/schemas/**'
       - '.agents/scripts/markdoc-validate.sh'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/plugin-import-check.yml
+++ b/.github/workflows/plugin-import-check.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - '.agents/plugins/**/*.mjs'
 
+permissions:
+  contents: read
+
 concurrency:
   group: plugin-import-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -3,14 +3,9 @@ name: Publish Packages
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g., 2.52.1)'
-        required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.version || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
   cancel-in-progress: true
 
 jobs:
@@ -24,7 +19,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify immutable release provenance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          bash .agents/scripts/release-provenance-helper.sh verify \
+            --tag "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY"
+
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -50,20 +57,8 @@ jobs:
       
       - name: Get version
         id: version
-        env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ -n "$INPUT_VERSION" ]; then
-            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Update package.json version
-        env:
-          PKG_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          npm version "$PKG_VERSION" --no-git-tag-version --allow-same-version
+          echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
       
       # No token needed - uses OIDC Trusted Publisher authentication
       - name: Publish to npm
@@ -88,23 +83,29 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-npm
     permissions:
-      contents: write
+      contents: read
     
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify immutable release provenance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          bash .agents/scripts/release-provenance-helper.sh verify \
+            --tag "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY"
+
       - name: Get version and SHA
         id: release
-        env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ -n "$INPUT_VERSION" ]; then
-            VERSION="$INPUT_VERSION"
-          else
-            VERSION=$(cat VERSION)
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION=$(cat VERSION)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           
           # Get SHA256 of the release tarball (fail on HTTP errors)
           TARBALL_URL="https://github.com/marcusquinn/aidevops/archive/refs/tags/v${VERSION}.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Verify immutable release provenance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          bash .agents/scripts/release-provenance-helper.sh verify \
+            --tag "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY"
 
       - name: Extract CHANGELOG section
         id: changelog

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -32,6 +32,11 @@ on:
     # not on the Phase 2 edit that makes the placeholder a real review.
     types: [created, edited]
 
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
 jobs:
   gate:
     # Apply the complete event matrix before concurrency admission. GitHub keeps

--- a/.github/workflows/task-id-collision-check.yml
+++ b/.github/workflows/task-id-collision-check.yml
@@ -23,6 +23,10 @@ on:
       - 'README.md'
       - 'CHANGELOG.md'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/update-website-docs.yml
+++ b/.github/workflows/update-website-docs.yml
@@ -10,6 +10,9 @@ on:
       - 'docs/assets/star-history.svg'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/version-validation.yml
+++ b/.github/workflows/version-validation.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- add a shared fail-closed verifier for signed annotated release tags, immutable tag-object identity, version consistency, canonical ancestry, and direct source-PR merge provenance
- gate GitHub release, npm, and Homebrew publication paths before side effects; remove arbitrary manual version publication and package rewriting
- declare least-privilege permissions for workflows that relied on repository defaults
- abort concurrent-main release attempts without rebasing or recreating unsigned tags
- document the separately approved live-settings rollout for protected tags, release environments, Actions defaults, and npm Trusted Publisher identity

## Verification

- focused release provenance, publication workflow, version-manager provenance, and REST fallback suites
- concurrent-main negative regression proving no local or remote release tag remains
- ShellCheck and Bash syntax checks for changed shell files
- actionlint for all changed workflows
- `.agents/scripts/linters-local.sh`
- independent security re-review: APPROVE

## Scope

This is the code-hardening checkpoint for #28625. Live repository, environment, npm, and tag-policy mutations remain deferred for separate explicit approval, so this PR intentionally does not close the parent issue.

For #28625

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 1h 9m and 611,349 tokens on this with the user in an interactive session.