### PR TITLE
GH#28654: Eliminate residual unknown GitHub quota attempts from Pulse

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -90,12 +90,18 @@ _fetch_subissue_numbers() {
 	# reconciler close parents before the tail children are checked.
 	# The jq filter returns `PAGINATED` (non-numeric) when hasNextPage=true,
 	# which the caller treats as "empty" → falls back to body regex.
-	local graphql_result
+	local graphql_response="" graphql_result="" reported_cost=""
 	# shellcheck disable=SC2016  # GraphQL variable markers ($owner/$name/$number) are intentional literals, not bash expansions
-	graphql_result=$(gh api graphql \
-		-f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){subIssues(first:50){nodes{number state}pageInfo{hasNextPage}}}}}' \
+	graphql_response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_GH_ROUTE_DECISION="pulse-subissues-exact-cost" \
+		gh api graphql \
+		-f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){subIssues(first:50){nodes{number state}pageInfo{hasNextPage}}}}rateLimit{cost}}' \
 		-F "owner=$owner" -F "name=$name" -F "number=$issue_num" \
-		--jq 'if (.data.repository.issue.subIssues.pageInfo.hasNextPage // false) then "PAGINATED" else (.data.repository.issue.subIssues.nodes // [] | .[] | .number) end' 2>/dev/null) || return 0
+		2>/dev/null) || return 0
+	reported_cost=$(printf '%s' "$graphql_response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || return 0
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 0
+	graphql_result=$(printf '%s' "$graphql_response" | jq -r \
+		'if (.data.repository.issue.subIssues.pageInfo.hasNextPage // false) then "PAGINATED" else (.data.repository.issue.subIssues.nodes // [] | .[] | .number) end' \
+		2>/dev/null) || return 0
 
 	# Fail-closed guard: if hasNextPage, pretend we got nothing so the
 	# caller falls back to body regex (where pagination is not an issue).

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -44,6 +44,40 @@ _PULSE_MERGE_GATES_LOADED=1
 # --- Functions ---
 
 #######################################
+# Read PR conversation comments through the issue-comments REST endpoint.
+# Native `gh pr view --json comments` is GraphQL-only and cannot return its
+# operation-owned cost, so exact-attribution Pulse paths use bounded REST pages.
+# Args: $1=pr_number, $2=repo_slug
+# Output: newline-delimited comment bodies
+#######################################
+_pulse_merge_pr_comment_bodies_rest() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
+	AIDEVOPS_GH_ROUTE_DECISION="pulse-pr-comments-rest" \
+		gh api --paginate "repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
+			--jq '.[].body'
+	return $?
+}
+
+#######################################
+# Read PR changed-file paths through the pull-files REST endpoint.
+# Args: $1=pr_number, $2=repo_slug
+# Output: newline-delimited paths
+#######################################
+_pulse_merge_pr_file_paths_rest() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
+	AIDEVOPS_GH_ROUTE_DECISION="pulse-pr-files-rest" \
+		gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/files?per_page=100" \
+			--jq '.[].filename'
+	return $?
+}
+
+#######################################
 # Confirm PR gate helpers may write GitHub issue/PR state for this repo.
 # #aidevops:trust-boundary — contributor/read-only repos are external
 # observation targets. Pulse must never comment, label, close, approve, or
