### PR TITLE
fix: symlink canonical Node dependencies in worktrees

### DIFF
--- a/.agents/scripts/tests/test-worktree-dependency-symlinks.sh
+++ b/.agents/scripts/tests/test-worktree-dependency-symlinks.sh
@@ -22,17 +22,15 @@ fixture_dir=$(mktemp -d)
 trap 'rm -rf "$fixture_dir"' EXIT
 repo_dir="${fixture_dir}/repo"
 worktree_dir="${fixture_dir}/worktree"
-mkdir -p "${repo_dir}/node_modules/.bin" "${repo_dir}/vendor/bin" "$worktree_dir" || fail "failed to create fixture"
-touch "${repo_dir}/package.json" "${repo_dir}/composer.json" "${repo_dir}/node_modules/.bin/tool" "${repo_dir}/vendor/bin/tool"
-touch "${worktree_dir}/package.json" "${worktree_dir}/composer.json"
+mkdir -p "${repo_dir}/node_modules/.bin" "$worktree_dir" || fail "failed to create fixture"
+touch "${repo_dir}/package.json" "${repo_dir}/node_modules/.bin/tool"
+touch "${worktree_dir}/package.json"
 
 WORKTREE_NODE_MODULES_RESTORE_LOCK_TIMEOUT_S=0
 WORKTREE_NODE_MODULES_RESTORE_MAX_DIRS=2
 _restore_worktree_node_modules "$worktree_dir" "$repo_dir"
 
 [[ -L "${worktree_dir}/node_modules" ]] || fail "node_modules was not symlinked"
-[[ -L "${worktree_dir}/vendor" ]] || fail "vendor was not symlinked"
 [[ "$(readlink "${worktree_dir}/node_modules")" == "${repo_dir}/node_modules" ]] || fail "node_modules link target was incorrect"
-[[ "$(readlink "${worktree_dir}/vendor")" == "${repo_dir}/vendor" ]] || fail "vendor link target was incorrect"
 
 printf 'PASS worktree dependencies link to canonical checkout\n'

