### PR TITLE
GH#28654: Remove final native Pulse PR views

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -12,6 +12,7 @@
 # Functions in this module (in source order):
 #   - _triage_prefetch_issue        (private: fetch issue data + skip checks)
 #   - _triage_write_prompt_file     (private: write prompt heredoc to temp file)
+#   - _triage_pr_file_paths_json_rest (private: exact REST PR-file projection)
 #   - _build_triage_review_prompt   (private: orchestrate prompt construction)
 #   - _extract_and_post_triage_review (private: validate + post review output)
 #   - _finalize_triage_state        (private: label management + cache update)
@@ -839,6 +840,30 @@ PREFETCH_EOF
 }
 
 #######################################
+# Read all changed-file paths for a PR through the pull-files REST endpoint.
+# Native `gh pr view --json files` is GraphQL-only and cannot report its
+# operation-owned cost. Slurping REST pages preserves the JSON-array prompt
+# contract while exact instrumentation accounts for every response page.
+#
+# Arguments:
+#   $1 - pr_number
+#   $2 - repo_slug
+#
+# Output: JSON array of changed-file paths.
+#######################################
+_triage_pr_file_paths_json_rest() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
+	AIDEVOPS_GH_ROUTE_DECISION="pulse-triage-pr-files-rest" \
+		gh api --paginate --slurp \
+			"repos/${repo_slug}/pulls/${pr_number}/files?per_page=100" \
+			--jq '[.[][] | .filename]'
+	return $?
+}
+
+#######################################
 # Build the triage review prompt for a given issue/PR.
 #
 # Orchestrates: issue prefetch + skip checks, PR context fetch,
