### PR TITLE
GH#28644: Restore exact GitHub quota attribution and merge-state safety

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -385,6 +385,58 @@ _shim_transport_page() {
 	return 0
 }
 
+#######################################
+# Execute one fixed-shape GraphQL query whose response includes
+# data.rateLimit.cost. Capture stdout privately, record the returned operation-
+# owned cost, then replay stdout unchanged to the caller. Return 125 when this
+# exact path is unavailable so normal fail-closed instrumentation can run.
+#######################################
+_shim_run_response_metered_graphql() {
+	local response_rc=0
+	(
+		local executable="$1"; shift
+		local path="$1"; shift
+		local caller="$1"; shift
+		local retry="$1"; shift
+		local temp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+		local output_file="" start_ms="" end_ms="" elapsed_ms="" quota_cost=""
+		local rc=0 replay_rc=0 outcome="success"
+
+		[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-0}" == "1" && "$path" == "graphql" ]] || return 125
+		declare -F gh_record_attempt >/dev/null 2>&1 || return 125
+		declare -F _ghqa_prepare_private_dir >/dev/null 2>&1 || return 125
+		command -v jq >/dev/null 2>&1 || return 125
+		_ghqa_prepare_private_dir "$temp_dir" || return 125
+		output_file=$(mktemp "${temp_dir}/gh-graphql-cost-response.XXXXXX" 2>/dev/null) || return 125
+		trap 'rm -f -- "$output_file" 2>/dev/null || true' EXIT
+		trap 'exit 129' HUP
+		trap 'exit 130' INT
+		trap 'exit 143' TERM
+		chmod 0600 "$output_file" 2>/dev/null || return 125
+
+		start_ms=$(_gh_now_ms 2>/dev/null || true)
+		if "$executable" "$@" >"$output_file"; then
+			rc=0
+		else
+			rc=$?
+			outcome="error"
+		fi
+		end_ms=$(_gh_now_ms 2>/dev/null || true)
+		elapsed_ms=$(_ghqa_elapsed_ms "$start_ms" "$end_ms" 2>/dev/null || true)
+		quota_cost=$(jq -r 'try (.data.rateLimit.cost // empty) catch empty' "$output_file" 2>/dev/null) || quota_cost=""
+		[[ "$quota_cost" =~ ^[0-9]+$ ]] || quota_cost=""
+
+		command cat "$output_file" || replay_rc=$?
+		gh_record_attempt graphql "$caller" "$AIDEVOPS_GH_LOGICAL_ID" "" 1 "$retry" "$outcome" \
+			"" "$elapsed_ms" "$quota_cost" "${AIDEVOPS_GH_AUTH_MODE:-}" graphql \
+			"${AIDEVOPS_GH_ROUTE_DECISION:-graphql-response-metered}" "" 2>/dev/null || true
+		[[ "$rc" -ne 0 ]] && return "$rc"
+		[[ "$replay_rc" -ne 0 ]] && return "$replay_rc"
+		return 0
+	) || response_rc=$?
+	return "$response_rc"
+}
+
 _shim_run_single_transport() {
 	local executable="$1"; shift
 	local path="$1"; shift
@@ -396,6 +448,11 @@ _shim_run_single_transport() {
 	page=$(_shim_transport_page "$@")
 	if [[ "$page" == "0" ]]; then
 		decision="native-pagination-opaque"
+	fi
+	local response_metered_rc=0
+	_shim_run_response_metered_graphql "$executable" "$path" "$caller" "$retry" "$@" || response_metered_rc=$?
+	if [[ "$response_metered_rc" -ne 125 ]]; then
+		return "$response_metered_rc"
 	fi
 	exact_success_cost=$(_ghqa_exact_success_cost "$path" "$@" 2>/dev/null || true)
 	AIDEVOPS_GH_ROUTE_DECISION="$decision" \

--- a/.agents/scripts/gh-quota-attribution-lib.sh
+++ b/.agents/scripts/gh-quota-attribution-lib.sh
@@ -470,12 +470,14 @@ _ghqa_run_uncaptured_to_result() {
 	local path="$2"
 	local page="$3"
 	shift 3
-	local started_ms finished_ms elapsed_ms exact_success_cost
+	local started_ms="" finished_ms="" elapsed_ms="" exact_success_cost=""
 	local rc=0 outcome=success quota_cost="${AIDEVOPS_GH_QUOTA_COST:-}"
+	local success_quota_cost="${AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS:-}"
 	started_ms=$(_gh_now_ms 2>/dev/null || true)
 	if "$@"; then
 		rc=0
 		exact_success_cost=$(_ghqa_exact_success_cost "$path" "${@:2}" 2>/dev/null || true)
+		[[ -n "$quota_cost" || -z "$success_quota_cost" ]] || quota_cost="$success_quota_cost"
 		[[ -n "$quota_cost" ]] || quota_cost="$exact_success_cost"
 	else
 		rc=$?
@@ -530,7 +532,7 @@ _ghqa_response_cost() {
 	local resource="$2"
 	local used="$3"
 	local reset="$4"
-	local previous previous_used previous_reset delta
+	local previous="" previous_used="" previous_reset="" delta=""
 	previous=$(_ghqa_state_get "$state_file" "$resource" 2>/dev/null || true)
 	IFS=$'\t' read -r previous_used previous_reset <<<"$previous"
 	if [[ "$previous_used" =~ ^[0-9]+$ && "$previous_reset" == "$reset" \
@@ -554,8 +556,9 @@ _ghqa_write_complete_frames() {
 	local command_rc="$5"
 	local parsed="$6"
 	shift 6
-	local kind frame_index status_count status resource used remaining reset elapsed
-	local frame_total=0 path pool page outcome quota_cost exact_success_cost decision
+	local kind="" frame_index="" status_count="" status="" resource="" used="" remaining="" reset="" elapsed=""
+	local frame_total=0 path="" pool="" page="" outcome="" quota_cost="" exact_success_cost="" decision=""
+	local success_quota_cost="${AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS:-}"
 	frame_total=$(printf '%s\n' "$parsed" | awk -F '\t' '$1 == "frame" { count++ } END { print count + 0 }')
 	if [[ "$command_rc" -eq 0 && "$frame_total" -eq 1 ]]; then
 		exact_success_cost=$(_ghqa_exact_success_cost "$original_path" "${@:2}" 2>/dev/null || true)
@@ -573,6 +576,8 @@ _ghqa_write_complete_frames() {
 		quota_cost=""
 		if [[ "$frame_total" -eq 1 && -n "${AIDEVOPS_GH_QUOTA_COST:-}" ]]; then
 			quota_cost="$AIDEVOPS_GH_QUOTA_COST"
+		elif [[ "$command_rc" -eq 0 && -n "$success_quota_cost" ]]; then
+			quota_cost="$success_quota_cost"
 		elif [[ -n "$exact_success_cost" ]]; then
 			quota_cost="$exact_success_cost"
 		else

--- a/.agents/scripts/pulse-capacity.sh
+++ b/.agents/scripts/pulse-capacity.sh
@@ -372,7 +372,7 @@ count_runnable_candidates() {
 		# (separate budget pool, ~15x smaller payload).
 		local pr_json pr_rc_err
 		pr_rc_err=$(mktemp)
-		pr_json=$(pulse_pr_list_get --repo "$slug" --state open --json number,reviewDecision,headRefOid --limit "$PULSE_RUNNABLE_PR_LIMIT" 2>"$pr_rc_err") || pr_json="[]"
+		pr_json=$(pulse_pr_list_get --repo "$slug" --state open --json number,headRefOid --limit "$PULSE_RUNNABLE_PR_LIMIT" 2>"$pr_rc_err") || pr_json="[]"
 		if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
 			local _pr_rc_err_msg
 			_pr_rc_err_msg=$(cat "$pr_rc_err" 2>/dev/null || echo "unknown error")
@@ -380,6 +380,9 @@ count_runnable_candidates() {
 			pr_json="[]"
 		fi
 		rm -f "$pr_rc_err"
+		if declare -F _pmp_enrich_prs_with_review_decisions >/dev/null 2>&1; then
+			pr_json=$(_pmp_enrich_prs_with_review_decisions "$slug" "$pr_json")
+		fi
 
 		# Enrich with REST check status, then count "runnable" PRs:
 		# CHANGES_REQUESTED OR aggregate check status == FAIL.

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -76,6 +76,9 @@ source "${_PULSE_MERGE_PROCESS_DIR}/pulse-merge-timing.sh"
 # shellcheck source=./pulse-merge-pass.sh
 # shellcheck disable=SC1091  # sub-library resolved via _PULSE_MERGE_PROCESS_DIR
 source "${_PULSE_MERGE_PROCESS_DIR}/pulse-merge-pass.sh"
+# shellcheck source=./pulse-merge-rest-state.sh
+# shellcheck disable=SC1091  # sub-library resolved via _PULSE_MERGE_PROCESS_DIR
+source "${_PULSE_MERGE_PROCESS_DIR}/pulse-merge-rest-state.sh"
 
 _pmp_cache_key() {
 	local raw_key="$1"
@@ -120,210 +123,6 @@ _pmp_normalize_pr_lifecycle_state_into() {
 	*) normalized_state="$raw_state" ;;
 	esac
 	printf -v "$dest_var" '%s' "$normalized_state"
-	return 0
-}
-
-#######################################
-# Normalize PR mergeable values from mixed GitHub API paths.
-#
-# gh GraphQL returns MERGEABLE/CONFLICTING/UNKNOWN, while REST fallback and
-# some cached jq paths can surface true/false/null. The merge gate is enum-
-# based, so normalize before comparing to avoid treating boolean `true` as a
-# non-mergeable state.
-#
-# Args: $1=raw mergeable value
-# Stdout: normalized mergeable enum
-#######################################
-_pmp_normalize_mergeable_state() {
-	local raw_state="$1"
-	local normalized_state=""
-	case "$raw_state" in
-	MERGEABLE|mergeable|true|TRUE) normalized_state="MERGEABLE" ;;
-	CONFLICTING|conflicting|false|FALSE) normalized_state="CONFLICTING" ;;
-	UNKNOWN|unknown|''|null|NULL) normalized_state="UNKNOWN" ;;
-	*) normalized_state="$raw_state" ;;
-	esac
-	printf '%s' "$normalized_state"
-	return 0
-}
-
-#######################################
-# Normalize PR mergeable values into a caller variable without command substitution.
-#
-# Args: $1=destination variable name, $2=raw mergeable value
-#######################################
-_pmp_normalize_mergeable_state_into() {
-	local dest_var="$1"
-	local raw_state="$2"
-	local normalized_state=""
-
-	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
-	case "$raw_state" in
-	MERGEABLE|mergeable|true|TRUE) normalized_state="MERGEABLE" ;;
-	CONFLICTING|conflicting|false|FALSE) normalized_state="CONFLICTING" ;;
-	UNKNOWN|unknown|''|null|NULL) normalized_state="UNKNOWN" ;;
-	*) normalized_state="$raw_state" ;;
-	esac
-	printf -v "$dest_var" '%s' "$normalized_state"
-	return 0
-}
-
-#######################################
-# Refresh empty/UNKNOWN PR mergeable state into a caller variable.
-#
-# REST-first PR list reads cannot preserve GraphQL-only mergeable data. Before
-# write decisions, refresh only ambiguous per-PR states through gh_pr_view with
-# the PR-view cache disabled so existing CONFLICTING handling can run.
-#
-# Args:
-#   $1 - destination variable name
-#   $2 - PR number
-#   $3 - repo slug
-#   $4 - current mergeable state
-#######################################
-_pmp_refresh_unknown_mergeable_state_into() {
-	local _pmp_dest_var="$1"
-	local _pmp_pr_number="$2"
-	local _pmp_repo_slug="$3"
-	local _pmp_current_mergeable="$4"
-	local _pmp_refreshed_mergeable=""
-	local _pmp_refresh_exit=0
-
-	[[ "$_pmp_dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
-	_pmp_normalize_mergeable_state_into _pmp_refreshed_mergeable "$_pmp_current_mergeable"
-
-	if [[ "$_pmp_refreshed_mergeable" == "UNKNOWN" || -z "$_pmp_refreshed_mergeable" ]]; then
-		_pmp_refreshed_mergeable=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$_pmp_pr_number" --repo "$_pmp_repo_slug" \
-			--json mergeable --jq '.mergeable // ""')
-		_pmp_refresh_exit=$?
-		[[ $_pmp_refresh_exit -eq 0 && -n "$_pmp_refreshed_mergeable" ]] || _pmp_refreshed_mergeable="UNKNOWN"
-		_pmp_normalize_mergeable_state_into _pmp_refreshed_mergeable "$_pmp_refreshed_mergeable"
-	fi
-
-	printf -v "$_pmp_dest_var" '%s' "$_pmp_refreshed_mergeable"
-	return 0
-}
-
-# Normalize mixed-path reviewDecision values. REST PR payloads omit this
-# GraphQL-only field, so null/empty means UNKNOWN, not NONE (GH#26218).
-_pmp_normalize_review_decision_into() {
-	local dest_var="$1"
-	local raw_decision="$2"
-	local normalized_decision=""
-
-	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
-	case "$raw_decision" in
-	CHANGES_REQUESTED|APPROVED|REVIEW_REQUIRED|NONE) normalized_decision="$raw_decision" ;;
-	changes_requested) normalized_decision="CHANGES_REQUESTED" ;;
-	approved) normalized_decision="APPROVED" ;;
-	review_required) normalized_decision="REVIEW_REQUIRED" ;;
-	none) normalized_decision="NONE" ;;
-	''|null|NULL|UNKNOWN|unknown) normalized_decision="UNKNOWN" ;;
-	*) normalized_decision="$raw_decision" ;;
-	esac
-	printf -v "$dest_var" '%s' "$normalized_decision"
-	return 0
-}
-
-_pmp_review_decision_is_unknown() {
-	local raw_decision="$1"
-	local _pmp_normalized_decision=""
-	_pmp_normalize_review_decision_into _pmp_normalized_decision "$raw_decision"
-	[[ "$_pmp_normalized_decision" == "UNKNOWN" ]]
-	return $?
-}
-
-# Conservative REST fallback for GraphQL reviewDecision refresh failures.
-# Groups state-changing reviews by reviewer and keeps each latest state.
-_pmp_rest_review_decision_from_reviews() {
-	local pr_number="$1"
-	local repo_slug="$2"
-	local reviews_json=""
-
-	reviews_json=$(_gh_with_timeout read gh api --paginate \
-		"repos/${repo_slug}/pulls/${pr_number}/reviews" 2>/dev/null) || return 1
-	printf '%s' "$reviews_json" | jq -rs '
-		flatten
-		| map(select((.user.login // "") != "" and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")))
-		| group_by(.user.login)
-		| map(max_by(.submitted_at // .submittedAt // ""))
-		| if any(.state == "CHANGES_REQUESTED") then "CHANGES_REQUESTED" else "NONE" end
-	' 2>/dev/null || return 1
-	return 0
-}
-
-# Refresh unknown PR reviewDecision state into a caller variable.
-# Args: $1=dest var, $2=PR number, $3=repo slug, $4=current state
-_pmp_refresh_unknown_review_decision_into() {
-	local _pmp_dest_var="$1"
-	local _pmp_pr_number="$2"
-	local _pmp_repo_slug="$3"
-	local _pmp_current_review="$4"
-	local _pmp_refreshed_review=""
-	local _pmp_refresh_exit=0
-
-	[[ "$_pmp_dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
-	_pmp_normalize_review_decision_into _pmp_refreshed_review "$_pmp_current_review"
-
-	if [[ "$_pmp_refreshed_review" == "UNKNOWN" ]]; then
-		_pmp_refreshed_review=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$_pmp_pr_number" --repo "$_pmp_repo_slug" \
-			--json reviewDecision --jq '.reviewDecision // ""' 2>/dev/null)
-		_pmp_refresh_exit=$?
-		_pmp_normalize_review_decision_into _pmp_refreshed_review "$_pmp_refreshed_review"
-		if [[ $_pmp_refresh_exit -ne 0 || "$_pmp_refreshed_review" == "UNKNOWN" ]]; then
-			_pmp_refreshed_review=$(_pmp_rest_review_decision_from_reviews "$_pmp_pr_number" "$_pmp_repo_slug" 2>/dev/null) || _pmp_refreshed_review="UNKNOWN"
-			_pmp_normalize_review_decision_into _pmp_refreshed_review "$_pmp_refreshed_review"
-		fi
-	fi
-
-	printf -v "$_pmp_dest_var" '%s' "$_pmp_refreshed_review"
-	return 0
-}
-
-# Resolve unknown review decisions once before backlog logging and sorting.
-# Both consumers classify the full PR list, so network refreshes inside the
-# classifier would otherwise run twice per unknown PR in one merge pass.
-# Args: $1=repo slug, $2=PR JSON array
-_pmp_enrich_prs_with_review_decisions() {
-	local repo_slug="$1"
-	local pr_json="$2"
-	local enriched_json="$pr_json"
-	local pr_rows=""
-	local _US=$'\x1f'
-	local i="" number="" review_decision=""
-
-	if [[ -z "$repo_slug" ]]; then
-		printf '%s' "$pr_json"
-		return 0
-	fi
-
-	pr_rows=$(printf '%s' "$pr_json" | jq -r '
-		if type != "array" then error("expected PR array")
-		else to_entries[] | [
-			(.key | tostring),
-			(if ((.value | has("number") | not) or .value.number == null or (.value.number | tostring | length) == 0)
-			 then "" else (.value.number | tostring) end),
-			(if ((.value | has("reviewDecision") | not) or .value.reviewDecision == null or (.value.reviewDecision | tostring | length) == 0)
-			 then "UNKNOWN" else .value.reviewDecision end)
-		] | join("\u001f")
-		end' 2>/dev/null) || {
-		printf '%s' "$pr_json"
-		return 0
-	}
-
-	while IFS="$_US" read -r i number review_decision; do
-		[[ -n "$i" ]] || continue
-		_pmp_normalize_review_decision_into review_decision "$review_decision"
-		if [[ "$number" =~ ^[0-9]+$ ]] && _pmp_review_decision_is_unknown "$review_decision"; then
-			_pmp_refresh_unknown_review_decision_into review_decision "$number" "$repo_slug" "$review_decision"
-			enriched_json=$(printf '%s' "$enriched_json" | jq --argjson index "$i" --arg review "$review_decision" '.[$index].reviewDecision = $review' 2>/dev/null) || {
-				printf '%s' "$pr_json"
-				return 0
-			}
-		fi
-	done <<<"$pr_rows"
-
-	printf '%s' "$enriched_json"
 	return 0
 }
 
@@ -591,6 +390,7 @@ _merge_ready_prs_for_repo() {
 		echo "[pulse-wrapper] Merge pass: per-repo cache setup incomplete for ${repo_slug}; continuing without one or more caches (GH#25696)" >>"$LOGFILE"
 	fi
 
+	pr_json=$(_pmp_enrich_prs_with_mergeability "$repo_slug" "$pr_json")
 	pr_json=$(_pmp_enrich_prs_with_rest_check_status "$repo_slug" "$pr_json")
 	pr_json=$(_pmp_enrich_prs_with_review_decisions "$repo_slug" "$pr_json")
 
@@ -641,7 +441,8 @@ _merge_ready_prs_for_repo() {
 
 #######################################
 # Attempt to fast-forward the PR's branch to the latest base branch head
-# via `gh pr update-branch`. GitHub's server-side merger will merge main
+# via GitHub's update-a-pull-request-branch REST endpoint. The server-side
+# merger will merge main
 # into the branch when the changes don't semantically conflict; this
 # salvages a large class of CONFLICTING PRs where the only issue is that
 # main advanced while the worker was finishing or waiting (t2116).
@@ -650,18 +451,19 @@ _merge_ready_prs_for_repo() {
 # mergeable state), 1 on failure (true semantic conflict, caller should
 # fall through to the close path).
 #
-# Rate-limit considerations: one `gh pr update-branch` call per CONFLICTING
+# Rate-limit considerations: one REST update-branch call per CONFLICTING
 # PR per merge cycle. No retry — the next pulse cycle will try again if
 # appropriate.
 #
-# Args: $1=pr_number, $2=repo_slug
+# Args: $1=pr_number, $2=repo_slug, $3=expected current head SHA
 #######################################
 _attempt_pr_update_branch() {
 	local pr_number="$1"
 	local repo_slug="$2"
+	local expected_head_sha="${3:-}"
 
 	local _ub_output _ub_exit
-	_ub_output=$(gh pr update-branch "$pr_number" --repo "$repo_slug" 2>&1)
+	_ub_output=$(_pmp_update_branch_rest "$pr_number" "$repo_slug" "$expected_head_sha" 2>&1)
 	_ub_exit=$?
 
 	if [[ $_ub_exit -eq 0 ]]; then
@@ -859,7 +661,7 @@ _attempt_pr_ci_rebase_retry() {
 	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: attempting CI-drift rebase via update-branch (t2805)" >>"$LOGFILE"
 
 	local _ub_output _ub_exit
-	_ub_output=$(gh pr update-branch "$pr_number" --repo "$repo_slug" 2>&1)
+	_ub_output=$(_pmp_update_branch_rest "$pr_number" "$repo_slug" "$_head_oid" 2>&1)
 	_ub_exit=$?
 
 	if [[ $_ub_exit -eq 0 ]]; then
@@ -869,23 +671,6 @@ _attempt_pr_ci_rebase_retry() {
 
 	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: CI-drift rebase failed (update-branch exit ${_ub_exit}), falling through to fix-worker routing (t2805): ${_ub_output}" >>"$LOGFILE"
 	return 1
-}
-
-_pmp_extract_update_branch_state() {
-	local __auto_var="$1"
-	local __state_var="$2"
-	local __mergeable_var="$3"
-	local _pr_state="$4"
-	local __existing_auto_val="" __merge_state_val="" __mergeable_val="" _RS=$'\x1e'
-
-	IFS="$_RS" read -r __existing_auto_val __merge_state_val __mergeable_val <<<"$(printf '%s' "$_pr_state" \
-		| jq -r '"\(if .autoMergeRequest then "present" else "" end)\u001e\(.mergeStateStatus // "")\u001e\(.mergeable // "")"' \
-		|| true)"
-	_pmp_normalize_mergeable_state_into __mergeable_val "$__mergeable_val"
-	printf -v "$__auto_var" '%s' "$__existing_auto_val"
-	printf -v "$__state_var" '%s' "$__merge_state_val"
-	printf -v "$__mergeable_var" '%s' "$__mergeable_val"
-	return 0
 }
 
 #######################################
@@ -908,12 +693,11 @@ _attempt_existing_auto_merge_behind_update_branch() {
 	local repo_slug="$2"
 
 	local _pr_state=""
-	_pr_state=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json autoMergeRequest,mergeStateStatus,mergeable 2>/dev/null) || _pr_state=""
+	_pr_state=$(_pmp_rest_pr_merge_state "$pr_number" "$repo_slug" 2>/dev/null) || _pr_state=""
 	[[ -n "$_pr_state" ]] || return 1
 
-	local _existing_auto="" _merge_state="" _mergeable=""
-	_pmp_extract_update_branch_state _existing_auto _merge_state _mergeable "$_pr_state"
+	local _existing_auto="" _merge_state="" _mergeable="" _head_oid=""
+	_pmp_extract_update_branch_state _existing_auto _merge_state _mergeable "$_pr_state" _head_oid
 
 	[[ -n "$_existing_auto" ]] || return 1
 	[[ "$_merge_state" == BEHIND ]] || return 1
@@ -921,7 +705,7 @@ _attempt_existing_auto_merge_behind_update_branch() {
 	_check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1 || return 1
 
 	local _ub_output="" _ub_exit=0
-	_ub_output=$(gh pr update-branch "$pr_number" --repo "$repo_slug" 2>&1)
+	_ub_output=$(_pmp_update_branch_rest "$pr_number" "$repo_slug" "$_head_oid" 2>&1)
 	_ub_exit=$?
 	if [[ $_ub_exit -eq 0 ]]; then
 		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge is green but BEHIND — update-branch succeeded, deferring to next cycle (GH#24839)" >>"$LOGFILE"
@@ -952,12 +736,11 @@ _attempt_green_behind_update_branch() {
 	local repo_slug="$2"
 
 	local _pr_state=""
-	_pr_state=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json autoMergeRequest,mergeStateStatus,mergeable 2>/dev/null) || _pr_state=""
+	_pr_state=$(_pmp_rest_pr_merge_state "$pr_number" "$repo_slug" 2>/dev/null) || _pr_state=""
 	[[ -n "$_pr_state" ]] || return 1
 
-	local _existing_auto="" _merge_state="" _mergeable=""
-	_pmp_extract_update_branch_state _existing_auto _merge_state _mergeable "$_pr_state"
+	local _existing_auto="" _merge_state="" _mergeable="" _head_oid=""
+	_pmp_extract_update_branch_state _existing_auto _merge_state _mergeable "$_pr_state" _head_oid
 
 	[[ -z "$_existing_auto" ]] || return 1
 	[[ "$_merge_state" == BEHIND ]] || return 1
@@ -965,7 +748,7 @@ _attempt_green_behind_update_branch() {
 	_check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1 || return 1
 
 	local _ub_output="" _ub_exit=0
-	_ub_output=$(gh pr update-branch "$pr_number" --repo "$repo_slug" 2>&1)
+	_ub_output=$(_pmp_update_branch_rest "$pr_number" "$repo_slug" "$_head_oid" 2>&1)
 	_ub_exit=$?
 	if [[ $_ub_exit -eq 0 ]]; then
 		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: green but BEHIND without native auto-merge — update-branch succeeded, deferring to next cycle (GH#26659)" >>"$LOGFILE"
@@ -1807,14 +1590,14 @@ _repo_allows_auto_merge() {
 # Stuck means ALL of:
 #   * mergeStateStatus == BLOCKED
 #   * mergeable == MERGEABLE
-#   * reviewDecision != CHANGES_REQUESTED  (don't bypass real review blocks)
+#   * reviewDecision is known-safe for this already-gated cycle
 #   * autoMergeRequest.enabledAt > $threshold seconds ago
 #   * No required check is in fail/pending/cancel bucket (only pass/skipping)
 #
 # Threshold defaults to 300s, overridable via
 # AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS.
 #
-# Args: $1=pr_number, $2=repo_slug, $3=raw JSON from gh_pr_view
+# Args: $1=pr_number, $2=repo_slug, $3=normalized current-cycle PR state JSON
 # Stdout: stuck-seconds count when stuck (caller logs it)
 # Returns: 0=stuck, safe to fall through to --admin; 1=defer to GitHub
 #######################################
@@ -1829,12 +1612,10 @@ _auto_merge_stuck_seconds() {
 		| jq -r '[.autoMergeRequest.enabledAt // "", .mergeStateStatus // "", .mergeable // "", .reviewDecision // ""] | @tsv' \
 		|| true)"
 
-	# Glob form (unquoted RHS inside [[ ]]) avoids adding new repeated
-	# string literals to this file — the validator counts only quoted
-	# 4+-char literals (see pre-commit-hook.sh::_count_repeated_literals).
+	# Glob form (unquoted RHS inside [[ ]]) avoids adding new repeated string
+	# literals — the validator counts only quoted 4+-char literals.
 	[[ "$merge_state" == BLOCKED ]] || return 1
 	[[ "$mergeable" == MERGEABLE ]] || return 1
-	[[ "$review_decision" != CHANGES_REQUESTED ]] || return 1
 	[[ -n "$enabled_at" ]] || return 1
 
 	local enabled_epoch now_epoch stuck_seconds
@@ -1845,6 +1626,16 @@ _auto_merge_stuck_seconds() {
 	now_epoch=$(date -u +%s)
 	stuck_seconds=$((now_epoch - enabled_epoch))
 	[[ "$stuck_seconds" -gt "$threshold" ]] || return 1
+
+	# The cycle's review projection can become stale between its gate and this
+	# destructive wedge bypass. Re-read bounded REST history now; unavailable or
+	# contradictory evidence must not authorize an admin fall-through.
+	local fresh_review_decision=""
+	_pmp_refresh_native_auto_review_into fresh_review_decision "$pr_number" "$repo_slug" "$review_decision" || return 1
+	case "$fresh_review_decision" in
+	OBSERVED_APPROVED | NONE) ;;
+	*) return 1 ;;
+	esac
 
 	# Confirm no required check is still pending or has failed. We require
 	# every required check to be in `pass` or `skipping` bucket — anything
@@ -1862,19 +1653,102 @@ _auto_merge_stuck_seconds() {
 _stop_external_native_auto_merge() {
 	local pr_number="$1"
 	local repo_slug="$2"
+	local hold_reason="${3:-external approval state must be revalidated at the actual merge call}"
 	local disable_output=""
 	local draft_hold_output=""
 
 	if disable_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --disable-auto 2>&1); then
-		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disabled deferred native auto-merge because external approval state must be revalidated at the actual merge call" >>"$LOGFILE"
-		return 2
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disabled deferred native auto-merge because ${hold_reason}" >>"$LOGFILE"
+		return 0
 	fi
 	if draft_hold_output=$(gh pr ready "$pr_number" --repo "$repo_slug" --undo 2>&1); then
-		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disable-auto failed, so PR was returned to draft to stop deferred merge pending fresh approval: ${disable_output}" >>"$LOGFILE"
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disable-auto failed, so PR was returned to draft because ${hold_reason}: ${disable_output}" >>"$LOGFILE"
 		return 2
 	fi
-	echo "[pulse-merge] SECURITY HOLD FAILED for PR #${pr_number} in ${repo_slug}: could not disable external auto-merge or return PR to draft; manual intervention required. disable=${disable_output}; draft=${draft_hold_output}" >>"$LOGFILE"
+	echo "[pulse-merge] SECURITY HOLD FAILED for PR #${pr_number} in ${repo_slug}: could not disable external auto-merge or return PR to draft because ${hold_reason}; manual intervention required. disable=${disable_output}; draft=${draft_hold_output}" >>"$LOGFILE"
 	return 3
+}
+
+_enable_native_auto_merge_for_head() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+	local pending_count="$4"
+	local auto_output=""
+	local auto_exit=0
+
+	if [[ -z "$expected_head_sha" ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: native auto-merge not set because the gated head SHA is unavailable" >>"$LOGFILE"
+		return 1
+	fi
+	auto_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash \
+		--match-head-commit "$expected_head_sha" 2>&1)
+	auto_exit=$?
+	if [[ "$auto_exit" -eq 0 ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: native auto-merge set (CI ${pending_count} pending), GitHub merges on green (t3070)" >>"$LOGFILE"
+		return 0
+	fi
+	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: gh pr merge --auto failed (exit ${auto_exit}): ${auto_output} — falling through to immediate merge (t3070)" >>"$LOGFILE"
+	return 1
+}
+
+_handle_existing_native_auto_merge() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local require_synchronous_final_gate="$3"
+	local expected_head_sha="$4"
+	local pr_state="$5"
+	local snapshot_head_sha="" stop_rc=0
+
+	if [[ "$require_synchronous_final_gate" == "1" ]]; then
+		_stop_external_native_auto_merge "$pr_number" "$repo_slug" || stop_rc=$?
+		[[ "$stop_rc" -eq 0 ]] && return 2
+		return "$stop_rc"
+	fi
+	snapshot_head_sha=$(printf '%s' "$pr_state" | jq -r '.headRefOid // empty' 2>/dev/null) || snapshot_head_sha=""
+	if [[ -z "$expected_head_sha" || -z "$snapshot_head_sha" || "$snapshot_head_sha" != "$expected_head_sha" ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: existing native auto-merge head no longer matches the gated head; disarming and deferring" >>"$LOGFILE"
+		_stop_external_native_auto_merge "$pr_number" "$repo_slug" \
+			"the live head no longer matches the gated head" || stop_rc=$?
+		[[ "$stop_rc" -eq 0 ]] && return 2
+		return "$stop_rc"
+	fi
+
+	local stuck_seconds=""
+	if stuck_seconds=$(_auto_merge_stuck_seconds "$pr_number" "$repo_slug" "$pr_state"); then
+		local threshold="${AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS:-300}"
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge stuck ${stuck_seconds}s (>${threshold}s) in BLOCKED+MERGEABLE with no failing/pending required checks — attempting synchronous recovery (t3192)" >>"$LOGFILE"
+		stop_rc=0
+		_stop_external_native_auto_merge "$pr_number" "$repo_slug" \
+			"stale wedge recovery requires a fresh synchronous merge (GH#26897)" || stop_rc=$?
+		if [[ "$stop_rc" -eq 0 ]]; then
+			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disabled stale native auto-merge before immediate merge (GH#26897)" >>"$LOGFILE"
+			return 1
+		fi
+		return "$stop_rc"
+	fi
+
+	local pending_count=0
+	if ! _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
+		pending_count=1
+	fi
+	if [[ "$pending_count" -gt 0 ]]; then
+		local enabled_at="" enabled_epoch="0" now_epoch="0" age_seconds="0"
+		enabled_at=$(printf '%s' "$pr_state" | jq -r '.autoMergeRequest.enabledAt // ""' 2>/dev/null) || enabled_at=""
+		enabled_epoch=$(date -u -d "$enabled_at" +%s 2>/dev/null \
+			|| TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$enabled_at" +%s 2>/dev/null \
+			|| echo "0")
+		[[ "$enabled_epoch" =~ ^[0-9]+$ ]] || enabled_epoch=0
+		now_epoch=$(date -u +%s)
+		age_seconds=$((now_epoch - enabled_epoch))
+		local threshold="${AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS:-300}"
+		if [[ "$enabled_epoch" -gt 0 && "$age_seconds" -gt "$threshold" ]]; then
+			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge has ${pending_count} required check(s) pending for ${age_seconds}s (>${threshold}s) — deferring as non-terminal (t3567)" >>"$LOGFILE"
+			return 0
+		fi
+	fi
+	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge already set, deferring to GitHub (t3070)" >>"$LOGFILE"
+	return 0
 }
 
 #######################################
@@ -1909,7 +1783,8 @@ _stop_external_native_auto_merge() {
 # fallback (returns 1 path) — this trade-off is acceptable for owned-org
 # repos where allow_auto_merge=true is bulk-enabled and CI is fast.
 #
-# Args: $1=pr_number, $2=repo_slug, $3=require synchronous final gate (0|1)
+# Args: $1=pr_number, $2=repo_slug, $3=require synchronous final gate (0|1),
+#       $4=current already-gated review state, $5=gated head SHA
 # Returns: 0=native-auto requested/deferred, 1=fall through,
 #          2=defer without native auto-merge so mutable approval state is
 #            revalidated on a later synchronous merge cycle
@@ -1918,12 +1793,14 @@ _set_native_auto_merge_or_skip() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local require_synchronous_final_gate="${3:-0}"
+	local current_review="${4:-UNKNOWN}"
+	local expected_head_sha="${5:-}"
 
-	# Fetch auto_merge metadata + merge state in one call so the stuck-state
-	# check (t3192) does not require an extra round trip.
+	# Fetch auto_merge metadata + merge state through exact-attribution routes.
+	# Carry forward the review state that passed this cycle's gate; unknown or
+	# blocking states cannot authorize stale native-auto wedge recovery.
 	local _pr_state
-	_pr_state=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json autoMergeRequest,mergeStateStatus,mergeable,reviewDecision 2>/dev/null)
+	_pr_state=$(_pmp_native_auto_merge_state "$pr_number" "$repo_slug" "$current_review" 2>/dev/null) || _pr_state=""
 
 	local _existing_auto=""
 	if [[ -n "$_pr_state" ]]; then
@@ -1931,49 +1808,9 @@ _set_native_auto_merge_or_skip() {
 	fi
 
 	if [[ -n "$_existing_auto" ]]; then
-		if [[ "$require_synchronous_final_gate" == "1" ]]; then
-			_stop_external_native_auto_merge "$pr_number" "$repo_slug"
-			return $?
-		fi
-		# Auto-merge already requested — check for the GitHub auto_merge wedge
-		# before unconditionally deferring (t3192).
-		local _stuck_seconds=""
-		if _stuck_seconds=$(_auto_merge_stuck_seconds "$pr_number" "$repo_slug" "$_pr_state"); then
-			local _threshold="${AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS:-300}"
-			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge stuck ${_stuck_seconds}s (>${_threshold}s) in BLOCKED+MERGEABLE with no failing/pending required checks — falling through to immediate merge (t3192)" >>"$LOGFILE"
-			local _disable_auto_output=""
-			if _disable_auto_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --disable-auto 2>&1); then
-				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: disabled stale native auto-merge before immediate merge (GH#26897)" >>"$LOGFILE"
-			else
-				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: failed to disable stale native auto-merge before immediate merge (GH#26897): ${_disable_auto_output}" >>"$LOGFILE"
-			fi
-			return 1
-		fi
-
-		# t3567: pending required checks are non-terminal. Even if native
-		# auto-merge has been waiting past the stuck threshold, do not route CI
-		# repair/close/requeue unless a terminal failure has been observed.
-		local _pending_count=0
-		if ! _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
-			_pending_count=1
-		fi
-		if [[ "$_pending_count" -gt 0 ]]; then
-			local _enabled_at="" _enabled_epoch="0" _now_epoch="0" _age_seconds="0"
-			_enabled_at=$(printf '%s' "$_pr_state" | jq -r '.autoMergeRequest.enabledAt // ""' 2>/dev/null) || _enabled_at=""
-			_enabled_epoch=$(date -u -d "$_enabled_at" +%s 2>/dev/null \
-				|| TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$_enabled_at" +%s 2>/dev/null \
-				|| echo "0")
-			[[ "$_enabled_epoch" =~ ^[0-9]+$ ]] || _enabled_epoch=0
-			_now_epoch=$(date -u +%s)
-			_age_seconds=$((_now_epoch - _enabled_epoch))
-			local _threshold="${AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS:-300}"
-			if [[ "$_enabled_epoch" -gt 0 && "$_age_seconds" -gt "$_threshold" ]]; then
-				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge has ${_pending_count} required check(s) pending for ${_age_seconds}s (>${_threshold}s) — deferring as non-terminal (t3567)" >>"$LOGFILE"
-				return 0
-			fi
-		fi
-		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge already set, deferring to GitHub (t3070)" >>"$LOGFILE"
-		return 0
+		_handle_existing_native_auto_merge "$pr_number" "$repo_slug" \
+			"$require_synchronous_final_gate" "$expected_head_sha" "$_pr_state"
+		return $?
 	fi
 
 	# Skip if repo does not allow auto-merge — fall through to immediate merge.
@@ -1999,16 +1836,7 @@ _set_native_auto_merge_or_skip() {
 		return 2
 	fi
 
-	# CI in flight — ask GitHub to merge on green.
-	local _auto_output=""
-	local _auto_exit=0
-	_auto_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash 2>&1)
-	_auto_exit=$?
-	if [[ $_auto_exit -eq 0 ]]; then
-		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: native auto-merge set (CI ${pending_count} pending), GitHub merges on green (t3070)" >>"$LOGFILE"
-		return 0
-	fi
-
-	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: gh pr merge --auto failed (exit ${_auto_exit}): ${_auto_output} — falling through to immediate merge (t3070)" >>"$LOGFILE"
-	return 1
+	# CI in flight — ask GitHub to merge on green, bound to the gated head.
+	_enable_native_auto_merge_for_head "$pr_number" "$repo_slug" "$expected_head_sha" "$pending_count"
+	return $?
 }

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -257,11 +257,17 @@ _pmrc_snapshot_review_threads_clear() {
 	local pr_number="$2"
 	local base_branch="$3"
 	local owner="${repo_slug%%/*}" name="${repo_slug##*/}" response="" counts="" has_next=""
-	local total_count="" bot_count="" resolution_required="" log_target="${LOGFILE:-/dev/stderr}"
+	local total_count="" bot_count="" resolution_required="" reported_cost="" log_target="${LOGFILE:-/dev/stderr}"
 	local bot_re="coderabbitai|gemini-code-assist|augment-code|augmentcode|copilot"
 
+	# This fixed query has a documented/calibrated GraphQL cost of one point.
+	# Request the operation-owned cost in the same response and fail closed if
+	# GitHub ever changes that contract; exact-capture telemetry can therefore
+	# attribute this otherwise irreducible GraphQL review-thread read without a
+	# racy before/after pool delta (GH#27777).
 	# shellcheck disable=SC2016
-	response=$(_pmrc_gh_read gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_GH_ROUTE_DECISION="pulse-review-threads-exact-cost" \
+		_pmrc_gh_read gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
 		query($owner: String!, $name: String!, $pr: Int!) {
 			repository(owner: $owner, name: $name) {
 				pullRequest(number: $pr) {
@@ -271,10 +277,16 @@ _pmrc_snapshot_review_threads_clear() {
 					}
 				}
 			}
+			rateLimit { cost }
 		}
 	' 2>/dev/null) || return 1
 	[[ -n "$response" ]] || return 1
 	if ! printf '%s' "$response" | jq -e 'try (.data.repository.pullRequest != null) catch false' >/dev/null; then
+		return 1
+	fi
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty') || return 1
+	if [[ "$reported_cost" != "1" ]]; then
+		echo "[pulse-merge] pre-merge snapshot: review-thread GraphQL cost contract changed for ${repo_slug} PR #${pr_number} — failing closed (GH#27777)" >>"$log_target"
 		return 1
 	fi
 	has_next=$(printf '%s' "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false') || return 1

--- a/.agents/scripts/pulse-merge-rest-state.sh
+++ b/.agents/scripts/pulse-merge-rest-state.sh
@@ -1,0 +1,464 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Pulse merge REST state helpers: exact mergeability, review history, and
+# update-branch transport without native gh GraphQL reads.
+
+[[ -n "${_PULSE_MERGE_REST_STATE_LOADED:-}" ]] && return 0
+_PULSE_MERGE_REST_STATE_LOADED=1
+
+_pmrs_gh_call() {
+	local operation="$1"
+	shift
+	local rc=0
+
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout "$operation" "$@" || rc=$?
+	else
+		"$@" || rc=$?
+	fi
+	return "$rc"
+}
+
+_pmrs_review_max_pages() {
+	local max_pages="${AIDEVOPS_PULSE_REVIEW_MAX_PAGES:-10}"
+	[[ "$max_pages" =~ ^[0-9]+$ ]] || max_pages=10
+	[[ "$max_pages" -ge 1 ]] || max_pages=1
+	[[ "$max_pages" -le 100 ]] || max_pages=100
+	printf '%s' "$max_pages"
+	return 0
+}
+
+#######################################
+# Normalize PR mergeable values from mixed GitHub API paths.
+# Args: $1=raw mergeable value
+# Stdout: normalized mergeable enum
+#######################################
+_pmp_normalize_mergeable_state() {
+	local raw_state="$1"
+	local normalized_state=""
+	case "$raw_state" in
+	MERGEABLE|mergeable|true|TRUE) normalized_state="MERGEABLE" ;;
+	CONFLICTING|conflicting|false|FALSE) normalized_state="CONFLICTING" ;;
+	UNKNOWN|unknown|''|null|NULL) normalized_state="UNKNOWN" ;;
+	*) normalized_state="$raw_state" ;;
+	esac
+	printf '%s' "$normalized_state"
+	return 0
+}
+
+#######################################
+# Normalize PR mergeable values into a caller variable.
+# Args: $1=destination variable name, $2=raw mergeable value
+#######################################
+_pmp_normalize_mergeable_state_into() {
+	local dest_var="$1"
+	local raw_state="$2"
+	local normalized_state=""
+
+	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	case "$raw_state" in
+	MERGEABLE|mergeable|true|TRUE) normalized_state="MERGEABLE" ;;
+	CONFLICTING|conflicting|false|FALSE) normalized_state="CONFLICTING" ;;
+	UNKNOWN|unknown|''|null|NULL) normalized_state="UNKNOWN" ;;
+	*) normalized_state="$raw_state" ;;
+	esac
+	printf -v "$dest_var" '%s' "$normalized_state"
+	return 0
+}
+
+#######################################
+# Refresh empty/UNKNOWN mergeability through the exact single-PR REST route.
+# Args: $1=destination var, $2=PR number, $3=repo slug, $4=current state
+#######################################
+_pmp_refresh_unknown_mergeable_state_into() {
+	local dest_var="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local current_mergeable="$4"
+	local refreshed_mergeable=""
+	local refresh_exit=0
+
+	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	_pmp_normalize_mergeable_state_into refreshed_mergeable "$current_mergeable"
+
+	if [[ "$refreshed_mergeable" == "UNKNOWN" || -z "$refreshed_mergeable" ]]; then
+		refreshed_mergeable=$(AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 \
+			gh_pr_view "$pr_number" --repo "$repo_slug" --json mergeable --jq '.mergeable // ""')
+		refresh_exit=$?
+		[[ $refresh_exit -eq 0 && -n "$refreshed_mergeable" ]] || refreshed_mergeable="UNKNOWN"
+		_pmp_normalize_mergeable_state_into refreshed_mergeable "$refreshed_mergeable"
+	fi
+
+	printf -v "$dest_var" '%s' "$refreshed_mergeable"
+	return 0
+}
+
+#######################################
+# Add exact single-PR REST mergeability to every unknown list item.
+# Args: $1=repo slug, $2=PR JSON array
+#######################################
+_pmp_enrich_prs_with_mergeability() {
+	local repo_slug="$1"
+	local pr_json="$2"
+	local enriched_json="$pr_json"
+	local rows=""
+	local _US=$'\x1f'
+	local index="" number="" mergeable=""
+
+	if [[ -z "$repo_slug" ]]; then
+		printf '%s' "$pr_json"
+		return 0
+	fi
+	rows=$(printf '%s' "$pr_json" | jq -r '
+		if type != "array" then error("expected PR array")
+		else to_entries[] | [
+			(.key | tostring),
+			(if ((.value | has("number") | not) or .value.number == null) then "" else (.value.number | tostring) end),
+			(if ((.value | has("mergeable") | not) or .value.mergeable == null or (.value.mergeable | tostring | length) == 0)
+			 then "UNKNOWN" else (.value.mergeable | tostring) end)
+		] | join("\u001f")
+		end' 2>/dev/null) || {
+		printf '%s' "$pr_json"
+		return 0
+	}
+
+	while IFS="$_US" read -r index number mergeable; do
+		[[ -n "$index" ]] || continue
+		_pmp_normalize_mergeable_state_into mergeable "$mergeable"
+		if [[ "$number" =~ ^[0-9]+$ && "$mergeable" == "UNKNOWN" ]]; then
+			_pmp_refresh_unknown_mergeable_state_into mergeable "$number" "$repo_slug" "$mergeable"
+			enriched_json=$(printf '%s' "$enriched_json" | jq --argjson index "$index" --arg mergeable "$mergeable" '.[$index].mergeable = $mergeable' 2>/dev/null) || {
+				printf '%s' "$pr_json"
+				return 0
+			}
+		fi
+	done <<<"$rows"
+
+	printf '%s' "$enriched_json"
+	return 0
+}
+
+_pmp_normalize_review_decision_into() {
+	local dest_var="$1"
+	local raw_decision="$2"
+	local normalized_decision=""
+
+	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	case "$raw_decision" in
+	CHANGES_REQUESTED|APPROVED|OBSERVED_APPROVED|REVIEW_REQUIRED|NONE) normalized_decision="$raw_decision" ;;
+	changes_requested) normalized_decision="CHANGES_REQUESTED" ;;
+	approved) normalized_decision="APPROVED" ;;
+	observed_approved) normalized_decision="OBSERVED_APPROVED" ;;
+	review_required) normalized_decision="REVIEW_REQUIRED" ;;
+	none) normalized_decision="NONE" ;;
+	''|null|NULL|UNKNOWN|unknown) normalized_decision="UNKNOWN" ;;
+	*) normalized_decision="$raw_decision" ;;
+	esac
+	printf -v "$dest_var" '%s' "$normalized_decision"
+	return 0
+}
+
+_pmp_review_decision_is_unknown() {
+	local raw_decision="$1"
+	local checked_decision=""
+	_pmp_normalize_review_decision_into checked_decision "$raw_decision"
+	[[ "$checked_decision" == "UNKNOWN" ]]
+	return $?
+}
+
+#######################################
+# Fetch review history in explicit, bounded REST pages. Every transport has a
+# concrete page number; a full final page at the bound fails closed.
+# Args: $1=PR number, $2=repo slug
+# Stdout: one flattened JSON review array
+#######################################
+_pmp_rest_reviews_json() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local page=1
+	local max_pages=10
+	local endpoint="" page_json="" page_count=0 reviews_json='[]'
+
+	max_pages=$(_pmrs_review_max_pages)
+	while [[ "$page" -le "$max_pages" ]]; do
+		endpoint="repos/${repo_slug}/pulls/${pr_number}/reviews?per_page=100&page=${page}"
+		page_json=$(AIDEVOPS_GH_PAGE_NUMBER="$page" \
+			AIDEVOPS_GH_ROUTE_DECISION="pulse-review-explicit-page" \
+			_pmrs_gh_call read gh api "$endpoint" 2>/dev/null) || return 1
+		printf '%s' "$page_json" | jq -e 'type == "array"' >/dev/null 2>&1 || return 1
+		page_count=$(printf '%s' "$page_json" | jq 'length' 2>/dev/null) || return 1
+		[[ "$page_count" =~ ^[0-9]+$ ]] || return 1
+		reviews_json=$(printf '%s\n%s\n' "$reviews_json" "$page_json" | jq -cs '.[0] + .[1]' 2>/dev/null) || return 1
+		if [[ "$page_count" -lt 100 ]]; then
+			printf '%s' "$reviews_json"
+			return 0
+		fi
+		page=$((page + 1))
+	done
+	return 1
+}
+
+#######################################
+# Derive active review state from each reviewer's latest state-changing review.
+# This preserves active blockers and exposes observed approvals without
+# fabricating policy-level APPROVED/REVIEW_REQUIRED state that review history
+# alone cannot prove.
+#######################################
+_pmp_rest_review_decision_from_reviews() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local reviews_json=""
+
+	reviews_json=$(_pmp_rest_reviews_json "$pr_number" "$repo_slug") || return 1
+	printf '%s' "$reviews_json" | jq -r '
+		def state_changing: .state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED";
+		if type != "array" then error("expected review array")
+		elif any(.[]?; state_changing and (
+			(.user | type) != "object"
+			or (.user.login | type) != "string"
+			or (.user.login | length) == 0
+			or (.submitted_at | type) != "string"
+			or (.submitted_at | length) == 0
+			or (.id | type) != "number"
+		)) then error("malformed state-changing review")
+		else map(select(state_changing))
+		| group_by(.user.login)
+		| map(max_by([.submitted_at // "", .id // 0]))
+		| if any(.state == "CHANGES_REQUESTED") then "CHANGES_REQUESTED"
+		  elif any(.state == "APPROVED") then "OBSERVED_APPROVED"
+		  else "NONE" end end
+	' 2>/dev/null || return 1
+	return 0
+}
+
+_pmp_refresh_unknown_review_decision_into() {
+	local dest_var="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local current_review="$4"
+	local refreshed_review=""
+
+	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	_pmp_normalize_review_decision_into refreshed_review "$current_review"
+	if [[ "$refreshed_review" == "UNKNOWN" ]]; then
+		refreshed_review=$(_pmp_rest_review_decision_from_reviews "$pr_number" "$repo_slug" 2>/dev/null) || refreshed_review="UNKNOWN"
+		_pmp_normalize_review_decision_into refreshed_review "$refreshed_review"
+	fi
+	printf -v "$dest_var" '%s' "$refreshed_review"
+	return 0
+}
+
+#######################################
+# Reconcile the already-gated review state with a fresh, bounded REST review
+# history immediately before stale native-auto recovery. A new blocker is
+# authoritative; unavailable or contradictory evidence fails closed.
+# Args: $1=destination var, $2=PR number, $3=repo slug, $4=gated review state
+#######################################
+_pmp_refresh_native_auto_review_into() {
+	local dest_var="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local gated_review="$4"
+	local fresh_review=""
+
+	[[ "$dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+	_pmp_normalize_review_decision_into gated_review "$gated_review"
+	fresh_review=$(_pmp_rest_review_decision_from_reviews "$pr_number" "$repo_slug" 2>/dev/null) || {
+		printf -v "$dest_var" '%s' UNKNOWN
+		return 1
+	}
+	_pmp_normalize_review_decision_into fresh_review "$fresh_review"
+
+	if [[ "$fresh_review" == "CHANGES_REQUESTED" ]]; then
+		printf -v "$dest_var" '%s' "$fresh_review"
+		return 0
+	fi
+	case "${gated_review}:${fresh_review}" in
+	APPROVED:OBSERVED_APPROVED | OBSERVED_APPROVED:OBSERVED_APPROVED | NONE:OBSERVED_APPROVED | NONE:NONE)
+		printf -v "$dest_var" '%s' "$fresh_review"
+		return 0
+		;;
+	esac
+	printf -v "$dest_var" '%s' UNKNOWN
+	return 1
+}
+
+#######################################
+# Resolve unknown review states once before backlog logging and sorting.
+# Args: $1=repo slug, $2=PR JSON array
+#######################################
+_pmp_enrich_prs_with_review_decisions() {
+	local repo_slug="$1"
+	local pr_json="$2"
+	local enriched_json="$pr_json"
+	local pr_rows=""
+	local _US=$'\x1f'
+	local index="" number="" review_decision=""
+
+	if [[ -z "$repo_slug" ]]; then
+		printf '%s' "$pr_json"
+		return 0
+	fi
+	pr_rows=$(printf '%s' "$pr_json" | jq -r '
+		if type != "array" then error("expected PR array")
+		else to_entries[] | [
+			(.key | tostring),
+			(if ((.value | has("number") | not) or .value.number == null or (.value.number | tostring | length) == 0)
+			 then "" else (.value.number | tostring) end),
+			(if ((.value | has("reviewDecision") | not) or .value.reviewDecision == null or (.value.reviewDecision | tostring | length) == 0)
+			 then "UNKNOWN" else .value.reviewDecision end)
+		] | join("\u001f")
+		end' 2>/dev/null) || {
+		printf '%s' "$pr_json"
+		return 0
+	}
+
+	while IFS="$_US" read -r index number review_decision; do
+		[[ -n "$index" ]] || continue
+		_pmp_normalize_review_decision_into review_decision "$review_decision"
+		if [[ "$number" =~ ^[0-9]+$ ]] && _pmp_review_decision_is_unknown "$review_decision"; then
+			_pmp_refresh_unknown_review_decision_into review_decision "$number" "$repo_slug" "$review_decision"
+			enriched_json=$(printf '%s' "$enriched_json" | jq --argjson index "$index" --arg review "$review_decision" '.[$index].reviewDecision = $review' 2>/dev/null) || {
+				printf '%s' "$pr_json"
+				return 0
+			}
+		fi
+	done <<<"$pr_rows"
+
+	printf '%s' "$enriched_json"
+	return 0
+}
+
+#######################################
+# Execute GitHub's update-a-pull-request-branch REST endpoint.
+# Args: $1=PR number, $2=repo slug, $3=expected current head SHA
+#######################################
+_pmp_update_branch_rest() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="${3:-}"
+
+	if [[ -z "$expected_head_sha" ]]; then
+		printf 'update-branch refused: expected head SHA is required for PR #%s in %s\n' \
+			"$pr_number" "$repo_slug" >&2
+		return 2
+	fi
+	AIDEVOPS_GH_ROUTE_DECISION="pulse-update-branch-rest" \
+		_pmrs_gh_call write gh api --method PUT "repos/${repo_slug}/pulls/${pr_number}/update-branch" \
+			-f expected_head_sha="$expected_head_sha"
+	return $?
+}
+
+#######################################
+# Read auto-merge enablement time through a fixed-cost GraphQL query when the
+# REST representation omits auto_merge.enabled_at. The operation reports its
+# own cost and fails closed if GitHub changes the calibrated one-point shape.
+# Args: $1=PR number, $2=repo slug
+# Stdout: enabledAt timestamp, or empty when no request exists
+#######################################
+_pmrs_auto_merge_enabled_at_graphql() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local owner="${repo_slug%%/*}"
+	local name="${repo_slug##*/}"
+	local response="" reported_cost="" enabled_at=""
+
+	# shellcheck disable=SC2016
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_GH_ROUTE_DECISION="pulse-auto-merge-enabled-at-exact-cost" \
+		_pmrs_gh_call read gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
+		query($owner: String!, $name: String!, $pr: Int!) {
+			repository(owner: $owner, name: $name) {
+				pullRequest(number: $pr) { autoMergeRequest { enabledAt } }
+			}
+			rateLimit { cost }
+		}
+	') || return 1
+	[[ -n "$response" ]] || return 1
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty') || return 1
+	if [[ "$reported_cost" != "1" ]]; then
+		printf 'auto-merge enabledAt GraphQL cost contract changed for PR #%s in %s\n' \
+			"$pr_number" "$repo_slug" >&2
+		return 1
+	fi
+	enabled_at=$(printf '%s' "$response" \
+		| jq -r '.data.repository.pullRequest.autoMergeRequest.enabledAt // empty') || return 1
+	printf '%s' "$enabled_at"
+	return 0
+}
+
+#######################################
+# Fetch native-auto and merge-state metadata through REST. If REST omits the
+# auto-merge timestamp, recover that one GraphQL-only field through a fixed,
+# response-metered query; a failed recovery leaves the age unknown/fail-closed.
+# Args: $1=PR number, $2=repo slug
+#######################################
+_pmp_rest_pr_merge_state() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_state="" enabled_at=""
+	pr_state=$(AIDEVOPS_GH_ROUTE_DECISION="pulse-pr-merge-state-rest" \
+		_pmrs_gh_call read gh api "repos/${repo_slug}/pulls/${pr_number}" --jq '
+		{
+			autoMergeRequest: (if .auto_merge == null then null else {
+				enabledAt: (.auto_merge.enabled_at // null),
+				enabledBy: (.auto_merge.enabled_by // null)
+			} end),
+			mergeStateStatus: ((.mergeable_state // "unknown") | ascii_upcase),
+			mergeable: (if .mergeable == true then "MERGEABLE"
+				elif .mergeable == false then "CONFLICTING" else "UNKNOWN" end),
+			headRefOid: (.head.sha // "")
+		}'
+	) || return $?
+	[[ -n "$pr_state" ]] || return 1
+	if printf '%s' "$pr_state" | jq -e '.autoMergeRequest != null and .autoMergeRequest.enabledAt == null' >/dev/null 2>&1; then
+		enabled_at=$(_pmrs_auto_merge_enabled_at_graphql "$pr_number" "$repo_slug" 2>/dev/null) || enabled_at=""
+		if [[ -n "$enabled_at" ]]; then
+			pr_state=$(printf '%s' "$pr_state" | jq -c --arg enabled_at "$enabled_at" \
+				'.autoMergeRequest.enabledAt = $enabled_at') || return 1
+		fi
+	fi
+	printf '%s' "$pr_state"
+	return 0
+}
+
+#######################################
+# Overlay the review state that already passed the current merge gate onto the
+# exact-attribution REST/native-auto snapshot.
+# Args: $1=PR number, $2=repo slug, $3=current review state
+#######################################
+_pmp_native_auto_merge_state() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local current_review="$3"
+	local pr_state=""
+
+	pr_state=$(_pmp_rest_pr_merge_state "$pr_number" "$repo_slug") || return 1
+	_pmp_normalize_review_decision_into current_review "$current_review"
+	pr_state=$(printf '%s' "$pr_state" | jq -c --arg review "$current_review" \
+		'.reviewDecision = $review' 2>/dev/null) || return 1
+	printf '%s' "$pr_state"
+	return 0
+}
+
+_pmp_extract_update_branch_state() {
+	local auto_var="$1"
+	local state_var="$2"
+	local mergeable_var="$3"
+	local pr_state="$4"
+	local head_var="${5:-}"
+	local existing_auto="" merge_state="" mergeable="" head_oid="" _RS=$'\x1e'
+
+	IFS="$_RS" read -r existing_auto merge_state mergeable head_oid <<<"$(printf '%s' "$pr_state" \
+		| jq -r '"\(if .autoMergeRequest then "present" else "" end)\u001e\(.mergeStateStatus // "")\u001e\(.mergeable // "")\u001e\(.headRefOid // "")"' \
+		|| true)"
+	_pmp_normalize_mergeable_state_into mergeable "$mergeable"
+	printf -v "$auto_var" '%s' "$existing_auto"
+	printf -v "$state_var" '%s' "$merge_state"
+	printf -v "$mergeable_var" '%s' "$mergeable"
+	if [[ -n "$head_var" ]]; then
+		[[ "$head_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+		printf -v "$head_var" '%s' "$head_oid"
+	fi
+	return 0
+}

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -229,13 +229,11 @@ _pmr_graphql_remaining() {
 		printf '%s\n' "$remaining"
 		return 0
 	fi
-	# Query the GraphQL budget through GraphQL itself. The REST /rate_limit
-	# endpoint consumes the independent core budget and returns 403 when core is
-	# exhausted, even while GraphQL still has capacity. Treating that failure as
-	# zero falsely disabled every standalone merge pass (GH#24904 regression).
-	remaining=$(_pmr_gh_read gh api graphql \
-		-f 'query=query { rateLimit { remaining } }' \
-		--jq '.data.rateLimit.remaining // 0' 2>/dev/null) || remaining="0"
+	# The REST rate_limit endpoint reports the independent GraphQL pool without
+	# consuming primary quota, and unlike a native GraphQL probe has exact
+	# zero-cost attribution in transport telemetry.
+	remaining=$(_pmr_gh_read gh api rate_limit \
+		--jq '.resources.graphql.remaining // 0' 2>/dev/null) || remaining="0"
 	[[ "$remaining" =~ ^[0-9]+$ ]] || remaining=0
 	printf '%s\n' "$remaining"
 	return 0

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -132,13 +132,27 @@ readonly _PMS_ISSUE_STATE_OPEN="OPEN"
 #######################################
 # Shared open-PR field shape for stuck-merge list scans.
 #
-# Keeps the zero-progress counter and stuck detector on one exact-output
-# provider-cache key while preserving both consumers' fields: author is needed
-# by _pms_count_eligible_unmerged_for_repo, updatedAt by
-# pulse_merge_stuck_run_pass, and the remaining fields gate eligibility.
+# Keeps the zero-progress counter and stuck detector on one REST-safe provider
+# cache key. Exact mergeability and observed active review state are enriched
+# per PR before either consumer classifies eligibility.
 #######################################
 _pms_pr_list_json_fields() {
-	printf '%s' 'number,mergeable,reviewDecision,isDraft,labels,author,updatedAt,headRefOid'
+	printf '%s' 'number,isDraft,labels,author,updatedAt,headRefOid'
+	return 0
+}
+
+_pms_enrich_pr_state() {
+	local repo_slug="$1"
+	local pr_json="$2"
+
+	if ! declare -F _pmp_enrich_prs_with_mergeability >/dev/null 2>&1 \
+		|| ! declare -F _pmp_enrich_prs_with_review_decisions >/dev/null 2>&1; then
+		printf '%s' "$pr_json"
+		return 0
+	fi
+	pr_json=$(_pmp_enrich_prs_with_mergeability "$repo_slug" "$pr_json")
+	pr_json=$(_pmp_enrich_prs_with_review_decisions "$repo_slug" "$pr_json")
+	printf '%s' "$pr_json"
 	return 0
 }
 
@@ -1384,11 +1398,12 @@ _pms_count_eligible_unmerged_for_repo() {
 		--json "$(_pms_pr_list_json_fields)" \
 		--limit 50 2>/dev/null) || pr_json="[]"
 	[[ -n "$pr_json" && "$pr_json" != "$_PMS_JQ_NULL_GUARD" ]] || pr_json="[]"
+	pr_json=$(_pms_enrich_pr_state "$repo_slug" "$pr_json")
 
 	# Enumerate PRs matching the basic eligibility criteria via jq. .mergeable and
-	# .reviewDecision are already upper-case in the GraphQL response — no
-	# ascii_upcase needed (the FAILURE selector keeps it because legacy
-	# commit-status `.state` values can be lower-case).
+	# .mergeable and .reviewDecision are normalized to upper-case enums. Only a
+	# policy-level APPROVED value qualifies; REST history's OBSERVED_APPROVED
+	# cannot trigger stuck-PR escalation or sibling-affecting diagnostics.
 	local candidates
 	candidates=$(printf '%s' "$pr_json" | jq -r '
 		[ .[]
@@ -1610,6 +1625,7 @@ pulse_merge_stuck_run_pass() {
 		--json "$(_pms_pr_list_json_fields)" \
 		--limit 50 2>/dev/null) || pr_json="[]"
 	[[ -n "$pr_json" && "$pr_json" != "$_PMS_JQ_NULL_GUARD" ]] || pr_json="[]"
+	pr_json=$(_pms_enrich_pr_state "$repo_slug" "$pr_json")
 
 	local pr_count
 	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -170,11 +170,11 @@ _pulse_merge_changes_requested_thread_remediation_first_enabled() {
 	return 0
 }
 
-# Standard PR JSON fields consumed by _process_single_ready_pr. Keep every
-# caller that builds a PR object on this helper so draft/label/staleness
-# metadata cannot drift between list-based and webhook-triggered merge paths.
+# REST-safe PR list fields consumed by _process_single_ready_pr. Exact
+# mergeability, active review state, and check status are enriched separately
+# from bounded REST endpoints before any classification or write decision.
 _pulse_merge_ready_pr_json_fields() {
-	printf '%s' 'number,state,mergeable,reviewDecision,author,title,isDraft,labels,updatedAt,headRefOid,headRefName,baseRefName,createdAt,statusCheckRollup'
+	printf '%s' 'number,state,author,title,isDraft,labels,updatedAt,headRefOid,headRefName,baseRefName,createdAt'
 	return 0
 }
 
@@ -1293,7 +1293,7 @@ _process_single_ready_pr() {
 	fi
 
 	# CONFLICTING handling (t2116): before closing, attempt to salvage the
-	# PR via `gh pr update-branch` which fast-forwards the base branch into
+	# PR via GitHub's REST update-branch endpoint, which fast-forwards the base branch into
 	# the PR's branch when the conflict is purely due to base advancement
 	# (common case: ratchet PRs on a file that other PRs also touched, docs
 	# simplifications on adjacent sections). If update-branch succeeds, the
@@ -1327,11 +1327,11 @@ _process_single_ready_pr() {
 			fi
 		fi
 
-		# Attempt auto-rebase via gh pr update-branch. This is idempotent
+		# Attempt auto-rebase via the REST update-branch endpoint. This is idempotent
 		# and cheap: on success the branch is fast-forwarded and the next
 		# mergeable re-fetch returns MERGEABLE; on failure (true semantic
 		# conflict) we fall through to the close path.
-		if _attempt_pr_update_branch "$pr_number" "$repo_slug"; then
+		if _attempt_pr_update_branch "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
 			# Re-fetch mergeable state after update-branch; GitHub needs a
 			# moment to recompute it. _resolve_pr_mergeable_status already
 			# has a UNKNOWN-retry loop so we reuse it.
@@ -1547,7 +1547,9 @@ _process_single_ready_pr() {
 	# pulse poll cycle (~120s). Falls through to --admin immediate merge
 	# when CI is already green, repo opts out, or the API call fails.
 	local _native_auto_rc=0
-	_set_native_auto_merge_or_skip "$pr_number" "$repo_slug" "${_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE:-0}" || _native_auto_rc=$?
+	_set_native_auto_merge_or_skip "$pr_number" "$repo_slug" \
+		"${_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE:-0}" "$pr_review" \
+		"$pr_head_ref_oid" || _native_auto_rc=$?
 	case "$_native_auto_rc" in
 		0)
 			return 4
@@ -1598,7 +1600,7 @@ ${merge_output}"
 		&& ( "$merge_output" == *" is expected"* || "$merge_output" == *" is pending"* ) ]]; then
 		local _missing_check_update_output=""
 		local _missing_check_update_exit=0
-		_missing_check_update_output=$(gh pr update-branch "$pr_number" --repo "$repo_slug" 2>&1)
+		_missing_check_update_output=$(_pmp_update_branch_rest "$pr_number" "$repo_slug" "$pr_head_ref_oid" 2>&1)
 		_missing_check_update_exit=$?
 		if [[ $_missing_check_update_exit -eq 0 ]]; then
 			echo "[pulse-wrapper] Deterministic merge: admin merge reported an expected/pending required status check for PR #${pr_number} in ${repo_slug}; update-branch requested and merge deferred (GH#26899): ${merge_output}" >>"$LOGFILE"

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -1337,15 +1337,51 @@ _find_qualifying_pr_for_stale_recovery() {
 	local slug="$2"
 	local nmr_at="$3"
 
-	# GH#21799: dropped statusCheckRollup (heaviest GraphQL field). headRefOid
-	# is added so per-PR check-run state can be fetched via REST below — that
-	# call only fires for PRs that pass the cheap gates first.
-	local pr_json
-	pr_json=$(gh_pr_list --search "Resolves #${issue_num} in:body" --state open \
-		--repo "$slug" --json number,reviewDecision,headRefOid,authorAssociation,labels,createdAt \
-		--limit 10 2>/dev/null) || pr_json="[]"
-	[[ -n "$pr_json" && "$pr_json" != "null" ]] || pr_json="[]"
 	[[ -n "$nmr_at" ]] || return 0
+
+	# reviewDecision is policy-level GraphQL state and cannot be reconstructed
+	# from REST review history. Use a fixed-shape search query that reports its
+	# own calibrated one-point cost instead of native gh pr list, whose cost is
+	# otherwise unattributable (GH#27777). headRefOid feeds REST check-runs below.
+	local query_string="repo:${slug} is:pr is:open Resolves #${issue_num} in:body"
+	local response="" reported_cost="" pr_json="[]"
+	# shellcheck disable=SC2016
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_GH_ROUTE_DECISION="pulse-nmr-pr-search-exact-cost" \
+		gh api graphql -F queryString="$query_string" -f query='
+		query($queryString: String!) {
+			search(type: ISSUE, query: $queryString, first: 10) {
+				nodes {
+					... on PullRequest {
+						number
+						reviewDecision
+						headRefOid
+						authorAssociation
+						labels(first: 100) { nodes { name } pageInfo { hasNextPage } }
+						createdAt
+					}
+				}
+			}
+			rateLimit { cost }
+		}
+	' 2>/dev/null) || response=""
+	[[ -n "$response" ]] || return 0
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	[[ "$reported_cost" == "1" ]] || return 0
+	pr_json=$(printf '%s' "$response" | jq -c '
+		.data.search.nodes
+		| if type != "array" then error("search nodes must be an array") else . end
+		| if any(.[]?; (.labels.pageInfo.hasNextPage // false) == true)
+			then error("PR label page is incomplete") else . end
+		| map({
+			number,
+			reviewDecision,
+			headRefOid,
+			authorAssociation,
+			labels: (.labels.nodes // []),
+			createdAt
+		})
+	' 2>/dev/null) || pr_json="[]"
+	[[ -n "$pr_json" && "$pr_json" != "null" ]] || pr_json="[]"
 
 	local candidate_prs
 	candidate_prs=$(printf '%s' "$pr_json" | jq -r \

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -63,6 +63,15 @@ _prefetch_prs_try_delta() {
 	local cache_entry="$2"
 	local pr_err="$3"
 
+	# gh pr list --search is GraphQL-only in the compatibility wrapper and does
+	# not expose operation-owned cost. Under REST-first collection, prefer one
+	# full REST list over an unattributable delta query (GH#27777).
+	if [[ "${AIDEVOPS_GH_REST_FIRST_READS:-0}" == "1" || "${AIDEVOPS_GH_FORCE_REST_READS:-0}" == "1" ]]; then
+		echo "[pulse-wrapper] _prefetch_repo_prs: REST-first mode bypasses GraphQL-only delta search for ${slug}; using full REST sweep (GH#27777)" >>"$LOGFILE"
+		PREFETCH_PR_SWEEP_MODE="$_PREFETCH_PR_SWEEP_FULL"
+		return 0
+	fi
+
 	local last_prefetch
 	last_prefetch=$(echo "$cache_entry" | jq -r '.last_prefetch // ""' 2>/dev/null) || last_prefetch=""
 
@@ -76,7 +85,7 @@ _prefetch_prs_try_delta() {
 	# headRefOid required for REST check-suites lookup (GH#21799).
 	local delta_json=""
 	delta_json=$(gh_pr_list --repo "$slug" --state open \
-		--json number,title,reviewDecision,updatedAt,headRefName,headRefOid,createdAt,author \
+		--json number,title,updatedAt,headRefName,headRefOid,createdAt,author \
 		--search "updated:>=${last_prefetch}" \
 		--limit "$PULSE_PREFETCH_PR_LIMIT" 2>"$pr_err") || delta_json=""
 
@@ -258,7 +267,7 @@ _prefetch_prs_fetch_full() {
 	local err_msg=""
 
 	PREFETCH_PR_RESULT=$(gh_pr_list --repo "$slug" --state open \
-		--json number,title,reviewDecision,updatedAt,headRefName,headRefOid,createdAt,author \
+		--json number,title,updatedAt,headRefName,headRefOid,createdAt,author \
 		--limit "$PULSE_PREFETCH_PR_LIMIT" 2>"$pr_err") || PREFETCH_PR_RESULT=""
 	if [[ -z "$PREFETCH_PR_RESULT" || "$PREFETCH_PR_RESULT" == "$_PREFETCH_JSON_NULL" ]]; then
 		err_msg=$(cat "$pr_err" 2>/dev/null || echo "$_PREFETCH_UNKNOWN_ERROR")
@@ -291,7 +300,8 @@ _prefetch_repo_prs() {
 	#
 	# Fix: fetch without statusCheckRollup first (fast, always works), then
 	# enrich with check status in a separate lightweight call. If the enrichment
-	# fails, the pulse still sees the PR list and can act on review status.
+	# fails, the pulse still sees the PR list; authoritative merge review state is
+	# enriched separately from bounded REST review history.
 	#
 	# GH#15286: Delta mode — fetch only PRs updated since last_prefetch, then
 	# merge into cached full list. Full sweep replaces the cache entirely.

--- a/.agents/scripts/pulse-prefetch-infra.sh
+++ b/.agents/scripts/pulse-prefetch-infra.sh
@@ -74,10 +74,10 @@ _pulse_gh_err_is_rate_limit() {
 }
 
 #######################################
-# Verify live GraphQL rate limit before committing to rate-limit abort.
+# Verify live GraphQL-pool rate limit before committing to rate-limit abort.
 #
-# Cross-checks the classifier's signal against a non-cached query path
-# (rateLimit query, not SearchType_enumValues introspection). Defends
+# Cross-checks the classifier's signal against the zero-cost REST rate_limit
+# resource instead of spending an unattributable GraphQL request. Defends
 # against gh CLI cache poisoning (stale RATE_LIMIT response from a prior
 # transient budget exhaustion) keeping the pulse stuck for hours.
 #
@@ -95,9 +95,9 @@ _pulse_gh_err_is_rate_limit() {
 _pulse_verify_rate_limit_live() {
 	local threshold="${1:-100}"
 	local remaining
-	# rateLimit query does not hit the --label/--search introspection cache.
+	# The REST rate_limit resource does not hit the --label/--search cache.
 	# Failure modes: network error, auth error — treat as "can't verify, trust classifier".
-	remaining=$(gh api graphql -f query='{rateLimit{remaining}}' --jq '.data.rateLimit.remaining' 2>/dev/null) || return 0
+	remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null) || return 0
 	[[ -z "$remaining" || ! "$remaining" =~ ^[0-9]+$ ]] && return 0
 	[[ "$remaining" -lt "$threshold" ]] && return 0
 	return 1

--- a/.agents/scripts/pulse-queue-governor.sh
+++ b/.agents/scripts/pulse-queue-governor.sh
@@ -55,7 +55,7 @@ _fetch_queue_metrics() {
 		# PASS/FAIL/PENDING via REST check-suites (separate budget pool).
 		local pr_json pr_qm_err
 		pr_qm_err=$(mktemp)
-		pr_json=$(pulse_pr_list_get --repo "$slug" --state open --json number,reviewDecision,headRefOid --limit "$PULSE_RUNNABLE_PR_LIMIT" 2>"$pr_qm_err") || pr_json="[]"
+		pr_json=$(pulse_pr_list_get --repo "$slug" --state open --json number,headRefOid --limit "$PULSE_RUNNABLE_PR_LIMIT" 2>"$pr_qm_err") || pr_json="[]"
 		if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
 			local _pr_qm_err_msg
 			_pr_qm_err_msg=$(cat "$pr_qm_err" 2>/dev/null || echo "unknown error")
@@ -63,6 +63,9 @@ _fetch_queue_metrics() {
 			pr_json="[]"
 		fi
 		rm -f "$pr_qm_err"
+		if declare -F _pmp_enrich_prs_with_review_decisions >/dev/null 2>&1; then
+			pr_json=$(_pmp_enrich_prs_with_review_decisions "$slug" "$pr_json")
+		fi
 
 		# Enrich with REST check status; aggregate counts using the resulting
 		# pre-computed status string per PR.
@@ -72,6 +75,9 @@ _fetch_queue_metrics() {
 
 		local repo_pr_total repo_ready repo_failing
 		repo_pr_total=$(echo "$pr_json" | jq 'length' 2>/dev/null) || repo_pr_total=0
+		# Only policy-level APPROVED counts as ready. REST review history emits
+		# OBSERVED_APPROVED instead, which is intentionally not promoted without
+		# required-count/code-owner proof.
 		repo_ready=$(jq -n --argjson prs "$pr_json" --argjson checks "$pr_checks_json" '
 			($checks | map({(.number | tostring): .status}) | add // {}) as $check_map |
 			[$prs[] | (.number | tostring) as $n | select(.reviewDecision == "APPROVED" and ($check_map[$n] // "none") == "PASS")] | length

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -1036,6 +1036,7 @@ _rest_issue_object_json_jq() {
 		author) projection="${projection}${projection:+,}author: (.user | ${actor_projection})" ;;
 		stateReason) projection="${projection}${projection:+,}stateReason: (if .state_reason == null then null else (.state_reason | ascii_upcase) end)" ;;
 		closed) projection="${projection}${projection:+,}closed: (.state == \"closed\")" ;;
+		locked) projection="${projection}${projection:+,}locked: (if (.locked | type) == \"boolean\" then .locked else error(\"REST issue locked field must be boolean\") end)" ;;
 		*) return 1 ;;
 		esac
 	done < <(_rest_split_csv "$fields")

--- a/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
@@ -167,7 +167,7 @@ _rest_issue_view_fields_supported() {
 	local field=""
 	while IFS= read -r field; do
 		case "$field" in
-		number|state|url|title|body|createdAt|updatedAt|closedAt|labels|assignees|author|stateReason|closed) ;;
+		number|state|url|title|body|createdAt|updatedAt|closedAt|labels|assignees|author|stateReason|closed|locked) ;;
 		*) return 1 ;;
 		esac
 	done < <(_rest_split_csv "$fields")
@@ -266,8 +266,7 @@ _rest_pr_view_fields_supported() {
 	local field=""
 	while IFS= read -r field; do
 		case "$field" in
-		number|state|merged|mergedAt|closedAt|mergeCommit|mergedBy|isDraft|labels|author|title|body|url|createdAt|updatedAt|baseRefName|headRefName|headRefOid) ;;
-		mergeable) [[ "$mode" == "emergency" ]] || return 1 ;;
+		number|state|merged|mergedAt|closedAt|mergeCommit|mergedBy|mergeable|isDraft|labels|author|title|body|url|createdAt|updatedAt|baseRefName|headRefName|headRefOid) ;;
 		*) return 1 ;;
 		esac
 	done < <(_rest_split_csv "$fields")

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -345,8 +345,8 @@ _gh_pr_view_snapshot_put() {
 _gh_pr_view_field_route_class() {
 	local _field="$1"
 	case "$_field" in
-	number|state|merged|mergedAt|closedAt|mergeCommit|mergedBy|isDraft|labels|author|title|body|url|createdAt|updatedAt|baseRefName|headRefName|headRefOid) printf 'rest' ;;
-	mergeable|statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files|reviewDecision|autoMergeRequest|mergeStateStatus) printf 'gql' ;;
+	number|state|merged|mergedAt|closedAt|mergeCommit|mergedBy|mergeable|isDraft|labels|author|title|body|url|createdAt|updatedAt|baseRefName|headRefName|headRefOid) printf 'rest' ;;
+	statusCheckRollup|reviews|latestReviews|reviewThreads|commits|files|reviewDecision|autoMergeRequest|mergeStateStatus) printf 'gql' ;;
 	*) printf 'unsupported' ;;
 	esac
 	return 0

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -95,6 +95,8 @@ echo ""
 # --- Test 1: source instrumentation directly and record a few calls ----
 # shellcheck source=../gh-api-instrument.sh
 source "${PARENT_DIR}/gh-api-instrument.sh"
+# shellcheck source=../gh-quota-attribution-lib.sh
+source "${PARENT_DIR}/gh-quota-attribution-lib.sh"
 
 gh_record_call rest test-instrument
 gh_record_call graphql test-instrument
@@ -444,6 +446,36 @@ assert_eq "inferred-cost transport failure status preserved" "1" "$inferred_fail
 gh_aggregate_calls
 assert_eq "successful inferred and explicit costs reconcile" "4" "$(jq -r '._meta.known_quota_cost' "$AIDEVOPS_GH_API_REPORT")"
 assert_eq "failed inferred cost remains unknown" "1" "$(jq -r '._meta.unknown_quota_cost_attempts' "$AIDEVOPS_GH_API_REPORT")"
+
+# --- Test 11c: exact-frame capture honours success-only quota costs ----------
+exact_success_result="$TMPDIR/exact-success.result"
+exact_failure_result="$TMPDIR/exact-failure.result"
+exact_success_state="$TMPDIR/exact-success.state"
+exact_failure_state="$TMPDIR/exact-failure.state"
+: >"$exact_success_result"
+: >"$exact_failure_result"
+_ghqa_state_write_all "$exact_success_state" 0 1800000000 0 1800000000 0 1800000000
+_ghqa_state_write_all "$exact_failure_state" 0 1800000000 0 1800000000 0 1800000000
+exact_success_frame=$'frame\t1\t1\t200\tgraphql\t10\t4990\t1800000000\t25'
+exact_failure_frame=$'frame\t1\t1\t200\tgraphql\t12\t4988\t1800000000\t25'
+exact_success_rc=0
+exact_failure_rc=0
+set +e
+AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS=1 \
+	_ghqa_write_complete_frames "$exact_success_result" "$exact_success_state" graphql 1 0 \
+	"$exact_success_frame" -- gh api graphql
+exact_success_rc=$?
+AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS=1 \
+	_ghqa_write_complete_frames "$exact_failure_result" "$exact_failure_state" graphql 1 1 \
+	"$exact_failure_frame" -- gh api graphql
+exact_failure_rc=$?
+set -e
+assert_eq "exact successful frame writer returns zero" "0" "$exact_success_rc"
+assert_eq "exact failed-command frame writer returns zero" "0" "$exact_failure_rc"
+assert_eq "exact successful frame records inferred quota" "1" \
+	"$(awk -F '\t' 'NR == 1 { print $7 }' "$exact_success_result")"
+assert_eq "exact failed frame leaves inferred quota unknown" "x" \
+	"$(awk -F '\t' 'NR == 1 { print $7 }' "$exact_failure_result")"
 
 # --- Test 12: effective window comes from retained attempt timestamps -----
 gh_clear_log

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -34,6 +34,7 @@ unset AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE
 unset AIDEVOPS_EXTERNAL_GH_WRITE_ALLOWLIST
 unset AIDEVOPS_GH_QUOTA_COST
 unset AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS
+unset AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE
 unset GH_HOST
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
@@ -113,6 +114,10 @@ elif [[ -n "${STUB_GH_UNFRAMED_PRIVATE_STDERR:-}" ]]; then
 fi
 if [[ "${STUB_GH_EXIT_CODE:-0}" =~ ^[1-9][0-9]*$ ]]; then
 	exit "$STUB_GH_EXIT_CODE"
+fi
+if [[ "$1" == "api" && "$2" == "graphql" && -n "${STUB_GRAPHQL_RESPONSE_JSON:-}" ]]; then
+	printf '%s\n' "$STUB_GRAPHQL_RESPONSE_JSON"
+	exit 0
 fi
 if [[ "$1" == "api" && "$2" == "-i" && "$3" =~ ^/search/issues\? ]]; then
 	fixture='{"items":[{"number":22350,"state":"open","title":"Authored PR","html_url":"https://github.com/owner/repo/pull/22350","user":{"login":"managed"},"pull_request":{"merged_at":null}}]}'
@@ -1081,6 +1086,38 @@ if [[ "$(grep -c $'\tattempt\t' "$local_log" || true)" == "0" && ! -e "$local_st
 	_pass "known local-only gh commands avoid quota bootstrap and transport attempts"
 else
 	_fail "local-only exact-capture bypass" "log: $(cat "$local_log" 2>/dev/null || true)"
+fi
+
+# =============================================================================
+# Test 24: response-owned GraphQL cost is recorded after reading the response
+# =============================================================================
+echo ""
+echo "Test 24: response-metered GraphQL quota attribution"
+response_cost_log="$TMP/response-cost-graphql.log"
+response_cost_out="$TMP/response-cost-graphql.out"
+: >"$response_cost_log"
+STUB_GRAPHQL_RESPONSE_JSON='{"data":{"rateLimit":{"cost":2},"viewer":{"login":"fixture"}}}' \
+	AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$response_cost_log" "$SHIM_RUN" api graphql \
+	-f 'query={viewer{login} rateLimit{cost}}' >"$response_cost_out"
+if [[ "$(_read_attempt_quota "$response_cost_log")" == "2" \
+	&& "$(_read_last_attempt_field "$response_cost_log" 12)" == "1" \
+	&& "$(jq -r '.data.rateLimit.cost' "$response_cost_out")" == "2" ]]; then
+	_pass "GraphQL response-owned cost records the returned value on page one"
+else
+	_fail "response-metered GraphQL attribution" "log: $(cat "$response_cost_log" 2>/dev/null || true) output: $(cat "$response_cost_out" 2>/dev/null || true)"
+fi
+
+response_missing_log="$TMP/response-cost-missing.log"
+: >"$response_missing_log"
+STUB_GRAPHQL_RESPONSE_JSON='{"data":{"viewer":{"login":"fixture"}}}' \
+	AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$response_missing_log" "$SHIM_RUN" api graphql \
+	-f 'query={viewer{login}}' >/dev/null
+if [[ "$(_read_attempt_quota "$response_missing_log")" == "unknown" ]]; then
+	_pass "missing GraphQL response cost remains unknown"
+else
+	_fail "missing response-cost fail-closed behavior" "log: $(cat "$response_missing_log" 2>/dev/null || true)"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -249,6 +249,12 @@ _stub_gh_api() {
 		return $?
 	fi
 	if [[ "$subcommand" =~ ^/repos/.+/issues/[0-9]+$ ]]; then
+		if [[ -n "${STUB_ISSUE_VIEW_FIXTURE:-}" ]]; then
+			local jq_filter=""
+			jq_filter="$(_stub_jq_filter_arg 3 api "$@")"
+			_stub_print_fixture_with_jq "$STUB_ISSUE_VIEW_FIXTURE" "$jq_filter" -r
+			return $?
+		fi
 		printf '%s\n' "${STUB_CURRENT_LABELS:-bug}"
 		return 0
 	fi
@@ -843,6 +849,44 @@ else
 		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 
+# Locked is a direct REST issue field used by Pulse dispatch admission. Keep
+# the full state/label/assignee view on REST instead of falling back to GraphQL.
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=5000
+export AIDEVOPS_GH_REST_FIRST_READS=1
+export STUB_ISSUE_VIEW_FIXTURE='{"state":"open","locked":true,"labels":[{"name":"status:available"}],"assignees":[]}'
+
+issue_locked=$(gh_issue_view 4242 --repo "owner/repo" \
+	--json state,labels,assignees,locked --jq '.locked' 2>/dev/null || true)
+
+if [[ "$issue_locked" == "true" ]] &&
+	grep -qE '^api /repos/owner/repo/issues/4242' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^issue view 4242' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_view preserves locked admission state through REST"
+else
+	fail "gh_issue_view preserves locked admission state through REST" \
+		"locked=${issue_locked} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# Missing or malformed admission state must never be projected as unlocked.
+: >"$GH_CALLS"
+export STUB_ISSUE_VIEW_FIXTURE='{"state":"open","locked":null,"labels":[{"name":"status:available"}],"assignees":[]}'
+issue_locked=""
+issue_locked_rc=0
+issue_locked=$(gh_issue_view 4242 --repo "owner/repo" \
+	--json state,labels,assignees,locked --jq '.locked' 2>/dev/null) || issue_locked_rc=$?
+
+if [[ "$issue_locked_rc" -ne 0 && -z "$issue_locked" ]] &&
+	grep -qE '^api /repos/owner/repo/issues/4242' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^issue view 4242' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_view fails closed on malformed REST locked state"
+else
+	fail "gh_issue_view fails closed on malformed REST locked state" \
+		"rc=${issue_locked_rc} locked=${issue_locked} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_ISSUE_VIEW_FIXTURE AIDEVOPS_GH_REST_FIRST_READS
+
 # =============================================================================
 # Test 21: gh_issue_list keeps the primary path when GraphQL is healthy
 # =============================================================================
@@ -1170,6 +1214,26 @@ else
 		"output=${pr_view_merged} GH_CALLS=$(cat "$GH_CALLS")"
 fi
 unset STUB_PR_VIEW_FIXTURE
+
+# Exact REST-first reads can preserve the volatile mergeable enum from the
+# single-PR endpoint without spending GraphQL quota.
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_RATE_LIMIT_REMAINING=5000
+export AIDEVOPS_GH_REST_FIRST_READS=1
+export STUB_PR_VIEW_FIXTURE='{"number":123,"mergeable":false}'
+
+pr_view_mergeable=$(gh_pr_view 123 --repo "owner/repo" --json mergeable --jq '.mergeable' 2>/dev/null || true)
+
+if [[ "$pr_view_mergeable" == "CONFLICTING" ]] &&
+	grep -qE '^api /repos/owner/repo/pulls/123( |$)' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^pr view 123' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_view REST-first mode preserves exact mergeable state"
+else
+	fail "gh_pr_view REST-first mode preserves exact mergeable state" \
+		"output=${pr_view_mergeable} GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_PR_VIEW_FIXTURE AIDEVOPS_GH_REST_FIRST_READS
 
 # =============================================================================
 # Test 25b: REST PR view normalizes REST boolean mergeable to gh GraphQL enum
@@ -1572,7 +1636,7 @@ unset AIDEVOPS_GH_PR_VIEW_CACHE AIDEVOPS_GH_PR_VIEW_CACHE_DIR AIDEVOPS_GH_PR_VIE
 
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
-unsupported_pr_view_fields=(mergeable statusCheckRollup reviews latestReviews reviewThreads commits files reviewDecision autoMergeRequest mergeStateStatus)
+unsupported_pr_view_fields=(statusCheckRollup reviews latestReviews reviewThreads commits files reviewDecision autoMergeRequest mergeStateStatus)
 unsupported_preserve_ok=1
 for field in "${unsupported_pr_view_fields[@]}"; do
 	if _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json "$field"; then
@@ -1629,12 +1693,12 @@ else
 fi
 
 if _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json title &&
-	! _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json mergeable &&
+	_rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json mergeable &&
 	_rest_pr_view_can_emergency_fallback_args 123 --repo "owner/repo" --json mergeable &&
 	! _rest_pr_view_can_emergency_fallback_args 123 --repo "owner/repo" --json reviewDecision; then
-	pass "gh_pr_view validators distinguish stable, volatile, and GraphQL-only fields"
+	pass "gh_pr_view validators preserve exact REST and GraphQL-only fields"
 else
-	fail "gh_pr_view validators distinguish stable, volatile, and GraphQL-only fields" \
+	fail "gh_pr_view validators preserve exact REST and GraphQL-only fields" \
 		"unexpected proactive or emergency field classification"
 fi
 

--- a/.agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh
@@ -186,10 +186,11 @@ test_healthiest_candidate_beats_newer_unhealthy_pr() {
 
 test_health_score_handles_precomputed_legacy_mergeable_values() {
 	reset_case
-	local lowercase_score="" true_score="" false_score=""
+	local lowercase_score="" true_score="" false_score="" observed_approval_score=""
 	lowercase_score=$(_pmp_pr_consolidation_health_score "owner/repo" '{}' "501" "mergeable" "NONE" "false") || lowercase_score="0"
 	true_score=$(_pmp_pr_consolidation_health_score "owner/repo" '{}' "502" "true" "NONE" "false") || true_score="0"
 	false_score=$(_pmp_pr_consolidation_health_score "owner/repo" '{}' "503" "false" "NONE" "false") || false_score="0"
+	observed_approval_score=$(_pmp_pr_consolidation_health_score "owner/repo" '{}' "504" "MERGEABLE" "OBSERVED_APPROVED" "false") || observed_approval_score="0"
 	if [[ "$lowercase_score" -eq 250 ]]; then
 		pass "lowercase mergeable keeps healthy score"
 	else
@@ -204,6 +205,12 @@ test_health_score_handles_precomputed_legacy_mergeable_values() {
 		pass "boolean-string conflicting value does not get mergeable score"
 	else
 		fail "boolean-string conflicting value does not get mergeable score" "Expected 50, got ${false_score}"
+	fi
+	if [[ "$observed_approval_score" -eq 250 ]]; then
+		pass "observed REST approval does not receive policy-approval score"
+	else
+		fail "observed REST approval does not receive policy-approval score" \
+			"Expected 250, got ${observed_approval_score}"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -24,6 +24,12 @@
 #             → update-branch succeeds and caller defers to the next cycle
 #   Case (G): no autoMergeRequest + MERGEABLE + BEHIND + green required checks
 #             → update-branch succeeds and caller defers to the next cycle
+#   Case (H): stale autoMergeRequest + green required checks
+#             → disables stale auto-merge and falls through
+#   Case (I): REST auto_merge omits enabled_at
+#             → unavailable exact fallback keeps wedge age unknown and defers
+#   Case (J): REST auto_merge omits enabled_at, exact GraphQL fallback has it
+#             → stale wedge recovery remains available
 #
 # Also verifies the caller contract: native auto-merge defer returns 4 from
 # _process_single_ready_pr and _merge_ready_prs_for_repo does not count that as
@@ -40,6 +46,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
+REST_STATE_SCRIPT="${SCRIPT_DIR}/../pulse-merge-rest-state.sh"
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
 
 readonly TEST_RED='\033[0;31m'
@@ -50,6 +57,15 @@ TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
 GH_LOG=""
+
+initialize_native_auto_fixtures() {
+	printf '{"auto_merge":null,"mergeable_state":"blocked","mergeable":true,"head":{"sha":"default-head-sha"}}' \
+		>"${TEST_ROOT}/auto_merge_request.txt"
+	printf 'true' >"${TEST_ROOT}/allow_auto_merge.txt"
+	printf '1' >"${TEST_ROOT}/pending_count.txt"
+	printf '[]' >"${TEST_ROOT}/reviews.json"
+	return 0
+}
 
 print_result() {
 	local test_name="$1"
@@ -78,15 +94,8 @@ setup_test_env() {
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
 
-	# Default fixtures. Overridden per-test before invocation.
-	#  * pr_state:           autoMergeRequest=null (auto-merge NOT set);
-	#                        full state JSON since t3192 added stuck check
-	#  * allow_auto_merge:   true  (repo allows it)
-	#  * pending_count:      1     (one required check pending)
-	printf '{"autoMergeRequest":null,"mergeStateStatus":"BLOCKED","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
-		>"${TEST_ROOT}/auto_merge_request.txt"
-	printf 'true' >"${TEST_ROOT}/allow_auto_merge.txt"
-	printf '1' >"${TEST_ROOT}/pending_count.txt"
+	# Default fixtures are overridden per test before invocation.
+	initialize_native_auto_fixtures
 
 	# Cache dir is keyed on PID — wipe between tests so allow_auto_merge
 	# fixture changes are honoured (otherwise Case D inherits Case A).
@@ -97,11 +106,36 @@ setup_test_env() {
 #!/usr/bin/env bash
 printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
 
-# `gh pr view <N> --repo <slug> --json autoMergeRequest --jq ...`
-if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"autoMergeRequest"* ]]; then
-	cat "${TEST_ROOT}/auto_merge_request.txt"
+# Exact single-PR REST merge-state projection.
+if [[ "$1" == "api" && "$2" == repos/*/pulls/*/reviews\?* ]]; then
+	cat "${TEST_ROOT}/reviews.json"
 	echo
 	exit 0
+fi
+if [[ "$1" == "api" && "$2" == repos/*/pulls/* && "$2" != */update-branch ]]; then
+	filter=""
+	while [[ $# -gt 0 ]]; do
+		if [[ "$1" == "--jq" && $# -ge 2 ]]; then
+			filter="$2"
+			break
+		fi
+		shift
+	done
+	if [[ -n "$filter" ]]; then
+		jq -c "$filter" "${TEST_ROOT}/auto_merge_request.txt"
+	else
+		cat "${TEST_ROOT}/auto_merge_request.txt"
+		echo
+	fi
+	exit 0
+fi
+
+# Fixed-cost GraphQL fallback for REST's missing auto_merge.enabled_at field.
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+	[[ -f "${TEST_ROOT}/graphql_auto_merge_response.txt" ]] || exit 1
+	cat "${TEST_ROOT}/graphql_auto_merge_response.txt"
+	echo
+	exit "${GRAPHQL_AUTO_EXIT:-0}"
 fi
 
 # `gh api repos/<slug> --jq '.allow_auto_merge // false'`
@@ -134,8 +168,8 @@ if [[ "$1" == "pr" && "$2" == "ready" && "$*" == *"--undo"* ]]; then
 	exit 0
 fi
 
-# `gh pr update-branch <N> --repo <slug>`
-if [[ "$1" == "pr" && "$2" == "update-branch" ]]; then
+# REST update-a-pull-request-branch endpoint.
+if [[ "$1" == "api" && "$2" == "--method" && "$3" == "PUT" && "$4" == repos/*/pulls/*/update-branch ]]; then
 	exit 0
 fi
 
@@ -149,6 +183,7 @@ GHEOF
 teardown_test_env() {
 	# Wipe cache dir for next test.
 	rm -rf "${TMPDIR:-/tmp}/aidevops-pulse-allow-auto-merge-$$" 2>/dev/null || true
+	unset GRAPHQL_AUTO_EXIT
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
 	fi
@@ -159,15 +194,15 @@ teardown_test_env() {
 # into the test shell. _set_native_auto_merge_or_skip calls
 # _auto_merge_stuck_seconds (t3192), so we extract that too.
 define_helpers_under_test() {
-	local src_stuck src_repo_allow src_extract_state src_existing_green_behind src_green_behind src_stop_external src_set_native
+	local src_stuck src_repo_allow src_existing_green_behind src_green_behind
+	local src_stop_external src_enable_native src_handle_existing src_set_native
+	# shellcheck source=/dev/null
+	source "$REST_STATE_SCRIPT"
 	src_stuck=$(awk '
 		/^_auto_merge_stuck_seconds\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	src_repo_allow=$(awk '
 		/^_repo_allows_auto_merge\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
-	' "$PROCESS_SCRIPT")
-	src_extract_state=$(awk '
-		/^_pmp_extract_update_branch_state\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	src_existing_green_behind=$(awk '
 		/^_attempt_existing_auto_merge_behind_update_branch\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
@@ -181,7 +216,18 @@ define_helpers_under_test() {
 	src_stop_external=$(awk '
 		/^_stop_external_native_auto_merge\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
-	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_extract_state" || -z "$src_existing_green_behind" || -z "$src_green_behind" || -z "$src_stop_external" || -z "$src_set_native" ]]; then
+	src_enable_native=$(awk '
+		/^_enable_native_auto_merge_for_head\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$PROCESS_SCRIPT")
+	src_handle_existing=$(awk '
+		/^_handle_existing_native_auto_merge\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+	' "$PROCESS_SCRIPT")
+	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_existing_green_behind" \
+		|| -z "$src_green_behind" || -z "$src_stop_external" || -z "$src_enable_native" \
+		|| -z "$src_handle_existing" || -z "$src_set_native" ]] \
+		|| ! declare -F _pmp_extract_update_branch_state >/dev/null 2>&1 \
+		|| ! declare -F _pmp_rest_pr_merge_state >/dev/null 2>&1 \
+		|| ! declare -F _pmp_update_branch_rest >/dev/null 2>&1; then
 		printf 'ERROR: could not extract helpers from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
@@ -189,20 +235,17 @@ define_helpers_under_test() {
 	eval "$src_stuck"
 	# shellcheck disable=SC1090
 	eval "$src_repo_allow"
-	# shellcheck disable=SC1090
-	eval "$src_extract_state"
-	# shellcheck disable=SC1090
 	eval "$src_existing_green_behind"
 	# shellcheck disable=SC1090
 	eval "$src_green_behind"
 	# shellcheck disable=SC1090
 	eval "$src_stop_external"
 	# shellcheck disable=SC1090
+	eval "$src_enable_native"
+	# shellcheck disable=SC1090
+	eval "$src_handle_existing"
+	# shellcheck disable=SC1090
 	eval "$src_set_native"
-	gh_pr_view() {
-		gh pr view "$@"
-		return $?
-	}
 	_pmp_normalize_mergeable_state_into() {
 		local __target_var="$1"
 		local __value="$2"
@@ -256,7 +299,7 @@ test_case_a_pending_ci_sets_auto_merge() {
 	# pending_count=1.
 
 	local result=0
-	_set_native_auto_merge_or_skip "100" "owner/repo" || result=$?
+	_set_native_auto_merge_or_skip "100" "owner/repo" "0" "NONE" "case-a-head-sha" || result=$?
 
 	if [[ "$result" -ne 0 ]]; then
 		print_result "Case (A): CI pending + repo allows → returns 0" 1 \
@@ -264,7 +307,7 @@ test_case_a_pending_ci_sets_auto_merge() {
 		teardown_test_env
 		return 0
 	fi
-	if ! grep -qE 'gh pr merge 100 --repo owner/repo --auto --squash' "$GH_LOG"; then
+	if ! grep -qE 'gh pr merge 100 --repo owner/repo --auto --squash --match-head-commit case-a-head-sha$' "$GH_LOG"; then
 		print_result "Case (A): CI pending + repo allows → invokes gh pr merge --auto" 1 \
 			"gh log: $(cat "$GH_LOG")"
 		teardown_test_env
@@ -277,6 +320,24 @@ test_case_a_pending_ci_sets_auto_merge() {
 		return 0
 	fi
 	print_result "Case (A): CI pending + repo allows → returns 0 + invokes --auto" 0
+	teardown_test_env
+	return 0
+}
+
+test_case_a_missing_head_does_not_set_auto_merge() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	local result=0
+	_set_native_auto_merge_or_skip "101" "owner/repo" "0" "NONE" || result=$?
+	if [[ "$result" -eq 1 ]] \
+		&& ! grep -qE 'gh pr merge 101 .*--auto' "$GH_LOG" \
+		&& grep -qF 'gated head SHA is unavailable' "$LOGFILE"; then
+		print_result "Case (A2): missing gated head never enables native auto-merge" 0
+	else
+		print_result "Case (A2): missing gated head never enables native auto-merge" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG"); pulse log: $(cat "$LOGFILE")"
+	fi
 	teardown_test_env
 	return 0
 }
@@ -325,11 +386,11 @@ test_case_c_already_set_no_op() {
 	# and we fall through to the t3070 "auto_merge already set" path.
 	local enabled_at_now
 	enabled_at_now=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo '2026-04-30T16:00:00Z')
-	printf '{"autoMergeRequest":{"enabledAt":"%s"},"mergeStateStatus":"BLOCKED","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+	printf '{"auto_merge":{"enabled_at":"%s"},"mergeable_state":"blocked","mergeable":true,"head":{"sha":"case-c-head"}}' \
 		"$enabled_at_now" >"${TEST_ROOT}/auto_merge_request.txt"
 
 	local result=0
-	_set_native_auto_merge_or_skip "300" "owner/repo" || result=$?
+	_set_native_auto_merge_or_skip "300" "owner/repo" "0" "NONE" "case-c-head" || result=$?
 
 	if [[ "$result" -ne 0 ]]; then
 		print_result "Case (C): auto_merge already set → returns 0 (no-op)" 1 \
@@ -350,6 +411,28 @@ test_case_c_already_set_no_op() {
 		return 0
 	fi
 	print_result "Case (C): auto_merge already set → returns 0 (deferred to GitHub)" 0
+	teardown_test_env
+	return 0
+}
+
+test_case_c2_existing_auto_head_mismatch_is_disarmed() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	local enabled_at_now
+	enabled_at_now=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo '2026-04-30T16:00:00Z')
+	printf '{"auto_merge":{"enabled_at":"%s"},"mergeable_state":"blocked","mergeable":true,"head":{"sha":"new-live-head"}}' \
+		"$enabled_at_now" >"${TEST_ROOT}/auto_merge_request.txt"
+
+	local result=0
+	_set_native_auto_merge_or_skip "301" "owner/repo" "0" "NONE" "previous-gated-head" || result=$?
+	if [[ "$result" -eq 2 ]] \
+		&& grep -qE 'gh pr merge 301 --repo owner/repo --disable-auto' "$GH_LOG" \
+		&& grep -qF 'existing native auto-merge head no longer matches the gated head' "$LOGFILE"; then
+		print_result "Case (C2): existing auto-merge is disarmed after a head race" 0
+	else
+		print_result "Case (C2): existing auto-merge is disarmed after a head race" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG"); pulse log: $(cat "$LOGFILE")"
+	fi
 	teardown_test_env
 	return 0
 }
@@ -394,13 +477,13 @@ test_case_e_stale_pending_defers() {
 	old_enabled_at=$(date -u -v-30M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
 		|| date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
 		|| echo '2026-04-30T16:00:00Z')
-	printf '{"autoMergeRequest":{"enabledAt":"%s"},"mergeStateStatus":"BLOCKED","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+	printf '{"auto_merge":{"enabled_at":"%s"},"mergeable_state":"blocked","mergeable":true,"head":{"sha":"case-e-head"}}' \
 		"$old_enabled_at" >"${TEST_ROOT}/auto_merge_request.txt"
 	printf '1' >"${TEST_ROOT}/pending_count.txt"
 	export AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS=60
 
 	local result=0
-	_set_native_auto_merge_or_skip "500" "owner/repo" || result=$?
+	_set_native_auto_merge_or_skip "500" "owner/repo" "0" "NONE" "case-e-head" || result=$?
 	unset AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS
 
 	if [[ "$result" -ne 0 ]]; then
@@ -437,13 +520,13 @@ test_case_h_stuck_green_disables_auto_before_fallthrough() {
 	old_enabled_at=$(date -u -v-30M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
 		|| date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
 		|| echo '2026-04-30T16:00:00Z')
-	printf '{"autoMergeRequest":{"enabledAt":"%s"},"mergeStateStatus":"BLOCKED","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+	printf '{"auto_merge":{"enabled_at":"%s"},"mergeable_state":"blocked","mergeable":true,"head":{"sha":"case-h-head"}}' \
 		"$old_enabled_at" >"${TEST_ROOT}/auto_merge_request.txt"
 	printf '0' >"${TEST_ROOT}/pending_count.txt"
 	export AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS=60
 
 	local result=0
-	_set_native_auto_merge_or_skip "800" "owner/repo" || result=$?
+	_set_native_auto_merge_or_skip "800" "owner/repo" "0" "NONE" "case-h-head" || result=$?
 	unset AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS
 
 	if [[ "$result" -ne 1 ]]; then
@@ -469,6 +552,90 @@ test_case_h_stuck_green_disables_auto_before_fallthrough() {
 	return 0
 }
 
+test_case_h2_stale_disarm_failure_applies_hold() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	local old_enabled_at
+	old_enabled_at=$(date -u -v-30M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+		|| date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+		|| echo '2026-04-30T16:00:00Z')
+	printf '{"auto_merge":{"enabled_at":"%s"},"mergeable_state":"blocked","mergeable":true,"head":{"sha":"case-h2-head"}}' \
+		"$old_enabled_at" >"${TEST_ROOT}/auto_merge_request.txt"
+	printf '0' >"${TEST_ROOT}/pending_count.txt"
+	export AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS=60 FAIL_DISABLE_AUTO=1
+
+	local result=0
+	_set_native_auto_merge_or_skip "801" "owner/repo" "0" "NONE" "case-h2-head" || result=$?
+	unset AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS FAIL_DISABLE_AUTO
+	if [[ "$result" -eq 2 ]] \
+		&& grep -qE 'gh pr merge 801 --repo owner/repo --disable-auto' "$GH_LOG" \
+		&& grep -qE 'gh pr ready 801 --repo owner/repo --undo' "$GH_LOG"; then
+		print_result "Case (H2): stale-auto disable failure applies a draft hold" 0
+	else
+		print_result "Case (H2): stale-auto disable failure applies a draft hold" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG"); pulse log: $(cat "$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (I): REST auto_merge without enabled_at keeps wedge recovery fail-closed
+# =============================================================================
+test_case_i_missing_enabled_at_defers() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '%s' '{"auto_merge":{"enabled_by":{"login":"maintainer"}},"mergeable_state":"blocked","mergeable":true,"head":{"sha":"case-i-head"}}' \
+		>"${TEST_ROOT}/auto_merge_request.txt"
+	printf '0' >"${TEST_ROOT}/pending_count.txt"
+
+	local result=0
+	_set_native_auto_merge_or_skip "850" "owner/repo" "0" "NONE" "case-i-head" || result=$?
+
+	if [[ "$result" -eq 0 ]] \
+		&& grep -qE 'gh api repos/owner/repo/pulls/850 --jq' "$GH_LOG" \
+		&& ! grep -qE 'gh pr view|gh pr merge 850 .*--disable-auto' "$GH_LOG" \
+		&& grep -qE 'auto_merge already set.*t3070' "$LOGFILE"; then
+		print_result "Case (I): missing REST enabled_at keeps wedge recovery fail-closed" 0
+	else
+		print_result "Case (I): missing REST enabled_at keeps wedge recovery fail-closed" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG"); pulse log: $(cat "$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (J): exact GraphQL enabledAt fallback preserves stale-wedge recovery
+# =============================================================================
+test_case_j_graphql_enabled_at_restores_wedge_recovery() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '%s' '{"auto_merge":{"enabled_by":{"login":"maintainer"}},"mergeable_state":"blocked","mergeable":true,"head":{"sha":"case-j-head"}}' \
+		>"${TEST_ROOT}/auto_merge_request.txt"
+	printf '%s' '{"data":{"repository":{"pullRequest":{"autoMergeRequest":{"enabledAt":"2026-06-15T14:00:00Z"}}},"rateLimit":{"cost":1}}}' \
+		>"${TEST_ROOT}/graphql_auto_merge_response.txt"
+	printf '0' >"${TEST_ROOT}/pending_count.txt"
+
+	local result=0
+	_set_native_auto_merge_or_skip "851" "owner/repo" "0" "NONE" "case-j-head" || result=$?
+
+	if [[ "$result" -eq 1 ]] \
+		&& grep -qE '^gh api graphql ' "$GH_LOG" \
+		&& grep -qF 'rateLimit { cost }' "$GH_LOG" \
+		&& grep -qE 'gh pr merge 851 --repo owner/repo --disable-auto' "$GH_LOG" \
+		&& grep -qE 'disabled stale native auto-merge.*GH#26897' "$LOGFILE"; then
+		print_result "Case (J): exact enabledAt fallback restores stale-wedge recovery" 0
+	else
+		print_result "Case (J): exact enabledAt fallback restores stale-wedge recovery" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG"); pulse log: $(cat "$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
 # =============================================================================
 # Case (F): existing auto-merge is green but behind → update branch and defer
 # =============================================================================
@@ -476,7 +643,7 @@ test_case_f_green_behind_updates_branch() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
 
-	printf '{"autoMergeRequest":{"enabledAt":"2026-06-15T14:00:00Z"},"mergeStateStatus":"BEHIND","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+	printf '{"auto_merge":{"enabled_at":"2026-06-15T14:00:00Z"},"mergeable_state":"behind","mergeable":true,"head":{"sha":"case-f-head-sha"}}' \
 		>"${TEST_ROOT}/auto_merge_request.txt"
 	printf '0' >"${TEST_ROOT}/pending_count.txt"
 
@@ -489,7 +656,7 @@ test_case_f_green_behind_updates_branch() {
 		teardown_test_env
 		return 0
 	fi
-	if ! grep -qE 'gh pr update-branch 600 --repo owner/repo' "$GH_LOG"; then
+	if ! grep -qE 'gh api --method PUT repos/owner/repo/pulls/600/update-branch -f expected_head_sha=case-f-head-sha' "$GH_LOG"; then
 		print_result "Case (F): green BEHIND auto_merge → invokes update-branch" 1 \
 			"gh log: $(cat "$GH_LOG")"
 		teardown_test_env
@@ -513,7 +680,7 @@ test_case_g_green_behind_without_auto_merge_updates_branch() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
 
-	printf '{"autoMergeRequest":null,"mergeStateStatus":"BEHIND","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+	printf '{"auto_merge":null,"mergeable_state":"behind","mergeable":true,"head":{"sha":"case-g-head-sha"}}' \
 		>"${TEST_ROOT}/auto_merge_request.txt"
 	printf '0' >"${TEST_ROOT}/pending_count.txt"
 
@@ -526,7 +693,7 @@ test_case_g_green_behind_without_auto_merge_updates_branch() {
 		teardown_test_env
 		return 0
 	fi
-	if ! grep -qE 'gh pr update-branch 700 --repo owner/repo' "$GH_LOG"; then
+	if ! grep -qE 'gh api --method PUT repos/owner/repo/pulls/700/update-branch -f expected_head_sha=case-g-head-sha' "$GH_LOG"; then
 		print_result "Case (G): green BEHIND without auto_merge → invokes update-branch" 1 \
 			"gh log: $(cat "$GH_LOG")"
 		teardown_test_env
@@ -546,7 +713,7 @@ test_case_g_green_behind_without_auto_merge_updates_branch() {
 test_native_auto_defer_not_counted_as_completed_merge() {
 	local process_src merge_src
 	process_src=$(awk '
-		/^_merge_ready_prs_for_repo\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
+		/^_pmp_record_processed_pr_result\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
 	' "$PROCESS_SCRIPT")
 	merge_src=$(awk '
 		/^_process_single_ready_pr\(\)[[:space:]]*\{[[:space:]]*$/, /^\}[[:space:]]*$/ { print }
@@ -564,9 +731,9 @@ test_native_auto_defer_not_counted_as_completed_merge() {
 		return 0
 	fi
 
-	if [[ "$process_src" != *'4) ;;'* ]]; then
+	if [[ "$process_src" != *'4) outcome="deferred" ;;'* ]]; then
 		print_result "Native auto defer is not counted as completed merge" 1 \
-			"Expected _merge_ready_prs_for_repo to handle rc=4 without merged++"
+			"Expected _pmp_record_processed_pr_result to record rc=4 as deferred without merged++"
 		return 0
 	fi
 
@@ -593,7 +760,7 @@ test_external_pending_ci_never_sets_deferred_auto_merge() {
 test_external_existing_auto_merge_is_disabled() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
-	printf '%s' '{"autoMergeRequest":{"enabledAt":"2026-07-14T12:00:00Z"},"mergeStateStatus":"BLOCKED","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+	printf '%s' '{"auto_merge":{"enabled_at":"2026-07-14T12:00:00Z"},"mergeable_state":"blocked","mergeable":true}' \
 		>"${TEST_ROOT}/auto_merge_request.txt"
 
 	local result=0
@@ -611,7 +778,7 @@ test_external_existing_auto_merge_is_disabled() {
 test_external_auto_merge_disable_failure_applies_draft_hold() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
-	printf '%s' '{"autoMergeRequest":{"enabledAt":"2026-07-14T12:00:00Z"},"mergeStateStatus":"BLOCKED","mergeable":"MERGEABLE","reviewDecision":"APPROVED"}' \
+	printf '%s' '{"auto_merge":{"enabled_at":"2026-07-14T12:00:00Z"},"mergeable_state":"blocked","mergeable":true}' \
 		>"${TEST_ROOT}/auto_merge_request.txt"
 	export FAIL_DISABLE_AUTO=1
 	local result=0
@@ -629,11 +796,16 @@ test_external_auto_merge_disable_failure_applies_draft_hold() {
 
 main() {
 	test_case_a_pending_ci_sets_auto_merge
+	test_case_a_missing_head_does_not_set_auto_merge
 	test_case_b_ci_green_falls_through
 	test_case_c_already_set_no_op
+	test_case_c2_existing_auto_head_mismatch_is_disarmed
 	test_case_d_repo_disallows_falls_through
 	test_case_e_stale_pending_defers
 	test_case_h_stuck_green_disables_auto_before_fallthrough
+	test_case_h2_stale_disarm_failure_applies_hold
+	test_case_i_missing_enabled_at_defers
+	test_case_j_graphql_enabled_at_restores_wedge_recovery
 	test_case_f_green_behind_updates_branch
 	test_case_g_green_behind_without_auto_merge_updates_branch
 	test_native_auto_defer_not_counted_as_completed_merge

--- a/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh
@@ -51,10 +51,10 @@ set +o pipefail 2>/dev/null || true
 REFRESHED_REVIEW_DECISION="CHANGES_REQUESTED"
 REFRESH_SHOULD_FAIL=0
 : >"${TEST_TMPDIR}/review-refresh.log"
-gh_pr_view() {
-	local pr_number="$1" repo_flag="$2" repo_slug="$3"
-	[[ -n "$pr_number$repo_flag$repo_slug" ]]
-	printf '%s|%s|%s\n' "$pr_number" "$repo_flag" "$repo_slug" >>"${TEST_TMPDIR}/review-refresh.log"
+_pmp_rest_review_decision_from_reviews() {
+	local pr_number="$1" repo_slug="$2"
+	[[ -n "$pr_number$repo_slug" ]]
+	printf '%s|%s\n' "$pr_number" "$repo_slug" >>"${TEST_TMPDIR}/review-refresh.log"
 	[[ "$REFRESH_SHOULD_FAIL" -eq 0 ]] || return 1
 	printf '%s\n' "$REFRESHED_REVIEW_DECISION"
 	return 0

--- a/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
@@ -69,16 +69,21 @@ test_ready_pr_fields_include_process_metadata() {
 	fields="$(_pulse_merge_ready_pr_json_fields)"
 
 	local required missing=""
-	for required in number state mergeable reviewDecision author title isDraft labels updatedAt headRefOid headRefName baseRefName createdAt; do
+	for required in number state author title isDraft labels updatedAt headRefOid headRefName baseRefName createdAt; do
 		if [[ ",${fields}," != *",${required},"* ]]; then
 			missing="${missing:+${missing},}${required}"
 		fi
 	done
 	if [[ -n "$missing" ]]; then
-		print_result "ready PR fields include process metadata" 1 "missing=${missing}; fields=${fields}"
+		print_result "ready PR REST fields include process metadata" 1 "missing=${missing}; fields=${fields}"
 		return 0
 	fi
-	print_result "ready PR fields include process metadata" 0
+	if [[ ",${fields}," == *",mergeable,"* || ",${fields}," == *",reviewDecision,"* || ",${fields}," == *",statusCheckRollup,"* ]]; then
+		print_result "ready PR REST fields exclude enriched GraphQL metadata" 1 "fields=${fields}"
+		return 0
+	fi
+	print_result "ready PR REST fields include process metadata" 0
+	print_result "ready PR REST fields exclude enriched GraphQL metadata" 0
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -83,13 +83,15 @@ _ci_check_url_has_infra_failure_log() {
 
 stub_review_threads() {
 	if [[ "$SNAPSHOT_MODE" == "review_threads_paginated" ]]; then
-		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"}}]}}]}}}}}'
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"}}]}}]}}},"rateLimit":{"cost":1}}}'
 	elif [[ "$SNAPSHOT_MODE" == "unresolved" ]]; then
-		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"}}]}}]}}}}}'
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"}}]}}]}}},"rateLimit":{"cost":1}}}'
 	elif [[ "$SNAPSHOT_MODE" == human_* ]]; then
-		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"human-reviewer"}}]}}]}}}}}'
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"human-reviewer"}}]}}]}}},"rateLimit":{"cost":1}}}'
+	elif [[ "$SNAPSHOT_MODE" == "review_threads_cost_changed" ]]; then
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[]}}},"rateLimit":{"cost":2}}}'
 	else
-		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}'
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[]}}},"rateLimit":{"cost":1}}}'
 	fi
 	return 0
 }
@@ -411,6 +413,8 @@ assert_review_and_head_snapshot_cases() {
 	assert_gate_blocker "unresolved late inline finding blocks merge" unresolved 1 "$PMRC_BLOCKER_REVIEW_BOT_THREADS"
 	assert_gate_blocker "paginated review-thread snapshot fails closed without actionable remediation" \
 		review_threads_paginated 1 "$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+	assert_gate_logged "review-thread quota-cost contract drift" \
+		review_threads_cost_changed "GraphQL cost contract changed"
 	assert_human_review_thread_rules
 	assert_gate "late review activity invalidates stale gate success" stale_gate 1
 	set_live_evidence PASS sha-reviewed trusted true 2026-01-01T00:00:50Z

--- a/.agents/scripts/tests/test-pulse-merge-rest-readiness.sh
+++ b/.agents/scripts/tests/test-pulse-merge-rest-readiness.sh
@@ -6,9 +6,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 MERGE_PROCESS="${SCRIPT_DIR}/../pulse-merge-process.sh"
+REST_STATE_MODULE="${SCRIPT_DIR}/../pulse-merge-rest-state.sh"
+
+# shellcheck source=/dev/null
+source "$REST_STATE_MODULE"
 
 TESTS_RUN=0
 TESTS_FAILED=0
+MERGEABLE_CALLS=""
 
 print_result() {
 	local name="$1"
@@ -44,6 +49,19 @@ gh_pr_check_status_rest_batch() {
 	return 0
 }
 
+gh_pr_view() {
+	local pr_number="$1"
+	shift
+	[[ -n "$MERGEABLE_CALLS" ]] || return 1
+	printf '%s\n' "$pr_number" >>"$MERGEABLE_CALLS"
+	case "$pr_number" in
+	1) printf 'MERGEABLE\n' ;;
+	2) printf 'CONFLICTING\n' ;;
+	*) printf 'UNKNOWN\n' ;;
+	esac
+	return 0
+}
+
 assert_rollup() {
 	local name="$1"
 	local number="$2"
@@ -58,8 +76,17 @@ assert_rollup() {
 
 main() {
 	define_functions_under_test || { printf 'failed to load function\n' >&2; return 1; }
-	local prs output
+	local prs output mergeability_output actual
+	MERGEABLE_CALLS=$(mktemp)
+	trap 'rm -f "$MERGEABLE_CALLS"' EXIT
 	prs='[{"number":1,"headRefOid":"a"},{"number":2,"headRefOid":"b"},{"number":3,"headRefOid":"c"},{"number":4,"headRefOid":"d"}]'
+	mergeability_output=$(_pmp_enrich_prs_with_mergeability "owner/repo" "$prs")
+	actual=$(printf '%s' "$mergeability_output" | jq -r '[.[].mergeable] | join(",")') || actual=""
+	if [[ "$actual" == "MERGEABLE,CONFLICTING,UNKNOWN,UNKNOWN" && "$(wc -l <"$MERGEABLE_CALLS" | tr -d ' ')" == "4" ]]; then
+		print_result "REST mergeability enriches every unknown list item" 0
+	else
+		print_result "REST mergeability enriches every unknown list item" 1 "states=${actual} calls=$(wc -l <"$MERGEABLE_CALLS" | tr -d ' ')"
+	fi
 	output=$(_pmp_enrich_prs_with_rest_check_status "owner/repo" "$prs")
 	assert_rollup "green REST check maps to success rollup" 1 "SUCCESS" "$output"
 	assert_rollup "failing REST check maps to failure rollup" 2 "FAILURE" "$output"

--- a/.agents/scripts/tests/test-pulse-merge-rest-review-decision.sh
+++ b/.agents/scripts/tests/test-pulse-merge-rest-review-decision.sh
@@ -66,25 +66,40 @@ gh_pr_view() {
 write_gh_mock() {
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
-if [[ "${1:-} ${2:-}" == "api --paginate" && "${3:-}" == "repos/owner/repo/pulls/123/reviews" ]]; then
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/pulls/123/reviews?per_page=100&page=1" ]]; then
 	cat <<'JSON'
 [
-  {"user":{"login":"reviewer"},"state":"CHANGES_REQUESTED","submitted_at":"2026-07-01T10:00:00Z"},
-  {"user":{"login":"reviewer"},"state":"COMMENTED","submitted_at":"2026-07-01T11:00:00Z"},
-  {"user":{"login":"other"},"state":"APPROVED","submitted_at":"2026-07-01T12:00:00Z"}
+  {"id":1,"user":{"login":"reviewer"},"state":"CHANGES_REQUESTED","submitted_at":"2026-07-01T10:00:00Z"},
+  {"id":2,"user":{"login":"reviewer"},"state":"COMMENTED","submitted_at":"2026-07-01T11:00:00Z"},
+  {"id":3,"user":{"login":"other"},"state":"APPROVED","submitted_at":"2026-07-01T12:00:00Z"}
 ]
 JSON
 	exit 0
 fi
 
-if [[ "${1:-} ${2:-}" == "api --paginate" && "${3:-}" == "repos/owner/repo/pulls/124/reviews" ]]; then
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/pulls/124/reviews?per_page=100&page=1" ]]; then
 	cat <<'JSON'
 [
-  {"user":{"login":"reviewer"},"state":"CHANGES_REQUESTED","submitted_at":"2026-07-01T10:00:00Z"},
-  {"user":{"login":"reviewer"},"state":"DISMISSED","submitted_at":"2026-07-01T11:00:00Z"},
-  {"user":{"login":"other"},"state":"COMMENTED","submitted_at":"2026-07-01T12:00:00Z"}
+  {"id":4,"user":{"login":"reviewer"},"state":"CHANGES_REQUESTED","submitted_at":"2026-07-01T10:00:00Z"},
+  {"id":5,"user":{"login":"reviewer"},"state":"DISMISSED","submitted_at":"2026-07-01T11:00:00Z"},
+  {"id":6,"user":{"login":"other"},"state":"COMMENTED","submitted_at":"2026-07-01T12:00:00Z"}
 ]
 JSON
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/pulls/126/reviews?per_page=100&page=1" ]]; then
+	jq -nc '[range(0; 100) | {id: ., user: {login: ("commenter-" + (. | tostring))}, state: "COMMENTED", submitted_at: "2026-07-01T10:00:00Z"}]'
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/pulls/126/reviews?per_page=100&page=2" ]]; then
+	printf '%s\n' '[{"id":101,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-07-01T12:00:00Z"}]'
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/pulls/127/reviews?per_page=100&page=1" ]]; then
+	printf '%s\n' '[{"id":201,"user":{"login":"approver"},"state":"APPROVED","submitted_at":"2026-07-01T12:00:00Z"},{"id":202,"user":null,"state":"CHANGES_REQUESTED","submitted_at":"2026-07-01T13:00:00Z"}]'
 	exit 0
 fi
 
@@ -118,10 +133,10 @@ assert_review_decision() {
 test_review_fetch_uses_bounded_read() {
 	: >"$TIMEOUT_LOG"
 	assert_review_decision "REST fallback still derives active review state" "123" "CHANGES_REQUESTED"
-	if grep -Fqx 'read gh api --paginate repos/owner/repo/pulls/123/reviews' "$TIMEOUT_LOG"; then
-		print_result "REST fallback wraps paginated reviews in a bounded read" 0
+	if grep -Fqx 'read gh api repos/owner/repo/pulls/123/reviews?per_page=100&page=1' "$TIMEOUT_LOG"; then
+		print_result "REST review fetch uses an explicit bounded page" 0
 	else
-		print_result "REST fallback wraps paginated reviews in a bounded read" 1 \
+		print_result "REST review fetch uses an explicit bounded page" 1 \
 			"timeout calls=$(tr '\n' ';' <"$TIMEOUT_LOG")"
 	fi
 	return 0
@@ -134,10 +149,51 @@ test_timeout_failure_preserves_unknown_decision() {
 	_pmp_refresh_unknown_review_decision_into decision "125" "owner/repo" "UNKNOWN"
 	unset TEST_TIMEOUT_FAIL
 	if [[ "$decision" == "UNKNOWN" ]] &&
-		grep -Fqx 'read gh api --paginate repos/owner/repo/pulls/125/reviews' "$TIMEOUT_LOG"; then
+		grep -Fqx 'read gh api repos/owner/repo/pulls/125/reviews?per_page=100&page=1' "$TIMEOUT_LOG"; then
 		print_result "timed-out REST review fetch returns UNKNOWN without blocking" 0
 	else
 		print_result "timed-out REST review fetch returns UNKNOWN without blocking" 1 \
+			"decision=${decision}, timeout calls=$(tr '\n' ';' <"$TIMEOUT_LOG")"
+	fi
+	return 0
+}
+
+test_review_fetch_assigns_every_page() {
+	: >"$TIMEOUT_LOG"
+	assert_review_decision "observed approval remains distinct from policy approval" "126" "OBSERVED_APPROVED"
+	if grep -Fqx 'read gh api repos/owner/repo/pulls/126/reviews?per_page=100&page=1' "$TIMEOUT_LOG" &&
+		grep -Fqx 'read gh api repos/owner/repo/pulls/126/reviews?per_page=100&page=2' "$TIMEOUT_LOG" &&
+		! grep -q -- '--paginate' "$TIMEOUT_LOG"; then
+		print_result "REST review pagination records every explicit page" 0
+	else
+		print_result "REST review pagination records every explicit page" 1 \
+			"timeout calls=$(tr '\n' ';' <"$TIMEOUT_LOG")"
+	fi
+	return 0
+}
+
+test_malformed_state_changing_review_fails_closed() {
+	local decision=""
+	if decision=$(_pmp_rest_review_decision_from_reviews "127" "owner/repo"); then
+		print_result "malformed state-changing review fails closed" 1 "unexpected decision=${decision}"
+	else
+		print_result "malformed state-changing review fails closed" 0
+	fi
+	return 0
+}
+
+test_review_fetch_respects_page_bound() {
+	local decision=""
+	: >"$TIMEOUT_LOG"
+	export AIDEVOPS_PULSE_REVIEW_MAX_PAGES=1
+	_pmp_refresh_unknown_review_decision_into decision "126" "owner/repo" "UNKNOWN"
+	unset AIDEVOPS_PULSE_REVIEW_MAX_PAGES
+	if [[ "$decision" == "UNKNOWN" ]] \
+		&& grep -Fqx 'read gh api repos/owner/repo/pulls/126/reviews?per_page=100&page=1' "$TIMEOUT_LOG" \
+		&& ! grep -Fq 'page=2' "$TIMEOUT_LOG"; then
+		print_result "REST review pagination fails closed at the configured page bound" 0
+	else
+		print_result "REST review pagination fails closed at the configured page bound" 1 \
 			"decision=${decision}, timeout calls=$(tr '\n' ';' <"$TIMEOUT_LOG")"
 	fi
 	return 0
@@ -149,6 +205,9 @@ main() {
 
 	test_review_fetch_uses_bounded_read
 	assert_review_decision "DISMISSED review clears prior changes requested" "124" "NONE"
+	test_review_fetch_assigns_every_page
+	test_malformed_state_changing_review_fails_closed
+	test_review_fetch_respects_page_bound
 	test_timeout_failure_preserves_unknown_decision
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -435,7 +435,7 @@ cat >"$BUDGET_HARNESS" <<'BUDGET_HARNESS_EOF'
 set -uo pipefail
 
 gh() {
-	if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+	if [[ "${1:-}" == "api" && "${2:-}" == "rate_limit" ]]; then
 		printf '700\n'
 		return 0
 	fi
@@ -443,7 +443,7 @@ gh() {
 }
 
 # Extract the production read wrapper and budget probe without executing the
-# routine entry point. The mock deliberately rejects every non-GraphQL call.
+# routine entry point. The mock accepts only the zero-cost REST budget probe.
 # shellcheck disable=SC1090
 source <(awk '
 	/^_pmr_gh_read\(\)/ { capture=1 }
@@ -460,9 +460,9 @@ budget_output=$(ROUTINE_FILE="$ROUTINE_FILE" bash "$BUDGET_HARNESS" 2>&1)
 budget_rc=$?
 
 if [[ "$budget_rc" -eq 0 ]]; then
-	pass "17: GraphQL budget probe is independent of REST core rate limit"
+	pass "17: GraphQL budget probe uses the zero-cost REST rate resource"
 else
-	fail "17: GraphQL budget probe is independent of REST core rate limit" \
+	fail "17: GraphQL budget probe uses the zero-cost REST rate resource" \
 		"harness rc=${budget_rc}, output=${budget_output}"
 fi
 

--- a/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh
@@ -106,7 +106,7 @@ if [[ "$mode" == "pending-check" && "$1" == "pr" && "$2" == "merge" && "$*" == *
 	exit 1
 fi
 
-if [[ ( "$mode" == "expected-check" || "$mode" == "pending-check" ) && "$1" == "pr" && "$2" == "update-branch" ]]; then
+if [[ ( "$mode" == "expected-check" || "$mode" == "pending-check" ) && "$1" == "api" && "${2:-}" == "--method" && "${3:-}" == "PUT" && "${4:-}" == "repos/owner/repo/pulls/77/update-branch" ]]; then
 	exit 0
 fi
 
@@ -240,6 +240,12 @@ _set_native_auto_merge_or_skip() { return 1; }
 _repo_allows_auto_merge() { return "${REPO_ALLOWS_AUTO_MERGE_RC:-0}"; }
 _attempt_existing_auto_merge_behind_update_branch() { return 1; }
 _attempt_green_behind_update_branch() { return "${GREEN_BEHIND_UPDATE_RC:-1}"; }
+_pmp_update_branch_rest() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	gh api --method PUT "repos/${repo_slug}/pulls/${pr_number}/update-branch"
+	return $?
+}
 sleep() {
 	local seconds="$1"
 	printf 'sleep:%s\n' "$seconds" >>"$MERGE_EVENT_LOG"
@@ -542,7 +548,7 @@ test_expected_required_check_updates_branch_and_defers() {
 		unset GH_STUB_MODE
 		return 0
 	fi
-	if ! grep -qE 'gh pr update-branch 77 --repo owner/repo' "$GH_LOG"; then
+	if ! grep -qE 'gh api --method PUT repos/owner/repo/pulls/77/update-branch' "$GH_LOG"; then
 		print_result "expected required-check blocker invokes update-branch" 1 \
 			"gh log: $(cat "$GH_LOG")"
 		teardown_test_env
@@ -578,7 +584,7 @@ test_pending_required_check_updates_branch_and_defers() {
 		unset GH_STUB_MODE
 		return 0
 	fi
-	if ! grep -qE 'gh pr update-branch 77 --repo owner/repo' "$GH_LOG"; then
+	if ! grep -qE 'gh api --method PUT repos/owner/repo/pulls/77/update-branch' "$GH_LOG"; then
 		print_result "pending required-check blocker invokes update-branch" 1 \
 			"gh log: $(cat "$GH_LOG")"
 		teardown_test_env

--- a/.agents/scripts/tests/test-pulse-merge-stuck-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck-auto.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
+REST_STATE_SCRIPT="${SCRIPT_DIR}/../pulse-merge-rest-state.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -78,12 +79,15 @@ setup_test_env() {
   "autoMergeRequest": {"enabledAt": "${enabled_at_default}", "mergeMethod": "SQUASH"},
   "mergeStateStatus": "BLOCKED",
   "mergeable": "MERGEABLE",
+  "headRefOid": "stuck-head",
   "reviewDecision": "APPROVED"
 }
 JSONEOF
 	# Default required-checks state: 0 non-pass/skipping (i.e. all green).
 	printf '0' >"${TEST_ROOT}/non_ok_count.txt"
 	printf 'true' >"${TEST_ROOT}/allow_auto_merge.txt"
+	printf '%s' '[{"id":1,"user":{"login":"reviewer"},"state":"APPROVED","submitted_at":"2026-07-25T12:00:00Z"}]' \
+		>"${TEST_ROOT}/reviews.json"
 
 	# Cache dir is keyed on PID — wipe between tests so allow_auto_merge
 	# fixture changes are honoured.
@@ -94,16 +98,14 @@ JSONEOF
 #!/usr/bin/env bash
 printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
 
-# `gh pr view <N> --repo <slug> --json autoMergeRequest,mergeStateStatus,...`
-if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"autoMergeRequest"* && "$*" == *"mergeStateStatus"* ]]; then
-	cat "${TEST_ROOT}/pr_state.json"
+# Exact single-PR REST merge-state projection.
+if [[ "$1" == "api" && "$2" == repos/*/pulls/*/reviews\?* ]]; then
+	[[ "${FAIL_REVIEWS:-0}" == "1" ]] && exit 1
+	cat "${TEST_ROOT}/reviews.json"
 	exit 0
 fi
-
-# Legacy single-field call (for fall-through tests that bypass stuck check).
-if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"autoMergeRequest"* ]]; then
-	jq -c '.autoMergeRequest // empty' "${TEST_ROOT}/pr_state.json" 2>/dev/null
-	echo
+if [[ "$1" == "api" && "$2" == repos/*/pulls/* ]]; then
+	cat "${TEST_ROOT}/pr_state.json"
 	exit 0
 fi
 
@@ -136,6 +138,7 @@ GHEOF
 }
 
 teardown_test_env() {
+	unset FAIL_REVIEWS
 	rm -rf "${TMPDIR:-/tmp}/aidevops-pulse-allow-auto-merge-$$" 2>/dev/null || true
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
@@ -148,7 +151,9 @@ teardown_test_env() {
 # _repo_allows_auto_merge and _set_native_auto_merge_or_skip are the
 # pre-existing t3070 helpers we extend.
 define_helpers_under_test() {
-	local src_stuck src_repo_allow src_set_native
+	local src_stuck src_repo_allow src_stop_external src_handle_existing src_set_native
+	# shellcheck source=/dev/null
+	source "$REST_STATE_SCRIPT"
 	src_stuck=$(awk '
 		/^_auto_merge_stuck_seconds\(\) \{/,/^\}$/ { print }
 	' "$PROCESS_SCRIPT")
@@ -158,7 +163,15 @@ define_helpers_under_test() {
 	src_set_native=$(awk '
 		/^_set_native_auto_merge_or_skip\(\) \{/,/^\}$/ { print }
 	' "$PROCESS_SCRIPT")
-	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_set_native" ]]; then
+	src_handle_existing=$(awk '
+		/^_handle_existing_native_auto_merge\(\) \{/,/^\}$/ { print }
+	' "$PROCESS_SCRIPT")
+	src_stop_external=$(awk '
+		/^_stop_external_native_auto_merge\(\) \{/,/^\}$/ { print }
+	' "$PROCESS_SCRIPT")
+	if [[ -z "$src_stuck" || -z "$src_repo_allow" || -z "$src_stop_external" \
+		|| -z "$src_handle_existing" || -z "$src_set_native" ]] \
+		|| ! declare -F _pmp_rest_pr_merge_state >/dev/null 2>&1; then
 		printf 'ERROR: could not extract helpers from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
@@ -167,7 +180,20 @@ define_helpers_under_test() {
 	# shellcheck disable=SC1090
 	eval "$src_repo_allow"
 	# shellcheck disable=SC1090
+	eval "$src_stop_external"
+	# shellcheck disable=SC1090
+	eval "$src_handle_existing"
+	# shellcheck disable=SC1090
 	eval "$src_set_native"
+	_check_required_checks_passing() {
+		local repo_slug="$1"
+		local pr_number="$2"
+		local non_ok_count=""
+		[[ -n "$repo_slug$pr_number" ]] || return 1
+		non_ok_count=$(<"${TEST_ROOT}/non_ok_count.txt")
+		[[ "$non_ok_count" == "0" ]]
+		return $?
+	}
 	return 0
 }
 
@@ -182,7 +208,7 @@ test_case_1_stuck_falls_through() {
 	# 0 non-ok checks. Threshold default is 300s, 1h >> 300s → stuck.
 
 	local result=0
-	_set_native_auto_merge_or_skip "100" "owner/repo" || result=$?
+	_set_native_auto_merge_or_skip "100" "owner/repo" "0" "APPROVED" "stuck-head" || result=$?
 
 	if [[ "$result" -ne 1 ]]; then
 		print_result "Case (1): stuck → returns 1 (fall-through to --admin)" 1 \
@@ -224,12 +250,13 @@ test_case_2_under_threshold_defers() {
   "autoMergeRequest": {"enabledAt": "${enabled_at_recent}", "mergeMethod": "SQUASH"},
   "mergeStateStatus": "BLOCKED",
   "mergeable": "MERGEABLE",
+  "headRefOid": "stuck-head",
   "reviewDecision": "APPROVED"
 }
 JSONEOF
 
 	local result=0
-	_set_native_auto_merge_or_skip "200" "owner/repo" || result=$?
+	_set_native_auto_merge_or_skip "200" "owner/repo" "0" "APPROVED" "stuck-head" || result=$?
 
 	if [[ "$result" -ne 0 ]]; then
 		print_result "Case (2): under threshold → returns 0 (defer)" 1 \
@@ -266,7 +293,7 @@ test_case_3_pending_ci_defers() {
 	printf '1' >"${TEST_ROOT}/non_ok_count.txt"
 
 	local result=0
-	_set_native_auto_merge_or_skip "300" "owner/repo" || result=$?
+	_set_native_auto_merge_or_skip "300" "owner/repo" "0" "APPROVED" "stuck-head" || result=$?
 
 	if [[ "$result" -ne 0 ]]; then
 		print_result "Case (3): pending CI → returns 0 (defer)" 1 \
@@ -304,12 +331,13 @@ test_case_4_changes_requested_defers() {
   "autoMergeRequest": {"enabledAt": "${enabled_at_old}", "mergeMethod": "SQUASH"},
   "mergeStateStatus": "BLOCKED",
   "mergeable": "MERGEABLE",
+  "headRefOid": "stuck-head",
   "reviewDecision": "CHANGES_REQUESTED"
 }
 JSONEOF
 
 	local result=0
-	_set_native_auto_merge_or_skip "400" "owner/repo" || result=$?
+	_set_native_auto_merge_or_skip "400" "owner/repo" "0" "CHANGES_REQUESTED" "stuck-head" || result=$?
 
 	if [[ "$result" -ne 0 ]]; then
 		print_result "Case (4): CHANGES_REQUESTED → returns 0 (defer, not our problem)" 1 \
@@ -329,6 +357,65 @@ JSONEOF
 }
 
 # =============================================================================
+# Case (4b): unknown review state cannot authorize wedge bypass
+# =============================================================================
+test_case_4b_unknown_review_defers() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	local result=0
+	_set_native_auto_merge_or_skip "401" "owner/repo" "0" "UNKNOWN" "stuck-head" || result=$?
+
+	if [[ "$result" -eq 0 ]] && ! grep -qE 'auto_merge stuck.*t3192' "$LOGFILE"; then
+		print_result "Case (4b): UNKNOWN review state defers wedge recovery" 0
+	else
+		print_result "Case (4b): UNKNOWN review state defers wedge recovery" 1 \
+			"rc=${result}; pulse log: $(cat "$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_case_4c_fresh_changes_requested_defers() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	printf '%s' '[{"id":2,"user":{"login":"reviewer"},"state":"CHANGES_REQUESTED","submitted_at":"2026-07-25T12:01:00Z"}]' \
+		>"${TEST_ROOT}/reviews.json"
+
+	local result=0
+	_set_native_auto_merge_or_skip "402" "owner/repo" "0" "APPROVED" "stuck-head" || result=$?
+	if [[ "$result" -eq 0 ]] \
+		&& grep -qE 'pulls/402/reviews\?per_page=100&page=1' "$GH_LOG" \
+		&& ! grep -qE 'gh pr merge 402 .*--disable-auto' "$GH_LOG"; then
+		print_result "Case (4c): fresh CHANGES_REQUESTED blocks stale wedge recovery" 0
+	else
+		print_result "Case (4c): fresh CHANGES_REQUESTED blocks stale wedge recovery" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG"); pulse log: $(cat "$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_case_4d_unavailable_review_refresh_defers() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	export FAIL_REVIEWS=1
+
+	local result=0
+	_set_native_auto_merge_or_skip "403" "owner/repo" "0" "APPROVED" "stuck-head" || result=$?
+	if [[ "$result" -eq 0 ]] \
+		&& grep -qE 'pulls/403/reviews\?per_page=100&page=1' "$GH_LOG" \
+		&& ! grep -qE 'gh pr merge 403 .*--disable-auto' "$GH_LOG"; then
+		print_result "Case (4d): unavailable fresh review evidence blocks wedge recovery" 0
+	else
+		print_result "Case (4d): unavailable fresh review evidence blocks wedge recovery" 1 \
+			"rc=${result}; gh log: $(cat "$GH_LOG"); pulse log: $(cat "$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
 # Case (5): threshold override via env → larger threshold defers a 1h-stuck PR
 # =============================================================================
 test_case_5_env_threshold_override() {
@@ -339,7 +426,7 @@ test_case_5_env_threshold_override() {
 	# would fall through; with threshold=7200 (2h) it should defer.
 	local result=0
 	AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS=7200 \
-		_set_native_auto_merge_or_skip "500" "owner/repo" || result=$?
+		_set_native_auto_merge_or_skip "500" "owner/repo" "0" "APPROVED" "stuck-head" || result=$?
 
 	if [[ "$result" -ne 0 ]]; then
 		print_result "Case (5): env threshold override → defer when raised above stuck duration" 1 \
@@ -363,6 +450,9 @@ main() {
 	test_case_2_under_threshold_defers
 	test_case_3_pending_ci_defers
 	test_case_4_changes_requested_defers
+	test_case_4b_unknown_review_defers
+	test_case_4c_fresh_changes_requested_defers
+	test_case_4d_unavailable_review_refresh_defers
 	test_case_5_env_threshold_override
 
 	printf '\n=================================\n'

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -550,7 +550,7 @@ _pms_handle_classified_pr() {
 AIDEVOPS_MERGE_STUCK_AGE_MINUTES=1
 AIDEVOPS_MERGE_PATTERN_MIN_PRS=99
 pulse_merge_stuck_run_pass "example/repo" >/dev/null 2>&1
-shape_calls=$(grep -cF -- '--json number,mergeable,reviewDecision,isDraft,labels,author,updatedAt,headRefOid --limit 50' "$PMS_TEST_PR_LIST_CALLS" 2>/dev/null || true)
+shape_calls=$(grep -cF -- '--json number,isDraft,labels,author,updatedAt,headRefOid --limit 50' "$PMS_TEST_PR_LIST_CALLS" 2>/dev/null || true)
 assert_eq "6a.3: stuck scans share one provider-cache PR-list shape" "1" "$shape_calls"
 AIDEVOPS_MERGE_PATTERN_MIN_PRS=3
 

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -28,6 +28,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # read it from $MERGE_SCRIPT.
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
 PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
+REST_STATE_SCRIPT="${SCRIPT_DIR}/../pulse-merge-rest-state.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -78,7 +79,7 @@ teardown_test_env() {
 
 # Install a gh stub that:
 #   - logs every invocation to LAST_GH_ARGS_FILE (one line per call, tab-joined)
-#   - `gh pr update-branch <N> --repo <slug>` → exit code controlled by GH_UB_EXIT
+#   - REST update-branch endpoint → exit code controlled by GH_UB_EXIT
 #   - `gh pr view <N> --repo <slug> --json mergeable --jq ...` → emits
 #     GH_VIEW_MERGEABLE (default MERGEABLE)
 #   - every other gh call → exit 0, no output
@@ -86,7 +87,7 @@ install_gh_stub() {
 	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"${LAST_GH_ARGS_FILE}"
-if [[ "${1:-}" == "pr" && "${2:-}" == "update-branch" ]]; then
+if [[ "${1:-}" == "api" && "${2:-}" == "--method" && "${3:-}" == "PUT" && "${4:-}" == repos/*/pulls/*/update-branch ]]; then
 	exit "${GH_UB_EXIT:-0}"
 fi
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
@@ -109,14 +110,15 @@ gh_pr_view() {
 # pattern used by test-pulse-merge-rebase-nudge.sh.
 define_helper_under_test() {
 	local helper_src
+	# shellcheck source=/dev/null
+	source "$REST_STATE_SCRIPT"
 	helper_src=$(awk '
-		/^_pmp_normalize_mergeable_state\(\) \{/,/^}$/ { print }
-		/^_pmp_normalize_mergeable_state_into\(\) \{/,/^}$/ { print }
-		/^_pmp_refresh_unknown_mergeable_state_into\(\) \{/,/^}$/ { print }
 		/^_attempt_pr_update_branch\(\) \{/,/^}$/ { print }
 		/^_resolve_pr_mergeable_status\(\) \{/,/^}$/ { print }
 	' "$PROCESS_SCRIPT")
-	if [[ -z "$helper_src" || "$helper_src" != *"_pmp_normalize_mergeable_state"* || "$helper_src" != *"_pmp_normalize_mergeable_state_into"* || "$helper_src" != *"_pmp_refresh_unknown_mergeable_state_into"* || "$helper_src" != *"_attempt_pr_update_branch"* || "$helper_src" != *"_resolve_pr_mergeable_status"* ]]; then
+	if [[ -z "$helper_src" || "$helper_src" != *"_attempt_pr_update_branch"* || "$helper_src" != *"_resolve_pr_mergeable_status"* ]] \
+		|| ! declare -F _pmp_update_branch_rest >/dev/null 2>&1 \
+		|| ! declare -F _pmp_refresh_unknown_mergeable_state_into >/dev/null 2>&1; then
 		printf 'ERROR: could not extract pulse-merge-process helpers from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
@@ -127,7 +129,7 @@ define_helper_under_test() {
 
 test_update_branch_success_returns_zero() {
 	install_gh_stub
-	GH_UB_EXIT=0 _attempt_pr_update_branch "18988" "marcusquinn/aidevops"
+	GH_UB_EXIT=0 _attempt_pr_update_branch "18988" "marcusquinn/aidevops" "0123456789abcdef"
 	local rc=$?
 
 	if [[ $rc -ne 0 ]]; then
@@ -137,9 +139,9 @@ test_update_branch_success_returns_zero() {
 	fi
 
 	# Verify gh was called with the expected arguments.
-	if ! grep -qE '^pr update-branch 18988 --repo marcusquinn/aidevops$' "$LAST_GH_ARGS_FILE"; then
+	if ! grep -qE '^api --method PUT repos/marcusquinn/aidevops/pulls/18988/update-branch -f expected_head_sha=0123456789abcdef$' "$LAST_GH_ARGS_FILE"; then
 		print_result "update-branch success → return 0" 1 \
-			"Expected 'pr update-branch 18988 --repo marcusquinn/aidevops' in gh args. Got: $(cat "$LAST_GH_ARGS_FILE")"
+			"Expected exact REST update-branch endpoint in gh args. Got: $(cat "$LAST_GH_ARGS_FILE")"
 		return 0
 	fi
 
@@ -154,12 +156,27 @@ test_update_branch_success_returns_zero() {
 	return 0
 }
 
+test_update_branch_missing_head_fails_before_write() {
+	install_gh_stub
+	: >"$LAST_GH_ARGS_FILE"
+	local output="" rc=0
+	output=$(_pmp_update_branch_rest "18988" "marcusquinn/aidevops" 2>&1) || rc=$?
+
+	if [[ "$rc" -eq 2 && ! -s "$LAST_GH_ARGS_FILE" && "$output" == *"expected head SHA is required"* ]]; then
+		print_result "update-branch without expected head fails before write" 0
+	else
+		print_result "update-branch without expected head fails before write" 1 \
+			"rc=${rc}; output=${output}; calls=$(cat "$LAST_GH_ARGS_FILE")"
+	fi
+	return 0
+}
+
 test_update_branch_failure_returns_one() {
 	install_gh_stub
 	# gh returns non-zero (true semantic conflict). `set -e` is active so
 	# we MUST guard the failing call with a conditional to capture rc.
 	local rc=0
-	GH_UB_EXIT=1 _attempt_pr_update_branch "19094" "marcusquinn/aidevops" || rc=$?
+	GH_UB_EXIT=1 _attempt_pr_update_branch "19094" "marcusquinn/aidevops" "fedcba9876543210" || rc=$?
 
 	if [[ $rc -ne 1 ]]; then
 		print_result "update-branch failure → return 1" 1 \
@@ -181,7 +198,7 @@ test_update_branch_failure_returns_one() {
 test_update_branch_tags_log_with_task_id() {
 	install_gh_stub
 	: >"$LOGFILE"
-	GH_UB_EXIT=0 _attempt_pr_update_branch "12345" "marcusquinn/aidevops"
+	GH_UB_EXIT=0 _attempt_pr_update_branch "12345" "marcusquinn/aidevops" "1234567890abcdef"
 
 	# All t2116 log entries must carry the (t2116) tag for later audit.
 	if ! grep -q '(t2116)' "$LOGFILE"; then
@@ -467,8 +484,8 @@ test_unknown_mergeable_refreshed_before_conflict_handler() {
 		/^_pmp_refresh_unknown_mergeable_state_into\(\) \{/ { in_fn=1 }
 		in_fn { print }
 		in_fn && /^\}$/ { exit }
-	' "$PROCESS_SCRIPT")
-	if [[ "$helper_src" != *"AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view"* || "$helper_src" != *"_pmp_normalize_mergeable_state_into _pmp_refreshed_mergeable"* || "$helper_src" != *"printf -v \"\$_pmp_dest_var\""* ]]; then
+	' "$REST_STATE_SCRIPT")
+	if [[ "$helper_src" != *"AIDEVOPS_GH_REST_FIRST_READS=1"* || "$helper_src" != *"AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1"* || "$helper_src" != *"_pmp_normalize_mergeable_state_into refreshed_mergeable"* || "$helper_src" != *"printf -v \"\$dest_var\""* ]]; then
 		print_result "UNKNOWN mergeable refresh precedes CONFLICTING branch" 1 \
 			"Helper must bypass cache, normalize refreshed state, and write caller variable"
 		return 0
@@ -488,7 +505,7 @@ test_ci_rebase_update_branch_has_active_check_guard() {
 
 	terminal_pos=$(printf '%s\n' "$helper_src" | awk '/_check_required_checks_has_terminal_failure/ { print NR; exit }')
 	guard_pos=$(printf '%s\n' "$helper_src" | awk '/_check_required_checks_have_pending_or_in_progress/ { print NR; exit }')
-	update_pos=$(printf '%s\n' "$helper_src" | awk '/_ub_output=\$\(gh pr update-branch/ { print NR; exit }')
+	update_pos=$(printf '%s\n' "$helper_src" | awk '/_ub_output=\$\(_pmp_update_branch_rest/ { print NR; exit }')
 
 	if [[ -z "$terminal_pos" || -z "$guard_pos" || -z "$update_pos" ]]; then
 		print_result "CI-drift update-branch checks current-head required state first" 1 \
@@ -552,6 +569,7 @@ main() {
 	fi
 
 	test_update_branch_success_returns_zero
+	test_update_branch_missing_head_fails_before_write
 	test_update_branch_failure_returns_one
 	test_update_branch_tags_log_with_task_id
 	test_resolve_mergeable_retries_unknown

--- a/.agents/scripts/tests/test-pulse-nmr-approval.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-approval.sh
@@ -64,7 +64,7 @@ setup_test_env() {
 	export COMMENTS_FIXTURE PR_LIST_FIXTURE CHECK_RUNS_FIXTURE POSTED_COMMENT
 
 	# gh stub: serves comments from COMMENTS_FIXTURE for 'gh api ...comments',
-	# serves PR list from PR_LIST_FIXTURE for 'gh pr list', serves REST
+	# serves exact GraphQL PR-search data from PR_LIST_FIXTURE, serves REST
 	# check-runs from CHECK_RUNS_FIXTURE for 'gh api ...commits/SHA/check-runs'
 	# (GH#21799), and captures comment posts for 'gh issue comment'.
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
@@ -72,6 +72,11 @@ setup_test_env() {
 set -euo pipefail
 if [[ "${1:-}" == "api" ]]; then
 	path="${2:-}"
+	if [[ "$path" == "graphql" ]]; then
+		jq -c --argjson cost "${STUB_GRAPHQL_COST:-1}" \
+			'{data:{search:{nodes:[.[] | .labels={nodes:(.labels // []),pageInfo:{hasNextPage:false}}]},rateLimit:{cost:$cost}}}' "$PR_LIST_FIXTURE"
+		exit 0
+	fi
 	jq_filter=""
 	shift 2 2>/dev/null || true
 	while [[ $# -gt 0 ]]; do
@@ -108,18 +113,6 @@ if [[ "${1:-}" == "api" ]]; then
 		fi
 		exit 0
 	fi
-fi
-if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
-	shift 2
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-			--search|--state|--repo|--limit) shift 2 ;;
-			--json) shift 2 ;;
-			*) shift ;;
-		esac
-	done
-	cat "$PR_LIST_FIXTURE"
-	exit 0
 fi
 if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
 	shift 2
@@ -517,6 +510,26 @@ test_j_ever_nmr_remediation_includes_repo_slug() {
 	return 0
 }
 
+# Case K: calibrated GraphQL cost drift must fail closed rather than treating
+# an unmetered policy-level review decision as authoritative.
+test_k_graphql_cost_drift_no_candidate() {
+	reset_posted_comment
+	local pr_data candidate
+	pr_data=$(build_pr_json 21716 "APPROVED" "OWNER" "2026-04-29T09:19:00Z" "origin:worker" "SUCCESS" "FAILURE")
+	set_pr_list "[${pr_data}]"
+	export STUB_GRAPHQL_COST=2
+	candidate=$(_find_qualifying_pr_for_stale_recovery 21699 "marcusquinn/aidevops" "2026-04-29T09:14:00Z")
+	unset STUB_GRAPHQL_COST
+
+	if [[ -z "$candidate" ]]; then
+		print_result "Case K: GraphQL cost drift fails closed" 0
+	else
+		print_result "Case K: GraphQL cost drift fails closed" 1 \
+			"Expected no candidate when cost contract changes, got: ${candidate}"
+	fi
+	return 0
+}
+
 # ============================================================
 # Main
 # ============================================================
@@ -540,6 +553,7 @@ main() {
 	test_h_idempotency_no_duplicate
 	test_i_empty_nmr_timestamp_no_candidate
 	test_j_ever_nmr_remediation_includes_repo_slug
+	test_k_graphql_cost_drift_no_candidate
 
 	printf '\n%d tests run, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-prefetch-canonical-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-prefetch-canonical-snapshot.sh
@@ -33,6 +33,7 @@ setup_env() {
 	export PULSE_PREFETCH_FULL_SWEEP_INTERVAL=86400
 	export PULSE_PREFETCH_PR_LIMIT=100
 	export PULSE_PREFETCH_ISSUE_LIMIT=100
+	export DAILY_PR_CAP=10
 	mkdir -p "$HOME" "$PULSE_BATCH_PREFETCH_CACHE_DIR" "$TEST_ROOT/bin"
 	: >"$LOGFILE"
 	: >"$TEST_ROOT/provider-calls.log"
@@ -128,7 +129,7 @@ write_snapshot() {
 	local generation="$4"
 	local projection="$5"
 	local timestamp="${6:-}"
-	local auth_scope="${7:-github.com}"
+	local auth_scope="${7:-${PULSE_BATCH_SNAPSHOT_AUTH_SCOPE}|${AIDEVOPS_GH_API_POOL:-default}}"
 	[[ -n "$timestamp" ]] || timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	jq -n --arg schema "$_PREFETCH_SNAPSHOT_SCHEMA" --arg repo "owner/repo" \
 		--arg kind "$kind" --arg projection "$projection" --arg auth_scope "$auth_scope" \
@@ -317,6 +318,32 @@ test_cache_entry_records_snapshot_contract() {
 	return 0
 }
 
+test_rest_first_prefetch_avoids_unattributed_review_search() {
+	local pr_err="$TEST_ROOT/pr-fetch.err"
+	: >"$pr_err"
+	: >"$TEST_ROOT/github-list-calls.log"
+	AIDEVOPS_GH_REST_FIRST_READS=1
+	PREFETCH_PR_SWEEP_MODE="delta"
+	_prefetch_prs_try_delta owner/repo '{}' "$pr_err"
+	if [[ "$PREFETCH_PR_SWEEP_MODE" == "full" && ! -s "$TEST_ROOT/github-list-calls.log" ]]; then
+		print_result "REST-first prefetch bypasses GraphQL-only delta search" 0
+	else
+		print_result "REST-first prefetch bypasses GraphQL-only delta search" 1
+	fi
+	unset AIDEVOPS_GH_REST_FIRST_READS
+
+	: >"$TEST_ROOT/github-list-calls.log"
+	_prefetch_prs_fetch_full owner/repo "$pr_err"
+	if grep -q -- '--json number,title,updatedAt,headRefName,headRefOid,createdAt,author' \
+		"$TEST_ROOT/github-list-calls.log" \
+		&& ! grep -q 'reviewDecision' "$TEST_ROOT/github-list-calls.log"; then
+		print_result "full prefetch projection remains REST-equivalent" 0
+	else
+		print_result "full prefetch projection remains REST-equivalent" 1
+	fi
+	return 0
+}
+
 setup_env
 trap teardown_env EXIT
 test_single_resolution_and_local_reuse
@@ -325,6 +352,7 @@ test_single_repo_cycle_threads_one_snapshot_pair
 test_local_eviction_invalidates_completeness
 test_incomplete_and_incompatible_pairs_miss
 test_cache_entry_records_snapshot_contract
+test_rest_first_prefetch_avoids_unattributed_review_search
 
 printf 'Tests run: %s\n' "$TESTS_RUN"
 printf 'Tests failed: %s\n' "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-rate-limit-classifier.sh
+++ b/.agents/scripts/tests/test-pulse-rate-limit-classifier.sh
@@ -19,23 +19,29 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 # Stub environment — the helpers read $LOGFILE and $PULSE_RATE_LIMIT_FLAG
 LOGFILE=$(mktemp)
 PULSE_RATE_LIMIT_FLAG=$(mktemp -u)
-export LOGFILE PULSE_RATE_LIMIT_FLAG
+GH_CALL_LOG=$(mktemp)
+GH_GRAPHQL_REMAINING=0
+export LOGFILE PULSE_RATE_LIMIT_FLAG GH_CALL_LOG GH_GRAPHQL_REMAINING
 
 cleanup() {
-	rm -f "$LOGFILE" "$PULSE_RATE_LIMIT_FLAG"
+	rm -f "$LOGFILE" "$PULSE_RATE_LIMIT_FLAG" "$GH_CALL_LOG"
 }
 trap cleanup EXIT
 
-# Stub module guard (pulse-prefetch.sh checks this) + stub helpers we don't need
-_PULSE_PREFETCH_LOADED=""
+# Stub the only live API read used by _pulse_mark_rate_limited.
+gh() {
+	printf '%s\n' "$*" >>"$GH_CALL_LOG"
+	if [[ "${1:-}" == "api" && "${2:-}" == "rate_limit" ]]; then
+		printf '%s\n' "$GH_GRAPHQL_REMAINING"
+		return 0
+	fi
+	return 1
+}
 
-# Source only the helper functions we need, in a minimal way. We can't source
-# the whole pulse-prefetch.sh because it transitively depends on pulse-wrapper
-# state. Extract the two helper function bodies instead.
-eval "$(awk '
-	/^_pulse_gh_err_is_rate_limit\(\) \{$/,/^\}$/ { print }
-	/^_pulse_mark_rate_limited\(\) \{$/,/^\}$/ { print }
-' "${REPO_ROOT}/.agents/scripts/pulse-prefetch.sh")"
+# Source the focused infrastructure module without the pulse orchestrator.
+_PULSE_PREFETCH_INFRA_LOADED=""
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/.agents/scripts/pulse-prefetch-infra.sh"
 
 # Verify the helpers were extracted
 if ! declare -F _pulse_gh_err_is_rate_limit >/dev/null; then
@@ -179,6 +185,15 @@ if grep -q "RATE_LIMIT_EXHAUSTED during site_one:owner/repo1" "$LOGFILE" 2>/dev/
 	PASS=$((PASS + 1))
 else
 	echo "FAIL: log-line-emitted — expected loud log line" >&2
+	FAIL=$((FAIL + 1))
+fi
+
+if grep -q '^api rate_limit --jq .resources.graphql.remaining$' "$GH_CALL_LOG" &&
+	! grep -q 'api graphql' "$GH_CALL_LOG"; then
+	echo "PASS: live-probe-uses-rest-rate-limit"
+	PASS=$((PASS + 1))
+else
+	echo "FAIL: live-probe-uses-rest-rate-limit — calls: $(tr '\n' ';' <"$GH_CALL_LOG")" >&2
 	FAIL=$((FAIL + 1))
 fi
 


### PR DESCRIPTION
## Summary

Restore response-owned GraphQL cost attribution and fail-closed merge-state handling as a prerequisite for GH#27777. For #27777.

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-quota-attribution-lib.sh, .agents/scripts/pulse-capacity.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/pulse-merge-rest-state.sh, .agents/scripts/pulse-merge-routine.sh, .agents/scripts/pulse-merge-stuck.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/pulse-nmr-approval.sh, .agents/scripts/pulse-prefetch-fetch.sh, .agents/scripts/pulse-prefetch-infra.sh, .agents/scripts/pulse-queue-governor.sh, .agents/scripts/shared-gh-wrappers-rest-fallback.sh, .agents/scripts/shared-gh-wrappers-rest-read-semantics.sh, .agents/scripts/shared-gh-wrappers-status.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-gh-shim.sh, .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh, .agents/scripts/tests/test-pulse-merge-duplicate-pr-consolidation.sh, .agents/scripts/tests/test-pulse-merge-native-auto.sh, .agents/scripts/tests/test-pulse-merge-pr-backlog-priority.sh, .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh, .agents/scripts/tests/test-pulse-merge-rest-readiness.sh, .agents/scripts/tests/test-pulse-merge-rest-review-decision.sh, .agents/scripts/tests/test-pulse-merge-routine-standalone.sh, .agents/scripts/tests/test-pulse-merge-ruleset-fallback.sh, .agents/scripts/tests/test-pulse-merge-stuck-auto.sh, .agents/scripts/tests/test-pulse-merge-stuck.sh, .agents/scripts/tests/test-pulse-merge-update-branch.sh, .agents/scripts/tests/test-pulse-nmr-approval.sh, .agents/scripts/tests/test-pulse-prefetch-canonical-snapshot.sh, .agents/scripts/tests/test-pulse-rate-limit-classifier.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified: immutable bundle 72614cf3ff5b was manifest-validated and activated; a live read-only production-shaped GraphQL probe reported one exact attempt, known quota cost 1, zero unknown quota/page/elapsed attempts, zero malformed/duplicate records; Pulse and merge launchd jobs were observed running; focused suites, changed lint, and ShellCheck passed.

Resolves #28644


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 9d and 31,159,177 tokens on this with the user in an interactive session.