@@ -282,7 +316,7 @@ check_external_contributor_pr() {
 
 	# Step 2: Check for existing comment
 	local comment_output
-	comment_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body')
+	comment_output=$(_pulse_merge_pr_comment_bodies_rest "$pr_number" "$repo_slug")
 	local comment_exit=$?
 
 	local has_comment=false
@@ -620,7 +654,7 @@ check_permission_failure_pr() {
 
 	# Check for existing permission-failure comment (fail closed on API error)
 	local perm_comments
-	perm_comments=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body')
+	perm_comments=$(_pulse_merge_pr_comment_bodies_rest "$pr_number" "$repo_slug")
 	local perm_exit=$?
 
 	if [[ $perm_exit -ne 0 ]]; then
@@ -846,7 +880,7 @@ check_pr_modifies_workflows() {
 	fi
 
 	local files_output
-	files_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json files --jq '.files[].path')
+	files_output=$(_pulse_merge_pr_file_paths_rest "$pr_number" "$repo_slug")
 	local files_exit=$?
 
 	if [[ $files_exit -ne 0 ]]; then
@@ -953,7 +987,7 @@ check_workflow_merge_guard() {
 
 	# Step 3: PR modifies workflows AND token lacks scope — check for existing comment
 	local comments_output
-	comments_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body')
+	comments_output=$(_pulse_merge_pr_comment_bodies_rest "$pr_number" "$repo_slug")
 	local comments_exit=$?
 
 	if [[ $comments_exit -ne 0 ]]; then

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1357,7 +1357,9 @@ _required_contexts_for_default_branch_uncached() {
 	# intentionally-unprotected default branches and blocking the worker-
 	# briefed merge cascade.
 	local protection_resp="" _rc_exit=0
-	protection_resp=$(gh api \
+	protection_resp=$(AIDEVOPS_GH_QUOTA_COST=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-branch-protection-required-contexts-rest" \
+		gh api \
 		"repos/${repo_slug}/branches/${default_branch}/protection/required_status_checks" \
 		2>&1)
 	_rc_exit=$?

--- a/.agents/scripts/pulse-merge-rest-state.sh
+++ b/.agents/scripts/pulse-merge-rest-state.sh
@@ -344,7 +344,8 @@ _pmp_update_branch_rest() {
 			"$pr_number" "$repo_slug" >&2
 		return 2
 	fi
-	AIDEVOPS_GH_ROUTE_DECISION="pulse-update-branch-rest" \
+	AIDEVOPS_GH_QUOTA_COST=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-update-branch-rest" \
 		_pmrs_gh_call write gh api --method PUT "repos/${repo_slug}/pulls/${pr_number}/update-branch" \
 			-f expected_head_sha="$expected_head_sha"
 	return $?

--- a/.agents/scripts/tests/test-pulse-merge-gates-rest-reads.sh
+++ b/.agents/scripts/tests/test-pulse-merge-gates-rest-reads.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for operation-owned REST comment/file reads in PR gates.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+GATES_SCRIPT="${SCRIPT_DIR}/../pulse-merge-gates.sh"
+
+TEST_ROOT=""
+GH_CALL_LOG=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
+	export HOME="${TEST_ROOT}/home"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	mkdir -p "${HOME}/.aidevops/logs"
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+print_result() {
+	local description="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$description"
+		return 0
+	fi
+	printf 'FAIL %s%s\n' "$description" "${detail:+: ${detail}}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+gh() {
+	local args="$*"
+	printf '%s|%s\n' "${AIDEVOPS_GH_ROUTE_DECISION:-}" "$args" >>"$GH_CALL_LOG"
+	case "$args" in
+	"api --paginate repos/owner/repo/issues/123/comments?per_page=100 --jq .[].body")
+		printf 'first comment\nsecond comment\n'
+		return 0
+		;;
+	"api --paginate repos/owner/repo/pulls/123/files?per_page=100 --jq .[].filename")
+		printf 'README.md\n.github/workflows/ci.yml\n'
+		return 0
+		;;
+	esac
+	return 1
+}
+
+assert_eq() {
+	local description="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		print_result "$description" 0
+		return 0
+	fi
+	print_result "$description" 1 "expected=${expected}; actual=${actual}"
+	return 0
+}
+
+assert_call() {
+	local description="$1"
+	local expected="$2"
+	if grep -Fqx "$expected" "$GH_CALL_LOG"; then
+		print_result "$description" 0
+		return 0
+	fi
+	print_result "$description" 1 "calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+	return 0
+}
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+	# shellcheck source=../pulse-merge-gates.sh
+	source "$GATES_SCRIPT"
+
+	local comments=""
+	comments=$(_pulse_merge_pr_comment_bodies_rest "123" "owner/repo")
+	assert_eq "PR comment bodies are projected from REST" \
+		$'first comment\nsecond comment' "$comments"
+	assert_call "PR comment reads carry their REST route decision" \
+		"pulse-pr-comments-rest|api --paginate repos/owner/repo/issues/123/comments?per_page=100 --jq .[].body"
+
+	local files=""
+	files=$(_pulse_merge_pr_file_paths_rest "123" "owner/repo")
+	assert_eq "PR file paths are projected from REST" \
+		$'README.md\n.github/workflows/ci.yml' "$files"
+	assert_call "PR file reads carry their REST route decision" \
+		"pulse-pr-files-rest|api --paginate repos/owner/repo/pulls/123/files?per_page=100 --jq .[].filename"
+
+	if grep -Eq '^[[:space:]]*[^#[:space:]].*gh pr view.*--json (comments|files)([,[:space:]]|$)' "$GATES_SCRIPT"; then
+		print_result "PR gate comments/files avoid native GraphQL views" 1
+	else
+		print_result "PR gate comments/files avoid native GraphQL views" 0
+	fi
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
+++ b/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
@@ -94,12 +94,14 @@ setup_test_env() {
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
 	export GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
+	export GH_QUOTA_LOG="${TEST_ROOT}/gh-quota.log"
 	export MOCK_REPO_MODE="ok"
 	export MOCK_BP_MODE="three_required"
 	export MOCK_RULESETS_MODE="none"
 	export MOCK_ROLLUP_MODE="all_required_pass"
 	: >"$LOGFILE"
 	: >"$GH_CALL_LOG"
+	: >"$GH_QUOTA_LOG"
 
 	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
 #!/usr/bin/env bash
@@ -216,6 +218,8 @@ fi
 
 # Match: gh api repos/SLUG/branches/BRANCH/protection/required_status_checks
 if [[ "$1" == "api" && "$*" == *"protection/required_status_checks"* ]]; then
+	printf '%s|%s\n' "${AIDEVOPS_GH_QUOTA_COST:-}" \
+		"${AIDEVOPS_GH_ROUTE_DECISION:-}" >>"${GH_QUOTA_LOG}"
 	local_json=""
 	case "${MOCK_BP_MODE:-three_required}" in
 	three_required)
@@ -436,6 +440,7 @@ assert_log_contains() {
 reset_logs() {
 	: >"$LOGFILE"
 	: >"$GH_CALL_LOG"
+	: >"$GH_QUOTA_LOG"
 	export MOCK_REPO_MODE="ok"
 	export MOCK_BP_MODE="three_required"
 	export MOCK_RULESETS_MODE="none"
@@ -520,6 +525,12 @@ test_rulesets_required_on_branch_protection_404_block() {
 		"rulesets_404_block: ruleset context logged"
 	assert_log_contains "required context(s) not passing" \
 		"rulesets_404_block: block message logged"
+	if grep -Fqx '1|pulse-branch-protection-required-contexts-rest' "$GH_QUOTA_LOG"; then
+		print_result "branch protection HTTP 404 carries explicit one-request cost" 0
+	else
+		print_result "branch protection HTTP 404 carries explicit one-request cost" 1 \
+			"quota log: $(cat "$GH_QUOTA_LOG")"
+	fi
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -38,6 +38,7 @@ TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
 LAST_GH_ARGS_FILE=""
+LAST_GH_QUOTA_FILE=""
 
 print_result() {
 	local test_name="$1"
@@ -65,8 +66,10 @@ setup_test_env() {
 	export LOGFILE="${TEST_ROOT}/pulse.log"
 	: >"$LOGFILE"
 	LAST_GH_ARGS_FILE="${TEST_ROOT}/gh-args.log"
-	export LAST_GH_ARGS_FILE
+	LAST_GH_QUOTA_FILE="${TEST_ROOT}/gh-quota.log"
+	export LAST_GH_ARGS_FILE LAST_GH_QUOTA_FILE
 	: >"$LAST_GH_ARGS_FILE"
+	: >"$LAST_GH_QUOTA_FILE"
 	return 0
 }
 
@@ -88,6 +91,11 @@ install_gh_stub() {
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"${LAST_GH_ARGS_FILE}"
 if [[ "${1:-}" == "api" && "${2:-}" == "--method" && "${3:-}" == "PUT" && "${4:-}" == repos/*/pulls/*/update-branch ]]; then
+	printf '%s|%s|%s\n' "${AIDEVOPS_GH_QUOTA_COST:-}" \
+		"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$*" >>"${LAST_GH_QUOTA_FILE}"
+	if [[ -n "${GH_UB_STATUS:-}" ]]; then
+		printf 'gh: HTTP %s: update branch rejected\n' "$GH_UB_STATUS" >&2
+	fi
 	exit "${GH_UB_EXIT:-0}"
 fi
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
@@ -192,6 +200,24 @@ test_update_branch_failure_returns_one() {
 	fi
 
 	print_result "update-branch failure → return 1" 0
+	return 0
+}
+
+test_update_branch_http_422_records_known_cost() {
+	install_gh_stub
+	: >"$LAST_GH_QUOTA_FILE"
+	local rc=0
+	GH_UB_EXIT=1 GH_UB_STATUS=422 \
+		_pmp_update_branch_rest "19094" "marcusquinn/aidevops" "fedcba9876543210" \
+		>/dev/null 2>&1 || rc=$?
+
+	local expected="1|pulse-update-branch-rest|api --method PUT repos/marcusquinn/aidevops/pulls/19094/update-branch -f expected_head_sha=fedcba9876543210"
+	if [[ "$rc" -eq 1 ]] && grep -Fqx "$expected" "$LAST_GH_QUOTA_FILE"; then
+		print_result "update-branch HTTP 422 carries explicit one-request cost" 0
+	else
+		print_result "update-branch HTTP 422 carries explicit one-request cost" 1 \
+			"rc=${rc}; quota=$(cat "$LAST_GH_QUOTA_FILE")"
+	fi
 	return 0
 }
 
@@ -571,6 +597,7 @@ main() {
 	test_update_branch_success_returns_zero
 	test_update_branch_missing_head_fails_before_write
 	test_update_branch_failure_returns_one
+	test_update_branch_http_422_records_known_cost
 	test_update_branch_tags_log_with_task_id
 	test_resolve_mergeable_retries_unknown
 	test_resolve_mergeable_accepts_boolean_true

--- a/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
+++ b/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
@@ -73,25 +73,36 @@ case "$1" in
 	api)
 		shift
 		if [[ "${1:-}" == "graphql" ]]; then
+			printf 'graphql-cost-from-response=%s\n' "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" >>"${GH_CALLS}"
 			# Per-scenario override: non-zero exit simulates a GraphQL
 			# failure (auth, rate-limit, network). The helper under test
 			# must treat this as empty and fall back to body regex.
 			if [[ -n "${GH_GRAPHQL_EXIT_CODE:-}" ]]; then
 				exit "${GH_GRAPHQL_EXIT_CODE}"
 			fi
-			# Per-scenario override: hasNextPage=true makes the helper's
-			# jq filter emit "PAGINATED" which the helper maps to empty →
-			# body-regex fallback (fail-closed on partial child lists).
-			if [[ "${GH_GRAPHQL_HAS_NEXT_PAGE:-false}" == "true" ]]; then
-				printf '%s\n' "PAGINATED"
-				exit 0
-			fi
-			# Emit the subIssues nodes list. Matches the jq filter
-			# `.data.repository.issue.subIssues.nodes // [] | .[] | .number`
-			# that the helper uses to pull numbers.
+			# Emit the raw GraphQL envelope. Production retains this shape until
+			# response-owned rateLimit.cost is metered and validated, then projects
+			# child numbers locally.
+			_nodes='[]'
 			if [[ -f "${TEST_ROOT}/gh-subissues.json" ]]; then
-				jq '.[] | .number' "${TEST_ROOT}/gh-subissues.json" 2>/dev/null
+				_nodes=$(jq -c '.' "${TEST_ROOT}/gh-subissues.json" 2>/dev/null) || _nodes='[]'
 			fi
+			_has_next="${GH_GRAPHQL_HAS_NEXT_PAGE:-false}"
+			case "${GH_GRAPHQL_COST:-1}" in
+			missing)
+				jq -cn --argjson nodes "$_nodes" --argjson has_next "$_has_next" \
+					'{data:{repository:{issue:{subIssues:{nodes:$nodes,pageInfo:{hasNextPage:$has_next}}}}}}'
+				;;
+			malformed)
+				jq -cn --argjson nodes "$_nodes" --argjson has_next "$_has_next" \
+					'{data:{repository:{issue:{subIssues:{nodes:$nodes,pageInfo:{hasNextPage:$has_next}}}},rateLimit:{cost:"invalid"}}}'
+				;;
+			*)
+				jq -cn --argjson nodes "$_nodes" --argjson has_next "$_has_next" \
+					--argjson cost "${GH_GRAPHQL_COST:-1}" \
+					'{data:{repository:{issue:{subIssues:{nodes:$nodes,pageInfo:{hasNextPage:$has_next}}}},rateLimit:{cost:$cost}}}'
+				;;
+			esac
 			exit 0
 		fi
 		# `gh api repos/X/Y/issues/N --jq '.state // "unknown"'` or `--jq '.title // ""'`
@@ -194,6 +205,7 @@ reset_scenario() {
 	: >"$LOGFILE"
 	rm -f "${TEST_ROOT}/gh-subissues.json" "${TEST_ROOT}/gh-child-states.env" \
 		"${TEST_ROOT}/gh-issue-list.json" "${TEST_ROOT}/gh-closed-issue-list.json"
+	return 0
 }
 
 set_parent_list() {
@@ -201,6 +213,7 @@ set_parent_list() {
 	local num="$1" title="$2" body="$3"
 	jq -n --argjson n "$num" --arg t "$title" --arg b "$body" \
 		'[{number:$n, title:$t, body:$b}]' >"${TEST_ROOT}/gh-issue-list.json"
+	return 0
 }
 
 set_closed_parent_list() {
@@ -225,6 +238,7 @@ set_subissues() {
 	done
 	json+="]"
 	printf '%s\n' "$json" >"${TEST_ROOT}/gh-subissues.json"
+	return 0
 }
 
 set_child_states() {
@@ -237,6 +251,7 @@ set_child_states() {
 			echo "ISSUE_${num}_TITLE=${title}"
 		} >>"${TEST_ROOT}/gh-child-states.env"
 	done
+	return 0
 }
 
 # -----------------------------------------------------------------------------
@@ -360,6 +375,34 @@ if grep -q "api graphql" "$GH_CALLS"; then
 else
 	print_result "graph query is always attempted first" 1 \
 		"(expected 'api graphql' invocation; calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+if grep -q 'graphql-cost-from-response=1' "$GH_CALLS" \
+	&& grep -q 'rateLimit{cost}' "$GH_CALLS"; then
+	print_result "graph query carries response-owned quota cost through projection" 0
+else
+	print_result "graph query carries response-owned quota cost through projection" 1 \
+		"(expected metering env and rateLimit field; calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+# Missing or malformed response-owned cost must fail closed before child-number
+# projection. The parent reconciler will then use its legacy body fallback.
+reset_scenario
+set_subissues "910:CLOSED"
+missing_cost_result=$(GH_GRAPHQL_COST=missing _fetch_subissue_numbers "test/repo" "909")
+if [[ -z "$missing_cost_result" ]]; then
+	print_result "missing GraphQL rateLimit.cost blocks projected child output" 0
+else
+	print_result "missing GraphQL rateLimit.cost blocks projected child output" 1 \
+		"(unexpected output: ${missing_cost_result})"
+fi
+
+malformed_cost_result=$(GH_GRAPHQL_COST=malformed _fetch_subissue_numbers "test/repo" "909")
+if [[ -z "$malformed_cost_result" ]]; then
+	print_result "malformed GraphQL rateLimit.cost blocks projected child output" 0
+else
+	print_result "malformed GraphQL rateLimit.cost blocks projected child output" 1 \
+		"(unexpected output: ${malformed_cost_result})"
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- replace recurring merge-gate PR comment and file GraphQL views with bounded REST reads
- retain raw subissue GraphQL responses through response-owned cost validation before local projection
- assign explicit one-request cost to update-branch and expected branch-protection REST responses, including HTTP 422 and 404
- add focused regressions for each formerly unknown-cost shape

## Verification

- `.agents/scripts/tests/test-gh-shim.sh`
- `.agents/scripts/tests/test-gh-api-instrument.sh`
- focused Pulse merge-gate, update-branch, branch-protection, reconcile, preflight, and routine suites
- `bash -n` and ShellCheck on all changed shell files
- `.agents/scripts/linters-local.sh`

## Decisions

- preserve fail-closed unknown classification rather than infer operation cost from shared token-wide counters
- keep baseline collection blocked until an immutable merged-bundle smoke reaches `smoke-passed-restored`
- no release publication is requested by this change

Resolves #28654
For #27777

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 9d 10h and 32,708,426 tokens on this with the user in an interactive session.