### PR TITLE
GH#28633: Preserve untracked state during canonical updates

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
@@ -33,6 +33,18 @@ fi
 
 _AIDEVOPS_UPDATE_TRUE=true
 
+_update_canonical_has_untracked_only() {
+	local real_git="$1"
+	local repo_path="$2"
+	local tracked_status=""
+	local untracked_files=""
+	tracked_status=$("$real_git" -C "$repo_path" status --porcelain=v1 --untracked-files=no 2>/dev/null) || return 1
+	[[ -z "$tracked_status" ]] || return 1
+	untracked_files=$("$real_git" -C "$repo_path" ls-files --others --exclude-standard 2>/dev/null) || return 1
+	[[ -n "$untracked_files" ]]
+	return $?
+}
+
 _update_fetch_main() {
 	local branch="$1"
 	_AIDEVOPS_UPDATE_CANONICAL_FAST_FORWARDED=false
@@ -53,7 +65,7 @@ _update_fetch_main() {
 	local stable_helper="${HOME}/.aidevops/agents/scripts/canonical-recovery-helper.sh"
 	for candidate in "$bundled_helper" "$source_helper" "$stable_helper"; do
 		[[ -f "$candidate" ]] || continue
-		if grep -q -- '--reason aidevops-update' "$candidate" 2>/dev/null; then
+		if grep -q -- 'sync-mirror.*--reason aidevops-update' "$candidate" 2>/dev/null; then
 			helper="$candidate"
 			break
 		fi
@@ -64,10 +76,27 @@ _update_fetch_main() {
 		return 1
 	fi
 
-	print_info "Using audited canonical fast-forward for the source checkout..."
-	if ! AIDEVOPS_REAL_GIT_BIN="$real_git" bash "$helper" fast-forward-current \
-		--repo "$INSTALL_DIR" --branch "$branch" --reason aidevops-update \
-		--confirm FAST_FORWARD_CANONICAL_BRANCH; then
+	local recovery_command="fast-forward-current"
+	local recovery_confirmation="FAST_FORWARD_CANONICAL_BRANCH"
+	local status_output=""
+	status_output=$("$real_git" -C "$INSTALL_DIR" status --porcelain=v1 2>/dev/null) || return 1
+	if [[ -n "$status_output" ]]; then
+		if ! _update_canonical_has_untracked_only "$real_git" "$INSTALL_DIR"; then
+			print_error "Audited canonical update requires a clean tracked/index state."
+			return 1
+		fi
+		recovery_command="sync-mirror"
+		recovery_confirmation="SYNCHRONIZE_CANONICAL_MIRROR"
+		print_info "Preserving untracked canonical files before the audited update..."
+	else
+		print_info "Using audited canonical fast-forward for the source checkout..."
+	fi
+	local recovery_args=("$recovery_command" --repo "$INSTALL_DIR")
+	if [[ "$recovery_command" == "fast-forward-current" ]]; then
+		recovery_args+=(--branch "$branch")
+	fi
+	recovery_args+=(--reason aidevops-update --confirm "$recovery_confirmation")
+	if ! AIDEVOPS_REAL_GIT_BIN="$real_git" bash "$helper" "${recovery_args[@]}"; then
 		print_error "Audited canonical fast-forward failed; no update was deployed."
 		return 1
 	fi

--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -3,11 +3,13 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 set -euo pipefail
+# Supports: sync-mirror --repo PATH --reason aidevops-update
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 FAST_FORWARD_CMD="fast-forward-current"
 SYNC_MIRROR_CMD="sync-mirror"
 CLEAR_STALE_REBASE_CMD="clear-stale-rebase"
 CLEAR_ABANDONED_REBASE_CMD="clear-abandoned-rebase"
+AIDEVOPS_UPDATE_REASON="aidevops-update"
 ABANDONED_REBASE_MIN_AGE_SECONDS=86400
 ABANDONED_REBASE_KIND="abandoned"
 HEAD_COMMIT_EXPR='HEAD^{commit}'
@@ -265,8 +267,9 @@ usage() {
 		"  canonical-recovery-helper.sh ${CLEAR_STALE_REBASE_CMD} --repo PATH --issue N --confirm CLEAR_CONVERGED_STALE_REBASE" \
 		"  canonical-recovery-helper.sh ${CLEAR_ABANDONED_REBASE_CMD} --repo PATH --issue N --confirm CLEAR_ABANDONED_STALE_REBASE" \
 		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --issue N --confirm FAST_FORWARD_CANONICAL_BRANCH" \
-		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --reason aidevops-update --confirm FAST_FORWARD_CANONICAL_BRANCH" \
-		"  canonical-recovery-helper.sh ${SYNC_MIRROR_CMD} --repo PATH --issue N --confirm SYNCHRONIZE_CANONICAL_MIRROR"
+		"  canonical-recovery-helper.sh ${FAST_FORWARD_CMD} --repo PATH --branch BRANCH --reason ${AIDEVOPS_UPDATE_REASON} --confirm FAST_FORWARD_CANONICAL_BRANCH" \
+		"  canonical-recovery-helper.sh ${SYNC_MIRROR_CMD} --repo PATH --issue N --confirm SYNCHRONIZE_CANONICAL_MIRROR" \
+		"  canonical-recovery-helper.sh ${SYNC_MIRROR_CMD} --repo PATH --reason ${AIDEVOPS_UPDATE_REASON} --confirm SYNCHRONIZE_CANONICAL_MIRROR"
 	return 0
 }
 
@@ -353,7 +356,8 @@ esac
 }
 if [[ "$issue_number" =~ ^[0-9]+$ && -z "$maintenance_reason" ]]; then
 	audit_reference="issue ${issue_number}"
-elif [[ -z "$issue_number" && "$cmd" == "$FAST_FORWARD_CMD" && "$maintenance_reason" == "aidevops-update" ]]; then
+elif [[ -z "$issue_number" && ("$cmd" == "$FAST_FORWARD_CMD" || "$cmd" == "$SYNC_MIRROR_CMD") &&
+	"$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]]; then
 	audit_reference="reason ${maintenance_reason}"
 else
 	usage
@@ -444,6 +448,20 @@ local_sha=$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit
 	printf 'BLOCKED: local %s tip cannot be resolved\n' "$target_branch" >&2
 	exit 1
 }
+if [[ "$cmd" == "$SYNC_MIRROR_CMD" && "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]]; then
+	tracked_status=$("$REAL_GIT" -C "$repo_path" status --porcelain=v1 --untracked-files=no) || {
+		printf 'BLOCKED: canonical tracked/index state cannot be read safely\n' >&2
+		exit 1
+	}
+	[[ -z "$tracked_status" ]] || {
+		printf 'BLOCKED: routine update synchronization accepts untracked-only state\n' >&2
+		exit 1
+	}
+	"$REAL_GIT" -C "$repo_path" merge-base --is-ancestor "$local_ref" "$target_sha" || {
+		printf 'BLOCKED: routine update synchronization will not replace local commits\n' >&2
+		exit 1
+	}
+fi
 
 stale_rebase_dir=""
 stale_rebase_fingerprint=""
@@ -575,10 +593,11 @@ if [[ "$cmd" == "$SYNC_MIRROR_CMD" ]]; then
 			printf 'BLOCKED: dirty-worktree backup helper is unavailable\n' >&2
 			exit 1
 		}
+		backup_operation_key="${issue_number:-$maintenance_reason}"
 		backup_output=$(AIDEVOPS_REAL_GIT_BIN="$REAL_GIT" bash "$backup_helper" backup \
 			--repo "$repo_path" --reason "canonical mirror synchronization" \
 			--issue "$issue_number" \
-			--operation-id "canonical-sync-${issue_number}-${target_sha}" --machine) || {
+			--operation-id "canonical-sync-${backup_operation_key}-${target_sha}" --machine) || {
 			printf 'BLOCKED: canonical dirty state could not be preserved\n' >&2
 			exit 1
 		}
@@ -998,6 +1017,18 @@ if [[ "$cmd" == "$FAST_FORWARD_CMD" || "$cmd" == "$SYNC_MIRROR_CMD" ]]; then
 	[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] || exit 1
 	[[ -z "$("$REAL_GIT" -C "$repo_path" status --porcelain)" ]] || exit 1
 	if [[ "$cmd" == "$SYNC_MIRROR_CMD" ]]; then
+		if [[ "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" && -n "$sync_backup_id" ]]; then
+			retention_days="${AIDEVOPS_DIRTY_BACKUP_RETENTION_DAYS:-30}"
+			[[ "$retention_days" =~ ^[0-9]+$ ]] || retention_days=30
+			if ! AIDEVOPS_REAL_GIT_BIN="$REAL_GIT" bash "$backup_helper" acknowledge \
+				--backup "$sync_backup_id" --confirm ACKNOWLEDGE_DIRTY_WORKTREE_BACKUP >/dev/null; then
+				printf 'WARNING: synchronized backup remains open and requires manual acknowledgement: %s\n' \
+					"$sync_backup_id" >&2
+			elif ! AIDEVOPS_REAL_GIT_BIN="$REAL_GIT" bash "$backup_helper" prune \
+				--force --retention-days "$retention_days" >/dev/null; then
+				printf 'WARNING: synchronized mirror succeeded but expired backup pruning failed\n' >&2
+			fi
+		fi
 		printf 'SYNCHRONIZED_CANONICAL_MIRROR=true\n'
 		printf 'OLD_SHA=%s\n' "$local_sha"
 		printf 'NEW_SHA=%s\n' "$target_sha"

--- a/.agents/scripts/dirty-worktree-backup-helper.sh
+++ b/.agents/scripts/dirty-worktree-backup-helper.sh
@@ -708,8 +708,8 @@ backup_age_days() {
 	local now_epoch=""
 	local backup_epoch=""
 	now_epoch=$(date +%s)
-	if command -v portable_stat_mtime >/dev/null 2>&1; then
-		backup_epoch=$(portable_stat_mtime "$backup_dir" 2>/dev/null || printf '%s' "$now_epoch")
+	if command -v _file_mtime_epoch >/dev/null 2>&1; then
+		backup_epoch=$(_file_mtime_epoch "$backup_dir" 2>/dev/null || printf '%s' "$now_epoch")
 	else
 		backup_epoch="$now_epoch"
 	fi

--- a/.agents/scripts/tests/test-aidevops-update-transaction.sh
+++ b/.agents/scripts/tests/test-aidevops-update-transaction.sh
@@ -53,6 +53,10 @@ for function_name in _update_verify_deployment_state _run_update_setup_transacti
 done
 extract_function _update_fetch_main "$TEST_ROOT/_update_fetch_main.sh" \
 	"$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
+extract_function _update_canonical_has_untracked_only "$TEST_ROOT/_update_canonical_has_untracked_only.sh" \
+	"$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
+# shellcheck source=/dev/null
+source "$TEST_ROOT/_update_canonical_has_untracked_only.sh"
 # shellcheck source=/dev/null
 source "$TEST_ROOT/_update_fetch_main.sh"
 
@@ -335,6 +339,7 @@ INTEGRATION_REPO="$TEST_ROOT/integration-repo"
 INTEGRATION_PEER="$TEST_ROOT/integration-peer"
 SETUP_CALLS="$TEST_ROOT/setup-calls"
 CANONICAL_HELPER_CALLS="$TEST_ROOT/canonical-helper-calls"
+UPDATE_HELPER_DIR="$TEST_ROOT/update-helper"
 /usr/bin/git init -q --bare -b main "$INTEGRATION_REMOTE"
 /usr/bin/git init -q -b main "$INTEGRATION_REPO"
 /usr/bin/git -C "$INTEGRATION_REPO" config user.email test@example.invalid
@@ -354,12 +359,14 @@ printf 'updated\n' >"$INTEGRATION_PEER/runtime.txt"
 /usr/bin/git -C "$INTEGRATION_PEER" push -q origin main
 REMOTE_SHA=$(/usr/bin/git -C "$INTEGRATION_PEER" rev-parse HEAD)
 
-mkdir -p "$INTEGRATION_REPO/.agents/scripts"
-cat >"$INTEGRATION_REPO/.agents/scripts/canonical-recovery-helper.sh" <<'EOF'
+mkdir -p "$UPDATE_HELPER_DIR"
+cat >"$UPDATE_HELPER_DIR/canonical-recovery-helper.sh" <<'EOF'
 #!/usr/bin/env bash
-# Supports: --reason aidevops-update
+# Supports: sync-mirror --repo PATH --reason aidevops-update
 set -euo pipefail
 printf '%s\n' "$*" >>"$CANONICAL_HELPER_CALLS"
+command_name="$1"
+shift
 repo=""
 branch=""
 while [[ $# -gt 0 ]]; do
@@ -368,12 +375,22 @@ while [[ $# -gt 0 ]]; do
 	--branch) branch="$2"; shift 2 ;;
 	*) shift ;;
 	esac
-done
+	done
+if [[ "$command_name" == "sync-mirror" ]]; then
+	branch="main"
+	mkdir -p "$HOME/untracked-update-backup"
+	while IFS= read -r untracked_path; do
+		[[ -n "$untracked_path" ]] || continue
+	cp "$repo/$untracked_path" "$HOME/untracked-update-backup/${untracked_path##*/}"
+	rm "$repo/$untracked_path"
+	done < <(/usr/bin/git -C "$repo" ls-files --others --exclude-standard)
+fi
 /usr/bin/git -C "$repo" fetch origin "$branch" --tags --quiet
 /usr/bin/git -C "$repo" merge --ff-only "origin/$branch" --quiet
 EOF
-chmod +x "$INTEGRATION_REPO/.agents/scripts/canonical-recovery-helper.sh"
+chmod +x "$UPDATE_HELPER_DIR/canonical-recovery-helper.sh"
 export CANONICAL_HELPER_CALLS
+_AIDEVOPS_UPDATE_HELPER_DIR="$UPDATE_HELPER_DIR"
 
 INSTALL_DIR="$INTEGRATION_REPO"
 SETUP_RC=0
@@ -413,6 +430,17 @@ else
 	fail "shim-safe audited canonical fast-forward reaches setup and verifies activation" "$integration_output"
 fi
 
+printf 'untracked update fixture\n' >"$INTEGRATION_REPO/untracked-update.txt"
+if untracked_output=$(cmd_update --skip-project-sync --compact) &&
+	[[ ! -e "$INTEGRATION_REPO/untracked-update.txt" ]] &&
+	[[ -f "$HOME/untracked-update-backup/untracked-update.txt" ]] &&
+	grep -q -- '^sync-mirror .*--reason aidevops-update' "$CANONICAL_HELPER_CALLS" &&
+	[[ "$untracked_output" == *"Preserving untracked canonical files"* ]]; then
+	pass "untracked-only canonical update uses lossless mirror synchronization"
+else
+	fail "untracked-only canonical update uses lossless mirror synchronization" "$untracked_output"
+fi
+
 printf 'dirty update fixture\n' >>"$INTEGRATION_REPO/runtime.txt"
 helper_calls_before=$(wc -l <"$CANONICAL_HELPER_CALLS")
 if dirty_output=$(cmd_update --skip-project-sync --compact 2>&1); then
@@ -426,7 +454,7 @@ else
 fi
 /usr/bin/git -C "$INTEGRATION_REPO" checkout -q -- runtime.txt
 
-rm "$INTEGRATION_REPO/.agents/scripts/canonical-recovery-helper.sh"
+rm "$UPDATE_HELPER_DIR/canonical-recovery-helper.sh"
 if missing_helper_output=$(_update_fetch_main main 2>&1); then
 	fail "missing canonical helper fails with stable-path guidance" "unexpected success"
 elif [[ "$missing_helper_output" == *"$HOME/.aidevops/agents/scripts/canonical-recovery-helper.sh"* ]] &&

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -826,3 +826,76 @@ else
 	printf 'FAIL repeated synchronization duplicated evidence or lost auditability\n'
 	exit 1
 fi
+
+UPDATE_REMOTE="${ROOT}/update-remote.git"
+UPDATE_REPO="${ROOT}/update-repo"
+UPDATE_PEER="${ROOT}/update-peer"
+UPDATE_BACKUPS="${ROOT}/update-backups"
+mkdir -p "$UPDATE_REPO"
+/usr/bin/git init -q --bare "$UPDATE_REMOTE"
+/usr/bin/git -C "$UPDATE_REPO" init -q -b main
+/usr/bin/git -C "$UPDATE_REPO" config user.name Test
+/usr/bin/git -C "$UPDATE_REPO" config user.email test@example.invalid
+/usr/bin/git -C "$UPDATE_REPO" config commit.gpgsign false
+printf 'update seed\n' >"${UPDATE_REPO}/README.md"
+/usr/bin/git -C "$UPDATE_REPO" add README.md
+/usr/bin/git -C "$UPDATE_REPO" commit -q -m seed
+/usr/bin/git -C "$UPDATE_REPO" remote add origin "$UPDATE_REMOTE"
+/usr/bin/git -C "$UPDATE_REPO" push -q -u origin main
+/usr/bin/git -C "$UPDATE_REMOTE" symbolic-ref HEAD refs/heads/main
+/usr/bin/git -C "$UPDATE_REPO" remote set-head origin main
+/usr/bin/git clone -q "$UPDATE_REMOTE" "$UPDATE_PEER"
+/usr/bin/git -C "$UPDATE_PEER" config user.name Test
+/usr/bin/git -C "$UPDATE_PEER" config user.email test@example.invalid
+
+printf 'old retained state\n' >"${UPDATE_REPO}/old-untracked.txt"
+old_backup_output=$(AIDEVOPS_REAL_GIT_BIN=/usr/bin/git AIDEVOPS_DIRTY_BACKUP_ROOT="$UPDATE_BACKUPS" \
+	bash "$DIRTY_HELPER" backup --repo "$UPDATE_REPO" --operation-id old-update --machine)
+IFS='|' read -r old_backup_id old_backup_dir <<<"$old_backup_output"
+AIDEVOPS_REAL_GIT_BIN=/usr/bin/git AIDEVOPS_DIRTY_BACKUP_ROOT="$UPDATE_BACKUPS" \
+	bash "$DIRTY_HELPER" clean --repo "$UPDATE_REPO" --backup "$old_backup_id" \
+	--confirm CLEAN_VERIFIED_DIRTY_WORKTREE_BACKUP >/dev/null
+AIDEVOPS_DIRTY_BACKUP_ROOT="$UPDATE_BACKUPS" bash "$DIRTY_HELPER" acknowledge \
+	--backup "$old_backup_id" --confirm ACKNOWLEDGE_DIRTY_WORKTREE_BACKUP >/dev/null
+touch -t 202001010000 "$old_backup_dir"
+
+printf 'remote update\n' >"${UPDATE_PEER}/remote.txt"
+/usr/bin/git -C "$UPDATE_PEER" add remote.txt
+/usr/bin/git -C "$UPDATE_PEER" commit -q -m 'remote update'
+/usr/bin/git -C "$UPDATE_PEER" push -q origin main
+update_remote_tip=$(/usr/bin/git -C "$UPDATE_REMOTE" rev-parse refs/heads/main)
+printf 'current retained state\n' >"${UPDATE_REPO}/current-untracked.txt"
+
+update_output=$(AIDEVOPS_REAL_GIT_BIN=/usr/bin/git AIDEVOPS_DIRTY_BACKUP_ROOT="$UPDATE_BACKUPS" \
+	bash "$HELPER" sync-mirror --repo "$UPDATE_REPO" --reason aidevops-update \
+	--confirm SYNCHRONIZE_CANONICAL_MIRROR 2>&1)
+update_backup_id=""
+while IFS= read -r update_line; do
+	case "$update_line" in
+	PRESERVED_BACKUP_ID=*) update_backup_id="${update_line#PRESERVED_BACKUP_ID=}" ;;
+	esac
+done <<<"$update_output"
+update_backup_dir="${UPDATE_BACKUPS}/${update_backup_id}"
+if [[ "$update_output" == *"SYNCHRONIZED_CANONICAL_MIRROR=true"* ]] &&
+	[[ "$update_output" == *"RESTORE_COMMAND="* ]] &&
+	[[ "$(/usr/bin/git -C "$UPDATE_REPO" rev-parse HEAD)" == "$update_remote_tip" ]] &&
+	[[ -z "$(/usr/bin/git -C "$UPDATE_REPO" status --porcelain=v1)" ]] &&
+	[[ "$(awk -F '\t' '$1 == "state" { print $2 }' "$update_backup_dir/manifest.tsv")" == "acknowledged" ]] &&
+	[[ ! -d "$old_backup_dir" ]]; then
+	printf 'PASS routine update preserves untracked state, acknowledges reusable evidence, and prunes backups older than 30 days\n'
+else
+	printf 'FAIL routine update did not preserve, acknowledge, or prune backup evidence safely\n'
+	exit 1
+fi
+
+AIDEVOPS_REAL_GIT_BIN=/usr/bin/git AIDEVOPS_DIRTY_BACKUP_ROOT="$UPDATE_BACKUPS" \
+	bash "$DIRTY_HELPER" restore --repo "$UPDATE_REPO" --backup "$update_backup_id" \
+	--confirm RESTORE_DIRTY_WORKTREE_BACKUP >/dev/null
+if [[ -f "${UPDATE_REPO}/current-untracked.txt" ]] &&
+	AIDEVOPS_REAL_GIT_BIN=/usr/bin/git AIDEVOPS_DIRTY_BACKUP_ROOT="$UPDATE_BACKUPS" \
+		bash "$DIRTY_HELPER" matches --repo "$UPDATE_REPO" --backup "$update_backup_id" >/dev/null; then
+	printf 'PASS routine update backup remains byte-restorable during the retention window\n'
+else
+	printf 'FAIL routine update backup did not restore the original untracked state\n'
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Route untracked-only canonical updates through audited mirror synchronization, acknowledge successful recovery evidence, and prune completed backups after the configured retention window.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-update-lib.sh, .agents/scripts/canonical-recovery-helper.sh, .agents/scripts/dirty-worktree-backup-helper.sh, .agents/scripts/tests/test-aidevops-update-transaction.sh, .agents/scripts/tests/test-canonical-recovery-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Local linters passed; ShellCheck passed; update transaction tests passed (14/14); canonical recovery integration tests passed, including restore and 30-day pruning coverage.

Resolves #28633


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 2h 48m and 593,774 tokens on this with the user in an interactive session.