--- a/.agents/scripts/tests/test-worktree-dependency-symlinks.sh
+++ b/.agents/scripts/tests/test-worktree-dependency-symlinks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+: "${RED:=}"
+: "${NC:=}"
+print_warning() { return 0; }
+
+# shellcheck source=../worktree-helper-add.sh
+source "${SCRIPT_DIR}/worktree-helper-add.sh"
+
+fail() {
+	local message="$1"
+	printf 'FAIL %s\n' "$message"
+	return 1
+}
+
+fixture_dir=$(mktemp -d)
+trap 'rm -rf "$fixture_dir"' EXIT
+repo_dir="${fixture_dir}/repo"
+worktree_dir="${fixture_dir}/worktree"
+mkdir -p "${repo_dir}/node_modules/.bin" "${repo_dir}/vendor/bin" "$worktree_dir" || fail "failed to create fixture"
+touch "${repo_dir}/package.json" "${repo_dir}/composer.json" "${repo_dir}/node_modules/.bin/tool" "${repo_dir}/vendor/bin/tool"
+touch "${worktree_dir}/package.json" "${worktree_dir}/composer.json"
+
+WORKTREE_NODE_MODULES_RESTORE_LOCK_TIMEOUT_S=0
+WORKTREE_NODE_MODULES_RESTORE_MAX_DIRS=2
+_restore_worktree_node_modules "$worktree_dir" "$repo_dir"
+
+[[ -L "${worktree_dir}/node_modules" ]] || fail "node_modules was not symlinked"
+[[ -L "${worktree_dir}/vendor" ]] || fail "vendor was not symlinked"
+[[ "$(readlink "${worktree_dir}/node_modules")" == "${repo_dir}/node_modules" ]] || fail "node_modules link target was incorrect"
+[[ "$(readlink "${worktree_dir}/vendor")" == "${repo_dir}/vendor" ]] || fail "vendor link target was incorrect"
+
+printf 'PASS worktree dependencies link to canonical checkout\n'

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -328,10 +328,11 @@ _interactive_session_auto_claim() {
 
 # --- cmd_add Helpers ---
 
-# Link gitignored dependencies from the canonical repo into a new worktree.
+# Link gitignored Node dependencies from the canonical repo into a new worktree.
 # Git worktrees only contain tracked files — dirs in .gitignore are missing.
-# A symlink avoids expensive copies while ensuring the worktree uses the same
-# locked dependency tree as its canonical checkout.
+# Composer vendor is deliberately excluded: Composer's authoritative classmap
+# embeds the canonical source path, which would load stale classes from another
+# worktree. A symlink avoids expensive copies while preserving JS tooling.
 _restore_worktree_node_modules_lock_dir() {
 	local workspace_dir="${AIDEVOPS_WORKSPACE_DIR:-${HOME}/.aidevops/.agent-workspace}"
 	printf '%s\n' "${workspace_dir}/tmp/worktree-node-modules-restore.lock.d"
@@ -397,16 +398,13 @@ _restore_worktree_node_modules() {
 		local _pdir="" _rel=""
 		_pdir=$(dirname "$_pkg_file") || continue
 		_rel="${_pdir#"$wt_path"}"
-		local _dependency=""
-		for _dependency in node_modules vendor; do
-			local _src="${repo_root}${_rel}/${_dependency}"
-			local _dst="${wt_path}${_rel}/${_dependency}"
-			if [[ -d "$_src" && ! -e "$_dst" ]]; then
-				ln -s "$_src" "$_dst" 2>/dev/null || true
-				[[ -L "$_dst" ]] && _restored=$((_restored + 1))
-			fi
-		done
-	done < <(find "$wt_path" -maxdepth 3 \( -name "package.json" -o -name "composer.json" \) -not -path "*/node_modules/*" -not -path "*/vendor/*" 2>/dev/null)
+		local _src="${repo_root}${_rel}/node_modules"
+		local _dst="${wt_path}${_rel}/node_modules"
+		if [[ -d "$_src" && ! -e "$_dst" ]]; then
+			ln -s "$_src" "$_dst" 2>/dev/null || true
+			[[ -L "$_dst" ]] && _restored=$((_restored + 1))
+		fi
+	done < <(find "$wt_path" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" 2>/dev/null)
 	_restore_worktree_node_modules_release_lock "$_lock_dir"
 	return 0
 }

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -328,10 +328,10 @@ _interactive_session_auto_claim() {
 
 # --- cmd_add Helpers ---
 
-# Restore gitignored node_modules from the canonical repo into a new worktree.
+# Link gitignored dependencies from the canonical repo into a new worktree.
 # Git worktrees only contain tracked files — dirs in .gitignore are missing.
-# If .opencode/tool/*.ts imports from node_modules the runtime crashes on
-# startup. See pulse-dispatch-worker-launch.sh _dlw_restore_worktree_deps.
+# A symlink avoids expensive copies while ensuring the worktree uses the same
+# locked dependency tree as its canonical checkout.
 _restore_worktree_node_modules_lock_dir() {
 	local workspace_dir="${AIDEVOPS_WORKSPACE_DIR:-${HOME}/.aidevops/.agent-workspace}"
 	printf '%s\n' "${workspace_dir}/tmp/worktree-node-modules-restore.lock.d"
@@ -397,15 +397,16 @@ _restore_worktree_node_modules() {
 		local _pdir="" _rel=""
 		_pdir=$(dirname "$_pkg_file") || continue
 		_rel="${_pdir#"$wt_path"}"
-		local _src="${repo_root}${_rel}/node_modules"
-		local _dst="${wt_path}${_rel}/node_modules"
-		if [[ -d "$_src" && ! -d "$_dst" ]]; then
-			# t2889: fast_cp uses APFS clonefile / btrfs reflink CoW where
-			# available — sub-second copy on macOS, near-zero disk delta.
-			fast_cp "$_src" "$_dst" 2>/dev/null || true
-			_restored=$((_restored + 1))
-		fi
-	done < <(find "$wt_path" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" 2>/dev/null)
+		local _dependency=""
+		for _dependency in node_modules vendor; do
+			local _src="${repo_root}${_rel}/${_dependency}"
+			local _dst="${wt_path}${_rel}/${_dependency}"
+			if [[ -d "$_src" && ! -e "$_dst" ]]; then
+				ln -s "$_src" "$_dst" 2>/dev/null || true
+				[[ -L "$_dst" ]] && _restored=$((_restored + 1))
+			fi
+		done
+	done < <(find "$wt_path" -maxdepth 3 \( -name "package.json" -o -name "composer.json" \) -not -path "*/node_modules/*" -not -path "*/vendor/*" 2>/dev/null)
 	_restore_worktree_node_modules_release_lock "$_lock_dir"
 	return 0
 }


### PR DESCRIPTION
## Summary
- Link canonical `node_modules` into new worktrees.
- Preserve local Composer vendors because Composer classmaps resolve project classes from the canonical checkout when vendor is shared.
- Add a focused symlink regression test.

## Verification
- `bash .agents/scripts/tests/test-worktree-dependency-symlinks.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4
