### PR TITLE
GH#28650: reduce Qlty smells in tools.mjs

### DIFF
--- a/.agents/plugins/opencode-aidevops/hook-file-inspection.mjs
+++ b/.agents/plugins/opencode-aidevops/hook-file-inspection.mjs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { lstatSync, readFileSync } from "fs";
+import { join } from "path";
+
+const MAX_HOOK_INSPECTION_BYTES = 1024 * 1024;
+
+function readHookStat(hookPath) {
+  let hookStat;
+  let status = "";
+  try {
+    hookStat = lstatSync(hookPath);
+  } catch {
+    status = "missing";
+  }
+  return { hookStat, status };
+}
+
+function classifyHookStat(hookStat) {
+  let status = "regular-file";
+  if (hookStat.isSymbolicLink()) status = "unsafe-symlink";
+  else if (!hookStat.isFile()) status = "unsupported-file-type";
+  else if (hookStat.size > MAX_HOOK_INSPECTION_BYTES) status = "oversized";
+  return status;
+}
+
+export function inspectHookFile(hooksDir, hookName, markers, directorySafe) {
+  const markerStatus = Object.fromEntries(Object.keys(markers).map((name) => [name, false]));
+  let status = "unsafe-hooks-directory";
+  let content = "";
+
+  if (directorySafe) {
+    const hookPath = join(hooksDir, hookName);
+    const inspected = readHookStat(hookPath);
+    status = inspected.status;
+    if (inspected.hookStat) {
+      status = classifyHookStat(inspected.hookStat);
+      if (status === "regular-file") content = readFileSync(hookPath, "utf-8");
+    }
+  }
+
+  for (const [name, marker] of Object.entries(markers)) markerStatus[name] = content.includes(marker);
+  return { status, markers: markerStatus };
+}

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -1,6 +1,7 @@
 import { execFileSync, execSync, spawn } from "child_process";
-import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "fs";
+import { existsSync, lstatSync, realpathSync, statSync } from "fs";
 import { isAbsolute, join, resolve } from "path";
+import { inspectHookFile } from "./hook-file-inspection.mjs";
 
 export let tool;
 try {
@@ -171,7 +172,6 @@ const PRE_EDIT_GUIDANCE = {
   3: "WARNING — proceed with caution.",
 };
 
-const MAX_HOOK_INSPECTION_BYTES = 1024 * 1024;
 const HOOK_MARKERS = {
   "pre-commit": {
     quality: "# aidevops-pre-commit-hook",
@@ -221,26 +221,6 @@ function resolveGitMetadataPath(worktree, selector) {
     },
   ).trim();
   return realpathSync(isAbsolute(rawPath) ? rawPath : resolve(worktree, rawPath));
-}
-
-function inspectHookFile(hooksDir, hookName, markers, directorySafe) {
-  const markerStatus = Object.fromEntries(Object.keys(markers).map((name) => [name, false]));
-  if (!directorySafe) return { status: "unsafe-hooks-directory", markers: markerStatus };
-
-  const hookPath = join(hooksDir, hookName);
-  let hookStat;
-  try {
-    hookStat = lstatSync(hookPath);
-  } catch {
-    return { status: "missing", markers: markerStatus };
-  }
-  if (hookStat.isSymbolicLink()) return { status: "unsafe-symlink", markers: markerStatus };
-  if (!hookStat.isFile()) return { status: "unsupported-file-type", markers: markerStatus };
-  if (hookStat.size > MAX_HOOK_INSPECTION_BYTES) return { status: "oversized", markers: markerStatus };
-
-  const content = readFileSync(hookPath, "utf-8");
-  for (const [name, marker] of Object.entries(markers)) markerStatus[name] = content.includes(marker);
-  return { status: "regular-file", markers: markerStatus };
 }
 
 function inspectGitHooks(worktree) {


### PR DESCRIPTION
## Summary

- Extract bounded Git hook-file inspection from `tools.mjs` into a focused sibling module.
- Preserve the existing `createTools` API and hook-status result schema.
- Consolidate hook-file result assembly so no function exceeds Qlty's return-statement threshold.

## Testing

- `~/.qlty/bin/qlty smells .agents/plugins/opencode-aidevops/tools.mjs .agents/plugins/opencode-aidevops/hook-file-inspection.mjs --no-snippets --quiet`
- `node --check` on both changed modules
- `npm test --prefix .agents/plugins/opencode-aidevops`: 478 passed
- `.agents/scripts/linters-local.sh`: passed
- Qlty repository threshold: 52 smells against threshold 53
- Complexity regression metrics: no applicable shell changes
- Root TypeScript validator was inapplicable to these `.mjs` files and unavailable because the existing checkout lacks the lockfile's `@types/bun`; normal pre-push hooks remained enabled
- Low-risk closeout review bundle `eee52137e2062dc92d92475cce26a8034935a4d0b7b112f11f241a88b63b48a2`: clean

## Runtime Testing

Self-assessed as a low-risk structural refactor. Existing integration tests exercise regular hook files, assigned linked worktrees, and symlink rejection through the public tool API.

## Complexity Bump Justification

The issue requires the `ratchet-bump` label for this structural split. Before the split, Qlty 0.619.0 reported `base=2` findings at `.agents/plugins/opencode-aidevops/tools.mjs:226`: file complexity `55` and return count `6`. The current branch reports `head=0` findings across the original and extracted modules, with `new=0`; the split removes debt rather than introducing a new complexity identity.

Resolves #28650

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 13m and 325,308 tokens on this as a headless worker.