@@ -878,7 +903,7 @@ _build_triage_review_prompt() {
 	is_pr=$(gh pr view "$issue_num" --repo "$repo_slug" --json number --jq '.number' 2>/dev/null) || is_pr=""
 	if [[ -n "$is_pr" ]]; then
 		pr_diff=$(gh pr diff "$issue_num" --repo "$repo_slug" 2>/dev/null | head -500) || pr_diff=""
-		pr_files=$(gh pr view "$issue_num" --repo "$repo_slug" --json files --jq '[.files[].path]' 2>/dev/null) || pr_files="[]"
+		pr_files=$(_triage_pr_file_paths_json_rest "$issue_num" "$repo_slug" 2>/dev/null) || pr_files="[]"
 	fi
 
 	local prefetch_file=""

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -776,6 +776,29 @@ _dirty_pr_classify() {
 # Each action returns 0 on success (or dry-run), 1 on failure. Actions post
 # PR comments with idempotency markers so repeated invocations don't spam.
 
+#######################################
+# Read PR conversation comment bodies through the issue-comments REST endpoint.
+# Native `gh pr view --json comments` is GraphQL-only and cannot report its
+# operation-owned cost to exact Pulse instrumentation.
+#
+# Arguments:
+#   $1 - pr_number
+#   $2 - repo_slug
+#
+# Output: newline-delimited comment bodies.
+#######################################
+_dps_pr_comment_bodies_rest() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
+	AIDEVOPS_GH_ROUTE_DECISION="pulse-dirty-pr-comments-rest" \
+		gh api --paginate \
+			"repos/${repo_slug}/issues/${pr_number}/comments?per_page=100" \
+			--jq '.[].body'
+	return $?
+}
+
 # Post a comment if the marker doesn't already exist on the PR.
 # Idempotent by design — safe to call every cycle.
 _dps_post_comment_if_new() {
@@ -786,8 +809,7 @@ _dps_post_comment_if_new() {
 
 	# Check existing comments for marker.
 	local existing
-	existing=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments \
-		--jq '.comments[].body' 2>/dev/null) || existing=""
+	existing=$(_dps_pr_comment_bodies_rest "$pr_number" "$repo_slug" 2>/dev/null) || existing=""
 	if printf '%s' "$existing" | grep -qF "$marker"; then
 		_dps_log "PR #$pr_number ($repo_slug): comment marker '$marker' already present — skipping"
 		return 0

--- a/.agents/scripts/tests/test-pulse-residual-rest-reads.sh
+++ b/.agents/scripts/tests/test-pulse-residual-rest-reads.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for the final recurring native PR file/comment reads.
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+ANCILLARY_SCRIPT="${TEST_SCRIPT_DIR}/../pulse-ancillary-dispatch.sh"
+DIRTY_SWEEP_SCRIPT="${TEST_SCRIPT_DIR}/../pulse-dirty-pr-sweep.sh"
+
+TEST_ROOT=""
+ORIGINAL_HOME="${HOME}"
+GH_CALL_LOG=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
+	mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.config/aidevops"
+	printf '%s\n' '{"initialized_repos":[]}' >"${HOME}/.config/aidevops/repos.json"
+	: >"$LOGFILE"
+	: >"$GH_CALL_LOG"
+	return 0
+}
+
+teardown_test_env() {
+	export HOME="$ORIGINAL_HOME"
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+print_result() {
+	local description="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$description"
+		return 0
+	fi
+	printf 'FAIL %s%s\n' "$description" "${detail:+: ${detail}}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+gh() {
+	local args="$*"
+	printf '%s|%s\n' "${AIDEVOPS_GH_ROUTE_DECISION:-}" "$args" >>"$GH_CALL_LOG"
+	case "$args" in
+	"api --paginate --slurp repos/owner/repo/pulls/123/files?per_page=100 --jq [.[][] | .filename]")
+		printf '%s\n' '["README.md",".github/workflows/ci.yml"]'
+		return 0
+		;;
+	"api --paginate repos/owner/repo/issues/123/comments?per_page=100 --jq .[].body")
+		printf 'first comment\nsecond comment\n'
+		return 0
+		;;
+	esac
+	return 1
+}
+
+assert_eq() {
+	local description="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		print_result "$description" 0
+		return 0
+	fi
+	print_result "$description" 1 "expected=${expected}; actual=${actual}"
+	return 0
+}
+
+assert_call() {
+	local description="$1"
+	local expected="$2"
+	if grep -Fqx "$expected" "$GH_CALL_LOG"; then
+		print_result "$description" 0
+		return 0
+	fi
+	print_result "$description" 1 "calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+	return 0
+}
+
+assert_source_contains() {
+	local description="$1"
+	local source_file="$2"
+	local expected="$3"
+	if grep -Fq "$expected" "$source_file"; then
+		print_result "$description" 0
+		return 0
+	fi
+	print_result "$description" 1 "missing=${expected}"
+	return 0
+}
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+	unset SCRIPT_DIR || true
+	# shellcheck source=../pulse-ancillary-dispatch.sh
+	source "$ANCILLARY_SCRIPT"
+	# shellcheck source=../pulse-dirty-pr-sweep.sh
+	source "$DIRTY_SWEEP_SCRIPT"
+
+	local files=""
+	files=$(_triage_pr_file_paths_json_rest "123" "owner/repo")
+	assert_eq "triage PR file paths preserve their JSON-array contract" \
+		'["README.md",".github/workflows/ci.yml"]' "$files"
+	assert_call "triage PR files use bounded slurped REST pages" \
+		"pulse-triage-pr-files-rest|api --paginate --slurp repos/owner/repo/pulls/123/files?per_page=100 --jq [.[][] | .filename]"
+
+	local comments=""
+	comments=$(_dps_pr_comment_bodies_rest "123" "owner/repo")
+	assert_eq "dirty-PR marker checks project REST comment bodies" \
+		$'first comment\nsecond comment' "$comments"
+	assert_call "dirty-PR comment reads use bounded REST pages" \
+		"pulse-dirty-pr-comments-rest|api --paginate repos/owner/repo/issues/123/comments?per_page=100 --jq .[].body"
+
+	assert_source_contains "triage prompt calls the exact REST file helper" \
+		"$ANCILLARY_SCRIPT" \
+		"pr_files=\$(_triage_pr_file_paths_json_rest \"\$issue_num\" \"\$repo_slug\""
+	assert_source_contains "dirty-PR idempotency calls the exact REST comment helper" \
+		"$DIRTY_SWEEP_SCRIPT" \
+		"existing=\$(_dps_pr_comment_bodies_rest \"\$pr_number\" \"\$repo_slug\""
+
+	if grep -Eq '^[[:space:]]*[^#[:space:]].*gh pr view.*--json files' "$ANCILLARY_SCRIPT"; then
+		print_result "ancillary dispatch avoids native GraphQL PR-file views" 1
+	else
+		print_result "ancillary dispatch avoids native GraphQL PR-file views" 0
+	fi
+	if grep -Eq '^[[:space:]]*[^#[:space:]].*gh pr view.*--json comments' "$DIRTY_SWEEP_SCRIPT"; then
+		print_result "dirty-PR sweep avoids native GraphQL comment views" 1
+	else
+		print_result "dirty-PR sweep avoids native GraphQL comment views" 0
+	fi
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- replace the final two production `gh pr view` comment/file fallbacks observed by the restored smoke
- preserve triage prompt file lists as a single JSON array across bounded REST pages
- preserve dirty-PR comment-marker idempotency through bounded issue-comment REST pages
- add focused route, projection, call-site, and native-view absence regressions

## Smoke evidence

- the first merged-bundle retry restored every control and recorded 366 exact attempts
- 361 quota cost was known; the only two unknown-cost attempts were successful native `gh_pr_view` GraphQL fallbacks
- baseline remains blocked pending a zero-unknown `smoke-passed-restored` retry

## Verification

- `.agents/scripts/tests/test-pulse-residual-rest-reads.sh`
- dirty-PR sweep and interactive-staleness suites
- triage failure, output-shape, prefetch-evidence, and worker-contract suites
- `.agents/scripts/tests/test-gh-api-instrument.sh`
- `.agents/scripts/tests/test-gh-shim.sh`
- Bash syntax and ShellCheck on all changed files
- `.agents/scripts/linters-local.sh`

## Decisions

- use installed GitHub CLI `--paginate --slurp` support to retain the existing all-pages JSON contract
- keep operation cost response-owned; shared token-wide counter deltas remain invalid
- no release publication is requested

Resolves #28654
For #27777

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 9d 10h and 33,103,386 tokens on this with the user in an interactive session.