### PR TITLE
GH#28647: Validate causal reports and preserve model attribution

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -31,7 +31,11 @@ import { execSync } from "child_process";
 // Extracted modules
 import { createConfigHook } from "./config-hook.mjs";
 import { createQualityHooks } from "./quality-hooks.mjs";
-import { createShellEnvHook } from "./shell-env.mjs";
+import {
+  createSessionModelStore,
+  createShellEnvHook,
+  sessionModelIdentity,
+} from "./shell-env.mjs";
 import { compactingHook } from "./compaction.mjs";
 import { createCompactionAutoContinueGuard } from "./compaction-lifecycle.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
@@ -242,11 +246,13 @@ export async function AidevopsPlugin({ directory, client }) {
     repository: directory,
     checkpointHelper: join(SCRIPTS_DIR, "session-checkpoint-helper.sh"),
   });
+  const sessionModels = createSessionModelStore();
   const { toolExecuteBefore, toolExecuteAfter, qualityLog } = createQualityHooks({
     activeScriptsDir: join(ACTIVE_AGENTS_DIR, "scripts"),
     scriptsDir: SCRIPTS_DIR,
     logsDir: LOGS_DIR,
     continuationGuard,
+    resolveSessionModel: (sessionId) => sessionModels.resolve(sessionId),
   });
 
   const shellEnvHook = createShellEnvHook({
@@ -254,6 +260,7 @@ export async function AidevopsPlugin({ directory, client }) {
     agentsDir: AGENTS_DIR,
     scriptsDir: SCRIPTS_DIR,
     workspaceDir: WORKSPACE_DIR,
+    onSessionIdentity: (sessionId, modelId) => sessionModels.remember(sessionId, modelId),
   });
   const tierReasoning = loadTierReasoningPolicies([
     join(AGENTS_DIR, "custom", "configs", "model-routing-table.json"),
@@ -381,7 +388,11 @@ export async function AidevopsPlugin({ directory, client }) {
 
     // Select the lowest suitable child effort, capped by the parent session.
     "chat.message": subagentEffortHooks.chatMessage,
-    "chat.params": subagentEffortHooks.chatParams,
+    "chat.params": async (input, output) => {
+      const { sessionId, modelId } = sessionModelIdentity(input);
+      sessionModels.remember(sessionId, modelId);
+      return subagentEffortHooks.chatParams(input, output);
+    },
 
     // Quality hooks
     "tool.execute.before": async (input, output) => {

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -63,13 +63,16 @@ import {
 export { FAIL_REASON };
 export { SIG_MARKER, hasTrustedSignatureSignal, isGhWriteCommand, isMachineProtocolCommand };
 
-function _signatureHelperEnv() {
+function _signatureHelperEnv(explicitModel = "", useProcessModelFallback = true) {
   const helperEnv = {
     ...process.env,
     AIDEVOPS_SIG_CLI: process.env.AIDEVOPS_SIG_CLI || "OpenCode",
     AIDEVOPS_SIG_TOKENS: process.env.AIDEVOPS_SIG_TOKENS || "0",
   };
-  const model = process.env.AIDEVOPS_SIG_MODEL || process.env.OPENCODE_MODEL || "";
+  const fallbackModel = useProcessModelFallback
+    ? process.env.AIDEVOPS_SIG_MODEL || process.env.OPENCODE_MODEL || ""
+    : "";
+  const model = explicitModel || fallbackModel;
   if (model) {
     helperEnv.AIDEVOPS_SIG_MODEL = model;
   } else {
@@ -88,13 +91,13 @@ function _signatureHelperEnv() {
  * @param {Function} log
  * @returns {{ status: "ok", sig: string } | { status: "fail", reason: string, detail: string }}
  */
-function _generateSignature(helperPath, bodyValue, log) {
+function _generateSignature(helperPath, bodyValue, log, options = {}) {
   try {
     const sig = execFileSync(helperPath, ["footer", "--no-session", "--body", bodyValue], {
       encoding: "utf-8",
       timeout: 1500,
       stdio: ["pipe", "pipe", "pipe"],
-      env: _signatureHelperEnv(),
+      env: _signatureHelperEnv(options.model, options.useProcessModelFallback),
     });
     if (!sig || !sig.includes(SIG_MARKER)) {
       log("WARN", "gh-signature-helper output missing marker; refusing to inject");
@@ -173,9 +176,9 @@ function _matchBodyArg(cmd) {
  * @param {Function} log
  * @returns {{ status: "ok", cmd: string } | { status: "fail", reason: string, detail: string }}
  */
-function _repairBodyArg(cmd, parsed, helperPath, log) {
+function _repairBodyArg(cmd, parsed, helperPath, log, options = {}) {
   const { match, bodyValue, quote } = parsed;
-  const sigResult = _generateSignature(helperPath, bodyValue, log);
+  const sigResult = _generateSignature(helperPath, bodyValue, log, options);
   if (sigResult.status === "fail") return sigResult;
   const { sig } = sigResult;
   // If sig contains our delimiter quote, rewrite would break escaping —
@@ -232,7 +235,8 @@ export function tryRepairSignature(cmd, scriptsDir, log, options = {}) {
       commandWorkdir: options.commandWorkdir,
       sigMarker: SIG_MARKER,
       isMachineProtocolCommand,
-      generateSignature: _generateSignature,
+      generateSignature: (path, body, signatureLog) =>
+        _generateSignature(path, body, signatureLog, options),
     });
   }
 
@@ -247,7 +251,7 @@ export function tryRepairSignature(cmd, scriptsDir, log, options = {}) {
       : `gh-signature-helper.sh not found at ${helperPath}; cannot repair`);
     return { status: "fail", reason, ...(detail ? { detail } : {}) };
   }
-  return _repairBodyArg(cmd, parsed, helperPath, log);
+  return _repairBodyArg(cmd, parsed, helperPath, log, options);
 }
 
 /**
@@ -257,7 +261,7 @@ export function tryRepairSignature(cmd, scriptsDir, log, options = {}) {
  * @param {string} scriptsDir - Path to .agents/scripts (for helper invocation)
  * @param {object} output - Tool output (mutated on successful repair)
  */
-export function checkSignatureFooterGate(cmd, log, scriptsDir, output) {
+export function checkSignatureFooterGate(cmd, log, scriptsDir, output, options = {}) {
   if (!isGhWriteCommand(cmd)) return;
   if (isMachineProtocolCommand(cmd)) return;
   if (hasTrustedSignatureSignal(cmd)) return;
@@ -267,7 +271,11 @@ export function checkSignatureFooterGate(cmd, log, scriptsDir, output) {
   // user/session gets correct output without an error-retry cycle.
   if (scriptsDir && output && output.args) {
     const commandWorkdir = output.args.workdir || output.args.cwd || process.cwd();
-    const result = tryRepairSignature(cmd, scriptsDir, log, { commandWorkdir });
+    const result = tryRepairSignature(cmd, scriptsDir, log, {
+      commandWorkdir,
+      model: options.model,
+      useProcessModelFallback: options.useProcessModelFallback,
+    });
     if (result.status === "ok") {
       if (result.cmd !== cmd) {
         output.args.command = result.cmd;

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -301,7 +301,12 @@ function handleToolBefore(ctx, log, input, output) {
     );
     // t2685: pass scriptsDir + output so the hook can repair (mutate
     // output.args.command) or block (throw) as appropriate.
-    checkSignatureFooterGate(bashArgs.command || "", log, ctx.scriptsDir, output);
+    const sessionId = input.sessionID || input.sessionId || input.session?.id || "";
+    const signatureModel = ctx.resolveSessionModel(sessionId);
+    checkSignatureFooterGate(bashArgs.command || "", log, ctx.scriptsDir, output, {
+      model: signatureModel,
+      useProcessModelFallback: false,
+    });
   }
 
   checkSecretReadGate(input.tool, output.args || {}, log);
@@ -390,6 +395,9 @@ export function createQualityHooks(deps) {
     detailLogPath,
     detailMaxBytes,
     continuationGuard,
+    resolveSessionModel: typeof deps.resolveSessionModel === "function"
+      ? deps.resolveSessionModel
+      : () => "",
   };
 
   function boundQualityLog(level, message) {

--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -41,7 +41,13 @@ function hasAgentsDir(value) {
  * @returns {string}
  */
 function getSessionId(input) {
-  const candidates = [input?.session?.id, input?.sessionID, input?.session_id, input?.id];
+  const candidates = [
+    input?.session?.id,
+    input?.message?.sessionID,
+    input?.sessionID,
+    input?.session_id,
+    input?.id,
+  ];
   return candidates.find((value) => value) || "";
 }
 
@@ -51,13 +57,45 @@ function getSessionId(input) {
  * @returns {string}
  */
 function getModelId(input) {
-  const provider = input?.model?.providerID || "";
-  const model = input?.model?.modelID || input?.modelID || input?.model || "";
+  const provider = input?.model?.providerID || input?.provider?.id || "";
+  const model = input?.model?.modelID || input?.model?.id || input?.modelID || input?.model || "";
 
   if (provider && model && typeof model === "string" && !model.includes("/")) {
     return `${provider}/${model}`;
   }
   return typeof model === "string" ? model : "";
+}
+
+/**
+ * Extract normalized session/model identity from shell.env or chat.params input.
+ * @param {object} input
+ * @returns {{ sessionId: string, modelId: string }}
+ */
+export function sessionModelIdentity(input) {
+  return { sessionId: getSessionId(input), modelId: getModelId(input) };
+}
+
+/**
+ * Create bounded session-scoped model state for hooks that do not receive model
+ * metadata directly. Entries are keyed by OpenCode session ID so concurrent
+ * sessions cannot inherit one another's signature attribution.
+ * @param {number} maxEntries
+ * @returns {{ remember: Function, resolve: Function }}
+ */
+export function createSessionModelStore(maxEntries = 128) {
+  const models = new Map();
+  const limit = Math.max(1, Number(maxEntries) || 128);
+  return {
+    remember(sessionId, modelId) {
+      if (!sessionId || !modelId) return;
+      models.delete(sessionId);
+      models.set(sessionId, modelId);
+      while (models.size > limit) models.delete(models.keys().next().value);
+    },
+    resolve(sessionId) {
+      return sessionId ? models.get(sessionId) || "" : "";
+    },
+  };
 }
 
 /**
@@ -157,15 +195,17 @@ function projectFrameworkEnvironment(env, config) {
   if (version) env.AIDEVOPS_VERSION = version;
 }
 
-function projectSessionIdentity(input, env) {
-  const sessionId = getSessionId(input);
+function projectSessionIdentity(input, env, onSessionIdentity) {
+  const { sessionId, modelId } = sessionModelIdentity(input);
   if (sessionId) {
     env.OPENCODE_SESSION_ID = sessionId;
     env.AIDEVOPS_OPENCODE_SESSION_ID = sessionId;
   }
 
-  const modelId = getModelId(input);
   if (modelId && !env.AIDEVOPS_SIG_MODEL) env.AIDEVOPS_SIG_MODEL = modelId;
+  if (sessionId && env.AIDEVOPS_SIG_MODEL) {
+    onSessionIdentity(sessionId, env.AIDEVOPS_SIG_MODEL);
+  }
 }
 
 function projectOtelEnvironment(env) {
@@ -182,6 +222,7 @@ function normalizeDependencies(deps) {
     scriptsDir = "",
     workspaceDir = "",
     version,
+    onSessionIdentity,
   } = deps || {};
   return {
     activeAgentsDir,
@@ -189,19 +230,20 @@ function normalizeDependencies(deps) {
     scriptsDir,
     workspaceDir,
     precomputedVersion: typeof version === "string" ? version.trim() : "",
+    onSessionIdentity: typeof onSessionIdentity === "function" ? onSessionIdentity : () => {},
   };
 }
 
 async function shellEnvHook(config, input, output) {
   prependFrameworkPaths(output.env, config.scriptsDir, config.agentsDir);
   projectFrameworkEnvironment(output.env, config);
-  projectSessionIdentity(input, output.env);
+  projectSessionIdentity(input, output.env, config.onSessionIdentity);
   projectOtelEnvironment(output.env);
 }
 
 /**
  * Create the shell environment hook.
- * @param {object} deps - { activeAgentsDir?, agentsDir, scriptsDir, workspaceDir, version? }
+ * @param {object} deps - { activeAgentsDir?, agentsDir, scriptsDir, workspaceDir, version?, onSessionIdentity? }
  * @returns {Function} Shell env hook function
  */
 export function createShellEnvHook(deps) {

--- a/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs
@@ -11,7 +11,11 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createShellEnvHook } from "../shell-env.mjs";
+import {
+  createSessionModelStore,
+  createShellEnvHook,
+  sessionModelIdentity,
+} from "../shell-env.mjs";
 
 function makeHook() {
   return createShellEnvHook({
@@ -160,6 +164,50 @@ test("shell env derives the signature model without replacing an explicit value"
   const explicit = { env: { PATH: "/usr/bin:/bin", AIDEVOPS_SIG_MODEL: "configured/model" } };
   await hook({ model: { providerID: "openai", modelID: "other-model" } }, explicit);
   assert.equal(explicit.env.AIDEVOPS_SIG_MODEL, "configured/model");
+});
+
+test("shell env records the effective model against only its session", async () => {
+  const store = createSessionModelStore();
+  const hook = createShellEnvHook({
+    agentsDir: "/tmp/aidevops-agents",
+    scriptsDir: "/tmp/aidevops-scripts",
+    workspaceDir: "/tmp/aidevops-workspace",
+    onSessionIdentity: (sessionId, modelId) => store.remember(sessionId, modelId),
+  });
+
+  await hook(
+    { sessionID: "session-a", model: { providerID: "openai", modelID: "model-a" } },
+    { env: { PATH: "/usr/bin:/bin" } },
+  );
+  await hook(
+    { sessionID: "session-b", model: { providerID: "anthropic", modelID: "model-b" } },
+    { env: { PATH: "/usr/bin:/bin" } },
+  );
+
+  assert.equal(store.resolve("session-a"), "openai/model-a");
+  assert.equal(store.resolve("session-b"), "anthropic/model-b");
+  assert.equal(store.resolve("session-missing"), "");
+});
+
+test("session model store evicts old entries at its bound", () => {
+  const store = createSessionModelStore(2);
+  store.remember("session-a", "model-a");
+  store.remember("session-b", "model-b");
+  store.remember("session-c", "model-c");
+  assert.equal(store.resolve("session-a"), "");
+  assert.equal(store.resolve("session-b"), "model-b");
+  assert.equal(store.resolve("session-c"), "model-c");
+});
+
+test("chat params identity seeds the session model before tool execution", () => {
+  assert.deepEqual(
+    sessionModelIdentity({
+      message: { sessionID: "chat-session" },
+      provider: { id: "openai" },
+      model: { id: "gpt-5.6-sol" },
+    }),
+    { sessionId: "chat-session", modelId: "openai/gpt-5.6-sol" },
+  );
 });
 
 test("shell env forwards OTEL values without replacing shell-specific values", async () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -18,7 +18,8 @@ import assert from "node:assert/strict";
 import { execFileSync } from "child_process";
 import { mkdtempSync, writeFileSync, readFileSync, chmodSync, symlinkSync, rmSync, mkdirSync } from "fs";
 import { tmpdir, homedir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
 import {
   SIG_MARKER,
@@ -27,6 +28,7 @@ import {
   hasTrustedSignatureSignal,
   tryRepairSignature,
   checkSignatureFooterGate,
+  createQualityHooks,
 } from "../quality-hooks.mjs";
 import { FAIL_REASON } from "../quality-hooks-signature.mjs";
 
@@ -489,6 +491,70 @@ printf '\n\n${SIG_MARKER}\n---\n[aidevops.sh](https://aidevops.sh) v9.9.9 stub\n
       } else {
         process.env.OPENCODE_MODEL = priorOpenCodeModel;
       }
+    }
+  });
+
+  test("explicit session model overrides plugin-process model", () => {
+    const priorSigModel = process.env.AIDEVOPS_SIG_MODEL;
+    process.env.AIDEVOPS_SIG_MODEL = "openai/wrong-session";
+    const dir = mkdtempSync(join(tmpdir(), "session-model-"));
+    try {
+      const helper = join(dir, "gh-signature-helper.sh");
+      const envLog = join(dir, "helper-env.log");
+      writeFileSync(
+        helper,
+        `#!/usr/bin/env bash
+printf '%s' "\${AIDEVOPS_SIG_MODEL-}" >"${envLog}"
+printf '\n\n${SIG_MARKER}\n---\n[aidevops.sh](https://aidevops.sh) v9.9.9 stub\n'
+`,
+      );
+      chmodSync(helper, 0o755);
+      const { log } = makeLogger();
+      const cmd = 'gh issue comment 1 --repo o/r --body "hello"';
+      const out = tryRepairSignature(cmd, dir, log, { model: "anthropic/correct-session" });
+      assert.equal(out.status, "ok");
+      assert.equal(readFileSync(envLog, "utf-8"), "anthropic/correct-session");
+    } finally {
+      if (priorSigModel === undefined) delete process.env.AIDEVOPS_SIG_MODEL;
+      else process.env.AIDEVOPS_SIG_MODEL = priorSigModel;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("pre-execution hook resolves model by session without process-env leakage", async () => {
+    const priorSigModel = process.env.AIDEVOPS_SIG_MODEL;
+    process.env.AIDEVOPS_SIG_MODEL = "openai/stale-global";
+    const dir = mkdtempSync(join(tmpdir(), "session-hook-model-"));
+    try {
+      const scriptsDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "scripts");
+      const hooks = createQualityHooks({
+        scriptsDir,
+        logsDir: dir,
+        resolveSessionModel: (sessionId) =>
+          sessionId === "session-a" ? "anthropic/session-a" : "",
+      });
+
+      const sessionAOutput = {
+        args: { command: 'gh issue comment 1 --repo o/r --body "one"', workdir: process.cwd() },
+      };
+      await hooks.toolExecuteBefore(
+        { tool: "bash", sessionID: "session-a" },
+        sessionAOutput,
+      );
+      const sessionBOutput = {
+        args: { command: 'gh issue comment 1 --repo o/r --body "two"', workdir: process.cwd() },
+      };
+      await hooks.toolExecuteBefore(
+        { tool: "bash", sessionID: "session-b" },
+        sessionBOutput,
+      );
+
+      assert.match(sessionAOutput.args.command, / with session-a/);
+      assert.doesNotMatch(sessionBOutput.args.command, / with stale-global/);
+    } finally {
+      if (priorSigModel === undefined) delete process.env.AIDEVOPS_SIG_MODEL;
+      else process.env.AIDEVOPS_SIG_MODEL = priorSigModel;
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 

--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -105,13 +105,16 @@ get_git_context() {
 
 gather_diagnostics() {
 	local current_version latest_version ai_assistant install_method
-	local os_info shell_info git_context
+	local os_info shell_info git_context ai_model_line=""
 
 	current_version=$(get_aidevops_version)
 	latest_version=$(get_latest_version)
 	ai_assistant=$(detect_ai_assistant)
 	install_method=$(get_install_method)
 	git_context=$(get_git_context)
+	if [[ -n "${AIDEVOPS_SIG_MODEL:-}" ]]; then
+		ai_model_line=$'\n- **AI Model**: '"${AIDEVOPS_SIG_MODEL//$'\n'/}"
+	fi
 
 	# OS info
 	if [[ "$(uname)" == "Darwin" ]]; then
@@ -138,7 +141,7 @@ gather_diagnostics() {
 - **aidevops version**: $current_version
 - **Latest version**: $latest_version
 - **Install method**: $install_method
-- **AI Assistant**: $ai_assistant
+- **AI Assistant**: $ai_assistant${ai_model_line}
 - **OS**: $os_info
 - **Shell**: $shell_info
 - **Working repo**: $git_context
@@ -241,15 +244,15 @@ check_recent_filing() {
 	local now
 	now=$(date +%s)
 	local cutoff
-	cutoff=$(( now - dedup_window ))
+	cutoff=$((now - dedup_window))
 
 	local match filed_epoch issue_num age
 	match=$(grep -F "\"hash\":\"$fingerprint\"" "$fp_file" | tail -n 1 || true)
 
 	if [[ -n "$match" ]]; then
-		read -r filed_epoch issue_num < <(sed -E 's/.*"issue":([0-9]+).*"filed_epoch":([0-9]+).*/\2 \1/' <<< "$match" || true)
+		read -r filed_epoch issue_num < <(sed -E 's/.*"issue":([0-9]+).*"filed_epoch":([0-9]+).*/\2 \1/' <<<"$match" || true)
 		if [[ "$filed_epoch" =~ ^[0-9]+$ ]] && is_valid_issue_number "$issue_num" && [[ "$filed_epoch" -gt "$cutoff" ]]; then
-			age=$(( now - filed_epoch ))
+			age=$((now - filed_epoch))
 			echo "DUPLICATE:${issue_num}:${age}"
 			return 1
 		fi
@@ -286,7 +289,7 @@ record_filing() {
 	fi
 
 	printf '{"hash":"%s","issue":%s,"filed_at":"%s","filed_epoch":%s}\n' \
-		"$fingerprint" "$issue_number" "$iso_ts" "$now" >> "$fp_file"
+		"$fingerprint" "$issue_number" "$iso_ts" "$now" >>"$fp_file"
 
 	echo "[INFO] Fingerprint recorded for issue #${issue_number} in ${fp_file}"
 	return 0
@@ -331,6 +334,17 @@ cause as unconfirmed rather than asserting that it caused the symptom.
 <describe what you expected>
 ```
 
+**Causal status**: unconfirmed investigation | confirmed
+
+For a confirmed cause, provide all three owning-path facts. These prove that the
+cited code owns the observed production behavior rather than merely resembling it.
+
+**Owning-path proof**:
+
+- **Production entry point**: <file:line and command/event that enters the owning path>
+- **Call chain**: <end-to-end calls from the entry point to the observed failure>
+- **Integrated verification**: <test or trace that exercises that same production path>
+
 **Causal code** (optional — if you identified the file/line or commit that introduced this):
 
 ```bash
@@ -368,7 +382,10 @@ _brief_has_placeholder() {
 
 _brief_is_causal_investigation() {
 	local body="$1"
-	if grep -Eqi 'investigation|candidate cause|suspected cause|cause (is )?unconfirmed|causality (is )?not established' <<<"$body"; then
+	if grep -Eqi '\*\*Causal status\*\*:[[:space:]]*confirmed' <<<"$body"; then
+		return 1
+	fi
+	if grep -Eqi '\*\*Causal status\*\*:[[:space:]]*unconfirmed investigation|(^|[[:space:]])investigation:|candidate cause|suspected cause|cause (is )?unconfirmed|causality (is )?not established' <<<"$body"; then
 		return 0
 	fi
 	return 1
@@ -388,6 +405,25 @@ _brief_has_transport_evidence() {
 	local body="$1"
 	if grep -Eqi '\*\*Blocked command\*\*[^[:alnum:]]*.{4,}' <<<"$body" &&
 		grep -Eqi '\*\*Backend state\*\*[^[:alnum:]]*.{4,}' <<<"$body"; then
+		return 0
+	fi
+	return 1
+}
+
+_brief_asserts_confirmed_cause() {
+	local body="$1"
+	local confirmed='\*\*Causal status\*\*:[[:space:]]*confirmed|root cause[[:space:]]*(is|:)|confirmed cause[[:space:]]*(is|:)|cause(s|d)? the observed|results? in the observed|leads? to the observed|triggers? the observed'
+	if grep -Eqi "$confirmed" <<<"$body"; then
+		return 0
+	fi
+	return 1
+}
+
+_brief_has_owning_path_proof() {
+	local body="$1"
+	if grep -Eqi '\*\*Production entry point\*\*:[[:space:]]*.{8,}' <<<"$body" &&
+		grep -Eqi '\*\*Call chain\*\*:[[:space:]]*.{8,}' <<<"$body" &&
+		grep -Eqi '\*\*Integrated verification\*\*:[[:space:]]*.{8,}' <<<"$body"; then
 		return 0
 	fi
 	return 1
@@ -415,6 +451,10 @@ validate_brief_has_reproducer() {
 	fi
 	if _brief_asserts_transport_cause "$body" && ! _brief_is_causal_investigation "$body" && ! _brief_has_transport_evidence "$body"; then
 		echo "ERROR: Confirmed hang/timeout/rate-limit/API-budget/transport claims require **Blocked command** and **Backend state** evidence; otherwise frame this as an investigation with an unconfirmed cause" >&2
+		return 1
+	fi
+	if _brief_asserts_confirmed_cause "$body" && ! _brief_is_causal_investigation "$body" && ! _brief_has_owning_path_proof "$body"; then
+		echo "ERROR: Confirmed root-cause claims require substantive **Production entry point**, **Call chain**, and **Integrated verification** owning-path proof; otherwise use **Causal status**: unconfirmed investigation" >&2
 		return 1
 	fi
 

--- a/.agents/tests/log-issue-helper.bats
+++ b/.agents/tests/log-issue-helper.bats
@@ -160,9 +160,67 @@ _source_helper() {
 @test "validate brief accepts confirmed transport claim with direct evidence" {
 	_source_helper
 	local body
-	body="$(printf '## Reproducer\n**Symptom command**\n```\nps -ef --forest\n```\n**Actual output**\n```\npulse -> gh api rate_limit remained blocked\n```\n**Blocked command**: gh api rate_limit (PID 42)\n**Backend state**: x-ratelimit-remaining=0 captured at the same timestamp\nThe exhausted rate limit caused the probe to hang.')"
+	body="$(printf '## Reproducer\n**Symptom command**\n```\nps -ef --forest\n```\n**Actual output**\n```\npulse -> gh api rate_limit remained blocked\n```\n**Blocked command**: gh api rate_limit (PID 42)\n**Backend state**: x-ratelimit-remaining=0 captured at the same timestamp\n**Causal status**: confirmed\n**Owning-path proof**:\n- **Production entry point**: pulse.sh:42 invokes the rate-limit probe\n- **Call chain**: pulse_tick -> probe_budget -> gh api rate_limit\n- **Integrated verification**: bash tests/test-pulse-rate-limit.sh exercises pulse_tick\nThe exhausted rate limit caused the probe to hang.')"
 	run validate_brief_has_reproducer "$body"
 	[ "$status" -eq 0 ]
+}
+
+@test "validate brief rejects confirmed cause without owning-path proof" {
+	_source_helper
+	local body
+	body="$(printf '## Reproducer\n**Symptom command**: aidevops pulse\n**Actual output**: cleanup failed with rc=2\n**Causal status**: confirmed\nThe root cause is a permissive guard in cleanup.sh:42.')"
+	run validate_brief_has_reproducer "$body"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"owning-path proof"* ]]
+}
+
+@test "validate brief accepts confirmed cause with owning-path proof" {
+	_source_helper
+	local body
+	body="$(printf '## Reproducer\n**Symptom command**: aidevops pulse\n**Actual output**: cleanup failed with rc=2\n**Causal status**: confirmed\n**Owning-path proof**:\n- **Production entry point**: pulse.sh:42 starts merged-PR cleanup\n- **Call chain**: pulse_tick -> cleanup_merged_pr -> remove_worktree\n- **Integrated verification**: bash tests/test-cleanup.sh exercises pulse_tick with rc=2\nThe root cause is cleanup_merged_pr dropping the recovery return code.')"
+	run validate_brief_has_reproducer "$body"
+	[ "$status" -eq 0 ]
+}
+
+@test "validate brief accepts explicit unconfirmed investigation" {
+	_source_helper
+	local body
+	body="$(printf '## Reproducer\n**Symptom command**: aidevops pulse\n**Actual output**: cleanup failed with rc=2\n**Causal status**: unconfirmed investigation\nA guard in cleanup.sh:42 is a suspected cause; causality is not established.')"
+	run validate_brief_has_reproducer "$body"
+	[ "$status" -eq 0 ]
+}
+
+@test "validate brief does not let unrelated investigation text bypass confirmed status" {
+	_source_helper
+	local body
+	body="$(printf '## Reproducer\n**Symptom command**: aidevops pulse\n**Actual output**: cleanup failed with rc=2\n**Causal status**: confirmed\nThe prior investigation collected useful logs. The root cause is cleanup.sh:42.')"
+	run validate_brief_has_reproducer "$body"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"owning-path proof"* ]]
+}
+
+@test "diagnostics includes a supplied AI model" {
+	_source_helper
+	get_aidevops_version() { printf '%s\n' "test-version"; return 0; }
+	get_latest_version() { printf '%s\n' "test-version"; return 0; }
+	get_install_method() { printf '%s\n' "test"; return 0; }
+	get_git_context() { printf '%s\n' "test (branch)"; return 0; }
+	export AIDEVOPS_SIG_MODEL="openai/test-model"
+	run gather_diagnostics
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"**AI Model**: openai/test-model"* ]]
+}
+
+@test "diagnostics omits an unknown AI model" {
+	_source_helper
+	get_aidevops_version() { printf '%s\n' "test-version"; return 0; }
+	get_latest_version() { printf '%s\n' "test-version"; return 0; }
+	get_install_method() { printf '%s\n' "test"; return 0; }
+	get_git_context() { printf '%s\n' "test (branch)"; return 0; }
+	unset AIDEVOPS_SIG_MODEL
+	run gather_diagnostics
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"**AI Model**"* ]]
 }
 
 @test "check_recent_filing returns OK when no state file" {

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -102,6 +102,8 @@ This outputs the section template. Collect and include in the issue body:
 2. **Expected**: what should have happened
 3. **Causal code**: `git blame <file> -L <line>,<line>` output or commit SHA suspected to have introduced the regression
 4. **Call-site sweep**: `rg "<function-or-pattern>" .agents/scripts/` to enumerate all affected locations
+5. **Causal status**: explicitly choose `unconfirmed investigation` or `confirmed`
+6. **Owning-path proof** (required for `confirmed`): the production entry point, end-to-end call chain, and an integrated test or trace that exercises that same path
 
 For hang, timeout, rate-limit, API-budget, or transport claims, distinguish the
 observed symptom from its cause. A long-running parent process proves only the
@@ -220,6 +222,14 @@ For framework bugs, use this expanded template that includes Evidence Attributio
 
 {what should have happened}
 
+**Causal status**: {unconfirmed investigation | confirmed}
+
+**Owning-path proof**:
+
+- **Production entry point**: {file:line and command/event that enters the owning path}
+- **Call chain**: {end-to-end calls from entry point to observed failure}
+- **Integrated verification**: {test or trace exercising that production path}
+
 **Causal code** (if identified):
 
 ```bash
@@ -305,6 +315,17 @@ posting.
 
 Then use a separate Bash tool call to post the already-created file. Do not
 combine body-file creation and the `gh issue create` write in one call.
+
+For framework bugs, validate that final body file immediately before posting.
+Do not validate an earlier draft or inline copy:
+
+```bash
+~/.aidevops/agents/scripts/log-issue-helper.sh validate-brief \
+  "/absolute/path/to/aidevops-issue-body.md"
+```
+
+If validation fails, correct the evidence or explicitly reframe the report as an
+unconfirmed investigation. Do not run `gh issue create` until validation passes.
 
 ```bash
 gh issue create -R marcusquinn/aidevops \


### PR DESCRIPTION
## Summary

Require owning-path proof for confirmed framework bug causes, validate final issue bodies, include model diagnostics, and carry session-scoped OpenCode model identity into pre-execution signatures.

## Files Changed

.agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs, .agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/shell-env.mjs, .agents/plugins/opencode-aidevops/tests/test-shell-env-origin.mjs, .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs, .agents/scripts/log-issue-helper.sh, .agents/tests/log-issue-helper.bats, .agents/workflows/log-issue-aidevops.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — ShellCheck and shfmt clean; 21 shell brief tests, 17 shell-env tests, and 74 signature-gate tests pass; changed-file linters pass; live diagnostics include the supplied model.

Resolves #28647


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 27m and 567,536 tokens on this with the user in an interactive session.